### PR TITLE
[FSDP] Merge all-gather and reduce-scatter into one CUDA stream

### DIFF
--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
@@ -82,9 +82,9 @@ class FSDPCommContext:
         # All-gather and reduce-scatter share the same NCCL communicator, so
         # the collectives serialize regardless of stream. Use one stream for
         # both to avoid unnecessary stream overhead.
-        comm_stream = self.device_handle.Stream(priority=high_priority)
-        self.all_gather_stream = comm_stream
-        self.reduce_scatter_stream = comm_stream
+        ag_rs_shared_stream = self.device_handle.Stream(priority=high_priority)
+        self.all_gather_stream = ag_rs_shared_stream
+        self.reduce_scatter_stream = ag_rs_shared_stream
         # Run the HSDP all-reduces concurrently with all-gather/reduce-scatter
         # since collectives use different network resources and can overlap
         # in the typical intra-node sharding / inter-node replication case

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
@@ -79,12 +79,12 @@ class FSDPCommContext:
         self.all_gather_copy_in_stream = self.device_handle.Stream(
             priority=high_priority
         )
-        # All-gather stream allows overlapping next all-gather with current
-        # forward compute
-        self.all_gather_stream = self.device_handle.Stream(priority=high_priority)
-        # Reduce-scatter stream gives separate execution "thread" for post-
-        # backward logic like pre/post-gradient division and reduce-scatter
-        self.reduce_scatter_stream = self.device_handle.Stream(priority=high_priority)
+        # All-gather and reduce-scatter share the same NCCL communicator, so
+        # the collectives serialize regardless of stream. Use one stream for
+        # both to avoid unnecessary stream overhead.
+        comm_stream = self.device_handle.Stream(priority=high_priority)
+        self.all_gather_stream = comm_stream
+        self.reduce_scatter_stream = comm_stream
         # Run the HSDP all-reduces concurrently with all-gather/reduce-scatter
         # since collectives use different network resources and can overlap
         # in the typical intra-node sharding / inter-node replication case


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #177098

All-gather and reduce-scatter use the same NCCL communicator. We have 2 options
* Option 1: Merge all-gather and reduce-scatter into one: this is the PR
* Option 2: Use seaprate PGs to truly overlap all-gather and reduce-scatter https://github.com/pytorch/pytorch/pull/177015


