### PR TITLE
[CuTe][TEST] Fix `test_cutedsl_op_overrides`

### DIFF
--- a/test/inductor/test_cutedsl_template.py
+++ b/test/inductor/test_cutedsl_template.py
@@ -418,11 +418,13 @@ SCALE_FACTOR: cutlass.Constexpr = 1.5
         mock_cse_a.__str__.return_value = "tensor_a"
         mock_cse_a.dtype = torch.float32
         mock_cse_a.bounds = ValueRanges.unknown()
+        mock_cse_a.shape = (32, 64)
 
         mock_cse_b = MagicMock(spec=CSEVariable)
         mock_cse_b.__str__.return_value = "tensor_b"
         mock_cse_b.dtype = torch.float32
         mock_cse_b.bounds = ValueRanges.unknown()
+        mock_cse_b.shape = (32, 64)
 
         mock_graph = MockGraphHandler()
         with V.set_graph_handler(mock_graph):
@@ -447,14 +449,20 @@ SCALE_FACTOR: cutlass.Constexpr = 1.5
                 result = CuteDSLOpOverrides.sqrt(mock_cse_a)
                 self.assertIsInstance(result, CSEVariable)
 
-                with self.assertRaises(NotImplementedError):
-                    result = CuteDSLOpOverrides.maximum(mock_cse_a, mock_cse_b)
-                    result = CuteDSLOpOverrides.minimum(mock_cse_a, mock_cse_b)
+                result = CuteDSLOpOverrides.maximum(mock_cse_a, mock_cse_b)
+                self.assertIsInstance(result, CSEVariable)
 
-        scalar_result = CuteDSLOpOverrides._ensure_tensor_ssa("5.0", mock_cse_a)
+                result = CuteDSLOpOverrides.minimum(mock_cse_a, mock_cse_b)
+                self.assertIsInstance(result, CSEVariable)
+
+        scalar_result = CuteDSLOpOverrides._ensure_tensor_ssa(
+            "5.0", mock_cse_a, is_tensor=False
+        )
         self.assertEqual(scalar_result, "cute.full_like(tensor_a, 5.0)")
 
-        tensor_result = CuteDSLOpOverrides._ensure_tensor_ssa(mock_cse_a, mock_cse_b)
+        tensor_result = CuteDSLOpOverrides._ensure_tensor_ssa(
+            mock_cse_a, mock_cse_b, is_tensor=True
+        )
         self.assertEqual(tensor_result, "tensor_a")
 
     def test_cse_integration(self):


### PR DESCRIPTION
Not sure this is due to an incorrect check or if the mocks were incomplete (this PR assumes the latter)
Otherwise seems to fail with
```
  File "/usr/lib/python3.12/unittest/mock.py", line 658, in __getattr__
    raise AttributeError("Mock object has no attribute %r" % name)
AttributeError: Mock object has no attribute 'shape'
```
authored with claude code


failing lines were introduced in https://github.com/pytorch/pytorch/commit/6e1dce470745cb6dc6bb1027eba96c31b7adac28


cc @mruberry @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo