### PR TITLE
Fix AOTI incorrect loads from bool tensor pointers in user-defined Triton kernels

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -115,6 +115,7 @@ if HAS_GPU:
         add_kernel_with_tma_2d_new_api,
         add_kernel_with_tma_2d_old_api,
         create_tensor_descriptor_shim,
+        masked_add_kernel_with_bool_tensor,
         mul2_inplace_kernel,
         strange_config_matmul_kernel,
         sub_kernel_autotuned,
@@ -250,6 +251,31 @@ class AOTInductorTestsTemplate:
                 return out
 
         inputs = (torch.randn(4, device=self.device),)
+        self.check_model(Model(), inputs)
+
+    def test_triton_kernel_bool_tensor_arg(self):
+        if self.device != GPU_TYPE or self.device == "mps":
+            raise unittest.SkipTest("requires GPU")
+
+        class Model(torch.nn.Module):
+            def forward(self, x, y, mask):
+                out = torch.zeros_like(x)
+                n = x.numel()
+                masked_add_kernel_with_bool_tensor[(n,)](
+                    in_ptr0=x,
+                    in_ptr1=y,
+                    mask_ptr=mask,
+                    out_ptr=out,
+                    n_elements=n,
+                    BLOCK_SIZE=1024,
+                )
+                return out
+
+        n = 128
+        x = torch.randn(n, device=self.device)
+        y = torch.randn(n, device=self.device)
+        mask = torch.arange(n, device=self.device) < n // 2
+        inputs = (x, y, mask)
         self.check_model(Model(), inputs)
 
     @unittest.skipIf(

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -15059,6 +15059,36 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         inputs = (torch.randn(4, device=self.device),)
         self.common(Model(), inputs)
 
+    @requires_gpu_and_triton
+    def test_triton_kernel_bool_tensor_arg(self):
+        if self.device != GPU_TYPE or self.device == "mps":
+            raise unittest.SkipTest("requires GPU")
+
+        from torch.testing._internal.triton_utils import (
+            masked_add_kernel_with_bool_tensor,
+        )
+
+        class Model(torch.nn.Module):
+            def forward(self, x, y, mask):
+                out = torch.zeros_like(x)
+                n = x.numel()
+                masked_add_kernel_with_bool_tensor[(n,)](
+                    in_ptr0=x,
+                    in_ptr1=y,
+                    mask_ptr=mask,
+                    out_ptr=out,
+                    n_elements=n,
+                    BLOCK_SIZE=1024,
+                )
+                return out
+
+        n = 128
+        x = torch.randn(n, device=self.device)
+        y = torch.randn(n, device=self.device)
+        mask = torch.arange(n, device=self.device) < n // 2
+        inputs = (x, y, mask)
+        self.common(Model(), inputs)
+
     @skipIfXpu(
         msg="Profile not enabled on XPU CI, "
         "https://github.com/intel/torch-xpu-ops/issues/2334"

--- a/torch/_higher_order_ops/triton_kernel_wrap.py
+++ b/torch/_higher_order_ops/triton_kernel_wrap.py
@@ -462,7 +462,14 @@ def generate_ttir(
             if kernel.params[idx].is_constexpr:
                 return "constexpr"
             # pyrefly: ignore [not-callable]
-            return mangle_type(arg)
+            result = mangle_type(arg)
+            # Workaround for Triton i1/u1 AOTI bug: PyTorch stores bool
+            # tensors as uint8 (1 byte per element), but *i1/*u1 causes
+            # the compiled kernel to generate bit-packed loads. Use *u8
+            # so loads correctly read 1 byte per element.
+            if result in ("*i1", "*u1"):
+                result = "*u8"
+            return result
 
     else:
 

--- a/torch/testing/_internal/triton_utils.py
+++ b/torch/testing/_internal/triton_utils.py
@@ -1055,6 +1055,26 @@ if has_triton():
             output = x
         tl.store(out_ptr + offsets, output, mask=mask)
 
+    @triton.jit
+    def masked_add_kernel_with_bool_tensor(
+        in_ptr0,
+        in_ptr1,
+        mask_ptr,
+        out_ptr,
+        n_elements,
+        BLOCK_SIZE: "tl.constexpr",
+    ):
+        """Kernel that loads a bool tensor and uses it as a mask."""
+        pid = tl.program_id(axis=0)
+        block_start = pid * BLOCK_SIZE
+        offsets = block_start + tl.arange(0, BLOCK_SIZE)
+        valid = offsets < n_elements
+        x = tl.load(in_ptr0 + offsets, mask=valid)
+        y = tl.load(in_ptr1 + offsets, mask=valid)
+        keep = tl.load(mask_ptr + offsets, mask=valid, other=0) != 0
+        output = tl.where(keep, x + y, x)
+        tl.store(out_ptr + offsets, output, mask=valid)
+
     # support the old (experimental) and new (tensor_descriptor) APIs
     def create_tensor_descriptor_shim(
         tensor, block_sizes: list[int], new_api: bool = True


### PR DESCRIPTION
User-defined Triton kernels (via @triton.jit or @triton_op) that take
bool tensor arguments produce incorrect results when compiled through
AOTI. The root cause is that Triton's mangle_type maps torch.bool
tensors to *i1/*u1 (1-bit pointer), but PyTorch stores bool tensors as
uint8 (1 byte per element). The compiled cubin kernel generates
bit-packed loads for *i1/*u1 pointers, reading garbled data from the
byte-addressed memory.

Inductor-generated kernels already work around this (Triton issue https://github.com/triton-lang/triton/issues/2151 and corresponding workaround in pytorch https://github.com/pytorch/pytorch/blob/da0eb6647126f1b0e57112a79a83f55393de635f/torch/_inductor/codegen/triton.py#L3657-L3661)
by adding .to(tl.int1) after loads and converting to int8 for stores.
But user-defined kernels don't get these workarounds since their code is
user-written.

Fix: override *i1/*u1 -> *u8 in the mangle_type signature for
user-defined kernels. This makes the compiled kernel use byte-addressed
loads matching PyTorch's bool memory layout.

Test Plan: 

```
  # Existing bool param test (should still pass)
  python -m pytest test/inductor/test_aot_inductor.py -k "test_triton_kernel_bool_param" -x -v

  # New bool tensor test
  python -m pytest test/inductor/test_aot_inductor.py -k "test_triton_kernel_bool_tensor_arg" -x -v

  # Inductor torch.compile path
  python -m pytest test/inductor/test_torchinductor.py -k "test_triton_kernel_bool_tensor_arg" -x -v

  # Broader regression check — all user-defined triton kernel tests
  python -m pytest test/inductor/test_aot_inductor.py -k "triton_kernel" -x -v
  ```


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo