### PR TITLE
[ROCm] Fix flaky SymmMemPoolTest mempool tests with process-group warmup

### DIFF
--- a/test/distributed/test_symmetric_memory.py
+++ b/test/distributed/test_symmetric_memory.py
@@ -1533,6 +1533,11 @@ class SymmMemPoolTest(MultiProcContinuousTest):
     @skip_if_lt_x_gpu(2)
     def test_mempool_tensor_factory(self):
         self._init_process()
+
+        # Need this all_reduce to initialize the process-group communicator.
+        # Otherwise, first-use one-shot symmetric-memory collectives can flake.
+        dist.all_reduce(torch.ones(1, device=self.device))
+
         group_name = dist.group.WORLD.group_name
 
         dtype = torch.float


### PR DESCRIPTION
This change stabilizes a flaky distributed test by adding a small process-group warmup (dist.all_reduce) before first-use one-shot symmetric-memory collectives in SymmMemPoolTest.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang