### PR TITLE
feat: Add MPS support for embedding_renorm_

### DIFF
--- a/aten/src/ATen/mps/MPSFallback.mm
+++ b/aten/src/ATen/mps/MPSFallback.mm
@@ -111,7 +111,6 @@ TORCH_LIBRARY_IMPL(aten, MPS, m) {
   // These ops are not supported via MPS backend currently, and we fallback to run on CPU.
   // For the rest of unsupported ops the user needs to pass 'PYTORCH_ENABLE_MPS_FALLBACK=1'
   // to fallback on CPU, otherwise we will error out.
-  m.impl("embedding_renorm_", torch::CppFunction::makeFromBoxedFunction<&mps_fallback>());
   m.impl("linalg_svd", torch::CppFunction::makeFromBoxedFunction<&mps_fallback>());
   m.impl("linalg_svd.U", torch::CppFunction::makeFromBoxedFunction<&mps_fallback>());
   m.impl("_slow_conv2d_forward", slow_conv2d_forward_mps);

--- a/aten/src/ATen/native/mps/operations/Indexing.mm
+++ b/aten/src/ATen/native/mps/operations/Indexing.mm
@@ -30,6 +30,7 @@
 #include <ATen/ops/count_nonzero.h>
 #include <ATen/ops/count_nonzero_native.h>
 #include <ATen/ops/embedding_dense_backward_native.h>
+#include <ATen/ops/embedding_renorm_native.h>
 #include <ATen/ops/flip_native.h>
 #include <ATen/ops/index.h>
 #include <ATen/ops/index_add_native.h>
@@ -43,6 +44,12 @@
 #include <ATen/ops/nonzero.h>
 #include <ATen/ops/nonzero_native.h>
 #include <ATen/ops/ones_like.h>
+#include <ATen/ops/renorm.h>
+#include <ATen/ops/renorm_native.h>
+#include <ATen/ops/sort.h>
+#include <ATen/ops/sort_native.h>
+#include <ATen/ops/unique_consecutive.h>
+#include <ATen/ops/unique_consecutive_native.h>
 #include <ATen/ops/view_as_real.h>
 #endif
 
@@ -955,6 +962,27 @@ Tensor embedding_dense_backward_mps(const Tensor& grad_,
     runMPSGraph(stream, cachedGraph->graph(), feeds, outgoingGradPlaceholder);
   }
   return outgoing_gradient;
+}
+
+Tensor& embedding_renorm_mps_(Tensor& self, const Tensor& indices, double max_norm, double norm_type) {
+  auto self_arg = TensorArg(self, "self", 1);
+  auto indices_arg = TensorArg(indices, "indices", 2);
+  checkDim("embedding_renorm_", self_arg, 2);
+  checkScalarTypes("embedding_renorm_", indices_arg, {kLong, kInt});
+  checkAllSameGPU(__func__, {self_arg, indices_arg});
+
+  auto indices_contig = indices.contiguous().view(-1);
+  if (indices_contig.numel() == 0) {
+    return self;
+  }
+
+  auto sorted_indices = std::get<0>(at::sort(indices_contig, /*dim=*/-1, /*descending=*/false));
+  auto unique_indices = std::get<0>(
+      at::unique_consecutive(sorted_indices, /*return_inverse=*/false, /*return_counts=*/false, std::nullopt));
+  auto rows = self.index_select(0, unique_indices);
+  auto rows_renorm = at::renorm(rows, norm_type, /*dim=*/0, max_norm);
+  self.index_put_({unique_indices}, rows_renorm, /*accumulate=*/false);
+  return self;
 }
 
 Tensor& masked_fill__mps(Tensor& self, const Tensor& mask, const Tensor& value) {

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2348,6 +2348,7 @@
   dispatch:
     CPU: embedding_renorm_cpu_
     CUDA: embedding_renorm_cuda_
+    MPS: embedding_renorm_mps_
   autogen: embedding_renorm, embedding_renorm.out
 
 - func: embedding_sparse_backward(Tensor grad, Tensor indices, int num_weights, int padding_idx, bool scale_grad_by_freq) -> Tensor

--- a/test/nn/test_embedding.py
+++ b/test/nn/test_embedding.py
@@ -10,6 +10,7 @@ import torch.nn.functional as F
 from torch.testing._internal.common_device_type import (
     dtypes,
     dtypesIfCUDA,
+    dtypesIfMPS,
     dtypesIfXPU,
     instantiate_device_type_tests,
     largeTensorTest,
@@ -1940,7 +1941,41 @@ class TestEmbeddingNNDeviceType(NNTestCase):
         bag(x, per_sample_weights=F.softmax(w, dim=-1))
 
 
+class TestEmbeddingNNRenormDeviceType(NNTestCase):
+    @onlyOn(["cuda", "xpu", "mps"])
+    @dtypesIfCUDA(torch.float32, torch.float16)
+    @dtypesIfXPU(torch.float32, torch.float16)
+    @dtypesIfMPS(torch.float32, torch.float16)
+    @dtypes(torch.float32)
+    def test_embedding_renorm_device(self, device, dtype):
+        weight = torch.tensor(
+            [
+                [3.0, 4.0, 0.0],
+                [0.3, 0.4, 0.0],
+                [6.0, 8.0, 0.0],
+                [5.0, 12.0, 0.0],
+            ],
+            dtype=dtype,
+        )
+        indices = torch.tensor([[2, 0, 2], [3, 0, 3]], dtype=torch.long)
+
+        expected = torch.embedding_renorm_(weight.clone(), indices, 5.0, 2.0)
+        actual = torch.embedding_renorm_(
+            weight.to(device), indices.to(device), 5.0, 2.0
+        )
+
+        atol = 0.01 if dtype == torch.float16 else None
+        rtol = 0.01 if dtype == torch.float16 else None
+        self.assertEqual(actual.cpu(), expected, atol=atol, rtol=rtol)
+
+
 instantiate_device_type_tests(TestEmbeddingNNDeviceType, globals(), allow_xpu=True)
+instantiate_device_type_tests(
+    TestEmbeddingNNRenormDeviceType,
+    globals(),
+    allow_mps=True,
+    allow_xpu=True,
+)
 instantiate_parametrized_tests(TestEmbeddingNN)
 
 if __name__ == "__main__":


### PR DESCRIPTION
#154052 

- Adds native MPS support for embedding_renorm_ by registering an MPS dispatch, implementing embedding_renorm_mps_
- Remove the old explicit MPS CPU fallback.
- Test Plan:
  - .venv/bin/python test/nn/test_embedding.py -v TestEmbeddingNNRenormDeviceTypeMPS: Ok
  - python scripts/lintrunner.py -a: Ok

BTW: TestEmbeddingNNDeviceType cannot run with MPS(many test cases failed).