### PR TITLE
[rocm][hipsparselt] Enable hipsparselt in caffe2 HIP builds

### DIFF
--- a/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.h
+++ b/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.h
@@ -14,6 +14,16 @@
 #include <cstdint>
 
 #if AT_CUSPARSELT_ENABLED()
+// ROCm 7.0.2's amd_hip_bf16.h (pulled in via hipsparselt.h -> hip_fp8.h ->
+// amd_hip_fp8.h -> amd_hip_bf16.h) contains device-only builtins (warpSize,
+// __shfl_*_sync) that fail during host compilation. Pre-define the hip_fp8.h
+// include guard to prevent this chain. The hipsparselt C API uses opaque
+// handles and enum types, not C++ fp8 types directly.
+#if defined(USE_ROCM) && !defined(__HIP_DEVICE_COMPILE__)
+#ifndef HIP_INCLUDE_HIP_HIP_FP8_H
+#define HIP_INCLUDE_HIP_HIP_FP8_H
+#endif
+#endif
 #include <cusparseLt.h>
 #endif
 


### PR DESCRIPTION
Summary:
Enable hipsparselt (2:4 structured sparsity) in caffe2's ATen-hip target
on ROCm 7.0.2 using constraint-based opt-in (mirroring the existing
cusparselt pattern for CUDA).

Changes:
- Add enable_hipsparselt constraint setting/value in caffe2/TARGETS
- Conditionally add -DUSE_HIPSPARSELT pp_flag and hipsparselt-lazy dep
  via select() on the constraint
- Add get_build_args_for_generate_hip_config() to target_definitions.bzl
  for AT_HIPSPARSELT_ENABLED config generation
- Work around ROCm 7.0.2 header bug: amd_hip_bf16.h (pulled in via
  hipsparselt.h -> hip_fp8.h) contains device-only builtins (warpSize,
  __shfl_*_sync) that fail during host compilation. Pre-define the
  hip_fp8.h include guard to skip this chain in cuSPARSELtOps.h.

Build: buck2 build mode/opt-amd-gpu -m rocm_latest -m fbcode//caffe2:enable_hipsparselt fbcode//scripts/gylls/torchao:benchmark_semi_structured_sparsity
Run: buck2 run <same flags> -- --mode nvidia-bert

Test Plan:
Benchmark ran successfully on MI300X (ROCm 7.0.2), all shapes correct:
  3072x1024x16384 fp16: 0.88x speedup, correct=True
  4096x1024x16384 fp16: 0.93x speedup, correct=True
  1024x1024x16384 fp16: 0.91x speedup, correct=True
  1024x4096x16384 fp16: 0.98x speedup, correct=True

Differential Revision: D94411462




cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang