### PR TITLE
[SymmMem] Add thread safety to NCCL and NVSHMEM backends

### DIFF
--- a/torch/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.cu
@@ -19,6 +19,8 @@
 #include <c10/cuda/CUDAGuard.h>
 #include <c10/util/error.h>
 
+#include <mutex>
+
 namespace c10d {
 namespace symmetric_memory {
 
@@ -30,6 +32,7 @@ struct NCCLAllocation {
   void* ptr;
   size_t buffer_size;
   int device_idx;
+  std::mutex mutex;
   // Map of group name to peer alloc info
   std::unordered_map<std::string, c10::intrusive_ptr<NCCLPeerAllocInfo>> peer_alloc_infos_;
 
@@ -347,18 +350,21 @@ class NCCLSymmetricMemoryAllocator : public SymmetricMemoryAllocator {
     // TODO: we might need to use a roundup or mempool for mem allocation.
     void* ptr;
     C10D_NCCL_CHECK(ncclMemAlloc(&ptr, size), "ncclMemAlloc");
-    // TODO: thread safety
-    allocations_.try_emplace(
-        ptr, std::make_unique<NCCLAllocation>(ptr, size, device_idx));
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      allocations_.try_emplace(
+          ptr, std::make_unique<NCCLAllocation>(ptr, size, device_idx));
+    }
     return ptr;
   }
 
   void free(void* ptr) override {
-    // TODO: thread safety
+    std::lock_guard<std::mutex> lock(mutex_);
     allocations_.erase(ptr);
   };
 
   size_t get_alloc_size(void* ptr) override {
+    std::lock_guard<std::mutex> lock(mutex_);
     auto it = allocations_.find(ptr);
     if (it == allocations_.end()) {
       TORCH_CHECK(
@@ -371,31 +377,39 @@ class NCCLSymmetricMemoryAllocator : public SymmetricMemoryAllocator {
       void* ptr,
       const std::optional<std::string>& group_name) override {
     TORCH_CHECK(group_name.has_value(), "group_name must be provided");
-    // Then search allocation covering the ptr, get the base address
-    auto alloc_it = std::find_if(
-        allocations_.begin(), allocations_.end(), [&](const auto& pair) {
-          auto& allocation = pair.second;
-          auto ptr_int = reinterpret_cast<uintptr_t>(ptr);
-          auto base_ptr = reinterpret_cast<uintptr_t>(allocation->ptr);
-          return ptr_int >= base_ptr &&
-              ptr_int < base_ptr + allocation->buffer_size;
-        });
-    TORCH_CHECK(
-        alloc_it != allocations_.end(),
-        "Pointer not within any SymmetricMemory allocation, "
-        "is the tensor allocated from SymmetricMemory?");
 
-    auto& allocation = alloc_it->second;
+    // Find the allocation covering the ptr under the allocator lock.
+    // We grab a raw pointer to the NCCLAllocation so we can release the
+    // allocator lock before doing expensive per-allocation work.
+    NCCLAllocation* allocation;
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      auto alloc_it = std::find_if(
+          allocations_.begin(), allocations_.end(), [&](const auto& pair) {
+            auto& alloc = pair.second;
+            auto ptr_int = reinterpret_cast<uintptr_t>(ptr);
+            auto base_ptr = reinterpret_cast<uintptr_t>(alloc->ptr);
+            return ptr_int >= base_ptr &&
+                ptr_int < base_ptr + alloc->buffer_size;
+          });
+      TORCH_CHECK(
+          alloc_it != allocations_.end(),
+          "Pointer not within any SymmetricMemory allocation, "
+          "is the tensor allocated from SymmetricMemory?");
+      allocation = alloc_it->second.get();
+    }
 
-    // Get or create peer alloc info for the group
+    // Get or create peer alloc info for the group under the per-allocation
+    // lock. This serializes concurrent rendezvous on the same allocation
+    // for different groups (e.g., forward vs backward).
+    std::lock_guard<std::mutex> alloc_lock(allocation->mutex);
     auto& peer_alloc_infos = allocation->peer_alloc_infos_;
     auto pai_it = peer_alloc_infos.find(*group_name);
     if (pai_it == peer_alloc_infos.end()) {
-      // Never rendezvoused with this group before, create a new peer alloc info
       pai_it = peer_alloc_infos.emplace_hint(
           pai_it,
           *group_name,
-          c10::make_intrusive<NCCLPeerAllocInfo>(allocation.get(), *group_name));
+          c10::make_intrusive<NCCLPeerAllocInfo>(allocation, *group_name));
     }
 
     auto& pai = pai_it->second;
@@ -416,6 +430,7 @@ class NCCLSymmetricMemoryAllocator : public SymmetricMemoryAllocator {
   }
 
  private:
+  std::mutex mutex_;
   std::unordered_map<void*, std::unique_ptr<NCCLAllocation>> allocations_;
 };
 

--- a/torch/csrc/distributed/c10d/symm_mem/NVSHMEMSymmetricMemory.cpp
+++ b/torch/csrc/distributed/c10d/symm_mem/NVSHMEMSymmetricMemory.cpp
@@ -11,6 +11,8 @@
 #include <c10/cuda/CUDAGuard.h>
 #include <c10/util/error.h>
 
+#include <mutex>
+
 // Starting from NVSHMEM 3.3.9, nvshmem_host.h exists so that we can cleanly
 // include only the nvshmem host library headers:
 // #include <nvshmem_host.h>
@@ -51,6 +53,7 @@ struct NVSHMEMAllocation {
 };
 
 // A map from group name to rank-to-global rank mapping
+static std::mutex rank_map_mutex;
 static std::unordered_map<std::string, std::vector<int>>
     rank_to_global_rank_map{};
 // A map from group name to rank-to-global rank device array
@@ -78,6 +81,7 @@ class NVSHMEMPeerAllocInfo : public c10::intrusive_ptr_target {
 
     // Exchange rank to global rank mapping for this group.
     // If it is already available, skip the exchange.
+    std::lock_guard<std::mutex> rank_map_lock(rank_map_mutex);
     auto it = rank_to_global_rank_map.find(group_name);
     if (it == rank_to_global_rank_map.end()) {
       auto global_group = resolve_process_group("0");
@@ -257,6 +261,7 @@ class NVSHMEMSymmetricMemory : public SymmetricMemory {
   }
 
   const std::vector<int>& get_rank_to_global_rank() override {
+    std::lock_guard<std::mutex> lock(rank_map_mutex);
     auto it = rank_to_global_rank_map.find(group_name_);
     if (it == rank_to_global_rank_map.end()) {
       TORCH_CHECK(false, "Group name not found in rank_to_global_rank_map");
@@ -265,6 +270,7 @@ class NVSHMEMSymmetricMemory : public SymmetricMemory {
   };
 
   int* get_rank_to_global_rank_dev() override {
+    std::lock_guard<std::mutex> lock(rank_map_mutex);
     auto it = rank_to_global_rank_dev_map.find(group_name_);
     if (it == rank_to_global_rank_dev_map.end()) {
       TORCH_CHECK(false, "Group name not found in rank_to_global_rank_dev_map");
@@ -366,18 +372,21 @@ class NVSHMEMSymmetricMemoryAllocator : public SymmetricMemoryAllocator {
     auto ptr = nvshmem_malloc(size);
     // If size is 0 (which is legal allocation request) we shouldn't error out
     TORCH_CHECK(ptr != nullptr || size == 0, "nvshmem_malloc failed");
-    // TODO: thread safety
-    allocations_.try_emplace(
-        ptr, std::make_unique<NVSHMEMAllocation>(ptr, size, device_idx));
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      allocations_.try_emplace(
+          ptr, std::make_unique<NVSHMEMAllocation>(ptr, size, device_idx));
+    }
     return ptr;
   }
 
   void free(void* ptr) override {
-    // TODO: thread safety
+    std::lock_guard<std::mutex> lock(mutex_);
     allocations_.erase(ptr);
   };
 
   size_t get_alloc_size(void* ptr) override {
+    std::lock_guard<std::mutex> lock(mutex_);
     auto it = allocations_.find(ptr);
     if (it == allocations_.end()) {
       TORCH_CHECK(
@@ -390,6 +399,7 @@ class NVSHMEMSymmetricMemoryAllocator : public SymmetricMemoryAllocator {
       void* ptr,
       const std::optional<std::string>& group_name) override {
     TORCH_CHECK(group_name.has_value());
+    std::lock_guard<std::mutex> lock(mutex_);
     {
       auto it = symm_mems_.find(std::make_tuple(ptr, *group_name));
       if (it != symm_mems_.end()) {
@@ -458,6 +468,7 @@ class NVSHMEMSymmetricMemoryAllocator : public SymmetricMemoryAllocator {
   }
 
  private:
+  std::mutex mutex_;
   std::unordered_map<void*, std::unique_ptr<NVSHMEMAllocation>> allocations_;
   std::map<
       std::tuple<void*, std::string>,

--- a/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.cpp
+++ b/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.cpp
@@ -4,6 +4,7 @@
 #include <torch/custom_class.h>
 
 #include <atomic>
+#include <mutex>
 
 namespace {
 
@@ -37,16 +38,19 @@ class AllocatorMap {
   void register_allocator(
       c10::DeviceType device_type,
       c10::intrusive_ptr<SymmetricMemoryAllocator> allocator) {
+    std::lock_guard<std::mutex> lock(mutex_);
     map_[device_type] = std::move(allocator);
   }
 
   void register_availability(
       const std::string& name,
       c10::intrusive_ptr<SymmetricMemoryAllocator> allocator) {
+    std::lock_guard<std::mutex> lock(mutex_);
     avail_map_[name] = std::move(allocator);
   }
 
   void set_backend(const std::string& name) {
+    std::lock_guard<std::mutex> lock(mutex_);
     auto it = avail_map_.find(name);
     TORCH_CHECK(
         it != avail_map_.end(),
@@ -62,10 +66,11 @@ class AllocatorMap {
       }
       TORCH_CHECK(!in_use_, "Backend can not be changed after use.");
     }
-    register_allocator(device_type, it->second);
+    map_[device_type] = it->second;
   }
 
   std::optional<std::string> get_backend(c10::DeviceType device_type) {
+    std::lock_guard<std::mutex> lock(mutex_);
     auto it = map_.find(device_type);
     if (it == map_.end()) {
       return std::nullopt;
@@ -75,6 +80,7 @@ class AllocatorMap {
 
   c10::intrusive_ptr<SymmetricMemoryAllocator> get_allocator(
       c10::DeviceType device_type) {
+    std::lock_guard<std::mutex> lock(mutex_);
     auto it = map_.find(device_type);
     TORCH_CHECK(
         it != map_.end(),
@@ -85,6 +91,7 @@ class AllocatorMap {
   }
 
   bool has_allocator(c10::DeviceType device_type) {
+    std::lock_guard<std::mutex> lock(mutex_);
     auto it = map_.find(device_type);
     return it != map_.end();
   }
@@ -96,6 +103,7 @@ class AllocatorMap {
  private:
   AllocatorMap() = default;
 
+  std::mutex mutex_;
   std::unordered_map<
       c10::DeviceType,
       c10::intrusive_ptr<SymmetricMemoryAllocator>>
@@ -113,9 +121,11 @@ class AllocatorMap {
   bool in_use_ = false;
 };
 
+static std::mutex group_info_mutex;
 static std::unordered_map<std::string, GroupInfo> group_info_map{};
 
 // Data structures for tracking persistent allocations
+static std::mutex persistent_alloc_mutex;
 static std::unordered_map<uint64_t, void*> alloc_id_to_dev_ptr{};
 static std::unordered_map<uint64_t, c10::weak_intrusive_ptr<c10::StorageImpl>>
     alloc_id_to_storage{};
@@ -127,6 +137,7 @@ static at::Tensor empty_strided_p2p_persistent(
     c10::Device device,
     const std::optional<std::string>& group_name,
     uint64_t alloc_id) {
+  std::lock_guard<std::mutex> lock(persistent_alloc_mutex);
   // Make the allocation fails if a previous allocation with the same alloc_id
   // is still active.
   auto storage = alloc_id_to_storage.find(alloc_id);
@@ -227,6 +238,7 @@ void set_group_info(
     int rank,
     int world_size,
     c10::intrusive_ptr<Store> store) {
+  std::lock_guard<std::mutex> lock(group_info_mutex);
   TORCH_CHECK(group_info_map.find(group_name) == group_info_map.end());
   GroupInfo group_info;
   group_info.rank = rank;
@@ -236,6 +248,7 @@ void set_group_info(
 }
 
 GroupInfo& get_group_info(const std::string& group_name) {
+  std::lock_guard<std::mutex> lock(group_info_mutex);
   TORCH_CHECK(
       group_info_map.find(group_name) != group_info_map.end(),
       "get_group_info: no group info associated with the group name ",

--- a/torch/csrc/distributed/c10d/symm_mem/nccl_devcomm_manager.hpp
+++ b/torch/csrc/distributed/c10d/symm_mem/nccl_devcomm_manager.hpp
@@ -4,6 +4,7 @@
 #include <c10/cuda/CUDAGuard.h>
 #include <c10/util/Exception.h>
 #include <torch/csrc/distributed/c10d/symm_mem/nccl_dev_cap.hpp>
+#include <mutex>
 #include <string>
 #include <unordered_map>
 
@@ -28,6 +29,7 @@ class NCCLDevCommManager {
 
   // Get an NCCL device communicator for a group.
   ncclDevComm& get_devcomm(const std::string& group_name) {
+    std::lock_guard<std::mutex> lock(mutex_);
     auto it = group_to_comms_.find(group_name);
     if (it == group_to_comms_.end()) {
       TORCH_CHECK(
@@ -41,6 +43,7 @@ class NCCLDevCommManager {
 
   // Get a host-side communicator for a group.
   ncclComm_t get_comm(const std::string& group_name) {
+    std::lock_guard<std::mutex> lock(mutex_);
     auto it = group_to_comms_.find(group_name);
     if (it == group_to_comms_.end()) {
       TORCH_CHECK(
@@ -58,6 +61,7 @@ class NCCLDevCommManager {
       ncclComm_t comm,
       int lsa_barrier_count,
       int gin_barrier_count) {
+    std::lock_guard<std::mutex> lock(mutex_);
     auto it = group_to_comms_.find(group_name);
     if (it != group_to_comms_.end()) {
       return;
@@ -108,6 +112,7 @@ class NCCLDevCommManager {
  private:
   // Device where the NCCL device communicator manager is created
   const c10::Device device_;
+  std::mutex mutex_;
   // A map from group name to NCCL device communicator for that group.
   std::unordered_map<std::string, std::pair<ncclComm_t, ncclDevComm>>
       group_to_comms_;


### PR DESCRIPTION
Both forward and backward passes can request symmetric memory concurrently (e.g., on different CUDA streams), but the NCCL and NVSHMEM allocator backends had unprotected shared mutable state. The CUDA backend already uses std::shared_mutex correctly; this brings the other backends and shared infrastructure to the same standard by adding std::mutex guards around all shared maps and allocation state.

FIXES #176419