### PR TITLE
Fix TMA descriptor init/update shape mismatch

### DIFF
--- a/test/inductor/test_cutedsl_grouped_mm.py
+++ b/test/inductor/test_cutedsl_grouped_mm.py
@@ -188,7 +188,9 @@ class TestCuTeDSLGroupedGemm(InductorTestCase):
                 "autotune_fallback_to_aten": False,
             },
         ):
-            grouped_gemm_compiled = torch.compile(grouped_gemm_fn, backend="inductor", dynamic=False)
+            grouped_gemm_compiled = torch.compile(
+                grouped_gemm_fn, backend="inductor", dynamic=False
+            )
             c_compiled = grouped_gemm_compiled(A, B, offsets)
 
         self.assertEqual(c_eager.dtype, dtype)

--- a/test/inductor/test_cutedsl_grouped_mm.py
+++ b/test/inductor/test_cutedsl_grouped_mm.py
@@ -153,6 +153,48 @@ class TestCuTeDSLGroupedGemm(InductorTestCase):
         self.assertEqual(c_compiled.dtype, dtype)
         torch.testing.assert_close(c_eager, c_compiled)
 
+    @parametrize(
+        "G,K,N",
+        [
+            (256, 3072, 1024),
+            (256, 2048, 7168),
+            (256, 3072, 1536),
+            (256, 1536, 3072),
+            (256, 2048, 512),
+            (128, 2880, 2880),
+        ],
+        name_fn=lambda G, K, N: f"G{G}_K{K}_N{N}",
+    )
+    def test_grouped_gemm_moe_shapes(self, G: int, K: int, N: int):
+        """Regression test for init/update shape mismatch."""
+        device = "cuda"
+        dtype = torch.bfloat16
+        M_per_group = 16
+
+        A, B, offsets = self._get_inputs(
+            G, M_per_group, K, N, device, dtype, alignment=16
+        )
+
+        def grouped_gemm_fn(A_packed, B_batched, offs):
+            return F.grouped_mm(A_packed, B_batched, offs=offs)
+
+        c_eager = grouped_gemm_fn(A, B, offsets)
+
+        with config.patch(
+            {
+                "max_autotune": True,
+                "max_autotune_gemm_backends": "CUTEDSL",
+                "test_configs.autotune_choice_name_regex": "cutedsl",
+                "autotune_fallback_to_aten": False,
+            },
+        ):
+            grouped_gemm_compiled = torch.compile(grouped_gemm_fn, backend="inductor", dynamic=False)
+            c_compiled = grouped_gemm_compiled(A, B, offsets)
+
+        self.assertEqual(c_eager.dtype, dtype)
+        self.assertEqual(c_compiled.dtype, dtype)
+        torch.testing.assert_close(c_eager, c_compiled)
+
 
 if __name__ == "__main__":
     run_tests()

--- a/torch/_inductor/kernel/templates/cutedsl_mm_grouped.py.jinja
+++ b/torch/_inductor/kernel/templates/cutedsl_mm_grouped.py.jinja
@@ -298,10 +298,17 @@ def launch_build_group_ptrs_from_bases(
     # GroupedGemmKernel uses initial tensors only for dtype/majorness detection
     # and TMA descriptor creation.
     # They should represent a single group's shape, not the full concatenated tensor.
-    first_m = int(input_a_offs[0])
-    initial_a = from_dlpack(input_a[:first_m].unsqueeze(-1), assumed_align=16)
-    initial_b = from_dlpack(input_b[0].unsqueeze(-1), assumed_align=16)
-    initial_c = from_dlpack({{get_output()}}[:first_m], assumed_align=16)
+    # Use the group with the largest M so the initial TMA descriptor is never
+    # undersized (matching the CuTeDSL example's smallest-tensor strategy isn't
+    # safe here because packed-tensor slices with M < TILE_M break TMA tiling).
+    offs_cpu = input_a_offs.cpu()
+    group_sizes = torch.diff(offs_cpu, prepend=offs_cpu.new_zeros(1))
+    max_g = int(group_sizes.argmax())
+    max_m = int(group_sizes[max_g])
+    max_m_start = int(offs_cpu[max_g - 1]) if max_g > 0 else 0
+    initial_a = from_dlpack(input_a[max_m_start:max_m_start + max_m].unsqueeze(-1), assumed_align=16)
+    initial_b = from_dlpack(input_b[max_g].unsqueeze(-1), assumed_align=16)
+    initial_c = from_dlpack({{get_output()}}[max_m_start:max_m_start + max_m].unsqueeze(-1), assumed_align=16)
 
     if gemm_executor is None:
         grouped_gemm = GroupedGemmKernel(

--- a/torch/_inductor/kernel/templates/cutedsl_mm_grouped.py.jinja
+++ b/torch/_inductor/kernel/templates/cutedsl_mm_grouped.py.jinja
@@ -295,6 +295,14 @@ def launch_build_group_ptrs_from_bases(
     )
     gemm_executor = gemm_cache.get(gemm_cache_key)
 
+    # GroupedGemmKernel uses initial tensors only for dtype/majorness detection
+    # and TMA descriptor creation.
+    # They should represent a single group's shape, not the full concatenated tensor.
+    first_m = int(input_a_offs[0])
+    initial_a = from_dlpack(input_a[:first_m].unsqueeze(-1), assumed_align=16)
+    initial_b = from_dlpack(input_b[0].unsqueeze(-1), assumed_align=16)
+    initial_c = from_dlpack({{get_output()}}[:first_m], assumed_align=16)
+
     if gemm_executor is None:
         grouped_gemm = GroupedGemmKernel(
             acc_dtype=ACC_DTYPE,
@@ -306,9 +314,9 @@ def launch_build_group_ptrs_from_bases(
 
         gemm_executor = cute.compile(
             grouped_gemm,
-            from_dlpack(input_a.unsqueeze(-1), assumed_align=16),
-            from_dlpack(input_b[0].unsqueeze(-1), assumed_align=16),
-            from_dlpack({{get_output()}}.unsqueeze(-1), assumed_align=16),
+            initial_a,
+            initial_b,
+            initial_c,
             G,
             probs,
             strides,
@@ -322,9 +330,9 @@ def launch_build_group_ptrs_from_bases(
         gemm_cache[gemm_cache_key] = gemm_executor
 
     gemm_executor(
-        from_dlpack(input_a.unsqueeze(-1), assumed_align=16),
-        from_dlpack(input_b[0].unsqueeze(-1), assumed_align=16),
-        from_dlpack({{get_output()}}.unsqueeze(-1), assumed_align=16),
+        initial_a,
+        initial_b,
+        initial_c,
         probs,
         strides,
         ptrs,


### PR DESCRIPTION
CuTeDSL example of grouped gemm picks per-group tensors with the smallest shapes for initializing TMA descriptor: https://github.com/NVIDIA/cutlass/blob/4faf1a1568cf1e4ad8ff71846a13e16f2a6a6f6b/examples/python/CuTeDSL/blackwell/grouped_gemm.py#L1985-L1993

Wrote with claude 4.6 opus.

fixes #176178

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos