### PR TITLE
[BE] Add in-place collect_env execution

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -51,7 +51,11 @@ body:
     description: |
       Please run the following and paste the output below.
       ```sh
-      wget https://raw.githubusercontent.com/pytorch/pytorch/main/torch/utils/collect_env.py
+      curl -sL https://raw.githubusercontent.com/pytorch/pytorch/main/torch/utils/collect_env.py | python
+      ```
+      Or, if you prefer to inspect the script first:
+      ```sh
+      curl -OL https://raw.githubusercontent.com/pytorch/pytorch/main/torch/utils/collect_env.py
       # For security purposes, please check the contents of collect_env.py before running it.
       python collect_env.py
       ```

--- a/.github/ISSUE_TEMPLATE/pt2-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/pt2-bug-report.yml
@@ -64,6 +64,10 @@ body:
       description: |
         Please run the following and paste the output below.
         ```sh
+        curl -sL https://raw.githubusercontent.com/pytorch/pytorch/main/torch/utils/collect_env.py | python3
+        ```
+        Or, if you prefer to inspect the script first:
+        ```sh
         curl -OL https://raw.githubusercontent.com/pytorch/pytorch/main/torch/utils/collect_env.py
         # For security purposes, please check the contents of collect_env.py before running it.
         python3 collect_env.py


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #176904

First of all, fewer systems now how `wget` installed by default, but almost all Linux/MacOS comes with curl

If script with such name already exists, `wget` will download it with `.${NUM}` suffixed alias, which results in reporter posting results from something else, for example see https://github.com/pytorch/pytorch/issues/176829
```
wget https://raw.githubusercontent.com/pytorch/pytorch/main/torch/utils/collect_env.py
python collect_env.py
--2026-03-08 23:35:37--  https://raw.githubusercontent.com/pytorch/pytorch/main/torch/utils/collect_env.py
Resolving raw.githubusercontent.com (raw.githubusercontent.com)... 2606:50c0:8001::154, 2606:50c0:8003::154, 2606:50c0:8000::154, ...
Connecting to raw.githubusercontent.com (raw.githubusercontent.com)|2606:50c0:8001::154|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 31107 (30K) [text/plain]
Saving to: ‘collect_env.py.1’

collect_env.py.1            100%[==========================================>]  30.38K  --.-KB/s    in 0.04s

2026-03-08 23:35:38 (707 KB/s) - ‘collect_env.py.1’ saved [31107/31107]

Traceback (most recent call last):
  File "/mnt/d/my/work/study/ai/kaggle_code/aimo2/collect_env.py", line 15, in <module>
```