### PR TITLE
[FUNCTORCH] Fix batch rules for group norm backward operator.

### DIFF
--- a/aten/src/ATen/functorch/BatchRulesNorm.cpp
+++ b/aten/src/ATen/functorch/BatchRulesNorm.cpp
@@ -351,7 +351,7 @@ static at::Tensor group_norm_backward_no_weight_bias_batch_rule(
   auto rstd_ = moveBatchDimToFront(rstd, rstd_bdim);
 
   const auto bdim_size = get_bdim_size2(grad_out, grad_out_bdim, input, input_bdim);
-  grad_out_ = ensure_has_bdim(grad_out, grad_out_bdim.has_value(), bdim_size);
+  grad_out_ = ensure_has_bdim(grad_out_, grad_out_bdim.has_value(), bdim_size);
   input_ = ensure_has_bdim(input_, input_bdim.has_value(), bdim_size);
   mean_ = ensure_has_bdim(mean_, mean_bdim.has_value(), bdim_size);
   rstd_ = ensure_has_bdim(rstd_, rstd_bdim.has_value(), bdim_size);

--- a/test/functorch/test_vmap.py
+++ b/test/functorch/test_vmap.py
@@ -4946,6 +4946,7 @@ class TestVmapOperatorsOpInfo(TestCase):
         test(self, op, (x, 4, weight, bias), in_dims=(0, None, 0, 0))
 
     def test_group_norm_layout_corruption(self, device):
+        # Regression test for https://github.com/pytorch/pytorch/issues/176432
         def op_function(cotangent):
             input = torch.tensor([[-6.517, -6.264]], device=device, requires_grad=True)
             result = F.group_norm(input, num_groups=1)

--- a/test/functorch/test_vmap.py
+++ b/test/functorch/test_vmap.py
@@ -4945,6 +4945,22 @@ class TestVmapOperatorsOpInfo(TestCase):
         bias = torch.randn(B, C)
         test(self, op, (x, 4, weight, bias), in_dims=(0, None, 0, 0))
 
+    def test_group_norm_layout_corruption(self, device):
+        def op_function(cotangent):
+            input = torch.tensor([[-6.517, -6.264]], device=device, requires_grad=True)
+            result = F.group_norm(input, num_groups=1)
+            return torch.autograd.grad(result, input, grad_outputs=cotangent)[0]
+
+        cotangent = torch.tensor([[-0.0236, -0.1431]], device=device)
+        result_in_dims_0 = vmap(op_function, in_dims=0)(
+            cotangent.unsqueeze(0).expand(2, -1, -1)
+        )
+        result_in_dims_neg1 = vmap(op_function, in_dims=-1)(
+            cotangent.unsqueeze(-1).expand(-1, -1, 2)
+        )
+
+        self.assertEqual(result_in_dims_0, result_in_dims_neg1)
+
     def test_index_put(self, device):
         def test(f, t, idx, values):
             base = f(t[0], idx[0], values[0])


### PR DESCRIPTION
Fixes: #176432 

This PR fixes very simple bug, where wrong variable name was present since the beginning.
This bug shows only in some very specific conditions and works correctly for most cases.

Related code fragment:
```cpp
auto grad_out_ = moveBatchDimToFront(grad_out, grad_out_bdim);
auto input_ = moveBatchDimToFront(input, input_bdim);
auto mean_ = moveBatchDimToFront(mean, mean_bdim);
auto rstd_ = moveBatchDimToFront(rstd, rstd_bdim);

const auto bdim_size = get_bdim_size2(grad_out, grad_out_bdim, input, input_bdim);
grad_out_ = ensure_has_bdim(grad_out, grad_out_bdim.has_value(), bdim_size);
input_ = ensure_has_bdim(input_, input_bdim.has_value(), bdim_size);
mean_ = ensure_has_bdim(mean_, mean_bdim.has_value(), bdim_size);
rstd_ = ensure_has_bdim(rstd_, rstd_bdim.has_value(), bdim_size);
```

It first performs `moveBatchDimToFront` operation on `grad_out`:
```cpp
auto grad_out_ = moveBatchDimToFront(grad_out, grad_out_bdim);
```

but then it was using the old value, before processing instead of the processed one:
```cpp
grad_out_ = ensure_has_bdim(grad_out, grad_out_bdim.has_value(), bdim_size);
```

so the fix was to use already processed `grad_out_` instead of original function input `grad_out`:
```cpp
grad_out_ = ensure_has_bdim(grad_out_, grad_out_bdim.has_value(), bdim_size);
```

## Example

In my case, the problem appeared when `vmap` was used with `in_dims=-1` parameter for tensor with shape `(1, 2)` with batch size `2`.

If the original tensor was: `[A, B]`
Then after expanding it to 2 batches with `vmap` using `in_dims=-1` the layout was: `[A, A, B, B]`
Then `moveBatchDimToFront` was correctly transforming it to layout `[A, B, A, B]`
But as `ensure_has_bdim` was using the original function input (`grad_out` instead of `grad_out_`), the wrong layout was used for further processing.

So basically the line:
```cpp
auto grad_out_ = moveBatchDimToFront(grad_out, grad_out_bdim);
```
was always needed to ensure correct behavior in all cases, but was never used.

#### Test

I added test case that verifies this, but I am not sure if that is necessary in this case where the issue was that simply wrong variable name was used.
