### PR TITLE
Accelerate SDPA on Arm CPUs: Implement fast exp in AdvSIMD vectorizer

### DIFF
--- a/aten/src/ATen/cpu/vec/vec128/vec128_float_neon.h
+++ b/aten/src/ATen/cpu/vec/vec128/vec128_float_neon.h
@@ -362,7 +362,7 @@ class Vectorized<float> {
     // - uses a third degree polynomial approximation for exp(r) instead of a
     // fifth degree one, with coefficients re-tuned.
     // - does not split natural log (ln) into high / low parts
-    // - clamps exp(x) to 0 for x < -87.6831131f and inf for x > 88.3762589f
+    // - clamps exp(x) to 0 for x < -87.346351f and inf for x > 88.3762589f
 
     const float32x4_t lower_bound = vdupq_n_f32(-0x1.5ebb82p+6f);
     const float32x4_t upper_bound = vdupq_n_f32(0x1.61814ap+6f);
@@ -370,24 +370,31 @@ class Vectorized<float> {
     constexpr float ln2 = 0x1.62e43p-1f;
     constexpr float c2 = 0x1.5592ecp-3f;
 
+    const uint32x4_t lt_lower = vcltq_f32(values, lower_bound);
+    const uint32x4_t gt_upper = vcgtq_f32(values, upper_bound);
+
     // exp(x) = 2^n (1 + exp(r))
     // r = x - n*ln2, with n = round(x/ln2)
     // exp(r) ~ poly(r) = r + r^2 * (c3 + c2 * r)
     const uint32x4_t exponent_bias = vdupq_n_u32(0x3f800000);
     const float32x4_t c3 = vdupq_n_f32(0x1.017d34p-1f);
 
+    // n = round(x / ln2), r = x - n*ln2
     float32x4_t n = vrndaq_f32(vmulq_f32(values, inv_ln2));
     float32x4_t r = vfmsq_n_f32(values, n, ln2);
+    // e = n << 23
     uint32x4_t e = vshlq_n_u32(vreinterpretq_u32_s32(vcvtq_s32_f32(n)), 23);
-    float32x4_t scale = vreinterpretq_f32_u32(vaddq_u32(e, exponent_bias));
 
     float32x4_t r2 = vmulq_f32(r, r);
     float32x4_t q = vfmaq_n_f32(c3, r, c2);
-    float32x4_t poly = vfmaq_f32(r, q, r2);
-    float32x4_t y = vfmaq_f32(scale, poly, scale);
+    float32x4_t s = vaddq_f32(vdupq_n_f32(1.0f), r);
+    float32x4_t p = vfmaq_f32(s, q, r2);
 
-    const uint32x4_t lt_lower = vcltq_f32(values, lower_bound);
-    const uint32x4_t gt_upper = vcgtq_f32(values, upper_bound);
+    // 2^n * p
+    // bump p's exponent by n
+    float32x4_t y =
+        vreinterpretq_f32_u32(vaddq_u32(vreinterpretq_u32_f32(p), e));
+
     y = vbslq_f32(lt_lower, vdupq_n_f32(0.0f), y);
     y = vbslq_f32(gt_upper, vdupq_n_f32(INFINITY), y);
     return y;

--- a/aten/src/ATen/cpu/vec/vec128/vec128_float_neon.h
+++ b/aten/src/ATen/cpu/vec/vec128/vec128_float_neon.h
@@ -321,10 +321,10 @@ class Vectorized<float> {
     }
 
     const float32x4_t inv_ln2 = vdupq_n_f32(0x1.715476p+0f);
-    const float ln2_hi = 0x1.62e4p-1f;
-    const float ln2_lo = 0x1.7f7d1cp-20f;
-    const float c0 = 0x1.0e4020p-7f;
-    const float c2 = 0x1.555e66p-3f;
+    constexpr float ln2_hi = 0x1.62e4p-1f;
+    constexpr float ln2_lo = 0x1.7f7d1cp-20f;
+    constexpr float c0 = 0x1.0e4020p-7f;
+    constexpr float c2 = 0x1.555e66p-3f;
     const float32x4_t ln2_c02 = {ln2_hi, ln2_lo, c0, c2};
 
     const uint32x4_t exponent_bias = vdupq_n_u32(0x3f800000);
@@ -367,8 +367,8 @@ class Vectorized<float> {
     const float32x4_t lower_bound = vdupq_n_f32(-0x1.5ebb82p+6f);
     const float32x4_t upper_bound = vdupq_n_f32(0x1.61814ap+6f);
     const float32x4_t inv_ln2 = vdupq_n_f32(0x1.715476p+0f);
-    const float ln2 = 0x1.62e43p-1f;
-    const float c2 = 0x1.5592ecp-3f;
+    constexpr float ln2 = 0x1.62e43p-1f;
+    constexpr float c2 = 0x1.5592ecp-3f;
 
     // exp(x) = 2^n (1 + exp(r))
     // r = x - n*ln2, with n = round(x/ln2)

--- a/aten/src/ATen/cpu/vec/vec128/vec128_float_neon.h
+++ b/aten/src/ATen/cpu/vec/vec128/vec128_float_neon.h
@@ -360,7 +360,7 @@ class Vectorized<float> {
     // inputs outside this range to 0 / inf. Implementation is similar to
     // exp_u20, but:
     // - uses a third degree polynomial approximation for exp(r) instead of a
-    // fifth degree one, with coefficients retuned.
+    // fifth degree one, with coefficients re-tuned.
     // - does not split natural log (ln) into high / low parts
     // - clamps exp(x) to 0 for x < -87.6831131f and inf for x > 88.3762589f
 

--- a/aten/src/ATen/cpu/vec/vec128/vec128_float_neon.h
+++ b/aten/src/ATen/cpu/vec/vec128/vec128_float_neon.h
@@ -354,7 +354,43 @@ class Vectorized<float> {
     return vexpq_f32_u20();
   }
   Vectorized<float> fexp_u20() const {
-    return exp_u20();
+    // fast exponential intended for cases where outputs will be downcasted to
+    // FP16 / BF16 (e.g. attention softmax). Accurate within 1 ULP for FP16
+    // Accurate within 1 ULP for BF16 for inputs in [-87.683, 88.376] & clamps
+    // inputs outside this range to 0 / inf. Implementation is similar to
+    // exp_u20, but:
+    // - uses a third degree polynomial approximation for exp(r) instead of a
+    // fifth degree one, with coefficients retuned.
+    // - does not split natural log (ln) into high / low parts
+    // - clamps exp(x) to 0 for x < -87.6831131f and inf for x > 88.3762589f
+
+    const float32x4_t lower_bound = vdupq_n_f32(-0x1.5ebb82p+6f);
+    const float32x4_t upper_bound = vdupq_n_f32(0x1.61814ap+6f);
+    const float32x4_t inv_ln2 = vdupq_n_f32(0x1.715476p+0f);
+    const float ln2 = 0x1.62e43p-1f;
+    const float c2 = 0x1.5592ecp-3f;
+
+    // exp(x) = 2^n (1 + exp(r))
+    // r = x - n*ln2, with n = round(x/ln2)
+    // exp(r) ~ poly(r) = r + r^2 * (c3 + c2 * r)
+    const uint32x4_t exponent_bias = vdupq_n_u32(0x3f800000);
+    const float32x4_t c3 = vdupq_n_f32(0x1.017d34p-1f);
+
+    float32x4_t n = vrndaq_f32(vmulq_f32(values, inv_ln2));
+    float32x4_t r = vfmsq_n_f32(values, n, ln2);
+    uint32x4_t e = vshlq_n_u32(vreinterpretq_u32_s32(vcvtq_s32_f32(n)), 23);
+    float32x4_t scale = vreinterpretq_f32_u32(vaddq_u32(e, exponent_bias));
+
+    float32x4_t r2 = vmulq_f32(r, r);
+    float32x4_t q = vfmaq_n_f32(c3, r, c2);
+    float32x4_t poly = vfmaq_f32(r, q, r2);
+    float32x4_t y = vfmaq_f32(scale, poly, scale);
+
+    const uint32x4_t lt_lower = vcltq_f32(values, lower_bound);
+    const uint32x4_t gt_upper = vcgtq_f32(values, upper_bound);
+    y = vbslq_f32(lt_lower, vdupq_n_f32(0.0f), y);
+    y = vbslq_f32(gt_upper, vdupq_n_f32(INFINITY), y);
+    return y;
   }
   DEFINE_SLEEF_COMPATIBLE_BINARY_ELEMENTWISE_FUNC_WITH_SLEEF_NAME(
       fmod,

--- a/aten/src/ATen/cpu/vec/vec128/vec128_float_neon.h
+++ b/aten/src/ATen/cpu/vec/vec128/vec128_float_neon.h
@@ -369,15 +369,13 @@ class Vectorized<float> {
     const float32x4_t inv_ln2 = vdupq_n_f32(0x1.715476p+0f);
     constexpr float ln2 = 0x1.62e43p-1f;
     constexpr float c2 = 0x1.5592ecp-3f;
-
+    const float32x4_t c3 = vdupq_n_f32(0x1.017d34p-1f);
     const uint32x4_t lt_lower = vcltq_f32(values, lower_bound);
     const uint32x4_t gt_upper = vcgtq_f32(values, upper_bound);
 
     // exp(x) = 2^n (1 + exp(r))
     // r = x - n*ln2, with n = round(x/ln2)
     // exp(r) ~ poly(r) = r + r^2 * (c3 + c2 * r)
-    const uint32x4_t exponent_bias = vdupq_n_u32(0x3f800000);
-    const float32x4_t c3 = vdupq_n_f32(0x1.017d34p-1f);
 
     // n = round(x / ln2), r = x - n*ln2
     float32x4_t n = vrndaq_f32(vmulq_f32(values, inv_ln2));
@@ -391,7 +389,6 @@ class Vectorized<float> {
     float32x4_t p = vfmaq_f32(s, q, r2);
 
     // 2^n * p
-    // bump p's exponent by n
     float32x4_t y =
         vreinterpretq_f32_u32(vaddq_u32(vreinterpretq_u32_f32(p), e));
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #177012
* #177009
* __->__ #176881

Similar to #151441 - this PR adds an ASIMD implementation for fast exponential intended for cases where outputs will be downcasted to FP16 / BF16 (e.g. attention softmax).

Implementation is similar to the existing exp_u20, but:
  - uses a third degree polynomial approximation for exp(r) instead of a
    fifth degree one, with coefficients re-tuned.
  - does not split natural log (ln) into high / low parts
  - clamps exp(x) to 0 for x < -87.346351f and inf for x > 88.3762589f

Overall, this allows us to ditch 4 FMLAs (out of 7 in the current impl) and the nasty if branch

## Accuracy

Following a similar approach to #151441, I tested accuracy for fast exp using [this](https://gist.github.com/fadara01/1f0a7bc4b63193102b5f6b0283a9b02f) script. The script iterates over all possible FP32 bit patterns and calculates ULP between:
- `fexp_u20` with inputs in FP32, outputs converted to BF16/FP16
- `std::exp` with inputs in FP32, outputs converted to BF16/FP16  

Accuracy script shows that fast exp is:
- for FP16: accurate within a maximum of 1 FP16 ULPs
- for BF16: accurate within a maximum of 1 BF16 ULPs for inputs in [-87.346351, 88.376] - we clamp inputs outside this range to 0 / inf.

## Performance

Using [this SDPA benchmark](https://gist.github.com/fadara01/5357a52299a3722587f6691d145e71e9), here are the scaled-dot-production-attention speedups achieved with 16 Neoverse-V2 cores:

| B | Hq | Hkv | Lq | Lk | D | causal | gqa | Speedup vs current |
|---:|---:|---:|---:|---:|---:|---|---|---:|
| 1 | 32 | 8 | 2048 | 2048 | 128 | True | True | +9.48% |
| 1 | 32 | 8 | 1 | 2048 | 128 | False | True | -1.42% (noise) |
| 1 | 16 | 16 | 6400 | 6400 | 80 | False | False | +5.18% |
| 1 | 20 | 20 | 1500 | 1500 | 64 | False | False | +6.63% |
| 8 | 20 | 20 | 1500 | 1500 | 64 | False | False | +9.31% |



cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01 @drisspg @liangel-02 @howardzhang-cv