### PR TITLE
patching alban's trunc_normal to support DTensor

### DIFF
--- a/torch/nn/init.py
+++ b/torch/nn/init.py
@@ -116,12 +116,15 @@ def _no_grad_trunc_normal_(
                     break
                 result = torch.where(
                     mask,
-                    torch.normal(
-                        mean,
-                        std,
+                    # creating a DTensor if result is a DTensor
+                    # which cannot be achieved using torch.normal()
+                    result.new_empty(
                         size=result.shape,
                         dtype=result.dtype,
                         device=result.device,
+                    ).normal_(
+                        mean,
+                        std,
                         generator=generator,
                     ),
                     result,


### PR DESCRIPTION
It seems https://github.com/pytorch/pytorch/pull/174997 breaks torchtitan
```
  traceback : Traceback (most recent call last):
    File "/home/lty/local/pytorch/torch/distributed/elastic/multiprocessing/errors/__init__.py", line 366, in wrapper
      return f(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^
    File "/home/lty/local/torchtitan/torchtitan/trainer.py", line 391, in __init__
      cast(BaseModel, model).init_weights(buffer_device=buffer_device)
    File "/home/lty/local/torchtitan/torchtitan/models/common/decoder.py", line 117, in init_weights
      trunc_normal_(
    File "/home/lty/local/torchtitan/torchtitan/models/common/utils.py", line 40, in trunc_normal_
      nn.init.trunc_normal_(tmp, mean=mean, std=std, a=a, b=b)
    File "/home/lty/local/pytorch/torch/nn/init.py", line 337, in trunc_normal_
      return _no_grad_trunc_normal_(tensor, mean, std, a, b, generator=generator)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/home/lty/local/pytorch/torch/nn/init.py", line 117, in _no_grad_trunc_normal_
      result = torch.where(
               ^^^^^^^^^^^^
  RuntimeError: aten.where.self got mixed torch.Tensor and DTensor, need to convert all torch.Tensor to DTensor before calling distributed operators!
```

test: verified in torchtitan via `./run_train.sh`