### PR TITLE
[dynamo] Use fma for add_ with tensor alpha decomposition

### DIFF
--- a/test/dynamo/test_dynamo_decompositions.py
+++ b/test/dynamo/test_dynamo_decompositions.py
@@ -571,7 +571,11 @@ class GraphModule(torch.nn.Module):
     @skipIfCrossRef
     @torch._dynamo.config.patch(enable_dynamo_decompositions=True)
     def test_addcmul_tensor_value_numerics(self):
-        """Compiled addcmul_ with tensor value matches eager."""
+        """Compiled addcmul_ with tensor value matches eager.
+
+        Not bitwise on CPU: inductor may decompose fma to mul+add rather
+        than emitting a hardware fma instruction.
+        """
 
         def fn(x, tensor1, tensor2, value):
             return x.addcmul_(tensor1, tensor2, value=value)
@@ -600,7 +604,7 @@ class GraphModule(torch.nn.Module):
 
         expected = fn(x.clone(), tensor1, tensor2, value)
         actual = torch.compile(fn, fullgraph=True)(x.clone(), tensor1, tensor2, value)
-        self.assertEqual(expected, actual)
+        self.assertEqual(expected, actual, atol=0, rtol=0)
 
     @skipIfCrossRef
     @torch._dynamo.config.patch(enable_dynamo_decompositions=True)
@@ -616,7 +620,7 @@ class GraphModule(torch.nn.Module):
 
         expected = fn(x.clone(), other, alpha)
         actual = torch.compile(fn, fullgraph=True)(x.clone(), other, alpha)
-        self.assertEqual(expected, actual)
+        self.assertEqual(expected, actual, atol=0, rtol=0)
 
     @skipIfCrossRef
     @torch._dynamo.config.patch(enable_dynamo_decompositions=True)
@@ -634,7 +638,7 @@ class GraphModule(torch.nn.Module):
 
         expected = fn(x.clone(), other, alpha)
         actual = torch.compile(fn, fullgraph=True)(x.clone(), other, alpha)
-        self.assertEqual(expected, actual)
+        self.assertEqual(expected, actual, atol=0, rtol=0)
 
     @skipIfCrossRef
     @torch._dynamo.config.patch(enable_dynamo_decompositions=True)
@@ -656,7 +660,7 @@ class GraphModule(torch.nn.Module):
 
         expected = fn(x.clone(), t1)
         actual = torch.compile(fn, fullgraph=True)(x.clone(), t1)
-        self.assertEqual(expected, actual)
+        self.assertEqual(expected, actual, atol=0, rtol=0)
 
     @skipIfCrossRef
     @torch._dynamo.config.patch(enable_dynamo_decompositions=True)
@@ -673,7 +677,7 @@ class GraphModule(torch.nn.Module):
 
         expected = fn(x.clone(), t1, t2)
         actual = torch.compile(fn, fullgraph=True)(x.clone(), t1, t2)
-        self.assertEqual(expected, actual)
+        self.assertEqual(expected, actual, atol=0, rtol=0)
 
     @skipIfCrossRef
     @torch._dynamo.config.patch(enable_dynamo_decompositions=True)
@@ -691,13 +695,17 @@ class GraphModule(torch.nn.Module):
 
         expected = fn(x.clone(), t1, t2, value)
         actual = torch.compile(fn, fullgraph=True)(x.clone(), t1, t2, value)
-        self.assertEqual(expected, actual)
+        self.assertEqual(expected, actual, atol=0, rtol=0)
 
     @skipIfCrossRef
     @torch._dynamo.config.patch(enable_dynamo_decompositions=True)
     @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
     def test_addcdiv_scalar_value_cuda(self):
-        """Compiled addcdiv_ with scalar value matches eager on CUDA."""
+        """Compiled addcdiv_ with scalar value matches eager on CUDA.
+
+        Not bitwise: ATen inlines the division into fma(alpha, t1/t2, input)
+        which nvcc can optimize differently than separate div + fma kernels.
+        """
         torch.manual_seed(42)
         x = torch.randn(64, 64, device="cuda")
         t1 = torch.randn(64, 64, device="cuda")
@@ -714,7 +722,11 @@ class GraphModule(torch.nn.Module):
     @torch._dynamo.config.patch(enable_dynamo_decompositions=True)
     @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
     def test_addcdiv_tensor_value_cuda(self):
-        """Compiled addcdiv_ with tensor value matches eager on CUDA."""
+        """Compiled addcdiv_ with tensor value matches eager on CUDA.
+
+        Not bitwise: ATen inlines the division into fma(alpha, t1/t2, input)
+        which nvcc can optimize differently than separate div + fma kernels.
+        """
         torch.manual_seed(42)
         x = torch.randn(64, 64, device="cuda")
         t1 = torch.randn(64, 64, device="cuda")
@@ -742,7 +754,7 @@ class GraphModule(torch.nn.Module):
 
         expected = fn(x.clone(), other)
         actual = torch.compile(fn, fullgraph=True)(x.clone(), other)
-        self.assertEqual(expected, actual)
+        self.assertEqual(expected, actual, atol=0, rtol=0)
 
 
 if __name__ == "__main__":

--- a/test/dynamo/test_dynamo_decompositions.py
+++ b/test/dynamo/test_dynamo_decompositions.py
@@ -148,9 +148,9 @@ class GraphModule(torch.nn.Module):
         l_other_ = L_other_
         l_alpha_ = L_alpha_
 
-        mul: "f32[4]" = torch.mul(l_other_, l_alpha_);  l_other_ = l_alpha_ = None
-        add_: "f32[4]" = l_x_.add_(mul);  l_x_ = mul = None
-        return (add_,)
+        fma_default: "f32[4]" = torch.ops.prims.fma.default(l_other_, l_alpha_, l_x_);  l_other_ = l_alpha_ = None
+        copy_: "f32[4]" = l_x_.copy_(fma_default);  l_x_ = fma_default = None
+        return (copy_,)
 """,
         )
 
@@ -621,6 +621,24 @@ class GraphModule(torch.nn.Module):
     @skipIfCrossRef
     @torch._dynamo.config.patch(enable_dynamo_decompositions=True)
     @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
+    def test_add_tensor_alpha_fma_matches_aten_cuda(self):
+        """On CUDA, ATen add_ with tensor alpha extracts the scalar and uses
+        fma(other, alpha, self). Our decomposition must use fma to match."""
+        torch.manual_seed(42)
+        x = torch.randn(64, 64, device="cuda")
+        other = torch.randn(64, 64, device="cuda")
+        alpha = torch.tensor(2.3, device="cuda")
+
+        def fn(x, other, alpha):
+            return x.add_(other, alpha=alpha)
+
+        expected = fn(x.clone(), other, alpha)
+        actual = torch.compile(fn, fullgraph=True)(x.clone(), other, alpha)
+        self.assertEqual(expected, actual)
+
+    @skipIfCrossRef
+    @torch._dynamo.config.patch(enable_dynamo_decompositions=True)
+    @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
     def test_addcmul_value_1_fma_matches_aten_cuda(self):
         """On CUDA, ATen addcmul_ with value=1 uses hardware fma(t1, t2, self).
 
@@ -643,18 +661,30 @@ class GraphModule(torch.nn.Module):
     @skipIfCrossRef
     @torch._dynamo.config.patch(enable_dynamo_decompositions=True)
     @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
-    def test_addcmul_scalar_value_neq_1_cuda(self):
-        """On CUDA, ATen addcmul_ with value!=1 uses mul+add (no fma).
-
-        The polyfill self.add_(t1 * t2, alpha=value) matches this. Inductor's
-        add lowering then applies fma for the alpha multiply, but since ATen
-        also fuses this with nvcc --fmad, both paths agree.
-        """
+    def test_addcmul_scalar_value_cuda(self):
+        """Compiled addcmul_ with scalar value matches eager on CUDA."""
         torch.manual_seed(42)
         x = torch.randn(64, 64, device="cuda")
         t1 = torch.randn(64, 64, device="cuda")
         t2 = torch.randn(64, 64, device="cuda")
-        value = torch.tensor(0.5)
+
+        def fn(x, t1, t2):
+            return x.addcmul_(t1, t2, value=0.5)
+
+        expected = fn(x.clone(), t1, t2)
+        actual = torch.compile(fn, fullgraph=True)(x.clone(), t1, t2)
+        self.assertEqual(expected, actual)
+
+    @skipIfCrossRef
+    @torch._dynamo.config.patch(enable_dynamo_decompositions=True)
+    @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
+    def test_addcmul_tensor_value_cuda(self):
+        """Compiled addcmul_ with tensor value matches eager on CUDA."""
+        torch.manual_seed(42)
+        x = torch.randn(64, 64, device="cuda")
+        t1 = torch.randn(64, 64, device="cuda")
+        t2 = torch.randn(64, 64, device="cuda")
+        value = torch.tensor(0.5, device="cuda")
 
         def fn(x, t1, t2, value):
             return x.addcmul_(t1, t2, value=value)
@@ -667,12 +697,7 @@ class GraphModule(torch.nn.Module):
     @torch._dynamo.config.patch(enable_dynamo_decompositions=True)
     @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
     def test_addcdiv_scalar_value_cuda(self):
-        """On CUDA, ATen addcdiv_ computes self + value * (t1 / t2).
-
-        nvcc fuses the multiply-add into fma. The scalar alpha path through
-        add_(quotient, alpha=value) gets fma via inductor's lowering, matching
-        ATen's behavior.
-        """
+        """Compiled addcdiv_ with scalar value matches eager on CUDA."""
         torch.manual_seed(42)
         x = torch.randn(64, 64, device="cuda")
         t1 = torch.randn(64, 64, device="cuda")
@@ -683,6 +708,40 @@ class GraphModule(torch.nn.Module):
 
         expected = fn(x.clone(), t1, t2)
         actual = torch.compile(fn, fullgraph=True)(x.clone(), t1, t2)
+        self.assertEqual(expected, actual)
+
+    @skipIfCrossRef
+    @torch._dynamo.config.patch(enable_dynamo_decompositions=True)
+    @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
+    def test_addcdiv_tensor_value_cuda(self):
+        """Compiled addcdiv_ with tensor value matches eager on CUDA."""
+        torch.manual_seed(42)
+        x = torch.randn(64, 64, device="cuda")
+        t1 = torch.randn(64, 64, device="cuda")
+        t2 = torch.randn(64, 64, device="cuda") + 0.1
+        value = torch.tensor(-0.01, device="cuda")
+
+        def fn(x, t1, t2, value):
+            return x.addcdiv_(t1, t2, value=value)
+
+        expected = fn(x.clone(), t1, t2, value)
+        actual = torch.compile(fn, fullgraph=True)(x.clone(), t1, t2, value)
+        self.assertEqual(expected, actual)
+
+    @skipIfCrossRef
+    @torch._dynamo.config.patch(enable_dynamo_decompositions=True)
+    @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
+    def test_add_scalar_alpha_cuda(self):
+        """Compiled add_ with scalar alpha matches eager on CUDA."""
+        torch.manual_seed(42)
+        x = torch.randn(64, 64, device="cuda")
+        other = torch.randn(64, 64, device="cuda")
+
+        def fn(x, other):
+            return x.add_(other, alpha=2.3)
+
+        expected = fn(x.clone(), other)
+        actual = torch.compile(fn, fullgraph=True)(x.clone(), other)
         self.assertEqual(expected, actual)
 
 

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -1555,19 +1555,18 @@ class TensorVariable(VariableTracker):
         *,
         alpha: VariableTracker | None = None,
     ) -> VariableTracker | None:
-        # Decompose only for tensor alpha to avoid item() graph breaks.
-        # Scalar alpha passes through to ATen where the inductor lowering emits
-        # FMA. addcmul_ and addcdiv_ route through here via alpha=value so this
-        # is the single place that handles the scalar/tensor distinction.
+        # Tensor alpha: ATen would call .item() and fma internally.
+        # Use fma directly to avoid the item() graph break.
         if (
             alpha is not None
             and isinstance(alpha, TensorVariable)
             and config.enable_dynamo_decompositions
         ):
-            result = variables.TorchInGraphFunctionVariable(torch.mul).call_function(
-                tx, [other, alpha], {}
-            )
-            return self.call_method(tx, "add_", [result], {})
+            from torch._inductor import inductor_prims
+
+            fma_var = variables.TorchInGraphFunctionVariable(inductor_prims.fma)
+            result = fma_var.call_function(tx, [other, alpha, self], {})
+            return self.call_method(tx, "copy_", [result], {})
         return None
 
     def method_addcdiv_(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #176874
* __->__ #176873
* #176872
* #176871
* #176807
* #176806
* #176805
* #176804

The add_ tensor alpha decomposition previously did mul(other, alpha)
then add_(self, product) — two separate ops without fma. ATen extracts
the scalar and computes fma(other, alpha, self) internally, so this
could produce different rounding. Use inductor_prims.fma to match.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo