### PR TITLE
Add _sym_log2 to allowed export operators

### DIFF
--- a/torch/_export/verifier.py
+++ b/torch/_export/verifier.py
@@ -233,6 +233,7 @@ class Verifier(metaclass=_VerifierMeta):
                 torch.sym_not,
                 torch.sym_sqrt,
                 torch.sym_sum,
+                torch._sym_log2,
                 torch.export.custom_ops._call_custom_autograd_function_in_pre_dispatch,
                 # TODO (tmanlaibaatar)
                 # Predispatch export is able to contain autograd ops.


### PR DESCRIPTION
Required to export models that contains torch.math.log2(symint).