### PR TITLE
docs: add docstring for
  torch.autograd.graph.Node.next_functions

### DIFF
--- a/torch/autograd/graph.py
+++ b/torch/autograd/graph.py
@@ -70,6 +70,35 @@ class Node(abc.ABC):
     @property
     @abc.abstractmethod
     def next_functions(self) -> tuple[tuple[Optional["Node"], int], ...]:
+        r"""Return the next functions in the autograd graph.
+
+        This property provides access to the edges connecting this node to its
+        input nodes in the autograd computation graph. Each edge represents a
+        gradient flow path during backpropagation.
+
+        Returns:
+            A tuple of ``(Node, int)`` pairs. Each pair contains:
+                - ``Node``: The next function (gradient function) in the backward
+                  graph. For leaf tensors with ``requires_grad=True``, this is an
+                  ``AccumulateGrad`` node. For inputs that do not require gradients,
+                  this is ``None``.
+                - ``int``: The output index of the corresponding node, indicating
+                  which output of the next function this edge connects to.
+
+        Example::
+
+            >>> # xdoctest: +SKIP
+            >>> import torch
+            >>> a = torch.tensor([1., 2., 3.], requires_grad=True)
+            >>> b = torch.tensor([4., 5., 6.], requires_grad=True)
+            >>> c = a * b
+            >>> print(c.grad_fn.name())
+            MulBackward0
+            >>> for next_fn, idx in c.grad_fn.next_functions:
+            ...     print(f"Node: {next_fn.name()}, output index: {idx}")
+            Node: AccumulateGrad, output index: 0
+            Node: AccumulateGrad, output index: 0
+        """
         raise NotImplementedError
 
     @abc.abstractmethod


### PR DESCRIPTION
Add documentation for the
  next_functions property in torch.autograd.graph.Node, addressing issue
  #171620. Fixes #171620. cc @soulitzer
  
  Cherry picked changes from the old PR:-> https://github.com/pytorch/pytorch/pull/171976