### PR TITLE
[inductor] Improve fusion scoring for split/cat patterns (#175376)

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -5648,22 +5648,18 @@ class AOTInductorTestsTemplate:
 
         example_inputs = (torch.randint(high=1024, size=(1,), device=self.device),)
 
-        expected_scalar_args = [
-            "triton_poi_fused_zeros_like_0_xnumel",
-            "triton_poi_fused_ones_1_xnumel",
-            "std::max(static_cast<int64_t>(512L), static_cast<int64_t>(u0))",
-        ]
-
         with config.patch({"aot_inductor.debug_intermediate_value_printer": "2"}):
             result, code = run_and_get_cpp_code(
                 AOTIRunnerUtil.compile, Model(), example_inputs
             )
             self.assertEqual("aoti_torch_print_tensor_handle" in code, True)
-            for scalar in expected_scalar_args:
-                FileCheck().check_count(
-                    f"{scalar}",
-                    2,
-                ).run(code)
+            # The debug printer should emit xnumel scalar args for the
+            # fill kernels (ones/zeros_like). Kernel names may change due
+            # to fusion, so match the pattern rather than exact names.
+            FileCheck().check_regex(r"triton_poi_fused_\w+_xnumel").check_count(
+                "std::max(static_cast<int64_t>(512L), static_cast<int64_t>(u0))",
+                2,
+            ).run(code)
 
     @unittest.skipIf(
         not PLATFORM_SUPPORTS_FP8,
@@ -5807,24 +5803,19 @@ class AOTInductorTestsTemplate:
         example_inputs = (
             torch.randint(high=1024, size=(1,), device=self.device, dtype=torch.int32),
         )
-        # This simple unit test case model generates two triton kernels:
-        # 1. triton_poi_fused_ones_1:
-        # triton_meta={'signature': {'out_ptr0': '*fp32', 'xnumel': 'i64'}
-        # 2. add_kernel:
-        # triton_meta={'signature': {'in_ptr0': '*fp32', 'in_ptr1': '*fp32', 'out_ptr': '*fp32', 'n_elements': 'i64'}
-        # input u0 was defined as int32_t initially, verify for every kernel var args downstream,
-        # it gets explicitly declared using its data types in the cpp wrapper codegen code.
+        # This simple unit test case model generates triton kernels:
+        # 1. triton_poi_fused_ones_zeros_like (fill ops fused)
+        # 2. add_kernel
+        # input u0 was defined as int32_t initially, verify for every kernel
+        # var args downstream, it gets explicitly declared using its data
+        # types in the cpp wrapper codegen code.
         expected_scalar_args = [
-            "buf3, u0",
-            "buf4, u0",
-            "buf4, buf5, buf3, u0",
+            "buf3, buf4, buf5, u0",
         ]
         if full_aoti_runtime_assert():
-            # we'll have one more assertion
+            # OSS has one more assertion
             expected_scalar_args = [
-                "buf4, u0",
-                "buf5, u0",
-                "buf5, buf6, buf4, u0",
+                "buf4, buf5, buf6, u0",
             ]
         # check the new behavior of codegen is expected
         result, code = run_and_get_cpp_code(

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -6107,6 +6107,18 @@ class Scheduler:
         """
         The first term in our fusion score that estimates number of saved
         memory operations.
+
+        This function scores fusion candidates based on shared memory access patterns.
+        Higher scores indicate better fusion candidates.
+
+        Scoring strategy:
+        1. If nodes share exact memory deps (same buffer + same indexing), return
+           the sum of shared dep sizes (original behavior).
+        2. If no exact matches (score == 0), check for same-buffer reads with
+           different indexing (e.g., split operations reading different slices).
+           - Give bonus if nodes read from exactly the same set of buffers
+           - Score based on overlap ratio: common_buffer_size / total_read_size
+           - High overlap (>50%) suggests good cache locality benefit from fusion
         """
 
         def _construct_return_value(score, is_mix_order_reduction):
@@ -6174,9 +6186,189 @@ class Scheduler:
         common_memory_deps = (node1.read_writes.reads | node1.read_writes.writes) & (
             node2.read_writes.reads | node2.read_writes.writes
         )
-        return _construct_return_value(
-            sum(self.dep_size_hint(dep) for dep in common_memory_deps), False
+
+        score = sum(self.dep_size_hint(dep) for dep in common_memory_deps)
+
+        # If no exact dep matches, check for same-buffer reads with different indexing.
+        # This handles cases like split operations that read different slices of the
+        # same buffer - they should fuse for cache locality benefits.
+        if score == 0 and self._can_use_buffer_overlap_scoring(node1, node2):
+            score = self._score_fusion_memory_by_buffer_overlap(node1, node2)
+
+        return _construct_return_value(score, False)
+
+    def _can_use_buffer_overlap_scoring(
+        self,
+        node1: BaseSchedulerNode,
+        node2: BaseSchedulerNode,
+    ) -> bool:
+        """
+        Check if buffer overlap scoring should be used for this node pair.
+
+        Buffer overlap scoring handles split/cat patterns where nodes read from
+        the same buffer at different indices. We skip it when:
+        - Either node is a reduction (different memory access patterns)
+        - Either node is a template
+        - Both nodes are prologue/epilogue candidates for the same template,
+          because horizontal fusion would prevent them from being absorbed
+          into the template kernel. For example, in:
+            q = a[:64, :]; k = a[64:, :]
+            return mm(q + 2, k - 2)
+          "q + 2" and "k - 2" both read from `a` and would get a high overlap
+          score, but fusing them horizontally prevents prologue fusion into mm
+          (resulting in 2 kernels instead of 1).
+
+        We allow buffer overlap scoring when:
+        - The node outputs are not actually in the template's allowed_prologue_inps,
+          meaning they can't be prologue-fused anyway, so horizontal fusion doesn't
+          prevent any optimization opportunity.
+        """
+        if node1.is_reduction() or node2.is_reduction():
+            return False
+        if node1.is_template() or node2.is_template():
+            return False
+
+        if config.max_autotune and (config.prologue_fusion or config.epilogue_fusion):
+            node1_outputs = node1.get_outputs()
+            node2_outputs = node2.get_outputs()
+
+            # Early return if either node has no outputs
+            if not node1_outputs or not node2_outputs:
+                return True
+
+            node1_output_names = OrderedSet(buf.get_name() for buf in node1_outputs)
+            node2_output_names = OrderedSet(buf.get_name() for buf in node2_outputs)
+
+            # Find templates that consume node1's outputs via buffer users
+            # and check if the outputs are actually prologue-fusable
+            node1_prologue_eligible_template_users: OrderedSet[BaseSchedulerNode] = (
+                OrderedSet()
+            )
+            for buf in node1_outputs:
+                for user in buf.users:
+                    if (
+                        isinstance(user.node, BaseSchedulerNode)
+                        and user.node.is_template()
+                    ):
+                        # Check if this output is actually in the template's
+                        # allowed_prologue_inps. If not, fusing horizontally
+                        # won't prevent any prologue fusion opportunity.
+                        template_node = user.node.get_template_node()
+                        if template_node is not None and isinstance(
+                            template_node, ir.TritonTemplateBuffer
+                        ):
+                            allowed_inps = template_node.get_allowed_prologue_inps()
+                            if node1_output_names & allowed_inps:
+                                node1_prologue_eligible_template_users.add(user.node)
+                        else:
+                            # Conservative: assume it could be a prologue candidate
+                            node1_prologue_eligible_template_users.add(user.node)
+
+            # Check if any of node1's prologue-eligible template users also consume
+            # node2's outputs in a prologue-eligible way
+            if node1_prologue_eligible_template_users:
+                for buf in node2_outputs:
+                    for user in buf.users:
+                        if (
+                            isinstance(user.node, BaseSchedulerNode)
+                            and user.node.is_template()
+                            and user.node in node1_prologue_eligible_template_users
+                        ):
+                            # Also verify node2's output is prologue-eligible
+                            template_node = user.node.get_template_node()
+                            if template_node is not None and isinstance(
+                                template_node, ir.TritonTemplateBuffer
+                            ):
+                                allowed_inps = template_node.get_allowed_prologue_inps()
+                                if node2_output_names & allowed_inps:
+                                    return False
+                            else:
+                                # Conservative: block fusion
+                                return False
+
+        return True
+
+    def _score_fusion_memory_by_buffer_overlap(
+        self, node1: BaseSchedulerNode, node2: BaseSchedulerNode
+    ) -> int:
+        """
+        Score fusion based on buffer name overlap when exact dep matching fails.
+
+        This handles the split/cat fusion case where nodes read from the same buffer
+        but at different indices (e.g., different slices from a split operation).
+
+        Scoring logic:
+        - If nodes read from exactly the same buffers: high bonus (encourages fusion)
+        - For common buffers: score based on overlap ratio
+          - overlap_ratio = common_buffer_size / max(node1_total_reads, node2_total_reads)
+          - If overlap_ratio > threshold (e.g., 0.5): give proportional score
+          - If overlap_ratio < threshold: minimal/no score (not worth fusing)
+
+        Note on dynamic shapes:
+        - When deps have unbacked symbols (dynamic shapes), dep_size_hint returns 0
+        - In this case, we use count * 10 as a proxy for size
+        - This ensures fusion still works for models with dynamic batch sizes
+
+        Note on multiple deps from same buffer:
+        - A node may have multiple MemoryDep entries for the same buffer name
+          (e.g., 4 split reads from arg0_1 at different indices)
+        - We sum ALL dep sizes for each buffer, not just take max
+        - This ensures overlap ratio is calculated correctly when nodes read
+          multiple slices from the same underlying buffer
+        """
+        # Minimum overlap ratio to consider fusion beneficial
+        MIN_OVERLAP_RATIO = 0.5
+        # Fallback size when dep_size_hint returns 0 (e.g., unbacked symbols)
+        FALLBACK_DEP_SIZE = 10
+
+        def get_dep_size(dep: Dep) -> int:
+            size = self.dep_size_hint(dep)
+            return size if size > 0 else FALLBACK_DEP_SIZE
+
+        node1_read_names = OrderedSet(dep.name for dep in node1.read_writes.reads)
+        node2_read_names = OrderedSet(dep.name for dep in node2.read_writes.reads)
+
+        # Early exit if no common buffer names
+        common_names = node1_read_names & node2_read_names
+
+        if not common_names:
+            return 0
+
+        # Calculate total read sizes for each node (sum of ALL deps)
+        node1_total_read_size = sum(
+            get_dep_size(dep) for dep in node1.read_writes.reads
         )
+        node2_total_read_size = sum(
+            get_dep_size(dep) for dep in node2.read_writes.reads
+        )
+
+        max_total_read_size = max(node1_total_read_size, node2_total_read_size)
+        if max_total_read_size == 0:
+            return 0
+
+        # Calculate total reads from common buffers for each node
+        # Sum ALL deps for each common buffer name (handles multiple reads from same buffer)
+        node1_common_read_size = sum(
+            get_dep_size(dep)
+            for dep in node1.read_writes.reads
+            if dep.name in common_names
+        )
+        node2_common_read_size = sum(
+            get_dep_size(dep)
+            for dep in node2.read_writes.reads
+            if dep.name in common_names
+        )
+
+        # Use max of the two as the common buffer size estimate
+        # This represents how much data is being read from shared buffers
+        common_read_buffer_size = max(node1_common_read_size, node2_common_read_size)
+
+        # Calculate overlap ratio
+        overlap_ratio = common_read_buffer_size / max_total_read_size
+        # Scale score by overlap ratio and common buffer size
+        # Higher overlap = higher score
+        # Larger common buffer = higher score (more cache benefit)
+        return common_read_buffer_size if overlap_ratio >= MIN_OVERLAP_RATIO else 0
 
     def get_possible_fusions_with_highest_priority(
         self, possible_fusions: list[tuple[BaseSchedulerNode, BaseSchedulerNode]]


### PR DESCRIPTION
Summary:

The existing score_fusion_memory only gives credit for exact MemoryDep matches, failing to fuse split/cat patterns where nodes read from the same buffer at different indices

This diff added _score_fusion_memory_by_buffer_overlap fallback that: Identifies common buffer names (even with different indices) Calculates overlap ratio = common_buffer_reads / max_total_reads Returns score when overlap_ratio >= threshold

facebook
See discussion in this post: https://fb.workplace.com/groups/385893200869952/permalink/903164959142771/

**Detailed explanation in: https://fburl.com/gdoc/j3fz4y0h**

Test Plan:
#facebook

Split/cat ops that previously got score=0 → 2 kernels, now get score=512 → 1 kernel

```
buck2 run mode/opt \
  -c fbcode.platform010_cuda_version=12.8 \
  -c fbcode.nvcc_arch=b200 \
  fbcode//caffe2/test/inductor:inductor_scheduler -- TestScoreFusionMemory
```
For the model described in the post,
QPS improves from 1024: https://www.internalfb.com/vanguard/serving_test_cases/1227345635634286 to
1464: https://www.internalfb.com/vanguard/serving_test_cases/776937304961572

Reviewed By: htyu

Differential Revision: D93671962

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo