### PR TITLE
Fix root cause of extraneous termination handler error logging (eval) (#176747)

### DIFF
--- a/torch/csrc/jit/python/pybind_utils.cpp
+++ b/torch/csrc/jit/python/pybind_utils.cpp
@@ -84,8 +84,8 @@ IValue toIValue(py::handle obj, const TypePtr& type, std::optional<int32_t> N) {
         return var;
       } else {
         if (!allow_numbers_as_tensors) {
-          throw py::cast_error(
-              c10::str("Unable to cast ", py::str(obj), " to Tensor"));
+          throw py::cast_error(c10::str(
+              "Unable to cast ", friendlyTypeName(obj), " object to Tensor"));
         }
         bool save_symint = false;
         at::Scalar scalar;
@@ -108,7 +108,7 @@ IValue toIValue(py::handle obj, const TypePtr& type, std::optional<int32_t> N) {
           scalar = at::Scalar(true);
         } else {
           throw py::cast_error(
-              c10::str("Unable to cast ", py::str(obj), " to Tensor"));
+              c10::str("Unable to cast ", friendlyTypeName(obj), " to Tensor"));
         }
         at::Tensor tensor = at::scalar_to_tensor(scalar);
         tensor.unsafeGetTensorImpl()->set_wrapped_number(true);
@@ -221,7 +221,7 @@ IValue toIValue(py::handle obj, const TypePtr& type, std::optional<int32_t> N) {
     case TypeKind::NoneType:
       if (!obj.is_none()) {
         throw py::cast_error(
-            c10::str("Cannot cast ", py::str(obj), " to None"));
+            c10::str("Cannot cast ", friendlyTypeName(obj), " to None"));
       }
       return {};
     case TypeKind::BoolType:
@@ -243,9 +243,13 @@ IValue toIValue(py::handle obj, const TypePtr& type, std::optional<int32_t> N) {
       const auto& elem_types = tuple_type->elements();
       if (elem_types.size() != tuple_size) {
         throw py::cast_error(c10::str(
-            "Object ",
-            py::str(obj),
-            " had a different number of elements than type ",
+            "Object of type ",
+            friendlyTypeName(obj),
+            " had a different number of elements (",
+            tuple_size,
+            " vs ",
+            elem_types.size(),
+            ") than type ",
             type->repr_str()));
       }
       std::vector<IValue> values;
@@ -477,11 +481,11 @@ IValue toIValue(py::handle obj, const TypePtr& type, std::optional<int32_t> N) {
         classType = pyCu->get_class(c10::QualifiedName(qualified_name));
         if (!classType) {
           throw std::runtime_error(c10::str(
-              "Assigning the object ",
-              py::str(obj),
+              "Assigning an object of type ",
+              friendlyTypeName(obj),
               " to an interface fails because the value is not "
               "a TorchScript compatible type, did you forget to",
-              "turn it into a user defined TorchScript class?"));
+              " turn it into a user defined TorchScript class?"));
         }
         res = toIValue(obj, classType);
       }
@@ -527,8 +531,8 @@ IValue toIValue(py::handle obj, const TypePtr& type, std::optional<int32_t> N) {
       } else if (torch::is_symbool(obj)) {
         return py::cast<c10::SymBool>(obj);
       } else {
-        throw py::cast_error(
-            c10::str("Cannot cast ", py::str(obj), " to ", type->repr_str()));
+        throw py::cast_error(c10::str(
+            "Cannot cast ", friendlyTypeName(obj), " to ", type->repr_str()));
       }
     }
     case TypeKind::RRefType: {
@@ -565,8 +569,8 @@ IValue toIValue(py::handle obj, const TypePtr& type, std::optional<int32_t> N) {
       if (py::isinstance<py::int_>(obj)) {
         return static_cast<at::QScheme>(py::cast<int64_t>(obj));
       }
-      throw py::cast_error(
-          c10::str("Cannot cast ", py::str(obj), " to ", type->repr_str()));
+      throw py::cast_error(c10::str(
+          "Cannot cast ", friendlyTypeName(obj), " to ", type->repr_str()));
     }
     case TypeKind::GeneratorType:
       return py::cast<at::Generator>(obj);

--- a/torch/csrc/jit/python/pybind_utils.h
+++ b/torch/csrc/jit/python/pybind_utils.h
@@ -830,19 +830,13 @@ inline IValue argumentToIValue(
   } catch (const py::cast_error& error) {
     throw schema_match_error(c10::str(
         schema.formatTypeMismatchMsg(
-            argument,
-            friendlyTypeName(object),
-            argumentPosition,
-            py::repr(object)),
+            argument, friendlyTypeName(object), argumentPosition, std::nullopt),
         "\nCast error details: ",
         error.what()));
   } catch (const py::error_already_set& error) {
     throw schema_match_error(c10::str(
         schema.formatTypeMismatchMsg(
-            argument,
-            friendlyTypeName(object),
-            argumentPosition,
-            py::repr(object)),
+            argument, friendlyTypeName(object), argumentPosition, std::nullopt),
         "\n Python error details: ",
         error.what()));
   }
@@ -856,10 +850,8 @@ inline IValue returnToIValue(const TypePtr& type, py::handle object) {
         " expected value of type ",
         type->str(),
         " for return value but instead got value of type ",
-        py::str(py::type::handle_of(object).attr("__name__")),
+        friendlyTypeName(object),
         ".",
-        "\nValue: ",
-        py::repr(object),
         "\nCast error details: ",
         error.what()));
   }
@@ -921,7 +913,7 @@ inline bool validateFakeScriptObjectSchema(
             argument,
             friendlyTypeName(object),
             argumentPosition,
-            py::repr(object.attr("wrapped_obj"))),
+            friendlyTypeName(object.attr("wrapped_obj"))),
         "\nCast error details: ",
         argument.name(),
         " is expected to be a FakeScriptObject of ",


### PR DESCRIPTION
Summary:

When an exception occurs in a `noexcept` destructor during shutdown, it triggers `std::terminate`. This leads to noisy logging of errors in our dataset. It manifests as
```
std::terminate() invoked but parsed exception is empty. Backtrace captured at c++ termination handler entry point is shown below.

Backtrace:
 (unknown)
 <11aae1975e3632c1>    @ 0000000035cbf759
 (unknown)
 <11aae1975e3632c1>    @ 0000000035d017fb
 __cxxabiv1::__terminate(void (*)())
                       /home/engshare/third-party2/libgcc/11.x/src/gcc-11.x/x86_64-facebook-linux/libstdc++-v3/libsupc++/../../.././libstdc++-v3/libsupc++/eh_terminate.cc:48
 std::terminate()
                       /home/engshare/third-party2/libgcc/11.x/src/gcc-11.x/x86_64-facebook-linux/libstdc++-v3/libsupc++/../../.././libstdc++-v3/libsupc++/eh_terminate.cc:58
 __clang_call_terminate
 <11aae1975e3632c1>    @ 0000000012d6955d
 c10::TensorImpl::decref_pyobject() const
 <11aae1975e3632c1>    @ 0000000051aead2e
 at::Tensor c10::Dispatcher::callWithDispatchKeySlowPath<at::Tensor, at::Tensor const&, c10::ArrayRef<c10::SymInt>, c10::ArrayRef<c10::SymInt>, std::optional<c10::SymInt> >(c10::TypedOperatorHandle<at::Tensor (at::Tensor const&, c10::ArrayRef<c10::SymInt>, c10::ArrayRef<c10::SymInt>, std::optional<c10::SymInt>)> const&, at::StepCallbacks&, c10::DispatchKeySet, c10::KernelFunction const&, at::Tensor const&, c10::ArrayRef<c10::SymInt>, c10::ArrayRef<c10::SymInt>, std::optional<c10::SymInt>)
 <11aae1975e3632c1>    @ 0000000019d0cfb8
 at::_ops::as_strided::call(at::Tensor const&, c10::ArrayRef<c10::SymInt>, c10::ArrayRef<c10::SymInt>, std::optional<c10::SymInt>)
 <11aae1975e3632c1>    @ 0000000019d0c6e7
 at::native::select_symint(at::Tensor const&, long, c10::SymInt)
 <11aae1975e3632c1>    @ 000000001584ed84
 (unknown)
 <11aae1975e3632c1>    @ 000000001763f3ea
 c10::detail::CaptureKernelCall<at::Tensor>::CaptureKernelCall<c10::KernelFunction, at::Tensor const&, long, c10::SymInt>(c10::KernelFunction const&, c10::TypedOperatorHandle<at::Tensor (at::Tensor const&, long, c10::SymInt)> const&, c10::DispatchKeySet const&, at::Tensor const&, long&&, c10::SymInt&&)
 <11aae1975e3632c1>    @ 000000001a425fbc
 at::Tensor c10::Dispatcher::callWithDispatchKeySlowPath<at::Tensor, at::Tensor const&, long, c10::SymInt>(c10::TypedOperatorHandle<at::Tensor (at::Tensor const&, long, c10::SymInt)> const&, at::StepCallbacks&, c10::DispatchKeySet, c10::KernelFunction const&, at::Tensor const&, long, c10::SymInt)
 <11aae1975e3632c1>    @ 000000001a425e0d
 at::_ops::select_int::call(at::Tensor const&, long, c10::SymInt)
 <11aae1975e3632c1>    @ 000000001a425570
 at::native::unbind(at::Tensor const&, long)
 <11aae1975e3632c1>    @ 0000000015868082
 (unknown)
 <11aae1975e3632c1>    @ 00000000176608f3
 at::_ops::unbind_int::redispatch(c10::DispatchKeySet, at::Tensor const&, long)
 <11aae1975e3632c1>    @ 0000000019dec1c0
 (unknown)
 <11aae1975e3632c1>    @ 0000000018c499a5
 at::_ops::unbind_int::redispatch(c10::DispatchKeySet, at::Tensor const&, long)
 <11aae1975e3632c1>    @ 0000000019dec1c0
 (unknown)
 <11aae1975e3632c1>    @ 00000000181068b7
 std::vector<at::Tensor, std::allocator<at::Tensor> > c10::Dispatcher::callWithDispatchKeySlowPath<std::vector<at::Tensor, std::allocator<at::Tensor> >, at::Tensor const&, long>(c10::TypedOperatorHandle<std::vector<at::Tensor, std::allocator<at::Tensor> > (at::Tensor const&, long)> const&, at::StepCallbacks&, c10::DispatchKeySet, c10::KernelFunction const&, at::Tensor const&, long)
 <11aae1975e3632c1>    @ 0000000019debe89
 at::_ops::unbind_int::call(at::Tensor const&, long)
 <11aae1975e3632c1>    @ 0000000019deb926
 (unknown)
 <11aae1975e3632c1>    @ 00000000648c081b
 method_vectorcall_VARARGS_KEYWORDS(_object*, _object* const*, unsigned long, _object*) [clone .__uniq.339039793189136938154982213481861155478] [clone .llvm.15832437935994608857]
                       ./third-party/python/3.12/Objects/descrobject.c:365
 PyObject_Vectorcall
                       third-party/python/3.12/Include/internal/pycore_call.h:92
                       -> ./third-party/python/3.12/Objects/call.c
 _PyEval_EvalFrameDefault
                       Python/bytecodes.c:2807
                       -> ./third-party/python/3.12/Python/ceval.c
 PyObject_CallOneArg
                       third-party/python/3.12/Include/internal/pycore_ceval.h:90
                       -> ./third-party/python/3.12/Objects/call.c
 slot_tp_iter(_object*) [clone .__uniq.143322246853036901010628582432473509685]
                       ./third-party/python/3.12/Objects/typeobject.c:2243
 PyObject_GetIter
                       ./third-party/python/3.12/Objects/abstract.c:2788
 _PyEval_EvalFrameDefault
                       Python/bytecodes.c:2357
                       -> ./third-party/python/3.12/Python/ceval.c
 PyObject_Vectorcall
                       third-party/python/3.12/Include/internal/pycore_ceval.h:90
                       -> ./third-party/python/3.12/Objects/call.c
 _PyEval_EvalFrameDefault
                       Python/bytecodes.c:2807
                       -> ./third-party/python/3.12/Python/ceval.c
 PyObject_CallOneArg
                       third-party/python/3.12/Include/internal/pycore_ceval.h:90
                       -> ./third-party/python/3.12/Objects/call.c
 slot_tp_repr(_object*) [clone .__uniq.143322246853036901010628582432473509685] [clone .llvm.15785171207116590357]
                       ./third-party/python/3.12/Objects/typeobject.c:2243
 PyObject_Repr
                       ./third-party/python/3.12/Objects/object.c:572
 tuplerepr(PyTupleObject*) [clone .__uniq.101365645866725480646397884559911849171]
                       ./third-party/python/3.12/Objects/tupleobject.c:258
 PyObject_Repr
                       ./third-party/python/3.12/Objects/object.c:572
 dict_repr(PyDictObject*) [clone .__uniq.149819802126897409227579466864541652227]
                       ./third-party/python/3.12/Objects/dictobject.c:2724
 PyObject_Repr
                       ./third-party/python/3.12/Objects/object.c:572
 PyUnicode_Format
                       ./third-party/python/3.12/Objects/unicodeobject.c:14346
 PyNumber_Remainder
                       ./third-party/python/3.12/Objects/abstract.c:882
 _PyEval_EvalFrameDefault
                       Python/bytecodes.c:3483
                       -> ./third-party/python/3.12/Python/ceval.c
 PyObject_CallOneArg
                       third-party/python/3.12/Include/internal/pycore_ceval.h:90
                       -> ./third-party/python/3.12/Objects/call.c
 slot_tp_repr(_object*) [clone .__uniq.143322246853036901010628582432473509685] [clone .llvm.15785171207116590357]
                       ./third-party/python/3.12/Objects/typeobject.c:2243
 PyObject_Str
                       third-party/python/3.12/Objects/typeobject.c:5583
                       -> ./third-party/python/3.12/Objects/object.c
 pybind11::str::str(pybind11::handle)
 <11aae1975e3632c1>    @ 000000001b2f7074
 torch::jit::toIValue(pybind11::handle, c10::Type::SingletonOrSharedTypePtr<c10::Type> const&, std::optional<int>)
 <11aae1975e3632c1>    @ 0000000064c48c16
 torch::jit::argumentToIValue(c10::FunctionSchema const&, unsigned long, pybind11::handle)
 <11aae1975e3632c1>    @ 0000000064c5565e
 torch::jit::createStackForSchema(c10::FunctionSchema const&, torch::jit::tuple_slice const&, pybind11::kwargs const&, std::optional<c10::IValue>)
 <11aae1975e3632c1>    @ 0000000064c54f2e
 torch::jit::runAndInsertCall(torch::jit::Function&, torch::jit::tuple_slice const&, pybind11::kwargs const&, std::optional<c10::IValue>, std::function<torch::jit::Value* (torch::jit::Graph&, torch::jit::MatchedSchema const&)> const&)
 <11aae1975e3632c1>    @ 0000000064c61ce1
 torch::jit::invokeScriptMethodFromPython(torch::jit::Method&, torch::jit::tuple_slice const&, pybind11::kwargs const&)
 <11aae1975e3632c1>    @ 0000000064c617ac
 (unknown)
 <11aae1975e3632c1>    @ 0000000064d26d2f
 (unknown)
 <11aae1975e3632c1>    @ 0000000064d268d5
 pybind11::cpp_function::dispatcher(_object*, _object*, _object*)
 <11aae1975e3632c1>    @ 000000001b2f446f
 _PyObject_MakeTpCall
                       third-party/python/3.12/Objects/methodobject.c:537
                       -> ./third-party/python/3.12/Objects/call.c
 method_vectorcall(_object*, _object* const*, unsigned long, _object*) [clone .__uniq.44356567273764464108930774188262547171] [clone .llvm.17919720346844690814]
                       third-party/python/3.12/Include/internal/pycore_call.h:90
                       -> ./third-party/python/3.12/Objects/classobject.c
 slot_tp_call(_object*, _object*, _object*) [clone .__uniq.143322246853036901010628582432473509685]
                       ./third-party/python/3.12/Objects/typeobject.c:8818
 PyObject_Call
                       ./third-party/python/3.12/Objects/call.c:367
 _PyEval_EvalFrameDefault
                       Python/bytecodes.c:3355
                       -> ./third-party/python/3.12/Python/ceval.c
 PyObject_Call
                       third-party/python/3.12/Include/internal/pycore_call.h:92
                       -> ./third-party/python/3.12/Objects/call.c
 _PyEval_EvalFrameDefault
                       Python/bytecodes.c:3355
                       -> ./third-party/python/3.12/Python/ceval.c
 _PyObject_Call_Prepend
                       third-party/python/3.12/Include/internal/pycore_ceval.h:90
                       -> ./third-party/python/3.12/Objects/call.c
 slot_tp_call(_object*, _object*, _object*) [clone .__uniq.143322246853036901010628582432473509685]
                       ./third-party/python/3.12/Objects/typeobject.c:8815
 PyObject_Vectorcall
                       ./third-party/python/3.12/Objects/call.c:240
 _PyEval_EvalFrameDefault
                       Python/bytecodes.c:2807
                       -> ./third-party/python/3.12/Python/ceval.c
 PyObject_Call
                       third-party/python/3.12/Include/internal/pycore_call.h:92
                       -> ./third-party/python/3.12/Objects/call.c
 _PyEval_EvalFrameDefault
                       Python/bytecodes.c:3355
                       -> ./third-party/python/3.12/Python/ceval.c
 PyObject_Call
                       third-party/python/3.12/Include/internal/pycore_call.h:92
                       -> ./third-party/p
... (truncated)
```
for pyper

There can be many root causes for this. One class of problems this occurs for is VanillaPreprocXX types.

The backtrace reads (bottom-to-top):

1. torch::jit::invokeScriptMethodFromPython → createStackForSchema → argumentToIValue → toIValue
2. toIValue, TupleType case (line 244-249 in pybind_utils.cpp): detects tuple size mismatch (8 fields vs expected 7), constructs error message with py::str(obj) on line 247
3. py::str(obj) → PyObject_Str → __repr__ → recursively repr's the NamedTuple → dict → tuple → tensors
4. Tensor repr calls detach() → dispatcher → creates temporary tensor → temporary's destructor runs
5. TensorImpl::decref_pyobject() (noexcept) → ConcretePyInterpreterVTable::decref → pybind11::gil_scoped_acquire or Py_DECREF throws
6. noexcept violation → __clang_call_terminate → std::terminate()

The critical problem: decref_pyobject() is declared noexcept (line 1002 of TensorImpl.cpp) but delegates to ConcretePyInterpreterVTable::decref (line 240 of PyInterpreter.cpp) which can throw — pybind11::gil_scoped_acquire or Python finalizers triggered by Py_DECREF can raise. A try-catch around py::str(obj) would NOT help since std::terminate fires inside the noexcept function, before any exception reaches the caller.

Solution is to replace these unsafe repr / str calls with calls to `friendlyTypeName`

Test Plan:
Original run f1045825852 would log this additional error
```
std::terminate() invoked but parsed exception is empty. Backtrace captured at c++ termination handler entry point is shown below.
```
https://fburl.com/scuba/pyper_training_events/y8mn0rll

New run with changes
f1045863577
In Scuba, we can see that there is no more termination handler exception
https://fburl.com/scuba/pyper_training_events/bm073ltf

Differential Revision: D95600044


