### PR TITLE
[dynamo] Fix incorrect output with torch.Size dict keys containing TensorVariable

### DIFF
--- a/test/dynamo/test_dicts.py
+++ b/test/dynamo/test_dicts.py
@@ -2310,6 +2310,60 @@ class DunderDictVariableTests(torch._dynamo.test_case.TestCase):
         result = fn(obj)
         self.assertEqual(result, [("a", 1), ("b", 2), ("c", 3)])
 
+    def test_dict_torch_size_dynamic_key(self):
+        import torch
+        import torch.nn as nn
+
+        class DynamicShapeModel(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.layer_configs = {
+                    torch.Size([32, 64]): nn.Linear(32, 64),
+                    torch.Size([64, 128]): nn.Linear(64, 128),
+                    torch.Size([128, 256]): nn.Linear(128, 256),
+                }
+                self.activation_functions = {
+                    torch.Size([32]): nn.ReLU(),
+                    torch.Size([64]): nn.Tanh(),
+                    torch.Size([128]): nn.Sigmoid(),
+                }
+
+            def forward(self, x):
+                current_shape = torch.tensor(x.shape[1:])
+                shape_key = torch.Size([current_shape[0], 64])
+                if shape_key in self.layer_configs:
+                    x = self.layer_configs[shape_key](x)
+
+                activation_shape = torch.Size([x.shape[1]])
+                if activation_shape in self.activation_functions:
+                    x = self.activation_functions[activation_shape](x)
+                return x
+
+        model = DynamicShapeModel().eval()
+
+        for features in [32, 64, 128]:
+            x = torch.randn(4, features)
+            eager_out = model(x)
+
+            torch._dynamo.reset()
+            compiled_model = torch.compile(model, backend="eager")
+            with torch.no_grad():
+                compiled_out = compiled_model(x)
+
+            self.assertEqual(eager_out.shape, compiled_out.shape)
+            self.assertTrue(torch.allclose(eager_out, compiled_out, atol=1e-6))
+
+        x = torch.randn(4, 16)
+        eager_out = model(x)
+
+        torch._dynamo.reset()
+        compiled_model = torch.compile(model, backend="eager")
+        with torch.no_grad():
+            compiled_out = compiled_model(x)
+
+        self.assertEqual(eager_out.shape, compiled_out.shape)
+        self.assertEqual(compiled_out.shape, torch.Size([4, 16]))
+
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/torch/_dynamo/variables/dicts.py
+++ b/torch/_dynamo/variables/dicts.py
@@ -25,6 +25,7 @@ import types
 from collections.abc import Callable, Iterable, Iterator, Sequence
 from typing import Any, Literal, Optional, TYPE_CHECKING, Union
 
+import torch
 from torch.utils._ordered_set import OrderedSet
 from torch.utils._pytree import MappingKey
 
@@ -267,11 +268,24 @@ class ConstDictVariable(VariableTracker):
     def __contains__(self, vt: VariableTracker) -> bool:
         assert isinstance(vt, VariableTracker)
         Hashable = ConstDictVariable._HashableTracker
-        return (
-            vt.is_python_hashable()
-            and Hashable(vt) in self.items
-            and not isinstance(self.items[Hashable(vt)], variables.DeletedVariable)
-        )
+        if not vt.is_python_hashable():
+            return False
+        if Hashable(vt) in self.items and not isinstance(
+            self.items[Hashable(vt)], variables.DeletedVariable
+        ):
+            return True
+        if vt.is_python_constant():
+            try:
+                const_vt = VariableTracker.build(
+                    None, vt.as_python_constant()
+                )
+                if const_vt.is_python_hashable() and Hashable(const_vt) in self.items:
+                    return not isinstance(
+                        self.items[Hashable(const_vt)], variables.DeletedVariable
+                    )
+            except Exception:
+                pass
+        return False
 
     def call_tree_map_branch(
         self,
@@ -773,12 +787,35 @@ class ConstDictVariable(VariableTracker):
                     f"{len(args)} args and {len(kwargs)} kwargs",
                 )
 
-            arg_hashable = args and is_hashable(args[0])
-            if not arg_hashable:
-                raise_unhashable(args[0], tx)
+            from .lists import SizeVariable
+            from .tensor import TensorVariable
 
-            self.install_dict_contains_guard(tx, args)
-            contains = args[0] in self
+            key = args[0]
+            if isinstance(key, SizeVariable) and key not in self:
+                try:
+                    resolved_items = []
+                    for item in key.items:
+                        if item.is_python_constant():
+                            resolved_items.append(item.as_python_constant())
+                        elif isinstance(item, TensorVariable):
+                            example = item.as_proxy().node.meta.get("example_value", None)
+                            if example is not None:
+                                resolved_items.append(example.item())
+                            else:
+                                raise NotImplementedError
+                        else:
+                            raise NotImplementedError
+                    const_key = torch.Size(resolved_items)
+                    key = VariableTracker.build(tx, const_key)
+                except (NotImplementedError, RuntimeError):
+                    pass
+
+            arg_hashable = is_hashable(key)
+            if not arg_hashable:
+                raise_unhashable(key, tx)
+
+            self.install_dict_contains_guard(tx, [key])
+            contains = key in self
             return VariableTracker.build(tx, contains)
         elif name == "setdefault" and self.is_mutable():
             if len(args) not in (1, 2):

--- a/torch/_dynamo/variables/dicts.py
+++ b/torch/_dynamo/variables/dicts.py
@@ -61,7 +61,6 @@ from .constant import (
     ConstantVariable,
 )
 
-
 if TYPE_CHECKING:
     from torch._dynamo.codegen import PyCodegen
     from torch._dynamo.side_effects import SideEffects
@@ -130,6 +129,7 @@ class ConstDictVariable(VariableTracker):
     }
 
     class _HashableTracker:
+        _MISSING = object()
         """
         Auxiliary opaque internal class that wraps a VariableTracker and makes it hashable
         This should not be seen or touched by anything outside of ConstDictVariable and its children
@@ -144,6 +144,43 @@ class ConstDictVariable(VariableTracker):
             if not is_hashable(vt):
                 raise_unhashable(vt)
             self.vt = vt
+
+        @classmethod
+        def _maybe_constant_key(cls, vt: VariableTracker) -> object:
+            from .lists import SizeVariable
+            from .tensor import TensorVariable
+
+            if not isinstance(vt, SizeVariable):
+                return cls._MISSING
+
+            items = []
+            for item in vt.items:
+                if item.is_python_constant():
+                    items.append(item.as_python_constant())
+                    continue
+
+                if isinstance(item, TensorVariable):
+                    proxy = getattr(item, "proxy", None)
+                    node = getattr(proxy, "node", None)
+                    meta = getattr(node, "meta", None) if node is not None else None
+                    example_value = (
+                        meta.get("example_value") if isinstance(meta, dict) else None
+                    )
+
+                    if (
+                        isinstance(example_value, torch.Tensor)
+                        and example_value.numel() == 1
+                    ):
+                        items.append(example_value.item())
+                        continue
+
+                    if isinstance(example_value, (int, bool)):
+                        items.append(example_value)
+                        continue
+
+                return cls._MISSING
+
+            return torch.Size(items)
 
         def __hash__(self) -> int:
             """
@@ -162,6 +199,11 @@ class ConstDictVariable(VariableTracker):
                 and self.vt.is_hashable()
             ):
                 return hash(self.vt.original_value())
+
+            maybe_constant = self._maybe_constant_key(self.vt)
+            if maybe_constant is not self._MISSING:
+                return hash(maybe_constant)
+
             return self.vt.get_python_hash()
 
         def __eq__(self, other: object) -> bool:
@@ -181,6 +223,15 @@ class ConstDictVariable(VariableTracker):
                 return False
             if self.vt is other.vt:
                 return True
+
+            self_constant = self._maybe_constant_key(self.vt)
+            other_constant = self._maybe_constant_key(other.vt)
+            if (
+                self_constant is not self._MISSING
+                and other_constant is not self._MISSING
+            ):
+                return self_constant == other_constant
+
             return self.vt.is_python_equal(other.vt)
 
     def __init__(
@@ -268,24 +319,12 @@ class ConstDictVariable(VariableTracker):
     def __contains__(self, vt: VariableTracker) -> bool:
         assert isinstance(vt, VariableTracker)
         Hashable = ConstDictVariable._HashableTracker
-        if not vt.is_python_hashable():
+        if not is_hashable(vt):
             return False
-        if Hashable(vt) in self.items and not isinstance(
-            self.items[Hashable(vt)], variables.DeletedVariable
-        ):
-            return True
-        if vt.is_python_constant():
-            try:
-                const_vt = VariableTracker.build(
-                    None, vt.as_python_constant()
-                )
-                if const_vt.is_python_hashable() and Hashable(const_vt) in self.items:
-                    return not isinstance(
-                        self.items[Hashable(const_vt)], variables.DeletedVariable
-                    )
-            except Exception:
-                pass
-        return False
+        key = Hashable(vt)
+        return key in self.items and not isinstance(
+            self.items[key], variables.DeletedVariable
+        )
 
     def call_tree_map_branch(
         self,
@@ -787,29 +826,7 @@ class ConstDictVariable(VariableTracker):
                     f"{len(args)} args and {len(kwargs)} kwargs",
                 )
 
-            from .lists import SizeVariable
-            from .tensor import TensorVariable
-
             key = args[0]
-            if isinstance(key, SizeVariable) and key not in self:
-                try:
-                    resolved_items = []
-                    for item in key.items:
-                        if item.is_python_constant():
-                            resolved_items.append(item.as_python_constant())
-                        elif isinstance(item, TensorVariable):
-                            example = item.as_proxy().node.meta.get("example_value", None)
-                            if example is not None:
-                                resolved_items.append(example.item())
-                            else:
-                                raise NotImplementedError
-                        else:
-                            raise NotImplementedError
-                    const_key = torch.Size(resolved_items)
-                    key = VariableTracker.build(tx, const_key)
-                except (NotImplementedError, RuntimeError):
-                    pass
-
             arg_hashable = is_hashable(key)
             if not arg_hashable:
                 raise_unhashable(key, tx)


### PR DESCRIPTION
## Summary
Fixes #176862

## Problem
When a model uses `torch.tensor(x.shape[1:])` to build `torch.Size` keys for dictionary lookups, `torch.compile` produces an incorrect output and the compiled model returns the wrong shape.

**Eager:** `[4, 32]` to  `[4, 64]` 
**Compiled:** `[4, 32]` to `[4, 32]` layer skipped

## Root Cause
During Dynamo tracing, `torch.tensor(x.shape[1:])` creates a `TensorVariable` and indexing it with `[0]` produces another `TensorVariable`. When `torch.Size([TensorVariable, ConstantVariable(64)])` is used as a dict key in `__contains__`, the `_HashableTracker` comparison fails to match against the concrete `torch.Size([32, 64])` keys and the `if` branch is never taken, the `nn.Linear` is skipped which makes the output wrong.

## Fix
In `ConstDictVariable.call_method` for `__contains__` (`torch/_dynamo/variables/dicts.py`), when a `SizeVariable` lookup fails and it contains `TensorVariable` elements, resolve each element to its concrete value with the FX node's `example_value` metadata, rebuild as a constant `SizeVariable`, and retry the lookup.

## Test
Reproduction script confirms fix:
```python
# Before fix:
Eager output shape:    torch.Size([4, 64])
Compiled output shape: torch.Size([4, 32])  # Wrong

# After fix:
Eager output shape:    torch.Size([4, 64])
Compiled output shape: torch.Size([4, 64])  # Correct
```

Tested edge cases:
- Multiple input feature sizes (32, 64, 128) all match
- Correctly skips layer in both eager and compiled
- `torch.allclose` passes between eager and compiled

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @ezyang @jansel