### PR TITLE
Fix ATen/OpenMP parallel_for behavior under mixed OpenMP runtimes on Windows

### DIFF
--- a/aten/src/ATen/ParallelOpenMP.h
+++ b/aten/src/ATen/ParallelOpenMP.h
@@ -37,8 +37,7 @@ inline void invoke_parallel(
   std::atomic<int64_t> tid_counter{0};
   std::atomic<int64_t> next{begin};
   int64_t chunk_size = std::max<int64_t>(
-      grain_size > 0 ? grain_size : 1,
-      divup((end - begin), num_threads));
+      grain_size > 0 ? grain_size : 1, divup((end - begin), num_threads));
 
 #pragma omp parallel
   {

--- a/aten/src/ATen/ParallelOpenMP.h
+++ b/aten/src/ATen/ParallelOpenMP.h
@@ -19,29 +19,43 @@ inline void invoke_parallel(
     int64_t end,
     int64_t grain_size,
     const F& f) {
+  if (end <= begin)
+    return;
+
   std::atomic_flag err_flag = ATOMIC_FLAG_INIT;
   std::exception_ptr eptr;
 
+  // choose number of tasks based on grain size and number of threads
+  // can't use num_threads clause due to bugs in GOMP's thread pool (See
+  // #32008)
+  int64_t num_threads = omp_get_max_threads();
+  if (grain_size > 0) {
+    num_threads = std::min(num_threads, divup((end - begin), grain_size));
+  }
+  num_threads = std::max<int64_t>(1, num_threads);
+
+  std::atomic<int64_t> tid_counter{0};
+  std::atomic<int64_t> next{begin};
+  int64_t chunk_size = std::max<int64_t>(
+      grain_size > 0 ? grain_size : 1,
+      divup((end - begin), num_threads));
+
 #pragma omp parallel
   {
-    // choose number of tasks based on grain size and number of threads
-    // can't use num_threads clause due to bugs in GOMP's thread pool (See
-    // #32008)
-    int64_t num_threads = omp_get_num_threads();
-    if (grain_size > 0) {
-      num_threads = std::min(num_threads, divup((end - begin), grain_size));
-    }
-
-    int64_t tid = omp_get_thread_num();
-    int64_t chunk_size = divup((end - begin), num_threads);
-    int64_t begin_tid = begin + tid * chunk_size;
-    if (begin_tid < end) {
-      try {
-        internal::ThreadIdGuard tid_guard(tid);
-        f(begin_tid, std::min(end, chunk_size + begin_tid));
-      } catch (...) {
-        if (!err_flag.test_and_set()) {
-          eptr = std::current_exception();
+    int64_t tid = tid_counter.fetch_add(1, std::memory_order_relaxed);
+    if (tid < num_threads) {
+      internal::ThreadIdGuard tid_guard(tid);
+      for (;;) {
+        int64_t b = next.fetch_add(chunk_size, std::memory_order_relaxed);
+        if (b >= end)
+          break;
+        try {
+          f(b, std::min(end, b + chunk_size));
+        } catch (...) {
+          if (!err_flag.test_and_set()) {
+            eptr = std::current_exception();
+          }
+          break;
         }
       }
     }


### PR DESCRIPTION
On Windows in my environment, both VCOMP and libomp are loaded. Under this mixed-runtime setup, OpenMP query functions (`omp_get_thread_num`, `omp_in_parallel`, etc.) appear to report incorrect values inside parallel regions (e.g., thread id collapses to 0). This breaks ATen’s OpenMP `invoke_parallel` partitioning and causes `at::get_thread_num()` to be incorrect, which can corrupt CPU FlashAttention (per-thread scratch indexing) when intra-op threads > 1. `omp_in_parallel()` also appears to return false inside an outer `parallel_for`, which can allow unintended nested parallelism and potentially affect reductions.

### What I changed

In `aten/src/ATen/ParallelOpenMP.h` I replaced static tid-indexed partitioning in `invoke_parallel` with an atomic work-queue so thread IDs and work chunks are assigned independently of `omp_get_thread_num()`.

In `aten/src/ATen/ParallelOpenMP.cpp` I changed `in_parallel_region()` to check `c10::ParallelGuard::is_enabled()` in addition to `omp_in_parallel()`, since `ParallelGuard` is already set by `at::parallel_for` on all platforms.

In `aten/src/ATen/test/test_parallel.cpp` I added a couple regression tests.

Fixes : #176091