### PR TITLE
Reorder type declarations and move definitions to fix Windows builds with TheRock

### DIFF
--- a/torch/csrc/jit/passes/subgraph_rewrite.h
+++ b/torch/csrc/jit/passes/subgraph_rewrite.h
@@ -18,8 +18,18 @@
 
 namespace torch::jit {
 
+/** Rewrite pattern descriptor.
+ *
+ * This structure is used in the implementation of `SubgraphRewriter` and
+ * is not supposed to be used externally.
+ */
+struct RewritePatternDescr {
+  std::string pattern;
+  std::string replacement;
+  std::unordered_map<std::string, std::string> value_name_map;
+};
+
 // Forward declarations.
-struct RewritePatternDescr;
 struct Match;
 
 using MatchFilter = std::function<
@@ -99,17 +109,6 @@ class TORCH_API SubgraphRewriter {
       const std::vector<MatchFilter>& filters);
 
   bool overlapsWithPreviousMatches(const Match* match);
-};
-
-/** Rewrite pattern descriptor.
- *
- * This structure is used in the implementation of `SubgraphRewriter` and
- * is not supposed to be used externally.
- */
-struct RewritePatternDescr {
-  std::string pattern;
-  std::string replacement;
-  std::unordered_map<std::string, std::string> value_name_map;
 };
 
 } // namespace torch::jit

--- a/torch/csrc/jit/runtime/static/impl.h
+++ b/torch/csrc/jit/runtime/static/impl.h
@@ -241,7 +241,6 @@ class TORCH_API StaticRuntimeMetadata : public torch::CustomClassHolder {
 /// @endcode
 ///
 class MemoryPlanner;
-class StaticNodeInfo;
 class ProcessedNode;
 class StaticRuntime;
 
@@ -294,6 +293,36 @@ class TORCH_API ProcessedFunction {
   Kind kind_{ProcessedFunction::Kind::kOutVariant};
   bool check_memory_overlap_{false};
   size_t num_outputs_{0};
+};
+
+class TORCH_API StaticNodeInfo {
+ public:
+  StaticNodeInfo(
+      Node* n,
+      ProcessedFunction* fn,
+      ProcessedNodeInputs inputs,
+      uint16_t outputs_offset);
+
+  Node* node() const {
+    return node_;
+  }
+
+  size_t num_outputs() const {
+    DCHECK(fn_ != nullptr);
+    return fn_->num_outputs();
+  }
+
+  bool has_out_variant() const {
+    return fn_->kind() == ProcessedFunction::Kind::kOutVariant;
+  }
+
+ private:
+  friend class ProcessedNode;
+
+  Node* node_;
+  const ProcessedFunction* fn_;
+  ProcessedNodeInputs inputs_;
+  uint16_t outputs_offset_;
 };
 
 // A `BlockInfo` instance stores all of the shared state that each
@@ -813,36 +842,6 @@ class TORCH_API BlockRunner {
 
   std::vector<IValue*> outputs_;
   std::vector<ProcessedNode> nodes_;
-};
-
-class TORCH_API StaticNodeInfo {
- public:
-  StaticNodeInfo(
-      Node* n,
-      ProcessedFunction* fn,
-      ProcessedNodeInputs inputs,
-      uint16_t outputs_offset);
-
-  Node* node() const {
-    return node_;
-  }
-
-  size_t num_outputs() const {
-    DCHECK(fn_ != nullptr);
-    return fn_->num_outputs();
-  }
-
-  bool has_out_variant() const {
-    return fn_->kind() == ProcessedFunction::Kind::kOutVariant;
-  }
-
- private:
-  friend class ProcessedNode;
-
-  Node* node_;
-  const ProcessedFunction* fn_;
-  ProcessedNodeInputs inputs_;
-  uint16_t outputs_offset_;
 };
 
 inline size_t BlockInfo::num_nodes() const {

--- a/torch/csrc/jit/tensorexpr/codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/codegen.cpp
@@ -21,6 +21,16 @@ CodeGen::CodeGen(
   allocIntermediateBufs();
 }
 
+CodeGen::CodeGen(const CodeGen& rhs) = default;
+
+CodeGen::CodeGen(CodeGen&& rhs) = default;
+
+CodeGen::~CodeGen() = default;
+
+CodeGen& CodeGen::operator=(const CodeGen& rhs) = default;
+
+CodeGen& CodeGen::operator=(CodeGen&& rhs) = default;
+
 RegisterCodeGenList& RegisterCodeGenList::GetInstance() {
   static RegisterCodeGenList codegen_list;
   return codegen_list;

--- a/torch/csrc/jit/tensorexpr/codegen.h
+++ b/torch/csrc/jit/tensorexpr/codegen.h
@@ -26,7 +26,15 @@ class TORCH_API CodeGen {
       at::Device device = at::kCPU,
       std::string kernel_func_name = "func");
 
-  virtual ~CodeGen() = default;
+  CodeGen(const CodeGen& rhs);
+
+  CodeGen(CodeGen&& rhs);
+
+  virtual ~CodeGen();
+
+  CodeGen& operator=(const CodeGen& rhs);
+
+  CodeGen& operator=(CodeGen&& rhs);
 
   StmtPtr stmt() const {
     return stmt_;

--- a/torch/csrc/lazy/core/ir.cpp
+++ b/torch/csrc/lazy/core/ir.cpp
@@ -96,6 +96,16 @@ Node::Node(OpKind op, Shape shape, size_t num_outputs) : Node(op, num_outputs) {
   shapes_.push_back(std::move(shape));
 }
 
+Node::Node(const Node& rhs) = default;
+
+Node::Node(Node&& rhs) = default;
+
+Node::~Node() = default;
+
+Node& Node::operator=(const Node& rhs) = default;
+
+Node& Node::operator=(Node&& rhs) = default;
+
 // Retrieves the full shape of the IR Node.
 c10::ArrayRef<Shape> Node::shapes() const {
   return shapes_;

--- a/torch/csrc/lazy/core/ir.h
+++ b/torch/csrc/lazy/core/ir.h
@@ -101,7 +101,15 @@ class TORCH_API Node {
   // Construct node with shape and no operands
   Node(OpKind op, Shape shape, size_t num_outputs = 1);
 
-  virtual ~Node() = default;
+  Node(const Node& rhs);
+
+  Node(Node&& rhs);
+
+  virtual ~Node();
+
+  Node& operator=(const Node& rhs);
+
+  Node& operator=(Node&& rhs);
 
   const OpKind& op() const {
     return op_;

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -125,8 +125,6 @@ enum class ParameterType {
   DISPATCH_KEY_SET
 };
 
-struct FunctionParameter;
-struct FunctionSignature;
 struct PythonArgs;
 
 // Contains bound Python arguments in declaration order
@@ -135,6 +133,81 @@ struct ParsedArgs {
   ParsedArgs() : args() {}
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
   PyObject* args[N];
+};
+
+// FunctionParameter is a single formal parameter of a Python function.
+// It is immutable once constructed.
+struct FunctionParameter {
+  FunctionParameter(const std::string& fmt, bool keyword_only);
+
+  bool check(
+      PyObject* obj,
+      std::vector<PyObject*>& overloaded_args,
+      int argnum,
+      int64_t* failed_idx = nullptr);
+
+  bool _check(
+      PyObject* obj,
+      std::vector<PyObject*>& overloaded_args,
+      int argnum,
+      int64_t* failed_idx = nullptr);
+
+  void set_default_str(const std::string& str);
+  TORCH_PYTHON_API std::string type_name() const;
+
+  ParameterType type_;
+  bool optional{false};
+  bool allow_none{false};
+  bool keyword_only;
+  bool allow_numbers_as_tensors = false;
+  int size{0};
+  std::string name;
+  // having this as a raw PyObject * will presumably leak it, but these are only
+  // held by static objects anyway, and Py_Finalize can already be called when
+  // this is destructed.
+  PyObject* python_name;
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
+  at::SmallVector<PyObject*, 5> numpy_python_names;
+  at::Scalar default_scalar;
+  std::vector<int64_t> default_intlist;
+  std::string default_string;
+  union {
+    bool default_bool;
+    int64_t default_int;
+    double default_double;
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
+    double default_complex[2]; // see Scalar
+    at::ScalarType default_scalartype;
+    at::Layout default_layout;
+  };
+  std::string default_value;
+};
+
+// FunctionSignature represents a single valid signature for a Python function.
+// It is immutable once constructed. The contained data can be concurrently
+// accessed by multiple calls.
+struct FunctionSignature {
+  explicit FunctionSignature(const std::string& fmt, int index);
+
+  bool parse(
+      PyObject* self,
+      PyObject* args,
+      PyObject* kwargs,
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
+      PyObject* dst[],
+      std::vector<PyObject*>& overloaded_args,
+      bool raise_exception);
+
+  std::string toString() const;
+
+  std::string name;
+  std::vector<FunctionParameter> params;
+  size_t min_args{0};
+  size_t max_args{0};
+  size_t max_pos_args{0};
+  int index;
+  bool hidden{false};
+  bool deprecated{false};
 };
 
 // A PythonArgParser contains a list of valid signatures. Instances are
@@ -179,33 +252,6 @@ struct PYBIND11_EXPORT PythonArgParser {
   std::string function_name;
   size_t max_args{0};
   bool traceable;
-};
-
-// FunctionSignature represents a single valid signature for a Python function.
-// It is immutable once constructed. The contained data can be concurrently
-// accessed by multiple calls.
-struct FunctionSignature {
-  explicit FunctionSignature(const std::string& fmt, int index);
-
-  bool parse(
-      PyObject* self,
-      PyObject* args,
-      PyObject* kwargs,
-      // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
-      PyObject* dst[],
-      std::vector<PyObject*>& overloaded_args,
-      bool raise_exception);
-
-  std::string toString() const;
-
-  std::string name;
-  std::vector<FunctionParameter> params;
-  size_t min_args{0};
-  size_t max_args{0};
-  size_t max_pos_args{0};
-  int index;
-  bool hidden{false};
-  bool deprecated{false};
 };
 
 // PythonArgs contains bound Python arguments for an actual invocation
@@ -309,54 +355,6 @@ struct TORCH_PYTHON_API PythonArgs {
   at::Tensor tensor_slow(int i);
   at::Scalar scalar_slow(int i);
   at::Scalar scalar_slow(PyObject* arg);
-};
-
-// FunctionParameter is a single formal parameter of a Python function.
-// It is immutable once constructed.
-struct FunctionParameter {
-  FunctionParameter(const std::string& fmt, bool keyword_only);
-
-  bool check(
-      PyObject* obj,
-      std::vector<PyObject*>& overloaded_args,
-      int argnum,
-      int64_t* failed_idx = nullptr);
-
-  bool _check(
-      PyObject* obj,
-      std::vector<PyObject*>& overloaded_args,
-      int argnum,
-      int64_t* failed_idx = nullptr);
-
-  void set_default_str(const std::string& str);
-  TORCH_PYTHON_API std::string type_name() const;
-
-  ParameterType type_;
-  bool optional{false};
-  bool allow_none{false};
-  bool keyword_only;
-  bool allow_numbers_as_tensors = false;
-  int size{0};
-  std::string name;
-  // having this as a raw PyObject * will presumably leak it, but these are only
-  // held by static objects anyway, and Py_Finalize can already be called when
-  // this is destructed.
-  PyObject* python_name;
-  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-  at::SmallVector<PyObject*, 5> numpy_python_names;
-  at::Scalar default_scalar;
-  std::vector<int64_t> default_intlist;
-  std::string default_string;
-  union {
-    bool default_bool;
-    int64_t default_int;
-    double default_double;
-    // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
-    double default_complex[2]; // see Scalar
-    at::ScalarType default_scalartype;
-    at::Layout default_layout;
-  };
-  std::string default_value;
 };
 
 template <int N>


### PR DESCRIPTION
These changes reorder type definitions to fix half of the problem in https://github.com/ROCm/TheRock/issues/3603. The new issue with `torch\c10\hip\HIPCachingAllocator.cpp` attempting to include `<sys/syscall.h>` on Windows is not fixed in these changes.

The current problem is that some of these classes contain vectors of a type by value that have not been defined yet. This causes a problem when attempting to define a destructor or constructor that needs to know the size of that type in order to create/destroy the value, even if said destructor/constructor is implicit. The is solved by simply reordering the declarations in the file, or moving them to the compile unit. This does technically prevent them from being inlined, but I'm not sure if that can even occur with how they are currently declared anyway.

cc @EikanWang @jgong5