### PR TITLE
[WIP] Allow dtype Half usage on XPU

### DIFF
--- a/aten/src/ATen/native/SpectralOps.cpp
+++ b/aten/src/ATen/native/SpectralOps.cpp
@@ -80,9 +80,10 @@ ScalarType promote_type_fft(ScalarType type, bool require_complex, Device device
   }
 
   const bool maybe_support_half = (
-    // Only CUDA supports half precision, but since meta tensors don't have a
-    // device we err on the side of accepting it
-    device.is_cuda() || device.is_meta()
+    // CUDA and XPU support half precision. Some XPU builds route through
+    // PrivateUse1, and meta tensors don't have a concrete device.
+    device.is_cuda() || device.is_xpu() || device.is_privateuseone() ||
+    device.is_meta()
   );
   if (maybe_support_half) {
     TORCH_CHECK(type == kHalf || type == kFloat || type == kDouble, "Unsupported dtype ", type);

--- a/torch/_refs/fft.py
+++ b/torch/_refs/fft.py
@@ -67,7 +67,7 @@ def _promote_type_fft(
         dtype = torch.get_default_dtype()
 
     allowed_types = [torch.float32, torch.float64]
-    maybe_support_half = device.type in ["cuda", "meta"]
+    maybe_support_half = device.type in ["cuda", "xpu", "meta"]
 
     if maybe_support_half:
         allowed_types.append(torch.float16)


### PR DESCRIPTION
### Summary
Enable FFT float16 (Half) dtype on XPU, removing unsupported dtype Half failures in XPU FFT op tests.
### Problem
Several op_ut failures in #2708[https://github.com/intel/torch-xpu-ops/issues/2708](url) and #2615[https://github.com/intel/torch-xpu-ops/issues/2615](url) were caused by a dtype-promotion mismatch: FFT type checks still treated half support as CUDA-only (plus meta), so XPU float16 inputs were rejected.
### Solution
Update FFT promotion logic to include XPU half support.

Fixes:
[#2615](https://github.com/intel/torch-xpu-ops/issues/2615)
[#2708](https://github.com/intel/torch-xpu-ops/issues/2708)
but requires [#2996](https://github.com/intel/torch-xpu-ops/pull/2996) to take effect.