### PR TITLE
Add dilation support for max_pool2d_with_indices_backward lowering

### DIFF
--- a/test/inductor/pallas_expected_failures/CpuTests.test_max_pool2d_with_indices_backward6_cpu
+++ b/test/inductor/pallas_expected_failures/CpuTests.test_max_pool2d_with_indices_backward6_cpu
@@ -1,0 +1,4 @@
+ERROR
+  Pallas backend does not support indirect_indexing patterns used by
+  max_pool2d_with_indices_backward lowering (dilation=[1,2] variant).
+  Same root cause as backward/backward2/backward3/backward4.

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -10329,7 +10329,7 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
 
     # From https://github.com/pytorch/pytorch/issues/93384
     def test_max_pool2d_with_indices_backward6(self):
-        # dilation is not 1. Should fallback
+        # dilation is not 1. Should still generate kernels.
         def fn(a, b, c):
             return aten.max_pool2d_with_indices_backward(
                 a, b, [3, 2], [2, 1], [1, 1], [1, 2], False, c
@@ -10353,7 +10353,7 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
                 indices,
             ],
         )
-        assertGeneratedKernelCountEqual(self, 0)
+        assertGeneratedKernelCountEqual(self, 1)
 
     def test_issue102546(self):
         def fn(x):

--- a/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
@@ -219,9 +219,6 @@ test_failures = {
     "test_max_pool2d_with_indices_backward5_dynamic_shapes": TestFailure(
         ("cpu", "cuda")
     ),
-    "test_max_pool2d_with_indices_backward6_dynamic_shapes": TestFailure(
-        ("cpu", "cuda", "xpu")
-    ),
     "test_misaligned_address_issue1_dynamic_shapes": TestFailure(("cpu",)),
     "test_mm_views_dynamic_shapes": TestFailure(("cpu", "cuda", "xpu")),
     "test_new_empty_dynamic_shapes": TestFailure(("cpu", "cuda", "xpu")),

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -5152,11 +5152,6 @@ def max_pool2d_with_indices_backward(
     is_channels_last = (x_stride is not None and x_stride[1] == 1) or (
         gO_stride is not None and gO_stride[1] == 1
     )
-    if any(d != 1 for d in dilation):
-        # dilation NYI
-        return fallback_max_pool2d_with_indices_backward(
-            grad_output, x, kernel_size, stride, padding, dilation, ceil_mode, indices
-        )
 
     *_batch, _height, width = x.get_size()
     *_, pooled_height, pooled_width = grad_output.get_size()
@@ -5165,13 +5160,17 @@ def max_pool2d_with_indices_backward(
     grad_loader = grad_output.make_loader()
     new_size = list(x.get_size())
 
+    # Effective kernel size accounts for dilation
+    effective_kh = (kernel_size[0] - 1) * dilation[0] + 1
+    effective_kw = (kernel_size[1] - 1) * dilation[1] + 1
+
     h_window_size = max(
-        max(FloorDiv(h, stride[0]) - max(0, FloorDiv(h - kernel_size[0], stride[0])), 1)
-        for h in range(kernel_size[0] * 2)
+        max(FloorDiv(h, stride[0]) - max(0, FloorDiv(h - effective_kh, stride[0])), 1)
+        for h in range(effective_kh * 2)
     )
     w_window_size = max(
-        max(FloorDiv(w, stride[1]) - max(0, FloorDiv(w - kernel_size[1], stride[1])), 1)
-        for w in range(kernel_size[1] * 2)
+        max(FloorDiv(w, stride[1]) - max(0, FloorDiv(w - effective_kw, stride[1])), 1)
+        for w in range(effective_kw * 2)
     )
 
     window_size = h_window_size * w_window_size
@@ -5190,10 +5189,10 @@ def max_pool2d_with_indices_backward(
         h = h + padding[0]
         w = w + padding[1]
         phstart = ops.index_expr(
-            FloorDiv(h - kernel_size[0] + stride[0], stride[0]), torch.int32
+            FloorDiv(h - effective_kh + stride[0], stride[0]), torch.int32
         )
         pwstart = ops.index_expr(
-            FloorDiv(w - kernel_size[1] + stride[1], stride[1]), torch.int32
+            FloorDiv(w - effective_kw + stride[1], stride[1]), torch.int32
         )
         phend = ops.index_expr(FloorDiv(h, stride[0]) + 1, torch.int32)
         pwend = ops.index_expr(FloorDiv(w, stride[1]) + 1, torch.int32)


### PR DESCRIPTION
Summary:
The Inductor lowering for `aten.max_pool2d_with_indices_backward` fell
back to `FallbackKernel` when dilation != 1 (marked as "NYI"). This
caused compilation failures on the target backend since the fallback op
is unsupported.

Fix: Use the effective kernel size `(kernel_size - 1) * dilation + 1`
instead of `kernel_size` in the window size computation and the
phstart/pwstart calculation. The index comparison logic (`ops.eq` on
stored argmax indices) remains unchanged since the forward pass already
computes correct flat indices accounting for dilation.

Also adds `aten.max_pool2d_with_indices_backward` to
`SAFE_AND_PERFORMANT_INDUCTOR_OPS` so it is not force-overridden with
`make_fallback()` on the target backend, and adds the passing test to CI.

Test Plan:
OPINFO_START_INDEX=6437 OPINFO_END_INDEX=6438 \
  OPINFO_LOWERING_MODE=AFG_INDUCTOR_COMPILE OPINFO_AUTO_DS=1 \
  buck2 run fbcode//mtia/compiler/graph_compiler/test_library/afg_opinfo_e2e_tests:test_afg_opinfo_e2e

Reviewed By: chenmillie

@diff-train-skip-merge





cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo