### PR TITLE
Replace deprecated check in inductor diagonal lowering

### DIFF
--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -31,7 +31,6 @@ from torch._library.utils import get_layout_constraint_tag
 from torch._prims_common import (
     canonicalize_dim,
     canonicalize_dims,
-    check,
     dtype_to_type,
     elementwise_dtypes,
     ELEMENTWISE_TYPE_PROMOTION_KIND,
@@ -2085,7 +2084,7 @@ def diagonal(input, offset: int = 0, dim1: int = 0, dim2: int = 1):
     dim1 = canonicalize_dim(idx=dim1, rank=num_dims)
     dim2 = canonicalize_dim(idx=dim2, rank=num_dims)
 
-    check(
+    torch._check(
         dim1 != dim2, lambda: f"diagonal dimensions cannot be identical {dim1}, {dim2}"
     )
 


### PR DESCRIPTION
Fixes #176658 

Replaces torch._prims_common.check with torch._check in the diagonal lowering function to fix FutureWarning that appears. Didn’t feel like this needed a test, but can add one if people want


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo