### PR TITLE
[ROCm][CI] Use 2-GPU runners for ROCm distributed shards in trunk.yml

### DIFF
--- a/.github/workflows/periodic-rocm-mi355.yml
+++ b/.github/workflows/periodic-rocm-mi355.yml
@@ -2,6 +2,7 @@ name: periodic-rocm-mi355
 
 on:
   schedule:
+    - cron: 0 0,3,6,9,12,15,18,21 * * *
     - cron: 29 8 * * *  # about 1:29am PDT, for mem leak check and rerun disabled tests
   push:
     tags:

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -286,9 +286,9 @@ jobs:
           { config: "default", shard: 4, num_shards: 6, runner: "linux.rocm.gpu.gfx950.1" },
           { config: "default", shard: 5, num_shards: 6, runner: "linux.rocm.gpu.gfx950.1" },
           { config: "default", shard: 6, num_shards: 6, runner: "linux.rocm.gpu.gfx950.1" },
-          # { config: "distributed", shard: 1, num_shards: 3, runner: "linux.rocm.gpu.gfx950.4" },
-          # { config: "distributed", shard: 2, num_shards: 3, runner: "linux.rocm.gpu.gfx950.4" },
-          # { config: "distributed", shard: 3, num_shards: 3, runner: "linux.rocm.gpu.gfx950.4" },
+          { config: "distributed", shard: 1, num_shards: 3, runner: "linux.rocm.gpu.gfx950.2" },
+          { config: "distributed", shard: 2, num_shards: 3, runner: "linux.rocm.gpu.gfx950.2" },
+          { config: "distributed", shard: 3, num_shards: 3, runner: "linux.rocm.gpu.gfx950.2" },
         ]}
     secrets: inherit
 

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -286,9 +286,9 @@ jobs:
           { config: "default", shard: 4, num_shards: 6, runner: "linux.rocm.gpu.gfx950.1" },
           { config: "default", shard: 5, num_shards: 6, runner: "linux.rocm.gpu.gfx950.1" },
           { config: "default", shard: 6, num_shards: 6, runner: "linux.rocm.gpu.gfx950.1" },
-          { config: "distributed", shard: 1, num_shards: 3, runner: "linux.rocm.gpu.gfx950.4" },
-          { config: "distributed", shard: 2, num_shards: 3, runner: "linux.rocm.gpu.gfx950.4" },
-          { config: "distributed", shard: 3, num_shards: 3, runner: "linux.rocm.gpu.gfx950.4" },
+          # { config: "distributed", shard: 1, num_shards: 3, runner: "linux.rocm.gpu.gfx950.4" },
+          # { config: "distributed", shard: 2, num_shards: 3, runner: "linux.rocm.gpu.gfx950.4" },
+          # { config: "distributed", shard: 3, num_shards: 3, runner: "linux.rocm.gpu.gfx950.4" },
         ]}
     secrets: inherit
 


### PR DESCRIPTION
TTS has taken a big hit for ROCm distributed shards on trunk.yml: [link](https:/hud.pytorch.org/tts?jobNamesCompressed=NoIgLgTgrgdg1gAgPQIDYEsZQB4FoBWAhgLbECeuEA9gMbG4AOZAzAHQCMADMgmAKYBnMAgAUAE3RCI6AEZR%2BYgDQJ2y5soxZsranVYBzBlAMAzbAE4ArJ1YAWAJQhF4aPB6acBEuUq16TNi4efiFRCSlZeT4lBAAmNQ1MHB0-AyNTC2s7R2dIWEQUDzwiUgpdfxYObhQQ4XFJSEiFBIR1NCTtcrTjfTMrGwcQAF0gA&startTime=2026-02-08T22%3A45%3A50.747&stopTime=2026-03-10T21%3A45%3A50.747&granularity=day&timeRange=30&ttsPercentile=0.9)
* p90 for TTS has gone from 3.4h to 7.3h
* p90 for duration has also gone from 3.6h to 4.2h, with a significant jump around 2/21. This PR doesn't address/resolve that increase; it is pending investigation

### This PR:
* uses 2-GPU runners instead of 4-GPU runners for ROCm distributed shards on trunk.yml. This should reduce the pressure from distributed trunk jobs by half.
* runs 4-GPU distributed shards on periodic-rocm-mi355.yml every 3 hours to get full distributed coverage

### Reasoning:
(h/t @pragupta)
Total distributed config: 4495 UTs
Total >2GPU tests: 324 UTs
 
So, only about 7% UTs requires >2 GPUs. By reducing the testing to 2 GPU runners, we'd be reducing our test coverage by 7%.

cc @jeffdaily @sunway513 @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang