### PR TITLE
[ROCm][Inductor] Emit tt.pointer_range=32 for small tensor arguments

### DIFF
--- a/test/inductor/test_codegen_triton.py
+++ b/test/inductor/test_codegen_triton.py
@@ -16,8 +16,8 @@ from torch._inductor.dtype_propagation import DtypePropagationOpsHandler, promot
 from torch._inductor.graph import GraphLowering
 from torch._inductor.test_case import TestCase as InductorTestCase
 from torch._inductor.virtualized import V
-from torch.testing._internal.inductor_utils import HAS_CPU, HAS_GPU, HAS_GPU_AND_TRITON
 from torch._inductor.utils import run_and_get_code
+from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_CPU, HAS_GPU, HAS_GPU_AND_TRITON
 from torch.utils._sympy.functions import FloorDiv, TruncToFloat, TruncToInt
 from torch.utils._sympy.value_ranges import ValueRanges
 
@@ -195,7 +195,7 @@ class TestCodegenTriton(InductorTestCase):
         def fn(x):
             return x + 1
 
-        x = torch.randn(64, 64, device="cuda", dtype=torch.bfloat16)
+        x = torch.randn(64, 64, device=GPU_TYPE, dtype=torch.bfloat16)
         _, code = run_and_get_code(torch.compile(fn), x)
         code_str = " ".join(code)
         self.assertIn("tt.pointer_range", code_str)

--- a/test/inductor/test_codegen_triton.py
+++ b/test/inductor/test_codegen_triton.py
@@ -189,7 +189,6 @@ class TestCodegenTriton(InductorTestCase):
             sympy.Float(0.5) + TruncToFloat(s0),
         )
 
-
     @unittest.skipUnless(
         torch.version.hip is not None, "pointer_range_32 is HIP-only"
     )

--- a/test/inductor/test_codegen_triton.py
+++ b/test/inductor/test_codegen_triton.py
@@ -15,9 +15,14 @@ from torch._inductor.codegen.triton import (
 from torch._inductor.dtype_propagation import DtypePropagationOpsHandler, promote_types
 from torch._inductor.graph import GraphLowering
 from torch._inductor.test_case import TestCase as InductorTestCase
-from torch._inductor.virtualized import V
 from torch._inductor.utils import run_and_get_code
-from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_CPU, HAS_GPU, HAS_GPU_AND_TRITON
+from torch._inductor.virtualized import V
+from torch.testing._internal.inductor_utils import (
+    GPU_TYPE,
+    HAS_CPU,
+    HAS_GPU,
+    HAS_GPU_AND_TRITON,
+)
 from torch.utils._sympy.functions import FloorDiv, TruncToFloat, TruncToInt
 from torch.utils._sympy.value_ranges import ValueRanges
 

--- a/test/inductor/test_codegen_triton.py
+++ b/test/inductor/test_codegen_triton.py
@@ -189,9 +189,7 @@ class TestCodegenTriton(InductorTestCase):
             sympy.Float(0.5) + TruncToFloat(s0),
         )
 
-    @unittest.skipUnless(
-        torch.version.hip is not None, "pointer_range_32 is HIP-only"
-    )
+    @unittest.skipUnless(torch.version.hip is not None, "pointer_range_32 is HIP-only")
     @unittest.skipUnless(HAS_GPU_AND_TRITON, "requires GPU and Triton")
     def test_pointer_range_in_generated_code(self):
         """Verify tt.pointer_range=32 appears in generated Triton code on HIP."""

--- a/test/inductor/test_codegen_triton.py
+++ b/test/inductor/test_codegen_triton.py
@@ -1,5 +1,6 @@
 # Owner(s): ["module: inductor"]
 import contextlib
+import unittest
 
 import sympy
 
@@ -15,7 +16,8 @@ from torch._inductor.dtype_propagation import DtypePropagationOpsHandler, promot
 from torch._inductor.graph import GraphLowering
 from torch._inductor.test_case import TestCase as InductorTestCase
 from torch._inductor.virtualized import V
-from torch.testing._internal.inductor_utils import HAS_CPU, HAS_GPU
+from torch.testing._internal.inductor_utils import HAS_CPU, HAS_GPU, HAS_GPU_AND_TRITON
+from torch._inductor.utils import run_and_get_code
 from torch.utils._sympy.functions import FloorDiv, TruncToFloat, TruncToInt
 from torch.utils._sympy.value_ranges import ValueRanges
 
@@ -181,6 +183,22 @@ class TestCodegenTriton(InductorTestCase):
             _materialize_trunc_to_float_expr(float_expr, torch.float64),
             sympy.Float(0.5) + TruncToFloat(s0),
         )
+
+
+    @unittest.skipUnless(
+        torch.version.hip is not None, "pointer_range_32 is HIP-only"
+    )
+    @unittest.skipUnless(HAS_GPU_AND_TRITON, "requires GPU and Triton")
+    def test_pointer_range_in_generated_code(self):
+        """Verify tt.pointer_range=32 appears in generated Triton code on HIP."""
+
+        def fn(x):
+            return x + 1
+
+        x = torch.randn(64, 64, device="cuda", dtype=torch.bfloat16)
+        _, code = run_and_get_code(torch.compile(fn), x)
+        code_str = " ".join(code)
+        self.assertIn("tt.pointer_range", code_str)
 
 
 if __name__ == "__main__":

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -5707,8 +5707,6 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             if flops is not None:
                 inductor_meta["kernel_flop"] = flops
 
-        triton_meta["configs"] = [config_of(signature)]
-
         # Triton compiler includes equal_to_1 args into constants even
         # when they are not constexpr. otherwise there may be a segfault
         # during launching the Inductor-compiled Triton kernel.
@@ -5723,6 +5721,14 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         self.codegen_prologue(self.body)
         self.codegen_body()
         self._filter_pdl(self.body)
+
+        # Compute configs after codegen_body() so we know if the kernel
+        # uses atomic ops. On HIP, buffer ops don't support atomics, so
+        # we must not tag any args with pointer_range_32 in that case.
+        if torch.version.hip is not None and self.atomic_add_found:
+            triton_meta["configs"] = [config_of(signature, pointer_range_override=())]
+        else:
+            triton_meta["configs"] = [config_of(signature)]
 
         for helper in self.helper_functions:
             code.writeline("")

--- a/torch/_inductor/codegen/triton_utils.py
+++ b/torch/_inductor/codegen/triton_utils.py
@@ -295,13 +295,17 @@ def config_of(
 
     # On AMD/HIP, tag tensor args whose storage fits in 2GB so Triton
     # can use 32-bit pointer offsets and emit buffer load/store ops.
+    # Exclude mutated buffers (e.g. atomic scatter targets from index_put_
+    # with accumulate) since buffer ops don't support atomics on ROCm.
     pointer_range_32: tuple[int, ...] = ()
     if torch.version.hip is not None:
         pointer_range_32 = tuple(
             i
             for i, arg in zip(indices, args)
-            if isinstance(arg, TensorArg) and _is_tensor_within_2gb(arg)
+            if isinstance(arg, TensorArg)
+            and _is_tensor_within_2gb(arg)
+            and arg.buffer not in V.graph.mutated_buffers
         )
 
-    # pyrefly: ignore [bad-argument-count]
+    # pyrefly: ignore [bad-argument-count, bad-argument-type]
     return AttrsDescriptorWrapper(divisible_by_16, equal_to_1, pointer_range_32)

--- a/torch/_inductor/codegen/triton_utils.py
+++ b/torch/_inductor/codegen/triton_utils.py
@@ -227,7 +227,16 @@ def _is_tensor_within_2gb(arg: TensorArg) -> bool:
     """
     MAX_BYTES = 2**31 - 1
     try:
-        layout = _get_buffer_layout(arg.buffer)
+        # Graph inputs aren't tracked by the scheduler; get their layout
+        # from the graph_inputs dict to avoid KeyError in get_buffer_layout.
+        if arg.buffer in V.graph.graph_inputs:
+            inp = V.graph.graph_inputs[arg.buffer]
+            if hasattr(inp, "get_layout"):
+                layout = inp.get_layout()
+            else:
+                return False
+        else:
+            layout = _get_buffer_layout(arg.buffer)
         storage_bytes = layout.storage_size() * arg.dtype.itemsize
         return V.graph.sizevars.statically_known_true(storage_bytes <= MAX_BYTES)
     except Exception:

--- a/torch/_inductor/codegen/triton_utils.py
+++ b/torch/_inductor/codegen/triton_utils.py
@@ -160,6 +160,24 @@ def signature_to_meta(
     }
 
 
+def _get_buffer_layout(buf_name: str):
+    """Get the layout for a buffer, handling both scheduler buffers and graph inputs."""
+    if V.graph.scheduler:
+        try:
+            return V.graph.scheduler.get_buffer_layout(buf_name)
+        except (KeyError, AttributeError):
+            pass
+
+    buffer = V.graph.try_get_buffer(buf_name)
+    if buffer:
+        return buffer.get_layout()
+
+    if hasattr(V, "kernel") and V.kernel is not None and buf_name == V.kernel.output_node.name:
+        return V.kernel.output_node.layout
+
+    return None
+
+
 def is_unaligned_buffer(arg: TensorArg):
     buf_name = arg.buffer
     if buf_name in V.graph.unaligned_buffers:
@@ -175,17 +193,7 @@ def is_unaligned_buffer(arg: TensorArg):
         # all constants are assumed to be aligned
         return False
 
-    if V.graph.scheduler:
-        layout = V.graph.scheduler.get_buffer_layout(buf_name)
-    else:
-        buffer = V.graph.try_get_buffer(buf_name)
-        # output arg
-        if not buffer:
-            assert buf_name == V.kernel.output_node.name
-            layout = V.kernel.output_node.layout
-        else:
-            layout = buffer.get_layout()
-
+    layout = _get_buffer_layout(buf_name)
     if isinstance(layout, torch._inductor.ir.NonOwningLayout):
         return not layout.maybe_guard_aligned()
     else:
@@ -211,24 +219,6 @@ def equal_1_arg_indices(
     equal_to_1 = tuple(i for i, arg in zip(indices, args) if _arg_equals_1(arg))
 
     return equal_to_1
-
-
-def _get_buffer_layout(buf_name: str):
-    """Get the layout for a buffer, handling both scheduler buffers and graph inputs."""
-    if V.graph.scheduler:
-        try:
-            return V.graph.scheduler.get_buffer_layout(buf_name)
-        except (KeyError, AttributeError):
-            pass
-
-    buffer = V.graph.try_get_buffer(buf_name)
-    if buffer:
-        return buffer.get_layout()
-
-    if hasattr(V, "kernel") and V.kernel is not None and buf_name == V.kernel.output_node.name:
-        return V.kernel.output_node.layout
-
-    return None
 
 
 def _is_tensor_within_2gb(arg: TensorArg) -> bool:

--- a/torch/_inductor/codegen/triton_utils.py
+++ b/torch/_inductor/codegen/triton_utils.py
@@ -213,6 +213,43 @@ def equal_1_arg_indices(
     return equal_to_1
 
 
+def _get_buffer_layout(buf_name: str):
+    """Get the layout for a buffer, handling both scheduler buffers and graph inputs."""
+    if V.graph.scheduler:
+        try:
+            return V.graph.scheduler.get_buffer_layout(buf_name)
+        except (KeyError, AttributeError):
+            pass
+
+    buffer = V.graph.try_get_buffer(buf_name)
+    if buffer:
+        return buffer.get_layout()
+
+    if hasattr(V, "kernel") and V.kernel is not None and buf_name == V.kernel.output_node.name:
+        return V.kernel.output_node.layout
+
+    return None
+
+
+def _is_tensor_within_2gb(arg: TensorArg) -> bool:
+    """Check if a tensor argument's storage is provably within 2GB.
+
+    Mirrors HIPBackend.is_within_2gb() but uses compile-time symbolic analysis
+    instead of runtime tensor inspection. This enables canonicalize_pointers to
+    decompose pointer arithmetic into (splat(base), offset) form for buffer ops.
+    """
+    MAX_BYTES = 2**31 - 1
+    try:
+        layout = _get_buffer_layout(arg.buffer)
+        if layout is None:
+            return False
+
+        storage_bytes = layout.storage_size() * arg.dtype.itemsize
+        return V.graph.sizevars.statically_known_true(storage_bytes <= MAX_BYTES)
+    except Exception:
+        return False
+
+
 def config_of(
     args: list[KernelArgType],
     *,
@@ -263,5 +300,15 @@ def config_of(
 
     equal_to_1 = equal_1_arg_indices(args, indices=indices)
 
+    # On AMD/HIP, tag tensor args whose storage fits in 2GB so Triton
+    # can use 32-bit pointer offsets and emit buffer load/store ops.
+    pointer_range_32: tuple[int, ...] = ()
+    if torch.version.hip is not None:
+        pointer_range_32 = tuple(
+            i
+            for i, arg in zip(indices, args)
+            if isinstance(arg, TensorArg) and _is_tensor_within_2gb(arg)
+        )
+
     # pyrefly: ignore [bad-argument-type]
-    return AttrsDescriptorWrapper(divisible_by_16, equal_to_1)
+    return AttrsDescriptorWrapper(divisible_by_16, equal_to_1, pointer_range_32)

--- a/torch/_inductor/codegen/triton_utils.py
+++ b/torch/_inductor/codegen/triton_utils.py
@@ -294,5 +294,5 @@ def config_of(
             if isinstance(arg, TensorArg) and _is_tensor_within_2gb(arg)
         )
 
-    # pyrefly: ignore [bad-argument-type]
+    # pyrefly: ignore [bad-argument-count]
     return AttrsDescriptorWrapper(divisible_by_16, equal_to_1, pointer_range_32)

--- a/torch/_inductor/codegen/triton_utils.py
+++ b/torch/_inductor/codegen/triton_utils.py
@@ -247,6 +247,7 @@ def config_of(
     args: list[KernelArgType],
     *,
     indices: list[int] | None = None,
+    pointer_range_override: tuple[int, ...] | None = None,
 ) -> Any:
     if indices is None:
         indices = list(range(len(args)))
@@ -295,17 +296,16 @@ def config_of(
 
     # On AMD/HIP, tag tensor args whose storage fits in 2GB so Triton
     # can use 32-bit pointer offsets and emit buffer load/store ops.
-    # Exclude mutated buffers (e.g. atomic scatter targets from index_put_
-    # with accumulate) since buffer ops don't support atomics on ROCm.
-    pointer_range_32: tuple[int, ...] = ()
-    if torch.version.hip is not None:
+    if pointer_range_override is not None:
+        pointer_range_32 = pointer_range_override
+    elif torch.version.hip is not None:
         pointer_range_32 = tuple(
             i
             for i, arg in zip(indices, args)
-            if isinstance(arg, TensorArg)
-            and _is_tensor_within_2gb(arg)
-            and arg.buffer not in V.graph.mutated_buffers
+            if isinstance(arg, TensorArg) and _is_tensor_within_2gb(arg)
         )
+    else:
+        pointer_range_32 = ()
 
     # pyrefly: ignore [bad-argument-count, bad-argument-type]
     return AttrsDescriptorWrapper(divisible_by_16, equal_to_1, pointer_range_32)

--- a/torch/_inductor/codegen/triton_utils.py
+++ b/torch/_inductor/codegen/triton_utils.py
@@ -160,22 +160,19 @@ def signature_to_meta(
     }
 
 
-def _get_buffer_layout(buf_name: str):
+def _get_buffer_layout(buf_name: str) -> "torch._inductor.ir.Layout":
     """Get the layout for a buffer, handling both scheduler buffers and graph inputs."""
     if V.graph.scheduler:
-        try:
-            return V.graph.scheduler.get_buffer_layout(buf_name)
-        except (KeyError, AttributeError):
-            pass
-
-    buffer = V.graph.try_get_buffer(buf_name)
-    if buffer:
-        return buffer.get_layout()
-
-    if hasattr(V, "kernel") and V.kernel is not None and buf_name == V.kernel.output_node.name:
-        return V.kernel.output_node.layout
-
-    return None
+        layout = V.graph.scheduler.get_buffer_layout(buf_name)
+    else:
+        buffer = V.graph.try_get_buffer(buf_name)
+        # output arg
+        if not buffer:
+            assert buf_name == V.kernel.output_node.name
+            layout = V.kernel.output_node.layout
+        else:
+            layout = buffer.get_layout()
+    return layout
 
 
 def is_unaligned_buffer(arg: TensorArg):
@@ -231,9 +228,6 @@ def _is_tensor_within_2gb(arg: TensorArg) -> bool:
     MAX_BYTES = 2**31 - 1
     try:
         layout = _get_buffer_layout(arg.buffer)
-        if layout is None:
-            return False
-
         storage_bytes = layout.storage_size() * arg.dtype.itemsize
         return V.graph.sizevars.statically_known_true(storage_bytes <= MAX_BYTES)
     except Exception:

--- a/torch/_inductor/runtime/hints.py
+++ b/torch/_inductor/runtime/hints.py
@@ -47,6 +47,7 @@ if has_triton_package():
         def AttrsDescriptorWrapper(
             divisible_by_16=None,
             equal_to_1=None,
+            pointer_range_32=None,
         ):
             # Prepare the arguments for AttrsDescriptor
             kwargs = {
@@ -69,6 +70,7 @@ if has_triton_package():
         def AttrsDescriptorWrapper(
             divisible_by_16=None,
             equal_to_1=None,
+            pointer_range_32=None,
         ):
             # Prepare the arguments for AttrsDescriptor
             kwargs = {
@@ -107,8 +109,8 @@ else:
     AttrsDescriptorWrapper = collections.namedtuple(  # type: ignore[no-redef, name-match]
         # pyrefly: ignore [invalid-argument]
         "AttrsDescriptor",
-        ["divisible_by_16", "equal_to_1"],
-        defaults=[(), ()],
+        ["divisible_by_16", "equal_to_1", "pointer_range_32"],
+        defaults=[(), (), ()],
     )
 
 

--- a/torch/_inductor/runtime/hints.py
+++ b/torch/_inductor/runtime/hints.py
@@ -96,7 +96,7 @@ if has_triton_package():
             # Build attr dict merging divisibility and pointer_range per arg index,
             # since a single arg can carry both attributes.
             result = {(x,): [["tt.divisibility", 16]] for x in (divisible_by_16 or ())}
-            for x in (pointer_range_32 or ()):
+            for x in pointer_range_32 or ():
                 key = (x,)
                 if key in result:
                     result[key].append(["tt.pointer_range", 32])

--- a/torch/_inductor/runtime/hints.py
+++ b/torch/_inductor/runtime/hints.py
@@ -88,9 +88,19 @@ if has_triton_package():
         def AttrsDescriptorWrapper(
             divisible_by_16=None,
             equal_to_1=None,
+            pointer_range_32=None,
         ):
             # pyrefly: ignore [not-iterable]
-            return {(x,): [["tt.divisibility", 16]] for x in divisible_by_16}
+            # Build attr dict merging divisibility and pointer_range per arg index,
+            # since a single arg can carry both attributes.
+            result = {(x,): [["tt.divisibility", 16]] for x in (divisible_by_16 or ())}
+            for x in (pointer_range_32 or ()):
+                key = (x,)
+                if key in result:
+                    result[key].append(["tt.pointer_range", 32])
+                else:
+                    result[key] = [["tt.pointer_range", 32]]
+            return result
 
 else:
     # Define a namedtuple as a fallback when AttrsDescriptor is not available


### PR DESCRIPTION
On AMD/HIP targets, annotate Triton kernel pointer arguments with tt.pointer_range=32 when the tensor's storage is provably within 2GB. This enables Triton's canonicalize_pointers pass to decompose 64-bit pointer arithmetic into (splat(base), offset) form using 32-bit offsets, which in turn allows ConvertToBufferOps to emit efficient amdgpu.buffer_load/store instructions.

This improves performance across all kernels going through the Triton compilation path with small tensors as it generates efficient buffer ops.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben