### PR TITLE
[inductor] Add lerp lowering and fix addcmul_ decomposition for bitwise parity

### DIFF
--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -1430,7 +1430,14 @@ class TensorVariable(VariableTracker):
         *,
         value: Any | None = None,
     ) -> Any | None:
-        if value is not None and config.enable_dynamo_decompositions:
+        # Only decompose when value is a tensor (to avoid item() graph breaks).
+        # For scalar values, let addcmul_ pass through to ATen so that the
+        # inductor lowering can emit FMA + mul_rn for bitwise parity with eager.
+        if (
+            value is not None
+            and isinstance(value, TensorVariable)
+            and config.enable_dynamo_decompositions
+        ):
             from .. import polyfills
 
             return tx.inline_user_function_return(

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -136,6 +136,8 @@ decomps_to_exclude: list[torch._ops.OpOverload | torch._ops.OpOverloadPacket] = 
     aten.addcdiv_,
     aten._foreach_addcdiv.Scalar,
     aten._foreach_addcdiv_,
+    aten.lerp,
+    aten.lerp_,
 ]
 
 remove_decompositions(decompositions, decomps_to_exclude)

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -7064,6 +7064,124 @@ square = register_pointwise(aten.square)
 sub = register_pointwise(aten.sub, allow_alpha=True)
 
 
+@register_lowering(aten.lerp.Scalar, broadcast=True)
+def lerp_scalar(start, end, weight):
+    """
+    Computes start + weight * (end - start) using FMA for CUDA floating-point.
+
+    Matches eager CUDA kernel's dual-formula approach (see aten/src/ATen/native/Lerp.h):
+      |w| <  0.5: start + w * (end - start)       → fma(w, end - start, start)
+      |w| >= 0.5: end + (-(1-w)) * (end - start)  → fma(-(1-w), end - start, end)
+    """
+    dtype = get_promoted_dtype(
+        start,
+        end,
+        type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT,
+    )
+
+    start_loader = start.make_loader()
+    end_loader = end.make_loader()
+
+    device = start.get_device()
+    use_fma = (
+        dtype.is_floating_point
+        and not torch.version.hip
+        and device is not None
+        and device.type in ["cuda", "xpu"]
+    )
+
+    if isinstance(weight, (int, float)):
+        use_high = weight >= 0.5 or weight <= -0.5
+    else:
+        use_high = False
+
+    def inner_fn(idx):
+        start_val = start_loader(idx)
+        end_val = end_loader(idx)
+        diff = ops.sub(end_val, start_val)
+
+        if use_fma:
+            if use_high:
+                coeff = ops.constant(-(1.0 - weight), dtype)
+                return ops.fma(coeff, diff, end_val)
+            else:
+                w = ops.constant(weight, dtype)
+                return ops.fma(w, diff, start_val)
+        else:
+            if use_high:
+                coeff = ops.constant(-(1.0 - weight), dtype)
+                return ops.add(end_val, ops.mul(coeff, diff))
+            else:
+                w = ops.constant(weight, dtype)
+                return ops.add(start_val, ops.mul(w, diff))
+
+    return Pointwise.create(
+        device=start.get_device(),
+        dtype=dtype,
+        inner_fn=inner_fn,
+        ranges=start.get_size(),
+    )
+
+
+@register_lowering(aten.lerp.Tensor, broadcast=True)
+def lerp_tensor(start, end, weight):
+    """
+    Computes lerp with tensor weight using FMA.
+
+    Matches eager CUDA kernel's dual-formula approach (see aten/src/ATen/native/Lerp.h):
+      |w| <  0.5: start + w * (end - start)       → fma(w, end - start, start)
+      |w| >= 0.5: end + (-(1-w)) * (end - start)  → fma(-(1-w), end - start, end)
+    """
+    dtype = get_promoted_dtype(
+        start,
+        end,
+        weight,
+        type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT,
+    )
+
+    start_loader = start.make_loader()
+    end_loader = end.make_loader()
+    weight_loader = weight.make_loader()
+
+    device = start.get_device()
+    use_fma = (
+        dtype.is_floating_point
+        and not torch.version.hip
+        and device is not None
+        and device.type in ["cuda", "xpu"]
+    )
+
+    def inner_fn(idx):
+        start_val = start_loader(idx)
+        end_val = end_loader(idx)
+        w_val = weight_loader(idx)
+        diff = ops.sub(end_val, start_val)
+        abs_w = ops.abs(w_val)
+        threshold = ops.constant(0.5, dtype)
+        mask = ops.ge(abs_w, threshold)
+        one = ops.constant(1.0, dtype)
+
+        if use_fma:
+            # Low: fma(w, diff, start)
+            low = ops.fma(w_val, diff, start_val)
+            # High: fma(-(1-w), diff, end)
+            neg_omw = ops.neg(ops.sub(one, w_val))
+            high = ops.fma(neg_omw, diff, end_val)
+        else:
+            low = ops.add(start_val, ops.mul(w_val, diff))
+            neg_omw = ops.neg(ops.sub(one, w_val))
+            high = ops.add(end_val, ops.mul(neg_omw, diff))
+
+        return ops.where(mask, high, low)
+
+    return Pointwise.create(
+        device=start.get_device(),
+        dtype=dtype,
+        inner_fn=inner_fn,
+        ranges=start.get_size(),
+    )
+
+
 @register_lowering(aten.addcmul, broadcast=True)
 def addcmul(self, tensor1, tensor2, *, value=1):
     """


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #176802
* #176800
* #176799
* #176798
* __->__ #176797

The singletensor optimizer path (foreach=False) was producing different
results from eager because of two numerical mismatches:

1. lerp_ was being decomposed by _refs into mul+add instead of matching
   eager CUDA's dual-formula FMA approach (|w|<0.5 vs |w|>=0.5). Added
   explicit aten.lerp.Scalar and aten.lerp.Tensor lowerings in inductor
   that emit FMA matching the eager Lerp.h kernel, and excluded lerp from
   decompositions so the lowerings take effect.

2. addcmul_ was always being decomposed by the dynamo polyfill into
   tensor1 * tensor2 * value (two separate multiplies) instead of reaching
   the inductor FMA+mul_rn lowering. The polyfill exists to avoid item()
   graph breaks when value is a tensor, but for scalar values this
   decomposition is unnecessary. Changed method_addcmul_ to only
   decompose for TensorVariable values, letting scalar values pass through
   to ATen's addcmul_ which gets proper FMA treatment in inductor.

Together these changes give singletensor Adam/AdamW bitwise parity with
eager under the precision configs (division_rounding, use_pytorch_libdevice,
emulate_precision_casts).

Authored with Claude.