### PR TITLE
Reduce memory usage of serialization test

### DIFF
--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -1218,6 +1218,10 @@ class TestSerialization(TestCase, SerializationMixin):
 
         with BytesIOContext() as f:
             torch.save(big_model.state_dict(), f)
+            # Delete the original model before loading another one to
+            # reduce peak memory from ~12GB to ~8GB
+            del big_model
+            gc.collect()
             f.seek(0)
             torch.load(f)
 


### PR DESCRIPTION
Should fix https://hud.pytorch.org/failure?name=pull%20%2F%20linux-jammy-py3.14t-clang15%20%2F%20test%20(crossref%2C%201%2C%202%2C%20linux.2xlarge)&jobName=undefined&failureCaptures=test%2Ftest_serialization.py%3A%3ATestSerialization%3A%3Atest_serialization_4gb_file

