### PR TITLE
dist.broadcast for fp8 on <sm90

### DIFF
--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -2992,10 +2992,12 @@ def broadcast(
     opts.rootRank = group_src
     opts.rootTensor = 0
     opts.asyncOp = async_op
-    no_native_fp8_support = torch.cuda.get_device_capability(tensor.device)[0] < 9
+    sm90_or_more = not (
+        tensor.is_cuda and torch.cuda.get_device_capability(tensor.device)[0] >= 9
+    )
     if tensor.is_complex():
         tensor = torch.view_as_real(tensor)
-    elif _is_fp8(tensor) and no_native_fp8_support:
+    elif _is_fp8(tensor) and not sm90_or_more:
         # FP8 is supported by NCCL on sm90+, use workaround for older GPUs
         tensor = tensor.view(torch.uint8)
     work = group.broadcast([tensor], opts)


### PR DESCRIPTION
Summary:

ran into this here: https://github.com/vllm-project/llm-compressor/pull/2404

dist.broadcast hits NCCL which doesn't support fp8 unless device
is at least sm_90. 

Its a simple fix to cast the data to uint8 and then broadcast
that, similar to the current .view_as_real fix to broadcast complex
tensors

Test Plan:

pytest /home/HDCharles/repos/pytorch/test/distributed/test_c10d_nccl.py
-k "test_broadcast_float8"

Signed-off-by: HDCharles <charlesdavidhernandez@gmail.com>