### PR TITLE
[Inductor] Normalize example inputs in register replacement

### DIFF
--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -2150,6 +2150,42 @@ class TestPatternMatcher(TestCase):
         self.assertEqual(result, x * 3)
         self.assertEqual(count, 1)
 
+    def test_register_replacement_single_tensor_input(self):
+        def pattern(x):
+            return x + 1
+
+        def replacement(x):
+            return x - 1
+
+        my_patterns = PatternMatcherPass()
+
+        # Single tensor (not list/tuple) to exercise normalization logic
+        example_input = torch.randn(4, 4, device=GPU_TYPE, requires_grad=True)
+        register_replacement(pattern, replacement, example_input, fwd_only, my_patterns)
+
+        count = 0
+
+        def custom_pass(graph: torch.fx.Graph) -> torch.fx.Graph:
+            nonlocal count
+            count = my_patterns.apply(graph)
+            graph.eliminate_dead_code()
+            return graph
+
+        def fn(x):
+            return x + 1
+
+        x = torch.randn(4, 4, device=GPU_TYPE, requires_grad=True)
+
+        compiled_fn = torch.compile(
+            fn,
+            fullgraph=True,
+            options={"post_grad_custom_post_pass": custom_pass},
+        )
+
+        result = compiled_fn(x)
+        self.assertEqual(count, 1)
+        torch.testing.assert_close(result, x - 1)
+
 
 class TestPatternMatcherLogging(LoggingTestCase):
     device_type = GPU_TYPE

--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -2168,7 +2168,6 @@ class TestPatternMatcher(TestCase):
         def custom_pass(graph: torch.fx.Graph) -> torch.fx.Graph:
             nonlocal count
             count = my_patterns.apply(graph)
-            graph.eliminate_dead_code()
             return graph
 
         def fn(x):

--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -2159,31 +2159,15 @@ class TestPatternMatcher(TestCase):
 
         my_patterns = PatternMatcherPass()
 
-        # Single tensor (not list/tuple) to exercise normalization logic
+        # Single tensor should fail fast instead of reaching tracing logic.
         example_input = torch.randn(4, 4, device=GPU_TYPE, requires_grad=True)
-        register_replacement(pattern, replacement, example_input, fwd_only, my_patterns)
-
-        count = 0
-
-        def custom_pass(graph: torch.fx.Graph) -> torch.fx.Graph:
-            nonlocal count
-            count = my_patterns.apply(graph)
-            return graph
-
-        def fn(x):
-            return x + 1
-
-        x = torch.randn(4, 4, device=GPU_TYPE, requires_grad=True)
-
-        compiled_fn = torch.compile(
-            fn,
-            fullgraph=True,
-            options={"post_grad_custom_post_pass": custom_pass},
-        )
-
-        result = compiled_fn(x)
-        self.assertEqual(count, 1)
-        torch.testing.assert_close(result, x - 1)
+        with self.assertRaisesRegex(
+            TypeError,
+            f"example_inputs must be a list or tuple, got {type(example_input)}",
+        ):
+            register_replacement(
+                pattern, replacement, example_input, fwd_only, my_patterns
+            )
 
 
 class TestPatternMatcherLogging(LoggingTestCase):

--- a/torch/_inductor/pattern_matcher.py
+++ b/torch/_inductor/pattern_matcher.py
@@ -1666,6 +1666,8 @@ def register_replacement(
 
     # TODO: Revisit the functionalize_rng_ops for lowmem dropout
     with functorch_config.patch(functionalize_rng_ops=False):
+        if not isinstance(example_inputs, (list, tuple)):
+            example_inputs = (example_inputs,)
         requires_grad: list[bool] = [
             isinstance(x, torch.Tensor) and x.requires_grad for x in example_inputs
         ]

--- a/torch/_inductor/pattern_matcher.py
+++ b/torch/_inductor/pattern_matcher.py
@@ -1509,7 +1509,7 @@ def register_replacement(
     if inspect.ismethod(replace_fn):
         replace_argnames = [*inspect.signature(replace_fn).parameters.keys()]
         replace_fn = _wrap_bound_method(replace_fn, replace_argnames)
-    
+
     if not isinstance(example_inputs, (list, tuple)):
         raise TypeError(
             f"example_inputs must be a list or tuple, got {type(example_inputs)}"

--- a/torch/_inductor/pattern_matcher.py
+++ b/torch/_inductor/pattern_matcher.py
@@ -1477,7 +1477,7 @@ def check_and_add_duplicate_pattern(
 def register_replacement(
     search_fn: SearchFn,
     replace_fn: ReplaceFn,
-    example_inputs: Iterable[Any],
+    example_inputs: list[Any] | tuple[Any, ...],
     trace_fn: TraceFn,
     pass_dicts: _PassDictsType | Sequence[_PassDictsType],
     extra_check: Callable[[Match], bool] = _return_true,
@@ -1509,6 +1509,11 @@ def register_replacement(
     if inspect.ismethod(replace_fn):
         replace_argnames = [*inspect.signature(replace_fn).parameters.keys()]
         replace_fn = _wrap_bound_method(replace_fn, replace_argnames)
+    
+    if not isinstance(example_inputs, (list, tuple)):
+        raise TypeError(
+            f"example_inputs must be a list or tuple, got {type(example_inputs)}"
+        )
 
     def check_fn(match: Match) -> bool:
         """
@@ -1666,8 +1671,6 @@ def register_replacement(
 
     # TODO: Revisit the functionalize_rng_ops for lowmem dropout
     with functorch_config.patch(functionalize_rng_ops=False):
-        if not isinstance(example_inputs, (list, tuple)):
-            example_inputs = (example_inputs,)
         requires_grad: list[bool] = [
             isinstance(x, torch.Tensor) and x.requires_grad for x in example_inputs
         ]


### PR DESCRIPTION
When example_inputs is a single tensor, iterating over it in

`[isinstance(x, torch.Tensor) and x.requires_grad for x in example_inputs]`

iterates along the tensor’s first dimension rather than over input arguments, producing multiple booleans instead of one and leads to the error below.
`Traceback (most recent call last):
  File "/mnt/workspace/miniforge3/envs/infer/lib/python3.10/site-packages/torch/_inductor/pattern_matcher.py", line 1870, in apply
    if is_match(m) and entry.extra_check(m):
  File "/mnt/workspace/miniforge3/envs/infer/lib/python3.10/site-packages/torch/_inductor/pattern_matcher.py", line 1335, in check_fn
    if isinstance(args[i], torch.Tensor):
IndexError: list index out of range
`

This PR normalizes a single tensor example input by wrapping it in a tuple before the iteration.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @eellison @cyyever