### PR TITLE
[ROCm] Fix void pointer arithmetic in CUDACachingAllocator for HIP build

### DIFF
--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -769,7 +769,7 @@ struct ExpandableSegment {
     for (auto i : c10::irange(begin, end)) {
 #ifdef USE_ROCM
       C10_CUDA_CHECK(hipMemMap(
-          reinterpret_cast<char*>(ptr_) + i * segment_size_,
+          ptr() + i * segment_size_,
           segment_size_,
           0,
           handles_.at(i).value().handle,
@@ -810,8 +810,7 @@ struct ExpandableSegment {
       Handle h = handles_.at(i).value();
       handles_.at(i) = std::nullopt;
 #ifdef USE_ROCM
-      C10_CUDA_CHECK(hipMemUnmap(
-          reinterpret_cast<char*>(ptr_) + segment_size_ * i, segment_size_));
+      C10_CUDA_CHECK(hipMemUnmap(ptr() + segment_size_ * i, segment_size_));
 #else
       C10_CUDA_DRIVER_CHECK(DriverAPI::get()->cuMemUnmap_(
           ptr_ + segment_size_ * i, segment_size_));


### PR DESCRIPTION
## Summary

- Uses `ptr()` helper (returns `char*`) instead of `reinterpret_cast<char*>(ptr_)` for pointer arithmetic in `hipMemMap` and `hipMemUnmap` calls
- After hipify converts `CUdeviceptr` (unsigned long long) to `hipDeviceptr_t` (void*), arithmetic on `ptr_` becomes void pointer arithmetic which Clang rejects with `-Werror`
- Forward fix for void* arithmetic errors introduced by #173330

Supersedes #176698 (which had a co-author tag that breaks pytorch CI).

## Test plan

- [ ] Verify HIP/ROCm build compiles without `-Werror` void pointer arithmetic errors
- [ ] Verify CUDA build is unaffected (changes are inside `#ifdef USE_ROCM` blocks only)

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang