### PR TITLE
[inductor][auto-chunker] Add some elementwise ops to propagation rule

### DIFF
--- a/test/inductor/test_auto_chunker.py
+++ b/test/inductor/test_auto_chunker.py
@@ -247,6 +247,30 @@ class AutoChunkerTest(TestCase):
             f"Actual peak_memory {peak_memory}, expected bound {expected_bound}",
         )
 
+    @config.patch("auto_chunker.output_size_threshold", 1024)
+    @config.patch("auto_chunker.num_chunk", 2)
+    def test_propagate_tanh_neg(self):
+        M, K, N = 256, 4, 256
+        x = torch.randn(M, K, device=GPU_TYPE, requires_grad=True)
+        w = torch.randn(K, N, device=GPU_TYPE, requires_grad=True)
+
+        def f(x, w):
+            out = (x * 2) @ w
+            out = torch.tanh(out)
+            out = -out
+            loss = out.sum()
+            loss.backward()
+            return loss
+
+        expect = (f(x, w), x.grad, w.grad)
+        x.grad = None
+        w.grad = None
+        opt_f = torch.compile(f)
+        actual = (opt_f(x, w), x.grad, w.grad)
+
+        self.assertTrue(same(expect, actual, tol=1e-3))
+        self.assertEqual(metrics.num_auto_chunking, 1)
+
     def test_set_num_chunk_with_compile_options(self):
         B = 32
         T = 1024

--- a/torch/_inductor/fx_passes/auto_chunker/propagate_scale_by.py
+++ b/torch/_inductor/fx_passes/auto_chunker/propagate_scale_by.py
@@ -133,8 +133,36 @@ def propagate_where(where_node: Node) -> bool:
 
 @register_propagate_rule(
     [
+        aten.exp.default,
+        aten.log.default,
+        aten.tanh.default,
+    ]
+)
+def propagate_nonlinear_requires_no_scaling(out_node: Node) -> bool:
+    """
+    For nonlinear ops like exp, log, tanh, scale_by cannot be propagated
+    through since f(S*x) != S*f(x). These ops typically appear in the chunking
+    subgraph when the final gradient is 1 (i.e. scale_by is None),
+    making scaling a no-op.
+    """
+    args_node = get_args_of_node_type(out_node)
+    args_meta = get_chunking_metas(args_node)
+    out_meta = get_chunking_meta(out_node)
+
+    scale_by = get_scale_by_from_metas(*args_meta)  # type: ignore[arg-type]
+    assert scale_by is None, (
+        f"Nonlinear op {out_node.target} requires scale_by=None, got {scale_by}"
+    )
+    assert out_meta is not None
+    out_meta.scale_by = None
+    return True
+
+
+@register_propagate_rule(
+    [
         aten.mul.Tensor,
         prims.convert_element_type.default,
+        aten.neg.default,
         aten.sum.dim_IntList,
         aten.sum.default,  # sum to scalar
         aten.mm.default,

--- a/torch/_inductor/fx_passes/auto_chunker/propagator.py
+++ b/torch/_inductor/fx_passes/auto_chunker/propagator.py
@@ -388,6 +388,7 @@ def propagate_mm(mm_node: Node) -> _HandlerRetType:
         prims.convert_element_type.default,
         aten.exp.default,
         aten.log.default,
+        aten.tanh.default,
         aten.add.Tensor,
         aten.sub.Tensor,
         aten.div.Tensor,


### PR DESCRIPTION
- These elementwise ops are seen when attempting auto-chunking with cross-entropy loss + weighted loss.

  Testing: Adding a new unit test that exercises the new rules

<!-- ps-id: 22f8b0ae-121f-4166-b9c3-ab2efcfbb6e1 -->

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo