### PR TITLE
Fix off-by-one error in distributed checkpoint get_element

### DIFF
--- a/torch/distributed/checkpoint/_traverse.py
+++ b/torch/distributed/checkpoint/_traverse.py
@@ -158,7 +158,7 @@ def get_element(
     cur_value = cast(CONTAINER_TYPE, root_dict)
     for part in path:
         if type(part) is int:
-            if not isinstance(cur_value, list) or len(cur_value) < part:
+            if not isinstance(cur_value, list) or len(cur_value) <= part:
                 return default_value
         elif not isinstance(cur_value, Mapping) or part not in cur_value:
             return default_value


### PR DESCRIPTION
## Description

`get_element` in `torch/distributed/checkpoint/_traverse.py` has an off-by-one error in its list bounds check.

The condition `len(cur_value) < part` fails to catch the boundary case where `part == len(cur_value)`. For a list of length 5, valid indices are 0-4, but index 5 passes the guard (`5 < 5` is `False`) and `cur_value[5]` raises `IndexError` instead of returning `default_value`.

**Fix:** `len(cur_value) < part` -> `len(cur_value) <= part`

cc @LucasLLC @wz337