### PR TITLE
[MergeRules] Remove dagitses from OSS CI merge rules

### DIFF
--- a/.github/merge_rules.yaml
+++ b/.github/merge_rules.yaml
@@ -47,7 +47,6 @@
   - tools/**
   approved_by:
   - alband
-  - dagitses
   - pytorch/pytorch-dev-infra
   mandatory_checks_name:
   - EasyCLA


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #176303
* #176304
* __->__ #176302
* #176301

As he has been inactive for quite some time