### PR TITLE
Support non-tensor attrs in __tensor_flatten__

### DIFF
--- a/test/test_opaque_obj_v2.py
+++ b/test/test_opaque_obj_v2.py
@@ -386,12 +386,13 @@ class TensorWithCounter(torch.Tensor):
         return f"TensorWithCounter({self.a}, {self.b}, {self._counter}, {self._size_store})"
 
     def __tensor_flatten__(self):
-        return ["a", "b"], (self._counter, self._size_store)
+        return ["a", "b", "_counter", "_size_store"], ()
 
     @staticmethod
     def __tensor_unflatten__(inner_tensors, ctx, outer_size, outer_stride):
         a, b = inner_tensors["a"], inner_tensors["b"]
-        counter, size_store = ctx
+        counter = inner_tensors["_counter"]
+        size_store = inner_tensors["_size_store"]
         return TensorWithCounter(a, b, counter, size_store, outer_size, outer_stride)
 
     @classmethod
@@ -838,6 +839,26 @@ class TestOpaqueObject(TestCase):
         @create_counter2_impl.register_fake
         def create_counter2_fake(start: int, end: int) -> tuple[Counter, Counter]:
             return Counter(start, end), Counter(end, start)
+
+        counter_type = get_opaque_type_name(Counter)
+        torch.library.define(
+            "_TestOpaqueObject::counter_start",
+            f"({counter_type} a) -> Tensor",
+            tags=torch.Tag.pt2_compliant_tag,
+            lib=self.lib,
+        )
+
+        @torch.library.impl(
+            "_TestOpaqueObject::counter_start",
+            "CompositeExplicitAutograd",
+            lib=self.lib,
+        )
+        def counter_start_impl(a: Counter) -> torch.Tensor:
+            return torch.scalar_tensor(a.start, dtype=torch.int64)
+
+        @torch.library.register_fake("_TestOpaqueObject::counter_start", lib=self.lib)
+        def counter_start_fake(a: Counter) -> torch.Tensor:
+            return torch.scalar_tensor(0, dtype=torch.int64)
 
         super().setUp()
 
@@ -1924,6 +1945,411 @@ class GraphModule(torch.nn.Module):
         # Recompile since SizeStore has changed
         self.assertEqual(cnt.frame_count, 3)
 
+    def test_tensor_subclass_with_opaque_attr_backward(self):
+        """Test opaque objects in tensor subclass are correctly remapped through backward."""
+
+        def fn(x):
+            return x * 2 + 1
+
+        a = torch.rand(4, 4, requires_grad=True)
+        b = torch.rand(4, 4, requires_grad=True)
+        counter = Counter(start=3, end=10)
+        size = SizeStore(4)
+        x = TensorWithCounter(a, b, counter, size)
+
+        cnt = CompileCounterWithBackend("aot_eager")
+        opt_fn = torch.compile(fn, backend=cnt, fullgraph=True)
+        out = opt_fn(x)
+
+        # Output should be TensorWithCounter with same opaque objects
+        self.assertTrue(isinstance(out, TensorWithCounter))
+        self.assertIs(out._counter, counter)
+        self.assertIs(out._size_store, size)
+
+        # Run backward
+        out.sum().backward()
+        self.assertIsNotNone(x.grad)
+        self.assertTrue(isinstance(x.grad, TensorWithCounter))
+
+        self.assertEqual(cnt.frame_count, 1)
+
+        # Call again with different instances that are __eq__ equal.
+        # Metadata guard uses ==, so equal values pass the guard.
+        # But they're different objects, so assertIs tests the fix.
+        a2 = torch.rand(4, 4, requires_grad=True)
+        b2 = torch.rand(4, 4, requires_grad=True)
+        counter2 = Counter(start=3, end=10)  # Same values, different instance
+        size2 = SizeStore(4)  # Same value, different instance
+        self.assertEqual(counter, counter2)  # Verify they're equal
+        self.assertIsNot(counter, counter2)  # But not the same object
+        x2 = TensorWithCounter(a2, b2, counter2, size2)
+
+        out2 = opt_fn(x2)
+        self.assertEqual(cnt.frame_count, 1)  # No recompilation
+
+        self.assertTrue(isinstance(out2, TensorWithCounter))
+        # Key checks: should use runtime instances, not traced instances
+        self.assertIs(out2._counter, counter2)
+        self.assertIs(out2._size_store, size2)
+
+        out2.sum().backward()
+        self.assertIsNotNone(x2.grad)
+        self.assertTrue(isinstance(x2.grad, TensorWithCounter))
+        self.assertIs(x2.grad._counter, counter2)
+        self.assertIs(x2.grad._size_store, size2)
+
+    def test_tensor_subclass_opaque_backward_compiled_autograd(self):
+        """Test opaque objects work with compiled autograd backward."""
+        import torch._dynamo.compiled_autograd
+
+        def fn(x):
+            return x * 2
+
+        a = torch.rand(4, 4, requires_grad=True)
+        b = torch.rand(4, 4, requires_grad=True)
+        counter = Counter(start=5, end=10)
+        size = SizeStore(4)
+        x = TensorWithCounter(a, b, counter, size)
+
+        opt_fn = torch.compile(fn, backend="aot_eager", fullgraph=True)
+        out = opt_fn(x)
+
+        self.assertTrue(isinstance(out, TensorWithCounter))
+        self.assertIs(out._counter, counter)
+        self.assertIs(out._size_store, size)
+
+        with torch._dynamo.compiled_autograd._enable(torch.compile(backend="eager")):
+            out.sum().backward()
+
+        self.assertIsNotNone(x.grad)
+        self.assertTrue(isinstance(x.grad, TensorWithCounter))
+
+        # Second invocation with different-but-equal opaques
+        a2 = torch.rand(4, 4, requires_grad=True)
+        b2 = torch.rand(4, 4, requires_grad=True)
+        counter2 = Counter(start=5, end=10)
+        size2 = SizeStore(4)
+        x2 = TensorWithCounter(a2, b2, counter2, size2)
+
+        out2 = opt_fn(x2)
+        self.assertTrue(isinstance(out2, TensorWithCounter))
+        self.assertIs(out2._counter, counter2)
+        self.assertIs(out2._size_store, size2)
+
+        with torch._dynamo.compiled_autograd._enable(torch.compile(backend="eager")):
+            out2.sum().backward()
+
+        self.assertIsNotNone(x2.grad)
+        self.assertTrue(isinstance(x2.grad, TensorWithCounter))
+        # TODO: compiled autograd doesn't yet remap backward opaques because
+        # the prologue/epilogue are dynamo-traced and opaques can't flow
+        # through the graph. Fix when compiled autograd supports non-tensor
+        # metadata.
+        self.assertIsNot(x2.grad._counter, counter2)
+        self.assertIsNot(x2.grad._size_store, size2)
+
+    def test_tensor_subclass_shared_opaque_remapping(self):
+        """Test that shared opaques across inputs are correctly handled."""
+
+        def fn(x, y):
+            return x + y
+
+        counter = Counter(start=3, end=10)  # Shared opaque
+        size = SizeStore(4)
+
+        a1 = torch.rand(4, 4, requires_grad=True)
+        b1 = torch.rand(4, 4, requires_grad=True)
+        x = TensorWithCounter(a1, b1, counter, size)
+
+        a2 = torch.rand(4, 4, requires_grad=True)
+        b2 = torch.rand(4, 4, requires_grad=True)
+        y = TensorWithCounter(a2, b2, counter, size)  # Same counter
+
+        opt_fn = torch.compile(fn, backend="aot_eager", fullgraph=True)
+        out = opt_fn(x, y)
+
+        self.assertTrue(isinstance(out, TensorWithCounter))
+        self.assertIs(out._counter, counter)
+
+        # Second invocation with different-but-equal shared opaques
+        counter2 = Counter(start=3, end=10)
+        size2 = SizeStore(4)
+
+        a3 = torch.rand(4, 4, requires_grad=True)
+        b3 = torch.rand(4, 4, requires_grad=True)
+        x2 = TensorWithCounter(a3, b3, counter2, size2)
+
+        a4 = torch.rand(4, 4, requires_grad=True)
+        b4 = torch.rand(4, 4, requires_grad=True)
+        y2 = TensorWithCounter(a4, b4, counter2, size2)
+
+        out2 = opt_fn(x2, y2)
+        self.assertTrue(isinstance(out2, TensorWithCounter))
+        self.assertIs(out2._counter, counter2)
+        self.assertIs(out2._size_store, size2)
+
+    def test_shared_opaque_identity_guard(self):
+        """When inputs share an opaque at trace time, breaking that sharing
+        should trigger recompilation.
+
+        Uses y + x so __torch_dispatch__ picks y's opaque (input 1), but
+        first-occurrence-wins remapping points to x's position (input 0).
+        With broken sharing, the output silently gets the wrong opaque.
+        """
+
+        def fn(x, y):
+            return y + x
+
+        counter = Counter(start=3, end=10)
+        size = SizeStore(4)
+
+        x = TensorWithCounter(torch.rand(4, 4), torch.rand(4, 4), counter, size)
+        y = TensorWithCounter(torch.rand(4, 4), torch.rand(4, 4), counter, size)
+
+        cnt = CompileCounterWithBackend("aot_eager")
+        opt_fn = torch.compile(fn, backend=cnt, fullgraph=True)
+        out = opt_fn(x, y)
+        self.assertEqual(cnt.frame_count, 1)
+        # Shared opaques: output should have the shared counter
+        self.assertIs(out._counter, counter)
+
+        # Same sharing pattern → no recompile
+        counter2 = Counter(start=3, end=10)
+        size2 = SizeStore(4)
+        x2 = TensorWithCounter(torch.rand(4, 4), torch.rand(4, 4), counter2, size2)
+        y2 = TensorWithCounter(torch.rand(4, 4), torch.rand(4, 4), counter2, size2)
+        out2 = opt_fn(x2, y2)
+        self.assertEqual(cnt.frame_count, 1)
+        self.assertIs(out2._counter, counter2)
+
+        # Sharing broken → should recompile.
+        # __torch_dispatch__ picks y's opaque, so the output should have
+        # counter3b. Without the guard, the remapping uses x's position
+        # and the output silently gets counter3a.
+        counter3a = Counter(start=3, end=10)
+        counter3b = Counter(start=3, end=10)
+        size3 = SizeStore(4)
+        x3 = TensorWithCounter(torch.rand(4, 4), torch.rand(4, 4), counter3a, size3)
+        y3 = TensorWithCounter(torch.rand(4, 4), torch.rand(4, 4), counter3b, size3)
+        out3 = opt_fn(x3, y3)
+        self.assertIs(out3._counter, counter3b)
+        self.assertEqual(cnt.frame_count, 2)
+
+    def test_shared_direct_opaque_identity_guard(self):
+        """When the same opaque is passed as multiple direct function
+        arguments, breaking the sharing should trigger recompilation.
+
+        Unlike test_shared_opaque_identity_guard where opaques are inside
+        tensor subclass metadata, here opaques are direct function arguments.
+        The tracer may conflate them when they're the same object, causing
+        counter_start(counter_b) to return counter_a's start instead.
+        """
+        get_start = torch.ops._TestOpaqueObject.counter_start
+
+        def fn(counter_a, counter_b, x):
+            return get_start(counter_a) + x, get_start(counter_b) + x
+
+        counter = Counter(start=3, end=10)
+        x = torch.rand(4, 4)
+
+        cnt = CompileCounterWithBackend("aot_eager")
+        opt_fn = torch.compile(fn, backend=cnt, fullgraph=True)
+        out_a, out_b = opt_fn(counter, counter, x)
+        self.assertEqual(cnt.frame_count, 1)
+        self.assertEqual(out_a, 3 + x)
+        self.assertEqual(out_b, 3 + x)
+
+        # Same sharing → no recompile
+        counter2 = Counter(start=3, end=10)
+        out_a2, out_b2 = opt_fn(counter2, counter2, x)
+        self.assertEqual(cnt.frame_count, 1)
+        self.assertEqual(out_a2, 3 + x)
+        self.assertEqual(out_b2, 3 + x)
+
+        # Broken sharing → should recompile.
+        # Both counters have start=3 so the existing guard_fn doesn't catch
+        # the difference — only an identity guard would.
+        counter3a = Counter(start=3, end=10)
+        counter3b = Counter(start=3, end=10)
+        out_a3, out_b3 = opt_fn(counter3a, counter3b, x)
+        self.assertEqual(cnt.frame_count, 2)
+        self.assertEqual(out_a3, 3 + x)
+        self.assertEqual(out_b3, 3 + x)
+
+    def test_tensor_subclass_shared_opaque_backward(self):
+        """Test backward with multiple subclass inputs sharing the same opaque.
+
+        This tests the case where grad_inputs share an opaque object.
+        The bug was that create_subclass_meta(grad_inputs) would incorrectly
+        build opaque_remappings between grad_inputs, causing an assertion
+        failure in wrap_tensor_subclasses.
+        """
+
+        def fn(x, y):
+            return x + y
+
+        # Create two TensorWithCounter inputs sharing the SAME opaque objects
+        counter = Counter(start=3, end=10)
+        size = SizeStore(4)
+
+        a1 = torch.rand(4, 4, requires_grad=True)
+        b1 = torch.rand(4, 4, requires_grad=True)
+        x = TensorWithCounter(a1, b1, counter, size)
+
+        a2 = torch.rand(4, 4, requires_grad=True)
+        b2 = torch.rand(4, 4, requires_grad=True)
+        y = TensorWithCounter(a2, b2, counter, size)  # Same counter and size
+
+        opt_fn = torch.compile(fn, backend="aot_eager", fullgraph=True)
+        out = opt_fn(x, y)
+
+        self.assertTrue(isinstance(out, TensorWithCounter))
+        self.assertIs(out._counter, counter)
+
+        out.sum().backward()
+        self.assertIsNotNone(x.grad)
+        self.assertIsNotNone(y.grad)
+
+        # Second invocation with different-but-equal shared opaques
+        counter2 = Counter(start=3, end=10)
+        size2 = SizeStore(4)
+
+        a3 = torch.rand(4, 4, requires_grad=True)
+        b3 = torch.rand(4, 4, requires_grad=True)
+        x2 = TensorWithCounter(a3, b3, counter2, size2)
+
+        a4 = torch.rand(4, 4, requires_grad=True)
+        b4 = torch.rand(4, 4, requires_grad=True)
+        y2 = TensorWithCounter(a4, b4, counter2, size2)
+
+        out2 = opt_fn(x2, y2)
+        self.assertTrue(isinstance(out2, TensorWithCounter))
+        self.assertIs(out2._counter, counter2)
+        self.assertIs(out2._size_store, size2)
+
+        out2.sum().backward()
+        self.assertIsNotNone(x2.grad)
+        self.assertIsNotNone(y2.grad)
+        self.assertTrue(isinstance(x2.grad, TensorWithCounter))
+        self.assertIs(x2.grad._counter, counter2)
+        self.assertIs(x2.grad._size_store, size2)
+
+    def test_deeply_nested_tensor_subclass_with_opaque(self):
+        """Test opaque objects in nested tensor subclasses are correctly remapped."""
+
+        # Outer subclass that wraps TensorWithCounter
+        class NestedSubclass(torch.Tensor):
+            @staticmethod
+            def __new__(cls, inner, scale):
+                # inner is a TensorWithCounter
+                kwargs = {
+                    "strides": inner.stride(),
+                    "storage_offset": inner.storage_offset(),
+                    "device": inner.device,
+                    "layout": inner.layout,
+                    "requires_grad": inner.requires_grad,
+                    "dtype": inner.dtype,
+                }
+                return torch.Tensor._make_wrapper_subclass(cls, inner.size(), **kwargs)
+
+            def __init__(self, inner, scale):
+                self._inner = inner
+                self._scale = scale
+
+            def __repr__(self):
+                return f"NestedSubclass({self._inner}, scale={self._scale})"
+
+            def __tensor_flatten__(self):
+                return ["_inner"], (self._scale,)
+
+            @staticmethod
+            def __tensor_unflatten__(inner_tensors, ctx, outer_size, outer_stride):
+                (scale,) = ctx
+                return NestedSubclass(inner_tensors["_inner"], scale)
+
+            @classmethod
+            def __torch_dispatch__(cls, func, types, args, kwargs):
+                if kwargs is None:
+                    kwargs = {}
+
+                def unwrap(x):
+                    return x._inner if isinstance(x, NestedSubclass) else x
+
+                def get_scale(x):
+                    if isinstance(x, NestedSubclass):
+                        return x._scale
+                    return None
+
+                scale = None
+                for arg in torch.utils._pytree.tree_leaves(args):
+                    scale = get_scale(arg)
+                    if scale is not None:
+                        break
+
+                unwrapped_args = torch.utils._pytree.tree_map(unwrap, args)
+                unwrapped_kwargs = torch.utils._pytree.tree_map(unwrap, kwargs)
+                out = func(*unwrapped_args, **unwrapped_kwargs)
+
+                def wrap(x):
+                    if isinstance(x, TensorWithCounter):
+                        return NestedSubclass(x, scale)
+                    return x
+
+                return torch.utils._pytree.tree_map(wrap, out)
+
+        def fn(x):
+            return x * 2 + 1
+
+        # Create nested structure: NestedSubclass -> TensorWithCounter -> tensors
+        a = torch.rand(4, 4, requires_grad=True)
+        b = torch.rand(4, 4, requires_grad=True)
+        counter = Counter(start=3, end=10)
+        size = SizeStore(4)
+        inner = TensorWithCounter(a, b, counter, size)
+        x = NestedSubclass(inner, scale=2.0)
+
+        cnt = CompileCounterWithBackend("aot_eager")
+        opt_fn = torch.compile(fn, backend=cnt, fullgraph=True)
+        out = opt_fn(x)
+
+        # Output should preserve nested structure with same opaque objects
+        self.assertTrue(isinstance(out, NestedSubclass))
+        self.assertTrue(isinstance(out._inner, TensorWithCounter))
+        self.assertIs(out._inner._counter, counter)
+        self.assertIs(out._inner._size_store, size)
+        self.assertEqual(out._scale, 2.0)
+
+        # Test backward
+        out.sum().backward()
+        self.assertIsNotNone(x.grad)
+        self.assertTrue(isinstance(x.grad, NestedSubclass))
+
+        self.assertEqual(cnt.frame_count, 1)
+
+        # Call again with different instances that are __eq__ equal.
+        a2 = torch.rand(4, 4, requires_grad=True)
+        b2 = torch.rand(4, 4, requires_grad=True)
+        counter2 = Counter(start=3, end=10)  # Same values, different instance
+        size2 = SizeStore(4)  # Same value, different instance
+        inner2 = TensorWithCounter(a2, b2, counter2, size2)
+        x2 = NestedSubclass(inner2, scale=2.0)
+
+        out2 = opt_fn(x2)
+        self.assertEqual(cnt.frame_count, 1)  # No recompilation
+
+        self.assertTrue(isinstance(out2, NestedSubclass))
+        # Key checks: should use runtime instances, not traced instances
+        self.assertIs(out2._inner._counter, counter2)
+        self.assertIs(out2._inner._size_store, size2)
+        self.assertEqual(out2._scale, 2.0)
+
+        out2.sum().backward()
+        self.assertIsNotNone(x2.grad)
+        self.assertTrue(isinstance(x2.grad, NestedSubclass))
+        self.assertTrue(isinstance(x2.grad._inner, TensorWithCounter))
+        self.assertIs(x2.grad._inner._counter, counter2)
+        self.assertIs(x2.grad._inner._size_store, size2)
+
     def test_opaque_obj_saved_for_backward(self):
         """Test that opaque objects are correctly saved and passed to backward."""
         import torch._dynamo.compiled_autograd
@@ -2412,6 +2838,107 @@ def forward(self, p_linear_weight, p_linear_bias, obj_lifted_custom_0, x):
     linear = torch.ops.aten.linear.default(x, p_linear_weight, p_linear_bias);  x = p_linear_weight = p_linear_bias = None
     return (linear,)""",  # noqa: B950
         )
+
+    def test_subclass_parametrization_with_opaque_attrs(self):
+        """unwrap_tensor_subclass_parameters should handle non-tensor attrs."""
+        from torch._functorch._aot_autograd.subclass_parametrization import (
+            unwrap_tensor_subclass_parameters,
+        )
+
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                a = torch.randn(3, 4)
+                b = torch.randn(3, 4)
+                self.p = torch.nn.Parameter(
+                    TensorWithCounter(a, b, Counter(1, 10), SizeStore(4))
+                )
+
+            def forward(self, x):
+                return x + self.p
+
+        m = M()
+        unwrap_tensor_subclass_parameters(m)
+        x = torch.randn(3, 4)
+        m(x)
+
+    def test_export_non_strict_with_opaque_attrs(self):
+        """torch.export with strict=False should handle subclasses with non-tensor attrs."""
+
+        class M(torch.nn.Module):
+            def forward(self, x):
+                return x * 2
+
+        a = torch.randn(4, 4)
+        b = torch.randn(4, 4)
+        x = TensorWithCounter(a, b, Counter(1, 10), SizeStore(4))
+        torch.export.export(M(), (x,), strict=False)
+
+    def test_get_untyped_storages_with_opaque_attrs(self):
+        """get_untyped_storages should skip non-tensor attrs without warning."""
+        from torch.distributed._tools.common_utils import get_untyped_storages
+
+        a = torch.randn(4, 4)
+        b = torch.randn(4, 4)
+        x = TensorWithCounter(a, b, Counter(1, 10), SizeStore(4))
+        import warnings
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            storages = get_untyped_storages(x)
+        # Should get storages from the two inner tensors (a and b)
+        self.assertTrue(len(storages) > 0)
+
+    @functorch_config.patch({"enable_autograd_cache": True})
+    @inductor_config.patch(
+        {
+            "fx_graph_cache": True,
+            "fx_graph_remote_cache": False,
+        }
+    )
+    def test_subclass_opaque_attrs_cache_hit(self):
+        """opaque_attrs in SubclassCreationMeta should survive AOTAutograd cache round-trip."""
+        torch._dynamo.reset()
+        AOTAutogradCache.clear()
+        torch._inductor.codecache.FxGraphCache.clear()
+        counters.clear()
+
+        @torch.compile(fullgraph=True)
+        def fn(x):
+            return x * 2
+
+        a = torch.randn(4, 4)
+        b = torch.randn(4, 4)
+        counter = Counter(start=3, end=10)
+        size = SizeStore(4)
+        x = TensorWithCounter(a, b, counter, size)
+
+        out = fn(x)
+        self.assertIsInstance(out, TensorWithCounter)
+        self.assertIs(out._counter, counter)
+        self.assertIs(out._size_store, size)
+        self.assertEqual(counters["aot_autograd"]["autograd_cache_miss"], 1)
+        self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 0)
+
+        # Reset dynamo to force a fresh compilation that should hit the cache
+        torch._dynamo.reset()
+
+        @torch.compile(fullgraph=True)
+        def fn2(x):
+            return x * 2
+
+        a2 = torch.randn(4, 4)
+        b2 = torch.randn(4, 4)
+        counter2 = Counter(start=3, end=10)
+        size2 = SizeStore(4)
+        x2 = TensorWithCounter(a2, b2, counter2, size2)
+
+        out2 = fn2(x2)
+        self.assertIsInstance(out2, TensorWithCounter)
+        # Runtime opaque values should be used, not the serialized ones
+        self.assertIs(out2._counter, counter2)
+        self.assertIs(out2._size_store, size2)
+        self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 1)
 
 
 instantiate_parametrized_tests(TestOpaqueObject)

--- a/tools/stats/monitor.py
+++ b/tools/stats/monitor.py
@@ -459,6 +459,7 @@ class UsageLogger:
                 self._gpu_lib_detected = "amdsmi"
                 self._gpu_handles = amdsmi.amdsmi_get_processor_handles()
 
+            # pyrefly: ignore[bad-assignment]
             self._num_of_cpus = psutil.cpu_count(logical=True)
             # update summary info
             self._metadata.gpu_count = len(self._gpu_handles)

--- a/torch/_dynamo/decorators.py
+++ b/torch/_dynamo/decorators.py
@@ -1032,7 +1032,7 @@ def _apply_func_to_inner_tensors_of_same_dim(
     assert isinstance(t, torch.Tensor)
     for attr in attrs:
         inner = getattr(t, attr)
-        if inner.dim() == t.dim():
+        if isinstance(inner, torch.Tensor) and inner.dim() == t.dim():
             func(inner, *args, **kwargs)
 
 

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -3687,10 +3687,12 @@ def _automatic_dynamic(
         inner_contexts = {}  # mapping from attr -> symbolic context
         attrs, _ = type(e).__tensor_flatten__(e)
         for attr in attrs:
-            inner_tensor = getattr(e, attr)
+            inner_value = getattr(e, attr)
+            if not isinstance(inner_value, torch.Tensor):
+                continue
             inner_source = AttrSource(source, attr)
             inner_contexts[attr] = _automatic_dynamic(
-                inner_tensor, tx, inner_source, static_shapes
+                inner_value, tx, inner_source, static_shapes
             )
 
         return SubclassSymbolicContext(

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -330,9 +330,7 @@ class TensorVariable(VariableTracker):
             attrs, _ctx = fake_val.__tensor_flatten__()
             proxy = getattr(self.as_proxy(), name)
             example_value = getattr(fake_val, name)
-            if name in attrs:
-                # attrs returned from tensor_flatten are always tensors
-                assert isinstance(example_value, torch.Tensor)
+            if name in attrs and isinstance(example_value, torch.Tensor):
                 from .builder import wrap_fx_proxy
 
                 return wrap_fx_proxy(tx=tx, proxy=proxy, example_value=example_value)

--- a/torch/_export/non_strict_utils.py
+++ b/torch/_export/non_strict_utils.py
@@ -257,10 +257,12 @@ def _create_symbolic_context_for_tensor(t, source, t_constraints, sources, mode)
 
         # Propagate outer tensor constraints to inner tensors if not already present
         for attr in attrs:
-            inner_tensor = getattr(t, attr)
+            inner_value = getattr(t, attr)
+            if not isinstance(inner_value, torch.Tensor):
+                continue
             inner_source = AttrSource(source, attr)
             inner_contexts[attr] = _create_symbolic_context_for_tensor(
-                inner_tensor, inner_source, t_constraints, sources, mode
+                inner_value, inner_source, t_constraints, sources, mode
             )
 
         symbolic_context = SubclassSymbolicContext(

--- a/torch/_functorch/_aot_autograd/collect_metadata_analysis.py
+++ b/torch/_functorch/_aot_autograd/collect_metadata_analysis.py
@@ -58,7 +58,7 @@ from .schemas import (
     OutputType,
     ViewAndMutationMeta,
 )
-from .subclass_utils import create_subclass_meta
+from .subclass_utils import build_opaque_input_map, create_subclass_meta
 from .utils import _get_autocast_states, KNOWN_TYPES, simple_wraps, strict_zip
 
 
@@ -870,6 +870,8 @@ from a multi-output view call"
                 grad_enabled_mutation,
             )
 
+        opaque_input_map = build_opaque_input_map(flat_args)
+
         metadata = ViewAndMutationMeta(
             input_info=input_info,
             output_info=output_info,
@@ -878,7 +880,10 @@ from a multi-output view call"
             traced_tangents=traced_tangents,
             traced_tangents_descs=traced_tangents_descs,
             subclass_inp_meta=create_subclass_meta(flat_args),
-            subclass_fw_graph_out_meta=create_subclass_meta(fw_graph_outs),
+            subclass_fw_graph_out_meta=create_subclass_meta(
+                fw_graph_outs,
+                opaque_input_map=opaque_input_map if opaque_input_map else None,
+            ),
             subclass_tangent_meta=create_subclass_meta(
                 traced_tangents, count_symints=False, with_memory_format=True
             ),

--- a/torch/_functorch/_aot_autograd/frontend_utils.py
+++ b/torch/_functorch/_aot_autograd/frontend_utils.py
@@ -66,8 +66,15 @@ def process_inputs(
                 return x
             if is_traceable_wrapper_subclass(x):
                 attrs, _ = x.__tensor_flatten__()
-                if all(isinstance(getattr(x, attr), FakeTensor) for attr in attrs):
-                    if all(getattr(x, attr).fake_mode is fake_mode for attr in attrs):
+                tensor_attrs = [
+                    attr for attr in attrs if isinstance(getattr(x, attr), torch.Tensor)
+                ]
+                if tensor_attrs and all(
+                    isinstance(getattr(x, attr), FakeTensor) for attr in tensor_attrs
+                ):
+                    if all(
+                        getattr(x, attr).fake_mode is fake_mode for attr in tensor_attrs
+                    ):
                         return x
                     # FakeTensor subclass from a different mode.
                     # Fall through to refakify.

--- a/torch/_functorch/_aot_autograd/functional_utils.py
+++ b/torch/_functorch/_aot_autograd/functional_utils.py
@@ -49,7 +49,9 @@ def sync_functional_tensor(t: torch.Tensor) -> None:
     if is_traceable_wrapper_subclass(t):
         attrs, _ctx = t.__tensor_flatten__()  # type: ignore[attr-defined]
         for attr in attrs:
-            sync_functional_tensor(getattr(t, attr))
+            inner = getattr(t, attr)
+            if isinstance(inner, torch.Tensor):
+                sync_functional_tensor(inner)
     else:
         torch._sync(t)
 
@@ -83,7 +85,7 @@ def is_fun(t: object) -> TypeGuard[FunctionalTensor | Tensor]:
         # goes at the bottom.
         # recurse here, so we can support nested wrapper subclasses
         t_attrs, _ = t.__tensor_flatten__()  # type: ignore[attr-defined]
-        t_inners = [getattr(t, attr) for attr in t_attrs]
+        t_inners = [v for attr in t_attrs if isinstance(v := getattr(t, attr), Tensor)]
         any_fun = any(is_fun(x) for x in t_inners)
         all_fun = all(is_fun(x) for x in t_inners)
         if any_fun != all_fun:
@@ -103,7 +105,11 @@ def has_data_mutation(t: object) -> bool:
     if is_traceable_wrapper_subclass(t):
         attrs, _ = t.__tensor_flatten__()
         # A tensor subclass was updated if any of its inner elements were updated
-        return any(has_data_mutation(getattr(t, attr)) for attr in attrs)
+        return any(
+            has_data_mutation(v)
+            for attr in attrs
+            if isinstance(v := getattr(t, attr), torch.Tensor)
+        )
     else:
         if isinstance(t, torch.Tensor):
             if not isinstance(t, FunctionalTensor):
@@ -117,7 +123,9 @@ def are_all_mutations_hidden_from_autograd(t: object) -> bool:
         attrs, _ = t.__tensor_flatten__()
         # If all inner elements are mutations hidden from autograd, then it is a mutation hidden from autograd.
         return all(
-            are_all_mutations_hidden_from_autograd(getattr(t, attr)) for attr in attrs
+            are_all_mutations_hidden_from_autograd(v)
+            for attr in attrs
+            if isinstance(v := getattr(t, attr), torch.Tensor)
         )
     elif isinstance(t, torch.Tensor):
         if not isinstance(t, FunctionalTensor):
@@ -131,8 +139,9 @@ def are_all_mutations_under_no_grad_or_inference_mode(t: torch.Tensor) -> bool:
     if is_traceable_wrapper_subclass(t):
         attrs, _ = t.__tensor_flatten__()
         return all(
-            are_all_mutations_under_no_grad_or_inference_mode(getattr(t, attr))
+            are_all_mutations_under_no_grad_or_inference_mode(v)
             for attr in attrs
+            if isinstance(v := getattr(t, attr), torch.Tensor)
         )
     else:
         if not isinstance(t, FunctionalTensor):
@@ -145,7 +154,11 @@ def are_all_mutations_under_no_grad_or_inference_mode(t: torch.Tensor) -> bool:
 def was_inductor_storage_resized(t: object) -> bool:
     if is_traceable_wrapper_subclass(t):
         attrs, _ = t.__tensor_flatten__()
-        if any(was_inductor_storage_resized(getattr(t, attr)) for attr in attrs):
+        if any(
+            was_inductor_storage_resized(v)
+            for attr in attrs
+            if isinstance(v := getattr(t, attr), torch.Tensor)
+        ):
             raise RuntimeError(
                 f"storage resizing is not supported on tensor subclass: {type(t)}"
             )
@@ -172,8 +185,11 @@ def has_metadata_mutation(
     if is_traceable_wrapper_subclass(f_arg):
         attrs, _ = f_arg.__tensor_flatten__()
         # A tensor subclass was updated if any of its inner elements were updated
-        f_inner_ts = [getattr(f_arg, attr) for attr in attrs]
-        inner_ts = [getattr(arg, attr) for attr in attrs]
+        tensor_attrs = [
+            attr for attr in attrs if isinstance(getattr(f_arg, attr), torch.Tensor)
+        ]
+        f_inner_ts = [getattr(f_arg, attr) for attr in tensor_attrs]
+        inner_ts = [getattr(arg, attr) for attr in tensor_attrs]
         return any(
             has_metadata_mutation(
                 f_inner_t,
@@ -441,8 +457,9 @@ def was_tensor_updated(arg: torch.Tensor, new_arg: torch.Tensor) -> bool:
             raise AssertionError(f"attrs mismatch: {attrs} != {new_attrs}")
         # A tensor subclass was updated if any of its inner elements were updated
         return any(
-            was_tensor_updated(getattr(arg, attr), getattr(new_arg, attr))
+            was_tensor_updated(v, getattr(new_arg, attr))
             for attr in attrs
+            if isinstance(v := getattr(arg, attr), torch.Tensor)
         )
     else:
         return arg is not new_arg
@@ -467,8 +484,9 @@ def was_tensor_metadata_updated(arg: Any, new_arg: Any) -> bool:
             raise AssertionError(f"attrs mismatch: {attrs} != {new_attrs}")
         # A tensor subclass was updated if any of its inner elements were updated
         return any(
-            was_tensor_metadata_updated(getattr(arg, attr), getattr(new_arg, attr))
+            was_tensor_metadata_updated(v, getattr(new_arg, attr))
             for attr in attrs
+            if isinstance(v := getattr(arg, attr), torch.Tensor)
         )
     else:
         return arg is not new_arg and StorageWeakRef(

--- a/torch/_functorch/_aot_autograd/graph_capture_wrappers.py
+++ b/torch/_functorch/_aot_autograd/graph_capture_wrappers.py
@@ -84,6 +84,7 @@ from .schemas import (
     ViewAndMutationMeta,
 )
 from .subclass_utils import (
+    build_opaque_input_map,
     create_subclass_meta,
     remap_unwrapped_subclass_arg_indices,
     requires_subclass_dispatch,
@@ -671,7 +672,9 @@ def sc_visit(
             return
 
         for a in e.__tensor_flatten__()[0]:
-            visit(getattr(e, a))
+            inner = getattr(e, a)
+            if isinstance(inner, torch.Tensor):
+                visit(inner)
 
     visit(t)
     return accum
@@ -1333,7 +1336,17 @@ def aot_dispatch_subclass(
                 )
             # Don't need fw outs since we already have subclass metadata on them
             grad_inputs = wrapped_outs[1]
-            subclass_meta.grad_input_metas = create_subclass_meta(grad_inputs)
+            # Build opaque_input_map from primals so grad_input_metas can
+            # remap opaques at runtime (same as forward output path).
+            # all_args is (wrapped_primals, wrapped_tangents) for the joint.
+            primals_for_map = all_args[0] if isinstance(all_args, tuple) else all_args
+            grad_opaque_input_map = build_opaque_input_map(primals_for_map)
+            subclass_meta.grad_input_metas = create_subclass_meta(
+                grad_inputs,
+                opaque_input_map=grad_opaque_input_map
+                if grad_opaque_input_map
+                else None,
+            )
 
             # Add extra symints as outputs to the forward/backward graphs
             # ignore nested ints here

--- a/torch/_functorch/_aot_autograd/runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/runtime_wrappers.py
@@ -952,6 +952,60 @@ class AOTDispatchSubclassWrapper(CompilerWrapper):
                 _log_input_metadata(runtime_metadata)
                 _log_args_list(args, "Incoming args")
 
+            # Note: [Opaque attr runtime remapping]
+            #
+            # When a subclass output (forward) or grad_input (backward)
+            # contains opaque (non-tensor) attrs that originated from a graph
+            # input, we need the *runtime* value — not the one baked in at
+            # compile time — so that cache reuse picks up the caller's
+            # current opaque objects (e.g. a different DeviceMesh).
+            #
+            # The chain works as follows:
+            #
+            # 1. Here (AOTDispatchSubclassWrapper): collect the subset of
+            #    original args referenced by opaque_attr_input_indices in any
+            #    SubclassCreationMeta.  Store them in `original_args`.
+            #
+            # 2. For forward outputs: pass original_args directly to
+            #    wrap_tensor_subclasses → SubclassCreationMeta.creation_fn,
+            #    which looks up the runtime value via opaque_attr_input_indices.
+            #
+            # 3. For backward grad_inputs: stash original_args on
+            #    SubclassMeta._pending_original_args, which
+            #    CompiledFunction.forward picks up into
+            #    ctx._original_subclass_args.  CompiledFunction.backward then
+            #    passes it to _backward_epilogue_functional →
+            #    wrap_tensor_subclasses → SubclassCreationMeta.creation_fn.
+            original_args: dict[int, Any] | None = None
+            opaque_indices: set[int] = set()
+
+            def _collect_opaque_indices(m: Any) -> None:
+                if not isinstance(m, SubclassCreationMeta):
+                    return
+                if m.opaque_attr_input_indices:
+                    for v in m.opaque_attr_input_indices.values():
+                        if isinstance(v, tuple):
+                            opaque_indices.add(v[0])
+                        else:
+                            opaque_indices.add(v)
+                for inner_m in m.attrs.values():
+                    _collect_opaque_indices(inner_m)
+
+            for m in subclass_metas:
+                _collect_opaque_indices(m)
+            # Also collect from grad_input_metas so backward can remap
+            # opaques in gradient subclasses.
+            grad_input_metas = (
+                self.maybe_subclass_meta.grad_input_metas
+                if self.maybe_subclass_meta is not None
+                else None
+            )
+            if grad_input_metas:
+                for m in grad_input_metas:
+                    _collect_opaque_indices(m)
+            if opaque_indices:
+                original_args = {i: args[i] for i in opaque_indices}
+
             unwrapped_args = runtime_unwrap_tensor_subclasses(
                 args,
                 subclass_metas=runtime_metadata.subclass_inp_meta,
@@ -962,6 +1016,10 @@ class AOTDispatchSubclassWrapper(CompilerWrapper):
                 _log_args_list(unwrapped_args, "After unwrapping, unwrapped_args")
 
             args.clear()
+            # Stash original_args on SubclassMeta so CompiledFunction.forward
+            # can save them on ctx for backward opaque remapping.
+            if self.maybe_subclass_meta is not None and original_args is not None:
+                self.maybe_subclass_meta._pending_original_args = original_args
             # expectation: runtime_fn is a boxed fn
             unwrapped_outs = compiled_fn(unwrapped_args)
 
@@ -976,6 +1034,7 @@ class AOTDispatchSubclassWrapper(CompilerWrapper):
                 num_fw_outs_saved_for_bw=self.num_fw_outs_saved_for_bw,
                 is_runtime=True,
                 included_subclass_symints=True,
+                original_args=original_args,
             )
 
             if aot_graphs_log.isEnabledFor(logging.DEBUG):
@@ -2193,6 +2252,7 @@ def _backward_epilogue_functional(
     out: Any,
     *,
     make_subclass_override: Callable[..., Any] | None = None,
+    original_args: dict[int, Any] | None = None,
 ) -> tuple[Any, ...]:
     # Toss out the backward output tokens
     num_bw_tokens = metadata.num_backward_tokens
@@ -2215,6 +2275,7 @@ def _backward_epilogue_functional(
             included_subclass_symints=True,
             is_runtime=True,
             make_subclass_override=make_subclass_override,
+            original_args=original_args,
         )
         return outs_wrapped
     return out
@@ -2477,10 +2538,11 @@ Your tensor subclass must implement __coerce_same_metadata_as_tangent__."""
         if orig_x is not x:
             runtime_subclass_keys = x.__tensor_flatten__()[0]
 
-        if len(meta.attrs) != len(runtime_subclass_keys):
+        num_opaque = len(meta.opaque_attrs) if meta.opaque_attrs else 0
+        if len(meta.attrs) + num_opaque != len(runtime_subclass_keys):
             raise AssertionError(
-                f"expected len(meta.attrs) == len(runtime_subclass_keys), "
-                f"got {len(meta.attrs)} != {len(runtime_subclass_keys)}"
+                f"expected len(meta.attrs) + opaque == len(runtime_subclass_keys), "
+                f"got {len(meta.attrs)} + {num_opaque} != {len(runtime_subclass_keys)}"
             )
         leaves = []
         for attr, attr_meta in meta.attrs.items():
@@ -2691,6 +2753,20 @@ Your tensor subclass must implement __coerce_same_metadata_as_tangent__."""
                     )
                 ctx.opaque_objects = opaque_object_outs
 
+                # Pick up original subclass args stashed by
+                # AOTDispatchSubclassWrapper for backward opaque remapping.
+                if (
+                    CompiledFunction.maybe_subclass_metadata is not None
+                    and CompiledFunction.maybe_subclass_metadata._pending_original_args
+                    is not None
+                ):
+                    ctx._original_subclass_args = (
+                        CompiledFunction.maybe_subclass_metadata._pending_original_args
+                    )
+                    CompiledFunction.maybe_subclass_metadata._pending_original_args = (
+                        None
+                    )
+
                 raw_returns = fw_outs[0:num_forward_returns]
 
                 # Wrap all autograd.Function.forward() outputs that are aliases
@@ -2837,6 +2913,7 @@ Your tensor subclass must implement __coerce_same_metadata_as_tangent__."""
                         CompiledFunction.metadata,
                         CompiledFunction.maybe_subclass_metadata,
                         out,
+                        original_args=getattr(ctx, "_original_subclass_args", None),
                     )
 
                 needs_grad = torch.is_grad_enabled() and any(

--- a/torch/_functorch/_aot_autograd/schemas.py
+++ b/torch/_functorch/_aot_autograd/schemas.py
@@ -261,6 +261,19 @@ class SubclassCreationMeta:
     # Used at runtime to determine the subclass type, so we don't need to save the original subclass
     original_subclass_type: type | None = None
     memory_format: MemoryFormatMeta | None = None
+    # Non-tensor values from __tensor_flatten__, passed through to __tensor_unflatten__
+    opaque_attrs: dict[str, Any] | None = None
+    # Maps opaque attr name to its location in the original (pre-unwrap) args.
+    # For top-level opaque args: int (index into args).
+    # For opaques nested inside input subclasses: tuple[int, tuple[str, ...]]
+    #   where the int is the arg index and the tuple of strings is the attr
+    #   path to traverse (e.g. (0, ("_inner", "_counter"))).
+    # When set, the runtime value is used instead of the baked-in value in
+    # opaque_attrs, so that reuse of a cached compilation picks up the new
+    # runtime opaque (e.g. a different DeviceMesh).
+    opaque_attr_input_indices: dict[str, int | tuple[int, tuple[str, ...]]] | None = (
+        None
+    )
 
     def compute_outer_size_and_stride(
         self,
@@ -299,6 +312,7 @@ class SubclassCreationMeta:
         all_args: Sequence[torch.Tensor | IntLikeType],
         *,
         is_runtime: bool,
+        original_args: dict[int, Any] | None = None,
     ) -> torch.Tensor:
         inner_tensors = {}
 
@@ -311,9 +325,34 @@ class SubclassCreationMeta:
                 subclass = creation_meta.creation_fn(
                     all_args,
                     is_runtime=is_runtime,
+                    original_args=original_args,
                 )
                 curr_start_idx += creation_meta.arg_count
             inner_tensors[attr] = subclass
+
+        if self.opaque_attrs:
+            if (
+                is_runtime
+                and self.opaque_attr_input_indices
+                and original_args is not None
+            ):
+                for attr, value in self.opaque_attrs.items():
+                    loc = self.opaque_attr_input_indices.get(attr)
+                    if loc is not None:
+                        if isinstance(loc, tuple):
+                            # Opaque nested inside an input subclass;
+                            # traverse the attr path to reach it.
+                            arg_idx, attr_path = loc
+                            obj = original_args[arg_idx]
+                            for step in attr_path:
+                                obj = getattr(obj, step)
+                            inner_tensors[attr] = obj
+                        else:
+                            inner_tensors[attr] = original_args[loc]
+                    else:
+                        inner_tensors[attr] = value
+            else:
+                inner_tensors.update(self.opaque_attrs)
 
         if is_runtime:
             if self.original_subclass_type is None:
@@ -850,6 +889,11 @@ class SubclassMeta:
     #
     # Optional field because we don't compute for inference graphs
     grad_input_metas: list[PlainTensorMeta | SubclassCreationMeta] | None = None
+
+    # Stashed by AOTDispatchSubclassWrapper so CompiledFunction.forward can
+    # save them on ctx for backward opaque remapping.  Transient: set before
+    # compiled_fn() and consumed immediately in CompiledFunction.forward().
+    _pending_original_args: dict[int, Any] | None = None
 
     def __init__(self) -> None:
         # The fields in this class get set after its construction.

--- a/torch/_functorch/_aot_autograd/schemas.py
+++ b/torch/_functorch/_aot_autograd/schemas.py
@@ -33,6 +33,7 @@ if TYPE_CHECKING:
     from torch._guards import Source
     from torch._inductor.output_code import OutputCode
     from torch._inductor.utils import InputType
+    from torch._opaque_base import OpaqueBase
     from torch._ops import OpOverload
     from torch.types import IntLikeType
 
@@ -262,7 +263,7 @@ class SubclassCreationMeta:
     original_subclass_type: type | None = None
     memory_format: MemoryFormatMeta | None = None
     # Non-tensor values from __tensor_flatten__, passed through to __tensor_unflatten__
-    opaque_attrs: dict[str, Any] | None = None
+    opaque_attrs: dict[str, OpaqueBase] | None = None
     # Maps opaque attr name to its location in the original (pre-unwrap) args.
     # For top-level opaque args: int (index into args).
     # For opaques nested inside input subclasses: tuple[int, tuple[str, ...]]
@@ -314,12 +315,14 @@ class SubclassCreationMeta:
         is_runtime: bool,
         original_args: dict[int, Any] | None = None,
     ) -> torch.Tensor:
-        inner_tensors = {}
+        inner_tensors: dict[str, Tensor | OpaqueBase] = {}
 
         curr_start_idx = self.flat_tensor_start_idx
         for attr, creation_meta in self.attrs.items():
             if isinstance(creation_meta, PlainTensorMeta):
                 subclass = all_args[curr_start_idx]
+                if not isinstance(subclass, Tensor):
+                    raise AssertionError("Tensor expected")
                 curr_start_idx += 1
             else:
                 subclass = creation_meta.creation_fn(

--- a/torch/_functorch/_aot_autograd/subclass_parametrization.py
+++ b/torch/_functorch/_aot_autograd/subclass_parametrization.py
@@ -1,10 +1,17 @@
+from __future__ import annotations
+
 import dataclasses
 import itertools
-from collections.abc import Iterable
-from typing import Any
+from typing import Any, TYPE_CHECKING
 
 import torch
 from torch.utils._python_dispatch import is_traceable_wrapper_subclass
+
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from torch._opaque_base import OpaqueBase
 
 
 # This is technically very similar to SubclassCreatingMeta
@@ -15,11 +22,11 @@ class SubclassCreationMeta:
     start_idx: int
     num_tensors: int
     class_type: Any
-    attrs: dict[str, "SubclassCreationMeta"]
+    attrs: dict[str, SubclassCreationMeta]
     metadata: Any
     outer_size: Iterable[None | int | torch.SymInt]
     outer_stride: Iterable[None | int | torch.SymInt]
-    opaque_attrs: dict[str, Any] = dataclasses.field(default_factory=dict)
+    opaque_attrs: dict[str, OpaqueBase] = dataclasses.field(default_factory=dict)
 
 
 class UnwrapTensorSubclass(torch.nn.Module):

--- a/torch/_functorch/_aot_autograd/subclass_parametrization.py
+++ b/torch/_functorch/_aot_autograd/subclass_parametrization.py
@@ -19,6 +19,7 @@ class SubclassCreationMeta:
     metadata: Any
     outer_size: Iterable[None | int | torch.SymInt]
     outer_stride: Iterable[None | int | torch.SymInt]
+    opaque_attrs: dict[str, Any] = dataclasses.field(default_factory=dict)
 
 
 class UnwrapTensorSubclass(torch.nn.Module):
@@ -32,6 +33,7 @@ class UnwrapTensorSubclass(torch.nn.Module):
             for attr, meta in subclass_meta.attrs.items():
                 built_tensor, offset = _unwrap_tensor_subclasses(meta, tensors, offset)
                 inner_tensors[attr] = built_tensor
+            inner_tensors.update(subclass_meta.opaque_attrs)
             rebuilt = subclass_meta.class_type.__tensor_unflatten__(
                 inner_tensors,
                 subclass_meta.metadata,
@@ -54,8 +56,12 @@ class UnwrapTensorSubclass(torch.nn.Module):
             inner_tensors_attrnames, metadata = tensor.__tensor_flatten__()  # type: ignore[attr-defined]
             new_idx = idx
             attr_to_meta = {}
+            opaque_attrs = {}
             for attr in inner_tensors_attrnames:
                 val = getattr(tensor, attr)
+                if not isinstance(val, torch.Tensor):
+                    opaque_attrs[attr] = val
+                    continue
                 subclass_meta, new_idx = _create_subclass_meta(
                     val, new_idx, plain_tensor_container
                 )
@@ -69,6 +75,7 @@ class UnwrapTensorSubclass(torch.nn.Module):
                     metadata=metadata,
                     outer_size=tensor.size(),
                     outer_stride=tensor.stride(),
+                    opaque_attrs=opaque_attrs,
                 ),
                 new_idx,
             )

--- a/torch/_functorch/_aot_autograd/subclass_utils.py
+++ b/torch/_functorch/_aot_autograd/subclass_utils.py
@@ -91,16 +91,63 @@ def get_subclass_typing_container(
         tracker[type(tensor_subclass)].append(tensor_subclass)
         inner_keys, _ = tensor_subclass.__tensor_flatten__()
         for key in inner_keys:
-            inner_tensor = getattr(tensor_subclass, key)
-            _get_types_for_subclass(inner_tensor)
+            inner_value = getattr(tensor_subclass, key)
+            if isinstance(inner_value, torch.Tensor):
+                _get_types_for_subclass(inner_value)
 
     tracker: dict[Any, list[Any]] = collections.defaultdict(list)
     _get_types_for_subclass(tensor_subclass)
     return tracker
 
 
+def build_opaque_input_map(
+    args: Sequence[Any],
+) -> dict[int, int | tuple[int, tuple[str, ...]]]:
+    """Build a mapping from id(opaque_obj) -> location for opaque objects in args.
+
+    Uses id() as the key, which is safe because the caller
+    (run_functionalized_fw_and_collect_metadata) keeps args alive for the
+    entire duration that this map is consulted by create_subclass_metadata.
+
+    For top-level opaque args, the location is the arg index (int).
+    For opaques nested inside input subclasses, the location is
+    (arg_index, attr_path) where attr_path is a tuple of attribute names.
+    """
+    from torch._library.fake_class_registry import FakeScriptObject
+    from torch._library.opaque_object import is_opaque_type as _is_opaque_type
+
+    opaque_input_map: dict[int, int | tuple[int, tuple[str, ...]]] = {}
+
+    def _collect_subclass_opaques(
+        obj: Any, arg_idx: int, path: tuple[str, ...] = ()
+    ) -> None:
+        if not is_traceable_wrapper_subclass(obj):
+            return
+        attrs, _ = obj.__tensor_flatten__()
+        for attr in attrs:
+            inner = getattr(obj, attr)
+            attr_path = (*path, attr)
+            if not isinstance(inner, torch.Tensor):
+                opaque_input_map[id(inner)] = (arg_idx, attr_path)
+            else:
+                _collect_subclass_opaques(inner, arg_idx, attr_path)
+
+    for i, arg in enumerate(args):
+        if isinstance(arg, FakeScriptObject):
+            opaque_input_map[id(arg)] = i
+        elif not isinstance(arg, torch.Tensor) and _is_opaque_type(type(arg)):
+            opaque_input_map[id(arg)] = i
+        _collect_subclass_opaques(arg, i)
+
+    return opaque_input_map
+
+
 def create_subclass_metadata(
-    a: Any, start_idx: int, count_symints: bool, with_memory_format: bool = False
+    a: Any,
+    start_idx: int,
+    count_symints: bool,
+    with_memory_format: bool = False,
+    opaque_input_map: dict[int, int | tuple[int, tuple[str, ...]]] | None = None,
 ) -> tuple[Any, int]:
     if not is_traceable_wrapper_subclass(a):
         idx = start_idx + 1
@@ -115,13 +162,28 @@ def create_subclass_metadata(
     inner_keys, metadata = a.__tensor_flatten__()
     new_start_idx = start_idx
     attrs = {}
+    opaque_attrs: dict[Any, Any] = {}
+    opaque_attr_input_indices: dict[Any, int | tuple[int, tuple[str, ...]]] = {}
 
     for key in inner_keys:
+        inner_value = getattr(a, key)
+        if not isinstance(inner_value, Tensor):
+            from torch._library.fake_class_registry import (
+                maybe_unwrap_fake_script_object,
+            )
+
+            # Check if this opaque came from an input arg
+            if opaque_input_map is not None and id(inner_value) in opaque_input_map:
+                opaque_attr_input_indices[key] = opaque_input_map[id(inner_value)]
+
+            opaque_attrs[key] = maybe_unwrap_fake_script_object(inner_value)
+            continue
         new_subclass_meta, new_start_idx = create_subclass_metadata(
-            getattr(a, key),
+            inner_value,
             new_start_idx,
             count_symints=count_symints,
             with_memory_format=with_memory_format,
+            opaque_input_map=opaque_input_map,
         )
         attrs[key] = new_subclass_meta
 
@@ -146,6 +208,10 @@ def create_subclass_metadata(
             outer_stride=a.stride(),  # type: ignore[arg-type]
             original_subclass=a,
             memory_format=maybe_suggest_memory_format(a, with_memory_format),
+            opaque_attrs=opaque_attrs if opaque_attrs else None,
+            opaque_attr_input_indices=(
+                opaque_attr_input_indices if opaque_attr_input_indices else None
+            ),
         ),
         new_start_idx,
     )
@@ -159,6 +225,7 @@ def create_subclass_meta(
     *,
     count_symints: bool = True,
     with_memory_format: bool = False,
+    opaque_input_map: dict[int, int | tuple[int, tuple[str, ...]]] | None = None,
 ) -> list[PlainTensorMeta | SubclassCreationMeta]:
     idx = 0
     infos: list[PlainTensorMeta | SubclassCreationMeta] = []
@@ -174,6 +241,7 @@ def create_subclass_meta(
                 start_idx,
                 count_symints=count_symints,
                 with_memory_format=with_memory_format,
+                opaque_input_map=opaque_input_map,
             )
             infos.append(subclass_meta)
             cnt = subclass_meta.arg_count
@@ -243,14 +311,16 @@ def unwrap_tensor_subclasses(
         attrs, _ = t.__tensor_flatten__()
 
         for attr in attrs:
-            inner_tensor = getattr(t, attr)
+            inner_value = getattr(t, attr)
+            if not isinstance(inner_value, Tensor):
+                continue
             n_desc: Any = (
                 SubclassGetAttrAOTInput(desc, attr)
                 if isinstance(desc, AOTInput)
                 # pyrefly: ignore [bad-argument-type]
                 else SubclassGetAttrAOTOutput(desc, attr)
             )
-            flatten_subclass(inner_tensor, n_desc, out=out)
+            flatten_subclass(inner_value, n_desc, out=out)
 
         if append_symints:
             sizes = enumerate_filter_symints(t.size())
@@ -295,10 +365,12 @@ def runtime_unwrap_tensor_subclasses(
         attrs, _ = x.__tensor_flatten__()
 
         for attr in attrs:
-            inner_tensor = getattr(x, attr)
+            inner_value = getattr(x, attr)
+            if not isinstance(inner_value, Tensor):
+                continue
             # pyrefly: ignore [missing-attribute]
             inner_meta = meta.attrs.get(attr)
-            flatten_subclass(inner_tensor, inner_meta, out=out)
+            flatten_subclass(inner_value, inner_meta, out=out)
 
         if append_symints:
             if not isinstance(meta, SubclassCreationMeta):
@@ -400,6 +472,7 @@ def wrap_tensor_subclasses(
     included_subclass_symints: bool = False,
     is_runtime: bool = False,
     make_subclass_override: Callable[..., Any] | None = None,
+    original_args: dict[int, Any] | None = None,
 ) -> tuple[Any, ...]:
     # pyrefly: ignore [implicit-any]
     wrapped_args = []
@@ -424,7 +497,11 @@ def wrap_tensor_subclasses(
                 )
             else:
                 wrapped_args.append(
-                    subclass_meta.creation_fn(unwrapped_args, is_runtime=is_runtime)
+                    subclass_meta.creation_fn(
+                        unwrapped_args,
+                        is_runtime=is_runtime,
+                        original_args=original_args,
+                    )
                 )
             num_args_tallied += subclass_meta.arg_count
 

--- a/torch/_functorch/_aot_autograd/subclass_utils.py
+++ b/torch/_functorch/_aot_autograd/subclass_utils.py
@@ -40,6 +40,7 @@ from .utils import strict_zip
 
 if TYPE_CHECKING:
     from torch._library.opaque_object import OpaqueType
+    from torch._opaque_base import OpaqueBase
 
 
 zip = strict_zip
@@ -162,8 +163,8 @@ def create_subclass_metadata(
     inner_keys, metadata = a.__tensor_flatten__()
     new_start_idx = start_idx
     attrs = {}
-    opaque_attrs: dict[Any, Any] = {}
-    opaque_attr_input_indices: dict[Any, int | tuple[int, tuple[str, ...]]] = {}
+    opaque_attrs: dict[str, OpaqueBase] = {}
+    opaque_attr_input_indices: dict[str, int | tuple[int, tuple[str, ...]]] = {}
 
     for key in inner_keys:
         inner_value = getattr(a, key)

--- a/torch/_functorch/compilers.py
+++ b/torch/_functorch/compilers.py
@@ -334,7 +334,8 @@ with torch.jit.fuser("fuser2"):
   minifier(fx.symbolic_trace(mod), inps, check_nvfuser_subprocess)
 """
     )
-    from foo import FxModule  # pyrefly: ignore[missing-import]
+    # pyrefly: ignore[missing-import, missing-module-attribute]
+    from foo import FxModule
 
     FxModule().cuda()(*inps)
 

--- a/torch/_library/fake_class_registry.py
+++ b/torch/_library/fake_class_registry.py
@@ -99,6 +99,13 @@ class FakeScriptObject:
         return new_obj
 
 
+def maybe_unwrap_fake_script_object(obj: Any) -> Any:
+    """If obj is a FakeScriptObject, return the underlying real object."""
+    if isinstance(obj, FakeScriptObject):
+        return obj.real_obj
+    return obj
+
+
 class FakeScriptMethod:
     def __init__(
         self,

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -193,7 +193,11 @@ def get_plain_tensors(
             continue
 
         inner_keys, _ = curr.__tensor_flatten__()
-        todo.extend(getattr(curr, key) for key in reversed(inner_keys))
+        todo.extend(
+            v
+            for key in reversed(inner_keys)
+            if isinstance(v := getattr(curr, key), Tensor)
+        )
 
     return out
 
@@ -205,7 +209,9 @@ def is_fake(x: object) -> TypeGuard[Tensor]:
         return True
     if is_traceable_wrapper_subclass(x):
         attrs, _ = type(x).__tensor_flatten__(x)
-        flattened_tensors = [getattr(x, attr) for attr in attrs]
+        flattened_tensors = [
+            v for attr in attrs if isinstance(v := getattr(x, attr), Tensor)
+        ]
         all_fake = all(is_fake(x) for x in flattened_tensors)
         any_fake = any(is_fake(x) for x in flattened_tensors)
         if all_fake != any_fake:
@@ -231,9 +237,11 @@ def maybe_get_fake_mode(t: object) -> FakeTensorMode | None:
     if is_traceable_wrapper_subclass(t):
         inner_tensor_names, _ = t.__tensor_flatten__()
         modes = [
-            maybe_get_fake_mode(getattr(t, t_name)) for t_name in inner_tensor_names
+            maybe_get_fake_mode(v)
+            for t_name in inner_tensor_names
+            if isinstance(v := getattr(t, t_name), Tensor)
         ]
-        m = modes[0]
+        m = modes[0] if modes else None
         if not all(m is x for x in modes):
             raise AssertionError("All fake tensor modes must be the same")
         return m

--- a/torch/_subclasses/meta_utils.py
+++ b/torch/_subclasses/meta_utils.py
@@ -48,6 +48,7 @@ if TYPE_CHECKING:
 
     from torch._C._functorch import CInterpreter
     from torch._guards import Source
+    from torch._opaque_base import OpaqueBase
     from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode
 
     # Import here to avoid cycle
@@ -680,7 +681,7 @@ class MetaTensorDesc(Generic[_TensorT]):
     bdim: int | None = None  # is_functorch_wrapped
     base: MetaTensorDesc[Any] | None = None  # is_view
     attrs: dict[str, MetaTensorDesc[Any]] | None = None  # is_traceable_wrapper_subclass
-    opaque_attrs: dict[str, Any] | None = (
+    opaque_attrs: dict[str, OpaqueBase] | None = (
         None  # non-tensor attrs from __tensor_flatten__
     )
     creation_meta: CreationMeta | None = None
@@ -1087,7 +1088,7 @@ class MetaConverter(Generic[_TensorT]):
                         symbolic_context,
                     )
 
-                inner_tensors = {}
+                inner_tensors: dict[str, torch.Tensor | OpaqueBase] = {}
                 for attr, meta_tensor_desc in t.attrs.items():
                     current_context = None
                     if symbolic_context is not None:

--- a/torch/_subclasses/meta_utils.py
+++ b/torch/_subclasses/meta_utils.py
@@ -365,6 +365,7 @@ class MetaTensorDescriber:
                 pass
 
         attrs = None
+        opaque_attrs = None
         ctx = None
         type_v = None
         if is_traceable_wrapper_subclass_v:
@@ -373,10 +374,18 @@ class MetaTensorDescriber:
                     "Traceable wrapper subclass must have __tensor_flatten__ method"
                 )
             raw_attrs, ctx = t.__tensor_flatten__()
-            attrs = {
-                attr: self.describe_tensor(getattr(t, attr), trace=trace)
-                for attr in raw_attrs
-            }
+            attrs = {}
+            opaque_attrs = {}
+            for attr in raw_attrs:
+                inner = getattr(t, attr)
+                if isinstance(inner, torch.Tensor):
+                    attrs[attr] = self.describe_tensor(inner, trace=trace)
+                else:
+                    from torch._library.fake_class_registry import (
+                        maybe_unwrap_fake_script_object,
+                    )
+
+                    opaque_attrs[attr] = maybe_unwrap_fake_script_object(inner)
             type_v = type(t)
 
         from torch.nested._internal.nested_tensor import _tensor_symint_registry
@@ -483,6 +492,7 @@ class MetaTensorDescriber:
             view_func=view_func,
             # pyrefly: ignore [bad-argument-type]
             attrs=attrs,
+            opaque_attrs=opaque_attrs if opaque_attrs else None,
             ctx=ctx,
             type=type_v,
             # NB: even if functorch is enabled, don't actually save the
@@ -670,6 +680,9 @@ class MetaTensorDesc(Generic[_TensorT]):
     bdim: int | None = None  # is_functorch_wrapped
     base: MetaTensorDesc[Any] | None = None  # is_view
     attrs: dict[str, MetaTensorDesc[Any]] | None = None  # is_traceable_wrapper_subclass
+    opaque_attrs: dict[str, Any] | None = (
+        None  # non-tensor attrs from __tensor_flatten__
+    )
     creation_meta: CreationMeta | None = None
     grad: MetaTensorDesc[Any] | None = None
 
@@ -1082,6 +1095,10 @@ class MetaConverter(Generic[_TensorT]):
                             raise AssertionError(
                                 f"Expected SubclassSymbolicContext, got {type(symbolic_context)}"
                             )
+                        if attr not in symbolic_context.inner_contexts:
+                            raise AssertionError(
+                                f"tensor attr {attr!r} missing from inner_contexts"
+                            )
                         if (
                             current_context_ := symbolic_context.inner_contexts[attr]
                         ) is not None:
@@ -1103,6 +1120,10 @@ class MetaConverter(Generic[_TensorT]):
                         current_source,
                     )
                     inner_tensors[attr] = new_empty_tensor
+
+                # Pass through opaque (non-tensor) attrs
+                if t.opaque_attrs:
+                    inner_tensors.update(t.opaque_attrs)
 
                 if t.type is None:
                     raise AssertionError("t.type must not be None for subclass")
@@ -1303,7 +1324,10 @@ class MetaConverter(Generic[_TensorT]):
                     )
                     attrs, _ = fake_t.__tensor_flatten__()  # type: ignore[attr-defined]
                     for attr in attrs:
-                        real_to_fake_mapping[t.attrs[attr].id] = getattr(fake_t, attr)
+                        if attr in t.attrs:
+                            real_to_fake_mapping[t.attrs[attr].id] = getattr(
+                                fake_t, attr
+                            )
 
                 def tensor_visitor_fn(
                     visited_t: torch.Tensor,

--- a/torch/distributed/_tools/common_utils.py
+++ b/torch/distributed/_tools/common_utils.py
@@ -20,7 +20,13 @@ def get_untyped_storages(t: torch.Tensor) -> set[torch.UntypedStorage]:
         obj = unflattened_tensors.pop()
         if is_traceable_wrapper_subclass(obj):
             attrs, _ = obj.__tensor_flatten__()  # type: ignore[attr-defined]
-            unflattened_tensors.extend([getattr(obj, attr) for attr in attrs])
+            unflattened_tensors.extend(
+                [
+                    v
+                    for attr in attrs
+                    if isinstance(v := getattr(obj, attr), torch.Tensor)
+                ]
+            )
         else:
             if not hasattr(obj, "untyped_storage"):
                 warnings.warn(

--- a/torch/distributed/fsdp/_init_utils.py
+++ b/torch/distributed/fsdp/_init_utils.py
@@ -1114,7 +1114,11 @@ def _sync_module_params_and_buffers(
                 # NOTE: Here we assume no nested subclasses, at most one level of subclass
                 # in both model's buffers and params
                 attrs, _ = detached_buffer.__tensor_flatten__()  # type: ignore[attr-defined]
-                inner_buffers = [getattr(detached_buffer, attr) for attr in attrs]
+                inner_buffers = [
+                    getattr(detached_buffer, attr)
+                    for attr in attrs
+                    if isinstance(getattr(detached_buffer, attr), torch.Tensor)
+                ]
                 module_states.extend(inner_buffers)
             else:
                 module_states.append(detached_buffer)
@@ -1123,7 +1127,11 @@ def _sync_module_params_and_buffers(
         detached_param = param.detach()
         if is_traceable_wrapper_subclass(detached_param):
             attrs, _ = detached_param.__tensor_flatten__()  # type: ignore[attr-defined]
-            inner_params = [getattr(detached_param, attr) for attr in attrs]
+            inner_params = [
+                getattr(detached_param, attr)
+                for attr in attrs
+                if isinstance(getattr(detached_param, attr), torch.Tensor)
+            ]
             module_states.extend(inner_params)
         else:
             module_states.append(detached_param)

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -5930,6 +5930,12 @@ class ShapeEnv:
                 attrs, _ = t.__tensor_flatten__()
                 for attr in attrs:
                     inner_t = getattr(t, attr)
+                    if not isinstance(inner_t, torch.Tensor):
+                        continue
+                    if attr not in context.inner_contexts:
+                        raise AssertionError(
+                            f"tensor attr {attr!r} missing from inner_contexts"
+                        )
                     inner_context = context.inner_contexts[attr]
                     sources_tensors_constraints.append(
                         (


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #176235

The first return value of `__tensor_flatten__` can now contain opaque
(non-tensor) references such as `DeviceMesh`. All code that iterates this list
and assumes every element is a tensor now checks isinstance before
operating on the value. Non-tensor attrs are tracked separately via new
`opaque_attrs` fields on `MetaTensorDesc` and `SubclassCreationMeta`.

To handle the case where an opaque attr in the output came from a graph
input (e.g. a `DeviceMesh` passed to `DTensor.from_local`), we track the
input index at compile time (`opaque_attr_input_indices`) so the runtime
value is used instead of the baked-in compile-time value when the cached
graph is reused.

Tests added (all in test/test_opaque_obj_v2.py):
- test_tensor_subclass_with_opaque_attr_backward: backward remapping with cache reuse uses runtime opaques
- test_tensor_subclass_opaque_backward_compiled_autograd: backward with compiled autograd
- test_tensor_subclass_shared_opaque_remapping: shared opaque across inputs remapped correctly
- test_shared_opaque_identity_guard: breaking shared opaque identity triggers recompilation
- test_shared_direct_opaque_identity_guard: same for direct (non-subclass) opaque inputs
- test_tensor_subclass_shared_opaque_backward: shared opaque remapping through backward
- test_deeply_nested_tensor_subclass_with_opaque: nested subclass with opaque attrs (tuple-form opaque_attr_input_indices)
- test_subclass_parametrization_with_opaque_attrs: unwrap_tensor_subclass_parameters handles non-tensor attrs
- test_export_non_strict_with_opaque_attrs: torch.export non-strict mode with subclass opaque attrs
- test_get_untyped_storages_with_opaque_attrs: profiling utility skips non-tensor attrs without warning
- test_subclass_opaque_attrs_cache_hit: AOTAutograd cache round-trip preserves opaque attrs and remaps at runtime

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo