### PR TITLE
[cuDNN][Convolution] Expose cuDNN `allow_reduced_precision_reduction` numerical note to fix `float16` tests

### DIFF
--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -239,6 +239,14 @@ void Context::setAllowTF32CuDNN(bool b) {
   allow_tf32_cudnn = b;
 }
 
+bool Context::allowReducedPrecisionReductionCuDNN() const {
+  return allow_reduced_precision_reduction_cudnn;
+}
+
+void Context::setAllowReducedPrecisionReductionCuDNN(bool b) {
+  allow_reduced_precision_reduction_cudnn = b;
+}
+
 void Context::setSDPPriorityOrder(const std::vector<int64_t>& order) {
   // TODO*eqy): should it always be the number of backends - 1 (override backend excluded?)
   TORCH_CHECK(at::num_sdp_backends == sdp_priority_order.size(),

--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -385,6 +385,8 @@ class TORCH_API Context {
       Float32Precision p);
   bool allowTF32CuDNN(std::optional<Float32Op> op = std::nullopt) const;
   void setAllowTF32CuDNN(bool /*b*/);
+  bool allowReducedPrecisionReductionCuDNN() const;
+  void setAllowReducedPrecisionReductionCuDNN(bool /*b*/);
   bool allowTF32OneDNN() const;
   void setAllowTF32OneDNN(bool /*b*/);
   bool allowTF32CuBLAS() const;
@@ -501,6 +503,7 @@ class TORCH_API Context {
       : at::Float32MatmulPrecision::HIGHEST;
   int benchmark_limit_cudnn = 10;
   bool allow_tf32_cudnn = true;
+  bool allow_reduced_precision_reduction_cudnn = true;
   CuBLASReductionOption allow_fp16_reduction_cublas =
       CuBLASReductionOption::AllowReducedPrecisionWithSplitK;
   CuBLASReductionOption allow_bf16_reduction_cublas =

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -142,6 +142,7 @@ void filterEngineConfigs(
     cudnn_frontend::EngineConfigList& to,
     bool deterministic,
     bool allow_tf32,
+    bool allow_reduced_precision_reduction,
     c10::ScalarType scalar_type) {
   auto filter = [=](cudnnBackendDescriptor_t c) {
     if (deterministic) {
@@ -159,6 +160,13 @@ void filterEngineConfigs(
       if (!allow_tf32 &&
           cudnn_frontend::hasNumericalNote<CUDNN_NUMERICAL_NOTE_TENSOR_CORE>(
               c)) {
+        return true;
+      }
+    }
+    if (!allow_reduced_precision_reduction &&
+        (scalar_type == kHalf || scalar_type == kBFloat16)) {
+      if (cudnn_frontend::hasNumericalNote<
+              CUDNN_NUMERICAL_NOTE_REDUCED_PRECISION_REDUCTION>(c)) {
         return true;
       }
     }
@@ -580,6 +588,7 @@ auto get_generator_sources(
     const Tensor& x,
     const bool deterministic,
     const bool allow_tf32,
+    const bool allow_reduced_precision_reduction,
     const cudnnBackendHeurMode_t heur_mode,
     const bool heuristic,
     const bool fallback,
@@ -590,6 +599,7 @@ auto get_generator_sources(
       [/*&desc,*/ &x,
        deterministic,
        allow_tf32,
+       allow_reduced_precision_reduction,
        heur_mode,
        get_all_heuristic_configs,
        heuristic_config_count](cudnn_frontend::OperationGraph& opGraph)
@@ -609,11 +619,12 @@ auto get_generator_sources(
         filtered_configs,
         deterministic,
         allow_tf32,
+        allow_reduced_precision_reduction,
         x.scalar_type());
     return filtered_configs;
   };
   // Method for engine config generator based on fallback list
-  const auto fallback_method = [&desc, &x, deterministic, allow_tf32](
+  const auto fallback_method = [&desc, &x, deterministic, allow_tf32, allow_reduced_precision_reduction](
                                    cudnn_frontend::OperationGraph& opGraph)
       -> cudnn_frontend::EngineConfigList {
     auto fallback = cudnn_frontend::EngineFallbackListBuilder()
@@ -627,6 +638,7 @@ auto get_generator_sources(
         filtered_configs,
         deterministic,
         allow_tf32,
+        allow_reduced_precision_reduction,
         x.scalar_type());
     return filtered_configs;
   };
@@ -778,7 +790,8 @@ auto get_plans_from_find(
     const IntArrayRef stride,
     const IntArrayRef dilation,
     const bool deterministic,
-    const bool allow_tf32) {
+    const bool allow_tf32,
+    const bool allow_reduced_precision_reduction) {
   auto opGraph =
       build_opgraph(handle, desc, x, y, w, key, padding, stride, dilation);
   void* data_ptrs[] = {x.data_ptr(), y.data_ptr(), w.data_ptr()};
@@ -790,6 +803,7 @@ auto get_plans_from_find(
       x,
       deterministic,
       allow_tf32,
+      allow_reduced_precision_reduction,
       CUDNN_HEUR_MODE_INSTANT,
       true,
       true,
@@ -834,7 +848,8 @@ auto get_plans_from_find_fused(
     const IntArrayRef stride,
     const IntArrayRef dilation,
     const bool deterministic,
-    const bool allow_tf32) {
+    const bool allow_tf32,
+    const bool allow_reduced_precision_reduction) {
   auto opGraph = build_opgraph_fused(
       handle, x, y, w, z, b, alpha, key, padding, stride, dilation);
   void* data_ptrs[] = {
@@ -846,6 +861,7 @@ auto get_plans_from_find_fused(
       x,
       deterministic,
       allow_tf32,
+      allow_reduced_precision_reduction,
       CUDNN_HEUR_MODE_INSTANT,
       true,
       true,
@@ -892,6 +908,7 @@ auto get_configs_from_heuristics(
     const IntArrayRef dilation,
     const bool deterministic,
     const bool allow_tf32,
+    const bool allow_reduced_precision_reduction,
     const bool fallback,
     const bool get_all_heuristic_configs = false) {
   auto opGraph =
@@ -906,6 +923,7 @@ auto get_configs_from_heuristics(
       x,
       deterministic,
       allow_tf32,
+      allow_reduced_precision_reduction,
       heuristic_mode,
       !fallback,
       fallback,
@@ -933,6 +951,7 @@ auto get_configs_from_heuristics_fused(
     const IntArrayRef dilation,
     const bool deterministic,
     const bool allow_tf32,
+    const bool allow_reduced_precision_reduction,
     const bool fallback,
     const bool get_all_heuristic_configs = false) {
   auto opGraph = build_opgraph_fused(
@@ -947,6 +966,7 @@ auto get_configs_from_heuristics_fused(
       x,
       deterministic,
       allow_tf32,
+      allow_reduced_precision_reduction,
       heuristic_mode,
       !fallback,
       fallback,
@@ -1121,6 +1141,8 @@ void run_single_conv(
     const bool deterministic,
     const bool allow_tf32) {
   cudnnHandle_t handle = getCudnnHandle();
+  auto allow_reduced_precision_reduction =
+      at::globalContext().allowReducedPrecisionReductionCuDNN();
   CacheKeyWrapper key(
       operation,
       y,
@@ -1158,6 +1180,7 @@ void run_single_conv(
         dilation,
         deterministic,
         allow_tf32,
+        allow_reduced_precision_reduction,
         false);
     const bool tried_top_config = !engine_config_result.configs.empty();
     if (tried_top_config) {
@@ -1188,6 +1211,7 @@ void run_single_conv(
           dilation,
           deterministic,
           allow_tf32,
+          allow_reduced_precision_reduction,
           false,
           true);
       auto configs_begin = engine_config_result.configs.begin();
@@ -1223,6 +1247,7 @@ void run_single_conv(
         dilation,
         deterministic,
         allow_tf32,
+        allow_reduced_precision_reduction,
         true);
     if (try_configs(
             engine_config_result.configs,
@@ -1249,7 +1274,8 @@ void run_single_conv(
         stride,
         dilation,
         deterministic,
-        allow_tf32);
+        allow_tf32,
+        allow_reduced_precision_reduction);
     // Replicate v7 behavior: clear cached blocks as benchmark incurs
     // significant memory consumptiont that is not needed after this step
     if (at::native::_cudnn_get_conv_benchmark_empty_cache()) {
@@ -1274,6 +1300,8 @@ void run_fused_conv(
     const bool deterministic,
     const bool allow_tf32) {
   cudnnHandle_t handle = getCudnnHandle();
+  auto allow_reduced_precision_reduction =
+      at::globalContext().allowReducedPrecisionReductionCuDNN();
 
   CacheKeyFusedWrapper key(
       y,
@@ -1315,6 +1343,7 @@ void run_fused_conv(
         dilation,
         deterministic,
         allow_tf32,
+        allow_reduced_precision_reduction,
         false);
     const bool tried_top_config = !engine_config_result.configs.empty();
     if (tried_top_config) {
@@ -1345,11 +1374,12 @@ void run_fused_conv(
           key,
           padding,
           stride,
-          dilation,
-          deterministic,
-          allow_tf32,
-          false,
-          true);
+        dilation,
+        deterministic,
+        allow_tf32,
+        allow_reduced_precision_reduction,
+        false,
+        true);
       auto configs_begin = engine_config_result.configs.begin();
       // The top-config path already tried the first filtered heuristic config.
       if (tried_top_config &&
@@ -1386,6 +1416,7 @@ void run_fused_conv(
         dilation,
         deterministic,
         allow_tf32,
+        allow_reduced_precision_reduction,
         true);
     if (try_configs_fused(
             engine_config_result.configs,
@@ -1415,7 +1446,8 @@ void run_fused_conv(
         stride,
         dilation,
         deterministic,
-        allow_tf32);
+        allow_tf32,
+        allow_reduced_precision_reduction);
     try_plans_fused(plans, key, handle, x, y, w, z, b);
   }
 }

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -624,8 +624,9 @@ auto get_generator_sources(
     return filtered_configs;
   };
   // Method for engine config generator based on fallback list
-  const auto fallback_method = [&desc, &x, deterministic, allow_tf32, allow_reduced_precision_reduction](
-                                   cudnn_frontend::OperationGraph& opGraph)
+  const auto fallback_method =
+      [&desc, &x, deterministic, allow_tf32, allow_reduced_precision_reduction](
+          cudnn_frontend::OperationGraph& opGraph)
       -> cudnn_frontend::EngineConfigList {
     auto fallback = cudnn_frontend::EngineFallbackListBuilder()
                         .setOperationGraph(opGraph)

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1248,9 +1248,7 @@ print(t.is_pinned())
 
     def test_cudnn_allow_reduced_precision_reduction_get_set(self):
         orig = torch._C._get_cudnn_allow_reduced_precision_reduction()
-        self.assertEqual(
-            torch.backends.cudnn.allow_reduced_precision_reduction, orig
-        )
+        self.assertEqual(torch.backends.cudnn.allow_reduced_precision_reduction, orig)
         with torch.backends.cudnn.flags(
             enabled=None,
             benchmark=None,
@@ -1258,9 +1256,7 @@ print(t.is_pinned())
             allow_tf32=None,
             allow_reduced_precision_reduction=False,
         ):
-            self.assertFalse(
-                torch.backends.cudnn.allow_reduced_precision_reduction
-            )
+            self.assertFalse(torch.backends.cudnn.allow_reduced_precision_reduction)
         with torch.backends.cudnn.flags(
             enabled=None,
             benchmark=None,
@@ -1268,9 +1264,7 @@ print(t.is_pinned())
             allow_tf32=None,
             allow_reduced_precision_reduction=True,
         ):
-            self.assertTrue(
-                torch.backends.cudnn.allow_reduced_precision_reduction
-            )
+            self.assertTrue(torch.backends.cudnn.allow_reduced_precision_reduction)
 
     @recover_orig_fp32_precision
     def test_fp32_precision_with_tf32(self):

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1246,6 +1246,32 @@ print(t.is_pinned())
             self.assertEqual(torch.backends.cudnn.depthwise_kernel, "native")
         self.assertEqual(torch.backends.cudnn.depthwise_kernel, "auto")
 
+    def test_cudnn_allow_reduced_precision_reduction_get_set(self):
+        orig = torch._C._get_cudnn_allow_reduced_precision_reduction()
+        self.assertEqual(
+            torch.backends.cudnn.allow_reduced_precision_reduction, orig
+        )
+        with torch.backends.cudnn.flags(
+            enabled=None,
+            benchmark=None,
+            deterministic=None,
+            allow_tf32=None,
+            allow_reduced_precision_reduction=False,
+        ):
+            self.assertFalse(
+                torch.backends.cudnn.allow_reduced_precision_reduction
+            )
+        with torch.backends.cudnn.flags(
+            enabled=None,
+            benchmark=None,
+            deterministic=None,
+            allow_tf32=None,
+            allow_reduced_precision_reduction=True,
+        ):
+            self.assertTrue(
+                torch.backends.cudnn.allow_reduced_precision_reduction
+            )
+
     @recover_orig_fp32_precision
     def test_fp32_precision_with_tf32(self):
         with torch.backends.cudnn.flags(

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -239,7 +239,8 @@ class TestModule(TestCase):
 
                 # === Do forward pass. ===
                 args, kwargs = module_input.forward_input.args, module_input.forward_input.kwargs
-                output = m(*args, **kwargs)
+                with torch.backends.cudnn.flags(enabled=True, allow_reduced_precision_reduction=False):
+                    output = m(*args, **kwargs)
 
                 # === Check saved/loaded module gives the same output. ===
                 with tempfile.TemporaryFile() as f:

--- a/torch/_C/__init__.pyi.in
+++ b/torch/_C/__init__.pyi.in
@@ -1245,6 +1245,8 @@ def _get_miopen_immediate() -> _bool: ...  # THPModule_userImmediateMiopen
 def _set_miopen_immediate(arg: _bool) -> None: ...  # THPModule_setUserImmediateMiopen
 def _get_cudnn_deterministic() -> _bool: ...  # THPModule_deterministicCuDNN
 def _set_cudnn_deterministic(arg: _bool) -> None: ...  # THPModule_setDeterministicCuDNN
+def _get_cudnn_allow_reduced_precision_reduction() -> _bool: ... THPModule_getAllowReducedPrecisionReductionCuDNN
+def _set_cudnn_allow_reduced_precision_reduction(arg: _bool) -> None: ... THPModule_setAllowReducedPrecisionReductionCuDNN
 def _get_mkldnn_deterministic() -> _bool: ...  # THPModule_deterministicMkldnn
 def _set_mkldnn_deterministic(
     arg: _bool,

--- a/torch/backends/cudnn/__init__.py
+++ b/torch/backends/cudnn/__init__.py
@@ -159,6 +159,7 @@ def set_flags(
     _allow_tf32=None,
     _fp32_precision="none",
     _depthwise_kernel=None,
+    _allow_reduced_precision_reduction=None,
 ):
     orig_flags = (
         torch._C._get_cudnn_enabled(),
@@ -168,6 +169,7 @@ def set_flags(
         torch._C._get_cudnn_allow_tf32(),
         torch._C._get_fp32_precision_getter("cuda", "all"),
         torch._C._get_cudnn_depthwise_kernel(),
+        torch._C._get_cudnn_allow_reduced_precision_reduction(),
     )
     if _enabled is not None:
         torch._C._set_cudnn_enabled(_enabled)
@@ -183,6 +185,10 @@ def set_flags(
         torch._C._set_fp32_precision_setter("cuda", "all", _fp32_precision)
     if _depthwise_kernel is not None:
         torch._C._set_cudnn_depthwise_kernel(_depthwise_kernel)
+    if _allow_reduced_precision_reduction is not None:
+        torch._C._set_cudnn_allow_reduced_precision_reduction(
+            _allow_reduced_precision_reduction
+        )
     return orig_flags
 
 
@@ -195,6 +201,7 @@ def flags(
     allow_tf32=True,
     fp32_precision="none",
     depthwise_kernel="auto",
+    allow_reduced_precision_reduction=True,
 ):
     with __allow_nonbracketed_mutation():
         orig_flags = set_flags(
@@ -205,6 +212,7 @@ def flags(
             allow_tf32,
             fp32_precision,
             depthwise_kernel,
+            allow_reduced_precision_reduction,
         )
     try:
         yield
@@ -217,6 +225,17 @@ def flags(
 # The magic here is to allow us to intercept code like this:
 #
 #   torch.backends.<cudnn|mkldnn>.enabled = True
+
+
+def _set_cudnn_allow_reduced_precision_reduction(b):
+    if os.environ.get("TORCH_CUDNN_V8_API_DISABLED", "0") == "1":
+        warnings.warn(
+            "torch.backends.cudnn.allow_reduced_precision_reduction has no "
+            "effect when the cuDNN V8 API is disabled via the "
+            "TORCH_CUDNN_V8_API_DISABLED environment variable",
+            stacklevel=2,
+        )
+    torch._C._set_cudnn_allow_reduced_precision_reduction(b)
 
 
 class CudnnModule(PropModule):
@@ -235,6 +254,10 @@ class CudnnModule(PropModule):
         )
     allow_tf32 = ContextProp(
         torch._C._get_cudnn_allow_tf32, torch._C._set_cudnn_allow_tf32
+    )
+    allow_reduced_precision_reduction = ContextProp(
+        torch._C._get_cudnn_allow_reduced_precision_reduction,
+        _set_cudnn_allow_reduced_precision_reduction,
     )
     conv = _FP32Precision("cuda", "conv")
     fp32_precision = ContextProp(
@@ -256,6 +279,7 @@ enabled: bool
 deterministic: bool
 benchmark: bool
 allow_tf32: bool
+allow_reduced_precision_reduction: bool
 fp32_precision: str
 benchmark_limit: int
 depthwise_kernel: str

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -939,6 +939,31 @@ static PyObject* THPModule_allowTF32CuDNN(PyObject* _unused, PyObject* noargs) {
   END_HANDLE_TH_ERRORS
 }
 
+static PyObject* THPModule_setAllowReducedPrecisionReductionCuDNN(
+    PyObject* _unused,
+    PyObject* arg) {
+  HANDLE_TH_ERRORS
+  TORCH_CHECK(
+      PyBool_Check(arg),
+      "set_allow_reduced_precision_reduction_cudnn expects a bool, "
+      "but got ",
+      THPUtils_typename(arg));
+  at::globalContext().setAllowReducedPrecisionReductionCuDNN(arg == Py_True);
+  Py_RETURN_NONE;
+  END_HANDLE_TH_ERRORS
+}
+
+static PyObject* THPModule_allowReducedPrecisionReductionCuDNN(
+    PyObject* _unused,
+    PyObject* noargs) {
+  HANDLE_TH_ERRORS
+  if (at::globalContext().allowReducedPrecisionReductionCuDNN())
+    Py_RETURN_TRUE;
+  else
+    Py_RETURN_FALSE;
+  END_HANDLE_TH_ERRORS
+}
+
 static PyObject* THPModule_setFloat32MatmulPrecision(
     PyObject* _unused,
     PyObject* arg) {
@@ -2130,6 +2155,14 @@ static std::initializer_list<PyMethodDef> TorchMethods = {
     {"_set_mkldnn_enabled", THPModule_setUserEnabledMkldnn, METH_O, nullptr},
     {"_get_cudnn_allow_tf32", THPModule_allowTF32CuDNN, METH_NOARGS, nullptr},
     {"_set_cudnn_allow_tf32", THPModule_setAllowTF32CuDNN, METH_O, nullptr},
+    {"_get_cudnn_allow_reduced_precision_reduction",
+     THPModule_allowReducedPrecisionReductionCuDNN,
+     METH_NOARGS,
+     nullptr},
+    {"_set_cudnn_allow_reduced_precision_reduction",
+     THPModule_setAllowReducedPrecisionReductionCuDNN,
+     METH_O,
+     nullptr},
     {"_get_onednn_allow_tf32", THPModule_allowTF32OneDNN, METH_NOARGS, nullptr},
     {"_set_onednn_allow_tf32", THPModule_setAllowTF32OneDNN, METH_O, nullptr},
     {"_get_cudnn_benchmark", THPModule_benchmarkCuDNN, METH_NOARGS, nullptr},


### PR DESCRIPTION
Similar to existing cuBLAS flag, useful to fix e.g., `complex32` test failures observed on SM 12.0 / SM 12.1

authored mostly with Claude code

cc @csarofeen @ptrblck @xwang233 @nWEIdia