### PR TITLE
[Dynamo] Require `VariableTracker` args for `raise_observed_exception`

### DIFF
--- a/torch/_dynamo/exc.py
+++ b/torch/_dynamo/exc.py
@@ -47,6 +47,7 @@ from .utils import counters
 if TYPE_CHECKING:
     import types
 
+    from torch._dynamo.variables import VariableTracker
     from torch._guards import CompileId
 
     from .output_graph import DynamoTracerOutput
@@ -418,8 +419,8 @@ def raise_observed_exception(
     exc_type: type[Exception],
     tx: InstructionTranslatorBase,
     *,
-    args: list[Any] | None = None,
-    kwargs: dict[str, Any] | None = None,
+    args: list[VariableTracker] | None = None,
+    kwargs: dict[str, VariableTracker] | None = None,
 ) -> NoReturn:
     from .symbolic_convert import ExceptionVals
     from .variables.builder import SourcelessBuilder
@@ -427,9 +428,7 @@ def raise_observed_exception(
     # CPython here raises an exception. Since there is no python code, we have to manually setup the exception
     # stack and raise the exception.
     exception_vt = SourcelessBuilder.create(tx, exc_type).call_function(
-        tx,
-        [SourcelessBuilder.create(tx, a) for a in args] if args else [],
-        kwargs or {},
+        tx, args or [], kwargs or {}
     )
     assert isinstance(exception_vt, ExceptionVals)
     tx._attach_traceback_to_exception(exception_vt)

--- a/torch/_dynamo/variables/base.py
+++ b/torch/_dynamo/variables/base.py
@@ -595,7 +595,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
                 raise_observed_exception(
                     type(e),
                     tx,
-                    args=[list(map(variables.ConstantVariable.create, e.args))],
+                    args=list(map(variables.ConstantVariable.create, e.args)),
                 )
         hints = [
             f"Avoid calling `{self.python_type_name()}.{name}` in your code.",

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -2455,12 +2455,13 @@ class BuiltinVariable(VariableTracker):
         ):
             isinstance_type_tuple = isinstance_type
         else:
+            msg = VariableTracker.build(
+                tx, "isinstance() arg 2 must be a type, a tuple of types, or a union"
+            )
             raise_observed_exception(
                 TypeError,
                 tx,
-                args=[
-                    "isinstance() arg 2 must be a type, a tuple of types, or a union"
-                ],
+                args=[msg],
             )
 
         try:

--- a/torch/_dynamo/variables/constant.py
+++ b/torch/_dynamo/variables/constant.py
@@ -10,7 +10,7 @@ import enum
 import operator
 from collections.abc import Sequence
 from typing import Any, Literal, Optional, overload, TYPE_CHECKING
-from typing_extensions import Never, override
+from typing_extensions import override
 
 import torch
 from torch._dynamo.source import AttrSource, GetItemSource
@@ -45,15 +45,7 @@ class ConstantVariable(VariableTracker):
 
     @overload
     @staticmethod
-    def create(value: None) -> Never: ...
-
-    @overload
-    @staticmethod
-    def create(value: Literal[True]) -> Never: ...
-
-    @overload
-    @staticmethod
-    def create(value: Literal[False]) -> Never: ...
+    def create(value: None) -> "ConstantVariable": ...
 
     @overload
     @staticmethod
@@ -150,7 +142,7 @@ its type to `common_constant_types`.
         self, tx: "InstructionTranslator", arg: VariableTracker
     ) -> VariableTracker:
         return ConstantVariable.create(
-            self.value[arg.as_python_constant()],
+            self.value[arg.as_python_constant()],  # type: ignore[index]
         )
 
     @staticmethod
@@ -179,7 +171,8 @@ its type to `common_constant_types`.
 
     def const_getattr(self, tx: "InstructionTranslator", name: str) -> VariableTracker:
         if not hasattr(self.value, name):
-            raise_observed_exception(AttributeError, tx, args=[name])
+            name_variable = variables.ConstantVariable.create(name)
+            raise_observed_exception(AttributeError, tx, args=[name_variable])
         member = getattr(self.value, name)
         if callable(member):
             raise NotImplementedError
@@ -283,13 +276,13 @@ its type to `common_constant_types`.
 
         if name == "__len__" and not (args or kwargs):
             try:
-                return ConstantVariable.create(len(self.value))
+                return ConstantVariable.create(len(self.value))  # type: ignore[bad-argument-type]
             except TypeError as e:
                 raise_observed_exception(type(e), tx, args=list(e.args))
         elif name == "__round__" and len(args) == 1 and args[0].is_python_constant():
             try:
                 return ConstantVariable.create(
-                    round(self.value, args[0].as_python_constant())
+                    round(self.value, args[0].as_python_constant())  # type: ignore[no-matching-overload]
                 )
             except Exception as e:
                 raise_observed_exception(
@@ -299,7 +292,7 @@ its type to `common_constant_types`.
             assert not kwargs
             search = args[0].as_python_constant()
             try:
-                result = search in self.value
+                result = search in self.value  # type: ignore[not-iterable]
                 return ConstantVariable.create(result)
             except TypeError as e:
                 raise_observed_exception(

--- a/torch/_dynamo/variables/constant.py
+++ b/torch/_dynamo/variables/constant.py
@@ -10,7 +10,7 @@ import enum
 import operator
 from collections.abc import Sequence
 from typing import Any, Literal, Optional, overload, TYPE_CHECKING
-from typing_extensions import override
+from typing_extensions import Never, override
 
 import torch
 from torch._dynamo.source import AttrSource, GetItemSource
@@ -45,7 +45,15 @@ class ConstantVariable(VariableTracker):
 
     @overload
     @staticmethod
-    def create(value: None) -> "ConstantVariable": ...
+    def create(value: None) -> Never: ...
+
+    @overload
+    @staticmethod
+    def create(value: Literal[True]) -> Never: ...
+
+    @overload
+    @staticmethod
+    def create(value: Literal[False]) -> Never: ...
 
     @overload
     @staticmethod
@@ -142,7 +150,7 @@ its type to `common_constant_types`.
         self, tx: "InstructionTranslator", arg: VariableTracker
     ) -> VariableTracker:
         return ConstantVariable.create(
-            self.value[arg.as_python_constant()],  # type: ignore[index]
+            self.value[arg.as_python_constant()],
         )
 
     @staticmethod
@@ -276,13 +284,13 @@ its type to `common_constant_types`.
 
         if name == "__len__" and not (args or kwargs):
             try:
-                return ConstantVariable.create(len(self.value))  # type: ignore[bad-argument-type]
+                return ConstantVariable.create(len(self.value))
             except TypeError as e:
                 raise_observed_exception(type(e), tx, args=list(e.args))
         elif name == "__round__" and len(args) == 1 and args[0].is_python_constant():
             try:
                 return ConstantVariable.create(
-                    round(self.value, args[0].as_python_constant())  # type: ignore[no-matching-overload]
+                    round(self.value, args[0].as_python_constant())
                 )
             except Exception as e:
                 raise_observed_exception(
@@ -292,7 +300,7 @@ its type to `common_constant_types`.
             assert not kwargs
             search = args[0].as_python_constant()
             try:
-                result = search in self.value  # type: ignore[not-iterable]
+                result = search in self.value
                 return ConstantVariable.create(result)
             except TypeError as e:
                 raise_observed_exception(

--- a/torch/_dynamo/variables/dicts.py
+++ b/torch/_dynamo/variables/dicts.py
@@ -466,9 +466,8 @@ class ConstDictVariable(VariableTracker):
                     f"Debug representation of the key is {arg.debug_repr()!r}"
                 )
             except Exception:
-                error_message = VariableTracker.build(
-                    tx, f"Dict key lookup failed for {str(arg)}"
-                )
+                error_message = f"Dict key lookup failed for {str(arg)}"
+            error_message = VariableTracker.build(tx, error_message)
             raise_observed_exception(KeyError, tx, args=[error_message])
         return self.items[key]
 
@@ -898,9 +897,10 @@ class ConstDictVariable(VariableTracker):
                 new_dict_vt.items.update(args[0].items)  # type: ignore[attr-defined]
                 return new_dict_vt
             else:
-                err_msg = (
+                err_msg = VariableTracker.build(
+                    tx,
                     f"unsupported operand type(s) for |: '{self.python_type().__name__}'"
-                    f"and '{other.python_type().__name__}'"
+                    f"and '{other.python_type().__name__}'",
                 )
                 raise_observed_exception(TypeError, tx, args=[err_msg])
         elif name == "__ior__":

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -135,9 +135,8 @@ class BaseListVariable(VariableTracker):
             try:
                 return self.items[index]
             except IndexError:
-                raise_observed_exception(
-                    IndexError, tx, args=["list index out of range"]
-                )
+                error_message = VariableTracker.build(tx, "list index out of range")
+                raise_observed_exception(IndexError, tx, args=[error_message])
 
     def unpack_var_sequence(self, tx: "InstructionTranslator") -> list[VariableTracker]:
         return list(self.items)
@@ -401,7 +400,10 @@ class BaseListVariable(VariableTracker):
                     op_str = cmp_name_to_op_str_mapping[name]
                     left_ty = left.python_type_name()
                     right_ty = right.python_type_name()
-                    msg = f"{op_str} not supported between instances of '{left_ty}' and '{right_ty}'"
+                    msg = VariableTracker.build(
+                        tx,
+                        f"{op_str} not supported between instances of '{left_ty}' and '{right_ty}'",
+                    )
                     raise_observed_exception(TypeError, tx, args=[msg])
 
             return SourcelessBuilder.create(tx, polyfills.list_cmp).call_function(
@@ -1276,9 +1278,10 @@ class DequeVariable(CommonListMethodsVariable):
                     f"{len(args)} args and {len(kwargs)} kwargs",
                 )
             if maxlen is not None and len(self.items) == maxlen:
-                raise_observed_exception(
-                    IndexError, tx, args=["deque already at its maximum size"]
+                error_message = VariableTracker.build(
+                    tx, "deque already at its maximum size"
                 )
+                raise_observed_exception(IndexError, tx, args=[error_message])
             result = super().call_method(tx, name, args, kwargs)
         else:
             result = super().call_method(tx, name, args, kwargs)

--- a/torch/_dynamo/variables/nn_module.py
+++ b/torch/_dynamo/variables/nn_module.py
@@ -116,14 +116,13 @@ def initialize_lazy_module(
             mod._infer_parameters(mod, fake_args, fake_kwargs)  # type: ignore[operator]
         except AttributeError as e:
             # Re-raise with the original error message from the AttributeError
+            error_message = VariableTracker.build(
+                tx, str(e) or "AttributeError during lazy module initialization"
+            )
             raise_observed_exception(
                 AttributeError,
                 tx,
-                args=[
-                    str(e)
-                    if str(e)
-                    else "AttributeError during lazy module initialization"
-                ],
+                args=[error_message],
             )
 
 
@@ -406,10 +405,13 @@ class NNModuleVariable(VariableTracker):
                 if result is not None:
                     return result
                 # if we can't find a __getattr__, we can't parse this, raise attribute error
+                error_message = VariableTracker.build(
+                    tx, f"'{type(base).__name__}' object has no attribute '{name}'"
+                )
                 raise_observed_exception(
                     AttributeError,
                     tx,
-                    args=[f"'{type(base).__name__}' object has no attribute '{name}'"],
+                    args=[error_message],
                 )
 
         if name == "forward":
@@ -1345,12 +1347,14 @@ class UnspecializedNNModuleVariable(UserDefinedObjectVariable):
         if out is None:
             out = self.getattr_helper(tx, "_buffers", name_vt)
         if out is None:
+            error_message = VariableTracker.build(
+                tx,
+                f"'{type(self.value).__name__}' object has no attribute '{name}'",
+            )
             raise_observed_exception(
                 AttributeError,
                 tx,
-                args=[
-                    f"'{type(self.value).__name__}' object has no attribute '{name}'"
-                ],
+                args=[error_message],
             )
         assert out is not None
         return out

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -384,12 +384,14 @@ class TensorVariable(VariableTracker):
         try:
             real_value = getattr(_input_associated_real_value, name)
         except AttributeError:
+            error_message = VariableTracker.build(
+                tx,
+                f"'{type(_input_associated_real_value).__name__}' object has no attribute '{name}'",
+            )
             raise_observed_exception(
                 AttributeError,
                 tx,
-                args=[
-                    f"'{type(_input_associated_real_value).__name__}' object has no attribute '{name}'"
-                ],
+                args=[error_message],
             )
 
         attr_source = AttrSource(self.source, name)

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -321,12 +321,13 @@ class UserDefinedClassVariable(UserDefinedVariable):
             obj = inspect.getattr_static(self.value, name)
         except AttributeError:
             if type(self.value) is type:
+                error_message = VariableTracker.build(
+                    tx, f"type object '{self.value.__name__}' has no attribute '{name}'"
+                )
                 raise_observed_exception(
                     AttributeError,
                     tx,
-                    args=[
-                        f"type object '{self.value.__name__}' has no attribute '{name}'"
-                    ],
+                    args=[error_message],
                 )
 
         if name == "__new__" and UserDefinedClassVariable.is_supported_new_method(obj):
@@ -1731,12 +1732,14 @@ class UserDefinedObjectVariable(UserDefinedVariable):
         if tx.output.side_effects.has_pending_mutation_of_attr(self, name):
             result = tx.output.side_effects.load_attr(self, name, deleted_ok=True)
             if isinstance(result, variables.DeletedVariable):
+                error_message = VariableTracker.build(
+                    tx,
+                    f"'{type(self.value).__name__}' object has no attribute '{name}'",
+                )
                 raise_observed_exception(
                     AttributeError,
                     tx,
-                    args=[
-                        f"'{type(self.value).__name__}' object has no attribute '{name}'"
-                    ],
+                    args=[error_message],
                 )
             return result
 
@@ -1857,10 +1860,13 @@ class UserDefinedObjectVariable(UserDefinedVariable):
             )
 
         # Step 7: AttributeError.
+        error_message = VariableTracker.build(
+            tx, f"'{type(self.value).__name__}' object has no attribute '{name}'"
+        )
         raise_observed_exception(
             AttributeError,
             tx,
-            args=[f"'{type(self.value).__name__}' object has no attribute '{name}'"],
+            args=[error_message],
         )
 
     def resolve_data_descriptor(
@@ -1895,12 +1901,13 @@ class UserDefinedObjectVariable(UserDefinedVariable):
         try:
             resolved = type(self.value).__getattribute__(self.value, name)
         except AttributeError:
+            error_message = VariableTracker.build(
+                tx, f"'{type(self.value).__name__}' object has no attribute '{name}'"
+            )
             raise_observed_exception(
                 AttributeError,
                 tx,
-                args=[
-                    f"'{type(self.value).__name__}' object has no attribute '{name}'"
-                ],
+                args=[error_message],
             )
         return VariableTracker.build(tx, resolved, source)
 


### PR DESCRIPTION
When people use `raise_observed_exception`, they often forget to wrap the arguments in `VariableTracker` objects.

(Suggested by @guilhermeleobas.)

There were a few cases in `constant.py` where `lintrunner` gave (unrelated, AFAICS) type check errors; I'm not sure why these didn't surface before. These were all of the type where someone calls a method, say `__len__`, on a VariableTracker, and pyrefly complains that this may fail. But the code is already in a try/except block, so it is okay. I added `type: ignore[...]` annotations to these.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo