### PR TITLE
Fix ATen/OpenMP parallel_for behavior under mixed OpenMP runtimes on Windows

### DIFF
--- a/aten/src/ATen/Parallel-inl.h
+++ b/aten/src/ATen/Parallel-inl.h
@@ -33,6 +33,7 @@ inline void parallel_for(
   internal::invoke_parallel(
       begin, end, grain_size, [&](int64_t begin, int64_t end) {
         c10::ParallelGuard guard(true);
+        c10::ParallelPathGuard pg;
         f(begin, end);
       });
 #else
@@ -75,6 +76,7 @@ inline scalar_t parallel_reduce(
       [&](const int64_t my_begin, const int64_t my_end) {
         const auto tid = at::get_thread_num();
         c10::ParallelGuard guard(true);
+        c10::ParallelPathGuard pg;
         results[tid] = f(my_begin, my_end, ident);
       });
 

--- a/aten/src/ATen/ParallelOpenMP.cpp
+++ b/aten/src/ATen/ParallelOpenMP.cpp
@@ -3,6 +3,7 @@
 #if AT_PARALLEL_OPENMP
 #include <ATen/Parallel.h>
 #include <ATen/ParallelFuture.h>
+#include <c10/util/ParallelGuard.h>
 
 #include <atomic>
 
@@ -14,7 +15,6 @@
 #include <ATen/native/mkldnn/IDeepRegistration.h>
 #endif
 
-#include <c10/util/ParallelGuard.h>
 #include <caffe2/utils/threadpool/pthreadpool-cpp.h>
 
 namespace at {
@@ -23,7 +23,6 @@ namespace {
 // Number of threads set by the user
 std::atomic<int> num_threads{-1};
 thread_local int this_thread_id{0};
-
 } // namespace
 
 void init_num_threads() {
@@ -94,11 +93,10 @@ void set_thread_num(int id) {
 
 bool in_parallel_region() {
 #ifdef _OPENMP
-  // Also check c10::ParallelGuard, which is set by at::parallel_for on all
-  // platforms. omp_in_parallel() suffices on most configurations, but on some
-  // Windows setups with mixed OpenMP runtimes the OpenMP in_parallel query
-  // returns false inside parallel regions, causing nested parallelism.
-  return omp_in_parallel() || c10::ParallelGuard::is_enabled();
+  // c10::ParallelPathGuard::is_active() is set only in the parallel path;
+  // on mixed OMP runtimes (e.g. VCOMP+libomp on Windows) omp_in_parallel()
+  // returns false inside active parallel regions, so we check both.
+  return omp_in_parallel() || c10::ParallelPathGuard::is_active();
 #else
   return false;
 #endif

--- a/aten/src/ATen/ParallelOpenMP.h
+++ b/aten/src/ATen/ParallelOpenMP.h
@@ -37,8 +37,7 @@ inline void invoke_parallel(
   std::atomic<int64_t> tid_counter{0};
   std::atomic<int64_t> next{begin};
   int64_t chunk_size = std::max<int64_t>(
-      grain_size > 0 ? grain_size : 1,
-      divup((end - begin), num_threads));
+      grain_size > 0 ? grain_size : 1, divup((end - begin), num_threads));
 
 #pragma omp parallel
   {

--- a/aten/src/ATen/ParallelOpenMP.h
+++ b/aten/src/ATen/ParallelOpenMP.h
@@ -19,29 +19,43 @@ inline void invoke_parallel(
     int64_t end,
     int64_t grain_size,
     const F& f) {
+  if (end <= begin)
+    return;
+
   std::atomic_flag err_flag = ATOMIC_FLAG_INIT;
   std::exception_ptr eptr;
 
+  // choose number of tasks based on grain size and number of threads
+  // can't use num_threads clause due to bugs in GOMP's thread pool (See
+  // #32008)
+  int64_t num_threads = omp_get_max_threads();
+  if (grain_size > 0) {
+    num_threads = std::min(num_threads, divup((end - begin), grain_size));
+  }
+  num_threads = std::max<int64_t>(1, num_threads);
+
+  std::atomic<int64_t> tid_counter{0};
+  std::atomic<int64_t> next{begin};
+  int64_t chunk_size = std::max<int64_t>(
+      grain_size > 0 ? grain_size : 1,
+      divup((end - begin), num_threads));
+
 #pragma omp parallel
   {
-    // choose number of tasks based on grain size and number of threads
-    // can't use num_threads clause due to bugs in GOMP's thread pool (See
-    // #32008)
-    int64_t num_threads = omp_get_num_threads();
-    if (grain_size > 0) {
-      num_threads = std::min(num_threads, divup((end - begin), grain_size));
-    }
-
-    int64_t tid = omp_get_thread_num();
-    int64_t chunk_size = divup((end - begin), num_threads);
-    int64_t begin_tid = begin + tid * chunk_size;
-    if (begin_tid < end) {
-      try {
-        internal::ThreadIdGuard tid_guard(tid);
-        f(begin_tid, std::min(end, chunk_size + begin_tid));
-      } catch (...) {
-        if (!err_flag.test_and_set()) {
-          eptr = std::current_exception();
+    int64_t tid = tid_counter.fetch_add(1, std::memory_order_relaxed);
+    if (tid < num_threads) {
+      internal::ThreadIdGuard tid_guard(tid);
+      for (;;) {
+        int64_t b = next.fetch_add(chunk_size, std::memory_order_relaxed);
+        if (b >= end)
+          break;
+        try {
+          f(b, std::min(end, b + chunk_size));
+        } catch (...) {
+          if (!err_flag.test_and_set()) {
+            eptr = std::current_exception();
+          }
+          break;
         }
       }
     }

--- a/aten/src/ATen/ParallelOpenMP.h
+++ b/aten/src/ATen/ParallelOpenMP.h
@@ -35,27 +35,40 @@ inline void invoke_parallel(
   num_threads = std::max<int64_t>(1, num_threads);
 
   std::atomic<int64_t> tid_counter{0};
-  std::atomic<int64_t> next{begin};
   int64_t chunk_size = std::max<int64_t>(
       grain_size > 0 ? grain_size : 1, divup((end - begin), num_threads));
 
 #pragma omp parallel
   {
     int64_t tid = tid_counter.fetch_add(1, std::memory_order_relaxed);
-    if (tid < num_threads) {
+    int64_t begin_tid = begin + tid * chunk_size;
+    if (begin_tid < end) {
       internal::ThreadIdGuard tid_guard(tid);
-      for (;;) {
-        int64_t b = next.fetch_add(chunk_size, std::memory_order_relaxed);
-        if (b >= end)
-          break;
-        try {
-          f(b, std::min(end, b + chunk_size));
-        } catch (...) {
-          if (!err_flag.test_and_set()) {
-            eptr = std::current_exception();
-          }
-          break;
+      try {
+        f(begin_tid, std::min(end, begin_tid + chunk_size));
+      } catch (...) {
+        if (!err_flag.test_and_set()) {
+          eptr = std::current_exception();
         }
+      }
+    }
+  }
+  if (!eptr) {
+    for (;;) {
+      int64_t tid = tid_counter.fetch_add(1, std::memory_order_relaxed);
+      if (tid >= num_threads)
+        break;
+      int64_t begin_tid = begin + tid * chunk_size;
+      if (begin_tid >= end)
+        break;
+      internal::ThreadIdGuard tid_guard(tid);
+      try {
+        f(begin_tid, std::min(end, begin_tid + chunk_size));
+      } catch (...) {
+        if (!err_flag.test_and_set()) {
+          eptr = std::current_exception();
+        }
+        break;
       }
     }
   }

--- a/aten/src/ATen/test/test_parallel.cpp
+++ b/aten/src/ATen/test/test_parallel.cpp
@@ -4,8 +4,6 @@
 #include <ATen/DLConvertor.h>
 #include <ATen/Parallel.h>
 #include <ATen/ParallelFuture.h>
-#include <c10/util/ParallelGuard.h>
-
 #include <atomic>
 #include <iostream>
 // NOLINTNEXTLINE(modernize-deprecated-headers)
@@ -128,12 +126,19 @@ TEST(TestParallel, ParallelForNoDuplicateWork) {
   }
 }
 
-TEST(TestParallel, InParallelRegionRespectsGuard) {
-  ASSERT_FALSE(at::in_parallel_region());
-  {
-    c10::ParallelGuard guard(true);
-    ASSERT_TRUE(at::in_parallel_region());
+TEST(TestParallel, InParallelRegionDetectedInsideParallelFor) {
+  NumThreadsGuard guard(4);
+  if (at::get_num_threads() < 2) {
+    GTEST_SKIP();
   }
+  ASSERT_FALSE(at::in_parallel_region());
+  std::atomic<bool> seen_in_parallel{false};
+  at::parallel_for(0, 100, 1, [&](int64_t /*begin*/, int64_t /*end*/) {
+    if (at::in_parallel_region()) {
+      seen_in_parallel.store(true, std::memory_order_relaxed);
+    }
+  });
+  ASSERT_TRUE(seen_in_parallel.load());
   ASSERT_FALSE(at::in_parallel_region());
 }
 

--- a/c10/util/ParallelGuard.cpp
+++ b/c10/util/ParallelGuard.cpp
@@ -2,10 +2,17 @@
 
 namespace c10 {
 
-thread_local static bool in_at_parallel = false;
+thread_local static bool in_at_parallel =
+    false; // set in both serial and parallel paths
+thread_local static bool in_parallel_path =
+    false; // set only in the parallel path
 
 bool ParallelGuard::is_enabled() {
   return in_at_parallel;
+}
+
+bool ParallelPathGuard::is_active() {
+  return in_parallel_path;
 }
 
 ParallelGuard::ParallelGuard(bool state) : previous_state_(is_enabled()) {
@@ -14,6 +21,14 @@ ParallelGuard::ParallelGuard(bool state) : previous_state_(is_enabled()) {
 
 ParallelGuard::~ParallelGuard() {
   in_at_parallel = previous_state_;
+}
+
+ParallelPathGuard::ParallelPathGuard() : previous_state_(in_parallel_path) {
+  in_parallel_path = true;
+}
+
+ParallelPathGuard::~ParallelPathGuard() {
+  in_parallel_path = previous_state_;
 }
 
 } // namespace c10

--- a/c10/util/ParallelGuard.h
+++ b/c10/util/ParallelGuard.h
@@ -17,4 +17,18 @@ class C10_API ParallelGuard {
   bool previous_state_;
 };
 
+// RAII guard that marks the calling thread as executing the parallel path of
+// parallel_for/parallel_reduce. Unlike ParallelGuard (set in both serial and
+// parallel paths for COW checks), this is set ONLY in the parallel path so
+// that at::in_parallel_region() correctly returns false in serial fallbacks.
+class C10_API ParallelPathGuard {
+ public:
+  static bool is_active();
+  ParallelPathGuard();
+  ~ParallelPathGuard();
+
+ private:
+  bool previous_state_;
+};
+
 } // namespace c10

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -1903,6 +1903,10 @@ if(BUILD_TEST)
     endif()
   endforeach()
 
+  if(TARGET caffe2::openmp)
+    target_link_libraries(test_parallel caffe2::openmp)
+  endif()
+
   if(USE_MPS)
     foreach(test_src ${Caffe2_MPS_TEST_SRCS})
       get_filename_component(test_name ${test_src} NAME_WE)


### PR DESCRIPTION
Fixes #176091

TLDR is On Windows, PyTorch loaded two OpenMP runtimes simultaneously, `vcomp140.dll` (MSVC, runs `#pragma omp parallel`) and `libiomp5md.dll` (libomp, resolves `omp_*()` API calls). These don't share state, so inside a VCOMP parallel region `omp_get_thread_num()` returns 0 for every thread and `omp_get_num_threads()` returns 1. `invoke_parallel` called both inside `#pragma omp parallel`, so all threads computed `tid=0` and a `chunk_size` equal to the full work range. CPU Flash Attention indexes per-thread scratch buffers by `at::get_thread_num()`, so all threads raced on slot 0 producing wrong results and NaN. `parallel_reduce` suffered the same, all threads wrote to `results[0]`. Separately, `omp_in_parallel()` returns false inside VCOMP regions, so `in_parallel_region()` was false on every worker and nested `parallel_for` calls would re-parallelize incorrectly.

### Changes

I fixed `invoke_parallel` in `ParallelOpenMP.h` by moving `num_threads` and `chunk_size` outside `#pragma omp parallel`, using `omp_get_max_threads()` instead of `omp_get_num_threads()`, and replacing `omp_get_thread_num()` with a `tid_counter` atomic so each thread gets a unique ID regardless of runtime. I also added a fallback loop on the calling thread to pick up any chunks VCOMP misses on cold start.

For `in_parallel_region()` I introduced `c10::ParallelPathGuard` in `c10/util/ParallelGuard.{h,cpp}`, a RAII thread-local set only in the parallel path of `parallel_for` and `parallel_reduce`. I also put it in `c10` rather than ATen because VCOMP creates its thread pool before `libtorch_cpu.dll` loads and `c10` thread-locals are reliably initialized by then. `in_parallel_region()` in `ParallelOpenMP.cpp` now checks `omp_in_parallel()` or `c10::ParallelPathGuard::is_active()`. finally i also wired the guard in `Parallel-inl.h` only on the parallel path, not the serial fallback, so `in_parallel_region()` stays false when `parallel_for` serializes.

And for testing, I added two tests to `test_parallel.cpp`, `ParallelForNoDuplicateWork` and `InParallelRegionDetectedInsideParallelFor`, and linked `test_parallel` with `caffe2::openmp` in `CMakeLists.txt` so the test binary actually compiles with the OMP flag and exercises real parallel paths.


cc @peterjc123 @mszhanyi @skyline75489 @nbcsm @iremyux @Blackhex @nkhasbag-nv