### PR TITLE
Fix N11W tensor's strides

### DIFF
--- a/torch/fx/experimental/sym_node.py
+++ b/torch/fx/experimental/sym_node.py
@@ -1224,7 +1224,7 @@ def sympy_is_channels_last_strides_generic(sizes, strides, dim_order):
         # Two cases could lead us here:
         # a. N111 contiguous Tensor ([N,1,1,1]@[1,1,1,1])
         # b. N11W contiguous Tensor sliced on the W-dimension.
-        # ([N,1,1,1]@[W,W,W,W])
+        # ([N,1,1,1]@[W,W,W,1])
         if d == 0:
             r &= sympy.Ne(m, strides[1])
         # This is necessary to:


### PR DESCRIPTION
I've performed an experiment:

```python
x = torch.arange(6).reshape(3,1,1,2)
x_slice = x[:,:,:,0:1]
print(x_slice)
print(x_slice.shape)
print(x_slice.stride())
```

```
# x_slice
tensor([[[[0]]],


        [[[2]]],


        [[[4]]]])
# x_slice.shape
torch.Size([3, 1, 1, 1])
# x_slice.stride
(2, 2, 2, 1)
```

It shows that the strides of a tensor of shape [N,1,1,1] is [W,W,W,1] rather than [W,W,W,W].