### PR TITLE
[Export] Fix unflatten crash when mutation intermediate has list args

### DIFF
--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -13,6 +13,7 @@ import os
 import random
 import re
 import tempfile
+from enum import Enum
 from collections.abc import Callable
 from itertools import chain, count
 from typing import Any, Optional, TYPE_CHECKING, Union
@@ -89,6 +90,24 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 pexpr = PythonPrinter().doprint
+
+
+def _sanitize_for_repr(obj: Any) -> Any:
+    """Convert Enum values to their underlying value for valid Python repr in code generation."""
+    if isinstance(obj, dict):
+        return {k: _sanitize_for_repr(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_sanitize_for_repr(v) for v in obj]
+    if type(obj) is tuple:
+        return tuple(_sanitize_for_repr(v) for v in obj)
+    # For namedtuples (have _fields), use _replace to preserve the type
+    if isinstance(obj, tuple) and hasattr(obj, "_fields"):
+        return obj._replace(
+            **{field: _sanitize_for_repr(getattr(obj, field)) for field in obj._fields}
+        )
+    if isinstance(obj, Enum):
+        return obj.value
+    return obj
 
 
 ReuseKey = tuple[torch.device, torch.dtype, str, bool]
@@ -2697,12 +2716,14 @@ class PythonWrapperCodegen(CodeGen):
         if config.triton.proton_profiling:
             compile_wrapper.writeline('pl.enable_semantic("triton")')
 
+        # Sanitize triton_meta to convert Enum values for valid Python repr
+        sanitized_triton_meta = _sanitize_for_repr(triton_meta)
         compile_wrapper.splice(
             f"""
             @triton_heuristics.user_autotune(
                 configs={[*map(config_to_dict, configs)]!r},
                 inductor_meta={inductor_meta!r},
-                triton_meta={triton_meta!r},
+                triton_meta={sanitized_triton_meta!r},
                 filename=__file__,
                 custom_kernel=True,
             )


### PR DESCRIPTION
Summary:
`torch.export.unflatten` crashes with `AttributeError: 'immutable_list' object has no attribute 'graph'` when processing mutation intermediates that have list-type arguments.

In `_IVals.read()`, the code calls `remap_input(node.args[0])` assuming `args[0]` is always a single `torch.fx.Node`. For ops like `torch.cat` or `torch.stack`, `args[0]` is an `immutable_list` of nodes, which has no `.graph` attribute. The fix checks `isinstance(arg0, torch.fx.Node)` before calling `remap_input`. When `arg0` is not a Node (e.g., a list), it removes the node from tracked mutations and adds it as a placeholder input to the subgraph instead.

This is triggered in production by models that combine buffer mutations with list-arg operations crossing module boundaries. For example, `dpa_product_ctr_model` has `HistogramBinningCalibration` modules that mutate buffers (`self.iterations.add_(1)`, `self.bin_num_examples.index_add_(...)`) inside `CTRCVRTrainSingleTaskArch`, while the parent `CTRCVRTrainTaskArchs` calls `torch.stack(losses)` to combine per-task results. The buffer mutations cause the unflattener to enter the `_IVals.read` codepath for cross-boundary nodes, and `torch.stack(losses)` hits the crash because its `args[0]` is a list of loss tensors, not a single Node.

Also adds `torch.ops.aten.sym_numel.default` to the list of sym-producing ops, which was missing and caused failures when `sym_numel` appeared in exported graphs.

Test Plan: Added `test_unflatten_sym_numel` and `test_unflatten_mutation_intermediate_list_args` in test_unflatten.py. Also tested E2E: buck2 run mode/opt fbcode//aps_models/ads/gmp:launcher_with_publish mode=dpa_product_ctr_model/experimental/local_mode_dpa_product_ctr_model_731499617_v0_fork_mp +training.ir_serializer=on_disk

Differential Revision: D94101192




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo