### PR TITLE
[inductor] Fix fallback_random dropout stride mismatch

### DIFF
--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -2928,6 +2928,12 @@ def constrain_to_fx_strides(fx_node, *args, **kwargs):
     return args, kwargs
 
 
+# native_dropout uses empty_like(input) internally, so bernoulli_ consumes
+# RNG values in the input's stride order. Constrain input strides to match
+# the FX graph (i.e. eager) so the dropout mask is identical.
+add_layout_constraint(aten.native_dropout.default, constrain_to_fx_strides)
+
+
 def sdpa_constraint(fx_node, *args, **kwargs):
     """Apply stride constraints to SDPA inputs, ensuring dense last dimension."""
 


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/174078

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #177077

When fallback_random=True, native_dropout runs as an opaque eager
FallbackKernel. The C++ implementation uses empty_like(input) to
allocate the dropout mask, so bernoulli_ consumes RNG values in the
input's stride order. Inductor's FlexibleLayout could choose a
different stride order for the input buffer than eager, causing the
dropout mask to differ.

Register constrain_to_fx_strides on aten.native_dropout.default so the
input strides match FX tracing (i.e. eager semantics) for both
contiguous and non-contiguous inputs.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo