### PR TITLE
[GHF] Update MPS mergerules

### DIFF
--- a/.github/merge_rules.yaml
+++ b/.github/merge_rules.yaml
@@ -198,9 +198,12 @@
 - name: MPS
   patterns:
   - test/test_mps.py
+  - test/inductor/test_mps_basic.py
+  - torch/testing/_internal/common_mps.py
   - aten/src/ATen/native/native_functions.yaml
   - aten/src/ATen/mps/**
   - aten/src/ATen/native/mps/**
+  - c10/metal/**
   approved_by:
   - malfet
   - DenisVieriu97

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -122,6 +122,7 @@ torch/_subclasses/fake_utils.py @aorenste
 
 # torch MPS
 test/test_mps.py @malfet
+c10/metal/ @malfet
 aten/src/ATen/mps/ @malfet
 aten/src/ATen/native/mps/ @malfet
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #176654

Add `c10/metal` and `test/inductor/test_mps_basic.py` to the rules