### PR TITLE
[Docs] Update LSTM docstring: h_n/c_n refer to batch elements

### DIFF
--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -920,11 +920,11 @@ class LSTM(RNNBase):
           a concatenation of the forward and reverse hidden states at each time step in the sequence.
         * **h_n**: tensor of shape :math:`(D * \text{num\_layers}, H_{out})` for unbatched input or
           :math:`(D * \text{num\_layers}, N, H_{out})` containing the
-          final hidden state for each element in the sequence. When ``bidirectional=True``,
+          final hidden state for each element in the batch. When ``bidirectional=True``,
           `h_n` will contain a concatenation of the final forward and reverse hidden states, respectively.
         * **c_n**: tensor of shape :math:`(D * \text{num\_layers}, H_{cell})` for unbatched input or
           :math:`(D * \text{num\_layers}, N, H_{cell})` containing the
-          final cell state for each element in the sequence. When ``bidirectional=True``,
+          final cell state for each element in the batch. When ``bidirectional=True``,
           `c_n` will contain a concatenation of the final forward and reverse cell states, respectively.
 
     Attributes:


### PR DESCRIPTION
Fixes #175479

The LSTM output docstring describes `h_n` and `c_n` as containing the final state "for each element in the sequence." Since these tensors have shape `(D * num_layers, N, ...)` where `N` is the batch dimension, "for each element in the batch" is more accurate. This is consistent with the `RNN` class docstring which already uses the correct wording (line 581).

This PR changes two words ("sequence" → "batch") on lines 923 and 927 of `torch/nn/modules/rnn.py`.