### PR TITLE
[torchTLX] unify knobs into one tlx_mode config

### DIFF
--- a/torch/_inductor/choices.py
+++ b/torch/_inductor/choices.py
@@ -229,6 +229,11 @@ class InductorChoices:
         Returns:
             True if we need to fix the layout, False otherwise
         """
+        # TLX force mode uses Triton templates which require fixed layouts
+        # This check is independent of max_autotune
+        if config.is_fbcode() and config.triton.tlx_mode == "force":
+            return True
+
         # TODO: debug and fix
         # NOTE: on mps, we see issues with flexible layouts on baddmm. This check just makes sure
         # that for mps, everything stays as it was before this optimization

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1815,10 +1815,6 @@ class triton:
         os.environ.get("TORCHINDUCTOR_MIX_ORDER_REDUCTION_ALLOW_MULTI_STAGES") == "1"
     )
 
-    enable_tlx_templates: bool = (
-        os.environ.get("TORCHINDUCTOR_ENABLE_TLX_TEMPLATES", "0") == "1"
-    )
-
     # Map for storing the amount of kernel runs with dumped input tensors
     # Based on hash of Triton source code to avoid bloating the folder
     debug_dump_kernel_inputs: dict[str, int] = {}
@@ -1827,6 +1823,14 @@ class triton:
     # When the maximum is reached the first values get overwritten
     # This ensures the last N runs are saved, where N is this value
     max_kernel_dump_occurrences = 3
+
+    # TLX template mode: "default", "allow", or "force"
+    tlx_mode: str = os.environ.get("TORCHINDUCTOR_TLX_MODE", "default")
+
+    # TLX heuristic config: when True, use heuristic-based config selection for TLX templates
+    tlx_heuristic_config: bool = (
+        os.environ.get("TORCHINDUCTOR_TLX_HEURISTIC_CONFIG", "1") == "1"
+    )
 
     proton_profiling: bool = (
         os.environ.get("TORCHINDUCTOR_TRITON_PROTON_PROFILING", "0") == "1"

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -398,7 +398,14 @@ def tuned_mm(mat1, mat2, out_dtype=None, *, layout=None):
 
     templates_to_use: list[ExternKernelChoice | KernelTemplate] = []
     kwarg_overrides: dict[str, dict[str, Any]] = {}
-    if use_aten_gemm_kernels():
+
+    # Check if TLX force mode is enabled (fbcode only)
+    tlx_force_mode = (
+        inductor_config.is_fbcode() and inductor_config.triton.tlx_mode == "force"
+    )
+
+    # Add ATEN kernels unless in TLX force mode (force mode uses only TLX)
+    if use_aten_gemm_kernels() and not tlx_force_mode:
         templates_to_use.append(aten_handler)
         if aten_extra_kwargs:
             kwarg_overrides[aten_handler.uid] = aten_extra_kwargs
@@ -424,15 +431,20 @@ def tuned_mm(mat1, mat2, out_dtype=None, *, layout=None):
             elif use_triton_tma_template(mat1, mat2, output_layout=layout):
                 templates_to_use.append(persistent_tma_mm_template)
 
-            if (
-                inductor_config.is_fbcode()
-                and inductor_config.triton.enable_tlx_templates
-            ):
-                from torch._inductor.fb.tlx_templates.mm_templates import append_tlx
-
-                templates_to_use = append_tlx(templates_to_use)
-
         templates_to_use.append(mm_contiguous_subgraph_template)
+
+    # TLX templates hook (fbcode only)
+    if inductor_config.is_fbcode():
+        from torch._inductor.fb.tlx_templates.mm_templates import apply_tlx_templates
+
+        templates_to_use = apply_tlx_templates(
+            templates_to_use,
+            m,
+            n,
+            k,
+            use_decompose_k_choice,
+            decompose_k_subgraph_template,
+        )
 
     choices.extend(
         V.choices.get_template_configs(

--- a/torch/_inductor/template_heuristics/triton.py
+++ b/torch/_inductor/template_heuristics/triton.py
@@ -814,7 +814,7 @@ class BaseConfigHeuristic(metaclass=BaseHeuristicSingleton):
                 key += (conf.epilogue_subtile, conf.warp_specialize, conf.flatten)
 
             # Add TlxGemmConfig specific fields to key if present
-            if config.is_fbcode() and config.triton.enable_tlx_templates:
+            if config.is_fbcode() and config.triton.tlx_mode in ("allow", "force"):
                 from torch._inductor.fb.tlx_templates.registry import (
                     get_tlx_config_key_and_kwargs,
                 )


### PR DESCRIPTION
Summary:
X-link: https://github.com/meta-pytorch/tritonbench/pull/917

Consolidates two separate TLX configuration knobs into a single unified `tlx_mode` config with three modes: "default", "allow", and "force".

Previously, TLX templates required setting two separate environment variables:
- `TORCHINDUCTOR_ENABLE_TLX_TEMPLATES=1` to add TLX to candidate pool
- `TORCHINDUCTOR_FORCE_TLX_EPILOGUE_FUSION=1` to force epilogue fusion

This made configuration confusing and error-prone. The new unified knob simplifies usage:
- `TORCHINDUCTOR_TLX_MODE=default` - TLX not considered (standard inductor behavior)
- `TORCHINDUCTOR_TLX_MODE=allow` - TLX added to candidates, competes via autotuning
- `TORCHINDUCTOR_TLX_MODE=force` - TLX templates enabled + forced epilogue fusion

The old `enable_tlx_templates` config and both environment variables are deprecated and removed.

Test Plan:
## Unit tests

mm template `buck run mode/opt -c fbcode.platform010_cuda_version=12.8 fbcode//caffe2/test/inductor/fb/tlx:test_tlx_templates`

fusion `buck run mode/opt -c fbcode.platform010_cuda_version=12.8 fbcode//caffe2/test/inductor/fb/tlx:test_torch_tlx`

Reviewed By: htyu



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo