### PR TITLE
[BE] Do not checkout submodules during test jobs

### DIFF
--- a/.ci/pytorch/macos-test.sh
+++ b/.ci/pytorch/macos-test.sh
@@ -49,6 +49,8 @@ test_python_mps() {
 test_python_openreg() {
   setup_test_python
 
+  git submodule update --init --depth 1 third_party/googletest
+
   time python test/run_test.py --openreg --verbose
 
   assert_git_not_dirty

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -1851,6 +1851,7 @@ test_attention_microbenchmark() {
 }
 
 test_openreg() {
+  git submodule update --init --depth 1 third_party/googletest
   python test/run_test.py --openreg --verbose
   assert_git_not_dirty
 }

--- a/.ci/pytorch/win-test-helpers/test_openreg.bat
+++ b/.ci/pytorch/win-test-helpers/test_openreg.bat
@@ -6,6 +6,8 @@ if not errorlevel 0 (
   exit /b
 )
 
+git submodule update --init --depth 1 third_party/googletest
+
 pushd test
 
 echo Run openreg tests

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -117,6 +117,7 @@ jobs:
         with:
           no-sudo: true
           checkout-mode: treeless
+          submodules: false
 
       - name: Setup Python
         if: contains(matrix.runner, 'b200')

--- a/.github/workflows/_mac-test.yml
+++ b/.github/workflows/_mac-test.yml
@@ -110,6 +110,8 @@ jobs:
       # [see note: pytorch repo ref]
       - name: Checkout PyTorch
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@main
+        with:
+          submodules: false
 
       - name: Get workflow job id
         id: get-job-id

--- a/.github/workflows/_win-test.yml
+++ b/.github/workflows/_win-test.yml
@@ -97,6 +97,7 @@ jobs:
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@main
         with:
           no-sudo: true
+          submodules: false
 
       - name: Setup Windows
         uses: ./.github/actions/setup-win


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #176655

As we don't really need them, and it reduced `Checkout PyTorch` step from 75s to 15s

Hattip to @yangw-dev for the idea