### PR TITLE
Fix flaky test_extra_collectives by disabling shape padding

### DIFF
--- a/test/distributed/tensor/parallel/test_micro_pipeline_tp.py
+++ b/test/distributed/tensor/parallel/test_micro_pipeline_tp.py
@@ -524,6 +524,7 @@ class MicroPipelineTP4GPUTest(TestCase):
 
     @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
     @fresh_cache()
+    @torch._inductor.config.patch(shape_padding=False)
     def test_extra_collectives(self):
         device_mesh = DeviceMesh(
             "cuda",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #176137

Force disable shape padding on the test_extra_collectives test

The pad_mm pass can non-deterministically pad the (16,7)@(7,10) matmul
when GPU spec queries fail under contention, which breaks the
fuse_matmul_reduce_scatter fusion because _find_producer_matmul
doesn't recognize the padded pattern (constant_pad_nd → mm → slice).

Authored with Claude.