### PR TITLE
[inductor] Rewrite multi-consumer F.pad as ConcatKernel for zero-copy

### DIFF
--- a/test/inductor/test_pad_as_cat.py
+++ b/test/inductor/test_pad_as_cat.py
@@ -1,9 +1,10 @@
 # Owner(s): ["module: inductor"]
-"""Tests for cat multi-consumer optimization (pytorch#125075)."""
+"""Tests for cat multi-consumer and pad-as-cat optimizations."""
 
 import re
 
 import torch
+from torch._dynamo.utils import counters
 from torch._inductor.test_case import TestCase
 from torch._inductor.utils import run_and_get_code
 from torch.testing._internal.inductor_utils import GPU_TYPE, requires_gpu
@@ -51,6 +52,52 @@ class TestCatMultiConsumer(TestCase):
         ref = fn(x)
 
         self.assertEqual(result, ref)
+
+
+class TestPadAsCat(TestCase):
+
+    @requires_gpu()
+    def test_mul_pad_addmm(self):
+        """Multi-consumer F.pad uses ConcatKernel zero-copy."""
+        counters.clear()
+
+        def fn(x, scale, bias, weight):
+            mul_result = x * scale
+            padded = torch.nn.functional.pad(mul_result, [0, 192])
+            mm_result = torch.addmm(bias, mul_result, weight)
+            return padded, mm_result
+
+        x = torch.randn(128, 2880, device=GPU_TYPE, dtype=torch.bfloat16)
+        scale = torch.randn(128, 2880, device=GPU_TYPE, dtype=torch.bfloat16)
+        bias = torch.randn(1024, device=GPU_TYPE, dtype=torch.bfloat16)
+        weight = torch.randn(2880, 1024, device=GPU_TYPE, dtype=torch.bfloat16)
+
+        compiled = torch.compile(fn)
+        result, (code,) = run_and_get_code(compiled, x, scale, bias, weight)
+        ref = fn(x, scale, bias, weight)
+
+        self.assertEqual(result[0], ref[0])
+        self.assertEqual(result[1], ref[1], atol=1e-2, rtol=1e-2)
+        self.assertIn("reinterpret_tensor", code)
+        self.assertGreater(counters["inductor"]["pad_as_cat"], 0)
+
+    @requires_gpu()
+    def test_single_consumer_pad_unchanged(self):
+        """Single-consumer F.pad skips _pad_as_cat."""
+        counters.clear()
+
+        def fn(x, scale):
+            return torch.nn.functional.pad(x * scale, [0, 192])
+
+        x = torch.randn(128, 2880, device=GPU_TYPE)
+        scale = torch.randn(128, 2880, device=GPU_TYPE)
+
+        compiled = torch.compile(fn)
+        result = compiled(x, scale)
+        ref = fn(x, scale)
+
+        self.assertEqual(result, ref)
+        self.assertEqual(counters["inductor"]["pad_as_cat"], 0)
 
 
 if __name__ == "__main__":

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -5867,9 +5867,9 @@ class ConcatKernel(NopKernel):
                     break
         any_input_is_storage_and_layout = any(is_storage_and_layout(x) for x in inputs)
         fx_node_args = V.graph.current_node.args[0]
-        assert isinstance(fx_node_args, list), type(fx_node_args)
         # If any of the inputs has meta tensor and the meta tensor is in CL format, use CL format for the output
-        if any_input_is_storage_and_layout is False and any(
+        # Skip this check when fx_node_args is not a list (e.g., called from _pad_as_cat).
+        if any_input_is_storage_and_layout is False and isinstance(fx_node_args, list) and any(
             # pyrefly: ignore [missing-attribute]
             "val" in arg.meta
             and (

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -4726,6 +4726,55 @@ def inplace_constant_pad_nd(
     return resized_x
 
 
+def _pad_as_cat(
+    x: TensorBox, padding: Sequence[int], fill_value: float
+) -> TensorBox | None:
+    """Rewrite right-pad as ConcatKernel for multi-consumer inputs (zero-copy)."""
+    sizes = x.get_size()
+    ndim = len(sizes)
+    pad_pairs = list(zip(padding[::2], padding[1::2]))
+
+    # Only support single-dimension right-pad
+    pad_dim = None
+    pad_amount = None
+    for i, (left, right) in enumerate(pad_pairs):
+        if left != 0:
+            return None
+        if right > 0:
+            if pad_dim is not None:
+                return None  # multi-dim pad
+            pad_dim = ndim - 1 - i  # padding format is reversed dim order
+            pad_amount = right
+        elif right < 0:
+            return None  # trim, not pad
+
+    if pad_dim is None:
+        return None
+
+    # Single-consumer pads are already optimal with masked Pointwise.
+    pad_node = V.current_node
+    if pad_node is None:
+        return None
+    input_node = pad_node.args[0]
+    if not isinstance(input_node, torch.fx.Node):
+        return None
+    if len(input_node.users) <= 1:
+        return None
+
+    # Build the fill tensor for the padding region
+    pad_shape = list(sizes)
+    pad_shape[pad_dim] = pad_amount
+    dtype = x.get_dtype()
+    device = x.get_device()
+    fill_value_typed = dtype_to_type(dtype)(fill_value)
+    pad_tensor = tensor_constructor(fill_value_typed)(
+        pad_shape, dtype=dtype, device=device
+    )
+
+    counters["inductor"]["pad_as_cat"] += 1
+    return TensorBox(ir.ConcatKernel.create([x, pad_tensor], pad_dim))
+
+
 @register_lowering(aten.constant_pad_nd, type_promotion_kind=None)
 def constant_pad_nd(x, padding, fill_value=0):
     assert (len(padding) % 2) == 0
@@ -4737,6 +4786,10 @@ def constant_pad_nd(x, padding, fill_value=0):
         if out:
             return out
             # fall through if can not inplace the padding
+
+    out = _pad_as_cat(x, padding, fill_value)
+    if out is not None:
+        return out
 
     sizes = x.get_size()
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #177066
* #175729

Rewrite constant_pad_nd as ConcatKernel([x, fill_tensor]) when the pad
input has multiple consumers. This avoids duplicate computation by
leveraging ConcatKernel's realize-into-slice zero-copy mechanism.

Only supports right-pad on a single dimension. Single-consumer pads
are unchanged (default masked Pointwise is optimal).

Fixes: vllm-project/vllm#24917

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #177066
* __->__ #175729

## Summary

Fixes a performance issue where `torch.cat` and `F.pad` (constant_pad_nd)
generate redundant computation when their inputs have multiple consumers.


## Problem

### vLLM MoE (mul + pad + addmm) https://github.com/vllm-project/vllm/pull/25477

```python
mul_result = x * scale                            # [tokens, 2880]
padded = F.pad(mul_result, [0, 192])              # [tokens, 3072]
mm_result = torch.addmm(bias, mul_result, weight) # also uses mul_result
```

mul_result has two consumers. constant_pad_nd lowering inlines mul via pointwise_cat with tl.where masking, but mul_result must also be realized for addmm — causing mul to be computed twice.

## Solution

Add _pad_as_cat() path in constant_pad_nd lowering: for right-pad on a single dimension with multi-consumer input, rewrite as ConcatKernel.create([x, fill_tensor], dim). This lets F.pad benefit from ConcatKernel's realize-into-slice zero-copy mechanism.

Also relaxes an assert in ConcatKernel.create() (ir.py) to allow calls from non-aten.cat contexts.

Only supports right-pad, single dimension. Single-consumer pads unchanged.


## Codegen: vLLM MoE pattern (mul + pad + addmm)
Pattern: mul [4096, 2880] + F.pad [4096, 3072] + addmm (GPT-OSS MoE, vllm#24917)

### BEFORE:
```python
buf1 = empty_strided_cuda((4096, 2880), ...)          # mul buffer
triton_poi_fused_mul_0.run(x, scale, buf1)             # Kernel 1: mul → buf1
extern_kernels.addmm(bias, buf1, weight, out=buf2)     # addmm reads buf1
del buf1
buf0 = empty_strided_cuda((4096, 3072), ...)           # padded buffer
triton_poi_fused_pad_mul_1.run(x, scale, buf0)         # Kernel 2: mul RECOMPUTED + tl.where
```

### AFTER:
```python
buf0 = empty_strided_cuda((4096, 3072), (3072, 1), ...)        # padded buffer (pre-alloc)
buf_mul = reinterpret_tensor(buf0, (4096, 2880), (3072, 1), 0) # slice alias
triton_poi_fused_mul_0.run(x, scale, buf_mul)                   # Kernel 1: mul → slice
buf_pad = reinterpret_tensor(buf0, (4096, 192), (3072, 1), 2880)
triton_poi_fused_zeros_1.run(buf_pad)                            # Kernel 2: fill zeros
extern_kernels.addmm(bias, buf_mul, weight, out=buf2)           # addmm reads same slice
```


Codegen:
  BEFORE: pointwise_cat inlines mul → mul computed 2x, 3 buffers, tl.where masking
  AFTER:  ConcatKernel zero-copy → mul computed 1x, 2 buffers, reinterpret_tensor

Perf (NVIDIA H100, bf16):
  BEFORE: 0.122 ms/iter
  AFTER:  0.085 ms/iter  (**+30% speedup**)


## What This Does NOT Cover
- Left-pad or multi-dimension padding
- RMSNorm reduction + pad full fusion (needs scheduler changes)
- Single-consumer pad (already optimal with masked Pointwise)


## Test Plan
Added unit tests

Verified with repro scripts on NVIDIA B200:

**vLLM MoE pattern:**

| Variant | Buffers Before | Buffers After | Correctness |
|---------|---------------|---------------|-------------|
| F.pad + addmm (multi-consumer) | 3 | **2** | PASS |
| torch.cat + addmm (multi-consumer) | 3 | **2** | PASS |
| torch.cat single consumer | 1 | **1 (unchanged)** | PASS |
| F.pad single consumer | 1 | **1 (unchanged)** | PASS |

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos