### PR TITLE
Avoid redundant allocations and recomputation in optimizer, nn.Module and foreach utils

### DIFF
--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -2646,21 +2646,21 @@ class Module:
         self, get_members_fn, prefix="", recurse=True, remove_duplicate: bool = True
     ):
         r"""Help yield various names + members of modules."""
-        memo = set()
+        memo = set() if remove_duplicate else None
         modules = (
             self.named_modules(prefix=prefix, remove_duplicate=remove_duplicate)
             if recurse
             else [(prefix, self)]
         )
         for module_prefix, module in modules:
-            members = get_members_fn(module)
-            for k, v in members:
-                if v is None or v in memo:
+            for k, v in get_members_fn(module):
+                if v is None:
                     continue
-                if remove_duplicate:
+                if memo is not None:
+                    if v in memo:
+                        continue
                     memo.add(v)
-                name = module_prefix + ("." if module_prefix else "") + k
-                yield name, v
+                yield (module_prefix + "." + k) if module_prefix else k, v
 
     def parameters(self, recurse: bool = True) -> Iterator[Parameter]:
         r"""Return an iterator over module parameters.

--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -1179,7 +1179,7 @@ class Optimizer:
 
         param_set: set[torch.Tensor] = set()
         for group in self.param_groups:
-            param_set.update(set(group["params"]))
+            param_set.update(group["params"])
             if ("param_names" in param_group) != ("param_names" in group):
                 current_group_txt = (
                     "with names" if "param_names" in param_group else "without names"
@@ -1189,7 +1189,7 @@ class Optimizer:
                     f"cannot add param group {current_group_txt} to the optimizer"
                 )
 
-        if not param_set.isdisjoint(set(param_group["params"])):
+        if not param_set.isdisjoint(param_group["params"]):
             raise ValueError("some parameters appear in more than one parameter group")
 
         self.param_groups.append(param_group)

--- a/torch/utils/_foreach_utils.py
+++ b/torch/utils/_foreach_utils.py
@@ -1,3 +1,4 @@
+import functools
 from typing import TypeAlias
 
 import torch
@@ -5,11 +6,13 @@ from torch import Tensor
 from torch.autograd.grad_mode import no_grad
 
 
+@functools.cache
 def _get_foreach_kernels_supported_devices() -> list[str]:
     r"""Return the device type list that supports foreach kernels."""
     return ["cuda", "xpu", "mtia", torch._C._get_privateuse1_backend_name()]
 
 
+@functools.cache
 def _get_fused_kernels_supported_devices() -> list[str]:
     r"""Return the device type list that supports fused kernels in optimizer."""
     return [


### PR DESCRIPTION
This PR removes a few small sources of unnecessary allocations and repeated
computation in Python frontend utilities.

The changes are behavior-preserving and aim to slightly reduce overhead in
frequently used helper paths.

Changes included:

1. torch.optim.Optimizer.add_param_group
   - Remove redundant set() construction when updating and checking parameter sets.
   - `set.update()` and `set.isdisjoint()` already accept arbitrary iterables, so
     converting to `set(...)` first is unnecessary.

   Before:
       param_set.update(set(group["params"]))
       param_set.isdisjoint(set(param_group["params"]))

   After:
       param_set.update(group["params"])
       param_set.isdisjoint(param_group["params"])

   This avoids temporary set allocations when adding parameter groups.

2. torch.nn.Module._named_members
   - Avoid allocating the memo set when `remove_duplicate=False`.
   - Inline `get_members_fn(module)` iteration to remove the temporary
     `members` variable.

   This removes a set allocation in the non-deduplicating path and slightly
   simplifies the loop.

3. torch.utils._foreach_utils
   - Cache device lists returned by helper functions that query backend
     capabilities.

   The supported device sets are constant for the lifetime of the process,
   so caching avoids repeated recomputation.

All changes preserve existing behavior and pass the existing test suite.