### PR TITLE
Add TORCH_VERSION_2_12_0 guard to torch_from_blob_v2 implementation

### DIFF
--- a/torch/csrc/shim_common.cpp
+++ b/torch/csrc/shim_common.cpp
@@ -697,6 +697,7 @@ AOTI_TORCH_EXPORT AOTITorchError torch_from_blob(
   });
 }
 
+#if TORCH_FEATURE_VERSION >= TORCH_VERSION_2_12_0
 AOTI_TORCH_EXPORT AOTITorchError torch_from_blob_v2(
     void* data,
     int64_t ndim,
@@ -745,3 +746,4 @@ AOTI_TORCH_EXPORT AOTITorchError torch_from_blob_v2(
     *ret_new_tensor = torch::aot_inductor::new_tensor_handle(std::move(tensor));
   });
 }
+#endif // TORCH_FEATURE_VERSION >= TORCH_VERSION_2_12_0


### PR DESCRIPTION
Fixes #176133

shim.h has the header guard
https://github.com/pytorch/pytorch/blob/main/torch/csrc/stable/c/shim.h#L195

this PR adds the cpp imp counterpart

<details>
<summary>Before: shim_common.cpp:700:34: error: no previous prototype for function 'torch_from_blob_v2'</summary>
https://gist.github.com/cluePrints/060096442c9be94de40142a30e17b94b
</details>

<details>
<summary>After: builds ok</summary>
</details>