### PR TITLE
Fix UnicodeDecodeError in Triton depthwise conv template

### DIFF
--- a/torch/_inductor/kernel/templates/triton_depthwise_conv.py.jinja
+++ b/torch/_inductor/kernel/templates/triton_depthwise_conv.py.jinja
@@ -1,5 +1,5 @@
 {{def_kernel("X", "W")}}
-    # Depthwise conv1d – channels-last (NLC) layout
+    # Depthwise conv1d - channels-last (NLC) layout
     # Each group has exactly 1 input channel (groups == in_channels == out_channels)
     # 3D tiling: BLOCK_N x BLOCK_L x BLOCK_C
     # Matches the hand-written NLC kernel from depthwise_conv1d_benchmark.py


### PR DESCRIPTION
Summary:
Our test is failing with a `UnicodeDecodeError` during Triton template loading. The cause was a non-ASCII em-dash character (`–`, U+2013) in a comment on line 2 of `triton_depthwise_conv.py.jinja`. When the Triton template engine reads the file, it uses ASCII decoding, which cannot handle multi-byte UTF-8 characters.

The fix replaces the em-dash with a standard ASCII hyphen (`-`).

Test Plan: Ran cogwheel test

Reviewed By: chevalierNoir, kqfu

Differential Revision: D95211429




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo