### PR TITLE
Add note about RFCs to feature template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -10,6 +10,10 @@ body:
   attributes:
     value: >
       #### Note: Please write your feature request in English to ensure it can be understood and addressed by the development team.
+- type: markdown
+  attributes:
+    value: >
+      #### Note: For new features in PyTorch and PyTorch CI/CD Infrastructure we recommend [drafting an RFC](https://github.com/pytorch/pytorch/wiki/How-to-propose-feature-changes-to-PyTorch) and building consensus first.
 - type: textarea
   attributes:
     label: 🚀 The feature, motivation and pitch


### PR DESCRIPTION
Make a note directly in the issue/feature template about the use of RFCs. RFCs are already mentioned in the Wiki, but bringing them up as a note in the template directly gives them more visiblity.

Wiki: https://github.com/pytorch/pytorch/wiki/How-to-propose-feature-changes-to-PyTorch