### PR TITLE
Add per-param mesh memory and overlap tests for FSDP2

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_memory.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_memory.py
@@ -6,6 +6,11 @@ import unittest
 
 import torch
 from torch.distributed.fsdp import CPUOffloadPolicy, fully_shard, OffloadPolicy
+from torch.distributed.fsdp._fully_shard._fsdp_common import (
+    FSDPMeshInfo,
+    ShardPlacementResult,
+)
+from torch.distributed.tensor import init_device_mesh, Shard
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import FSDPTest, get_devtype
 from torch.testing._internal.common_utils import (
@@ -343,6 +348,215 @@ class TestFullyShardMemory(FSDPTest):
 
         for param in model.parameters():
             param.register_post_accumulate_grad_hook(optim_hook)
+
+
+class TestFullyShardPerParamMeshMemory(FSDPTest):
+    @property
+    def world_size(self) -> int:
+        return min(8, torch.get_device_module(device_type).device_count())
+
+    @skip_if_lt_x_gpu(8)
+    @unittest.skipIf(TEST_HPU, " 'empty_cache' is not supported on hpu")
+    def test_per_param_mesh_training_memory_no_gc(self):
+        """Memory should not grow across training steps with per-param meshes.
+
+        Verifies that per-PG reduce-scatter state (from shard_placement_fn
+        routing params to different process groups) doesn't accumulate across
+        training steps when GC is disabled.
+        """
+        torch.manual_seed(42)
+        gc.disable()
+        try:
+            # Pre-run a linear forward and backward to allocate the cuBLAS
+            # workspaces before measuring memory
+            lin = torch.nn.Linear(64, 64, device=device_type)
+            inp = torch.randn(2, 64, device=device_type)
+            lin(inp).sum().backward()
+            del lin, inp
+            torch.get_device_module(device_type).empty_cache()
+            base_mem_mb = self._get_peak_active_memory_mb()
+
+            # Set up per-param meshes: dp_mesh for regular params,
+            # efsdp_mesh for expert params (unflattened from dp_mesh)
+            ep_degree = 2
+            efsdp_size = self.world_size // ep_degree
+            dp_mesh = init_device_mesh(
+                device_type.type,
+                (self.world_size,),
+                mesh_dim_names=("dp",),
+            )
+            sparse_mesh = dp_mesh._unflatten(
+                0,
+                (efsdp_size, ep_degree),
+                ("efsdp", "ep"),
+            )
+            ep_mesh = sparse_mesh["ep"]
+            dp_mesh_info = FSDPMeshInfo(mesh=dp_mesh, shard_mesh_dim=0)
+            efsdp_mesh_info = FSDPMeshInfo(mesh=sparse_mesh["efsdp"], shard_mesh_dim=0)
+
+            model_args = ModelArgs(
+                n_layers=2,
+                vocab_size=256,
+                max_seq_len=32,
+                dim=64,
+                n_heads=4,
+                dropout_p=0.0,
+                num_experts=8,
+            )
+            model = Transformer(model_args)
+            Transformer.parallelize(
+                model, tp_mesh=None, use_seq_parallel=False, ep_mesh=ep_mesh
+            )
+
+            # Compute parameter counts before FSDP sharding.
+            # After EP, expert params are DTensors with Shard(0) on ep_mesh.
+            block0_expert_params = set(
+                model.layers[0].expert_layer.experts.parameters()
+            )
+            block_non_expert_numel = sum(
+                p.numel()
+                for p in model.layers[0].parameters()
+                if p not in block0_expert_params
+            )
+            # EP-local expert numel (each rank has num_experts/ep_degree experts)
+            block_expert_local_numel = sum(
+                p.to_local().numel() for p in block0_expert_params
+            )
+            block_unsharded_numel = block_non_expert_numel + block_expert_local_numel
+            non_block_numel = sum(
+                p.numel()
+                for name, p in model.named_parameters()
+                if not name.startswith("layers.")
+            )
+            # Non-expert params sharded across dp_mesh (world_size),
+            # expert params sharded across efsdp (efsdp_size)
+            model_sharded_numel = (
+                model_args.n_layers
+                * (
+                    (block_non_expert_numel + self.world_size - 1) // self.world_size
+                    + (block_expert_local_numel + efsdp_size - 1) // efsdp_size
+                )
+                + (non_block_numel + self.world_size - 1) // self.world_size
+            )
+
+            for block in model.layers:
+                expert_params = set(block.expert_layer.experts.parameters())
+
+                def _shard_placement_fn(
+                    param,
+                    _expert_params=expert_params,
+                ):
+                    if param in _expert_params:
+                        return ShardPlacementResult(
+                            placement=Shard(0),
+                            mesh_info=efsdp_mesh_info,
+                        )
+                    return ShardPlacementResult(
+                        placement=Shard(0),
+                        mesh_info=dp_mesh_info,
+                    )
+
+                fully_shard(
+                    block,
+                    mesh=dp_mesh,
+                    shard_placement_fn=_shard_placement_fn,
+                )
+
+            fully_shard(
+                [model.tok_embeddings, model.norm, model.output],
+                mesh=dp_mesh,
+            )
+            fully_shard(model, mesh=dp_mesh)
+
+            optim = torch.optim.Adam(model.parameters(), lr=1e-2, foreach=False)
+            inp = torch.randint(
+                0,
+                model_args.vocab_size,
+                (2, model_args.max_seq_len),
+                device=device_type.type,
+            )
+
+            buffer_mb = 16 if torch.version.cuda else 18
+
+            # Forward: 3x block unsharded (current all-gather + copy-out
+            # + next block prefetch), non-block params, sharded params
+            loss = model(inp)
+            mem_mb = self._get_peak_active_memory_mb()
+            expected_fwd_mb = (
+                3 * block_unsharded_numel + non_block_numel + model_sharded_numel
+            ) * 4 / 1e6 + buffer_mb
+            self.assertLessEqual(mem_mb - base_mem_mb, expected_fwd_mb)
+
+            # Backward: 2x block unsharded (all-gather + copy-out),
+            # 2x block gradients (grads + reduce-scatter input),
+            # non-block params, 2x sharded params/gradients
+            loss.sum().backward()
+            mem_mb = self._get_peak_active_memory_mb()
+            expected_bwd_mb = (
+                4 * block_unsharded_numel + non_block_numel + 2 * model_sharded_numel
+            ) * 4 / 1e6 + buffer_mb
+            self.assertLessEqual(mem_mb - base_mem_mb, expected_bwd_mb)
+            del loss
+            torch.get_device_module(device_type).reset_peak_memory_stats()
+
+            # Optimizer step: 1x sharded params, 1x sharded grads,
+            # 2x sharded optimizer states (Adam m and v)
+            optim.step()
+            mem_mb = self._get_peak_active_memory_mb()
+            expected_optim_mb = 4 * model_sharded_numel * 4 / 1e6 + buffer_mb
+            self.assertLessEqual(mem_mb - base_mem_mb, expected_optim_mb)
+
+            # Zero grad: sharded gradients freed, leaving
+            # 1x sharded params + 2x optimizer states
+            optim.zero_grad()
+            torch.get_device_module(device_type).reset_peak_memory_stats()
+            mem_mb = self._get_peak_active_memory_mb()
+            expected_post_step_mb = (
+                model_sharded_numel * 4 / 1e6
+                + buffer_mb
+                + 2 * model_sharded_numel * 4 / 1e6
+                + buffer_mb
+            )
+            self.assertLessEqual(mem_mb - base_mem_mb, expected_post_step_mb)
+
+            # Record steady-state memory after warmup step
+            gc.collect()
+            torch.get_device_module(device_type).synchronize()
+            mem_after_warmup = self._get_curr_active_memory_mb()
+
+            # Run N steps and verify no growth (per-PG RS state leak check)
+            num_steps = 10
+            for _ in range(num_steps):
+                loss = model(inp)
+                loss.sum().backward()
+                optim.step()
+                optim.zero_grad()
+
+            torch.get_device_module(device_type).synchronize()
+            mem_after_steps = self._get_curr_active_memory_mb()
+            self.assertLessEqual(
+                mem_after_steps - mem_after_warmup,
+                2,
+                f"Memory grew by {mem_after_steps - mem_after_warmup} MB over "
+                f"{num_steps} steps with per-param meshes and gc disabled, "
+                f"indicating per-PG reduce-scatter state is leaking",
+            )
+        finally:
+            gc.enable()
+
+    def _get_peak_active_memory_mb(self) -> int:
+        mem_stats = torch.get_device_module(device_type).memory_stats()
+        if TEST_CUDA or TEST_XPU:
+            return round(mem_stats["active_bytes.all.peak"] / 1e6)
+        if TEST_HPU:
+            return round(mem_stats["MaxInUse"] / 1e6)
+
+    def _get_curr_active_memory_mb(self) -> int:
+        mem_stats = torch.get_device_module(device_type).memory_stats()
+        if TEST_CUDA or TEST_XPU:
+            return round(mem_stats["active_bytes.all.current"] / 1e6)
+        if TEST_HPU:
+            return round(mem_stats["InUse"] / 1e6)
 
 
 if __name__ == "__main__":

--- a/test/distributed/_composable/fsdp/test_fully_shard_overlap.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_overlap.py
@@ -1,5 +1,6 @@
 # Owner(s): ["oncall: distributed"]
 
+import contextlib
 import copy
 import functools
 import unittest
@@ -9,6 +10,13 @@ import torch
 import torch.distributed as dist
 import torch.nn as nn
 from torch.distributed.fsdp import fully_shard
+from torch.distributed.fsdp._fully_shard._fsdp_common import (
+    FSDPMeshInfo,
+    ShardPlacementResult,
+)
+from torch.distributed.fsdp._fully_shard._fsdp_param_group import FSDPParamGroup
+from torch.distributed.fsdp._fully_shard._fsdp_state import _get_module_fsdp_state
+from torch.distributed.tensor import init_device_mesh, Shard
 from torch.distributed.tensor.experimental import implicit_replication
 from torch.testing._internal.common_distributed import (
     skip_if_lt_x_gpu,
@@ -30,6 +38,44 @@ from torch.testing._internal.common_utils import (
 
 device_type = torch.device(get_devtype())
 device_module = torch.get_device_module(device_type)
+
+
+def _time_fn(fn: Callable):
+    start_event = device_module.Event(enable_timing=True)
+    end_event = device_module.Event(enable_timing=True)
+    dist.barrier()
+    device_module.synchronize()
+    start_event.record()
+    fn()
+    end_event.record()
+    device_module.synchronize()
+    return start_event.elapsed_time(end_event)
+
+
+def _make_delayed_collectives(comm_sleep_ms: int):
+    """Returns (delayed_all_gather, delayed_reduce_scatter) that add a sleep
+    on a shared comm stream before the original collective."""
+    orig_all_gather = dist.all_gather_into_tensor
+    orig_reduce_scatter = dist.reduce_scatter_tensor
+    comm_stream = device_module.Stream()
+
+    def delay_collective():
+        # Share a stream so that all-gather and reduce-scatter block each
+        # other like in `ProcessGroupNCCL`
+        comm_stream.wait_stream(device_module.current_stream())
+        with device_module.stream(comm_stream):
+            device_module._sleep(int(comm_sleep_ms * get_cycles_per_ms()))
+        device_module.current_stream().wait_stream(comm_stream)
+
+    def delayed_all_gather(*args, **kwargs):
+        delay_collective()
+        return orig_all_gather(*args, **kwargs)
+
+    def delayed_reduce_scatter(*args, **kwargs):
+        delay_collective()
+        return orig_reduce_scatter(*args, **kwargs)
+
+    return delayed_all_gather, delayed_reduce_scatter
 
 
 class TestFullyShardOverlap(FSDPTest):
@@ -69,31 +115,9 @@ class TestFullyShardOverlap(FSDPTest):
             fully_shard(lin, reshard_after_forward=True)
         fully_shard(model, reshard_after_forward=True)
 
-        orig_all_gather_into_tensor = dist.all_gather_into_tensor
-        orig_reduce_scatter_tensor = dist.reduce_scatter_tensor
-        comm_stream = torch.get_device_module(device_type).Stream()
-
-        def delay_collective():
-            # Share a stream so that all-gather and reduce-scatter block each
-            # other like in `ProcessGroupNCCL`
-            comm_stream.wait_stream(
-                torch.get_device_module(device_type).current_stream()
-            )
-            with torch.get_device_module(device_type).stream(comm_stream):
-                torch.get_device_module(device_type)._sleep(
-                    int(comm_sleep_ms * get_cycles_per_ms())
-                )
-            torch.get_device_module(device_type).current_stream().wait_stream(
-                comm_stream
-            )
-
-        def delayed_all_gather(*args, **kwargs):
-            delay_collective()
-            return orig_all_gather_into_tensor(*args, **kwargs)
-
-        def delayed_reduce_scatter(*args, **kwargs):
-            delay_collective()
-            return orig_reduce_scatter_tensor(*args, **kwargs)
+        delayed_all_gather, delayed_reduce_scatter = _make_delayed_collectives(
+            comm_sleep_ms
+        )
 
         inp = torch.randn((2, dim), device=device_type.type)
         loss = model(inp).sum()  # warmup CUDA and allocator
@@ -114,8 +138,8 @@ class TestFullyShardOverlap(FSDPTest):
             with patch_all_gather(delayed_all_gather):
                 model(inp)
 
-        ref_fwd_time = self._time_fn(ref_fwd)
-        fwd_time = self._time_fn(fwd)
+        ref_fwd_time = _time_fn(ref_fwd)
+        fwd_time = _time_fn(fwd)
         # Forward: only 1st all-gather is exposed
         # NOTE: Do not enforce the expected forward time due to flakiness in CI
         # expected_fwd_time = comm_sleep_ms + num_linears * compute_sleep_ms + buffer_ms
@@ -156,8 +180,8 @@ class TestFullyShardOverlap(FSDPTest):
                 loss = model(inp).sum()
                 loss.backward()
 
-        ref_fwd_bwd_time = self._time_fn(ref_fwd_bwd)
-        fwd_bwd_time = self._time_fn(fwd_bwd)
+        ref_fwd_bwd_time = _time_fn(ref_fwd_bwd)
+        fwd_bwd_time = _time_fn(fwd_bwd)
         # Backward: only 1st all-gather and last reduce-scatter are exposed;
         # double the backward compute since computing two gradients per layer
         # NOTE: Do not enforce the expected forward-backward time due to
@@ -210,10 +234,8 @@ class TestFullyShardOverlap(FSDPTest):
 
         run_train_steps(1, False)  # warmup CUDA and allocator
         num_iters = 5
-        baseline_time = self._time_fn(
-            functools.partial(run_train_steps, num_iters, False)
-        )
-        test_time = self._time_fn(functools.partial(run_train_steps, num_iters, True))
+        baseline_time = _time_fn(functools.partial(run_train_steps, num_iters, False))
+        test_time = _time_fn(functools.partial(run_train_steps, num_iters, True))
 
         buffer_ms = 4  # CPU delays and copies
         # Baseline: FSDP all-gather is exposed since the FSDP module waits for
@@ -234,18 +256,6 @@ class TestFullyShardOverlap(FSDPTest):
         # ms, so we relax the baseline check to just that it is greater than
         # the test time rather than the expected test time
         self.assertGreater(baseline_time, test_time)
-
-    def _time_fn(self, fn: Callable):
-        start_event = device_module.Event(enable_timing=True)
-        end_event = device_module.Event(enable_timing=True)
-        dist.barrier()
-        device_module.synchronize()
-        start_event.record()
-        fn()
-        end_event.record()
-        device_module.synchronize()
-        elapsed_time = start_event.elapsed_time(end_event)
-        return elapsed_time
 
 
 class Matmul(torch.autograd.Function):
@@ -276,6 +286,198 @@ class LinearWithSleep(nn.Module):
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         return nn.functional.relu(Matmul.apply(x, self.weight, self.sleep_ms))
+
+
+class DualParamLinearWithSleep(nn.Module):
+    """Module with two weights for testing per-param mesh overlap.
+
+    weight_a and weight_b can be routed to different FSDP param groups
+    via shard_placement_fn.
+    """
+
+    def __init__(self, dim: int, sleep_ms: int):
+        super().__init__()
+        self.weight_a = nn.Parameter(torch.randn((dim, dim)))
+        self.weight_b = nn.Parameter(torch.randn((dim, dim)))
+        self.sleep_ms = sleep_ms
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return nn.functional.relu(
+            Matmul.apply(x, self.weight_a + self.weight_b, self.sleep_ms)
+        )
+
+
+def _make_delayed_reduce_scatter(comm_sleep_ms: int):
+    """Returns a delayed reduce_scatter that sleeps on the current stream."""
+    orig_rs = dist.reduce_scatter_tensor
+
+    def delayed_rs(*args, **kwargs):
+        device_module._sleep(int(comm_sleep_ms * get_cycles_per_ms()))
+        return orig_rs(*args, **kwargs)
+
+    return delayed_rs
+
+
+def _median(times: list[float]) -> float:
+    times = sorted(times)
+    return times[len(times) // 2]
+
+
+@contextlib.contextmanager
+def _separate_ag_pgs(
+    model: nn.Module, world_size: int, ep_degree: int
+) -> None:
+    """Monkey-patch AG to use separate NCCL PGs from RS.
+
+    Within ProcessGroupNCCL, all collectives on the same PG share one NCCL
+    stream.  When we inject a CUDA sleep before the RS to simulate slow
+    communication, that sleep also blocks the AG on the same PG.  Creating
+    fresh PGs for AG gives them their own NCCL streams, so AG and RS can
+    overlap just as they would with real (non-simulated) collectives.
+    """
+    ag_dp_pg = dist.new_group(list(range(world_size)))
+    ag_efsdp_pg = None
+    my_rank = dist.get_rank()
+    for i in range(ep_degree):
+        ranks = list(range(i, world_size, ep_degree))
+        g = dist.new_group(ranks)
+        if my_rank in ranks:
+            ag_efsdp_pg = g
+
+    pg_map: dict[dist.ProcessGroup, dist.ProcessGroup] = {}
+    for mod in model:
+        state = _get_module_fsdp_state(mod)
+        if state is None:
+            continue
+        for param_group in state._fsdp_param_groups:
+            orig_pg = param_group.mesh_info.shard_process_group
+            if orig_pg not in pg_map:
+                pg_map[orig_pg] = (
+                    ag_dp_pg if orig_pg.size() == world_size else ag_efsdp_pg
+                )
+
+    orig_fget = FSDPParamGroup._all_gather_process_group.fget
+
+    @property
+    def _patched_ag_pg(self):
+        orig_pg = orig_fget(self)
+        return pg_map.get(orig_pg, orig_pg)
+
+    FSDPParamGroup._all_gather_process_group = _patched_ag_pg
+    try:
+        yield
+    finally:
+        FSDPParamGroup._all_gather_process_group = property(orig_fget)
+
+
+class TestFullyShardPerParamMeshOverlap(FSDPTest):
+    @property
+    def world_size(self) -> int:
+        return min(8, torch.get_device_module(device_type).device_count())
+
+    @skip_if_rocm_arch_multiprocess(MI200_ARCH)
+    @skip_if_lt_x_gpu(8)
+    @unittest.skipIf(TEST_HPU, "Sleep is not supported on HPU")
+    def test_fully_shard_per_param_mesh_training_overlap(self):
+        """Test per-PG reduce-scatter state for per-param mesh FSDP.
+
+        With per-param mesh, each module has two param groups using different
+        process groups.  Per-PG reduce-scatter state (HEAD) avoids intra-module
+        cross-PG stalls on the compute stream, allowing the RS to overlap with
+        the next module's backward compute.  Shared state (HEAD~1) forces each
+        module's second param group to wait for the first's RS, adding
+        ``comm_sleep`` per module to the critical path.
+
+        We use ``reshard_after_forward=True`` and give AG and RS separate NCCL
+        PGs via ``_separate_ag_pgs`` so the simulated RS delay doesn't also
+        block the backward AG (which would happen if they shared one NCCL
+        stream).
+        """
+        torch.manual_seed(42)
+
+        dim, num_modules = 8, 5
+        compute_sleep_ms, comm_sleep_ms = 100, 50
+        ep_degree = 2
+
+        efsdp_size = self.world_size // ep_degree
+        dp_mesh = init_device_mesh(
+            device_type.type,
+            (self.world_size,),
+            mesh_dim_names=("dp",),
+        )
+        sparse_mesh = dp_mesh._unflatten(
+            0,
+            (efsdp_size, ep_degree),
+            ("efsdp", "ep"),
+        )
+        dp_mesh_info = FSDPMeshInfo(mesh=dp_mesh, shard_mesh_dim=0)
+        efsdp_mesh_info = FSDPMeshInfo(mesh=sparse_mesh["efsdp"], shard_mesh_dim=0)
+
+        model = nn.Sequential(
+            *[
+                DualParamLinearWithSleep(dim, compute_sleep_ms)
+                for _ in range(num_modules)
+            ]
+        )
+
+        for mod in model:
+
+            def _shard_placement_fn(param, _mod=mod):
+                if param is _mod.weight_b:
+                    return ShardPlacementResult(
+                        placement=Shard(0), mesh_info=efsdp_mesh_info
+                    )
+                return ShardPlacementResult(placement=Shard(0), mesh_info=dp_mesh_info)
+
+            fully_shard(
+                mod,
+                mesh=dp_mesh,
+                reshard_after_forward=True,
+                shard_placement_fn=_shard_placement_fn,
+            )
+        fully_shard(model, mesh=dp_mesh, reshard_after_forward=True)
+
+        with _separate_ag_pgs(model, self.world_size, ep_degree):
+            inp = torch.randn((2, dim), device=device_type.type)
+
+            def fwd_bwd():
+                model(inp).sum().backward()
+
+            # Warmup
+            for _ in range(3):
+                fwd_bwd()
+                model.zero_grad()
+
+            # Measure no-delay baseline
+            baseline_times = [_time_fn(fwd_bwd) for _ in range(3)]
+            for _ in range(3):
+                model.zero_grad()
+
+            # Measure with delayed reduce-scatter
+            delayed_rs = _make_delayed_reduce_scatter(comm_sleep_ms)
+            with patch_reduce_scatter(delayed_rs):
+                for _ in range(3):
+                    fwd_bwd()
+                    model.zero_grad()
+                delayed_times = [_time_fn(fwd_bwd) for _ in range(3)]
+                for _ in range(3):
+                    model.zero_grad()
+
+        baseline = _median(baseline_times)
+        delayed = _median(delayed_times)
+        overhead = delayed - baseline
+        # 2 param groups * N modules * comm_sleep = total RS sleep injected
+        total_rs = 2 * num_modules * comm_sleep_ms
+        # With per-PG state the RS overlaps with compute and the overhead
+        # is roughly 2*comm_sleep (the tail of the last module).  With
+        # shared state the intra-module stall adds ~(N-1)*comm_sleep to the
+        # critical path.  The 0.5 threshold sits between these two regimes.
+        self.assertLess(
+            overhead,
+            0.5 * total_rs,
+            f"RS overhead {overhead:.0f}ms >= 50% of total RS {total_rs}ms; "
+            f"per-PG RS state may not be preventing cross-PG stalls",
+        )
 
 
 if __name__ == "__main__":

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_common.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_common.py
@@ -48,6 +48,9 @@ class FSDPMeshInfo(DataParallelMeshInfo):
         self.shard_mesh_size: int = self.mesh.size(self.shard_mesh_dim)
         self.shard_process_group = self.mesh.get_group(self.shard_mesh_dim)
         self.shard_mesh_rank: int = self.shard_process_group.rank()
+        # Separate PG for all-gather so AG and RS use different NCCL streams;
+        # initialized by _init_ag_process_groups() during lazy init
+        self.ag_shard_process_group: dist.ProcessGroup | None = None
 
 
 @dataclass

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
@@ -89,11 +89,14 @@ class FSDPCommContext:
         # since collectives use different network resources and can overlap
         # in the typical intra-node sharding / inter-node replication case
         self.all_reduce_stream = self.device_handle.Stream()
-        # All-gather/reduce-scatter states keep references to collective
-        # tensors produced in one stream and used in another and accompanying
-        # CUDA events for synchronization
+        # All-gather state keeps references to collective tensors produced in
+        # one stream and used in another and accompanying CUDA events
         self.all_gather_state: AllGatherState | None = None
-        self.reduce_scatter_state: ReduceScatterState | None = None
+        # Per-process-group reduce-scatter state so that param groups with
+        # different process groups do not block each other's RS overlap
+        self._pg_to_reduce_scatter_state: dict[
+            dist.ProcessGroup, ReduceScatterState
+        ] = {}
         # Post-forward order for explicit backward prefetching
         self.post_forward_order: list[FSDPParamGroup] = []  # will cause ref cycles
 
@@ -525,14 +528,11 @@ class FSDPParamGroup:
         if len(fsdp_params_with_grad) == 0:
             return
         with record_function(self._with_fqn("FSDP::post_backward_reduce")):
-            if (
-                self.comm_ctx.reduce_scatter_state is not None
-                and self.comm_ctx.reduce_scatter_state.event is not None
-            ):
-                self.device_handle.current_stream().wait_event(
-                    self.comm_ctx.reduce_scatter_state.event
-                )
-            self.comm_ctx.reduce_scatter_state = None
+            rs_pg = self._reduce_scatter_process_group
+            rs_state = self.comm_ctx._pg_to_reduce_scatter_state.get(rs_pg)
+            if rs_state is not None and rs_state.event is not None:
+                self.device_handle.current_stream().wait_event(rs_state.event)
+            self.comm_ctx._pg_to_reduce_scatter_state.pop(rs_pg, None)
             all_reduce_pg = (
                 self._all_reduce_process_group
                 if isinstance(self.mesh_info, DDPMeshInfo)
@@ -584,7 +584,7 @@ class FSDPParamGroup:
                 self._all_reduce_hook,
                 self.force_sum_reduction_for_comms,
             )
-            self.comm_ctx.reduce_scatter_state = ReduceScatterState(
+            self.comm_ctx._pg_to_reduce_scatter_state[rs_pg] = ReduceScatterState(
                 reduce_scatter_input, reduce_scatter_event
             )
             if all_reduce_input is not None:
@@ -768,7 +768,8 @@ class FSDPParamGroup:
             raise AssertionError(
                 f"Expected mesh_info to be FSDPMeshInfo, got {type(mesh_info)}"
             )
-        return mesh_info.shard_process_group
+        ag_pg = mesh_info.ag_shard_process_group
+        return ag_pg if ag_pg is not None else mesh_info.shard_process_group
 
     @property
     def _reduce_scatter_process_group(self) -> dist.ProcessGroup:

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_state.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_state.py
@@ -6,6 +6,7 @@ from collections.abc import Callable, Sequence
 from typing import Any, Generic, TYPE_CHECKING, TypeVar
 
 import torch
+import torch.distributed as dist
 import torch.nn as nn
 from torch._logging import warning_once
 from torch.autograd import Variable
@@ -20,7 +21,7 @@ from torch.distributed.fsdp._common_utils import collect_grad_tensors
 from torch.distributed.utils import _apply_to_tensors, _to_kwargs
 
 from ._fsdp_api import MixedPrecisionPolicy
-from ._fsdp_common import _cast_fp_tensor, _dynamo_disable, TrainingState
+from ._fsdp_common import _cast_fp_tensor, _dynamo_disable, FSDPMeshInfo, TrainingState
 from ._fsdp_param_group import FSDPCommContext, FSDPParamGroup
 
 
@@ -200,6 +201,7 @@ class FSDPState(_State):
                 fsdp_param_group.post_forward_mesh_info = None
         self._init_fqns()
         self._init_shared_state()
+        self._init_ag_process_groups()
         # Run parameter group lazy inits after initializing FQNs for improved
         # error messages
         for state in self._state_ctx.all_states:
@@ -213,6 +215,49 @@ class FSDPState(_State):
             state._comm_ctx = self._comm_ctx
             for fsdp_param_group in state._fsdp_param_groups:
                 fsdp_param_group.comm_ctx = self._comm_ctx
+
+    def _init_ag_process_groups(self) -> None:
+        """Create separate PGs for all-gather so AG and RS use different NCCL
+        streams, allowing them to overlap."""
+        # Collect unique shard PGs and their associated FSDPMeshInfos
+        pg_to_mesh_infos: dict[dist.ProcessGroup, list[FSDPMeshInfo]] = {}
+        for state in self._state_ctx.all_states:
+            for param_group in state._fsdp_param_groups:
+                for mi in (param_group.mesh_info, param_group.post_forward_mesh_info):
+                    if not isinstance(mi, FSDPMeshInfo):
+                        continue
+                    pg = mi.shard_process_group
+                    if pg not in pg_to_mesh_infos:
+                        pg_to_mesh_infos[pg] = []
+                    if mi not in pg_to_mesh_infos[pg]:
+                        pg_to_mesh_infos[pg].append(mi)
+        if not pg_to_mesh_infos:
+            return
+
+        # Different ranks may have different submesh PGs (e.g. efsdp
+        # [0,2,4,6] vs [1,3,5,7]).  Discover ALL rank sets so that every
+        # rank calls dist.new_group with the same args in the same order.
+        local_rank_sets = [
+            tuple(sorted(dist.get_process_group_ranks(pg)))
+            for pg in pg_to_mesh_infos
+        ]
+        gathered: list[object] = [None] * dist.get_world_size()
+        dist.all_gather_object(gathered, local_rank_sets)
+        all_rank_sets: set[tuple[int, ...]] = set()
+        for rs in gathered:
+            all_rank_sets.update(rs)  # type: ignore[arg-type]
+
+        # Create duplicate PGs in deterministic order (sorted rank tuples)
+        ranks_to_ag_pg: dict[tuple[int, ...], dist.ProcessGroup] = {}
+        for ranks in sorted(all_rank_sets):
+            ranks_to_ag_pg[ranks] = dist.new_group(list(ranks))
+
+        # Assign the new AG PGs to the corresponding mesh_infos
+        for pg, mesh_infos in pg_to_mesh_infos.items():
+            ranks = tuple(sorted(dist.get_process_group_ranks(pg)))
+            ag_pg = ranks_to_ag_pg[ranks]
+            for mi in mesh_infos:
+                mi.ag_shard_process_group = ag_pg
 
     def _init_fqns(self) -> None:
         """Sets module and parameter FQN attributes for debugging."""
@@ -337,11 +382,10 @@ class FSDPState(_State):
                     state._finalize_backward()
             if self._state_ctx.is_last_backward:
                 self._comm_ctx.post_forward_order.clear()
-                if self._comm_ctx.reduce_scatter_state is not None:
-                    self._device_handle.current_stream().wait_event(
-                        self._comm_ctx.reduce_scatter_state.event
-                    )
-                    self._comm_ctx.reduce_scatter_state = None
+                for rs_state in self._comm_ctx._pg_to_reduce_scatter_state.values():
+                    if rs_state.event is not None:
+                        self._device_handle.current_stream().wait_event(rs_state.event)
+                self._comm_ctx._pg_to_reduce_scatter_state.clear()
             self._state_ctx.post_backward_final_callback_queued = False
 
     def _finalize_backward(self) -> None:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #176945
* #176140

Add tests to verify that FSDP with per-param mesh (shard_placement_fn routing
different parameters to different process groups) works correctly:

- TestFullyShardPerParamMeshMemory: verifies that per-PG reduce-scatter state
  does not leak memory across training steps (warm up, then assert no growth).

- TestFullyShardPerParamMeshOverlap: verifies that AG/RS overlap with compute
  by comparing FSDP (overlapped) against a sequential reference where dummy
  collectives and compute run serially.

Both tests use 8 GPUs with a dp_mesh of shape (8,) and an unflatten to
(efsdp=4, ep=2), routing weight_b to the efsdp mesh and weight_a to the
full dp mesh.

Also refactors _time_fn and _make_delayed_collectives to module-level shared
helpers in test_fully_shard_overlap.py.

Authored with Claude.