### PR TITLE
Fix int32 overflow in CUDA AdaptiveAvgPool2d START_IND macro

### DIFF
--- a/aten/src/ATen/native/cuda/AdaptiveAveragePooling.cu
+++ b/aten/src/ATen/native/cuda/AdaptiveAveragePooling.cu
@@ -26,7 +26,7 @@
 #include <cfloat>
 #include <cmath>
 
-#define START_IND(a,b,c) ((int64_t)((a / b) * c + ((a % b) * c) / b))
+#define START_IND(a,b,c) ((int64_t)(a / b) * c + ((int64_t)(a % b) * c) / b)
 #define END_IND(a,b,c) (1 + ((int64_t)(a + 1) * c - 1) / b)
 
 #define START_IND_INT(a,b,c) ((a * c) / b)

--- a/test/nn/test_pooling.py
+++ b/test/nn/test_pooling.py
@@ -375,6 +375,24 @@ class TestPoolingNN(NNTestCase):
         self.assertFalse(torch.isinf(out).any())
         self.assertFalse(torch.isnan(out).any())
 
+    @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
+    @largeTensorTest("1GB", device="cuda")
+    def test_adaptive_avg_pooling_index_overflow(self):
+        # See https://github.com/pytorch/pytorch/issues/176784
+        # START_IND macro int32 overflow when osizeH * isizeH > INT_MAX
+        # Use arange so every input element is unique and any index
+        # miscalculation produces a detectably wrong value.
+        x = torch.arange(47, dtype=torch.float32).reshape(1, 1, 47, 1)
+        pool = torch.nn.AdaptiveAvgPool2d((67108864, 1))
+        expected = pool(x)
+        actual = pool(x.cuda())
+        self.assertEqual(actual.cpu(), expected)
+
+        # Also overflow in the width dimension
+        x_w = x.permute(0, 1, 3, 2)  # (1, 1, 1, 47)
+        pool_w = torch.nn.AdaptiveAvgPool2d((1, 67108864))
+        self.assertEqual(pool_w(x_w.cuda()).cpu(), pool_w(x_w))
+
     def test_MaxUnpool2d_output_size(self):
         m = nn.MaxPool2d(3, stride=2, return_indices=True)
         mu = nn.MaxUnpool2d(3, stride=2)


### PR DESCRIPTION
Fixes #176784

## Summary

The `START_IND` macro in `AdaptiveAveragePooling.cu` casts to `int64_t` on
the outside of the expression, but the intermediate `(a % b) * c` is
computed in `int32`, so it overflows when `output_size * input_size > INT_MAX`.
This produces garbage indices and silent out-of-bounds reads on CUDA.

Add an `(int64_t)` cast on the intermediate multiply to promote it before
overflow can occur.

## Test plan

- Added `test_adaptive_avg_pooling_index_overflow` comparing CPU vs CUDA
  output with a large output size that triggers the overflow.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>