### PR TITLE
Use PyObject_IsInstance instead of direct type comparison for torch.Event

### DIFF
--- a/torch/csrc/Event.cpp
+++ b/torch/csrc/Event.cpp
@@ -215,7 +215,7 @@ static PyObject* THPEvent_elapsed_time(PyObject* _self, PyObject* _other) {
   auto self = reinterpret_cast<THPEvent*>(_self);
   // We expect it to be an explicit torch.Event instance.
   TORCH_CHECK(
-      Py_TYPE(_other) == THPEventClass,
+      PyObject_IsInstance(_other, (PyObject*)THPEventClass),
       "expected other to be a torch.Event object");
   auto other = reinterpret_cast<THPEvent*>(_other);
   return PyFloat_FromDouble(self->event.elapsedTime(other->event));

--- a/torch/csrc/Stream.cpp
+++ b/torch/csrc/Stream.cpp
@@ -227,7 +227,7 @@ static PyObject* THPStream_record_event(
   if (_event != Py_None) {
     // We expect it to be an explicit torch.Event instance.
     TORCH_CHECK(
-        Py_TYPE(_event) == THPEventClass,
+        PyObject_IsInstance(_event, (PyObject*)THPEventClass),
         "expected event to be a torch.Event object");
     // Increase the refcount of the event to avoid it being destroyed.
     Py_INCREF(_event);


### PR DESCRIPTION
Replace direct type comparison with PyObject_IsInstance to support subclasses of torch.Event.