### PR TITLE
[Inductor][NVGEMM] [Inductor][NVGEMM] Add infrastructure for vendored CuTeDSL kernel wrappers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,7 +127,8 @@ torch/test/
 torch/utils/benchmark/utils/valgrind_wrapper/callgrind.h
 torch/utils/benchmark/utils/valgrind_wrapper/valgrind.h
 torch/version.py
-torch/_inductor/kernel/vendored_templates/*
+torch/_inductor/kernel/vendored_templates/cutedsl/kernels/*
+torch/_inductor/kernel/vendored_templates/cutedsl_grouped_gemm.py
 test/inductor/test_tlx*
 minifier_launcher.py
 aten/src/ATen/native/transformers/hip/flash_attn/ck/fav_v3/asm_fmha_v3_bwd_configs.hpp

--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -95,6 +95,7 @@ ignore-missing-imports = [
     "boto3.*",
     "dill.*",
     "usort.*",
+    "cutlass.*",
     "cutlass_library.*",
     "cutlass_api.*",
     "deeplearning.*",

--- a/setup.py
+++ b/setup.py
@@ -637,7 +637,8 @@ def mirror_inductor_external_kernels() -> None:
     cuda_is_disabled = not str2bool(os.getenv("USE_CUDA"))
     paths = [
         (
-            CWD / "torch/_inductor/kernel/vendored_templates/cutedsl_grouped_gemm.py",
+            CWD
+            / "torch/_inductor/kernel/vendored_templates/cutedsl/kernels/cutedsl_grouped_gemm.py",
             CWD
             / "third_party/cutlass/examples/python/CuTeDSL/blackwell/grouped_gemm.py",
             True,

--- a/torch/_inductor/codegen/nv_universal_gemm/kernel_cache.py
+++ b/torch/_inductor/codegen/nv_universal_gemm/kernel_cache.py
@@ -26,6 +26,14 @@ def _build_kernel_cache() -> dict[str, Any]:
     import cutlass_api
 
     log.debug("Building NVGEMM kernel cache (this may take a few seconds)...")
+
+    try:
+        from torch._inductor.kernel.vendored_templates.cutedsl import (  # noqa: F401
+            wrappers,
+        )
+    except ImportError:
+        log.debug("Vendored kernel wrappers not available")
+
     all_kernels = cutlass_api.get_kernels()
     cache = {k.metadata.kernel_name: k for k in all_kernels}
     log.debug("NVGEMM kernel cache built: %d kernels", len(cache))

--- a/torch/_inductor/kernel/templates/cutedsl_mm_grouped.py.jinja
+++ b/torch/_inductor/kernel/templates/cutedsl_mm_grouped.py.jinja
@@ -3,7 +3,7 @@ from torch._inductor.runtime.runtime_utils import ceildiv
 from cutlass.utils import TensorMapUpdateMode
 {{gen_defines()}}
 # ---- Import GroupedGemm implementation, copied on PyTorch build from Cutlass repository: cutlass/examples/python/CuTeDSL/blackwell/grouped_gemm.py ----
-from torch._inductor.kernel.vendored_templates.cutedsl_grouped_gemm import (
+from torch._inductor.kernel.vendored_templates.cutedsl.kernels.cutedsl_grouped_gemm import (
     GroupedGemmKernel,
 )
 

--- a/torch/_inductor/kernel/vendored_templates/cutedsl/__init__.py
+++ b/torch/_inductor/kernel/vendored_templates/cutedsl/__init__.py
@@ -1,0 +1,1 @@
+# CuTeDSL vendored kernels and wrappers for PyTorch Inductor.

--- a/torch/_inductor/kernel/vendored_templates/cutedsl/wrappers/__init__.py
+++ b/torch/_inductor/kernel/vendored_templates/cutedsl/wrappers/__init__.py
@@ -1,0 +1,1 @@
+# Cutlass API registration wrappers for PyTorch Inductor.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #176531
* #176530
* #176528
* #176527
* #176526
* #176525
* __->__ #176524



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo