### PR TITLE
Use deterministic algorithms for `pytorch_CycleGAN_and_pix2pix` on XPU

### DIFF
--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -4022,6 +4022,16 @@ def setup_determinism_for_accuracy_test(args):
     if args.devices == ["rocm"]:
         torch.use_deterministic_algorithms(True, warn_only=True)
 
+    # Some deterministic kernels have been implemented on XPU
+    if (
+        args.devices == ["xpu"]
+        and args.only
+        in {
+            "pytorch_CycleGAN_and_pix2pix",  # https://github.com/intel/torch-xpu-ops/pull/2901
+        }
+    ):
+        torch.use_deterministic_algorithms(True, warn_only=True)
+
     torch.backends.cudnn.deterministic = True
     torch.backends.cudnn.benchmark = False
     torch.backends.mkldnn.deterministic = True


### PR DESCRIPTION
The `pytorch_CycleGAN_and_pix2pix` end2end test fails on XPU due to non-deterministic kernel behaviour. PR [1] implements the missing deterministic variants of the `ReflectionPad2d` backward kernel, allowing the mentioned model to pass on XPU.

[1] https://github.com/intel/torch-xpu-ops/pull/2901

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo