### PR TITLE
Fixes precision issue when padding nested tensor

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -14734,7 +14734,7 @@
 #   torch/nested/__init__.py, and the desired C++ name in torch/csrc/api/include/torch/nested.h.
 #   The "nested_" names should be hidden from the user and not documented.
 
-- func: nested_to_padded_tensor(Tensor self, float padding, int[]? output_size=None) -> Tensor
+- func: nested_to_padded_tensor(Tensor self, Scalar padding, int[]? output_size=None) -> Tensor
   python_module: nested
   variants: function
 
@@ -15112,7 +15112,7 @@
   tags: view_copy
   autogen: alias_copy.out
 
-- func: to_padded_tensor(Tensor self, float padding, SymInt[]? output_size=None) -> Tensor
+- func: to_padded_tensor(Tensor self, Scalar padding, SymInt[]? output_size=None) -> Tensor
   variants: method
   dispatch:
     NestedTensorCPU: NestedTensor_to_padded_tensor_generic

--- a/aten/src/ATen/native/nested/NestedTensorAliases.cpp
+++ b/aten/src/ATen/native/nested/NestedTensorAliases.cpp
@@ -6,7 +6,7 @@ namespace at::native {
 // alias for to_padded_tensor in nested namespace
 Tensor nested_to_padded_tensor(
     const Tensor& t,
-    double padding,
+    const Scalar& padding,
     OptionalIntArrayRef output_size) {
     return t.to_padded_tensor(padding, output_size);
 }

--- a/aten/src/ATen/native/nested/NestedTensorMath.cpp
+++ b/aten/src/ATen/native/nested/NestedTensorMath.cpp
@@ -41,7 +41,7 @@ int64_t num_bytes(IntArrayRef sizes) {
 Tensor pad_tensor_to_shape(
     const Tensor& t,
     IntArrayRef goal_shape,
-    double value = 0) {
+    const Scalar& value) {
   std::vector<int64_t> padding;
   auto tup = t.sizes();
   TORCH_CHECK(
@@ -236,7 +236,7 @@ Tensor nested_from_padded_generic(
         size.data_ptr<int64_t>(), size.data_ptr<int64_t>() + size.numel());
     at::Tensor mask_i = padded_transformed.new_full(
         sizes_i, true, kBool, std::nullopt, std::nullopt, std::nullopt);
-    masks.push_back(pad_tensor_to_shape(mask_i, target_size_arr));
+    masks.push_back(pad_tensor_to_shape(mask_i, target_size_arr, false));
   }
   at::Tensor final_mask = at::stack(masks);
   at::Tensor new_buffer = padded_transformed.masked_select(final_mask).to(padded.device());
@@ -246,7 +246,7 @@ Tensor nested_from_padded_generic(
 
 Tensor NestedTensor_to_padded_tensor_generic(
     const Tensor& t,
-    double padding,
+    const Scalar& padding,
     OptionalIntArrayRef output_size) {
   // TODO: support noncontiguous case
   // error out for now

--- a/aten/src/ATen/native/nested/NestedTensorMath.h
+++ b/aten/src/ATen/native/nested/NestedTensorMath.h
@@ -8,7 +8,7 @@ namespace at::native {
 
 TORCH_API Tensor NestedTensor_to_padded_tensor_generic(
     const Tensor& t,
-    double padding,
+    const Scalar& padding,
     OptionalIntArrayRef output_size);
 
 template <typename Func>

--- a/aten/src/ATen/native/nested/cuda/NestedTensorTransformerFunctions.cpp
+++ b/aten/src/ATen/native/nested/cuda/NestedTensorTransformerFunctions.cpp
@@ -137,7 +137,7 @@ static Tensor batch_offsets_from_efficient_size(const Tensor& ef_sizes) {
 
 Tensor NestedTensor_to_padded_tensor_cuda(
     const Tensor& t,
-    double padding,
+    const Scalar& padding,
     OptionalIntArrayRef output_size) {
   TORCH_CHECK(t.numel() > 0, "to_padded_tensor: at least one constituent tensor should have non-zero numel")
   int64_t t_dim = t.dim();
@@ -202,7 +202,7 @@ Tensor NestedTensor_to_padded_tensor_cuda(
           add_padding_kernelLauncher(
               nt_buffer.data_ptr<scalar_t>(),
               output.data_ptr<scalar_t>(),
-              (scalar_t)(padding),
+              padding.to<scalar_t>(),
               offsets.data_ptr<int>(),
               nt_sizes.data_ptr<int>(),
               input_dim,

--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -1415,6 +1415,21 @@ class TestNestedTensorDeviceType(NestedTensorTestCase):
         padded = torch.nested.to_padded_tensor(nt, pad)
         self.assertEqual(padded, correct_output)
 
+    def test_to_padded_tensor_int64_padding_precision(self, device):
+        # Large int64 values beyond float64 precision (2^53) must not lose precision
+        padding_value = -7704671799122851728
+        nt = torch.nested.nested_tensor(
+            [
+                torch.tensor([1, padding_value], device=device, dtype=torch.int64),
+                torch.tensor([padding_value], device=device, dtype=torch.int64),
+            ]
+        )
+        padded = torch.nested.to_padded_tensor(nt, padding=padding_value)
+        self.assertEqual(padded[0, 0], 1)
+        self.assertEqual(padded[0, 1], padding_value)
+        self.assertEqual(padded[1, 0], padding_value)
+        self.assertEqual(padded[1, 1], padding_value)
+
     # TODO: test noncontiguous to_padded_tensor
     # For now this tests the functionality of noncontiguous_to_padded_tensor
     # and the error message of to_padded_tensor

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -2860,7 +2860,7 @@
   padded: _nested_from_padded_backward(grad, padded, fuse_transform_0213)
   cpu_nested_shape_example: non_differentiable
 
-- name: to_padded_tensor(Tensor self, float padding, SymInt[]? output_size=None) -> Tensor
+- name: to_padded_tensor(Tensor self, Scalar padding, SymInt[]? output_size=None) -> Tensor
   self: "self.layout() == c10::kJagged ? at::_nested_from_padded_tensor_symint(grad, at::_nested_get_offsets(self), at::_nested_get_jagged_dummy(self), at::_nested_get_ragged_idx(self), at::_nested_get_min_seqlen(self).defined() ? std::optional<Tensor>(at::_nested_get_min_seqlen(self)) : ::std::nullopt, at::_nested_get_max_seqlen(self).defined() ? std::optional<Tensor>(at::_nested_get_max_seqlen(self)) : ::std::nullopt, std::optional<c10::SymInt>(at::_nested_get_values(self).sym_size(0))) : at::_nested_from_padded(grad, self._nested_tensor_size())"
   padding: non_differentiable
 

--- a/torch/nested/__init__.py
+++ b/torch/nested/__init__.py
@@ -172,7 +172,7 @@ while the trailing entries will be padded.
     since the nested and the non-nested tensors differ in memory layout.
 
 Args:
-    padding (float): The padding value for the trailing entries.
+    padding (Number): The padding value for the trailing entries.
 
 Keyword args:
     output_size (Tuple[int]): The size of the output tensor.


### PR DESCRIPTION
Fixes #175866

The padding for Nested Long Tensor might lead to loss of precision.

```python
import torch

sample = nested_tensor([
  tensor([                   1, -7704671799122851728]),
  tensor([-7704671799122851728])
])

padded_tensor = torch.nested.to_padded_tensor(sample, padding=-7704671799122851728)
print(padded_tensor)
# tensor([[                   1, -7704671799122851728],
#         [-7704671799122851728, -7704671799122851840]])
```
As can be seen, the padding value loses precision. 

_Note that rest of the values don't lose precision (e.g. -7704671799122851728 in the sample don't lose precision but the same value when used for padding loses the precision)_