### PR TITLE
Set ROCM_SOURCE_DIR to ROCM_PATH unless specified

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1666,7 +1666,7 @@ if(USE_KINETO)
 
   if(NOT LIBKINETO_NOROCTRACER)
     if("$ENV{ROCM_SOURCE_DIR}" STREQUAL "")
-      set(ENV{ROCM_SOURCE_DIR} "/opt/rocm")
+      set(ENV{ROCM_SOURCE_DIR} "${ROCM_PATH}")
     endif()
   endif()
 


### PR DESCRIPTION
Fixes https://github.com/ROCm/pytorch/issues/2996.

Current implementation defaults to `/opt/rocm` if no `ROCM_SOURCE_DIR` is explicitly set. Updating to default to `ROCM_PATH` which will be increasingly important with TheRock venv based builds and the shift to `/opt/rocm/core` with ROCm apt installations.

ROCM_PATH should always be available via LoadHIP.cmake.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang