### PR TITLE
[MPS] Register uint16/uint32/uint64 binary op Metal kernels

### DIFF
--- a/aten/src/ATen/native/mps/kernels/BinaryKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/BinaryKernel.metal
@@ -405,12 +405,15 @@ struct gcd_functor {
   }
 };
 
-#define REGISTER_INTEGER_BINARY_OP(NAME)  \
-  REGISTER_BINARY_OP(NAME, long, long);   \
-  REGISTER_BINARY_OP(NAME, int, int);     \
-  REGISTER_BINARY_OP(NAME, short, short); \
-  REGISTER_BINARY_OP(NAME, uchar, uchar); \
-  REGISTER_BINARY_OP(NAME, char, char);   \
+#define REGISTER_INTEGER_BINARY_OP(NAME)    \
+  REGISTER_BINARY_OP(NAME, long, long);     \
+  REGISTER_BINARY_OP(NAME, int, int);       \
+  REGISTER_BINARY_OP(NAME, short, short);   \
+  REGISTER_BINARY_OP(NAME, uchar, uchar);   \
+  REGISTER_BINARY_OP(NAME, ushort, ushort); \
+  REGISTER_BINARY_OP(NAME, uint, uint);     \
+  REGISTER_BINARY_OP(NAME, ulong, ulong);   \
+  REGISTER_BINARY_OP(NAME, char, char);     \
   REGISTER_BINARY_OP(NAME, bool, bool)
 
 #define REGISTER_INT2FLOAT_BINARY_OP(NAME) \
@@ -418,6 +421,9 @@ struct gcd_functor {
   REGISTER_BINARY_OP(NAME, int, float);    \
   REGISTER_BINARY_OP(NAME, short, float);  \
   REGISTER_BINARY_OP(NAME, uchar, float);  \
+  REGISTER_BINARY_OP(NAME, ushort, float); \
+  REGISTER_BINARY_OP(NAME, uint, float);   \
+  REGISTER_BINARY_OP(NAME, ulong, float);  \
   REGISTER_BINARY_OP(NAME, char, float);   \
   REGISTER_BINARY_OP(NAME, bool, float)
 
@@ -496,6 +502,9 @@ REGISTER_BINARY_ALPHA_OP(add_alpha, float, float, float);
 REGISTER_BINARY_ALPHA_OP(add_alpha, half, half, half);
 REGISTER_BINARY_ALPHA_OP(add_alpha, short, short, short);
 REGISTER_BINARY_ALPHA_OP(add_alpha, uchar, uchar, uchar);
+REGISTER_BINARY_ALPHA_OP(add_alpha, ushort, ushort, ushort);
+REGISTER_BINARY_ALPHA_OP(add_alpha, uint, uint, uint);
+REGISTER_BINARY_ALPHA_OP(add_alpha, ulong, ulong, ulong);
 REGISTER_BINARY_ALPHA_OP(add_alpha, char, char, char);
 REGISTER_BINARY_ALPHA_OP(add_alpha, bool, bool, bool);
 REGISTER_BINARY_ALPHA_OP(sub_alpha, long, long, long);
@@ -504,6 +513,9 @@ REGISTER_BINARY_ALPHA_OP(sub_alpha, float, float, float);
 REGISTER_BINARY_ALPHA_OP(sub_alpha, half, half, half);
 REGISTER_BINARY_ALPHA_OP(sub_alpha, short, short, short);
 REGISTER_BINARY_ALPHA_OP(sub_alpha, uchar, uchar, uchar);
+REGISTER_BINARY_ALPHA_OP(sub_alpha, ushort, ushort, ushort);
+REGISTER_BINARY_ALPHA_OP(sub_alpha, uint, uint, uint);
+REGISTER_BINARY_ALPHA_OP(sub_alpha, ulong, ulong, ulong);
 REGISTER_BINARY_ALPHA_OP(sub_alpha, char, char, char);
 REGISTER_BINARY_ALPHA_OP(sub_alpha, bool, bool, bool);
 REGISTER_BINARY_ALPHA_OP(lerp_alpha, long, long, long);
@@ -512,6 +524,9 @@ REGISTER_BINARY_ALPHA_OP(lerp_alpha, float, float, float);
 REGISTER_BINARY_ALPHA_OP(lerp_alpha, half, half, half);
 REGISTER_BINARY_ALPHA_OP(lerp_alpha, short, short, short);
 REGISTER_BINARY_ALPHA_OP(lerp_alpha, uchar, uchar, uchar);
+REGISTER_BINARY_ALPHA_OP(lerp_alpha, ushort, ushort, ushort);
+REGISTER_BINARY_ALPHA_OP(lerp_alpha, uint, uint, uint);
+REGISTER_BINARY_ALPHA_OP(lerp_alpha, ulong, ulong, ulong);
 REGISTER_BINARY_ALPHA_OP(lerp_alpha, char, char, char);
 REGISTER_BINARY_ALPHA_OP(lerp_alpha, bool, bool, bool);
 

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -8490,6 +8490,62 @@ class TestMPS(TestCaseMPS):
         y = x / 64
         self.assertEqual(y, torch.tensor([0., 1023.9844], device="mps"))
 
+    def test_mps_binary_ops_dtype_coverage(self):
+        """Test binary ops work for every dtype MPS can allocate.
+
+        Catches missing Metal kernel registrations that cause garbage values
+        (e.g. uint16/uint32/uint64 division returned garbage before the fix).
+        Dynamically probes all torch dtypes so new types are covered automatically.
+        """
+        device = "mps"
+        all_dtypes = {getattr(torch, name) for name in dir(torch)
+                      if isinstance(getattr(torch, name), torch.dtype)}
+        failures = []
+        for dtype in all_dtypes:
+            # Skip types MPS can't allocate
+            # Values chosen to fit int4 (-8..7) and work with bool
+            try:
+                a = torch.tensor([1, 2], dtype=dtype, device=device)
+                b = torch.tensor([1, 2], dtype=dtype, device=device)
+            except (TypeError, RuntimeError):
+                continue
+
+            al, bl = a.tolist(), b.tolist()
+
+            # Division works for all types including bool (True/True == 1.0)
+            try:
+                actual = (a / b).tolist()
+                expected = [x / y for x, y in zip(al, bl)]
+                if actual != expected:
+                    failures.append(f"{dtype}: {al} / {bl} = {actual}, expected {expected}")
+            except RuntimeError:
+                pass
+
+            # Integer add/sub/mul (bool has different semantics: no sub, add returns bool)
+            if not dtype.is_floating_point and not dtype.is_complex and dtype != torch.bool:
+                try:
+                    actual = (a + b).tolist()
+                    expected = [x + y for x, y in zip(al, bl)]
+                    if actual != expected:
+                        failures.append(f"{dtype}: {al} + {bl} = {actual}, expected {expected}")
+
+                    actual = (a - b).tolist()
+                    expected = [x - y for x, y in zip(al, bl)]
+                    if actual != expected:
+                        failures.append(f"{dtype}: {al} - {bl} = {actual}, expected {expected}")
+
+                    actual = (a * b).tolist()
+                    expected = [x * y for x, y in zip(al, bl)]
+                    if actual != expected:
+                        failures.append(f"{dtype}: {al} * {bl} = {actual}, expected {expected}")
+                except RuntimeError:
+                    pass
+
+        self.assertFalse(
+            failures,
+            "Binary ops produced wrong results for these dtypes:\n" + "\n".join(failures),
+        )
+
 
 class TestLargeTensors(TestCaseMPS):
     @serialTest()


### PR DESCRIPTION
Fixes #176296

## Summary

Binary operations (add, sub, mul, div, etc.) on `uint16`, `uint32`, and `uint64` tensors on MPS produce garbage values because the Metal shader infrastructure is missing kernel registrations and type-cast handling for these unsigned integer types.

PR #159094 added MPS dispatch-layer support for unsigned integers in `OperationUtils.mm`, but the Metal-side kernel registrations and type casting were not updated.

Overlaps with #176343 on the `common.h`/`indexing.h` changes. This PR additionally registers the Metal binary op kernels (`BinaryKernel.metal`) so that `add`, `sub`, `mul`, and alpha ops work for unsigned integers — not just division/cast. Also adds a dynamic dtype coverage test.

### Changes

1. **`c10/metal/common.h`** — Add `UInt16(27)`, `UInt32(28)`, `UInt64(29)` to `C10_METAL_ALL_TYPES_FUNCTOR` so the Metal-side `ScalarType` enum includes them. *(overlaps #176343)*

2. **`c10/metal/indexing.h`** — Add `ushort`/`uint`/`ulong` cases to the `val_at_offs` switch for dynamic type casting in `_cast` kernel variants. *(overlaps #176343)*

3. **`aten/src/ATen/native/mps/kernels/BinaryKernel.metal`** — Register `ushort`/`uint`/`ulong` in `REGISTER_INTEGER_BINARY_OP`, `REGISTER_INT2FLOAT_BINARY_OP`, and individual `REGISTER_BINARY_ALPHA_OP` calls, consistent with existing `uchar` (uint8) registrations.

4. **`test/test_mps.py`** — Add `test_mps_binary_ops_dtype_coverage` that dynamically probes every `torch.dtype` MPS can allocate and verifies binary ops produce correct results. Catches missing kernel registrations automatically for any dtype.

### Repro (before fix)
```python
>>> import torch
>>> torch.tensor([0, 65535], dtype=torch.uint16, device="mps") / 65535
tensor([0.0000e+00, 3.0518e-05], device='mps:0')  # garbage
```

### After fix
```python
>>> torch.tensor([0, 65535], dtype=torch.uint16, device="mps") / 65535
tensor([0., 1.], device='mps:0')  # correct
```

## Checklist

- [x] Passes lint (`spin fixlint`)
- [x] Added/updated tests

## BC-breaking?

No