### PR TITLE
[distributed] Add max_dumps parameter to PeriodicDumper

### DIFF
--- a/torch/distributed/debug/__init__.py
+++ b/torch/distributed/debug/__init__.py
@@ -33,6 +33,7 @@ def start_debug_server(
     enabled_dumps: set[str] | None = None,
     handlers: list["DebugHandler"] | None = None,
     fetch_timeout: float = 60.0,
+    max_dumps: int | None = None,
 ) -> None:
     """
     Start the debug server stack on all workers. The frontend debug server is
@@ -75,6 +76,8 @@ def start_debug_server(
         fetch_timeout (float): Timeout in seconds for fetching data from individual
             workers. Defaults to 60. Workers that don't respond within this time
             will be reported as unavailable.
+        max_dumps (int | None): Maximum number of dump cycles to perform. If None
+            (default), dumps continue indefinitely until the server is stopped.
     """
     global _WORKER_SERVER, _DEBUG_SERVER_PROC
 
@@ -109,6 +112,7 @@ def start_debug_server(
             "enabled_dumps": enabled_dumps,
             "handlers": handlers,
             "fetch_timeout": fetch_timeout,
+            "max_dumps": max_dumps,
         }
 
         if start_method is not None:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #176061
* #176060
* __->__ #176059
* #176058

PeriodicDumper writes dump files indefinitely with no way to limit
output. A long-running job with default 60s interval and 2 handlers
produces ~2,880 files/day. This adds a `max_dumps` parameter to cap
the total number of dump cycles, after which the dumper thread exits
cleanly.

The parameter is threaded through `start_debug_server()` and `main()`.

Authored with Claude.