### PR TITLE
fix: copy and then convert dtype for privateuseone backends cout

### DIFF
--- a/aten/src/ATen/core/Formatting.cpp
+++ b/aten/src/ATen/core/Formatting.cpp
@@ -303,6 +303,9 @@ std::ostream& print(
   } else if (tensor_.is_mps()) {
     // MPS does not support double tensors, so first copy then convert
     tensor = tensor_.to(kCPU).to(kDouble).contiguous();
+  } else if (tensor_.is_privateuseone()) {
+    // PrivateUseOne backends may not support double tensors
+    tensor = tensor_.to(kCPU).to(kDouble).contiguous();
   } else {
     tensor = tensor_.to(kCPU, kDouble).contiguous();
   }


### PR DESCRIPTION
PrivateUseOne backends may not support double like the case of metal, so strictly enforcing double conversion for output stream would not allow its usage. This PR tries to relax that constraint. 

cc @NmomoN @mengpenghui @fwenguang @cdzhan @1274085042 @PHLens @albanD