### PR TITLE
[dynamo][precompile] lazy initialize for precompile package

### DIFF
--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -72,6 +72,7 @@ from torch.testing._internal.inductor_utils import (
     patch_inductor_backend,
     requires_gpu,
     requires_triton,
+    RUN_CPU,
 )
 from torch.testing._internal.triton_utils import (
     requires_cuda_and_triton,
@@ -630,6 +631,97 @@ class TestFxGraphCache(TestCase):
             self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 2)
             self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 1)
             self.assertEqual(counters["inductor"]["fxgraph_lookup_write_file"], 1)
+
+    @requires_triton()
+    @config.patch(
+        {
+            "fx_graph_cache": True,
+            "fx_graph_remote_cache": False,
+        }
+    )
+    @torch._dynamo.config.patch(
+        {
+            "caching_precompile": True,
+        }
+    )
+    @parametrize("device", (GPU_TYPE, "cpu"))
+    @parametrize("dtype", (torch.float32, torch.bfloat16))
+    @parametrize("dynamic", (False, True))
+    @torch._functorch.config.patch({"enable_autograd_cache": True})
+    def test_caching_precompile_with_func_mode(self, device, dtype, dynamic):
+        """
+        Verify that we can hot load functions from the cache with global ctx.
+        """
+        if device == GPU_TYPE and not HAS_GPU:
+            raise unittest.SkipTest(f"requires {GPU_TYPE}")
+        if RUN_CPU and dtype == torch.float32:
+            raise unittest.SkipTest("skip float32 on CPU")
+        if (
+            device == "cuda"
+            and torch.version.hip is None
+            and dtype == torch.bfloat16
+            and not SM80OrLater
+        ):
+            raise unittest.SkipTest("requires SM80 or later")
+
+        def fn(x, y):
+            return x.cos() @ y
+
+        a = torch.rand(100, 100, dtype=dtype, device=device, requires_grad=True)
+        b = torch.rand(100, 100, dtype=dtype, device=device, requires_grad=True)
+
+        # Record artifacts
+        with fresh_cache():
+            compiled_fn = torch.compile(fn, dynamic=dynamic)
+
+            # A first call should miss in the cache.
+            with torch.amp.autocast(device_type=device, dtype=dtype):
+                eager_result = fn(a, b)
+                compiled_result = compiled_fn(a, b)
+            self.assertEqual(eager_result, compiled_result)
+            self.assertEqual(counters["dynamo_cache"]["dynamo_cache_miss"], 1)
+            self.assertEqual(counters["dynamo_cache"]["dynamo_cache_hit"], 0)
+
+            artifacts = torch.compiler.save_cache_artifacts()
+
+        self.assertIsNotNone(artifacts)
+
+        artifact_bytes, cache_info = artifacts
+
+        self.assertEqual(len(cache_info.precompile_artifacts), 1)
+
+        self.reset()
+
+        # Clean triton kernels
+        shutil.rmtree(os.path.join(cache_dir(), "triton"), ignore_errors=True)
+
+        # We did not load anything so dont hit yet
+        with fresh_cache():
+            eager_result = fn(a, b)
+            # With caching precompile, we have to re torch.compile the function
+            # to trigger cache lookup
+            with torch.amp.autocast(device_type=device, dtype=dtype):
+                compiled_fn = torch.compile(fn, dynamic=dynamic)
+                compiled_result = compiled_fn(a, b)
+            self.assertEqual(eager_result, compiled_result)
+            self.assertEqual(counters["dynamo_cache"]["dynamo_cache_miss"], 2)
+            self.assertEqual(counters["dynamo_cache"]["dynamo_cache_hit"], 0)
+        # Hot load and hit
+        with fresh_cache(), torch.compiler.set_stance("fail_on_recompile"):
+            cache_info = torch.compiler.load_cache_artifacts(artifact_bytes)
+            self.assertEqual(len(cache_info.precompile_artifacts), 1)
+
+            # With caching precompile, we have to re torch.compile the function
+            # to trigger cache lookup
+            compiled_fn = torch.compile(fn, dynamic=dynamic)
+
+            with torch.amp.autocast(device_type=device, dtype=dtype):
+                eager_result = fn(a, b)
+                compiled_result = compiled_fn(a, b)
+            self.assertEqual(eager_result, compiled_result)
+            self.assertEqual(counters["dynamo_cache"]["dynamo_cache_miss"], 2)
+            self.assertEqual(counters["dynamo_cache"]["dynamo_cache_hit"], 1)
+        self.reset()
 
     @requires_triton()
     @config.patch(

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -816,30 +816,6 @@ class _TorchDynamoContext:
         def get_compiler_config() -> Any:
             return self.compiler_config
 
-        from .package import DynamoCache
-
-        # If self._package is lazily initialized, we should check the dynamo cache now
-        if config.caching_precompile:
-            if self._package is not None and not self._package.is_initialized():
-                fn_key = fn.forward if isinstance(fn, torch.nn.Module) else fn
-                result = DynamoCache.load(fn_key)
-                if result is None:
-                    # Create a fresh CompilePackage
-                    self._package.initialize(fn_key, None, ignore_inlined_sources=False)
-                else:
-                    try:
-                        self._package.initialize(
-                            fn_key, result.dynamo, ignore_inlined_sources=False
-                        )
-                        self._package.install(result.backends)
-                    except RuntimeError:
-                        log.warning(
-                            "Failed to load entry from dynamo cache", exc_info=True
-                        )
-                        self._package.initialize(
-                            fn_key, None, ignore_inlined_sources=False
-                        )
-
         fn = innermost_fn(fn)
 
         def aot_compile(example_inputs: tuple[tuple[Any, ...], dict[str, Any]]) -> Any:
@@ -947,6 +923,31 @@ class _TorchDynamoContext:
         @functools.wraps(fn)
         def compile_wrapper(*args: Any, **kwargs: Any) -> Any:
             prior = set_eval_frame(None)
+            # lazily initialize
+            if config.caching_precompile:
+                from .package import DynamoCache
+
+                if self._package is not None and not self._package.is_initialized():
+                    fn_key = fn.forward if isinstance(fn, torch.nn.Module) else fn
+                    result = DynamoCache.load(fn_key)
+                    if result is None:
+                        # Create a fresh CompilePackage
+                        self._package.initialize(
+                            fn_key, None, ignore_inlined_sources=False
+                        )
+                    else:
+                        try:
+                            self._package.initialize(
+                                fn_key, result.dynamo, ignore_inlined_sources=False
+                            )
+                            self._package.install(result.backends)
+                        except RuntimeError:
+                            log.warning(
+                                "Failed to load entry from dynamo cache", exc_info=True
+                            )
+                            self._package.initialize(
+                                fn_key, None, ignore_inlined_sources=False
+                            )
             prior_eval_frame_override: _EvalFrameOverride | None = None
             if self.fullgraph:
                 prior_eval_frame_override = set_eval_frame_override(


### PR DESCRIPTION
This PR fixes https://github.com/pytorch/pytorch/issues/175025

Maybe we need to postpone the initialization of the precompile package until the stage of starting the eval frame? This ensures the state is consistent when constructing the guard. After the modification, the case in the issue can pass.
We can discuss this.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Lucaskabela @azahed98