### PR TITLE
[DTensor] Update dtensor_dispatch_inplace instruction count benchmark

### DIFF
--- a/benchmarks/dynamo/pr_time_benchmarks/expected_results.csv
+++ b/benchmarks/dynamo/pr_time_benchmarks/expected_results.csv
@@ -106,7 +106,7 @@ dtensor_dispatch_add_backward,instruction_count,346201,0.1
 
 
 
-dtensor_dispatch_inplace,instruction_count,56530,0.1
+dtensor_dispatch_inplace,instruction_count,58710,0.1
 
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #177074

The expected count for dtensor_dispatch_inplace (add_) regressed from
56530 to 58710 (~3.9%) after #175795 registered single-dim strategies
for categorized pointwise ops. The regression is on the cached dispatch
path and comes from two sources: an extra dict lookup in the C++
get_runtime_schema_info_for_op (~890 instructions), and a Python heap
layout difference in the cached OutputSharding object (~2860
instructions). Both are minor and not particularly worth fixing. While
the regression is within the 10% CI noise margin, it's better to reset
the counts so we still have our full 10% margin for the future.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98 @Lucaskabela