### PR TITLE
[DTensor] Register sharding strategy for aten.detach_.default

### DIFF
--- a/test/distributed/tensor/test_tensor_ops.py
+++ b/test/distributed/tensor/test_tensor_ops.py
@@ -60,12 +60,16 @@ class DistTensorOpsTest(DTensorContinuousTestBase):
     def test_detach_(self):
         device_mesh = self.build_device_mesh()
         shard_spec = [Shard(0)]
+        comm_mode = CommDebugMode()
 
         tensor_to_detach = torch.randn(12, 8, requires_grad=True)
         mat = distribute_tensor(tensor_to_detach, device_mesh, shard_spec)
         self.assertTrue(mat.requires_grad)
-        mat.detach_()
+        with comm_mode:
+            mat.detach_()
+            self.assertEqual(comm_mode.get_total_counts(), 0)
         self.assertFalse(mat.requires_grad)
+        self.assertEqual(mat.placements, tuple(shard_spec))
 
     def test_clone(self):
         device_mesh = self.build_device_mesh()

--- a/test/distributed/tensor/test_tensor_ops.py
+++ b/test/distributed/tensor/test_tensor_ops.py
@@ -57,6 +57,16 @@ class DistTensorOpsTest(DTensorContinuousTestBase):
         detached_mat = mat.detach()
         self.assertFalse(detached_mat is mat)
 
+    def test_detach_(self):
+        device_mesh = self.build_device_mesh()
+        shard_spec = [Shard(0)]
+
+        tensor_to_detach = torch.randn(12, 8, requires_grad=True)
+        mat = distribute_tensor(tensor_to_detach, device_mesh, shard_spec)
+        self.assertTrue(mat.requires_grad)
+        mat.detach_()
+        self.assertFalse(mat.requires_grad)
+
     def test_clone(self):
         device_mesh = self.build_device_mesh()
         specs = [[Replicate()], [Shard(0)]]

--- a/torch/distributed/tensor/_ops/_tensor_ops.py
+++ b/torch/distributed/tensor/_ops/_tensor_ops.py
@@ -90,6 +90,7 @@ register_op_strategy(
         aten.clone.default,
         aten.contiguous.default,
         aten.detach.default,
+        aten.detach_.default,
         aten.alias.default,
         aten.fill_.Scalar,
         aten.view.dtype,


### PR DESCRIPTION
## Summary
- Register `aten.detach_.default` with `propagate_single_input_strategy`, alongside the existing `aten.detach.default`
- Add unit test for `detach_()` on a sharded DTensor

## Motivation
Fixes #167917

Calling `detach_()` on a DTensor currently raises `NotImplementedError: Operator aten.detach_.default does not have a sharding strategy registered`. The inplace `detach_` has the same sharding semantics as the out-of-place `detach` — the output placement should match the input — so it belongs in the same `propagate_single_input_strategy` registration group.

## Test Plan
- `python test/distributed/tensor/test_tensor_ops.py DistTensorOpsTest.test_detach_ -v`
- Existing `test_detach` continues to pass

cc @wanchaol @wconstab