### PR TITLE
fix-cutedsl

### DIFF
--- a/torch/_inductor/codegen/cutedsl/cutedsl_op_overrides.py
+++ b/torch/_inductor/codegen/cutedsl/cutedsl_op_overrides.py
@@ -12,7 +12,7 @@ import sympy
 
 import torch
 from torch._inductor.codegen.common import CSEVariable, OpOverrides
-from torch._inductor.virtualized import NullHandler, OpsValue, V
+from torch._inductor.virtualized import OpsValue, V
 from torch.utils._sympy.value_ranges import ValueRanges
 
 
@@ -71,7 +71,7 @@ class CuteDSLOpOverrides(OpOverrides):
     @staticmethod
     def _node_tensor_flags() -> tuple[bool, bool] | None:
         node = V.current_node
-        if isinstance(node, NullHandler) or node is None or len(node.args) < 2:
+        if not isinstance(node, torch.fx.Node) or len(node.args) < 2:
             return None
 
         def _is_tensor(raw_arg: object) -> bool:
@@ -181,7 +181,7 @@ class CuteDSLOpOverrides(OpOverrides):
     def _expected_tensor_val() -> torch.Tensor | None:
         """Return the fake-tensor value from the current FX node's metadata, if any."""
         node = V.current_node
-        if isinstance(node, NullHandler) or node is None:
+        if not isinstance(node, torch.fx.Node):
             return None
         val = node.meta.get("val")
         return val if isinstance(val, torch.Tensor) else None

--- a/torch/_inductor/codegen/cutedsl/cutedsl_op_overrides.py
+++ b/torch/_inductor/codegen/cutedsl/cutedsl_op_overrides.py
@@ -12,7 +12,7 @@ import sympy
 
 import torch
 from torch._inductor.codegen.common import CSEVariable, OpOverrides
-from torch._inductor.virtualized import OpsValue, V
+from torch._inductor.virtualized import NullHandler, OpsValue, V
 from torch.utils._sympy.value_ranges import ValueRanges
 
 
@@ -71,7 +71,7 @@ class CuteDSLOpOverrides(OpOverrides):
     @staticmethod
     def _node_tensor_flags() -> tuple[bool, bool] | None:
         node = V.current_node
-        if node is None or len(node.args) < 2:
+        if isinstance(node, NullHandler) or node is None or len(node.args) < 2:
             return None
 
         def _is_tensor(raw_arg: object) -> bool:
@@ -181,7 +181,7 @@ class CuteDSLOpOverrides(OpOverrides):
     def _expected_tensor_val() -> torch.Tensor | None:
         """Return the fake-tensor value from the current FX node's metadata, if any."""
         node = V.current_node
-        if node is None:
+        if isinstance(node, NullHandler) or node is None:
             return None
         val = node.meta.get("val")
         return val if isinstance(val, torch.Tensor) else None


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* #176055
* __->__ #176048


❯ pytest -n 15 test/inductor/test_flex_flash.py
=============================================================================== test session starts ===============================================================================
platform linux -- Python 3.12.11, pytest-8.4.1, pluggy-1.6.0
rootdir: /home/dev/meta/pytorch
configfile: pytest.ini
plugins: flakefinder-1.1.0, anyio-4.11.0, typeguard-4.4.4, hypothesis-6.138.7, xdist-3.8.0, rerunfailures-16.0.1
15 workers [210 items]    
.............................

flex_flash was broken, this fixes

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo