### PR TITLE
Add regression test for Conv3d consistency (Fixes #175982).

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -7641,26 +7641,23 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
             test_rnn_cell(cell_fn, gate_count)
 
     def test_conv3d_initialization_consistency(self):
-        # Verify Conv3d initialization parity across different memory formats
-        # to address inconsistency in non-contiguous layouts (e.g., channels_last_3d)
+        # 1. Conv3d layer create karein
         m = torch.nn.Conv3d(3, 6, kernel_size=3)
         
-        # Scenario 1: Default contiguous initialization
+        # 2. Contiguous (Default) format test karein
         torch.manual_seed(42)
         m.reset_parameters()
         weights_default = m.weight.clone().detach()
         
-        # Scenario 2: Non-contiguous (channels_last_3d) initialization
+        # 3. Channels Last 3D format test karein
         m.to(memory_format=torch.channels_last_3d)
         torch.manual_seed(42)
         m.reset_parameters()
         weights_channels_last = m.weight.clone().detach()
         
-        # Assert bit-wise parity between the two layouts
-        self.assertTrue(
-            torch.allclose(weights_default, weights_channels_last),
-            "Conv3d initialization is inconsistent between contiguous and non-contiguous layouts"
-        )
+        # 4. Compare karein ke dono identical hain
+        self.assertEqual(weights_default, weights_channels_last, 
+                         msg="Conv3d initialization is inconsistent between memory formats")
 
 class TestFusionEval(TestCase):
     @set_default_dtype(torch.double)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -7641,21 +7641,21 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
             test_rnn_cell(cell_fn, gate_count)
 
     def test_conv3d_initialization_consistency(self):
-        # 1. Conv3d layer create karein
+        # 1. Create a Conv3d layer
         m = torch.nn.Conv3d(3, 6, kernel_size=3)
         
-        # 2. Contiguous (Default) format test karein
+        # 2. Test initialization in default (contiguous) format
         torch.manual_seed(42)
         m.reset_parameters()
         weights_default = m.weight.clone().detach()
         
-        # 3. Channels Last 3D format test karein
+        # 3. Test initialization in channels_last_3d format
         m.to(memory_format=torch.channels_last_3d)
         torch.manual_seed(42)
         m.reset_parameters()
         weights_channels_last = m.weight.clone().detach()
         
-        # 4. Compare karein ke dono identical hain
+        # 4. Verify both initializations are identical
         self.assertEqual(weights_default, weights_channels_last, 
                          msg="Conv3d initialization is inconsistent between memory formats")
 


### PR DESCRIPTION
Added a unit test to the TestNN class to verify that Conv3d.reset_parameters  ensures numerical consistency across contiguous and non-contiguous layouts. 

This test specifically addresses the bug reported in #175982 and ensures  that future changes do not re-introduce the initialization disparity  found in channels_last_3d format.