### PR TITLE
[inductor] Replace lerp_scalar lowering with decomposition into add(alpha=weight)

### DIFF
--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -152,6 +152,16 @@ def register_decomposition(
     return decomp.register_decomposition(ops, decompositions)
 
 
+@register_decomposition([aten.lerp.Scalar])
+def _lerp_scalar(start: torch.Tensor, end: torch.Tensor, weight: float) -> torch.Tensor:
+    # Decompose into sub + add(alpha=weight) so that the add lowering emits FMA,
+    # matching eager CUDA's dual-formula (see aten/src/ATen/native/Lerp.h).
+    diff = end - start
+    if weight >= 0.5 or weight <= -0.5:
+        return torch.add(end, diff, alpha=-(1.0 - weight))
+    return torch.add(start, diff, alpha=weight)
+
+
 @register_decomposition([aten.embedding_dense_backward])
 def _embedding_dense_backward(
     grad_output: torch.Tensor,

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -7064,65 +7064,6 @@ square = register_pointwise(aten.square)
 sub = register_pointwise(aten.sub, allow_alpha=True)
 
 
-@register_lowering(aten.lerp.Scalar, broadcast=True)
-def lerp_scalar(start, end, weight):
-    """
-    Computes start + weight * (end - start) using FMA for CUDA floating-point.
-
-    Matches eager CUDA kernel's dual-formula approach (see aten/src/ATen/native/Lerp.h):
-      |w| <  0.5: start + w * (end - start)       → fma(w, end - start, start)
-      |w| >= 0.5: end + (-(1-w)) * (end - start)  → fma(-(1-w), end - start, end)
-    """
-    dtype = get_promoted_dtype(
-        start,
-        end,
-        type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT,
-    )
-
-    start_loader = start.make_loader()
-    end_loader = end.make_loader()
-
-    device = start.get_device()
-    use_fma = (
-        dtype.is_floating_point
-        and not torch.version.hip
-        and device is not None
-        and device.type in ["cuda", "xpu"]
-    )
-
-    if isinstance(weight, (int, float)):
-        use_high = weight >= 0.5 or weight <= -0.5
-    else:
-        use_high = False
-
-    def inner_fn(idx):
-        start_val = start_loader(idx)
-        end_val = end_loader(idx)
-        diff = ops.sub(end_val, start_val)
-
-        if use_fma:
-            if use_high:
-                coeff = ops.constant(-(1.0 - weight), dtype)
-                return ops.fma(coeff, diff, end_val)
-            else:
-                w = ops.constant(weight, dtype)
-                return ops.fma(w, diff, start_val)
-        else:
-            if use_high:
-                coeff = ops.constant(-(1.0 - weight), dtype)
-                return ops.add(end_val, ops.mul(coeff, diff))
-            else:
-                w = ops.constant(weight, dtype)
-                return ops.add(start_val, ops.mul(w, diff))
-
-    return Pointwise.create(
-        device=start.get_device(),
-        dtype=dtype,
-        inner_fn=inner_fn,
-        ranges=start.get_size(),
-    )
-
-
 @register_lowering(aten.lerp.Tensor, broadcast=True)
 def lerp_tensor(start, end, weight):
     """


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #176802
* #176800
* #176799
* #176798
* #176797

Same approach as the foreach_lerp polyfill (sub + addcmul for FMA) but
for singletensor: decompose aten.lerp.Scalar into sub + add(alpha=weight)
where add's existing FMA lowering handles the numerics. This replaces the
custom lerp_scalar lowering with a simpler inductor decomposition.

The tensor-weight lerp lowering is kept since add doesn't support tensor
alpha.

Authored with Claude.