### PR TITLE
Fix internal diff-train of TorchCodec

### DIFF
--- a/build.bzl
+++ b/build.bzl
@@ -71,7 +71,8 @@ def define_targets(rules):
         "$(execpath //torchgen:gen)",
         "--install_dir=$(RULEDIR)",
         "--source-path aten/src/ATen",
-        "--aoti_install_dir=$(RULEDIR)/torch/csrc/inductor/aoti_torch/generated"
+        "--aoti_install_dir=$(RULEDIR)/torch/csrc/inductor/aoti_torch/generated",
+        "--update-aoti-c-shim"
     ] + (["--static_dispatch_backend CPU"] if rules.is_cpu_static_dispatch_build() else []) + ["--mtia"])
 
     gen_aten_outs_cuda = (
@@ -327,6 +328,7 @@ GENERATED_AUTOGRAD_CPP = [
 
 GENERATED_AOTI_CPP = [
     "torch/csrc/inductor/aoti_torch/generated/c_shim_cpu.cpp",
+    "torch/csrc/inductor/aoti_torch/generated/c_shim_aten.cpp",
 ]
 
 GENERATED_AOTI_CUDA_CPP = [

--- a/build.bzl
+++ b/build.bzl
@@ -71,8 +71,7 @@ def define_targets(rules):
         "$(execpath //torchgen:gen)",
         "--install_dir=$(RULEDIR)",
         "--source-path aten/src/ATen",
-        "--aoti_install_dir=$(RULEDIR)/torch/csrc/inductor/aoti_torch/generated",
-        "--update-aoti-c-shim"
+        "--aoti_install_dir=$(RULEDIR)/torch/csrc/inductor/aoti_torch/generated"
     ] + (["--static_dispatch_backend CPU"] if rules.is_cpu_static_dispatch_build() else []) + ["--mtia"])
 
     gen_aten_outs_cuda = (


### PR DESCRIPTION
https://github.com/meta-pytorch/torchcodec/pull/1242 migrated part of TorchCodec to rely on the stable ABI. It went fine on GH. It's broken internally on fbcode (D93770012) with errors like `undefined symbol: aoti_torch_aten_narrow`, and our diff-train is currently on hold until we can resolve this.

This PR is aimed at fixing (part of) these problems, and it can be verified that they work via D94539677. More changes will be needed to the fbcode codebase, these are the GH-facing ones.