### PR TITLE
[Experiment only][Don't review]make_fx trace over fsdp2

### DIFF
--- a/test/distributed/_composable/fsdp/minimal_tracer.py
+++ b/test/distributed/_composable/fsdp/minimal_tracer.py
@@ -1,0 +1,376 @@
+"""
+Minimal make_fx based tracer with:
+- FSDP internal parameter lifting (_sharded_param_data as graph inputs)
+- FSDP hooks use fsdp::unshard_ custom op (set via _make_fx_tracing flag)
+- Tensor subclass input/output support (e.g., DTensor)
+- Fake mode tracing
+
+Cloned from sixlib/sixlib/minimal_tracer.py for FSDP2 tracing experiments.
+"""
+
+import contextlib
+import itertools
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+import torch.nn as nn
+import torch.utils._pytree as pytree
+from torch._subclasses import FakeTensorMode
+from torch.distributed._composable_state import _get_module_state
+from torch.distributed.fsdp._fully_shard._fsdp_common import _make_fx_tracing
+from torch.distributed.fsdp._fully_shard._fsdp_param import FSDPParam
+from torch.distributed.fsdp._fully_shard._fsdp_state import FSDPState
+from torch.fx.experimental.proxy_tensor import make_fx
+from torch.fx.traceback import preserve_node_meta
+from torch.utils._python_dispatch import is_traceable_wrapper_subclass
+
+
+# =============================================
+# FSDP utilities
+# =============================================
+
+
+@dataclass
+class FSDPParamMeta:
+    """Metadata for one FSDP-managed parameter."""
+
+    fqn: str
+    orig_size: list[int]
+    orig_stride: list[int]
+    group_size: int
+
+
+def _collect_fsdp_params_and_metas(
+    mod: nn.Module,
+) -> tuple[list[FSDPParam], list[FSDPParamMeta]]:
+    """Collect FSDPParam objects and their metadata from FSDP-wrapped modules."""
+    fsdp_params = []
+    param_metas = []
+    for module in mod.modules():
+        state = _get_module_state(module)
+        if isinstance(state, FSDPState) and state._fsdp_param_group is not None:
+            pg = state._fsdp_param_group
+            group_size = pg._all_gather_process_group.size()
+            for fp in pg.fsdp_params:
+                fsdp_params.append(fp)
+                param_metas.append(
+                    FSDPParamMeta(
+                        fqn=fp._param_fqn,
+                        orig_size=list(fp._orig_size),
+                        orig_stride=list(fp._contiguous_orig_stride),
+                        group_size=group_size,
+                    )
+                )
+    return fsdp_params, param_metas
+
+
+@contextmanager
+def _enable_make_fx_tracing():
+    """Enable make_fx tracing mode for FSDP hooks."""
+    import torch.distributed.fsdp._fully_shard._fsdp_common as fsdp_common
+
+    original = fsdp_common._make_fx_tracing
+    fsdp_common._make_fx_tracing = True
+    try:
+        yield
+    finally:
+        fsdp_common._make_fx_tracing = original
+
+
+@contextmanager
+def _swap_sharded_param_data(
+    fsdp_params: list[FSDPParam],
+    new_sharded_datas: list[torch.Tensor],
+):
+    """Temporarily swap _sharded_param_data on FSDPParam objects."""
+    originals = []
+    for fsdp_param, new_data in zip(fsdp_params, new_sharded_datas):
+        originals.append(fsdp_param._sharded_param_data)
+        fsdp_param._sharded_param_data = new_data
+    try:
+        yield
+    finally:
+        for fsdp_param, orig in zip(fsdp_params, originals):
+            fsdp_param._sharded_param_data = orig
+
+
+# =============================================
+# Subclass handling
+# =============================================
+
+
+@dataclass
+class SubclassMeta:
+    cls: type
+    attrs: list[str]
+    ctx: Any
+    inner_metas: dict[str, tuple[int, Any]]
+    outer_size: torch.Size
+    outer_stride: tuple[int, ...]
+
+
+def unwrap_subclass(
+    t: torch.Tensor,
+) -> tuple[list[torch.Tensor], SubclassMeta | None]:
+    if not is_traceable_wrapper_subclass(t):
+        return [t], None
+    attrs, ctx = t.__tensor_flatten__()
+    all_inner = []
+    inner_metas = {}
+    for attr in attrs:
+        inner_t = getattr(t, attr)
+        tensors, meta = unwrap_subclass(inner_t)
+        all_inner.extend(tensors)
+        inner_metas[attr] = (len(tensors), meta)
+    meta = SubclassMeta(
+        cls=type(t), attrs=attrs, ctx=ctx, inner_metas=inner_metas,
+        outer_size=t.size(), outer_stride=t.stride(),
+    )
+    return all_inner, meta
+
+
+def wrap_to_subclass(
+    plain_tensors: list[torch.Tensor], meta: SubclassMeta
+) -> torch.Tensor:
+    inner_dict = {}
+    idx = 0
+    for attr in meta.attrs:
+        num_inner, inner_meta = meta.inner_metas[attr]
+        inner_tensors = plain_tensors[idx : idx + num_inner]
+        idx += num_inner
+        if inner_meta is None:
+            inner_dict[attr] = inner_tensors[0]
+        else:
+            inner_dict[attr] = wrap_to_subclass(list(inner_tensors), inner_meta)
+    return meta.cls.__tensor_unflatten__(
+        inner_dict, meta.ctx, meta.outer_size, meta.outer_stride
+    )
+
+
+def wrap_inputs_to_subclasses(
+    plain_args: tuple[torch.Tensor, ...],
+    subclass_metas: list[tuple[int, SubclassMeta | None]],
+) -> list[torch.Tensor]:
+    wrapped = []
+    idx = 0
+    for num_tensors, meta in subclass_metas:
+        tensors = plain_args[idx : idx + num_tensors]
+        idx += num_tensors
+        if meta is None:
+            wrapped.append(tensors[0])
+        else:
+            wrapped.append(wrap_to_subclass(list(tensors), meta))
+    return wrapped
+
+
+# =============================================
+# Graph cleanup
+# =============================================
+
+
+def _remove_cpu_shadow_chains(gm: torch.fx.GraphModule) -> None:
+    to_remove: set[torch.fx.Node] = set()
+    for node in gm.graph.nodes:
+        if node in to_remove:
+            continue
+        if not (
+            node.op == "call_function"
+            and node.target == torch.ops.aten.empty_strided.default
+        ):
+            continue
+        device = node.kwargs.get("device")
+        if device is None or device.type != "cpu":
+            continue
+        chain: set[torch.fx.Node] = set()
+        queue = [node]
+        feeds_gpu = False
+        while queue and not feeds_gpu:
+            current = queue.pop()
+            if current in chain:
+                continue
+            chain.add(current)
+            for user in current.users:
+                val = user.meta.get("val")
+                if isinstance(val, torch.Tensor) and val.device.type != "cpu":
+                    if user.users:
+                        feeds_gpu = True
+                        break
+                    chain.add(user)
+                    continue
+                queue.append(user)
+        if not feeds_gpu:
+            to_remove |= chain
+    for node in reversed(list(gm.graph.nodes)):
+        if node in to_remove:
+            gm.graph.erase_node(node)
+    gm.graph.lint()
+    gm.recompile()
+
+
+# =============================================
+# Main tracer
+# =============================================
+
+
+def trace_module(
+    mod: nn.Module,
+    args: tuple,
+) -> torch.fx.GraphModule:
+    """
+    Trace an FSDP2-wrapped module with make_fx.
+
+    Strategy:
+    1. Lift FSDP's _sharded_param_data as graph inputs
+    2. Enable _make_fx_tracing flag so FSDP hooks use fsdp::unshard_ custom op
+    3. Swap lifted sharded data into FSDPParam objects so hooks use graph inputs
+    4. FSDP hooks fire naturally (model(x) pattern), but use the custom op path
+    5. Sharded data is passed as extra args to mod.forward so user code can
+       call autograd.grad w.r.t. them (gradient flows through fsdp::unshard
+       backward → fsdp::reduce_scatter_grad)
+
+    Args:
+        mod: The nn.Module to trace (must be FSDP-wrapped with lazy init done)
+        args: Tuple of input arguments to the module's forward method
+
+    Returns:
+        traced: A traced fx.GraphModule
+    """
+
+    # ========================================
+    # Step 1: Collect FSDP internal sharded param data
+    # ========================================
+    fsdp_params, param_metas = _collect_fsdp_params_and_metas(mod)
+    # Clone sharded data with requires_grad so fsdp::unshard output has grad_fn
+    # and autograd.grad can backprop through it
+    sharded_datas = []
+    for fp in fsdp_params:
+        data = fp._sharded_param_data
+        if fp.sharded_param.requires_grad:
+            data = data.detach().requires_grad_(True)
+        sharded_datas.append(data)
+    n_fsdp_params = len(sharded_datas)
+
+    # ========================================
+    # Step 2: Create functional call wrapper
+    # ========================================
+    def functional_call(*all_args):
+        fsdp_sharded = list(all_args[:n_fsdp_params])
+        user_args = all_args[n_fsdp_params:]
+
+        # Swap sharded data into FSDP params so hooks use graph inputs,
+        # and enable tracing flag so hooks use the custom op path.
+        # Pass fsdp_sharded as extra kwarg so the module can use them
+        # as targets for autograd.grad.
+        with (
+            _swap_sharded_param_data(fsdp_params, fsdp_sharded),
+            _enable_make_fx_tracing(),
+        ):
+            return mod.forward(*user_args, fsdp_sharded_params=fsdp_sharded)
+
+    # Pytree-flatten user args
+    user_args_flat, user_args_spec = pytree.tree_flatten(args)
+    full_args = tuple(sharded_datas) + tuple(user_args_flat)
+
+    # ========================================
+    # Step 3: Detect & unwrap subclass inputs
+    # ========================================
+    unwrapped_args = []
+    subclass_metas = []
+
+    for arg in full_args:
+        if isinstance(arg, torch.Tensor) and is_traceable_wrapper_subclass(arg):
+            inner_tensors, meta = unwrap_subclass(arg)
+            unwrapped_args.extend(inner_tensors)
+            subclass_metas.append((len(inner_tensors), meta))
+        else:
+            unwrapped_args.append(arg)
+            subclass_metas.append((1, None))
+
+    # ========================================
+    # Step 4: Convert to fake tensors
+    # ========================================
+    fake_mode = FakeTensorMode(allow_non_fake_inputs=True)
+
+    def to_fake(t):
+        if isinstance(t, torch.Tensor):
+            return fake_mode.from_tensor(t)
+        return t
+
+    fake_args = tuple(to_fake(a) for a in unwrapped_args)
+
+    # ========================================
+    # Step 5: Create fn that handles subclass wrap/unwrap
+    # ========================================
+    output_subclass_metas = []
+
+    def fn_with_subclass_handling(*plain_args):
+        nonlocal output_subclass_metas
+        output_subclass_metas = []
+
+        wrapped_args = wrap_inputs_to_subclasses(plain_args, subclass_metas)
+        fsdp_args = wrapped_args[:n_fsdp_params]
+        user_args_wrapped = wrapped_args[n_fsdp_params:]
+        user_args_restored = pytree.tree_unflatten(
+            list(user_args_wrapped), user_args_spec
+        )
+
+        outputs = functional_call(*fsdp_args, *user_args_restored)
+
+        flat_outputs, _ = pytree.tree_flatten(outputs)
+        unwrapped_outputs = []
+        for out in flat_outputs:
+            if isinstance(out, torch.Tensor) and is_traceable_wrapper_subclass(out):
+                inner, meta = unwrap_subclass(out)
+                unwrapped_outputs.extend(inner)
+                output_subclass_metas.append((len(inner), meta))
+            else:
+                unwrapped_outputs.append(out)
+                output_subclass_metas.append((1, None))
+
+        return unwrapped_outputs
+
+    # ========================================
+    # Step 6: Trace with make_fx under fake mode
+    # ========================================
+    with fake_mode, preserve_node_meta():
+        traced = make_fx(fn_with_subclass_handling, record_stack_traces=True)(
+            *fake_args
+        )
+
+    # ========================================
+    # Step 6.5: Remove CPU shadow nodes
+    # ========================================
+    _remove_cpu_shadow_chains(traced)
+
+    # ========================================
+    # Step 7: Attach metadata for runtime
+    # ========================================
+    traced._n_fsdp_params = n_fsdp_params
+    traced._param_metas = param_metas
+    traced._input_subclass_metas = subclass_metas
+    traced._output_subclass_metas = output_subclass_metas
+
+    return traced
+
+
+def run_traced_module(
+    traced: torch.fx.GraphModule,
+    mod: nn.Module,
+    args: tuple,
+) -> list[torch.Tensor]:
+    """Run traced graph with FSDP sharded params."""
+    fsdp_params, _ = _collect_fsdp_params_and_metas(mod)
+    sharded_datas = [fp._sharded_param_data for fp in fsdp_params]
+    user_args_flat, _ = pytree.tree_flatten(args)
+
+    all_args = []
+    for a in itertools.chain(sharded_datas, user_args_flat):
+        if isinstance(a, torch.Tensor) and is_traceable_wrapper_subclass(a):
+            inner, _ = unwrap_subclass(a)
+            all_args.extend(inner)
+        else:
+            all_args.append(a)
+
+    return traced(*all_args)

--- a/test/distributed/_composable/fsdp/minimal_tracer.py
+++ b/test/distributed/_composable/fsdp/minimal_tracer.py
@@ -1,14 +1,13 @@
 """
 Minimal make_fx based tracer with:
 - FSDP internal parameter lifting (_sharded_param_data as graph inputs)
-- FSDP hooks use fsdp::unshard_ custom op (set via _make_fx_tracing flag)
+- FSDP hooks detect tracing via proxy tensor mode (no manual flag needed)
 - Tensor subclass input/output support (e.g., DTensor)
 - Fake mode tracing
 
 Cloned from sixlib/sixlib/minimal_tracer.py for FSDP2 tracing experiments.
 """
 
-import contextlib
 import itertools
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -19,7 +18,6 @@ import torch.nn as nn
 import torch.utils._pytree as pytree
 from torch._subclasses import FakeTensorMode
 from torch.distributed._composable_state import _get_module_state
-from torch.distributed.fsdp._fully_shard._fsdp_common import _make_fx_tracing
 from torch.distributed.fsdp._fully_shard._fsdp_param import FSDPParam
 from torch.distributed.fsdp._fully_shard._fsdp_state import FSDPState
 from torch.fx.experimental.proxy_tensor import make_fx
@@ -64,19 +62,6 @@ def _collect_fsdp_params_and_metas(
                     )
                 )
     return fsdp_params, param_metas
-
-
-@contextmanager
-def _enable_make_fx_tracing():
-    """Enable make_fx tracing mode for FSDP hooks."""
-    import torch.distributed.fsdp._fully_shard._fsdp_common as fsdp_common
-
-    original = fsdp_common._make_fx_tracing
-    fsdp_common._make_fx_tracing = True
-    try:
-        yield
-    finally:
-        fsdp_common._make_fx_tracing = original
 
 
 @contextmanager
@@ -223,12 +208,12 @@ def trace_module(
 
     Strategy:
     1. Lift FSDP's _sharded_param_data as graph inputs
-    2. Enable _make_fx_tracing flag so FSDP hooks use fsdp::unshard_ custom op
-    3. Swap lifted sharded data into FSDPParam objects so hooks use graph inputs
-    4. FSDP hooks fire naturally (model(x) pattern), but use the custom op path
-    5. Sharded data is passed as extra args to mod.forward so user code can
-       call autograd.grad w.r.t. them (gradient flows through fsdp::unshard
-       backward → fsdp::reduce_scatter_grad)
+    2. Swap lifted sharded data into FSDPParam objects so hooks use graph inputs
+    3. FSDP hooks auto-detect tracing (via proxy tensor mode) and use custom ops:
+       fsdp::pre_forward, fsdp::post_forward, fsdp::pre_backward, fsdp::post_backward
+    4. Sharded data is passed as extra args to mod.forward so user code can
+       call autograd.grad w.r.t. them (gradient flows through fsdp::pre_forward
+       backward → fsdp::post_backward)
 
     Args:
         mod: The nn.Module to trace (must be FSDP-wrapped with lazy init done)
@@ -259,14 +244,11 @@ def trace_module(
         fsdp_sharded = list(all_args[:n_fsdp_params])
         user_args = all_args[n_fsdp_params:]
 
-        # Swap sharded data into FSDP params so hooks use graph inputs,
-        # and enable tracing flag so hooks use the custom op path.
+        # Swap sharded data into FSDP params so hooks use graph inputs.
+        # FSDP hooks auto-detect tracing via proxy tensor mode (_is_tracing).
         # Pass fsdp_sharded as extra kwarg so the module can use them
         # as targets for autograd.grad.
-        with (
-            _swap_sharded_param_data(fsdp_params, fsdp_sharded),
-            _enable_make_fx_tracing(),
-        ):
+        with _swap_sharded_param_data(fsdp_params, fsdp_sharded):
             return mod.forward(*user_args, fsdp_sharded_params=fsdp_sharded)
 
     # Pytree-flatten user args

--- a/test/distributed/_composable/fsdp/minimal_tracer.py
+++ b/test/distributed/_composable/fsdp/minimal_tracer.py
@@ -5,7 +5,7 @@ Minimal make_fx based tracer with:
 - Tensor subclass input/output support (e.g., DTensor)
 - Fake mode tracing
 
-Cloned from sixlib/sixlib/minimal_tracer.py for FSDP2 tracing experiments.
+Minimal tracer for FSDP2 tracing experiments.
 """
 
 import itertools

--- a/test/distributed/_composable/fsdp/test_fully_shard_make_fx.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_make_fx.py
@@ -1,0 +1,201 @@
+# Owner(s): ["oncall: distributed"]
+"""
+Standalone test for make_fx tracing of FSDP2-wrapped models.
+
+Uses a local clone of sixlib's minimal_tracer (trace_module) which lifts
+params as graph inputs via stateless._reparametrize_module.
+
+Usage:
+    torchrun --nproc_per_node=2 test_fully_shard_make_fx.py
+"""
+
+import logging
+import os
+import sys
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+from minimal_tracer import _collect_fsdp_params_and_metas, run_traced_module, trace_module
+from torch.distributed.device_mesh import init_device_mesh
+from torch.distributed.fsdp import fully_shard
+
+logging.basicConfig(level=logging.INFO, stream=sys.stdout)
+log = logging.getLogger(__name__)
+
+
+# =============================================
+# Model definitions
+# =============================================
+
+
+class SimpleMLP(nn.Module):
+    def __init__(self, dim: int = 32, device: torch.device | None = None):
+        super().__init__()
+        self.fc1 = nn.Linear(dim, dim * 4, device=device, bias=False)
+        self.fc2 = nn.Linear(dim * 4, dim, device=device, bias=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = F.relu(self.fc1(x))
+        x = self.fc2(x)
+        return x
+
+
+class StackedMLP(nn.Module):
+    def __init__(
+        self, dim: int = 32, n_layers: int = 3, device: torch.device | None = None
+    ):
+        super().__init__()
+        self.layers = nn.ModuleList(
+            [SimpleMLP(dim, device=device) for _ in range(n_layers)]
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        for layer in self.layers:
+            x = layer(x)
+        return x
+
+
+class FwdBwdModule(nn.Module):
+    """Module that calls autograd.grad in forward, capturing both fwd+bwd."""
+
+    def __init__(self, model: nn.Module):
+        super().__init__()
+        self.model = model
+
+    def forward(
+        self, x: torch.Tensor, fsdp_sharded_params: list[torch.Tensor] | None = None,
+    ) -> tuple[torch.Tensor, ...]:
+        out = self.model(x)
+        loss = out.sum()
+        if fsdp_sharded_params is not None:
+            grads = torch.autograd.grad(
+                loss, fsdp_sharded_params, allow_unused=True
+            )
+            grads = tuple(
+                g if g is not None else torch.zeros_like(s)
+                for g, s in zip(grads, fsdp_sharded_params)
+            )
+            return (loss, *grads)
+        return loss
+
+
+# =============================================
+# Utilities
+# =============================================
+
+
+def setup_distributed():
+    dist.init_process_group("nccl")
+    local_rank = int(os.environ.get("LOCAL_RANK", 0))
+    torch.cuda.set_device(local_rank)
+    return local_rank
+
+
+def build_fsdp_model(dim: int = 32, n_layers: int = 3) -> nn.Module:
+    device = torch.device("cuda")
+    model = StackedMLP(dim=dim, n_layers=n_layers, device=device)
+    mesh = init_device_mesh("cuda", (dist.get_world_size(),))
+    for layer in model.layers:
+        fully_shard(layer, mesh=mesh)
+    fully_shard(model, mesh=mesh)
+    return model
+
+
+def test_trace_module():
+    """Trace FSDP2 model with forward + backward (fwd+bwd graph)."""
+    rank = dist.get_rank()
+    model = build_fsdp_model()
+
+    # Trigger lazy init
+    x_init = torch.randn(4, 32, device="cuda")
+    out_init = model(x_init)
+    out_init.sum().backward()
+    model.zero_grad()
+    if rank == 0:
+        log.info("[trace_module] Lazy init done")
+
+    # Wrap model so forward calls autograd.grad (captures fwd+bwd)
+    fwd_bwd = FwdBwdModule(model)
+
+    x = torch.randn(4, 32, device="cuda")
+
+    if rank == 0:
+        log.info("[trace_module] Starting trace...")
+
+    try:
+        traced = trace_module(fwd_bwd, (x,))
+    except Exception as e:
+        if rank == 0:
+            log.info(
+                f"[trace_module] Tracing failed: {type(e).__name__}: {e}"
+            )
+            import traceback
+            traceback.print_exc()
+        return
+
+    if rank == 0:
+        log.info("[trace_module] Tracing complete!")
+        log.info("[trace_module] Readable graph:")
+        traced.print_readable()
+
+    # Numerical check: compare eager vs traced outputs
+    # Note: numerics may not match yet (WIP)
+
+    # Run traced graph
+    traced_out = run_traced_module(traced, fwd_bwd, (x,))
+    traced_loss = traced_out[0]
+    traced_grads = traced_out[1:]
+
+    # Run eager: forward + backward to get sharded param grads
+    model.zero_grad()
+    eager_loss = model(x).sum()
+    eager_loss.backward()
+    fsdp_params, _ = _collect_fsdp_params_and_metas(fwd_bwd)
+    eager_grads = [fp.sharded_param.grad for fp in fsdp_params]
+
+    if rank == 0:
+        # Compare loss
+        loss_diff = (eager_loss - traced_loss).abs().item()
+        log.info(f"[numerical] loss: max_diff={loss_diff:.6e}")
+
+        # Compare gradients
+        for i, (eg, tg) in enumerate(zip(eager_grads, traced_grads)):
+            if eg is not None and isinstance(tg, torch.Tensor):
+                # eager grad may be DTensor, get local tensor
+                eg_local = eg._local_tensor if hasattr(eg, "_local_tensor") else eg
+                # traced grad is flat sharded [numel], eager is shaped — flatten both
+                diff = (eg_local.flatten() - tg.flatten()).abs().max().item()
+                log.info(
+                    f"  grad[{i}]: max_diff={diff:.6e}, "
+                    f"eager={eg_local.shape}, traced={tg.shape}"
+                )
+            else:
+                log.info(f"  grad[{i}]: eager={eg}, traced={tg}")
+
+
+def main():
+    setup_distributed()
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+
+    if rank == 0:
+        log.info(f"Running with {world_size} GPUs")
+        log.info("=" * 60)
+
+    if rank == 0:
+        log.info("=" * 60)
+        log.info("Test: trace_module with FSDP2")
+    test_trace_module()
+    dist.barrier()
+
+    if rank == 0:
+        log.info("=" * 60)
+        log.info("All tests done!")
+
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/test/distributed/_composable/fsdp/test_fully_shard_make_fx.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_make_fx.py
@@ -2,8 +2,8 @@
 """
 Standalone test for make_fx tracing of FSDP2-wrapped models.
 
-Uses a local clone of sixlib's minimal_tracer (trace_module) which lifts
-params as graph inputs via stateless._reparametrize_module.
+Uses minimal_tracer (trace_module) which lifts FSDP sharded param data
+as graph inputs for make_fx tracing.
 
 Usage:
     torchrun --nproc_per_node=2 test_fully_shard_make_fx.py

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_common.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_common.py
@@ -14,6 +14,12 @@ from torch.distributed.tensor._dtensor_spec import DTensorSpec
 
 
 _compiled_autograd_enabled: bool = False
+_make_fx_tracing: bool = False
+
+
+def make_fx_tracing_enabled() -> bool:
+    global _make_fx_tracing
+    return _make_fx_tracing
 
 
 def detect_compiled_autograd():

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
@@ -52,106 +52,239 @@ _ModuleToHandleDict = dict[nn.Module, RemovableHandle]  # for state dict
 
 
 # =============================================
-# Custom op: black-box unshard for make_fx tracing
+# Custom ops for make_fx tracing of FSDP hooks
+# (per param group — one op call per FSDPParamGroup)
+#
+# These ops are thin wrappers over the original FSDP implementation.
+# A module-level _param_group_ctx is set by the caller to pass the
+# FSDPParamGroup instance, so the ops can delegate to original methods.
 # =============================================
 
 
-@torch.library.custom_op("fsdp::unshard", mutates_args=())
-def _unshard_op(
-    sharded_data: torch.Tensor,
+# Set by _unshard_via_custom_op / _reshard_via_custom_op before calling the op
+_param_group_ctx: "FSDPParamGroup | None" = None
+
+
+def _split_by_ndims(flat: list[int], ndims: list[int]) -> list[list[int]]:
+    """Split a flat list into sublists based on ndims."""
+    result = []
+    idx = 0
+    for nd in ndims:
+        result.append(flat[idx : idx + nd])
+        idx += nd
+    return result
+
+
+def _unshard_all(
+    sharded_datas: list[torch.Tensor],
     group_size: int,
-    orig_size: list[int],
-    orig_stride: list[int],
-) -> torch.Tensor:
-    """Black-box unshard: all-gather one sharded param, return unsharded.
+    orig_sizes_flat: list[int],
+    orig_strides_flat: list[int],
+    ndims: list[int],
+) -> list[torch.Tensor]:
+    """Standalone all-gather fallback (used when replaying traced graph)."""
+    orig_sizes = _split_by_ndims(orig_sizes_flat, ndims)
+    orig_strides = _split_by_ndims(orig_strides_flat, ndims)
+    results = []
+    for sharded_data, orig_size, orig_stride in zip(
+        sharded_datas, orig_sizes, orig_strides
+    ):
+        gathered = torch.empty(
+            sharded_data.numel() * group_size,
+            dtype=sharded_data.dtype,
+            device=sharded_data.device,
+        )
+        dist.all_gather_into_tensor(gathered, sharded_data)
+        results.append(
+            torch.as_strided(gathered, orig_size, orig_stride).contiguous()
+        )
+    return results
 
-    This op appears as a single node in the FX graph, making the data flow
-    from sharded input to unsharded param explicit and traceable.
-    """
-    gathered = torch.empty(
-        sharded_data.numel() * group_size,
-        dtype=sharded_data.dtype,
-        device=sharded_data.device,
-    )
-    dist.all_gather_into_tensor(gathered, sharded_data)
-    return torch.as_strided(
-        gathered, orig_size, orig_stride
-    ).contiguous()
 
-
-@_unshard_op.register_fake
-def _unshard_op_fake(
-    sharded_data: torch.Tensor,
+def _unshard_all_fake(
+    sharded_datas: list[torch.Tensor],
     group_size: int,
-    orig_size: list[int],
-    orig_stride: list[int],
-) -> torch.Tensor:
-    return sharded_data.new_empty(orig_size)
+    orig_sizes_flat: list[int],
+    orig_strides_flat: list[int],
+    ndims: list[int],
+) -> list[torch.Tensor]:
+    orig_sizes = _split_by_ndims(orig_sizes_flat, ndims)
+    return [s.new_empty(sz) for s, sz in zip(sharded_datas, orig_sizes)]
 
 
-def _unshard_op_setup_context(ctx, inputs, output):
-    sharded_data, group_size, orig_size, orig_stride = inputs
+def _reshard_all(
+    unshardeds: list[torch.Tensor],
+    group_size: int,
+    sharded_numels: list[int],
+) -> list[torch.Tensor]:
+    """Standalone reshard fallback (used when replaying traced graph)."""
+    return [
+        u.contiguous().view(-1)[:n].clone()
+        for u, n in zip(unshardeds, sharded_numels)
+    ]
+
+
+def _reshard_all_fake(
+    unshardeds: list[torch.Tensor],
+    group_size: int,
+    sharded_numels: list[int],
+) -> list[torch.Tensor]:
+    return [u.new_empty(n) for u, n in zip(unshardeds, sharded_numels)]
+
+
+def _reduce_scatter_all(
+    grads: list[torch.Tensor],
+    group_size: int,
+    sharded_numels: list[int],
+) -> list[torch.Tensor]:
+    """Standalone reduce-scatter fallback (used when replaying traced graph)."""
+    results = []
+    for grad, sharded_numel in zip(grads, sharded_numels):
+        flat_grad = grad.contiguous().view(-1)
+        output = torch.empty(
+            sharded_numel, dtype=flat_grad.dtype, device=flat_grad.device
+        )
+        dist.reduce_scatter_tensor(output, flat_grad)
+        results.append(output)
+    return results
+
+
+def _reduce_scatter_all_fake(
+    grads: list[torch.Tensor],
+    group_size: int,
+    sharded_numels: list[int],
+) -> list[torch.Tensor]:
+    return [g.new_empty(n) for g, n in zip(grads, sharded_numels)]
+
+
+# -- fsdp::pre_forward: all-gather in forward, with autograd backward --
+
+@torch.library.custom_op("fsdp::pre_forward", mutates_args=())
+def _pre_forward_op(
+    sharded_datas: list[torch.Tensor],
+    group_size: int,
+    orig_sizes_flat: list[int],
+    orig_strides_flat: list[int],
+    ndims: list[int],
+) -> list[torch.Tensor]:
+    pg = _param_group_ctx
+    if pg is not None:
+        pg.unshard(pg.unshard_async_op)
+        pg.wait_for_unshard()
+        return [fp._unsharded_param.data for fp in pg.fsdp_params]
+    return _unshard_all(sharded_datas, group_size, orig_sizes_flat, orig_strides_flat, ndims)
+
+
+@_pre_forward_op.register_fake
+def _pre_forward_op_fake(
+    sharded_datas: list[torch.Tensor],
+    group_size: int,
+    orig_sizes_flat: list[int],
+    orig_strides_flat: list[int],
+    ndims: list[int],
+) -> list[torch.Tensor]:
+    return _unshard_all_fake(sharded_datas, group_size, orig_sizes_flat, orig_strides_flat, ndims)
+
+
+def _pre_forward_op_setup_context(ctx, inputs, output):
+    sharded_datas, group_size, orig_sizes_flat, orig_strides_flat, ndims = inputs
     ctx.group_size = group_size
-    ctx.sharded_numel = sharded_data.numel()
+    ctx.sharded_numels = [s.numel() for s in sharded_datas]
 
 
-def _unshard_op_backward(ctx, grad_output):
-    grad_sharded = torch.ops.fsdp.reduce_scatter_grad(
-        grad_output, ctx.group_size, ctx.sharded_numel
+def _pre_forward_op_backward(ctx, *grad_outputs):
+    # For list[Tensor] output, grad_outputs is (list_of_grads,)
+    grads = grad_outputs[0] if len(grad_outputs) == 1 and isinstance(grad_outputs[0], list) else list(grad_outputs)
+    grad_shardeds = torch.ops.fsdp.post_backward(
+        grads, ctx.group_size, ctx.sharded_numels,
     )
-    return grad_sharded, None, None, None
+    return grad_shardeds, None, None, None, None
 
 
-_unshard_op.register_autograd(
-    _unshard_op_backward, setup_context=_unshard_op_setup_context
+_pre_forward_op.register_autograd(
+    _pre_forward_op_backward, setup_context=_pre_forward_op_setup_context
 )
 
 
-@torch.library.custom_op("fsdp::reduce_scatter_grad", mutates_args=())
-def _reduce_scatter_grad_op(
-    grad: torch.Tensor,
+# -- fsdp::post_forward: reshard after forward --
+
+@torch.library.custom_op("fsdp::post_forward", mutates_args=())
+def _post_forward_op(
+    unshardeds: list[torch.Tensor],
     group_size: int,
-    sharded_numel: int,
-) -> torch.Tensor:
-    """Reduce-scatter gradient: inverse of all-gather unshard."""
-    flat_grad = grad.contiguous().view(-1)
-    output = torch.empty(
-        sharded_numel, dtype=flat_grad.dtype, device=flat_grad.device
-    )
-    dist.reduce_scatter_tensor(output, flat_grad)
-    return output
+    sharded_numels: list[int],
+) -> list[torch.Tensor]:
+    pg = _param_group_ctx
+    if pg is not None:
+        pg.reshard()
+        return [fp._sharded_param_data for fp in pg.fsdp_params]
+    return _reshard_all(unshardeds, group_size, sharded_numels)
 
 
-@_reduce_scatter_grad_op.register_fake
-def _reduce_scatter_grad_op_fake(
-    grad: torch.Tensor,
+@_post_forward_op.register_fake
+def _post_forward_op_fake(
+    unshardeds: list[torch.Tensor],
     group_size: int,
-    sharded_numel: int,
-) -> torch.Tensor:
-    return grad.new_empty(sharded_numel)
+    sharded_numels: list[int],
+) -> list[torch.Tensor]:
+    return _reshard_all_fake(unshardeds, group_size, sharded_numels)
 
 
-@torch.library.custom_op("fsdp::reshard", mutates_args=())
-def _reshard_op(
-    unsharded: torch.Tensor,
+# -- fsdp::pre_backward: all-gather in backward --
+
+@torch.library.custom_op("fsdp::pre_backward", mutates_args=())
+def _pre_backward_op(
+    sharded_datas: list[torch.Tensor],
     group_size: int,
-    sharded_numel: int,
-) -> torch.Tensor:
-    """Reshard: return the local shard of an unsharded param.
+    orig_sizes_flat: list[int],
+    orig_strides_flat: list[int],
+    ndims: list[int],
+) -> list[torch.Tensor]:
+    pg = _param_group_ctx
+    if pg is not None:
+        pg.unshard(pg.unshard_async_op)
+        pg.wait_for_unshard()
+        return [fp._unsharded_param.data for fp in pg.fsdp_params]
+    return _unshard_all(sharded_datas, group_size, orig_sizes_flat, orig_strides_flat, ndims)
 
-    Inverse of unshard. In eager mode, this is just slicing the local chunk.
-    In a real training loop, this represents freeing the all-gather buffer.
-    """
-    return unsharded.contiguous().view(-1)[:sharded_numel].clone()
 
-
-@_reshard_op.register_fake
-def _reshard_op_fake(
-    unsharded: torch.Tensor,
+@_pre_backward_op.register_fake
+def _pre_backward_op_fake(
+    sharded_datas: list[torch.Tensor],
     group_size: int,
-    sharded_numel: int,
-) -> torch.Tensor:
-    return unsharded.new_empty(sharded_numel)
+    orig_sizes_flat: list[int],
+    orig_strides_flat: list[int],
+    ndims: list[int],
+) -> list[torch.Tensor]:
+    return _unshard_all_fake(sharded_datas, group_size, orig_sizes_flat, orig_strides_flat, ndims)
+
+
+# -- fsdp::post_backward: reduce-scatter gradient --
+
+@torch.library.custom_op("fsdp::post_backward", mutates_args=())
+def _post_backward_op(
+    grads: list[torch.Tensor],
+    group_size: int,
+    sharded_numels: list[int],
+) -> list[torch.Tensor]:
+    pg = _param_group_ctx
+    if pg is not None:
+        # Set grads on unsharded params, then delegate to original post_backward
+        for fp, grad in zip(pg.fsdp_params, grads):
+            if hasattr(fp, "_unsharded_param"):
+                fp._unsharded_param.grad = grad
+        pg.post_backward()
+        return [fp.sharded_param.grad for fp in pg.fsdp_params]
+    return _reduce_scatter_all(grads, group_size, sharded_numels)
+
+
+@_post_backward_op.register_fake
+def _post_backward_op_fake(
+    grads: list[torch.Tensor],
+    group_size: int,
+    sharded_numels: list[int],
+) -> list[torch.Tensor]:
+    return _reduce_scatter_all_fake(grads, group_size, sharded_numels)
 
 
 """
@@ -556,37 +689,52 @@ class FSDPParamGroup:
         with record_function(self._with_fqn("FSDP::pre_forward")):
             self._training_state = TrainingState.FORWARD
             if make_fx_tracing_enabled():
-                self._unshard_via_custom_op()
+                self._unshard_via_custom_op(is_forward=True)
             else:
                 self.unshard(self.unshard_async_op)
                 self.wait_for_unshard()
             args, kwargs = self._register_post_backward_hook(args, kwargs)
             return args, kwargs
 
-    def _unshard_via_custom_op(self) -> None:
-        """Unshard using black-box custom op for make_fx tracing.
+    def _unshard_via_custom_op(self, *, is_forward: bool) -> None:
+        """Unshard using custom op for make_fx tracing (per param group).
 
-        Calls fsdp::unshard per param, which takes sharded data and returns
-        unsharded param. This makes the data flow explicit in the FX graph.
+        Wraps the original unshard/wait_for_unshard via fsdp::pre_forward or
+        fsdp::pre_backward custom op. The op delegates to self.unshard() +
+        self.wait_for_unshard() via _param_group_ctx.
 
-        Unlike the normal unshard path, we do NOT wrap in nn.Parameter because
-        that detaches the tensor (Parameters are leaves), breaking gradient
-        flow for autograd.grad tracing. Instead we set the raw tensor directly
-        on the module so gradients flow through fsdp::unshard.
+        The raw tensors (not nn.Parameter) are then set on modules to preserve
+        gradient flow for autograd.grad tracing.
         """
+        global _param_group_ctx
+
         if isinstance(self.mesh_info, FSDPMeshInfo):
             group_size = self._all_gather_process_group.size()
         else:
             group_size = 1
 
-        for fsdp_param in self.fsdp_params:
-            unsharded_data = torch.ops.fsdp.unshard(
-                fsdp_param._sharded_param_data,
-                group_size,
-                list(fsdp_param._orig_size),
-                list(fsdp_param._contiguous_orig_stride),
-            )
-            # Set directly on module, bypassing nn.Parameter to avoid detach
+        unshard_op = torch.ops.fsdp.pre_forward if is_forward else torch.ops.fsdp.pre_backward
+
+        sharded_datas = [fp._sharded_param_data for fp in self.fsdp_params]
+        orig_sizes_flat = []
+        orig_strides_flat = []
+        ndims = []
+        for fp in self.fsdp_params:
+            sz = list(fp._orig_size)
+            st = list(fp._contiguous_orig_stride)
+            orig_sizes_flat.extend(sz)
+            orig_strides_flat.extend(st)
+            ndims.append(len(sz))
+
+        _param_group_ctx = self
+        unsharded_list = unshard_op(
+            sharded_datas, group_size, orig_sizes_flat, orig_strides_flat, ndims
+        )
+        _param_group_ctx = None
+
+        # Override module params with the custom op outputs (raw tensors, not
+        # nn.Parameter) so gradient flows through the op for autograd.grad.
+        for fsdp_param, unsharded_data in zip(self.fsdp_params, unsharded_list):
             module_info = fsdp_param._module_info
             unsafe_setattr_param(
                 module_info.module, module_info.param_name, unsharded_data
@@ -598,26 +746,28 @@ class FSDPParamGroup:
         self._sharded_state = ShardedState.UNSHARDED
 
     def _reshard_via_custom_op(self) -> None:
-        """Reshard using custom op for make_fx tracing.
+        """Reshard using custom op for make_fx tracing (per param group).
 
-        Calls fsdp::reshard per param, which takes the unsharded param and
-        returns the sharded data. The sharded output is stored so that
-        pre_backward can unshard from it.
+        Wraps the original reshard() via fsdp::post_forward custom op.
         """
+        global _param_group_ctx
+
         if isinstance(self.mesh_info, FSDPMeshInfo):
             group_size = self._all_gather_process_group.size()
         else:
             group_size = 1
 
-        for fsdp_param in self.fsdp_params:
-            module_info = fsdp_param._module_info
-            unsharded = getattr(module_info.module, module_info.param_name)
-            sharded = torch.ops.fsdp.reshard(
-                unsharded,
-                group_size,
-                fsdp_param._sharded_param_data.numel(),
-            )
-            # Store resharded data so pre_backward can unshard from it
+        unshardeds = [
+            getattr(fp._module_info.module, fp._module_info.param_name)
+            for fp in self.fsdp_params
+        ]
+        sharded_numels = [fp._sharded_param_data.numel() for fp in self.fsdp_params]
+
+        _param_group_ctx = self
+        sharded_list = torch.ops.fsdp.post_forward(unshardeds, group_size, sharded_numels)
+        _param_group_ctx = None
+
+        for fsdp_param, sharded in zip(self.fsdp_params, sharded_list):
             fsdp_param._sharded_param_data = sharded
         self._sharded_state = ShardedState.SHARDED
 
@@ -661,7 +811,7 @@ class FSDPParamGroup:
         with record_function(self._with_fqn("FSDP::pre_backward")):
             self._training_state = TrainingState.PRE_BACKWARD
             if make_fx_tracing_enabled():
-                self._unshard_via_custom_op()
+                self._unshard_via_custom_op(is_forward=False)
             else:
                 self.unshard(self.unshard_async_op)  # no-op if prefetched
                 self.wait_for_unshard()

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
@@ -34,7 +34,6 @@ from ._fsdp_common import (
     FSDPMeshInfo,
     HSDPMeshInfo,
     is_bw,
-    make_fx_tracing_enabled,
     TrainingState,
 )
 from ._fsdp_param import (
@@ -59,6 +58,17 @@ _ModuleToHandleDict = dict[nn.Module, RemovableHandle]  # for state dict
 # A module-level _param_group_ctx is set by the caller to pass the
 # FSDPParamGroup instance, so the ops can delegate to original methods.
 # =============================================
+
+
+def _is_tracing() -> bool:
+    """Detect if we are inside torch.compile or make_fx tracing."""
+    if torch.compiler.is_compiling():
+        return True
+    # make_fx uses proxy tensor tracing which doesn't set is_compiling().
+    # Detect it via the active proxy tensor mode.
+    from torch.fx.experimental.proxy_tensor import get_proxy_mode
+
+    return get_proxy_mode() is not None
 
 
 # Set by _unshard_via_custom_op / _reshard_via_custom_op before calling the op
@@ -116,10 +126,16 @@ def _reshard_all(
     unshardeds: list[torch.Tensor],
     group_size: int,
     sharded_numels: list[int],
+    shard_rank: int,
 ) -> list[torch.Tensor]:
-    """Standalone reshard fallback (used when replaying traced graph)."""
+    """Standalone reshard fallback (used when replaying traced graph).
+
+    Extracts the local rank's shard from each unsharded param. After all-gather,
+    the flat layout is [rank0_shard, rank1_shard, ...], so we slice at offset
+    shard_rank * sharded_numel.
+    """
     return [
-        u.contiguous().view(-1)[:n].clone()
+        u.contiguous().view(-1)[shard_rank * n : (shard_rank + 1) * n].clone()
         for u, n in zip(unshardeds, sharded_numels)
     ]
 
@@ -128,6 +144,7 @@ def _reshard_all_fake(
     unshardeds: list[torch.Tensor],
     group_size: int,
     sharded_numels: list[int],
+    shard_rank: int,
 ) -> list[torch.Tensor]:
     return [u.new_empty(n) for u, n in zip(unshardeds, sharded_numels)]
 
@@ -144,7 +161,7 @@ def _reduce_scatter_all(
         output = torch.empty(
             sharded_numel, dtype=flat_grad.dtype, device=flat_grad.device
         )
-        dist.reduce_scatter_tensor(output, flat_grad)
+        dist.reduce_scatter_tensor(output, flat_grad, op=dist.ReduceOp.AVG)
         results.append(output)
     return results
 
@@ -190,14 +207,19 @@ def _pre_forward_op_setup_context(ctx, inputs, output):
     sharded_datas, group_size, orig_sizes_flat, orig_strides_flat, ndims = inputs
     ctx.group_size = group_size
     ctx.sharded_numels = [s.numel() for s in sharded_datas]
+    # Capture the param group context so post_backward can delegate to original impl
+    ctx._param_group_ctx = _param_group_ctx
 
 
 def _pre_forward_op_backward(ctx, *grad_outputs):
+    global _param_group_ctx
     # For list[Tensor] output, grad_outputs is (list_of_grads,)
     grads = grad_outputs[0] if len(grad_outputs) == 1 and isinstance(grad_outputs[0], list) else list(grad_outputs)
+    _param_group_ctx = ctx._param_group_ctx
     grad_shardeds = torch.ops.fsdp.post_backward(
         grads, ctx.group_size, ctx.sharded_numels,
     )
+    _param_group_ctx = None
     return grad_shardeds, None, None, None, None
 
 
@@ -213,12 +235,13 @@ def _post_forward_op(
     unshardeds: list[torch.Tensor],
     group_size: int,
     sharded_numels: list[int],
+    shard_rank: int,
 ) -> list[torch.Tensor]:
     pg = _param_group_ctx
     if pg is not None:
         pg.reshard()
         return [fp._sharded_param_data for fp in pg.fsdp_params]
-    return _reshard_all(unshardeds, group_size, sharded_numels)
+    return _reshard_all(unshardeds, group_size, sharded_numels, shard_rank)
 
 
 @_post_forward_op.register_fake
@@ -226,8 +249,9 @@ def _post_forward_op_fake(
     unshardeds: list[torch.Tensor],
     group_size: int,
     sharded_numels: list[int],
+    shard_rank: int,
 ) -> list[torch.Tensor]:
-    return _reshard_all_fake(unshardeds, group_size, sharded_numels)
+    return _reshard_all_fake(unshardeds, group_size, sharded_numels, shard_rank)
 
 
 # -- fsdp::pre_backward: all-gather in backward --
@@ -688,7 +712,7 @@ class FSDPParamGroup:
             logger.debug("%s", self._with_fqn("FSDP::pre_forward"))
         with record_function(self._with_fqn("FSDP::pre_forward")):
             self._training_state = TrainingState.FORWARD
-            if make_fx_tracing_enabled():
+            if _is_tracing():
                 self._unshard_via_custom_op(is_forward=True)
             else:
                 self.unshard(self.unshard_async_op)
@@ -754,8 +778,10 @@ class FSDPParamGroup:
 
         if isinstance(self.mesh_info, FSDPMeshInfo):
             group_size = self._all_gather_process_group.size()
+            shard_rank = self.mesh_info.shard_mesh_rank
         else:
             group_size = 1
+            shard_rank = 0
 
         unshardeds = [
             getattr(fp._module_info.module, fp._module_info.param_name)
@@ -764,7 +790,9 @@ class FSDPParamGroup:
         sharded_numels = [fp._sharded_param_data.numel() for fp in self.fsdp_params]
 
         _param_group_ctx = self
-        sharded_list = torch.ops.fsdp.post_forward(unshardeds, group_size, sharded_numels)
+        sharded_list = torch.ops.fsdp.post_forward(
+            unshardeds, group_size, sharded_numels, shard_rank
+        )
         _param_group_ctx = None
 
         for fsdp_param, sharded in zip(self.fsdp_params, sharded_list):
@@ -775,7 +803,7 @@ class FSDPParamGroup:
         if not compiled_autograd_enabled():
             logger.debug("%s", self._with_fqn("FSDP::post_forward"))
         with record_function(self._with_fqn("FSDP::post_forward")):
-            if make_fx_tracing_enabled():
+            if _is_tracing():
                 self._reshard_via_custom_op()
             elif not compiled_autograd_enabled():
                 # for AC(fully_shard(model)), AC runs fsdp's _pre_forward
@@ -810,7 +838,7 @@ class FSDPParamGroup:
             logger.debug("%s", self._with_fqn("FSDP::pre_backward"))
         with record_function(self._with_fqn("FSDP::pre_backward")):
             self._training_state = TrainingState.PRE_BACKWARD
-            if make_fx_tracing_enabled():
+            if _is_tracing():
                 self._unshard_via_custom_op(is_forward=False)
             else:
                 self.unshard(self.unshard_async_op)  # no-op if prefetched

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
@@ -34,14 +34,124 @@ from ._fsdp_common import (
     FSDPMeshInfo,
     HSDPMeshInfo,
     is_bw,
+    make_fx_tracing_enabled,
     TrainingState,
 )
-from ._fsdp_param import alloc_storage, FSDPParam, ParamModuleInfo, ShardedState
+from ._fsdp_param import (
+    alloc_storage,
+    FSDPParam,
+    ParamModuleInfo,
+    ShardedState,
+    unsafe_setattr_param,
+)
 
 
 logger = logging.getLogger("torch.distributed.fsdp.fully_shard")
 
 _ModuleToHandleDict = dict[nn.Module, RemovableHandle]  # for state dict
+
+
+# =============================================
+# Custom op: black-box unshard for make_fx tracing
+# =============================================
+
+
+@torch.library.custom_op("fsdp::unshard", mutates_args=())
+def _unshard_op(
+    sharded_data: torch.Tensor,
+    group_size: int,
+    orig_size: list[int],
+    orig_stride: list[int],
+) -> torch.Tensor:
+    """Black-box unshard: all-gather one sharded param, return unsharded.
+
+    This op appears as a single node in the FX graph, making the data flow
+    from sharded input to unsharded param explicit and traceable.
+    """
+    gathered = torch.empty(
+        sharded_data.numel() * group_size,
+        dtype=sharded_data.dtype,
+        device=sharded_data.device,
+    )
+    dist.all_gather_into_tensor(gathered, sharded_data)
+    return torch.as_strided(
+        gathered, orig_size, orig_stride
+    ).contiguous()
+
+
+@_unshard_op.register_fake
+def _unshard_op_fake(
+    sharded_data: torch.Tensor,
+    group_size: int,
+    orig_size: list[int],
+    orig_stride: list[int],
+) -> torch.Tensor:
+    return sharded_data.new_empty(orig_size)
+
+
+def _unshard_op_setup_context(ctx, inputs, output):
+    sharded_data, group_size, orig_size, orig_stride = inputs
+    ctx.group_size = group_size
+    ctx.sharded_numel = sharded_data.numel()
+
+
+def _unshard_op_backward(ctx, grad_output):
+    grad_sharded = torch.ops.fsdp.reduce_scatter_grad(
+        grad_output, ctx.group_size, ctx.sharded_numel
+    )
+    return grad_sharded, None, None, None
+
+
+_unshard_op.register_autograd(
+    _unshard_op_backward, setup_context=_unshard_op_setup_context
+)
+
+
+@torch.library.custom_op("fsdp::reduce_scatter_grad", mutates_args=())
+def _reduce_scatter_grad_op(
+    grad: torch.Tensor,
+    group_size: int,
+    sharded_numel: int,
+) -> torch.Tensor:
+    """Reduce-scatter gradient: inverse of all-gather unshard."""
+    flat_grad = grad.contiguous().view(-1)
+    output = torch.empty(
+        sharded_numel, dtype=flat_grad.dtype, device=flat_grad.device
+    )
+    dist.reduce_scatter_tensor(output, flat_grad)
+    return output
+
+
+@_reduce_scatter_grad_op.register_fake
+def _reduce_scatter_grad_op_fake(
+    grad: torch.Tensor,
+    group_size: int,
+    sharded_numel: int,
+) -> torch.Tensor:
+    return grad.new_empty(sharded_numel)
+
+
+@torch.library.custom_op("fsdp::reshard", mutates_args=())
+def _reshard_op(
+    unsharded: torch.Tensor,
+    group_size: int,
+    sharded_numel: int,
+) -> torch.Tensor:
+    """Reshard: return the local shard of an unsharded param.
+
+    Inverse of unshard. In eager mode, this is just slicing the local chunk.
+    In a real training loop, this represents freeing the all-gather buffer.
+    """
+    return unsharded.contiguous().view(-1)[:sharded_numel].clone()
+
+
+@_reshard_op.register_fake
+def _reshard_op_fake(
+    unsharded: torch.Tensor,
+    group_size: int,
+    sharded_numel: int,
+) -> torch.Tensor:
+    return unsharded.new_empty(sharded_numel)
 
 
 """
@@ -445,16 +555,79 @@ class FSDPParamGroup:
             logger.debug("%s", self._with_fqn("FSDP::pre_forward"))
         with record_function(self._with_fqn("FSDP::pre_forward")):
             self._training_state = TrainingState.FORWARD
-            self.unshard(self.unshard_async_op)
-            self.wait_for_unshard()
+            if make_fx_tracing_enabled():
+                self._unshard_via_custom_op()
+            else:
+                self.unshard(self.unshard_async_op)
+                self.wait_for_unshard()
             args, kwargs = self._register_post_backward_hook(args, kwargs)
             return args, kwargs
+
+    def _unshard_via_custom_op(self) -> None:
+        """Unshard using black-box custom op for make_fx tracing.
+
+        Calls fsdp::unshard per param, which takes sharded data and returns
+        unsharded param. This makes the data flow explicit in the FX graph.
+
+        Unlike the normal unshard path, we do NOT wrap in nn.Parameter because
+        that detaches the tensor (Parameters are leaves), breaking gradient
+        flow for autograd.grad tracing. Instead we set the raw tensor directly
+        on the module so gradients flow through fsdp::unshard.
+        """
+        if isinstance(self.mesh_info, FSDPMeshInfo):
+            group_size = self._all_gather_process_group.size()
+        else:
+            group_size = 1
+
+        for fsdp_param in self.fsdp_params:
+            unsharded_data = torch.ops.fsdp.unshard(
+                fsdp_param._sharded_param_data,
+                group_size,
+                list(fsdp_param._orig_size),
+                list(fsdp_param._contiguous_orig_stride),
+            )
+            # Set directly on module, bypassing nn.Parameter to avoid detach
+            module_info = fsdp_param._module_info
+            unsafe_setattr_param(
+                module_info.module, module_info.param_name, unsharded_data
+            )
+            for shared_module, shared_param_name in zip(
+                module_info.shared_modules, module_info.shared_param_names
+            ):
+                unsafe_setattr_param(shared_module, shared_param_name, unsharded_data)
+        self._sharded_state = ShardedState.UNSHARDED
+
+    def _reshard_via_custom_op(self) -> None:
+        """Reshard using custom op for make_fx tracing.
+
+        Calls fsdp::reshard per param, which takes the unsharded param and
+        returns the sharded data. The sharded output is stored so that
+        pre_backward can unshard from it.
+        """
+        if isinstance(self.mesh_info, FSDPMeshInfo):
+            group_size = self._all_gather_process_group.size()
+        else:
+            group_size = 1
+
+        for fsdp_param in self.fsdp_params:
+            module_info = fsdp_param._module_info
+            unsharded = getattr(module_info.module, module_info.param_name)
+            sharded = torch.ops.fsdp.reshard(
+                unsharded,
+                group_size,
+                fsdp_param._sharded_param_data.numel(),
+            )
+            # Store resharded data so pre_backward can unshard from it
+            fsdp_param._sharded_param_data = sharded
+        self._sharded_state = ShardedState.SHARDED
 
     def post_forward(self, module: nn.Module, input: Any, output: Any):
         if not compiled_autograd_enabled():
             logger.debug("%s", self._with_fqn("FSDP::post_forward"))
         with record_function(self._with_fqn("FSDP::post_forward")):
-            if not compiled_autograd_enabled():
+            if make_fx_tracing_enabled():
+                self._reshard_via_custom_op()
+            elif not compiled_autograd_enabled():
                 # for AC(fully_shard(model)), AC runs fsdp's _pre_forward
                 # it shouldn't change post_forward_order
                 if not is_bw():
@@ -487,10 +660,13 @@ class FSDPParamGroup:
             logger.debug("%s", self._with_fqn("FSDP::pre_backward"))
         with record_function(self._with_fqn("FSDP::pre_backward")):
             self._training_state = TrainingState.PRE_BACKWARD
-            self.unshard(self.unshard_async_op)  # no-op if prefetched
-            self.wait_for_unshard()
-            if default_prefetch and not compiled_autograd_enabled():
-                self._backward_prefetch()
+            if make_fx_tracing_enabled():
+                self._unshard_via_custom_op()
+            else:
+                self.unshard(self.unshard_async_op)  # no-op if prefetched
+                self.wait_for_unshard()
+                if default_prefetch:
+                    self._backward_prefetch()
 
     def post_backward(self, *unused: Any):
         # This method should be idempotent and safe to call even when this


### PR DESCRIPTION
Summary:
  Add make_fx tracing support for FSDP2-wrapped models by introducing 4 custom
  ops that capture FSDP communication as opaque nodes in the FX graph:
  - `fsdp::pre_forward`: all-gather in forward (with autograd backward → post_backward)
  - `fsdp::post_forward`: reshard after forward
  - `fsdp::pre_backward`: all-gather in backward
  - `fsdp::post_backward`: reduce-scatter gradients
  

  ## Why custom ops instead of tracing into the hooks?
  
  FSDP hooks perform extensive in-place storage mutations that are incompatible
  with make_fx's functional tracing. The hooks mutate internal buffers like
  `_all_gather_output`, `_sharded_param_data`, and `_unsharded_param`, and manage
  storage lifecycle via `alloc_storage`/`free_storage` to overlap communication
  with computation. These mutations cannot be captured by make_fx's proxy tensor
  tracing, which expects functional semantics.
  
  By wrapping each hook phase as an opaque custom op, we get clean functional
  boundaries in the graph (sharded data → unsharded data, unsharded data →
  sharded data, gradients → reduced gradients) while the actual implementation
  inside the ops remains free to mutate storage as needed.
  
  ## Design decisions
  
  - **Per param group**: Each op takes/returns `list[Tensor]`, called once per
    FSDPParamGroup rather than once per parameter.
  - **Wrapper over original impl**: Ops delegate to original FSDP methods via a
    module-level `_param_group_ctx` global set by the caller. Standalone fallbacks
    are provided for graph replay (`run_traced_module`).
  - **Auto tracing detection**: Uses `_is_tracing()` (proxy tensor mode detection)
    instead of manual flags — FSDP hooks automatically switch to custom ops when
    traced by make_fx.
  - **Parameter lifting**: Sharded param data (`_sharded_param_data`) is lifted as
    graph inputs so `autograd.grad` can backprop through them.
  
  The traced graph captures the full fwd+bwd computation with FSDP communication
  ops as boundaries. Loss and all 6 parameter gradients match exactly between
  eager and traced execution (max_diff=0.000000e+00).
  
  Traced graph output: https://www.internalfb.com/intern/paste/P2227251843/
  
  Test Plan:
  ```
  cd ~/pytorch && torchrun --nproc_per_node=2 test/distributed/_composable/fsdp/test_fully_shard_make_fx.py
  ```
  
  ghstack-source-id: 6c9055b496247b43a190181b2d6716f3483f98e8
  Pull Request resolved: https://github.com/pytorch/pytorch/pull/176749

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #176749
* #176748

