### PR TITLE
[opaque obj] Support return in inductor

### DIFF
--- a/test/test_opaque_obj_v2.py
+++ b/test/test_opaque_obj_v2.py
@@ -889,7 +889,7 @@ class TestOpaqueObject(TestCase):
         self.assertEqual(size, 0)
 
     def test_custom_op_reference_return(self):
-        @torch.compile(backend="eager", fullgraph=True)
+        @torch.compile(backend="inductor", fullgraph=True)
         def f(x):
             c1 = torch.ops._TestOpaqueObject.create_counter(0, 10)
             c2, c3 = torch.ops._TestOpaqueObject.create_counter2(0, 10)

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -1536,6 +1536,7 @@ class GraphLowering(torch.fx.Interpreter):
                     ir.EffectfulKernel,
                     ir.ShapeAsConstantBuffer,
                     TorchBindObject,
+                    ir.OpaqueMultiOutput,
                 ),
             )
             for x in result
@@ -1868,7 +1869,7 @@ class GraphLowering(torch.fx.Interpreter):
                 result.realize()
 
             if (is_output or is_input_for_as_strided) and isinstance(
-                n.meta["val"], torch.Tensor
+                n.meta.get("val"), torch.Tensor
             ):
                 if is_user_visible:
                     strides = self.user_visible_output_strides.get(n)

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -42,7 +42,8 @@ from torch._export.serde.serialize import GraphModuleSerializer
 from torch._higher_order_ops.auto_functionalize import can_auto_functionalize
 from torch._inductor import metrics
 from torch._inductor.utils import get_free_symbols
-from torch._library.opaque_object import is_opaque_type
+from torch._library.fake_class_registry import FakeScriptObject
+from torch._library.opaque_object import is_opaque_value
 from torch._prims_common import (
     compute_required_storage_length,
     is_boolean_dtype,
@@ -118,7 +119,6 @@ from .virtualized import ops, OpsValue, V
 
 
 if TYPE_CHECKING:
-    from torch._library.fake_class_registry import FakeScriptObject
     from torch.fx.experimental.symbolic_shapes import SympyBoolean
     from torch.fx.node import Argument
 
@@ -257,6 +257,7 @@ def validate_ir(node_or_nodes: _NodeOrNodes | None) -> None:
                     int,
                     EffectfulKernel,
                     ShapeAsConstantBuffer,
+                    OpaqueMultiOutput,
                 ),
             ), (
                 f"Found {type(nodes)}, which is not a supported top level IR node. See [Note: Inductor IR]"
@@ -584,6 +585,9 @@ class IRNode:
                 TemplateBuffer,
             ),
         )
+
+    def wrap_for_lowering(self) -> IRNode:
+        return TensorBox.create(self)
 
     def _post_init_setattr(self, attr: str, value: Any) -> None:
         # Intended for use in __post_init__ for enforcing an invariant on a dataclass
@@ -6293,6 +6297,8 @@ class ExternKernel(InputsKernel):
                 example_args.append(V.graph.torchbind_constants[x.get_name()])
             elif isinstance(x, TorchBindObject):
                 example_args.append(x.get_value())
+            elif isinstance(x, OpaqueMultiOutput):
+                example_args.append(x.opaque_example_value)
             elif isinstance(x, torch._inductor.ir.GeneratorState):
                 device_index = x.device.index
                 assert x.device.type == "cuda" and device_index is not None
@@ -6449,7 +6455,7 @@ class ExternKernel(InputsKernel):
             # TODO(jansel): impose layout preference on realized buffer
             x.realize()
             return x
-        if isinstance(x, (NonTensorObj, ShapeAsConstantBuffer)):
+        if isinstance(x, (NonTensorObj, ShapeAsConstantBuffer, OpaqueMultiOutput)):
             return x
         return cls.copy_input(x)
 
@@ -8314,6 +8320,10 @@ class FallbackKernel(ExternKernelAlloc):
             return devices[0]
         if isinstance(example_output, torch.Tensor):
             return example_output.device
+        if isinstance(
+            example_output, (torch._C.ScriptObject, FakeScriptObject)
+        ) or is_opaque_value(example_output):
+            return torch.device("cpu")
         if isinstance(example_output, (list, tuple)):
             device_set = OrderedSet(
                 # pyrefly: ignore [bad-argument-type]
@@ -8324,6 +8334,8 @@ class FallbackKernel(ExternKernelAlloc):
             devices = [device for device in device_set if device]
             if len(devices) == 1:
                 return devices[0]
+            if not devices:
+                return None
             for device in devices:
                 assert isinstance(device, torch.device)
                 if is_gpu(device.type):
@@ -8716,6 +8728,15 @@ class FallbackKernel(ExternKernelAlloc):
                 return output
             elif isinstance(output, torch.SymInt):
                 return output.node.expr
+            elif isinstance(
+                output, (torch._C.ScriptObject, FakeScriptObject)
+            ) or is_opaque_value(output):
+                return OpaqueMultiOutput(
+                    NoneLayout(device=device),
+                    packed,
+                    indices,
+                    output,
+                )
             else:
                 assert output is None, (
                     f"FallbackKernel output type {type(output)} is not supported"
@@ -8861,6 +8882,37 @@ class MultiOutput(ExternKernel):
         return dependencies.ReadWrites(
             reads=reads,
             writes=write_rw.writes,
+            index_exprs=OrderedSet(),
+        )
+
+
+class OpaqueMultiOutput(MultiOutput):
+    """MultiOutput for opaque objects."""
+
+    def __init__(
+        self,
+        layout: OutputSpec,
+        input: IRNode,
+        indices: list[tuple[Any, ...]],
+        opaque_value: Any,
+    ) -> None:
+        super().__init__(layout, input, indices, skip_size_stride_alignment_checks=True)
+        self.opaque_example_value = opaque_value
+
+    def wrap_for_lowering(self) -> OpaqueMultiOutput:
+        return self
+
+    def get_read_writes(self) -> dependencies.ReadWrites:
+        reads: OrderedSet[dependencies.Dep] = OrderedSet()
+        for inp in self.inputs:
+            if isinstance(inp, IRNode):
+                reads.add(dependencies.StarDep(inp.get_name()))
+        writes: OrderedSet[dependencies.Dep] = OrderedSet(
+            [dependencies.StarDep(self.get_name())]
+        )
+        return dependencies.ReadWrites(
+            reads=reads,
+            writes=writes,
             index_exprs=OrderedSet(),
         )
 
@@ -10070,7 +10122,7 @@ class TorchBindObject(NonTensorObj):
         # Returns the sum of all tensors in the flattened object
         real_script_obj = self.get_real_obj()
 
-        if is_opaque_type(type(real_script_obj)):
+        if is_opaque_value(real_script_obj):
             return 0
 
         assert hasattr(real_script_obj, "__obj_flatten__")

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -26,6 +26,7 @@ from torch._dynamo.utils import counters
 from torch._higher_order_ops.associative_scan import associative_scan_op
 from torch._higher_order_ops.triton_kernel_wrap import triton_kernel_wrapper_mutation
 from torch._library.fake_class_registry import FakeScriptObject
+from torch._library.opaque_object import is_opaque_value
 from torch._library.utils import get_layout_constraint_tag
 from torch._prims_common import (
     canonicalize_dim,
@@ -2299,7 +2300,7 @@ def fallback_handler(kernel, add_to_fallback_set=True):
 
     def handler(*args, **kwargs):
         def wrap_tensors(x):
-            return TensorBox.create(x) if isinstance(x, ir.IRNode) else x
+            return x.wrap_for_lowering() if isinstance(x, ir.IRNode) else x
 
         return pytree.tree_map(
             wrap_tensors, ir.FallbackKernel.create(kernel, *args, **kwargs)
@@ -2888,7 +2889,7 @@ def require_channels_last(_, *args, **kwargs):
 def constrain_to_fake_tensor(arg, fake_arg):
     if fake_arg is None:
         return arg
-    if isinstance(fake_arg, FakeScriptObject):
+    if isinstance(fake_arg, FakeScriptObject) or is_opaque_value(fake_arg):
         return arg
     if isinstance(arg, ir.IRNode):
         return ir.ExternKernel.require_exact_strides(arg, fake_arg.stride())
@@ -7938,7 +7939,7 @@ def with_effects(token, op, *args, **kwargs):
     else:
 
         def wrap_tensors(x):
-            return TensorBox.create(x) if isinstance(x, ir.IRNode) else x
+            return x.wrap_for_lowering() if isinstance(x, ir.IRNode) else x
 
         result = pytree.tree_map(
             wrap_tensors, ir.FallbackKernel.create(op, *args, **kwargs)


### PR DESCRIPTION
This PR adds inductor backend support for returning opaque (reference-type) objects from custom operators. It introduces an OpaqueMultiOutput IR node.

Example inductor output: 
```python
def call(self, args):
      arg0_1, = args
      args.clear()
      assert_size_stride(arg0_1, (), ())
      # Topologically Sorted Source Nodes: [create_counter2], Original ATen: [_TestOpaqueObject.create_counter2]
      buf0 = torch.ops._TestOpaqueObject.create_counter2.default(0, 10)
      buf1 = buf0[0]
      buf2 = buf0[1]
      del buf0
      # Topologically Sorted Source Nodes: [create_counter], Original ATen: [_TestOpaqueObject.create_counter]
      buf3 = torch.ops._TestOpaqueObject.create_counter.default(0, 10)
      buf4 = buf3
      del buf3
      # Topologically Sorted Source Nodes: [increment_counter], Original ATen: [_TestOpaqueObject.increment_counter]
      buf5 = torch.ops._TestOpaqueObject.increment_counter.default(buf4, arg0_1)
      buf7 = buf5
      assert_size_stride(buf7, (), (), 'torch.ops._TestOpaqueObject.increment_counter.default')
      # buffer buf7 (op: torch.ops._TestOpaqueObject.increment_counter.default) is assumed to be not aligned
      del buf5
      # Topologically Sorted Source Nodes: [increment_counter_1], Original ATen: [_TestOpaqueObject.increment_counter]
      buf8 = torch.ops._TestOpaqueObject.increment_counter.default(buf1, arg0_1)
      buf10 = buf8
      assert_size_stride(buf10, (), (), 'torch.ops._TestOpaqueObject.increment_counter.default')
      # buffer buf10 (op: torch.ops._TestOpaqueObject.increment_counter.default) is assumed to be not aligned
      del buf8
      # Topologically Sorted Source Nodes: [increment_counter_2], Original ATen: [_TestOpaqueObject.increment_counter]
      buf11 = torch.ops._TestOpaqueObject.increment_counter.default(buf2, arg0_1)
      del arg0_1
      buf13 = buf11
      assert_size_stride(buf13, (), (), 'torch.ops._TestOpaqueObject.increment_counter.default')
      # buffer buf13 (op: torch.ops._TestOpaqueObject.increment_counter.default) is assumed to be not aligned
      return (buf4, buf7, buf1, buf10, buf2, buf13, )
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Lucaskabela