### PR TITLE
[dynamo] Disallow side effects in invoke_subgraph

### DIFF
--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -2034,9 +2034,7 @@ from user code:
 
         self.assertExpectedInlineMunged(
             UncapturedHigherOrderOpError,
-            lambda: torch.compile(fn, backend="eager", fullgraph=True)(
-                torch.randn(4)
-            ),
+            lambda: torch.compile(fn, backend="eager", fullgraph=True)(torch.randn(4)),
             """\
 This higher order operator doesn't work unless it is captured completely with torch.compile. Got graph break/error:
 
@@ -2044,7 +2042,7 @@ HOP: Unsafe side effect
   Higher Order Operator: torch.ops.higher_order.invoke_subgraph
   Explanation: Mutating a variable from outside the scope of this HOP is not supported.
   Hint: If the HOP is activation checkpointing (torch.utils.checkpoint.checkpoint), this points to a side effect in forward method. Eager activation checkpointing replays that side-effect while recomputing the forward in the backward. If you are ok with side-effect not replayed in the backward, try setting `torch._dynamo.config.skip_fwd_side_effects_in_bwd_under_checkpoint = True`
-  Hint: If the HOP is a nested compile region (torch.compiler.nested_compile_region), consider removing the side effect from the region. Side effects prevent compile-time caching of the region, reducing the compile time benefit. If you must keep the side effect, set `torch._dynamo.config.allow_side_effects_under_nested_compile_region = True`.
+  Hint: If the HOP is a nested compile region (torch.ops.higher_order.invoke_subgraph / torch.compiler.nested_compile_region), consider removing the side effect from the region. Side effects prevent compile-time caching of the region, reducing the compile time benefit. If you must keep the side effect, set `torch._dynamo.config.allow_side_effects_under_nested_compile_region = True`.
 
   Developer debug context: Attempted to mutate ListVariable(length=0)
 

--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -2019,6 +2019,44 @@ from user code:
     stack.append(1)  # Mutation outside checkpoint scope""",
         )
 
+    def test_invoke_subgraph_side_effect_error(self):
+        from torch._dynamo.exc import UncapturedHigherOrderOpError
+
+        stack = []
+
+        @torch.compiler.nested_compile_region
+        def gn(x):
+            stack.append(1)
+            return x.sin()
+
+        def fn(x):
+            return gn(x)
+
+        self.assertExpectedInlineMunged(
+            UncapturedHigherOrderOpError,
+            lambda: torch.compile(fn, backend="eager", fullgraph=True)(
+                torch.randn(4)
+            ),
+            """\
+This higher order operator doesn't work unless it is captured completely with torch.compile. Got graph break/error:
+
+HOP: Unsafe side effect
+  Higher Order Operator: torch.ops.higher_order.invoke_subgraph
+  Explanation: Mutating a variable from outside the scope of this HOP is not supported.
+  Hint: If the HOP is activation checkpointing (torch.utils.checkpoint.checkpoint), this points to a side effect in forward method. Eager activation checkpointing replays that side-effect while recomputing the forward in the backward. If you are ok with side-effect not replayed in the backward, try setting `torch._dynamo.config.skip_fwd_side_effects_in_bwd_under_checkpoint = True`
+  Hint: If the HOP is a nested compile region (torch.compiler.nested_compile_region), consider removing the side effect from the region. Side effects prevent compile-time caching of the region, reducing the compile time benefit. If you must keep the side effect, set `torch._dynamo.config.allow_side_effects_under_nested_compile_region = True`.
+
+  Developer debug context: Attempted to mutate ListVariable(length=0)
+
+ For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0067.html
+
+from user code:
+   File "test_error_messages.py", line N, in fn
+    return gn(x)
+  File "test_error_messages.py", line N, in gn
+    stack.append(1)""",
+        )
+
     def test_cond_with_graph_break_shows_hop_context(self):
         # Test that torch.cond graph breaks include HOP context
         def true_fn(x):

--- a/test/higher_order_ops/test_invoke_subgraph.py
+++ b/test/higher_order_ops/test_invoke_subgraph.py
@@ -339,11 +339,11 @@ class GraphModule(torch.nn.Module):
 
         subgraph_0 = self.subgraph_0
         invoke_subgraph = torch.ops.higher_order.invoke_subgraph(subgraph_0, 'subgraph_0', l_mod_buffers_buf_, l_x_, l_y_);  subgraph_0 = None
-        getitem_8: "f32[8]" = invoke_subgraph[0];  invoke_subgraph = None
+        getitem: "f32[8]" = invoke_subgraph[0];  invoke_subgraph = None
         subgraph_1 = self.subgraph_0
         invoke_subgraph_1 = torch.ops.higher_order.invoke_subgraph(subgraph_1, 'subgraph_0', l_mod_buffers_buf_, l_x_, l_y_);  subgraph_1 = l_mod_buffers_buf_ = l_x_ = l_y_ = None
-        getitem_9: "f32[8]" = invoke_subgraph_1[0];  invoke_subgraph_1 = None
-        add: "f32[8]" = getitem_8 + getitem_9;  getitem_8 = getitem_9 = None
+        getitem_1: "f32[8]" = invoke_subgraph_1[0];  invoke_subgraph_1 = None
+        add: "f32[8]" = getitem + getitem_1;  getitem = getitem_1 = None
         return (add,)
 
     class subgraph_0(torch.nn.Module):
@@ -1056,8 +1056,8 @@ class GraphModule(torch.nn.Module):
 
         subgraph_0 = self.subgraph_0
         invoke_subgraph = torch.ops.higher_order.invoke_subgraph(subgraph_0, 'subgraph_0', l_x_);  subgraph_0 = l_x_ = None
-        getitem_2: "f32[8]" = invoke_subgraph[0];  invoke_subgraph = None
-        detach: "f32[8]" = getitem_2.detach();  getitem_2 = None
+        getitem: "f32[8]" = invoke_subgraph[0];  invoke_subgraph = None
+        detach: "f32[8]" = getitem.detach();  getitem = None
         return (detach,)
 
     class subgraph_0(torch.nn.Module):
@@ -1122,12 +1122,12 @@ class GraphModule(torch.nn.Module):
 
         subgraph_0 = self.subgraph_0
         invoke_subgraph = torch.ops.higher_order.invoke_subgraph(subgraph_0, 'subgraph_0', l_x_, l_y_);  subgraph_0 = l_x_ = None
-        getitem_4: "f32[8]" = invoke_subgraph[0];  invoke_subgraph = None
+        a: "f32[8]" = invoke_subgraph[0];  invoke_subgraph = None
 
         subgraph_1 = self.subgraph_1
-        invoke_subgraph_1 = torch.ops.higher_order.invoke_subgraph(subgraph_1, 'subgraph_1', getitem_4, l_y_);  subgraph_1 = getitem_4 = l_y_ = None
-        getitem_5: "f32[8]" = invoke_subgraph_1[0];  invoke_subgraph_1 = None
-        return (getitem_5,)
+        invoke_subgraph_1 = torch.ops.higher_order.invoke_subgraph(subgraph_1, 'subgraph_1', a, l_y_);  subgraph_1 = a = l_y_ = None
+        getitem_1: "f32[8]" = invoke_subgraph_1[0];  invoke_subgraph_1 = None
+        return (getitem_1,)
 
     class subgraph_0(torch.nn.Module):
         def forward(self, l_x_: "f32[8]", l_y_: "f32[8]"):
@@ -1143,6 +1143,7 @@ class GraphModule(torch.nn.Module):
 """,
             )
 
+    @torch._dynamo.config.patch("allow_side_effects_under_nested_compile_region", True)
     def test_nonlocal_list_mutation_hidden(self):
         """Test that nonlocal list mutation inside nested_compile_region is handled correctly."""
 
@@ -1244,20 +1245,20 @@ class GraphModule(torch.nn.Module):
 
         subgraph_0 = self.subgraph_0
         invoke_subgraph = torch.ops.higher_order.invoke_subgraph(subgraph_0, 'subgraph_0', l_x_, l_y_);  subgraph_0 = l_x_ = None
-        getitem_25: "f32[8]" = invoke_subgraph[0];  invoke_subgraph = None
+        getitem: "f32[8]" = invoke_subgraph[0];  invoke_subgraph = None
         subgraph_1 = self.subgraph_0
-        invoke_subgraph_1 = torch.ops.higher_order.invoke_subgraph(subgraph_1, 'subgraph_0', getitem_25, l_y_);  subgraph_1 = getitem_25 = None
-        getitem_26: "f32[8]" = invoke_subgraph_1[0];  invoke_subgraph_1 = None
+        invoke_subgraph_1 = torch.ops.higher_order.invoke_subgraph(subgraph_1, 'subgraph_0', getitem, l_y_);  subgraph_1 = getitem = None
+        getitem_1: "f32[8]" = invoke_subgraph_1[0];  invoke_subgraph_1 = None
         subgraph_2 = self.subgraph_0
-        invoke_subgraph_2 = torch.ops.higher_order.invoke_subgraph(subgraph_2, 'subgraph_0', getitem_26, l_y_);  subgraph_2 = getitem_26 = None
-        getitem_27: "f32[8]" = invoke_subgraph_2[0];  invoke_subgraph_2 = None
+        invoke_subgraph_2 = torch.ops.higher_order.invoke_subgraph(subgraph_2, 'subgraph_0', getitem_1, l_y_);  subgraph_2 = getitem_1 = None
+        getitem_2: "f32[8]" = invoke_subgraph_2[0];  invoke_subgraph_2 = None
         subgraph_3 = self.subgraph_0
-        invoke_subgraph_3 = torch.ops.higher_order.invoke_subgraph(subgraph_3, 'subgraph_0', getitem_27, l_y_);  subgraph_3 = getitem_27 = None
-        getitem_28: "f32[8]" = invoke_subgraph_3[0];  invoke_subgraph_3 = None
+        invoke_subgraph_3 = torch.ops.higher_order.invoke_subgraph(subgraph_3, 'subgraph_0', getitem_2, l_y_);  subgraph_3 = getitem_2 = None
+        getitem_3: "f32[8]" = invoke_subgraph_3[0];  invoke_subgraph_3 = None
         subgraph_4 = self.subgraph_0
-        invoke_subgraph_4 = torch.ops.higher_order.invoke_subgraph(subgraph_4, 'subgraph_0', getitem_28, l_y_);  subgraph_4 = getitem_28 = l_y_ = None
-        getitem_29: "f32[8]" = invoke_subgraph_4[0];  invoke_subgraph_4 = None
-        return (getitem_29,)
+        invoke_subgraph_4 = torch.ops.higher_order.invoke_subgraph(subgraph_4, 'subgraph_0', getitem_3, l_y_);  subgraph_4 = getitem_3 = l_y_ = None
+        getitem_4: "f32[8]" = invoke_subgraph_4[0];  invoke_subgraph_4 = None
+        return (getitem_4,)
 
     class subgraph_0(torch.nn.Module):
         def forward(self, l_x_: "f32[8]", l_y_: "f32[8]"):
@@ -1488,6 +1489,7 @@ class GraphModule(torch.nn.Module):
         ):
             opt_fn(x)
 
+    @torch._dynamo.config.patch("allow_side_effects_under_nested_compile_region", True)
     def test_side_effect_with_aliased_intermediate(self):
         captured_views = []
 
@@ -1505,12 +1507,13 @@ class GraphModule(torch.nn.Module):
             return result
 
         x = torch.randn(8, requires_grad=False)
-        # Side effects in nested compile regions cause a graph break because
-        # allow_side_effects=False for invoke_subgraph.
         opt_fn = torch.compile(fn, backend="inductor", fullgraph=True)
+        # TODO When a filtered aliased intermediate is captured by side effects,
+        # it will fail later with "does not belong to this Graph" error
+        # because the proxy from the inner graph is used in the outer graph.
         with self.assertRaisesRegex(
-            torch._dynamo.exc.Unsupported,
-            "Unsafe side effect",
+            torch._dynamo.exc.InternalTorchDynamoError,
+            "does not belong to this Graph",
         ):
             opt_fn(x)
 
@@ -2459,12 +2462,12 @@ class GraphModule(torch.nn.Module):
 
         subgraph_0 = self.subgraph_0
         invoke_subgraph = torch.ops.higher_order.invoke_subgraph(subgraph_0, 'subgraph_0', x, y);  subgraph_0 = x = None
-        getitem_4: "f32[5]" = invoke_subgraph[0];  invoke_subgraph = None
+        z: "f32[5]" = invoke_subgraph[0];  invoke_subgraph = None
 
         subgraph_1 = self.subgraph_1
-        invoke_subgraph_1 = torch.ops.higher_order.invoke_subgraph(subgraph_1, 'subgraph_1', getitem_4, y);  subgraph_1 = getitem_4 = y = None
-        getitem_5: "f32[5]" = invoke_subgraph_1[0];  invoke_subgraph_1 = None
-        return (getitem_5,)
+        invoke_subgraph_1 = torch.ops.higher_order.invoke_subgraph(subgraph_1, 'subgraph_1', z, y);  subgraph_1 = z = y = None
+        getitem_1: "f32[5]" = invoke_subgraph_1[0];  invoke_subgraph_1 = None
+        return (getitem_1,)
 
     class subgraph_0(torch.nn.Module):
         def forward(self, x: "f32[5]", y: "f32[5]"):

--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -848,6 +848,13 @@ enable_aot_compile = False
 # HACK: this is for testing custom ops profiling only
 _custom_ops_profile: Any | None = None
 
+# Allow externally visible side effects inside nested compile regions
+# (torch.compiler.nested_compile_region). When False (default), side effects
+# cause a graph break. Enable this if your region intentionally mutates
+# outer-scope state, at the cost of disabling compile-time caching for that
+# region.
+allow_side_effects_under_nested_compile_region: bool = False
+
 # Experimental flag to enable regional compile on invoke_subgraph HOP.
 # For testing only!
 enable_invoke_subgraph_regional_compile: bool = False

--- a/torch/_dynamo/graph_break_registry.json
+++ b/torch/_dynamo/graph_break_registry.json
@@ -810,6 +810,22 @@
         "If the HOP is activation checkpointing (torch.utils.checkpoint.checkpoint), this points to a ",
         "side effect in forward method. Eager activation checkpointing replays that side-effect while ",
         "recomputing the forward in the backward. If you are ok with side-effect not replayed in the ",
+        "backward, try setting `torch._dynamo.config.skip_fwd_side_effects_in_bwd_under_checkpoint = True`",
+        "If the HOP is a nested compile region (torch.ops.higher_order.invoke_subgraph / ",
+        "torch.compiler.nested_compile_region), consider removing ",
+        "the side effect from the region. Side effects prevent compile-time caching of the region, ",
+        "reducing the compile time benefit. If you must keep the side effect, set ",
+        "`torch._dynamo.config.allow_side_effects_under_nested_compile_region = True`."
+      ]
+    },
+    {
+      "Gb_type": "HOP: Unsafe side effect",
+      "Context": "Attempted to mutate {item}",
+      "Explanation": "Mutating a variable from outside the scope of this HOP is not supported.",
+      "Hints": [
+        "If the HOP is activation checkpointing (torch.utils.checkpoint.checkpoint), this points to a ",
+        "side effect in forward method. Eager activation checkpointing replays that side-effect while ",
+        "recomputing the forward in the backward. If you are ok with side-effect not replayed in the ",
         "backward, try setting `torch._dynamo.config.skip_fwd_side_effects_in_bwd_under_checkpoint = True`"
       ]
     },

--- a/torch/_dynamo/side_effects.py
+++ b/torch/_dynamo/side_effects.py
@@ -294,7 +294,8 @@ class SideEffects:
                     "backward, try setting `torch._dynamo.config.skip_fwd_side_effects_in_bwd_under_checkpoint = True`",
                     "If the HOP is a nested compile region (torch.compiler.nested_compile_region), consider removing "
                     "the side effect from the region. Side effects prevent compile-time caching of the region, "
-                    "reducing the compile time benefit.",
+                    "reducing the compile time benefit. If you must keep the side effect, set "
+                    "`torch._dynamo.config.allow_side_effects_under_nested_compile_region = True`.",
                 ],
             )
         return False

--- a/torch/_dynamo/side_effects.py
+++ b/torch/_dynamo/side_effects.py
@@ -292,6 +292,9 @@ class SideEffects:
                     "side effect in forward method. Eager activation checkpointing replays that side-effect while "
                     "recomputing the forward in the backward. If you are ok with side-effect not replayed in the "
                     "backward, try setting `torch._dynamo.config.skip_fwd_side_effects_in_bwd_under_checkpoint = True`",
+                    "If the HOP is a nested compile region (torch.compiler.nested_compile_region), consider removing "
+                    "the side effect from the region. Side effects prevent compile-time caching of the region, "
+                    "reducing the compile time benefit.",
                 ],
             )
         return False

--- a/torch/_dynamo/side_effects.py
+++ b/torch/_dynamo/side_effects.py
@@ -292,7 +292,8 @@ class SideEffects:
                     "side effect in forward method. Eager activation checkpointing replays that side-effect while "
                     "recomputing the forward in the backward. If you are ok with side-effect not replayed in the "
                     "backward, try setting `torch._dynamo.config.skip_fwd_side_effects_in_bwd_under_checkpoint = True`",
-                    "If the HOP is a nested compile region (torch.compiler.nested_compile_region), consider removing "
+                    "If the HOP is a nested compile region (torch.ops.higher_order.invoke_subgraph / "
+                    "torch.compiler.nested_compile_region), consider removing "
                     "the side effect from the region. Side effects prevent compile-time caching of the region, "
                     "reducing the compile time benefit. If you must keep the side effect, set "
                     "`torch._dynamo.config.allow_side_effects_under_nested_compile_region = True`.",

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -5107,7 +5107,7 @@ class InvokeSubgraphHigherOrderVariable(WrapHigherOrderVariable):
     _ALLOW_FALLBACK_TO_EAGER = False
     supports_input_mutation = True
     supports_aliasing = False
-    allow_side_effects = True
+    allow_side_effects = False
     # invoke_subgraph is NOT desugared in AOTAutograd, so the HOP input/output
     # shouldn't alias. For checkpoint HOP, we inline it so we don't need
     # alias analysis as functionalization would just work on the flat graph.

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -5107,11 +5107,14 @@ class InvokeSubgraphHigherOrderVariable(WrapHigherOrderVariable):
     _ALLOW_FALLBACK_TO_EAGER = False
     supports_input_mutation = True
     supports_aliasing = False
-    allow_side_effects = False
     # invoke_subgraph is NOT desugared in AOTAutograd, so the HOP input/output
     # shouldn't alias. For checkpoint HOP, we inline it so we don't need
     # alias analysis as functionalization would just work on the flat graph.
     filter_aliased_intermediates = True
+
+    @property
+    def allow_side_effects(self) -> bool:  # pyrefly: ignore[bad-override]
+        return torch._dynamo.config.allow_side_effects_under_nested_compile_region
 
     # pyrefly: ignore[bad-override]
     def install_subgraph_in_output_graph(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #176120
* #176105
* __->__ #176107
* #176033
* #176081
* #176082
* #176086
* #176032

Side effects in nested compile regions prevent compile-time caching,
reducing the compile time benefit. Set allow_side_effects=False on
InvokeSubgraphHigherOrderVariable so that side effects cause a graph
break with a descriptive message.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo