### PR TITLE
[Web Calling][WASM](2a/n) Add WASM/Emscripten compiler flags to third-party dependencies

### DIFF
--- a/third_party/xnnpack.buck.bzl
+++ b/third_party/xnnpack.buck.bzl
@@ -43,6 +43,15 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         "-Wno-error=incompatible-pointer-types-discards-qualifiers",
     ]
 
+    WASM_EMSCRIPTEN_COMPILER_FLAGS = select({
+        "DEFAULT": [],
+        "ovr_config//runtime:wasm-emscripten": [
+            "-pthread",
+            "-matomics",
+            "-mbulk-memory",
+        ],
+    })
+
     XNN_COMMON_MICROKERNEL_EXPORTED_DEPS = [
         ":interface",
         third_party("FP16"),
@@ -73,7 +82,7 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         apple_sdks = (IOS, MACOSX),
         compiler_flags = [
             "-O2",
-        ],
+        ] + WASM_EMSCRIPTEN_COMPILER_FLAGS,
         labels = labels,
         fbandroid_link_whole = True,
         preferred_linkage = "static",
@@ -100,7 +109,7 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         apple_sdks = (IOS, MACOSX),
         compiler_flags = [
             "-O2",
-        ],
+        ] + WASM_EMSCRIPTEN_COMPILER_FLAGS,
         labels = labels,
         fbandroid_link_whole = True,
         preferred_linkage = "static",
@@ -127,7 +136,7 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
             "-fno-fast-math",
             "-fno-math-errno",
             "-ffp-contract=off",
-        ],
+        ] + WASM_EMSCRIPTEN_COMPILER_FLAGS,
         labels = labels,
         fbandroid_link_whole = True,
         preferred_linkage = "static",
@@ -1843,7 +1852,7 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         compiler_flags = select({
             "DEFAULT": [],
             "ovr_config//os:macos": ["-fvisibility=default"],
-        }),
+        }) + WASM_EMSCRIPTEN_COMPILER_FLAGS,
         platforms = (APPLE, ANDROID, CXX, WINDOWS),
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS + [
             "-DXNN_NO_Q8_OPERATORS",


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/executorch/pull/17860

Add pthread compiler flags (-pthread, -matomics, -mbulk-memory) for
Emscripten/WASM builds across third-party dependencies and ExecuTorch
runtime wrapper.

These flags are required when linking into WASM binaries that use
-sUSE_PTHREADS=1. Without them, wasm-ld fails with:
  "error: --shared-memory is disallowed by <file>.o because it was not
   compiled with 'atomics' or 'bulk-memory' features."

Changes:
- xnnpack.buck.bzl (fbcode + xplat): Add WASM_EMSCRIPTEN_COMPILER_FLAGS select
- runtime_wrapper.bzl (fbcode + xplat): Add emcc compiler flags
- cpuinfo/BUCK: Add wasm-emscripten compatible_with, compiler_flags, and emscripten/init.c wrapper
- clog/BUCK: Add wasm-emscripten compiler_flags
- pthreadpool/BUCK: Add compiler_flags and WASM preprocessor_flags (condvar mode)

Test Plan:
```
$ buck build fbsource//third-party/cpuinfo:cpuinfo
BUILD SUCCEEDED

$ buck build fbsource//xplat/third-party/pthreadpool:pthreadpool
BUILD SUCCEEDED

$ buck build fbsource//xplat/third-party/clog:clog
BUILD SUCCEEDED
```

Reviewed By: GregoryComer

Differential Revision: D94744813


