### PR TITLE
[Helion + torch.compile] Add `ExternalTritonTemplateKernel` for external template prologue/epilogue fusion

### DIFF
--- a/test/inductor/test_select_algorithm.py
+++ b/test/inductor/test_select_algorithm.py
@@ -25,7 +25,9 @@ from torch._inductor.ir import FixedLayout
 from torch._inductor.kernel_inputs import KernelInputs
 from torch._inductor.select_algorithm import (
     autotune_select_algorithm,
+    ExternalTritonTemplateKernel,
     ExternKernelChoice,
+    PartialRender,
     TritonTemplate,
     TritonTemplateKernel,
 )
@@ -897,6 +899,192 @@ class TestTemplateRender(TestCase):
             FileCheck().check("triton_meta=").check(str(custom_triton_meta)).run(
                 kernels[0]
             )
+
+    @requires_gpu()
+    @requires_triton()
+    @config.patch(cuda_backend="triton")
+    def test_external_template_prologue_epilogue_fusion(self):
+        """
+        Tests prologue fusion, epilogue fusion, and extra inputs through the
+        ExternalTritonTemplateKernel render()-based path.
+
+        Compiled function: relu(template_add(a, sigmoid(b))) * bias
+          - Prologue: sigmoid(b) fused into template as <LOAD_INPUT_B>
+          - Epilogue: relu(...) * bias fused into template as <STORE_OUTPUT_0>
+          - Extra inputs: bias is read by the epilogue but is not among the
+            template's original inputs, exercising kernel._extra_inputs
+        """
+        import torch._inductor.ir as ir
+        from torch._inductor.ir import OrderedSet
+        from torch._inductor.utils import Placeholder, run_and_get_code
+
+        XBLOCK = 128
+        render_called = [False]
+
+        class _MockExternalTemplateBuffer(ir.TemplateBuffer):
+            def __init__(self, layout, inputs):
+                tb_self = self
+
+                def _make_kernel_render(out_node, hint_override=None):
+                    kernel = ExternalTritonTemplateKernel(tb_self)
+
+                    def render():
+                        return tb_self._render(kernel)
+
+                    return kernel, render
+
+                super().__init__(
+                    layout,
+                    inputs,
+                    _make_kernel_render,
+                    named_inputs={"A": inputs[0], "B": inputs[1]},
+                )
+                # Allow prologue fusion on input B (sigmoid(b) can be
+                # absorbed so the template reads b directly)
+                self.allowed_prologue_inps = OrderedSet([inputs[1].get_name()])
+                self.epilogue_fusable_outputs = {self.name: "result"}
+
+            def _render(self, kernel):
+                render_called[0] = True
+                epilogues = kernel._eligible_epilogues
+                prologue_sources = kernel._prologue_sources
+
+                # Mark prologue buffers
+                for pro_buf, source_bufs in prologue_sources.items():
+                    kernel.store_buffer_names.add(pro_buf)
+                    if not source_bufs:
+                        kernel.removed_buffers.add(pro_buf)
+
+                # Set up epilogue/prologue render hooks
+                for epi_idx in range(len(self.epilogue_fusable_outputs)):
+                    epi = epilogues[epi_idx] if epi_idx < len(epilogues) else None
+                    kernel._setup_epilogue_hook(
+                        output_buf=epi[1] if epi else None,
+                        output_param=epi[2] if epi else None,
+                    )
+                for param_name in self._named_inputs:
+                    kernel._setup_prologue_hook(
+                        param_name, prologue_sources=prologue_sources
+                    )
+                kernel.render_hooks["<DEF_KERNEL>"] = lambda: ""
+
+                # --- Prologue handling for B ---
+                b_arg = self.inputs[1].get_name()
+                prologue_load_b = "    b = tl.load(B + xindex, mask=xmask)\n"
+                if kernel._prologue_source_buffers.get("B") is not None:
+                    b_arg = kernel._prologue_source_buffers["B"]
+                    prologue_load_b = (
+                        "    _prologue_B_xindex = xindex\n"
+                        "    _prologue_B_xmask = xmask\n"
+                        "    <LOAD_INPUT_B>\n"
+                        "    b = _prologue_B_result\n"
+                    )
+
+                call_args = [self.inputs[0].get_name(), b_arg]
+
+                # --- Epilogue handling ---
+                out_param = "result"
+                out_arg = self.name
+                if epilogues:
+                    _, _, _, store_target = epilogues[0]
+                    if store_target is not None:
+                        # Pre-register and use store target param
+                        kernel.args.output(store_target)
+                        st_param = kernel.args.output_buffers.get(store_target)
+                        if st_param is not None:
+                            out_param = st_param
+                            out_arg = store_target
+
+                call_args.append(out_arg)
+
+                # --- Extra inputs ---
+                extra_params = []
+                for buf_name, param_name in kernel._extra_inputs.items():
+                    extra_params.append(param_name)
+                    call_args.append(buf_name)
+
+                numel = self.get_size()[0]
+                call_args.append(str(numel))
+
+                # Build the inner kernel signature
+                extra_sig = (
+                    ", " + ", ".join(extra_params) if extra_params else ""
+                )
+
+                kn = str(Placeholder.KERNEL_NAME)
+                source = (
+                    "import triton\n"
+                    "import triton.language as tl\n"
+                    "import torch\n"
+                    "from torch._inductor.runtime import triton_helpers\n"
+                    "\n"
+                    "@triton.jit\n"
+                    f"def _mock_inner_add(A, B, {out_param}"
+                    f"{extra_sig},"
+                    " numel, XBLOCK: tl.constexpr):\n"
+                    "    xoffset = tl.program_id(0) * XBLOCK\n"
+                    "    xindex = xoffset + tl.arange(0, XBLOCK)\n"
+                    "    xmask = xindex < numel\n"
+                    "    a = tl.load(A + xindex, mask=xmask)\n"
+                    + prologue_load_b
+                    + "    _kernel_val_0 = a + b\n"
+                    "    x_epilogue0_0 = xindex\n"
+                    "    _tile_mask_0 = xmask\n"
+                    "    <STORE_OUTPUT_0>\n"
+                    "\n"
+                    f"def {kn}(A, B, {out_param}"
+                    f"{extra_sig}, numel):\n"
+                    f"    grid = ((numel + {XBLOCK} - 1) // {XBLOCK},)\n"
+                    f"    _mock_inner_add[grid]("
+                    f"A, B, {out_param}"
+                    f"{extra_sig}, numel, XBLOCK={XBLOCK})\n"
+                    f"    return {out_param}\n"
+                )
+
+                # Store call state on kernel
+                kernel._call_preamble = []
+                kernel._call_args = call_args
+
+                return PartialRender(source, kernel.render_hooks)
+
+        def add_override(a, b, alpha=None):
+            layout = FixedLayout(a.get_device(), a.get_dtype(), a.get_size())
+            a = ir.ExternKernel.require_stride1(ir.ExternKernel.realize_input(a))
+            b = ir.ExternKernel.require_stride1(ir.ExternKernel.realize_input(b))
+            return ir.TensorBox.create(_MockExternalTemplateBuffer(layout, [a, b]))
+
+        with patch_lowering(
+            {
+                torch.ops.aten.add.Tensor: (
+                    add_override,
+                    True,
+                    ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT,
+                    False,
+                )
+            }
+        ):
+
+            @torch.compile
+            def f(a, b, bias):
+                # Use * for bias so it doesn't trigger add_override again
+                return torch.relu(a + torch.sigmoid(b)) * bias
+
+            a = torch.randn(32, device=GPU_TYPE)
+            b = torch.randn(32, device=GPU_TYPE)
+            bias = torch.randn(32, device=GPU_TYPE)
+
+            result, (code,) = run_and_get_code(f, a, b, bias)
+            expected = torch.relu(a + torch.sigmoid(b)) * bias
+            torch.testing.assert_close(result, expected)
+
+            # Verify render() was called (new protocol)
+            self.assertTrue(render_called[0])
+            # Verify template kernel was used
+            self.assertIn("_mock_inner_add", code)
+            # Verify epilogue fusion: relu fused via hook
+            self.assertIn("triton_helpers.maximum", code)
+            # Verify prologue fusion: sigmoid fused via hook
+            self.assertIn("tl.sigmoid", code)
 
 
 if __name__ == "__main__":

--- a/torch/_inductor/choices.py
+++ b/torch/_inductor/choices.py
@@ -529,8 +529,19 @@ class InductorChoices:
             - config.triton.tiling_prevents_reduction_fusion
             - config.aggressive_fusion (will cause this function to be called more times)
         """
-        if shared_data_score == 0 and (
-            not config.aggressive_fusion or node1.is_reduction() or node2.is_reduction()
+        # When node1 or node2 is a template, skip this heuristic: prologue
+        # fusion (pointwise → template) and epilogue fusion (template →
+        # pointwise) both have shared_data_score==0 by design and are gated
+        # separately by check_prologue_fusion_heuristics_fusable / can_fuse.
+        if (
+            shared_data_score == 0
+            and not node1.is_template()
+            and not node2.is_template()
+            and (
+                not config.aggressive_fusion
+                or node1.is_reduction()
+                or node2.is_reduction()
+            )
         ):
             if is_metric_table_enabled("fusion_failure_due_to_indexing_mismatch"):
                 common_buf_names: OrderedSet[str] = (

--- a/torch/_inductor/codegen/cutedsl/cutedsl_kernel.py
+++ b/torch/_inductor/codegen/cutedsl/cutedsl_kernel.py
@@ -344,8 +344,7 @@ class CuteDSLTemplateKernel(Kernel):
                 # pyrefly: ignore [bad-argument-type]
                 unpacking_lines.append(f"{buffer_name} = {buffer_list_name}[{i}]")
 
-            indent = " " * indent_width
-            return "\n" + indent + ("\n" + indent).join(unpacking_lines)
+            return "\n".join(unpacking_lines)
 
         # Register the hook and return placeholder
         placeholder = "<UNPACK_BUFFERS>"

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -463,7 +463,7 @@ class SIMDKernel(Kernel[CSEVariableType], Generic[CSEVariableType]):
         self.rsplit_size = 0
         self.saved_partial_accumulate: list[PartialAccumulate] = []
 
-    def codegen_template_override(
+    def codegen_template_body(
         self,
         scheduling,
         template_node,
@@ -472,14 +472,26 @@ class SIMDKernel(Kernel[CSEVariableType], Generic[CSEVariableType]):
         buf_name_to_prologue_group,
         prologue_preserves_zero_mask_fn,
         render,
-        only_gen_src_code: bool,
-    ) -> str | None:
-        """Override template codegen. Return None to use default flow.
+    ) -> str:
+        """Generate template source code with fused prologues and epilogues.
 
-        External template handlers (e.g. Helion) can override this method
-        to implement custom code generation.
+        Subclasses override this to implement custom code generation.
+        The default implementation raises NotImplementedError — the actual
+        standard path lives in ``TritonTemplateKernel.codegen_template_body``.
         """
-        return None
+        raise NotImplementedError
+
+    def get_unfused_epilogues(self) -> list[Any]:
+        """Return epilogue nodes that were not fused into the kernel.
+
+        These nodes need separate codegen (via ``call_kernel``) and must
+        be excluded from ``mark_run`` in ``_codegen_single_template``.
+
+        The standard path fuses all epilogues, so this returns ``[]``.
+        ``ExternalTritonTemplateKernel`` overrides this for epilogues that
+        don't read exactly one template output and cannot be fused.
+        """
+        return []
 
     def _get_store_output_subgraph_name(self, i: int) -> str:
         return f"<STORE_OUTPUT_{i}>"
@@ -2069,8 +2081,15 @@ class SIMDScheduling(BaseScheduling):
         # all prologue groups should have finalized with use in template
         assert len(prologue_group) == 0
 
-        # External template handlers (e.g. Helion) can override codegen
-        result = kernel.codegen_template_override(
+        # Remove prologue-fused inputs from input_buffers so that
+        # remove_kernel_local_buffers can remove them.
+        for buf_name in kernel.prologue_fused_inputs:
+            kernel.args.input_buffers.pop(buf_name, None)
+
+        # Dispatch to the kernel for source generation.  TritonTemplateKernel
+        # handles the standard Triton path; ExternalTritonTemplateKernel
+        # handles external backends (e.g. Helion).
+        src_code = kernel.codegen_template_body(
             self,
             template_node,
             epilogue_nodes,
@@ -2078,110 +2097,35 @@ class SIMDScheduling(BaseScheduling):
             buf_name_to_prologue_group,
             prologue_preserves_zero_mask,
             render,
-            only_gen_src_code,
         )
-        if result is not None:
-            return result
 
-        with kernel:
-            if not only_gen_src_code:
-                # prologue nodes can only be fused if their only use is in the template,
-                # so they are necessarily not allocated
-                for node in [template_node, *epilogue_nodes]:
-                    node.mark_run()
+        if config.benchmark_kernel:
+            num_gb = kernel.estimate_kernel_num_bytes() / 1e9
+            src_code = (
+                f"{kernel.imports_for_benchmark_kernel()}\n"
+                f"{src_code}\n"
+                f"{kernel.codegen_kernel_benchmark(num_gb).getvalue()}"
+            )
 
-            partial_code = render()
+        node_schedule = [*prologue_nodes, template_node, *epilogue_nodes]
 
-            num_store_subgraphs = kernel.get_store_output_count()
-            for i in range(num_store_subgraphs):
-                subgraph_name = kernel._get_store_output_subgraph_name(i)
-                with kernel.set_subgraph_body(subgraph_name):
-                    for node in epilogue_nodes:
-                        node.codegen(kernel.split_and_set_ranges(node.get_ranges()))
-                    kernel.cse.invalidate(OrderedSet())
+        if only_gen_src_code:
+            return src_code
 
-            for input_name, buffer in kernel.named_input_nodes.items():
-                subgraph_name = f"<LOAD_INPUT_{input_name}>"
-                if prologue_group := buf_name_to_prologue_group.get(
-                    buffer.get_name(), []
-                ):
-                    can_codegen_without_upcast = all(
-                        p_n.can_codegen_without_upcasts() for p_n in prologue_group
-                    )
-
-                    # TODO - this doesn't work with libdevice calls, potentially other bugs
-                    # upcasting to fp32 and downcasting gives large slowdown
-                    with config.patch(
-                        "triton.codegen_upcast_to_fp32", not can_codegen_without_upcast
-                    ):
-                        with kernel.set_subgraph_body(subgraph_name):
-                            for prologue_node in prologue_group:
-                                if (
-                                    len(prologue_node.get_buffer_names()) == 1
-                                    and len(prologue_group) == 1
-                                ):
-                                    if prologue_preserves_zero_mask(prologue_node):
-                                        kernel.prologue_fused_inputs_preserve_zero |= (
-                                            prologue_node.get_buffer_names()
-                                        )
-
-                                prologue_node.codegen(
-                                    kernel.split_and_set_ranges(
-                                        prologue_node.get_ranges()
-                                    )
-                                )
-                            kernel.cse.invalidate(OrderedSet())
-
-        # Template hooks must be finalised after kernel.remove_kernel_local_buffers
-        # is called (this is called when the kernel context is exited above), and when
-        # the kernel handler is set (as below). This is because the hooks may add
-        # DeferredLine type lines, which preclude lines involving buffers that have
-        # been removed
-
-        # finalize must be called after adding epilogue above
+        # Unfused epilogues are codegen'd separately in call_kernel;
+        # exclude them from mark_run.
+        unfused_set = OrderedSet([id(n) for n in kernel.get_unfused_epilogues()])
         with V.set_kernel_handler(kernel):
-            if not isinstance(partial_code, str):
-                # This is used to calculate flops in TritonTemplateKernels
-                with ir.IRNode.current_origins(template_node.node.origins):
-                    partial_code.finalize_hook("<DEF_KERNEL>")
-                partial_code.finalize_hook("<ARGDEFS>", strict=False)
+            template_node.mark_run()
+            for node in epilogue_nodes:
+                if id(node) not in unfused_set:
+                    node.mark_run()
+            for node in prologue_nodes:
+                node.mark_run()
 
-            # TODO: Maybe unify CUTLASSTemplateKernel to also use PartialRender for flexible epilogue fusion.
+        kernel.kernel_name = self.define_kernel(src_code, node_schedule, kernel)
 
-            for input_name in kernel.named_input_nodes:
-                subgraph_name = f"<LOAD_INPUT_{input_name}>"
-
-                partial_code.finalize_hook(subgraph_name, strict=False)
-
-            num_store_subgraphs = kernel.get_store_output_count()
-            for i in range(num_store_subgraphs):
-                subgraph_name = kernel._get_store_output_subgraph_name(i)
-
-                partial_code.finalize_hook(subgraph_name)
-
-            if isinstance(partial_code, str):
-                src_code = partial_code
-            else:
-                # Ensure all hooks are finalized before the kernel is defined.
-                # Note: some of these hooks may have been registered by a kernel subclass
-                src_code = partial_code.finalize_remaining()
-
-            node_schedule = [*prologue_nodes, template_node, *epilogue_nodes]
-
-            if config.benchmark_kernel:
-                num_gb = kernel.estimate_kernel_num_bytes() / 1e9
-                src_code = (
-                    f"{kernel.imports_for_benchmark_kernel()}\n"
-                    f"{src_code}\n"
-                    f"{kernel.codegen_kernel_benchmark(num_gb).getvalue()}"
-                )
-
-            if only_gen_src_code:
-                return src_code
-
-            kernel.kernel_name = self.define_kernel(src_code, node_schedule, kernel)
-
-            return kernel
+        return kernel
 
     def _get_multikernel_shapes(
         self, node: MultiTemplateBuffer

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -5204,10 +5204,91 @@ class ComputedBuffer(OperationBuffer):
         return self.data.constant_to_device(device)
 
 
+@dataclasses.dataclass
+class EpilogueSpec:
+    """Describes one kernel output that has an epilogue fused into it.
+
+    Example: a matmul kernel outputs buf3 via param "result", and the
+    epilogue stores to buf5.  If buf3 has no other consumers, the fused
+    kernel can write directly to buf5 (can_remove_output=True) and buf3
+    is elided from allocation.
+    """
+
+    # Name of the kernel parameter that produces this output (e.g. "result").
+    kernel_output_param: str
+    # Inductor buffer name for the kernel's original output (e.g. "buf3").
+    kernel_output_buf: str
+    # Buffer that the epilogue ultimately stores into (e.g. "buf5").
+    # None when there is no store in the epilogue subgraph.
+    store_target: str | None
+    # Kernel parameter name for store_target (e.g. "out_ptr0").
+    # None when store_target is None.
+    store_target_param: str | None
+    # Dtype of kernel_output_buf.  When this is float16/bfloat16, the
+    # fused epilogue may need to upcast to float32 before computation.
+    output_dtype: torch.dtype
+    # True when kernel_output_buf has no consumers outside the epilogue,
+    # meaning the fused kernel can skip writing it entirely and write
+    # directly to store_target instead.
+    can_remove_output: bool
+
+
+@dataclasses.dataclass
+class PrologueSpec:
+    """Describes one kernel input that has a prologue fused into it.
+
+    Example: a matmul kernel reads input param "A" from buf3, but buf3
+    is computed by relu(buf1).  After prologue fusion the kernel reads
+    buf1 directly, so source_buffer="buf1".
+    """
+
+    # Name of the kernel parameter for this input (e.g. "A").
+    input_param: str
+    # Inductor buffer name for the *original* data the prologue reads
+    # from (e.g. "buf1" if the prologue is relu(buf1) → buf3).
+    # Used to resolve the correct call argument for the fused kernel.
+    # None when the source cannot be determined.
+    source_buffer: str | None
+
+
+@dataclasses.dataclass
+class TemplateFusionSpec:
+    """All metadata an external backend needs to produce fused kernel source."""
+
+    epilogue_specs: list[EpilogueSpec]
+    prologue_specs: list[PrologueSpec]
+    # Buffers that the fused kernel reads but that are not among the
+    # template's original inputs or outputs.  These arise when an epilogue
+    # reads from a buffer other than the kernel output (e.g. a bias add
+    # where the bias tensor is neither A nor B), or when a prologue has
+    # multiple source buffers.
+    # Mapping: Inductor buffer name → kernel parameter name.
+    extra_inputs: dict[str, str]
+
+
+@dataclasses.dataclass
+class TemplateFusionOutput:
+    """Everything Inductor needs to define and call the fused kernel."""
+
+    # Complete kernel source code (may still contain render-hook
+    # placeholders like _STORE_OUTPUT_0 that get resolved later).
+    source: str
+    # Ordered argument names for the kernel call, e.g.
+    # ["buf0", "buf1", "out_ptr0", ...].
+    call_args: list[str]
+    # Lines emitted before the kernel call, e.g.
+    # reinterpret_tensor() calls for ReinterpretView inputs.
+    call_preamble: list[str]
+    # Buffers that the fused kernel no longer needs allocated
+    # (their writes were redirected to store_target).
+    removed_buffers: OrderedSet[str]
+
+
 class TemplateBuffer(OperationBuffer):
     """
-    Represents a Triton (in the future other type) of template operator
-    that we can fuse an epilogue onto.
+    Base class for template operators that support epilogue and prologue fusion.
+    Subclasses: TritonTemplateBuffer (built-in Triton templates),
+    HelionTemplateBuffer (Helion kernels), etc.
     """
 
     def __init__(
@@ -5215,6 +5296,9 @@ class TemplateBuffer(OperationBuffer):
         layout: OutputSpec,
         inputs: Sequence[IRNode],
         make_kernel_render: Callable[..., Any] | None,
+        mutated_inputs: Iterable[IRNode] | None = None,
+        allowed_prologue_inps: OrderedSet[str] | None = None,
+        named_inputs: dict[str, IRNode] | None = None,
     ) -> None:
         super().__init__(name=None, layout=layout)
         self.inputs = InputsKernel.unwrap_storage(inputs)
@@ -5224,10 +5308,83 @@ class TemplateBuffer(OperationBuffer):
         # Annotations dict for storing metadata (e.g., KernelTemplateChoice)
         self.annotations: dict[str, Any] = {}
 
+        # Output buffer names eligible for epilogue fusion.
+        # Maps buffer name → kernel parameter name (e.g. "buf3" → "result").
+        self.epilogue_fusable_outputs: dict[str, str] = {}
+        # All output buffers: [self] plus any MutationOutput entries.
+        self.outputs: list[Buffer] = [self]
+        # For multi-output kernels: maps child buffer name → MultiOutput
+        # node.  Used by call_kernel to emit tuple-unpacking lines.
+        self._multi_output_children: dict[str, MultiOutput] = {}
+        # Maps kernel parameter name → IRNode for each tensor input.
+        # Used by ExternalTritonTemplateKernel to set up prologue fusion and
+        # by HelionTemplateBuffer to resolve call arguments.
+        self._named_inputs: dict[str, IRNode] = (
+            dict(named_inputs) if named_inputs else {}
+        )
+
+        # Inputs that the kernel mutates in-place.
+        self.mutated_inputs = mutated_inputs
+        if mutated_inputs is not None:
+            first_input = self.inputs[0]
+            assert isinstance(first_input, IRNode), type(first_input)
+            device = first_input.get_device()
+            self.outputs += [
+                MutationOutput(NoneLayout(device=device), buf, self)
+                for buf in mutated_inputs
+            ]
+        # Input buffer names eligible for prologue fusion (pointwise
+        # ops that feed into this template can be absorbed).
+        self.allowed_prologue_inps: OrderedSet[str] = (
+            allowed_prologue_inps or OrderedSet()
+        )
+
     def get_read_writes(self) -> dependencies.ReadWrites:
         return self.extract_read_writes(normalize=True)
 
+    def _read_deps_from_inputs(self, normalize: bool) -> OrderedSet[dependencies.Dep]:
+        """Build read dependencies from all inputs."""
+        reads: OrderedSet[dependencies.Dep] = OrderedSet()
+        for inp_raw in self.inputs:
+            assert isinstance(inp_raw, (ReinterpretView, Buffer)), type(inp_raw)
+            inp: ReinterpretView | Buffer = inp_raw
+            assert isinstance(inp.layout, Layout), type(inp.layout)
+            inp_indexer = inp.layout.make_indexer()
+
+            def dummy(index: Sequence[Any], rindex: Sequence[Any]) -> Any:
+                assert len(rindex) == 0
+                return ops.load(inp.get_name(), inp_indexer(index))
+
+            reads |= dependencies.extract_read_writes(
+                dummy, inp.get_size(), (), normalize=normalize
+            ).reads
+        return reads
+
     def extract_read_writes(self, normalize: bool = False) -> dependencies.ReadWrites:
+        """Extract read/write dependencies for this TemplateBuffer.
+
+        When the layout is MultiOutputLayout (multi-output templates), the
+        buffer itself has no data layout, so we cannot build an indexer.
+        Instead, synthesize a trivial write dep and derive read deps from
+        the named tensor inputs (``_named_inputs``).  For single-output
+        templates with a concrete layout, fall through to the standard path.
+        """
+        if isinstance(self.layout, MultiOutputLayout):
+            writes: OrderedSet[dependencies.Dep] = OrderedSet(
+                [
+                    dependencies.MemoryDep(
+                        self.get_name(), sympy.Integer(0), var_names=(), size=()
+                    ),
+                ]
+            )
+            return dependencies.ReadWrites(
+                reads=self._read_deps_from_inputs(normalize),
+                writes=writes,
+                index_exprs=OrderedSet(),
+                range_vars=None,
+                var_ranges=None,
+            )
+
         name = self.get_name()
         indexer = self.get_layout().make_indexer()
 
@@ -5238,22 +5395,7 @@ class TemplateBuffer(OperationBuffer):
         deps = dependencies.extract_read_writes(
             dummy, self.get_size(), (), normalize=normalize
         )
-
-        for inp in self.inputs:
-            assert isinstance(inp, (ReinterpretView, Buffer)), type(inp)
-            assert isinstance(inp.layout, Layout), type(inp.layout)
-
-            indexer = inp.layout.make_indexer()
-
-            def dummy(index: Sequence[Any], rindex: Sequence[Any]) -> Any:
-                assert len(rindex) == 0
-                # pyrefly: ignore [missing-attribute]
-                return ops.load(inp.get_name(), indexer(index))
-
-            deps.reads |= dependencies.extract_read_writes(
-                dummy, inp.get_size(), (), normalize=normalize
-            ).reads
-
+        deps.reads |= self._read_deps_from_inputs(normalize)
         return deps
 
     def get_reduction_size(self) -> Sequence[Expr]:
@@ -5282,14 +5424,77 @@ class TemplateBuffer(OperationBuffer):
         """Whether this template produces multiple outputs via MultiOutputLayout."""
         return isinstance(self.layout, MultiOutputLayout)
 
-    def can_fuse_multi_output_epilogue(self, snode: object) -> bool:
-        """Whether scheduler node can be fused as an epilogue of this multi-output template.
+    def get_allowed_prologue_inps(self) -> OrderedSet[str]:
+        return self.allowed_prologue_inps
 
-        Returns ``False`` by default.  Subclasses may override to support
-        additional fusion patterns (e.g. epilogue fusion with multi-output
-        extraction and pointwise operations).
+    def get_outputs(self) -> list[Buffer]:
+        return self.outputs
+
+    def fuse(self, spec: TemplateFusionSpec) -> TemplateFusionOutput:
+        """Entry point for external template fusion.
+
+        Called by ``ExternalTritonTemplateKernel.codegen_template_body``
+        with captured prologue/epilogue code snippets.  Override in
+        subclasses to splice them into the backend's kernel source.
+        Returns everything Inductor needs to emit the fused kernel.
         """
-        return False
+        raise NotImplementedError
+
+    @classmethod
+    def realize_template_input(cls, tb: TensorBox) -> IRNode:
+        """Realize a TensorBox, preserving MultiOutput layout (unlike ExternKernel.realize_input)."""
+        if isinstance(tb, TensorBox) and isinstance(tb.data, MultiOutput):
+            return tb.data
+        result = ExternKernel.realize_input(tb)
+        if isinstance(result, StorageBox):
+            result = result.data
+        if isinstance(result.layout, FlexibleLayout):  # type: ignore[union-attr]
+            result.freeze_layout()
+        return result
+
+    @classmethod
+    def build_multi_outputs(
+        cls,
+        template_buf: TemplateBuffer,
+        structured: object,
+        *,
+        direct_alias_at_leaf: dict[int, IRNode] | None = None,
+        on_tensor_leaf: Callable[[str, MultiOutput, list[tuple[type, int]], int], None]
+        | None = None,
+        on_non_tensor_leaf: Callable[[int], None] | None = None,
+    ) -> tuple[TensorBox, ...]:
+        """Walk a structured output tree, creating MultiOutput nodes for tensor leaves."""
+        seen_outputs: dict[int, TensorBox] = {}
+        leaf_counter = itertools.count()
+
+        def walk(output: object, indices: list[tuple[type, int]]) -> list[TensorBox]:
+            if isinstance(output, (list, tuple)):
+                results: list[TensorBox] = []
+                for i, item in enumerate(output):
+                    results.extend(walk(item, [*indices, (type(output), i)]))
+                return results
+            leaf_idx = next(leaf_counter)
+            if isinstance(output, torch.Tensor):
+                if direct_alias_at_leaf and leaf_idx in direct_alias_at_leaf:
+                    return [TensorBox.create(direct_alias_at_leaf[leaf_idx])]
+                tid = id(output)
+                if tid in seen_outputs:
+                    return [seen_outputs[tid]]
+                mo = MultiOutput(
+                    FallbackKernel.tensor_to_layout(output), template_buf, indices
+                )
+                template_buf._multi_output_children[mo.get_name()] = mo
+                if on_tensor_leaf is not None:
+                    on_tensor_leaf(mo.get_name(), mo, indices, leaf_idx)
+                tb = TensorBox(mo)
+                seen_outputs[tid] = tb
+                return [tb]
+            # Non-tensor leaf (int, SymInt, None, etc.)
+            if on_non_tensor_leaf is not None:
+                on_non_tensor_leaf(leaf_idx)
+            return []
+
+        return tuple(walk(structured, []))
 
 
 class TritonTemplateBuffer(TemplateBuffer):
@@ -5310,21 +5515,17 @@ class TritonTemplateBuffer(TemplateBuffer):
         We work around this by creating an extra input buffer during the lowering
         and we mark them as mutated inputs.
         """
-        super().__init__(layout, inputs, make_kernel_render)
-        self.mutated_inputs = mutated_inputs
-        self.outputs: list[Buffer] = [self]
-        if mutated_inputs is not None:
-            assert isinstance(self.inputs[0], IRNode), type(self.inputs[0])
-            device = self.inputs[0].get_device()
-            self.outputs += [
-                MutationOutput(NoneLayout(device=device), buf, self)
-                for buf in mutated_inputs
-            ]
-
-        self.allowed_prologue_inps = (
-            allowed_prologue_inps if allowed_prologue_inps else OrderedSet()
+        super().__init__(
+            layout,
+            inputs,
+            make_kernel_render,
+            mutated_inputs=mutated_inputs,
+            allowed_prologue_inps=allowed_prologue_inps,
         )
+        assert self.name is not None
+        self.epilogue_fusable_outputs = {self.name: self.name}
 
+        # Triton-specific subgraph state.
         self.subgraph_inps: list[IRNode | sympy.Expr | None] | None = None
         self.subgraph_outs: list[IRNode | None] | None = None
 
@@ -5351,12 +5552,6 @@ class TritonTemplateBuffer(TemplateBuffer):
                 assert out is None
 
         return res
-
-    def get_outputs(self) -> list[Buffer]:
-        return self.outputs
-
-    def get_allowed_prologue_inps(self) -> OrderedSet[str]:
-        return self.allowed_prologue_inps
 
     def __str__(self) -> str:
         out = f"TritonTemplateBuffer(layout={self.layout})"
@@ -5576,12 +5771,18 @@ class CppTemplateBuffer(TemplateBuffer):
         super().__init__(layout, inputs, make_kernel_render)
         self.template = template
         self.choice = choice
-        self.outputs: list[Buffer] | None = None
+
+    def get_outputs(self) -> list[Buffer]:
+        # The grouped GEMM lowering sets self.outputs to MultiOutput
+        # children (used by the template rendering code).  But for the
+        # scheduler, we must return [self] so that the parent buffer name
+        # is registered in name_to_buf — MultiOutput children depend on
+        # it via StarDep.
+        return [self]
 
     def get_layout(self) -> Layout:
         if isinstance(self.layout, MultiOutputLayout):
             assert isinstance(self.outputs, Iterable), type(self.outputs)
-
             first_output = self.outputs[0]
             assert isinstance(first_output, Buffer), type(first_output)
             layout = first_output.layout

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -1920,19 +1920,28 @@ class FusedSchedulerNode(BaseSchedulerNode):
             # of the template node and its epilogue requires the same type of dependencies
             assert isinstance(node2.node, MultiOutput)
             assert len(node2.read_writes.writes) == 1
-            assert isinstance(next(iter(node2.read_writes.writes)), StarDep)
-            name = next(iter(node2.read_writes.writes)).name
-            template_nodes = [node for node in node1.get_nodes() if node.is_template()]
-            assert len(template_nodes) == 1
-            template_node = template_nodes[0]
-            assert len(template_node.read_writes.writes) == 1
-            write = next(iter(template_node.read_writes.writes))
-            assert isinstance(write, MemoryDep)
+            star_dep = next(iter(node2.read_writes.writes))
+            assert isinstance(star_dep, StarDep)
+            name = star_dep.name
+            # MultiOutput nodes (ExternKernel subclass) produce a StarDep
+            # write, but score_fusion_memory() requires a MemoryDep with real
+            # index expressions to compute a positive score.  Build one from
+            # the MultiOutput child's FixedLayout so that can_fuse_vertical()
+            # can decide to fuse a downstream epilogue.
+            from torch._inductor.dependencies import index_vars_squeeze
+
+            mo_size = node2.node.get_size()
+            (mo_vars,), var_ranges = index_vars_squeeze(mo_size, prefix="d")
+            mo_index = node2.node.get_layout().make_indexer()(mo_vars)
             node2.read_writes.writes = OrderedSet(
                 [
                     MemoryDep(
-                        name, write.index, write.var_names, write.size, write.mode
-                    ),
+                        name,
+                        mo_index,
+                        tuple(var_ranges.keys()),
+                        tuple(var_ranges.values()),
+                        None,
+                    )
                 ]
             )
         else:
@@ -5803,11 +5812,10 @@ class Scheduler:
                 return False
 
             template = node2.get_template_node_or_throw()
-            if not isinstance(template, ir.TritonTemplateBuffer):
-                why("prologue fusion only supported for TritonTemplates")
-                return False
-
             allowed_prologue_inps = template.get_allowed_prologue_inps()
+            if not allowed_prologue_inps:
+                why("template has no allowed prologue inputs")
+                return False
 
             unsupported_prologue_args = (
                 OrderedSet(inp.get_name() for inp in template.inputs)  # type: ignore[union-attr]
@@ -5851,13 +5859,21 @@ class Scheduler:
             if not self.check_prologue_fusion_heuristics_fusable(node1, node2, why):
                 return False
 
-        if node1.is_template() and (
-            node2.has_aliasing_or_mutation()
-            or node2.is_reduction()
-            or not config.epilogue_fusion
-        ):
-            why("template epilogue not satisfied")
-            return False
+        if node1.is_template():
+            if (
+                node2.has_aliasing_or_mutation()
+                or node2.is_reduction()
+                or not config.epilogue_fusion
+            ):
+                why("template epilogue not satisfied")
+                return False
+            template_buf = node1.get_template_node()
+            assert template_buf is not None
+            if template_buf.is_multi_outputs_template() and not isinstance(
+                node2.node, ir.ComputedBuffer
+            ):
+                why("multi-output template epilogue requires ComputedBuffer")
+                return False
 
         if (node1.get_buffer_names() & V.graph.no_fuse_buffer_names) or (
             node2.get_buffer_names() & V.graph.no_fuse_buffer_names
@@ -7419,16 +7435,20 @@ class BaseScheduling:  # noqa: docstring_linter
         and node2 corresponds to one of its outputs. If so, we further check if
         backend supports this fusion.
 
-        Delegates to ``TemplateBuffer.can_fuse_multi_output_epilogue`` which
-        TemplateBuffer subclasses may override to allow fusion of additional node types.
         """
         template_buf = node1.get_template_node()
         if not isinstance(template_buf, ir.TemplateBuffer):
             return False
         if not template_buf.is_multi_outputs_template():
             return False
-        if template_buf.can_fuse_multi_output_epilogue(node2):
-            return True
+
+        if isinstance(node2.node, ir.MultiOutput):
+            return (
+                len(node2.node.inputs) == 1
+                and isinstance(node2.node.inputs[0], ir.IRNode)
+                and node2.node.inputs[0].get_name() == template_buf.get_name()
+            )
+
         return False
 
     def fuse(

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -58,6 +58,7 @@ from .codegen.common import (
     IndentedBuffer,
     KernelTemplate,
     OpOverrides,
+    RemovedArg,
     WorkspaceArg,
     WorkspaceZeroMode,
 )
@@ -74,7 +75,13 @@ from .codegen.triton_utils import config_of, equal_1_arg_indices, signature_to_m
 from .codegen.wrapper import pexpr
 from .exc import CUDACompileError
 from .fx_utils import count_flops_fx
-from .ir import ChoiceCaller, PrimitiveInfoType
+from .ir import (
+    ChoiceCaller,
+    EpilogueSpec,
+    PrimitiveInfoType,
+    PrologueSpec,
+    TemplateFusionSpec,
+)
 from .ops_handler import StoreMode
 from .runtime.hints import DeviceProperties
 from .runtime.triton_compat import HAS_WARP_SPEC
@@ -208,6 +215,36 @@ class PartialRender:
         )
         return self._code
 
+    def _replace_placeholder(self, hook_key: str, result: str) -> str:
+        """Replace a placeholder in the code with the hook result.
+
+        If the placeholder sits alone on its line:
+        - empty result: remove the entire line
+        - non-empty result: dedent + re-indent to match the placeholder's column
+
+        If the placeholder is inline: substitute the result as-is.
+        """
+        idx = self._code.find(hook_key)
+        if idx < 0:
+            return self._code.replace(hook_key, result)
+
+        line_start = self._code.rfind("\n", 0, idx) + 1
+        line_end = self._code.find("\n", idx)
+        if line_end == -1:
+            line_end = len(self._code)
+
+        if self._code[line_start:line_end].strip() != hook_key:
+            return self._code.replace(hook_key, result)
+
+        # Whole-line placeholder
+        if not (result and result.strip()):
+            return self._code[:line_start] + self._code[line_end + 1 :]
+
+        indent_str = self._code[line_start:idx]
+        dedented = textwrap.dedent(result.rstrip("\n"))
+        indented = textwrap.indent(dedented, indent_str).strip()
+        return self._code.replace(hook_key, indented)
+
     def finalize_hook(self, hook_key: str, strict: bool = True) -> None:
         """
         Finalize a hook by name.
@@ -226,8 +263,7 @@ class PartialRender:
 
         hook = self.replacement_hooks[hook_key]
         assert hook is not None, f"Hook key {hook_key} can only be called once"
-        self._code = self._code.replace(hook_key, hook())
-
+        self._code = self._replace_placeholder(hook_key, hook())
         self.replacement_hooks[hook_key] = None
 
     def finalize_remaining(self) -> str:
@@ -1122,7 +1158,7 @@ class TritonTemplateKernel(TritonKernel):
                     assert load_code is not None
                     self.body.writeline(load_code)
 
-                return textwrap.indent(self.body.getvalue(), " " * indent_width).strip()
+                return self.body.getvalue().strip()
 
         return self._register_hook(hook_key, hook)
 
@@ -1395,7 +1431,7 @@ class TritonTemplateKernel(TritonKernel):
                 self.codegen_body()
                 self.cse.invalidate(OrderedSet())
 
-                return textwrap.indent(self.body.getvalue(), " " * indent_width).strip()
+                return self.body.getvalue().strip()
 
         return self._register_hook(subgraph_name, hook)
 
@@ -1610,6 +1646,560 @@ class TritonTemplateKernel(TritonKernel):
                 return list(fixed_layout_copy.stride)
         # Already frozen or not a FlexibleLayout, just return current strides
         return node.get_stride()
+
+    def codegen_template_body(
+        self,
+        scheduling,
+        template_node,
+        epilogue_nodes,
+        prologue_nodes,
+        buf_name_to_prologue_group,
+        prologue_preserves_zero_mask_fn,
+        render,
+    ) -> str:
+        """Generate template source code with fused prologues and epilogues.
+
+        This is the standard path for built-in Triton templates.  External
+        backends (e.g. Helion) override this in ExternalTritonTemplateKernel.
+
+        Returns the final source code string.
+        """
+        with self:
+            partial_code = render()
+
+            num_store_subgraphs = self.get_store_output_count()
+            for i in range(num_store_subgraphs):
+                subgraph_name = self._get_store_output_subgraph_name(i)
+                with self.set_subgraph_body(subgraph_name):
+                    for node in epilogue_nodes:
+                        node.codegen(self.split_and_set_ranges(node.get_ranges()))
+                    self.cse.invalidate(OrderedSet())
+
+            self.codegen_prologues_in_subgraphs(
+                buf_name_to_prologue_group, prologue_preserves_zero_mask_fn
+            )
+
+        # Template hooks must be finalised after kernel.remove_kernel_local_buffers
+        # is called (this is called when the kernel context is exited above), and when
+        # the kernel handler is set (as below). This is because the hooks may add
+        # DeferredLine type lines, which preclude lines involving buffers that have
+        # been removed
+
+        # finalize must be called after adding epilogue above
+        with V.set_kernel_handler(self):
+            if not isinstance(partial_code, str):
+                # This is used to calculate flops in TritonTemplateKernels
+                with ir.IRNode.current_origins(template_node.node.origins):
+                    partial_code.finalize_hook("<DEF_KERNEL>")
+                partial_code.finalize_hook("<ARGDEFS>", strict=False)
+
+            # TODO: Maybe unify CUTLASSTemplateKernel to also use PartialRender for flexible epilogue fusion.
+
+            for input_name in self.named_input_nodes:
+                subgraph_name = f"<LOAD_INPUT_{input_name}>"
+
+                partial_code.finalize_hook(subgraph_name, strict=False)
+
+            num_store_subgraphs = self.get_store_output_count()
+            for i in range(num_store_subgraphs):
+                subgraph_name = self._get_store_output_subgraph_name(i)
+
+                partial_code.finalize_hook(subgraph_name)
+
+            if isinstance(partial_code, str):
+                src_code = partial_code
+            else:
+                # Ensure all hooks are finalized before the kernel is defined.
+                # Note: some of these hooks may have been registered by a kernel subclass
+                src_code = partial_code.finalize_remaining()
+
+        return src_code
+
+    def codegen_prologues_in_subgraphs(
+        self, buf_name_to_prologue_group, prologue_preserves_zero_mask_fn
+    ):
+        """Run prologue codegen in each load-input subgraph body."""
+        for input_name, buffer in self.named_input_nodes.items():
+            subgraph_name = f"<LOAD_INPUT_{input_name}>"
+            prologue_group = buf_name_to_prologue_group.get(buffer.get_name(), [])
+            if not prologue_group:
+                continue
+            can_codegen_without_upcast = all(
+                p_n.can_codegen_without_upcasts() for p_n in prologue_group
+            )
+            with config.patch(
+                "triton.codegen_upcast_to_fp32", not can_codegen_without_upcast
+            ):
+                with self.set_subgraph_body(subgraph_name):
+                    for prologue_node in prologue_group:
+                        if (
+                            len(prologue_node.get_buffer_names()) == 1
+                            and len(prologue_group) == 1
+                        ):
+                            if prologue_preserves_zero_mask_fn(prologue_node):
+                                self.prologue_fused_inputs_preserve_zero |= (
+                                    prologue_node.get_buffer_names()
+                                )
+                        prologue_node.codegen(
+                            self.split_and_set_ranges(prologue_node.get_ranges())
+                        )
+                    self.cse.invalidate(OrderedSet())
+
+
+class ExternalTritonTemplateKernel(TritonTemplateKernel):
+    """TritonTemplateKernel variant for external template backends (e.g. Helion).
+
+    Orchestrates prologue/epilogue fusion by running Inductor's codegen ops
+    (store, load, indexing) on fused scheduler nodes, capturing the generated
+    code into subgraph buffers, building a ``TemplateFusionSpec``, and passing
+    it to the backend's ``TemplateBuffer.fuse()`` method.
+
+    Also implements ``call_kernel`` and ``emit_kernel_override`` for
+    post-codegen emission of the fused kernel.
+
+    Subclasses TritonTemplateKernel for subgraph body management and
+    template indexing support.
+    """
+
+    def __init__(self, template_buffer: "ir.TemplateBuffer") -> None:
+        class _RealOutputNode:
+            def get_size(self) -> list:
+                return list(template_buffer.get_size())
+
+            def get_layout(self):
+                return template_buffer.get_layout()
+
+            def get_name(self) -> str:
+                return template_buffer.get_name()
+
+        # Pass dummy values for TritonTemplateKernel params that are only
+        # relevant for standalone Triton kernel codegen (grid, warps, etc.).
+        super().__init__(
+            kernel_name="",
+            input_nodes=(),
+            output_node=_RealOutputNode(),
+            defines={},
+            num_stages=0,
+            num_warps=1,
+            grid_fn=None,
+            meta={},
+            call_sizes=[],
+            hint_override=None,
+        )
+        self._template_buffer = template_buffer
+        # Extra inputs needed by fused ops beyond the template's own I/O
+        self._extra_inputs: dict[str, str] = {}
+        # Prologue primary source buffers, populated by load_input
+        self._prologue_source_buffers: dict[str, str | None] = {}
+        # Epilogues that could not be fused into the kernel
+        self._unfused_epilogues: list[Any] = []
+
+    def codegen_range_tree(self):
+        pass
+
+    def get_unfused_epilogues(self) -> list[Any]:
+        return self._unfused_epilogues
+
+    def _find_eligible_epilogues(self, epilogue_nodes, output_param_mapping):
+        """Compute fusion eligibility and register extra inputs.
+
+        Returns list of eligible epilogue tuples:
+            [(snode, output_buf, output_param, store_target), ...]
+        """
+        from torch._inductor.dependencies import MemoryDep
+
+        # Filter eligible epilogues
+        epilogues = []
+        for epilogue_node in epilogue_nodes:
+            if isinstance(epilogue_node.node, ir.MultiOutput):
+                continue
+            dep_names = OrderedSet(
+                d.name
+                for d in epilogue_node.read_writes.reads
+                if isinstance(d, MemoryDep) and d.name in output_param_mapping
+            )
+            if len(dep_names) != 1:
+                continue
+            output_buf = next(iter(dep_names))
+            epilogue_writes = epilogue_node.read_writes.writes
+            raw_st = next(iter(epilogue_writes)).name if epilogue_writes else None
+            epilogues.append(
+                (
+                    epilogue_node,
+                    output_buf,
+                    output_param_mapping[output_buf],
+                    raw_st if raw_st != output_buf else None,
+                )
+            )
+
+        # Register extra inputs needed by fused epilogues
+        for snode, _, _, _ in epilogues:
+            for dep in snode.read_writes.reads:
+                if isinstance(dep, MemoryDep) and dep.name not in output_param_mapping:
+                    if dep.name not in self._extra_inputs:
+                        param = f"_extra_input_{len(self._extra_inputs)}"
+                        self._extra_inputs[dep.name] = param
+                        self.args.input_buffers[dep.name] = param
+
+        return epilogues
+
+    def _make_independent_subgraph(self, subgraph_name, numel, **extra_fields):
+        groups = {"x": V.graph.sizevars.simplify(numel), "r0_": sympy.S.One}
+        self.subgraph_bodies[subgraph_name] = SubgraphInfo(
+            body=IndentedBuffer(),
+            cse=self.cse.clone(),
+            range_trees=self.construct_range_trees(
+                pid_cache=None,
+                inside_reduction=False,
+                is_reduction=False,
+                numels=groups,
+                no_x_dim=False,
+            ),
+            range_tree_nodes={},
+            numels=groups,
+            **extra_fields,
+        )
+
+    def _setup_epilogue_hook(self, output_buf=None, output_param=None):
+        store_idx = next(self.store_output_ctr)
+        subgraph_name = self._get_store_output_subgraph_name(store_idx)
+        if output_buf is None:
+            self.subgraph_bodies[subgraph_name] = SubgraphInfo(body=IndentedBuffer())
+            return
+
+        n_dims = len(self._template_buffer.get_size())
+        indices = [f"x_epilogue{store_idx}_{d}" for d in range(n_dims)]
+        val = f"_kernel_val_{store_idx}"
+        mask = f"_tile_mask_{store_idx}"
+
+        buf = output_buf
+        node = V.graph.get_buffer(buf) if buf else None
+        output_size = (
+            list(node.get_size())
+            if node is not None
+            else list(self.output_node.get_size())
+        )
+        self._make_independent_subgraph(subgraph_name, sympy_product(output_size))
+        with self.set_subgraph_body(subgraph_name):
+            indices = list(map(OpOverrides.paren, indices))
+            index_symbols = [sympy.Symbol(x, integer=True) for x in indices]
+            lengths = [V.graph.sizevars.simplify(s) for s in output_size]
+            assert len(indices) == len(lengths)
+            self.template_out = val
+            for name, entry in zip(
+                indices, self.range_trees[0].construct_entries(lengths)
+            ):
+                entry.set_name(name)
+            contiguous_index = self.rename_indexing(
+                sympy_dot(ir.FlexibleLayout.contiguous_strides(lengths), index_symbols)
+            )
+            xindex = f"x_epilogue{store_idx}_index"
+            self.body.writeline(f"{xindex} = " + texpr(contiguous_index))
+            self.range_trees[0].lookup(sympy.S.One, sympy_product(lengths)).set_name(
+                xindex
+            )
+            self.template_mask = mask
+            self.template_indices = indices
+            self.template_out_shape = val
+
+            # Set up CSE state for epilogue codegen
+            block_shape = tuple(
+                f"{rt.prefix.upper()}BLOCK"
+                for rt in self.range_trees
+                if not rt.is_reduction
+            )
+            if not block_shape:
+                block_shape = ("XBLOCK",)
+            self.cse.store_cache[buf] = self.cse.namedvar(
+                val, dtype=torch.float32, shape=block_shape
+            )
+            assert output_param is not None
+            self.args.output_buffers[buf] = output_param
+
+        def hook():
+            with self.set_subgraph_body(subgraph_name):
+                self.codegen_body()
+                self.cse.invalidate(OrderedSet())
+                return self.body.getvalue().strip()
+
+        key = f"_STORE_OUTPUT_{store_idx}"
+        self.render_hooks[key] = hook
+
+    def _setup_prologue_hook(self, input_name, prologue_sources=None):
+        ir_node = self._template_buffer._named_inputs.get(input_name)
+        if ir_node is None:
+            return
+        self.named_input_nodes[input_name] = ir_node
+        input_buf = ir_node.get_name()
+        source_bufs = (
+            prologue_sources.get(input_buf) if prologue_sources is not None else None
+        )
+        if source_bufs is None:
+            return
+        source_buffer = next(iter(source_bufs)) if source_bufs else None
+        self._prologue_source_buffers[input_name] = source_buffer
+        if source_buffer is not None:
+            self.args.input_buffers[source_buffer] = input_name
+        for src in source_bufs:
+            if src != source_buffer:
+                if src not in self._extra_inputs:
+                    self._extra_inputs[src] = f"_extra_input_{len(self._extra_inputs)}"
+                self.args.input_buffers[src] = self._extra_inputs[src]
+
+        subgraph_name = f"<LOAD_INPUT_{input_name}>"
+        result_var = f"_prologue_{input_name}_result"
+
+        class _CaptureStoreHandler(V.WrapperHandler):  # type: ignore[name-defined]
+            def store(self, name, index, value, mode=None):
+                V.kernel.store_buffer_names.add(name)
+                V.kernel.cse.store_cache[name] = value
+                V.kernel.compute.writeline(f"{result_var} = {value}")
+
+        self._make_independent_subgraph(
+            subgraph_name,
+            sympy_product(ir_node.get_size()),
+            ops_handler=_CaptureStoreHandler,
+        )
+
+        def hook(_name=subgraph_name, _input=input_name, _self=self):
+            with _self.set_subgraph_body(_name):
+                _self.codegen_body()
+                _self.cse.invalidate(OrderedSet())
+                body = _self.body.getvalue()
+            # Rename range-tree root variables (xindex/xmask) to avoid collisions
+            # across prologue subgraphs.  tmp/x0 names are already unique (shared
+            # kernel-level counters).
+            body = re.sub(r"\bxindex\b", f"_prologue_{_input}_xindex", body)
+            body = re.sub(r"\bxmask\b", f"_prologue_{_input}_xmask", body)
+            return body.rstrip()
+
+        self.render_hooks[f"_LOAD_INPUT_{input_name}"] = hook
+
+    def codegen_template_body(
+        self,
+        scheduling,
+        template_node,
+        epilogue_nodes,
+        prologue_nodes,
+        buf_name_to_prologue_group,
+        prologue_preserves_zero_mask_fn,
+        render,
+    ) -> str:
+        """Orchestrate prologue/epilogue codegen for external template backends.
+
+        1. Build fusable prologue/epilogue lists from scheduler inputs.
+        2. Set up store/load hooks and run Inductor codegen in subgraphs
+           to generate prologue/epilogue code.
+        3. Build a TemplateFusionSpec and call TemplateBuffer.fuse(spec).
+        4. Finalize hook placeholders in the fused source and store state
+           for call_kernel.
+
+        Returns the fused source code string.  Unfused epilogues
+        (nodes not fused) are stored on ``self._unfused_epilogues``
+        for the caller to read.  Node marking (``mark_run``) is handled
+        by the caller in ``_codegen_single_template``.
+        """
+        from torch._inductor.dependencies import MemoryDep
+
+        tb = self._template_buffer
+
+        # Build fusable prologue from prologue groups:
+        #   [(snode, buf_name, frozenset_of_source_bufs), ...]
+        prologues = [
+            (
+                pro_node,
+                buf_name,
+                frozenset(
+                    d.name
+                    for d in pro_node.read_writes.reads
+                    if isinstance(d, MemoryDep)
+                ),
+            )
+            for buf_name, pro_nodes in buf_name_to_prologue_group.items()
+            for pro_node in pro_nodes
+        ]
+
+        # Compute eligible epilogues and register extra inputs:
+        #   [(snode, output_buf, output_param, store_target), ...]
+        epilogues = self._find_eligible_epilogues(
+            epilogue_nodes,
+            output_param_mapping=tb.epilogue_fusable_outputs,
+        )
+
+        # Epilogues not eligible for fusion are codegen'd separately
+        fused_ids = OrderedSet(id(sn) for sn, _, _, _ in epilogues)
+        self._unfused_epilogues = [
+            n
+            for n in epilogue_nodes
+            if id(n) not in fused_ids and not isinstance(n.node, ir.MultiOutput)
+        ]
+
+        # Build prologue lookup: buf_name -> source_bufs
+        prologue_sources = {
+            buf_name: source_bufs for _, buf_name, source_bufs in prologues
+        }
+
+        with self:
+            for pro_buf, source_bufs in prologue_sources.items():
+                self.store_buffer_names.add(pro_buf)
+                # Source-less prologues (e.g. ones_like) have no readers in
+                # store_buffer_names, so remove_kernel_local_buffers cannot
+                # discover them.  Mark them removed directly.
+                if not source_bufs:
+                    self.removed_buffers.add(pro_buf)
+
+            # Set up epilogue/prologue render hooks
+            for epilogue_idx in range(len(tb.epilogue_fusable_outputs)):
+                epi = epilogues[epilogue_idx] if epilogue_idx < len(epilogues) else None
+                self._setup_epilogue_hook(
+                    output_buf=epi[1] if epi else None,
+                    output_param=epi[2] if epi else None,
+                )
+            for param_name in tb._named_inputs:
+                self._setup_prologue_hook(param_name, prologue_sources=prologue_sources)
+
+            # Epilogue codegen in each store subgraph
+            for i in range(len(tb.epilogue_fusable_outputs)):
+                epilogue_group = [epilogues[i][0]] if i < len(epilogues) else []
+                with self.set_subgraph_body(self._get_store_output_subgraph_name(i)):
+                    self.codegen_body()
+                    for node in epilogue_group:
+                        node.codegen(self.split_and_set_ranges(node.get_ranges()))
+                    self.cse.invalidate(OrderedSet())
+
+            # Prologue codegen in load subgraph bodies
+            self.codegen_prologues_in_subgraphs(
+                buf_name_to_prologue_group, prologue_preserves_zero_mask_fn
+            )
+
+        spec = self._build_fusion_spec(epilogues)
+        output = tb.fuse(spec)
+
+        # Finalize hook placeholders in the fused source
+        partial = PartialRender(output.source, self.render_hooks)
+        with V.set_kernel_handler(self):
+            final_source = partial.finalize_remaining()
+
+        # Store state for call_kernel to use during post-processing
+        self._fusion_output = output
+        self._scheduling_ref = scheduling
+        self.removed_buffers |= output.removed_buffers
+        return final_source
+
+    def call_kernel(self, name, node=None, deallocate_ws=True):
+        """Emit the kernel call, multi-output unpacking, and unfused epilogues."""
+        output = self._fusion_output
+        tb = self._template_buffer
+        wrapper = V.graph.wrapper_code
+        for line in output.call_preamble:
+            wrapper.writeline(line)
+        output_name = tb.get_name()
+        wrapper.writeline(f"{output_name} = {name}({', '.join(output.call_args)})")
+        # Unpack multi-output children from the kernel result
+        for mo_name, mo in sorted(tb._multi_output_children.items()):
+            if mo_name not in output.removed_buffers:
+                idx_str = output_name
+                for _, idx in mo.indices:
+                    idx_str = f"{idx_str}[{idx}]"
+                wrapper.writeline(f"{mo_name} = {idx_str}")
+        # Unfused epilogues are codegen'd separately after the kernel call
+        for epi_node in self._unfused_epilogues:
+            self._scheduling_ref.codegen_node(epi_node)
+
+    def _build_fusion_spec(self, epilogues):
+        """Build a TemplateFusionSpec from the generated prologue/epilogue code."""
+        tb = self._template_buffer
+        scheduler = V.graph.scheduler
+
+        # Compute fused node names for buffer removability
+        fused_node_names = None
+        if scheduler is not None:
+            all_store_names = OrderedSet([tb.get_name()])
+            all_store_names.update(tb._multi_output_children)
+            all_store_names.update(st for _, _, _, st in epilogues if st)
+            fused_node_names = OrderedSet(
+                scheduler.name_to_buf[n].defining_op_name()
+                for n in all_store_names
+                if n in scheduler.name_to_buf
+            )
+
+        epilogue_specs = []
+        for _, output_buf, output_param, store_target in epilogues:
+            can_remove = (
+                store_target is not None
+                and fused_node_names is not None
+                and scheduler.can_buffer_be_removed_through_fusion(
+                    output_buf, fused_node_names
+                )
+            )
+            store_target_param_raw = (
+                self.args.output_buffers.get(store_target)
+                if store_target is not None
+                else None
+            )
+            store_target_param = (
+                None
+                if isinstance(store_target_param_raw, RemovedArg)
+                else store_target_param_raw
+            )
+            epilogue_specs.append(
+                EpilogueSpec(
+                    kernel_output_param=output_param,
+                    kernel_output_buf=output_buf,
+                    store_target=store_target,
+                    store_target_param=store_target_param,
+                    output_dtype=V.graph.get_dtype(output_buf)
+                    if output_buf
+                    else torch.float32,
+                    can_remove_output=can_remove,
+                )
+            )
+
+        prologue_specs = [
+            PrologueSpec(
+                input_param=name,
+                source_buffer=self._prologue_source_buffers.get(name),
+            )
+            for name in self.named_input_nodes
+            if f"_LOAD_INPUT_{name}" in self.render_hooks
+        ]
+
+        return TemplateFusionSpec(
+            epilogue_specs=epilogue_specs,
+            prologue_specs=prologue_specs,
+            extra_inputs=dict(self._extra_inputs),
+        )
+
+    def emit_kernel_override(
+        self,
+        wrapper,
+        src_code,
+        kernel_name,
+        node_schedule,
+        kernel_path,
+        get_kernel_metadata,
+    ):
+        origins, detailed = get_kernel_metadata(node_schedule, wrapper)
+        wrapper.header.writeline(f"# kernel path: {kernel_path}\n{origins}\n{detailed}")
+        for line in src_code.split("\n"):
+            s = line.strip()
+            if not s:
+                continue
+            if s.startswith("from __future__"):
+                continue
+            if s.startswith(("import ", "from ")):
+                wrapper.add_import_once(s)
+                continue
+            wrapper.header.writeline(line)
+        # Hooks may reference standard Inductor runtime modules
+        wrapper.add_import_once(
+            "from torch._inductor.runtime import triton_helpers, triton_heuristics"
+        )
+        wrapper.add_import_once(
+            "from torch._inductor.runtime.triton_helpers import libdevice, math as tl_math"
+        )
+        wrapper.header.writeline("")
+        return True
 
 
 @functools.cache


### PR DESCRIPTION
Add support for external template backends (e.g. Helion) to fuse prologue and epilogue pointwise ops into their kernels via Inductor's existing fusion infrastructure.

```
Template Codegen Lifecycle
==========================

_codegen_single_template (simd.py)
├── Build prologue groups from prologue_nodes
├── Remove prologue-fused inputs from kernel.args.input_buffers
├── kernel.codegen_template_body(...)  →  dispatches by kernel type:
│   │
│   ├── [Standard] TritonTemplateKernel
│   │   ├── with self:
│   │   │   ├── render()  →  PartialRender with hook placeholders
│   │   │   ├── Codegen ALL epilogues into each store subgraph
│   │   │   └── codegen_prologues_in_subgraphs
│   │   └── Finalize hooks (<DEF_KERNEL>, <ARGDEFS>, <LOAD_INPUT_*>, <STORE_OUTPUT_*>)
│   │   └── return src_code
│   │
│   └── [External] ExternalTritonTemplateKernel
│       ├── Build prologue list from prologue groups
│       ├── _find_eligible_epilogues  →  epilogues reading exactly 1 template output
│       ├── Compute _unfused_epilogues  →  everything else (non-MultiOutput)
│       ├── Build prologue_sources dict: buf_name → source_bufs
│       ├── with self:
│       │   ├── _setup_epilogue_hook  →  one per epilogue-fusable output
│       │   ├── _setup_prologue_hook  →  one per named input with a prologue
│       │   ├── Codegen each eligible epilogue into its store subgraph
│       │   └── codegen_prologues_in_subgraphs
│       ├── _build_fusion_spec  →  TemplateFusionSpec
│       ├── tb.fuse(spec)  →  TemplateFusionOutput (backend splices into Triton AST)
│       ├── Finalize hook placeholders (_STORE_OUTPUT_*, _LOAD_INPUT_*)
│       └── return src_code
│
├── kernel.get_unfused_epilogues()
│   ├── [Standard]  →  []
│   └── [External]  →  self._unfused_epilogues
│
├── mark_run on template_node, fused epilogues, prologues
├── define_kernel(src_code)
└── return kernel

call_kernel
├── [Standard] Emit kernel call + workspace deallocation
└── [External] Emit kernel call + multi-output unpacking + codegen_node for each unfused epilogue
```

Helion-side changes are in https://github.com/pytorch/helion/pull/1520.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo