### PR TITLE
[Inductor] Log autotuning config on kernel launch failure

### DIFF
--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -933,7 +933,7 @@ class CachingAutotuner(KernelInterface):
         return TritonCompileResult(binary, cfg, compile_meta, self.inductor_meta)
 
     def bench(self, launcher, *args, with_profiler=False, **kwargs):
-        """Measure the performance of a given launcher"""
+        """Measure the performance of a given launcher."""
         # we don't skip configs with spilled registers when auto-tuning custom
         # (user-written) Triton kernels, as (i) we don't have any knowledge or
         # control over the kernel code; (ii) there is empirical evidence that
@@ -978,7 +978,11 @@ class CachingAutotuner(KernelInterface):
                             stream=stream,
                         )
                     except Exception:
-                        log.error("Failed during launch %s: ", kernel_name)
+                        log.error(
+                            "Failed during launch %s with config %s: ",
+                            kernel_name,
+                            launcher.config,
+                        )
                         raise
 
             else:
@@ -989,7 +993,11 @@ class CachingAutotuner(KernelInterface):
                         stream=stream,
                     )
                 except Exception:
-                    log.error("Failed during launch %s: ", kernel_name)
+                    log.error(
+                        "Failed during launch %s with config %s: ",
+                        kernel_name,
+                        launcher.config,
+                    )
                     raise
             self.restore_args_from_cpu(cpu_copies)
 


### PR DESCRIPTION
Summary:
When a Triton kernel launch fails during autotuning (e.g. CUDA invalid
argument from grid overflow), the error log only prints the kernel name.
This makes it difficult to identify which autotune config caused the
failure. Add launcher.config to the error log in both exception handlers
in CachingAutotuner.bench() for easier debugging.

Test Plan:
Reproduced AOTI lowering failure on model entity 1041929970 at rev
2408f4ef (ien.lower:9b47e5647578). The enhanced log now shows:
```
Failed during launch triton_poi_fused_24 with config XBLOCK: 1024, YBLOCK: 1, ...
```
which identified the failing config as XBLOCK=1024, YBLOCK=1 causing
gridDim.y=98304 > 65535 CUDA limit.

Reviewed By: jijunyan

Differential Revision: D94685742




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo