### PR TITLE
Fix: Preserve FSDP mixed precision during non-reentrant checkpoint recompute

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_training.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_training.py
@@ -2018,9 +2018,7 @@ class TestFullyShardWorldSize1(FSDPTest):
                 super().__init__()
                 self.linear = nn.Linear(dim, dim)
 
-            def forward(
-                self, x: torch.Tensor, cpu_bias: torch.Tensor
-            ) -> torch.Tensor:
+            def forward(self, x: torch.Tensor, cpu_bias: torch.Tensor) -> torch.Tensor:
                 observed_cpu_bias_devices.append(cpu_bias.device)
                 test_case.assertEqual(cpu_bias.device.type, "cpu")
                 return self.linear(x + cpu_bias.to(device=x.device, dtype=x.dtype))

--- a/test/distributed/_composable/fsdp/test_fully_shard_training.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_training.py
@@ -22,6 +22,7 @@ from torch.distributed.fsdp import (
     CPUOffloadPolicy,
     FSDPModule,
     fully_shard,
+    MixedPrecisionPolicy,
     OffloadPolicy,
     register_fsdp_forward_method,
     share_comm_ctx,
@@ -89,6 +90,13 @@ class TestFullyShardForwardInputs(FSDPTestMultiThread):
     def world_size(self) -> int:
         return 2
 
+    def _get_test_mp_dtype(self, device: torch.device) -> torch.dtype:
+        if device.type == "cuda":
+            return torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+        if device.type == "cpu":
+            return torch.bfloat16
+        self.skipTest("mixed precision checkpoint regression is scoped to CPU/CUDA")
+
     def test_root_move_forward_input_to_device(self):
         device = torch.device(device_type.type, 0)
 
@@ -116,6 +124,55 @@ class TestFullyShardForwardInputs(FSDPTestMultiThread):
         self.assertEqual(ys[0].device, torch.device("cpu"))
         self.assertEqual(ys[1].device, torch.device("cpu"))
         model(x, ys)
+
+    def test_cast_forward_inputs_applied_during_checkpoint_recompute(self):
+        class SinModule(nn.Module):
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                return torch.sin(x)
+
+        device = torch.device(device_type.type, 0)
+        mp_dtype = self._get_test_mp_dtype(device)
+        model = SinModule().to(device)
+        fully_shard(
+            model,
+            mp_policy=MixedPrecisionPolicy(param_dtype=mp_dtype),
+        ).to(device)
+        x = torch.randn(8, dtype=torch.float32, requires_grad=True)
+        if device.type != "cpu":
+            self.assertEqual(x.device, torch.device("cpu"))
+        y = torch.utils.checkpoint.checkpoint(model, x, use_reentrant=False)
+        self.assertEqual(y.dtype, mp_dtype)
+        self.assertEqual(y.device.type, device.type)
+        y.sum().backward()
+
+    def test_output_dtype_applied_during_checkpoint_recompute(self):
+        class SinModule(nn.Module):
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                return torch.sin(x)
+
+        device = torch.device(device_type.type, 0)
+        output_dtype = self._get_test_mp_dtype(device)
+        model = SinModule().to(device)
+        fully_shard(
+            model,
+            mp_policy=MixedPrecisionPolicy(output_dtype=output_dtype),
+        ).to(device)
+        observed_output_dtypes: list[torch.dtype] = []
+
+        def run(x: torch.Tensor) -> torch.Tensor:
+            y = model(x)
+            observed_output_dtypes.append(y.dtype)
+            return y
+
+        x = torch.randn(8, dtype=torch.float32, requires_grad=True)
+        if device.type != "cpu":
+            self.assertEqual(x.device, torch.device("cpu"))
+        with torch.utils.checkpoint.set_checkpoint_early_stop(False):
+            y = torch.utils.checkpoint.checkpoint(run, x, use_reentrant=False)
+        self.assertEqual(y.dtype, output_dtype)
+        self.assertEqual(y.device.type, device.type)
+        y.sum().backward()
+        self.assertEqual(observed_output_dtypes, [output_dtype, output_dtype])
 
 
 class TestFullyShardRegisteredParams(FSDPTestMultiThread):
@@ -1948,6 +2005,50 @@ class TestFullyShardWorldSize1(FSDPTest):
     @property
     def world_size(self) -> int:
         return 1
+
+    def test_non_root_checkpoint_recompute_preserves_cpu_inputs(self):
+        if device_type.type == "cpu":
+            self.skipTest("requires accelerator input-device movement")
+        device = torch.device(device_type.type, self.rank)
+        observed_cpu_bias_devices: list[torch.device] = []
+        test_case = self
+
+        class Inner(nn.Module):
+            def __init__(self, dim: int) -> None:
+                super().__init__()
+                self.linear = nn.Linear(dim, dim)
+
+            def forward(
+                self, x: torch.Tensor, cpu_bias: torch.Tensor
+            ) -> torch.Tensor:
+                observed_cpu_bias_devices.append(cpu_bias.device)
+                test_case.assertEqual(cpu_bias.device.type, "cpu")
+                return self.linear(x + cpu_bias.to(device=x.device, dtype=x.dtype))
+
+        class Model(nn.Module):
+            def __init__(self, dim: int) -> None:
+                super().__init__()
+                self.pre = nn.Linear(dim, dim)
+                self.inner = Inner(dim)
+
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                x = self.pre(x)
+                cpu_bias = torch.arange(x.size(-1), dtype=torch.float32, device="cpu")
+                cpu_bias = cpu_bias.expand_as(x)
+                return torch.utils.checkpoint.checkpoint(
+                    self.inner,
+                    x,
+                    cpu_bias,
+                    use_reentrant=False,
+                )
+
+        model = Model(dim=8).to(device)
+        fully_shard(model.inner).to(device)
+        fully_shard(model).to(device)
+        x = torch.randn(4, 8, dtype=torch.float32, requires_grad=True)
+        out = model(x)
+        out.sum().backward()
+        self.assertEqual(observed_cpu_bias_devices, [torch.device("cpu")] * 2)
 
     def test_train_parity_single_worldsize1(self):
         """

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -91,6 +91,7 @@ from torch.utils.checkpoint import (
     checkpoint_sequential,
     CheckpointPolicy,
     create_selective_checkpoint_contexts,
+    set_checkpoint_early_stop,
 )
 from torch.utils.flop_counter import FlopCounterMode
 
@@ -7388,6 +7389,69 @@ for shape in [(1,), ()]:
         non-reentrant checkpoint recomputation on GPU.
         """
         self._test_checkpointing_non_reentrant_autocast(device_type="cuda")
+
+    def _run_checkpointing_non_reentrant_autocast_with_grad_toggle(
+        self, device_type: str
+    ) -> None:
+        seen_mm_dtypes: list[torch.dtype] = []
+
+        class Block(nn.Module):
+            def __init__(self, size: int):
+                super().__init__()
+                self.probe_weight = nn.Parameter(torch.randn(size, size))
+                self.norm = nn.LayerNorm(size)
+                self.linear = nn.Linear(size, size)
+
+            def forward(self, x):
+                probe = torch.mm(self.probe_weight, self.probe_weight)
+                seen_mm_dtypes.append(probe.dtype)
+                return self.linear(self.norm(x)) + probe[0]
+
+        class PairStack(nn.Module):
+            def __init__(self, size: int):
+                super().__init__()
+                self.block = Block(size)
+
+            def forward(self, x):
+                if torch.is_grad_enabled():
+                    return checkpoint(self.block, x, use_reentrant=False)
+                return self.block(x)
+
+        class Mod(nn.Module):
+            def __init__(self, size: int):
+                super().__init__()
+                self.stack = PairStack(size)
+                self.linear = nn.Linear(size, size)
+
+            def forward(self, x):
+                with torch.set_grad_enabled(False):
+                    x = self.stack(x)
+                x = self.stack(x)
+                return self.linear(x)
+
+        size = 64
+        model = Mod(size=size)
+        x = torch.linspace(0, 1, 2 * 3 * size).reshape(2, 3, size)
+        if device_type == "cuda":
+            model = model.cuda()
+            x = x.cuda()
+        with set_checkpoint_early_stop(False):
+            with torch.autocast(device_type=device_type, dtype=torch.bfloat16):
+                out = model(x)
+        out.sum().backward()
+        self.assertGreaterEqual(len(seen_mm_dtypes), 3)
+        self.assertEqual(seen_mm_dtypes[-1], torch.bfloat16)
+        self.assertEqual(seen_mm_dtypes[-2], torch.bfloat16)
+
+    def test_checkpointing_non_reentrant_autocast_with_grad_toggle_cpu(self):
+        self._run_checkpointing_non_reentrant_autocast_with_grad_toggle("cpu")
+
+    @unittest.skipIf(
+        not torch.cuda.is_available() or not torch.cuda.is_bf16_supported(),
+        "Test requires CUDA bf16 support",
+    )
+    def test_checkpointing_non_reentrant_autocast_with_grad_toggle_cuda(self):
+        self._run_checkpointing_non_reentrant_autocast_with_grad_toggle("cuda")
 
     @unittest.skipIf(not torch.cuda.is_available(), "Test requires CUDA")
     @slowTest

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_state.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_state.py
@@ -88,6 +88,9 @@ class FSDPState(_State):
         self._states_to_forward_prefetch: list[FSDPState] = []
         self._states_to_backward_prefetch: list[FSDPState] = []
         self._modules_to_run_forward: set[nn.Module] = set()
+        # Activation checkpoint recompute should only replay input-to-device
+        # movement for module forwards that originally ran as the iteration root.
+        self._needs_input_device_move_for_recompute: list[bool] = []
         # ``False`` when user set reshard_after_forward
         # through ``fully_shard`` or ``set_reshard_after_forward``
         self._auto_reshard_after_forward: bool | None = True
@@ -168,18 +171,24 @@ class FSDPState(_State):
                 current_stream = self._device_handle.current_stream()
                 self._comm_ctx.all_gather_copy_in_stream.wait_stream(current_stream)
                 self._comm_ctx.all_gather_stream.wait_stream(current_stream)
-            if self._device.type in [
-                "cuda",
-                "hpu",
-                "xpu",
-                "mtia",
-                torch._C._get_privateuse1_backend_name(),
-            ]:
-                with torch.profiler.record_function("FSDP::inputs_to_device"):
-                    args_tuple, kwargs_tuple = _to_kwargs(
-                        args, kwargs, self._device, False
-                    )  # same as DDP
-                args, kwargs = args_tuple[0], kwargs_tuple[0]
+            args, kwargs = self._move_forward_inputs_to_device(args, kwargs)
+        return args, kwargs
+
+    def _move_forward_inputs_to_device(
+        self, args: tuple[Any, ...], kwargs: dict[str, Any]
+    ) -> tuple[tuple[Any, ...], dict[str, Any]]:
+        if self._device.type in [
+            "cuda",
+            "hpu",
+            "xpu",
+            "mtia",
+            torch._C._get_privateuse1_backend_name(),
+        ]:
+            with torch.profiler.record_function("FSDP::inputs_to_device"):
+                args_tuple, kwargs_tuple = _to_kwargs(
+                    args, kwargs, self._device, False
+                )  # same as DDP
+            return args_tuple[0], kwargs_tuple[0]
         return args, kwargs
 
     def _lazy_init(self) -> None:
@@ -284,6 +293,20 @@ class FSDPState(_State):
                 if not fsdp_param_group.is_unsharded:
                     fsdp_param_group.unshard()
                     fsdp_param_group.wait_for_unshard()
+            if (
+                self._needs_input_device_move_for_recompute
+                and self._needs_input_device_move_for_recompute.pop()
+            ):
+                args, kwargs = self._move_forward_inputs_to_device(args, kwargs)
+            if self._mp_policy.cast_forward_inputs and self._mp_policy.param_dtype:
+                with torch.profiler.record_function("FSDP::cast_forward_inputs"):
+                    cast_fn = functools.partial(
+                        _cast_fp_tensor, self._mp_policy.param_dtype
+                    )
+                    args, kwargs = (
+                        _apply_to_tensors(cast_fn, args),
+                        _apply_to_tensors(cast_fn, kwargs),
+                    )
             return args, kwargs
         self._training_state = TrainingState.FORWARD
         args, kwargs = self._root_pre_forward(module, args, kwargs)
@@ -308,10 +331,21 @@ class FSDPState(_State):
         # When composing with module-hook-based activation checkpointing, the
         # post-backward hook is responsible for the reshard
         if self._training_state == TrainingState.PRE_BACKWARD:
+            if self._mp_policy.output_dtype is not None:
+                with torch.profiler.record_function("FSDP::cast_forward_outputs"):
+                    output = _apply_to_tensors(
+                        functools.partial(
+                            _cast_fp_tensor, self._mp_policy.output_dtype
+                        ),
+                        output,
+                    )
             return output
         for fsdp_param_group in self._fsdp_param_groups:
             output = fsdp_param_group.post_forward(module, input, output)
-        output = self._register_pre_backward_hook(output)
+        output = self._register_pre_backward_hook(
+            output,
+            move_inputs_to_device=self._state_ctx.iter_forward_root is self,
+        )
         self._training_state = TrainingState.IDLE
         if self._state_ctx.iter_forward_root is self:
             if all_gather_state := self._comm_ctx.all_gather_state:
@@ -354,6 +388,7 @@ class FSDPState(_State):
                         fsdp_param_group.post_backward()
                     fsdp_param_group._training_state = TrainingState.IDLE
                 state._training_state = TrainingState.IDLE
+                state._needs_input_device_move_for_recompute.clear()
                 if self._state_ctx.is_last_backward:
                     state._finalize_backward()
             if self._state_ctx.is_last_backward:
@@ -366,6 +401,7 @@ class FSDPState(_State):
             self._state_ctx.post_backward_final_callback_queued = False
 
     def _finalize_backward(self) -> None:
+        self._needs_input_device_move_for_recompute.clear()
         if self._modules_to_run_forward:
             msg = (
                 f"{len(self._modules_to_run_forward)} of the {len(self._modules)} "
@@ -381,13 +417,26 @@ class FSDPState(_State):
         for fsdp_param_group in self._fsdp_param_groups:
             fsdp_param_group.finalize_backward()
 
-    def _register_pre_backward_hook(self, output: Any) -> Any:
+    def _register_pre_backward_hook(
+        self, output: Any, move_inputs_to_device: bool
+    ) -> Any:
         if not torch.is_grad_enabled():
             return output
         flat_outputs, _ = tree_flatten(output)
+        seen_graph_task_ids: set[int] = set()
+
+        def pre_backward(grad: torch.Tensor) -> torch.Tensor:
+            graph_task_id = torch._C._current_graph_task_id()
+            if graph_task_id not in seen_graph_task_ids:
+                self._needs_input_device_move_for_recompute.append(
+                    move_inputs_to_device
+                )
+                seen_graph_task_ids.add(graph_task_id)
+            return self._pre_backward(grad)
+
         for t in flat_outputs:
             if torch.is_tensor(t) and t.requires_grad:
-                t.register_hook(self._pre_backward)
+                t.register_hook(pre_backward)
         return output
 
     def _register_root_post_backward_final_callback(self):


### PR DESCRIPTION
Fixes #148831

Composable FSDP (`fully_shard`) recomputation under `torch.utils.checkpoint.checkpoint(..., use_reentrant=False)` did not fully mirror the original forward, which could cause checkpoint metadata mismatches during recompute, including dtype and device mismatches.

### changes
- Preserves `MixedPrecisionPolicy.param_dtype` casting of forward inputs during recomputation.
- Preserves `MixedPrecisionPolicy.output_dtype` casting of forward outputs during recomputation.
- Replays "move inputs to FSDP device" during recomputation only for module forwards that originally executed as the iteration root, so non-root checkpointed modules do not incorrectly move CPU inputs to the FSDP device.

### Tests
Added regression coverage for:
- recompute with `param_dtype`
- recompute with `output_dtype`
- non-root recompute preserving CPU inputs
- non-reentrant checkpoint autocast with grad-enabled toggling on CPU and CUDA
- External repros and a stress run passed.