### PR TITLE
Added 'gelsd' to CUDA torch.linalg.lstsq driver so that underdetermined least square systems can be solved on CUDA 

### DIFF
--- a/aten/src/ATen/native/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebra.cpp
@@ -3517,7 +3517,7 @@ static std::string get_default_lstsq_driver(std::optional<std::string_view> driv
       };
       TORCH_CHECK(
         allowed_drivers_cuda.find(driver_str) != allowed_drivers_cuda.end(),
-        "torch.linalg.lstsq: `driver` other than `gels` or 'gelsd' is not supported on CUDA"
+        "torch.linalg.lstsq: `driver` other than `gels` or `gelsd` is not supported on CUDA"
       );
     }
   } else {

--- a/aten/src/ATen/native/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebra.cpp
@@ -3456,7 +3456,7 @@ static void linalg_lstsq_out_info(
   if (m > n && driver != "gelsy") {
     // if the driver is gelss or gelsd then the residuals are available only if rank == n
     bool compute_residuals = true;
-    if (driver == "gelss" || driver == "gelsd") {
+    if ((driver == "gelss" || driver == "gelsd") && solution.device().is_cpu()) {
       if (input.dim() == 2) {
         compute_residuals = (rank.item().toInt() == n);
       } else {
@@ -3502,19 +3502,22 @@ static std::string get_default_lstsq_driver(std::optional<std::string_view> driv
     // convert `driver_str` to lower case inplace.
     std::transform(driver_str.begin(), driver_str.end(), driver_str.begin(),
       [](unsigned char c) { return std::tolower(c); });
-    static std::unordered_set<std::string_view> allowed_drivers = {
-      "gels", "gelsy", "gelsd", "gelss"
-    };
     if (input.device() == at::kCPU) {
+      static std::unordered_set<std::string_view> allowed_drivers_cpu = {
+        "gels", "gelsy", "gelsd", "gelss"
+      };
       TORCH_CHECK(
-        allowed_drivers.find(driver_str) != allowed_drivers.end(),
+        allowed_drivers_cpu.find(driver_str) != allowed_drivers_cpu.end(),
         "torch.linalg.lstsq: parameter `driver` should be one of "
         "(gels, gelsy, gelsd, gelss)"
       );
     } else { // else if (input.is_cuda())
+      static std::unordered_set<std::string_view> allowed_drivers_cuda = {
+        "gels", "gelsd"
+      };
       TORCH_CHECK(
-        driver_str == "gels",
-        "torch.linalg.lstsq: `driver` other than `gels` is not supported on CUDA"
+        allowed_drivers_cuda.find(driver_str) != allowed_drivers_cuda.end(),
+        "torch.linalg.lstsq: `driver` other than `gels` or 'gelsd' is not supported on CUDA"
       );
     }
   } else {

--- a/aten/src/ATen/native/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebra.cpp
@@ -3447,7 +3447,7 @@ static void linalg_lstsq_out_info(
   if (m > n && driver != "gelsy") {
     // if the driver is gelss or gelsd then the residuals are available only if rank == n
     bool compute_residuals = true;
-    if (driver == "gelss" || driver == "gelsd") {
+    if ((driver == "gelss" || driver == "gelsd") && solution.device().is_cpu()) {
       if (input.dim() == 2) {
         compute_residuals = (rank.item().toInt() == n);
       } else {
@@ -3493,18 +3493,21 @@ static std::string get_default_lstsq_driver(std::optional<std::string_view> driv
     // convert `driver_str` to lower case inplace.
     std::transform(driver_str.begin(), driver_str.end(), driver_str.begin(),
       [](unsigned char c) { return std::tolower(c); });
-    static std::unordered_set<std::string_view> allowed_drivers = {
+    static std::unordered_set<std::string_view> allowed_drivers_cpu_mps = {
       "gels", "gelsy", "gelsd", "gelss"
     };
-    // CUDA supports only the 'gels' driver; CPU and MPS support all four.
+    // CUDA supports 'gels' and 'gelsd'; CPU and MPS support all four.
     if (input.is_cuda()) {
+      static std::unordered_set<std::string_view> allowed_drivers_cuda = {
+        "gels", "gelsd"
+      };
       TORCH_CHECK(
-        driver_str == "gels",
-        "torch.linalg.lstsq: `driver` other than `gels` is not supported on CUDA"
+        allowed_drivers_cuda.find(driver_str) != allowed_drivers_cuda.end(),
+        "torch.linalg.lstsq: `driver` other than `gels` or `gelsd` is not supported on CUDA"
       );
     } else { // CPU and MPS
       TORCH_CHECK(
-        allowed_drivers.find(driver_str) != allowed_drivers.end(),
+        allowed_drivers_cpu_mps.find(driver_str) != allowed_drivers_cpu_mps.end(),
         "torch.linalg.lstsq: parameter `driver` should be one of "
         "(gels, gelsy, gelsd, gelss)"
       );

--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp
@@ -1469,33 +1469,13 @@ void linalg_lstsq_gels(const Tensor& A, const Tensor& B, const Tensor& /*infos*/
 }
 
 void linalg_lstsq_gelsd(const Tensor& A, Tensor& B, Tensor& rank, Tensor& singular_values, Tensor& infos, double rcond) {
-  // Least squares via reduced SVD: A = U @ diag(S) @ Vh, solution = Vh.mH() @ (S_pinv * (U.mH() @ B))
   auto m = A.size(-2);
   auto n = A.size(-1);
-  // auto mn = std::min(m, n);
-  auto batch_sizes = A.sizes().slice(0, A.dim() - 2);
-
   ScalarType real_dtype = toRealValueType(A.scalar_type());
 
-  // Allocate U and Vh; SVD writes directly into singular_values (no copy).
-  // DimVector U_shape(batch_sizes.begin(), batch_sizes.end());
-  // U_shape.insert(U_shape.end(), {m, mn});
-  // DimVector Vh_shape(batch_sizes.begin(), batch_sizes.end());
-  // Vh_shape.insert(Vh_shape.end(), {mn, n});
-
-  // Tensor U = at::empty(U_shape, A.options());
-  // Tensor Vh = at::empty(Vh_shape, A.options());
-  // at::linalg_svd_out(U, singular_values, Vh, A, /*full_matrices=*/false, std::nullopt);
-
-  bool test1 = false;
-  bool compute_full_matrices = false;
-  if (!test1) compute_full_matrices = m > n;
-
-  auto [U, S, Vh] = at::linalg_svd(A, /*full_matrices=*/compute_full_matrices, std::nullopt);
-
+  auto [U, S, Vh] = at::linalg_svd(A, /*full_matrices=*/false, std::nullopt);
   singular_values.copy_(S);
 
-  // Tolerance for rank: rcond * max(S) per batch, or machine epsilon * max(m,n) if rcond <= 0
   Tensor tol;
   if (rcond > 0) {
     auto s_max = singular_values.select(-1, 0).unsqueeze(-1).expand(singular_values.sizes());
@@ -1507,30 +1487,22 @@ void linalg_lstsq_gelsd(const Tensor& A, Tensor& B, Tensor& rank, Tensor& singul
   Tensor above_tol = singular_values.gt(tol);
   rank.copy_((above_tol).sum(-1).to(at::kLong));
   Tensor S_pinv = at::where(above_tol, at::reciprocal(singular_values), at::zeros_like(singular_values));
-  
-  auto B_narrowed = B.narrow(-2, 0, m); // B may have expanded if m < n.
-  Tensor UhB = at::matmul(U.mH(), B_narrowed);  // B may have expanded if m < n. 
+
+  auto B_narrowed = B.narrow(-2, 0, m);
+  Tensor UhB = at::matmul(U.mH(), B_narrowed);
   Tensor Spinv_expanded = S_pinv.unsqueeze(-1).to(A.scalar_type());
-  // Tensor SpinvUhB = at::mul(Spinv_expanded, UhB);
-  Tensor SpinvUhB = at::mul(Spinv_expanded, UhB.narrow(-2, 0, S_pinv.size(-1))); // only the first min(m,n) rows of UhB are multiplied by Spinv, the rest are zero'd out
-  
-  if (test1) {
-    auto X = at::matmul(Vh.mH(), SpinvUhB);
-    if (m > n)
-    {
-      // Most of the clever 'tricks' to computing the residuals from the SVD require the full unitary U matrix which we don't have (because we used reduced svd). 
-      // Thus, the residual will be computed directly and saved on the last location.  
-      // the increase in runtime to compute the residual directly is not significant compared to the rest of the computation.
-      auto residual = at::sub(at::matmul(A, X), B_narrowed);
-      auto col_norms = at::linalg_norm(residual, 2, std::vector<int64_t>{-2}, false);
-      B.narrow(-2, n, m - n).zero_();
-      B.select(-2, m - 1).copy_(col_norms);
-    }
-    B.narrow(-2, 0, n).copy_(X);
-  } else {
-    B.narrow(-2, 0, n) = at::matmul(Vh.mH(), SpinvUhB);
-    B.narrow(-2, n, m - n) = UhB.narrow(-2, n, m - n);
+  Tensor SpinvUhB = at::mul(Spinv_expanded, UhB);
+  auto X = at::matmul(Vh.mH(), SpinvUhB);
+  if (m > n)
+  {
+    // The increase in runtime to compute the residual directly is not significant compared to the rest of the computation.
+    auto residual = at::sub(at::matmul(A, X), B_narrowed);
+    auto col_norms = at::linalg_norm(residual, 2, std::vector<int64_t>{-2}, false);
+    B.narrow(-2, n, m - n).zero_();
+    B.select(-2, m - 1).copy_(col_norms);
   }
+  B.narrow(-2, 0, n).copy_(X);
+
 }
 
 void lstsq_kernel(const Tensor& a, Tensor& b, Tensor& rank, Tensor& singular_values, Tensor& infos, double rcond, std::string driver_name)  {
@@ -1560,10 +1532,10 @@ void lstsq_kernel(const Tensor& a, Tensor& b, Tensor& rank, Tensor& singular_val
     linalg_lstsq_gelsd(a, b, rank, singular_values, infos, rcond);
 
   } else {
-    // this should never be reached since the driver is checked in get_default_lstsq_driver() 
+    // this should never be reached since the driver is checked in get_default_lstsq_driver()
     TORCH_CHECK(false, "linalg.lstsq: Does not support driver '", driver_name, "' on CUDA.");
   }
-  
+
 }
 
 REGISTER_CUDA_DISPATCH(lstsq_stub, &lstsq_kernel)

--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp
@@ -1471,13 +1471,16 @@ void linalg_lstsq_gels(const Tensor& A, const Tensor& B, const Tensor& /*infos*/
 void linalg_lstsq_gelsd(const Tensor& A, Tensor& B, Tensor& rank, Tensor& singular_values, Tensor& infos, double rcond) {
   auto m = A.size(-2);
   auto n = A.size(-1);
+
+  if (m == 0 || n == 0) return;
+
   ScalarType real_dtype = toRealValueType(A.scalar_type());
 
   auto [U, S, Vh] = at::linalg_svd(A, /*full_matrices=*/false, std::nullopt);
   singular_values.copy_(S);
 
   Tensor tol;
-  if (rcond > 0) {
+  if (rcond > 0 && rcond < 1) {
     auto s_max = singular_values.select(-1, 0).unsqueeze(-1).expand(singular_values.sizes());
     tol = at::mul(s_max, rcond);
   } else {

--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp
@@ -27,10 +27,19 @@
 #include <ATen/ops/empty.h>
 #include <ATen/ops/empty_like.h>
 #include <ATen/ops/empty_strided.h>
+#include <ATen/ops/full_like.h>
 #include <ATen/ops/linalg_eigh.h>
 #include <ATen/ops/linalg_eigvalsh.h>
+#include <ATen/ops/linalg_norm.h>
+#include <ATen/ops/linalg_svd.h>
 #include <ATen/ops/linalg_solve_triangular.h>
+#include <ATen/ops/matmul.h>
+#include <ATen/ops/mul.h>
+#include <ATen/ops/reciprocal.h>
+#include <ATen/ops/sub.h>
+#include <ATen/ops/where.h>
 #include <ATen/ops/zeros.h>
+#include <ATen/ops/zeros_like.h>
 #include <ATen/ops/_linalg_check_errors.h>
 #endif
 
@@ -1459,25 +1468,102 @@ void linalg_lstsq_gels(const Tensor& A, const Tensor& B, const Tensor& /*infos*/
   }
 }
 
-void lstsq_kernel(const Tensor& a, Tensor& b, Tensor& /*rank*/, Tensor& /*singular_values*/, Tensor& infos, double /*rcond*/, std::string /*driver_name*/)  {
+void linalg_lstsq_gelsd(const Tensor& A, Tensor& B, Tensor& rank, Tensor& singular_values, Tensor& infos, double rcond) {
+  // Least squares via reduced SVD: A = U @ diag(S) @ Vh, solution = Vh.mH() @ (S_pinv * (U.mH() @ B))
+  auto m = A.size(-2);
+  auto n = A.size(-1);
+  // auto mn = std::min(m, n);
+  auto batch_sizes = A.sizes().slice(0, A.dim() - 2);
+
+  ScalarType real_dtype = toRealValueType(A.scalar_type());
+
+  // Allocate U and Vh; SVD writes directly into singular_values (no copy).
+  // DimVector U_shape(batch_sizes.begin(), batch_sizes.end());
+  // U_shape.insert(U_shape.end(), {m, mn});
+  // DimVector Vh_shape(batch_sizes.begin(), batch_sizes.end());
+  // Vh_shape.insert(Vh_shape.end(), {mn, n});
+
+  // Tensor U = at::empty(U_shape, A.options());
+  // Tensor Vh = at::empty(Vh_shape, A.options());
+  // at::linalg_svd_out(U, singular_values, Vh, A, /*full_matrices=*/false, std::nullopt);
+
+  bool test1 = false;
+  bool compute_full_matrices = false;
+  if (!test1) compute_full_matrices = m > n;
+
+  auto [U, S, Vh] = at::linalg_svd(A, /*full_matrices=*/compute_full_matrices, std::nullopt);
+
+  singular_values.copy_(S);
+
+  // Tolerance for rank: rcond * max(S) per batch, or machine epsilon * max(m,n) if rcond <= 0
+  Tensor tol;
+  if (rcond > 0) {
+    auto s_max = singular_values.select(-1, 0).unsqueeze(-1).expand(singular_values.sizes());
+    tol = at::mul(s_max, rcond);
+  } else {
+    tol = at::full_like(singular_values, _get_epsilon(real_dtype) * static_cast<double>(std::max(m, n)));
+  }
+
+  Tensor above_tol = singular_values.gt(tol);
+  rank.copy_((above_tol).sum(-1).to(at::kLong));
+  Tensor S_pinv = at::where(above_tol, at::reciprocal(singular_values), at::zeros_like(singular_values));
+  
+  auto B_narrowed = B.narrow(-2, 0, m); // B may have expanded if m < n.
+  Tensor UhB = at::matmul(U.mH(), B_narrowed);  // B may have expanded if m < n. 
+  Tensor Spinv_expanded = S_pinv.unsqueeze(-1).to(A.scalar_type());
+  // Tensor SpinvUhB = at::mul(Spinv_expanded, UhB);
+  Tensor SpinvUhB = at::mul(Spinv_expanded, UhB.narrow(-2, 0, S_pinv.size(-1))); // only the first min(m,n) rows of UhB are multiplied by Spinv, the rest are zero'd out
+  
+  if (test1) {
+    auto X = at::matmul(Vh.mH(), SpinvUhB);
+    if (m > n)
+    {
+      // Most of the clever 'tricks' to computing the residuals from the SVD require the full unitary U matrix which we don't have (because we used reduced svd). 
+      // Thus, the residual will be computed directly and saved on the last location.  
+      // the increase in runtime to compute the residual directly is not significant compared to the rest of the computation.
+      auto residual = at::sub(at::matmul(A, X), B_narrowed);
+      auto col_norms = at::linalg_norm(residual, 2, std::vector<int64_t>{-2}, false);
+      B.narrow(-2, n, m - n).zero_();
+      B.select(-2, m - 1).copy_(col_norms);
+    }
+    B.narrow(-2, 0, n).copy_(X);
+  } else {
+    B.narrow(-2, 0, n) = at::matmul(Vh.mH(), SpinvUhB);
+    B.narrow(-2, n, m - n) = UhB.narrow(-2, n, m - n);
+  }
+}
+
+void lstsq_kernel(const Tensor& a, Tensor& b, Tensor& rank, Tensor& singular_values, Tensor& infos, double rcond, std::string driver_name)  {
   auto m = a.size(-2);
   auto n = a.size(-1);
 
   _warn_once_magma_deprecation("linalg.lstsq");
-  // first handle the underdetermined case (m < n)
-  // this case is not supported by cuBLAS
-  if (m < n) {
-    linalg_lstsq_gels(a, b, infos);
-  } else { // m >= n
-    // On CUDA platform we use either cuBLAS or cuSOLVER here
-    // the batched vs looped dispatch is implemented based on the following performance results
-    // https://github.com/pytorch/pytorch/pull/54725#issuecomment-832234456
-    if (m <= 256 && batchCount(b) >= std::max<int64_t>(2, m / 16)) {
-      gels_batched_cublas(a, b, infos);
-    } else {
+
+  if (driver_name == "gels")
+  {
+    // first handle the underdetermined case (m < n)
+    // this case is not supported by cuBLAS
+    if (m < n) {
       linalg_lstsq_gels(a, b, infos);
+    } else { // m >= n
+      // On CUDA platform we use either cuBLAS or cuSOLVER here
+      // the batched vs looped dispatch is implemented based on the following performance results
+      // https://github.com/pytorch/pytorch/pull/54725#issuecomment-832234456
+      if (m <= 256 && batchCount(b) >= std::max<int64_t>(2, m / 16)) {
+        gels_batched_cublas(a, b, infos);
+      } else {
+        linalg_lstsq_gels(a, b, infos);
+      }
     }
+
+  } else if (driver_name == "gelsd") {
+    linalg_lstsq_gelsd(a, b, rank, singular_values, infos, rcond);
+
+  } else {
+    // this should never be reached since the driver is checked in get_default_lstsq_driver() 
+    TORCH_CHECK(false, "linalg.lstsq: Does not support driver '", driver_name, "' on CUDA.");
   }
+  
 }
 
 REGISTER_CUDA_DISPATCH(lstsq_stub, &lstsq_kernel)

--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp
@@ -37,6 +37,7 @@
 #include <ATen/ops/mul.h>
 #include <ATen/ops/reciprocal.h>
 #include <ATen/ops/sub.h>
+#include <ATen/ops/scalar_tensor.h>
 #include <ATen/ops/where.h>
 #include <ATen/ops/zeros.h>
 #include <ATen/ops/zeros_like.h>
@@ -1481,20 +1482,24 @@ void linalg_lstsq_gelsd(const Tensor& A, Tensor& B, Tensor& rank, Tensor& singul
 
   Tensor tol;
   if (rcond > 0 && rcond < 1) {
-    auto s_max = singular_values.select(-1, 0).unsqueeze(-1).expand(singular_values.sizes());
+    auto s_max = singular_values.select(-1, 0);
     tol = at::mul(s_max, rcond);
   } else {
-    tol = at::full_like(singular_values, _get_epsilon(real_dtype) * static_cast<double>(std::max(m, n)));
+    tol = at::scalar_tensor(_get_epsilon(real_dtype) * static_cast<double>(std::max(m, n)), at::device(A.device()));
   }
 
-  Tensor above_tol = singular_values.gt(tol);
-  rank.copy_((above_tol).sum(-1).to(at::kLong));
-  Tensor S_pinv = at::where(above_tol, at::reciprocal(singular_values), at::zeros_like(singular_values));
+  Tensor above_tol = singular_values.gt(tol.unsqueeze(-1));
+  rank.copy_((above_tol).sum(-1));
 
+  // Avoid dividing by zero by masking singular values that are not above the tolerance
+  Tensor S_safe = singular_values.mul(above_tol).add_(above_tol.logical_not());
   auto B_narrowed = B.narrow(-2, 0, m);
   Tensor UhB = at::matmul(U.mH(), B_narrowed);
-  Tensor Spinv_expanded = S_pinv.unsqueeze(-1).to(A.scalar_type());
-  Tensor SpinvUhB = at::mul(Spinv_expanded, UhB);
+  Tensor S_safe_expanded = S_safe.unsqueeze(-1).to(A.scalar_type());
+  Tensor SpinvUhB = UhB.div(S_safe_expanded);
+  // Zero out contributions from singular values below tolerance
+  SpinvUhB = at::where(above_tol.unsqueeze(-1), SpinvUhB, 0.0);
+
   auto X = at::matmul(Vh.mH(), SpinvUhB);
   if (m > n)
   {

--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp
@@ -1492,13 +1492,14 @@ void linalg_lstsq_gelsd(const Tensor& A, Tensor& B, Tensor& rank, Tensor& singul
   rank.copy_((above_tol).sum(-1));
 
   // Avoid dividing by zero by masking singular values that are not above the tolerance
-  Tensor S_safe = singular_values.mul(above_tol).add_(above_tol.logical_not());
+  Tensor S_safe = at::where(above_tol, singular_values, 1.0);
+  S_safe.unsqueeze_(-1);
+  above_tol.unsqueeze_(-1);
   auto B_narrowed = B.narrow(-2, 0, m);
   Tensor UhB = at::matmul(U.mH(), B_narrowed);
-  Tensor S_safe_expanded = S_safe.unsqueeze(-1).to(A.scalar_type());
-  Tensor SpinvUhB = UhB.div(S_safe_expanded);
+  Tensor SpinvUhB = UhB.div(S_safe.to(A.scalar_type()));
   // Zero out contributions from singular values below tolerance
-  SpinvUhB = at::where(above_tol.unsqueeze(-1), SpinvUhB, 0.0);
+  SpinvUhB.masked_fill_(~above_tol, 0.0);
 
   auto X = at::matmul(Vh.mH(), SpinvUhB);
   if (m > n)

--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp
@@ -27,10 +27,19 @@
 #include <ATen/ops/empty.h>
 #include <ATen/ops/empty_like.h>
 #include <ATen/ops/empty_strided.h>
+#include <ATen/ops/full_like.h>
 #include <ATen/ops/linalg_eigh.h>
 #include <ATen/ops/linalg_eigvalsh.h>
+#include <ATen/ops/linalg_norm.h>
+#include <ATen/ops/linalg_svd.h>
 #include <ATen/ops/linalg_solve_triangular.h>
+#include <ATen/ops/matmul.h>
+#include <ATen/ops/mul.h>
+#include <ATen/ops/reciprocal.h>
+#include <ATen/ops/sub.h>
+#include <ATen/ops/where.h>
 #include <ATen/ops/zeros.h>
+#include <ATen/ops/zeros_like.h>
 #include <ATen/ops/_linalg_check_errors.h>
 #endif
 
@@ -1563,25 +1572,102 @@ void linalg_lstsq_gels(const Tensor& A, const Tensor& B, const Tensor& /*infos*/
   }
 }
 
-void lstsq_kernel(const Tensor& a, Tensor& b, Tensor& /*rank*/, Tensor& /*singular_values*/, Tensor& infos, double /*rcond*/, std::string /*driver_name*/)  {
+void linalg_lstsq_gelsd(const Tensor& A, Tensor& B, Tensor& rank, Tensor& singular_values, Tensor& infos, double rcond) {
+  // Least squares via reduced SVD: A = U @ diag(S) @ Vh, solution = Vh.mH() @ (S_pinv * (U.mH() @ B))
+  auto m = A.size(-2);
+  auto n = A.size(-1);
+  // auto mn = std::min(m, n);
+  auto batch_sizes = A.sizes().slice(0, A.dim() - 2);
+
+  ScalarType real_dtype = toRealValueType(A.scalar_type());
+
+  // Allocate U and Vh; SVD writes directly into singular_values (no copy).
+  // DimVector U_shape(batch_sizes.begin(), batch_sizes.end());
+  // U_shape.insert(U_shape.end(), {m, mn});
+  // DimVector Vh_shape(batch_sizes.begin(), batch_sizes.end());
+  // Vh_shape.insert(Vh_shape.end(), {mn, n});
+
+  // Tensor U = at::empty(U_shape, A.options());
+  // Tensor Vh = at::empty(Vh_shape, A.options());
+  // at::linalg_svd_out(U, singular_values, Vh, A, /*full_matrices=*/false, std::nullopt);
+
+  bool test1 = false;
+  bool compute_full_matrices = false;
+  if (!test1) compute_full_matrices = m > n;
+
+  auto [U, S, Vh] = at::linalg_svd(A, /*full_matrices=*/compute_full_matrices, std::nullopt);
+
+  singular_values.copy_(S);
+
+  // Tolerance for rank: rcond * max(S) per batch, or machine epsilon * max(m,n) if rcond <= 0
+  Tensor tol;
+  if (rcond > 0) {
+    auto s_max = singular_values.select(-1, 0).unsqueeze(-1).expand(singular_values.sizes());
+    tol = at::mul(s_max, rcond);
+  } else {
+    tol = at::full_like(singular_values, _get_epsilon(real_dtype) * static_cast<double>(std::max(m, n)));
+  }
+
+  Tensor above_tol = singular_values.gt(tol);
+  rank.copy_((above_tol).sum(-1).to(at::kLong));
+  Tensor S_pinv = at::where(above_tol, at::reciprocal(singular_values), at::zeros_like(singular_values));
+  
+  auto B_narrowed = B.narrow(-2, 0, m); // B may have expanded if m < n.
+  Tensor UhB = at::matmul(U.mH(), B_narrowed);  // B may have expanded if m < n. 
+  Tensor Spinv_expanded = S_pinv.unsqueeze(-1).to(A.scalar_type());
+  // Tensor SpinvUhB = at::mul(Spinv_expanded, UhB);
+  Tensor SpinvUhB = at::mul(Spinv_expanded, UhB.narrow(-2, 0, S_pinv.size(-1))); // only the first min(m,n) rows of UhB are multiplied by Spinv, the rest are zero'd out
+  
+  if (test1) {
+    auto X = at::matmul(Vh.mH(), SpinvUhB);
+    if (m > n)
+    {
+      // Most of the clever 'tricks' to computing the residuals from the SVD require the full unitary U matrix which we don't have (because we used reduced svd). 
+      // Thus, the residual will be computed directly and saved on the last location.  
+      // the increase in runtime to compute the residual directly is not significant compared to the rest of the computation.
+      auto residual = at::sub(at::matmul(A, X), B_narrowed);
+      auto col_norms = at::linalg_norm(residual, 2, std::vector<int64_t>{-2}, false);
+      B.narrow(-2, n, m - n).zero_();
+      B.select(-2, m - 1).copy_(col_norms);
+    }
+    B.narrow(-2, 0, n).copy_(X);
+  } else {
+    B.narrow(-2, 0, n) = at::matmul(Vh.mH(), SpinvUhB);
+    B.narrow(-2, n, m - n) = UhB.narrow(-2, n, m - n);
+  }
+}
+
+void lstsq_kernel(const Tensor& a, Tensor& b, Tensor& rank, Tensor& singular_values, Tensor& infos, double rcond, std::string driver_name)  {
   auto m = a.size(-2);
   auto n = a.size(-1);
 
   _warn_once_magma_deprecation("linalg.lstsq");
-  // first handle the underdetermined case (m < n)
-  // this case is not supported by cuBLAS
-  if (m < n) {
-    linalg_lstsq_gels(a, b, infos);
-  } else { // m >= n
-    // On CUDA platform we use either cuBLAS or cuSOLVER here
-    // the batched vs looped dispatch is implemented based on the following performance results
-    // https://github.com/pytorch/pytorch/pull/54725#issuecomment-832234456
-    if (m <= 256 && batchCount(b) >= std::max<int64_t>(2, m / 16)) {
-      gels_batched_cublas(a, b, infos);
-    } else {
+
+  if (driver_name == "gels")
+  {
+    // first handle the underdetermined case (m < n)
+    // this case is not supported by cuBLAS
+    if (m < n) {
       linalg_lstsq_gels(a, b, infos);
+    } else { // m >= n
+      // On CUDA platform we use either cuBLAS or cuSOLVER here
+      // the batched vs looped dispatch is implemented based on the following performance results
+      // https://github.com/pytorch/pytorch/pull/54725#issuecomment-832234456
+      if (m <= 256 && batchCount(b) >= std::max<int64_t>(2, m / 16)) {
+        gels_batched_cublas(a, b, infos);
+      } else {
+        linalg_lstsq_gels(a, b, infos);
+      }
     }
+
+  } else if (driver_name == "gelsd") {
+    linalg_lstsq_gelsd(a, b, rank, singular_values, infos, rcond);
+
+  } else {
+    // this should never be reached since the driver is checked in get_default_lstsq_driver() 
+    TORCH_CHECK(false, "linalg.lstsq: Does not support driver '", driver_name, "' on CUDA.");
   }
+  
 }
 
 REGISTER_CUDA_DISPATCH(lstsq_stub, &lstsq_kernel)

--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp
@@ -1573,33 +1573,13 @@ void linalg_lstsq_gels(const Tensor& A, const Tensor& B, const Tensor& /*infos*/
 }
 
 void linalg_lstsq_gelsd(const Tensor& A, Tensor& B, Tensor& rank, Tensor& singular_values, Tensor& infos, double rcond) {
-  // Least squares via reduced SVD: A = U @ diag(S) @ Vh, solution = Vh.mH() @ (S_pinv * (U.mH() @ B))
   auto m = A.size(-2);
   auto n = A.size(-1);
-  // auto mn = std::min(m, n);
-  auto batch_sizes = A.sizes().slice(0, A.dim() - 2);
-
   ScalarType real_dtype = toRealValueType(A.scalar_type());
 
-  // Allocate U and Vh; SVD writes directly into singular_values (no copy).
-  // DimVector U_shape(batch_sizes.begin(), batch_sizes.end());
-  // U_shape.insert(U_shape.end(), {m, mn});
-  // DimVector Vh_shape(batch_sizes.begin(), batch_sizes.end());
-  // Vh_shape.insert(Vh_shape.end(), {mn, n});
-
-  // Tensor U = at::empty(U_shape, A.options());
-  // Tensor Vh = at::empty(Vh_shape, A.options());
-  // at::linalg_svd_out(U, singular_values, Vh, A, /*full_matrices=*/false, std::nullopt);
-
-  bool test1 = false;
-  bool compute_full_matrices = false;
-  if (!test1) compute_full_matrices = m > n;
-
-  auto [U, S, Vh] = at::linalg_svd(A, /*full_matrices=*/compute_full_matrices, std::nullopt);
-
+  auto [U, S, Vh] = at::linalg_svd(A, /*full_matrices=*/false, std::nullopt);
   singular_values.copy_(S);
 
-  // Tolerance for rank: rcond * max(S) per batch, or machine epsilon * max(m,n) if rcond <= 0
   Tensor tol;
   if (rcond > 0) {
     auto s_max = singular_values.select(-1, 0).unsqueeze(-1).expand(singular_values.sizes());
@@ -1611,30 +1591,22 @@ void linalg_lstsq_gelsd(const Tensor& A, Tensor& B, Tensor& rank, Tensor& singul
   Tensor above_tol = singular_values.gt(tol);
   rank.copy_((above_tol).sum(-1).to(at::kLong));
   Tensor S_pinv = at::where(above_tol, at::reciprocal(singular_values), at::zeros_like(singular_values));
-  
-  auto B_narrowed = B.narrow(-2, 0, m); // B may have expanded if m < n.
-  Tensor UhB = at::matmul(U.mH(), B_narrowed);  // B may have expanded if m < n. 
+
+  auto B_narrowed = B.narrow(-2, 0, m);
+  Tensor UhB = at::matmul(U.mH(), B_narrowed);
   Tensor Spinv_expanded = S_pinv.unsqueeze(-1).to(A.scalar_type());
-  // Tensor SpinvUhB = at::mul(Spinv_expanded, UhB);
-  Tensor SpinvUhB = at::mul(Spinv_expanded, UhB.narrow(-2, 0, S_pinv.size(-1))); // only the first min(m,n) rows of UhB are multiplied by Spinv, the rest are zero'd out
-  
-  if (test1) {
-    auto X = at::matmul(Vh.mH(), SpinvUhB);
-    if (m > n)
-    {
-      // Most of the clever 'tricks' to computing the residuals from the SVD require the full unitary U matrix which we don't have (because we used reduced svd). 
-      // Thus, the residual will be computed directly and saved on the last location.  
-      // the increase in runtime to compute the residual directly is not significant compared to the rest of the computation.
-      auto residual = at::sub(at::matmul(A, X), B_narrowed);
-      auto col_norms = at::linalg_norm(residual, 2, std::vector<int64_t>{-2}, false);
-      B.narrow(-2, n, m - n).zero_();
-      B.select(-2, m - 1).copy_(col_norms);
-    }
-    B.narrow(-2, 0, n).copy_(X);
-  } else {
-    B.narrow(-2, 0, n) = at::matmul(Vh.mH(), SpinvUhB);
-    B.narrow(-2, n, m - n) = UhB.narrow(-2, n, m - n);
+  Tensor SpinvUhB = at::mul(Spinv_expanded, UhB);
+  auto X = at::matmul(Vh.mH(), SpinvUhB);
+  if (m > n)
+  {
+    // The increase in runtime to compute the residual directly is not significant compared to the rest of the computation.
+    auto residual = at::sub(at::matmul(A, X), B_narrowed);
+    auto col_norms = at::linalg_norm(residual, 2, std::vector<int64_t>{-2}, false);
+    B.narrow(-2, n, m - n).zero_();
+    B.select(-2, m - 1).copy_(col_norms);
   }
+  B.narrow(-2, 0, n).copy_(X);
+
 }
 
 void lstsq_kernel(const Tensor& a, Tensor& b, Tensor& rank, Tensor& singular_values, Tensor& infos, double rcond, std::string driver_name)  {
@@ -1664,10 +1636,10 @@ void lstsq_kernel(const Tensor& a, Tensor& b, Tensor& rank, Tensor& singular_val
     linalg_lstsq_gelsd(a, b, rank, singular_values, infos, rcond);
 
   } else {
-    // this should never be reached since the driver is checked in get_default_lstsq_driver() 
+    // this should never be reached since the driver is checked in get_default_lstsq_driver()
     TORCH_CHECK(false, "linalg.lstsq: Does not support driver '", driver_name, "' on CUDA.");
   }
-  
+
 }
 
 REGISTER_CUDA_DISPATCH(lstsq_stub, &lstsq_kernel)

--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp
@@ -37,6 +37,7 @@
 #include <ATen/ops/mul.h>
 #include <ATen/ops/reciprocal.h>
 #include <ATen/ops/sub.h>
+#include <ATen/ops/scalar_tensor.h>
 #include <ATen/ops/where.h>
 #include <ATen/ops/zeros.h>
 #include <ATen/ops/zeros_like.h>
@@ -1585,20 +1586,24 @@ void linalg_lstsq_gelsd(const Tensor& A, Tensor& B, Tensor& rank, Tensor& singul
 
   Tensor tol;
   if (rcond > 0 && rcond < 1) {
-    auto s_max = singular_values.select(-1, 0).unsqueeze(-1).expand(singular_values.sizes());
+    auto s_max = singular_values.select(-1, 0);
     tol = at::mul(s_max, rcond);
   } else {
-    tol = at::full_like(singular_values, _get_epsilon(real_dtype) * static_cast<double>(std::max(m, n)));
+    tol = at::scalar_tensor(_get_epsilon(real_dtype) * static_cast<double>(std::max(m, n)), at::device(A.device()));
   }
 
-  Tensor above_tol = singular_values.gt(tol);
-  rank.copy_((above_tol).sum(-1).to(at::kLong));
-  Tensor S_pinv = at::where(above_tol, at::reciprocal(singular_values), at::zeros_like(singular_values));
+  Tensor above_tol = singular_values.gt(tol.unsqueeze(-1));
+  rank.copy_((above_tol).sum(-1));
 
+  // Avoid dividing by zero by masking singular values that are not above the tolerance
+  Tensor S_safe = singular_values.mul(above_tol).add_(above_tol.logical_not());
   auto B_narrowed = B.narrow(-2, 0, m);
   Tensor UhB = at::matmul(U.mH(), B_narrowed);
-  Tensor Spinv_expanded = S_pinv.unsqueeze(-1).to(A.scalar_type());
-  Tensor SpinvUhB = at::mul(Spinv_expanded, UhB);
+  Tensor S_safe_expanded = S_safe.unsqueeze(-1).to(A.scalar_type());
+  Tensor SpinvUhB = UhB.div(S_safe_expanded);
+  // Zero out contributions from singular values below tolerance
+  SpinvUhB = at::where(above_tol.unsqueeze(-1), SpinvUhB, 0.0);
+
   auto X = at::matmul(Vh.mH(), SpinvUhB);
   if (m > n)
   {

--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp
@@ -1596,13 +1596,14 @@ void linalg_lstsq_gelsd(const Tensor& A, Tensor& B, Tensor& rank, Tensor& singul
   rank.copy_((above_tol).sum(-1));
 
   // Avoid dividing by zero by masking singular values that are not above the tolerance
-  Tensor S_safe = singular_values.mul(above_tol).add_(above_tol.logical_not());
+  Tensor S_safe = at::where(above_tol, singular_values, 1.0);
+  S_safe.unsqueeze_(-1);
+  above_tol.unsqueeze_(-1);
   auto B_narrowed = B.narrow(-2, 0, m);
   Tensor UhB = at::matmul(U.mH(), B_narrowed);
-  Tensor S_safe_expanded = S_safe.unsqueeze(-1).to(A.scalar_type());
-  Tensor SpinvUhB = UhB.div(S_safe_expanded);
+  Tensor SpinvUhB = UhB.div(S_safe.to(A.scalar_type()));
   // Zero out contributions from singular values below tolerance
-  SpinvUhB = at::where(above_tol.unsqueeze(-1), SpinvUhB, 0.0);
+  SpinvUhB.masked_fill_(~above_tol, 0.0);
 
   auto X = at::matmul(Vh.mH(), SpinvUhB);
   if (m > n)

--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp
@@ -1575,13 +1575,16 @@ void linalg_lstsq_gels(const Tensor& A, const Tensor& B, const Tensor& /*infos*/
 void linalg_lstsq_gelsd(const Tensor& A, Tensor& B, Tensor& rank, Tensor& singular_values, Tensor& infos, double rcond) {
   auto m = A.size(-2);
   auto n = A.size(-1);
+
+  if (m == 0 || n == 0) return;
+
   ScalarType real_dtype = toRealValueType(A.scalar_type());
 
   auto [U, S, Vh] = at::linalg_svd(A, /*full_matrices=*/false, std::nullopt);
   singular_values.copy_(S);
 
   Tensor tol;
-  if (rcond > 0) {
+  if (rcond > 0 && rcond < 1) {
     auto s_max = singular_values.select(-1, 0).unsqueeze(-1).expand(singular_values.sizes());
     tol = at::mul(s_max, rcond);
   } else {

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -339,7 +339,7 @@ class TestLinalg(TestCase):
         if self.device_type == 'cpu':
             drivers = ('gels', 'gelsy', 'gelsd', 'gelss', None)
         else:
-            drivers = ('gels', None)
+            drivers = ('gels', 'gelsd', None)
 
         def check_solution_correctness(a, b, sol):
             sol2 = a.pinverse() @ b
@@ -365,10 +365,10 @@ class TestLinalg(TestCase):
             a_3d = a.view(batch_size, m, n)
             b_3d = b.view(batch_size, m, nrhs)
 
-            solution_3d = res.solution.view(batch_size, n, nrhs)
-            residuals_2d = apply_if_not_empty(res.residuals, lambda t: t.view(-1, nrhs))
-            rank_1d = apply_if_not_empty(res.rank, lambda t: t.view(-1))
-            singular_values_2d = res.singular_values.view(batch_size, res.singular_values.shape[-1])
+            solution_3d = res.solution.cpu().view(batch_size, n, nrhs)
+            residuals_2d = apply_if_not_empty(res.residuals.cpu(), lambda t: t.view(-1, nrhs))
+            rank_1d = apply_if_not_empty(res.rank.cpu(), lambda t: t.view(-1))
+            singular_values_2d = res.singular_values.cpu().view(batch_size, res.singular_values.shape[-1])
 
             if a.numel() > 0:
                 for i in range(batch_size):
@@ -428,7 +428,7 @@ class TestLinalg(TestCase):
 
                 def numpy_ref(a, b):
                     return np.linalg.lstsq(a, b, rcond=rcond)
-                check_correctness_ref(a, b, res, numpy_ref)
+                check_correctness_ref(a.cpu(), b.cpu(), res, numpy_ref)
 
         ms = [2 ** i for i in range(5)]
         m_ge_n_sizes = [(m, m // 2) for m in ms] + [(m, m) for m in ms]
@@ -605,7 +605,7 @@ class TestLinalg(TestCase):
         b = torch.rand(2, 2, 2, dtype=dtype, device=device)
 
         if device != 'cpu':
-            with self.assertRaisesRegex(RuntimeError, '`driver` other than `gels` is not supported on CUDA'):
+            with self.assertRaisesRegex(RuntimeError, '`driver` other than `gels` or `gelsd` is not supported on CUDA'):
                 torch.linalg.lstsq(a, b, driver='fictitious_driver')
         # if on cpu
         else:

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -420,7 +420,7 @@ class TestLinalg(TestCase):
 
                 def scipy_ref(a, b):
                     return scipy.linalg.lstsq(a, b, lapack_driver=driver, cond=cond)
-                check_correctness_ref(a, b, res, scipy_ref, driver=driver)
+                check_correctness_ref(a.cpu(), b.cpu(), res, scipy_ref, driver=driver)
 
         def check_correctness_numpy(a, b, res, driver, rcond):
             # NumPy uses only gelsd routine

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -365,10 +365,10 @@ class TestLinalg(TestCase):
             a_3d = a.view(batch_size, m, n)
             b_3d = b.view(batch_size, m, nrhs)
 
-            solution_3d = res.solution.cpu().view(batch_size, n, nrhs)
-            residuals_2d = apply_if_not_empty(res.residuals.cpu(), lambda t: t.view(-1, nrhs))
-            rank_1d = apply_if_not_empty(res.rank.cpu(), lambda t: t.view(-1))
-            singular_values_2d = res.singular_values.cpu().view(batch_size, res.singular_values.shape[-1])
+            solution_3d = res.solution.view(batch_size, n, nrhs)
+            residuals_2d = apply_if_not_empty(res.residuals, lambda t: t.view(-1, nrhs))
+            rank_1d = apply_if_not_empty(res.rank, lambda t: t.view(-1))
+            singular_values_2d = res.singular_values.view(batch_size, res.singular_values.shape[-1])
 
             if a.numel() > 0:
                 for i in range(batch_size):
@@ -480,6 +480,66 @@ class TestLinalg(TestCase):
             # because NumPy and SciPy do not implement this driver
             if driver == 'gels' and rcond is None:
                 check_solution_correctness(a, b, sol)
+
+    @skipCUDAIfNoCusolver
+    @skipCPUIfNoLapack
+    @skipIfTorchDynamo("flaky, needs investigation")
+    @dtypes(torch.float, torch.double, torch.cfloat, torch.cdouble)
+    def test_linalg_lstsq_gelsd_rank_deficient(self, device, dtype):
+        from torch.testing._internal.common_utils import random_well_conditioned_matrix
+
+        def make_rank_deficient(a, effective_rank):
+            """Zero out singular values beyond effective_rank by modifying the matrix."""
+            # a is (..., m, n). Compute SVD and set smallest singular values to zero.
+            m, n = a.size(-2), a.size(-1)
+            min_mn = min(m, n)
+            if effective_rank >= min_mn:
+                return a
+            U, S, Vh = torch.linalg.svd(a, full_matrices=False)
+            S[..., effective_rank:] = 0
+            return (U * S) @ Vh
+
+        # Check solution equals pinverse @ b (minimum-norm least-squares solution)
+        def check_solution(a, b, res, rank_ref, atol=1e-5, rtol=1e-5):
+            sol_ref = a.pinverse() @ b
+            self.assertEqual(res.solution, sol_ref, atol=atol, rtol=rtol)
+            self.assertEqual(res.rank, rank_ref)
+            m, n = a.size(-2), a.size(-1)
+            self.assertEqual(res.singular_values.shape, (*a.shape[:-2], min(m, n)))
+
+        # Case 1: one column zero
+        m, n = 6, 4
+        a = random_well_conditioned_matrix(m, n, dtype=dtype, device=device)
+        a[..., -1] = 0
+        b = torch.rand(m, dtype=dtype, device=device)
+        res = torch.linalg.lstsq(a, b, driver='gelsd')
+        check_solution(a, b, res, rank_ref=3)
+        self.assertLessEqual(res.rank.item(), n - 1)
+
+        # Case 2: compare against NumPy
+        a = random_well_conditioned_matrix(5, 4, dtype=dtype, device=device)
+        b = torch.rand(5, 2, dtype=dtype, device=device)
+        expected_sol, _, expected_rank, expected_sv = np.linalg.lstsq(a.cpu(), b.cpu(), rcond=None)
+        res = torch.linalg.lstsq(a, b, driver='gelsd')
+        self.assertEqual(res.solution, expected_sol, atol=1e-5, rtol=1e-5)
+        self.assertEqual(res.rank.item(), expected_rank)
+        self.assertEqual(res.singular_values, expected_sv, atol=1e-5, rtol=1e-5)
+
+        # a.pinverse uses different tolerance than torch.linalg.lstsq so only checking double types.
+        if dtype in (torch.double, torch.cdouble):
+            # Case 3: matrix with effective_rank = 2 (m >= n)
+            a = random_well_conditioned_matrix(5, 4, dtype=dtype, device=device)
+            a = make_rank_deficient(a, 2)
+            b = torch.rand(5, 2, dtype=dtype, device=device)
+            res = torch.linalg.lstsq(a, b, driver='gelsd')
+            check_solution(a, b, res, rank_ref=2)
+
+            # Case 4: batched with one rank-deficient
+            a = random_well_conditioned_matrix(2, 5, 4, dtype=dtype, device=device)
+            a[0, :, :] = make_rank_deficient(a[0, :, :], 3)
+            b = torch.rand(2, 5, 3, dtype=dtype, device=device)
+            res = torch.linalg.lstsq(a, b, driver='gelsd')
+            check_solution(a, b, res, rank_ref=(3, 4))
 
     @skipCUDAIfNoCusolver
     @skipCPUIfNoLapack

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -313,10 +313,10 @@ class TestLinalg(TestCase):
             a_3d = a.view(batch_size, m, n)
             b_3d = b.view(batch_size, m, nrhs)
 
-            solution_3d = res.solution.cpu().view(batch_size, n, nrhs)
-            residuals_2d = apply_if_not_empty(res.residuals.cpu(), lambda t: t.view(-1, nrhs))
-            rank_1d = apply_if_not_empty(res.rank.cpu(), lambda t: t.view(-1))
-            singular_values_2d = res.singular_values.cpu().view(batch_size, res.singular_values.shape[-1])
+            solution_3d = res.solution.view(batch_size, n, nrhs)
+            residuals_2d = apply_if_not_empty(res.residuals, lambda t: t.view(-1, nrhs))
+            rank_1d = apply_if_not_empty(res.rank, lambda t: t.view(-1))
+            singular_values_2d = res.singular_values.view(batch_size, res.singular_values.shape[-1])
 
             if a.numel() > 0:
                 for i in range(batch_size):
@@ -443,6 +443,66 @@ class TestLinalg(TestCase):
         result = torch.linalg.lstsq(a, b, driver='gelsy')
         expected_rank = torch.tensor([3, 2], device=device)
         self.assertEqual(result.rank, expected_rank)
+
+    @skipCUDAIfNoCusolver
+    @skipCPUIfNoLapack
+    @skipIfTorchDynamo("flaky, needs investigation")
+    @dtypes(torch.float, torch.double, torch.cfloat, torch.cdouble)
+    def test_linalg_lstsq_gelsd_rank_deficient(self, device, dtype):
+        from torch.testing._internal.common_utils import random_well_conditioned_matrix
+
+        def make_rank_deficient(a, effective_rank):
+            """Zero out singular values beyond effective_rank by modifying the matrix."""
+            # a is (..., m, n). Compute SVD and set smallest singular values to zero.
+            m, n = a.size(-2), a.size(-1)
+            min_mn = min(m, n)
+            if effective_rank >= min_mn:
+                return a
+            U, S, Vh = torch.linalg.svd(a, full_matrices=False)
+            S[..., effective_rank:] = 0
+            return (U * S) @ Vh
+
+        # Check solution equals pinverse @ b (minimum-norm least-squares solution)
+        def check_solution(a, b, res, rank_ref, atol=1e-5, rtol=1e-5):
+            sol_ref = a.pinverse() @ b
+            self.assertEqual(res.solution, sol_ref, atol=atol, rtol=rtol)
+            self.assertEqual(res.rank, rank_ref)
+            m, n = a.size(-2), a.size(-1)
+            self.assertEqual(res.singular_values.shape, (*a.shape[:-2], min(m, n)))
+
+        # Case 1: one column zero
+        m, n = 6, 4
+        a = random_well_conditioned_matrix(m, n, dtype=dtype, device=device)
+        a[..., -1] = 0
+        b = torch.rand(m, dtype=dtype, device=device)
+        res = torch.linalg.lstsq(a, b, driver='gelsd')
+        check_solution(a, b, res, rank_ref=3)
+        self.assertLessEqual(res.rank.item(), n - 1)
+
+        # Case 2: compare against NumPy
+        a = random_well_conditioned_matrix(5, 4, dtype=dtype, device=device)
+        b = torch.rand(5, 2, dtype=dtype, device=device)
+        expected_sol, _, expected_rank, expected_sv = np.linalg.lstsq(a.cpu(), b.cpu(), rcond=None)
+        res = torch.linalg.lstsq(a, b, driver='gelsd')
+        self.assertEqual(res.solution, expected_sol, atol=1e-5, rtol=1e-5)
+        self.assertEqual(res.rank.item(), expected_rank)
+        self.assertEqual(res.singular_values, expected_sv, atol=1e-5, rtol=1e-5)
+
+        # a.pinverse uses different tolerance than torch.linalg.lstsq so only checking double types.
+        if dtype in (torch.double, torch.cdouble):
+            # Case 3: matrix with effective_rank = 2 (m >= n)
+            a = random_well_conditioned_matrix(5, 4, dtype=dtype, device=device)
+            a = make_rank_deficient(a, 2)
+            b = torch.rand(5, 2, dtype=dtype, device=device)
+            res = torch.linalg.lstsq(a, b, driver='gelsd')
+            check_solution(a, b, res, rank_ref=2)
+
+            # Case 4: batched with one rank-deficient
+            a = random_well_conditioned_matrix(2, 5, 4, dtype=dtype, device=device)
+            a[0, :, :] = make_rank_deficient(a[0, :, :], 3)
+            b = torch.rand(2, 5, 3, dtype=dtype, device=device)
+            res = torch.linalg.lstsq(a, b, driver='gelsd')
+            check_solution(a, b, res, rank_ref=(3, 4))
 
     @skipCUDAIfNoCusolver
     @skipCPUIfNoLapack

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -368,7 +368,7 @@ class TestLinalg(TestCase):
 
                 def scipy_ref(a, b):
                     return scipy.linalg.lstsq(a, b, lapack_driver=driver, cond=cond)
-                check_correctness_ref(a, b, res, scipy_ref, driver=driver)
+                check_correctness_ref(a.cpu(), b.cpu(), res, scipy_ref, driver=driver)
 
         def check_correctness_numpy(a, b, res, driver, rcond):
             # NumPy uses only gelsd routine

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -287,7 +287,7 @@ class TestLinalg(TestCase):
         if self.device_type == 'cpu':
             drivers = ('gels', 'gelsy', 'gelsd', 'gelss', None)
         else:
-            drivers = ('gels', None)
+            drivers = ('gels', 'gelsd', None)
 
         def check_solution_correctness(a, b, sol):
             sol2 = a.pinverse() @ b
@@ -313,10 +313,10 @@ class TestLinalg(TestCase):
             a_3d = a.view(batch_size, m, n)
             b_3d = b.view(batch_size, m, nrhs)
 
-            solution_3d = res.solution.view(batch_size, n, nrhs)
-            residuals_2d = apply_if_not_empty(res.residuals, lambda t: t.view(-1, nrhs))
-            rank_1d = apply_if_not_empty(res.rank, lambda t: t.view(-1))
-            singular_values_2d = res.singular_values.view(batch_size, res.singular_values.shape[-1])
+            solution_3d = res.solution.cpu().view(batch_size, n, nrhs)
+            residuals_2d = apply_if_not_empty(res.residuals.cpu(), lambda t: t.view(-1, nrhs))
+            rank_1d = apply_if_not_empty(res.rank.cpu(), lambda t: t.view(-1))
+            singular_values_2d = res.singular_values.cpu().view(batch_size, res.singular_values.shape[-1])
 
             if a.numel() > 0:
                 for i in range(batch_size):
@@ -376,7 +376,7 @@ class TestLinalg(TestCase):
 
                 def numpy_ref(a, b):
                     return np.linalg.lstsq(a, b, rcond=rcond)
-                check_correctness_ref(a, b, res, numpy_ref)
+                check_correctness_ref(a.cpu(), b.cpu(), res, numpy_ref)
 
         ms = [2 ** i for i in range(5)]
         m_ge_n_sizes = [(m, m // 2) for m in ms] + [(m, m) for m in ms]
@@ -569,7 +569,7 @@ class TestLinalg(TestCase):
         b = torch.rand(2, 2, 2, dtype=dtype, device=device)
 
         if device != 'cpu':
-            with self.assertRaisesRegex(RuntimeError, '`driver` other than `gels` is not supported on CUDA'):
+            with self.assertRaisesRegex(RuntimeError, '`driver` other than `gels` or `gelsd` is not supported on CUDA'):
                 torch.linalg.lstsq(a, b, driver='fictitious_driver')
         # if on cpu
         else:

--- a/torch/testing/_internal/opinfo/definitions/linalg.py
+++ b/torch/testing/_internal/opinfo/definitions/linalg.py
@@ -732,7 +732,7 @@ def sample_inputs_linalg_lstsq(op_info, device, dtype, requires_grad=False, **kw
 
     drivers: tuple[str, ...]
     if device.type == "cuda":
-        drivers = ("gels",)
+        drivers = ("gels", "gelsd")
     else:
         drivers = ("gels", "gelsy", "gelss", "gelsd")
 

--- a/torch/testing/_internal/opinfo/definitions/linalg.py
+++ b/torch/testing/_internal/opinfo/definitions/linalg.py
@@ -735,7 +735,7 @@ def sample_inputs_linalg_lstsq(op_info, device, dtype, requires_grad=False, **kw
 
     drivers: tuple[str, ...]
     if device.type == "cuda":
-        drivers = ("gels",)
+        drivers = ("gels", "gelsd")
     else:
         drivers = ("gels", "gelsy", "gelss", "gelsd")
 


### PR DESCRIPTION
Fixes #117122 

Updated `torch.linalg.lstsq` to be able to use `driver='gelsd'` and solve the system of equation using the SVD of the matrix $A$ for $||Ax-b||_2^2$. This allows a user to be able to solve any system, not just the systems where $A$ has full rank. In the case where there are multiple solutions, the `'gelsd' `solver finds the solution such that $||x||_2$ is minimized. 

In the referenced issue, there is discussion about also having the 'gels' (QR solver) method always throw an error when the input is not full rank. I am not going to implement this as it would require extra work that will slow down the current algorithm. Currently, the only reason it will sometimes throw an error on batched tensors (such as the example given when the tensor is of size 2 x 5 x 3)  is because in special cases the method calls the cuBLAS `gelsBatched()` method. This method returns the `infos` parameter that tells if the matrix is rank deficient (see `lstsq_kernel()` in `aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp` in the **Files Changed**). The reasons for sometimes dispatching to cuBLAS and sometimes using the PyTorch implementation is due to performance and is discussed in this PR #54725. 

Also, note that the error for cuBLAS `gelsBatched()` does not always work. I ran the example from the linked issue but replaced:
`A[...,-1] = 0` with `A[...,-1] = A[...,-2] + A[...,-3]` 
and it gave me incorrect results without throwing any errors, so even the cuBLAS implementation `infos` argument is not always reliable. 

Currently, the `driver` argument has to be set explicitly to use `'gelsd'` but if there is convincing reason to make it a default on underdetermined systems (n_cols > n_rows) then I can add this as well.  