### PR TITLE
[torchTLX] Improve mm performance with heuristic rules

### DIFF
--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -424,12 +424,16 @@ def tuned_mm(mat1, mat2, out_dtype=None, *, layout=None):
         # To be conservative we increase this threshold for N/M by 2.
         is_exhaustive = inductor_config.max_autotune_gemm_search_space == "exhaustive"
         if is_exhaustive or not use_decompose_k_choice(m, n, k, threshold_multiple=2):
-            templates_to_use.append(mm_template)
+            # In TLX force mode, skip non-TLX templates
+            if not tlx_force_mode:
+                templates_to_use.append(mm_template)
 
-            if use_triton_blackwell_tma_template(mat1, mat2, output_layout=layout):
-                templates_to_use.append(blackwell_ws_persistent_device_tma_mm_template)
-            elif use_triton_tma_template(mat1, mat2, output_layout=layout):
-                templates_to_use.append(persistent_tma_mm_template)
+                if use_triton_blackwell_tma_template(mat1, mat2, output_layout=layout):
+                    templates_to_use.append(
+                        blackwell_ws_persistent_device_tma_mm_template
+                    )
+                elif use_triton_tma_template(mat1, mat2, output_layout=layout):
+                    templates_to_use.append(persistent_tma_mm_template)
 
         templates_to_use.append(mm_contiguous_subgraph_template)
 


### PR DESCRIPTION
Summary:
This diff:

(1) Apply Rule Heuristics Following Standalone TLX (as much as possible)

| Rule | Name | Condition |
|------|------|-----------|
| 0 | Fallback (Scoring) | No single-config rule matches |
| 1 | Tall-M Small-K Low-AI | `is_tall_m AND gpu_sat AND K≤384 AND AI≤1.5` |
| 2 | Tall-M Normal-K Low-AI | `is_tall_m AND gpu_sat AND K>384 AND AI≤1.5` |
| 3 | Tall-M High-AI Large-K | `is_tall_m AND gpu_sat AND AI>1.5 AND K>N*2` |
| 4 | Tall-M High-AI Small-K | `is_tall_m AND gpu_sat AND AI>1.5 AND K≤N*2` |
| 5 | Undersaturated Large Split-K | `undersat AND MN≥1M` |
| 6 | Undersaturated Small Split-K | `undersat AND MN<1M` |
| 7 | GPU-Saturated General | `gpu_sat AND NOT is_tall_m` |

"AI" stands for "Arithmetic Intensity".

Arithmetic Intensity = FLOPs / Bytes transferred

(2) replaces TMA async store with `tl.store`

TODO. Extend Inductor to apply epilogue fusions before TMA staging, enabling both TMA performance AND fusion.

(3) Small-K Specialized Config

Tall-M shapes with small K (≤384) underperformed by 40-45%.
- K=128 with BLOCK_K=128 → 1 K-tile (no pipelining)

Make `BLOCK_K=64` and `NUM_SMEM_BUFFERS=3` for K ≤ 384:
- K=128 → 2 K-tiles (2× better pipelining)
- K=384 → 6 K-tiles (2× better pipelining)

## Split-K Cannot Be Supported
Standalone TLX uses Split-K, but PT2 cannot because:
1. **Atomic reduction incompatible**: Split-K needs `atomicAdd`, Inductor assumes single-writer
2. **Output zeroing unsupported**: Split-K needs pre-zeroed buffers
3. **Epilogue fusion conflict**: Bias/activation can't apply atomically
4. **Grid mismatch**: Inductor grid = `MN_tiles`, Split-K needs `MN_tiles × SPLIT_K`

Test Plan:
## Correctness (unit test)

mm template `buck run mode/opt -c fbcode.platform010_cuda_version=12.8 fbcode//caffe2/test/inductor/fb/tlx:test_templates`

fusion `buck run mode/opt -c fbcode.platform010_cuda_version=12.8 fbcode//caffe2/test/inductor/fb/tlx:test_fusions`

## Standalone TLX and torchTLX

`TRITON_ALWAY_COMPILE=1 TRITON_PRINT_AUTOTUNING=1 ads_mkl/benchmarks/denoise.sh buck2 run @//mode/opt -m ovr_config//triton:beta -c fbcode.enable_gpu_sections=true -c fbcode.nvcc_arch=b200a -c fbcode.platform010_cuda_version=12.8 //pytorch/tritonbench:run_lite -- --op gemm --only aten_matmul,tlx_matmul_ws,torch_tlx_mm --input-loader 'pytorch/tritonbench/tritonbench/data/input_configs/fb/ads_omnifm_v5/gemm.json' --metrics accuracy,tflops,speedup --baseline aten_matmul --simple-output`

LOG P2227826895

```
                                                                                           (M, N, K)    aten_matmul-tflops    tlx_matmul_ws-accuracy    tlx_matmul_ws-tflops    tlx_matmul_ws-speedup    torch_tlx_mm-accuracy    torch_tlx_mm-tflops    torch_tlx_mm-speedup
----------------------------------------------------------------------------------------------------  --------------------  ------------------------  ----------------------  -----------------------  -----------------------  ---------------------  ----------------------
                                                                                (2304, 12800, 32768)              1275.05                          1                1102.45                  0.864634                        1               1143.23                 0.896614
                                                                                (32768, 12800, 2304)              1445.17                          1                1110.93                  0.76872                         1                556.448                0.38504
                                                                                (2304, 32768, 12800)              1212.74                          1                1161.48                  0.957732                        1                950.281                0.783584
                                                                                (1024, 2048, 442368)              1143.92                          1                1157.77                  1.0121                          1               1040.26                 0.90938
                                                                                  (768, 992, 589824)               695.416                         1                1171.72                  1.68493                         1                818.019                1.1763
                                                                                (442368, 1024, 2048)              1150.32                          1                1145.21                  0.995556                        1               1161.5                  1.00972
                                                                                 (2304, 1024, 12800)               906.55                          1                1034.78                  1.14145                         1                736.992                0.812964
                                                                                (442368, 2048, 1024)              1073.52                          1                1057.18                  0.984776                        1                892.567                0.831437
                                                                                 (2304, 12800, 1024)               998.116                         1                1032.51                  1.03446                         1                964.454                0.966275
                                                                                 (12800, 1024, 2304)              1076.08                          1                1075.46                  0.99943                         1                393.216                0.365417
                                                                                 (1024, 12800, 2304)              1110.26                          1                1108.95                  0.998825                        1                404.076                0.363948
                                                                                 (4096, 31744, 4608)              1206.56                          1                1057.82                  0.876723                        1                733.243                0.607715
                                                                                 (4608, 31744, 4096)              1211.36                          1                 895.32                  0.739103                        1               1198.03                 0.988995
                                                                                 (4608, 4096, 31744)              1265.09                          1                1087.49                  0.859616                        1               1059.07                 0.837151
                                                                                 (512, 4096, 294912)               821.829                         1                 964.872                 1.17406                         1                983.68                 1.19694
                                                                                 (384, 3072, 294912)               739.416                         1                 782.695                 1.05853                         1                943.677                1.27625
                                                                                (1152, 12800, 32768)              1008.35                          1                1066.39                  1.05756                         1               1107.61                 1.09844
                                                                                 (4096, 294912, 512)              1151.5                           1                 957.084                 0.831163                        1                237.679                0.206408
                                                                                 (589824, 2048, 512)               933.486                         1                1022.83                  1.09571                         1                791.553                0.847954
                                                                                  (589824, 992, 768)              1203.87                          1                 952.908                 0.791538                        1                782.924                0.65034
                                                                                 (512, 2048, 589824)               778.842                         1                 853.041                 1.09527                         1               1115.41                 1.43215
                                                                                 (512, 294912, 4096)              1017.71                          1                 944.341                 0.927906                        1               1064.22                 1.0457
                                                                                 (2304, 1024, 12800)               880.745                         1                 935.301                 1.06194                         1                649.273                0.737186
                                                                                 (589824, 512, 2048)              1163.7                           1                 868.997                 0.746752                        1                970.2                  0.833718
```

## Detailed perf numbers (PT2 vs torchTLX vs TLX) grouped by heuristic rules

NOTE: following screenshots are collected from an older set of mm shapes

{F1986190143}

{F1986190146}

{F1986190148}

{F1986190150}

{F1986190152}

{F1986190153}

Reviewed By: htyu



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos