### PR TITLE
[inductor][CI] Fix cpp-wrapper CI failures

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -15100,6 +15100,7 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         inputs = (torch.randn(4, device=self.device),)
         self.common(Model(), inputs)
 
+    @skip_if_cpp_wrapper("skip cpp wrapper")
     @requires_gpu_and_triton
     def test_triton_kernel_bool_tensor_arg(self):
         if self.device != GPU_TYPE or self.device == "mps":

--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -30,7 +30,6 @@ from torch.testing._internal import common_utils
 from torch.testing._internal.common_utils import parametrize, skipIfWindows, skipIfXpu
 from torch.testing._internal.inductor_utils import (
     get_func_call,
-    get_kernel_launch,
     GPU_TYPE,
     HAS_CUDA_AND_TRITON,
     HAS_GPU,
@@ -4922,8 +4921,11 @@ class TestUserKernelEpilogueFusion(torch._inductor.test_case.TestCase):
         torch._inductor.config.epilogue_fusion_user_defined_triton_kernel = True
 
     def check_code(self, code_str, num_kernels, num_allocs, num_deallocs):
+        from torch._inductor import config
+
+        kernel_launch = "call_" if config.cpp_wrapper else ".run("
         FileCheck().check(get_func_call()).check_count(
-            get_kernel_launch(),
+            kernel_launch,
             num_kernels,
             exactly=True,
         ).run(code_str)
@@ -4935,8 +4937,6 @@ class TestUserKernelEpilogueFusion(torch._inductor.test_case.TestCase):
 
         # skip the deallocation check when using cpp_wrapper; most deallocations happen
         # outside of our control via RAIIAtenTensorHandle
-        from torch._inductor import config
-
         if num_deallocs is not None and not config.cpp_wrapper:
             FileCheck().check(get_func_call()).check_count(
                 "del", num_deallocs, exactly=True


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #176745

Summary:
1. https://github.com/pytorch/pytorch/pull/173662 added more tests to test/inductor/test_triton_kernels.py, and https://github.com/pytorch/pytorch/pull/175416 enable cpp-wrapper test on test/inductor/test_triton_kernels.py. So there was a land race and https://github.com/pytorch/pytorch/pull/173662 didn't have the failing CI signal at the landing time.

Forward fix by updating the code checking target for cpp-wrapper.

2. https://github.com/pytorch/pytorch/pull/176353 also had land race. Skip now and the fix is coming later.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo