### PR TITLE
[dynamo] Route addcmul_/addcdiv_ decompositions through add_ with alpha

### DIFF
--- a/test/inductor/test_compiled_optimizers.py
+++ b/test/inductor/test_compiled_optimizers.py
@@ -1105,8 +1105,7 @@ def _make_bitwise_test(optim_cls, **optim_kwargs):
 
 for optim_cls, name, kwargs, scheduler_cls in COMPILED_OPT_KWARG_DB:
     if (
-        optim_cls
-        in (Adam, AdamW, Adadelta, Adamax, ASGD, NAdam, RAdam, RMSprop, Rprop)
+        optim_cls in (Adam, AdamW, Adadelta, Adamax, ASGD, NAdam, RAdam, RMSprop, Rprop)
         and kwargs.get("capturable", False)
         and kwargs.get("device") == GPU_TYPE
         and "tensor_lr" not in name

--- a/torch/_dynamo/polyfills/__init__.py
+++ b/torch/_dynamo/polyfills/__init__.py
@@ -536,7 +536,7 @@ def foreach_pow_scalar(
 def addcmul_inplace(
     self, tensor1: torch.Tensor, tensor2: torch.Tensor, value: Any
 ) -> None:
-    return self.add_(tensor1 * tensor2 * value)
+    return self.add_(tensor1 * tensor2, alpha=value)
 
 
 def predicate(obj: object) -> bool:

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -1430,14 +1430,7 @@ class TensorVariable(VariableTracker):
         *,
         value: Any | None = None,
     ) -> Any | None:
-        # Only decompose when value is a tensor (to avoid item() graph breaks).
-        # For scalar values, let addcmul_ pass through to ATen so that the
-        # inductor lowering can emit FMA + mul_rn for bitwise parity with eager.
-        if (
-            value is not None
-            and isinstance(value, TensorVariable)
-            and config.enable_dynamo_decompositions
-        ):
+        if value is not None and config.enable_dynamo_decompositions:
             from .. import polyfills
 
             return tx.inline_user_function_return(
@@ -1561,9 +1554,10 @@ class TensorVariable(VariableTracker):
         *,
         alpha: VariableTracker | None = None,
     ) -> VariableTracker | None:
-        # Only decompose when alpha is a tensor (to avoid item() graph breaks).
-        # For scalar alpha, let add_ pass through to ATen so that the inductor
-        # lowering can emit FMA for bitwise parity with eager.
+        # Decompose only for tensor alpha to avoid item() graph breaks.
+        # Scalar alpha passes through to ATen where the inductor lowering emits
+        # FMA. addcmul_ and addcdiv_ route through here via alpha=value so this
+        # is the single place that handles the scalar/tensor distinction.
         if (
             alpha is not None
             and isinstance(alpha, TensorVariable)
@@ -1583,21 +1577,11 @@ class TensorVariable(VariableTracker):
         *,
         value: VariableTracker | None = None,
     ) -> VariableTracker | None:
-        # Only decompose when value is a tensor (to avoid item() graph breaks).
-        # For scalar values, let addcdiv_ pass through to ATen so that the
-        # inductor lowering can emit FMA + div_rn for bitwise parity with eager.
-        if (
-            value is not None
-            and isinstance(value, TensorVariable)
-            and config.enable_dynamo_decompositions
-        ):
+        if value is not None and config.enable_dynamo_decompositions:
             result = variables.TorchInGraphFunctionVariable(torch.div).call_function(
                 tx, [tensor1, tensor2], {}
             )
-            result = variables.TorchInGraphFunctionVariable(torch.mul).call_function(
-                tx, [result, value], {}
-            )
-            return self.call_method(tx, "add_", [result], {})
+            return self.call_method(tx, "add_", [result], {"alpha": value})
         return None
 
     def method___contains__(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #176802
* __->__ #176800
* #176799
* #176798
* #176797

Instead of having separate isinstance(TensorVariable) checks in each
decomposition method, make them all route through add_ with alpha=value.
method_add_ is the single gatekeeper that handles the scalar/tensor
distinction: scalar alpha passes through to ATen (inductor emits FMA),
tensor alpha decomposes to mul+add_ (avoiding item() graph breaks).

- addcmul_ polyfill: self.add_(t1 * t2, alpha=value)
- addcdiv_: self.add_(div(t1, t2), alpha=value)
- add_: decompose only for tensor alpha (isinstance check)

Authored with Claude.