### PR TITLE
[Partitioner] Utilify _extract_fwd_bwd_modules for di/dw splitting

### DIFF
--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -61,6 +61,11 @@ from torch._functorch.aot_autograd import (
 )
 from torch._higher_order_ops.out_dtype import out_dtype
 from torch._inductor.codecache import compiled_fx_graph_hash
+from torch._functorch.partitioners import (
+    _extract_fwd_bwd_modules,
+    _extract_fwd_bwd_outputs,
+    _extract_graph_with_inputs_outputs,
+)
 from torch._inductor.custom_graph_pass import CustomPartitionerFn
 from torch._inductor.output_code import MockFXGraphCacheOutput
 from torch._subclasses.fake_tensor import DynamicOutputShapeException, FakeTensorMode
@@ -5962,6 +5967,84 @@ class TestPartitioning(AOTTestCase):
         )
         self.assertEqual(get_num_ins_outs(fw_graph), (3, 6))
         self.assertEqual(get_num_ins_outs(bw_graph), (6, 3))
+
+    def test_extract_fwd_bwd_modules_omit_aot_autograd_runtime(self):
+        """Test splitting a backward graph into dI/dW subgraphs using
+        omit_aot_autograd_runtime and ignore_must_be_in_fw_bw."""
+        from torch._functorch.partitioners import is_sym_node
+
+        def f(x, w):
+            return ((x @ w).sum(),)
+
+        x = torch.randn(4, 4, requires_grad=True)
+        w = torch.randn(4, 4, requires_grad=True)
+        joint = aot_export_joint_simple(f, [x, w], trace_joint=True)
+        fw_g, bw_g = default_partition(joint, [x, w], num_fwd_outputs=1)
+
+        # Run reference full backward
+        fw_outs = fw_g(x.detach(), w.detach())
+        activations = fw_outs[1:]
+        grad_out = torch.ones_like(fw_outs[0])
+        full_bw = bw_g(*activations, grad_out)
+
+        # Re-partition bw_g into dI (grad_x) and dW (grad_w),
+        # mimicking the split_dI_dW pattern.
+        # NOTE: placeholder names are load-bearing for the partitioner —
+        # _is_primal / _is_tangent classify nodes by checking substrings of
+        # node.target (e.g. "tangents" in target → is_tangent). We must create
+        # new placeholder nodes (not just rename) so the target is also updated.
+        bw_gm = copy.deepcopy(bw_g)
+        for p in list(bw_gm.graph.find_nodes(op="placeholder")):
+            if p.name.startswith("tangent"):
+                with bw_gm.graph.inserting_before(p):
+                    new_p = bw_gm.graph.placeholder(f"not_tngnt{p.name[8:]}")
+                    new_p.meta.update(p.meta)
+                    p.replace_all_uses_with(new_p)
+                    bw_gm.graph.erase_node(p)
+        bw_gm.recompile()
+
+        num_di = 1  # first output = grad_x
+        di_outs, dw_outs, di_descs, _ = _extract_fwd_bwd_outputs(
+            bw_gm, num_fwd_outputs=num_di
+        )
+        args = list(bw_gm.graph.find_nodes(op="placeholder"))
+        di_graph = _extract_graph_with_inputs_outputs(
+            bw_gm.graph, args, di_outs, di_descs, "forward",
+            ignore_must_be_in_fw_bw=True,
+        )
+        di_names = {n.name for n in di_graph.nodes if n.op != "output"}
+
+        saved_values = [
+            n for n in bw_gm.graph.nodes
+            if n.name in di_names and not is_sym_node(n)
+            and "tensor_meta" in n.meta
+            and any(n2.name not in di_names for n2 in n.users)
+        ]
+
+        di_mod, dw_mod = _extract_fwd_bwd_modules(
+            bw_gm, saved_values, saved_sym_nodes=[],
+            num_fwd_outputs=num_di,
+            ignore_must_be_in_fw_bw=True,
+            omit_aot_autograd_runtime=True,
+        )
+
+        # Verify graph structure
+        def ph_names(gm):
+            return [n.name for n in gm.graph.find_nodes(op="placeholder")]
+
+        self.assertFalse(any(n.startswith("tangent") for n in ph_names(di_mod)))
+        self.assertFalse(any(n.startswith("tangent") for n in ph_names(dw_mod)))
+
+        # Verify numerics: dI + dW matches full backward
+        bw_inputs = [*activations, grad_out]
+        di_outs = di_mod(*bw_inputs)
+        grad_x = di_outs[:num_di]
+        dw_inputs = di_outs[num_di:]
+        grad_w = dw_mod(*dw_inputs)
+        if not isinstance(grad_w, (list, tuple)):
+            grad_w = [grad_w]
+        self.assertEqual(grad_x[0], full_bw[0])
+        self.assertEqual(grad_w[0], full_bw[1])
 
     @unittest.skipIf(not USE_NETWORKX, "networkx not available")
     def test_min_cut_partitioner_raise_getitems(self):

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -59,13 +59,13 @@ from torch._functorch.aot_autograd import (
     aot_export_module,
     SerializableAOTDispatchCompiler,
 )
-from torch._higher_order_ops.out_dtype import out_dtype
-from torch._inductor.codecache import compiled_fx_graph_hash
 from torch._functorch.partitioners import (
     _extract_fwd_bwd_modules,
     _extract_fwd_bwd_outputs,
     _extract_graph_with_inputs_outputs,
 )
+from torch._higher_order_ops.out_dtype import out_dtype
+from torch._inductor.codecache import compiled_fx_graph_hash
 from torch._inductor.custom_graph_pass import CustomPartitionerFn
 from torch._inductor.output_code import MockFXGraphCacheOutput
 from torch._subclasses.fake_tensor import DynamicOutputShapeException, FakeTensorMode
@@ -6009,20 +6009,28 @@ class TestPartitioning(AOTTestCase):
         )
         args = list(bw_gm.graph.find_nodes(op="placeholder"))
         di_graph = _extract_graph_with_inputs_outputs(
-            bw_gm.graph, args, di_outs, di_descs, "forward",
+            bw_gm.graph,
+            args,
+            di_outs,
+            di_descs,
+            "forward",
             ignore_must_be_in_fw_bw=True,
         )
         di_names = {n.name for n in di_graph.nodes if n.op != "output"}
 
         saved_values = [
-            n for n in bw_gm.graph.nodes
-            if n.name in di_names and not is_sym_node(n)
+            n
+            for n in bw_gm.graph.nodes
+            if n.name in di_names
+            and not is_sym_node(n)
             and "tensor_meta" in n.meta
             and any(n2.name not in di_names for n2 in n.users)
         ]
 
         di_mod, dw_mod = _extract_fwd_bwd_modules(
-            bw_gm, saved_values, saved_sym_nodes=[],
+            bw_gm,
+            saved_values,
+            saved_sym_nodes=[],
             num_fwd_outputs=num_di,
             ignore_must_be_in_fw_bw=True,
             omit_aot_autograd_runtime=True,

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -986,13 +986,31 @@ def _extract_fwd_bwd_modules(
     *,
     num_fwd_outputs: int,
     static_lifetime_input_nodes: OrderedSet[fx.Node] | None = None,
+    ignore_must_be_in_fw_bw: bool = False,
+    omit_aot_autograd_runtime: bool = False,
 ) -> tuple[fx.GraphModule, fx.GraphModule]:
+    """Extract forward and backward graph modules from a joint graph.
+
+    Args:
+        ignore_must_be_in_fw_bw: When True, disables forward/backward placement
+            enforcement in _extract_graph_with_inputs_outputs. Needed when the
+            joint_module is not an original fwd+bwd joint graph (e.g. a backward
+            graph being re-partitioned for dI/dW splitting).
+        omit_aot_autograd_runtime: When True, skips postprocessing that is
+            only needed when the resulting modules will be wrapped in a custom
+            autograd.Function (the AOTAutograd path). This includes: tangent input
+            handling, version-counter check sorting of saved tensors, opaque object
+            (FakeScriptObject) separation, and fp8 activation quantization. Set this
+            to True when the fwd/bwd modules will be executed directly without autograd.
+    """
     fwd_outputs, bwd_outputs, fwd_outputs_descs, bwd_outputs_descs = (
         _extract_fwd_bwd_outputs(joint_module, num_fwd_outputs=num_fwd_outputs)
     )
     placeholders = joint_module.graph.find_nodes(op="placeholder")
     primal_inputs = [*filter(_is_primal, placeholders)]
-    tangent_inputs = [*filter(_is_tangent, placeholders)]
+    tangent_inputs = (
+        [] if omit_aot_autograd_runtime else [*filter(_is_tangent, placeholders)]
+    )
     fwd_seed_offset_inputs = [*filter(_is_fwd_seed_offset, placeholders)]
     bwd_seed_offset_inputs = [*filter(_is_bwd_seed_offset, placeholders)]
     backward_state_inputs = [*filter(_is_backward_state, placeholders)]
@@ -1003,6 +1021,7 @@ def _extract_fwd_bwd_modules(
         bwd_outputs,
         bwd_outputs_descs,
         "backward",
+        ignore_must_be_in_fw_bw=ignore_must_be_in_fw_bw,
     )
 
     distributed_enabled = torch.distributed.is_available()
@@ -1070,75 +1089,104 @@ def _extract_fwd_bwd_modules(
     saved_sym_nodes.clear()
     saved_sym_nodes.extend(saved_sym_nodes_binding + saved_sym_nodes_derived)
 
-    # See Note [Activations with no version counter checks in eager]
-    # Sort saved_values so that tensors with saved_tensor_with_no_vc_check=True
-    # are at the end. This allows us to have two consecutive slices:
-    # 1. tensors_saved_with_vc_check_slice - tensors saved via save_for_backward
-    # 2. tensors_saved_with_no_vc_check_slice - tensors stashed on ctx without save_for_backward
-    # The sort is stable, so the relative order within each group is preserved.
-    #
-    # Additionally, separate out opaque objects (FakeScriptObject) from tensors.
-    # Opaque objects should be placed after tensors in the forward outputs.
-    saved_values_with_vc_check = []
-    saved_values_no_vc_check = []
-    saved_opaque_objects = []
-    for node in saved_values:
-        # Check if this is an opaque object
-        if isinstance(node.meta.get("val"), FakeScriptObject):
-            saved_opaque_objects.append(node)
-        elif node.meta.get("saved_tensor_with_no_vc_check", False):
-            saved_values_no_vc_check.append(node)
-        else:
-            saved_values_with_vc_check.append(node)
-    saved_values.clear()
-    saved_values.extend(saved_values_with_vc_check + saved_values_no_vc_check)
-    no_vc_check_start_idx = len(saved_values_with_vc_check)
+    if not omit_aot_autograd_runtime:
+        # See Note [Activations with no version counter checks in eager]
+        # Sort saved_values so that tensors with saved_tensor_with_no_vc_check=True
+        # are at the end. This allows us to have two consecutive slices:
+        # 1. tensors_saved_with_vc_check_slice - tensors saved via save_for_backward
+        # 2. tensors_saved_with_no_vc_check_slice - tensors stashed on ctx without save_for_backward
+        # The sort is stable, so the relative order within each group is preserved.
+        #
+        # Additionally, separate out opaque objects (FakeScriptObject) from tensors.
+        # Opaque objects should be placed after tensors in the forward outputs.
+        saved_values_with_vc_check = []
+        saved_values_no_vc_check = []
+        saved_opaque_objects = []
+        for node in saved_values:
+            # Check if this is an opaque object
+            if isinstance(node.meta.get("val"), FakeScriptObject):
+                saved_opaque_objects.append(node)
+            elif node.meta.get("saved_tensor_with_no_vc_check", False):
+                saved_values_no_vc_check.append(node)
+            else:
+                saved_values_with_vc_check.append(node)
+        saved_values.clear()
+        saved_values.extend(saved_values_with_vc_check + saved_values_no_vc_check)
+        no_vc_check_start_idx = len(saved_values_with_vc_check)
 
-    # debug assert: given saved_values where the last k of them are expected to not
-    # require VC checks, they should all have node metadata indicating so.
-    for i, node in enumerate(saved_values):
-        if i >= no_vc_check_start_idx:
-            if not node.meta.get("saved_tensor_with_no_vc_check", False):
-                raise AssertionError(
-                    f"i={i}, no_vc_check_start_idx={no_vc_check_start_idx}, len(saved_values)={len(saved_values)}"
+        # debug assert: given saved_values where the last k of them are expected to not
+        # require VC checks, they should all have node metadata indicating so.
+        for i, node in enumerate(saved_values):
+            if i >= no_vc_check_start_idx:
+                if not node.meta.get("saved_tensor_with_no_vc_check", False):
+                    raise AssertionError(
+                        f"i={i}, no_vc_check_start_idx={no_vc_check_start_idx}, len(saved_values)={len(saved_values)}"
+                    )
+
+        # Now, we re-generate the fwd/bwd graphs.
+        # NB: This might increase compilation time, but I doubt it matters
+        # Convention for saved acts is (tensors_with_vc_check, tensors_no_vc_check, opaque_objects, symints)
+        fwd_graph = _extract_graph_with_inputs_outputs(
+            joint_module.graph,
+            primal_inputs + fwd_seed_offset_inputs,
+            fwd_outputs + saved_values + saved_opaque_objects + saved_sym_nodes,
+            fwd_outputs_descs
+            + [
+                SavedForBackwardsNoVcCheckAOTOutput(i)
+                if i >= no_vc_check_start_idx and i < len(saved_values)
+                else SavedForBackwardsAOTOutput(i)
+                for i in range(
+                    len(saved_values) + len(saved_opaque_objects) + len(saved_sym_nodes)
                 )
-
-    # Now, we re-generate the fwd/bwd graphs.
-    # NB: This might increase compilation time, but I doubt it matters
-    # Convention for saved acts is (tensors_with_vc_check, tensors_no_vc_check, opaque_objects, symints)
-    fwd_graph = _extract_graph_with_inputs_outputs(
-        joint_module.graph,
-        primal_inputs + fwd_seed_offset_inputs,
-        fwd_outputs + saved_values + saved_opaque_objects + saved_sym_nodes,
-        fwd_outputs_descs
-        + [
-            SavedForBackwardsNoVcCheckAOTOutput(i)
-            if i >= no_vc_check_start_idx and i < len(saved_values)
-            else SavedForBackwardsAOTOutput(i)
-            for i in range(
-                len(saved_values) + len(saved_opaque_objects) + len(saved_sym_nodes)
-            )
-        ],
-        "forward",
-    )
-    bwd_graph = _extract_graph_with_inputs_outputs(
-        joint_module.graph,
-        saved_sym_nodes
-        + saved_values
-        + saved_opaque_objects
-        + tangent_inputs
-        + bwd_seed_offset_inputs
-        + backward_state_inputs,
-        bwd_outputs,
-        bwd_outputs_descs,
-        "backward",
-    )
+            ],
+            "forward",
+            ignore_must_be_in_fw_bw=ignore_must_be_in_fw_bw,
+        )
+        bwd_graph = _extract_graph_with_inputs_outputs(
+            joint_module.graph,
+            saved_sym_nodes
+            + saved_values
+            + saved_opaque_objects
+            + tangent_inputs
+            + bwd_seed_offset_inputs
+            + backward_state_inputs,
+            bwd_outputs,
+            bwd_outputs_descs,
+            "backward",
+            ignore_must_be_in_fw_bw=ignore_must_be_in_fw_bw,
+        )
+    else:
+        # Raw fwd/bwd split for direct execution without autograd
+        fwd_graph = _extract_graph_with_inputs_outputs(
+            joint_module.graph,
+            primal_inputs + fwd_seed_offset_inputs,
+            fwd_outputs + saved_values + saved_sym_nodes,
+            fwd_outputs_descs
+            + [
+                SavedForBackwardsAOTOutput(i)
+                for i in range(len(saved_values) + len(saved_sym_nodes))
+            ],
+            "forward",
+            ignore_must_be_in_fw_bw=ignore_must_be_in_fw_bw,
+        )
+        bwd_graph = _extract_graph_with_inputs_outputs(
+            joint_module.graph,
+            saved_values
+            + saved_sym_nodes
+            + bwd_seed_offset_inputs
+            + backward_state_inputs,
+            bwd_outputs,
+            bwd_outputs_descs,
+            "backward",
+            ignore_must_be_in_fw_bw=ignore_must_be_in_fw_bw,
+        )
 
     fwd_module = fx._lazy_graph_module._make_graph_module(joint_module, fwd_graph)
     bwd_module = fx._lazy_graph_module._make_graph_module(joint_module, bwd_graph)
-    enable_activation_quantization(
-        saved_values, fwd_module, bwd_module, static_lifetime_input_nodes
-    )
+    if not omit_aot_autograd_runtime:
+        enable_activation_quantization(
+            saved_values, fwd_module, bwd_module, static_lifetime_input_nodes
+        )
     return fwd_module, bwd_module
 
 

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -938,14 +938,6 @@ def enable_activation_quantization(
     bwd_module: fx.GraphModule,
     static_lifetime_input_nodes: OrderedSet[fx.Node] | None = None,
 ) -> None:
-    if (
-        inductor_config.post_grad_fusion_options.get(
-            "activation_quantization_aten_pass", None
-        )
-        is None
-    ):
-        return
-
     static_input_names: list[str] = (
         [node.name for node in static_lifetime_input_nodes]
         if static_lifetime_input_nodes
@@ -1183,7 +1175,12 @@ def _extract_fwd_bwd_modules(
 
     fwd_module = fx._lazy_graph_module._make_graph_module(joint_module, fwd_graph)
     bwd_module = fx._lazy_graph_module._make_graph_module(joint_module, bwd_graph)
-    if not omit_aot_autograd_runtime:
+    if (
+        inductor_config.post_grad_fusion_options.get(
+            "activation_quantization_aten_pass", None
+        )
+        is not None
+    ):
         enable_activation_quantization(
             saved_values, fwd_module, bwd_module, static_lifetime_input_nodes
         )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #177205
* #177201
* __->__ #177058

Allows for better out of tree path splitting UX: https://github.com/meta-pytorch/autoparallel/pull/359.

Add two new keyword arguments to _extract_fwd_bwd_modules to support
callers that re-partition a backward graph (e.g. splitting into dI/dW
subgraphs for pipelined training):

- ignore_must_be_in_fw_bw: threads through to _extract_graph_with_inputs_outputs
  to disable forward/backward placement enforcement.
- omit_aot_autograd_runtime: skips tangent input handling, version-counter
  sorting, opaque object separation, and fp8 activation quantization —
  postprocessing only needed when wrapping in a custom autograd.Function.

Both default to False, so all existing callers are unaffected.

Test graphs:

bw_gm (full backward):
```python
def forward(self, primals_1, primals_2, not_tngnt_1):
    expand = torch.ops.aten.expand.default(not_tngnt_1, [4, 4]);  not_tngnt_1 = None
    t = torch.ops.aten.t.default(primals_1);  primals_1 = None
    mm_1 = torch.ops.aten.mm.default(t, expand);  t = None
    t_1 = torch.ops.aten.t.default(primals_2);  primals_2 = None
    mm_2 = torch.ops.aten.mm.default(expand, t_1);  expand = t_1 = None
    return (mm_2, mm_1)
```

di_mod (only grads wrt input activations):
```python
def forward(self, primals_1, primals_2, not_tngnt_1):
    expand = torch.ops.aten.expand.default(not_tngnt_1, [4, 4]);  not_tngnt_1 = None
    t_1 = torch.ops.aten.t.default(primals_2);  primals_2 = None
    mm_2 = torch.ops.aten.mm.default(expand, t_1);  t_1 = None
    return (mm_2, primals_1, expand)
```

dw_mod
```python
def forward(self, primals_1, expand):
    t = torch.ops.aten.t.default(primals_1);  primals_1 = None
    mm_1 = torch.ops.aten.mm.default(t, expand);  t = expand = None
    return (mm_1,)
```

Authored with Claude.