### PR TITLE
[CI] Disable TRANSFORMERS_OFFLINE for nightly vLLM benchmark runs

### DIFF
--- a/.github/workflows/_vllm-benchmark.yml
+++ b/.github/workflows/_vllm-benchmark.yml
@@ -33,6 +33,11 @@ on:
         type: string
         description: A JSON string for vLLM --compilation-config, applied to all benchmark tests.
         default: ''
+      is_nightly:
+        required: false
+        type: boolean
+        description: Whether this is a nightly scheduled run. When true, TRANSFORMERS_OFFLINE is disabled.
+        default: false
 
 jobs:
   benchmark:
@@ -198,7 +203,8 @@ jobs:
         env:
           HF_TOKEN: ${{ secrets.VLLM_TEST_HUGGING_FACE_TOKEN }}
           HF_HOME: /mnt/hf_cache
-          TRANSFORMERS_OFFLINE: 1
+          # Nightly runs download from HF to periodically refresh the local cache
+          TRANSFORMERS_OFFLINE: ${{ inputs.is_nightly && '0' || '1' }}
           # vLLM-related environment variables
           ENGINE_VERSION: v1
           SAVE_TO_PYTORCH_BENCHMARK_FORMAT: 1

--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -127,4 +127,5 @@ jobs:
       pytorch_commit: ${{ inputs.pytorch_commit }}
       models: ${{ matrix.models }}
       compilation_config: ${{ inputs.compilation_config }}
+      is_nightly: ${{ github.event_name == 'schedule' }}
     secrets: inherit


### PR DESCRIPTION
Instead of always using offline mode, we need to have a way to periodically refresh the local cache. This job runs only once per day, so rate limit wouldn't be an issue

I observe [a failure in trunk](https://github.com/pytorch/pytorch/actions/runs/22625578355/job/65575251092#step:15:13837) for `pytorch/gemma-3-12b-it-int4` where the local cache doesn't seem to work anymore, not sure why, could be due to the recent transformers version update.  The failure goes away when I turn off TRANSFORMERS_OFFLINE to refresh the local cache.

