### PR TITLE
[Pytorch][Kineto] Expose comms_id in traces

### DIFF
--- a/test/cpp/profiler/comms_id.cpp
+++ b/test/cpp/profiler/comms_id.cpp
@@ -1,0 +1,188 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gtest/gtest.h>
+
+#include <c10/util/ThreadLocalDebugInfo.h>
+#include <c10/util/hash.h>
+#include <torch/csrc/distributed/c10d/ParamCommsUtils.hpp>
+#include <torch/csrc/profiler/util.h>
+
+using torch::ParamCommsDebugInfo;
+using namespace torch::profiler::impl;
+
+namespace {
+
+ParamCommsDebugInfo makeDebugInfo(
+    const std::string& pgName,
+    const std::string& pgDesc,
+    int rank,
+    std::string collName,
+    int worldSize,
+    int64_t seqNumber,
+    bool isP2P,
+    int globalRankStart = 0,
+    int globalRankStride = 1) {
+  return ParamCommsDebugInfo(
+      std::make_tuple(pgName, pgDesc),
+      rank,
+      std::move(collName),
+      /*inNelems=*/1024,
+      /*outNelems=*/1024,
+      /*dType=*/at::kFloat,
+      /*inSplitSizes=*/std::vector<int64_t>{},
+      /*outSplitSizes=*/std::vector<int64_t>{},
+      globalRankStart,
+      globalRankStride,
+      worldSize,
+      /*isAsynchronizedOp=*/true,
+      seqNumber,
+      isP2P);
+}
+
+size_t computeExpectedCommsId(
+    const std::string& pgName,
+    int64_t seqNumber,
+    bool isP2P,
+    int globalRankStart = 0,
+    int globalRankStride = 1,
+    int worldSize = 8) {
+  return c10::get_hash(
+      pgName, seqNumber, isP2P, globalRankStart, globalRankStride, worldSize);
+}
+
+} // namespace
+
+TEST(CommsIdTest, ParamCommsDebugInfoStoresSeqNumberAndIsP2P) {
+  auto info =
+      makeDebugInfo("pg_uid_123", "default_pg", 0, "allreduce", 8, 42, false);
+
+  EXPECT_EQ(info.getSeqNumber(), 42);
+  EXPECT_FALSE(info.isP2P());
+  EXPECT_EQ(info.getProcessGroupName(), "pg_uid_123");
+  EXPECT_EQ(info.getCollectiveName(), "allreduce");
+  EXPECT_EQ(info.getWorldSize(), 8);
+}
+
+TEST(CommsIdTest, ParamCommsDebugInfoP2PFlag) {
+  auto info =
+      makeDebugInfo("pg_uid_456", "custom_pg", 3, "send", 4, 7, true);
+
+  EXPECT_EQ(info.getSeqNumber(), 7);
+  EXPECT_TRUE(info.isP2P());
+}
+
+TEST(CommsIdTest, ParamCommsDebugInfoDefaultSeqNumberAndIsP2P) {
+  auto info = ParamCommsDebugInfo(
+      std::make_tuple(std::string("pg_uid_789"), std::string("default_pg")),
+      /*rank=*/1,
+      /*collName=*/std::string("allgather"),
+      /*inNelems=*/256,
+      /*outNelems=*/512,
+      /*dType=*/at::kFloat,
+      /*inSplitSizes=*/std::vector<int64_t>{},
+      /*outSplitSizes=*/std::vector<int64_t>{},
+      /*globalRankStart=*/0,
+      /*globalRankStride=*/1,
+      /*worldSize=*/2);
+
+  EXPECT_EQ(info.getSeqNumber(), 0);
+  EXPECT_FALSE(info.isP2P());
+}
+
+TEST(CommsIdTest, SaveNcclMetaEmitsCommsId) {
+  auto debugInfo = std::make_shared<ParamCommsDebugInfo>(
+      std::make_tuple(std::string("pg_uid_123"), std::string("default_pg")),
+      /*rank=*/0,
+      /*collName=*/std::string("allreduce"),
+      /*inNelems=*/1024,
+      /*outNelems=*/1024,
+      /*dType=*/at::kFloat,
+      /*inSplitSizes=*/std::vector<int64_t>{},
+      /*outSplitSizes=*/std::vector<int64_t>{},
+      /*globalRankStart=*/0,
+      /*globalRankStride=*/1,
+      /*worldSize=*/8,
+      /*isAsynchronizedOp=*/true,
+      /*seqNumber=*/int64_t(42),
+      /*isP2P=*/false);
+
+  c10::DebugInfoGuard guard(
+      c10::DebugInfoKind::PARAM_COMMS_INFO, debugInfo);
+
+  // Create a dummy RecordFunction to pass to saveNcclMeta
+  at::RecordFunction fn(at::RecordScope::USER_SCOPE);
+  fn._setAsync();
+
+  auto meta = saveNcclMeta(fn);
+
+  // Verify comms_id is in the metadata
+  ASSERT_TRUE(meta.count(kCommsId) > 0);
+
+  // Verify the comms_id value matches
+  // hash(pg_name, seqNumber, isP2P, globalRankStart, globalRankStride,
+  // worldSize)
+  size_t expected_comms_id = computeExpectedCommsId(
+      "pg_uid_123", int64_t(42), false, /*globalRankStart=*/0,
+      /*globalRankStride=*/1, /*worldSize=*/8);
+  EXPECT_EQ(meta.at(kCommsId), std::to_string(expected_comms_id));
+}
+
+TEST(CommsIdTest, CommsIdDeterministicAcrossInstances) {
+  std::string pg_name = "pg_uid_shared";
+  int64_t seq = 100;
+
+  size_t comms_id_1 = computeExpectedCommsId(pg_name, seq, false);
+  size_t comms_id_2 = computeExpectedCommsId(pg_name, seq, false);
+
+  EXPECT_EQ(comms_id_1, comms_id_2);
+}
+
+TEST(CommsIdTest, CommsIdDiffersForDifferentSeqNumbers) {
+  std::string pg_name = "pg_uid_shared";
+
+  size_t comms_id_seq1 = computeExpectedCommsId(pg_name, int64_t(1), false);
+  size_t comms_id_seq2 = computeExpectedCommsId(pg_name, int64_t(2), false);
+
+  EXPECT_NE(comms_id_seq1, comms_id_seq2);
+}
+
+TEST(CommsIdTest, CommsIdDiffersForDifferentPGNames) {
+  int64_t seq = 42;
+
+  size_t comms_id_pg1 = computeExpectedCommsId("pg_uid_A", seq, false);
+  size_t comms_id_pg2 = computeExpectedCommsId("pg_uid_B", seq, false);
+
+  EXPECT_NE(comms_id_pg1, comms_id_pg2);
+}
+
+TEST(CommsIdTest, CommsIdDiffersForP2PvsCollective) {
+  std::string pg_name = "pg_uid_shared";
+  int64_t seq = 42;
+
+  size_t comms_id_collective = computeExpectedCommsId(pg_name, seq, false);
+  size_t comms_id_p2p = computeExpectedCommsId(pg_name, seq, true);
+
+  EXPECT_NE(comms_id_collective, comms_id_p2p);
+}
+
+TEST(CommsIdTest, CommsIdDiffersForDifferentCommunicatorTopology) {
+  std::string pg_name = "pg_uid_shared";
+  int64_t seq = 42;
+
+  // Same PG name and seq, but different communicator topology
+  // (e.g., after comm split producing different rank subsets)
+  size_t comms_id_full =
+      computeExpectedCommsId(pg_name, seq, false, 0, 1, 8);
+  size_t comms_id_split =
+      computeExpectedCommsId(pg_name, seq, false, 0, 1, 4);
+
+  EXPECT_NE(comms_id_full, comms_id_split);
+
+  // Different globalRankStart (different subset of ranks)
+  size_t comms_id_start0 =
+      computeExpectedCommsId(pg_name, seq, false, 0, 2, 4);
+  size_t comms_id_start1 =
+      computeExpectedCommsId(pg_name, seq, false, 1, 2, 4);
+
+  EXPECT_NE(comms_id_start0, comms_id_start1);
+}

--- a/torch/csrc/distributed/c10d/ParamCommsUtils.cpp
+++ b/torch/csrc/distributed/c10d/ParamCommsUtils.cpp
@@ -19,7 +19,9 @@ ParamCommsDebugInfo::ParamCommsDebugInfo(
     int globalRankStart,
     int globalRankStride,
     int worldSize,
-    bool isAsynchronizedOp)
+    bool isAsynchronizedOp,
+    int64_t seqNumber,
+    bool isP2P)
     : pgName_(std::move(pgName)),
       rank_(rank),
       worldSize_(worldSize),
@@ -31,6 +33,8 @@ ParamCommsDebugInfo::ParamCommsDebugInfo(
       outputSplitSizes_(std::move(outSplitSizes)),
       globalRankStart_(globalRankStart),
       globalRankStride_(globalRankStride),
+      seqNumber_(seqNumber),
+      isP2P_(isP2P),
       isAsynchronizedOp_(isAsynchronizedOp) {
   if (globalRankStride > 0) {
     for (int i = 0; i < worldSize; i++) {

--- a/torch/csrc/distributed/c10d/ParamCommsUtils.hpp
+++ b/torch/csrc/distributed/c10d/ParamCommsUtils.hpp
@@ -24,7 +24,9 @@ class TORCH_API ParamCommsDebugInfo : public c10::DebugInfoBase {
       int globalRankStart,
       int globalRankStride,
       int worldSize,
-      bool isAsynchronizedOp = true);
+      bool isAsynchronizedOp = true,
+      int64_t seqNumber = 0,
+      bool isP2P = false);
 
   ~ParamCommsDebugInfo() override = default;
 
@@ -84,6 +86,14 @@ class TORCH_API ParamCommsDebugInfo : public c10::DebugInfoBase {
     return isAsynchronizedOp_;
   }
 
+  int64_t getSeqNumber() const {
+    return seqNumber_;
+  }
+
+  bool isP2P() const {
+    return isP2P_;
+  }
+
  private:
   std::tuple<std::string, std::string> pgName_; // <group_name, group_desc>
   int rank_{};
@@ -96,6 +106,8 @@ class TORCH_API ParamCommsDebugInfo : public c10::DebugInfoBase {
   std::vector<int64_t> outputSplitSizes_;
   int globalRankStart_{};
   int globalRankStride_{};
+  int64_t seqNumber_{0};
+  bool isP2P_{false};
   std::vector<int64_t> groupRanks_;
   bool isAsynchronizedOp_{};
 };
@@ -125,7 +137,9 @@ class TORCH_API ParamCommsDebugInfo : public c10::DebugInfoBase {
       globalRankStart,                                                         \
       globalRankStride,                                                        \
       worldSize,                                                               \
-      false);                                                                  \
+      false,                                                                   \
+      std::get<0>(seq),                                                        \
+      std::get<1>(seq));                                                       \
   c10::DebugInfoGuard g(c10::DebugInfoKind::PARAM_COMMS_INFO, paramCommsInfo); \
   std::initializer_list<const c10::IValue> paramList = {                       \
       seq,                                                                     \
@@ -201,7 +215,9 @@ class TORCH_API ParamCommsDebugInfo : public c10::DebugInfoBase {
       globalRankStart,                                                         \
       globalRankStride,                                                        \
       worldSize,                                                               \
-      isAsyncOp);                                                              \
+      isAsyncOp,                                                               \
+      std::get<0>(seq),                                                        \
+      std::get<1>(seq));                                                       \
   c10::DebugInfoGuard g(c10::DebugInfoKind::PARAM_COMMS_INFO, paramCommsInfo); \
   std::initializer_list<const c10::IValue> paramList = {                       \
       c10::IValue(InputTensors),                                               \

--- a/torch/csrc/profiler/util.cpp
+++ b/torch/csrc/profiler/util.cpp
@@ -509,6 +509,18 @@ std::unordered_map<std::string, std::string> saveNcclMeta(
         map.emplace(kP2pSrc, std::to_string(groupRanks[rank]));
       }
     }
+
+    auto seqNumber = debugInfo->getSeqNumber();
+    auto isP2P = debugInfo->isP2P();
+    const auto& group_name_for_hash = debugInfo->getProcessGroupName();
+    size_t comms_id = c10::get_hash(
+        group_name_for_hash,
+        seqNumber,
+        isP2P,
+        globalRankStart,
+        globalRankStride,
+        debugInfo->getWorldSize());
+    map.emplace(kCommsId, std::to_string(comms_id));
   }
 
   map.emplace(

--- a/torch/csrc/profiler/util.h
+++ b/torch/csrc/profiler/util.h
@@ -204,6 +204,7 @@ constexpr auto kP2pDst = "Dst Rank";
 constexpr auto kInTensorsStart = "Input Tensors start";
 constexpr auto kOutTensorsStart = "Output Tensors start";
 constexpr auto kIsAsynchronizedOp = "Is asynchronized op";
+constexpr auto kCommsId = "Comms Id";
 #endif // USE_DISTRIBUTED
 
 } // namespace torch::profiler::impl


### PR DESCRIPTION
Summary:
# Context

Add a comms_id to PyTorch profiler traces that uniquely identifies each collective/P2P       
communication operation across all ranks. This enables trace analysis tools (e.g., Holistic
Trace Analysis) to correlate the same operation across different ranks for debugging
distributed training performance.

How comms_id is computed

comms_id = hash(pg_name, seqNumber, isP2P, globalRankStart, globalRankStride, worldSize)

  - pg_name — identifies the process group
  - seqNumber — per-PG operation counter, identifies which operation within the PG
  - isP2P — distinguishes P2P ops (send/recv) from collectives (allreduce, etc.), since they
 
use separate sequence number counters
- globalRankStart, globalRankStride, worldSize — encodes the communicator topology,
  disambiguating cases where one PG creates multiple communicators (e.g., comm splits)

 Changes by layer

 1. Data model (ParamCommsUtils.hpp/.cpp) — Added seqNumber, isP2P fields to ParamCommsDebugInfo, the class that carries communication metadata through the profiling stack.
 2. Hash computation (profiler/util.cpp/.h) — In saveNcclMeta(), computes comms_id from the 6 fields above and emits it as "Comms Id" in the profiler metadata map.
3. Trace output (output_json.cpp) — Kineto reads "Comms Id" from the metadata and writes it into the Chrome trace JSON, making it visible in trace viewers.
4. Tests (comms_id.cpp, CuptiActivityProfilerTest.cpp) — 9 unit tests covering:
  - Storage/retrieval of seqNumber and isP2P
  - Default values
  - End-to-end: comms_id appears in saveNcclMeta() output with correct hash
  - Determinism across instances
  - Uniqueness across different PG names, sequence numbers, P2P vs collective, and communicator topologies

Test Plan: 1. added unit tests

Differential Revision: D95659539


