### PR TITLE
[do not merge] benchmark combokernels, benchmark_combo_kernel and combo_kernel_per_subkernel_blocks enabled

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -875,9 +875,9 @@ compute_all_bounds = False
 
 # enable the combo kernel that combines data-independent kernels (additional
 # to foreach kernels) into a single one (Experimental)
-combo_kernels = False
+combo_kernels = True
 # benchmark combo kernels and only allow ones with perf gains
-benchmark_combo_kernel = False
+benchmark_combo_kernel = True
 # combo_kernel autotuning options: 0 - disable, 1 - enable except for foreach,
 # 2 - enable for all
 combo_kernels_autotune = 1

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -891,7 +891,7 @@ combo_kernel_max_num_args = 250
 # When True, each combo sub-kernel gets its own block sizes (XBLOCK_0, YBLOCK_0, etc.)
 # allowing different sub-kernels to use different tile sizes based on their heuristics.
 # When False, all sub-kernels share block sizes (XBLOCK, YBLOCK, etc.)
-combo_kernel_per_subkernel_blocks = False
+combo_kernel_per_subkernel_blocks = True
 # When True, only pointwise kernels are eligible for combo kernel fusion.
 combo_kernels_pointwise_only = False
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #176249



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo