### PR TITLE
[test]  Resolve undefined GRAPH_EXECUTOR in test_jit_profiling.py

### DIFF
--- a/test/test_jit_profiling.py
+++ b/test/test_jit_profiling.py
@@ -1,9 +1,17 @@
 # Owner(s): ["oncall: jit"]
 
 import sys
+
 sys.argv.append("--jit-executor=profiling")
+if __name__ == "__main__":
+    from torch.testing._internal.common_utils import parse_cmd_line_args
+
+    # The value of GRAPH_EXECUTOR depends on command line arguments so make sure they're parsed
+    # before instantiating tests.
+    parse_cmd_line_args()
+
 from test_jit import *  # noqa: F403
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     if sys.version_info < (3, 14):
         run_tests()


### PR DESCRIPTION
`test/test_jit_profiling.py` works fine if launched using pytest since pytest has setup code to parse command arguments. 

But if launching this test from python it'll fail:


```
> python /opt/pytorch/pytorch/test/test_jit_profiling.py
Traceback (most recent call last):
  File "/opt/pytorch/pytorch/test/test_jit_profiling.py", line 5, in <module>
    from test_jit import *  # noqa: F403
    ^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/pytorch/pytorch/test/test_jit.py", line 29, in <module>
    from jit.test_autodiff_subgraph_slicing import TestAutodiffSubgraphSlicing  # noqa: F401
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/pytorch/pytorch/test/jit/test_autodiff_subgraph_slicing.py", line 30, in <module>
    assert GRAPH_EXECUTOR is not None
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError
```

This change would allow us to launch this test from either method.