### PR TITLE
Add __torch_function__ support to create_block_mask

### DIFF
--- a/torch/nn/attention/flex_attention.py
+++ b/torch/nn/attention/flex_attention.py
@@ -20,6 +20,7 @@ from torch._higher_order_ops.flex_attention import flex_attention as flex_attent
 from torch._higher_order_ops.utils import setup_compilation_env
 from torch._prims_common import DeviceLikeType
 from torch.nn.attention._utils import _validate_sdpa_input
+from torch.overrides import handle_torch_function, has_torch_function
 from torch.utils._pytree import GetAttrKey, tree_map_only
 
 
@@ -1247,6 +1248,19 @@ def create_block_mask(
             value = torch.randn(1, 1, 8192, 64, device="cuda", dtype=torch.float16)
             output = flex_attention(query, key, value, block_mask=block_mask)
     """
+    if has_torch_function((B, H, Q_LEN, KV_LEN)):
+        return handle_torch_function(
+            create_block_mask,
+            (B, H, Q_LEN, KV_LEN),
+            mask_mod,
+            B,
+            H,
+            Q_LEN,
+            KV_LEN,
+            device=device,
+            BLOCK_SIZE=BLOCK_SIZE,
+            _compile=_compile,
+        )
     if device is None:
         device = torch.accelerator.current_accelerator() or "cpu"
     mod_type = _get_mod_type(mask_mod)
@@ -1545,6 +1559,21 @@ def flex_attention(
         Read more about feature classification at: https://pytorch.org/blog/pytorch-feature-classification-changes/#prototype
 
     """
+    if has_torch_function((query, key, value)):
+        return handle_torch_function(
+            flex_attention,
+            (query, key, value),
+            query,
+            key,
+            value,
+            score_mod=score_mod,
+            block_mask=block_mask,
+            scale=scale,
+            enable_gqa=enable_gqa,
+            return_lse=return_lse,
+            kernel_options=kernel_options,
+            return_aux=return_aux,
+        )
     # Some basic input validation
     _validate_sdpa_input(query, key, value, allow_lowp_kv=True)
     _validate_embed_dim(query, key, value)

--- a/torch/nn/attention/flex_attention.py
+++ b/torch/nn/attention/flex_attention.py
@@ -1559,21 +1559,6 @@ def flex_attention(
         Read more about feature classification at: https://pytorch.org/blog/pytorch-feature-classification-changes/#prototype
 
     """
-    if has_torch_function((query, key, value)):
-        return handle_torch_function(
-            flex_attention,
-            (query, key, value),
-            query,
-            key,
-            value,
-            score_mod=score_mod,
-            block_mask=block_mask,
-            scale=scale,
-            enable_gqa=enable_gqa,
-            return_lse=return_lse,
-            kernel_options=kernel_options,
-            return_aux=return_aux,
-        )
     # Some basic input validation
     _validate_sdpa_input(query, key, value, allow_lowp_kv=True)
     _validate_embed_dim(query, key, value)

--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -280,6 +280,7 @@ def get_ignored_functions() -> set[Callable]:
         torch.nn.init.orthogonal,
         torch.nn.init.sparse,
         torch.nested.to_padded_tensor,
+        flex_attention_mod.flex_attention,
         flex_attention_mod.create_mask,
         flex_attention_mod.or_masks,
         flex_attention_mod.and_masks,

--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -998,7 +998,6 @@ def get_testing_overrides() -> dict[Callable, Callable]:
         torch.nn.functional.silu: lambda input, inplace=False: -1,
         torch.nn.functional.mish: lambda input, inplace=False: -1,
         torch.nn.functional.scaled_dot_product_attention: lambda query, key, value, attn_mask=None, dropout_p=0.0: -1,
-        flex_attention_mod.flex_attention: lambda query, key, value, score_mod=None, block_mask=None, scale=None, enable_gqa=False, return_lse=False, kernel_options=None, return_aux=None: -1,  # noqa: B950
         flex_attention_mod.create_block_mask: lambda mask_mod, B, H, Q_LEN, KV_LEN, device=None, BLOCK_SIZE=128, _compile=False: -1,
         torch.nn.functional.smooth_l1_loss: lambda input, target, size_average=None, reduce=None, reduction="mean", beta=1.0: -1,  # noqa: B950
         torch.nn.functional.huber_loss: lambda input, target, reduction="mean", delta=1.0, weight=None: -1,

--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -119,6 +119,8 @@ def get_ignored_functions() -> set[Callable]:
     >>> torch.add in torch.overrides.get_ignored_functions()
     False
     """
+    import torch.nn.attention.flex_attention as flex_attention_mod
+
     Tensor = torch.Tensor
     functions = {
         torch.typename,
@@ -278,6 +280,10 @@ def get_ignored_functions() -> set[Callable]:
         torch.nn.init.orthogonal,
         torch.nn.init.sparse,
         torch.nested.to_padded_tensor,
+        flex_attention_mod.create_mask,
+        flex_attention_mod.or_masks,
+        flex_attention_mod.and_masks,
+        flex_attention_mod.noop_mask,
         has_torch_function,
         handle_torch_function,
         torch.set_autocast_enabled,
@@ -439,6 +445,8 @@ def get_testing_overrides() -> dict[Callable, Callable]:
     >>> inspect.signature(my_add)
     <Signature (input, other, out=None)>
     """
+    import torch.nn.attention.flex_attention as flex_attention_mod
+
     # Every function in the PyTorchAPI that can be overridden needs an entry
     # in this dict.
     #
@@ -990,6 +998,8 @@ def get_testing_overrides() -> dict[Callable, Callable]:
         torch.nn.functional.silu: lambda input, inplace=False: -1,
         torch.nn.functional.mish: lambda input, inplace=False: -1,
         torch.nn.functional.scaled_dot_product_attention: lambda query, key, value, attn_mask=None, dropout_p=0.0: -1,
+        flex_attention_mod.flex_attention: lambda query, key, value, score_mod=None, block_mask=None, scale=None, enable_gqa=False, return_lse=False, kernel_options=None, return_aux=None: -1,  # noqa: B950
+        flex_attention_mod.create_block_mask: lambda mask_mod, B, H, Q_LEN, KV_LEN, device=None, BLOCK_SIZE=128, _compile=False: -1,
         torch.nn.functional.smooth_l1_loss: lambda input, target, size_average=None, reduce=None, reduction="mean", beta=1.0: -1,  # noqa: B950
         torch.nn.functional.huber_loss: lambda input, target, reduction="mean", delta=1.0, weight=None: -1,
         torch.nn.functional.soft_margin_loss: lambda input, target, size_average=None, reduce=None, reduction="mean": -1,  # noqa: B950
@@ -1832,6 +1842,8 @@ def _get_overridable_functions() -> tuple[
 ]:
     overridable_funcs = collections.defaultdict(list)
     index = {}
+    import torch.nn.attention.flex_attention as flex_attention_mod
+
     tested_namespaces = [
         ("torch", torch, torch.__all__),
         ("torch.functional", torch.functional, torch.functional.__all__),
@@ -1841,6 +1853,11 @@ def _get_overridable_functions() -> tuple[
         ("torch.linalg", torch.linalg, dir(torch.linalg)),
         ("torch.fft", torch.fft, dir(torch.fft)),
         ("torch.special", torch.special, dir(torch.special)),
+        (
+            "torch.nn.attention.flex_attention",
+            flex_attention_mod,
+            flex_attention_mod.__all__,
+        ),
     ]
     for namespace_str, namespace, ns_funcs in tested_namespaces:
         for func_name in ns_funcs:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #176990

This allows tensor subclasses to intercept create_block_mask (checking B, H, Q_LEN,
KV_LEN) calls.

Authored with Claude.