### PR TITLE
[nativert] Additional verbose logging for nativert optimizations

### DIFF
--- a/torch/nativert/executor/ConstantFolder.cpp
+++ b/torch/nativert/executor/ConstantFolder.cpp
@@ -123,10 +123,12 @@ void ConstantFolder::unlinkConstants(
     }
   }
 
-  for (const auto& f : foldables_) {
-    VLOG(1) << "Const-folded node: " << *f.node;
+  if (VLOG_IS_ON(1)) {
+    for (const auto& f : foldables_) {
+      VLOG(1) << "Const-folded node: " << *f.node;
+    }
+    VLOG(1) << "Const-folded " << foldables_.size() << " nodes";
   }
-  LOG(INFO) << "Const-folded " << foldables_.size() << " nodes";
 
   // remove moved (i.e., associated w/ const-folded nodes) kernels
   // from the input kernel vector

--- a/torch/nativert/graph/Graph.cpp
+++ b/torch/nativert/graph/Graph.cpp
@@ -553,6 +553,24 @@ bool Graph::cleanupDeadNodes() {
 
   const bool mutated = !toRemove.empty();
 
+  if (mutated && VLOG_IS_ON(1)) {
+    c10::FastMap<std::string_view, int> removedByTarget;
+    for (const auto* n : toRemove) {
+      removedByTarget[n->target()]++;
+    }
+    VLOG(1) << "cleanupDeadNodes: removing " << toRemove.size()
+            << " dead nodes. Breakdown by op:";
+    // Sort by count descending for readability
+    std::vector<std::pair<std::string_view, int>> sorted(
+        removedByTarget.begin(), removedByTarget.end());
+    std::sort(sorted.begin(), sorted.end(), [](const auto& a, const auto& b) {
+      return a.second > b.second;
+    });
+    for (const auto& [target, count] : sorted) {
+      VLOG(1) << "  " << target << ": " << count;
+    }
+  }
+
   // Remove nodes in reverse order to handle input/output dependencies
   for (auto it = toRemove.rbegin(); it != toRemove.rend(); ++it) {
     removeNode(*it);

--- a/torch/nativert/graph/passes/pass_manager/PassManager.cpp
+++ b/torch/nativert/graph/passes/pass_manager/PassManager.cpp
@@ -26,9 +26,27 @@ bool GraphPassManager::run(Graph* graph) {
 bool GraphPassManager::run_pass(Graph* graph, const GraphPassIdentifier& name) {
   const auto& pass = GraphPassRegistry::get().get_pass(name);
 
+  size_t nodesBefore = 0;
+  if (VLOG_IS_ON(1)) {
+    nodesBefore = graph->nodes().size();
+  }
+
   bool changed = pass_pre_run_hook(graph, pass);
   changed |= (pass.get())(graph);
   changed |= pass_post_run_hook(graph, pass);
+
+  if (VLOG_IS_ON(1)) {
+    size_t nodesAfter = graph->nodes().size();
+    if (changed) {
+      VLOG(1) << "Pass " << name << ": " << nodesBefore << " -> " << nodesAfter
+              << " nodes (delta: "
+              << static_cast<int64_t>(nodesAfter) -
+              static_cast<int64_t>(nodesBefore)
+              << ")";
+    } else {
+      VLOG(1) << "Pass " << name << ": no change (" << nodesAfter << " nodes)";
+    }
+  }
 
   return changed;
 }


### PR DESCRIPTION
Summary:
Add Claude skill for benchmarking TorchScript vs Sigmoid model latency

Automates the workflow for comparing inference performance between TorchScript 
and Sigmoid (PT2) models using load_net_predictor. Handles model download from 
Manifold, sample input extraction, and benchmark execution with correct flags 
per module type (local/merge/remote/input_dist). Ensures fair comparisons by 
using the same sample inputs for both model types.

Also adds verbose logging to help the claude skill understand what graph passes are takign effect

Test Plan:
Example outputs:
Doc: IG Reels Preproc: TS vs Sigmoid CPU Benchmark Results by Georgia Phillips
Visualization: https://www.internalfb.com/intern/px/p/91hvp/

Differential Revision: D94741035


