### PR TITLE
Fix stride handling in FFT meta registrations

### DIFF
--- a/test/test_meta.py
+++ b/test/test_meta.py
@@ -348,6 +348,9 @@ aten = torch.ops.aten
 
 CHECK_STRIDES = {
     torch.Tensor.__getitem__,
+    aten._fft_c2c.default,
+    aten._fft_c2r.default,
+    aten._fft_r2c.default,
 }
 
 CHECK_ALL_STRIDES = {
@@ -356,9 +359,6 @@ CHECK_ALL_STRIDES = {
 
 CHECK_STRIDES_SKIPS = {
     aten._conj_physical.default,
-    aten._fft_c2c.default,
-    aten._fft_c2r.default,
-    aten._fft_r2c.default,
     aten._linalg_svd.default,
     aten.binary_cross_entropy.default,
     aten.complex.default,

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -255,14 +255,9 @@ def _exec_fft(out, self, out_sizes, dim, *, forward):
     for d in dim:
         is_transformed_dim[d] = True
 
-    # std::partition
-    left, right = [], []
-    for d in dim_permute:
-        if not is_transformed_dim[d]:
-            left.append(d)
-        else:
-            right.append(d)
-    dim_permute = left + right
+    # std::partition + std::copy(dim.begin(), dim.end(), batch_end)
+    left = [d for d in dim_permute if not is_transformed_dim[d]]
+    dim_permute = left + list(dim)
     batch_end = len(left)
 
     self_strides = self.stride()
@@ -300,8 +295,9 @@ def _exec_fft(out, self, out_sizes, dim, *, forward):
 def _sort_dims(self: Tensor, dim: list[int], exclude_last: bool = False):
     sorted_dims = list(dim)
     self_strides = self.stride()
-    sorted_dims[: len(sorted_dims) - int(exclude_last)].sort(
-        key=lambda i: self_strides[i]
+    end = len(sorted_dims) - int(exclude_last)
+    sorted_dims[:end] = sorted(
+        sorted_dims[:end], key=lambda i: self_strides[i], reverse=True
     )
     return sorted_dims
 
@@ -314,6 +310,10 @@ def meta_fft_c2c(self, dim, normalization, forward):
     torch._check(self.dtype.is_complex)
     if not dim:
         return self.clone()
+
+    # PocketFFT writes into a contiguous empty tensor directly
+    if device_hint(self) == "cpu" and not torch._C.has_mkl:
+        return self.new_empty(self.size())
 
     sorted_dims = _sort_dims(self, dim)
     out = self.new_empty(self.size())
@@ -385,7 +385,16 @@ def meta_fft_r2c(self, dim, normalization, onesided):
 
         return output
 
+    elif torch._C.has_mkl:
+        # _fft_r2c_mkl in aten/src/ATen/native/mkl/SpectralOps.cpp
+        sorted_dims = _sort_dims(self, dim, exclude_last=True)
+        output = self.new_empty(
+            out_sizes, dtype=utils.corresponding_complex_dtype(self.dtype)
+        )
+        return _exec_fft(output, self, out_sizes, sorted_dims, forward=True)
+
     else:
+        # PocketFFT writes into a contiguous empty tensor
         return self.new_empty(
             out_sizes, dtype=utils.corresponding_complex_dtype(self.dtype)
         )
@@ -488,7 +497,8 @@ def meta_fft_c2r(self: Tensor, dim: list[int], normalization: int, lastdim: int)
                 temp = self.clone(memory_format=torch.contiguous_format)
             return _exec_fft(output, temp, out_sizes, [dim[-1]], forward=False)
 
-    else:
+    elif torch._C.has_mkl:
+        # _fft_c2r_mkl in aten/src/ATen/native/mkl/SpectralOps.cpp
         input = self
         if len(dim) > 1:
             c2c_dims = dim[:-1]
@@ -499,6 +509,12 @@ def meta_fft_c2r(self: Tensor, dim: list[int], normalization: int, lastdim: int)
         out_sizes[dim[-1]] = lastdim
         out = self.new_empty(out_sizes, dtype=toRealValueType(self.dtype))
         return _exec_fft(out, input, out_sizes, dim, forward=False)
+
+    else:
+        # PocketFFT writes into a contiguous empty tensor
+        out_sizes = list(self.size())
+        out_sizes[dim[-1]] = lastdim
+        return self.new_empty(out_sizes, dtype=toRealValueType(self.dtype))
 
 
 @register_meta(aten.copy_.default)

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -311,7 +311,6 @@ def meta_fft_c2c(self, dim, normalization, forward):
     if not dim:
         return self.clone()
 
-    # PocketFFT writes into a contiguous empty tensor directly
     if device_hint(self) == "cpu" and not torch.backends.mkl.is_available():
         return self.new_empty(self.size())
 
@@ -394,7 +393,6 @@ def meta_fft_r2c(self, dim, normalization, onesided):
         return _exec_fft(output, self, out_sizes, sorted_dims, forward=True)
 
     else:
-        # PocketFFT writes into a contiguous empty tensor
         return self.new_empty(
             out_sizes, dtype=utils.corresponding_complex_dtype(self.dtype)
         )
@@ -511,7 +509,6 @@ def meta_fft_c2r(self: Tensor, dim: list[int], normalization: int, lastdim: int)
         return _exec_fft(out, input, out_sizes, dim, forward=False)
 
     else:
-        # PocketFFT writes into a contiguous empty tensor
         out_sizes = list(self.size())
         out_sizes[dim[-1]] = lastdim
         return self.new_empty(out_sizes, dtype=toRealValueType(self.dtype))

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -312,7 +312,7 @@ def meta_fft_c2c(self, dim, normalization, forward):
         return self.clone()
 
     # PocketFFT writes into a contiguous empty tensor directly
-    if device_hint(self) == "cpu" and not torch._C.has_mkl:
+    if device_hint(self) == "cpu" and not torch.backends.mkl.is_available():
         return self.new_empty(self.size())
 
     sorted_dims = _sort_dims(self, dim)
@@ -385,7 +385,7 @@ def meta_fft_r2c(self, dim, normalization, onesided):
 
         return output
 
-    elif torch._C.has_mkl:
+    elif torch.backends.mkl.is_available():
         # _fft_r2c_mkl in aten/src/ATen/native/mkl/SpectralOps.cpp
         sorted_dims = _sort_dims(self, dim, exclude_last=True)
         output = self.new_empty(
@@ -497,7 +497,7 @@ def meta_fft_c2r(self: Tensor, dim: list[int], normalization: int, lastdim: int)
                 temp = self.clone(memory_format=torch.contiguous_format)
             return _exec_fft(output, temp, out_sizes, [dim[-1]], forward=False)
 
-    elif torch._C.has_mkl:
+    elif torch.backends.mkl.is_available():
         # _fft_c2r_mkl in aten/src/ATen/native/mkl/SpectralOps.cpp
         input = self
         if len(dim) > 1:


### PR DESCRIPTION
Fixes #167636 

#### Summary
- Fix `meta_fft_r2c` missing CPU/MKL code path 
- Fix `_sort_dims` no-op also add `reverse=True` to match C++ descending sort
- Fix `_exec_fft` signal dim ordering
- Add PocketFFT early return paths for `meta_fft_c2c` and `meta_fft_c2r` on CPU without MKL
- Move FFT ops from `CHECK_STRIDES_SKIPS` to `CHECK_STRIDES` in `test_meta.py`
- Use `torch.backends.mkl.is_available()` per [this](https://github.com/pytorch/pytorch/issues/167636#issuecomment-3953140789)

cc @mruberry @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos