### PR TITLE
[ROCm] update convnext accuracy issues

### DIFF
--- a/benchmarks/dynamo/ci_expected_accuracy/rocm/dynamic_inductor_timm_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/rocm/dynamic_inductor_timm_training.csv
@@ -10,7 +10,7 @@ beit_base_patch16_224,pass,7
 
 
 
-convnextv2_nano.fcmae_ft_in22k_in1k,fail_accuracy,7
+convnextv2_nano.fcmae_ft_in22k_in1k,pass,7
 
 
 


### PR DESCRIPTION
Update inductor expected results

This comes from
https://hud.pytorch.org/pytorch/pytorch/commit/d0ea7fae7ed7cb44f63034b9627497d3f4b577cc#65714135134-box
Logs:
https://[ossci-raw-job-status.s3.amazonaws.com/log/65714135134](https://ossci-raw-job-status.s3.amazonaws.com/log/65714135134)

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela