### PR TITLE
[Inductor] Support convert_element_type lowering to emulate PyTorch eager numerics

### DIFF
--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -1460,6 +1460,25 @@ class CudaReproTests(TestCase):
         self.assertEqual(ref, res)
 
     @torch._inductor.config.patch(emulate_precision_casts=True)
+    @torch._inductor.config.patch(pattern_matcher=False)
+    def test_emulate_precision_casts_convert_element_type(self):
+        torch.manual_seed(0)
+        torch.cuda.manual_seed_all(0)
+
+        x = torch.rand(1000, device="cuda", dtype=torch.float32)
+
+        def fn(x):
+            x_bf16 = x.to(torch.bfloat16)
+            x_fp32_casted = x_bf16.to(torch.float32)
+            return x_fp32_casted
+
+        opt_fn = torch.compile(fn, backend="inductor", fullgraph=True, dynamic=True)
+
+        expected = fn(x)
+        actual = opt_fn(x)
+        self.assertEqual(expected, actual)
+
+    @torch._inductor.config.patch(emulate_precision_casts=True)
     def test_emulate_precision_casts_norm_rounding(self):
         torch.manual_seed(0)
         torch.cuda.manual_seed_all(0)

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -862,7 +862,9 @@ def to_dtype(x: TensorBox, dtype: torch.dtype, copy: bool = False):
         return clone(x) if copy else x
 
     def _to_dtype(x):
-        return ops.to_dtype(x, dtype, src_dtype=src_dtype)
+        return ops.to_dtype(
+            x, dtype, src_dtype=src_dtype, use_compute_types=not config.emulate_precision_casts
+        )
 
     return make_pointwise(_to_dtype, override_return_dtype=dtype)(x)
 

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -856,14 +856,17 @@ def foreach_group_loop(groups, num_outputs, apply_fn, realize_outputs):
     return outputs
 
 
-def to_dtype(x: TensorBox, dtype: torch.dtype, copy: bool = False):
+def to_dtype(x: TensorBox, dtype: torch.dtype, copy: bool = False, use_compute_types: bool = True):
     src_dtype = x.get_dtype()
     if src_dtype == dtype:
         return clone(x) if copy else x
 
     def _to_dtype(x):
         return ops.to_dtype(
-            x, dtype, src_dtype=src_dtype, use_compute_types=not config.emulate_precision_casts
+            x,
+            dtype,
+            src_dtype=src_dtype,
+            use_compute_types=use_compute_types,
         )
 
     return make_pointwise(_to_dtype, override_return_dtype=dtype)(x)
@@ -927,7 +930,13 @@ def _convert_element_type(x: TensorBox, dtype: torch.dtype):
             return fallback_handler(
                 prims.convert_element_type.default, add_to_fallback_set=False
             )(x, dtype)
-    return to_dtype(x, dtype, copy=True)
+    src_dtype = x.get_dtype()
+    low_pr_fp = (torch.bfloat16, torch.float16)
+    use_compute_types = not (
+        config.emulate_precision_casts
+        and (src_dtype in low_pr_fp or dtype in low_pr_fp)
+    )
+    return to_dtype(x, dtype, copy=True, use_compute_types=use_compute_types)
 
 
 def to_dtype_bitcast(x: TensorBox, dtype: torch.dtype, *, copy=False):

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -873,7 +873,9 @@ def to_dtype(
             use_compute_types=use_compute_types,
         )
 
-    return make_pointwise(_to_dtype, override_return_dtype=dtype, skip_emulation=not use_compute_types)(x)
+    return make_pointwise(
+        _to_dtype, override_return_dtype=dtype, skip_emulation=not use_compute_types
+    )(x)
 
 
 @register_lowering(torch._higher_order_ops._foreach_map, type_promotion_kind=None)

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -671,6 +671,7 @@ def make_pointwise(
     allow_alpha=False,
     use_fma_for_alpha=False,
     triton_fallback=None,
+    skip_emulation=False,
 ):
     """Wraps a pointwise fn and returns a function representing the pointwise in
     the define-by-run IR."""
@@ -717,7 +718,8 @@ def make_pointwise(
         # during decompositions are not annotated.
         low_pr_fp = (torch.bfloat16, torch.float16)
         emulate_precision_casts = (
-            V.graph is not None
+            not skip_emulation
+            and V.graph is not None
             and getattr(V.graph, "current_node", None) is not None
             and V.graph.current_node.meta is not None
             and V.graph.current_node.meta.get("low_precision_pointwise_barrier", False)
@@ -871,7 +873,7 @@ def to_dtype(
             use_compute_types=use_compute_types,
         )
 
-    return make_pointwise(_to_dtype, override_return_dtype=dtype)(x)
+    return make_pointwise(_to_dtype, override_return_dtype=dtype, skip_emulation=not use_compute_types)(x)
 
 
 @register_lowering(torch._higher_order_ops._foreach_map, type_promotion_kind=None)

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -671,7 +671,6 @@ def make_pointwise(
     allow_alpha=False,
     use_fma_for_alpha=False,
     triton_fallback=None,
-    skip_emulation=False,
 ):
     """Wraps a pointwise fn and returns a function representing the pointwise in
     the define-by-run IR."""
@@ -718,8 +717,7 @@ def make_pointwise(
         # during decompositions are not annotated.
         low_pr_fp = (torch.bfloat16, torch.float16)
         emulate_precision_casts = (
-            not skip_emulation
-            and V.graph is not None
+            V.graph is not None
             and getattr(V.graph, "current_node", None) is not None
             and V.graph.current_node.meta is not None
             and V.graph.current_node.meta.get("low_precision_pointwise_barrier", False)
@@ -866,16 +864,21 @@ def to_dtype(
         return clone(x) if copy else x
 
     def _to_dtype(x):
-        return ops.to_dtype(
+        result = ops.to_dtype(
             x,
             dtype,
             src_dtype=src_dtype,
             use_compute_types=use_compute_types,
         )
+        low_pr_fp = (torch.bfloat16, torch.float16)
+        if not use_compute_types and dtype in low_pr_fp:
+            # Upcast back to compute type so fused consumers see a compute-type
+            # value. Without this, a raw low-precision value gets a redundant
+            # downcast from the consumer's input emulation.
+            result = ops.to_dtype(result, dtype)
+        return result
 
-    return make_pointwise(
-        _to_dtype, override_return_dtype=dtype, skip_emulation=not use_compute_types
-    )(x)
+    return make_pointwise(_to_dtype, override_return_dtype=dtype)(x)
 
 
 @register_lowering(torch._higher_order_ops._foreach_map, type_promotion_kind=None)

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -856,7 +856,9 @@ def foreach_group_loop(groups, num_outputs, apply_fn, realize_outputs):
     return outputs
 
 
-def to_dtype(x: TensorBox, dtype: torch.dtype, copy: bool = False, use_compute_types: bool = True):
+def to_dtype(
+    x: TensorBox, dtype: torch.dtype, copy: bool = False, use_compute_types: bool = True
+):
     src_dtype = x.get_dtype()
     if src_dtype == dtype:
         return clone(x) if copy else x


### PR DESCRIPTION
Fix #176565

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo