### PR TITLE
Fix cuda test _mixed_dtypes_linear sm80

### DIFF
--- a/test/test_matmul_cuda.py
+++ b/test/test_matmul_cuda.py
@@ -1104,11 +1104,11 @@ class TestMixedDtypesLinearCuda(TestCase):
             input_ref = input.reshape(-1, input.shape[-1])
 
             # First, test plain multiplication.
-            weight_ref = weight.T.to(input.dtype) * scale.view(1, n)
+            weight_ref = weight.T.to(torch.float32) * scale.float().view(1, n)
             weightq = (
                 pack_int4_to_int8(weight.T) if dtypeq == torch.quint4x2 else weight.T
             )
-            output_ref = torch.mm(input_ref, weight_ref).reshape(*input.shape[:-1], n)
+            output_ref = torch.mm(input_ref.float(), weight_ref).to(input.dtype).reshape(*input.shape[:-1], n)
             output = torch.ops.aten._mixed_dtypes_linear(
                 input,
                 quantized_weight_reorder_for_mixed_dtypes_linear_cutlass(
@@ -1119,12 +1119,12 @@ class TestMixedDtypesLinearCuda(TestCase):
             torch.testing.assert_close(output, output_ref, rtol=rtol, atol=atol)
 
             # Second, test the linear operator itself.
-            weight_ref = weight.to(input.dtype) * scale.view(n, 1)
+            weight_ref = weight.to(torch.float32) * scale.float().view(n, 1)
             weightq = pack_int4_to_int8(weight) if dtypeq == torch.quint4x2 else weight
-            bias_ref = bias.view(1, n) if add_bias else None
+            bias_ref = bias.float().view(1, n) if add_bias else None
             output_ref = torch.nn.functional.linear(
-                input_ref, weight_ref, bias=bias_ref
-            ).reshape(*input.shape[:-1], n)
+                input_ref.float(), weight_ref, bias=bias_ref
+            ).to(input.dtype).reshape(*input.shape[:-1], n)
             if activation == "relu":
                 relu = torch.nn.ReLU()
                 output_ref = relu(output_ref)


### PR DESCRIPTION
Fixes self-tests SM_80 SKU like A100, Orin:
- python test/test_matmul_cuda.py TestMixedDtypesLinearCudaCUDA.test_mixed_dtypes_linear_cuda_float16
- python test/test_matmul_cuda.py TestMixedDtypesLinearCudaCUDA.test_mixed_dtypes_linear_cuda_bfloat16

The `TestMixedDtypesLinearCudaCUDA` calls on :


```
output = torch.ops.aten._mixed_dtypes_linear(
                input,
                quantized_weight_reorder_for_mixed_dtypes_linear_cutlass(
                    weightq, dtypeq, transpose=False
                ),
                scale,
            )
```

where [`_mixed_dtypes_linear `](https://github.com/pytorch/pytorch/blob/e8d776f2a626c3929e26a2a9f628633bf01adf77/test/test_matmul_cuda.py#L1122) uses fp32 precision for the accumulator based on emperical test . The current test uses the dtype of the input which will show larger error with bigger input sizes in dot product etc as evidenced by these tests below:

```
import torch
from torch.testing import make_tensor
from torch.quantization._quantized_conversions import (
    pack_int4_to_int8,
    quantized_weight_reorder_for_mixed_dtypes_linear_cutlass,
)

dtype = torch.bfloat16
dtypeq = torch.int8
m, n = 8, 256
device = "cuda"

print(f"Device: {torch.cuda.get_device_name()}")
print(f"Capability: {torch.cuda.get_device_capability()}")
print()

scale = make_tensor((n,), low=-1, high=1, dtype=dtype, device=device)
bias = make_tensor((n,), low=-1, high=1, dtype=dtype, device=device)

for k_test in [64, 128, 192, 256, 384]:
    inp = make_tensor(m, k_test, low=-1, high=1, dtype=dtype, device=device)
    w = make_tensor(n, k_test, low=-2, high=2, dtype=torch.int8, device=device)
    w_ref = w.to(dtype) * scale.view(n, 1)
    ref = torch.nn.functional.linear(inp, w_ref, bias=bias.view(1, n))
    out = torch.ops.aten._mixed_dtypes_linear(
        inp,
        quantized_weight_reorder_for_mixed_dtypes_linear_cutlass(w, dtypeq, transpose=True),
        scale,
        bias=bias,
        activation="none",
    )
    d = (out - ref).abs()
    print(f"k={k_test:4d}: max_diff={d.max().item():.6f}, mismatched={(d > 1e-3).sum().item():4d}/{d.numel()}")

> python test.py
k=  64: max_diff=0.000000, mismatched=   0/2048
k= 128: max_diff=0.000000, mismatched=   0/2048
k= 192: max_diff=0.000000, mismatched=   0/2048
k= 256: max_diff=0.000000, mismatched=   0/2048
k= 384: max_diff=0.125000, mismatched= 538/2048
```




Doing this test confirmed that if using fp32 as reference then we get 0 error which implies that the accumulator is fp32.


```
import torch
from torch.testing import make_tensor
from torch.quantization._quantized_conversions import (
    pack_int4_to_int8,
    quantized_weight_reorder_for_mixed_dtypes_linear_cutlass,
)

dtype = torch.bfloat16
dtypeq = torch.int8
m, n, k = 8, 256, 384
batch_shape = []
add_bias = True
device = "cuda"

print("=== GPU Info ===")
print(f"Device: {torch.cuda.get_device_name()}")
print(f"Capability: {torch.cuda.get_device_capability()}")
print()

input = make_tensor(*batch_shape, m, k, low=-1, high=1, dtype=dtype, device=device)
weight = make_tensor(n, k, low=-2, high=2, dtype=torch.int8, device=device)
scale = make_tensor((n,), low=-1, high=1, dtype=dtype, device=device)
bias = make_tensor((n,), low=-1, high=1, dtype=dtype, device=device)
input_ref = input.reshape(-1, input.shape[-1])

weight_ref = weight.to(dtype) * scale.view(n, 1)
weightq = weight

output = torch.ops.aten._mixed_dtypes_linear(
    input,
    quantized_weight_reorder_for_mixed_dtypes_linear_cutlass(weightq, dtypeq, transpose=True),
    scale,
    bias=bias,
    activation="none",
)


# === Test 3: Compare against fp32 reference ===
print("=== Test 3: vs fp32 reference (accumulation precision check) ===")
output_ref_fp32 = torch.nn.functional.linear(
    input_ref.float(), weight_ref.float(), bias=bias.float().view(1, n)
).to(dtype).reshape(*input.shape[:-1], n)
diff_fp32 = (output - output_ref_fp32).abs()
print(f"Max abs diff: {diff_fp32.max().item()}")
print(f"Mismatched (atol=1e-3): {(diff_fp32 > 1e-3).sum().item()} / {diff_fp32.numel()}")
print()


=== Test 3: vs fp32 reference (accumulation precision check) ===
Max abs diff: 0.0
Mismatched (atol=1e-3): 0 / 2048

```