### PR TITLE
Dispatch alias instead of detach in shallow_copy_and_detach when tracing

### DIFF
--- a/aten/src/ATen/FunctionalTensorWrapper.cpp
+++ b/aten/src/ATen/FunctionalTensorWrapper.cpp
@@ -432,7 +432,8 @@ c10::intrusive_ptr<TensorImpl> FunctionalTensorWrapper::shallow_copy_and_detach_
     bool allow_tensor_metadata_change) const {
   if (key_set_.has(DispatchKey::Python) &&
       !c10::impl::tls_is_dispatch_key_excluded(DispatchKey::Python)) {
-    auto r = pyobj_slot_.load_pyobj_interpreter()->detach(this);
+    auto r = pyobj_slot_.load_pyobj_interpreter()
+                 ->detach_or_alias_for_save(this);
     if (r) {
       r->set_version_counter(std::forward<VariableVersion>(version_counter));
       r->set_allow_tensor_metadata_change(allow_tensor_metadata_change);

--- a/aten/src/ATen/NestedTensorImpl.cpp
+++ b/aten/src/ATen/NestedTensorImpl.cpp
@@ -302,7 +302,8 @@ c10::intrusive_ptr<TensorImpl> NestedTensorImpl::shallow_copy_and_detach_core(
     bool allow_tensor_metadata_change) const {
   if (key_set_.has(DispatchKey::Python) &&
       !c10::impl::tls_is_dispatch_key_excluded(DispatchKey::Python)) {
-    auto r = pyobj_slot_.load_pyobj_interpreter()->detach(this);
+    auto r = pyobj_slot_.load_pyobj_interpreter()
+                 ->detach_or_alias_for_save(this);
     if (r) {
       r->set_version_counter(std::forward<VariableVersion>(version_counter));
       r->set_allow_tensor_metadata_change(allow_tensor_metadata_change);

--- a/aten/src/ATen/SparseCsrTensorImpl.h
+++ b/aten/src/ATen/SparseCsrTensorImpl.h
@@ -136,7 +136,7 @@ struct TORCH_API SparseCsrTensorImpl : public TensorImpl {
       impl->refresh_numel();
       return impl;
     }
-    auto r = interpreter->detach(this);
+    auto r = interpreter->detach_or_alias_for_save(this);
     r->set_version_counter(std::forward<VariableVersion>(version_counter));
     r->set_allow_tensor_metadata_change(allow_tensor_metadata_change);
     return r;

--- a/aten/src/ATen/SparseTensorImpl.h
+++ b/aten/src/ATen/SparseTensorImpl.h
@@ -335,7 +335,7 @@ struct TORCH_API SparseTensorImpl : public TensorImpl {
       impl->refresh_numel();
       return impl;
     }
-    auto r = interpreter->detach(this);
+    auto r = interpreter->detach_or_alias_for_save(this);
     r->set_version_counter(std::forward<VariableVersion>(version_counter));
     r->set_allow_tensor_metadata_change(allow_tensor_metadata_change);
     return r;

--- a/c10/core/TensorImpl.cpp
+++ b/c10/core/TensorImpl.cpp
@@ -502,11 +502,13 @@ c10::intrusive_ptr<TensorImpl> TensorImpl::shallow_copy_and_detach_core(
       !c10::impl::tls_is_dispatch_key_excluded(DispatchKey::Python)) {
     const auto& cur_torch_dispatch_mode_state =
         c10::impl::TorchDispatchModeTLS::get_stack_at(mode_stack_len - 1);
-    r = cur_torch_dispatch_mode_state->pyinterpreter()->detach(this);
+    r = cur_torch_dispatch_mode_state->pyinterpreter()
+            ->detach_or_alias_for_save(this);
   } else if (
       key_set_.has(DispatchKey::Python) &&
       !c10::impl::tls_is_dispatch_key_excluded(DispatchKey::Python)) {
-    r = (pyobj_slot_.load_pyobj_interpreter())->detach(this);
+    r = (pyobj_slot_.load_pyobj_interpreter())
+            ->detach_or_alias_for_save(this);
   }
   if (r) {
     if (!r->is_inference()) {

--- a/c10/core/impl/PyInterpreter.cpp
+++ b/c10/core/impl/PyInterpreter.cpp
@@ -31,6 +31,11 @@ struct NoopPyInterpreterVTable final : public PyInterpreterVTable {
     PANIC(detach);
   }
 
+  c10::intrusive_ptr<TensorImpl> detach_or_alias_for_save(
+      const TensorImpl* self) const override {
+    PANIC(detach_or_alias_for_save);
+  }
+
   void dispatch(const c10::OperatorHandle& op, torch::jit::Stack* stack)
       const override {
     PANIC(dispatch);

--- a/c10/core/impl/PyInterpreter.h
+++ b/c10/core/impl/PyInterpreter.h
@@ -142,6 +142,15 @@ struct C10_API PyInterpreterVTable {
   virtual c10::intrusive_ptr<TensorImpl> detach(
       const TensorImpl* self) const = 0;
 
+  // Like detach(), but dispatches aten.alias instead of aten.detach when
+  // building a traced graph (PROXY mode active). This avoids recording detach
+  // nodes that would block gradient flow when the graph is replayed for
+  // higher-order differentiation. Falls back to aten.detach when not tracing,
+  // to prevent reference cycles in autograd's save-for-backward.
+  // See https://github.com/pytorch/pytorch/issues/175477
+  virtual c10::intrusive_ptr<TensorImpl> detach_or_alias_for_save(
+      const TensorImpl* self) const = 0;
+
   // Invoke the Python boxed fallback dispatch to go back into Python
   virtual void dispatch(const c10::OperatorHandle& op, torch::jit::Stack* stack)
       const = 0;

--- a/test/test_proxy_tensor.py
+++ b/test/test_proxy_tensor.py
@@ -422,34 +422,36 @@ def forward(self, x_1):
 
     def test_make_fx_second_order_grad(self):
         # Regression test for https://github.com/pytorch/pytorch/issues/175477
-        # Autograd's save-for-backward internally detaches saved tensors.
-        # make_fx must decompose these detach ops to alias so they don't
-        # block gradient flow when the traced graph is replayed with
-        # create_graph=True for higher-order differentiation.
-        def fn(x, weight):
+        # Autograd's save-for-backward internally detaches saved tensors via
+        # shallow_copy_and_detach. PyInterpreterVTable::detach_or_alias_for_save
+        # dispatches aten.alias (not aten.detach) when tracing, so these
+        # internal operations don't block gradient flow when the traced graph
+        # is replayed with create_graph=True for higher-order differentiation.
+        def fn(x, w):
             x = x.detach().requires_grad_(True)
-            h = x @ weight.T
-            energy = (h / torch.sqrt((h ** 2).mean(-1, keepdim=True) + 1e-5)).pow(2).sum()
+            # sqrt saves its output for backward; this is the op whose
+            # internal detach previously blocked 2nd-order gradient flow.
+            energy = torch.sqrt(torch.abs(x * w)).sum()
             force = -torch.autograd.grad(energy, x, create_graph=True)[0]
             return energy, force
 
-        x = torch.randn(4, 3)
-        weight = torch.randn(8, 3, requires_grad=True)
+        x = torch.randn(4)
+        w = torch.randn(4, requires_grad=True)
 
         # Eager reference
-        weight.grad = None
-        e_eager, f_eager = fn(x, weight)
+        w.grad = None
+        e_eager, f_eager = fn(x, w)
         (e_eager + f_eager.sum()).backward()
-        grad_eager = weight.grad.clone()
+        grad_eager = w.grad.clone()
 
         # Traced
-        weight.grad = None
+        w.grad = None
         traced = make_fx(fn, tracing_mode=self.tracing_mode, _allow_non_fake_inputs=True)(
-            x.clone(), weight.clone().requires_grad_(True)
+            x.clone(), w.clone().requires_grad_(True)
         )
-        e_traced, f_traced = traced(x, weight)
+        e_traced, f_traced = traced(x, w)
         (e_traced + f_traced.sum()).backward()
-        grad_traced = weight.grad.clone()
+        grad_traced = w.grad.clone()
 
         self.assertEqual(grad_eager, grad_traced)
 

--- a/test/test_proxy_tensor.py
+++ b/test/test_proxy_tensor.py
@@ -420,6 +420,39 @@ def forward(self, x_1):
         for f in [f_grad, f_backward]:
             self._test(f, [torch.randn(3, requires_grad=True)])
 
+    def test_make_fx_second_order_grad(self):
+        # Regression test for https://github.com/pytorch/pytorch/issues/175477
+        # Autograd's save-for-backward internally detaches saved tensors.
+        # make_fx must decompose these detach ops to alias so they don't
+        # block gradient flow when the traced graph is replayed with
+        # create_graph=True for higher-order differentiation.
+        def fn(x, weight):
+            x = x.detach().requires_grad_(True)
+            h = x @ weight.T
+            energy = (h / torch.sqrt((h ** 2).mean(-1, keepdim=True) + 1e-5)).pow(2).sum()
+            force = -torch.autograd.grad(energy, x, create_graph=True)[0]
+            return energy, force
+
+        x = torch.randn(4, 3)
+        weight = torch.randn(8, 3, requires_grad=True)
+
+        # Eager reference
+        weight.grad = None
+        e_eager, f_eager = fn(x, weight)
+        (e_eager + f_eager.sum()).backward()
+        grad_eager = weight.grad.clone()
+
+        # Traced
+        weight.grad = None
+        traced = make_fx(fn, tracing_mode=self.tracing_mode, _allow_non_fake_inputs=True)(
+            x.clone(), weight.clone().requires_grad_(True)
+        )
+        e_traced, f_traced = traced(x, weight)
+        (e_traced + f_traced.sum()).backward()
+        grad_traced = weight.grad.clone()
+
+        self.assertEqual(grad_eager, grad_traced)
+
     def test_pickle_issue89626(self):
         import pickle
         x = torch.randn(2)

--- a/torch/csrc/PyInterpreter.cpp
+++ b/torch/csrc/PyInterpreter.cpp
@@ -1,5 +1,6 @@
 #include <ATen/core/PythonFallbackKernel.h>
 #include <ATen/core/PythonOpRegistrationTrampoline.h>
+#include <c10/core/impl/TorchDispatchModeTLS.h>
 #include <torch/csrc/PyInterpreter.h>
 #include <torch/csrc/THP.h>
 #include <torch/csrc/autograd/generated/VariableType.h>
@@ -52,6 +53,9 @@ struct ConcretePyInterpreterVTable final
   // TODO: Need to make this work for StorageImpl too. I imagine I'll want to
   // operate upon a PyObjectSlot rather than a TensorImpl
   c10::intrusive_ptr<c10::TensorImpl> detach(
+      const c10::TensorImpl* self) const override;
+
+  c10::intrusive_ptr<c10::TensorImpl> detach_or_alias_for_save(
       const c10::TensorImpl* self) const override;
 
   void dispatch(const c10::OperatorHandle& op, torch::jit::Stack* stack)
@@ -413,6 +417,48 @@ c10::intrusive_ptr<c10::TensorImpl> ConcretePyInterpreterVTable::detach(
   TORCH_CHECK(
       THPVariable_Check(out.ptr()),
       "detach returned invalid type ",
+      py::detail::get_fully_qualified_tp_name(Py_TYPE(out.ptr())),
+      ", expected Tensor");
+  const at::Tensor& res_t = THPVariable_Unpack(out.ptr());
+  return res_t.getIntrusivePtr();
+}
+
+c10::intrusive_ptr<c10::TensorImpl>
+ConcretePyInterpreterVTable::detach_or_alias_for_save(
+    const c10::TensorImpl* self) const {
+  // When tracing (PROXY mode active), dispatch aten.alias to preserve gradient
+  // flow in the traced graph. Otherwise dispatch aten.detach to prevent
+  // reference cycles in autograd's save-for-backward.
+  // See https://github.com/pytorch/pytorch/issues/175477
+  bool use_alias =
+      c10::impl::TorchDispatchModeTLS::get_mode(
+          c10::impl::TorchDispatchModeKey::PROXY)
+          .has_value();
+
+  pybind11::gil_scoped_acquire gil;
+  at::impl::MaybeSetTLSOnEntryGuard guard;
+
+  py::object op = use_alias
+      ? py::module::import("torch")
+            .attr("ops")
+            .attr("aten")
+            .attr("alias")
+            .attr("default")
+      : py::module::import("torch")
+            .attr("ops")
+            .attr("aten")
+            .attr("detach")
+            .attr("default");
+
+  auto out = torchDispatchFromTensorImpl(
+      self,
+      use_alias ? "alias" : "detach",
+      op.ptr(),
+      "torch.ops.aten");
+
+  TORCH_CHECK(
+      THPVariable_Check(out.ptr()),
+      "detach_or_alias_for_save returned invalid type ",
       py::detail::get_fully_qualified_tp_name(Py_TYPE(out.ptr())),
       ", expected Tensor");
   const at::Tensor& res_t = THPVariable_Unpack(out.ptr());

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -2428,14 +2428,6 @@ class _MakefxTracer:
         self.decomposition_table.setdefault(
             torch.ops.aten.sym_numel.default, torch._decomp.decompositions.sym_numel
         )
-        # Decompose detach -> alias so that autograd's internal detach
-        # operations (e.g. from save-for-backward) don't block gradient
-        # flow when the traced graph is re-executed with higher-order
-        # differentiation (create_graph=True).
-        self.decomposition_table.setdefault(
-            torch.ops.aten.detach.default,
-            torch._decomp.decompositions.nop_decomposition,
-        )
         self.tracing_mode: str = tracing_mode
         self._allow_non_fake_inputs: bool = _allow_non_fake_inputs
         self.pre_dispatch: bool = pre_dispatch

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -2428,6 +2428,14 @@ class _MakefxTracer:
         self.decomposition_table.setdefault(
             torch.ops.aten.sym_numel.default, torch._decomp.decompositions.sym_numel
         )
+        # Decompose detach -> alias so that autograd's internal detach
+        # operations (e.g. from save-for-backward) don't block gradient
+        # flow when the traced graph is re-executed with higher-order
+        # differentiation (create_graph=True).
+        self.decomposition_table.setdefault(
+            torch.ops.aten.detach.default,
+            torch._decomp.decompositions.nop_decomposition,
+        )
         self.tracing_mode: str = tracing_mode
         self._allow_non_fake_inputs: bool = _allow_non_fake_inputs
         self.pre_dispatch: bool = pre_dispatch

--- a/torch/nested/_internal/ops.py
+++ b/torch/nested/_internal/ops.py
@@ -754,6 +754,9 @@ def copy_default(func, *args, **kwargs):
 register_jagged_func(torch.ops.aten.detach.default, "self: jt_all")(
     jagged_unary_pointwise
 )
+register_jagged_func(torch.ops.aten.alias.default, "self: jt_all")(
+    jagged_unary_pointwise
+)
 
 
 @register_jagged_func(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #176224

When autograd saves a tensor for backward, SavedVariable calls
tensor_data() → shallow_copy_and_detach(), which dispatches
aten.detach.default through Python modes. During make_fx tracing,
ProxyTorchDispatchMode captures these as detach nodes in the graph.
When the traced graph is replayed with create_graph=True for
higher-order differentiation, these detach nodes block gradient flow,
producing incorrect results.

Add PyInterpreterVTable::detach_or_alias_for_save() which checks
whether PROXY mode is active (i.e., we're tracing). If so, it
dispatches aten.alias.default (preserves gradient flow). Otherwise it
dispatches aten.detach.default (prevents reference cycles in eager
mode). Replace all detach() calls in shallow_copy_and_detach_core
implementations with the new method.
Fixes https://github.com/pytorch/pytorch/issues/175477

Authored with Claude.