### PR TITLE
[Inductor] Use masked expansion for pointwise fusion with mismatched domains

### DIFF
--- a/test/inductor/test_expand_dim_fusion.py
+++ b/test/inductor/test_expand_dim_fusion.py
@@ -1,0 +1,120 @@
+# Owner(s): ["module: inductor"]
+"""
+Tests for expand_dimension_for_pointwise_nodes fusion optimization.
+
+This feature expands a smaller node's iteration domain to match a larger node's,
+using out mask (masked tl.load/tl.store) to skip out-of-bounds accesses, enabling
+kernel fusion between nodes with mismatched iteration domains.
+
+References:
+  - pytorch#125075: cat + to_fp16 fusion
+  - vllm#24917 / vllm#25477: mul + pad + addmm fusion
+"""
+
+import re
+import unittest
+
+import torch
+import torch._inductor.config as inductor_config
+from torch._inductor.test_case import TestCase
+from torch._inductor.utils import run_and_get_code
+from torch.testing._internal.inductor_utils import GPU_TYPE, requires_gpu
+
+
+def _count_triton_kernels(code: str) -> int:
+    """Count the number of triton kernel definitions in generated code."""
+    return len(re.findall(r"def triton_\w+\(", code))
+
+
+class TestExpandDimFusion(TestCase):
+    """Tests for padding fusion via expand_dimension_for_pointwise_nodes."""
+
+    # ─── Case 1: cat + to_fp16 (pytorch#125075) ─────────────────────────
+
+    @requires_gpu()
+    @inductor_config.patch(expand_dimension_for_pointwise_nodes=True)
+    def test_cat_to_fp16(self):
+        """cat [30528,768] + to_fp16 [30522,768] should fuse into 1 kernel."""
+
+        def fn(x):
+            z = torch.cat([x, torch.zeros([6, 768], device=GPU_TYPE)], dim=0)
+            y = x.to(torch.float16)
+            return z, y
+
+        x = torch.randn(30522, 768, device=GPU_TYPE)
+        compiled = torch.compile(fn)
+        result, (code,) = run_and_get_code(compiled, x)
+        ref = fn(x)
+
+        self.assertTrue(torch.allclose(result[0], ref[0]))
+        self.assertTrue(torch.allclose(result[1], ref[1]))
+        self.assertEqual(
+            _count_triton_kernels(code),
+            1,
+            "cat and to_fp16 should be fused via dimension expansion.",
+        )
+
+    # ─── Case 2: mul + pad + addmm (vllm#24917) ────────────────────────
+
+    @requires_gpu()
+    @inductor_config.patch(expand_dimension_for_pointwise_nodes=True)
+    def test_mul_pad_addmm(self):
+        """mul [4096,2880] + pad [4096,3072] should fuse into 1 triton kernel."""
+
+        def fn(x, scale, bias, weight):
+            mul_result = x * scale
+            padded = torch.nn.functional.pad(mul_result, [0, 192])
+            mm_result = torch.addmm(bias, mul_result, weight)
+            return padded, mm_result
+
+        x = torch.randn(4096, 2880, device=GPU_TYPE, dtype=torch.bfloat16)
+        scale = torch.randn(4096, 2880, device=GPU_TYPE, dtype=torch.bfloat16)
+        bias = torch.randn(1024, device=GPU_TYPE, dtype=torch.bfloat16)
+        weight = torch.randn(2880, 1024, device=GPU_TYPE, dtype=torch.bfloat16)
+
+        compiled = torch.compile(fn)
+        result, (code,) = run_and_get_code(compiled, x, scale, bias, weight)
+        ref = fn(x, scale, bias, weight)
+
+        self.assertTrue(torch.allclose(result[0], ref[0]))
+        self.assertTrue(torch.allclose(result[1], ref[1], atol=1e-2, rtol=1e-2))
+        self.assertEqual(
+            _count_triton_kernels(code),
+            1,
+            "mul and pad should be fused; addmm is an extern kernel.",
+        )
+
+    # ─── Large expansion ratio ──────────────────────────────────────────
+
+    @requires_gpu()
+    @inductor_config.patch(expand_dimension_for_pointwise_nodes=True)
+    def test_large_expansion_ratio(self):
+        """50% expansion ratio should still fuse — no ratio guard."""
+
+        def fn(x):
+            z = torch.cat([x, torch.zeros([512, 768], device=GPU_TYPE)], dim=0)
+            y = x.to(torch.float16)
+            return z, y
+
+        x = torch.randn(512, 768, device=GPU_TYPE)
+        compiled = torch.compile(fn)
+        result, (code,) = run_and_get_code(compiled, x)
+        ref = fn(x)
+
+        self.assertTrue(torch.allclose(result[0], ref[0]))
+        self.assertTrue(torch.allclose(result[1], ref[1]))
+        self.assertEqual(
+            _count_triton_kernels(code),
+            1,
+            "Large expansion ratio should not prevent fusion.",
+        )
+
+    # ─── Config ─────────────────────────────────────────────────────────
+
+    def test_expand_disabled_by_default(self):
+        """Feature is disabled by default."""
+        self.assertFalse(inductor_config.expand_dimension_for_pointwise_nodes)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torch/_inductor/loop_body.py
+++ b/torch/_inductor/loop_body.py
@@ -243,9 +243,11 @@ class LoopBody:
         self, dimension: int, new_range: int
     ) -> LoopBody:
         """
-        Expand node on `dimension` to `new_range` and rely on index modular to avoid
-        out-of-boundary access.
+        Expand node on `dimension` to `new_range` using out mask to skip
+        loads/stores for out-of-bounds indices. Uses ops.masked so that
+        codegen emits masked tl.load/tl.store with the dimension bound check.
         """
+        import torch
 
         old_body = self
         old_sizes = self.sizes
@@ -267,10 +269,25 @@ class LoopBody:
             iter_idx = index[: len(iter_size)]
             reduce_idx = index[len(iter_size) :]
 
+            # Out mask: only execute loads/stores when index is in original range
+            mask = ops.lt(
+                ops.index_expr(iter_idx[dimension], torch.int64),
+                ops.index_expr(sympy.Integer(original_range), torch.int64),
+            )
+
+            # Use % wrapping for index computation so that address expressions
+            # stay in bounds (masked-out threads still compute addresses)
             new_iter_idx = list(iter_idx)
             new_iter_idx[dimension] = iter_idx[dimension] % original_range
 
-            return old_body(new_iter_idx, reduce_idx)
+            def masked_body():
+                old_body(new_iter_idx, reduce_idx)
+                # Return a dummy value since ops.masked expects a return value,
+                # but the real outputs are stores (side effects masked by
+                # the _load_mask context)
+                return ops.constant(0, torch.int32)
+
+            return ops.masked(mask, masked_body, 0)
 
         loop_body = LoopBody(
             new_body, (iter_vars, reduce_vars), var_ranges, iter_vars, reduce_vars

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -4673,6 +4673,7 @@ class Scheduler:
             self.fuse_two_nodes(node1, node2, fused_nodes)
             return True
 
+        self._revert_expansion_if_needed(node1, node2)
         return False
 
     def _evaluate_pending_template_fusions(
@@ -4795,9 +4796,10 @@ class Scheduler:
             ):
                 continue
 
-            if self.can_fuse(
-                node1, node2, is_reorder_round
-            ) and not self.will_fusion_create_cycle(node1, node2):
+            can_fuse_result = self.can_fuse(node1, node2, is_reorder_round)
+            if can_fuse_result and not self.will_fusion_create_cycle(
+                node1, node2
+            ):
                 fusion_res = self.speedup_by_fusion(node1, node2)
                 if fusion_res.callable_fn is not None:
                     pending_fusion = PendingFusion(
@@ -4822,9 +4824,13 @@ class Scheduler:
                     continue
 
                 if not fusion_res.should_fuse:
+                    self._revert_expansion_if_needed(node1, node2)
                     continue
 
                 self.fuse_two_nodes(node1, node2, fused_nodes)
+            else:
+                # can_fuse returned False, or cycle detected after expansion
+                self._revert_expansion_if_needed(node1, node2)
 
     def _finish_pending_fusions(
         self,
@@ -5617,12 +5623,11 @@ class Scheduler:
         ):
             return None
 
-        # does not support mutation yet since relying on index mod to handle
-        # out-of-boundary access.
+        # does not support mutation since expansion changes the iteration domain
         if node1.has_aliasing_or_mutation() or node2.has_aliasing_or_mutation():
             return None
 
-        # skip halide which does not support mod for index
+        # skip halide which does not support the masked expansion codegen
         if config.cpu_backend == "halide":
             return None
 
@@ -5642,18 +5647,8 @@ class Scheduler:
         if len(node1.read_writes.writes) > 1 or len(node2.read_writes.writes) > 1:
             return None
 
-        # When memory access is small, reducing gpu kernel overhead is profitable over
-        # slightly larger memory access.
-        node1_write_memory = self.dep_size_hint(next(iter(node1.read_writes.writes)))
-        node2_write_memory = self.dep_size_hint(next(iter(node1.read_writes.writes)))
-        if (
-            max(node1_write_memory, node2_write_memory)
-            > config.small_memory_access_threshold
-        ):
-            return None
-
-        # does not support reinplace since `index % boundary` may lead to
-        # race condition
+        # does not support reinplace since masked stores on inplace buffers
+        # could have subtle correctness issues
         def has_reusable_buffer(node: BaseSchedulerNode) -> bool:
             for read in node.read_writes.reads:
                 input_buf: SchedulerBuffer | SchedulerDonatedBuffer | None
@@ -5687,6 +5682,13 @@ class Scheduler:
             n1_iter_sizes[mismatch_dim],
             n2_iter_sizes[mismatch_dim],
         )
+
+        # NOTE: we intentionally do not gate on expansion ratio here.
+        # Expansion only wastes ALU on masked-out threads; for memory-bound
+        # pointwise kernels this cost is negligible. If future workloads show
+        # expansion hurting (e.g. compute-bound kernels or register pressure),
+        # consider adding a max_expand_ratio config guard here.
+
         if V.graph.sizevars.statically_known_lt(mismatch_size1, mismatch_size2):
             return mismatch_dim, node1, mismatch_size2
         elif V.graph.sizevars.statically_known_lt(mismatch_size2, mismatch_size1):
@@ -5889,9 +5891,55 @@ class Scheduler:
             expand_analysis := self.get_expand_dim_for_pointwise_nodes(node1, node2)
         ):
             (expand_dim, smaller_node, expand_size) = expand_analysis
+            # Save state before expansion so we can rollback if fusion is
+            # rejected by downstream checks (V.choices.can_fuse, backend, etc.)
+            saved_body = smaller_node._body
+            saved_sizes = smaller_node._sizes
+            saved_group = smaller_node.group
+            saved_read_writes = smaller_node.read_writes
+            saved_unmet_deps = smaller_node.unmet_dependencies
+
             smaller_node.expand_dimension_for_pointwise_node(expand_dim, expand_size)
-            shared_data_score = self.score_fusion_memory(node1, node2)
-            assert isinstance(shared_data_score, int)
+            smaller_node._expanded_for_fusion = True  # type: ignore[attr-defined]
+            smaller_node._expansion_saved_state = {  # type: ignore[attr-defined]
+                "body": saved_body,
+                "sizes": saved_sizes,
+                "group": saved_group,
+                "read_writes": saved_read_writes,
+                "unmet_dependencies": saved_unmet_deps,
+            }
+            smaller_node.pointwise_read_writes.clear_cache(smaller_node)
+            shared_data_score = max(
+                self.score_fusion_memory(node1, node2),
+                config.score_fusion_memory_threshold,
+            )
+
+            # Run remaining fusion checks; rollback expansion if any rejects.
+            # Note: we skip loop_index_inversion_in_fusion here because after
+            # expansion the domains already match — index inversion is only
+            # needed when domains match but indexing patterns differ.
+            can_fuse_result = self._can_fuse_expanded(
+                node1, node2, shared_data_score, device
+            )
+            if not can_fuse_result:
+                self._revert_expansion(smaller_node)
+            return can_fuse_result
+        elif (
+            config.expand_dimension_for_pointwise_nodes
+            and shared_data_score < config.score_fusion_memory_threshold
+            and (
+                getattr(node1, "_expanded_for_fusion", False)
+                or getattr(node2, "_expanded_for_fusion", False)
+            )
+        ):
+            # can_fuse is called twice for each pair: first in
+            # get_possible_fusions (which expands and returns True), then again
+            # in _try_fusion_pairs (where sizes now match so get_expand_dim
+            # returns None). Force the score past the threshold since expansion
+            # profitability was already validated in the first call.
+            shared_data_score = max(
+                shared_data_score, config.score_fusion_memory_threshold
+            )
 
         if (
             config.loop_index_inversion_in_fusion
@@ -5922,6 +5970,54 @@ class Scheduler:
                 and self.get_backend(device).can_fuse_vertical(node1, node2)
             )
         else:  # nodes don't depend on each other, but may have common reads
+            return V.choices.can_fuse_horizontal(
+                self, node1, node2, shared_data_score
+            ) and self.get_backend(device).can_fuse_horizontal(node1, node2)
+
+    def _revert_expansion(self, node: BaseSchedulerNode) -> None:
+        """Revert a node's dimension expansion performed during can_fuse.
+
+        Called when fusion is ultimately rejected after can_fuse returned True
+        (e.g., by will_fusion_create_cycle or speedup_by_fusion)."""
+        saved = getattr(node, "_expansion_saved_state", None)
+        if saved is None:
+            return
+        node._body = saved["body"]
+        node._sizes = saved["sizes"]
+        node.group = saved["group"]
+        node.read_writes = saved["read_writes"]
+        node.unmet_dependencies = saved["unmet_dependencies"]
+        node._expanded_for_fusion = False  # type: ignore[attr-defined]
+        del node._expansion_saved_state  # type: ignore[attr-defined]
+        node.pointwise_read_writes.clear_cache(node)
+
+    def _revert_expansion_if_needed(
+        self, node1: BaseSchedulerNode, node2: BaseSchedulerNode
+    ) -> None:
+        """Revert expansion on either node if it was expanded but fusion failed."""
+        for node in (node1, node2):
+            if getattr(node, "_expanded_for_fusion", False):
+                self._revert_expansion(node)
+
+    def _can_fuse_expanded(
+        self,
+        node1: BaseSchedulerNode,
+        node2: BaseSchedulerNode,
+        shared_data_score: int,
+        device: object,
+    ) -> bool:
+        """Remaining fusion checks after dimension expansion. Factored out so
+        that the caller can rollback the expansion if this returns False."""
+        if not V.choices.can_fuse(self, node1, node2, shared_data_score):
+            return False
+
+        if node1.get_operation_names() & node2.ancestors:
+            return (
+                self.can_fuse_vertical(node1, node2)
+                and V.choices.can_fuse_vertical(self, node1, node2, shared_data_score)
+                and self.get_backend(device).can_fuse_vertical(node1, node2)
+            )
+        else:
             return V.choices.can_fuse_horizontal(
                 self, node1, node2, shared_data_score
             ) and self.get_backend(device).can_fuse_horizontal(node1, node2)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #176932

Replace % wrapping with ops.masked for expand_dimension_for_pointwise_node,
add rollback on fusion rejection, fix cache invalidation, and remove the
16MB threshold and expansion ratio guards.

This enables fusing two pointwise kernels with slightly different iteration
domains (e.g., [tokens, 2880] vs [tokens, 3072]) by expanding the smaller
node's domain and masking out-of-bounds accesses.

References:
  - pytorch#125075: cat + to_fp16 fusion
  - vllm#24917: mul + pad + addmm fusion
  - PR #161420: BoyuanFeng's original expand_dimension feature

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo