### PR TITLE
Fixes MSELoss failing to compute the gradients when inputs have different dtype

### DIFF
--- a/aten/src/ATen/native/Loss.cpp
+++ b/aten/src/ATen/native/Loss.cpp
@@ -489,6 +489,9 @@ Tensor& mse_loss_backward_out(const Tensor& grad_output,
     .add_const_input(input)
     .add_const_input(target)
     .add_const_input(grad_output)
+    .promote_inputs_to_common_dtype(true)
+    .cast_common_dtype_to_outputs(true)
+    .enforce_safe_casting_to_output(true)
     .build();
   mse_backward_stub(iter.device_type(), iter, norm);
   return grad_input;

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2682,7 +2682,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         expected_grad_y = torch.tensor([0.5, 0.5], dtype=torch.float64)
         self.assertTrue(torch.allclose(x.grad, expected_grad_x), f"Expected {expected_grad_x}, but got {x.grad}")
         self.assertTrue(torch.allclose(y.grad, expected_grad_y), f"Expected {expected_grad_y}, but got {y.grad}")
-        
+
     def test_weighted_l1_loss_with_weights(self):
         inputs = torch.tensor([1.0, 2.0, 3.0, 4.0], requires_grad=True)
         targets = torch.tensor([1.5, 2.5, 3.5, 4.5])

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2668,20 +2668,59 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         self.assertTrue(torch.isclose(loss, expected_loss), f"Expected {expected_loss}, but got {loss}")
 
     def test_mse_loss_mixed_dtype_grad(self):
-        x = torch.tensor([1.0, 2.0], dtype=torch.float32, requires_grad=True)
-        y = torch.tensor([1.5, 2.5], dtype=torch.float64, requires_grad=True)
-        loss = F.mse_loss(x, y, reduction='mean')
-        expected_loss = torch.tensor(0.25, dtype=torch.float64)
-        self.assertTrue(torch.isclose(loss, expected_loss), f"Expected {expected_loss}, but got {loss}")
-        loss.backward()
-        self.assertIsNotNone(x.grad)
-        self.assertIsNotNone(y.grad)
-        self.assertEqual(x.grad.dtype, torch.float32)
-        self.assertEqual(y.grad.dtype, torch.float64)
-        expected_grad_x = torch.tensor([-0.5, -0.5], dtype=torch.float32)
-        expected_grad_y = torch.tensor([0.5, 0.5], dtype=torch.float64)
-        self.assertTrue(torch.allclose(x.grad, expected_grad_x), f"Expected {expected_grad_x}, but got {x.grad}")
-        self.assertTrue(torch.allclose(y.grad, expected_grad_y), f"Expected {expected_grad_y}, but got {y.grad}")
+        for reduction in ['mean', 'sum', 'none']:
+            x = torch.tensor([1.0, 2.0], dtype=torch.float32, requires_grad=True)
+            y = torch.tensor([1.5, 2.5], dtype=torch.float64, requires_grad=True)
+            loss = F.mse_loss(x, y, reduction=reduction)
+            if reduction == 'mean':
+                expected_loss = torch.tensor(0.25, dtype=torch.float64)
+                expected_grad_x = torch.tensor([-0.5, -0.5], dtype=torch.float32)
+                expected_grad_y = torch.tensor([0.5, 0.5], dtype=torch.float64)
+            elif reduction == 'sum':
+                expected_loss = torch.tensor(0.5, dtype=torch.float64)
+                expected_grad_x = torch.tensor([-1.0, -1.0], dtype=torch.float32)
+                expected_grad_y = torch.tensor([1.0, 1.0], dtype=torch.float64)
+            else:  # 'none'
+                expected_loss = torch.tensor([0.25, 0.25], dtype=torch.float64)
+                expected_grad_x = torch.tensor([-1.0, -1.0], dtype=torch.float32)
+                expected_grad_y = torch.tensor([1.0, 1.0], dtype=torch.float64)
+            self.assertEqual(loss, expected_loss, atol=1e-6, rtol=0)
+            grad = torch.ones_like(loss) if reduction == 'none' else None
+            loss.backward(grad)
+            self.assertIsNotNone(x.grad)
+            self.assertIsNotNone(y.grad)
+            self.assertEqual(x.grad.dtype, torch.float32)
+            self.assertEqual(y.grad.dtype, torch.float64)
+            self.assertEqual(x.grad, expected_grad_x, atol=1e-6, rtol=0)
+            self.assertEqual(y.grad, expected_grad_y, atol=1e-6, rtol=0)
+
+    @unittest.skipIf(not TEST_CUDA, 'CUDA not available')
+    def test_mse_loss_mixed_dtype_grad_cuda(self):
+        for reduction in ['mean', 'sum', 'none']:
+            x = torch.tensor([1.0, 2.0], dtype=torch.float32, requires_grad=True, device='cuda')
+            y = torch.tensor([1.5, 2.5], dtype=torch.float64, requires_grad=True, device='cuda')
+            loss = F.mse_loss(x, y, reduction=reduction)
+            if reduction == 'mean':
+                expected_loss = torch.tensor(0.25, dtype=torch.float64, device='cuda')
+                expected_grad_x = torch.tensor([-0.5, -0.5], dtype=torch.float32, device='cuda')
+                expected_grad_y = torch.tensor([0.5, 0.5], dtype=torch.float64, device='cuda')
+            elif reduction == 'sum':
+                expected_loss = torch.tensor(0.5, dtype=torch.float64, device='cuda')
+                expected_grad_x = torch.tensor([-1.0, -1.0], dtype=torch.float32, device='cuda')
+                expected_grad_y = torch.tensor([1.0, 1.0], dtype=torch.float64, device='cuda')
+            else:  # 'none'
+                expected_loss = torch.tensor([0.25, 0.25], dtype=torch.float64, device='cuda')
+                expected_grad_x = torch.tensor([-1.0, -1.0], dtype=torch.float32, device='cuda')
+                expected_grad_y = torch.tensor([1.0, 1.0], dtype=torch.float64, device='cuda')
+            self.assertEqual(loss, expected_loss, atol=1e-6, rtol=0)
+            grad = torch.ones_like(loss) if reduction == 'none' else None
+            loss.backward(grad)
+            self.assertIsNotNone(x.grad)
+            self.assertIsNotNone(y.grad)
+            self.assertEqual(x.grad.dtype, torch.float32)
+            self.assertEqual(y.grad.dtype, torch.float64)
+            self.assertEqual(x.grad, expected_grad_x, atol=1e-6, rtol=0)
+            self.assertEqual(y.grad, expected_grad_y, atol=1e-6, rtol=0)
 
     def test_weighted_l1_loss_with_weights(self):
         inputs = torch.tensor([1.0, 2.0, 3.0, 4.0], requires_grad=True)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2668,61 +2668,34 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         self.assertTrue(torch.isclose(loss, expected_loss), f"Expected {expected_loss}, but got {loss}")
 
     def test_mse_loss_mixed_dtype_grad(self):
-        for reduction in ['mean', 'sum', 'none']:
-            with self.subTest(reduction=reduction):
-                x = torch.tensor([1.0, 2.0], dtype=torch.float32, requires_grad=True)
-                y = torch.tensor([1.5, 2.5], dtype=torch.float64, requires_grad=True)
-                loss = F.mse_loss(x, y, reduction=reduction)
-                if reduction == 'mean':
-                    expected_loss = torch.tensor(0.25, dtype=torch.float64)
-                    expected_grad_x = torch.tensor([-0.5, -0.5], dtype=torch.float32)
-                    expected_grad_y = torch.tensor([0.5, 0.5], dtype=torch.float64)
-                elif reduction == 'sum':
-                    expected_loss = torch.tensor(0.5, dtype=torch.float64)
-                    expected_grad_x = torch.tensor([-1.0, -1.0], dtype=torch.float32)
-                    expected_grad_y = torch.tensor([1.0, 1.0], dtype=torch.float64)
-                else:  # 'none'
-                    expected_loss = torch.tensor([0.25, 0.25], dtype=torch.float64)
-                    expected_grad_x = torch.tensor([-1.0, -1.0], dtype=torch.float32)
-                    expected_grad_y = torch.tensor([1.0, 1.0], dtype=torch.float64)
-                self.assertEqual(loss, expected_loss, atol=1e-6, rtol=0)
-                grad = torch.ones_like(loss) if reduction == 'none' else None
-                loss.backward(grad)
-                self.assertIsNotNone(x.grad)
-                self.assertIsNotNone(y.grad)
-                self.assertEqual(x.grad.dtype, torch.float32)
-                self.assertEqual(y.grad.dtype, torch.float64)
-                self.assertEqual(x.grad, expected_grad_x, atol=1e-6, rtol=0)
-                self.assertEqual(y.grad, expected_grad_y, atol=1e-6, rtol=0)
-
-    @unittest.skipIf(not TEST_CUDA, 'CUDA not available')
-    def test_mse_loss_mixed_dtype_grad_cuda(self):
-        for reduction in ['mean', 'sum', 'none']:
-            with self.subTest(reduction=reduction):
-                x = torch.tensor([1.0, 2.0], dtype=torch.float32, requires_grad=True, device='cuda')
-                y = torch.tensor([1.5, 2.5], dtype=torch.float64, requires_grad=True, device='cuda')
-                loss = F.mse_loss(x, y, reduction=reduction)
-                if reduction == 'mean':
-                    expected_loss = torch.tensor(0.25, dtype=torch.float64, device='cuda')
-                    expected_grad_x = torch.tensor([-0.5, -0.5], dtype=torch.float32, device='cuda')
-                    expected_grad_y = torch.tensor([0.5, 0.5], dtype=torch.float64, device='cuda')
-                elif reduction == 'sum':
-                    expected_loss = torch.tensor(0.5, dtype=torch.float64, device='cuda')
-                    expected_grad_x = torch.tensor([-1.0, -1.0], dtype=torch.float32, device='cuda')
-                    expected_grad_y = torch.tensor([1.0, 1.0], dtype=torch.float64, device='cuda')
-                else:  # 'none'
-                    expected_loss = torch.tensor([0.25, 0.25], dtype=torch.float64, device='cuda')
-                    expected_grad_x = torch.tensor([-1.0, -1.0], dtype=torch.float32, device='cuda')
-                    expected_grad_y = torch.tensor([1.0, 1.0], dtype=torch.float64, device='cuda')
-                self.assertEqual(loss, expected_loss, atol=1e-6, rtol=0)
-                grad = torch.ones_like(loss) if reduction == 'none' else None
-                loss.backward(grad)
-                self.assertIsNotNone(x.grad)
-                self.assertIsNotNone(y.grad)
-                self.assertEqual(x.grad.dtype, torch.float32)
-                self.assertEqual(y.grad.dtype, torch.float64)
-                self.assertEqual(x.grad, expected_grad_x, atol=1e-6, rtol=0)
-                self.assertEqual(y.grad, expected_grad_y, atol=1e-6, rtol=0)
+        devices = ['cpu'] + (['cuda'] if TEST_CUDA else [])
+        for device in devices:
+            for reduction in ['mean', 'sum', 'none']:
+                with self.subTest(device=device, reduction=reduction):
+                    x = torch.tensor([1.0, 2.0], dtype=torch.float32, requires_grad=True, device=device)
+                    y = torch.tensor([1.5, 2.5], dtype=torch.float64, requires_grad=True, device=device)
+                    loss = F.mse_loss(x, y, reduction=reduction)
+                    if reduction == 'mean':
+                        expected_loss = torch.tensor(0.25, dtype=torch.float64, device=device)
+                        expected_grad_x = torch.tensor([-0.5, -0.5], dtype=torch.float32, device=device)
+                        expected_grad_y = torch.tensor([0.5, 0.5], dtype=torch.float64, device=device)
+                    elif reduction == 'sum':
+                        expected_loss = torch.tensor(0.5, dtype=torch.float64, device=device)
+                        expected_grad_x = torch.tensor([-1.0, -1.0], dtype=torch.float32, device=device)
+                        expected_grad_y = torch.tensor([1.0, 1.0], dtype=torch.float64, device=device)
+                    else:  # 'none'
+                        expected_loss = torch.tensor([0.25, 0.25], dtype=torch.float64, device=device)
+                        expected_grad_x = torch.tensor([-1.0, -1.0], dtype=torch.float32, device=device)
+                        expected_grad_y = torch.tensor([1.0, 1.0], dtype=torch.float64, device=device)
+                    self.assertEqual(loss, expected_loss, atol=1e-6, rtol=0)
+                    grad = torch.ones_like(loss) if reduction == 'none' else None
+                    loss.backward(grad)
+                    self.assertIsNotNone(x.grad)
+                    self.assertIsNotNone(y.grad)
+                    self.assertEqual(x.grad.dtype, torch.float32)
+                    self.assertEqual(y.grad.dtype, torch.float64)
+                    self.assertEqual(x.grad, expected_grad_x, atol=1e-6, rtol=0)
+                    self.assertEqual(y.grad, expected_grad_y, atol=1e-6, rtol=0)
 
     def test_weighted_l1_loss_with_weights(self):
         inputs = torch.tensor([1.0, 2.0, 3.0, 4.0], requires_grad=True)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2669,58 +2669,60 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
 
     def test_mse_loss_mixed_dtype_grad(self):
         for reduction in ['mean', 'sum', 'none']:
-            x = torch.tensor([1.0, 2.0], dtype=torch.float32, requires_grad=True)
-            y = torch.tensor([1.5, 2.5], dtype=torch.float64, requires_grad=True)
-            loss = F.mse_loss(x, y, reduction=reduction)
-            if reduction == 'mean':
-                expected_loss = torch.tensor(0.25, dtype=torch.float64)
-                expected_grad_x = torch.tensor([-0.5, -0.5], dtype=torch.float32)
-                expected_grad_y = torch.tensor([0.5, 0.5], dtype=torch.float64)
-            elif reduction == 'sum':
-                expected_loss = torch.tensor(0.5, dtype=torch.float64)
-                expected_grad_x = torch.tensor([-1.0, -1.0], dtype=torch.float32)
-                expected_grad_y = torch.tensor([1.0, 1.0], dtype=torch.float64)
-            else:  # 'none'
-                expected_loss = torch.tensor([0.25, 0.25], dtype=torch.float64)
-                expected_grad_x = torch.tensor([-1.0, -1.0], dtype=torch.float32)
-                expected_grad_y = torch.tensor([1.0, 1.0], dtype=torch.float64)
-            self.assertEqual(loss, expected_loss, atol=1e-6, rtol=0)
-            grad = torch.ones_like(loss) if reduction == 'none' else None
-            loss.backward(grad)
-            self.assertIsNotNone(x.grad)
-            self.assertIsNotNone(y.grad)
-            self.assertEqual(x.grad.dtype, torch.float32)
-            self.assertEqual(y.grad.dtype, torch.float64)
-            self.assertEqual(x.grad, expected_grad_x, atol=1e-6, rtol=0)
-            self.assertEqual(y.grad, expected_grad_y, atol=1e-6, rtol=0)
+            with self.subTest(reduction=reduction):
+                x = torch.tensor([1.0, 2.0], dtype=torch.float32, requires_grad=True)
+                y = torch.tensor([1.5, 2.5], dtype=torch.float64, requires_grad=True)
+                loss = F.mse_loss(x, y, reduction=reduction)
+                if reduction == 'mean':
+                    expected_loss = torch.tensor(0.25, dtype=torch.float64)
+                    expected_grad_x = torch.tensor([-0.5, -0.5], dtype=torch.float32)
+                    expected_grad_y = torch.tensor([0.5, 0.5], dtype=torch.float64)
+                elif reduction == 'sum':
+                    expected_loss = torch.tensor(0.5, dtype=torch.float64)
+                    expected_grad_x = torch.tensor([-1.0, -1.0], dtype=torch.float32)
+                    expected_grad_y = torch.tensor([1.0, 1.0], dtype=torch.float64)
+                else:  # 'none'
+                    expected_loss = torch.tensor([0.25, 0.25], dtype=torch.float64)
+                    expected_grad_x = torch.tensor([-1.0, -1.0], dtype=torch.float32)
+                    expected_grad_y = torch.tensor([1.0, 1.0], dtype=torch.float64)
+                self.assertEqual(loss, expected_loss, atol=1e-6, rtol=0)
+                grad = torch.ones_like(loss) if reduction == 'none' else None
+                loss.backward(grad)
+                self.assertIsNotNone(x.grad)
+                self.assertIsNotNone(y.grad)
+                self.assertEqual(x.grad.dtype, torch.float32)
+                self.assertEqual(y.grad.dtype, torch.float64)
+                self.assertEqual(x.grad, expected_grad_x, atol=1e-6, rtol=0)
+                self.assertEqual(y.grad, expected_grad_y, atol=1e-6, rtol=0)
 
     @unittest.skipIf(not TEST_CUDA, 'CUDA not available')
     def test_mse_loss_mixed_dtype_grad_cuda(self):
         for reduction in ['mean', 'sum', 'none']:
-            x = torch.tensor([1.0, 2.0], dtype=torch.float32, requires_grad=True, device='cuda')
-            y = torch.tensor([1.5, 2.5], dtype=torch.float64, requires_grad=True, device='cuda')
-            loss = F.mse_loss(x, y, reduction=reduction)
-            if reduction == 'mean':
-                expected_loss = torch.tensor(0.25, dtype=torch.float64, device='cuda')
-                expected_grad_x = torch.tensor([-0.5, -0.5], dtype=torch.float32, device='cuda')
-                expected_grad_y = torch.tensor([0.5, 0.5], dtype=torch.float64, device='cuda')
-            elif reduction == 'sum':
-                expected_loss = torch.tensor(0.5, dtype=torch.float64, device='cuda')
-                expected_grad_x = torch.tensor([-1.0, -1.0], dtype=torch.float32, device='cuda')
-                expected_grad_y = torch.tensor([1.0, 1.0], dtype=torch.float64, device='cuda')
-            else:  # 'none'
-                expected_loss = torch.tensor([0.25, 0.25], dtype=torch.float64, device='cuda')
-                expected_grad_x = torch.tensor([-1.0, -1.0], dtype=torch.float32, device='cuda')
-                expected_grad_y = torch.tensor([1.0, 1.0], dtype=torch.float64, device='cuda')
-            self.assertEqual(loss, expected_loss, atol=1e-6, rtol=0)
-            grad = torch.ones_like(loss) if reduction == 'none' else None
-            loss.backward(grad)
-            self.assertIsNotNone(x.grad)
-            self.assertIsNotNone(y.grad)
-            self.assertEqual(x.grad.dtype, torch.float32)
-            self.assertEqual(y.grad.dtype, torch.float64)
-            self.assertEqual(x.grad, expected_grad_x, atol=1e-6, rtol=0)
-            self.assertEqual(y.grad, expected_grad_y, atol=1e-6, rtol=0)
+            with self.subTest(reduction=reduction):
+                x = torch.tensor([1.0, 2.0], dtype=torch.float32, requires_grad=True, device='cuda')
+                y = torch.tensor([1.5, 2.5], dtype=torch.float64, requires_grad=True, device='cuda')
+                loss = F.mse_loss(x, y, reduction=reduction)
+                if reduction == 'mean':
+                    expected_loss = torch.tensor(0.25, dtype=torch.float64, device='cuda')
+                    expected_grad_x = torch.tensor([-0.5, -0.5], dtype=torch.float32, device='cuda')
+                    expected_grad_y = torch.tensor([0.5, 0.5], dtype=torch.float64, device='cuda')
+                elif reduction == 'sum':
+                    expected_loss = torch.tensor(0.5, dtype=torch.float64, device='cuda')
+                    expected_grad_x = torch.tensor([-1.0, -1.0], dtype=torch.float32, device='cuda')
+                    expected_grad_y = torch.tensor([1.0, 1.0], dtype=torch.float64, device='cuda')
+                else:  # 'none'
+                    expected_loss = torch.tensor([0.25, 0.25], dtype=torch.float64, device='cuda')
+                    expected_grad_x = torch.tensor([-1.0, -1.0], dtype=torch.float32, device='cuda')
+                    expected_grad_y = torch.tensor([1.0, 1.0], dtype=torch.float64, device='cuda')
+                self.assertEqual(loss, expected_loss, atol=1e-6, rtol=0)
+                grad = torch.ones_like(loss) if reduction == 'none' else None
+                loss.backward(grad)
+                self.assertIsNotNone(x.grad)
+                self.assertIsNotNone(y.grad)
+                self.assertEqual(x.grad.dtype, torch.float32)
+                self.assertEqual(y.grad.dtype, torch.float64)
+                self.assertEqual(x.grad, expected_grad_x, atol=1e-6, rtol=0)
+                self.assertEqual(y.grad, expected_grad_y, atol=1e-6, rtol=0)
 
     def test_weighted_l1_loss_with_weights(self):
         inputs = torch.tensor([1.0, 2.0, 3.0, 4.0], requires_grad=True)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2671,31 +2671,26 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         devices = ['cpu'] + (['cuda'] if TEST_CUDA else [])
         for device in devices:
             for reduction in ['mean', 'sum', 'none']:
-                with self.subTest(device=device, reduction=reduction):
-                    x = torch.tensor([1.0, 2.0], dtype=torch.float32, requires_grad=True, device=device)
-                    y = torch.tensor([1.5, 2.5], dtype=torch.float64, requires_grad=True, device=device)
-                    loss = F.mse_loss(x, y, reduction=reduction)
-                    if reduction == 'mean':
-                        expected_loss = torch.tensor(0.25, dtype=torch.float64, device=device)
-                        expected_grad_x = torch.tensor([-0.5, -0.5], dtype=torch.float32, device=device)
-                        expected_grad_y = torch.tensor([0.5, 0.5], dtype=torch.float64, device=device)
-                    elif reduction == 'sum':
-                        expected_loss = torch.tensor(0.5, dtype=torch.float64, device=device)
-                        expected_grad_x = torch.tensor([-1.0, -1.0], dtype=torch.float32, device=device)
-                        expected_grad_y = torch.tensor([1.0, 1.0], dtype=torch.float64, device=device)
-                    else:  # 'none'
-                        expected_loss = torch.tensor([0.25, 0.25], dtype=torch.float64, device=device)
-                        expected_grad_x = torch.tensor([-1.0, -1.0], dtype=torch.float32, device=device)
-                        expected_grad_y = torch.tensor([1.0, 1.0], dtype=torch.float64, device=device)
-                    self.assertEqual(loss, expected_loss, atol=1e-6, rtol=0)
-                    grad = torch.ones_like(loss) if reduction == 'none' else None
-                    loss.backward(grad)
-                    self.assertIsNotNone(x.grad)
-                    self.assertIsNotNone(y.grad)
-                    self.assertEqual(x.grad.dtype, torch.float32)
-                    self.assertEqual(y.grad.dtype, torch.float64)
-                    self.assertEqual(x.grad, expected_grad_x, atol=1e-6, rtol=0)
-                    self.assertEqual(y.grad, expected_grad_y, atol=1e-6, rtol=0)
+                x = torch.tensor([1.0, 2.0], dtype=torch.float32, requires_grad=True, device=device)
+                y = torch.tensor([1.5, 2.5], dtype=torch.float64, requires_grad=True, device=device)
+                loss = F.mse_loss(x, y, reduction=reduction)
+                if reduction == 'mean':
+                    expected_loss = torch.tensor(0.25, dtype=torch.float64, device=device)
+                    expected_grad_x = torch.tensor([-0.5, -0.5], dtype=torch.float32, device=device)
+                    expected_grad_y = torch.tensor([0.5, 0.5], dtype=torch.float64, device=device)
+                elif reduction == 'sum':
+                    expected_loss = torch.tensor(0.5, dtype=torch.float64, device=device)
+                    expected_grad_x = torch.tensor([-1.0, -1.0], dtype=torch.float32, device=device)
+                    expected_grad_y = torch.tensor([1.0, 1.0], dtype=torch.float64, device=device)
+                else:  # 'none'
+                    expected_loss = torch.tensor([0.25, 0.25], dtype=torch.float64, device=device)
+                    expected_grad_x = torch.tensor([-1.0, -1.0], dtype=torch.float32, device=device)
+                    expected_grad_y = torch.tensor([1.0, 1.0], dtype=torch.float64, device=device)
+                self.assertEqual(loss, expected_loss, atol=1e-6, rtol=0)
+                grad = torch.ones_like(loss) if reduction == 'none' else None
+                loss.backward(grad)
+                self.assertEqual(x.grad, expected_grad_x, atol=1e-6, rtol=0)
+                self.assertEqual(y.grad, expected_grad_y, atol=1e-6, rtol=0)
 
     def test_weighted_l1_loss_with_weights(self):
         inputs = torch.tensor([1.0, 2.0, 3.0, 4.0], requires_grad=True)


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/94086

Summary:

In aten/src/ATen/native/Loss.cpp (mse_loss_backward_out), setting promote_inputs_to_common_dtype(true), cast_common_dtype_to_outputs(true), and enforce_safe_casting_to_output(true) on the backward TensorIterator so gradients match each tensor’s dtype as per  [this](https://github.com/pytorch/pytorch/issues/94086#issuecomment-1426008120)

cc @ezyang @albanD @zou3519 @gqchen @pearu @nikitaved @soulitzer @lezcano @Varal7 @mruberry @jbschlosser @walterddr @saketh-are