### PR TITLE
test: big gpu required to run test_original_aten_preserved_split_addmm

### DIFF
--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -1301,6 +1301,7 @@ class TestPatternMatcher(TestCase):
             "max_autotune_gemm_backends": "TRITON",
         }
     )
+    @unittest.skipIf(not IS_BIG_GPU, "templates require big gpu")
     def test_original_aten_preserved_split_addmm(self):
         # addmm -> elementwise should be decomposed into mm -> add -> elementwise
         def fn(x, y, z):


### PR DESCRIPTION
`test_original_aten_preserved_split_addmm` uses templates and they need a big gpu to run. Otherwise, the next error is raised:
```python 
File "/build/work/d72ad510f627427d60bb45dd0704233cdb7a/google3/runfiles/google3/third_party/py/torch/_inductor/select_algorithm.py", [line 3062](https://cs.corp.google.com/piper///depot/google3/third_party/py/torch/_inductor/select_algorithm.py?l=3062&ws=ddelgadovargas/5324&snapshot=30587), in __call__
    raise self.create_no_valid_choices(name, "No choices exist for backend.")
torch._inductor.exc.InductorError: LoweringException: NoValidChoicesError: No choices to select. Provided reason: No choices exist for backend. please consider adding ATEN into max_autotune_gemm_backends config (defined in torch/_inductor/config.py) to allow at least one choice. 
  target: aten.mm.default
  args[0]: TensorBox(StorageBox(
    InputBuffer(name='arg1_1', layout=FixedLayout('cuda:0', torch.float32, size=[16, 24], stride=[24, 1]))
  ))
  args[1]: TensorBox(StorageBox(
    InputBuffer(name='arg2_1', layout=FixedLayout('cuda:0', torch.float32, size=[24, 32], stride=[32, 1]))
  ))NoValidChoicesError: No choices to select. Provided reason: No choices exist for backend. please consider adding ATEN into max_autotune_gemm_backends config (defined in torch/_inductor/config.py) to allow at least one choice. 
  target: aten.mm.default
  args[0]: TensorBox(StorageBox(
    InputBuffer(name='arg1_1', layout=FixedLayout('cuda:0', torch.float32, size=[16, 24], stride=[24, 1]))
  ))
  args[1]: TensorBox(StorageBox(
    InputBuffer(name='arg2_1', layout=FixedLayout('cuda:0', torch.float32, size=[24, 32], stride=[32, 1]))
  ))
Found from : 
   File "/build/work/d72ad510f627427d60bb45dd0704233cdb7a/google3/runfiles/google3/third_party/py/torch/test/inductor/test_pattern_matcher.py", [line 1307](https://cs.corp.google.com/piper///depot/google3/third_party/py/torch/test/inductor/test_pattern_matcher.py?l=1307&ws=ddelgadovargas/5324&snapshot=30587), in fn
    return torch.addmm(z, x, y).sin()
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo