### PR TITLE
[Native DSL] Use whitelisted DSL runtime versions

### DIFF
--- a/test/python_native/test_native_dsl_ops.py
+++ b/test/python_native/test_native_dsl_ops.py
@@ -179,6 +179,126 @@ class TestNativeDSLOps(TestCase):
         result = _subprocess_lastline(script, env=env)
         self.assertEqual(result, "True")
 
+    def test_register_op_skips_when_version_not_blessed(self):
+        """register_op does not enqueue fn when version is not in _BLESSED_VERSIONS."""
+        from torch._native.registry import _RegisteredFns
+        from torch._native import triton_utils, cutedsl_utils
+
+        for mod, avail_flag, ver_flag in [
+            (triton_utils, "_TRITON_AVAILABLE", "_TRITON_VERSION"),
+            (cutedsl_utils, "_CUTEDSL_AVAILABLE", "_CUTEDSL_VERSION"),
+        ]:
+            original_len = len(_RegisteredFns)
+            saved_avail = getattr(mod, avail_flag)
+            saved_ver = getattr(mod, ver_flag)
+            try:
+                setattr(mod, avail_flag, True)
+                setattr(mod, ver_flag, (99, 99, 99))
+                mod.register_op(lambda: None)
+                self.assertEqual(
+                    len(_RegisteredFns),
+                    original_len,
+                    f"{mod.__name__}.register_op should not enqueue with non-blessed version",
+                )
+            finally:
+                setattr(mod, avail_flag, saved_avail)
+                setattr(mod, ver_flag, saved_ver)
+
+    def test_register_op_skips_when_version_is_none(self):
+        """register_op does not enqueue fn when version is None."""
+        from torch._native.registry import _RegisteredFns
+        from torch._native import triton_utils, cutedsl_utils
+
+        for mod, avail_flag, ver_flag in [
+            (triton_utils, "_TRITON_AVAILABLE", "_TRITON_VERSION"),
+            (cutedsl_utils, "_CUTEDSL_AVAILABLE", "_CUTEDSL_VERSION"),
+        ]:
+            original_len = len(_RegisteredFns)
+            saved_avail = getattr(mod, avail_flag)
+            saved_ver = getattr(mod, ver_flag)
+            try:
+                setattr(mod, avail_flag, True)
+                setattr(mod, ver_flag, None)
+                mod.register_op(lambda: None)
+                self.assertEqual(
+                    len(_RegisteredFns),
+                    original_len,
+                    f"{mod.__name__}.register_op should not enqueue when version is None",
+                )
+            finally:
+                setattr(mod, avail_flag, saved_avail)
+                setattr(mod, ver_flag, saved_ver)
+
+    def test_version_skip_env_var_overrides(self):
+        """TORCH_NATIVE_SKIP_VERSION_CHECK=1 allows non-blessed versions."""
+        script = textwrap.dedent("""\
+            from torch._native import triton_utils, cutedsl_utils
+            from torch._native.registry import _RegisteredFns
+
+            # Force runtime "available" with a non-blessed version
+            triton_utils._TRITON_AVAILABLE = True
+            triton_utils._TRITON_VERSION = (99, 99, 99)
+            cutedsl_utils._CUTEDSL_AVAILABLE = True
+            cutedsl_utils._CUTEDSL_VERSION = (99, 99, 99)
+
+            before = len(_RegisteredFns)
+            triton_utils.register_op(lambda: None)
+            cutedsl_utils.register_op(lambda: None)
+            after = len(_RegisteredFns)
+            print(after - before)
+        """)
+        env = os.environ.copy()
+        env["TORCH_NATIVE_SKIP_VERSION_CHECK"] = "1"
+        result = _subprocess_lastline(script, env=env)
+        self.assertEqual(result, "2")
+
+    def test_check_native_version_skip_default(self):
+        """TORCH_NATIVE_SKIP_VERSION_CHECK unset -> returns False."""
+        script = textwrap.dedent("""\
+            import os
+            os.environ.pop("TORCH_NATIVE_SKIP_VERSION_CHECK", None)
+            from torch._native.common_utils import check_native_version_skip
+            print(check_native_version_skip())
+        """)
+        result = _subprocess_lastline(script)
+        self.assertEqual(result, "False")
+
+    def test_check_native_version_skip_set(self):
+        """TORCH_NATIVE_SKIP_VERSION_CHECK=1 -> returns True."""
+        script = textwrap.dedent("""\
+            from torch._native.common_utils import check_native_version_skip
+            print(check_native_version_skip())
+        """)
+        env = os.environ.copy()
+        env["TORCH_NATIVE_SKIP_VERSION_CHECK"] = "1"
+        result = _subprocess_lastline(script, env=env)
+        self.assertEqual(result, "True")
+
+    def test_available_version_prerelease(self):
+        """_available_version handles pre-release suffixes correctly."""
+        from unittest.mock import patch
+        from torch._native.common_utils import _available_version
+
+        cases = [
+            ("0.7.0rc1", (0, 7, 0)),
+            ("3.1.0.post1", (3, 1, 0)),
+            ("2.4.0a1", (2, 4, 0)),
+            ("1.2.3", (1, 2, 3)),
+        ]
+        for version_str, expected in cases:
+            with patch("importlib.metadata.version", return_value=version_str):
+                result = _available_version("fake_package")
+                self.assertEqual(
+                    result,
+                    expected,
+                    f"_available_version({version_str!r}) = {result}, expected {expected}",
+                )
+
+        # Completely unparseable -> None
+        with patch("importlib.metadata.version", return_value="abc"):
+            result = _available_version("fake_package")
+            self.assertIsNone(result)
+
 
 if __name__ == "__main__":
     run_tests()

--- a/torch/_native/common_utils.py
+++ b/torch/_native/common_utils.py
@@ -1,6 +1,7 @@
 import importlib
 import importlib.metadata
 import os
+import re
 
 from functools import cache
 
@@ -31,16 +32,37 @@ def _unavailable_reason(deps: list[tuple[str, str]]) -> None | str:
             )
     return None
 
-def _available_version(package: str) -> tuple[int, int, int]:
+def _available_version(package: str) -> tuple[int, int, int] | None:
     """
-    Get version of the installed "nvidia-cutlass-dsl" package
+    Get the installed version of a package as (major, minor, patch).
 
-    Assumes the package exists, i.e. will fail if it doesn't
+    Handles pre-release suffixes like "0.7.0rc1" or "3.1.0.post1" by
+    stripping non-numeric tails from each component. Returns None on
+    parse failure.
     """
     version = importlib.metadata.version(package)
+    parts = version.split(".")[:3]
+    if len(parts) != 3:
+        return None
+    try:
+        nums = []
+        for part in parts:
+            m = re.match(r"(\d+)", part)
+            if m is None:
+                return None
+            nums.append(int(m.group(1)))
+        return (nums[0], nums[1], nums[2])
+    except (ValueError, IndexError):
+        return None
 
-    major, minor, update = (int(vi) for vi in version.split("."))
 
-    return (major, minor, update)
+@cache
+def check_native_version_skip() -> bool:
+    """
+    Single point to check if native DSL version gating should be skipped,
+    checked via:
+    TORCH_NATIVE_SKIP_VERSION_CHECK=1
+    """
+    return int(os.getenv("TORCH_NATIVE_SKIP_VERSION_CHECK", 0)) == 1
 
 

--- a/torch/_native/cutedsl_utils.py
+++ b/torch/_native/cutedsl_utils.py
@@ -7,6 +7,7 @@ import os
 from .registry import register_op_registerer, _RegisterFn
 from .common_utils import (
     check_native_jit_disabled,
+    check_native_version_skip,
     _available_version,
     _unavailable_reason,
 )
@@ -16,7 +17,9 @@ log = logging.getLogger(__name__)
 _CUTEDSL_AVAILABLE = None
 _CUTEDSL_VERSION = None
 
-log = logging.getLogger(__name__)
+_BLESSED_VERSIONS: set[tuple[int, int, int]] = {
+    (4, 4, 1),
+}
 
 @functools.cache
 def _check_runtime_available() -> bool:
@@ -57,9 +60,26 @@ def runtime_available() -> bool:
 def runtime_version() -> None | tuple[int, int, int]:
     return _CUTEDSL_VERSION
 
+def _version_is_blessed() -> bool:
+    if check_native_version_skip():
+        return True
+    if _CUTEDSL_VERSION is None:
+        return False
+    return _CUTEDSL_VERSION in _BLESSED_VERSIONS
+
+
 def register_op(fn: _RegisterFn) -> None:
     if (not _CUTEDSL_AVAILABLE) or check_native_jit_disabled():
         log.info(f'{__name__} not registering native ops')
+        return
+
+    if not _version_is_blessed():
+        log.warning(
+            "cutedsl version %s is not blessed (blessed: %s); "
+            "set TORCH_NATIVE_SKIP_VERSION_CHECK=1 to override",
+            _CUTEDSL_VERSION,
+            _BLESSED_VERSIONS,
+        )
         return
 
     register_op_registerer(fn)

--- a/torch/_native/triton_utils.py
+++ b/torch/_native/triton_utils.py
@@ -7,6 +7,7 @@ import os
 from .registry import register_op_registerer, _RegisterFn
 from .common_utils import (
     check_native_jit_disabled,
+    check_native_version_skip,
     _available_version,
     _unavailable_reason,
 )
@@ -15,6 +16,10 @@ log = logging.getLogger(__name__)
 
 _TRITON_AVAILABLE = None
 _TRITON_VERSION = None
+
+_BLESSED_VERSIONS: set[tuple[int, int, int]] = {
+    (3, 6, 0),
+}
 
 @functools.cache
 def _check_runtime_available() -> bool:
@@ -51,8 +56,25 @@ def runtime_available() -> bool:
 def runtime_version() -> None | tuple[int, int, int]:
     return _TRITON_VERSION
 
+def _version_is_blessed() -> bool:
+    if check_native_version_skip():
+        return True
+    if _TRITON_VERSION is None:
+        return False
+    return _TRITON_VERSION in _BLESSED_VERSIONS
+
+
 def register_op(fn: _RegisterFn) -> None:
     if (not _TRITON_AVAILABLE) or check_native_jit_disabled():
+        return
+
+    if not _version_is_blessed():
+        log.warning(
+            "triton version %s is not blessed (blessed: %s); "
+            "set TORCH_NATIVE_SKIP_VERSION_CHECK=1 to override",
+            _TRITON_VERSION,
+            _BLESSED_VERSIONS,
+        )
         return
 
     register_op_registerer(fn)

--- a/torch/backends/cutedsl/__init__.py
+++ b/torch/backends/cutedsl/__init__.py
@@ -12,6 +12,13 @@ def is_available() -> bool:
     return cutedsl_utils.runtime_available()
 
 
+def version() -> tuple[int, int, int] | None:
+    r"""Return the installed CuTeDSL runtime version, or None if unavailable."""
+    from torch._native import cutedsl_utils
+
+    return cutedsl_utils.runtime_version()
+
+
 def _set_enabled(_enabled: bool) -> None:
     global enabled
     enabled = _enabled

--- a/torch/backends/triton/__init__.py
+++ b/torch/backends/triton/__init__.py
@@ -12,6 +12,13 @@ def is_available() -> bool:
     return triton_utils.runtime_available()
 
 
+def version() -> tuple[int, int, int] | None:
+    r"""Return the installed Triton runtime version, or None if unavailable."""
+    from torch._native import triton_utils
+
+    return triton_utils.runtime_version()
+
+
 def _set_enabled(_enabled: bool) -> None:
     global enabled
     enabled = _enabled


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #176284
* #176283
* __->__ #176282
* #176281
* #176280

Summary:

Disable native DSL kernels unless white-listed versions are installed,
with optional override via. environment variable.

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags:
Signed-off-by: Simon Layton <simonlayton@meta.com>