### PR TITLE
Add checkpoint_name() API for per-tensor selective activation checkpointing

### DIFF
--- a/test/dynamo/test_activation_checkpointing.py
+++ b/test/dynamo/test_activation_checkpointing.py
@@ -2130,6 +2130,158 @@ class GraphModule(torch.nn.Module):
         with torch._dynamo.config.patch(capture_profiler_record_function=True):
             self._validate(fn, backend, x, y)
 
+    def test_compile_checkpoint_name_basic(self):
+        from torch.utils.checkpoint import checkpoint_name
+
+        def _name_policy():
+            def _policy(ctx, func, *args, **kwargs):
+                if ctx.tensor_name == "sin_out":
+                    return CheckpointPolicy.MUST_SAVE
+                return CheckpointPolicy.PREFER_RECOMPUTE
+            return _policy
+
+        def gn(x):
+            y = torch.sin(x)
+            checkpoint_name(y, "sin_out")
+            return torch.cos(y)
+
+        def fn(x):
+            context_fn = functools.partial(
+                create_selective_checkpoint_contexts,
+                _name_policy(),
+            )
+            return checkpoint(gn, x, use_reentrant=False, context_fn=context_fn)
+
+        x = torch.randn(4, 4, requires_grad=True)
+        opt_fn = torch.compile(fn, backend="aot_eager_decomp_partition", fullgraph=True)
+
+        expected = fn(x)
+        result = opt_fn(x.clone().detach().requires_grad_(True))
+        self.assertEqual(result, expected)
+
+    def test_compile_checkpoint_name_with_policy(self):
+        from torch.utils.checkpoint import checkpoint_name
+
+        def _name_policy():
+            def _policy(ctx, func, *args, **kwargs):
+                if ctx.tensor_name == "matmul_out":
+                    return CheckpointPolicy.MUST_SAVE
+                return CheckpointPolicy.PREFER_RECOMPUTE
+            return _policy
+
+        def gn(x, y):
+            h = torch.matmul(x, y)
+            checkpoint_name(h, "matmul_out")
+            return torch.sigmoid(h + torch.sin(x))
+
+        def fn(x, y):
+            context_fn = functools.partial(
+                create_selective_checkpoint_contexts,
+                _name_policy(),
+            )
+            return checkpoint(gn, x, y, use_reentrant=False, context_fn=context_fn)
+
+        x = torch.randn(4, 4, requires_grad=True)
+        y = torch.randn(4, 4, requires_grad=True)
+        opt_fn = torch.compile(fn, backend="aot_eager_decomp_partition", fullgraph=True)
+
+        expected = fn(x, y)
+        result = opt_fn(
+            x.clone().detach().requires_grad_(True),
+            y.clone().detach().requires_grad_(True),
+        )
+        self.assertEqual(result, expected)
+
+    def test_compile_checkpoint_name_gradient_correctness(self):
+        from torch.utils.checkpoint import checkpoint_name
+
+        def _name_policy():
+            def _policy(ctx, func, *args, **kwargs):
+                if ctx.tensor_name == "matmul_out":
+                    return CheckpointPolicy.MUST_SAVE
+                return CheckpointPolicy.PREFER_RECOMPUTE
+            return _policy
+
+        def gn(x, y):
+            h = torch.matmul(x, y)
+            checkpoint_name(h, "matmul_out")
+            return torch.relu(h)
+
+        def fn(x, y):
+            context_fn = functools.partial(
+                create_selective_checkpoint_contexts,
+                _name_policy(),
+            )
+            return checkpoint(gn, x, y, use_reentrant=False, context_fn=context_fn)
+
+        x = torch.randn(4, 4, requires_grad=True)
+        y = torch.randn(4, 4, requires_grad=True)
+
+        # Reference: eager, no compile
+        x_ref = x.clone().detach().requires_grad_(True)
+        y_ref = y.clone().detach().requires_grad_(True)
+        fn(x_ref, y_ref).sum().backward()
+
+        # Compiled
+        x_comp = x.clone().detach().requires_grad_(True)
+        y_comp = y.clone().detach().requires_grad_(True)
+        opt_fn = torch.compile(fn, backend="aot_eager_decomp_partition", fullgraph=True)
+        opt_fn(x_comp, y_comp).sum().backward()
+
+        self.assertEqual(x_ref.grad, x_comp.grad)
+        self.assertEqual(y_ref.grad, y_comp.grad)
+
+    def test_compile_checkpoint_name_sets_recompute_metadata(self):
+        from torch.utils.checkpoint import checkpoint_name
+
+        def _name_policy():
+            def _policy(ctx, func, *args, **kwargs):
+                if ctx.tensor_name == "sin_out":
+                    return CheckpointPolicy.MUST_SAVE
+                return CheckpointPolicy.PREFER_RECOMPUTE
+            return _policy
+
+        def gn(x):
+            y = torch.sin(x)
+            checkpoint_name(y, "sin_out")
+            return torch.cos(y)
+
+        def fn(x):
+            context_fn = functools.partial(
+                create_selective_checkpoint_contexts,
+                _name_policy(),
+            )
+            return checkpoint(gn, x, use_reentrant=False, context_fn=context_fn)
+
+        joint_graph = None
+
+        def partition_fn(joint_module, joint_inputs, *, num_fwd_outputs, **kwargs):
+            nonlocal joint_graph
+            joint_graph = joint_module
+            return min_cut_rematerialization_partition(
+                joint_module, joint_inputs, num_fwd_outputs=num_fwd_outputs, **kwargs,
+            )
+
+        backend = aot_autograd(
+            fw_compiler=nop,
+            bw_compiler=nop,
+            partition_fn=partition_fn,
+        )
+
+        x = torch.randn(4, 4, requires_grad=True)
+        opt_fn = torch.compile(fn, backend=backend, fullgraph=True)
+        opt_fn(x).sum().backward()
+
+        # Find the sin node and verify it has recompute=MUST_SAVE
+        sin_nodes = [
+            n for n in joint_graph.graph.nodes
+            if n.target == torch.ops.aten.sin.default
+        ]
+        self.assertTrue(len(sin_nodes) > 0, "Expected sin node in joint graph")
+        sin_node = sin_nodes[0]
+        self.assertIn("recompute", sin_node.meta)
+        self.assertEqual(sin_node.meta["recompute"], CheckpointPolicy.MUST_SAVE)
+
 
 class RematerializeACNodesPassTests(torch._dynamo.test_case.TestCase):
     """Tests for AC reordering optimization in full graph (forward+backward in one graph)."""

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -91,6 +91,7 @@ from torch.utils.checkpoint import (
     checkpoint_sequential,
     CheckpointPolicy,
     create_selective_checkpoint_contexts,
+    checkpoint_name,
 )
 from torch.utils.flop_counter import FlopCounterMode
 
@@ -14863,6 +14864,30 @@ class TestNestedCheckpoint(TestCase):
         self.assertEqual(counter[0], 1)
 
 
+def _make_counter_op(name):
+    counts = [0]
+
+    @torch.library.custom_op(f"test_ckpt::{name}", mutates_args=())
+    def op(x: torch.Tensor) -> torch.Tensor:
+        counts[0] += 1
+        return x.sin()
+
+    @op.register_fake
+    def _(x):
+        return torch.empty_like(x)
+
+    def setup_context(ctx, inputs, output):
+        ctx.save_for_backward(inputs[0])
+
+    def backward(ctx, grad):
+        (x,) = ctx.saved_tensors
+        return grad * x.cos()
+
+    op.register_autograd(backward, setup_context=setup_context)
+
+    return op, counts
+
+
 class TestSelectiveActivationCheckpoint(TestCase):
     @unittest.skipIf(not TEST_CUDA, "requires CUDA")
     def test_flops_and_mem(self):
@@ -15262,9 +15287,6 @@ class TestSelectiveActivationCheckpoint(TestCase):
 
     @skipIfTorchDynamo("compile tested in test/dynamo/test_activation_checkpointing.py")
     def test_can_only_trigger_recompute_once(self):
-        # We don't support this to avoid adding extra complexity for now.
-        # If there's a need, we could probably do some kind of use_count tracking.
-        # TODO: have a nice error message here.
         def policy_fn(ctx, op, *args, **kwargs):
             if op == torch.ops.aten.sin.default:
                 return CheckpointPolicy.MUST_SAVE
@@ -15281,6 +15303,126 @@ class TestSelectiveActivationCheckpoint(TestCase):
 
         with self.assertRaisesRegex(RuntimeError, "Trying to backward an extra time"):
             out.sum().backward(retain_graph=True)
+
+    @skipIfTorchDynamo("compile tested in test/dynamo/test_activation_checkpointing.py")
+    def test_checkpoint_name_skips_recomputation(self):
+        # checkpoint_name() + policy should prevent recomputation
+        op_a, counts_a = _make_counter_op("name_a")
+        op_b, counts_b = _make_counter_op("name_b")
+
+        def policy_fn(ctx, op, *args, **kwargs):
+            if ctx.tensor_name == "keep_this":
+                return CheckpointPolicy.MUST_SAVE
+            return CheckpointPolicy.PREFER_RECOMPUTE
+
+        def fn(x):
+            y = op_a(x)
+            checkpoint_name(y, "keep_this")
+            return op_b(y)
+
+        x = torch.randn(4, requires_grad=True)
+        context_fn = functools.partial(create_selective_checkpoint_contexts, policy_fn)
+        out = checkpoint(fn, x, use_reentrant=False, context_fn=context_fn)
+        self.assertEqual(counts_a[0], 1)
+        self.assertEqual(counts_b[0], 1)
+
+        out.sum().backward()
+        # op_a was named "keep_this" and policy returned MUST_SAVE: not recomputed
+        self.assertEqual(counts_a[0], 1)
+        # op_b was not named: recomputed
+        self.assertEqual(counts_b[0], 2)
+
+    @skipIfTorchDynamo("compile tested in test/dynamo/test_activation_checkpointing.py")
+    def test_checkpoint_name_with_policy_fn(self):
+        # checkpoint_name() works alongside a policy that already saves some ops
+        op_a, counts_a = _make_counter_op("namepol_a")
+        op_b, counts_b = _make_counter_op("namepol_b")
+        op_c, counts_c = _make_counter_op("namepol_c")
+
+        def policy_fn(ctx, op, *args, **kwargs):
+            if ctx.tensor_name == "save_b":
+                return CheckpointPolicy.MUST_SAVE
+            if op == torch.ops.test_ckpt.namepol_a.default:
+                return CheckpointPolicy.MUST_SAVE
+            return CheckpointPolicy.PREFER_RECOMPUTE
+
+        def fn(x):
+            y = op_a(x)
+            z = op_b(y)
+            checkpoint_name(z, "save_b")
+            return op_c(z)
+
+        x = torch.randn(4, requires_grad=True)
+        context_fn = functools.partial(create_selective_checkpoint_contexts, policy_fn)
+        out = checkpoint(fn, x, use_reentrant=False, context_fn=context_fn)
+
+        out.sum().backward()
+        # op_a: policy saved by op match
+        self.assertEqual(counts_a[0], 1)
+        # op_b: policy saved by name match
+        self.assertEqual(counts_b[0], 1)
+        # op_c: recomputed
+        self.assertEqual(counts_c[0], 2)
+
+    @skipIfTorchDynamo("compile tested in test/dynamo/test_activation_checkpointing.py")
+    def test_checkpoint_name_policy_recompute(self):
+        # Policy can still decide to recompute a named tensor
+        op_a, counts_a = _make_counter_op("namerecomp_a")
+
+        def policy_fn(ctx, op, *args, **kwargs):
+            return CheckpointPolicy.PREFER_RECOMPUTE
+
+        def fn(x):
+            y = op_a(x)
+            checkpoint_name(y, "dont_save")
+            return y
+
+        x = torch.randn(4, requires_grad=True)
+        context_fn = functools.partial(create_selective_checkpoint_contexts, policy_fn)
+        out = checkpoint(fn, x, use_reentrant=False, context_fn=context_fn)
+        out.sum().backward()
+        # Policy said PREFER_RECOMPUTE even for the named tensor, so it was recomputed
+        self.assertEqual(counts_a[0], 2)
+
+    @skipIfTorchDynamo("compile tested in test/dynamo/test_activation_checkpointing.py")
+    def test_checkpoint_name_gradient_correctness(self):
+        def fn(x, w):
+            h = x @ w
+            return torch.relu(h).sum()
+
+        def fn_with_name(x, w):
+            h = x @ w
+            checkpoint_name(h, "hidden")
+            return torch.relu(h).sum()
+
+        x = torch.randn(4, 4, requires_grad=True)
+        w = torch.randn(4, 4, requires_grad=True)
+
+        # Reference (no checkpoint)
+        x_ref = x.clone().detach().requires_grad_(True)
+        w_ref = w.clone().detach().requires_grad_(True)
+        fn(x_ref, w_ref).backward()
+
+        # Checkpointed with checkpoint_name, policy saves named tensors
+        x_ckpt = x.clone().detach().requires_grad_(True)
+        w_ckpt = w.clone().detach().requires_grad_(True)
+
+        def policy_fn(ctx, op, *args, **kwargs):
+            if ctx.tensor_name is not None:
+                return CheckpointPolicy.MUST_SAVE
+            return CheckpointPolicy.PREFER_RECOMPUTE
+
+        context_fn = functools.partial(create_selective_checkpoint_contexts, policy_fn)
+        checkpoint(fn_with_name, x_ckpt, w_ckpt, use_reentrant=False, context_fn=context_fn).backward()
+
+        self.assertEqual(x_ref.grad, x_ckpt.grad)
+        self.assertEqual(w_ref.grad, w_ckpt.grad)
+
+    @skipIfTorchDynamo("compile tested in test/dynamo/test_activation_checkpointing.py")
+    def test_checkpoint_name_no_sac_is_noop(self):
+        # checkpoint_name without SAC context is a silent no-op
+        x = torch.randn(4)
+        checkpoint_name(x, "foo")  # should not raise
 
 
 class TestAutogradMultipleDispatch(TestCase):

--- a/torch/_dynamo/trace_rules.py
+++ b/torch/_dynamo/trace_rules.py
@@ -367,6 +367,7 @@ manual_torch_name_rule_map: dict[
     "torch.fx.experimental.symbolic_shapes.guard_scalar": TorchInGraphFunctionVariable,
     "torch.fx.experimental.symbolic_shapes.has_static_value": TorchInGraphFunctionVariable,
     "torch.cuda._get_device_properties": TorchInGraphFunctionVariable,
+    "torch.utils.checkpoint.checkpoint_name": TorchInGraphFunctionVariable,
     "torch.utils.hooks.BackwardHook": TorchInGraphFunctionVariable,
     "torch.set_default_device": UserFunctionVariable,
     "torch.sparse_bsc_tensor": SparseTensorCreationSkipVariable,

--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -4,7 +4,7 @@ import platform
 import uuid
 import warnings
 import weakref
-from collections import defaultdict
+from collections import defaultdict, OrderedDict
 from typing import *  # noqa: F403
 import enum
 from weakref import ReferenceType
@@ -14,7 +14,9 @@ import torch.fx.traceback as fx_traceback
 from torch.utils._pytree import tree_map
 from torch.testing._internal.logging_tensor import capture_logs, LoggingTensorMode
 from torch.utils._python_dispatch import TorchDispatchMode
+from torch.utils.weak import WeakTensorKeyDictionary
 from torch._C._autograd import _make_saved_tensor, SavedTensor
+from torch.utils.hooks import RemovableHandle
 from typing import NoReturn
 
 __all__ = [
@@ -34,6 +36,7 @@ __all__ = [
     "SelectiveCheckpointContext",
     "create_selective_checkpoint_contexts",
     "SAC_IGNORED_OPS",
+    "checkpoint_name",
     "GraphExecGroup",
 ]
 
@@ -1275,8 +1278,9 @@ class SelectiveCheckpointContext:
         >>>     context_fn=context_fn,
         >>> )
     """
-    def __init__(self, *, is_recompute) -> None:
+    def __init__(self, *, is_recompute, tensor_name=None) -> None:
         self.is_recompute = is_recompute
+        self.tensor_name = tensor_name
 
 
 class CheckpointPolicy(enum.Enum):
@@ -1327,6 +1331,61 @@ SAC_IGNORED_OPS = {
 } | set(torch._subclasses.functional_tensor.FunctionalTensor.metadata_fns)  # type: ignore[has-type]
 
 
+_tensor_naming_hooks: Dict[int, Callable] = OrderedDict()
+
+
+def _register_tensor_naming_hook(hook: Callable) -> RemovableHandle:
+    handle = RemovableHandle(_tensor_naming_hooks)
+    _tensor_naming_hooks[handle.id] = hook
+    return handle
+
+
+def checkpoint_name(tensor: torch.Tensor, name: Any) -> None:
+    """Name a tensor for selective activation checkpointing.
+
+    Call this inside a checkpointed function to associate a name with a
+    tensor.  The policy function receives the name via
+    ``ctx.tensor_name`` and can decide whether to save or recompute:
+
+    Example::
+
+        >>> import functools
+        >>> from torch.utils.checkpoint import (
+        ...     checkpoint, checkpoint_name, CheckpointPolicy,
+        ...     create_selective_checkpoint_contexts,
+        ... )
+        >>> def policy_fn(ctx, op, *args, **kwargs):
+        ...     if ctx.tensor_name == "hidden":
+        ...         return CheckpointPolicy.MUST_SAVE
+        ...     return CheckpointPolicy.PREFER_RECOMPUTE
+        >>> def fn(x, w):
+        ...     h = x @ w
+        ...     checkpoint_name(h, "hidden")
+        ...     return torch.relu(h)
+        >>> context_fn = functools.partial(create_selective_checkpoint_contexts, policy_fn)
+        >>> out = checkpoint(fn, x, w, use_reentrant=False, context_fn=context_fn)
+
+    Outside of a selective activation checkpoint context, this is a no-op.
+
+    Args:
+        tensor: The tensor to name.
+        name: An arbitrary name (typically a string).
+    """
+    # During recompute (backward), checkpoint_name() is a no-op
+    if torch._C._current_graph_task_id() != -1:
+        return
+    for hook in _tensor_naming_hooks.values():
+        hook(tensor, name)
+
+
+def _get_current_caching_mode():
+    from torch.utils._python_dispatch import _get_current_dispatch_mode_stack
+    for mode in reversed(_get_current_dispatch_mode_stack()):
+        if isinstance(mode, _CachingTorchDispatchMode):
+            return mode
+    return None
+
+
 class _CachingTorchDispatchMode(TorchDispatchMode):
     @classmethod
     def ignore_compile_internals(cls):
@@ -1336,6 +1395,52 @@ class _CachingTorchDispatchMode(TorchDispatchMode):
     def __init__(self, policy_fn, storage) -> None:
         self.policy_fn = policy_fn
         self.storage = storage
+        self.func_counter: Dict[Any, int] = defaultdict(int)
+        self.tensor_tracker: WeakTensorKeyDictionary = WeakTensorKeyDictionary()
+        self._naming_hook_handle: Optional[RemovableHandle] = None
+        # Names arriving before the tensor is tracked (mode ordering issue:
+        # an inner mode like AutoNamingMode names the tensor before we've
+        # returned from our own func(*args, **kwargs) call).
+        self._pending_names: Dict[int, str] = {}
+
+    def __enter__(self):
+        self._naming_hook_handle = _register_tensor_naming_hook(self._on_tensor_named)
+        return super().__enter__()
+
+    def __exit__(self, *args):
+        if self._naming_hook_handle is not None:
+            self._naming_hook_handle.remove()
+            self._naming_hook_handle = None
+        return super().__exit__(*args)
+
+    def _on_tensor_named(self, tensor, name):
+        info = self.tensor_tracker.get(tensor)
+        if info is None:
+            self._pending_names[id(tensor)] = name
+            return
+        self._process_named_tensor(tensor, name, info)
+
+    def _process_named_tensor(self, tensor, name, info):
+        func, idx, any_ret_has_alias_info = info
+
+        policy = self.policy_fn(
+            SelectiveCheckpointContext(is_recompute=False, tensor_name=name),
+            func,
+        )
+        if isinstance(policy, bool):
+            policy = _policy_from_bool(policy)
+
+        is_compiling = _is_compiling(func, (), None)
+
+        if is_compiling:
+            _set_save_policy_for_partitioner(tensor, policy)
+            return
+
+        if policy in (CheckpointPolicy.MUST_SAVE, CheckpointPolicy.PREFER_SAVE):
+            self.storage[func][idx] = tree_map(
+                lambda x: _VersionWrapper(_maybe_detach(x, any_ret_has_alias_info)),
+                tensor,
+            )
 
     def __torch_dispatch__(self, func, types, args=(), kwargs=None):
         if func in SAC_IGNORED_OPS:
@@ -1363,8 +1468,26 @@ class _CachingTorchDispatchMode(TorchDispatchMode):
         else:
             any_ret_has_alias_info = any(ret.alias_info is not None for ret in func._schema.returns)
 
+        idx = self.func_counter[func]
+        self.func_counter[func] += 1
+
+        # Track all output tensors so checkpoint_name() can retroactively find them
+        tree_map(
+            lambda x: self.tensor_tracker.__setitem__(x, (func, idx, any_ret_has_alias_info)) if isinstance(x, torch.Tensor) else None,
+            out,
+        )
+
+        # Process names that arrived while we were inside func() (from an
+        # inner mode that named the tensor before we had a chance to track it).
+        def _check_pending(x):
+            if isinstance(x, torch.Tensor):
+                name = self._pending_names.pop(id(x), None)
+                if name is not None:
+                    self._process_named_tensor(x, name, (func, idx, any_ret_has_alias_info))
+        tree_map(_check_pending, out)
+
         if policy in (CheckpointPolicy.MUST_SAVE, CheckpointPolicy.PREFER_SAVE) or is_compiling:
-            self.storage[func].append(tree_map(lambda x: _VersionWrapper(_maybe_detach(x, any_ret_has_alias_info)), out))
+            self.storage[func][idx] = tree_map(lambda x: _VersionWrapper(_maybe_detach(x, any_ret_has_alias_info)), out)
         return out
 
 class _CachedTorchDispatchMode(TorchDispatchMode):
@@ -1372,11 +1495,12 @@ class _CachedTorchDispatchMode(TorchDispatchMode):
     def ignore_compile_internals(cls):
         return True
 
-    # Used together with _CachedTorchDispatchMode to implement SAC.
+    # Used together with _CachingTorchDispatchMode to implement SAC.
     def __init__(self, policy_fn, storage, allow_cache_entry_mutation) -> None:
         self.policy_fn = policy_fn
         self.storage = storage
         self.allow_cache_entry_mutation = allow_cache_entry_mutation
+        self.func_counter: Dict[Any, int] = defaultdict(int)
 
     def __torch_dispatch__(self, func, types, args=(), kwargs=None):
         if func in SAC_IGNORED_OPS:
@@ -1390,16 +1514,19 @@ class _CachedTorchDispatchMode(TorchDispatchMode):
 
         is_compiling = _is_compiling(func, args, kwargs)
 
-        if policy in (CheckpointPolicy.MUST_SAVE, CheckpointPolicy.PREFER_SAVE) or is_compiling:
-            storage = self.storage.get(func)
-            if storage is None:
+        idx = self.func_counter[func]
+        self.func_counter[func] += 1
+
+        cached = self.storage.get(func, {}).pop(idx, None)
+        if cached is not None:
+            out = tree_map(lambda x: x.get_val(self.allow_cache_entry_mutation), cached)
+        elif policy in (CheckpointPolicy.MUST_SAVE, CheckpointPolicy.PREFER_SAVE) or is_compiling:
+            if func not in self.storage:
                 raise RuntimeError(f"{func} encountered during backward, but not found in storage")
-            if len(storage) == 0:
-                raise RuntimeError(
-                    "Trying to backward an extra time. You are only allowed to backward once "
-                    "on any region computed under selective activation checkpoint."
-                )
-            out = tree_map(lambda x: x.get_val(self.allow_cache_entry_mutation), storage.pop(0))
+            raise RuntimeError(
+                "Trying to backward an extra time. You are only allowed to backward once "
+                "on any region computed under selective activation checkpoint."
+            )
         else:
             out = func(*args, **kwargs)
         return out
@@ -1484,11 +1611,48 @@ def create_selective_checkpoint_contexts(policy_fn_or_list, allow_cache_entry_mu
     else:
         raise TypeError("policy_fn_or_list must be either a function or a list of ops.")
 
-    storage: Dict[Any, List[Any]] = defaultdict(list)
+    storage: Dict[Any, Dict[int, Any]] = defaultdict(dict)
     return (
         _CachingTorchDispatchMode(policy_fn, storage),
         _CachedTorchDispatchMode(policy_fn, storage, allow_cache_entry_mutation),
     )
+
+
+def _set_save_policy_for_partitioner(tensor, policy):
+    from torch.fx.experimental.proxy_tensor import get_proxy_mode
+
+    mode = get_proxy_mode()
+    if mode is None:
+        return
+
+    # ProxyTorchDispatchMode sees tensors after FunctionalTensor is unwrapped
+    from torch._subclasses.functional_tensor import mb_unwrap_functional_tensor
+    unwrapped = mb_unwrap_functional_tensor(tensor)
+
+    proxy_tensor = mode.tracer.tensor_tracker.get(unwrapped)
+    if proxy_tensor is None:
+        return
+    node = proxy_tensor.proxy.node
+
+    if _is_getitem_of_multi_output(node):
+        parent = node.args[0]
+        parent.meta["recompute"] = policy
+        parent.meta["ac_graph_id"] = 0
+
+    node.meta["recompute"] = policy
+    node.meta["ac_graph_id"] = 0
+
+
+def _is_getitem_of_multi_output(node):
+    import operator
+    if node.target != operator.getitem:
+        return False
+    parent = node.args[0]
+    # Same check as is_multi_output in partitioners.py
+    return len(parent.users) > 0 and all(
+        u.target == operator.getitem for u in parent.users
+    )
+
 
 # NB: this helper wraps fn before calling checkpoint_impl. kwargs and
 #     saving/restoring of global state is handled here.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

checkpoint_name(tensor, name) names a tensor inside a checkpointed region.
The policy function receives the name via ctx.tensor_name and decides
whether to save or recompute — keeping the policy as the single source
of truth for what gets saved. This follows JAX's checkpoint_name pattern.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo