### PR TITLE
[BE] Move binary build scripts from .circleci/ to .ci/pytorch/

### DIFF
--- a/.ci/pytorch/binary_linux_test.sh
+++ b/.ci/pytorch/binary_linux_test.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+
+OUTPUT_SCRIPT=${OUTPUT_SCRIPT:-/home/circleci/project/ci_test_script.sh}
+
+# only source if file exists
+if [[ -f /home/circleci/project/env ]]; then
+  source /home/circleci/project/env
+fi
+cat >"${OUTPUT_SCRIPT}" <<EOL
+# =================== The following code will be executed inside Docker container ===================
+set -eux -o pipefail
+
+retry () {
+    "\$@"  || (sleep 1 && "\$@") || (sleep 2 && "\$@")
+}
+
+# Source binary env file here if exists
+if [[ -e "${BINARY_ENV_FILE:-/nofile}" ]]; then
+  source "${BINARY_ENV_FILE:-/nofile}"
+fi
+
+python_nodot="\$(echo $DESIRED_PYTHON | tr -d m.u)"
+
+# Set up Python
+if [[ "$PACKAGE_TYPE" != libtorch ]]; then
+  python_path="/opt/python/cp\$python_nodot-cp\${python_nodot}"
+  if [[ "\$python_nodot" = *t ]]; then
+    python_digits="\$(echo $DESIRED_PYTHON | tr -cd [:digit:])"
+    python_path="/opt/python/cp\$python_digits-cp\${python_digits}t"
+  fi
+  export PATH="\${python_path}/bin:\$PATH"
+fi
+
+# Move debug wheels out of the package dir so they don't get installed
+mkdir -p /tmp/debug_final_pkgs
+mv /final_pkgs/debug-*.zip /tmp/debug_final_pkgs || echo "no debug packages to move"
+
+# Install the package
+# These network calls should not have 'retry's because they are installing
+# locally and aren't actually network calls
+# Pick only one package of multiple available (which happens as result of workflow re-runs)
+pkg="/final_pkgs/\$(ls -1 /final_pkgs|sort|tail -1)"
+if [[ "\$PYTORCH_BUILD_VERSION" == *dev* ]]; then
+    CHANNEL="nightly"
+else
+    CHANNEL="test"
+fi
+
+if [[ "$PACKAGE_TYPE" != libtorch ]]; then
+  if [[ "\$BUILD_ENVIRONMENT" != *s390x* ]]; then
+    pip install "\$pkg" --index-url "https://download.pytorch.org/whl/\${CHANNEL}/${DESIRED_CUDA}"
+
+    # numpy tests:
+    # We test 1 version no numpy. 1 version with numpy 1.x and rest with numpy 2.x
+    if [[ "\$python_nodot" = *311* ]]; then
+      retry pip install -q numpy==1.23.5 protobuf typing-extensions
+    elif [[ "\$python_nodot" = *312* ]]; then
+      retry pip install -q protobuf typing-extensions
+    else
+      retry pip install -q numpy protobuf typing-extensions
+    fi
+
+  else
+    pip install "\$pkg"
+    retry pip install -q numpy protobuf typing-extensions
+  fi
+fi
+
+if [[ "$PACKAGE_TYPE" == libtorch ]]; then
+  pkg="\$(ls /final_pkgs/*-latest.zip)"
+  unzip "\$pkg" -d /tmp
+  cd /tmp/libtorch
+fi
+
+# Test the package
+/pytorch/.ci/pytorch/check_binary.sh
+
+if [[ "\$GPU_ARCH_TYPE" != *s390x* && "\$GPU_ARCH_TYPE" != *xpu* && "\$GPU_ARCH_TYPE" != *rocm*  && "$PACKAGE_TYPE" != libtorch ]]; then
+
+  torch_pkg_size="$(ls -1 /final_pkgs/torch-* | sort |tail -1 |xargs wc -c |cut -d ' ' -f1)"
+  # todo: implement check for large binaries
+  # if the package is larger than 1.5GB, we disable the pypi check.
+  # this package contains all libraries packaged in torch libs folder
+  # example of such package is https://download.pytorch.org/whl/cu126_full/torch
+  if [[ "\$torch_pkg_size" -gt  1500000000 ]]; then
+    python /pytorch/.ci/pytorch/smoke_test/smoke_test.py --package=torchonly --torch-compile-check disabled --pypi-pkg-check disabled
+  else
+    python /pytorch/.ci/pytorch/smoke_test/smoke_test.py --package=torchonly --torch-compile-check disabled $extra_parameters
+  fi
+
+  if [[ "\$GPU_ARCH_TYPE" != *cpu-aarch64* ]]; then
+    # https://github.com/pytorch/pytorch/issues/149422
+    python /pytorch/.ci/pytorch/smoke_test/check_gomp.py
+  fi
+fi
+
+# Clean temp files
+cd /pytorch/.ci/pytorch/ && git clean -ffdx
+
+# =================== The above code will be executed inside Docker container ===================
+EOL
+echo
+echo
+echo "The script that will run in the next step is:"
+cat "${OUTPUT_SCRIPT}"

--- a/.ci/pytorch/binary_populate_env.sh
+++ b/.ci/pytorch/binary_populate_env.sh
@@ -1,0 +1,184 @@
+#!/bin/bash
+set -eux -o pipefail
+export TZ=UTC
+
+tagged_version() {
+  GIT_DIR="${workdir}/pytorch/.git"
+  GIT_DESCRIBE="git --git-dir ${GIT_DIR} describe --tags --match v[0-9]*.[0-9]*.[0-9]*"
+  if [[ ! -d "${GIT_DIR}" ]]; then
+    echo "Abort, abort! Git dir ${GIT_DIR} does not exists!"
+    kill $$
+  elif ${GIT_DESCRIBE} --exact >/dev/null; then
+    ${GIT_DESCRIBE}
+  else
+    return 1
+  fi
+}
+
+envfile=${BINARY_ENV_FILE:-/tmp/env}
+if [[ -n "${PYTORCH_ROOT}"  ]]; then
+  workdir=$(dirname "${PYTORCH_ROOT}")
+else
+  # docker executor (binary builds)
+  workdir="/"
+fi
+
+if [[ "$PACKAGE_TYPE" == 'libtorch' ]]; then
+  export BUILD_PYTHONLESS=1
+fi
+
+# Pick docker image
+export DOCKER_IMAGE=${DOCKER_IMAGE:-}
+if [[ -z "$DOCKER_IMAGE" ]]; then
+  if [[ "$DESIRED_CUDA" == cpu ]]; then
+    export DOCKER_IMAGE="pytorch/manylinux2_28:cpu"
+  else
+    export DOCKER_IMAGE="pytorch/manylinux2_28-builder:${DESIRED_CUDA:2}"
+  fi
+fi
+
+USE_GOLD_LINKER="OFF"
+# GOLD linker can not be used if CUPTI is statically linked into PyTorch, see https://github.com/pytorch/pytorch/issues/57744
+if [[ ${DESIRED_CUDA} == "cpu" ]]; then
+  USE_GOLD_LINKER="ON"
+fi
+
+
+# Default to nightly, since that's where this normally uploads to
+PIP_UPLOAD_FOLDER='nightly/'
+# We put this here so that OVERRIDE_PACKAGE_VERSION below can read from it
+export DATE="$(date -u +%Y%m%d)"
+BASE_BUILD_VERSION="$(cat ${PYTORCH_ROOT}/version.txt|cut -da -f1).dev${DATE}"
+
+# Change BASE_BUILD_VERSION to git tag when on a git tag
+# Use 'git -C' to make doubly sure we're in the correct directory for checking
+# the git tag
+if tagged_version >/dev/null; then
+  # Switch upload folder to 'test/' if we are on a tag
+  PIP_UPLOAD_FOLDER='test/'
+  # Grab git tag, remove prefixed v and remove everything after -
+  # Used to clean up tags that are for release candidates like v1.6.0-rc1
+  # Turns tag v1.6.0-rc1 -> v1.6.0
+  BASE_BUILD_VERSION="$(tagged_version | sed -e 's/^v//' -e 's/-.*$//')"
+fi
+if [[ "$(uname)" == 'Darwin' ]]; then
+  export PYTORCH_BUILD_VERSION="${BASE_BUILD_VERSION}"
+else
+  export PYTORCH_BUILD_VERSION="${BASE_BUILD_VERSION}+$DESIRED_CUDA"
+fi
+
+export PYTORCH_BUILD_NUMBER=1
+
+# Set triton version as part of PYTORCH_EXTRA_INSTALL_REQUIREMENTS
+TRITON_VERSION=$(cat $PYTORCH_ROOT/.ci/docker/triton_version.txt)
+TRITON_CONSTRAINT="platform_system == 'Linux'"
+
+if [[ "$PACKAGE_TYPE" =~ .*wheel.* &&  -n "${PYTORCH_EXTRA_INSTALL_REQUIREMENTS:-}" && ! "$PYTORCH_BUILD_VERSION" =~ .*xpu.* ]]; then
+  TRITON_REQUIREMENT="triton==${TRITON_VERSION}; ${TRITON_CONSTRAINT}"
+  if [[ -n "$PYTORCH_BUILD_VERSION" && "$PYTORCH_BUILD_VERSION" =~ .*dev.* ]]; then
+      TRITON_SHORTHASH=$(cut -c1-8 $PYTORCH_ROOT/.ci/docker/ci_commit_pins/triton.txt)
+      TRITON_REQUIREMENT="triton==${TRITON_VERSION}+git${TRITON_SHORTHASH}; ${TRITON_CONSTRAINT}"
+  fi
+  export PYTORCH_EXTRA_INSTALL_REQUIREMENTS="${PYTORCH_EXTRA_INSTALL_REQUIREMENTS} | ${TRITON_REQUIREMENT}"
+fi
+
+# Set triton via PYTORCH_EXTRA_INSTALL_REQUIREMENTS for triton rocm package
+if [[ "$PACKAGE_TYPE" =~ .*wheel.* && -n "$PYTORCH_BUILD_VERSION" && "$PYTORCH_BUILD_VERSION" =~ .*rocm.* && $(uname) == "Linux" ]]; then
+    TRITON_REQUIREMENT="triton-rocm==${TRITON_VERSION}; ${TRITON_CONSTRAINT}"
+    if [[ -n "$PYTORCH_BUILD_VERSION" && "$PYTORCH_BUILD_VERSION" =~ .*dev.* ]]; then
+        TRITON_SHORTHASH=$(cut -c1-8 $PYTORCH_ROOT/.ci/docker/ci_commit_pins/triton.txt)
+        TRITON_REQUIREMENT="triton-rocm==${TRITON_VERSION}+git${TRITON_SHORTHASH}; ${TRITON_CONSTRAINT}"
+    fi
+    if [[ -z "${PYTORCH_EXTRA_INSTALL_REQUIREMENTS:-}" ]]; then
+        export PYTORCH_EXTRA_INSTALL_REQUIREMENTS="${TRITON_REQUIREMENT}"
+    else
+        export PYTORCH_EXTRA_INSTALL_REQUIREMENTS="${PYTORCH_EXTRA_INSTALL_REQUIREMENTS} | ${TRITON_REQUIREMENT}"
+    fi
+fi
+
+# Set triton via PYTORCH_EXTRA_INSTALL_REQUIREMENTS for triton xpu package
+if [[ "$PACKAGE_TYPE" =~ .*wheel.* && -n "$PYTORCH_BUILD_VERSION" && "$PYTORCH_BUILD_VERSION" =~ .*xpu.* ]]; then
+    TRITON_VERSION=$(cat $PYTORCH_ROOT/.ci/docker/triton_xpu_version.txt)
+    TRITON_REQUIREMENT="triton-xpu==${TRITON_VERSION}"
+    if [[ -n "$PYTORCH_BUILD_VERSION" && "$PYTORCH_BUILD_VERSION" =~ .*dev.* ]]; then
+        TRITON_SHORTHASH=$(cut -c1-8 $PYTORCH_ROOT/.ci/docker/ci_commit_pins/triton-xpu.txt)
+        TRITON_REQUIREMENT="triton-xpu==${TRITON_VERSION}+git${TRITON_SHORTHASH}"
+    fi
+    if [[ -z "${PYTORCH_EXTRA_INSTALL_REQUIREMENTS:-}" ]]; then
+        export PYTORCH_EXTRA_INSTALL_REQUIREMENTS="${TRITON_REQUIREMENT}"
+    else
+        export PYTORCH_EXTRA_INSTALL_REQUIREMENTS="${PYTORCH_EXTRA_INSTALL_REQUIREMENTS} | ${TRITON_REQUIREMENT}"
+    fi
+fi
+
+USE_GLOO_WITH_OPENSSL="ON"
+if [[ "$GPU_ARCH_TYPE" =~ .*aarch64.* ]]; then
+  USE_GLOO_WITH_OPENSSL="OFF"
+  USE_GOLD_LINKER="OFF"
+fi
+
+cat >"$envfile" <<EOL
+# =================== The following code will be executed inside Docker container ===================
+export TZ=UTC
+echo "Running on $(uname -a) at $(date)"
+
+export PACKAGE_TYPE="$PACKAGE_TYPE"
+export DESIRED_PYTHON="${DESIRED_PYTHON:-}"
+export DESIRED_CUDA="$DESIRED_CUDA"
+export LIBTORCH_VARIANT="${LIBTORCH_VARIANT:-}"
+export BUILD_PYTHONLESS="${BUILD_PYTHONLESS:-}"
+if [[ "${OSTYPE}" == "msys" ]]; then
+  export LIBTORCH_CONFIG="${LIBTORCH_CONFIG:-}"
+  if [[ "${LIBTORCH_CONFIG:-}" == 'debug' ]]; then
+    export DEBUG=1
+  fi
+  export DESIRED_DEVTOOLSET=""
+else
+  export DESIRED_DEVTOOLSET="${DESIRED_DEVTOOLSET:-}"
+fi
+
+export DATE="$DATE"
+export NIGHTLIES_DATE_PREAMBLE=1.14.0.dev
+export PYTORCH_BUILD_VERSION="$PYTORCH_BUILD_VERSION"
+export PYTORCH_BUILD_NUMBER="$PYTORCH_BUILD_NUMBER"
+export OVERRIDE_PACKAGE_VERSION="$PYTORCH_BUILD_VERSION"
+export PYTORCH_EXTRA_INSTALL_REQUIREMENTS="${PYTORCH_EXTRA_INSTALL_REQUIREMENTS:-}"
+
+# TODO: We don't need this anymore IIUC
+export TORCH_PACKAGE_NAME='torch'
+
+export USE_FBGEMM=1
+export PIP_UPLOAD_FOLDER="$PIP_UPLOAD_FOLDER"
+export DOCKER_IMAGE="$DOCKER_IMAGE"
+
+
+export USE_GOLD_LINKER="${USE_GOLD_LINKER}"
+export USE_GLOO_WITH_OPENSSL="${USE_GLOO_WITH_OPENSSL}"
+# =================== The above code will be executed inside Docker container ===================
+EOL
+
+# nproc doesn't exist on darwin
+if [[ "$(uname)" != Darwin ]]; then
+  # This was lowered from 18 to 12 to avoid OOMs when compiling FlashAttentionV2
+  MEMORY_LIMIT_MAX_JOBS=12
+  NUM_CPUS=$(( $(nproc) - 2 ))
+
+  if [[ "$(uname)" == Linux ]]; then
+    # Defaults here for **binary** linux builds so they can be changed in one place
+    export MAX_JOBS=${MAX_JOBS:-$(( ${NUM_CPUS} > ${MEMORY_LIMIT_MAX_JOBS} ? ${MEMORY_LIMIT_MAX_JOBS} : ${NUM_CPUS} ))}
+  else
+    # For other builds
+    export MAX_JOBS=${NUM_CPUS}
+  fi
+
+  cat >>"$envfile" <<EOL
+  export MAX_JOBS="${MAX_JOBS}"
+EOL
+fi
+
+echo 'retry () {' >> "$envfile"
+echo '    $*  || (sleep 1 && $*) || (sleep 2 && $*) || (sleep 4 && $*) || (sleep 8 && $*)' >> "$envfile"
+echo '}' >> "$envfile"
+echo 'export -f retry' >> "$envfile"
+
+cat "$envfile"

--- a/.ci/pytorch/binary_upload.sh
+++ b/.ci/pytorch/binary_upload.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+PACKAGE_TYPE=${PACKAGE_TYPE:-wheel}
+
+PKG_DIR=${PKG_DIR:-/tmp/workspace/final_pkgs}
+
+# Designates whether to submit as a release candidate or a nightly build
+# Value should be `test` when uploading release candidates
+# currently set within `designate_upload_channel`
+UPLOAD_CHANNEL=${UPLOAD_CHANNEL:-nightly}
+# Designates what subfolder to put packages into
+UPLOAD_SUBFOLDER=${UPLOAD_SUBFOLDER:-}
+UPLOAD_BUCKET="s3://pytorch"
+BACKUP_BUCKET="s3://pytorch-backup"
+BUILD_NAME=${BUILD_NAME:-}
+
+DRY_RUN=${DRY_RUN:-enabled}
+# Don't actually do work unless explicit
+AWS_S3_CP="aws s3 cp --dryrun"
+if [[ "${DRY_RUN}" = "disabled" ]]; then
+  AWS_S3_CP="aws s3 cp"
+fi
+
+# this is special build with all dependencies packaged
+if [[ ${BUILD_NAME} == *-full* ]]; then
+  UPLOAD_SUBFOLDER="${UPLOAD_SUBFOLDER}_full"
+fi
+
+
+do_backup() {
+  local backup_dir
+  backup_dir=$1
+  (
+    pushd /tmp/workspace
+    set -x
+    ${AWS_S3_CP} --recursive . "${BACKUP_BUCKET}/${CIRCLE_TAG}/${backup_dir}/"
+  )
+}
+
+s3_upload() {
+  local extension
+  local pkg_type
+  extension="$1"
+  pkg_type="$2"
+  s3_root_dir="${UPLOAD_BUCKET}/${pkg_type}/${UPLOAD_CHANNEL}"
+  if [[ -z ${UPLOAD_SUBFOLDER:-} ]]; then
+    s3_upload_dir="${s3_root_dir}/"
+  else
+    s3_upload_dir="${s3_root_dir}/${UPLOAD_SUBFOLDER}/"
+  fi
+  (
+    for pkg in ${PKG_DIR}/*.${extension}; do
+      (
+        set -x
+        shm_id=$(sha256sum "${pkg}" | awk '{print $1}')
+        ${AWS_S3_CP} --no-progress --acl public-read "${pkg}" "${s3_upload_dir}" \
+          --metadata "checksum-sha256=${shm_id}"
+      )
+    done
+  )
+}
+
+R2_UPLOAD=${R2_UPLOAD:-}
+R2_BUCKET="s3://pytorch-downloads"
+R2_ACCOUNT_ID=${R2_ACCOUNT_ID:-}
+R2_ACCESS_KEY_ID=${R2_ACCESS_KEY_ID:-}
+R2_SECRET_ACCESS_KEY=${R2_SECRET_ACCESS_KEY:-}
+
+r2_upload() {
+  if [[ -z "${R2_ACCOUNT_ID}" || -z "${R2_ACCESS_KEY_ID}" || -z "${R2_SECRET_ACCESS_KEY}" ]]; then
+    echo "WARNING: R2 credentials not configured, skipping R2 upload"
+    return
+  fi
+  local extension
+  local pkg_type
+  extension="$1"
+  pkg_type="$2"
+  r2_root_dir="${R2_BUCKET}/${pkg_type}/${UPLOAD_CHANNEL}"
+  if [[ -z ${UPLOAD_SUBFOLDER:-} ]]; then
+    r2_upload_dir="${r2_root_dir}/"
+  else
+    r2_upload_dir="${r2_root_dir}/${UPLOAD_SUBFOLDER}/"
+  fi
+  (
+    for pkg in ${PKG_DIR}/*.${extension}; do
+      (
+        set -x
+        shm_id=$(sha256sum "${pkg}" | awk '{print $1}')
+        AWS_ACCESS_KEY_ID="${R2_ACCESS_KEY_ID}" \
+        AWS_SECRET_ACCESS_KEY="${R2_SECRET_ACCESS_KEY}" \
+        AWS_SESSION_TOKEN="" \
+        AWS_DEFAULT_REGION="auto" \
+        ${AWS_S3_CP} --no-progress "${pkg}" "${r2_upload_dir}" \
+          --metadata "checksum-sha256=${shm_id}" \
+          --endpoint-url "https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
+      )
+    done
+  )
+}
+
+# Install dependencies (should be a no-op if previously installed)
+pip install -q awscli uv
+
+case "${PACKAGE_TYPE}" in
+  libtorch)
+    s3_upload "zip" "libtorch"
+    if [[ "${R2_UPLOAD}" == "true" ]]; then
+      r2_upload "zip" "libtorch"
+    fi
+    BACKUP_DIR="libtorch/${UPLOAD_CHANNEL}/${UPLOAD_SUBFOLDER}"
+    ;;
+  # wheel can either refer to wheel/manywheel
+  *wheel)
+    s3_upload "whl" "whl"
+    if [[ "${R2_UPLOAD}" == "true" ]]; then
+      r2_upload "whl" "whl"
+    fi
+    BACKUP_DIR="whl/${UPLOAD_CHANNEL}/${UPLOAD_SUBFOLDER}"
+    ;;
+  *)
+    echo "ERROR: unknown package type: ${PACKAGE_TYPE}"
+    exit 1
+    ;;
+esac
+
+# CIRCLE_TAG is defined by upstream circleci,
+# this can be changed to recognize tagged versions
+if [[ -n "${CIRCLE_TAG:-}" ]]; then
+  do_backup "${BACKUP_DIR}"
+fi

--- a/.ci/pytorch/binary_windows_build.sh
+++ b/.ci/pytorch/binary_windows_build.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -eux -o pipefail
+
+source "${BINARY_ENV_FILE:-/c/w/env}"
+mkdir -p "$PYTORCH_FINAL_PACKAGE_DIR"
+
+if [[ "$OS" != "windows-arm64" ]]; then
+    export CUDA_VERSION="${DESIRED_CUDA/cu/}"
+    export USE_SCCACHE=1
+    export SCCACHE_BUCKET=ossci-compiler-cache
+    export SCCACHE_IGNORE_SERVER_IO_ERROR=1
+    export VC_YEAR=2022
+fi
+
+if [[ "$DESIRED_CUDA" == 'xpu' ]]; then
+    export VC_YEAR=2022
+    export USE_SCCACHE=0
+    export XPU_VERSION=2025.3
+fi
+
+echo "Free space on filesystem before build:"
+df -h
+
+pushd "$PYTORCH_ROOT/.ci/pytorch/"
+export NIGHTLIES_PYTORCH_ROOT="$PYTORCH_ROOT"
+
+if [[ "$OS" == "windows-arm64" ]]; then
+    if [[ "$PACKAGE_TYPE" == 'libtorch' ]]; then
+        ./windows/arm64/build_libtorch.bat
+    elif [[ "$PACKAGE_TYPE" == 'wheel' ]]; then
+        ./windows/arm64/build_pytorch.bat
+    fi
+else
+    ./windows/internal/build_wheels.bat
+fi
+
+echo "Free space on filesystem after build:"
+df -h

--- a/.ci/pytorch/binary_windows_test.sh
+++ b/.ci/pytorch/binary_windows_test.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -eux -o pipefail
+
+source "${BINARY_ENV_FILE:-/c/w/env}"
+
+export CUDA_VERSION="${DESIRED_CUDA/cu/}"
+export VC_YEAR=2022
+
+if [[ "$DESIRED_CUDA" == 'xpu' ]]; then
+    export VC_YEAR=2022
+    export XPU_VERSION=2025.3
+fi
+
+pushd "$PYTORCH_ROOT/.ci/pytorch/"
+
+if [[ "$OS" == "windows-arm64" ]]; then
+    ./windows/arm64/smoke_test.bat
+else
+    ./windows/internal/smoke_test.bat
+fi
+
+popd

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,4 @@
 *.bat text eol=crlf
-.circleci/config.yml linguist-generated=true
 .github/workflows/generated-*.yml linguist-generated=true
 .github/generated-* linguist-generated=true
 .github/scripts/gql_mocks.json linguist-generated=true

--- a/.github/actions/test-pytorch-binary/action.yml
+++ b/.github/actions/test-pytorch-binary/action.yml
@@ -34,9 +34,9 @@ runs:
 
         echo "CONTAINER_NAME=${container_name}" >> "$GITHUB_ENV"
 
-        docker exec -t -w "${PYTORCH_ROOT}" "${container_name}" bash -c "bash .circleci/scripts/binary_populate_env.sh"
+        docker exec -t -w "${PYTORCH_ROOT}" "${container_name}" bash -c "bash .ci/pytorch/binary_populate_env.sh"
         # Generate test script
-        docker exec -t -w "${PYTORCH_ROOT}" -e OUTPUT_SCRIPT="/run.sh" "${container_name}" bash -c "bash .circleci/scripts/binary_linux_test.sh"
+        docker exec -t -w "${PYTORCH_ROOT}" -e OUTPUT_SCRIPT="/run.sh" "${container_name}" bash -c "bash .ci/pytorch/binary_linux_test.sh"
         docker exec -t "${container_name}" bash -c "source ${BINARY_ENV_FILE} && bash -x /run.sh"
 
     - name: Cleanup docker

--- a/.github/merge_rules.yaml
+++ b/.github/merge_rules.yaml
@@ -58,7 +58,6 @@
 - name: OSS CI
   patterns:
   - .github/**
-  - .circleci/**
   - .ci/**
   - scripts/**
   - tools/**

--- a/.github/templates/macos_binary_build_workflow.yml.j2
+++ b/.github/templates/macos_binary_build_workflow.yml.j2
@@ -74,7 +74,7 @@ jobs:
       !{{ common.checkout(deep_clone=False, directory="pytorch") }}
       - name: Populate binary env
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Build PyTorch binary
         run: |
           set -eux -o pipefail

--- a/.github/templates/windows_binary_build_workflow.yml.j2
+++ b/.github/templates/windows_binary_build_workflow.yml.j2
@@ -140,11 +140,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Build PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_build.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_build.sh"
       - uses: !{{ common.upload_artifact_action }}
         if: always()
         with:
@@ -222,11 +222,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Test PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_test.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_test.sh"
 {%- if os != "windows-arm64" %}
       !{{ common.wait_and_kill_ssh_windows('pytorch') }}
 {%- endif %}

--- a/.github/workflows/_binary-build-linux.yml
+++ b/.github/workflows/_binary-build-linux.yml
@@ -260,7 +260,7 @@ jobs:
             -w / \
             "${DOCKER_IMAGE}"
           )
-          docker exec -t -w "${PYTORCH_ROOT}" "${container_name}" bash -c "bash .circleci/scripts/binary_populate_env.sh"
+          docker exec -t -w "${PYTORCH_ROOT}" "${container_name}" bash -c "bash .ci/pytorch/binary_populate_env.sh"
           # Unified build script for all architectures (x86_64, aarch64, s390x)
           docker exec -t "${container_name}" bash -c "source ${BINARY_ENV_FILE} && bash /pytorch/.ci/${{ inputs.PACKAGE_TYPE }}/build.sh"
 

--- a/.github/workflows/_binary-upload-flash-attention-wheel.yml
+++ b/.github/workflows/_binary-upload-flash-attention-wheel.yml
@@ -67,7 +67,7 @@ jobs:
         run: |
           set -ex
           for subfolder in ${{ matrix.upload_subfolders }}; do
-            UPLOAD_SUBFOLDER="${subfolder}" bash .circleci/scripts/binary_upload.sh
+            UPLOAD_SUBFOLDER="${subfolder}" bash .ci/pytorch/binary_upload.sh
           done
 
   upload-wheel-windows:
@@ -114,5 +114,5 @@ jobs:
         run: |
           set -ex
           for subfolder in ${{ matrix.upload_subfolders }}; do
-            UPLOAD_SUBFOLDER="${subfolder}" bash .circleci/scripts/binary_upload.sh
+            UPLOAD_SUBFOLDER="${subfolder}" bash .ci/pytorch/binary_upload.sh
           done

--- a/.github/workflows/_binary-upload.yml
+++ b/.github/workflows/_binary-upload.yml
@@ -146,4 +146,4 @@ jobs:
           R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
         run: |
             set -ex
-            bash .circleci/scripts/binary_upload.sh
+            bash .ci/pytorch/binary_upload.sh

--- a/.github/workflows/build-triton-wheel.yml
+++ b/.github/workflows/build-triton-wheel.yml
@@ -339,4 +339,4 @@ jobs:
         shell: bash
         run: |
           set -ex
-          bash .circleci/scripts/binary_upload.sh
+          bash .ci/pytorch/binary_upload.sh

--- a/.github/workflows/build-vllm-wheel.yml
+++ b/.github/workflows/build-vllm-wheel.yml
@@ -253,4 +253,4 @@ jobs:
         shell: bash
         run: |
           set -ex
-          bash .circleci/scripts/binary_upload.sh
+          bash .ci/pytorch/binary_upload.sh

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -82,7 +82,7 @@ jobs:
           cp -r "$PWD" "/tmp/$PT_RELEASE_NAME"
           mv "/tmp/$PT_RELEASE_NAME" .
           # Cleanup
-          rm -rf "$PT_RELEASE_NAME"/{.circleci,.ci}
+          rm -rf "$PT_RELEASE_NAME"/.ci
           find "$PT_RELEASE_NAME" -name '.git*' -exec rm -rv {} \; || true
           # Create archive
           tar -czf "$PT_RELEASE_FILE" "$PT_RELEASE_NAME"

--- a/.github/workflows/generated-macos-arm64-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-macos-arm64-binary-wheel-nightly.yml
@@ -77,7 +77,7 @@ jobs:
         working-directory: pytorch
       - name: Populate binary env
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Build PyTorch binary
         run: |
           set -eux -o pipefail
@@ -190,7 +190,7 @@ jobs:
         working-directory: pytorch
       - name: Populate binary env
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Build PyTorch binary
         run: |
           set -eux -o pipefail
@@ -303,7 +303,7 @@ jobs:
         working-directory: pytorch
       - name: Populate binary env
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Build PyTorch binary
         run: |
           set -eux -o pipefail
@@ -416,7 +416,7 @@ jobs:
         working-directory: pytorch
       - name: Populate binary env
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Build PyTorch binary
         run: |
           set -eux -o pipefail
@@ -529,7 +529,7 @@ jobs:
         working-directory: pytorch
       - name: Populate binary env
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Build PyTorch binary
         run: |
           set -eux -o pipefail
@@ -642,7 +642,7 @@ jobs:
         working-directory: pytorch
       - name: Populate binary env
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Build PyTorch binary
         run: |
           set -eux -o pipefail
@@ -755,7 +755,7 @@ jobs:
         working-directory: pytorch
       - name: Populate binary env
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Build PyTorch binary
         run: |
           set -eux -o pipefail

--- a/.github/workflows/generated-windows-arm64-binary-libtorch-debug-nightly.yml
+++ b/.github/workflows/generated-windows-arm64-binary-libtorch-debug-nightly.yml
@@ -110,11 +110,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Build PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_build.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_build.sh"
       - uses: actions/upload-artifact@v4.4.0
         if: always()
         with:
@@ -179,11 +179,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Test PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_test.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_test.sh"
   libtorch-cpu-shared-with-deps-debug-upload:  # Uploading
     if: ${{ github.repository_owner == 'pytorch' }}
     permissions:

--- a/.github/workflows/generated-windows-arm64-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-windows-arm64-binary-wheel-nightly.yml
@@ -107,11 +107,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Build PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_build.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_build.sh"
       - uses: actions/upload-artifact@v4.4.0
         if: always()
         with:
@@ -172,11 +172,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Test PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_test.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_test.sh"
   wheel-py3_11-cpu-upload:  # Uploading
     if: ${{ github.repository_owner == 'pytorch' }}
     permissions:
@@ -257,11 +257,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Build PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_build.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_build.sh"
       - uses: actions/upload-artifact@v4.4.0
         if: always()
         with:
@@ -322,11 +322,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Test PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_test.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_test.sh"
   wheel-py3_12-cpu-upload:  # Uploading
     if: ${{ github.repository_owner == 'pytorch' }}
     permissions:
@@ -407,11 +407,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Build PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_build.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_build.sh"
       - uses: actions/upload-artifact@v4.4.0
         if: always()
         with:
@@ -472,11 +472,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Test PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_test.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_test.sh"
   wheel-py3_13-cpu-upload:  # Uploading
     if: ${{ github.repository_owner == 'pytorch' }}
     permissions:

--- a/.github/workflows/generated-windows-binary-libtorch-debug-nightly.yml
+++ b/.github/workflows/generated-windows-binary-libtorch-debug-nightly.yml
@@ -128,11 +128,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Build PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_build.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_build.sh"
       - uses: actions/upload-artifact@v4.4.0
         if: always()
         with:
@@ -248,11 +248,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Test PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_test.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_test.sh"
       - name: Wait until all sessions have drained
         shell: powershell
         working-directory: pytorch
@@ -379,11 +379,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Build PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_build.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_build.sh"
       - uses: actions/upload-artifact@v4.4.0
         if: always()
         with:
@@ -500,11 +500,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Test PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_test.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_test.sh"
       - name: Wait until all sessions have drained
         shell: powershell
         working-directory: pytorch
@@ -632,11 +632,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Build PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_build.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_build.sh"
       - uses: actions/upload-artifact@v4.4.0
         if: always()
         with:
@@ -753,11 +753,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Test PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_test.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_test.sh"
       - name: Wait until all sessions have drained
         shell: powershell
         working-directory: pytorch
@@ -885,11 +885,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Build PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_build.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_build.sh"
       - uses: actions/upload-artifact@v4.4.0
         if: always()
         with:
@@ -1006,11 +1006,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Test PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_test.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_test.sh"
       - name: Wait until all sessions have drained
         shell: powershell
         working-directory: pytorch

--- a/.github/workflows/generated-windows-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-windows-binary-wheel-nightly.yml
@@ -125,11 +125,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Build PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_build.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_build.sh"
       - uses: actions/upload-artifact@v4.4.0
         if: always()
         with:
@@ -241,11 +241,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Test PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_test.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_test.sh"
       - name: Wait until all sessions have drained
         shell: powershell
         working-directory: pytorch
@@ -364,11 +364,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Build PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_build.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_build.sh"
       - uses: actions/upload-artifact@v4.4.0
         if: always()
         with:
@@ -481,11 +481,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Test PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_test.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_test.sh"
       - name: Wait until all sessions have drained
         shell: powershell
         working-directory: pytorch
@@ -605,11 +605,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Build PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_build.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_build.sh"
       - uses: actions/upload-artifact@v4.4.0
         if: always()
         with:
@@ -722,11 +722,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Test PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_test.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_test.sh"
       - name: Wait until all sessions have drained
         shell: powershell
         working-directory: pytorch
@@ -846,11 +846,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Build PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_build.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_build.sh"
       - uses: actions/upload-artifact@v4.4.0
         if: always()
         with:
@@ -963,11 +963,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Test PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_test.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_test.sh"
       - name: Wait until all sessions have drained
         shell: powershell
         working-directory: pytorch
@@ -1087,11 +1087,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Build PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_build.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_build.sh"
       - uses: actions/upload-artifact@v4.4.0
         if: always()
         with:
@@ -1203,11 +1203,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Test PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_test.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_test.sh"
       - name: Wait until all sessions have drained
         shell: powershell
         working-directory: pytorch
@@ -1325,11 +1325,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Build PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_build.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_build.sh"
       - uses: actions/upload-artifact@v4.4.0
         if: always()
         with:
@@ -1441,11 +1441,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Test PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_test.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_test.sh"
       - name: Wait until all sessions have drained
         shell: powershell
         working-directory: pytorch
@@ -1564,11 +1564,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Build PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_build.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_build.sh"
       - uses: actions/upload-artifact@v4.4.0
         if: always()
         with:
@@ -1681,11 +1681,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Test PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_test.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_test.sh"
       - name: Wait until all sessions have drained
         shell: powershell
         working-directory: pytorch
@@ -1805,11 +1805,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Build PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_build.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_build.sh"
       - uses: actions/upload-artifact@v4.4.0
         if: always()
         with:
@@ -1922,11 +1922,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Test PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_test.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_test.sh"
       - name: Wait until all sessions have drained
         shell: powershell
         working-directory: pytorch
@@ -2046,11 +2046,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Build PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_build.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_build.sh"
       - uses: actions/upload-artifact@v4.4.0
         if: always()
         with:
@@ -2163,11 +2163,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Test PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_test.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_test.sh"
       - name: Wait until all sessions have drained
         shell: powershell
         working-directory: pytorch
@@ -2287,11 +2287,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Build PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_build.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_build.sh"
       - uses: actions/upload-artifact@v4.4.0
         if: always()
         with:
@@ -2403,11 +2403,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Test PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_test.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_test.sh"
       - name: Wait until all sessions have drained
         shell: powershell
         working-directory: pytorch
@@ -2525,11 +2525,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Build PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_build.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_build.sh"
       - uses: actions/upload-artifact@v4.4.0
         if: always()
         with:
@@ -2641,11 +2641,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Test PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_test.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_test.sh"
       - name: Wait until all sessions have drained
         shell: powershell
         working-directory: pytorch
@@ -2764,11 +2764,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Build PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_build.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_build.sh"
       - uses: actions/upload-artifact@v4.4.0
         if: always()
         with:
@@ -2881,11 +2881,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Test PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_test.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_test.sh"
       - name: Wait until all sessions have drained
         shell: powershell
         working-directory: pytorch
@@ -3005,11 +3005,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Build PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_build.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_build.sh"
       - uses: actions/upload-artifact@v4.4.0
         if: always()
         with:
@@ -3122,11 +3122,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Test PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_test.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_test.sh"
       - name: Wait until all sessions have drained
         shell: powershell
         working-directory: pytorch
@@ -3246,11 +3246,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Build PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_build.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_build.sh"
       - uses: actions/upload-artifact@v4.4.0
         if: always()
         with:
@@ -3363,11 +3363,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Test PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_test.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_test.sh"
       - name: Wait until all sessions have drained
         shell: powershell
         working-directory: pytorch
@@ -3487,11 +3487,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Build PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_build.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_build.sh"
       - uses: actions/upload-artifact@v4.4.0
         if: always()
         with:
@@ -3603,11 +3603,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Test PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_test.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_test.sh"
       - name: Wait until all sessions have drained
         shell: powershell
         working-directory: pytorch
@@ -3725,11 +3725,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Build PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_build.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_build.sh"
       - uses: actions/upload-artifact@v4.4.0
         if: always()
         with:
@@ -3841,11 +3841,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Test PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_test.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_test.sh"
       - name: Wait until all sessions have drained
         shell: powershell
         working-directory: pytorch
@@ -3964,11 +3964,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Build PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_build.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_build.sh"
       - uses: actions/upload-artifact@v4.4.0
         if: always()
         with:
@@ -4081,11 +4081,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Test PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_test.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_test.sh"
       - name: Wait until all sessions have drained
         shell: powershell
         working-directory: pytorch
@@ -4205,11 +4205,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Build PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_build.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_build.sh"
       - uses: actions/upload-artifact@v4.4.0
         if: always()
         with:
@@ -4322,11 +4322,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Test PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_test.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_test.sh"
       - name: Wait until all sessions have drained
         shell: powershell
         working-directory: pytorch
@@ -4446,11 +4446,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Build PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_build.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_build.sh"
       - uses: actions/upload-artifact@v4.4.0
         if: always()
         with:
@@ -4563,11 +4563,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Test PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_test.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_test.sh"
       - name: Wait until all sessions have drained
         shell: powershell
         working-directory: pytorch
@@ -4687,11 +4687,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Build PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_build.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_build.sh"
       - uses: actions/upload-artifact@v4.4.0
         if: always()
         with:
@@ -4803,11 +4803,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Test PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_test.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_test.sh"
       - name: Wait until all sessions have drained
         shell: powershell
         working-directory: pytorch
@@ -4925,11 +4925,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Build PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_build.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_build.sh"
       - uses: actions/upload-artifact@v4.4.0
         if: always()
         with:
@@ -5041,11 +5041,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Test PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_test.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_test.sh"
       - name: Wait until all sessions have drained
         shell: powershell
         working-directory: pytorch
@@ -5164,11 +5164,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Build PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_build.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_build.sh"
       - uses: actions/upload-artifact@v4.4.0
         if: always()
         with:
@@ -5281,11 +5281,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Test PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_test.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_test.sh"
       - name: Wait until all sessions have drained
         shell: powershell
         working-directory: pytorch
@@ -5405,11 +5405,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Build PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_build.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_build.sh"
       - uses: actions/upload-artifact@v4.4.0
         if: always()
         with:
@@ -5522,11 +5522,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Test PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_test.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_test.sh"
       - name: Wait until all sessions have drained
         shell: powershell
         working-directory: pytorch
@@ -5646,11 +5646,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Build PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_build.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_build.sh"
       - uses: actions/upload-artifact@v4.4.0
         if: always()
         with:
@@ -5763,11 +5763,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Test PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_test.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_test.sh"
       - name: Wait until all sessions have drained
         shell: powershell
         working-directory: pytorch
@@ -5887,11 +5887,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Build PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_build.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_build.sh"
       - uses: actions/upload-artifact@v4.4.0
         if: always()
         with:
@@ -6003,11 +6003,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Test PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_test.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_test.sh"
       - name: Wait until all sessions have drained
         shell: powershell
         working-directory: pytorch
@@ -6125,11 +6125,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Build PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_build.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_build.sh"
       - uses: actions/upload-artifact@v4.4.0
         if: always()
         with:
@@ -6241,11 +6241,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Test PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_test.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_test.sh"
       - name: Wait until all sessions have drained
         shell: powershell
         working-directory: pytorch
@@ -6364,11 +6364,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Build PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_build.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_build.sh"
       - uses: actions/upload-artifact@v4.4.0
         if: always()
         with:
@@ -6481,11 +6481,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Test PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_test.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_test.sh"
       - name: Wait until all sessions have drained
         shell: powershell
         working-directory: pytorch
@@ -6605,11 +6605,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Build PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_build.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_build.sh"
       - uses: actions/upload-artifact@v4.4.0
         if: always()
         with:
@@ -6722,11 +6722,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Test PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_test.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_test.sh"
       - name: Wait until all sessions have drained
         shell: powershell
         working-directory: pytorch
@@ -6846,11 +6846,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Build PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_build.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_build.sh"
       - uses: actions/upload-artifact@v4.4.0
         if: always()
         with:
@@ -6963,11 +6963,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Test PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_test.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_test.sh"
       - name: Wait until all sessions have drained
         shell: powershell
         working-directory: pytorch
@@ -7087,11 +7087,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Build PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_build.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_build.sh"
       - uses: actions/upload-artifact@v4.4.0
         if: always()
         with:
@@ -7203,11 +7203,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Test PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_test.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_test.sh"
       - name: Wait until all sessions have drained
         shell: powershell
         working-directory: pytorch
@@ -7325,11 +7325,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Build PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_build.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_build.sh"
       - uses: actions/upload-artifact@v4.4.0
         if: always()
         with:
@@ -7441,11 +7441,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Test PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_test.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_test.sh"
       - name: Wait until all sessions have drained
         shell: powershell
         working-directory: pytorch
@@ -7564,11 +7564,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Build PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_build.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_build.sh"
       - uses: actions/upload-artifact@v4.4.0
         if: always()
         with:
@@ -7681,11 +7681,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Test PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_test.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_test.sh"
       - name: Wait until all sessions have drained
         shell: powershell
         working-directory: pytorch
@@ -7805,11 +7805,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Build PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_build.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_build.sh"
       - uses: actions/upload-artifact@v4.4.0
         if: always()
         with:
@@ -7922,11 +7922,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Test PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_test.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_test.sh"
       - name: Wait until all sessions have drained
         shell: powershell
         working-directory: pytorch
@@ -8046,11 +8046,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Build PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_build.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_build.sh"
       - uses: actions/upload-artifact@v4.4.0
         if: always()
         with:
@@ -8163,11 +8163,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Test PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_test.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_test.sh"
       - name: Wait until all sessions have drained
         shell: powershell
         working-directory: pytorch
@@ -8287,11 +8287,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Build PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_build.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_build.sh"
       - uses: actions/upload-artifact@v4.4.0
         if: always()
         with:
@@ -8403,11 +8403,11 @@ jobs:
       - name: Populate binary env
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_populate_env.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_populate_env.sh"
       - name: Test PyTorch binary
         shell: bash
         run: |
-          "${PYTORCH_ROOT}/.circleci/scripts/binary_windows_test.sh"
+          "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_test.sh"
       - name: Wait until all sessions have drained
         shell: powershell
         working-directory: pytorch

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -277,7 +277,6 @@ dependencies as well as the nightly binaries into the repo directory.
   * [core](caffe2/core) - Core files of Caffe2, e.g., tensor, workspace,
     blobs, etc.
   * ...
-* [.circleci](.circleci) - CircleCI configuration management. [README](.circleci/README.md)
 
 ## AI-Assisted Development
 

--- a/scripts/release_notes/commitlist.py
+++ b/scripts/release_notes/commitlist.py
@@ -231,7 +231,6 @@ class CommitList:
                 file,
                 [
                     "docker/",
-                    ".circleci",
                     ".github",
                     ".jenkins",
                     ".ci",

--- a/tools/testing/explicit_ci_jobs.py
+++ b/tools/testing/explicit_ci_jobs.py
@@ -7,90 +7,10 @@ import fnmatch
 import subprocess
 import textwrap
 from pathlib import Path
-from typing import Any
-
-import yaml
 
 
 REPO_ROOT = Path(__file__).parents[2]
-CONFIG_YML = REPO_ROOT / ".circleci" / "config.yml"
 WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
-
-
-WORKFLOWS_TO_CHECK = [
-    "binary_builds",
-    "build",
-    "master_build",
-    # These are formatted slightly differently, skip them
-    # "scheduled-ci",
-    # "debuggable-scheduled-ci",
-    # "slow-gradcheck-scheduled-ci",
-    # "promote",
-]
-
-
-def add_job(
-    workflows: dict[str, Any],
-    workflow_name: str,
-    type: str,
-    job: dict[str, Any],
-    past_jobs: dict[str, Any],
-) -> None:
-    """
-    Add job 'job' under 'type' and 'workflow_name' to 'workflow' in place. Also
-    add any dependencies (they must already be in 'past_jobs')
-    """
-    if workflow_name not in workflows:
-        workflows[workflow_name] = {"when": "always", "jobs": []}
-
-    requires = job.get("requires")
-    if requires is not None:
-        for requirement in requires:
-            dependency = past_jobs[requirement]
-            add_job(
-                workflows,
-                dependency["workflow_name"],
-                dependency["type"],
-                dependency["job"],
-                past_jobs,
-            )
-
-    workflows[workflow_name]["jobs"].append({type: job})
-
-
-def get_filtered_circleci_config(
-    workflows: dict[str, Any], relevant_jobs: list[str]
-) -> dict[str, Any]:
-    """
-    Given an existing CircleCI config, remove every job that's not listed in
-    'relevant_jobs'
-    """
-    new_workflows: dict[str, Any] = {}
-    past_jobs: dict[str, Any] = {}
-    for workflow_name, workflow in workflows.items():
-        if workflow_name not in WORKFLOWS_TO_CHECK:
-            # Don't care about this workflow, skip it entirely
-            continue
-
-        for job_dict in workflow["jobs"]:
-            for type, job in job_dict.items():
-                if "name" not in job:
-                    # Job doesn't have a name so it can't be handled
-                    print("Skipping", type)
-                else:
-                    if job["name"] in relevant_jobs:
-                        # Found a job that was specified at the CLI, add it to
-                        # the new result
-                        add_job(new_workflows, workflow_name, type, job, past_jobs)
-
-                    # Record the job in case it's needed as a dependency later
-                    past_jobs[job["name"]] = {
-                        "workflow_name": workflow_name,
-                        "type": type,
-                        "job": job,
-                    }
-
-    return new_workflows
 
 
 def commit_ci(files: list[str], message: str) -> None:
@@ -114,9 +34,8 @@ def commit_ci(files: list[str], message: str) -> None:
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
-        description="make .circleci/config.yml only have a specific set of jobs and delete GitHub actions"
+        description="delete GitHub Actions workflow files that don't match a filter"
     )
-    parser.add_argument("--job", action="append", help="job name", default=[])
     parser.add_argument(
         "--filter-gha", help="keep only these github actions (glob match)", default=""
     )
@@ -127,16 +46,7 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    touched_files = [CONFIG_YML]
-    with open(CONFIG_YML) as f:
-        config_yml = yaml.safe_load(f.read())
-
-    config_yml["workflows"] = get_filtered_circleci_config(
-        config_yml["workflows"], args.job
-    )
-
-    with open(CONFIG_YML, "w") as f:
-        yaml.dump(config_yml, f)
+    touched_files: list[Path] = []
 
     if args.filter_gha:
         for relative_file in WORKFLOWS_DIR.iterdir():
@@ -146,13 +56,9 @@ if __name__ == "__main__":
                 path.resolve().unlink()
 
     if args.make_commit:
-        jobs_str = "\n".join([f" * {job}" for job in args.job])
         message = textwrap.dedent(
-            f"""
-        [skip ci][do not merge] Edit config.yml to filter specific jobs
-
-        Filter CircleCI to only run:
-        {jobs_str}
+            """
+        [skip ci][do not merge] Filter GitHub Actions workflow files
 
         See [Run Specific CI Jobs](https://github.com/pytorch/pytorch/blob/master/CONTRIBUTING.md#run-specific-ci-jobs) for details.
         """

--- a/tools/testing/modulefinder_determinator.py
+++ b/tools/testing/modulefinder_determinator.py
@@ -117,7 +117,7 @@ def test_impact_of_file(filename: str) -> str:
         CI - CI configuration files
     """
     parts = filename.split(os.sep)
-    if parts[0] in [".jenkins", ".circleci", ".ci"]:
+    if parts[0] in [".jenkins", ".ci"]:
         return "CI"
     if parts[0] in ["docs", "scripts", "CODEOWNERS", "README.md"]:
         return "NONE"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #175918
* #175917
* __->__ #175916
* #175915

5 binary build/test/upload scripts in .circleci/scripts/ are still actively
called by GitHub Actions workflows for nightly and release builds, but were
never relocated during the CircleCI migration.

This copies them to .ci/pytorch/ where they belong alongside other
build/test scripts (build.sh, test.sh, etc.) and updates all workflow
references. The old copies are kept temporarily so that in-flight PRs
don't break — a follow-up PR deletes them.

Authored with Claude.