### PR TITLE
[dynamo] Add validation for config override env vars

### DIFF
--- a/test/dynamo/test_debug_utils.py
+++ b/test/dynamo/test_debug_utils.py
@@ -763,6 +763,55 @@ instantiate_device_type_tests(
 )
 
 
+class TestConfigOverrideValidation(TestCase):
+    def setUp(self):
+        super().setUp()
+        from torch._dynamo.graph_id_filter import (
+            _validate_backend_names,
+            _validate_dynamo_config_keys,
+            _validate_inductor_config_keys,
+        )
+
+        _validate_backend_names.cache_clear()
+        _validate_dynamo_config_keys.cache_clear()
+        _validate_inductor_config_keys.cache_clear()
+        torch._dynamo.reset()
+
+    def tearDown(self):
+        torch._dynamo.reset()
+        super().tearDown()
+
+    @torch._dynamo.config.patch(
+        debug_backend_override="0:not_a_real_backend",
+    )
+    def test_invalid_backend_raises_on_compile(self):
+        def fn(x):
+            return x + 1
+
+        with self.assertRaisesRegex(ValueError, "not_a_real_backend"):
+            torch.compile(fn, backend="eager")(torch.randn(4))
+
+    @torch._dynamo.config.patch(
+        debug_dynamo_config_override="0:nonexistent_dynamo_option=True",
+    )
+    def test_invalid_dynamo_config_raises_on_compile(self):
+        def fn(x):
+            return x + 1
+
+        with self.assertRaisesRegex(ValueError, "nonexistent_dynamo_option"):
+            torch.compile(fn, backend="eager")(torch.randn(4))
+
+    @torch._dynamo.config.patch(
+        debug_inductor_config_override="0:nonexistent_inductor_option=True",
+    )
+    def test_invalid_inductor_config_raises_on_compile(self):
+        def fn(x):
+            return x + 1
+
+        with self.assertRaisesRegex(ValueError, "nonexistent_inductor_option"):
+            torch.compile(fn, backend="eager")(torch.randn(4))
+
+
 class TestDynamoConfigOverrideIntegration(TestCase):
     def setUp(self):
         super().setUp()

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -1857,21 +1857,30 @@ def _compile(
         torch._dynamo.utils.ReinplaceCounters.clear()
         guarded_code = None
         tracer_output = None
-        # Eagerly validate config override strings before entering the
-        # compilation try/except so that typos surface as clean ValueErrors
-        # instead of being wrapped as InternalTorchDynamoError.
-        from .graph_id_filter import (
-            _validate_backend_names,
-            _validate_dynamo_config_keys,
-            _validate_inductor_config_keys,
-        )
 
-        if err := _validate_backend_names(config.debug_backend_override):
-            raise ValueError(err)
-        if err := _validate_dynamo_config_keys(config.debug_dynamo_config_override):
-            raise ValueError(err)
-        if err := _validate_inductor_config_keys(config.debug_inductor_config_override):
-            raise ValueError(err)
+        if (
+            config.debug_backend_override
+            or config.debug_dynamo_config_override
+            or config.debug_inductor_config_override
+        ):
+            # Eagerly validate config override strings before entering the
+            # compilation try/except so that typos surface as clean ValueErrors
+            # instead of being wrapped as InternalTorchDynamoError.
+            from .graph_id_filter import (
+                _validate_backend_names,
+                _validate_dynamo_config_keys,
+                _validate_inductor_config_keys,
+            )
+
+            if err := _validate_backend_names(config.debug_backend_override):
+                raise ValueError(err)
+            if err := _validate_dynamo_config_keys(config.debug_dynamo_config_override):
+                raise ValueError(err)
+            if err := _validate_inductor_config_keys(
+                config.debug_inductor_config_override
+            ):
+                raise ValueError(err)
+
         try:
             guarded_code, tracer_output = compile_inner(code, one_graph, hooks)
 

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -1857,6 +1857,21 @@ def _compile(
         torch._dynamo.utils.ReinplaceCounters.clear()
         guarded_code = None
         tracer_output = None
+        # Eagerly validate config override strings before entering the
+        # compilation try/except so that typos surface as clean ValueErrors
+        # instead of being wrapped as InternalTorchDynamoError.
+        from .graph_id_filter import (
+            _validate_backend_names,
+            _validate_dynamo_config_keys,
+            _validate_inductor_config_keys,
+        )
+
+        if err := _validate_backend_names(config.debug_backend_override):
+            raise ValueError(err)
+        if err := _validate_dynamo_config_keys(config.debug_dynamo_config_override):
+            raise ValueError(err)
+        if err := _validate_inductor_config_keys(config.debug_inductor_config_override):
+            raise ValueError(err)
         try:
             guarded_code, tracer_output = compile_inner(code, one_graph, hooks)
 

--- a/torch/_dynamo/graph_id_filter.py
+++ b/torch/_dynamo/graph_id_filter.py
@@ -323,8 +323,65 @@ def _create_backend_router(config_str: str) -> GraphBackendRouter:
 
 
 @functools.lru_cache
+def _validate_backend_names(config_str: str) -> str | None:
+    """Return an error message if any backend name is invalid, else None."""
+    if not config_str or not config_str.strip():
+        return None
+    from .backends.registry import lookup_backend
+
+    for rule_str in config_str.split(";"):
+        rule_str = rule_str.strip()
+        if not rule_str or ":" not in rule_str:
+            continue
+        backend_name = rule_str[rule_str.find(":") + 1 :].strip()
+        if not backend_name:
+            continue
+        try:
+            lookup_backend(backend_name)
+        except Exception:
+            return (
+                f"TORCH_COMPILE_OVERRIDE_BACKENDS: "
+                f"'{backend_name}' is not a valid backend, "
+                f"see `torch._dynamo.list_backends()` for available backends"
+            )
+    return None
+
+
+@functools.lru_cache
+def _validate_inductor_config_keys(config_str: str) -> str | None:
+    """Return an error message if any config key is invalid, else None."""
+    router = GraphConfigRouter(config_str)
+    from torch._inductor import config
+
+    for _, config_dict in router._rules:
+        for key in config_dict:
+            if not hasattr(config, key):
+                return (
+                    f"TORCH_COMPILE_OVERRIDE_INDUCTOR_CONFIGS: "
+                    f"'{key}' is not a valid torch._inductor.config option"
+                )
+    return None
+
+
+@functools.lru_cache
+def _validate_dynamo_config_keys(config_str: str) -> str | None:
+    """Return an error message if any config key is invalid, else None."""
+    router = GraphConfigRouter(config_str)
+    from torch._dynamo import config
+
+    for _, config_dict in router._rules:
+        for key in config_dict:
+            if not hasattr(config, key):
+                return (
+                    f"TORCH_COMPILE_OVERRIDE_DYNAMO_CONFIGS: "
+                    f"'{key}' is not a valid torch._dynamo.config option"
+                )
+    return None
+
+
+@functools.lru_cache
 def _create_inductor_config_router(config_str: str) -> GraphConfigRouter:
-    """Create and cache GraphConfigRouter instances based on config string."""
+    """Create and cache GraphConfigRouter for inductor config overrides."""
     return GraphConfigRouter(config_str)
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #176735
* #176734

Validate config keys at parse time for both
dynamo and inductor overrides, surfacing typos as clear ValueErrors
instead of deep InternalTorchDynamoError stack traces.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo