### PR TITLE
Draft

### DIFF
--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -120,6 +120,7 @@ _global_forward_pre_hooks: dict[int, Callable] = OrderedDict()
 _global_forward_hooks: dict[int, Callable] = OrderedDict()
 _global_forward_hooks_always_called: dict[int, bool] = OrderedDict()
 _global_forward_hooks_with_kwargs: dict[int, bool] = OrderedDict()
+_noHookSet = True
 
 
 def _has_any_global_hook():
@@ -243,6 +244,7 @@ def register_module_forward_pre_hook(hook: Callable[..., None]) -> RemovableHand
     """
     handle = RemovableHandle(_global_forward_pre_hooks)
     _global_forward_pre_hooks[handle.id] = hook
+    _noHookSet = False
     return handle
 
 
@@ -286,6 +288,7 @@ def register_module_forward_hook(
         _global_forward_hooks, extra_dict=_global_forward_hooks_always_called
     )
     _global_forward_hooks[handle.id] = hook
+    _noHookSet = False
     if with_kwargs:
         _global_forward_hooks_with_kwargs[handle.id] = True
     if always_call:
@@ -319,6 +322,7 @@ def register_module_backward_hook(
 
     handle = RemovableHandle(_global_backward_hooks)
     _global_backward_hooks[handle.id] = hook
+    _noHookSet = False
     return handle
 
 
@@ -346,6 +350,7 @@ def register_module_full_backward_pre_hook(
     """
     handle = RemovableHandle(_global_backward_pre_hooks)
     _global_backward_pre_hooks[handle.id] = hook
+    _noHookSet = False
     return handle
 
 
@@ -382,6 +387,7 @@ def register_module_full_backward_hook(
 
     handle = RemovableHandle(_global_backward_hooks)
     _global_backward_hooks[handle.id] = hook
+    _noHookSet = False
     return handle
 
 
@@ -1427,6 +1433,8 @@ class Module:
         """
         handle = RemovableHandle(self._backward_pre_hooks)
         self._backward_pre_hooks[handle.id] = hook
+        global _noHookSet
+        _noHookSet = False
         if prepend:
             self._backward_pre_hooks.move_to_end(handle.id, last=False)  # type: ignore[attr-defined]
         return handle
@@ -1455,6 +1463,8 @@ class Module:
 
         handle = RemovableHandle(self._backward_hooks)
         self._backward_hooks[handle.id] = hook
+        global _noHookSet
+        _noHookSet = False
         return handle
 
     def register_full_backward_hook(
@@ -1519,6 +1529,8 @@ class Module:
 
         handle = RemovableHandle(self._backward_hooks)
         self._backward_hooks[handle.id] = hook
+        global _noHookSet
+        _noHookSet = False
         if prepend:
             self._backward_hooks.move_to_end(handle.id, last=False)  # type: ignore[attr-defined]
         return handle
@@ -1677,6 +1689,8 @@ class Module:
             self._forward_pre_hooks, extra_dict=self._forward_pre_hooks_with_kwargs
         )
         self._forward_pre_hooks[handle.id] = hook
+        global _noHookSet
+        _noHookSet = False
         if with_kwargs:
             self._forward_pre_hooks_with_kwargs[handle.id] = True
 
@@ -1743,6 +1757,8 @@ class Module:
             ],
         )
         self._forward_hooks[handle.id] = hook
+        global _noHookSet
+        _noHookSet = False
         if with_kwargs:
             self._forward_hooks_with_kwargs[handle.id] = True
         if always_call:
@@ -1783,9 +1799,18 @@ class Module:
         forward_call = (self._slow_forward if torch._C._get_tracing_state() else self.forward)
         # If we don't have any hooks, we want to skip the rest of the logic in
         # this function, and just call forward.
-        if not (self._backward_hooks or self._backward_pre_hooks or self._forward_hooks or self._forward_pre_hooks
-                or _global_backward_pre_hooks or _global_backward_hooks
-                or _global_forward_hooks or _global_forward_pre_hooks):
+        if (_noHookSet):
+            return forward_call(*args, **kwargs)
+        elif not (
+            self._backward_hooks
+            or self._backward_pre_hooks
+            or self._forward_hooks
+            or self._forward_pre_hooks
+            or _global_backward_pre_hooks
+            or _global_backward_hooks
+            or _global_forward_hooks
+            or _global_forward_pre_hooks
+        ):
             return forward_call(*args, **kwargs)
 
         result = None
@@ -1803,10 +1828,24 @@ class Module:
                 full_backward_hooks, non_full_backward_hooks = self._get_backward_hooks()
 
             if _global_forward_pre_hooks or self._forward_pre_hooks:
-                for hook_id, hook in (
-                    *_global_forward_pre_hooks.items(),
-                    *self._forward_pre_hooks.items(),
-                ):
+                for hook_id, hook in _global_forward_pre_hooks.items():
+                    if hook_id in _global_forward_hooks_with_kwargs:
+                        args_kwargs_result = hook(self, args, kwargs)  # type: ignore[misc]
+                        if args_kwargs_result is not None:
+                            if isinstance(args_kwargs_result, tuple) and len(args_kwargs_result) == 2:
+                                args, kwargs = args_kwargs_result
+                            else:
+                                raise RuntimeError(
+                                    "forward pre-hook must return None or a tuple "
+                                    f"of (new_args, new_kwargs), but got {args_kwargs_result}."
+                                )
+                    else:
+                        args_result = hook(self, args)
+                        if args_result is not None:
+                            if not isinstance(args_result, tuple):
+                                args_result = (args_result,)
+                            args = args_result
+                for hook_id, hook in self._forward_pre_hooks.items():
                     if hook_id in self._forward_pre_hooks_with_kwargs:
                         args_kwargs_result = hook(self, args, kwargs)  # type: ignore[misc]
                         if args_kwargs_result is not None:
@@ -1831,15 +1870,22 @@ class Module:
 
             result = forward_call(*args, **kwargs)
             if _global_forward_hooks or self._forward_hooks:
-                for hook_id, hook in (
-                    *_global_forward_hooks.items(),
-                    *self._forward_hooks.items(),
-                ):
-                    # mark that always called hook is run
-                    if hook_id in self._forward_hooks_always_called or hook_id in _global_forward_hooks_always_called:
+                for hook_id, hook in _global_forward_hooks.items():
+                    if hook_id in _global_forward_hooks_always_called:
                         called_always_called_hooks.add(hook_id)
 
-                    if hook_id in self._forward_hooks_with_kwargs or hook_id in _global_forward_hooks_with_kwargs:
+                    if hook_id in _global_forward_hooks_with_kwargs:
+                        hook_result = hook(self, args, kwargs, result)
+                    else:
+                        hook_result = hook(self, args, result)
+
+                    if hook_result is not None:
+                        result = hook_result
+                for hook_id, hook in self._forward_hooks.items():
+                    if hook_id in self._forward_hooks_always_called:
+                        called_always_called_hooks.add(hook_id)
+
+                    if hook_id in self._forward_hooks_with_kwargs:
                         hook_result = hook(self, args, kwargs, result)
                     else:
                         hook_result = hook(self, args, result)


### PR DESCRIPTION
# Summary
This pull request fixes #176628 and implements changes to `torch/nn/modules/module.py` in the `_call_impl()` method combining improvements in performance by around 9% (see benchmark results down below) for all use cases (with hooks and without hooks) via two different approaches (each for one use case) with some minor changes to `hook_id`-checks.

# Description
The changes focus on an ultra-fast-path for the already existing fast-path which only requires one check (`_noHookSet`) instead of many hook checks for the fast-path (via setting `_noHookSet` to `True` by default (which should be relevant in most use cases (that's what the original fast-path already existed for, but in a less effective way)) and changing this only in way less often executed paths (hook registrations)) for use case one using the fast-path and more efficient iterations over global and local hooks and correcting missing checks for `_global_forward_hooks_with_kwargs` for use case two for the improvements for the checks with hooks.

# Background
For the first improvement (for the most-common use-case), a global variable called `_noHookSet` for the very common use case of having no hook(s) set (like the name already says) is added which makes the `_call_impl()` fast-path-check

```python
if not (self._backward_hooks or self._backward_pre_hooks or self._forward_hooks or self._forward_pre_hooks
                or _global_backward_pre_hooks or _global_backward_hooks
                or _global_forward_hooks or _global_forward_pre_hooks):
```

way faster by changing it to

```python
if (_noHookSet):
```

resulting in around 9 percent faster performance benchmarks for the fast-forward-path (see results down below). Additionally, I add another fall-back check including

```python

elif not (
    self._backward_hooks
    or self._backward_pre_hooks
    or self._forward_hooks
    or self._forward_pre_hooks
    or _global_backward_pre_hooks
    or _global_backward_hooks
    or _global_forward_hooks
    or _global_forward_pre_hooks
):
```

(which is basically the same as before again) for some edge-cases (e.g. in case hooks are removed) which means that the original check stays as a fallback, but this does not have any effects on performance for the first performance improvement with the ultra-fast-path in case we do have no hook set. This is also no problem for the performance for the second case (when hooks are set) because it's basically the same check that we had before (the only thing changed is that we have one other check (`if _noHookSet:`) before, but this is not relevant for performance for the second case because the other checks and loops dominate in this case (in (at least) nearly all cases) and we also implement some other improvements for the second case which are way more relevant for the performance of the second case than this minimal change resulting in total in around 9% improvement for the second case as well (originally even around 10%, but with slightly decreased performance through this change still around 9% like in the first case) (for nearly all cases (IMO))).

For the second improvement, I suggest changing the check `if hook_id in self._forward_pre_hooks_with_kwargs:` in

```python
for hook_id, hook in (
    *_global_forward_pre_hooks.items(),
    *self._forward_pre_hooks.items(),
):
```

which only included `self._forward_pre_hooks_with_kwargs` in the first place while in the second place also `_global_forward_hooks_with_kwargs` was included in `if hook_id in self._forward_hooks_with_kwargs or hook_id in _global_forward_hooks_with_kwargs:` (which was missing in the first check (IMO, but please correct me (like anywhere else where I could be mistaken) if I'm mistaken)).

Don't be confused that in the second statement the second part (of this second statement) seems to be removed in the diff link (this is only because we now use separate loops for checking both (`self._forward_pre_hooks_with_kwargs` and `_global_forward_hooks_with_kwargs` (which we (by the way) now do in both places (so second and first place) as well (see the explanation above)))).

And there is another change made and that is (because we use separate loops (like mentioned above)) that we won't check for `self._forward_hooks_with_kwargs` inside the loop for `_global_forward_hooks_with_kwargs` (and the other way around) like we already do so in the other part down below (not belonging to this change directly, but it's implemented in the same place (lines 1935-1936 and 1946-1947 (in the changed version (because the lines differ from version to version)))).

# Benchmarks
I've benchmarked the changes with the following scripts:

`torchcontroller.py` (for both use cases)

```python
import subprocess
import statistics
import math
import time

pythontorch_A = r"C:\Users\User\pythontorch\PCbuild\amd64\python.exe"
pythontorch_B = r"C:\Users\User\pythontorch_patch\PCbuild\amd64\python.exe"
benchmark_script = r"C:\Users\User\Desktop\torchperformancetest.py"

runs = 100

results_A = []
results_B = []

for i in range(runs):
    out_A = subprocess.check_output([pythontorch_A, benchmark_script])
    time_A = float(out_A.strip())
    results_A.append(time_A)
    print(f"Run {i+1}/{runs} completed for PyTorch A | Time: {time_A} s")
    
    out_B = subprocess.check_output([pythontorch_B, benchmark_script])
    time_B = float(out_B.strip())
    results_B.append(time_B)
    print(f"Run {i+1}/{runs} completed for PyTorch B | Time: {time_B} s")

def summarize(data, label):
    n = len(data)
    mean = statistics.mean(data)
    stdev = statistics.stdev(data)
    median = statistics.median(data)

    z = 1.96
    margin = z * (stdev / math.sqrt(n))
    ci_lower = mean - margin
    ci_upper = mean + margin

    print(f"\n--- {label} ---")
    print(f"Mean: {mean:.6f} s")
    print(f"Median: {median:.6f} s")
    print(f"Std Dev: {stdev:.6f} s")
    print(f"95% CI: [{ci_lower:.6f}, {ci_upper:.6f}] s")

print("\n===== STATS =====")
summarize(results_A, "PyTorch")
summarize(results_B, "PyTorch PATCH")

speedup = statistics.mean(results_A) / statistics.mean(results_B)
print(f"\nSpeedup A/B: {speedup:.4f}x")
```

`torchperformancetest.py` (for the most common use case without hooks)

```python
import torch
import torch.nn as nn
import time

class TestModule(nn.Module):
    def forward(self, x):
        return x  

def main():
    device = torch.device('cpu')
    model = TestModule().to(device)
    x = torch.tensor(1.0, device=device)

    for _ in range(100_000):
        model(x)

    num_iter = 250_000
    start = time.perf_counter()
    for _ in range(num_iter):
        model(x)
    end = time.perf_counter()
    elapsed = end - start
    print(f"{elapsed:.6f}")

if __name__ == "__main__":
    main()
```

`torchperformancetest.py` (for the other use case with (at least one hook which is the same as with multiple) hooks)

```python
import torch
import torch.nn as nn
import time

class TestModule(nn.Module):
    def forward(self, x):
        return x  

def main():
    device = torch.device('cpu')
    model = TestModule().to(device)
    x = torch.tensor(1.0, device=device)

    def pre_hook(module, args):
        return args
    def hook(module, args, out):
        return out

    model.register_forward_pre_hook(pre_hook)
    model.register_forward_hook(hook)

    for _ in range(100_000):
        model(x)

    num_iter = 250_000
    start = time.perf_counter()
    for _ in range(num_iter):
        model(x)
    end = time.perf_counter()
    elapsed = end - start
    print(f"{elapsed:.6f}")

if __name__ == "__main__":
    main()
```

# Results

The full logs are available online here (https://justpaste.it/d4o64 for use case one via the ultra-fast-path and https://justpaste.it/fhbjs for use case two with hooks) because it's way too long (100 runs for both scripts and each for both PyTorch itself and PyTorch with the patch) for pasting it on GitHub, but you can visit the link above and view all results.

Summary (for use case one via the ultra-fast-path (see https://justpaste.it/d4o64)):

    --- PyTorch ---
    Mean: 0.321232 s
    Median: 0.316562 s
    Std Dev: 0.014545 s
    95% CI: [0.318381, 0.324083] s

    --- PyTorch PATCH ---
    Mean: 0.294690 s
    Median: 0.290719 s
    Std Dev: 0.015987 s
    95% CI: [0.291557, 0.297823] s

    Speedup A/B: 1.0901x

Summary (for use case two with hooks (see https://justpaste.it/fhbjs)):

    --- PyTorch ---
    Mean: 0.781225 s
    Median: 0.779607 s
    Std Dev: 0.016377 s
    95% CI: [0.778015, 0.784435] s

    --- PyTorch PATCH ---
    Mean: 0.711719 s
    Median: 0.709915 s
    Std Dev: 0.013265 s
    95% CI: [0.709119, 0.714319] s

    Speedup A/B: 1.0977x


cc @jerryzh168 @albanD @mruberry @jbschlosser @walterddr @mikaylagawarecki

Improvements by Benedikt Johannes