### PR TITLE
[MPS] Fix SDPA output shape when value head dim differs

### DIFF
--- a/aten/src/ATen/native/mps/operations/Attention.mm
+++ b/aten/src/ATen/native/mps/operations/Attention.mm
@@ -64,9 +64,9 @@ static std::tuple<Tensor, Tensor> sdpa_general_mps(const Tensor& query,
   int64_t batchSize = query.size(0);
   int64_t num_head = query.size(1);
   int64_t qSize = query.size(2);
-  int64_t headSize = query.size(3);
+  int64_t valueHeadSize = value.size(3);
   int64_t maxSeqLength = key.size(2);
-  auto out = at::empty({batchSize, num_head, qSize, headSize}, query.options());
+  auto out = at::empty({batchSize, num_head, qSize, valueHeadSize}, query.options());
   auto attn = at::empty({batchSize, num_head, qSize, maxSeqLength}, query.options());
   auto scale_factor = sdp::calculate_scale(query, scale).expect_float();
   @autoreleasepool {
@@ -149,12 +149,25 @@ static std::tuple<Tensor, Tensor> sdpa_general_mps(const Tensor& query,
     runMPSGraph(getCurrentMPSStream(), cachedGraph->graph(), feeds, outs);
   }
 
-  auto final_out = unsqueezed ? out.view_as(orig_query) : out;
-  auto final_attn = unsqueezed ? (orig_query.dim() == 3 ? attn.squeeze(0) : [&]{
-    std::vector<int64_t> shape(orig_query.sizes().begin(), orig_query.sizes().end() - 3);
-    shape.insert(shape.end(), {attn.size(1), attn.size(2), attn.size(3)});
-    return attn.view(shape);
-  }()) : attn;
+  auto final_out = out;
+  auto final_attn = attn;
+  if (unsqueezed) {
+    if (orig_query.dim() == 3) {
+      final_out = out.squeeze(0);
+      final_attn = attn.squeeze(0);
+    } else {
+      std::vector<int64_t> prefix_shape(orig_query.sizes().begin(), orig_query.sizes().end() - 3);
+
+      auto out_shape = prefix_shape;
+      auto attn_shape = prefix_shape;
+
+      out_shape.insert(out_shape.end(), {out.size(1), out.size(2), out.size(3)});
+      attn_shape.insert(attn_shape.end(), {attn.size(1), attn.size(2), attn.size(3)});
+
+      final_out = out.view(out_shape);
+      final_attn = attn.view(attn_shape);
+    }
+  }
 
   return {std::move(final_out), std::move(final_attn)};
 }
@@ -170,6 +183,8 @@ static std::tuple<Tensor, Tensor> sdpa_vector_fast_mps(const Tensor& q_,
                                                        std::optional<double> scale,
                                                        const Tensor& orig_query,
                                                        bool unsqueezed) {
+  TORCH_CHECK(q_.size(3) == k_.size(3) && q_.size(3) == v_.size(3),
+              "sdpa_vector_fast_mps expects query, key, and value to have the same head dimension");
   const auto macOS15_0_plus = is_macos_13_or_newer(MacOSVersion::MACOS_VER_15_0_PLUS);
   using namespace mps;
   uint batchSize = q_.size(0);
@@ -246,6 +261,8 @@ static std::tuple<Tensor, Tensor> sdpa_vector_2pass_mps(const Tensor& q_,
                                                         std::optional<double> scale,
                                                         const Tensor& orig_query,
                                                         bool unsqueezed) {
+  TORCH_CHECK(q_.size(3) == k_.size(3) && q_.size(3) == v_.size(3),
+              "sdpa_vector_2pass_mps expects query, key, and value to have the same head dimension");
   using namespace mps;
   uint batchSize = q_.size(0);
   uint num_heads = q_.size(1);

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -10050,6 +10050,26 @@ class TestSDPA(TestCaseMPS):
         q, k, v = self.generate_qkv(batch, NH, q_len, s_len, head_dim, layout, dtype)
         self.run_fast_attention_test(q, k, v, with_mask)
 
+    def test_sdpa_output_qv_shape_diff(self):
+        # This intentionally checks both output shape semantics and numerical consistency
+        # against CPU for Ev != E. It is stricter than a shape-only regression test.
+        # Regression test for https://github.com/pytorch/pytorch/issues/176767
+        test_cases = [
+            ((1, 16, 32), (1, 16, 32), (1, 16, 24)),
+            ((1, 1, 16, 32), (1, 1, 16, 32), (1, 1, 16, 24)),
+            ((2, 3, 1, 16, 32), (2, 3, 1, 16, 32), (2, 3, 1, 16, 24)),
+        ]
+
+        for q_shape, k_shape, v_shape in test_cases:
+            q = torch.randn(*q_shape, device="mps", dtype=torch.float32)
+            k = torch.randn(*k_shape, device="mps", dtype=torch.float32)
+            v = torch.randn(*v_shape, device="mps", dtype=torch.float32)
+
+            y_mps = torch.nn.functional.scaled_dot_product_attention(q, k, v)
+            y_cpu = torch.nn.functional.scaled_dot_product_attention(q.cpu(), k.cpu(), v.cpu())
+
+            self.assertEqual(y_cpu, y_mps)
+
 
 
 class TestSDPAMetaDispatchMode(TorchDispatchMode):

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -2208,6 +2208,25 @@ class TestSDPA(NNTestCase):
             self.assertEqual(k.grad.shape, k.shape)
             self.assertEqual(v.grad.shape, v.shape)
 
+    def test_sdpa_output_shape_uses_value_head_dim(self, device):
+        # Regression test for https://github.com/pytorch/pytorch/issues/176767
+        test_cases = [
+            ((1, 16, 32), (1, 16, 32), (1, 16, 24)),
+            ((1, 1, 16, 32), (1, 1, 16, 32), (1, 1, 16, 24)),
+            ((2, 3, 1, 16, 32), (2, 3, 1, 16, 32), (2, 3, 1, 16, 24)),
+        ]
+
+        for q_shape, k_shape, v_shape in test_cases:
+            q = torch.randn(*q_shape, device=device, dtype=torch.float32)
+            k = torch.randn(*k_shape, device=device, dtype=torch.float32)
+            v = torch.randn(*v_shape, device=device, dtype=torch.float32)
+
+            actual = torch.nn.functional.scaled_dot_product_attention(q, k, v)
+
+            expected_shape = list(q_shape)
+            expected_shape[-1] = v_shape[-1]
+            self.assertEqual(actual.shape, torch.Size(expected_shape))
+
 
 class TestSDPACpuOnly(NNTestCase):
     """ Used to test CPU only functionality of scaled_dot_product_attention """

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -6116,9 +6116,15 @@ def meta__scaled_dot_product_attention_math_for_mps(
     q_, unsqueezed = ensure_4d(query)
     k_, _ = ensure_4d(key)
     v_, _ = ensure_4d(value)
+    mask_ = None
+    if attn_mask is not None:
+        mask_expanded_dims = list(query.shape)
+        mask_expanded_dims[-1] = k_.size(2)
+        mask_ = attn_mask.expand(mask_expanded_dims)
+        mask_, _ = ensure_4d(mask_)
 
-    batch_size, num_head, q_size, head_size = q_.shape
-    _, k_size, max_seq_length, _ = k_.shape
+    batch_size, num_head, q_size, query_head_size = q_.shape
+    _, k_size, max_seq_length, value_head_size = v_.shape
 
     def sdpa_vector_fast_mps():
         out = q_.new_empty(q_.shape)
@@ -6137,10 +6143,42 @@ def meta__scaled_dot_product_attention_math_for_mps(
     def sdpa_vector_2pass_mps():
         blocks = 32
         out = q_.new_empty(q_.shape)
-        intermediate = q_.new_empty((batch_size, num_head, q_size, blocks, head_size))
+        intermediate = q_.new_empty(
+            (batch_size, num_head, q_size, blocks, query_head_size)
+        )
         return out, intermediate
 
-    if (max_seq_length >= 1024) or (k_size < q_size and max_seq_length >= 4096):
+    def sdpa_general_mps():
+        out = q_.new_empty((batch_size, num_head, q_size, value_head_size))
+        attn = q_.new_empty((batch_size, num_head, q_size, max_seq_length))
+        if unsqueezed:
+            if query.dim() == 3:
+                out = out.squeeze(0)
+                attn = attn.squeeze(0)
+            else:
+                out_shape = list(query.shape[:-3]) + list(out.shape[1:4])
+                attn_shape = list(query.shape[:-3]) + list(attn.shape[1:4])
+                out = out.view(out_shape)
+                attn = attn.view(attn_shape)
+        return out, attn
+
+    query_head_dim = q_.size(3)
+    value_head_dim = v_.size(3)
+    sdpa_vector_supported_head_dim = (query_head_dim == value_head_dim) and (
+        query_head_dim == 64 or query_head_dim == 96 or query_head_dim == 128
+    )
+    query_seq_len = q_.size(2)
+    supports_sdpa_vector = (
+        (query_seq_len <= 8)
+        and (query_seq_len <= k_.size(2))
+        and ((mask_ is None) or (mask_.dtype == torch.bool))
+        and sdpa_vector_supported_head_dim
+    )
+    supports_fast_sdpa = (not is_causal) and supports_sdpa_vector
+
+    if not supports_fast_sdpa:
+        return sdpa_general_mps()
+    elif (max_seq_length >= 1024) or (k_size < q_size and max_seq_length >= 4096):
         return sdpa_vector_2pass_mps()
     else:
         return sdpa_vector_fast_mps()


### PR DESCRIPTION
This fixes MPS SDPA output shape for cases where `value.size(-1) != query.size(-1)`, so output now follows `(..., L, Ev)` as expected. I also added guards in Metal kernel paths that assume equal qkv head dims.

Added the updated meta shape inference for the `sdpa_general_mps` path which seems to have been left out initially.

Added regression coverage in `test/test_transformers.py` covering the shape semantics, and a similar one in `test/test_mps.py` that also checks for numerical parity with CPU.

Fixes #176767