### PR TITLE
Fix exception messages displaying as tuples instead of formatted strings

### DIFF
--- a/torch/_higher_order_ops/partitioner.py
+++ b/torch/_higher_order_ops/partitioner.py
@@ -109,8 +109,7 @@ class HopPartitionedGraph:
         if len(invalid_reasons) > 0:
             newline = "\n"
             raise RuntimeError(
-                "Invalid HopPartitionedGraph. Reasons:\n",
-                f"{newline.join(invalid_reasons)}",
+                f"Invalid HopPartitionedGraph. Reasons:\n{newline.join(invalid_reasons)}"
             )
 
     def _reorder_fw_output(self) -> None:

--- a/torch/_numpy/_funcs_impl.py
+++ b/torch/_numpy/_funcs_impl.py
@@ -210,7 +210,7 @@ def _split_helper(tensor, indices_or_sections, axis, strict=False):
         # NB: drop split=..., it only applies to split_helper_int
         return _split_helper_list(tensor, list(indices_or_sections), axis)
     else:
-        raise TypeError("split_helper: ", type(indices_or_sections))
+        raise TypeError(f"split_helper: {type(indices_or_sections)}")
 
 
 def _split_helper_int(tensor, indices_or_sections, axis, strict=False):

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -406,8 +406,7 @@ def _broadcast_shapes(*_shapes):
     for shape in shapes:
         if not isinstance(shape, Sequence):
             raise RuntimeError(
-                "Input shapes should be of type ints, a tuple of ints, or a list of ints, got ",
-                shape,
+                f"Input shapes should be of type ints, a tuple of ints, or a list of ints, got {shape}"
             )
 
     # Computes common shape

--- a/torch/ao/quantization/backend_config/utils.py
+++ b/torch/ao/quantization/backend_config/utils.py
@@ -280,7 +280,9 @@ def _get_pattern_in_reversed_nested_tuple_format(
         (a, b, c) = config.pattern
         return (c, (b, a))
     else:
-        raise ValueError(f"Expected a tuple with 2 or 3 elements, got: {config.pattern}")
+        raise ValueError(
+            f"Expected a tuple with 2 or 3 elements, got: {config.pattern}"
+        )
 
 
 def _get_fuser_method_in_reversed_nested_tuple_format(
@@ -314,4 +316,6 @@ def _get_fuser_method_in_reversed_nested_tuple_format(
     elif len(config.pattern) == 3:
         return _reverse3(config.fuser_method)
     else:
-        raise ValueError(f"Expected a tuple with 2 or 3 elements, got: {config.pattern}")
+        raise ValueError(
+            f"Expected a tuple with 2 or 3 elements, got: {config.pattern}"
+        )

--- a/torch/ao/quantization/backend_config/utils.py
+++ b/torch/ao/quantization/backend_config/utils.py
@@ -280,7 +280,7 @@ def _get_pattern_in_reversed_nested_tuple_format(
         (a, b, c) = config.pattern
         return (c, (b, a))
     else:
-        raise ValueError("Expected a tuple with 2 or 3 elements, got: ", config.pattern)
+        raise ValueError(f"Expected a tuple with 2 or 3 elements, got: {config.pattern}")
 
 
 def _get_fuser_method_in_reversed_nested_tuple_format(
@@ -306,7 +306,7 @@ def _get_fuser_method_in_reversed_nested_tuple_format(
     if config._pattern_complex_format is not None:
         return config.fuser_method
     if not isinstance(config.pattern, tuple):
-        raise ValueError("Expected pattern to be a tuple, got: ", config.pattern)
+        raise ValueError(f"Expected pattern to be a tuple, got: {config.pattern}")
 
     # Pattern is specified in the simple tuple format, need to convert
     if len(config.pattern) == 2:
@@ -314,4 +314,4 @@ def _get_fuser_method_in_reversed_nested_tuple_format(
     elif len(config.pattern) == 3:
         return _reverse3(config.fuser_method)
     else:
-        raise ValueError("Expected a tuple with 2 or 3 elements, got: ", config.pattern)
+        raise ValueError(f"Expected a tuple with 2 or 3 elements, got: {config.pattern}")

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -1532,14 +1532,14 @@ else:
         if mesh_dim_names is not None:
             if len(set(mesh_dim_names)) != len(mesh_dim_names):
                 raise RuntimeError(
-                    "Each mesh_dim_name must be unique.",
-                    f"Found repeated mesh_dim_name in mesh_dim_names {mesh_dim_names}",
+                    "Each mesh_dim_name must be unique. "
+                    f"Found repeated mesh_dim_name in mesh_dim_names {mesh_dim_names}"
                 )
 
             if len(mesh_shape) != len(mesh_dim_names):
                 raise RuntimeError(
-                    "mesh_shape and mesh_dim_names should have same length!",
-                    f"Found len(mesh_dim_names): {len(mesh_dim_names)} and len(mesh_shape):{len(mesh_shape)}.",
+                    "mesh_shape and mesh_dim_names should have same length! "
+                    f"Found len(mesh_dim_names): {len(mesh_dim_names)} and len(mesh_shape):{len(mesh_shape)}."
                 )
 
         if backend_override is not None:

--- a/torch/distributed/fsdp/_optim_utils.py
+++ b/torch/distributed/fsdp/_optim_utils.py
@@ -2104,9 +2104,9 @@ def _set_optim_use_dtensor(
         state_dict_type = state_dict_settings.state_dict_type
         if state_dict_type == StateDictType.LOCAL_STATE_DICT:
             raise RuntimeError(
-                "Found state_dict_type LOCAL_STATE_DICT.",
-                "DeviceMesh is not compatible with LOCAL_STATE_DICT.",
-                "Please set state_dict_type to SHARDED_STATE_DICT to get DTensor state_dict.",
+                "Found state_dict_type LOCAL_STATE_DICT. "
+                "DeviceMesh is not compatible with LOCAL_STATE_DICT. "
+                "Please set state_dict_type to SHARDED_STATE_DICT to get DTensor state_dict."
             )
         else:
             state_dict_settings.optim_state_dict_config._use_dtensor = True

--- a/torch/distributed/fsdp/_state_dict_utils.py
+++ b/torch/distributed/fsdp/_state_dict_utils.py
@@ -801,9 +801,9 @@ def _set_use_dtensor(fsdp_state: _FSDPState) -> None:
         state_dict_type = fsdp_state._state_dict_type
         if state_dict_type == StateDictType.LOCAL_STATE_DICT:
             raise RuntimeError(
-                "Found state_dict_type LOCAL_STATE_DICT",
-                "DeviceMesh is not compatible with LOCAL_STATE_DICT.",
-                "Please set state_dict_type to SHARDED_STATE_DICT to get DTensor state_dict.",
+                "Found state_dict_type LOCAL_STATE_DICT. "
+                "DeviceMesh is not compatible with LOCAL_STATE_DICT. "
+                "Please set state_dict_type to SHARDED_STATE_DICT to get DTensor state_dict."
             )
         else:
             fsdp_state._state_dict_config._use_dtensor = True

--- a/torch/library.py
+++ b/torch/library.py
@@ -88,12 +88,11 @@ class Library:
         from torch.fx.operator_schemas import _SCHEMA_TO_SIGNATURE_CACHE
 
         if kind not in ("IMPL", "DEF", "FRAGMENT"):
-            raise ValueError("Unsupported kind: ", kind)
+            raise ValueError(f"Unsupported kind: {kind}")
 
         if ns in _reserved_namespaces and (kind == "DEF" or kind == "FRAGMENT"):
             raise ValueError(
-                ns,
-                " is a reserved namespace. Please try creating a library with another name.",
+                f"{ns} is a reserved namespace. Please try creating a library with another name."
             )
 
         frame = traceback.extract_stack(limit=2)[0]

--- a/torch/masked/maskedtensor/_ops_refs.py
+++ b/torch/masked/maskedtensor/_ops_refs.py
@@ -93,7 +93,7 @@ class _MaskedToDense(torch.autograd.Function):
             return grad_output.to_sparse_csr()
         elif layout == torch.strided:
             return grad_output.to_dense()
-        raise ValueError("to_dense: Unsupported input layout: ", layout)
+        raise ValueError(f"to_dense: Unsupported input layout: {layout}")
 
 
 class _MaskedToSparse(torch.autograd.Function):

--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -81,8 +81,7 @@ def detach_variable(inputs: Tuple[Any, ...]) -> Tuple[torch.Tensor, ...]:
         return tuple(out)
     else:
         raise RuntimeError(
-            "Only tuple of tensors is supported. Got Unsupported input type: ",
-            type(inputs).__name__,
+            f"Only tuple of tensors is supported. Got Unsupported input type: {type(inputs).__name__}"
         )
 
 


### PR DESCRIPTION
## Description

Several exception constructors across the codebase pass multiple arguments separated by commas (e.g., `RuntimeError("msg", value)`). In Python, this stores the arguments as a tuple in `BaseException.args`, causing `str(exc)` to display as `('msg', value)` instead of a properly formatted message.

This PR converts all such instances to use f-strings or string concatenation so error messages display correctly.

**Before:**
```python
raise RuntimeError("Unsupported input type: ", type(inputs).__name__)
# str(exc) -> "('Unsupported input type: ', 'dict')"
```

**After:**
```python
raise RuntimeError(f"Unsupported input type: {type(inputs).__name__}")
# str(exc) -> "Unsupported input type: dict"
```

**Files fixed:**
- `torch/utils/checkpoint.py`
- `torch/_refs/__init__.py`
- `torch/_numpy/_funcs_impl.py`
- `torch/masked/maskedtensor/_ops_refs.py`
- `torch/library.py`
- `torch/_higher_order_ops/partitioner.py`
- `torch/ao/quantization/backend_config/utils.py`
- `torch/distributed/device_mesh.py`
- `torch/distributed/fsdp/_state_dict_utils.py`
- `torch/distributed/fsdp/_optim_utils.py`

cc @albanD