### PR TITLE
Fix USE_NINJA flag during build after move to pip

### DIFF
--- a/tools/setup_helpers/cmake.py
+++ b/tools/setup_helpers/cmake.py
@@ -17,6 +17,7 @@ from subprocess import CalledProcessError, check_call, check_output, DEVNULL
 from .cmake_utils import CMakeValue, get_cmake_cache_variables_from_file
 from .env import (
     BUILD_DIR,
+    check_env_flag,
     check_negative_env_flag,
     CMAKE_MINIMUM_VERSION_STRING,
     IS_64BIT,
@@ -50,9 +51,17 @@ eprint = functools.partial(print, file=sys.stderr, flush=True)
 
 
 # Ninja
-# Use ninja if it is on the PATH. Previous version of PyTorch required the
-# ninja python package, but we no longer use it, so we do not have to import it
-USE_NINJA = bool(not check_negative_env_flag("USE_NINJA") and shutil.which("ninja"))
+# USE_NINJA=1 opts in to ninja (error if not found), USE_NINJA=0 opts out,
+# unset means auto-detect from PATH. CMAKE_GENERATOR overrides everything.
+if check_env_flag("USE_NINJA"):
+    if not shutil.which("ninja"):
+        raise RuntimeError(
+            "USE_NINJA=1 is set but ninja could not be found on PATH. "
+            "Install it with: pip install ninja"
+        )
+    USE_NINJA = True
+else:
+    USE_NINJA = bool(not check_negative_env_flag("USE_NINJA") and shutil.which("ninja"))
 if "CMAKE_GENERATOR" in os.environ:
     USE_NINJA = os.environ["CMAKE_GENERATOR"].lower() == "ninja"
 


### PR DESCRIPTION
## Human Note
USE_NINJA=1 was handled in setup.py. Updating it so it works now that we bypass that. Tested locally.

## Agent Report
<details>
<summary>Agent Worklog</summary>

## Run 1

> **User:** I want to enable USE_NINJA=1 to work with the new pip install -based installation workflow, the same way it used to work with setup.py.

### Exploration: Current USE_NINJA Behavior

- **Detection**: `tools/setup_helpers/cmake.py:55` — `USE_NINJA = bool(not check_negative_env_flag("USE_NINJA") and shutil.which("ninja"))`
- When env var is not set to a negative value AND ninja is on PATH → use ninja
- Setting `USE_NINJA=1` is effectively the same as not setting it at all
- Setting `USE_NINJA=0` disables ninja
- The env var is passed through to cmake as `-DUSE_NINJA=<value>`

### Testing: pip install with USE_NINJA=1

Tested all scenarios — env vars propagate correctly through both `uv pip install` and `pip install`. Ninja is correctly used when available. Generator switching (Makefiles → Ninja) fails without cache clear.

### Key finding: USE_NINJA env var is not excluded from cmake pass-through

The env var `USE_NINJA` is passed to cmake as `-DUSE_NINJA=1` because it starts with `USE_`. CMake doesn't use this variable (not in CMakeLists.txt), so it's harmless noise.



</details>

---
*This PR was generated by [ptq](https://github.com/drisspg/pt_job_queue) with human review.*