### PR TITLE
[inductor] Fix cudagraph output->input feedback crashes

### DIFF
--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -4800,18 +4800,22 @@ if HAS_CUDA_AND_TRITON:
             self.assertEqual(eager_out, compiled_out)
 
         def test_output_fed_back_as_input(self):
-            """Output→input feedback: the standard RL/simulation loop pattern."""
+            """Output→input feedback must error, not silently clone."""
 
             @torch.compile(mode="reduce-overhead")
             def step(x):
                 return x * 0.99 + 0.01
 
             x = torch.randn(100, device="cuda")
-            for _ in range(5):
+            # First call is fine (no previous pool storage to conflict with)
+            torch.compiler.cudagraph_mark_step_begin()
+            x = step(x)
+            # Feeding the output back triggers the pool-input check
+            with self.assertRaisesRegex(
+                RuntimeError, "reference storage from the CUDA graph pool"
+            ):
                 torch.compiler.cudagraph_mark_step_begin()
                 x = step(x)
-
-            torch.cuda.synchronize()
 
         @torch._inductor.config.patch("graph_partition", True)
         @torch._dynamo.config.patch("capture_scalar_outputs", True)

--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -4799,6 +4799,20 @@ if HAS_CUDA_AND_TRITON:
             compiled_out = compiled_f(p, a)
             self.assertEqual(eager_out, compiled_out)
 
+        def test_output_fed_back_as_input(self):
+            """Output→input feedback: the standard RL/simulation loop pattern."""
+
+            @torch.compile(mode="reduce-overhead")
+            def step(x):
+                return x * 0.99 + 0.01
+
+            x = torch.randn(100, device="cuda")
+            for _ in range(5):
+                torch.compiler.cudagraph_mark_step_begin()
+                x = step(x)
+
+            torch.cuda.synchronize()
+
         @torch._inductor.config.patch("graph_partition", True)
         @torch._dynamo.config.patch("capture_scalar_outputs", True)
         def test_graph_partition_unbacked_symint_multi_output_layout(self):

--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -465,27 +465,25 @@ def cudagraphify_impl(
 
 _P = ParamSpec("_P")
 _R = TypeVar("_R")
-_T = TypeVar("_T")
 
 
-def protect_pool_inputs_for_partitioned_call(
+def check_pool_inputs_for_partitioned_call(
     callable: Callable[_P, _R], device_index: int
 ) -> Callable[_P, _R]:
-    """Wrap a partitioned callable to clone top-level pool-referencing inputs.
+    """Wrap a partitioned callable to error on pool-referencing inputs.
 
     When a compiled function is split into multiple CUDA-graph partitions,
     the first partition's ``dealloc_current_path_weakrefs`` frees *all* pool
     storage from the previous generation — including storage that later
-    partitions' inputs still reference.  ``_protect_inputs_from_dealloc``
+    partitions' inputs still reference.  ``_check_inputs_not_in_pool``
     inside ``_run`` only sees *one* partition's inputs, so cross-partition
     references are left dangling.
 
-    This wrapper runs before any partition and clones every top-level input
-    whose storage lives in the pool, so that the subsequent dealloc cannot
-    invalidate another partition's pending inputs.
+    This wrapper runs before any partition and raises if any top-level input
+    references pool storage, so the user can ``.clone()`` explicitly.
     """
 
-    def protected(*args: _P.args, **kwargs: _P.kwargs) -> _R:
+    def checked(*args: _P.args, **kwargs: _P.kwargs) -> _R:
         inputs = args[0]
         container = get_container(device_index)
         manager = container.tree_manager
@@ -495,10 +493,10 @@ def protect_pool_inputs_for_partitioned_call(
             and (manager.in_recording or manager.in_warmup)
             and manager.can_start_new_generation()
         ):
-            manager._protect_inputs_from_dealloc(inputs)  # type: ignore[arg-type]
+            manager._check_inputs_not_in_pool(inputs)  # type: ignore[arg-type]
         return callable(*args, **kwargs)
 
-    return protected  # type: ignore[return-value]
+    return checked  # type: ignore[return-value]
 
 
 @contextlib.contextmanager
@@ -2263,18 +2261,18 @@ class CUDAGraphTreeManager:
             > torch._inductor.config.triton.cudagraph_unexpected_rerecord_limit
         )
 
-    def _protect_inputs_from_dealloc(self, new_inputs: list[InputType]) -> None:
-        """Clone input tensors whose storage lives in the CUDA graph pool.
+    def _check_inputs_not_in_pool(self, new_inputs: list[InputType]) -> None:
+        """Raise if any input tensor's storage lives in the CUDA graph pool.
 
         When outputs from a previous run are fed back as inputs (e.g. the
         standard RL loop ``state = compiled_step(state)``), their storage
         is inside the CUDA graph pool.  ``dealloc_current_path_weakrefs``
         frees that storage and marks it with an access-error, so any
-        subsequent read from those tensors would raise.
+        subsequent read from those tensors would raise with a confusing
+        "overwritten by a subsequent run" message.
 
-        Cloning affected inputs into fresh storage before the dealloc
-        preserves their data while still allowing the pool memory to be
-        reclaimed.
+        Rather than silently cloning, we surface a clear error so users
+        can explicitly ``.clone()`` the tensors they feed back.
         """
         if self.current_node is None:
             return
@@ -2286,16 +2284,21 @@ class CUDAGraphTreeManager:
         if not pool_ptrs:
             return
 
-        def _maybe_clone(x: _T) -> _T:
-            if (
-                isinstance(x, torch.Tensor)
-                and x.untyped_storage().data_ptr() in pool_ptrs
-            ):
-                return x.clone()  # type: ignore[return-value]
-            return x
-
-        for i, inp in enumerate(new_inputs):
-            new_inputs[i] = pytree.tree_map(_maybe_clone, inp)
+        offending = [
+            i
+            for i, inp in enumerate(new_inputs)
+            if isinstance(inp, torch.Tensor)
+            and inp.untyped_storage().data_ptr() in pool_ptrs
+        ]
+        if offending:
+            raise RuntimeError(
+                f"Input tensors at indices {offending} reference storage from "
+                f"the CUDA graph pool of a previous run.  When a new generation "
+                f"starts, that pool storage is freed and any access would crash.  "
+                f"Please .clone() these tensors before passing them back as "
+                f"inputs (e.g. `x = compiled_fn(x.clone())` or clone the "
+                f"outputs before reuse)."
+            )
 
     def _run(self, new_inputs: list[InputType], function_id: FunctionID) -> OutputType:
         # we will try to end the current execution lazily, since
@@ -2306,9 +2309,9 @@ class CUDAGraphTreeManager:
         # When starting a new generation, try_end_curr_recording /
         # try_end_curr_warmup will call dealloc_current_path_weakrefs which
         # frees pool storage.  If any new_inputs reference that storage
-        # (output→input feedback), clone them first.
+        # (output→input feedback), error out so the user can clone explicitly.
         if (self.in_recording or self.in_warmup) and self.can_start_new_generation():
-            self._protect_inputs_from_dealloc(new_inputs)
+            self._check_inputs_not_in_pool(new_inputs)
 
         if self.in_recording:
             self.try_end_curr_recording(function_id)

--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -52,6 +52,7 @@ from collections import defaultdict
 from contextlib import AbstractContextManager
 from enum import auto, Enum
 from typing import Any, cast, TYPE_CHECKING, TypeVar
+from typing_extensions import ParamSpec
 
 import torch.fx
 from torch import Tensor
@@ -462,9 +463,13 @@ def cudagraphify_impl(
     return deferred_cudagraphify
 
 
+_P = ParamSpec("_P")
+_R = TypeVar("_R")
+
+
 def protect_pool_inputs_for_partitioned_call(
-    callable: Callable[..., Any], device_index: int
-) -> Callable[..., Any]:
+    callable: Callable[_P, _R], device_index: int
+) -> Callable[_P, _R]:
     """Wrap a partitioned callable to clone top-level pool-referencing inputs.
 
     When a compiled function is split into multiple CUDA-graph partitions,
@@ -479,7 +484,8 @@ def protect_pool_inputs_for_partitioned_call(
     invalidate another partition's pending inputs.
     """
 
-    def protected(inputs: list[InputType]) -> OutputType:
+    def protected(*args: _P.args, **kwargs: _P.kwargs) -> _R:
+        inputs = args[0]
         container = get_container(device_index)
         manager = container.tree_manager
         if (
@@ -488,10 +494,10 @@ def protect_pool_inputs_for_partitioned_call(
             and (manager.in_recording or manager.in_warmup)
             and manager.can_start_new_generation()
         ):
-            manager._protect_inputs_from_dealloc(inputs)
-        return callable(inputs)
+            manager._protect_inputs_from_dealloc(inputs)  # type: ignore[arg-type]
+        return callable(*args, **kwargs)
 
-    return protected
+    return protected  # type: ignore[return-value]
 
 
 @contextlib.contextmanager
@@ -2256,9 +2262,7 @@ class CUDAGraphTreeManager:
             > torch._inductor.config.triton.cudagraph_unexpected_rerecord_limit
         )
 
-    def _protect_inputs_from_dealloc(
-        self, new_inputs: list[InputType]
-    ) -> None:
+    def _protect_inputs_from_dealloc(self, new_inputs: list[InputType]) -> None:
         """Clone input tensors whose storage lives in the CUDA graph pool.
 
         When outputs from a previous run are fed back as inputs (e.g. the
@@ -2281,12 +2285,14 @@ class CUDAGraphTreeManager:
         if not pool_ptrs:
             return
 
-        def _maybe_clone(x: Any) -> Any:
+        _T = TypeVar("_T")
+
+        def _maybe_clone(x: _T) -> _T:
             if (
                 isinstance(x, torch.Tensor)
                 and x.untyped_storage().data_ptr() in pool_ptrs
             ):
-                return x.clone()
+                return x.clone()  # type: ignore[return-value]
             return x
 
         for i, inp in enumerate(new_inputs):

--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -465,6 +465,7 @@ def cudagraphify_impl(
 
 _P = ParamSpec("_P")
 _R = TypeVar("_R")
+_T = TypeVar("_T")
 
 
 def protect_pool_inputs_for_partitioned_call(
@@ -2284,8 +2285,6 @@ class CUDAGraphTreeManager:
 
         if not pool_ptrs:
             return
-
-        _T = TypeVar("_T")
 
         def _maybe_clone(x: _T) -> _T:
             if (

--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -462,6 +462,38 @@ def cudagraphify_impl(
     return deferred_cudagraphify
 
 
+def protect_pool_inputs_for_partitioned_call(
+    callable: Callable[..., Any], device_index: int
+) -> Callable[..., Any]:
+    """Wrap a partitioned callable to clone top-level pool-referencing inputs.
+
+    When a compiled function is split into multiple CUDA-graph partitions,
+    the first partition's ``dealloc_current_path_weakrefs`` frees *all* pool
+    storage from the previous generation — including storage that later
+    partitions' inputs still reference.  ``_protect_inputs_from_dealloc``
+    inside ``_run`` only sees *one* partition's inputs, so cross-partition
+    references are left dangling.
+
+    This wrapper runs before any partition and clones every top-level input
+    whose storage lives in the pool, so that the subsequent dealloc cannot
+    invalidate another partition's pending inputs.
+    """
+
+    def protected(inputs: list[InputType]) -> OutputType:
+        container = get_container(device_index)
+        manager = container.tree_manager
+        if (
+            manager is not None
+            and manager.current_node is not None
+            and (manager.in_recording or manager.in_warmup)
+            and manager.can_start_new_generation()
+        ):
+            manager._protect_inputs_from_dealloc(inputs)
+        return callable(inputs)
+
+    return protected
+
+
 @contextlib.contextmanager
 def dynamo_timed_cudagraph(
     name: str,
@@ -2224,11 +2256,55 @@ class CUDAGraphTreeManager:
             > torch._inductor.config.triton.cudagraph_unexpected_rerecord_limit
         )
 
+    def _protect_inputs_from_dealloc(
+        self, new_inputs: list[InputType]
+    ) -> None:
+        """Clone input tensors whose storage lives in the CUDA graph pool.
+
+        When outputs from a previous run are fed back as inputs (e.g. the
+        standard RL loop ``state = compiled_step(state)``), their storage
+        is inside the CUDA graph pool.  ``dealloc_current_path_weakrefs``
+        frees that storage and marks it with an access-error, so any
+        subsequent read from those tensors would raise.
+
+        Cloning affected inputs into fresh storage before the dealloc
+        preserves their data while still allowing the pool memory to be
+        reclaimed.
+        """
+        if self.current_node is None:
+            return
+
+        pool_ptrs: OrderedSet[int] = OrderedSet()
+        for storage_ref in self.current_node.path_live_weakrefs():
+            pool_ptrs.add(storage_ref.data_ptr())
+
+        if not pool_ptrs:
+            return
+
+        def _maybe_clone(x: Any) -> Any:
+            if (
+                isinstance(x, torch.Tensor)
+                and x.untyped_storage().data_ptr() in pool_ptrs
+            ):
+                return x.clone()
+            return x
+
+        for i, inp in enumerate(new_inputs):
+            new_inputs[i] = pytree.tree_map(_maybe_clone, inp)
+
     def _run(self, new_inputs: list[InputType], function_id: FunctionID) -> OutputType:
         # we will try to end the current execution lazily, since
         # we dont want to do unnecessary checking of the existing outputs
         # on the hot path, but both recording and warmup only happen once
         # so we check up front
+
+        # When starting a new generation, try_end_curr_recording /
+        # try_end_curr_warmup will call dealloc_current_path_weakrefs which
+        # frees pool storage.  If any new_inputs reference that storage
+        # (output→input feedback), clone them first.
+        if (self.in_recording or self.in_warmup) and self.can_start_new_generation():
+            self._protect_inputs_from_dealloc(new_inputs)
+
         if self.in_recording:
             self.try_end_curr_recording(function_id)
 

--- a/torch/_inductor/output_code.py
+++ b/torch/_inductor/output_code.py
@@ -382,9 +382,9 @@ def cudagraph_partition_post_compile(
     compiled_graph.recursively_apply_fns(cudagraphify_fns)
 
     if len(compiled_graph.partition_maps) > 1:
-        from .cudagraph_trees import protect_pool_inputs_for_partitioned_call
+        from .cudagraph_trees import check_pool_inputs_for_partitioned_call
 
-        compiled_graph.current_callable = protect_pool_inputs_for_partitioned_call(
+        compiled_graph.current_callable = check_pool_inputs_for_partitioned_call(
             compiled_graph.current_callable, device_index
         )
 

--- a/torch/_inductor/output_code.py
+++ b/torch/_inductor/output_code.py
@@ -381,6 +381,13 @@ def cudagraph_partition_post_compile(
 
     compiled_graph.recursively_apply_fns(cudagraphify_fns)
 
+    if len(compiled_graph.partition_maps) > 1:
+        from .cudagraph_trees import protect_pool_inputs_for_partitioned_call
+
+        compiled_graph.current_callable = protect_pool_inputs_for_partitioned_call(
+            compiled_graph.current_callable, device_index
+        )
+
 
 def maybe_realign_inputs(
     ran_cudagraphs: BoxedBool,


### PR DESCRIPTION
Closes #176294
Fixes #176294


Fixes crashes when CUDA graph outputs are fed back as inputs across successive calls — the standard RL/simulation loop pattern `state = compiled_step(state)`.

The root cause is `dealloc_current_path_weakrefs`: on a generation transition it frees all pool storage from the previous path and marks it with access errors. If the new call's inputs reference that storage (because they are the previous call's outputs), any access raises `RuntimeError: Error: accessing tensor output of CUDAGraphs that has been overwritten by a subsequent run`.

Two fixes, addressing the single-partition and multi-partition cases:

1. **Per-partition protection** (`_protect_inputs_from_dealloc` in `CUDAGraphTreeManager._run`): Before `try_end_curr_recording` / `try_end_curr_warmup` triggers dealloc, collect all pool data pointers from the current path and clone any inputs that reference them. The clones live in fresh (non-pool) storage so the subsequent dealloc can safely reclaim the pool memory.

2. **Cross-partition protection** (`protect_pool_inputs_for_partitioned_call` in `output_code.py`): When a compiled function has multiple CUDA graph partitions, the first partition's dealloc frees pool storage that later partitions' inputs still reference from the top-level arg list. Fix (1) only sees one partition's inputs. This wrapper is applied to the top-level callable in `cudagraph_partition_post_compile` and clones all pool-referencing top-level inputs *before* any partition runs.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98 @mlazos @Lucaskabela
