### PR TITLE
torch.arange() crashes when "step" attribute is non-integer value with SIGFPE, arithmetic exception

### DIFF
--- a/aten/src/ATen/native/RangeUtils.h
+++ b/aten/src/ATen/native/RangeUtils.h
@@ -38,15 +38,22 @@ int64_t compute_arange_size(const Scalar& start, const Scalar& end, const Scalar
   // and the effective output size starts differing on CPU vs GPU because of precision issues, which
   // we dont want.
   // the corner-case we do want to take into account is int64_t, which has higher precision than double
-  double size_d;
+  double size_d = 0.0;
+  bool fallback_to_double = true;
+
   if constexpr (std::is_same_v<scalar_t, int64_t>) {
-    using accscalar_t = at::acc_type<scalar_t, false>;
-    auto xstart = start.to<accscalar_t>();
-    auto xend = end.to<accscalar_t>();
-    auto xstep = step.to<accscalar_t>();
-    int64_t sgn = (xstep > 0) - (xstep < 0);
-    size_d = std::ceil((xend - xstart + xstep - sgn) / xstep);
-  } else {
+    if (!start.isFloatingPoint() && !end.isFloatingPoint() && !step.isFloatingPoint()) {
+      using accscalar_t = at::acc_type<scalar_t, false>;
+      auto xstart = start.to<accscalar_t>();
+      auto xend = end.to<accscalar_t>();
+      auto xstep = step.to<accscalar_t>();
+      int64_t sgn = (xstep > 0) - (xstep < 0);
+      size_d = std::ceil((xend - xstart + xstep - sgn) / xstep);
+      fallback_to_double = false;
+    }
+  }
+
+  if (fallback_to_double) {
     size_d = std::ceil((end.to<double>() - start.to<double>())
                         / step.to<double>());
   }

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -5361,14 +5361,14 @@ def arange(
 
     # For int64 we truncate arguments to int before calculating length, but
     # other integral dtypes we don't. Weird... but needed to match ATen shapes.
-    if dtype == torch.int64 or integer_args:
+    if dtype == torch.int64 and integer_args:
         # Uses floordiv to avoid ceil in inductor.
         sgn = bool(xstep > 0) - bool(xstep < 0)  # type: ignore[possibly-undefined]
         length = (xend - xstart + xstep - sgn) // xstep  # type: ignore[possibly-undefined]
     else:
         length = math.ceil((end - start) / step)
 
-    if is_integer:
+    if is_integer and integer_args:
         return prims.iota(
             length,
             start=xstart,  # type: ignore[possibly-undefined]
@@ -5391,7 +5391,13 @@ def arange(
         torch.long if integer_args else utils.get_acc_type(dtype, device)
     )
     index = _maybe_convert_to_dtype(index, computation_dtype)
-    result = start + step * index
+
+    if is_integer:
+        # ATen C++ truncates start and step before sequence generation
+        result = xstart + xstep * index  # type: ignore[possibly-undefined]
+    else:
+        result = start + step * index
+
     result = _maybe_convert_to_dtype(result, dtype)
 
     if requires_grad:

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -9340,8 +9340,17 @@ repeated values or unexpected rounding. For precise sequences, it is recommended
 integer dtypes instead of floating-point dtypes.
 
 Note that non-integer :attr:`step` is subject to floating point rounding errors when
-comparing against :attr:`end`; to avoid inconsistency, we advise subtracting a small epsilon from :attr:`end`
-in such cases.
+comparing against :attr:`end`; to avoid inconsistency, we advise subtracting a small epsilon
+from :attr:`end` in such cases. Additionally, when the output is an integer dtype,
+a floating-point :attr:`step` is truncated to an integer before the sequence is generated.
+In the special case where :attr:`step` is within the range (-1, 1), it will be truncated to 0,
+yielding a sequence of identical values.
+
+Note: If :attr:`start`, :attr:`end`, or :attr:`step` are floating-point numbers but the resulting
+:attr:`dtype` is an integer (either explicitly specified or inferred from an integer ``out`` tensor),
+the sequence is computed using floating-point math and then cast to the requested integer dtype.
+For example, an integer tensor with a step of `0.5` will safely compute `[0.0, 0.5, 1.0, 1.5, ...]`
+and then cast it to yield `[0, 0, 1, 1, ...]`.
 
 .. math::
     \text{out}_{{i+1}} = \text{out}_{i} + \text{step}

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -824,6 +824,12 @@ def sample_inputs_arange(op, device, dtype, requires_grad, **kwargs):
         (1., 5. + 1e-6, 2.),
         (0., -8., -4.),
         (1., 5., 2.),
+        # start and end: int or float, step: float
+        (0, 5, 0.5),
+        (0, 5., 0.5),
+        (0., 5, 0.5),
+        (0., 5., 0.25),
+        (5., 1., -0.01),
         *(to_float(start, end, step) for (start, end, step) in int_samples),
     )
 


### PR DESCRIPTION
When `torch.arange()` is called with a floating-point `step` (e.g., 0.5) it crashes with SIGFPE, arithmetic exception.

Stack trace clearly points the place:
```C++
Program terminated with signal SIGFPE, Arithmetic exception.                                                                                                                                                                                                                               
#0  0x00007f02468d0469 in at::native::compute_arange_size<long> (start=..., end=..., step=...) at /src/pytorch/aten/src/ATen/native/RangeUtils.h:48                                                                                                                                        
48          size_d = std::ceil((xend - xstart + xstep - sgn) / xstep);                                                                                                                                                                                                                     
[Current thread is 1 (Thread 0x7f026afece80 (LWP 25605))] 
```
Full stack trace in bug #175761 .

The cast of floating-point "step" to an integer "xstep", truncates values like 0.5 to 0. As a result, the following size calculation divides by zero, causing a SIGFPE (Arithmetic exception):

```C++
  size_d = std::ceil((xend - xstart + xstep - sgn) / xstep);
```
Because ```step``` is a floating-point number from range ```0<step<1```, when the code enters the  ```if constexpr (std::is_same_v<scalar_t, int64_t>)``` block and ```step.to<accscalar_t>()``` casts ```step``` into an int64_t, this truncates it to 0. And the next line then attempts to divide by 0.

This fix the issue by adding a runtime check to ensure "start", "end", and "step" are not floating-point numbers before taking the integer path. If any are floats, it falls back to the standard "double" path.

The same problem reported as #175761 and #173574.

With the fix:

1. It does not crash with the floating point:
```Python
>>> signal = torch.arange(128)
>>> torch.arange(start=0, end=64, step=0.5, out=signal)
tensor([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
        0, 0, 0, 0, 0, 0, 0, 0])
```
2. If is a flotat ```step >= 1 ```: 
```Python
>>> torch.arange(start=8, end=24, step=2.0, out=signal)
tensor([ 8, 10, 12, 14, 16, 18, 20, 22])
```
3. If ```0 =< step < 1``` :
```Python
>>> signal = torch.arange(8)
>>> torch.arange(start=8, end=72, step=.8, out=signal)
<stdin>:1: UserWarning: The number of elements in the out tensor of shape [8] is 8 which does not match the computed number of elements 80. Note that this may occur as a result of rounding error. The out tensor will be resized to a tensor of shape (80,). (Triggered internally at /src/pytorch/aten/src/ATen/native/RangeFactories.cpp:199.)
tensor([8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8,
        8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8,
        8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8,
        8, 8, 8, 8, 8, 8, 8, 8])
```

When it comes to the proposed fix:
1. In ```aten/src/ATen/native/RangeUtils.h```, this is the simplest fix I can think of. And because that additional new if statement is being executed only once so there is no impact on performance.
2. In ```torch/_refs/__init__.py``` I tried to mimic ATen engine.
3. Added few more edged cases to OpInfo tests.
4. Finally update the torch.arange() documentation to be clear when this edge case can happen and warn user that in some cases step can be rounded to 0.

All dedicated tests are passing just fine:
```Python
python test/test_ops.py -v -k arange
```

@lakshayg, @malfet  can you have a look on this, please ?
