### PR TITLE
Let stable::from_blob accept a lambda as deleter (cherry-pick)

### DIFF
--- a/test/cpp_extensions/libtorch_agn_2_11_extension/csrc/my_from_blob_with_lambda_deleter.cpp
+++ b/test/cpp_extensions/libtorch_agn_2_11_extension/csrc/my_from_blob_with_lambda_deleter.cpp
@@ -1,0 +1,101 @@
+#include <torch/csrc/stable/device.h>
+#include <torch/csrc/stable/library.h>
+#include <torch/csrc/stable/ops.h>
+#include <torch/csrc/stable/tensor.h>
+
+#ifdef LAE_USE_CUDA
+#include <cuda_runtime.h>
+#endif
+
+using torch::stable::Tensor;
+
+// Global counter to track lambda deleter calls for testing
+static int64_t g_lambda_deleter_call_count = 0;
+
+// Wrapper for from_blob with a capturing-lambda deleter.
+// The lambda captures a pointer to the global counter and increments it,
+// which exercises the capturing-lambda code path in torch_from_blob.
+Tensor my_from_blob_with_lambda_deleter(
+    int64_t data_ptr,
+    torch::headeronly::HeaderOnlyArrayRef<int64_t> sizes,
+    torch::headeronly::HeaderOnlyArrayRef<int64_t> strides,
+    torch::stable::Device device,
+    torch::headeronly::ScalarType dtype) {
+  void* data = reinterpret_cast<void*>(data_ptr);
+  int64_t* counter = &g_lambda_deleter_call_count;
+  auto deleter = [counter](void* /*data*/) { (*counter)++; };
+  return torch::stable::from_blob(data, sizes, strides, device, dtype, deleter);
+}
+
+int64_t get_lambda_deleter_call_count() {
+  return g_lambda_deleter_call_count;
+}
+
+void reset_lambda_deleter_call_count() {
+  g_lambda_deleter_call_count = 0;
+}
+
+STABLE_TORCH_LIBRARY_FRAGMENT(STABLE_LIB_NAME, m) {
+  m.def(
+      "my_from_blob_with_lambda_deleter(int data_ptr, int[] sizes, int[] strides, Device device, ScalarType dtype) -> Tensor");
+  m.def("get_lambda_deleter_call_count() -> int");
+  m.def("reset_lambda_deleter_call_count() -> ()");
+}
+
+STABLE_TORCH_LIBRARY_IMPL(
+    STABLE_LIB_NAME,
+    CompositeExplicitAutograd,
+    m) {
+  m.impl(
+      "my_from_blob_with_lambda_deleter",
+      TORCH_BOX(&my_from_blob_with_lambda_deleter));
+  m.impl(
+      "get_lambda_deleter_call_count",
+      TORCH_BOX(&get_lambda_deleter_call_count));
+  m.impl(
+      "reset_lambda_deleter_call_count",
+      TORCH_BOX(&reset_lambda_deleter_call_count));
+}
+
+#ifdef LAE_USE_CUDA
+
+// Same as my_from_blob_with_cuda_deleter (from 2.11) but uses a non-capturing
+// lambda deleter.
+Tensor my_from_blob_with_cuda_lambda_deleter(
+    int64_t numel,
+    torch::stable::Device device) {
+  size_t size_bytes = numel * sizeof(float);
+
+  void* data = nullptr;
+  cudaError_t err = cudaMalloc(&data, size_bytes);
+  if (err != cudaSuccess) {
+    throw std::runtime_error("cudaMalloc failed");
+  }
+
+  // Zero the memory
+  cudaMemset(data, 0, size_bytes);
+
+  std::array<int64_t, 1> sizes = {numel};
+  std::array<int64_t, 1> strides = {1};
+
+  // This lambda doesn't capture anything, but capture is tested above in
+  // my_from_blob_with_lambda_deleter
+  auto deleter = [](void* data) { cudaFree(data); };
+  return torch::stable::from_blob(
+      data,
+      torch::headeronly::HeaderOnlyArrayRef<int64_t>(sizes.data(), sizes.size()),
+      torch::headeronly::HeaderOnlyArrayRef<int64_t>(strides.data(), strides.size()),
+      device,
+      torch::headeronly::ScalarType::Float,
+      deleter);
+}
+
+STABLE_TORCH_LIBRARY_FRAGMENT(STABLE_LIB_NAME, m) {
+  m.def("my_from_blob_with_cuda_lambda_deleter(int numel, Device device) -> Tensor");
+}
+
+STABLE_TORCH_LIBRARY_IMPL(STABLE_LIB_NAME, CompositeExplicitAutograd, m) {
+  m.impl("my_from_blob_with_cuda_lambda_deleter", TORCH_BOX(&my_from_blob_with_cuda_lambda_deleter));
+}
+
+#endif  // LAE_USE_CUDA

--- a/test/cpp_extensions/libtorch_agn_2_11_extension/libtorch_agn_2_11/ops.py
+++ b/test/cpp_extensions/libtorch_agn_2_11_extension/libtorch_agn_2_11/ops.py
@@ -57,6 +57,59 @@ def my_from_blob_with_cuda_deleter(numel: int, device) -> Tensor:
     )
 
 
+def my_from_blob_with_lambda_deleter(data_ptr, sizes, strides, device, dtype) -> Tensor:
+    """
+    Creates a Tensor from existing memory with a capturing-lambda deleter.
+
+    The deleter is a capturing lambda that updates a global call count,
+    exercising the capturing-lambda code path in torch_from_blob.
+
+    Args:
+        data_ptr: int - pointer to the data buffer
+        sizes: tuple[int] - size of the tensor
+        strides: tuple[int] - strides of the tensor
+        device: Device - device on which the tensor resides
+        dtype: ScalarType - data type of the tensor
+
+    Returns: Tensor - tensor wrapping the existing memory
+    """
+    return torch.ops.libtorch_agn_2_11.my_from_blob_with_lambda_deleter.default(
+        data_ptr, sizes, strides, device, dtype
+    )
+
+
+def get_lambda_deleter_call_count() -> int:
+    """
+    Returns the number of times the lambda test deleter has been called.
+    """
+    return torch.ops.libtorch_agn_2_11.get_lambda_deleter_call_count.default()
+
+
+def reset_lambda_deleter_call_count() -> None:
+    """
+    Resets the lambda deleter call counter to zero.
+    """
+    torch.ops.libtorch_agn_2_11.reset_lambda_deleter_call_count.default()
+
+
+def my_from_blob_with_cuda_lambda_deleter(numel: int, device) -> Tensor:
+    """
+    Creates a CUDA tensor that owns its memory via cudaMalloc, using a lambda deleter.
+
+    Similar to my_from_blob_with_cuda_deleter but uses the capturing-lambda
+    code path in torch_from_blob.
+
+    Args:
+        numel: int - number of elements in the tensor
+        device: Device - CUDA device
+
+    Returns: Tensor - a 1D float32 tensor of zeros
+    """
+    return torch.ops.libtorch_agn_2_11.my_from_blob_with_cuda_lambda_deleter.default(
+        numel, device
+    )
+
+
 # =============================================================================
 # Proxy for inherited ops (from libtorch_agn_2_9 and libtorch_agn_2_10 csrc/)
 #

--- a/test/cpp_extensions/test_libtorch_agnostic.py
+++ b/test/cpp_extensions/test_libtorch_agnostic.py
@@ -1809,6 +1809,81 @@ except RuntimeError as e:
             curr_mem = torch.cuda.memory_allocated(device)
             self.assertEqual(curr_mem, init_mem)
 
+    @skipIfTorchVersionLessThan(2, 11)
+    @skipIfTorchDynamo("no data pointer defined for FakeTensor, FunctionalTensor")
+    def test_my_from_blob_with_lambda_deleter(self, device):
+        """Test for from_blob with capturing-lambda deleter (2.11 feature)."""
+        import libtorch_agn_2_11 as libtorch_agnostic
+
+        from_blob_fn = libtorch_agnostic.ops.my_from_blob_with_lambda_deleter
+        get_count = libtorch_agnostic.ops.get_lambda_deleter_call_count
+        reset_count = libtorch_agnostic.ops.reset_lambda_deleter_call_count
+
+        is_cuda = torch.device(device).type == "cuda"
+        if is_cuda:
+            init_mem = torch.cuda.memory_allocated(device)
+
+        def inner():
+            reset_count()
+            self.assertEqual(get_count(), 0)
+
+            # We need an original tensor to create the tensor with from_blob.
+            original = torch.rand(2, 3, device=device, dtype=torch.float32)
+            blob_tensor = from_blob_fn(
+                original.data_ptr(),
+                original.size(),
+                original.stride(),
+                device,
+                torch.float32,
+            )
+
+            self.assertEqual(blob_tensor, original)
+            self.assertEqual(blob_tensor.data_ptr(), original.data_ptr())
+
+            self.assertEqual(get_count(), 0)
+
+            del blob_tensor
+            gc.collect()
+
+            # Ensure the deleter was called. The original tensor still exists
+            # and can be used.
+            self.assertEqual(get_count(), 1)
+            original += 1
+            # original goes out of scope here and its cuda memory should be
+            # freed.
+
+        inner()
+
+        if is_cuda:
+            # original tensor is out of scope, all the memory should be freed
+            torch.cuda.synchronize(device)
+            curr_mem = torch.cuda.memory_allocated(device)
+            self.assertEqual(curr_mem, init_mem)
+
+    @onlyCUDA
+    @skipIfTorchVersionLessThan(2, 11)
+    def test_my_from_blob_with_cuda_lambda_deleter_no_leak(self, device):
+        """Test that from_blob lambda deleter properly frees cudaMalloc'd memory."""
+        import libtorch_agn_2_11 as libtorch_agnostic
+
+        from_blob_fn = libtorch_agnostic.ops.my_from_blob_with_cuda_lambda_deleter
+
+        torch.cuda.synchronize(device)
+        init_mem = torch.cuda.memory_allocated(device)
+        numel = 1024 * 1024  # 4 MB per tensor
+
+        for _ in range(10):
+            tensor = from_blob_fn(numel, device)
+            # Verify tensor was created correctly
+            self.assertEqual(tensor.numel(), numel)
+            self.assertEqual(tensor.device, torch.device(device))
+            del tensor
+            gc.collect()
+            torch.cuda.synchronize(device)
+
+            curr_mem = torch.cuda.memory_allocated(device)
+            self.assertEqual(curr_mem, init_mem)
+
     @onlyCPU
     def test_my_layout(self, device):
         """Test layout() method for various tensor layouts."""

--- a/torch/csrc/shim_common.cpp
+++ b/torch/csrc/shim_common.cpp
@@ -667,7 +667,8 @@ AOTI_TORCH_EXPORT AOTITorchError torch_from_blob(
     int32_t layout,
     const uint8_t* opaque_metadata,
     int64_t opaque_metadata_size,
-    void (*deleter)(void*)) {
+    void (*deleter_callback)(void* data, void* ctx),
+    void* deleter_ctx) {
   AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
     c10::IntArrayRef sizes(sizes_ptr, ndim);
     c10::IntArrayRef strides(strides_ptr, ndim);
@@ -676,11 +677,14 @@ AOTI_TORCH_EXPORT AOTITorchError torch_from_blob(
         static_cast<c10::ScalarType>(dtype));
     at::Tensor tensor;
     if (data != nullptr) {
-      if (deleter != nullptr) {
+      if (deleter_callback != nullptr) {
+        auto wrapped_deleter = [deleter_callback, deleter_ctx](void* data) {
+          deleter_callback(data, deleter_ctx);
+        };
         tensor = at::for_blob(data, sizes)
                      .strides(strides)
                      .storage_offset(storage_offset)
-                     .deleter(deleter)
+                     .deleter(wrapped_deleter)
                      .options(options)
                      .make_tensor();
       } else {

--- a/torch/csrc/stable/c/shim.h
+++ b/torch/csrc/stable/c/shim.h
@@ -165,8 +165,9 @@ AOTI_TORCH_EXPORT int32_t torch_dtype_float8_e8m0fnu();
 AOTI_TORCH_EXPORT int32_t torch_dtype_float4_e2m1fn_x2();
 
 // Creates a tensor from an existing data blob with an optional deleter.
-// The deleter is called with the data pointer when the tensor's storage
-// is deallocated.
+// The deleter receives both the data pointer and a caller-supplied context
+// pointer, which allows passing capturing lambdas across the C ABI boundary
+// by heap-allocating the callable and passing it as deleter_ctx.
 AOTI_TORCH_EXPORT AOTITorchError torch_from_blob(
     void* data,
     int64_t ndim,
@@ -180,7 +181,8 @@ AOTI_TORCH_EXPORT AOTITorchError torch_from_blob(
     int32_t layout,
     const uint8_t* opaque_metadata,
     int64_t opaque_metadata_size,
-    void (*deleter)(void*));
+    void (*deleter)(void* data, void* ctx),
+    void* deleter_ctx);
 
 #endif // TORCH_FEATURE_VERSION >= TORCH_VERSION_2_11_0
 

--- a/torch/csrc/stable/ops.h
+++ b/torch/csrc/stable/ops.h
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <optional>
 #include <string>
+#include <type_traits>
 
 #include <torch/csrc/inductor/aoti_torch/generated/c_shim_aten.h>
 #include <torch/csrc/stable/c/shim.h>
@@ -722,26 +723,28 @@ inline torch::stable::Tensor from_blob(
 ///
 /// This is the same as the from_blob function above, but allows specifying a
 /// custom deleter function that will be called when the tensor's storage is
-/// deallocated.
+/// deallocated. Accepts both plain function pointers and capturing lambdas.
+///
 /// Minimum compatible version: PyTorch 2.11.
 ///
+/// @tparam F The callable type. Must be invocable with (void*).
 /// @param data Pointer to the data buffer.
 /// @param sizes The size of each dimension of the tensor.
 /// @param strides The stride for each dimension.
 /// @param device The device where the data resides.
 /// @param dtype The scalar type of the data.
-/// @param deleter Function to call when the tensor is deallocated. May be
-///                nullptr if no cleanup is needed.
+/// @param deleter Callable to invoke when the tensor is deallocated.
 /// @param storage_offset The offset into the data buffer. Defaults to 0.
 /// @param layout The memory layout. Defaults to Strided.
 /// @return A tensor backed by the provided data.
+template <class F, std::enable_if_t<std::is_invocable_v<F, void*>, int> = 0>
 inline torch::stable::Tensor from_blob(
     void* data,
     torch::headeronly::IntHeaderOnlyArrayRef sizes,
     torch::headeronly::IntHeaderOnlyArrayRef strides,
     torch::stable::Device device,
     torch::headeronly::ScalarType dtype,
-    DeleterFnPtr deleter,
+    F deleter,
     int64_t storage_offset = 0,
     torch::headeronly::Layout layout = torch::headeronly::Layout::Strided) {
   auto shim_dtype =
@@ -750,21 +753,53 @@ inline torch::stable::Tensor from_blob(
       torch::stable::detail::from(device.type()));
   auto shim_layout =
       torch::stable::detail::to<int32_t>(torch::stable::detail::from(layout));
+
   AtenTensorHandle ath;
-  TORCH_ERROR_CODE_CHECK(torch_from_blob(
-      data,
-      sizes.size(),
-      sizes.data(),
-      strides.data(),
-      storage_offset,
-      shim_dtype,
-      shim_device_type,
-      device.index(),
-      &ath,
-      shim_layout,
-      nullptr,
-      0,
-      deleter));
+  if constexpr (std::is_convertible_v<F, DeleterFnPtr>) {
+    // Simple function pointer: pass it as ctx, no heap allocation.
+    auto deleter_callback = [](void* data, void* ctx) {
+      auto fn = reinterpret_cast<DeleterFnPtr>(ctx);
+      fn(data);
+    };
+    TORCH_ERROR_CODE_CHECK(torch_from_blob(
+        data,
+        sizes.size(),
+        sizes.data(),
+        strides.data(),
+        storage_offset,
+        shim_dtype,
+        shim_device_type,
+        device.index(),
+        &ath,
+        shim_layout,
+        nullptr,
+        0,
+        deleter_callback,
+        reinterpret_cast<void*>(static_cast<DeleterFnPtr>(deleter))));
+  } else {
+    // Capturing lambda: heap-allocate and type-erase.
+    F* heap_allocated_deleter = new F(std::move(deleter));
+    auto deleter_callback = [](void* data, void* ctx) {
+      F* func = static_cast<F*>(ctx);
+      (*func)(data);
+      delete func;
+    };
+    TORCH_ERROR_CODE_CHECK(torch_from_blob(
+        data,
+        sizes.size(),
+        sizes.data(),
+        strides.data(),
+        storage_offset,
+        shim_dtype,
+        shim_device_type,
+        device.index(),
+        &ath,
+        shim_layout,
+        nullptr,
+        0,
+        deleter_callback,
+        static_cast<void*>(heap_allocated_deleter)));
+  }
   return torch::stable::Tensor(ath);
 }
 #endif // TORCH_FEATURE_VERSION >= TORCH_VERSION_2_11_0


### PR DESCRIPTION
This captures the changes in https://github.com/pytorch/pytorch/pull/175089 and https://github.com/pytorch/pytorch/pull/177048

 Mainly to gate the `from_blob` deleter shim in shim.h and the corresponding op in `ops.h` with  `TORCH_FEATURE_VERSION >= TORCH_VERSION_2_11_0` rather than `TORCH_FEATURE_VERSION >= TORCH_VERSION_2_12_0 `