### PR TITLE
[inductor][auto_chunker] Add support for amax backward

### DIFF
--- a/test/inductor/test_auto_chunker.py
+++ b/test/inductor/test_auto_chunker.py
@@ -271,6 +271,31 @@ class AutoChunkerTest(TestCase):
         self.assertTrue(same(expect, actual, tol=1e-3))
         self.assertEqual(metrics.num_auto_chunking, 1)
 
+    @config.patch("auto_chunker.output_size_threshold", 1024)
+    @config.patch("auto_chunker.num_chunk", 2)
+    def test_propagate_amax_unsqueeze(self):
+        M, K, N = 256, 4, 256
+        x = torch.randn(M, K, device=GPU_TYPE, requires_grad=True)
+        w = torch.randn(K, N, device=GPU_TYPE, requires_grad=True)
+
+        def f(x, w):
+            out = (x * 2) @ w
+            max_val = out.amax(dim=-1)
+            out = out - max_val.unsqueeze(-1)
+            out = torch.exp(out)
+            loss = out.sum()
+            loss.backward()
+            return loss
+
+        expect = (f(x, w), x.grad, w.grad)
+        x.grad = None
+        w.grad = None
+        opt_f = torch.compile(f)
+        actual = (opt_f(x, w), x.grad, w.grad)
+
+        self.assertTrue(same(expect, actual, tol=1e-3))
+        self.assertEqual(metrics.num_auto_chunking, 1)
+
     def test_set_num_chunk_with_compile_options(self):
         B = 32
         T = 1024

--- a/torch/_inductor/fx_passes/auto_chunker/applier.py
+++ b/torch/_inductor/fx_passes/auto_chunker/applier.py
@@ -275,6 +275,22 @@ class ChunkingApplier:
                 )
                 continue
 
+            # Chunk aten.view: adjust the target shape at the chunk dimension
+            if (
+                original_node.target == aten.view.default
+                and isinstance(original_node.args[0], torch.fx.Node)
+                and (meta := get_chunking_meta(original_node)) is not None
+                and meta.chunk_dim is not None
+            ):
+                shape = list(original_node.args[1])  # type: ignore[arg-type]
+                shape[meta.chunk_dim] = chunk_size
+                env[original_node] = new_graph.call_function(
+                    aten.view.default,
+                    (env[original_node.args[0]], shape),  # type: ignore[arg-type]
+                    original_node.kwargs,
+                )
+                continue
+
             # create the node with chunked inputs
             env[original_node] = new_graph.node_copy(original_node, lambda x: env[x])
 

--- a/torch/_inductor/fx_passes/auto_chunker/propagate_scale_by.py
+++ b/torch/_inductor/fx_passes/auto_chunker/propagate_scale_by.py
@@ -136,14 +136,15 @@ def propagate_where(where_node: Node) -> bool:
         aten.exp.default,
         aten.log.default,
         aten.tanh.default,
+        aten.eq.Tensor,
     ]
 )
-def propagate_nonlinear_requires_no_scaling(out_node: Node) -> bool:
+def propagate_requires_no_scaling(out_node: Node) -> bool:
     """
-    For nonlinear ops like exp, log, tanh, scale_by cannot be propagated
-    through since f(S*x) != S*f(x). These ops typically appear in the chunking
-    subgraph when the final gradient is 1 (i.e. scale_by is None),
-    making scaling a no-op.
+    For nonlinear ops (exp, log, tanh) scale_by cannot be propagated
+    through since f(S*x) != S*f(x). For boolean-output ops (eq) scale_by
+    is meaningless. These ops only appear in the chunking subgraph when
+    scale_by is None (e.g. the final gradient is 1).
     """
     args_node = get_args_of_node_type(out_node)
     args_meta = get_chunking_metas(args_node)
@@ -165,9 +166,13 @@ def propagate_nonlinear_requires_no_scaling(out_node: Node) -> bool:
         aten.neg.default,
         aten.sum.dim_IntList,
         aten.sum.default,  # sum to scalar
+        aten.amax.default,
         aten.mm.default,
         aten.permute.default,
         aten.expand.default,
+        aten.squeeze.dim,
+        aten.unsqueeze.default,
+        aten.view.default,
     ]
 )
 def propagate_general_copy(out_node: Node) -> bool:

--- a/torch/_inductor/fx_passes/auto_chunker/propagator.py
+++ b/torch/_inductor/fx_passes/auto_chunker/propagator.py
@@ -1,5 +1,6 @@
 import functools
 import logging
+import math
 from collections.abc import Callable, Sequence
 from enum import Enum
 from queue import Queue
@@ -396,6 +397,7 @@ def propagate_mm(mm_node: Node) -> _HandlerRetType:
         prims.fma.default,
         aten.where.self,
         aten.neg.default,
+        aten.eq.Tensor,
     ]
 )
 def propagate_general_copy_metadata(
@@ -632,6 +634,118 @@ def propagate_nop(node: Node) -> _HandlerRetType:
 
     def bwd() -> PropagateStatus:
         return _bool_to_status(False)
+
+    return fwd(), bwd()
+
+
+@register_propagate_rule(aten.unsqueeze.default)
+def propagate_unsqueeze(unsqueeze_node: Node) -> _HandlerRetType:
+    input_node, unsqueeze_dim = unsqueeze_node.args[:2]
+    assert isinstance(input_node, Node)
+    assert isinstance(unsqueeze_dim, int)
+    input_ndim = get_fake_tensor_from_node_arg(input_node).ndim  # type: ignore[union-attr]
+    # Normalize negative dim: unsqueeze valid range is [-(ndim+1), ndim]
+    normalized_dim = (
+        unsqueeze_dim + input_ndim + 1 if unsqueeze_dim < 0 else unsqueeze_dim
+    )
+
+    def fwd() -> PropagateStatus:
+        assert isinstance(input_node, Node)
+        input_meta = get_chunking_meta(input_node)
+        if input_meta is None:
+            return _bool_to_status(False)
+        if input_meta.chunk_dim is None:
+            return _bool_to_status(copy_chunking_meta(unsqueeze_node, input_meta))
+
+        # pyrefly: ignore[unsupported-operation]
+        new_dim = input_meta.chunk_dim + (
+            1 if input_meta.chunk_dim >= normalized_dim else 0
+        )
+        return _bool_to_status(
+            set_chunking_meta(unsqueeze_node, meta=input_meta, chunk_dim=new_dim)
+        )
+
+    def bwd() -> PropagateStatus:
+        assert isinstance(input_node, Node)
+        output_meta = get_chunking_meta(unsqueeze_node)
+        if output_meta is None:
+            return _bool_to_status(False)
+        if output_meta.chunk_dim is None:
+            return _bool_to_status(copy_chunking_meta(input_node, output_meta))
+        # pyrefly: ignore[unsupported-operation]
+        new_dim = output_meta.chunk_dim - (
+            1 if output_meta.chunk_dim > normalized_dim else 0
+        )
+        return _bool_to_status(
+            set_chunking_meta(input_node, meta=output_meta, chunk_dim=new_dim)
+        )
+
+    return fwd(), bwd()
+
+
+def _find_chunk_dim_after_reshape(
+    old_shape: Sequence[int], new_shape: Sequence[int], chunk_dim: int
+) -> int | None:
+    """
+    Find the equivalent chunk_dim position after a reshape by matching
+    the prefix product (number of elements before the dimension) and
+    the dimension size. Returns None if the chunk dimension is merged
+    or split by the reshape, making it unsafe to propagate.
+
+    Examples:
+      [M, N] -> [M, N, 1], chunk_dim=0: returns 0 (trailing dim added)
+      [M]    -> [M, 1],     chunk_dim=0: returns 0
+      [M, N] -> [M1, M2, N] where M1*M2=M, chunk_dim=0: returns None (split)
+      [M, N] -> [M*N],      chunk_dim=0: returns None (merged)
+    """
+    chunk_size = old_shape[chunk_dim]
+    old_offset = math.prod(old_shape[:chunk_dim])
+    new_offset = 1
+    for new_dim in range(len(new_shape)):
+        if new_offset == old_offset and new_shape[new_dim] == chunk_size:
+            return new_dim
+        new_offset *= new_shape[new_dim]
+    return None
+
+
+@register_propagate_rule(aten.view.default)
+def propagate_view(view_node: Node) -> _HandlerRetType:
+    input_node = view_node.args[0]
+    assert isinstance(input_node, Node)
+    input_shape = list(get_fake_tensor_from_node_arg(input_node).shape)  # type: ignore[union-attr]
+    output_shape = list(get_fake_tensor_from_node_arg(view_node).shape)  # type: ignore[union-attr]
+
+    def fwd() -> PropagateStatus:
+        assert isinstance(input_node, Node)
+        input_meta = get_chunking_meta(input_node)
+        if input_meta is None:
+            return _bool_to_status(False)
+        if input_meta.chunk_dim is None:
+            return _bool_to_status(copy_chunking_meta(view_node, input_meta))
+        new_dim = _find_chunk_dim_after_reshape(
+            input_shape, output_shape, input_meta.chunk_dim
+        )
+        if new_dim is None:
+            return PropagateStatus.FAIL
+        return _bool_to_status(
+            set_chunking_meta(view_node, meta=input_meta, chunk_dim=new_dim)
+        )
+
+    def bwd() -> PropagateStatus:
+        assert isinstance(input_node, Node)
+        output_meta = get_chunking_meta(view_node)
+        if output_meta is None:
+            return _bool_to_status(False)
+        if output_meta.chunk_dim is None:
+            return _bool_to_status(copy_chunking_meta(input_node, output_meta))
+        new_dim = _find_chunk_dim_after_reshape(
+            output_shape, input_shape, output_meta.chunk_dim
+        )
+        if new_dim is None:
+            return PropagateStatus.FAIL
+        return _bool_to_status(
+            set_chunking_meta(input_node, meta=output_meta, chunk_dim=new_dim)
+        )
 
     return fwd(), bwd()
 


### PR DESCRIPTION

  amax backward emits view (to reshape for broadcasting), eq (to build a
  mask of max positions), and unsqueeze (to add broadcast dimensions).
  Add propagation handlers for these ops so the auto_chunker can propagate
  through graphs containing amax, such as the numerically stable softmax
  pattern (amax → unsqueeze → sub → exp).

  The view handler uses a prefix-product approach to find the chunk
  dimension's new position after reshape, and the applier gets
  corresponding shape adjustment support for view nodes.

  Testing: Adding new unit test

<!-- ps-id: 0484ba32-e6b8-4234-ac15-76602582c5d1 -->

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo