### PR TITLE
[autograd] Fix layer_norm higher-order gradients by recomputing mean/invstd

### DIFF
--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -4916,8 +4916,27 @@ std::tuple<Tensor, Tensor, Tensor> layer_norm_double_backward(
 
   auto input = input_t.reshape_symint({M, N});
   auto gO = gO_t.reshape_symint({M, N});
-  auto save_mean = save_mean_t.reshape_symint({M, c10::SymInt(1)});
-  auto save_invstd = save_invstd_t.reshape_symint({M, c10::SymInt(1)});
+  Tensor save_mean, save_invstd;
+  if (input.requires_grad()) {
+    // Recompute mean and invstd from input so that autograd can
+    // differentiate through them for higher-order (3rd+) gradients.
+    // The saved tensors have no autograd history connecting them to
+    // input, so using them directly makes autograd treat them as
+    // constants w.r.t. input.  The double backward formula gives
+    // correct second-order values but is not itself correctly
+    // differentiable without this.
+    save_mean = input.mean(1, true);
+    auto input_sub_mean = input - save_mean;
+    auto var = (input_sub_mean * input_sub_mean).mean(1, true);
+    // Recover eps from the saved invstd: invstd = 1/sqrt(var + eps)
+    // => eps = 1/invstd^2 - var.  Detach so eps is a constant.
+    auto eps = (save_invstd_t.reshape_symint({M, c10::SymInt(1)}).pow(-2) -
+                var.detach()).detach();
+    save_invstd = (var + eps).rsqrt();
+  } else {
+    save_mean = save_mean_t.reshape_symint({M, c10::SymInt(1)});
+    save_invstd = save_invstd_t.reshape_symint({M, c10::SymInt(1)});
+  }
 
   bool affine = isDefined(gamma);
   Tensor gamma_expanded;


### PR DESCRIPTION
## Summary

The saved mean and invstd tensors passed to `layer_norm_double_backward` have no autograd history connecting them to the input (they come from the forward kernel). The double backward formula analytically accounts for their dependency on input, so second-order gradients are correct. However, when autograd differentiates *through* the double backward for 3rd+ order derivatives, it cannot see this dependency and treats mean/invstd as constants, producing silently wrong results.

Fix: when `input.requires_grad()`, recompute mean and invstd from input using autograd-tracked ops. Epsilon is recovered from the saved invstd (`eps = 1/invstd² − var`) and detached.

## Test plan

```python
import torch
from torch import Tensor

def layer_norm_native(x: Tensor) -> Tensor:
    return torch.nn.functional.layer_norm(x, (x.shape[-1],))

def layer_norm_manual(x: Tensor) -> Tensor:
    mean = x.mean(-1, keepdim=True)
    centered = x - mean
    var = (centered * centered).mean(-1, keepdim=True)
    return centered * (var + 1e-5).rsqrt()

def nth_directional_derivative(f, x, v, n):
    x = x.detach().requires_grad_(True)
    y = f(x)
    if n == 0:
        return y.detach()
    for i in range(n):
        (g,) = torch.autograd.grad(y, x, create_graph=(i < n - 1))
        y = (g * v).sum()
    return y.detach()

torch.manual_seed(0)
x = torch.randn(1, 8, dtype=torch.float64)
v = torch.randn(1, 8, dtype=torch.float64)
w = torch.randn(1, 8, dtype=torch.float64)
f_native = lambda x: (layer_norm_native(x) * w).sum()
f_manual = lambda x: (layer_norm_manual(x) * w).sum()

for order in range(0, 7):
    d_native = nth_directional_derivative(f_native, x, v, order)
    d_manual = nth_directional_derivative(f_manual, x, v, order)
    match = torch.allclose(d_native, d_manual, atol=1e-10, rtol=1e-10)
    status = "PASS" if match else "FAIL"
    print(f"order {order}: native={d_native.item(): .10f}  manual={d_manual.item(): .10f}  [{status}]")
```

Before fix: orders 3+ FAIL. After fix: all orders PASS through at least order 6.