### PR TITLE
Tiny typo fix in the ATen native README.md

### DIFF
--- a/aten/src/ATen/native/README.md
+++ b/aten/src/ATen/native/README.md
@@ -5,7 +5,7 @@ in one of the `cpp` files in this directory.
 
 Like all ATen methods/functions, native functions are made available
 from both ATen's C++ and Python APIs.  In C++, they are made available
-either as methods on `Tensor` (`t.mymeth()`) and functions in the ATen
+either as methods on `Tensor` (`t.mymeth()`) or as functions in the ATen
 namespace (`at::myfunc()`).  In PyTorch, they are made available as
 methods on `Variable` or as functions on `torch._C._FunctionBase`.
 (It is the user's responsibility to re-export these functions in


### PR DESCRIPTION
Tiny fix for a typo in the ATen native README.md