### PR TITLE
[torch][inductor] Emit int64_t type declaration for kernel numel variables

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -5504,6 +5504,52 @@ class AOTInductorTestsTemplate:
 
             self.check_model(Model(N, K, self.device), example_inputs)
 
+    @unittest.skipIf(
+        sys.platform not in ["linux", "win32"],
+        "enable_kernel_profile only supported on linux and win32",
+    )
+    def test_kernel_profile_repeated_kernel_numel(self):
+        # When enable_kernel_profile is on, each kernel call is wrapped in its
+        # own {} scope block. If the same kernel is called multiple times with
+        # symbolic numel, the int64_t declaration must be emitted each time
+        # (not just on first use) since prior declarations go out of scope.
+        class Model(torch.nn.Module):
+            def forward(self, x, y, z):
+                return torch.cat([x, y, z], dim=0)
+
+        example_inputs = tuple(torch.randn(4, 8, device=self.device) for _ in range(3))
+        dim0 = Dim("dim0", min=1, max=32)
+        dynamic_shapes = {"x": {0: dim0}, "y": {0: dim0}, "z": {0: dim0}}
+
+        with config.patch({"cpp.enable_kernel_profile": True}):
+            _, code = run_and_get_cpp_code(
+                AOTIRunnerUtil.compile,
+                Model(),
+                example_inputs,
+                dynamic_shapes=dynamic_shapes,
+            )
+            # When profiling is enabled, every kernel numel variable must have
+            # the int64_t type declaration since each kernel call lives in its
+            # own scope block. Verify no bare assignment (without int64_t)
+            # appears for numel variables.
+            if self.device == GPU_TYPE:
+                # Match bare numel assignments like "foo_xnumel = expr;"
+                # but not declarations like "int64_t foo_xnumel = expr;"
+                bare_numel_assign = re.compile(r"^\s*(\w+_[xr]numel)\s*=\s*.+;$")
+                for line in code.splitlines():
+                    m = bare_numel_assign.match(line)
+                    if m:
+                        self.fail(
+                            f"Found numel assignment without int64_t declaration "
+                            f"in profiling mode: {line.strip()}"
+                        )
+
+            self.check_model(
+                Model(),
+                example_inputs,
+                dynamic_shapes=dynamic_shapes,
+            )
+
     def test_aoti_user_defined_triton_kernel_profiling(self):
         if self.device != GPU_TYPE or self.device == "mps":
             raise unittest.SkipTest("requires GPU")

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -1581,8 +1581,14 @@ class CppWrapperCpu(PythonWrapperCodegen):
     def _generate_symbolic_call_arg_helper(
         self, arg: SymbolicCallArg, graph: GraphLowering
     ) -> None:
-        if (arg.inner, graph) not in self.kernel_numel_expr:
-            # declare expr once in each graph (scope)
+        enable_kernel_profile = config.cpp.enable_kernel_profile and sys.platform in [
+            "linux",
+            "win32",
+        ]
+        if enable_kernel_profile or (arg.inner, graph) not in self.kernel_numel_expr:
+            # When enable_kernel_profile is on, each kernel call is wrapped in
+            # its own {} scope block, so we must redeclare the variable each
+            # time since prior declarations are no longer visible.
             self.kernel_numel_expr.add((arg.inner, graph))
             self.writeline(f"int64_t {arg.inner} = {cexpr(arg.inner_expr)};")
         else:


### PR DESCRIPTION
Summary:
# What changed

 In caffe2/torch/_inductor/codegen/cpp_wrapper_cpu.py, method _generate_symbolic_call_arg_helper: when config.cpp.enable_kernel_profile is enabled, always emit the int64_t type declaration for kernel numel variables instead of omitting it
 on subsequent uses of the same kernel.

 # The issue:

 When TORCHINDUCTOR_CPP_ENABLE_KERNEL_PROFILE=1 is set, the codegen wraps each kernel launch in its own {} scope block (for RAII cleanup of KernelContextGuard and RAIIAtenRecordFunctionHandle). The method _generate_symbolic_call_arg_helper
 tracks which numel variables have been declared (via the kernel_numel_expr set) and only emits int64_t var = expr; on the first use — subsequent uses emit var = expr; (assignment without declaration). Without profiling, all kernel calls
share the function scope so this works fine. With profiling, each call is in a separate {} block, so the first declaration goes out of scope and subsequent assignments fail with:
```
  error: use of undeclared identifier 'triton_poi_fused_cat_0_xnumel'
```
This happens whenever the same Triton kernel is called multiple times (e.g., triton_poi_fused_cat_0 called 10 times for a cat over 10 tensors).

# The fix

 When enable_kernel_profile is active, always emit the full int64_t declaration since each kernel call lives in its own scope. The condition changes from:
```
  if (arg.inner, graph) not in self.kernel_numel_expr:
```
 to:
```
  if enable_kernel_profile or (arg.inner, graph) not in self.kernel_numel_expr:
```
 This is a no-op when profiling is disabled (the existing deduplication logic is preserved).

Test Plan: Tested with an AOT Inductor model that calls the same Triton kernel multiple times with TORCHINDUCTOR_CPP_ENABLE_KERNEL_PROFILE=1 enabled. Was crashing before the change, generates a correct trace after.

Reviewed By: desertfire

Differential Revision: D94577289




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo