### PR TITLE
[Build] Update TORCH_BUILD_VERSION when version.txt changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -813,6 +813,7 @@ if(INTERN_BUILD_MOBILE)
 endif()
 
 # ---[ Version numbers for generated libraries
+set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS version.txt)
 file(READ version.txt TORCH_DEFAULT_VERSION)
 # Strip trailing newline
 string(REGEX REPLACE "\n$" "" TORCH_DEFAULT_VERSION "${TORCH_DEFAULT_VERSION}")
@@ -824,16 +825,10 @@ if("${TORCH_DEFAULT_VERSION} " STREQUAL " ")
 endif()
 set(TORCH_BUILD_VERSION
     "${TORCH_DEFAULT_VERSION}"
-    CACHE STRING "Torch build version")
+    CACHE STRING "Torch build version" FORCE)
 if(DEFINED ENV{PYTORCH_BUILD_VERSION})
   set(TORCH_BUILD_VERSION
       "$ENV{PYTORCH_BUILD_VERSION}"
-      CACHE STRING "Torch build version" FORCE)
-endif()
-if(NOT TORCH_BUILD_VERSION)
-  # An empty string was specified so force version to the default
-  set(TORCH_BUILD_VERSION
-      "${TORCH_DEFAULT_VERSION}"
       CACHE STRING "Torch build version" FORCE)
 endif()
 caffe2_parse_version_str(TORCH ${TORCH_BUILD_VERSION})


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #176167

Before `TORCH_BUILD_VERSION` was permannetly baked into CMake variable cache, and updating version.txt and/or re-running cmake would never pick up changes, which was fine until StableABI got introduced, which causes build problems if `torch/headeronly/version.h` is out of date.

This change adds `FORCE` to the default cache set and registers `version.txt` via `CMAKE_CONFIGURE_DEPENDS` so that ninja/make automatically re-configures when the version file changes.

Fixes https://github.com/pytorch/pytorch/issues/176133