### PR TITLE
[ci] Remove dead CentOS code paths from .ci scripts

### DIFF
--- a/.ci/docker/build.sh
+++ b/.ci/docker/build.sh
@@ -337,9 +337,6 @@ case "$tag" in
       # To ensure that any ROCm config will build using conda cmake
       # and thus have LAPACK/MKL enabled
       fi
-    if [[ "$image" == *centos7* ]]; then
-      NINJA_VERSION=1.10.2
-    fi
     if [[ "$image" == *gcc* ]]; then
       extract_version_from_image_name gcc GCC_VERSION
     fi

--- a/.ci/docker/common/install_base.sh
+++ b/.ci/docker/common/install_base.sh
@@ -82,54 +82,11 @@ install_ubuntu() {
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 }
 
-install_centos() {
-  # Need EPEL for many packages we depend on.
-  # See http://fedoraproject.org/wiki/EPEL
-  yum --enablerepo=extras install -y epel-release
-
-  ccache_deps="asciidoc docbook-dtds docbook-style-xsl libxslt"
-  numpy_deps="gcc-gfortran"
-  yum install -y \
-    $ccache_deps \
-    $numpy_deps \
-    autoconf \
-    automake \
-    bzip2 \
-    cmake \
-    cmake3 \
-    curl \
-    gcc \
-    gcc-c++ \
-    gflags-devel \
-    git \
-    glibc-devel \
-    glibc-headers \
-    glog-devel \
-    libstdc++-devel \
-    libsndfile-devel \
-    make \
-    opencv-devel \
-    sudo \
-    wget \
-    vim \
-    unzip \
-    gdb
-
-  # Cleanup
-  yum clean all
-  rm -rf /var/cache/yum
-  rm -rf /var/lib/yum/yumdb
-  rm -rf /var/lib/yum/history
-}
-
 # Install base packages depending on the base OS
 ID=$(grep -oP '(?<=^ID=).+' /etc/os-release | tr -d '"')
 case "$ID" in
   ubuntu)
     install_ubuntu
-    ;;
-  centos)
-    install_centos
     ;;
   *)
     echo "Unable to determine OS..."

--- a/.ci/docker/common/install_devtoolset.sh
+++ b/.ci/docker/common/install_devtoolset.sh
@@ -4,7 +4,9 @@ set -ex
 
 [ -n "$DEVTOOLSET_VERSION" ]
 
-yum install -y centos-release-scl
-yum install -y devtoolset-$DEVTOOLSET_VERSION
+yum install -y \
+  gcc-toolset-$DEVTOOLSET_VERSION-gcc \
+  gcc-toolset-$DEVTOOLSET_VERSION-gcc-c++ \
+  gcc-toolset-$DEVTOOLSET_VERSION-gcc-gfortran
 
-echo "source scl_source enable devtoolset-$DEVTOOLSET_VERSION" > "/etc/profile.d/devtoolset-$DEVTOOLSET_VERSION.sh"
+echo "source scl_source enable gcc-toolset-$DEVTOOLSET_VERSION" > "/etc/profile.d/gcc-toolset-$DEVTOOLSET_VERSION.sh"

--- a/.ci/docker/common/install_glibc.sh
+++ b/.ci/docker/common/install_glibc.sh
@@ -3,9 +3,6 @@
 set -ex
 
 [ -n "$GLIBC_VERSION" ]
-if [[ -n "$CENTOS_VERSION" ]]; then
-  [ -n "$DEVTOOLSET_VERSION" ]
-fi
 
 yum install -y wget sed
 
@@ -19,8 +16,8 @@ if [[ "$GLIBC_VERSION" == "2.26" ]]; then
 fi
 mkdir -p glibc-$GLIBC_VERSION-build && cd glibc-$GLIBC_VERSION-build
 
-if [[ -n "$CENTOS_VERSION" ]]; then
-  export PATH=/opt/rh/devtoolset-$DEVTOOLSET_VERSION/root/usr/bin:$PATH
+if [[ -n "$DEVTOOLSET_VERSION" ]]; then
+  export PATH=/opt/rh/gcc-toolset-$DEVTOOLSET_VERSION/root/usr/bin:$PATH
 fi
 
 ../glibc-$GLIBC_VERSION/configure --prefix=/usr CFLAGS='-Wno-stringop-truncation -Wno-format-overflow -Wno-restrict -Wno-format-truncation -g -O2'

--- a/.ci/docker/common/install_miopen.sh
+++ b/.ci/docker/common/install_miopen.sh
@@ -16,7 +16,7 @@ case "$ID" in
   ubuntu)
     IS_UBUNTU=1
     ;;
-  centos|almalinux)
+  almalinux)
     IS_UBUNTU=0
     ;;
   *)

--- a/.ci/docker/common/install_rocm_drm.sh
+++ b/.ci/docker/common/install_rocm_drm.sh
@@ -14,7 +14,7 @@ case "$ID" in
     apt-get install -y libpciaccess-dev pkg-config
     apt-get clean
     ;;
-  centos|almalinux)
+  almalinux)
     yum install -y libpciaccess-devel pkgconfig
     ;;
   *)

--- a/.ci/docker/common/install_vision.sh
+++ b/.ci/docker/common/install_vision.sh
@@ -12,29 +12,11 @@ install_ubuntu() {
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 }
 
-install_centos() {
-  # Need EPEL for many packages we depend on.
-  # See http://fedoraproject.org/wiki/EPEL
-  yum --enablerepo=extras install -y epel-release
-
-  yum install -y \
-      opencv-devel
-
-  # Cleanup
-  yum clean all
-  rm -rf /var/cache/yum
-  rm -rf /var/lib/yum/yumdb
-  rm -rf /var/lib/yum/history
-}
-
 # Install base packages depending on the base OS
 ID=$(grep -oP '(?<=^ID=).+' /etc/os-release | tr -d '"')
 case "$ID" in
   ubuntu)
     install_ubuntu
-    ;;
-  centos)
-    install_centos
     ;;
   *)
     echo "Unable to determine OS..."

--- a/.ci/docker/manywheel/build_scripts/manylinux1-check.py
+++ b/.ci/docker/manywheel/build_scripts/manylinux1-check.py
@@ -17,7 +17,7 @@ def is_manylinux1_compatible():
         # Fall through to heuristic check below
         pass
 
-    # Check glibc version. CentOS 5 uses glibc 2.5.
+    # manylinux1 baseline requires glibc 2.5.
     return have_compatible_glibc(2, 5)
 
 

--- a/.ci/manywheel/build_cpu.sh
+++ b/.ci/manywheel/build_cpu.sh
@@ -56,9 +56,7 @@ fi
 mkdir -p "$PYTORCH_FINAL_PACKAGE_DIR" || true
 
 OS_NAME=$(awk -F= '/^NAME/{print $2}' /etc/os-release)
-if [[ "$OS_NAME" == *"CentOS Linux"* ]]; then
-    LIBGOMP_PATH="/usr/lib64/libgomp.so.1"
-elif [[ "$OS_NAME" == *"Red Hat Enterprise Linux"* ]]; then
+if [[ "$OS_NAME" == *"Red Hat Enterprise Linux"* ]]; then
     LIBGOMP_PATH="/usr/lib64/libgomp.so.1"
 elif [[ "$OS_NAME" == *"AlmaLinux"* ]]; then
     LIBGOMP_PATH="/usr/lib64/libgomp.so.1"

--- a/.ci/manywheel/build_rocm.sh
+++ b/.ci/manywheel/build_rocm.sh
@@ -112,29 +112,19 @@ if [[ $ROCM_INT -ge 70000 ]]; then
 fi
 
 OS_NAME=`awk -F= '/^NAME/{print $2}' /etc/os-release`
-if [[ "$OS_NAME" == *"CentOS Linux"* || "$OS_NAME" == *"AlmaLinux"* ]]; then
+if [[ "$OS_NAME" == *"Red Hat Enterprise Linux"* || "$OS_NAME" == *"AlmaLinux"* ]]; then
     LIBGOMP_PATH="/usr/lib64/libgomp.so.1"
     LIBNUMA_PATH="/usr/lib64/libnuma.so.1"
     LIBELF_PATH="/usr/lib64/libelf.so.1"
-    if [[ "$OS_NAME" == *"CentOS Linux"* ]]; then
-        LIBTINFO_PATH="/usr/lib64/libtinfo.so.5"
-    else
-        LIBTINFO_PATH="/usr/lib64/libtinfo.so.6"
-    fi
+    LIBTINFO_PATH="/usr/lib64/libtinfo.so.6"
     LIBDRM_PATH="/opt/amdgpu/lib64/libdrm.so.2"
     LIBDRM_AMDGPU_PATH="/opt/amdgpu/lib64/libdrm_amdgpu.so.1"
     if [[ $ROCM_INT -ge 60100 && $ROCM_INT -lt 60300 ]]; then
         # Below libs are direct dependencies of libhipsolver
         LIBSUITESPARSE_CONFIG_PATH="/lib64/libsuitesparseconfig.so.4"
-        if [[ "$OS_NAME" == *"CentOS Linux"* ]]; then
-            LIBCHOLMOD_PATH="/lib64/libcholmod.so.2"
-            # Below libs are direct dependencies of libsatlas
-            LIBGFORTRAN_PATH="/lib64/libgfortran.so.3"
-        else
-            LIBCHOLMOD_PATH="/lib64/libcholmod.so.3"
-            # Below libs are direct dependencies of libsatlas
-            LIBGFORTRAN_PATH="/lib64/libgfortran.so.5"
-        fi
+        LIBCHOLMOD_PATH="/lib64/libcholmod.so.3"
+        # Below libs are direct dependencies of libsatlas
+        LIBGFORTRAN_PATH="/lib64/libgfortran.so.5"
         # Below libs are direct dependencies of libcholmod
         LIBAMD_PATH="/lib64/libamd.so.2"
         LIBCAMD_PATH="/lib64/libcamd.so.2"

--- a/.ci/manywheel/build_xpu.sh
+++ b/.ci/manywheel/build_xpu.sh
@@ -39,9 +39,7 @@ fi
 mkdir -p "$PYTORCH_FINAL_PACKAGE_DIR" || true
 
 OS_NAME=$(awk -F= '/^NAME/{print $2}' /etc/os-release)
-if [[ "$OS_NAME" == *"CentOS Linux"* ]]; then
-    LIBGOMP_PATH="/usr/lib64/libgomp.so.1"
-elif [[ "$OS_NAME" == *"Red Hat Enterprise Linux"* ]]; then
+if [[ "$OS_NAME" == *"Red Hat Enterprise Linux"* ]]; then
     LIBGOMP_PATH="/usr/lib64/libgomp.so.1"
 elif [[ "$OS_NAME" == *"AlmaLinux"* ]]; then
     LIBGOMP_PATH="/usr/lib64/libgomp.so.1"

--- a/.ci/pytorch/check_binary.sh
+++ b/.ci/pytorch/check_binary.sh
@@ -46,7 +46,7 @@ fi
 # The install root depends on both the package type and the os
 # All MacOS packages use conda, even for the wheel packages.
 if [[ "$PACKAGE_TYPE" == libtorch ]]; then
-  # NOTE: Only $PWD works on both CentOS and Ubuntu
+  # NOTE: Only $PWD works reliably across Linux build images
   export install_root="$PWD"
 else
 


### PR DESCRIPTION
CentOS-based CI images have been disabled for a long time, but .ci still contained CentOS-specific branches (e.g. install_centos handlers, centos7 special cases, and CentOS-only dependency paths).

Remove CentOS-only logic and keep supported distro paths (Ubuntu/AlmaLinux/RHEL where applicable) to reduce maintenance overhead and avoid confusion.

Fixes #175994

Test plan:
- bash -n .ci/docker/build.sh .ci/docker/common/*.sh .ci/manywheel/*.sh .ci/pytorch/check_binary.sh
- python3 -m py_compile .ci/docker/manywheel/build_scripts/manylinux1-check.py
- grep -RIn "CentOS\\|centos\\|CENTOS" .ci  # expect no matches