### PR TITLE
[rocm][7.0/7.2] Fix [[nodiscard]] build errors and BUCK deps across comms, gloo, caffe2 (#176671)

### DIFF
--- a/torch/nativert/executor/triton/CudaTritonKernelManager.cpp
+++ b/torch/nativert/executor/triton/CudaTritonKernelManager.cpp
@@ -14,12 +14,12 @@ const at::cuda::NVRTC& get_nvrtc() {
 }
 } // namespace
 
-#define CU_LOG_ERROR(fn, result, ...)                   \
-  {                                                     \
-    LOG(ERROR) << #fn << " returned error: " << result; \
-    const char* errMsg = nullptr;                       \
-    get_nvrtc().cuGetErrorString(result, &errMsg);      \
-    LOG(ERROR) << "cuGetErrorString: " << errMsg;       \
+#define CU_LOG_ERROR(fn, result, ...)                    \
+  {                                                      \
+    LOG(ERROR) << #fn << " returned error: " << result;  \
+    const char* errMsg = nullptr;                        \
+    (void)get_nvrtc().cuGetErrorString(result, &errMsg); \
+    LOG(ERROR) << "cuGetErrorString: " << errMsg;        \
   }
 
 namespace torch::nativert {


### PR DESCRIPTION
Summary:
ROCm 7.0+ HIP headers annotate API functions (hipStreamDestroy,
hipMemcpyAsync, hipStreamSynchronize, hipSetDevice, hipGetDevice, hipFree,
hipHostUnregister, hipDeviceEnablePeerAccess, cuGetErrorString) with
[[nodiscard]]. Combined with -Werror, this causes build failures wherever
return values are discarded.

Originally discovered building with ROCm 7.2 headers, but confirmed to
also affect ROCm 7.0 builds (reported independently by yvliu and hqguo).
The [[nodiscard]] attribute is present in both ROCm 7.0 and 7.2 HIP
headers — the fix is the same for both versions.

Changes:
- Add (void) casts to suppress [[nodiscard]] warnings across comms/
  (tcp_devmem, ctran, rcclx), gloo/, and caffe2/ (nativert) — 12 C++ files
- Fix BUCK dependency issues in comms/tcp_devmem/nccl (replace devmgr-client
  with common:common) and comms/tcp_devmem/unpack (explicit glog dep path)
  that surface when building these targets under ROCm constraints

The (void) casts are no-ops on CUDA and older ROCm — safe to land
regardless of ROCm version.


Test Plan: buck2 build mode/amd-gpu -m rocm72 fbcode//comms/tcp_devmem/unpack:batch_unpack_producer fbcode//gloo:cuda_collectives_native — builds successfully

Differential Revision: D93759269

Pulled By: gyllstromk


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang