### PR TITLE
[inductor][heuristics] Update total tiling score when it is zero

### DIFF
--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -3314,6 +3314,7 @@ def match_target_block_product(
         # just assume even score with no minimum block size
         min_block_size = 1
         tiling_scores = dict.fromkeys(tiling_scores.keys(), target_block_product)
+        total_score = target_block_product * len(tiling_scores)
 
     # First, give each coalescing dimension at least min_block_size
     block_sizes = {}


### PR DESCRIPTION
- When the total score is zero, it should be updated otherwise there will be a division by zero error
- Trying to create a repro proved difficult. Example state that produces this is:

```python
size_hints = {"y": 4096, "x": 64, "r0_": 128}
inductor_meta = {
        "tiling_scores": {"y": 134217728, "x": 2097152, "r0_": 0},
        "num_load": 1,
    }
triton_meta = {
        "signature": {
            "in_ptr0": "*fp32",
            "out_ptr0": "*fp32",
            "ynumel": "i32",
            "xnumel": "i32",
            "r0_numel": "i32",
            "YBLOCK": "constexpr",
            "XBLOCK": "constexpr",
            "R0_BLOCK": "constexpr",
        }
    }
persistent_reduction=False
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo