### PR TITLE
docs: Clarify CPU vs CUDA-stream semantics for send/recv/isend/irecv and Work.wait() on NCCL

### DIFF
--- a/docs/source/distributed.md
+++ b/docs/source/distributed.md
@@ -424,6 +424,7 @@ used to create new DeviceMesh, with a mesh shape describing the device topology.
     :members:
 ```
 
+(distributed-p2p)=
 ## Point-to-point communication
 
 ```{eval-rst}
@@ -439,8 +440,14 @@ return distributed request objects when used. In general, the type of this objec
 as they should never be created manually, but they are guaranteed to support two methods:
 
 - `is_completed()` - returns True if the operation has finished
-- `wait()` - will block the process until the operation is finished.
-  `is_completed()` is guaranteed to return True once it returns.
+- `wait()` - For CPU operations, blocks the calling thread until the operation is
+  finished. For CUDA tensors with NCCL, `wait()` synchronizes the operation with the
+  currently active CUDA stream (i.e., it makes subsequent work on that stream wait
+  for NCCL work) and by default does not block the CPU thread. If a timeout
+  is specified, or if `TORCH_NCCL_BLOCKING_WAIT=1`, `wait()` blocks the CPU thread until
+  completion or timeout.
+  Also see
+  [Synchronous and asynchronous collective operations](#synchronous-and-asynchronous-collective-operations).
 
 ```{eval-rst}
 .. autofunction:: isend

--- a/docs/source/distributed.md
+++ b/docs/source/distributed.md
@@ -424,7 +424,6 @@ used to create new DeviceMesh, with a mesh shape describing the device topology.
     :members:
 ```
 
-(distributed-p2p)=
 ## Point-to-point communication
 
 ```{eval-rst}
@@ -435,6 +434,8 @@ used to create new DeviceMesh, with a mesh shape describing the device topology.
 .. autofunction:: recv
 ```
 
+(distributed-p2p)=
+### Asynchronous point-to-point operations
 {func}`~torch.distributed.isend` and {func}`~torch.distributed.irecv`
 return distributed request objects when used. In general, the type of this object is unspecified
 as they should never be created manually, but they are guaranteed to support two methods:
@@ -447,7 +448,7 @@ as they should never be created manually, but they are guaranteed to support two
   is specified, or if `TORCH_NCCL_BLOCKING_WAIT=1`, `wait()` blocks the CPU thread until
   completion or timeout.
   Also see
-  [Synchronous and asynchronous collective operations](#synchronous-and-asynchronous-collective-operations).
+  [Synchronous and asynchronous collective operations](#distributed-async-collectives).
 
 ```{eval-rst}
 .. autofunction:: isend
@@ -473,6 +474,7 @@ as they should never be created manually, but they are guaranteed to support two
 .. autoclass:: P2POp
 ```
 
+(distributed-async-collectives)=
 ## Synchronous and asynchronous collective operations
 
 Every collective operation function supports the following two kinds of operations,

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -2532,6 +2532,11 @@ def isend(
     """
     Send a tensor asynchronously.
 
+    .. note::
+        For CUDA tensors with the NCCL backend, the returned :class:`~torch.distributed.Work`
+        object provides CUDA stream synchronization; It may not block the CPU thread by default.
+        See :ref:`distributed-p2p` for details.
+
     .. warning::
         Modifying ``tensor`` before the request completes causes undefined
         behavior.
@@ -2588,6 +2593,11 @@ def irecv(
 ) -> Work | None:
     """
     Receives a tensor asynchronously.
+
+    .. note::
+        For CUDA tensors with the NCCL backend, the returned :class:`~torch.distributed.Work`
+        object provides CUDA stream synchronization; It may not block the CPU thread by default.
+        See :ref:`distributed-p2p` for details.
 
     .. warning::
         ``tag`` is not supported with the NCCL backend.
@@ -2647,6 +2657,11 @@ def send(
     """
     Send a tensor synchronously.
 
+    .. note::
+        For CUDA tensors with the NCCL backend, "synchronous" refers to CUDA stream
+        synchronization rather than blocking the CPU thread. The Python call may
+        return before GPU communication has completed. See :ref:`distributed-p2p` for details.
+
     .. warning::
         ``tag`` is not supported with the NCCL backend.
 
@@ -2690,6 +2705,11 @@ def recv(
 ) -> int:
     """
     Receives a tensor synchronously.
+
+    .. note::
+        For CUDA tensors with the NCCL backend, "synchronous" refers to CUDA stream
+        synchronization rather than blocking the CPU thread. The Python call may
+        return before GPU communication has completed. See :ref:`distributed-p2p` for details.
 
     .. warning::
         ``tag`` is not supported with the NCCL backend.


### PR DESCRIPTION
This PR clarifies the semantics of point-to-point ops (`send/recv/isend/irecv`) and `Work.wait()` when using CUDA tensors with the NCCL backend.

Today the API docs describe these ops as "synchronous" / "asynchronous", which is easy to misinterpret as CPU-thread blocking. In practice, for CUDA+NCCL the operations are typically stream-synchronous and the Python call (and `Work.wait()` by default) may return without blocking the CPU thread, which has caused confusion for me and other users. See #129341

Changes:

* Add a dedicated note in the point-to-point communication section explaining `Work.wait()` behavior for CPU vs CUDA/NCCL.
* Add cross-referencing `.. note::` blocks to `send/recv/isend/irecv` docstrings pointing readers to the detailed P2P semantics section.
No functional / runtime behavior changes; documentation-only.
