### PR TITLE
test(inductor): add regression test for empty cudagraph partitions

### DIFF
--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -5416,6 +5416,23 @@ if HAS_CUDA_AND_TRITON:
                 obs.op_outputs[aten.rand.default][2],
             )
 
+        @patch('torch._inductor.compile_fx.cudagraph_partition_post_compile')
+        def test_cudagraph_empty_partition_raises_error(self, mock_post_compile):
+            """Verify RuntimeError is raised when partitions are empty and cudagraph_or_error=True"""
+            # 1. Simulate empty partitions returning from the post-compile step
+            mock_post_compile.return_value = []
+        
+            def fn(x):
+                return x * 2
+
+            x = torch.randn(4, device='cuda')
+            # This option triggers the logic you fixed
+            compiled_fn = torch.compile(fn, options={"cudagraph_or_error": True})
+        
+            # 2. Verify the fix for issue #176611
+            with self.assertRaisesRegex(RuntimeError, "Unable to find any CUDA graphable partitions"):
+                compiled_fn(x)
+
     instantiate_parametrized_tests(CudaGraphTreeTests)
     instantiate_parametrized_tests(TestSAC)
 


### PR DESCRIPTION
Introduces a regression test in test_cudagraph_trees.py to verify that a RuntimeError is correctly raised when no graphable partitions are found while 'cudagraph_or_error=True' is set.

- Mocks cudagraph_partition_post_compile to return empty partitions.
- Validates the fix for silent failures identified in issue #176611.
- Ensures robust error handling in the Inductor compilation pipeline.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo