### PR TITLE
[onnx] Clarify that output_names labels outputs but does not reorder them

### DIFF
--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -128,6 +128,9 @@ def export(
         verbose: Whether to enable verbose logging.
         input_names: names to assign to the input nodes of the graph, in order.
         output_names: names to assign to the output nodes of the graph, in order.
+            These are labels only and do not affect the order of outputs. If the model
+            returns a dictionary, outputs are flattened in the dictionary's iteration
+            order regardless of the names specified here.
         opset_version: The version of the
             `default (ai.onnx) opset <https://github.com/onnx/onnx/blob/master/docs/Operators.md>`_
             to target. You should set ``opset_version`` according to the supported opset versions

--- a/torch/onnx/_internal/torchscript_exporter/utils.py
+++ b/torch/onnx/_internal/torchscript_exporter/utils.py
@@ -323,7 +323,10 @@ def export(
         input_names (list of str, default empty list): names to assign to the
             input nodes of the graph, in order.
         output_names (list of str, default empty list): names to assign to the
-            output nodes of the graph, in order.
+            output nodes of the graph, in order. These are labels only and do not
+            affect the order of outputs. If the model returns a dictionary, outputs
+            are flattened in the dictionary's iteration order regardless of the
+            names specified here.
         operator_export_type (enum, default OperatorExportTypes.ONNX):
 
             .. warning::


### PR DESCRIPTION
Fixes #165758

## Description

`output_names` in `torch.onnx.export` only assigns labels to output nodes. It
does not control their order. When a model returns a dictionary, outputs are
flattened in the dictionary's iteration order regardless of what names are
specified. This was not documented, leading to user confusion (see linked issue).

This PR adds a clarifying note to the `output_names` parameter docstring in
both the dynamo-based exporter (`torch/onnx/__init__.py`) and the legacy
TorchScript exporter (`torch/onnx/_internal/torchscript_exporter/utils.py`).

cc @justinchuby @titaiwangms