### PR TITLE
Add custom_autograd_cache_key_fn to compile_fx and standalone_compile

### DIFF
--- a/test/dynamo/test_aot_autograd_cache.py
+++ b/test/dynamo/test_aot_autograd_cache.py
@@ -25,6 +25,7 @@ from torch._functorch._aot_autograd.autograd_cache import (
 from torch._functorch._aot_autograd.schemas import AOTConfig
 from torch._guards import TracingContext
 from torch._inductor import config as inductor_config
+from torch._inductor.compile_fx import compile_fx
 from torch._inductor.custom_graph_pass import CustomRuntimeEstimator
 from torch._inductor.runtime.runtime_utils import cache_dir
 from torch._inductor.runtime.triton_compat import tl, triton
@@ -2537,6 +2538,138 @@ class AOTAutogradCacheTests(InductorTestCase):
         self.assertEqual(
             x_view2.untyped_storage().data_ptr(), x2.untyped_storage().data_ptr()
         )
+
+    @inductor_config.patch("fx_graph_remote_cache", False)
+    @inductor_config.patch("fx_graph_cache", True)
+    @functorch_config.patch({"enable_autograd_cache": True})
+    def test_custom_autograd_cache_key_fn(self):
+        """
+        Verify that a custom_autograd_cache_key_fn overrides the default
+        cache key generation. Uses a constant key to prove the custom
+        function's return value is what controls cache identity.
+        """
+
+        def constant_key_fn(gm, example_inputs, config, fx_config):
+            return "constant_key", []
+
+        def fn(x, y):
+            return (x * 2, y @ y)
+
+        a = torch.rand(25)
+        b = torch.rand(5, 5)
+
+        compiled_fn = torch.compile(
+            fn,
+            backend=functools.partial(
+                compile_fx, custom_autograd_cache_key_fn=constant_key_fn
+            ),
+        )
+
+        # First call: cache miss
+        self.assertEqual(fn(a, b), compiled_fn(a, b))
+        self.assertEqual(counters["aot_autograd"]["autograd_cache_miss"], 1)
+        self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 0)
+
+        self._clear_dynamo_and_codecache()
+
+        # Second call with a DIFFERENT graph but the same constant key:
+        # this must hit because our custom key fn returns the same key.
+        def fn2(x, y):
+            return (x * 3, y + y)
+
+        compiled_fn2 = torch.compile(
+            fn2,
+            backend=functools.partial(
+                compile_fx, custom_autograd_cache_key_fn=constant_key_fn
+            ),
+        )
+
+        compiled_fn2(a, b)
+        self.assertEqual(counters["aot_autograd"]["autograd_cache_miss"], 1)
+        self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 1)
+
+    @inductor_config.patch("fx_graph_remote_cache", False)
+    @inductor_config.patch("fx_graph_cache", True)
+    @functorch_config.patch({"enable_autograd_cache": True})
+    def test_custom_autograd_cache_key_fn_is_called(self):
+        """
+        Verify that the custom_autograd_cache_key_fn is actually invoked
+        and that stable keys produce cache hits on recompilation.
+        """
+        call_count = 0
+
+        def custom_key_fn(gm, example_inputs, config, fx_config):
+            nonlocal call_count
+            call_count += 1
+            return autograd_cache_key(gm, example_inputs, config, fx_config)
+
+        def fn(x, y):
+            return (x * 2, y @ y)
+
+        a = torch.rand(25)
+        b = torch.rand(5, 5)
+
+        compiled_fn = torch.compile(
+            fn,
+            backend=functools.partial(
+                compile_fx, custom_autograd_cache_key_fn=custom_key_fn
+            ),
+        )
+
+        # First call: cache miss, custom key fn is called
+        self.assertEqual(fn(a, b), compiled_fn(a, b))
+        self.assertGreater(call_count, 0)
+        self.assertEqual(counters["aot_autograd"]["autograd_cache_miss"], 1)
+        self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 0)
+
+        self._clear_dynamo_and_codecache()
+        prev_count = call_count
+
+        # Second call: cache hit, custom key fn is called again
+        self.assertEqual(fn(a, b), compiled_fn(a, b))
+        self.assertGreater(call_count, prev_count)
+        self.assertEqual(counters["aot_autograd"]["autograd_cache_miss"], 1)
+        self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 1)
+
+    @inductor_config.patch("fx_graph_remote_cache", False)
+    @inductor_config.patch("fx_graph_cache", True)
+    @functorch_config.patch({"enable_autograd_cache": True})
+    def test_custom_autograd_cache_key_fn_unique_disables_caching(self):
+        """
+        Verify that a custom key fn returning a unique key each time
+        effectively disables caching: every compilation is a miss.
+        """
+        counter = 0
+
+        def unique_key_fn(gm, example_inputs, config, fx_config):
+            nonlocal counter
+            counter += 1
+            return f"unique_{counter}", []
+
+        def fn(x, y):
+            return (x * 2, y @ y)
+
+        a = torch.rand(25)
+        b = torch.rand(5, 5)
+
+        compiled_fn = torch.compile(
+            fn,
+            backend=functools.partial(
+                compile_fx, custom_autograd_cache_key_fn=unique_key_fn
+            ),
+        )
+
+        # First call: miss
+        self.assertEqual(fn(a, b), compiled_fn(a, b))
+        self.assertEqual(counters["aot_autograd"]["autograd_cache_miss"], 1)
+        self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 0)
+
+        self._clear_dynamo_and_codecache()
+
+        # Second call with same graph: still a miss because the key changed
+        self.assertEqual(fn(a, b), compiled_fn(a, b))
+        self.assertEqual(counters["aot_autograd"]["autograd_cache_miss"], 2)
+        self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 0)
 
 
 @functorch_config.patch({"bundled_autograd_cache": True})

--- a/torch/_functorch/_aot_autograd/autograd_cache.py
+++ b/torch/_functorch/_aot_autograd/autograd_cache.py
@@ -750,6 +750,7 @@ class AOTAutogradCache(GuardedCache[GenericAOTAutogradResult[Any, Any]]):
         boxed_forward_device_index: BoxedDeviceIndex | None,
         local: bool,
         remote: bool,
+        custom_autograd_cache_key_fn: Callable[..., Any] | None = None,
     ) -> Callable[..., Any] | None:
         """
         Load a result from the cache, and reconstruct a runtime wrapper around the object
@@ -767,7 +768,10 @@ class AOTAutogradCache(GuardedCache[GenericAOTAutogradResult[Any, Any]]):
                 "boxed_forward_device_index": boxed_forward_device_index,
             }
             try:
-                cache_key, debug_lines = autograd_cache_key(
+                autograd_cache_key_fn = (
+                    custom_autograd_cache_key_fn or autograd_cache_key
+                )
+                cache_key, debug_lines = autograd_cache_key_fn(
                     gm, args, aot_config, fx_config
                 )
                 result: tuple[GenericAOTAutogradResult[Any, Any], bytes] | None = (

--- a/torch/_functorch/aot_autograd.py
+++ b/torch/_functorch/aot_autograd.py
@@ -1084,6 +1084,7 @@ def aot_module_simplified(
     boxed_forward_device_index: BoxedDeviceIndex | None = None,
     ignore_shape_env: bool = False,
     disable_functionalization: bool = False,
+    custom_autograd_cache_key_fn: Callable[..., Any] | None = None,
 ) -> Callable[..., Any]:
     """
     This is the simplified or low overhead version of aot_module. For frontends
@@ -1143,6 +1144,7 @@ def aot_module_simplified(
                     boxed_forward_device_index,
                     local,
                     remote,
+                    custom_autograd_cache_key_fn=custom_autograd_cache_key_fn,
                 )
 
         if compiled_fn is None:

--- a/torch/_inductor/__init__.py
+++ b/torch/_inductor/__init__.py
@@ -13,6 +13,8 @@ from .standalone_compile import CompiledArtifact  # noqa: TC001
 
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from torch._inductor.utils import InputType
     from torch.export import ExportedProgram
     from torch.export.pt2_archive._package import AOTICompiledModel
@@ -412,6 +414,7 @@ def standalone_compile(
     ] = "from_graph",
     options: dict[str, Any] | None = None,
     aot: bool = False,  # AOT mode, which uses BundledAOTAutogradCache
+    custom_autograd_cache_key_fn: Callable[..., Any] | None = None,
 ) -> CompiledArtifact:
     """
     Precompilation API for inductor.
@@ -443,7 +446,12 @@ def standalone_compile(
 
     options = options if options else {}
     return standalone_compile(
-        gm, example_inputs, dynamic_shapes=dynamic_shapes, options=options, aot=aot
+        gm,
+        example_inputs,
+        dynamic_shapes=dynamic_shapes,
+        options=options,
+        aot=aot,
+        custom_autograd_cache_key_fn=custom_autograd_cache_key_fn,
     )
 
 

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -2552,6 +2552,7 @@ def compile_fx(
     config_patches: dict[str, Any] | None = None,
     decompositions: dict[OpOverload, Callable[..., Any]] | None = None,
     ignore_shape_env: bool = False,
+    custom_autograd_cache_key_fn: Callable | None = None,
 ) -> CompileFxOutput:
     """
     Main entry point for compiling given FX graph.  Despite the fact that this
@@ -2582,6 +2583,7 @@ def compile_fx(
                 inner_compile=config.patch(config_patches)(inner_compile),
                 decompositions=decompositions,
                 ignore_shape_env=ignore_shape_env,
+                custom_autograd_cache_key_fn=custom_autograd_cache_key_fn,
             )
 
     # Wake up the AsyncCompile subproc pool as early as possible (if there's cuda).
@@ -2624,6 +2626,7 @@ def compile_fx(
                     ),
                     decompositions=decompositions,
                     ignore_shape_env=ignore_shape_env,
+                    custom_autograd_cache_key_fn=custom_autograd_cache_key_fn,
                 )
 
     return _maybe_wrap_and_compile_fx_main(
@@ -2632,6 +2635,7 @@ def compile_fx(
         inner_compile,
         decompositions,
         ignore_shape_env,
+        custom_autograd_cache_key_fn=custom_autograd_cache_key_fn,
     )
 
 
@@ -2672,6 +2676,7 @@ def _maybe_wrap_and_compile_fx_main(
     inner_compile: Callable[..., OutputCode],
     decompositions: dict[OpOverload, Callable[..., Any]] | None,
     ignore_shape_env: bool,
+    custom_autograd_cache_key_fn: Callable | None = None,
 ) -> CompileFxOutput:
     """
     Part of compile_fx, called after patching configs.
@@ -2687,6 +2692,7 @@ def _maybe_wrap_and_compile_fx_main(
         inner_compile=inner_compile,
         decompositions=decompositions,
         ignore_shape_env=ignore_shape_env,
+        custom_autograd_cache_key_fn=custom_autograd_cache_key_fn,
     )
     if not graph_returns_tuple(model_):
         return make_graph_return_tuple(model_, example_inputs_, compile_gm)
@@ -2709,6 +2715,7 @@ def _maybe_wrap_and_compile_fx_main(
         inner_compile,
         decompositions,
         ignore_shape_env,
+        custom_autograd_cache_key_fn=custom_autograd_cache_key_fn,
     )
 
 
@@ -2718,6 +2725,7 @@ def _compile_fx_main(
     inner_compile: Callable[..., OutputCode],
     decompositions: dict[OpOverload, Callable[..., Any]] | None,
     ignore_shape_env: bool,
+    custom_autograd_cache_key_fn: Callable | None = None,
 ) -> CompileFxOutput:
     """
     Main part of compile_fx, called after wrapping is done.
@@ -2909,6 +2917,7 @@ def _compile_fx_main(
                     cudagraphs=compiler_config_extra.cudagraphs,
                     boxed_forward_device_index=compiler_config_extra.forward_device,
                     ignore_shape_env=ignore_shape_env,
+                    custom_autograd_cache_key_fn=custom_autograd_cache_key_fn,
                 )(model_, example_inputs_)
             except ShortenTraceback as e:
                 # We will also shorten the traceback inside dynamo.

--- a/torch/_inductor/standalone_compile.py
+++ b/torch/_inductor/standalone_compile.py
@@ -378,6 +378,7 @@ def standalone_compile(
     dynamic_shapes: Any,
     options: Any,
     aot: bool = False,  # AOT mode, which uses BundledAOTAutogradCache
+    custom_autograd_cache_key_fn: Callable | None = None,
 ) -> CompiledArtifact:
     """
     Implementation of torch.inductor.standalone_compile
@@ -442,7 +443,11 @@ def standalone_compile(
         # compile_fx can mutate gm
         gm = copy.deepcopy(gm)
         compiled_fn = compile_fx(
-            gm, example_inputs, ignore_shape_env=ignore_shape_env, **options
+            gm,
+            example_inputs,
+            ignore_shape_env=ignore_shape_env,
+            **options,
+            custom_autograd_cache_key_fn=custom_autograd_cache_key_fn,
         )
         assert callable(compiled_fn)
         if aot:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #177072

Add custom_autograd_cache_key_fn to compile_fx and standalone_compile

Allow callers to provide a custom function for generating the autograd
cache key, overriding the default autograd_cache_key. The parameter
threads through standalone_compile, compile_fx, aot_module_simplified,
and into AOTAutogradCache.try_load. Three tests verify the behavior:
a constant key forces hits across different graphs, a wrapping key
proves the custom function is invoked, and a unique key effectively
disables caching.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Lucaskabela