### PR TITLE
[rnn] Prevent LSTMCell segfault on input/hidden shape mismatch

### DIFF
--- a/aten/src/ATen/native/RNN.cpp
+++ b/aten/src/ATen/native/RNN.cpp
@@ -1546,6 +1546,14 @@ std::tuple<Tensor, Tensor> lstm_cell(
   const Tensor& b_hh = b_hh_opt.value_or(Tensor());
 
   TORCH_CHECK(hx.size() == 2, "lstm_cell expects two hidden states");
+  TORCH_CHECK(input.dim() == hx[0].dim() && input.dim() == hx[1].dim(),
+              "LSTMCell: Expected input and hidden states to have the same number of dimensions, but got input dim: ",
+              input.dim(), ", hx dim: ", hx[0].dim(), ", and cx dim: ", hx[1].dim());
+  if (input.dim() == 2) {
+    TORCH_CHECK(input.size(0) == hx[0].size(0) && input.size(0) == hx[1].size(0),
+                "LSTMCell: Expected input and hidden states to have the same batch size, but got input batch: ",
+                input.size(0), ", hx batch: ", hx[0].size(0), ", and cx batch: ", hx[1].size(0));
+  }
   auto hidden_size = w_hh.sym_size(1);
   check_rnn_cell_forward_input(input, w_ih.sym_size(1));
   check_rnn_cell_forward_weights<4>(w_ih, w_hh, hidden_size);

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2909,6 +2909,36 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
 
             (hx + cx).sum().backward()
 
+    def test_LSTM_cell_input_hidden_dim_mismatch(self):
+        input_size = 5
+        hidden_size = 3
+        input = torch.randn(6, input_size)
+        hx = torch.randn(3, hidden_size)
+        cx = torch.randn(3, hidden_size)
+        lstm = nn.LSTMCell(input_size, hidden_size)
+        with self.assertRaisesRegex(RuntimeError, "same number of dimensions"):
+            for i in range(6):
+                hx, cx = lstm(input[i], (hx, cx))
+
+    def test_LSTM_cell_batch_mismatch(self):
+        input_size, hidden_size = 5, 3
+        x = torch.randn(2, input_size)      # batch=2
+        hx = torch.randn(3, hidden_size)    # batch=3
+        cx = torch.randn(3, hidden_size)
+        lstm = nn.LSTMCell(input_size, hidden_size)
+        with self.assertRaisesRegex(RuntimeError, "same batch size"):
+            lstm(x, (hx, cx))
+
+    def test_LSTM_cell_unbatched_ok(self):
+        input_size, hidden_size = 5, 3
+        x = torch.randn(input_size)
+        hx = torch.randn(hidden_size)
+        cx = torch.randn(hidden_size)
+        lstm = nn.LSTMCell(input_size, hidden_size)
+        hx2, cx2 = lstm(x, (hx, cx))
+        self.assertEqual(hx2.shape, (hidden_size,))
+        self.assertEqual(cx2.shape, (hidden_size,))
+
     def test_LSTM_cell_forward_input_size(self):
         input = torch.randn(3, 11)
         hx = torch.randn(3, 20)


### PR DESCRIPTION
aten::lstm_cell could segfault when called with mismatched input vs (hx, cx) ranks/batch sizes (e.g. unbatched input with batched hidden states), due to missing validation before downstream checks/kernels.

Add explicit TORCH_CHECKs for input/hx/cx dimensionality (and batch size for batched inputs) and add a few regression tests.

Fixes #175978
python test/test_nn.py \
  TestNN.test_LSTM_cell_input_hidden_dim_mismatch \
  TestNN.test_LSTM_cell_batch_mismatch \
  TestNN.test_LSTM_cell_unbatched_ok