### PR TITLE
[DTensor] Prevent squeeze from redistributing with strict_view

### DIFF
--- a/test/distributed/tensor/test_view_ops.py
+++ b/test/distributed/tensor/test_view_ops.py
@@ -2620,39 +2620,28 @@ class TestViewOps(DTensorContinuousTestBase):
             self.assertEqual(result.placements, (Shard(0),))
             self.assertEqual(result.full_tensor(), x.squeeze((0, 2)))
 
-        # S(0) on globally-singleton dim now errors (strict view, #174136)
-        with self.subTest("singleton_shard_errors"):
+        # Squeezing a sharded singleton dim requires redistribution and
+        # must error rather than silently allgathering (#174136).
+        with self.subTest("squeeze_sharded_dim_errors"):
             x = torch.randn(1, 4, device=self.device_type)
             dt = distribute_tensor(x, mesh, [Shard(0)])
-            with self.assertRaisesRegex(RuntimeError, "requires redistribution"):
-                dt.squeeze()
+            # All 6 squeeze ATen ops must error:
+            for op, args in [
+                (dt.squeeze, ()),  # squeeze.default
+                (dt.squeeze, (0,)),  # squeeze.dim
+                (dt.squeeze, ((0,),)),  # squeeze.dims
+                (dt.squeeze_, ()),  # squeeze_.default
+                (dt.squeeze_, (0,)),  # squeeze_.dim
+                (dt.squeeze_, ((0,),)),  # squeeze_.dims
+            ]:
+                with self.assertRaisesRegex(RuntimeError, "requires redistribution"):
+                    op(*args)
 
-    def test_squeeze_errors_when_sharded_dim_removed(self):
-        """Squeeze on a sharded singleton dim must error, not silently allgather."""
+    def test_squeeze_comm_free_cases(self):
+        """Squeeze is comm-free when no sharded dim is removed."""
         mesh = init_device_mesh(self.device_type, (self.world_size,))
-        x = torch.randn(1, 4, device=self.device_type)
-        dt = distribute_tensor(x, mesh, [Shard(0)])
-        with self.assertRaisesRegex(RuntimeError, "requires redistribution"):
-            dt.squeeze(0)
 
-    def test_squeeze_inplace_errors_when_sharded_dim_removed(self):
-        """squeeze_ on a sharded singleton dim must error (#174136)."""
-        mesh = init_device_mesh(self.device_type, (self.world_size,))
-        x = torch.randn(1, 4, device=self.device_type)
-
-        # squeeze_.dim
-        dt = distribute_tensor(x, mesh, [Shard(0)])
-        with self.assertRaisesRegex(RuntimeError, "requires redistribution"):
-            dt.squeeze_(0)
-
-        # squeeze_.dims
-        dt2 = distribute_tensor(x, mesh, [Shard(0)])
-        with self.assertRaisesRegex(RuntimeError, "requires redistribution"):
-            dt2.squeeze_((0,))
-
-    def test_squeeze_no_comm_when_non_sharded_dim_removed(self):
-        """Squeeze on a non-sharded singleton dim is communication-free."""
-        mesh = init_device_mesh(self.device_type, (self.world_size,))
+        # Non-sharded singleton removed (out-of-place), shard dim reindexes
         x = torch.randn(1, self.world_size, device=self.device_type)
         dt = distribute_tensor(x, mesh, [Shard(1)])
         with CommDebugMode() as comm_mode:
@@ -2662,33 +2651,39 @@ class TestViewOps(DTensorContinuousTestBase):
         self.assertEqual(result.placements, (Shard(0),))
         self.assertEqual(result.full_tensor(), x.squeeze(0))
 
-    def test_squeeze_after_explicit_redistribute(self):
-        """User redistributes to Replicate first, then squeeze is comm-free."""
-        mesh = init_device_mesh(self.device_type, (self.world_size,))
-        x = torch.randn(1, 4, device=self.device_type)
-        dt = distribute_tensor(x, mesh, [Shard(0)])
-        dt_replicate = dt.redistribute(mesh, [Replicate()])
+        # Same but inplace — exercises the dispatch reindex path
+        x_inp = torch.randn(1, self.world_size, device=self.device_type)
+        dt_inp = distribute_tensor(x_inp, mesh, [Shard(1)])
         with CommDebugMode() as comm_mode:
-            result = dt_replicate.squeeze(0)
+            dt_inp.squeeze_(0)
         self.assertEqual(comm_mode.get_total_counts(), 0)
-        self.assertEqual(result.shape, torch.Size([4]))
-        self.assertEqual(result.placements, (Replicate(),))
-        self.assertEqual(result.full_tensor(), x.squeeze(0))
+        self.assertEqual(dt_inp.shape, torch.Size([self.world_size]))
+        self.assertEqual(dt_inp.placements, (Shard(0),))
+        self.assertEqual(dt_inp.full_tensor(), x_inp.squeeze(0))
 
-    def test_squeeze_2d_mesh(self):
-        """2D mesh: squeeze removes non-sharded singleton, shard dims reindex."""
-        mesh = init_device_mesh(
+        # Explicit redistribute first, then squeeze
+        x2 = torch.randn(1, 4, device=self.device_type)
+        dt2 = distribute_tensor(x2, mesh, [Shard(0)])
+        dt2_rep = dt2.redistribute(mesh, [Replicate()])
+        with CommDebugMode() as comm_mode:
+            result2 = dt2_rep.squeeze(0)
+        self.assertEqual(comm_mode.get_total_counts(), 0)
+        self.assertEqual(result2.shape, torch.Size([4]))
+        self.assertEqual(result2.placements, (Replicate(),))
+        self.assertEqual(result2.full_tensor(), x2.squeeze(0))
+
+        # 2D mesh: both shard dims reindex
+        mesh_2d = init_device_mesh(
             self.device_type, (2, self.world_size // 2), mesh_dim_names=("dp", "tp")
         )
-        # shape (1, 2, world_size//2) sharded on dim 1 and dim 2
-        x = torch.randn(1, 2, self.world_size // 2, device=self.device_type)
-        dt = distribute_tensor(x, mesh, [Shard(1), Shard(2)])
+        x3 = torch.randn(1, 2, self.world_size // 2, device=self.device_type)
+        dt3 = distribute_tensor(x3, mesh_2d, [Shard(1), Shard(2)])
         with CommDebugMode() as comm_mode:
-            result = dt.squeeze(0)
+            result3 = dt3.squeeze(0)
         self.assertEqual(comm_mode.get_total_counts(), 0)
-        self.assertEqual(result.shape, torch.Size([2, self.world_size // 2]))
-        self.assertEqual(result.placements, (Shard(0), Shard(1)))
-        self.assertEqual(result.full_tensor(), x.squeeze(0))
+        self.assertEqual(result3.shape, torch.Size([2, self.world_size // 2]))
+        self.assertEqual(result3.placements, (Shard(0), Shard(1)))
+        self.assertEqual(result3.full_tensor(), x3.squeeze(0))
 
     def test_storage_offset_slice(self):
         """

--- a/test/distributed/tensor/test_view_ops.py
+++ b/test/distributed/tensor/test_view_ops.py
@@ -2620,14 +2620,75 @@ class TestViewOps(DTensorContinuousTestBase):
             self.assertEqual(result.placements, (Shard(0),))
             self.assertEqual(result.full_tensor(), x.squeeze((0, 2)))
 
-        # S(0) on globally-singleton dim becomes R after squeeze (#174136)
-        with self.subTest("singleton_shard_becomes_replicate"):
+        # S(0) on globally-singleton dim now errors (strict view, #174136)
+        with self.subTest("singleton_shard_errors"):
             x = torch.randn(1, 4, device=self.device_type)
             dt = distribute_tensor(x, mesh, [Shard(0)])
-            result = dt.squeeze()
-            self.assertEqual(result.shape, torch.Size([4]))
-            self.assertEqual(result.placements, (Replicate(),))
-            self.assertEqual(result.full_tensor(), x.squeeze())
+            with self.assertRaisesRegex(RuntimeError, "requires redistribution"):
+                dt.squeeze()
+
+    def test_squeeze_errors_when_sharded_dim_removed(self):
+        """Squeeze on a sharded singleton dim must error, not silently allgather."""
+        mesh = init_device_mesh(self.device_type, (self.world_size,))
+        x = torch.randn(1, 4, device=self.device_type)
+        dt = distribute_tensor(x, mesh, [Shard(0)])
+        with self.assertRaisesRegex(RuntimeError, "requires redistribution"):
+            dt.squeeze(0)
+
+    def test_squeeze_inplace_errors_when_sharded_dim_removed(self):
+        """squeeze_ on a sharded singleton dim must error (#174136)."""
+        mesh = init_device_mesh(self.device_type, (self.world_size,))
+        x = torch.randn(1, 4, device=self.device_type)
+
+        # squeeze_.dim
+        dt = distribute_tensor(x, mesh, [Shard(0)])
+        with self.assertRaisesRegex(RuntimeError, "requires redistribution"):
+            dt.squeeze_(0)
+
+        # squeeze_.dims
+        dt2 = distribute_tensor(x, mesh, [Shard(0)])
+        with self.assertRaisesRegex(RuntimeError, "requires redistribution"):
+            dt2.squeeze_((0,))
+
+    def test_squeeze_no_comm_when_non_sharded_dim_removed(self):
+        """Squeeze on a non-sharded singleton dim is communication-free."""
+        mesh = init_device_mesh(self.device_type, (self.world_size,))
+        x = torch.randn(1, self.world_size, device=self.device_type)
+        dt = distribute_tensor(x, mesh, [Shard(1)])
+        with CommDebugMode() as comm_mode:
+            result = dt.squeeze(0)
+        self.assertEqual(comm_mode.get_total_counts(), 0)
+        self.assertEqual(result.shape, torch.Size([self.world_size]))
+        self.assertEqual(result.placements, (Shard(0),))
+        self.assertEqual(result.full_tensor(), x.squeeze(0))
+
+    def test_squeeze_after_explicit_redistribute(self):
+        """User redistributes to Replicate first, then squeeze is comm-free."""
+        mesh = init_device_mesh(self.device_type, (self.world_size,))
+        x = torch.randn(1, 4, device=self.device_type)
+        dt = distribute_tensor(x, mesh, [Shard(0)])
+        dt_replicate = dt.redistribute(mesh, [Replicate()])
+        with CommDebugMode() as comm_mode:
+            result = dt_replicate.squeeze(0)
+        self.assertEqual(comm_mode.get_total_counts(), 0)
+        self.assertEqual(result.shape, torch.Size([4]))
+        self.assertEqual(result.placements, (Replicate(),))
+        self.assertEqual(result.full_tensor(), x.squeeze(0))
+
+    def test_squeeze_2d_mesh(self):
+        """2D mesh: squeeze removes non-sharded singleton, shard dims reindex."""
+        mesh = init_device_mesh(
+            self.device_type, (2, self.world_size // 2), mesh_dim_names=("dp", "tp")
+        )
+        # shape (1, 2, world_size//2) sharded on dim 1 and dim 2
+        x = torch.randn(1, 2, self.world_size // 2, device=self.device_type)
+        dt = distribute_tensor(x, mesh, [Shard(1), Shard(2)])
+        with CommDebugMode() as comm_mode:
+            result = dt.squeeze(0)
+        self.assertEqual(comm_mode.get_total_counts(), 0)
+        self.assertEqual(result.shape, torch.Size([2, self.world_size // 2]))
+        self.assertEqual(result.placements, (Shard(0), Shard(1)))
+        self.assertEqual(result.full_tensor(), x.squeeze(0))
 
     def test_storage_offset_slice(self):
         """

--- a/torch/distributed/tensor/_dispatch.py
+++ b/torch/distributed/tensor/_dispatch.py
@@ -173,11 +173,6 @@ class OpDispatcher:
             aten.bernoulli.default,
             aten.bernoulli_.float,
         }
-        self._squeeze_inplace_ops = {
-            aten.squeeze_.dim,
-            aten.squeeze_.default,
-            aten.squeeze_.dims,
-        }
         self._custom_op_handlers = {
             aten.is_same_size.default: is_same_size_handler,
             aten.is_pinned.default: is_pinned_handler,
@@ -496,29 +491,38 @@ class OpDispatcher:
                 if not isinstance(args[0], dtensor.DTensor):
                     raise AssertionError
 
-                # NOTE: squeeze_ inplace ops may change the tensor's metadata
-                # (shape/strides). We special-case them to update the spec.
-                if op_call in self._squeeze_inplace_ops:
-                    # update the spec to handle tensor meta changes
-                    args[0]._spec = output_spec
-                    # use return_and_correct_aliasing to match the outer and the inner
-                    # aliasing. See https://github.com/pytorch/pytorch/pull/158954
-                    return return_and_correct_aliasing(op_call, args, kwargs, args[0])
-                else:
-                    # For all other inplace ops, check if placement changes are required
-                    # Inplace operations that change placement are not supported because
-                    # they would require redistribution, which breaks aliasing semantics.
-                    # If there are views into the tensor, the views would not be updated.
-                    if args[0]._spec.placements != output_spec.placements:
-                        raise RuntimeError(
-                            f"{op_call}: in-place operations that require placement changes "
-                            f"are not supported. The operation would change placement from "
-                            f"{args[0]._spec.placements} to {output_spec.placements}, "
-                            f"which requires redistribution and breaks aliasing semantics. "
-                            f"Please use the out-of-place version of this operation instead."
+                # Check if arg 0's input placement actually needs to change.
+                # needs_redistribute can be True for reasons other than
+                # arg 0 placement changes (e.g. squeeze dim rewriting),
+                # so we check the redistribute schema directly.
+                if (
+                    output_sharding.needs_redistribute
+                    and output_sharding.redistribute_schema is not None
+                ):
+                    desired_arg0 = output_sharding.redistribute_schema.args_schema[0]
+                    if not isinstance(desired_arg0, DTensorSpec):
+                        raise AssertionError(
+                            f"Expected DTensorSpec for inplace arg 0, "
+                            f"got {type(desired_arg0)}"
                         )
-                    # Most inplace ops don't change tensor meta, so no spec update needed
+                    if args[0]._spec.placements != desired_arg0.placements:
+                        raise RuntimeError(
+                            f"{op_call}: in-place operations that require "
+                            f"redistribution of the first argument are not "
+                            f"supported because redistribution replaces the "
+                            f"local tensor, breaking aliasing semantics. "
+                            f"Please redistribute explicitly first."
+                        )
+
+                # Fast path: spec unchanged (common case: add_, mul_, etc.)
+                if args[0]._spec == output_spec:
                     return args[0]
+
+                # Spec changed without redistribution (e.g. dim reindexing
+                # in squeeze_: Shard(1) → Shard(0) after removing dim 0).
+                # Currently only squeeze_ inplace ops hit this path.
+                args[0]._spec = output_spec
+                return return_and_correct_aliasing(op_call, args, kwargs, args[0])
             else:
                 return None
         elif is_out_variant_op:

--- a/torch/distributed/tensor/_dispatch.py
+++ b/torch/distributed/tensor/_dispatch.py
@@ -491,35 +491,15 @@ class OpDispatcher:
                 if not isinstance(args[0], dtensor.DTensor):
                     raise AssertionError
 
-                # Check if arg 0's input placement actually needs to change.
-                # needs_redistribute can be True for reasons other than
-                # arg 0 placement changes (e.g. squeeze dim rewriting),
-                # so we check the redistribute schema directly.
-                if (
-                    output_sharding.needs_redistribute
-                    and output_sharding.redistribute_schema is not None
-                ):
-                    desired_arg0 = output_sharding.redistribute_schema.args_schema[0]
-                    if not isinstance(desired_arg0, DTensorSpec):
-                        raise AssertionError(
-                            f"Expected DTensorSpec for inplace arg 0, "
-                            f"got {type(desired_arg0)}"
-                        )
-                    if args[0]._spec.placements != desired_arg0.placements:
-                        raise RuntimeError(
-                            f"{op_call}: in-place operations that require "
-                            f"redistribution of the first argument are not "
-                            f"supported because redistribution replaces the "
-                            f"local tensor, breaking aliasing semantics. "
-                            f"Please redistribute explicitly first."
-                        )
-
                 # Fast path: placements unchanged (common case: add_, mul_, etc.)
                 if args[0]._spec.placements == output_spec.placements:
                     return args[0]
 
-                # Placement changed without redistribution (e.g. dim reindexing
-                # in squeeze_: Shard(1) → Shard(0) after removing dim 0).
+                # Placement reindexed (e.g. squeeze_ removing a non-sharded
+                # dim: Shard(1) → Shard(0)). No redistribution — the local
+                # tensor data is unchanged, only dim indices shift.
+                # strict_view=True in sharding prop prevents the illegal
+                # case (squeezing a sharded dim) from reaching here.
                 args[0]._spec = output_spec
                 return return_and_correct_aliasing(op_call, args, kwargs, args[0])
             else:

--- a/torch/distributed/tensor/_dispatch.py
+++ b/torch/distributed/tensor/_dispatch.py
@@ -514,13 +514,12 @@ class OpDispatcher:
                             f"Please redistribute explicitly first."
                         )
 
-                # Fast path: spec unchanged (common case: add_, mul_, etc.)
-                if args[0]._spec == output_spec:
+                # Fast path: placements unchanged (common case: add_, mul_, etc.)
+                if args[0]._spec.placements == output_spec.placements:
                     return args[0]
 
-                # Spec changed without redistribution (e.g. dim reindexing
+                # Placement changed without redistribution (e.g. dim reindexing
                 # in squeeze_: Shard(1) → Shard(0) after removing dim 0).
-                # Currently only squeeze_ inplace ops hit this path.
                 args[0]._spec = output_spec
                 return return_and_correct_aliasing(op_call, args, kwargs, args[0])
             else:

--- a/torch/distributed/tensor/_ops/_view_ops.py
+++ b/torch/distributed/tensor/_ops/_view_ops.py
@@ -722,9 +722,9 @@ class _ViewShardingPropagator:
             ):
                 if self.strict_view:
                     raise RuntimeError(
-                        f"Sharded dimension {p.dim} ({p}) would need to become "
-                        f"Replicate. This requires redistribution. "
-                        f"Please redistribute the input before this operation."
+                        f"This operation would remove or reshape sharded "
+                        f"dimension {p.dim}, which requires redistribution. "
+                        f"Please redistribute the input first."
                     )
                 input_tgt_placements.append(Replicate())
             else:

--- a/torch/distributed/tensor/_ops/_view_ops.py
+++ b/torch/distributed/tensor/_ops/_view_ops.py
@@ -720,6 +720,12 @@ class _ViewShardingPropagator:
                 isinstance(p, Shard | _StridedShard)
                 and not self.shard_allowed[p.dim][mesh_dim]
             ):
+                if self.strict_view:
+                    raise RuntimeError(
+                        f"Sharded dimension {p.dim} ({p}) would need to become "
+                        f"Replicate. This requires redistribution. "
+                        f"Please redistribute the input before this operation."
+                    )
                 input_tgt_placements.append(Replicate())
             else:
                 input_tgt_placements.append(p)
@@ -1313,19 +1319,31 @@ def register_op_strategy_map(
         return output_strategy
 
 
-register_op_strategy_map(aten.squeeze.default, torch.squeeze)
-register_op_strategy_map(aten.squeeze_.default, torch.squeeze)
+register_op_strategy_map(aten.squeeze.default, torch.squeeze, strict_view=True)
+register_op_strategy_map(aten.squeeze_.default, torch.squeeze, strict_view=True)
 register_op_strategy_map(
-    aten.squeeze_.dim, torch.squeeze, schema_info=RuntimeSchemaInfo(1)
+    aten.squeeze_.dim,
+    torch.squeeze,
+    schema_info=RuntimeSchemaInfo(1),
+    strict_view=True,
 )
 register_op_strategy_map(
-    aten.squeeze.dim, torch.squeeze, schema_info=RuntimeSchemaInfo(1)
+    aten.squeeze.dim,
+    torch.squeeze,
+    schema_info=RuntimeSchemaInfo(1),
+    strict_view=True,
 )
 register_op_strategy_map(
-    aten.squeeze.dims, torch.squeeze, schema_info=RuntimeSchemaInfo(1)
+    aten.squeeze.dims,
+    torch.squeeze,
+    schema_info=RuntimeSchemaInfo(1),
+    strict_view=True,
 )
 register_op_strategy_map(
-    aten.squeeze_.dims, torch.squeeze, schema_info=RuntimeSchemaInfo(1)
+    aten.squeeze_.dims,
+    torch.squeeze,
+    schema_info=RuntimeSchemaInfo(1),
+    strict_view=True,
 )
 register_op_strategy_map(
     aten.view.default,


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/174136
When squeeze_.dim triggers redistribution (e.g. squeezing a globally-singleton sharded dim forces Shard(0) → Replicate), redistribute_local_args creates a new local tensor. The dispatch path updated `_spec` but never assigned the new tensor back to `_local_tensor`, leaving the DTensor in an inconsistent state where the spec claims shape [4] but the local tensor is still [1, 4].

Update: Prevent squeeze, as a view op, from doing a redistribution using the  `view_strict` keyword.

~This PR syncs `_spec` and `_local_tensor`. It uses the inplace_view tag, so other inplace view ops (unsqueeze_, t_, transpose_) won't hit this, when strategies are registered for them.~


The C++ fast path in dispatchDTensorOp explicitly skips inplace ops, so no C++ change is needed.

