### PR TITLE
fix: use return value instead of errno for posix_fallocate error handling

### DIFF
--- a/aten/src/ATen/MapAllocator.cpp
+++ b/aten/src/ATen/MapAllocator.cpp
@@ -295,20 +295,21 @@ MapAllocator::MapAllocator(WithFd /*unused*/, std::string_view filename, int fd,
 #ifdef HAVE_POSIX_FALLOCATE
           if (flags_ & ALLOCATOR_MAPPED_SHAREDMEM) {
             for (;;) {
-              if (posix_fallocate(fd, 0, static_cast<off_t>(size)) == 0) {
+              int err = posix_fallocate(fd, 0, static_cast<off_t>(size));
+              if (err == 0) {
                 break;
               }
 
-              if (errno == EINTR) {
+              if (err == EINTR) {
                 continue;
               }
 
-              if (errno == EINVAL || errno == EOPNOTSUPP) {
+              if (err == EINVAL || err == EOPNOTSUPP) {
                 // the underlying filesystem does not support the operation
                 break;
               }
 
-              TORCH_CHECK(false, "unable to allocate shared memory(shm) for file <", filename_, ">: ", c10::utils::str_error(errno), " (", errno, ")");
+              TORCH_CHECK(false, "unable to allocate shared memory(shm) for file <", filename_, ">: ", c10::utils::str_error(err), " (", err, ")");
             }
           }
 #endif


### PR DESCRIPTION
Summary
Fixes #176069

Per POSIX, posix_fallocate() returns the error code directly as its return value and does not set errno. The previous code incorrectly checked errno, which contained stale values from previous syscalls, leading to misleading error messages.

Changes
- `aten/src/ATen/MapAllocator.cpp`: Capture the return value of posix_fallocate() and use it instead of errno for error handling

Root Cause
The POSIX specification for posix_fallocate() states:

> Upon successful completion, posix_fallocate() shall return zero; otherwise, an error number shall be returned to indicate the error.

Unlike most POSIX functions that return -1 and set errno, posix_fallocate() returns the error number directly.

How to verify the fix
Before this fix, when posix_fallocate() failed, the error message would show a stale errno value from a previous syscall (e.g., EAGAIN from a previous read() call). After this fix, the error message correctly shows the actual error returned by posix_fallocate().

Testing
This is a bug fix that corrects error handling behavior. The code path is exercised when using shared memory allocation with ALLOCATOR_MAPPED_SHAREDMEM flag on systems that support posix_fallocate().