### PR TITLE
[MPS] Migrate `index_fill_` to Metal

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -8435,9 +8435,7 @@
   device_check: NoCheck   # TensorIterator
   variants: method
   dispatch:
-    CPU: index_fill_
-    CUDA: index_fill_
-    MPS: index_fill_mps_
+    CPU, CUDA, MPS: index_fill_
   autogen: index_fill.int_Scalar_out
 
 - func: index_fill.int_Scalar(Tensor self, int dim, Tensor index, Scalar value) -> Tensor
@@ -8450,8 +8448,7 @@
   device_check: NoCheck   # TensorIterator
   variants: method
   dispatch:
-    CPU, CUDA: index_fill_
-    MPS: index_fill_mps_
+    CPU, CUDA, MPS: index_fill_
   autogen: index_fill.int_Tensor_out
 
 - func: index_fill.int_Tensor(Tensor self, int dim, Tensor index, Tensor value) -> Tensor

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -12778,9 +12778,10 @@ class TestConsistency(TestCaseMPS):
                 # TODO: Handle list inputs later
                 if not isinstance(mps_out, torch.Tensor):
                     raise
-                if mps_sample.input.dtype not in [torch.float16, torch.bfloat16]:
-                    raise
-                dtype = torch.float32
+                if mps_sample.input.dtype in [torch.float16, torch.bfloat16]:
+                    dtype = torch.float32
+                elif mps_sample.input.dtype == torch.bool:
+                    dtype = torch.uint8
 
                 # Often CPU ops are not implemented for low precision dtypes
                 # In that case, upcast to higher precision and try again

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -19651,18 +19651,6 @@ op_db: list[OpInfo] = [
            check_batched_forward_grad=False,
            sample_inputs_func=sample_inputs_index,
            reference_inputs_func=partial(sample_inputs_index, reference=True),
-           skips=(
-               # Exception: index_fill_(): Complex types are yet not supported
-               DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_dtypes', device_type='mps'),
-               DecorateInfo(
-                   unittest.expectedFailure, 'TestCommon', 'test_variant_consistency_eager',
-                   device_type='mps', dtypes=(torch.complex64,)
-               ),
-               DecorateInfo(
-                   unittest.expectedFailure, 'TestCommon', 'test_noncontiguous_samples',
-                   device_type='mps', dtypes=(torch.complex64,)
-               ),
-           ),
            gradcheck_nondet_tol=GRADCHECK_NONDET_TOL),
     OpInfo('index_select',
            dtypes=all_types_and_complex_and(torch.bool, torch.float16, torch.bfloat16, torch.chalf),

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -19639,10 +19639,6 @@ op_db: list[OpInfo] = [
                DecorateInfo(unittest.expectedFailure, 'TestFakeTensor', 'test_fake_crossref_backward_no_amp'),
                # RuntimeError: Mismatch on aten._unique.default: Shapes torch.Size([2]) and torch.Size([1]) are not equal!
                DecorateInfo(unittest.expectedFailure, 'TestFakeTensor', 'test_fake_crossref_backward_amp'),
-               # RuntimeError: index_fill_(): Complex types are yet not supported
-               # NotImplementedError: "_local_scalar_dense_mps" not implemented for 'ComplexHalf'
-               DecorateInfo(unittest.expectedFailure, 'TestCommon', device_type='mps', dtypes=(torch.complex64, torch.complex32)),
-               DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_dtypes', device_type='mps'),
            ),
            sample_inputs_func=sample_inputs_index,
            reference_inputs_func=partial(sample_inputs_index, reference=True)),
@@ -21223,17 +21219,13 @@ op_db: list[OpInfo] = [
            reference_inputs_func=reference_inputs_logsumexp),
     OpInfo('trace',
            dtypes=all_types_and_complex(),
+           dtypesIfMPS=all_types_and_complex_and(torch.bool, torch.half, torch.bfloat16),
            dtypesIfCUDA=all_types_and_complex_and(torch.chalf, torch.bool, torch.half, torch.bfloat16),
            error_inputs_func=error_inputs_trace,
            supports_inplace_autograd=False,
            supports_out=False,
            supports_forward_ad=True,
            supports_fwgrad_bwgrad=True,
-           skips=(
-               # RuntimeError: index_fill_(): Complex types are yet not supported
-               DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_dtypes', device_type='mps'),
-               DecorateInfo(unittest.expectedFailure, 'TestCommon', device_type='mps', dtypes=(torch.complex64,)),
-           ),
            sample_inputs_func=sample_inputs_trace),
     OpInfo('transpose',
            ref=_numpy_ref_transpose,
@@ -27115,11 +27107,6 @@ python_ref_db = [
         torch_opinfo_name="index_fill",
         # empty_strided
         skips=(
-            # RuntimeError: index_fill_(): Complex types are yet not supported
-            DecorateInfo(
-                unittest.expectedFailure, 'TestCommon', 'test_python_ref_torch_fallback',
-                device_type='mps', dtypes=(torch.complex64, torch.complex32)
-            ),
             # no _refs support for Tensor.__setitem__
             DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_python_ref'),)
     ),

--- a/torch/testing/_internal/common_mps.py
+++ b/torch/testing/_internal/common_mps.py
@@ -82,6 +82,7 @@ if torch.backends.mps.is_available():
             "imag",
             "index_add",
             "index_copy",
+            "index_fill",
             "index_select",
             "index_put",
             "isfinite",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #175822
* #175823

Replaces the MPSGraph  implementation with Metal kernels following the same pattern as `index_copy`. 
Adds `index_fill_dense` and `index_fill_strided` kernels covering all relevant dtypes with both int32 and int64 index types. 
The Tensor-source variant is simplified to match CPU/CUDA behavior (extract scalar item and delegate).
Extended to support complex datatype and removed bunch of xfails.

Measured perf using following script
```python
"""Benchmark torch.Tensor.index_fill_ on MPS across dtypes, sizes, and layouts."""
import torch
import time

device = torch.device("mps")
WARMUP = 20
ITERS = 200


def bench(fn, label):
    for _ in range(WARMUP):
        fn()
    torch.mps.synchronize()
    t0 = time.perf_counter()
    for _ in range(ITERS):
        fn()
    torch.mps.synchronize()
    ms = (time.perf_counter() - t0) * 1e3 / ITERS
    print(f"  {label:<52s}  {ms:.3f} ms")


def make_tensor(shape, dtype):
    if dtype.is_floating_point or dtype.is_complex:
        return torch.randn(shape, device=device, dtype=dtype)
    else:
        return torch.randint(torch.iinfo(dtype).min, torch.iinfo(dtype).max, shape, device=device, dtype=dtype)


print(f"{'case':<54s}  time")
print("-" * 68)

# --- Vary dtype ---
print("dtype sweep  [shape=(4096, 4096), dim=0, 512 indices]")
N, K, num_idx = 4096, 4096, 512
idx = torch.randint(0, N, (num_idx,), device=device)
for dtype in [torch.float32, torch.float16, torch.bfloat16,
              torch.int32, torch.int64, torch.int8]:
    t = make_tensor((N, K), dtype)
    fill = 1 if dtype == torch.bool else (1 + 2j if dtype == torch.complex64 else 3)
    name = str(dtype).replace("torch.", "")
    bench(lambda t=t, idx=idx, fill=fill: t.index_fill_(0, idx, fill), f"{name}")

# --- Vary tensor size, fixed index fraction ---
print()
print("size sweep  [dtype=float32, dim=0, indices=512]")
for shape in [(256, 256), (512, 512), (1024, 1024), (2048, 2048),
              (4096, 4096), (8192, 8192), (1 << 20, 1), (1 << 24, 1)]:
    N, K = shape
    num_idx = min(512, N)
    idx = torch.randint(0, N, (num_idx,), device=device)
    t = make_tensor((N, K), torch.float32)
    numel = N * K
    label = f"({N}x{K}) numel={numel//1024}K idx={num_idx}"
    bench(lambda t=t, idx=idx: t.index_fill_(0, idx, 3.0), label)

# --- Vary index count ---
print()
print("index count sweep  [shape=(8192, 8192), dtype=float32, dim=0]")
N, K = 8192, 8192
t = make_tensor((N, K), torch.float32)
for num_idx in [1, 8, 64, 512, 1024, 4096, 8192]:
    idx = torch.randint(0, N, (num_idx,), device=device)
    bench(lambda t=t, idx=idx: t.index_fill_(0, idx, 3.0),
          f"{num_idx:>5} indices ({100*num_idx//N}% of dim)")

# --- Dense vs strided ---
print()
print("layout  [shape=(4096, 4096), dtype=float32, 512 indices]")
N = 4096
idx = torch.randint(0, N, (512,), device=device)
t_dense = make_tensor((N, N), torch.float32)
t_nc = t_dense.t().contiguous().t()  # same strides as t_dense.t() but via as_strided
bench(lambda t=t_dense, idx=idx: t.index_fill_(0, idx, 3.0), "dense  dim=0")
bench(lambda t=t_dense, idx=idx: t.index_fill_(1, idx, 3.0), "dense  dim=1")
bench(lambda t=t_nc,    idx=idx: t.index_fill_(0, idx, 3.0), "strided dim=0 (transposed view)")
bench(lambda t=t_nc,    idx=idx: t.index_fill_(1, idx, 3.0), "strided dim=1 (transposed view)")

# --- Higher-rank tensors ---
print()
print("rank sweep  [dtype=float32, ~16M total elements, 64 indices]")
idx64 = torch.randint(0, 64, (64,), device=device)
for shape in [(16777216,), (4096, 4096), (256, 256, 256), (64, 64, 64, 64)]:
    N0 = shape[0]
    idx = torch.randint(0, N0, (64,), device=device)
    t = make_tensor(shape, torch.float32)
    label = f"shape={shape} dim=0"
    bench(lambda t=t, idx=idx: t.index_fill_(0, idx, 3.0), label)

# --- Non-square matrices: vary aspect ratio, fixed total elements ~16M ---
print()
print("non-square sweep  [dtype=float32, ~16M elements, index count sweep, dim=0]")
for rows, cols in [(1 << 4, 1 << 20), (1 << 8, 1 << 16), (1 << 12, 1 << 12),
                   (1 << 16, 1 << 8), (1 << 20, 1 << 4)]:
    t = make_tensor((rows, cols), torch.float32)
    for num_idx in [1, rows // 16, rows // 4, rows]:
        num_idx = max(1, min(num_idx, rows))
        idx = torch.randint(0, rows, (num_idx,), device=device)
        label = f"({rows}x{cols}) idx={num_idx:>7} ({100*num_idx//rows:>3}%)"
        bench(lambda t=t, idx=idx: t.index_fill_(0, idx, 3.0), label)

# --- Extreme aspect ratio: few rows × huge column dim ---
# Models real use cases like (batch, vocab) or (channels, time) where
# the indexed dimension has millions of elements.
print()
print("extreme non-square  [dtype=float32, few-rows × large-cols, dim=1]")
for rows, cols in [(1, 1_000_000), (3, 1_000_000), (8, 1_000_000),
                   (1_000_000, 1), (1_000_000, 3), (1_000_000, 8)]:
    dim = 1 if cols >= rows else 0
    dim_size = cols if dim == 1 else rows
    t = make_tensor((rows, cols), torch.float32)
    for num_idx in [1, dim_size // 100, dim_size // 4, dim_size]:
        num_idx = max(1, min(num_idx, dim_size))
        idx = torch.randint(0, dim_size, (num_idx,), device=device)
        label = f"({rows}x{cols}) dim={dim} idx={num_idx:>8} ({100*num_idx//dim_size:>3}%)"
        bench(lambda t=t, idx=idx, dim=dim: t.index_fill_(dim, idx, 3.0), label)
```

That demonstrated dense indexing is ~10–100x faster across all dtypes, sizes, shapes, and index counts — with the largest gains at small index counts and narrow/tall tensors, where overhead of computing/launching MPS graph is eliminated. Transposed layouts see little to no improvement. Most significant wins comes from an observation, that for large number of indices it's better to sort them (or use bit mask) to achieve better data locality

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>