### PR TITLE
[ROCm][CI] Always run reduced test set for ROCm Navi31 runners

### DIFF
--- a/.github/workflows/rocm-navi31.yml
+++ b/.github/workflows/rocm-navi31.yml
@@ -67,9 +67,8 @@ jobs:
       docker-image: ${{ needs.linux-jammy-rocm-py3_10-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-rocm-py3_10-build.outputs.test-matrix }}
       tests-to-include: >-
-         ${{ github.event_name == 'schedule' && 'test_nn test_torch test_cuda test_ops test_unary_ufuncs test_binary_ufuncs
          test_autograd inductor/test_torchinductor inductor/test_kernel_benchmark
          inductor/test_pad_mm inductor/test_benchmark_fusion inductor/test_aot_inductor
          inductor/test_torchinductor inductor/test_decompose_mem_bound_mm
-         inductor/test_flex_attention inductor/test_max_autotune' || '' }}
+         inductor/test_flex_attention inductor/test_max_autotune
     secrets: inherit


### PR DESCRIPTION
We cannot run all the test suites in `default` config using just 2 shards, it times out. However, due to insufficient Navi31 CI capacity, we cannot increase the shards per run either. Hence, reducing the test set to core unit tests unconditionally.

Testplan:
[rocm-navi31](https://github.com/pytorch/pytorch/actions/runs/22411229116/job/64893098527?pr=175770) passed

cc @jeffdaily @sunway513 @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang