### PR TITLE
[Inductor][NVGEMM] Enable nvMatmulHeuristics for FP4 blockscaled GEMM

### DIFF
--- a/torch/_inductor/template_heuristics/nv_universal_gemm.py
+++ b/torch/_inductor/template_heuristics/nv_universal_gemm.py
@@ -268,16 +268,20 @@ class NVUniversalGemmHeuristics(GemmMaxAutotuneTemplateConfigHeuristics):
             torch.bfloat16: "T",
             torch.float8_e4m3fn: "Q",
             torch.float8_e5m2: "R",
+            torch.float4_e2m1fn_x2: "F4",
         }
         a_char = dtype_to_cublas.get(dtype_a, "H")
         b_char = dtype_to_cublas.get(dtype_b or dtype_a, a_char)
         out_char = dtype_to_cublas.get(out_dtype or dtype_a, a_char)
         acc_char = dtype_to_cublas.get(accumulator_type, "S")
 
-        # 3-letter {input}{compute}{output}: used when A=B (standard GEMM).
-        # 5-letter {A}{B}{C}{compute}{D}: used when A≠B or for FP8/FP4
-        # (nvMatmulHeuristics discovery sets only have 5-letter entries for these).
-        if a_char != b_char or a_char in ("Q", "R", "O"):
+        # nvMatmulHeuristics precision string formats:
+        # - 3-letter {A}{B}{out}: used for standard GEMM and multi-char tokens (F4, BF)
+        # - 5-letter {A}{B}{C}{compute}{D}: used for single-char FP8 types (Q, R, O)
+        has_multichar = any(len(c) > 1 for c in (a_char, b_char, out_char))
+        if has_multichar:
+            precision = f"{a_char}{b_char}{out_char}"
+        elif a_char != b_char or a_char in ("Q", "R", "O"):
             precision = f"{a_char}{b_char}{out_char}{acc_char}{out_char}"
         else:
             precision = f"{a_char}{acc_char}{out_char}"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

Map torch.float4_e2m1fn_x2 to nvMatmulHeuristics type abbreviation
"F4" (multi-character token). FP4 precision strings use the 3-letter
format (e.g., F4F4S for FP4*FP4->FP32) since "F4" cannot be used in
the 5-letter single-char format.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo