### PR TITLE
Replace custom _broadcast_object with broadcast_object_list in ZeRO

### DIFF
--- a/test/distributed/optim/test_zero_redundancy_optimizer.py
+++ b/test/distributed/optim/test_zero_redundancy_optimizer.py
@@ -26,7 +26,6 @@ from torch.distributed.algorithms.ddp_comm_hooks.ddp_zero_hook import (
 from torch.distributed.algorithms.ddp_comm_hooks.default_hooks import allreduce_hook
 from torch.distributed.algorithms.join import Join, Joinable, JoinHook
 from torch.distributed.optim import ZeroRedundancyOptimizer
-from torch.distributed.optim.zero_redundancy_optimizer import _broadcast_object
 from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.optim import AdamW, SGD
 from torch.testing._internal.common_distributed import (
@@ -676,13 +675,14 @@ class TestZeroRedundancyOptimizerDistributed(TestZeroRedundancyOptimizer):
             optimizer_state_dict = {}
 
         # Load the optimizer state on all ranks without any exceptions
-        optimizer_state_dict = _broadcast_object(
-            optimizer_state_dict,
-            src_rank=REFERENCE_RANK,
+        object_list = [optimizer_state_dict]
+        dist.broadcast_object_list(
+            object_list,
+            src=REFERENCE_RANK,
             group=dist.group.WORLD,
             device=self.device,
         )
-        optimizer.load_state_dict(optimizer_state_dict)
+        optimizer.load_state_dict(object_list[0])
 
     def test_nondefault_process_group(self):
         """Check that ZeroRedundancyOptimizer works with a non-default process
@@ -996,18 +996,15 @@ class TestZeroRedundancyOptimizerDistributed(TestZeroRedundancyOptimizer):
 
         # Broadcast the saved gradients and parameters to all of the other
         # ranks (which joined early)
-        grads_and_params = [grads_at_each_iter, params_at_each_iter]
-        grads_and_params = _broadcast_object(
-            grads_and_params,
-            src_rank=world_size - 1,
+        object_list = [[grads_at_each_iter, params_at_each_iter]]
+        dist.broadcast_object_list(
+            object_list,
+            src=world_size - 1,
             group=dist.group.WORLD,
             device=device,
         )
-        grads_at_each_iter = grads_and_params[0]
-        params_at_each_iter = grads_and_params[1]
-        # TODO: Replace this `_broadcast_object` with `broadcast_object_list`
-        # once the latter supports loading to the destination device instead
-        # of the source device
+        grads_at_each_iter = object_list[0][0]
+        params_at_each_iter = object_list[0][1]
 
         # A process must still set the remaining gradients after joining, so we
         # define a join hook to do this before the ZeRO join hook

--- a/torch/distributed/optim/zero_redundancy_optimizer.py
+++ b/torch/distributed/optim/zero_redundancy_optimizer.py
@@ -9,7 +9,6 @@ import collections
 import copy
 import enum
 import inspect
-import io
 import logging
 from collections.abc import Callable
 from itertools import chain
@@ -68,55 +67,6 @@ def _recursive_copy_to_device(
 def _is_trainable(param: torch.Tensor) -> bool:
     r"""Return if a parameter is trainable, where trainability is equivalent to requiring a gradient."""
     return param.requires_grad
-
-
-def _broadcast_object(
-    obj: Any,
-    src_rank: int,
-    group: object = dist.group.WORLD,
-    device: torch.device = torch.device("cpu"),
-) -> Any:
-    r"""
-    Broadcasts an object to the given group.
-
-    It will be sending the object if called from the source rank and receiving
-    the object otherwise.
-
-    Arguments:
-        obj: object to broadcast; only used if called on the source rank.
-        src_rank (int): source rank.
-        group (``ProcessGroup``, optional): group used for the broadcast
-            (default: ``dist.group.WORLD``).
-        device (``torch.device``, optional): device to send from or receive
-            to (default: ``torch.device("cpu")``).
-
-    Returns:
-        The broadcasted object.
-    """
-    if dist.get_rank() == src_rank:
-        # Send the object
-        buffer = io.BytesIO()
-        torch.save(obj, buffer)
-        data = bytearray(buffer.getbuffer())
-        length_tensor = torch.LongTensor([len(data)]).to(device)
-        data_send_tensor = torch.ByteTensor(data).to(device)
-        # pyrefly: ignore [bad-argument-type]
-        dist.broadcast(length_tensor, src=src_rank, group=group, async_op=False)
-        # pyrefly: ignore [bad-argument-type]
-        dist.broadcast(data_send_tensor, src=src_rank, group=group, async_op=False)
-    else:
-        # Receive the object
-        length_tensor = torch.LongTensor([0]).to(device)
-        # pyrefly: ignore [bad-argument-type]
-        dist.broadcast(length_tensor, src=src_rank, group=group, async_op=False)
-        data_recv_tensor = torch.empty(
-            [int(length_tensor.item())], dtype=torch.uint8, device=device
-        )
-        # pyrefly: ignore [bad-argument-type]
-        dist.broadcast(data_recv_tensor, src=src_rank, group=group, async_op=False)
-        buffer = io.BytesIO(data_recv_tensor.cpu().numpy())
-        obj = torch.load(buffer, map_location=device, weights_only=False)
-    return obj
 
 
 class _ZeROJoinHook(JoinHook):
@@ -533,13 +483,9 @@ class ZeroRedundancyOptimizer(Optimizer, Joinable):
         self._sync_param_groups(self.param_groups, self.optim.param_groups)
 
         # Pull the sharded state from all ranks and store them in rank order
-        empty_messenger = torch.tensor(
-            [0], dtype=torch.uint8, device=self._default_device
-        )
-
-        # NOTE: We wastefully use `broadcast()` (e.g. instead of `gather()`)
-        # due to compatibility issues with NCCL backend; a possible follow-up
-        # is to move all sharded state management to RPC RRef
+        # NOTE: We use `broadcast_object_list()` instead of `gather()` due to
+        # compatibility issues with NCCL backend; a possible follow-up is to
+        # move all sharded state management to RPC RRef
         self._all_state_dicts = []
         for rank in range(self.world_size):
             global_rank = dist.distributed_c10d.get_global_rank(
@@ -547,51 +493,25 @@ class ZeroRedundancyOptimizer(Optimizer, Joinable):
                 self.process_group,
                 rank,
             )
+            # All ranks participate in the broadcast
+            object_list = [self.optim.state_dict() if rank == self.rank else None]
+            dist.broadcast_object_list(
+                object_list,
+                src=global_rank,
+                group=self.process_group,
+                device=self._default_device,
+            )
+
             if self.rank == to:
                 # Consolidate all local `state_dict`s on this rank, storing on
                 # CPU to save GPU memory
-                if rank == self.rank:
-                    # Directly append own optimizer state
-                    self._all_state_dicts.append(
-                        _recursive_copy_to_device(
-                            self.optim.state_dict(),
-                            non_blocking=True,
-                            device=torch.device("cpu"),
-                        )
+                self._all_state_dicts.append(
+                    _recursive_copy_to_device(
+                        object_list[0],
+                        non_blocking=True,
+                        device=torch.device("cpu"),
                     )
-                else:
-                    # Receive the optimizer state from the source rank
-                    local_state_dict = _broadcast_object(
-                        empty_messenger,
-                        src_rank=global_rank,
-                        group=self.process_group,
-                        device=self._default_device,
-                    )
-                    self._all_state_dicts.append(
-                        _recursive_copy_to_device(
-                            local_state_dict,
-                            non_blocking=True,
-                            device=torch.device("cpu"),
-                        )
-                    )
-            else:
-                if rank == self.rank:
-                    # Send the optimizer state to the target rank
-                    _ = _broadcast_object(
-                        self.optim.state_dict(),
-                        src_rank=self.global_rank,
-                        group=self.process_group,
-                        device=self._default_device,
-                    )
-                elif rank != to:
-                    # Discard the received object; `broadcast()` is used for
-                    # compatibility reasons
-                    _ = _broadcast_object(
-                        empty_messenger,
-                        src_rank=global_rank,
-                        group=self.process_group,
-                        device=self._default_device,
-                    )
+                )
 
     def _verify_params_per_rank(
         self,


### PR DESCRIPTION
## Summary
- Replace the custom `_broadcast_object` function in `ZeroRedundancyOptimizer` with the c10d `broadcast_object_list` API
- Remove 83 lines of manual serialization code (`torch.save`/`torch.load` + raw `dist.broadcast` calls)
- Simplify `consolidate_state_dict` by having all ranks participate uniformly in each broadcast round

## Motivation
Fixes #79452

The ZeRO optimizer had its own `_broadcast_object` implementation that manually serialized objects using `torch.save`/`torch.load` with `io.BytesIO` buffers, then sent length and data tensors via two separate `dist.broadcast` calls. This duplicated the functionality already provided by `dist.broadcast_object_list`, which handles serialization, size negotiation, and broadcasting in a single call.

## Changes
- **`torch/distributed/optim/zero_redundancy_optimizer.py`**: Removed the `_broadcast_object` function (49 lines) and the `io` import. Replaced the complex branching logic in `consolidate_state_dict` (send/receive/discard branches based on rank) with a uniform pattern where all ranks call `broadcast_object_list`, and only the target rank appends to `_all_state_dicts`.
- **`test/distributed/optim/test_zero_redundancy_optimizer.py`**: Replaced two test usages of `_broadcast_object` with `dist.broadcast_object_list`. Removed the now-stale TODO comment about this replacement.

## Test Plan
The existing tests in `test/distributed/optim/test_zero_redundancy_optimizer.py` cover the affected code paths (state dict consolidation, join behavior). These require a distributed environment and will be validated by CI.

cc @kwen2501 @H-Huang @awgu