### PR TITLE
[OpenReg] Fix lost wakeup race in stream destruction

### DIFF
--- a/test/cpp_extensions/open_registration_extension/torch_openreg/third_party/openreg/csrc/stream.cpp
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/third_party/openreg/csrc/stream.cpp
@@ -59,7 +59,10 @@ struct orStream {
   }
 
   ~orStream() {
-    stop_flag.store(true);
+    {
+      std::lock_guard<std::mutex> lock(mtx);
+      stop_flag.store(true);
+    }
     cv.notify_one();
     worker.join();
   }

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/third_party/openreg/tests/stream_tests.cpp
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/third_party/openreg/tests/stream_tests.cpp
@@ -83,8 +83,7 @@ TEST_F(StreamTest, AddTaskToStreamNullptr) {
   EXPECT_EQ(openreg::addTaskToStream(nullptr, [] {}), orErrorUnknown);
 }
 
-// Disabled: randomly hangs in CI. See https://github.com/pytorch/pytorch/issues/176286
-TEST_F(StreamTest, DISABLED_StreamQuery) {
+TEST_F(StreamTest, StreamQuery) {
   orStream_t stream = nullptr;
   EXPECT_EQ(orStreamCreate(&stream), orSuccess);
 


### PR DESCRIPTION
## Author Notes

Low risk fix in the impl. The notify is getting lost. Rather than disabling more tests that timeout, fixing it here directly.

## Agent Notes

Fixes a condition variable lost wakeup bug in `~orStream()` that caused random hangs in CI (e.g. `StreamTest.DeviceSynchronize` on aarch64, `StreamQuery` previously disabled via #176286).

The destructor set `stop_flag` via atomic store without holding the mutex, allowing a window where `cv.notify_one()` fires before the worker enters `cv.wait()`, permanently losing the wakeup. The fix acquires the mutex before setting `stop_flag`, ensuring proper ordering with the worker's predicate check — the standard pattern for condition variable usage.

Also re-enables the `StreamQuery` test that was disabled for the same root cause.

Fixes #176286

cc @ptrblck @nWEIdia