### PR TITLE
[ci] Add --compilation-config support to vLLM benchmark workflow

### DIFF
--- a/.github/workflows/_vllm-benchmark.yml
+++ b/.github/workflows/_vllm-benchmark.yml
@@ -28,6 +28,11 @@ on:
         type: string
         description: The list of models to benchmark. Default to all models.
         default: ''
+      compilation_config:
+        required: false
+        type: string
+        description: A JSON string for vLLM --compilation-config, applied to all benchmark tests.
+        default: ''
 
 jobs:
   benchmark:
@@ -163,6 +168,7 @@ jobs:
       - name: Setup benchmark tests
         env:
           MODELS: ${{ inputs.models }}
+          COMPILATION_CONFIG: ${{ inputs.compilation_config }}
         shell: bash
         run: |
           set -eux
@@ -178,7 +184,8 @@ jobs:
             --to-benchmark-configs-dir ../../vllm-project/vllm/.buildkite/performance-benchmarks/tests \
             --models "${MODELS}" \
             --device "${DEVICE_NAME}" \
-            --include-eager-mode
+            --include-eager-mode \
+            --compilation-config "${COMPILATION_CONFIG}"
           popd
 
           pushd vllm-project/vllm

--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -20,6 +20,12 @@ on:
         required: false
         type: string
         default: ''
+      compilation_config:
+        description: |
+          A JSON string for vLLM --compilation-config, applied to all benchmark tests, e.g. '{"cudagraph_mode": "PIECEWISE", "use_inductor_graph_partition": true}'
+        required: false
+        type: string
+        default: ''
       runners:
         description: |
           A comma-separated list of runners from .github/scripts/generate_vllm_benchmark_matrix.py to run the benchmark (optional, default to run everything)
@@ -120,4 +126,5 @@ jobs:
       pytorch_branch: ${{ inputs.pytorch_branch }}
       pytorch_commit: ${{ inputs.pytorch_commit }}
       models: ${{ matrix.models }}
+      compilation_config: ${{ inputs.compilation_config }}
     secrets: inherit

--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -22,7 +22,7 @@ on:
         default: ''
       compilation_config:
         description: |
-          A JSON string for vLLM --compilation-config, applied to all benchmark tests, e.g. '{"cudagraph_mode": "PIECEWISE", "use_inductor_graph_partition": true}'
+          A JSON string for vLLM --compilation-config, applied to all benchmark tests, e.g. {"cudagraph_mode": "PIECEWISE", "use_inductor_graph_partition": true}
         required: false
         type: string
         default: ''


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #175976

Summary: Add a compilation_config input to the vLLM benchmark workflows that
passes through to setup_vllm_benchmark.py's new --compilation-config
argument.

Authored with Claude.