### PR TITLE
Use indexed storage for SAC forward/backward matching

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -15404,6 +15404,53 @@ class TestSelectiveActivationCheckpoint(TestCase):
             out.sum().backward(retain_graph=True)
 
     @skipIfTorchDynamo("compile tested in test/dynamo/test_activation_checkpointing.py")
+    def test_auto_naming_mode_with_sac(self):
+        # AutoNamingMode + SAC: policy checks ctx.op_output in naming.names
+        expensive_op, expensive_count = _make_counter_op("expensive")
+        cheap_op, cheap_count = _make_counter_op("cheap")
+
+        class Block(torch.nn.Module):
+            def forward(self, x):
+                y = expensive_op(x)
+                return cheap_op(y)
+
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.layers = torch.nn.ModuleList([Block(), Block()])
+
+            def forward(self, x):
+                for layer in self.layers:
+                    x = layer(x)
+                return x
+
+        mod = Model()
+        naming = _AutoNamingMode()
+
+        def policy_fn(ctx, op, *args, **kwargs):
+            if ctx.is_recompute:
+                return CheckpointPolicy.PREFER_RECOMPUTE
+            out = ctx.op_output
+            if isinstance(out, torch.Tensor):
+                name = naming.names.get(out)
+                if name == ("Model.layers.1", "expensive", 0, 0):
+                    return CheckpointPolicy.MUST_SAVE
+            return CheckpointPolicy.PREFER_RECOMPUTE
+
+        x = torch.randn(4, requires_grad=True)
+        context_fn = functools.partial(create_selective_checkpoint_contexts, policy_fn)
+
+        with naming:
+            out = checkpoint(lambda x: mod(x), x, use_reentrant=False, context_fn=context_fn)
+            out.sum().backward()
+
+        # expensive_op runs twice in forward (layers.0 + layers.1),
+        # layers.1 is saved so only layers.0 is recomputed: 2 + 1 = 3
+        self.assertEqual(expensive_count[0], 3)
+        # cheap_op: neither layer matched, both recomputed: 2 + 2 = 4
+        self.assertEqual(cheap_count[0], 4)
+
+    @skipIfTorchDynamo("compile tested in test/dynamo/test_activation_checkpointing.py")
     def test_auto_naming_mode_names(self):
         class SubMod(torch.nn.Module):
             def forward(self, x):

--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -1337,6 +1337,7 @@ class _CachingTorchDispatchMode(TorchDispatchMode):
     def __init__(self, policy_fn, storage) -> None:
         self.policy_fn = policy_fn
         self.storage = storage
+        self.func_counter: Dict[Any, int] = defaultdict(int)
 
     def __torch_dispatch__(self, func, types, args=(), kwargs=None):
         kwargs = {} if kwargs is None else kwargs
@@ -1365,6 +1366,9 @@ class _CachingTorchDispatchMode(TorchDispatchMode):
         else:
             any_ret_has_alias_info = any(ret.alias_info is not None for ret in func._schema.returns)
 
+        idx = self.func_counter[func]
+        self.func_counter[func] += 1
+
         # Call policy after the op so inner modes (e.g. a naming mode) have
         # had a chance to annotate outputs before the policy inspects them.
         policy = self.policy_fn(SelectiveCheckpointContext(is_recompute=False, op_output=out),
@@ -1379,7 +1383,7 @@ class _CachingTorchDispatchMode(TorchDispatchMode):
                     node.meta["recompute"] = policy
 
         if policy in (CheckpointPolicy.MUST_SAVE, CheckpointPolicy.PREFER_SAVE) or is_compiling:
-            self.storage[func].append(tree_map(lambda x: _VersionWrapper(_maybe_detach(x, any_ret_has_alias_info)), out))
+            self.storage[func][idx] = tree_map(lambda x: _VersionWrapper(_maybe_detach(x, any_ret_has_alias_info)), out)
         return out
 
 class _CachedTorchDispatchMode(TorchDispatchMode):
@@ -1392,6 +1396,7 @@ class _CachedTorchDispatchMode(TorchDispatchMode):
         self.policy_fn = policy_fn
         self.storage = storage
         self.allow_cache_entry_mutation = allow_cache_entry_mutation
+        self.func_counter: Dict[Any, int] = defaultdict(int)
 
     def __torch_dispatch__(self, func, types, args=(), kwargs=None):
         if func in SAC_IGNORED_OPS:
@@ -1405,16 +1410,19 @@ class _CachedTorchDispatchMode(TorchDispatchMode):
 
         is_compiling = _is_compiling(func, args, kwargs)
 
-        if policy in (CheckpointPolicy.MUST_SAVE, CheckpointPolicy.PREFER_SAVE) or is_compiling:
-            storage = self.storage.get(func)
-            if storage is None:
+        idx = self.func_counter[func]
+        self.func_counter[func] += 1
+
+        cached = self.storage.get(func, {}).pop(idx, None)
+        if cached is not None:
+            out = tree_map(lambda x: x.get_val(self.allow_cache_entry_mutation), cached)
+        elif policy in (CheckpointPolicy.MUST_SAVE, CheckpointPolicy.PREFER_SAVE) or is_compiling:
+            if func not in self.storage:
                 raise RuntimeError(f"{func} encountered during backward, but not found in storage")
-            if len(storage) == 0:
-                raise RuntimeError(
-                    "Trying to backward an extra time. You are only allowed to backward once "
-                    "on any region computed under selective activation checkpoint."
-                )
-            out = tree_map(lambda x: x.get_val(self.allow_cache_entry_mutation), storage.pop(0))
+            raise RuntimeError(
+                "Trying to backward an extra time. You are only allowed to backward once "
+                "on any region computed under selective activation checkpoint."
+            )
         else:
             out = func(*args, **kwargs)
         return out
@@ -1499,7 +1507,7 @@ def create_selective_checkpoint_contexts(policy_fn_or_list, allow_cache_entry_mu
     else:
         raise TypeError("policy_fn_or_list must be either a function or a list of ops.")
 
-    storage: Dict[Any, List[Any]] = defaultdict(list)
+    storage: Dict[Any, Dict[int, Any]] = defaultdict(dict)
     return (
         _CachingTorchDispatchMode(policy_fn, storage),
         _CachedTorchDispatchMode(policy_fn, storage, allow_cache_entry_mutation),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #176451
* __->__ #176450
* #176449
* #175338
* #174328
* #174327

Switches SAC storage from List with append/pop(0) to Dict[int, Any]
keyed by per-op invocation counter. This allows the backward to find
cached values by index rather than relying on the backward policy to
reproduce the forward's save decisions, which is necessary when the
forward policy uses per-tensor information (like names) that isn't
available during backward.

Authored with Claude.