### PR TITLE
Add USE_BENCHMARK option to skip Google Benchmark in cmake

### DIFF
--- a/binaries/CMakeLists.txt
+++ b/binaries/CMakeLists.txt
@@ -18,7 +18,7 @@ target_include_directories(record_function_benchmark PUBLIC
 caffe2_binary_target("speed_benchmark_torch.cc")
 caffe2_binary_target("compare_models_torch.cc")
 
-if(BUILD_TEST)
+if(BUILD_TEST AND USE_BENCHMARK)
   # Core overhead benchmark
   caffe2_binary_target("core_overhead_benchmark.cc")
   target_link_libraries(core_overhead_benchmark benchmark)

--- a/c10/benchmark/CMakeLists.txt
+++ b/c10/benchmark/CMakeLists.txt
@@ -1,7 +1,7 @@
 # ---[ Benchmark binaries.
 
 file(GLOB_RECURSE C10_ALL_BENCH_FILES *.cpp)
-if(BUILD_TEST)
+if(BUILD_TEST AND USE_BENCHMARK)
   foreach(bench_src ${C10_ALL_BENCH_FILES})
     get_filename_component(bench_file_name ${bench_src} NAME_WE)
     set(bench_name "c10_${bench_file_name}")

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -662,20 +662,25 @@ if(BUILD_TEST OR BUILD_MOBILE_BENCHMARK OR BUILD_MOBILE_TEST)
   include_directories(BEFORE SYSTEM ${CMAKE_CURRENT_LIST_DIR}/../third_party/googletest/googletest/include)
   include_directories(BEFORE SYSTEM ${CMAKE_CURRENT_LIST_DIR}/../third_party/googletest/googlemock/include)
 
-  # We will not need to test benchmark lib itself.
-  set(BENCHMARK_ENABLE_TESTING OFF CACHE BOOL "Disable benchmark testing as we don't need it.")
-  # We will not need to install benchmark since we link it statically.
-  set(BENCHMARK_ENABLE_INSTALL OFF CACHE BOOL "Disable benchmark install to avoid overwriting vendor install.")
-  if(NOT USE_SYSTEM_BENCHMARK)
-    add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/../third_party/benchmark)
-  else()
-    add_library(benchmark SHARED IMPORTED)
-    find_library(BENCHMARK_LIBRARY benchmark)
-    if(NOT BENCHMARK_LIBRARY)
-      message(FATAL_ERROR "Cannot find google benchmark library")
+  if(NOT DEFINED USE_BENCHMARK)
+    set(USE_BENCHMARK ON)
+  endif()
+  if(USE_BENCHMARK)
+    # We will not need to test benchmark lib itself.
+    set(BENCHMARK_ENABLE_TESTING OFF CACHE BOOL "Disable benchmark testing as we don't need it.")
+    # We will not need to install benchmark since we link it statically.
+    set(BENCHMARK_ENABLE_INSTALL OFF CACHE BOOL "Disable benchmark install to avoid overwriting vendor install.")
+    if(NOT USE_SYSTEM_BENCHMARK)
+      add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/../third_party/benchmark)
+    else()
+      add_library(benchmark SHARED IMPORTED)
+      find_library(BENCHMARK_LIBRARY benchmark)
+      if(NOT BENCHMARK_LIBRARY)
+        message(FATAL_ERROR "Cannot find google benchmark library")
+      endif()
+      message("-- Found benchmark: ${BENCHMARK_LIBRARY}")
+      set_property(TARGET benchmark PROPERTY IMPORTED_LOCATION ${BENCHMARK_LIBRARY})
     endif()
-    message("-- Found benchmark: ${BENCHMARK_LIBRARY}")
-    set_property(TARGET benchmark PROPERTY IMPORTED_LOCATION ${BENCHMARK_LIBRARY})
   endif()
 
   # Recover build options.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #176170
* #176169
* #176052

Google Benchmark's cmake runs expensive try_run checks (~5s) that are
unnecessary for developers who only need Python tests. Add a
USE_BENCHMARK option (defaults to ON) that can be set to 0 to skip
configuring benchmark while keeping BUILD_TEST=ON for gtest.