### PR TITLE
[FSDP2] Use separate NCCL communicator for reduce-scatter to enable AG/RS overlap

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_overlap.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_overlap.py
@@ -167,6 +167,78 @@ class TestFullyShardOverlap(FSDPTest):
         # )
         self.assertLessEqual(fwd_bwd_time, ref_fwd_bwd_time)
 
+    @skip_if_rocm_arch_multiprocess(MI200_ARCH)
+    @skip_if_lt_x_gpu(2)
+    def test_fully_shard_backward_comm_overlap(self):
+        """Verify that backward all-gather and reduce-scatter overlap.
+
+        Uses real compute (large matmuls) and real collectives (large
+        parameter tensors) instead of CUDA sleeps.
+
+        ref_bwd: AG and RS use the same ProcessGroup (single NCCL
+        communicator), forcing serialization.
+
+        fsdp_bwd: real fully_shard code path with separate ProcessGroups
+        for AG and RS (FSDPMeshInfo.reduce_scatter_process_group),
+        enabling true overlap.
+        """
+        torch.manual_seed(42)
+
+        # Large dim for non-trivial collective time, small batch so
+        # comm dominates compute; AG becomes back-to-back on its stream
+        dim, num_linears, batch = 16384, 3, 4
+        model = nn.Sequential(
+            *[nn.Linear(dim, dim, bias=False) for _ in range(num_linears)]
+        )
+        for lin in model:
+            fully_shard(lin, reshard_after_forward=True)
+        fully_shard(model, reshard_after_forward=True)
+
+        optim = torch.optim.SGD(model.parameters(), lr=1e-2)
+        inp = torch.randn((batch, dim), device=device_type.type)
+        loss = model(inp).sum()
+        loss.backward()
+        with implicit_replication():
+            optim.step()
+        optim.zero_grad()  # warmup
+
+        # Collect FSDP param groups to toggle PG config
+        fsdp_param_groups = []
+        for module in model.modules():
+            state = fully_shard.state(module)
+            if state is not None:
+                fsdp_param_groups.extend(state._fsdp_param_groups)
+
+        # ref_bwd: force RS to use the same PG as AG (serialized)
+        saved_rs_pgs = []
+        for pg in fsdp_param_groups:
+            saved_rs_pgs.append(pg.mesh_info.reduce_scatter_process_group)
+            pg.mesh_info.reduce_scatter_process_group = pg.mesh_info.shard_process_group
+
+        def ref_bwd():
+            loss = model(inp).sum()
+            loss.backward()
+            with implicit_replication():
+                optim.step()
+            optim.zero_grad()
+
+        ref_time = self._time_fn(ref_bwd)
+
+        # Restore separate PGs for fsdp_bwd
+        for pg, saved_pg in zip(fsdp_param_groups, saved_rs_pgs):
+            pg.mesh_info.reduce_scatter_process_group = saved_pg
+
+        def fsdp_bwd():
+            loss = model(inp).sum()
+            loss.backward()
+            with implicit_replication():
+                optim.step()
+            optim.zero_grad()
+
+        fsdp_time = self._time_fn(fsdp_bwd)
+        # FSDP with separate PGs should be faster than serialized ref
+        self.assertLessEqual(fsdp_time, ref_time)
+
     @skip_if_lt_x_gpu(2)
     @unittest.skipIf(TEST_HPU, "Sleep is not supported on HPU")
     def test_fully_shard_post_optim_event_overlap(self):

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_common.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_common.py
@@ -48,6 +48,11 @@ class FSDPMeshInfo(DataParallelMeshInfo):
         self.shard_mesh_size: int = self.mesh.size(self.shard_mesh_dim)
         self.shard_process_group = self.mesh.get_group(self.shard_mesh_dim)
         self.shard_mesh_rank: int = self.shard_process_group.rank()
+        # Use a separate PG for reduce-scatter so that AG and RS go
+        # through different NCCL communicators and can overlap.
+        self.reduce_scatter_process_group = dist.new_group(
+            dist.get_process_group_ranks(self.shard_process_group)
+        )
 
 
 @dataclass

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
@@ -776,7 +776,7 @@ class FSDPParamGroup:
             raise AssertionError(
                 f"Expected mesh_info to be FSDPMeshInfo, got {type(self.mesh_info)}"
             )
-        return self.mesh_info.shard_process_group
+        return self.mesh_info.reduce_scatter_process_group
 
     @property
     def _all_reduce_process_group(self) -> dist.ProcessGroup:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #177015

@ngimel pointed that the same NCCL communicator serialize all-gather and reduce-scatter. Using different cuda streams are not enough. We must also use different PGs

This is confirmed with unit test and profiler traces below. Want to let @awgu take a look to see if this change makes sense. The risk is mainly extra NCCL workspace memory from separate reduce-scatter PG

`python -m torch.distributed.run --nproc_per_node=2 test/distributed/_composable/fsdp/test_fully_shard_overlap.py -k test_fully_shard_backward_comm_overlap`

<img width="3900" height="2461" alt="comparison_annotated" src="https://github.com/user-attachments/assets/fa3f8b24-5c15-4720-b0ff-bd3b895c73ba" />

