### PR TITLE
[ROCm][CI] Fix #168821: enable scaled_mm_deepseek_error_messages

### DIFF
--- a/test/test_scaled_matmul_cuda.py
+++ b/test/test_scaled_matmul_cuda.py
@@ -1626,12 +1626,11 @@ class TestFP8Matmul(TestCase):
             output_dtype
         )
 
-    @skipIfRocm
     @onlyCUDA
     @unittest.skipIf(not PLATFORM_SUPPORTS_FP8 or IS_WINDOWS, f8_msg)
     @unittest.skipIf(IS_SM90, "DeepSeek style (1x128, 128x128) blockwise scaling works on SM90 (Hopper)")
     @unittest.skipIf(
-        _get_torch_cuda_version() < (12, 9),
+        not torch.version.hip and _get_torch_cuda_version() < (12, 9),
         "cuBLAS blockwise scaling added in CUDA 12.9",
     )
     @parametrize("output_dtype", [torch.bfloat16, ])
@@ -1640,6 +1639,7 @@ class TestFP8Matmul(TestCase):
     def test_scaled_mm_deepseek_error_messages(
         self, output_dtype, lhs_block, rhs_block, M, N, K
     ):
+
         torch.manual_seed(42)
 
         x = torch.randn(M, K, device="cuda", dtype=output_dtype).pow(3)
@@ -1661,10 +1661,18 @@ class TestFP8Matmul(TestCase):
         else:
             rhs_recipe = ScalingType.BlockWise128x128
 
-        # Verify that actual F8 mm raises expected error on non-SM90
+        # Verify that actual F8 mm raises expected error
+        if torch.version.hip:
+            # ROCm does not yet support DeepSeek-style blockwise scaling
+            expected_error = ValueError
+            expected_pattern = "Invalid scaling configuration"
+        else:
+            # CUDA non-SM90 should raise NotImplementedError
+            expected_error = NotImplementedError
+            expected_pattern = ".*DeepSeek.*scaling.*only supported in CUDA for SM90.*"
         with self.assertRaisesRegex(
-            NotImplementedError,
-            ".*DeepSeek.*scaling.*only supported in CUDA for SM90.*"
+            expected_error,
+            expected_pattern
         ):
             scaled_mm_wrap(
                 x_fp8,


### PR DESCRIPTION
Fixes #168821

**Context**: this test is specifically designed for non-SM90 hardware with CUDA >= 12.9. The test verifies those GPUs produce a clear error message when someone tries Deepseek-style blockwise scaling, since only SM90 (Hopper) supports it from the Nvidia side. 

**Command to execute the test**: `PYTORCH_TEST_WITH_ROCM=1 python test/run_test.py -i test_scaled_matmul_cuda -- -k test_scaled_mm_deepseek_error_messages -v`

**The objective**: determine if Deepseek-styled scaled_mm is supported on ROCm. If not supported, remove `@skipIfRocm`, and ensure ROCm also raises a clear error message. This requires updating the test's `assertRaisesRegex` pattern to match both CUDA and ROCm error messages. If supported, remove `@skipIfRocm` and add a skip condition for the specific ROCm / GPU version where the test passes, similar to how the current `@unittest.skipIf(IS_SM90…)` is implemented. 

**Debugging**: as the test is currently skipped for ROCm configurations, I tested whether this feature is supported on MI300X with the newest PyTorch (version 2.12.0) build with ROCm (version 7.2.26015) backend. 

**My fix in this PR**: fix the decorators to enable ROCm tests and rerun them. The error produced now is `ValueError: Invalid scaling configuration`, it comes from `_scaled_mm_cuda_v2_out` at `/var/lib/jenkins/pytorch/aten/src/ATen/native/hip/ScaledBlas.cpp:1407`, showing the DeepSeek style blockwise scaling is rejected by validation inside `ScaledBlas.cpp`. Given this finding, and the current test expects NotImplementedError with "DeepSeek...SM90", but ROCm produces ValueError with "Invalid scaling configuration". The fix for the test is on ROCm, assert the error that ROCm actually produces. 

Result: all 6 test configurations now pass on ROCm

```
test_scaled_matmul_cuda.py::TestFP8MatmulCUDA::test_scaled_mm_deepseek_error_messages_bfloat16_lhs_block_128_rhs_block_1_M_256_N_256_K_256_cuda PASSED [0.1840s]                                                              [ 16%]
test_scaled_matmul_cuda.py::TestFP8MatmulCUDA::test_scaled_mm_deepseek_error_messages_bfloat16_lhs_block_128_rhs_block_1_M_256_N_256_K_512_cuda PASSED [0.0184s]                                                              [ 33%]
test_scaled_matmul_cuda.py::TestFP8MatmulCUDA::test_scaled_mm_deepseek_error_messages_bfloat16_lhs_block_1_rhs_block_128_M_256_N_256_K_256_cuda PASSED [0.0180s]                                                              [ 50%]
test_scaled_matmul_cuda.py::TestFP8MatmulCUDA::test_scaled_mm_deepseek_error_messages_bfloat16_lhs_block_1_rhs_block_128_M_256_N_256_K_512_cuda PASSED [0.0062s]                                                              [ 66%]
test_scaled_matmul_cuda.py::TestFP8MatmulCUDA::test_scaled_mm_deepseek_error_messages_bfloat16_lhs_block_1_rhs_block_1_M_256_N_256_K_256_cuda PASSED [0.0062s]                                                                [ 83%]
test_scaled_matmul_cuda.py::TestFP8MatmulCUDA::test_scaled_mm_deepseek_error_messages_bfloat16_lhs_block_1_rhs_block_1_M_256_N_256_K_512_cuda PASSED [0.0061s]  
```


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang