### PR TITLE
Update FSDP test patching to use AllGather/ReduceScatter comm abstraction

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_overlap.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_overlap.py
@@ -69,8 +69,6 @@ class TestFullyShardOverlap(FSDPTest):
             fully_shard(lin, reshard_after_forward=True)
         fully_shard(model, reshard_after_forward=True)
 
-        orig_all_gather_into_tensor = dist.all_gather_into_tensor
-        orig_reduce_scatter_tensor = dist.reduce_scatter_tensor
         comm_stream = torch.get_device_module(device_type).Stream()
 
         def delay_collective():
@@ -89,29 +87,29 @@ class TestFullyShardOverlap(FSDPTest):
 
         def delayed_all_gather(*args, **kwargs):
             delay_collective()
-            return orig_all_gather_into_tensor(*args, **kwargs)
+            return dist.all_gather_into_tensor(*args, **kwargs)
 
         def delayed_reduce_scatter(*args, **kwargs):
             delay_collective()
-            return orig_reduce_scatter_tensor(*args, **kwargs)
+            return dist.reduce_scatter_tensor(*args, **kwargs)
 
         inp = torch.randn((2, dim), device=device_type.type)
         loss = model(inp).sum()  # warmup CUDA and allocator
         loss.backward()
 
         def ref_fwd():
-            with patch_all_gather(delayed_all_gather):
-                # Run dummy all-gathers per weight (which is one FSDP group)
-                for lin in ref_model:
-                    dummy_ag_output = torch.empty_like(lin.weight)
-                    dummy_ag_input = torch.chunk(dummy_ag_output, self.world_size)[
-                        self.rank
-                    ]
-                    dist.all_gather_into_tensor(dummy_ag_output, dummy_ag_input)
-                return ref_model(inp)
+            # Run dummy delayed all-gathers per weight (which is one FSDP group)
+            for lin in ref_model:
+                dummy_ag_output = torch.empty_like(lin.weight)
+                dummy_ag_input = torch.chunk(dummy_ag_output, self.world_size)[
+                    self.rank
+                ]
+                delay_collective()
+                dist.all_gather_into_tensor(dummy_ag_output, dummy_ag_input)
+            return ref_model(inp)
 
         def fwd():
-            with patch_all_gather(delayed_all_gather):
+            with patch_all_gather(model, delayed_all_gather):
                 model(inp)
 
         ref_fwd_time = self._time_fn(ref_fwd)
@@ -122,36 +120,37 @@ class TestFullyShardOverlap(FSDPTest):
         self.assertLessEqual(fwd_time, ref_fwd_time)
 
         def ref_fwd_bwd():
-            with patch_all_gather(delayed_all_gather):
-                # Run dummy all-gathers per weight (which is one FSDP group)
-                for lin in ref_model:
-                    dummy_ag_output = torch.empty_like(lin.weight)
-                    dummy_ag_input = torch.chunk(dummy_ag_output, self.world_size)[
-                        self.rank
-                    ]
-                    dist.all_gather_into_tensor(dummy_ag_output, dummy_ag_input)
-                loss = ref_model(inp).sum()
-                # Run dummy all-gathers per weight again since we are
-                # resharding after forward
-                for lin in ref_model:
-                    dummy_ag_output = torch.empty_like(lin.weight)
-                    dummy_ag_input = torch.chunk(dummy_ag_output, self.world_size)[
-                        self.rank
-                    ]
-                    dist.all_gather_into_tensor(dummy_ag_output, dummy_ag_input)
-                loss.backward()
-                # Run dummy reduce-scatters per weight
-                for lin in ref_model:
-                    dummy_rs_input = torch.empty_like(lin.weight)
-                    dummy_rs_output = torch.chunk(dummy_rs_input, self.world_size)[
-                        self.rank
-                    ]
-                    dist.reduce_scatter_tensor(dummy_rs_output, dummy_rs_input)
+            # Run dummy delayed all-gathers per weight (which is one FSDP group)
+            for lin in ref_model:
+                dummy_ag_output = torch.empty_like(lin.weight)
+                dummy_ag_input = torch.chunk(dummy_ag_output, self.world_size)[
+                    self.rank
+                ]
+                delay_collective()
+                dist.all_gather_into_tensor(dummy_ag_output, dummy_ag_input)
+            loss = ref_model(inp).sum()
+            # Run dummy all-gathers per weight again since we are
+            # resharding after forward
+            for lin in ref_model:
+                dummy_ag_output = torch.empty_like(lin.weight)
+                dummy_ag_input = torch.chunk(dummy_ag_output, self.world_size)[
+                    self.rank
+                ]
+                delay_collective()
+                dist.all_gather_into_tensor(dummy_ag_output, dummy_ag_input)
+            loss.backward()
+            # Run dummy reduce-scatters per weight
+            for lin in ref_model:
+                dummy_rs_input = torch.empty_like(lin.weight)
+                dummy_rs_output = torch.chunk(dummy_rs_input, self.world_size)[
+                    self.rank
+                ]
+                dist.reduce_scatter_tensor(dummy_rs_output, dummy_rs_input)
 
         def fwd_bwd():
             with (
-                patch_all_gather(delayed_all_gather),
-                patch_reduce_scatter(delayed_reduce_scatter),
+                patch_all_gather(model, delayed_all_gather),
+                patch_reduce_scatter(model, delayed_reduce_scatter),
             ):
                 loss = model(inp).sum()
                 loss.backward()
@@ -182,20 +181,18 @@ class TestFullyShardOverlap(FSDPTest):
         fully_shard(model[1], reshard_after_forward=False)
         optim = torch.optim.AdamW(model.parameters(), lr=1e-2)
 
-        orig_all_gather_into_tensor = dist.all_gather_into_tensor
-
         def delayed_all_gather(*args, **kwargs):
             torch.get_device_module(device_type)._sleep(
                 int(comm_sleep_ms * get_cycles_per_ms())
             )
-            return orig_all_gather_into_tensor(*args, **kwargs)
+            return dist.all_gather_into_tensor(*args, **kwargs)
 
         inp = torch.randn((2, dim), device=device_type)
 
         def run_train_steps(num_iters: int, use_post_optim_event: bool):
             for _ in range(num_iters):
                 optim.zero_grad()
-                with patch_all_gather(delayed_all_gather):
+                with patch_all_gather(model, delayed_all_gather):
                     loss = model(inp).sum()
                 loss.backward()
                 with implicit_replication():

--- a/torch/testing/_internal/common_fsdp.py
+++ b/torch/testing/_internal/common_fsdp.py
@@ -986,22 +986,32 @@ class DoubleLinear(nn.Module):
         return self.relu(self.lin1(x))
 
 
-# NOTE: For these patch methods, if we want safety under multi-threading (e.g.
-# when using multi-threaded process group), then we want:
-# (1) a barrier immediately after reading the original value to ensure that all
-# threads see the same original value
-# (2) a barrier immediately before restoring the original value to ensure that
-# all threads use the patched value inside the context
+# NOTE: These patch methods replace the comm objects on FSDP param groups
+# directly via the AllGather/ReduceScatter abstraction, rather than
+# monkey-patching global dist functions.
 @contextlib.contextmanager
-def patch_all_gather(new_all_gather_into_tensor: Callable):
-    orig_all_gather = dist.all_gather_into_tensor
-    dist.barrier()
-    dist.all_gather_into_tensor = new_all_gather_into_tensor
+def patch_all_gather(model: nn.Module, new_all_gather_into_tensor: Callable):
+    from torch.distributed.fsdp._fully_shard._fsdp_collectives import DefaultAllGather
+
+    class _PatchedAllGather(DefaultAllGather):
+        def __call__(self, output_tensor, input_tensor, group, async_op=False):
+            return new_all_gather_into_tensor(
+                output_tensor, input_tensor, group=group, async_op=async_op
+            )
+
+    patched = _PatchedAllGather()
+    orig_comms: list[tuple] = []
+    for module in model.modules():
+        state = fully_shard.state(module)
+        if state is not None:
+            for pg in state._fsdp_param_groups:
+                orig_comms.append((pg, pg._all_gather_comm))
+                pg._all_gather_comm = patched
     try:
         yield
     finally:
-        dist.barrier()
-        dist.all_gather_into_tensor = orig_all_gather
+        for pg, orig_comm in orig_comms:
+            pg._all_gather_comm = orig_comm
 
 
 @contextlib.contextmanager
@@ -1041,15 +1051,30 @@ def patch_foreach_reduce(new_foreach_reduce: Callable):
 
 
 @contextlib.contextmanager
-def patch_reduce_scatter(new_reduce_scatter_tensor: Callable):
-    orig_reduce_scatter = dist.reduce_scatter_tensor
-    dist.barrier()
-    dist.reduce_scatter_tensor = new_reduce_scatter_tensor
+def patch_reduce_scatter(model: nn.Module, new_reduce_scatter_tensor: Callable):
+    from torch.distributed.fsdp._fully_shard._fsdp_collectives import (
+        DefaultReduceScatter,
+    )
+
+    class _PatchedReduceScatter(DefaultReduceScatter):
+        def __call__(self, output_tensor, input_tensor, group, op, async_op=False):
+            return new_reduce_scatter_tensor(
+                output_tensor, input_tensor, group=group, op=op, async_op=async_op
+            )
+
+    patched = _PatchedReduceScatter()
+    orig_comms: list[tuple] = []
+    for module in model.modules():
+        state = fully_shard.state(module)
+        if state is not None:
+            for pg in state._fsdp_param_groups:
+                orig_comms.append((pg, pg._reduce_scatter_comm))
+                pg._reduce_scatter_comm = patched
     try:
         yield
     finally:
-        dist.barrier()
-        dist.reduce_scatter_tensor = orig_reduce_scatter
+        for pg, orig_comm in orig_comms:
+            pg._reduce_scatter_comm = orig_comm
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #177008

patch_all_gather and patch_reduce_scatter in common_fsdp now take the
FSDP model and replace _all_gather_comm/_reduce_scatter_comm on param
groups via DefaultAllGather/DefaultReduceScatter subclasses, instead of
monkey-patching global dist.all_gather_into_tensor/dist.reduce_scatter_tensor.

Authored with Claude.