### PR TITLE
[dynamo] Remove "inductor:mode" support from GraphBackendRouter

### DIFF
--- a/test/dynamo/test_debug_utils.py
+++ b/test/dynamo/test_debug_utils.py
@@ -333,18 +333,6 @@ class TestBackendOverrideIntegration(TestCase):
         result = self._run_with_override(device, "0:aot_eager;>=2:inductor")
         self.assertEqual(result, ["aot_eager", "inductor", "inductor"])
 
-    def test_inductor_with_mode(self, device):
-        result = self._run_with_override(device, ">=0:inductor:reduce-overhead")
-        self.assertEqual(
-            result,
-            [
-                "inductor:reduce-overhead",
-                "inductor:reduce-overhead",
-                "inductor:reduce-overhead",
-                "inductor:reduce-overhead",
-            ],
-        )
-
     def test_override_with_backward(self, device):
         """Verify that backend override works when backward compilation occurs."""
         from torch._dynamo.graph_id_filter import (
@@ -463,8 +451,8 @@ class TestInductorConfigOverrideIntegration(TestCase):
         Test combining backend override with config override.
 
         Scenario: Default backend is eager, but override all graphs to use
-        inductor:reduce-overhead (cudagraphs enabled), and additionally
-        override graph 1 to use cudagraph_skip_dynamic_graphs=False.
+        inductor with cudagraphs enabled, and additionally override graph 1
+        to use cudagraph_skip_dynamic_graphs=False.
         """
         from torch._dynamo.graph_id_filter import (
             _create_backend_router,
@@ -494,35 +482,21 @@ class TestInductorConfigOverrideIntegration(TestCase):
             configs_applied.append(config_patches)
             return original_wrap(compiler_fn, config_patches)
 
-        # Build backend tracking map from config
-        backend_override = ">=0:inductor:reduce-overhead"
-        backend_str_map: dict[int, str] = {}
-        from torch._dynamo.graph_id_filter import GraphIdFilter
-
-        for rule_str in backend_override.split(";"):
-            if ":" not in rule_str:
-                continue
-            colon_idx = rule_str.find(":")
-            filter_str = rule_str[:colon_idx].strip()
-            backend_str = rule_str[colon_idx + 1 :].strip()
-            gf = GraphIdFilter(filter_str)
-            for gid in range(10):
-                if gid in gf and gid not in backend_str_map:
-                    backend_str_map[gid] = backend_str
-
+        backend_override = ">=0:inductor"
         from torch._dynamo.graph_id_filter import get_backend_override_for_compile_id
 
         original_get_backend = get_backend_override_for_compile_id
 
         def tracking_get_backend(compile_id, config_str):
             result = original_get_backend(compile_id, config_str)
-            if result is not None and compile_id.frame_id in backend_str_map:
-                backends_used.append(backend_str_map[compile_id.frame_id])
+            if result is not None:
+                backends_used.append("inductor")
             return result
 
         # Use both overrides:
-        # - Backend: all graphs use inductor:reduce-overhead
-        # - Config: graph 1 uses cudagraph_skip_dynamic_graphs=False
+        # - Backend: all graphs use inductor
+        # - Config: all graphs enable cudagraphs, graph 1 also disables
+        #   cudagraph_skip_dynamic_graphs
         with (
             patch.object(
                 torch._dynamo.config,
@@ -532,7 +506,7 @@ class TestInductorConfigOverrideIntegration(TestCase):
             patch.object(
                 torch._dynamo.config,
                 "debug_inductor_config_override",
-                "1:triton.cudagraph_skip_dynamic_graphs=False",
+                "1:triton.cudagraph_skip_dynamic_graphs=False;>=0:triton.cudagraphs=True",
             ),
             patch(
                 "torch._dynamo.output_graph.get_backend_override_for_compile_id",
@@ -544,19 +518,17 @@ class TestInductorConfigOverrideIntegration(TestCase):
             compiled_fn(torch.randn(10, device=device))
 
         self.assertEqual(len(backends_used), 3)
-        self.assertEqual(
-            backends_used,
-            [
-                "inductor:reduce-overhead",
-                "inductor:reduce-overhead",
-                "inductor:reduce-overhead",
-            ],
-        )
+        self.assertEqual(backends_used, ["inductor", "inductor", "inductor"])
 
-        self.assertEqual(len(configs_applied), 1)
+        # Graph 0 and 2 get cudagraphs=True, graph 1 gets
+        # cudagraph_skip_dynamic_graphs=False (first matching rule wins for
+        # config router)
+        self.assertEqual(len(configs_applied), 3)
+        self.assertEqual(configs_applied[0], {"triton.cudagraphs": True})
         self.assertEqual(
-            configs_applied[0], {"triton.cudagraph_skip_dynamic_graphs": False}
+            configs_applied[1], {"triton.cudagraph_skip_dynamic_graphs": False}
         )
+        self.assertEqual(configs_applied[2], {"triton.cudagraphs": True})
 
     def test_multiple_config_overrides_with_backend(self, device):
         """

--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -44,7 +44,7 @@ verify_correctness = False
 #   - Individual IDs: "0,5,10"
 #   - Ranges: "10-20" (inclusive)
 #   - Comparisons: ">10", ">=10", "<5", "<=5"
-# Backends can be: "eager", "aot_eager", "inductor", "inductor:reduce-overhead", etc.
+# Backends can be: "eager", "aot_eager", "inductor", etc.
 # Examples:
 #   ">10:eager"                    - Run graphs with frame_id > 10 in dynamo eager backend
 #   "<=5:aot_eager;>5:inductor"    - First 6 graphs use aot_eager, rest use inductor

--- a/torch/_dynamo/graph_id_filter.py
+++ b/torch/_dynamo/graph_id_filter.py
@@ -16,11 +16,6 @@ if TYPE_CHECKING:
 
 log = logging.getLogger(__name__)
 
-# Valid modes for inductor backend
-_INDUCTOR_MODES = frozenset(
-    {"default", "reduce-overhead", "max-autotune", "max-autotune-no-cudagraphs"}
-)
-
 
 class GraphIdFilter:
     """
@@ -196,37 +191,19 @@ class GraphBackendRouter(_GraphRouterBase[Any]):
         ">10:aot_eager"             - IDs > 10 use aot_eager
         "<=3:eager;4-10:aot_eager"  - IDs 0-3 use eager, 4-10 use aot_eager
 
-    Special backend values:
-        "eager"                     - Run in eager mode (no compilation)
-        "aot_eager"                 - AOT Autograd with eager execution
-        "aot_eager_decomp_partition" - AOT Autograd with partitioner and decomps
-        "inductor"                  - Default inductor backend
-        "inductor:reduce-overhead"  - Inductor with reduce-overhead mode (cudagraphs)
-        "inductor:max-autotune"     - Inductor with max-autotune mode
+    Supported backends include "eager", "aot_eager", "aot_eager_decomp_partition",
+    "inductor", and any other registered backend.
     """
 
     def __init__(self, config_str: str) -> None:
         super().__init__(config_str, "backend")
 
     def _parse_value_str(self, value_str: str) -> Any | None:
-        """Look up a backend, supporting 'backend:mode' format for inductor."""
-        import torch
-
+        """Look up a backend by name."""
         from .backends.registry import lookup_backend
         from .eval_frame import cached_backends
 
-        backend: Any = None
-        if ":" in value_str:
-            parts = value_str.split(":", 1)
-            backend_name, mode = parts[0], parts[1]
-
-            if backend_name == "inductor" and mode in _INDUCTOR_MODES:
-                backend = torch._TorchCompileInductorWrapper(
-                    mode=mode, options=None, dynamic=None
-                )
-
-        if backend is None:
-            backend = lookup_backend(value_str)
+        backend = lookup_backend(value_str)
 
         # Register the backend so its reset() is called during torch._dynamo.reset()
         assert backend is not None, "Invalid override backend: " + value_str


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #176364
* #176305
* __->__ #176363

Inductor modes like reduce-overhead and max-autotune can be expressed as
inductor config overrides (e.g. triton.cudagraphs=True), making the
special "inductor:mode" syntax in debug_backend_override unnecessary.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @mlazos

Differential Revision: [D95146778](https://our.internmc.facebook.com/intern/diff/D95146778)