### PR TITLE
[Test Infra] Fix MultiProcContinuousTest completion queue desync

### DIFF
--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -2009,21 +2009,25 @@ class MultiProcContinuousTest(TestCase):
         def wrapper(self):
             if self.rank == self.MAIN_PROCESS_RANK:
                 logger.debug(f"Waiting for workers to finish {self.id()}")  # noqa: G004
-                # Wait for the workers to finish the test
+                # Drain all completion queues before raising any exception,
+                # so stale results don't desync subsequent tests.
+                deferred_exception = None
                 for i, completion_queue in enumerate(self.completion_queues):
                     rv = completion_queue.get()
+                    if deferred_exception is not None:
+                        # Already captured an exception; just drain
+                        continue
                     if isinstance(rv, unittest.SkipTest):
-                        raise rv
+                        deferred_exception = rv
+                        continue
                     if isinstance(rv, BaseException):
-                        # Hit an exception, re-raise it in the main process.
                         logger.warning(
                             f"Detected failure from Rank {i} in: {self.id()}, "  # noqa: G004
                             f"skipping rest of tests in Test class: {self.__class__.__name__}"  # noqa: G004
                         )
-                        # Poison rest of tests (because ProcessGroup may be not
-                        # reusable now)
                         self.__class__.poison_pill = True
-                        raise rv
+                        deferred_exception = rv
+                        continue
 
                     # Success
                     if rv != self.id():
@@ -2033,6 +2037,9 @@ class MultiProcContinuousTest(TestCase):
                     logger.debug(
                         f"Main proc detected rank {i} finished {self.id()}"  # noqa: G004
                     )
+
+                if deferred_exception is not None:
+                    raise deferred_exception
             else:
                 # Worker just runs the test
                 fn()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #176225
* __->__ #176245

Fix a flaky test failure in MultiProcContinuousTest where
_worker_run_main_wait raises immediately on SkipTest or exception
from the first worker without draining remaining workers' completion
queues. Since setUp already dispatched the test to all workers, the
undrained results pollute subsequent tests.

Concrete failure scenario (on CI machines with <2 GPUs):

ReplicateTest has world_size=2. Tests run alphabetically:
 1. test_replicate_device_id        (@skip_if_lt_x_gpu(2))
 2. test_replicate_ignore_module    (@skip_if_lt_x_gpu(2))
 3. test_replicate_move_args_kwargs (@skip_if_lt_x_gpu(2))
 4. test_replicate_multi_module     (no GPU requirement)
 5. test_replicate_single_module    (no GPU requirement)
 6. test_replicate_with_kwargs      (no GPU requirement)
 7. test_replicate_wrong_device_id_type (no GPU requirement)

Tests 1-3: Both workers skip (SkipTest on both queues). Main reads
queue 0 → SkipTest → raises immediately, never reads queue 1. After
3 GPU tests, queue 1 has 3 orphaned SkipTest entries.

Tests 4-6 (no GPU requirement): Both workers succeed. Main reads
queue 0 → success. Reads queue 1 → gets stale SkipTest from tests
1-3 → raises SkipTest. The real success result from worker 1 is now
orphaned. Each test consumes one stale SkipTest and leaves one real
result behind.

After test 6, queue 1 contains: ["multi_module", "single_module",
"with_kwargs"] — all stale.

Test 7: Main reads queue 0 → "wrong_device_id_type" → success. Reads
queue 1 → "multi_module" (stale!) → rv != self.id() → AssertionError:
test_replicate_multi_module != test_replicate_wrong_device_id_type.

The invariant is: setUp sends exactly one entry per worker task queue,
so the main process must consume exactly one entry per worker
completion queue. The old code violated this on early-exit paths.

Fix: collect all results before raising. Use deferred_exception to
capture the first error/skip, continue draining remaining queues,
and only raise after all queues are consumed.

Co-authored-by: Claude <noreply@anthropic.com>