### PR TITLE
Fix GuardOnDataDependentSymNode UserError to preserve original exception

### DIFF
--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -3788,11 +3788,11 @@ def _get_fake_value_impl(
         elif isinstance(
             cause, torch.fx.experimental.symbolic_shapes.GuardOnDataDependentSymNode
         ):
-            raise UserError(  # noqa: B904
+            raise UserError(
                 UserErrorType.CONSTRAINT_VIOLATION,
                 str(cause),
                 case_name="constrain_as_size_example",
-            )
+            ) from cause
         elif isinstance(cause, ValueRangeError):
             raise UserError(UserErrorType.CONSTRAINT_VIOLATION, e.args[0]) from e
         elif isinstance(cause, TypeError) and "argument" in str(cause):


### PR DESCRIPTION
     Fixes #111075.

     When exporting, the branch that handles `GuardOnDataDependentSymNode` raised a new `UserError` without chaining the original exception. This could hide the underlying cause.

     This PR updates that branch in `torch/_dynamo/utils.py` to use `raise UserError(... ) from cause`, so the original exception is preserved while still surfacing the user-friendly error.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo