### PR TITLE
fix: handle mutable optional args in custom_op

### DIFF
--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -3075,6 +3075,28 @@ with warnings.catch_warnings(record=True) as w:
                 return
 
     @skipIfTorchDynamo("Expected to fail due to no FakeTensor support; not a bug")
+    def test_mutated_optional_not_supplied(self):
+        # https://github.com/pytorch/pytorch/issues/176078
+        @torch.library.custom_op(
+            "_torch_testing::mutable_optional", mutates_args=("out",), device_types="cpu"
+        )
+        def func(a: Tensor, b: Tensor, out: Optional[Tensor] = None) -> None:
+            if out is not None:
+                out.copy_(a + b)
+
+        a = torch.randn(10)
+        b = torch.randn(10)
+        # Should not raise IndexError when called without the optional argument
+        func(a, b)
+
+        # Also test with the argument supplied
+        out = torch.empty(10)
+        version = out._version
+        func(a, b, out=out)
+        self.assertEqual(out, a + b)
+        self.assertGreater(out._version, version)
+
+    @skipIfTorchDynamo("Expected to fail due to no FakeTensor support; not a bug")
     def test_library_register_torch_dispatch_rule_subclass(self):
         from torch.testing._internal.two_tensor import TwoTensor
 

--- a/torch/_library/custom_ops.py
+++ b/torch/_library/custom_ops.py
@@ -683,9 +683,11 @@ class CustomOpDef:
                 # Handle the mutated idx the user gave us explicitly
 
                 for idx in mutated_idxs:
-                    increment_version(args[idx])
+                    if idx < len(args):
+                        increment_version(args[idx])
                 for key in mutated_keys:
-                    increment_version(kwargs[key])
+                    if key in kwargs:
+                        increment_version(kwargs[key])
                 # Handle view + mutation that are in the schema
                 return original_kernel.call_boxed(keyset, *args, **kwargs)
 


### PR DESCRIPTION
## Summary
Fixes #176078

When a custom_op has a mutable optional argument with a default value, calling the op without supplying that argument would cause an `IndexError: tuple index out of range` because the code in `adinplaceorview_impl` tried to access `args[idx]` without checking bounds.

The fix adds:
- Bounds checking (`idx < len(args)`) before accessing `args[idx]`
- Key existence checking (`key in kwargs`) before accessing `kwargs[key]`

## Test plan
Added `test_mutated_optional_not_supplied` to `test/test_custom_ops.py` that:
- Tests calling a custom_op with a mutable optional argument without supplying the optional arg (should not raise)
- Tests calling with the optional arg supplied (should work as before)

