### PR TITLE
[dynamo] Fix add_ and addcdiv_ decompositions for bitwise parity

### DIFF
--- a/test/inductor/test_compiled_optimizers.py
+++ b/test/inductor/test_compiled_optimizers.py
@@ -1104,14 +1104,9 @@ def _make_bitwise_test(optim_cls, **optim_kwargs):
 
 
 for optim_cls, name, kwargs, scheduler_cls in COMPILED_OPT_KWARG_DB:
-    is_foreach = kwargs.get("foreach", False)
     if (
         optim_cls
         in (Adam, AdamW, Adadelta, Adamax, ASGD, NAdam, RAdam, RMSprop, Rprop)
-        and (
-            is_foreach
-            or optim_cls in (Adam, AdamW, Adamax, ASGD, NAdam, RAdam, Rprop)
-        )
         and kwargs.get("capturable", False)
         and kwargs.get("device") == GPU_TYPE
         and "tensor_lr" not in name

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -1561,7 +1561,14 @@ class TensorVariable(VariableTracker):
         *,
         alpha: VariableTracker | None = None,
     ) -> VariableTracker | None:
-        if alpha is not None and config.enable_dynamo_decompositions:
+        # Only decompose when alpha is a tensor (to avoid item() graph breaks).
+        # For scalar alpha, let add_ pass through to ATen so that the inductor
+        # lowering can emit FMA for bitwise parity with eager.
+        if (
+            alpha is not None
+            and isinstance(alpha, TensorVariable)
+            and config.enable_dynamo_decompositions
+        ):
             result = variables.TorchInGraphFunctionVariable(torch.mul).call_function(
                 tx, [other, alpha], {}
             )
@@ -1576,7 +1583,14 @@ class TensorVariable(VariableTracker):
         *,
         value: VariableTracker | None = None,
     ) -> VariableTracker | None:
-        if value is not None and config.enable_dynamo_decompositions:
+        # Only decompose when value is a tensor (to avoid item() graph breaks).
+        # For scalar values, let addcdiv_ pass through to ATen so that the
+        # inductor lowering can emit FMA + div_rn for bitwise parity with eager.
+        if (
+            value is not None
+            and isinstance(value, TensorVariable)
+            and config.enable_dynamo_decompositions
+        ):
             result = variables.TorchInGraphFunctionVariable(torch.div).call_function(
                 tx, [tensor1, tensor2], {}
             )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #176802
* #176800
* __->__ #176799
* #176798
* #176797

Same pattern as the addcmul_ fix: method_add_ and method_addcdiv_ in
dynamo were unconditionally decomposing scalar alpha/value parameters,
preventing inductor's FMA lowerings from being reached. Now these only
decompose for TensorVariable values (needed to avoid item() graph
breaks), letting scalar values pass through to ATen.

This fixes singletensor Adadelta (add_ with alpha=-lr) and RMSprop
(addcdiv_ with value=-lr), bringing all 9 capturable optimizers to
bitwise parity in both foreach and singletensor paths.

Authored with Claude.