### PR TITLE
Use tiling scores to recover INNER reduction hint for fused kernels

### DIFF
--- a/test/inductor/test_loop_ordering.py
+++ b/test/inductor/test_loop_ordering.py
@@ -484,6 +484,30 @@ class LoopOrderingTest(TestCase):
         self.assertEqual(1, metrics.generated_kernel_count)
         torch._dynamo.reset()
 
+    def test_reshape_reindexing_persistent(self):
+        """
+        After reindexing fuses a non-contiguous pointwise into a
+        reduction, tiling scores should recover INNER hint so the kernel
+        uses persistent reduction.
+        """
+
+        def f(x):
+            head_dim = 128
+            M, N = x.shape
+            x_reshaped = x.reshape(-1, head_dim)
+            x_f32 = x_reshaped.float()
+            variance = x_f32.pow(2).mean(dim=-1, keepdim=True)
+            x_normed = x_f32 * torch.rsqrt(variance + 1e-5)
+            return x_normed.reshape(M, N).to(x.dtype)
+
+        qkv = torch.randn(16, 10240, dtype=torch.bfloat16)
+        x = qkv[:, :8192]
+
+        _, (code,) = run_and_get_code(torch.compile(f), x)
+        # Single kernel and it should be persistent (triton_per)
+        self.assertEqual(code.count("def triton_"), 1)
+        self.assertIn("triton_per_", code)
+
     @unittest.skipIf(not PLATFORM_SUPPORTS_FP8, "FP8 requires H100+ and MI300+")
     def test_fp8_cast_and_t(self):
         """

--- a/torch/_inductor/choices.py
+++ b/torch/_inductor/choices.py
@@ -365,7 +365,9 @@ class InductorChoices:
 
     @staticmethod
     def should_use_persistent_reduction(
-        features: SIMDKernelFeatures, cooperative_reduction: bool
+        features: SIMDKernelFeatures,
+        cooperative_reduction: bool,
+        tiling_scores: Optional[dict[str, Any]] = None,
     ) -> bool:
         """
         Heuristic to decide if a persistent reduction should be used.
@@ -374,9 +376,9 @@ class InductorChoices:
             return False
         threshold = {
             ReductionHint.INNER: 1024,
-        }.get(features.get_reduction_hint(), 64)
+        }.get(features.get_reduction_hint(tiling_scores), 64)
 
-        if features.get_reduction_hint() not in (
+        if features.get_reduction_hint(tiling_scores) not in (
             ReductionHint.INNER,
             ReductionHint.OUTER_TINY,
         ):

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -2706,7 +2706,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
 
     def should_use_persistent_reduction(self) -> bool:
         return self.inside_reduction and V.choices.should_use_persistent_reduction(
-            self.features, self.cooperative_reduction
+            self.features, self.cooperative_reduction, self.tiling_scores
         )
 
     def want_no_x_dim(self):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #179091
* __->__ #176928
* #179090
* #176927
* #176345

When a pointwise node with non-contiguous access is fused into a
reduction kernel, get_reduction_hint downgrades INNER to DEFAULT. This
causes should_use_persistent_reduction to use a threshold of 64 instead
of 1024, preventing persistent reduction for moderately sized reductions
like head_dim=128.

Pass tiling_scores through to get_reduction_hint so it can check
coalescing ratios and upgrade DEFAULT back to INNER when the reduction
dimension genuinely has stride-1 access.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo