### PR TITLE
[device_mesh] Fix inverted condition in `_unflatten` string dim validation

### DIFF
--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -1375,7 +1375,7 @@ else:
                 raise ValueError(
                     f"dim {dim} specified in `_unflatten` is out of range {self.ndim}"
                 )
-            elif isinstance(dim, str) and dim in not_none(self.mesh_dim_names):
+            elif isinstance(dim, str) and dim not in not_none(self.mesh_dim_names):
                 raise ValueError(
                     f"dim {dim} specified in `_unflatten` is not in {self.mesh_dim_names}"
                 )


### PR DESCRIPTION
Fixes #176443

The validation in `DeviceMesh._unflatten` incorrectly rejects valid string dim names and accepts invalid ones. The condition checked `dim in mesh_dim_names` but should check `dim not in mesh_dim_names`.