### PR TITLE
Use FloorDiv and Mod instead of // and % on sympy exprs

### DIFF
--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -1855,7 +1855,7 @@ class Reduction(Loops):
             reduction_ranges, [reduction_numel], dense_index
         )
         need_mask = not V.graph.sizevars.statically_known_true(
-            sympy.Eq(reduction_numel % split, 0)
+            sympy.Eq(Mod(reduction_numel, split), 0)
         )
 
         def wrapper_fn(
@@ -2326,7 +2326,7 @@ class WelfordReduction(MultiOutputReduction):
         """
         reduction_numel = sympy_product(reduction_ranges)
         need_mask = not V.graph.sizevars.statically_known_true(
-            sympy.Eq(reduction_numel % split, 0)
+            sympy.Eq(Mod(reduction_numel, split), 0)
         )
 
         if need_mask and reduction_type != "welford_combine":

--- a/torch/_inductor/kernel/flex/flex_attention.py
+++ b/torch/_inductor/kernel/flex/flex_attention.py
@@ -15,6 +15,7 @@ import sympy
 import torch
 from torch._inductor.virtualized import V
 from torch.nn.attention.flex_attention import _Backend
+from torch.utils._sympy.functions import FloorDiv, Mod
 
 from ...ir import ComputedBuffer, ExternKernel, FixedLayout, TensorBox
 from ...lowering import empty, empty_strided, lowerings, register_lowering, to_dtype
@@ -318,10 +319,16 @@ def flex_attention(
 
     B = Bq
 
-    if seq_len_q % 128 != 0 or seq_len_kv % 128 != 0:
-        kernel_options.setdefault("IS_DIVISIBLE", False)
-    else:
+    seq_q_divisible = V.graph.sizevars.statically_known_true(
+        sympy.Eq(Mod(seq_len_q, 128), 0)
+    )
+    seq_kv_divisible = V.graph.sizevars.statically_known_true(
+        sympy.Eq(Mod(seq_len_kv, 128), 0)
+    )
+    if seq_q_divisible and seq_kv_divisible:
         kernel_options.setdefault("IS_DIVISIBLE", True)
+    else:
+        kernel_options.setdefault("IS_DIVISIBLE", False)
 
     # NB it is okay that the v_head_dim is different
     # We are using these to match fill order of the output.
@@ -353,7 +360,7 @@ def flex_attention(
     kernel_options.setdefault("SM_SCALE", scale)
 
     # Determine GQA broadcast factor.
-    gqa_shared_heads = Hq // Hkv
+    gqa_shared_heads = FloorDiv(Hq, Hkv)
     kernel_options.setdefault("GQA_SHARED_HEADS", gqa_shared_heads)
 
     # Inside of Triton kernel, only apply partial masking if partial blocks are computed.
@@ -704,8 +711,12 @@ def flex_attention_backward(*args, **kwargs):
         for k, v in kernel_options.items()
     }
     kernel_options.setdefault("FLOAT32_PRECISION", get_float32_precision())
-    seq_q_divisible = V.graph.sizevars.statically_known_true(seq_len_q % 128 == 0)
-    seq_kv_divisible = V.graph.sizevars.statically_known_true(seq_len_kv % 128 == 0)
+    seq_q_divisible = V.graph.sizevars.statically_known_true(
+        sympy.Eq(Mod(seq_len_q, 128), 0)
+    )
+    seq_kv_divisible = V.graph.sizevars.statically_known_true(
+        sympy.Eq(Mod(seq_len_kv, 128), 0)
+    )
     if seq_q_divisible and seq_kv_divisible:
         kernel_options.setdefault("IS_DIVISIBLE", True)
     else:
@@ -865,7 +876,7 @@ def flex_attention_backward(*args, **kwargs):
     kernel_options.setdefault("SM_SCALE", scale)
 
     # Determine GQA factor
-    gqa_shared_heads = Hq // Hkv
+    gqa_shared_heads = FloorDiv(Hq, Hkv)
     kernel_options.setdefault("GQA_SHARED_HEADS", gqa_shared_heads)
 
     # Inside of Triton kernel, only apply partial masking if partial blocks are computed.

--- a/torch/_inductor/kernel/flex/flex_decoding.py
+++ b/torch/_inductor/kernel/flex/flex_decoding.py
@@ -8,6 +8,7 @@ import sympy
 
 import torch
 from torch._inductor.virtualized import V
+from torch.utils._sympy.functions import FloorDiv, Mod
 
 from ... import ir
 from ...ir import FixedLayout, FlexibleLayout
@@ -69,7 +70,7 @@ def _use_flex_decoding(query, kv_indices, value, kernel_options, enable_gqa) -> 
 
     Hq = query.get_size()[1]
     Hkv = value.get_size()[1]
-    ratio = Hq // Hkv
+    ratio = FloorDiv(Hq, Hkv)
 
     pw_of_two = V.graph.sizevars.guard_or_false(
         sympy.And(sympy.Gt(ratio, 0), sympy.Eq(ratio & (ratio - 1), 0))
@@ -181,10 +182,10 @@ def create_flex_decoding_kernel(*args, **kwargs):
     }
 
     seq_q_divisible = V.graph.sizevars.statically_known_true(
-        sympy.Eq(seq_len_q % 128, 0)
+        sympy.Eq(Mod(seq_len_q, 128), 0)
     )
     seq_kv_divisible = V.graph.sizevars.statically_known_true(
-        sympy.Eq(seq_len_kv % 128, 0)
+        sympy.Eq(Mod(seq_len_kv, 128), 0)
     )
     if seq_q_divisible and seq_kv_divisible:
         kernel_options.setdefault("IS_DIVISIBLE", True)
@@ -192,7 +193,7 @@ def create_flex_decoding_kernel(*args, **kwargs):
         kernel_options.setdefault("IS_DIVISIBLE", False)
 
     # Calculate GQA head sharing
-    gqa_shared_heads = Hq // Hkv
+    gqa_shared_heads = FloorDiv(Hq, Hkv)
     if not is_power_of_2(gqa_shared_heads):
         raise ValueError(
             "Number of shared query heads sharing the same KV head must be power of 2. "
@@ -302,7 +303,7 @@ def create_flex_decoding_kernel(*args, **kwargs):
 
     kernel_options.setdefault(
         "SAFE_M_BOUNDARY",
-        ((seq_len_q * gqa_shared_heads) % kernel_options["BLOCK_M"]) == 0,
+        Mod(seq_len_q * gqa_shared_heads, kernel_options["BLOCK_M"]) == 0,
     )
     # TODO: This feels sketchy
     kernel_options.setdefault("SAFE_N_BOUNDARY", True)

--- a/torch/_inductor/loop_body.py
+++ b/torch/_inductor/loop_body.py
@@ -13,6 +13,7 @@ import sympy
 import torch.fx
 from torch._dynamo.utils import identity
 from torch.fx.proxy import Scope, TracerBase
+from torch.utils._sympy.functions import Mod
 from torch.utils._sympy.symbol import SymT
 
 from . import config, dependencies
@@ -268,7 +269,7 @@ class LoopBody:
             reduce_idx = index[len(iter_size) :]
 
             new_iter_idx = list(iter_idx)
-            new_iter_idx[dimension] = iter_idx[dimension] % original_range
+            new_iter_idx[dimension] = Mod(iter_idx[dimension], original_range)
 
             return old_body(new_iter_idx, reduce_idx)
 

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -3042,12 +3042,14 @@ def sdpa_constraint(fx_node, *args, **kwargs):
                 # we can make them expanded by setting the stride equal to 0
                 if i in expanded_dims:
                     if V.graph.sizevars.statically_known_equals(
-                        out_strides[i + 1] % ALIGNMENT, 0
+                        Mod(out_strides[i + 1], ALIGNMENT), 0
                     ):
                         out_strides[i] = 0
                         continue
 
-                if not V.graph.sizevars.statically_known_equals(stride % ALIGNMENT, 0):
+                if not V.graph.sizevars.statically_known_equals(
+                    Mod(stride, ALIGNMENT), 0
+                ):
                     stride = ceildiv(stride, ALIGNMENT) * ALIGNMENT
 
                 out_strides[i] = stride

--- a/torch/_inductor/sizevars.py
+++ b/torch/_inductor/sizevars.py
@@ -938,7 +938,7 @@ class SizeVarAllocator:
             if not _check_args(x2, div2, mod2, False):
                 return index
 
-            if mod2 % mod != 0:
+            if Mod(mod2, mod) != 0:
                 return index
 
             return ModularIndexing(x2, 1, mod)

--- a/torch/_inductor/template_heuristics/triton.py
+++ b/torch/_inductor/template_heuristics/triton.py
@@ -13,6 +13,7 @@ import sympy
 import torch
 from torch._inductor.template_heuristics.triton_addmm import AddMMConfigMixin
 from torch.utils._ordered_set import OrderedSet
+from torch.utils._sympy.functions import Mod
 from torch.utils._triton import has_triton_stable_tma_api
 
 from .. import config, config as inductor_config
@@ -2040,7 +2041,7 @@ class MMTemplateConfigMixin(GemmMaxAutotuneTemplateConfigHeuristics):
         Moved from mm_common.mm_options.
         """
         # Calculate EVEN_K symbolic. (It isn't worth guarding on this)
-        even_k_symbolic = (k % triton_config.kwargs["BLOCK_K"]) == 0
+        even_k_symbolic = sympy.Eq(Mod(k, triton_config.kwargs["BLOCK_K"]), 0)
         even_k_symbolic = V.graph.sizevars.statically_known_true(even_k_symbolic)
 
         # Build options dict

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -6871,7 +6871,7 @@ class ShapeEnv:
             for atom in expr.atoms(TruncToInt):
                 if isinstance(atom.args[0], IntTrueDiv):
                     base, divisor = atom.args[0].args
-                    if base % divisor == 0:
+                    if Mod(base, divisor) == 0:
                         trunc_replacements[atom] = CleanDiv(base, divisor)
                     else:
                         # TruncToInt(IntTrueDiv(a,b)) == FloorDiv(a, b)


### PR DESCRIPTION
Fixes #162868. Continuation of #175755.

Inductor call sites use Python `%` and `//` on raw sympy symbols, which create `sympy.Mod` and `sympy.floor` -- different types from the `torch.utils._sympy.functions.Mod`/`FloorDiv` that `torch._check` installs as axioms. This causes `statically_known_true` to miss divisibility constraints, leading to unnecessary masking and missed optimizations in generated Triton kernels.

16 call sites fixed across 8 files. ~900 other occurrences of `//`/`%` were triaged and confirmed safe (SymInt dispatch, concrete values, codegen output, or intentional sympy.Mod usage in the congruence solver).

## Benchmark: flex_attention 2.5x regression with dynamic shapes

The most impactful fix is in flex_attention, where `seq_len_q % 128 != 0` always evaluated to `True` for symbolic shapes (bypassing axioms entirely), forcing `IS_DIVISIBLE=False` unconditionally. Benchmark on GB200, `flex_attention` with S=2048 and `torch._check(seq_len % 128 == 0)`:

| | Before | After |
|---|---|---|
| `dynamic=False` | 0.43 ms | 0.43 ms |
| `dynamic=True` | 1.07 ms (2.5x regression) | 0.43 ms |

```python
import torch
import torch.utils.benchmark as benchmark
from torch.nn.attention.flex_attention import flex_attention

B, H, S, D = 4, 32, 2048, 64

for dynamic in [False, True]:
    torch._dynamo.reset()
    def fn(q, k, v):
        torch._check(q.shape[2] % 128 == 0)
        torch._check(k.shape[2] % 128 == 0)
        return flex_attention(q, k, v)
    compiled = torch.compile(fn, dynamic=dynamic)
    q = torch.randn(B, H, S, D, device="cuda", dtype=torch.float16)
    k = torch.randn(B, H, S, D, device="cuda", dtype=torch.float16)
    v = torch.randn(B, H, S, D, device="cuda", dtype=torch.float16)
    for _ in range(3): compiled(q, k, v)
    torch.cuda.synchronize()
    t = benchmark.Timer(
        stmt="fn(q, k, v)", globals={"fn": compiled, "q": q, "k": k, "v": v},
    )
    print(f"dynamic={str(dynamic):5s}: {t.blocked_autorange(min_run_time=0.5).median*1e3:.4f} ms")
```

See also [#175752](https://github.com/pytorch/pytorch/issues/175752) for the RMSNorm vectorization regression (27% on H100) fixed by [#175755](https://github.com/pytorch/pytorch/pull/175755).


## Search coverage

### Scope

Searched **444 Python files** across the compiler codebase:

- `torch/_inductor/` (the main inductor compiler)
- `torch/_dynamo/` (the graph capture frontend)
- `torch/fx/experimental/symbolic_shapes.py` (core shape inference)
- `torch/utils/_sympy/` (sympy utilities: functions, reference, value_ranges, printers)

It was done against PyTorch commit e47de660122.

### Method

Performed two parallel exhaustive searches:

1. **All `//` uses** on potentially-sympy operands across all 444 files
2. **All `%` uses** on potentially-sympy operands across all 444 files, excluding string formatting, comments, and codegen output

Out of **917 raw occurrences** of `//` or `%` across 97 files, each was triaged by examining the operand types in context:

- Is the operand a `sympy.Expr` (bare sympy expression)? → Needs fix
- Is the operand a `SymInt`? → Safe (`SymInt.__mod__`/`__floordiv__` dispatch through symnode which produces `Mod`/`FloorDiv` correctly)
- Is the operand a Python `int` / `sympy.Integer` (concrete)? → Safe (concrete arithmetic gives correct results)
- Is it in a string, comment, codegen template, or Jinja output? → Not applicable

### Results

| Category | Count | Action |
|---|---|---|
| **Fixed (sympy.Expr operands)** | 16 sites across 8 files | Changed to `Mod`/`FloorDiv` |
| **Excluded — SymInt dispatch** | ~10 sites | Safe: `SymInt` operators produce correct types |
| **Excluded — concrete values** | ~15 sites | Safe: Python int or `sympy.Integer` arithmetic |
| **Excluded — codegen/templates** | ~50+ sites | Not Python execution, just output strings |
| **Excluded — string formatting** | ~100+ sites | `%s`, `% (`, etc. |
| **Excluded — comments/URLs** | ~700+ sites | Not code |
| **Excluded — internal sympy solver** | 4 sites in `symbolic_shapes.py:3080-3236` | Congruence system feeds into sympy's equation solver which expects `sympy.Mod` |
| **Excluded — value range analysis** | 2 sites in `value_ranges.py` | Operates on concrete bounds |

## Changes made

Three distinct patterns:

### Pattern A: Axiom mismatch via `xreplace`

`statically_known_true(Eq(s % N, 0))` creates `sympy.Mod(s, N)`. The axiom uses `torch.utils._sympy.functions.Mod(s, N)`. They print identically but `xreplace` requires exact type match.

### Pattern B: Direct comparison bypasses axiom system

`s % 128 != 0` on a symbolic `sympy.Expr` resolves to concrete `True` (sympy's `__ne__`), unconditionally taking the "not divisible" branch. The fix replaces this with `statically_known_true(Eq(Mod(s, 128), 0))` which consults axioms.

### Pattern C: `//` creates wrong expression tree

`s // t` creates `floor(s/t)`, not `FloorDiv(s, t)`. Axioms and pattern matching on `FloorDiv` don't find the `floor(...)` form.


| File | Lines | Change | Bug pattern |
|---|---|---|---|
| `sizevars.py` | 941 | `mod2 % mod` → `Mod(mod2, mod)` | A |
| `ir.py` | 1858, 2329 | `reduction_numel % split` → `Mod(...)` in `sympy.Eq` | A |
| `lowering.py` | 3045, 3050 | `stride % ALIGNMENT` → `Mod(...)` | A |
| `loop_body.py` | 272 | `iter_idx[dim] % original_range` → `Mod(...)` | A, C |
| `flex_attention.py` | 321-328 | Rewrote direct `% 128 != 0` to `statically_known_true(Eq(Mod(...), 0))` | A, B |
| `flex_attention.py` | 356, 868 | `Hq // Hkv` → `FloorDiv(Hq, Hkv)` | C |
| `flex_attention.py` | 710-713 | `seq_len % 128 == 0` → `Eq(Mod(...), 0)` | A |
| `flex_decoding.py` | 72, 195 | `Hq // Hkv` → `FloorDiv(Hq, Hkv)` | C |
| `flex_decoding.py` | 184, 187 | `seq_len % 128` → `Mod(...)` in `sympy.Eq` | A |
| `flex_decoding.py` | 305 | `(expr) % BLOCK_M` → `Mod(...)` | A, B |
| `triton.py` | 2043 | `k % BLOCK_K` → `Mod(...)` in `sympy.Eq` | A |
| `symbolic_shapes.py` | 6874 | `base % divisor` → `Mod(base, divisor)` | B |


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo