### PR TITLE
Skip 4-GPU distributed tests on 2-GPU runners

### DIFF
--- a/test/distributed/_composable/test_replicate_with_fsdp.py
+++ b/test/distributed/_composable/test_replicate_with_fsdp.py
@@ -57,9 +57,9 @@ class ReplicateTest(MultiProcContinuousTest):
     @classmethod
     def _init_pg(cls, rank, world_size, rdvz_file):
         if torch.accelerator.is_available():
+            if torch.accelerator.device_count() < world_size:
+                sys.exit(TEST_SKIPS[f"multi-gpu-{world_size}"].exit_code)
             torch.accelerator.set_device_index(rank)
-        if torch.accelerator.device_count() < world_size:
-            sys.exit(TEST_SKIPS[f"multi-gpu-{world_size}"].exit_code)
         super()._init_pg(rank, world_size, rdvz_file)
 
     def init_replicate_tp_mesh(self) -> DeviceMesh:

--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -5346,7 +5346,7 @@ class LargeCommTest(test_c10d_common.AbstractLargeCommTest, MultiProcessTestCase
         self.assertEqual(scatter_object_output_list, expected)
 
     @requires_nccl()
-    @skip_if_lt_x_gpu(2)
+    @skip_if_lt_x_gpu(4)
     @parametrize("float8_dtype", [torch.float8_e4m3fn, torch.float8_e5m2])
     def test_broadcast_float8(self, float8_dtype):
         device = torch.device(f"cuda:{self.rank}")


### PR DESCRIPTION
- test_c10d_nccl: require 4 GPUs for test_broadcast_float8 (LargeCommTest uses world_size=4 and cuda:{rank}), so the test is skipped on 2-GPU runners instead of crashing with invalid device ordinal.
- test_replicate_with_fsdp: in _init_pg, check device_count() < world_size and exit with skip code before set_device_index(rank), so all ranks skip cleanly on 2-GPU runners instead of rank 2/3 crashing.