### PR TITLE
Fix torch.tensor defaulting to CPU under torch.compile when torch.set_default_device is used

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -14603,6 +14603,29 @@ class MiscTestsDevice(torch._inductor.test_case.TestCase):
         x = torch.zeros(4, 4)
         f(x)
 
+    def test_tensor_default_device(self, device):
+        def fn():
+            t1 = torch.tensor([1.0, 2.0])
+            t2 = torch.as_tensor([1.0, 2.0])
+            t3 = torch.scalar_tensor(1.0)
+            t4 = torch.asarray([1.0, 2.0])
+            return t1, t2, t3, t4
+
+        old_device = torch.get_default_device()
+        try:
+            torch.set_default_device(device)
+            expected = fn()
+
+            opt_fn = torch.compile(backend="eager", fullgraph=True)(fn)
+            actual = opt_fn()
+        finally:
+            torch.set_default_device(old_device)
+
+        for a, e in zip(actual, expected):
+            self.assertEqual(a.device, e.device)
+            self.assertEqual(a.device.type, torch.device(device).type)
+            self.assertTrue(torch.allclose(a, e))
+
     def test_dynamic_float_scalar_tensor_coersion(self):
         # Minified version of https://github.com/pytorch/pytorch/issues/158376#issuecomment-3079591367
         class Foo:

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -358,6 +358,10 @@ def get_overridable_functions() -> set[Callable[..., Any]]:
         torch.zeros_like,
         torch.empty,
         torch.full,
+        torch.tensor,
+        torch.as_tensor,
+        torch.scalar_tensor,
+        torch.asarray,
     }
     funcs.update(more)
     return funcs


### PR DESCRIPTION
Fixes #175953
### Description
Currently, when `torch.set_default_device("cuda")` is set globally, `torch.tensor(...)` respects this in eager mode but defaults to CPU under `torch.compile`. This mismatch causes fake tensor device incompatibility errors during tracing.
The root cause is that Dynamo restricts [__torch_function__](cci:1://file:///home/nosferatu/pytorch/test/dynamo/test_modes.py:493:12-499:76) overrides exclusively to operations explicitly listed in [get_overridable_functions()](cci:1://file:///home/nosferatu/pytorch/torch/_dynamo/variables/torch.py:346:0-366:16). Since `torch.tensor`, `torch.as_tensor`, and `torch.scalar_tensor` are builtin Python-C functions rather than `OpOverloads`, they lacked authorization to dispatch to `DeviceContext.__torch_function__`, causing them to silently fallback to their native CPU defaults.
This PR fixes this by appending `torch.tensor`, `torch.as_tensor`, `torch.scalar_tensor`, and `torch.asarray` to the `more` set configured within [torch/_dynamo/variables/torch.py](cci:7://file:///home/nosferatu/pytorch/torch/_dynamo/variables/torch.py:0:0-0:0)'s [get_overridable_functions()](cci:1://file:///home/nosferatu/pytorch/torch/_dynamo/variables/torch.py:346:0-366:16). 
As a result, the active [DeviceContext](cci:2://file:///home/nosferatu/pytorch/torch/utils/_device.py:60:0-114:36) properly intercepts trace-time invocations via [__torch_function__](cci:1://file:///home/nosferatu/pytorch/test/dynamo/test_modes.py:493:12-499:76) and injects the correct global device keyword.
### Testing
- Added [test_tensor_default_device](cci:1://file:///home/nosferatu/pytorch/test/dynamo/test_misc.py:14605:4-14624:49) parameterized unit tests in `test/dynamo/test_misc.py`.
- Verified the fix locally using the reproducer from the issue.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Lucaskabela @azahed98