### PR TITLE
Fix DataLoader file descriptor leak from atexit cleanup

### DIFF
--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -16,6 +16,7 @@ import tempfile
 import time
 import unittest
 import warnings
+from unittest import mock
 
 import torch
 import torch.utils.data.datapipes as dp
@@ -3392,31 +3393,73 @@ except RuntimeError as e:
     @unittest.skipIf(not TEST_CUDA, "pin_memory requires CUDA")
     def test_persistent_workers_pin_memory_atexit_registered_once(self):
         import atexit
-        from unittest import mock
+        import weakref
 
-        target_fn = dataloader._MultiProcessingDataLoaderIter._clean_up_persistent_workers_atexit
-        register_call_count = 0
-        orig_register = atexit.register
+        cleanup_callback = dataloader._MultiProcessingDataLoaderIter._clean_up_persistent_workers_atexit
+        register_spy = mock.Mock(wraps=atexit.register)
+        persistent_workers_atexit = weakref.WeakSet()
 
-        def wrapped_register(fn, *args, **kwargs):
-            nonlocal register_call_count
-            if fn is target_fn:
-                register_call_count += 1
-            return orig_register(fn, *args, **kwargs)
-
-        with mock.patch("atexit.register", side_effect=wrapped_register):
+        with (
+            mock.patch("atexit.register", register_spy),
+            mock.patch.object(
+                dataloader, "_persistent_workers_atexit_registered", False
+            ),
+            mock.patch.object(
+                dataloader, "_persistent_workers_atexit", persistent_workers_atexit
+            ),
+        ):
             for _ in range(8):
                 loader = self._get_data_loader(
                     self.dataset, batch_size=2, num_workers=1, pin_memory=True
                 )
                 it = iter(loader)
                 next(it)
-                it._shutdown_workers()
+                loader_ref = weakref.ref(loader)
+                it_ref = weakref.ref(it)
                 del it
                 del loader
                 gc.collect()
+                self.assertIsNone(it_ref())
+                self.assertIsNone(loader_ref())
 
-        self.assertEqual(register_call_count, 1)
+        self.assertEqual(len(persistent_workers_atexit), 0)
+        self.assertEqual(
+            sum(
+                1
+                for call in register_spy.call_args_list
+                if call.args and call.args[0] is cleanup_callback
+            ),
+            1,
+        )
+
+    @unittest.skipIf(not TEST_CUDA, "pin_memory requires CUDA")
+    def test_persistent_workers_pin_memory_atexit_uses_iterator_shutdown(self):
+        import weakref
+
+        with (
+            mock.patch.object(
+                dataloader, "_persistent_workers_atexit_registered", True
+            ),
+            mock.patch.object(
+                dataloader, "_persistent_workers_atexit", weakref.WeakSet()
+            ),
+        ):
+            loader = self._get_data_loader(
+                self.dataset, batch_size=2, num_workers=1, pin_memory=True
+            )
+            it = iter(loader)
+            next(it)
+
+            shutdown_workers_spy = mock.Mock(wraps=it._shutdown_workers)
+
+            with mock.patch.object(
+                it,
+                "_shutdown_workers",
+                shutdown_workers_spy,
+            ):
+                dataloader._MultiProcessingDataLoaderIter._clean_up_persistent_workers_atexit()
+
+            self.assertEqual(shutdown_workers_spy.call_count, 1)
 
     @unittest.skipIf(not HAS_PSUTIL, "psutil not found")
     @unittest.skipIf(not IS_LINUX, "fd counting is only reliable on Linux")
@@ -3424,7 +3467,9 @@ except RuntimeError as e:
     def test_persistent_workers_pin_memory_fd_does_not_grow_linearly(self):
         proc = psutil.Process()
 
-        def make_and_destroy_loader() -> None:
+        def run_loader_once() -> None:
+            import weakref
+
             loader = self._get_data_loader(
                 self.dataset,
                 batch_size=2,
@@ -3433,16 +3478,19 @@ except RuntimeError as e:
             )
             it = iter(loader)
             next(it)
-            it._shutdown_workers()
+            loader_ref = weakref.ref(loader)
+            it_ref = weakref.ref(it)
             del it
             del loader
             gc.collect()
+            self.assertIsNone(it_ref())
+            self.assertIsNone(loader_ref())
             time.sleep(0.05)
 
-        make_and_destroy_loader()
+        run_loader_once()
         baseline_fds = proc.num_fds()
         for _ in range(15):
-            make_and_destroy_loader()
+            run_loader_once()
         after_fds = proc.num_fds()
         self.assertLessEqual(after_fds, baseline_fds + 8)
 

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -1105,10 +1105,10 @@ def _test_get_worker_info():
         worker_init_fn=_test_worker_info_init_fn,
     )
     it = iter(dataloader)
+    worker_pids = [w.pid for w in it._workers]
     data = []
     for d in it:
         data.append(d)  # noqa: PERF402
-    worker_pids = [w.pid for w in it._workers]
     data = torch.cat(data, 0)
     for d in data:
         # each `d` is a [worker_id, worker_pid] pair, which is set in

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -3389,6 +3389,63 @@ except RuntimeError as e:
             ]
         )
 
+    @unittest.skipIf(not TEST_CUDA, "pin_memory requires CUDA")
+    def test_persistent_workers_pin_memory_atexit_registered_once(self):
+        import atexit
+        from unittest import mock
+
+        target_fn = dataloader._MultiProcessingDataLoaderIter._clean_up_persistent_workers_atexit
+        register_call_count = 0
+        orig_register = atexit.register
+
+        def wrapped_register(fn, *args, **kwargs):
+            nonlocal register_call_count
+            if fn is target_fn:
+                register_call_count += 1
+            return orig_register(fn, *args, **kwargs)
+
+        with mock.patch("atexit.register", side_effect=wrapped_register):
+            for _ in range(8):
+                loader = self._get_data_loader(
+                    self.dataset, batch_size=2, num_workers=1, pin_memory=True
+                )
+                it = iter(loader)
+                next(it)
+                it._shutdown_workers()
+                del it
+                del loader
+                gc.collect()
+
+        self.assertEqual(register_call_count, 1)
+
+    @unittest.skipIf(not HAS_PSUTIL, "psutil not found")
+    @unittest.skipIf(not IS_LINUX, "fd counting is only reliable on Linux")
+    @unittest.skipIf(not TEST_CUDA, "pin_memory requires CUDA")
+    def test_persistent_workers_pin_memory_fd_does_not_grow_linearly(self):
+        proc = psutil.Process()
+
+        def make_and_destroy_loader() -> None:
+            loader = self._get_data_loader(
+                self.dataset,
+                batch_size=2,
+                num_workers=1,
+                pin_memory=True,
+            )
+            it = iter(loader)
+            next(it)
+            it._shutdown_workers()
+            del it
+            del loader
+            gc.collect()
+            time.sleep(0.05)
+
+        make_and_destroy_loader()
+        baseline_fds = proc.num_fds()
+        for _ in range(15):
+            make_and_destroy_loader()
+        after_fds = proc.num_fds()
+        self.assertLessEqual(after_fds, baseline_fds + 8)
+
     def test_dataset_not_reset(self):
         dataset = DummyDataset()
         pin_memory_configs = [False]

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -77,7 +77,9 @@ logger = logging.getLogger(__name__)
 
 _persistent_workers_atexit_lock = threading.Lock()
 _persistent_workers_atexit_registered = False
-_persistent_workers_atexit: weakref.WeakSet[Any] = weakref.WeakSet()
+_persistent_workers_atexit: weakref.WeakSet[_MultiProcessingDataLoaderIter] = (
+    weakref.WeakSet()
+)
 
 
 class _DatasetKind:
@@ -1217,7 +1219,7 @@ class _MultiProcessingDataLoaderIter(_BaseDataLoaderIter):
         # atexit is used to shutdown thread and child processes in the
         # right sequence before main process exits
         if self._persistent_workers and self._pin_memory:
-            self._register_persistent_workers_atexit(self._workers)
+            self._register_persistent_workers_atexit()
 
         # .pid can be None only before process is spawned (not the case, so ignore)
         _utils.signal_handling._set_worker_pids(
@@ -1675,40 +1677,24 @@ class _MultiProcessingDataLoaderIter(_BaseDataLoaderIter):
                         # we kill the worker.
                         w.terminate()
                         w.join(timeout=_utils.MP_STATUS_CHECK_INTERVAL)
-                    with contextlib.suppress(Exception):
+                    if not w.is_alive():
                         w.close()
-
-    # staticmethod is used to remove reference to `_MultiProcessingDataLoaderIter`
-    @staticmethod
-    def _clean_up_worker(w) -> None:
-        with contextlib.suppress(ValueError):
-            w.join(timeout=_utils.MP_STATUS_CHECK_INTERVAL)
-        try:
-            if w.is_alive():
-                w.terminate()
-                with contextlib.suppress(ValueError):
-                    w.join(timeout=_utils.MP_STATUS_CHECK_INTERVAL)
-        except ValueError:
-            pass
-        finally:
-            with contextlib.suppress(Exception):
-                w.close()
 
     @staticmethod
     def _clean_up_persistent_workers_atexit() -> None:
+        # This callback is registered after `_utils._set_python_exit_flag`,
+        # so it runs while `_shutdown_workers()` can still use multiprocessing.
         with _persistent_workers_atexit_lock:
-            workers = tuple(_persistent_workers_atexit)
-        for worker in workers:
-            _MultiProcessingDataLoaderIter._clean_up_worker(worker)
+            iterators = tuple(_persistent_workers_atexit)
+        for iterator in iterators:
+            iterator._shutdown_workers()
 
-    @staticmethod
-    def _register_persistent_workers_atexit(workers) -> None:
+    def _register_persistent_workers_atexit(self) -> None:
         import atexit
 
         global _persistent_workers_atexit_registered
         with _persistent_workers_atexit_lock:
-            for worker in workers:
-                _persistent_workers_atexit.add(worker)
+            _persistent_workers_atexit.add(self)
             if _persistent_workers_atexit_registered:
                 return
             atexit.register(

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -1677,8 +1677,6 @@ class _MultiProcessingDataLoaderIter(_BaseDataLoaderIter):
                         # we kill the worker.
                         w.terminate()
                         w.join(timeout=_utils.MP_STATUS_CHECK_INTERVAL)
-                    if not w.is_alive():
-                        w.close()
 
     @staticmethod
     def _clean_up_persistent_workers_atexit() -> None:

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -17,6 +17,7 @@ import os
 import queue
 import threading
 import warnings
+import weakref
 from collections.abc import Callable
 from typing import Any, Generic, NoReturn, TYPE_CHECKING, TypeVar
 from typing_extensions import Self
@@ -73,6 +74,10 @@ default_convert = _utils.collate.default_convert
 get_worker_info = _utils.worker.get_worker_info
 
 logger = logging.getLogger(__name__)
+
+_persistent_workers_atexit_lock = threading.Lock()
+_persistent_workers_atexit_registered = False
+_persistent_workers_atexit: weakref.WeakSet[Any] = weakref.WeakSet()
 
 
 class _DatasetKind:
@@ -1212,10 +1217,7 @@ class _MultiProcessingDataLoaderIter(_BaseDataLoaderIter):
         # atexit is used to shutdown thread and child processes in the
         # right sequence before main process exits
         if self._persistent_workers and self._pin_memory:
-            import atexit
-
-            for w in self._workers:
-                atexit.register(_MultiProcessingDataLoaderIter._clean_up_worker, w)
+            self._register_persistent_workers_atexit(self._workers)
 
         # .pid can be None only before process is spawned (not the case, so ignore)
         _utils.signal_handling._set_worker_pids(
@@ -1672,15 +1674,47 @@ class _MultiProcessingDataLoaderIter(_BaseDataLoaderIter):
                         # here, which we shouldn't, (e.g., pytorch/pytorch#39570),
                         # we kill the worker.
                         w.terminate()
+                        w.join(timeout=_utils.MP_STATUS_CHECK_INTERVAL)
+                    with contextlib.suppress(Exception):
+                        w.close()
 
     # staticmethod is used to remove reference to `_MultiProcessingDataLoaderIter`
     @staticmethod
     def _clean_up_worker(w) -> None:
-        try:
+        with contextlib.suppress(ValueError):
             w.join(timeout=_utils.MP_STATUS_CHECK_INTERVAL)
-        finally:
+        try:
             if w.is_alive():
                 w.terminate()
+                with contextlib.suppress(ValueError):
+                    w.join(timeout=_utils.MP_STATUS_CHECK_INTERVAL)
+        except ValueError:
+            pass
+        finally:
+            with contextlib.suppress(Exception):
+                w.close()
+
+    @staticmethod
+    def _clean_up_persistent_workers_atexit() -> None:
+        with _persistent_workers_atexit_lock:
+            workers = tuple(_persistent_workers_atexit)
+        for worker in workers:
+            _MultiProcessingDataLoaderIter._clean_up_worker(worker)
+
+    @staticmethod
+    def _register_persistent_workers_atexit(workers) -> None:
+        import atexit
+
+        global _persistent_workers_atexit_registered
+        with _persistent_workers_atexit_lock:
+            for worker in workers:
+                _persistent_workers_atexit.add(worker)
+            if _persistent_workers_atexit_registered:
+                return
+            atexit.register(
+                _MultiProcessingDataLoaderIter._clean_up_persistent_workers_atexit
+            )
+            _persistent_workers_atexit_registered = True
 
     def __del__(self) -> None:
         self._shutdown_workers()


### PR DESCRIPTION
## Summary
Fixes a file descriptor leak in `DataLoader` when repeatedly creating loaders with `persistent_workers=True` and `pin_memory=True`.

Fixes issue #91252

## Problem
In the `persistent_workers + pin_memory` path, iterator construction registered cleanup with `atexit` per worker, per iterator. This had two effects:
- The number of `atexit` handlers grew linearly with repeated iterator construction.
- `atexit` retained strong references to worker `Process` objects until interpreter shutdown, which could keep internal pipe FDs reachable.

## PR changes:
- Replaces per-worker `atexit` registration with a single process-level registration.
- Tracks active workers for interpreter-exit cleanup without keeping strong references that outlive normal lifecycle.
- Runs existing worker cleanup at process exit through that single registration.

No public API is changed.

## Testing
Added regression tests in `test/test_dataloader.py`:
- `TestDataLoaderPersistentWorkers.test_persistent_workers_pin_memory_atexit_registered_once`
- `TestDataLoaderPersistentWorkers.test_persistent_workers_pin_memory_fd_does_not_grow_linearly`
- `TestDataLoaderPersistentWorkers.test_persistent_workers_pin_memory_atexit_uses_iterator_shutdown`

Also checked with a stress matrix over:
- `num_workers in {1,2,4}`
- `multiprocessing_context in {"fork","spawn"}`
- `persistent_workers=True`, `pin_memory=True`

Saw flat FD behavior after the change.


cc @andrewkho @divyanshk @SsnL @VitalyFedyunin @dzhulgakov @scotts