### PR TITLE
[wrap compiled regions] Fix supporting Nones in compiled outputs

### DIFF
--- a/torch/_inductor/output_code.py
+++ b/torch/_inductor/output_code.py
@@ -620,7 +620,8 @@ class CompiledFxGraph(OutputCode):
             from torch._higher_order_ops.wrap import OutputTensorMeta
 
             fake_vals = [
-                x.meta["val"] for x in gm.graph.find_nodes(op="output")[0].args[0]
+                x.meta["val"] if x is not None else None
+                for x in gm.graph.find_nodes(op="output")[0].args[0]
             ]
             for t in fake_vals:
                 if isinstance(t, torch.Tensor) and any(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #175733

Fixing the bug that was introduced in https://github.com/pytorch/pytorch/pull/174504 

This started failing torchtitan ci: https://github.com/pytorch/torchtitan/actions/runs/22321410424/job/64580392187

The test command:
```
NGPU=4 LOG_RANK=0,1,2,3 ./run_train.sh \
        --module llama3 \
        --config llama3_debugmodel_flex_attn \
        --parallelism.data_parallel_shard_degree=4 \
        --activation_checkpoint.mode='full' 2>&1 | tee /var/tmp/l
```

Outputs can be None - e.g. for backward graph for inputs that does not require gradients. This was not supported.




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo