### PR TITLE
[aot_inductor] Add clang_bracket_depth config for minimal arrayref interface

### DIFF
--- a/test/inductor/test_compile.py
+++ b/test/inductor/test_compile.py
@@ -230,6 +230,21 @@ class TestStandaloneInductor(TestCase):
         else:
             check_linux_debug_section(binary_path)
 
+    def test_clang_bracket_depth_flag(self):
+        from torch._inductor.cpp_builder import _get_optimization_cflags, _is_clang, get_cpp_compiler
+
+        compiler = get_cpp_compiler()
+        if not _is_clang(compiler):
+            self.skipTest("clang_bracket_depth only applies to Clang")
+
+        with torch._inductor.config.patch({"aot_inductor.clang_bracket_depth": 1024}):
+            cflags, _ = _get_optimization_cflags(compiler)
+            self.assertIn("fbracket-depth=1024", cflags)
+
+        with torch._inductor.config.patch({"aot_inductor.clang_bracket_depth": 0}):
+            cflags, _ = _get_optimization_cflags(compiler)
+            self.assertTrue(all("fbracket-depth" not in f for f in cflags))
+
 
 if __name__ == "__main__":
     if HAS_CPU:

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1996,6 +1996,11 @@ class aot_inductor:
     # Whether to enable link-time-optimization
     enable_lto = os.environ.get("AOT_INDUCTOR_ENABLE_LTO", "0") == "1"
 
+    # Override Clang's default -fbracket-depth=256 limit. The minimal arrayref
+    # interface generates fold expressions whose nesting depth is proportional
+    # to the number of model inputs. Set to 0 to use the compiler default.
+    clang_bracket_depth: int = 0
+
     # Whether the compiled .so should link to libtorch
     link_libtorch: bool = True
 

--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -936,6 +936,11 @@ def _get_optimization_cflags(
         if config.aot_inductor.enable_lto and _is_clang(cpp_compiler):
             cflags.append("flto=thin")
 
+        if config.aot_inductor.clang_bracket_depth > 0 and _is_clang(cpp_compiler):
+            cflags.append(
+                f"fbracket-depth={config.aot_inductor.clang_bracket_depth}"
+            )
+
     return cflags, ldflags
 
 


### PR DESCRIPTION
Summary:
Add aot_inductor.clang_bracket_depth config that passes -fbracket-depth=N to
the Clang compiler. The minimal arrayref interface generates fold expressions
whose nesting depth is proportional to input count, exceeding Clang's default
-fbracket-depth=256 for models with many inputs.

Test Plan: buck test //caffe2/test/inductor:test_compile -- TestCompile.test_clang_bracket_depth_flag

Reviewed By: helloguo

Differential Revision: D94628821




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo