### PR TITLE
[BE][Ez][Codemod]: Add missing std::move to tuple with std::vector elements

### DIFF
--- a/aten/src/ATen/native/RNN.cpp
+++ b/aten/src/ATen/native/RNN.cpp
@@ -852,7 +852,7 @@ struct FullLayer : Layer<Tensor, hidden_type, cell_params> {
       hidden = cell_(input, hidden, params, pre_compute_input);
       step_outputs.emplace_back(hidden_as_output(hidden));
     }
-    return {step_outputs, hidden};
+    return {std::move(step_outputs), std::move(hidden)};
   }
 
   output_type operator()(
@@ -1111,7 +1111,7 @@ apply_layer_stack(const Layer<io_type, hidden_type, weight_type>& layer, const i
     }
   }
 
-  return {layer_input, final_hiddens};
+  return {std::move(layer_input), std::move(final_hiddens)};
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/aten/src/ATen/native/cpu/UpSampleKernel.cpp
+++ b/aten/src/ATen/native/cpu/UpSampleKernel.cpp
@@ -939,7 +939,7 @@ struct HelperInterpBase {
       idx_ptr_stride[i] = stride;
       wt_idx_ptr[i] = i * max_interp_size * weight_index_stride;
     }
-    return {output, max_interp_size, wt_max};
+    return {std::move(output), max_interp_size, wt_max};
   }
 
   /*
@@ -1029,7 +1029,7 @@ struct HelperInterpBase {
       }
     }
 
-    return {indices_weights, aligned_interp_size, weights_precision};
+    return {std::move(indices_weights), aligned_interp_size, weights_precision};
   }
 };
 

--- a/aten/src/ATen/native/cudnn/RNN.cpp
+++ b/aten/src/ATen/native/cudnn/RNN.cpp
@@ -2249,7 +2249,7 @@ std::tuple<Tensor, Tensor, Tensor, std::vector<Tensor>> _cudnn_rnn_backward(
         reserve);
   }
   return std::tuple<Tensor, Tensor, Tensor, std::vector<Tensor>>{
-      dx, dhx, dcx, dw};
+      std::move(dx), std::move(dhx), std::move(dcx), std::move(dw)};
 }
 
 // TODO: I am not sure if we actually need the 'dropout' and 'train' parameters

--- a/aten/src/ATen/native/miopen/RNN_miopen.cpp
+++ b/aten/src/ATen/native/miopen/RNN_miopen.cpp
@@ -866,7 +866,7 @@ std::tuple<Tensor, Tensor, Tensor, std::vector<Tensor>> miopen_rnn_backward(
             }
         }
     }
-    return std::tuple<Tensor, Tensor, Tensor, std::vector<Tensor>>{dx, dhx, dcx, dw};
+    return std::tuple<Tensor, Tensor, Tensor, std::vector<Tensor>>{std::move(dx), std::move(dhx), std::move(dcx), std::move(dw)};
 }
 
 namespace {

--- a/aten/src/ATen/native/mkldnn/xpu/Linear.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/Linear.cpp
@@ -22,7 +22,10 @@ collapse_in_out_dim(at::Tensor input, int64_t dim, at::Tensor weight) {
   // [BM, N]
   std::vector<int64_t> output_reshaped_size{
       input_reshaped_size[0], weight.size(0)};
-  return {input_reshaped_size, output_size, output_reshaped_size};
+  return {
+      std::move(input_reshaped_size),
+      std::move(output_size),
+      std::move(output_reshaped_size)};
 }
 
 Tensor linear_pointwise(


### PR DESCRIPTION
Used Claude to find examples of std::vectors inside of std::tuple returns that could be moved, preventing expensive copy and reallocations.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01