### PR TITLE
Fix regression in _check_capability() causing false warnings when get_arch_list() is empty

### DIFF
--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -361,7 +361,11 @@ def _check_capability():
     if torch.version.cuda is None:  # on ROCm we don't want this check
         return
 
-    code_ccs = [_extract_arch_version(cc) for cc in get_arch_list()]
+    arch_list = get_arch_list()
+    if len(arch_list) == 0:
+        return
+
+    code_ccs = [_extract_arch_version(cc) for cc in arch_list]
     for d in range(device_count()):
         major, minor = get_device_capability(d)
         device_cc = 10 * major + minor


### PR DESCRIPTION
Summary:
Fix regression in _check_capability() causing false warnings when get_arch_list() is empty

D89669810 introduced a regression where _check_capability() no longer checks if get_arch_list() returns an empty list before iterating. This causes the `any()` call on line 368-370 to return False for every device (since iterating over an empty list produces no truthy values), which triggers a spurious UserWarning for ALL GPUs even when PyTorch was built without any specific CUDA arch list.

The old code had a guard:
```
if (torch.version.cuda is not None and torch.cuda.get_arch_list()):
```

The new code removed this guard. This fix restores the check by adding:
```
arch_list = get_arch_list()
if len(arch_list) == 0:
    return
```

This matches the behavior of the existing _check_cubins() function which already has this guard.

Fixes torchvision CUDA test failures that started on Dec 23.

Test Plan:
The torchvision CUDA tests that were failing due to this regression should now pass.

https://www.internalfb.com/intern/testinfra/testconsole/testrun/27021597764789975/

Differential Revision: D95201643


