### PR TITLE
[BE] Add error handling to get-changed-files workflow

### DIFF
--- a/.github/workflows/_get-changed-files.yml
+++ b/.github/workflows/_get-changed-files.yml
@@ -25,6 +25,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          set -e
           # Check if we're in a pull request context
           if [ "${{ github.event_name }}" = "pull_request" ] || [ "${{ github.event_name }}" = "pull_request_target" ]; then
             echo "Running in PR context"


### PR DESCRIPTION
Should prevent following unparseable errors: https://github.com/pytorch/pytorch/actions/runs/22588895835/job/65450200847?pr=174532

Where the actual error was rate limit exceeded error that were not correctly surfaced, see https://github.com/pytorch/pytorch/actions/runs/22588895835/job/65450200427?pr=174532 that returned
```
Changed files: { 	"message": "API rate limit exceeded for installation. If you reach out to GitHub Support for help, please include the request ID EBC0:26A07F:7DECB7:21BC454:69A5D036 and timestamp 2026-03-02 18:00:22 UTC. For more on scraping GitHub and how it may affect your rights, please review our Terms of Service (https:\/\/docs.github.com\/en\/site-policy\/github-terms\/github-terms-of-service)", 	"documentation_url": "https://docs.github.com/en/rest/using-the-rest-api/getting-started-with-the-rest-api#rate-limiting", 	"status": "403" }
```