### PR TITLE
[Inductor][CUTLASS] Skip CUTLASS backend in non-AOT cpp_wrapper mode

### DIFF
--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -2091,7 +2091,7 @@ def use_cutlass_template(layout: Layout, m: int, n: int, k: int) -> bool:
     if V.graph.cpp_wrapper and not V.graph.aot_mode:
         log.warning(
             "CUTLASS backend is not supported with non-AOT cpp_wrapper mode. "
-            "Skipping CUTLASS backend. See https://github.com/pytorch/pytorch/issues/176080"
+            "Skipping CUTLASS backend."
         )
         return False
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #176332
* #176331



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo