### PR TITLE
[WIP][flex] create_block_mask HOP that installs subgraph

### DIFF
--- a/test/dynamo/test_modes.py
+++ b/test/dynamo/test_modes.py
@@ -2159,6 +2159,44 @@ class outer_fn(torch.nn.Module):
                     print(submod.graph)
 
 
+    @requires_gpu
+    def test_torch_compile_create_block_mask_flex_attention(self):
+        from torch.nn.attention.flex_attention import (
+            create_block_mask,
+            flex_attention,
+        )
+
+        d_model = 64
+        n_heads = 4
+
+        def causal_mask(b, h, q_idx, kv_idx):
+            return q_idx >= kv_idx
+
+        def fn(q, k, v):
+            bs = q.shape[0]
+            sl = q.shape[2]
+            bm = create_block_mask(
+                causal_mask,
+                B=bs,
+                H=q.shape[1],
+                Q_LEN=sl,
+                KV_LEN=sl,
+                device=q.device,
+            )
+            return flex_attention(q, k, v, block_mask=bm)
+
+        q = torch.randn(
+            2, n_heads, 128, d_model // n_heads, device=GPU_TYPE, dtype=torch.float32
+        )
+        k = torch.randn_like(q)
+        v = torch.randn_like(q)
+
+        ref = fn(q, k, v)
+        compiled_fn = torch.compile(fn)
+        out = compiled_fn(q, k, v)
+        self.assertEqual(out, ref, atol=1e-3, rtol=1e-3)
+
+
 class TorchFunctionModeLifecycleTests(torch._dynamo.test_case.TestCase):
     def test_default_device_restored_after_mode_tests(self):
         case = TorchFunctionModeTests("test_stack_state_mutation_default_device")

--- a/test/dynamo/test_modes.py
+++ b/test/dynamo/test_modes.py
@@ -2045,7 +2045,6 @@ class outer_fn(torch.nn.Module):
     def test_blockmask_tensor_closure_nested_compile_aot_export(self):
         """2-tier AOT export with BlockMask whose mask_mod captures tensors.
 
-        Matches sixlib architecture:
         - Outer: aot_export_joint_with_descriptors (non-strict FX trace)
         - Inner: torch.compile via regional_inductor annotation
         - create_block_mask with tensor closure in its own compiled region,

--- a/test/dynamo/test_modes.py
+++ b/test/dynamo/test_modes.py
@@ -1935,6 +1935,229 @@ class outer_fn(torch.nn.Module):
 
         dist.destroy_process_group()
 
+    @unittest.skipUnless(
+        IS_FLEX_ATTENTION_CUDA_PLATFORM_SUPPORTED and not torch.version.hip,
+        "Requires CUDA with SM >= 8.0, Triton, and not ROCm",
+    )
+    def test_create_block_mask_hop_dynamo(self):
+        """2-tier trace: outer aot_export + inner Dynamo on create_block_mask.
+
+        Simple causal mask_mod with no tensor closure.
+        create_block_mask is inside regional_inductor, so Dynamo traces it
+        as a HOP with the mask_mod subgraph.
+        """
+        import contextlib
+
+        import torch.fx.traceback as fx_traceback
+        from torch._functorch.aot_autograd import aot_export_joint_with_descriptors
+        from torch._subclasses import FakeTensorMode
+        from torch.nn.attention.flex_attention import create_block_mask, flex_attention
+
+        d_model, n_heads = 64, 4
+        batch_size, seq_len = 2, 32
+
+        def causal_mask(b, h, q_idx, kv_idx):
+            return q_idx >= kv_idx
+
+        class SimpleModel(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.q_proj = torch.nn.Linear(d_model, d_model)
+                self.k_proj = torch.nn.Linear(d_model, d_model)
+                self.v_proj = torch.nn.Linear(d_model, d_model)
+
+            def forward(self, x):
+                bs, sl, _ = x.shape
+
+                # Region 1: create block_mask once at the start
+                with fx_traceback.annotate({"compile_with_inductor": 1}):
+                    bm = create_block_mask(
+                        causal_mask,
+                        B=bs,
+                        H=None,
+                        Q_LEN=sl,
+                        KV_LEN=sl,
+                        device=x.device,
+                    )
+
+                q = (
+                    self.q_proj(x)
+                    .view(bs, sl, n_heads, d_model // n_heads)
+                    .transpose(1, 2)
+                )
+                k = (
+                    self.k_proj(x)
+                    .view(bs, sl, n_heads, d_model // n_heads)
+                    .transpose(1, 2)
+                )
+                v = (
+                    self.v_proj(x)
+                    .view(bs, sl, n_heads, d_model // n_heads)
+                    .transpose(1, 2)
+                )
+
+                # Region 2: reuse block_mask in attention
+                with fx_traceback.annotate({"compile_with_inductor": 1}):
+                    attn_out = flex_attention(q, k, v, block_mask=bm)
+
+                return attn_out.transpose(1, 2).contiguous().view(bs, sl, -1)
+
+        with (
+            torch._dynamo.config.patch(force_compile_during_fx_trace=True),
+            torch._inductor.config.patch(wrap_inductor_compiled_regions=True),
+            torch._functorch.config.patch(force_non_lazy_backward_lowering=True),
+        ):
+            torch._dynamo.reset()
+
+            model = SimpleModel().to(GPU_TYPE)
+            x = torch.randn(
+                batch_size,
+                seq_len,
+                d_model,
+                device=GPU_TYPE,
+                dtype=torch.float32,
+                requires_grad=True,
+            )
+
+            fake_mode = FakeTensorMode(allow_non_fake_inputs=True)
+            with contextlib.ExitStack() as stack:
+                stack.enter_context(fake_mode)
+                result = aot_export_joint_with_descriptors(
+                    stack,
+                    model,
+                    args=(x,),
+                    kwargs={},
+                    keep_inference_input_mutations=True,
+                    _disable_torch_fn_metadata_mode=True,
+                )
+
+            print("=== Outer (aot_export) graph ===")
+            print(result.graph_module.graph)
+            for name, submod in result.graph_module.named_modules():
+                if name and hasattr(submod, "graph"):
+                    print(f"\n=== Submodule: {name} ===")
+                    print(submod.graph)
+
+    @unittest.skipUnless(
+        IS_FLEX_ATTENTION_CUDA_PLATFORM_SUPPORTED and not torch.version.hip,
+        "Requires CUDA with SM >= 8.0, Triton, and not ROCm",
+    )
+    def test_blockmask_tensor_closure_nested_compile_aot_export(self):
+        """2-tier AOT export with BlockMask whose mask_mod captures tensors.
+
+        Matches sixlib architecture:
+        - Outer: aot_export_joint_with_descriptors (non-strict FX trace)
+        - Inner: torch.compile via regional_inductor annotation
+        - create_block_mask with tensor closure in its own compiled region,
+          block mask reused by flex_attention in a second compiled region.
+
+        visibility is a model input → FunctionalTensor during outer trace.
+        mask_mod closure captures derived slices (lower, upper).
+        """
+        import contextlib
+
+        import torch.fx.traceback as fx_traceback
+        from torch._functorch.aot_autograd import aot_export_joint_with_descriptors
+        from torch._subclasses import FakeTensorMode
+        from torch.nn.attention.flex_attention import create_block_mask, flex_attention
+
+        d_model, n_heads = 64, 4
+        batch_size, seq_len = 2, 32
+
+        class SimpleModel(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.q_proj = torch.nn.Linear(d_model, d_model)
+                self.k_proj = torch.nn.Linear(d_model, d_model)
+                self.v_proj = torch.nn.Linear(d_model, d_model)
+
+            def forward(self, x, visibility):
+                bs, sl, _ = x.shape
+                lower = visibility[:, 0, :]
+                upper = visibility[:, 1, :]
+
+                def mask_mod(b_idx, h_idx, q_idx, k_idx):
+                    return (lower[b_idx, q_idx] <= k_idx) & (
+                        k_idx <= upper[b_idx, q_idx]
+                    )
+
+                # Region 1: create block_mask once
+                with fx_traceback.annotate({"compile_with_inductor": 1}):
+                    bm = create_block_mask(
+                        mask_mod,
+                        B=bs,
+                        H=None,
+                        Q_LEN=sl,
+                        KV_LEN=sl,
+                        device=x.device,
+                    )
+
+                q = (
+                    self.q_proj(x)
+                    .view(bs, sl, n_heads, d_model // n_heads)
+                    .transpose(1, 2)
+                )
+                k = (
+                    self.k_proj(x)
+                    .view(bs, sl, n_heads, d_model // n_heads)
+                    .transpose(1, 2)
+                )
+                v = (
+                    self.v_proj(x)
+                    .view(bs, sl, n_heads, d_model // n_heads)
+                    .transpose(1, 2)
+                )
+
+                # Region 2: reuse block_mask in attention
+                with fx_traceback.annotate({"compile_with_inductor": 1}):
+                    attn_out = flex_attention(q, k, v, block_mask=bm)
+
+                return attn_out.transpose(1, 2).contiguous().view(bs, sl, -1)
+
+        with (
+            torch._dynamo.config.patch(force_compile_during_fx_trace=True),
+            torch._inductor.config.patch(wrap_inductor_compiled_regions=True),
+            torch._functorch.config.patch(force_non_lazy_backward_lowering=True),
+        ):
+            torch._dynamo.reset()
+
+            model = SimpleModel().to(GPU_TYPE)
+            x = torch.randn(
+                batch_size,
+                seq_len,
+                d_model,
+                device=GPU_TYPE,
+                dtype=torch.float32,
+                requires_grad=True,
+            )
+            visibility = torch.zeros(
+                batch_size,
+                2,
+                seq_len,
+                device=GPU_TYPE,
+                dtype=torch.int64,
+            )
+            visibility[:, 1, :] = seq_len - 1
+
+            fake_mode = FakeTensorMode(allow_non_fake_inputs=True)
+            with contextlib.ExitStack() as stack:
+                stack.enter_context(fake_mode)
+                result = aot_export_joint_with_descriptors(
+                    stack,
+                    model,
+                    args=(x, visibility),
+                    kwargs={},
+                    keep_inference_input_mutations=True,
+                    _disable_torch_fn_metadata_mode=True,
+                )
+
+            print("=== Outer (aot_export) graph ===")
+            print(result.graph_module.graph)
+            for name, submod in result.graph_module.named_modules():
+                if name and hasattr(submod, "graph"):
+                    print(f"\n=== Submodule: {name} ===")
+                    print(submod.graph)
+
 
 class TorchFunctionModeLifecycleTests(torch._dynamo.test_case.TestCase):
     def test_default_device_restored_after_mode_tests(self):

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -4132,18 +4132,9 @@ class FlexAttentionHigherOrderVariable(TorchHigherOrderOperatorVariable):
             fn_name,
             torch.fx.GraphModule(tx.output.nn_modules, body_graph),
         )
-
         body_node = make_attr(tx, body_name)
-
-        # It is possible that the score-mod function captures some free variables that are not
-        # passed in as arguments. In this case, we need to lift them, which is handled by speculate_subgraph.
-        # We then need to create proxies for this + the inputs.
-
         lifted_args = tuple(arg for arg in body_lifted_freevars)
-
-        proxy_args = (body_node, lifted_args)
-
-        return proxy_args
+        return body_node, lifted_args
 
     def _call_function(
         self,
@@ -4211,6 +4202,100 @@ class FlexAttentionHigherOrderVariable(TorchHigherOrderOperatorVariable):
                         inp_arg_kernel_options,
                         score_mod_lifted_args,
                         mask_fn_lifted_args,
+                    ),
+                    kwargs={},
+                ),
+                example_value=None,
+            )
+        return proxy
+
+
+class CreateBlockMaskHigherOrderVariable(TorchHigherOrderOperatorVariable):
+    _HOP_NAME = "torch.ops.higher_order.create_block_mask"
+
+    def create_wrapped_node(
+        self,
+        tx: "InstructionTranslator",
+        fn: VariableTracker,
+        device_var: VariableTracker,
+    ) -> tuple[Proxy, tuple[Proxy, ...]]:
+        from .._trace_wrapped_higher_order_op import TransformGetItemToIndex
+        from .torch import TorchInGraphFunctionVariable
+
+        zeros_var = TorchInGraphFunctionVariable(torch.zeros)
+
+        def create_scalar() -> VariableTracker:
+            return zeros_var.call_function(
+                tx,
+                [VariableTracker.build(tx, [])],
+                {
+                    "dtype": VariableTracker.build(tx, torch.int32),
+                    "device": VariableTracker.build(tx, "cpu"),
+                },
+            )
+
+        with discard_graph_changes(tx):
+            bhmn = [create_scalar() for _ in range(4)]
+            new_args = [*bhmn]
+
+        with TransformGetItemToIndex():
+            (
+                (_body_output, _body_spec),
+                body_graph,
+                body_lifted_freevars,
+            ) = speculate_subgraph(
+                tx,
+                fn,
+                new_args,
+                {},
+                description=f"{self._HOP_NAME}: mask_mod",
+                source_target=self.value,
+                set_subgraph_inputs="flatten_manual",
+            )
+
+        body_name = tx.output.install_subgraph(
+            "create_block_mask_mask",
+            torch.fx.GraphModule(tx.output.nn_modules, body_graph),
+        )
+        body_node = make_attr(tx, body_name)
+        lifted_args = tuple(arg for arg in body_lifted_freevars)
+        return body_node, lifted_args
+
+    def _call_function(
+        self,
+        tx: "InstructionTranslator",
+        args: Sequence[VariableTracker],
+        kwargs: dict[str, VariableTracker],
+    ) -> VariableTracker:
+        from .builder import wrap_fx_proxy
+
+        # Signature: mask_mod, B, H, Q_LEN, KV_LEN, device, BLOCK_SIZE,
+        #            mask_mod_other_buffers
+        mask_mod = args[0]
+        B = args[1]
+        H = args[2]
+        Q_LEN = args[3]
+        KV_LEN = args[4]
+        device = args[5] if len(args) > 5 else VariableTracker.build(tx, "cpu")
+        BLOCK_SIZE = args[6] if len(args) > 6 else VariableTracker.build(tx, (128, 128))
+
+        mask_mod_node, mask_mod_lifted_args = self.create_wrapped_node(
+            tx, mask_mod, device,
+        )
+
+        proxied_args = [B, H, Q_LEN, KV_LEN, device, BLOCK_SIZE]
+        inp_args, _ = proxy_args_kwargs(proxied_args, {})
+
+        with torch.fx.experimental.proxy_tensor.set_original_aten_op(self.value):
+            proxy = wrap_fx_proxy(
+                tx=tx,
+                proxy=tx.output.create_proxy(
+                    "call_function",
+                    self.value,
+                    args=(
+                        mask_mod_node,
+                        *inp_args,
+                        mask_mod_lifted_args,
                     ),
                     kwargs={},
                 ),
@@ -5525,6 +5610,7 @@ _hop_name_to_variable_class = {
     "hints_wrapper": HintsWrapperHigherOrderVariable,
     "flex_attention": FlexAttentionHigherOrderVariable,
     "flex_attention_backward": FlexAttentionBackwardHighOrderVariable,
+    "create_block_mask": CreateBlockMaskHigherOrderVariable,
     "wrap_activation_checkpoint": CheckpointHigherOrderVariable,
     "tag_activation_checkpoint": CheckpointHigherOrderVariable,
     "_export_tracepoint": ExportTracepointHigherOrderVariable,

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -4132,9 +4132,18 @@ class FlexAttentionHigherOrderVariable(TorchHigherOrderOperatorVariable):
             fn_name,
             torch.fx.GraphModule(tx.output.nn_modules, body_graph),
         )
+
         body_node = make_attr(tx, body_name)
+
+        # It is possible that the score-mod function captures some free variables that are not
+        # passed in as arguments. In this case, we need to lift them, which is handled by speculate_subgraph.
+        # We then need to create proxies for this + the inputs.
+
         lifted_args = tuple(arg for arg in body_lifted_freevars)
-        return body_node, lifted_args
+
+        proxy_args = (body_node, lifted_args)
+
+        return proxy_args
 
     def _call_function(
         self,
@@ -4254,7 +4263,7 @@ class CreateBlockMaskHigherOrderVariable(TorchHigherOrderOperatorVariable):
             )
 
         body_name = tx.output.install_subgraph(
-            "create_block_mask_mask",
+            "flex_create_block_mask",
             torch.fx.GraphModule(tx.output.nn_modules, body_graph),
         )
         body_node = make_attr(tx, body_name)
@@ -4270,7 +4279,7 @@ class CreateBlockMaskHigherOrderVariable(TorchHigherOrderOperatorVariable):
         from .builder import wrap_fx_proxy
 
         # Signature: mask_mod, B, H, Q_LEN, KV_LEN, device, BLOCK_SIZE,
-        #            mask_mod_other_buffers
+        #            mask_mod_closure_tensors
         mask_mod = args[0]
         B = args[1]
         H = args[2]

--- a/torch/_higher_order_ops/flex_attention.py
+++ b/torch/_higher_order_ops/flex_attention.py
@@ -1539,6 +1539,13 @@ class CreateBlockMaskHOP(HigherOrderOperator):
         BLOCK_SIZE: tuple[int, int] = (128, 128),
         mask_mod_other_buffers: tuple = (),
     ) -> tuple:
+        # Extract closure tensors so they flow through the dispatch stack as
+        # explicit positional args (functionalize/fake/proxy properly unwrap them).
+        # Under Dynamo, speculate_subgraph handles lifting instead.
+        if not mask_mod_other_buffers:
+            mask_mod, mask_mod_other_buffers = _extract_tensor_closure_vars(
+                mask_mod
+            )
         validate_subgraph_args_types(mask_mod_other_buffers)
         return super().__call__(
             mask_mod,
@@ -1570,21 +1577,32 @@ def _create_block_mask_tensors(
     from torch.nn.attention.flex_attention import (
         _convert_mask_to_block_mask,
         _create_sparse_block_from_block_mask,
-        _vmap_for_bhqkv,
         BlockMask,
     )
 
-    # Compute mask tensor directly (avoid create_mask's _get_mod_type check
-    # which fails on functionalized callables).
-    b = torch.arange(0, B, device=device)
-    h = torch.arange(0, H, device=device)
-    m = torch.arange(0, Q_LEN, device=device)
-    n = torch.arange(0, KV_LEN, device=device)
+    if mask_mod_other_buffers:
+        _mask_mod = mask_mod
+        _bufs = mask_mod_other_buffers
 
-    mask_mod_in_dim_buffers = (None,) * len(mask_mod_other_buffers)
-    vmapped = _vmap_for_bhqkv(mask_mod, prefix=(), suffix=mask_mod_in_dim_buffers)
+        def effective_mask_mod(b, h, q_idx, kv_idx):
+            return _mask_mod(b, h, q_idx, kv_idx, *_bufs)
+    else:
+        effective_mask_mod = mask_mod
+
+    # Broadcast index tensors to [B, H, Q_LEN, KV_LEN] via stride-0 expand
+    # (no memory overhead). This avoids vmap which creates BatchedTensors
+    # incompatible with FakeTensorMode during AOTAutograd proxy tracing.
+    b_idx = torch.arange(B, device=device).view(B, 1, 1, 1).expand(B, H, Q_LEN, KV_LEN)
+    h_idx = torch.arange(H, device=device).view(1, H, 1, 1).expand(B, H, Q_LEN, KV_LEN)
+    q_idx = torch.arange(Q_LEN, device=device).view(1, 1, Q_LEN, 1).expand(B, H, Q_LEN, KV_LEN)
+    kv_idx = (
+        torch.arange(KV_LEN, device=device)
+        .view(1, 1, 1, KV_LEN)
+        .expand(B, H, Q_LEN, KV_LEN)
+    )
+
     with TransformGetItemToIndex():
-        mask_tensor = vmapped(b, h, m, n, *mask_mod_other_buffers)
+        mask_tensor = effective_mask_mod(b_idx, h_idx, q_idx, kv_idx)
 
     Q_BLOCK_SIZE, KV_BLOCK_SIZE = BLOCK_SIZE
     partial_block_mask, full_block_mask = _convert_mask_to_block_mask(
@@ -1593,18 +1611,6 @@ def _create_block_mask_tensors(
         KV_BLOCK_SIZE=KV_BLOCK_SIZE,
         separate_full_blocks=True,
     )
-
-    # Build a 4-arg mask_mod for _create_sparse_block_from_block_mask
-    if mask_mod_other_buffers:
-        original_mask_mod = mask_mod
-
-        def bound_mask_mod(b, h, q_idx, kv_idx):
-            return original_mask_mod(b, h, q_idx, kv_idx, *mask_mod_other_buffers)
-
-        effective_mask_mod = bound_mask_mod
-    else:
-        effective_mask_mod = mask_mod
-
     bm = _create_sparse_block_from_block_mask(
         (partial_block_mask, full_block_mask),
         effective_mask_mod,
@@ -1663,7 +1669,8 @@ def trace_create_block_mask(
     from torch._dynamo._trace_wrapped_higher_order_op import TransformGetItemToIndex
 
     example_out = create_block_mask_hop(
-        mask_mod, B, H, Q_LEN, KV_LEN, device, BLOCK_SIZE, mask_mod_other_buffers
+        mask_mod, B, H, Q_LEN, KV_LEN, device, BLOCK_SIZE,
+        mask_mod_other_buffers,
     )
 
     # Trace mask_mod with scalar example values (b, h, q_idx, kv_idx)

--- a/torch/_higher_order_ops/flex_attention.py
+++ b/torch/_higher_order_ops/flex_attention.py
@@ -1449,3 +1449,350 @@ def flex_attention_backward_fake_tensor_mode(
 flex_attention_backward.py_autograd_impl(
     autograd_not_implemented(flex_attention_backward, deferred_error=True)
 )
+
+
+# ---------------------------- CreateBlockMask HOP ----------------------------
+
+
+def _extract_tensor_closure_vars(fn: Callable) -> tuple[Callable, tuple]:
+    """Extract tensor free variables from fn's closure.
+
+    Returns (new_fn, tensors) where new_fn accepts the original positional
+    args followed by the extracted tensors, and tensors is the tuple of
+    extracted tensor values.
+
+    During make_fx tracing the extra args become graph-input placeholders
+    instead of being baked into the subgraph as constants.
+    """
+    import types
+
+    closure = getattr(fn, "__closure__", None)
+    if closure is None:
+        return fn, ()
+
+    freevars = fn.__code__.co_freevars
+    tensor_indices: list[int] = []
+    tensors: list[Tensor] = []
+
+    for i, cell in enumerate(closure):
+        try:
+            val = cell.cell_contents
+        except ValueError:
+            continue
+        if isinstance(val, torch.Tensor):
+            tensor_indices.append(i)
+            tensors.append(val)
+
+    if not tensors:
+        return fn, ()
+
+    _fn = fn
+    _indices = tensor_indices
+    _n_orig = fn.__code__.co_argcount
+
+    def _make_cell(val: object) -> object:
+        x = val
+        def _inner():
+            return x
+        return _inner.__closure__[0]  # type: ignore[index]
+
+    def modified_fn(*args):
+        orig_args = args[:_n_orig]
+        extra_tensors = args[_n_orig:]
+        new_closure = list(_fn.__closure__)  # type: ignore[arg-type]
+        for idx, t in zip(_indices, extra_tensors):
+            new_closure[idx] = _make_cell(t)
+        rebuilt = types.FunctionType(
+            _fn.__code__,
+            _fn.__globals__,
+            _fn.__name__,
+            _fn.__defaults__,
+            tuple(new_closure),
+        )
+        return rebuilt(*orig_args)
+
+    return modified_fn, tuple(tensors)
+
+
+class CreateBlockMaskHOP(HigherOrderOperator):
+    """HOP for create_block_mask that traces mask_mod and lifts its closure tensors.
+
+    Returns a tuple of 8 tensors (the BlockMask tensor attributes):
+      (kv_num_blocks, kv_indices, full_kv_num_blocks, full_kv_indices,
+       q_num_blocks, q_indices, full_q_num_blocks, full_q_indices)
+
+    The caller reconstructs the BlockMask from these tensors plus the known
+    constants (seq_lengths, BLOCK_SIZE) and the mask_mod subgraph.
+    """
+
+    def __init__(self) -> None:
+        super().__init__("create_block_mask", cacheable=True)
+
+    def __call__(
+        self,
+        mask_mod: Callable,
+        B: int,
+        H: int,
+        Q_LEN: int,
+        KV_LEN: int,
+        device: str = "cpu",
+        BLOCK_SIZE: tuple[int, int] = (128, 128),
+        mask_mod_other_buffers: tuple = (),
+    ) -> tuple:
+        validate_subgraph_args_types(mask_mod_other_buffers)
+        return super().__call__(
+            mask_mod,
+            B,
+            H,
+            Q_LEN,
+            KV_LEN,
+            device,
+            BLOCK_SIZE,
+            mask_mod_other_buffers,
+        )
+
+
+create_block_mask_hop = CreateBlockMaskHOP()
+
+
+def _create_block_mask_tensors(
+    mask_mod: Callable,
+    B: int,
+    H: int,
+    Q_LEN: int,
+    KV_LEN: int,
+    device: str = "cpu",
+    BLOCK_SIZE: tuple[int, int] = (128, 128),
+    mask_mod_other_buffers: tuple = (),
+) -> tuple:
+    """Compute create_block_mask and return the 8 BlockMask tensor attrs as a tuple."""
+    from torch._dynamo._trace_wrapped_higher_order_op import TransformGetItemToIndex
+    from torch.nn.attention.flex_attention import (
+        _convert_mask_to_block_mask,
+        _create_sparse_block_from_block_mask,
+        _vmap_for_bhqkv,
+        BlockMask,
+    )
+
+    # Compute mask tensor directly (avoid create_mask's _get_mod_type check
+    # which fails on functionalized callables).
+    b = torch.arange(0, B, device=device)
+    h = torch.arange(0, H, device=device)
+    m = torch.arange(0, Q_LEN, device=device)
+    n = torch.arange(0, KV_LEN, device=device)
+
+    mask_mod_in_dim_buffers = (None,) * len(mask_mod_other_buffers)
+    vmapped = _vmap_for_bhqkv(mask_mod, prefix=(), suffix=mask_mod_in_dim_buffers)
+    with TransformGetItemToIndex():
+        mask_tensor = vmapped(b, h, m, n, *mask_mod_other_buffers)
+
+    Q_BLOCK_SIZE, KV_BLOCK_SIZE = BLOCK_SIZE
+    partial_block_mask, full_block_mask = _convert_mask_to_block_mask(
+        mask_tensor,
+        Q_BLOCK_SIZE=Q_BLOCK_SIZE,
+        KV_BLOCK_SIZE=KV_BLOCK_SIZE,
+        separate_full_blocks=True,
+    )
+
+    # Build a 4-arg mask_mod for _create_sparse_block_from_block_mask
+    if mask_mod_other_buffers:
+        original_mask_mod = mask_mod
+
+        def bound_mask_mod(b, h, q_idx, kv_idx):
+            return original_mask_mod(b, h, q_idx, kv_idx, *mask_mod_other_buffers)
+
+        effective_mask_mod = bound_mask_mod
+    else:
+        effective_mask_mod = mask_mod
+
+    bm = _create_sparse_block_from_block_mask(
+        (partial_block_mask, full_block_mask),
+        effective_mask_mod,
+        (Q_LEN, KV_LEN),
+        Q_BLOCK_SIZE,
+        KV_BLOCK_SIZE,
+    )
+    return tuple(getattr(bm, attr) for attr in BlockMask._TENSOR_ATTRS)
+
+
+@create_block_mask_hop.py_impl(DispatchKey.CompositeExplicitAutograd)
+def create_block_mask_dense(
+    mask_mod: Callable,
+    B: int,
+    H: int,
+    Q_LEN: int,
+    KV_LEN: int,
+    device: str = "cpu",
+    BLOCK_SIZE: tuple[int, int] = (128, 128),
+    mask_mod_other_buffers: tuple = (),
+) -> tuple:
+    return _create_block_mask_tensors(
+        mask_mod, B, H, Q_LEN, KV_LEN, device, BLOCK_SIZE, mask_mod_other_buffers
+    )
+
+
+@create_block_mask_hop.py_impl(ProxyTorchDispatchMode)
+def create_block_mask_proxy_torch_dispatch_mode(
+    mode: ProxyTorchDispatchMode,
+    mask_mod: Callable,
+    B: int,
+    H: int,
+    Q_LEN: int,
+    KV_LEN: int,
+    device: str = "cpu",
+    BLOCK_SIZE: tuple[int, int] = (128, 128),
+    mask_mod_other_buffers: tuple = (),
+):
+    return trace_create_block_mask(
+        mode, mask_mod, B, H, Q_LEN, KV_LEN, device, BLOCK_SIZE,
+        mask_mod_other_buffers,
+    )
+
+
+def trace_create_block_mask(
+    proxy_mode: ProxyTorchDispatchMode,
+    mask_mod: Callable,
+    B: int,
+    H: int,
+    Q_LEN: int,
+    KV_LEN: int,
+    device: str = "cpu",
+    BLOCK_SIZE: tuple[int, int] = (128, 128),
+    mask_mod_other_buffers: tuple = (),
+):
+    from torch._dynamo._trace_wrapped_higher_order_op import TransformGetItemToIndex
+
+    example_out = create_block_mask_hop(
+        mask_mod, B, H, Q_LEN, KV_LEN, device, BLOCK_SIZE, mask_mod_other_buffers
+    )
+
+    # Trace mask_mod with scalar example values (b, h, q_idx, kv_idx)
+    any_tensor = None
+    for buf in mask_mod_other_buffers:
+        if isinstance(buf, torch.Tensor):
+            any_tensor = buf
+            break
+
+    if any_tensor is not None:
+        example_vals = [
+            any_tensor.new_zeros((), dtype=torch.int) for _ in range(4)
+        ]
+    else:
+        example_vals = [
+            torch.zeros((), dtype=torch.int, device=device) for _ in range(4)
+        ]
+
+    with TransformGetItemToIndex():
+        mask_graph = reenter_make_fx(mask_mod)(
+            *example_vals, *mask_mod_other_buffers
+        )
+
+    if not isinstance(proxy_mode.tracer, torch.fx.Tracer):
+        raise AssertionError(
+            f"expected proxy_mode.tracer to be torch.fx.Tracer, "
+            f"got {type(proxy_mode.tracer)}"
+        )
+
+    qualname = proxy_mode.tracer.get_fresh_qualname("create_block_mask_mask")
+    proxy_mode.tracer.root.register_module(qualname, mask_graph)
+
+    node_args = (
+        mask_graph,
+        B, H, Q_LEN, KV_LEN,
+        device, BLOCK_SIZE,
+        mask_mod_other_buffers,
+    )
+    proxy_args = pytree.tree_map(proxy_mode.tracer.unwrap_proxy, node_args)
+    with torch.fx.experimental.proxy_tensor.set_original_aten_op(
+        create_block_mask_hop
+    ):
+        out_proxy = proxy_mode.tracer.create_proxy(
+            "call_function", create_block_mask_hop, proxy_args, {}
+        )
+    return track_tensor_tree(
+        example_out, out_proxy, constant=None, tracer=proxy_mode.tracer,
+    )
+
+
+@register_fake(create_block_mask_hop)
+def create_block_mask_fake_impl(
+    mask_mod: Callable,
+    B: int,
+    H: int,
+    Q_LEN: int,
+    KV_LEN: int,
+    device: str = "cpu",
+    BLOCK_SIZE: tuple[int, int] = (128, 128),
+    mask_mod_other_buffers: tuple = (),
+) -> tuple:
+    from torch.nn.attention.flex_attention import _round_up_to_multiple
+
+    Q_BLOCK_SIZE, KV_BLOCK_SIZE = BLOCK_SIZE
+    num_q_blocks = _round_up_to_multiple(Q_LEN, Q_BLOCK_SIZE) // Q_BLOCK_SIZE
+    num_kv_blocks = _round_up_to_multiple(KV_LEN, KV_BLOCK_SIZE) // KV_BLOCK_SIZE
+
+    # Shape: [B, H, num_q_blocks] for num_blocks, [B, H, num_q_blocks, num_kv_blocks] for indices
+    kv_num_blocks = torch.empty(B, H, num_q_blocks, dtype=torch.int32, device=device)
+    kv_indices = torch.empty(
+        B, H, num_q_blocks, num_kv_blocks, dtype=torch.int32, device=device
+    )
+    full_kv_num_blocks = torch.empty(
+        B, H, num_q_blocks, dtype=torch.int32, device=device
+    )
+    full_kv_indices = torch.empty(
+        B, H, num_q_blocks, num_kv_blocks, dtype=torch.int32, device=device
+    )
+    q_num_blocks = torch.empty(B, H, num_kv_blocks, dtype=torch.int32, device=device)
+    q_indices = torch.empty(
+        B, H, num_kv_blocks, num_q_blocks, dtype=torch.int32, device=device
+    )
+    full_q_num_blocks = torch.empty(
+        B, H, num_kv_blocks, dtype=torch.int32, device=device
+    )
+    full_q_indices = torch.empty(
+        B, H, num_kv_blocks, num_q_blocks, dtype=torch.int32, device=device
+    )
+    return (
+        kv_num_blocks,
+        kv_indices,
+        full_kv_num_blocks,
+        full_kv_indices,
+        q_num_blocks,
+        q_indices,
+        full_q_num_blocks,
+        full_q_indices,
+    )
+
+
+@create_block_mask_hop.py_functionalize_impl
+def create_block_mask_functionalize(
+    ctx: torch._subclasses.functional_tensor.BaseFunctionalizeAPI,
+    mask_mod: Callable,
+    B: int,
+    H: int,
+    Q_LEN: int,
+    KV_LEN: int,
+    device: str = "cpu",
+    BLOCK_SIZE: tuple[int, int] = (128, 128),
+    mask_mod_other_buffers: tuple = (),
+):
+    mask_mod_other_buffers_unwrapped = ctx.unwrap_tensors(mask_mod_other_buffers)
+    if not isinstance(mask_mod_other_buffers_unwrapped, tuple):
+        raise AssertionError(
+            f"expected mask_mod_other_buffers_unwrapped to be tuple, "
+            f"got {type(mask_mod_other_buffers_unwrapped)}"
+        )
+    with ctx.redispatch_to_next():
+        functional_mask_mod = ctx.functionalize(mask_mod)
+        out = create_block_mask_hop(
+            functional_mask_mod,
+            B, H, Q_LEN, KV_LEN,
+            device, BLOCK_SIZE,
+            mask_mod_other_buffers_unwrapped,
+        )
+    return ctx.wrap_tensors(out)
+
+
+create_block_mask_hop.py_autograd_impl(
+    autograd_not_implemented(create_block_mask_hop, deferred_error=True)
+)

--- a/torch/_higher_order_ops/flex_attention.py
+++ b/torch/_higher_order_ops/flex_attention.py
@@ -1537,16 +1537,16 @@ class CreateBlockMaskHOP(HigherOrderOperator):
         KV_LEN: int,
         device: str = "cpu",
         BLOCK_SIZE: tuple[int, int] = (128, 128),
-        mask_mod_other_buffers: tuple = (),
+        mask_mod_closure_tensors: tuple = (),
     ) -> tuple:
         # Extract closure tensors so they flow through the dispatch stack as
         # explicit positional args (functionalize/fake/proxy properly unwrap them).
         # Under Dynamo, speculate_subgraph handles lifting instead.
-        if not mask_mod_other_buffers:
-            mask_mod, mask_mod_other_buffers = _extract_tensor_closure_vars(
+        if not mask_mod_closure_tensors:
+            mask_mod, mask_mod_closure_tensors = _extract_tensor_closure_vars(
                 mask_mod
             )
-        validate_subgraph_args_types(mask_mod_other_buffers)
+        validate_subgraph_args_types(mask_mod_closure_tensors)
         return super().__call__(
             mask_mod,
             B,
@@ -1555,7 +1555,7 @@ class CreateBlockMaskHOP(HigherOrderOperator):
             KV_LEN,
             device,
             BLOCK_SIZE,
-            mask_mod_other_buffers,
+            mask_mod_closure_tensors,
         )
 
 
@@ -1570,7 +1570,7 @@ def _create_block_mask_tensors(
     KV_LEN: int,
     device: str = "cpu",
     BLOCK_SIZE: tuple[int, int] = (128, 128),
-    mask_mod_other_buffers: tuple = (),
+    mask_mod_closure_tensors: tuple = (),
 ) -> tuple:
     """Compute create_block_mask and return the 8 BlockMask tensor attrs as a tuple."""
     from torch._dynamo._trace_wrapped_higher_order_op import TransformGetItemToIndex
@@ -1580,14 +1580,15 @@ def _create_block_mask_tensors(
         BlockMask,
     )
 
-    if mask_mod_other_buffers:
-        _mask_mod = mask_mod
-        _bufs = mask_mod_other_buffers
+    # Rebind lifted closure tensors to produce the standard 4-arg mask_mod.
+    if mask_mod_closure_tensors:
+        _fn = mask_mod
+        _ct = mask_mod_closure_tensors
 
-        def effective_mask_mod(b, h, q_idx, kv_idx):
-            return _mask_mod(b, h, q_idx, kv_idx, *_bufs)
+        def mod(b, h, q_idx, kv_idx):
+            return _fn(b, h, q_idx, kv_idx, *_ct)
     else:
-        effective_mask_mod = mask_mod
+        mod = mask_mod
 
     # Broadcast index tensors to [B, H, Q_LEN, KV_LEN] via stride-0 expand
     # (no memory overhead). This avoids vmap which creates BatchedTensors
@@ -1602,7 +1603,7 @@ def _create_block_mask_tensors(
     )
 
     with TransformGetItemToIndex():
-        mask_tensor = effective_mask_mod(b_idx, h_idx, q_idx, kv_idx)
+        mask_tensor = mod(b_idx, h_idx, q_idx, kv_idx)
 
     Q_BLOCK_SIZE, KV_BLOCK_SIZE = BLOCK_SIZE
     partial_block_mask, full_block_mask = _convert_mask_to_block_mask(
@@ -1613,7 +1614,7 @@ def _create_block_mask_tensors(
     )
     bm = _create_sparse_block_from_block_mask(
         (partial_block_mask, full_block_mask),
-        effective_mask_mod,
+        mod,
         (Q_LEN, KV_LEN),
         Q_BLOCK_SIZE,
         KV_BLOCK_SIZE,
@@ -1630,10 +1631,10 @@ def create_block_mask_dense(
     KV_LEN: int,
     device: str = "cpu",
     BLOCK_SIZE: tuple[int, int] = (128, 128),
-    mask_mod_other_buffers: tuple = (),
+    mask_mod_closure_tensors: tuple = (),
 ) -> tuple:
     return _create_block_mask_tensors(
-        mask_mod, B, H, Q_LEN, KV_LEN, device, BLOCK_SIZE, mask_mod_other_buffers
+        mask_mod, B, H, Q_LEN, KV_LEN, device, BLOCK_SIZE, mask_mod_closure_tensors
     )
 
 
@@ -1647,11 +1648,11 @@ def create_block_mask_proxy_torch_dispatch_mode(
     KV_LEN: int,
     device: str = "cpu",
     BLOCK_SIZE: tuple[int, int] = (128, 128),
-    mask_mod_other_buffers: tuple = (),
+    mask_mod_closure_tensors: tuple = (),
 ):
     return trace_create_block_mask(
         mode, mask_mod, B, H, Q_LEN, KV_LEN, device, BLOCK_SIZE,
-        mask_mod_other_buffers,
+        mask_mod_closure_tensors,
     )
 
 
@@ -1664,18 +1665,18 @@ def trace_create_block_mask(
     KV_LEN: int,
     device: str = "cpu",
     BLOCK_SIZE: tuple[int, int] = (128, 128),
-    mask_mod_other_buffers: tuple = (),
+    mask_mod_closure_tensors: tuple = (),
 ):
     from torch._dynamo._trace_wrapped_higher_order_op import TransformGetItemToIndex
 
     example_out = create_block_mask_hop(
         mask_mod, B, H, Q_LEN, KV_LEN, device, BLOCK_SIZE,
-        mask_mod_other_buffers,
+        mask_mod_closure_tensors,
     )
 
     # Trace mask_mod with scalar example values (b, h, q_idx, kv_idx)
     any_tensor = None
-    for buf in mask_mod_other_buffers:
+    for buf in mask_mod_closure_tensors:
         if isinstance(buf, torch.Tensor):
             any_tensor = buf
             break
@@ -1691,7 +1692,7 @@ def trace_create_block_mask(
 
     with TransformGetItemToIndex():
         mask_graph = reenter_make_fx(mask_mod)(
-            *example_vals, *mask_mod_other_buffers
+            *example_vals, *mask_mod_closure_tensors
         )
 
     if not isinstance(proxy_mode.tracer, torch.fx.Tracer):
@@ -1700,14 +1701,14 @@ def trace_create_block_mask(
             f"got {type(proxy_mode.tracer)}"
         )
 
-    qualname = proxy_mode.tracer.get_fresh_qualname("create_block_mask_mask")
+    qualname = proxy_mode.tracer.get_fresh_qualname("flex_create_block_mask")
     proxy_mode.tracer.root.register_module(qualname, mask_graph)
 
     node_args = (
         mask_graph,
         B, H, Q_LEN, KV_LEN,
         device, BLOCK_SIZE,
-        mask_mod_other_buffers,
+        mask_mod_closure_tensors,
     )
     proxy_args = pytree.tree_map(proxy_mode.tracer.unwrap_proxy, node_args)
     with torch.fx.experimental.proxy_tensor.set_original_aten_op(
@@ -1730,7 +1731,7 @@ def create_block_mask_fake_impl(
     KV_LEN: int,
     device: str = "cpu",
     BLOCK_SIZE: tuple[int, int] = (128, 128),
-    mask_mod_other_buffers: tuple = (),
+    mask_mod_closure_tensors: tuple = (),
 ) -> tuple:
     from torch.nn.attention.flex_attention import _round_up_to_multiple
 
@@ -1781,13 +1782,13 @@ def create_block_mask_functionalize(
     KV_LEN: int,
     device: str = "cpu",
     BLOCK_SIZE: tuple[int, int] = (128, 128),
-    mask_mod_other_buffers: tuple = (),
+    mask_mod_closure_tensors: tuple = (),
 ):
-    mask_mod_other_buffers_unwrapped = ctx.unwrap_tensors(mask_mod_other_buffers)
-    if not isinstance(mask_mod_other_buffers_unwrapped, tuple):
+    unwrapped = ctx.unwrap_tensors(mask_mod_closure_tensors)
+    if not isinstance(unwrapped, tuple):
         raise AssertionError(
-            f"expected mask_mod_other_buffers_unwrapped to be tuple, "
-            f"got {type(mask_mod_other_buffers_unwrapped)}"
+            f"expected unwrapped mask_mod_closure_tensors to be tuple, "
+            f"got {type(unwrapped)}"
         )
     with ctx.redispatch_to_next():
         functional_mask_mod = ctx.functionalize(mask_mod)
@@ -1795,7 +1796,7 @@ def create_block_mask_functionalize(
             functional_mask_mod,
             B, H, Q_LEN, KV_LEN,
             device, BLOCK_SIZE,
-            mask_mod_other_buffers_unwrapped,
+            unwrapped,
         )
     return ctx.wrap_tensors(out)
 

--- a/torch/nn/attention/flex_attention.py
+++ b/torch/nn/attention/flex_attention.py
@@ -1275,25 +1275,25 @@ def create_block_mask(
         )
 
     # Under make_fx tracing, use the HOP so create_block_mask appears as a
-    # single node in the outer graph with mask_mod traced as a subgraph.
-    if not torch.compiler.is_dynamo_compiling():
-        from torch._higher_order_ops.flex_attention import (
-            _extract_tensor_closure_vars,
-            create_block_mask_hop,
-        )
+    # single node with mask_mod traced as a subgraph. Under Dynamo
+    # (torch.compile), the inline path is used instead because flex_attention
+    # already traces mask_mod as a subgraph, and the HOP's FakeTensor outputs
+    # conflict with flex_attention's nested torch.compile architecture.
+    # is_dynamo_compiling() check must come first to short-circuit before
+    # get_proxy_mode() which Dynamo can't trace through.
+    from torch.fx.experimental.proxy_tensor import get_proxy_mode
 
-        modified_mask_mod, mask_mod_other_buffers = _extract_tensor_closure_vars(
-            mask_mod
-        )
+    if not torch.compiler.is_dynamo_compiling() and get_proxy_mode() is not None:
+        from torch._higher_order_ops.flex_attention import create_block_mask_hop
+
         tensors = create_block_mask_hop(
-            modified_mask_mod,
+            mask_mod,
             B,
             H,
             Q_LEN,
             KV_LEN,
             str(device),
             (Q_BLOCK_SIZE, KV_BLOCK_SIZE),
-            mask_mod_other_buffers,
         )
         kwargs = dict(zip(BlockMask._TENSOR_ATTRS, tensors))
         return BlockMask(

--- a/torch/nn/attention/flex_attention.py
+++ b/torch/nn/attention/flex_attention.py
@@ -1274,6 +1274,35 @@ def create_block_mask(
             mask_mod, B, H, Q_LEN, KV_LEN, device, BLOCK_SIZE
         )
 
+    # Under make_fx tracing, use the HOP so create_block_mask appears as a
+    # single node in the outer graph with mask_mod traced as a subgraph.
+    if not torch.compiler.is_dynamo_compiling():
+        from torch._higher_order_ops.flex_attention import (
+            _extract_tensor_closure_vars,
+            create_block_mask_hop,
+        )
+
+        modified_mask_mod, mask_mod_other_buffers = _extract_tensor_closure_vars(
+            mask_mod
+        )
+        tensors = create_block_mask_hop(
+            modified_mask_mod,
+            B,
+            H,
+            Q_LEN,
+            KV_LEN,
+            str(device),
+            (Q_BLOCK_SIZE, KV_BLOCK_SIZE),
+            mask_mod_other_buffers,
+        )
+        kwargs = dict(zip(BlockMask._TENSOR_ATTRS, tensors))
+        return BlockMask(
+            seq_lengths=(Q_LEN, KV_LEN),
+            BLOCK_SIZE=(Q_BLOCK_SIZE, KV_BLOCK_SIZE),
+            mask_mod=mask_mod,
+            **kwargs,
+        )
+
     mask_tensor = create_mask(mask_mod, B, H, Q_LEN, KV_LEN, device)
     partial_block_mask, full_block_mask = _convert_mask_to_block_mask(
         mask_tensor,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #176316
* #175967


```
flex] create_block_mask HOP that installs mask_mod as a subgraph
Adds a create_block_mask Higher Order Operator (HOP) that traces
mask_mod as a subgraph instead of inlining it.
In the two-tier compilation architecture (outer aot_export trace +
inner torch.compile via regional Inductor), create_block_mask needs
to appear as a single FX graph node with mask_mod captured as a
subgraph. Without this, the outer make_fx trace inlines all of
create_block_mask's internals (vmap, block mask conversion, sparse
block creation), which breaks because these operations aren't
designed to be traced through ProxyTorchDispatchMode.
========================================================================
TESTS
========================================================================
test_create_block_mask_hop_dynamo
    Two-tier AOT export with a simple causal mask (q_idx >= kv_idx),
    no tensor closure. A model calls create_block_mask inside a
    compile_with_inductor region, then flex_attention in a second
    region. Runs aot_export_joint_with_descriptors under FakeTensorMode.
    Verifies the outer graph has a create_block_mask HOP node and its
    subgraph contains a ge op from the causal mask.
test_blockmask_tensor_closure_nested_compile_aot_export
    Same two-tier structure, but mask_mod captures tensors (lower/upper
    slices of a visibility input). During the outer trace these are
    FunctionalTensors.
    Verifies _extract_tensor_closure_vars lifts them from the closure,
    the functionalize dispatch unwraps/rewraps them, and the subgraph
    has index/le ops with closure tensors as placeholders (not
    baked-in constants).
test_torch_compile_create_block_mask_flex_attention
    Standard torch.compile (no two-tier tracing). create_block_mask +
    flex_attention end-to-end. Under Dynamo the HOP branch does not
    fire (is_dynamo_compiling() short-circuits), so the inline path
    runs and produces real tensors.
    Verifies compiled output matches eager reference.
========================================================================
EXAMPLE GRAPHS FROM TESTS
========================================================================
------------------------------------------------------------------------
Test 1: causal mask, no tensor closure
------------------------------------------------------------------------
Outer graph (trimmed to show HOP nodes only):
    %flex_create_block_mask0 = get_attr[target=flex_create_block_mask0]
    %create_block_mask = call_function[target=torch.ops.higher_order.create_block_mask](
        args = (%flex_create_block_mask0, 2, 1, 32, 32, cuda:0, (128, 128), ()))
    %getitem   = call_function[target=operator.getitem](args = (%create_block_mask, 0))
    %getitem_1 = call_function[target=operator.getitem](args = (%create_block_mask, 1))
    ...  (8 getitems total, one per BlockMask tensor attr)
    %flex_attention = call_function[target=torch.ops.higher_order.flex_attention](
        args = (%transpose, %transpose_1, %transpose_2, %sdpa_score0,
                (32, 32, %getitem, %getitem_1, ..., 128, 128, %sdpa_mask0),
                0.25, {...}, (), ()))
    The 8 block mask tensors from create_block_mask flow directly
    into flex_attention's block_mask tuple arg.
mask_mod subgraph (flex_create_block_mask0):
    arg0_1 = placeholder  (b)
    arg1_1 = placeholder  (h)       -- unused
    arg2_1 = placeholder  (q_idx)
    arg3_1 = placeholder  (kv_idx)
    ge = torch.ops.aten.ge.Tensor(arg2_1, arg3_1)
    return ge
    Simple causal mask: q_idx >= kv_idx. No closure tensor args.
------------------------------------------------------------------------
Test 2: visibility mask with tensor closure
------------------------------------------------------------------------
Outer graph (trimmed):
    %primals_8 = placeholder   (visibility input, shape [B, 2, seq_len])
    %select   = aten.select.int(%primals_8, 1, 0)   (lower)
    %select_1 = aten.select.int(%primals_8, 1, 1)   (upper)
    %flex_create_block_mask0 = get_attr[target=flex_create_block_mask0]
    %create_block_mask = call_function[target=torch.ops.higher_order.create_block_mask](
        args = (%flex_create_block_mask0, 2, 1, 32, 32, cuda:0, (128, 128),
                (%select, %select_1)))
                 ^^^^^^^^^^^^^^^^^^^^^^^
                 closure tensors (lower, upper) are lifted as explicit args
    The same %select / %select_1 also flow into flex_attention and
    flex_attention_backward as mask_mod closure args.
mask_mod subgraph (flex_create_block_mask0):
    arg0_1 = placeholder  (b)
    arg1_1 = placeholder  (h)       -- unused
    arg2_1 = placeholder  (q_idx)
    arg3_1 = placeholder  (kv_idx)
    arg4_1 = placeholder  (lower)   -- lifted closure tensor
    arg5_1 = placeholder  (upper)   -- lifted closure tensor
    index   = aten.index.Tensor(arg4_1, [arg0_1, arg2_1])    lower[b, q_idx]
    le      = aten.le.Tensor(index, arg3_1)                   lower[b,q] <= kv_idx
    index_1 = aten.index.Tensor(arg5_1, [arg0_1, arg2_1])    upper[b, q_idx]
    le_1    = aten.le.Tensor(arg3_1, index_1)                 kv_idx <= upper[b,q]
    bitwise_and = aten.bitwise_and.Tensor(le, le_1)
    return bitwise_and
    The closure tensors (lower, upper) appear as subgraph placeholders
    (arg4_1, arg5_1) rather than baked-in constants. This is what
    _extract_tensor_closure_vars achieves on the make_fx path.
========================================================================
KEY DECISIONS
========================================================================
HOP only under make_fx, not Dynamo
    (flex_attention.py:1289)
    Condition: not is_dynamo_compiling() and get_proxy_mode() is not None
      Eager:  both false          -> inline path (no change)
      make_fx: proxy mode active  -> HOP path
      Dynamo: is_dynamo_compiling -> inline path
    Why not Dynamo: flex_attention uses a nested torch.compile
    internally. Block mask tensors from the HOP would enter that
    nested compile as FakeTensors. AOTAutograd promotes small non-grad
    integer inputs to graph constants, and FakeTensor constants can't
    be lowered by Inductor. The inline path produces real tensors
    during Dynamo, avoiding this.
    flex_attention already captures mask_mod as a subgraph via
    FlexAttentionHigherOrderVariable, so the subgraph is not lost.
    is_dynamo_compiling() must come first to short-circuit before
    get_proxy_mode() which Dynamo can't trace through.
Manual broadcasting instead of vmap
    (_create_block_mask_tensors, flex_attention.py:1565)
    The original create_block_mask uses _vmap_for_bhqkv. This HOP
    uses stride-0 expand broadcasting instead: arange + view + expand
    for each of B, H, Q_LEN, KV_LEN dimensions.
    Why: vmap creates BatchedTensors which are incompatible with
    FakeTensorMode during AOTAutograd proxy tracing. Stride-0 expand
    uses regular tensors, no extra memory, traces cleanly.
Closure tensor lifting
    (_extract_tensor_closure_vars, flex_attention.py:1457)
    mask_mod may capture tensors (e.g. visibility masks). During
    make_fx tracing, closed-over tensors would be baked into the
    subgraph as constants. This function inspects fn.__closure__,
    extracts tensors, and builds a modified_fn that accepts them as
    extra positional args. At call time it rebuilds the closure via
    types.FunctionType with patched cells.
    The tensors then flow through the dispatch stack
    (functionalize/fake/proxy) as explicit args. Under Dynamo,
    speculate_subgraph handles this lifting natively instead.
HOP returns 8 tensors, caller rebuilds BlockMask
    create_block_mask_hop returns (kv_num_blocks, kv_indices,
    full_kv_num_blocks, full_kv_indices, q_num_blocks, q_indices,
    full_q_num_blocks, full_q_indices).
    The caller in create_block_mask reconstructs BlockMask from these
    plus known constants (seq_lengths, BLOCK_SIZE) and the original
    mask_mod.
========================================================================
ADDED CODE
========================================================================
torch/_higher_order_ops/flex_attention.py
------------------------------------------------------------------------
_extract_tensor_closure_vars(fn) - line 1457
    Extracts tensor free variables from fn's closure. Returns
    (new_fn, tensors) where new_fn takes original args + extra tensor
    args. Rebuilds the closure at call time by replacing tensor cells
    with the extra args via types.FunctionType. _make_cell helper
    creates closure cells by exploiting nested function's
    __closure__[0].
CreateBlockMaskHOP - line 1517
    HigherOrderOperator subclass named "create_block_mask". __call__
    extracts closure tensors if not already extracted, validates
    types, dispatches.
_create_block_mask_tensors(...) - line 1565
    CompositeExplicitAutograd implementation. Rebinds closure tensors
    if present, creates B/H/Q/KV index tensors via stride-0 expand,
    calls mask_mod, then _convert_mask_to_block_mask +
    _create_sparse_block_from_block_mask. Returns 8 tensor attrs via
    BlockMask._TENSOR_ATTRS.
trace_create_block_mask(...) - line 1659
    ProxyTorchDispatchMode handler. Computes example outputs via
    redispatch, traces mask_mod via reenter_make_fx with scalar int
    example values, registers the subgraph as
    "flex_create_block_mask" on the tracer root, creates the proxy
    node, tracks output tensors.
create_block_mask_fake_impl(...) - line 1725
    FakeTensorMode handler. Returns 8 empty int32 tensors with correct
    shapes (num_blocks: [B,H,num_q_blocks], indices:
    [B,H,num_q_blocks,num_kv_blocks], and transposed for q).
create_block_mask_functionalize(...) - line 1775
    Unwraps FunctionalTensors from closure tensors, functionalizes
    mask_mod, redispatches, rewraps outputs. Critical for two-tier
    export where closure tensors are FunctionalTensors from the outer
    aot_export trace.
torch/_dynamo/variables/higher_order_ops.py
------------------------------------------------------------------------
CreateBlockMaskHigherOrderVariable - line 4222
    Dynamo variable class for the HOP. create_wrapped_node traces
    mask_mod via speculate_subgraph with 4 scalar dummy inputs, lifts
    closure tensors as body_lifted_freevars, installs subgraph as
    "flex_create_block_mask". _call_function unpacks args, calls
    create_wrapped_node, creates the call_function proxy with
    subgraph + scalar args + lifted closure tensors.
Authored with Claude.
```



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo