### PR TITLE
[Test] Add device type test support for op decorators and skips in `DeviceTypeTestBase`

### DIFF
--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
@@ -74,8 +74,8 @@ op_skip = _make_dummy_op("op_skip")
 op_skip_f32 = _make_dummy_op("op_skip_f32")
 op_xfail = _make_dummy_op("op_xfail")
 # op_precision starts with a low precision override (1e-5) declared in the OpInfo itself.
-# op_decorators will later register a higher override (1e-2) for float32 to verify
-# that the op_decorators entry takes precedence (because it is appended last to
+# op_overrides will later register a higher override (1e-2) for float32 to verify
+# that the op_overrides entry takes precedence (because it is appended last to
 # op.decorators and therefore applied last, overwriting precision_overrides).
 op_precision = _make_dummy_op(
     "op_precision",
@@ -115,7 +115,7 @@ class TestDeviceTypeOpenReg(TestCase):
                 self.precision,
                 1e-2,
                 msg=(
-                    f"Expected op_decorators precisionOverride (1e-2) to win over "
+                    f"Expected op_overrides precisionOverride (1e-2) to win over "
                     f"OpInfo precisionOverride (1e-5), but got {self.precision}"
                 ),
             )
@@ -123,10 +123,10 @@ class TestDeviceTypeOpenReg(TestCase):
 
     @ops([op_normal])
     def test_op_narrow_ops(self, device, dtype, op):
-        """Verify that having extra entries in op_skips that are NOT present in
+        """Verify that having extra entries in op_overrides that are NOT present in
         the @ops list does not raise a KeyError (safety check in _apply_op_overrides).
 
-        op_skips includes op_skip and PrivateUse1TestBase.op_skips also
+        op_overrides includes op_skip and PrivateUse1TestBase.op_overrides also
         lists op_skip; here @ops only exposes op_normal.  The safety check
         introduced in _apply_op_overrides must silently ignore the missing keys.
         """
@@ -134,13 +134,11 @@ class TestDeviceTypeOpenReg(TestCase):
 
 
 # Modify PrivateUse1TestBase which is automatically included for OpenReg
-PrivateUse1TestBase.op_skips = {
+PrivateUse1TestBase.op_overrides = {
     "op_skip": [DecorateInfo(unittest.skip("skip op_skip"))],
     "op_skip_f32": [
         DecorateInfo(unittest.skip("skip op_skip"), dtypes=(torch.float32,))
     ],
-}
-PrivateUse1TestBase.op_decorators = {
     "op_xfail": [DecorateInfo(unittest.expectedFailure)],
     # This overrides the 1e-5 precision already declared on op_precision's OpInfo.
     "op_precision": [DecorateInfo(precisionOverride({torch.float32: 1e-2}))],

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
@@ -1,12 +1,18 @@
 # Owner(s): ["module: PrivateUse1"]
 
+import unittest
+
 import torch
+import torch.testing._internal.common_device_type as common_device_type
 from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
     onlyCUDA,
     onlyOn,
+    ops,
+    PrivateUse1TestBase,
 )
 from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.opinfo.core import DecorateInfo, OpInfo
 
 
 class TestBypassDeviceRestrictions(TestCase):
@@ -52,10 +58,42 @@ class TestBypassDeviceRestrictions(TestCase):
         )
 
 
+dummy_op1 = OpInfo(
+    "dummy_op1", op=lambda x: x, dtypes=common_device_type.get_all_dtypes()
+)
+dummy_op2 = OpInfo(
+    "dummy_op2", op=lambda x: x, dtypes=common_device_type.get_all_dtypes()
+)
+dummy_op3 = OpInfo(
+    "dummy_op3", op=lambda x: x, dtypes=common_device_type.get_all_dtypes()
+)
+
+
+class TestDeviceTypeOpenReg(TestCase):
+    def test_normal(self, device):
+        pass
+
+    @ops([dummy_op1, dummy_op2, dummy_op3])
+    def test_op(self, device, dtype, op):
+        if op.name == "dummy_op2":
+            self.fail("dummy_op2 should be skipped via op_skips")
+        if op.name == "dummy_op3":
+            # This should fail, but since we decorated it with expectedFailure, the test will pass!
+            self.fail("dummy_op3 fails but is decorated with expectedFailure")
+
+
+# Modify PrivateUse1TestBase which is automatically included for OpenReg
+PrivateUse1TestBase.op_skips = {
+    "dummy_op2": [DecorateInfo(unittest.skip("skip dummy_op2"))],
+}
+PrivateUse1TestBase.op_decorators = {
+    "dummy_op3": [DecorateInfo(unittest.expectedFailure)],
+}
+
+instantiate_device_type_tests(TestDeviceTypeOpenReg, globals(), only_for=("openreg",))
 instantiate_device_type_tests(
     TestBypassDeviceRestrictions, globals(), only_for="openreg"
 )
-
 
 if __name__ == "__main__":
     run_tests()

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
@@ -124,11 +124,11 @@ class TestDeviceTypeOpenReg(TestCase):
     @ops([op_normal])
     def test_op_narrow_ops(self, device, dtype, op):
         """Verify that having extra entries in op_skips that are NOT present in
-        the @ops list does not raise a KeyError (safety check in update_op_list).
+        the @ops list does not raise a KeyError (safety check in _apply_op_overrides).
 
         op_skips includes op_skip and PrivateUse1TestBase.op_skips also
         lists op_skip; here @ops only exposes op_normal.  The safety check
-        introduced in update_op_list must silently ignore the missing keys.
+        introduced in _apply_op_overrides must silently ignore the missing keys.
         """
         # If we reach here without a KeyError the safety check worked.
 

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
@@ -4,7 +4,6 @@ import unittest
 from collections import defaultdict
 
 import torch
-import torch.testing._internal.common_device_type as common_device_type
 from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
     onlyCUDA,
@@ -60,23 +59,26 @@ class TestBypassDeviceRestrictions(TestCase):
         )
 
 
-dummy_op1 = OpInfo(
-    "dummy_op1", op=lambda x: x, dtypes=common_device_type.get_all_dtypes()
-)
-dummy_op2 = OpInfo(
-    "dummy_op2", op=lambda x: x, dtypes=common_device_type.get_all_dtypes()
-)
-dummy_op3 = OpInfo(
-    "dummy_op3", op=lambda x: x, dtypes=common_device_type.get_all_dtypes()
-)
-# dummy_op4 starts with a low precision override (1e-5) declared in the OpInfo itself.
+def _make_dummy_op(name, **kwargs):
+    return OpInfo(
+        name,
+        op=lambda x: x,
+        dtypes={torch.float32, torch.float64},
+        sample_inputs_func=lambda op, device, dtype, requires_grad, **kw: [],
+        **kwargs,
+    )
+
+
+op_normal = _make_dummy_op("op_normal")
+op_skip = _make_dummy_op("op_skip")
+op_skip_f32 = _make_dummy_op("op_skip_f32")
+op_xfail = _make_dummy_op("op_xfail")
+# op_precision starts with a low precision override (1e-5) declared in the OpInfo itself.
 # op_decorators will later register a higher override (1e-2) for float32 to verify
 # that the op_decorators entry takes precedence (because it is appended last to
 # op.decorators and therefore applied last, overwriting precision_overrides).
-dummy_op4 = OpInfo(
-    "dummy_op4",
-    op=lambda x: x,
-    dtypes=common_device_type.get_all_dtypes(),
+op_precision = _make_dummy_op(
+    "op_precision",
     decorators=[DecorateInfo(precisionOverride({torch.float32: 1e-5}))],
 )
 
@@ -89,54 +91,30 @@ class TestDeviceTypeOpenReg(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        # dummy_op1: all dtypes must run (no skips/xfails).
-        if cls._executed["dummy_op1"] <= 0:
+        should_run = ("op_normal", "op_precision")
+        should_not_run = ("op_skip", "op_xfail")
+        for op_name in should_run:
+            if op_name not in cls._executed or cls._executed[op_name] == 0:
+                raise AssertionError(f"{op_name} tests should have run")
+        for op_name in should_not_run:
+            if op_name in cls._executed and cls._executed[op_name] != 0:
+                raise AssertionError(f"{op_name} test body should never run")
+        if cls._executed["op_skip_f32"] != 1:
             raise AssertionError(
-                "dummy_op1 tests should have run, but executed count is 0"
-            )
-        # dummy_op2: all variants are skipped, so the test body must never run.
-        if cls._executed["dummy_op2"] != 0:
-            raise AssertionError(
-                "dummy_op2 test body should never run because all variants are op_skipped"
-            )
-        # dummy_op3: all variants are expectedFailure, so the test body must always
-        # fail (and therefore never reach the counter increment).
-        if cls._executed["dummy_op3"] != 0:
-            raise AssertionError(
-                "dummy_op3 test body should always fail (expectedFailure), never increment counter"
-            )
-        # dummy_op4: op_decorators precisionOverride must have been applied.
-        if cls._executed["dummy_op4_precision_ok"] <= 0:
-            raise AssertionError(
-                "dummy_op4 float32 variant must have verified op_decorators precisionOverride wins"
+                "op_skip_f32 should have run exactly once,"
+                f"but ran {cls._executed['op_skip_f32']} times"
             )
         super().tearDownClass()
 
     def test_normal(self, device):
         pass
 
-    @ops([dummy_op1, dummy_op2, dummy_op3])
+    @ops([op_normal, op_skip, op_xfail, op_precision])
     def test_op(self, device, dtype, op):
-        if op.name == "dummy_op2":
-            self.fail("dummy_op2 should be skipped via op_skips")
-        if op.name == "dummy_op3":
-            # This should fail, but since we decorated it with expectedFailure, the test will pass!
-            self.fail("dummy_op3 fails but is decorated with expectedFailure")
         type(self)._executed[op.name] += 1
-
-    @ops([dummy_op4])
-    def test_op_precision_override(self, device, dtype, op):
-        """Verify that a precisionOverride registered via op_decorators takes
-        precedence over the one declared inside the OpInfo.
-
-        dummy_op4's OpInfo sets precisionOverride({torch.float32: 1e-5}).
-        PrivateUse1TestBase.op_decorators additionally registers
-        precisionOverride({torch.float32: 1e-2}) for dummy_op4.
-        Because op_decorators entries are appended *after* the OpInfo's own
-        decorators, the op_decorators value is the last to be applied and
-        therefore wins.
-        """
-        if dtype == torch.float32:
+        if op.name in ("op_skip", "op_xfail"):
+            self.fail(f"{op.name} deliberately fails")
+        if op.name == "op_precision" and dtype == torch.float32:
             self.assertEqual(
                 self.precision,
                 1e-2,
@@ -145,15 +123,14 @@ class TestDeviceTypeOpenReg(TestCase):
                     f"OpInfo precisionOverride (1e-5), but got {self.precision}"
                 ),
             )
-            type(self)._executed["dummy_op4_precision_ok"] += 1
 
-    @ops([dummy_op1])
+    @ops([op_normal])
     def test_op_narrow_ops(self, device, dtype, op):
         """Verify that having extra entries in op_skips that are NOT present in
         the @ops list does not raise a KeyError (safety check in update_op_list).
 
-        op_skips includes dummy_op2 and PrivateUse1TestBase.op_skips also
-        lists dummy_op2; here @ops only exposes dummy_op1.  The safety check
+        op_skips includes op_skip and PrivateUse1TestBase.op_skips also
+        lists op_skip; here @ops only exposes op_normal.  The safety check
         introduced in update_op_list must silently ignore the missing keys.
         """
         # If we reach here without a KeyError the safety check worked.
@@ -161,12 +138,13 @@ class TestDeviceTypeOpenReg(TestCase):
 
 # Modify PrivateUse1TestBase which is automatically included for OpenReg
 PrivateUse1TestBase.op_skips = {
-    "dummy_op2": [DecorateInfo(unittest.skip("skip dummy_op2"))],
+    "op_skip": [DecorateInfo(unittest.skip("skip op_skip"))],
+    "op_skip_f32": [DecorateInfo(unittest.skip("skip op_skip"), dtypes=(torch.float32,))],
 }
 PrivateUse1TestBase.op_decorators = {
-    "dummy_op3": [DecorateInfo(unittest.expectedFailure)],
-    # This overrides the 1e-5 precision already declared on dummy_op4's OpInfo.
-    "dummy_op4": [DecorateInfo(precisionOverride({torch.float32: 1e-2}))],
+    "op_xfail": [DecorateInfo(unittest.expectedFailure)],
+    # This overrides the 1e-5 precision already declared on op_precision's OpInfo.
+    "op_precision": [DecorateInfo(precisionOverride({torch.float32: 1e-2}))],
 }
 
 instantiate_device_type_tests(TestDeviceTypeOpenReg, globals(), only_for=("openreg",))

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
@@ -106,9 +106,6 @@ class TestDeviceTypeOpenReg(TestCase):
             )
         super().tearDownClass()
 
-    def test_normal(self, device):
-        pass
-
     @ops([op_normal, op_skip, op_skip_f32, op_xfail, op_precision])
     def test_op(self, device, dtype, op):
         if op.name in ("op_skip", "op_xfail"):

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
@@ -1,6 +1,7 @@
 # Owner(s): ["module: PrivateUse1"]
 
 import unittest
+from collections import defaultdict
 
 import torch
 import torch.testing._internal.common_device_type as common_device_type
@@ -9,6 +10,7 @@ from torch.testing._internal.common_device_type import (
     onlyCUDA,
     onlyOn,
     ops,
+    precisionOverride,
     PrivateUse1TestBase,
 )
 from torch.testing._internal.common_utils import run_tests, TestCase
@@ -67,9 +69,49 @@ dummy_op2 = OpInfo(
 dummy_op3 = OpInfo(
     "dummy_op3", op=lambda x: x, dtypes=common_device_type.get_all_dtypes()
 )
+# dummy_op4 starts with a low precision override (1e-5) declared in the OpInfo itself.
+# op_decorators will later register a higher override (1e-2) for float32 to verify
+# that the op_decorators entry takes precedence (because it is appended last to
+# op.decorators and therefore applied last, overwriting precision_overrides).
+dummy_op4 = OpInfo(
+    "dummy_op4",
+    op=lambda x: x,
+    dtypes=common_device_type.get_all_dtypes(),
+    decorators=[DecorateInfo(precisionOverride({torch.float32: 1e-5}))],
+)
 
 
 class TestDeviceTypeOpenReg(TestCase):
+    # Track which test variants actually executed so we can assert on them in
+    # tearDownClass and catch silent regressions (e.g. accidentally skipping
+    # all op variants or executing too few/many).
+    _executed: dict = defaultdict(int)
+
+    @classmethod
+    def tearDownClass(cls):
+        # dummy_op1: all dtypes must run (no skips/xfails).
+        if cls._executed["dummy_op1"] <= 0:
+            raise AssertionError(
+                "dummy_op1 tests should have run, but executed count is 0"
+            )
+        # dummy_op2: all variants are skipped, so the test body must never run.
+        if cls._executed["dummy_op2"] != 0:
+            raise AssertionError(
+                "dummy_op2 test body should never run because all variants are op_skipped"
+            )
+        # dummy_op3: all variants are expectedFailure, so the test body must always
+        # fail (and therefore never reach the counter increment).
+        if cls._executed["dummy_op3"] != 0:
+            raise AssertionError(
+                "dummy_op3 test body should always fail (expectedFailure), never increment counter"
+            )
+        # dummy_op4: op_decorators precisionOverride must have been applied.
+        if cls._executed["dummy_op4_precision_ok"] <= 0:
+            raise AssertionError(
+                "dummy_op4 float32 variant must have verified op_decorators precisionOverride wins"
+            )
+        super().tearDownClass()
+
     def test_normal(self, device):
         pass
 
@@ -80,6 +122,41 @@ class TestDeviceTypeOpenReg(TestCase):
         if op.name == "dummy_op3":
             # This should fail, but since we decorated it with expectedFailure, the test will pass!
             self.fail("dummy_op3 fails but is decorated with expectedFailure")
+        type(self)._executed[op.name] += 1
+
+    @ops([dummy_op4])
+    def test_op_precision_override(self, device, dtype, op):
+        """Verify that a precisionOverride registered via op_decorators takes
+        precedence over the one declared inside the OpInfo.
+
+        dummy_op4's OpInfo sets precisionOverride({torch.float32: 1e-5}).
+        PrivateUse1TestBase.op_decorators additionally registers
+        precisionOverride({torch.float32: 1e-2}) for dummy_op4.
+        Because op_decorators entries are appended *after* the OpInfo's own
+        decorators, the op_decorators value is the last to be applied and
+        therefore wins.
+        """
+        if dtype == torch.float32:
+            self.assertEqual(
+                self.precision,
+                1e-2,
+                msg=(
+                    f"Expected op_decorators precisionOverride (1e-2) to win over "
+                    f"OpInfo precisionOverride (1e-5), but got {self.precision}"
+                ),
+            )
+            type(self)._executed["dummy_op4_precision_ok"] += 1
+
+    @ops([dummy_op1])
+    def test_op_narrow_ops(self, device, dtype, op):
+        """Verify that having extra entries in op_skips that are NOT present in
+        the @ops list does not raise a KeyError (safety check in update_op_list).
+
+        op_skips includes dummy_op2 and PrivateUse1TestBase.op_skips also
+        lists dummy_op2; here @ops only exposes dummy_op1.  The safety check
+        introduced in update_op_list must silently ignore the missing keys.
+        """
+        # If we reach here without a KeyError the safety check worked.
 
 
 # Modify PrivateUse1TestBase which is automatically included for OpenReg
@@ -88,6 +165,8 @@ PrivateUse1TestBase.op_skips = {
 }
 PrivateUse1TestBase.op_decorators = {
     "dummy_op3": [DecorateInfo(unittest.expectedFailure)],
+    # This overrides the 1e-5 precision already declared on dummy_op4's OpInfo.
+    "dummy_op4": [DecorateInfo(precisionOverride({torch.float32: 1e-2}))],
 }
 
 instantiate_device_type_tests(TestDeviceTypeOpenReg, globals(), only_for=("openreg",))

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
@@ -139,7 +139,9 @@ class TestDeviceTypeOpenReg(TestCase):
 # Modify PrivateUse1TestBase which is automatically included for OpenReg
 PrivateUse1TestBase.op_skips = {
     "op_skip": [DecorateInfo(unittest.skip("skip op_skip"))],
-    "op_skip_f32": [DecorateInfo(unittest.skip("skip op_skip"), dtypes=(torch.float32,))],
+    "op_skip_f32": [
+        DecorateInfo(unittest.skip("skip op_skip"), dtypes=(torch.float32,))
+    ],
 }
 PrivateUse1TestBase.op_decorators = {
     "op_xfail": [DecorateInfo(unittest.expectedFailure)],

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
@@ -109,7 +109,7 @@ class TestDeviceTypeOpenReg(TestCase):
     def test_normal(self, device):
         pass
 
-    @ops([op_normal, op_skip, op_xfail, op_precision])
+    @ops([op_normal, op_skip, op_skip_f32, op_xfail, op_precision])
     def test_op(self, device, dtype, op):
         if op.name in ("op_skip", "op_xfail"):
             self.fail(f"{op.name} deliberately fails")

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
@@ -111,7 +111,6 @@ class TestDeviceTypeOpenReg(TestCase):
 
     @ops([op_normal, op_skip, op_xfail, op_precision])
     def test_op(self, device, dtype, op):
-        type(self)._executed[op.name] += 1
         if op.name in ("op_skip", "op_xfail"):
             self.fail(f"{op.name} deliberately fails")
         if op.name == "op_precision" and dtype == torch.float32:
@@ -123,6 +122,7 @@ class TestDeviceTypeOpenReg(TestCase):
                     f"OpInfo precisionOverride (1e-5), but got {self.precision}"
                 ),
             )
+        type(self)._executed[op.name] += 1
 
     @ops([op_normal])
     def test_op_narrow_ops(self, device, dtype, op):

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -335,8 +335,7 @@ class DeviceTypeTestBase(TestCase):
     # These are intentionally placed on DeviceTypeTestBase (rather than solely on
     # PrivateUse1TestBase) so that in-tree backends can adopt the same mechanism
     # in the future.
-    op_decorators = None  # type: Optional[dict[str, list[DecorateInfo]]]
-    op_skips = None  # type: Optional[dict[str, list[DecorateInfo]]]
+    op_overrides = None  # type: Optional[dict[str, list[DecorateInfo]]]
 
     # Flag to disable test suite early due to unrecoverable error such as CUDA error.
     _stop_test_suite = False
@@ -364,40 +363,22 @@ class DeviceTypeTestBase(TestCase):
 
     @classmethod
     def _apply_op_overrides(cls, ops):
-        if cls.op_decorators is None and cls.op_skips is None:
+        if cls.op_overrides is None:
             return
 
         op_dict = {op.full_name: op for op in copy.deepcopy(ops.op_list)}
 
-        if cls.op_decorators is not None:
-            for op_name, decorators in cls.op_decorators.items():
+        if cls.op_overrides is not None:
+            for op_name, decorators in cls.op_overrides.items():
                 for decorator in decorators:
                     if cls.device_type == "privateuse1":
                         decorator.device_type = torch._C._get_privateuse1_backend_name()
                     else:
                         decorator.device_type = cls.device_type
                     # op_name may not be in op_dict if @ops() has restricted the
-                    # OpInfo list to a smaller set than op_decorators covers.
+                    # OpInfo list to a smaller set than op_overrides covers.
                     if op_name in op_dict:
                         op_dict[op_name].decorators += (decorator,)
-
-        if cls.op_skips is not None:
-            for op_name, skips in cls.op_skips.items():
-                for skip in skips:
-                    if cls.device_type == "privateuse1":
-                        skip.device_type = torch._C._get_privateuse1_backend_name()
-                    else:
-                        skip.device_type = cls.device_type
-                    # op_name may not be in op_dict if @ops() has restricted the
-                    # OpInfo list to a smaller set than op_skips covers.
-                    if op_name in op_dict:
-                        # We must add to both .skips and .decorators because
-                        # OpInfo.__post_init__ has already executed and folded the
-                        # original .skips into .decorators (see OpInfo.__post_init__).
-                        # Only .decorators is consulted by ops._parametrize_test, so
-                        # adding to .skips alone would have no effect at this point.
-                        op_dict[op_name].skips += (skip,)
-                        op_dict[op_name].decorators += (skip,)
 
         ops.op_list = list(op_dict.values())
 

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -363,7 +363,7 @@ class DeviceTypeTestBase(TestCase):
         self._tls.rel_tol = prec
 
     @classmethod
-    def update_op_list(cls, ops):
+    def _apply_op_overrides(cls, ops):
         if cls.op_decorators is None and cls.op_skips is None:
             return
 
@@ -1144,7 +1144,7 @@ class ops(_TestParametrizer):
                 "instantiate_parametrized_tests()"
             )
 
-        device_cls.update_op_list(self)
+        device_cls._apply_op_overrides(self)
         op = check_exhausted_iterator = object()
         for op in self.op_list:
             # Determine the set of dtypes to use.

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -329,10 +329,9 @@ class DeviceTypeTestBase(TestCase):
 
     # Decorators and skips to apply to tests that are parametrized by ops.
     # Keys are OpInfo.full_name (e.g. "op" or "linalg.norm"), NOT OpInfo.name.
-    # Note that OpInfo.full_name and OpInfo.name differ for namespaced ops:
-    # OpInfo.name omits the namespace prefix, while OpInfo.full_name includes it.
-    # Values are lists of DecorateInfo objects, each of which may target a
-    # specific device type or dtype.
+    # Note that OpInfo.full_name and OpInfo.name have difference: OpInfo.full_name
+    # includes the variant suffix (e.g., "div.floor_rounding") if it has, otherwise,
+    # OpInfo.full_name identical to OpInfo.name.
     # These are intentionally placed on DeviceTypeTestBase (rather than solely on
     # PrivateUse1TestBase) so that in-tree backends can adopt the same mechanism
     # in the future.

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -328,6 +328,14 @@ class DeviceTypeTestBase(TestCase):
     bypass_device_restrictions: bool = False
 
     # Decorators and skips to apply to tests that are parametrized by ops.
+    # Keys are OpInfo.full_name (e.g. "op" or "linalg.norm"), NOT OpInfo.name.
+    # Note that OpInfo.full_name and OpInfo.name differ for namespaced ops:
+    # OpInfo.name omits the namespace prefix, while OpInfo.full_name includes it.
+    # Values are lists of DecorateInfo objects, each of which may target a
+    # specific device type or dtype.
+    # These are intentionally placed on DeviceTypeTestBase (rather than solely on
+    # PrivateUse1TestBase) so that in-tree backends can adopt the same mechanism
+    # in the future.
     op_decorators = None  # type: Optional[dict[str, list[DecorateInfo]]]
     op_skips = None  # type: Optional[dict[str, list[DecorateInfo]]]
 
@@ -369,7 +377,10 @@ class DeviceTypeTestBase(TestCase):
                         decorator.device_type = torch._C._get_privateuse1_backend_name()
                     else:
                         decorator.device_type = cls.device_type
-                    op_dict[op_name].decorators += (decorator,)
+                    # op_name may not be in op_dict if @ops() has restricted the
+                    # OpInfo list to a smaller set than op_decorators covers.
+                    if op_name in op_dict:
+                        op_dict[op_name].decorators += (decorator,)
 
         if cls.op_skips is not None:
             for op_name, skips in cls.op_skips.items():
@@ -378,8 +389,16 @@ class DeviceTypeTestBase(TestCase):
                         skip.device_type = torch._C._get_privateuse1_backend_name()
                     else:
                         skip.device_type = cls.device_type
-                    op_dict[op_name].skips += (skip,)
-                    op_dict[op_name].decorators += (skip,)
+                    # op_name may not be in op_dict if @ops() has restricted the
+                    # OpInfo list to a smaller set than op_skips covers.
+                    if op_name in op_dict:
+                        # We must add to both .skips and .decorators because
+                        # OpInfo.__post_init__ has already executed and folded the
+                        # original .skips into .decorators (see OpInfo.__post_init__).
+                        # Only .decorators is consulted by ops._parametrize_test, so
+                        # adding to .skips alone would have no effect at this point.
+                        op_dict[op_name].skips += (skip,)
+                        op_dict[op_name].decorators += (skip,)
 
         ops.op_list = list(op_dict.values())
 

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -327,6 +327,10 @@ class DeviceTypeTestBase(TestCase):
     # device-generic and removing @onlyCUDA on tests that should be device-generic.
     bypass_device_restrictions: bool = False
 
+    # Decorators and skips to apply to tests that are parametrized by ops.
+    op_decorators = None  # type: Optional[dict[str, list[DecorateInfo]]]
+    op_skips = None  # type: Optional[dict[str, list[DecorateInfo]]]
+
     # Flag to disable test suite early due to unrecoverable error such as CUDA error.
     _stop_test_suite = False
 
@@ -350,6 +354,31 @@ class DeviceTypeTestBase(TestCase):
     @rel_tol.setter
     def rel_tol(self, prec):
         self._tls.rel_tol = prec
+
+    @classmethod
+    def update_op_list(cls, ops):
+        op_dict = {op.full_name: op for op in copy.deepcopy(ops.op_list)}
+
+        if cls.op_decorators is not None:
+            for op_name, decorators in cls.op_decorators.items():
+                for decorator in decorators:
+                    if cls.device_type == "privateuse1":
+                        decorator.device_type = torch._C._get_privateuse1_backend_name()
+                    else:
+                        decorator.device_type = cls.device_type
+                    op_dict[op_name].decorators += (decorator,)
+
+        if cls.op_skips is not None:
+            for op_name, skips in cls.op_skips.items():
+                for skip in skips:
+                    if cls.device_type == "privateuse1":
+                        skip.device_type = torch._C._get_privateuse1_backend_name()
+                    else:
+                        skip.device_type = cls.device_type
+                    op_dict[op_name].skips += (skip,)
+                    op_dict[op_name].decorators += (skip,)
+
+        ops.op_list = list(op_dict.values())
 
     # Returns a string representing the device that single device tests should use.
     # Note: single device tests use this device exclusively.
@@ -1094,6 +1123,7 @@ class ops(_TestParametrizer):
                 "instantiate_parametrized_tests()"
             )
 
+        device_cls.update_op_list(self)
         op = check_exhausted_iterator = object()
         for op in self.op_list:
             # Determine the set of dtypes to use.

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -357,6 +357,9 @@ class DeviceTypeTestBase(TestCase):
 
     @classmethod
     def update_op_list(cls, ops):
+        if cls.op_decorators is None and cls.op_skips is None:
+            return
+
         op_dict = {op.full_name: op for op in copy.deepcopy(ops.op_list)}
 
         if cls.op_decorators is not None:


### PR DESCRIPTION
- https://github.com/pytorch/pytorch/issues/174469
Fixes https://github.com/pytorch/pytorch/issues/177256 

## Summary
This pull request enhances the device type test infrastructure to allow device-specific decorators and skips for operator tests, and demonstrates this with a new test for the Open Registration (PrivateUse1) extension. The main improvements are the introduction of `op_overrides` hook, and new tests in `test_testing.py` that exercises these features for custom backend scenarios.

**Device-specific test customization:**

* Added `op_overrides` class attribute to `DeviceTypeTestBase`, enabling device-specific decorators (like `expectedFailure`) and skips to be applied to operator tests.
* Implemented `_apply_op_overrides` class method to apply these decorators and skips to the relevant operator tests, handling device type mapping (including custom backends like PrivateUse1).
* Integrated `_apply_op_overrides` into the test parametrization process to ensure operator test configurations are updated before test instantiation.