### PR TITLE
[CI] Add torchtitan tests to PyTorch CI

### DIFF
--- a/.ci/lumen_cli/cli/lib/core/torchtitan/lib.py
+++ b/.ci/lumen_cli/cli/lib/core/torchtitan/lib.py
@@ -1,0 +1,65 @@
+import logging
+from pathlib import Path
+from typing import Any
+
+import yaml
+from cli.lib.common.git_helper import clone_external_repo
+from cli.lib.common.utils import run_command, temp_environ, working_directory
+
+
+logger = logging.getLogger(__name__)
+
+_TORCHTITAN_TEST_LIBRARY_PATH = Path(__file__).parent / "torchtitan_test_library.yaml"
+
+
+def _load_torchtitan_test_library_yaml() -> dict[str, Any]:
+    if not _TORCHTITAN_TEST_LIBRARY_PATH.exists():
+        raise FileNotFoundError(
+            f"torchtitan test library YAML not found: {_TORCHTITAN_TEST_LIBRARY_PATH}"
+        )
+    with open(_TORCHTITAN_TEST_LIBRARY_PATH, encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def load_torchtitan_test_library() -> dict[str, Any]:
+    return _load_torchtitan_test_library_yaml()
+
+
+def clone_torchtitan(dst: str = "torchtitan"):
+    _, commit = clone_external_repo(
+        target="torchtitan",
+        repo="https://github.com/pytorch/torchtitan.git",
+        dst=dst,
+    )
+    return commit
+
+
+def run_test_plan(
+    test_plan: str,
+    tests_map: dict[str, Any],
+):
+    logger.info("Running torchtitan test plan: %s", test_plan)
+    if test_plan not in tests_map:
+        raise RuntimeError(
+            f"test plan '{test_plan}' not found in torchtitan test library"
+        )
+
+    tests = tests_map[test_plan]
+    title = tests.get("title", "unknown test")
+    logger.info("Running tests: %s", title)
+
+    with (
+        working_directory(tests.get("working_directory", "")),
+        temp_environ(tests.get("env_vars", {})),
+    ):
+        failures = []
+        for step in tests["steps"]:
+            logger.info("Running step: %s", step)
+            code = run_command(cmd=step, check=False, use_shell=True)
+            if code != 0:
+                failures.append(step)
+            logger.info("Finished step: %s", step)
+        if failures:
+            logger.error("Failed steps: %s", failures)
+            raise RuntimeError(f"{len(failures)} test steps failed: {failures}")
+        logger.info("All tests passed for plan: %s", test_plan)

--- a/.ci/lumen_cli/cli/lib/core/torchtitan/torchtitan_test.py
+++ b/.ci/lumen_cli/cli/lib/core/torchtitan/torchtitan_test.py
@@ -1,0 +1,40 @@
+import logging
+from typing import Any
+
+from cli.lib.common.cli_helper import BaseRunner
+from cli.lib.common.pip_helper import pip_install_packages
+from cli.lib.common.utils import working_directory
+from cli.lib.core.torchtitan.lib import (
+    clone_torchtitan,
+    load_torchtitan_test_library,
+    run_test_plan,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+class TorchtitanTestRunner(BaseRunner):
+    def __init__(self, args: Any):
+        self.work_directory = "torchtitan"
+        self.test_plan = args.test_plan
+
+    def prepare(self):
+        clone_torchtitan(dst=self.work_directory)
+        # torchao nightly is required by torchtitan
+        pip_install_packages(
+            packages=[
+                "--pre",
+                "torchao",
+                "--index-url",
+                "https://download.pytorch.org/whl/nightly/cu129",
+            ],
+        )
+        with working_directory(self.work_directory):
+            pip_install_packages(packages=["-e", "."])
+            pip_install_packages(packages=["pytest", "pytest-cov"])
+
+    def run(self):
+        self.prepare()
+        with working_directory(self.work_directory):
+            run_test_plan(self.test_plan, load_torchtitan_test_library())

--- a/.ci/lumen_cli/cli/lib/core/torchtitan/torchtitan_test_library.yaml
+++ b/.ci/lumen_cli/cli/lib/core/torchtitan/torchtitan_test_library.yaml
@@ -1,0 +1,34 @@
+# torchtitan Test Library Configuration
+# Each test plan maps to torchtitan's own test runners and pytest suites.
+# When tests are added/removed in torchtitan, the daily pin bump picks them up.
+
+torchtitan_unit_tests:
+  title: torchtitan CPU Unit Tests
+  id: torchtitan_unit_tests
+  steps:
+    - pytest tests/unit_tests --cov=. --durations=20 -vv
+
+torchtitan_features_integration:
+  title: torchtitan Feature Integration Tests (8 GPU)
+  id: torchtitan_features_integration
+  env_vars:
+    NGPU: "8"
+  steps:
+    - python -m tests.integration_tests.run_tests --test_suite features /tmp/output --ngpu 8
+
+torchtitan_models_integration:
+  title: torchtitan Model Integration Tests (8 GPU)
+  id: torchtitan_models_integration
+  env_vars:
+    NGPU: "8"
+  steps:
+    - python -m tests.integration_tests.run_tests --test_suite models /tmp/output --ngpu 8
+
+torchtitan_h100_integration:
+  title: torchtitan H100 Integration Tests (8 GPU)
+  id: torchtitan_h100_integration
+  env_vars:
+    NGPU: "8"
+    TORCH_SHOW_CPP_STACKTRACES: "1"
+  steps:
+    - python -m tests.integration_tests.run_tests --test_suite h100 /tmp/output --ngpu 8

--- a/.ci/lumen_cli/cli/test_cli/register_test.py
+++ b/.ci/lumen_cli/cli/test_cli/register_test.py
@@ -2,6 +2,7 @@ import argparse
 import logging
 
 from cli.lib.common.cli_helper import register_targets, RichHelp, TargetSpec
+from cli.lib.core.torchtitan.torchtitan_test import TorchtitanTestRunner
 from cli.lib.core.vllm.vllm_test import VllmTestRunner
 
 
@@ -13,8 +14,11 @@ _TARGETS: dict[str, TargetSpec] = {
     "vllm": {
         "runner": VllmTestRunner,
         "help": "test vLLM with pytorch main",
-    }
-    # add yours ...
+    },
+    "torchtitan": {
+        "runner": TorchtitanTestRunner,
+        "help": "test torchtitan with pytorch main",
+    },
 }
 
 

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -1881,6 +1881,9 @@ elif [[ "$TEST_CONFIG" == *vllm* ]]; then
     (cd .ci/lumen_cli && python -m pip install -e .)
 
     python -m cli.run test external vllm --test-plan "$TEST_CONFIG" --shard-id "$SHARD_NUMBER" --num-shards "$NUM_TEST_SHARDS"
+elif [[ "$TEST_CONFIG" == *torchtitan* ]]; then
+    (cd .ci/lumen_cli && python -m pip install -e .)
+    python -m cli.run test external torchtitan --test-plan "$TEST_CONFIG" --shard-id "$SHARD_NUMBER" --num-shards "$NUM_TEST_SHARDS"
 elif [[ "${TEST_CONFIG}" == *executorch* ]]; then
   test_executorch
 elif [[ "$TEST_CONFIG" == 'jit_legacy' ]]; then

--- a/.github/ci_commit_pins/torchtitan.txt
+++ b/.github/ci_commit_pins/torchtitan.txt
@@ -1,0 +1,1 @@
+6fefe5fb11c51a9837b2cea7ba5b32237de11c2e

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -90,6 +90,10 @@ jobs:
             repo-owner: vllm-project
             branch: main
             pin-folder: .github/ci_commit_pins
+          - repo-name: torchtitan
+            repo-owner: pytorch
+            branch: main
+            pin-folder: .github/ci_commit_pins
     # Allow this to be triggered on either a schedule or on workflow_dispatch to allow for easier testing
     if: github.repository_owner == 'pytorch' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
     steps:

--- a/.github/workflows/torchtitan.yml
+++ b/.github/workflows/torchtitan.yml
@@ -1,0 +1,47 @@
+name: torchtitan-test
+
+on:
+  push:
+    branches:
+      - main
+      - release/*
+    tags:
+      - ciflow/torchtitan/*
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
+  cancel-in-progress: true
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  build:
+    name: torchtitan-x-pytorch-build
+    if: github.repository_owner == 'pytorch'
+    uses: ./.github/workflows/_linux-build.yml
+    with:
+      build-environment: linux-jammy-cuda12.9-py3.12-gcc11
+      docker-image-name: ci-image:pytorch-linux-jammy-cuda12.9-cudnn9-py3.12-gcc11
+      cuda-arch-list: '8.0 8.9 9.0 10.0'
+      runner: linux.24xlarge
+      test-matrix: |
+        { include: [
+          { config: "torchtitan_unit_tests", shard: 1, num_shards: 1, runner: "linux.24xlarge" },
+          { config: "torchtitan_features_integration", shard: 1, num_shards: 1, runner: "linux.g5.48xlarge.nvidia.gpu" },
+          { config: "torchtitan_models_integration", shard: 1, num_shards: 1, runner: "linux.g5.48xlarge.nvidia.gpu" },
+          { config: "torchtitan_h100_integration", shard: 1, num_shards: 1, runner: "linux.aws.h100.8" }
+        ]}
+    secrets: inherit
+
+  test:
+    name: torchtitan-x-pytorch-test
+    uses: ./.github/workflows/_linux-test.yml
+    needs: build
+    with:
+      build-environment: linux-jammy-cuda12.9-py3.12-gcc11
+      docker-image: ${{ needs.build.outputs.docker-image }}
+      test-matrix: ${{ needs.build.outputs.test-matrix }}
+    secrets: inherit


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #175815

torchtitan currently runs its own CI against PyTorch nightly every 6-12h,
but PyTorch CI has no awareness of torchtitan. A breaking PyTorch commit
is only discovered hours later with no signal back to the committer. This
adds non-blocking torchtitan tests that run on push to main and on-demand
via ciflow labels.

The dispatch chain is: torchtitan.yml → _linux-build.yml → _linux-test.yml
→ test.sh (pattern-match TEST_CONFIG == *torchtitan*) → lumen_cli →
TorchtitanTestRunner → torchtitan's own test runners.

The lumen_cli runner is simpler than VllmTestRunner mainly because
torchtitan is pure Python and doesn't need a separate build step—torch is
pre-installed from _linux-build.yml. torchao is installed from nightly
since torchtitan depends on it at runtime. The test library YAML delegates
to torchtitan's own test runners (pytest for unit tests, run_tests.py for
integration), so torchtitan owns its test definitions and the daily pin
bump picks up changes automatically.

Test plan:
To trigger the workflow on a PR, push a tag matching ciflow/torchtitan/*.
The /* is a glob—any suffix works, e.g.:
  git tag ciflow/torchtitan/your-branch-name
  git push origin ciflow/torchtitan/your-branch-name
This fires the torchtitan.yml workflow against the tagged commit. After
merging, the workflow also runs automatically on every push to main.
workflow_dispatch can be used to trigger it manually from the Actions tab.

Follow-ups for subsequent PRs:
- Golden loss regression checks: torchtitan CI compares training loss
  against golden values; this is omitted here (we just check "doesn't
  crash") and should be added once the basic signal is stable
- Experiment suites: compiler toolkit, SimpleFSDP, VLM, etc. are not
  included yet
- ROCm support: torchtitan supports ROCm but we start CUDA-only

Authored with Claude.