### PR TITLE
[dynamo] Track mutated_sources on SideEffects for precise mutation detection

### DIFF
--- a/torch/_dynamo/side_effects.py
+++ b/torch/_dynamo/side_effects.py
@@ -45,7 +45,7 @@ from .bytecode_transformation import (
 )
 from .codegen import PyCodegen
 from .exc import collapse_resume_frames, get_stack_above_dynamo, unimplemented
-from .source import GlobalSource, LocalCellSource, Source, TempLocalSource
+from .source import AttrSource, GlobalSource, LocalCellSource, Source, TempLocalSource
 from .utils import is_frozen_dataclass, nn_module_new, object_new
 from .variables.base import (
     AttributeMutation,
@@ -57,6 +57,7 @@ from .variables.base import (
     VariableTracker,
 )
 from .variables.user_defined import FrozenDataClassVariable
+from torch.utils._ordered_set import OrderedSet
 
 
 if TYPE_CHECKING:
@@ -159,6 +160,10 @@ class SideEffects:
         # Used for temporary mutations in contexts like torch.func.functional_call,
         # where module parameters/buffers are modified but later restored.
         self.ignore_mutation_on_these_variables: set[VariableTracker] = set()
+        # Attribute-granularity mutation tracking: records the exact
+        # AttrSource for every store_attr call so that invoke_subgraph
+        # reuse can do a precise set intersection with traced_sources.
+        self.mutated_sources: OrderedSet[Source] = OrderedSet()
 
     def ignore_mutations_on(self, var: VariableTracker) -> None:
         """Mutations to this variable will be executed but not not tracked,
@@ -321,6 +326,9 @@ class SideEffects:
         self.store_attr_mutations[item][name] = value
         # Capture user stack for this mutation
         self._capture_user_stack(item)
+        item_source = getattr(item, "source", None)
+        if item_source is not None:
+            self.mutated_sources.add(AttrSource(item_source, name))
 
     def load_attr(
         self,
@@ -355,14 +363,15 @@ class SideEffects:
 
     def load_cell(self, cellvar: VariableTracker) -> VariableTracker:
         assert isinstance(cellvar, variables.CellVariable)
-        # Track cell source during subgraph tracing so that mutations to the
-        # cell (e.g. nonlocal counter = 3) are detected by the reuse mechanism.
+        # Track the cell_contents source during subgraph tracing so that
+        # mutations (e.g. nonlocal counter = 3) are detected by the reuse
+        # mechanism via set intersection with mutated_sources.
         output_graph = self.output_graph_weakref()
         if output_graph:
             cell_source = getattr(cellvar, "source", None)
             if cell_source is not None:
                 output_graph.current_tx.output.current_tracer.traced_sources.add(
-                    cell_source
+                    AttrSource(cell_source, "cell_contents")
                 )
         if self.has_pending_mutation_of_attr(cellvar, "cell_contents"):
             return self.load_attr(cellvar, "cell_contents", check=False)
@@ -728,6 +737,8 @@ class SideEffects:
 
         if isinstance(var.mutation_type, ValueMutationExisting):
             var.mutation_type.is_modified = True
+        if var.source is not None:
+            self.mutated_sources.add(var.source)
         if (
             var.source
             and isinstance(var, variables.ConstDictVariable)

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -5226,32 +5226,19 @@ def _has_mutated_vars(
     tx: "InstructionTranslator",
     traced_sources: set[Any],
 ) -> bool:
-    """Check if any variable accessed by the subgraph has been mutated.
+    """Check if any source accessed by the subgraph has been mutated.
 
-    Guards are snapshotted on sources, but if the object behind a source has
-    been mutated (e.g. ``cfg.c = 10``), the guard would still resolve to the
-    original (pre-mutation) value because the actual Python object isn't
-    updated until codegen. We must bail out of reuse in this case.
-
-    traced_sources contains all sources accessed via VariableBuilder during
-    the subgraph trace, plus cell sources from load_cell. This covers both
-    direct inputs (arg_sources) and captured variables (freevars, cells).
+    SideEffects.mutated_sources records the exact AttrSource for every
+    store_attr call. A simple set intersection with traced_sources tells
+    us whether any source the subgraph read was later written to.
     """
-    from torch._dynamo.source import is_from_source
-
-    for var in tx.output.side_effects._get_modified_vars():
-        var_source = getattr(var, "source", None)
-        if var_source is None:
-            continue
-        for ts in traced_sources:
-            if is_from_source(ts, var_source):
-                hc_log.debug(
-                    "subgraph_reuse: mutated variable detected -- %s (source: %r)",
-                    type(var).__name__,
-                    var_source,
-                )
-                return True
-
+    overlap = tx.output.side_effects.mutated_sources & traced_sources
+    if overlap:
+        hc_log.debug(
+            "subgraph_reuse: mutated sources detected -- %s",
+            overlap,
+        )
+        return True
     return False
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #176469
* #176460
* #176459
* #176033
* #176082
* #176453
* #176452

Record the exact source (AttrSource for store_attr, var.source for
value mutations) into an OrderedSet on SideEffects. This enables
invoke_subgraph reuse to detect mutations via a simple set
intersection with traced_sources instead of walking source chains,
and is more precise -- mutating mod.d no longer invalidates a
subgraph that only read mod.c.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo