### PR TITLE
Skip storage memo for wrapper subclasses in MetaConverter to fix cross-device error

### DIFF
--- a/test/dynamo/test_subclasses.py
+++ b/test/dynamo/test_subclasses.py
@@ -3755,6 +3755,76 @@ class TestIssubclass(torch._dynamo.test_case.TestCase):
         ):
             fn(torch.randn(3))
 
+    def test_wrapper_subclass_vmap_compile(self):
+        class TransparentTensor(torch.Tensor):
+            __torch_function__ = torch._C._disabled_torch_function_impl
+
+            @staticmethod
+            def __new__(cls, data):
+                if isinstance(data, cls):
+                    return data
+                if not isinstance(data, torch.Tensor):
+                    data = torch.as_tensor(data)
+                kwargs = {}
+                if data.layout == torch.strided:
+                    kwargs["strides"] = data.stride()
+                    kwargs["storage_offset"] = data.storage_offset()
+                r = torch.Tensor._make_wrapper_subclass(
+                    cls,
+                    data.shape,
+                    dtype=data.dtype,
+                    layout=data.layout,
+                    device=data.device,
+                    requires_grad=data.requires_grad,
+                    **kwargs,
+                )
+                r._data = data
+                return r
+
+            def __tensor_flatten__(self):
+                return ["_data"], {}
+
+            @classmethod
+            def __tensor_unflatten__(
+                cls, inner_tensors, metadata, outer_size, outer_stride
+            ):
+                return cls(inner_tensors["_data"])
+
+            @classmethod
+            def __torch_dispatch__(cls, func, types, args=(), kwargs=None):
+                if kwargs is None:
+                    kwargs = {}
+
+                def unwrap(x):
+                    if isinstance(x, TransparentTensor):
+                        return x._data
+                    if isinstance(x, (list, tuple)):
+                        return type(x)(unwrap(a) for a in x)
+                    return x
+
+                result = func(*unwrap(args), **unwrap(kwargs))
+                if isinstance(result, torch.Tensor):
+                    return cls(result)
+                if isinstance(result, (tuple, list)):
+                    return type(result)(
+                        cls(r) if isinstance(r, torch.Tensor) else r for r in result
+                    )
+                return result
+
+        def fn(x, tag):
+            return x + tag
+
+        vmapped = torch.vmap(fn, in_dims=(0, None))
+
+        x = torch.randn(8, 4)
+        tag = TransparentTensor(torch.tensor([1.0, 2.0, 3.0, 4.0]))
+
+        result_eager = vmapped(x, tag)
+
+        compiled = torch.compile(vmapped, backend="eager", fullgraph=True)
+        result_compiled = compiled(x, tag)
+        self.assertEqual(result_eager, result_compiled)
+
 
 class TestNestedTensor(
     _SubclassCompileCheckMixin,

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -506,7 +506,6 @@ class FakeTensorTest(TestCase):
         fake_t = mode.from_tensor(t)
         self.assertEqual(fake_t.requires_grad, t.requires_grad)
 
-    @expectedFailurePropagateRealTensors
     def test_non_parameter_grad_tensor_subclass_stateful_context(self):
         mode = FakeTensorMode(shape_env=ShapeEnv())
         t = torch.ones(2, requires_grad=True)

--- a/torch/_subclasses/meta_utils.py
+++ b/torch/_subclasses/meta_utils.py
@@ -2097,150 +2097,154 @@ class MetaConverter(Generic[_TensorT]):
                             # pyrefly: ignore [bad-argument-type]
                             r = self._backward_error(r)
 
-                    s = t.storage
-                    if s is None:
-                        raise AssertionError("t.storage must not be None")
-                    from torch.fx.experimental.symbolic_shapes import (
-                        guard_or_false,
-                        sym_eq,
-                    )
-
-                    storage_needs_resize = False
-                    source_storage_size = s.size
-                    source_storage_is_zero = (
-                        isinstance(source_storage_size, int)
-                        and source_storage_size == 0
-                    )
-                    if not r.is_nested:
-                        r_storage = r.untyped_storage()
-                        r_storage_size = r_storage.size()
-                        if isinstance(r_storage_size, int) and isinstance(
-                            source_storage_size, int
-                        ):
-                            storage_needs_resize = (
-                                source_storage_size != 0
-                                and r_storage_size < source_storage_size
-                            )
-                    if s.id not in self.storage_memo and (
-                        r.is_nested
-                        or (
-                            guard_or_false(sym_eq(r.stride(), strides))
-                            and guard_or_false(r.storage_offset() == storage_offset)
+                    # Storage aliasing for traceable wrapper subclasses is tracked
+                    # through their inner tensors. Memoizing the wrapper placeholder
+                    # storage can later force a cross-device set_ on the wrapper.
+                    if not t.is_traceable_wrapper_subclass:
+                        s = t.storage
+                        if s is None:
+                            raise AssertionError("t.storage must not be None")
+                        from torch.fx.experimental.symbolic_shapes import (
+                            guard_or_false,
+                            sym_eq,
                         )
-                    ):
+
+                        storage_needs_resize = False
+                        source_storage_size = s.size
+                        source_storage_is_zero = (
+                            isinstance(source_storage_size, int)
+                            and source_storage_size == 0
+                        )
                         if not r.is_nested:
-                            # The freshly allocated tensor storage can stand in
-                            # for the source storage only if it covers the whole
-                            # storage. Parameters made from views are not
-                            # autograd views, but can still share a larger
-                            # storage with later parameters. Leave symbolic
-                            # sizes alone; this preserves the fast path for
-                            # dynamic inputs without adding storage-size guards.
-                            # Zero-sized source storages are handled by the
-                            # resize_(0) below.
-                            if storage_needs_resize:
-                                r.untyped_storage().resize_(s.size)
-                        # You're normal and happy, install the fresh storage into the memo
-                        self.set_storage_memo(s, r.untyped_storage())
-                        if self.copy_data:
-                            if not _is_fake_tensor(r):
-                                raise AssertionError("Expected r to be a FakeTensor")
-                            if r.real_tensor is None:
-                                raise AssertionError(
-                                    "r.real_tensor must not be None when copy_data is True"
+                            r_storage = r.untyped_storage()
+                            r_storage_size = r_storage.size()
+                            if isinstance(r_storage_size, int) and isinstance(
+                                source_storage_size, int
+                            ):
+                                storage_needs_resize = (
+                                    source_storage_size != 0
+                                    and r_storage_size < source_storage_size
                                 )
-                            if source_storage_is_zero:
-                                _set_real_storage(
-                                    r.untyped_storage(),
-                                    r.real_tensor.untyped_storage(),
-                                )
-                            else:
-                                if t.size is None:
-                                    raise AssertionError(
-                                        "t.size must not be None when copy_data is True"
-                                    )
-                                if t.stride is None:
-                                    raise AssertionError(
-                                        "t.stride must not be None when copy_data is True"
-                                    )
-                                if t.data is None:
-                                    raise AssertionError(
-                                        "t.data must not be None when copy_data is True"
-                                    )
-                                with torch.no_grad(), no_dispatch():
-                                    real_storage = _clone_real_storage_from_tensor(
-                                        t.data
-                                    )
-                                    _set_real_storage(r.untyped_storage(), real_storage)
-                                    r.real_tensor.set_(
-                                        real_storage,
-                                        t.storage_offset,
-                                        t.size,
-                                        t.stride,
-                                    )
-                    else:
-                        # You're in crazy town; somehow you gave us a tensor
-                        # that wasn't a view, but had nonzero storage offset,
-                        # nontrivial strides (such that clone() couldn't
-                        # preserve them), or already aliases with another
-                        # tensor's storage.  The most typical way to end
-                        # up here is with set_.  So use set_ to bludgeon this
-                        # in.
-                        r_s = self.meta_storage(s, callback=callback)
-                        # NB: In principle, this should always work, but there
-                        # is some subtle difference in the autograd metadata
-                        # that means we will backprop the set_ call, even if
-                        # r is declared as an input to grad.
-                        # See https://github.com/pytorch/pytorch/issues/87956
-                        # for the reproducer.
-                        # NB: The in_kernel_invocation_manager here is necessary
-                        # for fake tensor.  If we run the set_ call with fake
-                        # tensor on, r will improperly report that it is NOT a
-                        # meta tensor but a cpu tensor, and then the set_ call
-                        # will fail due to device mismatch.  no_dispatch() is
-                        # not enough, because the fake tensor will still claim
-                        # to be a CPU tensor and you'll end up in the CPU
-                        # kernel.  Arguably this is a hack; a cleaner way to
-                        # solve this is to have a FakeStorage concept which
-                        # would report it's CPU device--no problem now!  But
-                        # this is difficult to do because we don't have storage
-                        # subclasses.  Relevant test is
-                        # DynamicShapesFunctionTests::test_add_dynamic_shapes in
-                        # test/dynamo/test_dynamic_shapes.py
-                        maybe_fake_mgr: AbstractContextManager[None] = (
-                            contextlib.nullcontext()
-                        )
-                        from torch._subclasses.fake_tensor import (
-                            in_kernel_invocation_manager,
-                            maybe_get_fake_mode,
-                        )
-
-                        mb_fake_mode = maybe_get_fake_mode(r)
-                        if mb_fake_mode is not None:
-                            maybe_fake_mgr = in_kernel_invocation_manager(mb_fake_mode)
-                        with torch.no_grad(), maybe_suppress():
-                            with maybe_fake_mgr:
-                                r.set_(r_s, storage_offset, sizes, strides)
+                        if s.id not in self.storage_memo and (
+                            r.is_nested
+                            or (
+                                guard_or_false(sym_eq(r.stride(), strides))
+                                and guard_or_false(r.storage_offset() == storage_offset)
+                            )
+                        ):
+                            if not r.is_nested:
+                                # The freshly allocated tensor storage can stand in
+                                # for the source storage only if it covers the whole
+                                # storage. Parameters made from views are not
+                                # autograd views, but can still share a larger
+                                # storage with later parameters. Leave symbolic
+                                # sizes alone; this preserves the fast path for
+                                # dynamic inputs without adding storage-size guards.
+                                # Zero-sized source storages are handled by the
+                                # resize_(0) below.
+                                if storage_needs_resize:
+                                    r.untyped_storage().resize_(s.size)
+                            # You're normal and happy, install the fresh storage into the memo
+                            self.set_storage_memo(s, r.untyped_storage())
                             if self.copy_data:
-                                with torch.no_grad(), no_dispatch():
-                                    if not _is_fake_tensor(r):
+                                if not _is_fake_tensor(r):
+                                    raise AssertionError("Expected r to be a FakeTensor")
+                                if r.real_tensor is None:
+                                    raise AssertionError(
+                                        "r.real_tensor must not be None when copy_data is True"
+                                    )
+                                if source_storage_is_zero:
+                                    _set_real_storage(
+                                        r.untyped_storage(),
+                                        r.real_tensor.untyped_storage(),
+                                    )
+                                else:
+                                    if t.size is None:
                                         raise AssertionError(
-                                            "Expected r to be a FakeTensor"
-                                        )
-                                    if r.real_tensor is None:
-                                        raise AssertionError(
-                                            "r.real_tensor must not be None when copy_data is True"
+                                            "t.size must not be None when copy_data is True"
                                         )
                                     if t.stride is None:
                                         raise AssertionError(
                                             "t.stride must not be None when copy_data is True"
                                         )
-                                    r.real_tensor.set_(
-                                        _get_real_storage(r_s),
-                                        t.storage_offset,
-                                        t.size,
-                                        t.stride,
-                                    )
+                                    if t.data is None:
+                                        raise AssertionError(
+                                            "t.data must not be None when copy_data is True"
+                                        )
+                                    with torch.no_grad(), no_dispatch():
+                                        real_storage = _clone_real_storage_from_tensor(
+                                            t.data
+                                        )
+                                        _set_real_storage(r.untyped_storage(), real_storage)
+                                        r.real_tensor.set_(
+                                            real_storage,
+                                            t.storage_offset,
+                                            t.size,
+                                            t.stride,
+                                        )
+                        else:
+                            # You're in crazy town; somehow you gave us a tensor
+                            # that wasn't a view, but had nonzero storage offset,
+                            # nontrivial strides (such that clone() couldn't
+                            # preserve them), or already aliases with another
+                            # tensor's storage.  The most typical way to end
+                            # up here is with set_.  So use set_ to bludgeon this
+                            # in.
+                            r_s = self.meta_storage(s, callback=callback)
+                            # NB: In principle, this should always work, but there
+                            # is some subtle difference in the autograd metadata
+                            # that means we will backprop the set_ call, even if
+                            # r is declared as an input to grad.
+                            # See https://github.com/pytorch/pytorch/issues/87956
+                            # for the reproducer.
+                            # NB: The in_kernel_invocation_manager here is necessary
+                            # for fake tensor.  If we run the set_ call with fake
+                            # tensor on, r will improperly report that it is NOT a
+                            # meta tensor but a cpu tensor, and then the set_ call
+                            # will fail due to device mismatch.  no_dispatch() is
+                            # not enough, because the fake tensor will still claim
+                            # to be a CPU tensor and you'll end up in the CPU
+                            # kernel.  Arguably this is a hack; a cleaner way to
+                            # solve this is to have a FakeStorage concept which
+                            # would report it's CPU device--no problem now!  But
+                            # this is difficult to do because we don't have storage
+                            # subclasses.  Relevant test is
+                            # DynamicShapesFunctionTests::test_add_dynamic_shapes in
+                            # test/dynamo/test_dynamic_shapes.py
+                            maybe_fake_mgr: AbstractContextManager[None] = (
+                                contextlib.nullcontext()
+                            )
+                            from torch._subclasses.fake_tensor import (
+                                in_kernel_invocation_manager,
+                                maybe_get_fake_mode,
+                            )
+
+                            mb_fake_mode = maybe_get_fake_mode(r)
+                            if mb_fake_mode is not None:
+                                maybe_fake_mgr = in_kernel_invocation_manager(mb_fake_mode)
+                            with torch.no_grad(), maybe_suppress():
+                                with maybe_fake_mgr:
+                                    r.set_(r_s, storage_offset, sizes, strides)
+                                if self.copy_data:
+                                    with torch.no_grad(), no_dispatch():
+                                        if not _is_fake_tensor(r):
+                                            raise AssertionError(
+                                                "Expected r to be a FakeTensor"
+                                            )
+                                        if r.real_tensor is None:
+                                            raise AssertionError(
+                                                "r.real_tensor must not be None when copy_data is True"
+                                            )
+                                        if t.stride is None:
+                                            raise AssertionError(
+                                                "t.stride must not be None when copy_data is True"
+                                            )
+                                        r.real_tensor.set_(
+                                            _get_real_storage(r_s),
+                                            t.storage_offset,
+                                            t.size,
+                                            t.stride,
+                                        )
 
                 if t.grad is not None:
                     from torch._dynamo.source import AttrSource

--- a/torch/_subclasses/meta_utils.py
+++ b/torch/_subclasses/meta_utils.py
@@ -2148,7 +2148,9 @@ class MetaConverter(Generic[_TensorT]):
                             self.set_storage_memo(s, r.untyped_storage())
                             if self.copy_data:
                                 if not _is_fake_tensor(r):
-                                    raise AssertionError("Expected r to be a FakeTensor")
+                                    raise AssertionError(
+                                        "Expected r to be a FakeTensor"
+                                    )
                                 if r.real_tensor is None:
                                     raise AssertionError(
                                         "r.real_tensor must not be None when copy_data is True"
@@ -2175,7 +2177,9 @@ class MetaConverter(Generic[_TensorT]):
                                         real_storage = _clone_real_storage_from_tensor(
                                             t.data
                                         )
-                                        _set_real_storage(r.untyped_storage(), real_storage)
+                                        _set_real_storage(
+                                            r.untyped_storage(), real_storage
+                                        )
                                         r.real_tensor.set_(
                                             real_storage,
                                             t.storage_offset,
@@ -2221,7 +2225,9 @@ class MetaConverter(Generic[_TensorT]):
 
                             mb_fake_mode = maybe_get_fake_mode(r)
                             if mb_fake_mode is not None:
-                                maybe_fake_mgr = in_kernel_invocation_manager(mb_fake_mode)
+                                maybe_fake_mgr = in_kernel_invocation_manager(
+                                    mb_fake_mode
+                                )
                             with torch.no_grad(), maybe_suppress():
                                 with maybe_fake_mgr:
                                     r.set_(r_s, storage_offset, sizes, strides)


### PR DESCRIPTION
## Summary

Fixes #176957

`_make_wrapper_subclass` tensor subclasses crash with a cross-device storage error when used as non-batched inputs to `torch.vmap` inside `torch.compile`:

```
RuntimeError: Attempted to set the storage of a tensor on device "cuda:0"
to a storage on different device "meta"
```

The root cause is in `MetaConverter.meta_tensor()`. When Dynamo creates fake tensors for a wrapper subclass, `__tensor_unflatten__` calls `_make_wrapper_subclass`, which creates a placeholder storage with a null `DataPtr` but the *original device* (e.g. `cuda:0`) and a meta allocator. This storage gets entered into the `MetaConverter` storage memo.

When vmap later processes the same tensor (e.g. `unsqueeze(0).expand()` for non-batched inputs), the storage ID is already in the memo, so the code falls into the "crazy town" fallback path which calls `r.set_(meta_storage, ...)`. This `set_()` runs inside `in_kernel_invocation_manager`, which disables `__torch_dispatch__`, so it dispatches directly to the C++ kernel. That kernel checks device compatibility between the tensor (`cuda:0`) and the new storage (`meta`), and raises the cross-device error.

The fix guards the entire storage memo block with `if not t.is_traceable_wrapper_subclass`. This is safe because:

- Wrapper subclass storages are independent placeholders (null data pointer, meta allocator) created per instance by `_make_wrapper_subclass` — they never alias with other tensors' storages.
- Real storage aliasing for subclasses is tracked at the inner-tensor level via `__tensor_flatten__`, where each inner tensor goes through `MetaConverter` independently with its own storage memo handling.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98