### PR TITLE
Fix DeviceMesh opaque __getitem__ failure during aot_export

### DIFF
--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -731,7 +731,10 @@ else:
                 # yet and need a follow-up,
                 # TODO: compiler + device_mesh slicing.
                 with torch._subclasses.fake_tensor.unset_fake_temporarily():
-                    submesh = self._create_sub_mesh(sliced_mesh_layout, mesh_dim_names)
+                    with torch._C._DisableTorchDispatch():
+                        submesh = self._create_sub_mesh(
+                            sliced_mesh_layout, mesh_dim_names
+                        )
                 return submesh
 
         def get_group(self, mesh_dim: int | str | None = None) -> ProcessGroup:

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -730,11 +730,12 @@ else:
                 # we can compile device_mesh `slicing` (no graph break) is not verified
                 # yet and need a follow-up,
                 # TODO: compiler + device_mesh slicing.
-                with torch._subclasses.fake_tensor.unset_fake_temporarily():
-                    with torch._C._DisableTorchDispatch():
-                        submesh = self._create_sub_mesh(
-                            sliced_mesh_layout, mesh_dim_names
-                        )
+                with (
+                    torch._subclasses.fake_tensor.unset_fake_temporarily(),
+                    torch._subclasses.functional_tensor.disable_functional_mode(),
+                    torch.fx.experimental.proxy_tensor.disable_proxy_modes_tracing(),
+                ):
+                    submesh = self._create_sub_mesh(sliced_mesh_layout, mesh_dim_names)
                 return submesh
 
         def get_group(self, mesh_dim: int | str | None = None) -> ProcessGroup:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #176051

When `DeviceMesh.__getitem__` is registered as `INLINED`, it creates a
call_method FX node. During make_fx retracing in aot_export, the FX
interpreter executes `__getitem__` inside proxy tensor tracing. The
`_create_sub_mesh` path does data-dependent tensor ops (nonzero + scalar
indexing) that fail under ProxyTorchDispatchMode/FunctionalTensorMode.

The existing `unset_fake_temporarily()` only disables FakeTensorMode. Add
`disable_functional_mode()` and `disable_proxy_modes_tracing()` to also
disable the proxy dispatch modes, since `_create_sub_mesh` only operates
on integer rank-map metadata tensors that don't need tracing.

The error was introduced in #169867 and broke TorchTitan

Authored with Claude.