### PR TITLE
[aps]Start the TW health check thrift server before rendezvous

### DIFF
--- a/test/distributed/elastic/agent/server/test/local_elastic_agent_test.py
+++ b/test/distributed/elastic/agent/server/test/local_elastic_agent_test.py
@@ -32,6 +32,7 @@ from torch.distributed.elastic.agent.server.api import (
 )
 from torch.distributed.elastic.agent.server.local_elastic_agent import (
     LocalElasticAgent,
+    TORCHELASTIC_ENABLE_FILE_TIMER,
     TORCHELASTIC_HEALTH_CHECK_PORT,
     TORCHELASTIC_TIMER_FILE,
 )
@@ -1466,6 +1467,238 @@ class LocalElasticAgentTest(unittest.TestCase):
     )
     def test_rank_restart_after_failure(self):
         self.run_test_with_backend(backend="c10d", test_to_run=self.fail_rank_one_once)
+
+    def test_get_alive_time_without_watchdog(self):
+        """Test _get_alive_time returns current time when watchdog is not set."""
+        node_conf = Conf(entrypoint=_happy_function, local_world_size=1)
+
+        # Use a mocked rendezvous handler to avoid blocking on real connections
+        rdzv_handler = Mock()
+        rdzv_handler.get_backend.return_value = "c10d"
+        spec = WorkerSpec(
+            role=node_conf.role,
+            local_world_size=node_conf.local_world_size,
+            entrypoint=node_conf.entrypoint,
+            args=node_conf.args,
+            rdzv_handler=rdzv_handler,
+            max_restarts=0,
+            monitor_interval=0.01,
+        )
+        agent = self.get_agent(spec, node_config=node_conf)
+
+        # Watchdog is None by default at initialization
+        self.assertIsNone(agent._worker_watchdog)
+
+        # _get_alive_time should return current time when watchdog is None
+        before = int(time.time())
+        alive_time = agent._get_alive_time()
+        after = int(time.time())
+
+        self.assertGreaterEqual(alive_time, before)
+        self.assertLessEqual(alive_time, after)
+
+    def test_get_alive_time_with_watchdog(self):
+        """Test _get_alive_time returns watchdog time when watchdog is active."""
+        node_conf = Conf(entrypoint=_happy_function, local_world_size=1)
+
+        # Use a mocked rendezvous handler to avoid blocking on real connections
+        rdzv_handler = Mock()
+        rdzv_handler.get_backend.return_value = "c10d"
+        spec = WorkerSpec(
+            role=node_conf.role,
+            local_world_size=node_conf.local_world_size,
+            entrypoint=node_conf.entrypoint,
+            args=node_conf.args,
+            rdzv_handler=rdzv_handler,
+            max_restarts=0,
+            monitor_interval=0.01,
+        )
+        agent = self.get_agent(spec, node_config=node_conf)
+
+        # Mock the watchdog with a specific return value
+        mock_watchdog = Mock()
+        expected_time = 1234567890
+        mock_watchdog.get_last_progress_time.return_value = expected_time
+        agent._worker_watchdog = mock_watchdog
+
+        # _get_alive_time should delegate to watchdog when available
+        alive_time = agent._get_alive_time()
+
+        self.assertEqual(alive_time, expected_time)
+        mock_watchdog.get_last_progress_time.assert_called_once()
+
+    def test_setup_healthcheck_idempotent(self):
+        """Test _setup_healthcheck is idempotent and does not recreate server when JK is enabled."""
+        node_conf = Conf(entrypoint=_happy_function, local_world_size=1)
+
+        # Use a mocked rendezvous handler to avoid blocking on real connections
+        rdzv_handler = Mock()
+        rdzv_handler.get_backend.return_value = "c10d"
+        spec = WorkerSpec(
+            role=node_conf.role,
+            local_world_size=node_conf.local_world_size,
+            entrypoint=node_conf.entrypoint,
+            args=node_conf.args,
+            rdzv_handler=rdzv_handler,
+            max_restarts=0,
+            monitor_interval=0.01,
+        )
+        agent = self.get_agent(spec, node_config=node_conf)
+
+        # Pre-set a mock health check server
+        mock_server = Mock()
+        agent._health_check_server = mock_server
+
+        # Set the env for healthcheck port
+        healthcheck_port_env_name = TORCHELASTIC_HEALTH_CHECK_PORT
+        original_value = os.environ.get(healthcheck_port_env_name)
+        os.environ[healthcheck_port_env_name] = "12345"
+
+        try:
+            # Patch justknobs_check to return True for the healthcheck knob
+            with patch(
+                "torch.distributed.elastic.agent.server.local_elastic_agent.justknobs_check",
+                return_value=True,
+            ):
+                # Call _setup_healthcheck - should be a no-op since server already exists
+                agent._setup_healthcheck()
+
+            # Verify the mock server was not replaced or modified
+            self.assertIs(agent._health_check_server, mock_server)
+            # Verify start was not called on the mock (it was already "running")
+            mock_server.start.assert_not_called()
+        finally:
+            # Restore env
+            if original_value is None:
+                if healthcheck_port_env_name in os.environ:
+                    del os.environ[healthcheck_port_env_name]
+            else:
+                os.environ[healthcheck_port_env_name] = original_value
+
+    def test_setup_healthcheck_creates_server_when_none(self):
+        """Test _setup_healthcheck creates server when none exists."""
+        node_conf = Conf(entrypoint=_happy_function, local_world_size=1)
+        self._backend = "c10d"
+        self._endpoint = f"localhost:{acquire_available_port()}"
+        spec = self.get_worker_spec(node_conf)
+        agent = self.get_agent(spec, node_config=node_conf)
+
+        # Ensure no health check server exists
+        self.assertIsNone(agent._health_check_server)
+
+        # Set the env for healthcheck
+        healthcheck_port_env_name = TORCHELASTIC_HEALTH_CHECK_PORT
+        original_value = os.environ.get(healthcheck_port_env_name)
+        healthcheck_port = str(acquire_available_port())
+        os.environ[healthcheck_port_env_name] = healthcheck_port
+
+        try:
+            # Call _setup_healthcheck
+            agent._setup_healthcheck()
+
+            # Verify a health check server was created
+            self.assertIsNotNone(agent._health_check_server)
+        finally:
+            # Cleanup
+            if agent._health_check_server is not None:
+                agent._health_check_server.stop()
+                agent._health_check_server = None
+            if original_value is None:
+                if healthcheck_port_env_name in os.environ:
+                    del os.environ[healthcheck_port_env_name]
+            else:
+                os.environ[healthcheck_port_env_name] = original_value
+
+    def test_pre_invoke_run_calls_setup_healthcheck(self):
+        """Test _pre_invoke_run calls _setup_healthcheck when JK is enabled."""
+        node_conf = Conf(entrypoint=_happy_function, local_world_size=1)
+        self._backend = "c10d"
+        self._endpoint = f"localhost:{acquire_available_port()}"
+        spec = self.get_worker_spec(node_conf)
+        agent = self.get_agent(spec, node_config=node_conf)
+
+        with (
+            patch(
+                "torch.distributed.elastic.agent.server.local_elastic_agent.justknobs_check",
+                return_value=True,
+            ),
+            patch.object(agent, "_setup_healthcheck") as mock_setup,
+        ):
+            agent._pre_invoke_run()
+        mock_setup.assert_called_once()
+
+    def test_pre_invoke_run_skips_healthcheck_without_jk(self):
+        """Test _pre_invoke_run does NOT call _setup_healthcheck when JK is disabled."""
+        node_conf = Conf(entrypoint=_happy_function, local_world_size=1)
+
+        # Use a mocked rendezvous handler to avoid blocking on real connections
+        rdzv_handler = Mock()
+        rdzv_handler.get_backend.return_value = "c10d"
+        spec = WorkerSpec(
+            role=node_conf.role,
+            local_world_size=node_conf.local_world_size,
+            entrypoint=node_conf.entrypoint,
+            args=node_conf.args,
+            rdzv_handler=rdzv_handler,
+            max_restarts=0,
+            monitor_interval=0.01,
+        )
+        agent = self.get_agent(spec, node_config=node_conf)
+
+        with (
+            patch(
+                "torch.distributed.elastic.agent.server.local_elastic_agent.justknobs_check",
+                return_value=False,
+            ),
+            patch.object(agent, "_setup_healthcheck") as mock_setup,
+        ):
+            agent._pre_invoke_run()
+        mock_setup.assert_not_called()
+
+    def test_healthcheck_with_watchdog_enabled(self):
+        """Test healthcheck works with watchdog enabled during agent run."""
+        # Set the env for watchdog and healthcheck
+        watchdog_env_name = TORCHELASTIC_ENABLE_FILE_TIMER
+        healthcheck_port_env_name = TORCHELASTIC_HEALTH_CHECK_PORT
+
+        original_watchdog = os.environ.get(watchdog_env_name)
+        original_healthcheck = os.environ.get(healthcheck_port_env_name)
+
+        os.environ[watchdog_env_name] = "1"
+        os.environ[healthcheck_port_env_name] = str(acquire_available_port())
+
+        try:
+            node_conf = Conf(
+                entrypoint=_check_local_watchdog_setup,
+                local_world_size=1,
+                args=(TORCHELASTIC_ENABLE_FILE_TIMER, True),
+            )
+
+            def run_test():
+                spec = self.get_worker_spec(node_conf, max_restarts=0)
+                agent = self.get_agent(spec, node_config=node_conf)
+
+                # Run the agent with justknobs_check returning True
+                with patch(
+                    "torch.distributed.elastic.agent.server.local_elastic_agent.justknobs_check",
+                    return_value=True,
+                ):
+                    res = agent.run()
+                self.assertFalse(res.is_failed())
+
+            self.run_test_with_backend(backend="c10d", test_to_run=run_test)
+        finally:
+            # Restore env
+            if original_watchdog is None:
+                if watchdog_env_name in os.environ:
+                    del os.environ[watchdog_env_name]
+            else:
+                os.environ[watchdog_env_name] = original_watchdog
+            if original_healthcheck is None:
+                if healthcheck_port_env_name in os.environ:
+                    del os.environ[healthcheck_port_env_name]
+            else:
+                os.environ[healthcheck_port_env_name] = original_healthcheck
 
 
 if __name__ == "__main__":

--- a/torch/distributed/elastic/agent/server/api.py
+++ b/torch/distributed/elastic/agent/server/api.py
@@ -902,8 +902,18 @@ class SimpleElasticAgent(ElasticAgent):
 
         put_metric(f"workers.{spec.role}.flakiness", int(flakiness))
 
+    def _pre_invoke_run(self) -> None:
+        """Hook called before the worker lifecycle loop in ``_invoke_run``.
+
+        Subclasses can override this to perform setup that must happen
+        before rendezvous and worker initialization (e.g. starting a
+        health check server).  The default implementation is a no-op.
+        """
+
     def _invoke_run(self, role: str = DEFAULT_ROLE) -> RunResult:
         # NOTE: currently only works for a single role
+
+        self._pre_invoke_run()
 
         spec = self._worker_group.spec
         role = spec.role

--- a/torch/distributed/elastic/agent/server/local_elastic_agent.py
+++ b/torch/distributed/elastic/agent/server/local_elastic_agent.py
@@ -19,6 +19,7 @@ from string import Template
 from typing import Any, TYPE_CHECKING
 
 import torch.distributed.elastic.timer as timer
+from torch._utils_internal import justknobs_check
 from torch.distributed.elastic import events
 from torch.distributed.elastic.agent.server.api import (
     RunResult,
@@ -206,6 +207,21 @@ class LocalElasticAgent(SimpleElasticAgent):
     def _get_current_time_secs() -> int:
         return int(time.time())
 
+    def _get_alive_time(self) -> int:
+        """Return the last progress time from the watchdog, or the current time.
+
+        This callback is passed to the health check server at startup and
+        is called on every TW health check poll. During initialization
+        (before rendezvous and worker launch), the watchdog does not exist
+        yet, so we return the current time to signal the agent is alive.
+        Once workers are running and the watchdog is active, we delegate
+        to the watchdog's ``get_last_progress_time`` for real liveness
+        tracking.
+        """
+        if self._worker_watchdog is not None:
+            return self._worker_watchdog.get_last_progress_time()
+        return int(time.time())
+
     def _setup_healthcheck(self) -> None:
         healthcheck_port_env_name = TORCHELASTIC_HEALTH_CHECK_PORT
         healthcheck_port = os.getenv(healthcheck_port_env_name)
@@ -215,13 +231,28 @@ class LocalElasticAgent(SimpleElasticAgent):
                 healthcheck_port_env_name,
                 healthcheck_port,
             )
-            if self._worker_watchdog is None:
-                logger.info(
-                    "FileTimerServer doesn't exist, using current time as dummy callback"
-                )
-                alive_callback = LocalElasticAgent._get_current_time_secs
+
+            if justknobs_check(
+                "ai_infra/pytorch_distributed:torchelastic_enable_healthcheck_before_rendezvous",
+                default=False,
+            ):
+                # New behavior: idempotent guard + dynamic callback that
+                # returns current time before watchdog exists and delegates
+                # to watchdog once workers are running.
+                if self._health_check_server is not None:
+                    return
+                alive_callback = self._get_alive_time
             else:
-                alive_callback = self._worker_watchdog.get_last_progress_time
+                # Original behavior: pick callback based on watchdog state
+                # at call time (only called from _start_workers where
+                # watchdog is already set up).
+                if self._worker_watchdog is None:
+                    logger.info(
+                        "FileTimerServer doesn't exist, using current time as dummy callback"
+                    )
+                    alive_callback = LocalElasticAgent._get_current_time_secs
+                else:
+                    alive_callback = self._worker_watchdog.get_last_progress_time
 
             try:
                 healthcheck_port_as_int = int(healthcheck_port)
@@ -408,6 +439,22 @@ class LocalElasticAgent(SimpleElasticAgent):
 
         if "CUDA_VISIBLE_DEVICES" in os.environ:
             worker_env["CUDA_VISIBLE_DEVICES"] = os.environ["CUDA_VISIBLE_DEVICES"]
+
+    def _pre_invoke_run(self) -> None:
+        # Start the health check server immediately, before rendezvous,
+        # so that TW sees a healthy thrift port while the agent is still
+        # initializing (package fetch, rendezvous, model load, etc.).
+        # The _get_alive_time callback dynamically checks self._worker_watchdog:
+        # returns current time during init, real watchdog time once workers run.
+        if justknobs_check(
+            "ai_infra/pytorch_distributed:torchelastic_enable_healthcheck_before_rendezvous",
+            default=False,
+        ):
+            logger.info(
+                "Starting health check server before rendezvous "
+                "(torchelastic_enable_healthcheck_before_rendezvous=True)"
+            )
+            self._setup_healthcheck()
 
     def _shutdown(
         self, death_sig: signal.Signals = signal.SIGTERM, timeout: int = 30


### PR DESCRIPTION
Summary
Start the TW health check thrift server before rendezvous to prevent TW from killing healthy tasks during long rendezvous windows.


Reviewed By: joecoli, d4l3k

Differential Revision: D94674549


