### PR TITLE
Fix cuDNN SDPA with zero-stride (broadcast) Q/K/V inputs

### DIFF
--- a/aten/src/ATen/native/transformers/sdp_utils.h
+++ b/aten/src/ATen/native/transformers/sdp_utils.h
@@ -21,6 +21,10 @@ void alloc_with_matching_layout(
   std::vector<int> fill_order(shape.size());
   std::iota(fill_order.begin(), fill_order.end(), 0);
   const auto q_strides = q.strides();
+  // note: why INT64_MAX instead of 1.
+  // When Q's strides include 0, e.g. (0, 0, 128, 1), mapping stride 0 to 1 leads to
+  // fill_order of [0, 1, 3, 2], i.e. the output strides are [1, 8, 1024, 16].
+  // To match output strides with Q, use INT64_MAx so that broadcast dims come last in fill_order.
   std::stable_sort(
       fill_order.begin(), fill_order.end(), [&q_strides](int idx1, int idx2) {
         int64_t s1 = q_strides[idx1] ? q_strides[idx1] : INT64_MAX;

--- a/aten/src/ATen/native/transformers/sdp_utils.h
+++ b/aten/src/ATen/native/transformers/sdp_utils.h
@@ -23,8 +23,8 @@ void alloc_with_matching_layout(
   const auto q_strides = q.strides();
   std::stable_sort(
       fill_order.begin(), fill_order.end(), [&q_strides](int idx1, int idx2) {
-        int64_t s1 = q_strides[idx1] ? q_strides[idx1] : 1;
-        int64_t s2 = q_strides[idx2] ? q_strides[idx2] : 1;
+        int64_t s1 = q_strides[idx1] ? q_strides[idx1] : INT64_MAX;
+        int64_t s2 = q_strides[idx2] ? q_strides[idx2] : INT64_MAX;
         return s1 < s2;
       });
   std::vector<int64_t> ordered_strides(shape.size());

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -2922,6 +2922,32 @@ class TestSDPACudaOnly(NNTestCase):
                 test_attention(SDPBackend.CUDNN_ATTENTION, list(permute_order) + [3], use_compile)
 
     @unittest.skipIf(not PLATFORM_SUPPORTS_CUDNN_ATTENTION, "cudnn Attention is not supported on this system")
+    @parametrize("dtype", [torch.float16, torch.bfloat16])
+    def test_cudnn_attention_broadcast_stride_zero(self, device, dtype):
+        # Regression test: Q/K/V with zero strides (broadcast via as_strided)
+        # caused alloc_with_matching_layout to produce output with stride[-1] != 1,
+        # which cuDNN Frontend rejects.
+        N, n_head, L, S, E, Ev = 8, 2, 64, 16, 128, 64
+        q = torch.randn(N, n_head, L, E, dtype=dtype, device=device)
+        k = torch.randn(N, n_head, S, E, dtype=dtype, device=device)
+        v = torch.randn(N, n_head, S, Ev, dtype=dtype, device=device)
+
+        q_bc = torch.as_strided(q, size=q.shape, stride=(0, 0, E, 1))
+        k_bc = torch.as_strided(k, size=k.shape, stride=(0, 0, E, 1))
+        v_bc = torch.as_strided(v, size=v.shape, stride=(0, 0, Ev, 1))
+
+        with sdpa_kernel(SDPBackend.CUDNN_ATTENTION):
+            out = F.scaled_dot_product_attention(q_bc, k_bc, v_bc, is_causal=True)
+
+        self.assertEqual(out.shape, (N, n_head, L, Ev))
+        self.assertEqual(out.stride(-1), 1)
+
+        out_ref = F.scaled_dot_product_attention(
+            q_bc.contiguous(), k_bc.contiguous(), v_bc.contiguous(), is_causal=True
+        )
+        torch.testing.assert_close(out, out_ref, atol=3e-3, rtol=3e-3)
+
+    @unittest.skipIf(not PLATFORM_SUPPORTS_CUDNN_ATTENTION, "cudnn Attention is not supported on this system")
     @unittest.skipIf(
         not (isSM90Device and torch.backends.cudnn.version() >= 91000),
         "head_dim > 128 requires SM90 with cuDNN >= 9.1.0"


### PR DESCRIPTION
`alloc_with_matching_layout` mapped stride-0 dims to 1 for sorting, causing them to tie with the actual stride-1 dim (head_dim).

stable_sort preserved original order for ties, placing broadcast dims first and producing output with stride[-1] != 1, which cuDNN Frontend rejects.

Map stride 0 to `INT64_MAX` instead so broadcast dims sort last, keeping stride[-1] = 1 for the output tensor.

Assisted by: claude 4.6 opus