### PR TITLE
Optimize _jit_pass_onnx_deduplicate_initializers from O(N^2) to O(N)

### DIFF
--- a/torch/csrc/jit/passes/onnx/deduplicate_initializers.cpp
+++ b/torch/csrc/jit/passes/onnx/deduplicate_initializers.cpp
@@ -28,7 +28,7 @@ struct HashValue {
     uint64_t first_elem_uint64 = 0;
 
     if (t.numel() > 0 && t.has_storage()) {
-      auto scalar = t.view(-1)[0].item();
+      auto scalar = t.reshape(-1)[0].item();
 
       if (scalar.isFloatingPoint()) {
         first_elem_double = scalar.to<double>();

--- a/torch/csrc/jit/passes/onnx/deduplicate_initializers.cpp
+++ b/torch/csrc/jit/passes/onnx/deduplicate_initializers.cpp
@@ -2,7 +2,11 @@
 #include <torch/csrc/jit/passes/onnx/deduplicate_initializers.h>
 #include <torch/csrc/jit/passes/onnx/helper.h>
 
+#include <c10/util/hash.h>
 #include <c10/util/irange.h>
+
+#include <functional>
+#include <unordered_set>
 
 namespace torch::jit {
 
@@ -10,27 +14,72 @@ namespace onnx {
 using namespace ::c10::onnx;
 }
 
+struct HashValue {
+  HashValue(ValueToParamPairMap& valsToParamsMap)
+      : valsToParamsMap_(valsToParamsMap) {}
+
+  size_t operator()(Value* v) const {
+    auto t = valsToParamsMap_.find(v)->second.second.toTensor();
+
+    // Use first element of the tensor data as part of the hash to reduce hash
+    // collision, since most tensors differ from one another from the very first
+    // element.
+    double first_elem_double = 0.0;
+    int64_t first_elem_int64 = 0;
+    uint64_t first_elem_uint64 = 0;
+
+    if (t.numel() > 0 && t.has_storage()) {
+      auto scalar = t.view(-1)[0].item();
+
+      if (scalar.isFloatingPoint()) {
+        first_elem_double = scalar.to<double>();
+      } else if (scalar.isIntegral(/*includeBool=*/true)) {
+        if (scalar.isUnsigned()) {
+          first_elem_uint64 = scalar.to<uint64_t>();
+        } else {
+          first_elem_int64 = scalar.to<int64_t>();
+        }
+      }
+    }
+
+    return at::get_hash(
+        first_elem_double,
+        first_elem_int64,
+        first_elem_uint64,
+        t.scalar_type(),
+        t.sizes(),
+        t.strides());
+  }
+
+ private:
+  ValueToParamPairMap& valsToParamsMap_;
+};
+
+struct CompareValue {
+  CompareValue(std::function<bool(Value*, Value*)> is_same_tensor_as)
+      : is_same_tensor_as_(is_same_tensor_as) {}
+
+  bool operator()(Value* v1, Value* v2) const {
+    return is_same_tensor_as_(v1, v2);
+  }
+
+ private:
+  std::function<bool(Value*, Value*)> is_same_tensor_as_;
+};
+
 static void DeduplicateInitializers(
     std::shared_ptr<Graph>& g,
     ValueToParamPairMap& valsToParamsMap,
     bool (*comp)(at::Tensor&, at::Tensor&)) {
-  auto is_same_tensor_as = [&valsToParamsMap, comp](Value* v1) {
-    return [&valsToParamsMap, v1, comp](Value* v2) {
-      if ((valsToParamsMap.find(v1) == valsToParamsMap.end()) ||
-          (valsToParamsMap.find(v2) == valsToParamsMap.end())) {
-        return false;
-      }
-      auto iv1 = valsToParamsMap.find(v1)->second.second;
-      auto iv2 = valsToParamsMap.find(v2)->second.second;
-      if (!iv1.isTensor() || !iv2.isTensor()) {
-        return false;
-      }
-      auto t1 = iv1.toTensor();
-      auto t2 = iv2.toTensor();
-      return comp(t1, t2);
-    };
+  auto is_same_tensor_as = [&valsToParamsMap, comp](Value* v1, Value* v2) {
+    auto t1 = valsToParamsMap.find(v1)->second.second.toTensor();
+    auto t2 = valsToParamsMap.find(v2)->second.second.toTensor();
+    return comp(t1, t2);
   };
-  std::vector<Value*> uniqueVals;
+
+  // std::vector<Value*> uniqueVals;
+  std::unordered_set<Value*, HashValue, CompareValue> uniqueVals(
+      0, HashValue(valsToParamsMap), CompareValue(is_same_tensor_as));
   std::vector<size_t> inputsIndicesToRemove;
   auto b = g->block();
 
@@ -40,15 +89,26 @@ static void DeduplicateInitializers(
       // Skip model inputs
       continue;
     }
-    auto it = std::find_if(
-        uniqueVals.begin(), uniqueVals.end(), is_same_tensor_as(v));
-    if (it == uniqueVals.end()) {
-      uniqueVals.emplace_back(v);
-    } else {
+
+    // Skip parameters without initializers
+    if (valsToParamsMap.find(v) == valsToParamsMap.end()) {
+      continue;
+    }
+
+    auto iv = valsToParamsMap.find(v)->second.second;
+
+    // Skip non-tensors
+    if (!iv.isTensor()) {
+      continue;
+    }
+
+    auto it = uniqueVals.insert(v);
+    if (!it.second) {
+      // Same value already exists
       inputsIndicesToRemove.emplace_back(i);
       auto id_node = g->create(onnx::Identity);
       id_node->insertAfter(g->block()->param_node());
-      id_node->addInput(*it);
+      id_node->addInput(*it.first);
       id_node->output()->copyMetadata(v);
       id_node->copyMetadata(g->block()->param_node());
       v->replaceAllUsesWith(id_node->output());

--- a/torch/csrc/jit/passes/onnx/deduplicate_initializers.cpp
+++ b/torch/csrc/jit/passes/onnx/deduplicate_initializers.cpp
@@ -21,9 +21,8 @@ struct HashValue {
   size_t operator()(Value* v) const {
     auto t = valsToParamsMap_.find(v)->second.second.toTensor();
 
-    // Use first element of the tensor data as part of the hash to reduce hash
-    // collision, since most tensors differ from one another from the very first
-    // element.
+    // Use first element of the tensor as hash key to reduce hash collision,
+    // since most tensors differ from one another from the very first element.
     double first_elem_double = 0.0;
     int64_t first_elem_int64 = 0;
     uint64_t first_elem_uint64 = 0;
@@ -77,7 +76,6 @@ static void DeduplicateInitializers(
     return comp(t1, t2);
   };
 
-  // std::vector<Value*> uniqueVals;
   std::unordered_set<Value*, HashValue, CompareValue> uniqueVals(
       0, HashValue(valsToParamsMap), CompareValue(is_same_tensor_as));
   std::vector<size_t> inputsIndicesToRemove;

--- a/torch/csrc/jit/passes/onnx/deduplicate_initializers.cpp
+++ b/torch/csrc/jit/passes/onnx/deduplicate_initializers.cpp
@@ -15,14 +15,21 @@ using namespace ::c10::onnx;
 }
 
 struct HashValue {
-  HashValue(ValueToParamPairMap& valsToParamsMap)
-      : valsToParamsMap_(valsToParamsMap) {}
+  HashValue(ValueToParamPairMap& valsToParamsMap, bool compare_by_ptr)
+      : valsToParamsMap_(valsToParamsMap), compare_by_ptr_(compare_by_ptr) {}
 
   size_t operator()(Value* v) const {
     auto t = valsToParamsMap_.find(v)->second.second.toTensor();
 
-    // Use first element of the tensor as hash key to reduce hash collision,
-    // since most tensors differ from one another from the very first element.
+    if (compare_by_ptr_) {
+      // Hash by metadata + data pointer
+      return at::get_hash(
+          t.sizes(), t.strides(), t.has_storage() ? t.data_ptr() : 0);
+    }
+
+    // Hash by metadata + first element value (if exists). This is a fast
+    // approximation of hashing by the whole tensor value, which can be
+    // expensive for large tensors.
     double first_elem_double = 0.0;
     int64_t first_elem_int64 = 0;
     uint64_t first_elem_uint64 = 0;
@@ -51,6 +58,7 @@ struct HashValue {
 
  private:
   ValueToParamPairMap& valsToParamsMap_;
+  bool compare_by_ptr_;
 };
 
 struct CompareValue {
@@ -65,6 +73,9 @@ struct CompareValue {
   std::function<bool(Value*, Value*)> is_same_tensor_as_;
 };
 
+// forward declaration
+static bool DeduplicateInitializersByDataPtr(at::Tensor& t1, at::Tensor& t2);
+
 static void DeduplicateInitializers(
     std::shared_ptr<Graph>& g,
     ValueToParamPairMap& valsToParamsMap,
@@ -75,8 +86,11 @@ static void DeduplicateInitializers(
     return comp(t1, t2);
   };
 
+  bool compare_by_ptr = comp == &DeduplicateInitializersByDataPtr;
   std::unordered_set<Value*, HashValue, CompareValue> uniqueVals(
-      0, HashValue(valsToParamsMap), CompareValue(is_same_tensor_as));
+      0,
+      HashValue(valsToParamsMap, compare_by_ptr),
+      CompareValue(is_same_tensor_as));
   std::vector<size_t> inputsIndicesToRemove;
   auto b = g->block();
 

--- a/torch/csrc/jit/passes/onnx/deduplicate_initializers.cpp
+++ b/torch/csrc/jit/passes/onnx/deduplicate_initializers.cpp
@@ -45,7 +45,6 @@ struct HashValue {
         first_elem_double,
         first_elem_int64,
         first_elem_uint64,
-        t.scalar_type(),
         t.sizes(),
         t.strides());
   }

--- a/torch/csrc/jit/passes/onnx/deduplicate_initializers.cpp
+++ b/torch/csrc/jit/passes/onnx/deduplicate_initializers.cpp
@@ -83,20 +83,15 @@ static void DeduplicateInitializers(
 
   for (auto i : c10::irange(b->inputs().size())) {
     auto v = g->inputs().at(i);
-    if (valsToParamsMap.find(v) == valsToParamsMap.end()) {
-      // Skip model inputs
-      continue;
-    }
+    auto vals_to_param_it = valsToParamsMap.find(v);
 
     // Skip parameters without initializers
-    if (valsToParamsMap.find(v) == valsToParamsMap.end()) {
+    if (vals_to_param_it == valsToParamsMap.end()) {
       continue;
     }
 
-    auto iv = valsToParamsMap.find(v)->second.second;
-
     // Skip non-tensors
-    if (!iv.isTensor()) {
+    if (!vals_to_param_it->second.second.isTensor()) {
       continue;
     }
 


### PR DESCRIPTION
Implemented the suggestion in #175872.
Below is the toy benchmark result from the reproducible example script in #175872

* Unit: s
* Numbers outside parentheses: full execution time of torch.onnx.export
* Numbers inside parentheses: of which _jit_pass_onnx_deduplicate_initializers

|     |  256-layers | 512-layers | 1024-layers | 2048-layers | 4096-layers |
|:---:|:-------------:|:-----:|:---------:|:-------:|:------:|
| v2.9.1 cpu | 0.6<br>(0.1) | 1.4<br>(0.5) | 4.4<br>(11.8) | 15.6<br>(11.8) | 66.7<br>(58.6) |
| **+ this PR** | **0.2<br>(0.0)** | **0.4<br>(0.0)** | **0.9<br>(0.0)** | **1.9<br>(0.0)** | **4.1<br>(0.0)** |
| v2.9.1 cuda | 3.0<br>(2.4) | 10.6<br>(9.6) | 41.5<br>(39.4) | 159.8<br>(164.3) | 654.9<br>(645.9) |
| **+ this PR** | **0.3<br>(0.0)** | **0.5<br>(0.0)** | **1.0<br>(0.0)** | **2.2<br>(0.1)** | **4.7<br>(0.1)** |

cc @gujinghui @PenghuiCheng @XiaobingSuper @jianyuh @jgong5 @mingfeima @sanchitintel @ashokei @jingxu10 @min-jean-cho @yanbing-j @Guobing-Chen @Xia-Weiwen @snadampal