### PR TITLE
[inductor] Fix overlap/bucketing bugs found by fuzzing

### DIFF
--- a/torch/_inductor/fx_passes/bucketing.py
+++ b/torch/_inductor/fx_passes/bucketing.py
@@ -43,20 +43,20 @@ def _ag_group_key_multidtype(node: torch.fx.Node) -> tuple[str]:
     return (group_name,)
 
 
-def _rs_group_key(node: torch.fx.Node) -> tuple[str, str, torch.dtype]:  # type: ignore[name-defined]
+def _rs_group_key(node: torch.fx.Node) -> tuple[str, str, str, torch.dtype]:  # type: ignore[name-defined]
     _, reduce_op, group_size, group_name = node.args
     dtype = node.meta["val"].dtype
     assert isinstance(group_name, str)
     assert isinstance(reduce_op, str)
-    return (group_name, reduce_op, dtype)
+    return ("rs", group_name, reduce_op, dtype)
 
 
-def _ar_group_key(node: torch.fx.Node) -> tuple[str, str, torch.dtype]:
+def _ar_group_key(node: torch.fx.Node) -> tuple[str, str, str, torch.dtype]:
     _, reduce_op, group_name = node.args
     dtype = node.meta["val"].dtype
     assert isinstance(group_name, str)
     assert isinstance(reduce_op, str)
-    return (group_name, reduce_op, dtype)
+    return ("ar", group_name, reduce_op, dtype)
 
 
 def _compute_foreach_groups(

--- a/torch/_inductor/fx_passes/overlap_scheduling.py
+++ b/torch/_inductor/fx_passes/overlap_scheduling.py
@@ -392,7 +392,7 @@ class OverlapScheduler:
         self.insert_overlap_deps = insert_overlap_deps
         self.max_compute_pre_fetch = max_compute_pre_fetch
         # In deterministic mode, force analytical estimation to avoid GPU sync
-        if config.deterministic:
+        if torch._inductor.config.deterministic:
             self.collective_estimator = "analytical"
             self.compute_estimator = "analytical"
         else:
@@ -1065,8 +1065,12 @@ class OverlapScheduler:
         """Handle scheduling compute or other nodes and attempt to overlap with collectives."""
         runtime_estimate = self.get_non_collective_runtime_estimate(node)
 
-        # TODO: we could consider skipping overlapping for overlapable, unary chains to collectives.
-        # using these nodes for overlap prevents bucketing. potentially if chain time < latency
+        # Skip overlapping for dtype conversions that will be fused into a
+        # bucketed all_gather.  Using them for overlap adds extra_deps that
+        # become self-dependencies after bucketing merges them.
+        if runtime_estimate is not None and self._is_fuseable_all_gather_dtype(node):
+            runtime_estimate = None
+
         if runtime_estimate is None:
             assert not is_compute_node(node), "should have estimate for compute nodes"
             self._schedule(node)
@@ -1140,6 +1144,18 @@ class OverlapScheduler:
         return getattr(node.target, "is_view", False) or torch.Tag.pointwise in getattr(
             node.target, "tags", ()
         )
+
+    @staticmethod
+    def _is_fuseable_all_gather_dtype(node: fx.Node) -> bool:
+        """Check if node is a dtype conversion that will be fused into a bucketed all_gather."""
+        from torch._inductor.fx_passes.bucketing import (
+            has_mergeable_all_gather_convert_dtype,
+        )
+
+        if len(node.users) != 1:
+            return False
+        user = next(iter(node.users))
+        return has_mergeable_all_gather_convert_dtype(user)
 
     def in_overlappable_collective_unary_chain(self, curr: fx.Node) -> bool:
         while True:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #175814
* #175813
* __->__ #175812

Four bugs found by the torchfuzz distributed_overlap template:

1. Bucket key collision (seed 20): reduce_scatter and all_reduce had
   the same bucket key format, causing them to be incorrectly grouped.
   Fix: Add "rs"/"ar" prefixes to distinguish collective types.

2. Missing bucketing import (seed 22): Generated inductor code uses
   torch.ops.bucketing._pre_bucket_reduce_scatter but the module wasn't
   imported. Fix: Add conditional wrapper import.

3. Getitem nodes not tracked (seed 26): When expand_fusion_regions
   inlines fusion modules, getitem users weren't mapped to their
   replacement nodes. Fix: Capture getitem users before inlining and
   map them to corresponding output elements.

4. Self-dependencies from fusible dtype conversions (seed 26): Dtype
   conversions fused into bucketed all_gathers could get overlap deps
   that become self-dependencies after bucketing merges them.
   Fix: Treat fusible all_gather dtype conversions as free in the
   overlap scheduler so they don't receive overlap deps.

Regression tests for all four bugs.

Written with Claude Code.