### PR TITLE
[ROCm][CK] Remove fmha_fwd_args fields not in fbsource CK version

### DIFF
--- a/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_fwd_ck.hip
+++ b/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_fwd_ck.hip
@@ -112,8 +112,6 @@ fmha_fwd_args get_ck_fmha_fwd_args(bool has_lse,
                          nullptr, // seqlen_k_ptr
                          nullptr, // cu_seqlen_q_ptr
                          nullptr, // cu_seqlen_k_ptr
-                         nullptr, // block_scale_seqstart_q_ptr
-                         nullptr, // block_scale_seqstart_k_ptr
                          nullptr, // sink_ptr
                          seqlen_q,
                          seqlen_k,
@@ -138,9 +136,6 @@ fmha_fwd_args get_ck_fmha_fwd_args(bool has_lse,
                          nhead_stride_randval,
                          nhead_stride_lse,
                          nhead_stride_o,
-                         0, // nhead_stride_q_descale
-                         0, // nhead_stride_k_descale
-                         0, // nhead_stride_v_descale
                          batch_stride_q,
                          batch_stride_k,
                          batch_stride_v,
@@ -148,9 +143,6 @@ fmha_fwd_args get_ck_fmha_fwd_args(bool has_lse,
                          batch_stride_randval,
                          batch_stride_lse,
                          batch_stride_o,
-                         0, // batch_stride_q_descale
-                         0, // batch_stride_k_descale
-                         0, // batch_stride_v_descale
                          mask.left,
                          mask.right,
                          0,                                 // sink_size
@@ -158,10 +150,7 @@ fmha_fwd_args get_ck_fmha_fwd_args(bool has_lse,
                          -1,                                // min_seqlen_q
                          p_dropout,
                          has_dropout_randval,
-                         drop_seed_offset,
-                         0, // block_scale_size_q
-                         0 // block_scale_size_kv
-                         };
+                         drop_seed_offset};
 }
 
 std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor>

--- a/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_varlen_fwd_ck.hip
+++ b/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_varlen_fwd_ck.hip
@@ -113,8 +113,6 @@ fmha_fwd_args get_ck_fmha_varlen_fwd_args(bool has_lse,
                          nullptr, // seqlen_k_ptr
                          nullptr, // cu_seqlen_q_ptr
                          nullptr, // cu_seqlen_k_ptr
-                         nullptr, // block_scale_seqstart_q_ptr
-                         nullptr, // block_scale_seqstart_k_ptr
                          nullptr, // sink_ptr
                          total_q,
                          total_k,
@@ -139,9 +137,6 @@ fmha_fwd_args get_ck_fmha_varlen_fwd_args(bool has_lse,
                          nhead_stride_randval,
                          nhead_stride_lse,
                          nhead_stride_o,
-                         0, // nhead_stride_q_descale
-                         0, // nhead_stride_k_descale
-                         0, // nhead_stride_v_descale
                          batch_stride_q,
                          batch_stride_k,
                          batch_stride_v,
@@ -149,9 +144,6 @@ fmha_fwd_args get_ck_fmha_varlen_fwd_args(bool has_lse,
                          batch_stride_randval,
                          batch_stride_lse,
                          batch_stride_o,
-                         0, // batch_stride_q_descale
-                         0, // batch_stride_k_descale
-                         0, // batch_stride_v_descale
                          mask.left,
                          mask.right,
                          0,             // sink_size
@@ -159,10 +151,7 @@ fmha_fwd_args get_ck_fmha_varlen_fwd_args(bool has_lse,
                          -1,                                // min_seqlen_q
                          p_dropout,
                          has_dropout_randval,
-                         drop_seed_offset,
-                         0, // block_scale_size_q
-                         0 // block_scale_size_kv
-                         };
+                         drop_seed_offset};
 }
 
 std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor>


### PR DESCRIPTION
## Summary
Forward fix for #172246 ([ROCm][CK] Enable variable-length attention support).

The internal fbsource build uses a pinned CK version that does not have 10 struct fields added for a newer CK:
- `block_scale_seqstart_{q,k}_ptr`
- `nhead_stride_{q,k,v}_descale`, `batch_stride_{q,k,v}_descale`
- `block_scale_size_{q,kv}`

These cause type mismatch build errors (`nullptr` for `int` fields, int/float narrowing).

Removes the extra fields from `fmha_fwd_args` initialization in both `mha_fwd_ck.hip` and `mha_varlen_fwd_ck.hip`.

## Test plan
- Combined test diff D95734289 is green
- `buck build --flagfile fbcode//mode/opt-amd-gpu fbcode//torchrec/sparse/tests:test_keyed_tensor`


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang