### PR TITLE
[CUDA/ROCm] avoid double casting in ReduceLogicKernel

### DIFF
--- a/aten/src/ATen/native/cuda/ReduceLogicKernel.cu
+++ b/aten/src/ATen/native/cuda/ReduceLogicKernel.cu
@@ -13,8 +13,8 @@ void and_kernel_cuda(TensorIterator& iter) {
       kHalf, kBFloat16, kBool, iter.common_dtype(), "and_cuda", [&]() {
         gpu_reduce_kernel<scalar_t, bool>(
             iter,
-            func_wrapper<bool>([] GPU_LAMBDA(scalar_t a, scalar_t b) -> bool {
-              return (static_cast<bool>(a) && static_cast<bool>(b));
+            func_wrapper<bool>([] GPU_LAMBDA(bool acc, scalar_t val) -> bool {
+              return (acc && static_cast<bool>(val));
             }),
             true);
       });
@@ -25,8 +25,8 @@ void or_kernel_cuda(TensorIterator& iter) {
       kHalf, kBFloat16, kBool, iter.common_dtype(), "or_cuda", [&]() {
         gpu_reduce_kernel<scalar_t, bool>(
             iter,
-            func_wrapper<bool>([] GPU_LAMBDA(scalar_t a, scalar_t b) -> bool {
-              return (static_cast<bool>(a) || static_cast<bool>(b));
+            func_wrapper<bool>([] GPU_LAMBDA(bool acc, scalar_t val) -> bool {
+              return (acc || static_cast<bool>(val));
             }),
             false);
       });


### PR DESCRIPTION
Avoid double casting in and_cuda as well as or_cuda kernels.

The lambda function `func_wrapper<bool>([] GPU_LAMBDA(...)` is used in call 'arg_t reduce(arg_t acc,  scalar_t val,..' where the return type is the same as the type of the first argument where it is actually is used:

```C++
// wrap a normal reduction that ignores the index
  __device__ arg_t reduce(arg_t acc, scalar_t val, int64_t idx) const {
    return combine(acc, val);
```
Roughly speaking intention is to do `acc = acc+val` in a loop.

For AND and OR logical reduce kernels, ` bool` is the return type of the `combine` function. Since the return type and the type of the first parameter is the same, `bool` should be the accumulator type, too.

This change will eliminate unnecessary double casting for the first parameter from `bool` to `float` and back.  

For ROCm 7.1, it fixes a compilation error where implicit conversion from bool is not natively supported for all possible float types like bf16.  See https://github.com/pytorch/pytorch/pull/175303 for motivation of this change.



cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang