### PR TITLE
Fix #110505

### DIFF
--- a/aten/src/ATen/native/transformers/cuda/attention.cu
+++ b/aten/src/ATen/native/transformers/cuda/attention.cu
@@ -646,7 +646,7 @@ std::tuple<Tensor, Tensor> native_multi_head_attention_cuda(
 
 #endif
   const auto dim_per_head = D / num_head;
-  if ((query.is_same(key) && key.is_same(value)) && dim_per_head % 8 == 0 && !need_weights) {
+  if ((query.is_same(key) && key.is_same(value)) && !need_weights) {
 
     // We have not done linear projection yet but the input for SDP
     // Is expected to be 4 dimensional. We "cheaply" create view tensors

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -379,6 +379,31 @@ class TestTransformers(NNTestCase):
             # of NaNs for fully masked rows
             self.assertEqual(out, out_fp.nan_to_num())
 
+    @onlyCUDA
+    def test_multiheadattention_fastpath_fp16_head_dim_alignment(self, device):
+        previous_fastpath = torch.backends.mha.get_fastpath_enabled()
+        try:
+            torch.manual_seed(0)
+            mha = nn.MultiheadAttention(
+                96,
+                16,
+                dropout=0.2,
+                batch_first=True,
+                dtype=torch.float16,
+                device=device,
+            )
+            x = torch.randn(8, 32, 96, device=device, dtype=torch.float16) * 238.15560380049612
+            with torch.no_grad():
+                torch.backends.mha.set_fastpath_enabled(True)
+                mha.eval()
+                out, _ = mha(x, x, x, need_weights=False)
+                torch.backends.mha.set_fastpath_enabled(False)
+                out_ref, _ = mha(x, x, x, need_weights=False)
+            self.assertTrue(torch.isfinite(out).all())
+            self.assertEqual(out, out_ref, atol=2e-2, rtol=8e-2)
+        finally:
+            torch.backends.mha.set_fastpath_enabled(previous_fastpath)
+
     @parametrize("nhead", [1, 4, 8])
     def test_transformerencoderlayer_src_mask(self, device, nhead):
         batch_size = 2


### PR DESCRIPTION
## Human Note
Okay went a few rounds on this one, and did a few iterations. TLDR is that I think the BT code uses fp16 for accumulation which is bad but fast. I dont really wanna hurt perf here and this should be deprecated anyways. SO basically we just some more dispatch to sdpa in fast path since we fixed the mod8 bug head dim already and forgot to update here. 

Happy clauding :)

## Agent Report
# Issue Summary

`nn.MultiheadAttention` could return all-NaN outputs in `eval()` for CUDA `float16` self-attention when `head_dim` was not divisible by 8, while training/slowpath remained finite.

# Root Cause Analysis

In `native_multi_head_attention_cuda`, the native MHA fastpath only attempted the SDPA route when `dim_per_head % 8 == 0`. For non-multiple-of-8 head dimensions, execution fell back to a legacy fp16 path (`bmm -> softmax -> bmm`).

For the failing repro, the legacy score matmul produced `+inf` logits, and softmax over those rows emitted NaNs.

# Fix

Implemented a kernel-path fix in `aten/src/ATen/native/transformers/cuda/attention.cu`:

- Removed the hard `dim_per_head % 8 == 0` gate before trying SDPA.
- Kept the existing SDPA backend filter in this path (`flash_attention`, `efficient_attention`, or `cudnn_attention`) instead of broadening to all non-error backends.

This keeps native MHA on the numerically stable SDPA route for `head_dim=6` instead of the unstable legacy fp16 score path.

Also kept the regression test in `test/test_transformers.py` and adjusted its fp16 comparison tolerance to account for expected backend numeric variation while still checking finiteness.

# Test Results

## Rebuild

- Ran: `bash ~/.ptq_workspace/scripts/rebuild.sh ~/.ptq_workspace/jobs/20260304-110505/pytorch`
- Result: success (incremental rebuild completed, torch reinstalled from local source).

## Repro

Ran:

- `~/.ptq_workspace/jobs/20260304-110505/.venv/bin/python ~/.ptq_workspace/jobs/20260304-110505/repro.py`

Observed:

- `native_head_dim8_has_nan=False`
- `native_head_dim6_has_nan=False`
- `module_head_dim8_has_nan=False`
- `module_head_dim6_has_nan=False`
- `native_head_dim6_poison_has_nan=False`

## Targeted tests

- `~/.ptq_workspace/jobs/20260304-110505/.venv/bin/python test/test_transformers.py -k test_multiheadattention_fastpath_fp16_head_dim_alignment` → passed (re-run after narrowing the fix scope)
- `~/.ptq_workspace/jobs/20260304-110505/.venv/bin/python test/test_transformers.py -k test_multiheadattention_fastpath_attn_mask` → passed

# Additional Analysis (Run 9)

Per follow-up request, the backend broadening was removed. The final fix now only removes the `dim_per_head % 8` gate while preserving the original backend allowlist in this native MHA SDPA path.

This means `head_dim=6` is no longer blocked up front by `% 8`, and can use the SDPA route when one of the previously allowed fused backends is selected, avoiding the legacy fp16 `bmm -> softmax -> bmm` route that produced NaNs in the repro.


Fixes #110505


<details>
<summary>Agent Worklog</summary>

## Run 1

> **User:** Be sure to repro first

### Retrieved issue context and checked environment
- Found the job issue details in `system_prompt.md` (issue #110505: NaNs in SDPA with eval/dropout=0).
- Verified the dedicated job Python and runtime: torch `2.12.0a0+git01a11e6`, CUDA available.
- Confirmed there was no pre-generated `repro.py`, so a standalone repro script needs to be created.
### Built and ran standalone repro
- Added `repro.py` with a deterministic `nn.MultiheadAttention` eval/no_grad scenario.
- Reproduced failure: train path is finite, eval fastpath returns NaNs, and eval slowpath (fastpath disabled) is finite.
- This narrows the issue to the native MHA fastpath (`torch._native_multi_head_attention`).
### Implemented fix for eval fastpath NaNs
- Root cause: `nn.MultiheadAttention` native eval fastpath can emit NaNs in CUDA `float16` when `head_dim` is not divisible by 8.
- Added a fastpath guard in `torch/nn/modules/activation.py` to skip the native fastpath for this unsupported/unstable shape regime.
- Added regression test `test_multiheadattention_fastpath_fp16_head_dim_alignment` in `test/test_transformers.py`.

### Validation
- `python repro.py` now passes (`eval_fast_has_nan=False`).
- `python test/test_transformers.py -k test_multiheadattention_fastpath_fp16_head_dim_alignment` passed.
- `python test/test_transformers.py -k test_multiheadattention_fastpath_attn_mask` passed.


## Run 2

> **User:** hey


### Agent Summary (auto-extracted)
Hi — what would you like me to work on?



## Run 3

> **User:** did you verify that you ran a small traning job and got nans locally first before doing any fixes?

### Clarification and verification
- In the original reproduction (before applying the fix), I used a small standalone `nn.MultiheadAttention` train/eval script rather than a full end-to-end training loop.
- That script explicitly checked train-mode output and eval-mode output on the same finite CUDA `float16` inputs.
- The recorded pre-fix behavior was: `train_has_nan=False`, `eval_fast_has_nan=True`, `eval_slow_has_nan=False`.
- I re-ran the current `repro.py` in this run and confirmed post-fix behavior is now fully finite: `train_has_nan=False`, `eval_fast_has_nan=False`, `eval_slow_has_nan=False`.


## Run 4

> **User:** Can you do something in the reproduction a little differently 
I want to basically run it once with the same input with head dim divisible by eight and one with it not And then show that in the divisible by 8 case for the exact same inputs we do not see a NAN. And the next one we do see a NAN. For head dim, let's say divisbile by 6

Also, if you think it's because of like an out-of-bounds read, potentially We could use the um compute sanitizer to debug. And verify that this is happening 
Also if we could craft the inputs or might be the initialization. Such that we have some NAN poisoning, meaning like we basically have nans for wherever the invalued invalid reads are. That'd be interesting. And stronger signal

### Repro updated to matched head dimensions (8 vs 6)
- Rewrote `repro.py` to run two cases from the same base tensor and matched weights:
  - `head_dim=8` (`embed_dim=128`, `num_heads=16`)
  - `head_dim=6` (`embed_dim=96`, `num_heads=16`, slice of the same base input/weights)
- Used direct `torch._native_multi_head_attention` calls for both cases to isolate the underlying native kernel behavior.
- Result:
  - `native_head_dim8_has_nan=False`
  - `native_head_dim6_has_nan=True`
- Also printed module-level behavior under current tree:
  - `module_head_dim8_has_nan=False`
  - `module_head_dim6_has_nan=False`
  - This matches the current Python-level fastpath guard behavior.

### Compute-sanitizer check for invalid memory access
- Added `csan_native_mha.py` with the same matched 8-vs-6 native call.
- Ran:
  - `/usr/local/cuda-13.0/bin/compute-sanitizer --tool memcheck ~/.ptq_workspace/jobs/20260304-110505/.venv/bin/python ~/.ptq_workspace/jobs/20260304-110505/csan_native_mha.py`
- Also ran:
  - `/usr/local/cuda-13.0/bin/compute-sanitizer --tool initcheck ~/.ptq_workspace/jobs/20260304-110505/.venv/bin/python ~/.ptq_workspace/jobs/20260304-110505/csan_native_mha.py`
- Output confirmed the NaN split (`8 -> False`, `6 -> True`) with:
  - `ERROR SUMMARY: 0 errors` for both tools.
- No out-of-bounds/illegal-access/uninitialized-read report was produced by sanitizer in this repro.

### NaN poisoning attempt
- Tried poisoning tail storage outside the logical `embed_dim=96` slice with `NaN` values, then reran the same native `head_dim=6` case.
- The failing output stayed NaN in both clean and poisoned variants, and `nan_to_num` outputs were identical.
- This did not provide additional evidence of OOB reads from padding/tail memory in this setup.


## Run 5

> **User:** I think this change is fine. is not very actively used code and I think this is the right fix, But can you investigate the actual kernel to see why this is failing for headtim mod eight? Like w what where's a nan coming from and what is a potential fixer

### Kernel-path investigation and NaN origin
- Re-ran `repro.py` to confirm baseline behavior remains:
  - `native_head_dim8_has_nan=False`
  - `native_head_dim6_has_nan=True`
- Traced `torch._native_multi_head_attention` into `aten/src/ATen/native/transformers/cuda/attention.cu`:
  - If `dim_per_head % 8 == 0`, native path attempts fused SDPA (`scaled_dot_product_attention`).
  - If not, it falls back to the legacy path: `qkv_projection -> _transform_bias_rescale_qkv -> bmm -> softmax -> bmm`.
- Reproduced the legacy path in Python and compared intermediates:
  - `q`, `k`, `v` are finite.
  - `qkt = q @ k^T` in fp16 contains `+inf`.
  - `softmax(qkt)` then produces NaNs on rows with `+inf` (NaN rows exactly matched rows containing positive infinity logits).
  - For `head_dim=6`, this manual legacy path matched native output exactly (including NaNs).
- Verified this is not specific to non-contiguous slicing:
  - contiguous `head_dim=6` inputs still reproduced NaNs.

### Why `head_dim % 8` appears as trigger
- `head_dim % 8 != 0` does not directly generate NaNs by itself.
- It diverts execution away from the fused SDPA route in native MHA and into the legacy fp16 `bmm+softmax` route, where score overflow to `+inf` occurs.
- For `head_dim=8`, native uses fused SDPA and remains finite in this repro.

### Potential fixes validated locally
- **Fix direction A (preferred):** remove/relax the native `dim_per_head % 8 == 0` gate and let fused SDPA backend selection handle support. In this tree, SDPA flash path pads head dim internally and can handle non-multiple-of-8 dims.
- **Fix direction B:** keep legacy path but compute score/softmax in fp32 for fp16/bf16 inputs, then cast back. Local prototype removed NaNs and closely matched slowpath output (`max_abs_diff` around `0.03125`).
- **Non-fix option tested:** clamping fp16 scores before softmax removes NaNs but diverges substantially from stable reference (`max_abs_diff` around `150+`), so it is not a good correctness fix.


## Run 6

> **User:** yeah lets try that and rebuield and seee if its ovles the issue

### Implemented kernel-side fix and removed temporary Python workaround
- Updated `aten/src/ATen/native/transformers/cuda/attention.cu`:
  - Removed the `dim_per_head % 8 == 0` gate before trying the SDPA fastpath in native MHA.
  - Allowed the SDPA route for any viable backend selected by `select_sdp_backend` (all non-`error` backends), instead of restricting to flash/efficient/cuDNN only.
- Removed the Python-level fastpath block in `torch/nn/modules/activation.py` for CUDA fp16 `head_dim % 8 != 0`, so fixed native behavior is used instead of forcing slowpath.

### Rebuild and validation
- Rebuilt with:
  - `bash ~/.ptq_workspace/scripts/rebuild.sh ~/.ptq_workspace/jobs/20260304-110505/pytorch`
- Re-ran repro:
  - `native_head_dim8_has_nan=False`
  - `native_head_dim6_has_nan=False`
  - `module_head_dim8_has_nan=False`
  - `module_head_dim6_has_nan=False`
- Updated `repro.py` assertion to match fixed behavior (both head dims finite), and reran successfully.

### Tests
- Ran `python test/test_transformers.py -k test_multiheadattention_fastpath_fp16_head_dim_alignment`
  - Initially failed due strict numerical equality tolerance.
  - Relaxed comparison tolerances (`atol=2e-2`, `rtol=8e-2`) while still enforcing finiteness.
  - Re-run passed.
- Ran `python test/test_transformers.py -k test_multiheadattention_fastpath_attn_mask` and it passed.


## Run 7

> **User:** hmm I guess tha thtis will end up ptoenitall going ot the math backend right?

### Backend dispatch clarification
- Confirmed in `aten/src/ATen/native/transformers/cuda/attention.cu` that native MHA now enters SDPA whenever `select_sdp_backend(...)` returns any non-`error` backend.
- This means **math backend is allowed** as a fallback in this SDPA path if flash / mem-efficient / cuDNN are unavailable or disabled.
- On this A100 setup with fp16 and the tested shapes, dispatch is expected to prefer fused kernels first per SDPA priority order, with math only as fallback.
- Verified locally with `torch._fused_sdp_choice` on shape `[B=2, H=16, T=64, D=6]` (`float16`, CUDA): selected backend was `FLASH_ATTENTION` (`choice=1`), with `can_use_flash_attention=True`, `can_use_efficient_attention=False`, `can_use_cudnn_attention=False`.
- This is still preferable to the previous native MHA legacy fp16 `bmm -> softmax -> bmm` route that produced NaNs for the failing case.


## Run 8

> **User:** okay in this cause then lets just remove teh headdim % 8 thing woudlnt stil allow us to got to sdpa for headdim 6 and get the benefits of that dispatch

### Confirmation on `% 8` gate removal and SDPA dispatch
- Confirmed in `aten/src/ATen/native/transformers/cuda/attention.cu` that native MHA no longer gates SDPA on `dim_per_head % 8 == 0`.
- Current condition enters SDPA for any viable backend (`select_sdp_backend(...) != error`) under the same fastpath constraints.
- Therefore `head_dim=6` is now eligible for SDPA dispatch and can use fused backends when available, with SDPA math as fallback.
- This preserves the dispatch benefits and avoids the older legacy fp16 `bmm -> softmax -> bmm` route that produced NaNs in the repro.



## Run 9

> **User:** can we remove the backend chagne and just remove the ehaddim 8 restriction

### Requested scope adjustment
- Reverted the backend broadening in `native_multi_head_attention_cuda` and restored the SDPA backend allowlist to `flash_attention`, `efficient_attention`, or `cudnn_attention`.
- Kept the `dim_per_head % 8` gate removal so non-multiple-of-8 head dimensions can still enter SDPA when one of those backends is selected.

### Validation
- Rebuilt with:
  - `bash ~/.ptq_workspace/scripts/rebuild.sh ~/.ptq_workspace/jobs/20260304-110505/pytorch`
- Re-ran repro:
  - `native_head_dim8_has_nan=False`
  - `native_head_dim6_has_nan=False`
  - `module_head_dim8_has_nan=False`
  - `module_head_dim6_has_nan=False`
- Re-ran focused tests:
  - `~/.ptq_workspace/jobs/20260304-110505/.venv/bin/python test/test_transformers.py -k test_multiheadattention_fastpath_fp16_head_dim_alignment` passed
  - `~/.ptq_workspace/jobs/20260304-110505/.venv/bin/python test/test_transformers.py -k test_multiheadattention_fastpath_attn_mask` passed

### Run 9 addendum (requested variant)
- Confirmed `git diff` for `attention.cu` now contains only one semantic change: dropping `dim_per_head % 8 == 0` from the native-MHA SDPA-entry guard.
- Confirmed the backend condition is back to the original fused allowlist (flash / efficient / cuDNN), i.e. no `backend != error` broadening remains.

</details>

---
*This PR was generated by [ptq](https://github.com/drisspg/pt_job_queue) with human review.*

cc @albanD @mruberry @jbschlosser @walterddr @mikaylagawarecki @liangel-02 @howardzhang-cv