### PR TITLE
Fix RMSNorm eps default value documentation

### DIFF
--- a/torch/nn/modules/normalization.py
+++ b/torch/nn/modules/normalization.py
@@ -356,10 +356,11 @@ class RMSNorm(Module):
 
             If a single integer is used, it is treated as a singleton list, and this module will
             normalize over the last dimension which is expected to be of that specific size.
-        eps: a value added to the denominator for numerical stability. If not specified,
-            uses the machine epsilon of the computation (opmath) type: fp16/bf16 and
-            fp32 inputs use ``torch.finfo(torch.float32).eps``, while fp64 inputs use
-            ``torch.finfo(torch.float64).eps``.
+        eps (float, optional): a value added to the denominator for numerical stability.
+            Default: ``None`` (in which case ``eps`` is dynamically determined at runtime
+            based on the input dtype — fp16/bf16 and fp32 inputs use
+            ``torch.finfo(torch.float32).eps``, while fp64 inputs use
+            ``torch.finfo(torch.float64).eps``).
         elementwise_affine: a boolean value that when set to ``True``, this module
             has learnable per-element affine parameters initialized to ones (for weights). Default: ``True``.
 


### PR DESCRIPTION
Clarifies the default value of the `eps` parameter in `RMSNorm` documentation.

The function signature has `eps=None`, but the docstring didn't mention that the default is `None` or that the value is resolved dynamically at runtime. This updates the docstring to make that explicit.

Fixes #155527.