### PR TITLE
[inductor] Add singletensor capturable optimizers to bitwise tests

### DIFF
--- a/test/inductor/test_compiled_optimizers.py
+++ b/test/inductor/test_compiled_optimizers.py
@@ -1104,9 +1104,14 @@ def _make_bitwise_test(optim_cls, **optim_kwargs):
 
 
 for optim_cls, name, kwargs, scheduler_cls in COMPILED_OPT_KWARG_DB:
+    is_foreach = kwargs.get("foreach", False)
     if (
-        optim_cls in (Adam, AdamW, Adadelta, Adamax, ASGD, NAdam, RAdam, RMSprop, Rprop)
-        and kwargs.get("foreach", False)
+        optim_cls
+        in (Adam, AdamW, Adadelta, Adamax, ASGD, NAdam, RAdam, RMSprop, Rprop)
+        and (
+            is_foreach
+            or optim_cls in (Adam, AdamW, Adamax, ASGD, NAdam, RAdam, Rprop)
+        )
         and kwargs.get("capturable", False)
         and kwargs.get("device") == GPU_TYPE
         and "tensor_lr" not in name


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #176802
* #176800
* #176799
* __->__ #176798
* #176797

With the lerp and addcmul_ fixes from the previous commit, singletensor
(non-foreach) capturable optimizers now achieve bitwise parity with eager
for Adam, AdamW, Adamax, ASGD, NAdam, RAdam, and Rprop. This adds 18
new singletensor bitwise tests (40 total, up from 22 foreach-only).

Adadelta and RMSprop singletensor are excluded since they have other
numerical operations that still need separate fixes.

Authored with Claude.