### PR TITLE
Fix ROCm build in CUDACachingAllocator

### DIFF
--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -755,7 +755,7 @@ struct ExpandableSegment {
     desc.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
 #ifdef USE_ROCM
     C10_CUDA_CHECK(hipMemSetAccess(
-        reinterpret_cast<char*>(ptr_) + begin * segment_size_,
+        ptr() + begin * segment_size_,
         (end - begin) * segment_size_,
         &desc,
         1));

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -662,7 +662,7 @@ struct ExpandableSegment {
               "Consider using expandable_segments:False via torch.cuda.memory._set_allocator_settings('expandable_segments:False') for this allocation.");
           TORCH_CHECK(false, "pidfd_getfd: ", c10::utils::str_error(err));
         }
-      CUmemGenericAllocationHandle handle = 0;
+        CUmemGenericAllocationHandle handle = 0;
 #ifdef USE_ROCM
 #if ROCM_VERSION >= 70100
         void* myfd_ptr = reinterpret_cast<void*>(static_cast<uintptr_t>(myfd));
@@ -670,9 +670,7 @@ struct ExpandableSegment {
         void* myfd_ptr = (void*)(uintptr_t)&myfd;
 #endif
         C10_CUDA_CHECK(hipMemImportFromShareableHandle(
-            &handle,
-            myfd_ptr,
-            hipMemHandleTypePosixFileDescriptor));
+            &handle, myfd_ptr, hipMemHandleTypePosixFileDescriptor));
 #else
         C10_CUDA_DRIVER_CHECK(DriverAPI::get()->cuMemImportFromShareableHandle_(
             &handle,
@@ -812,8 +810,8 @@ struct ExpandableSegment {
       Handle h = handles_.at(i).value();
       handles_.at(i) = std::nullopt;
 #ifdef USE_ROCM
-      C10_CUDA_CHECK(
-          hipMemUnmap(reinterpret_cast<char*>(ptr_) + segment_size_ * i, segment_size_));
+      C10_CUDA_CHECK(hipMemUnmap(
+          reinterpret_cast<char*>(ptr_) + segment_size_ * i, segment_size_));
 #else
       C10_CUDA_DRIVER_CHECK(DriverAPI::get()->cuMemUnmap_(
           ptr_ + segment_size_ * i, segment_size_));


### PR DESCRIPTION
Fixes the ROCm (HIP) build of CUDACachingAllocator.cpp which was broken by two categories of errors:

1. Embedded preprocessor directives inside macro arguments — The #if ROCM_VERSION >= 70100 / #endif block was nested inside a C10_CUDA_CHECK(hipMemImportFromShareableHandle(...)) macro call. Clang rejects this with -Werror,-Wembedded-directive. Fixed by hoisting the conditional into a separate variable (myfd_ptr) before the macro invocation.
2. Void pointer arithmetic — The HIP API uses void* for ptr_, unlike the CUDA driver API which uses CUdeviceptr (an integer type). Arithmetic on void* is undefined behavior and rejected by Clang. Fixed by casting ptr_ to char* via reinterpret_cast in the three call sites (hipMemSetAccess, hipMemMap, hipMemUnmap).

Also fixes requestedHandleTypes → requestedHandleType for the HIP CUmemAllocationProp struct, which uses a different field name than the CUDA equivalent.

This is a FF for issues introduced in https://github.com/pytorch/pytorch/pull/173330


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang