### PR TITLE
[autograd] Add mutex to PyNode::apply

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -8354,8 +8354,15 @@ for shape in [(1,), ()]:
             y.sum().backward()
 
     def test_custom_function_concurrent_backward(self):
+        # Test that the mutex on PyNode::apply serializes concurrent backward
+        # calls. time.sleep releases the GIL, so without the mutex another
+        # thread could enter backward on the same node concurrently.
         import threading
         import time
+
+        concurrent = 0
+        max_concurrent = 0
+        count_lock = threading.Lock()
 
         class SlowMul(Function):
             @staticmethod
@@ -8365,8 +8372,14 @@ for shape in [(1,), ()]:
 
             @staticmethod
             def backward(ctx, grad_output):
+                nonlocal concurrent, max_concurrent
                 a, b = ctx.saved_tensors
-                time.sleep(0.1)
+                with count_lock:
+                    concurrent += 1
+                    max_concurrent = max(max_concurrent, concurrent)
+                time.sleep(0.2)
+                with count_lock:
+                    concurrent -= 1
                 return grad_output * b, grad_output * a
 
         a = torch.randn(100, requires_grad=True)
@@ -8374,30 +8387,27 @@ for shape in [(1,), ()]:
         out = SlowMul.apply(a, b)
         loss = out.sum()
 
-        results = [None] * 10
-        errors = [None] * 10
+        barrier = threading.Barrier(4)
+        errors = []
 
-        def run_backward(idx):
+        def run_backward():
             try:
+                barrier.wait()
                 loss.backward(retain_graph=True)
-                results[idx] = a.grad.clone()
-                a.grad = None
             except Exception as e:
-                errors[idx] = e
+                errors.append(e)
 
-        threads = [threading.Thread(target=run_backward, args=(i,)) for i in range(10)]
+        threads = [threading.Thread(target=run_backward) for _ in range(4)]
         for t in threads:
             t.start()
         for t in threads:
             t.join()
 
-        for i, e in enumerate(errors):
-            self.assertIsNone(e, f"Thread {i} raised: {e}")
-
-        expected = b.detach()
-        for i, r in enumerate(results):
-            self.assertIsNotNone(r, f"Thread {i} got no result")
-            self.assertEqual(r, expected)
+        self.assertEqual(errors, [])
+        # The mutex serializes calls: at most one thread in backward at a time.
+        # Without the mutex, time.sleep releases the GIL, allowing other
+        # threads to enter backward concurrently (max_concurrent > 1).
+        self.assertEqual(max_concurrent, 1)
     def test_autograd_node_isinstance(self):
         # Node is a "virtual" base class of codegen'd nodes. This means that
         # isinstance and issubclass are overridden, but mro is unchanged

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -8353,6 +8353,51 @@ for shape in [(1,), ()]:
         with self.assertRaisesRegex(RuntimeError, "can only be accessed once"):
             y.sum().backward()
 
+    def test_custom_function_concurrent_backward(self):
+        import threading
+        import time
+
+        class SlowMul(Function):
+            @staticmethod
+            def forward(ctx, a, b):
+                ctx.save_for_backward(a, b)
+                return a * b
+
+            @staticmethod
+            def backward(ctx, grad_output):
+                a, b = ctx.saved_tensors
+                time.sleep(0.1)
+                return grad_output * b, grad_output * a
+
+        a = torch.randn(100, requires_grad=True)
+        b = torch.randn(100, requires_grad=True)
+        out = SlowMul.apply(a, b)
+        loss = out.sum()
+
+        results = [None] * 10
+        errors = [None] * 10
+
+        def run_backward(idx):
+            try:
+                loss.backward(retain_graph=True)
+                results[idx] = a.grad.clone()
+                a.grad = None
+            except Exception as e:
+                errors[idx] = e
+
+        threads = [threading.Thread(target=run_backward, args=(i,)) for i in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        for i, e in enumerate(errors):
+            self.assertIsNone(e, f"Thread {i} raised: {e}")
+
+        expected = b.detach()
+        for i, r in enumerate(results):
+            self.assertIsNotNone(r, f"Thread {i} got no result")
+            self.assertEqual(r, expected)
     def test_autograd_node_isinstance(self):
         # Node is a "virtual" base class of codegen'd nodes. This means that
         # isinstance and issubclass are overridden, but mro is unchanged

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -8408,6 +8408,7 @@ for shape in [(1,), ()]:
         # Without the mutex, time.sleep releases the GIL, allowing other
         # threads to enter backward concurrently (max_concurrent > 1).
         self.assertEqual(max_concurrent, 1)
+
     def test_autograd_node_isinstance(self):
         # Node is a "virtual" base class of codegen'd nodes. This means that
         # isinstance and issubclass are overridden, but mro is unchanged

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -329,16 +329,6 @@ auto PyNode::release_variables() -> void {
   // that the python interpreter is already dead here. In that case
   // we just leak the saved objects.
   if (Py_IsInitialized()) {
-    // Release GIL before acquiring mutex to maintain lock ordering
-    // (mutex then GIL) and avoid deadlock with apply() which acquires
-    // mutex then GIL. This function may be called with GIL held (e.g.,
-    // from Python destructor or THPFunction_maybe_clear_saved_tensors).
-    std::optional<pybind11::gil_scoped_release> no_gil;
-    if (PyGILState_Check()) {
-      no_gil.emplace();
-    }
-    // see Note [Thread Safety on Autograd Node]
-    std::lock_guard<std::mutex> lock(mutex_);
     pybind11::gil_scoped_acquire gil;
     auto f = (THPFunction*)obj;
     f->saved_variables.clear();

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -155,7 +155,12 @@ namespace torch::autograd {
 // NOLINTNEXTLINE(*-rvalue-reference*)
 auto PyNode::apply(variable_list&& inputs) -> variable_list {
   // see Note [Thread Safety on Autograd Node]
-  assert(!PyGILState_Check());
+  // Release GIL before acquiring mutex to maintain lock ordering
+  // (mutex then GIL). Compiled autograd may call this with GIL held.
+  std::optional<pybind11::gil_scoped_release> no_gil;
+  if (PyGILState_Check()) {
+    no_gil.emplace();
+  }
   std::lock_guard<std::mutex> lock(mutex_);
   pybind11::gil_scoped_acquire gil;
   at::OptionalDeviceGuard _device_guard;
@@ -209,7 +214,12 @@ auto PyNode::apply_with_saved_impl(
     const variable_list& inputs,
     const SwapSavedVariables& saved) -> variable_list {
   // see Note [Thread Safety on Autograd Node]
-  assert(!PyGILState_Check());
+  // Release GIL before acquiring mutex to maintain lock ordering
+  // (mutex then GIL). Compiled autograd may call this with GIL held.
+  std::optional<pybind11::gil_scoped_release> no_gil;
+  if (PyGILState_Check()) {
+    no_gil.emplace();
+  }
   std::lock_guard<std::mutex> lock(mutex_);
   pybind11::gil_scoped_acquire gil;
   at::OptionalDeviceGuard _device_guard;

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -155,8 +155,6 @@ namespace torch::autograd {
 // NOLINTNEXTLINE(*-rvalue-reference*)
 auto PyNode::apply(variable_list&& inputs) -> variable_list {
   // see Note [Thread Safety on Autograd Node]
-  // Release GIL before acquiring mutex to maintain lock ordering
-  // (mutex then GIL). Compiled autograd may call this with GIL held.
   std::optional<pybind11::gil_scoped_release> no_gil;
   if (PyGILState_Check()) {
     no_gil.emplace();
@@ -214,8 +212,6 @@ auto PyNode::apply_with_saved_impl(
     const variable_list& inputs,
     const SwapSavedVariables& saved) -> variable_list {
   // see Note [Thread Safety on Autograd Node]
-  // Release GIL before acquiring mutex to maintain lock ordering
-  // (mutex then GIL). Compiled autograd may call this with GIL held.
   std::optional<pybind11::gil_scoped_release> no_gil;
   if (PyGILState_Check()) {
     no_gil.emplace();

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -155,6 +155,7 @@ namespace torch::autograd {
 // NOLINTNEXTLINE(*-rvalue-reference*)
 auto PyNode::apply(variable_list&& inputs) -> variable_list {
   // see Note [Thread Safety on Autograd Node]
+  assert(!PyGILState_Check());
   std::lock_guard<std::mutex> lock(mutex_);
   pybind11::gil_scoped_acquire gil;
   at::OptionalDeviceGuard _device_guard;
@@ -208,6 +209,7 @@ auto PyNode::apply_with_saved_impl(
     const variable_list& inputs,
     const SwapSavedVariables& saved) -> variable_list {
   // see Note [Thread Safety on Autograd Node]
+  assert(!PyGILState_Check());
   std::lock_guard<std::mutex> lock(mutex_);
   pybind11::gil_scoped_acquire gil;
   at::OptionalDeviceGuard _device_guard;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* #176234
* #174079
* __->__ #176233

Add mutex protection to PyNode::apply, apply_with_saved_impl, following the same pattern as CppNode (see Note
[Thread Safety on Autograd Node]).

Does not add to release_variables because it is possible to call release_variables from within apply, resulting in a deadlock.

The lock ordering is mutex-then-GIL: apply() and apply_with_saved_impl()
acquire the mutex before the GIL since they are called from the engine
(without GIL). 

Co-authored-by: Claude <noreply@anthropic.com>