### PR TITLE
Increase tolerance for conv_transpose3d in TestCompositeCompliance on XPU

### DIFF
--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -16067,6 +16067,9 @@ op_db: list[OpInfo] = [
                    'TestCompositeCompliance', 'test_forward_ad', device_type='cuda',
                    active_if=TEST_CUDNN),
                DecorateInfo(
+                   toleranceOverride({torch.float32: tol(atol=1e-04, rtol=2e-05), }),
+                   'TestCompositeCompliance', 'test_backward', device_type='xpu'),
+               DecorateInfo(
                    toleranceOverride({torch.complex64: tol(atol=1e-4, rtol=1e-4)}),
                    "TestMathBits", "test_conj_view", device_type='cuda'),
                DecorateInfo(


### PR DESCRIPTION
This PR fixes TestCompositeComplianceXPU.test_backward_nn_functional_conv_transpose3d_xpu_float32. Issue raised [here](https://github.com/intel/torch-xpu-ops/issues/2729)

# Why is this needed
The test first computes the expected backward gradients from a direct op call, then reruns the same op many times with different combinations of inputs and grad outputs wrapped in CompositeCompliantTensor, and compares the resulting gradients.

Assert expects the results to be the same, but oneDNN's implementations of convolutional operations are non-deterministic (unless deterministic algorithms are explicitly enabled) For this reason we should expect slightly different results, therefore tolerance should be slightly less strict.