### PR TITLE
[NN] Improved performance for nn/modules/module.py _call_impl() by around 10% for certain cases and some minor changes

### DIFF
--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -1803,10 +1803,24 @@ class Module:
                 full_backward_hooks, non_full_backward_hooks = self._get_backward_hooks()
 
             if _global_forward_pre_hooks or self._forward_pre_hooks:
-                for hook_id, hook in (
-                    *_global_forward_pre_hooks.items(),
-                    *self._forward_pre_hooks.items(),
-                ):
+                for hook_id, hook in _global_forward_pre_hooks.items():
+                    if hook_id in _global_forward_hooks_with_kwargs:
+                        args_kwargs_result = hook(self, args, kwargs)  # type: ignore[misc]
+                        if args_kwargs_result is not None:
+                            if isinstance(args_kwargs_result, tuple) and len(args_kwargs_result) == 2:
+                                args, kwargs = args_kwargs_result
+                            else:
+                                raise RuntimeError(
+                                    "forward pre-hook must return None or a tuple "
+                                    f"of (new_args, new_kwargs), but got {args_kwargs_result}."
+                                )
+                    else:
+                        args_result = hook(self, args)
+                        if args_result is not None:
+                            if not isinstance(args_result, tuple):
+                                args_result = (args_result,)
+                            args = args_result
+                for hook_id, hook in self._forward_pre_hooks.items():
                     if hook_id in self._forward_pre_hooks_with_kwargs:
                         args_kwargs_result = hook(self, args, kwargs)  # type: ignore[misc]
                         if args_kwargs_result is not None:
@@ -1831,15 +1845,22 @@ class Module:
 
             result = forward_call(*args, **kwargs)
             if _global_forward_hooks or self._forward_hooks:
-                for hook_id, hook in (
-                    *_global_forward_hooks.items(),
-                    *self._forward_hooks.items(),
-                ):
-                    # mark that always called hook is run
-                    if hook_id in self._forward_hooks_always_called or hook_id in _global_forward_hooks_always_called:
+                for hook_id, hook in _global_forward_hooks.items():
+                    if hook_id in _global_forward_hooks_always_called:
                         called_always_called_hooks.add(hook_id)
 
-                    if hook_id in self._forward_hooks_with_kwargs or hook_id in _global_forward_hooks_with_kwargs:
+                    if hook_id in _global_forward_hooks_with_kwargs:
+                        hook_result = hook(self, args, kwargs, result)
+                    else:
+                        hook_result = hook(self, args, result)
+
+                    if hook_result is not None:
+                        result = hook_result
+                for hook_id, hook in self._forward_hooks.items():
+                    if hook_id in self._forward_hooks_always_called:
+                        called_always_called_hooks.add(hook_id)
+
+                    if hook_id in self._forward_hooks_with_kwargs:
                         hook_result = hook(self, args, kwargs, result)
                     else:
                         hook_result = hook(self, args, result)


### PR DESCRIPTION
## Summary

This PR combines an increase in performance of `nn/modules/module.py` `_call_impl()` by around 10% for certain cases (see measurements down below) with some minor changes to `hook_id` checks.

## Changes made

This check `if hook_id in self._forward_pre_hooks_with_kwargs:` in

    for hook_id, hook in (
        *_global_forward_pre_hooks.items(),
        *self._forward_pre_hooks.items(),
    ):

only included `self._forward_pre_hooks_with_kwargs` in the first place while in the second place also `_global_forward_hooks_with_kwargs` was included in `if hook_id in self._forward_hooks_with_kwargs or hook_id in _global_forward_hooks_with_kwargs:` which was missing in the first check (IMO).

Don't be confused that in the second statement the second part (of this second statement) seems to be removed in the diff link (this is only because we now use seperate loops for checking both (`self._forward_pre_hooks_with_kwargs` and `_global_forward_hooks_with_kwargs` (which we (by the way) now do in both places (so second and first place) as well (see the explanation above)))).

And there is another change made and that is (because we use seperate loops (like mentioned above)) that we won't check for `self._forward_hooks_with_kwargs` inside the loop for `_global_forward_hooks_with_kwargs` (and the other way around) like we already do so in the other part down below (not belongig to this change directly, but it's implemented in the same place (lines 1910-1911 and 1921-1922 (in the changed version (because the lines differ from version to version)))).

## Performance improvements

Instead of using

    for hook_id, hook in (
        *_global_forward_pre_hooks.items(),
        *self._forward_pre_hooks.items(),
    ):

we use seperate loops and also did some other changes (mentioned above) which in total increases performance by around 10% measured by the following scripts:

`torchcontroller.py`

    import subprocess
    import statistics
    import math
    import time

    pythontorch_A = r"C:\Users\User\pythontorch\PCbuild\amd64\python.exe"
    pythontorch_B = r"C:\Users\User\pythontorch_patch\PCbuild\amd64\python.exe"
    benchmark_script = r"C:\Users\User\Desktop\torchperformancetest.py"

    runs = 100

    results_A = []
    results_B = []

    for i in range(runs):
        out_A = subprocess.check_output([pythontorch_A, benchmark_script])
        time_A = float(out_A.strip())
        results_A.append(time_A)
        print(f"Run {i+1}/{runs} completed for PyTorch A | Time: {time_A} s")
    
        out_B = subprocess.check_output([pythontorch_B, benchmark_script])
        time_B = float(out_B.strip())
        results_B.append(time_B)
        print(f"Run {i+1}/{runs} completed for PyTorch B | Time: {time_B} s")

    def summarize(data, label):
        n = len(data)
        mean = statistics.mean(data)
        stdev = statistics.stdev(data)
        median = statistics.median(data)

        z = 1.96
        margin = z * (stdev / math.sqrt(n))
        ci_lower = mean - margin
        ci_upper = mean + margin

        print(f"\n--- {label} ---")
        print(f"Mean: {mean:.6f} s")
        print(f"Median: {median:.6f} s")
        print(f"Std Dev: {stdev:.6f} s")
        print(f"95% CI: [{ci_lower:.6f}, {ci_upper:.6f}] s")

    print("\n===== STATS =====")
    summarize(results_A, "PyTorch")
    summarize(results_B, "PyTorch PATCH")

    speedup = statistics.mean(results_A) / statistics.mean(results_B)
    print(f"\nSpeedup A/B: {speedup:.4f}x")

`torchperformancetest.py`

    import torch
    import torch.nn as nn
    import time

    class TestModule(nn.Module):
        def forward(self, x):
            return x  

    def main():
        device = torch.device('cpu')
        model = TestModule().to(device)
        x = torch.tensor(1.0, device=device)

        def pre_hook(module, args):
            return args
        def hook(module, args, out):
            return out

        model.register_forward_pre_hook(pre_hook)
        model.register_forward_hook(hook)

        for _ in range(100_000):
            model(x)

        num_iter = 250_000
        start = time.perf_counter()
        for _ in range(num_iter):
            model(x)
        end = time.perf_counter()
        elapsed = end - start
        print(f"{elapsed:.6f}")

    if __name__ == "__main__":
        main()

## Results

The full log is viewable online here (https://justpaste.it/komma) because it's way too long (100 runs for both scripts) for pasting it on GitHub, but you can visit the link above and view all results.

Summary:

    --- PyTorch ---
    Mean: 0.795447 s
    Median: 0.791746 s
    Std Dev: 0.029037 s
    95% CI: [0.789756, 0.801138] s

    --- PyTorch PATCH ---
    Mean: 0.722853 s
    Median: 0.715638 s
    Std Dev: 0.025819 s
    95% CI: [0.717793, 0.727914] s

    Speedup A/B: 1.1004x