### PR TITLE
remove `TORCH_CHECK_MSG` usage in `torch/csrc/inductor/aoti_torch/c/shim.h`

### DIFF
--- a/torch/csrc/inductor/aoti_torch/c/shim.h
+++ b/torch/csrc/inductor/aoti_torch/c/shim.h
@@ -640,17 +640,18 @@ AOTI_TORCH_EXPORT void aoti_torch_check(
         __func__,                                \
         __FILE__,                                \
         static_cast<uint32_t>(__LINE__),         \
-        TORCH_CHECK_MSG(cond, "", __VA_ARGS__)); \
+        #cond " CHECK FAILED at " __FILE__);     \
   }
 #else
-#define AOTI_TORCH_CHECK(cond, ...)                \
-  if (!(cond)) {                                   \
-    aoti_torch_check(                              \
-        false,                                     \
-        __func__,                                  \
-        __FILE__,                                  \
-        static_cast<uint32_t>(__LINE__),           \
-        TORCH_CHECK_MSG(cond, "", ##__VA_ARGS__)); \
+#define AOTI_TORCH_CHECK(cond, ...)              \
+  if (!(cond)) {                                 \
+    aoti_torch_check(                            \
+        false,                                   \
+        __func__,                                \
+        __FILE__,                                \
+        static_cast<uint32_t>(__LINE__),         \
+        #cond " AOTI_TORCH_CHECK failed. "       \
+        #__VA_ARGS__);                           \
   }
 #endif
 


### PR DESCRIPTION
Doesn't seem to be available, otherwise we observe failures like
```
hmqsv6ahnmkzsf2kbs2f344b2bycpypu3wqs.wrapper.o

Output:
In file included from /usr/local/lib/python3.12/dist-packages/torch/include/torch/csrc/inductor/aoti_runtime/utils.h:15,
                 from /usr/local/lib/python3.12/dist-packages/torch/include/torch/csrc/inductor/aoti_runtime/interface.h:8,
                 from /usr/local/lib/python3.12/dist-packages/torch/include/torch/csrc/inductor/aoti_include/common.h:8,
                 from /usr/local/lib/python3.12/dist-packages/torch/include/torch/csrc/inductor/aoti_include/cuda.h:4,
                 from /tmp/torchinductor_root/precompiled_headers/cc7t4ra64mzvtmub3oulotbekvftpmsnzsatuen4f23v6yybnjgk.h:1:
/tmp/tmpy8si4z09/cclba4dxphu7kzfjkl4iq34w7ausznmunfpnmodw62je6z2bv4mu/crdi5mfier2zsiyjhmqsv6ahnmkzsf2kbs2f344b2bycpypu3wqs.wrapper.cpp: In member function ‘void torch::aot_inductor::AOTInductorModel::run_impl(AtenTensorOpaque**, AtenTensorOpaque**, torch::aot_inductor::DeviceStreamType, AOTIProxyExecutorHandle)’:
/usr/local/lib/python3.12/dist-packages/torch/include/torch/csrc/inductor/aoti_torch/c/shim.h:653:9: error: ‘TORCH_CHECK_MSG’ was not declared in this scope
  653 |         TORCH_CHECK_MSG(cond, "", ##__VA_ARGS__)); \
      |         ^~~~~~~~~~~~~~~
/tmp/tmpy8si4z09/cclba4dxphu7kzfjkl4iq34w7ausznmunfpnmodw62je6z2bv4mu/crdi5mfier2zsiyjhmqsv6ahnmkzsf2kbs2f344b2bycpypu3wqs.wrapper.cpp:1059:5: note: in expansion of macro ‘AOTI_TORCH_CHECK’
 1059 |     AOTI_TORCH_CHECK(u3 != 0, "Integer floor division by zero");
      |     ^~~~~~~~~~~~~~~~
/usr/local/lib/python3.12/dist-packages/torch/include/torch/csrc/inductor/aoti_torch/c/shim.h:653:9: error: ‘TORCH_CHECK_MSG’ was not declared in this scope
  653 |         TORCH_CHECK_MSG(cond, "", ##__VA_ARGS__)); \
      |         ^~~~~~~~~~~~~~~
/tmp/tmpy8si4z09/cclba4dxphu7kzfjkl4iq34w7ausznmunfpnmodw62je6z2bv4mu/crdi5mfier2zsiyjhmqsv6ahnmkzsf2kbs2f344b2bycpypu3wqs.wrapper.cpp:1061:5: note: in expansion of macro ‘AOTI_TORCH_CHECK’
 1061 |     AOTI_TORCH_CHECK(u3 != 0, "Integer floor division by zero");
      |     ^~~~~~~~~~~~~~~~
/usr/local/lib/python3.12/dist-packages/torch/include/torch/csrc/inductor/aoti_torch/c/shim.h:653:9: error: ‘TORCH_CHECK_MSG’ was not declared in this scope
  653 |         TORCH_CHECK_MSG(cond, "", ##__VA_ARGS__)); \
      |         ^~~~~~~~~~~~~~~
/tmp/tmpy8si4z09/cclba4dxphu7kzfjkl4iq34w7ausznmunfpnmodw62je6z2bv4mu/crdi5mfier2zsiyjhmqsv6ahnmkzsf2kbs2f344b2bycpypu3wqs.wrapper.cpp:1063:5: note: in expansion of macro ‘AOTI_TORCH_CHECK’
 1063 |     AOTI_TORCH_CHECK(u3 != 0, "Integer floor division by zero");
      |     ^~~~~~~~~~~~~~~~
/usr/local/lib/python3.12/dist-packages/torch/include/torch/csrc/inductor/aoti_torch/c/shim.h:653:9: error: ‘TORCH_CHECK_MSG’ was not declared in this scope
  653 |         TORCH_CHECK_MSG(cond, "", ##__VA_ARGS__)); \
      |         ^~~~~~~~~~~~~~~
/tmp/tmpy8si4z09/cclba4dxphu7kzfjkl4iq34w7ausznmunfpnmodw62je6z2bv4mu/crdi5mfier2zsiyjhmqsv6ahnmkzsf2kbs2f344b2bycpypu3wqs.wrapper.cpp:1065:5: note: in expansion of macro ‘AOTI_TORCH_CHECK’
 1065 |     AOTI_TORCH_CHECK(u3 != 0, "Integer floor division by zero");
      |     ^~~~~~~~~~~~~~~~
/usr/local/lib/python3.12/dist-packages/torch/include/torch/csrc/inductor/aoti_torch/c/shim.h:653:9: error: ‘TORCH_CHECK_MSG’ was not declared in this scope
  653 |         TORCH_CHECK_MSG(cond, "", ##__VA_ARGS__)); \
      |         ^~~~~~~~~~~~~~~
/tmp/tmpy8si4z09/cclba4dxphu7kzfjkl4iq34w7ausznmunfpnmodw62je6z2bv4mu/crdi5mfier2zsiyjhmqsv6ahnmkzsf2kbs2f344b2bycpypu3wqs.wrapper.cpp:1134:5: note: in expansion of macro ‘AOTI_TORCH_CHECK’
 1134 |     AOTI_TORCH_CHECK(u3 != 0, "Integer floor division by zero");
      |     ^~~~~~~~~~~~~~~~
/usr/local/lib/python3.12/dist-packages/torch/include/torch/csrc/inductor/aoti_torch/c/shim.h:653:9: error: ‘TORCH_CHECK_MSG’ was not declared in this scope
  653 |         TORCH_CHECK_MSG(cond, "", ##__VA_ARGS__)); \
      |         ^~~~~~~~~~~~~~~
/tmp/tmpy8si4z09/cclba4dxphu7kzfjkl4iq34w7ausznmunfpnmodw62je6z2bv4mu/crdi5mfier2zsiyjhmqsv6ahnmkzsf2kbs2f344b2bycpypu3wqs.wrapper.cpp:1135:5: note: in expansion of macro ‘AOTI_TORCH_CHECK’
 1135 |     AOTI_TORCH_CHECK(u3 != 0, "Integer floor division by zero");
      |     ^~~~~~~~~~~~~~~~
/usr/local/lib/python3.12/dist-packages/torch/include/torch/csrc/inductor/aoti_torch/c/shim.h:653:9: error: ‘TORCH_CHECK_MSG’ was not declared in this scope
  653 |         TORCH_CHECK_MSG(cond, "", ##__VA_ARGS__)); \
      |         ^~~~~~~~~~~~~~~
/tmp/tmpy8si4z09/cclba4dxphu7kzfjkl4iq34w7ausznmunfpnmodw62je6z2bv4mu/crdi5mfier2zsiyjhmqsv6ahnmkzsf2kbs2f344b2bycpypu3wqs.wrapper.cpp:1144:5: note: in expansion of macro ‘AOTI_TORCH_CHECK’
 1144 |     AOTI_TORCH_CHECK(u3 != 0, "Integer floor division by zero");
      |     ^~~~~~~~~~~~~~~~
/usr/local/lib/python3.12/dist-packages/torch/include/torch/csrc/inductor/aoti_torch/c/shim.h:653:9: error: ‘TORCH_CHECK_MSG’ was not declared in this scope
  653 |         TORCH_CHECK_MSG(cond, "", ##__VA_ARGS__)); \
      |         ^~~~~~~~~~~~~~~
/tmp/tmpy8si4z09/cclba4dxphu7kzfjkl4iq34w7ausznmunfpnmodw62je6z2bv4mu/crdi5mfier2zsiyjhmqsv6ahnmkzsf2kbs2f344b2bycpypu3wqs.wrapper.cpp:1145:5: note: in expansion of macro ‘AOTI_TORCH_CHECK’
 1145 |     AOTI_TORCH_CHECK(u3 != 0, "Integer floor division by zero");
      |     ^~~~~~~~~~~~~~~~
/usr/local/lib/python3.12/dist-packages/torch/include/torch/csrc/inductor/aoti_torch/c/shim.h:653:9: error: ‘TORCH_CHECK_MSG’ was not declared in this scope
  653 |         TORCH_CHECK_MSG(cond, "", ##__VA_ARGS__)); \
      |         ^~~~~~~~~~~~~~~
/tmp/tmpy8si4z09/cclba4dxphu7kzfjkl4iq34w7ausznmunfpnmodw62je6z2bv4mu/crdi5mfier2zsiyjhmqsv6ahnmkzsf2kbs2f344b2bycpypu3wqs.wrapper.cpp:1154:5: note: in expansion of macro ‘AOTI_TORCH_CHECK’
 1154 |     AOTI_TORCH_CHECK(u3 != 0, "Integer floor division by zero");
      |     ^~~~~~~~~~~~~~~~
/usr/local/lib/python3.12/dist-packages/torch/include/torch/csrc/inductor/aoti_torch/c/shim.h:653:9: error: ‘TORCH_CHECK_MSG’ was not declared in this scope
  653 |         TORCH_CHECK_MSG(cond, "", ##__VA_ARGS__)); \
      |         ^~~~~~~~~~~~~~~
/tmp/tmpy8si4z09/cclba4dxphu7kzfjkl4iq34w7ausznmunfpnmodw62je6z2bv4mu/crdi5mfier2zsiyjhmqsv6ahnmkzsf2kbs2f344b2bycpypu3wqs.wrapper.cpp:1155:5: note: in expansion of macro ‘AOTI_TORCH_CHECK’
 1155 |     AOTI_TORCH_CHECK(u3 != 0, "Integer floor division by zero");
      |     ^~~~~~~~~~~~~~~~


To execute this test, run the following from the base repo dir:
    python test/inductor/test_aot_inductor.py AOTInductorTestABICompatibleGpu.test_unbacked_expr_replacements_shift_k_0_use_static_size_False_cuda

```
authored with claude code

cc @mruberry @desertfire @penguinwu @yushangdi @benjaminglass1 @jataylo @iupaikov-amd