### PR TITLE
Fix typo in  `index_copy` doc

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -339,7 +339,7 @@ add_docstr(
     r"""
 index_copy(input: Tensor, dim: int, index: Tensor, source: Tensor, *, out: Optional[Tensor]) -> Tensor
 
-See :meth:`~Tensor.index_add_` for function description.
+See :meth:`~Tensor.index_copy_` for function description.
 """,
 )
 


### PR DESCRIPTION
supersedes https://github.com/pytorch/pytorch/pull/175768