### PR TITLE
Fix SIGSEGV on AMD RDNA (Wave32) from removed reduction masks in persistent kernels

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -16635,6 +16635,41 @@ if RUN_GPU:
                 self.assertTrue("ymask = yindex < ynumel" in code)
                 self.assertTrue("xmask = xindex < xnumel" in code)
 
+        @parametrize(
+            "rnumel",
+            [16, 32],
+        )
+        @config.patch("triton.persistent_reductions", True)
+        def test_has_constant_mask_small_persistent_reduction(self, rnumel):
+            from torch._inductor.runtime.hints import DeviceProperties
+
+            def fn(x):
+                return x.sum(dim=-1)
+
+            x = torch.randn(1024, rnumel, device=GPU_TYPE)
+            opt_fn = torch.compile(fn)
+            code = run_and_get_triton_code(opt_fn, x)
+
+            device = torch.device(GPU_TYPE, 0)
+            warp_size = DeviceProperties.create(device).warp_size or 32
+
+            rblock = 1
+            while rblock < rnumel:
+                rblock *= 2
+
+            if rblock < warp_size:
+                self.assertTrue(
+                    "r0_index < r0_numel" in code or "rindex < rnumel" in code,
+                    f"Expected dynamic reduction mask for RBLOCK={rblock} < warp_size={warp_size}",
+                )
+            else:
+                self.assertTrue(
+                    "r0_mask = tl.full" in code or "rmask = tl.full" in code,
+                    f"Expected constant reduction mask for RBLOCK={rblock} >= warp_size={warp_size}",
+                )
+
+            self.assertEqual(fn(x), opt_fn(x))
+
         @config.patch("triton.native_matmul", False)
         def test_kernel_names_descriptive(self):
             @torch.compile(backend="inductor")

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -5894,7 +5894,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             max_block = self._get_persistent_RBLOCK(tree.numel)
             # Triton's auto-tuner can map a full hardware warp along the
             # reduction axis.  When RBLOCK < warp_size the excess lanes
-            # would execute out-of-bounds global loads.  This results in 
+            # would execute out-of-bounds global loads.  This results in
             # faults on AMD hardware.  Keep the dynamic mask so that all
             # hardware stays correct.
             device = V.graph.get_current_device_or_throw()

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -5885,12 +5885,22 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 return True
         elif not self.is_combo_kernel:
             if V.graph.sizevars.statically_known_equals(tree.numel, 1):
-                return True
+                if not (tree.is_reduction and self.persistent_reduction):
+                    return True
 
         # Masks are superfluous if numel is a multiple of BLOCK
         # (We use the fact that BLOCK is required by triton to be a power of 2)
         if tree.is_reduction and self.persistent_reduction:
             max_block = self._get_persistent_RBLOCK(tree.numel)
+            # Triton's auto-tuner can map a full hardware warp along the
+            # reduction axis.  When RBLOCK < warp_size the excess lanes
+            # would execute out-of-bounds global loads.  NVIDIA silently
+            # returns 0 for such loads, but AMD (RDNA) faults.  Keep the
+            # dynamic mask so that all hardware stays correct.
+            device = V.graph.get_current_device_or_throw()
+            warp_size = DeviceProperties.create(device).warp_size or 32
+            if isinstance(max_block, int) and max_block < warp_size:
+                return False
         elif tree.prefix == "x" and self.no_x_dim:
             max_block = 1
         else:

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -5894,9 +5894,9 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             max_block = self._get_persistent_RBLOCK(tree.numel)
             # Triton's auto-tuner can map a full hardware warp along the
             # reduction axis.  When RBLOCK < warp_size the excess lanes
-            # would execute out-of-bounds global loads.  NVIDIA silently
-            # returns 0 for such loads, but AMD (RDNA) faults.  Keep the
-            # dynamic mask so that all hardware stays correct.
+            # would execute out-of-bounds global loads.  This results in 
+            # faults on AMD hardware.  Keep the dynamic mask so that all
+            # hardware stays correct.
             device = V.graph.get_current_device_or_throw()
             warp_size = DeviceProperties.create(device).warp_size or 32
             if isinstance(max_block, int) and max_block < warp_size:

--- a/torch/_inductor/runtime/triton_compat.py
+++ b/torch/_inductor/runtime/triton_compat.py
@@ -150,11 +150,10 @@ else:
 
 def cc_warp_size(cc: str | int) -> int:
     if torch.version.hip:
-        cc_str = str(cc)
-        if "gfx10" in cc_str or "gfx11" in cc_str:
-            return 32
-        else:
+        if "gfx9" in str(cc):
             return 64
+        else:
+            return 32
     else:
         return 32
 


### PR DESCRIPTION
## Summary

Persistent reductions with small `rnumel` (< warp size) can crash with a segmentation fault on AMD RDNA GPUs. The root cause is that Inductor's `_has_constant_mask` optimization removes the bounds-checking mask when `rnumel` evenly divides `RBLOCK`, under the assumption that all lanes will access valid memory. This assumption breaks when `RBLOCK < warp_size`,
because Triton maps a full hardware warp along the reduction axis -- the excess lanes execute out-of-bounds global loads. On NVIDIA hardware these loads silently return zero, but on AMD RDNA (which uses Wave32) they raise a memory access fault (`SIGSEGV`).

### Changes

**`torch/_inductor/codegen/triton.py`** -- two fixes in `_has_constant_mask`:

1. The early-return for `numel == 1` unconditionally returned `True` (constant mask). For persistent reductions `RBLOCK` can be larger than 1 even when `rnumel == 1`, so the mask must be preserved. This is now guarded so the early return is skipped for persistent reductions, allowing the code to fall through to the warp-size check.

2. The main divisibility check (`numel % RBLOCK == 0`) would drop the mask whenever `RBLOCK` is a power-of-2 ceiling of `rnumel`. A new guard queries the device's actual warp size via `DeviceProperties` and returns `False` (keep dynamic mask) when `RBLOCK < warp_size`. This only affects the small-reduction corner case and has no impact on the common path where `RBLOCK >= warp_size`.

**`torch/_inductor/runtime/triton_compat.py`** -- `cc_warp_size` now explicitly recognizes `gfx12` (RDNA4) as Wave32. Previously this was incorrectly falling back to `64` in the `else` branch.

## Test plan

- Added `test_has_constant_mask_small_persistent_reduction` to `TritonCodeGenTests`, parametrized over `rnumel` in {16, 32}. The test inspects the generated Triton code to verify that:
  - `rnumel=16` (RBLOCK=16 < warp_size=32) retains a dynamic reduction mask (`r0_index < r0_numel`).
  - `rnumel=32` (RBLOCK=32 >= warp_size=32, exact multiple) uses a constant mask (`r0_mask = tl.full`), confirming the optimization still applies when safe.
  - Both cases verify numerical correctness via `assertEqual`.
- Confirmed the `rnumel=16` case fails without the fix and passes with it.
- Reproduced the original `SIGSEGV` on AMD gfx1201 (RDNA4, Wave32) using an Unsloth EmbeddingGemma-300M fine-tuning workload with various batch sizes. Verified the fix eliminates the crash across all previously failing configurations.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo