### PR TITLE
[claude skill] run ts vs sigmoid benchmark with strobe profiling and op comparison

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -18150,6 +18150,48 @@ def forward(self, x):
         exported_param_names = [name for name, _ in gm.named_parameters()]
         self.assertEqual(original_param_names, exported_param_names)
 
+    def test_run_decompositions_tensor_list_list(self):
+        """run_decompositions should work for custom ops with List[List[Tensor]] args.
+
+        The C++ Functionalize kernel strips the FakeTensor subclass from tensors
+        in List[List[Tensor]] args. The fix bypasses the C++ kernel using
+        Python-level functionalization for these ops.
+        """
+        lib = torch.library.Library("test_tll", "DEF")
+        lib.define(
+            "merge_op(Tensor[][] nested, Tensor[] flat, int[] weights)"
+            " -> (Tensor[], Tensor)",
+            tags=[torch.Tag.pt2_compliant_tag],
+        )
+
+        @torch.library.impl("test_tll::merge_op", "cpu", lib=lib)
+        def merge_op_cpu(nested, flat, weights):
+            out = [nested[i][0] + flat[i] for i in range(len(flat))]
+            combined = torch.cat([f.unsqueeze(0) for f in flat], dim=0).sum(dim=0)
+            return out, combined
+
+        @torch.library.register_fake("test_tll::merge_op")
+        def merge_op_fake(nested, flat, weights):
+            out = [torch.empty_like(flat[i]) for i in range(len(flat))]
+            combined = torch.empty_like(flat[0])
+            return out, combined
+
+        class M(torch.nn.Module):
+            def forward(self, a, b, c, d):
+                return torch.ops.test_tll.merge_op([[a, b], [c, d]], [a, c], [1, 2])
+
+        m = M()
+        a, b, c, d = (torch.randn(3, 4) for _ in range(4))
+        ep = export(m, (a, b, c, d))
+        ep2 = ep.run_decompositions({})
+        eager_out = m(a, b, c, d)
+        decomp_out = ep2.module()(a, b, c, d)
+        self.assertEqual(len(eager_out[0]), len(decomp_out[0]))
+        for e, d_ in zip(eager_out[0], decomp_out[0]):
+            self.assertEqual(e, d_)
+        self.assertEqual(eager_out[1], decomp_out[1])
+        del lib
+
 
 @unittest.skipIf(not torchdynamo.is_dynamo_supported(), "dynamo doesn't support")
 class TestExportCustomClass(TorchTestCase):

--- a/torch/_subclasses/functional_tensor.py
+++ b/torch/_subclasses/functional_tensor.py
@@ -35,6 +35,16 @@ from torch.utils._python_dispatch import (
 not_implemented_log = torch._logging.getArtifactLogger(__name__, "not_implemented")
 
 
+def _has_tensor_list_list_in_schema(func: Any) -> bool:
+    """Check if op schema has any List[List[Tensor]] arguments."""
+    if not isinstance(func, torch._ops.OpOverload):
+        return False
+    for arg in func._schema.arguments:
+        if "List[List[Tensor]]" in str(arg.type):
+            return True
+    return False
+
+
 # NOTE Some special handling for tensor conversion during export is needed.
 # Normally, when tracing through the model with tensor.to(), the maybe-aliasing
 # relationship between input and output tensors will be baked into the graph.
@@ -562,6 +572,22 @@ class FunctionalTensorMode(TorchDispatchMode):
             # inputs are FakeScriptObjects, we need to skip c++ dispatcher and
             # dispatch in python because C++ dispatcher will check the schema
             # and cannot recognize FakeScriptObject.
+            ctx = PythonFunctionalizeAPI()
+            fully_unwrapped_args = ctx.unwrap_tensors(args)
+            fully_unwrapped_kwargs = ctx.unwrap_tensors(
+                kwargs  # pyrefly: ignore[bad-argument-type]
+            )
+            outs_unwrapped = func(
+                *fully_unwrapped_args,
+                **fully_unwrapped_kwargs,
+            )
+            outs_wrapped = ctx.wrap_tensors(outs_unwrapped)
+        elif _has_tensor_list_list_in_schema(func):
+            # The C++ Functionalize kernel has a bug where it strips the
+            # FakeTensor Python subclass from tensors in List[List[Tensor]]
+            # args during conversion between Python list[list[Tensor]] and
+            # C++ c10::List<c10::List<at::Tensor>>. Bypass the C++ kernel
+            # using Python-level functionalization, same as TorchBindOpOverload.
             ctx = PythonFunctionalizeAPI()
             fully_unwrapped_args = ctx.unwrap_tensors(args)
             fully_unwrapped_kwargs = ctx.unwrap_tensors(

--- a/torch/nativert/executor/ConstantFolder.cpp
+++ b/torch/nativert/executor/ConstantFolder.cpp
@@ -123,10 +123,12 @@ void ConstantFolder::unlinkConstants(
     }
   }
 
-  for (const auto& f : foldables_) {
-    VLOG(1) << "Const-folded node: " << *f.node;
+  if (VLOG_IS_ON(1)) {
+    for (const auto& f : foldables_) {
+      VLOG(1) << "Const-folded node: " << *f.node;
+    }
+    VLOG(1) << "Const-folded " << foldables_.size() << " nodes";
   }
-  LOG(INFO) << "Const-folded " << foldables_.size() << " nodes";
 
   // remove moved (i.e., associated w/ const-folded nodes) kernels
   // from the input kernel vector

--- a/torch/nativert/graph/Graph.cpp
+++ b/torch/nativert/graph/Graph.cpp
@@ -553,6 +553,24 @@ bool Graph::cleanupDeadNodes() {
 
   const bool mutated = !toRemove.empty();
 
+  if (mutated && VLOG_IS_ON(1)) {
+    c10::FastMap<std::string_view, int> removedByTarget;
+    for (const auto* n : toRemove) {
+      removedByTarget[n->target()]++;
+    }
+    VLOG(1) << "cleanupDeadNodes: removing " << toRemove.size()
+            << " dead nodes. Breakdown by op:";
+    // Sort by count descending for readability
+    std::vector<std::pair<std::string_view, int>> sorted(
+        removedByTarget.begin(), removedByTarget.end());
+    std::sort(sorted.begin(), sorted.end(), [](const auto& a, const auto& b) {
+      return a.second > b.second;
+    });
+    for (const auto& [target, count] : sorted) {
+      VLOG(1) << "  " << target << ": " << count;
+    }
+  }
+
   // Remove nodes in reverse order to handle input/output dependencies
   for (auto it = toRemove.rbegin(); it != toRemove.rend(); ++it) {
     removeNode(*it);

--- a/torch/nativert/graph/passes/pass_manager/PassManager.cpp
+++ b/torch/nativert/graph/passes/pass_manager/PassManager.cpp
@@ -26,9 +26,28 @@ bool GraphPassManager::run(Graph* graph) {
 bool GraphPassManager::run_pass(Graph* graph, const GraphPassIdentifier& name) {
   const auto& pass = GraphPassRegistry::get().get_pass(name);
 
+  size_t nodesBefore = 0;
+  if (VLOG_IS_ON(1)) {
+    nodesBefore = graph->nodes().size();
+  }
+
   bool changed = pass_pre_run_hook(graph, pass);
   changed |= (pass.get())(graph);
   changed |= pass_post_run_hook(graph, pass);
+
+  if (VLOG_IS_ON(1)) {
+    size_t nodesAfter = graph->nodes().size();
+    if (changed) {
+      VLOG(1) << "Pass " << name << ": " << nodesBefore << " -> "
+              << nodesAfter << " nodes (delta: "
+              << static_cast<int64_t>(nodesAfter) -
+              static_cast<int64_t>(nodesBefore)
+              << ")";
+    } else {
+      VLOG(1) << "Pass " << name << ": no change (" << nodesAfter
+              << " nodes)";
+    }
+  }
 
   return changed;
 }


### PR DESCRIPTION
Summary:
Add Strobelight profiling and graph pass logging to TS vs Sigmoid benchmarking
Enhances the benchmark-ts-vs-sigmoid Claude skill with:
Strobelight profiling: New run_benchmark.sh script to collect CPU flamegraphs during benchmarks
Graph pass observability: VLOG instrumentation in ModelRunner, PassManager, Graph, and ConstantFolder to track node count changes and dead code elimination
Improved documentation: Relocated to sigmoid/inference/.claude/skills with expanded workflow guide covering profiling, VLOG usage, and MTIA support
Enables performance engineers to correlate CPU hotspots with specific graph optimizations and debug pass effectiveness.

Test Plan:
Example outputs:
Doc: https://docs.google.com/document/d/1-gyMc9Z9ZZneu3s1eKG8BbxrH5jEuRNTCZM1d-FwNm8/edit?usp=sharing
Visualization: https://www.internalfb.com/intern/px/p/91hvp/

Differential Revision: D95226656


