### PR TITLE
[ROCm] Avoid watchdog hipEventQuery during active graph capture

### DIFF
--- a/aten/src/ATen/cuda/CUDAGraph.cpp
+++ b/aten/src/ATen/cuda/CUDAGraph.cpp
@@ -12,6 +12,13 @@ namespace at::cuda {
 
 static bool _cuda_graphs_debug = false;
 
+#if defined(USE_ROCM)
+bool is_graph_capture_active() {
+  std::unique_lock<std::mutex> lock(_currently_capturing_graphs_mutex);
+  return !_currently_capturing_graphs.empty();
+}
+#endif
+
 MempoolId_t graph_pool_handle() {
   // Sets just the second value, to distinguish it from MempoolId_ts created from
   // cudaStreamGetCaptureInfo id_s in capture_begin.
@@ -129,7 +136,9 @@ void CUDAGraph::capture_end() {
   TORCH_CHECK(stream.stream() == capture_stream_.stream(),
               "Capture must end on the same stream it began on.");
 
-  AT_CUDA_CHECK(cudaStreamEndCapture(capture_stream_, &graph_));
+  cudaError_t endCaptureErr = cudaStreamEndCapture(capture_stream_, &graph_);
+
+  AT_CUDA_CHECK(endCaptureErr);
 
   c10::cuda::CUDACachingAllocator::endAllocateToPool(capture_dev_, mempool_id_);
   at::getHostAllocator(at::kCUDA)->end_allocate_to_pool(mempool_id_);

--- a/aten/src/ATen/cuda/CUDAGraph.cpp
+++ b/aten/src/ATen/cuda/CUDAGraph.cpp
@@ -12,6 +12,14 @@ namespace at::cuda {
 
 static bool _cuda_graphs_debug = false;
 
+// To support stream capture across multiple threads, we use a global
+// hashmap mapping cuda stream capture IDs to CUDAGraph objects. This
+// was originally a thread_local std::stack<CUDAGraph*>, but that was
+// not acceptable since stream capture does span threads in certain
+// circumstances (in particular, during autograd).
+static std::mutex _currently_capturing_graphs_mutex;
+static ska::flat_hash_map<CaptureId_t, CUDAGraph*> _currently_capturing_graphs;
+
 #if defined(USE_ROCM)
 bool is_graph_capture_active() {
   std::unique_lock<std::mutex> lock(_currently_capturing_graphs_mutex);
@@ -127,7 +135,10 @@ void CUDAGraph::capture_begin(MempoolId_t pool/*=0*/, cudaStreamCaptureMode capt
   cudaStreamCaptureStatus status{};
   AT_CUDA_CHECK(cudaStreamGetCaptureInfo(stream, &status, &capture_id_));
   TORCH_INTERNAL_ASSERT(status == cudaStreamCaptureStatus::cudaStreamCaptureStatusActive);
-
+  {
+    std::unique_lock<std::mutex> lock(_currently_capturing_graphs_mutex);
+    _currently_capturing_graphs.emplace(capture_id_, this);
+  }
 }
 
 void CUDAGraph::capture_end() {
@@ -137,6 +148,13 @@ void CUDAGraph::capture_end() {
               "Capture must end on the same stream it began on.");
 
   cudaError_t endCaptureErr = cudaStreamEndCapture(capture_stream_, &graph_);
+  {
+    std::unique_lock<std::mutex> lock(_currently_capturing_graphs_mutex);
+    TORCH_CHECK(
+        _currently_capturing_graphs.count(capture_id_),
+        "capture_end() called before capture_begin().");
+    _currently_capturing_graphs.erase(capture_id_);
+  }
 
   AT_CUDA_CHECK(endCaptureErr);
 

--- a/aten/src/ATen/cuda/CUDAGraph.h
+++ b/aten/src/ATen/cuda/CUDAGraph.h
@@ -19,6 +19,14 @@ namespace cuda {
 // to CUDAGraph::capture_begin
 TORCH_CUDA_CPP_API MempoolId_t graph_pool_handle();
 
+// Returns true if any CUDAGraph capture is currently active in this process.
+// Used by ProcessGroupNCCL's watchdog to avoid calling hipEventQuery during
+// active capture on pre-7.2 HIP runtimes, where doing so poisons the session.
+// Not needed on CUDA/NVIDIA where hipEventQuery does not have this restriction.
+#if defined(USE_ROCM)
+TORCH_CUDA_CPP_API bool is_graph_capture_active();
+#endif
+
 struct TORCH_CUDA_CPP_API CUDAGraph {
   CUDAGraph(bool keep_graph=false);
   ~CUDAGraph();

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -11,6 +11,7 @@
 #include <utility>
 
 #include <ATen/cuda/CUDAContext.h>
+#include <ATen/cuda/CUDAGraph.h>
 #include <c10/core/DeviceType.h>
 #include <c10/cuda/CUDAAllocatorConfig.h>
 #include <c10/cuda/CUDAGraphsC10Utils.h>
@@ -223,6 +224,13 @@ std::string getExceptionMsgFromExceptionPtr(
 
 bool safeEventQuery(const std::shared_ptr<at::cuda::CUDAEvent>& event) {
 #ifdef USE_ROCM
+  // hipEventQuery from a non-capturing thread while another thread has GLOBAL
+  // capture active poisons the capture session
+  // (hipErrorStreamCaptureUnsupported -> hipErrorStreamCaptureInvalidated).
+  // Avoid the call entirely when any capture is in progress.
+  if (at::cuda::is_graph_capture_active()) {
+    return false;
+  }
   try {
     return event->query();
   } catch (const c10::Error& e) {
@@ -2303,7 +2311,14 @@ void ProcessGroupNCCL::Watchdog::runLoop() {
 
       // Then check if work has timed out
       // Skip if work has encountered an error
-      bool timedout = !work.exception() && work.checkTimeout();
+      bool timedout = false;
+#ifdef USE_ROCM
+      if (!at::cuda::is_graph_capture_active()) {
+        timedout = !work.exception() && work.checkTimeout();
+      }
+#else
+      timedout = !work.exception() && work.checkTimeout();
+#endif
 
       // Report desync state in case of timeout (if TORCH_NCCL_DESYNC_DEBUG is
       // turned on; otherwise, run() is no-op)


### PR DESCRIPTION
This PR fixes a ROCm issue where NCCL watchdog polling can call hipEventQuery from a non-capturing thread while another thread is in active HIP graph capture, which can invalidate the capture session and later fail at graph capture end. The fix makes watchdog polling capture-aware (safeEventQuery plus timeout gating via is_graph_capture_active) and completes CUDAGraph capture-state bookkeeping by registering capture IDs in capture_begin() and removing them in capture_end().

**Content sources for this PR:**
#175377 (full) - capture-time HIP event query handling in NCCL watchdog.
#176251 (full) - avoid watchdog hipEventQuery during active graph capture; add capture-aware timeout behavior.
#168912 (partial) - only the CUDAGraph capture-state map lifecycle pieces needed by is_graph_capture_active (declaration + begin/end registration/cleanup).

**Impact:** this affects any users running distributed workloads on ROCm with HIP graph capture enabled, where watchdog polling during capture can cause flaky failures, capture invalidation, or runtime errors in collective-heavy paths.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang