### PR TITLE
[torch][inductor] Get shape information for extern/Aten kernels with enable_kernel_profile (#177087)

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -6184,6 +6184,84 @@ class AOTInductorTestsTemplate:
             self.check_model(Model(N, K, self.device), example_inputs)
 
     @unittest.skipIf(
+        config.triton.native_matmul, "different kernel name when native matmul"
+    )
+    @unittest.skipIf(
+        sys.platform not in ["linux", "win32"],
+        "enable_kernel_profile only supported on linux and win32",
+    )
+    def test_aoti_profiler_input_shapes(self):
+        # Verify that kernel profiling records tensor input shapes,
+        # scalar args, output handles, and ReinterpretView logical shapes.
+        class Model(torch.nn.Module):
+            def __init__(self, n, k, device):
+                super().__init__()
+                self.weight = torch.randn(n, k, device=device)
+                self.bias = torch.randn(n, device=device)
+
+            def forward(self, a):
+                # addmm: exercises scalar args (alpha, beta) and output handle
+                out = torch.nn.functional.linear(a, self.weight, self.bias)
+                # mm with transposed view: exercises ReinterpretView input path
+                return torch.mm(out.t(), a)
+
+        M = 8
+        N = 6
+        K = 16
+        model = Model(N, K, self.device)
+        a = torch.randn(M, K, device=self.device)
+        example_inputs = (a,)
+        with config.patch({"cpp.enable_kernel_profile": True}):
+            _, code = run_and_get_cpp_code(
+                AOTIRunnerUtil.compile, model, example_inputs
+            )
+            # Verify that tensor inputs are converted to IValues for
+            # shape recording (3-arg RAIIAtenRecordFunctionHandle form).
+            FileCheck().check("aoti_torch_tensor_to_ivalue").run(code)
+            # Verify dummy scalar IValues are generated for non-tensor args.
+            FileCheck().check("aoti_torch_int64_to_ivalue").run(code)
+            FileCheck().check("std::vector<C10IValueHandle>").run(code)
+            # Verify output tensor is included in IValues for out-variant
+            # kernels.
+            FileCheck().check_regex(r"tmp_.*_output\b").run(code)
+            # Verify ReinterpretView inputs use reinterpret_tensor_wrapper
+            # for correct logical shapes in profiling.
+            FileCheck().check("reinterpret_tensor_wrapper").run(code)
+
+            self.check_model(Model(N, K, self.device), example_inputs)
+
+    @unittest.skipIf(
+        sys.platform not in ["linux", "win32"],
+        "enable_kernel_profile only supported on linux and win32",
+    )
+    def test_aoti_profiler_conv_input_shapes(self):
+        # Convolution flows through the extern/fallback kernel codegen path;
+        # verify its tensor inputs are recorded with shapes when profiling is
+        # enabled (3-arg RAIIAtenRecordFunctionHandle with an IValue vector).
+        class Model(torch.nn.Module):
+            def __init__(self, device):
+                super().__init__()
+                self.conv = torch.nn.Conv2d(3, 6, kernel_size=3, padding=1).to(device)
+
+            def forward(self, x):
+                return self.conv(x)
+
+        model = Model(self.device)
+        x = torch.randn(2, 3, 16, 16, device=self.device)
+        example_inputs = (x,)
+        with config.patch({"cpp.enable_kernel_profile": True}):
+            _, code = run_and_get_cpp_code(
+                AOTIRunnerUtil.compile, model, example_inputs
+            )
+            # Conv tensor inputs are converted to IValues for shape recording,
+            # collected into a vector, and passed to the record function.
+            FileCheck().check("aoti_torch_tensor_to_ivalue").run(code)
+            FileCheck().check("std::vector<C10IValueHandle>").run(code)
+            FileCheck().check("RAIIAtenRecordFunctionHandle").run(code)
+
+            self.check_model(Model(self.device), example_inputs)
+
+    @unittest.skipIf(
         sys.platform not in ["linux", "win32"],
         "enable_kernel_profile only supported on linux and win32",
     )

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -46,6 +46,7 @@ from .cpp_utils import (
     LAYOUT_TO_ATEN,
 )
 from .wrapper import (
+    _get_profiling_input_handles,
     _rewrite_symbol_solution_for_int_codegen,
     codegen_reinterpret_view_helper,
     EnterSubgraphLine,
@@ -1879,6 +1880,9 @@ class CppWrapperCpu(PythonWrapperCodegen):
         *,
         debug_args: list[str] | None = None,
         stack_traces: OrderedSet[str] | None = None,
+        input_handles: list[str] | None = None,
+        num_scalars: int = 0,
+        output_handle: str | None = None,
     ) -> None:
         """debug_args kwarg allows CppWrapperCpuArrayRef to pass in wrapped arguments in
         place of args while preserving debug printer output."""
@@ -1903,7 +1907,7 @@ class CppWrapperCpu(PythonWrapperCodegen):
             ]
             if enable_kernel_profile:
                 call_code = shim_fn_codes[0]
-                shim_fn_codes = ["{"]
+                stack_trace_str = ""
                 if enable_kernel_context_guard:
                     stack_trace_str = 'R"('
                     if stack_traces:
@@ -1912,16 +1916,82 @@ class CppWrapperCpu(PythonWrapperCodegen):
                                 stack_trace_str += f"\n{line}"
                             stack_trace_str += "\n"
                     stack_trace_str += ')"'
-                    shim_fn_codes.append(
-                        f"""KernelContextGuard _ctx("{shim_fn}", {stack_trace_str});"""
+
+                has_profiling_inputs = input_handles or num_scalars > 0 or output_handle
+                if has_profiling_inputs:
+                    # Generate IValue conversions so that tensor shapes
+                    # and scalar types are recorded by the profiler.
+                    ivalue_lines: list[str] = []
+                    ivalue_names: list[str] = []
+
+                    # Convert tensor input handles to IValues.
+                    if input_handles:
+                        for idx, handle in enumerate(input_handles):
+                            ivalue_var = f"tmp_{shim_fn}_input_{idx}"
+                            ivalue_lines.extend(
+                                [
+                                    f"C10IValueHandle {ivalue_var};",
+                                    f"aoti_torch_tensor_to_ivalue({handle}, &{ivalue_var});",
+                                    f"RAIIC10IValueHandle RAII_{ivalue_var}({ivalue_var});",
+                                ]
+                            )
+                            ivalue_names.append(ivalue_var)
+
+                    # Generate dummy scalar IValues (we only care about
+                    # shapes, so use int64(0) as a placeholder).
+                    for idx in range(num_scalars):
+                        ivalue_var = f"tmp_{shim_fn}_scalar_{idx}"
+                        ivalue_lines.extend(
+                            [
+                                f"C10IValueHandle {ivalue_var};",
+                                f"aoti_torch_int64_to_ivalue(0, &{ivalue_var});",
+                                f"RAIIC10IValueHandle RAII_{ivalue_var}({ivalue_var});",
+                            ]
+                        )
+                        ivalue_names.append(ivalue_var)
+
+                    # Convert output tensor handle to IValue.
+                    if output_handle:
+                        ivalue_var = f"tmp_{shim_fn}_output"
+                        ivalue_lines.extend(
+                            [
+                                f"C10IValueHandle {ivalue_var};",
+                                f"aoti_torch_tensor_to_ivalue({output_handle}, &{ivalue_var});",
+                                f"RAIIC10IValueHandle RAII_{ivalue_var}({ivalue_var});",
+                            ]
+                        )
+                        ivalue_names.append(ivalue_var)
+
+                    inputs_vec_var = f"{shim_fn}_inputs_"
+                    ivalue_lines.append(
+                        f"std::vector<C10IValueHandle> {inputs_vec_var}({{{', '.join(ivalue_names)}}});"
                     )
-                shim_fn_codes.extend(
-                    [
-                        f"""RAIIAtenRecordFunctionHandle record_{shim_fn}_("{shim_fn}", nullptr);""",
-                        call_code,
-                        "}",
-                    ]
-                )
+
+                    shim_fn_codes = ["{", *ivalue_lines]
+                    if enable_kernel_context_guard:
+                        shim_fn_codes.append(
+                            f"""KernelContextGuard _ctx("{shim_fn}", {stack_trace_str});"""
+                        )
+                    shim_fn_codes.extend(
+                        [
+                            f"""RAIIAtenRecordFunctionHandle record_{shim_fn}_("{shim_fn}", nullptr, {inputs_vec_var});""",
+                            call_code,
+                            "}",
+                        ]
+                    )
+                else:
+                    shim_fn_codes = ["{"]
+                    if enable_kernel_context_guard:
+                        shim_fn_codes.append(
+                            f"""KernelContextGuard _ctx("{shim_fn}", {stack_trace_str});"""
+                        )
+                    shim_fn_codes.extend(
+                        [
+                            f"""RAIIAtenRecordFunctionHandle record_{shim_fn}_("{shim_fn}", nullptr);""",
+                            call_code,
+                            "}",
+                        ]
+                    )
             self.writelines(shim_fn_codes)
 
     def generate_c_shim_extern_kernel_alloc(
@@ -1941,8 +2011,15 @@ class CppWrapperCpu(PythonWrapperCodegen):
 
         device = d.type if (d := extern_kernel.get_device()) else self.device
 
+        num_kwargs = sum(
+            1 for key in extern_kernel.ordered_kwargs_for_cpp_kernel if key != "out"
+        )
         self.generate_c_shim_extern_kernel_call(
-            extern_kernel.get_kernel_name(), args, device
+            extern_kernel.get_kernel_name(),
+            args,
+            device,
+            input_handles=_get_profiling_input_handles(extern_kernel.inputs, args),
+            num_scalars=len(extern_kernel.constant_args) + num_kwargs,
         )
 
         if extern_kernel.python_kernel_name in (
@@ -1968,6 +2045,15 @@ class CppWrapperCpu(PythonWrapperCodegen):
     def generate_c_shim_fallback_kernel(
         self, fallback_kernel: ir.FallbackKernel, args: list[str]
     ) -> None:
+        # FallbackKernel.codegen_args() interleaves tensors and constants
+        # via unflatten_args, so args[i] may not correspond to inputs[i].
+        # Use get_name() for tensor (IRNode) inputs; skip nested-list args
+        # (e.g. TensorList) which have no single handle.
+        input_handles = []
+        for inp in fallback_kernel.inputs:
+            if isinstance(inp, ir.IRNode):
+                input_handles.append(inp.get_name())
+
         output_args = []
         output_raii_handles = []
         output_name_base = fallback_kernel.get_name()
@@ -2001,10 +2087,15 @@ class CppWrapperCpu(PythonWrapperCodegen):
         args = args + output_args
         device = d.type if (d := fallback_kernel.get_device()) else self.device
 
+        num_kwargs = sum(
+            1 for key in fallback_kernel.ordered_kwargs_for_cpp_kernel if key != "out"
+        )
         self.generate_c_shim_extern_kernel_call(
             fallback_kernel.cpp_kernel_name,  # type: ignore[arg-type]
             args,
             device,
+            input_handles=input_handles,
+            num_scalars=len(fallback_kernel.constant_args) + num_kwargs,
         )
         for raii_handle in output_raii_handles:
             self.writeline(raii_handle)
@@ -2017,16 +2108,25 @@ class CppWrapperCpu(PythonWrapperCodegen):
         args: list[str],
         device: str,
         stack_traces: OrderedSet[str] | None = None,
+        input_handles: list[str] | None = None,
+        num_scalars: int = 0,
     ) -> None:
         if out_view:
             out_name = f"{out}_as_strided"
             self.writeline(f"auto {out_name} = {out_view};")
             args.insert(0, out_name)
         else:
+            out_name = out
             args.insert(0, out)
 
         self.generate_c_shim_extern_kernel_call(
-            kernel, args, device, stack_traces=stack_traces
+            kernel,
+            args,
+            device,
+            stack_traces=stack_traces,
+            input_handles=input_handles,
+            num_scalars=num_scalars,
+            output_handle=out_name,
         )
 
     def _get_scatter_reduce_enum(self, reduce):

--- a/torch/_inductor/codegen/cpp_wrapper_cpu_array_ref.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu_array_ref.py
@@ -1047,7 +1047,15 @@ class CppWrapperCpuArrayRef(CppWrapperCpu):
         self.writeline("}")
 
     def generate_c_shim_extern_kernel_call(
-        self, kernel: str, args: list[str], device: str, **_
+        self,
+        kernel: str,
+        args: list[str],
+        device: str,
+        *,
+        input_handles: list[str] | None = None,
+        num_scalars: int = 0,
+        output_handle: str | None = None,
+        **_,
     ) -> None:
         # In the abi_compatible mode, we call fallback aten ops through a C shim layer
         # Setting self.allow_stack_allocation to False because the exchange between
@@ -1069,7 +1077,13 @@ class CppWrapperCpuArrayRef(CppWrapperCpu):
             wrapped_args.append(arg)
 
         super().generate_c_shim_extern_kernel_call(
-            kernel, wrapped_args, device, debug_args=args
+            kernel,
+            wrapped_args,
+            device,
+            debug_args=args,
+            input_handles=input_handles,
+            num_scalars=num_scalars,
+            output_handle=output_handle,
         )
 
     def generate_scatter_fallback(self, node: ir.ScatterFallback):

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -651,6 +651,27 @@ class ExternKernelAllocLine(WrapperLine):
         return converter._generate_extern_kernel_alloc
 
 
+def _get_profiling_input_handles(
+    inputs: Sequence[IRNode | Sequence[IRNode]], args: list[str]
+) -> list[str]:
+    """Build input handles for profiling: use codegen args for ReinterpretView
+    inputs (to capture logical view shapes) and get_name() for everything
+    else (to avoid issues with multi-token args like tensor lists)."""
+    handles = []
+    for i, inp in enumerate(inputs):
+        if isinstance(inp, ReinterpretView):
+            handle = args[i]
+            # Strip RAII wrapper to get raw handle to avoid double-ownership
+            # when the expression is evaluated for profiling AND for the
+            # actual kernel call.
+            if handle.startswith("RAIIAtenTensorHandle(") and handle.endswith(")"):
+                handle = handle[len("RAIIAtenTensorHandle(") : -1]
+            handles.append(handle)
+        elif isinstance(inp, IRNode):
+            handles.append(inp.get_name())
+    return handles
+
+
 @dataclasses.dataclass
 class ExternKernelOutLine(WrapperLine):
     wrapper: PythonWrapperCodegen
@@ -669,6 +690,11 @@ class ExternKernelOutLine(WrapperLine):
         else:
             kernel_name = node.get_kernel_name()
         device = d.type if (d := node.get_device()) else V.graph.device_type
+        # Count scalar args from both constant_args and kwargs
+        # (e.g., addmm has alpha/beta in kwargs, not constant_args).
+        num_kwargs = sum(
+            1 for key in self.node.ordered_kwargs_for_cpp_kernel if key != "out"
+        )
         self.wrapper._generate_extern_kernel_out_helper(
             kernel_name,
             node.codegen_reference(),
@@ -676,6 +702,8 @@ class ExternKernelOutLine(WrapperLine):
             args,
             device,
             self.node.get_stack_traces(),
+            input_handles=_get_profiling_input_handles(self.node.inputs, args),
+            num_scalars=len(self.node.constant_args) + num_kwargs,
         )
 
     def codegen_fx(self, converter: FxConverter) -> FxConversionFunc:
@@ -2159,7 +2187,11 @@ class PythonWrapperCodegen(CodeGen):
         args: list[str],
         device: str,
         stack_traces: OrderedSet[str] | None = None,
+        input_handles: list[str] | None = None,
+        num_scalars: int = 0,
     ) -> None:
+        # input_handles / num_scalars are consumed only by the CppWrapperCpu
+        # override (to record profiling metadata); the Python wrapper ignores them.
         # add debug printer code for triton kernel calls at (jit) inductor level
         debug_printer_manager = V.graph.wrapper_code.debug_printer
         debug_printer_manager.set_printer_args(args, kernel, None, None, "extern")


### PR DESCRIPTION
Summary:

 # Problem

 When profiling AOT Inductor compiled models with TORCHINDUCTOR_CPP_ENABLE_KERNEL_PROFILE=1, the generated GPU trace showed input tensor shapes for Triton kernels but not for extern/ATen kernels (e.g., aten::mm, aten::addmm).

 # Root Cause

 The issue was in cpp_wrapper_cpu.py, in the generate_c_shim_extern_kernel_call method. When kernel profiling is enabled, each kernel call is wrapped in a {} scope block containing a RAIIAtenRecordFunctionHandle object. This RAII object creates an at::RecordFunction event that the PyTorch
 profiler picks up.

 The RAIIAtenRecordFunctionHandle class has two constructors:
  - 2-arg: (name, kwargs) — records the kernel name but no input shapes
  - 3-arg: (name, kwargs, inputs) — records the kernel name AND a std::vector of input tensors, whose shapes are then visible in the trace

 For Triton kernels, the codegen in cpp_wrapper_gpu.py already used the 3-arg constructor: it iterated over each kernel argument, checked its type via arg_types, converted tensor arguments to c10::IValue using aoti_torch_tensor_to_ivalue(), and passed the resulting vector to
  RAIIAtenRecordFunctionHandle.

 For extern kernels, the codegen in cpp_wrapper_cpu.py used the 2-arg constructor with nullptr in place of inputs:
  RAIIAtenRecordFunctionHandle record_aoti_torch_cuda_mm_out_("aoti_torch_cuda_mm_out", nullptr);

 This meant the profiler had no tensor inputs to extract shapes from, so extern kernels appeared in the trace without any shape information.

 # Solution

 Tensor input shape recording

 Extended generate_c_shim_extern_kernel_call to accept an optional input_handles: list[str] parameter — a list of C++ expressions corresponding to the tensor inputs for the kernel. When kernel profiling is enabled and input_handles is provided, the method now generates code that:

  - Converts each tensor handle to a c10::IValue via aoti_torch_tensor_to_ivalue(handle, &ivalue_var)
  - Wraps each in an RAII guard (RAIIC10IValueHandle) for automatic cleanup
  - Collects them into a std::vector
  - Passes the vector to the 3-arg RAIIAtenRecordFunctionHandle constructor

 The generated C++ code for an extern kernel like aten::mm now looks like:
  {
    C10IValueHandle tmp_aoti_torch_cuda_mm_out_input_0;
    aoti_torch_tensor_to_ivalue(buf0, &tmp_aoti_torch_cuda_mm_out_input_0);
    RAIIC10IValueHandle RAII_tmp_aoti_torch_cuda_mm_out_input_0(tmp_aoti_torch_cuda_mm_out_input_0);
    C10IValueHandle tmp_aoti_torch_cuda_mm_out_input_1;
    aoti_torch_tensor_to_ivalue(buf1, &tmp_aoti_torch_cuda_mm_out_input_1);
    RAIIC10IValueHandle RAII_tmp_aoti_torch_cuda_mm_out_input_1(tmp_aoti_torch_cuda_mm_out_input_1);
    std::vector<C10IValueHandle> aoti_torch_cuda_mm_out_inputs_({tmp_aoti_torch_cuda_mm_out_input_0, tmp_aoti_torch_cuda_mm_out_input_1});
    KernelContextGuard _ctx("aoti_torch_cuda_mm_out", R"(...)");
    RAIIAtenRecordFunctionHandle record_aoti_torch_cuda_mm_out_("aoti_torch_cuda_mm_out", nullptr, aoti_torch_cuda_mm_out_inputs_);
    AOTI_TORCH_ERROR_CODE_CHECK(aoti_torch_cuda_mm_out(buf0, buf1, &buf2_handle));
  }

 Building input handles: the _get_profiling_input_handles method

 The input handles passed to generate_c_shim_extern_kernel_call are built by a new _get_profiling_input_handles method (added to both CppWrapperCpu and ExternKernelOutLine). This method uses a selective approach for each input:

 - ReinterpretView inputs: Uses the codegen arg expression (args[i]), which contains the reinterpret_tensor_wrapper call with the correct logical view shape. Any RAIIAtenTensorHandle(...) wrapper is stripped to avoid double-ownership when the expression is evaluated for both profiling and the
 actual kernel call.
 - All other inputs: Uses inp.get_name(), which returns a simple C++ variable name (e.g., buf0). This avoids issues with multi-token args like tensor lists (e.g., index_Tensor args contain top-level commas that would break the aoti_torch_tensor_to_ivalue call signature).

 This selective approach ensures that ReinterpretView inputs report their logical view shapes (e.g., [800, 14400]) rather than the physical buffer shapes, while remaining safe for all other input types.

 The three callers of generate_c_shim_extern_kernel_call were updated:

 - generate_c_shim_extern_kernel_alloc — uses _get_profiling_input_handles(extern_kernel.inputs, args)
  - generate_c_shim_fallback_kernel — uses [inp.get_name() for inp in fallback_kernel.inputs] (cannot use the selective approach because FallbackKernel.codegen_args() uses unflatten_args which may interleave tensor and scalar arguments in schema order, so args[i] does not necessarily correspond to inputs[i])
  - _generate_extern_kernel_out_helper — receives input_handles from its caller (ExternKernelOutLine.codegen() which uses _get_profiling_input_handles)

 Output tensor shapes (out-variant kernels)

 For out-variant extern kernels (ExternKernelOut), the output tensor is pre-allocated and available at recording time. The _generate_extern_kernel_out_helper method now passes the output tensor handle (out or out_as_strided) via a new output_handle parameter to generate_c_shim_extern_kernel_call,
 which converts it to an IValue and appends it at the end of the inputs vector. This matches eager trace behavior where the out parameter appears last in "Input Dims".

 Scalar argument recording

 ATen ops like addmm have scalar arguments (e.g., beta, alpha) that appear in eager traces as entries with Input type "Scalar" and empty Input Dims []. To match this, generate_c_shim_extern_kernel_call now accepts a num_scalars parameter and generates dummy int64(0) IValues via
 aoti_torch_int64_to_ivalue (the same approach used by Triton kernel profiling in cpp_wrapper_gpu.py). Only shapes matter for profiling analysis, so the actual scalar values are not preserved similar to how it is done for triton operations.

 Scalar args can be stored in two places on ExternKernel nodes:
  - constant_args: positional non-tensor args (from process_kernel)
  - kwargs + ordered_kwargs_for_cpp_kernel: keyword-only scalar args (e.g., alpha, beta for addmm)

 The total scalar count is computed as:
   len(node.constant_args) + len(ordered_kwargs_for_cpp_kernel excluding "out")

 Resulting trace format

  For an addmm kernel, the generated AOTI trace now shows:
    "Input type": ["c10::Half", "c10::Half", "c10::Half", "Scalar", "Scalar", "c10::Half"]
    "Input Dims": [[N], [M, K], [K, N], [], [], [M, N]]

 matching the eager trace format.

 ## Files changed

  - caffe2/torch/_inductor/codegen/cpp_wrapper_cpu.py — Added _get_profiling_input_handles method to CppWrapperCpu; added input_handles, num_scalars, and output_handle parameters to generate_c_shim_extern_kernel_call and _generate_extern_kernel_out_helper; updated
 generate_c_shim_extern_kernel_alloc to use _get_profiling_input_handles and generate_c_shim_fallback_kernel to pass tensor input handles via get_name()
  - caffe2/torch/_inductor/codegen/wrapper.py — Added _get_profiling_input_handles method to ExternKernelOutLine; added input_handles parameter to the base class _generate_extern_kernel_out_helper signature; updated ExternKernelOutLine.codegen() to extract and pass input handles using the
 selective approach
 - caffe2/torch/_inductor/codegen/cpp_wrapper_cpu_array_ref.py — Updated the generate_c_shim_extern_kernel_call override to forward the input_handles, num_scalars, and output_handle kwargs to super()

Test Plan:
Now generates a trace that has shape information and has the correct order for the shapes (not transposed or more dims than it should):
```
  {
    "ph": "X", "cat": "cpu_op", "name": "aoti_torch_cuda_mm_out", "pid": 4023436, "tid": 4023436,
    "ts": 5464826158019.994, "dur": 85.519,
    "args": {
      "External id": 890,"Record function id": 0, "Concrete Inputs": ["", "", ""], "Input type": ["c10::Half", "c10::Half", "c10::Half"], "Input Dims": [[800, 14400], [14400, 1024], [800, 1024]], "Ev Idx": 889
    }
  },
```
while before the change this would look like:
```
  {
    "ph": "X", "cat": "cpu_op", "name": "aoti_torch_cuda_mm_out", "pid": 2290421, "tid": 2290421,
    "ts": 4971258491467.797, "dur": 41.293,
    "args": {
      "External id": 1672,"Record function id": 0, "Ev Idx": 1671
    }
  },
```
and operations also have the Scalars in their args:
```
  {
    "ph": "X", "cat": "cpu_op", "name": "aoti_torch_cuda_addmm_out", "pid": 4023436, "tid": 4023436,
    "ts": 5464826172563.836, "dur": 61.243,
    "args": {
      "External id": 2456,"Record function id": 0, "Concrete Inputs": ["", "", "", "0", "0", ""], "Input type": ["c10::Half", "c10::Half", "c10::Half", "Scalar", "Scalar", "c10::Half"], "Input Dims": [[800, 5120], [800, 8192], [8192, 5120], [], [], [800, 5120]], "Ev Idx": 2455
    }
  },
```

Reviewed By: desertfire

Differential Revision: D94735563




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo