### PR TITLE
[Inductor][NVGEMM] Patch cutlass_api FP4 dtype mapping

### DIFF
--- a/test/inductor/test_utils.py
+++ b/test/inductor/test_utils.py
@@ -1,5 +1,6 @@
 # Owner(s): ["module: inductor"]
 
+import importlib.util
 import unittest
 
 from sympy import I, Max, Min, Symbol, sympify
@@ -229,6 +230,25 @@ instantiate_device_type_tests(TestUtils, globals(), allow_xpu=True)
 
 class TestFP4Support(TestCase):
     """Tests for FP4 (float4_e2m1fn_x2) infrastructure support."""
+
+    @unittest.skipIf(
+        not torch.cuda.is_available()
+        or importlib.util.find_spec("cutlass_api") is None,
+        "requires CUDA and cutlass_api",
+    )
+    def test_ensure_fp4_dtype_registered(self):
+        """_ensure_fp4_dtype_registered should patch cutlass_api for FP4."""
+        from torch._inductor.utils import _ensure_fp4_dtype_registered
+
+        _ensure_fp4_dtype_registered()
+        import cutlass
+        import cutlass_api.utils
+
+        result = cutlass_api.utils.cutlass_type_from_torch_type(torch.float4_e2m1fn_x2)
+        self.assertEqual(result, cutlass.Float4E2M1FN)
+
+        result_fp32 = cutlass_api.utils.cutlass_type_from_torch_type(torch.float32)
+        self.assertEqual(result_fp32, cutlass.Float32)
 
     def test_rand_strided_fp4(self):
         """rand_strided should produce valid FP4 tensors."""

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -2022,9 +2022,36 @@ def ensure_nv_universal_gemm_available() -> bool:
     in the same interpreter to retry the import.
     """
     try:
-        return importlib.util.find_spec("cutlass_api") is not None
+        available = importlib.util.find_spec("cutlass_api") is not None
     except ImportError:
         return False
+    if available:
+        _ensure_fp4_dtype_registered()
+    return available
+
+
+def _ensure_fp4_dtype_registered():
+    """Patch cutlass_api to handle torch.float4_e2m1fn_x2 -> cutlass.Float4E2M1FN.
+
+    NOTE: cutlass_api doesn't natively map this dtype. We patch the lookup function
+    in-place so all callers (including TensorWrapper) pick up the change.
+    Remove once cutlass_api adds native FP4 support.
+    """
+    import cutlass_api.utils
+
+    try:
+        cutlass_api.utils.cutlass_type_from_torch_type(torch.float4_e2m1fn_x2)
+    except (KeyError, AttributeError):
+        import cutlass
+
+        _orig = cutlass_api.utils.cutlass_type_from_torch_type
+
+        def _patched(dtype):
+            if dtype == torch.float4_e2m1fn_x2:
+                return cutlass.Float4E2M1FN
+            return _orig(dtype)
+
+        cutlass_api.utils.cutlass_type_from_torch_type = _patched
 
 
 @functools.lru_cache(maxsize=1)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

cutlass_api.utils.cutlass_type_from_torch_type doesn't map
torch.float4_e2m1fn_x2 to cutlass.Float4E2M1FN. Monkey-patch
it in ensure_nv_universal_gemm_available() so the mapping is
in place before any TensorWrapper creation.

Remove once cutlass_api adds native FP4 support.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo