### PR TITLE
[CI] Increase macos-py3-arm64 default test shards from 3 to 4

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -193,9 +193,10 @@ jobs:
       python-version: 3.12.7
       test-matrix: |
         { include: [
-          { config: "default", shard: 1, num_shards: 3, runner: "macos-m1-stable" },
-          { config: "default", shard: 2, num_shards: 3, runner: "macos-m1-stable" },
-          { config: "default", shard: 3, num_shards: 3, runner: "macos-m1-stable" },
+          { config: "default", shard: 1, num_shards: 4, runner: "macos-m1-stable" },
+          { config: "default", shard: 2, num_shards: 4, runner: "macos-m1-stable" },
+          { config: "default", shard: 3, num_shards: 4, runner: "macos-m1-stable" },
+          { config: "default", shard: 4, num_shards: 4, runner: "macos-m1-stable" },
           { config: "mps", shard: 1, num_shards: 1, runner: "macos-m1-14" },
           { config: "mps", shard: 1, num_shards: 1, runner: "macos-m2-15" },
           { config: "openreg", shard: 1, num_shards: 1, runner: "macos-m1-stable" },


### PR DESCRIPTION
## Summary

- Increases the `macos-py3-arm64 / test (default)` shard count from 3 to 4 in the trunk workflow
- The job is consistently timing out at 4 hours on main, with shard 1 intermittently hanging on tests like `test_fx` and `test_cpp_extensions_aot_ninja`
- With 3 shards, each shard takes ~1.3h normally — leaving little headroom before the 270-minute timeout. With 4 shards, per-shard time drops to ~1h

## Root Cause

Shard 1 intermittently hangs for 4+ hours instead of the normal ~1.3h. Recent failures:

| Run | Shard 1 | Shard 2 | Shard 3 |
|-----|---------|---------|---------|
| 22819628401 | **4h FAIL (timeout)** | 1.5h OK | 1.3h FAIL |
| 22813638105 | **4h FAIL (timeout)** | 1.4h OK | 1.3h OK |
| 22810029503 | **4h FAIL (timeout)** | 1.2h OK | 1.4h FAIL |

The hangs appear to be on `test_fx` or `test_cpp_extensions_aot_ninja`. More shards reduce per-shard load, making the job more resilient.

## Test plan

- [ ] Verify the trunk workflow generates 4 shard jobs for macos-py3-arm64 default config
- [ ] Monitor that per-shard runtime drops from ~1.3h to ~1h
- [ ] Confirm no more 4h timeout failures on this job

cc @pytorch/pytorch-dev-infra