### PR TITLE
[pytorch][profiler] Emit Input Strides metadata regardless of record_concrete_inputs setting (#176823)

### DIFF
--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -1439,6 +1439,32 @@ class TestProfiler(TestCase):
                     if e["name"] == "aten::add":
                         self.assertEqual(args["Input Strides"], [[17, 1], [25, 2], []])
 
+    def test_profiler_strides_without_concrete_inputs(self):
+        torch._C._profiler._set_record_concrete_inputs_enabled_val(False)
+        try:
+            base_tensor = torch.randn(1024, dtype=torch.float32)
+            a = base_tensor.as_strided((16, 16), (17, 1), 0)
+            b = base_tensor.as_strided((16, 16), (25, 2), 272)
+            with _profile(record_shapes=True) as prof:
+                c = torch.add(a, b)
+
+            with TemporaryFileName(mode="w+") as fname:
+                prof.export_chrome_trace(fname)
+                with open(fname) as f:
+                    j = json.load(f)
+                    op_events = [
+                        e for e in j["traceEvents"] if e.get("cat", "") == "cpu_op"
+                    ]
+                    for e in op_events:
+                        args = e["args"]
+                        if e["name"] == "aten::add":
+                            self.assertIn("Input Strides", args)
+                            self.assertEqual(
+                                args["Input Strides"], [[17, 1], [25, 2], []]
+                            )
+        finally:
+            torch._C._profiler._set_record_concrete_inputs_enabled_val(True)
+
     def test_profiler_fwd_bwd_link(self):
         with _profile(use_kineto=True) as prof:
             t1, t2 = (

--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -269,10 +269,10 @@ struct AddGenericMetadata : public MetadataBase {
     if (arg_data.hasData) {
       if (get_record_concrete_inputs_enabled()) {
         addMetadata("Input Dims", variantShapesToStr(arg_data.shapes));
-        addMetadata("Input Strides", variantShapesToStr(arg_data.strides));
       } else {
         addMetadata("Input Dims", shapesToStr(arg_data.shapesForKinetoEvent));
       }
+      addMetadata("Input Strides", variantShapesToStr(arg_data.strides));
       addMetadata("Input type", strListToStr(arg_data.dtypes));
       if (!arg_data.concreteInputs.empty()) {
         addMetadata(


### PR DESCRIPTION
Summary:

Previously, the "Input Strides" metadata was only added to profiler trace
events when `get_record_concrete_inputs_enabled()` returned true. However,
stride information comes from `TensorMetadata::strides_` which is populated
from `input_shapes`, not from concrete inputs. This meant strides were
silently dropped when concrete input recording was disabled.

Move the `addMetadata("Input Strides", ...)` call outside the
`get_record_concrete_inputs_enabled()` conditional so that stride
information is always emitted when shape data is available.

Test Plan:
Added `test_profiler_strides_without_concrete_inputs` which sets
`_set_record_concrete_inputs_enabled_val(False)`, profiles a `torch.add`
on tensors with custom strides, and verifies the exported chrome trace
contains the correct "Input Strides" metadata.

```
$ buck test fbcode//caffe2/test:profiler -- test_profiler_strides_without_concrete_inputs  # pass
# buck test fbcode//caffe2/test:profiler -- test_profiler_strides  # pass (no regression)
```

Reviewed By: leitian, echen4096, jhadidjojo

@diff-train-skip-merge
