### PR TITLE
[TESTING] Skipped ROCm tests failing with triton 3.7 release

### DIFF
--- a/test/distributed/tensor/test_attention.py
+++ b/test/distributed/tensor/test_attention.py
@@ -688,6 +688,7 @@ class CPFlexAttentionTest(DTensorTestBase):
     @unittest.skipIf(
         not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Does not support flash attention"
     )
+    @skipIfRocm(msg="Fails with Triton 3.7")
     def test_cp_flex_attention_document_mask(self) -> None:
         random.seed(10)
 

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -95,6 +95,7 @@ from torch.testing._internal.common_utils import (
     set_default_dtype,
     skipIfHpu,
     skipIfNNModuleInlined,
+    skipIfRocm,
     skipIfWindows,
     subtest,
     TEST_HPU,
@@ -244,6 +245,7 @@ class MiscTests(torch._inductor.test_case.TestCase):
         self.assertTrue(same(val4, correct1))
         self.assertEqual(counter.frame_count, 3)
 
+    @skipIfRocm(msg="Flaky with Triton 3.7")
     @unittest.skipIf(not TEST_CUDA, "cuda needed")
     def test_assume_32_bit_indexing(self):
         @torch.compile(backend="inductor")

--- a/test/dynamo/test_structured_trace.py
+++ b/test/dynamo/test_structured_trace.py
@@ -21,7 +21,7 @@ import torch.fx as fx
 from torch._inductor.test_case import TestCase
 from torch._logging._internal import TorchLogsFormatter
 from torch.nn.parallel import DistributedDataParallel as DDP
-from torch.testing._internal.common_utils import find_free_port
+from torch.testing._internal.common_utils import find_free_port, skipIfRocm
 from torch.testing._internal.triton_utils import requires_cuda_and_triton
 
 
@@ -802,6 +802,7 @@ class StructuredTraceTest(TestCase):
 
         self.assertParses()
 
+    @skipIfRocm(msg="Fails with Triton 3.7")
     @requires_tlparse
     @unittest.skip("https://github.com/pytorch/pytorch/issues/176188")
     def test_graph_breaks(self):

--- a/test/functorch/test_ops.py
+++ b/test/functorch/test_ops.py
@@ -996,6 +996,8 @@ class TestOperators(TestCase):
                 ),  # derivate not implemented for _ctc_loss_backward
                 # flaky on ROCM needs investigation
                 decorate("nn.functional.conv_transpose2d", decorator=skipIfRocm),
+                # Flaky with triton 3.7
+                decorate("nn.functional.conv3d", decorator=skipIfRocm),
                 skip("nn.functional.dropout"),  # calls random op
                 skip("nn.functional.dropout2d"),  # calls random op
                 skip("nn.functional.dropout3d"),  # calls random op

--- a/test/functorch/test_vmap.py
+++ b/test/functorch/test_vmap.py
@@ -69,6 +69,7 @@ from torch.testing._internal.common_utils import (
     markDynamoStrictTest,
     parametrize,
     run_tests,
+    skipIfRocm,
     skipIfTorchDynamo,
     subtest,
     TEST_WITH_TORCHDYNAMO,
@@ -4436,6 +4437,7 @@ class TestVmapOperatorsOpInfo(TestCase):
             }
         ),
     )
+    @skipIfRocm(msg="Fails with Triton 3.7 on MI200")
     def test_vmap_exhaustive(self, device, dtype, op):
         # needs to be fixed
         inplace_failure_list = ()

--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -257,6 +257,7 @@ class AOTInductorTestsTemplate:
         "toolchain doesn't support ptx to fatbin",
     )
     @skipIfMPS
+    @skipIfRocm(msg="Fails with Triton 3.7")
     # Skip embed_kernel_binary == True for now as it shows random
     # failure on CI
     @common_utils.parametrize("embed_kernel_binary", [False])
@@ -3506,6 +3507,7 @@ class AOTInductorTestsTemplate:
         example_inputs = (torch.randn(3, 10, device=self.device),)
         self.check_model(Model(), example_inputs)
 
+    @skipIfRocm(msg="Fails with Triton 3.7")
     @skipIfRocmArch(NAVI_ARCH)  # regression on ROCm 7.2
     def test_repeated_calling(self):
         if self.device != "cuda":

--- a/test/inductor/test_aot_inductor_package.py
+++ b/test/inductor/test_aot_inductor_package.py
@@ -32,7 +32,7 @@ from torch.testing._internal.common_cuda import (
     requires_triton_ptxas_compat,
     TRITON_PTXAS_VERSION,
 )
-from torch.testing._internal.common_utils import IS_FBCODE, TEST_CUDA
+from torch.testing._internal.common_utils import IS_FBCODE, skipIfRocm, TEST_CUDA
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
 
 
@@ -319,6 +319,7 @@ class TestAOTInductorPackage(TestCase):
                 self.assertTrue(torch.allclose(actual, expected))
 
     @requires_triton_ptxas_compat
+    @skipIfRocm(msg="Fails with Triton 3.7")
     @unittest.skipIf(IS_FBCODE, "cmake won't work in fbcode")
     def test_compile_after_package_multi_arch(self):
         if self.device != GPU_TYPE:

--- a/test/inductor/test_ck_backend.py
+++ b/test/inductor/test_ck_backend.py
@@ -16,9 +16,8 @@ from torch._inductor.utils import try_import_ck_lib
 from torch.testing._internal.common_cuda import tf32_off
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
-    MI350_ARCH,
     parametrize,
-    skipIfRocmArch,
+    skipIfRocm,
 )
 from torch.testing._internal.inductor_utils import (
     _quantize_rowwise,
@@ -241,8 +240,8 @@ class TestCKBackend(TestCase):
             Y_eager = a @ b
             torch.testing.assert_close(Y_compiled, Y_eager, equal_nan=True)
 
-    # regression in ROCm 7.2, Mismatched elements, significantly
-    @skipIfRocmArch(MI350_ARCH)
+    # No valid choices error
+    @skipIfRocm(msg="Fails with Triton 3.7")
     @unittest.skipIf(not torch.version.hip, "ROCM only")
     @unittest.mock.patch.dict(os.environ, _test_env)
     @parametrize("max_autotune_gemm_backends", ("CK", "ATen,Triton,CK"))

--- a/test/inductor/test_combo_kernels.py
+++ b/test/inductor/test_combo_kernels.py
@@ -410,6 +410,7 @@ class ComboKernelTests(TestCase):
         self.assertEqual(torch._inductor.metrics.generated_kernel_count, 2)
 
     @skipIfXpu(msg="Profiler JSON traceEvents is not supported on XPU")
+    @skipIfRocm(msg="Fails with Triton 3.7")
     @requires_gpu_and_triton
     def test_combo_kernel_per_config_subkernel_block_size(self):
         from torch.profiler import ProfilerActivity
@@ -489,6 +490,7 @@ class ComboKernelTests(TestCase):
             FileCheck().check("pid_offset = pid").run(code[0])
 
     @skipIfXpu(msg="Profiler JSON traceEvents is not supported on XPU")
+    @skipIfRocm(msg="Fails with Triton 3.7")
     @requires_gpu_and_triton
     @torch._dynamo.config.patch("assume_static_by_default", False)
     def test_combo_kernel_dynamic_shapes_grid_changes(self):
@@ -569,6 +571,7 @@ class ComboKernelTests(TestCase):
             )
 
     @skipIfXpu(msg="Profiler JSON traceEvents is not supported on XPU")
+    @skipIfRocm(msg="Fails with Triton 3.7")
     @requires_gpu_and_triton
     @unittest.skipIf(not SM90OrLater, "Avoid oom on CI")
     def test_combo_kernel_yz_overflow(self):

--- a/test/inductor/test_compiled_autograd.py
+++ b/test/inductor/test_compiled_autograd.py
@@ -46,6 +46,7 @@ from torch.testing._internal.common_utils import (
     scoped_load_inline,
     skipIfWindows,
     skipIfXpu,
+    TEST_WITH_ROCM,
 )
 from torch.testing._internal.hop_db import hop_db
 from torch.testing._internal.inductor_utils import (
@@ -5412,6 +5413,10 @@ if IS_S390X:
 skipped_tests.add("test_clear_saved_tensors_on_access")
 skipped_tests.add("test_clear_saved_tensors_on_access_double_access_error")
 skipped_tests.add("test_forward_traceback_preserves_exception_with_checkpoint")
+
+# Fails with triton 3.7
+if TEST_WITH_ROCM:
+    skipped_tests.add("test_concat_unbacked_shape_tensor")
 
 test_autograd = load_test_module("test_autograd")
 test_custom_ops = load_test_module("test_custom_ops")

--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -36,6 +36,7 @@ from torch.testing._internal.common_utils import (
     IS_MACOS,
     MI200_ARCH,
     parametrize,
+    skipIfRocm,
     skipIfRocmArch,
     slowTest,
     TEST_MKL,
@@ -5121,6 +5122,7 @@ class CPUReproTests(TestCase):
                     "at::vec::VectorizedN<double,2>::loadu", 2, exactly=True
                 ).run(code)
 
+    @skipIfRocm(msg="Fails with Triton 3.7")
     def test_convert_fp32_to_double_vec(self):
         def fn(x):
             return x.to(torch.double)

--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -2012,6 +2012,7 @@ class CudaReproTests(TestCase):
         self.assertEqual(graph.device_types, {"cuda"})
         self.assertEqual(compiled_fn(*inp), fn(*inp))
 
+    @skipIfRocm(msg="Fails with Triton 3.7")
     def test_epilogue_fusion_with_view(self):
         class ToyModel(torch.nn.Module):
             def __init__(self) -> None:

--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -70,6 +70,7 @@ from torch.testing._internal.common_device_type import (
     skipXPUIf,
 )
 from torch.testing._internal.common_quantized import _snr
+from torch.testing._internal.common_utils import skipIfRocm
 from torch.testing._internal.inductor_utils import HAS_GPU
 from torch.utils._triton import has_triton, has_triton_tma_device
 
@@ -2345,6 +2346,8 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
     @dtypes(*device_configs["cpu"].dtypes_fast)
     @dtypesIfCUDA(*device_configs["cuda"].dtypes_fast)
     @dtypesIfXPU(*device_configs["xpu"].dtypes_fast)
+    # Flaky with triton 3.7
+    @skipIfRocm(msg="Fails with Triton 3.7")
     @skip_on_cpu
     def test_return_aux_deprecation_warnings(self, device, dtype):
         """Test that deprecation warnings are issued for legacy parameters"""
@@ -7852,6 +7855,8 @@ class TestLearnableBiases(InductorTestCase):
         )
 
     @skip_on_cpu
+    # Fails with triton 3.7
+    @skip_on_rocm
     def test_flex_attention_with_dynamic_max_autotune(self, device):
         self._test_flex_attention_with_dynamic_max_autotune(device)
 
@@ -7861,6 +7866,7 @@ class TestLearnableBiases(InductorTestCase):
         self._test_flex_attention_with_dynamic_max_autotune(device)
 
     @skip_on_cpu
+    @skipIfRocm(msg="Fails with Triton 3.7")
     def test_flex_attention_logging(self, device):
         with tempfile.TemporaryDirectory() as tmpdir:
             log_file = os.path.join(tmpdir, "flex_attention_configs")

--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -155,6 +155,7 @@ class TestMaxAutotune(TestCase):
         b = make_matrix(K, N, *batch_dims, reduction_dim=-2)
         return a, b
 
+    @skipIfRocm(msg="Flaky with Triton 3.7")
     @parametrize("dynamic", (False, True))
     @parametrize("search_space", ("DEFAULT", "EXHAUSTIVE"))
     def test_max_autotune_mm_plus_mm_zero_size_input(self, dynamic, search_space):
@@ -858,6 +859,7 @@ class TestMaxAutotune(TestCase):
             actual = torch.compile(fn)(*args)
             torch.testing.assert_close(actual, expected, atol=1e-2, rtol=1e-2)
 
+    @skipIfRocm(msg="Flaky with Triton 3.7")
     @config.patch(
         benchmark_kernel=True,
         fallback_random=True,
@@ -1029,6 +1031,7 @@ class TestMaxAutotune(TestCase):
         f_c = torch.compile(mode="max-autotune-no-cudagraphs")(f)
         self.assertEqual(f_c(*inps), f(*inps), atol=0.03, rtol=0.25)
 
+    @skipIfRocm(msg="Fails with Triton 3.7")
     @config.patch("trace.enabled", True)
     @config.patch({"test_configs.force_extern_kernel_in_multi_template": True})
     @config.patch("triton.native_matmul", False)
@@ -1082,6 +1085,7 @@ class TestMaxAutotune(TestCase):
 
         torch._logging.set_logs()
 
+    @skipIfRocm(msg="Fails with Triton 3.7")
     @config.patch({"test_configs.force_extern_kernel_in_multi_template": True})
     def test_cat_max_autotune_extern(self):
         self._test_cat_max_autotune_impl(using_triton_mm=False)
@@ -1294,6 +1298,7 @@ class TestMaxAutotune(TestCase):
             if not same(expect, actual, tol=1e-2):
                 raise AssertionError(f"ref:\n{expect}\nact:\n{actual}")
 
+    @skipIfRocm(msg="Fails with Triton 3.7")
     @unittest.skipIf(
         config.cpp_wrapper, "decompose_k not supported for cpp_wrapper yet"
     )
@@ -1417,6 +1422,7 @@ class TestMaxAutotune(TestCase):
                 bf16_red_setting
             )
 
+    @skipIfRocm(msg="Fails with Triton 3.7")
     @unittest.skipIf(
         config.cpp_wrapper, "decompose_k not supported for cpp_wrapper yet"
     )
@@ -1470,6 +1476,7 @@ class TestMaxAutotune(TestCase):
                     rtol=1e-4,
                 )
 
+    @skipIfRocm(msg="Fails with Triton 3.7")
     @unittest.skipIf(
         config.cpp_wrapper, "decompose_k not supported for cpp_wrapper yet"
     )
@@ -1525,6 +1532,7 @@ class TestMaxAutotune(TestCase):
                     code[1]
                 )
 
+    @skipIfRocm(msg="Fails with Triton 3.7")
     @unittest.skipIf(
         config.cpp_wrapper, "decompose_k not supported for cpp_wrapper yet"
     )
@@ -1576,6 +1584,7 @@ class TestMaxAutotune(TestCase):
                     f" empty_strided_{GPU_TYPE}((256, 1096), (1096, 1), torch.bfloat16)"
                 ).run(code[0])
 
+    @skipIfRocm(msg="Fails with Triton 3.7")
     @unittest.skipIf(not torch.version.hip, "ROCM only")
     @parametrize("dtype", (torch.float16, torch.bfloat16, torch.float32))
     @parametrize("sizes", ((64, 128, 256), (128, 256, 512), (256, 512, 1024)))
@@ -1619,6 +1628,7 @@ class TestMaxAutotune(TestCase):
             # Check that contiguous transform was used
             FileCheck().check("contiguous_mm").run(code[0])
 
+    @skipIfRocm(msg="Fails with Triton 3.7")
     @unittest.skipIf(not torch.version.hip, "ROCM only")
     @parametrize("dtype", (torch.float16, torch.bfloat16, torch.float32))
     @parametrize("sizes", ((64, 128, 256), (128, 256, 512), (256, 512, 1024)))
@@ -1663,6 +1673,7 @@ class TestMaxAutotune(TestCase):
             # Check that contiguous transform was used
             FileCheck().check("contiguous_addmm").run(code[0])
 
+    @skipIfRocm(msg="Fails with Triton 3.7")
     @unittest.skipIf(not torch.version.hip, "ROCM only")
     @parametrize("dynamic", (False, True))
     def test_max_autotune_contiguous_transform_non_contiguous_second_matrix(
@@ -1730,6 +1741,7 @@ class TestMaxAutotune(TestCase):
             out2, expected2_fp64.to(torch.float32), atol=1e-2, rtol=1e-2
         )
 
+    @skipIfRocm(msg="Fails with Triton 3.7")
     @unittest.skipIf(not torch.version.hip, "ROCM only")
     @config.patch(
         max_autotune=True,
@@ -2181,6 +2193,7 @@ class TestMaxAutotune(TestCase):
 
     @fresh_cache()
     @skipIfXpu
+    @skipIfRocm(msg="Fails with Triton 3.7")
     @unittest.skipIf(
         config.cpp_wrapper, "decompose_k not supported for cpp_wrapper yet"
     )
@@ -2481,6 +2494,7 @@ class TestMaxAutotune(TestCase):
         self.assertObjectIn(k, (15, 16))
         self.assertEqual("'EVEN_K': True" in cache_key, k == 16 and not dynamic)
 
+    @skipIfRocm(msg="Fails with Triton 3.7")
     @config.patch(
         {
             "max_autotune": True,
@@ -4289,6 +4303,7 @@ class TestEpilogueFusionStaticAnalysis(TestCase):
                 tma_heuristic.mm_configs = original_tma_mm_configs
                 mm_heuristic.mm_configs = original_mm_mm_configs
 
+    @skipIfRocm(msg="Fails with Triton 3.7")
     @unittest.skipIf(
         not HAS_CUDA_AND_TRITON, "Scheduler static analysis only tested on cuda"
     )
@@ -4599,6 +4614,7 @@ class TestMaxAutotuneAsyncPipelined(TestMaxAutotune, TestEpilogueFusionStaticAna
         # Clear the AsyncAutotuner cache to prevent test pollution
         AsyncAutotuner.choice_hash_to_future.clear()
 
+    @skipIfRocm(msg="Flaky with Triton 3.7")
     @config.patch(max_autotune_gemm=True)
     def test_async_autotuner_cache_same_inputs(self):
         M, K, N = 128, 64, 256
@@ -4655,6 +4671,7 @@ class TestMaxAutotuneAsyncPipelined(TestMaxAutotune, TestEpilogueFusionStaticAna
         self.assertIsNone(pool_instance._timer)
         self.assertTrue(AutotuneProcessPool._shutdown_for_inactivity)
 
+    @skipIfRocm(msg="Flaky with Triton 3.7")
     @patch(
         "torch._inductor.autotune_process.AUTOTUNE_POOL_INACTIVITY_TIMEOUT",
         2,
@@ -4702,6 +4719,7 @@ class TestMaxAutotuneAsyncPipelined(TestMaxAutotune, TestEpilogueFusionStaticAna
         cache_entries_after_second = len(AsyncAutotuner.choice_hash_to_future)
         self.assertEqual(cache_entries_after_second, 0)
 
+    @skipIfRocm(msg="Fails with Triton 3.7")
     @config.patch(max_autotune_gemm=True)
     def test_triton_error_precompilation_and_autotuning(self):
         """

--- a/test/inductor/test_memory.py
+++ b/test/inductor/test_memory.py
@@ -8,7 +8,7 @@ from torch._dynamo.utils import same
 from torch._inductor import config, memory
 from torch._inductor.test_case import TestCase
 from torch._inductor.utils import run_and_get_triton_code
-from torch.testing._internal.common_utils import serialTest, skipIfXpu
+from torch.testing._internal.common_utils import serialTest, skipIfRocm, skipIfXpu
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
 
 
@@ -240,6 +240,7 @@ class TestOperatorReorderForPeakMemory(TestCase):
             outp = compiled_model(self.inputs)
             self.assertTrue(same(outp, outp_corr))
 
+    @skipIfRocm(msg="Fails with Triton 3.7")
     @skipIfXpu(msg="Blocked by https://github.com/pytorch/pytorch/issues/170049")
     @mock.patch.object(config, "allow_buffer_reuse", False)
     @unittest.skipUnless(TRITON_AVAILABLE, "Triton is not available")

--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -36,6 +36,7 @@ from torch.testing._internal.common_utils import (
     IS_X86,
     skipCUDAMemoryLeakCheckIf,
     skipIfCrossRef,
+    skipIfRocm,
     skipIfTorchDynamo,
     suppress_warnings,
     TEST_MKL,
@@ -1177,6 +1178,7 @@ class TestInductorOpInfo(TestCase):
     @unittest.skipIf(TEST_WITH_ASAN, "Skipped under ASAN")
     @skipIfTorchDynamo("Test uses dynamo already")
     @skipIfCrossRef
+    @skipIfRocm(msg="Fails with Triton 3.7 on MI200")
     @_ops(op_db[START:END])
     @skipOps("TestInductorOpInfo", "test_comprehensive", test_skips_or_fails)
     @patch("torch._dynamo.config.raise_on_unsafe_aot_autograd", True)

--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -26,7 +26,12 @@ from torch._inductor.utils import run_and_get_code, triton_version_uses_attrs_di
 from torch._library import capture_triton
 from torch.testing import FileCheck
 from torch.testing._internal import common_utils
-from torch.testing._internal.common_utils import parametrize, skipIfWindows, skipIfXpu
+from torch.testing._internal.common_utils import (
+    parametrize,
+    skipIfRocm,
+    skipIfWindows,
+    skipIfXpu,
+)
 from torch.testing._internal.inductor_utils import (
     GPU_TYPE,
     HAS_CUDA_AND_TRITON,
@@ -3386,6 +3391,7 @@ class MutationTests(torch._inductor.test_case.TestCase):
         )
 
     @skipIfXpu(msg="Blocked by https://github.com/pytorch/pytorch/issues/170049")
+    @skipIfRocm(msg="Fails with Triton 3.7")
     @make_mutation_test
     def test_for_loop_arg_2():
         @triton.jit
@@ -3447,6 +3453,7 @@ class MutationTests(torch._inductor.test_case.TestCase):
         )
 
     @skipIfXpu(msg="Blocked by https://github.com/pytorch/pytorch/issues/170049")
+    @skipIfRocm(msg="Fails with Triton 3.7")
     @make_mutation_test
     def test_while_loop():
         @triton.jit

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -200,12 +200,10 @@ ROCM_BLOCKLIST = [
 
 # Add architecture-specific blocklist entries
 if TEST_WITH_ROCM and isRocmArchAnyOf(("gfx1100",)):
-    # Some autotune tests on gfx1100 are hanging, disable for now
-    ROCM_BLOCKLIST.append("inductor/test_max_autotune")
-    # ROCm 7.2 gfx1100 started timing out due to these
-    ROCM_BLOCKLIST.append("inductor/test_torchinductor_dynamic_shapes")
-    ROCM_BLOCKLIST.append("inductor/test_torchinductor_opinfo")
-    ROCM_BLOCKLIST.append("inductor/test_ck_backend")
+    # Skip all inductor tests on Navi arch
+    ROCM_BLOCKLIST.extend(
+        test for test in TESTS if test.startswith(INDUCTOR_TEST_PREFIX)
+    )
 
 S390X_BLOCKLIST = [
     # these tests fail due to various reasons

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -71,7 +71,6 @@ from torch.testing._internal.common_utils import (
     load_tests,
     MI200_ARCH,
     MI300_ARCH,
-    MI350_ARCH,
     parametrize,
     recover_orig_fp32_precision,
     run_tests,
@@ -4329,7 +4328,7 @@ class TestCudaMallocAsync(TestCase):
         TEST_CUDAMALLOCASYNC, "setContextRecorder not supported by CUDAMallocAsync"
     )
     @requiresCppContext
-    @skipIfRocmArch(MI350_ARCH)
+    @skipIfRocm(msg="Fails with Triton 3.7")
     def test_memory_plots(self):
         for context, stacks in (
             ("all", "all" if IS_LINUX else "python"),
@@ -4493,6 +4492,7 @@ class TestCudaMallocAsync(TestCase):
     @unittest.skipIf(
         TEST_CUDAMALLOCASYNC, "setContextRecorder not supported by CUDAMallocAsync"
     )
+    @skipIfRocm(msg="Fails with Triton 3.7")
     @requiresCppContext
     def test_memory_plots_free_segment_stack(self):
         for context in ["alloc", "all", "state"]:

--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -73,6 +73,7 @@ from torch.testing._internal.common_utils import (
     IS_WINDOWS,
     run_tests,
     skipIfTorchDynamo,
+    skipIfRocm,
 )
 from torch.testing._internal.jit_utils import JitTestCase
 
@@ -4426,6 +4427,8 @@ def forward(self, args_list: List[torch.Tensor]){maybe_return_annotation}:
         # recorver mutable checking flag
         torch.fx.proxy.TracerBase.check_mutable_operations = orig_tracer_mutable_flag
 
+    # This only fails on navi31
+    @skipIfRocm(msg="Fails with Triton 3.7")
     @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
     @torch.fx.experimental._config.patch("enrich_profiler_metadata", True)
     def test_profiler_stack_trace_augmentation(self):

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -6116,6 +6116,8 @@ class TestLinalg(TestCase):
 
     @onlyCUDA
     @skipCUDAIfNotRocm
+    # Fails with triton 3.7
+    @skipIfRocmArch(NAVI_ARCH)
     @dtypes(torch.float)
     def test_mm_submatrix_offline_tunableop(self, device, dtype):
         import os

--- a/test/test_matmul_cuda.py
+++ b/test/test_matmul_cuda.py
@@ -47,6 +47,7 @@ from torch.testing._internal.common_utils import (
     runOnRocmArch,
     serialTest,
     skipIfRocm,
+    skipIfRocmArch,
     TEST_CUDA,
     TEST_WITH_ROCM,
     TestCase,
@@ -250,6 +251,8 @@ class TestMatmulCuda(InductorTestCase):
 
 
     @onlyCUDA
+    # Fails with triton 3.7
+    @skipIfRocmArch(NAVI_ARCH)
     @dtypes(torch.float16)
     # m == 4 chooses OUTPUT_TYPE reduction on H200
     # m == 8 chooses OUTPUT_TYPE reduction on A100
@@ -719,6 +722,8 @@ class TestMatmulCuda(InductorTestCase):
             self.assertEqual(C, C_ref)
 
     @skipCUDAIfNotRocm
+    # Fails with triton 3.7
+    @skipIfRocmArch(NAVI_ARCH)
     def test_grouped_gemm_rocm_ck_flag(self):
         CK_HINT = "kernel_grouped_gemm_xdl_splitk"
         HIPBLASLT_HINT = "Cijk_Alik_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs"

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -66,6 +66,7 @@ from torch.testing._internal.common_utils import (
     parametrize,
     run_tests,
     set_default_dtype,
+    skipIfRocm,
     skipIfTorchDynamo,
     skipIfTorchInductor,
     suppress_warnings,
@@ -493,6 +494,7 @@ class TestCommon(TestCase):
     @onlyOn(["cuda", "xpu"])
     @suppress_warnings
     @skipCUDAIfNotRocm
+    @skipIfRocm(msg="Fails with Triton 3.7")
     @ops(_ops_and_refs_with_no_numpy_ref, dtypes=OpDTypes.any_common_cpu_cuda_one)
     def test_compare_cpu(self, device, dtype, op):
         def to_cpu(arg):
@@ -833,6 +835,7 @@ class TestCommon(TestCase):
     # Tests that the function produces the same result when called with
     #   noncontiguous tensors.
     @skipXPU
+    @skipIfRocm(msg="Fails with Triton 3.7")
     @with_tf32_off
     @onlyNativeDeviceTypesAnd(["hpu"])
     @suppress_warnings
@@ -1602,6 +1605,7 @@ class TestCommon(TestCase):
     #   correctly for CPU and CUDA devices
     @skipXPU
     @skipMeta
+    @skipIfRocm(msg="Fails with Triton 3.7")
     @onlyNativeDeviceTypesAnd(["hpu"])
     @ops(ops_and_refs, dtypes=OpDTypes.none)
     def test_dtypes(self, device, op):

--- a/test/test_ops_gradients.py
+++ b/test/test_ops_gradients.py
@@ -11,6 +11,7 @@ from torch.testing._internal.common_device_type import (
 from torch.testing._internal.common_methods_invocations import op_db
 from torch.testing._internal.common_utils import (
     run_tests,
+    skipIfRocm,
     TestCase,
     TestGradients,
     unMarkDynamoStrictTest,
@@ -27,6 +28,7 @@ _gradcheck_ops = partial(
 
 @unMarkDynamoStrictTest
 class TestBwdGradients(TestGradients):
+    @skipIfRocm(msg="Fails with Triton 3.7")
     # Tests that gradients are computed correctly
     @_gradcheck_ops(op_db + hop_db + custom_op_db)
     def test_fn_grad(self, device, dtype, op):
@@ -63,6 +65,7 @@ class TestBwdGradients(TestGradients):
                 device, dtype, op, self._get_safe_inplace(op.get_inplace())
             )
 
+    @skipIfRocm(msg="Fails with Triton 3.7")
     # Test that gradients of gradients are computed correctly
     @_gradcheck_ops(op_db + hop_db + custom_op_db)
     def test_fn_gradgrad(self, device, dtype, op):

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -21,6 +21,7 @@ from torch.testing._internal.common_utils import (
     TestCase, run_tests, skipIfNoSciPy, slowTest, torch_to_numpy_dtype_dict,
     parametrize,
     skipIfTorchDynamo,
+    skipIfRocm,
     IS_WINDOWS)
 from torch.testing._internal.common_device_type import (
     OpDTypes, expectedFailureMeta, instantiate_device_type_tests, onlyCPU, dtypes, dtypesIfCUDA, dtypesIfCPU,
@@ -2523,6 +2524,7 @@ class TestReductions(TestCase):
     @dtypes(torch.int, torch.long, torch.float, torch.double)
     @dtypesIfCUDA(torch.int, torch.long, torch.half, torch.float, torch.double)
     @dtypesIfXPU(torch.int, torch.long, torch.half, torch.float, torch.double)
+    @skipIfRocm(msg="Fails with Triton 3.7 on MI200")
     def test_median_real_values(self, device, dtype):
         # Generate random 0-3D sizes
         sizes = [random.sample(range(1, 32), i) for i in range(4) for _ in range(2)]
@@ -2553,6 +2555,7 @@ class TestReductions(TestCase):
     @dtypes(torch.float, torch.double)
     @dtypesIfCUDA(torch.half, torch.float, torch.double)
     @dtypesIfXPU(torch.half, torch.float, torch.double)
+    @skipIfRocm(msg="Fails with Triton 3.7 on MI200")
     def test_median_nan_values(self, device, dtype):
         # Generate random 0-3D sizes
         sizes = [random.sample(range(1, 32), i) for i in range(4) for _ in range(2)]
@@ -2591,6 +2594,7 @@ class TestReductions(TestCase):
                     ref = numpy_op(t_numpy, dim, keepdims=True)[mask.cpu().numpy()]
                     self.assertEqual(res, torch.from_numpy(ref))
 
+    @skipIfRocm(msg="Fails with Triton 3.7 on MI200")
     def test_median_corner_cases(self, device):
         def check(op, a, args, key):
             t = torch.tensor(a, device=device)

--- a/test/test_sort_and_select.py
+++ b/test/test_sort_and_select.py
@@ -26,6 +26,7 @@ from torch.testing._internal.common_dtype import (
 )
 from torch.testing._internal.common_utils import (
     run_tests,
+    skipIfRocm,
     skipIfTorchDynamo,
     slowTest,
     TestCase,
@@ -1073,6 +1074,7 @@ class TestSortAndSelect(TestCase):
             )
             self._test_unique_scalar_empty(dtype, device, f)
 
+    @skipIfRocm(msg="Fails with Triton 3.7 on MI200")
     @dtypes(torch.double)
     def test_kthvalue(self, device, dtype):
         SIZE = 50

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -22,7 +22,7 @@ from torch.testing import make_tensor
 from torch.testing._internal.common_utils import (
     IS_FBCODE, IS_JETSON, IS_MACOS, IS_SANDCASTLE, IS_WINDOWS, TestCase, run_tests, slowTest,
     parametrize, reparametrize, subtest, instantiate_parametrized_tests, dtype_name,
-    TEST_WITH_ROCM, decorateIf
+    TEST_WITH_ROCM, decorateIf, skipIfRocm
 )
 from torch.testing._internal.common_device_type import \
     (PYTORCH_TESTING_DEVICE_EXCEPT_FOR_KEY, PYTORCH_TESTING_DEVICE_ONLY_FOR_KEY, dtypes,
@@ -2398,6 +2398,7 @@ class TestImports(TestCase):
 
     # The test is flaky on ROCm/XPU and has been open and close multiple times
     # https://github.com/pytorch/pytorch/issues/110040
+    @skipIfRocm(msg="Fails with Triton 3.7")
     def test_circular_dependencies(self) -> None:
         """ Checks that all modules inside torch can be imported
         Prevents regression reported in https://github.com/pytorch/pytorch/issues/77441 """


### PR DESCRIPTION
Just a dummy PR for convenience with all of the skips squashed into one commit.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @Lucaskabela @azahed98