### PR TITLE
[CI] Remove duplicate openreg test on linux-aarch64 m8g runner

### DIFF
--- a/.github/workflows/linux-aarch64.yml
+++ b/.github/workflows/linux-aarch64.yml
@@ -44,7 +44,6 @@ jobs:
           { config: "default", shard: 1, num_shards: 3, runner: "${{ needs.get-label-type.outputs.label-type }}linux.arm64.m8g.4xlarge" },
           { config: "default", shard: 2, num_shards: 3, runner: "${{ needs.get-label-type.outputs.label-type }}linux.arm64.m8g.4xlarge" },
           { config: "default", shard: 3, num_shards: 3, runner: "${{ needs.get-label-type.outputs.label-type }}linux.arm64.m8g.4xlarge" },
-          { config: "openreg", shard: 1, num_shards: 1, runner: "${{ needs.get-label-type.outputs.label-type }}linux.arm64.m8g.4xlarge" },
         ]}
     secrets: inherit
 


### PR DESCRIPTION
## Summary

The `openreg` test config runs identically on both `m7g.4xlarge` and `m8g.4xlarge` ARM runners in the `linux-aarch64` workflow. When not skipped by target determination, it consistently times out at ~215 minutes (it builds a C++ extension from source on ARM, which is inherently slow).

This means every `linux-aarch64` CI run has **two copies** of the same test that both timeout — wasting ~430 runner-minutes per run with zero additional signal.

**Fix:** Remove the duplicate `m8g.4xlarge` openreg entry. The m7g entry provides identical test coverage.

**Impact:** ~6,450 runner-minutes/day of wasted compute eliminated (50% reduction of openreg timeout waste).

## Evidence

Sampled 13 recent trunk runs — openreg times out ~100% of the time when not skipped by TD:

| Run ID | Runner | Duration | Result |
|--------|--------|----------|--------|
| 22663208848 | m8g | 3h 35m | TIMEOUT |
| 22742959229 | m8g | 3h 34m | TIMEOUT |
| 22742689281 | m7g | 3h 35m | TIMEOUT |
| 22741272513 | m8g | 3h 34m | TIMEOUT |
| 22741272513 | m7g | 3h 35m | TIMEOUT |

## Test plan
- [ ] Verify linux-aarch64 workflow still runs default shards (3 per runner type) correctly
- [ ] Verify openreg still runs on m7g runner
- [ ] Monitor for 2-3 trunk commits to confirm no regressions