### PR TITLE
[distributed] Add max_dumps cleanup to PeriodicDumper

### DIFF
--- a/test/distributed/test_debug.py
+++ b/test/distributed/test_debug.py
@@ -178,6 +178,38 @@ class _StubHandler(DebugHandler):
         return self._name
 
 
+class _CountingHandler(DebugHandler):
+    """Handler that counts dump() calls and signals after N calls."""
+
+    def __init__(
+        self,
+        name: str = "counting",
+        content: str | None = "data",
+        *,
+        notify_after: int = 1,
+    ) -> None:
+        self.dump_count = 0
+        self._name = name
+        self._content = content
+        self._notify_after = notify_after
+        self.ready = threading.Event()
+
+    def routes(self) -> list[Route]:
+        return []
+
+    def nav_links(self) -> list[NavLink]:
+        return []
+
+    def dump(self) -> str | None:
+        self.dump_count += 1
+        if self.dump_count >= self._notify_after:
+            self.ready.set()
+        return self._content
+
+    def dump_filename(self) -> str:
+        return self._name
+
+
 class _ErrorHandler(DebugHandler):
     """Handler whose dump() always raises."""
 
@@ -197,10 +229,10 @@ class _ErrorHandler(DebugHandler):
 class TestPeriodicDumper(TestCase):
     def test_writes_dump_files(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
-            h = _StubHandler("mystub", "hello world")
-            dumper = PeriodicDumper([h], tmp, interval_seconds=0.1)
+            h = _CountingHandler("mystub", "hello world")
+            dumper = PeriodicDumper([h], tmp, interval_seconds=60.0)
             dumper.start()
-            time.sleep(0.35)
+            h.ready.wait(timeout=5)
             dumper.stop()
 
             files = os.listdir(tmp)
@@ -211,23 +243,23 @@ class TestPeriodicDumper(TestCase):
 
     def test_skips_none_dump(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
-            h = _StubHandler("nodump", None)
-            dumper = PeriodicDumper([h], tmp, interval_seconds=0.1)
+            h = _CountingHandler("nodump", None)
+            dumper = PeriodicDumper([h], tmp, interval_seconds=60.0)
             dumper.start()
-            time.sleep(0.25)
+            h.ready.wait(timeout=5)
             dumper.stop()
 
             self.assertEqual(os.listdir(tmp), [])
 
     def test_enabled_dumps_filter(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
-            h1 = _StubHandler("included", "yes")
-            h2 = _StubHandler("excluded", "no")
+            h1 = _CountingHandler("included", "yes")
+            h2 = _CountingHandler("excluded", "no")
             enabled = {"included"}
             filtered = [h for h in [h1, h2] if h.dump_filename() in enabled]
-            dumper = PeriodicDumper(filtered, tmp, interval_seconds=0.1)
+            dumper = PeriodicDumper(filtered, tmp, interval_seconds=60.0)
             dumper.start()
-            time.sleep(0.25)
+            h1.ready.wait(timeout=5)
             dumper.stop()
 
             files = os.listdir(tmp)
@@ -236,11 +268,13 @@ class TestPeriodicDumper(TestCase):
 
     def test_enabled_dumps_none_runs_all(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
-            h1 = _StubHandler("alpha", "a")
-            h2 = _StubHandler("beta", "b")
-            dumper = PeriodicDumper([h1, h2], tmp, interval_seconds=0.1)
+            h1 = _CountingHandler("alpha", "a")
+            h2 = _CountingHandler("beta", "b")
+            dumper = PeriodicDumper([h1, h2], tmp, interval_seconds=60.0)
             dumper.start()
-            time.sleep(0.25)
+            # Both handlers are called in the same cycle, so waiting on either
+            # guarantees the cycle completed.
+            h2.ready.wait(timeout=5)
             dumper.stop()
 
             files = os.listdir(tmp)
@@ -252,10 +286,10 @@ class TestPeriodicDumper(TestCase):
     def test_survives_handler_exception(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             err = _ErrorHandler()
-            ok = _StubHandler("ok", "survived")
-            dumper = PeriodicDumper([err, ok], tmp, interval_seconds=0.1)
+            ok = _CountingHandler("ok", "survived")
+            dumper = PeriodicDumper([err, ok], tmp, interval_seconds=60.0)
             dumper.start()
-            time.sleep(0.25)
+            ok.ready.wait(timeout=5)
             dumper.stop()
 
             files = os.listdir(tmp)
@@ -263,6 +297,40 @@ class TestPeriodicDumper(TestCase):
             self.assertGreater(len(ok_files), 0)
             err_files = [f for f in files if f.startswith("error_handler_")]
             self.assertEqual(len(err_files), 0)
+
+    def test_max_dumps_cleans_old_files(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            h = _CountingHandler(notify_after=5)
+            dumper = PeriodicDumper([h], tmp, interval_seconds=0, max_dumps=2)
+            dumper.start()
+            h.ready.wait(timeout=5)
+            dumper.stop()
+            files = [f for f in os.listdir(tmp) if f.startswith("counting_")]
+            self.assertEqual(len(files), 2)
+            self.assertGreaterEqual(h.dump_count, 5)
+
+    def test_max_dumps_none_keeps_all(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            h = _CountingHandler(notify_after=5)
+            dumper = PeriodicDumper([h], tmp, interval_seconds=0, max_dumps=None)
+            dumper.start()
+            h.ready.wait(timeout=5)
+            dumper.stop()
+            files = [f for f in os.listdir(tmp) if f.startswith("counting_")]
+            self.assertGreaterEqual(len(files), 5)
+
+    def test_max_dumps_per_handler(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            h1 = _CountingHandler("aaa", "data1", notify_after=5)
+            h2 = _CountingHandler("bbb", "data2", notify_after=5)
+            dumper = PeriodicDumper([h1, h2], tmp, interval_seconds=0, max_dumps=2)
+            dumper.start()
+            h2.ready.wait(timeout=5)
+            dumper.stop()
+            aaa_files = [f for f in os.listdir(tmp) if f.startswith("aaa_")]
+            bbb_files = [f for f in os.listdir(tmp) if f.startswith("bbb_")]
+            self.assertEqual(len(aaa_files), 2)
+            self.assertEqual(len(bbb_files), 2)
 
     def test_stop_is_idempotent(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -461,10 +529,10 @@ class TestHandlerPartialDumps(TestCase):
                 "=== Rank 0 ===\ndata0\n"
                 "=== Rank 1 ===\nError: 503"
             )
-            h = _StubHandler("partial_stacks", partial_content)
-            dumper = PeriodicDumper([h], tmp, interval_seconds=0.1)
+            h = _CountingHandler("partial_stacks", partial_content)
+            dumper = PeriodicDumper([h], tmp, interval_seconds=60.0)
             dumper.start()
-            time.sleep(0.25)
+            h.ready.wait(timeout=5)
             dumper.stop()
 
             files = os.listdir(tmp)

--- a/torch/distributed/debug/__init__.py
+++ b/torch/distributed/debug/__init__.py
@@ -33,6 +33,7 @@ def start_debug_server(
     enabled_dumps: set[str] | None = None,
     handlers: list["DebugHandler"] | None = None,
     fetch_timeout: float = 60.0,
+    max_dumps: int | None = None,
 ) -> None:
     """
     Start the debug server stack on all workers. The frontend debug server is
@@ -75,6 +76,9 @@ def start_debug_server(
         fetch_timeout (float): Timeout in seconds for fetching data from individual
             workers. Defaults to 60. Workers that don't respond within this time
             will be reported as unavailable.
+        max_dumps (int | None): Maximum number of dump files to keep per handler.
+            Older dumps are deleted after each cycle. If None (default), dumps
+            are never cleaned up.
     """
     global _WORKER_SERVER, _DEBUG_SERVER_PROC
 
@@ -109,6 +113,7 @@ def start_debug_server(
             "enabled_dumps": enabled_dumps,
             "handlers": handlers,
             "fetch_timeout": fetch_timeout,
+            "max_dumps": max_dumps,
         }
 
         if start_method is not None:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #176062
* #176058

Add a `max_dumps` parameter that caps the number of dump files kept per
handler by deleting the oldest files after each cycle. This bounds disk
usage for long-running jobs while keeping diagnostic data flowing.

Also adds microsecond precision to dump filenames to prevent overwrites
at sub-second intervals, and replaces sleep-based PeriodicDumper tests
with event-based synchronization for determinism and speed.

Authored with Claude.