### PR TITLE
AtomicFPOps for bfloat16 and half should read 2 bytes only.

### DIFF
--- a/aten/src/ATen/cuda/Atomic.cuh
+++ b/aten/src/ATen/cuda/Atomic.cuh
@@ -19,9 +19,15 @@ struct AtomicFPOp<at::Half> {
   inline __device__ at::Half operator() (at::Half *address, at::Half val, const func_t& func) {
     unsigned int * address_as_ui =
       (unsigned int *) ((char *)address - ((size_t)address & 2));
-    unsigned int old = *address_as_ui;
-    unsigned int assumed;
 
+    // read 2 bytes only in case this is the last element of an array.
+    unsigned short target_val = *reinterpret_cast<unsigned short*>(address);
+
+    unsigned int old = ((size_t)address & 2)
+        ? (static_cast<unsigned int>(target_val) << 16)
+        : static_cast<unsigned int>(target_val);
+
+    unsigned int assumed;
     at::Half hsum;
     do {
       assumed = old;
@@ -41,9 +47,15 @@ struct AtomicFPOp<at::BFloat16> {
   inline __device__ at::BFloat16 operator() (at::BFloat16 *address, at::BFloat16 val, const func_t& func) {
     unsigned int * address_as_ui =
       (unsigned int *) ((char *)address - ((size_t)address & 2));
-    unsigned int old = *address_as_ui;
-    unsigned int assumed;
 
+    // read 2 bytes only in case this is the last element of an array.
+    unsigned short target_val = *reinterpret_cast<unsigned short*>(address);
+
+    unsigned int old = ((size_t)address & 2)
+        ? (static_cast<unsigned int>(target_val) << 16)
+        : static_cast<unsigned int>(target_val);
+
+    unsigned int assumed;
     at::BFloat16 bsum;
     do {
       assumed = old;


### PR DESCRIPTION
This patch prevents AtomicFOOps () operator to read 4 bytes instead of 2. This issue was caught with GPU asan support on AMDGPUs, specifically when running test_torch.py test_index_add_bfloat16. This test results in an AtomicFPOp on the last element of the array, which is aligned to a 4-byte boundary: we read and apply an atomic on 4 bytes starting from that last element, i.e. we go out-of-bound by 2 bytes. It was not detected as a memory error because the array is usually part of a larger allocation and the atomic rewrites the same value for the second 2 bytes. Under asan the read of 4 bytes triggers an access to the red zone, which is reported. When that is fixed, the atomic still reads and writes out-of-bound. However, in AMDGPUs, the asan check is inserted early in the compilation process, when the atomic is still operating over 2 bytes. Later, in code generation, the 2 bytes atomicCAS is lowered to a 4 bytes atomicCAS (as that's the smallest available in gfx942), but the asan check preceding it is not changed.
The result is that asan cannot catch the out-of-bound error but it is still present.

AI tools were used to assist debugging and problem resolution.