### PR TITLE
[ROCm][Inductor] Enable pipelining for FlexAttention

### DIFF
--- a/torch/_inductor/template_heuristics/triton.py
+++ b/torch/_inductor/template_heuristics/triton.py
@@ -1554,9 +1554,9 @@ class ROCmConfigHeuristic(BaseConfigHeuristic):
             (torch.float32, 64): ROCmFlexConfig(128, 32, 1, 4),
             (torch.float32, 128): ROCmFlexConfig(128, 32, 1, 4),
             (torch.float32, 256): ROCmFlexConfig(64, 16, 1, 4),
-            (torch.bfloat16, 64): ROCmFlexConfig(128, 64, 2, 8),
-            (torch.bfloat16, 128): ROCmFlexConfig(128, 64, 2, 8),
-            (torch.bfloat16, 256): ROCmFlexConfig(32, 64, 2, 8),
+            (torch.bfloat16, 64): ROCmFlexConfig(128, 64, 2, 4),
+            (torch.bfloat16, 128): ROCmFlexConfig(128, 64, 2, 4),
+            (torch.bfloat16, 256): ROCmFlexConfig(32, 64, 2, 4),
             (torch.float16, 64): ROCmFlexConfig(128, 64, 2, 8),
             (torch.float16, 128): ROCmFlexConfig(128, 64, 2, 8),
             (torch.float16, 256): ROCmFlexConfig(32, 64, 2, 4),
@@ -1564,7 +1564,7 @@ class ROCmConfigHeuristic(BaseConfigHeuristic):
 
         self.flex_attn_fwd_autotune_configs: list[FlexConfig] = [
             ROCmFlexConfig(BLOCK1, BLOCK2, 1, w)
-            for BLOCK1 in [16, 64, 128, 256]
+            for BLOCK1 in [16, 64, 128]
             for BLOCK2 in [16, 32, 64, 128]
             for w in [4, 8]
         ]
@@ -1590,7 +1590,7 @@ class ROCmConfigHeuristic(BaseConfigHeuristic):
 
         self.exhaustive_flex_attn_fwd_configs: list[FlexConfig] = [
             ROCmFlexConfig(BLOCK_M, BLOCK_N, num_stages, num_warps, mfma, wpeu)
-            for BLOCK_M in [16, 32, 64, 128, 256]
+            for BLOCK_M in [16, 32, 64, 128]
             for BLOCK_N in [32, 64, 128]
             for num_stages in [1, 2]
             for num_warps in [2, 4, 8]
@@ -1735,7 +1735,7 @@ class ROCmConfigHeuristic(BaseConfigHeuristic):
             if dtype == torch.float32:
                 default_config = ROCmFlexConfig(64, 64, 1, 4)
             else:
-                default_config = ROCmFlexConfig(128, 64, 2, 8)
+                default_config = ROCmFlexConfig(128, 64, 2, 4)
             default_config = self.default_flex_config.get(
                 (dtype, head_dim), default_config
             )

--- a/torch/_inductor/template_heuristics/triton.py
+++ b/torch/_inductor/template_heuristics/triton.py
@@ -1554,12 +1554,12 @@ class ROCmConfigHeuristic(BaseConfigHeuristic):
             (torch.float32, 64): ROCmFlexConfig(128, 32, 1, 4),
             (torch.float32, 128): ROCmFlexConfig(128, 32, 1, 4),
             (torch.float32, 256): ROCmFlexConfig(64, 16, 1, 4),
-            (torch.bfloat16, 64): ROCmFlexConfig(128, 64, 1, 4),
-            (torch.bfloat16, 128): ROCmFlexConfig(128, 64, 1, 4),
-            (torch.bfloat16, 256): ROCmFlexConfig(32, 64, 1, 4),
-            (torch.float16, 64): ROCmFlexConfig(128, 64, 1, 8),
-            (torch.float16, 128): ROCmFlexConfig(128, 64, 1, 8),
-            (torch.float16, 256): ROCmFlexConfig(32, 64, 1, 4),
+            (torch.bfloat16, 64): ROCmFlexConfig(128, 64, 2, 8),
+            (torch.bfloat16, 128): ROCmFlexConfig(128, 64, 2, 8),
+            (torch.bfloat16, 256): ROCmFlexConfig(32, 64, 2, 8),
+            (torch.float16, 64): ROCmFlexConfig(128, 64, 2, 8),
+            (torch.float16, 128): ROCmFlexConfig(128, 64, 2, 8),
+            (torch.float16, 256): ROCmFlexConfig(32, 64, 2, 4),
         }
 
         self.flex_attn_fwd_autotune_configs: list[FlexConfig] = [
@@ -1735,7 +1735,7 @@ class ROCmConfigHeuristic(BaseConfigHeuristic):
             if dtype == torch.float32:
                 default_config = ROCmFlexConfig(64, 64, 1, 4)
             else:
-                default_config = ROCmFlexConfig(128, 64, 1, 8)
+                default_config = ROCmFlexConfig(128, 64, 2, 8)
             default_config = self.default_flex_config.get(
                 (dtype, head_dim), default_config
             )
@@ -1743,7 +1743,7 @@ class ROCmConfigHeuristic(BaseConfigHeuristic):
             if dtype == torch.float32:
                 default_config = ROCmFlexConfig(32, 16, 1, 4)
             else:
-                default_config = ROCmFlexConfig(64, 32, 1, 4)
+                default_config = ROCmFlexConfig(64, 32, 2, 4)
 
         if default_config not in flex_attn_fwd_configs:
             flex_attn_fwd_configs.append(default_config)

--- a/torch/_inductor/template_heuristics/triton.py
+++ b/torch/_inductor/template_heuristics/triton.py
@@ -1564,7 +1564,7 @@ class ROCmConfigHeuristic(BaseConfigHeuristic):
 
         self.flex_attn_fwd_autotune_configs: list[FlexConfig] = [
             ROCmFlexConfig(BLOCK1, BLOCK2, 1, w)
-            for BLOCK1 in [16, 64, 128]
+            for BLOCK1 in [16, 64, 128, 256]
             for BLOCK2 in [16, 32, 64, 128]
             for w in [4, 8]
         ]
@@ -1590,7 +1590,7 @@ class ROCmConfigHeuristic(BaseConfigHeuristic):
 
         self.exhaustive_flex_attn_fwd_configs: list[FlexConfig] = [
             ROCmFlexConfig(BLOCK_M, BLOCK_N, num_stages, num_warps, mfma, wpeu)
-            for BLOCK_M in [16, 32, 64, 128]
+            for BLOCK_M in [16, 32, 64, 128, 256]
             for BLOCK_N in [32, 64, 128]
             for num_stages in [1, 2]
             for num_warps in [2, 4, 8]


### PR DESCRIPTION
Changing the `num_stages` value from 1 to 2 enables more efficient pipelining in Triton backend which improves the performance. Here's some benchmark numbers for comparison run on MI350X.

  | Attn Type      | Shape (B,Hq,M,Hkv,N,D)         | stages=1 (μs) | stages=2 (μs) | Speedup |
  |----------------|----------------------------------|----------------|----------------|---------|
  | causal         | (2, 16, 512, 16, 512, 64)       | 37.6           | 35.8           | 1.05x   |
  | causal         | (2, 16, 512, 2, 512, 128)       | 35.7           | 35.1           | 1.02x   |
  | causal         | (2, 16, 1024, 16, 1024, 64)     | 39.5           | 31.4           | 1.26x   |
  | causal         | (2, 16, 4096, 16, 4096, 128)    | 680.3          | 580.6          | 1.17x   |
  | causal         | (2, 16, 4096, 2, 4096, 64)      | 259.0          | 238.4          | 1.09x   |
  | noop           | (8, 16, 1024, 16, 1024, 128)    | 196.2          | 183.3          | 1.07x   |
  | causal         | (8, 16, 1024, 2, 1024, 64)      | 79.7           | 75.5           | 1.06x   |
  | alibi          | (8, 16, 4096, 16, 4096, 64)     | 2017.7         | 1727.3         | 1.17x   |
  | causal         | (8, 16, 4096, 16, 4096, 128)    | 2686.0         | 2258.7         | 1.19x   |
  | sliding_window | (8, 16, 4096, 2, 4096, 64)      | 610.4          | 559.3          | 1.09x   |
  | causal         | (16, 16, 512, 16, 512, 128)     | 111.6          | 99.0           | 1.13x   |
  | alibi          | (16, 16, 1024, 2, 1024, 128)    | 391.6          | 335.3          | 1.17x   |
  | causal         | (16, 16, 1024, 16, 1024, 64)    | 163.6          | 142.6          | 1.15x   |
  | noop           | (16, 16, 4096, 16, 4096, 128)   | 6260.5         | 5130.3         | 1.22x   |
  | causal         | (16, 16, 4096, 2, 4096, 64)     | 2084.5         | 1780.5         | 1.17x   |
  | causal         | (1, 32, 16384, 4, 16384, 64)    | 2687.9         | 2472.8         | 1.09x   |
  | **Geo-mean**   |                                  |                |                | **1.13x** |


  All configs: `num_warps=4`, `dtype=bfloat16`, fwd only. Benchmarked with `attention-gym` on ROCm.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben