### PR TITLE
[RNG] Decouple Philox subsequence from hardware topology for cross-platform consistency

### DIFF
--- a/aten/src/ATen/native/cuda/DistributionTemplates.h
+++ b/aten/src/ATen/native/cuda/DistributionTemplates.h
@@ -36,31 +36,35 @@ const uint32_t grid_size_bound = 4;
 // See: https://docs.nvidia.com/cuda/archive/11.8.0/curand/group__DEVICE.html
 const uint32_t max_generator_offsets_per_curand_call = 4;
 
-// utility function that calculates proper philox_offset
-// for distributions utilizing TensorIterator. For distributions using
-// TensorIterator, we are using a grid-stride loop with each
-// thread yielding one element per thread. For the edge of the grid-stride
-// loop, if the tensor size is large, the unroll loop will kick in and the float4
-// from curand4 will start getting utilized (for common tensor sizes, we end up
-// using rand.x from each thread). The philox_offset calculation was changed to
-// (number of elements per thread * maximum generator increment per "curand_*" call), which makes
-// sure that philox offset increment is not less than the number of randoms used
-// in each thread.
+// Calculates counter_offset and CUDA launch config for distribution kernels
+// utilizing TensorIterator with a grid-stride loop.
+//
+// Previously, each physical thread was assigned a unique Philox subsequence
+// (subsequence = thread_id), which made the RNG output dependent on the
+// GPU's SM count and thread topology.  To guarantee identical output across
+// devices with different hardware configurations, we now map each *element
+// group* (0 .. ceil(numel/unroll_factor)-1) to a unique subsequence instead.
+// Each element group makes exactly one curand call, so counter_offset is
+// simply max_generator_offsets_per_curand_call.
 std::tuple<uint64_t, dim3, dim3> calc_execution_policy(const int64_t total_elements, const uint32_t unroll_factor) {
   const uint64_t numel = static_cast<uint64_t>(total_elements);
   const uint32_t block_size = block_size_bound;
+  const uint64_t T = (numel + unroll_factor - 1) / unroll_factor;
   dim3 dim_block(block_size);
-  dim3 grid((numel + block_size - 1) / block_size);
+  dim3 grid((T + block_size - 1) / block_size);
   uint32_t blocks_per_sm = at::cuda::getCurrentDeviceProperties()->maxThreadsPerMultiProcessor / block_size;
   grid.x = std::min(
       static_cast<uint32_t>(at::cuda::getCurrentDeviceProperties()->multiProcessorCount) * blocks_per_sm,
       grid.x);
-  //number of times random will be generated per thread, to offset philox counter in thc random state
-  uint64_t counter_offset = ((numel - 1) / (block_size * grid.x * unroll_factor) + 1) * max_generator_offsets_per_curand_call;
+  uint64_t counter_offset = max_generator_offsets_per_curand_call;
   return std::make_tuple(counter_offset, grid, dim_block);
 }
 
-// grid stride loop kernel for distributions
+// Grid-stride loop kernel for distributions.
+// T = ceil(numel/unroll_factor) element groups each map 1:1 to a Philox
+// subsequence (curand_init with subsequence = element_group_index), so the
+// output is deterministic across devices with different SM counts.  Physical
+// threads stride over element groups to maintain hardware utilization.
 template<typename accscalar_t, int unroll_factor, typename dist_t, typename transform_t>
 C10_LAUNCH_BOUNDS_2(block_size_bound, grid_size_bound)
 __global__ void distribution_elementwise_grid_stride_kernel(int64_t numel,
@@ -68,22 +72,22 @@ __global__ void distribution_elementwise_grid_stride_kernel(int64_t numel,
                                                             const dist_t dist_func,
                                                             const transform_t transform_func) {
   auto [seed, offset] = at::cuda::philox::unpack(philox_args);
-  int64_t idx = ((int64_t) blockIdx.x) * blockDim.x + threadIdx.x;
-  curandStatePhilox4_32_10_t state;
-  curand_init(seed, idx, offset, &state);
+  int64_t tid = ((int64_t) blockIdx.x) * blockDim.x + threadIdx.x;
+  int64_t total_threads = ((int64_t) blockDim.x) * gridDim.x;
+  int64_t T = (numel + unroll_factor - 1) / unroll_factor;
 
-  int64_t rounded_size = ((numel - 1)/(blockDim.x * gridDim.x * unroll_factor)+1) *
-      blockDim.x * gridDim.x * unroll_factor;
-  for(int64_t linear_index = idx; linear_index < rounded_size; linear_index += blockDim.x * gridDim.x * unroll_factor) {
+  for (int64_t idx = tid; idx < T; idx += total_threads) {
+    curandStatePhilox4_32_10_t state;
+    curand_init(seed, idx, offset, &state);
+
     auto rand = dist_func(&state);
     #pragma unroll
     for (int ii = 0; ii < unroll_factor; ii++) {
-      int64_t li = linear_index + blockDim.x * gridDim.x * ii;
+      int64_t li = idx + T * ii;
       if (li < numel) {
         transform_func(li, static_cast<accscalar_t>((&rand.x)[ii]));
       }
     }
-    __syncthreads();
   }
 }
 


### PR DESCRIPTION
## Problem

With a fixed seed, `torch.randn()` produces different output sequences on GPUs with different SM/CU counts. The divergence point is predictable and occurs exactly at `min(grid.x * block_size)` of the two devices (i.e., the smaller number of launched threads).

We tested `torch.randn(200000, device="cuda")` with seed=123 across 5 GPUs:

| GPU | multiProcessorCount | maxThreadsPerMultiProcessor | blocks_per_sm | grid.x × block_size |
|-----|----:|----:|----:|-------:|
| 4090D (NVIDIA) | 114 | 1536 | 6 | 175,104 |
| H20 (NVIDIA) | 78 | 2048 | 8 | 159,744 |
| W7900 (AMD) | 48 | 2048 | 8 | 98,304 |
| MI308X (AMD) | 80 | 2048 | 8 | 163,840 |
| W7800 (AMD) | 35 | 2048 | 8 | 71,680 |

Where `block_size = 256`, `blocks_per_sm = maxThreadsPerMultiProcessor / block_size`, and `grid.x = multiProcessorCount × blocks_per_sm`, as computed in [`calc_execution_policy`](https://github.com/pytorch/pytorch/blob/main/aten/src/ATen/native/cuda/DistributionTemplates.h#L49).

The predicted divergence boundary (`min(grid.x * block_size)` of each pair) matches the observed boundary exactly in all tested combinations:

| Pair | Predicted boundary | Observed | Match |
|------|-------------------:|---------:|:-----:|
| 4090D vs H20 | 159,744 | 159,744 | ✓ |
| 4090D vs W7900 | 98,304 | 98,304 | ✓ |
| 4090D vs W7800 | 71,680 | 71,680 | ✓ |
| 4090D vs MI308X | 163,840 | 163,840 | ✓ |
| W7900 vs MI308X | 98,304 | 98,304 | ✓ |
| W7900 vs W7800 | 71,680 | 71,680 | ✓ |

Before the boundary, same-vendor pairs are bit-exact; cross-vendor pairs differ at floating-point precision level (due to math library implementation differences). After the boundary, values are completely uncorrelated:

**4090D vs H20** (boundary at index 159,744 = H20's `grid.x × block_size`):
```
Index   H20              4090D            Diff      Status
159740  -0.062478378415  -0.062478378415  0.00e+00  OK
159741   0.213011711836   0.213011711836  0.00e+00  OK
159742  -0.351162850857  -0.351162850857  0.00e+00  OK
159743   0.384488165379   0.384488165379  0.00e+00  OK
159744  -1.901149272919  -0.212807074189  1.69e+00  DIFF  <-- boundary
159745  -0.267296552658  -2.370528697968  2.10e+00  DIFF
159746  -0.415752172470  -1.641909003258  1.23e+00  DIFF
159747  -1.530634403229   0.432760477066  1.96e+00  DIFF
159748  -3.093700170517  -0.256178021431  2.84e+00  DIFF
```

**4090D vs W7900** (boundary at index 98,304 = W7900's `grid.x × block_size`):
```
Index   W7900            4090D            Diff      Status
 98300  -0.124241054058  -0.124240726233  3.28e-07  OK
 98301  -1.352036595345  -1.352036237717  3.58e-07  OK
 98302   1.160541772842   1.160541653633  1.19e-07  OK
 98303   1.858857035637   1.858856916428  1.19e-07  OK
 98304  -1.901149272919  -0.438017874956  1.46e+00  DIFF  <-- boundary
 98305  -0.267296552658  -1.225109457970  9.58e-01  DIFF
 98306  -0.415752053261  -0.032564643770  3.83e-01  DIFF
 98307  -1.530634403229  -1.613942980766  8.33e-02  DIFF
 98308  -3.093699693680  -0.472934395075  2.62e+00  DIFF
```

This affects reproducibility across different GPU models, even within the same vendor (4090D vs H20 are both NVIDIA).

## Root Cause

The distribution kernel `distribution_elementwise_grid_stride_kernel` in [`DistributionTemplates.h`](https://github.com/pytorch/pytorch/blob/main/aten/src/ATen/native/cuda/DistributionTemplates.h) uses the physical thread ID as the Philox PRNG subsequence:

```cpp
int64_t idx = ((int64_t) blockIdx.x) * blockDim.x + threadIdx.x;
curand_init(seed, idx, offset, &state);  // subsequence = thread_id
```

Each thread then strides by `blockDim.x * gridDim.x` to cover all elements. Since `grid.x = min(multiProcessorCount * blocks_per_sm, ceil(numel / block_size))` is hardware-dependent, the mapping from `(subsequence, curand_call_index, component)` → `tensor_element` varies across devices. The same tensor position receives a different random value on different GPUs.

## Solution

Remap the Philox subsequence from the hardware-dependent `thread_id` to the application-dependent `element_group_index`:

```
T = ceil(numel / unroll_factor)     // determined solely by tensor size
subsequence = element_group_index   // 0 .. T-1, hardware-independent
```

Each element group (4 elements mapped to one `curand4` call) gets a unique, hardware-independent subsequence. Physical threads still stride over element groups via a grid-stride loop for hardware utilization, but the RNG output is identical regardless of which thread executes a given group.

This follows the recommendation from the Philox paper:

> *"Generating random numbers from state associated with application variables allows for machine-independent streams of random numbers... This approach permits deterministic results across different computing platforms."*
> — Salmon et al., ["Parallel Random Numbers: As Easy as 1, 2, 3"](https://dl.acm.org/doi/10.1145/2063384.2063405), SC'11

This affects all ops routed through `distribution_elementwise_grid_stride_kernel`: `torch.randn`, `torch.rand`, `exponential_`, `cauchy_`, `log_normal_`, `geometric_`, `bernoulli` (scalar p), `torch.randint`, `random_`.

## Verification

Tested with source-compiled PyTorch on NVIDIA 4090D and AMD W7900:

- **Cross-platform consistency**: `randn`, `rand`, `exponential_` with 4 tensor sizes (100K, 200K, 500K, 1M) × multiple seeds — all elements within max_diff < 1.5e-05 (vendor math library precision differences across CUDA/ROCm).
- **Same-vendor consistency**: bit-exact across NVIDIA GPUs with different SM counts (4090D vs H20).
- **Determinism**: same seed on same device produces bit-exact output across repeated runs.

## Performance

Benchmarked on NVIDIA 4090D, CUDA 13.0, same machine.
- **Original**: PyTorch `2.12.0a0+gitf0bae19` (`f0bae19a8e3d86c69e9608aac50f85f5a92d1f60`)
- **Modified**: PyTorch `2.12.0a0+gitfab9584` (`fab958438e43c425707b8c6379f039da86a36488`)

Measured with CUDA Events (5 trials × 200 repeats, 50 warmup iterations). Overhead percentages are stable across runs; absolute times may vary with GPU boost/thermal state.

| numel | Original (ms) | Modified (ms) | Overhead |
|------:|--------------:|--------------:|-------:|
| 1K | 0.0067 | 0.0066 | ~0% |
| 10K | 0.0067 | 0.0066 | ~0% |
| 50K | 0.0067 | 0.0066 | ~0% |
| 100K | 0.0066 | 0.0066 | ~0% |
| 200K | 0.0067 | 0.0066 | ~0% |
| 500K | 0.0067 | 0.0066 | ~0% |
| 1M | 0.0067 | 0.0066 | ~0% |
| 5M | 0.0140 | 0.0152 | +9% |
| 10M | 0.0242 | 0.0278 | +15% |
| 20M | 0.0932 | 0.1026 | +10% |
| 50M | 0.2326 | 0.2692 | +16% |
| 100M | 0.4686 | 0.5485 | +17% |
| 200M | 0.9404 | 1.1179 | +19% |
| 500M | 2.3518 | 2.8463 | +21% |
| 1B | 4.7017 | 5.6862 | +21% |
| 2B | 9.4022 | 11.3690 | +21% |

<details>
<summary>Benchmark script</summary>

```python
import torch

def bench(numel, warmup=50, repeats=200, trials=5):
    trial_results = []
    for _ in range(trials):
        start = torch.cuda.Event(enable_timing=True)
        end = torch.cuda.Event(enable_timing=True)
        for _ in range(warmup):
            torch.randn(numel, device="cuda")
        torch.cuda.synchronize()
        start.record()
        for _ in range(repeats):
            torch.randn(numel, device="cuda")
        end.record()
        torch.cuda.synchronize()
        trial_results.append(start.elapsed_time(end) / repeats)
    return trial_results
```

</details>

## Breaking change

**Output values for a given seed will differ from previous versions.** This is intentional — the element-to-subsequence mapping has changed to achieve hardware independence.

We understand the original design may have had specific considerations we're not fully aware of. We'd appreciate any feedback on whether this trade-off is acceptable, or if there's a preferred approach to achieving cross-platform RNG consistency.

cc @fritzo @neerajprad @alicanb @nikitaved @ezyang @gchanan @jeffdaily