### PR TITLE
[dcp] Fix save plan caching bug during validation failures

### DIFF
--- a/test/distributed/checkpoint/test_planner.py
+++ b/test/distributed/checkpoint/test_planner.py
@@ -1,6 +1,7 @@
 # Owner(s): ["oncall: distributed"]
 
 import sys
+from unittest.mock import patch
 
 import torch
 import torch.distributed.checkpoint as dcp
@@ -155,7 +156,13 @@ class TestSavePlan(TestCase):
         # First iteration, should create a new plan
         first_plan = planner.create_local_plan()
 
-        # Validate that the plan has been cached
+        # Plan should be pending, not yet in the class-level cache
+        self.assertNotIn(planner._cached_plans_key, SavePlanner._cached_save_plan)
+
+        # Promote the pending plan by calling finish_plan
+        planner.finish_plan(first_plan)
+
+        # Validate that the plan has been cached after finish_plan
         cached_plan = SavePlanner._cached_save_plan[planner._cached_plans_key]
         self.assertEqual(first_plan, cached_plan)
 
@@ -165,6 +172,11 @@ class TestSavePlan(TestCase):
         self.assertEqual(0, len(second_plan.items))
         self.assertIsNone(second_plan.planner_data)
         self.assertIsNone(second_plan.storage_data)
+
+        # Clean up class-level caches
+        key = planner._cached_plans_key
+        SavePlanner._cached_save_plan.pop(key, None)
+        SavePlanner._cached_final_save_plan.pop(key, None)
 
     def test_global_plan(self):
         def create_data(rank):
@@ -313,6 +325,14 @@ class TestSavePlan(TestCase):
         ]
         self.assertEqual(cached_global_plan, tensor_plan)
 
+        # Clean up class-level caches
+        key = planner._cached_plans_key
+        SavePlanner._cached_save_plan.pop(key, None)
+        SavePlanner._cached_final_save_plan.pop(key, None)
+        SavePlanner._cached_all_plans.pop(key, None)
+        SavePlanner._cached_global_plan.pop(key, None)
+        SavePlanner._cached_metadata.pop(key, None)
+
     def test_finish_plan_with_caching(self):
         planner = DefaultSavePlanner(enable_plan_caching=True)
         tensor = torch.rand(10)
@@ -333,6 +353,67 @@ class TestSavePlan(TestCase):
         # second iteration, should return the cached plan
         second_finished_plan = planner.finish_plan(SavePlan([], usable=False))
         self.assertEqual(second_finished_plan, first_finished_plan)
+
+        # Clean up class-level caches
+        key = planner._cached_plans_key
+        SavePlanner._cached_save_plan.pop(key, None)
+        SavePlanner._cached_final_save_plan.pop(key, None)
+
+    def test_caching_after_validation_failure(self):
+        def create_data(rank):
+            with with_dist(rank=rank, world_size=4):
+                planner = DefaultSavePlanner(enable_plan_caching=True)
+                tensor = torch.rand(10)
+                val = [1, 2, 3]
+                st = create_sharded_tensor(rank=rank, world_size=4, shards_per_rank=1)
+                state_dict = {"tensor": tensor, "value": val, "st": st}
+                planner.set_up_planner(state_dict, is_coordinator=(rank == 0))
+                return planner.create_local_plan()
+
+        planner = DefaultSavePlanner(enable_plan_caching=True)
+        key = planner._cached_plans_key
+
+        tensor = torch.rand(10)
+        val = [1, 2, 3]
+        state_dict = {"tensor": tensor, "value": val}
+        planner.set_up_planner(state_dict, is_coordinator=True)
+
+        local_plan = planner.create_local_plan()
+        self.assertTrue(local_plan.usable)
+        self.assertNotIn(key, SavePlanner._cached_save_plan)
+
+        all_plans = [create_data(0), create_data(1), create_data(2), create_data(3)]
+
+        with patch(
+            "torch.distributed.checkpoint.default_planner._validate_global_plan",
+            return_value=False,
+        ):
+            with self.assertRaises(ValueError):
+                planner.create_global_plan(all_plans)
+
+        self.assertNotIn(key, SavePlanner._cached_all_plans)
+        self.assertNotIn(key, SavePlanner._cached_global_plan)
+        self.assertNotIn(key, SavePlanner._cached_metadata)
+        self.assertNotIn(key, SavePlanner._cached_save_plan)
+
+        # Second save should succeed, not KeyError
+        planner.set_up_planner(state_dict, is_coordinator=True)
+        local_plan_2 = planner.create_local_plan()
+        self.assertTrue(local_plan_2.usable)
+
+        global_plan, metadata = planner.create_global_plan(all_plans)
+        self.assertIsNotNone(global_plan)
+        self.assertIsNotNone(metadata)
+        self.assertIn(key, SavePlanner._cached_all_plans)
+        self.assertIn(key, SavePlanner._cached_global_plan)
+        self.assertIn(key, SavePlanner._cached_metadata)
+
+        # Clean up class-level caches
+        SavePlanner._cached_save_plan.pop(key, None)
+        SavePlanner._cached_final_save_plan.pop(key, None)
+        SavePlanner._cached_all_plans.pop(key, None)
+        SavePlanner._cached_global_plan.pop(key, None)
+        SavePlanner._cached_metadata.pop(key, None)
 
     def test_local_load_plan(self):
         def create_state_dict(rank):

--- a/torch/distributed/checkpoint/default_planner.py
+++ b/torch/distributed/checkpoint/default_planner.py
@@ -123,7 +123,12 @@ class DefaultSavePlanner(SavePlanner):
                 )
                 return SavePlan([], usable=False)
             else:
-                SavePlanner._cached_save_plan[self._cached_plans_key] = plan
+                # Store the plan as pending. It will be promoted to the
+                # class-level cache in finish_plan after the global plan
+                # has succeeded. This avoids a stale local cache when
+                # the global plan fails (e.g. validation error) but the
+                # local cache was already populated.
+                self._pending_local_plan = plan
 
         return self.plan
 
@@ -164,12 +169,13 @@ class DefaultSavePlanner(SavePlanner):
             # Case 1: If the plans are not cached, the cache will be hydrated with the
             # all_plans, global_plans (Deduped), and metadata.
 
-            # Cache the original all_plans
-            SavePlanner._cached_all_plans[self._cached_plans_key] = all_plans
+            # First create and validate the global plan. Only cache everything
+            # after success to avoid partial cache state
             global_plan, metadata = self._create_global_plan(all_plans)
-            # Cache the deduped and validated global_plan
+
+            # Cache all plans atomically after successful validation
+            SavePlanner._cached_all_plans[self._cached_plans_key] = all_plans
             SavePlanner._cached_global_plan[self._cached_plans_key] = global_plan
-            # Cache the metadata
             SavePlanner._cached_metadata[self._cached_plans_key] = metadata
             # If plans are not cached, global_plan delta will be the same as global plan.
             return global_plan, global_plan, metadata
@@ -247,6 +253,16 @@ class DefaultSavePlanner(SavePlanner):
 
         if self._enable_plan_caching:
             finished_plan = self._finish_plan_with_caching(new_plan)
+
+            # Promote the pending local plan to the class-level cache now
+            # that the global plan has succeeded and we are finalizing.
+            # This ensures the local cache is only populated after a
+            # successful end-to-end checkpoint plan creation.
+            if hasattr(self, "_pending_local_plan"):
+                SavePlanner._cached_save_plan[self._cached_plans_key] = (
+                    self._pending_local_plan
+                )
+                del self._pending_local_plan
 
         self.plan = finished_plan
         return self.plan


### PR DESCRIPTION
Summary:
User reported bug https://fb.workplace.com/groups/modelstore.users/permalink/4146986708857322/
where save plan caching results in the following error.
```
[trainer61|5]:Traceback (most recent call last): (RANK 0)
[trainer61|5]:  File "/packages/aps.ads.icvr/icvr_launcher#link-tree/torch/distributed/checkpoint/utils.py", line 209, in reduce_scatter
[trainer61|5]:    reduce_fun(cast(list[T], all_data)),
[trainer61|5]:    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[trainer61|5]:  File "/packages/aps.ads.icvr/icvr_launcher#link-tree/torch/distributed/checkpoint/logger.py", line 90, in wrapper
[trainer61|5]:    result = func(*args, **kwargs)
[trainer61|5]:             ^^^^^^^^^^^^^^^^^^^^^
[trainer61|5]:  File "/packages/aps.ads.icvr/icvr_launcher#link-tree/torch/distributed/checkpoint/state_dict_saver.py", line 457, in global_step
[trainer61|5]:    all_local_plans, global_metadata = planner.create_global_plan(all_local_plans)
[trainer61|5]:                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[trainer61|5]:  File "/packages/aps.ads.icvr/icvr_launcher#link-tree/torch/distributed/checkpoint/default_planner.py", line 224, in create_global_plan
[trainer61|5]:    ) = self._create_global_plan_with_caching(all_plans)
[trainer61|5]:        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[trainer61|5]:  File "/packages/aps.ads.icvr/icvr_launcher#link-tree/torch/distributed/checkpoint/default_planner.py", line 183, in _create_global_plan_with_caching
[trainer61|5]:    global_plan = SavePlanner._cached_global_plan[self._cached_plans_key]
[trainer61|5]:                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^
[trainer61|5]:KeyError: 'ModelstoreAsyncSavePlanner'
```


The checkpoint planner uses class-level dictionaries to cache save plans across saves. The bug was a cache consistency problem:

On the first checkpoint save, create_local_plan() immediately populated the local plan cache (_cached_save_plan).
Later, create_global_plan() populated the global caches (_cached_all_plans, _cached_global_plan, _cached_metadata) before validating the plan.
If validation failed (e.g., a ValueError from _validate_global_plan), some caches were partially populated while others were not.
On the next save attempt, the code saw that the local cache existed and assumed all caches were populated — but the global caches were missing, causing an unguarded dictionary lookup to throw KeyError.
This masked the real error (the validation failure) with a confusing KeyError: 'ModelstoreAsyncSavePlanner'.

What the fix does
Two key changes to make caching atomic — either all caches are populated or none are:

Deferred local plan caching: Instead of writing to the class-level _cached_save_plan immediately in create_local_plan(), the plan is stored in a temporary instance attribute _pending_local_plan. It's only promoted to the class-level cache in finish_plan(), after the entire plan creation pipeline has succeeded.

Reordered global plan caching: In _create_global_plan_with_caching(), validation now runs before any caching. The three global caches are written together only after successful validation, preventing partial cache state.

Test Plan:
new unit test
tested with users job and found that the correct error of Global Plan Validation is correctly raised on every failure, instead of being masked by the caching error
https://www.internalfb.com/mlhub/pipelines/runs/mast/aps-V5Test2_0203tk_128gpu-71454e7bc2?job_attempt=3&version=0&tab=definition&env=PRODUCTION&referrer=MAST_JOB_NOTIFICATION_BOT

Reviewed By: sibuachu

Differential Revision: D94036625


