### PR TITLE
Fix search for OpenMP using e.g. GCC

### DIFF
--- a/cmake/Modules/FindOpenMP.cmake
+++ b/cmake/Modules/FindOpenMP.cmake
@@ -289,21 +289,13 @@ function(_OPENMP_GET_FLAGS LANG FLAG_MODE OPENMP_FLAG_VAR OPENMP_LIB_NAMES_VAR)
       mark_as_advanced(OpenMP_libomp_LIBRARY)
     endif()
 
-    if (NOT OpenMP_libomp_LIBRARY)
-      find_library(OpenMP_libomp_LIBRARY
-        NAMES omp gomp iomp5
-        HINTS ${CMAKE_${LANG}_IMPLICIT_LINK_DIRECTORIES}
-        DOC "libomp location for OpenMP"
-      )
-      mark_as_advanced(OpenMP_libomp_LIBRARY)
-    endif()
-
     # Use OpenMP_PREFIX if defined
     if (NOT OpenMP_libomp_LIBRARY AND NOT "${OpenMP_PREFIX}" STREQUAL "")
       find_library(OpenMP_libomp_LIBRARY
         NAMES omp gomp iomp5
         HINTS "${OpenMP_PREFIX}/lib"
         DOC "libomp location for OpenMP"
+        NO_DEFAULT_PATH
       )
       mark_as_advanced(OpenMP_libomp_LIBRARY)
     endif()

--- a/cmake/Modules/FindOpenMP.cmake
+++ b/cmake/Modules/FindOpenMP.cmake
@@ -307,21 +307,13 @@ function(_OPENMP_GET_FLAGS LANG FLAG_MODE OPENMP_FLAG_VAR OPENMP_LIB_NAMES_VAR)
       unset(_omp_clang_lib)
     endif()
 
-    if (NOT OpenMP_libomp_LIBRARY)
-      find_library(OpenMP_libomp_LIBRARY
-        NAMES omp gomp iomp5
-        HINTS ${CMAKE_${LANG}_IMPLICIT_LINK_DIRECTORIES}
-        DOC "libomp location for OpenMP"
-      )
-      mark_as_advanced(OpenMP_libomp_LIBRARY)
-    endif()
-
     # Use OpenMP_PREFIX if defined
-    if (NOT OpenMP_libomp_LIBRARY AND NOT "${OpenMP_PREFIX}" STREQUAL "")
+    if (NOT "${OpenMP_PREFIX}" STREQUAL "")
       find_library(OpenMP_libomp_LIBRARY
         NAMES omp gomp iomp5
         HINTS "${OpenMP_PREFIX}/lib"
         DOC "libomp location for OpenMP"
+        NO_DEFAULT_PATH
       )
       mark_as_advanced(OpenMP_libomp_LIBRARY)
     endif()


### PR DESCRIPTION
When Clang is installed a `libomp.so` will exist in addition to `libgomp.so`.
GCC uses `-fopenmp` which will link `libgomp.so`.

However in the MKL workaround path an explicit search for `libomp.so` is inserted taking precedence over `libgomp.so`.

This is not required as the library search will be done further below based on compiler introspection which yields the correct libraries.

Additionally this is seemingly also a bug breaking assumptions in `FindMKL.cmake`: https://github.com/pytorch/pytorch/blob/88b3d0caf11f6074e669f78dbdc7e063d784e347/cmake/Modules/FindMKL.cmake#L282

With the addition to FindOpenMP.cmake in #104224 it will not search for libgomp, but prefer libomp
What is even more confusing:
- FindMKL runs and wants to search for "gomp"
- Calls FindOpenMP


A similar issue exists with `OpenMP_PREFIX`: Only that folder should be checked, not all default folders which will be checked by the introspection below.

Code changed is introduced in #104224

With this change:
- `OpenMP_CXX_LIB_NAMES` will contain `libgomp.so`
- `MKL_OPENMP_LIBRARY` will be `-fopenmp` (from `OpenMP_CXX_FLAGS`)
- `OpenMP_libgomp_LIBRARY` will be set instead of `OpenMP_libomp_LIBRARY`

It seems like #104224 was supposed to resolve this TODO:
```
    # TODO: refactor to solve this weird dependency where
    #         - for non-GNU, FindOpenMP.cmake replies on FindMKL.cmake to finish first, but
    #         - for GNU,     FindMKL.cmake replies on FindOpenMP.cmake to finish first.
```

For non-GNU it seems the only issue concerns where `iomp` from `mklrtls` is tried:
Then `find_library(MKL_IOMP5_LIBRARY)` is run and OpenMP should use that as `OpenMP_libomp_LIBRARY` but [FindOpenMP](https://gitlab.kitware.com/cmake/cmake/-/blob/v3.18.0/Modules/FindOpenMP.cmake) doesn't seem to support preferring a specific implementation so the patch with https://github.com/Flamefire/pytorch/blob/146b405e1db8ff7f130f0a7eef90206c1ff321b9/cmake/Modules/FindOpenMP.cmake#L321-L327

is required so it does not match `-fopenmp` with `-liomp5`. The other part https://github.com/Flamefire/pytorch/blob/146b405e1db8ff7f130f0a7eef90206c1ff321b9/cmake/Modules/FindOpenMP.cmake#L267C7-L267C99
could be done in FindMKL

In any case the code block removed here is not required: Either OpenMP_libomp_LIBRARY is already set to iomp5 through MKL_OPENMP_LIBRARY or the auto-detection below that is more reliably picking the right library
