### PR TITLE
[inductor] Add guard-based tt.divisibility=16 hints for dynamic shapes

### DIFF
--- a/test/inductor/test_codegen_triton.py
+++ b/test/inductor/test_codegen_triton.py
@@ -98,6 +98,44 @@ class TestCodegenTriton(InductorTestCase):
             ),
         )
 
+    @inductor_config.patch("triton.divisible_by_16", True)
+    def test_config_of_dynamic_shapes_hint_divisibility(self):
+        """Guard-based tt.divisibility=16 for backed symbolic SizeArgs.
+
+        When dynamic=True, numel args are symbolic but have concrete backing
+        values. If the backing value is divisible by 16, config_of() should
+        install a guard and emit the hint, recovering vectorization.
+        """
+        from torch._dynamo.source import ConstantSource
+        from torch.fx.experimental.symbolic_shapes import ShapeEnv
+
+        shape_env = ShapeEnv()
+        s0 = shape_env.create_symbol(512, source=ConstantSource("s0"))
+        s1 = shape_env.create_symbol(2048, source=ConstantSource("s1"))
+        s2 = shape_env.create_symbol(13, source=ConstantSource("s2"))
+
+        gm = torch.fx.symbolic_trace(
+            type("M", (torch.nn.Module,), {"forward": lambda self, x: x * 2})()
+        )
+        graph = GraphLowering(gm, shape_env=shape_env)
+
+        with V.set_graph_handler(graph):
+            cfg = triton_utils.config_of(
+                [
+                    SizeArg("xnumel", s0 * s1),  # 0: 1048576, div by 16
+                    SizeArg("r0_numel", s0),  # 1: 512, div by 16
+                    SizeArg("r1_numel", s2),  # 2: 13, NOT div by 16
+                    SizeArg("ks0", s0 * s2),  # 3: 6656, div by 16
+                ]
+            )
+
+        # cfg is a dict like {(idx,): [["tt.divisibility", 16]], ...}
+        if not isinstance(cfg, dict):
+            self.skipTest("Test only applies to dict-based Triton attrs API")
+        for idx in (0, 1, 3):
+            self.assertIn(["tt.divisibility", 16], cfg[(idx,)])
+        self.assertNotIn((2,), cfg)
+
 
 if __name__ == "__main__":
     from torch._inductor.test_case import run_tests

--- a/torch/_inductor/codegen/triton_utils.py
+++ b/torch/_inductor/codegen/triton_utils.py
@@ -258,6 +258,25 @@ def config_of(
             for i, arg in zip(indices, args)
             if is_aligned(arg, alignment=16, include_tensor=True)
         )
+        # Use the concrete hint value to determine if we can consider
+        # this arg as divisible by 16 and install guards if so.
+        # This recovers vectorization for dynamic=True compilation
+        # where symbolic proof fails but the concrete shape is aligned.
+        # If a future input breaks this guard, Dynamo recompiles.
+        for i, arg in zip(indices, args):
+            if i in divisible_by_16:
+                continue
+            if isinstance(arg, SizeArg) and arg.expr is not None:
+                if isinstance(arg.expr, float):
+                    continue
+                try:
+                    hint = V.graph.sizevars.guarding_hint_or_throw(arg.expr)
+                except Exception:
+                    continue
+                if hint % 16 == 0:
+                    guard_expr = sympy.Eq(arg.expr % 16, 0)
+                    V.graph.sizevars.expect_true(guard_expr)
+                    divisible_by_16 = divisible_by_16 + (i,)
     else:
         divisible_by_16 = ()
 


### PR DESCRIPTION
Following https://github.com/pytorch/pytorch/pull/175755

When `torch.compile(dynamic=True)` is used, TorchInductor generates Triton kernels where numel arguments (xnumel, rnumel, etc.) are symbolic. The existing `statically_known_multiple_of` check in `config_of()` cannot prove these symbolic expressions are divisible by 16, so `tt.divisibility=16` is not emitted. Without this hint, Triton falls back from vectorized loads (LDG.E.128) to scalar loads (LDG.E.16), causing `1.5x-3.4x slowdowns` across many operation types e.g. `pointwise, reduction, normalization`.

This patch adds a fallback path: when the static divisibility proof fails for a SizeArg, we check the concrete backing value via `guarding_hint_or_throw()`. If divisible by 16, we install a guard via `expect_true(Eq(expr % 16, 0))` so Dynamo will recompile if a future input breaks this assumption. This is analogous to how nvFuser evaluates vectorization heuristics with concrete runtime shapes and recompiles when heuristics change.

Benchmarked on GB200 (SM 10.0) with bf16, shape (8192, 73728) with ops defined at [nvFuser repo](https://github.com/NVIDIA/Fuser/blob/main/benchmarks/python/torch_ops.py).
<img width="2154" height="1130" alt="image" src="https://github.com/user-attachments/assets/33842403-bd40-42b1-a4f8-bbdf12483731" />

Fixes: https://github.com/pytorch/pytorch/issues/175752

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo