### PR TITLE
Temporarily disable fbscribelogger due to graph API errors

### DIFF
--- a/torch/_logging/scribe.py
+++ b/torch/_logging/scribe.py
@@ -3,6 +3,8 @@ from typing import TypeAlias, Union
 
 
 try:
+    # temporarily disabled due to graph API 400 errors, re-enable once fixed
+    raise ImportError("fbscribelogger temporarily disabled")
     from fbscribelogger import (  # type: ignore[import-untyped, import-not-found]
         make_scribe_logger,
     )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #176377

The fbscribelogger scribe endpoint is returning 400 Bad Request
from the graph API ("Application does not have the capability to
make this API call"). Disable it by forcing the ImportError fallback
path so open_source_signpost becomes a no-op until the API issue
is resolved.

Authored with Claude.