### PR TITLE
[decomp] Fix affine_grid_generator fp16/bf16 mismatch between eager and inductor

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -6677,6 +6677,31 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
                 self.assertEqual(out_cpu, out_cuda)
                 self.assertEqual(input_cpu.grad, input_gpu.grad)
 
+    @unittest.skipIf(not TEST_CUDA, 'CUDA not available')
+    def test_affine_grid_inductor_float16(self):
+        # Verify that the affine_grid_generator decomposition under inductor
+        # matches the native CUDA kernel for reduced-precision types.
+        for dtype in [torch.float16, torch.bfloat16]:
+            for align_corners in [True, False]:
+                for h, w in [(8, 8), (7, 13), (32, 32)]:
+                    torch._dynamo.reset()
+                    theta = torch.randn(2, 2, 3, dtype=dtype, device="cuda")
+                    size = [2, 1, h, w]
+                    expected = torch.ops.aten.affine_grid_generator(
+                        theta, size=size, align_corners=align_corners
+                    )
+
+                    def fn(theta, size):
+                        return torch.ops.aten.affine_grid_generator(
+                            theta, size=size, align_corners=align_corners
+                        )
+
+                    actual = torch.compile(fn, backend="inductor")(theta, size)
+                    # Allow small tolerance for residual fp32-vs-dtype rounding
+                    # from inductor's codegen_upcast_to_fp32
+                    atol = 2e-3 if dtype == torch.float16 else 0.035
+                    self.assertEqual(actual, expected, atol=atol, rtol=0)
+
     def test_channel_shuffle_return_alias_of_self(self):
         # gh-76616: nn.ChannelShuffle will return alias of self with an empty input tensor
         groups = 3

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -4334,9 +4334,11 @@ def _linspace_from_neg_one(
 ):
     if num_steps <= 1:
         return torch.tensor(0, device=device, dtype=dtype)
-
-    a = ((num_steps - 1) / num_steps) if not align_corners else 1
-    return torch.linspace(-a, a, steps=num_steps, device=device, dtype=dtype)
+    if align_corners:
+        return torch.linspace(-1, 1, steps=num_steps, device=device, dtype=dtype)
+    return torch.linspace(-1, 1, steps=num_steps, device=device, dtype=dtype) * (
+        (num_steps - 1) / num_steps
+    )
 
 
 def _make_base_grid_4d(theta: Tensor, h: int, w: int, align_corners: bool):
@@ -4376,26 +4378,21 @@ def _make_base_grid_5d(theta: Tensor, d: int, h: int, w: int, align_corners: boo
 def _affine_grid_generator_4d(theta: Tensor, size: list[int], align_corners: bool):
     n, _, h, w = size
     base_grid = _make_base_grid_4d(theta, h, w, align_corners=align_corners)
-    # base_grid shape is (h, w, 3) and theta shape is (n, 2, 3)
-    # We do manually a matrix multiplication which is faster than mm()
-    # (h * w, 3, 1) * (n, 1, 3, 2) -> (n, h * w, 2)
-    grid = (base_grid.view(-1, 3, 1) * theta.mT.unsqueeze(1)).sum(-2)
+    # base_grid: (h, w, 3), theta: (n, 2, 3)
+    grid = base_grid.view(1, h * w, 3).expand(n, -1, -1).bmm(theta.mT)
     return grid.view(n, h, w, 2)
 
 
 def _affine_grid_generator_5d(theta: Tensor, size: list[int], align_corners: bool):
     n, _, d, h, w = size
     base_grid = _make_base_grid_5d(theta, d, h, w, align_corners=align_corners)
-    # base_grid shape is (d, h, w, 4) and theta shape is (n, 3, 4)
-    # We do manually a matrix multiplication which is faster than mm()
-    # (d * h * w, 4, 1) * (n, 1, 4, 3) -> (n, h * w, 3)
-    grid = (base_grid.view(-1, 4, 1) * theta.mT.unsqueeze(1)).sum(-2)
+    # base_grid: (d, h, w, 4), theta: (n, 3, 4)
+    grid = base_grid.view(1, d * h * w, 4).expand(n, -1, -1).bmm(theta.mT)
     return grid.view(n, d, h, w, 3)
 
 
 @register_decomposition(aten.affine_grid_generator)
 @out_wrapper()
-@pw_cast_for_opmath
 def affine_grid_generator(theta: Tensor, size: list[int], align_corners: bool):
     torch._check(
         len(size) in (4, 5),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #176721
* #176720

Now that the linspace decomposition computes step in the target dtype,
simplify `_linspace_from_neg_one` back to calling `torch.linspace`
directly.

Also switch from the manual broadcast-multiply-sum pattern to `bmm`
for the theta matmul, and remove `@pw_cast_for_opmath` which was
upcasting fp16 inputs to fp32 (causing further mismatch with the
native kernel that operates in the original dtype).

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo