### PR TITLE
[Inductor] Disable "jax_enable_x64" for TPU Pallas codegen.

### DIFF
--- a/torch/_inductor/codegen/pallas.py
+++ b/torch/_inductor/codegen/pallas.py
@@ -3493,7 +3493,7 @@ from torch._inductor.runtime.runtime_utils import (
             f"def {main_name}({', '.join(ctx.full_kernel_params)}, stream=None):"
         )
         with code.indent():
-            code.writeline("jax.config.update('jax_enable_x64', True)")
+            code.writeline("jax.config.update('jax_enable_x64', False)")
             code.writeline("jax.clear_caches()")
 
             # Build JAX placeholders for all inputs

--- a/torch/_inductor/codegen/pallas.py
+++ b/torch/_inductor/codegen/pallas.py
@@ -3493,7 +3493,6 @@ from torch._inductor.runtime.runtime_utils import (
             f"def {main_name}({', '.join(ctx.full_kernel_params)}, stream=None):"
         )
         with code.indent():
-            code.writeline("jax.config.update('jax_enable_x64', False)")
             code.writeline("jax.clear_caches()")
 
             # Build JAX placeholders for all inputs


### PR DESCRIPTION
TPU lacks some support for x64 dtype, so this PR disables x64 for TPU codegen.

**Before this change, the issue with "test_rope" in "test_pallas.py" will be** 

```
    File "/mnt/hyperdisk/pytorch/.venv/lib/python3.12/site-packages/jax/_src/pallas/mosaic/lowering.py", line 1206, in jaxpr_subcomp
    ans = lowering_rules[ctx.kernel_type][eqn.primitive](
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/hyperdisk/pytorch/.venv/lib/python3.12/site-packages/jax/_src/pallas/mosaic/lowering.py", line 2364, in _convert_element_type_lowering_rule
    return lower_fun(functools.partial(_convert_helper, to_dtype=new_dtype),
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/hyperdisk/pytorch/.venv/lib/python3.12/site-packages/jax/_src/pallas/mosaic/lowering.py", line 1095, in f_lowered
    jaxpr, _, consts = pe.trace_to_jaxpr_dynamic(wrapped_fun, ctx.avals_in)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/hyperdisk/pytorch/.venv/lib/python3.12/site-packages/jax/_src/profiler.py", line 359, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/hyperdisk/pytorch/.venv/lib/python3.12/site-packages/jax/_src/interpreters/partial_eval.py", line 2451, in trace_to_jaxpr_dynamic
    ans = fun.call_wrapped(*in_tracers)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/hyperdisk/pytorch/.venv/lib/python3.12/site-packages/jax/_src/linear_util.py", line 212, in call_wrapped
    return self.f_transformed(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/hyperdisk/pytorch/.venv/lib/python3.12/site-packages/jax/_src/pallas/mosaic/lowering.py", line 1090, in <lambda>
    f = fun if multiple_results else lambda *args, **kw: (fun(*args, **kw),)
                                                          ^^^^^^^^^^^^^^^^
  File "/mnt/hyperdisk/pytorch/.venv/lib/python3.12/site-packages/jax/_src/pallas/mosaic/lowering.py", line 2291, in _convert_helper
    return x.astype(to_dtype)
           ^^^^^^^^^^^^^^^^^^
  File "/mnt/hyperdisk/pytorch/.venv/lib/python3.12/site-packages/jax/_src/numpy/array_methods.py", line 1152, in meth
    return getattr(self.aval, name).fun(self, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/hyperdisk/pytorch/.venv/lib/python3.12/site-packages/jax/_src/numpy/array_methods.py", line 125, in _astype
    return lax_numpy.astype(self, dtype, copy=copy, device=device)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/hyperdisk/pytorch/.venv/lib/python3.12/site-packages/jax/_src/numpy/lax_numpy.py", line 5361, in astype
    result = lax._convert_element_type(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/hyperdisk/pytorch/.venv/lib/python3.12/site-packages/jax/_src/lax/lax.py", line 1689, in _convert_element_type
    return convert_element_type_p.bind(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/hyperdisk/pytorch/.venv/lib/python3.12/site-packages/jax/_src/core.py", line 632, in bind
    return self._true_bind(*args, **params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/hyperdisk/pytorch/.venv/lib/python3.12/site-packages/jax/_src/core.py", line 648, in _true_bind
    return self.bind_with_trace(prev_trace, args, params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/hyperdisk/pytorch/.venv/lib/python3.12/site-packages/jax/_src/lax/lax.py", line 5012, in _convert_element_type_bind_with_trace
    operand = core.Primitive.bind_with_trace(convert_element_type_p, trace, args, params)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/hyperdisk/pytorch/.venv/lib/python3.12/site-packages/jax/_src/core.py", line 660, in bind_with_trace
    return trace.process_primitive(self, args, params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/hyperdisk/pytorch/.venv/lib/python3.12/site-packages/jax/_src/interpreters/partial_eval.py", line 2031, in process_primitive
    return self.default_process_primitive(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/hyperdisk/pytorch/.venv/lib/python3.12/site-packages/jax/_src/interpreters/partial_eval.py", line 2049, in default_process_primitive
    out_avals, effs = _cached_abstract_eval(primitive, *aval_qdds, **params)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/hyperdisk/pytorch/.venv/lib/python3.12/site-packages/jax/_src/util.py", line 462, in wrapper
    args, kwargs = weakrefs_to_sentinel((orig_args, orig_kwargs),
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/hyperdisk/pytorch/.venv/lib/python3.12/site-packages/jax/_src/util.py", line 410, in weakrefs_to_sentinel
    return tuple(weakrefs_to_sentinel(v1, acc) for v1 in v)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/hyperdisk/pytorch/.venv/lib/python3.12/site-packages/jax/_src/util.py", line 410, in <genexpr>
    return tuple(weakrefs_to_sentinel(v1, acc) for v1 in v)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/hyperdisk/pytorch/.venv/lib/python3.12/site-packages/jax/_src/util.py", line 410, in weakrefs_to_sentinel
    return tuple(weakrefs_to_sentinel(v1, acc) for v1 in v)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/hyperdisk/pytorch/.venv/lib/python3.12/site-packages/jax/_src/util.py", line 410, in <genexpr>
    return tuple(weakrefs_to_sentinel(v1, acc) for v1 in v)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RecursionError: maximum recursion depth exceeded
```

**After this change, the issue with "test_rope" in "test_pallas.py" will be**

```
Traceback (most recent call last):
  File "/root/.local/share/uv/python/cpython-3.12.12-linux-x86_64-gnu/lib/python3.12/unittest/case.py", line 58, in testPartExecutor
    yield
  File "/root/.local/share/uv/python/cpython-3.12.12-linux-x86_64-gnu/lib/python3.12/unittest/case.py", line 634, in run
    self._callTestMethod(testMethod)
  File "/root/.local/share/uv/python/cpython-3.12.12-linux-x86_64-gnu/lib/python3.12/unittest/case.py", line 589, in _callTestMethod
    if method() is not None:
       ^^^^^^^^
  File "/mnt/hyperdisk/pytorch/torch/testing/_internal/common_utils.py", line 3368, in wrapper
    method(*args, **kwargs)
  File "/mnt/hyperdisk/pytorch/test/inductor/test_pallas.py", line 109, in wrapper
    fn(self, *args, **kwargs)
  File "/mnt/hyperdisk/pytorch/test/inductor/test_pallas.py", line 1193, in test_rope
    result = compiled(x, cos, sin)
             ^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/hyperdisk/pytorch/torch/_dynamo/eval_frame.py", line 1020, in compile_wrapper
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/mnt/hyperdisk/pytorch/test/inductor/test_pallas.py", line 1182, in fn
    def fn(x, cos, sin):
  File "/mnt/hyperdisk/pytorch/torch/_dynamo/eval_frame.py", line 1258, in _fn
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/mnt/hyperdisk/pytorch/torch/_functorch/aot_autograd.py", line 1200, in forward
    return compiled_fn(full_args)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/hyperdisk/pytorch/torch/_functorch/_aot_autograd/runtime_wrappers.py", line 580, in runtime_wrapper
    all_outs = call_func_at_runtime_with_args(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/hyperdisk/pytorch/torch/_functorch/_aot_autograd/utils.py", line 138, in call_func_at_runtime_with_args
    out = normalize_as_list(f(args))
                            ^^^^^^^
  File "/mnt/hyperdisk/pytorch/torch/_functorch/_aot_autograd/runtime_wrappers.py", line 2315, in __call__
    return self.compiled_fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/hyperdisk/pytorch/torch/_functorch/_aot_autograd/runtime_wrappers.py", line 783, in wrapper
    return compiled_fn(runtime_args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/hyperdisk/pytorch/torch/_functorch/_aot_autograd/runtime_wrappers.py", line 1011, in inner_fn
    outs = compiled_fn(args)
           ^^^^^^^^^^^^^^^^^
  File "/mnt/hyperdisk/pytorch/torch/_inductor/output_code.py", line 671, in __call__
    return self.current_callable(inputs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/tmpo48h6d3q/iy/ciyq4lywfjbu22unmm655tuip2at364ym54xknfy33wjrx7fciy7.py", line 181, in call
  File "/mnt/hyperdisk/pytorch/torch/_inductor/codegen/pallas.py", line 113, in run
    return self.kernel_fn(*args, stream=stream, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/tmpo48h6d3q/t4/ct4nlxmnbsc4tp2sjbqhnp53wrgodtuhrehlltegnpy7qfxcmumz.py", line 91, in pallas_fused_add_cat_mul_slice_sub_6cf0e1c4_main
  File "/mnt/hyperdisk/pytorch/.venv/lib/python3.12/site-packages/jax/_src/export/_export.py", line 645, in do_export
    lowered = traced.lower(
              ^^^^^^^^^^^^^
  File "/mnt/hyperdisk/pytorch/.venv/lib/python3.12/site-packages/jax/_src/stages.py", line 483, in lower
    lowering = _resolve_and_lower(
               ^^^^^^^^^^^^^^^^^^^
  File "/mnt/hyperdisk/pytorch/.venv/lib/python3.12/site-packages/jax/_src/pjit.py", line 1118, in _resolve_and_lower
    return _pjit_lower(
           ^^^^^^^^^^^^
  File "/mnt/hyperdisk/pytorch/.venv/lib/python3.12/site-packages/jax/_src/pjit.py", line 1298, in _pjit_lower
    return pxla.lower_sharding_computation(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/hyperdisk/pytorch/.venv/lib/python3.12/site-packages/jax/_src/profiler.py", line 359, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/hyperdisk/pytorch/.venv/lib/python3.12/site-packages/jax/_src/interpreters/pxla.py", line 2394, in lower_sharding_computation
    nreps, tuple_args, shape_poly_state) = _cached_lowering_to_hlo(
                                           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/hyperdisk/pytorch/.venv/lib/python3.12/site-packages/jax/_src/interpreters/pxla.py", line 1990, in _cached_lowering_to_hlo
    lowering_result = mlir.lower_jaxpr_to_module(
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/hyperdisk/pytorch/.venv/lib/python3.12/site-packages/jax/_src/interpreters/mlir.py", line 1312, in lower_jaxpr_to_module
    lower_jaxpr_to_fun(
  File "/mnt/hyperdisk/pytorch/.venv/lib/python3.12/site-packages/jax/_src/interpreters/mlir.py", line 1889, in lower_jaxpr_to_fun
    out_vals, tokens_out = jaxpr_subcomp(
                           ^^^^^^^^^^^^^^
  File "/mnt/hyperdisk/pytorch/.venv/lib/python3.12/site-packages/jax/_src/interpreters/mlir.py", line 2067, in jaxpr_subcomp
    out_nodes, tokens_out = _cached_lowering(
                            ^^^^^^^^^^^^^^^^^
  File "/mnt/hyperdisk/pytorch/.venv/lib/python3.12/site-packages/jax/_src/interpreters/mlir.py", line 2126, in _cached_lowering
    cache_entry = _emit_lowering_rule_as_fun(
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/hyperdisk/pytorch/.venv/lib/python3.12/site-packages/jax/_src/interpreters/mlir.py", line 2205, in _emit_lowering_rule_as_fun
    outs, inline = lowering_rule(sub_ctx, *unflattened_args, **params)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/hyperdisk/pytorch/.venv/lib/python3.12/site-packages/jax/_src/interpreters/mlir.py", line 2256, in _uncached_lowering
    ans = lower_per_platform(ctx, str(primitive), platform_rules, default_rule,
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/hyperdisk/pytorch/.venv/lib/python3.12/site-packages/jax/_src/interpreters/mlir.py", line 2374, in lower_per_platform
    output = kept_rules[0](ctx, *rule_args, **rule_kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/hyperdisk/pytorch/.venv/lib/python3.12/site-packages/jax/_src/pallas/pallas_call.py", line 1158, in _pallas_call_lowering
    return mlir.lower_per_platform(ctx, "pallas_call",
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/hyperdisk/pytorch/.venv/lib/python3.12/site-packages/jax/_src/interpreters/mlir.py", line 2374, in lower_per_platform
    output = kept_rules[0](ctx, *rule_args, **rule_kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/hyperdisk/pytorch/.venv/lib/python3.12/site-packages/jax/_src/pallas/pallas_call.py", line 1131, in tpu_lowering
    return mosaic_tpu_backend.pallas_call_tpu_lowering_rule(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/hyperdisk/pytorch/.venv/lib/python3.12/site-packages/jax/_src/pallas/mosaic/pallas_call_registration.py", line 159, in pallas_call_tpu_lowering_rule
    mosaic_module = lower_jaxpr_to_module(
                    ^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/hyperdisk/pytorch/.venv/lib/python3.12/site-packages/jax/_src/pallas/mosaic/lowering.py", line 778, in lower_jaxpr_to_module
    func_op = lower_jaxpr_to_func(
              ^^^^^^^^^^^^^^^^^^^^
  File "/mnt/hyperdisk/pytorch/.venv/lib/python3.12/site-packages/jax/_src/pallas/mosaic/lowering.py", line 1074, in lower_jaxpr_to_func
    body: Any = func.FuncOp.from_py_func(*arg_types, name=name)(body_func)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/hyperdisk/pytorch/.venv/lib/python3.12/site-packages/jaxlib/mlir/dialects/func.py", line 197, in decorator
    return_values = f(*func_args, **func_kwargs)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/hyperdisk/pytorch/.venv/lib/python3.12/site-packages/jax/_src/pallas/mosaic/lowering.py", line 1070, in body_func
    return jaxpr_subcomp(
           ^^^^^^^^^^^^^^
  File "/mnt/hyperdisk/pytorch/.venv/lib/python3.12/site-packages/jax/_src/pallas/mosaic/lowering.py", line 1206, in jaxpr_subcomp
    ans = lowering_rules[ctx.kernel_type][eqn.primitive](
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/hyperdisk/pytorch/.venv/lib/python3.12/site-packages/jax/_src/pallas/mosaic/lowering.py", line 2482, in _gather_lowering_rule
    raise NotImplementedError("Only 2D gather is supported")
NotImplementedError: Only 2D gather is supported
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo