### PR TITLE
[distributed] Add configurable worker timeout and partial data support to debug server

### DIFF
--- a/test/distributed/test_debug.py
+++ b/test/distributed/test_debug.py
@@ -2,8 +2,13 @@
 
 import os
 import shutil
+import socket
 import tempfile
+import threading
 import time
+import unittest
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from unittest.mock import patch
 
 import requests
 from requests.adapters import HTTPAdapter
@@ -15,11 +20,22 @@ import torch.distributed.debug as debug_module
 from torch.distributed.debug import start_debug_server, stop_debug_server
 from torch.distributed.debug._frontend import (
     DebugHandler,
+    fetch_thread_pool,
+    format_fetch_summary,
     NavLink,
     PeriodicDumper,
+    Response,
     Route,
 )
 from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+try:
+    from torch.distributed.debug._frontend import fetch_aiohttp
+
+    HAS_AIOHTTP = True
+except ImportError:
+    HAS_AIOHTTP = False
 
 
 session = requests.Session()
@@ -255,6 +271,208 @@ class TestPeriodicDumper(TestCase):
             dumper.start()
             dumper.stop()
             dumper.stop()
+
+
+class TestFetchUnavailableWorkers(TestCase):
+    @staticmethod
+    def _get_refused_port() -> int:
+        """Return a port that will refuse connections."""
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.bind(("localhost", 0))
+        port = sock.getsockname()[1]
+        sock.close()
+        return port
+
+    def test_fetch_thread_pool_connection_refused(self) -> None:
+        port = self._get_refused_port()
+        resps = fetch_thread_pool(
+            [f"http://localhost:{port}/handler/ping"], timeout=1.0
+        )
+        self.assertEqual(len(resps), 1)
+        self.assertEqual(resps[0].status_code, 503)
+        self.assertIn("ConnectionError:", resps[0].text)
+
+    def test_fetch_thread_pool_timeout(self) -> None:
+        server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        server.bind(("localhost", 0))
+        server.listen(1)
+        port = server.getsockname()[1]
+        try:
+            resps = fetch_thread_pool(
+                [f"http://localhost:{port}/handler/ping"], timeout=0.5
+            )
+            self.assertEqual(len(resps), 1)
+            self.assertEqual(resps[0].status_code, 408)
+            self.assertIn("Timeout:", resps[0].text)
+        finally:
+            server.close()
+
+    @unittest.skipUnless(HAS_AIOHTTP, "aiohttp not installed")
+    def test_fetch_aiohttp_connection_refused(self) -> None:
+        port = self._get_refused_port()
+        resps = fetch_aiohttp([f"http://localhost:{port}/handler/ping"], timeout=1.0)
+        self.assertEqual(len(resps), 1)
+        self.assertEqual(resps[0].status_code, 503)
+        self.assertIn("Error:", resps[0].text)
+
+    @unittest.skipUnless(HAS_AIOHTTP, "aiohttp not installed")
+    def test_fetch_aiohttp_timeout(self) -> None:
+        server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        server.bind(("localhost", 0))
+        server.listen(1)
+        port = server.getsockname()[1]
+        try:
+            resps = fetch_aiohttp(
+                [f"http://localhost:{port}/handler/ping"], timeout=0.5
+            )
+            self.assertEqual(len(resps), 1)
+            # aiohttp may report timeout as 408 or wrap it in a ClientError (503)
+            self.assertIn(resps[0].status_code, (408, 503))
+        finally:
+            server.close()
+
+    def test_mixed_available_and_unavailable(self) -> None:
+        class _OKHandler(BaseHTTPRequestHandler):
+            def do_POST(self):
+                self.send_response(200)
+                self.end_headers()
+                self.wfile.write(b"pong")
+
+            def log_message(self, *args):
+                pass
+
+        http_server = HTTPServer(("localhost", 0), _OKHandler)
+        good_port = http_server.server_address[1]
+        t = threading.Thread(target=http_server.serve_forever, daemon=True)
+        t.start()
+
+        bad_port = self._get_refused_port()
+        try:
+            urls = [
+                f"http://localhost:{good_port}/handler/ping",
+                f"http://localhost:{bad_port}/handler/ping",
+            ]
+            resps = fetch_thread_pool(urls, timeout=1.0)
+            self.assertEqual(len(resps), 2)
+            self.assertEqual(resps[0].status_code, 200)
+            self.assertEqual(resps[0].text, "pong")
+            self.assertNotEqual(resps[1].status_code, 200)
+        finally:
+            http_server.shutdown()
+
+
+class TestFormatFetchSummary(TestCase):
+    def test_all_success_returns_none(self) -> None:
+        addrs = ["http://host0:1", "http://host1:1"]  # @lint-ignore
+        resps = [Response(200, "ok"), Response(200, "ok")]
+        self.assertIsNone(format_fetch_summary(addrs, resps))
+
+    def test_partial_failure(self) -> None:
+        addrs = ["http://h0:1", "http://h1:1", "http://h2:1"]  # @lint-ignore
+        resps = [
+            Response(200, "ok"),
+            Response(503, "Worker unavailable"),
+            Response(200, "ok"),
+        ]
+        summary = format_fetch_summary(addrs, resps)
+        self.assertIsNotNone(summary)
+        self.assertIn("PARTIAL DATA", summary)
+        self.assertIn("2/3", summary)
+        self.assertIn("Rank 1", summary)
+
+    def test_all_failed(self) -> None:
+        addrs = ["http://h0:1", "http://h1:1"]  # @lint-ignore
+        resps = [Response(503, "unavailable"), Response(408, "timeout")]
+        summary = format_fetch_summary(addrs, resps)
+        self.assertIsNotNone(summary)
+        self.assertIn("0/2", summary)
+
+    def test_timeout_message_included(self) -> None:
+        addrs = ["http://h0:1"]  # @lint-ignore
+        resps = [Response(408, "Request timed out after 10.0s")]
+        summary = format_fetch_summary(addrs, resps)
+        self.assertIn("timed out", summary)
+
+
+class TestFetchTimeout(TestCase):
+    def test_handler_default_fetch_timeout(self) -> None:
+        from torch.distributed.debug._frontend import _DEFAULT_FETCH_TIMEOUT
+
+        handler = _StubHandler("test", "data")
+        self.assertEqual(handler.fetch_timeout, _DEFAULT_FETCH_TIMEOUT)
+
+    def test_handler_fetch_timeout_override(self) -> None:
+        handler = _StubHandler("test", "data")
+        handler.fetch_timeout = 5.0
+        self.assertEqual(handler.fetch_timeout, 5.0)
+
+    def test_fetch_all_requires_timeout(self) -> None:
+        from torch.distributed.debug._frontend import fetch_all
+
+        with self.assertRaises(TypeError):
+            # fetch_all requires timeout as a keyword-only argument
+            fetch_all("test_endpoint")  # type: ignore[call-arg]
+
+
+class TestHandlerPartialDumps(TestCase):
+    @patch("torch.distributed.debug._debug_handlers.fetch_all")
+    def test_stacks_handler_partial_dump(self, mock_fetch_all) -> None:
+        from torch.distributed.debug._debug_handlers import StacksHandler
+
+        mock_fetch_all.return_value = (
+            [
+                "http://h0:1/handler/dump_traceback?",  # @lint-ignore
+                "http://h1:1/handler/dump_traceback?",  # @lint-ignore
+            ],
+            [Response(200, "stack0"), Response(503, "Worker unavailable")],
+        )
+        handler = StacksHandler()
+        content = handler.dump()
+        self.assertIn("PARTIAL DATA", content)
+        self.assertIn("1/2", content)
+        self.assertIn("stack0", content)
+        self.assertIn("Error: 503", content)
+
+    @patch("torch.distributed.debug._debug_handlers.fetch_all")
+    def test_stacks_handler_all_success(self, mock_fetch_all) -> None:
+        from torch.distributed.debug._debug_handlers import StacksHandler
+
+        mock_fetch_all.return_value = (
+            [
+                "http://h0:1/handler/dump_traceback?",  # @lint-ignore
+                "http://h1:1/handler/dump_traceback?",  # @lint-ignore
+            ],
+            [Response(200, "stack0"), Response(200, "stack1")],
+        )
+        handler = StacksHandler()
+        content = handler.dump()
+        self.assertNotIn("PARTIAL", content)
+        self.assertIn("stack0", content)
+        self.assertIn("stack1", content)
+
+    def test_periodic_dumper_writes_partial_data(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            partial_content = (
+                "PARTIAL DATA: 1/2 workers responded\n"
+                "  Rank 1: Worker unavailable\n"
+                "\n"
+                "=== Rank 0 ===\ndata0\n"
+                "=== Rank 1 ===\nError: 503"
+            )
+            h = _StubHandler("partial_stacks", partial_content)
+            dumper = PeriodicDumper([h], tmp, interval_seconds=0.1)
+            dumper.start()
+            time.sleep(0.25)
+            dumper.stop()
+
+            files = os.listdir(tmp)
+            self.assertGreater(len(files), 0)
+            with open(os.path.join(tmp, files[0])) as f:
+                content = f.read()
+            self.assertIn("PARTIAL DATA", content)
+            self.assertIn("1/2 workers responded", content)
 
 
 if __name__ == "__main__":

--- a/torch/distributed/debug/__init__.py
+++ b/torch/distributed/debug/__init__.py
@@ -32,6 +32,7 @@ def start_debug_server(
     dump_interval: float = 60.0,
     enabled_dumps: set[str] | None = None,
     handlers: list["DebugHandler"] | None = None,
+    fetch_timeout: float = 60.0,
 ) -> None:
     """
     Start the debug server stack on all workers. The frontend debug server is
@@ -71,6 +72,9 @@ def start_debug_server(
         handlers (list[DebugHandler] | None): List of debug handlers to use. If None,
             uses the default handlers. See torch.distributed.debug._handlers for
             the default handlers.
+        fetch_timeout (float): Timeout in seconds for fetching data from individual
+            workers. Defaults to 60. Workers that don't respond within this time
+            will be reported as unavailable.
     """
     global _WORKER_SERVER, _DEBUG_SERVER_PROC
 
@@ -104,6 +108,7 @@ def start_debug_server(
             "dump_interval": dump_interval,
             "enabled_dumps": enabled_dumps,
             "handlers": handlers,
+            "fetch_timeout": fetch_timeout,
         }
 
         if start_method is not None:

--- a/torch/distributed/debug/_frontend.py
+++ b/torch/distributed/debug/_frontend.py
@@ -6,7 +6,7 @@ import socket
 import threading
 import time
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Iterable
+from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -18,6 +18,8 @@ from torch.distributed.debug._store import get_world_size, tcpstore_client
 
 
 logger: logging.Logger = logging.getLogger(__name__)
+
+_DEFAULT_FETCH_TIMEOUT: float = 60.0
 
 
 # ---------------------------------------------------------------------------
@@ -51,6 +53,8 @@ class Route:
 
 
 class DebugHandler(ABC):
+    fetch_timeout: float = _DEFAULT_FETCH_TIMEOUT
+
     @abstractmethod
     def routes(self) -> list[Route]: ...
 
@@ -72,49 +76,66 @@ class DebugHandler(ABC):
 # ---------------------------------------------------------------------------
 
 
-def fetch_thread_pool(urls: list[str]) -> Iterable[Response]:
+def fetch_thread_pool(urls: list[str], timeout: float) -> list[Response]:
     # late import for optional dependency
     import requests
 
     max_workers = 20
 
     def get(url: str) -> Response:
-        resp = requests.post(url)
-        return Response(resp.status_code, resp.text)
+        try:
+            resp = requests.post(url, timeout=timeout)
+            return Response(resp.status_code, resp.text)
+        except requests.exceptions.Timeout as e:
+            return Response(408, f"Timeout: {e}")
+        except requests.exceptions.ConnectionError as e:
+            return Response(503, f"ConnectionError: {e}")
+        except Exception as e:
+            return Response(502, f"{type(e).__name__}: {e}")
 
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
-        resps = executor.map(get, urls)
+        resps = list(executor.map(get, urls))
 
     return resps
 
 
-def fetch_aiohttp(urls: list[str]) -> Iterable[Response]:
+def fetch_aiohttp(urls: list[str], timeout: float) -> list[Response]:
     # late import for optional dependency
     # pyrefly: ignore [missing-import]
     import aiohttp
 
     async def fetch(session: aiohttp.ClientSession, url: str) -> Response:
-        async with session.post(url) as resp:
-            text = await resp.text()
-            return Response(resp.status, text)
+        try:
+            async with session.post(url) as resp:
+                text = await resp.text()
+                return Response(resp.status, text)
+        except asyncio.TimeoutError as e:
+            return Response(408, f"TimeoutError: {e}")
+        except aiohttp.ClientError as e:
+            return Response(503, f"{type(e).__name__}: {e}")
+        except Exception as e:
+            return Response(502, f"{type(e).__name__}: {e}")
 
-    async def gather(urls: list[str]) -> Iterable[Response]:
-        async with aiohttp.ClientSession() as session:
-            return await asyncio.gather(*[fetch(session, url) for url in urls])
+    async def gather(urls: list[str]) -> list[Response]:
+        client_timeout = aiohttp.ClientTimeout(total=timeout)
+        async with aiohttp.ClientSession(timeout=client_timeout) as session:
+            return list(await asyncio.gather(*[fetch(session, url) for url in urls]))
 
     return asyncio.run(gather(urls))
 
 
-def fetch_all(endpoint: str, args: str = "") -> tuple[list[str], Iterable[Response]]:
+def fetch_all(
+    endpoint: str, args: str = "", *, timeout: float
+) -> tuple[list[str], list[Response]]:
     store = tcpstore_client()
     keys = [f"rank{r}" for r in range(get_world_size())]
     addrs = store.multi_get(keys)
     addrs = [f"{addr.decode()}/handler/{endpoint}?{args}" for addr in addrs]
 
     try:
-        resps = fetch_aiohttp(addrs)
+        resps = fetch_aiohttp(addrs, timeout=timeout)
     except ImportError:
-        resps = fetch_thread_pool(addrs)
+        resps = fetch_thread_pool(addrs, timeout=timeout)
 
     return addrs, resps
 
@@ -122,6 +143,19 @@ def fetch_all(endpoint: str, args: str = "") -> tuple[list[str], Iterable[Respon
 def format_json(blob: str):
     parsed = json.loads(blob)
     return json.dumps(parsed, indent=2)
+
+
+def format_fetch_summary(addrs: list[str], resps: list[Response]) -> str | None:
+    """Return a summary string if any workers failed, or None if all succeeded."""
+    failed = [(i, r) for i, r in enumerate(resps) if r.status_code != 200]
+    if not failed:
+        return None
+    total = len(addrs)
+    ok = total - len(failed)
+    lines = [f"PARTIAL DATA: {ok}/{total} workers responded"]
+    for rank, resp in failed:
+        lines.append(f"  Rank {rank}: {resp.text}")
+    return "\n".join(lines)
 
 
 # ---------------------------------------------------------------------------
@@ -428,7 +462,11 @@ def main(
     dump_interval: float,
     handlers: list[DebugHandler],
     enabled_dumps: set[str],
+    fetch_timeout: float = 60.0,
 ) -> None:
+    for handler in handlers:
+        handler.fetch_timeout = fetch_timeout
+
     logger.setLevel(logging.INFO)
 
     server = FrontendServer(port=port, handlers=handlers)


### PR DESCRIPTION
Previously, fetch_all() had no timeout when pulling data from workers, so a single hung worker would block the entire frontend indefinitely. This adds a configurable worker_timeout (default 10s) to start_debug_server() that propagates through to all HTTP fetch calls.

Fetch functions now catch connection errors and timeouts per-worker, returning error Response objects instead of crashing. This allows the periodic dumpers and web handlers to continue with partial data from the workers that did respond. All dump() methods now prepend a "PARTIAL DATA: N/M workers responded" summary when any workers fail.

FlightRecorderHandler._build_db() no longer calls raise_for_status() on every response — it skips failed workers and only raises if all workers are unreachable.


Test plan:
- TestFetchUnavailableWorkers: verifies fetch_thread_pool and
  fetch_aiohttp return error Response objects (503 for connection
  refused, 408 for timeout) instead of raising. Also tests mixed
  available/unavailable workers in a single fetch call.
- TestFormatFetchSummary: verifies the partial data summary helper
  returns None on all-success, correct "PARTIAL DATA: N/M" messages
  on partial failure, and includes timeout details.
- TestWorkerTimeout: verifies set_worker_timeout() updates the
  module-level default and that fetch_thread_pool uses it when no
  explicit timeout is passed.
- TestHandlerPartialDumps: verifies StacksHandler.dump() includes
  PARTIAL DATA header when some workers fail (via mocked fetch_all),
  omits it on all-success, and that PeriodicDumper writes files
  containing partial data indicators.
- All existing tests continue to pass.