### PR TITLE
Move pre-grad passes after AOTAutograd cache lookup

### DIFF
--- a/test/dynamo/test_aot_autograd_cache.py
+++ b/test/dynamo/test_aot_autograd_cache.py
@@ -3,10 +3,12 @@
 import copy
 import dataclasses
 import functools
+import operator
 import os
 import pickle
 import shutil
 import unittest
+from collections.abc import Sequence
 from unittest.mock import patch
 
 import torch
@@ -29,9 +31,10 @@ from torch._inductor.custom_graph_pass import CustomRuntimeEstimator
 from torch._inductor.runtime.runtime_utils import cache_dir
 from torch._inductor.runtime.triton_compat import tl, triton
 from torch._inductor.test_case import TestCase as InductorTestCase
-from torch._inductor.utils import fresh_cache
+from torch._inductor.utils import fresh_cache, InputType
 from torch._subclasses import FakeTensorMode
 from torch.compiler._cache import CacheArtifactManager
+from torch.fx import GraphModule
 from torch.fx.experimental.symbolic_shapes import ShapeEnv
 from torch.testing._internal.common_cuda import SM80OrLater, TEST_MULTIGPU
 from torch.testing._internal.common_device_type import largeTensorTest
@@ -48,6 +51,18 @@ from torch.utils.checkpoint import (
     CheckpointPolicy,
     create_selective_checkpoint_contexts,
 )
+
+
+def custom_pre_grad_pass_remove_ident_muls(g: torch.fx.Graph) -> None:
+    """
+    Pre-grad pass that removes redundant identity multiplications (1 * x).
+    """
+    for n in g.nodes:
+        if n.op == "call_function" and n.target is operator.mul:
+            lhs, rhs = n.args
+            if lhs == 1:
+                n.replace_all_uses_with(rhs)
+                g.erase_node(n)
 
 
 def aot_eager_regional_inductor():
@@ -2537,6 +2552,134 @@ class AOTAutogradCacheTests(InductorTestCase):
         self.assertEqual(
             x_view2.untyped_storage().data_ptr(), x2.untyped_storage().data_ptr()
         )
+
+    @inductor_config.patch("fx_graph_cache", True)
+    @functorch_config.patch("enable_autograd_cache", True)
+    def test_pre_grad_passes_called_on_cache_miss_only(self):
+        """
+        Verify that pre_grad_passes are called on cache miss but not on cache hit.
+        Also, verify that pre_grad_custom_pass is still considered correctly for the cache key.
+        Do this in 4 steps:
+        - Compile w/o  custom pre-grad pass, expect cache miss, expect to run pre-grad passes, expect NO graph change
+        - Compile w/o  custom pre-grad pass, expect cache hit
+        - Compile with custom pre-grad pass, expect cache miss, expect to run pre-grad passes, expect graph change
+        - Compile with custom pre-grad pass, expect cache hit
+        """
+
+        from torch._inductor.compile_fx import run_pre_grad_passes
+
+        # Target function with an identity multiplication that we can remove with a custom pre-grad pass
+        def fn(x, y):
+            return 1 * x + y
+
+        # Track the invocations of run_pre_grad_passes
+        @dataclasses.dataclass
+        class PreGradInvocation:
+            num_nodes_before: int
+            num_nodes_after: int
+
+        pre_grad_invocations: list[PreGradInvocation] = []
+
+        def wrap_run_pre_grad_passes(
+            model: GraphModule, example_inputs: Sequence[InputType]
+        ) -> GraphModule:
+            nonlocal pre_grad_invocations
+            num_nodes_before = len(model.graph.nodes)
+            run_pre_grad_passes(model, example_inputs)
+            num_nodes_after = len(model.graph.nodes)
+            pre_grad_invocations.append(
+                PreGradInvocation(
+                    num_nodes_before=num_nodes_before, num_nodes_after=num_nodes_after
+                )
+            )
+            return model
+
+        x = torch.randn(10)
+        y = torch.randn(10)
+
+        with (
+            unittest.mock.patch(
+                "torch._inductor.compile_fx.run_pre_grad_passes",
+                wrap_run_pre_grad_passes,
+            ),
+        ):
+            self._clear_all_caches()
+
+            # First compilation - cache miss, pre-grad passes should be called, no changes to graph expected
+            compiled_fn = torch.compile(fn)
+            result1 = compiled_fn(x, y)
+
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_miss"], 1)
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 0)
+            self.assertEqual(
+                len(pre_grad_invocations),
+                1,
+                "run_pre_grad_passes should be called on cache miss",
+            )
+            self.assertEqual(
+                pre_grad_invocations[-1].num_nodes_after
+                - pre_grad_invocations[-1].num_nodes_before,
+                0,
+            )
+
+            # Reset dynamo but keep the cache
+            torch._dynamo.reset()
+
+            # Second compilation - cache hit, pre-grad passes should NOT be called
+            compiled_fn2 = torch.compile(fn)
+            result2 = compiled_fn2(x, y)
+
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_miss"], 1)
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 1)
+            self.assertEqual(
+                len(pre_grad_invocations),
+                1,
+                "run_pre_grad_passes should NOT be called on cache hit",
+            )
+
+            # Reset dynamo but keep the cache
+            torch._dynamo.reset()
+
+            # Third compilation with custom pre-grad pass - cache miss, pre-grad passes should be called,
+            # expect one graph node removed
+            with inductor_config.patch(
+                "pre_grad_custom_pass", custom_pre_grad_pass_remove_ident_muls
+            ):
+                compiled_fn3 = torch.compile(fn)
+                result3 = compiled_fn3(x, y)
+
+                self.assertEqual(counters["aot_autograd"]["autograd_cache_miss"], 2)
+                self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 1)
+                self.assertEqual(
+                    len(pre_grad_invocations),
+                    2,
+                    "run_pre_grad_passes should be called on cache miss",
+                )
+                self.assertEqual(
+                    pre_grad_invocations[-1].num_nodes_after
+                    - pre_grad_invocations[-1].num_nodes_before,
+                    -1,
+                )
+
+                # Reset dynamo but keep the cache
+                torch._dynamo.reset()
+
+                # Fourth compilation with custom pre-grad pass - cache hit, pre-grad passes should NOT be called
+                compiled_fn4 = torch.compile(fn)
+                result4 = compiled_fn4(x, y)
+
+                self.assertEqual(counters["aot_autograd"]["autograd_cache_miss"], 2)
+                self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 2)
+                self.assertEqual(
+                    len(pre_grad_invocations),
+                    2,
+                    "run_pre_grad_passes should NOT be called on cache hit",
+                )
+
+            # Results should match
+            self.assertEqual(result1, result2)
+            self.assertEqual(result2, result3)
+            self.assertEqual(result3, result4)
 
 
 @functorch_config.patch({"bundled_autograd_cache": True})

--- a/torch/_functorch/aot_autograd.py
+++ b/torch/_functorch/aot_autograd.py
@@ -1085,6 +1085,11 @@ def aot_module_simplified(
     boxed_forward_device_index: BoxedDeviceIndex | None = None,
     ignore_shape_env: bool = False,
     disable_functionalization: bool = False,
+    # Optional callback to run passes on the module at the start of AOT autograd.
+    pre_grad_passes: Callable[
+        [torch.fx.GraphModule, Sequence[InputType]], torch.fx.GraphModule
+    ]
+    | None = None,
 ) -> Callable[..., Any]:
     """
     This is the simplified or low overhead version of aot_module. For frontends
@@ -1147,6 +1152,10 @@ def aot_module_simplified(
                 )
 
         if compiled_fn is None:
+            # Run pre-grad passes after cache lookup to cache pre-grad transforms.
+            if pre_grad_passes is not None and isinstance(mod, torch.fx.GraphModule):
+                mod = pre_grad_passes(mod, fake_flat_args)
+
             stack.enter_context(compiled_autograd._disable())
             aot_state = create_aot_state(
                 stack,

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -2742,13 +2742,8 @@ def _compile_fx_main(
         ),
         torch._inductor.debug.reset_provenance_globals(),
     ):
-        # Pre-grad passes cannot be run if we weren't given a GraphModule.
-        # Dynamo will always produce a GraphModule, but this handles cases
-        # where a user directly passes a plain Module with the intention of
-        # having AOTAutograd trace it.
-        # TODO: Get rid of this?
-        if isinstance(model_, GraphModule):
-            model_ = run_pre_grad_passes(model_, example_inputs_)
+        # Note: Pre-grad passes are now run inside aot_module_simplified (via the
+        # pre_grad_passes callback) after the cache lookup.
 
         assert not config._raise_error_for_testing
 
@@ -2831,6 +2826,12 @@ def _compile_fx_main(
 
             is_valid_aoti_model_name()
 
+            # Pre-grad passes for the aot_autograd path are run inside
+            # aot_module_simplified after the cache lookup.  The
+            # aot_export_module path doesn't use that cache so run them here.
+            if isinstance(model_, GraphModule):
+                model_ = run_pre_grad_passes(model_, example_inputs_)
+
             with functorch_config.patch(
                 unlift_effect_tokens=True,
                 selective_decompose=config.selective_decompose,
@@ -2912,6 +2913,7 @@ def _compile_fx_main(
                     cudagraphs=compiler_config_extra.cudagraphs,
                     boxed_forward_device_index=compiler_config_extra.forward_device,
                     ignore_shape_env=ignore_shape_env,
+                    pre_grad_passes=run_pre_grad_passes,
                 )(model_, example_inputs_)
             except ShortenTraceback as e:
                 # We will also shorten the traceback inside dynamo.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #176529

Previously, `run_pre_grad_passes` was called unconditionally at the top
of `_compile_fx_main`.  This meant pre-grad transformations were not
included in cached artifacts and ran unnecessarily on cache hits.

Move pre-grad passes into `aot_module_simplified` (Path B) via a
callback so they run after the cache lookup — on cache miss only.

`_compile_fx_main` has two compilation paths that diverge at the
`V.aot_compilation` check: Path A uses `aot_export_module` (AOTInductor,
no cache) and Path B uses `aot_autograd` → `aot_module_simplified` (with
`AOTAutogradCache`).  Since Path A has no cache, run pre-grad passes
explicitly before `aot_export_module`.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Lucaskabela