### PR TITLE
[distributed] Add `sort_ranks` parameter to `new_group` to allow preserving user-provided rank order

### DIFF
--- a/test/distributed/test_c10d_common.py
+++ b/test/distributed/test_c10d_common.py
@@ -1547,6 +1547,42 @@ class AbstractLargeCommTest:
             ]
             self.assertEqual(output_tensor_list, expected)
 
+    def _test_new_group_ordered(self, backend):
+        store = dist.FileStore(self.file_name, self.world_size)
+        dist.init_process_group(
+            backend,
+            world_size=self.world_size,
+            rank=self.rank,
+            store=store,
+        )
+        rank = dist.get_rank()
+
+        # Reverse-order ranks: group rank 0 = highest global rank
+        reversed_ranks = list(range(self.world_size - 1, -1, -1))
+        new_pg = dist.new_group(ranks=reversed_ranks, sort_ranks=False)
+
+        # Verify that the group rank assignment follows the user-provided order
+        expected_group_rank = reversed_ranks.index(rank)
+        self.assertEqual(dist.get_group_rank(new_pg, rank), expected_group_rank)
+        self.assertEqual(
+            dist.get_process_group_ranks(new_pg),
+            reversed_ranks,
+        )
+
+        # Verify that all_gather results follow the custom rank order
+        input_tensor = torch.tensor([rank], device=self.device)
+        output_tensor_list = [
+            torch.tensor([-1], device=self.device) for _ in range(self.world_size)
+        ]
+        dist.all_gather(output_tensor_list, input_tensor, group=new_pg)
+
+        # Group rank i holds global rank reversed_ranks[i]
+        expected = [
+            torch.tensor([reversed_ranks[i]], device=self.device)
+            for i in range(self.world_size)
+        ]
+        self.assertEqual(output_tensor_list, expected)
+
 
 class CommTest(AbstractCommTest, MultiProcessTestCase):
     def setUp(self):

--- a/test/distributed/test_c10d_gloo.py
+++ b/test/distributed/test_c10d_gloo.py
@@ -2952,6 +2952,10 @@ class LargeCommTest(test_c10d_common.AbstractLargeCommTest, MultiProcessTestCase
     def test_new_group_local_sync_duplicate_pg(self):
         self._test_new_group_local_sync_duplicate_pg(backend="gloo")
 
+    @requires_gloo()
+    def test_new_group_ordered(self):
+        self._test_new_group_ordered(backend="gloo")
+
 
 if __name__ == "__main__":
     if torch.cuda._initialized:

--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -4957,6 +4957,11 @@ class LargeCommTest(test_c10d_common.AbstractLargeCommTest, MultiProcessTestCase
     def test_new_group_local_sync_duplicated_pg(self):
         self._test_new_group_local_sync_duplicate_pg(backend="nccl")
 
+    @requires_nccl()
+    @skip_if_lt_x_gpu(4)
+    def test_new_group_ordered(self):
+        self._test_new_group_ordered(backend="nccl")
+
     def _init_two_pg2_subgroups(self, world_size: int = 4):
         if world_size != 4:
             raise NotImplementedError(

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -5531,6 +5531,10 @@ def _new_group_with_tag(
     if ranks is not None:
         if sort_ranks:
             ranks = sorted(ranks)
+        if len(set(ranks)) != len(ranks):
+            raise ValueError(
+                f"ranks list must not contain duplicate entries, got {ranks}"
+            )
         group_world_size = len(ranks)
         if group_world_size > global_world_size:
             raise ValueError(
@@ -5541,10 +5545,7 @@ def _new_group_with_tag(
         # check ranks' sanity
         for rank in ranks:
             if rank < 0 or rank >= global_world_size:
-                raise ValueError(
-                    "The new group's rank should be within "
-                    "the world_size set by init_process_group"
-                )
+                raise ValueError(f"Rank {rank} is not within [0, {global_world_size})")
         if global_rank in ranks:
             group_rank = ranks.index(global_rank)
         else:

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -5387,6 +5387,7 @@ def new_group(
     use_local_synchronization: bool = False,
     group_desc=None,
     device_id: torch.device | None = None,
+    sort_ranks: bool = True,
 ):
     """
     Create a new distributed group.
@@ -5441,6 +5442,11 @@ def new_group(
         device_id (torch.device, optional): a single, specific device
             to "bind" this process to,  The `new_group` call will try to initialize
             a communication backend immediately for the device if this field is given.
+        sort_ranks (bool, optional): If ``True`` (the default), sort the
+            ``ranks`` list before creating the group. If ``False``, preserve
+            the caller-provided rank order so that position in the ``ranks``
+            list determines group rank.  All processes must pass the identical
+            ``ranks`` list.  Default is ``True``.
 
     Returns:
         A handle of distributed group that can be given to collective calls or
@@ -5465,6 +5471,7 @@ def new_group(
         use_local_synchronization=use_local_synchronization,
         group_desc=group_desc,
         device_id=device_id,
+        sort_ranks=sort_ranks,
     )
 
 
@@ -5477,6 +5484,7 @@ def _new_group_with_tag(
     use_local_synchronization=False,
     group_desc=None,
     device_id: torch.device | None = None,
+    sort_ranks: bool = True,
 ):
     """
     Variant of ``new_group`` that exposes tag creation.
@@ -5521,7 +5529,8 @@ def _new_group_with_tag(
 
     # checks the input ranks
     if ranks is not None:
-        ranks = sorted(ranks)
+        if sort_ranks:
+            ranks = sorted(ranks)
         group_world_size = len(ranks)
         if group_world_size > global_world_size:
             raise ValueError(

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -5545,7 +5545,10 @@ def _new_group_with_tag(
         # check ranks' sanity
         for rank in ranks:
             if rank < 0 or rank >= global_world_size:
-                raise ValueError(f"Rank {rank} is not within [0, {global_world_size})")
+                raise ValueError(
+                    f"Rank {rank} is out of range. Valid ranks are 0 to {global_world_size - 1} "
+                    f"(world_size={global_world_size})"
+                )
         if global_rank in ranks:
             group_rank = ranks.index(global_rank)
         else:

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -1018,7 +1018,7 @@ class DistributedTest:
 
             with self.assertRaisesRegex(
                 ValueError,
-                "The new group's rank should be within the world_size set by init_process_group",
+                f"Rank {world_size} is out of range",
             ):
                 dist.new_subgroups_by_enumeration(
                     ranks_per_subgroup_list=[[0, 1], [world_size, 2]]
@@ -1034,7 +1034,7 @@ class DistributedTest:
 
             with self.assertRaisesRegex(
                 ValueError,
-                "The new group's rank should be within the world_size set by init_process_group",
+                r"Rank -\d+ is out of range",
             ):
                 dist.new_subgroups_by_enumeration(
                     ranks_per_subgroup_list=[[-1, -2], [-3, -4]]


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/176126

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #176580

the PR is not bc breaking. it requires user to provides consistent rank ordering

from claude
```
History of ranks = sorted(ranks)                                                                                                              
   
  Before commit ce166d949d8 (2019-04-10, by @pietern):                                                                                          
  - The code used input_ranks = list(ranks) (preserving user order) and passed input_ranks to the MPI backend                                 
  - The _pg_group_ranks mapping was built via ranks.index(rank) on the unsorted user-provided list
  - So the original code actually did honor user-provided rank order

  In commit ce166d949d8:
  - Pietern refactored MPI process group creation to unify it with NCCL/Gloo
  - He replaced input_ranks = list(ranks) with ranks = sorted(ranks)
  - The _pg_group_ranks mapping changed from ranks.index(rank) to enumerate(ranks) — which produces the same result only if ranks are sorted
  - The sort was introduced as a simplification during the MPI refactor, not as a deliberate design constraint. There's no comment explaining
  why sorting is necessary.

  Risks of sort_ranks=False

  There are two real risks:

  1. Inconsistent ranks across processes (the main risk)

  If different processes pass different orderings of ranks, they'll disagree on rank-to-group-rank mapping, producing silent data corruption.
  With sorting, this class of bug is impossible — [3,2,1,0] and [0,1,2,3] both become [0,1,2,3].

  With sort_ranks=False, all processes must pass the identical list. This is already a documented precondition of new_group(), but sorting acted
   as a safety net.

  2. _process_group_name / _hash_ranks_to_str consistency

  When use_local_synchronization=True, the group name is hashed from the ranks list. If processes disagree on rank order, they'd generate
  different group names and fail to find each other. Again, this is only a problem if processes pass different orderings.

  What is NOT a risk

  - NCCL backend: ncclCommInitRank takes (nranks, commId, rank) — the rank parameter is the local process's rank within the communicator, which
  is set by group_rank = ranks.index(global_rank). This works correctly regardless of sort order.
  - Gloo backend: Same — it receives (store, rank, world_size) and the rank is derived from position in the list.

  Mitigation idea

  We could add a validation check when sort_ranks=False to detect mismatched orderings across processes — e.g., hash the ranks list and exchange
   hashes via the store. But that adds latency and complexity. The simpler approach is to just document it clearly, which we've done.

  Bottom line: The sort was introduced incidentally during a refactor, not as an intentional safety mechanism. The only risk with
  sort_ranks=False is user error (passing different orderings on different ranks), which violates the existing documented contract of
  new_group().
```