### PR TITLE
[XPU] test_indexing test_reductions: Remove obsolete XPU skip guards after verification

### DIFF
--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -25,7 +25,6 @@ from torch.testing._internal.common_device_type import (
     onlyOn,
     skipMPS,
     skipXLA,
-    skipXPUIf,
 )
 from torch.testing._internal.common_dtype import (
     all_mps_types_and,

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -2000,7 +2000,6 @@ class TestIndexing(TestCase):
         return (x, index, src)
 
     @onlyNativeDeviceTypes
-    @skipXPUIf(True, "https://github.com/intel/torch-xpu-ops/issues/1973")
     @expectedFailureMPS  # See https://github.com/pytorch/pytorch/issues/161029
     def test_index_copy_deterministic(self, device: torch.device) -> None:
         for dim in range(3):
@@ -2146,7 +2145,6 @@ class TestIndexing(TestCase):
                     self.assertEqual(y_nd, y0, atol=1e-3, rtol=1e-5)
 
     @onlyNativeDeviceTypes
-    @skipXPUIf(True, "https://github.com/intel/torch-xpu-ops/issues/1973")
     def test_index_put_non_accumulate_deterministic(self, device) -> None:
         with DeterministicGuard(True):
             for i in range(3):

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -3776,8 +3776,6 @@ as the input tensor excluding its innermost dimension'):
     @onlyOn(["cuda", "xpu"])
     @largeTensorTest("8GB")
     @dtypes(torch.half, torch.chalf, torch.bfloat16)
-    # skip chalf and half when XPU, see issues https://github.com/intel/torch-xpu-ops/issues/1973
-    @dtypesIfXPU(torch.bfloat16)
     def test_reductions_large_half_tensors(self, device, dtype):
         t = torch.ones(2**31, device=device, dtype=dtype)
         t[2**30:] = -1


### PR DESCRIPTION
Fixes:
https://github.com/intel/torch-xpu-ops/issues/1973

Remove obsolete XPU skip guards after verification in:
test_indexing
- test_index_put_non_accumulate_deterministic_xpu
- test_index_copy_deterministic_xpu
Verified on XPU: both tests pass.

test_reductions
- test_reductions_large_half_tensors_xpu_float16
- test_reductions_large_half_tensors_xpu_complex32
Both tests are now passing consistently on XPU.
