### PR TITLE
[Inductor] Fix cache key pickle failure with cyclic object

### DIFF
--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -2843,6 +2843,17 @@ class TestFxGraphCacheHashing(TestCase):
                 torch.fx.experimental._backward_state.BackwardState()
             )
 
+    def test_bypass_cyclic_objects(self):
+        """
+        Test that cyclic objects (which raise ValueError under pickler.fast=True)
+        are caught and converted to BypassFxGraphCache.
+        """
+        gm = torch.fx.GraphModule({}, torch.fx.Graph())
+        cyclic_dict: dict = {}
+        cyclic_dict["self"] = cyclic_dict
+        with self.assertRaises(BypassFxGraphCache):
+            FxGraphCachePickler(gm).dumps(cyclic_dict)
+
     def test_stable_strings(self):
         """
         Test that objects containing identical strings pickle the same

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -625,8 +625,10 @@ class FxGraphCachePickler(pickle.Pickler):
         try:
             self.dump(obj)
             return self._stream.getvalue()
-        except (TypeError, AttributeError, pickle.PicklingError) as e:
-            # Some configs options may not pickle.
+        except (TypeError, AttributeError, pickle.PicklingError, ValueError) as e:
+            # Some configs options may not pickle. ValueError is raised when
+            # pickler.fast=True encounters cyclic references (e.g., from
+            # DTensor/process group objects in tensor parallel setups).
             log.warning("Failed to pickle cache key", exc_info=True)
             raise BypassFxGraphCache("Failed to pickle cache key") from e
         finally:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #176557



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo