### PR TITLE
[UT][ROCm][TunableOp] Fix test_call_count_tunableop to correctly extract kernel names for RDNA

### DIFF
--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -6493,9 +6493,9 @@ class TestLinalg(TestCase):
             # launched per PyTorch API. The kernels have string
             # that always starts with `Cijk*`
             mm_key = 'Cijk'
-            events = prof.key_averages()
+            events = prof.events()
             for evt in events:
-                if mm_key in evt.key:
+                if mm_key in evt.name:
                     self.assertEqual(evt.count, 1)
                     kernel_count = kernel_count + 1
 


### PR DESCRIPTION
Fixes #155953 

Original test introduction: https://github.com/pytorch/pytorch/pull/155077

test_call_count_tunableop was failing because key_averages() groups profiler events by name, causing two dispatches of the same kernel to be collapsed into a single entry instead of appearing as separate events. This fix switches to prof.events() to get ungrouped events and matches on evt.name instead of evt.key, so each kernel dispatch is verified individually.

Verified on RDNA hardware with ROCm.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang