### PR TITLE
Add SAC annotation edge case tests

### DIFF
--- a/test/dynamo/test_activation_checkpointing.py
+++ b/test/dynamo/test_activation_checkpointing.py
@@ -2212,7 +2212,7 @@ class GraphModule(torch.nn.Module):
         out.sum().backward()
         return "\n".join(annotations)
 
-    def test_ignored_op_annotation_no_leak(self):
+    def test_pre_mode_decomp_has_sac_ignored_ops(self):
         """detach (a SAC_IGNORED_OP) should get PREFER_RECOMPUTE,
         not leak the annotation from the preceding op."""
 
@@ -2232,20 +2232,19 @@ add: aten.add.Tensor -> PREFER_RECOMPUTE
 cos: aten.cos.default -> MUST_SAVE""",
         )
 
-    def test_decomposed_op_annotation(self):
+    def test_post_mode_decomp(self):
         """SiLU decomposes under inductor decomps. All decomposed ops should
         get the policy returned for the original op, not leak from neighbors."""
         from torch._inductor.compile_fx import select_decomp_table
 
-        @torch._dynamo.allow_in_graph
-        def op_with_silu(x):
+        def fn(x):
             x = x.sin()
             x = torch.nn.functional.silu(x)
             x = x.cos()
             return x
 
         self.assertExpectedInline(
-            self._get_sac_annotations(op_with_silu, decompositions=select_decomp_table),
+            self._get_sac_annotations(fn, decompositions=select_decomp_table),
             """\
 sin: aten.sin.default -> MUST_RECOMPUTE
 neg: aten.neg.default -> PREFER_RECOMPUTE
@@ -2255,12 +2254,11 @@ div: aten.div.Tensor -> PREFER_RECOMPUTE
 cos: aten.cos.default -> MUST_SAVE""",
         )
 
-    def test_multi_output_op_annotation(self):
+    def test_multi_output_op(self):
         """Multi-output ops produce getitem nodes. All should get the same
         annotation as the op itself."""
 
-        @torch._dynamo.allow_in_graph
-        def op_with_multi_output(x):
+        def fn(x):
             x = x.sin()
             vals, idxs = torch.topk(x, k=2)
             out = vals.sum()
@@ -2268,7 +2266,7 @@ cos: aten.cos.default -> MUST_SAVE""",
             return out
 
         self.assertExpectedInline(
-            self._get_sac_annotations(op_with_multi_output),
+            self._get_sac_annotations(fn),
             """\
 sin: aten.sin.default -> MUST_RECOMPUTE
 topk: aten.topk.default -> PREFER_RECOMPUTE

--- a/test/dynamo/test_activation_checkpointing.py
+++ b/test/dynamo/test_activation_checkpointing.py
@@ -2164,6 +2164,120 @@ class GraphModule(torch.nn.Module):
         with torch._dynamo.config.patch(capture_profiler_record_function=True):
             self._validate(fn, backend, x, y)
 
+    def _get_sac_annotations(self, checkpointed_fn, decompositions=None):
+        """Compile checkpointed_fn with SAC and return annotation strings
+        from the joint graph. Policy: sin=MUST_RECOMPUTE, cos=MUST_SAVE,
+        everything else=PREFER_RECOMPUTE."""
+
+        def policy_fn(ctx, func, *args, **kwargs):
+            if func == torch.ops.aten.sin.default:
+                return CheckpointPolicy.MUST_RECOMPUTE
+            if func == torch.ops.aten.cos.default:
+                return CheckpointPolicy.MUST_SAVE
+            return CheckpointPolicy.PREFER_RECOMPUTE
+
+        annotations = []
+
+        def capture_partition(joint_gm, joint_args, **kwargs):
+            for node in joint_gm.graph.nodes:
+                if node.op == "call_function":
+                    recompute = node.meta.get("recompute", None)
+                    if recompute is not None:
+                        annotations.append(
+                            f"{node.name}: {node.target} -> {recompute.name}"
+                        )
+            return min_cut_rematerialization_partition(joint_gm, joint_args, **kwargs)
+
+        backend = aot_autograd(
+            fw_compiler=nop,
+            bw_compiler=nop,
+            partition_fn=capture_partition,
+            decompositions=decompositions,
+        )
+
+        def fn(x):
+            return checkpoint(
+                checkpointed_fn,
+                x,
+                use_reentrant=False,
+                context_fn=functools.partial(
+                    create_selective_checkpoint_contexts, policy_fn
+                ),
+            )
+
+        x = torch.randn(4, requires_grad=True)
+        torch._dynamo.reset()
+        compiled = torch.compile(fn, backend=backend)
+        out = compiled(x)
+        out.sum().backward()
+        return "\n".join(annotations)
+
+    def test_ignored_op_annotation_no_leak(self):
+        """detach (a SAC_IGNORED_OP) should get PREFER_RECOMPUTE,
+        not leak the annotation from the preceding op."""
+
+        @torch._dynamo.allow_in_graph
+        def op_with_detach(x):
+            a = x.sin()
+            out = a.detach() + a
+            out = out.cos()
+            return out
+
+        self.assertExpectedInline(
+            self._get_sac_annotations(op_with_detach),
+            """\
+sin: aten.sin.default -> MUST_RECOMPUTE
+detach_1: aten.detach.default -> PREFER_RECOMPUTE
+add: aten.add.Tensor -> PREFER_RECOMPUTE
+cos: aten.cos.default -> MUST_SAVE""",
+        )
+
+    def test_decomposed_op_annotation(self):
+        """SiLU decomposes under inductor decomps. All decomposed ops should
+        get the policy returned for the original op, not leak from neighbors."""
+        from torch._inductor.compile_fx import select_decomp_table
+
+        @torch._dynamo.allow_in_graph
+        def op_with_silu(x):
+            x = x.sin()
+            x = torch.nn.functional.silu(x)
+            x = x.cos()
+            return x
+
+        self.assertExpectedInline(
+            self._get_sac_annotations(op_with_silu, decompositions=select_decomp_table),
+            """\
+sin: aten.sin.default -> MUST_RECOMPUTE
+neg: aten.neg.default -> PREFER_RECOMPUTE
+exp: aten.exp.default -> PREFER_RECOMPUTE
+add: aten.add.Tensor -> PREFER_RECOMPUTE
+div: aten.div.Tensor -> PREFER_RECOMPUTE
+cos: aten.cos.default -> MUST_SAVE""",
+        )
+
+    def test_multi_output_op_annotation(self):
+        """Multi-output ops produce getitem nodes. All should get the same
+        annotation as the op itself."""
+
+        @torch._dynamo.allow_in_graph
+        def op_with_multi_output(x):
+            x = x.sin()
+            vals, idxs = torch.topk(x, k=2)
+            out = vals.sum()
+            out = out.cos()
+            return out
+
+        self.assertExpectedInline(
+            self._get_sac_annotations(op_with_multi_output),
+            """\
+sin: aten.sin.default -> MUST_RECOMPUTE
+topk: aten.topk.default -> PREFER_RECOMPUTE
+getitem: <built-in function getitem> -> PREFER_RECOMPUTE
+getitem_1: <built-in function getitem> -> PREFER_RECOMPUTE
+sum_1: aten.sum.default -> PREFER_RECOMPUTE
+cos: aten.cos.default -> MUST_SAVE""",
+        )
+
 
 class RematerializeACNodesPassTests(torch._dynamo.test_case.TestCase):
     """Tests for AC reordering optimization in full graph (forward+backward in one graph)."""

--- a/test/dynamo/test_activation_checkpointing.py
+++ b/test/dynamo/test_activation_checkpointing.py
@@ -2165,10 +2165,6 @@ class GraphModule(torch.nn.Module):
             self._validate(fn, backend, x, y)
 
     def _get_sac_annotations(self, checkpointed_fn, decompositions=None):
-        """Compile checkpointed_fn with SAC and return annotation strings
-        from the joint graph. Policy: sin=MUST_RECOMPUTE, cos=MUST_SAVE,
-        everything else=PREFER_RECOMPUTE."""
-
         def policy_fn(ctx, func, *args, **kwargs):
             if func == torch.ops.aten.sin.default:
                 return CheckpointPolicy.MUST_RECOMPUTE
@@ -2213,9 +2209,6 @@ class GraphModule(torch.nn.Module):
         return "\n".join(annotations)
 
     def test_pre_mode_decomp_has_sac_ignored_ops(self):
-        """detach (a SAC_IGNORED_OP) should get PREFER_RECOMPUTE,
-        not leak the annotation from the preceding op."""
-
         @torch._dynamo.allow_in_graph
         def op_with_detach(x):
             a = x.sin()
@@ -2233,8 +2226,6 @@ cos: aten.cos.default -> MUST_SAVE""",
         )
 
     def test_post_mode_decomp(self):
-        """SiLU decomposes under inductor decomps. All decomposed ops should
-        get the policy returned for the original op, not leak from neighbors."""
         from torch._inductor.compile_fx import select_decomp_table
 
         def fn(x):
@@ -2255,9 +2246,6 @@ cos: aten.cos.default -> MUST_SAVE""",
         )
 
     def test_multi_output_op(self):
-        """Multi-output ops produce getitem nodes. All should get the same
-        annotation as the op itself."""
-
         def fn(x):
             x = x.sin()
             vals, idxs = torch.topk(x, k=2)

--- a/test/dynamo/test_activation_checkpointing.py
+++ b/test/dynamo/test_activation_checkpointing.py
@@ -2164,14 +2164,7 @@ class GraphModule(torch.nn.Module):
         with torch._dynamo.config.patch(capture_profiler_record_function=True):
             self._validate(fn, backend, x, y)
 
-    def _get_sac_annotations(self, checkpointed_fn, decompositions=None):
-        def policy_fn(ctx, func, *args, **kwargs):
-            if func == torch.ops.aten.sin.default:
-                return CheckpointPolicy.MUST_RECOMPUTE
-            if func == torch.ops.aten.cos.default:
-                return CheckpointPolicy.MUST_SAVE
-            return CheckpointPolicy.PREFER_RECOMPUTE
-
+    def _get_sac_annotations(self, checkpointed_fn, policy_fn, decompositions=None):
         annotations = []
 
         def capture_partition(joint_gm, joint_args, **kwargs):
@@ -2209,6 +2202,13 @@ class GraphModule(torch.nn.Module):
         return "\n".join(annotations)
 
     def test_pre_mode_decomp_has_sac_ignored_ops(self):
+        def policy_fn(ctx, func, *args, **kwargs):
+            if func == torch.ops.aten.sin.default:
+                return CheckpointPolicy.MUST_RECOMPUTE
+            if func == torch.ops.aten.add.Tensor:
+                return CheckpointPolicy.MUST_SAVE
+            return CheckpointPolicy.PREFER_RECOMPUTE
+
         @torch._dynamo.allow_in_graph
         def op_with_detach(x):
             a = x.sin()
@@ -2217,16 +2217,23 @@ class GraphModule(torch.nn.Module):
             return out
 
         self.assertExpectedInline(
-            self._get_sac_annotations(op_with_detach),
+            self._get_sac_annotations(op_with_detach, policy_fn),
             """\
 sin: aten.sin.default -> MUST_RECOMPUTE
 detach_1: aten.detach.default -> PREFER_RECOMPUTE
-add: aten.add.Tensor -> PREFER_RECOMPUTE
-cos: aten.cos.default -> MUST_SAVE""",
+add: aten.add.Tensor -> MUST_SAVE
+cos: aten.cos.default -> PREFER_RECOMPUTE""",
         )
 
     def test_post_mode_decomp(self):
         from torch._inductor.compile_fx import select_decomp_table
+
+        def policy_fn(ctx, func, *args, **kwargs):
+            if func == torch.ops.aten.sin.default:
+                return CheckpointPolicy.MUST_SAVE
+            if func == torch.ops.aten.cos.default:
+                return CheckpointPolicy.MUST_RECOMPUTE
+            return CheckpointPolicy.PREFER_SAVE
 
         def fn(x):
             x = x.sin()
@@ -2235,17 +2242,24 @@ cos: aten.cos.default -> MUST_SAVE""",
             return x
 
         self.assertExpectedInline(
-            self._get_sac_annotations(fn, decompositions=select_decomp_table),
+            self._get_sac_annotations(fn, policy_fn, decompositions=select_decomp_table),
             """\
-sin: aten.sin.default -> MUST_RECOMPUTE
-neg: aten.neg.default -> PREFER_RECOMPUTE
-exp: aten.exp.default -> PREFER_RECOMPUTE
-add: aten.add.Tensor -> PREFER_RECOMPUTE
-div: aten.div.Tensor -> PREFER_RECOMPUTE
-cos: aten.cos.default -> MUST_SAVE""",
+sin: aten.sin.default -> MUST_SAVE
+neg: aten.neg.default -> PREFER_SAVE
+exp: aten.exp.default -> PREFER_SAVE
+add: aten.add.Tensor -> PREFER_SAVE
+div: aten.div.Tensor -> PREFER_SAVE
+cos: aten.cos.default -> MUST_RECOMPUTE""",
         )
 
     def test_multi_output_op(self):
+        def policy_fn(ctx, func, *args, **kwargs):
+            if func == torch.ops.aten.topk.default:
+                return CheckpointPolicy.MUST_SAVE
+            if func == torch.ops.aten.sin.default:
+                return CheckpointPolicy.MUST_RECOMPUTE
+            return CheckpointPolicy.PREFER_RECOMPUTE
+
         def fn(x):
             x = x.sin()
             vals, idxs = torch.topk(x, k=2)
@@ -2254,14 +2268,14 @@ cos: aten.cos.default -> MUST_SAVE""",
             return out
 
         self.assertExpectedInline(
-            self._get_sac_annotations(fn),
+            self._get_sac_annotations(fn, policy_fn),
             """\
 sin: aten.sin.default -> MUST_RECOMPUTE
-topk: aten.topk.default -> PREFER_RECOMPUTE
-getitem: <built-in function getitem> -> PREFER_RECOMPUTE
-getitem_1: <built-in function getitem> -> PREFER_RECOMPUTE
+topk: aten.topk.default -> MUST_SAVE
+getitem: <built-in function getitem> -> MUST_SAVE
+getitem_1: <built-in function getitem> -> MUST_SAVE
 sum_1: aten.sum.default -> PREFER_RECOMPUTE
-cos: aten.cos.default -> MUST_SAVE""",
+cos: aten.cos.default -> PREFER_RECOMPUTE""",
         )
 
 

--- a/test/dynamo/test_activation_checkpointing.py
+++ b/test/dynamo/test_activation_checkpointing.py
@@ -2202,10 +2202,14 @@ class GraphModule(torch.nn.Module):
         return "\n".join(annotations)
 
     def test_pre_mode_decomp_has_sac_ignored_ops(self):
+        SAVE_OPS = {
+            torch.ops.aten.sin.default,
+            torch.ops.aten.add.Tensor,
+            torch.ops.aten.cos.default,
+        }
+
         def policy_fn(ctx, func, *args, **kwargs):
-            if func == torch.ops.aten.sin.default:
-                return CheckpointPolicy.MUST_RECOMPUTE
-            if func == torch.ops.aten.add.Tensor:
+            if func in SAVE_OPS:
                 return CheckpointPolicy.MUST_SAVE
             return CheckpointPolicy.PREFER_RECOMPUTE
 
@@ -2219,21 +2223,19 @@ class GraphModule(torch.nn.Module):
         self.assertExpectedInline(
             self._get_sac_annotations(op_with_detach, policy_fn),
             """\
-sin: aten.sin.default -> MUST_RECOMPUTE
+sin: aten.sin.default -> MUST_SAVE
 detach_1: aten.detach.default -> PREFER_RECOMPUTE
 add: aten.add.Tensor -> MUST_SAVE
-cos: aten.cos.default -> PREFER_RECOMPUTE""",
+cos: aten.cos.default -> MUST_SAVE""",
         )
 
     def test_post_mode_decomp(self):
         from torch._inductor.compile_fx import select_decomp_table
 
         def policy_fn(ctx, func, *args, **kwargs):
-            if func == torch.ops.aten.sin.default:
+            if func == torch.ops.aten.silu.default:
                 return CheckpointPolicy.MUST_SAVE
-            if func == torch.ops.aten.cos.default:
-                return CheckpointPolicy.MUST_RECOMPUTE
-            return CheckpointPolicy.PREFER_SAVE
+            return CheckpointPolicy.PREFER_RECOMPUTE
 
         def fn(x):
             x = x.sin()
@@ -2244,20 +2246,18 @@ cos: aten.cos.default -> PREFER_RECOMPUTE""",
         self.assertExpectedInline(
             self._get_sac_annotations(fn, policy_fn, decompositions=select_decomp_table),
             """\
-sin: aten.sin.default -> MUST_SAVE
-neg: aten.neg.default -> PREFER_SAVE
-exp: aten.exp.default -> PREFER_SAVE
-add: aten.add.Tensor -> PREFER_SAVE
-div: aten.div.Tensor -> PREFER_SAVE
-cos: aten.cos.default -> MUST_RECOMPUTE""",
+sin: aten.sin.default -> PREFER_RECOMPUTE
+neg: aten.neg.default -> MUST_SAVE
+exp: aten.exp.default -> MUST_SAVE
+add: aten.add.Tensor -> MUST_SAVE
+div: aten.div.Tensor -> MUST_SAVE
+cos: aten.cos.default -> PREFER_RECOMPUTE""",
         )
 
     def test_multi_output_op(self):
         def policy_fn(ctx, func, *args, **kwargs):
             if func == torch.ops.aten.topk.default:
                 return CheckpointPolicy.MUST_SAVE
-            if func == torch.ops.aten.sin.default:
-                return CheckpointPolicy.MUST_RECOMPUTE
             return CheckpointPolicy.PREFER_RECOMPUTE
 
         def fn(x):
@@ -2270,7 +2270,7 @@ cos: aten.cos.default -> MUST_RECOMPUTE""",
         self.assertExpectedInline(
             self._get_sac_annotations(fn, policy_fn),
             """\
-sin: aten.sin.default -> MUST_RECOMPUTE
+sin: aten.sin.default -> PREFER_RECOMPUTE
 topk: aten.topk.default -> MUST_SAVE
 getitem: <built-in function getitem> -> MUST_SAVE
 getitem_1: <built-in function getitem> -> MUST_SAVE


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #175338
* #176447
* #176455
* __->__ #176925
* #175348
* #176464

Adds a regression test that verifies SAC_IGNORED_OPS (like detach) get
PREFER_RECOMPUTE and don't leak the annotation from the preceding op.
Uses allow_in_graph to create a stable test that won't break if
decomposition behavior changes.

Authored with Claude.