### PR TITLE
Add outer-product-decomo

### DIFF
--- a/test/inductor/test_mmdecomp.py
+++ b/test/inductor/test_mmdecomp.py
@@ -6,7 +6,7 @@ from typing import Union
 
 import torch
 from torch._inductor import config
-from torch._inductor.decomposition import mm
+from torch._inductor.decomposition import bmm as decomp_bmm, mm
 from torch._subclasses.fake_tensor import FakeTensorMode
 from torch.fx.experimental.symbolic_shapes import (
     DimDynamic,
@@ -167,6 +167,21 @@ class TestDecomp(NNTestCase):
         t2 = torch.randn(1, 2, 1, device=device)
 
         run_comp_nocomp(torch_bmm, t1, t2, rtol=rtol, atol=atol)
+
+    @unittest.skipIf(not HAS_GPU, "GPU tests require triton")
+    @config.patch(coordinate_descent_tuning=False)
+    def test_bmm_outer_product_k_is_one(self, device):
+        t1 = torch.randn(32, 8, 1, device=device)
+        t2 = torch.randn(32, 1, 256, device=device)
+        expected = torch.bmm(t1, t2)
+
+        out = decomp_bmm(t1, t2)
+
+        if device == "cpu":
+            self.assertIs(out, NotImplemented)
+        else:
+            self.assertIsNot(out, NotImplemented)
+            self.assertEqual(expected, out)
 
     @unittest.skipIf(not HAS_GPU, "GPU tests require triton")
     @parametrize("dtype", [torch.float, torch.bfloat16, torch.int])

--- a/test/inductor/test_mmdecomp.py
+++ b/test/inductor/test_mmdecomp.py
@@ -184,6 +184,36 @@ class TestDecomp(NNTestCase):
             self.assertEqual(expected, out)
 
     @unittest.skipIf(not HAS_GPU, "GPU tests require triton")
+    def test_bmm_outer_product_k_is_one_with_unbacked_k(self, device):
+        if device == "cpu":
+            self.skipTest("test exercises non-CPU bmm decomposition")
+
+        shape_env = ShapeEnv()
+        with FakeTensorMode(shape_env=shape_env):
+            b, m, n = [shape_env.create_unbacked_symint() for _ in range(3)]
+            lhs_k_unbacked, rhs_k_unbacked = [
+                shape_env.create_unbacked_symint() for _ in range(2)
+            ]
+
+            lhs_static_k = torch.empty((b, m, 1), device=device)
+            rhs_static_k = torch.empty((b, 1, n), device=device)
+            lhs_unbacked_k = torch.empty((b, m, lhs_k_unbacked), device=device)
+            rhs_unbacked_k = torch.empty((b, rhs_k_unbacked, n), device=device)
+
+            self.assertIsNot(
+                decomp_bmm(lhs_static_k, rhs_unbacked_k),
+                NotImplemented,
+            )
+            self.assertIsNot(
+                decomp_bmm(lhs_unbacked_k, rhs_static_k),
+                NotImplemented,
+            )
+            self.assertIs(
+                decomp_bmm(lhs_unbacked_k, rhs_unbacked_k),
+                NotImplemented,
+            )
+
+    @unittest.skipIf(not HAS_GPU, "GPU tests require triton")
     @parametrize("dtype", [torch.float, torch.bfloat16, torch.int])
     def test_some(self, device, dtype):
         # this Pytorch data type is not fully supported on cuda today

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -313,6 +313,14 @@ def bmm(
     batch2: torch.Tensor,
     out_dtype: torch.dtype | None = None,
 ) -> torch.Tensor:
+    if self.device.type not in ["cpu", "mps"]:
+        # Outer-product specialization: [B, M, 1] x [B, 1, N] -> [B, M, N].
+        # This avoids introducing a reduction and maps directly to broadcasted mul.
+        if statically_known_true(self.shape[2] == 1) or statically_known_true(
+            batch2.shape[1] == 1
+        ):
+            return self * batch2
+
     # TODO: Re-enable for mps once our reductions are performant enough
     # (https://github.com/pytorch/pytorch/issues/150121)
     if config.coordinate_descent_tuning and self.device.type not in ["cpu", "mps"]:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #176552

## Summary

cublas sucks at fp32 outer reduction, 

One commit before this PR: 
Eager Perf: 
<img width="524" height="386" alt="image" src="https://github.com/user-attachments/assets/ad349a62-5fce-4bb9-8d87-3b088077d1e5" />

Compiled Perf:
<img width="497" height="392" alt="image" src="https://github.com/user-attachments/assets/1f7f436d-7750-4b65-ad0d-c2c627edef0c" />

You can see grad_routed is no bueno. I wrote a small triton kernel that does a pretty naive tiled product and got near roofline. 

If we add this decomp:

<img width="538" height="405" alt="image" src="https://github.com/user-attachments/assets/cd54591c-706d-480e-b951-df89bbb388b3" />


Reported: https://github.com/pytorch/torchtitan/issues/2225



Eager: 
<img width="995" height="231" alt="image" src="https://github.com/user-attachments/assets/f1d33908-3372-46ad-a854-ca7af736be2e" />


Compile
<img width="780" height="250" alt="image" src="https://github.com/user-attachments/assets/8c8881f9-b19a-40f3-91f2-d353e3d80071" />



cc @ptrblck @msaroufim @eqy @jerryzh168 @tinglvv @nWEIdia @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos