### PR TITLE
[ROCm] No fence optimization to jit reduce template.

### DIFF
--- a/aten/src/ATen/native/cuda/reduction_template.cuh
+++ b/aten/src/ATen/native/cuda/reduction_template.cuh
@@ -43,6 +43,43 @@ const std::string reduction_template_0 = R"ESCAPE(
     scalar_t val[vec_size];
   };
 
+  #ifdef USE_ROCM
+  // This function implements a committed store.
+  // Upon returning, the store is committed to global memory.
+  // This is useful in avoiding the need for fences.
+  template <typename T>
+  __device__ inline void cmtdStore(void* address, T value) {
+        int constexpr num_long_per_val = sizeof(value)/sizeof(long);
+        int constexpr num_int_per_val = sizeof(value)/sizeof(int);
+        int constexpr num_short_per_val = sizeof(value)/sizeof(short);
+        int constexpr num_char_per_val = sizeof(value)/sizeof(char);
+        union pnr { T v;
+                    long l[num_long_per_val];
+                    int i[num_int_per_val];
+                    short s[num_short_per_val];
+                    char c[num_char_per_val]; }
+              _pnr = {.v = value };
+        if constexpr (num_long_per_val*sizeof(long) == sizeof(value))
+          for (int i=0; i<num_long_per_val; i++)
+            __hip_atomic_store(reinterpret_cast<long *>(address)+i, _pnr.l[i], __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+        else if constexpr (num_int_per_val*sizeof(int) == sizeof(value))
+          for (int i=0; i<num_int_per_val; i++)
+            __hip_atomic_store(reinterpret_cast<int *>(address)+i, _pnr.i[i], __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+        else if constexpr (num_short_per_val*sizeof(short) == sizeof(value))
+          for (int i=0; i<num_short_per_val; i++)
+            __hip_atomic_store(reinterpret_cast<short *>(address)+i, _pnr.s[i], __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+        else if constexpr (num_char_per_val*sizeof(char) == sizeof(value))
+          for (int i=0; i<num_char_per_val; i++)
+            __hip_atomic_store(reinterpret_cast<char *>(address)+i, _pnr.c[i], __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+        __atomic_signal_fence(__ATOMIC_SEQ_CST);
+  #ifdef __gfx1250__
+        asm volatile("s_wait_loadcnt(0)" ::: "memory");
+  #else
+        asm volatile("s_waitcnt vmcnt(0)" ::: "memory");
+  #endif
+        __atomic_signal_fence(__ATOMIC_SEQ_CST);
+  }
+  #endif
 
   C10_HOST_DEVICE static void reduce_fraction(size_t &numerator, size_t &denominator) {
     // get GCD of num and denom using Euclid's algorithm.
@@ -588,17 +625,27 @@ struct ReduceJitOp {
     }
 
     bool should_store = config.should_store(output_idx);
-    if (should_store) {
+    if (should_store) {    
       uint32_t offset = config.staging_memory_offset(blockIdx.y);
+#ifndef USE_ROCM
       reduce_buffer[offset] = value;
+#else // [CMTSTRS]
+      // In architectures with split caches, global fences are costly.
+      // Here we preempt need for fences by committing stores to global memory.
+      cmtdStore(&reduce_buffer[offset], value);
+#endif
     }
 
+  #ifndef USE_ROCM // skip fence if store are committed [CMTSTRS]  
     __threadfence(); // make sure writes are globally visible
+  #endif
     __syncthreads(); // if multiple warps in this block wrote to staging, make sure they're all done
     bool is_last_block_done = mark_block_finished();
 
     if (is_last_block_done) {
+  #ifndef USE_ROCM // skip fence if store are committed [CMTSTRS]   
       __threadfence(); //complete acquire pattern
+  #endif
       value = ident;
       if (config.should_block_x_reduce()) {
         uint32_t input_offset = threadIdx.x + threadIdx.y * blockDim.x;

--- a/aten/src/ATen/native/cuda/reduction_template.cuh
+++ b/aten/src/ATen/native/cuda/reduction_template.cuh
@@ -625,7 +625,7 @@ struct ReduceJitOp {
     }
 
     bool should_store = config.should_store(output_idx);
-    if (should_store) {    
+    if (should_store) {
       uint32_t offset = config.staging_memory_offset(blockIdx.y);
 #ifndef USE_ROCM
       reduce_buffer[offset] = value;

--- a/aten/src/ATen/native/cuda/reduction_template.cuh
+++ b/aten/src/ATen/native/cuda/reduction_template.cuh
@@ -43,43 +43,6 @@ const std::string reduction_template_0 = R"ESCAPE(
     scalar_t val[vec_size];
   };
 
-  #ifdef USE_ROCM
-  // This function implements a committed store.
-  // Upon returning, the store is committed to global memory.
-  // This is useful in avoiding the need for fences.
-  template <typename T>
-  __device__ inline void cmtdStore(void* address, T value) {
-        int constexpr num_long_per_val = sizeof(value)/sizeof(long);
-        int constexpr num_int_per_val = sizeof(value)/sizeof(int);
-        int constexpr num_short_per_val = sizeof(value)/sizeof(short);
-        int constexpr num_char_per_val = sizeof(value)/sizeof(char);
-        union pnr { T v;
-                    long l[num_long_per_val];
-                    int i[num_int_per_val];
-                    short s[num_short_per_val];
-                    char c[num_char_per_val]; }
-              _pnr = {.v = value };
-        if constexpr (num_long_per_val*sizeof(long) == sizeof(value))
-          for (int i=0; i<num_long_per_val; i++)
-            __hip_atomic_store(reinterpret_cast<long *>(address)+i, _pnr.l[i], __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-        else if constexpr (num_int_per_val*sizeof(int) == sizeof(value))
-          for (int i=0; i<num_int_per_val; i++)
-            __hip_atomic_store(reinterpret_cast<int *>(address)+i, _pnr.i[i], __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-        else if constexpr (num_short_per_val*sizeof(short) == sizeof(value))
-          for (int i=0; i<num_short_per_val; i++)
-            __hip_atomic_store(reinterpret_cast<short *>(address)+i, _pnr.s[i], __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-        else if constexpr (num_char_per_val*sizeof(char) == sizeof(value))
-          for (int i=0; i<num_char_per_val; i++)
-            __hip_atomic_store(reinterpret_cast<char *>(address)+i, _pnr.c[i], __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-        __atomic_signal_fence(__ATOMIC_SEQ_CST);
-  #ifdef __gfx1250__
-        asm volatile("s_wait_loadcnt(0)" ::: "memory");
-  #else
-        asm volatile("s_waitcnt vmcnt(0)" ::: "memory");
-  #endif
-        __atomic_signal_fence(__ATOMIC_SEQ_CST);
-  }
-  #endif
 
   C10_HOST_DEVICE static void reduce_fraction(size_t &numerator, size_t &denominator) {
     // get GCD of num and denom using Euclid's algorithm.
@@ -607,6 +570,49 @@ struct ReduceJitOp {
     }
   }
 
+  #ifdef USE_ROCM
+  // This function implements a committed store.
+  // Upon returning, the store is committed to global memory.
+  // This is useful in avoiding the need for fences.
+  // If multiple stores are done in a row there is option to skip
+  // waiting for commit for all but the last store.
+  template <typename T, bool wait_for_commit = true>
+  __device__ inline void cmtdStore(void* address, T value) {
+        int constexpr num_long_per_val = sizeof(value)/sizeof(long);
+        int constexpr num_int_per_val = sizeof(value)/sizeof(int);
+        int constexpr num_short_per_val = sizeof(value)/sizeof(short);
+        int constexpr num_char_per_val = sizeof(value)/sizeof(char);
+        union pnr { T v;
+                    long l[num_long_per_val];
+                    int i[num_int_per_val];
+                    short s[num_short_per_val];
+                    char c[num_char_per_val]; }
+              _pnr = {.v = value };
+        if constexpr (num_long_per_val*sizeof(long) == sizeof(value))
+          for (int i=0; i<num_long_per_val; i++)
+            __hip_atomic_store(reinterpret_cast<long *>(address)+i, _pnr.l[i], __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+        else if constexpr (num_int_per_val*sizeof(int) == sizeof(value))
+          for (int i=0; i<num_int_per_val; i++)
+            __hip_atomic_store(reinterpret_cast<int *>(address)+i, _pnr.i[i], __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+        else if constexpr (num_short_per_val*sizeof(short) == sizeof(value))
+          for (int i=0; i<num_short_per_val; i++)
+            __hip_atomic_store(reinterpret_cast<short *>(address)+i, _pnr.s[i], __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+        else if constexpr (num_char_per_val*sizeof(char) == sizeof(value))
+          for (int i=0; i<num_char_per_val; i++)
+            __hip_atomic_store(reinterpret_cast<char *>(address)+i, _pnr.c[i], __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+        if constexpr (wait_for_commit)
+        {
+          __atomic_signal_fence(__ATOMIC_SEQ_CST);
+  #ifdef __gfx1250__
+          asm volatile("s_wait_loadcnt(0)" ::: "memory");
+  #else
+          asm volatile("s_waitcnt vmcnt(0)" ::: "memory");
+  #endif
+          __atomic_signal_fence(__ATOMIC_SEQ_CST);
+        }
+  }
+  #endif
+
   template <int output_vec_size>
   C10_DEVICE Array<arg_t, output_vec_size> global_reduce(Array<arg_t, output_vec_size> value, Array<arg_t, output_vec_size> *acc, char* shared_memory) const {
     using arg_vec_t = Array<arg_t, output_vec_size>;
@@ -627,13 +633,13 @@ struct ReduceJitOp {
     bool should_store = config.should_store(output_idx);
     if (should_store) {
       uint32_t offset = config.staging_memory_offset(blockIdx.y);
-#ifndef USE_ROCM
+  #ifndef USE_ROCM
       reduce_buffer[offset] = value;
-#else // [CMTSTRS]
+  #else // [CMTSTRS]
       // In architectures with split caches, global fences are costly.
       // Here we preempt need for fences by committing stores to global memory.
       cmtdStore(&reduce_buffer[offset], value);
-#endif
+  #endif // [CMTSTRS]
     }
 
   #ifndef USE_ROCM // skip fence if store are committed [CMTSTRS]  

--- a/aten/src/ATen/native/cuda/reduction_template.cuh
+++ b/aten/src/ATen/native/cuda/reduction_template.cuh
@@ -642,14 +642,14 @@ struct ReduceJitOp {
   #endif // [CMTSTRS]
     }
 
-  #ifndef USE_ROCM // skip fence if store are committed [CMTSTRS]  
+  #ifndef USE_ROCM // skip fence if store are committed [CMTSTRS]
     __threadfence(); // make sure writes are globally visible
   #endif
     __syncthreads(); // if multiple warps in this block wrote to staging, make sure they're all done
     bool is_last_block_done = mark_block_finished();
 
     if (is_last_block_done) {
-  #ifndef USE_ROCM // skip fence if store are committed [CMTSTRS]   
+  #ifndef USE_ROCM // skip fence if store are committed [CMTSTRS]
       __threadfence(); //complete acquire pattern
   #endif
       value = ident;

--- a/aten/src/ATen/native/cuda/reduction_template.cuh
+++ b/aten/src/ATen/native/cuda/reduction_template.cuh
@@ -4,6 +4,7 @@ const std::string reduction_template_0 = R"ESCAPE(
   #define C10_HOST_DEVICE __host__ __device__
   #define C10_DEVICE __device__
   #if defined(__clang__) && defined(__HIP__)
+  #define USE_ROCM 1
   #ifndef __forceinline__
   #define __forceinline__ inline __attribute__((always_inline))
   #endif
@@ -577,7 +578,7 @@ struct ReduceJitOp {
   // If multiple stores are done in a row there is option to skip
   // waiting for commit for all but the last store.
   template <typename T, bool wait_for_commit = true>
-  __device__ inline void cmtdStore(void* address, T value) {
+  __device__ inline void cmtdStore(void* address, T value) const {
         int constexpr num_long_per_val = sizeof(value)/sizeof(long);
         int constexpr num_int_per_val = sizeof(value)/sizeof(int);
         int constexpr num_short_per_val = sizeof(value)/sizeof(short);


### PR DESCRIPTION
Removing need for fences in normalization kernel by converting the stores into atomics+return. This is crucial for perf in architectures with split caches (e.g. MI300), where fences are inherently costly.

Reproducer:

```
import torch

shapes = [(4096, 8192)]


for shape in shapes:
    lo, hi = 0.999, 1.001
    x = lo + (hi - lo) * torch.randn(shape, device='cuda', dtype=torch.torch.float32)
    for _ in range(20):
        _ = torch.prod(x)
    torch.cuda.synchronize()

    start_evt = torch.cuda.Event(enable_timing=True)
    end_evt = torch.cuda.Event(enable_timing=True)
    start_evt.record()
    for _ in range(100):
        _ = torch.prod(x)
    end_evt.record()
    torch.cuda.synchronize()
    print(f"Avg time for shape {shape}: {start_evt.elapsed_time(end_evt) / 100 * 1e3:.2f} us")
```
**Before:**
Avg time for shape (4096, 8192): **112.59 us**
**After:**
Avg time for shape (4096, 8192): **41.05 us**


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang