### PR TITLE
[Re-apply][AArch64][SVE][BF16]: Add vectorized BF16 transpose_mxn specialization

### DIFF
--- a/aten/src/ATen/cpu/vec/sve/vec_bfloat16.h
+++ b/aten/src/ATen/cpu/vec/sve/vec_bfloat16.h
@@ -6,7 +6,9 @@
 #include <ATen/cpu/vec/sve/vec_float.h>
 #include <ATen/cpu/vec/vec_base.h>
 #include <c10/util/bit_cast.h>
+#include <algorithm>
 #include <cmath>
+
 namespace at {
 namespace vec {
 // Note [CPU_CAPABILITY namespace]
@@ -584,6 +586,85 @@ Vectorized<BFloat16> inline fmadd(
     const Vectorized<BFloat16>& b,
     const Vectorized<BFloat16>& c) {
   return a * b + c;
+}
+
+template <>
+void inline transpose_mxn<BFloat16>(
+    const BFloat16* src,
+    int64_t ld_src,
+    BFloat16* dst,
+    int64_t ld_dst,
+    int M,
+    int N) {
+  if (M <= 0 || N <= 0) {
+    return;
+  }
+  constexpr int TILE = 8;
+
+  alignas(64) BFloat16 tile_in[TILE * TILE];
+  alignas(64) BFloat16 tile_out[TILE * TILE];
+
+  // Predicated bf16 load with zeroing of inactiva lanes as raw 16-bit lanes
+  auto ld_bf16_u16_zeroed = [](const BFloat16* p, int count) -> svuint16_t {
+    svuint16_t z = svdup_n_u16(0);
+    if (count <= 0) {
+      return z;
+    }
+    // Works for any count<= vector lanes
+    svbool_t pg = svwhilelt_b16((uint64_t)0, (uint64_t)count);
+    const uint16_t* pu16 = reinterpret_cast<const uint16_t*>(p);
+    svuint16_t v = svld1_u16(pg, pu16);
+    return svsel_u16(pg, v, z);
+  };
+
+  // Predicated bf16 store as raw 16-bit lanes(only those active will be stored)
+  auto st_bf16_u16 = [](BFloat16* p, int count, svuint16_t v) {
+    if (count <= 0) {
+      return;
+    }
+    svbool_t pg = svwhilelt_b16((uint64_t)0, (uint64_t)count);
+    uint16_t* pu16 = reinterpret_cast<uint16_t*>(p);
+    svst1_u16(pg, pu16, v);
+  };
+
+  for (int i0 = 0; i0 < M; i0 += TILE) {
+    const int m_blk = std::min(TILE, M - i0);
+    for (int j0 = 0; j0 < N; j0 += TILE) {
+      const int n_blk = std::min(TILE, N - j0);
+
+      // Load src tile into tile_in(row major, ld=TILE), pad with zeros
+      // Use SVE load+store(from the helpers above) into each row
+      for (int r = 0; r < TILE; r++) {
+        for (int c = 0; c < TILE; c++) {
+          tile_in[r * TILE + c] = BFloat16(0);
+        }
+        if (r < m_blk) {
+          const BFloat16* srow = src + (i0 + r) * ld_src + j0;
+          svuint16_t v = ld_bf16_u16_zeroed(srow, n_blk);
+          st_bf16_u16(tile_in + r * TILE, n_blk, v);
+        }
+      }
+
+      // Transpose tile_in to tile_out (scalar on tiny tile)
+      for (int r = 0; r < TILE; r++) {
+        for (int c = 0; c < TILE; c++) {
+          tile_out[r * TILE + c] = BFloat16(0);
+        }
+      }
+      for (int r = 0; r < m_blk; r++) {
+        for (int c = 0; c < n_blk; c++) {
+          tile_out[c * TILE + r] = tile_in[r * TILE + c];
+        }
+      }
+
+      // Store tile_out to dst with SVE store(from the helpers above)
+      for (int r = 0; r < n_blk; r++) {
+        BFloat16* drow = dst + (j0 + r) * ld_dst + i0;
+        svuint16_t v = ld_bf16_u16_zeroed(tile_out + r * TILE, m_blk);
+        st_bf16_u16(drow, m_blk, v);
+      }
+    }
+  }
 }
 
 #endif // defined(CPU_CAPABILITY_SVE256) && defined(__ARM_FEATURE_BF16)

--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -74,7 +74,6 @@ from torch.testing._internal.common_utils import (
     DeterministicGuard,
     IS_ARM64,
     IS_CI,
-    IS_CPU_CAPABILITY_SVE256,
     IS_FBCODE,
     IS_MACOS,
     IS_WINDOWS,
@@ -1140,8 +1139,6 @@ class AOTInductorTestsTemplate:
         IS_FBCODE,
         "Not yet runnable in fbcode when the model.so is newly generated while older PyTorch is used",
     )
-    @xfailIf(IS_ARM64 and IS_CPU_CAPABILITY_SVE256)
-    # see https://github.com/pytorch/pytorch/issues/177243
     @tf32_on_and_off(0.005)
     def test_deconv_freezing(self):
         dtypes = [torch.float]

--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -3856,8 +3856,6 @@ class CPUReproTests(TestCase):
                     self.common(m, (x,))
                     check_metrics_vec_kernel_count(8)
 
-    @xfailIf(IS_ARM64 and IS_CPU_CAPABILITY_SVE256)
-    # see https://github.com/pytorch/pytorch/issues/169958
     @requires_vectorization
     @config.patch("cpp.enable_tiling_heuristics", False)
     def test_transpose_copy(self):
@@ -4105,8 +4103,6 @@ class CPUReproTests(TestCase):
         self.common(fn, (x, y))
         check_metrics_vec_kernel_count(2)
 
-    @xfailIf(IS_ARM64 and IS_CPU_CAPABILITY_SVE256)
-    # see https://github.com/pytorch/pytorch/issues/170877
     def test_transpose_mxn_16_16_bf16_fp16(self):
         def fn(a, b):
             c = a * b


### PR DESCRIPTION
This PR is to reapply the changes from the reverted https://github.com/pytorch/pytorch/pull/174097

This PR adds an explicit `transpose_mxn` `BF16` specialization for AArch64 SVE, providing a deterministic and vectorized BF16 transpose implementation for SVE backends.

Prior to this change, AArch64 SVE builds relied on generic or indirectly routed paths for `BF16` transpose, which were not designed specifically for SVE’s variable vector length and `BF16` storage semantics. Inspired by https://github.com/pytorch/pytorch/pull/170042,  this PR introduces a dedicated SVE implementation that:
+ supports arbitrary `M×N` via `8×8` blocking
+ uses SVE predication for vectorized memory operations
+ is independent of fixed vector widths (SVE128 / SVE256 / More)
+ and is deterministic for partial tiles

This PR introduces a `transpose_mxn<BFloat16>` specialization under the SVE `BF16` capacity. The vectorized transpose is implemented under an `8x8` blocking, allowing arbitrary `MxN` without falling back to the scalar path. It performs vectorized memory operations using SVE predicated `load/store`. In this function, `BFloat16` memory is treated as raw 16-bit lanes(`uint16_t`) for SVE `load/store`, which
+ matches the physical storage of `c10::BFloat16`
+ avoids relying on aliasing or layout assumptions of `value_type`
+ keeps the implementation consistent and robust under optimization

+ SVE's scalable vector length makes assumptions used in fixed-width(such as ASIMD) implementations unreliable
+ `BF16` memory handling differs from `FP32` and can benefit from explicit lane management
+ providing a first-class specialization avoid accidental reliance on generic behaviour of `transpose_mxn` from `vec/vec_base.h`, making the backend more maintainable

This PR is also a permanent fix for https://github.com/pytorch/pytorch/pull/173190, should https://github.com/pytorch/pytorch/pull/173190 is not merged yet, this PR can replace it. This PR should also fix https://github.com/pytorch/pytorch/issues/169958 and https://github.com/pytorch/pytorch/pull/171101

Pull Request resolved: https://github.com/pytorch/pytorch/pull/174097
Approved by: https://github.com/v0i0, https://github.com/jansel

Could you help review and approve this? @jansel @v0i0 Thanks!
cc: @robert-hardwick @aditew01 @fadara01 @Joshua-Ward1


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo