### PR TITLE
docs: unify macOS spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,15 +262,6 @@ pip install mkl-static mkl-include
 make triton
 ```
 
-**On macOS**
-
-```bash
-# Add this package on Intel x86 processor machines only. Skip on ARM64.
-pip install mkl-static mkl-include
-# Add these packages if torch.distributed is needed
-conda install pkg-config libuv
-```
-
 **On Windows**
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -262,10 +262,10 @@ pip install mkl-static mkl-include
 make triton
 ```
 
-**On MacOS**
+**On macOS**
 
 ```bash
-# Add this package on intel x86 processor machines only
+# Add this package on Intel x86 processor machines only. Skip on ARM64.
 pip install mkl-static mkl-include
 # Add these packages if torch.distributed is needed
 conda install pkg-config libuv

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -129,7 +129,7 @@ Following requirements need to be met prior to cutting a release branch:
 
 * Triton release branch must be created (e.g., [release/3.6.x](https://github.com/triton-lang/triton/tree/release/3.6.x)) and the Triton pin update PR must be landed (e.g., [#168096](https://github.com/pytorch/pytorch/pull/168096)) at least 1 week before the branch cut
 * Resolve all outstanding issues in the milestones that are feature work and release blocking (for example [release 2.10 milestone](https://github.com/pytorch/pytorch/milestone/57)). A report of outstanding cherry-picks can be produced by running the [github-analytics-daily workflow](https://github.com/pytorch/test-infra/blob/main/.github/workflows/github-analytics-daily.yml)
-* Validate that all new workflows have been created in the PyTorch and domain libraries included in the release. Validate it against all dimensions of release matrix, including operating systems (Linux, MacOS, Windows), Python versions as well as CPU architectures (x86 and arm) and accelerator versions (CUDA, ROCm, XPU).
+* Validate that all new workflows have been created in the PyTorch and domain libraries included in the release. Validate it against all dimensions of release matrix, including operating systems (Linux, macOS, Windows), Python versions as well as CPU architectures (x86 and arm) and accelerator versions (CUDA, ROCm, XPU).
 * All [viable/strict](.github/workflows/update-viablestrict.yml) jobs are green, which requires the following jobs to pass: `pull`, `trunk`, `lint`, `linux-aarch64`
 * All the nightly jobs for pytorch and domain libraries should be green. Validate this using the following HUD links:
   * [PyTorch](https://hud.pytorch.org/hud/pytorch/pytorch/nightly)
@@ -475,7 +475,7 @@ Supported OS flavors are summarized in the table below:
 | Operating System family | Architecture | Notes |
 | --- | --- | --- |
 | Linux | aarch64, x86_64 | Wheels are manylinux2014 compatible, i.e. they should be runnable on any Linux system with glibc-2.17 or above. |
-| MacOS | arm64 | Builds should be compatible with MacOS 11 (Big Sur) or newer, but are actively tested against MacOS 14 (Sonoma). MPS support is enabled on MacOS 13 (Ventura) or later. |
+| macOS | arm64 | Builds should be compatible with macOS 11 (Big Sur) or newer, but are actively tested against macOS 14 (Sonoma). MPS support is enabled on macOS 14 (Sonoma) or later. |
 | Windows | x86_64 | Builds are compatible with Windows-10 or newer. |
 
 # Submitting Tutorials

--- a/aten/src/ATen/mps/EmptyTensor.cpp
+++ b/aten/src/ATen/mps/EmptyTensor.cpp
@@ -12,7 +12,7 @@
 
 #define MPS_ERROR_NOT_COMPILED "PyTorch code is not compiled with MPS enabled"
 #define MPS_ERROR_RUNTIME_TOO_LOW \
-  "The MPS backend is supported on MacOS 14.0+. ", \
+  "The MPS backend is supported on macOS 14.0+. ", \
   "Current OS version can be queried using `sw_vers`"
 #define MPS_ERROR_DOUBLE_NOT_SUPPORTED "Cannot convert a MPS Tensor to float64 dtype " \
   "as the MPS framework doesn't support float64. Please use float32 instead."

--- a/docs/source/notes/mps.rst
+++ b/docs/source/notes/mps.rst
@@ -4,7 +4,7 @@ MPS backend
 ===========
 
 :mod:`mps` device enables high-performance
-training on GPU for MacOS devices with Metal programming framework.  It
+training on GPU for macOS devices with Metal programming framework.  It
 introduces a new device to map Machine Learning computational graphs and
 primitives on highly efficient Metal Performance Shaders Graph framework and
 tuned kernels provided by Metal Performance Shaders framework respectively.
@@ -22,7 +22,7 @@ To get started, simply move your Tensor and Module to the ``mps`` device:
             print("MPS not available because the current PyTorch install was not "
                   "built with MPS enabled.")
         else:
-            print("MPS not available because the current MacOS version is not 12.3+ "
+            print("MPS not available because the current macOS version is not 12.3+ "
                   "and/or you do not have an MPS-enabled device on this machine.")
 
     else:

--- a/docs/source/notes/mps.rst
+++ b/docs/source/notes/mps.rst
@@ -22,7 +22,7 @@ To get started, simply move your Tensor and Module to the ``mps`` device:
             print("MPS not available because the current PyTorch install was not "
                   "built with MPS enabled.")
         else:
-            print("MPS not available because the current macOS version is not 12.3+ "
+            print("MPS not available because the current macOS version is not 14.0+ "
                   "and/or you do not have an MPS-enabled device on this machine.")
 
     else:


### PR DESCRIPTION
Fixes #176907

- Standardize `MacOS` to `macOS`
- Delete section about Intel Macs
- Update MPS min supported macOS versions to 14.0
