### PR TITLE
[ROCm][CI] Use gfx942 for rocm nightly binaries

### DIFF
--- a/.github/templates/linux_binary_build_workflow.yml.j2
+++ b/.github/templates/linux_binary_build_workflow.yml.j2
@@ -166,7 +166,7 @@ jobs:
       - name: Teardown XPU
         uses: ./.github/actions/teardown-xpu
     {%- else %}
-    runs-on: linux.rocm.gpu.mi250.1
+    runs-on: linux.rocm.gpu.gfx942.1
     timeout-minutes: !{{ common.timeout_minutes }}
     !{{ upload.binary_env(config) }}
     permissions:

--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -421,7 +421,7 @@ jobs:
     needs:
       - manywheel-py3_10-rocm7_1-build
       - get-label-type
-    runs-on: linux.rocm.gpu.mi250.1
+    runs-on: linux.rocm.gpu.gfx942.1
     timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch
@@ -540,7 +540,7 @@ jobs:
     needs:
       - manywheel-py3_10-rocm7_2-build
       - get-label-type
-    runs-on: linux.rocm.gpu.mi250.1
+    runs-on: linux.rocm.gpu.gfx942.1
     timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch
@@ -1112,7 +1112,7 @@ jobs:
     needs:
       - manywheel-py3_11-rocm7_1-build
       - get-label-type
-    runs-on: linux.rocm.gpu.mi250.1
+    runs-on: linux.rocm.gpu.gfx942.1
     timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch
@@ -1231,7 +1231,7 @@ jobs:
     needs:
       - manywheel-py3_11-rocm7_2-build
       - get-label-type
-    runs-on: linux.rocm.gpu.mi250.1
+    runs-on: linux.rocm.gpu.gfx942.1
     timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch
@@ -1803,7 +1803,7 @@ jobs:
     needs:
       - manywheel-py3_12-rocm7_1-build
       - get-label-type
-    runs-on: linux.rocm.gpu.mi250.1
+    runs-on: linux.rocm.gpu.gfx942.1
     timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch
@@ -1922,7 +1922,7 @@ jobs:
     needs:
       - manywheel-py3_12-rocm7_2-build
       - get-label-type
-    runs-on: linux.rocm.gpu.mi250.1
+    runs-on: linux.rocm.gpu.gfx942.1
     timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch
@@ -2494,7 +2494,7 @@ jobs:
     needs:
       - manywheel-py3_13-rocm7_1-build
       - get-label-type
-    runs-on: linux.rocm.gpu.mi250.1
+    runs-on: linux.rocm.gpu.gfx942.1
     timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch
@@ -2613,7 +2613,7 @@ jobs:
     needs:
       - manywheel-py3_13-rocm7_2-build
       - get-label-type
-    runs-on: linux.rocm.gpu.mi250.1
+    runs-on: linux.rocm.gpu.gfx942.1
     timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch
@@ -3185,7 +3185,7 @@ jobs:
     needs:
       - manywheel-py3_13t-rocm7_1-build
       - get-label-type
-    runs-on: linux.rocm.gpu.mi250.1
+    runs-on: linux.rocm.gpu.gfx942.1
     timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch
@@ -3304,7 +3304,7 @@ jobs:
     needs:
       - manywheel-py3_13t-rocm7_2-build
       - get-label-type
-    runs-on: linux.rocm.gpu.mi250.1
+    runs-on: linux.rocm.gpu.gfx942.1
     timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch
@@ -3876,7 +3876,7 @@ jobs:
     needs:
       - manywheel-py3_14-rocm7_1-build
       - get-label-type
-    runs-on: linux.rocm.gpu.mi250.1
+    runs-on: linux.rocm.gpu.gfx942.1
     timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch
@@ -3995,7 +3995,7 @@ jobs:
     needs:
       - manywheel-py3_14-rocm7_2-build
       - get-label-type
-    runs-on: linux.rocm.gpu.mi250.1
+    runs-on: linux.rocm.gpu.gfx942.1
     timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch
@@ -4567,7 +4567,7 @@ jobs:
     needs:
       - manywheel-py3_14t-rocm7_1-build
       - get-label-type
-    runs-on: linux.rocm.gpu.mi250.1
+    runs-on: linux.rocm.gpu.gfx942.1
     timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch
@@ -4686,7 +4686,7 @@ jobs:
     needs:
       - manywheel-py3_14t-rocm7_2-build
       - get-label-type
-    runs-on: linux.rocm.gpu.mi250.1
+    runs-on: linux.rocm.gpu.gfx942.1
     timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch


### PR DESCRIPTION
Depends on https://github.com/pytorch/pytorch/pull/174290 and also tested in that PR here: https://github.com/pytorch/pytorch/actions/runs/22320747400/job/64886625635?pr=174290

Given the relative inconsistency of the mi250 runners (See [here](https://hud.pytorch.org/hud/pytorch/pytorch/d9958fd/1?per_page=50&name_filter=rocm&mergeEphemeralLF=true)), we have decided to switch the nightly builds to the gfx942 runners.
cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang