### PR TITLE
[BE] Remove dead CircleCI config filtering from explicit_ci_jobs.py

### DIFF
--- a/tools/testing/explicit_ci_jobs.py
+++ b/tools/testing/explicit_ci_jobs.py
@@ -7,90 +7,10 @@ import fnmatch
 import subprocess
 import textwrap
 from pathlib import Path
-from typing import Any
-
-import yaml
 
 
 REPO_ROOT = Path(__file__).parents[2]
-CONFIG_YML = REPO_ROOT / ".circleci" / "config.yml"
 WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
-
-
-WORKFLOWS_TO_CHECK = [
-    "binary_builds",
-    "build",
-    "master_build",
-    # These are formatted slightly differently, skip them
-    # "scheduled-ci",
-    # "debuggable-scheduled-ci",
-    # "slow-gradcheck-scheduled-ci",
-    # "promote",
-]
-
-
-def add_job(
-    workflows: dict[str, Any],
-    workflow_name: str,
-    type: str,
-    job: dict[str, Any],
-    past_jobs: dict[str, Any],
-) -> None:
-    """
-    Add job 'job' under 'type' and 'workflow_name' to 'workflow' in place. Also
-    add any dependencies (they must already be in 'past_jobs')
-    """
-    if workflow_name not in workflows:
-        workflows[workflow_name] = {"when": "always", "jobs": []}
-
-    requires = job.get("requires")
-    if requires is not None:
-        for requirement in requires:
-            dependency = past_jobs[requirement]
-            add_job(
-                workflows,
-                dependency["workflow_name"],
-                dependency["type"],
-                dependency["job"],
-                past_jobs,
-            )
-
-    workflows[workflow_name]["jobs"].append({type: job})
-
-
-def get_filtered_circleci_config(
-    workflows: dict[str, Any], relevant_jobs: list[str]
-) -> dict[str, Any]:
-    """
-    Given an existing CircleCI config, remove every job that's not listed in
-    'relevant_jobs'
-    """
-    new_workflows: dict[str, Any] = {}
-    past_jobs: dict[str, Any] = {}
-    for workflow_name, workflow in workflows.items():
-        if workflow_name not in WORKFLOWS_TO_CHECK:
-            # Don't care about this workflow, skip it entirely
-            continue
-
-        for job_dict in workflow["jobs"]:
-            for type, job in job_dict.items():
-                if "name" not in job:
-                    # Job doesn't have a name so it can't be handled
-                    print("Skipping", type)
-                else:
-                    if job["name"] in relevant_jobs:
-                        # Found a job that was specified at the CLI, add it to
-                        # the new result
-                        add_job(new_workflows, workflow_name, type, job, past_jobs)
-
-                    # Record the job in case it's needed as a dependency later
-                    past_jobs[job["name"]] = {
-                        "workflow_name": workflow_name,
-                        "type": type,
-                        "job": job,
-                    }
-
-    return new_workflows
 
 
 def commit_ci(files: list[str], message: str) -> None:
@@ -114,9 +34,8 @@ def commit_ci(files: list[str], message: str) -> None:
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
-        description="make .circleci/config.yml only have a specific set of jobs and delete GitHub actions"
+        description="delete GitHub Actions workflow files that don't match a filter"
     )
-    parser.add_argument("--job", action="append", help="job name", default=[])
     parser.add_argument(
         "--filter-gha", help="keep only these github actions (glob match)", default=""
     )
@@ -127,16 +46,7 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    touched_files = [CONFIG_YML]
-    with open(CONFIG_YML) as f:
-        config_yml = yaml.safe_load(f.read())
-
-    config_yml["workflows"] = get_filtered_circleci_config(
-        config_yml["workflows"], args.job
-    )
-
-    with open(CONFIG_YML, "w") as f:
-        yaml.dump(config_yml, f)
+    touched_files: list[Path] = []
 
     if args.filter_gha:
         for relative_file in WORKFLOWS_DIR.iterdir():
@@ -146,13 +56,9 @@ if __name__ == "__main__":
                 path.resolve().unlink()
 
     if args.make_commit:
-        jobs_str = "\n".join([f" * {job}" for job in args.job])
         message = textwrap.dedent(
-            f"""
-        [skip ci][do not merge] Edit config.yml to filter specific jobs
-
-        Filter CircleCI to only run:
-        {jobs_str}
+            """
+        [skip ci][do not merge] Filter GitHub Actions workflow files
 
         See [Run Specific CI Jobs](https://github.com/pytorch/pytorch/blob/master/CONTRIBUTING.md#run-specific-ci-jobs) for details.
         """


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #175918
* #175917
* #175921
* __->__ #175920
* #175915

This script's --job flag and CircleCI config filtering code
(get_filtered_circleci_config, add_job, WORKFLOWS_TO_CHECK, CONFIG_YML)
have been dead since .circleci/config.yml was deleted in the
CircleCI-to-GitHub-Actions migration (Dec 2023, PR #115701). Calling
--job would immediately crash with FileNotFoundError.

The --filter-gha flag (GitHub Actions workflow filtering) is preserved
as it still works. Nothing in the repo imports or calls this script
(verified with org-wide code search).

Authored with Claude.