### PR TITLE
[Inductor] Stricter heuristics for epilogue fusion to prevent unprofitable fusions

### DIFF
--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -4057,8 +4057,23 @@ class TestEpilogueFusionStaticAnalysis(TestCase):
         )
 
     @contextlib.contextmanager
-    def get_common_patches(self, async_compile: bool, persistent_tma: bool):
-        common_patches = (
+    def get_common_patches(
+        self,
+        async_compile: bool,
+        persistent_tma: bool,
+        *,
+        aten_time: float | None = None,
+        triton_time: float | None = None,
+        mock_n_spills: int | None = None,
+        mock_fused_n_regs: int | None = None,
+        mock_unfused_n_regs: int | None = None,
+        epilogue_runtime: float | None = None,
+    ):
+        from torch._inductor.autotune_process import TritonBenchmarkRequest
+        from torch._inductor.runtime.triton_heuristics import CachingAutotuner
+        from torch._inductor.scheduler import BaseSchedulerNode
+
+        common_patches = [
             config.patch(
                 {
                     "triton.enable_persistent_tma_matmul": persistent_tma,
@@ -4072,12 +4087,95 @@ class TestEpilogueFusionStaticAnalysis(TestCase):
                 autotune_select_algorithm_wrapper_return_multi(),
             ),
             fresh_cache(),
-        )
+        ]
+
+        if aten_time is not None and triton_time is not None:
+            common_patches.extend(
+                [
+                    mock.patch.object(
+                        AlgorithmSelectorCache,
+                        "benchmark_choice",
+                        mock_benchmark_choice_wrapper(aten_time, triton_time),
+                    ),
+                    mock.patch(
+                        "torch._inductor.autotune_process.run_autotune_in_subprocess",
+                        mock_benchmark_choice_wrapper(aten_time, triton_time),
+                    ),
+                ]
+            )
+
+        if mock_n_spills is not None or mock_fused_n_regs is not None:
+            original_precompile = CachingAutotuner.precompile
+
+            def mock_precompile(self, *args, **kwargs):
+                original_precompile(self, *args, **kwargs)
+                for launcher in self.launchers:
+                    if mock_n_spills is not None:
+                        launcher.n_spills = mock_n_spills
+                    if mock_fused_n_regs is not None:
+                        launcher.n_regs = mock_fused_n_regs
+
+            common_patches.append(
+                mock.patch.object(CachingAutotuner, "precompile", mock_precompile)
+            )
+
+        if mock_unfused_n_regs is not None:
+            original_bmreq_precompile = TritonBenchmarkRequest.precompile
+
+            def mock_bmreq_precompile(self):
+                original_bmreq_precompile(self)
+                self.n_regs = mock_unfused_n_regs
+
+            common_patches.append(
+                mock.patch.object(
+                    TritonBenchmarkRequest, "precompile", mock_bmreq_precompile
+                )
+            )
+
+        if epilogue_runtime is not None:
+            common_patches.append(
+                mock.patch.object(
+                    BaseSchedulerNode,
+                    "_get_estimated_runtime",
+                    lambda node: epilogue_runtime,
+                )
+            )
+
         with contextlib.ExitStack() as stack:
             for p in common_patches:
                 stack.enter_context(p)
 
             yield
+
+    def _get_mm_inputs(self):
+        """Common matmul inputs for epilogue fusion tests."""
+        a = torch.randn(512, 1024, device=GPU_TYPE, dtype=torch.bfloat16)
+        b = torch.randn(1024, 2048, device=GPU_TYPE, dtype=torch.bfloat16)
+        return a, b
+
+    def _get_mm_with_epilogue_fn(self):
+        """Common function: matmul with type cast and add epilogue."""
+
+        def f(a, b):
+            return (a @ b).to(torch.float32) + 1.0
+
+        return f
+
+    @contextlib.contextmanager
+    def _setup_mm_heuristic(self, use_async_compile: bool):
+        """Setup MM heuristic with single GemmConfig and handle cleanup."""
+        mm_heuristic = CUDAMMTemplateConfigHeuristic()
+        original_mm_configs = mm_heuristic.mm_configs
+        gemm_config = GemmConfig(64, 64, 32, 2, 4, group_m=8)
+        mm_heuristic.mm_configs = [gemm_config]
+
+        if use_async_compile:
+            torch._inductor.async_compile.AsyncCompile.wait_pool_ready()
+
+        try:
+            yield
+        finally:
+            mm_heuristic.mm_configs = original_mm_configs
 
     @unittest.skipIf(not has_triton_tma_device(), "Need TMA support in Triton")
     @skipIfXpu(msg="Bad tma config can be covered by XPU TMA")
@@ -4206,23 +4304,6 @@ class TestEpilogueFusionStaticAnalysis(TestCase):
         1. Register spillage (n_spills <= 8 required for fusion)
         2. Runtime comparison (epilogue_runtime + ms_min_choice > choice_timings[choice])
         """
-
-        def f(a, b):
-            return (a @ b).to(torch.float32) + 1.0
-
-        a = torch.randn(512, 1024, device=GPU_TYPE, dtype=torch.bfloat16)
-        b = torch.randn(1024, 2048, device=GPU_TYPE, dtype=torch.bfloat16)
-
-        mm_heuristic = CUDAMMTemplateConfigHeuristic()
-        original_mm_configs = mm_heuristic.mm_configs
-
-        # Use a single GemmConfig for the regular MM template
-        gemm_config = GemmConfig(64, 64, 32, 2, 4, group_m=8)
-        mm_heuristic.mm_configs = [gemm_config]
-
-        if use_async_compile:
-            torch._inductor.async_compile.AsyncCompile.wait_pool_ready()
-
         if test_case == "spills_reject":
             mock_n_spills = 100
             triton_time = 0.1
@@ -4241,41 +4322,24 @@ class TestEpilogueFusionStaticAnalysis(TestCase):
         elif test_case == "accept_with_aten_faster":
             mock_n_spills = 0
             triton_time = 0.1
-            aten_time = 0.100000001
+            aten_time = 0.09999
             expect_fusion = True
         else:
             raise RuntimeError("Invalid test case")
 
-        from torch._inductor.runtime.triton_heuristics import CachingAutotuner
+        f = self._get_mm_with_epilogue_fn()
+        a, b = self._get_mm_inputs()
 
-        original_precompile = CachingAutotuner.precompile
-
-        def mock_precompile(self, *args, **kwargs):
-            original_precompile(self, *args, **kwargs)
-            # After precompile, patch launchers with mock n_spills
-            for launcher in self.launchers:
-                launcher.n_spills = mock_n_spills
-
-        try:
-            with (
-                self.get_common_patches(use_async_compile, False),
-                mock.patch.object(
-                    AlgorithmSelectorCache,
-                    "benchmark_choice",
-                    mock_benchmark_choice_wrapper(aten_time, triton_time),
-                ),
-                mock.patch.object(
-                    CachingAutotuner,
-                    "precompile",
-                    mock_precompile,
-                ),
-                mock.patch(
-                    "torch._inductor.autotune_process.run_autotune_in_subprocess",
-                    mock_benchmark_choice_wrapper(aten_time, triton_time),
-                ),
+        with self._setup_mm_heuristic(use_async_compile):
+            with self.get_common_patches(
+                use_async_compile,
+                False,
+                aten_time=aten_time,
+                triton_time=triton_time,
+                mock_n_spills=mock_n_spills,
             ):
                 compiled_f = torch.compile(f)
-                out, code = run_and_get_code(compiled_f, a, b)
+                _, code = run_and_get_code(compiled_f, a, b)
 
                 if expect_fusion:
                     FileCheck().check("triton_tem_fused__to_copy_add_mm_0.run").run(
@@ -4290,14 +4354,6 @@ class TestEpilogueFusionStaticAnalysis(TestCase):
                         "triton_poi_fused__to_copy"
                     ).run(code[0])
 
-                # TODO (paulzhan): Accuracy fails with cpp_warpper, ok for now
-                # as path is only hit with Async Pipelined Autotuning
-                # mainly for training
-                if not config.cpp_wrapper:
-                    torch.testing.assert_close(out, f(a, b), atol=1e-2, rtol=1e-2)
-        finally:
-            mm_heuristic.mm_configs = original_mm_configs
-
     @unittest.skipIf(
         not HAS_CUDA_AND_TRITON, "Scheduler static analysis only tested on cuda"
     )
@@ -4307,7 +4363,8 @@ class TestEpilogueFusionStaticAnalysis(TestCase):
     def test_template_epilogue_fusion_extra_reads(
         self, fuse_epilogue: bool, use_async_compile: bool
     ):
-        # Function has 2 extra reads for epilogue, same size as write
+        """Test epilogue fusion with extra reads (bias and scale tensors)."""
+
         def fn(x, w, bias, scale):
             out = torch.mm(x, w)
             return out * scale + bias
@@ -4318,15 +4375,6 @@ class TestEpilogueFusionStaticAnalysis(TestCase):
         w = torch.randn(1024, 2048, device=GPU_TYPE, dtype=torch.bfloat16)
         bias = torch.randn(512, 2048, device=GPU_TYPE, dtype=torch.bfloat16)
         scale = torch.randn(512, 2048, device=GPU_TYPE, dtype=torch.bfloat16)
-
-        mm_heuristic = CUDAMMTemplateConfigHeuristic()
-        original_mm_configs = mm_heuristic.mm_configs
-
-        gemm_config = GemmConfig(64, 64, 32, 2, 4, group_m=8)
-        mm_heuristic.mm_configs = [gemm_config]
-
-        if use_async_compile:
-            torch._inductor.async_compile.AsyncCompile.wait_pool_ready()
 
         epilogue_runtime = 0.5
         aten_time = 1.0
@@ -4341,46 +4389,149 @@ class TestEpilogueFusionStaticAnalysis(TestCase):
         else:
             triton_time = unfused_time - estimated_fused + 0.01
 
-        from torch._inductor.scheduler import BaseSchedulerNode
-
-        def mock_get_estimated_runtime(node):
-            return epilogue_runtime
-
-        try:
-            with (
-                self.get_common_patches(use_async_compile, False),
-                mock.patch.object(
-                    AlgorithmSelectorCache,
-                    "benchmark_choice",
-                    mock_benchmark_choice_wrapper(aten_time, triton_time),
-                ),
-                mock.patch.object(
-                    BaseSchedulerNode,
-                    "_get_estimated_runtime",
-                    mock_get_estimated_runtime,
-                ),
-                mock.patch(
-                    "torch._inductor.autotune_process.run_autotune_in_subprocess",
-                    mock_benchmark_choice_wrapper(aten_time, triton_time),
-                ),
+        with self._setup_mm_heuristic(use_async_compile):
+            with self.get_common_patches(
+                use_async_compile,
+                False,
+                aten_time=aten_time,
+                triton_time=triton_time,
+                epilogue_runtime=epilogue_runtime,
             ):
                 compiled_fn = torch.compile(fn)
-                out, code = run_and_get_code(compiled_fn, x, w, bias, scale)
+                _, code = run_and_get_code(compiled_fn, x, w, bias, scale)
 
                 if fuse_epilogue:
                     FileCheck().check("triton_tem_fused_add_mm_mul").run(code[0])
                 else:
-                    # Aten wins in unfused case
                     FileCheck().check_not("triton_tem").check(
                         "triton_poi_fused_add_mul"
                     ).run(code[0])
 
-                if not config.cpp_wrapper:
-                    torch.testing.assert_close(
-                        out, fn(x, w, bias, scale), atol=1e-1, rtol=1e-1
-                    )
-        finally:
-            mm_heuristic.mm_configs = original_mm_configs
+    @unittest.skipIf(
+        not HAS_CUDA_AND_TRITON, "Scheduler static analysis only tested on cuda"
+    )
+    @skipIfRocm(msg="Scheduler static analysis needs investigation on ROCm")
+    @parametrize(
+        "test_case",
+        [
+            "occupancy_ratio_accept",  # ratio > 0.5, accept via Branch B
+            "occupancy_ratio_reject",  # ratio <= 0.5, reject
+        ],
+    )
+    @parametrize("use_async_compile", (True, False))
+    def test_template_epilogue_fusion_occupancy_ratio(
+        self, test_case: str, use_async_compile: bool
+    ):
+        """
+        Test occupancy ratio branch of _fuse_epilogue.
+
+        Occupancy calculation (assuming regs_per_sm = 65536):
+        blocks = regs_per_sm // (n_regs * threads_per_block)
+        threads_per_block = num_warps * warp_size = 4 * 32 = 128
+        """
+        triton_time = 0.1
+        epilogue_runtime = triton_time
+
+        if test_case == "occupancy_ratio_accept":
+            # blocks_unfused=5, blocks_fused=3, ratio=0.6 > 0.5 -> accept
+            # aten slightly faster to verify fusion picks triton even when aten wins
+            mock_unfused_n_regs, mock_fused_n_regs = 100, 160
+            aten_time = 0.09
+            expect_fusion = True
+        elif test_case == "occupancy_ratio_reject":
+            # blocks_unfused=8, blocks_fused=2, ratio=0.25 < 0.5 -> reject
+            mock_unfused_n_regs, mock_fused_n_regs = 64, 200
+            aten_time = 0.11
+            expect_fusion = False
+        else:
+            raise RuntimeError("Invalid test case")
+
+        f = self._get_mm_with_epilogue_fn()
+        a, b = self._get_mm_inputs()
+
+        with self._setup_mm_heuristic(use_async_compile):
+            with self.get_common_patches(
+                use_async_compile,
+                False,
+                aten_time=aten_time,
+                triton_time=triton_time,
+                mock_n_spills=0,
+                mock_fused_n_regs=mock_fused_n_regs,
+                mock_unfused_n_regs=mock_unfused_n_regs,
+                epilogue_runtime=epilogue_runtime,
+            ):
+                compiled_f = torch.compile(f)
+                _, code = run_and_get_code(compiled_f, a, b)
+
+                if expect_fusion:
+                    FileCheck().check("triton_tem_fused__to_copy_add_mm").run(code[0])
+                else:
+                    FileCheck().check("triton_tem_fused_mm").check(
+                        "triton_poi_fused__to_copy"
+                    ).run(code[0])
+
+    @unittest.skipIf(
+        not HAS_CUDA_AND_TRITON, "Scheduler static analysis only tested on cuda"
+    )
+    @skipIfRocm(msg="Scheduler static analysis needs investigation on ROCm")
+    @parametrize(
+        "test_case",
+        [
+            "memory_bound_accept",
+            "memory_bound_reject_low_occupancy",
+        ],
+    )
+    @parametrize("use_async_compile", (True, False))
+    def test_template_epilogue_fusion_dominating_epilogue(
+        self, test_case: str, use_async_compile: bool
+    ):
+        """
+        Test memory-bound epilogue branch of _fuse_epilogue (Branch C).
+
+        When Branches A and B fail (low occupancy), fusion can still be accepted
+        if the epilogue is memory-bound (ms2 > 2*ms1) AND blocks_fused > 1.
+        """
+        triton_time = 0.1
+
+        if test_case == "memory_bound_accept":
+            # blocks_fused=2 > 1, ms2=0.3 > 2*ms1=0.2 -> Branch C accepts
+            # aten slightly faster to verify fusion picks triton even when aten wins
+            mock_unfused_n_regs, mock_fused_n_regs = 64, 256
+            aten_time = 0.09
+            epilogue_runtime = 0.3
+            expect_fusion = True
+        elif test_case == "memory_bound_reject_low_occupancy":
+            # blocks_fused=1, ms2=0.3 > 2*ms1=0.2 BUT blocks_fused <= 1 -> reject
+            mock_unfused_n_regs, mock_fused_n_regs = 64, 512
+            aten_time = 0.11
+            epilogue_runtime = 0.3
+            expect_fusion = False
+        else:
+            raise RuntimeError("Invalid test case")
+
+        f = self._get_mm_with_epilogue_fn()
+        a, b = self._get_mm_inputs()
+
+        with self._setup_mm_heuristic(use_async_compile):
+            with self.get_common_patches(
+                use_async_compile,
+                False,
+                aten_time=aten_time,
+                triton_time=triton_time,
+                mock_n_spills=0,
+                mock_fused_n_regs=mock_fused_n_regs,
+                mock_unfused_n_regs=mock_unfused_n_regs,
+                epilogue_runtime=epilogue_runtime,
+            ):
+                compiled_f = torch.compile(f)
+                _, code = run_and_get_code(compiled_f, a, b)
+
+                if expect_fusion:
+                    FileCheck().check("triton_tem_fused__to_copy_add_mm").run(code[0])
+                else:
+                    FileCheck().check("triton_tem_fused_mm").check(
+                        "triton_poi_fused__to_copy"
+                    ).run(code[0])
 
 
 def simple_fn():

--- a/torch/_inductor/autotune_process.py
+++ b/torch/_inductor/autotune_process.py
@@ -719,7 +719,10 @@ class TritonBenchmarkRequest(BenchmarkRequest):
 
     def precompile(self):
         mod = PyCodeCache.load_by_key_path(self.module_cache_key, self.module_path)
-        getattr(mod, self.kernel_name).precompile()
+        kernel = getattr(mod, self.kernel_name)
+        kernel.precompile()
+
+        self.n_regs = kernel.launchers[0].n_regs
 
     def __str__(self) -> str:
         return f"{self.kernel_name=}, {self.module_path=}, {self.module_cache_key=}"

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -62,7 +62,7 @@ from .ir import (
 )
 from .loop_body import LoopBody
 from .memory import MemoryPlanningInfoForBuffer, MemoryPlanningInfoForNode
-from .runtime.hints import ReductionHint
+from .runtime.hints import DeviceProperties, ReductionHint
 from .runtime.runtime_utils import green_text, red_text
 from .sizevars import SimplifyIndexing
 from .utils import (
@@ -2760,16 +2760,75 @@ def _replace_operation_buffer(
 
 
 def _estimate_fused_epilogue_runtime(node1, node2, epilogue_runtime) -> float:
+    template_write_bytes = node1.get_write_buffer_sizes()
+    epilogue_read_bytes = node2.get_read_buffer_sizes()
+    extra_bytes = epilogue_read_bytes - template_write_bytes
     # If no extra memory read by epilogue, assume epilogue is free
     # if extra memory is read by epilogue, add to minimum choice
-    total_read_bytes = node2.get_read_buffer_sizes()
-    template_write_bytes = node1.get_write_buffer_sizes()
-    extra_bytes = total_read_bytes - template_write_bytes
     extra_bytes_ratio = extra_bytes / template_write_bytes
 
     # Smoothly approaches 1 as extra_bytes_ratio increases
     extra_memory_ratio = extra_bytes_ratio / (1 + extra_bytes_ratio)
     return extra_memory_ratio * epilogue_runtime
+
+
+def _occupancy_before_and_after_fusion(
+    unfused_n_regs: int,
+    fused_n_regs: int,
+    fused_n_spills: int,
+    num_warps: int,
+    device_props: DeviceProperties,
+) -> tuple[int, int]:
+    if fused_n_spills >= 8:
+        return 0, -1
+
+    # # Need device info to calculate occupancy
+    regs_per_sm = device_props.regs_per_multiprocessor
+    if regs_per_sm is None:
+        return 1, 1  # Can't calculate, allow fusion
+
+    assert num_warps
+    threads_per_block = num_warps * (device_props.warp_size or 32)
+
+    regs_per_block_unfused = unfused_n_regs * threads_per_block
+    regs_per_block_fused = fused_n_regs * threads_per_block
+
+    blocks_unfused = regs_per_sm // regs_per_block_unfused
+    blocks_fused = regs_per_sm // regs_per_block_fused
+
+    return blocks_unfused, blocks_fused
+
+
+def _fuse_epilogue(
+    ms1: float,
+    ms2: float,
+    unfused_n_regs: int,
+    fused_n_regs: int,
+    fused_n_spills: int,
+    num_warps: int,
+    device_props: DeviceProperties,
+) -> bool:
+    """
+    Determine whether to fuse an epilogue into a GEMM template.
+    """
+    MIN_ACCEPTED_OCCUPANCY = 4
+    REGRESSED_OCCUPANCY_RATIO = 0.5
+
+    # Check occupancy impact
+    blocks_unfused, blocks_fused = _occupancy_before_and_after_fusion(
+        unfused_n_regs, fused_n_regs, fused_n_spills, num_warps, device_props
+    )
+
+    epilogue_dominated_with_sufficient_occupancy = ms2 > 2 * ms1 and blocks_fused > 1
+
+    # fuse if no major register spills
+    # Occupancy can decrease but if memory bound/epilogue dominated
+    # optimistically fuse
+    return blocks_fused != -1 and (
+        blocks_fused >= MIN_ACCEPTED_OCCUPANCY
+        or blocks_fused / blocks_unfused > REGRESSED_OCCUPANCY_RATIO
+        or epilogue_dominated_with_sufficient_occupancy
+    )
 
 
 @dataclasses.dataclass
@@ -4271,16 +4330,28 @@ class Scheduler:
                             or ms2 + ms1 > choice_timings[choice] + ms2_fused
                         )
 
-                        if (
-                            res
+                        if res and fusible_choice:
+                            choice.precompile()
                             # pyrefly: ignore [missing-attribute]
-                            and len(res.launchers) == 1
+                            assert res.launchers and choice.n_regs
                             # pyrefly: ignore [bad-index]
-                            and res.launchers[0].n_spills <= 8
-                            and fusible_choice
-                        ):
-                            ms_fused_choice = choice
-                            break
+                            compiled_kernel = res.launchers[0]
+                            # pyrefly: ignore [missing-attribute]
+                            fused_n_regs = compiled_kernel.n_regs
+                            # pyrefly: ignore [missing-attribute]
+                            fused_n_spills = compiled_kernel.n_spills
+                            should_fuse_epilogue = _fuse_epilogue(
+                                ms1,
+                                ms2,
+                                choice.n_regs,
+                                fused_n_regs,
+                                fused_n_spills,
+                                choice.bmreq.num_warps,
+                                DeviceProperties.create(device),
+                            )
+                            if should_fuse_epilogue:
+                                ms_fused_choice = choice
+                                break
 
                 if bench_epilogue:
                     log_fusion(min_ms_fused, ms1, ms2)

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -2389,6 +2389,10 @@ class ExternKernelChoice:
 
 
 class TritonTemplateCaller(ir.TritonTemplateCallerBase):
+    """
+    Represents a ChoiceCaller for a TritonTemplate
+    """
+
     def __init__(
         self,
         name,
@@ -2425,6 +2429,8 @@ class TritonTemplateCaller(ir.TritonTemplateCallerBase):
         )
         self.hint_override = hint_override
 
+        self.n_regs = None
+
     def benchmark(self, *args, out):
         assert self.bmreq is not None
         if (
@@ -2439,6 +2445,8 @@ class TritonTemplateCaller(ir.TritonTemplateCallerBase):
     def precompile(self):
         assert self.bmreq is not None
         self.bmreq.precompile()
+
+        self.n_regs = self.bmreq.n_regs
 
     def __str__(self) -> str:
         return f"TritonTemplateCaller({self.bmreq.module_path}, {self.description})"


### PR DESCRIPTION
Differential Revision: D94115251

Previously, the heuristics for whether or not to do epilogue fusion mainly had to do with whether or not register spillage occurred. This still led to a lot of fusions that generally were not profitable. The new heuristics consider occupancy differences between the old and new kernel, along with whether or not the epilogue time dominates the template, which captures more optimal decisions.

Testing was done on 2 internal models, where the decision was essentially equivalent to benchmarking epilogues for all template fusions.



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo