### PR TITLE
[xpu][inductor] Add some heuristic for reduce

### DIFF
--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -3247,6 +3247,8 @@ def _reduction_configs(
     elif max_autotune_enabled:
         pass  # skip all these cases
     elif reduction_hint == ReductionHint.INNER:
+        if torch.xpu.is_available():
+            configs.append(make_config(64, 64, num_warps=16))
         return configs + [contiguous_config]
     elif reduction_hint == ReductionHint.OUTER:
         return configs + [outer_config]

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -2918,7 +2918,7 @@ def pointwise(
                     )
             if torch.xpu.is_available():
                 configs.extend(
-                    [  # intel-xpu-backend-for-triton #5133
+                    [  # intel-xpu-backend-for-triton #5124
                         triton_config_with_settings(size_hints, 32),
                     ]
                 )


### PR DESCRIPTION
We see performance regression on xpu in some models because reduction hint change from default to inner in 2.11 release by https://github.com/pytorch/pytorch/commit/bc4d0bf39cc56f4ff3517d503dd80e225143580b. I tried to add more configs for xpu only

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo