### PR TITLE
Fix test_fake_device_property_normalization failure on XPU

### DIFF
--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -540,7 +540,7 @@ class FakeTensorConverter:
 @functools.cache
 def init_gpu_context(device: torch.device) -> None:
     # Backward will error with cuda Fake Tensors if no cuda tensors have been initialized first
-    if torch.cuda.is_available() or torch.xpu.is_available():
+    if torch.accelerator.current_accelerator(True) == device.type:
         (
             torch.empty(1, device=device)
             if torch.version.hip is None


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #176409

# Motivation
This PR aims to fix https://github.com/pytorch/pytorch/issues/176125.

The root cause is the following code would call [init_gpu_context](https://github.com/pytorch/pytorch/blob/14f828cb8c2ac10e66497b3bfe32ffe557753d5f/torch/_subclasses/fake_tensor.py#L543), on XPU machine, `torch.cuda.is_available() or torch.xpu.is_available()` returns `True` but the `device.type` maybe `cuda`, resulting in the failure on XPU.
https://github.com/pytorch/pytorch/blob/14f828cb8c2ac10e66497b3bfe32ffe557753d5f/test/test_fake_tensor.py#L203-L205
see https://github.com/pytorch/pytorch/blob/14f828cb8c2ac10e66497b3bfe32ffe557753d5f/torch/_subclasses/fake_tensor.py#L540-L548

# Solution
use `if torch.accelerator.current_accelerator(True) == device.type:` to ensure:
1. the current accelerator is available;
2. the current accelerator matches the `device.type`;

# Additional Context
Introduced by https://github.com/pytorch/pytorch/pull/175669