### PR TITLE
[Mergerules] Remove `NVFuser` group

### DIFF
--- a/.github/merge_rules.yaml
+++ b/.github/merge_rules.yaml
@@ -38,23 +38,6 @@
   - Lint
   - pull
 
-- name: NVFuser
-  patterns:
-  - test/test_jit_cuda_fuser.py
-  - torch/csrc/jit/codegen/fuser/cuda/**
-  - torch/csrc/jit/codegen/cuda/**
-  - benchmarks/cpp/nvfuser/**
-  approved_by:
-  - csarofeen
-  - ngimel
-  - jjsjann123
-  - kevinstephano
-  - ptrblck
-  mandatory_checks_name:
-  - EasyCLA
-  - Lint
-  - pull
-
 - name: OSS CI
   patterns:
   - .github/**


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #176303
* #176304
* #176302
* __->__ #176301

As project has been moved out of core for quite some time