### PR TITLE
[MPS] Add error checking for bmm

### DIFF
--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -1079,7 +1079,7 @@ static Tensor& tiled_bmm_out_mps_impl(const Tensor& batch1, const Tensor& batch2
 
 static Tensor& bmm_out_mps_impl(const Tensor& batch1, const Tensor& batch2, Tensor& result) {
   TORCH_CHECK(batch1.scalar_type() == batch2.scalar_type(),
-              "Expected arguments of same time but got ",
+              "Expected arguments of same type but got ",
               batch1.scalar_type(),
               " and ",
               batch2.scalar_type());

--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -1078,6 +1078,7 @@ static Tensor& tiled_bmm_out_mps_impl(const Tensor& batch1, const Tensor& batch2
 }
 
 static Tensor& bmm_out_mps_impl(const Tensor& batch1, const Tensor& batch2, Tensor& result) {
+  TORCH_CHECK(batch1.scalar_type() == batch2.scalar_type(), "Expected arguments of same time but got ", batch1.scalar_type(), " and ", batch2.scalar_type());
   using namespace mps;
 
   // Matmul not supported if any output dimension size is larger than 2**32

--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -1078,7 +1078,11 @@ static Tensor& tiled_bmm_out_mps_impl(const Tensor& batch1, const Tensor& batch2
 }
 
 static Tensor& bmm_out_mps_impl(const Tensor& batch1, const Tensor& batch2, Tensor& result) {
-  TORCH_CHECK(batch1.scalar_type() == batch2.scalar_type(), "Expected arguments of same time but got ", batch1.scalar_type(), " and ", batch2.scalar_type());
+  TORCH_CHECK(batch1.scalar_type() == batch2.scalar_type(),
+              "Expected arguments of same time but got ",
+              batch1.scalar_type(),
+              " and ",
+              batch2.scalar_type());
   using namespace mps;
 
   // Matmul not supported if any output dimension size is larger than 2**32

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -19306,9 +19306,6 @@ op_db: list[OpInfo] = [
                DecorateInfo(unittest.expectedFailure, 'TestSchemaCheckModeOpInfo', 'test_schema_correctness',
                             dtypes=(torch.complex64, torch.complex128)),
                DecorateInfo(slowTest, 'TestCompositeCompliance', 'test_forward_ad'),
-               # MPS matmul aborts with uint8 input
-               DecorateInfo(unittest.skip("MPS driver aborts process on uint8 matmul"), 'TestCommon', 'test_dtypes',
-                            device_type='mps'),
            )),
     OpInfo('pca_lowrank',
            op=lambda *args, **kwargs: wrapper_set_seed(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #176771

Before that invoking it with float + int matrices casued a crash with MPSGraph internal abort, now it aborts similar to CPU/CUDA
```
% python -c "import torch;torch.bmm(torch.rand(3, 3, 3), torch.randint(0, 10, (3, 3, 3)))"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
    import torch;torch.bmm(torch.rand(3, 3, 3), torch.randint(0, 10, (3, 3, 3)))
                 ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: expected scalar type Float but found Long
% python -c "import torch;torch.bmm(torch.rand(3, 3, 3, device='mps'), torch.randint(0, 10, (3, 3, 3), device='mps'))"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
    import torch;torch.bmm(torch.rand(3, 3, 3, device='mps'), torch.randint(0, 10, (3, 3, 3), device='mps'))
                 ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: Expected arguments of same type but got Float and Long

```