### PR TITLE
[Inductor][CUTLASS] Skip CUTLASS backend in non-AOT cpp_wrapper mode

### DIFF
--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -2080,6 +2080,21 @@ def use_blackwell_cutedsl_grouped_mm(
 def use_cutlass_template(layout: Layout, m: int, n: int, k: int) -> bool:
     from .virtualized import V
 
+    # TODO: Enable CUTLASS in non-AOT cpp_wrapper mode. The CUTLASS
+    # codegen (CUDATemplateKernel.call_kernel) already has cpp_wrapper-aware
+    # arg handling, but the other half is missing: the non-triton branch of
+    # CppWrapperGpu._generate_kernel_call_helper unconditionally emits
+    # `kernels.<name>(...)`, and that AOTInductorModelKernels struct only
+    # exists in AOT mode. Fixing this requires adding dlopen/dlsym loading
+    # for the compiled CUTLASS .so, similar to how the triton branch uses
+    # static CUfunction + loadKernel for non-AOT mode.
+    if V.graph.cpp_wrapper and not V.graph.aot_mode:
+        log.warning(
+            "CUTLASS backend is not supported with non-AOT cpp_wrapper mode. "
+            "Skipping CUTLASS backend. See https://github.com/pytorch/pytorch/issues/176080"
+        )
+        return False
+
     gemm_size = V.graph.sizevars.optimization_hint(m * n * k, fallback=-1)
     if gemm_size <= 0 or gemm_size < config.cutlass.cutlass_backend_min_gemm_size:
         return False


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo