### PR TITLE
Applied fix for the getattr handling for torch._dynamo

### DIFF
--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -53,6 +53,7 @@ import torch.fx
 import torch.utils._pytree as pytree
 import torch.utils.checkpoint
 from torch import _guards
+from torch._dynamo.exc import raise_observed_exception
 
 # see discussion at https://github.com/pytorch/pytorch/issues/120699
 from torch._C._dynamo.eval_frame import (  # noqa: F401

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -547,7 +547,10 @@ class OptimizedModule(torch.nn.Module):
     def __getattr__(self, name: str) -> Any:
         if name == "_orig_mod":
             return self._modules["_orig_mod"]
-        return getattr(self._orig_mod, name)
+        try:
+            return getattr(self._orig_mod, name)
+        except AttributeError:
+            raise_observed_exception()
 
     def __setattr__(self, name: str, value: Any) -> None:
         # Allow patching over class attributes


### PR DESCRIPTION
Fixes #174166

This PR updates Dynamo to properly handle dynamic attribute access:

- Import `raise_observed_exception` from `torch._dynamo.exc`
- Use `raise_observed_exception` in `getattr` within `eval_frame.py`

This ensures tracing behaves correctly when an attribute does not exist.