### PR TITLE
Use blocking CUDA->CPU copy in _GeneralMultiDeviceReplicator to prevent async DMA from overwriting inf detection result

### DIFF
--- a/torch/distributed/fsdp/sharded_grad_scaler.py
+++ b/torch/distributed/fsdp/sharded_grad_scaler.py
@@ -41,18 +41,19 @@ class _GeneralMultiDeviceReplicator(_MultiDeviceReplicator):
             )
         self.master = master_tensor
         self._per_device_tensors: dict[torch.device, torch.Tensor] = {}
-    
+
         def get(self, device: torch.device) -> torch.Tensor:
-        retval = self._per_device_tensors.get(device, None)
-        if retval is None:
-            # Unlike the parent class which only handles CUDA->CUDA, this subclass
-            # also serves CPU targets (CPU offload). Use non_blocking=False so that
-            # a CUDA->CPU transfer completes before the returned tensor is handed to
-            # a CPU kernel; with non_blocking=True the async DMA can race against
-            # _amp_foreach_non_finite_check_and_unscale_ and overwrite its result.
-            retval = self.master.to(device=device, non_blocking=False, copy=True)
-            self._per_device_tensors[device] = retval
-        return retval
+            retval = self._per_device_tensors.get(device, None)
+            if retval is None:
+                # Unlike the parent class which only handles CUDA->CUDA, this subclass
+                # also serves CPU targets (CPU offload). Use non_blocking=False so that
+                # a CUDA->CPU transfer completes before the returned tensor is handed to
+                # a CPU kernel; with non_blocking=True the async DMA can race against
+                # _amp_foreach_non_finite_check_and_unscale_ and overwrite its result.
+                retval = self.master.to(device=device, non_blocking=False, copy=True)
+                self._per_device_tensors[device] = retval
+            return retval
+
 
 class ShardedGradScaler(GradScaler):
     """

--- a/torch/distributed/fsdp/sharded_grad_scaler.py
+++ b/torch/distributed/fsdp/sharded_grad_scaler.py
@@ -41,7 +41,18 @@ class _GeneralMultiDeviceReplicator(_MultiDeviceReplicator):
             )
         self.master = master_tensor
         self._per_device_tensors: dict[torch.device, torch.Tensor] = {}
-
+    
+        def get(self, device: torch.device) -> torch.Tensor:
+        retval = self._per_device_tensors.get(device, None)
+        if retval is None:
+            # Unlike the parent class which only handles CUDA->CUDA, this subclass
+            # also serves CPU targets (CPU offload). Use non_blocking=False so that
+            # a CUDA->CPU transfer completes before the returned tensor is handed to
+            # a CPU kernel; with non_blocking=True the async DMA can race against
+            # _amp_foreach_non_finite_check_and_unscale_ and overwrite its result.
+            retval = self.master.to(device=device, non_blocking=False, copy=True)
+            self._per_device_tensors[device] = retval
+        return retval
 
 class ShardedGradScaler(GradScaler):
     """


### PR DESCRIPTION
## Summary

`_GeneralMultiDeviceReplicator.get()` inherited `non_blocking=True` from
`_MultiDeviceReplicator`, which was only designed for CUDA→CUDA copies.
When FSDP CPU offload is active, `found_inf` gets copied CUDA→CPU
asynchronously, and the pending DMA can complete *after*
`_amp_foreach_non_finite_check_and_unscale_()` writes `1.0` into the tensor
— overwriting the inf result with `0.0`. The scale never backs off.

### Fix
Override `get()` in `_GeneralMultiDeviceReplicator` to use `non_blocking=False`.
Since this class exclusively manages single-element tensors (`found_inf` = 1×fp32,
`inv_scale` = 1×fp64), there is no measurable latency impact.

## Test
Existing test covers this:
distributed/fsdp/test_fsdp_sharded_grad_scaler.py -k test_sharded_grad_scaler_found_inf