### PR TITLE
[TEST][cuBLAS][CUDA graphs] fix `test_repeat_graph_capture_cublas_workspace_memory`

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -2469,7 +2469,6 @@ exit(2)
         free_bytes_after, _ = torch.cuda.mem_get_info()
         used_gb_after = (total_bytes - free_bytes_after) / 1e9
 
-        self.assertFalse(used_gb_before + 0.1 < used_gb_after)
         self.assertGreater(0.005 + used_gb_before, used_gb_after)
 
     @unittest.skipIf(


### PR DESCRIPTION
Fix for this failing if run as a standalone test, I'm guessing perhaps because the very first graph capture initializes some extra state that bumps device memory usage which this test tracks to monitor total device memory usage. 

However the spirit of the test is to check for explicit leaks in device memory with a large number of graph captures, so I think it is acceptable to check for increases in memory usage after we know at least _one_ graph capture has happened. That would also explain why it doesn't seem to fail when run in the full suite of tests. Initializing the _before_ after one capture also helps us avoid gymnastics around the capture being on a different stream from the warmup, which would also inflate the peak memory usage between warmup and the first capture (as workspaces are stream-specific).

cc @ptrblck @msaroufim @jerryzh168 @tinglvv @nWEIdia @csarofeen @xwang233 @mcarilli @ezyang @eellison @penguinwu @BoyuanFeng