### PR TITLE
[pytorch] fix parsing of compressed aoti stacks for fused kernels

### DIFF
--- a/torch/csrc/inductor/aoti_runtime/kernel_context_tls.h
+++ b/torch/csrc/inductor/aoti_runtime/kernel_context_tls.h
@@ -14,8 +14,9 @@ struct KernelContext {
   std::string compressed_python_stack;
 
   KernelContext(std::string name, std::string stack)
-      : kernel_name(std::move(name)), python_stack(std::move(stack)) {
-    compressed_python_stack = compress_python_stack(python_stack);
+      : kernel_name(std::move(name)) {
+    python_stack = trim_stack(stack);
+    compressed_python_stack = compress_stack(python_stack);
   }
 
   KernelContext(const KernelContext&) = default;
@@ -24,28 +25,84 @@ struct KernelContext {
   KernelContext& operator=(KernelContext&&) = default;
 
  private:
-  static std::string compress_python_stack(const std::string& stack) {
-    namespace fs = std::filesystem;
-    char func[129];
-    char path[1025];
-    uint32_t line;
-    int ret;
-    std::string compressed_stack;
-    std::stringstream stream{stack};
-    std::string str;
-    std::string fmt = "File \"%1024[^\"]\", line %u, in %128[^\n]\n";
-    while (std::getline(stream, str)) {
-      ret = sscanf(str.c_str(), fmt.c_str(), path, &line, func);
-      if (ret == 3) {
-        compressed_stack += func;
-        compressed_stack += ' ';
-        compressed_stack += fs::path{path}.filename();
-        compressed_stack += ':';
-        compressed_stack += std::to_string(line);
-        compressed_stack += '\n';
-      }
+  // Strip leading and trailing newlines from stack:
+  // - finds first and last non-newline characters
+  // - outputs substring between them (inclusive)
+  // - returns empty string if stack contains only newlines
+  static std::string trim_stack(const std::string& stack) {
+    std::string res_stack;
+    auto beg = stack.find_first_not_of('\n');
+    if (beg == std::string::npos) {
+      return res_stack;
     }
-    return compressed_stack;
+    auto end = stack.find_last_not_of('\n');
+    if (end == std::string::npos) {
+      res_stack = stack.substr(beg);
+    } else {
+      res_stack = stack.substr(beg, end - beg + 1);
+    }
+    return res_stack;
+  }
+
+  // Compress stack into compact format:
+  // - blank lines are treated as stack separators
+  // - lines with 0 or 2 spaces of indentation are parsed as filename, fileline
+  //   and function
+  // - lines with 4 spaces of indentation are parsed as the code snippet
+  // - outputs function[code], filename and fileline (at newline each)
+  // - returns empty string on any parse error
+  static std::string compress_stack(const std::string& stack) {
+    std::string res_stack;
+    namespace fs = std::filesystem;
+    char function[1025];
+    char filename[1025];
+    uint32_t fileline;
+    int ret, n, ws;
+    const char* p;
+    std::stringstream stream{stack};
+    std::string line;
+    std::string fmt = "File \"%1024[^\"]\", line %u, in %1024[^\n]\n%n";
+    while (std::getline(stream, line)) {
+      // check if new stack
+      if (line.empty()) {
+        res_stack += '\n';
+        continue;
+      }
+      p = line.c_str();
+      ws = 0;
+      while (*p == ' ') {
+        ++p;
+        ++ws;
+      }
+      // check if new file
+      if (ws != 0 && ws != 2) {
+        return {};
+      }
+      ret = sscanf(p, fmt.c_str(), filename, &fileline, function, &n);
+      if (ret != 3) {
+        return {};
+      }
+      if (!std::getline(stream, line)) {
+        return {};
+      }
+      p = line.c_str();
+      ws = 0;
+      while (*p == ' ') {
+        ++p;
+        ++ws;
+      }
+      // check if command
+      if (ws != 4) {
+        return {};
+      }
+      res_stack += std::string{function} + '[' + std::string{p} + ']';
+      res_stack += '\n';
+      res_stack += fs::path{filename}.filename();
+      res_stack += '\n';
+      res_stack += std::to_string(fileline);
+      res_stack += '\n';
+    }
+    return res_stack;
   }
 };
 


### PR DESCRIPTION
Summary:
Fix parsing of compressed aoti stacks for fused kernels.

More info here D95789019.

Test Plan:
Patch provenance tests:
```
[nbeloborodov@devgpu031]~/fbcode2/fbcode% hg diff
diff --git a/fbcode/caffe2/torch/csrc/inductor/aoti_runtime/kernel_context_tls.h b/fbcode/caffe2/torch/csrc/inductor/aoti_runtime/kernel_context_tls.h
--- a/fbcode/caffe2/torch/csrc/inductor/aoti_runtime/kernel_context_tls.h
+++ b/fbcode/caffe2/torch/csrc/inductor/aoti_runtime/kernel_context_tls.h
@@ -10,7 +10,10 @@
   std::string python_stack;
 
   KernelContext(std::string name, std::string stack)
-      : kernel_name(std::move(name)), python_stack(std::move(stack)) {}
+      : kernel_name(std::move(name)), python_stack(std::move(stack)) {
+    std::cout << "!!! kernel_name: " << kernel_name.size() << ", stack: " << python_stack.size() << std::endl;
+    sleep(15);
+  }
 };
 
 // Thread-local pointer
```
Run provenance tests:
```
[nbeloborodov@devgpu031]~/fbcode2/fbcode% buck2 run mode/dev-nosan fbcode//caffe2/test/inductor:provenance_tracing -- -r test_aoti_python_stack_traces
```
Get pid:
```
nbelobo+  174851  0.0  0.0 288836 11592 pts/25   Tl   04:46   0:00 buck2 run mode/dev-nosan fbcode//caffe2/test/inductor:provenance_tracing -- -r test_aoti_python_stack_traces
nbelobo+  175300  6.1  0.1 6775860 2682384 pts/25 Tl  04:46   0:09 /usr/local/fbcode/platform010/bin/python3.12 -ttWdefault /data/users/nbeloborodov/fbsource/buck-out/v2/art/fbcode/2d02ffff63630e73/caffe2/test/inductor/__provenance_tracin __/provenance_tracing#link-tree/__run_lpar_main__.py -r test_aoti_python_stack_traces
nbelobo+  296140  0.0  0.0   6556  2672 pts/25   S+   04:48   0:00 grep --color=auto provenance_tracin
```
Wait until you see "!!! kernel_name ... " and run profiler:
```
[nbeloborodov@devgpu031]~/fbsource/fbcode% strobe gpuevent --duration-ms=90000 --collect-kernel-events --kernel-sample-interval=0 --attach-to-driver-api --collect-aoti-stacks --pids 175300 
Running "gpuevent" with run id -6741276093645087 and group_trace_id "" on hosts: ["::1"]                                                                                                    
Press Ctrl-C to stop the run
> Queuing...	 (00:00:00.000)
> Preparing...	 (00:00:02.837)
> Profiling...	 (00:01:30.418)
> Processing...	 (00:00:00.706)
> Logging...	 (00:00:00.027)
> Finished
| Host | Return Code | Samples | Result Links                                               |
|------|-------------|---------|------------------------------------------------------------|
| ::1  | SUCCESS     | 47      | Raw samples:                                               |
|      |             |         | https://fburl.com/scuba/strobelight_gpu/on_demand/vc5olalb |
|      |             |         |                                                            |
|      |             |         | Run Details:                                               |
|      |             |         | https://fburl.com/scuba/strobelight_runs/ako6sh5q          |
```

https://pxl.cl/940qt

Example of aoti_stack:
```
forward[x = self.sigmoid(x)]
forward[return torch.sigmoid(input)]
-
forward[x = self.relu(x)]
forward[return F.relu(input, inplace=self.inplace)]
-
forward[x = self.fc1(x)]
forward[return F.linear(input, self.weight, self.bias)]
```
Example of aoti_stack_linenums:
```
test_provenance_tracing.py:871
activation.py:361
-:0
test_provenance_tracing.py:870
activation.py:143
-:0
test_provenance_tracing.py:869
linear.py:134
```

Reviewed By: peremyach

Differential Revision: D95935281


