### PR TITLE
Fix: raise RuntimeError when cudagraph partitions are empty

### DIFF
--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -12,7 +12,6 @@ import unittest
 import warnings
 from collections import defaultdict
 from collections.abc import Mapping, Sequence
-from unittest.mock import patch
 
 import torch
 import torch._dynamo.config as dynamo_config
@@ -6674,14 +6673,12 @@ if HAS_CUDA_AND_TRITON:
                 obs.op_outputs[aten.rand.default][2],
             )
 
-        @patch("torch._inductor.compile_fx.cudagraph_partition_post_compile")
         def test_cudagraph_empty_partition_raises_error(self, mock_post_compile):
             """Verify RuntimeError is raised when partitions are empty and cudagraph_or_error=True"""
             # 1. Simulate empty partitions returning from the post-compile step
-            mock_post_compile.return_value = []
 
-            def fn(x):
-                return x * 2
+            def f(x):
+                return torch.cond(x.sum() > 0, lambda x: x * 2, lambda x: x * 3, (x,))
 
             x = torch.randn(4, device="cuda")
             # This option triggers the logic you fixed

--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -6676,18 +6676,30 @@ if HAS_CUDA_AND_TRITON:
         @unittest.skipUnless(torch.cuda.is_available(), "CUDA required")
         def test_cudagraph_empty_partition_raises_error(self):
             """Verify RuntimeError is raised when partitions are empty and cudagraph_or_error=True"""
-            # 1. Simulate empty partitions returning from the post-compile step
+            @torch.library.custom_op(
+                "test_cudagraph_empty_partition::unsafe_mul",
+                mutates_args=(),
+                tags=(torch._C.Tag.cudagraph_unsafe,),
+            )
+            def unsafe_mul(x: torch.Tensor) -> torch.Tensor:
+                return x * 2.0
 
-            def f(x):
-                return torch.cond(x.sum() > 0, lambda x: x * 2, lambda x: x * 3, (x,))
+            @unsafe_mul.register_fake
+            def _(x: torch.Tensor) -> torch.Tensor:
+                return torch.empty_like(x)
 
-            x = torch.randn(4, device="cuda")
+            def f(x: torch.Tensor) -> torch.Tensor:
+                return unsafe_mul(x)
 
-            # Enable cudagraph_or_error only for this test to force an error on empty partitions.
-            with config.patch("triton.cudagraph_or_error", True):
+            with config.patch(
+                {
+                    "triton.cudagraph_trees": True,
+                    "triton.cudagraph_or_error": True,
+                }
+            ):
                 compiled_fn = torch.compile(f, mode="reduce-overhead")
                 with self.assertRaisesRegex(RuntimeError, "skipping cudagraphs as len"):
-                    compiled_fn(x)
+                    compiled_fn(torch.randn(4, device="cuda"))
 
     instantiate_parametrized_tests(CudaGraphTreeTests)
     instantiate_parametrized_tests(TestCUDAGraphPolicy)

--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -12,6 +12,7 @@ import unittest
 import warnings
 from collections import defaultdict
 from collections.abc import Mapping, Sequence
+from unittest.mock import patch
 
 import torch
 import torch._dynamo.config as dynamo_config
@@ -6673,21 +6674,23 @@ if HAS_CUDA_AND_TRITON:
                 obs.op_outputs[aten.rand.default][2],
             )
 
-        @patch('torch._inductor.compile_fx.cudagraph_partition_post_compile')
+        @patch("torch._inductor.compile_fx.cudagraph_partition_post_compile")
         def test_cudagraph_empty_partition_raises_error(self, mock_post_compile):
             """Verify RuntimeError is raised when partitions are empty and cudagraph_or_error=True"""
             # 1. Simulate empty partitions returning from the post-compile step
             mock_post_compile.return_value = []
-        
+
             def fn(x):
                 return x * 2
 
-            x = torch.randn(4, device='cuda')
+            x = torch.randn(4, device="cuda")
             # This option triggers the logic you fixed
             compiled_fn = torch.compile(fn, options={"cudagraph_or_error": True})
-        
+
             # 2. Verify the fix for issue #176611
-            with self.assertRaisesRegex(RuntimeError, "Unable to find any CUDA graphable partitions"):
+            with self.assertRaisesRegex(
+                RuntimeError, "Unable to find any CUDA graphable partitions"
+            ):
                 compiled_fn(x)
 
     instantiate_parametrized_tests(CudaGraphTreeTests)

--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -6673,6 +6673,23 @@ if HAS_CUDA_AND_TRITON:
                 obs.op_outputs[aten.rand.default][2],
             )
 
+        @patch('torch._inductor.compile_fx.cudagraph_partition_post_compile')
+        def test_cudagraph_empty_partition_raises_error(self, mock_post_compile):
+            """Verify RuntimeError is raised when partitions are empty and cudagraph_or_error=True"""
+            # 1. Simulate empty partitions returning from the post-compile step
+            mock_post_compile.return_value = []
+        
+            def fn(x):
+                return x * 2
+
+            x = torch.randn(4, device='cuda')
+            # This option triggers the logic you fixed
+            compiled_fn = torch.compile(fn, options={"cudagraph_or_error": True})
+        
+            # 2. Verify the fix for issue #176611
+            with self.assertRaisesRegex(RuntimeError, "Unable to find any CUDA graphable partitions"):
+                compiled_fn(x)
+
     instantiate_parametrized_tests(CudaGraphTreeTests)
     instantiate_parametrized_tests(TestCUDAGraphPolicy)
     instantiate_parametrized_tests(TestSAC)

--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -6685,7 +6685,7 @@ if HAS_CUDA_AND_TRITON:
 
             # Enable cudagraph_or_error only for this test to force an error on empty partitions.
             with config.patch("triton.cudagraph_or_error", True):
-                compiled_fn = torch.compile(f)
+                compiled_fn = torch.compile(f, mode="reduce-overhead")
                 with self.assertRaisesRegex(RuntimeError, "skipping cudagraphs as len"):
                     compiled_fn(x)
 

--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -6683,13 +6683,9 @@ if HAS_CUDA_AND_TRITON:
             x = torch.randn(4, device="cuda")
 
             # Enable cudagraph_or_error only for this test to force an error on empty partitions.
-            with config.patch(
-                "triton.cudagraph_or_error", True
-            ):
+            with config.patch("triton.cudagraph_or_error", True):
                 compiled_fn = torch.compile(f)
-                with self.assertRaisesRegex(
-                    RuntimeError, "skipping cudagraphs as len"
-                ):
+                with self.assertRaisesRegex(RuntimeError, "skipping cudagraphs as len"):
                     compiled_fn(x)
 
     instantiate_parametrized_tests(CudaGraphTreeTests)

--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -6681,14 +6681,16 @@ if HAS_CUDA_AND_TRITON:
                 return torch.cond(x.sum() > 0, lambda x: x * 2, lambda x: x * 3, (x,))
 
             x = torch.randn(4, device="cuda")
-            # This option triggers the logic you fixed
-            compiled_fn = torch.compile(f, options={"cudagraph_or_error": True})
 
-            # 2. Verify the fix for issue #176611
-            with self.assertRaisesRegex(
-                RuntimeError, "skipping cudagraphs as len"
+            # Enable cudagraph_or_error only for this test to force an error on empty partitions.
+            with config.patch(
+                "triton.cudagraph_or_error", True
             ):
-                compiled_fn(x)
+                compiled_fn = torch.compile(f)
+                with self.assertRaisesRegex(
+                    RuntimeError, "skipping cudagraphs as len"
+                ):
+                    compiled_fn(x)
 
     instantiate_parametrized_tests(CudaGraphTreeTests)
     instantiate_parametrized_tests(TestCUDAGraphPolicy)

--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -6673,7 +6673,7 @@ if HAS_CUDA_AND_TRITON:
                 obs.op_outputs[aten.rand.default][2],
             )
 
-        def test_cudagraph_empty_partition_raises_error(self, mock_post_compile):
+        def test_cudagraph_empty_partition_raises_error(self):
             """Verify RuntimeError is raised when partitions are empty and cudagraph_or_error=True"""
             # 1. Simulate empty partitions returning from the post-compile step
 
@@ -6682,11 +6682,11 @@ if HAS_CUDA_AND_TRITON:
 
             x = torch.randn(4, device="cuda")
             # This option triggers the logic you fixed
-            compiled_fn = torch.compile(fn, options={"cudagraph_or_error": True})
+            compiled_fn = torch.compile(f, options={"cudagraph_or_error": True})
 
             # 2. Verify the fix for issue #176611
             with self.assertRaisesRegex(
-                RuntimeError, "Unable to find any CUDA graphable partitions"
+                RuntimeError, "skipping cudagraphs as len"
             ):
                 compiled_fn(x)
 

--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -6673,6 +6673,7 @@ if HAS_CUDA_AND_TRITON:
                 obs.op_outputs[aten.rand.default][2],
             )
 
+        @unittest.skipUnless(torch.cuda.is_available(), "CUDA required")
         def test_cudagraph_empty_partition_raises_error(self):
             """Verify RuntimeError is raised when partitions are empty and cudagraph_or_error=True"""
             # 1. Simulate empty partitions returning from the post-compile step

--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -6274,6 +6274,26 @@ if HAS_CUDA_AND_TRITON:
             self.assertGreater(counters["inductor"]["cudagraph_skips"], 0)
             self.assertGreater(len(wrap_calls), 0)
 
+    if torch.cuda.is_available():
+
+    @torch.library.custom_op(
+        "test_cudagraph_empty_partition::unsafe_mul",
+        mutates_args=(),
+        tags=(torch._C.Tag.cudagraph_unsafe,),
+    )
+    def _test_cudagraph_empty_partition_unsafe_mul(x: torch.Tensor) -> torch.Tensor:
+        return x * 2.0
+
+    @_test_cudagraph_empty_partition_unsafe_mul.register_fake
+    def _(x: torch.Tensor) -> torch.Tensor:
+        return torch.empty_like(x)
+
+    from torch._inductor.lowering import make_fallback
+
+    make_fallback(
+        torch.ops.test_cudagraph_empty_partition.unsafe_mul.default
+    )
+
     class TestSAC(TestCase):
         def _make_observer_mode(self):
             class ObserverMode(TorchDispatchMode):
@@ -6677,24 +6697,8 @@ if HAS_CUDA_AND_TRITON:
         def test_cudagraph_empty_partition_raises_error(self):
             """Verify RuntimeError is raised when partitions are empty and cudagraph_or_error=True"""
 
-            @torch.library.custom_op(
-                "test_cudagraph_empty_partition::unsafe_mul",
-                mutates_args=(),
-                tags=(torch._C.Tag.cudagraph_unsafe,),
-            )
-            def unsafe_mul(x: torch.Tensor) -> torch.Tensor:
-                return x * 2.0
-
-            @unsafe_mul.register_fake
-            def _(x: torch.Tensor) -> torch.Tensor:
-                return torch.empty_like(x)
-
-            from torch._inductor.lowering import make_fallback
-
-            make_fallback(torch.ops.test_cudagraph_empty_partition.unsafe_mul.default)
-
             def f(x: torch.Tensor) -> torch.Tensor:
-                return unsafe_mul(x)
+                return _test_cudagraph_empty_partition_unsafe_mul(x)
 
             with config.patch(
                 {

--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -6688,6 +6688,9 @@ if HAS_CUDA_AND_TRITON:
             def _(x: torch.Tensor) -> torch.Tensor:
                 return torch.empty_like(x)
 
+            from torch._inductor.lowering import make_fallback
+            make_fallback(torch.ops.test_cudagraph_empty_partition.unsafe_mul.default)
+
             def f(x: torch.Tensor) -> torch.Tensor:
                 return unsafe_mul(x)
 

--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -6676,7 +6676,7 @@ if HAS_CUDA_AND_TRITON:
         @unittest.skipUnless(torch.cuda.is_available(), "CUDA required")
         def test_cudagraph_empty_partition_raises_error(self):
             """Verify RuntimeError is raised when partitions are empty and cudagraph_or_error=True"""
-            
+
             @torch.library.custom_op(
                 "test_cudagraph_empty_partition::unsafe_mul",
                 mutates_args=(),
@@ -6690,7 +6690,7 @@ if HAS_CUDA_AND_TRITON:
                 return torch.empty_like(x)
 
             from torch._inductor.lowering import make_fallback
-            
+
             make_fallback(torch.ops.test_cudagraph_empty_partition.unsafe_mul.default)
 
             def f(x: torch.Tensor) -> torch.Tensor:

--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -6676,6 +6676,7 @@ if HAS_CUDA_AND_TRITON:
         @unittest.skipUnless(torch.cuda.is_available(), "CUDA required")
         def test_cudagraph_empty_partition_raises_error(self):
             """Verify RuntimeError is raised when partitions are empty and cudagraph_or_error=True"""
+            
             @torch.library.custom_op(
                 "test_cudagraph_empty_partition::unsafe_mul",
                 mutates_args=(),
@@ -6689,6 +6690,7 @@ if HAS_CUDA_AND_TRITON:
                 return torch.empty_like(x)
 
             from torch._inductor.lowering import make_fallback
+            
             make_fallback(torch.ops.test_cudagraph_empty_partition.unsafe_mul.default)
 
             def f(x: torch.Tensor) -> torch.Tensor:

--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -6700,6 +6700,7 @@ if HAS_CUDA_AND_TRITON:
                 {
                     "triton.cudagraph_trees": True,
                     "triton.cudagraph_or_error": True,
+                    "graph_partition": True,
                 }
             ):
                 compiled_fn = torch.compile(f, mode="reduce-overhead")

--- a/torch/_inductor/output_code.py
+++ b/torch/_inductor/output_code.py
@@ -353,6 +353,10 @@ def cudagraph_partition_post_compile(
                 "skipping cudagraphs as compiled_graph.partition_maps is None"
             )
         else:
+            if config.triton.cudagraph_or_error:
+                raise RuntimeError(
+                    "skipping cudagraphs as len(compiled_graph.partition_maps) == 0"
+                    )
             log_cudagraph_skip_and_bump_counter(
                 "skipping cudagraphs as len(compiled_graph.partition_maps) == 0"
             )

--- a/torch/_inductor/output_code.py
+++ b/torch/_inductor/output_code.py
@@ -344,6 +344,13 @@ def cudagraph_partition_post_compile(
         # cudagraphify is not called if there are no partitions
         BoxedBool.disable(cudagraphs)
         maybe_handle_backward_generation(compiled_graph, boxed_forward_device_index)
+        # Log reasons and raise error if cudagraph_or_error=True
+        if cudagraph_fail_reasons:
+            log_cudagraph_skip_and_bump_counter(f"skipping cudagraphs due to {cudagraph_fail_reasons=}")
+        elif compiled_graph.partition_maps is None:
+            log_cudagraph_skip_and_bump_counter("skipping cudagraphs as compiled_graph.partition_maps is None")
+        else:
+            log_cudagraph_skip_and_bump_counter("skipping cudagraphs as len(compiled_graph.partition_maps) == 0")
         return
 
     if compiled_graph.current_callable is None:

--- a/torch/_inductor/output_code.py
+++ b/torch/_inductor/output_code.py
@@ -34,7 +34,6 @@ from torch._custom_class_base import CustomClassBase
 from torch._dynamo.utils import counters, get_runtime_metrics_context
 from torch._guards import compile_context, CompileContext
 from torch._higher_order_ops.wrap import inductor_compiled_code
-from torch._inductor import config
 from torch._inductor.cudagraph_utils import (
     BoxedDeviceIndex,
     cudagraph_trees_clone_live_user_visible_outputs,

--- a/torch/_inductor/output_code.py
+++ b/torch/_inductor/output_code.py
@@ -345,11 +345,17 @@ def cudagraph_partition_post_compile(
         BoxedBool.disable(cudagraphs)
         maybe_handle_backward_generation(compiled_graph, boxed_forward_device_index)
         if cudagraph_fail_reasons:
-            log_cudagraph_skip_and_bump_counter(f"skipping cudagraphs due to {cudagraph_fail_reasons=}")
+            log_cudagraph_skip_and_bump_counter(
+                f"skipping cudagraphs due to {cudagraph_fail_reasons=}"
+            )
         elif compiled_graph.partition_maps is None:
-            log_cudagraph_skip_and_bump_counter("skipping cudagraphs as compiled_graph.partition_maps is None")
+            log_cudagraph_skip_and_bump_counter(
+                "skipping cudagraphs as compiled_graph.partition_maps is None"
+            )
         else:
-            log_cudagraph_skip_and_bump_counter("skipping cudagraphs as len(compiled_graph.partition_maps) == 0")
+            log_cudagraph_skip_and_bump_counter(
+                "skipping cudagraphs as len(compiled_graph.partition_maps) == 0"
+            )
         return
 
     if compiled_graph.current_callable is None:

--- a/torch/_inductor/output_code.py
+++ b/torch/_inductor/output_code.py
@@ -353,10 +353,6 @@ def cudagraph_partition_post_compile(
                 "skipping cudagraphs as compiled_graph.partition_maps is None"
             )
         else:
-            if config.triton.cudagraph_or_error:
-                raise RuntimeError(
-                    "skipping cudagraphs as len(compiled_graph.partition_maps) == 0"
-                )
             log_cudagraph_skip_and_bump_counter(
                 "skipping cudagraphs as len(compiled_graph.partition_maps) == 0"
             )

--- a/torch/_inductor/output_code.py
+++ b/torch/_inductor/output_code.py
@@ -346,11 +346,17 @@ def cudagraph_partition_post_compile(
         maybe_handle_backward_generation(compiled_graph, boxed_forward_device_index)
         # Log reasons and raise error if cudagraph_or_error=True
         if cudagraph_fail_reasons:
-            log_cudagraph_skip_and_bump_counter(f"skipping cudagraphs due to {cudagraph_fail_reasons=}")
+            log_cudagraph_skip_and_bump_counter(
+                f"skipping cudagraphs due to {cudagraph_fail_reasons=}"
+            )
         elif compiled_graph.partition_maps is None:
-            log_cudagraph_skip_and_bump_counter("skipping cudagraphs as compiled_graph.partition_maps is None")
+            log_cudagraph_skip_and_bump_counter(
+                "skipping cudagraphs as compiled_graph.partition_maps is None"
+            )
         else:
-            log_cudagraph_skip_and_bump_counter("skipping cudagraphs as len(compiled_graph.partition_maps) == 0")
+            log_cudagraph_skip_and_bump_counter(
+                "skipping cudagraphs as len(compiled_graph.partition_maps) == 0"
+            )
         if V.config.inductor.cudagraph_or_error:
             raise RuntimeError("Unable to find any CUDA graphable partitions")
         return

--- a/torch/_inductor/output_code.py
+++ b/torch/_inductor/output_code.py
@@ -34,6 +34,7 @@ from torch._custom_class_base import CustomClassBase
 from torch._dynamo.utils import counters, get_runtime_metrics_context
 from torch._guards import compile_context, CompileContext
 from torch._higher_order_ops.wrap import inductor_compiled_code
+from torch._inductor import config
 from torch._inductor.cudagraph_utils import (
     BoxedDeviceIndex,
     cudagraph_trees_clone_live_user_visible_outputs,
@@ -344,20 +345,9 @@ def cudagraph_partition_post_compile(
         # cudagraphify is not called if there are no partitions
         BoxedBool.disable(cudagraphs)
         maybe_handle_backward_generation(compiled_graph, boxed_forward_device_index)
-        # Log reasons and raise error if cudagraph_or_error=True
-        if cudagraph_fail_reasons:
-            log_cudagraph_skip_and_bump_counter(
-                f"skipping cudagraphs due to {cudagraph_fail_reasons=}"
-            )
-        elif compiled_graph.partition_maps is None:
-            log_cudagraph_skip_and_bump_counter(
-                "skipping cudagraphs as compiled_graph.partition_maps is None"
-            )
-        else:
-            log_cudagraph_skip_and_bump_counter(
-                "skipping cudagraphs as len(compiled_graph.partition_maps) == 0"
-            )
-        if V.config.inductor.cudagraph_or_error:
+        # Raise an error if no CUDA graphable partitions are found and the user 
+        # has explicitly enabled the 'cudagraph_or_error' configuration.
+        if config.inductor.cudagraph_or_error and len(compiled_graph.partition_maps) == 0:
             raise RuntimeError("Unable to find any CUDA graphable partitions")
         return
 

--- a/torch/_inductor/output_code.py
+++ b/torch/_inductor/output_code.py
@@ -351,6 +351,8 @@ def cudagraph_partition_post_compile(
             log_cudagraph_skip_and_bump_counter("skipping cudagraphs as compiled_graph.partition_maps is None")
         else:
             log_cudagraph_skip_and_bump_counter("skipping cudagraphs as len(compiled_graph.partition_maps) == 0")
+        if V.config.inductor.cudagraph_or_error:
+            raise RuntimeError("Unable to find any CUDA graphable partitions")
         return
 
     if compiled_graph.current_callable is None:

--- a/torch/_inductor/output_code.py
+++ b/torch/_inductor/output_code.py
@@ -345,10 +345,12 @@ def cudagraph_partition_post_compile(
         # cudagraphify is not called if there are no partitions
         BoxedBool.disable(cudagraphs)
         maybe_handle_backward_generation(compiled_graph, boxed_forward_device_index)
-        # Raise an error if no CUDA graphable partitions are found and the user 
-        # has explicitly enabled the 'cudagraph_or_error' configuration.
-        if config.inductor.cudagraph_or_error and len(compiled_graph.partition_maps) == 0:
-            raise RuntimeError("Unable to find any CUDA graphable partitions")
+        if cudagraph_fail_reasons:
+            log_cudagraph_skip_and_bump_counter(f"skipping cudagraphs due to {cudagraph_fail_reasons=}")
+        elif compiled_graph.partition_maps is None:
+            log_cudagraph_skip_and_bump_counter("skipping cudagraphs as compiled_graph.partition_maps is None")
+        else:
+            log_cudagraph_skip_and_bump_counter("skipping cudagraphs as len(compiled_graph.partition_maps) == 0")
         return
 
     if compiled_graph.current_callable is None:

--- a/torch/_inductor/output_code.py
+++ b/torch/_inductor/output_code.py
@@ -356,7 +356,7 @@ def cudagraph_partition_post_compile(
             if config.triton.cudagraph_or_error:
                 raise RuntimeError(
                     "skipping cudagraphs as len(compiled_graph.partition_maps) == 0"
-                    )
+                )
             log_cudagraph_skip_and_bump_counter(
                 "skipping cudagraphs as len(compiled_graph.partition_maps) == 0"
             )

--- a/torch/_inductor/output_code.py
+++ b/torch/_inductor/output_code.py
@@ -345,14 +345,17 @@ def cudagraph_partition_post_compile(
         BoxedBool.disable(cudagraphs)
         maybe_handle_backward_generation(compiled_graph, boxed_forward_device_index)
         if cudagraph_fail_reasons:
-            log_cudagraph_skip_and_bump_counter(
-                f"skipping cudagraphs due to {cudagraph_fail_reasons=}"
-            )
+            # Preserve original non-raising behavior: log and bump counter only,
+            # do not escalate to RuntimeError even if cudagraph_or_error is set.
+            log.warning("skipping cudagraphs due to %s", cudagraph_fail_reasons)
+            counters["inductor"]["cudagraph_skips"] += 1
         elif compiled_graph.partition_maps is None:
-            log_cudagraph_skip_and_bump_counter(
-                "skipping cudagraphs as compiled_graph.partition_maps is None"
-            )
+            # Preserve original non-raising behavior.
+            log.warning("skipping cudagraphs as compiled_graph.partition_maps is None")
+            counters["inductor"]["cudagraph_skips"] += 1
         else:
+            # This is the actual case this PR targets: empty partitions.
+            # Use the shared helper so cudagraph_or_error=True correctly raises.
             log_cudagraph_skip_and_bump_counter(
                 "skipping cudagraphs as len(compiled_graph.partition_maps) == 0"
             )


### PR DESCRIPTION
This commit ensures that 'log_cudagraph_skip_and_bump_counter' is called when  'cudagraph_partition_post_compile' returns early due to empty partitions. 

This prevents silent failures when 'cudagraph_or_error=True' is set, ensuring the expected RuntimeError is raised instead of silently falling back to eager execution. Verified using the reproduction script in issue #176611.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo