### PR TITLE
[distributed] Change max_dumps to clean up old dumps instead of limiting total

### DIFF
--- a/torch/distributed/debug/__init__.py
+++ b/torch/distributed/debug/__init__.py
@@ -76,8 +76,9 @@ def start_debug_server(
         fetch_timeout (float): Timeout in seconds for fetching data from individual
             workers. Defaults to 60. Workers that don't respond within this time
             will be reported as unavailable.
-        max_dumps (int | None): Maximum number of dump cycles to perform. If None
-            (default), dumps continue indefinitely until the server is stopped.
+        max_dumps (int | None): Maximum number of dump files to keep per handler.
+            Older dumps are deleted after each cycle. If None (default), dumps
+            are never cleaned up.
     """
     global _WORKER_SERVER, _DEBUG_SERVER_PROC
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #176061
* __->__ #176060
* #176059
* #176058

max_dumps now caps the number of dump files kept per handler by deleting
the oldest files after each cycle, rather than stopping the dumper after
N cycles. This keeps diagnostic data flowing while bounding disk usage.

Also adds microsecond precision to dump filenames to avoid overwrites
when the dump interval is sub-second.

Authored with Claude.