### PR TITLE
[torchbench] Fix incorrect attempt to import FB code in OSS

### DIFF
--- a/benchmarks/dynamo/torchbench.py
+++ b/benchmarks/dynamo/torchbench.py
@@ -9,6 +9,7 @@ import sys
 import tempfile
 import warnings
 from collections import namedtuple
+from functools import cached_property
 from os.path import abspath, exists
 
 import torch
@@ -21,7 +22,6 @@ except ImportError:
 
 from torch._dynamo.testing import collect_results, reduce_to_scalar_loss
 from torch._dynamo.utils import clone_inputs
-from torch.testing._internal.common_utils import IS_FBCODE
 
 
 # We are primarily interested in tf32 datatype
@@ -221,6 +221,12 @@ class TorchBenchmarkRunner(BenchmarkRunner):
             "doctr_reco_predictor",
         }
 
+    @cached_property
+    def _fb_models_available(self):
+        """This property exists because importing IS_FBCODE causes some models to be
+        frozen out of setting certain config flags."""
+        return importlib.util.find_spec("torchbenchmark.models.fb") is not None
+
     def load_model(
         self,
         device,
@@ -240,7 +246,7 @@ class TorchBenchmarkRunner(BenchmarkRunner):
             f"torchbenchmark.models.{model_name}",
             f"torchbenchmark.canary_models.{model_name}",
         ]
-        if IS_FBCODE:
+        if self._fb_models_available:
             candidates.append(f"torchbenchmark.models.fb.{model_name}")
 
         for c in candidates:

--- a/benchmarks/dynamo/torchbench.py
+++ b/benchmarks/dynamo/torchbench.py
@@ -21,6 +21,7 @@ except ImportError:
 
 from torch._dynamo.testing import collect_results, reduce_to_scalar_loss
 from torch._dynamo.utils import clone_inputs
+from torch.testing._internal.common_utils import IS_FBCODE
 
 
 # We are primarily interested in tf32 datatype
@@ -234,11 +235,14 @@ class TorchBenchmarkRunner(BenchmarkRunner):
             )
         is_training = self.args.training
         use_eval_mode = self.args.use_eval_mode
+
         candidates = [
             f"torchbenchmark.models.{model_name}",
             f"torchbenchmark.canary_models.{model_name}",
-            f"torchbenchmark.models.fb.{model_name}",
         ]
+        if IS_FBCODE:
+            candidates.append(f"torchbenchmark.models.fb.{model_name}")
+
         for c in candidates:
             try:
                 module = importlib.import_module(c)
@@ -415,7 +419,7 @@ class TorchBenchmarkRunner(BenchmarkRunner):
             yield model_name
 
     def pick_grad(self, name, is_training):
-        if is_training or name in ("maml",):
+        if is_training or name == "maml":
             return torch.enable_grad()
         else:
             return torch.no_grad()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #176337

Suppresses an uninformative message that looks like "ModuleNotFoundError: No module named 'torchbenchmark.models.fb'" any time a misspelled model name is put in the benchmark runner in the OSS side.

Also fixes lint noticed by Ruff.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo