### PR TITLE
[dynamo] Add debug_dynamo_config_override support

### DIFF
--- a/test/dynamo/test_debug_utils.py
+++ b/test/dynamo/test_debug_utils.py
@@ -486,12 +486,12 @@ class TestInductorConfigOverrideIntegration(TestCase):
         """
         from torch._dynamo.graph_id_filter import (
             _create_backend_router,
-            _create_config_router,
+            _create_inductor_config_router,
         )
 
         torch._dynamo.reset()
         _create_backend_router.cache_clear()
-        _create_config_router.cache_clear()
+        _create_inductor_config_router.cache_clear()
 
         backends_used: list[str] = []
         configs_applied: list[dict] = []
@@ -571,12 +571,12 @@ class TestInductorConfigOverrideIntegration(TestCase):
         """
         from torch._dynamo.graph_id_filter import (
             _create_backend_router,
-            _create_config_router,
+            _create_inductor_config_router,
         )
 
         torch._dynamo.reset()
         _create_backend_router.cache_clear()
-        _create_config_router.cache_clear()
+        _create_inductor_config_router.cache_clear()
 
         backends_used: list[str] = []
         configs_applied: list[dict] = []
@@ -661,14 +661,14 @@ class TestInductorConfigOverrideIntegration(TestCase):
         time for both forward and backward, across multiple graph breaks.
         """
         import torch._functorch.config
-        from torch._dynamo.graph_id_filter import _create_config_router
+        from torch._dynamo.graph_id_filter import _create_inductor_config_router
         from torch._inductor import (
             compile_fx as compile_fx_mod,
             config as inductor_config,
         )
 
         torch._dynamo.reset()
-        _create_config_router.cache_clear()
+        _create_inductor_config_router.cache_clear()
 
         TRACKED_CONFIGS = [
             "triton.cudagraphs",
@@ -761,6 +761,71 @@ class TestInductorConfigOverrideIntegration(TestCase):
 instantiate_device_type_tests(
     TestInductorConfigOverrideIntegration, globals(), only_for=["cpu", "cuda"]
 )
+
+
+class TestDynamoConfigOverrideIntegration(TestCase):
+    def setUp(self):
+        super().setUp()
+        torch._dynamo.reset()
+
+    def tearDown(self):
+        torch._dynamo.reset()
+        super().tearDown()
+
+    @torch._dynamo.config.patch(
+        specialize_float=False,
+        verbose=False,
+        debug_dynamo_config_override=(
+            "0:specialize_float=True;1:verbose=True,recompile_limit=10"
+        ),
+    )
+    def test_dynamo_config_override_per_graph(self):
+        """Per-graph dynamo config overrides target the right graphs.
+
+        Graph 0: specialize_float overridden True (base False)
+        Graph 1: verbose+recompile_limit overridden (multiple keys)
+        Graph 2: no override, keeps base values
+        """
+        from torch._dynamo.graph_id_filter import _create_dynamo_config_router
+
+        _create_dynamo_config_router.cache_clear()
+
+        observed: dict[int, dict] = {}
+
+        def capturing_backend(gm, example_inputs):
+            fid = torch._guards.CompileContext.current_compile_id().frame_id
+            observed[fid] = {
+                "specialize_float": torch._dynamo.config.specialize_float,
+                "verbose": torch._dynamo.config.verbose,
+                "recompile_limit": torch._dynamo.config.recompile_limit,
+            }
+            return gm
+
+        def fn(x):
+            x = x + 1
+            torch._dynamo.graph_break()
+            x = x * 2
+            torch._dynamo.graph_break()
+            return x - 1
+
+        torch.compile(fn, backend=capturing_backend)(torch.randn(4))
+
+        self.assertTrue(observed[0]["specialize_float"])
+        self.assertFalse(observed[0]["verbose"])
+
+        self.assertFalse(observed[1]["specialize_float"])
+        self.assertTrue(observed[1]["verbose"])
+        self.assertEqual(observed[1]["recompile_limit"], 10)
+
+        self.assertFalse(observed[2]["specialize_float"])
+        self.assertFalse(observed[2]["verbose"])
+
+    def test_dynamo_config_override_warning(self):
+        from torch._dynamo.graph_id_filter import _create_dynamo_config_router
+
+        _create_dynamo_config_router.cache_clear()
+        with self.assertWarnsRegex(UserWarning, "debug_dynamo_config_override"):
+            _create_dynamo_config_router("0:specialize_float=True")
 
 
 if __name__ == "__main__":

--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -62,6 +62,17 @@ debug_inductor_config_override: str = os.environ.get(
     "TORCH_COMPILE_OVERRIDE_INDUCTOR_CONFIGS", ""
 )
 
+# Override dynamo config for specific graphs (for debugging/bisecting).
+# Format: "filter1:config1;filter2:config2;..." where filter uses same syntax as
+# debug_backend_override, and config is "key=value" or "key=value,key2=value2".
+# Examples:
+#   "0-5:specialize_float=True"  - Specialize floats for graphs 0-5
+#   ">10:automatic_dynamic_shapes=False"  - Disable dynamic shapes for graphs > 10
+# [@compile_ignored: debug]
+debug_dynamo_config_override: str = os.environ.get(
+    "TORCH_COMPILE_OVERRIDE_DYNAMO_CONFIGS", ""
+)
+
 # Validate that fake_fn and real_fn in @leaf_function decorators produce outputs
 # with matching shapes and dtypes in eager mode. Helps catch mismatches early.
 # Disabled by default to avoid runtime overhead.

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -1536,22 +1536,32 @@ def _compile(
                 payload_fn=lambda: dis.Bytecode(code).dis(),
             )
         out_code = None
+        from .graph_id_filter import get_dynamo_config_override_for_compile_id
+
+        dynamo_config_override = get_dynamo_config_override_for_compile_id(
+            compile_id, config.debug_dynamo_config_override
+        )
         try:
-            dynamo_output = compile_frame(
-                code,
-                globals,
-                locals,
-                builtins,
-                closure,
-                compiler_fn,
-                one_graph,
-                restart_reasons,
-                export=export,
-                export_constraints=export_constraints,
-                frame_state=frame_state,
-                distributed_state=distributed_state,
-                package=package,
-            )
+            with (
+                config.patch(dynamo_config_override)
+                if dynamo_config_override
+                else contextlib.nullcontext()
+            ):
+                dynamo_output = compile_frame(
+                    code,
+                    globals,
+                    locals,
+                    builtins,
+                    closure,
+                    compiler_fn,
+                    one_graph,
+                    restart_reasons,
+                    export=export,
+                    export_constraints=export_constraints,
+                    frame_state=frame_state,
+                    distributed_state=distributed_state,
+                    package=package,
+                )
         except exc.SkipFrame as e:
             if one_graph:
                 log.debug("No graph captured with export/fullgraph=True")

--- a/torch/_dynamo/graph_id_filter.py
+++ b/torch/_dynamo/graph_id_filter.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import functools
 import logging
 import re
+import warnings
 from typing import Any, Generic, TYPE_CHECKING, TypeVar
 
 
@@ -322,9 +323,27 @@ def _create_backend_router(config_str: str) -> GraphBackendRouter:
 
 
 @functools.lru_cache
-def _create_config_router(config_str: str) -> GraphConfigRouter:
+def _create_inductor_config_router(config_str: str) -> GraphConfigRouter:
     """Create and cache GraphConfigRouter instances based on config string."""
     return GraphConfigRouter(config_str)
+
+
+@functools.lru_cache
+def _create_dynamo_config_router(config_str: str) -> GraphConfigRouter:
+    """Create and cache GraphConfigRouter for dynamo config overrides.
+
+    Warns that dynamo config overrides are keyed by frame ID and some configs
+    can affect graph breaks, which may shift frame IDs.
+    """
+    router = GraphConfigRouter(config_str)
+    if not router.is_empty():
+        warnings.warn(
+            "TORCH_COMPILE_OVERRIDE_DYNAMO_CONFIGS is set. Dynamo config overrides are "
+            "keyed by frame ID. Some dynamo configs can affect graph breaks, "
+            "which may alter the number of frames and shift frame IDs, causing "
+            "overrides to target the wrong graphs.",
+        )
+    return router
 
 
 def get_backend_override_for_compile_id(
@@ -356,8 +375,25 @@ def get_inductor_config_override_for_compile_id(
     return _get_override_for_compile_id(
         compile_id,
         config_str,
-        _create_config_router,  # type: ignore[arg-type]
+        _create_inductor_config_router,  # type: ignore[arg-type]
         "inductor config",
+    )
+
+
+def get_dynamo_config_override_for_compile_id(
+    compile_id: CompileId | None,
+    config_str: str,
+) -> dict[str, Any] | None:
+    """
+    Get the dynamo config override for a given CompileId.
+
+    Returns a dict of config patches to apply, or None if no override applies.
+    """
+    return _get_override_for_compile_id(
+        compile_id,
+        config_str,
+        _create_dynamo_config_router,  # type: ignore[arg-type]
+        "dynamo config",
     )
 
 

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -2688,7 +2688,8 @@ class OutputGraph(OutputGraphCommon):
 
         # Check for per-graph inductor config override (for debugging/bisecting)
         inductor_config_override = get_inductor_config_override_for_compile_id(
-            self.dynamo_compile_id, config.debug_inductor_config_override
+            self.dynamo_compile_id,
+            config.debug_inductor_config_override,
         )
         if inductor_config_override:
             compiler_fn = _wrap_with_inductor_config(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #176681
* #176680

Add per-graph dynamo config overrides, mirroring the existing
debug_inductor_config_override. Set via TORCH_COMPILE_OVERRIDE_DYNAMO_CONFIGS
env var or config.debug_dynamo_config_override. The override is applied as a
config.patch context manager around the entire compile_frame call, so dynamo
config is patched for all tracing and backend compilation within that frame.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo