### PR TITLE
Fix BlockMask._adjust to update seq_lengths

### DIFF
--- a/test/distributed/tensor/test_attention.py
+++ b/test/distributed/tensor/test_attention.py
@@ -365,6 +365,21 @@ compiled_create_block_mask = torch.compile(
 def causal_mask(b, h, q_idx, kv_idx):
     return q_idx >= kv_idx
 
+def test_blockmask_adjust_updates_seq_lengths_cpu():
+    bm = create_block_mask(
+        causal_mask,
+        B=1,
+        H=1,
+        Q_LEN=128,
+        KV_LEN=128,
+        device="cpu",
+    )
+    bm2 = bm._adjust(16, 16)
+
+    # Regression for #175533: _adjust must update seq_lengths
+    assert bm2.seq_lengths == (16, 16)
+    assert bm2.shape[-2:] == (16, 16)
+
 
 # copied from https://github.com/meta-pytorch/attention-gym/blob/main/attn_gym/masks/document_mask.py
 def generate_random_lengths(total_length, num_documents) -> list[int]:

--- a/torch/nn/attention/flex_attention.py
+++ b/torch/nn/attention/flex_attention.py
@@ -846,8 +846,10 @@ class BlockMask:
             new_kv_indices,
             new_full_kv_num_blocks,
             new_full_kv_indices,
-            self.BLOCK_SIZE,
-            self.mask_mod,
+            BLOCK_SIZE=self.BLOCK_SIZE,
+            mask_mod=self.mask_mod,
+            seq_lengths=(new_q_len, new_kv_len),
+            compute_q_blocks=self.q_indices is not None,
         )
 
     def numel(self):


### PR DESCRIPTION
Fix BlockMask._adjust() to update seq_lengths when cropping. Adds a small unit test.
Fixes #175533