### PR TITLE
[pt] Reland vec8 vectorization

### DIFF
--- a/aten/src/ATen/native/cuda/BinaryRemainderKernel.cu
+++ b/aten/src/ATen/native/cuda/BinaryRemainderKernel.cu
@@ -6,6 +6,7 @@
 #include <ATen/native/TensorIterator.h>
 #include <c10/util/TypeSafeSignMath.h>
 
+#include <limits>
 #include <type_traits>
 
 // NOTE: CUDA on Windows requires that the enclosing function
@@ -15,6 +16,25 @@ namespace at::native {
 
 void remainder_kernel_cuda(TensorIteratorBase& iter) {
   if (isIntegralType(iter.common_dtype(), /*includeBool*/ false)) {
+#ifndef USE_ROCM
+    // Guard uint8 div-by-zero: NVIDIA hardware returns all-1s (255) for
+    // integer mod by zero, while ROCm returns the dividend unchanged, so
+    // we only need this explicit guard on the CUDA path.
+    AT_DISPATCH_INTEGRAL_TYPES(iter.common_dtype(), "remainder_cuda", [&]() {
+      gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
+        if constexpr (std::is_same_v<scalar_t, uint8_t>) {
+          if (b == 0) {
+            return std::numeric_limits<uint8_t>::max();
+          }
+        }
+        scalar_t r = a % b;
+        if (r != 0 && c10::signs_differ(r, b)) {
+          r += b;
+        }
+        return r;
+      });
+    });
+#else
     AT_DISPATCH_INTEGRAL_TYPES(iter.common_dtype(), "remainder_cuda", [&]() {
       gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
         scalar_t r = a % b;
@@ -24,6 +44,7 @@ void remainder_kernel_cuda(TensorIteratorBase& iter) {
         return r;
       });
     });
+#endif
   } else {
     AT_DISPATCH_FLOATING_TYPES_AND2(kHalf, kBFloat16, iter.common_dtype(), "remainder_cuda", [&]() {
       gpu_kernel_with_scalars(iter,

--- a/aten/src/ATen/native/cuda/CUDALoops.cuh
+++ b/aten/src/ATen/native/cuda/CUDALoops.cuh
@@ -316,12 +316,11 @@ static inline void launch_vectorized_kernel(
   if (p->major != 9 && p->major != 10) {
     vec_size = std::min<uint16_t>(vec_size, 4);
   }
-  // Here we purposely omit vec8 for 1-byte data because of a bug in NVCC
-  // that causes some numerical mismatches with uint8 on sm80 and sm90.
-  // TODO: Revisit this after CUDA 12.8 update.
+#if !defined(CUDA_VERSION) || CUDA_VERSION < 12080
   if constexpr (sizeof(cpp_type) < 2) {
     vec_size = std::min<uint16_t>(vec_size, 4);
   }
+#endif
   int tws = elems_per_thread<io_size>();
 #endif
   int bws = tws * num_threads();


### PR DESCRIPTION
Summary: This is a reland of reverted vec8 vectorization from D92296654, which now makes it only for cuda

Test Plan: All tests now pass.

Differential Revision: D95015282


