### PR TITLE
[Windows] Fix missing-prototypes error for flock_() in FileStore.cpp

### DIFF
--- a/torch/csrc/distributed/c10d/FileStore.cpp
+++ b/torch/csrc/distributed/c10d/FileStore.cpp
@@ -32,7 +32,7 @@
 #define LOCK_SH 0x00000010
 #define LOCK_UN 0x00000100
 
-#if defined(_WIN32) && defined(USE_ROCM)
+#ifdef _WIN32
 static
 #endif
     int


### PR DESCRIPTION
When building PyTorch on Windows with clang-cl (which enforces -Werror=missing-prototypes), the torch_cpu target fails with:

  error: no previous prototype for function 'flock_'
         [-Werror=missing-prototypes]

The flock_() function is a Windows-only replacement for the POSIX flock() syscall. Its `static` specifier was incorrectly guarded by both _WIN32 and USE_ROCM, but the function is used by torch_cpu which does not define USE_ROCM. This left the function without `static` in non-ROCm Windows builds, triggering the missing-prototypes error.

The fix removes the USE_ROCM condition so that `static` is always applied on Windows, which is the correct behavior regardless of the ROCm build configuration.

Tested on Windows 11 with AMD gfx1151 (Strix Halo iGPU), ROCm 7.12, clang-cl (MSVC-compatible frontend).