### PR TITLE
Add NCCL collective sequence number (seq_num) to Kineto profiler traces

### DIFF
--- a/torch/csrc/distributed/c10d/ParamCommsUtils.hpp
+++ b/torch/csrc/distributed/c10d/ParamCommsUtils.hpp
@@ -84,6 +84,19 @@ class TORCH_API ParamCommsDebugInfo : public c10::DebugInfoBase {
     return isAsynchronizedOp_;
   }
 
+  int64_t getSequenceNumber() const {
+    return sequenceNumber_;
+  }
+
+  bool getIsP2P() const {
+    return isP2P_;
+  }
+
+  void setSequenceInfo(int64_t seqNum, bool isP2P) {
+    sequenceNumber_ = seqNum;
+    isP2P_ = isP2P;
+  }
+
  private:
   std::tuple<std::string, std::string> pgName_; // <group_name, group_desc>
   int rank_{};
@@ -98,6 +111,8 @@ class TORCH_API ParamCommsDebugInfo : public c10::DebugInfoBase {
   int globalRankStride_{};
   std::vector<int64_t> groupRanks_;
   bool isAsynchronizedOp_{};
+  int64_t sequenceNumber_{-1};
+  bool isP2P_{false};
 };
 
 #define RECORD_PARAM_COMMS(                                                    \
@@ -126,6 +141,11 @@ class TORCH_API ParamCommsDebugInfo : public c10::DebugInfoBase {
       globalRankStride,                                                        \
       worldSize,                                                               \
       false);                                                                  \
+  {                                                                            \
+    auto seqTuple = seq;                                                       \
+    paramCommsInfo->setSequenceInfo(                                            \
+        std::get<0>(seqTuple), std::get<1>(seqTuple));                         \
+  }                                                                            \
   c10::DebugInfoGuard g(c10::DebugInfoKind::PARAM_COMMS_INFO, paramCommsInfo); \
   std::initializer_list<const c10::IValue> paramList = {                       \
       seq,                                                                     \
@@ -202,6 +222,11 @@ class TORCH_API ParamCommsDebugInfo : public c10::DebugInfoBase {
       globalRankStride,                                                        \
       worldSize,                                                               \
       isAsyncOp);                                                              \
+  {                                                                            \
+    auto seqTuple = seq;                                                       \
+    paramCommsInfo->setSequenceInfo(                                            \
+        std::get<0>(seqTuple), std::get<1>(seqTuple));                         \
+  }                                                                            \
   c10::DebugInfoGuard g(c10::DebugInfoKind::PARAM_COMMS_INFO, paramCommsInfo); \
   std::initializer_list<const c10::IValue> paramList = {                       \
       c10::IValue(InputTensors),                                               \

--- a/torch/csrc/profiler/util.cpp
+++ b/torch/csrc/profiler/util.cpp
@@ -509,6 +509,11 @@ std::unordered_map<std::string, std::string> saveNcclMeta(
         map.emplace(kP2pSrc, std::to_string(groupRanks[rank]));
       }
     }
+
+    auto seqNum = debugInfo->getSequenceNumber();
+    if (seqNum >= 0) {
+      map.emplace(kSeqNum, std::to_string(seqNum));
+    }
   }
 
   map.emplace(

--- a/torch/csrc/profiler/util.h
+++ b/torch/csrc/profiler/util.h
@@ -201,6 +201,7 @@ constexpr auto kGroupRanks = "Process Group Ranks";
 constexpr auto kRank = "Rank";
 constexpr auto kP2pSrc = "Src Rank";
 constexpr auto kP2pDst = "Dst Rank";
+constexpr auto kSeqNum = "Seq";
 constexpr auto kInTensorsStart = "Input Tensors start";
 constexpr auto kOutTensorsStart = "Output Tensors start";
 constexpr auto kIsAsynchronizedOp = "Is asynchronized op";


### PR DESCRIPTION
Summary:
Thread the per-process-group sequence number from ProcessGroupNCCL through
ParamCommsDebugInfo into the Kineto trace JSON output.

This enables cross-rank correlation of collective operations: all ranks
participating in the same collective instance share the same seq_num
within a process group. Without this, there is no way to match collective
events across ranks in production trace data (gpu_comms_events Scuba table).

Changes:
- ParamCommsUtils.hpp: Add sequenceNumber_/isP2P_ fields and setter to
  ParamCommsDebugInfo. Update RECORD_PARAM_COMMS and RECORD_PARAM_COMMS_DATA
  macros to populate them from the existing seq tuple.
- util.h: Add kSeqNum constant ("Seq")
- util.cpp: Emit seq_num in saveNcclMeta() when available
- default_event_args.py (HTA): Add nccl::seq mapping so HTA parses the
  new field into a seq_num column

Test Plan:
* Added new tests:
```
[marvindz@devvm12146.ncg0 /data/repos/fbsource (e3e89a12f0)]$ buck2 test fbcode//mode/dev-nosan   fbcode//caffe2/test/distributed/fb:test_c10d_nccl_seq_num_trace
File changed: fbcode//caffe2/test/distributed/fb/test_c10d_nccl_seq_num_trace.py
File changed: fbsource//xplat/caffe2/test/distributed/fb/test_c10d_nccl_seq_num_trace.py
Buck UI: https://www.internalfb.com/buck2/56eecce1-7093-4f2f-841d-d9215077e212
Test UI: https://www.internalfb.com/intern/testinfra/testrun/17732923687903807
Network: Up: 0B  Down: 2.6KiB  (reSessionID-fbf39a12-a6aa-4a8b-a5f2-74f91464714d)
Executing actions. Remaining     0/2                                                     0.1s exec time total
Command: test.     Finished 1 local                                                                                                                           
Time elapsed: 1:55.8s
Tests finished: Pass 2. Fail 0. Timeout 0. Fatal 0. Skip 0. Omit 0. Infra Failure 0. Build failure 0
[marvindz@devvm12146.ncg0 /data/repos/fbsource (bf2aaca219)]$ 
```

Differential Revision: D94566477


