### PR TITLE
Move caffe2/aten/src/ATen/test/test_install/CMakeLists.txt onto C++20

### DIFF
--- a/aten/src/ATen/test/test_install/CMakeLists.txt
+++ b/aten/src/ATen/test/test_install/CMakeLists.txt
@@ -2,9 +2,9 @@ cmake_minimum_required(VERSION 3.10)
 find_package(ATen REQUIRED)
 include_directories(${ATEN_INCLUDE_DIR})
 
-# C++17
+# C++20
 if(not MSVC)
-    set(CMAKE_CXX_FLAGS "--std=c++17 ${CMAKE_CXX_FLAGS}")
+    set(CMAKE_CXX_FLAGS "--std=c++20 ${CMAKE_CXX_FLAGS}")
 endif()
 add_executable(main main.cpp)
 target_link_libraries(main ${ATEN_LIBRARIES})


### PR DESCRIPTION
Summary: PyTorch is moving onto C++20. See https://github.com/pytorch/pytorch/issues/176662

Test Plan: Sandcastle

Differential Revision: D95820384


