### PR TITLE
[export] Handle unused List[Tensor] outputs in serialization

### DIFF
--- a/test/export/test_serialize.py
+++ b/test/export/test_serialize.py
@@ -564,6 +564,61 @@ def forward(self, x):
             self.assertNotIn(name, seen)
             seen.add(name)
 
+    def test_multi_return_list_tensor_unused(self) -> None:
+        """
+        Make sure serialization handles unused List[Tensor] outputs in
+        multi-return ops. The getitem node for the unused list output is
+        removed by DCE, so the serializer must synthesize names.
+        """
+        lib = torch.library.Library("mylib", "DEF")
+        lib.define(
+            "tensor_and_list(Tensor x) -> (Tensor, Tensor[])",
+        )
+
+        @torch.library.impl(lib, "tensor_and_list", "CPU")
+        def tensor_and_list_impl(x):
+            return x * 2, [x, x + 1]
+
+        @torch.library.impl(lib, "tensor_and_list", "Meta")
+        def tensor_and_list_meta(x):
+            return x * 2, [x, x + 1]
+
+        class MyModule(torch.nn.Module):
+            def forward(self, x):
+                # Only use the first (Tensor) output; the List[Tensor] is unused
+                return torch.ops.mylib.tensor_and_list(x)[0]
+
+        exported_module = export(MyModule(), (torch.ones(3),), strict=True)
+        # Simulate the scenario where DCE removes the getitem for the
+        # unused List[Tensor] output (as happens in real serialization
+        # pipelines like package_sigmoid_model).
+        exported_module.graph.eliminate_dead_code()
+        exported_module.graph_module.recompile()
+
+        serialized = ExportedProgramSerializer().serialize(exported_module)
+        node = serialized.exported_program.graph_module.graph.nodes[-1]
+        self.assertEqual(node.target, "torch.ops.mylib.tensor_and_list.default")
+        self.assertEqual(len(node.outputs), 2)
+
+        # First output is a single tensor
+        self.assertTrue(node.outputs[0].as_tensor.name != "")
+        # Second output is the unused list -- should still have tensor entries
+        self.assertTrue(len(node.outputs[1].as_tensors) > 0)
+        for t in node.outputs[1].as_tensors:
+            self.assertIn("_unused_", t.name)
+
+        # Roundtrip: deserialize and verify functional correctness
+        deserialized_ep = deserialize(serialize(exported_module))
+        inp = torch.randn(3)
+        self.assertTrue(
+            torch.allclose(
+                exported_module.module()(inp),
+                deserialized_ep.module()(inp),
+            )
+        )
+
+        del lib
+
     def test_rational_ranges(self) -> None:
         class M(torch.nn.Module):
             def forward(self, x):

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -1975,17 +1975,15 @@ class GraphModuleSerializer(metaclass=Final):
                         f"expected ListType with TensorType element, got {type(return_schema.real_type).__name__}"
                     )
                 user_node = self._output_node_at_index(node, idx)
-                if user_node is None:
-                    raise AssertionError(
-                        f"user_node should not be None for list output at index {idx}"
-                    )
-
                 args = []
                 for i, m in enumerate(meta):
                     if m is None:
                         continue
-                    sub_user_node_name = self._output_node_name_at_index(user_node, i)
-                    args.append(self.serialize_tensor_output(sub_user_node_name, m))
+                    if user_node is None:
+                        name = f"{node.name}_unused_{idx}_{i}"
+                    else:
+                        name = self._output_node_name_at_index(user_node, i)
+                    args.append(self.serialize_tensor_output(name, m))
                 output_arguments.append(Argument.create(as_tensors=args))
             elif isinstance(meta, (int, SymInt, float, SymFloat)):
                 user_node_name = self._output_node_name_at_index(node, idx)
@@ -2009,11 +2007,6 @@ class GraphModuleSerializer(metaclass=Final):
                 user_node = self._output_node_at_index(node, i)
                 if isinstance(element_meta_val, list):
                     # e.g "-> Tensor[]"
-                    if user_node is None:
-                        raise AssertionError(
-                            f"user_node should not be None for list output at index {i}"
-                        )
-
                     tensors = []
                     for j, m in enumerate(element_meta_val):
                         if not isinstance(m, torch.Tensor):
@@ -2021,7 +2014,10 @@ class GraphModuleSerializer(metaclass=Final):
                                 f"Serialize list output with type {type(m)} nyi"
                             )
 
-                        name = self._output_node_name_at_index(user_node, j)
+                        if user_node is None:
+                            name = f"{node.name}_unused_{i}_{j}"
+                        else:
+                            name = self._output_node_name_at_index(user_node, j)
                         tensors.append(self.serialize_tensor_output(name, m))
                     outputs.append(Argument.create(as_tensors=tensors))
 


### PR DESCRIPTION
Summary:
Fix export serialization to handle the case where a multi-return op has an
unused `List[Tensor]` output. When DCE removes the `getitem` node for the
unused list output, the serializer previously raised an AssertionError
because `user_node` was None. Now it synthesizes placeholder names
(`{node_name}_unused_{idx}_{i}`) for the tensor entries instead of crashing.

This occurs in practice when `serialize_sigmoid_model` / `package_sigmoid_model`
runs DCE on the exported program.

Test Plan: buck test fbcode//caffe2/test/export:test_serialize -- TestSerialize.test_multi_return_list_tensor_unused

Differential Revision: D95282654


