### PR TITLE
[Test] Make TestUnaryUfuncs device-generic in test_unary_ufuncs.py

### DIFF
--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -4,6 +4,7 @@
 import torch
 import numpy as np
 
+import pytest
 import sys
 import math
 import warnings
@@ -39,7 +40,7 @@ from torch.testing._internal.common_utils import (
 from torch.testing._internal.common_device_type import (
     expectedFailureMeta, instantiate_device_type_tests, deviceCountAtLeast, onlyNativeDeviceTypes,
     onlyCPU, largeTensorTest, precisionOverride, dtypes,
-    onlyCUDA, skipCPUIf, dtypesIfCUDA, dtypesIfCPU, skipMeta, onlyAccelerator, xfailIfMPSUnsupportedDtype)
+    onlyCUDA, skipCPUIf, dtypesIfCUDA, dtypesIfCPU, skipMeta, onlyAccelerator)
 from torch.testing._internal.common_dtype import (
     all_types_and_complex, all_types_and_complex_and, all_types_and, floating_and_complex_types, complex_types,
     floating_types, floating_and_complex_types_and, integral_types, integral_types_and, get_all_dtypes,
@@ -4242,6 +4243,9 @@ class TestAsArray(TestCase):
         # Copy is forced because of different device
         other = get_another_device(device)
         if other is not None:
+            caps = torch.accelerator.get_device_capability(other)
+            if dtype not in caps.get("supported_dtypes", set()):
+                pytest.xfail(f"{other} doesn't support {dtype}")
             check(same_device=False, device=other, dtype=dtype)
             check(same_device=False, device=other, dtype=dtype, copy=True)
 
@@ -4252,25 +4256,21 @@ class TestAsArray(TestCase):
                     check(same_dtype=False, dtype=other)
                     check(same_dtype=False, dtype=other, copy=True)
 
-    @xfailIfMPSUnsupportedDtype
     @skipMeta
     @dtypes(*all_types_and_complex_and(torch.half, torch.bool, torch.bfloat16))
     def test_copy_tensor(self, device, dtype):
         self._test_copy_with_cvt(identity, device, dtype)
 
-    @xfailIfMPSUnsupportedDtype
     @onlyCPU
     @dtypes(*set(numpy_to_torch_dtype_dict.values()))
     def test_copy_from_numpy(self, device, dtype):
         self._test_copy_with_cvt(to_numpy, device, dtype)
 
-    @xfailIfMPSUnsupportedDtype
     @skipMeta
     @dtypes(*all_types_and_complex_and(torch.half, torch.bfloat16))
     def test_copy_from_dlpack(self, device, dtype):
         self._test_copy_with_cvt(to_dlpack, device, dtype)
 
-    @xfailIfMPSUnsupportedDtype
     @onlyCPU
     @dtypes(*set(numpy_to_torch_dtype_dict.values()))
     def test_copy_from_buffer(self, device, dtype):

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -4119,7 +4119,14 @@ class TestBufferProtocol(TestCase):
 #   The implementation itself is based on the Python Array API:
 #   https://data-apis.org/array-api/latest/API_specification/creation_functions.html
 def get_another_device(device):
-    return "cuda" if torch.device(device).type == "cpu" else "cpu"
+    device_type = torch.device(device).type
+    if device_type == "cpu":
+        # Return first available accelerator, or None if none available
+        if torch.cuda.is_available():
+            return "cuda"
+        return None
+    else:
+        return "cpu"
 
 def identity(tensor):
     return tensor
@@ -4233,8 +4240,8 @@ class TestAsArray(TestCase):
         check(device=device, dtype=dtype, copy=True)
 
         # Copy is forced because of different device
-        if torch.cuda.is_available():
-            other = get_another_device(device)
+        other = get_another_device(device)
+        if other is not None:
             check(same_device=False, device=other, dtype=dtype)
             check(same_device=False, device=other, dtype=dtype, copy=True)
 
@@ -4306,8 +4313,8 @@ class TestAsArray(TestCase):
     def test_unsupported_alias(self, device, dtype):
         original = make_tensor((5, 5), dtype=dtype, device=device)
 
-        if torch.cuda.is_available():
-            other_device = get_another_device(device)
+        other_device = get_another_device(device)
+        if other_device is not None:
             with self.assertRaisesRegex(ValueError,
                                         f"from device '{device}' to '{other_device}'"):
                 torch.asarray(original, device=other_device, copy=False)
@@ -4420,15 +4427,17 @@ class TestAsArray(TestCase):
                 else:
                     self.assertEqual(data, tensor)
 
-    @onlyCUDA
+    @skipMeta  # meta devices don't have meaningful device index behavior
+    @onlyNativeDeviceTypes
     def test_device_without_index(self, device):
-        original = torch.arange(5, device="cuda")
+        device_type = torch.device(device).type  # e.g., "cuda" or "cpu"
+        original = torch.arange(5, device=device_type)
 
-        tensor = torch.asarray(original, device="cuda")
+        tensor = torch.asarray(original, device=device_type)
         # The storage pointers should be equal
         self.assertEqual(original.data_ptr(), tensor.data_ptr())
 
-        tensor = torch.asarray(original, copy=True, device="cuda")
+        tensor = torch.asarray(original, copy=True, device=device_type)
         # The storage pointers should not be equal
         self.assertNotEqual(original.data_ptr(), tensor.data_ptr())
 

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -39,7 +39,7 @@ from torch.testing._internal.common_utils import (
 from torch.testing._internal.common_device_type import (
     expectedFailureMeta, instantiate_device_type_tests, deviceCountAtLeast, onlyNativeDeviceTypes,
     onlyCPU, largeTensorTest, precisionOverride, dtypes,
-    onlyCUDA, skipCPUIf, dtypesIfCUDA, dtypesIfCPU, skipMeta)
+    onlyCUDA, skipCPUIf, dtypesIfCUDA, dtypesIfCPU, skipMeta, onlyAccelerator)
 from torch.testing._internal.common_dtype import (
     all_types_and_complex, all_types_and_complex_and, all_types_and, floating_and_complex_types, complex_types,
     floating_types, floating_and_complex_types_and, integral_types, integral_types_and, get_all_dtypes,
@@ -4122,8 +4122,8 @@ def get_another_device(device):
     device_type = torch.device(device).type
     if device_type == "cpu":
         # Return first available accelerator, or None if none available
-        if torch.cuda.is_available():
-            return "cuda"
+        if torch.accelerator.is_available():
+            return torch.accelerator.current_accelerator().type
         return None
     else:
         return "cpu"
@@ -4427,8 +4427,8 @@ class TestAsArray(TestCase):
                 else:
                     self.assertEqual(data, tensor)
 
-    @skipMeta  # meta devices don't have meaningful device index behavior
-    @onlyNativeDeviceTypes
+    @skipMeta
+    @onlyAccelerator
     def test_device_without_index(self, device):
         device_type = torch.device(device).type  # e.g., "cuda" or "cpu"
         original = torch.arange(5, device=device_type)

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -4427,17 +4427,15 @@ class TestAsArray(TestCase):
                 else:
                     self.assertEqual(data, tensor)
 
-    @skipMeta
     @onlyAccelerator
     def test_device_without_index(self, device):
-        device_type = torch.device(device).type  # e.g., "cuda" or "cpu"
-        original = torch.arange(5, device=device_type)
+        original = torch.arange(5, device=device)
 
-        tensor = torch.asarray(original, device=device_type)
+        tensor = torch.asarray(original, device=device)
         # The storage pointers should be equal
         self.assertEqual(original.data_ptr(), tensor.data_ptr())
 
-        tensor = torch.asarray(original, copy=True, device=device_type)
+        tensor = torch.asarray(original, copy=True, device=device)
         # The storage pointers should not be equal
         self.assertNotEqual(original.data_ptr(), tensor.data_ptr())
 

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -4241,6 +4241,9 @@ class TestAsArray(TestCase):
 
         # Copy is forced because of different device
         other = get_another_device(device)
+        # Skip cross-device test on macOS (MPS doesn't support all dtypes like float64)
+        if other is not None and sys.platform == "darwin":
+            other = None
         if other is not None:
             check(same_device=False, device=other, dtype=dtype)
             check(same_device=False, device=other, dtype=dtype, copy=True)

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -39,11 +39,11 @@ from torch.testing._internal.common_utils import (
 from torch.testing._internal.common_device_type import (
     expectedFailureMeta, instantiate_device_type_tests, deviceCountAtLeast, onlyNativeDeviceTypes,
     onlyCPU, largeTensorTest, precisionOverride, dtypes,
-    onlyCUDA, skipCPUIf, dtypesIfCUDA, dtypesIfCPU, skipMeta, onlyAccelerator)
+    onlyCUDA, skipCPUIf, dtypesIfCUDA, dtypesIfCPU, dtypesIfMPS, skipMeta, onlyAccelerator)
 from torch.testing._internal.common_dtype import (
     all_types_and_complex, all_types_and_complex_and, all_types_and, floating_and_complex_types, complex_types,
     floating_types, floating_and_complex_types_and, integral_types, integral_types_and, get_all_dtypes,
-    float_to_corresponding_complex_type_map, all_types_complex_float8_and
+    float_to_corresponding_complex_type_map, all_types_complex_float8_and, all_mps_types
 )
 
 from torch.utils.dlpack import to_dlpack
@@ -4254,6 +4254,7 @@ class TestAsArray(TestCase):
 
     @skipMeta
     @dtypes(*all_types_and_complex_and(torch.half, torch.bool, torch.bfloat16))
+    @dtypesIfMPS(*all_mps_types())
     def test_copy_tensor(self, device, dtype):
         self._test_copy_with_cvt(identity, device, dtype)
 
@@ -4264,6 +4265,7 @@ class TestAsArray(TestCase):
 
     @skipMeta
     @dtypes(*all_types_and_complex_and(torch.half, torch.bfloat16))
+    @dtypesIfMPS(*all_mps_types())
     def test_copy_from_dlpack(self, device, dtype):
         self._test_copy_with_cvt(to_dlpack, device, dtype)
 

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -4119,14 +4119,14 @@ class TestBufferProtocol(TestCase):
 #   The implementation itself is based on the Python Array API:
 #   https://data-apis.org/array-api/latest/API_specification/creation_functions.html
 def get_another_device(device):
-    device_type = torch.device(device).type
-    if device_type == "cpu":
-        # Return first available accelerator, or None if none available
-        if torch.accelerator.is_available():
-            return torch.accelerator.current_accelerator().type
-        return None
-    else:
+    device = torch.device(device)
+
+    if device.type != "cpu":
         return "cpu"
+
+    acc = torch.accelerator.current_accelerator(True)
+
+    return acc.type if acc is not None else None
 
 def identity(tensor):
     return tensor
@@ -4241,9 +4241,6 @@ class TestAsArray(TestCase):
 
         # Copy is forced because of different device
         other = get_another_device(device)
-        # Skip cross-device test on macOS (MPS doesn't support all dtypes like float64)
-        if other is not None and sys.platform == "darwin":
-            other = None
         if other is not None:
             check(same_device=False, device=other, dtype=dtype)
             check(same_device=False, device=other, dtype=dtype, copy=True)

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -39,11 +39,11 @@ from torch.testing._internal.common_utils import (
 from torch.testing._internal.common_device_type import (
     expectedFailureMeta, instantiate_device_type_tests, deviceCountAtLeast, onlyNativeDeviceTypes,
     onlyCPU, largeTensorTest, precisionOverride, dtypes,
-    onlyCUDA, skipCPUIf, dtypesIfCUDA, dtypesIfCPU, dtypesIfMPS, skipMeta, onlyAccelerator)
+    onlyCUDA, skipCPUIf, dtypesIfCUDA, dtypesIfCPU, skipMeta, onlyAccelerator, xfailIfMPSUnsupportedDtype)
 from torch.testing._internal.common_dtype import (
     all_types_and_complex, all_types_and_complex_and, all_types_and, floating_and_complex_types, complex_types,
     floating_types, floating_and_complex_types_and, integral_types, integral_types_and, get_all_dtypes,
-    float_to_corresponding_complex_type_map, all_types_complex_float8_and, all_mps_types
+    float_to_corresponding_complex_type_map, all_types_complex_float8_and
 )
 
 from torch.utils.dlpack import to_dlpack
@@ -4252,23 +4252,25 @@ class TestAsArray(TestCase):
                     check(same_dtype=False, dtype=other)
                     check(same_dtype=False, dtype=other, copy=True)
 
+    @xfailIfMPSUnsupportedDtype
     @skipMeta
     @dtypes(*all_types_and_complex_and(torch.half, torch.bool, torch.bfloat16))
-    @dtypesIfMPS(*all_mps_types())
     def test_copy_tensor(self, device, dtype):
         self._test_copy_with_cvt(identity, device, dtype)
 
+    @xfailIfMPSUnsupportedDtype
     @onlyCPU
     @dtypes(*set(numpy_to_torch_dtype_dict.values()))
     def test_copy_from_numpy(self, device, dtype):
         self._test_copy_with_cvt(to_numpy, device, dtype)
 
+    @xfailIfMPSUnsupportedDtype
     @skipMeta
     @dtypes(*all_types_and_complex_and(torch.half, torch.bfloat16))
-    @dtypesIfMPS(*all_mps_types())
     def test_copy_from_dlpack(self, device, dtype):
         self._test_copy_with_cvt(to_dlpack, device, dtype)
 
+    @xfailIfMPSUnsupportedDtype
     @onlyCPU
     @dtypes(*set(numpy_to_torch_dtype_dict.values()))
     def test_copy_from_buffer(self, device, dtype):

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -4,7 +4,6 @@
 import torch
 import numpy as np
 
-import pytest
 import sys
 import math
 import warnings
@@ -4241,18 +4240,16 @@ class TestAsArray(TestCase):
         check(device=device, dtype=dtype, copy=True)
 
         # Copy is forced because of different device
-         other = get_another_device(device)
-          if other is not None:
-              try:
-                  caps = torch.accelerator.get_device_capability(other)
-              except Exception:
-                  pass
-              else:
-                  if dtype not in caps["supported_dtypes"]:
-                      self.skipTest(f"{other} doesn't support {dtype}")
-                      
-              check(same_device=False, device=other, dtype=dtype)
-              check(same_device=False, device=other, dtype=dtype, copy=True)
+        other = get_another_device(device)
+        if other is not None:
+            try:
+                caps = torch.accelerator.get_device_capability(other)
+            except Exception:
+                pass
+            else:
+                if dtype not in caps["supported_dtypes"]:
+                    self.skipTest(f"{other} doesn't support {dtype}")
+
             check(same_device=False, device=other, dtype=dtype)
             check(same_device=False, device=other, dtype=dtype, copy=True)
 

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -4241,11 +4241,18 @@ class TestAsArray(TestCase):
         check(device=device, dtype=dtype, copy=True)
 
         # Copy is forced because of different device
-        other = get_another_device(device)
-        if other is not None:
-            caps = torch.accelerator.get_device_capability(other)
-            if dtype not in caps.get("supported_dtypes", set()):
-                pytest.xfail(f"{other} doesn't support {dtype}")
+         other = get_another_device(device)
+          if other is not None:
+              try:
+                  caps = torch.accelerator.get_device_capability(other)
+              except Exception:
+                  pass
+              else:
+                  if dtype not in caps["supported_dtypes"]:
+                      self.skipTest(f"{other} doesn't support {dtype}")
+                      
+              check(same_device=False, device=other, dtype=dtype)
+              check(same_device=False, device=other, dtype=dtype, copy=True)
             check(same_device=False, device=other, dtype=dtype)
             check(same_device=False, device=other, dtype=dtype, copy=True)
 

--- a/test/test_unary_ufuncs.py
+++ b/test/test_unary_ufuncs.py
@@ -17,6 +17,7 @@ from torch.testing._internal.common_device_type import (
     dtypesIfCUDA,
     instantiate_device_type_tests,
     largeTensorTest,
+    onlyAccelerator,
     onlyCPU,
     onlyCUDA,
     onlyNativeDeviceTypes,
@@ -1548,7 +1549,7 @@ class TestUnaryUfuncs(TestCase):
             self.assertGreater(math.copysign(1.0, v), 0.0)
 
     # TODO: update to compare against NumPy by rationalizing with OpInfo
-    @onlyCUDA
+    @onlyAccelerator
     @dtypes(torch.float, torch.double)
     def test_abs_zero(self, device, dtype):
         # Both abs(0.0) and abs(-0.0) should result in 0.0
@@ -1556,7 +1557,7 @@ class TestUnaryUfuncs(TestCase):
         for num in abs_zeros:
             self.assertGreater(math.copysign(1.0, num), 0.0)
 
-    @onlyCUDA
+    @onlyAccelerator
     @dtypes(torch.bool, torch.int8)
     def test_narrow_dtypes(self, device, dtype):
         x_int = torch.randint(2, (8 * 1024,), device=device, dtype=torch.int)
@@ -1612,7 +1613,7 @@ class TestUnaryUfuncs(TestCase):
         self.assertEqual(1, len(z))
         self.assertEqual(torch.empty(0, dtype=torch.long), z[0])
 
-    @onlyCUDA
+    @onlyAccelerator
     @dtypes(torch.int8)
     @largeTensorTest("8GB")
     def test_nonzero_large(self, device, dtype):

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -1703,6 +1703,19 @@ def onlyPRIVATEUSE1(fn):
     return onlyOn(device_type)(fn)
 
 
+def onlyAccelerator(fn):
+    """Skip test if not running on an accelerator device (i.e., skip on CPU and meta)."""
+
+    @wraps(fn)
+    def only_fn(self, *args, **kwargs):
+        if self.device_type in ("cpu", "meta"):
+            reason = "onlyAccelerator: doesn't run on CPU or meta devices"
+            raise unittest.SkipTest(reason)
+        return fn(self, *args, **kwargs)
+
+    return only_fn
+
+
 def onlyCUDAAndPRIVATEUSE1(fn):
     @wraps(fn)
     def only_fn(self, *args, **kwargs):

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -15,8 +15,6 @@ from functools import partial, wraps
 from typing import Any, ClassVar, TypeVar
 from typing_extensions import ParamSpec
 
-import pytest
-
 import torch
 from torch._inductor.utils import GPU_TYPES
 from torch._utils import _is_privateuse1_backend_available
@@ -27,7 +25,7 @@ from torch.testing._internal.common_cuda import (
     TEST_CUSPARSE_GENERIC,
     TEST_HIPSPARSE_GENERIC,
 )
-from torch.testing._internal.common_dtype import all_mps_types, get_all_dtypes
+from torch.testing._internal.common_dtype import get_all_dtypes
 from torch.testing._internal.common_utils import (
     _TestParametrizer,
     clear_tracked_input,
@@ -1716,18 +1714,6 @@ def onlyAccelerator(fn):
         return fn(self, *args, **kwargs)
 
     return only_fn
-
-
-def xfailIfMPSUnsupportedDtype(fn):
-    """Mark test as xfail if MPS is available and dtype is unsupported by MPS."""
-
-    @wraps(fn)
-    def wrapper(self, device, dtype, *args, **kwargs):
-        if torch.backends.mps.is_available() and dtype not in all_mps_types():
-            pytest.xfail(f"MPS doesn't support {dtype}")
-        return fn(self, device, dtype, *args, **kwargs)
-
-    return wrapper
 
 
 def onlyCUDAAndPRIVATEUSE1(fn):

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -15,6 +15,8 @@ from functools import partial, wraps
 from typing import Any, ClassVar, TypeVar
 from typing_extensions import ParamSpec
 
+import pytest
+
 import torch
 from torch._inductor.utils import GPU_TYPES
 from torch._utils import _is_privateuse1_backend_available
@@ -25,7 +27,7 @@ from torch.testing._internal.common_cuda import (
     TEST_CUSPARSE_GENERIC,
     TEST_HIPSPARSE_GENERIC,
 )
-from torch.testing._internal.common_dtype import get_all_dtypes
+from torch.testing._internal.common_dtype import all_mps_types, get_all_dtypes
 from torch.testing._internal.common_utils import (
     _TestParametrizer,
     clear_tracked_input,
@@ -1714,6 +1716,18 @@ def onlyAccelerator(fn):
         return fn(self, *args, **kwargs)
 
     return only_fn
+
+
+def xfailIfMPSUnsupportedDtype(fn):
+    """Mark test as xfail if MPS is available and dtype is unsupported by MPS."""
+
+    @wraps(fn)
+    def wrapper(self, device, dtype, *args, **kwargs):
+        if torch.backends.mps.is_available() and dtype not in all_mps_types():
+            pytest.xfail(f"MPS doesn't support {dtype}")
+        return fn(self, device, dtype, *args, **kwargs)
+
+    return wrapper
 
 
 def onlyCUDAAndPRIVATEUSE1(fn):


### PR DESCRIPTION
## Summary
Makes `TestUnaryUfuncs` in `test_unary_ufuncs.py` device-generic by replacing `@onlyCUDA` with `@onlyAccelerator` for tests that can run on any accelerator.

**Depends on #176593** - this PR is stacked on top of it. Only `test/test_unary_ufuncs.py` changes are from this PR.

## Changes
- `test_abs_zero`: `@onlyCUDA` → `@onlyAccelerator`
- `test_narrow_dtypes`: `@onlyCUDA` → `@onlyAccelerator`  
- `test_nonzero_large`: `@onlyCUDA` → `@onlyAccelerator`

## Not changed
- `test_nonzero_static_large`: Kept `@onlyCUDA` - has H100-specific sizing and hardcoded `device="cuda"` literals

CC: @mikaylagawarecki @mansiag05 @fffrog @zeshengzong
