### PR TITLE
Don't use sharding for tests with a single shard

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -526,13 +526,14 @@ def run_test(
     if is_cpp_test:
         stepcurrent_key = f"{test_file}_{os.urandom(8).hex()}"
     else:
-        unittest_args.extend(
-            [
-                f"--shard-id={test_module.shard}",
-                f"--num-shards={test_module.num_shards}",
-            ]
-        )
         stepcurrent_key = f"{test_file}_{test_module.shard}_{os.urandom(8).hex()}"
+        if test_module.num_shards > 1:
+            unittest_args.extend(
+                [
+                    f"--shard-id={test_module.shard}",
+                    f"--num-shards={test_module.num_shards}",
+                ]
+            )
 
     if options.verbose:
         unittest_args.append(f"-{'v' * options.verbose}")  # in case of pytest

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -560,13 +560,14 @@ def run_test(
     if is_cpp_test:
         stepcurrent_key = f"{test_file}_{os.urandom(8).hex()}"
     else:
-        unittest_args.extend(
-            [
-                f"--shard-id={test_module.shard}",
-                f"--num-shards={test_module.num_shards}",
-            ]
-        )
         stepcurrent_key = f"{test_file}_{test_module.shard}_{os.urandom(8).hex()}"
+        if test_module.num_shards > 1:
+            unittest_args.extend(
+                [
+                    f"--shard-id={test_module.shard}",
+                    f"--num-shards={test_module.num_shards}",
+                ]
+            )
 
     if options.verbose:
         unittest_args.append(f"-{'v' * options.verbose}")  # in case of pytest


### PR DESCRIPTION
Passing `--num-shards` will initialize the (custom) pytest-shard plugin. This will then attempt to filter tests by calculating the SHA256 hashes.

With `num_shards == 1` no tests will be filtered so this work is not necessary, so ommit the parameter in this case.

The only possible issue I see is that the message "Running x items in this shard: ....." won't be printed anymore.
If this is undesirable I'd only skip the filtering inside `PytestShardPlugin` for this case instead of fully disabling it.