### PR TITLE
[OpenReg] Disable StreamQuery test that randomly hangs in CI

### DIFF
--- a/test/cpp_extensions/open_registration_extension/torch_openreg/third_party/openreg/tests/stream_tests.cpp
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/third_party/openreg/tests/stream_tests.cpp
@@ -83,7 +83,8 @@ TEST_F(StreamTest, AddTaskToStreamNullptr) {
   EXPECT_EQ(openreg::addTaskToStream(nullptr, [] {}), orErrorUnknown);
 }
 
-TEST_F(StreamTest, StreamQuery) {
+// Disabled: randomly hangs in CI. See https://github.com/pytorch/pytorch/issues/176286
+TEST_F(StreamTest, DISABLED_StreamQuery) {
   orStream_t stream = nullptr;
   EXPECT_EQ(orStreamCreate(&stream), orSuccess);
 


### PR DESCRIPTION
The StreamQuery test in the OpenReg C++ stream tests has been randomly hanging the openreg test job in CI (see linked issue for example failures). This disables it using the gtest `DISABLED_` prefix until the root cause is identified.

Mitigates while we look into  https://github.com/pytorch/pytorch/issues/176286

Authored with Claude.

cc @ptrblck @msaroufim @eqy