### PR TITLE
Fix refcount leak in DTensor OpSchema comparison key computation

### DIFF
--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -1888,7 +1888,7 @@ static bool DTensor_OpSchema_recompute_comparison_key_impl(
     comparison_key = PyTuple_Pack(
         2,
         self_handle.attr(dtensor_interned_strings.op).ptr(),
-        args_to_hash_tup.release().ptr());
+        args_to_hash_tup.ptr());
   }
   if (!comparison_key) {
     return false;


### PR DESCRIPTION
Fixes a +1 leaked reference per call

In practice, the leak affects foreach operations because they use `needs_pytree=True` and create a new OpSchema every single call.

```
import os, gc, torch, torch.distributed as dist
from torch.distributed.device_mesh import init_device_mesh
from torch.distributed.tensor import DTensor, Replicate

def mem_mb():
  with open('/proc/self/smaps_rollup') as f:
    for line in f:
      if line.startswith('Private_Dirty:'):
        return int(line.split()[1]) / 1024
  return 0

dist.init_process_group(backend='nccl')
torch.cuda.set_device(int(os.environ.get('LOCAL_RANK', 0)))
mesh = init_device_mesh('cuda', (1,))

ts = [DTensor.from_local(torch.randn(64, 64, device='cuda'), mesh, [Replicate()]) for _ in range(50)]

for _ in range(10):  # warmup
  torch._foreach_mul_(ts, 0.999)

gc.collect(); start = mem_mb()
for step in range(5000):
  torch._foreach_mul_(ts, 0.999)
  if (step + 1) % 1000 == 0:
    gc.collect()
    print(f"step {step+1}: {mem_mb():.0f} MB (delta {mem_mb() - start:+.1f})")

dist.destroy_process_group()

# torchrun --nproc_per_node=1 test_foreach_dtensor_leak.py
```