### PR TITLE
Add distributed runtime autotuning for Triton kernels

### DIFF
--- a/test/inductor/test_distributed_runtime_autotune.py
+++ b/test/inductor/test_distributed_runtime_autotune.py
@@ -1,0 +1,478 @@
+# Owner(s): ["module: inductor"]
+
+import os
+import sys
+import time
+
+import torch
+import torch.distributed as dist
+
+
+if not dist.is_available() or not dist.is_nccl_available():
+    print("c10d NCCL not available, skipping tests", file=sys.stderr)
+    sys.exit(0)
+
+from torch._inductor import config
+from torch._inductor.runtime import distributed_runtime_autotune as dra
+from torch._inductor.test_case import run_tests
+from torch.testing._internal.common_distributed import (
+    MultiProcessTestCase,
+    skip_if_lt_x_gpu,
+)
+
+
+class TestDistributedRuntimeAutotune(MultiProcessTestCase):
+    """
+    Test distributed runtime autotuning across 2 ranks.
+    """
+
+    @property
+    def world_size(self):
+        return 2
+
+    def setUp(self):
+        super().setUp()
+        dra._AUTOTUNE_PG = None
+        dra._COORDINATORS.clear()
+        os.environ["LOCAL_WORLD_SIZE"] = str(self.world_size)
+        self._spawn_processes()
+
+    @skip_if_lt_x_gpu(1)
+    @config.patch(
+        coordinate_descent_tuning=True,
+        distributed_runtime_autotune=True,
+        distributed_runtime_autotune_max_wait_seconds=5,
+        distributed_runtime_autotune_min_kernels=2,
+        force_disable_caches=True,
+    )
+    def test_distributed_autotune_single_gpu(self):
+        """
+        Functional test if we have only one GPU: Two ranks share a single GPU
+        and collaborate to perform distributed autotune using the gloo backend.
+        """
+        dist.init_process_group(
+            backend="gloo",
+            init_method=f"file://{self.file_name}",
+            world_size=self.world_size,
+            rank=self.rank,
+        )
+        os.environ["LOCAL_RANK"] = str(self.rank)
+
+        device = "cuda:0"
+        torch.cuda.set_device(device)
+
+        class Model(torch.nn.Module):
+            def forward(self, x):
+                x = x - x.amax(dim=-1, keepdim=True)
+                x = x.exp()
+                x = x / x.sum(dim=-1, keepdim=True)
+                x = torch.mm(x, x)
+                x = x - x.mean(dim=-1, keepdim=True)
+                x = torch.mm(x, x)
+                return x.sum()
+
+        model = Model().to(device)
+        torch.manual_seed(42)
+        x = torch.randn(256, 256, device=device, requires_grad=True)
+
+        # Eager
+        out_eager = model(x)
+        out_eager.backward()
+        grad_eager = x.grad.clone()
+        x.grad = None
+
+        # Compiled
+        compiled = torch.compile(model)
+        out_compiled = compiled(x)
+        self.assertEqual(out_eager, out_compiled)
+
+        out_compiled.backward()
+        self.assertIsNotNone(x.grad)
+        self.assertEqual(grad_eager, x.grad)
+
+        # Verify distributed autotuning succeeded with full results
+        fwd_coord = [v for k, v in dra._COORDINATORS.items() if k.endswith("/fwd")]
+        bwd_coord = [v for k, v in dra._COORDINATORS.items() if k.endswith("/bwd")]
+        self.assertGreater(len(fwd_coord), 0)
+        self.assertGreater(len(bwd_coord), 0)
+
+        for coordinator in fwd_coord + bwd_coord:
+            self.assertTrue(coordinator._autotuning_done)
+            self.assertTrue(coordinator._autotuning_attempted)
+            self.assertTrue(coordinator._autotuning_full_match)
+
+        dist.barrier()
+        dist.destroy_process_group()
+
+    @skip_if_lt_x_gpu(2)
+    @config.patch(
+        coordinate_descent_tuning=True,
+        distributed_runtime_autotune=True,
+        distributed_runtime_autotune_max_wait_seconds=5,
+        distributed_runtime_autotune_min_kernels=2,
+        force_disable_caches=True,
+    )
+    def test_distributed_autotune_multi_kernel(self):
+        """
+        Both ranks compile the same model that produces multiple kernels and
+        then collaborate to perform distributed autotune.
+        """
+        dist.init_process_group(
+            backend="nccl",
+            init_method=f"file://{self.file_name}",
+            world_size=self.world_size,
+            rank=self.rank,
+        )
+        os.environ["LOCAL_RANK"] = str(self.rank)
+
+        device = f"cuda:{self.rank}"
+        torch.cuda.set_device(device)
+
+        class Model(torch.nn.Module):
+            def forward(self, x):
+                x = x - x.amax(dim=-1, keepdim=True)
+                x = x.exp()
+                x = x / x.sum(dim=-1, keepdim=True)
+                x = torch.mm(x, x)
+                x = x - x.mean(dim=-1, keepdim=True)
+                x = torch.mm(x, x)
+                return x.sum()
+
+        model = Model().to(device)
+        torch.manual_seed(42)
+        x = torch.randn(256, 256, device=device, requires_grad=True)
+        dist.broadcast(x, src=0)
+
+        # Eager
+        out_eager = model(x)
+        out_eager.backward()
+        grad_eager = x.grad.clone()
+        x.grad = None
+
+        # Compiled
+        compiled = torch.compile(model)
+        out_compiled = compiled(x)
+        self.assertEqual(out_eager, out_compiled)
+
+        out_compiled.backward()
+        self.assertIsNotNone(x.grad)
+        self.assertEqual(grad_eager, x.grad)
+
+        # Verify distributed autotuning succeeded with full results
+        fwd_coord = [v for k, v in dra._COORDINATORS.items() if k.endswith("/fwd")]
+        bwd_coord = [v for k, v in dra._COORDINATORS.items() if k.endswith("/bwd")]
+        self.assertGreater(len(fwd_coord), 0)
+        self.assertGreater(len(bwd_coord), 0)
+
+        for coordinator in fwd_coord + bwd_coord:
+            self.assertTrue(coordinator._autotuning_done)
+            self.assertTrue(coordinator._autotuning_attempted)
+            self.assertTrue(coordinator._autotuning_full_match)
+
+        dist.barrier()
+        dist.destroy_process_group()
+
+    @skip_if_lt_x_gpu(2)
+    @config.patch(
+        coordinate_descent_tuning=True,
+        distributed_runtime_autotune=True,
+        distributed_runtime_autotune_max_wait_seconds=5,
+        distributed_runtime_autotune_min_kernels=1,
+        force_disable_caches=True,
+    )
+    def test_distributed_autotune_single_kernel(self):
+        """
+        Both ranks compile a function that produces a single reduction Triton
+        kernel. One rank autotunes it and the other receives the result.
+        """
+        dist.init_process_group(
+            backend="nccl",
+            init_method=f"file://{self.file_name}",
+            world_size=self.world_size,
+            rank=self.rank,
+        )
+        os.environ["LOCAL_RANK"] = str(self.rank)
+
+        device = f"cuda:{self.rank}"
+        torch.cuda.set_device(device)
+
+        def f(x):
+            return x.sum(dim=-1)
+
+        torch.manual_seed(42)
+        x = torch.randn(256, 256, device=device, requires_grad=True)
+        dist.broadcast(x, src=0)
+
+        # Eager
+        out_eager = f(x)
+        loss_eager = out_eager.sum()
+        loss_eager.backward()
+        grad_eager = x.grad.clone()
+        x.grad = None
+
+        # Compiled
+        compiled = torch.compile(f)
+        out_compiled = compiled(x)
+        self.assertEqual(out_eager, out_compiled)
+
+        loss_compiled = out_compiled.sum()
+        loss_compiled.backward()
+        self.assertIsNotNone(x.grad)
+        self.assertEqual(grad_eager, x.grad)
+
+        # Verify distributed autotuning succeeded with full results
+        fwd_coord = [v for k, v in dra._COORDINATORS.items() if k.endswith("/fwd")]
+        self.assertGreater(len(fwd_coord), 0)
+
+        for coordinator in fwd_coord:
+            self.assertTrue(coordinator._autotuning_done)
+            self.assertTrue(coordinator._autotuning_attempted)
+            self.assertTrue(coordinator._autotuning_full_match)
+
+        dist.barrier()
+        dist.destroy_process_group()
+
+    @skip_if_lt_x_gpu(2)
+    @config.patch(
+        coordinate_descent_tuning=True,
+        distributed_runtime_autotune=True,
+        distributed_runtime_autotune_max_wait_seconds=5,
+        distributed_runtime_autotune_min_kernels=1000,
+        force_disable_caches=True,
+    )
+    def test_distributed_autotune_too_few_kernels(self):
+        """
+        Both ranks compile the same function, but the min_kernels threshold
+        is set high enough that the leader rejects distributed autotuning.
+        Both ranks should fall back to local autotuning.
+        """
+        dist.init_process_group(
+            backend="nccl",
+            init_method=f"file://{self.file_name}",
+            world_size=self.world_size,
+            rank=self.rank,
+        )
+        os.environ["LOCAL_RANK"] = str(self.rank)
+
+        device = f"cuda:{self.rank}"
+        torch.cuda.set_device(device)
+
+        def f(x):
+            return x.sum(dim=-1)
+
+        torch.manual_seed(42)
+        x = torch.randn(256, 256, device=device, requires_grad=True)
+        dist.broadcast(x, src=0)
+
+        # Eager
+        out_eager = f(x)
+        loss_eager = out_eager.sum()
+        loss_eager.backward()
+        grad_eager = x.grad.clone()
+        x.grad = None
+
+        # Compiled
+        compiled = torch.compile(f)
+        out_compiled = compiled(x)
+        self.assertEqual(out_eager, out_compiled)
+
+        loss_compiled = out_compiled.sum()
+        loss_compiled.backward()
+        self.assertIsNotNone(x.grad)
+        self.assertEqual(grad_eager, x.grad)
+
+        # Verify distributed autotuning was not attempted
+        fwd_coord = [v for k, v in dra._COORDINATORS.items() if k.endswith("/fwd")]
+        self.assertGreater(len(fwd_coord), 0)
+
+        for coordinator in fwd_coord:
+            self.assertTrue(coordinator._autotuning_done)
+            self.assertFalse(coordinator._autotuning_attempted)
+            self.assertFalse(coordinator._autotuning_full_match)
+
+        dist.barrier()
+        dist.destroy_process_group()
+
+    @skip_if_lt_x_gpu(2)
+    @config.patch(
+        coordinate_descent_tuning=True,
+        distributed_runtime_autotune=True,
+        distributed_runtime_autotune_max_wait_seconds=5,
+        distributed_runtime_autotune_min_kernels=1,
+        force_disable_caches=True,
+    )
+    def test_distributed_autotune_kernel_mismatch(self):
+        """
+        The ranks compile different functions, causing kernel list mismatch.
+        Distributed autotuning still proceeds; each rank autotunes its
+        round-robin subset and uses whatever matching results come back.
+        """
+        dist.init_process_group(
+            backend="nccl",
+            init_method=f"file://{self.file_name}",
+            world_size=self.world_size,
+            rank=self.rank,
+        )
+        os.environ["LOCAL_RANK"] = str(self.rank)
+
+        device = f"cuda:{self.rank}"
+        torch.cuda.set_device(device)
+
+        # Two functions producing different reduction kernels.
+        def fn_sum(x):
+            return x.sum(dim=-1)
+
+        def fn_amax(x):
+            return x.amax(dim=-1)
+
+        fn = fn_sum if self.rank == 0 else fn_amax
+        torch.manual_seed(42)
+        x = torch.randn(256, 256, device=device)
+
+        # Eager
+        out_eager = fn(x)
+
+        # Compiled
+        compiled = torch.compile(fn)
+        out_compiled = compiled(x)
+        self.assertEqual(out_eager, out_compiled)
+
+        # Distributed autotuning was attempted despite mismatched kernel lists.
+        fwd_coord = [v for k, v in dra._COORDINATORS.items() if k.endswith("/fwd")]
+        self.assertGreater(len(fwd_coord), 0)
+
+        for coordinator in fwd_coord:
+            self.assertTrue(coordinator._autotuning_done)
+            self.assertTrue(coordinator._autotuning_attempted)
+
+        dist.barrier()
+        dist.destroy_process_group()
+
+    @skip_if_lt_x_gpu(2)
+    @config.patch(
+        coordinate_descent_tuning=True,
+        distributed_runtime_autotune=True,
+        distributed_runtime_autotune_max_wait_seconds=5,
+        distributed_runtime_autotune_min_kernels=1,
+        force_disable_caches=True,
+    )
+    def test_distributed_autotune_one_rank_compiles(self):
+        """
+        Only one rank compiles a reduction kernel. It should attempt distributed
+        autotuning, but fall back to local when the other rank doesn't signal
+        participation.
+        """
+        dist.init_process_group(
+            backend="nccl",
+            init_method=f"file://{self.file_name}",
+            world_size=self.world_size,
+            rank=self.rank,
+        )
+        os.environ["LOCAL_RANK"] = str(self.rank)
+
+        device = f"cuda:{self.rank}"
+        torch.cuda.set_device(device)
+
+        # Rank 0 compiles a reduction; rank 1 compiles pointwise (no reduction
+        # kernels, so no coordinator is created and rank 1 never votes).
+        def fn_reduction(x):
+            return x.sum(dim=-1)
+
+        def fn_pointwise(x):
+            return x * 2 + 1
+
+        fn = fn_reduction if self.rank == 0 else fn_pointwise
+        torch.manual_seed(42)
+        x = torch.randn(256, 256, device=device)
+
+        # Eager
+        out_eager = fn(x)
+
+        # Compiled
+        compiled = torch.compile(fn)
+        out_compiled = compiled(x)
+        self.assertEqual(out_eager, out_compiled)
+
+        if self.rank == 0:
+            # Verify coordinator was created but not attempted (other rank
+            # never voted, so participation check failed)
+            fwd_coord = [v for k, v in dra._COORDINATORS.items() if k.endswith("/fwd")]
+            self.assertGreater(len(fwd_coord), 0)
+            for coordinator in fwd_coord:
+                self.assertTrue(coordinator._autotuning_done)
+                self.assertFalse(coordinator._autotuning_attempted)
+                self.assertFalse(coordinator._autotuning_full_match)
+        else:
+            self.assertEqual(len(dra._COORDINATORS), 0)
+
+        dist.barrier()
+        dist.destroy_process_group()
+
+    @skip_if_lt_x_gpu(2)
+    @config.patch(
+        coordinate_descent_tuning=True,
+        distributed_runtime_autotune=True,
+        distributed_runtime_autotune_max_wait_seconds=0.1,
+        distributed_runtime_autotune_min_kernels=1,
+        force_disable_caches=True,
+    )
+    def test_distributed_autotune_late_participation(self):
+        """
+        One rank compiles immediately while the other delays. The leader should
+        time out waiting for the late rank's vote. Both ranks should then fall
+        back to local autotuning.
+        """
+        dist.init_process_group(
+            backend="nccl",
+            init_method=f"file://{self.file_name}",
+            world_size=self.world_size,
+            rank=self.rank,
+        )
+        os.environ["LOCAL_RANK"] = str(self.rank)
+
+        device = f"cuda:{self.rank}"
+        torch.cuda.set_device(device)
+
+        def f(x):
+            return x.sum(dim=-1)
+
+        torch.manual_seed(42)
+        x = torch.randn(256, 256, device=device, requires_grad=True)
+        dist.broadcast(x, src=0)
+
+        # Eager
+        out_eager = f(x)
+        loss_eager = out_eager.sum()
+        loss_eager.backward()
+        grad_eager = x.grad.clone()
+        x.grad = None
+
+        # Rank 1 sleeps so the leader (rank 0) times out waiting for its vote
+        if self.rank == 1:
+            time.sleep(3)
+
+        # Compiled — both ranks fall back to local autotuning
+        compiled = torch.compile(f)
+        out_compiled = compiled(x)
+        self.assertEqual(out_eager, out_compiled)
+
+        loss_compiled = out_compiled.sum()
+        loss_compiled.backward()
+        self.assertIsNotNone(x.grad)
+        self.assertEqual(grad_eager, x.grad)
+
+        # Verify distributed autotuning was not attempted (leader timed out)
+        fwd_coord = [v for k, v in dra._COORDINATORS.items() if k.endswith("/fwd")]
+        self.assertGreater(len(fwd_coord), 0)
+
+        for coordinator in fwd_coord:
+            self.assertTrue(coordinator._autotuning_done)
+            self.assertFalse(coordinator._autotuning_attempted)
+            self.assertFalse(coordinator._autotuning_full_match)
+
+        dist.barrier()
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -6083,29 +6083,32 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         self.post_loop_combine.clear()
         self.post_loop_store.clear()
 
-    def kernel_benchmark_extra_args(self) -> list[str]:
-        args = []
+    def _kernel_benchmark_extra_args(self) -> list[Any]:
+        args: list[Any] = []
         if self.need_numel_args():
             numel_args: list[sympy.Expr] = []
             self.add_numel_to_call_args("", numel_args, [])
             for arg in numel_args:
                 if isinstance(arg, int):
-                    args.append(str(arg))
+                    args.append(arg)
                 elif isinstance(arg, SymbolicCallArg):
                     hint = V.graph.sizevars.optimization_hint_with_override(
                         arg.inner_expr,
                         hint_override=self.hint_override,
                     )
-                    args.append(str(hint))
+                    args.append(hint)
                 elif isinstance(arg, sympy.Expr):
                     hint = V.graph.sizevars.optimization_hint_with_override(
                         arg,
                         hint_override=self.hint_override,
                     )
-                    args.append(str(hint))
+                    args.append(hint)
                 else:
                     raise ValueError(f"Unsupported numel argument type: {type(arg)}")
         return args
+
+    def kernel_benchmark_extra_args(self) -> list[str]:
+        return [str(a) for a in self._kernel_benchmark_extra_args()]
 
     def codegen_kernel_benchmark(self, num_gb: float | None) -> IndentedBuffer:
         """
@@ -6227,6 +6230,49 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             )
 
         return result
+
+    def get_arg_metadata_for_benchmarking(self) -> list[Any]:
+        """
+        Get metadata for all kernel arguments that can be used to construct
+        random tensors for distributed autotuning.
+        """
+        from torch._inductor.runtime.distributed_runtime_autotune import (
+            TensorMeta,
+            WorkspaceMeta,
+        )
+
+        args: list[Any] = []
+        _, call_args, signature, _ = self.args.python_argdefs()
+        for arg_name, arg_sig in zip(call_args, signature):
+            if buf := V.graph.try_get_buffer(arg_name):
+                args.append(
+                    TensorMeta.from_irnode(
+                        buf, V.graph.sizevars, hint_override=self.hint_override
+                    )
+                )
+            elif arg_name in V.graph.constants:
+                const_tensor = V.graph.constants[arg_name]
+                args.append(TensorMeta.from_tensor(const_tensor))
+            elif isinstance(arg_sig, SizeArg):
+                symval_hint = V.graph.sizevars.optimization_hint_with_override(
+                    arg_sig.expr,
+                    hint_override=self.hint_override,
+                )
+                args.append(symval_hint)
+            elif isinstance(arg_sig, WorkspaceArg):
+                args.append(
+                    WorkspaceMeta.from_workspace(
+                        arg_sig, V.graph.sizevars, hint_override=self.hint_override
+                    )
+                )
+            else:
+                raise KeyError(
+                    f"Distributed autotune: Didn't find buffer or const tensor: for {arg_name}"
+                )
+
+        extra_args = self._kernel_benchmark_extra_args()
+        args.extend(extra_args)
+        return args
 
     def imports_for_benchmark_kernel(self):
         return textwrap.dedent(
@@ -7453,6 +7499,30 @@ class TritonScheduling(SIMDScheduling):
                 kernel_path,
                 get_kernel_metadata,
             )
+
+            # Register kernel for distributed runtime autotuning.
+            # TODO: Should we support more than TritonKernels, e.g., what's a ComboKernel
+            # and can that be autotuned? Also, what about user-defined kernels?
+            if (
+                config.distributed_runtime_autotune
+                and isinstance(kernel, TritonKernel)
+                and kernel.features.is_reduction()
+            ):
+                from torch._inductor.runtime.distributed_runtime_autotune import (
+                    try_register_kernel_from_codegen,
+                )
+
+                # Hash the kernel body instead of the full source because the body doesn't
+                # contain the device (which would vary across ranks). But include the name
+                # because we see different kernels with identical bodies. TODO: Is this
+                # sufficient? Should we include the size hints as well, for example?
+                kernel_hash = code_hash(kernel.body.getvalue(), extra=kernel_name)
+                try_register_kernel_from_codegen(
+                    kernel_name,
+                    kernel_hash,
+                    V.graph.is_backward,
+                    kernel.get_arg_metadata_for_benchmarking,
+                )
 
             # log kernel metadata for offline analysis.
             # E.g. one can find all unaligned inner reduction and check if

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -502,6 +502,37 @@ distributed_max_autotune_gemm = (
     os.environ.get("TORCHINDUCTOR_DISTRIBUTED_MAX_AUTOTUNE_GEMM") == "1"
 )
 
+# Enable distributed runtime autotuning. When enabled, runtime Triton autotuning is
+# distributed across ranks in the same process group (or optionally, same host).
+# If coordinate_descent_tuning is enabled, honors that setting during distributed
+# autotuning.
+distributed_runtime_autotune = (
+    os.environ.get("TORCHINDUCTOR_DISTRIBUTED_RUNTIME_AUTOTUNE") == "1"
+)
+
+# Maximum time in seconds to wait for all ranks to signal participation in distributed
+# runtime autotuning before falling back to local autotuning. This time is essentially
+# the per-frame overhead paid in the case that not all ranks participate. It should be
+# large enough to accommodate the skew among ranks, but low enough to avoid waiting
+# unnecessarily when not all ranks are compiling.
+distributed_runtime_autotune_max_wait_seconds: float = float(
+    os.environ.get(
+        "TORCHINDUCTOR_DISTRIBUTED_RUNTIME_AUTOTUNE_MAX_WAIT_SECONDS", "30.0"
+    )
+)
+
+# Restrict distributed runtime autotuning to ranks on the same host. Assumes
+# global ranks are assigned consecutively per host and that the LOCAL_RANK and
+# LOCAL_WORLD_SIZE env vars are set appropriately (as with torchrun).
+distributed_runtime_autotune_host_only = (
+    os.environ.get("TORCHINDUCTOR_DISTRIBUTED_RUNTIME_AUTOTUNE_HOST_ONLY") == "1"
+)
+
+# Minimum number of kernels required to justify the overhead of distributing autotuning.
+distributed_runtime_autotune_min_kernels: int = int(
+    os.environ.get("TORCHINDUCTOR_DISTRIBUTED_RUNTIME_AUTOTUNE_MIN_KERNELS", "8")
+)
+
 # Pipeline autotuning for max-autotune-gemm. Overlap lowering and benchmarking on GPU
 pipeline_max_autotune_gemm = (
     os.environ.get("TORCHINDUCTOR_PIPELINE_GEMM_AUTOTUNING") == "1"

--- a/torch/_inductor/runtime/distributed_runtime_autotune.py
+++ b/torch/_inductor/runtime/distributed_runtime_autotune.py
@@ -1,0 +1,651 @@
+from __future__ import annotations
+
+import dataclasses
+import datetime
+import logging
+import os
+import threading
+import time
+from typing import Any, TYPE_CHECKING
+
+import torch
+import torch.distributed as dist
+from torch._dynamo.testing import rand_strided
+from torch._inductor import config
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from torch._inductor.runtime.triton_compat import Config
+    from torch._inductor.runtime.triton_heuristics import CachingAutotuner
+    from torch._prims_common import ShapeType, StrideType
+
+log = logging.getLogger(__name__)
+
+_AUTOTUNE_PG: dist.ProcessGroup | None = None
+_AUTOTUNE_PG_LOCK = threading.Lock()
+
+
+def get_or_create_autotune_pg() -> dist.ProcessGroup | None:
+    """
+    Lazily create the autotuning process group. Must only be called after all
+    participating ranks have confirmed via the 2PC protocol, since PG creation
+    requires all member ranks to participate.
+    """
+    global _AUTOTUNE_PG
+    if _AUTOTUNE_PG is not None:
+        return _AUTOTUNE_PG
+
+    with _AUTOTUNE_PG_LOCK:
+        if _AUTOTUNE_PG is not None:
+            return _AUTOTUNE_PG
+
+        if not dist.is_available() or not dist.is_initialized():
+            return None
+
+        if config.distributed_runtime_autotune_host_only:
+            local_world_size = int(os.environ.get("LOCAL_WORLD_SIZE", 0))
+            local_rank = int(os.environ.get("LOCAL_RANK", -1))
+            if local_world_size <= 0 or local_rank < 0:
+                log.error(
+                    "Distributed autotune: LOCAL_WORLD_SIZE or LOCAL_RANK not set, "
+                    "cannot initialize host-only autotune process group"
+                )
+                return None
+            global_rank = dist.get_rank()
+            base = global_rank - local_rank
+            local_ranks = list(range(base, base + local_world_size))
+            _AUTOTUNE_PG = dist.new_group(
+                ranks=local_ranks,
+                use_local_synchronization=True,
+                group_desc="pt2_distributed_runtime_autotune",
+            )
+        else:
+            _AUTOTUNE_PG = dist.new_group(
+                group_desc="pt2_distributed_runtime_autotune",
+            )
+
+        return _AUTOTUNE_PG
+
+
+@dataclasses.dataclass
+class TensorMeta:
+    """
+    Contains all the metadata needed to construct a random tensor for
+    benchmarking a Triton kernel.
+    """
+
+    size: ShapeType
+    stride: StrideType
+    dtype: torch.dtype
+    offset: int | torch.SymInt
+
+    @classmethod
+    def from_irnode(
+        cls,
+        node: Any,
+        sizevars: Any,
+        hint_override: int | None = None,
+    ) -> TensorMeta:
+        size = sizevars.optimization_hints_with_override(node.get_size(), hint_override)
+        stride = sizevars.optimization_hints_with_override(
+            node.get_stride(), hint_override
+        )
+        offset = sizevars.optimization_hint_with_override(
+            node.get_layout().offset, hint_override
+        )
+        dtype = node.get_dtype()
+
+        return cls(
+            size=size,
+            stride=stride,
+            dtype=dtype,
+            offset=offset,
+        )
+
+    @classmethod
+    def from_tensor(cls, tensor: torch.Tensor) -> TensorMeta:
+        return cls(
+            size=tuple(tensor.size()),
+            stride=tuple(tensor.stride()),
+            dtype=tensor.dtype,
+            offset=tensor.storage_offset(),
+        )
+
+    def to_tensor(self) -> torch.Tensor:
+        """
+        Create a random tensor from metadata.
+        """
+        return rand_strided(
+            self.size,
+            self.stride,
+            dtype=self.dtype,
+            device=torch.device("cuda", torch.cuda.current_device()),
+            extra_size=int(self.offset),
+        )
+
+
+@dataclasses.dataclass
+class WorkspaceMeta(TensorMeta):
+    """
+    Metadata for a Workspace buffer. Produces a zeroed tensor.
+    """
+
+    @classmethod
+    def from_workspace(
+        cls,
+        workspace_arg: Any,
+        sizevars: Any,
+        hint_override: int | None = None,
+    ) -> WorkspaceMeta:
+        count = sizevars.optimization_hint_with_override(
+            workspace_arg.count, hint_override
+        )
+        return cls(size=(count,), stride=(1,), dtype=workspace_arg.dtype, offset=0)
+
+    def to_tensor(self) -> torch.Tensor:
+        return torch.zeros(
+            self.size,
+            dtype=self.dtype,
+            device=torch.device("cuda", torch.cuda.current_device()),
+        )
+
+
+class DistributedAutotuneCoordinator:
+    """
+    Distributes runtime autotuning work across ranks using a Two-Phase Commit
+    protocol. When enabled, each rank autotunes at most 1/world_size of the
+    kernels and results are synchronized, primarily reducing total autotuning
+    time, but adding the benefit that all ranks use the same config for a
+    given kernel.
+
+    Phase 1 (codegen): Each rank fires a non-collective participation vote via
+    store.add(). The first rank to vote becomes the leader. NOTE that we assume
+    that if a rank generates at least one tunable kernel for a given compile_id,
+    then it's guaranteed to enter CachingAutotuner.run() and we'll perform phase
+    2 exactly once.
+
+    Phase 2 (runtime, on first kernel invocation): The leader polls until all
+    ranks have voted or timeout, then writes a commit/abort decision. All ranks
+    read the decision before proceeding to any collectives, preventing the case
+    where some ranks enter a collective while others have timed out. If all
+    ranks are confirmed to participate, work is distributed round-robin, each
+    rank autotunes its subset, and results are synchronized via all_gather.
+    Finally, the best config is applied to each CachingAutotuner. Note that
+    we assume that all ranks autotune the same kernels. If that is not the
+    case, we simply apply the results we get back and those kernels that get no
+    result fall back to local autotuning.
+    """
+
+    def __init__(self, key):
+        self.key = key
+
+        # A lock is probably overkill, but better for future proofing.
+        self._lock = threading.Lock()
+        self._autotuning_done = False
+
+        # These just help with testing: whether the distributed autotuning
+        # was attempted at all and whether we were able to get results for
+        # the full set of kernels.
+        self._autotuning_attempted = False
+        self._autotuning_full_match = False
+
+        self._kernel_metadata: dict[str, list[TensorMeta | int]] = {}
+        self._autotuners: dict[str, CachingAutotuner] = {}
+
+        # When coordinating across ranks, we use kernel hashes instead of names
+        # alone to identify the same kernel.
+        self._kernel_name_to_hash: dict[str, str] = {}
+        self._kernel_hash_to_name: dict[str, str] = {}
+
+        default_pg = dist.distributed_c10d._get_default_group()
+        self._store = dist.distributed_c10d._get_default_store()
+
+        if config.distributed_runtime_autotune_host_only:
+            local_world_size = int(os.environ["LOCAL_WORLD_SIZE"])
+            local_rank = int(os.environ["LOCAL_RANK"])
+            self.world_size = local_world_size
+            self.rank = local_rank
+            host_base_rank = default_pg.rank() - local_rank
+            key_prefix = f"pt2_dra_host_{host_base_rank}"
+        else:
+            self.world_size = default_pg.size()
+            self.rank = default_pg.rank()
+            key_prefix = "pt2_dra"
+
+        self.pg: dist.ProcessGroup | None = None
+
+        # Store keys for 2PC participation protocol
+        key_suffix = key.replace("/", "_")
+        self._vote_key = f"{key_prefix}_vote_{key_suffix}"
+        self._decision_key = f"{key_prefix}_decision_{key_suffix}"
+
+        # Fire participation vote (2PC Phase 1) when the coordinator is created.
+        # The first rank to vote is the leader for Phase 2.
+        vote_count = self._store.add(self._vote_key, 1)
+        self._is_leader = vote_count == 1
+        if self._is_leader:
+            log.debug("[%s] Rank %d is the leader", self.key, self.rank)
+
+    def register_kernel(
+        self,
+        kernel_name: str,
+        kernel_hash: str,
+        arg_metadata: list[TensorMeta | int],
+    ) -> None:
+        """
+        Register a kernel during codegen (when we have arg metadata).
+        """
+        with self._lock:
+            if kernel_hash in self._kernel_hash_to_name:
+                log.error(
+                    "[%s] Distributed autotune: BUG: kernel hash collision: "
+                    "%s and %s have the same hash",
+                    self.key,
+                    self._kernel_hash_to_name[kernel_hash],
+                    kernel_name,
+                )
+
+            self._kernel_metadata[kernel_name] = arg_metadata
+            self._kernel_name_to_hash[kernel_name] = kernel_hash
+            self._kernel_hash_to_name[kernel_hash] = kernel_name
+
+    def register_autotuner(
+        self,
+        kernel_name: str,
+        autotuner: CachingAutotuner,
+    ) -> None:
+        """
+        Register a CachingAutotuner instance at runtime. Must be called after we
+        know the CachingAutotuner's compile_id.
+        """
+        with self._lock:
+            # Not all compiled kernels are eligible for autotuning
+            if kernel_name in self._kernel_metadata:
+                assert kernel_name not in self._autotuners
+                self._autotuners[kernel_name] = autotuner
+
+    def _leader_collect_votes_and_decide(self, kernel_count: int) -> None:
+        """
+        Poll until all ranks have voted or timeout, then write the commit/abort
+        decision. Also checks whether there are enough kernels to justify the
+        coordination overhead — this check must happen here (not per-rank)
+        because all ranks must agree on whether to enter the all_gather collective.
+        We optimize for the case where the ranks autotune the same kernels. If
+        non-leader ranks would have enough kernels, we're ok skipping autotuning.
+        """
+        if kernel_count < config.distributed_runtime_autotune_min_kernels:
+            log.warning(
+                "[%s] Distributed autotune: too few kernels (%d < %d)",
+                self.key,
+                kernel_count,
+                config.distributed_runtime_autotune_min_kernels,
+            )
+            # '0' indicates too few kernels.
+            self._store.set(self._decision_key, "0")
+            return
+
+        start = time.monotonic()
+        deadline = start + config.distributed_runtime_autotune_max_wait_seconds
+        poll_interval = 0.1
+
+        while time.monotonic() < deadline:
+            vote_count = self._store.add(self._vote_key, 0)
+            if vote_count == self.world_size:
+                self._store.set(self._decision_key, str(self.world_size))
+                log.debug(
+                    "[%s] Distributed autotune: rank %d marking "
+                    "all %d ranks participating, waited %.2fs",
+                    self.key,
+                    self.rank,
+                    self.world_size,
+                    time.monotonic() - start,
+                )
+                return
+            time.sleep(poll_interval)
+
+        # Timeout: do a final read in case the last vote arrived between the
+        # last poll and the deadline.
+        vote_count = self._store.add(self._vote_key, 0)
+        self._store.set(self._decision_key, str(vote_count))
+        if vote_count == self.world_size:
+            log.debug(
+                "[%s] Distributed autotune: rank %d marking "
+                "all %d ranks participating (late, after timeout)",
+                self.key,
+                self.rank,
+                self.world_size,
+            )
+        else:
+            log.warning(
+                "[%s] Distributed autotune: rank %d marking only %d / %d ranks responding",
+                self.key,
+                self.rank,
+                vote_count,
+                self.world_size,
+            )
+
+    def _check_participation(self, kernel_count: int) -> bool:
+        """
+        Phase 2 (store-based only, no collectives): the leader collects votes
+        and writes a commit/abort decision, then all ranks read the decision
+        and lazily create the process group if needed. Returns True if all
+        ranks are participating.
+        """
+        # Phase 2a: Leader collects votes and writes decision
+        if self._is_leader:
+            self._leader_collect_votes_and_decide(kernel_count)
+
+        # Phase 2b: All ranks wait for the leader's decision. Specify a timeout so we
+        # can at least get an error message. But we already account for the max wait
+        # seconds when writing the decision node, so we'd only expect a timeout only
+        # for a serious problem like a leader crash.
+        log.debug("[%s] Distributed autotune: waiting for decision", self.key)
+        try:
+            self._store.wait([self._decision_key], datetime.timedelta(minutes=5))
+        except RuntimeError:
+            log.exception(
+                "[%s] Distributed autotune: error waiting for leader decision",
+                self.key,
+            )
+            return False
+
+        decision = int(self._store.get(self._decision_key))
+        if decision == 0:
+            log.warning(
+                "[%s] Distributed autotune: leader found too few kernels to autotune",
+                self.key,
+            )
+            return False
+        if decision != self.world_size:
+            log.warning(
+                "[%s] Distributed autotune: no consensus (%d / %d ranks participating)",
+                self.key,
+                decision,
+                self.world_size,
+            )
+            return False
+
+        # All ranks confirmed — lazily create the process group. This is safe
+        # because every participating rank reaches this point.
+        self.pg = get_or_create_autotune_pg()
+        if self.pg is None:
+            log.error(
+                "[%s] Distributed autotune: failed to create process group",
+                self.key,
+            )
+            return False
+
+        return True
+
+    def run_autotuning(self) -> None:
+        """
+        Run distributed autotuning and apply results directly to all registered
+        CachingAutotuners. Called on the first kernel run(). On success, each
+        autotuner receives its winning Config. On failure, autotuners fall back
+        to local autotuning.
+        """
+        if self._autotuning_done:
+            return
+
+        self._autotuning_done = True
+        log.debug("[%s] Distributed autotune: starting on rank %d", self.key, self.rank)
+
+        kernel_hashes = self._compute_kernel_hashes()
+
+        results: dict[str, Config] = {}
+        try:
+            start = time.monotonic()
+            if self._check_participation(len(kernel_hashes)):
+                self._autotuning_attempted = True
+                results = self._perform_distributed_autotuning(kernel_hashes)
+                self._autotuning_full_match = len(results) == len(kernel_hashes)
+                log.debug(
+                    "[%s] Distributed autotune: rank %d received %d / %d results in %.2fs",
+                    self.key,
+                    self.rank,
+                    len(results),
+                    len(kernel_hashes),
+                    time.monotonic() - start,
+                )
+        except Exception:
+            log.exception("[%s] Distributed autotune: failed", self.key)
+
+        # Apply results to autotuners that received a distributed result.
+        # Autotuners without a result will fall back to local autotuning.
+        for kernel_name, autotuner in self._autotuners.items():
+            result = results.get(kernel_name)
+            if result is not None:
+                try:
+                    autotuner._apply_distributed_autotune_result(result)
+                except Exception:
+                    log.exception(
+                        "[%s] Distributed autotune: failed to apply result for %s",
+                        self.key,
+                        kernel_name,
+                    )
+
+        # Clean up data structures, but deliberately do not remove the coordinator
+        # from _COORDINATORS so other CachingAutotuners can check _autotuning_done.
+        self.cleanup()
+
+    def _compute_kernel_hashes(self) -> list[str]:
+        """
+        Compute the kernel hashes eligible for autotuning (and sort for distribution).
+        """
+        if self._kernel_metadata.keys() != self._autotuners.keys():
+            # This should never happen, but fail safe to avoid hanging the collective
+            log.error("[%s] Distributed autotune: BUG: kernel name mismatch", self.key)
+            return []
+
+        # Kernels with more than one config, or all kernels if coordinate
+        # descent is enabled. Sorted for consistent round-robin assignment.
+        if config.coordinate_descent_tuning:
+            return sorted(self._kernel_name_to_hash.values())
+
+        return sorted(
+            kernel_hash
+            for name, kernel_hash in self._kernel_name_to_hash.items()
+            if self._autotuners[name].initial_num_configs > 1
+        )
+
+    def _perform_distributed_autotuning(
+        self, kernel_hashes: list[str]
+    ) -> dict[str, Config]:
+        """
+        Autotune assigned kernels round-robin and sync results via all_gather.
+        Optimizes for the common case where all ranks have the same kernel list,
+        but gracefully handles mismatches by using whatever results match locally.
+        """
+        log.debug(
+            "[%s] Distributed autotune: ready with %d kernels across %d ranks",
+            self.key,
+            len(kernel_hashes),
+            self.world_size,
+        )
+
+        # Autotune kernels assigned to this rank
+        local_results: list[tuple[str, Config]] = []
+
+        for i, kernel_hash in enumerate(kernel_hashes):
+            if i % self.world_size == self.rank:
+                kernel_name = self._kernel_hash_to_name[kernel_hash]
+                try:
+                    result = self._autotune_kernel(kernel_name)
+                except Exception:
+                    log.exception(
+                        "[%s] Distributed autotune: failed to autotune kernel %s",
+                        self.key,
+                        kernel_name,
+                    )
+                    result = None
+                if result is not None:
+                    local_results.append((kernel_hash, result))
+
+        # Sync results across all ranks (keyed by hash, not name)
+        all_results: list[list[tuple[str, Config]]] = [
+            [] for _ in range(self.world_size)
+        ]
+        dist.all_gather_object(all_results, local_results, group=self.pg)
+
+        # Map results back to local kernel names. With matching kernel lists,
+        # we get results for all kernels. With mismatched lists, we use
+        # whatever matches and fall back to local autotuning for the rest.
+        results: dict[str, Config] = {}
+        for rank_results in all_results:
+            for kernel_hash, result_config in rank_results:
+                kernel_name = self._kernel_hash_to_name.get(kernel_hash)
+                if kernel_name is not None:
+                    results[kernel_name] = result_config
+
+        if len(results) < len(kernel_hashes):
+            log.warning(
+                "[%s] Distributed autotune: received results for only %d / %d kernels",
+                self.key,
+                len(results),
+                len(kernel_hashes),
+            )
+
+        return results
+
+    def _autotune_kernel(self, kernel_name: str) -> Config | None:
+        """
+        Autotune a single kernel using stored metadata.
+        """
+        autotuner = self._autotuners[kernel_name]
+        arg_metadata = self._kernel_metadata[kernel_name]
+
+        log.debug(
+            "[%s] Distributed autotune: locally tuning kernel %s", self.key, kernel_name
+        )
+
+        # Construct args from metadata
+        args: list[Any] = []
+        for meta in arg_metadata:
+            if isinstance(meta, TensorMeta):
+                args.append(meta.to_tensor())
+            else:
+                args.append(meta)
+
+        # Precompile if needed
+        if len(autotuner.launchers) == 0:
+            autotuner.precompile()
+
+        # Run autotuning
+        if len(autotuner.launchers) > 1:
+            autotuner.autotune_to_one_config(*args)
+
+        # Extract winning config
+        if not autotuner.launchers:
+            log.warning(
+                "[%s] Distributed autotune: no launcher after autotuning %s",
+                self.key,
+                kernel_name,
+            )
+            return None
+
+        # Run coordinate descent tuning if enabled
+        if not getattr(
+            autotuner.launchers[0].config, "found_by_coordesc", False
+        ) and autotuner.inductor_meta.get("coordinate_descent_tuning", False):
+            autotuner.launchers = [
+                autotuner.coordinate_descent_tuning(autotuner.launchers[0], *args)
+            ]
+
+        return autotuner.launchers[0].config
+
+    def cleanup(self) -> None:
+        self._kernel_metadata.clear()
+        self._autotuners.clear()
+        self._kernel_name_to_hash.clear()
+        self._kernel_hash_to_name.clear()
+
+
+# Per-compile coordinator instances, keyed by (compile_id, is_backward) via
+# _coordinator_key(). Forward and backward passes are handled separately.
+_COORDINATORS: dict[str, DistributedAutotuneCoordinator | None] = {}
+_COORDINATORS_LOCK = threading.Lock()
+
+
+def _coordinator_key(compile_id: str, is_backward: bool) -> str:
+    return f"{compile_id}/{'bwd' if is_backward else 'fwd'}"
+
+
+def get_coordinator(
+    compile_id: str, is_backward: bool
+) -> DistributedAutotuneCoordinator | None:
+    return _COORDINATORS.get(_coordinator_key(compile_id, is_backward))
+
+
+def get_or_create_coordinator(
+    compile_id: str, is_backward: bool
+) -> DistributedAutotuneCoordinator | None:
+    key = _coordinator_key(compile_id, is_backward)
+    if key in _COORDINATORS:
+        return _COORDINATORS[key]
+
+    with _COORDINATORS_LOCK:
+        if key in _COORDINATORS:
+            return _COORDINATORS[key]
+
+        assert config.distributed_runtime_autotune
+
+        if not dist.is_available() or not dist.is_initialized():
+            _COORDINATORS[key] = None
+            return None
+
+        if config.distributed_runtime_autotune_host_only:
+            local_world_size = int(os.environ.get("LOCAL_WORLD_SIZE", 0))
+            local_rank = int(os.environ.get("LOCAL_RANK", -1))
+            if local_world_size <= 0 or local_rank < 0:
+                log.error(
+                    "[%s] Distributed autotune: LOCAL_WORLD_SIZE or LOCAL_RANK not set",
+                    key,
+                )
+                _COORDINATORS[key] = None
+                return None
+
+        coordinator = DistributedAutotuneCoordinator(key)
+        _COORDINATORS[key] = coordinator
+        return coordinator
+
+
+def try_register_kernel_from_codegen(
+    kernel_name: str,
+    kernel_hash: str,
+    is_backward: bool,
+    get_arg_metadata: Callable[[], list[TensorMeta | int]],
+) -> None:
+    """
+    Try to register a kernel during codegen.
+    """
+    compile_id = torch._guards.CompileContext.current_compile_id()
+    if compile_id is None:
+        log.error(
+            "Distributed autotune: Unable to get compile_id for kernel %s",
+            kernel_name,
+        )
+        return
+
+    try:
+        coordinator = get_or_create_coordinator(str(compile_id), is_backward)
+        if coordinator is not None:
+            arg_metadata = get_arg_metadata()
+            coordinator.register_kernel(kernel_name, kernel_hash, arg_metadata)
+    except Exception:
+        log.exception(
+            "[%s] Distributed autotune: Failed to register kernel",
+            _coordinator_key(str(compile_id), is_backward),
+        )
+
+
+def register_autotuner(
+    compile_id: str,
+    is_backward: bool,
+    kernel_name: str,
+    autotuner: CachingAutotuner,
+) -> None:
+    coordinator = get_coordinator(compile_id, is_backward)
+    if coordinator is not None:
+        coordinator.register_autotuner(kernel_name, autotuner)

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -479,6 +479,9 @@ class CachingAutotuner(KernelInterface):
         self.optimize_mem = optimize_mem
         cached_config = lookup_autotune_config(size_hints, fn)
         self.configs = [cached_config] if cached_config else configs
+        # For distributed autotuning; so we can easily identify the kernels
+        # that won't be autotuned:
+        self.initial_num_configs = len(self.configs)
 
         self.heuristic_type = heuristic_type
         self.custom_kernel = custom_kernel
@@ -558,9 +561,14 @@ class CachingAutotuner(KernelInterface):
 
         self._plugins = get_caching_autotuner_plugins(self)
 
-        # Compile-time info included in runtime logginging
+        # Compile-time info included in runtime logging
         self.compile_id: CompileId | None = None
         self.is_backward = False
+
+        # To skip distributed autotuning as fast as possible after first attempt
+        self._distributed_autotune_checked = False
+        # To avoid local coord desc tuning if a distributed result was found
+        self._distributed_autotune_applied = False
 
         # Mode for launch grid calculation
         self.grid_mode: Literal["python", "cpp"] = "python"
@@ -647,6 +655,18 @@ class CachingAutotuner(KernelInterface):
     def set_compile_info(self, compile_id: CompileId | None, is_backward: bool) -> None:
         self.compile_id = compile_id
         self.is_backward = is_backward
+
+        # If we're doing distributed autotuning, the distributed tuner needs to
+        # be able to look up CachingAutotuners to perform the tuning.
+        if torch._inductor.config.distributed_runtime_autotune:
+            from torch._inductor.runtime.distributed_runtime_autotune import (
+                register_autotuner,
+            )
+
+            kernel_name = self.inductor_meta.get("kernel_name")
+            assert kernel_name
+            assert compile_id
+            register_autotuner(str(compile_id), is_backward, kernel_name, self)
 
     def precompile(
         self,
@@ -2063,6 +2083,78 @@ class CachingAutotuner(KernelInterface):
         log.debug("Function hash %s has best config %s", fn_hash, best_config)
         return winner
 
+    def _try_distributed_autotune(self) -> None:
+        """
+        Try distributed autotuning. If a coordinator exists and autotuning succeeds,
+        results are applied directly to all CachingAutotuners by the coordinator.
+        On any outcome (success, failure, no coordinator), we fall back to local
+        autotuning for any kernel that didn't get a distributed result.
+        """
+        self._distributed_autotune_checked = True
+
+        if not torch._inductor.config.distributed_runtime_autotune:
+            return
+
+        from torch._inductor.runtime.distributed_runtime_autotune import get_coordinator
+
+        with dynamo_timed(
+            "CachingAutotuner.distributed_autotune",
+            log_pt2_compile_event=True,
+            dynamo_compile_column_us="runtime_triton_autotune_time_us",
+            compile_id=self.compile_id,
+            is_backward=self.is_backward,
+            log_waitcounter=True,
+            waitcounter_name_override="triton_autotuner",
+        ):
+            assert self.compile_id
+            coordinator = get_coordinator(str(self.compile_id), self.is_backward)
+            if coordinator is None:
+                return
+
+            coordinator.run_autotuning()
+
+    def _apply_distributed_autotune_result(self, result: Config | None) -> None:
+        """
+        Called by the distributed autotuner to apply the winning config.
+        """
+        # First, try to find the launcher with matching config among existing
+        # launchers. Note that it could be the launcher that was tuned locally
+        # if this rank was responsible for this kernel.
+        assert result is not None
+        for launcher in self.launchers:
+            if launcher.config == result:
+                self.launchers = [launcher]
+                break
+        else:
+            # Config not found - this can happen with coordinate descent tuning
+            # which creates new configs dynamically. Create a new launcher.
+            # Load the kernel if needed (for parent process after worker compilation)
+            if self.fn.fn is None:
+                assert hasattr(self, "_reload_kernel")
+                assert callable(self._reload_kernel)
+                self.fn = self._reload_kernel().fn
+
+            # Precompile and create launcher for the new config
+            self.launchers = [self._precompile_config(result).make_launcher()]
+
+        assert len(self.launchers) == 1
+        self.launchers[0].config.found_by_coordesc = bool(
+            getattr(self.launchers[0].config, "found_by_coordesc", False)
+            or getattr(result, "found_by_coordesc", False)
+        )
+
+        self._distributed_autotune_applied = True
+
+        if self.save_cache_hook:
+            self.save_cache_hook(
+                self.launchers[0].config,
+                0,
+                found_by_coordesc=getattr(
+                    self.launchers[0].config, "found_by_coordesc", False
+                ),
+                triton_cache_hash=self.launchers[0].cache_hash,
+            )
+
     def get_profiler_kwargs(self, stream, launcher):
         kernel_kwargs_str = ",".join(
             f"{k}={v}" for (k, v) in launcher.config.kwargs.items()
@@ -2182,22 +2274,23 @@ class CachingAutotuner(KernelInterface):
             ) is not DEFER:
                 return result
 
-        if len(self.launchers) != 1:
-            if len(self.launchers) == 0:
-                start_time = time.time_ns()
-                self.precompile()
-                self.precompile_time_taken_ns = time.time_ns() - start_time
+        if len(self.launchers) == 0:
+            start_time = time.time_ns()
+            self.precompile()
+            self.precompile_time_taken_ns = time.time_ns() - start_time
+
+        if not self._distributed_autotune_checked:
+            self._try_distributed_autotune()
+
+        if len(self.launchers) > 1:
+            for plugin in self._plugins:
+                if (
+                    result := plugin.pre_autotune(self, *args, stream=stream, **kwargs)
+                ) is not DEFER:
+                    return result
+            # Re-check: a plugin may have mutated launchers down to one.
             if len(self.launchers) > 1:
-                for plugin in self._plugins:
-                    if (
-                        result := plugin.pre_autotune(
-                            self, *args, stream=stream, **kwargs
-                        )
-                    ) is not DEFER:
-                        return result
-                # Re-check: a plugin may have mutated launchers down to one.
-                if len(self.launchers) > 1:
-                    self.autotune_to_one_config(*args, **kwargs)
+                self.autotune_to_one_config(*args, **kwargs)
 
         if self.inductor_meta.get("combo_tuning_groups") and not getattr(
             self.launchers[0].config, "found_by_combo_autotune", False
@@ -2216,9 +2309,11 @@ class CachingAutotuner(KernelInterface):
                     self._combo_sequential_autotune(self.launchers[0], *args, **kwargs)
                 ]
 
-        if not getattr(
-            self.launchers[0].config, "found_by_coordesc", False
-        ) and self.inductor_meta.get("coordinate_descent_tuning", False):
+        if (
+            not getattr(self.launchers[0].config, "found_by_coordesc", False)
+            and self.inductor_meta.get("coordinate_descent_tuning", False)
+            and not self._distributed_autotune_applied
+        ):
             self.launchers = [
                 self.coordinate_descent_tuning(self.launchers[0], *args, **kwargs)
             ]


### PR DESCRIPTION
Summary:

This change adds optional distributed runtime autotuning, where autotuning work for Triton kernels is distributed across ranks in a process group. When enabled, each rank autotunes only 1/world_size of the kernels and results are synchronized, reducing total autotuning time.

## Design

The design tries to optimize for the case where all ranks compile the same thing, but supports falling back (after a timeout) to local autotuning in case the ranks are doing different things. We distribute autotuning work across ranks when:
1. All ranks signal intent to participate
2. All ranks present the same list of kernels to autotune
3. There are enough kernels to justify the coordination overhead (controlled by config)

There are two modes (controlled by config): one where all global ranks participate in distributed autotuning, and another where we create a collective among only the ranks on each host.

Coordination uses a Two-Phase Commit (2PC) protocol via the dist.Store:
- **Phase 1 (during Codegen)**: Each rank fires a non-collective participation vote via store.add(). The first rank to vote becomes the leader. At codegen, we also gather the tensor metadata needed to generate random tensors when it comes time to benchmark.
- **Phase 2 (Runtime)**: On the first kernel run(), the leader polls the vote counter until all ranks have voted or timeout expires, then writes a commit/abort decision via store.set(). All other ranks wait for the leader's decision via store.wait() before proceeding to any collectives. This prevents the race where some ranks enter a collective while others have timed out and fallen back to local autotuning.

## Key Components

**DistributedAutotuneCoordinator** (in `distributed_runtime_autotune.py`):
- Created per (compile_id, is_backward) pair, so forward and backward passes are handled as separate steps with independent coordination. Note that we attempt the distributed autotuning only once per compile_id/is_backward (whether it succeeds or fails). The autotuning starts on the first execution of the first kernel, but we apply autotuning results to all kernels considered.
- Implements the 2PC protocol: the leader polls for consensus during Phase 2 and writes a single go/no-go decision that all ranks read before proceeding.
- After confirming all ranks, lazily creates the process group via `dist.new_group()`. For host-only mode, computes the local rank list from environment variables and uses `use_local_synchronization=True` so that only local ranks need to participate in PG creation (no global collective). The PG is a singleton shared across all coordinators.
- Validates all ranks have matching kernel lists via all_gather_object.
- Distributes kernels round-robin across ranks (kernel i → rank i % world_size).
- Synchronizes results via all_gather_object. Always participates in the all_gather even when a local error is detected (e.g., kernel metadata mismatch), to avoid hanging other ranks.
- After autotuning, applies results directly to _all_ the CachingAutotuners tuned during this phase, and then cleans up its internal state.

**TensorMeta / WorkspaceMeta**: Store tensor metadata (size, stride, dtype, offset) captured during codegen, used to reconstruct tensors for benchmarking at runtime. WorkspaceMeta is a TensorMeta subclass for workspace buffers that produces zeroed tensors.

## Integration Points

1. **codegen/triton.py**: Registers kernels with metadata during define_kernel()
2. **triton_heuristics.py**:
   - Registers CachingAutotuner instances in set_compile_info(). This is the point where we know the compile_id for any kernel
   - _try_distributed_autotune() triggers the coordinator on first kernel run()
   - The coordinator applies results to all CachingAutotuners at once, then falls back to local autotuning for any kernel without a distributed result

## Fallback Behavior

If distributed autotuning cannot proceed (not all ranks participating, kernel list mismatch, or any failure), each rank independently falls back to local autotuning. The 2PC protocol ensures that no rank enters a collective unless all ranks have committed to participate.

## Testing
* New distributed unit tests
* Tested torchtitan llama3 8b on an 8x H100. Enabled coordinate descent (to dial up autotuning; there's not much without it). Across ranks, baseline shows a max compile time of 32s (26s autotuning overhead). With distributed autotuning enabled: a max of 16s compile time (10s autotuning time).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos