### PR TITLE
[CUDA] Fix offset_t operators to be __host__ __device__ in SortStable.cu

### DIFF
--- a/aten/src/ATen/native/cuda/SortStable.cu
+++ b/aten/src/ATen/native/cuda/SortStable.cu
@@ -21,11 +21,11 @@ namespace {
 struct offset_t {
   int stride;
   int begin;
-  __device__ int operator[](int i) const {
+  __host__ __device__ int operator[](int i) const {
     return stride * (begin + i);
   }
 #if CCCL_VERSION >= 3001000
-  __device__ offset_t& operator+=(int i) {
+  __host__ __device__ offset_t& operator+=(int i) {
     begin += i;
     return *this;
   }


### PR DESCRIPTION
With CCCL v3.x, CUB's dispatch_radix_sort.cuh calls offset_t::operator[] and offset_t::operator+= from a CUB_RUNTIME_FUNCTION context that is `__host__`.

E.g.
https://github.com/NVIDIA/cccl/blob/4872515b07a7e21c0bdc8b7968d217c34c37857a/cub/cub/device/dispatch/dispatch_radix_sort.cuh#L1425

Context:
https://github.com/pytorch/pytorch/pull/164570#discussion_r2836607781