### PR TITLE
[BE] Add Union/Optional rewrites to optim through special subdirectories

### DIFF
--- a/torch/ao/quantization/__init__.py
+++ b/torch/ao/quantization/__init__.py
@@ -2,7 +2,6 @@
 
 import sys
 from collections.abc import Callable
-from typing import Optional, Union
 from typing_extensions import TypeAliasType
 
 import torch

--- a/torch/ao/quantization/qconfig.py
+++ b/torch/ao/quantization/qconfig.py
@@ -2,7 +2,7 @@
 import copy
 import warnings
 from collections import namedtuple
-from typing import Any, Union
+from typing import Any
 from typing_extensions import deprecated, TypeAliasType
 
 import torch
@@ -621,9 +621,9 @@ def _add_module_to_qconfig_obs_ctr(
     return QConfig(activation, weight)
 
 
-_ObserverOrFakeQuantizeConstructor = Union[
-    _PartialWrapper, type[ObserverBase], type[FakeQuantizeBase]
-]
+_ObserverOrFakeQuantizeConstructor = (
+    _PartialWrapper | type[ObserverBase] | type[FakeQuantizeBase]
+)
 
 
 def _obs_or_fq_ctr_equals(

--- a/torch/optim/adam.py
+++ b/torch/optim/adam.py
@@ -316,7 +316,7 @@ Adam.__doc__ = (
         lr (float, Tensor, optional): learning rate (default: 1e-3). A tensor LR
             is not yet supported for all our implementations. Please use a float
             LR if you are not also specifying fused=True or capturable=True.
-        betas (tuple[Union[float, Tensor], Union[float, Tensor]], optional):
+        betas (tuple[float | Tensor, float | Tensor], optional):
             coefficients used for computing running averages of gradient and
             its square. If a tensor is provided, must be 1-element. (default: (0.9, 0.999))
         eps (float, optional): term added to the denominator to improve

--- a/torch/optim/adamw.py
+++ b/torch/optim/adamw.py
@@ -101,7 +101,7 @@ AdamW.__doc__ = (
         lr (float, Tensor, optional): learning rate (default: 1e-3). A tensor LR
             is not yet supported for all our implementations. Please use a float
             LR if you are not also specifying fused=True or capturable=True.
-        betas (tuple[Union[float, Tensor], Union[float, Tensor]], optional):
+        betas (tuple[float | Tensor, float | Tensor], optional):
             coefficients used for computing running averages of gradient and
             its square. If a tensor is provided, must be 1-element. (default: (0.9, 0.999))
         eps (float, optional): term added to the denominator to improve

--- a/torch/optim/swa_utils.py
+++ b/torch/optim/swa_utils.py
@@ -1,12 +1,13 @@
 # mypy: allow-untyped-defs
 r"""Implementation for Stochastic Weight Averaging implementation."""
 
+from __future__ import annotations
+
 import itertools
 import math
 import warnings
-from collections.abc import Callable, Iterable
 from copy import deepcopy
-from typing import Any, cast, Literal, Union
+from typing import Any, cast, Literal, TYPE_CHECKING
 from typing_extensions import override
 
 import torch
@@ -15,7 +16,11 @@ from torch.nn import Module
 from torch.optim.lr_scheduler import _format_param, LRScheduler
 from torch.utils._foreach_utils import _get_foreach_kernels_supported_devices
 
-from .optimizer import Optimizer
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable
+
+    from .optimizer import Optimizer
 
 
 __all__ = [
@@ -31,7 +36,7 @@ __all__ = [
 from torch.utils._foreach_utils import _group_tensors_by_device_and_dtype
 
 
-PARAM_LIST = Union[tuple[Tensor, ...], list[Tensor]]
+PARAM_LIST = tuple[Tensor, ...] | list[Tensor]
 
 
 def get_ema_multi_avg_fn(decay=0.999):

--- a/torch/package/file_structure_representation.py
+++ b/torch/package/file_structure_representation.py
@@ -120,10 +120,10 @@ def _create_directory_from_file_list(
 
         file_list (List[str]): List of files to add to the top-level directory.
 
-        include (Union[List[str], str]): An optional pattern that limits what is included from the file_list to
+        include (list[str] | str): An optional pattern that limits what is included from the file_list to
             files whose name matches the pattern.
 
-        exclude (Union[List[str], str]): An optional pattern that excludes files whose name match the pattern.
+        exclude (list[str] | str): An optional pattern that excludes files whose name match the pattern.
 
     Returns:
             :class:`Directory`: a :class:`Directory` file structure representation created from a list of files.

--- a/torch/package/glob_group.py
+++ b/torch/package/glob_group.py
@@ -1,10 +1,11 @@
 # mypy: allow-untyped-defs
+from __future__ import annotations
+
 import re
 from collections.abc import Iterable
-from typing import Union
 
 
-GlobPattern = Union[str, Iterable[str]]
+GlobPattern = str | Iterable[str]
 
 
 class GlobGroup:
@@ -27,10 +28,10 @@ class GlobGroup:
     none of the ``exclude`` patterns.
 
     Args:
-        include (Union[str, Iterable[str]]): A string or list of strings,
+        include (str | Iterable[str]): A string or list of strings,
             each representing a pattern to be matched against. A candidate
             will match if it matches *any* include pattern
-        exclude (Union[str, Iterable[str]]): A string or list of strings,
+        exclude (str | Iterable[str]): A string or list of strings,
             each representing a pattern to be matched against. A candidate
             will be excluded from matching if it matches *any* exclude pattern.
         separator (str): A string that delimits segments in candidates and

--- a/torch/package/package_exporter.py
+++ b/torch/package/package_exporter.py
@@ -822,10 +822,10 @@ class PackageExporter:
         included in the package and have its dependencies processed recursively.
 
         Args:
-            include (Union[List[str], str]): A string e.g. "my_package.my_subpackage", or list of strings
+            include (list[str] | str): A string e.g. "my_package.my_subpackage", or list of strings
                 for the names of the modules to be externed. This can also be a glob-style pattern, as described in :meth:`mock`.
 
-            exclude (Union[List[str], str]): An optional pattern that excludes some patterns that match the include string.
+            exclude (list[str] | str): An optional pattern that excludes some patterns that match the include string.
 
             allow_empty (bool): An optional flag that specifies whether the intern modules specified by this call
                 to the ``intern`` method must be matched to some module during packaging. If an ``intern`` module glob
@@ -851,7 +851,7 @@ class PackageExporter:
         Use this function to mock this functionality out without having to modify the original code.
 
         Args:
-            include (Union[List[str], str]): A string e.g. ``"my_package.my_subpackage"``, or list of strings
+            include (list[str] | str): A string e.g. ``"my_package.my_subpackage"``, or list of strings
                 for the names of the modules to be mocked out. Strings can also be a glob-style pattern
                 string that may match multiple modules. Any required dependencies that match this pattern
                 string will be mocked out automatically.
@@ -863,7 +863,7 @@ class PackageExporter:
                     ``'torch.*'`` -- matches ``'torch.nn'`` or ``'torch.functional'``, but not
                     ``'torch.nn.functional'``
 
-            exclude (Union[List[str], str]): An optional pattern that excludes some patterns that match the include string.
+            exclude (list[str] | str): An optional pattern that excludes some patterns that match the include string.
                 e.g. ``include='torch.**', exclude='torch.foo'`` will mock all torch packages except ``'torch.foo'``,
                 Default: is ``[]``.
 
@@ -891,11 +891,11 @@ class PackageExporter:
         Code for extern modules must also exist in the process loading the package.
 
         Args:
-            include (Union[List[str], str]): A string e.g. ``"my_package.my_subpackage"``, or list of strings
+            include (list[str] | str): A string e.g. ``"my_package.my_subpackage"``, or list of strings
                 for the names of the modules to be externed. This can also be a glob-style pattern, as
                 described in :meth:`mock`.
 
-            exclude (Union[List[str], str]): An optional pattern that excludes some patterns that match the
+            exclude (list[str] | str): An optional pattern that excludes some patterns that match the
                 include string.
 
             allow_empty (bool): An optional flag that specifies whether the extern modules specified by this call
@@ -914,10 +914,10 @@ class PackageExporter:
         If a dependency on any matching packages is found, a :class:`PackagingError` is raised.
 
         Args:
-            include (Union[List[str], str]): A string e.g. ``"my_package.my_subpackage"``, or list of strings
+            include (list[str] | str): A string e.g. ``"my_package.my_subpackage"``, or list of strings
                 for the names of the modules to be externed. This can also be a glob-style pattern, as described in :meth:`mock`.
 
-            exclude (Union[List[str], str]): An optional pattern that excludes some patterns that match the include string.
+            exclude (list[str] | str): An optional pattern that excludes some patterns that match the include string.
         """
         self.patterns[GlobGroup(include, exclude=exclude)] = _PatternInfo(
             _ModuleProviderAction.DENY, allow_empty=True

--- a/torch/package/package_importer.py
+++ b/torch/package/package_importer.py
@@ -328,11 +328,11 @@ class PackageImporter(Importer):
         """Returns a file structure representation of package's zipfile.
 
         Args:
-            include (Union[List[str], str]): An optional string e.g. ``"my_package.my_subpackage"``, or optional list of strings
+            include (list[str] | str): An optional string e.g. ``"my_package.my_subpackage"``, or optional list of strings
                 for the names of the files to be included in the zipfile representation. This can also be
                 a glob-style pattern, as described in :meth:`PackageExporter.mock`
 
-            exclude (Union[List[str], str]): An optional pattern that excludes files whose name match the pattern.
+            exclude (list[str] | str): An optional pattern that excludes files whose name match the pattern.
 
         Returns:
             :class:`Directory`
@@ -348,7 +348,7 @@ class PackageImporter(Importer):
         file later on.
 
         Returns:
-            :class:`Optional[str]` a python version e.g. 3.8.9 or None if no version was stored with this package
+            :class:`str | None` a python version e.g. 3.8.9 or None if no version was stored with this package
         """
         python_version_path = ".data/python_version"
         return (

--- a/torch/profiler/profiler.py
+++ b/torch/profiler/profiler.py
@@ -1,14 +1,15 @@
 # mypy: allow-untyped-defs
+from __future__ import annotations
+
 import gzip
 import json
 import os
 import shutil
 import tempfile
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Iterable
 from enum import Enum
 from functools import partial
-from typing import Any, Optional
+from typing import Any, TYPE_CHECKING
 from typing_extensions import deprecated, Self
 from warnings import warn
 
@@ -26,6 +27,10 @@ from torch._environment import is_fbcode
 from torch._utils_internal import profiler_allow_cudagraph_cupti_lazy_reinit_cuda12
 from torch.autograd import kineto_available, ProfilerActivity
 from torch.profiler._memory_profiler import MemoryProfile, MemoryProfileTimeline
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable
 
 
 __all__ = [
@@ -774,8 +779,7 @@ class profile(_KinetoProfile):
             with_modules=with_modules,
             experimental_config=experimental_config,
             execution_trace_observer=execution_trace_observer
-            if execution_trace_observer
-            else ExecutionTraceObserver.build_execution_trace_obs_from_env(),
+            or ExecutionTraceObserver.build_execution_trace_obs_from_env(),
             acc_events=acc_events,
             custom_trace_id_callback=custom_trace_id_callback,
             post_processing_timeout_s=post_processing_timeout_s,
@@ -966,7 +970,7 @@ class ExecutionTraceObserver(_ITraceObserver):
         self.unregister_callback()
 
     @staticmethod
-    def build_execution_trace_obs_from_env() -> Optional["ExecutionTraceObserver"]:
+    def build_execution_trace_obs_from_env() -> ExecutionTraceObserver | None:
         """
         Returns an ExecutionTraceObserver instance if the environment variable
         ENABLE_PYTORCH_EXECUTION_TRACE is set to 1, otherwise returns None.

--- a/torch/sparse/__init__.py
+++ b/torch/sparse/__init__.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 # The Tensor classes are added to this module by python_tensor.cpp
 # A workaround to support both TorchScript and MyPy:
-from typing import Any, Optional, TYPE_CHECKING, Union
+from typing import Any, TYPE_CHECKING
 
 import torch
 from torch import Tensor
@@ -19,11 +19,11 @@ from .semi_structured import (
 if TYPE_CHECKING:
     from torch.types import _dtype as DType
 
-    DimOrDims = Optional[int | tuple[int, ...] | list[int]]
+    DimOrDims = int | tuple[int, ...] | list[int] | None
 else:
     # The JIT doesn't understand Union, nor torch.dtype here
     DType = int
-    DimOrDims = Optional[tuple[int]]
+    DimOrDims = tuple[int] | None
 
 
 __all__ = [


### PR DESCRIPTION
Convert Union[X, Y] to X | Y and Optional[X] to X | None using ruff rules UP007 and UP045 in torch/optim through torch/special.

Fix misc ruff issues related to callable as well