### PR TITLE
[AOTAutograd] Fix static_input_indices not offset when effect tokens are prepended

### DIFF
--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -6736,6 +6736,67 @@ def forward(self, primals_1, tangents_1):
         finally:
             handle.destroy()
 
+    def test_static_input_indices_with_effect_tokens(self):
+        """Test that static_input_indices are correctly offset when effect tokens are prepended."""
+        from torch._functorch._aot_autograd.descriptors import PlainAOTInput
+        from torch._functorch._aot_autograd.graph_capture_wrappers import (
+            handle_effect_tokens_fn,
+        )
+        from torch._functorch._aot_autograd.schemas import ViewAndMutationMeta
+        from torch._higher_order_ops.effects import _register_effectful_op
+        from torch._library.effects import EffectType
+
+        @torch.library.custom_op(
+            "test::effectful_static_idx_op", mutates_args=()
+        )
+        def effectful_static_idx_op(x: torch.Tensor) -> torch.Tensor:
+            return x.clone()
+
+        @effectful_static_idx_op.register_fake
+        def _(x: torch.Tensor) -> torch.Tensor:
+            return torch.empty_like(x)
+
+        handle = _register_effectful_op(effectful_static_idx_op, EffectType.ORDERED)
+
+        try:
+            meta = ViewAndMutationMeta(
+                input_info=[],
+                output_info=[],
+                num_intermediate_bases=0,
+                keep_input_mutations=False,
+                traced_tangents=[],
+                subclass_inp_meta=[],
+                subclass_fw_graph_out_meta=[],
+                subclass_tangent_meta=[],
+                is_train=False,
+                traced_tangents_descs=[],
+            )
+            meta.tokens = {EffectType.ORDERED: torch.tensor([])}
+            # Simulate: params at indices 1, 2 before token insertion
+            meta.static_input_indices = [1, 2]
+
+            args = [torch.randn(4, 3), torch.randn(2, 3), torch.randn(2)]
+            args_descs = [PlainAOTInput(i) for i in range(3)]
+
+            _, new_args, _ = handle_effect_tokens_fn(
+                lambda *a: (torch.randn(1), []),
+                args,
+                args_descs,
+                meta=meta,
+                trace_joint=False,
+            )
+
+            num_tokens = len(meta.tokens)
+            self.assertGreater(num_tokens, 0)
+            # After prepending tokens, args grow and indices must be offset
+            self.assertEqual(len(new_args), len(args) + num_tokens)
+            self.assertEqual(
+                meta.static_input_indices,
+                [1 + num_tokens, 2 + num_tokens],
+            )
+        finally:
+            handle.destroy()
+
 
 class TestAOTDispatch(AOTTestCase):
     # Tests to add cases for (non-exhaustive list, mostly for my notes):

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -6746,9 +6746,7 @@ def forward(self, primals_1, tangents_1):
         from torch._higher_order_ops.effects import _register_effectful_op
         from torch._library.effects import EffectType
 
-        @torch.library.custom_op(
-            "test::effectful_static_idx_op", mutates_args=()
-        )
+        @torch.library.custom_op("test::effectful_static_idx_op", mutates_args=())
         def effectful_static_idx_op(x: torch.Tensor) -> torch.Tensor:
             return x.clone()
 

--- a/torch/_functorch/_aot_autograd/graph_capture_wrappers.py
+++ b/torch/_functorch/_aot_autograd/graph_capture_wrappers.py
@@ -1271,6 +1271,9 @@ def handle_effect_tokens_fn(
     else:
         args = [*additional_fwd_token_inputs, *args]
         args_descs = [*additional_fwd_token_inputs_descs, *args_descs]
+
+        if num_tokens > 0:
+            meta.static_input_indices = [idx + num_tokens for idx in meta.static_input_indices]
     return inner_fn, args, args_descs
 
 

--- a/torch/_functorch/_aot_autograd/graph_capture_wrappers.py
+++ b/torch/_functorch/_aot_autograd/graph_capture_wrappers.py
@@ -1273,7 +1273,9 @@ def handle_effect_tokens_fn(
         args_descs = [*additional_fwd_token_inputs_descs, *args_descs]
 
         if num_tokens > 0:
-            meta.static_input_indices = [idx + num_tokens for idx in meta.static_input_indices]
+            meta.static_input_indices = [
+                idx + num_tokens for idx in meta.static_input_indices
+            ]
     return inner_fn, args, args_descs
 
 


### PR DESCRIPTION
## Summary

  When effectful ops (e.g., `with_effects`) are present, `handle_effect_tokens_fn()` prepends effect token placeholders to the input args. However, `static_input_indices` in `ViewAndMutationMeta` is computed before this prepending and is not adjusted afterwards. This causes indices to point to wrong inputs, leading to issues like unnecessary CUDA graph re-recording.

  ## Problem

  In `handle_effect_tokens_fn()`, effect tokens are prepended to args:

  ```python
  additional_fwd_token_inputs = [torch.tensor([])] * num_tokens
  args = [*additional_fwd_token_inputs, *args]  # tokens prepended at index 0
```

  But meta.static_input_indices is not offset by num_tokens. When these indices are later used (e.g., by CUDAGraph's check_invariants), they point to the wrong inputs:

  Before tokens: `args=[activation, weight], static_input_indices=[1]  → weight ✓`
  After tokens:  `args=[token, activation, weight], static_input_indices=[1]  → activation ✗`
  Expected:     ` static_input_indices=[2] (offset by num_tokens=1)  → weight ✓`

  ## Impact

  - Activations get incorrectly marked as static inputs
  - CUDAGraph's check_invariants sees data pointer changes for "static" inputs
  - This triggers unnecessary re-recording, causing performance degradation

  ## Fix

  Offset static_input_indices by num_tokens after prepending effect tokens in the forward-only (trace_joint=False) path:

```python
  if num_tokens > 0:
      meta.static_input_indices = [
          idx + num_tokens for idx in meta.static_input_indices
      ]
```

  ## Unit Test

  Added `test_static_input_indices_with_effect_tokens` in `test/functorch/test_aotdispatch.py` which:
  1. Registers a custom effectful op via _register_effectful_op
  2. Compiles a function with torch.compile using a metadata-capturing backend
  3. Verifies that all `static_input_indices are >= num_tokens` after effect tokens are prepended (i.e., no index
  incorrectly points to a token input)

  cc @yanboliang
