### PR TITLE
Dynamo update frozen ctor bytecode gen to initialize attributes

### DIFF
--- a/test/dynamo/test_exceptions.py
+++ b/test/dynamo/test_exceptions.py
@@ -1,6 +1,7 @@
 # Owner(s): ["module: dynamo"]
 
 import contextlib
+import dataclasses
 import sys
 
 import torch
@@ -1026,6 +1027,24 @@ class ExceptionTests(torch._dynamo.test_case.TestCase):
         # The error should point to 'raise Exception("Invalid")' in g()
         self.assertIn("in g", str(ctx.exception))
         self.assertIn('raise Exception("Invalid")', str(ctx.exception))
+
+    def test_frozen_dataclass_setattr_raises(self):
+        @dataclasses.dataclass(frozen=True)
+        class TestDataClass:
+            x: int
+
+        @torch.compile(backend="eager", fullgraph=True)
+        def fn(t):
+            dc = TestDataClass(1)
+            try:
+                dc.x = 2
+            except dataclasses.FrozenInstanceError:
+                return t + 1
+            except Exception:
+                return t + 2
+            return t + dc.x
+
+        self.assertEqual(fn(torch.zeros(1)), 1)
 
 
 instantiate_parametrized_tests(ExceptionTests)

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -12197,22 +12197,6 @@ def ___make_guard_fn():
         for i in range(4):
             self.assertEqual(eager_result[i], compiled_result[i])
 
-    def test_frozen_dataclass_setattr_raises(self):
-        @dataclasses.dataclass(frozen=True)
-        class TestDataClass:
-            x: int
-
-        def fn(t):
-            dc = TestDataClass(1)
-            dc.x = 2
-            return t + dc.x
-
-        with self.assertRaises(dataclasses.FrozenInstanceError):
-            fn(torch.randn(4))
-
-        with self.assertRaises(torch._dynamo.exc.Unsupported):
-            torch.compile(fn, fullgraph=True)(torch.randn(4))
-
     def test_shape_env_no_recording(self):
         main = ShapeEnv(should_record_events=False)
 

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -12168,6 +12168,35 @@ def ___make_guard_fn():
         expected = fn(*inps)
         self.assertEqual(actual, expected)
 
+    def test_frozen_dataclass_in_compile(self):
+        from torch.utils._pytree import MappingKey, SequenceKey
+
+        def fn(x):
+            path = (MappingKey("a"), SequenceKey(0))
+            msg = f"path={path}"
+            return x * 2, msg
+
+        x = torch.randn(4, 4)
+        eager_result = fn(x)
+        compiled_result = torch.compile(fn, fullgraph=True)(x)
+        self.assertEqual(eager_result[0], compiled_result[0])
+        self.assertEqual(eager_result[1], compiled_result[1])
+
+    def test_frozen_dataclass_treespec_method_and_fields(self):
+        from torch.utils._pytree import tree_flatten
+
+        def fn(x):
+            d = {"a": x, "b": [x * 2, x * 3]}
+            flat, spec = tree_flatten(d)
+            is_leaf = spec.is_leaf()
+            return sum(flat), spec.num_leaves, spec.num_nodes, is_leaf
+
+        x = torch.randn(4)
+        eager_result = fn(x)
+        compiled_result = torch.compile(fn, fullgraph=True)(x)
+        for i in range(4):
+            self.assertEqual(eager_result[i], compiled_result[i])
+
     def test_shape_env_no_recording(self):
         main = ShapeEnv(should_record_events=False)
 

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -12197,6 +12197,22 @@ def ___make_guard_fn():
         for i in range(4):
             self.assertEqual(eager_result[i], compiled_result[i])
 
+    def test_frozen_dataclass_setattr_raises(self):
+        @dataclasses.dataclass(frozen=True)
+        class TestDataClass:
+            x: int
+
+        def fn(t):
+            dc = TestDataClass(1)
+            dc.x = 2
+            return t + dc.x
+
+        with self.assertRaises(dataclasses.FrozenInstanceError):
+            fn(torch.randn(4))
+
+        with self.assertRaises(torch._dynamo.exc.Unsupported):
+            torch.compile(fn, fullgraph=True)(torch.randn(4))
+
     def test_shape_env_no_recording(self):
         main = ShapeEnv(should_record_events=False)
 

--- a/torch/_dynamo/exc.py
+++ b/torch/_dynamo/exc.py
@@ -31,6 +31,7 @@ import logging
 import re
 import textwrap
 import typing
+from dataclasses import FrozenInstanceError
 from enum import auto, Enum
 from functools import lru_cache
 from pathlib import Path
@@ -399,6 +400,10 @@ class ObservedTypeError(ObservedException):
     # A TypeError exception to be raised from inside Dynamo tracing. This can happen on generator.send(..) method
     pass
 
+class ObservedFrozenInstanceError(ObservedException):
+    # A FrozenInstanceError exception to be raised from inside Dynamo tracing. This can happen on a frozen dataclass __getattr__ or __delattr__.
+    pass
+
 
 observed_exception_map = {
     StopIteration: ObservedUserStopIteration,
@@ -410,6 +415,7 @@ observed_exception_map = {
     RuntimeError: ObservedRuntimeError,
     NotImplementedError: ObservedNotImplementedError,
     TypeError: ObservedTypeError,
+    FrozenInstanceError: ObservedFrozenInstanceError,
 }
 
 

--- a/torch/_dynamo/exc.py
+++ b/torch/_dynamo/exc.py
@@ -31,7 +31,6 @@ import logging
 import re
 import textwrap
 import typing
-from dataclasses import FrozenInstanceError
 from enum import auto, Enum
 from functools import lru_cache
 from pathlib import Path
@@ -401,12 +400,6 @@ class ObservedTypeError(ObservedException):
     pass
 
 
-class ObservedFrozenInstanceError(ObservedException):
-    # A FrozenInstanceError exception to be raised from inside Dynamo tracing.
-    # This can happen on a frozen dataclass __getattr__ or __delattr__.
-    pass
-
-
 observed_exception_map = {
     StopIteration: ObservedUserStopIteration,
     LookupError: ObservedLookupError,
@@ -417,7 +410,6 @@ observed_exception_map = {
     RuntimeError: ObservedRuntimeError,
     NotImplementedError: ObservedNotImplementedError,
     TypeError: ObservedTypeError,
-    FrozenInstanceError: ObservedFrozenInstanceError,
 }
 
 

--- a/torch/_dynamo/exc.py
+++ b/torch/_dynamo/exc.py
@@ -400,8 +400,10 @@ class ObservedTypeError(ObservedException):
     # A TypeError exception to be raised from inside Dynamo tracing. This can happen on generator.send(..) method
     pass
 
+
 class ObservedFrozenInstanceError(ObservedException):
-    # A FrozenInstanceError exception to be raised from inside Dynamo tracing. This can happen on a frozen dataclass __getattr__ or __delattr__.
+    # A FrozenInstanceError exception to be raised from inside Dynamo tracing.
+    # This can happen on a frozen dataclass __getattr__ or __delattr__.
     pass
 
 

--- a/torch/_dynamo/side_effects.py
+++ b/torch/_dynamo/side_effects.py
@@ -1017,12 +1017,6 @@ class SideEffects:
 
         suffixes = []
         for var in self._get_modified_vars():
-            # These frozen attribute initializations are handled in codegen_save_tempvars
-            # and don't need to be reset in the suffix.
-            if isinstance(var.mutation_type, AttributeMutationNew) and isinstance(
-                var, variables.FrozenDataClassVariable
-            ):
-                continue
             # When replay_side_effects=False, only update variables with TempLocalSource
             if not config.replay_side_effects and not isinstance(
                 var.source, TempLocalSource
@@ -1204,6 +1198,12 @@ class SideEffects:
                         ]
                     )
                     _maybe_log_side_effect(var._dict_vt)
+                elif isinstance(var.mutation_type, AttributeMutationNew) and isinstance(
+                    var, variables.FrozenDataClassVariable
+                ):
+                    # These frozen attribute initializations are handled in codegen_save_tempvars
+                    # and don't need to be reset in the suffix.
+                    continue
                 elif isinstance(
                     var,
                     variables.UserDefinedListVariable,

--- a/torch/_dynamo/side_effects.py
+++ b/torch/_dynamo/side_effects.py
@@ -1143,7 +1143,13 @@ class SideEffects:
                     _maybe_log_side_effect(var)
 
             elif self.is_attribute_mutation(var):
-                if isinstance(
+                if isinstance(var.mutation_type, AttributeMutationNew) and isinstance(
+                    var, variables.FrozenDataClassVariable
+                ):
+                    # These frozen attribute initializations are handled in codegen_save_tempvars
+                    # and don't need to be reset in the suffix.
+                    continue
+                elif isinstance(
                     var,
                     variables.UserDefinedDictVariable,
                 ) and self.is_modified(var._dict_vt):
@@ -1198,12 +1204,6 @@ class SideEffects:
                         ]
                     )
                     _maybe_log_side_effect(var._dict_vt)
-                elif isinstance(var.mutation_type, AttributeMutationNew) and isinstance(
-                    var, variables.FrozenDataClassVariable
-                ):
-                    # These frozen attribute initializations are handled in codegen_save_tempvars
-                    # and don't need to be reset in the suffix.
-                    continue
                 elif isinstance(
                     var,
                     variables.UserDefinedListVariable,

--- a/torch/_dynamo/side_effects.py
+++ b/torch/_dynamo/side_effects.py
@@ -835,6 +835,17 @@ class SideEffects:
                 cg.add_cache(var)
                 var.source = TempLocalSource(cg.tempvars[var])
 
+                if isinstance(var, variables.FrozenDataClassVariable):
+                    for name, value in var.fields.items():
+                        cg.load_import_from("builtins", "object")
+                        cg.load_method("__setattr__")
+                        cg(var.source)  # type: ignore[attr-defined]
+                        cg(variables.ConstantVariable(name))
+                        cg(value)
+                        cg.extend_output(
+                            [*create_call_method(3), create_instruction("POP_TOP")]
+                        )
+
         for ctx, args in self.save_for_backward:
             cg(ctx.source)
             cg.load_method("save_for_backward")

--- a/torch/_dynamo/side_effects.py
+++ b/torch/_dynamo/side_effects.py
@@ -836,7 +836,7 @@ class SideEffects:
                 var.source = TempLocalSource(cg.tempvars[var])
 
                 if isinstance(var, variables.FrozenDataClassVariable):
-                    for name, value in var.fields.items():
+                    for name, value in self.store_attr_mutations.get(var, {}).items():
                         cg.load_import_from("builtins", "object")
                         cg.load_method("__setattr__")
                         cg(var.source)  # type: ignore[attr-defined]
@@ -1017,6 +1017,12 @@ class SideEffects:
 
         suffixes = []
         for var in self._get_modified_vars():
+            # These frozen attribute initializations are handled in codegen_save_tempvars
+            # and don't need to be reset in the suffix.
+            if isinstance(var.mutation_type, AttributeMutationNew) and isinstance(
+                var, variables.FrozenDataClassVariable
+            ):
+                continue
             # When replay_side_effects=False, only update variables with TempLocalSource
             if not config.replay_side_effects and not isinstance(
                 var.source, TempLocalSource

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -4267,6 +4267,8 @@ class SourcelessBuilder:
         elif isinstance(value, (type, abc.ABCMeta)):
             if isinstance(value, type) and issubclass(value, enum.Enum):
                 return UserDefinedEnumClassVariable(value)
+            elif issubclass(type(value), type) and issubclass(value, BaseException):
+                return UserDefinedExceptionClassVariable(value)
             return UserDefinedClassVariable(value)
         elif isinstance(value, types.MethodWrapperType):
             return MethodWrapperVariable(value)

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -1066,10 +1066,18 @@ class UserDefinedExceptionClassVariable(UserDefinedClassVariable):
         tx: "InstructionTranslator",
         args: Sequence[VariableTracker],
         kwargs: dict[str, VariableTracker],
-        ) -> VariableTracker:
-        real_args = [a.as_python_constant() for a in args]
-        real_kwargs = {k: v.as_python_constant() for k, v in kwargs.items()}
-        return VariableTracker.build(tx, self.value(*real_args, **real_kwargs))
+    ) -> VariableTracker:
+        if self.source is None:
+            # NB: If source is added via side effects, create the exception
+            # object through side_effects as well. See FrozenDataClass creation
+            var = tx.output.side_effects.track_new_user_defined_object(
+                self,
+                self,
+                list(args),
+            )
+            var.call_method(tx, "__init__", list(args), dict(kwargs))
+            return var
+        return super().call_function(tx, args, kwargs)
 
 
 class UserDefinedEnumClassVariable(UserDefinedClassVariable):

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -1068,6 +1068,7 @@ class UserDefinedExceptionClassVariable(UserDefinedClassVariable):
         kwargs: dict[str, VariableTracker],
     ) -> VariableTracker:
         from .builder import SourcelessBuilder
+
         if self.source is None:
             # NB: If source is added via side effects, create the exception
             # object through side_effects as well. See FrozenDataClass creation

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -1014,8 +1014,6 @@ class UserDefinedClassVariable(UserDefinedVariable):
                     [self, *args],
                     kwargs,
                 )
-        elif issubclass(self.value, BaseException):
-            return variables.ExceptionVariable(self.value, tuple(args), kwargs)
 
         return super().call_function(tx, args, kwargs)
 
@@ -1062,6 +1060,16 @@ class UserDefinedExceptionClassVariable(UserDefinedClassVariable):
     @property
     def fn(self) -> type[object]:
         return self.value
+
+    def call_function(
+        self,
+        tx: "InstructionTranslator",
+        args: Sequence[VariableTracker],
+        kwargs: dict[str, VariableTracker],
+        ) -> VariableTracker:
+        real_args = [a.as_python_constant() for a in args]
+        real_kwargs = {k: v.as_python_constant() for k, v in kwargs.items()}
+        return VariableTracker.build(tx, self.value(*real_args, **real_kwargs))
 
 
 class UserDefinedEnumClassVariable(UserDefinedClassVariable):

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -1067,11 +1067,12 @@ class UserDefinedExceptionClassVariable(UserDefinedClassVariable):
         args: Sequence[VariableTracker],
         kwargs: dict[str, VariableTracker],
     ) -> VariableTracker:
+        from .builder import SourcelessBuilder
         if self.source is None:
             # NB: If source is added via side effects, create the exception
             # object through side_effects as well. See FrozenDataClass creation
             var = tx.output.side_effects.track_new_user_defined_object(
-                self,
+                SourcelessBuilder.create(tx, object),
                 self,
                 list(args),
             )

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -1073,7 +1073,7 @@ class UserDefinedExceptionClassVariable(UserDefinedClassVariable):
             # NB: If source is added via side effects, create the exception
             # object through side_effects as well. See FrozenDataClass creation
             var = tx.output.side_effects.track_new_user_defined_object(
-                SourcelessBuilder.create(tx, object),
+                SourcelessBuilder.create(tx, BaseException),
                 self,
                 list(args),
             )

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -553,7 +553,6 @@ class UserDefinedClassVariable(UserDefinedVariable):
                         "Set TORCHDYNAMO_ENABLE_P2P_COMPILATION=1 to enable.",
                     ],
                 )
-
             var = tx.output.side_effects.track_new_user_defined_object(
                 SourcelessBuilder.create(tx, object),
                 self,
@@ -893,7 +892,6 @@ class UserDefinedClassVariable(UserDefinedVariable):
 
                     default_kwargs[field.name] = var_tracker
             kwargs.update(default_kwargs)
-
             var = tx.output.side_effects.track_new_user_defined_object(
                 SourcelessBuilder.create(tx, object),
                 self,
@@ -1018,7 +1016,7 @@ class UserDefinedClassVariable(UserDefinedVariable):
                 )
         elif issubclass(self.value, BaseException):
             return variables.ExceptionVariable(self.value, tuple(args), kwargs)
-        
+
         return super().call_function(tx, args, kwargs)
 
     def is_standard_new(self) -> bool:
@@ -2409,11 +2407,6 @@ class FrozenDataClassVariable(UserDefinedObjectVariable):
         ctor = self.python_type()
         return ctor(*args, **kwargs)
 
-    def var_getattr(self, tx: "InstructionTranslator", name: str) -> VariableTracker:
-        if name in self.fields:
-            return self.fields[name]
-        return super().var_getattr(tx, name)
-
     def reconstruct(self, codegen: "PyCodegen") -> None:
         from dataclasses import fields
 
@@ -2496,7 +2489,7 @@ class FrozenDataClassVariable(UserDefinedObjectVariable):
         directly_update_dict: bool = False,
     ) -> VariableTracker:
         self.fields[name.as_python_constant()] = value
-        return variables.CONSTANT_VARIABLE_NONE
+        return super().method_setattr_standard(tx, name, value, directly_update_dict)
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self.value_type.__name__})"

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -2407,6 +2407,11 @@ class FrozenDataClassVariable(UserDefinedObjectVariable):
         ctor = self.python_type()
         return ctor(*args, **kwargs)
 
+    def var_getattr(self, tx, name):
+        if name in self.fields:
+            return self.fields[name]
+        return super().var_getattr(tx, name)
+
     def reconstruct(self, codegen: "PyCodegen") -> None:
         from dataclasses import fields
 
@@ -2489,7 +2494,7 @@ class FrozenDataClassVariable(UserDefinedObjectVariable):
         directly_update_dict: bool = False,
     ) -> VariableTracker:
         self.fields[name.as_python_constant()] = value
-        return super().method_setattr_standard(tx, name, value, directly_update_dict)
+        return variables.CONSTANT_VARIABLE_NONE
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self.value_type.__name__})"

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -1016,7 +1016,9 @@ class UserDefinedClassVariable(UserDefinedVariable):
                     [self, *args],
                     kwargs,
                 )
-
+        elif issubclass(self.value, BaseException):
+            return variables.ExceptionVariable(self.value, tuple(args), kwargs)
+        
         return super().call_function(tx, args, kwargs)
 
     def is_standard_new(self) -> bool:
@@ -2407,7 +2409,7 @@ class FrozenDataClassVariable(UserDefinedObjectVariable):
         ctor = self.python_type()
         return ctor(*args, **kwargs)
 
-    def var_getattr(self, tx, name):
+    def var_getattr(self, tx: "InstructionTranslator", name: str) -> VariableTracker:
         if name in self.fields:
             return self.fields[name]
         return super().var_getattr(tx, name)


### PR DESCRIPTION
Fixes #173221 

Addresses the bytecode generation order when using FrozenDataClass. Attached gist shows the original bytecode at the top and the bytecode generated after update at the bottom (happens immediately after initialization).
https://gist.github.com/trichmo/33b4930b4d3cd91d7ab3f7909aee1ef3

The underlying problem here is that for any FrozenDataClassVariables which were created in the compile region - the object gets initialized without attributes. The attributes are set through the same route as UserDefinedVariable's application of mutations in the bytecode suffix. Because frozen dataclasses have their __setattr__ overriden, an additional set of bytecode to object.__setattr__ must be added at initializtion - this is not a problem for UserDefinedVariables which don't override __setattr__ as their attr is set on init.

This fix has 3 parts:
1) Update method_setattr_standard to not route through UserDefinedVariable as we don't want to track the attributes as mutations to be applied in the bytecode suffix (no call to tx.output.side_effects.store_attr). Instead, we will directly access the FrozenDataVariable's field when setting it's value.
2) Add a FrozenDataVariable var_getattr to not use it's superclass's implementation when trying to access fields. Previously the field value would be flagged as has_pending_mutation and tx.output.side_effects.load_attr would get the value stored in side_effects. Because 1 no longer stores as a mutation, we now directly access a field if present and fallback to the super's implementation for other attributes (function handles are tested against).
3) Update the bytecode generation for the constructor of FrozenDataClassVariable to now not only create the dataclass with uninitialized attributes during the call to codegen_save_tempvars,  but also set the attribute value to it's proper initialized state. Same as for the UserDefinedObjectVariable bytecode is generated as "# __setattr__ is defined on this object, so call object.__setattr__ directly", but instead of using the sideeffect tracked value, the field is directly used.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo