### PR TITLE
[EZ][MPS] Extend histogram to float/bfloat

### DIFF
--- a/aten/src/ATen/native/mps/kernels/HistogramKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/HistogramKernel.metal
@@ -42,7 +42,7 @@ kernel void histogramdd(
     constant uint8_t& algorithm [[buffer(10)]],
     constant int64_t& weight_stride [[buffer(11)]],
     uint tid [[thread_position_in_grid]]) {
-  constexpr T eps = 4e-6;
+  constexpr auto eps = T(4e-6);
   bool skip_element = false;
   int64_t hist_index = 0;
   int64_t bin_seq_offset = 0;
@@ -113,6 +113,7 @@ kernel void histogramdd(
 
 REGISTER_HISTOGRAMDD_OP(float);
 REGISTER_HISTOGRAMDD_OP(half);
+REGISTER_HISTOGRAMDD_OP(bfloat);
 
 kernel void kernel_index_offset(
     constant uint* strides [[buffer(0)]],

--- a/aten/src/ATen/native/mps/operations/HistogramKernel.mm
+++ b/aten/src/ATen/native/mps/operations/HistogramKernel.mm
@@ -1,5 +1,5 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
-#include <ATen/Dispatch.h>
+#include <ATen/Dispatch_v2.h>
 #include <ATen/mps/MPSProfiler.h>
 #include <ATen/native/Histogram.h>
 #include <ATen/native/mps/OperationUtils.h>
@@ -167,9 +167,9 @@ static void histogramdd_out_mps_template(const Tensor& self,
     bin_edges_contig[dim] = bin_edges[dim].contiguous();
   }
 
-  AT_DISPATCH_FLOATING_TYPES(self.scalar_type(), "histogram_mps", [&]() {
+  AT_DISPATCH_V2(self.scalar_type(), "histogram_mps", AT_WRAP([&]() {
     mps::histogramdd_kernel_impl<scalar_t, bin_algorithm>(hist, bin_edges_contig, reshaped_input, reshaped_weight);
-  });
+  }), kFloat, kHalf, kBFloat16);
 
   /* Divides each bin's value by the total count/weight in all bins,
    * and by the bin's volume.

--- a/aten/src/ATen/native/mps/operations/HistogramKernel.mm
+++ b/aten/src/ATen/native/mps/operations/HistogramKernel.mm
@@ -33,7 +33,6 @@ void histogramdd_kernel_impl(Tensor& hist_output,
                              const TensorList& bin_edges,
                              const Tensor& input,
                              const std::optional<Tensor>& weight) {
-  TORCH_CHECK(input.dtype() != at::kDouble, "float64 is not supported on MPS");
   TORCH_INTERNAL_ASSERT(input.dim() == 2);
 
   constexpr uint8_t bin_selection_algorithm = algorithm;
@@ -167,9 +166,15 @@ static void histogramdd_out_mps_template(const Tensor& self,
     bin_edges_contig[dim] = bin_edges[dim].contiguous();
   }
 
-  AT_DISPATCH_V2(self.scalar_type(), "histogram_mps", AT_WRAP([&]() {
-    mps::histogramdd_kernel_impl<scalar_t, bin_algorithm>(hist, bin_edges_contig, reshaped_input, reshaped_weight);
-  }), kFloat, kHalf, kBFloat16);
+  AT_DISPATCH_V2(self.scalar_type(),
+                 "histogram_mps",
+                 AT_WRAP([&]() {
+                   mps::histogramdd_kernel_impl<scalar_t, bin_algorithm>(
+                       hist, bin_edges_contig, reshaped_input, reshaped_weight);
+                 }),
+                 kFloat,
+                 kHalf,
+                 kBFloat16);
 
   /* Divides each bin's value by the total count/weight in all bins,
    * and by the bin's volume.
@@ -211,6 +216,7 @@ static void histogramdd_linear_kernel(const Tensor& self,
   if (local_search) {
     // histogramdd codepath: both hist and bin_edges are eventually returned as output,
     // so we'll keep them consistent
+    TORCH_CHECK(self.scalar_type() == kFloat, "histogram is only supported for float32");
     mps::histogramdd_out_mps_template<mps::LINEAR_INTERPOLATION_WITH_LOCAL_SEARCH>(
         self, weight, density, hist, bin_edges);
   } else {

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -20713,8 +20713,6 @@ op_db: list[OpInfo] = [
                # "AssertionError: RuntimeError not raised : Expected RuntimeError when doing an unsafe cast
                # from a result of dtype torch.float32 into an out= with dtype torch.long"
                DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_out', device_type='cuda'),
-               # The following dtypes did not work in forward but are listed by the OpInfo: {torch.bfloat16, torch.float16}.
-               DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_dtypes', device_type='mps'),
            )),
     OpInfo('bincount',
            dtypes=integral_types_and(),

--- a/torch/testing/_internal/common_mps.py
+++ b/torch/testing/_internal/common_mps.py
@@ -623,7 +623,6 @@ if torch.backends.mps.is_available():
                 torch.float16,
             ],
             # Unsupported dtypes
-            "histc": [torch.float16, torch.bfloat16],
             # GEMM on MPS is not supported for integral types
             "nn.functional.linear": [
                 torch.int16,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #176913

The code was there for a while, at least for half, but dispatch was misconfigured. Though restrict `histogram`/`histogramdd` to support only float32, to match OpInfo definition. 
Also, switch to DispatchV2

Related to https://github.com/pytorch/pytorch/issues/176879