### PR TITLE
[CI] enable ciflow/torchtitan on certain PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -194,3 +194,18 @@
 - torch/distributed/_symmetric_memory/**
 - test/distributed/**/*mem*
 - test/distributed/**/*mem*/**
+
+"ciflow/torchtitan":
+# torch.distributed (FSDP, DTensor, etc.)
+- torch/distributed/**
+# torch.compile
+- torch/_dynamo/**
+- torch/_inductor/**
+# activation checkpointing / selective activation checkpointing
+- torch/utils/checkpoint.py
+- torch/_functorch/_activation_checkpointing/**
+- torch/_functorch/partitioners.py
+# flexattention
+- torch/nn/attention/flex_attention.py
+- torch/_higher_order_ops/flex_attention.py
+- torch/_inductor/kernel/flex/**

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -205,6 +205,7 @@
 - torch/utils/checkpoint.py
 - torch/_functorch/_activation_checkpointing/**
 - torch/_functorch/partitioners.py
+- torch/distributed/algorithms/_checkpoint/checkpoint_wrapper.py
 # flexattention
 - torch/nn/attention/flex_attention.py
 - torch/_higher_order_ops/flex_attention.py


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #176774
* #175901

Targeted filepaths that seem most likely to disrupt torchtitan, can
revisit the specific paths over time.

Fixes https://github.com/pytorch/torchtitan/issues/2350