### PR TITLE
[ROCm] Retry heuristic query once on non-success status

### DIFF
--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -531,7 +531,7 @@ static inline bool bgemm_internal_cublaslt(CUDABLAS_BGEMM_ARGTYPES_AND_C_DTYPE(D
         &heuristicResult,
         &returnedResult));
   } else {
-    TORCH_CUDABLAS_CHECK(cublasLtMatmulAlgoGetHeuristic(
+    cublasStatus_t heuristic_status = cublasLtMatmulAlgoGetHeuristic(
         ltHandle,
         computeDesc.descriptor(),
         Adesc.descriptor(),
@@ -541,7 +541,24 @@ static inline bool bgemm_internal_cublaslt(CUDABLAS_BGEMM_ARGTYPES_AND_C_DTYPE(D
         preference.descriptor(),
         1,
         &heuristicResult,
-        &returnedResult));
+        &returnedResult);
+#ifdef USE_ROCM
+    if (heuristic_status != CUBLAS_STATUS_SUCCESS) {
+      TORCH_WARN("ROCm: bgemm retrying heuristic");
+      heuristic_status = cublasLtMatmulAlgoGetHeuristic(
+          ltHandle,
+          computeDesc.descriptor(),
+          Adesc.descriptor(),
+          Bdesc.descriptor(),
+          Cdesc.descriptor(),
+          Cdesc.descriptor(),
+          preference.descriptor(),
+          1,
+          &heuristicResult,
+          &returnedResult);
+    }
+#endif
+    TORCH_CUDABLAS_CHECK(heuristic_status);
   }
   if (returnedResult == 0) {
     cublasStatus = CUBLAS_STATUS_NOT_SUPPORTED;

--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -544,6 +544,8 @@ static inline bool bgemm_internal_cublaslt(CUDABLAS_BGEMM_ARGTYPES_AND_C_DTYPE(D
         &returnedResult);
 #ifdef USE_ROCM
     if (heuristic_status != CUBLAS_STATUS_SUCCESS) {
+      // HipblasLt heuristic lookup may transiently fail for some GEMM descriptors.
+      // An immediate retry often succeeds, retry once before surfacing the error.
       TORCH_WARN("ROCm: bgemm retrying heuristic");
       heuristic_status = cublasLtMatmulAlgoGetHeuristic(
           ltHandle,

--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -544,6 +544,9 @@ static inline bool bgemm_internal_cublaslt(CUDABLAS_BGEMM_ARGTYPES_AND_C_DTYPE(D
         &returnedResult);
 #ifdef USE_ROCM
     if (heuristic_status != CUBLAS_STATUS_SUCCESS) {
+      // TODO: Remove the below workaround when we rootcause the issue or move ROCm
+      // into new version.
+      // This workaround is needed for ROCm7.1 Pytorch nightly whl.
       // HipblasLt heuristic lookup may transiently fail for some GEMM descriptors.
       // An immediate retry often succeeds, retry once before surfacing the error.
       TORCH_WARN("ROCm: bgemm retrying heuristic");


### PR DESCRIPTION
Retry cublasLtMatmulAlgoGetHeuristic once in ROCm
bgemm_internal_cublaslt path when heuristic status is non-success.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang