### PR TITLE
[dtensor] Fix tp_conv rejecting batch-dim-only sharding for valid configs

### DIFF
--- a/test/distributed/tensor/test_convolution_ops.py
+++ b/test/distributed/tensor/test_convolution_ops.py
@@ -294,6 +294,33 @@ class DistConvolutionOpsTest(DTensorTestBase):
         self.assertIsNotNone(w_dt.grad)
         self.assertEqual(w_dt.grad.shape, torch.Size([8, 4, 3, 3]))
 
+    @with_tf32_off
+    @with_comms
+    @skip_if_lt_x_gpu(2)
+    def test_conv2d_batch_shard_strided(self):
+        """Batch-dim sharding with stride != 1 should not hit _is_supported."""
+        device_mesh = self.build_device_mesh()
+
+        model = nn.Conv2d(3, 8, kernel_size=7, stride=2, padding=3).to(
+            self.device_type
+        )
+        model_ref = copy.deepcopy(model).to(self.device_type)
+        model = distribute_module(model, device_mesh, _conv_fn)
+
+        x = torch.randn(4, 3, 16, 16, device=self.device_type, requires_grad=True)
+        x_ref = x.detach().clone().requires_grad_(True)
+        x_dt = distribute_tensor(x, device_mesh, [Shard(0)])
+
+        out_dt = model(x_dt)
+        out_ref = model_ref(x_ref)
+        self.assertEqual(out_dt.full_tensor(), out_ref)
+
+        grad = torch.randn_like(out_ref)
+        grad_dt = distribute_tensor(grad, device_mesh, [Shard(0)])
+        out_dt.backward(grad_dt)
+        out_ref.backward(grad)
+        self.assertEqual(x_dt.grad.full_tensor(), x_ref.grad)
+
     @with_comms
     def test_conv2d_module_no_bias(self):
         """Test nn.Conv2d module with bias=False (Issue #167091)
@@ -332,6 +359,7 @@ DistConvolutionOpsTestWithLocalTensor = create_local_tensor_test_class(
         "test_conv_backward_none_grad_inp",
         "test_depthwise_convolution",
         "test_downsampling_convolution",
+        "test_conv2d_batch_shard_strided",
         # New tests for Issue #167091 - use send/recv via tp_convolution
         "test_conv2d_no_bias_compile",
         "test_conv2d_no_bias_backward",

--- a/test/distributed/tensor/test_convolution_ops.py
+++ b/test/distributed/tensor/test_convolution_ops.py
@@ -301,9 +301,7 @@ class DistConvolutionOpsTest(DTensorTestBase):
         """Batch-dim sharding with stride != 1 should not hit _is_supported."""
         device_mesh = self.build_device_mesh()
 
-        model = nn.Conv2d(3, 8, kernel_size=7, stride=2, padding=3).to(
-            self.device_type
-        )
+        model = nn.Conv2d(3, 8, kernel_size=7, stride=2, padding=3).to(self.device_type)
         model_ref = copy.deepcopy(model).to(self.device_type)
         model = distribute_module(model, device_mesh, _conv_fn)
 

--- a/test/distributed/tensor/test_convolution_ops.py
+++ b/test/distributed/tensor/test_convolution_ops.py
@@ -13,6 +13,7 @@ from torch.distributed.tensor import (
     Replicate,
     Shard,
 )
+from torch.distributed.tensor.debug import CommDebugMode
 from torch.nn import functional as F
 from torch.testing._internal.common_cuda import with_tf32_off
 from torch.testing._internal.common_utils import run_tests
@@ -309,13 +310,20 @@ class DistConvolutionOpsTest(DTensorTestBase):
         x_ref = x.detach().clone().requires_grad_(True)
         x_dt = distribute_tensor(x, device_mesh, [Shard(0)])
 
-        out_dt = model(x_dt)
+        comm_mode = CommDebugMode()
+        with comm_mode:
+            out_dt = model(x_dt)
+        self.assertEqual(comm_mode.get_total_counts(), 0)
+
         out_ref = model_ref(x_ref)
         self.assertEqual(out_dt.full_tensor(), out_ref)
 
         grad = torch.randn_like(out_ref)
         grad_dt = distribute_tensor(grad, device_mesh, [Shard(0)])
-        out_dt.backward(grad_dt)
+        with comm_mode:
+            out_dt.backward(grad_dt)
+        self.assertEqual(comm_mode.get_total_counts(), 0)
+
         out_ref.backward(grad)
         self.assertEqual(x_dt.grad.full_tensor(), x_ref.grad)
 

--- a/torch/distributed/tensor/_tp_conv.py
+++ b/torch/distributed/tensor/_tp_conv.py
@@ -123,8 +123,6 @@ def tp_convolution(
     weight = cast(torch.Tensor, local_tensor_args[1])
     stride, padding, dilation = local_tensor_args[3:6]
 
-    if not _is_supported(in_tensor.shape, weight.shape, stride, padding, dilation):
-        raise AssertionError
     if not isinstance(padding, list):
         raise AssertionError
 
@@ -132,6 +130,8 @@ def tp_convolution(
         local_results = op_call(*local_tensor_args, **local_tensor_kwargs)
         return local_results
     else:
+        if not _is_supported(in_tensor.shape, weight.shape, stride, padding, dilation):
+            raise AssertionError
         # step 0 compute the overlap pixels of the input tensor
         d = weight.shape[-1] - 1
         d1 = d // 2
@@ -183,8 +183,6 @@ def tp_convolution_backward(
     weight = cast(torch.Tensor, local_tensor_args[2])
     stride, padding, dilation = local_tensor_args[4:7]
 
-    if not _is_supported(in_tensor.shape, weight.shape, stride, padding, dilation):
-        raise AssertionError
     if not isinstance(padding, list):
         raise AssertionError
 
@@ -192,6 +190,8 @@ def tp_convolution_backward(
         local_results = op_call(*local_tensor_args, **local_tensor_kwargs)
         return local_results
     else:
+        if not _is_supported(in_tensor.shape, weight.shape, stride, padding, dilation):
+            raise AssertionError
         # step 0 compute the overlap pixels of the input tensor
         d = weight.shape[3] - 1
         d1 = d // 2

--- a/torch/distributed/tensor/_tp_conv.py
+++ b/torch/distributed/tensor/_tp_conv.py
@@ -131,7 +131,9 @@ def tp_convolution(
         return local_results
     else:
         if not _is_supported(in_tensor.shape, weight.shape, stride, padding, dilation):
-            raise AssertionError
+            raise AssertionError(
+                "tp_convolution data exchange requires supported stride/padding/dilation"
+            )
         # step 0 compute the overlap pixels of the input tensor
         d = weight.shape[-1] - 1
         d1 = d // 2
@@ -191,7 +193,9 @@ def tp_convolution_backward(
         return local_results
     else:
         if not _is_supported(in_tensor.shape, weight.shape, stride, padding, dilation):
-            raise AssertionError
+            raise AssertionError(
+                "tp_convolution_backward data exchange requires supported stride/padding/dilation"
+            )
         # step 0 compute the overlap pixels of the input tensor
         d = weight.shape[3] - 1
         d1 = d // 2


### PR DESCRIPTION
Fixes #176446

Move _is_supported() past the _requires_data_exchange() early-return in both tp_convolution() and tp_convolution_backward(). 

_is_supported() enforces spatial constraints (stride/kernel/padding relationships) that only matter when halo exchange is needed. When only the batch dim is sharded, _requires_data_exchange() returns False and the op runs locally — the spatial constraints are irrelevant.


