### PR TITLE
Skip redundant dtype cast in _to_copy_backward

### DIFF
--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -7212,7 +7212,13 @@ Tensor _to_copy_backward(
     grad = c10::MaybeOwned<at::Tensor>::owned(at::real(grad_));
   }
 
-  return grad->to(self_options, /*non_blocking=*/false, /*copy=*/false);
+  // Skip dtype cast — the engine's validate_outputs handles dtype via
+  // grad_dtype, avoiding redundant casts in mixed precision
+  // (e.g. bf16→f32→bf16 becomes a no-op).
+  return grad->to(
+      self_options.dtype(grad->scalar_type()),
+      /*non_blocking=*/false,
+      /*copy=*/false);
 }
 
 std::tuple<Tensor, Tensor> index_reduce_backward(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #176488

The engine's validate_outputs already handles dtype conversion via
grad_dtype after every node. The dtype cast in _to_copy_backward is
therefore always redundant — for mixed precision with grad_dtype set,
it causes a pointless bf16→f32→bf16 round-trip. This change skips
the dtype part of the conversion (keeping device/layout/complex
handling) and lets validate_outputs handle dtype.

Authored with Claude.