### PR TITLE
[inductor] Add RAdam to bitwise compiled optimizer tests

### DIFF
--- a/test/inductor/test_compiled_optimizers.py
+++ b/test/inductor/test_compiled_optimizers.py
@@ -1105,7 +1105,7 @@ def _make_bitwise_test(optim_cls, **optim_kwargs):
 
 for optim_cls, name, kwargs, scheduler_cls in COMPILED_OPT_KWARG_DB:
     if (
-        optim_cls in (Adam, AdamW, Adadelta, Adamax, ASGD, NAdam)
+        optim_cls in (Adam, AdamW, Adadelta, Adamax, ASGD, NAdam, RAdam)
         and kwargs.get("foreach", False)
         and kwargs.get("capturable", False)
         and kwargs.get("device") == GPU_TYPE


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #176764
* #176763
* __->__ #176762
* #176761
* #176760
* #176759
* #176758

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo