### PR TITLE
[nn] Support meta device in trunc_normal_ init

### DIFF
--- a/test/nn/test_init.py
+++ b/test/nn/test_init.py
@@ -150,6 +150,11 @@ class TestNNInit(TestCase):
         if not self._is_trunc_normal(input_tensor, mean=0, std=1, a=0, b=1):
             raise AssertionError("Expected truncated normal distribution")
 
+    def test_trunc_normal_meta(self):
+        t = torch.empty(3, 5, device="meta")
+        result = init.trunc_normal_(t)
+        self.assertIs(result, t)
+
     def test_constant(self):
         for dims in [1, 2, 4]:
             input_tensor = self._create_random_nd_tensor(dims, size_min=1, size_max=5)

--- a/torch/nn/init.py
+++ b/torch/nn/init.py
@@ -91,6 +91,10 @@ def _no_grad_trunc_normal_(
     b: float,
     generator: torch.Generator | None = None,
 ) -> Tensor:
+    # Meta tensors have no storage, so sampling is a no-op.
+    if tensor.is_meta:
+        return tensor
+
     def norm_cdf(x: float) -> float:
         return (1.0 + math.erf(x / math.sqrt(2.0))) / 2.0
 


### PR DESCRIPTION
## Summary

`_no_grad_trunc_normal_` uses complex rejection sampling with loops, `torch.where`, and `torch.empty_like` which all fail on meta tensors (they have no storage). This adds an early return for meta tensors to match the behavior of simpler init functions like `normal_` and `uniform_` where the underlying ops are already no-ops on meta.

Authored with Claude.

## Test plan

- Added `test_trunc_normal_meta` in `test/nn/test_init.py` that creates a meta tensor and verifies `trunc_normal_` returns successfully.