### PR TITLE
[ROCm][CI] Add GPU-specific suffix to ROCm build-environment names

### DIFF
--- a/.github/workflows/inductor-perf-test-nightly-rocm-mi300.yml
+++ b/.github/workflows/inductor-perf-test-nightly-rocm-mi300.yml
@@ -82,7 +82,7 @@ jobs:
     name: rocm-py3_10-inductor-benchmark-build
     uses: ./.github/workflows/_linux-build.yml
     with:
-      build-environment: linux-jammy-rocm-py3_10-mi300
+      build-environment: linux-jammy-rocm-py3.10-mi300
       docker-image-name: ci-image:pytorch-linux-jammy-rocm-n-py3-benchmarks
       test-matrix: |
         { include: [

--- a/.github/workflows/inductor-perf-test-nightly-rocm-mi300.yml
+++ b/.github/workflows/inductor-perf-test-nightly-rocm-mi300.yml
@@ -79,7 +79,7 @@ jobs:
 
   linux-jammy-rocm-py3_10-inductor-benchmark-build:
     if: github.repository_owner == 'pytorch'
-    name: rocm-py3_10-inductor-benchmark-build
+    name: linux-jammy-rocm-py3.10-mi300
     uses: ./.github/workflows/_linux-build.yml
     with:
       build-environment: linux-jammy-rocm-py3.10-mi300
@@ -114,7 +114,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    name: rocm-py3_10-inductor-benchmark-test
+    name: linux-jammy-rocm-py3.10-mi300
     uses: ./.github/workflows/_rocm-test.yml
     needs: linux-jammy-rocm-py3_10-inductor-benchmark-build
     with:

--- a/.github/workflows/inductor-perf-test-nightly-rocm-mi300.yml
+++ b/.github/workflows/inductor-perf-test-nightly-rocm-mi300.yml
@@ -82,7 +82,7 @@ jobs:
     name: rocm-py3_10-inductor-benchmark-build
     uses: ./.github/workflows/_linux-build.yml
     with:
-      build-environment: linux-jammy-rocm-py3_10
+      build-environment: linux-jammy-rocm-py3_10-mi300
       docker-image-name: ci-image:pytorch-linux-jammy-rocm-n-py3-benchmarks
       test-matrix: |
         { include: [

--- a/.github/workflows/inductor-perf-test-nightly-rocm-mi355.yml
+++ b/.github/workflows/inductor-perf-test-nightly-rocm-mi355.yml
@@ -82,7 +82,7 @@ jobs:
     name: rocm-py3_10-inductor-benchmark-build
     uses: ./.github/workflows/_linux-build.yml
     with:
-      build-environment: linux-jammy-rocm-py3_10-mi355
+      build-environment: linux-jammy-rocm-py3.10-mi355
       docker-image-name: ci-image:pytorch-linux-jammy-rocm-n-py3-benchmarks
       test-matrix: |
         { include: [

--- a/.github/workflows/inductor-perf-test-nightly-rocm-mi355.yml
+++ b/.github/workflows/inductor-perf-test-nightly-rocm-mi355.yml
@@ -82,7 +82,7 @@ jobs:
     name: rocm-py3_10-inductor-benchmark-build
     uses: ./.github/workflows/_linux-build.yml
     with:
-      build-environment: linux-jammy-rocm-py3_10
+      build-environment: linux-jammy-rocm-py3_10-mi355
       docker-image-name: ci-image:pytorch-linux-jammy-rocm-n-py3-benchmarks
       test-matrix: |
         { include: [

--- a/.github/workflows/inductor-perf-test-nightly-rocm-mi355.yml
+++ b/.github/workflows/inductor-perf-test-nightly-rocm-mi355.yml
@@ -79,7 +79,7 @@ jobs:
 
   linux-jammy-rocm-py3_10-inductor-benchmark-build:
     if: github.repository_owner == 'pytorch'
-    name: rocm-py3_10-inductor-benchmark-build
+    name: linux-jammy-rocm-py3.10-mi355
     uses: ./.github/workflows/_linux-build.yml
     with:
       build-environment: linux-jammy-rocm-py3.10-mi355
@@ -114,7 +114,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    name: rocm-py3_10-inductor-benchmark-test
+    name: linux-jammy-rocm-py3.10-mi355
     uses: ./.github/workflows/_rocm-test.yml
     needs: linux-jammy-rocm-py3_10-inductor-benchmark-build
     with:

--- a/.github/workflows/inductor-periodic.yml
+++ b/.github/workflows/inductor-periodic.yml
@@ -87,7 +87,7 @@ jobs:
     name: rocm-periodic-dynamo-benchmarks-build
     uses: ./.github/workflows/_linux-build.yml
     with:
-      build-environment: linux-jammy-rocm-py3_10
+      build-environment: linux-jammy-rocm-py3_10-mi355
       docker-image-name: ci-image:pytorch-linux-jammy-rocm-n-py3-benchmarks
       test-matrix: |
         { include: [

--- a/.github/workflows/inductor-periodic.yml
+++ b/.github/workflows/inductor-periodic.yml
@@ -87,7 +87,7 @@ jobs:
     name: rocm-periodic-dynamo-benchmarks-build
     uses: ./.github/workflows/_linux-build.yml
     with:
-      build-environment: linux-jammy-rocm-py3_10-mi355
+      build-environment: linux-jammy-rocm-py3.10-mi355
       docker-image-name: ci-image:pytorch-linux-jammy-rocm-n-py3-benchmarks
       test-matrix: |
         { include: [

--- a/.github/workflows/inductor-rocm-mi200.yml
+++ b/.github/workflows/inductor-rocm-mi200.yml
@@ -36,7 +36,7 @@ jobs:
     needs: get-label-type
     with:
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
-      build-environment: linux-jammy-rocm-py3.10
+      build-environment: linux-jammy-rocm-py3.10-mi200
       docker-image-name: ci-image:pytorch-linux-jammy-rocm-n-py3
       test-matrix: |
         { include: [

--- a/.github/workflows/inductor-rocm-mi200.yml
+++ b/.github/workflows/inductor-rocm-mi200.yml
@@ -31,7 +31,7 @@ jobs:
       opt_out_experiments: lf
 
   linux-jammy-rocm-py3_10-inductor-build:
-    name: rocm-py3.10-inductor
+    name: linux-jammy-rocm-py3.10-mi200
     uses: ./.github/workflows/_linux-build.yml
     needs: get-label-type
     with:
@@ -49,7 +49,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    name: rocm-py3.10-inductor
+    name: linux-jammy-rocm-py3.10-mi200
     uses: ./.github/workflows/_rocm-test.yml
     needs: linux-jammy-rocm-py3_10-inductor-build
     with:

--- a/.github/workflows/inductor-rocm-mi300.yml
+++ b/.github/workflows/inductor-rocm-mi300.yml
@@ -39,7 +39,7 @@ jobs:
       opt_out_experiments: lf
 
   linux-noble-rocm-py3_12-inductor-build:
-    name: rocm-py3.12-inductor-mi300
+    name: linux-noble-rocm-py3.12-mi300
     uses: ./.github/workflows/_linux-build.yml
     needs: get-label-type
     with:
@@ -57,7 +57,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    name: rocm-py3.12-inductor-mi300
+    name: linux-noble-rocm-py3.12-mi300
     uses: ./.github/workflows/_rocm-test.yml
     needs: linux-noble-rocm-py3_12-inductor-build
     with:

--- a/.github/workflows/inductor-rocm-mi355.yml
+++ b/.github/workflows/inductor-rocm-mi355.yml
@@ -38,7 +38,7 @@ jobs:
       opt_out_experiments: lf
 
   linux-noble-rocm-py3_12-inductor-build:
-    name: rocm-py3.12-inductor-mi355
+    name: linux-noble-rocm-py3.12-mi355
     uses: ./.github/workflows/_linux-build.yml
     needs: get-label-type
     with:
@@ -56,7 +56,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    name: rocm-py3.12-inductor-mi355
+    name: linux-noble-rocm-py3.12-mi355
     uses: ./.github/workflows/_rocm-test.yml
     needs: linux-noble-rocm-py3_12-inductor-build
     with:

--- a/.github/workflows/periodic-rocm-mi200.yml
+++ b/.github/workflows/periodic-rocm-mi200.yml
@@ -46,7 +46,7 @@ jobs:
       curr_ref_type: ${{ github.ref_type }}
 
   linux-jammy-rocm-py3_10-build:
-    name: linux-jammy-rocm-py3.10
+    name: linux-jammy-rocm-py3.10-mi200
     uses: ./.github/workflows/_linux-build.yml
     needs: get-label-type
     with:
@@ -65,7 +65,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    name: linux-jammy-rocm-py3.10
+    name: linux-jammy-rocm-py3.10-mi200
     uses: ./.github/workflows/_rocm-test.yml
     needs:
       - linux-jammy-rocm-py3_10-build

--- a/.github/workflows/periodic-rocm-mi200.yml
+++ b/.github/workflows/periodic-rocm-mi200.yml
@@ -51,7 +51,7 @@ jobs:
     needs: get-label-type
     with:
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
-      build-environment: linux-jammy-rocm-py3.10
+      build-environment: linux-jammy-rocm-py3.10-mi200
       docker-image-name: ci-image:pytorch-linux-jammy-rocm-n-py3
       test-matrix: |
         { include: [

--- a/.github/workflows/rocm-mi200.yml
+++ b/.github/workflows/rocm-mi200.yml
@@ -38,7 +38,7 @@ jobs:
 
   linux-jammy-rocm-py3_10-build:
     if: ${{ (github.event_name != 'schedule' || github.repository == 'pytorch/pytorch') && github.repository_owner == 'pytorch' }}
-    name: linux-jammy-rocm-py3.10
+    name: linux-jammy-rocm-py3.10-mi200
     uses: ./.github/workflows/_linux-build.yml
     needs: get-label-type
     with:
@@ -61,7 +61,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    name: linux-jammy-rocm-py3.10
+    name: linux-jammy-rocm-py3.10-mi200
     uses: ./.github/workflows/_rocm-test.yml
     needs:
       - linux-jammy-rocm-py3_10-build

--- a/.github/workflows/rocm-mi200.yml
+++ b/.github/workflows/rocm-mi200.yml
@@ -43,7 +43,7 @@ jobs:
     needs: get-label-type
     with:
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
-      build-environment: linux-jammy-rocm-py3.10
+      build-environment: linux-jammy-rocm-py3.10-mi200
       docker-image-name: ci-image:pytorch-linux-jammy-rocm-n-py3
       sync-tag: rocm-build
       test-matrix: |

--- a/.github/workflows/rocm-navi31.yml
+++ b/.github/workflows/rocm-navi31.yml
@@ -43,7 +43,7 @@ jobs:
     needs: get-label-type
     with:
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
-      build-environment: linux-jammy-rocm-py3.10
+      build-environment: linux-jammy-rocm-py3.10-navi31
       docker-image-name: ci-image:pytorch-linux-jammy-rocm-n-py3
       sync-tag: rocm-build
       test-matrix: |

--- a/.github/workflows/rocm-navi31.yml
+++ b/.github/workflows/rocm-navi31.yml
@@ -38,7 +38,7 @@ jobs:
 
   linux-jammy-rocm-py3_10-build:
     if: ${{ (github.event_name != 'schedule' || github.repository == 'pytorch/pytorch') && github.repository_owner == 'pytorch' }}
-    name: linux-jammy-rocm-py3.10
+    name: linux-jammy-rocm-py3.10-navi31
     uses: ./.github/workflows/_linux-build.yml
     needs: get-label-type
     with:
@@ -57,7 +57,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    name: linux-jammy-rocm-py3_10
+    name: linux-jammy-rocm-py3.10-navi31
     uses: ./.github/workflows/_rocm-test.yml
     needs:
       - linux-jammy-rocm-py3_10-build

--- a/.github/workflows/slow-rocm-mi200.yml
+++ b/.github/workflows/slow-rocm-mi200.yml
@@ -55,7 +55,7 @@ jobs:
     needs: get-label-type
     with:
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
-      build-environment: linux-jammy-rocm-py3.10
+      build-environment: linux-jammy-rocm-py3.10-mi200
       docker-image-name: ci-image:pytorch-linux-jammy-rocm-n-py3
       sync-tag: rocm-build
       test-matrix: |

--- a/.github/workflows/slow-rocm-mi200.yml
+++ b/.github/workflows/slow-rocm-mi200.yml
@@ -50,7 +50,7 @@ jobs:
       curr_ref_type: ${{ github.ref_type }}
 
   linux-jammy-rocm-py3_10-build:
-    name: linux-jammy-rocm-py3.10
+    name: linux-jammy-rocm-py3.10-mi200
     uses: ./.github/workflows/_linux-build.yml
     needs: get-label-type
     with:
@@ -69,7 +69,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    name: linux-jammy-rocm-py3.10
+    name: linux-jammy-rocm-py3.10-mi200
     uses: ./.github/workflows/_rocm-test.yml
     needs:
       - linux-jammy-rocm-py3_10-build

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -268,7 +268,7 @@ jobs:
     secrets: inherit
 
   linux-jammy-rocm-py3_10-build:
-    name: linux-jammy-rocm-py3.10
+    name: linux-jammy-rocm-py3.10-mi355
     uses: ./.github/workflows/_linux-build.yml
     needs:
       - get-label-type
@@ -296,7 +296,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    name: linux-jammy-rocm-py3.10
+    name: linux-jammy-rocm-py3.10-mi355
     uses: ./.github/workflows/_rocm-test.yml
     needs:
       - linux-jammy-rocm-py3_10-build

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -275,7 +275,7 @@ jobs:
       - job-filter
     with:
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
-      build-environment: linux-jammy-rocm-py3.10
+      build-environment: linux-jammy-rocm-py3.10-mi355
       docker-image-name: ci-image:pytorch-linux-jammy-rocm-n-py3
       sync-tag: rocm-build
       test-matrix: |

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1862,13 +1862,18 @@ def load_test_times_from_file(file: str) -> dict[str, Any]:
 
     with open(path) as f:
         test_times_file = cast(dict[str, Any], json.load(f))
-    job_name = os.environ.get("JOB_NAME")
+    raw_job_name = os.environ.get("JOB_NAME")
+    build_env = os.environ.get("BUILD_ENVIRONMENT")
+    job_name = raw_job_name
     if job_name is None or job_name == "":
         # If job name isn't available, use build environment as a backup
-        job_name = os.environ.get("BUILD_ENVIRONMENT")
+        job_name = build_env
     else:
         job_name = job_name.split(" / test (")[0]
     test_config = os.environ.get("TEST_CONFIG")
+    print_to_stderr(f"JOB_NAME={raw_job_name}")
+    print_to_stderr(f"BUILD_ENVIRONMENT={build_env}")
+    print_to_stderr(f"test-times lookup key={job_name}, test_config={test_config}")
     if test_config in test_times_file.get(job_name, {}):
         print_to_stderr("Found test times from artifacts")
         return test_times_file[job_name][test_config]

--- a/tools/linter/adapters/workflow_consistency_linter.py
+++ b/tools/linter/adapters/workflow_consistency_linter.py
@@ -118,6 +118,10 @@ def get_jobs_with_sync_tag(
         del job["with"]["tests-to-include"]
     # and ['with']['build-environment'], since GPU-specific suffixes differ for ROCm
     if "build-environment" in job.get("with", {}) and "rocm" in job["with"]["build-environment"]:
+        if (
+            "build-environment" in job.get("with", {})
+            and "rocm" in job["with"]["build-environment"]
+        ):
         del job["with"]["build-environment"]
 
     # normalize needs: remove helper job-filter so comparisons ignore it

--- a/tools/linter/adapters/workflow_consistency_linter.py
+++ b/tools/linter/adapters/workflow_consistency_linter.py
@@ -122,6 +122,9 @@ def get_jobs_with_sync_tag(
         and "rocm" in job["with"]["build-environment"]
     ):
         del job["with"]["build-environment"]
+    # and ['name'], since ROCm jobs append a GPU-specific suffix to the job name
+    if "name" in job and "rocm" in job.get("name", ""):
+        del job["name"]
 
     # normalize needs: remove helper job-filter so comparisons ignore it
     needs = job.get("needs")

--- a/tools/linter/adapters/workflow_consistency_linter.py
+++ b/tools/linter/adapters/workflow_consistency_linter.py
@@ -116,12 +116,11 @@ def get_jobs_with_sync_tag(
     # and ['with']['tests-to-include'], since dispatch filters differ
     if "tests-to-include" in job.get("with", {}):
         del job["with"]["tests-to-include"]
-    # and ['with']['build-environment'], since GPU-specific suffixes differ for ROCm
-    if "build-environment" in job.get("with", {}) and "rocm" in job["with"]["build-environment"]:
-        if (
-            "build-environment" in job.get("with", {})
-            and "rocm" in job["with"]["build-environment"]
-        ):
+    # and ['with']['build-environment'], since GPU-specific suffixes differ for if
+    if (
+        "build-environment" in job.get("with", {})
+        and "rocm" in job["with"]["bubuild-environment
+    ):
         del job["with"]["build-environment"]
 
     # normalize needs: remove helper job-filter so comparisons ignore it

--- a/tools/linter/adapters/workflow_consistency_linter.py
+++ b/tools/linter/adapters/workflow_consistency_linter.py
@@ -119,7 +119,7 @@ def get_jobs_with_sync_tag(
     # and ['with']['build-environment'], since GPU-specific suffixes differ for ROCm
     if (
         "build-environment" in job.get("with", {})
-        and "rocm" in job["with"]["bubuild-environment
+        and "rocm" in job["with"]["build-environment"]
     ):
         del job["with"]["build-environment"]
 

--- a/tools/linter/adapters/workflow_consistency_linter.py
+++ b/tools/linter/adapters/workflow_consistency_linter.py
@@ -116,8 +116,8 @@ def get_jobs_with_sync_tag(
     # and ['with']['tests-to-include'], since dispatch filters differ
     if "tests-to-include" in job.get("with", {}):
         del job["with"]["tests-to-include"]
-    # and ['with']['build-environment'], since GPU-specific suffixes differ
-    if "build-environment" in job.get("with", {}):
+    # and ['with']['build-environment'], since GPU-specific suffixes differ for ROCm
+    if "build-environment" in job.get("with", {}) and "rocm" in job["with"]["build-environment"]:
         del job["with"]["build-environment"]
 
     # normalize needs: remove helper job-filter so comparisons ignore it

--- a/tools/linter/adapters/workflow_consistency_linter.py
+++ b/tools/linter/adapters/workflow_consistency_linter.py
@@ -116,7 +116,7 @@ def get_jobs_with_sync_tag(
     # and ['with']['tests-to-include'], since dispatch filters differ
     if "tests-to-include" in job.get("with", {}):
         del job["with"]["tests-to-include"]
-    # and ['with']['build-environment'], since GPU-specific suffixes differ for if
+    # and ['with']['build-environment'], since GPU-specific suffixes differ for ROCm
     if (
         "build-environment" in job.get("with", {})
         and "rocm" in job["with"]["bubuild-environment

--- a/tools/linter/adapters/workflow_consistency_linter.py
+++ b/tools/linter/adapters/workflow_consistency_linter.py
@@ -116,6 +116,9 @@ def get_jobs_with_sync_tag(
     # and ['with']['tests-to-include'], since dispatch filters differ
     if "tests-to-include" in job.get("with", {}):
         del job["with"]["tests-to-include"]
+    # and ['with']['build-environment'], since GPU-specific suffixes differ
+    if "build-environment" in job.get("with", {}):
+        del job["with"]["build-environment"]
 
     # normalize needs: remove helper job-filter so comparisons ignore it
     needs = job.get("needs")


### PR DESCRIPTION
This ensures that every gfx arch gets its own key in the dict in [test-times.json](https://raw.githubusercontent.com/pytorch/test-infra/generated-stats/stats/test-times.json), which is used to determine sharding of unit tests based on each test file's run time e.g.
```
  "linux-noble-rocm-py3.12-mi300": {
    "default": {
      "backends/xeon/test_launch": 6.392999887466431,
      "benchmark_utils/test_benchmark_utils": 0.28199999779462814,
      "complex_tensor/test_complex_tensor": 15.334999799728394,
```

As a result, the sharding for each gfx arch will be done using numbers specifically captured for that gfx arch i.e. sharding for an MI355 run wouldn't be done using numbers for a Navi31 run (which could have very different run times), or vice-versa. This should, in general, result in more equitable shard durations for each of the test runs on any gfx arch.



### Inductor

The workflow job name changes for inductor configs (e.g. `rocm-py3.12-inductor-mi300` → `linux-noble-rocm-py3.12-mi300`) will not show improved sharding until after this PR is merged. This is because test-times.json is populated by a [daily stats pipeline](https://github.com/pytorch/test-infra/blob/9492bbd4a0a70f547bec904620af365a8f26694c/tools/torchci/update_test_times.py) that only collects test durations from jobs that ran on [`viable/strict`](https://github.com/pytorch/test-infra/blob/03b8fcda76a50c4e1b62e5e2deb5967ae84d88a4/torchci/clickhouse_queries/test_times/per_file/query.sql#L2-L9) (i.e. main after CI passes). Since the new job names have never run on `viable/strict`, there is no inductor timing data under the new keys yet. After merge, the scheduled inductor-rocm workflows will run on main, the stats pipeline will pick up the data, and subsequent inductor runs will shard using GPU-specific times.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang
