### PR TITLE
[Inductor][CUDA] Update CUDA arch flags in _nvcc_arch_as_compile_option()

### DIFF
--- a/torch/_inductor/codegen/cuda/compile_utils.py
+++ b/torch/_inductor/codegen/cuda/compile_utils.py
@@ -129,12 +129,18 @@ def _nvcc_arch_as_compile_option() -> str:
     if arch == "90":
         # Required by cutlass compilation.
         return "90a"
-    if arch == "103":
-        return "100f"
     if arch == "100":
         return "100a"
+    if arch == "101":
+        return "101a"
+    if arch == "103":
+        return "103a"
+    if arch == "110":
+        return "110a"
     if arch == "120":
         return "120a"
+    if arch == "121":
+        return "121a"
     return arch
 
 


### PR DESCRIPTION
This PR adds missed CUDA architectures in `_nvcc_arch_as_compile_option` and replaces `100f` by `103a` which is more appropriate for JIT-compilation.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @eqy 