### PR TITLE
fix crash in replication_pad backward with empty grad_output

### DIFF
--- a/aten/src/ATen/native/ReplicationPadding.cpp
+++ b/aten/src/ATen/native/ReplicationPadding.cpp
@@ -208,7 +208,7 @@ void replication_pad2d_backward_out_cpu_template(
       "gradOutput height unexpected. Expected: ", oheight, ", Got: ",
       gradOutput.size(dimh));
 
-  if (gradInput.numel() == 0) {
+  if (gradOutput.numel() == 0 || gradInput.numel() == 0) {
     return;
   }
 
@@ -264,7 +264,7 @@ void replication_pad3d_backward_out_cpu_template(
       "gradOutput depth unexpected. Expected: ", odepth, ", Got: ",
       gradOutput.size(dimd));
 
-  if (gradInput.numel() == 0) {
+  if (gradOutput.numel() == 0 || gradInput.numel() == 0) {
     return;
   }
 
@@ -282,7 +282,7 @@ TORCH_IMPL_FUNC(replication_pad1d_out_cpu) (
 TORCH_IMPL_FUNC(replication_pad1d_backward_out_cpu) (
   const Tensor& gradOutput, const Tensor& input, IntArrayRef paddingSize, const Tensor& gradInput
 ) {
-  if (gradInput.numel() == 0) {
+  if (gradOutput.numel() == 0 || gradInput.numel() == 0) {
     return;
   }
   gradInput.zero_();

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -9435,6 +9435,13 @@ class TestNNDeviceType(NNTestCase):
         with self.assertRaisesRegex(RuntimeError, 'padding size is expected to be 6'):
             torch._C._nn.replication_pad3d(torch.randn([2]), padding=[])
 
+    def test_ReplicationPad_empty_grad_output(self, device):
+        # regression test for https://github.com/pytorch/pytorch/issues/142834
+        grad_output = torch.full((2, 0, 6, 8), 1, dtype=torch.float, device=device)
+        inp = torch.full((2, 2, 4, 4), 1, dtype=torch.float, device=device)
+        result = torch.ops.aten.replication_pad2d_backward(grad_output, inp, [2, 2, 1, 1])
+        self.assertEqual(result, torch.zeros_like(inp))
+
     @expectedFailureMPS  # Correctness issue https://github.com/pytorch/pytorch/issues/135447
     def test_ReplicationPad1d_large(self, device):
         shapes = ([2, 65736, 4], [65736, 2, 4])


### PR DESCRIPTION
fixes a crash in replication_pad2d_backward when grad_output is empty ( zero sized channel dim ) . the same empty -tensor check already exists in other paths in the same file but was missing from the template functions. 
same fix applied to 1d and 3d backward paths.
Fixes #142834
<img width="2559" height="1439" alt="스크린샷 2026-03-07 095714" src="https://github.com/user-attachments/assets/deb55b9f-e4a4-4d04-a5a8-751b6474186d" />
<img width="2559" height="1439" alt="스크린샷 2026-03-07 100405" src="https://github.com/user-attachments/assets/0922d45b-060c-4252-88fa-8eed46bfd06e" />
<img width="2559" height="1439" alt="스크린샷 2026-03-07 103012" src="https://github.com/user-attachments/assets/9fef9b3d-d294-4348-912f-1d4829ab4260" />

and i had checked and simulated on my local desktop ( RTX4060Ti , but this case is only CPU )