### PR TITLE
[FSDP2][docs] Document communication grouping and scheduling semantics

### DIFF
--- a/docs/source/distributed.fsdp.fully_shard.md
+++ b/docs/source/distributed.fsdp.fully_shard.md
@@ -85,17 +85,46 @@ with compute. This is almost never what you want.
 **If you apply** ``fully_shard`` **per submodule** — for example, calling
 ``fully_shard(m2)``, ``fully_shard(m3)``, and then ``fully_shard(model)`` —
 the remaining parameters (``a`` and ``d``) form the root group, while ``m2``
-and ``m3`` each get their own group:
+and ``m3`` each get their own group.
+
+In **forward**, all-gathers run on a separate CUDA stream, so the next
+module's all-gather can overlap with the current module's forward compute.
+Each module's pre-forward hook issues its own all-gather and waits for it to
+complete before running the module. Because the CPU typically runs ahead of
+the GPU, the next module's all-gather is issued on the AG stream while the
+current module's forward is still executing on the compute stream:
 
 ```
-all-gather(a,d) -> fwd(m1) -> all-gather(b) -> fwd(m2) -> all-gather(c) -> fwd(m3,m4)
--> bwd(m4,m3) -> reduce-scatter(c) -> bwd(m2) -> reduce-scatter(b) -> bwd(m1) -> reduce-scatter(a,d)
+              time ──────────────────────────────────────────────►
+
+compute:      [wait] [ fwd(m1)   | fwd(m2)    | fwd(m3,m4)     ]
+AG stream:    [AG(a,d)]  [AG(b)  |    AG(c)   ]
 ```
 
-Now communication can overlap with compute: while one group's parameters are
-being all-gathered, another group's forward or backward is executing. This is
-why the recommended pattern is to apply ``fully_shard`` bottom-up to each
-layer before applying it to the root.
+While ``fwd(m1)`` runs on the compute stream, the CPU fires ``m2``'s
+pre-forward hook, which issues ``AG(b)`` on the AG stream. To make this
+overlap more robust (e.g. when CPU-side overhead reduces the lead), use
+``set_modules_to_forward_prefetch`` to issue the next all-gather earlier —
+inside the current module's pre-forward hook rather than waiting for the next
+module's hook to fire.
+
+In **backward**, FSDP2 additionally prefetches the next module's all-gather
+explicitly and runs reduce-scatters on a separate CUDA stream, all without
+any additional configuration:
+
+```
+              time ──────────────────────────────────────────────►
+
+compute:      [ bwd(m4,m3)     | bwd(m2)        | bwd(m1)       ]
+AG stream:    [AG(c)] [ AG(b)  |   AG(a,d)      ]
+RS stream:                     |[RS(c)]  [ RS(b)|     RS(a,d)   ]
+```
+
+While ``bwd(m4,m3)`` runs on the compute stream, the all-gather for ``b``
+(needed by ``m2``) is prefetched on the AG stream. While ``bwd(m2)`` runs,
+both ``AG(a,d)`` and ``RS(c)`` overlap with compute. This pipelining is why
+the recommended pattern is to apply ``fully_shard`` bottom-up to each layer
+before applying it to the root.
 
 To control the size of each communication group, choose which modules to wrap:
 wrapping more fine-grained modules produces smaller, more overlappable groups

--- a/docs/source/distributed.fsdp.fully_shard.md
+++ b/docs/source/distributed.fsdp.fully_shard.md
@@ -55,6 +55,54 @@ The user contract for ``fully_shard(model)`` is as follows
   registers hooks to the original module.
 
 
+### Communication Grouping and Scheduling
+
+Each call to ``fully_shard`` creates one **communication group** containing all
+parameters in the module that are not already assigned to a group from an
+earlier call on a submodule. Each group's parameters are all-gathered together
+in one collective before forward, and their gradients are reduce-scattered
+together in one collective after backward. Unlike DDP, FSDP2 has no
+``bucket_cap_mb`` parameter — the communication boundaries are determined
+entirely by which modules you apply ``fully_shard`` to.
+
+Consider a model with four submodules where ``a``, ``b``, ``c``, and ``d``
+denote the number of parameters in each:
+
+```
+model[ m1[a] -> m2[b] -> m3[c] -> m4[d] ]
+```
+
+**If you only call** ``fully_shard(model)`` **(root only)**, all parameters are
+in a single group. This means the entire forward and backward look like:
+
+```
+all-gather(a+b+c+d) -> forward(m1,m2,m3,m4) -> backward(m4,m3,m2,m1) -> reduce-scatter(a+b+c+d)
+```
+
+All communication happens as two large blocking operations with no overlap
+with compute. This is almost never what you want.
+
+**If you apply** ``fully_shard`` **per submodule** — for example, calling
+``fully_shard(m2)``, ``fully_shard(m3)``, and then ``fully_shard(model)`` —
+the remaining parameters (``a`` and ``d``) form the root group, while ``m2``
+and ``m3`` each get their own group:
+
+```
+all-gather(a,d) -> fwd(m1) -> all-gather(b) -> fwd(m2) -> all-gather(c) -> fwd(m3,m4)
+-> bwd(m4,m3) -> reduce-scatter(c) -> bwd(m2) -> reduce-scatter(b) -> bwd(m1) -> reduce-scatter(a,d)
+```
+
+Now communication can overlap with compute: while one group's parameters are
+being all-gathered, another group's forward or backward is executing. This is
+why the recommended pattern is to apply ``fully_shard`` bottom-up to each
+layer before applying it to the root.
+
+To control the size of each communication group, choose which modules to wrap:
+wrapping more fine-grained modules produces smaller, more overlappable groups
+(similar to smaller DDP buckets), while wrapping fewer modules produces larger
+groups. There is no automatic bucketing — the grouping is explicit and
+determined by the module structure.
+
 Compared to PyTorch FSDP1 (`FullyShardedDataParallel`):
 
 - FSDP2 uses `DTensor`-based dim-0 per-parameter sharding for a simpler


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #176318

Add a "Communication Grouping and Scheduling" section to the FSDP2 docs
explaining how fully_shard calls control communication boundaries, why
there is no bucket_cap_mb equivalent, and the consequences of wrapping
only the root module vs. wrapping per-layer. Includes a concrete example
showing the forward/backward communication timeline for both cases.

The new part of the rendered doc:
<img width="1236" height="1226" alt="image" src="https://github.com/user-attachments/assets/9a4d2c57-9f4c-4bf8-a00c-ab86ac48a4f8" />



Claude