### PR TITLE
[FSDP] Merge all-gather and reduce-scatter into one CUDA stream

### DIFF
--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
@@ -79,12 +79,12 @@ class FSDPCommContext:
         self.all_gather_copy_in_stream = self.device_handle.Stream(
             priority=high_priority
         )
-        # All-gather stream allows overlapping next all-gather with current
-        # forward compute
-        self.all_gather_stream = self.device_handle.Stream(priority=high_priority)
-        # Reduce-scatter stream gives separate execution "thread" for post-
-        # backward logic like pre/post-gradient division and reduce-scatter
-        self.reduce_scatter_stream = self.device_handle.Stream(priority=high_priority)
+        # All-gather and reduce-scatter share the same NCCL communicator, so
+        # the collectives serialize regardless of stream. Use one stream for
+        # both to avoid unnecessary stream overhead.
+        ag_rs_shared_stream = self.device_handle.Stream(priority=high_priority)
+        self.all_gather_stream = ag_rs_shared_stream
+        self.reduce_scatter_stream = ag_rs_shared_stream
         # Run the HSDP all-reduces concurrently with all-gather/reduce-scatter
         # since collectives use different network resources and can overlap
         # in the typical intra-node sharding / inter-node replication case


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #177102

All-gather and reduce-scatter use the same NCCL communicator, so the
collectives serialize regardless of which CUDA stream they run on. Using
two separate streams adds unnecessary overhead without enabling any real
overlap. Merge them into a single stream while keeping both attribute
names (`all_gather_stream` and `reduce_scatter_stream`) for backward
compatibility.

Co-authored-by: Claude <noreply@anthropic.com>