### PR TITLE
add a config for explicitly disabling welford reduction

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -2283,6 +2283,11 @@ tpu_backend: Literal["pallas"] = "pallas"
 xpu_backend: Literal["triton"] = "triton"
 
 
+class mtia:
+    # Configuration to force inductor to never use welford reductions for MTIA backend
+    disable_welford_reduction = False
+
+
 class halide:
     # Base halide target to use for CPU devices
     cpu_target = "host"

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -2181,6 +2181,9 @@ class WelfordReduction(MultiOutputReduction):
         reduction_hint: ReductionHint = ReductionHint.DEFAULT,
     ) -> Sequence[TensorBox]:
         assert reduction_type in ("welford_reduce", "welford_combine")
+        assert not config.mtia.disable_welford_reduction, (
+            "welford reduction usage is explicitly disabled, please check you config"
+        )
 
         reduction_numel = V.graph.sizevars.simplify(sympy_product(reduction_ranges))
 

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -6449,7 +6449,10 @@ def var_mean_helper_(x, *, axis, correction, keepdim, return_mean):
     )
     output = (
         var_mean_sum_(**kwargs)
-        if use_two_step_variance(x, axis=axis, keepdim=keepdim)
+        if (
+            config.mtia.disable_welford_reduction
+            or use_two_step_variance(x, axis=axis, keepdim=keepdim)
+        )
         else var_mean_welford_(**kwargs)
     )
     output = tuple(to_dtype(x, out_dtype, copy=False) for x in output)


### PR DESCRIPTION
Summary:
Introduce `config.disable_welford_reduction` flag to configure inductor codegen to not use welford reduction. Updated relevant call sites like:
- var_means lowering: check `config.disable_welford_reduction` when deciding between two step variance or welford reduction.
- in WelfordReduction triton codegen, explicitly assert against `config.disable_welford_reduction`

Test Plan: added test in test_torchinductor_codegen_config_overrides.py to confirm the config is effective.

Differential Revision: D94303335




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos