### PR TITLE
fix remat_using_tags_for_fwd_loss_bwd_graph

### DIFF
--- a/test/dynamo/test_activation_checkpointing.py
+++ b/test/dynamo/test_activation_checkpointing.py
@@ -2261,7 +2261,7 @@ def forward(self, arg0_1, arg1_1):
 
         with self.assertRaisesRegex(
             torch._dynamo.exc.BackendCompilerFailed,
-            "Activation checkpoint rematerializing in `forward-loss-backward` graph does not support RNG ops in checkpointed regions.",
+            "Activation checkpoint rematerialization in `forward-loss-backward` graph does not support RNG ops in recompute regions.",
         ):
             self._compile_and_capture(fwd_bwd_with_rng, True, (x,))
 

--- a/torch/_functorch/_activation_checkpointing/remat_using_tags_for_fwd_loss_bwd_graph_pass.py
+++ b/torch/_functorch/_activation_checkpointing/remat_using_tags_for_fwd_loss_bwd_graph_pass.py
@@ -1,7 +1,6 @@
-"""
-AC rematerialize pass: Duplicates checkpointed nodes for backward, then DCE removes unused forward versions.
-"""
+"""AC rematerialize pass: Duplicates checkpointed nodes for backward, then DCE removes unused forward versions."""
 
+import logging
 from typing import Any, overload
 
 import torch
@@ -17,6 +16,8 @@ from torch._functorch.partitioners import (
     is_not_collective,
     must_recompute,
 )
+
+log = logging.getLogger(__name__)
 
 
 def is_impure_node_for_dce(node: fx.Node) -> bool:
@@ -96,10 +97,11 @@ def remat_using_tags_for_fwd_loss_bwd_graph(gm: fx.GraphModule) -> fx.GraphModul
     def gather_checkpointed_deps(node: fx.Node, visited: set[fx.Node]) -> None:
         if node in visited or node in recomputed_nodes:
             return
+        if not must_recompute(node):
+            return
         visited.add(node)
         for inp in node.all_input_nodes:
-            if must_recompute(inp):
-                gather_checkpointed_deps(inp, visited)
+            gather_checkpointed_deps(inp, visited)
 
     # Insert backward nodes
     for node in list(gm.graph.nodes)[bwd_start:]:
@@ -112,12 +114,17 @@ def remat_using_tags_for_fwd_loss_bwd_graph(gm: fx.GraphModule) -> fx.GraphModul
         # Insert deps in forward order (guaranteed disjoint from already-inserted)
         # This is not as inefficient as it looks, because we only add fresh dependencies
         # when they are not yet processed as recomputed nodes.
-        for dep in sorted(deps, key=lambda n: order[n]):
-            if dep in recomputed_nodes:
-                raise AssertionError(
-                    f"We shouldn't have recomputed {dep} before, "
-                    f"but found it in recomputed_nodes"
-                )
+        new_deps = sorted(
+            (dep for dep in deps if dep not in recomputed_nodes),
+            key=lambda n: order[n],
+        )
+        if new_deps and torch.distributed.get_rank() == 0:
+            print(
+                "remat: to compute backward node %s, recomputing [%s]",
+                node.name,
+                ", ".join(dep.name for dep in new_deps),
+            )
+        for dep in new_deps:
             dup = new_graph.node_copy(dep, remat_input)
             dup.name = dep.name + "_recomputed"
             recomputed_nodes[dep] = dup

--- a/torch/_functorch/_activation_checkpointing/remat_using_tags_for_fwd_loss_bwd_graph_pass.py
+++ b/torch/_functorch/_activation_checkpointing/remat_using_tags_for_fwd_loss_bwd_graph_pass.py
@@ -1,4 +1,4 @@
-"""AC rematerialize pass: Duplicates checkpointed nodes for backward, then DCE removes unused forward versions."""
+"""AC rematerialize pass: Duplicates recompute nodes for backward, then DCE removes unused forward versions."""
 
 import logging
 from typing import Any, overload
@@ -41,7 +41,7 @@ def _is_backward_node(node: fx.Node) -> bool:
 
 def remat_using_tags_for_fwd_loss_bwd_graph(gm: fx.GraphModule) -> fx.GraphModule:
     """
-    Duplicate checkpointed nodes for backward use. DCE removes unused forward versions. We assume that
+    Duplicate recompute nodes for backward use. DCE removes unused forward versions. We assume that
     you already annotated your backward region with fx.traceback.annotate({"remat_pass_tag": "is_backward"})
     which helps us identify the backward region.
     """
@@ -61,9 +61,9 @@ def remat_using_tags_for_fwd_loss_bwd_graph(gm: fx.GraphModule) -> fx.GraphModul
 
     if has_recomputable_rng_ops(gm):
         raise RuntimeError(
-            "Activation checkpoint rematerializing in `forward-loss-backward` graph does not support RNG ops "
-            "in checkpointed regions. Please move RNG operations outside "
-            "of checkpoint regions, or use joint graph mode (where partitioner handles RNG)."
+            "Activation checkpoint rematerialization in `forward-loss-backward` graph does not support RNG ops "
+            "in recompute regions. Please move RNG operations outside "
+            "of recompute regions, or use joint graph mode (where partitioner handles RNG)."
         )
 
     # Use partitioner pass to normalize AC node tags.
@@ -90,30 +90,31 @@ def remat_using_tags_for_fwd_loss_bwd_graph(gm: fx.GraphModule) -> fx.GraphModul
             return x
         return recomputed_nodes.get(x, env[x])
 
-    def gather_checkpointed_deps(node: fx.Node, visited: set[fx.Node]) -> None:
-        if node in visited or node in recomputed_nodes:
-            return
-        if not must_recompute(node):
-            return
-        visited.add(node)
+    def gather_recompute_deps(node: fx.Node) -> set[fx.Node]:
+        deps: set[fx.Node] = set()
+
+        def _gather(n: fx.Node) -> None:
+            if n in deps or n in recomputed_nodes or not must_recompute(n):
+                return
+            deps.add(n)
+            for inp in n.all_input_nodes:
+                _gather(inp)
+
+        # Can't call _gather(node) directly: node itself may not be must_recompute
+        # (e.g. backward nodes), so _gather would return early without visiting inputs.
         for inp in node.all_input_nodes:
-            gather_checkpointed_deps(inp, visited)
+            _gather(inp)
+        return deps
 
     # Insert backward nodes
     for node in list(gm.graph.nodes)[bwd_start:]:
-        # Gather all checkpointed deps needed by this node
-        deps = set()
-        for inp in node.all_input_nodes:
-            if must_recompute(inp):
-                gather_checkpointed_deps(inp, deps)
+        # Gather all deps that need to be recomputed for this node
+        deps = gather_recompute_deps(node)
 
         # Insert deps in forward order (guaranteed disjoint from already-inserted)
         # This is not as inefficient as it looks, because we only add fresh dependencies
         # when they are not yet processed as recomputed nodes.
-        new_deps = sorted(
-            (dep for dep in deps if dep not in recomputed_nodes),
-            key=lambda n: order[n],
-        )
+        new_deps = sorted(deps, key=lambda n: order[n])
         if new_deps:
             log.debug(
                 "To compute backward node %s, recomputing [%s]",

--- a/torch/_functorch/_activation_checkpointing/remat_using_tags_for_fwd_loss_bwd_graph_pass.py
+++ b/torch/_functorch/_activation_checkpointing/remat_using_tags_for_fwd_loss_bwd_graph_pass.py
@@ -5,17 +5,16 @@ from typing import Any, overload
 
 import torch
 import torch.fx as fx
-from torch._functorch import config
 from torch._functorch.compile_utils import raise_getitems
 from torch._functorch.partitioners import (
     cleanup_recompute_tags,
     force_save_bw_mutation_src,
-    force_save_collectives,
     has_recomputable_ops,
     has_recomputable_rng_ops,
     is_not_collective,
     must_recompute,
 )
+
 
 log = logging.getLogger(__name__)
 
@@ -70,9 +69,6 @@ def remat_using_tags_for_fwd_loss_bwd_graph(gm: fx.GraphModule) -> fx.GraphModul
     # Use partitioner pass to normalize AC node tags.
     gm = cleanup_recompute_tags(gm, is_default_partition=True)
 
-    if not config.unsafe_allow_optimization_of_collectives:
-        force_save_collectives(gm)
-
     force_save_bw_mutation_src(gm)
 
     new_graph = fx.Graph()
@@ -118,9 +114,9 @@ def remat_using_tags_for_fwd_loss_bwd_graph(gm: fx.GraphModule) -> fx.GraphModul
             (dep for dep in deps if dep not in recomputed_nodes),
             key=lambda n: order[n],
         )
-        if new_deps and torch.distributed.get_rank() == 0:
-            print(
-                "remat: to compute backward node %s, recomputing [%s]",
+        if new_deps:
+            log.debug(
+                "To compute backward node %s, recomputing [%s]",
                 node.name,
                 ", ".join(dep.name for dep in new_deps),
             )


### PR DESCRIPTION
  1. Fixed gather_checkpointed_deps logic — Moved the must_recompute() check to the beginning of the function (early return) instead of checking it on inputs before recursing. This ensures the current node itself is validated, not just its
  children, making the traversal more correct.
  2. Removed force_save_collectives — Dropped the unsafe_allow_optimization_of_collectives config guard and the force_save_collectives(gm) call, along with its import. **User should specify if they want to recompute collective or not. For example, ppl commonly recompute tp allgather, but save tp reduce_scatter.** 
  3. Relaxed duplicate recomputation assertion — Instead of raising an AssertionError when a dependency was already in recomputed_nodes, it now filters those out (dep not in recomputed_nodes). This handles cases where a dependency can be reached from multiple backward nodes.
  4. Added debug logging — Added a log.debug() call that logs which nodes are being recomputed for each backward node, aiding debuggability.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #176748



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo