### PR TITLE
[DTensor] Fix kwargs tensor handling in single-dim strategy expansion

### DIFF
--- a/test/distributed/tensor/test_single_dim_strategy.py
+++ b/test/distributed/tensor/test_single_dim_strategy.py
@@ -1819,6 +1819,42 @@ class TestSingleDimStrategyRegistration(TestCase):
         # Verify the result is None (no tensor output)
         self.assertIsNone(result, "No-output op should return None")
 
+    @patch(
+        "torch.distributed.tensor._api.DTensor._op_dispatcher.sharding_propagator.op_single_dim_strategy_funcs",
+        {},
+    )
+    def test_single_dim_strategy_with_kwargs_tensor(self):
+        """Test that single-dim strategy works when kwargs contain tensor inputs.
+
+        Single-dim strategy functions produce placements only for positional
+        args.  kwargs tensor inputs (like out=) must not inflate num_inputs,
+        which would shift the output/input boundary and corrupt the strategy.
+        """
+        mesh = DeviceMesh("cpu", torch.arange(self.world_size))
+        x = torch.randn(8, 16)
+        x_dt = distribute_tensor(x, mesh, [Shard(0)])
+        out = torch.empty_like(x)
+        out_dt = distribute_tensor(out, mesh, [Shard(0)])
+
+        @register_single_dim_strategy(torch.ops.mylib.dummy_out.default)
+        def dummy_out_single_dim_strategy(op, args_schema, kwargs_schema):
+            return [[_ShardingPlaceholder(0), _ShardingPlaceholder(0)]]
+
+        result = torch.ops.mylib.dummy_out(x_dt, out=out_dt)
+        self.assertIsInstance(result, DTensor)
+        self.assertEqual(result.placements, (Shard(0),))
+
+
+@torch.library.custom_op("mylib::dummy_out", mutates_args=("out",))
+def dummy_out(x: torch.Tensor, *, out: torch.Tensor) -> torch.Tensor:
+    out.copy_(x)
+    return out
+
+
+@dummy_out.register_fake
+def _dummy_out_fake(x: torch.Tensor, *, out: torch.Tensor) -> torch.Tensor:
+    return out
+
 
 if __name__ == "__main__":
     run_tests()

--- a/torch/distributed/tensor/_ops/single_dim_strategy.py
+++ b/torch/distributed/tensor/_ops/single_dim_strategy.py
@@ -183,14 +183,14 @@ def _get_unique_placements(op_schema: OpSchema) -> set[Placement]:
 
 
 def _get_num_tensor_inputs(op_schema: OpSchema) -> int:
+    """Count positional tensor inputs only.
+
+    Single-dim strategy functions produce placements for positional args, not
+    kwargs tensors.  kwargs tensor inputs (e.g., ``out=``) are handled
+    separately by expand_to_full_mesh_op_strategy.
+    """
     num_inputs = 0
     for obj in op_schema.args_schema:
-        if isinstance(obj, OpStrategy):
-            num_inputs += 1
-        elif isinstance(obj, TupleStrategy):
-            num_inputs += len(obj.children)
-    # Also count tensor kwargs (e.g., "out" for out-variant ops)
-    for obj in op_schema.kwargs_schema.values():
         if isinstance(obj, OpStrategy):
             num_inputs += 1
         elif isinstance(obj, TupleStrategy):

--- a/torch/distributed/tensor/_ops/utils.py
+++ b/torch/distributed/tensor/_ops/utils.py
@@ -469,10 +469,16 @@ def expand_to_full_mesh_op_strategy(
         ]
 
         if len(input_specs) != len(input_args_strategy):
-            raise AssertionError(
-                f"input_specs({len(input_specs)}) != strategies({len(input_args_strategy)}: "
-                f"{len(args_strategy)} args + {len(kwargs_strategy)} kwargs)"
-            )
+            # Single-dim strategy functions produce placements only for
+            # positional args.  When kwargs tensor inputs exist (e.g. out=),
+            # fall back to args_strategy only for cost/shardability checks.
+            if len(input_specs) == len(args_strategy) and len(kwargs_strategy) > 0:
+                input_args_strategy = args_strategy
+            else:
+                raise AssertionError(
+                    f"input_specs({len(input_specs)}) != strategies({len(input_args_strategy)}: "
+                    f"{len(args_strategy)} args + {len(kwargs_strategy)} kwargs)"
+                )
         self_spec = input_args_strategy[0].strategies[0].output_spec
 
         if inplace_op and self_spec.placements != input_specs[0].placements:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #176221
* __->__ #176220
* #175999
* #169438

Single-dim strategy functions produce placements only for positional
args, not kwargs tensors.  _get_num_tensor_inputs was counting kwargs,
which inflated num_inputs and shifted the output/input boundary in the
strategy rows.

Fix _get_num_tensor_inputs to count positional args only, and update
expand_to_full_mesh_op_strategy to fall back to args_strategy when the
strategy list doesn't include kwargs entries.

Add a test using a custom out= variant op to verify the full expansion
path works when kwargs contain tensor inputs.

Authored with Claude.