### PR TITLE
[autograd] Simplify overridable_args construction in backward() and grad()

### DIFF
--- a/torch/autograd/__init__.py
+++ b/torch/autograd/__init__.py
@@ -354,9 +354,7 @@ def backward(
 
     # Check for __torch_function__ on tensors (similar to torch.autograd.grad)
     # This allows tensor subclasses to customize backward behavior
-    t_tensors = tuple(t for t in tensors if is_tensor_like(t))
-    t_inputs = tuple(t for t in inputs_tuple if is_tensor_like(t))
-    overridable_args = t_tensors + t_inputs
+    overridable_args = tuple(t for t in tensors + inputs_tuple if is_tensor_like(t))
     if has_torch_function(overridable_args):
         return handle_torch_function(
             backward,
@@ -472,9 +470,7 @@ def grad(
     else:
         # pyrefly: ignore [bad-argument-type]
         inputs = tuple(inputs)
-    t_outputs = tuple(i for i in outputs if is_tensor_like(i))
-    t_inputs = tuple(i for i in inputs if is_tensor_like(i))
-    overridable_args = t_outputs + t_inputs
+    overridable_args = tuple(i for i in outputs + inputs if is_tensor_like(i))
     if has_torch_function(overridable_args):
         return handle_torch_function(
             grad,


### PR DESCRIPTION
Both backward() and grad() built two separate intermediate tuples (t_tensors/t_inputs and t_outputs/t_inputs) and concatenated them into a third, solely to pass to has_torch_function(). Neither intermediate is used after that check, making them redundant allocations on every call.

Since tensors, inputs_tuple, outputs, and inputs are already tuples at this point, replace the three-step construction with a single comprehension over their concatenation. This is clearer and avoids the unnecessary temporaries.

-----
This change removes an intermediate tuple construction and keeps the logic slightly simpler while preserving the existing behavior.