### PR TITLE
Move test out of build for openreg

### DIFF
--- a/test/cpp_extensions/open_registration_extension/torch_openreg/third_party/openreg/CMakeLists.txt
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/third_party/openreg/CMakeLists.txt
@@ -39,7 +39,4 @@ if(USE_TEST)
     )
 
     add_test(NAME alltests COMMAND ${LIBRARY_TEST})
-    add_custom_command(TARGET ${LIBRARY_TEST}
-                POST_BUILD
-                COMMAND ${CMAKE_CTEST_COMMAND} -C Release --output-on-failure --verbose)
 endif()

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -989,7 +989,9 @@ def test_openreg(test_module, test_directory, options):
         return return_code
 
     # Run the openreg C++ unit tests (gtest) built by cmake.
-    ortests_bin = os.path.join(openreg_dir, "build", "third_party", "openreg", "ortests")
+    ortests_bin = os.path.join(
+        openreg_dir, "build", "third_party", "openreg", "ortests"
+    )
     if os.path.isfile(ortests_bin):
         return_code = shell([ortests_bin], cwd=openreg_dir)
         if return_code != 0:

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -988,6 +988,13 @@ def test_openreg(test_module, test_directory, options):
     if return_code != 0:
         return return_code
 
+    # Run the openreg C++ unit tests (gtest) built by cmake.
+    ortests_bin = os.path.join(openreg_dir, "build", "third_party", "openreg", "ortests")
+    if os.path.isfile(ortests_bin):
+        return_code = shell([ortests_bin], cwd=openreg_dir)
+        if return_code != 0:
+            return return_code
+
     with extend_python_path([install_dir]):
         cmd = [
             sys.executable,


### PR DESCRIPTION
These tests have been flaky on trunk since they were added https://hud.pytorch.org/hud/pytorch/pytorch/main/1?per_page=50

The best guess is that one of the test deadlocks and thus the whole thing timeout.
Separating build and test so we get faster timeout (from the test harness) and we can get more info.