### PR TITLE
[dynamo] Use inductor_prims.fma for addcmul_ value=1 decomposition

### DIFF
--- a/test/dynamo/test_dynamo_decompositions.py
+++ b/test/dynamo/test_dynamo_decompositions.py
@@ -17,7 +17,7 @@ class TestDynamoDecompositions(torch._dynamo.test_case.TestCase):
 
     @skipIfCrossRef
     def test_addcmul_inplace_decomposition_enabled(self):
-        """With decompositions enabled, addcmul_ should decompose into mul and add_."""
+        """With decompositions enabled, addcmul_ should decompose into mul, fma, and copy_."""
 
         def fn(x, tensor1, tensor2, value):
             return x.addcmul_(tensor1, tensor2, value=value)
@@ -122,7 +122,7 @@ class GraphModule(torch.nn.Module):
 
     @skipIfCrossRef
     def test_add_inplace_with_alpha_decomposition_enabled(self):
-        """With decompositions enabled, add_ with alpha should decompose into mul and add_."""
+        """With decompositions enabled, add_ with tensor alpha should decompose into fma and copy_."""
 
         def fn(x, other, alpha):
             return x.add_(other, alpha=alpha)
@@ -220,7 +220,7 @@ class GraphModule(torch.nn.Module):
 
     @skipIfCrossRef
     def test_addcdiv_inplace_decomposition_enabled(self):
-        """With decompositions enabled, addcdiv_ should decompose into div, mul, and add_."""
+        """With decompositions enabled, addcdiv_ should decompose into div, fma, and copy_."""
 
         def fn(x, tensor1, tensor2, value):
             return x.addcdiv_(tensor1, tensor2, value=value)
@@ -562,6 +562,56 @@ class GraphModule(torch.nn.Module):
         return (getitem, getitem_1)
 """,
         )
+
+    @skipIfCrossRef
+    @torch._dynamo.config.patch(enable_dynamo_decompositions=True)
+    def test_addcmul_tensor_value_numerics(self):
+        """Compiled addcmul_ with tensor value matches eager."""
+
+        def fn(x, tensor1, tensor2, value):
+            return x.addcmul_(tensor1, tensor2, value=value)
+
+        x = torch.randn(4)
+        tensor1 = torch.randn(4)
+        tensor2 = torch.randn(4)
+        value = torch.tensor(0.5)
+
+        expected = fn(x.clone(), tensor1, tensor2, value)
+        actual = torch.compile(fn, fullgraph=True)(x.clone(), tensor1, tensor2, value)
+        self.assertEqual(expected, actual)
+
+    @skipIfCrossRef
+    @torch._dynamo.config.patch(enable_dynamo_decompositions=True)
+    def test_addcdiv_tensor_value_numerics(self):
+        """Compiled addcdiv_ with tensor value matches eager."""
+
+        def fn(x, tensor1, tensor2, value):
+            return x.addcdiv_(tensor1, tensor2, value=value)
+
+        x = torch.randn(4)
+        tensor1 = torch.randn(4)
+        tensor2 = torch.randn(4) + 0.1
+        value = torch.tensor(0.5)
+
+        expected = fn(x.clone(), tensor1, tensor2, value)
+        actual = torch.compile(fn, fullgraph=True)(x.clone(), tensor1, tensor2, value)
+        self.assertEqual(expected, actual)
+
+    @skipIfCrossRef
+    @torch._dynamo.config.patch(enable_dynamo_decompositions=True)
+    def test_add_tensor_alpha_numerics(self):
+        """Compiled add_ with tensor alpha matches eager."""
+
+        def fn(x, other, alpha):
+            return x.add_(other, alpha=alpha)
+
+        x = torch.randn(4)
+        other = torch.randn(4)
+        alpha = torch.tensor(2.0)
+
+        expected = fn(x.clone(), other, alpha)
+        actual = torch.compile(fn, fullgraph=True)(x.clone(), other, alpha)
+        self.assertEqual(expected, actual)
 
 
 if __name__ == "__main__":

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -1432,6 +1432,15 @@ class TensorVariable(VariableTracker):
         value: Any | None = None,
     ) -> Any | None:
         if value is not None and config.enable_dynamo_decompositions:
+            # When value == 1, ATen's addcmul_ kernel uses fma(t1, t2, self)
+            # internally. Using fma directly preserves that precision; the
+            # alternative mul(t1, t2) + add_ would round the product first.
+            if isinstance(value, variables.ConstantVariable) and value.value == 1:
+                from torch._inductor import inductor_prims
+
+                fma_var = variables.TorchInGraphFunctionVariable(inductor_prims.fma)
+                result = fma_var.call_function(tx, [tensor1, tensor2, self], {})
+                return self.call_method(tx, "copy_", [result], {})
             from .. import polyfills
 
             return tx.inline_user_function_return(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #176867
* __->__ #176866
* #176807
* #176806
* #176805
* #176804

ATen's addcmul_ kernel uses hardware fma when value=1, computing
fma(t1, t2, self) as a single operation. The previous decomposition
(mul + add_) rounds the product before adding, causing precision
divergence in optimizers like Adagrad that use addcmul_(grad, grad, value=1).

This uses inductor_prims.fma directly for the value=1 case to match
ATen's precision. For value != 1, ATen does mul+add (no fma), so we
keep the polyfill decomposition for that path.

Also adds numeric correctness tests for tensor-valued addcmul_, addcdiv_,
and add_ alpha.

Authored with Claude.