### PR TITLE
Fix numerical inconsistency in Conv3d.reset_parameters for channels_l…

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -7643,18 +7643,18 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
     def test_conv3d_initialization_consistency(self):
         # 1. Create a Conv3d layer
         m = torch.nn.Conv3d(3, 6, kernel_size=3)
-        
+
         # 2. Test initialization in default (contiguous) format
         torch.manual_seed(42)
         m.reset_parameters()
         weights_default = m.weight.clone().detach()
-        
+
         # 3. Test initialization in channels_last_3d format
         m.to(memory_format=torch.channels_last_3d)
         torch.manual_seed(42)
         m.reset_parameters()
         weights_channels_last = m.weight.clone().detach()
-        
+
         # 4. Verify both initializations are identical
         self.assertEqual(
             weights_default,

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -7654,9 +7654,13 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         torch.manual_seed(42)
         m.reset_parameters()
         weights_channels_last = m.weight.clone().detach()
+        
         # 4. Verify both initializations are identical
-        self.assertEqual(weights_default, weights_channels_last,msg="Conv3d initialization is inconsistent between memory formats")
-
+        self.assertEqual(
+            weights_default,
+            weights_channels_last,
+            msg="Conv3d initialization is inconsistent between memory formats"
+        )
 class TestFusionEval(TestCase):
     @set_default_dtype(torch.double)
     @given(X=hu.tensor(shapes=((5, 3, 5, 5),), dtype=np.double),

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -7640,6 +7640,25 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         ]:
             test_rnn_cell(cell_fn, gate_count)
 
+    def test_conv3d_initialization_consistency(self):
+        # 1. Create a Conv3d layer
+        m = torch.nn.Conv3d(3, 6, kernel_size=3)
+        
+        # 2. Test initialization in default (contiguous) format
+        torch.manual_seed(42)
+        m.reset_parameters()
+        weights_default = m.weight.clone().detach()
+        
+        # 3. Test initialization in channels_last_3d format
+        m.to(memory_format=torch.channels_last_3d)
+        torch.manual_seed(42)
+        m.reset_parameters()
+        weights_channels_last = m.weight.clone().detach()
+        
+        # 4. Verify both initializations are identical
+        self.assertEqual(weights_default, weights_channels_last, 
+                         msg="Conv3d initialization is inconsistent between memory formats")
+
 class TestFusionEval(TestCase):
     @set_default_dtype(torch.double)
     @given(X=hu.tensor(shapes=((5, 3, 5, 5),), dtype=np.double),

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -7654,10 +7654,8 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         torch.manual_seed(42)
         m.reset_parameters()
         weights_channels_last = m.weight.clone().detach()
-        
         # 4. Verify both initializations are identical
-        self.assertEqual(weights_default, weights_channels_last, 
-                         msg="Conv3d initialization is inconsistent between memory formats")
+        self.assertEqual(weights_default, weights_channels_last,msg="Conv3d initialization is inconsistent between memory formats")
 
 class TestFusionEval(TestCase):
     @set_default_dtype(torch.double)

--- a/torch/nn/modules/conv.py
+++ b/torch/nn/modules/conv.py
@@ -179,26 +179,16 @@ class _ConvNd(Module):
 
         self.reset_parameters()
 
-    """def reset_parameters(self) -> None:
-        # Setting a=sqrt(5) in kaiming_uniform is the same as initializing with
-        # uniform(-1/sqrt(k), 1/sqrt(k)), where k = weight.size(1) * prod(*kernel_size)
-        # For more details see: https://github.com/pytorch/pytorch/issues/15314#issuecomment-477448573
-        init.kaiming_uniform_(self.weight, a=math.sqrt(5))
-        if self.bias is not None:
-            fan_in, _ = init._calculate_fan_in_and_fan_out(self.weight)
-            if fan_in != 0:
-                bound = 1 / math.sqrt(fan_in)
-                init.uniform_(self.bias, -bound, bound)"""
     def reset_parameters(self) -> None:
         # Use torch.no_grad() to allow in-place modification of weights/bias
         with torch.no_grad():
             # Check if the weight tensor is in channels_last_3d format to ensure numerical consistency
-            if self.weight.is_contiguous(memory_format=torch.channels_last_3d):
-                # Create a temporary contiguous copy to ensure the RNG populates values in a layout-agnostic way
-                temp_weight = self.weight.contiguous() 
+            if not self.weight.is_contiguous():
+                # Use an empty contiguous buffer to optimize memory and ensure consistent initialization
+                temp_weight = torch.empty_like(self.weight).contiguous() 
                 init.kaiming_uniform_(temp_weight, a=math.sqrt(5))
-                # Copy the initialized values back to the original tensor while maintaining the memory format
-                self.weight.copy_(temp_weight.to(memory_format=torch.channels_last_3d))
+                # Copy the initialized values back to the original tensor
+                self.weight.copy_(temp_weight)
             else:
                 # Standard initialization for default contiguous memory format
                 init.kaiming_uniform_(self.weight, a=math.sqrt(5))

--- a/torch/nn/modules/conv.py
+++ b/torch/nn/modules/conv.py
@@ -186,7 +186,7 @@ class _ConvNd(Module):
             if not self.weight.is_contiguous():
                 # Use an empty contiguous buffer to optimize memory and ensure consistent initialization
                 temp_weight = torch.empty_like(
-                    self.weight, memory_format=torch.contiguous_format
+                    self.weight, memory_format = torch.contiguous_format
                 )
                 init.kaiming_uniform_(temp_weight, a=math.sqrt(5))
                 # Copy the initialized values back to the original tensor

--- a/torch/nn/modules/conv.py
+++ b/torch/nn/modules/conv.py
@@ -185,7 +185,9 @@ class _ConvNd(Module):
             # Check if the weight tensor is in channels_last_3d format to ensure numerical consistency
             if not self.weight.is_contiguous():
                 # Use an empty contiguous buffer to optimize memory and ensure consistent initialization
-                temp_weight = torch.empty_like(self.weight, memory_format=torch.contiguous_format)
+                temp_weight = torch.empty_like(
+                    self.weight, memory_format=torch.contiguous_format
+                )
                 init.kaiming_uniform_(temp_weight, a=math.sqrt(5))
                 # Copy the initialized values back to the original tensor
                 self.weight.copy_(temp_weight)

--- a/torch/nn/modules/conv.py
+++ b/torch/nn/modules/conv.py
@@ -194,7 +194,6 @@ class _ConvNd(Module):
             else:
                 # Standard initialization for default contiguous memory format
                 init.kaiming_uniform_(self.weight, a=math.sqrt(5))
-                
             if self.bias is not None:
                 # Bias initialization remains independent of weight memory format
                 fan_in, _ = init._calculate_fan_in_and_fan_out(self.weight)

--- a/torch/nn/modules/conv.py
+++ b/torch/nn/modules/conv.py
@@ -185,7 +185,7 @@ class _ConvNd(Module):
             # Check if the weight tensor is in channels_last_3d format to ensure numerical consistency
             if not self.weight.is_contiguous():
                 # Use an empty contiguous buffer to optimize memory and ensure consistent initialization
-                temp_weight = torch.empty_like(self.weight).contiguous() 
+                temp_weight = torch.empty_like(self.weight, memory_format=torch.contiguous_format)
                 init.kaiming_uniform_(temp_weight, a=math.sqrt(5))
                 # Copy the initialized values back to the original tensor
                 self.weight.copy_(temp_weight)

--- a/torch/nn/modules/conv.py
+++ b/torch/nn/modules/conv.py
@@ -186,7 +186,7 @@ class _ConvNd(Module):
             if not self.weight.is_contiguous():
                 # Use an empty contiguous buffer to optimize memory and ensure consistent initialization
                 temp_weight = torch.empty_like(
-                    self.weight, memory_format = torch.contiguous_format
+                    self.weight, memory_format=torch.contiguous_format
                 )
                 init.kaiming_uniform_(temp_weight, a=math.sqrt(5))
                 # Copy the initialized values back to the original tensor


### PR DESCRIPTION
Ensured that initialization results are identical across memory formats by using a temporary contiguous tensor and torch.no_grad() for in-place updates. Fixes #175982.