### PR TITLE
[opaque obj] Fix sourceless tracing issue

### DIFF
--- a/test/distributed/tensor/test_dtensor_compile.py
+++ b/test/distributed/tensor/test_dtensor_compile.py
@@ -45,6 +45,7 @@ from torch.distributed.tensor.parallel import (
     RowwiseParallel,
 )
 from torch.distributed.tensor.placement_types import _StridedShard
+from torch.fx.experimental.proxy_tensor import make_fx
 from torch.testing._internal.common_device_type import skipXPUIf
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import get_devtype
@@ -1723,25 +1724,25 @@ class outer_fn(torch.nn.Module):
             f"Expected 1 compilation, got {compile_counter.frame_count}",
         )
 
-    def test_device_mesh_slicing_during_make_fx(self):
-        from torch.fx.experimental.proxy_tensor import make_fx
-
+    def test_device_mesh_slice(self):
         dist.destroy_process_group()
         dist.init_process_group("fake", store=FakeStore(), rank=0, world_size=8)
         mesh = init_device_mesh(self.device_type, (2, 4), mesh_dim_names=("dp", "tp"))
 
         def fn(x):
-            # Slice the mesh during make_fx tracing. Previously this would fail
-            # because DeviceMesh.__getitem__ only disabled FakeTensorMode but not
-            # proxy tensor tracing, causing _local_scalar_dense errors in
-            # _get_mesh_tensor_from_full_mesh.
             tp_mesh = mesh["tp"]
             dt = DTensor.from_local(x, tp_mesh, [Shard(0)], run_check=False)
+            if "tp" not in dt.device_mesh.mesh_dim_names:
+                return x
             return dt.to_local()
 
         x = torch.randn(4, 4)
+        res = fn(x)
         traced = make_fx(fn, tracing_mode="fake")(x)
-        self.assertEqual(traced(x), fn(x))
+        self.assertEqual(traced(x), res)
+
+        compiled = torch.compile(fn, backend="aot_eager")(x)
+        self.assertEqual(compiled, res)
 
     def test_compile_redistribute_flattened_mesh(self):
         """

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -341,6 +341,11 @@ class TensorVariable(VariableTracker):
                     tx.output.fake_mode, example_value
                 )
                 return TorchScriptObjectVariable.create(proxy, fake_script_obj)
+            elif isinstance(
+                example_value,
+                torch._library.fake_class_registry.FakeScriptObject,
+            ):
+                return TorchScriptObjectVariable.create(proxy, example_value)
             # any other attributes on the subclass (that are not methods)
             # are assumed to be constant metadata.
             elif not callable(example_value):


### PR DESCRIPTION
Fixes error from torchtitan (P2214224672)
`NGPU=4 TRAIN_FILE=torchtitan.experiments.compiler_toolkit.train MODULE=compiler_toolkit.deepseek_v3 CONFIG=compiler_toolkit_deepseek_v3_debugmodel ./run_train.sh --parallelism.data_parallel_shard_degree=2 --parallelism.tensor_parallel_degree=2 --parallelism.expert_parallel_degree=2 --activation_checkpoint.mode none`

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo