### PR TITLE
[BE][Ez][Codemod]: Update missing std::move for Tensors into tuples

### DIFF
--- a/aten/src/ATen/native/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebra.cpp
@@ -3065,7 +3065,7 @@ std::tuple<Tensor, Tensor> linalg_eig(const Tensor& input) {
 
   at::linalg_eig_outf(input, values, vectors);
 
-  return std::tuple<Tensor, Tensor>(values, vectors);
+  return std::tuple<Tensor, Tensor>(std::move(values), std::move(vectors));
 }
 
 Tensor& linalg_eigvals_out(const Tensor& input, Tensor& values) {

--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -1980,7 +1980,7 @@ std::tuple<Tensor,Tensor,Tensor> _convolution_double_backward( const std::option
     }
   }
 
-  return std::tuple<Tensor,Tensor,Tensor>{ggO, gI, gW};
+  return std::tuple<Tensor,Tensor,Tensor>{std::move(ggO), std::move(gI), std::move(gW)};
 }
 
 static std::tuple<at::Tensor, at::Tensor, at::Tensor> _convolution_backward_nogroup_backend(
@@ -2325,7 +2325,7 @@ std::tuple<Tensor, Tensor, Tensor> convolution_backward(
     }
   }
 
-  return std::make_tuple(backend_grad_input, backend_grad_weight, backend_grad_bias);
+  return std::make_tuple(std::move(backend_grad_input), std::move(backend_grad_weight), std::move(backend_grad_bias));
 }
 
 void _cudnn_set_conv_benchmark_empty_cache(bool enable) {

--- a/aten/src/ATen/native/Dropout.cpp
+++ b/aten/src/ATen/native/Dropout.cpp
@@ -121,7 +121,7 @@ native_dropout_cpu(const Tensor& input, double p, std::optional<bool> train) {
     mask = at::ones_like(input, input.options().dtype(c10::CppTypeToScalarType<bool>::value));
     output = input.clone();
   }
-  return std::make_tuple(output, mask);
+  return std::make_tuple(std::move(output), std::move(mask));
 }
 
 Tensor native_dropout_backward(const Tensor& grad, const Tensor& mask, double scale) {

--- a/aten/src/ATen/native/LossNLL2d.cpp
+++ b/aten/src/ATen/native/LossNLL2d.cpp
@@ -432,7 +432,7 @@ std::tuple<Tensor, Tensor> nll_loss2d_forward_cpu(
   auto total_weight = at::empty({0}, self.options());
   at::native::nll_loss2d_forward_out_cpu(
       self, target, weight_opt, reduction, ignore_index, output, total_weight);
-  return std::make_tuple(output, total_weight);
+  return std::make_tuple(std::move(output), std::move(total_weight));
 }
 
 Tensor& nll_loss2d_backward_out_cpu(const Tensor& grad_output,

--- a/aten/src/ATen/native/NaiveConvolutionTranspose2d.cpp
+++ b/aten/src/ATen/native/NaiveConvolutionTranspose2d.cpp
@@ -868,7 +868,7 @@ static std::tuple<Tensor, Tensor, Tensor> slow_conv_transpose2d_backward_cpu(
         1);
   }
 
-  return std::tuple<Tensor, Tensor, Tensor>(grad_input, grad_weight, grad_bias);
+  return std::tuple<Tensor, Tensor, Tensor>(std::move(grad_input), std::move(grad_weight), std::move(grad_bias));
 }
 
 REGISTER_ALL_CPU_DISPATCH(slow_conv_transpose2d_backward_stub, &slow_conv_transpose2d_backward_cpu)

--- a/aten/src/ATen/native/Normalization.cpp
+++ b/aten/src/ATen/native/Normalization.cpp
@@ -341,7 +341,7 @@ static std::tuple<Tensor, Tensor, Tensor> batch_norm_backward_cpu_template(
     }
     batch_norm_cpu_backward_stub(kCPU, grad_input, grad_weight, grad_bias,
         grad_out_, input, weight, running_mean, running_var, save_mean, save_invstd, train, eps);
-    return std::make_tuple(grad_input, grad_weight, grad_bias);
+    return std::make_tuple(std::move(grad_input), std::move(grad_weight), std::move(grad_bias));
   }
 
   auto weight_a = conditional_accessor_1d<const param_t>(weight);
@@ -491,7 +491,7 @@ static std::tuple<Tensor, Tensor, Tensor> batch_norm_backward_cpu_template(
         }
       }
     });
-  return std::make_tuple(grad_input, grad_weight, grad_bias);
+  return std::make_tuple(std::move(grad_input), std::move(grad_weight), std::move(grad_bias));
 }
 
 BatchNormBackend _select_batch_norm_backend(
@@ -671,7 +671,7 @@ std::tuple<Tensor, Tensor, Tensor> _batch_norm_impl_index_backward(
     if (output_mask[0] && weight.defined()) {
       grad_input = grad_output * weight[0];
     }
-    return std::make_tuple(grad_input, grad_weight, grad_bias);
+    return std::make_tuple(std::move(grad_input), std::move(grad_weight), std::move(grad_bias));
   }
 
   // backward in inference mode is not supported in cudnn, fallback to native

--- a/aten/src/ATen/native/PackedSequence.cpp
+++ b/aten/src/ATen/native/PackedSequence.cpp
@@ -106,7 +106,7 @@ std::tuple<Tensor, Tensor> _pack_padded_sequence(const Tensor& _input, const Ten
     TORCH_CHECK(l >= prev_l);
   }
 
-  return std::make_tuple(at::cat(steps), batch_sizes_t);
+  return std::make_tuple(at::cat(steps), std::move(batch_sizes_t));
 }
 
 // `grad` could be on arbitrary device and of arbitrary dtype, but `_batch_sizes`
@@ -200,7 +200,7 @@ std::tuple<Tensor, Tensor> _pad_packed_sequence(const Tensor& data, const Tensor
     output = output.transpose(0, 1);
   }
 
-  return std::make_tuple(output, lengths_t);
+  return std::make_tuple(std::move(output), std::move(lengths_t));
 }
 
 Tensor pad_sequence(TensorList sequences, bool batch_first, double padding_value, const std::string_view padding_side) {

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -840,7 +840,7 @@ std::tuple<Tensor, Tensor> cummax(const Tensor& self, int64_t dim) {
   auto values = at::empty(self.sizes(), self.options());
   auto indices = at::empty(self.sizes(), self.options().dtype(at::kLong));
   at::cummax_out(values, indices, self, dim);
-  return std::make_tuple(values, indices);
+  return std::make_tuple(std::move(values), std::move(indices));
 }
 
 void cummin_helper_cpu(const Tensor& self, Tensor& values, Tensor& indices, int64_t dim) {
@@ -879,7 +879,7 @@ std::tuple<Tensor, Tensor> cummin(const Tensor& self, int64_t dim) {
   auto values = at::empty(self.sizes(), self.options());
   auto indices = at::empty(self.sizes(), self.options().dtype(at::kLong));
   at::cummin_out(values, indices, self, dim);
-  return std::make_tuple(values, indices);
+  return std::make_tuple(std::move(values), std::move(indices));
 }
 
 Tensor cummaxmin_backward(const Tensor& grad, const Tensor& input, const Tensor& indices, int64_t dim) {

--- a/aten/src/ATen/native/RowwisePrune.cpp
+++ b/aten/src/ATen/native/RowwisePrune.cpp
@@ -53,8 +53,8 @@ std::tuple<Tensor, Tensor> _rowwise_prune_helper(
       }
     }
   });
-  return std::tuple<Tensor, Tensor>(pruned_2d_tensor,
-      compressed_indices_mapping);
+  return std::tuple<Tensor, Tensor>(std::move(pruned_2d_tensor),
+      std::move(compressed_indices_mapping));
 }
 
 } // namespace

--- a/aten/src/ATen/native/SobolEngineOps.cpp
+++ b/aten/src/ATen/native/SobolEngineOps.cpp
@@ -58,7 +58,7 @@ std::tuple<Tensor, Tensor> _sobol_engine_draw(const Tensor& quasi, int64_t n, co
   });
 
   result.mul_(RECIPD);
-  return std::tuple<Tensor, Tensor>(result, wquasi);
+  return std::tuple<Tensor, Tensor>(std::move(result), std::move(wquasi));
 }
 
 /// This is the core function to fast-forward a `SobolEngine` given

--- a/aten/src/ATen/native/Sorting.cpp
+++ b/aten/src/ATen/native/Sorting.cpp
@@ -812,7 +812,7 @@ std::tuple<Tensor, Tensor> kthvalue(
   Tensor values = at::empty({0}, self.options());
   Tensor indices = at::empty({0}, self.options().dtype(kLong));
   at::kthvalue_out(values, indices, self, k, dim, keepdim);
-  return std::make_tuple(values, indices);
+  return std::make_tuple(std::move(values), std::move(indices));
 }
 
 std::tuple<Tensor, Tensor> kthvalue(
@@ -877,7 +877,7 @@ std::tuple<Tensor, Tensor> median(
   Tensor values = at::empty({0}, self.options());
   Tensor indices = at::empty({0}, self.options().dtype(kLong));
   at::median_out(values, indices, self, dim, keepdim);
-  return std::make_tuple(values, indices);
+  return std::make_tuple(std::move(values), std::move(indices));
 }
 
 std::tuple<Tensor, Tensor> median(
@@ -924,7 +924,7 @@ std::tuple<Tensor, Tensor> nanmedian(
   Tensor values = at::empty({0}, self.options());
   Tensor indices = at::empty({0}, self.options().dtype(kLong));
   at::nanmedian_out(values, indices, self, dim, keepdim);
-  return std::make_tuple(values, indices);
+  return std::make_tuple(std::move(values), std::move(indices));
 }
 
 std::tuple<Tensor, Tensor> nanmedian(

--- a/aten/src/ATen/native/UnaryOps.cpp
+++ b/aten/src/ATen/native/UnaryOps.cpp
@@ -936,7 +936,7 @@ std::tuple<Tensor, Tensor> frexp(const Tensor& self) {
   Tensor exponent = at::empty_like(self, self.options().dtype(at::kInt));
 
   at::frexp_out(mantissa, exponent, self);
-  return std::tuple<Tensor, Tensor>(mantissa, exponent);
+  return std::tuple<Tensor, Tensor>(std::move(mantissa), std::move(exponent));
 }
 
 std::tuple<Tensor&, Tensor&> frexp_out(const Tensor& self,

--- a/aten/src/ATen/native/WeightNorm.cpp
+++ b/aten/src/ATen/native/WeightNorm.cpp
@@ -59,7 +59,7 @@ std::tuple<Tensor,Tensor> weight_norm_cpu(
   auto norm = at::empty_strided(g.sizes(), g.strides(), g.options().dtype(dtype));
   weight_norm_stub(kCPU, w, norm, v, g, dim);
 
-  return std::tuple<Tensor, Tensor>{w, norm};
+  return std::tuple<Tensor, Tensor>{std::move(w), std::move(norm)};
 }
 
 std::tuple<Tensor, Tensor> weight_norm_backward_cpu(
@@ -76,7 +76,7 @@ std::tuple<Tensor, Tensor> weight_norm_backward_cpu(
   auto grad_g = at::empty_like(saved_g, at::MemoryFormat::Contiguous);
   weight_norm_backward_stub(kCPU, grad_v, grad_g, grad_w, saved_v, saved_g, saved_norm, dim);
 
-  return std::tuple<Tensor, Tensor>{grad_v, grad_g};
+  return std::tuple<Tensor, Tensor>{std::move(grad_v), std::move(grad_g)};
 }
 
 Tensor _weight_norm
@@ -146,13 +146,13 @@ std::tuple<Tensor, Tensor> _weight_norm_differentiable_backward
     auto per_dim_sums = (grad_w*saved_v).view({saved_v.size(0), -1}).sum(1).view(bcast_size);
     auto grad_v = (saved_g/norms)*(grad_w - saved_v*(per_dim_sums/(norms*norms)));
     auto grad_g = per_dim_sums/norms;
-    return std::tuple<Tensor, Tensor>{grad_v, grad_g};
+    return std::tuple<Tensor, Tensor>{std::move(grad_v), std::move(grad_g)};
   } else { // dim == last_dim
     bcast_size[last_dim] = last_size;
     auto per_dim_sums = (grad_w*saved_v).view({-1, last_size}).sum(0).view(bcast_size);
     auto grad_v = (saved_g/norms)*(grad_w - saved_v*(per_dim_sums/(norms*norms)));
     auto grad_g = per_dim_sums/norms;
-    return std::tuple<Tensor, Tensor>{grad_v, grad_g};
+    return std::tuple<Tensor, Tensor>{std::move(grad_v), std::move(grad_g)};
   }
 }
 

--- a/aten/src/ATen/native/cudnn/ConvShared.cpp
+++ b/aten/src/ATen/native/cudnn/ConvShared.cpp
@@ -632,7 +632,8 @@ std::tuple<at::Tensor, at::Tensor> cudnn_convolution_backward(
     }
   }
 
-  return std::tuple<Tensor, Tensor>{grad_input, grad_weight};
+  return std::tuple<Tensor, Tensor>{
+      std::move(grad_input), std::move(grad_weight)};
 }
 
 Tensor cudnn_convolution_transpose_backward_weight(
@@ -702,7 +703,8 @@ std::tuple<at::Tensor, at::Tensor> cudnn_convolution_transpose_backward(
         allow_tf32);
   }
 
-  return std::tuple<Tensor, Tensor>{grad_input, grad_weight};
+  return std::tuple<Tensor, Tensor>{
+      std::move(grad_input), std::move(grad_weight)};
 }
 
 Tensor cudnn_convolution_relu(

--- a/aten/src/ATen/native/cudnn/GridSampler.cpp
+++ b/aten/src/ATen/native/cudnn/GridSampler.cpp
@@ -183,7 +183,8 @@ std::tuple<Tensor, Tensor> cudnn_grid_sampler_backward(
       &zero,
       grad_grid_t.data_ptr()));
 
-  return std::tuple<Tensor, Tensor>{grad_input_t, grad_grid_t};
+  return std::tuple<Tensor, Tensor>{
+      std::move(grad_input_t), std::move(grad_grid_t)};
 }
 
 } // namespace at::native

--- a/aten/src/ATen/native/miopen/BatchNorm_miopen.cpp
+++ b/aten/src/ATen/native/miopen/BatchNorm_miopen.cpp
@@ -156,7 +156,7 @@ std::tuple<Tensor, Tensor, Tensor> miopen_batch_norm(
   // save_mean and save_var can be undefined
   // If this causes problems, we can initialize them to empty tensors
   // of the correct type
-  return std::tuple<Tensor, Tensor, Tensor>{output_t, save_mean, save_var};
+  return std::tuple<Tensor, Tensor, Tensor>{std::move(output_t), std::move(save_mean), std::move(save_var)};
 }
 
 std::tuple<Tensor, Tensor, Tensor> miopen_batch_norm_backward(
@@ -235,7 +235,7 @@ std::tuple<Tensor, Tensor, Tensor> miopen_batch_norm_backward(
     save_mean->const_data_ptr(),
     save_var->const_data_ptr()));
 
-  return std::tuple<Tensor,Tensor,Tensor>{grad_input_t, grad_weight_t, grad_bias_t};
+  return std::tuple<Tensor,Tensor,Tensor>{std::move(grad_input_t), std::move(grad_weight_t), std::move(grad_bias_t)};
 }
 
 }}  // namespace native

--- a/aten/src/ATen/native/miopen/Conv_miopen.cpp
+++ b/aten/src/ATen/native/miopen/Conv_miopen.cpp
@@ -1088,7 +1088,7 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> miopen_convolution_transpose_back
     grad_bias = miopen_convolution_backward_bias(grad_output);
   }
 
-  return std::tuple<Tensor,Tensor,Tensor>{grad_input, grad_weight, grad_bias};
+  return std::tuple<Tensor,Tensor,Tensor>{std::move(grad_input), std::move(grad_weight), std::move(grad_bias)};
 }
 
 // ---------------------------------------------------------------------
@@ -1572,7 +1572,7 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> miopen_convolution_backward(
     }
   }
 
-  return std::tuple<Tensor, Tensor, Tensor>{grad_input, grad_weight, grad_bias};
+  return std::tuple<Tensor, Tensor, Tensor>{std::move(grad_input), std::move(grad_weight), std::move(grad_bias)};
 }
 
 Tensor miopen_convolution_transpose_forward(
@@ -1761,7 +1761,7 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> miopen_depthwise_convolution_back
     grad_bias = miopen_convolution_backward_bias(grad_output);
   }
 
-  return std::tuple<Tensor,Tensor,Tensor>{grad_input, grad_weight, grad_bias};
+  return std::tuple<Tensor,Tensor,Tensor>{std::move(grad_input), std::move(grad_weight), std::move(grad_bias)};
 }
 
 // ---------------------------------------------------------------------

--- a/aten/src/ATen/native/mkldnn/Linear.cpp
+++ b/aten/src/ATen/native/mkldnn/Linear.cpp
@@ -203,7 +203,7 @@ std::tuple<Tensor, Tensor, Tensor> mkldnn_linear_backward(
   if (output_mask[1] || output_mask[2]) {
     std::tie(grad_weight, grad_bias) = at::mkldnn_linear_backward_weights(grad_output, input, weight, output_mask[2]);
   }
-  return std::tuple<Tensor, Tensor, Tensor>{grad_input, grad_weight, grad_bias};
+  return std::tuple<Tensor, Tensor, Tensor>{std::move(grad_input), std::move(grad_weight), std::move(grad_bias)};
 }
 
 Tensor mkldnn_linear_pointwise(

--- a/aten/src/ATen/native/quantized/FakeQuantPerTensorAffine.cpp
+++ b/aten/src/ATen/native/quantized/FakeQuantPerTensorAffine.cpp
@@ -86,7 +86,7 @@ std::tuple<Tensor, Tensor> fake_quantize_per_tensor_affine_cachemask(
       self.device().type(), Y, mask, self, scale, zero_point, quant_min, quant_max);
   // TODO(future, optional): look into packing the mask further (BoolTensor uses
   //   1 byte per element, we only need 1 bit per element).
-  return std::make_tuple(Y, mask);
+  return std::make_tuple(std::move(Y), std::move(mask));
 }
 
 std::tuple<Tensor, Tensor> _fake_quantize_per_tensor_affine_cachemask_tensor_qparams(
@@ -106,7 +106,7 @@ std::tuple<Tensor, Tensor> _fake_quantize_per_tensor_affine_cachemask_tensor_qpa
       self.device().type(), Y, mask, self, scale, zero_point, fake_quant_enabled, quant_min, quant_max);
   // TODO(future, optional): look into packing the mask further (BoolTensor uses
   //   1 byte per element, we only need 1 bit per element).
-  return std::make_tuple(Y, mask);
+  return std::make_tuple(std::move(Y), std::move(mask));
 }
 
 /* Backward path to fake-quantize the 'inputs' tensor, with mask.
@@ -231,7 +231,7 @@ std::tuple<Tensor, Tensor, Tensor> _fake_quantize_learnable_per_tensor_affine_ba
   auto dScale = dScale_vec.sum().unsqueeze(0).to(scale_.device());
   auto dZeroPoint = dZeroPoint_vec.sum().unsqueeze(0).to(zero_point_.device());
 
-  return std::make_tuple(dX, dScale, dZeroPoint);
+  return std::make_tuple(std::move(dX), std::move(dScale), std::move(dZeroPoint));
 }
 
 } // namespace at::native

--- a/aten/src/ATen/native/vulkan/ops/Lstm.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Lstm.cpp
@@ -158,7 +158,8 @@ std::tuple<Tensor, Tensor, Tensor> lstm_input(
   x = x.reshape({batch_size, seq_length, x.size(1)});
   h_n = h_n.reshape({h_n.size(0) * h_n.size(1), h_n.size(2), h_n.size(3)});
   c_n = c_n.reshape({c_n.size(0) * c_n.size(1), c_n.size(2), c_n.size(3)});
-  return std::tuple<Tensor, Tensor, Tensor>(x, h_n, c_n);
+  return std::tuple<Tensor, Tensor, Tensor>(
+      std::move(x), std::move(h_n), std::move(c_n));
 }
 
 #ifdef USE_VULKAN_API
@@ -419,7 +420,8 @@ std::tuple<Tensor, Tensor, Tensor> run_lstm_context(
   x = x.reshape({batch_size, seq_length, x.size(1)});
   h_n = h_n.reshape({h_n.size(0) * h_n.size(1), h_n.size(2), h_n.size(3)});
   c_n = c_n.reshape({c_n.size(0) * c_n.size(1), c_n.size(2), c_n.size(3)});
-  return std::tuple<Tensor, Tensor, Tensor>(x, h_n, c_n);
+  return std::tuple<Tensor, Tensor, Tensor>(
+      std::move(x), std::move(h_n), std::move(c_n));
 }
 
 } // namespace ops


### PR DESCRIPTION
Fixes a bunch of trivial ref count increments when returning tuples from cpp function. Move the Tensors into the tuple.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01