### PR TITLE
Fix CUDA allocator SIOF causing `torch.accelerator` API failures

### DIFF
--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -4809,7 +4809,7 @@ struct BackendStaticInitializer {
 // initialization, and doing so there may introduce static initialization
 // order (SIOF) issues.
 #define HIP_MASQUERADING_AS_CUDA "cuda"
-    at::SetAllocator(c10::Device(HIP_MASQUERADING_AS_CUDA).type(), r, 0);
+    at::SetAllocator(c10::Device(HIP_MASQUERADING_AS_CUDA).type(), r, 1);
     allocator.store(r);
 #undef HIP_MASQUERADING_AS_CUDA
   }


### PR DESCRIPTION
Summary:
The `CUDACachingAllocator` (a `DeviceAllocator`) and Caffe2's legacy
`DefaultCUDAAllocator` (a plain `Allocator`) both registered for
`DeviceType::CUDA` at priority 0. Since `SetAllocator` uses `>=` comparison,
whichever static initializer ran last would win. When the legacy
allocator won the race, `dynamic_cast<DeviceAllocator*>` in
`getDeviceAllocator()` would fail, crashing `torch.accelerator.empty_cache()`
and other `torch.accelerator` APIs. To be clear, this is not an issue in
pure OSS PyTorch, where the Caffe2 legacy CUAD allocator does not exist.

Fix by bumping `CUDACachingAllocator`'s registration priority to 1 so it
always takes precedence over the legacy Caffe2 allocator regardless of
static initialization order.

This SIOF surfaced recently in vLLM after some code was generalized to use
`torch.accelerator.empty_cache()` instead of `torch.cuda.empty_cache()` in
https://github.com/vllm-project/vllm/pull/30681.

Test Plan:
```
buck test fbcode//mode/opt fbcode//vllm/omni:test_kernels_rotary_embedding -- --exact 'fbcode//vllm/omni:test_kernels_rotary_embedding - test_rotary_embedding.py::test_rotary_embedding_opcheck[False-False-1024-108-32-True-11-cuda]'
```

Previously: 1 passed, 1 error (`RuntimeError` during teardown)
Now: 2 passed, 0 errors

Errors/stack traces like the following are resolved after this change:
```
    def empty_cache() -> None:
        r"""Release all unoccupied cached memory currently held by the caching
        allocator so that those can be used in other application.
    
        .. note:: This function is a no-op if the memory allocator for the current
            :ref:`accelerator <accelerators>` has not been initialized.
        """
>       if not torch._C._accelerator_isAllocatorInitialized():
E       RuntimeError: device_allocator INTERNAL ASSERT FAILED at "fbcode/caffe2/c10/core/CachingDeviceAllocator.h":253, please report a bug to PyTorch. Allocator for cuda is not a DeviceAllocator.
```

Differential Revision: D95703075


