### PR TITLE
Skip redundant dtype cast in _to_copy_backward

### DIFF
--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -7212,6 +7212,14 @@ Tensor _to_copy_backward(
     grad = c10::MaybeOwned<at::Tensor>::owned(at::real(grad_));
   }
 
+  // When only dtype differs, skip it — the engine's validate_outputs handles
+  // dtype via grad_dtype, avoiding redundant casts in mixed precision
+  // (e.g. bf16→f32→bf16 becomes a no-op). When device or layout also differs,
+  // do the full .to() so the conversion can be fused into one kernel.
+  if (grad->device() == self_options.device() &&
+      grad->layout() == self_options.layout()) {
+    return *grad;
+  }
   return grad->to(self_options, /*non_blocking=*/false, /*copy=*/false);
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #176494

The engine's validate_outputs already handles dtype conversion via
grad_dtype after every node. When _to_copy only changed the dtype
(same device/layout), the dtype cast in _to_copy_backward is redundant
— for mixed precision with grad_dtype set, it causes a pointless
bf16→f32→bf16 round-trip. When device or layout also differs, we keep
the full .to() so the conversion can be fused into one kernel.

Authored with Claude.