### PR TITLE
Inductor Decomposition-Fix Return Value Type Mismatch On binary_cross_entropy_with_logits

### DIFF
--- a/test/test_decomp.py
+++ b/test/test_decomp.py
@@ -1074,7 +1074,9 @@ def forward(self, scores_1, mask_1, value_1):
         ref = torch.ops.aten.binary_cross_entropy_with_logits.default(**op_config)
 
         decomp_table = torch._inductor.decomposition.select_decomp_table()
-        bce_decomp = decomp_table[torch.ops.aten.binary_cross_entropy_with_logits.default]
+        bce_decomp = decomp_table[
+            torch.ops.aten.binary_cross_entropy_with_logits.default
+        ]
         res = bce_decomp(**op_config)
 
         torch.testing.assert_close(ref, res, check_dtype=True)
@@ -1304,6 +1306,7 @@ class DecompOneOffTests(TestCase):
 
 
 instantiate_device_type_tests(DecompOneOffTests, globals())
+
 
 class HasDecompTest(TestCase):
     def setUp(self):

--- a/test/test_decomp.py
+++ b/test/test_decomp.py
@@ -1063,6 +1063,22 @@ def forward(self, scores_1, mask_1, value_1):
                     "only backwards is decomposed, but dtype doesn't support AD"
                 )
 
+    def test_binary_cross_entropy_with_logits_decomp(self, device):
+        op_config = {
+            "self": torch.randn([4, 5, 6], dtype=torch.bfloat16, device=device),
+            "target": torch.randn([4, 5, 6], dtype=torch.bfloat16, device=device),
+            "weight": torch.randn([6], dtype=torch.float32, device=device),
+            "reduction": 2,
+        }
+
+        ref = torch.ops.aten.binary_cross_entropy_with_logits.default(**op_config)
+
+        decomp_table = torch._inductor.decomposition.select_decomp_table()
+        bce_decomp = decomp_table[torch.ops.aten.binary_cross_entropy_with_logits.default]
+        res = bce_decomp(**op_config)
+
+        torch.testing.assert_close(ref, res, check_dtype=True)
+
 
 instantiate_device_type_tests(TestDecomp, globals())
 
@@ -1288,7 +1304,6 @@ class DecompOneOffTests(TestCase):
 
 
 instantiate_device_type_tests(DecompOneOffTests, globals())
-
 
 class HasDecompTest(TestCase):
     def setUp(self):

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -4624,7 +4624,8 @@ def binary_cross_entropy_with_logits(
     if weight is not None:
         loss = loss * weight
 
-    # this is to align the resulted data type with the in-place operation in binary_cross_entropy_with_logits of aten/src/ATen/native/Loss.cpp
+    # this is to align the resulted data type with the in-place
+    # operation in binary_cross_entropy_with_logits of aten/src/ATen/native/Loss.cpp
     loss = loss.to(target.dtype)
     return apply_loss_reduction(loss, reduction)
 

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -4624,6 +4624,8 @@ def binary_cross_entropy_with_logits(
     if weight is not None:
         loss = loss * weight
 
+    # this is to align the resulted data type with the in-place operation in binary_cross_entropy_with_logits of aten/src/ATen/native/Loss.cpp
+    loss = loss.to(target.dtype)
     return apply_loss_reduction(loss, reduction)
 
 


### PR DESCRIPTION
Fixes #171282
In #171282, a mismatch between the eager mode and the inductor mode on binary_cross_entropy_with_logits is reported.
In general, inductor decomposition doesn't maintain the alignment on return value type.
This fix is to align the return type for binary_cross_entropy_with_logits.