### PR TITLE
[DTensor] Track per-output placements for multi-output ops in strategy_validation

### DIFF
--- a/test/distributed/tensor/test_strategy_validation.py
+++ b/test/distributed/tensor/test_strategy_validation.py
@@ -28,7 +28,6 @@ from torch.distributed.tensor._ops.strategy_validation import (
     normalize_placement,
     normalize_placement_str,
     parse_placement,
-    placement_tuple_to_str,
     PlacementCombination,
     query_single_dim_strategy,
     resolve_op_names,
@@ -63,16 +62,6 @@ class TestPlacementUtilities(TestCase):
         p = parse_placement("P(max)")
         self.assertIsInstance(p, Partial)
         self.assertEqual(p.reduce_op, "max")
-
-    def test_placement_tuple_to_str(self):
-        s = placement_tuple_to_str((Replicate(),))
-        self.assertEqual(s, "(R)")
-
-        s = placement_tuple_to_str((Shard(0), Replicate()))
-        self.assertEqual(s, "(S(0), R)")
-
-        s = placement_tuple_to_str((Partial("sum"),))
-        self.assertEqual(s, "(P(sum))")
 
     def test_is_fully_replicated(self):
         self.assertTrue(is_fully_replicated((Replicate(),)))
@@ -146,49 +135,49 @@ class TestPlacementNormalization(TestCase):
     def test_normalize_combo_key_trivial_output(self):
         """Combo keys with trivial output shard should normalize output to R."""
         # P(max) -> S(0) on output [1,1,1] should become P(max) -> R
-        combo = (("P(max)",), "S(0)")
+        combo = (("P(max)",), ("S(0)",))
         input_shapes = ((4, 3),)
-        output_shape = (1, 1, 1)
+        output_shapes = ((1, 1, 1),)
 
-        result = normalize_combo_key(combo, input_shapes, output_shape)
-        self.assertEqual(result, (("P(max)",), "R"))
+        result = normalize_combo_key(combo, input_shapes, output_shapes)
+        self.assertEqual(result, (("P(max)",), ("R",)))
 
     def test_normalize_combo_key_trivial_input(self):
         """Combo keys with trivial input shard should normalize input to R."""
         # S(0),R -> R on input [1,4],[4,4] should become R,R -> R
-        combo = (("S(0)", "R"), "R")
+        combo = (("S(0)", "R"), ("R",))
         input_shapes = ((1, 4), (4, 4))
-        output_shape = (4, 4)
+        output_shapes = ((4, 4),)
 
-        result = normalize_combo_key(combo, input_shapes, output_shape)
-        self.assertEqual(result, (("R", "R"), "R"))
+        result = normalize_combo_key(combo, input_shapes, output_shapes)
+        self.assertEqual(result, (("R", "R"), ("R",)))
 
     def test_normalize_combo_key_all_trivial(self):
         """All-size-1 tensor should normalize all shards to R."""
         # S(0),S(1) -> S(2) on shape [1,1,1] should become R,R -> R
-        combo = (("S(0)", "S(1)"), "S(2)")
+        combo = (("S(0)", "S(1)"), ("S(2)",))
         input_shapes = ((1, 1, 1), (1, 1, 1))
-        output_shape = (1, 1, 1)
+        output_shapes = ((1, 1, 1),)
 
-        result = normalize_combo_key(combo, input_shapes, output_shape)
-        self.assertEqual(result, (("R", "R"), "R"))
+        result = normalize_combo_key(combo, input_shapes, output_shapes)
+        self.assertEqual(result, (("R", "R"), ("R",)))
 
     def test_normalize_combo_key_no_change(self):
         """Normal-sized tensors should not change."""
-        combo = (("S(0)", "S(1)"), "S(0)")
+        combo = (("S(0)", "S(1)"), ("S(0)",))
         input_shapes = ((4, 3), (4, 3))
-        output_shape = (4, 3)
+        output_shapes = ((4, 3),)
 
-        result = normalize_combo_key(combo, input_shapes, output_shape)
+        result = normalize_combo_key(combo, input_shapes, output_shapes)
         self.assertEqual(result, combo)
 
     def test_normalize_combo_key_partial_unchanged(self):
         """Partial placements should never be normalized."""
-        combo = (("P(max)", "P(sum)"), "P(max)")
+        combo = (("P(max)", "P(sum)"), ("P(max)",))
         input_shapes = ((1, 1), (1, 1))  # Even with all-size-1
-        output_shape = (1, 1)
+        output_shapes = ((1, 1),)
 
-        result = normalize_combo_key(combo, input_shapes, output_shape)
+        result = normalize_combo_key(combo, input_shapes, output_shapes)
         self.assertEqual(result, combo)  # Partials unchanged
 
     def test_normalize_deduplicates_equivalent_rules(self):
@@ -204,22 +193,22 @@ class TestPlacementNormalization(TestCase):
         After normalization, they should all become P(max) -> R.
         """
         input_shapes = ((1, 1, 1, 1),)
-        output_shape = (1, 1, 1)
+        output_shapes = ((1, 1, 1),)
 
         normalized_rules = set()
         for shard_dim in [0, 1, 2]:
-            combo = (("P(max)",), f"S({shard_dim})")
-            normalized = normalize_combo_key(combo, input_shapes, output_shape)
+            combo = (("P(max)",), (f"S({shard_dim})",))
+            normalized = normalize_combo_key(combo, input_shapes, output_shapes)
             normalized_rules.add(normalized)
 
         # Also add the explicit R version
-        combo_r = (("P(max)",), "R")
-        normalized_r = normalize_combo_key(combo_r, input_shapes, output_shape)
+        combo_r = (("P(max)",), ("R",))
+        normalized_r = normalize_combo_key(combo_r, input_shapes, output_shapes)
         normalized_rules.add(normalized_r)
 
         # All should have normalized to the same rule
         self.assertEqual(len(normalized_rules), 1)
-        self.assertEqual(normalized_rules.pop(), (("P(max)",), "R"))
+        self.assertEqual(normalized_rules.pop(), (("P(max)",), ("R",)))
 
 
 class TestInputPlacements(TestCase):
@@ -357,9 +346,7 @@ class TestValidateCombination(TestCase):
         ground_truth = torch.igamma(a, x)
         self.assertTrue(ground_truth.isnan().all(), "Expected all NaN ground truth")
 
-        combo = PlacementCombination(
-            input_placements=(Shard(0), Replicate()), output_placement=Shard(0)
-        )
+        combo: PlacementCombination = ((Shard(0), Replicate()), (Shard(0),))
 
         with LocalTensorMode(frozenset(range(self.world_size))):
             mesh = init_device_mesh("cpu", (self.world_size,))
@@ -523,7 +510,7 @@ class TestValidateCombination(TestCase):
 
                         for p_out in ALL_PLACEMENTS:
                             input_plcs = (p1, p2)
-                            combo = PlacementCombination(input_plcs, p_out)
+                            combo: PlacementCombination = (input_plcs, (p_out,))
 
                             is_valid, msg = validate_combination(
                                 op,
@@ -570,9 +557,9 @@ class TestValidateCombination(TestCase):
 
             # R + alpha*P(max) where alpha=-1 should produce P(min)
             # because -max(x) = min(-x)
-            combo_valid = PlacementCombination(
-                input_placements=(Replicate(), Partial("max")),
-                output_placement=Partial("min"),
+            combo_valid: PlacementCombination = (
+                (Replicate(), Partial("max")),
+                (Partial("min"),),
             )
             is_valid, msg = validate_combination(
                 torch.add,
@@ -588,9 +575,9 @@ class TestValidateCombination(TestCase):
             )
 
             # R + alpha*P(max) where alpha=-1 should NOT produce P(max)
-            combo_invalid = PlacementCombination(
-                input_placements=(Replicate(), Partial("max")),
-                output_placement=Partial("max"),
+            combo_invalid: PlacementCombination = (
+                (Replicate(), Partial("max")),
+                (Partial("max"),),
             )
             is_valid, msg = validate_combination(
                 torch.add,
@@ -605,9 +592,9 @@ class TestValidateCombination(TestCase):
 
             # Similarly, P(max) + alpha*R where alpha=-1 should produce P(max)
             # because we're subtracting a replicated value from P(max)
-            combo_pmax_minus_r = PlacementCombination(
-                input_placements=(Partial("max"), Replicate()),
-                output_placement=Partial("max"),
+            combo_pmax_minus_r: PlacementCombination = (
+                (Partial("max"), Replicate()),
+                (Partial("max"),),
             )
             is_valid, msg = validate_combination(
                 torch.add,
@@ -825,9 +812,9 @@ class TestPartialCombinationValidity(TestCase):
         tensors = extract_tensors_from_sample(sample)
         ground_truth = torch.abs(t)
 
-        combo = PlacementCombination(
-            input_placements=(Partial("sum"),),
-            output_placement=Partial("sum"),
+        combo: PlacementCombination = (
+            (Partial("sum"),),
+            (Partial("sum"),),
         )
 
         with LocalTensorMode(frozenset(range(self.world_size))):
@@ -848,9 +835,9 @@ class TestPartialCombinationValidity(TestCase):
         tensors = extract_tensors_from_sample(sample)
         ground_truth = torch.abs(t)
 
-        combo = PlacementCombination(
-            input_placements=(Partial("avg"),),
-            output_placement=Partial("avg"),
+        combo: PlacementCombination = (
+            (Partial("avg"),),
+            (Partial("avg"),),
         )
 
         with LocalTensorMode(frozenset(range(self.world_size))):
@@ -884,9 +871,9 @@ class TestPartialCombinationValidity(TestCase):
 
         # P(sum)->P(sum) is NOT valid for zeros_like, but with all-zero
         # output it trivially passes: sum(0,0)=0=ground_truth.
-        combo = PlacementCombination(
-            input_placements=(Partial("sum"),),
-            output_placement=Partial("sum"),
+        combo: PlacementCombination = (
+            (Partial("sum"),),
+            (Partial("sum"),),
         )
 
         with LocalTensorMode(frozenset(range(self.world_size))):
@@ -932,9 +919,9 @@ class TestPartialCombinationValidity(TestCase):
         ground_truth = torch.argmin(t, dim=0, keepdim=True)
 
         for reduce_op in ("min", "max"):
-            combo = PlacementCombination(
-                input_placements=(Partial(reduce_op),),
-                output_placement=Replicate(),
+            combo: PlacementCombination = (
+                (Partial(reduce_op),),
+                (Replicate(),),
             )
             with LocalTensorMode(frozenset(range(self.world_size))):
                 mesh = init_device_mesh("cpu", (self.world_size,))
@@ -971,9 +958,9 @@ class TestPartialCombinationValidity(TestCase):
 
         # P(sum)->P(sum) is NOT valid for zeros_like, but with all-zero
         # output it trivially passes: sum(0,0)=0=ground_truth.
-        combo = PlacementCombination(
-            input_placements=(Partial("sum"),),
-            output_placement=Partial("sum"),
+        combo: PlacementCombination = (
+            (Partial("sum"),),
+            (Partial("sum"),),
         )
 
         with LocalTensorMode(frozenset(range(self.world_size))):
@@ -1050,14 +1037,14 @@ class TestDecompStrategyPath(TestCase):
         self.assertIsNotNone(output_strategy)
 
         input_shapes = (t.shape,)
-        output_shape = tuple(torch.nn.functional.softplus(t).shape)
+        output_shapes = (tuple(torch.nn.functional.softplus(t).shape),)
         rules = _extract_rules_from_op_strategy(
-            output_strategy, input_shapes, output_shape
+            output_strategy, input_shapes, output_shapes
         )
 
         # Should discover elementwise sharding rules for a 2D tensor
-        self.assertIn((("S(0)",), "S(0)"), rules)
-        self.assertIn((("S(1)",), "S(1)"), rules)
+        self.assertIn((("S(0)",), ("S(0)",)), rules)
+        self.assertIn((("S(1)",), ("S(1)",)), rules)
 
     def test_compare_operator_uses_decomp_path(self):
         """
@@ -1187,6 +1174,107 @@ class TestQuerySingleDimStrategyKwargs(TestCase):
                 propagator.op_single_dim_strategy_funcs[aten_add] = original
             else:
                 propagator.op_single_dim_strategy_funcs.pop(aten_add, None)
+
+
+class TestCompareRules(TestCase):
+    """Test _compare_rules populates per-op statistics correctly."""
+
+    def test_true_positives_tracked_by_op(self):
+        from torch.distributed.tensor._ops.strategy_validation import (
+            _compare_rules,
+            ComparisonStats,
+        )
+
+        combo_a = (("S(0)",), ("R",))
+        combo_b = (("S(1)",), ("R",))
+        stats = ComparisonStats()
+        _compare_rules(
+            ground_truth_valid={combo_a, combo_b},
+            dtensor_rules={combo_a, combo_b},
+            input_shapes=((4, 8),),
+            output_shapes=((4, 8),),
+            sample_idx=0,
+            scalar_args=(),
+            scalar_kwargs={},
+            aten_op=torch.ops.aten.relu.default,
+            variant="",
+            stats=stats,
+        )
+        self.assertEqual(stats.true_positives, 2)
+        self.assertEqual(stats.true_positives_by_op, {"aten.relu.default": 2})
+        self.assertEqual(len(stats.false_positives), 0)
+        self.assertEqual(len(stats.false_negatives), 0)
+
+    def test_per_op_breakdown_multiple_aten_ops(self):
+        """Simulate an opinfo that dispatches to different aten variants per sample."""
+        from torch.distributed.tensor._ops.strategy_validation import (
+            _compare_rules,
+            ComparisonStats,
+        )
+
+        stats = ComparisonStats()
+
+        # Sample 0: aten.max.dim returns (values, indices)
+        combo_2out = (("S(0)",), ("R", "R"))
+        _compare_rules(
+            ground_truth_valid={combo_2out},
+            dtensor_rules={combo_2out},
+            input_shapes=((4, 8),),
+            output_shapes=((4, 8), (4, 8)),
+            sample_idx=0,
+            scalar_args=(1,),
+            scalar_kwargs={},
+            aten_op=torch.ops.aten.max.dim,
+            variant="",
+            stats=stats,
+        )
+        # Sample 1: aten.native_layer_norm returns (output, mean, rstd)
+        combo_3out = (("S(0)",), ("R", "R", "R"))
+        _compare_rules(
+            ground_truth_valid={combo_3out},
+            dtensor_rules={combo_3out},
+            input_shapes=((4, 8),),
+            output_shapes=((4, 8), (4,), (4,)),
+            sample_idx=1,
+            scalar_args=(),
+            scalar_kwargs={},
+            aten_op=torch.ops.aten.native_layer_norm.default,
+            variant="",
+            stats=stats,
+        )
+
+        self.assertEqual(stats.true_positives, 2)
+        self.assertEqual(
+            stats.true_positives_by_op,
+            {"aten.max.dim": 1, "aten.native_layer_norm.default": 1},
+        )
+
+    def test_false_positives_and_negatives_not_in_by_op(self):
+        """true_positives_by_op only tracks true positives, not FP/FN."""
+        from torch.distributed.tensor._ops.strategy_validation import (
+            _compare_rules,
+            ComparisonStats,
+        )
+
+        gt_only = (("S(0)",), ("R",))
+        dt_only = (("S(1)",), ("R",))
+        stats = ComparisonStats()
+        _compare_rules(
+            ground_truth_valid={gt_only},
+            dtensor_rules={dt_only},
+            input_shapes=((4, 8),),
+            output_shapes=((4, 8),),
+            sample_idx=0,
+            scalar_args=(),
+            scalar_kwargs={},
+            aten_op=torch.ops.aten.relu.default,
+            variant="",
+            stats=stats,
+        )
+        self.assertEqual(stats.true_positives, 0)
+        self.assertEqual(stats.true_positives_by_op, {})
+        self.assertEqual(len(stats.false_positives), 1)
+        self.assertEqual(len(stats.false_negatives), 1)
 
 
 class TestCompareOperatorEndToEnd(TestCase):

--- a/torch/distributed/tensor/_ops/strategy_validation.py
+++ b/torch/distributed/tensor/_ops/strategy_validation.py
@@ -50,8 +50,10 @@ from torch.testing._internal.opinfo import core as opinfo_core
 from torch.utils import _pytree as pytree
 
 
-# A combo key is (input_placement_strs, output_placement_str)
-ComboKey = tuple[tuple[str, ...], str]
+# A combo key is (input_placement_strs, output_placement_strs)
+# For single-output ops: (("S(0)",), ("P(min)",))
+# For multi-output ops:  (("S(0)",), ("P(min)", "P(min)"))
+ComboKey = tuple[tuple[str, ...], tuple[str, ...]]
 
 # Partial reduce ops to enumerate
 PARTIAL_REDUCE_OPS = ["sum", "avg", "min", "max"]
@@ -70,27 +72,7 @@ SKIP_OPS: dict[str, str] = {
 }
 
 
-@dataclass
-class PlacementCombination:
-    """Represents a combination of input and output placements."""
-
-    input_placements: tuple[Placement, ...]  # One placement per input tensor
-    output_placement: Placement  # Placement for the output tensor
-
-    def __hash__(self):
-        return hash(
-            (tuple(str(p) for p in self.input_placements), str(self.output_placement))
-        )
-
-    def __eq__(self, other):
-        if not isinstance(other, PlacementCombination):
-            return NotImplemented
-        return tuple(str(p) for p in self.input_placements) == tuple(
-            str(p) for p in other.input_placements
-        ) and str(self.output_placement) == str(other.output_placement)
-
-    def __str__(self):
-        return f"inputs={placement_tuple_to_str(self.input_placements)}, output={placement_tuple_to_str((self.output_placement,))}"
+PlacementCombination = tuple[tuple[Placement, ...], tuple[Placement, ...]]
 
 
 @dataclass
@@ -98,7 +80,7 @@ class Discrepancy:
     """Represents a discrepancy between ground truth and DTensor's rules."""
 
     input_placements: tuple[str, ...]
-    output_placement: str
+    output_placements: tuple[str, ...]
     sample_idx: int
     input_shapes: tuple[tuple[int, ...], ...]
     discrepancy_type: str  # "false_positive" or "false_negative"
@@ -147,21 +129,6 @@ class _FalsePositiveMitigations:
     non_rounded_negated_sample: SampleInput | None = None
     non_rounded_negated_tensors: list[tuple[str, torch.Tensor]] | None = None
     non_rounded_negated_ground_truth: torch.Tensor | list[torch.Tensor] | None = None
-
-
-def placement_tuple_to_str(placements: tuple[Placement, ...]) -> str:
-    """Convert a tuple of placements to a readable string."""
-    parts: list[str] = []
-    for p in placements:
-        if isinstance(p, Shard):
-            parts.append(f"S({p.dim})")
-        elif isinstance(p, Replicate):
-            parts.append("R")
-        elif isinstance(p, Partial):
-            parts.append(f"P({p.reduce_op})")
-        else:
-            parts.append(str(p))
-    return "(" + ", ".join(parts) + ")"
 
 
 def parse_placement(s: str) -> Placement | None:
@@ -227,7 +194,7 @@ def normalize_placement_str(p_str: str, shape: tuple[int, ...]) -> str:
 def normalize_combo_key(
     combo_key: ComboKey,
     input_shapes: tuple[tuple[int, ...], ...],
-    output_shape: tuple[int, ...],
+    output_shapes: tuple[tuple[int, ...], ...],
 ) -> ComboKey:
     """
     Normalize a combo_key by converting trivial shards to Replicate.
@@ -237,25 +204,26 @@ def normalize_combo_key(
     - S(0), R -> R on input [1,4] becomes R, R -> R
 
     Args:
-        combo_key: (input_placement_strs, output_placement_str) tuple
+        combo_key: (input_placement_strs, output_placement_strs) tuple
         input_shapes: Shapes of input tensors
-        output_shape: Shape of output tensor
+        output_shapes: Shapes of output tensors
 
     Returns:
         Normalized combo_key with trivial shards converted to Replicate
     """
-    input_placement_strs, output_placement_str = combo_key
+    input_placement_strs, output_placement_strs = combo_key
 
-    # Normalize input placements
     normalized_inputs = tuple(
         normalize_placement_str(p_str, shape)
         for p_str, shape in zip(input_placement_strs, input_shapes)
     )
 
-    # Normalize output placement
-    normalized_output = normalize_placement_str(output_placement_str, output_shape)
+    normalized_outputs = tuple(
+        normalize_placement_str(p_str, shape)
+        for p_str, shape in zip(output_placement_strs, output_shapes)
+    )
 
-    return (normalized_inputs, normalized_output)
+    return (normalized_inputs, normalized_outputs)
 
 
 def get_1d_input_placements_for_tensor(
@@ -500,7 +468,7 @@ def validate_combination(
 
         local_tensors = []
         for tensor_idx, ((name, tensor), placement) in enumerate(
-            zip(tensors, combination.input_placements)
+            zip(tensors, combination[0])
         ):
             if isinstance(placement, Partial):
                 local_tensor = _create_partial_input(
@@ -563,7 +531,16 @@ def validate_combination(
                 f"Output count mismatch: got {len(local_outputs)}, expected {len(ground_truths)}",
             )
 
-        for i, (local_out, gt) in enumerate(zip(local_outputs, ground_truths)):
+        if len(local_outputs) != len(combination[1]):
+            return (
+                False,
+                f"Output count mismatch with placements: "
+                f"got {len(local_outputs)}, expected {len(combination[1])}",
+            )
+
+        for i, (local_out, gt, out_plc) in enumerate(
+            zip(local_outputs, ground_truths, combination[1])
+        ):
             if not isinstance(local_out, torch.Tensor):
                 return False, f"Local output[{i}] is not a tensor: {type(local_out)}"
 
@@ -573,12 +550,12 @@ def validate_combination(
             output_dt = DTensor.from_local(
                 local_out,
                 mesh,
-                (combination.output_placement,),
+                (out_plc,),
                 shape=gt.shape,
                 stride=gt.stride(),
             )
 
-            if isinstance(combination.output_placement, Replicate):
+            if isinstance(out_plc, Replicate):
                 local_values = [local_out._local_tensors[r] for r in range(world_size)]
                 all_same = all(
                     torch.allclose(local_values[0], lv, atol=1e-5, rtol=1e-5)
@@ -619,29 +596,24 @@ def validate_combination(
 
 
 def has_pmin_pmax(
-    input_placements: tuple[Placement, ...], output_placement: Placement
+    input_placements: tuple[Placement, ...],
+    output_placements: tuple[Placement, ...],
 ) -> bool:
     """Check if any placement is Partial(min) or Partial(max)."""
-    for p in input_placements:
+    for p in (*input_placements, *output_placements):
         if isinstance(p, Partial) and p.reduce_op in ("min", "max"):
             return True
-    if isinstance(output_placement, Partial) and output_placement.reduce_op in (
-        "min",
-        "max",
-    ):
-        return True
     return False
 
 
 def has_any_partial(
-    input_placements: tuple[Placement, ...], output_placement: Placement
+    input_placements: tuple[Placement, ...],
+    output_placements: tuple[Placement, ...],
 ) -> bool:
     """Check if any placement is Partial (any reduce op)."""
-    for p in input_placements:
+    for p in (*input_placements, *output_placements):
         if isinstance(p, Partial):
             return True
-    if isinstance(output_placement, Partial):
-        return True
     return False
 
 
@@ -677,7 +649,7 @@ def _run_op_on_sample(op: Callable[..., Any], sample: SampleInput) -> Any:
 def _extract_rules_from_op_strategy(
     op_strategy: Any,
     input_shapes: tuple[tuple[int, ...], ...],
-    output_shape: tuple[int, ...],
+    output_shapes: tuple[tuple[int, ...], ...],
 ) -> set[ComboKey]:
     """Extract normalized sharding rules from an OpStrategy.
 
@@ -693,22 +665,25 @@ def _extract_rules_from_op_strategy(
         if spec.input_specs is None:
             continue
         if isinstance(spec.output_specs, tuple):
-            first_output_spec = spec.output_specs[0]
-            # output_specs tuple can contain None for non-tensor outputs
-            # (e.g. SDPA's philox_seed/offset, layer norm backward with
-            # output_mask). The validator doesn't support mixed outputs.
-            if first_output_spec is None:
-                raise NotImplementedError(
-                    f"Strategy has None in output_specs, indicating mixed "
-                    f"tensor/non-tensor outputs which the validator does not "
-                    f"support. output_specs: {spec.output_specs}"
-                )
-            output_plc = first_output_spec.placements[0]
+            output_plcs: list[Placement] = []
+            for out_spec in spec.output_specs:
+                if out_spec is None:
+                    raise NotImplementedError(
+                        f"Strategy has None in output_specs, indicating mixed "
+                        f"tensor/non-tensor outputs which the validator does not "
+                        f"support. output_specs: {spec.output_specs}"
+                    )
+                output_plcs.append(out_spec.placements[0])
         else:
-            output_plc = spec.output_spec.placements[0]
+            # Single DTensorSpec — the propagator duplicates it for all
+            # outputs of multi-output ops, so we do the same here.
+            output_plcs = [spec.output_spec.placements[0]] * len(output_shapes)
         input_plcs = tuple(s.placements[0] for s in spec.input_specs)
-        rule_key = (tuple(str(p) for p in input_plcs), str(output_plc))
-        normalized_rule = normalize_combo_key(rule_key, input_shapes, output_shape)
+        rule_key: ComboKey = (
+            tuple(str(p) for p in input_plcs),
+            tuple(str(p) for p in output_plcs),
+        )
+        normalized_rule = normalize_combo_key(rule_key, input_shapes, output_shapes)
         if not is_fully_replicated(
             tuple(parse_placement(p) or Replicate() for p in normalized_rule[0])
         ):
@@ -981,7 +956,7 @@ def _query_dtensor_rules(
     captured_args: tuple[Any, ...],
     captured_kwargs: dict[str, Any],
     input_shapes: tuple[tuple[int, ...], ...],
-    output_shape: tuple[int, ...],
+    output_shapes: tuple[tuple[int, ...], ...],
     world_size: int,
     verbose: bool,
 ) -> set[ComboKey]:
@@ -995,7 +970,7 @@ def _query_dtensor_rules(
     if not aten_op:
         return set()
 
-    num_tensors = len(tensors)
+    n_outputs = len(output_shapes)
     non_tensor_kwargs = {
         k: v for k, v in captured_kwargs.items() if not isinstance(v, torch.Tensor)
     }
@@ -1008,15 +983,17 @@ def _query_dtensor_rules(
         )
         if strategy_result:
             for combo in strategy_result:
-                if len(combo) >= num_tensors + 1:
+                if len(combo) >= len(tensors) + 1:
                     output_plc = combo[0]
-                    input_plcs = tuple(combo[1 : num_tensors + 1])
-                    rule_key = (
+                    input_plcs = tuple(combo[1 : len(tensors) + 1])
+                    # single_dim_strategy returns one output placement;
+                    # duplicate for all outputs (matches propagator behavior)
+                    rule_key: ComboKey = (
                         tuple(str(p) for p in input_plcs),
-                        str(output_plc),
+                        tuple(str(output_plc) for _ in range(n_outputs)),
                     )
                     normalized_rule = normalize_combo_key(
-                        rule_key, input_shapes, output_shape
+                        rule_key, input_shapes, output_shapes
                     )
                     if not is_fully_replicated(
                         tuple(
@@ -1055,7 +1032,7 @@ def _query_dtensor_rules(
             strategy_func = propagator.op_strategy_funcs[aten_op]
             output_strategy = strategy_func(op_schema)
             rules |= _extract_rules_from_op_strategy(
-                output_strategy, input_shapes, output_shape
+                output_strategy, input_shapes, output_shapes
             )
         except Exception as e:
             if verbose:
@@ -1095,7 +1072,7 @@ def _query_dtensor_rules(
                 )
                 if output_strategy is not None:
                     rules |= _extract_rules_from_op_strategy(
-                        output_strategy, input_shapes, output_shape
+                        output_strategy, input_shapes, output_shapes
                     )
             except Exception as e:
                 if verbose:
@@ -1109,14 +1086,14 @@ def _validate_with_mitigations(
     sample: SampleInput,
     tensors: list[tuple[str, torch.Tensor]],
     input_placements: tuple[Placement, ...],
-    output_placement: Placement,
+    output_placements: tuple[Placement, ...],
     ground_truth: torch.Tensor | list[torch.Tensor],
     world_size: int,
     mesh: DeviceMesh,
     mitigations: _FalsePositiveMitigations,
 ) -> bool:
     """Validate a combination, including false positive mitigation re-checks."""
-    combo = PlacementCombination(input_placements, output_placement)
+    combo: PlacementCombination = (input_placements, output_placements)
     is_valid, _ = validate_combination(
         op, sample, tensors, combo, ground_truth, world_size, mesh
     )
@@ -1127,8 +1104,8 @@ def _validate_with_mitigations(
     # to catch index-returning ops (argmin/argmax) where the result
     # coincidentally matches because the dominant value happens to land on
     # a position where both mask orientations preserve argmin/argmax.
-    if is_valid and has_any_partial(input_placements, output_placement):
-        flipped_valid, _ = validate_combination(
+    if is_valid and has_any_partial(input_placements, output_placements):
+        is_valid, _ = validate_combination(
             op,
             sample,
             tensors,
@@ -1138,68 +1115,56 @@ def _validate_with_mitigations(
             mesh,
             mask_shift=1,
         )
-        is_valid = is_valid and flipped_valid
 
     if (
         is_valid
         and mitigations.negated_sample
-        and has_pmin_pmax(input_placements, output_placement)
+        and has_pmin_pmax(input_placements, output_placements)
     ):
-        if mitigations.negated_tensors is None:
-            raise AssertionError("negated_tensors is None")
-        if mitigations.negated_ground_truth is None:
-            raise AssertionError("negated_ground_truth is None")
-        negated_combo = PlacementCombination(input_placements, output_placement)
-        negated_valid, _ = validate_combination(
+        assert mitigations.negated_tensors is not None
+        assert mitigations.negated_ground_truth is not None
+        is_valid, _ = validate_combination(
             op,
             mitigations.negated_sample,
             mitigations.negated_tensors,
-            negated_combo,
+            combo,
             mitigations.negated_ground_truth,
             world_size,
             mesh,
         )
-        is_valid = is_valid and negated_valid
 
     if (
         is_valid
         and mitigations.non_rounded_sample
-        and has_any_partial(input_placements, output_placement)
+        and has_any_partial(input_placements, output_placements)
     ):
-        if mitigations.non_rounded_ground_truth is None:
-            raise AssertionError("non_rounded_ground_truth is None")
-        non_rounded_combo = PlacementCombination(input_placements, output_placement)
-        non_rounded_valid, _ = validate_combination(
+        assert mitigations.non_rounded_ground_truth is not None
+        is_valid, _ = validate_combination(
             op,
             mitigations.non_rounded_sample,
             tensors,
-            non_rounded_combo,
+            combo,
             mitigations.non_rounded_ground_truth,
             world_size,
             mesh,
         )
-        is_valid = is_valid and non_rounded_valid
 
     if (
         is_valid
         and mitigations.non_rounded_negated_sample
-        and has_pmin_pmax(input_placements, output_placement)
+        and has_pmin_pmax(input_placements, output_placements)
     ):
-        if mitigations.non_rounded_negated_tensors is None:
-            raise AssertionError("non_rounded_negated_tensors is None")
-        if mitigations.non_rounded_negated_ground_truth is None:
-            raise AssertionError("non_rounded_negated_ground_truth is None")
-        nr_negated_combo = PlacementCombination(input_placements, output_placement)
-        nr_negated_valid, _ = validate_combination(
+        assert mitigations.non_rounded_negated_tensors is not None
+        assert mitigations.non_rounded_negated_ground_truth is not None
+        is_valid, _ = validate_combination(
             op,
             mitigations.non_rounded_negated_sample,
             mitigations.non_rounded_negated_tensors,
-            nr_negated_combo,
+            combo,
             mitigations.non_rounded_negated_ground_truth,
             world_size,
             mesh,
         )
-        is_valid = is_valid and nr_negated_valid
 
     return is_valid
 
@@ -1207,22 +1172,21 @@ def _validate_with_mitigations(
 def _assert_keys_normalized(
     keys: set[ComboKey],
     input_shapes: tuple[tuple[int, ...], ...],
-    output_shape: tuple[int, ...],
+    output_shapes: tuple[tuple[int, ...], ...],
 ) -> None:
     """Assert all combo keys have trivial shards already normalized to Replicate."""
     for key in keys:
-        if key != normalize_combo_key(key, input_shapes, output_shape):
-            raise AssertionError(
-                f"Key {key} contains un-normalized trivial shards; "
-                f"call normalize_combo_key before _compare_rules"
-            )
+        assert key == normalize_combo_key(key, input_shapes, output_shapes), (
+            f"Key {key} contains un-normalized trivial shards; "
+            f"call normalize_combo_key before _compare_rules"
+        )
 
 
 def _compare_rules(
     ground_truth_valid: set[ComboKey],
     dtensor_rules: set[ComboKey],
     input_shapes: tuple[tuple[int, ...], ...],
-    output_shape: tuple[int, ...],
+    output_shapes: tuple[tuple[int, ...], ...],
     sample_idx: int,
     scalar_args: tuple[Any, ...],
     scalar_kwargs: dict[str, Any],
@@ -1235,8 +1199,8 @@ def _compare_rules(
     if not dtensor_rules:
         return
 
-    _assert_keys_normalized(ground_truth_valid, input_shapes, output_shape)
-    _assert_keys_normalized(dtensor_rules, input_shapes, output_shape)
+    _assert_keys_normalized(ground_truth_valid, input_shapes, output_shapes)
+    _assert_keys_normalized(dtensor_rules, input_shapes, output_shapes)
 
     op_str = str(aten_op)
     for combo_key in ground_truth_valid:
@@ -1249,7 +1213,7 @@ def _compare_rules(
             stats.false_negatives.append(
                 Discrepancy(
                     input_placements=combo_key[0],
-                    output_placement=combo_key[1],
+                    output_placements=combo_key[1],
                     sample_idx=sample_idx,
                     input_shapes=input_shapes,
                     discrepancy_type="false_negative",
@@ -1266,7 +1230,7 @@ def _compare_rules(
             stats.false_positives.append(
                 Discrepancy(
                     input_placements=combo_key[0],
-                    output_placement=combo_key[1],
+                    output_placements=combo_key[1],
                     sample_idx=sample_idx,
                     input_shapes=input_shapes,
                     discrepancy_type="false_positive",
@@ -1324,14 +1288,15 @@ def _print_discrepancy_section(
     )
     for d in discrepancies:
         op_str = str(d.aten_op)
-        key = (d.input_placements, d.output_placement)
+        key = (d.input_placements, d.output_placements)
         by_op[op_str][key].append(d)
 
     for op_str in sorted(by_op.keys()):
         print(f"\n  [{op_str}]")
         for (inp, out), discs in sorted(by_op[op_str].items(), key=str):
             inp_str = ", ".join(inp)
-            print(f"    {inp_str} -> {out}")
+            out_str = out[0] if len(out) == 1 else "(" + ", ".join(out) + ")"
+            print(f"    {inp_str} -> {out_str}")
             if show_repro:
                 limit = len(discs) if show_repro < 0 else show_repro
                 for d in discs[:limit]:
@@ -1352,11 +1317,11 @@ def _print_comparison_summary(
     fp_by_op: dict[str, set[ComboKey]] = defaultdict(set)
     for d in stats.false_positives:
         op_str = str(d.aten_op)
-        fp_by_op[op_str].add((d.input_placements, d.output_placement))
+        fp_by_op[op_str].add((d.input_placements, d.output_placements))
     fn_by_op: dict[str, set[ComboKey]] = defaultdict(set)
     for d in stats.false_negatives:
         op_str = str(d.aten_op)
-        fn_by_op[op_str].add((d.input_placements, d.output_placement))
+        fn_by_op[op_str].add((d.input_placements, d.output_placements))
 
     all_ops = sorted(set(stats.true_positives_by_op) | set(fp_by_op) | set(fn_by_op))
     if len(all_ops) > 1:
@@ -1508,7 +1473,9 @@ def compare_operator(
                 continue
 
             input_shapes = tuple(t.shape for _, t in tensors)
-            output_shape = tuple(first_gt.shape)
+            gt_list = ground_truth if isinstance(ground_truth, list) else [ground_truth]
+            output_shapes = tuple(tuple(gt.shape) for gt in gt_list)
+            n_outputs = len(gt_list)
 
             scalar_args = tuple(
                 a for a in sample.args if not isinstance(a, torch.Tensor)
@@ -1525,6 +1492,8 @@ def compare_operator(
                 get_1d_input_placements_for_tensor(t, include_partial=True)
                 for _, t in tensors
             ]
+            # Use first output for enumerating placement options (DTensor applies
+            # the same placement to all outputs of multi-output ops)
             output_placement_options = get_1d_output_placements_for_tensor(first_gt)
 
             aten_op, captured_args, captured_kwargs = get_aten_op_for_sample(
@@ -1537,7 +1506,7 @@ def compare_operator(
                 captured_args,
                 captured_kwargs,
                 input_shapes,
-                output_shape,
+                output_shapes,
                 world_size,
                 verbose,
             )
@@ -1551,7 +1520,7 @@ def compare_operator(
                 if incorrect_only:
                     combinations_to_test = []
                     for combo_key in dtensor_rules:
-                        input_plc_strs, output_plc_str = combo_key
+                        input_plc_strs, output_plc_strs = combo_key
                         input_plcs_list: list[Placement] = []
                         all_valid = True
                         for s in input_plc_strs:
@@ -1560,11 +1529,21 @@ def compare_operator(
                                 all_valid = False
                                 break
                             input_plcs_list.append(p)
-                        output_plc = parse_placement(output_plc_str)
-                        if not all_valid or output_plc is None:
+                        output_plcs_list: list[Placement] = []
+                        for s in output_plc_strs:
+                            p = parse_placement(s)
+                            if p is None:
+                                all_valid = False
+                                break
+                            output_plcs_list.append(p)
+                        if not all_valid:
                             continue
                         combinations_to_test.append(
-                            (tuple(input_plcs_list), output_plc, combo_key)
+                            (
+                                tuple(input_plcs_list),
+                                tuple(output_plcs_list),
+                                combo_key,
+                            )
                         )
                 else:
                     combinations_to_test = []
@@ -1572,17 +1551,22 @@ def compare_operator(
                         if is_fully_replicated(input_placements):
                             continue
                         for output_placement in output_placement_options:
+                            # Apply same placement to all outputs (matches
+                            # DTensor propagator behavior for multi-output ops)
+                            output_placements = tuple(
+                                output_placement for _ in range(n_outputs)
+                            )
                             combo_key = (
                                 tuple(str(p) for p in input_placements),
-                                str(output_placement),
+                                tuple(str(p) for p in output_placements),
                             )
                             combinations_to_test.append(
-                                (input_placements, output_placement, combo_key)
+                                (input_placements, output_placements, combo_key)
                             )
 
                 for (
                     input_placements,
-                    output_placement,
+                    output_placements,
                     combo_key,
                 ) in combinations_to_test:
                     total_combinations += 1
@@ -1591,7 +1575,7 @@ def compare_operator(
                         sample,
                         tensors,
                         input_placements,
-                        output_placement,
+                        output_placements,
                         ground_truth,
                         world_size,
                         mesh,
@@ -1600,7 +1584,7 @@ def compare_operator(
 
                     if is_valid:
                         normalized_key = normalize_combo_key(
-                            combo_key, input_shapes, output_shape
+                            combo_key, input_shapes, output_shapes
                         )
                         if not is_fully_replicated(
                             tuple(
@@ -1614,7 +1598,7 @@ def compare_operator(
                 ground_truth_valid,
                 dtensor_rules,
                 input_shapes,
-                output_shape,
+                output_shapes,
                 sample_idx,
                 scalar_args,
                 scalar_kwargs,
@@ -1843,11 +1827,11 @@ if __name__ == "__main__":
 
             for name, stats, elapsed in formatted_results:
                 fp_rules = {
-                    (d.input_placements, d.output_placement)
+                    (d.input_placements, d.output_placements)
                     for d in stats.false_positives
                 }
                 fn_rules = {
-                    (d.input_placements, d.output_placement)
+                    (d.input_placements, d.output_placements)
                     for d in stats.false_negatives
                 }
                 n_fp = len(fp_rules)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* #176362
* __->__ #176361

For multi-output ops like aten.min.dim (returns values + indices), the
tool now tracks each output's placement separately instead of using a
single output placement for all outputs. This makes the display explicit:
`S(1) -> (P(min), P(min))` shows both outputs get P(min).

ComboKey changes from (inputs, single_output_str) to (inputs,
output_strs_tuple). PlacementCombination is simplified to a plain type
alias. normalize_combo_key normalizes each output against its own shape.

Pull request resolved: https://github.com/pytorch/pytorch/pull/175893