### PR TITLE
Enable FMA-based addcdiv lowering for XPU

### DIFF
--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -7019,7 +7019,7 @@ def addcmul(self, tensor1, tensor2, *, value=1):
         dtype.is_floating_point
         and not torch.version.hip
         and device is not None
-        and device.type == "cuda"
+        and device.type in ["cuda", "xpu"]
     )
 
     def inner_fn(idx):
@@ -7094,7 +7094,7 @@ def addcdiv(self, tensor1, tensor2, *, value=1):
         dtype.is_floating_point
         and not torch.version.hip
         and device is not None
-        and device.type == "cuda"
+        and device.type in ["cuda", "xpu"]
     )
 
     def inner_fn(idx):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #176163

# Motivation
https://github.com/pytorch/pytorch/pull/174912 introduces this feature on CUDA, this PR aims to enable it for XPU.

# Additional Context
fix https://github.com/pytorch/pytorch/issues/176152
fix https://github.com/pytorch/pytorch/issues/176157
fix https://github.com/pytorch/pytorch/issues/176168
fix https://github.com/pytorch/pytorch/issues/176407

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo