### PR TITLE
Fix running decompositions on ep with ops that have nested tensor list args

### DIFF
--- a/aten/src/ATen/FunctionalTensorWrapper.cpp
+++ b/aten/src/ATen/FunctionalTensorWrapper.cpp
@@ -864,6 +864,18 @@ void functionalize_op_helper(const c10::OperatorHandle& op, torch::jit::Stack* s
         "The composite op functionalization fallback expects its inputs all not to be functional tensors");
       auto t_new = c10::IValue(at::functionalization::impl::to_functional_tensor(opt_tensors));
       (*stack)[arguments_begin + idx] = t_new;
+    } else if (ivalue.isList()) {
+      // Handle nested lists containing tensor lists (e.g., Tensor[][]).
+      auto list = ivalue.toList();
+      for (const auto i : c10::irange(list.size())) {
+        const auto& elem = list.get(i);
+        if (elem.isTensorList()) {
+          auto tensors = elem.toTensorList();
+          TORCH_INTERNAL_ASSERT(!at::functionalization::impl::isFunctionalTensor(tensors),
+            "The composite op functionalization fallback expects its inputs all not to be functional tensors");
+          list.set(i, c10::IValue(at::functionalization::impl::to_functional_tensor(tensors)));
+        }
+      }
     }
   }
 
@@ -907,6 +919,17 @@ void functionalize_op_helper(const c10::OperatorHandle& op, torch::jit::Stack* s
       at::functionalization::impl::sync(opt_tensors);
       auto t_new = c10::IValue(at::functionalization::impl::from_functional_tensor(opt_tensors));
       (*stack)[returns_begin + idx] = t_new;
+    } else if (ivalue.isList()) {
+      // Handle nested lists containing tensor lists (e.g., Tensor[][]).
+      auto list = ivalue.toList();
+      for (const auto i : c10::irange(list.size())) {
+        const auto& elem = list.get(i);
+        if (elem.isTensorList()) {
+          auto tensors = elem.toTensorList();
+          at::functionalization::impl::sync(tensors);
+          list.set(i, c10::IValue(at::functionalization::impl::from_functional_tensor(tensors)));
+        }
+      }
     }
   }
 }

--- a/aten/src/ATen/FunctionalizeFallbackKernel.cpp
+++ b/aten/src/ATen/FunctionalizeFallbackKernel.cpp
@@ -112,6 +112,21 @@ namespace {
           auto t_new = c10::IValue(at::functionalization::impl::from_functional_tensor(opt_tensors));
           (*stack)[arguments_begin + idx] = t_new;
         }
+      } else if (ivalue.isList()) {
+        // Handle nested lists containing tensor lists (e.g., Tensor[][]).
+        auto list = ivalue.toList();
+        for (const auto i : c10::irange(list.size())) {
+          const auto& elem = list.get(i);
+          if (elem.isTensorList()) {
+            any_tensor_inputs = true;
+            auto tensors = elem.toTensorList();
+            if (at::functionalization::impl::isFunctionalTensor(tensors)) {
+              any_functional_inputs = true;
+              at::functionalization::impl::sync(tensors);
+              list.set(i, c10::IValue(at::functionalization::impl::from_functional_tensor(tensors)));
+            }
+          }
+        }
       }
     }
     // we should wrap the output if any inputs were wrapped,
@@ -142,6 +157,16 @@ namespace {
         auto opt_tensors = ivalue.toOptionalTensorList();
         auto t_new = c10::IValue(at::functionalization::impl::to_functional_tensor(opt_tensors));
         (*stack)[returns_begin + idx] = t_new;
+      } else if (ivalue.isList() && should_wrap_outputs) {
+        // Handle nested lists containing tensor lists (e.g., Tensor[][]).
+        auto list = ivalue.toList();
+        for (const auto i : c10::irange(list.size())) {
+          const auto& elem = list.get(i);
+          if (elem.isTensorList()) {
+            auto tensors = elem.toTensorList();
+            list.set(i, c10::IValue(at::functionalization::impl::to_functional_tensor(tensors)));
+          }
+        }
       }
     }
   }

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -18150,6 +18150,47 @@ def forward(self, x):
         exported_param_names = [name for name, _ in gm.named_parameters()]
         self.assertEqual(original_param_names, exported_param_names)
 
+    def test_run_decompositions_tensor_list_list(self):
+        """run_decompositions should work for custom ops with List[List[Tensor]] args.
+
+        The C++ Functionalize fallback kernel now handles nested list arguments
+        (Tensor[][]) by recursively unwrapping/wrapping functional tensors.
+        """
+        lib = torch.library.Library("test_tll", "DEF")
+        lib.define(
+            "merge_op(Tensor[][] nested, Tensor[] flat, int[] weights)"
+            " -> (Tensor[], Tensor)",
+            tags=[torch.Tag.pt2_compliant_tag],
+        )
+
+        @torch.library.impl("test_tll::merge_op", "cpu", lib=lib)
+        def merge_op_cpu(nested, flat, weights):
+            out = [nested[i][0] + flat[i] for i in range(len(flat))]
+            combined = torch.cat([f.unsqueeze(0) for f in flat], dim=0).sum(dim=0)
+            return out, combined
+
+        @torch.library.register_fake("test_tll::merge_op")
+        def merge_op_fake(nested, flat, weights):
+            out = [torch.empty_like(flat[i]) for i in range(len(flat))]
+            combined = torch.empty_like(flat[0])
+            return out, combined
+
+        class M(torch.nn.Module):
+            def forward(self, a, b, c, d):
+                return torch.ops.test_tll.merge_op([[a, b], [c, d]], [a, c], [1, 2])
+
+        m = M()
+        a, b, c, d = (torch.randn(3, 4) for _ in range(4))
+        ep = export(m, (a, b, c, d))
+        ep2 = ep.run_decompositions({})
+        eager_out = m(a, b, c, d)
+        decomp_out = ep2.module()(a, b, c, d)
+        self.assertEqual(len(eager_out[0]), len(decomp_out[0]))
+        for e, d_ in zip(eager_out[0], decomp_out[0]):
+            self.assertEqual(e, d_)
+        self.assertEqual(eager_out[1], decomp_out[1])
+        del lib
+
 
 @unittest.skipIf(not torchdynamo.is_dynamo_supported(), "dynamo doesn't support")
 class TestExportCustomClass(TorchTestCase):


### PR DESCRIPTION
Summary:
Fixes a bug in torch.export's run_decompositions() for custom ops with List[List[Tensor]] arguments.

The C++ Functionalize kernel incorrectly strips the FakeTensor subclass from tensors nested in List[List[Tensor]] arguments during the conversion between Python and C++ types. This causes failures when running decompositions on exported programs that use custom ops with nested tensor list arguments.

The fix detects ops with List[List[Tensor]] in their schema and bypasses the buggy C++ kernel by using Python-level functionalization instead (similar to the existing TorchBindOpOverload handling).

Test Plan:
Added test_run_decompositions_tensor_list_list that verifies run_decompositions works correctly for a custom op with Tensor[][] args.

`buck2 test fbcode//caffe2/test:test_export`

Differential Revision: D95093484


