### PR TITLE
Use insertion order instead of sorted order in Optimizer.__repr__

### DIFF
--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -1452,6 +1452,18 @@ class TestOptimRenewed(TestCase):
             optimizer = optim_cls(params, **optim_input.kwargs)
             optimizer.__repr__()
 
+    def test_repr_key_order(self):
+        param = Parameter(torch.randn(2, 3))
+        optimizer = SGD([param], lr=0.1)
+        repr_str = repr(optimizer)
+        keys = [
+            line.split(":")[0].strip()
+            for line in repr_str.splitlines()
+            if ":" in line and "Parameter Group" not in line
+        ]
+        group_keys = [k for k in optimizer.param_groups[0] if k != "params"]
+        self.assertEqual(keys, group_keys)
+
     @parametrize("is_named_optim0", [True, False])
     @parametrize("is_named_optim1", [True, False])
     @optims(optim_db, dtypes=[torch.float32])

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -1452,17 +1452,26 @@ class TestOptimRenewed(TestCase):
             optimizer = optim_cls(params, **optim_input.kwargs)
             optimizer.__repr__()
 
-    def test_repr_key_order(self):
-        param = Parameter(torch.randn(2, 3))
-        optimizer = SGD([param], lr=0.1)
-        repr_str = repr(optimizer)
-        keys = [
-            line.split(":")[0].strip()
-            for line in repr_str.splitlines()
-            if ":" in line and "Parameter Group" not in line
+    @optims(optim_db, dtypes=[torch.float32])
+    def test_repr_key_order(self, device, dtype, optim_info):
+        optim_cls = optim_info.optim_cls
+        all_optim_inputs = _get_optim_inputs_including_global_cliquey_kwargs(
+            device, dtype, optim_info
+        )
+        params = [
+            Parameter(torch.randn(2, 3, requires_grad=True, device=device, dtype=dtype))
+            for _ in range(2)
         ]
-        group_keys = [k for k in optimizer.param_groups[0] if k != "params"]
-        self.assertEqual(keys, group_keys)
+        for optim_input in all_optim_inputs:
+            optimizer = optim_cls(params, **optim_input.kwargs)
+            repr_str = repr(optimizer)
+            keys = [
+                line.split(":")[0].strip()
+                for line in repr_str.splitlines()
+                if ":" in line and "Parameter Group" not in line
+            ]
+            group_keys = [k for k in optimizer.param_groups[0] if k != "params"]
+            self.assertEqual(keys, group_keys)
 
     @parametrize("is_named_optim0", [True, False])
     @parametrize("is_named_optim1", [True, False])

--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -438,7 +438,7 @@ class Optimizer:
         for i, group in enumerate(self.param_groups):
             format_string += "\n"
             format_string += f"Parameter Group {i}\n"
-            for key in sorted(group.keys()):
+            for key in group:
                 if key != "params":
                     format_string += f"    {key}: {group[key]}\n"
         format_string += ")"


### PR DESCRIPTION
## Summary
- Replace `sorted()` with insertion-order iteration in `Optimizer.__repr__`
- Keys now appear in the order defined by each optimizer's `defaults` dict (e.g., `lr, momentum, dampening, ...` for SGD) rather than alphabetical order
- Add generic test verifying repr key order matches param_group insertion order across all optimizers

## Motivation
Fixes #169170

The current implementation sorts `param_group` keys alphabetically on every `__repr__` call. Since Python 3.7+ dicts maintain insertion order, this produces a less readable output — keys appear in arbitrary alphabetical order rather than the logical order chosen by the optimizer author (typically most important parameters first).

**Note: This is a BC-breaking change to the repr string output.** The key ordering changes from alphabetical to insertion order. `repr()` stability is not guaranteed, but anyone with snapshot tests against optimizer repr will see a diff. The tradeoff is improved readability: parameters appear in the order they were defined by the optimizer, which better matches how users think about them.

## Changes
- `torch/optim/optimizer.py`: Replace `for key in sorted(group.keys())` with `for key in group`
- `test/test_optim.py`: Add `test_repr_key_order` using `@optims` decorator to verify key ordering across all optimizers

## Test Plan
- `python test/test_optim.py TestOptimRenewed.test_repr_key_order_cpu_float32 -v` — new test across all optimizers
- `python test/test_optim.py TestOptimRenewed.test_optimizer_can_be_printed_cpu_float32 -v` — existing test passes

cc @albanD @janeyx99