### PR TITLE
[mvai][igr] Add _merge_overlapping_fusions() to FxNetSplitter with env var gate (#177099)

### DIFF
--- a/torch/fx/passes/splitter_base.py
+++ b/torch/fx/passes/splitter_base.py
@@ -563,6 +563,7 @@ class _SplitterBase:
             self.fusions = {}
         else:
             self.fusions = FxNetAccFusionsFinder(module, self.acc_nodes)()
+            self._merge_overlapping_fusions()
 
         # Modify deps to add more deps for fused nodes
         self.deps = self.find_deps()
@@ -619,6 +620,71 @@ class _SplitterBase:
                 for user in fused_neighbor.users:
                     if user not in fusion:
                         self.deps[user].add(node)
+
+    def _merge_overlapping_fusions(self):
+        """
+        Merge fusion groups that share nodes.
+
+        FxNetAccFusionsFinder can produce overlapping fusion groups when a
+        node is absorbed into multiple groups during expansion. When
+        update_deps_for_fusions() later propagates deps, shared nodes act
+        as bridges between groups, creating bidirectional dependency cycles
+        that crash the splitter with "Subgraph can't be empty".
+
+        This method detects overlapping groups via union-find and merges
+        them into single groups before dep propagation.
+        """
+        if os.environ.get("_SPLITTER_MERGE_OVERLAPPING_FUSIONS", "0") != "1":
+            return
+
+        if not self.fusions:
+            return
+
+        # Collect unique groups by identity.
+        unique_groups: dict[int, NodeSet] = {}
+        for group in self.fusions.values():
+            unique_groups[id(group)] = group
+
+        if len(unique_groups) <= 1:
+            return
+
+        # Map each node to all group IDs it belongs to.
+        node_to_gids: dict[torch.fx.Node, list[int]] = defaultdict(list)
+        for gid, group in unique_groups.items():
+            for node in group:
+                node_to_gids[node].append(gid)
+
+        # Union-find: merge groups that share nodes.
+        parent: dict[int, int] = {gid: gid for gid in unique_groups}
+
+        def find(x: int) -> int:
+            while parent[x] != x:
+                parent[x] = parent[parent[x]]
+                x = parent[x]
+            return x
+
+        needs_merge = False
+        for gids in node_to_gids.values():
+            if len(gids) > 1:
+                root = find(gids[0])
+                for i in range(1, len(gids)):
+                    other = find(gids[i])
+                    if other != root:
+                        parent[other] = root
+                        needs_merge = True
+
+        if not needs_merge:
+            return
+
+        # Build merged groups.
+        merged: dict[int, NodeSet] = defaultdict(set)
+        for gid, group in unique_groups.items():
+            merged[find(gid)].update(group)
+
+        # Rebuild self.fusions so every node points to its merged group.
+        for merged_group in merged.values():
+            for node in merged_group:
+                self.fusions[node] = merged_group
 
     # ===============================================================
     # Helpers for preview


### PR DESCRIPTION
Summary:

Adds a new `_merge_overlapping_fusions()` method to `_SplitterBase` that detects and merges overlapping fusion groups produced by `FxNetAccFusionsFinder` using a union-find algorithm.

Context:
- [Related post](https://fb.workplace.com/groups/gpuinference/permalink/3471402729675037/) in PyTorch Inference Enablement Q&A
- N9759841: Detailed explanation of this solution
- Root cause: `FxNetAccFusionsFinder` can produce overlapping fusion groups when a node is absorbed into multiple groups during expansion. When `update_deps_for_fusions()` later propagates deps, shared nodes act as bridges between groups, creating bidirectional dependency cycles that crash the splitter with "Subgraph can't be empty".
- Critical detail: The if node in result: continue guard prevents starting a NEW group from an already-assigned node. But add_node() during expansion does NOT check result -- it just adds. So a node can be absorbed into multiple groups. This is how overlapping groups form. Code pointer: https://www.internalfb.com/code/fbsource/fbcode/caffe2/torch/fx/passes/tools_common.py?lines=189
- This fix is gated behind the `_SPLITTER_MERGE_OVERLAPPING_FUSIONS` env var (default: disabled). Set `_SPLITTER_MERGE_OVERLAPPING_FUSIONS=1` to activate.

Changes:
- splitter_base.py (fbcode/ and xplat/ copies):
  - Added `_merge_overlapping_fusions()` method with union-find algorithm to detect and merge overlapping fusion groups before dep propagation
  - Added call to `self._merge_overlapping_fusions()` in `__init__` after `FxNetAccFusionsFinder`
  - Gated behind `_SPLITTER_MERGE_OVERLAPPING_FUSIONS` env var (default "0" = disabled)

Test Plan: Unit tests in a child diff (D95605463) validate the splitter behavior. The fix is disabled by default and can be enabled per-environment for testing.

Reviewed By: Indicator, georgiaphillips

Differential Revision: D96005940


