### PR TITLE
XPU: fallback to expandable seegments when allocaton exceeds max_mem_…

### DIFF
--- a/c10/xpu/XPUCachingAllocator.cpp
+++ b/c10/xpu/XPUCachingAllocator.cpp
@@ -1,6 +1,7 @@
 #include <c10/util/flat_hash_map.h>
 #include <c10/util/irange.h>
 #include <c10/xpu/XPUCachingAllocator.h>
+#include <c10/xpu/XPUFunctions.h>
 
 #include <deque>
 #include <mutex>
@@ -919,6 +920,20 @@ class DeviceCachingAllocator {
     } else {
       allocPrimitive(&ptr, size, p);
       if (!ptr) {
+        // When a direct allocation fails and the requested size exceeds the
+        // device's max_mem_alloc_size (Level Zero limit, typically ~4 GiB),
+        // fall back to expandable segments which use virtual memory with
+        // smaller physical memory chunks to bypass the per-allocation limit.
+        auto max_alloc = c10::xpu::get_raw_device(p.device())
+            .get_info<sycl::info::device::max_mem_alloc_size>();
+        if (size > max_alloc && !active_pool) {
+          p.block = try_allocate_expandable_block(
+              p.device(), p.queue(), p.pool, p.size());
+          if (p.block && p.pool->owner_PrivatePool) {
+            p.pool->owner_PrivatePool->allocation_count++;
+          }
+          return bool(p.block);
+        }
         return false;
       }
     }


### PR DESCRIPTION
…alloc_size

Level Zero imposes a per-allocation limit (max_mem_alloc_size) on XPU devices. When a single allocation request exceeds this lmit, the direct allocPrimitive call fails even if enough total free memoy exists, producing a misleadning XPU out-of-memory error.

When allocPrimitive fails and the requested size exceed the device's max_mem_alloc_size, fall back to try_allocate_expandable_block. Expandable segments back lage virtual memory reservations with multiple smaller physical chunks, each within the per-allocation limit, effectively bypassing the Level Zero restriction.

The allocation_count on th owning PrivatePool is incremented so pool accounting remains consistent with the non-fallback path.

Fixes: https://github.com/intel/torch-xpu-ops/issues/3011