### PR TITLE
[dynamo] Aggregate all matching rules in GraphConfigRouter

### DIFF
--- a/test/dynamo/test_debug_utils.py
+++ b/test/dynamo/test_debug_utils.py
@@ -438,6 +438,36 @@ class TestInductorConfigOverrideIntegration(TestCase):
         self.assertEqual(config["str_opt"], "hello")
         self.assertIsNone(config["none_opt"])
 
+    def test_config_router_aggregation(self, device):
+        from torch._dynamo.graph_id_filter import GraphConfigRouter
+
+        router = GraphConfigRouter("0:a=1;>=0:b=2")
+        # Graph 0 matches both rules, configs are merged
+        self.assertEqual(router.get_value_for_graph(0), {"a": 1, "b": 2})
+        # Graph 1 matches only the second rule
+        self.assertEqual(router.get_value_for_graph(1), {"b": 2})
+
+    def test_config_router_conflict_raises(self, device):
+        from torch._dynamo.graph_id_filter import GraphConfigRouter
+
+        with self.assertRaisesRegex(ValueError, "Conflicting config override"):
+            GraphConfigRouter("0:a=1;>=0:a=2")
+
+    def test_config_router_same_value_no_conflict(self, device):
+        from torch._dynamo.graph_id_filter import GraphConfigRouter
+
+        router = GraphConfigRouter("0:a=1;>=0:a=1")
+        self.assertEqual(router.get_value_for_graph(0), {"a": 1})
+        self.assertEqual(router.get_value_for_graph(1), {"a": 1})
+
+    def test_config_router_aggregation_multiple_rules(self, device):
+        from torch._dynamo.graph_id_filter import GraphConfigRouter
+
+        router = GraphConfigRouter("0:a=1;1:b=2;>=0:c=3")
+        self.assertEqual(router.get_value_for_graph(0), {"a": 1, "c": 3})
+        self.assertEqual(router.get_value_for_graph(1), {"b": 2, "c": 3})
+        self.assertEqual(router.get_value_for_graph(2), {"c": 3})
+
     def test_get_inductor_config_override_empty(self, device):
         from torch._dynamo.graph_id_filter import (
             get_inductor_config_override_for_compile_id,
@@ -520,13 +550,15 @@ class TestInductorConfigOverrideIntegration(TestCase):
         self.assertEqual(len(backends_used), 3)
         self.assertEqual(backends_used, ["inductor", "inductor", "inductor"])
 
-        # Graph 0 and 2 get cudagraphs=True, graph 1 gets
-        # cudagraph_skip_dynamic_graphs=False (first matching rule wins for
-        # config router)
+        # All matching rules are aggregated. Graph 1 matches both rules.
         self.assertEqual(len(configs_applied), 3)
         self.assertEqual(configs_applied[0], {"triton.cudagraphs": True})
         self.assertEqual(
-            configs_applied[1], {"triton.cudagraph_skip_dynamic_graphs": False}
+            configs_applied[1],
+            {
+                "triton.cudagraph_skip_dynamic_graphs": False,
+                "triton.cudagraphs": True,
+            },
         )
         self.assertEqual(configs_applied[2], {"triton.cudagraphs": True})
 

--- a/torch/_dynamo/graph_id_filter.py
+++ b/torch/_dynamo/graph_id_filter.py
@@ -223,12 +223,17 @@ class GraphConfigRouter(_GraphRouterBase[dict[str, Any]]):
     The router parses a configuration string with rules in the format:
         "filter1:config1;filter2:config2;..."
 
-    Rules are evaluated in order, and the first matching rule wins.
+    All matching rules are aggregated: configs from all matching rules are merged
+    into a single dict. Conflicting keys (same key, different value) raise an error.
     Config format is "key=value" or "key1=value1,key2=value2" for multiple settings.
 
     Examples:
         "0-5:triton.cudagraph_skip_dynamic_graphs=False"
         ">10:triton.cudagraphs=False,triton.cudagraph_trees=False"
+
+        With "0:a=1;>=0:b=2", graph 0 gets {"a": 1, "b": 2} (both rules match).
+        With "0:a=1;>=0:a=2", graph 0 raises an error (conflicting values for "a").
+        With "0:a=1;>=0:a=1", graph 0 gets {"a": 1} (same value is not a conflict).
     """
 
     def __init__(self, config_str: str) -> None:
@@ -250,6 +255,20 @@ class GraphConfigRouter(_GraphRouterBase[dict[str, Any]]):
             return int(value_str)
         except ValueError:
             return value_str
+
+    def _match_rules(self, graph_id: int) -> dict[str, Any] | None:
+        """Aggregate configs from all matching rules. Conflicts raise an error."""
+        result: dict[str, Any] = {}
+        for f, value in self._rules:
+            if graph_id in f:
+                for k, v in value.items():
+                    if k in result and result[k] != v:
+                        raise ValueError(
+                            f"Conflicting config override for graph {graph_id}: "
+                            f"key '{k}' has value {result[k]!r} and {v!r}"
+                        )
+                    result[k] = v
+        return result if result else None
 
     def _parse_value_str(self, value_str: str) -> dict[str, Any] | None:
         """Parse a config string like 'key1=val1,key2=val2' into a dict."""


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #176364
* #176305
* #176363

Instead of first-match-wins, GraphConfigRouter now merges configs from
all matching rules for a given graph ID. Conflicting keys (same key,
different value) raise a ValueError. Same key with same value is allowed.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @mlazos

Differential Revision: [D95146777](https://our.internmc.facebook.com/intern/diff/D95146777)