### PR TITLE
release notes prep: update instructions for module maintainers

### DIFF
--- a/scripts/release_notes/commitlist.py
+++ b/scripts/release_notes/commitlist.py
@@ -493,15 +493,18 @@ def get_markdown_header(category):
     header = f"""
 # Release Notes worksheet {category}
 
-The main goal of this process is to rephrase all the commit messages below to make them **clear and easy to read** by the end user. You should follow the following instructions to do so:
+You should:
 
-* **Please clean up and format commit titles to be readable by the general PyTorch user.** Make sure you're [following the guidance here](https://docs.google.com/document/d/14OmgGBr1w6gl1VO47GGGdwrIaUNr92DFhQbY_NEk8mQ/edit)! Your resulting notes must be consistent and easy to read.
+1. ensure commit categorization is correct
+2. write up major features, bc-breaking changes, deprecations in detail
+3. summarize the other sections
+
+## 1. Ensure commit categorization is correct
+
 * Please sort commits into the following categories (you should not rename the categories!), I tried to pre-sort these to ease your work, feel free to move commits around if the current categorization is not good.
 * Anything that is not public facing needs to be removed.
 * If anything is miscategorized/belongs to another domain, move it to `miscategorized.md`.
 * Please scan through `miscategorized.md` and handle any commits that belong within your domain according to these instructions.
-* We place a lot of emphasis on the “BC-breaking” and “deprecation” sections. Those should be where the most effort goes in. The “improvements” and “bug fixes” for Python API should be nice as well.
-* Once you are finished, move this very file from `todo/` to `done/` and submit a pull request.
 
 The categories below are as follows:
 
@@ -514,6 +517,23 @@ The categories below are as follows:
 * documentation: All commits that add/update documentation
 * Developers: All commits that are not end-user facing but still impact people that compile from source, develop into pytorch, extend pytorch, etc
 * not user facing: All commits that are not public end-user facing and hence should be dropped from the release notes
+
+## 2. Major features, BC-breaking changes, deprecations
+
+The main goal of this process is to rephrase all the commit messages below to make them **clear and easy to read** by the end user. You should follow the following instructions to do so:
+
+* **Please clean up and format commit titles to be readable by the general PyTorch user.** Make sure you're [following the guidance here](https://docs.google.com/document/d/14OmgGBr1w6gl1VO47GGGdwrIaUNr92DFhQbY_NEk8mQ/edit)! Your resulting notes must be consistent and easy to read.
+* We place a lot of emphasis on the “BC-breaking” and “deprecation” sections. Those should be where the most effort goes in. The “improvements” and “bug fixes” for Python API should be nice as well.
+
+## 3. Summarize the other sections
+
+For the other sections (improvements, bug fixes, performance, documentation, developers, not user facing) - use your
+judgement to summarize the key PRs. You do not need to make every commit description perfect
+(changed in v2.10 to simplify the process).
+
+Once you are finished, move this very file from `todo/` to `done/` and submit a pull request.
+
+Feel free to use https://github.com/pytorch/pytorch/releases/tag/v2.10.0 as an example.
 """
 
     return [header]


### PR DESCRIPTION
Summary:

Updates the release notes summarization instructions for module maintainers.

Test Plan:

```bash
python commitlist.py --export_markdown
```