### PR TITLE
Fix MPS memory leak in getStridedMPSNDArray: autorelease NSArray copies

### DIFF
--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -484,8 +484,8 @@ MPSNDArray* getStridedMPSNDArray(const TensorBase& src, MPSNDArray* srcNDArray) 
   MPSShape* originalSortedStridesShape = sortedStridesShape;
   bool hasNonZeroStrides = nStrides == 0 ? false : nonZeroStrides[sortedStridesIndices[nStrides - 1]] != 1;
   if (hasNonZeroStrides) {
-    originalSortedMPSShape = [sortedMPSShape copy];
-    originalSortedStridesShape = [sortedStridesShape copy];
+    originalSortedMPSShape = [[sortedMPSShape copy] autorelease];
+    originalSortedStridesShape = [[sortedStridesShape copy] autorelease];
     [sortedStridesShape addObject:[NSNumber numberWithInteger:1]];
     [sortedMPSShape addObject:[NSNumber numberWithInteger:1]];
   }


### PR DESCRIPTION
I noticed a memory leak while training on MPS. Instruments Allocations showed it was coming from getStridedMPSNDArray. Looking at the code, two copy calls return retained NSArray objects that are never released. Adding autorelease fixes it.

See attached screenshot.

<img width="1716" height="993" alt="Pytorch_MPS_Before_Fix" src="https://github.com/user-attachments/assets/ab8c4828-60e9-4925-87f7-a3e9d74ddade" />

<img width="1716" height="993" alt="Pytorch_MPS_After_Fix" src="https://github.com/user-attachments/assets/254e7a07-9783-4f28-b94d-c64ff8396c3d" />
