### PR TITLE
[inductor] Add forward/backward mode to cudagraph tree log messages

### DIFF
--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -3613,7 +3613,7 @@ if HAS_CUDA_AND_TRITON:
                 foo(torch.ones([10], device="cuda"), torch.ones([20]))
 
             FileCheck().check_count(
-                "Recording function=partition_0, cuda_graph_id=0",
+                "Recording function=partition_0, mode=INFERENCE, cuda_graph_id=0,",
                 1,
                 exactly=True,
             ).run(log_stream.getvalue())

--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -2247,9 +2247,10 @@ class CUDAGraphTreeManager:
                     if log.isEnabledFor(logging.DEBUG):
                         unexpected_rerecord_reason = status_logger()
                         log.debug(
-                            "[%s] Re-recording function=%s, reason=%s",
+                            "[%s] Re-recording function=%s, mode=%s, reason=%s",
                             self.compile_id,
                             self.get_func_name(function_id),
+                            self.id_to_mode[function_id].name,
                             unexpected_rerecord_reason,
                         )
                     else:
@@ -2338,9 +2339,10 @@ class CUDAGraphTreeManager:
         ):
             graph_id = self.new_graph_id()
             log.debug(
-                "[%s] Recording function=%s, cuda_graph_id=%d, inputs: %s",
+                "[%s] Recording function=%s, mode=%s, cuda_graph_id=%d, inputs: %s",
                 self.compile_id,
                 self.get_func_name(function_id),
+                self.id_to_mode[function_id].name,
                 graph_id.id,
                 format_inputs_log(new_inputs),
             )
@@ -2384,9 +2386,10 @@ class CUDAGraphTreeManager:
         func_name = self.get_func_name(function_id)
         if not already_warm:
             log.debug(
-                "[%s] Running warmup function=%s",
+                "[%s] Running warmup function=%s, mode=%s",
                 self.compile_id,
                 func_name,
+                self.id_to_mode[function_id].name,
             )
         else:
             log.debug(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #176164
* __->__ #176556

Include the compilation mode (FORWARD/BACKWARD/INFERENCE) in cudagraph
tree recording, warmup, and re-recording log messages to make it easier
to distinguish which phase a cudagraph partition belongs to.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos

Differential Revision: [D95315539](https://our.internmc.facebook.com/intern/diff/D95315539)