### PR TITLE
[ROCm][CI] Enabled some inductor unit tests

### DIFF
--- a/test/inductor/test_ck_backend.py
+++ b/test/inductor/test_ck_backend.py
@@ -16,9 +16,7 @@ from torch._inductor.utils import try_import_ck_lib
 from torch.testing._internal.common_cuda import tf32_off
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
-    MI350_ARCH,
     parametrize,
-    skipIfRocmArch,
 )
 from torch.testing._internal.inductor_utils import (
     _quantize_rowwise,
@@ -241,8 +239,6 @@ class TestCKBackend(TestCase):
             Y_eager = a @ b
             torch.testing.assert_close(Y_compiled, Y_eager, equal_nan=True)
 
-    # regression in ROCm 7.2, Mismatched elements, significantly
-    @skipIfRocmArch(MI350_ARCH)
     @unittest.skipIf(not torch.version.hip, "ROCM only")
     @unittest.mock.patch.dict(os.environ, _test_env)
     @parametrize("max_autotune_gemm_backends", ("CK", "ATen,Triton,CK"))

--- a/test/inductor/test_ck_backend.py
+++ b/test/inductor/test_ck_backend.py
@@ -17,6 +17,7 @@ from torch.testing._internal.common_cuda import tf32_off
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
+    skipIfRocm,
 )
 from torch.testing._internal.inductor_utils import (
     _quantize_rowwise,
@@ -239,10 +240,10 @@ class TestCKBackend(TestCase):
             Y_eager = a @ b
             torch.testing.assert_close(Y_compiled, Y_eager, equal_nan=True)
 
-    @unittest.skip("Numerical accuracy errors in CK backend on gfx950 as of 06/03/26")
     @unittest.skipIf(not torch.version.hip, "ROCM only")
     @unittest.mock.patch.dict(os.environ, _test_env)
     @parametrize("max_autotune_gemm_backends", ("CK", "ATen,Triton,CK"))
+    @skipIfRocm(msg="Numerical accuracy errors in CK backend on gfx950 as of 06/03/26")
     @parametrize(
         "x_shape", ([4096, 2048], [2048], [4096, 1])
     )  # NOTE: the first two shapes create "Tensor-likes are not close" errors

--- a/test/inductor/test_ck_backend.py
+++ b/test/inductor/test_ck_backend.py
@@ -239,10 +239,13 @@ class TestCKBackend(TestCase):
             Y_eager = a @ b
             torch.testing.assert_close(Y_compiled, Y_eager, equal_nan=True)
 
+    @unittest.skip("Numerical accuracy errors in CK backend on gfx950 as of 06/03/26")
     @unittest.skipIf(not torch.version.hip, "ROCM only")
     @unittest.mock.patch.dict(os.environ, _test_env)
     @parametrize("max_autotune_gemm_backends", ("CK", "ATen,Triton,CK"))
-    @parametrize("x_shape", ([4096, 2048], [2048], [4096, 1]))
+    @parametrize(
+        "x_shape", ([4096, 2048], [2048], [4096, 1])
+    )  # NOTE: the first two shapes create "Tensor-likes are not close" errors
     def test_max_autotune_addmm(self, max_autotune_gemm_backends, x_shape):
         m, k, n = 4096, 224, 2048
         alpha, beta = 1.0, 1.0

--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -3067,9 +3067,6 @@ class TestAutotuneCache(TestCase):
 
     @requires_cuda_and_triton
     @unittest.skipIf(not SM80OrLater, "Requires SM80+")
-    @unittest.skipIf(
-        TEST_WITH_ROCM, "Requires static cuda launcher, which does not support ROCM"
-    )
     @config.patch({"use_static_triton_launcher": True})
     @config.patch({"fx_graph_cache": True})
     @config.patch({"fx_graph_remote_cache": False})


### PR DESCRIPTION
These UTs work on ROCm 7.2 and triton rel/3.7


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben