### PR TITLE
Add cuDNN depthwise convolution backend flag

### DIFF
--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -85,6 +85,29 @@ std::string precision2str(Float32Precision prec) {
   TORCH_CHECK(false, "Invalid enum Float32Precision(", static_cast<int>(prec), ")");
 }
 
+CuDNNDepthwiseKernel str2cudnn_depthwise(const std::string& name) {
+  if (name == "auto")
+    return CuDNNDepthwiseKernel::AUTO;
+  else if (name == "cudnn")
+    return CuDNNDepthwiseKernel::CUDNN;
+  else if (name == "native")
+    return CuDNNDepthwiseKernel::NATIVE;
+  TORCH_CHECK(false, "Unknown cuDNN depthwise kernel mode: ", name,
+              ". Expected one of: auto, cudnn, native");
+}
+
+std::string cudnn_depthwise2str(CuDNNDepthwiseKernel k) {
+  switch (k) {
+    case CuDNNDepthwiseKernel::AUTO:
+      return "auto";
+    case CuDNNDepthwiseKernel::CUDNN:
+      return "cudnn";
+    case CuDNNDepthwiseKernel::NATIVE:
+      return "native";
+  }
+  TORCH_CHECK(false, "Invalid enum CuDNNDepthwiseKernel(", static_cast<int>(k), ")");
+}
+
 #ifdef USE_ROCM
 static constexpr const auto rocm_allow_group_gemm_ck = "ROCM_ALLOW_GROUP_GEMM_CK";
 #endif
@@ -180,6 +203,14 @@ bool Context::userEnabledNNPACK() const {
 
 void Context::setUserEnabledNNPACK(bool e) {
   enabled_nnpack = e;
+}
+
+CuDNNDepthwiseKernel Context::cudnnDepthwiseKernel() const {
+  return depthwise_kernel_cudnn;
+}
+
+void Context::setCuDNNDepthwiseKernel(CuDNNDepthwiseKernel k) {
+  depthwise_kernel_cudnn = k;
 }
 
 bool Context::allowTF32CuDNN(std::optional<Float32Op> op) const {

--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -49,10 +49,14 @@ enum class TORCH_API Float32Backend { GENERIC, CUDA, MKLDNN };
 enum class TORCH_API Float32Op { ALL, CONV, RNN, MATMUL };
 enum class TORCH_API Float32Precision { NONE, IEEE, TF32, BF16 };
 
+enum class TORCH_API CuDNNDepthwiseKernel { AUTO, CUDNN, NATIVE };
+
 TORCH_API Float32Backend str2backend(const std::string& name);
 TORCH_API Float32Op str2op(const std::string& name);
 TORCH_API Float32Precision str2precision(const std::string& name);
 TORCH_API std::string precision2str(Float32Precision prec);
+TORCH_API CuDNNDepthwiseKernel str2cudnn_depthwise(const std::string& name);
+TORCH_API std::string cudnn_depthwise2str(CuDNNDepthwiseKernel k);
 
 class TORCH_API Context {
  public:
@@ -250,6 +254,9 @@ class TORCH_API Context {
   void setDeterministicMkldnn(bool /*b*/);
   bool userEnabledNNPACK() const;
   void setUserEnabledNNPACK(bool e);
+
+  CuDNNDepthwiseKernel cudnnDepthwiseKernel() const;
+  void setCuDNNDepthwiseKernel(CuDNNDepthwiseKernel k);
 
   // Note [Disabling Fused SDP Kernels]
   // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -494,6 +501,7 @@ class TORCH_API Context {
   bool enabled_mkldnn = true;
   bool allow_tf32_onednn = false;
   bool enabled_nnpack = true;
+  CuDNNDepthwiseKernel depthwise_kernel_cudnn = CuDNNDepthwiseKernel::AUTO;
   at::LinalgBackend linalg_preferred_backend =
       (c10::utils::check_env("TORCH_LINALG_PREFER_CUSOLVER") == true ||
        c10::utils::check_env("TORCH_LINALG_PREFER_HIPSOLVER") == true) // alias

--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -473,6 +473,12 @@ struct ConvParams {
                            (stride[0] == stride[1] || at::symint::size<T>(input, 2) == 1) && // square or 1d
                            at::symint::size<T>(input, 1) >= 32); // min 32 channels supported)
       if (kernel_cond) {
+        auto depthwise_kernel = at::globalContext().cudnnDepthwiseKernel();
+        if (depthwise_kernel == at::CuDNNDepthwiseKernel::NATIVE) {
+          return false;
+        } else if (depthwise_kernel == at::CuDNNDepthwiseKernel::CUDNN) {
+          return true;
+        }
         return check_cudnn_depthwise_workload_with_filter<T>(input, stride[1], weight);
       }
       return false;

--- a/test/nn/test_convolution.py
+++ b/test/nn/test_convolution.py
@@ -3640,6 +3640,31 @@ class TestConvolutionNNDeviceType(NNTestCase):
             with torch.backends.cudnn.flags(enabled=cudnn_enabled):
                 torch.autograd.gradcheck(conv2d_depthwise, (x, weight))
 
+    @onlyCUDA
+    @skipCUDAIfNoCudnn
+    @skipCUDAIfRocm
+    @dtypes(torch.half)
+    def test_Conv2d_depthwise_kernel_flag(self, device, dtype):
+        # Use shapes that qualify for the cuDNN depthwise path:
+        # FP16, depthwise (groups==channels), 4D, no dilation, >= 32 channels
+        channels = 32
+        x = torch.randn(2, channels, 16, 16, device=device, dtype=dtype)
+        conv = nn.Conv2d(
+            channels, channels, kernel_size=3, padding=1, groups=channels
+        ).to(device, dtype)
+
+        # All three modes should produce the same numerics
+        results = {}
+        for mode in ("auto", "cudnn", "native"):
+            with torch.backends.cudnn.flags(
+                enabled=True, benchmark=False, deterministic=True,
+                depthwise_kernel=mode,
+            ):
+                results[mode] = conv(x).detach().clone()
+
+        self.assertEqual(results["cudnn"], results["native"], atol=1e-3, rtol=1e-3)
+        self.assertEqual(results["auto"], results["native"], atol=1e-3, rtol=1e-3)
+
     @onlyCPU
     @dtypes(torch.float, torch.double)
     def test_conv_thnn_nhwc(self, device, dtype):

--- a/test/nn/test_convolution.py
+++ b/test/nn/test_convolution.py
@@ -3657,7 +3657,9 @@ class TestConvolutionNNDeviceType(NNTestCase):
         results = {}
         for mode in ("auto", "cudnn", "native"):
             with torch.backends.cudnn.flags(
-                enabled=True, benchmark=False, deterministic=True,
+                enabled=True,
+                benchmark=False,
+                deterministic=True,
                 depthwise_kernel=mode,
             ):
                 results[mode] = conv(x).detach().clone()

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1050,8 +1050,11 @@ print(t.is_pinned())
         # Test all valid values via the flags() context manager
         for mode in ("auto", "cudnn", "native"):
             with torch.backends.cudnn.flags(
-                enabled=None, benchmark=None, deterministic=None,
-                allow_tf32=None, depthwise_kernel=mode,
+                enabled=None,
+                benchmark=None,
+                deterministic=None,
+                allow_tf32=None,
+                depthwise_kernel=mode,
             ):
                 self.assertEqual(torch.backends.cudnn.depthwise_kernel, mode)
 
@@ -1061,8 +1064,11 @@ print(t.is_pinned())
 
         # Verify the flags() context manager restores the previous value
         with torch.backends.cudnn.flags(
-            enabled=None, benchmark=None, deterministic=None,
-            allow_tf32=None, depthwise_kernel="native",
+            enabled=None,
+            benchmark=None,
+            deterministic=None,
+            allow_tf32=None,
+            depthwise_kernel="native",
         ):
             self.assertEqual(torch.backends.cudnn.depthwise_kernel, "native")
         self.assertEqual(torch.backends.cudnn.depthwise_kernel, "auto")

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1044,6 +1044,29 @@ print(t.is_pinned())
         ):
             self.assertTrue(torch.backends.cudnn.allow_tf32)
 
+    def test_cudnn_depthwise_kernel_get_set(self):
+        self.assertEqual(torch.backends.cudnn.depthwise_kernel, "auto")
+
+        # Test all valid values via the flags() context manager
+        for mode in ("auto", "cudnn", "native"):
+            with torch.backends.cudnn.flags(
+                enabled=None, benchmark=None, deterministic=None,
+                allow_tf32=None, depthwise_kernel=mode,
+            ):
+                self.assertEqual(torch.backends.cudnn.depthwise_kernel, mode)
+
+        # Invalid value should raise
+        with self.assertRaises(RuntimeError):
+            torch._C._set_cudnn_depthwise_kernel("invalid")
+
+        # Verify the flags() context manager restores the previous value
+        with torch.backends.cudnn.flags(
+            enabled=None, benchmark=None, deterministic=None,
+            allow_tf32=None, depthwise_kernel="native",
+        ):
+            self.assertEqual(torch.backends.cudnn.depthwise_kernel, "native")
+        self.assertEqual(torch.backends.cudnn.depthwise_kernel, "auto")
+
     @recover_orig_fp32_precision
     def test_fp32_precision_with_tf32(self):
         with torch.backends.cudnn.flags(

--- a/torch/_C/__init__.pyi.in
+++ b/torch/_C/__init__.pyi.in
@@ -1236,7 +1236,9 @@ def _set_mkldnn_enabled(arg: _bool) -> None: ...  # THPModule_setUserEnabledMkld
 def _get_cudnn_benchmark() -> _bool: ...  # THPModule_benchmarkCuDNN
 def _set_cudnn_benchmark(arg: _bool) -> None: ...  # THPModule_setBenchmarkCuDNN
 def _get_cudnn_depthwise_kernel() -> str: ...  # THPModule_getCuDNNDepthwiseKernel
-def _set_cudnn_depthwise_kernel(arg: str) -> None: ...  # THPModule_setCuDNNDepthwiseKernel
+def _set_cudnn_depthwise_kernel(
+    arg: str,
+) -> None: ...  # THPModule_setCuDNNDepthwiseKernel
 def _get_miopen_immediate() -> _bool: ...  # THPModule_userImmediateMiopen
 def _set_miopen_immediate(arg: _bool) -> None: ...  # THPModule_setUserImmediateMiopen
 def _get_cudnn_deterministic() -> _bool: ...  # THPModule_deterministicCuDNN

--- a/torch/_C/__init__.pyi.in
+++ b/torch/_C/__init__.pyi.in
@@ -1235,6 +1235,8 @@ def _get_mkldnn_enabled() -> _bool: ...  # THPModule_userEnabledMkldnn
 def _set_mkldnn_enabled(arg: _bool) -> None: ...  # THPModule_setUserEnabledMkldnn
 def _get_cudnn_benchmark() -> _bool: ...  # THPModule_benchmarkCuDNN
 def _set_cudnn_benchmark(arg: _bool) -> None: ...  # THPModule_setBenchmarkCuDNN
+def _get_cudnn_depthwise_kernel() -> str: ...  # THPModule_getCuDNNDepthwiseKernel
+def _set_cudnn_depthwise_kernel(arg: str) -> None: ...  # THPModule_setCuDNNDepthwiseKernel
 def _get_miopen_immediate() -> _bool: ...  # THPModule_userImmediateMiopen
 def _set_miopen_immediate(arg: _bool) -> None: ...  # THPModule_setUserImmediateMiopen
 def _get_cudnn_deterministic() -> _bool: ...  # THPModule_deterministicCuDNN

--- a/torch/backends/cudnn/__init__.py
+++ b/torch/backends/cudnn/__init__.py
@@ -158,6 +158,7 @@ def set_flags(
     _deterministic=None,
     _allow_tf32=None,
     _fp32_precision="none",
+    _depthwise_kernel=None,
 ):
     orig_flags = (
         torch._C._get_cudnn_enabled(),
@@ -166,6 +167,7 @@ def set_flags(
         torch._C._get_cudnn_deterministic(),
         torch._C._get_cudnn_allow_tf32(),
         torch._C._get_fp32_precision_getter("cuda", "all"),
+        torch._C._get_cudnn_depthwise_kernel(),
     )
     if _enabled is not None:
         torch._C._set_cudnn_enabled(_enabled)
@@ -179,6 +181,8 @@ def set_flags(
         torch._C._set_cudnn_allow_tf32(_allow_tf32)
     if _fp32_precision is not None:
         torch._C._set_fp32_precision_setter("cuda", "all", _fp32_precision)
+    if _depthwise_kernel is not None:
+        torch._C._set_cudnn_depthwise_kernel(_depthwise_kernel)
     return orig_flags
 
 
@@ -190,6 +194,7 @@ def flags(
     deterministic=False,
     allow_tf32=True,
     fp32_precision="none",
+    depthwise_kernel="auto",
 ):
     with __allow_nonbracketed_mutation():
         orig_flags = set_flags(
@@ -199,6 +204,7 @@ def flags(
             deterministic,
             allow_tf32,
             fp32_precision,
+            depthwise_kernel,
         )
     try:
         yield
@@ -235,6 +241,10 @@ class CudnnModule(PropModule):
         _get_fp32_precision_getter("cuda", "all"),
         _set_fp32_precision_setter("cuda", "all"),
     )
+    depthwise_kernel = ContextProp(
+        torch._C._get_cudnn_depthwise_kernel,
+        torch._C._set_cudnn_depthwise_kernel,
+    )
 
 
 # This is the sys.modules replacement trick, see
@@ -248,3 +258,4 @@ benchmark: bool
 allow_tf32: bool
 fp32_precision: str
 benchmark_limit: int
+depthwise_kernel: str

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -1310,6 +1310,31 @@ static PyObject* THPModule_benchmarkCuDNN(PyObject* _unused, PyObject* noargs) {
   Py_RETURN_FALSE;
 }
 
+static PyObject* THPModule_setCuDNNDepthwiseKernel(
+    PyObject* _unused,
+    PyObject* arg) {
+  HANDLE_TH_ERRORS
+  TORCH_CHECK(
+      THPUtils_checkString(arg),
+      "set_cudnn_depthwise_kernel expects a string, "
+      "but got ",
+      THPUtils_typename(arg));
+  std::string mode = THPUtils_unpackString(arg);
+  at::globalContext().setCuDNNDepthwiseKernel(at::str2cudnn_depthwise(mode));
+  Py_RETURN_NONE;
+  END_HANDLE_TH_ERRORS
+}
+
+static PyObject* THPModule_getCuDNNDepthwiseKernel(
+    PyObject* _unused,
+    PyObject* noargs) {
+  HANDLE_TH_ERRORS
+  auto mode = at::cudnn_depthwise2str(
+      at::globalContext().cudnnDepthwiseKernel());
+  return THPUtils_packString(mode);
+  END_HANDLE_TH_ERRORS
+}
+
 static PyObject* THPModule_setImmediateMiopen(
     PyObject* _unused,
     PyObject* arg) {
@@ -1936,6 +1961,14 @@ static std::initializer_list<PyMethodDef> TorchMethods = {
     {"_set_onednn_allow_tf32", THPModule_setAllowTF32OneDNN, METH_O, nullptr},
     {"_get_cudnn_benchmark", THPModule_benchmarkCuDNN, METH_NOARGS, nullptr},
     {"_set_cudnn_benchmark", THPModule_setBenchmarkCuDNN, METH_O, nullptr},
+    {"_get_cudnn_depthwise_kernel",
+     THPModule_getCuDNNDepthwiseKernel,
+     METH_NOARGS,
+     nullptr},
+    {"_set_cudnn_depthwise_kernel",
+     THPModule_setCuDNNDepthwiseKernel,
+     METH_O,
+     nullptr},
     {"_get_miopen_immediate", THPModule_immediateMiopen, METH_NOARGS, nullptr},
     {"_set_miopen_immediate", THPModule_setImmediateMiopen, METH_O, nullptr},
     {"_get_cudnn_deterministic",

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -1329,8 +1329,8 @@ static PyObject* THPModule_getCuDNNDepthwiseKernel(
     PyObject* _unused,
     PyObject* noargs) {
   HANDLE_TH_ERRORS
-  auto mode = at::cudnn_depthwise2str(
-      at::globalContext().cudnnDepthwiseKernel());
+  auto mode =
+      at::cudnn_depthwise2str(at::globalContext().cudnnDepthwiseKernel());
   return THPUtils_packString(mode);
   END_HANDLE_TH_ERRORS
 }


### PR DESCRIPTION
This change was separated from #170609, and adds a context flag to select the backend kernel for depthwise convolution. This allows easy benchmarking of cuDNN performance relative to fallback performance for heuristic tuning (and could also be used for debugging), while maintaining default behavior for standard use. 

There are three options: `["auto", "cudnn", "native"]`. The `"auto"` option chooses a kernel based on the existing heuristic function. The `"cudnn"` and `"native"` flags skip the heuristic, instead always dispatching to a cuDNN kernel or a fallback kernel, respectively.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01 @eqy 