### PR TITLE
[ROCm][Windows] Fix Linux-only headers in CUDACachingAllocator.cpp

### DIFF
--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -21,9 +21,13 @@
 #if defined(PYTORCH_C10_DRIVER_API_SUPPORTED)
 #include <c10/cuda/driver_api.h>
 #endif
+#ifndef _WIN32
 #include <sys/syscall.h>
 #include <sys/types.h>
 #include <unistd.h>
+#else
+#include <process.h>
+#endif
 #endif
 
 #include <c10/util/Exception.h>
@@ -562,7 +566,11 @@ struct ExpandableSegment {
     // thereby ensuring that the handle can be correctly matched in
     // ipcMemHandle_to_devptr.
     ShareHeader header{};
+#ifdef _WIN32
+    header.pid = _getpid();
+#else
     header.pid = getpid();
+#endif
     header.segment_size = segment_size_;
     header.num_handles = end - begin;
 
@@ -624,14 +632,20 @@ struct ExpandableSegment {
         device, std::nullopt, header.segment_size, std::move(peers));
 // older build setups (e.g. multiwheels) do not have this syscall, added 2020
 // but the kernel on the system might still support it.
+#ifndef _WIN32
 #ifndef SYS_pidfd_open
 #define SYS_pidfd_open 434
 #endif
 #ifndef SYS_pidfd_getfd
 #define SYS_pidfd_getfd 438
 #endif
+#endif // !_WIN32
     if (CUDAAllocatorConfig::expandable_segments_handle_type() !=
         Expandable_Segments_Handle_Type::FABRIC_HANDLE) {
+#ifdef _WIN32
+      TORCH_CHECK(
+          false, "IPC expandable segments are not supported on Windows");
+#else
       auto pidfd = syscall(SYS_pidfd_open, header.pid, 0);
       TORCH_CHECK(
           pidfd != -1 || errno != ENOSYS,
@@ -683,6 +697,7 @@ struct ExpandableSegment {
         segment->handles_.emplace_back(Handle{handle, std::nullopt});
       }
       close(static_cast<int>(pidfd));
+#endif // !_WIN32
     } else {
 #ifdef USE_ROCM
       TORCH_INTERNAL_ASSERT(
@@ -817,7 +832,9 @@ struct ExpandableSegment {
           ptr_ + segment_size_ * i, segment_size_));
 #endif
       if (h.shareable_handle) {
+#ifndef _WIN32
         close(std::get<int>(*h.shareable_handle));
+#endif
       }
 #ifdef USE_ROCM
       C10_CUDA_CHECK(hipMemRelease(h.handle));
@@ -871,7 +888,11 @@ struct ExpandableSegment {
     std::optional<std::variant<int, CUmemFabricHandle>> shareable_handle;
   };
   struct ShareHeader {
+#ifdef _WIN32
+    int pid;
+#else
     pid_t pid;
+#endif
     size_t segment_size;
     size_t num_handles;
   };


### PR DESCRIPTION
When building PyTorch with ROCm (USE_ROCM=ON) on Windows, the compiler fails with:

  fatal error: 'sys/syscall.h' file not found

The file CUDACachingAllocator.cpp (and its HIPIFY-generated counterpart HIPCachingAllocator.cpp) includes Linux-only POSIX headers under the `USE_ROCM` preprocessor condition without guarding them for Windows:

  #if defined(PYTORCH_C10_DRIVER_API_SUPPORTED) || defined(USE_ROCM)
  #include <sys/syscall.h>   // Linux only
  #include <sys/types.h>     // Linux only
  #include <unistd.h>        // Linux only
  #endif

This patch adds `#ifndef _WIN32` guards around the Linux-only includes and adds `#include <process.h>` for Windows (provides `_getpid()`).

Additional Windows-specific fixes in the same file:
- `pid_t` (POSIX type) in `ShareHeader` struct -> `int` on Windows
- `getpid()` -> `_getpid()` on Windows in `share()`
- Guard `syscall(SYS_pidfd_open/getfd, ...)` with `#ifndef _WIN32` in `fromShared()` (Linux kernel IPC not available on Windows); add a `TORCH_CHECK(false, ...)` stub so the code still compiles and gives a clear runtime error if called
- Guard `close()` of file descriptor in `unmapHandles()` with `#ifndef _WIN32`

Tested on Windows 11 with AMD gfx1151 (Strix Halo iGPU), ROCm 7.12, clang-cl (MSVC-compatible frontend). PyTorch builds and `torch.cuda.is_available()` returns True.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang