### PR TITLE
[wip][inductor] Fix overlap/bucketing bugs found by fuzzing

### DIFF
--- a/torch/_inductor/fx_passes/bucketing.py
+++ b/torch/_inductor/fx_passes/bucketing.py
@@ -43,20 +43,20 @@ def _ag_group_key_multidtype(node: torch.fx.Node) -> tuple[str]:
     return (group_name,)
 
 
-def _rs_group_key(node: torch.fx.Node) -> tuple[str, str, torch.dtype]:  # type: ignore[name-defined]
+def _rs_group_key(node: torch.fx.Node) -> tuple[str, str, str, torch.dtype]:  # type: ignore[name-defined]
     _, reduce_op, group_size, group_name = node.args
     dtype = node.meta["val"].dtype
     assert isinstance(group_name, str)
     assert isinstance(reduce_op, str)
-    return (group_name, reduce_op, dtype)
+    return ("rs", group_name, reduce_op, dtype)
 
 
-def _ar_group_key(node: torch.fx.Node) -> tuple[str, str, torch.dtype]:
+def _ar_group_key(node: torch.fx.Node) -> tuple[str, str, str, torch.dtype]:
     _, reduce_op, group_name = node.args
     dtype = node.meta["val"].dtype
     assert isinstance(group_name, str)
     assert isinstance(reduce_op, str)
-    return (group_name, reduce_op, dtype)
+    return ("ar", group_name, reduce_op, dtype)
 
 
 def _compute_foreach_groups(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #175803
* __->__ #175799

Four bugs found by the torchfuzz distributed_overlap template:

1. Bucket key collision (seed 20): reduce_scatter and all_reduce had
   the same bucket key format, causing them to be incorrectly grouped.
   Fix: Add "rs"/"ar" prefixes to distinguish collective types.

2. Missing bucketing import (seed 22): Generated inductor code uses
   torch.ops.bucketing._pre_bucket_reduce_scatter but the module wasn't
   imported. Fix: Add conditional wrapper import.

3. Getitem nodes not tracked (seed 26): When expand_fusion_regions
   inlines fusion modules, getitem users weren't mapped to their
   replacement nodes. Fix: Capture getitem users before inlining and
   map them to corresponding output elements.

4. Self-dependencies from fusible dtype conversions (seed 26): Dtype
   conversions fused into bucketed all_gathers could get overlap deps
   that become self-dependencies after bucketing merges them.
   Fix: Treat fusible all_gather dtype conversions as free in the
   overlap scheduler so they don't receive overlap deps.

Regression tests for all four bugs.

Written with Claude Code.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo