### PR TITLE
[inductor] Improve fusion scoring for split/cat patterns (#175376)

### DIFF
--- a/test/inductor/test_inductor_scheduler.py
+++ b/test/inductor/test_inductor_scheduler.py
@@ -4,6 +4,7 @@ from unittest import skipIf
 from unittest.mock import Mock
 
 import torch
+import torch._inductor.config as inductor_config
 import torch._inductor.metrics as metrics
 import torch.utils.flop_counter
 from torch._dynamo.utils import counters
@@ -23,7 +24,7 @@ from torch.testing._internal.common_utils import (
     skipIfXpu,
     TestCase,
 )
-from torch.testing._internal.inductor_utils import IS_BIG_GPU
+from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU, IS_BIG_GPU
 from torch.utils._ordered_set import OrderedSet
 
 
@@ -290,7 +291,143 @@ class TestScheduler(TestCase):
         )
 
 
+class TestScoreFusionMemory(TestCase):
+    """
+    Tests for _score_fusion_memory_by_buffer_overlap.
+
+    These tests validate the fusion scoring logic that determines when nodes
+    should be fused together based on their memory access patterns.
+
+    Key scenarios:
+    1. Exact matches: read/write has exact matches → should fuse (1 kernel)
+    2. Large overlap (split/cat): reads on different offset but overlap is huge
+       → should fuse because the benefit is large (1 kernel)
+    3. Small overlap: reads on different offset but overlap is small → don't fuse (2 kernels)
+    """
+
+    @skipIf(not HAS_GPU, "GPU not available")
+    @inductor_config.patch("score_fusion_memory_threshold", 1)
+    @inductor_config.patch("min_overlap_ratio", 0.5)
+    def test_exact_same_reads_should_fuse(self) -> None:
+        """
+        Case 1: Exact matches in read/write → should fuse into 1 kernel.
+
+        Two operations reading from the exact same input tensor should be
+        fused together since they can share the data read from memory.
+        """
+
+        def exact_reads(x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+            # Both operations read the exact same input
+            out1 = x * 2
+            out2 = x + 1
+            return out1, out2
+
+        torch._dynamo.reset()
+        metrics.reset()
+
+        x = torch.randn(8, 512, device=GPU_TYPE, dtype=torch.float16)
+
+        compiled_fn = torch.compile(exact_reads, backend="inductor", fullgraph=True)
+        out1_eager, out2_eager = exact_reads(x)
+        out1_compiled, out2_compiled = compiled_fn(x)
+
+        self.assertTrue(torch.allclose(out1_eager, out1_compiled, atol=1e-3, rtol=1e-3))
+        self.assertTrue(torch.allclose(out2_eager, out2_compiled, atol=1e-3, rtol=1e-3))
+        # Should fuse into 1 kernel since both ops read exact same buffer
+        self.assertEqual(metrics.generated_kernel_count, 1)
+
+    @skipIf(not HAS_GPU, "GPU not available")
+    @inductor_config.patch("score_fusion_memory_threshold", 1)
+    @inductor_config.patch("min_overlap_ratio", 0.5)
+    def test_split_cat_large_overlap_should_fuse(self) -> None:
+        """
+        Case 2: Reads on different offset but overlap is huge (split/cat) → should fuse into 1 kernel.
+
+        Split operations read from the same input buffer at different offsets.
+        Since the overlap is large (same underlying buffer), fusing these
+        operations together saves reads and kernel launches.
+        """
+
+        def split_and_process(x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+            s1, s2, s3, s4 = torch.split(x, x.shape[-1] // 4, dim=-1)
+            out1 = torch.cat([s4, s3], dim=-1)
+            out2 = torch.cat([s2, s1], dim=-1)
+            return out1, out2
+
+        torch._dynamo.reset()
+        metrics.reset()
+
+        x = torch.randn(8, 512, device=GPU_TYPE, dtype=torch.float16)
+
+        compiled_fn = torch.compile(
+            split_and_process, backend="inductor", fullgraph=True
+        )
+        out1_eager, out2_eager = split_and_process(x)
+        out1_compiled, out2_compiled = compiled_fn(x)
+
+        self.assertTrue(torch.allclose(out1_eager, out1_compiled, atol=1e-3, rtol=1e-3))
+        self.assertTrue(torch.allclose(out2_eager, out2_compiled, atol=1e-3, rtol=1e-3))
+        # Should fuse into 1 kernel since all ops read from the same underlying buffer
+        self.assertEqual(metrics.generated_kernel_count, 1)
+
+    @skipIf(not HAS_GPU, "GPU not available")
+    @inductor_config.patch("score_fusion_memory_threshold", 1)
+    def test_partial_overlap_below_threshold(self) -> None:
+        """
+        Case 3: Partial overlap below the 0.5 threshold → should NOT fuse (2 kernels).
+
+        Similar to test_split_cat_large_overlap_should_fuse, but each operation
+        also reads from a separate large tensor, making the shared buffer portion
+        less than 50% of total reads.
+
+        Example scenario:
+        - Split x into 4 slices: s1, s2, s3, s4 (each 25% of x)
+        - op1 reads: s1 (from x, ~25%) + y (separate tensor, ~75%) → total 100%
+        - op2 reads: s2 (from x, ~25%) + z (separate tensor, ~75%) → total 100%
+        - Common buffer is x, but each op only reads 25% of their total from x
+        - overlap_ratio = 25% / 100% = 0.25 < 0.5 threshold → score = 0
+        - Result: 2 separate kernels (not fused)
+        """
+
+        def partial_overlap_split(
+            x: torch.Tensor, y: torch.Tensor, z: torch.Tensor
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            # Split x into 4 parts, use different slices in each output
+            s1, s2, _, _ = torch.split(x, x.shape[-1] // 4, dim=-1)
+            # op1 reads: s1 (small slice of x) + y (large separate tensor)
+            # op2 reads: s2 (small slice of x) + z (large separate tensor)
+            # The slices s1 and s2 come from the same buffer x,
+            # but each is only ~25% of total reads for that op
+            out1 = torch.cat([s1, y, y, y], dim=-1)
+            out2 = torch.cat([s2, z, z, z], dim=-1)
+            return out1, out2
+
+        torch._dynamo.reset()
+        metrics.reset()
+
+        # x is split into 4 parts (each 128 elements)
+        # y and z are 3x larger (384 elements each)
+        # So each op reads: 128 (from x slice) + 384 (from y or z) = 512 total
+        # overlap_ratio = 128 / 512 = 0.25 < 0.5 threshold
+        x = torch.randn(8, 512, device=GPU_TYPE, dtype=torch.float16)
+        y = torch.randn(8, 128, device=GPU_TYPE, dtype=torch.float16)
+        z = torch.randn(8, 128, device=GPU_TYPE, dtype=torch.float16)
+
+        compiled_fn = torch.compile(
+            partial_overlap_split, backend="inductor", fullgraph=True
+        )
+        out1_eager, out2_eager = partial_overlap_split(x, y, z)
+        out1_compiled, out2_compiled = compiled_fn(x, y, z)
+
+        self.assertTrue(torch.allclose(out1_eager, out1_compiled, atol=1e-3, rtol=1e-3))
+        self.assertTrue(torch.allclose(out2_eager, out2_compiled, atol=1e-3, rtol=1e-3))
+        # Should NOT fuse (2 kernels) because overlap_ratio = 0.25 < 0.5 threshold
+        # The _score_fusion_memory_by_buffer_overlap returns 0 for this case
+        self.assertEqual(metrics.generated_kernel_count, 2)
+
+
 instantiate_device_type_tests(TestScheduler, globals(), allow_xpu=True)
+instantiate_device_type_tests(TestScoreFusionMemory, globals(), allow_xpu=True)
 
 if __name__ == "__main__":
     run_tests()

--- a/torch/_inductor/choices.py
+++ b/torch/_inductor/choices.py
@@ -58,12 +58,17 @@ class FusionScore:
     template_score: int
     node_type_score: bool
     memory_score: int
+    buffer_overlap_score: int
     proximity_score: int
 
     def __lt__(self, other):
         """
         node_type_score has higher priority than memory_score unless
-        the memory_score differs too much
+        the memory_score differs too much.
+
+        buffer_overlap_score is prioritized below memory_score so that
+        strict global memory savings (exact dep matches) are preferred
+        over buffer overlap scoring (same buffer, different indexing).
         """
         threshold = 16
         if self.template_score != other.template_score:
@@ -75,9 +80,15 @@ class FusionScore:
         ):
             return self.memory_score < other.memory_score
 
-        return (self.node_type_score, self.memory_score, self.proximity_score) < (
+        return (
+            self.node_type_score,
+            self.memory_score,
+            self.buffer_overlap_score,
+            self.proximity_score,
+        ) < (
             other.node_type_score,
             other.memory_score,
+            other.buffer_overlap_score,
             other.proximity_score,
         )
 
@@ -632,8 +643,8 @@ class InductorChoices:
         - Fusions closer together in original graph order
         """
 
-        memory_score, is_mix_order_reduction = typing.cast(
-            tuple[int, bool],
+        memory_score, buffer_overlap_score, is_mix_order_reduction = typing.cast(
+            tuple[int, int, bool],
             scheduler.score_fusion_memory(
                 node1, node2, return_is_mix_order_reduction=True
             ),
@@ -658,5 +669,6 @@ class InductorChoices:
             template_score,
             type_score,
             memory_score,
+            buffer_overlap_score,
             proximity_score,
         )

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -825,6 +825,10 @@ max_epilogue_benchmarked_choices = 1
 # how many nodes to allow into a single fusion
 max_fusion_size = 64
 
+# Minimum overlap ratio to consider fusion beneficial when inputs are shared by no indices overlapped.
+# Valid range: [0, 1]. Default to not fusion.
+min_overlap_ratio = 1.1
+
 # how many nodes to attempt pairwise fusion with in a buffer group
 max_fusion_buffer_group_pairwise_attempts = 64
 

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -6103,18 +6103,30 @@ class Scheduler:
         count_bytes: bool = True,
         return_is_mix_order_reduction: bool = False,
         allow_mix_order_reduction: bool = True,
-    ) -> int | tuple[int, bool]:
+    ) -> int | tuple[int, int, bool]:
         """
         The first term in our fusion score that estimates number of saved
         memory operations.
+
+        This function scores fusion candidates based on shared memory access patterns.
+        Higher scores indicate better fusion candidates.
+
+        Scoring strategy:
+        1. If nodes share exact memory deps (same buffer + same indexing), return
+           the sum of shared dep sizes (original behavior).
+        2. If no exact matches (score == 0), check for same-buffer reads with
+           different indexing (e.g., split operations reading different slices).
+           - Give bonus if nodes read from exactly the same set of buffers
+           - Score based on overlap ratio: common_buffer_size / total_read_size
+           - High overlap (>50%) suggests good cache locality benefit from fusion
         """
 
-        def _construct_return_value(score, is_mix_order_reduction):
-            return (
-                (score, is_mix_order_reduction)
-                if return_is_mix_order_reduction
-                else score
-            )
+        def _construct_return_value(
+            score, buffer_overlap_score, is_mix_order_reduction
+        ):
+            if return_is_mix_order_reduction:
+                return (score, buffer_overlap_score, is_mix_order_reduction)
+            return score + buffer_overlap_score
 
         if allow_mix_order_reduction and MixOrderReduction.can_fuse(node1, node2):
             # The fusion score for mix order reduction only count
@@ -6122,7 +6134,7 @@ class Scheduler:
             # sharing the same amount of numels go first; but make
             # fusions only share weight/bias go later.
             score = MixOrderReduction.get_fusion_score(node1, node2)
-            return _construct_return_value(score, True)
+            return _construct_return_value(score, 0, True)
 
         # for evaluating fusion memory scores of UserDefinedTritonKernel,
         # we use a slightly different logic which allows matching StarDep with MemoryDep in certain scenarios.
@@ -6151,7 +6163,7 @@ class Scheduler:
                             self.dep_size_hint(node1_dep), self.dep_size_hint(node2_dep)
                         )
 
-            return _construct_return_value(score, False)
+            return _construct_return_value(score, 0, False)
 
         node1_dep_len = len(node1.read_writes.reads) + len(node1.read_writes.writes)
         node2_dep_len = len(node2.read_writes.reads) + len(node2.read_writes.writes)
@@ -6168,14 +6180,208 @@ class Scheduler:
             ]
 
             return _construct_return_value(
-                sum(self.dep_size_hint(dep, count_bytes) for dep in deps), False
+                sum(self.dep_size_hint(dep, count_bytes) for dep in deps), 0, False
             )
 
         common_memory_deps = (node1.read_writes.reads | node1.read_writes.writes) & (
             node2.read_writes.reads | node2.read_writes.writes
         )
-        return _construct_return_value(
-            sum(self.dep_size_hint(dep) for dep in common_memory_deps), False
+
+        score = sum(self.dep_size_hint(dep) for dep in common_memory_deps)
+
+        # If no exact dep matches, check for same-buffer reads with different indexing.
+        # This handles cases like split operations that read different slices of the
+        # same buffer - they should fuse for cache locality benefits.
+        buffer_overlap_score = 0
+        if score == 0 and self._can_use_buffer_overlap_scoring(node1, node2):
+            buffer_overlap_score = self._score_fusion_memory_by_buffer_overlap(
+                node1, node2
+            )
+
+        return _construct_return_value(score, buffer_overlap_score, False)
+
+    def _can_use_buffer_overlap_scoring(
+        self,
+        node1: BaseSchedulerNode,
+        node2: BaseSchedulerNode,
+    ) -> bool:
+        """
+        Check if buffer overlap scoring should be used for this node pair.
+
+        Buffer overlap scoring handles split/cat patterns where nodes read from
+        the same buffer at different indices. We skip it when:
+        - Either node is a reduction (different memory access patterns)
+        - Either node is a template
+        - Both nodes are prologue/epilogue candidates for the same template,
+          because horizontal fusion would prevent them from being absorbed
+          into the template kernel. For example, in:
+            q = a[:64, :]; k = a[64:, :]
+            return mm(q + 2, k - 2)
+          "q + 2" and "k - 2" both read from `a` and would get a high overlap
+          score, but fusing them horizontally prevents prologue fusion into mm
+          (resulting in 2 kernels instead of 1).
+
+        We allow buffer overlap scoring when:
+        - The node outputs are not actually in the template's allowed_prologue_inps,
+          meaning they can't be prologue-fused anyway, so horizontal fusion doesn't
+          prevent any optimization opportunity.
+        """
+        if node1.is_reduction() or node2.is_reduction():
+            return False
+        if node1.is_template() or node2.is_template():
+            return False
+
+        if (config.max_autotune or config.max_autotune_gemm) and (
+            config.prologue_fusion or config.epilogue_fusion
+        ):
+            node1_outputs = node1.get_outputs()
+            node2_outputs = node2.get_outputs()
+
+            # Early return if either node has no outputs
+            if not node1_outputs or not node2_outputs:
+                return True
+
+            node1_output_names = OrderedSet(buf.get_name() for buf in node1_outputs)
+            node2_output_names = OrderedSet(buf.get_name() for buf in node2_outputs)
+
+            # Find templates that consume node1's outputs via buffer users
+            # and check if the outputs are actually prologue-fusable
+            node1_prologue_eligible_template_users: OrderedSet[BaseSchedulerNode] = (
+                OrderedSet()
+            )
+            for buf in node1_outputs:
+                for user in buf.users:
+                    if (
+                        isinstance(user.node, BaseSchedulerNode)
+                        and user.node.is_template()
+                    ):
+                        # Check if this output is actually in the template's
+                        # allowed_prologue_inps. If not, fusing horizontally
+                        # won't prevent any prologue fusion opportunity.
+                        template_node = user.node.get_template_node()
+                        if template_node is not None and isinstance(
+                            template_node, ir.TritonTemplateBuffer
+                        ):
+                            allowed_inps = template_node.get_allowed_prologue_inps()
+                            if node1_output_names & allowed_inps:
+                                node1_prologue_eligible_template_users.add(user.node)
+                        else:
+                            # Conservative: assume it could be a prologue candidate
+                            node1_prologue_eligible_template_users.add(user.node)
+
+            # Check if any of node1's prologue-eligible template users also consume
+            # node2's outputs in a prologue-eligible way
+            if node1_prologue_eligible_template_users:
+                for buf in node2_outputs:
+                    for user in buf.users:
+                        if (
+                            isinstance(user.node, BaseSchedulerNode)
+                            and user.node.is_template()
+                            and user.node in node1_prologue_eligible_template_users
+                        ):
+                            # Also verify node2's output is prologue-eligible
+                            template_node = user.node.get_template_node()
+                            if template_node is not None and isinstance(
+                                template_node, ir.TritonTemplateBuffer
+                            ):
+                                allowed_inps = template_node.get_allowed_prologue_inps()
+                                if node2_output_names & allowed_inps:
+                                    return False
+                            else:
+                                # Conservative: block fusion
+                                return False
+
+            if config.epilogue_fusion:
+                for node in (node1, node2):
+                    for dep in node.read_writes.reads:
+                        producer = self.name_to_fused_node.get(dep.name)
+                        if producer is not None and producer.is_template():
+                            return False
+
+        return True
+
+    def _score_fusion_memory_by_buffer_overlap(
+        self, node1: BaseSchedulerNode, node2: BaseSchedulerNode
+    ) -> int:
+        """
+        Score fusion based on buffer name overlap when exact dep matching fails.
+
+        This handles the split/cat fusion case where nodes read from the same buffer
+        but at different indices (e.g., different slices from a split operation).
+
+        Scoring logic:
+        - If nodes read from exactly the same buffers: high bonus (encourages fusion)
+        - For common buffers: score based on overlap ratio
+          - overlap_ratio = common_buffer_size /
+            max(node1_total_reads, node2_total_reads)
+          - If overlap_ratio > threshold (e.g., 0.5): give proportional score
+          - If overlap_ratio < threshold: minimal/no score (not worth fusing)
+
+        Note on dynamic shapes:
+        - When deps have unbacked symbols (dynamic shapes), dep_size_hint returns 0
+        - In this case, we use count * 10 as a proxy for size
+        - This ensures fusion still works for models with dynamic batch sizes
+
+        Note on multiple deps from same buffer:
+        - A node may have multiple MemoryDep entries for the same buffer name
+          (e.g., 4 split reads from arg0_1 at different indices)
+        - We sum ALL dep sizes for each buffer, not just take max
+        - This ensures overlap ratio is calculated correctly when nodes read
+          multiple slices from the same underlying buffer
+        """
+        # Fallback size when dep_size_hint returns 0 (e.g., unbacked symbols)
+        FALLBACK_DEP_SIZE = 10
+
+        def get_dep_size(dep: Dep) -> int:
+            size = self.dep_size_hint(dep)
+            return size if size > 0 else FALLBACK_DEP_SIZE
+
+        node1_read_names = OrderedSet(dep.name for dep in node1.read_writes.reads)
+        node2_read_names = OrderedSet(dep.name for dep in node2.read_writes.reads)
+
+        # Early exit if no common buffer names
+        common_names = node1_read_names & node2_read_names
+
+        if not common_names:
+            return 0
+
+        # Calculate total read sizes for each node (sum of ALL deps)
+        node1_total_read_size = sum(
+            get_dep_size(dep) for dep in node1.read_writes.reads
+        )
+        node2_total_read_size = sum(
+            get_dep_size(dep) for dep in node2.read_writes.reads
+        )
+
+        max_total_read_size = max(node1_total_read_size, node2_total_read_size)
+        if max_total_read_size == 0:
+            return 0
+
+        # Calculate total reads from common buffers for each node
+        # Sum ALL deps for each common buffer name
+        # (handles multiple reads from same buffer)
+        node1_common_read_size = sum(
+            get_dep_size(dep)
+            for dep in node1.read_writes.reads
+            if dep.name in common_names
+        )
+        node2_common_read_size = sum(
+            get_dep_size(dep)
+            for dep in node2.read_writes.reads
+            if dep.name in common_names
+        )
+
+        # Use max of the two as the common buffer size estimate
+        # This represents how much data is being read from shared buffers
+        common_read_buffer_size = max(node1_common_read_size, node2_common_read_size)
+
+        # Calculate overlap ratio
+        overlap_ratio = common_read_buffer_size / max_total_read_size
+        # Scale score by overlap ratio and common buffer size
+        # Higher overlap = higher score
+        # Larger common buffer = higher score (more cache benefit)
+        return (
+            common_read_buffer_size if overlap_ratio >= config.min_overlap_ratio else 0
         )
 
     def get_possible_fusions_with_highest_priority(


### PR DESCRIPTION
Summary:

The existing score_fusion_memory only gives credit for exact MemoryDep matches, failing to fuse split/cat patterns where nodes read from the same buffer at different indices

This diff added _score_fusion_memory_by_buffer_overlap fallback that:
Identifies common buffer names (even with different indices)
Calculates overlap ratio = common_buffer_reads / max_total_reads
Returns score when overlap_ratio >= threshold

facebook
See discussion in this post: https://fb.workplace.com/groups/385893200869952/permalink/903164959142771/

**Detailed explanation in: https://fburl.com/gdoc/j3fz4y0h**

Test Plan:
#facebook

Split/cat ops that previously got score=0 → 2 kernels, now get score=512 → 1 kernel

```
buck2 run mode/opt \
  -c fbcode.platform010_cuda_version=12.8 \
  -c fbcode.nvcc_arch=b200 \
  fbcode//caffe2/test/inductor:inductor_scheduler -- TestScoreFusionMemory
```
For the model described in the post,
QPS improves from 1024: https://www.internalfb.com/vanguard/serving_test_cases/1227345635634286
to
1464: https://www.internalfb.com/vanguard/serving_test_cases/776937304961572

Reviewed By: htyu

Differential Revision: D93671962




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo