### PR TITLE
[Fix] Revert support for pull request review comments in Claude Code review workflow

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -3,8 +3,6 @@ name: Claude Code
 on:
   issue_comment:
     types: [created]
-  pull_request_review_comment:
-    types: [created]
   issues:
     types: [opened]
 
@@ -20,11 +18,11 @@ jobs:
       (
         (github.event_name != 'issues' &&
          contains(github.event.comment.body, '@claude') &&
-         (contains(fromJSON('["OWNER","MEMBER","COLLABORATOR","CONTRIBUTOR"]'), github.event.comment.author_association) ||
+         (contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) ||
           github.actor == 'pytorch-auto-revert[bot]')) ||
         (github.event_name == 'issues' &&
          contains(github.event.issue.body, '@claude') &&
-         (contains(fromJSON('["OWNER","MEMBER","COLLABORATOR","CONTRIBUTOR"]'), github.event.issue.author_association) ||
+         (contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association) ||
           github.actor == 'pytorch-auto-revert[bot]'))
       )
     runs-on: ubuntu-latest


### PR DESCRIPTION
`pull_request_review_comment` is unsafe, as the workflow code runs from the PR branch, see:
https://github.com/orgs/community/discussions/55940#discussioncomment-5950832

in our usecase it creates an easy way to trick maintainer into execute arbitrary code on the runner by requesting claude review (much easier than via prompt injection)

---

we might add a support for inline review requests in the future, but for now removing the trigger to err on the safe side.