### PR TITLE
[Inductor] allow_32 to fp32_precision

### DIFF
--- a/torch/_inductor/autotune_process.py
+++ b/torch/_inductor/autotune_process.py
@@ -1189,7 +1189,7 @@ class AutotuneProcessPool:
                     self._warmup_start_time = time.perf_counter()
                     self._warmup_future = self.pool.submit(
                         _init_autotune_subprocess,
-                        allow_tf32=torch.backends.cuda.matmul.allow_tf32,
+                        fp32_precision=torch.backends.cuda.matmul.fp32_precision,
                     )
                     self._warmup_future.add_done_callback(self._on_warmup_complete)
                     autotuning_log.info("Warmup job submitted")
@@ -1249,7 +1249,7 @@ def use_pipelined_autotuning() -> bool:
     )
 
 
-def _init_autotune_subprocess(allow_tf32: bool) -> bool:
+def _init_autotune_subprocess(fp32_precision: bool) -> bool:
     """
     Warmup function run in the autotune subprocess.
     """
@@ -1259,7 +1259,7 @@ def _init_autotune_subprocess(allow_tf32: bool) -> bool:
     if torch.cuda.is_available():
         torch.zeros(1, device="cuda")
 
-    torch.backends.cuda.matmul.allow_tf32 = allow_tf32
+    torch.backends.cuda.matmul.fp32_precision = fp32_precision
 
     return True
 

--- a/torch/_inductor/autotune_process.py
+++ b/torch/_inductor/autotune_process.py
@@ -1249,7 +1249,7 @@ def use_pipelined_autotuning() -> bool:
     )
 
 
-def _init_autotune_subprocess(fp32_precision: bool) -> bool:
+def _init_autotune_subprocess(fp32_precision: str) -> bool:
     """
     Warmup function run in the autotune subprocess.
     """


### PR DESCRIPTION
Maintain new API usage in inductor as per [this](https://github.com/pytorch/pytorch/pull/173731) 
and [issue](https://github.com/pytorch/pytorch/issues/166387) 

As autotune process change was added [here](https://github.com/pytorch/pytorch/pull/174742), I am just setting things to fp32_precision. 

Since Inductor already normalizes precision semantics (see #173731), it might be cleaner to avoid old API atleast in Inductor to prevent divergence.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @PaulZhang12 @masnesral @isuruf @jansel 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo