### PR TITLE
Add cublaslt backend for scaled grouped GEMM

### DIFF
--- a/aten/src/ATen/BlasBackend.h
+++ b/aten/src/ATen/BlasBackend.h
@@ -37,6 +37,7 @@ enum class ScalingType : std::uint8_t {
   BlockWise1x32, // fp8_e8m0fnu scales
   BlockWise1x128, // fp32 scales
   BlockWise128x128, // fp32 scales
+  GroupWise, // fp32 scales, one per group
 };
 
 enum class SwizzleType : std::uint8_t { NO_SWIZZLE = 0, SWIZZLE_32_4_4 = 1 };

--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -2223,17 +2223,26 @@ void grouped_gemm(
     int64_t *DPtrArrayDev,
     const void *lddArrayDev,
     int batchCount,
-    bool use_int64_dims) {
+    bool use_int64_dims,
+    const std::optional<GroupedGemmScaleOptions>& scales) {
+  const bool scaled = scales.has_value();
 #if !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13030
   cudaDeviceProp* prop = at::cuda::getCurrentDeviceProperties();
   const bool sm90 = prop->major == 9;
-  TORCH_CHECK(prop->major >= 9 && prop->major < 12, "grouped cublasLtMatmul requires SM 9.0-11.0");
+  if (scaled) {
+    TORCH_CHECK(
+        scales->A_scale_ptr != nullptr && scales->B_scale_ptr != nullptr,
+        "scaled grouped cublasLtMatmul requires A and B scales");
+    TORCH_CHECK(prop->major == 10 || prop->major == 11, "scaled grouped cublasLtMatmul requires SM 10.x or 11.0");
+  } else {
+    TORCH_CHECK(prop->major >= 9 && prop->major < 12, "grouped cublasLtMatmul requires SM 9.0-11.0");
+  }
 
   const auto computeType = CUBLAS_COMPUTE_32F;
   const auto scaleType = CUDA_R_32F;
   const auto pointer_mode = CUBLASLT_POINTER_MODE_DEVICE;
-  const int64_t alphaBatchStride = sm90 ? 0 : 1;
-  const int64_t betaBatchStride = sm90 ? 0 : 1;
+  const int64_t alphaBatchStride = !scaled && sm90 ? 0 : 1;
+  const int64_t betaBatchStride = !scaled && sm90 ? 0 : 1;
 
   cublasOperation_t opa = detail::cublasOpFromChar(transa);
   cublasOperation_t opb = detail::cublasOpFromChar(transb);
@@ -2244,20 +2253,73 @@ void grouped_gemm(
   computeDesc.setAttribute(CUBLASLT_MATMUL_DESC_POINTER_MODE, pointer_mode);
   computeDesc.setAttribute(CUBLASLT_MATMUL_DESC_ALPHA_BATCH_STRIDE, alphaBatchStride);
   computeDesc.setAttribute(CUBLASLT_MATMUL_DESC_BETA_BATCH_STRIDE, betaBatchStride);
+  if (scaled) {
+    const int a_scale_mode = detail::cublasLtMatmulScaleMode(
+        scales->a_scaling_type,
+        scales->A_scale_dtype,
+        scales->use_fast_accum);
+    const int b_scale_mode = detail::cublasLtMatmulScaleMode(
+        scales->b_scaling_type,
+        scales->B_scale_dtype,
+        scales->use_fast_accum);
+    computeDesc.setAttribute(CUBLASLT_MATMUL_DESC_A_SCALE_POINTER, scales->A_scale_ptr);
+    computeDesc.setAttribute(CUBLASLT_MATMUL_DESC_B_SCALE_POINTER, scales->B_scale_ptr);
+    if (scales->D_scale_ptr != nullptr) {
+      computeDesc.setAttribute(CUBLASLT_MATMUL_DESC_D_SCALE_POINTER, scales->D_scale_ptr);
+    }
+    computeDesc.setAttribute(CUBLASLT_MATMUL_DESC_A_SCALE_MODE, a_scale_mode);
+    computeDesc.setAttribute(CUBLASLT_MATMUL_DESC_B_SCALE_MODE, b_scale_mode);
 
-  CuBlasLtGroupedMatrixLayout Adesc(ScalarTypeToCudaDataType(input_dtype), batchCount, mArrayDev, kArrayDev, ldaArrayDev, opa != CUBLAS_OP_N, use_int64_dims);
-  CuBlasLtGroupedMatrixLayout Bdesc(ScalarTypeToCudaDataType(input_dtype), batchCount, kArrayDev, nArrayDev, ldbArrayDev, opb != CUBLAS_OP_N, use_int64_dims);
-  CuBlasLtGroupedMatrixLayout Cdesc(ScalarTypeToCudaDataType(result_dtype), batchCount, mArrayDev, nArrayDev, ldcArrayDev, false, use_int64_dims);
-  CuBlasLtGroupedMatrixLayout Ddesc(ScalarTypeToCudaDataType(result_dtype), batchCount, mArrayDev, nArrayDev, lddArrayDev, false, use_int64_dims);
+    const int8_t fastAccuMode = scales->use_fast_accum ? 1 : 0;
+    computeDesc.setAttribute(CUBLASLT_MATMUL_DESC_FAST_ACCUM, fastAccuMode);
+  }
+
+  CuBlasLtGroupedMatrixLayout Adesc(
+      ScalarTypeToCudaDataType(input_dtype),
+      batchCount,
+      mArrayDev,
+      kArrayDev,
+      ldaArrayDev,
+      opa != CUBLAS_OP_N,
+      use_int64_dims);
+  CuBlasLtGroupedMatrixLayout Bdesc(
+      ScalarTypeToCudaDataType(scaled ? scales->B_dtype : input_dtype),
+      batchCount,
+      kArrayDev,
+      nArrayDev,
+      ldbArrayDev,
+      opb != CUBLAS_OP_N,
+      use_int64_dims);
+  CuBlasLtGroupedMatrixLayout Cdesc(
+      ScalarTypeToCudaDataType(result_dtype),
+      batchCount,
+      mArrayDev,
+      nArrayDev,
+      ldcArrayDev,
+      false,
+      use_int64_dims);
+  CuBlasLtGroupedMatrixLayout Ddesc(
+      ScalarTypeToCudaDataType(result_dtype),
+      batchCount,
+      mArrayDev,
+      nArrayDev,
+      lddArrayDev,
+      false,
+      use_int64_dims);
 
   CuBlasLtMatmulPreference preference;
   auto ltworkspace = CublasLtWorkspace();
   auto stream = at::cuda::getCurrentCUDAStream();
   preference.setAttribute(CUBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES, ltworkspace.size);
-  // As of CUDA 13.3u1, cuBLASLt grouped GEMM heuristics return suboptimal algos when inputs are row major
-  // Swap average rows and cols to recover optimal kernels, and update this once fixed in cuBLASLt
+  // cuBLAS 13.6.x grouped GEMM heuristics return suboptimal algos when inputs are row major.
+  // Swap average rows and cols to recover optimal kernels; other versions take the values as-is.
+#if defined(CUBLAS_VERSION) && CUBLAS_VERSION >= 130600 && CUBLAS_VERSION < 130700
   preference.setAttribute(CUBLASLT_MATMUL_PREF_GROUPED_DESC_D_AVERAGE_ROWS, avgN);
   preference.setAttribute(CUBLASLT_MATMUL_PREF_GROUPED_DESC_D_AVERAGE_COLS, avgM);
+#else
+  preference.setAttribute(CUBLASLT_MATMUL_PREF_GROUPED_DESC_D_AVERAGE_ROWS, avgM);
+  preference.setAttribute(CUBLASLT_MATMUL_PREF_GROUPED_DESC_D_AVERAGE_COLS, avgN);
+#endif
   preference.setAttribute(CUBLASLT_MATMUL_PREF_GROUPED_AVERAGE_REDUCTION_DIM, avgK);
 
   cublasLtMatmulHeuristicResult_t heuristicResult = {};
@@ -2306,10 +2368,14 @@ void grouped_gemm(
       cublasStatus == CUBLAS_STATUS_SUCCESS,
       "CUDA error: ",
       at::cuda::blas::_cublasGetErrorEnum(cublasStatus),
-      " when calling grouped cublasLtMatmul");
+      " when calling ",
+      scaled ? "scaled grouped cublasLtMatmul" : "grouped cublasLtMatmul");
   return;
 #else
-  TORCH_CHECK(false, "grouped cublasLtMatmul requires CUDA >= 13.3 and is not supported on ROCm. Current build does not meet these requirements.");
+  TORCH_CHECK(
+      false,
+      scaled ? "scaled grouped cublasLtMatmul" : "grouped cublasLtMatmul",
+      " requires CUDA >= 13.3 and is not supported on ROCm. Current build does not meet these requirements.");
 #endif // !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13030
 }
 

--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -2264,11 +2264,12 @@ void grouped_gemm(
         scales->use_fast_accum);
     computeDesc.setAttribute(CUBLASLT_MATMUL_DESC_A_SCALE_POINTER, scales->A_scale_ptr);
     computeDesc.setAttribute(CUBLASLT_MATMUL_DESC_B_SCALE_POINTER, scales->B_scale_ptr);
-    if (scales->D_scale_ptr != nullptr) {
-      computeDesc.setAttribute(CUBLASLT_MATMUL_DESC_D_SCALE_POINTER, scales->D_scale_ptr);
-    }
     computeDesc.setAttribute(CUBLASLT_MATMUL_DESC_A_SCALE_MODE, a_scale_mode);
     computeDesc.setAttribute(CUBLASLT_MATMUL_DESC_B_SCALE_MODE, b_scale_mode);
+    if (scales->D_scale_ptr != nullptr) {
+      // TODO: When D scaling support is added, update this and GroupedGemmScaleOptions to set D scale mode)
+      computeDesc.setAttribute(CUBLASLT_MATMUL_DESC_D_SCALE_POINTER, scales->D_scale_ptr);
+    }
 
     const int8_t fastAccuMode = scales->use_fast_accum ? 1 : 0;
     computeDesc.setAttribute(CUBLASLT_MATMUL_DESC_FAST_ACCUM, fastAccuMode);

--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -2259,7 +2259,7 @@ void grouped_gemm(
     TORCH_CHECK(
         scales->A_scale_ptr != nullptr && scales->B_scale_ptr != nullptr,
         "scaled grouped cublasLtMatmul requires A and B scales");
-    TORCH_CHECK(prop->major == 10 || prop->major == 11, "scaled grouped cublasLtMatmul requires SM 10.x or 11.0");
+    TORCH_CHECK(prop->major >= 9 && prop->major < 12, "scaled grouped cublasLtMatmul requires SM 9.0-11.0");
   } else {
     TORCH_CHECK(prop->major >= 9 && prop->major < 12, "grouped cublasLtMatmul requires SM 9.0-11.0");
   }
@@ -2267,8 +2267,8 @@ void grouped_gemm(
   const auto computeType = CUBLAS_COMPUTE_32F;
   const auto scaleType = CUDA_R_32F;
   const auto pointer_mode = CUBLASLT_POINTER_MODE_DEVICE;
-  const int64_t alphaBatchStride = !scaled && sm90 ? 0 : 1;
-  const int64_t betaBatchStride = !scaled && sm90 ? 0 : 1;
+  const int64_t alphaBatchStride = sm90 ? 0 : 1;
+  const int64_t betaBatchStride = sm90 ? 0 : 1;
 
   cublasOperation_t opa = detail::cublasOpFromChar(transa);
   cublasOperation_t opb = detail::cublasOpFromChar(transb);

--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -2249,17 +2249,26 @@ void grouped_gemm(
     int64_t *DPtrArrayDev,
     const void *lddArrayDev,
     int batchCount,
-    bool use_int64_dims) {
+    bool use_int64_dims,
+    const std::optional<GroupedGemmScaleOptions>& scales) {
+  const bool scaled = scales.has_value();
 #if !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13030
   cudaDeviceProp* prop = at::cuda::getCurrentDeviceProperties();
   const bool sm90 = prop->major == 9;
-  TORCH_CHECK(prop->major >= 9 && prop->major < 12, "grouped cublasLtMatmul requires SM 9.0-11.0");
+  if (scaled) {
+    TORCH_CHECK(
+        scales->A_scale_ptr != nullptr && scales->B_scale_ptr != nullptr,
+        "scaled grouped cublasLtMatmul requires A and B scales");
+    TORCH_CHECK(prop->major == 10 || prop->major == 11, "scaled grouped cublasLtMatmul requires SM 10.x or 11.0");
+  } else {
+    TORCH_CHECK(prop->major >= 9 && prop->major < 12, "grouped cublasLtMatmul requires SM 9.0-11.0");
+  }
 
   const auto computeType = CUBLAS_COMPUTE_32F;
   const auto scaleType = CUDA_R_32F;
   const auto pointer_mode = CUBLASLT_POINTER_MODE_DEVICE;
-  const int64_t alphaBatchStride = sm90 ? 0 : 1;
-  const int64_t betaBatchStride = sm90 ? 0 : 1;
+  const int64_t alphaBatchStride = !scaled && sm90 ? 0 : 1;
+  const int64_t betaBatchStride = !scaled && sm90 ? 0 : 1;
 
   cublasOperation_t opa = detail::cublasOpFromChar(transa);
   cublasOperation_t opb = detail::cublasOpFromChar(transb);
@@ -2270,11 +2279,59 @@ void grouped_gemm(
   computeDesc.setAttribute(CUBLASLT_MATMUL_DESC_POINTER_MODE, pointer_mode);
   computeDesc.setAttribute(CUBLASLT_MATMUL_DESC_ALPHA_BATCH_STRIDE, alphaBatchStride);
   computeDesc.setAttribute(CUBLASLT_MATMUL_DESC_BETA_BATCH_STRIDE, betaBatchStride);
+  if (scaled) {
+    const int a_scale_mode = detail::cublasLtMatmulScaleMode(
+        scales->a_scaling_type,
+        scales->A_scale_dtype,
+        scales->use_fast_accum);
+    const int b_scale_mode = detail::cublasLtMatmulScaleMode(
+        scales->b_scaling_type,
+        scales->B_scale_dtype,
+        scales->use_fast_accum);
+    computeDesc.setAttribute(CUBLASLT_MATMUL_DESC_A_SCALE_POINTER, scales->A_scale_ptr);
+    computeDesc.setAttribute(CUBLASLT_MATMUL_DESC_B_SCALE_POINTER, scales->B_scale_ptr);
+    if (scales->D_scale_ptr != nullptr) {
+      computeDesc.setAttribute(CUBLASLT_MATMUL_DESC_D_SCALE_POINTER, scales->D_scale_ptr);
+    }
+    computeDesc.setAttribute(CUBLASLT_MATMUL_DESC_A_SCALE_MODE, a_scale_mode);
+    computeDesc.setAttribute(CUBLASLT_MATMUL_DESC_B_SCALE_MODE, b_scale_mode);
 
-  CuBlasLtGroupedMatrixLayout Adesc(ScalarTypeToCudaDataType(input_dtype), batchCount, mArrayDev, kArrayDev, ldaArrayDev, opa != CUBLAS_OP_N, use_int64_dims);
-  CuBlasLtGroupedMatrixLayout Bdesc(ScalarTypeToCudaDataType(input_dtype), batchCount, kArrayDev, nArrayDev, ldbArrayDev, opb != CUBLAS_OP_N, use_int64_dims);
-  CuBlasLtGroupedMatrixLayout Cdesc(ScalarTypeToCudaDataType(result_dtype), batchCount, mArrayDev, nArrayDev, ldcArrayDev, false, use_int64_dims);
-  CuBlasLtGroupedMatrixLayout Ddesc(ScalarTypeToCudaDataType(result_dtype), batchCount, mArrayDev, nArrayDev, lddArrayDev, false, use_int64_dims);
+    const int8_t fastAccuMode = scales->use_fast_accum ? 1 : 0;
+    computeDesc.setAttribute(CUBLASLT_MATMUL_DESC_FAST_ACCUM, fastAccuMode);
+  }
+
+  CuBlasLtGroupedMatrixLayout Adesc(
+      ScalarTypeToCudaDataType(input_dtype),
+      batchCount,
+      mArrayDev,
+      kArrayDev,
+      ldaArrayDev,
+      opa != CUBLAS_OP_N,
+      use_int64_dims);
+  CuBlasLtGroupedMatrixLayout Bdesc(
+      ScalarTypeToCudaDataType(scaled ? scales->B_dtype : input_dtype),
+      batchCount,
+      kArrayDev,
+      nArrayDev,
+      ldbArrayDev,
+      opb != CUBLAS_OP_N,
+      use_int64_dims);
+  CuBlasLtGroupedMatrixLayout Cdesc(
+      ScalarTypeToCudaDataType(result_dtype),
+      batchCount,
+      mArrayDev,
+      nArrayDev,
+      ldcArrayDev,
+      false,
+      use_int64_dims);
+  CuBlasLtGroupedMatrixLayout Ddesc(
+      ScalarTypeToCudaDataType(result_dtype),
+      batchCount,
+      mArrayDev,
+      nArrayDev,
+      lddArrayDev,
+      false,
+      use_int64_dims);
 
   CuBlasLtMatmulPreference preference;
   auto ltworkspace = CublasLtWorkspace();
@@ -2330,10 +2387,14 @@ void grouped_gemm(
       cublasStatus == CUBLAS_STATUS_SUCCESS,
       "CUDA error: ",
       at::cuda::blas::_cublasGetErrorEnum(cublasStatus),
-      " when calling grouped cublasLtMatmul");
+      " when calling ",
+      scaled ? "scaled grouped cublasLtMatmul" : "grouped cublasLtMatmul");
   return;
 #else
-  TORCH_CHECK(false, "grouped cublasLtMatmul requires CUDA >= 13.3 and is not supported on ROCm. Current build does not meet these requirements.");
+  TORCH_CHECK(
+      false,
+      scaled ? "scaled grouped cublasLtMatmul" : "grouped cublasLtMatmul",
+      " requires CUDA >= 13.3 and is not supported on ROCm. Current build does not meet these requirements.");
 #endif // !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13030
 }
 

--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -2395,7 +2395,8 @@ void grouped_gemm(
   TORCH_CHECK(
       false,
       scaled ? "scaled grouped cublasLtMatmul" : "grouped cublasLtMatmul",
-      " requires CUDA >= 13.3 and is not supported on ROCm. Current build does not meet these requirements.");
+      " requires CUDA >= ", scaled ? "13.4" : "13.3",
+      " and is not supported on ROCm. Current build does not meet these requirements.");
 #endif // !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13030
 }
 

--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -2290,11 +2290,12 @@ void grouped_gemm(
         scales->use_fast_accum);
     computeDesc.setAttribute(CUBLASLT_MATMUL_DESC_A_SCALE_POINTER, scales->A_scale_ptr);
     computeDesc.setAttribute(CUBLASLT_MATMUL_DESC_B_SCALE_POINTER, scales->B_scale_ptr);
-    if (scales->D_scale_ptr != nullptr) {
-      computeDesc.setAttribute(CUBLASLT_MATMUL_DESC_D_SCALE_POINTER, scales->D_scale_ptr);
-    }
     computeDesc.setAttribute(CUBLASLT_MATMUL_DESC_A_SCALE_MODE, a_scale_mode);
     computeDesc.setAttribute(CUBLASLT_MATMUL_DESC_B_SCALE_MODE, b_scale_mode);
+    if (scales->D_scale_ptr != nullptr) {
+      // TODO: When D scaling support is added, update this and GroupedGemmScaleOptions to set D scale mode)
+      computeDesc.setAttribute(CUBLASLT_MATMUL_DESC_D_SCALE_POINTER, scales->D_scale_ptr);
+    }
 
     const int8_t fastAccuMode = scales->use_fast_accum ? 1 : 0;
     computeDesc.setAttribute(CUBLASLT_MATMUL_DESC_FAST_ACCUM, fastAccuMode);

--- a/aten/src/ATen/cuda/CUDABlas.h
+++ b/aten/src/ATen/cuda/CUDABlas.h
@@ -16,6 +16,7 @@
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/BlasBackend.h>
 #include <ATen/OpMathType.h>
+#include <optional>
 
 namespace at::cuda::blas {
 
@@ -178,6 +179,18 @@ void scaled_gemm(
     bool use_fast_accum,
     const std::optional<Tensor>& alpha);
 
+struct GroupedGemmScaleOptions {
+  ScalarType B_dtype;
+  const void* A_scale_ptr;
+  const void* B_scale_ptr;
+  const void* D_scale_ptr;
+  bool use_fast_accum;
+  ScalarType A_scale_dtype;
+  ScalarType B_scale_dtype;
+  at::blas::ScalingType a_scaling_type;
+  at::blas::ScalingType b_scaling_type;
+};
+
 void grouped_gemm(
       char transa,
       char transb,
@@ -202,7 +215,8 @@ void grouped_gemm(
       int64_t* DPtrArrayDev,
       const void* lddArrayDev,
       int batchCount,
-      bool use_int64_dims);
+      bool use_int64_dims,
+      const std::optional<GroupedGemmScaleOptions>& scales = std::nullopt);
 
 #define CUDABLAS_BGEMM_ARGTYPES(Dtype)  CUDABLAS_BGEMM_ARGTYPES_AND_C_DTYPE(Dtype, Dtype)
 

--- a/aten/src/ATen/cuda/CUDABlas.h
+++ b/aten/src/ATen/cuda/CUDABlas.h
@@ -16,6 +16,7 @@
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/BlasBackend.h>
 #include <ATen/OpMathType.h>
+#include <optional>
 
 namespace at::cuda::blas {
 
@@ -164,6 +165,18 @@ void scaled_gemm(
     bool use_fast_accum,
     const std::optional<Tensor>& alpha);
 
+struct GroupedGemmScaleOptions {
+  ScalarType B_dtype;
+  const void* A_scale_ptr;
+  const void* B_scale_ptr;
+  const void* D_scale_ptr;
+  bool use_fast_accum;
+  ScalarType A_scale_dtype;
+  ScalarType B_scale_dtype;
+  at::blas::ScalingType a_scaling_type;
+  at::blas::ScalingType b_scaling_type;
+};
+
 void grouped_gemm(
       char transa,
       char transb,
@@ -188,7 +201,8 @@ void grouped_gemm(
       int64_t* DPtrArrayDev,
       const void* lddArrayDev,
       int batchCount,
-      bool use_int64_dims);
+      bool use_int64_dims,
+      const std::optional<GroupedGemmScaleOptions>& scales = std::nullopt);
 
 #define CUDABLAS_BGEMM_ARGTYPES(Dtype)  CUDABLAS_BGEMM_ARGTYPES_AND_C_DTYPE(Dtype, Dtype)
 

--- a/aten/src/ATen/cuda/detail/CublasLtUtils.h
+++ b/aten/src/ATen/cuda/detail/CublasLtUtils.h
@@ -242,10 +242,10 @@ inline int cublasLtMatmulScaleMode(
 #endif
     case at::blas::ScalingType::GroupWise:
       TORCH_CHECK(scale_dtype == kFloat);
-#if !defined(USE_ROCM) && CUDA_VERSION >= 13020
+#if !defined(USE_ROCM) && CUDA_VERSION >= 13030
       return CUBLASLT_MATMUL_MATRIX_SCALE_PER_BATCH_SCALAR_32F;
 #else
-      TORCH_CHECK(false, "per-batch scalar scaling requires CUDA >= 13.2");
+      TORCH_CHECK(false, "per-batch scalar scaling requires CUDA >= 13.3");
 #endif
     default:
       TORCH_CHECK(false);

--- a/aten/src/ATen/cuda/detail/CublasLtUtils.h
+++ b/aten/src/ATen/cuda/detail/CublasLtUtils.h
@@ -240,6 +240,13 @@ inline int cublasLtMatmulScaleMode(
 #else
       return 0;
 #endif
+    case at::blas::ScalingType::GroupWise:
+      TORCH_CHECK(scale_dtype == kFloat);
+#if !defined(USE_ROCM) && CUDA_VERSION >= 13020
+      return CUBLASLT_MATMUL_MATRIX_SCALE_PER_BATCH_SCALAR_32F;
+#else
+      TORCH_CHECK(false, "per-batch scalar scaling requires CUDA >= 13.2");
+#endif
     default:
       TORCH_CHECK(false);
   }

--- a/aten/src/ATen/cuda/detail/CublasLtUtils.h
+++ b/aten/src/ATen/cuda/detail/CublasLtUtils.h
@@ -242,10 +242,10 @@ inline int cublasLtMatmulScaleMode(
 #endif
     case at::blas::ScalingType::GroupWise:
       TORCH_CHECK(scale_dtype == kFloat);
-#if !defined(USE_ROCM) && CUDA_VERSION >= 13030
+#if !defined(USE_ROCM) && CUDA_VERSION >= 13040
       return CUBLASLT_MATMUL_MATRIX_SCALE_PER_BATCH_SCALAR_32F;
 #else
-      TORCH_CHECK(false, "per-batch scalar scaling requires CUDA >= 13.3");
+      TORCH_CHECK(false, "per-batch scalar scaling requires CUDA >= 13.4");
 #endif
     default:
       TORCH_CHECK(false);

--- a/aten/src/ATen/native/cuda/CublasGroupedArgs.cu
+++ b/aten/src/ATen/native/cuda/CublasGroupedArgs.cu
@@ -65,6 +65,17 @@ void check_cublaslt_grouped_alignment(
   }
 }
 
+// cuBLAS VEC32_UE8M0 scale tensor size (bytes, since e8m0 is 1 byte each).
+// Mirrors getScaleTensorSize() from the cuBLAS samples.
+__device__ __forceinline__ int64_t cublas_vec32_scale_size(int inner, int outer) {
+  const int BLOCK_ROWS = 128; // S_BLOCK_INNER(4) * S_VSCALE(32)
+  const int BLOCK_COLS = 128; // S_BLOCK_COLS(32) * S_BLOCK_ROWS(4)
+  const int S_VSCALE = 32;
+  int64_t s_rows = ((inner + BLOCK_ROWS - 1) / BLOCK_ROWS) * (BLOCK_ROWS / S_VSCALE);
+  int64_t s_cols = ((outer + BLOCK_COLS - 1) / BLOCK_COLS) * BLOCK_COLS;
+  return s_rows * s_cols;
+}
+
 template <typename IndexType>
 __global__ void populate_cublas_grouped_args_kernel(
     const int32_t* __restrict__ offs,
@@ -79,7 +90,11 @@ __global__ void populate_cublas_grouped_args_kernel(
     IndexType* __restrict__ lda_out, IndexType* __restrict__ ldb_out, IndexType* __restrict__ ldd_out,
     int64_t* __restrict__ APtr_out, int64_t* __restrict__ BPtr_out, int64_t* __restrict__ DPtr_out,
     int64_t* __restrict__ alphaPtr_out, int64_t* __restrict__ betaPtr_out,
-    float* __restrict__ alpha_ptr, float* __restrict__ beta_ptr) {
+    float* __restrict__ alpha_ptr, float* __restrict__ beta_ptr,
+    int64_t base_scale_a, int64_t base_scale_b,
+    int64_t scale_a_stride_bytes, int64_t scale_b_stride_bytes,
+    int32_t scale_inner, int32_t scale_a_outer, int32_t scale_b_outer,
+    int64_t* __restrict__ scalePtrA_out, int64_t* __restrict__ scalePtrB_out) {
   int i = threadIdx.x;
 
   if (i == 0) {
@@ -140,6 +155,38 @@ __global__ void populate_cublas_grouped_args_kernel(
   // per-group alpha/beta as arrays of device pointers.
   alphaPtr_out[i] = reinterpret_cast<int64_t>(alpha_ptr);
   betaPtr_out[i] = reinterpret_cast<int64_t>(beta_ptr);
+
+  if (scalePtrA_out != nullptr) {
+    if (scale_a_stride_bytes != 0) {
+      // Uniform stride (3D/3D or GroupWise)
+      scalePtrA_out[i] = base_scale_a + i * scale_a_stride_bytes;
+    } else {
+      // Variable-size groups: prefix-sum over per-group scale sizes.
+      // A 0 value in scale_inner or scale_a_outer means "use delta from offs".
+      int64_t offset = 0;
+      for (int j = 0; j < i; j++) {
+        int32_t dim_j = (j == 0) ? offs[j] : offs[j] - offs[j - 1];
+        int32_t inner = scale_inner ? scale_inner : dim_j;
+        int32_t outer = scale_a_outer ? scale_a_outer : dim_j;
+        offset += cublas_vec32_scale_size(inner, outer);
+      }
+      scalePtrA_out[i] = base_scale_a + offset;
+    }
+  }
+  if (scalePtrB_out != nullptr) {
+    if (scale_b_stride_bytes != 0) {
+      scalePtrB_out[i] = base_scale_b + i * scale_b_stride_bytes;
+    } else {
+      int64_t offset = 0;
+      for (int j = 0; j < i; j++) {
+        int32_t dim_j = (j == 0) ? offs[j] : offs[j] - offs[j - 1];
+        int32_t inner = scale_inner ? scale_inner : dim_j;
+        int32_t outer = scale_b_outer ? scale_b_outer : dim_j;
+        offset += cublas_vec32_scale_size(inner, outer);
+      }
+      scalePtrB_out[i] = base_scale_b + offset;
+    }
+  }
 }
 
 // Carves up args.buf into typed sub-arrays, stores the pointers on `args`,
@@ -159,6 +206,10 @@ void launch_populate_cublas_grouped_args(
     int64_t a_offs_stride, int64_t a_idx_stride,
     int64_t b_offs_stride, int64_t b_idx_stride,
     int64_t d_offs_stride, int64_t d_idx_stride,
+    int64_t base_scale_a, int64_t base_scale_b,
+    int64_t scale_a_stride_bytes, int64_t scale_b_stride_bytes,
+    int32_t scale_inner, int32_t scale_a_outer, int32_t scale_b_outer,
+    int64_t* scalePtrA_out, int64_t* scalePtrB_out,
     cudaStream_t stream) {
   IndexType* m_arr   = reinterpret_cast<IndexType*>(args.buf.data_ptr());
   IndexType* n_arr   = m_arr + batchCount;
@@ -195,7 +246,11 @@ void launch_populate_cublas_grouped_args(
       lda_arr, ldb_arr, ldd_arr,
       args.APtrArray, args.BPtrArray, args.DPtrArray,
       args.alphaPtrArray, args.betaPtrArray,
-      args.alphaScalar, args.betaScalar);
+      args.alphaScalar, args.betaScalar,
+      base_scale_a, base_scale_b,
+      scale_a_stride_bytes, scale_b_stride_bytes,
+      scale_inner, scale_a_outer, scale_b_outer,
+      scalePtrA_out, scalePtrB_out);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 }
 
@@ -207,7 +262,12 @@ cublasGroupedArgs::cublasGroupedArgs(
     const std::optional<Tensor>& offs,
     Tensor& c,
     int batchCount_,
-    bool needs_int64) {
+    bool needs_int64,
+    const std::optional<Tensor>& scale_a,
+    const std::optional<Tensor>& scale_b,
+    const std::optional<Tensor>& scale_result,
+    const std::optional<at::blas::ScalingType>& scaling_choice_a,
+    const std::optional<at::blas::ScalingType>& scaling_choice_b) {
   const bool a_is_2d = mat1.dim() == 2;
   const bool b_is_2d = mat2.dim() == 2;
   if (a_is_2d || b_is_2d) {
@@ -229,6 +289,31 @@ cublasGroupedArgs::cublasGroupedArgs(
   const int64_t lda_val = transa == 'n' ? mat1.stride(-2) : mat1.stride(-1);
   const int64_t ldb_val = transb == 'n' ? mat2.stride(-2) : mat2.stride(-1);
   const int64_t ldd_val = c.stride(-2);
+
+  if (scale_a && scale_b) {
+    scale_mata_ptr = scale_a->data_ptr();
+    scale_matb_ptr = scale_b->data_ptr();
+    scale_mata_dtype = scale_a->scalar_type();
+    scale_matb_dtype = scale_b->scalar_type();
+
+    TORCH_CHECK(scaling_choice_a.has_value() && scaling_choice_b.has_value(),
+        "Scaling choice must be provided when scale tensors are provided");
+    scale_mata_scaling_type = scaling_choice_a.value();
+    scale_matb_scaling_type = scaling_choice_b.value();
+  }
+  if (scale_result) {
+    scale_result_ptr = scale_result->data_ptr();
+  }
+
+  // GroupWise and BlockWise1x32 scales need device-side pointer arrays
+  // (one pointer per group) because cuBLAS expects the scale pointer to
+  // be an array of device pointers for grouped GEMM.
+  auto needs_ptr_array = [](at::blas::ScalingType st) {
+    return st == at::blas::ScalingType::GroupWise
+        || st == at::blas::ScalingType::BlockWise1x32;
+  };
+  const bool mata_needs_ptr = needs_ptr_array(scale_mata_scaling_type);
+  const bool matb_needs_ptr = needs_ptr_array(scale_matb_scaling_type);
 
   // Determine per-case which dimensions are variable (delta-based)
   // and how pointer strides work
@@ -292,11 +377,62 @@ cublasGroupedArgs::cublasGroupedArgs(
   //   6 x dim_elem_size[batchCount]  (m, n, k, lda, ldb, ldd)
   //   5 x int64[batchCount]          (A, B, D, alpha, beta ptrs)
   //   2 x float                      (alpha, beta scalars)
+  // + optionally up to 2 x int64[batchCount] for per-group scale pointer arrays
+  const int scale_ptr_arrays = (mata_needs_ptr ? 1 : 0) + (matb_needs_ptr ? 1 : 0);
   const int64_t buf_bytes =
       static_cast<int64_t>(batchCount) * 6 * dim_elem_size +
       static_cast<int64_t>(batchCount) * 5 * sizeof(int64_t) +
       2 * sizeof(float);
-  buf = at::empty({buf_bytes}, mat1.options().dtype(at::kByte));
+  const int64_t scale_bytes = static_cast<int64_t>(scale_ptr_arrays) * batchCount * sizeof(int64_t);
+  buf = at::empty({buf_bytes + scale_bytes}, mat1.options().dtype(at::kByte));
+
+  // Per-group scale pointer arrays
+  int64_t offset = buf_bytes;
+  int64_t* scaleAPtrArray = nullptr;
+  int64_t* scaleBPtrArray = nullptr;
+  if (mata_needs_ptr) {
+    scaleAPtrArray = reinterpret_cast<int64_t*>(buf.data_ptr() + offset);
+    offset += batchCount * sizeof(int64_t);
+  }
+  if (matb_needs_ptr) {
+    scaleBPtrArray = reinterpret_cast<int64_t*>(buf.data_ptr() + offset);
+  }
+
+  const int64_t base_scale_a = scale_a ? reinterpret_cast<int64_t>(scale_a->data_ptr()) : 0;
+  const int64_t base_scale_b = scale_b ? reinterpret_cast<int64_t>(scale_b->data_ptr()) : 0;
+
+  // Byte stride between consecutive groups' scale data.
+  // For GroupWise (1D float): stride(0)*elem_size
+  // For BlockWise1x32 3D/3D: stride(0)*elem_size
+  // For BlockWise1x32 with jagged dims: 0 signals variable-size mode
+  const bool mata_blockwise = scale_mata_scaling_type == at::blas::ScalingType::BlockWise1x32;
+  const bool matb_blockwise = scale_matb_scaling_type == at::blas::ScalingType::BlockWise1x32;
+  const bool blockwise_variable_a = mata_blockwise && a_is_2d;
+  const bool blockwise_variable_b = matb_blockwise && b_is_2d;
+  const int64_t scale_a_stride_bytes = (scale_a && !blockwise_variable_a)
+      ? scale_a->stride(0) * scale_a->element_size()
+      : 0;
+  const int64_t scale_b_stride_bytes = (scale_b && !blockwise_variable_b)
+      ? scale_b->stride(0) * scale_b->element_size()
+      : 0;
+
+  // For variable-size BlockWise1x32, pass inner/outer dims for per-group
+  // scale size computation. A value of 0 means "substitute the jagged
+  // dimension (delta from offsets) at runtime".
+  // cuBLAS-A scale: getScaleTensorSize(inner=K, outer=M)
+  // cuBLAS-B scale: getScaleTensorSize(inner=K, outer=N)
+  const int32_t scale_inner = k_is_delta ? 0 : cublas_k;
+  const int32_t scale_a_outer = m_is_delta ? 0 : cublas_m;
+  const int32_t scale_b_outer = n_is_delta ? 0 : cublas_n;
+
+  // For per-group scales, point to the device-side pointer arrays
+  // instead of the raw data pointer
+  if (mata_needs_ptr) {
+    scale_mata_ptr = scaleAPtrArray;
+  }
+  if (matb_needs_ptr) {
+    scale_matb_ptr = scaleBPtrArray;
+  }
 
   const int64_t base_A = reinterpret_cast<int64_t>(mat1.data_ptr());
   const int64_t base_B = reinterpret_cast<int64_t>(mat2.data_ptr());
@@ -320,6 +456,10 @@ cublasGroupedArgs::cublasGroupedArgs(
       a_offs_stride, a_idx_stride,
       b_offs_stride, b_idx_stride,
       d_offs_stride, d_idx_stride,
+      base_scale_a, base_scale_b,
+      scale_a_stride_bytes, scale_b_stride_bytes,
+      scale_inner, scale_a_outer, scale_b_outer,
+      scaleAPtrArray, scaleBPtrArray,
       stream);
 }
 

--- a/aten/src/ATen/native/cuda/CublasGroupedArgs.cu
+++ b/aten/src/ATen/native/cuda/CublasGroupedArgs.cu
@@ -17,6 +17,8 @@ namespace at::native {
 
 namespace {
 
+constexpr int kMaxGroupedGemmGroups = 1024;
+
 void check_cublaslt_grouped_alignment(
     bool a_is_2d,
     bool b_is_2d,
@@ -156,36 +158,49 @@ __global__ void populate_cublas_grouped_args_kernel(
   alphaPtr_out[i] = reinterpret_cast<int64_t>(alpha_ptr);
   betaPtr_out[i] = reinterpret_cast<int64_t>(beta_ptr);
 
-  if (scalePtrA_out != nullptr) {
-    if (scale_a_stride_bytes != 0) {
-      // Uniform stride (3D/3D or GroupWise)
-      scalePtrA_out[i] = base_scale_a + i * scale_a_stride_bytes;
-    } else {
-      // Variable-size groups: prefix-sum over per-group scale sizes.
-      // A 0 value in scale_inner or scale_a_outer means "use delta from offs".
-      int64_t offset = 0;
-      for (int j = 0; j < i; j++) {
-        int32_t dim_j = (j == 0) ? offs[j] : offs[j] - offs[j - 1];
-        int32_t inner = scale_inner ? scale_inner : dim_j;
-        int32_t outer = scale_a_outer ? scale_a_outer : dim_j;
-        offset += cublas_vec32_scale_size(inner, outer);
-      }
-      scalePtrA_out[i] = base_scale_a + offset;
+  // Variable-size scale offsets: exclusive prefix-sum over per-group scale
+  // sizes via parallel scan. A 0 value in scale_inner or scale_*_outer
+  // means "use delta (per-group extent) from offs".
+  const bool scan_a = (scalePtrA_out != nullptr) && (scale_a_stride_bytes == 0);
+  const bool scan_b = (scalePtrB_out != nullptr) && (scale_b_stride_bytes == 0);
+  if (scan_a || scan_b) {
+    __shared__ int64_t s_a[kMaxGroupedGemmGroups];
+    __shared__ int64_t s_b[kMaxGroupedGemmGroups];
+    const int32_t inner_a = scale_inner ? scale_inner : delta;
+    const int32_t inner_b = scale_inner ? scale_inner : delta;
+    const int32_t outer_a = scale_a_outer ? scale_a_outer : delta;
+    const int32_t outer_b = scale_b_outer ? scale_b_outer : delta;
+    const int64_t size_a = scan_a ? cublas_vec32_scale_size(inner_a, outer_a) : 0;
+    const int64_t size_b = scan_b ? cublas_vec32_scale_size(inner_b, outer_b) : 0;
+    s_a[i] = size_a;
+    s_b[i] = size_b;
+    __syncthreads();
+
+    // Hillis-Steele inclusive scan over both A and B sizes at once.
+    for (int stride = 1; stride < blockDim.x; stride <<= 1) {
+      int64_t add_a = (i >= stride) ? s_a[i - stride] : 0;
+      int64_t add_b = (i >= stride) ? s_b[i - stride] : 0;
+      __syncthreads();
+      s_a[i] += add_a;
+      s_b[i] += add_b;
+      __syncthreads();
+    }
+
+    // Convert inclusive scan to exclusive prefix by subtracting own value.
+    if (scan_a) {
+      scalePtrA_out[i] = base_scale_a + (s_a[i] - size_a);
+    }
+    if (scan_b) {
+      scalePtrB_out[i] = base_scale_b + (s_b[i] - size_b);
     }
   }
-  if (scalePtrB_out != nullptr) {
-    if (scale_b_stride_bytes != 0) {
-      scalePtrB_out[i] = base_scale_b + i * scale_b_stride_bytes;
-    } else {
-      int64_t offset = 0;
-      for (int j = 0; j < i; j++) {
-        int32_t dim_j = (j == 0) ? offs[j] : offs[j] - offs[j - 1];
-        int32_t inner = scale_inner ? scale_inner : dim_j;
-        int32_t outer = scale_b_outer ? scale_b_outer : dim_j;
-        offset += cublas_vec32_scale_size(inner, outer);
-      }
-      scalePtrB_out[i] = base_scale_b + offset;
-    }
+
+  // Uniform stride (3D/3D or GroupWise): direct indexed offset.
+  if (scalePtrA_out != nullptr && scale_a_stride_bytes != 0) {
+    scalePtrA_out[i] = base_scale_a + i * scale_a_stride_bytes;
+  }
+  if (scalePtrB_out != nullptr && scale_b_stride_bytes != 0) {
+    scalePtrB_out[i] = base_scale_b + i * scale_b_stride_bytes;
   }
 }
 

--- a/aten/src/ATen/native/cuda/CublasGroupedArgs.h
+++ b/aten/src/ATen/native/cuda/CublasGroupedArgs.h
@@ -2,6 +2,7 @@
 
 #include <ATen/BlasBackend.h>
 #include <ATen/core/Tensor.h>
+#include <c10/core/ScalarType.h>
 #include <optional>
 
 #if !defined(USE_ROCM)
@@ -18,7 +19,12 @@ struct cublasGroupedArgs {
       const std::optional<Tensor>& offs,
       Tensor& c,
       int batchCount,
-      bool needs_int64);
+      bool needs_int64,
+      const std::optional<Tensor>& scale_a = std::nullopt,
+      const std::optional<Tensor>& scale_b = std::nullopt,
+      const std::optional<Tensor>& scale_result = std::nullopt,
+      const std::optional<at::blas::ScalingType>& scaling_choice_a = std::nullopt,
+      const std::optional<at::blas::ScalingType>& scaling_choice_b = std::nullopt);
 
   // In grouped GEMM, m/n/k are the cuBLASLt heuristic averages. The actual
   // per-group dimensions live in mArray, nArray, and kArray.
@@ -47,6 +53,14 @@ struct cublasGroupedArgs {
   int64_t* betaPtrArray;
   float* alphaScalar;
   float* betaScalar;
+
+  void* scale_mata_ptr = nullptr;
+  void* scale_matb_ptr = nullptr;
+  void* scale_result_ptr = nullptr;
+  at::blas::ScalingType scale_mata_scaling_type = at::blas::ScalingType::TensorWise;
+  at::blas::ScalingType scale_matb_scaling_type = at::blas::ScalingType::TensorWise;
+  c10::ScalarType scale_mata_dtype = c10::ScalarType::Float;
+  c10::ScalarType scale_matb_dtype = c10::ScalarType::Float;
 };
 #endif // !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13030
 

--- a/aten/src/ATen/native/cuda/GroupedBlas.cpp
+++ b/aten/src/ATen/native/cuda/GroupedBlas.cpp
@@ -140,6 +140,17 @@ bool should_use_cublaslt_grouped_gemm(
   return bf16_grouped_gemm && at::globalContext().preferCublasltGroupedGemm();
 }
 
+int64_t cublas_vec32_scale_size_host(int64_t inner, int64_t outer) {
+  constexpr int64_t BLOCK_ROWS = 128;
+  constexpr int64_t BLOCK_COLS = 128;
+  constexpr int64_t S_VSCALE = 32;
+  int64_t s_rows = ((inner + BLOCK_ROWS - 1) / BLOCK_ROWS) * (BLOCK_ROWS / S_VSCALE);
+  int64_t s_cols = ((outer + BLOCK_COLS - 1) / BLOCK_COLS) * BLOCK_COLS;
+  return s_rows * s_cols;
+}
+
+// Needs to stay synced with is_cublaslt_grouped_scaling_type and
+// check_cublaslt_grouped_scale_recipe to support both v1 and v2 APIs
 std::optional<ScalingType> get_cublaslt_grouped_scaling_type(
     const Tensor& scale,
     int64_t batchCount) {
@@ -157,21 +168,16 @@ std::optional<ScalingType> get_cublaslt_grouped_scaling_type(
   return std::nullopt;
 }
 
-int64_t cublas_vec32_scale_size_host(int64_t inner, int64_t outer) {
-  constexpr int64_t BLOCK_ROWS = 128;
-  constexpr int64_t BLOCK_COLS = 128;
-  constexpr int64_t S_VSCALE = 32;
-  int64_t s_rows = ((inner + BLOCK_ROWS - 1) / BLOCK_ROWS) * (BLOCK_ROWS / S_VSCALE);
-  int64_t s_cols = ((outer + BLOCK_COLS - 1) / BLOCK_COLS) * BLOCK_COLS;
-  return s_rows * s_cols;
-}
-
+// Needs to stay synced with get_cublaslt_grouped_scaling_type and
+// check_cublaslt_grouped_scale_recipe to support both v1 and v2 APIs
 bool is_cublaslt_grouped_scaling_type(ScalingType scaling) {
   return scaling == ScalingType::TensorWise ||
       scaling == ScalingType::GroupWise ||
       scaling == ScalingType::BlockWise1x32;
 }
 
+// Needs to stay synced with get_cublaslt_grouped_scaling_type and
+// is_cublaslt_grouped_scaling_type to support both v1 and v2 APIs
 void check_cublaslt_grouped_scale_recipe(
     const Tensor& mat,
     const Tensor& scale,
@@ -245,6 +251,7 @@ void check_cublaslt_grouped_scale_recipe(
   }
 }
 
+// Mirrored by _should_use_scaled_cublaslt_grouped_gemm in torch/_meta_registrations.py
 bool should_use_scaled_cublaslt_grouped_gemm(
   const Tensor& mat_a,
   const Tensor& mat_b,

--- a/aten/src/ATen/native/cuda/GroupedBlas.cpp
+++ b/aten/src/ATen/native/cuda/GroupedBlas.cpp
@@ -98,23 +98,23 @@ bool _scaled_mm_allowed_device(bool sm90_only=false, bool sm100_only=false) {
 }
 
 #if !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13030
+bool is_cublaslt_grouped_gemm_device(bool allow_sm90 = true) {
+  const auto dprops = at::cuda::getCurrentDeviceProperties();
+  bool supported = (
+    dprops->major == 10 || dprops->major == 11
+    || (dprops->major == 9 && allow_sm90)
+  );
+  return supported;
+}
+
 bool should_use_cublaslt_grouped_gemm(
     const Tensor& mat_a,
     const Tensor& mat_b,
     const std::optional<Tensor>& offs,
     std::optional<c10::ScalarType> out_dtype) {
-  const auto dprops = at::cuda::getCurrentDeviceProperties();
-  const bool valid_sm =
-      dprops->major >= 9 && dprops->major <= 11;
-  if (!valid_sm) {
+  if (!is_cublaslt_grouped_gemm_device()) {
     return false;
   }
-  const bool fp16_grouped_gemm =
-      mat_a.dtype() == at::kHalf && mat_b.dtype() == at::kHalf &&
-      out_dtype.value_or(at::kHalf) == at::kHalf;
-  const bool bf16_grouped_gemm =
-      mat_a.dtype() == at::kBFloat16 && mat_b.dtype() == at::kBFloat16 &&
-      out_dtype.value_or(at::kBFloat16) == at::kBFloat16;
 
   // The arg-packing kernel launches one thread per group in a single block, so
   // cuBLASLt grouped GEMM only handles [1, 1024] groups. Fall back otherwise.
@@ -127,11 +127,216 @@ bool should_use_cublaslt_grouped_gemm(
     return false;
   }
 
+  const bool fp16_grouped_gemm =
+      mat_a.dtype() == at::kHalf && mat_b.dtype() == at::kHalf &&
+      out_dtype.value_or(at::kHalf) == at::kHalf;
   if (fp16_grouped_gemm) {
     return true;
   }
-  return bf16_grouped_gemm &&
-      at::globalContext().preferCublasltGroupedGemm();
+
+  const bool bf16_grouped_gemm =
+      mat_a.dtype() == at::kBFloat16 && mat_b.dtype() == at::kBFloat16 &&
+      out_dtype.value_or(at::kBFloat16) == at::kBFloat16;
+  return bf16_grouped_gemm && at::globalContext().preferCublasltGroupedGemm();
+}
+
+std::optional<ScalingType> get_cublaslt_grouped_scaling_type(
+    const Tensor& scale,
+    int64_t batchCount) {
+  if (scale.scalar_type() == at::kFloat && scale.numel() == 1) {
+    return ScalingType::TensorWise;
+  }
+  if (scale.scalar_type() == at::kFloat &&
+      scale.dim() == 1 &&
+      scale.numel() == batchCount) {
+    return ScalingType::GroupWise;
+  }
+  if (scale.scalar_type() == at::kFloat8_e8m0fnu) {
+    return ScalingType::BlockWise1x32;
+  }
+  return std::nullopt;
+}
+
+int64_t cublas_vec32_scale_size_host(int64_t inner, int64_t outer) {
+  constexpr int64_t BLOCK_ROWS = 128;
+  constexpr int64_t BLOCK_COLS = 128;
+  constexpr int64_t S_VSCALE = 32;
+  int64_t s_rows = ((inner + BLOCK_ROWS - 1) / BLOCK_ROWS) * (BLOCK_ROWS / S_VSCALE);
+  int64_t s_cols = ((outer + BLOCK_COLS - 1) / BLOCK_COLS) * BLOCK_COLS;
+  return s_rows * s_cols;
+}
+
+bool is_cublaslt_grouped_scaling_type(ScalingType scaling) {
+  return scaling == ScalingType::TensorWise ||
+      scaling == ScalingType::GroupWise ||
+      scaling == ScalingType::BlockWise1x32;
+}
+
+void check_cublaslt_grouped_scale_recipe(
+    const Tensor& mat,
+    const Tensor& scale,
+    ScalingType scaling,
+    int64_t batchCount,
+    bool is_a,
+    const char* name) {
+  if (scaling == ScalingType::TensorWise) {
+    TORCH_CHECK(
+        scale.scalar_type() == at::kFloat &&
+        scale.numel() == 1,
+        name,
+        " tensorwise scale must be a single float32 value, got dtype ",
+        scale.scalar_type(),
+        " and ",
+        scale.numel(),
+        " elements");
+  } else if (scaling == ScalingType::GroupWise) {
+    TORCH_CHECK(
+        scale.scalar_type() == at::kFloat &&
+        scale.dim() == 1 &&
+        scale.numel() == batchCount &&
+        scale.is_contiguous(),
+        name,
+        " groupwise scale must be a contiguous 1D float32 tensor with one value per group, got dtype ",
+        scale.scalar_type(),
+        ", shape ",
+        scale.sizes(),
+        ", and ",
+        scale.numel(),
+        " elements for ",
+        batchCount,
+        " groups");
+  } else {
+    TORCH_CHECK(
+        scaling == ScalingType::BlockWise1x32 &&
+        scale.scalar_type() == at::kFloat8_e8m0fnu &&
+        scale.is_contiguous(),
+        name,
+        " blockwise scale must be a contiguous float8_e8m0fnu tensor");
+    const int64_t inner = is_a ? mat.size(-1) : mat.size(-2);
+    const int64_t outer = is_a ? mat.size(-2) : mat.size(-1);
+    const int64_t scale_size = cublas_vec32_scale_size_host(inner, outer);
+    if (mat.dim() == 3) {
+      TORCH_CHECK(
+          scale.dim() == 2 &&
+          scale.size(0) == batchCount &&
+          scale.size(1) == scale_size,
+          name,
+          " blockwise scale for cuBLASLt grouped GEMM must have shape (",
+          batchCount,
+          ", ",
+          scale_size,
+          "), got ",
+          scale.sizes());
+    } else {
+      // 2D inputs have data-dependent per-group extents along the jagged
+      // dimension (only known from offs on device), so the exact concatenated
+      // blocked-scale size can't be computed here. Because ceil() is
+      // subadditive, sum_g cublas_vec32_scale_size(g) >=
+      // cublas_vec32_scale_size(totals), so scale_size is a safe lower bound
+      // on the required element count.
+      TORCH_CHECK(
+          scale.numel() >= scale_size,
+          name,
+          " blockwise scale for cuBLASLt grouped GEMM must have at least ",
+          scale_size,
+          " elements, got ",
+          scale.numel());
+    }
+  }
+}
+
+bool should_use_scaled_cublaslt_grouped_gemm(
+  const Tensor& mat_a,
+  const Tensor& mat_b,
+  std::optional<c10::ScalarType> out_dtype_,
+  const std::optional<at::Tensor>& offs,
+  const Tensor& scale_a,
+  const Tensor& scale_b,
+  std::optional<ScalingType> scaling_a,
+  std::optional<ScalingType> scaling_b,
+  int64_t batchCount64) {
+  if (!at::globalContext().preferCublasltGroupedGemm()) {
+    return false;
+  }
+
+  if (!is_cublaslt_grouped_gemm_device(/*allow_sm90*/ false)) {
+    TORCH_WARN_ONCE(
+        "cuBLASLt scaled grouped GEMM is not used because this device is not supported; falling back to the non-cuBLASLt grouped GEMM path.");
+    return false;
+  }
+
+  if (!scaling_a.has_value() || !scaling_b.has_value()) {
+    TORCH_WARN_ONCE(
+        "cuBLASLt scaled grouped GEMM is not used because scale_a and scale_b must each be tensorwise, groupwise, or blockwise MXFP8 scales; falling back to the non-cuBLASLt grouped GEMM path.");
+    return false;
+  }
+
+  if (!is_cublaslt_grouped_scaling_type(*scaling_a) ||
+      !is_cublaslt_grouped_scaling_type(*scaling_b)) {
+    TORCH_WARN_ONCE(
+        "cuBLASLt scaled grouped GEMM is not used because scale_a and scale_b recipes must each be tensorwise, groupwise, or blockwise MXFP8; falling back to the non-cuBLASLt grouped GEMM path.");
+    return false;
+  }
+
+  if (batchCount64 < 1 || batchCount64 > 1024) {
+    TORCH_WARN_ONCE(
+        "cuBLASLt scaled grouped GEMM is not used because batchCount must be in [1, 1024], got ",
+        batchCount64,
+        "; falling back to the non-cuBLASLt grouped GEMM path.");
+    return false;
+  }
+
+  const bool mat_a_is_fp8 =
+      mat_a.scalar_type() == at::kFloat8_e4m3fn ||
+      mat_a.scalar_type() == at::kFloat8_e5m2;
+  const bool mat_b_is_fp8 =
+      mat_b.scalar_type() == at::kFloat8_e4m3fn ||
+      mat_b.scalar_type() == at::kFloat8_e5m2;
+  const bool valid_in_dtypes =
+      mat_a_is_fp8 &&
+      mat_b_is_fp8 &&
+      (mat_a.scalar_type() == at::kFloat8_e4m3fn ||
+       mat_b.scalar_type() == at::kFloat8_e4m3fn);
+  if (!valid_in_dtypes) {
+    TORCH_WARN_ONCE(
+        "cuBLASLt scaled grouped GEMM is not used because inputs must both be FP8 and at least one input must be Float8_e4m3fn, got mat_a dtype ",
+        mat_a.scalar_type(),
+        " and mat_b dtype ",
+        mat_b.scalar_type(),
+        "; falling back to the non-cuBLASLt grouped GEMM path.");
+    return false;
+  }
+
+  const auto out_dtype = out_dtype_.value_or(at::kBFloat16);
+  const bool valid_out_dtype = out_dtype == at::kBFloat16 ||
+      out_dtype == at::kHalf ||
+      out_dtype == at::kFloat;
+  if (!valid_out_dtype) {
+    TORCH_WARN_ONCE(
+        "cuBLASLt scaled grouped GEMM is not used because output dtype must be BFloat16, Float16, or Float32, got ",
+        out_dtype,
+        "; falling back to the non-cuBLASLt grouped GEMM path.");
+    return false;
+  }
+
+  return true;
+}
+
+bool cublaslt_grouped_mm_use_int64(const Tensor& mat_a, const Tensor& mat_b, const Tensor& out) {
+  // cuBLAS grouped GEMM packs per-group m/n/k and lda/ldb/ldd into device
+  // arrays whose width is either 32-bit or 64-bit. Switch to 64-bit if any
+  // dimension or any stride that ends up as a leading dim could overflow
+  // int32_t. Per-group deltas (jagged dim) are bounded by the corresponding
+  // total size, so checking sizes is sufficient.
+  return (mat_a.size(-2) > std::numeric_limits<int32_t>::max() ||
+      mat_a.size(-1) > std::numeric_limits<int32_t>::max() ||
+      mat_b.size(-2) > std::numeric_limits<int32_t>::max() ||
+      mat_b.size(-1) > std::numeric_limits<int32_t>::max() ||
+      mat_a.stride(-2) > std::numeric_limits<int32_t>::max() ||
+      mat_a.stride(-1) > std::numeric_limits<int32_t>::max() ||
+      mat_b.stride(-2) > std::numeric_limits<int32_t>::max() ||
+      mat_b.stride(-1) > std::numeric_limits<int32_t>::max() ||
+      out.stride(-2) > std::numeric_limits<int32_t>::max());
 }
 #endif
 
@@ -478,21 +683,7 @@ std::optional<c10::ScalarType> out_dtype) {
   const auto out_dtype_ = _resolve_grouped_mm_out_dtype(mat_a, mat_b, out_dtype);
   Tensor out = create_grouped_gemm_output_tensor(mat_a, mat_b, offs, out_dtype_);
 
-  // cuBLAS grouped GEMM packs per-group m/n/k and lda/ldb/ldd into device
-  // arrays whose width is either 32-bit or 64-bit. Switch to 64-bit if any
-  // dimension or any stride that ends up as a leading dim could overflow
-  // int32_t. Per-group deltas (jagged dim) are bounded by the corresponding
-  // total size, so checking sizes is sufficient.
-  const bool needs_int64 =
-      mat_a.size(-2) > std::numeric_limits<int32_t>::max() ||
-      mat_a.size(-1) > std::numeric_limits<int32_t>::max() ||
-      mat_b.size(-2) > std::numeric_limits<int32_t>::max() ||
-      mat_b.size(-1) > std::numeric_limits<int32_t>::max() ||
-      mat_a.stride(-2) > std::numeric_limits<int32_t>::max() ||
-      mat_a.stride(-1) > std::numeric_limits<int32_t>::max() ||
-      mat_b.stride(-2) > std::numeric_limits<int32_t>::max() ||
-      mat_b.stride(-1) > std::numeric_limits<int32_t>::max() ||
-      out.stride(-2) > std::numeric_limits<int32_t>::max();
+  const bool needs_int64 = cublaslt_grouped_mm_use_int64(mat_a, mat_b, out);
 
   cublasGroupedArgs args(mat_a, mat_b, offs, out, batchCount, needs_int64);
   at::cuda::blas::grouped_gemm(args.transa, args.transb,
@@ -512,6 +703,67 @@ std::optional<c10::ScalarType> out_dtype) {
 #endif // !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13030
 }
 
+static Tensor scaled_grouped_mm_cublaslt(
+    const Tensor& mat_a,
+    const Tensor& mat_b,
+    const Tensor& scale_a,
+    const Tensor& scale_b,
+    const std::optional<at::Tensor>& offs,
+    std::optional<c10::ScalarType> out_dtype,
+    bool use_fast_accum,
+    int batchCount,
+    ScalingType scaling_a,
+    ScalingType scaling_b) {
+#if !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13020
+  check_cublaslt_grouped_scale_recipe(mat_a, scale_a, scaling_a, batchCount, /*is_a*/ true, "scale_a");
+  check_cublaslt_grouped_scale_recipe(mat_b, scale_b, scaling_b, batchCount, /*is_a*/ false, "scale_b");
+
+  const auto out_dtype_ = out_dtype.value_or(at::kBFloat16);
+  Tensor out = create_grouped_gemm_output_tensor(mat_a, mat_b, offs, out_dtype_);
+
+  const bool needs_int64 = cublaslt_grouped_mm_use_int64(mat_a, mat_b, out);
+
+  cublasGroupedArgs args(
+      mat_a,
+      mat_b,
+      offs,
+      out,
+      batchCount,
+      needs_int64,
+      scale_a,
+      scale_b,
+      std::nullopt,
+      scaling_a,
+      scaling_b);
+  const at::cuda::blas::GroupedGemmScaleOptions scales{
+      mat_b.scalar_type(),
+      args.scale_mata_ptr,
+      args.scale_matb_ptr,
+      args.scale_result_ptr,
+      use_fast_accum,
+      args.scale_mata_dtype,
+      args.scale_matb_dtype,
+      args.scale_mata_scaling_type,
+      args.scale_matb_scaling_type};
+  at::cuda::blas::grouped_gemm(
+      args.transa, args.transb,
+      args.mArray, args.m,
+      args.nArray, args.n,
+      args.kArray, args.k,
+      args.alphaPtrArray, nullptr, mat_a.scalar_type(),
+      args.APtrArray, args.ldaArray,
+      args.BPtrArray, args.ldbArray,
+      args.betaPtrArray, nullptr, out.scalar_type(),
+      args.DPtrArray, args.lddArray,
+      args.DPtrArray, args.lddArray,
+      args.batchCount, args.use_int64,
+      scales);
+  return out;
+#else
+  TORCH_CHECK(false, "cublasLt scaled grouped GEMM requires CUDA >= 13.2 and is not supported on ROCm. Current build does not meet these requirements.");
+#endif // !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13020
+}
+
 Tensor
 _scaled_grouped_mm_cuda(
         const Tensor& mat_a,
@@ -523,9 +775,6 @@ _scaled_grouped_mm_cuda(
         const std::optional<at::Tensor>& scale_result,
         std::optional<c10::ScalarType> out_dtype,
         bool use_fast_accum) {
-  bool allowed_device = _scaled_mm_allowed_device(/*sm90_only*/true, /*sm100_only*/true);
-  TORCH_CHECK_VALUE(allowed_device, "torch._scaled_grouped_mm is only supported on CUDA devices with compute capability = [9.0, 10.0], or ROCm MI300+");
-
   TORCH_CHECK_VALUE(!check_valid_strides_and_return_transposed(mat_a), "Expected mat1 to not be transposed");
   TORCH_CHECK_VALUE(check_valid_strides_and_return_transposed(mat_b), "Expected mat2 to be transposed");
   TORCH_CHECK_VALUE(mat_a.dim() == 2 || mat_a.dim() == 3, "mat_a has to be 2 or 3d");
@@ -560,13 +809,52 @@ _scaled_grouped_mm_cuda(
   if (offs.has_value()) {
     TORCH_CHECK_VALUE(offs->dim() == 1, "offs has to be 1D");
     TORCH_CHECK_VALUE(offs->dtype() == at::kInt, "Offsets have to be int32");
+    TORCH_CHECK_VALUE(offs->is_contiguous(), "Offsets have to be contiguous");
   }
-  // FP8 per-tensor and per-row scaling expect fp32 scales.
+  // FP8 per-tensor, per-group, and per-row scaling expect fp32 scales.
   // MXFP8 expects float8_e8m0fnu scales.
   TORCH_CHECK_VALUE(
       (scale_a.scalar_type() == kFloat && scale_b.scalar_type() == kFloat) ||
       (scale_a.scalar_type() == at::kFloat8_e8m0fnu && scale_b.scalar_type() == at::kFloat8_e8m0fnu),
-      "For FP8 tensorwise and rowwise, both scales must both be float32 tensors. For MXFP8, scales must both be float8_e8m0fnu tensors.");
+      "For FP8 tensorwise, groupwise, and rowwise, both scales must both be float32 tensors. For MXFP8, scales must both be float8_e8m0fnu tensors.");
+
+#if !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13020
+  const int64_t batchCount64 = (a_is_2d || b_is_2d)
+      ? offs->size(0) : mat_a.size(0);
+
+  const auto scaling_a = get_cublaslt_grouped_scaling_type(scale_a, batchCount64);
+  const auto scaling_b = get_cublaslt_grouped_scaling_type(scale_b, batchCount64);
+  if (should_use_scaled_cublaslt_grouped_gemm(
+      mat_a,
+      mat_b,
+      out_dtype,
+      offs,
+      scale_a,
+      scale_b,
+      scaling_a,
+      scaling_b,
+      batchCount64)) {
+    return scaled_grouped_mm_cublaslt(
+        mat_a,
+        mat_b,
+        scale_a,
+        scale_b,
+        offs,
+        out_dtype,
+        use_fast_accum,
+        static_cast<int>(batchCount64),
+        *scaling_a,
+        *scaling_b);
+  }
+#endif
+
+  bool allowed_device = _scaled_mm_allowed_device(/*sm90_only*/true, /*sm100_only*/true);
+  TORCH_CHECK_VALUE(
+      allowed_device,
+      "torch._scaled_grouped_mm is only supported on CUDA devices with "
+      "compute capability = [9.0, 10.0], or ROCm MI300+. "
+      "The cublasLt backend additionally supports CUDA devices with "
+      "compute capability = [10.x, 11.0]");
 
   const int scale_multiplier = (mat_a.dim() == 2 && mat_b.dim() == 2) ? offs->size(0) : 1;
   check_scale(mat_a, scale_a, 0 ,0, scale_multiplier);
@@ -639,9 +927,6 @@ _scaled_grouped_mm_cuda_v2(
           const std::optional<c10::ScalarType> out_dtype,
           IntArrayRef contraction_dim,
           bool use_fast_accum) {
-  bool allowed_device = _scaled_mm_allowed_device(/*sm90_only*/true, /*sm100_only*/true);
-  TORCH_CHECK_VALUE(allowed_device, "torch._scaled_grouped_mm is only supported on CUDA devices with compute capability = [9.0, 10.0], or ROCm MI300+");
-
   TORCH_CHECK_VALUE(!check_valid_strides_and_return_transposed(mat_a), "Expected mat1 to not be transposed");
   TORCH_CHECK_VALUE(check_valid_strides_and_return_transposed(mat_b), "Expected mat2 to be transposed");
   TORCH_CHECK_VALUE(mat_a.dim() == 2 || mat_a.dim() == 3, "mat_a has to be 2 or 3d");
@@ -683,17 +968,58 @@ _scaled_grouped_mm_cuda_v2(
   if (offs.has_value()) {
     TORCH_CHECK_VALUE(offs->dim() == 1, "offs has to be 1D");
     TORCH_CHECK_VALUE(offs->dtype() == at::kInt, "Offsets have to be int32");
+    TORCH_CHECK_VALUE(offs->is_contiguous(), "Offsets have to be contiguous");
   }
+
+  // Conversion of implicitly-defined enums to explicit
+  auto scale_recipe_a_enum = convert_int_to_enum<ScalingType>(scale_recipe_a);
+  auto scale_recipe_b_enum = convert_int_to_enum<ScalingType>(scale_recipe_b);
+
+#if !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13020
+  const int64_t batchCount64 = (a_is_2d || b_is_2d)
+      ? offs->size(0) : mat_a.size(0);
+  if (scale_a.size() == 1 &&
+      scale_b.size() == 1 &&
+      scale_recipe_a_enum.size() == 1 &&
+      scale_recipe_b_enum.size() == 1 &&
+      should_use_scaled_cublaslt_grouped_gemm(
+          mat_a,
+          mat_b,
+          out_dtype,
+          offs,
+          scale_a[0],
+          scale_b[0],
+          scale_recipe_a_enum[0],
+          scale_recipe_b_enum[0],
+          batchCount64)) {
+    return scaled_grouped_mm_cublaslt(
+        mat_a,
+        mat_b,
+        scale_a[0],
+        scale_b[0],
+        offs,
+        out_dtype,
+        use_fast_accum,
+        static_cast<int>(batchCount64),
+        scale_recipe_a_enum[0],
+        scale_recipe_b_enum[0]);
+  }
+#endif
+
+  bool allowed_device = _scaled_mm_allowed_device(/*sm90_only*/true, /*sm100_only*/true);
+  TORCH_CHECK_VALUE(
+      allowed_device,
+      "torch._scaled_grouped_mm is only supported on CUDA devices with "
+      "compute capability = [9.0, 10.0], or ROCm MI300+. "
+      "The cublasLt backend additionally supports CUDA devices with "
+      "compute capability = [10.x, 11.0]");
 
   const auto out_dtype_ = out_dtype.value_or(kBFloat16);
   TORCH_CHECK_VALUE(out_dtype_ == kBFloat16, "Only bf16 high precision output types are supported for grouped gemm");
 
   Tensor out = create_grouped_gemm_output_tensor(mat_a, mat_b, offs, out_dtype_);
 
-  // Conversion of implicitly-defined enums to explicit
-  auto scale_recipe_a_enum = convert_int_to_enum<ScalingType>(scale_recipe_a);
   auto swizzle_a_enum = convert_int_to_enum<SwizzleType>(swizzle_a);
-  auto scale_recipe_b_enum = convert_int_to_enum<ScalingType>(scale_recipe_b);
   auto swizzle_b_enum = convert_int_to_enum<SwizzleType>(swizzle_b);
 
   // at this point we can start working out what we want to be doing

--- a/aten/src/ATen/native/cuda/GroupedBlas.cpp
+++ b/aten/src/ATen/native/cuda/GroupedBlas.cpp
@@ -714,7 +714,7 @@ static Tensor scaled_grouped_mm_cublaslt(
     int batchCount,
     ScalingType scaling_a,
     ScalingType scaling_b) {
-#if !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13020
+#if !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13030
   check_cublaslt_grouped_scale_recipe(mat_a, scale_a, scaling_a, batchCount, /*is_a*/ true, "scale_a");
   check_cublaslt_grouped_scale_recipe(mat_b, scale_b, scaling_b, batchCount, /*is_a*/ false, "scale_b");
 
@@ -760,8 +760,8 @@ static Tensor scaled_grouped_mm_cublaslt(
       scales);
   return out;
 #else
-  TORCH_CHECK(false, "cublasLt scaled grouped GEMM requires CUDA >= 13.2 and is not supported on ROCm. Current build does not meet these requirements.");
-#endif // !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13020
+  TORCH_CHECK(false, "cublasLt scaled grouped GEMM requires CUDA >= 13.3 and is not supported on ROCm. Current build does not meet these requirements.");
+#endif // !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13030
 }
 
 Tensor
@@ -818,7 +818,7 @@ _scaled_grouped_mm_cuda(
       (scale_a.scalar_type() == at::kFloat8_e8m0fnu && scale_b.scalar_type() == at::kFloat8_e8m0fnu),
       "For FP8 tensorwise, groupwise, and rowwise, both scales must both be float32 tensors. For MXFP8, scales must both be float8_e8m0fnu tensors.");
 
-#if !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13020
+#if !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13030
   const int64_t batchCount64 = (a_is_2d || b_is_2d)
       ? offs->size(0) : mat_a.size(0);
 
@@ -975,7 +975,7 @@ _scaled_grouped_mm_cuda_v2(
   auto scale_recipe_a_enum = convert_int_to_enum<ScalingType>(scale_recipe_a);
   auto scale_recipe_b_enum = convert_int_to_enum<ScalingType>(scale_recipe_b);
 
-#if !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13020
+#if !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13030
   const int64_t batchCount64 = (a_is_2d || b_is_2d)
       ? offs->size(0) : mat_a.size(0);
   if (scale_a.size() == 1 &&

--- a/aten/src/ATen/native/cuda/GroupedBlas.cpp
+++ b/aten/src/ATen/native/cuda/GroupedBlas.cpp
@@ -79,23 +79,23 @@ namespace at::native {
 namespace {
 
 #if !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13030
+bool is_cublaslt_grouped_gemm_device(bool allow_sm90 = true) {
+  const auto dprops = at::cuda::getCurrentDeviceProperties();
+  bool supported = (
+    dprops->major == 10 || dprops->major == 11
+    || (dprops->major == 9 && allow_sm90)
+  );
+  return supported;
+}
+
 bool should_use_cublaslt_grouped_gemm(
     const Tensor& mat_a,
     const Tensor& mat_b,
     const std::optional<Tensor>& offs,
     std::optional<c10::ScalarType> out_dtype) {
-  const auto dprops = at::cuda::getCurrentDeviceProperties();
-  const bool valid_sm =
-      dprops->major >= 9 && dprops->major <= 11;
-  if (!valid_sm) {
+  if (!is_cublaslt_grouped_gemm_device()) {
     return false;
   }
-  const bool fp16_grouped_gemm =
-      mat_a.dtype() == at::kHalf && mat_b.dtype() == at::kHalf &&
-      out_dtype.value_or(at::kHalf) == at::kHalf;
-  const bool bf16_grouped_gemm =
-      mat_a.dtype() == at::kBFloat16 && mat_b.dtype() == at::kBFloat16 &&
-      out_dtype.value_or(at::kBFloat16) == at::kBFloat16;
 
   // The arg-packing kernel launches one thread per group in a single block, so
   // cuBLASLt grouped GEMM only handles [1, 1024] groups. Fall back otherwise.
@@ -108,11 +108,216 @@ bool should_use_cublaslt_grouped_gemm(
     return false;
   }
 
+  const bool fp16_grouped_gemm =
+      mat_a.dtype() == at::kHalf && mat_b.dtype() == at::kHalf &&
+      out_dtype.value_or(at::kHalf) == at::kHalf;
   if (fp16_grouped_gemm) {
     return true;
   }
-  return bf16_grouped_gemm &&
-      at::globalContext().preferCublasltGroupedGemm();
+
+  const bool bf16_grouped_gemm =
+      mat_a.dtype() == at::kBFloat16 && mat_b.dtype() == at::kBFloat16 &&
+      out_dtype.value_or(at::kBFloat16) == at::kBFloat16;
+  return bf16_grouped_gemm && at::globalContext().preferCublasltGroupedGemm();
+}
+
+std::optional<ScalingType> get_cublaslt_grouped_scaling_type(
+    const Tensor& scale,
+    int64_t batchCount) {
+  if (scale.scalar_type() == at::kFloat && scale.numel() == 1) {
+    return ScalingType::TensorWise;
+  }
+  if (scale.scalar_type() == at::kFloat &&
+      scale.dim() == 1 &&
+      scale.numel() == batchCount) {
+    return ScalingType::GroupWise;
+  }
+  if (scale.scalar_type() == at::kFloat8_e8m0fnu) {
+    return ScalingType::BlockWise1x32;
+  }
+  return std::nullopt;
+}
+
+int64_t cublas_vec32_scale_size_host(int64_t inner, int64_t outer) {
+  constexpr int64_t BLOCK_ROWS = 128;
+  constexpr int64_t BLOCK_COLS = 128;
+  constexpr int64_t S_VSCALE = 32;
+  int64_t s_rows = ((inner + BLOCK_ROWS - 1) / BLOCK_ROWS) * (BLOCK_ROWS / S_VSCALE);
+  int64_t s_cols = ((outer + BLOCK_COLS - 1) / BLOCK_COLS) * BLOCK_COLS;
+  return s_rows * s_cols;
+}
+
+bool is_cublaslt_grouped_scaling_type(ScalingType scaling) {
+  return scaling == ScalingType::TensorWise ||
+      scaling == ScalingType::GroupWise ||
+      scaling == ScalingType::BlockWise1x32;
+}
+
+void check_cublaslt_grouped_scale_recipe(
+    const Tensor& mat,
+    const Tensor& scale,
+    ScalingType scaling,
+    int64_t batchCount,
+    bool is_a,
+    const char* name) {
+  if (scaling == ScalingType::TensorWise) {
+    TORCH_CHECK(
+        scale.scalar_type() == at::kFloat &&
+        scale.numel() == 1,
+        name,
+        " tensorwise scale must be a single float32 value, got dtype ",
+        scale.scalar_type(),
+        " and ",
+        scale.numel(),
+        " elements");
+  } else if (scaling == ScalingType::GroupWise) {
+    TORCH_CHECK(
+        scale.scalar_type() == at::kFloat &&
+        scale.dim() == 1 &&
+        scale.numel() == batchCount &&
+        scale.is_contiguous(),
+        name,
+        " groupwise scale must be a contiguous 1D float32 tensor with one value per group, got dtype ",
+        scale.scalar_type(),
+        ", shape ",
+        scale.sizes(),
+        ", and ",
+        scale.numel(),
+        " elements for ",
+        batchCount,
+        " groups");
+  } else {
+    TORCH_CHECK(
+        scaling == ScalingType::BlockWise1x32 &&
+        scale.scalar_type() == at::kFloat8_e8m0fnu &&
+        scale.is_contiguous(),
+        name,
+        " blockwise scale must be a contiguous float8_e8m0fnu tensor");
+    const int64_t inner = is_a ? mat.size(-1) : mat.size(-2);
+    const int64_t outer = is_a ? mat.size(-2) : mat.size(-1);
+    const int64_t scale_size = cublas_vec32_scale_size_host(inner, outer);
+    if (mat.dim() == 3) {
+      TORCH_CHECK(
+          scale.dim() == 2 &&
+          scale.size(0) == batchCount &&
+          scale.size(1) == scale_size,
+          name,
+          " blockwise scale for cuBLASLt grouped GEMM must have shape (",
+          batchCount,
+          ", ",
+          scale_size,
+          "), got ",
+          scale.sizes());
+    } else {
+      // 2D inputs have data-dependent per-group extents along the jagged
+      // dimension (only known from offs on device), so the exact concatenated
+      // blocked-scale size can't be computed here. Because ceil() is
+      // subadditive, sum_g cublas_vec32_scale_size(g) >=
+      // cublas_vec32_scale_size(totals), so scale_size is a safe lower bound
+      // on the required element count.
+      TORCH_CHECK(
+          scale.numel() >= scale_size,
+          name,
+          " blockwise scale for cuBLASLt grouped GEMM must have at least ",
+          scale_size,
+          " elements, got ",
+          scale.numel());
+    }
+  }
+}
+
+bool should_use_scaled_cublaslt_grouped_gemm(
+  const Tensor& mat_a,
+  const Tensor& mat_b,
+  std::optional<c10::ScalarType> out_dtype_,
+  const std::optional<at::Tensor>& offs,
+  const Tensor& scale_a,
+  const Tensor& scale_b,
+  std::optional<ScalingType> scaling_a,
+  std::optional<ScalingType> scaling_b,
+  int64_t batchCount64) {
+  if (!at::globalContext().preferCublasltGroupedGemm()) {
+    return false;
+  }
+
+  if (!is_cublaslt_grouped_gemm_device(/*allow_sm90*/ false)) {
+    TORCH_WARN_ONCE(
+        "cuBLASLt scaled grouped GEMM is not used because this device is not supported; falling back to the non-cuBLASLt grouped GEMM path.");
+    return false;
+  }
+
+  if (!scaling_a.has_value() || !scaling_b.has_value()) {
+    TORCH_WARN_ONCE(
+        "cuBLASLt scaled grouped GEMM is not used because scale_a and scale_b must each be tensorwise, groupwise, or blockwise MXFP8 scales; falling back to the non-cuBLASLt grouped GEMM path.");
+    return false;
+  }
+
+  if (!is_cublaslt_grouped_scaling_type(*scaling_a) ||
+      !is_cublaslt_grouped_scaling_type(*scaling_b)) {
+    TORCH_WARN_ONCE(
+        "cuBLASLt scaled grouped GEMM is not used because scale_a and scale_b recipes must each be tensorwise, groupwise, or blockwise MXFP8; falling back to the non-cuBLASLt grouped GEMM path.");
+    return false;
+  }
+
+  if (batchCount64 < 1 || batchCount64 > 1024) {
+    TORCH_WARN_ONCE(
+        "cuBLASLt scaled grouped GEMM is not used because batchCount must be in [1, 1024], got ",
+        batchCount64,
+        "; falling back to the non-cuBLASLt grouped GEMM path.");
+    return false;
+  }
+
+  const bool mat_a_is_fp8 =
+      mat_a.scalar_type() == at::kFloat8_e4m3fn ||
+      mat_a.scalar_type() == at::kFloat8_e5m2;
+  const bool mat_b_is_fp8 =
+      mat_b.scalar_type() == at::kFloat8_e4m3fn ||
+      mat_b.scalar_type() == at::kFloat8_e5m2;
+  const bool valid_in_dtypes =
+      mat_a_is_fp8 &&
+      mat_b_is_fp8 &&
+      (mat_a.scalar_type() == at::kFloat8_e4m3fn ||
+       mat_b.scalar_type() == at::kFloat8_e4m3fn);
+  if (!valid_in_dtypes) {
+    TORCH_WARN_ONCE(
+        "cuBLASLt scaled grouped GEMM is not used because inputs must both be FP8 and at least one input must be Float8_e4m3fn, got mat_a dtype ",
+        mat_a.scalar_type(),
+        " and mat_b dtype ",
+        mat_b.scalar_type(),
+        "; falling back to the non-cuBLASLt grouped GEMM path.");
+    return false;
+  }
+
+  const auto out_dtype = out_dtype_.value_or(at::kBFloat16);
+  const bool valid_out_dtype = out_dtype == at::kBFloat16 ||
+      out_dtype == at::kHalf ||
+      out_dtype == at::kFloat;
+  if (!valid_out_dtype) {
+    TORCH_WARN_ONCE(
+        "cuBLASLt scaled grouped GEMM is not used because output dtype must be BFloat16, Float16, or Float32, got ",
+        out_dtype,
+        "; falling back to the non-cuBLASLt grouped GEMM path.");
+    return false;
+  }
+
+  return true;
+}
+
+bool cublaslt_grouped_mm_use_int64(const Tensor& mat_a, const Tensor& mat_b, const Tensor& out) {
+  // cuBLAS grouped GEMM packs per-group m/n/k and lda/ldb/ldd into device
+  // arrays whose width is either 32-bit or 64-bit. Switch to 64-bit if any
+  // dimension or any stride that ends up as a leading dim could overflow
+  // int32_t. Per-group deltas (jagged dim) are bounded by the corresponding
+  // total size, so checking sizes is sufficient.
+  return (mat_a.size(-2) > std::numeric_limits<int32_t>::max() ||
+      mat_a.size(-1) > std::numeric_limits<int32_t>::max() ||
+      mat_b.size(-2) > std::numeric_limits<int32_t>::max() ||
+      mat_b.size(-1) > std::numeric_limits<int32_t>::max() ||
+      mat_a.stride(-2) > std::numeric_limits<int32_t>::max() ||
+      mat_a.stride(-1) > std::numeric_limits<int32_t>::max() ||
+      mat_b.stride(-2) > std::numeric_limits<int32_t>::max() ||
+      mat_b.stride(-1) > std::numeric_limits<int32_t>::max() ||
+      out.stride(-2) > std::numeric_limits<int32_t>::max());
 }
 #endif
 
@@ -459,21 +664,7 @@ std::optional<c10::ScalarType> out_dtype) {
   const auto out_dtype_ = _resolve_grouped_mm_out_dtype(mat_a, mat_b, out_dtype);
   Tensor out = create_grouped_gemm_output_tensor(mat_a, mat_b, offs, out_dtype_);
 
-  // cuBLAS grouped GEMM packs per-group m/n/k and lda/ldb/ldd into device
-  // arrays whose width is either 32-bit or 64-bit. Switch to 64-bit if any
-  // dimension or any stride that ends up as a leading dim could overflow
-  // int32_t. Per-group deltas (jagged dim) are bounded by the corresponding
-  // total size, so checking sizes is sufficient.
-  const bool needs_int64 =
-      mat_a.size(-2) > std::numeric_limits<int32_t>::max() ||
-      mat_a.size(-1) > std::numeric_limits<int32_t>::max() ||
-      mat_b.size(-2) > std::numeric_limits<int32_t>::max() ||
-      mat_b.size(-1) > std::numeric_limits<int32_t>::max() ||
-      mat_a.stride(-2) > std::numeric_limits<int32_t>::max() ||
-      mat_a.stride(-1) > std::numeric_limits<int32_t>::max() ||
-      mat_b.stride(-2) > std::numeric_limits<int32_t>::max() ||
-      mat_b.stride(-1) > std::numeric_limits<int32_t>::max() ||
-      out.stride(-2) > std::numeric_limits<int32_t>::max();
+  const bool needs_int64 = cublaslt_grouped_mm_use_int64(mat_a, mat_b, out);
 
   cublasGroupedArgs args(mat_a, mat_b, offs, out, batchCount, needs_int64);
   at::cuda::blas::grouped_gemm(args.transa, args.transb,
@@ -493,6 +684,67 @@ std::optional<c10::ScalarType> out_dtype) {
 #endif // !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13030
 }
 
+static Tensor scaled_grouped_mm_cublaslt(
+    const Tensor& mat_a,
+    const Tensor& mat_b,
+    const Tensor& scale_a,
+    const Tensor& scale_b,
+    const std::optional<at::Tensor>& offs,
+    std::optional<c10::ScalarType> out_dtype,
+    bool use_fast_accum,
+    int batchCount,
+    ScalingType scaling_a,
+    ScalingType scaling_b) {
+#if !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13020
+  check_cublaslt_grouped_scale_recipe(mat_a, scale_a, scaling_a, batchCount, /*is_a*/ true, "scale_a");
+  check_cublaslt_grouped_scale_recipe(mat_b, scale_b, scaling_b, batchCount, /*is_a*/ false, "scale_b");
+
+  const auto out_dtype_ = out_dtype.value_or(at::kBFloat16);
+  Tensor out = create_grouped_gemm_output_tensor(mat_a, mat_b, offs, out_dtype_);
+
+  const bool needs_int64 = cublaslt_grouped_mm_use_int64(mat_a, mat_b, out);
+
+  cublasGroupedArgs args(
+      mat_a,
+      mat_b,
+      offs,
+      out,
+      batchCount,
+      needs_int64,
+      scale_a,
+      scale_b,
+      std::nullopt,
+      scaling_a,
+      scaling_b);
+  const at::cuda::blas::GroupedGemmScaleOptions scales{
+      mat_b.scalar_type(),
+      args.scale_mata_ptr,
+      args.scale_matb_ptr,
+      args.scale_result_ptr,
+      use_fast_accum,
+      args.scale_mata_dtype,
+      args.scale_matb_dtype,
+      args.scale_mata_scaling_type,
+      args.scale_matb_scaling_type};
+  at::cuda::blas::grouped_gemm(
+      args.transa, args.transb,
+      args.mArray, args.m,
+      args.nArray, args.n,
+      args.kArray, args.k,
+      args.alphaPtrArray, nullptr, mat_a.scalar_type(),
+      args.APtrArray, args.ldaArray,
+      args.BPtrArray, args.ldbArray,
+      args.betaPtrArray, nullptr, out.scalar_type(),
+      args.DPtrArray, args.lddArray,
+      args.DPtrArray, args.lddArray,
+      args.batchCount, args.use_int64,
+      scales);
+  return out;
+#else
+  TORCH_CHECK(false, "cublasLt scaled grouped GEMM requires CUDA >= 13.2 and is not supported on ROCm. Current build does not meet these requirements.");
+#endif // !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13020
+}
+
 Tensor
 _scaled_grouped_mm_cuda(
         const Tensor& mat_a,
@@ -504,9 +756,6 @@ _scaled_grouped_mm_cuda(
         const std::optional<at::Tensor>& scale_result,
         std::optional<c10::ScalarType> out_dtype,
         bool use_fast_accum) {
-  bool allowed_device = scaled_mm_arch_allowed(/*sm90_only=*/true, /*sm100_only=*/true);
-  TORCH_CHECK_VALUE(allowed_device, "torch._scaled_grouped_mm is only supported on CUDA devices with compute capability = [9.0, 10.0], or ROCm MI300+");
-
   TORCH_CHECK_VALUE(!check_valid_strides_and_return_transposed(mat_a), "Expected mat1 to not be transposed");
   TORCH_CHECK_VALUE(check_valid_strides_and_return_transposed(mat_b), "Expected mat2 to be transposed");
   TORCH_CHECK_VALUE(mat_a.dim() == 2 || mat_a.dim() == 3, "mat_a has to be 2 or 3d");
@@ -541,13 +790,52 @@ _scaled_grouped_mm_cuda(
   if (offs.has_value()) {
     TORCH_CHECK_VALUE(offs->dim() == 1, "offs has to be 1D");
     TORCH_CHECK_VALUE(offs->dtype() == at::kInt, "Offsets have to be int32");
+    TORCH_CHECK_VALUE(offs->is_contiguous(), "Offsets have to be contiguous");
   }
-  // FP8 per-tensor and per-row scaling expect fp32 scales.
+  // FP8 per-tensor, per-group, and per-row scaling expect fp32 scales.
   // MXFP8 expects float8_e8m0fnu scales.
   TORCH_CHECK_VALUE(
       (scale_a.scalar_type() == kFloat && scale_b.scalar_type() == kFloat) ||
       (scale_a.scalar_type() == at::kFloat8_e8m0fnu && scale_b.scalar_type() == at::kFloat8_e8m0fnu),
-      "For FP8 tensorwise and rowwise, both scales must both be float32 tensors. For MXFP8, scales must both be float8_e8m0fnu tensors.");
+      "For FP8 tensorwise, groupwise, and rowwise, both scales must both be float32 tensors. For MXFP8, scales must both be float8_e8m0fnu tensors.");
+
+#if !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13020
+  const int64_t batchCount64 = (a_is_2d || b_is_2d)
+      ? offs->size(0) : mat_a.size(0);
+
+  const auto scaling_a = get_cublaslt_grouped_scaling_type(scale_a, batchCount64);
+  const auto scaling_b = get_cublaslt_grouped_scaling_type(scale_b, batchCount64);
+  if (should_use_scaled_cublaslt_grouped_gemm(
+      mat_a,
+      mat_b,
+      out_dtype,
+      offs,
+      scale_a,
+      scale_b,
+      scaling_a,
+      scaling_b,
+      batchCount64)) {
+    return scaled_grouped_mm_cublaslt(
+        mat_a,
+        mat_b,
+        scale_a,
+        scale_b,
+        offs,
+        out_dtype,
+        use_fast_accum,
+        static_cast<int>(batchCount64),
+        *scaling_a,
+        *scaling_b);
+  }
+#endif
+
+  bool allowed_device = scaled_mm_arch_allowed(/*sm90_only*/true, /*sm100_only*/true);
+  TORCH_CHECK_VALUE(
+      allowed_device,
+      "torch._scaled_grouped_mm is only supported on CUDA devices with "
+      "compute capability = [9.0, 10.0], or ROCm MI300+. "
+      "The cublasLt backend additionally supports CUDA devices with "
+      "compute capability = [10.x, 11.0]");
 
   const int scale_multiplier = (mat_a.dim() == 2 && mat_b.dim() == 2) ? offs->size(0) : 1;
   check_scale(mat_a, scale_a, 0 ,0, scale_multiplier);
@@ -624,9 +912,6 @@ TORCH_IMPL_FUNC(_scaled_grouped_mm_cuda_v2_out)(
           IntArrayRef contraction_dim,
           bool use_fast_accum,
           const Tensor& out) {
-  bool allowed_device = scaled_mm_arch_allowed(/*sm90_only=*/true, /*sm100_only=*/true);
-  TORCH_CHECK_VALUE(allowed_device, "torch._scaled_grouped_mm is only supported on CUDA devices with compute capability = [9.0, 10.0], or ROCm MI300+");
-
   TORCH_CHECK_VALUE(!check_valid_strides_and_return_transposed(mat_a), "Expected mat1 to not be transposed");
   TORCH_CHECK_VALUE(check_valid_strides_and_return_transposed(mat_b), "Expected mat2 to be transposed");
 
@@ -652,11 +937,50 @@ TORCH_IMPL_FUNC(_scaled_grouped_mm_cuda_v2_out)(
     out_mut.zero_();
   }
 #endif
-
   // Conversion of implicitly-defined enums to explicit
   auto scale_recipe_a_enum = convert_int_to_enum<ScalingType>(scale_recipe_a);
-  auto swizzle_a_enum = convert_int_to_enum<SwizzleType>(swizzle_a);
   auto scale_recipe_b_enum = convert_int_to_enum<ScalingType>(scale_recipe_b);
+
+#if !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13040
+  const int64_t batchCount64 = (a_is_2d || b_is_2d)
+      ? offs->size(0) : mat_a.size(0);
+  if (scale_a.size() == 1 &&
+      scale_b.size() == 1 &&
+      scale_recipe_a_enum.size() == 1 &&
+      scale_recipe_b_enum.size() == 1 &&
+      should_use_scaled_cublaslt_grouped_gemm(
+          mat_a,
+          mat_b,
+          out_dtype,
+          offs,
+          scale_a[0],
+          scale_b[0],
+          scale_recipe_a_enum[0],
+          scale_recipe_b_enum[0],
+          batchCount64)) {
+    return scaled_grouped_mm_cublaslt(
+        mat_a,
+        mat_b,
+        scale_a[0],
+        scale_b[0],
+        offs,
+        out_dtype,
+        use_fast_accum,
+        static_cast<int>(batchCount64),
+        scale_recipe_a_enum[0],
+        scale_recipe_b_enum[0]);
+  }
+#endif
+
+  bool allowed_device = scaled_mm_arch_allowed(/*sm90_only*/true, /*sm100_only*/true);
+  TORCH_CHECK_VALUE(
+      allowed_device,
+      "torch._scaled_grouped_mm is only supported on CUDA devices with "
+      "compute capability = [9.0, 10.0], or ROCm MI300+. "
+      "The cublasLt backend additionally supports CUDA devices with "
+      "compute capability = [10.x, 11.0]");
+
+  auto swizzle_a_enum = convert_int_to_enum<SwizzleType>(swizzle_a);
   auto swizzle_b_enum = convert_int_to_enum<SwizzleType>(swizzle_b);
 
   // at this point we can start working out what we want to be doing

--- a/aten/src/ATen/native/cuda/GroupedBlas.cpp
+++ b/aten/src/ATen/native/cuda/GroupedBlas.cpp
@@ -695,7 +695,7 @@ static Tensor scaled_grouped_mm_cublaslt(
     int batchCount,
     ScalingType scaling_a,
     ScalingType scaling_b) {
-#if !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13020
+#if !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13030
   check_cublaslt_grouped_scale_recipe(mat_a, scale_a, scaling_a, batchCount, /*is_a*/ true, "scale_a");
   check_cublaslt_grouped_scale_recipe(mat_b, scale_b, scaling_b, batchCount, /*is_a*/ false, "scale_b");
 
@@ -741,8 +741,8 @@ static Tensor scaled_grouped_mm_cublaslt(
       scales);
   return out;
 #else
-  TORCH_CHECK(false, "cublasLt scaled grouped GEMM requires CUDA >= 13.2 and is not supported on ROCm. Current build does not meet these requirements.");
-#endif // !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13020
+  TORCH_CHECK(false, "cublasLt scaled grouped GEMM requires CUDA >= 13.3 and is not supported on ROCm. Current build does not meet these requirements.");
+#endif // !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13030
 }
 
 Tensor
@@ -799,7 +799,7 @@ _scaled_grouped_mm_cuda(
       (scale_a.scalar_type() == at::kFloat8_e8m0fnu && scale_b.scalar_type() == at::kFloat8_e8m0fnu),
       "For FP8 tensorwise, groupwise, and rowwise, both scales must both be float32 tensors. For MXFP8, scales must both be float8_e8m0fnu tensors.");
 
-#if !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13020
+#if !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13030
   const int64_t batchCount64 = (a_is_2d || b_is_2d)
       ? offs->size(0) : mat_a.size(0);
 
@@ -941,7 +941,7 @@ TORCH_IMPL_FUNC(_scaled_grouped_mm_cuda_v2_out)(
   auto scale_recipe_a_enum = convert_int_to_enum<ScalingType>(scale_recipe_a);
   auto scale_recipe_b_enum = convert_int_to_enum<ScalingType>(scale_recipe_b);
 
-#if !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13040
+#if !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13030
   const int64_t batchCount64 = (a_is_2d || b_is_2d)
       ? offs->size(0) : mat_a.size(0);
   if (scale_a.size() == 1 &&

--- a/aten/src/ATen/native/cuda/GroupedBlas.cpp
+++ b/aten/src/ATen/native/cuda/GroupedBlas.cpp
@@ -121,6 +121,7 @@ bool should_use_cublaslt_grouped_gemm(
   return bf16_grouped_gemm && at::globalContext().preferCublasltGroupedGemm();
 }
 
+#if defined(CUDA_VERSION) && CUDA_VERSION >= 13040
 int64_t cublas_vec32_scale_size_host(int64_t inner, int64_t outer) {
   constexpr int64_t BLOCK_ROWS = 128;
   constexpr int64_t BLOCK_COLS = 128;
@@ -243,10 +244,6 @@ bool should_use_scaled_cublaslt_grouped_gemm(
   std::optional<ScalingType> scaling_a,
   std::optional<ScalingType> scaling_b,
   int64_t batchCount64) {
-  if (!at::globalContext().preferCublasltGroupedGemm()) {
-    return false;
-  }
-
   if (!is_cublaslt_grouped_gemm_device(/*allow_sm90*/ false)) {
     TORCH_WARN_ONCE(
         "cuBLASLt scaled grouped GEMM is not used because this device is not supported; falling back to the non-cuBLASLt grouped GEMM path.");
@@ -309,6 +306,7 @@ bool should_use_scaled_cublaslt_grouped_gemm(
 
   return true;
 }
+#endif
 
 bool cublaslt_grouped_mm_use_int64(const Tensor& mat_a, const Tensor& mat_b, const Tensor& out) {
   // cuBLAS grouped GEMM packs per-group m/n/k and lda/ldb/ldd into device
@@ -691,23 +689,20 @@ std::optional<c10::ScalarType> out_dtype) {
 #endif // !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13030
 }
 
-static Tensor scaled_grouped_mm_cublaslt(
+static void scaled_grouped_mm_cublaslt(
     const Tensor& mat_a,
     const Tensor& mat_b,
     const Tensor& scale_a,
     const Tensor& scale_b,
     const std::optional<at::Tensor>& offs,
-    std::optional<c10::ScalarType> out_dtype,
     bool use_fast_accum,
     int batchCount,
     ScalingType scaling_a,
-    ScalingType scaling_b) {
-#if !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13030
+    ScalingType scaling_b,
+    Tensor& out) {
+#if !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13040
   check_cublaslt_grouped_scale_recipe(mat_a, scale_a, scaling_a, batchCount, /*is_a*/ true, "scale_a");
   check_cublaslt_grouped_scale_recipe(mat_b, scale_b, scaling_b, batchCount, /*is_a*/ false, "scale_b");
-
-  const auto out_dtype_ = out_dtype.value_or(at::kBFloat16);
-  Tensor out = create_grouped_gemm_output_tensor(mat_a, mat_b, offs, out_dtype_);
 
   const bool needs_int64 = cublaslt_grouped_mm_use_int64(mat_a, mat_b, out);
 
@@ -746,10 +741,10 @@ static Tensor scaled_grouped_mm_cublaslt(
       args.DPtrArray, args.lddArray,
       args.batchCount, args.use_int64,
       scales);
-  return out;
+  return;
 #else
-  TORCH_CHECK(false, "cublasLt scaled grouped GEMM requires CUDA >= 13.3 and is not supported on ROCm. Current build does not meet these requirements.");
-#endif // !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13030
+  TORCH_CHECK(false, "cublasLt scaled grouped GEMM requires CUDA >= 13.4 and is not supported on ROCm. Current build does not meet these requirements.");
+#endif // !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13040
 }
 
 Tensor
@@ -806,7 +801,7 @@ _scaled_grouped_mm_cuda(
       (scale_a.scalar_type() == at::kFloat8_e8m0fnu && scale_b.scalar_type() == at::kFloat8_e8m0fnu),
       "For FP8 tensorwise, groupwise, and rowwise, both scales must both be float32 tensors. For MXFP8, scales must both be float8_e8m0fnu tensors.");
 
-#if !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13030
+#if !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13040
   const int64_t batchCount64 = (a_is_2d || b_is_2d)
       ? offs->size(0) : mat_a.size(0);
 
@@ -822,17 +817,20 @@ _scaled_grouped_mm_cuda(
       scaling_a,
       scaling_b,
       batchCount64)) {
-    return scaled_grouped_mm_cublaslt(
+    const auto out_dtype_ = out_dtype.value_or(at::kBFloat16);
+    Tensor out = create_grouped_gemm_output_tensor(mat_a, mat_b, offs, out_dtype_);
+    scaled_grouped_mm_cublaslt(
         mat_a,
         mat_b,
         scale_a,
         scale_b,
         offs,
-        out_dtype,
         use_fast_accum,
         static_cast<int>(batchCount64),
         *scaling_a,
-        *scaling_b);
+        *scaling_b,
+    out);
+    return out;
   }
 #endif
 
@@ -948,9 +946,9 @@ TORCH_IMPL_FUNC(_scaled_grouped_mm_cuda_v2_out)(
   auto scale_recipe_a_enum = convert_int_to_enum<ScalingType>(scale_recipe_a);
   auto scale_recipe_b_enum = convert_int_to_enum<ScalingType>(scale_recipe_b);
 
-#if !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13030
-  const int64_t batchCount64 = (a_is_2d || b_is_2d)
-      ? offs->size(0) : mat_a.size(0);
+#if !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13040
+  const int64_t batchCount64 = (mat_a.dim() == 2 || mat_b.dim() == 2)
+      ? offs_opt->size(0) : mat_a.size(0);
   if (scale_a.size() == 1 &&
       scale_b.size() == 1 &&
       scale_recipe_a_enum.size() == 1 &&
@@ -959,23 +957,24 @@ TORCH_IMPL_FUNC(_scaled_grouped_mm_cuda_v2_out)(
           mat_a,
           mat_b,
           out_dtype,
-          offs,
+          offs_opt,
           scale_a[0],
           scale_b[0],
           scale_recipe_a_enum[0],
           scale_recipe_b_enum[0],
           batchCount64)) {
-    return scaled_grouped_mm_cublaslt(
+    scaled_grouped_mm_cublaslt(
         mat_a,
         mat_b,
         scale_a[0],
         scale_b[0],
-        offs,
-        out_dtype,
+        offs_opt,
         use_fast_accum,
         static_cast<int>(batchCount64),
         scale_recipe_a_enum[0],
-        scale_recipe_b_enum[0]);
+        scale_recipe_b_enum[0],
+    out_mut);
+    return;
   }
 #endif
 

--- a/aten/src/ATen/native/cuda/GroupedBlas.cpp
+++ b/aten/src/ATen/native/cuda/GroupedBlas.cpp
@@ -244,12 +244,6 @@ bool should_use_scaled_cublaslt_grouped_gemm(
   std::optional<ScalingType> scaling_a,
   std::optional<ScalingType> scaling_b,
   int64_t batchCount64) {
-  if (!is_cublaslt_grouped_gemm_device(/*allow_sm90*/ false)) {
-    TORCH_WARN_ONCE(
-        "cuBLASLt scaled grouped GEMM is not used because this device is not supported; falling back to the non-cuBLASLt grouped GEMM path.");
-    return false;
-  }
-
   if (!scaling_a.has_value() || !scaling_b.has_value()) {
     TORCH_WARN_ONCE(
         "cuBLASLt scaled grouped GEMM is not used because scale_a and scale_b must each be tensorwise, groupwise, or blockwise MXFP8 scales; falling back to the non-cuBLASLt grouped GEMM path.");
@@ -260,6 +254,19 @@ bool should_use_scaled_cublaslt_grouped_gemm(
       !is_cublaslt_grouped_scaling_type(*scaling_b)) {
     TORCH_WARN_ONCE(
         "cuBLASLt scaled grouped GEMM is not used because scale_a and scale_b recipes must each be tensorwise, groupwise, or blockwise MXFP8; falling back to the non-cuBLASLt grouped GEMM path.");
+    return false;
+  }
+
+  bool valid_device;
+  if (*scaling_a == ScalingType::BlockWise1x32 ||
+      *scaling_b == ScalingType::BlockWise1x32) {
+    valid_device = is_cublaslt_grouped_gemm_device(/*allow_sm90*/ false);
+  } else {
+    valid_device = is_cublaslt_grouped_gemm_device(/*allow_sm90*/ true);
+  }
+  if (!valid_device) {
+    TORCH_WARN_ONCE(
+        "cuBLASLt scaled grouped GEMM is not used because this device is not supported; falling back to the non-cuBLASLt grouped GEMM path.");
     return false;
   }
 
@@ -733,10 +740,10 @@ static void scaled_grouped_mm_cublaslt(
       args.mArray, args.m,
       args.nArray, args.n,
       args.kArray, args.k,
-      args.alphaPtrArray, nullptr, mat_a.scalar_type(),
+      args.alphaPtrArray, args.alphaScalar, mat_a.scalar_type(),
       args.APtrArray, args.ldaArray,
       args.BPtrArray, args.ldbArray,
-      args.betaPtrArray, nullptr, out.scalar_type(),
+      args.betaPtrArray, args.betaScalar, out.scalar_type(),
       args.DPtrArray, args.lddArray,
       args.DPtrArray, args.lddArray,
       args.batchCount, args.use_int64,

--- a/aten/src/ATen/native/cuda/GroupedBlas.cpp
+++ b/aten/src/ATen/native/cuda/GroupedBlas.cpp
@@ -121,6 +121,17 @@ bool should_use_cublaslt_grouped_gemm(
   return bf16_grouped_gemm && at::globalContext().preferCublasltGroupedGemm();
 }
 
+int64_t cublas_vec32_scale_size_host(int64_t inner, int64_t outer) {
+  constexpr int64_t BLOCK_ROWS = 128;
+  constexpr int64_t BLOCK_COLS = 128;
+  constexpr int64_t S_VSCALE = 32;
+  int64_t s_rows = ((inner + BLOCK_ROWS - 1) / BLOCK_ROWS) * (BLOCK_ROWS / S_VSCALE);
+  int64_t s_cols = ((outer + BLOCK_COLS - 1) / BLOCK_COLS) * BLOCK_COLS;
+  return s_rows * s_cols;
+}
+
+// Needs to stay synced with is_cublaslt_grouped_scaling_type and
+// check_cublaslt_grouped_scale_recipe to support both v1 and v2 APIs
 std::optional<ScalingType> get_cublaslt_grouped_scaling_type(
     const Tensor& scale,
     int64_t batchCount) {
@@ -138,21 +149,16 @@ std::optional<ScalingType> get_cublaslt_grouped_scaling_type(
   return std::nullopt;
 }
 
-int64_t cublas_vec32_scale_size_host(int64_t inner, int64_t outer) {
-  constexpr int64_t BLOCK_ROWS = 128;
-  constexpr int64_t BLOCK_COLS = 128;
-  constexpr int64_t S_VSCALE = 32;
-  int64_t s_rows = ((inner + BLOCK_ROWS - 1) / BLOCK_ROWS) * (BLOCK_ROWS / S_VSCALE);
-  int64_t s_cols = ((outer + BLOCK_COLS - 1) / BLOCK_COLS) * BLOCK_COLS;
-  return s_rows * s_cols;
-}
-
+// Needs to stay synced with get_cublaslt_grouped_scaling_type and
+// check_cublaslt_grouped_scale_recipe to support both v1 and v2 APIs
 bool is_cublaslt_grouped_scaling_type(ScalingType scaling) {
   return scaling == ScalingType::TensorWise ||
       scaling == ScalingType::GroupWise ||
       scaling == ScalingType::BlockWise1x32;
 }
 
+// Needs to stay synced with get_cublaslt_grouped_scaling_type and
+// is_cublaslt_grouped_scaling_type to support both v1 and v2 APIs
 void check_cublaslt_grouped_scale_recipe(
     const Tensor& mat,
     const Tensor& scale,
@@ -226,6 +232,7 @@ void check_cublaslt_grouped_scale_recipe(
   }
 }
 
+// Mirrored by _should_use_scaled_cublaslt_grouped_gemm in torch/_meta_registrations.py
 bool should_use_scaled_cublaslt_grouped_gemm(
   const Tensor& mat_a,
   const Tensor& mat_b,

--- a/aten/src/ATen/native/cuda/GroupedBlas.cpp
+++ b/aten/src/ATen/native/cuda/GroupedBlas.cpp
@@ -244,16 +244,15 @@ bool should_use_scaled_cublaslt_grouped_gemm(
   std::optional<ScalingType> scaling_a,
   std::optional<ScalingType> scaling_b,
   int64_t batchCount64) {
+  // A non-cuBLASLt recipe (e.g. rowwise) is normal routing to another backend,
+  // not an anomaly, so fall back silently. The remaining guards warn because
+  // the recipe is one cuBLASLt supports and only some other condition missed.
   if (!scaling_a.has_value() || !scaling_b.has_value()) {
-    TORCH_WARN_ONCE(
-        "cuBLASLt scaled grouped GEMM is not used because scale_a and scale_b must each be tensorwise, groupwise, or blockwise MXFP8 scales; falling back to the non-cuBLASLt grouped GEMM path.");
     return false;
   }
 
   if (!is_cublaslt_grouped_scaling_type(*scaling_a) ||
       !is_cublaslt_grouped_scaling_type(*scaling_b)) {
-    TORCH_WARN_ONCE(
-        "cuBLASLt scaled grouped GEMM is not used because scale_a and scale_b recipes must each be tensorwise, groupwise, or blockwise MXFP8; falling back to the non-cuBLASLt grouped GEMM path.");
     return false;
   }
 
@@ -696,6 +695,7 @@ std::optional<c10::ScalarType> out_dtype) {
 #endif // !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13030
 }
 
+#if !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13040
 static void scaled_grouped_mm_cublaslt(
     const Tensor& mat_a,
     const Tensor& mat_b,
@@ -707,7 +707,6 @@ static void scaled_grouped_mm_cublaslt(
     ScalingType scaling_a,
     ScalingType scaling_b,
     Tensor& out) {
-#if !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13040
   check_cublaslt_grouped_scale_recipe(mat_a, scale_a, scaling_a, batchCount, /*is_a*/ true, "scale_a");
   check_cublaslt_grouped_scale_recipe(mat_b, scale_b, scaling_b, batchCount, /*is_a*/ false, "scale_b");
 
@@ -748,11 +747,8 @@ static void scaled_grouped_mm_cublaslt(
       args.DPtrArray, args.lddArray,
       args.batchCount, args.use_int64,
       scales);
-  return;
-#else
-  TORCH_CHECK(false, "cublasLt scaled grouped GEMM requires CUDA >= 13.4 and is not supported on ROCm. Current build does not meet these requirements.");
-#endif // !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13040
 }
+#endif // !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13040
 
 Tensor
 _scaled_grouped_mm_cuda(

--- a/test/test_matmul_cuda.py
+++ b/test/test_matmul_cuda.py
@@ -23,6 +23,7 @@ from torch.testing._internal.common_cuda import (
     _get_torch_rocm_version,
     _get_torch_cuda_version,
     blas_library_context,
+    prefer_cublaslt_grouped_gemm,
     IS_SM90,
     PLATFORM_SUPPORTS_BF16,
     SM80OrLater,
@@ -99,16 +100,6 @@ def rocm_group_gemm_ck_env(value):
             os.environ.pop(var, None)
         else:
             os.environ[var] = old
-
-
-@contextlib.contextmanager
-def prefer_cublaslt_grouped_gemm():
-    old = torch.backends.cuda.matmul.prefer_cublaslt_grouped_gemm
-    try:
-        torch.backends.cuda.matmul.prefer_cublaslt_grouped_gemm = True
-        yield
-    finally:
-        torch.backends.cuda.matmul.prefer_cublaslt_grouped_gemm = old
 
 
 @contextlib.contextmanager

--- a/test/test_scaled_matmul_cuda.py
+++ b/test/test_scaled_matmul_cuda.py
@@ -7,6 +7,7 @@ import re
 import itertools
 import tempfile
 import unittest
+import warnings
 
 import torch
 
@@ -55,6 +56,7 @@ from torch.testing._internal.common_utils import (
     random_matrix_with_scaled_reduction_dim,
     run_tests,
     runOnRocmArch,
+    set_warn_always_context,
     skipIfRocm,
     skipIfTorchDynamo,
     TEST_CUDA,
@@ -2635,8 +2637,7 @@ class TestFP8Matmul(TestCase):
                 self.scaled_grouped_mm_helper(a, blist, scale_a, bscalelist, outlist, fast_accum)
 
 
-    def scaled_grouped_gemm_cublaslt_helper(self, op, a_dtype, b_dtype, scale_mode):
-        device = "cuda"
+    def scaled_grouped_gemm_cublaslt_helper(self, op, a_dtype, b_dtype, scale_mode, device):
         ngroups = 5
         # FP8 is 1 byte, so 16-byte alignment requires dims/offsets to be multiples of 16
 
@@ -2743,10 +2744,10 @@ class TestFP8Matmul(TestCase):
     @parametrize("out_dtype", [torch.bfloat16, torch.float16, torch.float32])
     @parametrize("scale_mode", ["tensorwise", "groupwise"])
     @parametrize("fast_accum", [False, True])
-    def test_scaled_grouped_gemm_cublaslt(self, op, dtypes, out_dtype, scale_mode, fast_accum):
+    def test_scaled_grouped_gemm_cublaslt(self, op, dtypes, out_dtype, scale_mode, fast_accum, device):
         a_dtype, b_dtype = dtypes
         A, B_T, scale_a, scale_b, offs = self.scaled_grouped_gemm_cublaslt_helper(
-            op, a_dtype, b_dtype, scale_mode
+            op, a_dtype, b_dtype, scale_mode, device
         )
 
         with prefer_cublaslt_grouped_gemm():
@@ -2761,7 +2762,7 @@ class TestFP8Matmul(TestCase):
             )
 
         C_ref = self.cublaslt_grouped_gemm_ref(A, B_T, scale_a, scale_b, offs, out_dtype, fast_accum)
-        self.assertEqual(C, C_ref, atol=1e-2, rtol=1e-2)
+        self.assertEqual(C, C_ref)
 
 
     @onlyCUDA
@@ -2783,11 +2784,11 @@ class TestFP8Matmul(TestCase):
     @parametrize("scale_mode", ["tensorwise", "groupwise"])
     @parametrize("fast_accum", [False, True])
     @parametrize("mode", ["default", "reduce-overhead"])
-    def test_scaled_grouped_gemm_cublaslt_compiled(self, op, dtypes, out_dtype, scale_mode, fast_accum, mode):
+    def test_scaled_grouped_gemm_cublaslt_compiled(self, op, dtypes, out_dtype, scale_mode, fast_accum, mode, device):
         a_dtype, b_dtype = dtypes
         torch._dynamo.reset()  # each shape combination needs fresh compilation state
         A, B_T, scale_a, scale_b, offs = self.scaled_grouped_gemm_cublaslt_helper(
-            op, a_dtype, b_dtype, scale_mode
+            op, a_dtype, b_dtype, scale_mode, device
         )
 
         with prefer_cublaslt_grouped_gemm():
@@ -2806,8 +2807,7 @@ class TestFP8Matmul(TestCase):
             C = f(A, B_T.transpose(-2, -1), scale_a, scale_b, offs=offs, use_fast_accum=fast_accum, out_dtype=out_dtype)
             self.assertEqual(C, C_ref)
 
-    def scaled_grouped_gemm_cublaslt_mxfp8_helper(self, op):
-        device = "cuda"
+    def scaled_grouped_gemm_cublaslt_mxfp8_helper(self, op, device):
         ngroups = 4
         block_size = 32
 
@@ -2882,8 +2882,8 @@ class TestFP8Matmul(TestCase):
     @parametrize("op", ["2d/2d", "2d/3d", "3d/2d", "3d/3d"])
     @parametrize("out_dtype", [torch.bfloat16, torch.float16, torch.float32])
     @parametrize("fast_accum", [False, True])
-    def test_scaled_grouped_gemm_cublaslt_mxfp8(self, op, out_dtype, fast_accum):
-        A, B_T, scale_a, scale_b, offs = self.scaled_grouped_gemm_cublaslt_mxfp8_helper(op)
+    def test_scaled_grouped_gemm_cublaslt_mxfp8(self, op, out_dtype, fast_accum, device):
+        A, B_T, scale_a, scale_b, offs = self.scaled_grouped_gemm_cublaslt_mxfp8_helper(op, device)
 
         with prefer_cublaslt_grouped_gemm():
             C = torch._scaled_grouped_mm(
@@ -2897,7 +2897,7 @@ class TestFP8Matmul(TestCase):
             )
 
         C_ref = self.cublaslt_grouped_gemm_ref(A, B_T, scale_a, scale_b, offs, out_dtype, fast_accum)
-        self.assertEqual(C, C_ref, atol=1e-2, rtol=1e-2)
+        self.assertEqual(C, C_ref)
 
 
     @onlyCUDA
@@ -2909,9 +2909,9 @@ class TestFP8Matmul(TestCase):
     @parametrize("op", ["2d/2d", "2d/3d", "3d/2d", "3d/3d"])
     @parametrize("fast_accum", [False, True])
     @parametrize("mode", ["default", "reduce-overhead"])
-    def test_scaled_grouped_gemm_cublaslt_mxfp8_compiled(self, op, fast_accum, mode):
+    def test_scaled_grouped_gemm_cublaslt_mxfp8_compiled(self, op, fast_accum, mode, device):
         out_dtype = torch.bfloat16
-        A, B_T, scale_a, scale_b, offs = self.scaled_grouped_gemm_cublaslt_mxfp8_helper(op)
+        A, B_T, scale_a, scale_b, offs = self.scaled_grouped_gemm_cublaslt_mxfp8_helper(op, device)
 
         torch._dynamo.reset()
         with prefer_cublaslt_grouped_gemm():
@@ -2928,6 +2928,100 @@ class TestFP8Matmul(TestCase):
             )
             self.assertEqual(C, C_ref)
 
+
+    @onlyCUDA
+    @skipIfRocm
+    @unittest.skipIf(
+        not PLATFORM_SUPPORTS_CUBLASLT_FP8_GROUPED_GEMM,
+        cublaslt_grouped_mm_skip_msg
+    )
+    @parametrize("case", ["unsupported_input_dtype", "unsupported_out_dtype", "too_many_groups"])
+    def test_scaled_grouped_gemm_cublaslt_fallback_warns(self, case, device):
+        # Inputs that fail should_use_scaled_cublaslt_grouped_gemm must warn and
+        # fall back to the non-cuBLASLt path rather than erroring. On this device
+        # the fallback then rejects the inputs itself, so assert the fallback
+        # warning fires. set_warn_always_context forces the TORCH_WARN_ONCE to
+        # re-emit regardless of prior tests.
+        m, n, k = 16, 16, 64
+        offs = torch.tensor([0, 16, 32, 32, k], device=device, dtype=torch.int32)
+        scale_a = torch.rand(1, device=device, dtype=torch.float32)
+        scale_b = torch.rand(1, device=device, dtype=torch.float32)
+        if case == "unsupported_input_dtype":
+            a = torch.randn(m, k, device=device).to(torch.float8_e5m2)
+            b = torch.randn(n, k, device=device).to(torch.float8_e5m2)
+            out_dtype = torch.bfloat16
+            warn_regex = "inputs must both be FP8 and at least one input must be Float8_e4m3fn"
+        elif case == "unsupported_out_dtype":
+            a = torch.randn(m, k, device=device).to(e4m3_type)
+            b = torch.randn(n, k, device=device).to(e4m3_type)
+            out_dtype = torch.float64
+            warn_regex = "output dtype must be BFloat16, Float16, or Float32"
+        else:  # too_many_groups: batchCount above the cuBLASLt [1, 1024] limit
+            a = torch.randn(m, k, device=device).to(e4m3_type)
+            b = torch.randn(n, k, device=device).to(e4m3_type)
+            out_dtype = torch.bfloat16
+            offs = torch.arange(1, 1026, device=device, dtype=torch.int32)
+            warn_regex = r"batchCount must be in \[1, 1024\]"
+
+        with prefer_cublaslt_grouped_gemm():
+            with warnings.catch_warnings(record=True) as ws:
+                warnings.simplefilter("always")
+                with set_warn_always_context(True):
+                    with self.assertRaises(RuntimeError):
+                        torch._scaled_grouped_mm(
+                            a, b.t(), scale_a, scale_b, offs=offs, out_dtype=out_dtype
+                        )
+        self.assertTrue(
+            any(re.search(warn_regex, str(w.message)) for w in ws),
+            f"expected cuBLASLt fallback warning matching {warn_regex!r}, "
+            f"got {[str(w.message) for w in ws]}",
+        )
+
+    @onlyCUDA
+    @skipIfRocm
+    @unittest.skipIf(
+        not PLATFORM_SUPPORTS_CUBLASLT_FP8_GROUPED_GEMM,
+        cublaslt_grouped_mm_skip_msg
+    )
+    @parametrize(
+        "case",
+        [
+            "groupwise_noncontiguous",
+            "blockwise_noncontiguous",
+            "blockwise_wrong_shape",
+            "blockwise_too_few_elements",
+        ]
+    )
+    def test_scaled_grouped_gemm_cublaslt_scale_recipe_errors(self, case, device):
+        # Scales whose recipe is recognized by should_use_scaled_cublaslt_grouped_gemm
+        # but that violate check_cublaslt_grouped_scale_recipe must raise once the
+        # cuBLASLt path is selected.
+        e8m0 = torch.float8_e8m0fnu
+        if case == "groupwise_noncontiguous":
+            A, B_T, scale_a, scale_b, offs = self.scaled_grouped_gemm_cublaslt_helper(
+                "2d/2d", e4m3_type, e4m3_type, "groupwise", device
+            )
+            # 1D float32 with one value per group, but non-contiguous.
+            scale_a = torch.rand(2 * scale_a.numel(), device=device, dtype=torch.float32)[::2]
+            regex = "scale_a groupwise scale must be a contiguous 1D float32 tensor"
+        elif case == "blockwise_too_few_elements":
+            A, B_T, scale_a, scale_b, offs = self.scaled_grouped_gemm_cublaslt_mxfp8_helper("2d/2d", device)
+            scale_a = torch.ones(1, device=device, dtype=e8m0)
+            regex = "scale_a blockwise scale for cuBLASLt grouped GEMM must have at least"
+        else:
+            A, B_T, scale_a, scale_b, offs = self.scaled_grouped_gemm_cublaslt_mxfp8_helper("3d/3d", device)
+            if case == "blockwise_noncontiguous":
+                scale_a = torch.ones((A.shape[0], 2 * scale_a.shape[1]), device=device, dtype=e8m0)[:, ::2]
+                regex = "scale_a blockwise scale must be a contiguous float8_e8m0fnu tensor"
+            else:  # blockwise_wrong_shape
+                scale_a = torch.ones((A.shape[0], 1), device=device, dtype=e8m0)
+                regex = "scale_a blockwise scale for cuBLASLt grouped GEMM must have shape"
+
+        with prefer_cublaslt_grouped_gemm():
+            with self.assertRaisesRegex(RuntimeError, regex):
+                torch._scaled_grouped_mm(
+                    A, B_T.transpose(-2, -1), scale_a, scale_b, offs=offs, out_dtype=torch.bfloat16
+                )
 
     @onlyAccelerator
     @unittest.skipIf(not PLATFORM_SUPPORTS_MX_GEMM, mx_skip_msg)

--- a/test/test_scaled_matmul_cuda.py
+++ b/test/test_scaled_matmul_cuda.py
@@ -81,7 +81,7 @@ f8_msg = "FP8 is only supported on H100+, SM 8.9 and MI300+, XPU and CPU devices
 f8_grouped_msg = "FP8 grouped is only supported on SM90 and MI300/MI350 devices"
 mx_skip_msg = "MX gemm is only supported on CUDA capability 10.0+"
 mxfp8_grouped_mm_skip_msg = "MXFP8 grouped GEMM is only supported when PyTorch is built with USE_MSLK=1 on SM100+"
-cublaslt_grouped_mm_skip_msg = "cuBLASLt grouped GEMM requires SM 10.x or 11.0 with CUDA 13.2+"
+cublaslt_grouped_mm_skip_msg = "cuBLASLt grouped GEMM requires SM 10.x or 11.0 with CUDA 13.3+"
 
 # avoid division by zero when calculating scale
 EPS = 1e-12
@@ -2636,8 +2636,6 @@ class TestFP8Matmul(TestCase):
 
 
     def scaled_grouped_gemm_cublaslt_helper(self, op, a_dtype, b_dtype, scale_mode):
-        """Build FP8 inputs and scales for testing the cuBLASLt
-        grouped GEMM path via TORCH_GROUPED_MM_PREFER_CUBLASLT=1."""
         device = "cuda"
         ngroups = 5
         # FP8 is 1 byte, so 16-byte alignment requires dims/offsets to be multiples of 16

--- a/test/test_scaled_matmul_cuda.py
+++ b/test/test_scaled_matmul_cuda.py
@@ -22,6 +22,7 @@ from torch.nn.functional import (
 from torch.testing._internal.common_cuda import (
     IS_SM90,
     _get_torch_cuda_version,
+    PLATFORM_SUPPORTS_CUBLASLT_FP8_GROUPED_GEMM,
     PLATFORM_SUPPORTS_FP8,
     PLATFORM_SUPPORTS_FP8_GROUPED_GEMM,
     PLATFORM_SUPPORTS_MX_GEMM,
@@ -31,6 +32,7 @@ from torch.testing._internal.common_cuda import (
     SM89OrLater,
     SM90OrLater,
     with_tf32_off,
+    prefer_cublaslt_grouped_gemm,
 )
 from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
@@ -79,6 +81,7 @@ f8_msg = "FP8 is only supported on H100+, SM 8.9 and MI300+, XPU and CPU devices
 f8_grouped_msg = "FP8 grouped is only supported on SM90 and MI300/MI350 devices"
 mx_skip_msg = "MX gemm is only supported on CUDA capability 10.0+"
 mxfp8_grouped_mm_skip_msg = "MXFP8 grouped GEMM is only supported when PyTorch is built with USE_MSLK=1 on SM100+"
+cublaslt_grouped_mm_skip_msg = "cuBLASLt grouped GEMM requires SM 10.x or 11.0 with CUDA 13.2+"
 
 # avoid division by zero when calculating scale
 EPS = 1e-12
@@ -2630,6 +2633,302 @@ class TestFP8Matmul(TestCase):
                 outlist.append(out[:, start:offs_cpu[i]])
                 start = offs_cpu[i]
                 self.scaled_grouped_mm_helper(a, blist, scale_a, bscalelist, outlist, fast_accum)
+
+
+    def scaled_grouped_gemm_cublaslt_helper(self, op, a_dtype, b_dtype, scale_mode):
+        """Build FP8 inputs and scales for testing the cuBLASLt
+        grouped GEMM path via TORCH_GROUPED_MM_PREFER_CUBLASLT=1."""
+        device = "cuda"
+        ngroups = 5
+        # FP8 is 1 byte, so 16-byte alignment requires dims/offsets to be multiples of 16
+
+        if op == "2d/2d":
+            m, n, k_total = 16, 16, 64
+            offs = torch.tensor([0, 16, 32, 32, k_total], device=device, dtype=torch.int32)
+            A = torch.randn(m, k_total, device=device).to(a_dtype)
+            B_T = torch.randn(n, k_total, device=device).to(b_dtype)
+        elif op == "2d/3d":
+            n, k = 16, 32
+            m_total = 80
+            offs = torch.tensor([0, 16, 32, 32, m_total], device=device, dtype=torch.int32)
+            A = torch.randn(m_total, k, device=device).to(a_dtype)
+            B_T = torch.randn(ngroups, n, k, device=device).to(b_dtype)
+        elif op == "3d/2d":
+            m, k = 16, 32
+            n_total = 80
+            offs = torch.tensor([0, 16, 32, 32, n_total], device=device, dtype=torch.int32)
+            A = torch.randn(ngroups, m, k, device=device).to(a_dtype)
+            B_T = torch.randn(n_total, k, device=device).to(b_dtype)
+        elif op == "3d/3d":
+            m, n, k = 16, 16, 32
+            offs = None
+            A = torch.randn(ngroups, m, k, device=device).to(a_dtype)
+            B_T = torch.randn(ngroups, n, k, device=device).to(b_dtype)
+
+        scale_shape = (1,) if scale_mode == "tensorwise" else (ngroups,)
+        scale_a = torch.rand(scale_shape, device=device, dtype=torch.float32) + 0.5
+        scale_b = torch.rand(scale_shape, device=device, dtype=torch.float32) + 0.5
+        return A, B_T, scale_a, scale_b, offs
+
+    def cublaslt_grouped_gemm_ref(self, A, B_T, scale_a, scale_b, offs, out_dtype, fast_accum):
+        def cublaslt_grouped_gemm_slices():
+            a_is_2d = A.dim() == 2
+            b_is_2d = B_T.dim() == 2
+            off_vals = [0] + offs.tolist() if offs is not None else None
+            for g in range(ngroups):
+                if a_is_2d and b_is_2d:
+                    start, end = off_vals[g], off_vals[g + 1]
+                    yield g, A[:, start:end], B_T[:, start:end].t(), start, end
+                elif a_is_2d and not b_is_2d:
+                    start, end = off_vals[g], off_vals[g + 1]
+                    yield g, A[start:end, :], B_T[g].t(), start, end
+                elif not a_is_2d and b_is_2d:
+                    start, end = off_vals[g], off_vals[g + 1]
+                    yield g, A[g], B_T[start:end, :].t(), start, end
+                else:
+                    yield g, A[g], B_T[g].t(), None, None
+
+        def cublaslt_grouped_gemm_scale(scale, g, start, end, x_g, offset):
+            if scale.numel() == 1:
+                return scale, offset
+            if scale.dim() == 1 and scale.numel() == ngroups:
+                return scale[g:g + 1], offset
+            if scale.dim() >= 2:
+                return (scale[g] if scale.shape[0] == ngroups else scale[start:end]), offset
+
+            rows, cols = x_g.shape
+            size = 32 * ceil_div(rows, 128) * 16 * ceil_div(ceil_div(cols, 32), 4)
+            return scale[offset:offset + size], offset + size
+
+        ngroups = A.shape[0] if offs is None else offs.shape[0]
+        ref_parts = []
+        sa_offset, sb_offset = 0, 0
+        for g, a_g, b_g, start, end in cublaslt_grouped_gemm_slices():
+            sa_g, sa_offset = cublaslt_grouped_gemm_scale(
+                scale_a, g, start, end, a_g, sa_offset
+            )
+            sb_g, sb_offset = cublaslt_grouped_gemm_scale(
+                scale_b, g, start, end, b_g.t(), sb_offset
+            )
+            ref_parts.append(
+                torch._scaled_mm(
+                    a_g,
+                    b_g,
+                    scale_a=sa_g,
+                    scale_b=sb_g,
+                    out_dtype=out_dtype,
+                    use_fast_accum=fast_accum,
+                )
+            )
+        if A.dim() == 2 and B_T.dim() != 2:
+            return torch.cat(ref_parts, dim=0)
+        if A.dim() != 2 and B_T.dim() == 2:
+            return torch.cat(ref_parts, dim=1)
+        return torch.stack(ref_parts, dim=0)
+
+
+    @onlyCUDA
+    @skipIfRocm
+    @unittest.skipIf(
+        not PLATFORM_SUPPORTS_CUBLASLT_FP8_GROUPED_GEMM,
+        cublaslt_grouped_mm_skip_msg
+    )
+    @parametrize("op", ["2d/2d", "2d/3d", "3d/2d", "3d/3d"])
+    @parametrize(
+        "dtypes",
+        [
+            (torch.float8_e4m3fn, torch.float8_e4m3fn),
+            (torch.float8_e4m3fn, torch.float8_e5m2),
+            (torch.float8_e5m2, torch.float8_e4m3fn)
+        ]
+    )
+    @parametrize("out_dtype", [torch.bfloat16, torch.float16, torch.float32])
+    @parametrize("scale_mode", ["tensorwise", "groupwise"])
+    @parametrize("fast_accum", [False, True])
+    def test_scaled_grouped_gemm_cublaslt(self, op, dtypes, out_dtype, scale_mode, fast_accum):
+        a_dtype, b_dtype = dtypes
+        A, B_T, scale_a, scale_b, offs = self.scaled_grouped_gemm_cublaslt_helper(
+            op, a_dtype, b_dtype, scale_mode
+        )
+
+        with prefer_cublaslt_grouped_gemm():
+            C = torch._scaled_grouped_mm(
+                A,
+                B_T.transpose(-2, -1),
+                scale_a,
+                scale_b,
+                offs=offs,
+                use_fast_accum=fast_accum,
+                out_dtype=out_dtype
+            )
+
+        C_ref = self.cublaslt_grouped_gemm_ref(A, B_T, scale_a, scale_b, offs, out_dtype, fast_accum)
+        self.assertEqual(C, C_ref, atol=1e-2, rtol=1e-2)
+
+
+    @onlyCUDA
+    @skipIfRocm
+    @unittest.skipIf(
+        not PLATFORM_SUPPORTS_CUBLASLT_FP8_GROUPED_GEMM,
+        cublaslt_grouped_mm_skip_msg
+    )
+    @parametrize("op", ["2d/2d", "2d/3d", "3d/2d", "3d/3d"])
+    @parametrize(
+        "dtypes",
+        [
+            (torch.float8_e4m3fn, torch.float8_e4m3fn),
+            (torch.float8_e4m3fn, torch.float8_e5m2),
+            (torch.float8_e5m2, torch.float8_e4m3fn)
+        ]
+    )
+    @parametrize("out_dtype", [torch.bfloat16, torch.float16, torch.float32])
+    @parametrize("scale_mode", ["tensorwise", "groupwise"])
+    @parametrize("fast_accum", [False, True])
+    @parametrize("mode", ["default", "reduce-overhead"])
+    def test_scaled_grouped_gemm_cublaslt_compiled(self, op, dtypes, out_dtype, scale_mode, fast_accum, mode):
+        a_dtype, b_dtype = dtypes
+        torch._dynamo.reset()  # each shape combination needs fresh compilation state
+        A, B_T, scale_a, scale_b, offs = self.scaled_grouped_gemm_cublaslt_helper(
+            op, a_dtype, b_dtype, scale_mode
+        )
+
+        with prefer_cublaslt_grouped_gemm():
+            f_ref = torch._scaled_grouped_mm
+            f = torch.compile(f_ref, fullgraph=True, mode=mode)
+
+            C_ref = f_ref(
+                A,
+                B_T.transpose(-2, -1),
+                scale_a,
+                scale_b,
+                offs=offs,
+                use_fast_accum=fast_accum,
+                out_dtype=out_dtype
+            )
+            C = f(A, B_T.transpose(-2, -1), scale_a, scale_b, offs=offs, use_fast_accum=fast_accum, out_dtype=out_dtype)
+            self.assertEqual(C, C_ref)
+
+    def scaled_grouped_gemm_cublaslt_mxfp8_helper(self, op):
+        device = "cuda"
+        ngroups = 4
+        block_size = 32
+
+        if op == "2d/2d":
+            m, n, k_g = 128, 128, 128
+            k_total = k_g * ngroups
+            offs = torch.tensor(
+                [k_g * (i + 1) for i in range(ngroups)],
+                device=device, dtype=torch.int32,
+            )
+            A_bf16 = torch.randn(m, k_total, device=device, dtype=torch.bfloat16) * 0.1
+            B_bf16 = torch.randn(n, k_total, device=device, dtype=torch.bfloat16) * 0.01
+            a_groups = [A_bf16[:, g * k_g:(g + 1) * k_g] for g in range(ngroups)]
+            b_groups = [B_bf16[:, g * k_g:(g + 1) * k_g] for g in range(ngroups)]
+            a_cat, b_cat = 1, 1
+        elif op == "2d/3d":
+            n, k = 128, 128
+            m_per_group = 128
+            m_total = m_per_group * ngroups
+            offs = torch.tensor(
+                [m_per_group * (i + 1) for i in range(ngroups)],
+                device=device, dtype=torch.int32,
+            )
+            A_bf16 = torch.randn(m_total, k, device=device, dtype=torch.bfloat16) * 0.1
+            B_bf16 = torch.randn(ngroups, n, k, device=device, dtype=torch.bfloat16) * 0.01
+            a_groups = [A_bf16[g * m_per_group:(g + 1) * m_per_group] for g in range(ngroups)]
+            b_groups = [B_bf16[g] for g in range(ngroups)]
+            a_cat, b_cat = 0, None
+        elif op == "3d/2d":
+            m, k = 128, 128
+            n_per_group = 128
+            n_total = n_per_group * ngroups
+            offs = torch.tensor(
+                [n_per_group * (i + 1) for i in range(ngroups)],
+                device=device, dtype=torch.int32,
+            )
+            A_bf16 = torch.randn(ngroups, m, k, device=device, dtype=torch.bfloat16) * 0.1
+            B_bf16 = torch.randn(n_total, k, device=device, dtype=torch.bfloat16) * 0.01
+            a_groups = [A_bf16[g] for g in range(ngroups)]
+            b_groups = [B_bf16[g * n_per_group:(g + 1) * n_per_group] for g in range(ngroups)]
+            a_cat, b_cat = None, 0
+        elif op == "3d/3d":
+            m, n, k = 128, 128, 128
+            offs = None
+            A_bf16 = torch.randn(ngroups, m, k, device=device, dtype=torch.bfloat16) * 0.1
+            B_bf16 = torch.randn(ngroups, n, k, device=device, dtype=torch.bfloat16) * 0.01
+            a_groups = [A_bf16[g] for g in range(ngroups)]
+            b_groups = [B_bf16[g] for g in range(ngroups)]
+            a_cat, b_cat = None, None
+
+        a_scales, a_fp8 = zip(*(to_mxfp(t.contiguous(), format="mxfp8") for t in a_groups))
+        b_scales, b_fp8 = zip(*(to_mxfp(t.contiguous(), format="mxfp8") for t in b_groups))
+        a_blocked_scales = [to_blocked(scale) for scale in a_scales]
+        b_blocked_scales = [to_blocked(scale) for scale in b_scales]
+
+        A = (torch.stack(a_fp8, dim=0) if a_cat is None else torch.cat(a_fp8, dim=a_cat)).contiguous()
+        B_T = (torch.stack(b_fp8, dim=0) if b_cat is None else torch.cat(b_fp8, dim=b_cat)).contiguous()
+        scale_a = torch.stack(a_blocked_scales, dim=0) if a_cat is None else torch.cat(a_blocked_scales)
+        scale_b = torch.stack(b_blocked_scales, dim=0) if b_cat is None else torch.cat(b_blocked_scales)
+        if a_cat == 0:
+            scale_a = scale_a.reshape(-1, k // block_size)
+        if b_cat == 0:
+            scale_b = scale_b.reshape(-1, k // block_size)
+        return A, B_T, scale_a, scale_b, offs
+
+    @onlyCUDA
+    @skipIfRocm
+    @unittest.skipIf(
+        not PLATFORM_SUPPORTS_CUBLASLT_FP8_GROUPED_GEMM,
+        cublaslt_grouped_mm_skip_msg
+    )
+    @parametrize("op", ["2d/2d", "2d/3d", "3d/2d", "3d/3d"])
+    @parametrize("out_dtype", [torch.bfloat16, torch.float16, torch.float32])
+    @parametrize("fast_accum", [False, True])
+    def test_scaled_grouped_gemm_cublaslt_mxfp8(self, op, out_dtype, fast_accum):
+        A, B_T, scale_a, scale_b, offs = self.scaled_grouped_gemm_cublaslt_mxfp8_helper(op)
+
+        with prefer_cublaslt_grouped_gemm():
+            C = torch._scaled_grouped_mm(
+                A,
+                B_T.transpose(-2, -1),
+                scale_a,
+                scale_b,
+                offs=offs,
+                use_fast_accum=fast_accum,
+                out_dtype=out_dtype,
+            )
+
+        C_ref = self.cublaslt_grouped_gemm_ref(A, B_T, scale_a, scale_b, offs, out_dtype, fast_accum)
+        self.assertEqual(C, C_ref, atol=1e-2, rtol=1e-2)
+
+
+    @onlyCUDA
+    @skipIfRocm
+    @unittest.skipIf(
+        not PLATFORM_SUPPORTS_CUBLASLT_FP8_GROUPED_GEMM,
+        cublaslt_grouped_mm_skip_msg
+    )
+    @parametrize("op", ["2d/2d", "2d/3d", "3d/2d", "3d/3d"])
+    @parametrize("fast_accum", [False, True])
+    @parametrize("mode", ["default", "reduce-overhead"])
+    def test_scaled_grouped_gemm_cublaslt_mxfp8_compiled(self, op, fast_accum, mode):
+        out_dtype = torch.bfloat16
+        A, B_T, scale_a, scale_b, offs = self.scaled_grouped_gemm_cublaslt_mxfp8_helper(op)
+
+        torch._dynamo.reset()
+        with prefer_cublaslt_grouped_gemm():
+            f_ref = torch._scaled_grouped_mm
+            f = torch.compile(f_ref, fullgraph=True, mode=mode)
+
+            C_ref = f_ref(
+                A, B_T.transpose(-2, -1), scale_a, scale_b,
+                offs=offs, use_fast_accum=fast_accum, out_dtype=out_dtype,
+            )
+            C = f(
+                A, B_T.transpose(-2, -1), scale_a, scale_b,
+                offs=offs, use_fast_accum=fast_accum, out_dtype=out_dtype,
+            )
+            self.assertEqual(C, C_ref)
 
 
     @onlyAccelerator

--- a/test/test_scaled_matmul_cuda.py
+++ b/test/test_scaled_matmul_cuda.py
@@ -82,7 +82,7 @@ f8_msg = "FP8 is only supported on H100+, SM 8.9 and MI300+, XPU and CPU devices
 f8_grouped_msg = "FP8 grouped is only supported on SM90 and MI300/MI350 devices"
 mx_skip_msg = "MX gemm is only supported on CUDA capability 10.0+"
 mxfp8_grouped_mm_skip_msg = "MXFP8 grouped GEMM is only supported when PyTorch is built with USE_MSLK=1 on SM100+"
-cublaslt_grouped_mm_skip_msg = "cuBLASLt scaled grouped GEMM requires SM 10.x or 11.0 with CUDA 13.4+"
+cublaslt_grouped_mm_skip_msg = "cuBLASLt scaled grouped GEMM requires SM 9.0-11.0 with CUDA 13.4+"
 
 # avoid division by zero when calculating scale
 EPS = 1e-12
@@ -2974,7 +2974,10 @@ class TestFP8Matmul(TestCase):
     @onlyCUDA
     @skipIfRocm
     @unittest.skipIf(
-        not PLATFORM_SUPPORTS_CUBLASLT_FP8_GROUPED_GEMM,
+        not (
+            PLATFORM_SUPPORTS_CUBLASLT_FP8_GROUPED_GEMM
+            and PLATFORM_SUPPORTS_MXFP8_GROUPED_GEMM
+        ),
         cublaslt_grouped_mm_skip_msg
     )
     @parametrize("op", ["2d/2d", "2d/3d", "3d/2d", "3d/3d"])
@@ -3000,7 +3003,10 @@ class TestFP8Matmul(TestCase):
     @onlyCUDA
     @skipIfRocm
     @unittest.skipIf(
-        not PLATFORM_SUPPORTS_CUBLASLT_FP8_GROUPED_GEMM,
+        not (
+            PLATFORM_SUPPORTS_CUBLASLT_FP8_GROUPED_GEMM
+            and PLATFORM_SUPPORTS_MXFP8_GROUPED_GEMM
+        ),
         cublaslt_grouped_mm_skip_msg
     )
     @parametrize("op", ["2d/2d", "2d/3d", "3d/2d", "3d/3d"])
@@ -3078,28 +3084,38 @@ class TestFP8Matmul(TestCase):
         not PLATFORM_SUPPORTS_CUBLASLT_FP8_GROUPED_GEMM,
         cublaslt_grouped_mm_skip_msg
     )
+    def test_scaled_grouped_gemm_cublaslt_groupwise_scale_recipe_error(self, device):
+        A, B_T, scale_a, scale_b, offs = self.scaled_grouped_gemm_cublaslt_helper(
+            "2d/2d", e4m3_type, e4m3_type, "groupwise", device
+        )
+        scale_a = torch.rand(2 * scale_a.numel(), device=device, dtype=torch.float32)[::2]
+        regex = "scale_a groupwise scale must be a contiguous 1D float32 tensor"
+
+        with self.assertRaisesRegex(RuntimeError, regex):
+            torch._scaled_grouped_mm(
+                A, B_T.transpose(-2, -1), scale_a, scale_b, offs=offs, out_dtype=torch.bfloat16
+            )
+
+    @onlyCUDA
+    @skipIfRocm
+    @unittest.skipIf(
+        not (
+            PLATFORM_SUPPORTS_CUBLASLT_FP8_GROUPED_GEMM
+            and PLATFORM_SUPPORTS_MXFP8_GROUPED_GEMM
+        ),
+        cublaslt_grouped_mm_skip_msg
+    )
     @parametrize(
         "case",
         [
-            "groupwise_noncontiguous",
             "blockwise_noncontiguous",
             "blockwise_wrong_shape",
             "blockwise_too_few_elements",
         ]
     )
-    def test_scaled_grouped_gemm_cublaslt_scale_recipe_errors(self, case, device):
-        # Scales whose recipe is recognized by should_use_scaled_cublaslt_grouped_gemm
-        # but that violate check_cublaslt_grouped_scale_recipe must raise once the
-        # cuBLASLt path is selected.
+    def test_scaled_grouped_gemm_cublaslt_mxfp8_scale_recipe_errors(self, case, device):
         e8m0 = torch.float8_e8m0fnu
-        if case == "groupwise_noncontiguous":
-            A, B_T, scale_a, scale_b, offs = self.scaled_grouped_gemm_cublaslt_helper(
-                "2d/2d", e4m3_type, e4m3_type, "groupwise", device
-            )
-            # 1D float32 with one value per group, but non-contiguous.
-            scale_a = torch.rand(2 * scale_a.numel(), device=device, dtype=torch.float32)[::2]
-            regex = "scale_a groupwise scale must be a contiguous 1D float32 tensor"
-        elif case == "blockwise_too_few_elements":
+        if case == "blockwise_too_few_elements":
             A, B_T, scale_a, scale_b, offs = self.scaled_grouped_gemm_cublaslt_mxfp8_helper("2d/2d", device)
             scale_a = torch.ones(1, device=device, dtype=e8m0)
             regex = "scale_a blockwise scale for cuBLASLt grouped GEMM must have at least"

--- a/test/test_scaled_matmul_cuda.py
+++ b/test/test_scaled_matmul_cuda.py
@@ -22,6 +22,7 @@ from torch.nn.functional import (
 from torch.testing._internal.common_cuda import (
     IS_SM90,
     _get_torch_cuda_version,
+    PLATFORM_SUPPORTS_CUBLASLT_FP8_GROUPED_GEMM,
     PLATFORM_SUPPORTS_FP8,
     PLATFORM_SUPPORTS_FP8_GROUPED_GEMM,
     PLATFORM_SUPPORTS_MX_GEMM,
@@ -31,6 +32,7 @@ from torch.testing._internal.common_cuda import (
     SM89OrLater,
     SM90OrLater,
     with_tf32_off,
+    prefer_cublaslt_grouped_gemm,
 )
 from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
@@ -79,6 +81,7 @@ f8_msg = "FP8 is only supported on H100+, SM 8.9 and MI300+, XPU and CPU devices
 f8_grouped_msg = "FP8 grouped is only supported on SM90 and MI300/MI350 devices"
 mx_skip_msg = "MX gemm is only supported on CUDA capability 10.0+"
 mxfp8_grouped_mm_skip_msg = "MXFP8 grouped GEMM is only supported when PyTorch is built with USE_MSLK=1 on SM100+"
+cublaslt_grouped_mm_skip_msg = "cuBLASLt grouped GEMM requires SM 10.x or 11.0 with CUDA 13.2+"
 
 # avoid division by zero when calculating scale
 EPS = 1e-12
@@ -2731,6 +2734,302 @@ class TestFP8Matmul(TestCase):
                 outlist.append(out[:, start:offs_cpu[i]])
                 start = offs_cpu[i]
                 self.scaled_grouped_mm_helper(a, blist, scale_a, bscalelist, outlist, fast_accum)
+
+
+    def scaled_grouped_gemm_cublaslt_helper(self, op, a_dtype, b_dtype, scale_mode):
+        """Build FP8 inputs and scales for testing the cuBLASLt
+        grouped GEMM path via TORCH_GROUPED_MM_PREFER_CUBLASLT=1."""
+        device = "cuda"
+        ngroups = 5
+        # FP8 is 1 byte, so 16-byte alignment requires dims/offsets to be multiples of 16
+
+        if op == "2d/2d":
+            m, n, k_total = 16, 16, 64
+            offs = torch.tensor([0, 16, 32, 32, k_total], device=device, dtype=torch.int32)
+            A = torch.randn(m, k_total, device=device).to(a_dtype)
+            B_T = torch.randn(n, k_total, device=device).to(b_dtype)
+        elif op == "2d/3d":
+            n, k = 16, 32
+            m_total = 80
+            offs = torch.tensor([0, 16, 32, 32, m_total], device=device, dtype=torch.int32)
+            A = torch.randn(m_total, k, device=device).to(a_dtype)
+            B_T = torch.randn(ngroups, n, k, device=device).to(b_dtype)
+        elif op == "3d/2d":
+            m, k = 16, 32
+            n_total = 80
+            offs = torch.tensor([0, 16, 32, 32, n_total], device=device, dtype=torch.int32)
+            A = torch.randn(ngroups, m, k, device=device).to(a_dtype)
+            B_T = torch.randn(n_total, k, device=device).to(b_dtype)
+        elif op == "3d/3d":
+            m, n, k = 16, 16, 32
+            offs = None
+            A = torch.randn(ngroups, m, k, device=device).to(a_dtype)
+            B_T = torch.randn(ngroups, n, k, device=device).to(b_dtype)
+
+        scale_shape = (1,) if scale_mode == "tensorwise" else (ngroups,)
+        scale_a = torch.rand(scale_shape, device=device, dtype=torch.float32) + 0.5
+        scale_b = torch.rand(scale_shape, device=device, dtype=torch.float32) + 0.5
+        return A, B_T, scale_a, scale_b, offs
+
+    def cublaslt_grouped_gemm_ref(self, A, B_T, scale_a, scale_b, offs, out_dtype, fast_accum):
+        def cublaslt_grouped_gemm_slices():
+            a_is_2d = A.dim() == 2
+            b_is_2d = B_T.dim() == 2
+            off_vals = [0] + offs.tolist() if offs is not None else None
+            for g in range(ngroups):
+                if a_is_2d and b_is_2d:
+                    start, end = off_vals[g], off_vals[g + 1]
+                    yield g, A[:, start:end], B_T[:, start:end].t(), start, end
+                elif a_is_2d and not b_is_2d:
+                    start, end = off_vals[g], off_vals[g + 1]
+                    yield g, A[start:end, :], B_T[g].t(), start, end
+                elif not a_is_2d and b_is_2d:
+                    start, end = off_vals[g], off_vals[g + 1]
+                    yield g, A[g], B_T[start:end, :].t(), start, end
+                else:
+                    yield g, A[g], B_T[g].t(), None, None
+
+        def cublaslt_grouped_gemm_scale(scale, g, start, end, x_g, offset):
+            if scale.numel() == 1:
+                return scale, offset
+            if scale.dim() == 1 and scale.numel() == ngroups:
+                return scale[g:g + 1], offset
+            if scale.dim() >= 2:
+                return (scale[g] if scale.shape[0] == ngroups else scale[start:end]), offset
+
+            rows, cols = x_g.shape
+            size = 32 * ceil_div(rows, 128) * 16 * ceil_div(ceil_div(cols, 32), 4)
+            return scale[offset:offset + size], offset + size
+
+        ngroups = A.shape[0] if offs is None else offs.shape[0]
+        ref_parts = []
+        sa_offset, sb_offset = 0, 0
+        for g, a_g, b_g, start, end in cublaslt_grouped_gemm_slices():
+            sa_g, sa_offset = cublaslt_grouped_gemm_scale(
+                scale_a, g, start, end, a_g, sa_offset
+            )
+            sb_g, sb_offset = cublaslt_grouped_gemm_scale(
+                scale_b, g, start, end, b_g.t(), sb_offset
+            )
+            ref_parts.append(
+                torch._scaled_mm(
+                    a_g,
+                    b_g,
+                    scale_a=sa_g,
+                    scale_b=sb_g,
+                    out_dtype=out_dtype,
+                    use_fast_accum=fast_accum,
+                )
+            )
+        if A.dim() == 2 and B_T.dim() != 2:
+            return torch.cat(ref_parts, dim=0)
+        if A.dim() != 2 and B_T.dim() == 2:
+            return torch.cat(ref_parts, dim=1)
+        return torch.stack(ref_parts, dim=0)
+
+
+    @onlyCUDA
+    @skipIfRocm
+    @unittest.skipIf(
+        not PLATFORM_SUPPORTS_CUBLASLT_FP8_GROUPED_GEMM,
+        cublaslt_grouped_mm_skip_msg
+    )
+    @parametrize("op", ["2d/2d", "2d/3d", "3d/2d", "3d/3d"])
+    @parametrize(
+        "dtypes",
+        [
+            (torch.float8_e4m3fn, torch.float8_e4m3fn),
+            (torch.float8_e4m3fn, torch.float8_e5m2),
+            (torch.float8_e5m2, torch.float8_e4m3fn)
+        ]
+    )
+    @parametrize("out_dtype", [torch.bfloat16, torch.float16, torch.float32])
+    @parametrize("scale_mode", ["tensorwise", "groupwise"])
+    @parametrize("fast_accum", [False, True])
+    def test_scaled_grouped_gemm_cublaslt(self, op, dtypes, out_dtype, scale_mode, fast_accum):
+        a_dtype, b_dtype = dtypes
+        A, B_T, scale_a, scale_b, offs = self.scaled_grouped_gemm_cublaslt_helper(
+            op, a_dtype, b_dtype, scale_mode
+        )
+
+        with prefer_cublaslt_grouped_gemm():
+            C = torch._scaled_grouped_mm(
+                A,
+                B_T.transpose(-2, -1),
+                scale_a,
+                scale_b,
+                offs=offs,
+                use_fast_accum=fast_accum,
+                out_dtype=out_dtype
+            )
+
+        C_ref = self.cublaslt_grouped_gemm_ref(A, B_T, scale_a, scale_b, offs, out_dtype, fast_accum)
+        self.assertEqual(C, C_ref, atol=1e-2, rtol=1e-2)
+
+
+    @onlyCUDA
+    @skipIfRocm
+    @unittest.skipIf(
+        not PLATFORM_SUPPORTS_CUBLASLT_FP8_GROUPED_GEMM,
+        cublaslt_grouped_mm_skip_msg
+    )
+    @parametrize("op", ["2d/2d", "2d/3d", "3d/2d", "3d/3d"])
+    @parametrize(
+        "dtypes",
+        [
+            (torch.float8_e4m3fn, torch.float8_e4m3fn),
+            (torch.float8_e4m3fn, torch.float8_e5m2),
+            (torch.float8_e5m2, torch.float8_e4m3fn)
+        ]
+    )
+    @parametrize("out_dtype", [torch.bfloat16, torch.float16, torch.float32])
+    @parametrize("scale_mode", ["tensorwise", "groupwise"])
+    @parametrize("fast_accum", [False, True])
+    @parametrize("mode", ["default", "reduce-overhead"])
+    def test_scaled_grouped_gemm_cublaslt_compiled(self, op, dtypes, out_dtype, scale_mode, fast_accum, mode):
+        a_dtype, b_dtype = dtypes
+        torch._dynamo.reset()  # each shape combination needs fresh compilation state
+        A, B_T, scale_a, scale_b, offs = self.scaled_grouped_gemm_cublaslt_helper(
+            op, a_dtype, b_dtype, scale_mode
+        )
+
+        with prefer_cublaslt_grouped_gemm():
+            f_ref = torch._scaled_grouped_mm
+            f = torch.compile(f_ref, fullgraph=True, mode=mode)
+
+            C_ref = f_ref(
+                A,
+                B_T.transpose(-2, -1),
+                scale_a,
+                scale_b,
+                offs=offs,
+                use_fast_accum=fast_accum,
+                out_dtype=out_dtype
+            )
+            C = f(A, B_T.transpose(-2, -1), scale_a, scale_b, offs=offs, use_fast_accum=fast_accum, out_dtype=out_dtype)
+            self.assertEqual(C, C_ref)
+
+    def scaled_grouped_gemm_cublaslt_mxfp8_helper(self, op):
+        device = "cuda"
+        ngroups = 4
+        block_size = 32
+
+        if op == "2d/2d":
+            m, n, k_g = 128, 128, 128
+            k_total = k_g * ngroups
+            offs = torch.tensor(
+                [k_g * (i + 1) for i in range(ngroups)],
+                device=device, dtype=torch.int32,
+            )
+            A_bf16 = torch.randn(m, k_total, device=device, dtype=torch.bfloat16) * 0.1
+            B_bf16 = torch.randn(n, k_total, device=device, dtype=torch.bfloat16) * 0.01
+            a_groups = [A_bf16[:, g * k_g:(g + 1) * k_g] for g in range(ngroups)]
+            b_groups = [B_bf16[:, g * k_g:(g + 1) * k_g] for g in range(ngroups)]
+            a_cat, b_cat = 1, 1
+        elif op == "2d/3d":
+            n, k = 128, 128
+            m_per_group = 128
+            m_total = m_per_group * ngroups
+            offs = torch.tensor(
+                [m_per_group * (i + 1) for i in range(ngroups)],
+                device=device, dtype=torch.int32,
+            )
+            A_bf16 = torch.randn(m_total, k, device=device, dtype=torch.bfloat16) * 0.1
+            B_bf16 = torch.randn(ngroups, n, k, device=device, dtype=torch.bfloat16) * 0.01
+            a_groups = [A_bf16[g * m_per_group:(g + 1) * m_per_group] for g in range(ngroups)]
+            b_groups = [B_bf16[g] for g in range(ngroups)]
+            a_cat, b_cat = 0, None
+        elif op == "3d/2d":
+            m, k = 128, 128
+            n_per_group = 128
+            n_total = n_per_group * ngroups
+            offs = torch.tensor(
+                [n_per_group * (i + 1) for i in range(ngroups)],
+                device=device, dtype=torch.int32,
+            )
+            A_bf16 = torch.randn(ngroups, m, k, device=device, dtype=torch.bfloat16) * 0.1
+            B_bf16 = torch.randn(n_total, k, device=device, dtype=torch.bfloat16) * 0.01
+            a_groups = [A_bf16[g] for g in range(ngroups)]
+            b_groups = [B_bf16[g * n_per_group:(g + 1) * n_per_group] for g in range(ngroups)]
+            a_cat, b_cat = None, 0
+        elif op == "3d/3d":
+            m, n, k = 128, 128, 128
+            offs = None
+            A_bf16 = torch.randn(ngroups, m, k, device=device, dtype=torch.bfloat16) * 0.1
+            B_bf16 = torch.randn(ngroups, n, k, device=device, dtype=torch.bfloat16) * 0.01
+            a_groups = [A_bf16[g] for g in range(ngroups)]
+            b_groups = [B_bf16[g] for g in range(ngroups)]
+            a_cat, b_cat = None, None
+
+        a_scales, a_fp8 = zip(*(to_mxfp(t.contiguous(), format="mxfp8") for t in a_groups))
+        b_scales, b_fp8 = zip(*(to_mxfp(t.contiguous(), format="mxfp8") for t in b_groups))
+        a_blocked_scales = [to_blocked(scale) for scale in a_scales]
+        b_blocked_scales = [to_blocked(scale) for scale in b_scales]
+
+        A = (torch.stack(a_fp8, dim=0) if a_cat is None else torch.cat(a_fp8, dim=a_cat)).contiguous()
+        B_T = (torch.stack(b_fp8, dim=0) if b_cat is None else torch.cat(b_fp8, dim=b_cat)).contiguous()
+        scale_a = torch.stack(a_blocked_scales, dim=0) if a_cat is None else torch.cat(a_blocked_scales)
+        scale_b = torch.stack(b_blocked_scales, dim=0) if b_cat is None else torch.cat(b_blocked_scales)
+        if a_cat == 0:
+            scale_a = scale_a.reshape(-1, k // block_size)
+        if b_cat == 0:
+            scale_b = scale_b.reshape(-1, k // block_size)
+        return A, B_T, scale_a, scale_b, offs
+
+    @onlyCUDA
+    @skipIfRocm
+    @unittest.skipIf(
+        not PLATFORM_SUPPORTS_CUBLASLT_FP8_GROUPED_GEMM,
+        cublaslt_grouped_mm_skip_msg
+    )
+    @parametrize("op", ["2d/2d", "2d/3d", "3d/2d", "3d/3d"])
+    @parametrize("out_dtype", [torch.bfloat16, torch.float16, torch.float32])
+    @parametrize("fast_accum", [False, True])
+    def test_scaled_grouped_gemm_cublaslt_mxfp8(self, op, out_dtype, fast_accum):
+        A, B_T, scale_a, scale_b, offs = self.scaled_grouped_gemm_cublaslt_mxfp8_helper(op)
+
+        with prefer_cublaslt_grouped_gemm():
+            C = torch._scaled_grouped_mm(
+                A,
+                B_T.transpose(-2, -1),
+                scale_a,
+                scale_b,
+                offs=offs,
+                use_fast_accum=fast_accum,
+                out_dtype=out_dtype,
+            )
+
+        C_ref = self.cublaslt_grouped_gemm_ref(A, B_T, scale_a, scale_b, offs, out_dtype, fast_accum)
+        self.assertEqual(C, C_ref, atol=1e-2, rtol=1e-2)
+
+
+    @onlyCUDA
+    @skipIfRocm
+    @unittest.skipIf(
+        not PLATFORM_SUPPORTS_CUBLASLT_FP8_GROUPED_GEMM,
+        cublaslt_grouped_mm_skip_msg
+    )
+    @parametrize("op", ["2d/2d", "2d/3d", "3d/2d", "3d/3d"])
+    @parametrize("fast_accum", [False, True])
+    @parametrize("mode", ["default", "reduce-overhead"])
+    def test_scaled_grouped_gemm_cublaslt_mxfp8_compiled(self, op, fast_accum, mode):
+        out_dtype = torch.bfloat16
+        A, B_T, scale_a, scale_b, offs = self.scaled_grouped_gemm_cublaslt_mxfp8_helper(op)
+
+        torch._dynamo.reset()
+        with prefer_cublaslt_grouped_gemm():
+            f_ref = torch._scaled_grouped_mm
+            f = torch.compile(f_ref, fullgraph=True, mode=mode)
+
+            C_ref = f_ref(
+                A, B_T.transpose(-2, -1), scale_a, scale_b,
+                offs=offs, use_fast_accum=fast_accum, out_dtype=out_dtype,
+            )
+            C = f(
+                A, B_T.transpose(-2, -1), scale_a, scale_b,
+                offs=offs, use_fast_accum=fast_accum, out_dtype=out_dtype,
+            )
+            self.assertEqual(C, C_ref)
 
 
     @onlyAccelerator

--- a/test/test_scaled_matmul_cuda.py
+++ b/test/test_scaled_matmul_cuda.py
@@ -81,7 +81,7 @@ f8_msg = "FP8 is only supported on H100+, SM 8.9 and MI300+, XPU and CPU devices
 f8_grouped_msg = "FP8 grouped is only supported on SM90 and MI300/MI350 devices"
 mx_skip_msg = "MX gemm is only supported on CUDA capability 10.0+"
 mxfp8_grouped_mm_skip_msg = "MXFP8 grouped GEMM is only supported when PyTorch is built with USE_MSLK=1 on SM100+"
-cublaslt_grouped_mm_skip_msg = "cuBLASLt grouped GEMM requires SM 10.x or 11.0 with CUDA 13.2+"
+cublaslt_grouped_mm_skip_msg = "cuBLASLt grouped GEMM requires SM 10.x or 11.0 with CUDA 13.3+"
 
 # avoid division by zero when calculating scale
 EPS = 1e-12
@@ -2737,8 +2737,6 @@ class TestFP8Matmul(TestCase):
 
 
     def scaled_grouped_gemm_cublaslt_helper(self, op, a_dtype, b_dtype, scale_mode):
-        """Build FP8 inputs and scales for testing the cuBLASLt
-        grouped GEMM path via TORCH_GROUPED_MM_PREFER_CUBLASLT=1."""
         device = "cuda"
         ngroups = 5
         # FP8 is 1 byte, so 16-byte alignment requires dims/offsets to be multiples of 16

--- a/test/test_scaled_matmul_cuda.py
+++ b/test/test_scaled_matmul_cuda.py
@@ -7,6 +7,7 @@ import re
 import itertools
 import tempfile
 import unittest
+import warnings
 
 import torch
 
@@ -55,6 +56,7 @@ from torch.testing._internal.common_utils import (
     random_matrix_with_scaled_reduction_dim,
     run_tests,
     runOnRocmArch,
+    set_warn_always_context,
     skipIfRocm,
     skipIfTorchDynamo,
     TEST_CUDA,
@@ -2736,8 +2738,7 @@ class TestFP8Matmul(TestCase):
                 self.scaled_grouped_mm_helper(a, blist, scale_a, bscalelist, outlist, fast_accum)
 
 
-    def scaled_grouped_gemm_cublaslt_helper(self, op, a_dtype, b_dtype, scale_mode):
-        device = "cuda"
+    def scaled_grouped_gemm_cublaslt_helper(self, op, a_dtype, b_dtype, scale_mode, device):
         ngroups = 5
         # FP8 is 1 byte, so 16-byte alignment requires dims/offsets to be multiples of 16
 
@@ -2844,10 +2845,10 @@ class TestFP8Matmul(TestCase):
     @parametrize("out_dtype", [torch.bfloat16, torch.float16, torch.float32])
     @parametrize("scale_mode", ["tensorwise", "groupwise"])
     @parametrize("fast_accum", [False, True])
-    def test_scaled_grouped_gemm_cublaslt(self, op, dtypes, out_dtype, scale_mode, fast_accum):
+    def test_scaled_grouped_gemm_cublaslt(self, op, dtypes, out_dtype, scale_mode, fast_accum, device):
         a_dtype, b_dtype = dtypes
         A, B_T, scale_a, scale_b, offs = self.scaled_grouped_gemm_cublaslt_helper(
-            op, a_dtype, b_dtype, scale_mode
+            op, a_dtype, b_dtype, scale_mode, device
         )
 
         with prefer_cublaslt_grouped_gemm():
@@ -2862,7 +2863,7 @@ class TestFP8Matmul(TestCase):
             )
 
         C_ref = self.cublaslt_grouped_gemm_ref(A, B_T, scale_a, scale_b, offs, out_dtype, fast_accum)
-        self.assertEqual(C, C_ref, atol=1e-2, rtol=1e-2)
+        self.assertEqual(C, C_ref)
 
 
     @onlyCUDA
@@ -2884,11 +2885,11 @@ class TestFP8Matmul(TestCase):
     @parametrize("scale_mode", ["tensorwise", "groupwise"])
     @parametrize("fast_accum", [False, True])
     @parametrize("mode", ["default", "reduce-overhead"])
-    def test_scaled_grouped_gemm_cublaslt_compiled(self, op, dtypes, out_dtype, scale_mode, fast_accum, mode):
+    def test_scaled_grouped_gemm_cublaslt_compiled(self, op, dtypes, out_dtype, scale_mode, fast_accum, mode, device):
         a_dtype, b_dtype = dtypes
         torch._dynamo.reset()  # each shape combination needs fresh compilation state
         A, B_T, scale_a, scale_b, offs = self.scaled_grouped_gemm_cublaslt_helper(
-            op, a_dtype, b_dtype, scale_mode
+            op, a_dtype, b_dtype, scale_mode, device
         )
 
         with prefer_cublaslt_grouped_gemm():
@@ -2907,8 +2908,7 @@ class TestFP8Matmul(TestCase):
             C = f(A, B_T.transpose(-2, -1), scale_a, scale_b, offs=offs, use_fast_accum=fast_accum, out_dtype=out_dtype)
             self.assertEqual(C, C_ref)
 
-    def scaled_grouped_gemm_cublaslt_mxfp8_helper(self, op):
-        device = "cuda"
+    def scaled_grouped_gemm_cublaslt_mxfp8_helper(self, op, device):
         ngroups = 4
         block_size = 32
 
@@ -2983,8 +2983,8 @@ class TestFP8Matmul(TestCase):
     @parametrize("op", ["2d/2d", "2d/3d", "3d/2d", "3d/3d"])
     @parametrize("out_dtype", [torch.bfloat16, torch.float16, torch.float32])
     @parametrize("fast_accum", [False, True])
-    def test_scaled_grouped_gemm_cublaslt_mxfp8(self, op, out_dtype, fast_accum):
-        A, B_T, scale_a, scale_b, offs = self.scaled_grouped_gemm_cublaslt_mxfp8_helper(op)
+    def test_scaled_grouped_gemm_cublaslt_mxfp8(self, op, out_dtype, fast_accum, device):
+        A, B_T, scale_a, scale_b, offs = self.scaled_grouped_gemm_cublaslt_mxfp8_helper(op, device)
 
         with prefer_cublaslt_grouped_gemm():
             C = torch._scaled_grouped_mm(
@@ -2998,7 +2998,7 @@ class TestFP8Matmul(TestCase):
             )
 
         C_ref = self.cublaslt_grouped_gemm_ref(A, B_T, scale_a, scale_b, offs, out_dtype, fast_accum)
-        self.assertEqual(C, C_ref, atol=1e-2, rtol=1e-2)
+        self.assertEqual(C, C_ref)
 
 
     @onlyCUDA
@@ -3010,9 +3010,9 @@ class TestFP8Matmul(TestCase):
     @parametrize("op", ["2d/2d", "2d/3d", "3d/2d", "3d/3d"])
     @parametrize("fast_accum", [False, True])
     @parametrize("mode", ["default", "reduce-overhead"])
-    def test_scaled_grouped_gemm_cublaslt_mxfp8_compiled(self, op, fast_accum, mode):
+    def test_scaled_grouped_gemm_cublaslt_mxfp8_compiled(self, op, fast_accum, mode, device):
         out_dtype = torch.bfloat16
-        A, B_T, scale_a, scale_b, offs = self.scaled_grouped_gemm_cublaslt_mxfp8_helper(op)
+        A, B_T, scale_a, scale_b, offs = self.scaled_grouped_gemm_cublaslt_mxfp8_helper(op, device)
 
         torch._dynamo.reset()
         with prefer_cublaslt_grouped_gemm():
@@ -3029,6 +3029,100 @@ class TestFP8Matmul(TestCase):
             )
             self.assertEqual(C, C_ref)
 
+
+    @onlyCUDA
+    @skipIfRocm
+    @unittest.skipIf(
+        not PLATFORM_SUPPORTS_CUBLASLT_FP8_GROUPED_GEMM,
+        cublaslt_grouped_mm_skip_msg
+    )
+    @parametrize("case", ["unsupported_input_dtype", "unsupported_out_dtype", "too_many_groups"])
+    def test_scaled_grouped_gemm_cublaslt_fallback_warns(self, case, device):
+        # Inputs that fail should_use_scaled_cublaslt_grouped_gemm must warn and
+        # fall back to the non-cuBLASLt path rather than erroring. On this device
+        # the fallback then rejects the inputs itself, so assert the fallback
+        # warning fires. set_warn_always_context forces the TORCH_WARN_ONCE to
+        # re-emit regardless of prior tests.
+        m, n, k = 16, 16, 64
+        offs = torch.tensor([0, 16, 32, 32, k], device=device, dtype=torch.int32)
+        scale_a = torch.rand(1, device=device, dtype=torch.float32)
+        scale_b = torch.rand(1, device=device, dtype=torch.float32)
+        if case == "unsupported_input_dtype":
+            a = torch.randn(m, k, device=device).to(torch.float8_e5m2)
+            b = torch.randn(n, k, device=device).to(torch.float8_e5m2)
+            out_dtype = torch.bfloat16
+            warn_regex = "inputs must both be FP8 and at least one input must be Float8_e4m3fn"
+        elif case == "unsupported_out_dtype":
+            a = torch.randn(m, k, device=device).to(e4m3_type)
+            b = torch.randn(n, k, device=device).to(e4m3_type)
+            out_dtype = torch.float64
+            warn_regex = "output dtype must be BFloat16, Float16, or Float32"
+        else:  # too_many_groups: batchCount above the cuBLASLt [1, 1024] limit
+            a = torch.randn(m, k, device=device).to(e4m3_type)
+            b = torch.randn(n, k, device=device).to(e4m3_type)
+            out_dtype = torch.bfloat16
+            offs = torch.arange(1, 1026, device=device, dtype=torch.int32)
+            warn_regex = r"batchCount must be in \[1, 1024\]"
+
+        with prefer_cublaslt_grouped_gemm():
+            with warnings.catch_warnings(record=True) as ws:
+                warnings.simplefilter("always")
+                with set_warn_always_context(True):
+                    with self.assertRaises(RuntimeError):
+                        torch._scaled_grouped_mm(
+                            a, b.t(), scale_a, scale_b, offs=offs, out_dtype=out_dtype
+                        )
+        self.assertTrue(
+            any(re.search(warn_regex, str(w.message)) for w in ws),
+            f"expected cuBLASLt fallback warning matching {warn_regex!r}, "
+            f"got {[str(w.message) for w in ws]}",
+        )
+
+    @onlyCUDA
+    @skipIfRocm
+    @unittest.skipIf(
+        not PLATFORM_SUPPORTS_CUBLASLT_FP8_GROUPED_GEMM,
+        cublaslt_grouped_mm_skip_msg
+    )
+    @parametrize(
+        "case",
+        [
+            "groupwise_noncontiguous",
+            "blockwise_noncontiguous",
+            "blockwise_wrong_shape",
+            "blockwise_too_few_elements",
+        ]
+    )
+    def test_scaled_grouped_gemm_cublaslt_scale_recipe_errors(self, case, device):
+        # Scales whose recipe is recognized by should_use_scaled_cublaslt_grouped_gemm
+        # but that violate check_cublaslt_grouped_scale_recipe must raise once the
+        # cuBLASLt path is selected.
+        e8m0 = torch.float8_e8m0fnu
+        if case == "groupwise_noncontiguous":
+            A, B_T, scale_a, scale_b, offs = self.scaled_grouped_gemm_cublaslt_helper(
+                "2d/2d", e4m3_type, e4m3_type, "groupwise", device
+            )
+            # 1D float32 with one value per group, but non-contiguous.
+            scale_a = torch.rand(2 * scale_a.numel(), device=device, dtype=torch.float32)[::2]
+            regex = "scale_a groupwise scale must be a contiguous 1D float32 tensor"
+        elif case == "blockwise_too_few_elements":
+            A, B_T, scale_a, scale_b, offs = self.scaled_grouped_gemm_cublaslt_mxfp8_helper("2d/2d", device)
+            scale_a = torch.ones(1, device=device, dtype=e8m0)
+            regex = "scale_a blockwise scale for cuBLASLt grouped GEMM must have at least"
+        else:
+            A, B_T, scale_a, scale_b, offs = self.scaled_grouped_gemm_cublaslt_mxfp8_helper("3d/3d", device)
+            if case == "blockwise_noncontiguous":
+                scale_a = torch.ones((A.shape[0], 2 * scale_a.shape[1]), device=device, dtype=e8m0)[:, ::2]
+                regex = "scale_a blockwise scale must be a contiguous float8_e8m0fnu tensor"
+            else:  # blockwise_wrong_shape
+                scale_a = torch.ones((A.shape[0], 1), device=device, dtype=e8m0)
+                regex = "scale_a blockwise scale for cuBLASLt grouped GEMM must have shape"
+
+        with prefer_cublaslt_grouped_gemm():
+            with self.assertRaisesRegex(RuntimeError, regex):
+                torch._scaled_grouped_mm(
+                    A, B_T.transpose(-2, -1), scale_a, scale_b, offs=offs, out_dtype=torch.bfloat16
+                )
 
     @onlyAccelerator
     @unittest.skipIf(not PLATFORM_SUPPORTS_MX_GEMM, mx_skip_msg)

--- a/test/test_scaled_matmul_cuda.py
+++ b/test/test_scaled_matmul_cuda.py
@@ -33,7 +33,6 @@ from torch.testing._internal.common_cuda import (
     SM89OrLater,
     SM90OrLater,
     with_tf32_off,
-    prefer_cublaslt_grouped_gemm,
 )
 from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
@@ -83,7 +82,7 @@ f8_msg = "FP8 is only supported on H100+, SM 8.9 and MI300+, XPU and CPU devices
 f8_grouped_msg = "FP8 grouped is only supported on SM90 and MI300/MI350 devices"
 mx_skip_msg = "MX gemm is only supported on CUDA capability 10.0+"
 mxfp8_grouped_mm_skip_msg = "MXFP8 grouped GEMM is only supported when PyTorch is built with USE_MSLK=1 on SM100+"
-cublaslt_grouped_mm_skip_msg = "cuBLASLt grouped GEMM requires SM 10.x or 11.0 with CUDA 13.3+"
+cublaslt_grouped_mm_skip_msg = "cuBLASLt scaled grouped GEMM requires SM 10.x or 11.0 with CUDA 13.4+"
 
 # avoid division by zero when calculating scale
 EPS = 1e-12
@@ -2851,16 +2850,15 @@ class TestFP8Matmul(TestCase):
             op, a_dtype, b_dtype, scale_mode, device
         )
 
-        with prefer_cublaslt_grouped_gemm():
-            C = torch._scaled_grouped_mm(
-                A,
-                B_T.transpose(-2, -1),
-                scale_a,
-                scale_b,
-                offs=offs,
-                use_fast_accum=fast_accum,
-                out_dtype=out_dtype
-            )
+        C = torch._scaled_grouped_mm(
+            A,
+            B_T.transpose(-2, -1),
+            scale_a,
+            scale_b,
+            offs=offs,
+            use_fast_accum=fast_accum,
+            out_dtype=out_dtype
+        )
 
         C_ref = self.cublaslt_grouped_gemm_ref(A, B_T, scale_a, scale_b, offs, out_dtype, fast_accum)
         self.assertEqual(C, C_ref)
@@ -2892,21 +2890,20 @@ class TestFP8Matmul(TestCase):
             op, a_dtype, b_dtype, scale_mode, device
         )
 
-        with prefer_cublaslt_grouped_gemm():
-            f_ref = torch._scaled_grouped_mm
-            f = torch.compile(f_ref, fullgraph=True, mode=mode)
+        f_ref = torch._scaled_grouped_mm
+        f = torch.compile(f_ref, fullgraph=True, mode=mode)
 
-            C_ref = f_ref(
-                A,
-                B_T.transpose(-2, -1),
-                scale_a,
-                scale_b,
-                offs=offs,
-                use_fast_accum=fast_accum,
-                out_dtype=out_dtype
-            )
-            C = f(A, B_T.transpose(-2, -1), scale_a, scale_b, offs=offs, use_fast_accum=fast_accum, out_dtype=out_dtype)
-            self.assertEqual(C, C_ref)
+        C_ref = f_ref(
+            A,
+            B_T.transpose(-2, -1),
+            scale_a,
+            scale_b,
+            offs=offs,
+            use_fast_accum=fast_accum,
+            out_dtype=out_dtype
+        )
+        C = f(A, B_T.transpose(-2, -1), scale_a, scale_b, offs=offs, use_fast_accum=fast_accum, out_dtype=out_dtype)
+        self.assertEqual(C, C_ref)
 
     def scaled_grouped_gemm_cublaslt_mxfp8_helper(self, op, device):
         ngroups = 4
@@ -2986,16 +2983,15 @@ class TestFP8Matmul(TestCase):
     def test_scaled_grouped_gemm_cublaslt_mxfp8(self, op, out_dtype, fast_accum, device):
         A, B_T, scale_a, scale_b, offs = self.scaled_grouped_gemm_cublaslt_mxfp8_helper(op, device)
 
-        with prefer_cublaslt_grouped_gemm():
-            C = torch._scaled_grouped_mm(
-                A,
-                B_T.transpose(-2, -1),
-                scale_a,
-                scale_b,
-                offs=offs,
-                use_fast_accum=fast_accum,
-                out_dtype=out_dtype,
-            )
+        C = torch._scaled_grouped_mm(
+            A,
+            B_T.transpose(-2, -1),
+            scale_a,
+            scale_b,
+            offs=offs,
+            use_fast_accum=fast_accum,
+            out_dtype=out_dtype,
+        )
 
         C_ref = self.cublaslt_grouped_gemm_ref(A, B_T, scale_a, scale_b, offs, out_dtype, fast_accum)
         self.assertEqual(C, C_ref)
@@ -3015,19 +3011,18 @@ class TestFP8Matmul(TestCase):
         A, B_T, scale_a, scale_b, offs = self.scaled_grouped_gemm_cublaslt_mxfp8_helper(op, device)
 
         torch._dynamo.reset()
-        with prefer_cublaslt_grouped_gemm():
-            f_ref = torch._scaled_grouped_mm
-            f = torch.compile(f_ref, fullgraph=True, mode=mode)
+        f_ref = torch._scaled_grouped_mm
+        f = torch.compile(f_ref, fullgraph=True, mode=mode)
 
-            C_ref = f_ref(
-                A, B_T.transpose(-2, -1), scale_a, scale_b,
-                offs=offs, use_fast_accum=fast_accum, out_dtype=out_dtype,
-            )
-            C = f(
-                A, B_T.transpose(-2, -1), scale_a, scale_b,
-                offs=offs, use_fast_accum=fast_accum, out_dtype=out_dtype,
-            )
-            self.assertEqual(C, C_ref)
+        C_ref = f_ref(
+            A, B_T.transpose(-2, -1), scale_a, scale_b,
+            offs=offs, use_fast_accum=fast_accum, out_dtype=out_dtype,
+        )
+        C = f(
+            A, B_T.transpose(-2, -1), scale_a, scale_b,
+            offs=offs, use_fast_accum=fast_accum, out_dtype=out_dtype,
+        )
+        self.assertEqual(C, C_ref)
 
 
     @onlyCUDA
@@ -3064,14 +3059,13 @@ class TestFP8Matmul(TestCase):
             offs = torch.arange(1, 1026, device=device, dtype=torch.int32)
             warn_regex = r"batchCount must be in \[1, 1024\]"
 
-        with prefer_cublaslt_grouped_gemm():
-            with warnings.catch_warnings(record=True) as ws:
-                warnings.simplefilter("always")
-                with set_warn_always_context(True):
-                    with self.assertRaises(RuntimeError):
-                        torch._scaled_grouped_mm(
-                            a, b.t(), scale_a, scale_b, offs=offs, out_dtype=out_dtype
-                        )
+        with warnings.catch_warnings(record=True) as ws:
+            warnings.simplefilter("always")
+            with set_warn_always_context(True):
+                with self.assertRaises(RuntimeError):
+                    torch._scaled_grouped_mm(
+                        a, b.t(), scale_a, scale_b, offs=offs, out_dtype=out_dtype
+                    )
         self.assertTrue(
             any(re.search(warn_regex, str(w.message)) for w in ws),
             f"expected cuBLASLt fallback warning matching {warn_regex!r}, "
@@ -3118,11 +3112,10 @@ class TestFP8Matmul(TestCase):
                 scale_a = torch.ones((A.shape[0], 1), device=device, dtype=e8m0)
                 regex = "scale_a blockwise scale for cuBLASLt grouped GEMM must have shape"
 
-        with prefer_cublaslt_grouped_gemm():
-            with self.assertRaisesRegex(RuntimeError, regex):
-                torch._scaled_grouped_mm(
-                    A, B_T.transpose(-2, -1), scale_a, scale_b, offs=offs, out_dtype=torch.bfloat16
-                )
+        with self.assertRaisesRegex(RuntimeError, regex):
+            torch._scaled_grouped_mm(
+                A, B_T.transpose(-2, -1), scale_a, scale_b, offs=offs, out_dtype=torch.bfloat16
+            )
 
     @onlyAccelerator
     @unittest.skipIf(not PLATFORM_SUPPORTS_MX_GEMM, mx_skip_msg)

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -8388,18 +8388,37 @@ def _meta_grouped_mm_common(
     # _grouped_mm_cuda()/_scaled_grouped_mm_cuda() code in
     # aten/src/ATen/native/cuda/Blas.cpp.
 
-    if scaled:
-        fp8_dtype = torch.float8_e4m3fn
-        if (
-            torch.version.hip
-            and torch.cuda.is_available()
-            and "gfx94" in torch.cuda.get_device_properties(0).gcnArchName
-        ):
-            fp8_dtype = torch.float8_e4m3fnuz
-        torch._check(
-            mat_a.dtype == fp8_dtype and mat_b.dtype == fp8_dtype,
-            lambda: f"Expected inputs of E4M3 FP8 type but got mat_a.dtype={mat_a.dtype} and mat_b.dtype={mat_b.dtype}.",
+    use_scaled_cublaslt_grouped_gemm = (
+        scaled
+        and _should_use_scaled_cublaslt_grouped_gemm(
+            mat_a, mat_b, scale_a, scale_b, offs, out_dtype
         )
+    )
+
+    if scaled:
+        if use_scaled_cublaslt_grouped_gemm:
+            fp8_dtypes = (torch.float8_e4m3fn, torch.float8_e5m2)
+            torch._check(
+                mat_a.dtype in fp8_dtypes
+                and mat_b.dtype in fp8_dtypes
+                and (
+                    mat_a.dtype == torch.float8_e4m3fn
+                    or mat_b.dtype == torch.float8_e4m3fn
+                ),
+                lambda: f"Expected at least one E4M3 FP8 input for cuBLASLt scaled grouped GEMM, got mat_a.dtype={mat_a.dtype} and mat_b.dtype={mat_b.dtype}.",
+            )
+        else:
+            fp8_dtype = torch.float8_e4m3fn
+            if (
+                torch.version.hip
+                and torch.cuda.is_available()
+                and "gfx94" in torch.cuda.get_device_properties(0).gcnArchName
+            ):
+                fp8_dtype = torch.float8_e4m3fnuz
+            torch._check(
+                mat_a.dtype == fp8_dtype and mat_b.dtype == fp8_dtype,
+                lambda: f"Expected inputs of E4M3 FP8 type but got mat_a.dtype={mat_a.dtype} and mat_b.dtype={mat_b.dtype}.",
+            )
     elif mat_a.dtype == torch.bfloat16:
         torch._check(
             mat_b.dtype == mat_a.dtype,
@@ -8491,6 +8510,54 @@ def _meta_grouped_mm_common(
         )
 
         def check_scale(scale_name, scale, mat, scaled_dim, scale_multiplier=1):
+            if use_scaled_cublaslt_grouped_gemm:
+                batch_count = (
+                    offs.shape[0]
+                    if offs is not None and (mat_a_is_2d or mat_b_is_2d)
+                    else mat_a.shape[0]
+                )
+                if is_mxfp8:
+                    torch._check(
+                        scale.is_contiguous(),
+                        lambda: f"Expected {scale_name} to be contiguous.",
+                    )
+                    is_a = scaled_dim == 0
+                    inner = mat.shape[-1] if is_a else mat.shape[-2]
+                    outer = mat.shape[-2] if is_a else mat.shape[-1]
+                    # See cublas_vec32_scale_size_host in GroupedBlas.cpp
+                    scale_size = (
+                        ((inner + 127) // 128) * 4 * (((outer + 127) // 128) * 128)
+                    )
+                    if mat.dim() == 3:
+                        torch._check(
+                            scale.dim() == 2
+                            and scale.shape[0] == batch_count
+                            and scale.shape[1] == scale_size,
+                            lambda: f"Expected {scale_name} to have shape ({batch_count}, {scale_size}), got {scale.shape}.",
+                        )
+                    else:
+                        # 2D inputs have data-dependent per-group extents along the
+                        # jagged dim, so the exact concatenated blocked-scale size is
+                        # unknown here. Because ceil() is subadditive,
+                        # sum_g cublas_vec32_scale_size(g) >=
+                        # cublas_vec32_scale_size(totals), so scale_size is a safe
+                        # lower bound on the required element count.
+                        torch._check(
+                            scale.numel() >= scale_size,
+                            lambda: f"Expected {scale_name} to have at least {scale_size} elements, got {scale.numel()}.",
+                        )
+                else:
+                    groupwise = scale.numel() != 1 and scale.numel() == batch_count
+                    torch._check(
+                        scale.numel() == 1 or groupwise,
+                        lambda: f"Expected {scale_name} to have either one element or one element per group ({batch_count}), got {scale.numel()} elements.",
+                    )
+                    if groupwise:
+                        torch._check(
+                            scale.dim() == 1 and scale.is_contiguous(),
+                            lambda: f"Expected groupwise {scale_name} to be 1D and contiguous, got {scale.dim()}D with stride {scale.stride()}.",
+                        )
+                return
             if mat.dim() == 2:
                 torch._check(
                     scale.is_contiguous(),
@@ -8587,7 +8654,7 @@ def _meta_grouped_mm_common(
 
     if mat_a.dtype == torch.float16:
         torch._check(
-            _grouped_mm_fp16_cublaslt_supported(mat_a, mat_b, offs),
+            _grouped_mm_cublaslt_supported(mat_a, mat_b, offs, True),
             lambda: "Float16 grouped_mm requires cuBLASLt grouped GEMM support.",
         )
 
@@ -8597,10 +8664,17 @@ def _meta_grouped_mm_common(
     )
 
     if scaled:
-        torch._check(
-            out_dtype is None or out_dtype == torch.bfloat16,
-            lambda: "If output dtype provided, it must be torch.bfloat16.",
-        )
+        if use_scaled_cublaslt_grouped_gemm:
+            torch._check(
+                out_dtype is None
+                or out_dtype in (torch.bfloat16, torch.float16, torch.float32),
+                lambda: "If output dtype provided, cuBLASLt scaled grouped GEMM requires torch.bfloat16, torch.float16, or torch.float32.",
+            )
+        else:
+            torch._check(
+                out_dtype is None or out_dtype == torch.bfloat16,
+                lambda: "If output dtype provided, it must be torch.bfloat16.",
+            )
     else:
         out_dtype = out_dtype or mat_a.dtype
         torch._check(
@@ -8611,8 +8685,8 @@ def _meta_grouped_mm_common(
     return _create_grouped_mm_output_tensor(mat_a, mat_b, offs, out_dtype)
 
 
-def _grouped_mm_fp16_cublaslt_supported(
-    mat_a: Tensor, mat_b: Tensor, offs: Tensor | None
+def _grouped_mm_cublaslt_supported(
+    mat_a: Tensor, mat_b: Tensor, offs: Tensor | None, sm90_allowed: bool = False
 ) -> bool:
     if device_hint(mat_a) != "cuda" or device_hint(mat_b) != "cuda":
         return False
@@ -8632,9 +8706,57 @@ def _grouped_mm_fp16_cublaslt_supported(
     if torch.version.cuda:
         parts = torch.version.cuda.split(".")
         cuda_version = (int(parts[0]), int(parts[1]))
+    if device_capability[0] == 9:
+        return cuda_version >= (13, 3) and sm90_allowed
     return cuda_version >= (13, 3) and (
-        device_capability[0] >= 9 and device_capability[0] <= 11
+        device_capability[0] == 10 or device_capability == (11, 0)
     )
+
+
+# Mirror should_use_scaled_cublaslt_grouped_gemm in aten/src/ATen/native/cuda/GroupedBlas.cpp
+def _should_use_scaled_cublaslt_grouped_gemm(
+    mat_a: Tensor,
+    mat_b: Tensor,
+    scale_a: Tensor,
+    scale_b: Tensor,
+    offs: Tensor | None,
+    out_dtype: torch.dtype | None,
+) -> bool:
+    if not torch.backends.cuda.matmul.prefer_cublaslt_grouped_gemm:
+        return False
+    # Device support and the [1, 1024] group-count bound.
+    if not _grouped_mm_cublaslt_supported(mat_a, mat_b, offs):
+        return False
+
+    mat_a_is_2d = mat_a.dim() == 2
+    mat_b_is_2d = mat_b.dim() == 2
+    batch_count = (
+        offs.shape[0]
+        if offs is not None and (mat_a_is_2d or mat_b_is_2d)
+        else mat_a.shape[0]
+    )
+
+    def scaling_type_supported(scale: Tensor) -> bool:
+        # tensorwise, groupwise, or blockwise MXFP8
+        if scale.dtype == torch.float32:
+            return scale.numel() == 1 or (
+                scale.dim() == 1 and scale.numel() == batch_count
+            )
+        return scale.dtype == torch.float8_e8m0fnu
+
+    if not scaling_type_supported(scale_a) or not scaling_type_supported(scale_b):
+        return False
+
+    fp8_dtypes = (torch.float8_e4m3fn, torch.float8_e5m2)
+    if not (
+        mat_a.dtype in fp8_dtypes
+        and mat_b.dtype in fp8_dtypes
+        and (mat_a.dtype == torch.float8_e4m3fn or mat_b.dtype == torch.float8_e4m3fn)
+    ):
+        return False
+
+    resolved_out_dtype = out_dtype if out_dtype is not None else torch.bfloat16
+    return resolved_out_dtype in (torch.bfloat16, torch.float16, torch.float32)
 
 
 @register_meta(aten._grouped_mm)

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -8872,7 +8872,9 @@ def _should_use_scaled_cublaslt_grouped_gemm(
         return False
     cuda_version = tuple(map(int, torch.version.cuda.split(".")[:2]))
     # Device support and the [1, 1024] group-count bound.
-    if cuda_version < (13, 4) or not _grouped_mm_cublaslt_supported(mat_a, mat_b, offs):
+    if cuda_version < (13, 4) or not _grouped_mm_cublaslt_supported(
+        mat_a, mat_b, offs, sm90_allowed=True
+    ):
         return False
 
     mat_a_is_2d = mat_a.dim() == 2
@@ -8892,6 +8894,13 @@ def _should_use_scaled_cublaslt_grouped_gemm(
         return scale.dtype == torch.float8_e8m0fnu
 
     if not scaling_type_supported(scale_a) or not scaling_type_supported(scale_b):
+        return False
+
+    is_sm90 = torch.cuda.get_device_capability()[0] == 9
+    uses_mxfp8 = (
+        scale_a.dtype == torch.float8_e8m0fnu or scale_b.dtype == torch.float8_e8m0fnu
+    )
+    if is_sm90 and uses_mxfp8:
         return False
 
     fp8_dtypes = (torch.float8_e4m3fn, torch.float8_e5m2)

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -8868,10 +8868,11 @@ def _should_use_scaled_cublaslt_grouped_gemm(
     offs: Tensor | None,
     out_dtype: torch.dtype | None,
 ) -> bool:
-    if not torch.backends.cuda.matmul.prefer_cublaslt_grouped_gemm:
+    if not torch.version.cuda:
         return False
+    cuda_version = tuple(map(int, torch.version.cuda.split(".")[:2]))
     # Device support and the [1, 1024] group-count bound.
-    if not _grouped_mm_cublaslt_supported(mat_a, mat_b, offs):
+    if cuda_version < (13, 4) or not _grouped_mm_cublaslt_supported(mat_a, mat_b, offs):
         return False
 
     mat_a_is_2d = mat_a.dim() == 2

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -8534,18 +8534,37 @@ def _meta_grouped_mm_common(
     # _grouped_mm_cuda()/_scaled_grouped_mm_cuda() code in
     # aten/src/ATen/native/cuda/Blas.cpp.
 
-    if scaled:
-        fp8_dtype = torch.float8_e4m3fn
-        if (
-            torch.version.hip
-            and torch.cuda.is_available()
-            and "gfx94" in torch.cuda.get_device_properties(0).gcnArchName
-        ):
-            fp8_dtype = torch.float8_e4m3fnuz
-        torch._check(
-            mat_a.dtype == fp8_dtype and mat_b.dtype == fp8_dtype,
-            lambda: f"Expected inputs of E4M3 FP8 type but got mat_a.dtype={mat_a.dtype} and mat_b.dtype={mat_b.dtype}.",
+    use_scaled_cublaslt_grouped_gemm = (
+        scaled
+        and _should_use_scaled_cublaslt_grouped_gemm(
+            mat_a, mat_b, scale_a, scale_b, offs, out_dtype
         )
+    )
+
+    if scaled:
+        if use_scaled_cublaslt_grouped_gemm:
+            fp8_dtypes = (torch.float8_e4m3fn, torch.float8_e5m2)
+            torch._check(
+                mat_a.dtype in fp8_dtypes
+                and mat_b.dtype in fp8_dtypes
+                and (
+                    mat_a.dtype == torch.float8_e4m3fn
+                    or mat_b.dtype == torch.float8_e4m3fn
+                ),
+                lambda: f"Expected at least one E4M3 FP8 input for cuBLASLt scaled grouped GEMM, got mat_a.dtype={mat_a.dtype} and mat_b.dtype={mat_b.dtype}.",
+            )
+        else:
+            fp8_dtype = torch.float8_e4m3fn
+            if (
+                torch.version.hip
+                and torch.cuda.is_available()
+                and "gfx94" in torch.cuda.get_device_properties(0).gcnArchName
+            ):
+                fp8_dtype = torch.float8_e4m3fnuz
+            torch._check(
+                mat_a.dtype == fp8_dtype and mat_b.dtype == fp8_dtype,
+                lambda: f"Expected inputs of E4M3 FP8 type but got mat_a.dtype={mat_a.dtype} and mat_b.dtype={mat_b.dtype}.",
+            )
     elif mat_a.dtype == torch.bfloat16:
         torch._check(
             mat_b.dtype == mat_a.dtype,
@@ -8637,6 +8656,54 @@ def _meta_grouped_mm_common(
         )
 
         def check_scale(scale_name, scale, mat, scaled_dim, scale_multiplier=1):
+            if use_scaled_cublaslt_grouped_gemm:
+                batch_count = (
+                    offs.shape[0]
+                    if offs is not None and (mat_a_is_2d or mat_b_is_2d)
+                    else mat_a.shape[0]
+                )
+                if is_mxfp8:
+                    torch._check(
+                        scale.is_contiguous(),
+                        lambda: f"Expected {scale_name} to be contiguous.",
+                    )
+                    is_a = scaled_dim == 0
+                    inner = mat.shape[-1] if is_a else mat.shape[-2]
+                    outer = mat.shape[-2] if is_a else mat.shape[-1]
+                    # See cublas_vec32_scale_size_host in GroupedBlas.cpp
+                    scale_size = (
+                        ((inner + 127) // 128) * 4 * (((outer + 127) // 128) * 128)
+                    )
+                    if mat.dim() == 3:
+                        torch._check(
+                            scale.dim() == 2
+                            and scale.shape[0] == batch_count
+                            and scale.shape[1] == scale_size,
+                            lambda: f"Expected {scale_name} to have shape ({batch_count}, {scale_size}), got {scale.shape}.",
+                        )
+                    else:
+                        # 2D inputs have data-dependent per-group extents along the
+                        # jagged dim, so the exact concatenated blocked-scale size is
+                        # unknown here. Because ceil() is subadditive,
+                        # sum_g cublas_vec32_scale_size(g) >=
+                        # cublas_vec32_scale_size(totals), so scale_size is a safe
+                        # lower bound on the required element count.
+                        torch._check(
+                            scale.numel() >= scale_size,
+                            lambda: f"Expected {scale_name} to have at least {scale_size} elements, got {scale.numel()}.",
+                        )
+                else:
+                    groupwise = scale.numel() != 1 and scale.numel() == batch_count
+                    torch._check(
+                        scale.numel() == 1 or groupwise,
+                        lambda: f"Expected {scale_name} to have either one element or one element per group ({batch_count}), got {scale.numel()} elements.",
+                    )
+                    if groupwise:
+                        torch._check(
+                            scale.dim() == 1 and scale.is_contiguous(),
+                            lambda: f"Expected groupwise {scale_name} to be 1D and contiguous, got {scale.dim()}D with stride {scale.stride()}.",
+                        )
+                return
             if mat.dim() == 2:
                 torch._check(
                     scale.is_contiguous(),
@@ -8733,7 +8800,7 @@ def _meta_grouped_mm_common(
 
     if mat_a.dtype == torch.float16:
         torch._check(
-            _grouped_mm_fp16_cublaslt_supported(mat_a, mat_b, offs),
+            _grouped_mm_cublaslt_supported(mat_a, mat_b, offs, True),
             lambda: "Float16 grouped_mm requires cuBLASLt grouped GEMM support.",
         )
 
@@ -8743,10 +8810,17 @@ def _meta_grouped_mm_common(
     )
 
     if scaled:
-        torch._check(
-            out_dtype is None or out_dtype == torch.bfloat16,
-            lambda: "If output dtype provided, it must be torch.bfloat16.",
-        )
+        if use_scaled_cublaslt_grouped_gemm:
+            torch._check(
+                out_dtype is None
+                or out_dtype in (torch.bfloat16, torch.float16, torch.float32),
+                lambda: "If output dtype provided, cuBLASLt scaled grouped GEMM requires torch.bfloat16, torch.float16, or torch.float32.",
+            )
+        else:
+            torch._check(
+                out_dtype is None or out_dtype == torch.bfloat16,
+                lambda: "If output dtype provided, it must be torch.bfloat16.",
+            )
     else:
         out_dtype = out_dtype or mat_a.dtype
         torch._check(
@@ -8757,8 +8831,8 @@ def _meta_grouped_mm_common(
     return _create_grouped_mm_output_tensor(mat_a, mat_b, offs, out_dtype)
 
 
-def _grouped_mm_fp16_cublaslt_supported(
-    mat_a: Tensor, mat_b: Tensor, offs: Tensor | None
+def _grouped_mm_cublaslt_supported(
+    mat_a: Tensor, mat_b: Tensor, offs: Tensor | None, sm90_allowed: bool = False
 ) -> bool:
     if device_hint(mat_a) != "cuda" or device_hint(mat_b) != "cuda":
         return False
@@ -8778,9 +8852,57 @@ def _grouped_mm_fp16_cublaslt_supported(
     if torch.version.cuda:
         parts = torch.version.cuda.split(".")
         cuda_version = (int(parts[0]), int(parts[1]))
+    if device_capability[0] == 9:
+        return cuda_version >= (13, 3) and sm90_allowed
     return cuda_version >= (13, 3) and (
-        device_capability[0] >= 9 and device_capability[0] <= 11
+        device_capability[0] == 10 or device_capability == (11, 0)
     )
+
+
+# Mirror should_use_scaled_cublaslt_grouped_gemm in aten/src/ATen/native/cuda/GroupedBlas.cpp
+def _should_use_scaled_cublaslt_grouped_gemm(
+    mat_a: Tensor,
+    mat_b: Tensor,
+    scale_a: Tensor,
+    scale_b: Tensor,
+    offs: Tensor | None,
+    out_dtype: torch.dtype | None,
+) -> bool:
+    if not torch.backends.cuda.matmul.prefer_cublaslt_grouped_gemm:
+        return False
+    # Device support and the [1, 1024] group-count bound.
+    if not _grouped_mm_cublaslt_supported(mat_a, mat_b, offs):
+        return False
+
+    mat_a_is_2d = mat_a.dim() == 2
+    mat_b_is_2d = mat_b.dim() == 2
+    batch_count = (
+        offs.shape[0]
+        if offs is not None and (mat_a_is_2d or mat_b_is_2d)
+        else mat_a.shape[0]
+    )
+
+    def scaling_type_supported(scale: Tensor) -> bool:
+        # tensorwise, groupwise, or blockwise MXFP8
+        if scale.dtype == torch.float32:
+            return scale.numel() == 1 or (
+                scale.dim() == 1 and scale.numel() == batch_count
+            )
+        return scale.dtype == torch.float8_e8m0fnu
+
+    if not scaling_type_supported(scale_a) or not scaling_type_supported(scale_b):
+        return False
+
+    fp8_dtypes = (torch.float8_e4m3fn, torch.float8_e5m2)
+    if not (
+        mat_a.dtype in fp8_dtypes
+        and mat_b.dtype in fp8_dtypes
+        and (mat_a.dtype == torch.float8_e4m3fn or mat_b.dtype == torch.float8_e4m3fn)
+    ):
+        return False
+
+    resolved_out_dtype = out_dtype if out_dtype is not None else torch.bfloat16
+    return resolved_out_dtype in (torch.bfloat16, torch.float16, torch.float32)
 
 
 @register_meta(aten._grouped_mm)

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -3104,7 +3104,8 @@ Call this whenever a new thread is created in order to propagate values from
       .value(
           "BlockWise128x128",
           at::blas::ScalingType::BlockWise128x128,
-          "Scale per 128x128 tile");
+          "Scale per 128x128 tile")
+      .value("GroupWise", at::blas::ScalingType::GroupWise, "Scale per group");
 
   py::enum_<at::blas::SwizzleType>(
       py_module, "_SwizzleType", "Supported scale swizzle types")

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -3062,7 +3062,8 @@ Call this whenever a new thread is created in order to propagate values from
       .value(
           "BlockWise128x128",
           at::blas::ScalingType::BlockWise128x128,
-          "Scale per 128x128 tile");
+          "Scale per 128x128 tile")
+      .value("GroupWise", at::blas::ScalingType::GroupWise, "Scale per group");
 
   py::enum_<at::blas::SwizzleType>(
       py_module, "_SwizzleType", "Supported scale swizzle types")

--- a/torch/nn/functional.pyi.in
+++ b/torch/nn/functional.pyi.in
@@ -774,6 +774,7 @@ class ScalingType(Enum):
     BlockWise1x32 = 3
     BlockWise1x128 = 4
     BlockWise128x128 = 5
+    GroupWise = 6
 
 __all__ += ["ScalingType"]
 

--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -80,6 +80,15 @@ def blas_library_context(backend):
     finally:
         torch.backends.cuda.preferred_blas_library(prev_backend)
 
+@contextlib.contextmanager
+def prefer_cublaslt_grouped_gemm():
+    old = torch.backends.cuda.matmul.prefer_cublaslt_grouped_gemm
+    try:
+        torch.backends.cuda.matmul.prefer_cublaslt_grouped_gemm = True
+        yield
+    finally:
+        torch.backends.cuda.matmul.prefer_cublaslt_grouped_gemm = old
+
 def evaluate_gfx_arch_within(arch_list):
     if not torch.cuda.is_available():
         return False
@@ -273,6 +282,14 @@ def evaluate_platform_supports_mxfp8_grouped_gemm():
         return built_with_mslk and IS_SM100
     return False
 
+def evaluate_platform_supports_cublaslt_fp8_grouped_gemm():
+    return (
+        TEST_CUDA
+        and SM100OrLater
+        and not SM120OrLater
+        and _get_torch_cuda_version() >= (13, 2)
+    )
+
 def evaluate_platform_supports_fp8_sparse():
     if torch.cuda.is_available():
         if torch.version.hip:
@@ -290,6 +307,7 @@ PLATFORM_SUPPORTS_FP8: bool = LazyVal(lambda: evaluate_platform_supports_fp8())
 PLATFORM_SUPPORTS_FP8_SPARSE: bool = LazyVal(lambda: evaluate_platform_supports_fp8_sparse())
 PLATFORM_SUPPORTS_FP8_GROUPED_GEMM: bool = LazyVal(lambda: evaluate_platform_supports_fp8_grouped_gemm())
 PLATFORM_SUPPORTS_MXFP8_GROUPED_GEMM: bool = LazyVal(lambda: evaluate_platform_supports_mxfp8_grouped_gemm())
+PLATFORM_SUPPORTS_CUBLASLT_FP8_GROUPED_GEMM: bool = LazyVal(lambda: evaluate_platform_supports_cublaslt_fp8_grouped_gemm())
 
 if TEST_NUMBA:
     try:

--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -287,7 +287,7 @@ def evaluate_platform_supports_cublaslt_fp8_grouped_gemm():
         TEST_CUDA
         and SM100OrLater
         and not SM120OrLater
-        and _get_torch_cuda_version() >= (13, 2)
+        and _get_torch_cuda_version() >= (13, 3)
     )
 
 def evaluate_platform_supports_fp8_sparse():

--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -339,7 +339,7 @@ def evaluate_platform_supports_hipsparselt():
 def evaluate_platform_supports_cublaslt_fp8_grouped_gemm():
     return (
         TEST_CUDA
-        and SM100OrLater
+        and SM90OrLater
         and not SM120OrLater
         and _get_torch_cuda_version() >= (13, 4)
     )

--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -120,6 +120,15 @@ def blas_library_context(backend):
     finally:
         torch.backends.cuda.preferred_blas_library(prev_backend)
 
+@contextlib.contextmanager
+def prefer_cublaslt_grouped_gemm():
+    old = torch.backends.cuda.matmul.prefer_cublaslt_grouped_gemm
+    try:
+        torch.backends.cuda.matmul.prefer_cublaslt_grouped_gemm = True
+        yield
+    finally:
+        torch.backends.cuda.matmul.prefer_cublaslt_grouped_gemm = old
+
 def evaluate_gfx_arch_within(arch_list):
     if not torch.cuda.is_available():
         return False
@@ -327,6 +336,14 @@ def hipsparselt_supported_archs():
 def evaluate_platform_supports_hipsparselt():
     return bool(torch.version.hip) and evaluate_gfx_arch_within(hipsparselt_supported_archs())
 
+def evaluate_platform_supports_cublaslt_fp8_grouped_gemm():
+    return (
+        TEST_CUDA
+        and SM100OrLater
+        and not SM120OrLater
+        and _get_torch_cuda_version() >= (13, 2)
+    )
+
 def evaluate_platform_supports_fp8_sparse():
     if torch.cuda.is_available():
         if torch.version.hip:
@@ -344,6 +361,7 @@ PLATFORM_SUPPORTS_FP8: bool = LazyVal(lambda: evaluate_platform_supports_fp8())
 PLATFORM_SUPPORTS_FP8_SPARSE: bool = LazyVal(lambda: evaluate_platform_supports_fp8_sparse())
 PLATFORM_SUPPORTS_FP8_GROUPED_GEMM: bool = LazyVal(lambda: evaluate_platform_supports_fp8_grouped_gemm())
 PLATFORM_SUPPORTS_MXFP8_GROUPED_GEMM: bool = LazyVal(lambda: evaluate_platform_supports_mxfp8_grouped_gemm())
+PLATFORM_SUPPORTS_CUBLASLT_FP8_GROUPED_GEMM: bool = LazyVal(lambda: evaluate_platform_supports_cublaslt_fp8_grouped_gemm())
 
 if TEST_NUMBA:
     try:

--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -341,7 +341,7 @@ def evaluate_platform_supports_cublaslt_fp8_grouped_gemm():
         TEST_CUDA
         and SM100OrLater
         and not SM120OrLater
-        and _get_torch_cuda_version() >= (13, 3)
+        and _get_torch_cuda_version() >= (13, 4)
     )
 
 def evaluate_platform_supports_fp8_sparse():

--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -341,7 +341,7 @@ def evaluate_platform_supports_cublaslt_fp8_grouped_gemm():
         TEST_CUDA
         and SM100OrLater
         and not SM120OrLater
-        and _get_torch_cuda_version() >= (13, 2)
+        and _get_torch_cuda_version() >= (13, 3)
     )
 
 def evaluate_platform_supports_fp8_sparse():


### PR DESCRIPTION
This PR extends cublasLt grouped GEMM support to fp8 operations on Blackwell. This backend supports tensorwise and groupwise scaling (neither of which are supported by the existing MSLK kernel), as well as MXFP8. The cublasLt backend is opt-in for now, and can be enabled by setting `torch.backends.cuda.matmul.prefer_cublaslt_grouped_gemm=True`. Note that ops will warn the user and fall back to the MSLK backend if inputs do not meet the requirements for the cublasLt backend. The minimum CUDA version required for this feature is 13.3.

### Benchmarking

I profiled kernel performance for MXFP8 grouped GEMMs to compare the existing MSLK backend against cublasLt. On CUDA 13.3, cublasLt is 7-9% slower than MSLK on average, hence the opt-in default. On CUDA 13.4, cublasLt is 11-13% faster.

### Links
[Benchmarking results spreadsheet](https://docs.google.com/spreadsheets/d/1ZT-JyRGpQr7BJMQgxyh47Y8IfkAjiJnR)
[Benchmarking script](https://gist.github.com/gderossi/e8501027ec9b62005460db9425ae03dd)

Authored with assistance from agents

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98 @eqy