### PR TITLE
[Dynamo] Add more overloads to `istype`

### DIFF
--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -2124,7 +2124,7 @@ class InstructionTranslatorBase(
 
         # pyrefly: ignore [unbound-name]
         if istype(value, (types.ModuleType, DummyModule)):
-            # pyrefly: ignore [unbound-name]
+            # pyrefly: ignore [unbound-name, bad-argument-type]
             self.push(PythonModuleVariable(value, source=source))
         else:
             unimplemented(

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -162,6 +162,14 @@ except ImportError:
 T = TypeVar("T")
 T1 = TypeVar("T1")
 T2 = TypeVar("T2")
+T3 = TypeVar("T3")
+T4 = TypeVar("T4")
+T5 = TypeVar("T5")
+T6 = TypeVar("T6")
+T7 = TypeVar("T7")
+T8 = TypeVar("T8")
+T9 = TypeVar("T9")
+T10 = TypeVar("T10")
 R = TypeVar("R")
 _P = ParamSpec("_P")
 
@@ -1094,18 +1102,95 @@ def istype(
 ) -> TypeIs[T]: ...
 
 
+# This can be simplified once TypeVarTuple objects can be expanded into TypeIs.
 @overload
-def istype(obj: object, allowed_types: tuple[type[T], type[T1]]) -> TypeIs[T | T1]: ...
+def istype(
+    obj: object, allowed_types: tuple[type[T1], type[T2]]
+) -> TypeIs[T1 | T2]: ...
 
 
 @overload
 def istype(
-    obj: object, allowed_types: tuple[type[T], type[T1], type[T2]]
-) -> TypeIs[T | T1 | T2]: ...
+    obj: object, allowed_types: tuple[type[T1], type[T2], type[T3]]
+) -> TypeIs[T1 | T2 | T3]: ...
 
 
 @overload
-def istype(obj: object, allowed_types: Iterable[type]) -> bool: ...
+def istype(
+    obj: object, allowed_types: tuple[type[T1], type[T2], type[T3], type[T4]]
+) -> TypeIs[T1 | T2 | T3 | T4]: ...
+
+
+@overload
+def istype(
+    obj: object, allowed_types: tuple[type[T1], type[T2], type[T3], type[T4], type[T5]]
+) -> TypeIs[T1 | T2 | T3 | T4 | T5]: ...
+
+
+@overload
+def istype(
+    obj: object,
+    allowed_types: tuple[type[T1], type[T2], type[T3], type[T4], type[T5], type[T6]],
+) -> TypeIs[T1 | T2 | T3 | T4 | T5 | T6]: ...
+
+
+@overload
+def istype(
+    obj: object,
+    allowed_types: tuple[
+        type[T1], type[T2], type[T3], type[T4], type[T5], type[T6], type[T7]
+    ],
+) -> TypeIs[T1 | T2 | T3 | T4 | T5 | T6 | T7]: ...
+
+
+@overload
+def istype(
+    obj: object,
+    allowed_types: tuple[
+        type[T1], type[T2], type[T3], type[T4], type[T5], type[T6], type[T7], type[T8]
+    ],
+) -> TypeIs[T1 | T2 | T3 | T4 | T5 | T6 | T7 | T8]: ...
+
+
+@overload
+def istype(
+    obj: object,
+    allowed_types: tuple[
+        type[T1],
+        type[T2],
+        type[T3],
+        type[T4],
+        type[T5],
+        type[T6],
+        type[T7],
+        type[T8],
+        type[T9],
+    ],
+) -> TypeIs[T1 | T2 | T3 | T4 | T5 | T6 | T7 | T8 | T9]: ...
+
+
+@overload
+def istype(
+    obj: object,
+    allowed_types: tuple[
+        type[T1],
+        type[T2],
+        type[T3],
+        type[T4],
+        type[T5],
+        type[T6],
+        type[T7],
+        type[T8],
+        type[T9],
+        type[T10],
+    ],
+) -> TypeIs[T1 | T2 | T3 | T4 | T5 | T6 | T7 | T8 | T9 | T10]: ...
+
+
+@overload
+def istype(
+    obj: object, allowed_types: tuple[type, ...] | list[type] | set[type]
+) -> bool: ...
 
 
 def istype(obj: object, allowed_types: Any) -> bool:

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -160,6 +160,8 @@ except ImportError:
 
 
 T = TypeVar("T")
+T1 = TypeVar("T1")
+T2 = TypeVar("T2")
 R = TypeVar("R")
 _P = ParamSpec("_P")
 
@@ -1090,6 +1092,16 @@ def istype(obj: object, allowed_types: type[T]) -> TypeIs[T]: ...
 def istype(
     obj: object, allowed_types: tuple[type[list[T]], type[tuple[T, ...]]]
 ) -> TypeIs[T]: ...
+
+
+@overload
+def istype(obj: object, allowed_types: tuple[type[T], type[T1]]) -> TypeIs[T | T1]: ...
+
+
+@overload
+def istype(
+    obj: object, allowed_types: tuple[type[T], type[T1], type[T2]]
+) -> TypeIs[T | T1 | T2]: ...
 
 
 @overload


### PR DESCRIPTION
The current overloads for `istype` don't help pyrefly narrow types when it is invoked with a tuple of types. Here is a test case:

```
import torch
from torch._dynamo.utils import istype
from typing import reveal_type

def f(x: object) -> None:
    if istype(x, (int, float, str)):
        reveal_type(x)
```

This currently reveals just `object`. Adding overloads for 2- and 3-element tuples (which are pretty common) makes the revealed type `float | int | str`.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo