### PR TITLE
[decomp][wip] Fix linspace decomposition precision for fp16/bf16

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -6816,6 +6816,19 @@ class TestTorch(TestCase):
             self.assertFalse(torch.logspace(torch.tensor(start, requires_grad=True), end, step).requires_grad)
             self.assertFalse(torch.logspace(start, torch.tensor(end, requires_grad=True), step).requires_grad)
 
+    @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
+    def test_linspace_fp16_decomp(self):
+        # The linspace decomposition should match the native CUDA kernel for
+        # reduced-precision types.  Previously the decomposition promoted
+        # fp16/bf16 to fp32 for the step computation, causing numerical drift.
+        from torch._refs import linspace as linspace_decomp
+
+        for dtype in [torch.float16, torch.bfloat16]:
+            for steps in [8, 13, 32, 64, 128]:
+                native = torch.linspace(-1, 1, steps=steps, device="cuda", dtype=dtype)
+                decomp = linspace_decomp(-1, 1, steps=steps, device="cuda", dtype=dtype)
+                self.assertEqual(native, decomp)
+
     # FIXME: move to shape ops test suite
     def test_unflatten(self):
         # test args: tensor, int, sizes

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -6818,16 +6818,20 @@ class TestTorch(TestCase):
 
     @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
     def test_linspace_fp16_decomp(self):
-        # The linspace decomposition should match the native CUDA kernel for
-        # reduced-precision types.  Previously the decomposition promoted
-        # fp16/bf16 to fp32 for the step computation, causing numerical drift.
+        # The eager linspace decomposition should exactly match the native
+        # CUDA kernel for reduced-precision types.
         from torch._refs import linspace as linspace_decomp
 
         for dtype in [torch.float16, torch.bfloat16]:
-            for steps in [8, 13, 32, 64, 128]:
-                native = torch.linspace(-1, 1, steps=steps, device="cuda", dtype=dtype)
-                decomp = linspace_decomp(-1, 1, steps=steps, device="cuda", dtype=dtype)
-                self.assertEqual(native, decomp)
+            for steps in [8, 13, 32, 64, 128, 256]:
+                for start, end in [(-1, 1), (0, 10), (0.3, 0.7)]:
+                    native = torch.linspace(
+                        start, end, steps=steps, device="cuda", dtype=dtype
+                    )
+                    decomp = linspace_decomp(
+                        start, end, steps=steps, device="cuda", dtype=dtype
+                    )
+                    self.assertEqual(native, decomp, atol=0, rtol=0)
 
     # FIXME: move to shape ops test suite
     def test_unflatten(self):

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -5501,25 +5501,32 @@ def linspace(
     # Perform in arange in int because some backends like ATen or Triton do not support all the dtypes
     rg = torch.arange(0, steps, **factory_kwargs)  # type: ignore[arg-type]
 
-    # Small types need to be computed in higher precision as this is, at heart, an associative scan
     dtype_red = (
         torch.int64
         if (utils.is_boolean_dtype(dtype) or utils.is_integer_dtype(dtype))
         else dtype
     )
-    computation_dtype, _ = utils.reduction_dtypes(
-        rg, REDUCTION_OUTPUT_TYPE_KIND.SAME, dtype_red
-    )
-    cast_rg = partial(_maybe_convert_to_dtype, dtype=computation_dtype)
+    cast_rg = partial(_maybe_convert_to_dtype, dtype=dtype_red)
 
-    # We implement torch.lerp without performing rg / (steps - 1) explicitly
-    # With this we get out[0] == start, out[-1] == end
-    step = (end - start) / (steps - 1)
+    # Native CUDA/CPU linspace kernels compute step in scalar_t (the target
+    # dtype).  For reduced-precision types (fp16/bf16) this matters: computing
+    # step in fp64 gives visibly different rounding.  Cast start/end to the
+    # target dtype so step arithmetic matches the native kernels.
+    if dtype in (torch.float16, torch.bfloat16):
+        start_val = torch.tensor(start, dtype=dtype, device=device)
+        end_val = torch.tensor(end, dtype=dtype, device=device)
+        steps_div = torch.tensor(steps - 1, dtype=dtype, device=device)
+        step = (end_val - start_val) / steps_div
+    else:
+        start_val = start
+        end_val = end
+        step = (end - start) / (steps - 1)
+
     # pyrefly: ignore [no-matching-overload]
     out = torch.where(
         rg < steps / 2,
-        start + step * cast_rg(rg),  # type: ignore[arg-type,operator]
-        end - step * cast_rg((steps - 1) - rg),  # type: ignore[arg-type,operator]
+        start_val + step * cast_rg(rg),  # type: ignore[arg-type,operator]
+        end_val - step * cast_rg((steps - 1) - rg),  # type: ignore[arg-type,operator]
     )
     return _maybe_convert_to_dtype(out, dtype)  # type: ignore[return-value]
 

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -5508,25 +5508,17 @@ def linspace(
     )
     cast_rg = partial(_maybe_convert_to_dtype, dtype=dtype_red)
 
-    # Native CUDA/CPU linspace kernels compute step in scalar_t (the target
-    # dtype).  For reduced-precision types (fp16/bf16) this matters: computing
-    # step in fp64 gives visibly different rounding.  Cast start/end to the
-    # target dtype so step arithmetic matches the native kernels.
-    if dtype in (torch.float16, torch.bfloat16):
-        start_val = torch.tensor(start, dtype=dtype, device=device)
-        end_val = torch.tensor(end, dtype=dtype, device=device)
-        steps_div = torch.tensor(steps - 1, dtype=dtype, device=device)
-        step = (end_val - start_val) / steps_div
-    else:
-        start_val = start
-        end_val = end
-        step = (end - start) / (steps - 1)
+    # Native CUDA/CPU kernels compute step in scalar_t; match that by
+    # converting start/end to the target dtype before computing step.
+    start = torch.tensor(start, dtype=dtype_red, device=device)
+    end = torch.tensor(end, dtype=dtype_red, device=device)
+    step = (end - start) / (steps - 1)
 
     # pyrefly: ignore [no-matching-overload]
     out = torch.where(
         rg < steps / 2,
-        start_val + step * cast_rg(rg),  # type: ignore[arg-type,operator]
-        end_val - step * cast_rg((steps - 1) - rg),  # type: ignore[arg-type,operator]
+        start + step * cast_rg(rg),  # type: ignore[arg-type,operator]
+        end - step * cast_rg((steps - 1) - rg),  # type: ignore[arg-type,operator]
     )
     return _maybe_convert_to_dtype(out, dtype)  # type: ignore[return-value]
 

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -5510,8 +5510,14 @@ def linspace(
 
     # Native CUDA/CPU kernels compute step in scalar_t; match that by
     # converting start/end to the target dtype before computing step.
-    start = torch.tensor(start, dtype=dtype_red, device=device)
-    end = torch.tensor(end, dtype=dtype_red, device=device)
+    if isinstance(start, TensorLikeType):
+        start = _maybe_convert_to_dtype(start, dtype_red)
+    else:
+        start = torch.full((), start, dtype=dtype_red, device=device)
+    if isinstance(end, TensorLikeType):
+        end = _maybe_convert_to_dtype(end, dtype_red)
+    else:
+        end = torch.full((), end, dtype=dtype_red, device=device)
     step = (end - start) / (steps - 1)
 
     # pyrefly: ignore [no-matching-overload]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #176721
* __->__ #176720

The linspace decomposition was computing step in float64 (since
start/end arrive as Python floats), but the native CUDA and CPU
linspace kernels compute step in scalar_t (the target dtype). For
fp16/bf16, this causes visible numerical mismatches when code using
linspace is compiled through inductor vs run eagerly.

Fix by casting start, end, and (steps-1) to the target dtype before
computing step for fp16/bf16 types, matching native kernel behavior.

Authored with Claude.