### PR TITLE
[Inductor] Fix AsyncCollectiveTensor in Triton HOP by unwrapping at call site

### DIFF
--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -13,6 +13,7 @@ import os
 import random
 import re
 import tempfile
+from enum import Enum
 from collections.abc import Callable
 from itertools import chain, count
 from typing import Any, Optional, TYPE_CHECKING, Union
@@ -89,6 +90,24 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 pexpr = PythonPrinter().doprint
+
+
+def _sanitize_for_repr(obj: Any) -> Any:
+    """Convert Enum values to their underlying value for valid Python repr in code generation."""
+    if isinstance(obj, dict):
+        return {k: _sanitize_for_repr(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_sanitize_for_repr(v) for v in obj]
+    if type(obj) is tuple:
+        return tuple(_sanitize_for_repr(v) for v in obj)
+    # For namedtuples (have _fields), use _replace to preserve the type
+    if isinstance(obj, tuple) and hasattr(obj, "_fields"):
+        return obj._replace(
+            **{field: _sanitize_for_repr(getattr(obj, field)) for field in obj._fields}
+        )
+    if isinstance(obj, Enum):
+        return obj.value
+    return obj
 
 
 ReuseKey = tuple[torch.device, torch.dtype, str, bool]
@@ -2697,12 +2716,14 @@ class PythonWrapperCodegen(CodeGen):
         if config.triton.proton_profiling:
             compile_wrapper.writeline('pl.enable_semantic("triton")')
 
+        # Sanitize triton_meta to convert Enum values for valid Python repr
+        sanitized_triton_meta = _sanitize_for_repr(triton_meta)
         compile_wrapper.splice(
             f"""
             @triton_heuristics.user_autotune(
                 configs={[*map(config_to_dict, configs)]!r},
                 inductor_meta={inductor_meta!r},
-                triton_meta={triton_meta!r},
+                triton_meta={sanitized_triton_meta!r},
                 filename=__file__,
                 custom_kernel=True,
             )


### PR DESCRIPTION
Summary:
Under torch.compile with distributed training (MX4 qcomms + ir_serializer=on_disk), AllToAll outputs may be wrapped in AsyncCollectiveTensor. When these tensors appear in the kwargs dict passed to triton_kernel_wrapper_mutation, the HOP dispatch mechanism hits a mismatch: _compute_keyset flattens dicts via pytree and finds the AsyncCollectiveTensor (adding DispatchKey.Python to the keyset), but check_overloaded only checks lists/tuples and doesn't recurse into dicts, so it can't find the subclass to dispatch to, causing a TypeError.

This fix unwraps AsyncCollectiveTensors by calling wait_tensor() in both TritonKernelWrapperMutation.__call__ and TritonKernelWrapperFunctional.__call__, right before the tensors reach the HOP dispatch infrastructure. This is the least risky approach because it only affects the exact code path that invokes Triton HOPs, requires no changes to _ops.py (the core dispatch infrastructure), and involves no module-level py_impl registration or global state mutation.

Test Plan: Unit tests in test_triton_kernels.py (AsyncCollectiveUnwrapTests) verifying unwrap behavior and passthrough for non-async tensors. Also tested E2E: buck2 run mode/opt fbcode//aps_models/ads/gmp:launcher_with_publish mode=dpa_product_ctr_model/experimental/local_mode_dpa_product_ctr_model_731499617_v0_fork_mp +training.ir_serializer=on_disk

Differential Revision: D94101195




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo