### PR TITLE
[AOTI Eager] Support multi-return ops in AOTIPythonKernelHolder

### DIFF
--- a/test/cpp/aoti_eager/kernel_meta_info_test.cpp
+++ b/test/cpp/aoti_eager/kernel_meta_info_test.cpp
@@ -1,0 +1,138 @@
+// Tests for TensorMetadata::dynamic_check and ParameterMetadata::dynamic_check,
+// which enable a single compiled AOTI kernel to serve multiple input shapes by
+// matching dtype/device/rank instead of exact sizes and strides.
+
+#if !defined(C10_MOBILE) && !defined(ANDROID)
+
+#include <gtest/gtest.h>
+
+#include <torch/csrc/inductor/aoti_eager/kernel_meta_info.h>
+
+namespace torch::inductor {
+
+namespace {
+
+TensorMetadata makeTensorMeta(
+    c10::ScalarType dtype,
+    std::vector<int64_t> sizes,
+    std::vector<int64_t> strides,
+    c10::Device device = c10::Device(c10::kCPU)) {
+  return TensorMetadata(
+      /*is_symbolic=*/false,
+      dtype,
+      device,
+      c10::DispatchKeySet(c10::DispatchKey::CPU),
+      std::move(sizes),
+      std::move(strides));
+}
+
+} // namespace
+
+// ---------- TensorMetadata::dynamic_check ----------
+
+TEST(TensorMetadataDynamicCheckTest, MatchesSameDtypeDeviceRankDifferentSizes) {
+  auto a = makeTensorMeta(c10::kFloat, {4, 8}, {8, 1});
+  auto b = makeTensorMeta(c10::kFloat, {16, 32}, {32, 1});
+  EXPECT_TRUE(a.dynamic_check(b));
+  // Exact comparison should fail because sizes differ
+  EXPECT_FALSE(a == b);
+}
+
+TEST(TensorMetadataDynamicCheckTest, RejectsDifferentDtype) {
+  auto a = makeTensorMeta(c10::kFloat, {4, 8}, {8, 1});
+  auto b = makeTensorMeta(c10::kHalf, {4, 8}, {8, 1});
+  EXPECT_FALSE(a.dynamic_check(b));
+}
+
+TEST(TensorMetadataDynamicCheckTest, RejectsDifferentRank) {
+  auto a = makeTensorMeta(c10::kFloat, {4, 8}, {8, 1});
+  auto b = makeTensorMeta(c10::kFloat, {4, 8, 2}, {16, 2, 1});
+  EXPECT_FALSE(a.dynamic_check(b));
+}
+
+TEST(TensorMetadataDynamicCheckTest, RejectsDifferentDevice) {
+  auto cpu = makeTensorMeta(c10::kFloat, {4}, {1}, c10::Device(c10::kCPU));
+  auto cuda = makeTensorMeta(c10::kFloat, {4}, {1}, c10::Device(c10::kCUDA, 0));
+  EXPECT_FALSE(cpu.dynamic_check(cuda));
+}
+
+TEST(TensorMetadataDynamicCheckTest, MatchesIdenticalMetadata) {
+  auto a = makeTensorMeta(c10::kFloat, {4, 8}, {8, 1});
+  auto b = makeTensorMeta(c10::kFloat, {4, 8}, {8, 1});
+  EXPECT_TRUE(a.dynamic_check(b));
+  EXPECT_TRUE(a == b);
+}
+
+TEST(TensorMetadataDynamicCheckTest, MatchesScalarTensors) {
+  auto a = makeTensorMeta(c10::kFloat, {}, {});
+  auto b = makeTensorMeta(c10::kFloat, {}, {});
+  EXPECT_TRUE(a.dynamic_check(b));
+}
+
+// ---------- ParameterMetadata::dynamic_check ----------
+
+TEST(ParameterMetadataDynamicCheckTest, TensorMatchesDifferentSizes) {
+  ParameterMetadata a(makeTensorMeta(c10::kFloat, {4, 8}, {8, 1}), 0);
+  ParameterMetadata b(makeTensorMeta(c10::kFloat, {16, 32}, {32, 1}), 0);
+  EXPECT_TRUE(a.dynamic_check(b));
+  EXPECT_FALSE(a == b);
+}
+
+TEST(ParameterMetadataDynamicCheckTest, TensorRejectsDifferentDtype) {
+  ParameterMetadata a(makeTensorMeta(c10::kFloat, {4}, {1}), 0);
+  ParameterMetadata b(makeTensorMeta(c10::kHalf, {4}, {1}), 0);
+  EXPECT_FALSE(a.dynamic_check(b));
+}
+
+TEST(ParameterMetadataDynamicCheckTest, RejectsDifferentOrder) {
+  ParameterMetadata a(makeTensorMeta(c10::kFloat, {4}, {1}), 0);
+  ParameterMetadata b(makeTensorMeta(c10::kFloat, {4}, {1}), 1);
+  EXPECT_FALSE(a.dynamic_check(b));
+}
+
+TEST(ParameterMetadataDynamicCheckTest, ScalarUsesExactMatch) {
+  ParameterMetadata a(c10::Scalar(1.5), 0);
+  ParameterMetadata b(c10::Scalar(1.5), 0);
+  EXPECT_TRUE(a.dynamic_check(b));
+
+  ParameterMetadata c(c10::Scalar(2.0), 0);
+  EXPECT_FALSE(a.dynamic_check(c));
+}
+
+TEST(ParameterMetadataDynamicCheckTest, TensorListMatchesDifferentSizes) {
+  std::vector<TensorMetadata> list_a = {
+      makeTensorMeta(c10::kFloat, {4, 8}, {8, 1}),
+      makeTensorMeta(c10::kFloat, {2, 8}, {8, 1}),
+  };
+  std::vector<TensorMetadata> list_b = {
+      makeTensorMeta(c10::kFloat, {16, 32}, {32, 1}),
+      makeTensorMeta(c10::kFloat, {8, 32}, {32, 1}),
+  };
+  ParameterMetadata a(list_a, 0);
+  ParameterMetadata b(list_b, 0);
+  EXPECT_TRUE(a.dynamic_check(b));
+}
+
+TEST(ParameterMetadataDynamicCheckTest, TensorListRejectsDifferentLengths) {
+  std::vector<TensorMetadata> one = {makeTensorMeta(c10::kFloat, {4}, {1})};
+  std::vector<TensorMetadata> two = {
+      makeTensorMeta(c10::kFloat, {4}, {1}),
+      makeTensorMeta(c10::kFloat, {8}, {1}),
+  };
+  ParameterMetadata a(one, 0);
+  ParameterMetadata b(two, 0);
+  EXPECT_FALSE(a.dynamic_check(b));
+}
+
+TEST(ParameterMetadataDynamicCheckTest, StringUsesExactMatch) {
+  ParameterMetadata a(std::string("sum"), 0);
+  ParameterMetadata b(std::string("sum"), 0);
+  EXPECT_TRUE(a.dynamic_check(b));
+
+  ParameterMetadata c(std::string("mean"), 0);
+  EXPECT_FALSE(a.dynamic_check(c));
+}
+
+} // namespace torch::inductor
+
+#endif // !defined(C10_MOBILE) && !defined(ANDROID)

--- a/torch/csrc/inductor/aoti_eager/kernel_holder.cpp
+++ b/torch/csrc/inductor/aoti_eager/kernel_holder.cpp
@@ -198,11 +198,15 @@ bool AOTIPythonKernelHolder::cache_lookup(
     const torch::jit::Stack* stack,
     AOTIKernelMetadata& aoti_kernel_metadata) {
   TORCH_CHECK_NOT_IMPLEMENTED(
-      op.schema().returns().size() == 1,
-      "Not implemented for operations that return either multiple values or no value.");
-  TORCH_CHECK_NOT_IMPLEMENTED(
-      op.schema().returns()[0].type()->isSubtypeOf(c10::TensorType::get()),
-      "Not implemented for operations that return a non-Tensor value.");
+      op.schema().returns().size() >= 1,
+      "Not implemented for operations that return no value.");
+  for (const auto& ret : op.schema().returns()) {
+    TORCH_CHECK_NOT_IMPLEMENTED(
+        ret.type()->isSubtypeOf(c10::TensorType::get()),
+        "Not implemented for operations that return a non-Tensor value. "
+        "Got return type: ",
+        ret.type()->str());
+  }
 
   auto inputs_metadata =
       unpack_input_parameters(op.schema().arguments(), *stack);

--- a/torch/csrc/inductor/aoti_eager/kernel_meta_info.h
+++ b/torch/csrc/inductor/aoti_eager/kernel_meta_info.h
@@ -69,6 +69,10 @@ struct TensorMetadata {
 
   // Compare two TensorMetadata objects
   bool operator==(const TensorMetadata& other) const;
+
+  // Dynamic-shape-aware comparison: matches by dtype/device/rank but
+  // skips exact sizes/strides comparison.
+  bool dynamic_check(const TensorMetadata& other) const;
 };
 
 // ParameterTag is to represent the type of the input parameters of a aten
@@ -131,6 +135,11 @@ struct ParameterMetadata {
   ParameterMetadata(const c10::Device& device, uint64_t input_order);
 
   bool operator==(const ParameterMetadata& other) const;
+
+  // Dynamic-shape-aware comparison: matches by type/dtype/device/rank but
+  // skips exact size/stride comparison for tensors, so a single compiled
+  // kernel can serve multiple input shapes.
+  bool dynamic_check(const ParameterMetadata& other) const;
 
  private:
   // Helper function to compare two ParameterMetadata objects with the same


### PR DESCRIPTION
Summary:
Relax the cache_lookup assertion from requiring exactly 1 return value to requiring >= 1 return values, all of Tensor type. This enables ops like native_layer_norm (returns 3 Tensors) to dispatch through the AOTI eager path.

The existing cache_hit and cache_miss output handling already loops over all returned tensors and pushes them to the stack individually, so no changes are needed there. The only blocker was the overly restrictive TORCH_CHECK_NOT_IMPLEMENTED gate.

Test Plan:
```
buck run fbcode//mode/opt fbcode//mtia/host_runtime/aoti_eager:test_aoti_eager_dispatch_bin -- TestAotiEagerDispatch.test_multi_return_op_aminmax
```

Reviewed By: arui-meta

Differential Revision: D94364952




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo