### PR TITLE
[FSDP] Enable copy engine (zero-CTA) all-gather via symmetric memory

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_copy_engine.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_copy_engine.py
@@ -1,0 +1,93 @@
+# Owner(s): ["oncall: distributed"]
+
+import copy
+import sys
+from typing import Optional
+
+import torch
+import torch.distributed as dist
+import torch.distributed._symmetric_memory as symm_mem
+from torch.distributed.fsdp import fully_shard
+from torch.distributed.fsdp._fully_shard._fsdp_collectives import (
+    CopyEngineAllGather,
+    DefaultAllGather,
+)
+from torch.testing._internal.common_distributed import (
+    MultiProcContinuousTest,
+    requires_nccl_version,
+    skip_if_lt_x_gpu,
+)
+from torch.testing._internal.common_fsdp import MLP
+from torch.testing._internal.common_utils import requires_cuda_p2p_access, run_tests
+
+
+if not dist.is_available() or not dist.is_nccl_available():
+    print("c10d NCCL not available, skipping tests", file=sys.stderr)
+    sys.exit(0)
+
+
+@requires_nccl_version((2, 28), "Need NCCL 2.28+ for CE collectives")
+@requires_cuda_p2p_access()
+class TestCopyEngineAllGather(MultiProcContinuousTest):
+    @classmethod
+    def backend_str(cls) -> Optional[str]:
+        return "nccl"
+
+    @classmethod
+    def opts(cls) -> Optional[dist.ProcessGroupNCCL.Options]:
+        opts = dist.ProcessGroupNCCL.Options()
+        opts.config.cta_policy = dist.ProcessGroupNCCL.NCCL_CTA_POLICY_ZERO
+        return opts
+
+    @property
+    def device(self) -> torch.device:
+        return torch.device("cuda", self.rank)
+
+    @skip_if_lt_x_gpu(2)
+    def test_copy_engine_all_gather_fsdp(self):
+        torch.cuda.set_device(self.rank)
+        symm_mem.set_backend("NCCL")
+        # Warmup NCCL communicator
+        dist.all_reduce(torch.ones(1, device=self.device))
+
+        torch.manual_seed(42)
+        ref_model = MLP(16, device=self.device)
+        ref_model = copy.deepcopy(ref_model)
+
+        torch.manual_seed(42)
+        model = MLP(16, device=self.device)
+        fully_shard(model)
+        model.set_copy_engine_all_gather(True)
+
+        torch.manual_seed(self.rank)
+        inp = torch.randn(4, 16, device=self.device)
+
+        ref_out = ref_model(inp)
+        out = model(inp)
+        torch.testing.assert_close(out, ref_out)
+
+        ref_out.sum().backward()
+        out.sum().backward()
+
+    @skip_if_lt_x_gpu(2)
+    def test_copy_engine_all_gather_toggle(self):
+        torch.cuda.set_device(self.rank)
+        symm_mem.set_backend("NCCL")
+        dist.all_reduce(torch.ones(1, device=self.device))
+
+        torch.manual_seed(42)
+        model = MLP(16, device=self.device)
+        fully_shard(model)
+
+        model.set_copy_engine_all_gather(True)
+        state = model._get_fsdp_state()
+        for pg in state._fsdp_param_groups:
+            self.assertIsInstance(pg._all_gather_comm, CopyEngineAllGather)
+
+        model.set_copy_engine_all_gather(False)
+        for pg in state._fsdp_param_groups:
+            self.assertIsInstance(pg._all_gather_comm, DefaultAllGather)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/distributed/fsdp/__init__.py
+++ b/torch/distributed/fsdp/__init__.py
@@ -1,5 +1,6 @@
 from ._flat_param import FlatParameter as FlatParameter
 from ._fully_shard import (
+    CopyEngineAllGather,
     CPUOffloadPolicy,
     FSDPModule,
     fully_shard,
@@ -48,6 +49,7 @@ __all__ = [
     "StateDictSettings",
     "StateDictType",
     # FSDP2
+    "CopyEngineAllGather",
     "CPUOffloadPolicy",
     "FSDPModule",
     "fully_shard",
@@ -59,6 +61,7 @@ __all__ = [
 ]
 
 # Set namespace for exposed private names
+CopyEngineAllGather.__module__ = "torch.distributed.fsdp"
 CPUOffloadPolicy.__module__ = "torch.distributed.fsdp"
 FSDPModule.__module__ = "torch.distributed.fsdp"
 fully_shard.__module__ = "torch.distributed.fsdp"

--- a/torch/distributed/fsdp/_fully_shard/__init__.py
+++ b/torch/distributed/fsdp/_fully_shard/__init__.py
@@ -1,4 +1,5 @@
 from ._fsdp_api import CPUOffloadPolicy, MixedPrecisionPolicy, OffloadPolicy
+from ._fsdp_collectives import CopyEngineAllGather
 from ._fully_shard import (
     FSDPModule,
     fully_shard,
@@ -9,6 +10,7 @@ from ._fully_shard import (
 
 
 __all__ = [
+    "CopyEngineAllGather",
     "CPUOffloadPolicy",
     "FSDPModule",
     "fully_shard",

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_collectives.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_collectives.py
@@ -5,6 +5,7 @@ from typing import Any, cast, NamedTuple
 
 import torch
 import torch.distributed as dist
+import torch.distributed._symmetric_memory as symm_mem
 from torch.distributed.device_mesh import _get_device_handle
 from torch.distributed.distributed_c10d import ReduceOp
 from torch.distributed.fsdp._fully_shard._fsdp_api import AllGather, ReduceScatter
@@ -96,6 +97,44 @@ class DefaultAllGather(DefaultAllocMixin, AllGather):
 class ProcessGroupAllocAllGather(ProcessGroupAllocMixin, AllGather):
     def __init__(self, group: dist.ProcessGroup) -> None:
         super().__init__(group)
+
+    def __call__(
+        self,
+        output_tensor: torch.Tensor,
+        input_tensor: torch.Tensor,
+        group: dist.ProcessGroup,
+        async_op: bool = False,
+    ) -> dist.Work | None:
+        return dist.all_gather_into_tensor(
+            output_tensor,
+            input_tensor,
+            group=group,
+            async_op=async_op,
+        )
+
+
+class CopyEngineAllGather(AllGather):
+    """AllGather using symmetric memory buffers for copy engine (zero-CTA) collectives.
+
+    Requires the process group to be initialized with
+    cta_policy=ProcessGroupNCCL.NCCL_CTA_POLICY_ZERO (NCCL >= 2.28).
+    """
+
+    def __init__(self, group: dist.ProcessGroup) -> None:
+        self._group_name = group.group_name
+
+    def allocate(
+        self,
+        size: Sequence[int | torch.SymInt],
+        *,
+        dtype: torch.dtype,
+        device: torch.device,
+    ) -> torch.Tensor:
+        t = symm_mem.empty(  # pyrefly: ignore[no-matching-overload]
+            size, dtype=dtype, device=device
+        )
+        symm_mem.rendezvous(t, group=self._group_name)
+        return t
 
     def __call__(
         self,

--- a/torch/distributed/fsdp/_fully_shard/_fully_shard.py
+++ b/torch/distributed/fsdp/_fully_shard/_fully_shard.py
@@ -13,6 +13,7 @@ import torch.nn as nn
 from torch.distributed._composable import contract
 
 from ._fsdp_api import AllGather, MixedPrecisionPolicy, OffloadPolicy, ReduceScatter
+from ._fsdp_collectives import CopyEngineAllGather, DefaultAllGather
 from ._fsdp_common import FSDPMeshInfo, ShardPlacementFnResult
 from ._fsdp_init import (
     _apply_to_module,
@@ -488,6 +489,28 @@ class FSDPModule:
             )
         for fsdp_param_group in state._fsdp_param_groups:
             fsdp_param_group._all_gather_comm = comm
+
+    def set_copy_engine_all_gather(self, enable: bool = True) -> None:
+        """Enable copy engine (zero-CTA) all-gather for this FSDP module.
+
+        Allocates all-gather buffers from symmetric memory so NCCL uses
+        copy engines instead of SMs, reducing interference with overlapping
+        computation.
+
+        Requires:
+        - NCCL >= 2.28
+        - Process group created with
+          ``opts.config.cta_policy = ProcessGroupNCCL.NCCL_CTA_POLICY_ZERO``
+        - Symmetric memory backend set to NCCL via
+          ``torch.distributed._symmetric_memory.set_backend("NCCL")``
+        """
+        if enable:
+            state = self._get_fsdp_state()
+            for fsdp_param_group in state._fsdp_param_groups:
+                group = fsdp_param_group._all_gather_process_group
+                fsdp_param_group._all_gather_comm = CopyEngineAllGather(group)
+        else:
+            self.set_custom_all_gather(DefaultAllGather())
 
     def set_custom_reduce_scatter(self, comm: ReduceScatter) -> None:
         """


### PR DESCRIPTION
Add `CopyEngineAllGather` comm class that allocates buffers from symmetric memory (ncclMemAlloc-backed) so NCCL routes all-gather through copy engines instead of SMs, reducing interference with overlapping compute.

Users create their process group with `cta_policy=NCCL_CTA_POLICY_ZERO` and call `model.set_copy_engine_all_gather(True)` after `fully_shard()`.

FIXES #176418 