### PR TITLE
[ROCm] Tune Flex-Attention occupancy for head_dim=64/128/256

### DIFF
--- a/torch/_inductor/template_heuristics/triton.py
+++ b/torch/_inductor/template_heuristics/triton.py
@@ -1554,9 +1554,9 @@ class ROCmConfigHeuristic(BaseConfigHeuristic):
             (torch.float32, 64): ROCmFlexConfig(128, 32, 1, 4),
             (torch.float32, 128): ROCmFlexConfig(128, 32, 1, 4),
             (torch.float32, 256): ROCmFlexConfig(64, 16, 1, 4),
-            (torch.bfloat16, 64): ROCmFlexConfig(128, 64, 1, 8),
-            (torch.bfloat16, 128): ROCmFlexConfig(128, 64, 1, 8),
-            (torch.bfloat16, 256): ROCmFlexConfig(32, 64, 1, 8),
+            (torch.bfloat16, 64): ROCmFlexConfig(128, 64, 1, 4),
+            (torch.bfloat16, 128): ROCmFlexConfig(128, 64, 1, 4),
+            (torch.bfloat16, 256): ROCmFlexConfig(32, 64, 1, 4),
             (torch.float16, 64): ROCmFlexConfig(128, 64, 1, 8),
             (torch.float16, 128): ROCmFlexConfig(128, 64, 1, 8),
             (torch.float16, 256): ROCmFlexConfig(32, 64, 1, 4),
@@ -1766,7 +1766,7 @@ class ROCmConfigHeuristic(BaseConfigHeuristic):
             if head_dim == 64:
                 default_config = ROCmFlexBwDConfig(64, 64, 64, 64, 1, 4)
             elif head_dim == 128:
-                default_config = ROCmFlexBwDConfig(64, 128, 128, 64, 1, 8)
+                default_config = ROCmFlexBwDConfig(64, 128, 128, 64, 1, 4)
             else:
                 default_config = ROCmFlexBwDConfig(64, 64, 64, 64, 1, 4)
         else:


### PR DESCRIPTION
## [ROCm] Optimize Flex-Attention occupancy for head_dim=64/128/256

### **Summary**
This PR adjusts `n_warps` from 8 to 4 for `bfloat16` configurations with `head_dim=64, 128, and 256` on ROCm (**gfx942/MI325**). Reducing the warp count improves hardware occupancy and register management, leading to significant throughput gains across various attention patterns.

### **Performance Impact (Geomean Speedup)**
The following table summarizes the speedup compared to the current `n_warps=8` baseline. Results are averaged across **320 unique test cases**.

| Attention Pattern | hd=64 (Fwd) | hd=128 (Fwd) | hd=128 (Bwd) | hd=256 (Fwd) |
| :--- | :---: | :---: | :---: | :---: |
| **alibi** | 1.64x | 1.27x | **1.89x** | 1.31x |
| **causal** | 1.88x | 1.24x | 1.84x | 1.25x |
| **noop** | 1.88x | 1.26x | 1.73x | 1.28x |
| **prefix_lm** | 2.02x | 1.24x | 1.80x | 1.28x |
| **sliding_window** | 1.54x | 1.15x | 1.70x | 1.21x |
| **Overall (Geomean)** | **1.78x** | **1.23x** | **1.79x** | **1.26x** |

### **Benchmark Coverage**
* **Shapes**: Batch size [1, 2, 4, 8], Heads [16, 32], Seq_len [512, 1024, 2048, 4096].
* **Masking**: `window_size` and `prefix_length` ∈ [128, 256, 512, 1024, 2048].
* Note: Redundant cases (e.g., window_size >= seq_len) were excluded.
* **Validation**: All configurations were verified for both performance stability and numerical correctness.

---
**Note:** This is a resubmission from a personal fork to resolve `pytorchbot` merge permission issues. (Reference to original PR: https://github.com/pytorch/pytorch/pull/174867)

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben