### PR TITLE
Revert "[fx] Fix quadratic name generation in _NamespaceBase.create_name (#176515)"

### DIFF
--- a/torch/csrc/fx/graph.cpp
+++ b/torch/csrc/fx/graph.cpp
@@ -228,12 +228,8 @@ static PyObject* NamespaceBase_create_name(
   }
 
   if (!has_num || in_used_names) {
-    // num = self._base_count.get(base, 0)
-    THPObjectPtr base_key_lookup(PyUnicode_FromString(base.c_str()));
-    if (!base_key_lookup) {
-      return nullptr;
-    }
-    PyObject* count_obj = PyDict_GetItem(ns->base_count, base_key_lookup.get());
+    // num = self._base_count.get(candidate, 0)
+    PyObject* count_obj = PyDict_GetItem(ns->base_count, candidate_py.get());
     if (count_obj) {
       num = PyLong_AsLongLong(count_obj);
       if (num == -1 && PyErr_Occurred()) {


### PR DESCRIPTION
## Summary
Reverts #176515.

This is a prerequisite for reverting the full `[fx] Move _Namespace to C++` series (#170962), which was reverted internally due to S627920 but the revert was never exported to GitHub.

The quadratic fix patches `torch/csrc/fx/graph.cpp` which was introduced by #170962. This revert must land first so that #170962 can be cleanly reverted afterwards.

cc @jansel @anijain2305

## Test plan
CI — this revert removes a bugfix from C++ code that will itself be reverted in a follow-up PR.