### PR TITLE
Removed  skipIfTorchDynamo from test_set_default_dtype_works_with_foreach unit test

### DIFF
--- a/torch/optim/_adafactor.py
+++ b/torch/optim/_adafactor.py
@@ -499,11 +499,8 @@ def _multi_tensor_adafactor(
         device_grads = cast(list[Tensor], device_grads_)
         device_state_steps = cast(list[Tensor], device_state_steps_)
         if eps1 is None:
-            if dtype is None:
-                raise AssertionError(
-                    "dtype is needed to compute eps1 when eps1 is unset"
-                )
-            eps1 = torch.finfo(dtype).eps
+            eps_dtype = dtype if dtype is not None else device_params[0].dtype
+            eps1 = torch.finfo(eps_dtype).eps
 
         if TYPE_CHECKING:
             assert device_state_steps[0] is not None

--- a/torch/testing/_internal/common_optimizers.py
+++ b/torch/testing/_internal/common_optimizers.py
@@ -1426,11 +1426,6 @@ optim_db: list[OptimizerInfo] = [
         has_capturable_arg=True,
         skips=(
             DecorateInfo(
-                skipIfTorchDynamo("See #116028"),
-                "TestOptimRenewed",
-                "test_set_default_dtype_works_with_foreach",
-            ),
-            DecorateInfo(
                 skipIfTorchDynamo(
                     "Accessing grad.real errors, see https://github.com/pytorch/pytorch/issues/117184"
                 ),
@@ -1534,11 +1529,6 @@ optim_db: list[OptimizerInfo] = [
                 "TestOptimRenewed",
                 "test_save_load_equality_with_weights_only",
                 device_type="cuda",
-            ),
-            DecorateInfo(
-                skipIfTorchDynamo("See #116028 regarding copy not supported"),
-                "TestOptimRenewed",
-                "test_set_default_dtype_works_with_foreach",
             ),
             DecorateInfo(
                 skipIfTorchDynamo("See #133268 regarding dtype being None"),
@@ -1659,11 +1649,6 @@ optim_db: list[OptimizerInfo] = [
         ),
         skips=(
             DecorateInfo(
-                skipIfTorchDynamo("See #116028"),
-                "TestOptimRenewed",
-                "test_set_default_dtype_works_with_foreach",
-            ),
-            DecorateInfo(
                 skipIfTorchDynamo(
                     "Accessing grad.real errors, see https://github.com/pytorch/pytorch/issues/117184"
                 ),
@@ -1739,13 +1724,6 @@ optim_db: list[OptimizerInfo] = [
         skips=(
             DecorateInfo(
                 skipIfTorchDynamo(
-                    "Errors w/ Global state changed, see https://github.com/pytorch/pytorch/issues/116028"
-                ),
-                "TestOptimRenewed",
-                "test_set_default_dtype_works_with_foreach",
-            ),
-            DecorateInfo(
-                skipIfTorchDynamo(
                     "Accessing grad.real errors, see https://github.com/pytorch/pytorch/issues/117184"
                 ),
                 "TestOptimRenewed",
@@ -1767,11 +1745,6 @@ optim_db: list[OptimizerInfo] = [
         supported_impls=("foreach", "differentiable"),
         has_capturable_arg=True,
         skips=(
-            DecorateInfo(
-                skipIfTorchDynamo("See #116028"),
-                "TestOptimRenewed",
-                "test_set_default_dtype_works_with_foreach",
-            ),
             DecorateInfo(
                 skipIfTorchDynamo(
                     "Accessing grad.real errors, see https://github.com/pytorch/pytorch/issues/117184"
@@ -1835,13 +1808,6 @@ optim_db: list[OptimizerInfo] = [
         skips=(
             DecorateInfo(
                 skipIfTorchDynamo(
-                    "Errors w/ Global state changed, see https://github.com/pytorch/pytorch/issues/116028"
-                ),
-                "TestOptimRenewed",
-                "test_set_default_dtype_works_with_foreach",
-            ),
-            DecorateInfo(
-                skipIfTorchDynamo(
                     "Accessing grad.real errors, see https://github.com/pytorch/pytorch/issues/117184"
                 ),
                 "TestOptimRenewed",
@@ -1863,13 +1829,6 @@ optim_db: list[OptimizerInfo] = [
         supported_impls=("foreach", "differentiable"),
         has_capturable_arg=True,
         skips=(
-            DecorateInfo(
-                skipIfTorchDynamo(
-                    "Errors w/ Global state changed, see https://github.com/pytorch/pytorch/issues/116028"
-                ),
-                "TestOptimRenewed",
-                "test_set_default_dtype_works_with_foreach",
-            ),
             DecorateInfo(
                 skipIfTorchDynamo(
                     "Accessing grad.real errors, see https://github.com/pytorch/pytorch/issues/117184"
@@ -1990,13 +1949,6 @@ optim_db: list[OptimizerInfo] = [
         skips=(
             DecorateInfo(
                 skipIfTorchDynamo(
-                    "Errors w/ Global state changed, see https://github.com/pytorch/pytorch/issues/116028"
-                ),
-                "TestOptimRenewed",
-                "test_set_default_dtype_works_with_foreach",
-            ),
-            DecorateInfo(
-                skipIfTorchDynamo(
                     "Accessing grad.real errors, see https://github.com/pytorch/pytorch/issues/117184"
                 ),
                 "TestOptimRenewed",
@@ -2025,13 +1977,6 @@ optim_db: list[OptimizerInfo] = [
         supported_impls=("foreach", "differentiable"),
         has_capturable_arg=True,
         skips=(
-            DecorateInfo(
-                skipIfTorchDynamo(
-                    "Errors w/ Global state changed, see https://github.com/pytorch/pytorch/issues/116028"
-                ),
-                "TestOptimRenewed",
-                "test_set_default_dtype_works_with_foreach",
-            ),
             DecorateInfo(
                 skipIfTorchDynamo(
                     "Accessing grad.real errors, see https://github.com/pytorch/pytorch/issues/117184"
@@ -2066,11 +2011,6 @@ optim_db: list[OptimizerInfo] = [
         has_capturable_arg=True,
         skips=(
             DecorateInfo(
-                skipIfTorchDynamo("See #116028"),
-                "TestOptimRenewed",
-                "test_set_default_dtype_works_with_foreach",
-            ),
-            DecorateInfo(
                 skipIfTorchDynamo(
                     "Accessing grad.real errors, see https://github.com/pytorch/pytorch/issues/117184"
                 ),
@@ -2103,11 +2043,6 @@ optim_db: list[OptimizerInfo] = [
         supported_impls=("foreach", "differentiable"),
         has_capturable_arg=True,
         skips=(
-            DecorateInfo(
-                skipIfTorchDynamo("See #116028"),
-                "TestOptimRenewed",
-                "test_set_default_dtype_works_with_foreach",
-            ),
             DecorateInfo(
                 skipIfTorchDynamo(
                     "Accessing grad.real errors, see https://github.com/pytorch/pytorch/issues/117184"
@@ -2179,13 +2114,6 @@ optim_db: list[OptimizerInfo] = [
             "mps",
         ),
         skips=(
-            DecorateInfo(
-                skipIfTorchDynamo(
-                    "Errors w/ Global state changed, see https://github.com/pytorch/pytorch/issues/116028"
-                ),
-                "TestOptimRenewed",
-                "test_set_default_dtype_works_with_foreach",
-            ),
             DecorateInfo(
                 skipIfTorchDynamo(
                     "Accessing grad.real errors, see https://github.com/pytorch/pytorch/issues/117184"


### PR DESCRIPTION
Fixes #116028

Removed skips for test_set_default_dtype_works_with_foreach Dynamo test. Most of the test already pass due to past updates. Made a small change in the _multi_tensor_adafactor() function so that the only failing test (test_set_default_dtype_works_with_foreach_Adafactor_cuda_float64) passes as well.