### PR TITLE
[dynamo] Support kwargs in OpaqueObject hoisting and subgraph reuse

### DIFF
--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -816,14 +816,19 @@ class OutputGraph(OutputGraphCommon):
         # Bytecode to insert right before we call the graph
         self.pregraph_bytecode: list[Instruction] = []
 
-        # Maps SyntheticLocalSource → (fn, args, arg_sources) for hoisted
-        # graph inputs created by synthetic_graph_input, so invoke_subgraph
-        # reuse can recreate them on cache hit. arg_sources allows stamp-out
-        # to resolve new ctor arg values via source replacement.
+        # Maps SyntheticLocalSource → (fn, args, kwargs, arg_sources,
+        # kwarg_sources) for hoisted graph inputs created by
+        # synthetic_graph_input, so invoke_subgraph reuse can recreate them
+        # on cache hit. arg/kwarg_sources allow stamp-out to resolve new
+        # ctor values via source replacement.
         self.synthetic_source_ctor_info: dict[
             SyntheticLocalSource,
             tuple[
-                Callable[..., Any], tuple[Any, ...], tuple[Source | None, ...] | None
+                Callable[..., Any],
+                tuple[Any, ...],
+                dict[str, Any],
+                tuple[Source | None, ...] | None,
+                dict[str, Source | None] | None,
             ],
         ] = {}
 
@@ -1033,12 +1038,16 @@ class OutputGraph(OutputGraphCommon):
         self,
         fn: Callable[..., Any],
         args: tuple[Any, ...],
+        kwargs: dict[str, Any] | None = None,
         ctor_arg_sources: tuple[Source | None, ...] | None = None,
+        ctor_kwarg_sources: dict[str, Source | None] | None = None,
     ) -> VariableTracker:
         """
-        call fn(*args) before the graph runs and turn the result into a fake input.
+        call fn(*args, **kwargs) before the graph runs and turn the result into a fake input.
         """
-        example_value = fn(*args)
+        if kwargs is None:
+            kwargs = {}
+        example_value = fn(*args, **kwargs)
         varname = self.new_var()
         cg = PyCodegen(self.root_tx)
         cg.add_push_null(
@@ -1048,11 +1057,24 @@ class OutputGraph(OutputGraphCommon):
             )
         )
         cg.foreach(map(variables.ConstantVariable.create, args))
-        cg.call_function(len(args), False)
+        if kwargs:
+            cg.foreach(map(variables.ConstantVariable.create, kwargs.values()))
+            nargs = len(args) + len(kwargs)
+            cg.extend_output(
+                cg.create_call_function_kw(nargs, tuple(kwargs.keys()), False)
+            )
+        else:
+            cg.call_function(len(args), False)
         cg.store(varname)
         self.pregraph_bytecode.extend(cg.get_instructions())
         source = SyntheticLocalSource(varname)
-        self.synthetic_source_ctor_info[source] = (fn, args, ctor_arg_sources)
+        self.synthetic_source_ctor_info[source] = (
+            fn,
+            args,
+            kwargs,
+            ctor_arg_sources,
+            ctor_kwarg_sources,
+        )
         result = VariableTracker.build(self.root_tx, example_value, source)
         # Realize the VT because we will delete the guards on it in the next line.
         result = result.realize()

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -5738,9 +5738,10 @@ def stamp_out_subgraph(
         elif user_arg_idx == -2:
             # TorchScriptObject with SyntheticLocalSource: create a
             # fresh synthetic graph input using the cached constructor.
-            # If ctor_arg_sources are available, use source replacement
-            # to resolve new arg values (e.g. different string per layer).
-            ctor_fn, ctor_args, ctor_arg_sources = data
+            # If ctor_arg/kwarg_sources are available, use source
+            # replacement to resolve new values (e.g. different string
+            # per layer).
+            ctor_fn, ctor_args, ctor_kwargs, ctor_arg_sources, ctor_kwarg_sources = data
             if ctor_arg_sources and source_replacement:
                 new_ctor_args = []
                 for val, arg_src in zip(ctor_args, ctor_arg_sources):
@@ -5751,7 +5752,24 @@ def stamp_out_subgraph(
                         )
                     new_ctor_args.append(val)
                 ctor_args = tuple(new_ctor_args)
-            vt = tx.output.synthetic_graph_input(ctor_fn, ctor_args, ctor_arg_sources)
+            if ctor_kwarg_sources and source_replacement:
+                new_ctor_kwargs = {}
+                for key, val in ctor_kwargs.items():
+                    kw_src = ctor_kwarg_sources.get(key)
+                    if kw_src is not None:
+                        new_src = kw_src.clone(lambda s: source_replacement.get(s, s))
+                        val = new_src.get_value(
+                            resolve_globals, resolve_locals, resolve_cache
+                        )
+                    new_ctor_kwargs[key] = val
+                ctor_kwargs = new_ctor_kwargs
+            vt = tx.output.synthetic_graph_input(
+                ctor_fn,
+                ctor_args,
+                kwargs=ctor_kwargs or None,
+                ctor_arg_sources=ctor_arg_sources,
+                ctor_kwarg_sources=ctor_kwarg_sources,
+            )
             new_lifted_args.append(vt.as_proxy())
         else:
             source = data

--- a/torch/_dynamo/variables/script_object.py
+++ b/torch/_dynamo/variables/script_object.py
@@ -189,8 +189,19 @@ class OpaqueObjectClassVariable(UserDefinedVariable):
             tx.output.fake_mode, opaque_obj
         )
 
+        # Capture sources from the VT args/kwargs so subgraph reuse can apply
+        # source replacement to resolve new ctor values on stamp-out.
+        ctor_arg_sources = tuple(getattr(a, "source", None) for a in args)
+        ctor_kwarg_sources = {
+            k: getattr(v, "source", None) for k, v in kwargs.items()
+        }
+
         return TorchScriptObjectVariable.create(
-            opaque_obj, fake_script_obj, (constant_args, constant_kwargs)
+            opaque_obj,
+            fake_script_obj,
+            (constant_args, constant_kwargs),
+            ctor_arg_sources=ctor_arg_sources,
+            ctor_kwarg_sources=ctor_kwarg_sources,
         )
 
 
@@ -203,9 +214,21 @@ class TorchScriptObjectVariable(UserDefinedObjectVariable):
 
     @staticmethod
     def create(
-        proxy: Proxy, value: Any, ctor_args_kwargs: Any = None, **options: Any
+        proxy: Proxy,
+        value: Any,
+        ctor_args_kwargs: Any = None,
+        ctor_arg_sources: tuple[Source | None, ...] | None = None,
+        ctor_kwarg_sources: dict[str, Source | None] | None = None,
+        **options: Any,
     ) -> "TorchScriptObjectVariable":
-        return TorchScriptObjectVariable(proxy, value, ctor_args_kwargs, **options)
+        return TorchScriptObjectVariable(
+            proxy,
+            value,
+            ctor_args_kwargs,
+            ctor_arg_sources=ctor_arg_sources,
+            ctor_kwarg_sources=ctor_kwarg_sources,
+            **options,
+        )
 
     def __init__(
         self,
@@ -213,6 +236,8 @@ class TorchScriptObjectVariable(UserDefinedObjectVariable):
         value: Any,
         ctor_args_kwargs: Any = None,
         source: Source | None = None,
+        ctor_arg_sources: tuple[Source | None, ...] | None = None,
+        ctor_kwarg_sources: dict[str, Source | None] | None = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(value, **kwargs)
@@ -223,6 +248,10 @@ class TorchScriptObjectVariable(UserDefinedObjectVariable):
         # If the OpaqueObject is sourceless, then this is
         # the constant (args, kwargs) that Dynamo used to construct it.
         self.ctor_args_kwargs = ctor_args_kwargs
+        # Sources of the constructor args/kwargs, used by subgraph reuse to
+        # resolve new values via source replacement on stamp-out.
+        self.ctor_arg_sources = ctor_arg_sources
+        self.ctor_kwarg_sources = ctor_kwarg_sources
 
     def as_proxy(self) -> Proxy:
         if not isinstance(self.proxy, torch.fx.Proxy):
@@ -233,15 +262,12 @@ class TorchScriptObjectVariable(UserDefinedObjectVariable):
                 from torch._dynamo.symbolic_convert import InstructionTranslator
 
                 tx = InstructionTranslator.current_tx()
-                # if any kwargs (synthetic_graph_input doesn't support them yet)
-                # not a graph break because hard error more explicit here
-                # (and opaque objects are really just used for compile)
-                if self.ctor_args_kwargs[1]:
-                    raise RuntimeError(
-                        "NYI: hoisted opaque objects that accept kwargs, please pass as args"
-                    )
                 hoisted_vt = tx.output.synthetic_graph_input(
-                    type(self.proxy), self.ctor_args_kwargs[0]
+                    type(self.proxy),
+                    self.ctor_args_kwargs[0],
+                    kwargs=self.ctor_args_kwargs[1] if self.ctor_args_kwargs[1] else None,
+                    ctor_arg_sources=self.ctor_arg_sources,
+                    ctor_kwarg_sources=self.ctor_kwarg_sources,
                 )
                 self.proxy = hoisted_vt.as_proxy()
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #176632
* #176631
* #176033
* #176477

Extend synthetic_graph_input to accept kwargs and generate CALL_KW
bytecode, and thread ctor_kwarg_sources through TorchScriptObjectVariable
so subgraph reuse can apply source replacement for keyword arguments.
This removes the hard error for opaque objects constructed with kwargs.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo