### PR TITLE
[while_loop] support input mutation with auto_functionalize when inference

### DIFF
--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -10099,6 +10099,65 @@ class <lambda>(torch.nn.Module):
 """,  # noqa: B950
             )
 
+    @requires_cuda
+    @unittest.skipIf(not SM70OrLater, "triton")
+    @parametrize("device", ["cuda", "cpu"])
+    @parametrize("dynamic", [True, False])
+    def test_while_loop_auto_functionalize_captured_tensor_mutation(
+        self, device, dynamic
+    ):
+        class M(torch.nn.Module):
+            def forward(self, x, y):
+                def cond_fn(x):
+                    return x.sum() > 0
+
+                def body_fn(x):
+                    y.add_(-1)
+                    return (x + y.sum(),)
+
+                out = while_loop(cond_fn, body_fn, (x,))
+                return out[0] + y.sum()
+
+        x = torch.tensor([3.0, 2.0], requires_grad=False)
+        y = torch.ones(4, requires_grad=False)
+
+        fw_gm = self.check(M, (x, y), device, dynamic)
+        if not TEST_WITH_CROSSREF and not dynamic and device == "cuda":
+            print(normalize_gm(fw_gm.print_readable(print_output=False)))
+            self.assertExpectedInline(
+                normalize_gm(fw_gm.print_readable(print_output=False)),
+                """\
+class <lambda>(torch.nn.Module):
+    def forward(self, arg0_1: "f32[2]", arg1_1: "f32[4]"):
+        auto_functionalized_subgraph_0 = self.auto_functionalized_subgraph_0
+        auto_functionalized_subgraph_1 = self.auto_functionalized_subgraph_1
+        _tree_spec_constant0 = self._tree_spec_constant0
+        auto_functionalized_v2 = torch.ops.higher_order.auto_functionalized_v2(torch.ops.higher_order.while_loop, cond_fn = auto_functionalized_subgraph_0, body_fn = auto_functionalized_subgraph_1, carried_input0 = arg0_1, _additional_input0_base_index = 0, _all_bases = [arg1_1], _op_schema = _tree_spec_constant0);  auto_functionalized_subgraph_0 = auto_functionalized_subgraph_1 = arg0_1 = _tree_spec_constant0 = None
+        getitem: "f32[2]" = auto_functionalized_v2[0]
+        getitem_1: "f32[4]" = auto_functionalized_v2[1];  auto_functionalized_v2 = None
+
+        sum_1: "f32[]" = torch.ops.aten.sum.default(getitem_1)
+        add: "f32[2]" = torch.ops.aten.add.Tensor(getitem, sum_1);  getitem = sum_1 = None
+
+        copy_: "f32[4]" = torch.ops.aten.copy_.default(arg1_1, getitem_1);  arg1_1 = getitem_1 = copy_ = None
+        return (add,)
+
+    class auto_functionalized_subgraph_0(torch.nn.Module):
+        def forward(self, arg0_1: "f32[2]", arg1_1: "f32[4]"):
+            sum_1: "f32[]" = torch.ops.aten.sum.default(arg0_1);  arg0_1 = None
+            gt: "b8[]" = torch.ops.aten.gt.Scalar(sum_1, 0);  sum_1 = None
+            return gt
+
+    class auto_functionalized_subgraph_1(torch.nn.Module):
+        def forward(self, arg0_1: "f32[2]", arg1_1: "f32[4]"):
+            add: "f32[4]" = torch.ops.aten.add.Tensor(arg1_1, -1)
+            sum_1: "f32[]" = torch.ops.aten.sum.default(add)
+            add_1: "f32[2]" = torch.ops.aten.add.Tensor(arg0_1, sum_1);  arg0_1 = sum_1 = None
+            copy_: "f32[4]" = torch.ops.aten.copy_.default(arg1_1, add);  arg1_1 = add = copy_ = None
+            return (add_1,)
+""",  # noqa: B950
+            )
+
 
 _hop_schema_test_schema_types = [
     "bool",

--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -10483,6 +10483,7 @@ class TestHopSchema(TestCase):
             body_fn,
             (torch.randn(3, 3), torch.randn(3, 3), torch.randn(3, 3)),
             (c,),
+            "0,1,2,3",
         )
         self.assertExpectedInline(
             str(schema),

--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -9947,7 +9947,7 @@ class <lambda>(torch.nn.Module):
                 out = while_loop(cond_fn, body_fn, (x,))
                 return x + self.buf.sum() + out[0]
 
-        x = torch.tensor([2.0,1.0], requires_grad=False)
+        x = torch.tensor([2.0, 1.0], requires_grad=False)
         fw_gm = self.check(M, (x,), device, dynamic)
         if not TEST_WITH_CROSSREF and not dynamic and device == "cuda":
             self.assertExpectedInline(
@@ -9992,7 +9992,9 @@ class <lambda>(torch.nn.Module):
     @unittest.skipIf(not SM70OrLater, "triton")
     @parametrize("device", ["cuda", "cpu"])
     @parametrize("dynamic", [True, False])
-    def test_while_loop_auto_functionalize_multiple_buffer_mutation(self, device, dynamic):
+    def test_while_loop_auto_functionalize_multiple_buffer_mutation(
+        self, device, dynamic
+    ):
         class M(torch.nn.Module):
             def __init__(self):
                 super().__init__()

--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -9701,23 +9701,31 @@ class TestAutoFunctionalizeControlFlow(TestCase):
         # Only support input mutation in inference
         cloned_args = [_clone(args) for _ in range(3)]
         with torch.no_grad():
-            exp = _new_fn()(*cloned_args[0])
+            mod0 = _new_fn()
+            exp = mod0(*cloned_args[0])
         backend = AotEagerAndRecordGraphs()
         torch._dynamo.reset()
         with torch.no_grad():
+            mod1 = _new_fn()
             eager_out = torch.compile(
-                _new_fn(), backend=backend, fullgraph=True, dynamic=dynamic
+                mod1, backend=backend, fullgraph=True, dynamic=dynamic
             )(*cloned_args[1])
         torch._dynamo.reset()
         with torch.no_grad():
+            mod2 = _new_fn()
             inductor_out = torch.compile(
-                _new_fn(), backend="inductor", fullgraph=True, dynamic=dynamic
+                mod2, backend="inductor", fullgraph=True, dynamic=dynamic
             )(*cloned_args[2])
 
         self.assertEqual(exp, eager_out)
         self.assertEqual(exp, inductor_out)
         self.assertEqual(cloned_args[0], cloned_args[1])
         self.assertEqual(cloned_args[0], cloned_args[2])
+
+        for k in mod0._buffers:
+            self.assertTrue(k in mod1._buffers and k in mod2._buffers)
+            self.assertEqual(mod0._buffers[k], mod1._buffers[k])
+            self.assertEqual(mod0._buffers[k], mod2._buffers[k])
         return backend.fw_graphs[0]
 
     @requires_cuda
@@ -9918,61 +9926,6 @@ class <lambda>(torch.nn.Module):
     @unittest.skipIf(not SM70OrLater, "triton")
     @parametrize("device", ["cuda", "cpu"])
     @parametrize("dynamic", [True, False])
-    def test_while_loop_auto_functionalize_input_mutation(self, device, dynamic):
-        class M(torch.nn.Module):
-            def forward(self, x, y):
-                def cond_fn(x):
-                    return x.sum() > 0
-
-                def body_fn(x):
-                    x.add_(-1)
-                    return (x.clone(),)
-
-                x = x.clone()
-                ret = while_loop(cond_fn, body_fn, (x,))
-                return y + ret[0]
-
-        x, y = (
-            torch.randn(3, 4),
-            torch.randn(3, 4),
-        )
-        fw_gm = self.check(M, (x, y), device, dynamic)
-        if not TEST_WITH_CROSSREF and not dynamic and device == "cuda":
-            self.assertExpectedInline(
-                normalize_gm(fw_gm.print_readable(print_output=False)),
-                """\
-class <lambda>(torch.nn.Module):
-    def forward(self, arg0_1: "f32[3, 4]", arg1_1: "f32[3, 4]"):
-        clone: "f32[3, 4]" = torch.ops.aten.clone.default(arg0_1);  arg0_1 = None
-
-        auto_functionalized_subgraph_0 = self.auto_functionalized_subgraph_0
-        auto_functionalized_subgraph_1 = self.auto_functionalized_subgraph_1
-        _tree_spec_constant0 = self._tree_spec_constant0
-        auto_functionalized_v2 = torch.ops.higher_order.auto_functionalized_v2(torch.ops.higher_order.while_loop, cond_fn = auto_functionalized_subgraph_0, body_fn = auto_functionalized_subgraph_1, _carried_input0_base_index = 0, _all_bases = [clone], _op_schema = _tree_spec_constant0);  auto_functionalized_subgraph_0 = auto_functionalized_subgraph_1 = clone = _tree_spec_constant0 = None
-        getitem: "f32[3, 4]" = auto_functionalized_v2[0];  auto_functionalized_v2 = None
-
-        add: "f32[3, 4]" = torch.ops.aten.add.Tensor(arg1_1, getitem);  arg1_1 = getitem = None
-        return (add,)
-
-    class auto_functionalized_subgraph_0(torch.nn.Module):
-        def forward(self, arg0_1: "f32[3, 4]"):
-            sum_1: "f32[]" = torch.ops.aten.sum.default(arg0_1);  arg0_1 = None
-            gt: "b8[]" = torch.ops.aten.gt.Scalar(sum_1, 0);  sum_1 = None
-            return gt
-
-    class auto_functionalized_subgraph_1(torch.nn.Module):
-        def forward(self, arg0_1: "f32[3, 4]"):
-            add: "f32[3, 4]" = torch.ops.aten.add.Tensor(arg0_1, -1)
-            clone: "f32[3, 4]" = torch.ops.aten.clone.default(add)
-            copy_: "f32[3, 4]" = torch.ops.aten.copy_.default(arg0_1, add);  arg0_1 = add = copy_ = None
-            return (clone,)
-""",  # noqa: B950
-            )
-
-    @requires_cuda
-    @unittest.skipIf(not SM70OrLater, "triton")
-    @parametrize("device", ["cuda", "cpu"])
-    @parametrize("dynamic", [True, False])
     def test_while_loop_auto_functionalize_buffer_mutation(self, device, dynamic):
         class M(torch.nn.Module):
             def __init__(self):
@@ -9981,141 +9934,166 @@ class <lambda>(torch.nn.Module):
                     "buf", torch.ones(8, requires_grad=False, device=device)
                 )
 
-            def forward(self, p, x):
+            def forward(self, x):
                 def cond_fn(x):
-                    return x.sum() < 0
+                    return x.sum() > 0
 
                 def body_fn(x):
-                    x.add_(-1)
+                    x_new = x.add(-1)
                     self.buf.add_(-1)
-                    return (x + self.buf.sum(),)
+                    return (x_new + self.buf.sum(),)
 
                 x = x.clone()
                 out = while_loop(cond_fn, body_fn, (x,))
-                return x + self.buf + out[0]
+                return x + self.buf.sum() + out[0]
 
-        p, x = torch.tensor(True), torch.randn(1, requires_grad=True)
-        fw_gm = self.check(M, (p, x), device, dynamic)
+        x = torch.tensor([2.0,1.0], requires_grad=False)
+        fw_gm = self.check(M, (x,), device, dynamic)
         if not TEST_WITH_CROSSREF and not dynamic and device == "cuda":
             self.assertExpectedInline(
                 normalize_gm(fw_gm.print_readable(print_output=False)),
                 """\
 class <lambda>(torch.nn.Module):
-    def forward(self, arg0_1: "f32[1]", arg1_1: "f32[8]"):
-        clone: "f32[1]" = torch.ops.aten.clone.default(arg0_1);  arg0_1 = None
+    def forward(self, arg0_1: "f32[2]", arg1_1: "f32[8]"):
+        clone: "f32[2]" = torch.ops.aten.clone.default(arg0_1);  arg0_1 = None
 
         auto_functionalized_subgraph_0 = self.auto_functionalized_subgraph_0
         auto_functionalized_subgraph_1 = self.auto_functionalized_subgraph_1
         _tree_spec_constant0 = self._tree_spec_constant0
-        auto_functionalized_v2 = torch.ops.higher_order.auto_functionalized_v2(torch.ops.higher_order.while_loop, cond_fn = auto_functionalized_subgraph_0, body_fn = auto_functionalized_subgraph_1, _carried_input0_base_index = 0, _additional_input0_base_index = 1, _all_bases = [clone, arg1_1], _op_schema = _tree_spec_constant0);  auto_functionalized_subgraph_0 = auto_functionalized_subgraph_1 = clone = _tree_spec_constant0 = None
-        getitem: "f32[1]" = auto_functionalized_v2[0]
-        getitem_1: "f32[1]" = auto_functionalized_v2[1]
-        getitem_2: "f32[8]" = auto_functionalized_v2[2];  auto_functionalized_v2 = None
+        auto_functionalized_v2 = torch.ops.higher_order.auto_functionalized_v2(torch.ops.higher_order.while_loop, cond_fn = auto_functionalized_subgraph_0, body_fn = auto_functionalized_subgraph_1, carried_input0 = clone, _additional_input0_base_index = 0, _all_bases = [arg1_1], _op_schema = _tree_spec_constant0);  auto_functionalized_subgraph_0 = auto_functionalized_subgraph_1 = _tree_spec_constant0 = None
+        getitem: "f32[2]" = auto_functionalized_v2[0]
+        getitem_1: "f32[8]" = auto_functionalized_v2[1];  auto_functionalized_v2 = None
 
-        add: "f32[8]" = torch.ops.aten.add.Tensor(getitem_1, getitem_2);  getitem_1 = None
-        add_1: "f32[8]" = torch.ops.aten.add.Tensor(add, getitem);  add = getitem = None
+        sum_1: "f32[]" = torch.ops.aten.sum.default(getitem_1)
+        add: "f32[2]" = torch.ops.aten.add.Tensor(clone, sum_1);  clone = sum_1 = None
+        add_1: "f32[2]" = torch.ops.aten.add.Tensor(add, getitem);  add = getitem = None
 
-        copy_: "f32[8]" = torch.ops.aten.copy_.default(arg1_1, getitem_2);  arg1_1 = getitem_2 = copy_ = None
+        copy_: "f32[8]" = torch.ops.aten.copy_.default(arg1_1, getitem_1);  arg1_1 = getitem_1 = copy_ = None
         return (add_1,)
 
     class auto_functionalized_subgraph_0(torch.nn.Module):
-        def forward(self, arg0_1: "f32[1]", arg1_1: "f32[8]"):
+        def forward(self, arg0_1: "f32[2]", arg1_1: "f32[8]"):
             sum_1: "f32[]" = torch.ops.aten.sum.default(arg0_1);  arg0_1 = None
-            lt: "b8[]" = torch.ops.aten.lt.Scalar(sum_1, 0);  sum_1 = None
-            return lt
+            gt: "b8[]" = torch.ops.aten.gt.Scalar(sum_1, 0);  sum_1 = None
+            return gt
 
     class auto_functionalized_subgraph_1(torch.nn.Module):
-        def forward(self, arg0_1: "f32[1]", arg1_1: "f32[8]"):
-            add: "f32[1]" = torch.ops.aten.add.Tensor(arg0_1, -1)
+        def forward(self, arg0_1: "f32[2]", arg1_1: "f32[8]"):
+            add: "f32[2]" = torch.ops.aten.add.Tensor(arg0_1, -1);  arg0_1 = None
             add_1: "f32[8]" = torch.ops.aten.add.Tensor(arg1_1, -1)
             sum_1: "f32[]" = torch.ops.aten.sum.default(add_1)
-            add_2: "f32[1]" = torch.ops.aten.add.Tensor(add, sum_1);  sum_1 = None
-            copy_: "f32[1]" = torch.ops.aten.copy_.default(arg0_1, add);  arg0_1 = add = copy_ = None
-            copy__1: "f32[8]" = torch.ops.aten.copy_.default(arg1_1, add_1);  arg1_1 = add_1 = copy__1 = None
+            add_2: "f32[2]" = torch.ops.aten.add.Tensor(add, sum_1);  add = sum_1 = None
+            copy_: "f32[8]" = torch.ops.aten.copy_.default(arg1_1, add_1);  arg1_1 = add_1 = copy_ = None
             return (add_2,)
 """,  # noqa: B950
             )
 
     @requires_cuda
     @unittest.skipIf(not SM70OrLater, "triton")
-    @torch._dynamo.config.patch(capture_scalar_outputs=True)
-    @torch._dynamo.config.patch(prefer_deferred_runtime_asserts_over_guards=True)
     @parametrize("device", ["cuda", "cpu"])
     @parametrize("dynamic", [True, False])
-    def test_while_loop_auto_functionalize_inplace_mutate_out_buffer_as_carry(
-        self, device, dynamic
-    ):
+    def test_while_loop_auto_functionalize_multiple_buffer_mutation(self, device, dynamic):
         class M(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer(
-                    "buf", torch.ones(1, requires_grad=False, device=device)
-                )
+                self.register_buffer("buf1", torch.ones(4, device=device))
+                self.register_buffer("buf2", torch.zeros(4, device=device))
 
-            def forward(self, p, x):
-                def cond_fn(it, x, out_buf):
-                    return it < x.size(0)
+            def forward(self, x):
+                def cond_fn(x):
+                    return x.sum() > 0
 
-                def body_fn(it, x, out_buf):
-                    out = x.sin()
-                    idx = it.item()
-                    torch._check_is_size(idx, max=x.size(0) - 1)
-                    out_buf[idx].add_(out[idx])
-                    return (it + 1, x + 1, out_buf.clone())
+                def body_fn(x):
+                    self.buf1.add_(x)
+                    self.buf2.add_(self.buf1)
+                    return (x - 1,)
 
-                it = torch.tensor(0, dtype=torch.int64)
-                out_buf = x.clone()
-                x = x.clone()
-                out = while_loop(cond_fn, body_fn, (it, x, out_buf))
-                return x + self.buf + out[0]
+                return while_loop(cond_fn, body_fn, (x,))
 
-        p, x = torch.tensor(True), torch.randn(3, 4)
-        fw_gm = self.check(M, (p, x), device, dynamic)
+        x = torch.tensor([3.0, 2.0, 1.0, 1.0], requires_grad=False)
+        fw_gm = self.check(M, (x,), device, dynamic)
         if not TEST_WITH_CROSSREF and not dynamic and device == "cuda":
             self.assertExpectedInline(
                 normalize_gm(fw_gm.print_readable(print_output=False)),
                 """\
 class <lambda>(torch.nn.Module):
-    def forward(self, arg0_1: "f32[3, 4]", arg1_1: "f32[1]"):
-        _tensor_constant0: "i64[]" = self._tensor_constant0
-        lift_fresh_copy: "i64[]" = torch.ops.aten.lift_fresh_copy.default(_tensor_constant0);  _tensor_constant0 = None
-
-        clone: "f32[3, 4]" = torch.ops.aten.clone.default(arg0_1)
-
-        clone_1: "f32[3, 4]" = torch.ops.aten.clone.default(arg0_1);  arg0_1 = None
-
+    def forward(self, arg0_1: "f32[4]", arg1_1: "f32[4]", arg2_1: "f32[4]"):
         auto_functionalized_subgraph_0 = self.auto_functionalized_subgraph_0
         auto_functionalized_subgraph_1 = self.auto_functionalized_subgraph_1
         _tree_spec_constant0 = self._tree_spec_constant0
-        auto_functionalized_v2 = torch.ops.higher_order.auto_functionalized_v2(torch.ops.higher_order.while_loop, cond_fn = auto_functionalized_subgraph_0, body_fn = auto_functionalized_subgraph_1, carried_input0 = lift_fresh_copy, carried_input1 = clone_1, _carried_input2_base_index = 0, _all_bases = [clone], _op_schema = _tree_spec_constant0);  auto_functionalized_subgraph_0 = auto_functionalized_subgraph_1 = lift_fresh_copy = clone = _tree_spec_constant0 = None
-        getitem: "i64[]" = auto_functionalized_v2[0];  auto_functionalized_v2 = None
-
-        add: "f32[3, 4]" = torch.ops.aten.add.Tensor(clone_1, arg1_1);  clone_1 = arg1_1 = None
-        add_1: "f32[3, 4]" = torch.ops.aten.add.Tensor(add, getitem);  add = getitem = None
-        return (add_1,)
+        auto_functionalized_v2 = torch.ops.higher_order.auto_functionalized_v2(torch.ops.higher_order.while_loop, cond_fn = auto_functionalized_subgraph_0, body_fn = auto_functionalized_subgraph_1, carried_input0 = arg0_1, _additional_input0_base_index = 0, _additional_input1_base_index = 1, _all_bases = [arg1_1, arg2_1], _op_schema = _tree_spec_constant0);  auto_functionalized_subgraph_0 = auto_functionalized_subgraph_1 = arg0_1 = _tree_spec_constant0 = None
+        getitem: "f32[4]" = auto_functionalized_v2[0]
+        getitem_1: "f32[4]" = auto_functionalized_v2[1]
+        getitem_2: "f32[4]" = auto_functionalized_v2[2];  auto_functionalized_v2 = None
+        copy_: "f32[4]" = torch.ops.aten.copy_.default(arg1_1, getitem_1);  arg1_1 = getitem_1 = copy_ = None
+        copy__1: "f32[4]" = torch.ops.aten.copy_.default(arg2_1, getitem_2);  arg2_1 = getitem_2 = copy__1 = None
+        return (getitem,)
 
     class auto_functionalized_subgraph_0(torch.nn.Module):
-        def forward(self, arg0_1: "i64[]", arg1_1: "f32[3, 4]", arg2_1: "f32[3, 4]"):
-            lt: "b8[]" = torch.ops.aten.lt.Scalar(arg0_1, 3);  arg0_1 = None
+        def forward(self, arg0_1: "f32[4]", arg1_1: "f32[4]", arg2_1: "f32[4]"):
+            sum_1: "f32[]" = torch.ops.aten.sum.default(arg0_1);  arg0_1 = None
+            gt: "b8[]" = torch.ops.aten.gt.Scalar(sum_1, 0);  sum_1 = None
+            return gt
+
+    class auto_functionalized_subgraph_1(torch.nn.Module):
+        def forward(self, arg0_1: "f32[4]", arg1_1: "f32[4]", arg2_1: "f32[4]"):
+            add: "f32[4]" = torch.ops.aten.add.Tensor(arg1_1, arg0_1)
+            add_1: "f32[4]" = torch.ops.aten.add.Tensor(arg2_1, add)
+            sub: "f32[4]" = torch.ops.aten.sub.Tensor(arg0_1, 1);  arg0_1 = None
+            copy_: "f32[4]" = torch.ops.aten.copy_.default(arg1_1, add);  arg1_1 = add = copy_ = None
+            copy__1: "f32[4]" = torch.ops.aten.copy_.default(arg2_1, add_1);  arg2_1 = add_1 = copy__1 = None
+            return (sub,)
+""",  # noqa: B950
+            )
+
+    @requires_cuda
+    @unittest.skipIf(not SM70OrLater, "triton")
+    @parametrize("device", ["cuda", "cpu"])
+    @parametrize("dynamic", [True, False])
+    def test_while_loop_auto_functionalize_buffer_in_cond(self, device, dynamic):
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.register_buffer("counter", torch.tensor(0, device=device))
+
+            def forward(self, x):
+                def cond_fn(x):
+                    self.counter.add_(1)
+                    return self.counter < 3
+
+                def body_fn(x):
+                    return (x + 1,)
+
+                return while_loop(cond_fn, body_fn, (x,))
+
+        x = torch.tensor([0.0, 0.0], requires_grad=False)
+        fw_gm = self.check(M, (x,), device, dynamic)
+        if not TEST_WITH_CROSSREF and not dynamic and device == "cuda":
+            self.assertExpectedInline(
+                normalize_gm(fw_gm.print_readable(print_output=False)),
+                """\
+class <lambda>(torch.nn.Module):
+    def forward(self, arg0_1: "f32[2]", arg1_1: "i64[]"):
+        auto_functionalized_subgraph_0 = self.auto_functionalized_subgraph_0
+        auto_functionalized_subgraph_1 = self.auto_functionalized_subgraph_1
+        _tree_spec_constant0 = self._tree_spec_constant0
+        auto_functionalized_v2 = torch.ops.higher_order.auto_functionalized_v2(torch.ops.higher_order.while_loop, cond_fn = auto_functionalized_subgraph_0, body_fn = auto_functionalized_subgraph_1, carried_input0 = arg0_1, _additional_input0_base_index = 0, _all_bases = [arg1_1], _op_schema = _tree_spec_constant0);  auto_functionalized_subgraph_0 = auto_functionalized_subgraph_1 = arg0_1 = _tree_spec_constant0 = None
+        getitem: "f32[2]" = auto_functionalized_v2[0]
+        getitem_1: "i64[]" = auto_functionalized_v2[1];  auto_functionalized_v2 = None
+        copy_: "i64[]" = torch.ops.aten.copy_.default(arg1_1, getitem_1);  arg1_1 = getitem_1 = copy_ = None
+        return (getitem,)
+
+    class auto_functionalized_subgraph_0(torch.nn.Module):
+        def forward(self, arg0_1: "f32[2]", arg1_1: "i64[]"):
+            add: "i64[]" = torch.ops.aten.add.Tensor(arg1_1, 1)
+            lt: "b8[]" = torch.ops.aten.lt.Scalar(add, 3)
+            copy_: "i64[]" = torch.ops.aten.copy_.default(arg1_1, add);  arg1_1 = add = copy_ = None
             return lt
 
     class auto_functionalized_subgraph_1(torch.nn.Module):
-        def forward(self, arg0_1: "i64[]", arg1_1: "f32[3, 4]", arg2_1: "f32[3, 4]"):
-            sin: "f32[3, 4]" = torch.ops.aten.sin.default(arg1_1)
-            _local_scalar_dense: "Sym(u3)" = torch.ops.aten._local_scalar_dense.default(arg0_1)
-            ge_1: "Sym(u3 >= 0)" = _local_scalar_dense >= 0
-            _assert_scalar_default = torch.ops.aten._assert_scalar.default(ge_1, "Runtime assertion failed for expression u3 >= 0 on node 'ge_1'");  ge_1 = _assert_scalar_default = None
-            le_1: "Sym(u3 <= 2)" = _local_scalar_dense <= 2
-            _assert_scalar_default_1 = torch.ops.aten._assert_scalar.default(le_1, "Runtime assertion failed for expression u3 <= 2 on node 'le_1'");  le_1 = _assert_scalar_default_1 = None
-            select: "f32[4]" = torch.ops.aten.select.int(arg2_1, 0, _local_scalar_dense)
-            select_1: "f32[4]" = torch.ops.aten.select.int(sin, 0, _local_scalar_dense);  sin = None
-            add: "f32[4]" = torch.ops.aten.add.Tensor(select, select_1);  select = select_1 = None
-            select_scatter: "f32[3, 4]" = torch.ops.aten.select_scatter.default(arg2_1, add, 0, _local_scalar_dense);  add = _local_scalar_dense = None
-            add_1: "i64[]" = torch.ops.aten.add.Tensor(arg0_1, 1);  arg0_1 = None
-            add_2: "f32[3, 4]" = torch.ops.aten.add.Tensor(arg1_1, 1);  arg1_1 = None
-            clone: "f32[3, 4]" = torch.ops.aten.clone.default(select_scatter)
-            copy_: "f32[3, 4]" = torch.ops.aten.copy_.default(arg2_1, select_scatter);  arg2_1 = select_scatter = copy_ = None
-            return (add_1, add_2, clone)
+        def forward(self, arg0_1: "f32[2]", arg1_1: "i64[]"):
+            add: "f32[2]" = torch.ops.aten.add.Tensor(arg0_1, 1);  arg0_1 = None
+            return (add,)
 """,  # noqa: B950
             )
 

--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -9985,7 +9985,7 @@ class <lambda>(torch.nn.Module):
             add_2: "f32[2]" = torch.ops.aten.add.Tensor(add, sum_1);  add = sum_1 = None
             copy_: "f32[8]" = torch.ops.aten.copy_.default(arg1_1, add_1);  arg1_1 = add_1 = copy_ = None
             return (add_2,)
-""",  # noqa: B950
+""",
             )
 
     @requires_cuda
@@ -10045,7 +10045,7 @@ class <lambda>(torch.nn.Module):
             copy_: "f32[4]" = torch.ops.aten.copy_.default(arg1_1, add);  arg1_1 = add = copy_ = None
             copy__1: "f32[4]" = torch.ops.aten.copy_.default(arg2_1, add_1);  arg2_1 = add_1 = copy__1 = None
             return (sub,)
-""",  # noqa: B950
+""",
             )
 
     @requires_cuda
@@ -10096,7 +10096,7 @@ class <lambda>(torch.nn.Module):
         def forward(self, arg0_1: "f32[2]", arg1_1: "i64[]"):
             add: "f32[2]" = torch.ops.aten.add.Tensor(arg0_1, 1);  arg0_1 = None
             return (add,)
-""",  # noqa: B950
+""",
             )
 
     @requires_cuda
@@ -10155,7 +10155,7 @@ class <lambda>(torch.nn.Module):
             add_1: "f32[2]" = torch.ops.aten.add.Tensor(arg0_1, sum_1);  arg0_1 = sum_1 = None
             copy_: "f32[4]" = torch.ops.aten.copy_.default(arg1_1, add);  arg1_1 = add = copy_ = None
             return (add_1,)
-""",  # noqa: B950
+""",
             )
 
 

--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -9914,6 +9914,211 @@ class <lambda>(torch.nn.Module):
 """,
             )
 
+    @requires_cuda
+    @unittest.skipIf(not SM70OrLater, "triton")
+    @parametrize("device", ["cuda", "cpu"])
+    @parametrize("dynamic", [True, False])
+    def test_while_loop_auto_functionalize_input_mutation(self, device, dynamic):
+        class M(torch.nn.Module):
+            def forward(self, x, y):
+                def cond_fn(x):
+                    return x.sum() > 0
+
+                def body_fn(x):
+                    x.add_(-1)
+                    return (x.clone(),)
+
+                x = x.clone()
+                ret = while_loop(cond_fn, body_fn, (x,))
+                return y + ret[0]
+
+        x, y = (
+            torch.randn(3, 4),
+            torch.randn(3, 4),
+        )
+        fw_gm = self.check(M, (x, y), device, dynamic)
+        if not TEST_WITH_CROSSREF and not dynamic and device == "cuda":
+            self.assertExpectedInline(
+                normalize_gm(fw_gm.print_readable(print_output=False)),
+                """\
+class <lambda>(torch.nn.Module):
+    def forward(self, arg0_1: "f32[3, 4]", arg1_1: "f32[3, 4]"):
+        clone: "f32[3, 4]" = torch.ops.aten.clone.default(arg0_1);  arg0_1 = None
+
+        auto_functionalized_subgraph_0 = self.auto_functionalized_subgraph_0
+        auto_functionalized_subgraph_1 = self.auto_functionalized_subgraph_1
+        _tree_spec_constant0 = self._tree_spec_constant0
+        auto_functionalized_v2 = torch.ops.higher_order.auto_functionalized_v2(torch.ops.higher_order.while_loop, cond_fn = auto_functionalized_subgraph_0, body_fn = auto_functionalized_subgraph_1, _carried_input0_base_index = 0, _all_bases = [clone], _op_schema = _tree_spec_constant0);  auto_functionalized_subgraph_0 = auto_functionalized_subgraph_1 = clone = _tree_spec_constant0 = None
+        getitem: "f32[3, 4]" = auto_functionalized_v2[0];  auto_functionalized_v2 = None
+
+        add: "f32[3, 4]" = torch.ops.aten.add.Tensor(arg1_1, getitem);  arg1_1 = getitem = None
+        return (add,)
+
+    class auto_functionalized_subgraph_0(torch.nn.Module):
+        def forward(self, arg0_1: "f32[3, 4]"):
+            sum_1: "f32[]" = torch.ops.aten.sum.default(arg0_1);  arg0_1 = None
+            gt: "b8[]" = torch.ops.aten.gt.Scalar(sum_1, 0);  sum_1 = None
+            return gt
+
+    class auto_functionalized_subgraph_1(torch.nn.Module):
+        def forward(self, arg0_1: "f32[3, 4]"):
+            add: "f32[3, 4]" = torch.ops.aten.add.Tensor(arg0_1, -1)
+            clone: "f32[3, 4]" = torch.ops.aten.clone.default(add)
+            copy_: "f32[3, 4]" = torch.ops.aten.copy_.default(arg0_1, add);  arg0_1 = add = copy_ = None
+            return (clone,)
+""",  # noqa: B950
+            )
+
+    @requires_cuda
+    @unittest.skipIf(not SM70OrLater, "triton")
+    @parametrize("device", ["cuda", "cpu"])
+    @parametrize("dynamic", [True, False])
+    def test_while_loop_auto_functionalize_buffer_mutation(self, device, dynamic):
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.register_buffer(
+                    "buf", torch.ones(8, requires_grad=False, device=device)
+                )
+
+            def forward(self, p, x):
+                def cond_fn(x):
+                    return x.sum() < 0
+
+                def body_fn(x):
+                    x.add_(-1)
+                    self.buf.add_(-1)
+                    return (x + self.buf.sum(),)
+
+                x = x.clone()
+                out = while_loop(cond_fn, body_fn, (x,))
+                return x + self.buf + out[0]
+
+        p, x = torch.tensor(True), torch.randn(1, requires_grad=True)
+        fw_gm = self.check(M, (p, x), device, dynamic)
+        if not TEST_WITH_CROSSREF and not dynamic and device == "cuda":
+            self.assertExpectedInline(
+                normalize_gm(fw_gm.print_readable(print_output=False)),
+                """\
+class <lambda>(torch.nn.Module):
+    def forward(self, arg0_1: "f32[1]", arg1_1: "f32[8]"):
+        clone: "f32[1]" = torch.ops.aten.clone.default(arg0_1);  arg0_1 = None
+
+        auto_functionalized_subgraph_0 = self.auto_functionalized_subgraph_0
+        auto_functionalized_subgraph_1 = self.auto_functionalized_subgraph_1
+        _tree_spec_constant0 = self._tree_spec_constant0
+        auto_functionalized_v2 = torch.ops.higher_order.auto_functionalized_v2(torch.ops.higher_order.while_loop, cond_fn = auto_functionalized_subgraph_0, body_fn = auto_functionalized_subgraph_1, _carried_input0_base_index = 0, _additional_input0_base_index = 1, _all_bases = [clone, arg1_1], _op_schema = _tree_spec_constant0);  auto_functionalized_subgraph_0 = auto_functionalized_subgraph_1 = clone = _tree_spec_constant0 = None
+        getitem: "f32[1]" = auto_functionalized_v2[0]
+        getitem_1: "f32[1]" = auto_functionalized_v2[1]
+        getitem_2: "f32[8]" = auto_functionalized_v2[2];  auto_functionalized_v2 = None
+
+        add: "f32[8]" = torch.ops.aten.add.Tensor(getitem_1, getitem_2);  getitem_1 = None
+        add_1: "f32[8]" = torch.ops.aten.add.Tensor(add, getitem);  add = getitem = None
+
+        copy_: "f32[8]" = torch.ops.aten.copy_.default(arg1_1, getitem_2);  arg1_1 = getitem_2 = copy_ = None
+        return (add_1,)
+
+    class auto_functionalized_subgraph_0(torch.nn.Module):
+        def forward(self, arg0_1: "f32[1]", arg1_1: "f32[8]"):
+            sum_1: "f32[]" = torch.ops.aten.sum.default(arg0_1);  arg0_1 = None
+            lt: "b8[]" = torch.ops.aten.lt.Scalar(sum_1, 0);  sum_1 = None
+            return lt
+
+    class auto_functionalized_subgraph_1(torch.nn.Module):
+        def forward(self, arg0_1: "f32[1]", arg1_1: "f32[8]"):
+            add: "f32[1]" = torch.ops.aten.add.Tensor(arg0_1, -1)
+            add_1: "f32[8]" = torch.ops.aten.add.Tensor(arg1_1, -1)
+            sum_1: "f32[]" = torch.ops.aten.sum.default(add_1)
+            add_2: "f32[1]" = torch.ops.aten.add.Tensor(add, sum_1);  sum_1 = None
+            copy_: "f32[1]" = torch.ops.aten.copy_.default(arg0_1, add);  arg0_1 = add = copy_ = None
+            copy__1: "f32[8]" = torch.ops.aten.copy_.default(arg1_1, add_1);  arg1_1 = add_1 = copy__1 = None
+            return (add_2,)
+""",  # noqa: B950
+            )
+
+    @requires_cuda
+    @unittest.skipIf(not SM70OrLater, "triton")
+    @torch._dynamo.config.patch(capture_scalar_outputs=True)
+    @torch._dynamo.config.patch(prefer_deferred_runtime_asserts_over_guards=True)
+    @parametrize("device", ["cuda", "cpu"])
+    @parametrize("dynamic", [True, False])
+    def test_while_loop_auto_functionalize_inplace_mutate_out_buffer_as_carry(
+        self, device, dynamic
+    ):
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.register_buffer(
+                    "buf", torch.ones(1, requires_grad=False, device=device)
+                )
+
+            def forward(self, p, x):
+                def cond_fn(it, x, out_buf):
+                    return it < x.size(0)
+
+                def body_fn(it, x, out_buf):
+                    out = x.sin()
+                    idx = it.item()
+                    torch._check_is_size(idx, max=x.size(0) - 1)
+                    out_buf[idx].add_(out[idx])
+                    return (it + 1, x + 1, out_buf.clone())
+
+                it = torch.tensor(0, dtype=torch.int64)
+                out_buf = x.clone()
+                x = x.clone()
+                out = while_loop(cond_fn, body_fn, (it, x, out_buf))
+                return x + self.buf + out[0]
+
+        p, x = torch.tensor(True), torch.randn(3, 4)
+        fw_gm = self.check(M, (p, x), device, dynamic)
+        if not TEST_WITH_CROSSREF and not dynamic and device == "cuda":
+            self.assertExpectedInline(
+                normalize_gm(fw_gm.print_readable(print_output=False)),
+                """\
+class <lambda>(torch.nn.Module):
+    def forward(self, arg0_1: "f32[3, 4]", arg1_1: "f32[1]"):
+        _tensor_constant0: "i64[]" = self._tensor_constant0
+        lift_fresh_copy: "i64[]" = torch.ops.aten.lift_fresh_copy.default(_tensor_constant0);  _tensor_constant0 = None
+
+        clone: "f32[3, 4]" = torch.ops.aten.clone.default(arg0_1)
+
+        clone_1: "f32[3, 4]" = torch.ops.aten.clone.default(arg0_1);  arg0_1 = None
+
+        auto_functionalized_subgraph_0 = self.auto_functionalized_subgraph_0
+        auto_functionalized_subgraph_1 = self.auto_functionalized_subgraph_1
+        _tree_spec_constant0 = self._tree_spec_constant0
+        auto_functionalized_v2 = torch.ops.higher_order.auto_functionalized_v2(torch.ops.higher_order.while_loop, cond_fn = auto_functionalized_subgraph_0, body_fn = auto_functionalized_subgraph_1, carried_input0 = lift_fresh_copy, carried_input1 = clone_1, _carried_input2_base_index = 0, _all_bases = [clone], _op_schema = _tree_spec_constant0);  auto_functionalized_subgraph_0 = auto_functionalized_subgraph_1 = lift_fresh_copy = clone = _tree_spec_constant0 = None
+        getitem: "i64[]" = auto_functionalized_v2[0];  auto_functionalized_v2 = None
+
+        add: "f32[3, 4]" = torch.ops.aten.add.Tensor(clone_1, arg1_1);  clone_1 = arg1_1 = None
+        add_1: "f32[3, 4]" = torch.ops.aten.add.Tensor(add, getitem);  add = getitem = None
+        return (add_1,)
+
+    class auto_functionalized_subgraph_0(torch.nn.Module):
+        def forward(self, arg0_1: "i64[]", arg1_1: "f32[3, 4]", arg2_1: "f32[3, 4]"):
+            lt: "b8[]" = torch.ops.aten.lt.Scalar(arg0_1, 3);  arg0_1 = None
+            return lt
+
+    class auto_functionalized_subgraph_1(torch.nn.Module):
+        def forward(self, arg0_1: "i64[]", arg1_1: "f32[3, 4]", arg2_1: "f32[3, 4]"):
+            sin: "f32[3, 4]" = torch.ops.aten.sin.default(arg1_1)
+            _local_scalar_dense: "Sym(u3)" = torch.ops.aten._local_scalar_dense.default(arg0_1)
+            ge_1: "Sym(u3 >= 0)" = _local_scalar_dense >= 0
+            _assert_scalar_default = torch.ops.aten._assert_scalar.default(ge_1, "Runtime assertion failed for expression u3 >= 0 on node 'ge_1'");  ge_1 = _assert_scalar_default = None
+            le_1: "Sym(u3 <= 2)" = _local_scalar_dense <= 2
+            _assert_scalar_default_1 = torch.ops.aten._assert_scalar.default(le_1, "Runtime assertion failed for expression u3 <= 2 on node 'le_1'");  le_1 = _assert_scalar_default_1 = None
+            select: "f32[4]" = torch.ops.aten.select.int(arg2_1, 0, _local_scalar_dense)
+            select_1: "f32[4]" = torch.ops.aten.select.int(sin, 0, _local_scalar_dense);  sin = None
+            add: "f32[4]" = torch.ops.aten.add.Tensor(select, select_1);  select = select_1 = None
+            select_scatter: "f32[3, 4]" = torch.ops.aten.select_scatter.default(arg2_1, add, 0, _local_scalar_dense);  add = _local_scalar_dense = None
+            add_1: "i64[]" = torch.ops.aten.add.Tensor(arg0_1, 1);  arg0_1 = None
+            add_2: "f32[3, 4]" = torch.ops.aten.add.Tensor(arg1_1, 1);  arg1_1 = None
+            clone: "f32[3, 4]" = torch.ops.aten.clone.default(select_scatter)
+            copy_: "f32[3, 4]" = torch.ops.aten.copy_.default(arg2_1, select_scatter);  arg2_1 = select_scatter = copy_ = None
+            return (add_1, add_2, clone)
+""",  # noqa: B950
+            )
+
 
 _hop_schema_test_schema_types = [
     "bool",

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -228,6 +228,7 @@ class AliasingInfo:
 class MutationInfo:
     has_mutation: bool
     msg: str
+    mutated_input_indices: tuple[int, ...] = ()
 
 
 def collect_reachable_grad_fns(
@@ -4391,14 +4392,16 @@ class SubgraphTracer(fx.Tracer):
     def has_input_mutation(self) -> MutationInfo:
         input_versions_at_beginning = self._input_versions_at_beginning
         input_nodes = []
+        tensor_placeholder_indices = []
 
         input_versions_at_end = []
-        for node in self.graph.nodes:
+        for placeholder_idx, node in enumerate(self.graph.nodes):
             if node.op == "placeholder":
                 example_value = node.meta["example_value"]
                 if isinstance(example_value, torch.Tensor):
                     input_versions_at_end.append(example_value._version)
                     input_nodes.append(node)
+                    tensor_placeholder_indices.append(placeholder_idx)
             else:
                 break
 
@@ -4412,10 +4415,13 @@ class SubgraphTracer(fx.Tracer):
 
         if mutated_inputs:
             mutated_nodes = [input_nodes[i] for i in mutated_inputs]
+            mutated_input_indices = tuple(
+                tensor_placeholder_indices[i] for i in mutated_inputs
+            )
             msg = f"Input mutation detected at {mutated_nodes}"
-            return MutationInfo(True, msg)
+            return MutationInfo(True, msg, mutated_input_indices)
 
-        return MutationInfo(False, "")
+        return MutationInfo(False, "", ())
 
     def has_aliasing(self) -> AliasingInfo:
         from torch._dynamo.variables.higher_order_ops import get_tensor_storages

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -835,8 +835,8 @@ def _call_while_loop(
         source_target=self.value,
         set_subgraph_inputs="flatten_manual",
         should_flatten_outputs=True,
-        supports_input_mutation=False,
-        supports_aliasing=False,
+        supports_input_mutation=self.supports_input_mutation,
+        supports_aliasing=self.supports_aliasing,
         remove_consts_from_outputs=False,
     )
     validate_subgraph_output_types(body_r)
@@ -2527,8 +2527,8 @@ def validate_subgraph_output_types(
 class WhileLoopHigherOrderVariable(TorchHigherOrderOperatorVariable):
     _HOP_NAME = "torch.while_loop"
     _ALLOW_FALLBACK_TO_EAGER = False
-    supports_input_mutation = False
-    supports_aliasing = False
+    supports_input_mutation = True
+    supports_aliasing = True
 
     def _call_function(
         self,

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -2527,8 +2527,8 @@ def validate_subgraph_output_types(
 class WhileLoopHigherOrderVariable(TorchHigherOrderOperatorVariable):
     _HOP_NAME = "torch.while_loop"
     _ALLOW_FALLBACK_TO_EAGER = False
-    supports_input_mutation = not torch.is_grad_enabled()
-    supports_aliasing = not torch.is_grad_enabled()
+    supports_input_mutation = False
+    supports_aliasing = False
 
     def _call_function(
         self,
@@ -2537,6 +2537,8 @@ class WhileLoopHigherOrderVariable(TorchHigherOrderOperatorVariable):
         kwargs: dict[str, VariableTracker],
     ) -> VariableTracker:
         assert self._HOP_NAME is not None
+        self.supports_input_mutation = not torch.is_grad_enabled()
+        self.supports_aliasing = not torch.is_grad_enabled()
         return _call_while_loop(
             self, tx, args, kwargs, stack_output=False, hop_name=self._HOP_NAME
         )

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -840,6 +840,29 @@ def _call_while_loop(
         remove_consts_from_outputs=False,
     )
     validate_subgraph_output_types(body_r)
+    cond_mutated_inputs = set(getattr(cond_graph, "_dynamo_mutated_input_indices", ()))
+    body_mutated_inputs = set(getattr(body_graph, "_dynamo_mutated_input_indices", ()))
+
+    def _mutated_tensor_storages(
+        graph: torch.fx.Graph, mutated_input_indices: set[int]
+    ) -> set[StorageWeakRef]:
+        placeholders = [node for node in graph.nodes if node.op == "placeholder"]
+        storages: set[StorageWeakRef] = set()
+        for idx in mutated_input_indices:
+            assert idx < len(placeholders), (
+                f"mutated input index {idx} out of range for {len(placeholders)} placeholders"
+            )
+            placeholder = placeholders[idx]
+            example_value = placeholder.meta.get(
+                "example_value", placeholder.meta.get("val", None)
+            )
+            if isinstance(example_value, torch.Tensor):
+                storages |= get_tensor_storages(example_value)
+        return storages
+
+    mutated_input_storages = _mutated_tensor_storages(
+        cond_graph, cond_mutated_inputs
+    ) | _mutated_tensor_storages(body_graph, body_mutated_inputs)
 
     # We set include contiguity=False because we have vmap x HOP tests, where if
     # include_contiguity=True will call t.is_contiguous inside of vmap and get an error
@@ -873,6 +896,33 @@ def _call_while_loop(
     # Note: cond_shared and body_shared refer to the same proxy in parent graph
     # so using either of them is OK. Use cond_shared as it doesn't matter.
     additional_lifted_inputs = cond_shared + cond_unique + body_unique
+    all_while_loop_inputs: list[VariableTracker | Proxy] = (
+        list(operands_seq)
+        + list(additional_inputs_seq)
+        + list(additional_lifted_inputs)
+    )
+    storage_to_while_loop_input_indices: dict[StorageWeakRef, set[int]] = {}
+    for idx, inp in enumerate(all_while_loop_inputs):
+        example_value = None
+        if isinstance(inp, VariableTracker):
+            if inp.is_tensor():
+                example_value = inp.as_proxy().node.meta.get("example_value", None)
+        else:
+            assert isinstance(inp, Proxy)
+            example_value = inp.node.meta.get("example_value", inp.node.meta.get("val"))
+
+        if isinstance(example_value, torch.Tensor):
+            for storage in get_tensor_storages(example_value):
+                storage_to_while_loop_input_indices.setdefault(storage, set()).add(idx)
+
+    mutated_inputs = sorted(
+        {
+            i
+            for storage in mutated_input_storages
+            for i in storage_to_while_loop_input_indices.get(storage, set())
+        }
+    )
+    mutated_arg_indices = ",".join(str(i) for i in mutated_inputs)
 
     body_nn_modules = dict(tx.output.nn_modules)
 
@@ -894,11 +944,16 @@ def _call_while_loop(
         operands_proxy,
         additional_inputs_proxy,
     )
+    hop_kwargs = (
+        {"mutated_arg_indices": mutated_arg_indices}
+        if not stack_output and mutated_arg_indices
+        else {}
+    )
     return _call_function_and_unflatten_output(
         tx,
         self.value,
         p_args,
-        {},
+        hop_kwargs,
         None,
         body_treespec,
         body_r,
@@ -2015,6 +2070,10 @@ def speculate_subgraph(
                     supports_input_mutation,
                     supports_aliasing,
                     source_target,
+                )
+                mutation_info = subtracer.has_input_mutation()
+                graph._dynamo_mutated_input_indices = (
+                    mutation_info.mutated_input_indices
                 )
 
                 return (

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -2538,7 +2538,6 @@ class WhileLoopHigherOrderVariable(TorchHigherOrderOperatorVariable):
     ) -> VariableTracker:
         assert self._HOP_NAME is not None
         self.supports_input_mutation = not torch.is_grad_enabled()
-        self.supports_aliasing = not torch.is_grad_enabled()
         return _call_while_loop(
             self, tx, args, kwargs, stack_output=False, hop_name=self._HOP_NAME
         )

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -2527,8 +2527,8 @@ def validate_subgraph_output_types(
 class WhileLoopHigherOrderVariable(TorchHigherOrderOperatorVariable):
     _HOP_NAME = "torch.while_loop"
     _ALLOW_FALLBACK_TO_EAGER = False
-    supports_input_mutation = True
-    supports_aliasing = True
+    supports_input_mutation = not torch.is_grad_enabled()
+    supports_aliasing = not torch.is_grad_enabled()
 
     def _call_function(
         self,

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -856,8 +856,10 @@ def _call_while_loop(
             example_value = placeholder.meta.get(
                 "example_value", placeholder.meta.get("val", None)
             )
-            if isinstance(example_value, torch.Tensor):
-                storages |= get_tensor_storages(example_value)
+            assert isinstance(example_value, torch.Tensor), (
+                "The mutated input must be a tensor"
+            )
+            storages |= get_tensor_storages(example_value)
         return storages
 
     mutated_input_storages = _mutated_tensor_storages(
@@ -901,7 +903,7 @@ def _call_while_loop(
         + list(additional_inputs_seq)
         + list(additional_lifted_inputs)
     )
-    storage_to_while_loop_input_indices: dict[StorageWeakRef, set[int]] = {}
+    mutated_inputs = []
     for idx, inp in enumerate(all_while_loop_inputs):
         example_value = None
         if isinstance(inp, VariableTracker):
@@ -913,15 +915,10 @@ def _call_while_loop(
 
         if isinstance(example_value, torch.Tensor):
             for storage in get_tensor_storages(example_value):
-                storage_to_while_loop_input_indices.setdefault(storage, set()).add(idx)
+                if storage in mutated_input_storages:
+                    mutated_inputs.append(idx)
+                    break
 
-    mutated_inputs = sorted(
-        {
-            i
-            for storage in mutated_input_storages
-            for i in storage_to_while_loop_input_indices.get(storage, set())
-        }
-    )
     mutated_arg_indices = ",".join(str(i) for i in mutated_inputs)
 
     body_nn_modules = dict(tx.output.nn_modules)
@@ -2072,7 +2069,7 @@ def speculate_subgraph(
                     source_target,
                 )
                 mutation_info = subtracer.has_input_mutation()
-                graph._dynamo_mutated_input_indices = (
+                graph._dynamo_mutated_input_indices = (  # pyrefly: ignore[missing-attribute]
                     mutation_info.mutated_input_indices
                 )
 

--- a/torch/_higher_order_ops/auto_functionalize.py
+++ b/torch/_higher_order_ops/auto_functionalize.py
@@ -618,7 +618,10 @@ class FunctionalCallableWithEpilogue:
             if len(args) == 1 and isinstance(args[0], list):
                 return tuple(functionalized(args[0]))
             return tuple(functionalized(list(args)))
-        return tuple(functionalized(*args, **kwargs))
+        result = functionalized(*args, **kwargs)
+        if isinstance(result, (tuple, list)):
+            return tuple(result)
+        return result
 
     def __hash__(self):
         return id(self.orig_callable)

--- a/torch/_higher_order_ops/auto_functionalize.py
+++ b/torch/_higher_order_ops/auto_functionalize.py
@@ -618,10 +618,7 @@ class FunctionalCallableWithEpilogue:
             if len(args) == 1 and isinstance(args[0], list):
                 return tuple(functionalized(args[0]))
             return tuple(functionalized(list(args)))
-        result = functionalized(*args, **kwargs)
-        if isinstance(result, (tuple, list)):
-            return tuple(result)
-        return result
+        return functionalized(*args, **kwargs)
 
     def __hash__(self):
         return id(self.orig_callable)

--- a/torch/_higher_order_ops/utils.py
+++ b/torch/_higher_order_ops/utils.py
@@ -1037,6 +1037,21 @@ def _tensor_storage(t) -> StorageWeakRef:
     return StorageWeakRef(t._typed_storage())
 
 
+def _get_example_value(n):
+    if not isinstance(n, torch.fx.Node):
+        return n
+    if "val" in n.meta:
+        return n.meta["val"]
+    if "example_value" in n.meta:
+        return n.meta["example_value"]
+    return None
+
+
+def get_graph_output_example_values(gm: torch.fx.GraphModule) -> list[Any]:
+    output_node = gm.graph.find_nodes(op="output")[0]
+    return [_get_example_value(n) for n in pytree.tree_flatten(output_node.args[0])[0]]
+
+
 def check_input_alias_and_mutation_return_outputs(
     gm: torch.fx.GraphModule,
 ) -> tuple[
@@ -1046,24 +1061,12 @@ def check_input_alias_and_mutation_return_outputs(
     list[int],
     tuple[Any, ...] | list[Any],
 ]:
-    def _get_example_value(n):
-        if not isinstance(n, torch.fx.Node):
-            return n
-        if "val" in n.meta:
-            return n.meta["val"]
-        if "example_value" in n.meta:
-            return n.meta["example_value"]
-        return None
-
     fake_args = [
         _get_example_value(n)
         for n in gm.graph.find_nodes(op="placeholder")
         if isinstance(n, torch.fx.Node) and "val" in n.meta
     ]
-    outputs = [
-        _get_example_value(n)
-        for n in pytree.tree_flatten(gm.graph.find_nodes(op="output")[0].args[0])[0]
-    ]
+    outputs = get_graph_output_example_values(gm)
 
     # We need to analyze the original fake_args to detect
     # inp-inp alias.

--- a/torch/_higher_order_ops/while_loop.py
+++ b/torch/_higher_order_ops/while_loop.py
@@ -266,8 +266,6 @@ def while_loop_dense(
     stack_output=False,
     mutated_arg_indices="",
 ):
-    from torch.fx.experimental.proxy_tensor import _CURRENT_MAKE_FX_TRACER
-
     carried_vals = carried_inputs
 
     def _validate_cond_output(pred):
@@ -304,11 +302,6 @@ def while_loop_dense(
             )
 
     outputs: list[list[torch.Tensor]] = [[] for _ in carried_vals]
-    # During make_fx tracing, inputs may contain uninitialized data (from
-    # torch.empty_strided in materialize_as_graph), which can cause infinite
-    # loops. We only need one body iteration to determine output metadata,
-    # so bail out early.
-    is_tracing = _CURRENT_MAKE_FX_TRACER is not None
 
     while should_loop:
         out = body_fn(*carried_vals, *additional_inputs)
@@ -323,8 +316,6 @@ def while_loop_dense(
                 f"body_fn should return the same number of elements as carried_inputs, got {len(out)} vs {len(carried_inputs)}"
             )
         carried_vals = out
-        if is_tracing:
-            break
 
         should_loop = cond_fn(*carried_vals, *additional_inputs)
 

--- a/torch/_higher_order_ops/while_loop.py
+++ b/torch/_higher_order_ops/while_loop.py
@@ -204,7 +204,8 @@ def while_loop(cond_fn, body_fn, carried_inputs):
 
         - body_fn and cond_fn's output cannot alias any of the inputs. A clone is required.
 
-        - body_fn and cond_fn can in-place mutate module buffers during inference.
+        - During inference, body_fn and cond_fn can in-place mutate tensors that are not
+          carried_inputs, such as module buffers and captured tensors from the enclosing scope.
 
     """
 

--- a/torch/_higher_order_ops/while_loop.py
+++ b/torch/_higher_order_ops/while_loop.py
@@ -26,6 +26,15 @@ from torch.fx.experimental.proxy_tensor import (
 )
 
 
+def _is_aten_graph(gm: torch.fx.GraphModule) -> bool:
+    for node in gm.graph.nodes:
+        if node.op == "call_function" and not isinstance(
+            node.target, (torch._ops.OpOverload, torch._ops.HigherOrderOperator)
+        ):
+            return False
+    return True
+
+
 class WhileLoopOp(HigherOrderOperator):
     def __init__(self) -> None:
         super().__init__("while_loop")
@@ -69,6 +78,21 @@ class WhileLoopOp(HigherOrderOperator):
             if isinstance(body_fn, torch.fx.GraphModule)
             else materialize_as_graph(body_fn, all_inputs)
         )
+
+        # cond_gm = materialize_as_graph(cond_fn, all_inputs)
+        # body_gm = materialize_as_graph(body_fn, all_inputs)
+
+        # another try is to skip materialization if the function is already a aten op graph module
+        # def _maybe_materialize(fn, all_inputs):
+        #     if not isinstance(fn, torch.fx.GraphModule):
+        #         return materialize_as_graph(fn, all_inputs)
+        #     if _is_aten_graph(fn):
+        #         return fn
+        #     # return _retrace_as_aten(fn)
+        #     return materialize_as_graph(fn, all_inputs)
+
+        # cond_gm = _maybe_materialize(cond_fn, all_inputs)
+        # body_gm = _maybe_materialize(body_fn, all_inputs)
 
         def _find_example_value(n, real_inp):
             if "val" in n.meta:

--- a/torch/_higher_order_ops/while_loop.py
+++ b/torch/_higher_order_ops/while_loop.py
@@ -83,12 +83,14 @@ class WhileLoopOp(HigherOrderOperator):
 
         cond_gm: torch.fx.GraphModule = (
             cond_fn
-            if isinstance(cond_fn, torch.fx.GraphModule) and not _needs_rematerialization(cond_fn)
+            if isinstance(cond_fn, torch.fx.GraphModule)
+            and not _needs_rematerialization(cond_fn)
             else materialize_as_graph(cond_fn, all_inputs)
         )
         body_gm: torch.fx.GraphModule = (
             body_fn
-            if isinstance(body_fn, torch.fx.GraphModule) and not _needs_rematerialization(body_fn)
+            if isinstance(body_fn, torch.fx.GraphModule)
+            and not _needs_rematerialization(body_fn)
             else materialize_as_graph(body_fn, all_inputs)
         )
 
@@ -270,6 +272,8 @@ def while_loop(cond_fn, body_fn, carried_inputs):
 def while_loop_dense(
     cond_fn, body_fn, carried_inputs, additional_inputs, stack_output=False
 ):
+    from torch.fx.experimental.proxy_tensor import _CURRENT_MAKE_FX_TRACER
+
     carried_vals = carried_inputs
 
     def _validate_cond_output(pred):
@@ -306,6 +310,11 @@ def while_loop_dense(
             )
 
     outputs: list[list[torch.Tensor]] = [[] for _ in carried_vals]
+    # During make_fx tracing, inputs may contain uninitialized data (from
+    # torch.empty_strided in materialize_as_graph), which can cause infinite
+    # loops. We only need one body iteration to determine output metadata,
+    # so bail out early.
+    is_tracing = _CURRENT_MAKE_FX_TRACER is not None
 
     while should_loop:
         out = body_fn(*carried_vals, *additional_inputs)
@@ -320,6 +329,8 @@ def while_loop_dense(
                 f"body_fn should return the same number of elements as carried_inputs, got {len(out)} vs {len(carried_inputs)}"
             )
         carried_vals = out
+        if is_tracing:
+            break
 
         should_loop = cond_fn(*carried_vals, *additional_inputs)
 

--- a/torch/_higher_order_ops/while_loop.py
+++ b/torch/_higher_order_ops/while_loop.py
@@ -6,13 +6,19 @@ from collections.abc import Callable
 import torch
 import torch.utils._pytree as pytree
 from torch._C import DispatchKey
+from torch._higher_order_ops.auto_functionalize import (
+    can_auto_functionalize,
+    do_auto_functionalize_v2,
+)
 from torch._higher_order_ops.utils import (
+    _check_alias_and_mutation,
     _maybe_run_with_interpreter,
     autograd_not_implemented,
     check_input_alias_and_mutation_return_outputs,
     check_meta_consistency,
     fill_none_with_masks,
     filter_with_masks,
+    HopInstance,
     materialize_as_graph,
     reenter_make_fx,
     validate_subgraph_args_types,
@@ -592,12 +598,6 @@ def while_loop_fake_tensor_mode(
 def while_loop_func(
     ctx, cond_fn, body_fn, carried_inputs, additional_inputs, stack_output=False
 ):
-    from torch._higher_order_ops.auto_functionalize import (
-        can_auto_functionalize,
-        do_auto_functionalize_v2,
-    )
-    from torch._higher_order_ops.utils import _check_alias_and_mutation, HopInstance
-
     op = while_loop_stack_output_op if stack_output else while_loop_op
     # For now, we only support auto-functionalization for while_loop when using python
     # functionalization mode

--- a/torch/_higher_order_ops/while_loop.py
+++ b/torch/_higher_order_ops/while_loop.py
@@ -204,11 +204,7 @@ def while_loop(cond_fn, body_fn, carried_inputs):
 
         - body_fn and cond_fn's output cannot alias any of the inputs. A clone is required.
 
-    .. warning::
-
-        Temporal Limitations:
-
-        - 'while_loop' only supports **inference** right now. Autograd will be supported in the future.
+        - body_fn and cond_fn can in-place mutate module buffers during inference.
 
     """
 

--- a/torch/_higher_order_ops/while_loop.py
+++ b/torch/_higher_order_ops/while_loop.py
@@ -26,15 +26,6 @@ from torch.fx.experimental.proxy_tensor import (
 )
 
 
-def _is_aten_graph(gm: torch.fx.GraphModule) -> bool:
-    for node in gm.graph.nodes:
-        if node.op == "call_function" and not isinstance(
-            node.target, (torch._ops.OpOverload, torch._ops.HigherOrderOperator)
-        ):
-            return False
-    return True
-
-
 class WhileLoopOp(HigherOrderOperator):
     def __init__(self) -> None:
         super().__init__("while_loop")

--- a/torch/_higher_order_ops/while_loop.py
+++ b/torch/_higher_order_ops/while_loop.py
@@ -68,43 +68,29 @@ class WhileLoopOp(HigherOrderOperator):
 
         all_inputs = carried_inputs + additional_inputs
 
+        def _needs_rematerialization(fn):
+            """Check if a GraphModule needs re-tracing to detect mutations.
+
+            check_input_alias_and_mutation_return_outputs only detects mutations
+            via call_function nodes targeting OpOverloads with is_write args.
+            Dynamo-level graphs may express mutations as call_method nodes
+            (e.g. tensor.add_()) which would be missed. Re-materialize to get
+            an ATen-level graph where all mutations are OpOverload calls.
+            """
+            if not isinstance(fn, torch.fx.GraphModule):
+                return True
+            return any(node.op == "call_method" for node in fn.graph.nodes)
+
         cond_gm: torch.fx.GraphModule = (
             cond_fn
-            if isinstance(cond_fn, torch.fx.GraphModule)
+            if isinstance(cond_fn, torch.fx.GraphModule) and not _needs_rematerialization(cond_fn)
             else materialize_as_graph(cond_fn, all_inputs)
         )
         body_gm: torch.fx.GraphModule = (
             body_fn
-            if isinstance(body_fn, torch.fx.GraphModule)
+            if isinstance(body_fn, torch.fx.GraphModule) and not _needs_rematerialization(body_fn)
             else materialize_as_graph(body_fn, all_inputs)
         )
-
-        # cond_gm = materialize_as_graph(cond_fn, all_inputs)
-        # body_gm = materialize_as_graph(body_fn, all_inputs)
-
-        # another try is to skip materialization if the function is already a aten op graph module
-        # def _maybe_materialize(fn, all_inputs):
-        #     if not isinstance(fn, torch.fx.GraphModule):
-        #         return materialize_as_graph(fn, all_inputs)
-        #     if _is_aten_graph(fn):
-        #         return fn
-        #     # return _retrace_as_aten(fn)
-        #     return materialize_as_graph(fn, all_inputs)
-
-        # cond_gm = _maybe_materialize(cond_fn, all_inputs)
-        # body_gm = _maybe_materialize(body_fn, all_inputs)
-
-        def _find_example_value(n, real_inp):
-            if "val" in n.meta:
-                return n.meta["val"]
-            elif "example_value" in n.meta:
-                return n.meta["example_value"]
-            else:
-                if isinstance(real_inp, torch.Tensor):
-                    raise AssertionError(
-                        "expected non-Tensor real_inp when no val/example_value in meta, got Tensor"
-                    )
-                return real_inp
 
         (
             _,

--- a/torch/_higher_order_ops/while_loop.py
+++ b/torch/_higher_order_ops/while_loop.py
@@ -14,10 +14,10 @@ from torch._higher_order_ops.utils import (
     _check_alias_and_mutation,
     _maybe_run_with_interpreter,
     autograd_not_implemented,
-    check_input_alias_and_mutation_return_outputs,
     check_meta_consistency,
     fill_none_with_masks,
     filter_with_masks,
+    get_graph_output_example_values,
     HopInstance,
     materialize_as_graph,
     reenter_make_fx,
@@ -43,6 +43,8 @@ class WhileLoopOp(HigherOrderOperator):
         carried_inputs: tuple[torch.Tensor | int | float | bool],
         additional_inputs: tuple[torch.Tensor | torch.SymInt | int, ...],
         /,
+        *,
+        mutated_arg_indices: str = "",
     ):
         if not isinstance(carried_inputs, (tuple, list)):
             raise RuntimeError(
@@ -55,59 +57,49 @@ class WhileLoopOp(HigherOrderOperator):
 
         validate_subgraph_args_types(carried_inputs)
         validate_subgraph_args_types(additional_inputs)
+        kwargs = {}
+        if mutated_arg_indices:
+            kwargs["mutated_arg_indices"] = mutated_arg_indices
         # pyrefly: ignore [missing-attribute]
-        return super().__call__(cond_fn, body_fn, carried_inputs, additional_inputs)
+        return super().__call__(
+            cond_fn,
+            body_fn,
+            carried_inputs,
+            additional_inputs,
+            **kwargs,
+        )
 
     # pyrefly: ignore [bad-override]
-    def gen_schema(self, cond_fn, body_fn, carried_inputs, additional_inputs):
+    def gen_schema(
+        self,
+        cond_fn,
+        body_fn,
+        carried_inputs,
+        additional_inputs,
+        mutated_arg_indices="",
+    ):
         from torch._higher_order_ops.schema import HopSchemaGenerator
         from torch._higher_order_ops.utils import materialize_as_graph
 
         all_inputs = carried_inputs + additional_inputs
 
-        def _needs_rematerialization(fn):
-            """Check if a GraphModule needs re-tracing to detect mutations.
-
-            check_input_alias_and_mutation_return_outputs only detects mutations
-            via call_function nodes targeting OpOverloads with is_write args.
-            Dynamo-level graphs may express mutations as call_method nodes
-            (e.g. tensor.add_()) which would be missed. Re-materialize to get
-            an ATen-level graph where all mutations are OpOverload calls.
-            """
-            if not isinstance(fn, torch.fx.GraphModule):
-                return True
-            return any(node.op == "call_method" for node in fn.graph.nodes)
-
         cond_gm: torch.fx.GraphModule = (
             cond_fn
             if isinstance(cond_fn, torch.fx.GraphModule)
-            and not _needs_rematerialization(cond_fn)
             else materialize_as_graph(cond_fn, all_inputs)
         )
         body_gm: torch.fx.GraphModule = (
             body_fn
             if isinstance(body_fn, torch.fx.GraphModule)
-            and not _needs_rematerialization(body_fn)
             else materialize_as_graph(body_fn, all_inputs)
         )
 
-        (
-            _,
-            _,
-            _,
-            body_mutated_inputs,
-            body_outputs,
-        ) = check_input_alias_and_mutation_return_outputs(body_gm)
-
-        (
-            _,
-            _,
-            _,
-            cond_mutated_inputs,
-            _,
-        ) = check_input_alias_and_mutation_return_outputs(cond_gm)
-
-        mutated_inputs = set(body_mutated_inputs) | set(cond_mutated_inputs)
+        body_outputs = get_graph_output_example_values(body_gm)
+        mutated_inputs = (
+            {int(i) for i in mutated_arg_indices.split(",") if i}
+            if mutated_arg_indices
+            else set()
+        )
 
         schema_gen = HopSchemaGenerator(self)
         schema_gen.add_arg("cond_fn", cond_gm)
@@ -130,7 +122,10 @@ class WhileLoopOp(HigherOrderOperator):
             schema_gen.add_output(out)
 
         schema_gen.add_schema_tree_spec(
-            cond_fn, body_fn, carried_inputs, additional_inputs
+            cond_fn,
+            body_fn,
+            carried_inputs,
+            additional_inputs,
         )
         return schema_gen.gen_schema()
 
@@ -264,7 +259,12 @@ def while_loop(cond_fn, body_fn, carried_inputs):
 
 @while_loop_op.py_impl(DispatchKey.CompositeExplicitAutograd)
 def while_loop_dense(
-    cond_fn, body_fn, carried_inputs, additional_inputs, stack_output=False
+    cond_fn,
+    body_fn,
+    carried_inputs,
+    additional_inputs,
+    stack_output=False,
+    mutated_arg_indices="",
 ):
     from torch.fx.experimental.proxy_tensor import _CURRENT_MAKE_FX_TRACER
 
@@ -338,7 +338,9 @@ def while_loop_dense(
 
 
 @while_loop_op.py_autograd_impl
-def while_loop_autograd(cond_fn, body_fn, operands, additional_inputs):
+def while_loop_autograd(
+    cond_fn, body_fn, operands, additional_inputs, mutated_arg_indices=""
+):
     return WhileLoopAutogradOp.apply(
         cond_fn,
         body_fn,
@@ -381,11 +383,18 @@ def while_loop_tracing(
     carried_inputs,
     additional_inputs,
     stack_output=False,
+    mutated_arg_indices="",
 ):
     op = while_loop_stack_output_op if stack_output else while_loop_op
 
     def _trace_while_loop(
-        proxy_mode, op, cond_fn, body_fn, carried_inputs, additional_inputs
+        proxy_mode,
+        op,
+        cond_fn,
+        body_fn,
+        carried_inputs,
+        additional_inputs,
+        mutated_arg_indices,
     ):
         # NOTE [unspecialize int carry with unbacked symints]
         # When we support int carry, we'll also need to support int output of body_fn because.
@@ -485,16 +494,17 @@ def while_loop_tracing(
         proxy_mode.tracer.root.register_module(body_graph_name, body_graph)
 
         args = (cond_graph, body_graph, carried_inputs, additional_inputs)
+        kwargs = {}
+        if not stack_output and mutated_arg_indices:
+            kwargs["mutated_arg_indices"] = mutated_arg_indices
 
         proxy_args = pytree.tree_map(proxy_mode.tracer.unwrap_proxy, args)
 
         out_proxy = proxy_mode.tracer.create_proxy(
-            "call_function", op, proxy_args, {}, name=op._name
+            "call_function", op, proxy_args, kwargs, name=op._name
         )
 
-        out = op(
-            cond_graph, body_graph, unspecialized_carried_inputs, additional_inputs
-        )
+        out = op(*args, **kwargs)
         return track_tensor_tree(
             out, out_proxy, constant=None, tracer=proxy_mode.tracer
         )
@@ -506,12 +516,19 @@ def while_loop_tracing(
         body_fn,
         carried_inputs,
         additional_inputs,
+        mutated_arg_indices,
     )
 
 
 @while_loop_op.py_impl(FakeTensorMode)
 def while_loop_fake_tensor_mode(
-    mode, cond_fn, body_fn, carried_inputs, additional_inputs, stack_output=False
+    mode,
+    cond_fn,
+    body_fn,
+    carried_inputs,
+    additional_inputs,
+    stack_output=False,
+    mutated_arg_indices="",
 ):
     with mode:
         # NOTE: [Handling unback symints in subgraph of while_loop]
@@ -593,14 +610,25 @@ def while_loop_fake_tensor_mode(
 
 @while_loop_op.py_functionalize_impl
 def while_loop_func(
-    ctx, cond_fn, body_fn, carried_inputs, additional_inputs, stack_output=False
+    ctx,
+    cond_fn,
+    body_fn,
+    carried_inputs,
+    additional_inputs,
+    stack_output=False,
+    mutated_arg_indices="",
 ):
     op = while_loop_stack_output_op if stack_output else while_loop_op
     # For now, we only support auto-functionalization for while_loop when using python
     # functionalization mode
     if not stack_output and hasattr(ctx, "mode"):
         hop_instance = HopInstance.create(
-            op, cond_fn, body_fn, carried_inputs, additional_inputs
+            op,
+            cond_fn,
+            body_fn,
+            carried_inputs,
+            additional_inputs,
+            mutated_arg_indices=mutated_arg_indices,
         )
         if can_auto_functionalize(hop_instance):
             return do_auto_functionalize_v2(
@@ -626,11 +654,15 @@ def while_loop_func(
             (body_fn, "body_fn"),
         ]:
             _check_alias_and_mutation(fn, unwrapped_inputs, fn_name, pre_dispatch)
+        op_kwargs = {}
+        if not stack_output and mutated_arg_indices:
+            op_kwargs["mutated_arg_indices"] = mutated_arg_indices
         ret = op(
             functional_cond_fn,
             functional_body_fn,
             unwrapped_carried_inputs,
             unwrapped_additional_inputs,
+            **op_kwargs,
         )
         return ctx.wrap_tensors(ret)
 

--- a/torch/_higher_order_ops/while_loop.py
+++ b/torch/_higher_order_ops/while_loop.py
@@ -495,7 +495,13 @@ def while_loop_tracing(
             "call_function", op, proxy_args, kwargs, name=op._name
         )
 
-        out = op(*args, **kwargs)
+        out = op(
+            cond_graph,
+            body_graph,
+            unspecialized_carried_inputs,
+            additional_inputs,
+            **kwargs,
+        )
         return track_tensor_tree(
             out, out_proxy, constant=None, tracer=proxy_mode.tracer
         )


### PR DESCRIPTION
As a subtask of [issue](https://github.com/pytorch/pytorch/issues/172568)

Input Mutation Support for while_loop
Context: Input mutation allows the operator's subgraphs to mutate tensors passed as inputs, which is important for memory efficiency and compatibility with existing code patterns.

This PR revived the PR https://github.com/pytorch/pytorch/pull/159010, and fixed to make it work on the current main.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98