### PR TITLE
[inductor] Add defer_benchmark support for custom op autotuning

### DIFF
--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -1309,6 +1309,19 @@ class SIMDScheduling(BaseScheduling):
         ):
             return scheduler.ForeachKernelSchedulerNode.can_fuse(node1, node2)
 
+        # Deferred autotuning fusion barrier: don't fuse nodes from different variants
+        def _get_variant_id(node):
+            if isinstance(node, scheduler.SchedulerNode) and hasattr(
+                node.node, "_variant_id"
+            ):
+                return node.node._variant_id
+            return None
+
+        v1 = _get_variant_id(node1)
+        v2 = _get_variant_id(node2)
+        if v1 is not None and v2 is not None and v1 != v2:
+            return False
+
         _, (numel1, rnumel1) = node1.group
         _, (numel2, rnumel2) = node2.group
         why = WhyNoFuse(node1, node2)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #175785
* #175587

Summary:
Add defer_benchmark flag to register_custom_op_autotuning that defers
benchmarking to the scheduling phase via MultiTemplateBuffer, allowing
benchmark results to reflect post-fusion performance.

When defer_benchmark=True:
- autotune_custom_op passes return_multi_template=True to
  autotune_select_algorithm, returning a MultiTemplateBuffer
- Scheduler's finalize_multi_template_buffers handles SubgraphChoiceCaller
  winners via the existing output_node() → replace flow

Note: This is foundational plumbing. The current defer path goes through
SubgraphBuffer which forces max_autotune_gemm_backends=ATEN (cublas fallback).
A follow-up PR will implement inline-all-choices-at-lowering for proper
fusion-aware deferred autotuning.

Test Plan:
python -m pytest test/inductor/test_sdpa_custom_op_autotune.py -xvs
# All 3 tests pass including new test_sdpa_defer_benchmark

Pull Request resolved: placeholder

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo