### PR TITLE
Add mps support for addmm relu

### DIFF
--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -1,5 +1,9 @@
 //  Copyright © 2022 Apple Inc.
 
+#include <ATen/TensorMeta.h>
+#include <ATen/core/TensorBody.h>
+#include <ATen/ops/gelu.h>
+#include <ATen/ops/relu.h>
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/mps/MPSProfiler.h>
 #include <ATen/native/BatchLinearAlgebra.h>
@@ -17,6 +21,7 @@
 #include <ATen/Functions.h>
 #include <ATen/NativeFunctions.h>
 #else
+#include <ATen/ops/_addmm_activation_native.h>
 #include <ATen/ops/_linalg_solve_ex_native.h>
 #include <ATen/ops/addbmm_native.h>
 #include <ATen/ops/addmm_native.h>
@@ -946,6 +951,22 @@ static Tensor& addmm_out_mps_impl(const Tensor& bias,
   return output;
 }
 
+static Tensor& _addmm_activation_out_mps_impl(const Tensor& self,
+                                              const Tensor& mat1,
+                                              const Tensor& mat2,
+                                              const Scalar& beta,
+                                              const Scalar& alpha,
+                                              bool use_gelu,
+                                              Tensor& result) {
+  addmm_out_mps_impl(self, mat1, mat2, beta, alpha, result);
+  if (use_gelu) {
+    at::gelu_(const_cast<Tensor&>(result));
+  } else {
+    at::relu_(const_cast<Tensor&>(result));
+  }
+  return result;
+}
+
 static Tensor& tiled_bmm_out_mps_impl(const Tensor& batch1, const Tensor& batch2, Tensor& result) {
   if (is_macos_13_or_newer(MacOSVersion::MACOS_VER_15_0_PLUS)) {
     using namespace mps;
@@ -1687,6 +1708,17 @@ TORCH_IMPL_FUNC(addmm_out_mps)
  const Scalar& alpha,
  const Tensor& result) {
   mps::addmm_out_mps_impl(self, mat1, mat2, beta, alpha, const_cast<Tensor&>(result));
+}
+
+TORCH_IMPL_FUNC(addmm_activation_out_mps)
+(const Tensor& self,
+ const Tensor& mat1,
+ const Tensor& mat2,
+ const Scalar& beta,
+ const Scalar& alpha,
+ bool use_gelu,
+ const Tensor& result) {
+  mps::_addmm_activation_out_mps_impl(self, mat1, mat2, beta, alpha, use_gelu, const_cast<Tensor&>(result));
 }
 
 TORCH_IMPL_FUNC(bmm_out_mps)(const Tensor& batch1, const Tensor& batch2, const Tensor& result) {

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -7302,6 +7302,7 @@
     CPU: addmm_activation_out_cpu
     CUDA: addmm_activation_out_cuda
     XPU: addmm_activation_out_xpu
+    MPS: addmm_activation_out_mps
 
 - func: _addmm_activation(Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1, bool use_gelu=False) -> Tensor
   structured_delegate: _addmm_activation.out

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -9439,19 +9439,35 @@ class TestPad(TestCaseMPS):
         self.assertEqual(output_mps, input_mps)
 
 class TestLinalgMPS(TestCaseMPS):
-    def _test_addmm_addmv(self, f, t, m, v, *, alpha=None, beta=None, transpose_out=False):
+    def _test_addmm_addmv(self, f, t, m, v, *, alpha=None, beta=None, transpose_out=False, activation=None):
         dtype = t.dtype
         numpy_dtype = dtype
         alpha = 1.2 if alpha is None else alpha
         beta = 0.8 if beta is None else beta
-        res1 = f(t, m, v, alpha=alpha, beta=beta)
+        if activation == "gelu":
+            res1 = f(t, m, v, alpha=alpha, beta=beta, use_gelu=True)
+        else:
+            res1 = f(t, m, v, alpha=alpha, beta=beta)
         res2 = torch.full_like(res1, math.nan)
         if transpose_out:
             res2 = res2.t().clone(memory_format=torch.contiguous_format).t()
-        f(t, m, v, alpha=alpha, beta=beta, out=res2)
+        if activation == "gelu":
+            f(t, m, v, alpha=alpha, beta=beta, out=res2, use_gelu=True)
+        else:
+            f(t, m, v, alpha=alpha, beta=beta, out=res2)
         res3 = alpha * (m.to(numpy_dtype).cpu().numpy() @ v.to(numpy_dtype).cpu().numpy())
         if beta != 0:
             res3 += (torch.mul(t, beta)).to(numpy_dtype).cpu().numpy()
+        if activation == "relu":
+            res3 = res3 * (res3 > 0)
+        elif activation == "gelu":
+            res3_t = torch.from_numpy(res3).to(dtype)
+            approximate = "tanh" if t.is_cuda else "none"
+            res3_t = torch.nn.functional.gelu(res3_t, approximate=approximate)
+            res3 = res3_t.to(numpy_dtype).cpu().numpy()
+        else:
+            if activation is not None:
+                raise AssertionError(f"unsupported activation {activation}")
         res3 = torch.from_numpy(res3).to(dtype)
         self.assertEqual(res1, res2)
         self.assertEqual(res1, res3)
@@ -9479,6 +9495,51 @@ class TestLinalgMPS(TestCaseMPS):
         m1 = maybe_transpose(t2, torch.randn(10, 50, device=device).to(dtype))
         m2 = maybe_transpose(t3, torch.randn(50, 25, device=device).to(dtype))
         self._test_addmm_addmv(torch.addmm, M, m1, m2, transpose_out=t4)
+
+    def _test_addmm_impl(self, func, activation, device, dtype):
+        M = torch.randn(10, 25, device=device).to(dtype)
+        m1 = torch.randn(10, 50, device=device).to(dtype)
+        m2 = torch.randn(50, 25, device=device).to(dtype)
+        self._test_addmm_addmv(func, M, m1, m2, activation=activation)
+
+        # vector (or with 1-len dims in shape[:-1])/matrix-shaped bias
+        # and beta=1 result in epilogue fusion in CUDA
+        V = torch.randn(25, device=device).to(dtype)
+        for c in (V, V.unsqueeze(0), M):
+            self._test_addmm_addmv(func, c, m1, m2, beta=1, activation=activation)
+
+        # Test 0-strided
+        M = torch.randn(10, 1, device=device).to(dtype).expand(10, 25)
+        m1 = torch.randn(10, 1, device=device).to(dtype).expand(10, 50)
+        m2 = torch.randn(50, 25, device=device).to(dtype)
+        self._test_addmm_addmv(func, M, m1, m2, activation=activation)
+
+        # Test beta=0, M=nan
+        M = torch.full((10, 25), math.nan, device=device).to(dtype)
+        m1 = torch.randn(10, 50, device=device).to(dtype)
+        m2 = torch.randn(50, 25, device=device).to(dtype)
+        self._test_addmm_addmv(func, M, m1, m2, beta=0, activation=activation)
+
+        # Test transpose
+        for t1, t2, t3, t4 in itertools.product([True, False], repeat=4):
+            def maybe_transpose(cond, m):
+                if not cond:
+                    return m
+                return m.t().clone(memory_format=torch.contiguous_format).t()
+
+            M = maybe_transpose(t1, torch.randn(10, 25, device=device).to(dtype))
+            m1 = maybe_transpose(t2, torch.randn(10, 50, device=device).to(dtype))
+            m2 = maybe_transpose(t3, torch.randn(50, 25, device=device).to(dtype))
+
+            for c, beta in itertools.product((M, V, V.unsqueeze(0)), (0, 1)):
+                # beta=1 to test epilogue fusions with either vector or matrix input
+                self._test_addmm_addmv(func, c, m1, m2, beta=beta, transpose_out=t4, activation=activation)
+
+    def test_addmm_gelu(self, device="mps", dtype=torch.float32):
+        self._test_addmm_impl(torch._addmm_activation, "gelu", device, dtype)
+
+    def test_addmm_relu(self, device="mps", dtype=torch.float32):
+        self._test_addmm_impl(torch._addmm_activation, "relu", device, dtype)
 
     def _test_addr(self, f, t, m, v, alpha=None, beta=None):
         dtype = t.dtype

--- a/torch/csrc/inductor/aoti_torch/generated/c_shim_mps.h
+++ b/torch/csrc/inductor/aoti_torch/generated/c_shim_mps.h
@@ -13,6 +13,7 @@ extern "C" {
 
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_mps__adaptive_avg_pool2d(AtenTensorHandle self, const int64_t* output_size, int64_t output_size_len_, AtenTensorHandle* ret0);
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_mps__adaptive_avg_pool2d_backward(AtenTensorHandle grad_output, AtenTensorHandle self, AtenTensorHandle* ret0);
+AOTI_TORCH_EXPORT AOTITorchError aoti_torch_mps__addmm_activation(AtenTensorHandle self, AtenTensorHandle mat1, AtenTensorHandle mat2, double beta, double alpha, int32_t use_gelu, AtenTensorHandle* ret0);
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_mps__cdist_forward(AtenTensorHandle x1, AtenTensorHandle x2, double p, int64_t* compute_mode, AtenTensorHandle* ret0);
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_mps__efficientzerotensor(const int64_t* size, int64_t size_len_, int32_t* dtype, int32_t* layout, int32_t* device, int32_t device_index_, int32_t* pin_memory, AtenTensorHandle* ret0);
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_mps__embedding_bag(AtenTensorHandle weight, AtenTensorHandle indices, AtenTensorHandle offsets, int32_t scale_grad_by_freq, int64_t mode, int32_t sparse, AtenTensorHandle* per_sample_weights, int32_t include_last_offset, int64_t padding_idx, AtenTensorHandle* ret0, AtenTensorHandle* ret1, AtenTensorHandle* ret2, AtenTensorHandle* ret3);


### PR DESCRIPTION
#154052

benchmark: 

Apple M4 Max 64GB, Run 5 times and take the median. [benchmark script here](https://gist.github.com/Kingwl/08334879e9e8c0352c98bba9ffacd8f9)

 `((old - new) / old) * 100%` 

old commit: bc65f648c9c8ca7c6da252e00a867128c780e6b6
new commit: 4c4d4ea59d78cc2c323dfa82a19b5709ef8b167e

| M x N x K | MPS old (ms) | MPS new (ms) | Delta (ms) | Change |
|---|---:|---:|---:|---:|
| `128x128x128` | 0.222 | 0.202 | -0.020 | `+9.0%` |
| `256x256x256` | 0.233 | 0.226 | -0.007 | `+3.0%` |
| `512x512x512` | 0.343 | 0.335 | -0.008 | `+2.3%` |
| `1024x1024x1024` | 0.360 | 0.365 | +0.005 | `-1.4%` |
| `256x1024x64` | 0.214 | 0.181 | -0.033 | `+15.4%` |
| `1024x256x64` | 0.220 | 0.209 | -0.011 | `+5.0%` |
| `64x1024x256` | 0.211 | 0.193 | -0.018 | `+8.5%` |
| `1024x64x256` | 0.206 | 0.193 | -0.013 | `+6.3%` |
| `512x2048x128` | 0.366 | 0.368 | +0.002 | `-0.5%` |
| `2048x512x128` | 0.369 | 0.373 | +0.004 | `-1.1%` |
| `128x1536x768` | 0.349 | 0.320 | -0.029 | `+8.3%` |
| `1536x128x768` | 0.337 | 0.324 | -0.013 | `+3.9%` |
| `384x768x1536` | 0.265 | 0.264 | -0.001 | `+0.4%` |
| `768x384x1536` | 0.307 | 0.255 | -0.052 | `+16.9%` |

