### PR TITLE
Fix Pallas sign to match PyTorch NaN semantics

### DIFF
--- a/test/inductor/pallas_expected_failures/CpuTests.test_sgn_extremal_cpu
+++ b/test/inductor/pallas_expected_failures/CpuTests.test_sgn_extremal_cpu
@@ -1,5 +1,0 @@
-FAIL
-           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  File "/home/oulgen/dev/pytorch/torch/testing/_internal/common_utils.py", line 4280, in assertEqual
-    raise error_metas.pop()[0].to_error(  # type: ignore[index]
-AssertionError: Tensor-likes are not close!

--- a/torch/_inductor/codegen/pallas.py
+++ b/torch/_inductor/codegen/pallas.py
@@ -429,7 +429,8 @@ class PallasKernelOverrides(OpOverrides):
     # Sign operations
     @staticmethod
     def sign(x: str) -> str:
-        return f"jnp.sign({x})"
+        # PyTorch returns 0 for NaN, JAX returns NaN
+        return f"jnp.where(jnp.isnan({x}), 0.0, jnp.sign({x}))"
 
     @staticmethod
     def signbit(x: str) -> str:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #176814
* #176813



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo