### PR TITLE
Fix user-defined Triton kernel name mangling in Inductor codegen

### DIFF
--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -175,9 +175,12 @@ class KernelTests(torch._inductor.test_case.TestCase):
         eager_out = f(x, y)
         compiled_out, (code,) = run_and_get_code(torch.compile(f), x, y)
         self.assertEqual(compiled_out, eager_out)
-        # The generated variable name should not start with ``__`` to avoid
-        # name mangling when executed inside a class body.
-        self.assertNotIn("__dunder_add_kernel", code)
+        # The generated variable name should use single-underscore prefix
+        # (_dunder_add_kernel_0) not double (__dunder_add_kernel_0).
+        # The original __dunder_add_kernel still appears in triton source
+        # strings, which is fine -- only the variable name matters.
+        self.assertNotIn("__dunder_add_kernel_0", code)
+        self.assertIn("_dunder_add_kernel_0", code)
 
     @requires_gpu
     def test_triton_kernel_ill_formed(self):

--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -114,6 +114,24 @@ if HAS_GPU:
             )
             return x.to(idtype, bitcast=True)
 
+    # Kernel with dunder name for name-mangling regression test (issue #170398).
+    @triton.jit
+    def __dunder_add_kernel(
+        in_ptr0,
+        in_ptr1,
+        out_ptr,
+        n_elements,
+        BLOCK_SIZE: "tl.constexpr",
+    ):
+        pid = tl.program_id(axis=0)
+        block_start = pid * BLOCK_SIZE
+        offsets = block_start + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < n_elements
+        x = tl.load(in_ptr0 + offsets, mask=mask)
+        y = tl.load(in_ptr1 + offsets, mask=mask)
+        output = x + y
+        tl.store(out_ptr + offsets, output, mask=mask)
+
 
 class KernelTests(torch._inductor.test_case.TestCase):
     def _kernel_launched_in_code(self, kernel_name: str, code: str) -> bool:
@@ -136,6 +154,30 @@ class KernelTests(torch._inductor.test_case.TestCase):
         f(t1)
         # No need to assert anything, the goal is to make sure dynamo does
         # not crash
+
+    @requires_gpu
+    def test_triton_kernel_dunder_name_no_name_mangling(self):
+        # Regression test for https://github.com/pytorch/pytorch/issues/170398
+        # Triton kernels whose names start with ``__`` must not trigger
+        # Python class-based name mangling in the generated code.
+        # Use globals() to reference the dunder-named kernel without triggering
+        # name mangling inside this class body.
+        kernel = globals()["__dunder_add_kernel"]
+
+        def f(x, y):
+            out = torch.empty_like(x)
+            n_elements = x.numel()
+            kernel[(n_elements,)](x, y, out, n_elements, BLOCK_SIZE=16)
+            return out
+
+        x = torch.randn(4, device=GPU_TYPE)
+        y = torch.randn(4, device=GPU_TYPE)
+        eager_out = f(x, y)
+        compiled_out, (code,) = run_and_get_code(torch.compile(f), x, y)
+        self.assertEqual(compiled_out, eager_out)
+        # The generated variable name should not start with ``__`` to avoid
+        # name mangling when executed inside a class body.
+        self.assertNotIn("__dunder_add_kernel", code)
 
     @requires_gpu
     def test_triton_kernel_ill_formed(self):

--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -175,12 +175,13 @@ class KernelTests(torch._inductor.test_case.TestCase):
         eager_out = f(x, y)
         compiled_out, (code,) = run_and_get_code(torch.compile(f), x, y)
         self.assertEqual(compiled_out, eager_out)
-        # The generated variable name should use single-underscore prefix
-        # (_dunder_add_kernel_0) not double (__dunder_add_kernel_0).
-        # The original __dunder_add_kernel still appears in triton source
-        # strings, which is fine -- only the variable name matters.
-        self.assertNotIn("__dunder_add_kernel_0", code)
-        self.assertIn("_dunder_add_kernel_0", code)
+        # Match as a standalone identifier; substrings inside other names
+        # (e.g. cpp_wrapper's `call__dunder_add_kernel_0`) are harmless C++
+        # identifiers and aren't subject to Python name mangling.
+        import re as _re
+
+        self.assertIsNone(_re.search(r"\b__dunder_add_kernel_0\b", code))
+        self.assertIsNotNone(_re.search(r"\b_dunder_add_kernel_0\b", code))
 
     @requires_gpu
     def test_triton_kernel_ill_formed(self):

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -3020,6 +3020,11 @@ class PythonWrapperCodegen(CodeGen):
             )
 
         name = f"{original_name}_{len(self.user_defined_kernel_cache)}"
+        # Prevent Python class-based name mangling (``__x`` -> ``_Class__x``)
+        # when the generated call site is inside a class body.
+        # See https://github.com/pytorch/pytorch/issues/170398
+        if name.startswith("__") and not name.endswith("__"):
+            name = name[1:]
 
         compile_wrapper = IndentedBuffer()
         if config.triton.unique_user_kernel_names:

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -2790,6 +2790,15 @@ class PythonWrapperCodegen(CodeGen):
         grids: list[list[int | sympy.Expr]],
         epilogue_fusion: tuple[ir.ComputedBuffer, str] | None,
     ):
+        """Codegen a user-defined Triton kernel and return its cache entry.
+
+        Emits the ``async_compile.triton(...)`` wrapper, assigns a graph-unique
+        name (with a leading dunder stripped to avoid Python class-based name
+        mangling at the call site), and records the kernel in
+        ``user_defined_kernel_cache``. Returns ``(name, triton_meta,
+        inductor_meta, extra_launcher_call_args)``; subsequent calls with the
+        same ``cache_key`` reuse the previously assigned name.
+        """
         from ..runtime.triton_heuristics import (
             config_to_dict,
             FixedGrid,


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/170398

When a user-defined Triton kernel has a name starting with double underscores, the generated variable name in Inductor output code also starts with `__`. If the generated call site lives inside a class body (such as `class Runner` used by graph_partition), Python name mangling silently rewrites the reference to `_Runner__my_kernel_0`, causing a NameError at runtime.

Fix: Strip one leading underscore from the generated variable name when it starts with `__`, applied at the single point where user-defined kernel names are constructed. Internal Inductor kernel names are unaffected because they never start with `__`.

Changes:
- `torch/_inductor/codegen/wrapper.py`: Add name sanitization after constructing user-defined kernel variable name
- `test/inductor/test_triton_kernels.py`: Add regression test with a `__`-prefixed Triton kernel

This supersedes #171181 which was missing a test.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @v0i0 @zou3519 @Lucaskabela