### PR TITLE
[operator_benchmark] Fix ambiguous --output argparse error in benchmark_runner (#176780)

### DIFF
--- a/benchmarks/operator_benchmark/benchmark_runner.py
+++ b/benchmarks/operator_benchmark/benchmark_runner.py
@@ -16,6 +16,7 @@ parser = argparse.ArgumentParser(
     description="Run microbenchmarks.",
     formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     conflict_handler="resolve",
+    allow_abbrev=False,
 )
 
 


### PR DESCRIPTION
Summary:

The test_pt_single_op test has been failing with 0% pass rate (81 consecutive failures since Dec 2024) due to an argparse "ambiguous option" error. When buck test runs the test binary, it injects --output <path> into sys.argv. The benchmark_runner's ArgumentParser uses prefix matching by default, causing --output to ambiguously match --output-json, --output-csv, and --output-json-for-dashboard.

Fix by setting allow_abbrev=False on the ArgumentParser, which disables prefix matching and allows parse_known_args() to correctly ignore buck's --output flag as an unrecognized argument.

Failing test: https://www.internalfb.com/intern/test/844425190466153

Test Plan:
Repro command from the failing test page:
```
buck test fbcode//mode/opt fbcode//caffe2/benchmarks/operator_benchmark/fb:operator_benchmark_test -- --exact 'fbcode//caffe2/benchmarks/operator_benchmark/fb:operator_benchmark_test - test_pt_single_op (operator_benchmark_test.OperatorBenchmarkTest)' --run-disabled
```

Buck UI: https://www.internalfb.com/buck2/ed587c78-42a4-4538-93e7-3323ebb355b6
Test UI: https://www.internalfb.com/intern/testinfra/testrun/18858823441124545

Reviewed By: huydhn

Differential Revision: D95620844
