### PR TITLE
[xpu][feature]Enable SYCL Native Fast Math Support in `NumericUtils.h`

### DIFF
--- a/aten/src/ATen/NumericUtils.h
+++ b/aten/src/ATen/NumericUtils.h
@@ -135,6 +135,9 @@ C10_HOST_DEVICE inline T exp(T x) {
 #if defined(__CUDA_ARCH__) || defined(__HIP_ARCH__)
   // use __expf fast approximation for peak bandwidth
   return __expf(x);
+#elif defined(__SYCL_DEVICE_ONLY__)
+  // use native::exp fast approximation for peak bandwidth
+  return sycl::native::exp(x);
 #else
   return ::exp(x);
 #endif
@@ -153,6 +156,9 @@ C10_HOST_DEVICE inline T log(T x) {
 #if defined(__CUDA_ARCH__) || defined(__HIP_ARCH__)
   // use __logf fast approximation for peak bandwidth
   return __logf(x);
+#elif defined(__SYCL_DEVICE_ONLY__)
+  // use native::log fast approximation for peak bandwidth
+  return sycl::native::log(x);
 #else
   return ::log(x);
 #endif
@@ -172,6 +178,9 @@ C10_HOST_DEVICE inline T log1p(T x) {
   // use __logf fast approximation for peak bandwidth
   // NOTE: There is no __log1pf so unfortunately we lose precision.
   return __logf(1.0f + x);
+#elif defined(__SYCL_DEVICE_ONLY__)
+  // use native::log fast approximation for peak bandwidth
+  return sycl::native::log(1.0f + x);
 #else
   return ::log1p(x);
 #endif
@@ -190,6 +199,9 @@ C10_HOST_DEVICE inline T tan(T x) {
 #if defined(__CUDA_ARCH__) || defined(__HIP_ARCH__)
   // use __tanf fast approximation for peak bandwidth
   return __tanf(x);
+#elif defined(__SYCL_DEVICE_ONLY__)
+  // use native::tan fast approximation for peak bandwidth
+  return sycl::native::tan(x);
 #else
   return ::tan(x);
 #endif

--- a/test/test_xpu.py
+++ b/test/test_xpu.py
@@ -3020,6 +3020,7 @@ class TestCachingHostAllocatorXpuGraph(TestCase):
             else:
                 self.assertNotEqual(new_data_ptr, old_data_ptr)
 
+
 @unittest.skipIf(not TEST_XPU, "XPU not available, skipping tests")
 @torch.testing._internal.common_utils.markDynamoStrictTest
 class TestXpuNativeMath(TestCase):
@@ -3072,6 +3073,7 @@ class TestXpuNativeMath(TestCase):
         # Mean of LogNormal(mu, sigma) = exp(mu + sigma^2/2) = exp(0.125) ≈ 1.133
         expected_mean = math.exp(0.0 + 0.5**2 / 2)
         self.assertTrue(abs(x.mean().item() - expected_mean) < 0.05)
+
 
 @unittest.skipIf(not TEST_XPU, "XPU not available, skipping tests")
 @torch.testing._internal.common_utils.markDynamoStrictTest

--- a/test/test_xpu.py
+++ b/test/test_xpu.py
@@ -3020,6 +3020,58 @@ class TestCachingHostAllocatorXpuGraph(TestCase):
             else:
                 self.assertNotEqual(new_data_ptr, old_data_ptr)
 
+@unittest.skipIf(not TEST_XPU, "XPU not available, skipping tests")
+@torch.testing._internal.common_utils.markDynamoStrictTest
+class TestXpuNativeMath(TestCase):
+    """Test SYCL native fast math functions in NumericUtils.h on XPU."""
+
+    def test_cauchy_sanity(self):
+        """cauchy_() exercises at::tan -> sycl::native::tan via TransformationHelper."""
+        for dtype in [torch.float32, torch.float16, torch.bfloat16]:
+            x = torch.empty(10000, device="xpu", dtype=dtype)
+            x.cauchy_(median=0.0, sigma=1.0)
+            # Cauchy can produce large values but should mostly be finite
+            finite_ratio = torch.isfinite(x).float().mean().item()
+            self.assertTrue(
+                finite_ratio > 0.99,
+                f"cauchy_ produced too many non-finite for {dtype}",
+            )
+
+    def test_log_normal_sanity(self):
+        """log_normal_() exercises at::exp -> sycl::native::exp via TransformationHelper."""
+        for dtype in [torch.float32, torch.float16, torch.bfloat16]:
+            x = torch.empty(10000, device="xpu", dtype=dtype)
+            x.log_normal_(mean=0.0, std=1.0)
+            self.assertTrue(
+                (x > 0).all(),
+                f"log_normal_ produced non-positive for {dtype}",
+            )
+            if dtype == torch.float32:
+                self.assertTrue(
+                    torch.isfinite(x).all(),
+                    f"log_normal_ produced non-finite for {dtype}",
+                )
+
+    def test_cauchy_accuracy(self):
+        """Verify cauchy_() median is correct (exercises sycl::native::tan precision)."""
+        torch.manual_seed(42)
+        x = torch.empty(100000, device="xpu", dtype=torch.float32)
+        x.cauchy_(median=5.0, sigma=1.0)
+        # Median of Cauchy(median=5, sigma=1) should be 5.0
+        self.assertTrue(abs(x.median().item() - 5.0) < 0.1)
+
+    def test_log_normal_accuracy(self):
+        """Verify log_normal_() statistics (exercises sycl::native::exp precision)."""
+        import math
+
+        torch.manual_seed(42)
+        x = torch.empty(100000, device="xpu", dtype=torch.float32)
+        x.log_normal_(mean=0.0, std=0.5)
+        # Median of LogNormal(0, 0.5) = exp(0) = 1.0
+        self.assertTrue(abs(x.median().item() - 1.0) < 0.05)
+        # Mean of LogNormal(mu, sigma) = exp(mu + sigma^2/2) = exp(0.125) ≈ 1.133
+        expected_mean = math.exp(0.0 + 0.5**2 / 2)
+        self.assertTrue(abs(x.mean().item() - expected_mean) < 0.05)
 
 @unittest.skipIf(not TEST_XPU, "XPU not available, skipping tests")
 @torch.testing._internal.common_utils.markDynamoStrictTest


### PR DESCRIPTION
Updates several mathematical utility functions in `aten/src/ATen/NumericUtils.h` to add support for SYCL device compilation. Specifically, it introduces fast approximations for `exp`, `log`, `log1p`, and `tan` using SYCL's native math functions when compiling for SYCL devices. This ensures optimal performance and compatibility across CUDA, HIP, and SYCL backends.

Device-specific math optimizations:

* Updated the `exp`, `log`, `log1p`, and `tan` functions to use `sycl::native::exp`, `sycl::native::log`, and `sycl::native::tan` for fast approximations when compiling for SYCL devices. This matches the approach already used for CUDA and HIP devices, improving performance and consistency across different hardware backends.

cc @gujinghui @EikanWang @fengyuan14 @guangyey