### PR TITLE
Add CUDA header inclusion in CUDASymmetricMemoryTypes.hpp

### DIFF
--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryTypes.hpp
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryTypes.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cuda.h>
 #include <cstddef>
 #include <cstdint>
 


### PR DESCRIPTION
Build fails with `error: ‘CUmemGenericAllocationHandle’ does not name a type: using HandleType = CUmemGenericAllocationHandle;`

As needed headers are not present in the file, perhaps they arrive from some outside includes, which is flaky. 