### PR TITLE
fix to two forward pass of ddp wrapped batch norm raising error

### DIFF
--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -2340,7 +2340,10 @@ class DistributedDataParallel(Module, Joinable):
             # Update self.modules_buffers in case any buffers were
             # reassigned.
             self._assign_modules_buffers()
-            self._sync_module_buffers(authoritative_rank)
+            with torch.autograd._unsafe_preserve_version_counter(
+                tuple(self.modules_buffers)
+            ):
+                self._sync_module_buffers(authoritative_rank)
 
     def _sync_module_buffers(self, authoritative_rank):
         if not hasattr(self, "buffer_hook"):


### PR DESCRIPTION
Fixes #175024 #66504 

Wrapping _sync_buffers in `_unsafe_preserve_version_counter` so ddp wrapped  `BatchNorm` can be forward passed twice.