### PR TITLE
[inductor] Add SGD to bitwise optimizer tests

### DIFF
--- a/test/inductor/test_compiled_optimizers.py
+++ b/test/inductor/test_compiled_optimizers.py
@@ -1103,12 +1103,32 @@ def _make_bitwise_test(optim_cls, **optim_kwargs):
     return test_fn
 
 
+_BITWISE_CAPTURABLE_OPTIMS = (
+    Adam,
+    AdamW,
+    Adadelta,
+    Adamax,
+    ASGD,
+    NAdam,
+    RAdam,
+    RMSprop,
+    Rprop,
+)
+# SGD doesn't support capturable but has no item() calls
+# so it compiles without graph breaks and can be tested bitwise.
+_BITWISE_NON_CAPTURABLE_OPTIMS = (SGD,)
 for optim_cls, name, kwargs, scheduler_cls in COMPILED_OPT_KWARG_DB:
     if (
-        optim_cls in (Adam, AdamW, Adadelta, Adamax, ASGD, NAdam, RAdam, RMSprop, Rprop)
-        and kwargs.get("capturable", False)
-        and kwargs.get("device") == GPU_TYPE
+        kwargs.get("device") == GPU_TYPE
         and "tensor_lr" not in name
+        and scheduler_cls is None
+        and (
+            (
+                optim_cls in _BITWISE_CAPTURABLE_OPTIMS
+                and kwargs.get("capturable", False)
+            )
+            or optim_cls in _BITWISE_NON_CAPTURABLE_OPTIMS
+        )
     ):
         optim_kwargs = {
             k: v for k, v in kwargs.items() if k not in ("device", "kernel_count")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #176870
* #176869
* #176807
* #176806
* #176805
* #176804

SGD has no .item() calls and doesn't need capturable, so it can be
compiled without graph breaks. Adds all 14 SGD test variants to the
bitwise test suite.

Authored with Claude.