### PR TITLE
[dynamo] Use inductor_prims.fma for addcmul_/addcdiv_ tensor value decomposition

### DIFF
--- a/test/dynamo/test_dynamo_decompositions.py
+++ b/test/dynamo/test_dynamo_decompositions.py
@@ -1,5 +1,7 @@
 # Owner(s): ["module: dynamo"]
 
+import unittest
+
 import torch
 import torch._dynamo.config
 import torch._dynamo.test_case
@@ -17,7 +19,7 @@ class TestDynamoDecompositions(torch._dynamo.test_case.TestCase):
 
     @skipIfCrossRef
     def test_addcmul_inplace_decomposition_enabled(self):
-        """With decompositions enabled, addcmul_ should decompose into mul and add_."""
+        """With decompositions enabled, addcmul_ should decompose into mul, fma, and copy_."""
 
         def fn(x, tensor1, tensor2, value):
             return x.addcmul_(tensor1, tensor2, value=value)
@@ -43,10 +45,10 @@ class GraphModule(torch.nn.Module):
         l_tensor2_ = L_tensor2_
         l_value_ = L_value_
 
-        mul: "f32[4]" = l_tensor1_ * l_tensor2_;  l_tensor1_ = l_tensor2_ = None
-        mul_1: "f32[4]" = torch.mul(mul, l_value_);  mul = l_value_ = None
-        add_: "f32[4]" = l_x_.add_(mul_1);  l_x_ = mul_1 = None
-        return (add_,)
+        mul: "f32[4]" = torch.mul(l_tensor1_, l_tensor2_);  l_tensor1_ = l_tensor2_ = None
+        fma_default: "f32[4]" = torch.ops.prims.fma.default(mul, l_value_, l_x_);  mul = l_value_ = None
+        copy_: "f32[4]" = l_x_.copy_(fma_default);  l_x_ = fma_default = None
+        return (copy_,)
 """,
         )
 
@@ -122,7 +124,7 @@ class GraphModule(torch.nn.Module):
 
     @skipIfCrossRef
     def test_add_inplace_with_alpha_decomposition_enabled(self):
-        """With decompositions enabled, add_ with alpha should decompose into mul and add_."""
+        """With decompositions enabled, add_ with tensor alpha should decompose into fma and copy_."""
 
         def fn(x, other, alpha):
             return x.add_(other, alpha=alpha)
@@ -220,7 +222,10 @@ class GraphModule(torch.nn.Module):
 
     @skipIfCrossRef
     def test_addcdiv_inplace_decomposition_enabled(self):
-        """With decompositions enabled, addcdiv_ should decompose into div, mul, and add_."""
+        """With decompositions enabled, addcdiv_ should decompose into div, fma, and copy_.
+
+        ATen computes self + value * (t1/t2), nvcc fuses to fma(value, quotient, self).
+        """
 
         def fn(x, tensor1, tensor2, value):
             return x.addcdiv_(tensor1, tensor2, value=value)
@@ -247,9 +252,9 @@ class GraphModule(torch.nn.Module):
         l_value_ = L_value_
 
         div: "f32[4]" = torch.div(l_tensor1_, l_tensor2_);  l_tensor1_ = l_tensor2_ = None
-        mul: "f32[4]" = torch.mul(div, l_value_);  div = l_value_ = None
-        add_: "f32[4]" = l_x_.add_(mul);  l_x_ = mul = None
-        return (add_,)
+        fma_default: "f32[4]" = torch.ops.prims.fma.default(div, l_value_, l_x_);  div = l_value_ = None
+        copy_: "f32[4]" = l_x_.copy_(fma_default);  l_x_ = fma_default = None
+        return (copy_,)
 """,
         )
 
@@ -562,6 +567,123 @@ class GraphModule(torch.nn.Module):
         return (getitem, getitem_1)
 """,
         )
+
+    @skipIfCrossRef
+    @torch._dynamo.config.patch(enable_dynamo_decompositions=True)
+    def test_addcmul_tensor_value_numerics(self):
+        """Compiled addcmul_ with tensor value matches eager."""
+
+        def fn(x, tensor1, tensor2, value):
+            return x.addcmul_(tensor1, tensor2, value=value)
+
+        x = torch.randn(4)
+        tensor1 = torch.randn(4)
+        tensor2 = torch.randn(4)
+        value = torch.tensor(0.5)
+
+        expected = fn(x.clone(), tensor1, tensor2, value)
+        actual = torch.compile(fn, fullgraph=True)(x.clone(), tensor1, tensor2, value)
+        self.assertEqual(expected, actual)
+
+    @skipIfCrossRef
+    @torch._dynamo.config.patch(enable_dynamo_decompositions=True)
+    def test_addcdiv_tensor_value_numerics(self):
+        """Compiled addcdiv_ with tensor value matches eager."""
+
+        def fn(x, tensor1, tensor2, value):
+            return x.addcdiv_(tensor1, tensor2, value=value)
+
+        x = torch.randn(4)
+        tensor1 = torch.randn(4)
+        tensor2 = torch.randn(4) + 0.1
+        value = torch.tensor(0.5)
+
+        expected = fn(x.clone(), tensor1, tensor2, value)
+        actual = torch.compile(fn, fullgraph=True)(x.clone(), tensor1, tensor2, value)
+        self.assertEqual(expected, actual)
+
+    @skipIfCrossRef
+    @torch._dynamo.config.patch(enable_dynamo_decompositions=True)
+    def test_add_tensor_alpha_numerics(self):
+        """Compiled add_ with tensor alpha matches eager."""
+
+        def fn(x, other, alpha):
+            return x.add_(other, alpha=alpha)
+
+        x = torch.randn(4)
+        other = torch.randn(4)
+        alpha = torch.tensor(2.0)
+
+        expected = fn(x.clone(), other, alpha)
+        actual = torch.compile(fn, fullgraph=True)(x.clone(), other, alpha)
+        self.assertEqual(expected, actual)
+
+    @skipIfCrossRef
+    @torch._dynamo.config.patch(enable_dynamo_decompositions=True)
+    @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
+    def test_addcmul_value_1_fma_matches_aten_cuda(self):
+        """On CUDA, ATen addcmul_ with value=1 uses hardware fma(t1, t2, self).
+
+        Our decomposition uses inductor_prims.fma for this case. Without fma,
+        mul(t1, t2) + self rounds the product first, causing ~7% element
+        mismatches on typical inputs (e.g. Adagrad's addcmul_(grad, grad, value=1)).
+        """
+        torch.manual_seed(42)
+        x = torch.randn(64, 64, device="cuda")
+        t1 = torch.randn(64, 64, device="cuda")
+
+        def fn(x, t1):
+            # value=1 is a constant, triggers fma path in decomposition
+            return x.addcmul_(t1, t1, value=1)
+
+        expected = fn(x.clone(), t1)
+        actual = torch.compile(fn, fullgraph=True)(x.clone(), t1)
+        self.assertEqual(expected, actual)
+
+    @skipIfCrossRef
+    @torch._dynamo.config.patch(enable_dynamo_decompositions=True)
+    @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
+    def test_addcmul_scalar_value_neq_1_cuda(self):
+        """On CUDA, ATen addcmul_ with value!=1 uses mul+add (no fma).
+
+        The polyfill self.add_(t1 * t2, alpha=value) matches this. Inductor's
+        add lowering then applies fma for the alpha multiply, but since ATen
+        also fuses this with nvcc --fmad, both paths agree.
+        """
+        torch.manual_seed(42)
+        x = torch.randn(64, 64, device="cuda")
+        t1 = torch.randn(64, 64, device="cuda")
+        t2 = torch.randn(64, 64, device="cuda")
+        value = torch.tensor(0.5)
+
+        def fn(x, t1, t2, value):
+            return x.addcmul_(t1, t2, value=value)
+
+        expected = fn(x.clone(), t1, t2, value)
+        actual = torch.compile(fn, fullgraph=True)(x.clone(), t1, t2, value)
+        self.assertEqual(expected, actual)
+
+    @skipIfCrossRef
+    @torch._dynamo.config.patch(enable_dynamo_decompositions=True)
+    @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
+    def test_addcdiv_scalar_value_cuda(self):
+        """On CUDA, ATen addcdiv_ computes self + value * (t1 / t2).
+
+        nvcc fuses the multiply-add into fma. The scalar alpha path through
+        add_(quotient, alpha=value) gets fma via inductor's lowering, matching
+        ATen's behavior.
+        """
+        torch.manual_seed(42)
+        x = torch.randn(64, 64, device="cuda")
+        t1 = torch.randn(64, 64, device="cuda")
+        t2 = torch.randn(64, 64, device="cuda") + 0.1
+
+        def fn(x, t1, t2):
+            return x.addcdiv_(t1, t2, value=-0.01)
+
+        expected = fn(x.clone(), t1, t2)
+        actual = torch.compile(fn, fullgraph=True)(x.clone(), t1, t2)
+        self.assertEqual(expected, actual)
 
 
 if __name__ == "__main__":

--- a/torch/_dynamo/polyfills/__init__.py
+++ b/torch/_dynamo/polyfills/__init__.py
@@ -533,11 +533,6 @@ def foreach_pow_scalar(
     return torch._foreach_pow([scalar for _ in exps], exps)
 
 
-def addcmul_inplace(
-    self, tensor1: torch.Tensor, tensor2: torch.Tensor, value: Any
-) -> None:
-    return self.add_(tensor1 * tensor2, alpha=value)
-
 
 def predicate(obj: object) -> bool:
     # This will cause the rest of dynamo to handle the if statement correctly, so we don't have to rewrite it here.

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -1432,28 +1432,13 @@ class TensorVariable(VariableTracker):
         value: Any | None = None,
     ) -> Any | None:
         if value is not None and config.enable_dynamo_decompositions:
-            if isinstance(value, TensorVariable):
-                # Tensor value: ATen always extracts the scalar and computes
-                # fma(t1*t2, value, self) via nvcc fmad. We match this by
-                # computing mul(t1, t2) then fma(product, value, self) —
-                # same rounding order as the scalar polyfill path.
-                from torch._inductor import inductor_prims
+            from torch._inductor import inductor_prims
 
-                mul_var = variables.TorchInGraphFunctionVariable(torch.mul)
-                fma_var = variables.TorchInGraphFunctionVariable(inductor_prims.fma)
-                product = mul_var.call_function(tx, [tensor1, tensor2], {})
-                result = fma_var.call_function(tx, [product, value, self], {})
-                return self.call_method(tx, "copy_", [result], {})
-            # Scalar value: polyfill routes through add_(t1*t2, alpha=value).
-            # Inductor's add lowering emits fma(t1*t2, value, self) which
-            # matches ATen's nvcc fusion empirically.
-            from .. import polyfills
-
-            return tx.inline_user_function_return(
-                VariableTracker.build(tx, polyfills.addcmul_inplace),
-                [self, tensor1, tensor2, value],
-                {},
-            )
+            mul_var = variables.TorchInGraphFunctionVariable(torch.mul)
+            fma_var = variables.TorchInGraphFunctionVariable(inductor_prims.fma)
+            product = mul_var.call_function(tx, [tensor1, tensor2], {})
+            result = fma_var.call_function(tx, [product, value, self], {})
+            return self.call_method(tx, "copy_", [result], {})
         return None
 
     def method___setitem__(
@@ -1597,18 +1582,11 @@ class TensorVariable(VariableTracker):
             result = variables.TorchInGraphFunctionVariable(torch.div).call_function(
                 tx, [tensor1, tensor2], {}
             )
-            if isinstance(value, TensorVariable):
-                # Tensor value: use fma to match ATen's nvcc fusion
-                # fma(value, quotient, self). The old mul+add path had
-                # no fma for tensor values.
-                from torch._inductor import inductor_prims
+            from torch._inductor import inductor_prims
 
-                fma_var = variables.TorchInGraphFunctionVariable(inductor_prims.fma)
-                fma_result = fma_var.call_function(tx, [result, value, self], {})
-                return self.call_method(tx, "copy_", [fma_result], {})
-            # Scalar value: add_(quotient, alpha=value) lets inductor's
-            # add lowering emit fma(quotient, value, self), matching ATen.
-            return self.call_method(tx, "add_", [result], {"alpha": value})
+            fma_var = variables.TorchInGraphFunctionVariable(inductor_prims.fma)
+            fma_result = fma_var.call_function(tx, [result, value, self], {})
+            return self.call_method(tx, "copy_", [fma_result], {})
         return None
 
     def method___contains__(

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -1432,6 +1432,21 @@ class TensorVariable(VariableTracker):
         value: Any | None = None,
     ) -> Any | None:
         if value is not None and config.enable_dynamo_decompositions:
+            if isinstance(value, TensorVariable):
+                # Tensor value: ATen always extracts the scalar and computes
+                # fma(t1*t2, value, self) via nvcc fmad. We match this by
+                # computing mul(t1, t2) then fma(product, value, self) —
+                # same rounding order as the scalar polyfill path.
+                from torch._inductor import inductor_prims
+
+                mul_var = variables.TorchInGraphFunctionVariable(torch.mul)
+                fma_var = variables.TorchInGraphFunctionVariable(inductor_prims.fma)
+                product = mul_var.call_function(tx, [tensor1, tensor2], {})
+                result = fma_var.call_function(tx, [product, value, self], {})
+                return self.call_method(tx, "copy_", [result], {})
+            # Scalar value: polyfill routes through add_(t1*t2, alpha=value).
+            # Inductor's add lowering emits fma(t1*t2, value, self) which
+            # matches ATen's nvcc fusion empirically.
             from .. import polyfills
 
             return tx.inline_user_function_return(
@@ -1582,6 +1597,17 @@ class TensorVariable(VariableTracker):
             result = variables.TorchInGraphFunctionVariable(torch.div).call_function(
                 tx, [tensor1, tensor2], {}
             )
+            if isinstance(value, TensorVariable):
+                # Tensor value: use fma to match ATen's nvcc fusion
+                # fma(value, quotient, self). The old mul+add path had
+                # no fma for tensor values.
+                from torch._inductor import inductor_prims
+
+                fma_var = variables.TorchInGraphFunctionVariable(inductor_prims.fma)
+                fma_result = fma_var.call_function(tx, [result, value, self], {})
+                return self.call_method(tx, "copy_", [fma_result], {})
+            # Scalar value: add_(quotient, alpha=value) lets inductor's
+            # add lowering emit fma(quotient, value, self), matching ATen.
             return self.call_method(tx, "add_", [result], {"alpha": value})
         return None
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #176874
* #176873
* #176872
* __->__ #176871
* #176807
* #176806
* #176805
* #176804

ATen's addcmul_/addcdiv_ kernels always extract scalars from tensor
values and compute the same fused multiply-add via nvcc --fmad. Both
the scalar and tensor decomposition paths now match this:

- addcmul_: mul(t1, t2) then fma(product, value, self)
- addcdiv_: div(t1, t2) then fma(quotient, value, self)

For scalar values, the polyfill and add_(alpha=scalar) paths already
produce the same fma through inductor's add lowering. For tensor
values, this change adds explicit inductor_prims.fma calls where
previously there was only mul + add_ with no fma.

Also adds CUDA edge case tests verifying fma precision for addcmul_
and addcdiv_ decompositions.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo