### PR TITLE
[DataLoader] Eliminate redundant accelerator queries in _BaseDataLoad…

### DIFF
--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -2659,7 +2659,7 @@ class Module:
                     continue
                 if remove_duplicate:
                     memo.add(v)
-                name = module_prefix + ("." if module_prefix else "") + k
+                name = (module_prefix + "." + k) if module_prefix else k
                 yield name, v
 
     def parameters(self, recurse: bool = True) -> Iterator[Parameter]:
@@ -2877,7 +2877,7 @@ class Module:
             for name, module in self._modules.items():
                 if module is None:
                     continue
-                submodule_prefix = prefix + ("." if prefix else "") + name
+                submodule_prefix = (prefix + "." + name) if prefix else name
                 yield from module.named_modules(
                     memo, submodule_prefix, remove_duplicate
                 )

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -669,7 +669,10 @@ class _BaseDataLoaderIter:
                 f"ignore pin_memory_device='{loader.pin_memory_device}'.",
                 stacklevel=2,
             )
-        if loader.pin_memory and not torch.accelerator.is_available():
+        _acc = torch.accelerator.current_accelerator()
+        _acc_available = _acc is not None and torch.get_device_module(_acc).is_available()
+
+        if loader.pin_memory and not _acc_available:
             warn_msg = (
                 "'pin_memory' argument is set as true but no accelerator is found, "
                 "then device pinned memory won't be used."
@@ -678,15 +681,10 @@ class _BaseDataLoaderIter:
 
         # Enabling pin_memory in _BaseDataLoaderIter to support identical
         # behavior in forked implementations using _BaseDataLoaderIter.
-        self._pin_memory = loader.pin_memory and torch.accelerator.is_available()
+        self._pin_memory = loader.pin_memory and _acc_available
 
         # Set pin memory device based on the current accelerator.
-        self._pin_memory_device = (
-            acc.type
-            if self._pin_memory
-            and (acc := torch.accelerator.current_accelerator()) is not None
-            else None
-        )
+        self._pin_memory_device = _acc.type if self._pin_memory else None
 
         # Currently, pin_memory would raise error on the MPS backend (see
         # https://github.com/pytorch/pytorch/issues/86060), so forcibly


### PR DESCRIPTION
Previously, `_BaseDataLoaderIter.__init__` called `torch.accelerator.is_available()` twice and `torch.accelerator.current_accelerator()` a third time on every `DataLoader.__iter__()` invocation. Since `is_available()` internally calls `current_accelerator()` each time, this resulted in 3 C-level accelerator dispatch calls (including a potentially expensive `cuda.is_available()` check) where 1 is sufficient.

Fix by calling `current_accelerator()` once, deriving availability from the result, and reusing both values throughout the block.