### PR TITLE
[dynamo] Support kwargs in OpaqueObject hoisting and subgraph reuse

### DIFF
--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -1019,12 +1019,19 @@ class OutputGraph(OutputGraphCommon):
         return [pack_subgraph_name, unpack_subgraph_name]
 
     def synthetic_graph_input(
-        self, fn: Callable[..., Any], args: tuple[Any, ...]
+        self,
+        fn: Callable[..., Any],
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any] | None = None,
+        ctor_arg_sources: tuple[Source | None, ...] | None = None,
+        ctor_kwarg_sources: dict[str, Source | None] | None = None,
     ) -> VariableTracker:
         """
-        call fn(*args) before the graph runs and turn the result into a fake input.
+        call fn(*args, **kwargs) before the graph runs and turn the result into a fake input.
         """
-        example_value = fn(*args)
+        if kwargs is None:
+            kwargs = {}
+        example_value = fn(*args, **kwargs)
         varname = self.new_var()
         cg = PyCodegen(self.root_tx)
         cg.add_push_null(
@@ -1034,7 +1041,14 @@ class OutputGraph(OutputGraphCommon):
             )
         )
         cg.foreach(map(variables.ConstantVariable.create, args))
-        cg.call_function(len(args), False)
+        if kwargs:
+            cg.foreach(map(variables.ConstantVariable.create, kwargs.values()))
+            nargs = len(args) + len(kwargs)
+            cg.extend_output(
+                cg.create_call_function_kw(nargs, tuple(kwargs.keys()), False)
+            )
+        else:
+            cg.call_function(len(args), False)
         cg.store(varname)
         self.pregraph_bytecode.extend(cg.get_instructions())
         source = SyntheticLocalSource(varname)

--- a/torch/_dynamo/variables/script_object.py
+++ b/torch/_dynamo/variables/script_object.py
@@ -189,8 +189,19 @@ class OpaqueObjectClassVariable(UserDefinedVariable):
             tx.output.fake_mode, opaque_obj
         )
 
+        # Capture sources from the VT args/kwargs so subgraph reuse can apply
+        # source replacement to resolve new ctor values on stamp-out.
+        ctor_arg_sources = tuple(getattr(a, "source", None) for a in args)
+        ctor_kwarg_sources = {
+            k: getattr(v, "source", None) for k, v in kwargs.items()
+        }
+
         return TorchScriptObjectVariable.create(
-            opaque_obj, fake_script_obj, (constant_args, constant_kwargs)
+            opaque_obj,
+            fake_script_obj,
+            (constant_args, constant_kwargs),
+            ctor_arg_sources=ctor_arg_sources,
+            ctor_kwarg_sources=ctor_kwarg_sources,
         )
 
 
@@ -203,9 +214,21 @@ class TorchScriptObjectVariable(UserDefinedObjectVariable):
 
     @staticmethod
     def create(
-        proxy: Proxy, value: Any, ctor_args_kwargs: Any = None, **options: Any
+        proxy: Proxy,
+        value: Any,
+        ctor_args_kwargs: Any = None,
+        ctor_arg_sources: tuple[Source | None, ...] | None = None,
+        ctor_kwarg_sources: dict[str, Source | None] | None = None,
+        **options: Any,
     ) -> "TorchScriptObjectVariable":
-        return TorchScriptObjectVariable(proxy, value, ctor_args_kwargs, **options)
+        return TorchScriptObjectVariable(
+            proxy,
+            value,
+            ctor_args_kwargs,
+            ctor_arg_sources=ctor_arg_sources,
+            ctor_kwarg_sources=ctor_kwarg_sources,
+            **options,
+        )
 
     def __init__(
         self,
@@ -213,6 +236,8 @@ class TorchScriptObjectVariable(UserDefinedObjectVariable):
         value: Any,
         ctor_args_kwargs: Any = None,
         source: Source | None = None,
+        ctor_arg_sources: tuple[Source | None, ...] | None = None,
+        ctor_kwarg_sources: dict[str, Source | None] | None = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(value, **kwargs)
@@ -223,6 +248,10 @@ class TorchScriptObjectVariable(UserDefinedObjectVariable):
         # If the OpaqueObject is sourceless, then this is
         # the constant (args, kwargs) that Dynamo used to construct it.
         self.ctor_args_kwargs = ctor_args_kwargs
+        # Sources of the constructor args/kwargs, used by subgraph reuse to
+        # resolve new values via source replacement on stamp-out.
+        self.ctor_arg_sources = ctor_arg_sources
+        self.ctor_kwarg_sources = ctor_kwarg_sources
 
     def as_proxy(self) -> Proxy:
         if not isinstance(self.proxy, torch.fx.Proxy):
@@ -233,15 +262,12 @@ class TorchScriptObjectVariable(UserDefinedObjectVariable):
                 from torch._dynamo.symbolic_convert import InstructionTranslator
 
                 tx = InstructionTranslator.current_tx()
-                # if any kwargs (synthetic_graph_input doesn't support them yet)
-                # not a graph break because hard error more explicit here
-                # (and opaque objects are really just used for compile)
-                if self.ctor_args_kwargs[1]:
-                    raise RuntimeError(
-                        "NYI: hoisted opaque objects that accept kwargs, please pass as args"
-                    )
                 hoisted_vt = tx.output.synthetic_graph_input(
-                    type(self.proxy), self.ctor_args_kwargs[0]
+                    type(self.proxy),
+                    self.ctor_args_kwargs[0],
+                    kwargs=self.ctor_args_kwargs[1] if self.ctor_args_kwargs[1] else None,
+                    ctor_arg_sources=self.ctor_arg_sources,
+                    ctor_kwarg_sources=self.ctor_kwarg_sources,
                 )
                 self.proxy = hoisted_vt.as_proxy()
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #176636
* __->__ #176635
* #176033
* #176477

Extend synthetic_graph_input to accept kwargs and generate CALL_KW
bytecode, and thread ctor_kwarg_sources through TorchScriptObjectVariable
so subgraph reuse can apply source replacement for keyword arguments.
This removes the hard error for opaque objects constructed with kwargs.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo