### PR TITLE
refresh expected results after unreproducable mm_loop regression

### DIFF
--- a/benchmarks/dynamo/pr_time_benchmarks/expected_results.csv
+++ b/benchmarks/dynamo/pr_time_benchmarks/expected_results.csv
@@ -1,16 +1,16 @@
-add_loop_eager,compile_time_instruction_count,3347000000,0.1
+add_loop_eager,compile_time_instruction_count,3240000000,0.1
 
 
 
-add_loop_eager_dynamic,compile_time_instruction_count,4724000000,0.1
+add_loop_eager_dynamic,compile_time_instruction_count,4532000000,0.1
 
 
 
-add_loop_inductor,compile_time_instruction_count,29660000000,0.1
+add_loop_inductor,compile_time_instruction_count,29050000000,0.1
 
 
 
-add_loop_inductor_dynamic_gpu,compile_time_instruction_count,38190000000,0.1
+add_loop_inductor_dynamic_gpu,compile_time_instruction_count,37050000000,0.1
 
 
 
@@ -26,7 +26,7 @@ basic_modules_ListOfLinears_inductor,compile_time_instruction_count,15240000000,
 
 
 
-basic_modules_ListOfLinears_inductor_gpu_force_shape_pad,compile_time_instruction_count,17720000000,0.1
+basic_modules_ListOfLinears_inductor_gpu_force_shape_pad,compile_time_instruction_count,17260000000,0.1
 
 
 
@@ -34,19 +34,19 @@ basic_modules_ListOfLinears_inductor_gpu,compile_time_instruction_count,11090000
 
 
 
-update_hint_regression,compile_time_instruction_count,1645000000,0.1
+update_hint_regression,compile_time_instruction_count,1544000000,0.1
 
 
 
-sum_floordiv_regression,compile_time_instruction_count,3581000000,0.1
+sum_floordiv_regression,compile_time_instruction_count,3453000000,0.1
 
 
 
-symint_sum,compile_time_instruction_count,3237000000,0.1
+symint_sum,compile_time_instruction_count,3097000000,0.1
 
 
 
-symint_sum_loop,compile_time_instruction_count,4583000000,0.1
+symint_sum_loop,compile_time_instruction_count,4323000000,0.1
 
 
 
@@ -58,11 +58,11 @@ aotdispatcher_inference_subclass_cpu,compile_time_instruction_count,4988000000,0
 
 
 
-aotdispatcher_partitioner_cpu,compile_time_instruction_count,8217000000,0.1
+aotdispatcher_partitioner_cpu,compile_time_instruction_count,7846000000,0.1
 
 
 
-aotdispatcher_partitioner_cpu2,compile_time_instruction_count,1918000000,0.1
+aotdispatcher_partitioner_cpu2,compile_time_instruction_count,1828000000,0.1
 
 
 
@@ -70,19 +70,19 @@ aotdispatcher_training_nosubclass_cpu,compile_time_instruction_count,3152000000,
 
 
 
-aotdispatcher_training_subclass_cpu,compile_time_instruction_count,8301000000,0.1
+aotdispatcher_training_subclass_cpu,compile_time_instruction_count,8013000000,0.1
 
 
 
-mm_loop_inductor_gpu,compile_time_instruction_count,4597000000,0.1
+mm_loop_inductor_gpu,compile_time_instruction_count,5015000000,0.1
 
 
 
-mm_loop_inductor_dynamic_gpu,compile_time_instruction_count,9051000000,0.1
+mm_loop_inductor_dynamic_gpu,compile_time_instruction_count,9409000000,0.1
 
 
 
-basic_NestedModule_eager,compile_time_instruction_count,5927000000,0.1
+basic_NestedModule_eager,compile_time_instruction_count,5643000000,0.1
 
 
 
@@ -94,11 +94,11 @@ dtensor_dispatch_detach,instruction_count,56080,0.1
 
 
 
-dtensor_dispatch_to_from_local,instruction_count,220000,0.1
+dtensor_dispatch_to_from_local,instruction_count,229600,0.1
 
 
 
-dtensor_dispatch_collectives,instruction_count,26720000,0.1
+dtensor_dispatch_collectives,instruction_count,28970000,0.1
 
 
 
@@ -118,4 +118,4 @@ dtensor_dispatch_random,instruction_count,592800,0.1
 
 
 
-dtensor_dispatch_custom_handler,instruction_count,36120,0.1
+dtensor_dispatch_custom_handler,instruction_count,35040,0.1

--- a/benchmarks/dynamo/pr_time_benchmarks/expected_results.csv
+++ b/benchmarks/dynamo/pr_time_benchmarks/expected_results.csv
@@ -1,8 +1,8 @@
-add_loop_eager,compile_time_instruction_count,3254000000,0.1
+add_loop_eager,compile_time_instruction_count,3347000000,0.1
 
 
 
-add_loop_eager_dynamic,compile_time_instruction_count,4544000000,0.1
+add_loop_eager_dynamic,compile_time_instruction_count,4582000000,0.1
 
 
 
@@ -10,7 +10,7 @@ add_loop_inductor,compile_time_instruction_count,29660000000,0.1
 
 
 
-add_loop_inductor_dynamic_gpu,compile_time_instruction_count,37080000000,0.1
+add_loop_inductor_dynamic_gpu,compile_time_instruction_count,37230000000,0.1
 
 
 
@@ -26,7 +26,7 @@ basic_modules_ListOfLinears_inductor,compile_time_instruction_count,15240000000,
 
 
 
-basic_modules_ListOfLinears_inductor_gpu_force_shape_pad,compile_time_instruction_count,17190000000,0.1
+basic_modules_ListOfLinears_inductor_gpu_force_shape_pad,compile_time_instruction_count,17330000000,0.1
 
 
 
@@ -34,19 +34,19 @@ basic_modules_ListOfLinears_inductor_gpu,compile_time_instruction_count,11090000
 
 
 
-update_hint_regression,compile_time_instruction_count,1543000000,0.1
+update_hint_regression,compile_time_instruction_count,1552000000,0.1
 
 
 
-sum_floordiv_regression,compile_time_instruction_count,3458000000,0.1
+sum_floordiv_regression,compile_time_instruction_count,3483000000,0.1
 
 
 
-symint_sum,compile_time_instruction_count,3099000000,0.1
+symint_sum,compile_time_instruction_count,3108000000,0.1
 
 
 
-symint_sum_loop,compile_time_instruction_count,4287000000,0.1
+symint_sum_loop,compile_time_instruction_count,4302000000,0.1
 
 
 
@@ -58,11 +58,11 @@ aotdispatcher_inference_subclass_cpu,compile_time_instruction_count,4988000000,0
 
 
 
-aotdispatcher_partitioner_cpu,compile_time_instruction_count,7828000000,0.1
+aotdispatcher_partitioner_cpu,compile_time_instruction_count,7839000000,0.1
 
 
 
-aotdispatcher_partitioner_cpu2,compile_time_instruction_count,1828000000,0.1
+aotdispatcher_partitioner_cpu2,compile_time_instruction_count,1833000000,0.1
 
 
 
@@ -70,39 +70,39 @@ aotdispatcher_training_nosubclass_cpu,compile_time_instruction_count,3152000000,
 
 
 
-aotdispatcher_training_subclass_cpu,compile_time_instruction_count,8014000000,0.1
+aotdispatcher_training_subclass_cpu,compile_time_instruction_count,8027000000,0.1
 
 
 
-mm_loop_inductor_gpu,compile_time_instruction_count,4501000000,0.1
+mm_loop_inductor_gpu,compile_time_instruction_count,5021000000,0.1
 
 
 
-mm_loop_inductor_dynamic_gpu,compile_time_instruction_count,9051000000,0.1
+mm_loop_inductor_dynamic_gpu,compile_time_instruction_count,9466000000,0.1
 
 
 
-basic_NestedModule_eager,compile_time_instruction_count,5647000000,0.1
+basic_NestedModule_eager,compile_time_instruction_count,5734000000,0.1
 
 
 
-basic_InlineMod_eager,compile_time_instruction_count,7480000000,0.1
+basic_InlineMod_eager,compile_time_instruction_count,7711000000,0.1
 
 
 
-dtensor_dispatch_detach,instruction_count,57370,0.1
+dtensor_dispatch_detach,instruction_count,56080,0.1
 
 
 
-dtensor_dispatch_to_from_local,instruction_count,231900,0.1
+dtensor_dispatch_to_from_local,instruction_count,229200,0.1
 
 
 
-dtensor_dispatch_collectives,instruction_count,29000000,0.1
+dtensor_dispatch_collectives,instruction_count,29020000,0.1
 
 
 
-dtensor_dispatch_add_backward,instruction_count,354000,0.1
+dtensor_dispatch_add_backward,instruction_count,353300,0.1
 
 
 
@@ -118,4 +118,4 @@ dtensor_dispatch_random,instruction_count,592800,0.1
 
 
 
-dtensor_dispatch_custom_handler,instruction_count,36120,0.1
+dtensor_dispatch_custom_handler,instruction_count,35110,0.1

--- a/benchmarks/dynamo/pr_time_benchmarks/expected_results.csv
+++ b/benchmarks/dynamo/pr_time_benchmarks/expected_results.csv
@@ -1,16 +1,16 @@
-add_loop_eager,compile_time_instruction_count,3240000000,0.1
+add_loop_eager,compile_time_instruction_count,3254000000,0.1
 
 
 
-add_loop_eager_dynamic,compile_time_instruction_count,4532000000,0.1
+add_loop_eager_dynamic,compile_time_instruction_count,4544000000,0.1
 
 
 
-add_loop_inductor,compile_time_instruction_count,29050000000,0.1
+add_loop_inductor,compile_time_instruction_count,29660000000,0.1
 
 
 
-add_loop_inductor_dynamic_gpu,compile_time_instruction_count,37050000000,0.1
+add_loop_inductor_dynamic_gpu,compile_time_instruction_count,37080000000,0.1
 
 
 
@@ -26,7 +26,7 @@ basic_modules_ListOfLinears_inductor,compile_time_instruction_count,15240000000,
 
 
 
-basic_modules_ListOfLinears_inductor_gpu_force_shape_pad,compile_time_instruction_count,17260000000,0.1
+basic_modules_ListOfLinears_inductor_gpu_force_shape_pad,compile_time_instruction_count,17190000000,0.1
 
 
 
@@ -34,19 +34,19 @@ basic_modules_ListOfLinears_inductor_gpu,compile_time_instruction_count,11090000
 
 
 
-update_hint_regression,compile_time_instruction_count,1544000000,0.1
+update_hint_regression,compile_time_instruction_count,1543000000,0.1
 
 
 
-sum_floordiv_regression,compile_time_instruction_count,3453000000,0.1
+sum_floordiv_regression,compile_time_instruction_count,3458000000,0.1
 
 
 
-symint_sum,compile_time_instruction_count,3097000000,0.1
+symint_sum,compile_time_instruction_count,3099000000,0.1
 
 
 
-symint_sum_loop,compile_time_instruction_count,4323000000,0.1
+symint_sum_loop,compile_time_instruction_count,4287000000,0.1
 
 
 
@@ -58,7 +58,7 @@ aotdispatcher_inference_subclass_cpu,compile_time_instruction_count,4988000000,0
 
 
 
-aotdispatcher_partitioner_cpu,compile_time_instruction_count,7846000000,0.1
+aotdispatcher_partitioner_cpu,compile_time_instruction_count,7828000000,0.1
 
 
 
@@ -70,19 +70,19 @@ aotdispatcher_training_nosubclass_cpu,compile_time_instruction_count,3152000000,
 
 
 
-aotdispatcher_training_subclass_cpu,compile_time_instruction_count,8013000000,0.1
+aotdispatcher_training_subclass_cpu,compile_time_instruction_count,8014000000,0.1
 
 
 
-mm_loop_inductor_gpu,compile_time_instruction_count,5015000000,0.1
+mm_loop_inductor_gpu,compile_time_instruction_count,4501000000,0.1
 
 
 
-mm_loop_inductor_dynamic_gpu,compile_time_instruction_count,9409000000,0.1
+mm_loop_inductor_dynamic_gpu,compile_time_instruction_count,9051000000,0.1
 
 
 
-basic_NestedModule_eager,compile_time_instruction_count,5643000000,0.1
+basic_NestedModule_eager,compile_time_instruction_count,5647000000,0.1
 
 
 
@@ -90,19 +90,19 @@ basic_InlineMod_eager,compile_time_instruction_count,7480000000,0.1
 
 
 
-dtensor_dispatch_detach,instruction_count,56080,0.1
+dtensor_dispatch_detach,instruction_count,57370,0.1
 
 
 
-dtensor_dispatch_to_from_local,instruction_count,229600,0.1
+dtensor_dispatch_to_from_local,instruction_count,231900,0.1
 
 
 
-dtensor_dispatch_collectives,instruction_count,28970000,0.1
+dtensor_dispatch_collectives,instruction_count,29000000,0.1
 
 
 
-dtensor_dispatch_add_backward,instruction_count,346201,0.1
+dtensor_dispatch_add_backward,instruction_count,354000,0.1
 
 
 
@@ -118,4 +118,4 @@ dtensor_dispatch_random,instruction_count,592800,0.1
 
 
 
-dtensor_dispatch_custom_handler,instruction_count,35040,0.1
+dtensor_dispatch_custom_handler,instruction_count,36120,0.1


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #176756
* __->__ #176755
https://github.com/pytorch/pytorch/commit/615c79fa101e6d79144bf47ce8334d20c9787b2d
caused a  10% regression but 
we could not reproduce the regression on DevGPU
```
{
  "mm_loop_inductor_dynamic_gpu": 5.9145178937396,
  "mm_loop_inductor_gpu": 11.214689685666
}
```

CI is failing now. 
<img width="651" height="180" alt="Screenshot 2026-03-06 at 3 07 44 PM" src="https://github.com/user-attachments/assets/3fad732a-ff82-4f8d-b6ad-0501bbc6d335" />

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo