### PR TITLE
Fix the torch.Stream context manager reentrance

### DIFF
--- a/test/test_accelerator.py
+++ b/test/test_accelerator.py
@@ -116,6 +116,7 @@ class TestAccelerator(TestCase):
         s0 = torch.Stream()
         with s0, s0:
             self.assertEqual(torch.accelerator.current_stream(), s0)
+        self.assertEqual(torch.accelerator.current_stream(), prev_stream)
         s1 = torch.Stream()
         with s0:
             self.assertEqual(torch.accelerator.current_stream(), s0)

--- a/test/test_accelerator.py
+++ b/test/test_accelerator.py
@@ -113,11 +113,16 @@ class TestAccelerator(TestCase):
 
     def test_stream_context_manager_reentrance(self):
         prev_stream = torch.accelerator.current_stream()
-        s = torch.Stream()
-        with s:
-            self.assertEqual(torch.accelerator.current_stream(), s)
-            with s:
-                self.assertEqual(torch.accelerator.current_stream(), s)
+        s0 = torch.Stream()
+        with s0, s0:
+            self.assertEqual(torch.accelerator.current_stream(), s0)
+        s1 = torch.Stream()
+        with s0:
+            self.assertEqual(torch.accelerator.current_stream(), s0)
+            with s1:
+                self.assertEqual(torch.accelerator.current_stream(), s1)
+                with s0:
+                    self.assertEqual(torch.accelerator.current_stream(), s0)
         self.assertEqual(torch.accelerator.current_stream(), prev_stream)
 
     @unittest.skipIf(not TEST_MULTIACCELERATOR, "only one accelerator detected")

--- a/test/test_accelerator.py
+++ b/test/test_accelerator.py
@@ -111,6 +111,15 @@ class TestAccelerator(TestCase):
             self.assertEqual(torch.accelerator.current_stream(), s)
         self.assertEqual(torch.accelerator.current_stream(), prev_stream)
 
+    def test_stream_context_manager_reentrance(self):
+        prev_stream = torch.accelerator.current_stream()
+        s = torch.Stream()
+        with s:
+            self.assertEqual(torch.accelerator.current_stream(), s)
+            with s:
+                self.assertEqual(torch.accelerator.current_stream(), s)
+        self.assertEqual(torch.accelerator.current_stream(), prev_stream)
+
     @unittest.skipIf(not TEST_MULTIACCELERATOR, "only one accelerator detected")
     def test_multi_device_stream_context_manager(self):
         src_device = 0

--- a/torch/csrc/Stream.cpp
+++ b/torch/csrc/Stream.cpp
@@ -285,12 +285,18 @@ static PyObject* THPStream_enter(PyObject* _self, PyObject* unused) {
   c10::DeviceIndex cur_device_idx = at::accelerator::getDeviceIndex();
   c10::DeviceIndex stream_device_idx =
       static_cast<c10::DeviceIndex>(self->device_index);
+  c10::Stream cur_stream = at::accelerator::getCurrentStream(stream_device_idx);
+  // No operation if the stream is the current stream of the current device.
+  if (cur_stream.id() == self->stream_id &&
+      cur_stream.device_index() == stream_device_idx) {
+    Py_INCREF(_self);
+    return _self;
+  }
   // If the stream is not on the current device, switch the current device to
   // the device of the stream.
   if (stream_device_idx != cur_device_idx) {
     at::accelerator::setDeviceIndex(stream_device_idx);
   }
-  c10::Stream cur_stream = at::accelerator::getCurrentStream(stream_device_idx);
   at::accelerator::setCurrentStream(c10::Stream::unpack3(
       self->stream_id, stream_device_idx, stream_device_type));
   // Save the current device index and previous stream to the context.
@@ -324,6 +330,10 @@ static PyObject* THPStream_exit(PyObject* _self, PyObject* unused) {
           static_cast<c10::DeviceType>(self->device_type)))) {
     Py_RETURN_NONE;
   }
+  // No operation if the stream is the current stream of the current device.
+  if (!self->context) {
+    Py_RETURN_NONE;
+  }
   PyObject* py_stream = nullptr;
   if (PyDict_GetItemStringRef(self->context, "_ctx_stream", &py_stream) < 0) {
     throw python_error();
@@ -342,6 +352,12 @@ static PyObject* THPStream_exit(PyObject* _self, PyObject* unused) {
       ctx_device_index.get(),
       "ctx_device_index should be present on the context dict.");
   auto prev_device_index = THPUtils_unpackDeviceIndex(ctx_device_index.get());
+  // No operation if the stream is the current stream of the current device when
+  // reentrance occurs.
+  if (prev_stream->stream_id == self->stream_id &&
+      prev_device_index == self->device_index) {
+    Py_RETURN_NONE;
+  }
   at::accelerator::setCurrentStream(c10::Stream::unpack3(
       prev_stream->stream_id,
       static_cast<c10::DeviceIndex>(prev_stream->device_index),

--- a/torch/csrc/Stream.cpp
+++ b/torch/csrc/Stream.cpp
@@ -119,6 +119,7 @@ PyObject* THPStream_Wrap(const c10::Stream& stream) {
 
 static void THPStream_dealloc(THPStream* self) {
   PyObject_ClearWeakRefs((PyObject*)self);
+  Py_CLEAR(self->context);
   Py_TYPE(self)->tp_free(reinterpret_cast<PyObject*>(self));
 }
 
@@ -277,21 +278,46 @@ static PyObject* THPStream_enter(PyObject* _self, PyObject* unused) {
   auto self = reinterpret_cast<THPStream*>(_self);
   c10::DeviceType stream_device_type =
       static_cast<c10::DeviceType>(self->device_type);
+
   // No operation is performed if the stream does not belong to an accelerator.
   if (C10_UNLIKELY(!at::accelerator::isAccelerator(stream_device_type))) {
     Py_INCREF(_self);
     return _self;
   }
+
+  // Note [Reentrant Stream Context Manager]
+  //
+  // We maintain a stack of context entries to support nested/reentrant
+  // stream context managers. Each entry records the previously active
+  // stream and device so that they can be restored in __exit__.
+  //
+  // The stack is stored as a Python list where each entry is either:
+  //   - Py_None: no-op enter (stream was already current);
+  //   - dict:    {_ctx_stream, _ctx_device_index} saved before switching.
+  //
+  // self->context is initialized lazily as a PyList on first __enter__.
+  if (!self->context) {
+    self->context = PyList_New(0);
+    if (!self->context) {
+      throw python_error();
+    }
+  }
+
   c10::DeviceIndex cur_device_idx = at::accelerator::getDeviceIndex();
   c10::DeviceIndex stream_device_idx =
       static_cast<c10::DeviceIndex>(self->device_index);
   c10::Stream cur_stream = at::accelerator::getCurrentStream(stream_device_idx);
-  // No operation if the stream is the current stream of the current device.
+
+  // If the stream is already current, push None as a no-op sentinel.
   if (cur_stream.id() == self->stream_id &&
       cur_stream.device_index() == stream_device_idx) {
+    if (PyList_Append(self->context, Py_None) < 0) {
+      throw python_error();
+    }
     Py_INCREF(_self);
     return _self;
   }
+
   // If the stream is not on the current device, switch the current device to
   // the device of the stream.
   if (stream_device_idx != cur_device_idx) {
@@ -299,22 +325,23 @@ static PyObject* THPStream_enter(PyObject* _self, PyObject* unused) {
   }
   at::accelerator::setCurrentStream(c10::Stream::unpack3(
       self->stream_id, stream_device_idx, stream_device_type));
-  // Save the current device index and previous stream to the context.
+
+  // Save the current device index and previous stream as a dict on the stack.
   auto ctx_device_index =
       THPObjectPtr(THPUtils_packDeviceIndex(cur_device_idx));
   auto ctx_stream = THPObjectPtr(THPStream_Wrap(cur_stream));
-  TORCH_CHECK(!(self->context), "Stream's context should not be initialized.");
   auto dict = THPObjectPtr(PyDict_New());
   if (!dict) {
     throw python_error();
   }
-  self->context = dict.release();
   if (PyDict_SetItemString(
-          self->context, "_ctx_device_index", ctx_device_index.get()) < 0) {
+          dict.get(), "_ctx_device_index", ctx_device_index.get()) < 0) {
     throw python_error();
   }
-  if (PyDict_SetItemString(self->context, "_ctx_stream", ctx_stream.get()) <
-      0) {
+  if (PyDict_SetItemString(dict.get(), "_ctx_stream", ctx_stream.get()) < 0) {
+    throw python_error();
+  }
+  if (PyList_Append(self->context, dict.get()) < 0) {
     throw python_error();
   }
   Py_INCREF(_self);
@@ -325,23 +352,34 @@ static PyObject* THPStream_enter(PyObject* _self, PyObject* unused) {
 static PyObject* THPStream_exit(PyObject* _self, PyObject* unused) {
   HANDLE_TH_ERRORS
   auto self = reinterpret_cast<THPStream*>(_self);
+
   // No operation is performed if the stream does not belong to an accelerator.
   if (C10_UNLIKELY(!at::accelerator::isAccelerator(
           static_cast<c10::DeviceType>(self->device_type)))) {
     Py_RETURN_NONE;
   }
-  // No operation if the stream is the current stream of the current device.
-  if (!self->context) {
+
+  // Pop the top entry from the stack.
+  Py_ssize_t stack_size = PyList_Size(self->context);
+  TORCH_INTERNAL_ASSERT(stack_size > 0, "Stream context stack is empty.");
+  PyObject* top = PyList_GET_ITEM(self->context, stack_size - 1);
+
+  // Sentinel: this __enter__ was a no-op, nothing to restore.
+  if (top == Py_None) {
+    if (PyList_SetSlice(self->context, stack_size - 1, stack_size, nullptr) <
+        0) {
+      throw python_error();
+    }
     Py_RETURN_NONE;
   }
+
   PyObject* py_stream = nullptr;
-  if (PyDict_GetItemStringRef(self->context, "_ctx_stream", &py_stream) < 0) {
+  if (PyDict_GetItemStringRef(top, "_ctx_stream", &py_stream) < 0) {
     throw python_error();
   }
   auto ctx_stream = THPObjectPtr(py_stream);
   PyObject* py_device_index = nullptr;
-  if (PyDict_GetItemStringRef(
-          self->context, "_ctx_device_index", &py_device_index) < 0) {
+  if (PyDict_GetItemStringRef(top, "_ctx_device_index", &py_device_index) < 0) {
     throw python_error();
   }
   auto ctx_device_index = THPObjectPtr(py_device_index);
@@ -352,12 +390,7 @@ static PyObject* THPStream_exit(PyObject* _self, PyObject* unused) {
       ctx_device_index.get(),
       "ctx_device_index should be present on the context dict.");
   auto prev_device_index = THPUtils_unpackDeviceIndex(ctx_device_index.get());
-  // No operation if the stream is the current stream of the current device when
-  // reentrance occurs.
-  if (prev_stream->stream_id == self->stream_id &&
-      prev_device_index == self->device_index) {
-    Py_RETURN_NONE;
-  }
+
   at::accelerator::setCurrentStream(c10::Stream::unpack3(
       prev_stream->stream_id,
       static_cast<c10::DeviceIndex>(prev_stream->device_index),
@@ -366,7 +399,9 @@ static PyObject* THPStream_exit(PyObject* _self, PyObject* unused) {
   if (static_cast<c10::DeviceIndex>(self->device_index) != prev_device_index) {
     at::accelerator::setDeviceIndex(prev_device_index);
   }
-  Py_CLEAR(self->context);
+  if (PyList_SetSlice(self->context, stack_size - 1, stack_size, nullptr) < 0) {
+    throw python_error();
+  }
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
 }

--- a/torch/csrc/Stream.cpp
+++ b/torch/csrc/Stream.cpp
@@ -297,10 +297,11 @@ static PyObject* THPStream_enter(PyObject* _self, PyObject* unused) {
   //
   // self->context is initialized lazily as a PyList on first __enter__.
   if (!self->context) {
-    self->context = PyList_New(0);
-    if (!self->context) {
+    auto list = THPObjectPtr(PyList_New(0));
+    if (!list) {
       throw python_error();
     }
+    self->context = list.release();
   }
 
   c10::DeviceIndex cur_device_idx = at::accelerator::getDeviceIndex();


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #176568
# Motivation
This PR aims to fix `torch.Stream` as a context manager nested/reentrance scenario. `torch.cuda.stream` and `torch.xpu.stream` could support these usages.

The following scenario would be fixed with this PR:
```python
import torch
s0 = torch.Stream()
with s0, s0:
    pass
```
```python
import torch
s0 = torch.Stream()
s1 = torch.Stream()
with s0, s1:
    with s0, s1:
        pass
```

# Addtional Context
Fix https://github.com/pytorch/pytorch/issues/176560
