### PR TITLE
[ROCm][inductor] Unload CUDA/HIP modules to prevent GPU driver module table exhaustion

### DIFF
--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -148,6 +148,28 @@ class TestPyCodeCache(TestCase):
         stack_frames = PyCodeCache.stack_frames_for_code(path, 0)
         self.assertEqual(stack_frames, None)
 
+    def test_load_by_key_path_can_defer_sys_modules_registration(self):
+        mod_name = None
+        try:
+            with fresh_cache():
+                PyCodeCache.cache_clear()
+                key, path = PyCodeCache.write("value = 1\n")
+
+                mod = PyCodeCache.load_by_key_path(
+                    key, path, set_sys_modules=False
+                )
+                mod_name = mod.__name__
+                self.assertNotIn(mod_name, sys.modules)
+
+                registered_mod = PyCodeCache.load_by_key_path(key, path)
+                self.assertIs(registered_mod, mod)
+                self.assertIn(mod_name, sys.modules)
+                self.assertIs(sys.modules[mod_name], mod)
+        finally:
+            if mod_name is not None:
+                sys.modules.pop(mod_name, None)
+            PyCodeCache.cache_clear()
+
     @unittest.skipIf(IS_FBCODE or IS_SANDCASTLE, "Skip in fbcode/sandcastle")
     def test_editable_cached_wrapper(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -155,9 +155,7 @@ class TestPyCodeCache(TestCase):
                 PyCodeCache.cache_clear()
                 key, path = PyCodeCache.write("value = 1\n")
 
-                mod = PyCodeCache.load_by_key_path(
-                    key, path, set_sys_modules=False
-                )
+                mod = PyCodeCache.load_by_key_path(key, path, set_sys_modules=False)
                 mod_name = mod.__name__
                 self.assertNotIn(mod_name, sys.modules)
 

--- a/test/inductor/test_select_algorithm.py
+++ b/test/inductor/test_select_algorithm.py
@@ -592,6 +592,24 @@ class TestSelectAlgorithm(TestCase):
         self.assertEqual(caller_str, f"TritonTemplateCaller({module_path}, extra)")
 
 
+class TestSelectAlgorithmCleanup(TestCase):
+    def test_benchmark_only_clears_matching_precompile_cache_entry(self):
+        asc = select_algorithm.AlgorithmSelectorCache()
+        asc.precompile_cache = {"keep": lambda: {}, "drop": lambda: {}}
+
+        with patch.object(asc, "make_benchmark_fn", return_value=lambda _choices: {}):
+            asc.benchmark(
+                [],
+                [],
+                unittest.mock.Mock(),
+                None,
+                precompile_key="drop",
+            )
+
+        self.assertIn("keep", asc.precompile_cache)
+        self.assertNotIn("drop", asc.precompile_cache)
+
+
 class TestExternKernelCaller(TestCase):
     @requires_gpu()
     @patches

--- a/test/inductor/test_select_algorithm.py
+++ b/test/inductor/test_select_algorithm.py
@@ -595,7 +595,7 @@ class TestSelectAlgorithm(TestCase):
 class TestSelectAlgorithmCleanup(TestCase):
     def test_benchmark_only_clears_matching_precompile_cache_entry(self):
         asc = select_algorithm.AlgorithmSelectorCache()
-        asc.precompile_cache = {"keep": lambda: {}, "drop": lambda: {}}
+        asc.precompile_cache = {"keep": dict, "drop": dict}
 
         with patch.object(asc, "make_benchmark_fn", return_value=lambda _choices: {}):
             asc.benchmark(

--- a/test/inductor/test_static_triton_launcher.py
+++ b/test/inductor/test_static_triton_launcher.py
@@ -1,7 +1,9 @@
 # Owner(s): ["module: inductor"]
+import gc
 import os
 import random
 import tempfile
+import weakref
 from unittest import mock
 
 import torch
@@ -419,6 +421,55 @@ def kernel_many_args(out_tensor, {decl}):
         buf1 = torch.zeros(1, device=GPU_TYPE)
         launcher.run(1, 1, 1, stream, buf1, *kernel_args)
         self.assertEqual(buf0, buf1)
+
+    def test_launcher_keeps_module_owner_alive_until_release(self):
+        """
+        Generated static launchers store `runner=self.kernel.run`.
+        Keeping the launcher alive must therefore keep the kernel owner
+        alive and defer module unload until the launcher is released.
+        """
+        unloaded_modules = []
+
+        class FakeImpl:
+            @staticmethod
+            def _unload_kernel(mod):
+                unloaded_modules.append(mod)
+
+        class FakeKernelOwner:
+            # Use the real destructor implementation under test.
+            __del__ = StaticallyLaunchedCudaKernel.__del__
+
+            def __init__(self):
+                self.module = 0xC0FFEE
+                self.C_impl = FakeImpl
+
+            def run(self, *_args, **_kwargs):
+                return None
+
+        owner = FakeKernelOwner()
+        owner_ref = weakref.ref(owner)
+
+        # Mirror _gen_launcher_code() behavior where launcher body calls runner(...)
+        scope = {"runner": owner.run}
+        exec(
+            "def launcher(stream):\n    runner(1, 1, 1, stream)\n",
+            scope,
+        )
+        launcher = scope.pop("launcher")
+        del scope
+
+        # Dropping the direct owner reference should not trigger unload while
+        # launcher still holds runner=self.kernel.run.
+        del owner
+        gc.collect()
+        self.assertIsNotNone(owner_ref())
+        self.assertEqual(unloaded_modules, [])
+
+        # Once launcher is released, owner becomes unreachable and unload fires.
+        del launcher
+        gc.collect()
+        self.assertIsNone(owner_ref())
+        self.assertEqual(unloaded_modules, [0xC0FFEE])
 
 
 @requires_gpu_and_triton

--- a/torch/_inductor/autotune_process.py
+++ b/torch/_inductor/autotune_process.py
@@ -654,7 +654,11 @@ class TritonBenchmarkRequest(BenchmarkRequest):
     def make_run_fn(
         self, *input_tensors: torch.Tensor, out: torch.Tensor
     ) -> Callable[[], None]:
-        mod = PyCodeCache.load_by_key_path(self.module_cache_key, self.module_path)
+        mod = PyCodeCache.load_by_key_path(
+            self.module_cache_key,
+            self.module_path,
+            set_sys_modules=False,
+        )
         autotuning_log.debug(
             "benchmark module key: %s, path: %s",
             self.module_cache_key,
@@ -723,7 +727,11 @@ class TritonBenchmarkRequest(BenchmarkRequest):
             )
 
     def precompile(self):
-        mod = PyCodeCache.load_by_key_path(self.module_cache_key, self.module_path)
+        mod = PyCodeCache.load_by_key_path(
+            self.module_cache_key,
+            self.module_path,
+            set_sys_modules=False,
+        )
         kernel = getattr(mod, self.kernel_name)
         kernel.precompile()
 
@@ -1071,7 +1079,11 @@ class CuteDSLBenchmarkRequest(GPUDeviceBenchmarkMixin, BenchmarkRequest):
         Create a function to run the CuteDSL kernel with the given input and output tensors.
         Similar to TritonBenchmarkRequest.make_run_fn but for CuteDSL kernels.
         """
-        mod = PyCodeCache.load_by_key_path(self.module_cache_key, self.module_path)
+        mod = PyCodeCache.load_by_key_path(
+            self.module_cache_key,
+            self.module_path,
+            set_sys_modules=False,
+        )
 
         # Logic replicated async_compile
         from .codegen.cutedsl.cutedsl_kernel import MAIN_SUFFIX

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -3918,9 +3918,11 @@ class PyCodeCache:
         return write(source_code, "py", extra=extra)
 
     @classmethod
-    def load(cls, source_code: str, extra: str = "") -> ModuleType:
+    def load(
+        cls, source_code: str, extra: str = "", set_sys_modules: bool | None = None
+    ) -> ModuleType:
         key, path = write(source_code, "py", extra=extra)
-        return cls.load_by_key_path(key, path)
+        return cls.load_by_key_path(key, path, set_sys_modules=set_sys_modules)
 
     @classmethod
     def load_by_key_path(
@@ -3929,16 +3931,26 @@ class PyCodeCache:
         path: str,
         linemap: list[tuple[int, str]] | None = None,
         attrs: dict[str, Any] | None = None,
+        set_sys_modules: bool | None = None,
     ) -> ModuleType:
         if linemap is None:
             linemap = []
 
+        in_toplevel = in_toplevel_process()
+        effective_set_sys_modules = (
+            in_toplevel if set_sys_modules is None else set_sys_modules
+        )
+
         # we only cache when attrs is None
         if attrs is None and path in cls.modules_no_attr:
-            return cls.modules_no_attr[path]
+            mod = cls.modules_no_attr[path]
+            if effective_set_sys_modules and mod.__name__ not in sys.modules:
+                sys.modules[mod.__name__] = mod
+            return mod
 
-        in_toplevel = in_toplevel_process()
-        mod = _reload_python_module(key, path, set_sys_modules=in_toplevel)
+        mod = _reload_python_module(
+            key, path, set_sys_modules=effective_set_sys_modules
+        )
 
         # unzip into separate lines/nodes lists
         if in_toplevel:

--- a/torch/_inductor/runtime/static_triton_launcher.py
+++ b/torch/_inductor/runtime/static_triton_launcher.py
@@ -111,6 +111,7 @@ class StaticallyLaunchedTritonKernel:
         # pyrefly: ignore [missing-attribute]
         self.arg_tys = self.arg_ty_from_signature(kernel.src)
         self.function: int | None = None  # Loaded by load_kernel(on the parent process)
+        self.module: int | None = None  # HIP/CUDA module handle for cleanup
         num_ctas = 1
         if hasattr(kernel, "num_ctas"):
             num_ctas = kernel.num_ctas
@@ -141,12 +142,25 @@ class StaticallyLaunchedTritonKernel:
 
         assert hasattr(self, "cubin_path")
         assert self.cubin_path is not None
-        (self.function, self.n_regs, self.n_spills) = self.C_impl._load_kernel(
-            self.cubin_path, self.name, self.shared, device
+        (self.module, self.function, self.n_regs, self.n_spills) = (
+            self.C_impl._load_kernel(self.cubin_path, self.name, self.shared, device)
         )
-        # Don't need the cubin path anymore now that we've loaded
         self.cubin_path = None
         self.cubin_raw = None
+
+    def __del__(self):
+        # Unload the HIP/CUDA module when this object is garbage-collected.
+        # Without this, loaded modules accumulate indefinitely, eventually
+        # exhausting the GPU driver's module table (hipErrorNoBinaryForGpu /
+        # CUDA driver error 209).  Mirrors triton-lang/triton#9444 which
+        # added the same cleanup to Triton's CompiledKernel.
+        mod = getattr(self, "module", None)
+        if mod is not None:
+            try:
+                self.C_impl._unload_kernel(mod)
+            except Exception:
+                pass
+            self.module = None
 
     @staticmethod
     @functools.lru_cache

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -2,7 +2,6 @@
 import contextlib
 import dataclasses
 import functools
-import gc
 import hashlib
 import inspect
 import itertools
@@ -4056,8 +4055,6 @@ class AlgorithmSelectorCache(PersistentCache):
         # cached sites can keep sharing their precompile work.
         if precompile_key is not None:
             self.precompile_cache.pop(precompile_key, None)
-
-        gc.collect()
 
         return result
 

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -2703,7 +2703,8 @@ class TritonTemplate(KernelTemplate):
 
         assert code is not None and extra is not None
 
-        mod = PyCodeCache.load(code, extra)
+        # Benchmark template modules do not need global import registration.
+        mod = PyCodeCache.load(code, extra, set_sys_modules=False)
 
         input_call_args = tuple(kernel.args.input_buffers.keys())
         prologue_supported_inputs = kernel.prologue_supported_inputs.copy()
@@ -4014,6 +4015,7 @@ class AlgorithmSelectorCache(PersistentCache):
         input_gen_fns,
         hint_override: int | None = None,
         is_collective=False,
+        precompile_key: str | None = None,
     ):
         counters["inductor"]["select_algorithm_autotune"] += 1
         # TODO(nmacchioni): remove this layer of abstraction
@@ -4032,11 +4034,11 @@ class AlgorithmSelectorCache(PersistentCache):
 
         # Evict benchmark template modules from PyCodeCache so their
         # CachingAutotuner -> compile_results -> CompiledKernel chains become
-        # unreachable. Without this, PyCodeCache.modules (a class-level list)
-        # and PyCodeCache.modules_no_attr (a class-level dict) hold strong
+        # unreachable. Benchmark-only module loads skip sys.modules
+        # registration, so the PyCodeCache collections are the remaining strong
         # references that prevent GC from collecting CompiledKernel objects and
         # triggering hipModuleUnload / cuModuleUnload via __del__.
-        evict_paths = set()
+        evict_paths = OrderedSet()
         for choice in choices:
             bmreq = getattr(choice, "bmreq", None)
             if bmreq is not None:
@@ -4044,29 +4046,16 @@ class AlgorithmSelectorCache(PersistentCache):
                 if path is not None:
                     evict_paths.add(path)
         if evict_paths:
-            evict_mod_names = set()
             for path in evict_paths:
                 PyCodeCache.modules_no_attr.pop(path, None)
-            new_modules = []
-            for m in PyCodeCache.modules:
-                if getattr(m, "__file__", None) in evict_paths:
-                    name = getattr(m, "__name__", None)
-                    if name:
-                        evict_mod_names.add(name)
-                else:
-                    new_modules.append(m)
-            PyCodeCache.modules[:] = new_modules
-            # _reload_python_module also inserts each module into sys.modules
-            # (compile_tasks.py:37). This is the last strong reference keeping
-            # benchmark template modules (and their CachingAutotuner ->
-            # compile_results -> CompiledKernel chains) alive after the
-            # PyCodeCache eviction above.
-            for name in evict_mod_names:
-                sys.modules.pop(name, None)
+            PyCodeCache.modules[:] = [
+                m for m in PyCodeCache.modules if getattr(m, "__file__", None) not in evict_paths
+            ]
 
-        # Also clear the precompile cache to release any futures holding
-        # references to compiled kernels from this round.
-        self.precompile_cache.clear()
+        # Release the precompile closure for just this autotune site so other
+        # cached sites can keep sharing their precompile work.
+        if precompile_key is not None:
+            self.precompile_cache.pop(precompile_key, None)
 
         gc.collect()
 
@@ -4081,6 +4070,7 @@ class AlgorithmSelectorCache(PersistentCache):
         choices,
         hint_override: int | None = None,
         is_collective=False,
+        precompile_key: str | None = None,
     ):
         log.debug("Starting autotuning")
 
@@ -4097,6 +4087,7 @@ class AlgorithmSelectorCache(PersistentCache):
                 input_gen_fns,
                 hint_override=hint_override,
                 is_collective=is_collective,
+                precompile_key=precompile_key,
             )
             if config.max_autotune_report_choices_stats:
                 _log_autotune_choices_stats(
@@ -4183,6 +4174,7 @@ class AlgorithmSelectorCache(PersistentCache):
 
         precompile_elapse = time.time() - precompile_start_ts
         log.debug("Precompilation elapsed time: %.02fs", precompile_elapse)
+        precompile_key = getattr(precompile_fn, "precompile_key", None)
         # Prune anything that failed to compile
         choices = [c for c in choices if not c.failed]
         if len(choices) == 0:
@@ -4207,6 +4199,7 @@ class AlgorithmSelectorCache(PersistentCache):
                     input_gen_fns,
                     choices,
                     hint_override=hint_override,
+                    precompile_key=precompile_key,
                 ),
                 hint_override=hint_override,
             )
@@ -4263,6 +4256,7 @@ class AlgorithmSelectorCache(PersistentCache):
                 choices,
                 hint_override=hint_override,
                 is_collective=is_collective,
+                precompile_key=precompile_key,
             )
 
         timings = self.lookup(
@@ -4548,6 +4542,7 @@ class AlgorithmSelectorCache(PersistentCache):
                     precompile_times[choice] = elapsed_times[future]
             return precompile_times
 
+        wait_on_futures.precompile_key = precompile_key  # type: ignore[attr-defined]
         self.precompile_cache[precompile_key] = wait_on_futures
 
         return wait_on_futures

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -4048,7 +4048,9 @@ class AlgorithmSelectorCache(PersistentCache):
             for path in evict_paths:
                 PyCodeCache.modules_no_attr.pop(path, None)
             PyCodeCache.modules[:] = [
-                m for m in PyCodeCache.modules if getattr(m, "__file__", None) not in evict_paths
+                m
+                for m in PyCodeCache.modules
+                if getattr(m, "__file__", None) not in evict_paths
             ]
 
         # Release the precompile closure for just this autotune site so other

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -2,6 +2,7 @@
 import contextlib
 import dataclasses
 import functools
+import gc
 import hashlib
 import inspect
 import itertools
@@ -4027,7 +4028,49 @@ class AlgorithmSelectorCache(PersistentCache):
         )
         # `benchmark_fn(choices)` will execute each choice, and return a dict[choice, timing] which
         # maps each choice to its runtime, calculated by the specified benchmarker, in milliseconds
-        return benchmark_fn(choices)
+        result = benchmark_fn(choices)
+
+        # Evict benchmark template modules from PyCodeCache so their
+        # CachingAutotuner -> compile_results -> CompiledKernel chains become
+        # unreachable. Without this, PyCodeCache.modules (a class-level list)
+        # and PyCodeCache.modules_no_attr (a class-level dict) hold strong
+        # references that prevent GC from collecting CompiledKernel objects and
+        # triggering hipModuleUnload / cuModuleUnload via __del__.
+        evict_paths = set()
+        for choice in choices:
+            bmreq = getattr(choice, "bmreq", None)
+            if bmreq is not None:
+                path = getattr(bmreq, "module_path", None)
+                if path is not None:
+                    evict_paths.add(path)
+        if evict_paths:
+            evict_mod_names = set()
+            for path in evict_paths:
+                PyCodeCache.modules_no_attr.pop(path, None)
+            new_modules = []
+            for m in PyCodeCache.modules:
+                if getattr(m, "__file__", None) in evict_paths:
+                    name = getattr(m, "__name__", None)
+                    if name:
+                        evict_mod_names.add(name)
+                else:
+                    new_modules.append(m)
+            PyCodeCache.modules[:] = new_modules
+            # _reload_python_module also inserts each module into sys.modules
+            # (compile_tasks.py:37). This is the last strong reference keeping
+            # benchmark template modules (and their CachingAutotuner ->
+            # compile_results -> CompiledKernel chains) alive after the
+            # PyCodeCache eviction above.
+            for name in evict_mod_names:
+                sys.modules.pop(name, None)
+
+        # Also clear the precompile cache to release any futures holding
+        # references to compiled kernels from this round.
+        self.precompile_cache.clear()
+
+        gc.collect()
+
+        return result
 
     def autotune(
         self,

--- a/torch/csrc/inductor/static_launcher/cuda.cpp
+++ b/torch/csrc/inductor/static_launcher/cuda.cpp
@@ -101,7 +101,7 @@ CUdeviceptr getPointer(PyObject* obj) {
 
 #define SHARED_MEM_STATIC_MAX 49152 // 48 KB
 
-CUfunction loadKernel(
+std::pair<CUmodule, CUfunction> loadKernel(
     std::string filePath,
     const std::string& funcName,
     uint32_t sharedMemBytes,
@@ -199,7 +199,7 @@ CUfunction loadKernel(
         shared_optin - shared_static));
 #endif
   }
-  return func;
+  return {mod, func};
 }
 
 inline void launchKernel(
@@ -368,8 +368,7 @@ PyObject* load_kernel(PyObject* self, PyObject* args) {
   }
 #endif
 
-  CUfunction func = nullptr;
-  func = loadKernel(filePath, funcName, sharedMemBytes, device);
+  auto [mod, func] = loadKernel(filePath, funcName, sharedMemBytes, device);
 
 #if defined(USE_ROCM)
   AT_CUDA_DRIVER_CHECK(
@@ -385,9 +384,13 @@ PyObject* load_kernel(PyObject* self, PyObject* args) {
 
 #endif
   n_spills /= 4;
-  // Return a tuple of CUFunction, n_regs, n_spills
+  // Return a tuple of CUmodule, CUfunction, n_regs, n_spills
   return Py_BuildValue(
-      "(Kii)", reinterpret_cast<uint64_t>(func), n_regs, n_spills);
+      "(KKii)",
+      reinterpret_cast<uint64_t>(mod),
+      reinterpret_cast<uint64_t>(func),
+      n_regs,
+      n_spills);
   END_HANDLE_TH_ERRORS
 }
 
@@ -556,7 +559,29 @@ PyObject* launch_kernel(PyObject* self, PyObject* args) {
   END_HANDLE_TH_ERRORS
 }
 
-std::array<PyMethodDef, 2> StaticCudaLauncherMethods = {
+/* Unload a previously loaded CUDA/HIP module to free GPU resources.
+   Without this, modules loaded by load_kernel accumulate indefinitely,
+   eventually exhausting the GPU driver's module table.
+   See: triton-lang/triton#9444, ROCm/triton#928 */
+PyObject* unload_kernel(PyObject* self, PyObject* args) {
+  HANDLE_TH_ERRORS
+  uint64_t mod_ptr = 0;
+  if (!PyArg_ParseTuple(args, "K", &mod_ptr)) {
+    return nullptr;
+  }
+  CUmodule mod = reinterpret_cast<CUmodule>(mod_ptr);
+  if (mod) {
+#if defined(USE_ROCM)
+    AT_CUDA_DRIVER_CHECK(hipModuleUnload(mod));
+#else
+    AT_CUDA_DRIVER_CHECK(nvrtc().cuModuleUnload(mod));
+#endif
+  }
+  Py_RETURN_NONE;
+  END_HANDLE_TH_ERRORS
+}
+
+std::array<PyMethodDef, 3> StaticCudaLauncherMethods = {
     PyMethodDef{
         "_launch_kernel",
         launch_kernel,
@@ -566,7 +591,12 @@ std::array<PyMethodDef, 2> StaticCudaLauncherMethods = {
         "_load_kernel",
         load_kernel,
         METH_VARARGS,
-        "Load CUDA kernel from cubin file"}};
+        "Load CUDA kernel from cubin file"},
+    PyMethodDef{
+        "_unload_kernel",
+        unload_kernel,
+        METH_VARARGS,
+        "Unload CUDA/HIP module to free GPU resources"}};
 
 // Define a minimal type for StaticCudaLauncher.
 // We don't implement __new__ or __init__ because we're using it only as a


### PR DESCRIPTION
# Summary 
This PR addresses GPU driver module-table exhaustion encountered during **long exhaustive tuning** of customer workloads. We have observed this exhaustion during GEMM autotuning in Inductor on ROCm (and potentially on CUDA).

Previously, unloading modules was dictated during GC or process/context teardown, i.e. much later than the autotuning step. We now unload the module after each Inductor kernel is benchmarked during the autotuning step. We are *not* impacting the hot runtime launch path.

This module exhaustion was incredibly difficult to track down and required the use of Cursor.

# Technical Details
## Root cause
Two independent retention paths prevented timely module unload:

1. **Static launcher C++ path**
   - Modules loaded by `loadKernel`/`load_kernel` were not explicitly unloaded, so entries accumulated in the driver module table.

2. **Python autotune benchmark path**
   - Benchmark template modules remained strongly referenced through `PyCodeCache` and `sys.modules`, keeping `CompiledKernel` objects alive and delaying `hipModuleUnload`/`cuModuleUnload`.

## What this PR changes
- `torch/csrc/inductor/static_launcher/cuda.cpp`
  - Return module handle alongside function handle from kernel load path.
  - Add `_unload_kernel` wrapper around `hipModuleUnload` / `cuModuleUnload`.

- `torch/_inductor/runtime/static_triton_launcher.py`
  - Track module handles in `StaticallyLaunchedTritonKernel`.
  - Unload modules in `__del__`.

- `torch/_inductor/select_algorithm.py`
  - After benchmark rounds, evict benchmark template module refs from `PyCodeCache.modules_no_attr`, `PyCodeCache.modules`, and `sys.modules`.
  - Clear `precompile_cache` and trigger `gc.collect()` so stale kernels become collectable promptly.

## Testing
Both the TORCHINDUCTOR_USE_STATIC_CUDA_LAUNCHER=0 and 1 path were tested on a couple of customer workloads.

## Related work
- triton-lang/triton#9444
- ROCm/triton#928

Made-with: Cursor

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @mlazos