### PR TITLE
Use reusable Claude Code workflow from test-infra

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -8,79 +8,12 @@ on:
 
 jobs:
   claude-code:
-    # Early exit conditions (fast gate — avoids spinning up a runner for unauthorized users):
-    # 1. Must be pytorch org
-    # 2. Must mention @claude
-    # 3. Must be org member/collaborator OR an allowed bot
-    # Note: issue_comment and pull_request_review_comment share the same payload paths
-    if: |
-      github.repository_owner == 'pytorch' &&
-      (
-        (github.event_name != 'issues' &&
-         contains(github.event.comment.body, '@claude') &&
-         (contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) ||
-          github.actor == 'pytorch-auto-revert[bot]')) ||
-        (github.event_name == 'issues' &&
-         contains(github.event.issue.body, '@claude') &&
-         (contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association) ||
-          github.actor == 'pytorch-auto-revert[bot]'))
-      )
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    environment: bedrock
+    uses: pytorch/test-infra/.github/workflows/_claude-code.yml@main
     permissions:
       contents: read
       pull-requests: write
       issues: write
       id-token: write
-    steps:
-      - name: Verify write access
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const allowedBots = ['pytorch-auto-revert[bot]'];
-            const actor = context.actor;
-
-            console.log(`Actor: ${actor}`);
-            console.log(`Repository: ${context.repo.owner}/${context.repo.repo}`);
-            console.log(`author_association: ${{ github.event.comment.author_association || github.event.issue.author_association }}`);
-
-            if (allowedBots.includes(actor)) {
-              console.log(`${actor} is an allowed bot, skipping permission check`);
-              return;
-            }
-
-            const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              username: actor
-            });
-            console.log(`Permission: ${data.permission}`);
-            if (!['admin', 'write'].includes(data.permission)) {
-              core.setFailed(`${actor} does not have write access (has: ${data.permission})`);
-            }
-
-      # Fork PR support enabled by using izaitsevfb/claude-code-action@forked-pr-fix
-
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Configure AWS credentials via OIDC
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: arn:aws:iam::308535385114:role/gha_workflow_claude_code
-          aws-region: us-east-1
-
-      - name: Run Claude Code
-        uses: izaitsevfb/claude-code-action@forked-pr-fix
-        with:
-          # We filter by github.actor at workflow level, there is no point of filtering here as well
-          allowed_bots: "*"
-          use_bedrock: "true"
-          claude_args: "--model global.anthropic.claude-opus-4-6-v1 --allowedTools Skill"
-          settings: '{"alwaysThinkingEnabled": true}'
-
-      - name: Upload usage metrics
-        if: always()
-        uses: pytorch/test-infra/.github/actions/upload-claude-usage@main
+    secrets: inherit
+    with:
+      additional_claude_args: '--allowedTools Skill'


### PR DESCRIPTION
## Summary
Replaces the inline Claude Code workflow (~77 lines) with a call to the centralized reusable workflow in `pytorch/test-infra`.

The reusable workflow handles all shared logic: org/author checks, verify write access, OIDC auth, Claude invocation, and usage metrics upload.

### What changes
- Drops the inline `if` condition, verify write access step, checkout, OIDC config, and metrics upload — all handled by the reusable workflow
- Passes pytorch-specific config via inputs:
  - `additional_claude_args: '--allowedTools Skill'`
  - `prompt: 'When asked to review a PR, always use the /pr-review skill.'`

### What stays the same
- Same triggers (`issue_comment`, `issues`)
- Same security checks (org gate, author_association, verify write access, bot allowlist)
- Same model (opus-4-6, the reusable workflow default)
- Same usage metrics upload

Depends on https://github.com/pytorch/test-infra/pull/7810 which added the reusable workflow.

## Test plan
- [x] Reusable workflow tested end-to-end on pytorch/ciforge (https://github.com/pytorch/ciforge/actions/runs/22729410061)
- [ ] Verify `@claude` triggers correctly after merge