### PR TITLE
[inductor][cache] allow caching for unused graph placeholders

### DIFF
--- a/test/distributed/tensor/test_dtensor_compile.py
+++ b/test/distributed/tensor/test_dtensor_compile.py
@@ -4,6 +4,7 @@
 import contextlib
 import copy
 import functools
+import logging
 import unittest
 from unittest.mock import patch
 
@@ -1660,6 +1661,45 @@ class outer_fn(torch.nn.Module):
 
         # Test backward pass
         result.sum().backward()
+
+    @torch._functorch.config.patch(enable_autograd_cache=False)
+    @torch._inductor.config.patch(fx_graph_cache=True)
+    @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
+    def test_dtensor_compile_inductor_fxgraphcache(self):
+        """
+        Test that the inductor FxGraphCache can pickle the cache key when
+        DeviceMesh is lifted as a FakeScriptObject graph input. Uses a
+        flattened mesh (from a 2D mesh) which has circular references between
+        parent and child meshes that break pickle with fast=True.
+        """
+        mesh_2d = init_device_mesh(
+            self.device_type,
+            (1, self.world_size),
+            mesh_dim_names=("dp", "tp"),
+        )
+        flat_mesh = mesh_2d._flatten("dp_tp")
+
+        @torch.compile(fullgraph=True)
+        def fn(x):
+            dt = DTensor.from_local(x, flat_mesh, [Shard(0)], run_check=False)
+            dt = dt.redistribute(flat_mesh, [Replicate()])
+            return dt.to_local() + 1
+
+        # clear caches
+        torch.compiler.reset()
+
+        codecache_logger = logging.getLogger("torch._inductor.codecache")
+        x = torch.randn(4, 4, device=self.device_type)
+        with self.assertLogs(codecache_logger, level="DEBUG") as cm:
+            codecache_logger.debug("something to pass assert")
+            fn(x)
+
+        pickle_failures = [
+            msg
+            for msg in cm.output
+            if "Failed to pickle cache key" in msg or "Bypassing FX Graph Cache" in msg
+        ]
+        self.assertEqual(len(pickle_failures), 0)
 
 
 @instantiate_parametrized_tests

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -630,13 +630,13 @@ class FxGraphCachePickler(pickle.Pickler):
             return self._stream.getvalue()
         except (TypeError, AttributeError, pickle.PicklingError, ValueError) as e:
             # Some configs options may not pickle.
-            log.warning("Failed to pickle cache key", exc_info=True)
+            torch._dynamo.utils.warn_once(f"Failed to pickle cache key: {e}")
             raise BypassFxGraphCache("Failed to pickle cache key") from e
         except RuntimeError as e:
             # pybind11 raises RuntimeError with message like:
             # "<pybind11_builtins... object at 0x...> is not pickleable."
             if "pybind11" in str(e) and "is not pickleable" in str(e):
-                log.warning("Failed to pickle cache key", exc_info=True)
+                torch._dynamo.utils.warn_once(f"Failed to pickle cache key: {e}")
                 raise BypassFxGraphCache("Failed to pickle cache key") from e
             raise
         finally:

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -798,7 +798,17 @@ class FxGraphHashDetails:
         inputs_to_check: Sequence[int],
     ) -> None:
         self.gm = gm
-        self.example_inputs = example_inputs
+
+        # Filter out example_inputs for unused graph inputs (placeholders with no users
+        # that aren't graph outputs). Dead inputs don't affect compiled code and may
+        # contain unpicklable objects (e.g., DeviceMesh with circular refs).
+        # Guards should already be present to prevent cache misuse.
+        used_input_indices = []
+        for idx, node in enumerate(n for n in gm.graph.find_nodes(op="placeholder")):
+            if len(node.users) > 0:
+                used_input_indices.append(idx)
+
+        self.example_inputs = [example_inputs[i] for i in used_input_indices]
         self.cache_key_tag = cconfig.cache_key_tag
 
         # Order kwargs so hashing is stable to changes in kwarg order. Although


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #176664

Addresses most of the log spam in: https://github.com/pytorch/pytorch/issues/176532, where DeviceMesh has a self-referencing pattern between root and children, and DeviceMesh are inputs now that we have opaque objects cc @angelayi. These cycles cause issue with pickle fast mode, and cause log spam.

If a placeholder is unpickle-able, but isn't used anywhere in the graph (incl outputs), then we can just drop the example inputs for that placeholder.

While this fix indirectly addresses the issue for inductor cache (because post-dispatch aten graphs no longer need the DeviceMesh), there's still a log spam issue with the AOT autograd cache (because dynamo graphs do need the Device Mesh).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo