### PR TITLE
[MPS] addmm & mm implementations must return zero filled matrix if one of inputs are empty

### DIFF
--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -3710,6 +3710,7 @@ Tensor& _int_mm_out_cpu(const Tensor& self, const Tensor& mat2, Tensor& result) 
   TORCH_CHECK(result.dim() == 2, func_name, ": Expected result to be of dimension 2 but got ", result.dim());
   TORCH_CHECK(result.is_contiguous(), func_name, ": Expected result to be contiguous.");
 
+  // Outer or inner dimension is 0
   if (result.numel() == 0 || self.size(1) == 0) {
     return result.zero_();
   }

--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -876,7 +876,7 @@ static Tensor& addmm_out_mps_impl(const Tensor& bias,
       output.mul_(beta);
     }
     return output;
-}
+  }
 
   if (use_metal_mm(self, other, output)) {
     return do_metal_addmm(self, other, output, alpha, beta, *bias_);


### PR DESCRIPTION
Output of MM for zero-sized tensors should be zero'd out in MPS similar to CPU implementation
  - This was previously uncovered in MPS as the result tensor was automatically zero'd upon allocation in private memory
  - Once tensor allocation moved to unified memory, result tensor was not guaranteed to be zero'd, thus resulting in garbage.
  - Updating MPS `mm_out_mps_impl` to exactly match `_int_mm_out_cpu` CPU implementation in zero-sized matrix edge case behavior
  - Updating MPS `addmm_out_mps_impl` to exactly match `addmm_impl_cpu_` CPU implementation in zero-sized matrix edge case behavior

Fixes  https://github.com/pytorch/pytorch/issues/175902 
