### PR TITLE
[MPS] Allocating all tensors in unified memory

### DIFF
--- a/aten/src/ATen/mps/MPSAllocator.h
+++ b/aten/src/ATen/mps/MPSAllocator.h
@@ -227,8 +227,6 @@ typedef bool (*HeapComparison)(const HeapBlock*, const HeapBlock*);
 
 struct BufferPool {
   enum class Kind {
-    PRIVATE_SMALL,
-    PRIVATE_LARGE,
     SHARED_SMALL,
     SHARED_LARGE,
     SCALAR,

--- a/aten/src/ATen/mps/MPSAllocator.mm
+++ b/aten/src/ATen/mps/MPSAllocator.mm
@@ -40,15 +40,9 @@ void MPSHeapAllocatorImpl::init_allocator() {
 
 void MPSHeapAllocatorImpl::init_buffer_pools() {
   // using a container for pools to simplify iterating over them
-  // Pool of large buffers with private storage mode
-  m_pools.emplace(BufferPool::Kind::PRIVATE_LARGE,
-                  std::make_unique<BufferPool>(m_device, UsageFlags::PRIVATE | UsageFlags::HAZARD));
   // Pool of large buffers with shared storage mode
   m_pools.emplace(BufferPool::Kind::SHARED_LARGE,
                   std::make_unique<BufferPool>(m_device, UsageFlags::SHARED | UsageFlags::HAZARD));
-  // Pool of small buffers with private storage mode
-  m_pools.emplace(BufferPool::Kind::PRIVATE_SMALL,
-                  std::make_unique<BufferPool>(m_device, UsageFlags::SMALL | UsageFlags::PRIVATE | UsageFlags::HAZARD));
   // Pool of small buffers with shared storage mode
   m_pools.emplace(BufferPool::Kind::SHARED_SMALL,
                   std::make_unique<BufferPool>(m_device, UsageFlags::SMALL | UsageFlags::SHARED | UsageFlags::HAZARD));
@@ -64,12 +58,10 @@ BufferPool& MPSHeapAllocatorImpl::get_pool(size_t requested_size, size_t aligned
 
   if (usage & UsageFlags::SCALAR) {
     poolKind = BufferPool::Kind::SCALAR;
-  } else if (requested_size <= kMaxScalarAlloc && m_device.hasUnifiedMemory) {
-    poolKind = BufferPool::Kind::SHARED_SMALL;
   } else if (aligned_size <= kMaxSmallAlloc) {
-    poolKind = (usage & UsageFlags::SHARED) ? BufferPool::Kind::SHARED_SMALL : BufferPool::Kind::PRIVATE_SMALL;
+    poolKind = BufferPool::Kind::SHARED_SMALL;
   } else {
-    poolKind = (usage & UsageFlags::SHARED) ? BufferPool::Kind::SHARED_LARGE : BufferPool::Kind::PRIVATE_LARGE;
+    poolKind = BufferPool::Kind::SHARED_LARGE;
   }
   return *m_pools[poolKind];
 }
@@ -830,16 +822,9 @@ MPSAllocator& _getSharedAllocator() {
   return s_mps_shared_alloc;
 }
 
-MPSAllocator& _getPrivateAllocator() {
-  static MPSAllocator s_mps_private_alloc(HeapAllocator::UsageFlags::PRIVATE);
-  return s_mps_private_alloc;
-}
 } // anonymous namespace
 
-IMPSAllocator* getIMPSAllocator(bool sharedAllocator) {
-  if (!sharedAllocator) {
-    return &_getPrivateAllocator();
-  }
+IMPSAllocator* getIMPSAllocator() {
   auto& sa = _getSharedAllocator();
   if (sa.isSharedStorageSupported()) {
     return &sa;

--- a/aten/src/ATen/mps/MPSAllocatorInterface.h
+++ b/aten/src/ATen/mps/MPSAllocatorInterface.h
@@ -61,7 +61,7 @@ TORCH_DECLARE_REGISTRY(MPSAllocatorCallbacksRegistry, IMpsAllocatorCallback);
 #define REGISTER_MPS_ALLOCATOR_CALLBACK(name, ...) \
   C10_REGISTER_CLASS(MPSAllocatorCallbacksRegistry, name, __VA_ARGS__)
 
-IMPSAllocator* getIMPSAllocator(bool sharedAllocator = false);
+IMPSAllocator* getIMPSAllocator();
 
 bool isMPSPinnedPtr(const void* data);
 

--- a/aten/src/ATen/mps/MPSDevice.h
+++ b/aten/src/ATen/mps/MPSDevice.h
@@ -77,7 +77,7 @@ class TORCH_API MPSDevice {
 
 TORCH_API bool is_available();
 TORCH_API bool is_macos_13_or_newer(MacOSVersion version);
-TORCH_API at::Allocator* GetMPSAllocator(bool useSharedAllocator = false);
+TORCH_API at::Allocator* GetMPSAllocator();
 
 inline Device getDeviceFromPtr(void* ptr) {
   return {c10::DeviceType::MPS, 0};

--- a/aten/src/ATen/mps/MPSDevice.mm
+++ b/aten/src/ATen/mps/MPSDevice.mm
@@ -110,8 +110,8 @@ unsigned MPSDevice::getCoreCount() const {
   return core_count;
 }
 
-at::Allocator* GetMPSAllocator(bool useSharedAllocator) {
-  return getIMPSAllocator(useSharedAllocator);
+at::Allocator* GetMPSAllocator() {
+  return getIMPSAllocator();
 }
 bool is_available() {
   return MPSDevice::getInstance()->device() != nil;

--- a/aten/src/ATen/mps/MPSHooks.mm
+++ b/aten/src/ATen/mps/MPSHooks.mm
@@ -153,7 +153,7 @@ bool MPSHooks::isPinnedPtr(const void* data) const {
 }
 
 Allocator* MPSHooks::getPinnedMemoryAllocator() const {
-  return at::mps::getIMPSAllocator(true);
+  return at::mps::getIMPSAllocator();
 }
 
 using at::MPSHooksRegistry;


### PR DESCRIPTION
As all AppleSilicon devices support unified memory allocations, and, until it's mapped to CPU, there are no real difference between private and shared pools
  * Removing the `useSharedAllocator` argument from `getMPSAllocator()`, always use shared allocator
  * Removing the sharedAllocator, _getPrivateAllocator from getIMPSAllocator(), always returns _getSharedAllocator
  * Removing `PRIVATE_LARGE` and `PRIVATE_SMALL` buffer bools from MPSAllocator
Step 1 towards addressing https://github.com/pytorch/pytorch/issues/172987