### PR TITLE
fix cpp wrapper for AOTI compilation (#177073)

### DIFF
--- a/torch/_inductor/codegen/cpp_wrapper_cpu_array_ref.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu_array_ref.py
@@ -374,7 +374,7 @@ class CppWrapperCpuArrayRef(CppWrapperCpu):
             cache_type = "Array" if arr_iface else "Tensor"
             self.wrapper_call.writeline(
                 f"thread_local ThreadLocalCachedOutput{cache_type}<std::decay_t<decltype({output})>> "
-                f"{cached_output_name}({output});"
+                f"{cached_output_name}{{{output}}};"
             )
             if arr_iface:
                 self.wrapper_call.writeline(


### PR DESCRIPTION
Summary:

Fix C++ compilation error in AOTI CPU wrapper by using brace initialization

The thread_local cached output variable was using parentheses initialization `({output})`,
which causes compilation errors with AOTI (Ahead-Of-Time Inductor compilation). This changes
it to use brace initialization `{{{output}}}` instead, which properly initializes the
ThreadLocalCachedOutput{Array,Tensor} objects.

This affects both fbcode and xplat paths in the PyTorch Inductor C++ wrapper codegen.

Test Plan: Solved user issue in: https://fb.workplace.com/groups/gpuinference/permalink/3477606012388042/

Reviewed By: Bao2803

Differential Revision: D95851833


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo