### PR TITLE
bugfix: torch.arange + Inductor overflow

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -3210,6 +3210,16 @@ class CommonTemplate:
 
         self.common(fn, (torch.zeros(5, dtype=torch.int64),), check_lowp=False)
 
+    def test_arange8(self):
+        def fn(x):
+            # Create a small tensor with int64 values > INT32_MAX
+            idx = torch.arange(0, 2, device=x.device, dtype=torch.int64)
+            large_val = torch.tensor(2147483648, dtype=torch.int64, device=x.device)
+            return idx * large_val
+
+        x = torch.zeros(1, device=self.device)
+        self.common(fn, (x,))
+
     def test_linspace1(self):
         def fn(x):
             return torch.linspace(0.125, 0.875, 7, device=x.device) + x

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -3220,6 +3220,28 @@ class CommonTemplate:
         x = torch.zeros(1, device=self.device)
         self.common(fn, (x,))
 
+    def test_arange9(self):
+        # Reduction operation with int64 values
+        def fn(x):
+            idx = torch.arange(0, 100, device=x.device, dtype=torch.int64)
+            val = idx * int(1e7)  # Large but < INT32_MAX
+            return val.sum()
+
+        self.common(fn, (torch.zeros(1),))
+
+    def test_arange10(self):
+        # Multiple arange operations with different usage patterns
+        def fn(x):
+            idx_for_indexing = torch.arange(0, 10, device=x.device, dtype=torch.int64)
+            idx_for_values = torch.arange(0, 10, device=x.device, dtype=torch.int64)
+
+            indexed = x[idx_for_indexing]
+            computed = idx_for_values * int(1e9)
+
+            return indexed + computed
+
+        self.common(fn, (torch.ones(10),))
+
     def test_linspace1(self):
         def fn(x):
             return torch.linspace(0.125, 0.875, 7, device=x.device) + x

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -3229,19 +3229,6 @@ class CommonTemplate:
 
         self.common(fn, (torch.zeros(1),))
 
-    def test_arange10(self):
-        # Multiple arange operations with different usage patterns
-        def fn(x):
-            idx_for_indexing = torch.arange(0, 10, device=x.device, dtype=torch.int64)
-            idx_for_values = torch.arange(0, 10, device=x.device, dtype=torch.int64)
-
-            indexed = x[idx_for_indexing]
-            computed = idx_for_values * int(1e9)
-
-            return indexed + computed
-
-        self.common(fn, (torch.ones(10),))
-
     def test_linspace1(self):
         def fn(x):
             return torch.linspace(0.125, 0.875, 7, device=x.device) + x

--- a/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
@@ -132,6 +132,7 @@ test_failures = {
     "test_arange4_dynamic_shapes": TestFailure(("cpu",)),
     "test_arange6_dynamic_shapes": TestFailure(("cpu",)),
     "test_arange7_dynamic_shapes": TestFailure(("cpu",)),
+    "test_arange8_dynamic_shapes": TestFailure(("cpu",)),
     "test_clamp_type_promotion_dynamic_shapes": TestFailure(("cpu",)),
     "test_conv2d_channels_last_dynamic_shapes": TestFailure(("cpu",)),
     "test_conv3d_dynamic_shapes": TestFailure(("cpu",)),

--- a/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
@@ -133,6 +133,7 @@ test_failures = {
     "test_arange6_dynamic_shapes": TestFailure(("cpu",)),
     "test_arange7_dynamic_shapes": TestFailure(("cpu",)),
     "test_arange8_dynamic_shapes": TestFailure(("cpu",)),
+    "test_arange9_dynamic_shapes": TestFailure(("cpu",)),
     "test_clamp_type_promotion_dynamic_shapes": TestFailure(("cpu",)),
     "test_conv2d_channels_last_dynamic_shapes": TestFailure(("cpu",)),
     "test_conv3d_dynamic_shapes": TestFailure(("cpu",)),

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -2133,10 +2133,19 @@ class TritonKernelOverrides(TritonOverrides):
     @classmethod
     def index_expr(cls, expr, dtype):
         """
-        index expr behaviour.
-        If the index is used for values, we keep the original dtype.
-        Otherwise we downgrade the dtype to int32.
-        For non-integer dtypes, respect the requested dtype.
+        Handles dtype selection for index expressions based on usage.
+
+        - For non-integer int 32/64 dtypes: Respect the requested dtype
+        - elif used for VALUES and original dtype is int64: Use int64 to preserve semantics
+        - elif used for INDEXING or original dtype is not int64: Use kernel index dtype (int32)
+        
+
+        The VALUE vs INDEXING distinction is determined by analyzing the
+        LoopBody FX graph to trace which ops.store argument position the
+        index_expr feeds into.
+
+        The original dtype is retrieved from V.kernel.current_node.node.dtype,
+        which preserves the user's dtype choice before type promotion.
         """
         expr = _materialize_trunc_to_float_expr(expr, dtype)
         indexing = V.kernel.indexing(
@@ -2154,32 +2163,56 @@ class TritonKernelOverrides(TritonOverrides):
 
         # FIX for Issue #175966: Check if this index_expr is used for values vs indexing
         # Algorithm: Trace VALUE chains backward from store operations
-        # - If index_expr is in VALUE chain → compute in int64 (preserve semantics)
-        # - If index_expr is NOT in VALUE chain → use int32 (safe for indexing)
+        # - If index_expr is in VALUE chain AND may overflow → use int64
+        # - Otherwise → use kernel index dtype (int32)
         is_for_values_only = False
         index_str_to_use = indexing.index_str
 
-        # Check if current FX node is marked as "for values only"
+        # Check if current FX node is marked as "for values only" and get original dtype
         # During codegen, V.interpreter.current_node is the FX node being executed
         # V.kernel.current_node._body is the LoopBody containing the analysis
-  
-        current_fx_node = V.interpreter.current_node
-        if current_fx_node:
-            is_for_values_only = V.kernel.current_node._body.index_expr_usage.get(current_fx_node, False)
 
-        # Determine dtype to use based on usage chain
-        if is_for_values_only:
-            # In VALUE chain → force int64 to preserve original dtype semantics
-            # This ensures operations like idx*1e9 don't overflow, regardless of
-            # what dtype fusion/lowering requested (e.g., float32 due to later cast)
+        current_fx_node = V.interpreter.current_node
+        is_for_values_only = False
+        original_dtype = None
+
+        if current_fx_node:
+            # index_expr_usage now returns (is_for_values_only, original_dtype)
+            usage_info = V.kernel.current_node._body.index_expr_usage.get(current_fx_node, (False, None))
+            is_for_values_only, original_dtype = usage_info
+
+            # Try to find the original dtype from FX nodes in V.graph.user_to_last_uses
+            # The iota/arange FX node should have meta information with int64 dtype
+            # Only trust original_dtype if it's int64; otherwise look it up
+            if original_dtype != torch.int64 and hasattr(V, 'graph') and V.graph:
+                # Check FX nodes for int64 dtype in meta
+                for user, last_uses in V.graph.user_to_last_uses.items():
+                    for fx_node in last_uses:
+                        # Check if FX node has meta with dtype information
+                        if hasattr(fx_node, 'meta') and 'val' in fx_node.meta:
+                            val = fx_node.meta['val']
+                            if hasattr(val, 'dtype') and val.dtype == torch.int64:
+                                original_dtype = torch.int64
+                                break
+                    if original_dtype == torch.int64:
+                        break
+
+        # Determine dtype to use based on usage chain and original dtype
+        if is_for_values_only and original_dtype == torch.int64:
+            # In VALUE chain AND original dtype was int64 → use int64 to preserve semantics
+            # This catches cases like: idx * 1e9 where idx came from int64 arange
+            # Even if type promotion changed final dtype to float32, the intermediate
+            # multiplication needs int64 to avoid overflow
             dtype_to_use = torch.int64
-            index_str_to_use = cls._cast_index_vars_to_int64(indexing.index_str)
+            if index_dtype == torch.int32:
+                index_str_to_use = cls._cast_index_vars_to_int64(indexing.index_str)
+            # else: kernel index dtype is already int64, no cast needed
         elif dtype not in (torch.int32, torch.int64):
             # Non-integer dtypes: respect requested dtype
             dtype_to_use = dtype
         else:
-            # In INDEXING chain or uncertain → use kernel index dtype (int32)
-            # This is conservative and safe for indexing operations
+            # INDEXING chain OR original dtype was not int64 → use kernel index dtype (int32)
+            # Trust user's dtype choice: if they didn't specify int64, use int32
             dtype_to_use = index_dtype
 
         # Casting violates this assert, set to false if we can cast.
@@ -2204,9 +2237,9 @@ class TritonKernelOverrides(TritonOverrides):
                 dtype=upcast_compute_type(dtype),
                 shape=var.shape,
             )
-        elif is_for_values_only:
-            # For values only with int64: already generated with casts, no further action needed
-            # The var was generated with dtype_to_use (int64) and index vars cast to int64
+        elif is_for_values_only and original_dtype == torch.int64:
+            # For VALUE chain with int64 original dtype: already generated with int64
+            # The var was generated with dtype_to_use (int64) and index vars cast if needed
             pass
         else:
             # Original behavior: handle type promotion for indexing case

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -2132,6 +2132,12 @@ class TritonKernelOverrides(TritonOverrides):
 
     @classmethod
     def index_expr(cls, expr, dtype):
+        """
+        index expr behaviour.
+        If the index is used for values, we keep the original dtype.
+        Otherwise we downgrade the dtype to int32.
+        For non-integer dtypes, respect the requested dtype.
+        """
         expr = _materialize_trunc_to_float_expr(expr, dtype)
         indexing = V.kernel.indexing(
             expr, block_ptr=False, tma_compatibility_checker=None
@@ -2144,45 +2150,78 @@ class TritonKernelOverrides(TritonOverrides):
         else:
             shape = TritonSymbols.get_block_shape(indexing.index)
 
-        # Our sympy expr printing casts to the current kernel index dtype.
-        # we only respect non int32-int64 dtypes and otherwise use current kernel indexing dtype
         index_dtype = V.kernel.get_index_dtype_as_torch_dtype()
-        dtype = dtype if dtype not in (torch.int32, torch.int64) else index_dtype
 
-        # after we emit this var we cast it to the correct dtype
+        # FIX for Issue #175966: Check if this index_expr is used for values vs indexing
+        # Algorithm: Trace VALUE chains backward from store operations
+        # - If index_expr is in VALUE chain → compute in int64 (preserve semantics)
+        # - If index_expr is NOT in VALUE chain → use int32 (safe for indexing)
+        is_for_values_only = False
+        index_str_to_use = indexing.index_str
+
+        # Check if current FX node is marked as "for values only"
+        # During codegen, V.interpreter.current_node is the FX node being executed
+        # V.kernel.current_node._body is the LoopBody containing the analysis
+  
+        current_fx_node = V.interpreter.current_node
+        if current_fx_node:
+            is_for_values_only = V.kernel.current_node._body.index_expr_usage.get(current_fx_node, False)
+
+        # Determine dtype to use based on usage chain
+        if is_for_values_only:
+            # In VALUE chain → force int64 to preserve original dtype semantics
+            # This ensures operations like idx*1e9 don't overflow, regardless of
+            # what dtype fusion/lowering requested (e.g., float32 due to later cast)
+            dtype_to_use = torch.int64
+            index_str_to_use = cls._cast_index_vars_to_int64(indexing.index_str)
+        elif dtype not in (torch.int32, torch.int64):
+            # Non-integer dtypes: respect requested dtype
+            dtype_to_use = dtype
+        else:
+            # In INDEXING chain or uncertain → use kernel index dtype (int32)
+            # This is conservative and safe for indexing operations
+            dtype_to_use = index_dtype
+
+        # Casting violates this assert, set to false if we can cast.
         orig = config.test_configs.runtime_triton_dtype_assert
         try:
             config.test_configs.runtime_triton_dtype_assert = False
             var = V.kernel.cse.generate(
                 V.kernel.compute,
-                indexing.index_str,
+                index_str_to_use,
                 bounds=get_bounds_index_expr(expr),
-                dtype=dtype,
+                dtype=dtype_to_use,
                 shape=shape,
             )
         finally:
             config.test_configs.runtime_triton_dtype_assert = orig
 
-        if dtype not in (torch.int32, torch.int64):
+        if dtype_to_use not in (torch.int32, torch.int64):
+            # Non-integer dtype: cast to requested dtype
             var = V.kernel.cse.generate(
                 V.kernel.compute,
                 cls.to_dtype(var, dtype),
                 dtype=upcast_compute_type(dtype),
                 shape=var.shape,
             )
+        elif is_for_values_only:
+            # For values only with int64: already generated with casts, no further action needed
+            # The var was generated with dtype_to_use (int64) and index vars cast to int64
+            pass
         else:
+            # Original behavior: handle type promotion for indexing case
             # TODO: we are not always consistent in enforcing that the output of the index expr printing
             # results in the indexing dtype. So if we detect that we have an input which might type promote
             # to a dtype other than indexing dtype, add a cast.
             # Trying to avoid
-            dtype = index_dtype
+            dtype_check = index_dtype
             for index_var in expr.free_symbols:
                 if symbol_is_type(index_var, SymT.TMP):
-                    dtype = torch.promote_types(
-                        dtype, V.kernel.cse.varname_map[index_var.name].dtype
+                    dtype_check = torch.promote_types(
+                        dtype_check, V.kernel.cse.varname_map[index_var.name].dtype
                     )
 
-            if dtype != index_dtype:
+            if dtype_check != index_dtype:
                 var = V.kernel.cse.generate(
                     V.kernel.compute,
                     cls.to_dtype(var, index_dtype),
@@ -2192,6 +2231,47 @@ class TritonKernelOverrides(TritonOverrides):
 
         var.mask_vars = indexing.mask_vars
         return var
+
+    @classmethod
+    def _cast_index_vars_to_int64(cls, index_str: str) -> str:
+        """
+        Cast index variables to int64 for value computation.
+
+        This is used when an index_expr is determined to be used ONLY for computing
+        tensor values (not for indexing), and the requested dtype is int64 while
+        the kernel index dtype is int32.
+
+        Without this cast, int64 arithmetic would overflow when performed in int32.
+        By casting index variables (x0, x1, etc.) to int64, all arithmetic involving
+        them is promoted to int64, including multiplications with constants.
+
+        Example:
+            Input:  "1000000000*x0"
+            Output: "1000000000*x0.to(tl.int64)"
+
+            Input:  "10000000*r0_0"  (reduction variable)
+            Output: "10000000*r0_0.to(tl.int64)"
+
+            When Triton evaluates: 1000000000 (int32) * x0.to(tl.int64) (int64)
+            Result: int64 (type promotion)
+
+        Args:
+            index_str: String containing index expression with index variables
+
+        Returns:
+            Modified string with .to(tl.int64) casts on index variables
+        """
+        import re
+        # Cast index variables to tl.int64:
+        # - x0, x1, x2, ..., xindex (regular iteration variables)
+        # - r0_0, r1_2, etc. (reduction variables)
+        # Use word boundaries to avoid matching variables like "max0"
+        # This promotes all arithmetic involving these variables to int64
+        return re.sub(
+            r'\b(x\d+|xindex|r\d+_\d+)\b',
+            lambda m: f"{m.group(0)}.to(tl.int64)",
+            index_str
+        )
 
     @staticmethod
     def masked(mask, body, other):

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -2135,18 +2135,43 @@ class TritonKernelOverrides(TritonOverrides):
         """
         Handles dtype selection for index expressions based on usage.
 
-        - For non-integer int 32/64 dtypes: Respect the requested dtype
-        - elif used for VALUES and original dtype is int64: Use int64 to preserve semantics
-        - elif used for INDEXING or original dtype is not int64: Use kernel index dtype (int32)
-        
-
-        The VALUE vs INDEXING distinction is determined by analyzing the
-        LoopBody FX graph to trace which ops.store argument position the
-        index_expr feeds into.
-
-        The original dtype is retrieved from V.kernel.current_node.node.dtype,
-        which preserves the user's dtype choice before type promotion.
+        - For non-integer int 32/64 dtypes: Respect the requested dtype.
+        - elif used for VALUES and original dtype is int64: Use int64 to preserve semantics.
+        - elif used for INDEXING or original dtype is not int64: Use kernel index dtype.
         """
+
+        def _cast_index_vars_to_int64(index_str: str) -> str:
+            """
+            Cast index variables to int64 for value computation.
+
+            This is used when an index_expr is determined to be used ONLY for computing
+            tensor values, the original dtype is int64, and
+            the kernel index dtype is int32.
+
+            Example:
+                Input:  "1000000000*x0"
+                Output: "1000000000*x0.to(tl.int64)"
+
+                Input:  "10000000*r0_0"  (reduction variable)
+                Output: "10000000*r0_0.to(tl.int64)"
+
+                When Triton evaluates: 1000000000 (int32) * x0.to(tl.int64) (int64)
+                Result: int64 (type promotion)
+
+            Args:
+                index_str: String containing index expression with index variables
+
+            Returns:
+                Modified string with .to(tl.int64) casts on index variables
+            """
+            import re
+
+            return re.sub(
+                r"\b(x\d+|xindex|r\d+_\d+)\b",
+                lambda m: f"{m.group(0)}.to(tl.int64)",
+                index_str,
+            )
+
         expr = _materialize_trunc_to_float_expr(expr, dtype)
         indexing = V.kernel.indexing(
             expr, block_ptr=False, tma_compatibility_checker=None
@@ -2160,38 +2185,24 @@ class TritonKernelOverrides(TritonOverrides):
             shape = TritonSymbols.get_block_shape(indexing.index)
 
         index_dtype = V.kernel.get_index_dtype_as_torch_dtype()
-
-        # FIX for Issue #175966: Check if this index_expr is used for values vs indexing
-        # Algorithm: Trace VALUE chains backward from store operations
-        # - If index_expr is in VALUE chain AND may overflow → use int64
-        # - Otherwise → use kernel index dtype (int32)
         is_for_values_only = False
         index_str_to_use = indexing.index_str
-
-        # Check if current FX node is marked as "for values only" and get original dtype
-        # During codegen, V.interpreter.current_node is the FX node being executed
-        # V.kernel.current_node._body is the LoopBody containing the analysis
-
         current_fx_node = V.interpreter.current_node
         is_for_values_only = False
         original_dtype = None
 
+        # Find the original dtype from FX nodes before fusion.
         if current_fx_node:
-            # index_expr_usage now returns (is_for_values_only, original_dtype)
-            usage_info = V.kernel.current_node._body.index_expr_usage.get(current_fx_node, (False, None))
-            is_for_values_only, original_dtype = usage_info
-
-            # Try to find the original dtype from FX nodes in V.graph.user_to_last_uses
-            # The iota/arange FX node should have meta information with int64 dtype
-            # Only trust original_dtype if it's int64; otherwise look it up
-            if original_dtype != torch.int64 and hasattr(V, 'graph') and V.graph:
+            is_for_values_only = V.kernel.current_node._body.index_expr_usage.get(
+                current_fx_node, False
+            )
+            if original_dtype != torch.int64 and is_for_values_only:
                 # Check FX nodes for int64 dtype in meta
-                for user, last_uses in V.graph.user_to_last_uses.items():
+                for last_uses in V.graph.user_to_last_uses.values():
                     for fx_node in last_uses:
-                        # Check if FX node has meta with dtype information
-                        if hasattr(fx_node, 'meta') and 'val' in fx_node.meta:
-                            val = fx_node.meta['val']
-                            if hasattr(val, 'dtype') and val.dtype == torch.int64:
+                        val = fx_node.meta.get("val")
+                        if val is not None:
+                            if val.dtype == torch.int64:
                                 original_dtype = torch.int64
                                 break
                     if original_dtype == torch.int64:
@@ -2199,23 +2210,17 @@ class TritonKernelOverrides(TritonOverrides):
 
         # Determine dtype to use based on usage chain and original dtype
         if is_for_values_only and original_dtype == torch.int64:
-            # In VALUE chain AND original dtype was int64 → use int64 to preserve semantics
-            # This catches cases like: idx * 1e9 where idx came from int64 arange
-            # Even if type promotion changed final dtype to float32, the intermediate
-            # multiplication needs int64 to avoid overflow
             dtype_to_use = torch.int64
             if index_dtype == torch.int32:
-                index_str_to_use = cls._cast_index_vars_to_int64(indexing.index_str)
-            # else: kernel index dtype is already int64, no cast needed
+                index_str_to_use = _cast_index_vars_to_int64(indexing.index_str)
         elif dtype not in (torch.int32, torch.int64):
             # Non-integer dtypes: respect requested dtype
             dtype_to_use = dtype
         else:
-            # INDEXING chain OR original dtype was not int64 → use kernel index dtype (int32)
-            # Trust user's dtype choice: if they didn't specify int64, use int32
+            # INDEXING chain OR original dtype was not int64 → use kernel index dtyped
             dtype_to_use = index_dtype
 
-        # Casting violates this assert, set to false if we can cast.
+        # after we emit this var we cast it to the correct dtype
         orig = config.test_configs.runtime_triton_dtype_assert
         try:
             config.test_configs.runtime_triton_dtype_assert = False
@@ -2242,19 +2247,18 @@ class TritonKernelOverrides(TritonOverrides):
             # The var was generated with dtype_to_use (int64) and index vars cast if needed
             pass
         else:
-            # Original behavior: handle type promotion for indexing case
             # TODO: we are not always consistent in enforcing that the output of the index expr printing
             # results in the indexing dtype. So if we detect that we have an input which might type promote
             # to a dtype other than indexing dtype, add a cast.
             # Trying to avoid
-            dtype_check = index_dtype
+            dtype = index_dtype
             for index_var in expr.free_symbols:
                 if symbol_is_type(index_var, SymT.TMP):
-                    dtype_check = torch.promote_types(
-                        dtype_check, V.kernel.cse.varname_map[index_var.name].dtype
+                    dtype = torch.promote_types(
+                        dtype, V.kernel.cse.varname_map[index_var.name].dtype
                     )
 
-            if dtype_check != index_dtype:
+            if dtype != index_dtype:
                 var = V.kernel.cse.generate(
                     V.kernel.compute,
                     cls.to_dtype(var, index_dtype),
@@ -2264,47 +2268,6 @@ class TritonKernelOverrides(TritonOverrides):
 
         var.mask_vars = indexing.mask_vars
         return var
-
-    @classmethod
-    def _cast_index_vars_to_int64(cls, index_str: str) -> str:
-        """
-        Cast index variables to int64 for value computation.
-
-        This is used when an index_expr is determined to be used ONLY for computing
-        tensor values (not for indexing), and the requested dtype is int64 while
-        the kernel index dtype is int32.
-
-        Without this cast, int64 arithmetic would overflow when performed in int32.
-        By casting index variables (x0, x1, etc.) to int64, all arithmetic involving
-        them is promoted to int64, including multiplications with constants.
-
-        Example:
-            Input:  "1000000000*x0"
-            Output: "1000000000*x0.to(tl.int64)"
-
-            Input:  "10000000*r0_0"  (reduction variable)
-            Output: "10000000*r0_0.to(tl.int64)"
-
-            When Triton evaluates: 1000000000 (int32) * x0.to(tl.int64) (int64)
-            Result: int64 (type promotion)
-
-        Args:
-            index_str: String containing index expression with index variables
-
-        Returns:
-            Modified string with .to(tl.int64) casts on index variables
-        """
-        import re
-        # Cast index variables to tl.int64:
-        # - x0, x1, x2, ..., xindex (regular iteration variables)
-        # - r0_0, r1_2, etc. (reduction variables)
-        # Use word boundaries to avoid matching variables like "max0"
-        # This promotes all arithmetic involving these variables to int64
-        return re.sub(
-            r'\b(x\d+|xindex|r\d+_\d+)\b',
-            lambda m: f"{m.group(0)}.to(tl.int64)",
-            index_str
-        )
 
     @staticmethod
     def masked(mask, body, other):

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -2144,19 +2144,12 @@ class TritonKernelOverrides(TritonOverrides):
             """
             Cast index variables to int64 for value computation.
 
-            This is used when an index_expr is determined to be used ONLY for computing
-            tensor values, the original dtype is int64, and
-            the kernel index dtype is int32.
-
             Example:
                 Input:  "1000000000*x0"
                 Output: "1000000000*x0.to(tl.int64)"
 
                 Input:  "10000000*r0_0"  (reduction variable)
                 Output: "10000000*r0_0.to(tl.int64)"
-
-                When Triton evaluates: 1000000000 (int32) * x0.to(tl.int64) (int64)
-                Result: int64 (type promotion)
 
             Args:
                 index_str: String containing index expression with index variables
@@ -2188,44 +2181,32 @@ class TritonKernelOverrides(TritonOverrides):
         is_for_values_only = False
         index_str_to_use = indexing.index_str
         current_fx_node = V.interpreter.current_node
-        is_for_values_only = False
         original_dtype = None
 
-        # Check if this index_expr has int64 iota ancestor via origin_node tracing
+        # Check if this index_expr has int64 iota ancestor via tracing
         if current_fx_node:
-            # Lazy evaluation: only analyze once when first index_expr is encountered
-            if V.kernel.current_node._body.index_expr_usage is None:
-                from ..loop_body import analyze_index_expr_usage
+            from ..loop_body import get_index_expr_int64_usage
 
-                # Get IR node data (e.g., Pointwise) which has origin_node
-                ir_data = None
-                if hasattr(V.kernel.current_node, "node"):
-                    scheduler_node = V.kernel.current_node.node
-                    if hasattr(scheduler_node, "data"):
-                        ir_data = scheduler_node.data
-                V.kernel.current_node._body.index_expr_usage = analyze_index_expr_usage(
-                    V.kernel.current_node._body, ir_data
-                )
-
-            usage_info = V.kernel.current_node._body.index_expr_usage.get(
-                current_fx_node, (False, False)
-            )
-            is_for_values_only, has_int64_iota = usage_info
+            is_for_values_only, has_int64_iota = get_index_expr_int64_usage()
 
             # Set original_dtype if this is a value computation from int64 iota
             if is_for_values_only and has_int64_iota:
                 original_dtype = torch.int64
 
         # Determine dtype to use based on usage chain and original dtype
+        if (
+            is_for_values_only
+            and original_dtype == torch.int64
+            and index_dtype == torch.int32
+        ):
+            index_str_to_use = _cast_index_vars_to_int64(indexing.index_str)
+
         if is_for_values_only and original_dtype == torch.int64:
             dtype_to_use = torch.int64
-            if index_dtype == torch.int32:
-                index_str_to_use = _cast_index_vars_to_int64(indexing.index_str)
         elif dtype not in (torch.int32, torch.int64):
             # Non-integer dtypes: respect requested dtype
             dtype_to_use = dtype
         else:
-            # INDEXING chain OR original dtype was not int64 → use kernel index dtyped
             dtype_to_use = index_dtype
 
         # after we emit this var we cast it to the correct dtype
@@ -2251,8 +2232,6 @@ class TritonKernelOverrides(TritonOverrides):
                 shape=var.shape,
             )
         elif is_for_values_only and original_dtype == torch.int64:
-            # For VALUE chain with int64 original dtype: already generated with int64
-            # The var was generated with dtype_to_use (int64) and index vars cast if needed
             pass
         else:
             # TODO: we are not always consistent in enforcing that the output of the index expr printing

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -2191,22 +2191,30 @@ class TritonKernelOverrides(TritonOverrides):
         is_for_values_only = False
         original_dtype = None
 
-        # Find the original dtype from FX nodes before fusion.
+        # Check if this index_expr has int64 iota ancestor via origin_node tracing
         if current_fx_node:
-            is_for_values_only = V.kernel.current_node._body.index_expr_usage.get(
-                current_fx_node, False
+            # Lazy evaluation: only analyze once when first index_expr is encountered
+            if V.kernel.current_node._body.index_expr_usage is None:
+                from ..loop_body import analyze_index_expr_usage
+
+                # Get IR node data (e.g., Pointwise) which has origin_node
+                ir_data = None
+                if hasattr(V.kernel.current_node, "node"):
+                    scheduler_node = V.kernel.current_node.node
+                    if hasattr(scheduler_node, "data"):
+                        ir_data = scheduler_node.data
+                V.kernel.current_node._body.index_expr_usage = analyze_index_expr_usage(
+                    V.kernel.current_node._body, ir_data
+                )
+
+            usage_info = V.kernel.current_node._body.index_expr_usage.get(
+                current_fx_node, (False, False)
             )
-            if original_dtype != torch.int64 and is_for_values_only:
-                # Check FX nodes for int64 dtype in meta
-                for last_uses in V.graph.user_to_last_uses.values():
-                    for fx_node in last_uses:
-                        val = fx_node.meta.get("val")
-                        if val is not None:
-                            if hasattr(val, "dtype") and val.dtype == torch.int64:
-                                original_dtype = torch.int64
-                                break
-                    if original_dtype == torch.int64:
-                        break
+            is_for_values_only, has_int64_iota = usage_info
+
+            # Set original_dtype if this is a value computation from int64 iota
+            if is_for_values_only and has_int64_iota:
+                original_dtype = torch.int64
 
         # Determine dtype to use based on usage chain and original dtype
         if is_for_values_only and original_dtype == torch.int64:

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -2202,7 +2202,7 @@ class TritonKernelOverrides(TritonOverrides):
                     for fx_node in last_uses:
                         val = fx_node.meta.get("val")
                         if val is not None:
-                            if val.dtype == torch.int64:
+                            if hasattr(val, "dtype") and val.dtype == torch.int64:
                                 original_dtype = torch.int64
                                 break
                     if original_dtype == torch.int64:

--- a/torch/_inductor/dtype_propagation.py
+++ b/torch/_inductor/dtype_propagation.py
@@ -242,9 +242,18 @@ class DtypePropagationOpsHandler:
     def index_expr(expr: sympy.Expr, dtype: torch.dtype) -> torch.dtype:
         # TODO - TODO - rationalize index_expr. The dtype is not always used and we are inconsistent about int32 or int64
         # in lowerings. cpp just uses the dtype
-        if dtype not in (torch.int32, torch.int64) or not hasattr(
-            V.kernel, "index_dtype"
-        ):
+        if not hasattr(V.kernel, "index_dtype"):
+            return upcast_compute_type(dtype)
+
+        # Check if this index_expr should use int64 for value computation
+        from .loop_body import get_index_expr_int64_usage
+
+        is_for_values_only, has_int64_iota = get_index_expr_int64_usage()
+        if is_for_values_only and has_int64_iota:
+            return torch.int64
+
+        # For non-integer dtypes, use upcast
+        if dtype not in (torch.int32, torch.int64):
             return upcast_compute_type(dtype)
 
         return V.kernel.get_index_dtype_as_torch_dtype()

--- a/torch/_inductor/loop_body.py
+++ b/torch/_inductor/loop_body.py
@@ -134,11 +134,9 @@ class LoopBody:
             self._init_with_copy(fn, args, allow_same_symbol_in_index)
         else:
             self._init_with_tracing(fn, args)
+            self.index_expr_usage: dict[torch.fx.Node, tuple[bool, bool]] | None = None
 
         self.indexing = None
-        self.index_expr_usage: dict[torch.fx.Node, bool] = analyze_index_expr_usage(
-            self
-        )
 
     def get_original_num_rdims(self) -> int:
         assert self.has_partial_accumulate
@@ -190,6 +188,7 @@ class LoopBody:
         self.op_counts = other.op_counts
         self.root_block = other.root_block.clone(self)
         self.has_partial_accumulate = other.has_partial_accumulate
+        self.index_expr_usage = other.index_expr_usage
 
         submodules = {**other.submodules}
         submodules.pop("get_index")
@@ -852,24 +851,77 @@ class CaptureIndexing(WrapperHandler):
         self.tracer.create_proxy("output", "output", result, {})
 
 
+def _has_int64_iota_ancestor(dynamo_fx_node: torch.fx.Node | None) -> bool:
+    """
+    Trace backwards through Dynamo FX graph to find int64 iota ancestors.
+
+    Args:
+        dynamo_fx_node: Starting node in Dynamo FX graph (origin_node from IR)
+
+    Returns:
+        True if this node has an int64 iota ancestor that's used for int64 computation
+        (i.e., NOT immediately converted to float via convert_element_type)
+    """
+    if not dynamo_fx_node:
+        return False
+
+    visited: OrderedSet[torch.fx.Node] = OrderedSet()
+
+    def trace_backwards(node: torch.fx.Node) -> bool:
+        if node in visited or node.op == "placeholder":
+            return False
+        visited.add(node)
+
+        # Check if this is int64 iota used for int64 computation
+        if node.target == torch.ops.prims.iota.default:
+            val = node.meta.get("val")
+            if val is not None and hasattr(val, "dtype") and val.dtype == torch.int64:
+                # Check if any user is NOT convert_element_type (int64 usage)
+                for user in node.users:
+                    if user.target != torch.ops.prims.convert_element_type.default:
+                        return True
+            return False
+
+        # Recursively check inputs
+        for arg in node.args:
+            if isinstance(arg, torch.fx.Node):
+                if trace_backwards(arg):
+                    return True
+        for kwarg in node.kwargs.values():
+            if isinstance(kwarg, torch.fx.Node):
+                if trace_backwards(kwarg):
+                    return True
+
+        return False
+
+    return trace_backwards(dynamo_fx_node)
+
+
 def analyze_index_expr_usage(
     loop_body: LoopBody,
-) -> dict[torch.fx.Node, bool]:
+    ir_node: Any = None,
+) -> dict[torch.fx.Node, tuple[bool, bool]]:
     """
     Analyze the LoopBody's FX graph to determine which index_expr nodes
-    are used ONLY for values and which are used for indexing.
+    are used ONLY for values and which have int64 origins.
 
     Algorithm:
     1. Scan for terminal operations (load, store, store_reduction)
-    2. Recursively parse search ancestorrs for indexing or values usage.
+    2. Recursively parse search ancestors for indexing or values usage
     3. Stop at barriers
+    4. Trace back through IR origin_node to find int64 iota ancestors
+
+    Args:
+        loop_body: The LoopBody to analyze
+        ir_node: Optional IR node (e.g., Pointwise) with origin_node to Dynamo FX graph
 
     Returns:
-        dict mapping FX node -> is_used_only_for_values
+        dict mapping FX node -> (is_used_only_for_values, has_int64_iota_ancestor)
     """
     # Track what each FX node is used for
     used_for_indexing: OrderedSet[torch.fx.Node] = OrderedSet()
     used_for_values: OrderedSet[torch.fx.Node] = OrderedSet()
+    used_by_comparison: OrderedSet[torch.fx.Node] = OrderedSet()
 
     def mark_ancestors(
         node: torch.fx.Node,
@@ -901,8 +953,14 @@ def analyze_index_expr_usage(
             if isinstance(kwarg, torch.fx.Node):
                 mark_ancestors(kwarg, target_set, visited)
 
-    # Scan graph for terminal operations
     for node in loop_body.root_block.graph.nodes:
+        # These sproduce booleans not values.
+        if node.target in ("lt", "le", "gt", "ge", "eq", "ne"):
+            for arg in node.args:
+                if isinstance(arg, torch.fx.Node):
+                    used_by_comparison.add(arg)
+
+        # Trace terminal operations
         if node.target in ("store", "store_reduction"):
             if len(node.args) > 2 and isinstance(node.args[2], torch.fx.Node):
                 mark_ancestors(node.args[2], used_for_indexing)
@@ -913,16 +971,26 @@ def analyze_index_expr_usage(
             if len(node.args) > 2 and isinstance(node.args[2], torch.fx.Node):
                 mark_ancestors(node.args[2], used_for_indexing)
 
-    # Build result: for each index_expr node, determine usage AND capture original dtype
-    result: dict[torch.fx.Node, bool] = {}
+    # Build result: for each index_expr node, determine usage and int64 iota ancestry
+    result: dict[torch.fx.Node, tuple[bool, bool]] = {}
+
+    origin_fx_node = None
+    if ir_node and hasattr(ir_node, "get_origin_node"):
+        origin_fx_node = ir_node.get_origin_node()
+
     for node in loop_body.root_block.graph.nodes:
         if node.target == "index_expr":
             in_values = node in used_for_values
             in_indexing = node in used_for_indexing
+            in_comparison = node in used_by_comparison
+            is_for_values_only = in_values and not in_indexing and not in_comparison
 
-            # Original dtype lookup not needed - we'll look it up from V.graph during codegen
-            # Just return is_for_values_only
-            is_for_values_only = in_values and not in_indexing
-            result[node] = is_for_values_only
+            has_int64_iota = False
+            if is_for_values_only and origin_fx_node:
+                # The origin_node is for the entire buffer/operation
+                # Trace backwards from it through the Dynamo graph
+                has_int64_iota = _has_int64_iota_ancestor(origin_fx_node)
+
+            result[node] = (is_for_values_only, has_int64_iota)
 
     return result

--- a/torch/_inductor/loop_body.py
+++ b/torch/_inductor/loop_body.py
@@ -137,8 +137,8 @@ class LoopBody:
         self.indexing = None
 
         # Analyze index_expr usage for int64 overflow fix (Issue #175966)
-        # Maps FX nodes -> is_used_only_for_values
-        self.index_expr_usage: dict[torch.fx.Node, bool] = analyze_index_expr_usage(self)
+        # Maps FX nodes -> (is_used_only_for_values, original_dtype)
+        self.index_expr_usage: dict[torch.fx.Node, tuple[bool, Any]] = analyze_index_expr_usage(self)
 
     def get_original_num_rdims(self) -> int:
         assert self.has_partial_accumulate
@@ -852,10 +852,10 @@ class CaptureIndexing(WrapperHandler):
         self.tracer.create_proxy("output", "output", result, {})
 
 
-def analyze_index_expr_usage(loop_body: LoopBody) -> dict[torch.fx.Node, bool]:
+def analyze_index_expr_usage(loop_body: LoopBody) -> dict[torch.fx.Node, tuple[bool, Any]]:
     """
     Analyze the LoopBody's FX graph to determine which index_expr nodes
-    are used ONLY for values (never for indexing).
+    are used ONLY for values (never for indexing), and capture their original dtype.
 
     This implements the IR-level use-chain analysis to fix int64 overflow bug
     (Issue #175966). The bug occurs when int64 arithmetic is performed in int32
@@ -866,6 +866,7 @@ def analyze_index_expr_usage(loop_body: LoopBody) -> dict[torch.fx.Node, bool]:
     2. Mark ancestors as used for indexing or values based on argument position
     3. Stop at load barriers (don't propagate "for values" through load index)
     4. Conservative: if used for BOTH indexing and values, treat as indexing
+    5. Extract original dtype from ops.index_expr(expr, dtype) call
 
     Terminal operations:
     - ops.load(name, index) - index → INDEXING
@@ -876,9 +877,9 @@ def analyze_index_expr_usage(loop_body: LoopBody) -> dict[torch.fx.Node, bool]:
     - ops.load() - result is VALUES, but don't propagate backward through index arg
 
     Returns:
-        dict mapping FX node -> is_used_only_for_values (bool)
-        - True: CERTAIN it's only for values, never indexing (safe to use int64)
-        - False: Used for indexing OR uncertain (use int32 - conservative)
+        dict mapping FX node -> (is_used_only_for_values, original_dtype)
+        - is_used_only_for_values: True if CERTAIN it's only for values, False otherwise
+        - original_dtype: The dtype argument from ops.index_expr(expr, dtype) call
     """
     # Track what each FX node is used for
     used_for_indexing: set[torch.fx.Node] = set()
@@ -943,16 +944,17 @@ def analyze_index_expr_usage(loop_body: LoopBody) -> dict[torch.fx.Node, bool]:
             if len(node.args) > 2 and isinstance(node.args[2], torch.fx.Node):
                 mark_indexing_ancestors(node.args[2])
 
-    # Build result: for each index_expr node, determine usage
+    # Build result: for each index_expr node, determine usage AND capture original dtype
     # ULTRA-CONSERVATIVE: if in BOTH sets, treat as INDEXING (avoid Type 2 error)
-    result: dict[torch.fx.Node, bool] = {}
+    result: dict[torch.fx.Node, tuple[bool, Any]] = {}
     for node in loop_body.root_block.graph.nodes:
         if node.target == 'index_expr':
             in_values = node in used_for_values
             in_indexing = node in used_for_indexing
 
-            # Only True if ONLY used for values, never indexing
-            # This avoids Type 2 errors (false positive for values → perf regression)
-            result[node] = in_values and not in_indexing
+            # Original dtype lookup not needed - we'll look it up from V.graph during codegen
+            # Just return is_for_values_only
+            is_for_values_only = in_values and not in_indexing
+            result[node] = (is_for_values_only, None)
 
     return result

--- a/torch/_inductor/loop_body.py
+++ b/torch/_inductor/loop_body.py
@@ -13,6 +13,7 @@ import sympy
 import torch.fx
 from torch._dynamo.utils import identity
 from torch.fx.proxy import Scope, TracerBase
+from torch.utils._ordered_set import OrderedSet
 from torch.utils._sympy.functions import Mod
 from torch.utils._sympy.symbol import SymT
 
@@ -867,13 +868,13 @@ def analyze_index_expr_usage(
         dict mapping FX node -> is_used_only_for_values
     """
     # Track what each FX node is used for
-    used_for_indexing: set[torch.fx.Node] = set()
-    used_for_values: set[torch.fx.Node] = set()
+    used_for_indexing: OrderedSet[torch.fx.Node] = OrderedSet()
+    used_for_values: OrderedSet[torch.fx.Node] = OrderedSet()
 
     def mark_ancestors(
         node: torch.fx.Node,
-        target_set: set[torch.fx.Node],
-        visited: set[torch.fx.Node] | None = None,
+        target_set: OrderedSet[torch.fx.Node],
+        visited: OrderedSet[torch.fx.Node] | None = None,
     ) -> None:
         """
         Mark all ancestors by adding them to target_set, STOP at load barriers.
@@ -882,7 +883,7 @@ def analyze_index_expr_usage(
         because the loaded value is independent from the index used to load it.
         """
         if visited is None:
-            visited = set()
+            visited = OrderedSet()
         if node in visited or node.op == "placeholder":
             return
         visited.add(node)

--- a/torch/_inductor/loop_body.py
+++ b/torch/_inductor/loop_body.py
@@ -859,8 +859,7 @@ def _has_int64_iota_ancestor(dynamo_fx_node: torch.fx.Node | None) -> bool:
         dynamo_fx_node: Starting node in Dynamo FX graph (origin_node from IR)
 
     Returns:
-        True if this node has an int64 iota ancestor that's used for int64 computation
-        (i.e., NOT immediately converted to float via convert_element_type)
+        True if this node has an int64 iota ancestor that's used for int64)
     """
     if not dynamo_fx_node:
         return False
@@ -994,3 +993,32 @@ def analyze_index_expr_usage(
             result[node] = (is_for_values_only, has_int64_iota)
 
     return result
+
+
+def get_index_expr_int64_usage() -> tuple[bool, bool]:
+    """
+    Determine if index_expr should use int64 based on usage analysis.
+
+    Returns:
+        (is_for_values_only, has_int64_iota_ancestor)
+        - is_for_values_only: True if this index_expr is only used for tensor values
+        - has_int64_iota_ancestor: True if traced back to int64 iota operation
+    """
+    from .virtualized import V
+
+    if hasattr(V.interpreter, "current_node") and hasattr(
+        V.kernel.current_node, "_body"
+    ):
+        current_fx_node = V.interpreter.current_node
+        loop_body = V.kernel.current_node._body
+        scheduler_node = getattr(V.kernel.current_node, "node", None)
+        ir_node = getattr(scheduler_node, "data", None)
+
+        # Lazy evaluation: run analysis once per LoopBody and cache result
+        if loop_body.index_expr_usage is None:
+            loop_body.index_expr_usage = analyze_index_expr_usage(loop_body, ir_node)
+
+        # Look up usage info for this specific FX node
+        return loop_body.index_expr_usage.get(current_fx_node, (False, False))
+
+    return (False, False)

--- a/torch/_inductor/loop_body.py
+++ b/torch/_inductor/loop_body.py
@@ -135,10 +135,9 @@ class LoopBody:
             self._init_with_tracing(fn, args)
 
         self.indexing = None
-
-        # Analyze index_expr usage for int64 overflow fix (Issue #175966)
-        # Maps FX nodes -> (is_used_only_for_values, original_dtype)
-        self.index_expr_usage: dict[torch.fx.Node, tuple[bool, Any]] = analyze_index_expr_usage(self)
+        self.index_expr_usage: dict[torch.fx.Node, bool] = analyze_index_expr_usage(
+            self
+        )
 
     def get_original_num_rdims(self) -> int:
         assert self.has_partial_accumulate
@@ -852,109 +851,77 @@ class CaptureIndexing(WrapperHandler):
         self.tracer.create_proxy("output", "output", result, {})
 
 
-def analyze_index_expr_usage(loop_body: LoopBody) -> dict[torch.fx.Node, tuple[bool, Any]]:
+def analyze_index_expr_usage(
+    loop_body: LoopBody,
+) -> dict[torch.fx.Node, bool]:
     """
     Analyze the LoopBody's FX graph to determine which index_expr nodes
-    are used ONLY for values (never for indexing), and capture their original dtype.
-
-    This implements the IR-level use-chain analysis to fix int64 overflow bug
-    (Issue #175966). The bug occurs when int64 arithmetic is performed in int32
-    due to kernel index dtype override.
+    are used ONLY for values and which are used for indexing.
 
     Algorithm:
     1. Scan for terminal operations (load, store, store_reduction)
-    2. Mark ancestors as used for indexing or values based on argument position
-    3. Stop at load barriers (don't propagate "for values" through load index)
-    4. Conservative: if used for BOTH indexing and values, treat as indexing
-    5. Extract original dtype from ops.index_expr(expr, dtype) call
-
-    Terminal operations:
-    - ops.load(name, index) - index → INDEXING
-    - ops.store(name, index, value, mode) - index → INDEXING, value → VALUES
-    - ops.store_reduction(name, index, value) - index → INDEXING, value → VALUES
-
-    Barriers:
-    - ops.load() - result is VALUES, but don't propagate backward through index arg
+    2. Recursively parse search ancestorrs for indexing or values usage.
+    3. Stop at barriers
 
     Returns:
-        dict mapping FX node -> (is_used_only_for_values, original_dtype)
-        - is_used_only_for_values: True if CERTAIN it's only for values, False otherwise
-        - original_dtype: The dtype argument from ops.index_expr(expr, dtype) call
+        dict mapping FX node -> is_used_only_for_values
     """
     # Track what each FX node is used for
     used_for_indexing: set[torch.fx.Node] = set()
     used_for_values: set[torch.fx.Node] = set()
 
-    def mark_indexing_ancestors(node: torch.fx.Node, visited: set[torch.fx.Node] | None = None) -> None:
-        """Mark all ancestors as used for indexing"""
+    def mark_ancestors(
+        node: torch.fx.Node,
+        target_set: set[torch.fx.Node],
+        visited: set[torch.fx.Node] | None = None,
+    ) -> None:
+        """
+        Mark all ancestors by adding them to target_set, STOP at load barriers.
+
+        Load operations act as barriers: they break both indexing and value chains
+        because the loaded value is independent from the index used to load it.
+        """
         if visited is None:
             visited = set()
-        if node in visited or node.op == 'placeholder':
+        if node in visited or node.op == "placeholder":
             return
         visited.add(node)
 
-        used_for_indexing.add(node)
-
-        # Trace backward through inputs
-        for arg in node.args:
-            if isinstance(arg, torch.fx.Node):
-                mark_indexing_ancestors(arg, visited)
-        for kwarg in node.kwargs.values():
-            if isinstance(kwarg, torch.fx.Node):
-                mark_indexing_ancestors(kwarg, visited)
-
-    def mark_value_ancestors(node: torch.fx.Node, visited: set[torch.fx.Node] | None = None) -> None:
-        """Mark ancestors as used for values, STOP at load barriers"""
-        if visited is None:
-            visited = set()
-        if node in visited or node.op == 'placeholder':
-            return
-        visited.add(node)
-
-        # BARRIER: load breaks the value chain
-        # The loaded value depends on stored data, not the index's numeric value
-        if node.target == 'load':
+        if node.target == "load":
             return  # Don't propagate backward through load
 
-        used_for_values.add(node)
+        target_set.add(node)
 
         # Trace backward through inputs
         for arg in node.args:
             if isinstance(arg, torch.fx.Node):
-                mark_value_ancestors(arg, visited)
+                mark_ancestors(arg, target_set, visited)
         for kwarg in node.kwargs.values():
             if isinstance(kwarg, torch.fx.Node):
-                mark_value_ancestors(kwarg, visited)
+                mark_ancestors(kwarg, target_set, visited)
 
     # Scan graph for terminal operations
     for node in loop_body.root_block.graph.nodes:
-        if node.target in ('store', 'store_reduction'):
-            # ops.store(name, index, value, mode) - as call_method
-            # For call_method nodes: args[0]=self, args[1]=name, args[2]=index, args[3]=value, args[4]=mode
-            # ops.store_reduction(name, index, value) - as call_method
-            # For call_method nodes: args[0]=self, args[1]=name, args[2]=index, args[3]=value
+        if node.target in ("store", "store_reduction"):
             if len(node.args) > 2 and isinstance(node.args[2], torch.fx.Node):
-                mark_indexing_ancestors(node.args[2])
+                mark_ancestors(node.args[2], used_for_indexing)
             if len(node.args) > 3 and isinstance(node.args[3], torch.fx.Node):
-                mark_value_ancestors(node.args[3])
+                mark_ancestors(node.args[3], used_for_values)
 
-        elif node.target == 'load':
-            # ops.load(name, index) - as call_method
-            # For call_method nodes: args[0]=self, args[1]=name, args[2]=index
+        elif node.target == "load":
             if len(node.args) > 2 and isinstance(node.args[2], torch.fx.Node):
-                mark_indexing_ancestors(node.args[2])
+                mark_ancestors(node.args[2], used_for_indexing)
 
     # Build result: for each index_expr node, determine usage AND capture original dtype
-    # ULTRA-CONSERVATIVE: if in BOTH sets, treat as INDEXING (avoid Type 2 error)
-    result: dict[torch.fx.Node, tuple[bool, Any]] = {}
+    result: dict[torch.fx.Node, bool] = {}
     for node in loop_body.root_block.graph.nodes:
-        if node.target == 'index_expr':
+        if node.target == "index_expr":
             in_values = node in used_for_values
             in_indexing = node in used_for_indexing
 
             # Original dtype lookup not needed - we'll look it up from V.graph during codegen
             # Just return is_for_values_only
             is_for_values_only = in_values and not in_indexing
-            result[node] = (is_for_values_only, None)
+            result[node] = is_for_values_only
 
     return result

--- a/torch/_inductor/loop_body.py
+++ b/torch/_inductor/loop_body.py
@@ -136,6 +136,10 @@ class LoopBody:
 
         self.indexing = None
 
+        # Analyze index_expr usage for int64 overflow fix (Issue #175966)
+        # Maps FX nodes -> is_used_only_for_values
+        self.index_expr_usage: dict[torch.fx.Node, bool] = analyze_index_expr_usage(self)
+
     def get_original_num_rdims(self) -> int:
         assert self.has_partial_accumulate
         node = self.root_block.graph.find_nodes(
@@ -846,3 +850,109 @@ class CaptureIndexing(WrapperHandler):
 
     def output(self, *result):
         self.tracer.create_proxy("output", "output", result, {})
+
+
+def analyze_index_expr_usage(loop_body: LoopBody) -> dict[torch.fx.Node, bool]:
+    """
+    Analyze the LoopBody's FX graph to determine which index_expr nodes
+    are used ONLY for values (never for indexing).
+
+    This implements the IR-level use-chain analysis to fix int64 overflow bug
+    (Issue #175966). The bug occurs when int64 arithmetic is performed in int32
+    due to kernel index dtype override.
+
+    Algorithm:
+    1. Scan for terminal operations (load, store, store_reduction)
+    2. Mark ancestors as used for indexing or values based on argument position
+    3. Stop at load barriers (don't propagate "for values" through load index)
+    4. Conservative: if used for BOTH indexing and values, treat as indexing
+
+    Terminal operations:
+    - ops.load(name, index) - index → INDEXING
+    - ops.store(name, index, value, mode) - index → INDEXING, value → VALUES
+    - ops.store_reduction(name, index, value) - index → INDEXING, value → VALUES
+
+    Barriers:
+    - ops.load() - result is VALUES, but don't propagate backward through index arg
+
+    Returns:
+        dict mapping FX node -> is_used_only_for_values (bool)
+        - True: CERTAIN it's only for values, never indexing (safe to use int64)
+        - False: Used for indexing OR uncertain (use int32 - conservative)
+    """
+    # Track what each FX node is used for
+    used_for_indexing: set[torch.fx.Node] = set()
+    used_for_values: set[torch.fx.Node] = set()
+
+    def mark_indexing_ancestors(node: torch.fx.Node, visited: set[torch.fx.Node] | None = None) -> None:
+        """Mark all ancestors as used for indexing"""
+        if visited is None:
+            visited = set()
+        if node in visited or node.op == 'placeholder':
+            return
+        visited.add(node)
+
+        used_for_indexing.add(node)
+
+        # Trace backward through inputs
+        for arg in node.args:
+            if isinstance(arg, torch.fx.Node):
+                mark_indexing_ancestors(arg, visited)
+        for kwarg in node.kwargs.values():
+            if isinstance(kwarg, torch.fx.Node):
+                mark_indexing_ancestors(kwarg, visited)
+
+    def mark_value_ancestors(node: torch.fx.Node, visited: set[torch.fx.Node] | None = None) -> None:
+        """Mark ancestors as used for values, STOP at load barriers"""
+        if visited is None:
+            visited = set()
+        if node in visited or node.op == 'placeholder':
+            return
+        visited.add(node)
+
+        # BARRIER: load breaks the value chain
+        # The loaded value depends on stored data, not the index's numeric value
+        if node.target == 'load':
+            return  # Don't propagate backward through load
+
+        used_for_values.add(node)
+
+        # Trace backward through inputs
+        for arg in node.args:
+            if isinstance(arg, torch.fx.Node):
+                mark_value_ancestors(arg, visited)
+        for kwarg in node.kwargs.values():
+            if isinstance(kwarg, torch.fx.Node):
+                mark_value_ancestors(kwarg, visited)
+
+    # Scan graph for terminal operations
+    for node in loop_body.root_block.graph.nodes:
+        if node.target in ('store', 'store_reduction'):
+            # ops.store(name, index, value, mode) - as call_method
+            # For call_method nodes: args[0]=self, args[1]=name, args[2]=index, args[3]=value, args[4]=mode
+            # ops.store_reduction(name, index, value) - as call_method
+            # For call_method nodes: args[0]=self, args[1]=name, args[2]=index, args[3]=value
+            if len(node.args) > 2 and isinstance(node.args[2], torch.fx.Node):
+                mark_indexing_ancestors(node.args[2])
+            if len(node.args) > 3 and isinstance(node.args[3], torch.fx.Node):
+                mark_value_ancestors(node.args[3])
+
+        elif node.target == 'load':
+            # ops.load(name, index) - as call_method
+            # For call_method nodes: args[0]=self, args[1]=name, args[2]=index
+            if len(node.args) > 2 and isinstance(node.args[2], torch.fx.Node):
+                mark_indexing_ancestors(node.args[2])
+
+    # Build result: for each index_expr node, determine usage
+    # ULTRA-CONSERVATIVE: if in BOTH sets, treat as INDEXING (avoid Type 2 error)
+    result: dict[torch.fx.Node, bool] = {}
+    for node in loop_body.root_block.graph.nodes:
+        if node.target == 'index_expr':
+            in_values = node in used_for_values
+            in_indexing = node in used_for_indexing
+
+            # Only True if ONLY used for values, never indexing
+            # This avoids Type 2 errors (false positive for values → perf regression)
+            result[node] = in_values and not in_indexing
+
+    return result


### PR DESCRIPTION
fixes #175966

OP was correct that this was an integer overflow issue. I updated the triton code gen to check if int64 is specified. Generated triton kernel now shows the following:

```python
@triton.jit
def triton_poi_fused_arange_lift_fresh_mul_0(out_ptr0, xnumel, XBLOCK : tl.constexpr):
    xnumel = 11
    xoffset = tl.program_id(0).to(tl.int64) * XBLOCK
    xindex = xoffset + tl.arange(0, XBLOCK)[:].to(tl.int64)
    xmask = xindex < xnumel
    x0 = xindex
    tmp0 = 1000000000*x0
    tl.store(out_ptr0 + (x0), tmp0, xmask)

```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo