### PR TITLE
[aot_inductor] Fix proxy executor codegen for minimal arrayref interface

### DIFF
--- a/test/inductor/test_aot_inductor_arrayref.py
+++ b/test/inductor/test_aot_inductor_arrayref.py
@@ -160,8 +160,7 @@ CPU_TEST_FAILURES = {
     "test_while_loop_simple": fail_stack_allocation(is_skip=True),
     "test_while_loop_nested": fail_stack_allocation(is_skip=True),
     "test_while_loop_with_outer_code": fail_stack_allocation(is_skip=True),
-    # TODO: error: cannot convert ArrayRefTensor<float> to AtenTensorHandle
-    "test_while_loop_with_outer_buffers": fail_stack_allocation(is_skip=True),
+    "test_while_loop_with_outer_buffers": fail_stack_allocation(is_skip=False),
     # TODO: use of undeclared identifier 'float8_e4m3fn' and 'half'
     "test_fp8": fail_minimal_arrayref_interface(is_skip=True),
     "test_size_from_multi_output": fail_stack_allocation(is_skip=True),

--- a/test/inductor/test_compile.py
+++ b/test/inductor/test_compile.py
@@ -230,6 +230,21 @@ class TestStandaloneInductor(TestCase):
         else:
             check_linux_debug_section(binary_path)
 
+    def test_clang_bracket_depth_flag(self):
+        from torch._inductor.cpp_builder import _get_optimization_cflags, _is_clang, get_cpp_compiler
+
+        compiler = get_cpp_compiler()
+        if not _is_clang(compiler):
+            self.skipTest("clang_bracket_depth only applies to Clang")
+
+        with torch._inductor.config.patch({"aot_inductor.clang_bracket_depth": 1024}):
+            cflags, _ = _get_optimization_cflags(compiler)
+            self.assertIn("fbracket-depth=1024", cflags)
+
+        with torch._inductor.config.patch({"aot_inductor.clang_bracket_depth": 0}):
+            cflags, _ = _get_optimization_cflags(compiler)
+            self.assertTrue(all("fbracket-depth" not in f for f in cflags))
+
 
 if __name__ == "__main__":
     if HAS_CPU:

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1996,6 +1996,11 @@ class aot_inductor:
     # Whether to enable link-time-optimization
     enable_lto = os.environ.get("AOT_INDUCTOR_ENABLE_LTO", "0") == "1"
 
+    # Override Clang's default -fbracket-depth=256 limit. The minimal arrayref
+    # interface generates fold expressions whose nesting depth is proportional
+    # to the number of model inputs. Set to 0 to use the compiler default.
+    clang_bracket_depth: int = 0
+
     # Whether the compiled .so should link to libtorch
     link_libtorch: bool = True
 

--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -936,6 +936,11 @@ def _get_optimization_cflags(
         if config.aot_inductor.enable_lto and _is_clang(cpp_compiler):
             cflags.append("flto=thin")
 
+        if config.aot_inductor.clang_bracket_depth > 0 and _is_clang(cpp_compiler):
+            cflags.append(
+                f"fbracket-depth={config.aot_inductor.clang_bracket_depth}"
+            )
+
     return cflags, ldflags
 
 


### PR DESCRIPTION
Summary:
Override generate_fallback_kernel_with_runtime_lookup_aot in
CppWrapperCpuArrayRef to wrap ArrayRefTensor args with
borrow_arrayref_tensor_as_tensor() before placing them in
std::array<AtenTensorHandle, N>. Without this, models using proxy executor
calls with use_minimal_arrayref_interface=True fail with:
  error: no viable conversion from ArrayRefTensor<long> to AtenTensorOpaque*

Test Plan: buck test //caffe2/test/inductor:test_aot_inductor_arrayref -- AOTInductorTestABICompatibleCpuWithStackAllocationAndMinimalArrayRefInterface.test_while_loop_with_outer_buffers

Differential Revision: D94628822




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo