### PR TITLE
[Native DSL] Add _native ops framework

### DIFF
--- a/test/python_native/test_native_dsl_ops.py
+++ b/test/python_native/test_native_dsl_ops.py
@@ -93,12 +93,6 @@ class TestNativeDSLOps(TestCase):
         result = _subprocess_lastline(script, env=env)
         self.assertEqual(result, "True")
 
-    def test_unavailable_reason_present(self):
-        """Known package -> _unavailable_reason returns None."""
-        from torch._native.common_utils import _unavailable_reason
-
-        self.assertIsNone(_unavailable_reason([("torch", "torch")]))
-
     def test_unavailable_reason_missing(self):
         """Nonexistent package -> _unavailable_reason returns a string."""
         from torch._native.common_utils import _unavailable_reason
@@ -141,28 +135,6 @@ class TestNativeDSLOps(TestCase):
 
         # cleanup
         _RegisteredFns.pop()
-
-    def test_register_op_skips_when_runtime_unavailable(self):
-        """register_op does not enqueue fn when runtime is unavailable."""
-        from torch._native import cutedsl_utils, triton_utils
-        from torch._native.registry import _RegisteredFns
-
-        for mod, flag_name in [
-            (triton_utils, "_TRITON_AVAILABLE"),
-            (cutedsl_utils, "_CUTEDSL_AVAILABLE"),
-        ]:
-            original_len = len(_RegisteredFns)
-            saved = getattr(mod, flag_name)
-            try:
-                setattr(mod, flag_name, False)
-                mod.register_op(lambda: None)
-                self.assertEqual(
-                    len(_RegisteredFns),
-                    original_len,
-                    f"{mod.__name__}.register_op should not enqueue when runtime unavailable",
-                )
-            finally:
-                setattr(mod, flag_name, saved)
 
     def test_register_op_skips_when_jit_disabled(self):
         """register_op does not enqueue fn when TORCH_DISABLE_NATIVE_JIT=1."""

--- a/test/python_native/test_native_dsl_ops.py
+++ b/test/python_native/test_native_dsl_ops.py
@@ -25,20 +25,15 @@ class TestNativeDSLOps(TestCase):
 
     def test_consistent_helper_interface(self):
         """triton_utils and cutedsl_utils expose the same public API."""
-        import torch
+        from torch._native import cutedsl_utils, triton_utils
 
         REQUIRED_METHODS = {
             "runtime_available",
             "runtime_version",
             "register_op_override",
         }
-        utils = [
-            getattr(torch._native, u)
-            for u in dir(torch._native)
-            if u.endswith("utils") and not u.startswith("common")
-        ]
 
-        for mod in utils:
+        for mod in (cutedsl_utils, triton_utils):
             public = {name for name in dir(mod) if not name.startswith("_")}
             self.assertTrue(
                 REQUIRED_METHODS <= public,
@@ -47,20 +42,12 @@ class TestNativeDSLOps(TestCase):
             for name in REQUIRED_METHODS:
                 self.assertTrue(callable(getattr(mod, name)))
 
-        public = {}
+        triton_public = {n for n in dir(triton_utils) if not n.startswith("_")}
+        cute_public = {n for n in dir(cutedsl_utils) if not n.startswith("_")}
 
-        for mod in utils:
-            public[mod] = {n for n in dir(mod) if not n.startswith("_")}
-        # triton_public = {n for n in dir(triton_utils) if not n.startswith("_")}
-        # cute_public = {n for n in dir(cutedsl_utils) if not n.startswith("_")}
+        self.assertEqual(triton_public, cute_public)
 
-        base_mod = next(iter(public.keys()))
-
-        for mod in utils:
-            if mod != base_mod:
-                self.assertEqual(public[base_mod], public[mod])
-
-        for mod in utils:
+        for mod in (cutedsl_utils, triton_utils):
             self.assertIsInstance(mod.runtime_available(), bool)
             ver = mod.runtime_version()
             if ver is not None:

--- a/test/python_native/test_native_dsl_ops.py
+++ b/test/python_native/test_native_dsl_ops.py
@@ -10,16 +10,13 @@ from torch.testing._internal.common_utils import run_tests, TestCase
 
 def _subprocess_lastline(script, env=None):
     """Run script in a fresh interpreter and return the last line of stdout."""
-    result = (
-        subprocess.check_output(
-            [sys.executable, "-c", script],
-            cwd=os.path.dirname(os.path.realpath(__file__)),
-            env=env,
-            stderr=subprocess.DEVNULL,
-            text=True,
-        )
-        .strip()
-    )
+    result = subprocess.check_output(
+        [sys.executable, "-c", script],
+        cwd=os.path.dirname(os.path.realpath(__file__)),
+        env=env,
+        stderr=subprocess.DEVNULL,
+        text=True,
+    ).strip()
     return result.rsplit("\n", 1)[-1]
 
 

--- a/test/python_native/test_native_dsl_ops.py
+++ b/test/python_native/test_native_dsl_ops.py
@@ -25,15 +25,20 @@ class TestNativeDSLOps(TestCase):
 
     def test_consistent_helper_interface(self):
         """triton_utils and cutedsl_utils expose the same public API."""
-        from torch._native import cutedsl_utils, triton_utils
+        import torch
 
         REQUIRED_METHODS = {
             "runtime_available",
             "runtime_version",
             "register_op_override",
         }
+        utils = [
+            getattr(torch._native, u)
+            for u in dir(torch._native)
+            if u.endswith("utils") and not u.startswith("common")
+        ]
 
-        for mod in (triton_utils, cutedsl_utils):
+        for mod in utils:
             public = {name for name in dir(mod) if not name.startswith("_")}
             self.assertTrue(
                 REQUIRED_METHODS <= public,
@@ -42,11 +47,20 @@ class TestNativeDSLOps(TestCase):
             for name in REQUIRED_METHODS:
                 self.assertTrue(callable(getattr(mod, name)))
 
-        triton_public = {n for n in dir(triton_utils) if not n.startswith("_")}
-        cute_public = {n for n in dir(cutedsl_utils) if not n.startswith("_")}
-        self.assertEqual(triton_public, cute_public)
+        public = {}
 
-        for mod in (triton_utils, cutedsl_utils):
+        for mod in utils:
+            public[mod] = {n for n in dir(mod) if not n.startswith("_")}
+        # triton_public = {n for n in dir(triton_utils) if not n.startswith("_")}
+        # cute_public = {n for n in dir(cutedsl_utils) if not n.startswith("_")}
+
+        base_mod = next(iter(public.keys()))
+
+        for mod in utils:
+            if mod != base_mod:
+                self.assertEqual(public[base_mod], public[mod])
+
+        for mod in utils:
             self.assertIsInstance(mod.runtime_available(), bool)
             ver = mod.runtime_version()
             if ver is not None:

--- a/test/python_native/test_native_dsl_ops.py
+++ b/test/python_native/test_native_dsl_ops.py
@@ -16,8 +16,8 @@ def _subprocess_lastline(script, env=None):
             cwd=os.path.dirname(os.path.realpath(__file__)),
             env=env,
             stderr=subprocess.DEVNULL,
+            text=True,
         )
-        .decode("ascii")
         .strip()
     )
     return result.rsplit("\n", 1)[-1]

--- a/test/python_native/test_native_dsl_ops.py
+++ b/test/python_native/test_native_dsl_ops.py
@@ -10,12 +10,16 @@ from torch.testing._internal.common_utils import run_tests, TestCase
 
 def _subprocess_lastline(script, env=None):
     """Run script in a fresh interpreter and return the last line of stdout."""
-    result = subprocess.check_output(
-        [sys.executable, "-c", script],
-        cwd=os.path.dirname(os.path.realpath(__file__)),
-        env=env,
-        stderr=subprocess.DEVNULL,
-    ).decode("ascii").strip()
+    result = (
+        subprocess.check_output(
+            [sys.executable, "-c", script],
+            cwd=os.path.dirname(os.path.realpath(__file__)),
+            env=env,
+            stderr=subprocess.DEVNULL,
+        )
+        .decode("ascii")
+        .strip()
+    )
     return result.rsplit("\n", 1)[-1]
 
 
@@ -24,16 +28,12 @@ class TestNativeDSLOps(TestCase):
 
     def test_consistent_helper_interface(self):
         """triton_utils and cutedsl_utils expose the same public API."""
-        from torch._native import triton_utils, cutedsl_utils
+        from torch._native import cutedsl_utils, triton_utils
 
         REQUIRED_METHODS = {"runtime_available", "runtime_version", "register_op"}
 
         for mod in (triton_utils, cutedsl_utils):
-            public = {
-                name
-                for name in dir(mod)
-                if not name.startswith("_")
-            }
+            public = {name for name in dir(mod) if not name.startswith("_")}
             self.assertTrue(
                 REQUIRED_METHODS <= public,
                 f"{mod.__name__} missing: {REQUIRED_METHODS - public}",
@@ -128,7 +128,9 @@ class TestNativeDSLOps(TestCase):
         )
 
         sentinel = []
-        fn = lambda: sentinel.append(True)
+
+        def fn():
+            sentinel.append(True)
 
         original_len = len(_RegisteredFns)
         register_op_registerer(fn)
@@ -142,8 +144,8 @@ class TestNativeDSLOps(TestCase):
 
     def test_register_op_skips_when_runtime_unavailable(self):
         """register_op does not enqueue fn when runtime is unavailable."""
+        from torch._native import cutedsl_utils, triton_utils
         from torch._native.registry import _RegisteredFns
-        from torch._native import triton_utils, cutedsl_utils
 
         for mod, flag_name in [
             (triton_utils, "_TRITON_AVAILABLE"),

--- a/test/python_native/test_native_dsl_ops.py
+++ b/test/python_native/test_native_dsl_ops.py
@@ -1,4 +1,4 @@
-# Owner(s): ["module: unknown"]
+# Owner(s): ["module: dsl-native-ops"]
 
 import os
 import subprocess
@@ -152,6 +152,77 @@ class TestNativeDSLOps(TestCase):
         env["TORCH_DISABLE_NATIVE_JIT"] = "1"
         result = _subprocess_lastline(script, env=env)
         self.assertEqual(result, "True")
+
+    def test_version_skip_env_var_overrides(self):
+        """TORCH_NATIVE_SKIP_VERSION_CHECK=1 allows non-blessed versions."""
+        script = textwrap.dedent("""\
+            from torch._native import triton_utils, cutedsl_utils
+            from torch._native.registry import _RegisteredFns
+
+            # Force runtime "available" with a non-blessed version
+            triton_utils._TRITON_AVAILABLE = True
+            triton_utils._TRITON_VERSION = (99, 99, 99)
+            cutedsl_utils._CUTEDSL_AVAILABLE = True
+            cutedsl_utils._CUTEDSL_VERSION = (99, 99, 99)
+
+            before = len(_RegisteredFns)
+            triton_utils.register_op(lambda: None)
+            cutedsl_utils.register_op(lambda: None)
+            after = len(_RegisteredFns)
+            print(after - before)
+        """)
+        env = os.environ.copy()
+        env["TORCH_NATIVE_SKIP_VERSION_CHECK"] = "1"
+        result = _subprocess_lastline(script, env=env)
+        self.assertEqual(result, "2")
+
+    def test_check_native_version_skip_default(self):
+        """TORCH_NATIVE_SKIP_VERSION_CHECK unset -> returns False."""
+        script = textwrap.dedent("""\
+            import os
+            os.environ.pop("TORCH_NATIVE_SKIP_VERSION_CHECK", None)
+            from torch._native.common_utils import check_native_version_skip
+            print(check_native_version_skip())
+        """)
+        result = _subprocess_lastline(script)
+        self.assertEqual(result, "False")
+
+    def test_check_native_version_skip_set(self):
+        """TORCH_NATIVE_SKIP_VERSION_CHECK=1 -> returns True."""
+        script = textwrap.dedent("""\
+            from torch._native.common_utils import check_native_version_skip
+            print(check_native_version_skip())
+        """)
+        env = os.environ.copy()
+        env["TORCH_NATIVE_SKIP_VERSION_CHECK"] = "1"
+        result = _subprocess_lastline(script, env=env)
+        self.assertEqual(result, "True")
+
+    def test_available_version_prerelease(self):
+        """_available_version handles pre-release suffixes correctly."""
+        from unittest.mock import patch
+
+        from torch._native.common_utils import _available_version
+
+        cases = [
+            ("0.7.0rc1", (0, 7, 0)),
+            ("3.1.0.post1", (3, 1, 0)),
+            ("2.4.0a1", (2, 4, 0)),
+            ("1.2.3", (1, 2, 3)),
+        ]
+        for version_str, expected in cases:
+            with patch("importlib.metadata.version", return_value=version_str):
+                result = _available_version("fake_package")
+                self.assertEqual(
+                    result,
+                    expected,
+                    f"_available_version({version_str!r}) = {result}, expected {expected}",
+                )
+
+        # Completely unparsable -> None
+        with patch("importlib.metadata.version", return_value="abc"):
+            result = _available_version("fake_package")
+            self.assertIsNone(result)
 
 
 if __name__ == "__main__":

--- a/test/python_native/test_native_dsl_ops.py
+++ b/test/python_native/test_native_dsl_ops.py
@@ -1,0 +1,184 @@
+# Owner(s): ["module: unknown"]
+
+import os
+import subprocess
+import sys
+import textwrap
+
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+def _subprocess_lastline(script, env=None):
+    """Run script in a fresh interpreter and return the last line of stdout."""
+    result = subprocess.check_output(
+        [sys.executable, "-c", script],
+        cwd=os.path.dirname(os.path.realpath(__file__)),
+        env=env,
+        stderr=subprocess.DEVNULL,
+    ).decode("ascii").strip()
+    return result.rsplit("\n", 1)[-1]
+
+
+class TestNativeDSLOps(TestCase):
+    """Tests for the torch._native DSL ops framework."""
+
+    def test_consistent_helper_interface(self):
+        """triton_utils and cutedsl_utils expose the same public API."""
+        from torch._native import triton_utils, cutedsl_utils
+
+        REQUIRED_METHODS = {"runtime_available", "runtime_version", "register_op"}
+
+        for mod in (triton_utils, cutedsl_utils):
+            public = {
+                name
+                for name in dir(mod)
+                if not name.startswith("_")
+            }
+            self.assertTrue(
+                REQUIRED_METHODS <= public,
+                f"{mod.__name__} missing: {REQUIRED_METHODS - public}",
+            )
+            for name in REQUIRED_METHODS:
+                self.assertTrue(callable(getattr(mod, name)))
+
+        triton_public = {n for n in dir(triton_utils) if not n.startswith("_")}
+        cute_public = {n for n in dir(cutedsl_utils) if not n.startswith("_")}
+        self.assertEqual(triton_public, cute_public)
+
+        for mod in (triton_utils, cutedsl_utils):
+            self.assertIsInstance(mod.runtime_available(), bool)
+            ver = mod.runtime_version()
+            if ver is not None:
+                self.assertIsInstance(ver, tuple)
+                self.assertEqual(len(ver), 3)
+                for v in ver:
+                    self.assertIsInstance(v, int)
+
+    def test_no_dsl_imports_after_import_torch(self):
+        """import torch must not transitively import DSL runtimes.
+
+        Note: cuda.bindings may appear because importlib.util.find_spec on
+        nested modules (e.g. cuda.bindings.driver) imports parent packages
+        as a side-effect.  We check only the primary DSL runtimes here.
+        """
+        script = textwrap.dedent("""\
+            import sys
+            import torch
+            dsl_modules = ["triton", "cutlass", "tvm_ffi"]
+            leaked = [m for m in dsl_modules if m in sys.modules]
+            print(repr(leaked))
+        """)
+        result = _subprocess_lastline(script)
+        self.assertEqual(result, "[]", f"DSL modules leaked on import torch: {result}")
+
+    def test_check_native_jit_disabled_default(self):
+        """TORCH_DISABLE_NATIVE_JIT unset -> check returns False."""
+        script = textwrap.dedent("""\
+            import os
+            os.environ.pop("TORCH_DISABLE_NATIVE_JIT", None)
+            from torch._native.common_utils import check_native_jit_disabled
+            print(check_native_jit_disabled())
+        """)
+        result = _subprocess_lastline(script)
+        self.assertEqual(result, "False")
+
+    def test_check_native_jit_disabled_set(self):
+        """TORCH_DISABLE_NATIVE_JIT=1 -> check returns True."""
+        script = textwrap.dedent("""\
+            from torch._native.common_utils import check_native_jit_disabled
+            print(check_native_jit_disabled())
+        """)
+        env = os.environ.copy()
+        env["TORCH_DISABLE_NATIVE_JIT"] = "1"
+        result = _subprocess_lastline(script, env=env)
+        self.assertEqual(result, "True")
+
+    def test_unavailable_reason_present(self):
+        """Known package -> _unavailable_reason returns None."""
+        from torch._native.common_utils import _unavailable_reason
+
+        self.assertIsNone(_unavailable_reason([("torch", "torch")]))
+
+    def test_unavailable_reason_missing(self):
+        """Nonexistent package -> _unavailable_reason returns a string."""
+        from torch._native.common_utils import _unavailable_reason
+
+        reason = _unavailable_reason([("nonexistent_pkg_xyz", "nonexistent_pkg_xyz")])
+        self.assertIsNotNone(reason)
+        self.assertIn("nonexistent_pkg_xyz", reason)
+
+    def test_available_version(self):
+        """_available_version returns a 3-tuple of ints for a clean version."""
+        from torch._native.common_utils import _available_version
+
+        # Use typing_extensions which always has a clean major.minor.patch version,
+        # unlike torch which may have pre-release suffixes in dev builds.
+        ver = _available_version("typing_extensions")
+        self.assertIsInstance(ver, tuple)
+        self.assertEqual(len(ver), 3)
+        for v in ver:
+            self.assertIsInstance(v, int)
+
+    def test_registry_mechanics(self):
+        """register_op_registerer + register_all_operators round-trips."""
+        from torch._native.registry import (
+            _RegisteredFns,
+            register_all_operators,
+            register_op_registerer,
+        )
+
+        sentinel = []
+        fn = lambda: sentinel.append(True)
+
+        original_len = len(_RegisteredFns)
+        register_op_registerer(fn)
+        self.assertEqual(len(_RegisteredFns), original_len + 1)
+
+        register_all_operators()
+        self.assertTrue(sentinel, "registered fn was never called")
+
+        # cleanup
+        _RegisteredFns.pop()
+
+    def test_register_op_skips_when_runtime_unavailable(self):
+        """register_op does not enqueue fn when runtime is unavailable."""
+        from torch._native.registry import _RegisteredFns
+        from torch._native import triton_utils, cutedsl_utils
+
+        for mod, flag_name in [
+            (triton_utils, "_TRITON_AVAILABLE"),
+            (cutedsl_utils, "_CUTEDSL_AVAILABLE"),
+        ]:
+            original_len = len(_RegisteredFns)
+            saved = getattr(mod, flag_name)
+            try:
+                setattr(mod, flag_name, False)
+                mod.register_op(lambda: None)
+                self.assertEqual(
+                    len(_RegisteredFns),
+                    original_len,
+                    f"{mod.__name__}.register_op should not enqueue when runtime unavailable",
+                )
+            finally:
+                setattr(mod, flag_name, saved)
+
+    def test_register_op_skips_when_jit_disabled(self):
+        """register_op does not enqueue fn when TORCH_DISABLE_NATIVE_JIT=1."""
+        script = textwrap.dedent("""\
+            from torch._native.registry import _RegisteredFns
+            from torch._native import triton_utils, cutedsl_utils
+
+            before = len(_RegisteredFns)
+            triton_utils.register_op(lambda: None)
+            cutedsl_utils.register_op(lambda: None)
+            after = len(_RegisteredFns)
+            print(before == after)
+        """)
+        env = os.environ.copy()
+        env["TORCH_DISABLE_NATIVE_JIT"] = "1"
+        result = _subprocess_lastline(script, env=env)
+        self.assertEqual(result, "True")
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/python_native/test_native_dsl_ops.py
+++ b/test/python_native/test_native_dsl_ops.py
@@ -27,7 +27,7 @@ class TestNativeDSLOps(TestCase):
         """triton_utils and cutedsl_utils expose the same public API."""
         from torch._native import cutedsl_utils, triton_utils
 
-        REQUIRED_METHODS = {"runtime_available", "runtime_version", "register_op"}
+        REQUIRED_METHODS = {"runtime_available", "runtime_version", "register_op_override"}
 
         for mod in (triton_utils, cutedsl_utils):
             public = {name for name in dir(mod) if not name.startswith("_")}
@@ -46,10 +46,9 @@ class TestNativeDSLOps(TestCase):
             self.assertIsInstance(mod.runtime_available(), bool)
             ver = mod.runtime_version()
             if ver is not None:
-                self.assertIsInstance(ver, tuple)
-                self.assertEqual(len(ver), 3)
-                for v in ver:
-                    self.assertIsInstance(v, int)
+                from packaging.version import Version
+
+                self.assertIsInstance(ver, Version)
 
     def test_no_dsl_imports_after_import_torch(self):
         """import torch must not transitively import DSL runtimes.
@@ -99,51 +98,48 @@ class TestNativeDSLOps(TestCase):
         self.assertIn("nonexistent_pkg_xyz", reason)
 
     def test_available_version(self):
-        """_available_version returns a 3-tuple of ints for a clean version."""
+        """_available_version returns a packaging.version.Version"""
         from torch._native.common_utils import _available_version
+        from packaging.version import Version
 
         # Use typing_extensions which always has a clean major.minor.patch version,
         # unlike torch which may have pre-release suffixes in dev builds.
         ver = _available_version("typing_extensions")
-        self.assertIsInstance(ver, tuple)
-        self.assertEqual(len(ver), 3)
-        for v in ver:
-            self.assertIsInstance(v, int)
+        self.assertIsInstance(ver, Version)
 
     def test_registry_mechanics(self):
-        """register_op_registerer + register_all_operators round-trips."""
-        from torch._native.registry import (
-            _RegisteredFns,
-            register_all_operators,
-            register_op_registerer,
-        )
+        """_get_library caches Library instances per (lib, dispatch_key)."""
+        import torch.library
+        from torch._native.registry import _get_library, libs
 
-        sentinel = []
+        key = ("_test_native_dsl_registry", "CPU")
+        libs.pop(key, None)
 
-        def fn():
-            sentinel.append(True)
+        lib1 = _get_library(*key)
+        self.assertIsInstance(lib1, torch.library.Library)
+        lib2 = _get_library(*key)
+        self.assertIs(lib1, lib2, "should return cached instance")
 
-        original_len = len(_RegisteredFns)
-        register_op_registerer(fn)
-        self.assertEqual(len(_RegisteredFns), original_len + 1)
-
-        register_all_operators()
-        self.assertTrue(sentinel, "registered fn was never called")
+        # Different dispatch key -> different Library
+        key2 = ("_test_native_dsl_registry", "CUDA")
+        libs.pop(key2, None)
+        lib3 = _get_library(*key2)
+        self.assertIsNot(lib1, lib3)
 
         # cleanup
-        _RegisteredFns.pop()
+        libs.pop(key, None)
+        libs.pop(key2, None)
 
     def test_register_op_skips_when_jit_disabled(self):
-        """register_op does not enqueue fn when TORCH_DISABLE_NATIVE_JIT=1."""
+        """register_op_override does not call through when TORCH_DISABLE_NATIVE_JIT=1."""
         script = textwrap.dedent("""\
-            from torch._native.registry import _RegisteredFns
+            from unittest.mock import patch
             from torch._native import triton_utils, cutedsl_utils
 
-            before = len(_RegisteredFns)
-            triton_utils.register_op(lambda: None)
-            cutedsl_utils.register_op(lambda: None)
-            after = len(_RegisteredFns)
-            print(before == after)
+            with patch('torch._native.registry._register_op_override') as mock_reg:
+                triton_utils.register_op_override("aten", "add.Tensor", "CUDA", lambda: None)
+                cutedsl_utils.register_op_override("aten", "add.Tensor", "CUDA", lambda: None)
+                print(mock_reg.call_count == 0)
         """)
         env = os.environ.copy()
         env["TORCH_DISABLE_NATIVE_JIT"] = "1"
@@ -153,20 +149,19 @@ class TestNativeDSLOps(TestCase):
     def test_version_skip_env_var_overrides(self):
         """TORCH_NATIVE_SKIP_VERSION_CHECK=1 allows non-blessed versions."""
         script = textwrap.dedent("""\
+            from unittest.mock import patch, MagicMock
+            from packaging.version import Version
             from torch._native import triton_utils, cutedsl_utils
-            from torch._native.registry import _RegisteredFns
 
-            # Force runtime "available" with a non-blessed version
-            triton_utils._TRITON_AVAILABLE = True
-            triton_utils._TRITON_VERSION = (99, 99, 99)
-            cutedsl_utils._CUTEDSL_AVAILABLE = True
-            cutedsl_utils._CUTEDSL_VERSION = (99, 99, 99)
+            fake_version = Version("99.99.99")
 
-            before = len(_RegisteredFns)
-            triton_utils.register_op(lambda: None)
-            cutedsl_utils.register_op(lambda: None)
-            after = len(_RegisteredFns)
-            print(after - before)
+            with patch.object(triton_utils, '_check_runtime_available', return_value=(True, fake_version)), \\
+                 patch.object(cutedsl_utils, '_check_runtime_available', return_value=(True, fake_version)), \\
+                 patch.object(triton_utils, '_register_op_override') as triton_mock, \\
+                 patch.object(cutedsl_utils, '_register_op_override') as cute_mock:
+                triton_utils.register_op_override("aten", "add.Tensor", "CUDA", lambda: None)
+                cutedsl_utils.register_op_override("aten", "add.Tensor", "CUDA", lambda: None)
+                print(triton_mock.call_count + cute_mock.call_count)
         """)
         env = os.environ.copy()
         env["TORCH_NATIVE_SKIP_VERSION_CHECK"] = "1"
@@ -196,24 +191,21 @@ class TestNativeDSLOps(TestCase):
         self.assertEqual(result, "True")
 
     def test_available_version_prerelease(self):
-        """_available_version handles pre-release suffixes correctly."""
+        """_available_version parses valid versions and rejects unparsable ones."""
         from unittest.mock import patch
+
+        from packaging.version import Version
 
         from torch._native.common_utils import _available_version
 
-        cases = [
-            ("0.7.0rc1", (0, 7, 0)),
-            ("3.1.0.post1", (3, 1, 0)),
-            ("2.4.0a1", (2, 4, 0)),
-            ("1.2.3", (1, 2, 3)),
-        ]
-        for version_str, expected in cases:
+        valid_versions = ["0.7.0rc1", "3.1.0.post1", "2.4.0a1", "1.2.3"]
+        for version_str in valid_versions:
             with patch("importlib.metadata.version", return_value=version_str):
                 result = _available_version("fake_package")
                 self.assertEqual(
                     result,
-                    expected,
-                    f"_available_version({version_str!r}) = {result}, expected {expected}",
+                    Version(version_str),
+                    f"_available_version({version_str!r}) = {result}",
                 )
 
         # Completely unparsable -> None

--- a/test/python_native/test_native_dsl_ops.py
+++ b/test/python_native/test_native_dsl_ops.py
@@ -27,7 +27,11 @@ class TestNativeDSLOps(TestCase):
         """triton_utils and cutedsl_utils expose the same public API."""
         from torch._native import cutedsl_utils, triton_utils
 
-        REQUIRED_METHODS = {"runtime_available", "runtime_version", "register_op_override"}
+        REQUIRED_METHODS = {
+            "runtime_available",
+            "runtime_version",
+            "register_op_override",
+        }
 
         for mod in (triton_utils, cutedsl_utils):
             public = {name for name in dir(mod) if not name.startswith("_")}
@@ -99,8 +103,9 @@ class TestNativeDSLOps(TestCase):
 
     def test_available_version(self):
         """_available_version returns a packaging.version.Version"""
-        from torch._native.common_utils import _available_version
         from packaging.version import Version
+
+        from torch._native.common_utils import _available_version
 
         # Use typing_extensions which always has a clean major.minor.patch version,
         # unlike torch which may have pre-release suffixes in dev builds.

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -3013,3 +3013,6 @@ def _as_tensor_fullprec(t):
 # an autoloaded backend are defined
 if _is_device_backend_autoload_enabled():
     _import_device_backends()
+
+# Register all registered custom / override ops in torch/_native
+import torch._native

--- a/torch/_native/README.md
+++ b/torch/_native/README.md
@@ -10,6 +10,8 @@ When writing native ops, they are required to interact meaningfully with torch's
 
 As a further clarification, ops cannot be labelled as `CompositeImplicitAutograd` in `native_functions.yaml`, as-in the op must have an explicit autograd function registered, or at minimum an explicit implementation registered for the same backend as being overridden/added.
 
+Further, we expect the overriding function to take as the first argument `dispatch_keys` (of type `torch.DispatchKeySet`), which is necessary for fallback implementations.
+
 ## A Note on Imports
 
 All registrations will happen at the end of `import torch`. It is expected at that point that **no DSL runtime library is loaded** - this means that the runtime(s) must only be imported lazily. We can still check the presence of a module, and get it's version without importing, but special care must be taken when writing op kernels to not import DSLs too early. An illustrative example is below, using `triton`:
@@ -21,15 +23,20 @@ First, we're going to write the registration function, and a top-level call, bei
 
 # NOTE: no triton import in the file
 
-def calling_fn(...):
+from ... import triton_utils as tu
+
+def calling_fn(dispatch_key, ...):
     # Lazily import the kernels (and triton) on first call
     from .triton_kernels import outer_fn
     torch.library.wrap_triton(outer_fn)(...)
 
 def register_to_dispatch():
-    torch.library.custom_op(...)(calling_fn)
-    torch.library.register_autograd(...)
-    torch.library.register_fake(...)
+    tu.register_op_override(
+        "aten",
+        "_scaled_mm_v2",
+        "CUDA",
+        calling_fn,
+    )
 
 ```
 
@@ -66,10 +73,9 @@ This follows a simple and standard path, with a good example being the implement
 The following example replaces the implementation of `aten._scaled_grouped_mm_v2` on `CUDA` devices:
 
 ```
-# Note this must be global to avoid getting garbage collected
-lib = None
+from ... import cutedsl_utils as cu
 
-def my_impl(...) -> ...:
+def my_impl(dispatch_key, ...) -> ...:
     """
     Replacement implementation
     """
@@ -78,14 +84,12 @@ def my_impl(...) -> ...:
 # Override the symbol `aten._scaled_grouped_mm_v2` in this example with the implementation in `my_impl`,
 # noting the function signatures must match
 def register_kernel_override():
-    global lib
-
-    # If already registered, don't do it again
-    if lib is not None:
-        return
-
-    lib = torch.library.Library("aten", "IMPL", "CUDA")
-    lib.impl("_scaled_grouped_mm_v2", my_impl, "CUDA")
+    tu.register_op_override(
+        "aten",
+        "_scaled_grouped_mm_v2",
+        "CUDA",
+        my_impl,
+    )
 ```
 
 ### Replacing a Subset of Calls
@@ -93,7 +97,7 @@ def register_kernel_override():
 This time we only want to override the behavior of a subset of `aten._scaled_grouped_mm_v2` calls, and choose whether to invoke our implementation or the original depending on some input arguments. Note that the core of the example -- creating a `torch.library.Library`, and registering our function using `lib.impl(...)` are the same as in [Replacing an Operator](#Replacing-an-Operator).
 
 ```
-lib = None
+from ... import cutedsl_utils as cu
 
 def my_impl(...) -> ...:
     """
@@ -105,11 +109,6 @@ def my_impl(...) -> ...:
 # Override the symbol `aten._scaled_grouped_mm_v2` in this example with the implementation in `my_impl`,
 # only when the check-method `enable_my_impl` returns `True`
 def register_kernel_override():
-    global lib
-
-    # If already registered, don't do it again
-    if lib is not None:
-        return
 
     # Get the original implementation for fallback purposes
     fallback_kernel = torch.library.get_kernel("aten::_scaled_grouped_mm_v2", "CUDA")
@@ -126,15 +125,17 @@ def register_kernel_override():
                                    arg1, arg2, *args, **kwargs)
 
     # Same as before
-    lib = torch.library.Library("aten", "IMPL", "CUDA")
-    # Pass the enablement function, note needed with_keyset=True argument to
-    # get and pass dispatch keys
-    lib.impl("_scaled_grouped_mm_v2", enable_my_impl, "CUDA", with_keyset=True)
+    cu.register_op_override(
+        "aten",
+        "_scaled_grouped_mm_v2",
+        "CUDA",
+        enable_my_impl,
+    )
 ```
 
 ## Registering a New Operator
 
-We currently don't have any use for this, please come talk to us if you want this!
+We currently don't have a use for this functionality, please come talk to us if you want it!
 
 # Adding a new DSL
 
@@ -149,8 +150,19 @@ Some universal utilities are provided in `common_utils.py`:
 
 A DSL utils file, named `$dsl_utils.py` (i.e. `cutedsl_utils.py` for `$dsl=cutedsl`) requires three methods to be implemented.
 
-1. `runtime_available() -> bool` : tell the user if the runtime is available - note that this needs to be available during init, and must be fork-safe. Packages should also not be imported at this time - rely on `importlib.util.find_spec(package_name)` or similar to get the necessary information without importing.
-2. `runtime_version() -> tuple[int, int, int]` : return the `(major, minor, update)` version of the installed package.
-3. `register_op(Callable[..., None])` : Register a given op, where `Callable[..., None]` is similar to those defined in [Creating and registering...]. This can contain DSL-specific checks / features, for example one might choose to only register ops only if the DSL version is one of a pre-approved list.
+`runtime_available() -> bool` : tell the user if the runtime is available - note that this needs to be available during init, and must be fork-safe. Packages should also not be imported at this time - rely on `importlib.util.find_spec(package_name)` or similar to get the necessary information without importing.
+
+`runtime_version() -> tuple[int, int, int]` : return the `(major, minor, update)` version of the installed package.
+
+
+```
+register_op_override(
+    lib_symbol: str,
+    op_symbol: str,
+    dispatch_key: str,
+    implementation_fn: _OpOverrideFn,
+) -> None
+```
+Register a given implementation to a library - `lib_symbol = "aten"` for most cases, `op_symbol` refers to the library method you wish to override (ex. `"_scaled_grouped_mm_v2"` from above), and dispatch key will generally be one of `("CPU", "CUDA")` depending on what backend you're overriding.
 
 An example of an implementation of this spec can be found in [cutedsl_utils.py](cutedsl_utils.py), but please talk to us if you're planning on adding a new DSL.

--- a/torch/_native/README.md
+++ b/torch/_native/README.md
@@ -1,6 +1,6 @@
 # Native Ops (and DSLs)
 
-The `torch._native` directory provides a place for ops written in python and DSLs, along with utilities to help facilitate this.
+The `torch._native` directory provides a place for PyTorch native ops written in python and DSLs, along with utilities to help facilitate this.
 
 # Creating & Registering a native op
 
@@ -8,72 +8,16 @@ The `torch._native` directory provides a place for ops written in python and DSL
 
 When writing native ops, they are required to interact meaningfully with torch's dispatcher, and thus must be registered correctly.
 
-As a further restriction, ops cannot be labelled as `CompositeImplicitAutograd` in `native_functions.yaml`, as-in the op must have an explicit autograd function registered, or at minimum an explicit implementation registered for the same backend as being overridden/added.
+As a further clarification, ops cannot be labelled as `CompositeImplicitAutograd` in `native_functions.yaml`, as-in the op must have an explicit autograd function registered, or at minimum an explicit implementation registered for the same backend as being overridden/added.
 
 ## A Note on Imports
 
 All registrations will happen at the end of `import torch`. It is expected at that point that **no DSL runtime library is loaded** - this means that the runtime(s) must only be imported lazily. We can still check the presence of a module, and get it's version without importing, but special care must be taken when writing op kernels to not import DSLs too early. An illustrative example is below, using `triton`:
 
-This is a simplified version of how one might naively write the op and it's registration code - first the registration
-```
-# torch/_native/op/test_op/__init__.py
-from ... import triton_utils as tu
-
-from .triton_impl import register_to_dispatch
-
-tu.register_kernel(register_to_dispatch
-```
-
-Then the op implementation itself.
+First, we're going to write the registration function, and a top-level call, being very careful to not pull in the `triton` package early:
 
 ```
-# torch/_native/op/test_op/triton_impl.py
-
-import triton
-
-@triton.jit
-def inner_fn(...) -> ...:
-  # depends internally on triton, triton.language
-    pass
-
-@triton.jit
-def outer_fn(...) -> ...:
-    # depends internally on triton, triton.language
-    inner_fn(...)
-
-def calling_fn(...):
-    torch.library.wrap_triton(outer_fn)(...)
-
-def register_to_dispatch():
-    torch.library.custom_op(...)(calling_fn)
-    torch.library.register_autograd(...)
-    torch.library.register_fake(...)
-
-register_to_dispatch()
-```
-
-Unfortunately, when `register_to_dispatch` is imported from `triton_impl.py`, the entire file is pulled in, including the `import triton` statement -- this causes triton to be imported during op registration, which for both time and memory reasons we do not wish to happen - instead we need `triton` imported lazily. We can work around this by splitting `triton_impl.py` into two files - one contains the methods that rely on `triton.jit` (and must therefore call `import triton`, and one that doesn't depend on triton, and can be safely imported during registration.
-
-First, the kernels are in their own file:
-
-```
-# torch/_native/ops/test_op/triton_kernels.py
-import triton
-
-@triton.jit
-def inner_fn(...) -> ...:
-  # depends internally on triton, triton.language
-    pass
-
-@triton.jit
-def outer_fn(...) -> ...:
-    # depends internally on triton, triton.language
-    inner_fn(...)
-```
-Then the calling / registration code can go in another, lazily importing the kernels:
-
-```
-# torch/_native/op/test_op/triton_impl.py
+# torch/_native/ops/test_op/triton_impl.py
 
 # NOTE: no triton import in the file
 
@@ -87,6 +31,23 @@ def register_to_dispatch():
     torch.library.register_autograd(...)
     torch.library.register_fake(...)
 
+```
+
+Note the lazy import of kernels inside `calling_fn` - this function isn't called during registration (it just needs to be defined), and on first call it'll import the `triton_kernels` module, with all its dependencies. This kernels module can import anything it wants internally, our restriction on no DSL imports during registration has been met. Quick example of `triton_kernels.py` below:
+
+```
+# torch/_native/ops/test_op/triton_kernels.py
+import triton
+
+@triton.jit
+def inner_fn(...) -> ...:
+    # depends internally on triton, triton.language
+    pass
+
+@triton.jit
+def outer_fn(...) -> ...:
+    # depends internally on triton, triton.language
+    inner_fn(...)
 ```
 
 
@@ -136,9 +97,10 @@ lib = None
 
 def my_impl(...) -> ...:
     """
-    Replacement implementation
+    Replacement implementation - laxy import actual implementation and run it
     """
-    pass
+    from .my_impl_kernel import my_kernel
+    return my_kernel(...)
 
 # Override the symbol `aten._scaled_grouped_mm_v2` in this example with the implementation in `my_impl`,
 # only when the check-method `enable_my_impl` returns `True`
@@ -172,11 +134,16 @@ def register_kernel_override():
 
 ## Registering a New Operator
 
-TODO
+We currently don't have any use for this, please come talk to us if you want this!
 
 # Adding a new DSL
 
 Adding a new DSL is as simple as adding a single helper utils file, then writing your op.
+
+Some universal utilities are provided in `common_utils.py`:
+* `check_native_jit_disabled() -> bool` : returns `True` if native DSL ops have been globally disabled.
+* `_available_version(package: str) -> tuple[int,int,int] | None` : Gets the installed version of `package` without importing it
+* `_unavailable_reasons(deps: list[tuple[str,str]]) -> str | None` : For a list of `(package_name, module_name)` pairs, check (without importing) if the module is available, returning a string describing the mitigation step if it isn't.
 
 ## DSL utils file spec
 
@@ -186,4 +153,4 @@ A DSL utils file, named `$dsl_utils.py` (i.e. `cutedsl_utils.py` for `$dsl=cuted
 2. `runtime_version() -> tuple[int, int, int]` : return the `(major, minor, update)` version of the installed package.
 3. `register_op(Callable[..., None])` : Register a given op, where `Callable[..., None]` is similar to those defined in [Creating and registering...]. This can contain DSL-specific checks / features, for example one might choose to only register ops only if the DSL version is one of a pre-approved list.
 
-An example of an implementation of this spec can be found in [cutedsl_utils.py](cutedsl_utils.py).
+An example of an implementation of this spec can be found in [cutedsl_utils.py](cutedsl_utils.py), but please talk to us if you're planning on adding a new DSL.

--- a/torch/_native/README.md
+++ b/torch/_native/README.md
@@ -14,7 +14,7 @@ Further, we expect the overriding function to take as the first argument `dispat
 
 ## A Note on Imports
 
-All registrations will happen at the end of `import torch`. It is expected at that point that **no DSL runtime library is loaded** - this means that the runtime(s) must only be imported lazily. We can still check the presence of a module, and get it's version without importing, but special care must be taken when writing op kernels to not import DSLs too early. An illustrative example is below, using `triton`:
+All registrations will happen at the end of `import torch`. It is expected at that point that **no DSL runtime library is loaded by registration code** - this means that the runtime(s) must only be imported lazily. We can still check the presence of a module, and get it's version without importing, but special care must be taken when writing op kernels to not import DSLs too early. An illustrative example is below, using `triton`:
 
 First, we're going to write the registration function, and a top-level call, being very careful to not pull in the `triton` package early:
 
@@ -82,13 +82,15 @@ def my_impl(dispatch_key, ...) -> ...:
     pass
 
 # Override the symbol `aten._scaled_grouped_mm_v2` in this example with the implementation in `my_impl`,
-# noting the function signatures must match
+# noting the function signatures must match.
+# Replacing an operator completely (no fallback) requires passing the `unconditional_override=True` flag.
 def register_kernel_override():
     tu.register_op_override(
         "aten",
         "_scaled_grouped_mm_v2",
         "CUDA",
         my_impl,
+        unconditional_override=True
     )
 ```
 
@@ -106,6 +108,21 @@ def my_impl(...) -> ...:
     from .my_impl_kernel import my_kernel
     return my_kernel(...)
 
+
+# Note the dispatch_keys argument here - this must be passed as the first argument
+# to the fallback kernel.
+# Also note that we need the `fallback_kernel` argument to be specified, as
+# we this function gets called every operator invocation - the "fallback" is
+# actually the currently registered function, which is... this one.
+def enable_my_impl(dispatch_keys, arg1, arg2, *args, fallback_kernel, **kwargs):
+    # determine if we want to call our implementation
+    if arg1 == ... and arg2 == ...:
+        return my_impl(arg1, arg2, *args, **kwargs)
+    else:
+        # Call the fallback
+        return fallback_kernel(dispatch_keys,
+                               arg1, arg2, *args, **kwargs)
+
 # Override the symbol `aten._scaled_grouped_mm_v2` in this example with the implementation in `my_impl`,
 # only when the check-method `enable_my_impl` returns `True`
 def register_kernel_override():
@@ -113,23 +130,16 @@ def register_kernel_override():
     # Get the original implementation for fallback purposes
     fallback_kernel = torch.library.get_kernel("aten::_scaled_grouped_mm_v2", "CUDA")
 
-    # Note the dispatch_keys argument here - this must be passed as the first argument
-    # to the fallback kernel
-    def enable_my_impl(dispatch_keys, arg1, arg2, *args, **kwargs) -> bool:
-        # determine if we want to call our implementation
-        if arg1 == ... and arg2 == ...:
-            return my_impl(arg1, arg2, *args, **kwargs)
-        else:
-            # Call the fallback
-            return fallback_kernel(dispatch_keys,
-                                   arg1, arg2, *args, **kwargs)
+    # partially-specialize our function so that we're not grabbing the
+    # fallback every invocation.
+    fn = functools.partial(enable_my_impl, fallback_kernel=fallback_kernel)
 
     # Same as before
     cu.register_op_override(
         "aten",
         "_scaled_grouped_mm_v2",
         "CUDA",
-        enable_my_impl,
+        fn,
     )
 ```
 

--- a/torch/_native/README.md
+++ b/torch/_native/README.md
@@ -161,8 +161,11 @@ register_op_override(
     op_symbol: str,
     dispatch_key: str,
     implementation_fn: _OpOverrideFn,
+    *,
+    allow_multiple_override: bool = False,
+    unconditional_override: bool = False,
 ) -> None
 ```
-Register a given implementation to a library - `lib_symbol = "aten"` for most cases, `op_symbol` refers to the library method you wish to override (ex. `"_scaled_grouped_mm_v2"` from above), and dispatch key will generally be one of `("CPU", "CUDA")` depending on what backend you're overriding.
+Register a given implementation to a library - `lib_symbol = "aten"` for most cases, `op_symbol` refers to the library method you wish to override (ex. `"_scaled_grouped_mm_v2"` from above), and dispatch key will generally be one of `("CPU", "CUDA")` depending on what backend you're overriding. For all arguments, please see the comments for `_register_op_override` in [registry.py](registry.py).
 
 An example of an implementation of this spec can be found in [cutedsl_utils.py](cutedsl_utils.py), but please talk to us if you're planning on adding a new DSL.

--- a/torch/_native/__init__.py
+++ b/torch/_native/__init__.py
@@ -1,7 +1,2 @@
 # This handles collecting registration of all native ops
 from . import ops
-from .registry import register_all_operators
-
-
-# Perform the outstanding registrations
-register_all_operators()

--- a/torch/_native/__init__.py
+++ b/torch/_native/__init__.py
@@ -1,7 +1,7 @@
-from .registry import register_all_operators
-
 # This handles collecting registration of all native ops
 from . import ops
+from .registry import register_all_operators
+
 
 # Perform the outstanding registrations
 register_all_operators()

--- a/torch/_native/__init__.py
+++ b/torch/_native/__init__.py
@@ -1,0 +1,7 @@
+from .registry import register_all_operators
+
+# This handles collecting registration of all native ops
+from . import ops
+
+# Perform the outstanding registrations
+register_all_operators()

--- a/torch/_native/common_utils.py
+++ b/torch/_native/common_utils.py
@@ -5,6 +5,7 @@ from functools import cache
 
 import packaging.version
 
+
 @cache
 def check_native_jit_disabled() -> bool:
     """
@@ -45,13 +46,12 @@ def _available_version(package: str) -> packaging.version.Version | None:
     except importlib.metadata.PackageNotFoundError:
         return None
 
-
     try:
         v = packaging.version.parse(version)
     except packaging.version.InvalidVersion:
         return None
 
-    return v # (v.major, v.minor, v.micro)
+    return v
 
 
 @cache

--- a/torch/_native/common_utils.py
+++ b/torch/_native/common_utils.py
@@ -1,8 +1,8 @@
 import importlib
 import importlib.metadata
 import os
-
 from functools import cache
+
 
 @cache
 def check_native_jit_disabled() -> bool:
@@ -31,6 +31,7 @@ def _unavailable_reason(deps: list[tuple[str, str]]) -> None | str:
             )
     return None
 
+
 def _available_version(package: str) -> tuple[int, int, int]:
     """
     Get version of the installed "nvidia-cutlass-dsl" package
@@ -42,5 +43,3 @@ def _available_version(package: str) -> tuple[int, int, int]:
     major, minor, update = (int(vi) for vi in version.split("."))
 
     return (major, minor, update)
-
-

--- a/torch/_native/common_utils.py
+++ b/torch/_native/common_utils.py
@@ -22,8 +22,7 @@ def _unavailable_reason(deps: list[tuple[str, str]]) -> None | str:
     NOTE: Doesn't actually import anything.
     """
     for package_name, module_name in deps:
-        # This doesn't actually import the packages, to reduce
-        # overall import time & memory.
+        # Note this doesn't actually import the packages
         if importlib.util.find_spec(module_name) is None:
             return (
                 f"missing optional dependency `{package_name}` "
@@ -32,14 +31,34 @@ def _unavailable_reason(deps: list[tuple[str, str]]) -> None | str:
     return None
 
 
-def _available_version(package: str) -> tuple[int, int, int]:
+def _available_version(package: str) -> tuple[int, int, int] | None:
     """
-    Get version of the installed "nvidia-cutlass-dsl" package
+    Get the installed version of a package as (major, minor, patch).
 
-    Assumes the package exists, i.e. will fail if it doesn't
+    Handles pre-release suffixes like "0.7.0rc1" or "3.1.0.post1" by
+    stripping non-numeric tails from each component. Returns None on
+    parse failure.
     """
-    version = importlib.metadata.version(package)
+    try:
+        version = importlib.metadata.version(package)
+    except importlib.metadata.PackageNotFoundError:
+        return None
 
-    major, minor, update = (int(vi) for vi in version.split("."))
+    import packaging.version
 
-    return (major, minor, update)
+    try:
+        v = packaging.version.parse(version)
+    except packaging.version.InvalidVersion:
+        return None
+
+    return (v.major, v.minor, v.micro)
+
+
+@cache
+def check_native_version_skip() -> bool:
+    """
+    Single point to check if native DSL version gating should be skipped,
+    checked via:
+    TORCH_NATIVE_SKIP_VERSION_CHECK=1
+    """
+    return int(os.getenv("TORCH_NATIVE_SKIP_VERSION_CHECK", 0)) == 1

--- a/torch/_native/common_utils.py
+++ b/torch/_native/common_utils.py
@@ -3,6 +3,7 @@ import importlib.metadata
 import os
 from functools import cache
 
+import packaging.version
 
 @cache
 def check_native_jit_disabled() -> bool:
@@ -31,7 +32,7 @@ def _unavailable_reason(deps: list[tuple[str, str]]) -> None | str:
     return None
 
 
-def _available_version(package: str) -> tuple[int, int, int] | None:
+def _available_version(package: str) -> packaging.version.Version | None:
     """
     Get the installed version of a package as (major, minor, patch).
 
@@ -44,14 +45,13 @@ def _available_version(package: str) -> tuple[int, int, int] | None:
     except importlib.metadata.PackageNotFoundError:
         return None
 
-    import packaging.version
 
     try:
         v = packaging.version.parse(version)
     except packaging.version.InvalidVersion:
         return None
 
-    return (v.major, v.minor, v.micro)
+    return v # (v.major, v.minor, v.micro)
 
 
 @cache

--- a/torch/_native/common_utils.py
+++ b/torch/_native/common_utils.py
@@ -1,0 +1,46 @@
+import importlib
+import importlib.metadata
+import os
+
+from functools import cache
+
+@cache
+def check_native_jit_disabled() -> bool:
+    """
+    Single point to check if native DSL ops are disabled globally,
+    checked via:
+    TORCH_DISABLE_NATIVE_JIT=1
+    """
+    return int(os.getenv("TORCH_DISABLE_NATIVE_JIT", 0)) == 1
+
+
+def _unavailable_reason(deps: list[tuple[str, str]]) -> None | str:
+    """
+    Check availability of required packages - cuteDSL & deps,
+    informing user what (if anything) is missing
+
+    NOTE: Doesn't actually import anything.
+    """
+    for package_name, module_name in deps:
+        # This doesn't actually import the packages, to reduce
+        # overall import time & memory.
+        if importlib.util.find_spec(module_name) is None:
+            return (
+                f"missing optional dependency `{package_name}` "
+                f"(importlib.util.find_spec({package_name}) failed)"
+            )
+    return None
+
+def _available_version(package: str) -> tuple[int, int, int]:
+    """
+    Get version of the installed "nvidia-cutlass-dsl" package
+
+    Assumes the package exists, i.e. will fail if it doesn't
+    """
+    version = importlib.metadata.version(package)
+
+    major, minor, update = (int(vi) for vi in version.split("."))
+
+    return (major, minor, update)
+
+

--- a/torch/_native/cutedsl_utils.py
+++ b/torch/_native/cutedsl_utils.py
@@ -59,13 +59,19 @@ def runtime_version() -> None | Version:
     return version
 
 
+@functools.cache
 def _version_is_ok() -> bool:
     _, version = _check_runtime_available()
-    if version is None:
-        return False
-    if check_native_version_skip():
+    if check_native_version_skip() or (version in _CUTEDSL_REQUIRED_VERSIONS):
         return True
-    return version in _CUTEDSL_REQUIRED_VERSIONS
+
+    log.info(
+        "cutedsl version %s is not known-good (ok: %s); "
+        "set TORCH_NATIVE_SKIP_VERSION_CHECK=1 to override",
+        version,
+        _CUTEDSL_REQUIRED_VERSIONS,
+    )
+    return False
 
 
 def register_op_override(
@@ -87,12 +93,6 @@ def register_op_override(
         return
 
     if not _version_is_ok():
-        log.warning(
-            "cutedsl version %s is not known-good (ok: %s); "
-            "set TORCH_NATIVE_SKIP_VERSION_CHECK=1 to override",
-            version,
-            _CUTEDSL_REQUIRED_VERSIONS,
-        )
         return
 
     _register_op_override(

--- a/torch/_native/cutedsl_utils.py
+++ b/torch/_native/cutedsl_utils.py
@@ -7,10 +7,7 @@ from .common_utils import (
     check_native_jit_disabled,
     check_native_version_skip,
 )
-from .registry import (
-    _OpFn,
-    _register_op_override,
-)
+from .registry import _OpFn, _register_op_override
 
 
 log = logging.getLogger(__name__)

--- a/torch/_native/cutedsl_utils.py
+++ b/torch/_native/cutedsl_utils.py
@@ -7,7 +7,7 @@ from .common_utils import (
     check_native_jit_disabled,
     check_native_version_skip,
 )
-from .registry import _RegisterFn, register_op_registerer
+from .registry import _OpOverrideFn, _register_op_override
 
 
 log = logging.getLogger(__name__)
@@ -65,7 +65,14 @@ def _version_is_blessed() -> bool:
     return version in _CUTEDSL_BLESSED_VERSIONS
 
 
-def register_op(fn: _RegisterFn) -> None:
+def register_op_override(
+    lib_symbol: str,
+    op_symbol: str,
+    dispatch_key: str,
+    impl: _OpOverrideFn,
+    *,
+    allow_override=False,
+) -> None:
     available, version = _check_runtime_available()
     if (not available) or check_native_jit_disabled():
         return
@@ -79,4 +86,10 @@ def register_op(fn: _RegisterFn) -> None:
         )
         return
 
-    register_op_registerer(fn)
+    _register_op_override(
+        lib_symbol,
+        op_symbol,
+        dispatch_key,
+        impl,
+        allow_override=allow_override,
+    )

--- a/torch/_native/cutedsl_utils.py
+++ b/torch/_native/cutedsl_utils.py
@@ -1,15 +1,13 @@
 import functools
-import importlib
-import importlib.metadata
 import logging
-import os
 
-from .registry import register_op_registerer, _RegisterFn
 from .common_utils import (
-    check_native_jit_disabled,
     _available_version,
     _unavailable_reason,
+    check_native_jit_disabled,
 )
+from .registry import _RegisterFn, register_op_registerer
+
 
 log = logging.getLogger(__name__)
 
@@ -17,6 +15,7 @@ _CUTEDSL_AVAILABLE = None
 _CUTEDSL_VERSION = None
 
 log = logging.getLogger(__name__)
+
 
 @functools.cache
 def _check_runtime_available() -> bool:
@@ -31,10 +30,11 @@ def _check_runtime_available() -> bool:
     if _CUTEDSL_AVAILABLE is not None:
         return _CUTEDSL_AVAILABLE
 
-    deps = [("nvidia_cutlass_dsl", "cutlass"),
-            ("apache_tvm_ffi", "tvm_ffi"),
-            ("cuda_bindings", "cuda.bindings.driver"),
-           ]
+    deps = [
+        ("nvidia_cutlass_dsl", "cutlass"),
+        ("apache_tvm_ffi", "tvm_ffi"),
+        ("cuda_bindings", "cuda.bindings.driver"),
+    ]
     reason = _unavailable_reason(deps)
     if reason is None:
         _CUTEDSL_AVAILABLE = True
@@ -49,17 +49,21 @@ def _check_runtime_available() -> bool:
         _CUTEDSL_AVAILABLE = False
     return _CUTEDSL_AVAILABLE
 
+
 _check_runtime_available()
 
-def runtime_available() -> bool:
+
+def runtime_available() -> None | bool:
     return _CUTEDSL_AVAILABLE
+
 
 def runtime_version() -> None | tuple[int, int, int]:
     return _CUTEDSL_VERSION
 
+
 def register_op(fn: _RegisterFn) -> None:
     if (not _CUTEDSL_AVAILABLE) or check_native_jit_disabled():
-        log.info(f'{__name__} not registering native ops')
+        log.info("%s not registering native ops", __name__)
         return
 
     register_op_registerer(fn)

--- a/torch/_native/cutedsl_utils.py
+++ b/torch/_native/cutedsl_utils.py
@@ -5,11 +5,18 @@ from .common_utils import (
     _available_version,
     _unavailable_reason,
     check_native_jit_disabled,
+    check_native_version_skip,
 )
 from .registry import _RegisterFn, register_op_registerer
 
 
 log = logging.getLogger(__name__)
+
+
+_CUTEDSL_BLESSED_VERSIONS: set[tuple[int, int, int]] = {
+    # Current version
+    (4, 4, 1),
+}
 
 
 @functools.cache
@@ -22,7 +29,6 @@ def _check_runtime_available() -> tuple[bool, tuple[int, int, int] | None]:
     deps = [
         ("nvidia_cutlass_dsl", "cutlass"),
         ("apache_tvm_ffi", "tvm_ffi"),
-        ("cuda_bindings", "cuda.bindings.driver"),
     ]
     reason = _unavailable_reason(deps)
     if reason is None:
@@ -31,8 +37,8 @@ def _check_runtime_available() -> tuple[bool, tuple[int, int, int] | None]:
     else:
         log.info(
             "CuTeDSL operators require optional Python packages "
-            "`nvidia-cutlass-dsl`, `apache-tvm-ffi`, and `cuda-bindings` "
-            "(from NVIDIA cuda-python); %s",
+            "`nvidia-cutlass-dsl` and `apache-tvm-ffi`; "
+            "%s",
             reason,
         )
         available = False
@@ -40,7 +46,7 @@ def _check_runtime_available() -> tuple[bool, tuple[int, int, int] | None]:
     return available, version
 
 
-def runtime_available() -> None | bool:
+def runtime_available() -> bool:
     available, _ = _check_runtime_available()
     return available
 
@@ -50,9 +56,27 @@ def runtime_version() -> None | tuple[int, int, int]:
     return version
 
 
+def _version_is_blessed() -> bool:
+    _, version = _check_runtime_available()
+    if version is None:
+        return False
+    if check_native_version_skip():
+        return True
+    return version in _CUTEDSL_BLESSED_VERSIONS
+
+
 def register_op(fn: _RegisterFn) -> None:
-    available, _ = _check_runtime_available()
+    available, version = _check_runtime_available()
     if (not available) or check_native_jit_disabled():
+        return
+
+    if not _version_is_blessed():
+        log.warning(
+            "cutedsl version %s is not blessed (blessed: %s); "
+            "set TORCH_NATIVE_SKIP_VERSION_CHECK=1 to override",
+            version,
+            _CUTEDSL_BLESSED_VERSIONS,
+        )
         return
 
     register_op_registerer(fn)

--- a/torch/_native/cutedsl_utils.py
+++ b/torch/_native/cutedsl_utils.py
@@ -11,25 +11,14 @@ from .registry import _RegisterFn, register_op_registerer
 
 log = logging.getLogger(__name__)
 
-_CUTEDSL_AVAILABLE = None
-_CUTEDSL_VERSION = None
-
-log = logging.getLogger(__name__)
-
 
 @functools.cache
-def _check_runtime_available() -> bool:
+def _check_runtime_available() -> tuple[bool, tuple[int, int, int] | None]:
     """
     Check if cutedsl (and deps) are available.
 
     NOTE: Doesn't import at this point
     """
-    global _CUTEDSL_AVAILABLE
-    global _CUTEDSL_VERSION
-
-    if _CUTEDSL_AVAILABLE is not None:
-        return _CUTEDSL_AVAILABLE
-
     deps = [
         ("nvidia_cutlass_dsl", "cutlass"),
         ("apache_tvm_ffi", "tvm_ffi"),
@@ -37,33 +26,33 @@ def _check_runtime_available() -> bool:
     ]
     reason = _unavailable_reason(deps)
     if reason is None:
-        _CUTEDSL_AVAILABLE = True
-        _CUTEDSL_VERSION = _available_version("nvidia_cutlass_dsl")
+        available = True
+        version = _available_version("nvidia_cutlass_dsl")
     else:
-        print(
+        log.info(
             "CuTeDSL operators require optional Python packages "
             "`nvidia-cutlass-dsl`, `apache-tvm-ffi`, and `cuda-bindings` "
-            "(from NVIDIA cuda-python); "
-            f"{reason}"
+            "(from NVIDIA cuda-python); %s",
+            reason,
         )
-        _CUTEDSL_AVAILABLE = False
-    return _CUTEDSL_AVAILABLE
-
-
-_check_runtime_available()
+        available = False
+        version = None
+    return available, version
 
 
 def runtime_available() -> None | bool:
-    return _CUTEDSL_AVAILABLE
+    available, _ = _check_runtime_available()
+    return available
 
 
 def runtime_version() -> None | tuple[int, int, int]:
-    return _CUTEDSL_VERSION
+    _, version = _check_runtime_available()
+    return version
 
 
 def register_op(fn: _RegisterFn) -> None:
-    if (not _CUTEDSL_AVAILABLE) or check_native_jit_disabled():
-        log.info("%s not registering native ops", __name__)
+    available, _ = _check_runtime_available()
+    if (not available) or check_native_jit_disabled():
         return
 
     register_op_registerer(fn)

--- a/torch/_native/cutedsl_utils.py
+++ b/torch/_native/cutedsl_utils.py
@@ -7,7 +7,10 @@ from .common_utils import (
     check_native_jit_disabled,
     check_native_version_skip,
 )
-from .registry import _OpOverrideFn, _register_op_override
+from .registry import (
+    _OpFn,
+    _register_op_override,
+)
 
 
 log = logging.getLogger(__name__)
@@ -69,10 +72,16 @@ def register_op_override(
     lib_symbol: str,
     op_symbol: str,
     dispatch_key: str,
-    impl: _OpOverrideFn,
+    impl: _OpFn,
     *,
-    allow_override=False,
+    allow_multiple_override: bool = False,
+    unconditional_override: bool = False,
 ) -> None:
+    """
+    See torch/_native/registry.py for the underlying implementation
+    and arguments. This is a thin, DSL-checking wrapper over
+    _register_op_override
+    """
     available, version = _check_runtime_available()
     if (not available) or check_native_jit_disabled():
         return
@@ -91,5 +100,6 @@ def register_op_override(
         op_symbol,
         dispatch_key,
         impl,
-        allow_override=allow_override,
+        allow_multiple_override=allow_multiple_override,
+        unconditional_override=unconditional_override,
     )

--- a/torch/_native/cutedsl_utils.py
+++ b/torch/_native/cutedsl_utils.py
@@ -9,18 +9,20 @@ from .common_utils import (
 )
 from .registry import _OpFn, _register_op_override
 
+from packaging.version import Version
 
 log = logging.getLogger(__name__)
 
 
-_CUTEDSL_BLESSED_VERSIONS: set[tuple[int, int, int]] = {
-    # Current version
-    (4, 4, 1),
+_CUTEDSL_REQUIRED_VERSIONS: set[Version] = {
+    # Current version - Note Version.from_part(release=(4.4.1)) is better
+    #                   but > v26 of packaging.
+    Version(f'{4}.{4}.{1}'),
 }
 
 
 @functools.cache
-def _check_runtime_available() -> tuple[bool, tuple[int, int, int] | None]:
+def _check_runtime_available() -> tuple[bool, Version | None]:
     """
     Check if cutedsl (and deps) are available.
 
@@ -51,18 +53,18 @@ def runtime_available() -> bool:
     return available
 
 
-def runtime_version() -> None | tuple[int, int, int]:
+def runtime_version() -> None | Version:
     _, version = _check_runtime_available()
     return version
 
 
-def _version_is_blessed() -> bool:
+def _version_is_ok() -> bool:
     _, version = _check_runtime_available()
     if version is None:
         return False
     if check_native_version_skip():
         return True
-    return version in _CUTEDSL_BLESSED_VERSIONS
+    return version in _CUTEDSL_REQUIRED_VERSIONS
 
 
 def register_op_override(
@@ -83,12 +85,12 @@ def register_op_override(
     if (not available) or check_native_jit_disabled():
         return
 
-    if not _version_is_blessed():
+    if not _version_is_ok():
         log.warning(
-            "cutedsl version %s is not blessed (blessed: %s); "
+            "cutedsl version %s is not known-good (ok: %s); "
             "set TORCH_NATIVE_SKIP_VERSION_CHECK=1 to override",
             version,
-            _CUTEDSL_BLESSED_VERSIONS,
+            _CUTEDSL_REQUIRED_VERSIONS,
         )
         return
 

--- a/torch/_native/cutedsl_utils.py
+++ b/torch/_native/cutedsl_utils.py
@@ -1,6 +1,8 @@
 import functools
 import logging
 
+from packaging.version import Version
+
 from .common_utils import (
     _available_version,
     _unavailable_reason,
@@ -9,7 +11,6 @@ from .common_utils import (
 )
 from .registry import _OpFn, _register_op_override
 
-from packaging.version import Version
 
 log = logging.getLogger(__name__)
 
@@ -17,7 +18,7 @@ log = logging.getLogger(__name__)
 _CUTEDSL_REQUIRED_VERSIONS: set[Version] = {
     # Current version - Note Version.from_part(release=(4.4.1)) is better
     #                   but > v26 of packaging.
-    Version(f'{4}.{4}.{1}'),
+    Version(f"{4}.{4}.{1}"),
 }
 
 

--- a/torch/_native/cutedsl_utils.py
+++ b/torch/_native/cutedsl_utils.py
@@ -1,0 +1,65 @@
+import functools
+import importlib
+import importlib.metadata
+import logging
+import os
+
+from .registry import register_op_registerer, _RegisterFn
+from .common_utils import (
+    check_native_jit_disabled,
+    _available_version,
+    _unavailable_reason,
+)
+
+log = logging.getLogger(__name__)
+
+_CUTEDSL_AVAILABLE = None
+_CUTEDSL_VERSION = None
+
+log = logging.getLogger(__name__)
+
+@functools.cache
+def _check_runtime_available() -> bool:
+    """
+    Check if cutedsl (and deps) are available.
+
+    NOTE: Doesn't import at this point
+    """
+    global _CUTEDSL_AVAILABLE
+    global _CUTEDSL_VERSION
+
+    if _CUTEDSL_AVAILABLE is not None:
+        return _CUTEDSL_AVAILABLE
+
+    deps = [("nvidia_cutlass_dsl", "cutlass"),
+            ("apache_tvm_ffi", "tvm_ffi"),
+            ("cuda_bindings", "cuda.bindings.driver"),
+           ]
+    reason = _unavailable_reason(deps)
+    if reason is None:
+        _CUTEDSL_AVAILABLE = True
+        _CUTEDSL_VERSION = _available_version("nvidia_cutlass_dsl")
+    else:
+        print(
+            "CuTeDSL operators require optional Python packages "
+            "`nvidia-cutlass-dsl`, `apache-tvm-ffi`, and `cuda-bindings` "
+            "(from NVIDIA cuda-python); "
+            f"{reason}"
+        )
+        _CUTEDSL_AVAILABLE = False
+    return _CUTEDSL_AVAILABLE
+
+_check_runtime_available()
+
+def runtime_available() -> bool:
+    return _CUTEDSL_AVAILABLE
+
+def runtime_version() -> None | tuple[int, int, int]:
+    return _CUTEDSL_VERSION
+
+def register_op(fn: _RegisterFn) -> None:
+    if (not _CUTEDSL_AVAILABLE) or check_native_jit_disabled():
+        log.info(f'{__name__} not registering native ops')
+        return
+
+    register_op_registerer(fn)

--- a/torch/_native/native_dsl_ops.md
+++ b/torch/_native/native_dsl_ops.md
@@ -162,7 +162,7 @@ def register_kernel_override():
             # Call the fallback
             return fallback_kernel(dispatch_keys,
                                    arg1, arg2, *args, **kwargs)
-    
+
     # Same as before
     lib = torch.library.Library("aten", "IMPL", "CUDA")
     # Pass the enablement function, note needed with_keyset=True argument to
@@ -176,7 +176,7 @@ TODO
 
 # Adding a new DSL
 
-Adding a new DSL is as simple as adding a single helper utils file, then writing your op. 
+Adding a new DSL is as simple as adding a single helper utils file, then writing your op.
 
 ## DSL utils file spec
 

--- a/torch/_native/native_dsl_ops.md
+++ b/torch/_native/native_dsl_ops.md
@@ -1,0 +1,189 @@
+# Native Ops (and DSLs)
+
+The `torch._native` directory provides a place for ops written in python and DSLs, along with utilities to help facilitate this.
+
+# Creating & Registering a native op
+
+**All native ops must be registered to the dispatcher**
+
+When writing native ops, they are required to interact meaningfully with torch's dispatcher, and thus must be registered correctly.
+
+As a further restriction, ops cannot be labelled as `CompositeImplicitAutograd` in `native_functions.yaml`, as-in the op must have an explicit autograd function registered, or at minimum an explicit implementation registered for the same backend as being overridden/added.
+
+## A Note on Imports
+
+All registrations will happen at the end of `import torch`. It is expected at that point that **no DSL runtime library is loaded** - this means that the runtime(s) must only be imported lazily. We can still check the presence of a module, and get it's version without importing, but special care must be taken when writing op kernels to not import DSLs too early. An illustrative example is below, using `triton`:
+
+This is a simplified version of how one might naively write the op and it's registration code - first the registration
+```
+# torch/_native/op/test_op/__init__.py
+from ... import triton_utils as tu
+
+from .triton_impl import register_to_dispatch
+
+tu.register_kernel(register_to_dispatch
+```
+
+Then the op implementation itself.
+
+```
+# torch/_native/op/test_op/triton_impl.py
+
+import triton
+
+@triton.jit
+def inner_fn(...) -> ...:
+  # depends internally on triton, triton.language
+    pass
+
+@triton.jit
+def outer_fn(...) -> ...:
+    # depends internally on triton, triton.language
+    inner_fn(...)
+
+def calling_fn(...):
+    torch.library.wrap_triton(outer_fn)(...)
+
+def register_to_dispatch():
+    torch.library.custom_op(...)(calling_fn)
+    torch.library.register_autograd(...)
+    torch.library.register_fake(...)
+
+register_to_dispatch()
+```
+
+Unfortunately, when `register_to_dispatch` is imported from `triton_impl.py`, the entire file is pulled in, including the `import triton` statement -- this causes triton to be imported during op registration, which for both time and memory reasons we do not wish to happen - instead we need `triton` imported lazily. We can work around this by splitting `triton_impl.py` into two files - one contains the methods that rely on `triton.jit` (and must therefore call `import triton`, and one that doesn't depend on triton, and can be safely imported during registration.
+
+First, the kernels are in their own file:
+
+```
+# torch/_native/ops/test_op/triton_kernels.py
+import triton
+
+@triton.jit
+def inner_fn(...) -> ...:
+  # depends internally on triton, triton.language
+    pass
+
+@triton.jit
+def outer_fn(...) -> ...:
+    # depends internally on triton, triton.language
+    inner_fn(...)
+```
+Then the calling / registration code can go in another, lazily importing the kernels:
+
+```
+# torch/_native/op/test_op/triton_impl.py
+
+# NOTE: no triton import in the file
+
+def calling_fn(...):
+    # Lazily import the kernels (and triton) on first call
+    from .triton_kernels import outer_fn
+    torch.library.wrap_triton(outer_fn)(...)
+
+def register_to_dispatch():
+    torch.library.custom_op(...)(calling_fn)
+    torch.library.register_autograd(...)
+    torch.library.register_fake(...)
+
+```
+
+
+## Registering Implementations to Existing Operators
+
+There are 2 options when interacting with an existing operator:
+1. Replace the operator for **all** cases with a new implementation
+2. Replace **some subset of functionality** of a given operator with a new implementation, falling-back to the original implementation otherwise.
+
+Both cases are very similar, with 2) only requiring an extra step to obtain the original implementation, and logic to determine which implementation should be run for a given case.
+
+### Replacing an Operator
+
+This follows a simple and standard path, with a good example being the implementation of [FlashAttention v4 (FAv4)](https://github.com/pytorch/pytorch/blob/1f66f34cda5b5ad02d231b90fa0c0de2cb4e02d1/torch/nn/attention/_fa4.py#L67) in torch.
+
+The following example replaces the implementation of `aten._scaled_grouped_mm_v2` on `CUDA` devices:
+
+```
+# Note this must be global to avoid getting garbage collected
+lib = None
+
+def my_impl(...) -> ...:
+    """
+    Replacement implementation
+    """
+    pass
+
+# Override the symbol `aten._scaled_grouped_mm_v2` in this example with the implementation in `my_impl`,
+# noting the function signatures must match
+def register_kernel_override():
+    global lib
+
+    # If already registered, don't do it again
+    if lib is not None:
+        return
+
+    lib = torch.library.Library("aten", "IMPL", "CUDA")
+    lib.impl("_scaled_grouped_mm_v2", my_impl, "CUDA")
+```
+
+### Replacing a Subset of Calls
+
+This time we only want to override the behavior of a subset of `aten._scaled_grouped_mm_v2` calls, and choose whether to invoke our implementation or the original depending on some input arguments. Note that the core of the example -- creating a `torch.library.Library`, and registering our function using `lib.impl(...)` are the same as in [Replacing an Operator](#Replacing-an-Operator).
+
+```
+lib = None
+
+def my_impl(...) -> ...:
+    """
+    Replacement implementation
+    """
+    pass
+
+# Override the symbol `aten._scaled_grouped_mm_v2` in this example with the implementation in `my_impl`,
+# only when the check-method `enable_my_impl` returns `True`
+def register_kernel_override():
+    global lib
+
+    # If already registered, don't do it again
+    if lib is not None:
+        return
+
+    # Get the original implementation for fallback purposes
+    fallback_kernel = torch.library.get_kernel("aten::_scaled_grouped_mm_v2", "CUDA")
+
+    # Note the dispatch_keys argument here - this must be passed as the first argument
+    # to the fallback kernel
+    def enable_my_impl(dispatch_keys, arg1, arg2, *args, **kwargs) -> bool:
+        # determine if we want to call our implementation
+        if arg1 == ... and arg2 == ...:
+            return my_impl(arg1, arg2, *args, **kwargs)
+        else:
+            # Call the fallback
+            return fallback_kernel(dispatch_keys,
+                                   arg1, arg2, *args, **kwargs)
+    
+    # Same as before
+    lib = torch.library.Library("aten", "IMPL", "CUDA")
+    # Pass the enablement function, note needed with_keyset=True argument to
+    # get and pass dispatch keys
+    lib.impl("_scaled_grouped_mm_v2", enable_my_impl, "CUDA", with_keyset=True)
+```
+
+## Registering a New Operator
+
+TODO
+
+# Adding a new DSL
+
+Adding a new DSL is as simple as adding a single helper utils file, then writing your op. 
+
+## DSL utils file spec
+
+A DSL utils file, named `$dsl_utils.py` (i.e. `cutedsl_utils.py` for `$dsl=cutedsl`) requires three methods to be implemented.
+
+1. `runtime_available() -> bool` : tell the user if the runtime is available - note that this needs to be available during init, and must be fork-safe. Packages should also not be imported at this time - rely on `importlib.util.find_spec(package_name)` or similar to get the necessary information without importing.
+2. `runtime_version() -> tuple[int, int, int]` : return the `(major, minor, update)` version of the installed package.
+3. `register_op(Callable[..., None])` : Register a given op, where `Callable[..., None]` is similar to those defined in [Creating and registering...]. This can contain DSL-specific checks / features, for example one might choose to only register ops only if the DSL version is one of a pre-approved list.
+
+An example of an implementation of this spec can be found in [cutedsl_utils.py](cutedsl_utils.py).

--- a/torch/_native/ops/__init__.py
+++ b/torch/_native/ops/__init__.py
@@ -1,1 +1,0 @@
-from .. import cutedsl_utils as cu, triton_utils as tu

--- a/torch/_native/ops/__init__.py
+++ b/torch/_native/ops/__init__.py
@@ -1,2 +1,1 @@
 from .. import cutedsl_utils as cu, triton_utils as tu
-from . import cutedsl_mxfp8_scaled_grouped_mm, mxfp8_quant

--- a/torch/_native/ops/__init__.py
+++ b/torch/_native/ops/__init__.py
@@ -1,5 +1,2 @@
-from .. import cutedsl_utils as cu
-from .. import triton_utils as tu
-
-from . import cutedsl_mxfp8_scaled_grouped_mm
-from . import mxfp8_quant
+from .. import cutedsl_utils as cu, triton_utils as tu
+from . import cutedsl_mxfp8_scaled_grouped_mm, mxfp8_quant

--- a/torch/_native/ops/__init__.py
+++ b/torch/_native/ops/__init__.py
@@ -1,0 +1,5 @@
+from .. import cutedsl_utils as cu
+from .. import triton_utils as tu
+
+from . import cutedsl_mxfp8_scaled_grouped_mm
+from . import mxfp8_quant

--- a/torch/_native/registry.py
+++ b/torch/_native/registry.py
@@ -1,15 +1,52 @@
 from collections.abc import Callable
+from typing import Concatenate, ParamSpec, TypeVar
+
+import torch.library
 
 
-_RegisterFn = Callable[[], None]
+P = ParamSpec("P")
+R = TypeVar("R")
 
-_RegisteredFns: list[_RegisterFn] = []
-
-
-def register_op_registerer(fn: _RegisterFn) -> None:
-    _RegisteredFns.append(fn)
+_OpOverrideFn = Callable[Concatenate[torch.DispatchKeySet, P], R]
 
 
-def register_all_operators() -> None:
-    for fn in _RegisteredFns:
-        fn()
+libs = {}
+
+
+def _get_library(lib_symbol: str, dispatch_key: str) -> torch.library.Library:
+    """
+    Return a `torch.library.Library` instance unique to the passed
+    (lib_symbol, dispatch_key) pair. Create a new instance if necessary.
+    """
+    global libs
+
+    if (lib_symbol, dispatch_key) not in libs:
+        print(f"CREATING LIB: {lib_symbol=} : {dispatch_key=}")
+        libs[(lib_symbol, dispatch_key)] = torch.library.Library(
+            lib_symbol, "IMPL", dispatch_key
+        )
+
+    return libs[(lib_symbol, dispatch_key)]
+
+
+def _register_op_override(
+    lib_symbol: str,
+    op_symbol: str,
+    dispatch_key: str,
+    impl: _OpOverrideFn,
+    *,
+    allow_override=False,
+) -> None:
+    """
+    Register a passed override function to the dispatcher, based on the
+    passed lib and op symbols, and the dispatch key.
+    """
+    lib = _get_library(lib_symbol, dispatch_key)
+
+    lib.impl(
+        op_symbol,
+        impl,
+        dispatch_key,
+        with_keyset=True,
+        allow_override=allow_override,
+    )

--- a/torch/_native/registry.py
+++ b/torch/_native/registry.py
@@ -11,6 +11,5 @@ def register_op_registerer(fn: _RegisterFn) -> None:
 
 
 def register_all_operators() -> None:
-    print(f"{__name__=} registering {len(_RegisteredFns)} ops")
     for fn in _RegisteredFns:
         fn()

--- a/torch/_native/registry.py
+++ b/torch/_native/registry.py
@@ -1,15 +1,16 @@
 from collections.abc import Callable
 
+
 _RegisterFn = Callable[[], None]
 
-_RegisteredFns : list[_RegisterFn] = []
+_RegisteredFns: list[_RegisterFn] = []
+
 
 def register_op_registerer(fn: _RegisterFn) -> None:
     _RegisteredFns.append(fn)
 
+
 def register_all_operators() -> None:
-    print(f'{__name__=} registering {len(_RegisteredFns)} ops')
+    print(f"{__name__=} registering {len(_RegisteredFns)} ops")
     for fn in _RegisteredFns:
         fn()
-
-

--- a/torch/_native/registry.py
+++ b/torch/_native/registry.py
@@ -24,7 +24,6 @@ def _get_library(lib_symbol: str, dispatch_key: str) -> torch.library.Library:
     global libs
 
     if (lib_symbol, dispatch_key) not in libs:
-        print(f"CREATING LIB: {lib_symbol=} : {dispatch_key=}")
         libs[(lib_symbol, dispatch_key)] = torch.library.Library(
             lib_symbol, "IMPL", dispatch_key
         )

--- a/torch/_native/registry.py
+++ b/torch/_native/registry.py
@@ -8,6 +8,9 @@ P = ParamSpec("P")
 R = TypeVar("R")
 
 _OpOverrideFn = Callable[Concatenate[torch.DispatchKeySet, P], R]
+_OpReplaceFn = Callable[P, R]
+
+_OpFn = _OpOverrideFn | _OpReplaceFn
 
 
 libs = {}
@@ -33,13 +36,22 @@ def _register_op_override(
     lib_symbol: str,
     op_symbol: str,
     dispatch_key: str,
-    impl: _OpOverrideFn,
+    impl: _OpOverrideFn | _OpReplaceFn,
     *,
-    allow_override=False,
+    allow_multiple_override=False,
+    unconditional_override=False,
 ) -> None:
     """
     Register a passed override function to the dispatcher, based on the
     passed lib and op symbols, and the dispatch key.
+
+    lib_symbol: str - library yourve overriding symbols in (generally "aten")
+    op_symbol: str - name of the op you're overriding
+    dispatch_key: str - dispatch key to override
+    impl: Fn - implementation for the override
+    allow_multiple_override: bool - allow overriding an existing override
+    unconditional_override: bool - Impl doesn't have a fallback, and doesn't require
+                                   torch.DispatchKeySet as the first argument.
     """
     lib = _get_library(lib_symbol, dispatch_key)
 
@@ -47,6 +59,6 @@ def _register_op_override(
         op_symbol,
         impl,
         dispatch_key,
-        with_keyset=True,
-        allow_override=allow_override,
+        with_keyset=(not unconditional_override),
+        allow_override=allow_multiple_override,
     )

--- a/torch/_native/registry.py
+++ b/torch/_native/registry.py
@@ -1,0 +1,15 @@
+from collections.abc import Callable
+
+_RegisterFn = Callable[[], None]
+
+_RegisteredFns : list[_RegisterFn] = []
+
+def register_op_registerer(fn: _RegisterFn) -> None:
+    _RegisteredFns.append(fn)
+
+def register_all_operators() -> None:
+    print(f'{__name__=} registering {len(_RegisteredFns)} ops')
+    for fn in _RegisteredFns:
+        fn()
+
+

--- a/torch/_native/triton_utils.py
+++ b/torch/_native/triton_utils.py
@@ -7,10 +7,7 @@ from .common_utils import (
     check_native_jit_disabled,
     check_native_version_skip,
 )
-from .registry import (
-    _OpFn,
-    _register_op_override,
-)
+from .registry import _OpFn, _register_op_override
 
 
 log = logging.getLogger(__name__)

--- a/torch/_native/triton_utils.py
+++ b/torch/_native/triton_utils.py
@@ -51,16 +51,24 @@ def runtime_version() -> None | Version:
     return version
 
 
+@functools.cache
 def _version_is_sufficient() -> bool:
     _, version = _check_runtime_available()
-    if version is None:
-        return False
-    if check_native_version_skip():
-        return True
     # Either exact version, or same major
     major_ok = version.major == _TRITON_REQUIRED_VERSION_MAJOR
     minor_ok = version.minor >= _TRITON_MINIMUM_VERSION_MINOR
-    return major_ok and minor_ok
+
+    if (major_ok and minor_ok) or check_native_version_skip():
+        return True
+
+    log.info(
+        "triton version %s is not sufficient (>= (%s.%s.*)); "
+        "set TORCH_NATIVE_SKIP_VERSION_CHECK=1 to override",
+        version,
+        _TRITON_REQUIRED_VERSION_MAJOR,
+        _TRITON_MINIMUM_VERSION_MINOR,
+    )
+    return False
 
 
 def register_op_override(
@@ -82,13 +90,6 @@ def register_op_override(
         return
 
     if not _version_is_sufficient():
-        log.warning(
-            "triton version %s is not sufficient (>= (%s.%s.*)); "
-            "set TORCH_NATIVE_SKIP_VERSION_CHECK=1 to override",
-            version,
-            _TRITON_REQUIRED_VERSION_MAJOR,
-            _TRITON_MINIMUM_VERSION_MINOR,
-        )
         return
 
     _register_op_override(

--- a/torch/_native/triton_utils.py
+++ b/torch/_native/triton_utils.py
@@ -7,7 +7,7 @@ from .common_utils import (
     check_native_jit_disabled,
     check_native_version_skip,
 )
-from .registry import _RegisterFn, register_op_registerer
+from .registry import _OpOverrideFn, _register_op_override
 
 
 log = logging.getLogger(__name__)
@@ -61,7 +61,14 @@ def _version_is_sufficient() -> bool:
     return major_ok and minor_ok
 
 
-def register_op(fn: _RegisterFn) -> None:
+def register_op_override(
+    lib_symbol: str,
+    op_symbol: str,
+    dispatch_key: str,
+    impl: _OpOverrideFn,
+    *,
+    allow_override=False,
+) -> None:
     available, version = _check_runtime_available()
     if (not available) or check_native_jit_disabled():
         return
@@ -76,4 +83,10 @@ def register_op(fn: _RegisterFn) -> None:
         )
         return
 
-    register_op_registerer(fn)
+    _register_op_override(
+        lib_symbol,
+        op_symbol,
+        dispatch_key,
+        impl,
+        allow_override=allow_override,
+    )

--- a/torch/_native/triton_utils.py
+++ b/torch/_native/triton_utils.py
@@ -54,6 +54,10 @@ def runtime_version() -> None | Version:
 @functools.cache
 def _version_is_sufficient() -> bool:
     _, version = _check_runtime_available()
+
+    if version is None:
+        return False
+
     # Either exact version, or same major
     major_ok = version.major == _TRITON_REQUIRED_VERSION_MAJOR
     minor_ok = version.minor >= _TRITON_MINIMUM_VERSION_MINOR

--- a/torch/_native/triton_utils.py
+++ b/torch/_native/triton_utils.py
@@ -1,20 +1,19 @@
 import functools
-import importlib
-import importlib.metadata
 import logging
-import os
 
-from .registry import register_op_registerer, _RegisterFn
 from .common_utils import (
-    check_native_jit_disabled,
     _available_version,
     _unavailable_reason,
+    check_native_jit_disabled,
 )
+from .registry import _RegisterFn, register_op_registerer
+
 
 log = logging.getLogger(__name__)
 
 _TRITON_AVAILABLE = None
 _TRITON_VERSION = None
+
 
 @functools.cache
 def _check_runtime_available() -> bool:
@@ -29,27 +28,29 @@ def _check_runtime_available() -> bool:
     if _TRITON_AVAILABLE is not None:
         return _TRITON_AVAILABLE
 
-    deps = [("triton", "triton"), ]
+    deps = [
+        ("triton", "triton"),
+    ]
     reason = _unavailable_reason(deps)
     if reason is None:
         _TRITON_AVAILABLE = True
         _TRITON_VERSION = _available_version("triton")
     else:
-        print(
-            "triton native DSL ops require: "
-            "`triton`"
-            f"{reason}"
-        )
+        print(f"triton native DSL ops require: `triton`{reason}")
         _TRITON_AVAILABLE = False
     return _TRITON_AVAILABLE
 
+
 _check_runtime_available()
 
-def runtime_available() -> bool:
+
+def runtime_available() -> None | bool:
     return _TRITON_AVAILABLE
+
 
 def runtime_version() -> None | tuple[int, int, int]:
     return _TRITON_VERSION
+
 
 def register_op(fn: _RegisterFn) -> None:
     if (not _TRITON_AVAILABLE) or check_native_jit_disabled():

--- a/torch/_native/triton_utils.py
+++ b/torch/_native/triton_utils.py
@@ -11,49 +11,42 @@ from .registry import _RegisterFn, register_op_registerer
 
 log = logging.getLogger(__name__)
 
-_TRITON_AVAILABLE = None
-_TRITON_VERSION = None
-
 
 @functools.cache
-def _check_runtime_available() -> bool:
+def _check_runtime_available() -> tuple[bool, tuple[int, int, int] | None]:
     """
     Check if triton is available
 
     NOTE: Doesn't import at this point
     """
-    global _TRITON_AVAILABLE
-    global _TRITON_VERSION
-
-    if _TRITON_AVAILABLE is not None:
-        return _TRITON_AVAILABLE
 
     deps = [
         ("triton", "triton"),
     ]
     reason = _unavailable_reason(deps)
     if reason is None:
-        _TRITON_AVAILABLE = True
-        _TRITON_VERSION = _available_version("triton")
+        available = True
+        version = _available_version("triton")
     else:
-        print(f"triton native DSL ops require: `triton`{reason}")
-        _TRITON_AVAILABLE = False
-    return _TRITON_AVAILABLE
-
-
-_check_runtime_available()
+        log.info("triton native DSL ops require: `triton` %s", reason)
+        available = False
+        version = None
+    return available, version
 
 
 def runtime_available() -> None | bool:
-    return _TRITON_AVAILABLE
+    available, _ = _check_runtime_available()
+    return available
 
 
 def runtime_version() -> None | tuple[int, int, int]:
-    return _TRITON_VERSION
+    _, version = _check_runtime_available()
+    return version
 
 
 def register_op(fn: _RegisterFn) -> None:
-    if (not _TRITON_AVAILABLE) or check_native_jit_disabled():
+    available, _ = _check_runtime_available()
+    if (not available) or check_native_jit_disabled():
         return
 
     register_op_registerer(fn)

--- a/torch/_native/triton_utils.py
+++ b/torch/_native/triton_utils.py
@@ -7,7 +7,10 @@ from .common_utils import (
     check_native_jit_disabled,
     check_native_version_skip,
 )
-from .registry import _OpOverrideFn, _register_op_override
+from .registry import (
+    _OpFn,
+    _register_op_override,
+)
 
 
 log = logging.getLogger(__name__)
@@ -65,10 +68,16 @@ def register_op_override(
     lib_symbol: str,
     op_symbol: str,
     dispatch_key: str,
-    impl: _OpOverrideFn,
+    impl: _OpFn,
     *,
-    allow_override=False,
+    allow_multiple_override: bool = False,
+    unconditional_override: bool = False,
 ) -> None:
+    """
+    See torch/_native/registry.py for the underlying implementation
+    and arguments. This is a thin, DSL-checking wrapper over
+    _register_op_override
+    """
     available, version = _check_runtime_available()
     if (not available) or check_native_jit_disabled():
         return
@@ -88,5 +97,6 @@ def register_op_override(
         op_symbol,
         dispatch_key,
         impl,
-        allow_override=allow_override,
+        allow_multiple_override=allow_multiple_override,
+        unconditional_override=unconditional_override,
     )

--- a/torch/_native/triton_utils.py
+++ b/torch/_native/triton_utils.py
@@ -5,6 +5,7 @@ from .common_utils import (
     _available_version,
     _unavailable_reason,
     check_native_jit_disabled,
+    check_native_version_skip,
 )
 from .registry import _RegisterFn, register_op_registerer
 
@@ -12,12 +13,16 @@ from .registry import _RegisterFn, register_op_registerer
 log = logging.getLogger(__name__)
 
 
+_TRITON_REQUIRED_VERSION_MAJOR = 3
+_TRITON_MINIMUM_VERSION_MINOR = 6
+
+
 @functools.cache
 def _check_runtime_available() -> tuple[bool, tuple[int, int, int] | None]:
     """
     Check if triton is available
 
-    NOTE: Doesn't import at this point
+    NOTE: must not import at this point
     """
 
     deps = [
@@ -34,7 +39,7 @@ def _check_runtime_available() -> tuple[bool, tuple[int, int, int] | None]:
     return available, version
 
 
-def runtime_available() -> None | bool:
+def runtime_available() -> bool:
     available, _ = _check_runtime_available()
     return available
 
@@ -44,9 +49,31 @@ def runtime_version() -> None | tuple[int, int, int]:
     return version
 
 
+def _version_is_sufficient() -> bool:
+    _, version = _check_runtime_available()
+    if version is None:
+        return False
+    if check_native_version_skip():
+        return True
+    # Either exact version, or same major
+    major_ok = version[0] == _TRITON_REQUIRED_VERSION_MAJOR
+    minor_ok = version[1] >= _TRITON_MINIMUM_VERSION_MINOR
+    return major_ok and minor_ok
+
+
 def register_op(fn: _RegisterFn) -> None:
-    available, _ = _check_runtime_available()
+    available, version = _check_runtime_available()
     if (not available) or check_native_jit_disabled():
+        return
+
+    if not _version_is_sufficient():
+        log.warning(
+            "triton version %s is not sufficient (>= (%s.%s.*)); "
+            "set TORCH_NATIVE_SKIP_VERSION_CHECK=1 to override",
+            version,
+            _TRITON_REQUIRED_VERSION_MAJOR,
+            _TRITON_MINIMUM_VERSION_MINOR,
+        )
         return
 
     register_op_registerer(fn)

--- a/torch/_native/triton_utils.py
+++ b/torch/_native/triton_utils.py
@@ -1,0 +1,58 @@
+import functools
+import importlib
+import importlib.metadata
+import logging
+import os
+
+from .registry import register_op_registerer, _RegisterFn
+from .common_utils import (
+    check_native_jit_disabled,
+    _available_version,
+    _unavailable_reason,
+)
+
+log = logging.getLogger(__name__)
+
+_TRITON_AVAILABLE = None
+_TRITON_VERSION = None
+
+@functools.cache
+def _check_runtime_available() -> bool:
+    """
+    Check if triton is available
+
+    NOTE: Doesn't import at this point
+    """
+    global _TRITON_AVAILABLE
+    global _TRITON_VERSION
+
+    if _TRITON_AVAILABLE is not None:
+        return _TRITON_AVAILABLE
+
+    deps = [("triton", "triton"), ]
+    reason = _unavailable_reason(deps)
+    if reason is None:
+        _TRITON_AVAILABLE = True
+        _TRITON_VERSION = _available_version("triton")
+    else:
+        print(
+            "triton native DSL ops require: "
+            "`triton`"
+            f"{reason}"
+        )
+        _TRITON_AVAILABLE = False
+    return _TRITON_AVAILABLE
+
+_check_runtime_available()
+
+def runtime_available() -> bool:
+    return _TRITON_AVAILABLE
+
+def runtime_version() -> None | tuple[int, int, int]:
+    return _TRITON_VERSION
+
+def register_op(fn: _RegisterFn) -> None:
+    if (not _TRITON_AVAILABLE) or check_native_jit_disabled():
+        return
+
+    register_op_registerer(fn)

--- a/torch/_native/triton_utils.py
+++ b/torch/_native/triton_utils.py
@@ -1,5 +1,6 @@
 import functools
 import logging
+
 from packaging.version import Version
 
 from .common_utils import (
@@ -19,7 +20,7 @@ _TRITON_MINIMUM_VERSION_MINOR = 6
 
 
 @functools.cache
-def _check_runtime_available() -> [bool, Version | None]:
+def _check_runtime_available() -> tuple[bool, Version | None]:
     """
     Check if triton is available
 

--- a/torch/_native/triton_utils.py
+++ b/torch/_native/triton_utils.py
@@ -1,5 +1,6 @@
 import functools
 import logging
+from packaging.version import Version
 
 from .common_utils import (
     _available_version,
@@ -18,7 +19,7 @@ _TRITON_MINIMUM_VERSION_MINOR = 6
 
 
 @functools.cache
-def _check_runtime_available() -> tuple[bool, tuple[int, int, int] | None]:
+def _check_runtime_available() -> [bool, Version | None]:
     """
     Check if triton is available
 
@@ -44,7 +45,7 @@ def runtime_available() -> bool:
     return available
 
 
-def runtime_version() -> None | tuple[int, int, int]:
+def runtime_version() -> None | Version:
     _, version = _check_runtime_available()
     return version
 
@@ -56,8 +57,8 @@ def _version_is_sufficient() -> bool:
     if check_native_version_skip():
         return True
     # Either exact version, or same major
-    major_ok = version[0] == _TRITON_REQUIRED_VERSION_MAJOR
-    minor_ok = version[1] >= _TRITON_MINIMUM_VERSION_MINOR
+    major_ok = version.major == _TRITON_REQUIRED_VERSION_MAJOR
+    minor_ok = version.minor >= _TRITON_MINIMUM_VERSION_MINOR
     return major_ok and minor_ok
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #176284
* #176283
* #176892
* #176281
* __->__ #176280

Summary:

* Add common utils for checking packages & versions
* Add specific utils for triton & cutedsl DSLs
* Add general registry for registering all native ops in one place
* Add initial docs on adding DSLs and native ops

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags:
Signed-off-by: Simon Layton <simonlayton@meta.com>