### PR TITLE
[pytorch] address violations of warning unreachable-code-return in asserts (#177041)

### DIFF
--- a/c10/util/Exception.h
+++ b/c10/util/Exception.h
@@ -616,12 +616,19 @@ namespace c10::detail {
 // too expensive to run this assert on production builds.
 #ifdef NDEBUG
 // Optimized version - generates no code.
-#define TORCH_INTERNAL_ASSERT_DEBUG_ONLY(...) \
-  while (false)                               \
-  C10_EXPAND_MSVC_WORKAROUND(TORCH_INTERNAL_ASSERT(__VA_ARGS__))
+#define TORCH_INTERNAL_ASSERT_DEBUG_ONLY(...)                        \
+  do {                                                               \
+    if (false) {                                                     \
+      C10_EXPAND_MSVC_WORKAROUND(TORCH_INTERNAL_ASSERT(__VA_ARGS__)) \
+    }                                                                \
+  } while (false)
 #else
-#define TORCH_INTERNAL_ASSERT_DEBUG_ONLY(...) \
-  C10_EXPAND_MSVC_WORKAROUND(TORCH_INTERNAL_ASSERT(__VA_ARGS__))
+#define TORCH_INTERNAL_ASSERT_DEBUG_ONLY(...)                        \
+  do {                                                               \
+    if (true) {                                                      \
+      C10_EXPAND_MSVC_WORKAROUND(TORCH_INTERNAL_ASSERT(__VA_ARGS__)) \
+    }                                                                \
+  } while (false)
 #endif
 
 // TODO: We're going to get a lot of similar looking string literals


### PR DESCRIPTION
Summary:

For code like this:
```
TORCH_INTERNAL_ASSERT_DEBUG_ONLY(false, ...);
return; // <--- unreachable-code-return in debug only
```

We want the compiler not to issue diagnostic `unreachable-code-return` in this example. If the compiler did, then the alternatives include:
* ignoring the warning and not treating it as error
* suppressing the warning with `#pragma`s at every usage site
* using preprocessor conditionals to guard the code following the debug-only assert at every usage site

The idea here is to structure the code so that the compiler does not emit this diagnostic.

Test Plan: CI.

Differential Revision: D95726763
