### PR TITLE
[FakeTensor]: Support fast_bind used in normalize_function

### DIFF
--- a/test/test_inspect_utils.py
+++ b/test/test_inspect_utils.py
@@ -1,0 +1,150 @@
+# Owner(s): ["module: fx"]
+
+import inspect
+
+from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.utils._inspect import _fast_bind
+
+
+class TestFastBind(TestCase):
+    def _assert_fast_bind_matches_sig_bind(self, sig, args, kwargs):
+        try:
+            ref = sig.bind(*args, **kwargs)
+        except TypeError:
+            # _fast_bind should raise the same error
+            with self.assertRaises(TypeError):
+                _fast_bind(sig, *args, **kwargs)
+            return
+        # Success path: compare BoundArguments
+        got = _fast_bind(sig, *args, **kwargs)
+        self.assertEqual(ref.arguments, got.arguments)
+        self.assertEqual(ref.args, got.args)
+        self.assertEqual(ref.kwargs, got.kwargs)
+
+        # Also validate default population matches
+        ref.apply_defaults()
+        got.apply_defaults()
+        self.assertEqual(ref.arguments, got.arguments)
+        self.assertEqual(ref.args, got.args)
+        self.assertEqual(ref.kwargs, got.kwargs)
+
+    def test_positional_or_keyword_and_defaults(self):
+        def f(a, b=1, c=2):
+            pass
+
+        sig = inspect.signature(f)
+        self._assert_fast_bind_matches_sig_bind(sig, (10,), {"c": 3})
+        self._assert_fast_bind_matches_sig_bind(sig, (10, 20), {})
+        self._assert_fast_bind_matches_sig_bind(sig, (), {"a": 1})
+
+    def test_missing_required(self):
+        def f(a, b):
+            pass
+
+        sig = inspect.signature(f)
+        self._assert_fast_bind_matches_sig_bind(sig, (), {})
+        self._assert_fast_bind_matches_sig_bind(sig, (1,), {})
+
+    def test_too_many_positional(self):
+        def f(a, b=1):
+            pass
+
+        sig = inspect.signature(f)
+        self._assert_fast_bind_matches_sig_bind(sig, (1, 2, 3), {})
+
+    def test_multiple_values_for_argument(self):
+        def f(a, b):
+            pass
+
+        sig = inspect.signature(f)
+        self._assert_fast_bind_matches_sig_bind(sig, (1,), {"a": 2, "b": 3})
+
+    def test_unexpected_keyword(self):
+        def f(a, b=1):
+            pass
+
+        sig = inspect.signature(f)
+        self._assert_fast_bind_matches_sig_bind(sig, (1,), {"c": 3})
+
+    def test_keyword_only(self):
+        def f(a, *, b, c=1):
+            pass
+
+        sig = inspect.signature(f)
+        self._assert_fast_bind_matches_sig_bind(sig, (1,), {"b": 2})
+        self._assert_fast_bind_matches_sig_bind(sig, (1, 2), {})
+        self._assert_fast_bind_matches_sig_bind(sig, (1,), {})
+
+    def test_positional_only(self):
+        # def f(x, /, y, *, z=1): ...
+        sig = inspect.Signature(
+            [
+                inspect.Parameter("x", inspect.Parameter.POSITIONAL_ONLY),
+                inspect.Parameter("y", inspect.Parameter.POSITIONAL_OR_KEYWORD),
+                inspect.Parameter("z", inspect.Parameter.KEYWORD_ONLY, default=1),
+            ]
+        )
+        self._assert_fast_bind_matches_sig_bind(sig, (1, 2), {"z": 3})
+        self._assert_fast_bind_matches_sig_bind(sig, (), {"x": 1, "y": 2})
+        self._assert_fast_bind_matches_sig_bind(sig, (1,), {"x": 2, "y": 3})
+
+    def test_from_keyword_positional_only_pattern(self):
+        # Mirrors a common TorchScript schema normalization pattern in operator_schemas.py
+        # where "from" is treated as positional-only.
+        sig = inspect.Signature(
+            [
+                inspect.Parameter("input", inspect.Parameter.POSITIONAL_ONLY),
+                inspect.Parameter(
+                    "from", inspect.Parameter.POSITIONAL_ONLY, default=0.0
+                ),
+                inspect.Parameter(
+                    "to", inspect.Parameter.POSITIONAL_OR_KEYWORD, default=1.0
+                ),
+                inspect.Parameter(
+                    "generator",
+                    inspect.Parameter.KEYWORD_ONLY,
+                    default=None,
+                ),
+            ]
+        )
+        self._assert_fast_bind_matches_sig_bind(sig, ("t",), {})
+        self._assert_fast_bind_matches_sig_bind(sig, ("t", 0.25), {})
+        self._assert_fast_bind_matches_sig_bind(
+            sig, ("t", 0.25, 0.75), {"generator": None}
+        )
+        self._assert_fast_bind_matches_sig_bind(sig, (), {"input": "t", "from": 0.1})
+
+    def test_varargs_and_varkw_fallback(self):
+        def f(a, *args, b=0, **kwargs):
+            pass
+
+        sig = inspect.signature(f)
+        # Extra positional should be captured by *args; extra keywords by **kwargs
+        self._assert_fast_bind_matches_sig_bind(sig, (1, 2, 3), {"b": 4, "x": 5})
+        self._assert_fast_bind_matches_sig_bind(sig, (), {"a": 1, "x": 2})
+
+    def test_zero_params(self):
+        def f():
+            pass
+
+        sig = inspect.signature(f)
+        self._assert_fast_bind_matches_sig_bind(sig, (), {})
+        self._assert_fast_bind_matches_sig_bind(sig, (1,), {})  # too many args
+        self._assert_fast_bind_matches_sig_bind(sig, (), {"x": 1})  # unexpected kwarg
+        self._assert_fast_bind_matches_sig_bind(
+            sig, (1,), {"b": 1}
+        )  # unexpected arg & kwarg
+
+    def test_mutable_defaults(self):
+        # This test case reproduces an issue where unhashable default values (like list)
+        # caused _fast_bind to fail because of lru_cache on _signature_metadata
+        def f(a, b=[]):  # noqa: B006
+            pass
+
+        sig = inspect.signature(f)
+        self._assert_fast_bind_matches_sig_bind(sig, (1,), {})
+        self._assert_fast_bind_matches_sig_bind(sig, (1, [2]), {})
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/_prims_common/wrappers.py
+++ b/torch/_prims_common/wrappers.py
@@ -20,6 +20,7 @@ from torch._prims_common import (
     TensorLikeType,
 )
 from torch.utils import _pytree as pytree
+from torch.utils._inspect import _fast_bind
 from torch.utils._pytree import tree_flatten, tree_unflatten
 
 
@@ -129,7 +130,7 @@ class elementwise_type_promotion_wrapper:
         @torch._disable_dynamo
         @wraps(fn)
         def _fn(*args, **kwargs):
-            bound = sig.bind(*args, **kwargs)
+            bound = _fast_bind(sig, *args, **kwargs)
             type_promoting_args = tuple(
                 bound.arguments[x]
                 for x in self.type_promoting_arg_names  # type: ignore[union-attr]

--- a/torch/fx/operator_schemas.py
+++ b/torch/fx/operator_schemas.py
@@ -11,6 +11,7 @@ from typing import Any, cast, NamedTuple, TYPE_CHECKING
 import torch
 from torch._jit_internal import boolean_dispatched
 from torch._ops import OpOverload, OpOverloadPacket
+from torch.utils._inspect import _fast_bind
 
 from ._compatibility import compatibility
 
@@ -183,7 +184,7 @@ def check_for_mutable_operation(
         # values. If none matches, `new_args_and_kwargs` will be None
         for candidate_signature, schema in zip(signatures, schemas):
             try:
-                candidate_signature.bind(*args, **kwargs)
+                _fast_bind(candidate_signature, *args, **kwargs)
                 matched_schemas.append((candidate_signature, schema))
             except TypeError:
                 continue
@@ -449,7 +450,7 @@ def normalize_function(
             # values. If none matches, `new_args_and_kwargs` will be None
             for candidate_signature in torch_op_schemas:
                 try:
-                    candidate_signature.bind(*args, **kwargs)
+                    _fast_bind(candidate_signature, *args, **kwargs)
                     matched_schemas.append(candidate_signature)
                 except TypeError:
                     continue
@@ -469,8 +470,8 @@ def normalize_function(
                     for candidate_signature in torch_op_schemas:
                         sig_matches = True
                         try:
-                            bound_types = candidate_signature.bind(
-                                *arg_types, **kwarg_types
+                            bound_types = _fast_bind(
+                                candidate_signature, *arg_types, **kwarg_types
                             )
                             for arg_name, arg_type in bound_types.arguments.items():
                                 param = candidate_signature.parameters[arg_name]
@@ -589,7 +590,7 @@ def _args_kwargs_to_normalized_args_kwargs(
         if list(sig.parameters.keys()) != ["input", "from", "to", "generator"]:
             return None
 
-    bound_args = sig.bind(*args, **kwargs)
+    bound_args = _fast_bind(sig, *args, **kwargs)
     bound_args.apply_defaults()
 
     new_kwargs: dict[str, Any] = {}

--- a/torch/utils/_inspect.py
+++ b/torch/utils/_inspect.py
@@ -1,0 +1,90 @@
+import inspect
+from typing import Any
+
+
+def _signature_metadata(
+    sig: inspect.Signature,
+) -> tuple[tuple[inspect.Parameter, ...], bool, int]:
+    """
+    Returns tuple(sig.parameters.values()), if any has VAR_POSITIONAL or VAR_KEYWORD, and the max_positional
+    """
+    params = tuple(sig.parameters.values())
+    has_var_args = False
+    max_positional = 0
+
+    for p in params:
+        kind = p.kind
+        if kind in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD):
+            has_var_args = True
+        if kind in (
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        ):
+            max_positional += 1
+
+    return params, has_var_args, max_positional
+
+
+def _fast_bind(
+    sig: inspect.Signature, *args: Any, **kwargs: Any
+) -> inspect.BoundArguments:
+    """
+    Fast path for inspect.Signature.bind() for signatures without
+    VAR_POSITIONAL or VAR_KEYWORD parameters. Falls back to sig.bind()
+    for signatures that contain *args or **kwargs.
+    """
+    params, has_var_args, max_positional = _signature_metadata(sig)
+
+    # fallback for complex signatures
+    if has_var_args:
+        return sig.bind(*args, **kwargs)
+
+    len_args = len(args)
+
+    if len_args > max_positional:
+        raise TypeError(
+            f"Too many positional arguments: expected max {max_positional}, got {len_args}"
+        )
+
+    arguments: dict[str, Any] = {}
+    arg_i = 0
+
+    for p in params:
+        name = p.name
+        kind = p.kind
+
+        if kind is inspect.Parameter.POSITIONAL_ONLY:
+            if name in kwargs:
+                raise TypeError(
+                    f"Got some positional-only arguments passed as keyword arguments: '{name}'"
+                )
+            if arg_i < len_args:
+                arguments[name] = args[arg_i]
+                arg_i += 1
+            elif p.default is inspect.Parameter.empty:
+                raise TypeError(f"Missing required argument '{name}'")
+
+        elif kind is inspect.Parameter.POSITIONAL_OR_KEYWORD:
+            if arg_i < len_args:
+                if name in kwargs:
+                    raise TypeError(f"Multiple values for argument '{name}'")
+                arguments[name] = args[arg_i]
+                arg_i += 1
+            elif name in kwargs:
+                arguments[name] = kwargs[name]
+            elif p.default is inspect.Parameter.empty:
+                raise TypeError(f"Missing required argument '{name}'")
+
+        elif kind is inspect.Parameter.KEYWORD_ONLY:
+            if name in kwargs:
+                arguments[name] = kwargs[name]
+            elif p.default is inspect.Parameter.empty:
+                raise TypeError(f"Missing required argument '{name}'")
+
+    # disallow extra keyword arguments not in the signature
+    # cause kwargs have been processed by sig.bind at the beginning
+    for name in kwargs:
+        if name not in sig.parameters:
+            raise TypeError(f"Got an unexpected keyword argument '{name}'")
+
+    return inspect.BoundArguments(sig, arguments)  # type: ignore[arg-type]


### PR DESCRIPTION
## Motivation                                                                                                                                      
                                                                                                                                                     
  torch.fx.operator_schemas uses inspect.Signature.bind() in hot paths to (1) identify a matching overload/schema and (2) normalize args/kwargs into 
  a canonical form. While Signature.bind() is correct and general, it is relatively expensive for the limited signature shapes we typically handle   
  here.                                                                                                                                              
                                                                                                                                                     
  This overhead is especially visible in FakeTensor-heavy workflows (e.g., FakeTensor dispatch, meta/fake execution, and tracing paths), where       
  overall runtime is dominated by Python-side overhead rather than compute. Repeated signature binding can become a measurable contributor to end-to-
  end time.     

<img width="3070" height="818" alt="image" src="https://github.com/user-attachments/assets/b25c24fb-0659-4cc2-a19a-b87952492302" />
                                                                                                                                     
                                                                                                                                                     
  ## What this PR does                                                                                                                               
                                                                                                                                                     
  • Introduces _fast_bind(sig, args, kwargs) in torch/fx/operator_schemas.py as a fast-path subset of inspect.Signature.bind():                      
    • Supports POSITIONAL_ONLY, POSITIONAL_OR_KEYWORD, and KEYWORD_ONLY parameters (including defaults and common error cases).                      
    • Falls back to sig.bind(*args, **kwargs) for signatures containing *args / **kwargs (VAR_POSITIONAL / VAR_KEYWORD) to preserve correctness.     
  • Replaces multiple sig.bind(...) call sites in schema matching and normalization logic with _fast_bind(...).                                      
  • Adds a dedicated unit test suite to validate behavior matches Signature.bind() across a broad set of scenarios, including:                       
    • positional-only parameters (including the common "from"-style schema pattern),                                                                 
    • keyword-only parameters,                                                                                                                       
    • defaults / missing args / conflicting args,                                                                                                    
    • fallback behavior for VAR_POSITIONAL / VAR_KEYWORD.                                                                                            
                                                                                                                                                     
                                                                                                                                                     
  ## Why this is safe                                                                                                                                
                                                                                                                                                     
  • The fast path targets the parameter kinds already expected/handled by operator_schemas.py.                                                       
  • Complex signatures explicitly fall back to Signature.bind() to avoid semantic drift.                                                             
  • Tests compare BoundArguments results (including apply_defaults() behavior) against Signature.bind().                                             
                                                                                                                                                     
  ## Expected impact                                                                                                                                 
                                                                                                                                                     
  • Reduced Python overhead in FX operator schema matching and argument normalization(20x faster).                                                               
  • Improved throughput for FakeTensor-heavy execution (FakeTensor dispatch/tracing), where repeated binding costs are amplified.
  • End-to-End duration 5x faster for 10B model
<img width="2722" height="1168" alt="image" src="https://github.com/user-attachments/assets/a49d6c92-c306-4767-b3ec-0fe178a2b9e0" />

@bobrenjc93 @laithsakka could you help review this PR, thanks!
