### PR TITLE
[claude] Fix mode detection bug: move prompt to CLAUDE.md

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -79,7 +79,6 @@ jobs:
           allowed_bots: "*"
           use_bedrock: "true"
           claude_args: "--model global.anthropic.claude-opus-4-6-v1 --allowedTools Skill"
-          prompt: "When asked to review a PR, always use the /pr-review skill."
           settings: '{"alwaysThinkingEnabled": true}'
 
       - name: Upload usage metrics

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,7 @@
+# PR Review
+
+When asked to review a PR, always use the /pr-review skill.
+
 # Environment
 
 If any tool you're trying to use (pip, python, spin, etc) is missing, always stop and ask the user if an environment is needed. Do NOT try to find alternatives or install these tools.


### PR DESCRIPTION
## Summary

The `prompt` input in `claude-code-action` triggers **agent mode** instead of **tag mode** for `@claude` mentions, due to a priority bug in the action's mode detector (`src/modes/detector.ts:38-48`). This has been broken since #176490 landed on March 5.

### Background: tag mode vs agent mode

- **Tag mode** is the interactive `@claude` mode — creates a tracking comment, fetches the full PR conversation and diff, builds a rich prompt, configures MCP servers for posting comments, and updates the tracking comment with results.
- **Agent mode** is for headless automation with no human interaction (e.g., "auto-label every new issue on open", "fix lint errors on PR push"). The `prompt` IS the entire task — no `@claude` mention, no conversation to fetch, no comment to respond to. Claude just executes the prompt and exits.

### The bug

The mode detector checks `context.inputs.prompt` before `checkContainsTrigger()` for comment events, so any workflow that sets `prompt` forces agent mode even when the user triggered via `@claude`. In agent mode:

- **No tracking comment** — `shouldCreateTrackingComment()` returns `false`, so no "Claude is working..." comment is posted
- **No PR context** — the prompt is just the static string from the workflow config, not the user's comment, conversation, or diff
- **No comment MCP server** — agent mode only includes it if `mcp__github_comment__*` tools are explicitly in `allowedTools`
- **No response posted** — the "Update comment with job link" step is skipped because `claude_comment_id` is empty
- **Dead code in tag mode** — `tag/index.ts:234-244` already handles `prompt` correctly by appending it as `<custom_instructions>`, but the detector prevents tag mode from ever being selected when `prompt` is set

### Fix

Move the pr-review instruction from the workflow `prompt` parameter to `CLAUDE.md`, where tag mode picks it up as part of the normal prompt without affecting mode selection. The upstream bug in `anthropics/claude-code-action` still needs to be fixed separately — `checkContainsTrigger()` should have priority over `context.inputs.prompt` for comment events.

## Test plan

- [ ] After merging, comment `@claude review this PR` on a test PR and verify Claude posts a response
- [ ] Verify the `/pr-review` skill is still invoked when asked to review