### PR TITLE
[ROCm] disable lowp check for kernel fusion

### DIFF
--- a/test/inductor/test_benchmark_fusion.py
+++ b/test/inductor/test_benchmark_fusion.py
@@ -195,7 +195,8 @@ class BenchmarkFusionTestTemplate:
             return y + 1
 
         x = torch.randn(1024, 1024, device=self.device)
-        self.common(f, (x,))
+        # Disable lowp check due to non-deterministic kernel fusion strategies affecting fp16 precision.
+        self.common(f, (x,), check_lowp=False)
 
 
 if HAS_GPU_AND_TRITON:


### PR DESCRIPTION
Fixes #168208

### Summary
Disabling the low-precision (fp16) check in `test_tield_kernel_fusion` to stop intermittent CI failures, especially on ROCm.
The failures come from the low-precision (fp16) comparison , not the main float32 check. Benchmark fusion can choose different fusion strategies between runs, and those small differences show up more often when comparing fp16 results. 

### Fix
Set `check_lowp=False`to skip the fp16 comparison. This follows the pattern used in other inductor tests that disable low-precision checks due to fusion precision issues (e.g., `test_cumsum_zero_dim`, `test_cumprod_zero_dim`, `test_split_cumsum_low_prec`).

### Testing
`PYTORCH_TEST_WITH_ROCM=1 python test/inductor/test_benchmark_fusion.py BenchmarkFusionGpuTest.test_tield_kernel_fusion_cuda`
- Test passed on MI300.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben