### PR TITLE
[TEST][CUDA] Rename "TestCudaMallocAsync" tests to `TestCudaAllocator`

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -4185,7 +4185,7 @@ print(ret)
 
 @unittest.skipIf(not TEST_CUDA, "CUDA not available, skipping tests")
 @torch.testing._internal.common_utils.markDynamoStrictTest
-class TestCudaMallocAsync(TestCase):
+class TestCudaAllocator(TestCase):
     @unittest.skipIf(
         TEST_CUDAMALLOCASYNC, "setContextRecorder not supported by CUDAMallocAsync"
     )
@@ -8582,7 +8582,7 @@ class TestFXMemoryProfiler(TestCase):
 
 
 instantiate_parametrized_tests(TestCuda)
-instantiate_parametrized_tests(TestCudaMallocAsync)
+instantiate_parametrized_tests(TestCudaAllocator)
 instantiate_parametrized_tests(TestCompileKernel)
 instantiate_parametrized_tests(TestCachingHostAllocatorCudaGraph)
 instantiate_device_type_tests(TestCudaOptims, globals())

--- a/test/test_cuda_expandable_segments.py
+++ b/test/test_cuda_expandable_segments.py
@@ -7,7 +7,7 @@ import sys
 from test_cuda import (  # noqa: F401
     TestBlockStateAbsorption,
     TestCuda,
-    TestCudaMallocAsync,
+    TestCudaAllocator,
 )
 
 import torch


### PR DESCRIPTION
Since https://github.com/pytorch/pytorch/pull/104059 these tests were named `TestCudaMallocAsync` but their only relation to `CudaMallocAsync` seems to be that they are actually _skipped_ when testing under the `CudaMallocAsync` allocator

cc @ptrblck @msaroufim @jerryzh168 @tinglvv @nWEIdia @mruberry