### PR TITLE
[FR script] Fixed bug which caused FR script to fail in the case of a coalsced collective not scheduled (#177076)

### DIFF
--- a/torch/distributed/flight_recorder/components/builder.py
+++ b/torch/distributed/flight_recorder/components/builder.py
@@ -311,7 +311,12 @@ def build_collectives(
                 # This extra cleanup is needed because we need to pop all collectives within a coalesced collective.
                 for i, k in idx_map.items():
                     for _ in range(1, num_coalesced_entries):
-                        all_entries[i].pop(k)
+                        try:
+                            all_entries[i].pop(k)
+                        except IndexError:
+                            # In the case of a missing rank symptom that a rank didn't schedule the coalesced collective,
+                            # we should not fail the analysis script here.
+                            pass
         else:
             # Iterate through all the ranks and check if there is a mismatch for the current entry.
             check_current_entry_match(


### PR DESCRIPTION
Summary:

FR script assumed that the coalsced collective is always scheduled from all ranks in the pg, but in the case of a subset of ranks didn't schedule a coalsced collective, the FR script would try to remove the coalsced collective in its clean-up stage and fail abruptly. This diff fixed the bug to skip cleaning-up the non-scheduled coalseced collective.

Test Plan:
`buck2 run  //investigations/dr_patternson/analyzers/ai_observability:ai_observability-all-analyzers-cli -- flight_recorder_analyzer --mast_job_name fire-xiaoxuanw-f1047233868 --mast_job_version 0 --mast_job_attempt 2`
Confirm no error, confirm the SBDive view has insights https://fburl.com/ai_infra/ppmvoeb8

Reviewed By: fduwjj, YongzhongYang

Differential Revision: D96016690


