### PR TITLE
[xpu] Increase tolerance for tests that fail due to non-deterministic operators behavior.

### DIFF
--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -20398,6 +20398,12 @@ DecorateInfo(unittest.skip("Skipped!"), 'TestDecomp', 'test_quick'),
                DecorateInfo(unittest.skip("Skipped!"), 'TestOpInfo', device_type='xla'),
                # Align dtypes with CUDA for fallback ops
                DecorateInfo(unittest.skip("Skipped!"), 'TestCommon', 'test_dtypes', device_type='xpu'),
+           ),
+           decorators=(
+               DecorateInfo(
+                   toleranceOverride({torch.float32: tol(atol=5e-5, rtol=5e-6)}),
+                   'TestCompositeCompliance', 'test_operator', device_type="xpu",
+               ),
            )),
     OpInfo('histogramdd',
            dtypes=floating_types(),

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -16070,6 +16070,10 @@ op_db: list[OpInfo] = [
                    active_if=TEST_WITH_ROCM,
                ),
                DecorateInfo(
+                   toleranceOverride({torch.float32: tol(atol=5e-5, rtol=5e-5)}),
+                   'TestCompositeCompliance', 'test_backward', device_type="xpu"
+               ),
+               DecorateInfo(
                    toleranceOverride({torch.float16: tol(atol=5e-3, rtol=1e-3)}),
                    'TestInductorOpInfo', 'test_comprehensive',
                ),

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -16038,8 +16038,20 @@ op_db: list[OpInfo] = [
                    'TestOperators', 'test_jvpvjp', device_type="cuda"
                ),
                DecorateInfo(
+                   toleranceOverride({torch.float32: tol(atol=5e-4, rtol=5e-5)}),
+                   'TestOperators', 'test_jvpvjp', device_type="xpu"
+               ),
+               DecorateInfo(
                    toleranceOverride({torch.float32: tol(atol=5e-5, rtol=5e-6)}),
                    'TestOperators', 'test_vjp', device_type="cuda"
+               ),
+               DecorateInfo(
+                   toleranceOverride({torch.float32: tol(atol=4e-4, rtol=5e-5)}),
+                   'TestOperators', 'test_vjp', device_type="xpu"
+               ),
+               DecorateInfo(
+                   toleranceOverride({torch.float32: tol(atol=3e-4, rtol=5e-5)}),
+                   'TestOperators', 'test_grad', device_type="xpu"
                ),
                DecorateInfo(
                    toleranceOverride({torch.float32: tol(atol=5e-5, rtol=5e-6)}),


### PR DESCRIPTION
Is fix for: https://github.com/intel/torch-xpu-ops/issues/3103
Is fix for: https://github.com/intel/torch-xpu-ops/issues/2751

## Summary

This PR relaxes test tolerances for selected XPU tests that compare numerically sensitive computations across different execution paths and/or repeated runs.

The root issue is broader than a single operator: some XPU kernels and reduction-heavy paths are non-deterministic run-to-run, which can produce small but valid output drift even for identical inputs. These differences are expected in floating-point workloads and become more visible in gradient and higher-order derivative checks.

Relaxed tolerances are applied only to XPU devices. Changes do not influence other accelerators.

## Tests covered by this PR

This PR updates tolerances for the following 5 tests:

- `op_ut,third_party.torch-xpu-ops.test.xpu.functorch.test_ops_xpu.TestOperatorsXPU,test_vjp_nn_functional_conv3d_xpu_float32`
- `op_ut,third_party.torch-xpu-ops.test.xpu.functorch.test_ops_xpu.TestOperatorsXPU,test_grad_nn_functional_conv3d_xpu_float32`
- `op_ut,third_party.torch-xpu-ops.test.xpu.functorch.test_ops_xpu.TestOperatorsXPU,test_jvpvjp_nn_functional_conv3d_xpu_float32`
- `op_ut,third_party.torch-xpu-ops.test.xpu.test_ops_xpu.TestCompositeComplianceXPU,test_backward_nn_functional_conv3d_xpu_float32`
- `op_ut,third_party.torch-xpu-ops.test.xpu.test_ops_xpu.TestCompositeComplianceXPU,test_operator_histogram_xpu_float32`

## Root cause details

This PR addresses two distinct sources of non-deterministic run-to-run numeric drift in XPU operators:

**Conv3d tests (4 test cases):**
Comparisons are between different XPU execution paths that ultimately involve oneDNN convolution kernels, which exhibit non-deterministic behavior. Identical inputs can produce slightly different outputs across runs, and this numeric drift accumulates further in backward/double-backward derivative checks. A determinism experiment (forcing deterministic oneDNN conv behavior) made results identical, confirming this is expected numeric drift rather than a functional correctness bug. Deterministic oneDNN convolution is technically possible but may impact performance.

**Histogram test (1 test case):**
Weighted `torch.histogram` on XPU uses atomic accumulation (`atomicAdd`) to compute results. This atomic operation path is already explicitly marked as non-deterministic in the backend. Small run-to-run float32 differences surface occasionally when the test harness compares multiple executions.

## Why tolerance adjustment is the chosen fix

For conv3d, two approaches exist:
1. Force deterministic oneDNN behavior (trades performance for determinism).
2. Relax test tolerances to account for expected numeric drift.

For histogram, determinism is not easily enforced without changing the atomic accumulation path significantly.

This PR applies tolerance relaxation for both cases, allowing tests to pass reliably while remaining sensitive enough to catch real regressions. The tolerances are set with empirical margins derived from stress-testing.

## Validation

The conv3d tests were stress-run repeatedly (400 runs each) to capture worst-case absolute mismatch and derive empirical tolerance margins:

| Test Case | Max Absolute Mismatch |
| - | - |
| `test_vjp_nn_functional_conv3d_xpu_float32` | `2.90e-04` |
| `test_grad_nn_functional_conv3d_xpu_float32` | `1.60e-04` |
| `test_jvpvjp_nn_functional_conv3d_xpu_float32` | `4.27e-04` |

All tests with updated tolerances passed consistently across repeated runs. The histogram tolerance was also calibrated to account for run-to-run atomic accumulation variability.
