### PR TITLE
[inductor] Fix BF16/FP16 scalar comparison to match eager (#173987)

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -2947,6 +2947,15 @@ class CommonTemplate:
 
         self.common(fn, (torch.randint(4, (4,)),))
 
+    def test_comparison_scalar_type_promotion_bf16(self):
+        def fn(x):
+            return x == 3.14
+
+        x = torch.randn([3, 1, 64, 128], dtype=torch.bfloat16, device=self.device)
+        expected = fn(x)
+        actual = torch.compile(fn)(x)
+        self.assertEqual(actual, expected)
+
     @skip_if_gpu_halide
     @xfail_if_triton_cpu
     def test_dist(self):

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -2949,7 +2949,9 @@ class CommonTemplate:
 
     def test_comparison_scalar_type_promotion_bf16(self):
         if self.device == "mps":
-            raise unittest.SkipTest("MPS codegen doesn't upcast bf16 constants to float32")
+            raise unittest.SkipTest(
+                "MPS codegen doesn't upcast bf16 constants to float32"
+            )
 
         def fn(x):
             return x == 3.14

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -2948,6 +2948,9 @@ class CommonTemplate:
         self.common(fn, (torch.randint(4, (4,)),))
 
     def test_comparison_scalar_type_promotion_bf16(self):
+        if self.device == "mps":
+            raise unittest.SkipTest("MPS codegen doesn't upcast bf16 constants to float32")
+
         def fn(x):
             return x == 3.14
 

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -2951,7 +2951,9 @@ class CommonTemplate:
         def fn(x):
             return x == 3.14
 
-        x = torch.randn([3, 1, 64, 128], dtype=torch.bfloat16, device=self.device)
+        x = torch.tensor(
+            [3.14, 1.0, 3.140625, 0.0], dtype=torch.bfloat16, device=self.device
+        )
         expected = fn(x)
         actual = torch.compile(fn)(x)
         self.assertEqual(actual, expected)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #175807

When comparing a BF16/FP16 tensor with a Python scalar using aten.eq,
Inductor produced different results from eager. The scalar value was
kept at FP64 precision and converted directly to the compute type (FP32),
skipping the round-to-tensor-dtype step that eager performs.

Fix: in promote_constants(), round scalar values to the tensor's dtype
before creating ir.Constant for comparison ops (override_return_dtype=bool).
This ensures the Triton/C++ codegen constant matches eager's precision.

Fixes: https://github.com/pytorch/pytorch/issues/173987

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos