### PR TITLE
[CI] Fix assert_git_not_dirty false positive for third_party submodules

### DIFF
--- a/.github/actions/checkout-pytorch/action.yml
+++ b/.github/actions/checkout-pytorch/action.yml
@@ -71,13 +71,25 @@ runs:
       shell: bash
       env:
         NO_SUDO: ${{ inputs.no-sudo }}
+        SUBMODULES: ${{ inputs.submodules }}
       run: |
         cd "${GITHUB_WORKSPACE}"
-        # Clean stale submodule dirs
-        if [ -z "${NO_SUDO}" ]; then
-          sudo git submodule foreach --recursive git clean -ffdx
+        if [[ "${SUBMODULES}" == "false" ]]; then
+          # On persistent runners, a previous job may have checked out submodules.
+          # Deinit all submodules to remove stale directories that would otherwise
+          # cause assert_git_not_dirty to report false positives.
+          if [ -z "${NO_SUDO}" ]; then
+            sudo git submodule deinit --all -f 2>/dev/null || true
+          else
+            git submodule deinit --all -f 2>/dev/null || true
+          fi
         else
-          git submodule foreach --recursive git clean -ffdx
+          # Clean stale files inside initialized submodule dirs
+          if [ -z "${NO_SUDO}" ]; then
+            sudo git submodule foreach --recursive git clean -ffdx
+          else
+            git submodule foreach --recursive git clean -ffdx
+          fi
         fi
 
     - name: Clean workspace (try again)


### PR DESCRIPTION
## Summary

- Fixes false positive "Build left local git repository checkout dirty" failures on macOS test jobs (e.g., `trunk / macos-py3-arm64 / test (mps, 1, 1, macos-m1-14)`)
- Properly deinitializes stale submodules on persistent runners instead of suppressing the git status check

## Root Cause

macOS CI runners are **persistent** (not ephemeral). The failure chain:

1. **BUILD job** (`_mac-build.yml`) checks out with `submodules: recursive` — writes `third_party/composable_kernel`, `third_party/flash-attention`, etc. to disk
2. **TEST job** (`_mac-test.yml`) later runs on the **same machine** with `submodules: false`
3. `git clean -ffdx` at the superproject level does NOT clean inside nested `.git` repos (submodule dirs)
4. The post-checkout `git submodule foreach --recursive git clean -ffdx` is a **no-op** because no submodules are initialized when `submodules: false`
5. Stale submodule directories persist → `git status` reports ` M third_party/composable_kernel` and ` M third_party/flash-attention`
6. `assert_git_not_dirty()` fails — even though the current job never touched these files

Evidence: failing runs vs passing runs are on **different runner machines** (`i-0a0a039fa3f92e5e7` vs `i-029b446be608339a3`), confirming it's runner-state-dependent.

## Fix

In `checkout-pytorch/action.yml`, when `submodules` input is `false`, run `git submodule deinit --all -f` to properly remove stale submodule directories left by previous jobs. When submodules are initialized (recursive/true), keep the existing `git submodule foreach` cleanup behavior.

This fixes the problem at the source (clean up stale state) rather than masking it in `assert_git_not_dirty`.

## Test plan

- [ ] Verify `test (mps, 1, 1, macos-m1-14)` no longer fails with dirty checkout on persistent runners
- [ ] Verify build jobs with `submodules: recursive` still clean submodule dirs correctly
- [ ] Verify `assert_git_not_dirty` still catches real build-introduced dirtiness

cc @pytorch/pytorch-dev-infra