### PR TITLE
[Inductor] Fallback to super().get_read_writes when epilogue_fusion_user_defined_triton_kernel is disabled

### DIFF
--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -7553,6 +7553,11 @@ class UserDefinedTritonKernel(ExternKernel):
 
     @override
     def get_read_writes(self) -> dependencies.ReadWrites:
+        # Limit the new `get_read_writes` to `epilogue_fusion_user_defined_triton_kernel`
+        # to avoid potential regression to existing models.
+        if not config.epilogue_fusion_user_defined_triton_kernel:
+            return super().get_read_writes()
+
         # maps formal arg name to actual arg name
         read_renames = {
             formal_arg_dep.name: self.kernel_args[formal_arg_dep.name].get_name()


### PR DESCRIPTION
Summary: PR #173662 introduces a new fusion `epilogue_fusion_user_defined_triton_kernel`. It overrides the `get_read_writes` method of `UserDefinedTritonKernel`, even when `epilogue_fusion_user_defined_triton_kernel` is disabled. This may cause regression to existing Triton kernel CUDA graph for other models. This diff fixed the regression by falling back to the original `get_read_writes` when `epilogue_fusion_user_defined_triton_kernel` is disabled

Differential Revision: D95727036




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo