### PR TITLE
[CPU]Fix unsigned int ufunc scalar-only dispatch

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -580,7 +580,7 @@
   structured_inherits: TensorIteratorBase
   ufunc_inner_loop:
     Generic: add (AllAndComplex, BFloat16, Half, ComplexHalf)
-    ScalarOnly: add (Bool)
+    ScalarOnly: add (Bool, UInt16, UInt32, UInt64)
   dispatch:
     SparseCPU, SparseMeta: add_out_sparse_cpu
     SparseCUDA: add_out_sparse_cuda

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -3843,6 +3843,39 @@ class TestBinaryUfuncs(TestCase):
             lambda: torch.add(m1, m1, out=m2),
         )
 
+    @onlyCPU
+    @dtypes(*_unsigned_int_types)
+    def test_add_sub_mul_unsigned_int(self, device, dtype):
+        a = torch.tensor([10, 20, 30], dtype=dtype, device=device)
+        b = torch.tensor([1, 2, 3], dtype=dtype, device=device)
+
+        self.assertEqual(a + b, torch.tensor([11, 22, 33], dtype=dtype, device=device))
+        self.assertEqual(a - b, torch.tensor([9, 18, 27], dtype=dtype, device=device))
+        self.assertEqual(a * b, torch.tensor([10, 40, 90], dtype=dtype, device=device))
+
+        # in-place
+        c = a.clone()
+        c.add_(b)
+        self.assertEqual(c, torch.tensor([11, 22, 33], dtype=dtype, device=device))
+
+        c = a.clone()
+        c.sub_(b)
+        self.assertEqual(c, torch.tensor([9, 18, 27], dtype=dtype, device=device))
+
+        c = a.clone()
+        c.mul_(b)
+        self.assertEqual(c, torch.tensor([10, 40, 90], dtype=dtype, device=device))
+
+        # alpha parameter for add/sub
+        self.assertEqual(
+            torch.add(a, b, alpha=2),
+            torch.tensor([12, 24, 36], dtype=dtype, device=device),
+        )
+        self.assertEqual(
+            torch.sub(a, b, alpha=2),
+            torch.tensor([8, 16, 24], dtype=dtype, device=device),
+        )
+
     @onlyOn(["cuda", "xpu"])
     def test_addsub_half_tensor(self, device):
         x = torch.tensor([60000.0], dtype=torch.half, device=device)

--- a/torchgen/model.py
+++ b/torchgen/model.py
@@ -397,6 +397,9 @@ class ScalarType(Enum):
     Float8_e4m3fn = auto()
     Float8_e4m3fnuz = auto()
     Float8_e8m0fnu = auto()
+    UInt16 = auto()
+    UInt32 = auto()
+    UInt64 = auto()
 
     def __str__(self) -> str:
         return self.name


### PR DESCRIPTION
Fixes #176298 
**Summary**
Binary operations on `uint16`, `uint32`, and `uint64` raise `NotImplementedError` for tensors on CPU as addressed. A similar change for MPS was made in PR #176344. This happens because PyTorch's add kernel on CPU is auto-generated via ufunc codegen. This reads native_functions.yaml and emits AT_DISPATCH_CASE entires for each dtype listed. The ScalarType for these in torchgen/model.py didn't include UInt16, UInt32, and UInt64, so there was no way to reference them in the yaml.
**Changes**
1. torchgen/model.py: Add UInt16, UInt32, Uint64 to the ScalarType enum. The codegen emits at::ScalarType::{name} which already maps to correct C++ types. 
2. aten/src/ATen/native/native_functions.yaml: Added three types to ScalarOnly line of add.out's inner loop. These are in ScalarOnly because there aren't any vectorized specializations for the three types. 
3. test/test_binary_ufuncs.py: Added tests for out of place and in place and the alpha parameter for all three unsigned int types

Reproduction

```
import torch
a = torch.tensor([10, 20], dtype=torch.uint16)
b = torch.tensor([5, 10], dtype=torch.uint16)
print(a / b)   # Works: tensor([2., 2.])
print(a + b)   # NotImplementedError: "add_stub" not implemented for 'UInt16'
print(a - b)   # NotImplementedError: "sub_stub" not implemented for 'UInt16'
print(a * b)   # NotImplementedError: "mul_stub" not implemented for 'UInt16'
```

Reproduction After Fix
```
tensor([2., 2.])
tensor([15, 30], dtype=torch.uint16)
tensor([ 5, 10], dtype=torch.uint16)
tensor([ 50, 200], dtype=torch.uint16)
```

**Checklist**
Passes lint `(make lint)`
Added/updated tests