### PR TITLE
Set vitals in XPUHooks init

### DIFF
--- a/aten/src/ATen/core/Vitals.cpp
+++ b/aten/src/ATen/core/Vitals.cpp
@@ -91,6 +91,7 @@ APIVitals::APIVitals() : vitals_enabled(false) {
   // Set default values, force is necessary because in unit tests the env
   // variable may not be set when global APIVitals are constructed.
   setVital("CUDA", "used", "False", /* force = */ true);
+  setVital("XPU", "used", "False", /* force = */ true);
 }
 
 } // namespace at::vitals

--- a/aten/src/ATen/xpu/detail/XPUHooks.cpp
+++ b/aten/src/ATen/xpu/detail/XPUHooks.cpp
@@ -1,4 +1,5 @@
 #include <ATen/DynamicLibrary.h>
+#include <ATen/core/Vitals.h>
 #include <ATen/xpu/PeerToPeerAccess.h>
 #include <ATen/xpu/PinnedMemoryAllocator.h>
 #include <ATen/xpu/XPUContext.h>
@@ -14,6 +15,8 @@ namespace at::xpu::detail {
 
 void XPUHooks::init() const {
   C10_LOG_API_USAGE_ONCE("aten.init.xpu");
+  at::vitals::VitalsAPI.setVital("XPU", "used", "true", /* force = */ true);
+
   const auto device_count = c10::xpu::device_count_ensure_non_zero();
   c10::xpu::XPUCachingAllocator::init(device_count);
   at::xpu::detail::init_p2p_access_cache(device_count);


### PR DESCRIPTION
This commit aligns the XPU hook init with the CUDA implementation by calling the `VitalsAPI` and setting `XPU.used` to `true`. This change allows the `TestVitalSignsCuda::test_cuda_vitals_gpu_only` test to pass on XPU devices.