### PR TITLE
[Native DSL] Add triton, cutedsl to torch.backends

### DIFF
--- a/test/python_native/test_torch_backends.py
+++ b/test/python_native/test_torch_backends.py
@@ -13,364 +13,235 @@ class TestTorchBackends(TestCase):
 
     def setUp(self):
         """Set up test environment."""
-        # Note: Don't clear modules as it interferes with the PropModule replacement
+        # Store original module states for cleanup
+        self._original_modules = {}
+        self._backends_to_test = ["cutedsl", "triton"]
+
+    def tearDown(self):
+        """Clean up test environment."""
+        # Restore any modules that were cleared during testing
+        for module_name, module_obj in self._original_modules.items():
+            if module_name not in sys.modules:
+                sys.modules[module_name] = module_obj
+
+    def _clear_backend_modules(self, backend_name):
+        """Helper to clear backend and utility modules for clean imports."""
+        modules_to_clear = [
+            f"torch.backends.{backend_name}",
+            f"torch._native.{backend_name}_utils",
+        ]
+        for module_name in modules_to_clear:
+            if module_name in sys.modules:
+                if module_name not in self._original_modules:
+                    self._original_modules[module_name] = sys.modules[module_name]
+                del sys.modules[module_name]
 
     @contextmanager
-    def _mock_native_utils(self, runtime_available=True, runtime_version=None):
+    def _mock_native_utils(self, backend_names=None, runtime_available=True, runtime_version=None):
         """Context manager to mock the native utility functions."""
-        with (
-            patch(
-                "torch._native.cutedsl_utils.runtime_available",
-                return_value=runtime_available,
-            ),
-            patch(
-                "torch._native.cutedsl_utils.runtime_version",
-                return_value=runtime_version,
-            ),
-            patch(
-                "torch._native.triton_utils.runtime_available",
-                return_value=runtime_available,
-            ),
-            patch(
-                "torch._native.triton_utils.runtime_version",
-                return_value=runtime_version,
-            ),
-        ):
+        if backend_names is None:
+            backend_names = self._backends_to_test
+
+        patches = []
+        for backend in backend_names:
+            patches.extend([
+                patch(
+                    f"torch._native.{backend}_utils.runtime_available",
+                    return_value=runtime_available,
+                ),
+                patch(
+                    f"torch._native.{backend}_utils.runtime_version",
+                    return_value=runtime_version,
+                ),
+            ])
+
+        # Apply all patches using contextlib.ExitStack for proper cleanup
+        from contextlib import ExitStack
+        with ExitStack() as stack:
+            for patch_obj in patches:
+                stack.enter_context(patch_obj)
             yield
 
-    def test_cutedsl_module_import(self):
-        """Test that torch.backends.cutedsl can be imported."""
-        import torch.backends.cutedsl as cutedsl
+    def test_backend_module_import(self):
+        """Test that torch.backends modules can be imported and have required attributes."""
+        required_attrs = ["is_available", "version", "enabled", "flags", "set_flags"]
 
-        self.assertTrue(hasattr(cutedsl, "is_available"))
-        self.assertTrue(hasattr(cutedsl, "version"))
-        self.assertTrue(hasattr(cutedsl, "enabled"))
-        self.assertTrue(hasattr(cutedsl, "flags"))
-        self.assertTrue(hasattr(cutedsl, "set_flags"))
+        for backend_name in self._backends_to_test:
+            with self.subTest(backend=backend_name):
+                backend = __import__(f"torch.backends.{backend_name}", fromlist=[backend_name])
 
-    def test_triton_module_import(self):
-        """Test that torch.backends.triton can be imported."""
-        import torch.backends.triton as triton
+                for attr in required_attrs:
+                    with self.subTest(backend=backend_name, attribute=attr):
+                        self.assertTrue(hasattr(backend, attr))
 
-        self.assertTrue(hasattr(triton, "is_available"))
-        self.assertTrue(hasattr(triton, "version"))
-        self.assertTrue(hasattr(triton, "enabled"))
-        self.assertTrue(hasattr(triton, "flags"))
-        self.assertTrue(hasattr(triton, "set_flags"))
+    def test_backend_is_available(self):
+        """Test torch.backends.*.is_available() function with different availability states."""
+        availability_scenarios = [
+            (True, "runtime available"),
+            (False, "runtime not available"),
+        ]
 
-    def test_cutedsl_is_available(self):
-        """Test torch.backends.cutedsl.is_available() function."""
-        with self._mock_native_utils(runtime_available=True):
-            import torch.backends.cutedsl as cutedsl
+        for backend_name in self._backends_to_test:
+            for runtime_available, description in availability_scenarios:
+                with self.subTest(backend=backend_name, scenario=description):
+                    # Clear modules for clean import
+                    self._clear_backend_modules(backend_name)
 
-            result = cutedsl.is_available()
-            self.assertIsInstance(result, bool)
-            self.assertTrue(result)
+                    with self._mock_native_utils([backend_name], runtime_available=runtime_available):
+                        backend = __import__(f"torch.backends.{backend_name}", fromlist=[backend_name])
 
-        # Test with runtime not available
-        # Clear backend and utility modules first to ensure fresh import
-        for module_name in [
-            "torch.backends.cutedsl",
-            "torch._native.cutedsl_utils",
-        ]:
-            if module_name in sys.modules:
-                del sys.modules[module_name]
+                        result = backend.is_available()
+                        self.assertIsInstance(result, bool)
+                        self.assertEqual(result, runtime_available)
 
-        with self._mock_native_utils(runtime_available=False):
-            import torch.backends.cutedsl as cutedsl
-
-            result = cutedsl.is_available()
-            self.assertIsInstance(result, bool)
-            self.assertFalse(result)
-
-    def test_triton_is_available(self):
-        """Test torch.backends.triton.is_available() function."""
-        with self._mock_native_utils(runtime_available=True):
-            import torch.backends.triton as triton
-
-            result = triton.is_available()
-            self.assertIsInstance(result, bool)
-            self.assertTrue(result)
-
-        # Test with runtime not available
-        # Clear backend and utility modules first to ensure fresh import
-        for module_name in [
-            "torch.backends.triton",
-            "torch._native.triton_utils",
-        ]:
-            if module_name in sys.modules:
-                del sys.modules[module_name]
-
-        with self._mock_native_utils(runtime_available=False):
-            import torch.backends.triton as triton
-
-            result = triton.is_available()
-            self.assertIsInstance(result, bool)
-            self.assertFalse(result)
-
-    def test_cutedsl_version(self):
-        """Test torch.backends.cutedsl.version() function."""
+    def test_backend_version(self):
+        """Test torch.backends.*.version() function with different version scenarios."""
         from packaging.version import Version
 
-        test_version = Version("1.2.3")
-        with self._mock_native_utils(runtime_version=test_version):
-            import torch.backends.cutedsl as cutedsl
+        version_scenarios = [
+            (Version("1.2.3"), "version available"),
+            (None, "version not available"),
+        ]
 
-            result = cutedsl.version()
-            self.assertEqual(result, test_version)
+        for backend_name in self._backends_to_test:
+            for test_version, description in version_scenarios:
+                with self.subTest(backend=backend_name, scenario=description):
+                    # Clear modules for clean import
+                    self._clear_backend_modules(backend_name)
 
-        with self._mock_native_utils(runtime_version=None):
-            # Clear both backend and utility modules to ensure fresh import
-            for module_name in [
-                "torch.backends.cutedsl",
-                "torch._native.cutedsl_utils",
-            ]:
-                if module_name in sys.modules:
-                    del sys.modules[module_name]
-            import torch.backends.cutedsl as cutedsl
+                    with self._mock_native_utils([backend_name], runtime_version=test_version):
+                        backend = __import__(f"torch.backends.{backend_name}", fromlist=[backend_name])
 
-            result = cutedsl.version()
-            self.assertIsNone(result)
+                        result = backend.version()
+                        self.assertEqual(result, test_version)
 
-    def test_triton_version(self):
-        """Test torch.backends.triton.version() function."""
-        from packaging.version import Version
+    def test_backend_enabled_default_and_setter(self):
+        """Test that torch.backends.* enabled property defaults to True and can be set."""
+        for backend_name in self._backends_to_test:
+            with self.subTest(backend=backend_name):
+                backend = __import__(f"torch.backends.{backend_name}", fromlist=[backend_name])
 
-        test_version = Version("2.1.0")
-        with self._mock_native_utils(runtime_version=test_version):
-            import torch.backends.triton as triton
+                # Test default value
+                self.assertTrue(backend.enabled, f"{backend_name} should be enabled by default")
 
-            result = triton.version()
-            self.assertEqual(result, test_version)
+                # Get initial state for restoration
+                initial_state = backend.enabled
 
-        with self._mock_native_utils(runtime_version=None):
-            # Clear both backend and utility modules to ensure fresh import
-            for module_name in [
-                "torch.backends.triton",
-                "torch._native.triton_utils",
-            ]:
-                if module_name in sys.modules:
-                    del sys.modules[module_name]
-            import torch.backends.triton as triton
+                # Test disabling
+                with allow_nonbracketed_mutation():
+                    backend.enabled = False
+                self.assertFalse(backend.enabled, f"Should be able to disable {backend_name}")
 
-            result = triton.version()
-            self.assertIsNone(result)
+                # Test re-enabling
+                with allow_nonbracketed_mutation():
+                    backend.enabled = True
+                self.assertTrue(backend.enabled, f"Should be able to re-enable {backend_name}")
 
-    def test_cutedsl_enabled_default(self):
-        """Test that torch.backends.cutedsl.enabled is True by default."""
-        import torch.backends.cutedsl as cutedsl
-
-        self.assertTrue(cutedsl.enabled)
-
-    def test_triton_enabled_default(self):
-        """Test that torch.backends.triton.enabled is True by default."""
-        import torch.backends.triton as triton
-
-        self.assertTrue(triton.enabled)
-
-    def test_cutedsl_enabled_setter(self):
-        """Test setting torch.backends.cutedsl.enabled."""
-        import torch.backends.cutedsl as cutedsl
-
-        # Get initial state
-        initial_state = cutedsl.enabled
-
-        # Test disabling
-        with allow_nonbracketed_mutation():
-            cutedsl.enabled = False
-        self.assertFalse(cutedsl.enabled)
-
-        # Test re-enabling
-        with allow_nonbracketed_mutation():
-            cutedsl.enabled = True
-        self.assertTrue(cutedsl.enabled)
-
-        # Restore initial state
-        with allow_nonbracketed_mutation():
-            cutedsl.enabled = initial_state
-
-    def test_triton_enabled_setter(self):
-        """Test setting torch.backends.triton.enabled."""
-        import torch.backends.triton as triton
-
-        # Get initial state
-        initial_state = triton.enabled
-
-        # Test disabling
-        with allow_nonbracketed_mutation():
-            triton.enabled = False
-        self.assertFalse(triton.enabled)
-
-        # Test re-enabling
-        with allow_nonbracketed_mutation():
-            triton.enabled = True
-        self.assertTrue(triton.enabled)
-
-        # Restore initial state
-        with allow_nonbracketed_mutation():
-            triton.enabled = initial_state
+                # Restore initial state
+                with allow_nonbracketed_mutation():
+                    backend.enabled = initial_state
 
     @patch("torch._native.registry.reenable_op_overrides")
     @patch("torch._native.registry.deregister_op_overrides")
-    def test_cutedsl_set_flags(self, mock_disable, mock_reenable):
-        """Test torch.backends.cutedsl.set_flags() function."""
-        import torch.backends.cutedsl as cutedsl
+    def test_backend_set_flags(self, mock_disable, mock_reenable):
+        """Test torch.backends.*.set_flags() function."""
+        set_flags_scenarios = [
+            (False, "disable backend"),
+            (True, "enable backend"),
+            (None, "no change"),
+        ]
 
-        # Test set_flags with enabled=False
-        orig_flags = cutedsl.set_flags(_enabled=False)
-        self.assertEqual(orig_flags, (True,))  # Originally enabled
-        self.assertFalse(cutedsl.enabled)
-        mock_disable.assert_called_with(disable_dsl_names="cutedsl")
+        for backend_name in self._backends_to_test:
+            with self.subTest(backend=backend_name):
+                backend = __import__(f"torch.backends.{backend_name}", fromlist=[backend_name])
 
-        # Test set_flags with enabled=True
-        cutedsl.set_flags(_enabled=True)
-        self.assertTrue(cutedsl.enabled)
-        mock_reenable.assert_called_with(enable_dsl_names="cutedsl")
+                for enabled_value, description in set_flags_scenarios:
+                    with self.subTest(backend=backend_name, scenario=description):
+                        mock_disable.reset_mock()
+                        mock_reenable.reset_mock()
 
-        # Test set_flags with None (no change)
-        orig_flags = cutedsl.set_flags(_enabled=None)
-        self.assertEqual(orig_flags, (True,))
+                        # Ensure starting state is enabled
+                        with allow_nonbracketed_mutation():
+                            backend.enabled = True
 
-    @patch("torch._native.registry.reenable_op_overrides")
-    @patch("torch._native.registry.deregister_op_overrides")
-    def test_triton_set_flags(self, mock_disable, mock_reenable):
-        """Test torch.backends.triton.set_flags() function."""
-        import torch.backends.triton as triton
+                        orig_flags = backend.set_flags(_enabled=enabled_value)
+                        self.assertEqual(orig_flags, (True,))  # Originally enabled
 
-        # Test set_flags with enabled=False
-        orig_flags = triton.set_flags(_enabled=False)
-        self.assertEqual(orig_flags, (True,))  # Originally enabled
-        self.assertFalse(triton.enabled)
-        mock_disable.assert_called_with(disable_dsl_names="triton")
+                        if enabled_value is False:
+                            self.assertFalse(backend.enabled)
+                            mock_disable.assert_called_with(disable_dsl_names=backend_name)
+                            mock_reenable.assert_not_called()
+                        elif enabled_value is True:
+                            self.assertTrue(backend.enabled)
+                            mock_reenable.assert_called_with(enable_dsl_names=backend_name)
+                        else:  # None case
+                            self.assertTrue(backend.enabled)  # Should remain unchanged
+                            mock_disable.assert_not_called()
+                            mock_reenable.assert_not_called()
 
-        # Test set_flags with enabled=True
-        triton.set_flags(_enabled=True)
-        self.assertTrue(triton.enabled)
-        mock_reenable.assert_called_with(enable_dsl_names="triton")
+    def test_backend_flags_context_manager(self):
+        """Test torch.backends.*.flags context manager with various scenarios."""
+        context_scenarios = [
+            ({"enabled": False}, "disable in context"),
+            ({}, "no arguments"),
+        ]
 
-        # Test set_flags with None (no change)
-        orig_flags = triton.set_flags(_enabled=None)
-        self.assertEqual(orig_flags, (True,))
+        for backend_name in self._backends_to_test:
+            with self.subTest(backend=backend_name):
+                backend = __import__(f"torch.backends.{backend_name}", fromlist=[backend_name])
 
-    def test_cutedsl_flags_context_manager(self):
-        """Test torch.backends.cutedsl.flags context manager."""
-        import torch.backends.cutedsl as cutedsl
+                for flags_kwargs, description in context_scenarios:
+                    with self.subTest(backend=backend_name, scenario=description):
+                        # Ensure starting state is enabled
+                        with allow_nonbracketed_mutation():
+                            backend.enabled = True
+                        initial_state = backend.enabled
 
-        # Ensure starting state is enabled
-        with allow_nonbracketed_mutation():
-            cutedsl.enabled = True
-        initial_state = cutedsl.enabled
+                        # Test context manager
+                        with backend.flags(**flags_kwargs):
+                            if flags_kwargs.get("enabled") is False:
+                                self.assertFalse(backend.enabled)
+                            else:
+                                self.assertEqual(backend.enabled, initial_state)
 
-        # Test context manager disables and restores
-        with cutedsl.flags(enabled=False):
-            self.assertFalse(cutedsl.enabled)
+                        # Should restore original state
+                        self.assertEqual(backend.enabled, initial_state)
 
-        # Should restore original state
-        self.assertEqual(cutedsl.enabled, initial_state)
+    def test_backend_flags_context_manager_exception_handling(self):
+        """Test torch.backends.*.flags context manager restores state on exception."""
+        for backend_name in self._backends_to_test:
+            with self.subTest(backend=backend_name):
+                backend = __import__(f"torch.backends.{backend_name}", fromlist=[backend_name])
 
-    def test_triton_flags_context_manager(self):
-        """Test torch.backends.triton.flags context manager."""
-        import torch.backends.triton as triton
+                # Ensure starting state is enabled
+                with allow_nonbracketed_mutation():
+                    backend.enabled = True
+                initial_state = backend.enabled
 
-        # Ensure starting state is enabled
-        with allow_nonbracketed_mutation():
-            triton.enabled = True
-        initial_state = triton.enabled
+                # Test exception handling
+                with self.assertRaises(ValueError):
+                    with backend.flags(enabled=False):
+                        self.assertFalse(backend.enabled)
+                        raise ValueError("Test exception")
 
-        # Test context manager disables and restores
-        with triton.flags(enabled=False):
-            self.assertFalse(triton.enabled)
+                # Should restore original state even after exception
+                self.assertEqual(backend.enabled, initial_state)
 
-        # Should restore original state
-        self.assertEqual(triton.enabled, initial_state)
+    def test_backend_module_replacement(self):
+        """Test that torch.backends.* modules are properly replaced with PropModule."""
+        for backend_name in self._backends_to_test:
+            with self.subTest(backend=backend_name):
+                backend = __import__(f"torch.backends.{backend_name}", fromlist=[backend_name])
 
-    def test_cutedsl_flags_context_manager_exception_handling(self):
-        """Test torch.backends.cutedsl.flags context manager restores state on exception."""
-        import torch.backends.cutedsl as cutedsl
+                # Check that the module is the custom PropModule instance
+                from torch.backends import PropModule
 
-        # Ensure starting state is enabled
-        with allow_nonbracketed_mutation():
-            cutedsl.enabled = True
-        initial_state = cutedsl.enabled
+                module_key = f"torch.backends.{backend_name}"
+                self.assertIsInstance(sys.modules[module_key], PropModule)
 
-        # Test exception handling
-        with self.assertRaises(ValueError):
-            with cutedsl.flags(enabled=False):
-                self.assertFalse(cutedsl.enabled)
-                raise ValueError("Test exception")
-
-        # Should restore original state even after exception
-        self.assertEqual(cutedsl.enabled, initial_state)
-
-    def test_triton_flags_context_manager_exception_handling(self):
-        """Test torch.backends.triton.flags context manager restores state on exception."""
-        import torch.backends.triton as triton
-
-        # Ensure starting state is enabled
-        with allow_nonbracketed_mutation():
-            triton.enabled = True
-        initial_state = triton.enabled
-
-        # Test exception handling
-        with self.assertRaises(ValueError):
-            with triton.flags(enabled=False):
-                self.assertFalse(triton.enabled)
-                raise ValueError("Test exception")
-
-        # Should restore original state even after exception
-        self.assertEqual(triton.enabled, initial_state)
-
-    def test_cutedsl_flags_context_manager_no_args(self):
-        """Test torch.backends.cutedsl.flags context manager with no arguments."""
-        import torch.backends.cutedsl as cutedsl
-
-        original_state = cutedsl.enabled
-
-        # Context manager with no args should not change state
-        with cutedsl.flags():
-            self.assertEqual(cutedsl.enabled, original_state)
-
-        # State should remain unchanged after context
-        self.assertEqual(cutedsl.enabled, original_state)
-
-    def test_triton_flags_context_manager_no_args(self):
-        """Test torch.backends.triton.flags context manager with no arguments."""
-        import torch.backends.triton as triton
-
-        original_state = triton.enabled
-
-        # Context manager with no args should not change state
-        with triton.flags():
-            self.assertEqual(triton.enabled, original_state)
-
-        # State should remain unchanged after context
-        self.assertEqual(triton.enabled, original_state)
-
-    def test_cutedsl_module_replacement(self):
-        """Test that torch.backends.cutedsl module is properly replaced with CuTeDSLModule."""
-        import torch.backends.cutedsl as cutedsl
-
-        # Check that the module is the custom PropModule instance
-        from torch.backends import PropModule
-
-        self.assertIsInstance(sys.modules["torch.backends.cutedsl"], PropModule)
-
-        # Test that enabled property works through the module replacement
-        self.assertTrue(hasattr(cutedsl, "enabled"))
-        self.assertIsInstance(cutedsl.enabled, bool)
-
-    def test_triton_module_replacement(self):
-        """Test that torch.backends.triton module is properly replaced with TritonModule."""
-        import torch.backends.triton as triton
-
-        # Check that the module is the custom PropModule instance
-        from torch.backends import PropModule
-
-        self.assertIsInstance(sys.modules["torch.backends.triton"], PropModule)
-
-        # Test that enabled property works through the module replacement
-        self.assertTrue(hasattr(triton, "enabled"))
-        self.assertIsInstance(triton.enabled, bool)
+                # Test that enabled property works through the module replacement
+                self.assertTrue(hasattr(backend, "enabled"))
+                self.assertIsInstance(backend.enabled, bool)
 
     def test_both_backends_independent(self):
         """Test that cutedsl and triton backends operate independently."""

--- a/test/python_native/test_torch_backends.py
+++ b/test/python_native/test_torch_backends.py
@@ -37,26 +37,31 @@ class TestTorchBackends(TestCase):
                 del sys.modules[module_name]
 
     @contextmanager
-    def _mock_native_utils(self, backend_names=None, runtime_available=True, runtime_version=None):
+    def _mock_native_utils(
+        self, backend_names=None, runtime_available=True, runtime_version=None
+    ):
         """Context manager to mock the native utility functions."""
         if backend_names is None:
             backend_names = self._backends_to_test
 
         patches = []
         for backend in backend_names:
-            patches.extend([
-                patch(
-                    f"torch._native.{backend}_utils.runtime_available",
-                    return_value=runtime_available,
-                ),
-                patch(
-                    f"torch._native.{backend}_utils.runtime_version",
-                    return_value=runtime_version,
-                ),
-            ])
+            patches.extend(
+                [
+                    patch(
+                        f"torch._native.{backend}_utils.runtime_available",
+                        return_value=runtime_available,
+                    ),
+                    patch(
+                        f"torch._native.{backend}_utils.runtime_version",
+                        return_value=runtime_version,
+                    ),
+                ]
+            )
 
         # Apply all patches using contextlib.ExitStack for proper cleanup
         from contextlib import ExitStack
+
         with ExitStack() as stack:
             for patch_obj in patches:
                 stack.enter_context(patch_obj)
@@ -68,7 +73,9 @@ class TestTorchBackends(TestCase):
 
         for backend_name in self._backends_to_test:
             with self.subTest(backend=backend_name):
-                backend = __import__(f"torch.backends.{backend_name}", fromlist=[backend_name])
+                backend = __import__(
+                    f"torch.backends.{backend_name}", fromlist=[backend_name]
+                )
 
                 for attr in required_attrs:
                     with self.subTest(backend=backend_name, attribute=attr):
@@ -87,8 +94,12 @@ class TestTorchBackends(TestCase):
                     # Clear modules for clean import
                     self._clear_backend_modules(backend_name)
 
-                    with self._mock_native_utils([backend_name], runtime_available=runtime_available):
-                        backend = __import__(f"torch.backends.{backend_name}", fromlist=[backend_name])
+                    with self._mock_native_utils(
+                        [backend_name], runtime_available=runtime_available
+                    ):
+                        backend = __import__(
+                            f"torch.backends.{backend_name}", fromlist=[backend_name]
+                        )
 
                         result = backend.is_available()
                         self.assertIsInstance(result, bool)
@@ -109,8 +120,12 @@ class TestTorchBackends(TestCase):
                     # Clear modules for clean import
                     self._clear_backend_modules(backend_name)
 
-                    with self._mock_native_utils([backend_name], runtime_version=test_version):
-                        backend = __import__(f"torch.backends.{backend_name}", fromlist=[backend_name])
+                    with self._mock_native_utils(
+                        [backend_name], runtime_version=test_version
+                    ):
+                        backend = __import__(
+                            f"torch.backends.{backend_name}", fromlist=[backend_name]
+                        )
 
                         result = backend.version()
                         self.assertEqual(result, test_version)
@@ -119,10 +134,14 @@ class TestTorchBackends(TestCase):
         """Test that torch.backends.* enabled property defaults to True and can be set."""
         for backend_name in self._backends_to_test:
             with self.subTest(backend=backend_name):
-                backend = __import__(f"torch.backends.{backend_name}", fromlist=[backend_name])
+                backend = __import__(
+                    f"torch.backends.{backend_name}", fromlist=[backend_name]
+                )
 
                 # Test default value
-                self.assertTrue(backend.enabled, f"{backend_name} should be enabled by default")
+                self.assertTrue(
+                    backend.enabled, f"{backend_name} should be enabled by default"
+                )
 
                 # Get initial state for restoration
                 initial_state = backend.enabled
@@ -130,12 +149,16 @@ class TestTorchBackends(TestCase):
                 # Test disabling
                 with allow_nonbracketed_mutation():
                     backend.enabled = False
-                self.assertFalse(backend.enabled, f"Should be able to disable {backend_name}")
+                self.assertFalse(
+                    backend.enabled, f"Should be able to disable {backend_name}"
+                )
 
                 # Test re-enabling
                 with allow_nonbracketed_mutation():
                     backend.enabled = True
-                self.assertTrue(backend.enabled, f"Should be able to re-enable {backend_name}")
+                self.assertTrue(
+                    backend.enabled, f"Should be able to re-enable {backend_name}"
+                )
 
                 # Restore initial state
                 with allow_nonbracketed_mutation():
@@ -153,7 +176,9 @@ class TestTorchBackends(TestCase):
 
         for backend_name in self._backends_to_test:
             with self.subTest(backend=backend_name):
-                backend = __import__(f"torch.backends.{backend_name}", fromlist=[backend_name])
+                backend = __import__(
+                    f"torch.backends.{backend_name}", fromlist=[backend_name]
+                )
 
                 for enabled_value, description in set_flags_scenarios:
                     with self.subTest(backend=backend_name, scenario=description):
@@ -169,11 +194,15 @@ class TestTorchBackends(TestCase):
 
                         if enabled_value is False:
                             self.assertFalse(backend.enabled)
-                            mock_disable.assert_called_with(disable_dsl_names=backend_name)
+                            mock_disable.assert_called_with(
+                                disable_dsl_names=backend_name
+                            )
                             mock_reenable.assert_not_called()
                         elif enabled_value is True:
                             self.assertTrue(backend.enabled)
-                            mock_reenable.assert_called_with(enable_dsl_names=backend_name)
+                            mock_reenable.assert_called_with(
+                                enable_dsl_names=backend_name
+                            )
                         else:  # None case
                             self.assertTrue(backend.enabled)  # Should remain unchanged
                             mock_disable.assert_not_called()
@@ -188,7 +217,9 @@ class TestTorchBackends(TestCase):
 
         for backend_name in self._backends_to_test:
             with self.subTest(backend=backend_name):
-                backend = __import__(f"torch.backends.{backend_name}", fromlist=[backend_name])
+                backend = __import__(
+                    f"torch.backends.{backend_name}", fromlist=[backend_name]
+                )
 
                 for flags_kwargs, description in context_scenarios:
                     with self.subTest(backend=backend_name, scenario=description):
@@ -211,7 +242,9 @@ class TestTorchBackends(TestCase):
         """Test torch.backends.*.flags context manager restores state on exception."""
         for backend_name in self._backends_to_test:
             with self.subTest(backend=backend_name):
-                backend = __import__(f"torch.backends.{backend_name}", fromlist=[backend_name])
+                backend = __import__(
+                    f"torch.backends.{backend_name}", fromlist=[backend_name]
+                )
 
                 # Ensure starting state is enabled
                 with allow_nonbracketed_mutation():
@@ -231,7 +264,9 @@ class TestTorchBackends(TestCase):
         """Test that torch.backends.* modules are properly replaced with PropModule."""
         for backend_name in self._backends_to_test:
             with self.subTest(backend=backend_name):
-                backend = __import__(f"torch.backends.{backend_name}", fromlist=[backend_name])
+                backend = __import__(
+                    f"torch.backends.{backend_name}", fromlist=[backend_name]
+                )
 
                 # Check that the module is the custom PropModule instance
                 from torch.backends import PropModule

--- a/test/python_native/test_torch_backends.py
+++ b/test/python_native/test_torch_backends.py
@@ -1,0 +1,387 @@
+# Owner(s): ["module: dsl-native-ops"]
+
+import sys
+from contextlib import contextmanager
+from unittest.mock import patch
+
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+class TestTorchBackends(TestCase):
+    """Tests for torch.backends.cutedsl and torch.backends.triton modules."""
+
+    def setUp(self):
+        """Set up test environment."""
+        # Note: Don't clear modules as it interferes with the PropModule replacement
+        pass
+
+    @contextmanager
+    def _mock_native_utils(self, runtime_available=True, runtime_version=None):
+        """Context manager to mock the native utility functions."""
+        with patch("torch._native.cutedsl_utils.runtime_available", return_value=runtime_available), \
+             patch("torch._native.cutedsl_utils.runtime_version", return_value=runtime_version), \
+             patch("torch._native.triton_utils.runtime_available", return_value=runtime_available), \
+             patch("torch._native.triton_utils.runtime_version", return_value=runtime_version):
+            yield
+
+    def test_cutedsl_module_import(self):
+        """Test that torch.backends.cutedsl can be imported."""
+        import torch.backends.cutedsl as cutedsl
+        self.assertTrue(hasattr(cutedsl, 'is_available'))
+        self.assertTrue(hasattr(cutedsl, 'version'))
+        self.assertTrue(hasattr(cutedsl, 'enabled'))
+        self.assertTrue(hasattr(cutedsl, 'flags'))
+        self.assertTrue(hasattr(cutedsl, 'set_flags'))
+
+    def test_triton_module_import(self):
+        """Test that torch.backends.triton can be imported."""
+        import torch.backends.triton as triton
+        self.assertTrue(hasattr(triton, 'is_available'))
+        self.assertTrue(hasattr(triton, 'version'))
+        self.assertTrue(hasattr(triton, 'enabled'))
+        self.assertTrue(hasattr(triton, 'flags'))
+        self.assertTrue(hasattr(triton, 'set_flags'))
+
+    def test_cutedsl_is_available(self):
+        """Test torch.backends.cutedsl.is_available() function."""
+        with self._mock_native_utils(runtime_available=True):
+            import torch.backends.cutedsl as cutedsl
+            result = cutedsl.is_available()
+            self.assertIsInstance(result, bool)
+            self.assertTrue(result)
+
+        # Test with runtime not available
+        with self._mock_native_utils(runtime_available=False):
+            if 'torch.backends.cutedsl' in sys.modules:
+                del sys.modules['torch.backends.cutedsl']
+            import torch.backends.cutedsl as cutedsl
+            result = cutedsl.is_available()
+            self.assertIsInstance(result, bool)
+            self.assertFalse(result)
+
+    def test_triton_is_available(self):
+        """Test torch.backends.triton.is_available() function."""
+        with self._mock_native_utils(runtime_available=True):
+            import torch.backends.triton as triton
+            result = triton.is_available()
+            self.assertIsInstance(result, bool)
+            self.assertTrue(result)
+
+        # Test with runtime not available
+        with self._mock_native_utils(runtime_available=False):
+            if 'torch.backends.triton' in sys.modules:
+                del sys.modules['torch.backends.triton']
+            import torch.backends.triton as triton
+            result = triton.is_available()
+            self.assertIsInstance(result, bool)
+            self.assertFalse(result)
+
+    def test_cutedsl_version(self):
+        """Test torch.backends.cutedsl.version() function."""
+        from packaging.version import Version
+
+        test_version = Version("1.2.3")
+        with self._mock_native_utils(runtime_version=test_version):
+            import torch.backends.cutedsl as cutedsl
+            result = cutedsl.version()
+            self.assertEqual(result, test_version)
+
+        with self._mock_native_utils(runtime_version=None):
+            if 'torch.backends.cutedsl' in sys.modules:
+                del sys.modules['torch.backends.cutedsl']
+            import torch.backends.cutedsl as cutedsl
+            result = cutedsl.version()
+            self.assertIsNone(result)
+
+    def test_triton_version(self):
+        """Test torch.backends.triton.version() function."""
+        from packaging.version import Version
+
+        test_version = Version("2.1.0")
+        with self._mock_native_utils(runtime_version=test_version):
+            import torch.backends.triton as triton
+            result = triton.version()
+            self.assertEqual(result, test_version)
+
+        with self._mock_native_utils(runtime_version=None):
+            if 'torch.backends.triton' in sys.modules:
+                del sys.modules['torch.backends.triton']
+            import torch.backends.triton as triton
+            result = triton.version()
+            self.assertIsNone(result)
+
+    def test_cutedsl_enabled_default(self):
+        """Test that torch.backends.cutedsl.enabled is True by default."""
+        import torch.backends.cutedsl as cutedsl
+        self.assertTrue(cutedsl.enabled)
+
+    def test_triton_enabled_default(self):
+        """Test that torch.backends.triton.enabled is True by default."""
+        import torch.backends.triton as triton
+        self.assertTrue(triton.enabled)
+
+    def test_cutedsl_enabled_setter(self):
+        """Test setting torch.backends.cutedsl.enabled."""
+        import torch.backends.cutedsl as cutedsl
+
+        # Get initial state
+        initial_state = cutedsl.enabled
+
+        # Test disabling
+        cutedsl.enabled = False
+        self.assertFalse(cutedsl.enabled)
+
+        # Test re-enabling
+        cutedsl.enabled = True
+        self.assertTrue(cutedsl.enabled)
+
+        # Restore initial state
+        cutedsl.enabled = initial_state
+
+    def test_triton_enabled_setter(self):
+        """Test setting torch.backends.triton.enabled."""
+        import torch.backends.triton as triton
+
+        # Get initial state
+        initial_state = triton.enabled
+
+        # Test disabling
+        triton.enabled = False
+        self.assertFalse(triton.enabled)
+
+        # Test re-enabling
+        triton.enabled = True
+        self.assertTrue(triton.enabled)
+
+        # Restore initial state
+        triton.enabled = initial_state
+
+    @patch('torch._native.registry._reenable_op_overrides')
+    @patch('torch._native.registry._deregister_op_overrides')
+    def test_cutedsl_set_flags(self, mock_disable, mock_reenable):
+        """Test torch.backends.cutedsl.set_flags() function."""
+        import torch.backends.cutedsl as cutedsl
+
+        # Test set_flags with enabled=False
+        orig_flags = cutedsl.set_flags(_enabled=False)
+        self.assertEqual(orig_flags, (True,))  # Originally enabled
+        self.assertFalse(cutedsl.enabled)
+        mock_disable.assert_called_with(disable_dsl_names="cutedsl")
+
+        # Test set_flags with enabled=True
+        cutedsl.set_flags(_enabled=True)
+        self.assertTrue(cutedsl.enabled)
+        mock_reenable.assert_called_with(enable_dsl_names="cutedsl")
+
+        # Test set_flags with None (no change)
+        orig_flags = cutedsl.set_flags(_enabled=None)
+        self.assertEqual(orig_flags, (True,))
+
+    @patch('torch._native.registry._reenable_op_overrides')
+    @patch('torch._native.registry._deregister_op_overrides')
+    def test_triton_set_flags(self, mock_disable, mock_reenable):
+        """Test torch.backends.triton.set_flags() function."""
+        import torch.backends.triton as triton
+
+        # Test set_flags with enabled=False
+        orig_flags = triton.set_flags(_enabled=False)
+        self.assertEqual(orig_flags, (True,))  # Originally enabled
+        self.assertFalse(triton.enabled)
+        mock_disable.assert_called_with(disable_dsl_names="triton")
+
+        # Test set_flags with enabled=True
+        triton.set_flags(_enabled=True)
+        self.assertTrue(triton.enabled)
+        mock_reenable.assert_called_with(enable_dsl_names="triton")
+
+        # Test set_flags with None (no change)
+        orig_flags = triton.set_flags(_enabled=None)
+        self.assertEqual(orig_flags, (True,))
+
+    def test_cutedsl_flags_context_manager(self):
+        """Test torch.backends.cutedsl.flags context manager."""
+        import torch.backends.cutedsl as cutedsl
+
+        # Ensure starting state is enabled
+        cutedsl.enabled = True
+        initial_state = cutedsl.enabled
+
+        # Test context manager disables and restores
+        with cutedsl.flags(enabled=False):
+            self.assertFalse(cutedsl.enabled)
+
+        # Should restore original state
+        self.assertEqual(cutedsl.enabled, initial_state)
+
+    def test_triton_flags_context_manager(self):
+        """Test torch.backends.triton.flags context manager."""
+        import torch.backends.triton as triton
+
+        # Ensure starting state is enabled
+        triton.enabled = True
+        initial_state = triton.enabled
+
+        # Test context manager disables and restores
+        with triton.flags(enabled=False):
+            self.assertFalse(triton.enabled)
+
+        # Should restore original state
+        self.assertEqual(triton.enabled, initial_state)
+
+    def test_cutedsl_flags_context_manager_exception_handling(self):
+        """Test torch.backends.cutedsl.flags context manager restores state on exception."""
+        import torch.backends.cutedsl as cutedsl
+
+        # Ensure starting state is enabled
+        cutedsl.enabled = True
+        initial_state = cutedsl.enabled
+
+        # Test exception handling
+        with self.assertRaises(ValueError):
+            with cutedsl.flags(enabled=False):
+                self.assertFalse(cutedsl.enabled)
+                raise ValueError("Test exception")
+
+        # Should restore original state even after exception
+        self.assertEqual(cutedsl.enabled, initial_state)
+
+    def test_triton_flags_context_manager_exception_handling(self):
+        """Test torch.backends.triton.flags context manager restores state on exception."""
+        import torch.backends.triton as triton
+
+        # Ensure starting state is enabled
+        triton.enabled = True
+        initial_state = triton.enabled
+
+        # Test exception handling
+        with self.assertRaises(ValueError):
+            with triton.flags(enabled=False):
+                self.assertFalse(triton.enabled)
+                raise ValueError("Test exception")
+
+        # Should restore original state even after exception
+        self.assertEqual(triton.enabled, initial_state)
+
+    def test_cutedsl_flags_context_manager_no_args(self):
+        """Test torch.backends.cutedsl.flags context manager with no arguments."""
+        import torch.backends.cutedsl as cutedsl
+
+        original_state = cutedsl.enabled
+
+        # Context manager with no args should not change state
+        with cutedsl.flags():
+            self.assertEqual(cutedsl.enabled, original_state)
+
+        # State should remain unchanged after context
+        self.assertEqual(cutedsl.enabled, original_state)
+
+    def test_triton_flags_context_manager_no_args(self):
+        """Test torch.backends.triton.flags context manager with no arguments."""
+        import torch.backends.triton as triton
+
+        original_state = triton.enabled
+
+        # Context manager with no args should not change state
+        with triton.flags():
+            self.assertEqual(triton.enabled, original_state)
+
+        # State should remain unchanged after context
+        self.assertEqual(triton.enabled, original_state)
+
+    def test_cutedsl_module_replacement(self):
+        """Test that torch.backends.cutedsl module is properly replaced with CuTeDSLModule."""
+        import torch.backends.cutedsl as cutedsl
+
+        # Check that the module is the custom PropModule instance
+        from torch.backends import PropModule
+        self.assertIsInstance(sys.modules['torch.backends.cutedsl'], PropModule)
+
+        # Test that enabled property works through the module replacement
+        self.assertTrue(hasattr(cutedsl, 'enabled'))
+        self.assertIsInstance(cutedsl.enabled, bool)
+
+    def test_triton_module_replacement(self):
+        """Test that torch.backends.triton module is properly replaced with TritonModule."""
+        import torch.backends.triton as triton
+
+        # Check that the module is the custom PropModule instance
+        from torch.backends import PropModule
+        self.assertIsInstance(sys.modules['torch.backends.triton'], PropModule)
+
+        # Test that enabled property works through the module replacement
+        self.assertTrue(hasattr(triton, 'enabled'))
+        self.assertIsInstance(triton.enabled, bool)
+
+    def test_both_backends_independent(self):
+        """Test that cutedsl and triton backends operate independently."""
+        import torch.backends.cutedsl as cutedsl
+        import torch.backends.triton as triton
+
+        # Both should start enabled
+        self.assertTrue(cutedsl.enabled)
+        self.assertTrue(triton.enabled)
+
+        # Disable cutedsl, triton should remain enabled
+        cutedsl.enabled = False
+        self.assertFalse(cutedsl.enabled)
+        self.assertTrue(triton.enabled)
+
+        # Disable triton, cutedsl should remain disabled
+        triton.enabled = False
+        self.assertFalse(cutedsl.enabled)
+        self.assertFalse(triton.enabled)
+
+        # Re-enable cutedsl, triton should remain disabled
+        cutedsl.enabled = True
+        self.assertTrue(cutedsl.enabled)
+        self.assertFalse(triton.enabled)
+
+    @patch('torch._native.registry._reenable_op_overrides')
+    @patch('torch._native.registry._deregister_op_overrides')
+    def test_nested_context_managers(self, mock_disable, mock_reenable):
+        """Test nested context managers for both backends."""
+        import torch.backends.cutedsl as cutedsl
+        import torch.backends.triton as triton
+
+        # Both start enabled
+        self.assertTrue(cutedsl.enabled)
+        self.assertTrue(triton.enabled)
+
+        with cutedsl.flags(enabled=False):
+            self.assertFalse(cutedsl.enabled)
+            self.assertTrue(triton.enabled)
+
+            with triton.flags(enabled=False):
+                self.assertFalse(cutedsl.enabled)
+                self.assertFalse(triton.enabled)
+
+            # triton restored, cutedsl still disabled
+            self.assertFalse(cutedsl.enabled)
+            self.assertTrue(triton.enabled)
+
+        # Both restored to original state
+        self.assertTrue(cutedsl.enabled)
+        self.assertTrue(triton.enabled)
+
+    def test_integration_with_registry_calls(self):
+        """Test that backends correctly integrate with the registry system."""
+        # Test that the registry functions are properly imported and accessible
+        import torch.backends.cutedsl as cutedsl
+        import torch.backends.triton as triton
+
+        # These should not raise import errors
+        from torch._native.registry import _reenable_op_overrides, _deregister_op_overrides
+
+        # The backends should be able to call these functions without error
+        # (though they may be no-ops if no overrides are registered)
+        try:
+            _deregister_op_overrides(disable_dsl_names="cutedsl")
+            _reenable_op_overrides(enable_dsl_names="cutedsl")
+            _deregister_op_overrides(disable_dsl_names="triton")
+            _reenable_op_overrides(enable_dsl_names="triton")
+        except Exception as e:
+            self.fail(f"Registry integration failed: {e}")
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/python_native/test_torch_backends.py
+++ b/test/python_native/test_torch_backends.py
@@ -13,48 +13,65 @@ class TestTorchBackends(TestCase):
     def setUp(self):
         """Set up test environment."""
         # Note: Don't clear modules as it interferes with the PropModule replacement
-        pass
 
     @contextmanager
     def _mock_native_utils(self, runtime_available=True, runtime_version=None):
         """Context manager to mock the native utility functions."""
-        with patch("torch._native.cutedsl_utils.runtime_available", return_value=runtime_available), \
-             patch("torch._native.cutedsl_utils.runtime_version", return_value=runtime_version), \
-             patch("torch._native.triton_utils.runtime_available", return_value=runtime_available), \
-             patch("torch._native.triton_utils.runtime_version", return_value=runtime_version):
+        with (
+            patch(
+                "torch._native.cutedsl_utils.runtime_available",
+                return_value=runtime_available,
+            ),
+            patch(
+                "torch._native.cutedsl_utils.runtime_version",
+                return_value=runtime_version,
+            ),
+            patch(
+                "torch._native.triton_utils.runtime_available",
+                return_value=runtime_available,
+            ),
+            patch(
+                "torch._native.triton_utils.runtime_version",
+                return_value=runtime_version,
+            ),
+        ):
             yield
 
     def test_cutedsl_module_import(self):
         """Test that torch.backends.cutedsl can be imported."""
         import torch.backends.cutedsl as cutedsl
-        self.assertTrue(hasattr(cutedsl, 'is_available'))
-        self.assertTrue(hasattr(cutedsl, 'version'))
-        self.assertTrue(hasattr(cutedsl, 'enabled'))
-        self.assertTrue(hasattr(cutedsl, 'flags'))
-        self.assertTrue(hasattr(cutedsl, 'set_flags'))
+
+        self.assertTrue(hasattr(cutedsl, "is_available"))
+        self.assertTrue(hasattr(cutedsl, "version"))
+        self.assertTrue(hasattr(cutedsl, "enabled"))
+        self.assertTrue(hasattr(cutedsl, "flags"))
+        self.assertTrue(hasattr(cutedsl, "set_flags"))
 
     def test_triton_module_import(self):
         """Test that torch.backends.triton can be imported."""
         import torch.backends.triton as triton
-        self.assertTrue(hasattr(triton, 'is_available'))
-        self.assertTrue(hasattr(triton, 'version'))
-        self.assertTrue(hasattr(triton, 'enabled'))
-        self.assertTrue(hasattr(triton, 'flags'))
-        self.assertTrue(hasattr(triton, 'set_flags'))
+
+        self.assertTrue(hasattr(triton, "is_available"))
+        self.assertTrue(hasattr(triton, "version"))
+        self.assertTrue(hasattr(triton, "enabled"))
+        self.assertTrue(hasattr(triton, "flags"))
+        self.assertTrue(hasattr(triton, "set_flags"))
 
     def test_cutedsl_is_available(self):
         """Test torch.backends.cutedsl.is_available() function."""
         with self._mock_native_utils(runtime_available=True):
             import torch.backends.cutedsl as cutedsl
+
             result = cutedsl.is_available()
             self.assertIsInstance(result, bool)
             self.assertTrue(result)
 
         # Test with runtime not available
         with self._mock_native_utils(runtime_available=False):
-            if 'torch.backends.cutedsl' in sys.modules:
-                del sys.modules['torch.backends.cutedsl']
+            if "torch.backends.cutedsl" in sys.modules:
+                del sys.modules["torch.backends.cutedsl"]
             import torch.backends.cutedsl as cutedsl
+
             result = cutedsl.is_available()
             self.assertIsInstance(result, bool)
             self.assertFalse(result)
@@ -63,15 +80,17 @@ class TestTorchBackends(TestCase):
         """Test torch.backends.triton.is_available() function."""
         with self._mock_native_utils(runtime_available=True):
             import torch.backends.triton as triton
+
             result = triton.is_available()
             self.assertIsInstance(result, bool)
             self.assertTrue(result)
 
         # Test with runtime not available
         with self._mock_native_utils(runtime_available=False):
-            if 'torch.backends.triton' in sys.modules:
-                del sys.modules['torch.backends.triton']
+            if "torch.backends.triton" in sys.modules:
+                del sys.modules["torch.backends.triton"]
             import torch.backends.triton as triton
+
             result = triton.is_available()
             self.assertIsInstance(result, bool)
             self.assertFalse(result)
@@ -83,13 +102,15 @@ class TestTorchBackends(TestCase):
         test_version = Version("1.2.3")
         with self._mock_native_utils(runtime_version=test_version):
             import torch.backends.cutedsl as cutedsl
+
             result = cutedsl.version()
             self.assertEqual(result, test_version)
 
         with self._mock_native_utils(runtime_version=None):
-            if 'torch.backends.cutedsl' in sys.modules:
-                del sys.modules['torch.backends.cutedsl']
+            if "torch.backends.cutedsl" in sys.modules:
+                del sys.modules["torch.backends.cutedsl"]
             import torch.backends.cutedsl as cutedsl
+
             result = cutedsl.version()
             self.assertIsNone(result)
 
@@ -100,24 +121,28 @@ class TestTorchBackends(TestCase):
         test_version = Version("2.1.0")
         with self._mock_native_utils(runtime_version=test_version):
             import torch.backends.triton as triton
+
             result = triton.version()
             self.assertEqual(result, test_version)
 
         with self._mock_native_utils(runtime_version=None):
-            if 'torch.backends.triton' in sys.modules:
-                del sys.modules['torch.backends.triton']
+            if "torch.backends.triton" in sys.modules:
+                del sys.modules["torch.backends.triton"]
             import torch.backends.triton as triton
+
             result = triton.version()
             self.assertIsNone(result)
 
     def test_cutedsl_enabled_default(self):
         """Test that torch.backends.cutedsl.enabled is True by default."""
         import torch.backends.cutedsl as cutedsl
+
         self.assertTrue(cutedsl.enabled)
 
     def test_triton_enabled_default(self):
         """Test that torch.backends.triton.enabled is True by default."""
         import torch.backends.triton as triton
+
         self.assertTrue(triton.enabled)
 
     def test_cutedsl_enabled_setter(self):
@@ -156,8 +181,8 @@ class TestTorchBackends(TestCase):
         # Restore initial state
         triton.enabled = initial_state
 
-    @patch('torch._native.registry._reenable_op_overrides')
-    @patch('torch._native.registry._deregister_op_overrides')
+    @patch("torch._native.registry._reenable_op_overrides")
+    @patch("torch._native.registry._deregister_op_overrides")
     def test_cutedsl_set_flags(self, mock_disable, mock_reenable):
         """Test torch.backends.cutedsl.set_flags() function."""
         import torch.backends.cutedsl as cutedsl
@@ -177,8 +202,8 @@ class TestTorchBackends(TestCase):
         orig_flags = cutedsl.set_flags(_enabled=None)
         self.assertEqual(orig_flags, (True,))
 
-    @patch('torch._native.registry._reenable_op_overrides')
-    @patch('torch._native.registry._deregister_op_overrides')
+    @patch("torch._native.registry._reenable_op_overrides")
+    @patch("torch._native.registry._deregister_op_overrides")
     def test_triton_set_flags(self, mock_disable, mock_reenable):
         """Test torch.backends.triton.set_flags() function."""
         import torch.backends.triton as triton
@@ -294,10 +319,11 @@ class TestTorchBackends(TestCase):
 
         # Check that the module is the custom PropModule instance
         from torch.backends import PropModule
-        self.assertIsInstance(sys.modules['torch.backends.cutedsl'], PropModule)
+
+        self.assertIsInstance(sys.modules["torch.backends.cutedsl"], PropModule)
 
         # Test that enabled property works through the module replacement
-        self.assertTrue(hasattr(cutedsl, 'enabled'))
+        self.assertTrue(hasattr(cutedsl, "enabled"))
         self.assertIsInstance(cutedsl.enabled, bool)
 
     def test_triton_module_replacement(self):
@@ -306,10 +332,11 @@ class TestTorchBackends(TestCase):
 
         # Check that the module is the custom PropModule instance
         from torch.backends import PropModule
-        self.assertIsInstance(sys.modules['torch.backends.triton'], PropModule)
+
+        self.assertIsInstance(sys.modules["torch.backends.triton"], PropModule)
 
         # Test that enabled property works through the module replacement
-        self.assertTrue(hasattr(triton, 'enabled'))
+        self.assertTrue(hasattr(triton, "enabled"))
         self.assertIsInstance(triton.enabled, bool)
 
     def test_both_backends_independent(self):
@@ -336,8 +363,8 @@ class TestTorchBackends(TestCase):
         self.assertTrue(cutedsl.enabled)
         self.assertFalse(triton.enabled)
 
-    @patch('torch._native.registry._reenable_op_overrides')
-    @patch('torch._native.registry._deregister_op_overrides')
+    @patch("torch._native.registry._reenable_op_overrides")
+    @patch("torch._native.registry._deregister_op_overrides")
     def test_nested_context_managers(self, mock_disable, mock_reenable):
         """Test nested context managers for both backends."""
         import torch.backends.cutedsl as cutedsl
@@ -366,11 +393,12 @@ class TestTorchBackends(TestCase):
     def test_integration_with_registry_calls(self):
         """Test that backends correctly integrate with the registry system."""
         # Test that the registry functions are properly imported and accessible
-        import torch.backends.cutedsl as cutedsl
-        import torch.backends.triton as triton
 
         # These should not raise import errors
-        from torch._native.registry import _reenable_op_overrides, _deregister_op_overrides
+        from torch._native.registry import (
+            _deregister_op_overrides,
+            _reenable_op_overrides,
+        )
 
         # The backends should be able to call these functions without error
         # (though they may be no-ops if no overrides are registered)

--- a/torch/backends/__init__.py
+++ b/torch/backends/__init__.py
@@ -126,6 +126,7 @@ from torch.backends import (
     cuda as cuda,
     cudnn as cudnn,
     cusparselt as cusparselt,
+    cutedsl as cutedsl,
     kleidiai as kleidiai,
     mha as mha,
     miopen as miopen,
@@ -136,4 +137,5 @@ from torch.backends import (
     openmp as openmp,
     opt_einsum as opt_einsum,
     quantized as quantized,
+    triton as triton,
 )

--- a/torch/backends/cutedsl/__init__.py
+++ b/torch/backends/cutedsl/__init__.py
@@ -22,8 +22,15 @@ def version() -> Version | None:
 
 
 def _set_enabled(_enabled: bool) -> None:
+    from torch._native.registry import _deregister_op_overrides, _reenable_op_overrides
+
     global enabled
     enabled = _enabled
+
+    if enabled:
+        _reenable_op_overrides(enable_dsl_names="cutedsl")
+    else:
+        _deregister_op_overrides(disable_dsl_names="cutedsl")
 
 
 def _get_enabled() -> bool:
@@ -40,7 +47,7 @@ def set_flags(_enabled=None):
 @contextmanager
 def flags(enabled=None):
     with __allow_nonbracketed_mutation():
-        orig_flags = set_flags(enabled)
+        orig_flags = set_flags(_enabled=enabled)
     try:
         yield
     finally:

--- a/torch/backends/cutedsl/__init__.py
+++ b/torch/backends/cutedsl/__init__.py
@@ -42,6 +42,7 @@ def _get_enabled() -> bool:
 
 def set_flags(_enabled=None):
     import sys
+
     current_module = sys.modules[__name__]
     orig_flags = (current_module.enabled,)
     if _enabled is not None:

--- a/torch/backends/cutedsl/__init__.py
+++ b/torch/backends/cutedsl/__init__.py
@@ -28,11 +28,15 @@ def version() -> Version | None:
 def _set_enabled(_enabled: bool) -> None:
     from torch._native.registry import deregister_op_overrides, reenable_op_overrides
 
+    old_enabled = _state["enabled"]
+
     _state["enabled"] = _enabled
 
-    if _enabled:
+    if _enabled and (not old_enabled):
+        # now enabled, wasn't before
         reenable_op_overrides(enable_dsl_names="cutedsl")
-    else:
+    elif old_enabled and (not _enabled):
+        # was enabled, now isn't
         deregister_op_overrides(disable_dsl_names="cutedsl")
 
 

--- a/torch/backends/cutedsl/__init__.py
+++ b/torch/backends/cutedsl/__init__.py
@@ -1,0 +1,49 @@
+# mypy: allow-untyped-defs
+import sys
+from contextlib import contextmanager
+
+from torch.backends import __allow_nonbracketed_mutation, ContextProp, PropModule
+
+
+def is_available() -> bool:
+    r"""Return a bool indicating if the CuTeDSL runtime is currently available."""
+    from torch._native import cutedsl_utils
+
+    return cutedsl_utils.runtime_available()
+
+
+def _set_enabled(_enabled: bool) -> None:
+    global enabled
+    enabled = _enabled
+
+
+def _get_enabled() -> bool:
+    return enabled
+
+
+def set_flags(_enabled=None):
+    orig_flags = (enabled,)
+    if _enabled is not None:
+        _set_enabled(_enabled)
+    return orig_flags
+
+
+@contextmanager
+def flags(enabled=None):
+    with __allow_nonbracketed_mutation():
+        orig_flags = set_flags(enabled)
+    try:
+        yield
+    finally:
+        with __allow_nonbracketed_mutation():
+            set_flags(*orig_flags)
+
+
+class CuTeDSLModule(PropModule):
+    global enabled
+    enabled = ContextProp(_get_enabled, _set_enabled)
+
+
+sys.modules[__name__] = CuTeDSLModule(sys.modules[__name__], __name__)
+
+enabled = True

--- a/torch/backends/triton/__init__.py
+++ b/torch/backends/triton/__init__.py
@@ -28,11 +28,14 @@ def version() -> Version | None:
 def _set_enabled(_enabled: bool) -> None:
     from torch._native.registry import deregister_op_overrides, reenable_op_overrides
 
+    old_enabled = _state["enabled"]
     _state["enabled"] = _enabled
 
-    if _enabled:
+    if _enabled and (not old_enabled):
+        # now enabled, wasn't before
         reenable_op_overrides(enable_dsl_names="triton")
-    else:
+    elif old_enabled and (not _enabled):
+        # was enabled, now isn't
         deregister_op_overrides(disable_dsl_names="triton")
 
 

--- a/torch/backends/triton/__init__.py
+++ b/torch/backends/triton/__init__.py
@@ -22,8 +22,15 @@ def version() -> Version | None:
 
 
 def _set_enabled(_enabled: bool) -> None:
+    from torch._native.registry import _deregister_op_overrides, _reenable_op_overrides
+
     global enabled
     enabled = _enabled
+
+    if enabled:
+        _reenable_op_overrides(enable_dsl_names="triton")
+    else:
+        _deregister_op_overrides(disable_dsl_names="triton")
 
 
 def _get_enabled() -> bool:
@@ -40,7 +47,7 @@ def set_flags(_enabled=None):
 @contextmanager
 def flags(enabled=None):
     with __allow_nonbracketed_mutation():
-        orig_flags = set_flags(enabled)
+        orig_flags = set_flags(_enabled=enabled)
     try:
         yield
     finally:

--- a/torch/backends/triton/__init__.py
+++ b/torch/backends/triton/__init__.py
@@ -42,6 +42,7 @@ def _get_enabled() -> bool:
 
 def set_flags(_enabled=None):
     import sys
+
     current_module = sys.modules[__name__]
     orig_flags = (current_module.enabled,)
     if _enabled is not None:

--- a/torch/backends/triton/__init__.py
+++ b/torch/backends/triton/__init__.py
@@ -1,0 +1,49 @@
+# mypy: allow-untyped-defs
+import sys
+from contextlib import contextmanager
+
+from torch.backends import __allow_nonbracketed_mutation, ContextProp, PropModule
+
+
+def is_available() -> bool:
+    r"""Return a bool indicating if the Triton runtime is currently available."""
+    from torch._native import triton_utils
+
+    return triton_utils.runtime_available()
+
+
+def _set_enabled(_enabled: bool) -> None:
+    global enabled
+    enabled = _enabled
+
+
+def _get_enabled() -> bool:
+    return enabled
+
+
+def set_flags(_enabled=None):
+    orig_flags = (enabled,)
+    if _enabled is not None:
+        _set_enabled(_enabled)
+    return orig_flags
+
+
+@contextmanager
+def flags(enabled=None):
+    with __allow_nonbracketed_mutation():
+        orig_flags = set_flags(enabled)
+    try:
+        yield
+    finally:
+        with __allow_nonbracketed_mutation():
+            set_flags(*orig_flags)
+
+
+class TritonModule(PropModule):
+    global enabled
+    enabled = ContextProp(_get_enabled, _set_enabled)
+
+
+sys.modules[__name__] = TritonModule(sys.modules[__name__], __name__)
+
+enabled = True


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #176284
* #176283
* #176892
* #178518
* #178381
* #178327
* __->__ #176281
* #177550

Summary:

Add `torch.backends.{triton,cutedsl}`

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags:
Signed-off-by: Simon Layton <simonlayton@meta.com>

cc @albanD