### PR TITLE
[claude code review] Add CONTRIBUTOR role to Claude Code precheck conditions

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -20,11 +20,11 @@ jobs:
       (
         (github.event_name != 'issues' &&
          contains(github.event.comment.body, '@claude') &&
-         (contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) ||
+         (contains(fromJSON('["OWNER","MEMBER","COLLABORATOR","CONTRIBUTOR"]'), github.event.comment.author_association) ||
           github.actor == 'pytorch-auto-revert[bot]')) ||
         (github.event_name == 'issues' &&
          contains(github.event.issue.body, '@claude') &&
-         (contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association) ||
+         (contains(fromJSON('["OWNER","MEMBER","COLLABORATOR","CONTRIBUTOR"]'), github.event.issue.author_association) ||
           github.actor == 'pytorch-auto-revert[bot]'))
       )
     runs-on: ubuntu-latest


### PR DESCRIPTION
There is a bug in github webhooks.

When fired for `pull_request_review_comment` trigger, the `author_association` is `CONTRIBUTOR` (always?).
This messes up the pre-check logic for review workflow, causing it to skip.


This PR relaxes the pre-check (it's an optimization anyway), and I also relaxed `bedrock` environment protection rules, allowing PR merge branches.

[tested in ciforge](https://github.com/pytorch/ciforge/pull/145#discussion_r2886777001)