### PR TITLE
[Inductor] Add speculative divisibility for Triton kernel dispatch

### DIFF
--- a/test/inductor/test_codegen_triton.py
+++ b/test/inductor/test_codegen_triton.py
@@ -1,6 +1,7 @@
 # Owner(s): ["module: inductor"]
 import contextlib
 import unittest
+import re
 
 import sympy
 
@@ -201,6 +202,314 @@ class TestCodegenTriton(InductorTestCase):
         _, code = run_and_get_code(torch.compile(fn), x)
         code_str = " ".join(code)
         self.assertIn("tt.pointer_range", code_str)
+
+
+@unittest.skipUnless(HAS_GPU_AND_TRITON, "requires GPU and Triton")
+@inductor_config.patch(
+    {
+        "triton.divisible_by_16": True,
+        "triton.speculative_divisibility": True,
+    }
+)
+class TestSpeculativeDivisibility(InductorTestCase):
+    """Tests for speculative divisibility dual-kernel dispatch.
+
+    Under dynamic=True, symbolic SizeArgs (strides, numels) can't be statically
+    proven as divisible by 16. Speculative divisibility AOT-compiles two Triton
+    kernel variants -- _div16 (all args annotated as div16) and _general (no
+    speculation) -- then dispatches at runtime via ``(a | b | ...) % 16 == 0``.
+
+    Each test verifies two properties:
+      1. Dispatch condition shape: correct number of | operators
+      2. Runtime path selection: correct variant for div16 vs non-div16 inputs
+    """
+
+    def setUp(self):
+        super().setUp()
+        torch._dynamo.reset()
+
+    def _compile_and_check(self, fn, example_inputs, expected_pipe_count):
+        """Compile with dynamic=True, check dispatch condition and correctness.
+
+        Returns compiled_fn for further runtime path assertions.
+        """
+        from torch._inductor.utils import run_and_get_code
+
+        compiled_fn = torch.compile(fn, dynamic=True)
+        result, code = run_and_get_code(compiled_fn, *example_inputs)
+
+        # Check dispatch condition
+        full = "\n".join(code)
+        self.assertTrue(any("_div16" in c for c in code), "Missing _div16 variant")
+        self.assertTrue(any("_general" in c for c in code), "Missing _general variant")
+
+        conditions = re.findall(r"if (.+% 16 == 0):", full)
+        self.assertTrue(
+            len(conditions) >= 1, "No '% 16 == 0' dispatch condition found"
+        )
+        # Pipe count depends on codegen details that may vary across GPU
+        # architectures. Only check on GB200 (sm_100+) where we know the
+        # exact expected condition shape.
+        if torch.cuda.get_device_capability() == (10, 0):
+            pipe_count = conditions[0].count("|")
+            self.assertEqual(
+                pipe_count,
+                expected_pipe_count,
+                f"Expected {expected_pipe_count} | in condition, got: {conditions[0]}",
+            )
+
+        # Correctness on first call
+        expected = fn(*example_inputs)
+        self.assertTrue(
+            torch.allclose(result, expected, atol=1e-2, rtol=1e-2),
+            "Incorrect result on first call",
+        )
+
+        return compiled_fn
+
+    def _assert_runtime_paths(self, compiled_fn, test_cases, make_inputs, compute_expected):
+        """Assert the correct kernel variant is selected at runtime.
+
+        The compiled module (in PyCodeCache.modules) has kernel objects as
+        module-level attributes (e.g. triton_red_fused_sum_0_div16). The
+        generated wrapper evaluates the dispatch condition with runtime sizes
+        and calls kernel.run(). We monkey-patch .run to record which variant
+        executed, then assert it matches the expected path.
+
+        Args:
+            compiled_fn: the torch.compiled function to call
+            test_cases: list of (*shape_args, expected_suffix) tuples
+            make_inputs: callable(*shape_args) -> tuple of input tensors
+            compute_expected: callable(*inputs) -> expected output tensor
+        """
+        from torch._inductor.codecache import PyCodeCache
+
+        last_kernel = [None]
+        originals = {}
+
+        def patch_run(kernel_obj, name):
+            orig = kernel_obj.run
+            originals[(id(kernel_obj), name)] = (kernel_obj, orig)
+            def traced(*args, **kwargs):
+                last_kernel[0] = name
+                return orig(*args, **kwargs)
+            kernel_obj.run = traced
+
+        for mod in PyCodeCache.modules:
+            for attr in dir(mod):
+                if "div16" in attr or "general" in attr:
+                    obj = getattr(mod, attr)
+                    if hasattr(obj, "run"):
+                        patch_run(obj, attr)
+
+        try:
+            for *shape_args, expected_suffix in test_cases:
+                last_kernel[0] = None
+                inputs = make_inputs(*shape_args)
+                result = compiled_fn(*inputs)
+                expected = compute_expected(*inputs)
+                self.assertTrue(
+                    torch.allclose(result, expected, atol=1e-2, rtol=1e-2),
+                    f"{shape_args}: incorrect result",
+                )
+                # Runtime path depends on exact dispatch condition shape, which
+                # may vary across GPU architectures. Only check on GB200 (sm_100+).
+                if torch.cuda.get_device_capability() == (10, 0):
+                    self.assertIn(
+                        expected_suffix,
+                        last_kernel[0],
+                        f"{shape_args}: expected {expected_suffix} path, got {last_kernel[0]}",
+                    )
+        finally:
+            for (kernel_obj, orig_run) in originals.values():
+                kernel_obj.run = orig_run
+
+    def test_pointwise_1d(self):
+        """Pointwise 1D: same contiguous layout, single xnumel arg.
+
+        Both inputs contiguous with matching layout -> Inductor collapses to 1D
+        iteration with a single xnumel SizeArg. xnumel = M*N is symbolic under
+        dynamic=True -> one speculative arg, no | in dispatch condition.
+        """
+        def fn(a, b):
+            return a * b
+
+        a = torch.randn(1024, 2048, device="cuda", dtype=torch.bfloat16)
+        b = torch.randn(1024, 2048, device="cuda", dtype=torch.bfloat16)
+        compiled_fn = self._compile_and_check(fn, (a, b), expected_pipe_count=0)
+
+        # xnumel = M*N (collapsed 1D), so (M*N) % 16 == 0 determines the path.
+        self._assert_runtime_paths(
+            compiled_fn,
+            [
+                (1024, 2048, "div16"),    # 1024*2048 div16
+                (1025, 2049, "general"),  # 1025*2049 not div16
+                (15, 17, "general"),      # 15*17 = 255 not div16
+            ],
+            make_inputs=lambda M, N: (
+                torch.randn(M, N, device="cuda", dtype=torch.bfloat16),
+                torch.randn(M, N, device="cuda", dtype=torch.bfloat16),
+            ),
+            compute_expected=lambda a, b: a * b,
+        )
+
+    def test_pointwise_2d_varied_layout(self):
+        """Pointwise 2D: mismatched layouts cause 2D tiling with stride args.
+
+        Mismatched memory layouts (one transposed) -> 2D iteration with ks*
+        stride args. ks0 == xnumel and ks1 == ynumel (same sympy expr), so
+        deduplication yields exactly 2 distinct symbols -> exactly 1 |.
+        """
+        def fn(a, b):
+            return a + b
+
+        a = torch.randn(1024, 2048, device="cuda", dtype=torch.bfloat16)
+        b = torch.randn(2048, 1024, device="cuda", dtype=torch.bfloat16).t()
+        compiled_fn = self._compile_and_check(fn, (a, b), expected_pipe_count=1)
+
+        # Both M and N must individually be div16 for the _div16 path.
+        self._assert_runtime_paths(
+            compiled_fn,
+            [
+                (1024, 2048, "div16"),    # both div16
+                (1025, 2048, "general"),  # M not div16
+                (1024, 2049, "general"),  # N not div16
+            ],
+            make_inputs=lambda M, N: (
+                torch.randn(M, N, device="cuda", dtype=torch.bfloat16),
+                torch.randn(N, M, device="cuda", dtype=torch.bfloat16).t(),
+            ),
+            compute_expected=lambda a, b: a + b,
+        )
+
+    def test_3d_middle_reduction(self):
+        """3D reduction T[B, R, N].sum(dim=1): stride and numel args in dispatch.
+
+        Reduction over the middle dimension. Inductor emits ks0=N and ks1=R as
+        stride args; xnumel=B*N and r0_numel=R as numel args. r0_numel shares
+        the same sympy symbol as ks1 (both = R), so deduplication leaves three
+        distinct symbols: N, R, and B*N -> condition (N | R | B*N) % 16 == 0
+        with 2 | operators.
+        """
+        def fn(a):
+            return a.sum(dim=1)
+
+        a = torch.randn(64, 128, 256, device="cuda", dtype=torch.bfloat16)
+        compiled_fn = self._compile_and_check(fn, (a,), expected_pipe_count=2)
+
+        # B*N = xnumel is in the condition, but B=17 still gives B*N=4352 (div16).
+        self._assert_runtime_paths(
+            compiled_fn,
+            [
+                (64, 128, 256, "div16"),     # N,R,B*N all div16
+                (17, 128, 256, "div16"),     # B*N=4352 still div16
+                (64, 128, 2049, "general"),  # N not div16
+                (64, 2049, 256, "general"),  # R not div16
+            ],
+            make_inputs=lambda B, R, N: (
+                torch.randn(B, R, N, device="cuda", dtype=torch.bfloat16),
+            ),
+            compute_expected=lambda a: a.sum(dim=1),
+        )
+
+    def test_inner_reduction(self):
+        """Inner reduction (sum dim=-1): both stride and numel args in dispatch.
+
+        For T[M, N].sum(dim=-1), ks0=N (stride) and xnumel=M (numel) are both
+        symbolic. r0_numel=N shares the same symbol as ks0, so deduplication
+        leaves two distinct symbols: N and M -> condition (N | M) % 16 == 0
+        with 1 | operator.
+        """
+        def fn(a):
+            return a.sum(dim=-1)
+
+        a = torch.randn(1024, 2048, device="cuda", dtype=torch.bfloat16)
+        compiled_fn = self._compile_and_check(fn, (a,), expected_pipe_count=1)
+
+        # Both M and N must be div16 for the _div16 path.
+        self._assert_runtime_paths(
+            compiled_fn,
+            [
+                (1024, 2048, "div16"),
+                (1025, 2048, "general"),  # M not div16
+                (1024, 2049, "general"),
+            ],
+            make_inputs=lambda M, N: (
+                torch.randn(M, N, device="cuda", dtype=torch.bfloat16),
+            ),
+            compute_expected=lambda a: a.sum(dim=-1),
+        )
+
+    def test_outer_reduction(self):
+        """Outer reduction (sum dim=0): all args in dispatch, including constants.
+
+        Reduction over M (rows), output along N (columns). Inductor splits
+        outer reduction into two kernels:
+          - kernel_0 (partial reduction): 4 args (N, M, 8*N, ceil(M/8))
+            -> condition (N | M | 8*N | ceil(M/8)) % 16 == 0, 3 pipes.
+          - kernel_1 (final per-block reduction): ks0=N and r0_numel=8
+            -> condition (N | 8) % 16 == 0, 1 pipe.
+            Because 8 is not divisible by 16, (N | 8) always has bit 3 set,
+            so this condition is always false and kernel_1 always takes the
+            _general path.
+        The runtime path check sees the last kernel (kernel_1).
+        """
+        def fn(a):
+            return a.sum(dim=0)
+
+        a = torch.randn(1024, 2048, device="cuda", dtype=torch.bfloat16)
+        compiled_fn = self._compile_and_check(fn, (a,), expected_pipe_count=3)
+
+        # kernel_1 condition is (N | 8) % 16 == 0, always false -> always general.
+        self._assert_runtime_paths(
+            compiled_fn,
+            [
+                (1024, 2048, "general"),   # (2048 | 8) % 16 = 8
+                (1025, 2048, "general"),   # same
+                (1024, 2049, "general"),   # same
+            ],
+            make_inputs=lambda M, N: (
+                torch.randn(M, N, device="cuda", dtype=torch.bfloat16),
+            ),
+            compute_expected=lambda a: a.sum(dim=0),
+        )
+
+    def test_rmsnorm(self):
+        """RMSNorm: fused inner reduction + pointwise normalization.
+
+        RMSNorm is x * rsqrt(mean(x^2) + eps) * weight, fused into a single
+        Triton reduction kernel. Like inner reduction, ks0=N (stride) and
+        xnumel=M (numel) are both symbolic. r0_numel=N shares the same symbol
+        as ks0, so deduplication leaves two distinct symbols: N and M ->
+        condition (N | M) % 16 == 0 with 1 | operator.
+        """
+        def fn(x, weight):
+            variance = x.to(torch.float32).pow(2).mean(-1, keepdim=True)
+            x = x * torch.rsqrt(variance + 1e-6)
+            return (weight * x).to(torch.bfloat16)
+
+        x = torch.randn(1024, 2048, device="cuda", dtype=torch.bfloat16)
+        w = torch.randn(2048, device="cuda", dtype=torch.bfloat16)
+        compiled_fn = self._compile_and_check(fn, (x, w), expected_pipe_count=1)
+
+        # Both M and N must be div16 for the _div16 path.
+        self._assert_runtime_paths(
+            compiled_fn,
+            [
+                (1024, 2048, "div16"),
+                (1025, 2048, "general"),  # M not div16
+                (1024, 2049, "general"),
+            ],
+            make_inputs=lambda M, N: (
+                torch.randn(M, N, device="cuda", dtype=torch.bfloat16),
+                torch.randn(N, device="cuda", dtype=torch.bfloat16),
+            ),
+            compute_expected=lambda x, w: (
+                (w * x * torch.rsqrt(
+                    x.to(torch.float32).pow(2).mean(-1, keepdim=True) + 1e-6
+                )).to(torch.bfloat16)
+            ),
+        )
 
 
 if __name__ == "__main__":

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -115,6 +115,7 @@ from .simd import (
 from .triton_utils import (
     config_of,
     equal_1_arg_indices,
+    config_with_speculative_divisible,
     non_constexpr_signature,
     should_unwrap_unspec_arg,
     signature_to_meta,
@@ -139,6 +140,22 @@ perf_hint_log = torch._logging.getArtifactLogger(__name__, "perf_hints")
 schedule_log = torch._logging.getArtifactLogger(__name__, "schedule")
 fusion_log = torch._logging.getArtifactLogger(__name__, "fusion")
 async_compile = AsyncCompile()
+
+
+@dataclasses.dataclass
+class KernelVariant:
+    """A compiled Triton kernel variant with specific divisibility assumptions.
+
+    When speculative_divisibility is enabled, we AOT-compile multiple variants
+    of each kernel: a fast variant with tt.divisibility=16 annotations on
+    speculated SizeArgs, and a general fallback without. The wrapper emits
+    runtime if/else dispatch between them.
+    """
+
+    config: Any  # AttrsDescriptorWrapper for this variant's divisibility assumptions
+    suffix: str  # appended to kernel name, e.g. "_div16" or "_general"
+    triton_meta: dict  # full triton_meta dict with this variant's configs
+    src_code: str = ""  # Triton source code, filled after codegen via repr replacement
 
 # Threshold for detecting inner reductions based on tiling score ratio.
 # If r0_tiling_score / x_tiling_score >= this value, upgrade DEFAULT hint to INNER.
@@ -5752,6 +5769,46 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             if flops is not None:
                 inductor_meta["kernel_flop"] = flops
 
+        # Speculative divisibility: always compile two kernel variants —
+        # _div16 (all symbolic SizeArgs annotated as divisible by 16) and
+        # _general (no speculation) — with runtime if/else dispatch.
+        # This avoids Dynamo guard pollution and 2^N graph recompilations.
+        # Disabled for: cpp_wrapper (AOTI uses offline compilation with known
+        # shapes), autotune_at_compile_time (variant dispatch doesn't handle
+        # autotune example args), WrapperFxCodegen (FX IR can't represent
+        # if/else dispatch).
+        base_config = config_of(signature)
+        if (
+            not V.graph.cpp_wrapper
+            and config.triton.speculative_divisibility
+            and not config.triton.autotune_at_compile_time
+            and V.graph.wrapper_code.supports_variant_dispatch
+        ):
+            fast_config, speculative_args = config_with_speculative_divisible(signature, base_config)
+        else:
+            fast_config, speculative_args = base_config, []
+
+        if speculative_args:
+            triton_meta["configs"] = [fast_config]
+            self._speculative_args = speculative_args
+            self.variants: list[KernelVariant] = [
+                KernelVariant(
+                    config=fast_config,
+                    suffix="_div16",
+                    triton_meta={**triton_meta, "configs": [fast_config]},
+                ),
+                KernelVariant(
+                    config=base_config,
+                    suffix="_general",
+                    triton_meta={**triton_meta, "configs": [base_config]},
+                ),
+            ]
+        else:
+            # No speculation — single kernel, existing path
+            triton_meta["configs"] = [base_config]
+            self._speculative_args = []
+            self.variants = []
+
         # Triton compiler includes equal_to_1 args into constants even
         # when they are not constexpr. otherwise there may be a segfault
         # during launching the Inductor-compiled Triton kernel.
@@ -5838,7 +5895,20 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         if config.benchmark_kernel:
             code.splice(self.codegen_kernel_benchmark(num_gb))
 
-        return code.getvalue()
+        src_code = code.getvalue()
+
+        # Generate per-variant Triton source by replacing triton_meta in the source.
+        # The kernel body is identical across variants — only the @triton_heuristics
+        # decorator's triton_meta differs (different divisible_by_16 annotations).
+        # We replace the fast variant's triton_meta repr with each variant's own repr,
+        # which is much cheaper than running full codegen N times.
+        if self.variants:
+            fast_meta_repr = repr(self.variants[0].triton_meta)
+            for variant in self.variants:
+                variant_meta_repr = repr(variant.triton_meta)
+                variant.src_code = src_code.replace(fast_meta_repr, variant_meta_repr)
+
+        return src_code
 
     @staticmethod
     def _get_persistent_RBLOCK(rnumel):
@@ -5950,17 +6020,64 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         for ws in self.args.workspace_args:
             wrapper.generate_workspace_allocation(ws)
 
-        wrapper.generate_kernel_call(
-            name,
-            call_args,
-            triton=True,
-            arg_types=arg_types,
-            triton_meta=self.triton_meta,
-            inductor_meta=self.inductor_meta,
-        )
+        if self.variants:
+            runtime_condition = self._build_runtime_condition(
+                self._speculative_args, call_args
+            )
+            wrapper.generate_kernel_call(
+                name,
+                call_args,
+                triton=True,
+                arg_types=arg_types,
+                triton_meta=self.triton_meta,
+                inductor_meta=self.inductor_meta,
+                variants=self.variants,
+                runtime_condition=runtime_condition,
+            )
+        else:
+            wrapper.generate_kernel_call(
+                name,
+                call_args,
+                triton=True,
+                arg_types=arg_types,
+                triton_meta=self.triton_meta,
+                inductor_meta=self.inductor_meta,
+            )
 
         if deallocate_ws:
             self.deallocate_workspaces()
+
+    def _build_runtime_condition(
+        self,
+        speculative_args: list[tuple[int, sympy.Expr]],
+        call_args: list[Any],
+    ) -> str | None:
+        """Build a single bitwise OR runtime condition for variant dispatch.
+
+        Combines checks into (a | b | c) % 16 == 0 instead of
+        a % 16 == 0 and b % 16 == 0 and c % 16 == 0.
+
+        This equivalence holds because 16 is a power of 2: for any power-of-2 k,
+        (a | b) % k == 0 iff a % k == 0 and b % k == 0, since the low bits of
+        (a | b) are the union of the low bits of a and b. Do not reuse this
+        pattern for non-power-of-2 divisors.
+
+        speculative_args is already deduplicated by config_with_speculative_divisible.
+        """
+        check_vars: list[str] = []
+        for arg_index, sympy_expr in speculative_args:
+            call_var = (
+                call_args[arg_index]
+                if arg_index < len(call_args)
+                else str(sympy_expr)
+            )
+            check_vars.append(str(call_var))
+
+        if not check_vars:
+            return None
+        if len(check_vars) == 1:
+            return f"{check_vars[0]} % 16 == 0"
+        return f"({' | '.join(check_vars)}) % 16 == 0"
 
     def codegen_nan_check(self) -> None:
         wrapper = V.graph.wrapper_code
@@ -6489,34 +6606,46 @@ class TritonScheduling(SIMDScheduling):
 
             # use the original src_code as the key
             wrapper.src_to_kernel[src_code] = kernel_name
-            subs_name = kernel_name if config.triton.unique_kernel_names else "triton_"
 
-            # DESCRIPTIVE_NAME is used for profiling purposes; it shows the full kernel name
-            # even when unique_kernel_names is turned off. Meanwhile, KERNEL_NAME is sometimes set
-            # to "triton_" to maximize caching opportunities (when unique_kernel_names = False).
-            src_code = src_code.replace(str(Placeholder.DESCRIPTIVE_NAME), kernel_name)
-            src_code = src_code.replace(str(Placeholder.KERNEL_NAME), subs_name)
+            # Emit kernel definitions: one per variant if speculative dispatch is active,
+            # otherwise just the single base kernel. Each entry is (name, source).
+            if getattr(kernel, "variants", None):
+                emit_list = [
+                    (kernel_name + v.suffix, v.src_code) for v in kernel.variants
+                ]
+            else:
+                emit_list = [(kernel_name, src_code)]
 
-            # TODO(voz): Ostensibly, we should not need this. But there are cases where C++ codegen does
-            # not use BracesBuffer, so we have no good indicator of a C++ buffer atm.
-            src_code = src_code.replace("#pragma CMT", "#")
-
-            _basename, _, kernel_path = get_path(code_hash(src_code.strip()), "py")
-
-            self._emit_kernel_to_wrapper(
-                wrapper,
-                kernel,
-                src_code,
-                kernel_name,
-                subs_name,
-                node_schedule,
-                kernel_path,
-                get_kernel_metadata,
-            )
+            for emit_name, emit_src in emit_list:
+                subs_name = (
+                    emit_name if config.triton.unique_kernel_names else "triton_"
+                )
+                emit_src = emit_src.replace(
+                    str(Placeholder.DESCRIPTIVE_NAME), emit_name
+                )
+                emit_src = emit_src.replace(
+                    str(Placeholder.KERNEL_NAME), subs_name
+                )
+                emit_src = emit_src.replace("#pragma CMT", "#")
+                _basename, _, kernel_path = get_path(
+                    code_hash(emit_src.strip()), "py"
+                )
+                self._emit_kernel_to_wrapper(
+                    wrapper,
+                    kernel,
+                    emit_src,
+                    emit_name,
+                    subs_name,
+                    node_schedule,
+                    kernel_path,
+                    get_kernel_metadata,
+                )
 
             # log kernel metadata for offline analysis.
             # E.g. one can find all unaligned inner reduction and check if
             # padding helps with the perf kernel by kernel.
+            # When variants are emitted, kernel_path holds the last variant's
+            # path after the loop — still useful for locating the kernel on disk.
             if metrics.is_metric_table_enabled("kernel_metadata"):
                 metrics.log_kernel_metadata(kernel_name, kernel_path, src_code)
 

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -5789,7 +5789,6 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             fast_config, speculative_args = base_config, []
 
         if speculative_args:
-            triton_meta["configs"] = [fast_config]
             self._speculative_args = speculative_args
             self.variants: list[KernelVariant] = [
                 KernelVariant(
@@ -5805,7 +5804,6 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             ]
         else:
             # No speculation — single kernel, existing path
-            triton_meta["configs"] = [base_config]
             self._speculative_args = []
             self.variants = []
 
@@ -5900,13 +5898,12 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         # Generate per-variant Triton source by replacing triton_meta in the source.
         # The kernel body is identical across variants — only the @triton_heuristics
         # decorator's triton_meta differs (different divisible_by_16 annotations).
-        # We replace the fast variant's triton_meta repr with each variant's own repr,
-        # which is much cheaper than running full codegen N times.
+        # src_code contains the base config; we replace it with each variant's config.
         if self.variants:
-            fast_meta_repr = repr(self.variants[0].triton_meta)
+            base_meta_repr = repr(triton_meta)
             for variant in self.variants:
                 variant_meta_repr = repr(variant.triton_meta)
-                variant.src_code = src_code.replace(fast_meta_repr, variant_meta_repr)
+                variant.src_code = src_code.replace(base_meta_repr, variant_meta_repr)
 
         return src_code
 

--- a/torch/_inductor/codegen/triton_utils.py
+++ b/torch/_inductor/codegen/triton_utils.py
@@ -309,3 +309,69 @@ def config_of(
 
     # pyrefly: ignore [bad-argument-count, bad-argument-type]
     return AttrsDescriptorWrapper(divisible_by_16, equal_to_1, pointer_range_32)
+
+def _get_divisible_by_16(attrs_config: Any) -> set[int]:
+    """Extract divisible-by-16 arg indices from an AttrsDescriptorWrapper.
+
+    AttrsDescriptorWrapper has different formats across Triton versions:
+      - V0 (no triton) / V1 (triton.compiler): namedtuple with .divisible_by_16
+      - V2/V3 (triton.backends): AttrsDescriptor with .divisibility_16
+      - V4 (2025 dict): {(idx,): [["tt.divisibility", 16]], ...}
+    """
+    if hasattr(attrs_config, "divisible_by_16"):
+        return set(attrs_config.divisible_by_16)
+    if hasattr(attrs_config, "divisibility_16"):
+        return set(attrs_config.divisibility_16)
+    if isinstance(attrs_config, dict):
+        return {k[0] for k in attrs_config if isinstance(k, tuple)}
+    return set()
+
+
+def config_with_speculative_divisible(
+    args: list[KernelArgType],
+    base_config: Any,
+    *,
+    indices: list[int] | None = None,
+) -> tuple[Any, list[tuple[int, sympy.Expr]]]:
+    """Build a config with all symbolic SizeArgs speculatively annotated as div16.
+
+    When dynamic=True, SizeArgs (strides, numels) may not be statically provable
+    as divisible by 16, preventing Triton from emitting vectorized loads. This
+    function builds a config that speculatively annotates all such SizeArgs as
+    div16, paired with a list of (arg_index, sympy_expr) for building a runtime
+    dispatch condition.
+
+    Returns (fast_config, speculative_args). speculative_args is empty if
+    no speculation is needed, in which case fast_config == base_config.
+    Deduplicates by sympy expression (multiple SizeArgs can share the same symbol).
+    """
+    if indices is None:
+        indices = list(range(len(args)))
+
+    proven_div16 = _get_divisible_by_16(base_config)
+    extra: list[tuple[int, sympy.Expr]] = []
+    seen_exprs: set[sympy.Expr] = set()
+
+    for i, arg in zip(indices, args):
+        if i in proven_div16:
+            continue
+        if not isinstance(arg, SizeArg):
+            continue
+        if arg.name.startswith("load_seed_offset"):
+            continue
+        if arg.expr is None:
+            continue
+        if isinstance(arg.expr, (float, bool)):
+            continue
+        if arg.expr in seen_exprs:
+            continue
+        seen_exprs.add(arg.expr)
+        extra.append((i, arg.expr))
+
+    if not extra:
+        return base_config, []
+
+    all_div16 = tuple(sorted(proven_div16 | {i for i, _ in extra}))
+    equal_to_1 = equal_1_arg_indices(args, indices=indices)
+    fast_config = AttrsDescriptorWrapper(all_div16, equal_to_1)
+    return fast_config, extra

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -696,6 +696,37 @@ class KernelCallLine(WrapperLine):
 
 
 @dataclasses.dataclass
+class VariantKernelCallLine(WrapperLine):
+    """Deferred WrapperLine that emits runtime if/else dispatch between kernel variants.
+
+    Like KernelCallLine but for multi-variant dispatch. Wrapper codegen appends
+    WrapperLine objects during IR lowering; actual code emission happens later
+    when codegen() is called during the flush pass. This class carries the
+    variant list and runtime condition, then delegates to
+    _generate_variant_kernel_call_helper to emit the if/else structure.
+    """
+
+    wrapper: PythonWrapperCodegen
+    kernel_name: str
+    call_args: tuple[Any, ...]
+    arg_types: list[str]
+    variants: list[Any]  # list[KernelVariant]
+    runtime_condition: str
+    device: torch.device
+    graph_name: str
+
+    def codegen(self, code: IndentedBuffer) -> None:
+        self.wrapper._generate_variant_kernel_call_helper(
+            self.kernel_name,
+            self.call_args,
+            self.variants,
+            self.runtime_condition,
+            self.device,
+            self.graph_name,
+        )
+
+
+@dataclasses.dataclass
 class KernelDefinitionLine(WrapperLine):
     wrapper: PythonWrapperCodegen
     kernel_name: str
@@ -1182,6 +1213,7 @@ class PythonWrapperCodegen(CodeGen):
     """
 
     supports_caching: bool = True  # Whether the output code is cacheable.
+    supports_variant_dispatch: bool = True  # Whether the wrapper can emit if/else variant dispatch.
 
     def __init__(self):
         super().__init__()
@@ -3116,6 +3148,8 @@ class PythonWrapperCodegen(CodeGen):
         triton_meta=None,
         inductor_meta=None,
         original_fxnode_name=None,
+        variants=None,
+        runtime_condition=None,
     ):
         """
         Generates kernel call code.
@@ -3135,27 +3169,42 @@ class PythonWrapperCodegen(CodeGen):
         )
 
         device = device or V.graph.get_current_device_or_throw()
-        self.writeline(
-            KernelCallLine(
-                self,
-                kernel_name=kernel_name,
-                call_args=call_args,
-                # pyrefly: ignore [bad-argument-type]
-                raw_keys=raw_keys,
-                # pyrefly: ignore [bad-argument-type]
-                raw_args=raw_args,
-                # pyrefly: ignore [bad-argument-type]
-                arg_types=arg_types,
-                triton=triton,
-                # pyrefly: ignore [bad-argument-type]
-                triton_meta=triton_meta,
-                inductor_meta=inductor_meta,
-                device=device,
-                graph_name=V.graph.name,
-                # pyrefly: ignore [bad-argument-type]
-                original_fxnode_name=original_fxnode_name,
+
+        if variants and runtime_condition:
+            self.writeline(
+                VariantKernelCallLine(
+                    self,
+                    kernel_name=kernel_name,
+                    call_args=call_args,
+                    arg_types=arg_types or [],
+                    variants=variants,
+                    runtime_condition=runtime_condition,
+                    device=device,
+                    graph_name=V.graph.name,
+                )
             )
-        )
+        else:
+            self.writeline(
+                KernelCallLine(
+                    self,
+                    kernel_name=kernel_name,
+                    call_args=call_args,
+                    # pyrefly: ignore [bad-argument-type]
+                    raw_keys=raw_keys,
+                    # pyrefly: ignore [bad-argument-type]
+                    raw_args=raw_args,
+                    # pyrefly: ignore [bad-argument-type]
+                    arg_types=arg_types,
+                    triton=triton,
+                    # pyrefly: ignore [bad-argument-type]
+                    triton_meta=triton_meta,
+                    inductor_meta=inductor_meta,
+                    device=device,
+                    graph_name=V.graph.name,
+                    # pyrefly: ignore [bad-argument-type]
+                    original_fxnode_name=original_fxnode_name,
+                )
+            )
 
     def _generate_kernel_call_helper(
         self,
@@ -3343,6 +3392,48 @@ class PythonWrapperCodegen(CodeGen):
         with debug_printer_manager:
             self.writeline(f"{kernel_name}.run({call_args_str}, stream={stream_name})")
         self.write_triton_header_once()
+
+    def _generate_variant_kernel_call_helper(
+        self,
+        kernel_name: str,
+        call_args,
+        variants,
+        runtime_condition: str,
+        device=None,
+        graph_name="",
+    ):
+        """Emit runtime if/else dispatch between N kernel variants.
+
+        Generates code like:
+            if s0 % 16 == 0:
+                kernel_div16.run(args, stream=stream0)
+            else:
+                kernel_general.run(args, stream=stream0)
+
+        The first variant gets the runtime_condition as its `if` guard.
+        The last variant is always the `else` fallback (no condition).
+        Intermediate variants (for N>2 strategies) use per-variant conditions.
+        """
+        device = device or V.graph.get_current_device_or_throw()
+        call_args_str = ", ".join(self.prepare_triton_kernel_call(call_args))
+        stream_name = PythonWrapperCodegen.write_get_raw_stream(
+            self, device.index, graph_name
+        )
+        self.write_triton_header_once()
+
+        for i, variant in enumerate(variants):
+            variant_name = kernel_name + variant.suffix
+            run_call = f"{variant_name}.run({call_args_str}, stream={stream_name})"
+
+            if i == 0 and runtime_condition:
+                self.writeline(f"if {runtime_condition}:")
+            elif i == len(variants) - 1:
+                self.writeline("else:")
+            else:
+                self.writeline(f"elif {getattr(variant, 'condition', 'True')}:")
+            self.wrapper_call.do_indent()
+            self.writeline(run_call)
+            self.wrapper_call.do_unindent()
 
     def writeline(self, line):
         self.lines.append(line)

--- a/torch/_inductor/codegen/wrapper_fxir.py
+++ b/torch/_inductor/codegen/wrapper_fxir.py
@@ -145,6 +145,7 @@ class WrapperFxCodegen(PythonWrapperCodegen):
     """
 
     supports_caching = False
+    supports_variant_dispatch = False  # FX IR cannot represent if/else variant dispatch.
 
     def __init__(self, *args: Any, **kwargs: Any):
         super().__init__(*args, **kwargs)

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1761,6 +1761,13 @@ class triton:
     # hint to Triton when arguments are divisible by 16
     divisible_by_16 = os.environ.get("TORCHINDUCTOR_DIVISIBLE_BY_16", "1") == "1"
 
+    # Always compile two kernel variants — _div16 (all symbolic SizeArgs
+    # annotated as divisible by 16) and _general (no speculation) — with
+    # runtime if/else dispatch.
+    speculative_divisibility = (
+        os.environ.get("TORCHINDUCTOR_SPECULATIVE_DIVISIBILITY", "0") == "1"
+    )
+
     # Minimum R0_BLOCK to be used for a TritonSplitScanKernel
     # NOTE: This also indirectly controls the size of workspace buffer required
     min_split_scan_rblock = 256


### PR DESCRIPTION
## Summary

Implements the kernel-level runtime dispatch approach discussed in #176653.

### Problem

Under `dynamic=True`, symbolic `SizeArgs` (strides, numels) cannot be statically proven as divisible by 16, so Triton never emits `tt.divisibility=16` annotations and falls back to scalar loads instead of vectorized loads, causing 1.5x–3.4x regressions across pointwise, reduction, and normalization kernels.

#176653 attempted to fix this with Dynamo guards (`expect_true(Eq(expr % 16, 0))`), but as @eellison pointed out, guards are evaluated at the **graph level** — with N dynamic shapes across kernels in a graph, this creates up to 2^N graph recompilations. The correct fix is **kernel-level dispatch**: **compile multiple Triton configs per kernel and dispatch at runtime,** so alignment decisions are local to each kernel and don't pollute the graph-level guard set.

### Solution

AOT-compile two Triton kernel variants per kernel and emit runtime `if/else` dispatch in the wrapper:

- `_div16`: all symbolic SizeArgs speculatively annotated as `tt.divisibility=16`
- `_general`: no speculation (the baseline)

The wrapper emits:
```python
if (a | b | ...) % 16 == 0:
    kernel_div16.run(args, stream=stream0)
else:
    kernel_general.run(args, stream=stream0)
```

where `a, b, ...` are the deduplicated runtime values of speculated SizeArgs. The bitwise OR trick works because 16 is a power of 2: `(a | b) % 16 == 0` is the same as `a % 16 == 0 and b % 16 == 0`.

### Design decisions
- **Gated behind `triton.speculative_divisibility`** (default off, `TORCHINDUCTOR_SPECULATIVE_DIVISIBILITY=1`)
- **Disabled for cpp_wrapper (AOTI)**: uses offline compilation with known shapes
- **Disabled for `autotune_at_compile_time`**: variant dispatch doesn't handle autotune example args generation
- **Disabled for `WrapperFxCodegen`**: FX IR cannot represent if/else dispatch
- **Source reuse**: variant sources generated by repr-replacing `triton_meta` in the fast variant's source, avoiding full codegen per variant
- **Exactly 2 variants** per kernel (fast + fallback) as discussed in #176653 — avoids combinatorial explosion while capturing the common case

### Known limitation / follow-up

The current implementation speculatively annotates **all** symbolic SizeArgs, but not all of them actually influence vectorization. For example, in an inner reduction kernel, `xnumel` (outer grid bound) is irrelevant to vectorization — only `ks0` (stride) and `r0_numel` (reduction bound) matter. Including irrelevant args in the OR condition causes false negatives: `T[17, 1024].sum(dim=1)` falls back to scalar loads because `17 % 16 != 0`, even though all vectorization-relevant args are div16.

A follow-up should filter speculative args to only those that affect the vectorized dimension's mask or address, per kernel type:

## Test
- [x] New `TestSpeculativeDivisibility` class with 6 test cases:
  - Pointwise 1D (2D inputs collapsed single xnumel)
  - Pointwise 2D with mismatched layouts (transposed)
  - 3D middle reduction (T[iter, redu, iter])
  - Inner reduction (T[iter, redu])
  - Outer reduction (T[redu, iter])
  - RMSNorm fused kernel
- [x] Each test verifies dispatch condition shape (pipe count in the `|` expression) and runtime path selection (div16 vs general).


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo