### PR TITLE
[DRAFT][Guard][auto_dynamic]guard per cache entry for best match

### DIFF
--- a/test/dynamo/test_guard_exclusion.py
+++ b/test/dynamo/test_guard_exclusion.py
@@ -561,6 +561,71 @@ class TestGuardExclusion(TestCase):
         self.assertEqual(tracker.frame_count, 5, "Should not recompile")
         self.assertEqual(tracker.call_log[-1], 4, "All-new values should use Graph 4")
 
+    @torch._dynamo.config.patch(
+        automatic_dynamic_shapes=True, assume_static_by_default=True
+    )
+    def test_data_dependent_branch_exclusion(self):
+        """
+        Data-dependent branch: if x.size(0) > 5 creates separate graphs
+        per branch. When a later recompilation creates a dynamic graph for
+        one branch, the exclusion guard must still reject inputs that match
+        an older static graph — even though no dim transitioned.
+
+        1. foo(x=[3,4])  -> Graph 0: x+1 (else branch, static size(0)==3)
+        2. foo(x=[8,4])  -> Graph 1: x*2 (if branch, dynamic size(0),
+                            guard size(0)>5, exclusion Ne(s0,3))
+        3. foo(x=[4,4])  -> Graph 1 rejects (4>5 is False), Graph 0
+                            rejects (4!=3). Recompile:
+                            Graph 2: x+1 (else branch, dynamic size(0),
+                            guard size(0)<=5, exclusion Ne(s0,3) from
+                            Graph 0's static signature)
+        4. foo(x=[3,4])  -> Graph 2 should reject (exclusion Ne(s0,3))
+                            -> falls to Graph 0
+        """
+
+        def foo(x):
+            if x.size(0) > 5:
+                return x * 2
+            return x + 1
+
+        tracker = GraphTracker()
+        opt = torch.compile(foo, backend=tracker)
+
+        # Graph 0: else branch, static
+        opt(torch.randn(3, 4))
+        self.assertEqual(tracker.frame_count, 1)
+        self.assertEqual(tracker.call_log[-1], 0)
+
+        # Graph 1: if branch, dim0 becomes dynamic
+        opt(torch.randn(8, 4))
+        self.assertEqual(tracker.frame_count, 2)
+        self.assertEqual(tracker.call_log[-1], 1)
+
+        # Graph 2: else branch, dynamic (4 <= 5, no graph matches)
+        opt(torch.randn(4, 4))
+        self.assertEqual(tracker.frame_count, 3)
+        self.assertEqual(tracker.call_log[-1], 2)
+
+        # Key: (3, 4) should use Graph 0, not Graph 2
+        opt(torch.randn(3, 4))
+        self.assertEqual(
+            tracker.call_log[-1],
+            0,
+            "Input [3,4] should use Graph 0 (static), not Graph 2 (dynamic else branch)",
+        )
+
+        # Other else-branch inputs use Graph 2
+        opt(torch.randn(4, 4))
+        self.assertEqual(tracker.call_log[-1], 2)
+        opt(torch.randn(5, 4))
+        self.assertEqual(tracker.call_log[-1], 2)
+
+        # If-branch inputs use Graph 1
+        opt(torch.randn(8, 4))
+        self.assertEqual(tracker.call_log[-1], 1)
+
+        self.assertEqual(tracker.frame_count, 3, "No additional recompilations")
+
 
 if __name__ == "__main__":
     run_tests()

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -287,6 +287,7 @@ class GuardManagerWrapper:
         self.extra_state: ExtraState | None = None
         self.id_matched_objs: dict[str, ReferenceType[object]] = {}
         self.no_tensor_aliasing_sources: list[str] = []
+        self.static_signature: dict[str, int | None] = {}
 
         self.printed_relational_guards: set[RelationalGuard] = set()
 
@@ -2698,6 +2699,12 @@ class GuardBuilder(GuardBuilderBase):
             fs = output_graph.shape_env.tracked_fakes or []
             input_contexts = [a.symbolic_context for a in fs]
 
+            # Populate prior static signatures from cache entries for
+            # per-cache-entry exclusion guards.
+            output_graph.shape_env.prior_static_signatures = (
+                extract_prior_static_signatures(self.check_fn_manager.cache_entry)
+            )
+
             def get_sources(t_id: int, dim: int) -> list[Source]:
                 # Looks up base sources mapped to a tensor id and uses them to create
                 # sources for the corresponding tensor dimension.
@@ -3817,6 +3824,7 @@ class CheckFunctionManager:
         )
         self.output_graph: OutputGraphCommon | None = output_graph
         assert self.output_graph is not None
+        self.cache_entry = cache_entry
 
         # Only used for serialization.
         self.shape_code_parts = shape_code_parts
@@ -4395,6 +4403,12 @@ class CheckFunctionManager:
         self.guard_manager.cache_entry = None
         self.guard_manager.extra_state = None
         self.guard_manager.no_tensor_aliasing_sources = no_tensor_aliasing_names
+        # Store the static signature for this cache entry so future
+        # compilations can derive per-cache-entry exclusion guards.
+        if self.output_graph is not None:
+            self.guard_manager.static_signature = _build_static_signature(
+                self.output_graph
+            )
 
     def invalidate(self, obj_str: str) -> None:
         # Some tests reveal that CheckFunctionManager has no attribute
@@ -4801,6 +4815,74 @@ def update_diff_guard_managers_for_existing_cache_entries(
 
     # return the accumulated sources to set up the new cache line.
     return acc_diff_guard_sources
+
+
+def _build_static_signature(
+    output_graph: OutputGraphCommon,
+) -> dict[str, int | None]:
+    """Build a static signature from the current compilation.
+
+    Returns a dict mapping source_name -> int (static) | None (dynamic).
+    For tensor dims, source_name is TensorPropertySource(src, SIZE, i).name.
+    For scalars, source_name is the scalar source name.
+    """
+    from torch._dynamo.source import TensorProperty, TensorPropertySource
+
+    sig: dict[str, int | None] = {}
+
+    # Tensor dims: int = static, SymInt = dynamic.
+    for source, metadata in output_graph.input_source_to_sizes_strides.items():
+        sizes = metadata.get("size", ())
+        for i, sz in enumerate(sizes):
+            prop_name = TensorPropertySource(source, TensorProperty.SIZE, i).name
+            sig[prop_name] = sz if isinstance(sz, int) else None
+
+    # Scalars: use concrete values recorded during compilation.
+    # Static scalars (CONSTANT_MATCH) are in scalar_source_to_value but
+    # not in tracked_fakes. Dynamic scalars are in both.
+    scalar_values = getattr(output_graph, "scalar_source_to_value", {})
+    shape_env = output_graph.shape_env
+    if shape_env is not None and shape_env.tracked_fakes:
+        for tf in shape_env.tracked_fakes:
+            fake = tf.fake
+            if isinstance(fake, (torch.SymInt, int)):
+                src_name = tf.source.name
+                if src_name in sig:
+                    continue
+                if isinstance(fake, int) or (
+                    isinstance(fake, torch.SymInt)
+                    and fake.node.maybe_as_int() is not None
+                ):
+                    # Static scalar (backed by concrete int).
+                    sig[src_name] = (
+                        fake if isinstance(fake, int) else fake.node.maybe_as_int()
+                    )
+                else:
+                    # Dynamic scalar.
+                    sig[src_name] = None
+
+    # Add constant scalars that aren't in tracked_fakes.
+    for src_name, val in scalar_values.items():
+        if src_name not in sig:
+            sig[src_name] = val
+
+    return sig
+
+
+def extract_prior_static_signatures(
+    cache_entry: CacheEntry | None,
+) -> list[dict[str, int | None]]:
+    """Extract static signatures from each prior cache entry.
+
+    Each entry in the returned list corresponds to one prior compiled graph.
+    """
+    signatures: list[dict[str, int | None]] = []
+    while cache_entry is not None:
+        sig = cache_entry.guard_manager.static_signature
+        if sig:  # Skip empty signatures (e.g., from before this feature).
+            signatures.append(sig)
+        cache_entry = cache_entry.next  # type: ignore[assignment]
+    return signatures
 
 
 def guard_error_hook(

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -631,6 +631,9 @@ class OutputGraph(OutputGraphCommon):
         # Map from graph input's `Source` to its `VariableTracker` to
         # de-duplicate graph inputs by source and reuse the tracker
         self.input_source_to_var: dict[Source, VariableTracker] = {}
+        # Concrete scalar values seen during this compilation, keyed by
+        # source name. Used by per-cache-entry exclusion guards.
+        self.scalar_source_to_value: dict[str, int] = {}
         # List of TensorVariables that are leaf tensors created in-graph
         # (e.g., nn.Parameter via tracable_create_parameter). These need to be
         # tracked separately from input_source_to_var for backward() auto-detection.

--- a/torch/_dynamo/pgo.py
+++ b/torch/_dynamo/pgo.py
@@ -236,10 +236,6 @@ class FrameStateSizeEntry:
     stride: AutoDynamic | AutoUnset | tuple[int | AutoDynamic | InferStride, ...] = (
         dataclasses.field(default=auto_unset)
     )
-    excluded_sizes: tuple[int | None, ...] | None = dataclasses.field(
-        default=None, compare=False
-    )
-    excluded_scalar: int | None = dataclasses.field(default=None, compare=False)
 
     def render(self) -> str:
         # Special cases
@@ -365,31 +361,6 @@ class FrameStateSizeEntry:
         return tuple(cls._merge_atom(x, y) for x, y in zip(xs, ys))
 
     def __ior__(self, other: Self) -> Self:
-        # Record current static sizes before merge. For dims that become
-        # dynamic, the exclusion guard will reject these values so inputs
-        # fall through to the earlier, more specialized cache entry.
-        # Already-dynamic dims become None and are ignored by the guard.
-        # When no dim transitions, clear stale excluded_sizes so later
-        # compilations don't inherit exclusions from earlier transitions.
-        if isinstance(self.size, tuple):
-            new_size = self._merge_atom_tup(self.size, other.size)
-            if new_size != self.size:
-                self.excluded_sizes = tuple(
-                    s if type(s) is int else None for s in self.size
-                )
-            elif self.excluded_sizes is not None:
-                self.excluded_sizes = None
-        # Same idea for scalars: record the static value about to become dynamic.
-        # Re-derive like excluded_sizes: only set when transitioning from a
-        # concrete int, clear when already dynamic.
-        if (
-            type(self.scalar) is int
-            and type(other.scalar) is int
-            and self.scalar != other.scalar
-        ):
-            self.excluded_scalar = self.scalar
-        elif self.scalar is auto_dynamic and self.excluded_scalar is not None:
-            self.excluded_scalar = None
         self.scalar = self._merge_atom(self.scalar, other.scalar)
         self.size = self._merge_atom_tup(self.size, other.size)
         self.stride = self._merge_atom_tup(self.stride, other.stride)

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -2634,6 +2634,9 @@ class VariableBuilder:
                 is_unspecialized_nn_module=self.source.guard_source.is_unspecialized_nn_module(),
             )
 
+            # Record concrete scalar value for per-cache-entry exclusion guards.
+            self.tx.output.scalar_source_to_value[self.source.name] = value
+
             # TODO: This should be dynamic, as we in general do not
             # know if bare integers are actually going to be sizevars
             # and it is inappropriate to eagerly duck size them with
@@ -2668,17 +2671,10 @@ class VariableBuilder:
                 self.install_guards(GuardBuilder.CONSTANT_MATCH)
                 return ConstantVariable.create(value=value)
 
-            excluded_scalar = (
-                frame_state_entry.excluded_scalar
-                if frame_state_entry is not None
-                and config.stable_graph_selection_for_automatic_dynamic
-                else None
-            )
             wrapped_value = shape_env.create_unspecified_symint_and_symbol(
                 value,
                 source=self.source,
                 dynamic_dim=dynamic_dim,
-                excluded_value=excluded_scalar,
             )
 
             self.tx.output.tracked_fakes.append(
@@ -3933,7 +3929,6 @@ def _automatic_dynamic(
         tensor_source=source,
         shape_env_to_source_to_symbol_cache=shape_env_to_source_to_symbol_cache,
         shape_ids=getattr(e, "_dynamo_shape_ids", None),
-        excluded_sizes=frame_state_entry.excluded_sizes,
     )
 
 

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -2286,7 +2286,6 @@ class StatefulSymbolicContext(StatelessSymbolicContext):
     shape_env_to_source_to_symbol_cache: dict[int, dict[str, sympy.Expr]] = field(
         default_factory=dict
     )
-    excluded_sizes: tuple[int | None, ...] | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -3904,11 +3903,11 @@ class ShapeEnv:
         self.unbacked_renamings: dict[sympy.Symbol, sympy.Symbol] = {}
         # Set holds a % b expressions that evaluate to 0.
         self.divisible: set[sympy.Expr] = set()
-        # Exclusion constraints from automatic_dynamic transitions.
-        # Each (symbol, excluded_value) pair represents one dim/scalar that
-        # transitioned static → dynamic. All pairs are combined into a single
-        # Or(Ne(...), ...) guard in produce_guards_verbose.
-        self.exclusion_constraints: list[tuple[sympy.Symbol, int]] = []
+        # Prior cache entry static signatures for per-cache-entry exclusion
+        # guards. Each element is a dict mapping source_name -> int|None
+        # where int means static, None means dynamic.
+        # Populated from prior cache entries before produce_guards_verbose.
+        self.prior_static_signatures: list[dict[str, int | None]] = []
         # Set that holds "size-like" symbols.  When we perform
         # "size-oblivious" tests, these can be assumed to be >= 2.
         self.size_like: set[sympy.Symbol] = set()
@@ -4170,6 +4169,9 @@ class ShapeEnv:
             "_resimplify_floor_div_axioms",
             "_expr_sym_node_id",
             "specialization_stacks",
+            # Populated externally before produce_guards_verbose, not
+            # through recorded shape_env events.
+            "prior_static_signatures",
         )
 
         # Mapping of the value of each to-be-compared field into the values that
@@ -4790,27 +4792,6 @@ class ShapeEnv:
         size: list[sympy.Expr] = self._produce_dyn_sizes_from_int_tuple(
             ex_size, source, symbolic_context, hint_overrides=hint_overrides
         )
-        # Record tensor exclusion constraints for stable graph selection.
-        # The ndim check guards against stale excluded_sizes from graph
-        # breaks where the resumed tensor may have different dimensionality.
-        # Skip dims with hint overrides: the overridden hint in
-        # backed_var_to_val would mismatch the excluded value, causing the
-        # not-all check in produce_guards_verbose to emit a guard that
-        # immediately fails.
-        excluded_sizes = getattr(symbolic_context, "excluded_sizes", None)
-        if (
-            excluded_sizes
-            and len(excluded_sizes) == dim
-            and any(v is not None for v in excluded_sizes)
-        ):
-            for i in range(dim):
-                ev = excluded_sizes[i]
-                if (
-                    ev is not None
-                    and isinstance(size[i], sympy.Symbol)
-                    and i not in (hint_overrides or {})
-                ):
-                    self._record_exclusion_constraint(size[i], ev)
         stride = self._compute_symbolic_stride(
             source,
             size,
@@ -5016,16 +4997,11 @@ class ShapeEnv:
         return out
 
     @record_shapeenv_event()
-    def _record_exclusion_constraint(self, sym: sympy.Symbol, val: int) -> None:
-        self.exclusion_constraints.append((sym, val))
-
-    @record_shapeenv_event()
     def create_unspecified_symint_and_symbol(
         self,
         value: int,
         source: Source,
         dynamic_dim: DimDynamic,
-        excluded_value: int | None = None,
     ) -> IntLikeType:
         """Create a SymInt wrapping a new unspecified symbol"""
         sym = self.create_unspecified_symbol(
@@ -5033,8 +5009,6 @@ class ShapeEnv:
             source=source,
             dynamic_dim=dynamic_dim,
         )
-        if excluded_value is not None:
-            self._record_exclusion_constraint(sym, excluded_value)
         return self.create_symintnode(
             sym,
             hint=value,
@@ -5549,6 +5523,62 @@ class ShapeEnv:
         (no verbose guards produced.)
         """
         return self.produce_guards_verbose(*args, **kwargs, langs=("python",))[0].exprs
+
+    def _emit_per_cache_entry_exclusion_guards(
+        self,
+        symbol_to_source: dict[sympy.Symbol, list[Source]],
+        all_exprs: list[list[str]],
+        printers: list[_ShapeGuardPrinter],
+        langs: tuple[str, ...],
+    ) -> None:
+        """Emit one exclusion guard per prior cache entry.
+
+        For each prior compiled graph, compare its static signature against the
+        current graph. For each source_name that is static (int) in the prior
+        graph but backed by a symbol in the current graph, create Ne(sym, val).
+        Combine all such pairs for one prior graph into a single Or expression.
+        """
+        # Build reverse map: source_name -> symbol for the current graph.
+        source_name_to_symbol: dict[str, sympy.Symbol] = {}
+        for sym, srcs in symbol_to_source.items():
+            for src in srcs:
+                source_name_to_symbol[src.name] = sym
+
+        for prior_sig in self.prior_static_signatures:
+            pairs: list[tuple[sympy.Symbol, int]] = []
+            for source_name, val in prior_sig.items():
+                if val is None:
+                    # Dynamic in the prior graph, no exclusion needed.
+                    continue
+                if not isinstance(val, int):
+                    continue
+                # val is static (int) in the prior graph. Check if it's
+                # backed by a symbol in the current graph (i.e., dynamic).
+                sym = source_name_to_symbol.get(source_name)
+                if sym is not None:
+                    pairs.append((sym, val))
+
+            if not pairs:
+                continue
+
+            # Skip if current concrete values match ALL excluded values
+            # (the guard would fail on creation).
+            if all(self.backed_var_to_val.get(sym) == val for sym, val in pairs):
+                continue
+
+            if len(pairs) == 1:
+                excl_expr = sympy.Ne(pairs[0][0], pairs[0][1], evaluate=False)
+            else:
+                excl_expr = sympy.Or(
+                    *[sympy.Ne(sym, val, evaluate=False) for sym, val in pairs]
+                )
+            for exprs, printer, lang in zip(all_exprs, printers, langs):
+                guard_expr = printer.doprint(excl_expr)
+                if lang == "verbose_python":
+                    guard_expr = (
+                        f"{guard_expr}  # exclusion guard for automatic dynamic"
+                    )
+                exprs.append(guard_expr)
 
     def produce_guards_verbose(
         self,
@@ -6289,64 +6319,34 @@ class ShapeEnv:
                     else:
                         raise NotImplementedError(f"Unimplemented for lang: {lang}")
 
-        # Exclusion guard for stable graph selection with automatic dynamic.
+        # Per-cache-entry exclusion guards for stable graph selection.
         #
-        # When automatic_dynamic promotes a static dim to dynamic, the new
-        # (more general) graph is inserted *before* the old (specialized) graph
-        # in the guard cache.  Without an exclusion guard, inputs that exactly
-        # match the old graph's static sizes would be captured by the new
-        # dynamic graph instead, violating the invariant "once an input is
-        # served by graph X it is always served by graph X".
+        # When automatic_dynamic promotes static dims to dynamic, the new
+        # (more general) graph is inserted *before* older (specialized) graphs
+        # in the guard cache.  Without exclusion guards, inputs that exactly
+        # match an older graph's static sizes would be captured by the new
+        # dynamic graph instead of falling through to the correct prior graph.
         #
-        # Soundness argument (cache-flip / LIFO order):
-        #   Graph_new sits before Graph_old in the cache.  Graph_old accepts
-        #   only inputs whose sizes match its static constraints exactly.
-        #   Graph_new must therefore reject exactly that set of inputs so they
-        #   fall through to Graph_old.  The excluded values are the static
-        #   sizes from Graph_old, so the guard
-        #       Or(Ne(s0, v0), Ne(s1, v1), ...)
-        #   passes iff at least one dim differs from the old sizes — i.e. the
-        #   input does NOT fully match Graph_old.  Conversely, when every dim
-        #   matches the old sizes the guard fails and the input falls through
-        #   to Graph_old, which is guaranteed to accept it.
+        # We derive exclusions directly from prior cache entries' static
+        # signatures.  For each prior graph, we generate one Or(Ne(...), ...)
+        # guard covering the dims/scalars that are static in the prior graph
+        # but dynamic in the current graph.  Each prior graph gets its own
+        # guard expression (AND-ed implicitly since they're separate guards).
         #
-        # All exclusion pairs across all tensors and scalars are flattened
-        # into a single list — each pair is just (symbol, excluded_int),
-        # and the multi-tensor case is the same logic as multi-dim within
-        # one tensor.  The combined Or rejects only when ALL pairs match
-        # simultaneously, which is the exact condition for Graph_old to
-        # accept.  If the current concrete values already match every
-        # excluded value the guard is skipped (it would fail on creation).
+        # The guard Or(Ne(s0, v0), Ne(s1, v1), ...) for a prior graph passes
+        # iff at least one dim differs from that prior graph's static sizes.
+        # When ALL dims match, the guard fails and the input falls through
+        # to the prior graph.
         import torch._dynamo.config as dynamo_config
 
         if (
             dynamo_config.stable_graph_selection_for_automatic_dynamic
             and not dynamo_config.enable_compiler_collectives
-            and self.exclusion_constraints
+            and self.prior_static_signatures
         ):
-            all_pairs = [
-                (sym, val)
-                for sym, val in self.exclusion_constraints
-                if symbol_to_source.get(sym)
-            ]
-            if all_pairs and not all(
-                self.backed_var_to_val.get(sym) == val for sym, val in all_pairs
-            ):
-                if len(all_pairs) == 1:
-                    excl_expr = sympy.Ne(
-                        all_pairs[0][0], all_pairs[0][1], evaluate=False
-                    )
-                else:
-                    excl_expr = sympy.Or(
-                        *[sympy.Ne(sym, val, evaluate=False) for sym, val in all_pairs]
-                    )
-                for exprs, printer, lang in zip(all_exprs, printers, langs):
-                    guard_expr = printer.doprint(excl_expr)
-                    if lang == "verbose_python":
-                        guard_expr = (
-                            f"{guard_expr}  # exclusion guard for automatic dynamic"
-                        )
-                    exprs.append(guard_expr)
+            self._emit_per_cache_entry_exclusion_guards(
+                symbol_to_source, all_exprs, printers, langs
+            )
 
         if constraint_violations:
             warn_msgs: list[str] = []


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #176550
* #174993

# Exclusion Guard Design: Per-Cache-Entry Approach

## Correctness guarantee

Routing an input to the "wrong" graph (more general dynamic graph instead of the specialized static graph) always produces the **correct output**. Each graph also has branch guards, static size guards, and type/device guards that prevent cross-branch routing. The "wrong" graph is always a more general version computing the same function for the same branch path.

The differences when using the wrong graph are:
- **Floating point**: Different fusion/optimization → slightly different rounding
- **Performance**: More general graph may be less optimized
- **Autograd graph**: Different compilation → different activation checkpointing behavior

The exclusion guard's role is **stability** (same input → same graph always), not correctness. This matters most for activation checkpointing, which relies on consistent graph structure.

## Problem

When `automatic_dynamic_shapes` promotes a static dim to dynamic, the new dynamic graph is inserted before the old static graph in the guard cache. Without exclusion guards, the dynamic graph captures inputs that should use the static graph, violating the stability invariant "once an input uses graph X, it always uses graph X."

## Design

Each compiled graph stores a **static signature** (`source_name → int | None`) on its guard manager. When a new graph is compiled, it traverses existing cache entries and generates one `Or(Ne(s0, v0), Ne(s1, v1), ...)` exclusion guard per prior graph. Each guard rejects inputs that fully match that prior graph's static sizes, letting them fall through.

### How it works

1. **Build**: After guard construction, `_build_static_signature` captures which dims/scalars are static (int) vs dynamic (None) for each input source.
2. **Extract**: On recompilation, `extract_prior_static_signatures` traverses the cache linked list to collect all prior graphs' signatures.
3. **Emit**: `_emit_per_cache_entry_exclusion_guards` generates one Or guard per prior graph, covering dims that are static in the prior but dynamic in the current graph.
4. **Skip**: If the current compilation's concrete values match ALL excluded values for a prior graph, that guard is skipped (would fail on creation).

### Guard semantics

For prior graph with static sizes `(v0, v1, ...)`:
```
Or(Ne(s0, v0), Ne(s1, v1), ...)
```
- Passes iff at least one dim differs from the prior graph's static sizes
- Fails (rejects) iff ALL dims match → input falls through to the prior graph

Multiple prior graphs' guards are AND-ed (separate guard expressions).

## Files changed

| File | Change |
|---|---|
| `config.py` | `stable_graph_selection_for_automatic_dynamic = True` (kill switch) |
| `output_graph.py` | `scalar_source_to_value: dict[str, int]` for capturing scalar values |
| `builder.py` | Records scalar values to `scalar_source_to_value` (+3 lines) |
| `guards.py` | `static_signature` on GuardManagerWrapper, `_build_static_signature()`, `extract_prior_static_signatures()`, wiring in `SHAPE_ENV` |
| `symbolic_shapes.py` | `prior_static_signatures` field, `_emit_per_cache_entry_exclusion_guards()`, call in `produce_guards_verbose` |
| `printers.py` | `_print_Or` on CppPrinter |

No changes to: `pgo.py`, C++ files, `guards.pyi`

## Frame-state vs Per-cache-entry trade-offs

| Dimension | Frame-state (pgo.py) | Per-cache-entry |
|---|---|---|
| **Cache eviction** | Exclusions persist in pgo state | Evicted graph's exclusion becomes stale on newer graphs |
| **Serialization / PGO warm start** | `excluded_sizes`/`excluded_scalar` serialized with PGO state | `static_signature` not serialized; deserialized entries invisible |
| **Data-dependent branches** | Gap: exclusions cleared on no-transition | Fixed: cache entries persist |
| **Multi-tensor** | Correct (flat Or) | Correct (same prior graph = same Or) |
| **Accumulation** | Correct (clearing + `not all`) | Correct (separate guards per prior graph) |
| **Explainability** | One flat Or, no indication which old graph | One guard per prior graph, can label with compile_id |
| **Guard count** | Always 1 exclusion guard | Up to N guards (one per prior cache entry) |
| **pgo.py changes** | New fields, `__ior__` logic, `compare=False` | None |
| **Total files changed** | 4 | 5 |
| **Code added** | ~110 lines | ~190 lines |

## Runtime guard evaluation cost

| Scenario | Frame-state | Per-cache-entry |
|---|---|---|
| **1 static → 1 dynamic** | 1 Or expr | 1 guard, 1 Or expr |
| **3 cascading graphs** | 1 Or expr (only current transition) | 2 guards (one per prior graph) |
| **N cascading graphs** | 1 Or expr | N-1 guards |
| **Per-guard eval cost** | O(1) short-circuit (common case) | O(1) short-circuit (common case) |
| **Total eval cost** | O(1) always | O(N) worst case, O(1) common case |

Each exclusion guard short-circuits on the first mismatch. N is bounded by `cache_size_limit` (default 8-16).

## Known limitations

1. **Hint overrides**: `backed_var_to_val` stores overridden hints, not actual input values. The `not all` check could emit a guard that fails on creation. Needs skip for overridden dims.
2. **Serialization**: `static_signature` is not included in guard serialization. Deserialized cache entries won't generate exclusion guards for new compilations. Existing exclusion guards (already baked into guard expressions) do survive.
3. **Cache eviction**: When a graph is evicted, newer graphs still carry its exclusion guard. Inputs matching the evicted graph's sizes are rejected but have nowhere to fall → one unnecessary recompilation (self-healing).
4. **Duck sizing**: Two dims duck-sized to the same symbol could produce `Or(Ne(s0, 3), Ne(s0, 5))` which is trivially True (no-op exclusion).

## Test coverage

- `test_automatic_dynamic_exclusive_guard_basic` — basic static → dynamic → revert
- `test_accumulated_exclusion_does_not_shadow_intermediate_graph` — tensor accumulation
- `test_4d_progressive_dynamism_cascading` — 4 graphs cascading
- `test_5d_two_rounds_of_dynamism` — non-adjacent dims
- `test_many_entries_wrong_graph_selection` — stress-test routing
- `test_multi_dim_dynamic_and_semantics` — not-all semantics with partial matches
- `test_integer_input_exclusion_basic` — scalar exclusion
- `test_integer_input_exclusion_accumulation` — scalar accumulation
- `test_two_tensor_inputs_exclusion` — multi-tensor combined Or
- `test_multi_tensor_and_scalar_accumulation` — comprehensive mixed test
- `test_data_dependent_branch_exclusion` — if-statement with shape condition



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo