### PR TITLE
[ROCm][inductor] Modified addmm template call to support hipblaslt bias fused kernels

### DIFF
--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -2488,7 +2488,9 @@ class TestMaxAutotune(TestCase):
             mat1 = torch.randn(32, 128, device=GPU_TYPE)
             mat2 = torch.randn(128, 64, device=GPU_TYPE)
 
-            from torch._inductor.template_heuristics.aten import ATenAddMMConfigHeuristics
+            from torch._inductor.template_heuristics.aten import (
+                ATenAddMMConfigHeuristics,
+            )
 
             def allow_bias_addmm_configs(self, kernel_inputs, op_name):
                 yield from ATenAddMMConfigHeuristics._get_template_configs_impl(

--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -2455,6 +2455,70 @@ class TestMaxAutotune(TestCase):
         finally:
             clear_preprocessing_fns(clear_defaults=False)
 
+    @unittest.skipIf(not torch.version.hip, "ROCM only")
+    @config.patch(
+        {
+            "max_autotune": True,
+            "max_autotune_gemm_backends": "ATEN",
+            "triton.autotune_cublasLt": True,
+            "triton.native_matmul": False,
+        }
+    )
+    def test_rocm_addmm_aten_bias_input_is_1d(self):
+        """
+        ROCm regression test for addmm autotune input wiring.
+        A 1D bias is required for hipBLASLt bias-fused addmm kernels; expanded 2D
+        bias disables that fused path.
+        """
+        bias_input_ranks: dict[str, set[int]] = {"addmm": set(), "bias_addmm": set()}
+
+        def capture_bias_input_rank(choices):
+            for choice in choices:
+                if isinstance(choice, ExternKernelCaller) and choice.name in (
+                    "addmm",
+                    "bias_addmm",
+                ):
+                    bias_node = choice.input_nodes[0]
+                    bias_input_ranks[choice.name].add(len(bias_node.get_size()))
+            return choices
+
+        add_preprocessing_fn(capture_bias_input_rank)
+        try:
+            bias = torch.randn(64, device=GPU_TYPE)
+            mat1 = torch.randn(32, 128, device=GPU_TYPE)
+            mat2 = torch.randn(128, 64, device=GPU_TYPE)
+
+            from torch._inductor.template_heuristics.aten import ATenAddMMConfigHeuristics
+
+            def allow_bias_addmm_configs(self, kernel_inputs, op_name):
+                yield from ATenAddMMConfigHeuristics._get_template_configs_impl(
+                    self, kernel_inputs, op_name
+                )
+
+            # Relax bias_addmm heuristics here so this test can assert 1D vs 2D bias wiring.
+            with mock.patch(
+                "torch._inductor.template_heuristics.aten.ATenBiasAddMMConfigHeuristics._get_template_configs_impl",
+                autospec=True,
+                side_effect=allow_bias_addmm_configs,
+            ):
+                compiled_fn = torch.compile(
+                    lambda b, x, w: torch.addmm(b, x, w),
+                    dynamic=False,
+                )
+                _ = compiled_fn(bias, mat1, mat2)
+
+            self.assertTrue(
+                bias_input_ranks["addmm"], "Expected ATen addmm choice to be generated"
+            )
+            self.assertTrue(
+                bias_input_ranks["bias_addmm"],
+                "Expected ATen bias_addmm choice to be generated",
+            )
+            self.assertEqual(bias_input_ranks["addmm"], {1})
+            self.assertEqual(bias_input_ranks["bias_addmm"], {1})
+        finally:
+            clear_preprocessing_fns()
+
     @config.patch(
         {"test_configs.max_mm_configs": 4, "max_autotune_gemm_backends": "TRITON"}
     )

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -671,9 +671,10 @@ def tuned_addmm(inp, mat1, mat2, *, alpha=1, beta=1, layout=None):
         ):
             templates_to_use_aten.append(aten_bias_addmm)
         choices.extend(
-            V.choices.get_template_configs(kernel_inputs_aten, templates_to_use_aten, name)
+            V.choices.get_template_configs(
+                kernel_inputs_aten, templates_to_use_aten, name
+            )
         )
-
 
     templates_to_use: list[ExternKernelChoice | KernelTemplate] = []
     if is_nonzero and use_triton_template(layout, check_max_autotune=False):

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -661,22 +661,32 @@ def tuned_addmm(inp, mat1, mat2, *, alpha=1, beta=1, layout=None):
         )
         return node
 
-    # Separate Aten template and Triton template due to they have different kernel inputs
-    templates_to_use_aten: list[ExternKernelChoice | KernelTemplate] = []
-    if use_aten_gemm_kernels():
-        templates_to_use_aten.append(aten_addmm)
-        if (
-            inp_expanded.get_stride()[0] == 0
-            and inductor_config.triton.autotune_cublasLt
-        ):
-            templates_to_use_aten.append(aten_bias_addmm)
-        choices.extend(
-            V.choices.get_template_configs(
-                kernel_inputs_aten, templates_to_use_aten, name
-            )
-        )
-
     templates_to_use: list[ExternKernelChoice | KernelTemplate] = []
+
+    if use_aten_gemm_kernels():
+        is_rocm = torch.version.hip is not None
+        #For Aten on rocm, Separate Aten template and Triton template due to they have different kernel inputs
+        if is_rocm:
+            templates_to_use_aten: list[ExternKernelChoice | KernelTemplate] = []
+            templates_to_use_aten.append(aten_addmm)
+            if (
+                inp_expanded.get_stride()[0] == 0 
+                and inductor_config.triton.autotune_cublasLt
+            ):
+                templates_to_use_aten.append(aten_bias_addmm)
+            choices.extend(
+                V.choices.get_template_configs(
+                    kernel_inputs_aten, templates_to_use_aten, name
+                )
+            )
+        else:
+            templates_to_use.append(aten_addmm)
+            if (
+                inp_expanded.get_stride()[0] == 0
+                and inductor_config.triton.autotune_cublasLt
+            ):
+                templates_to_use.append(aten_bias_addmm)
+    
     if is_nonzero and use_triton_template(layout, check_max_autotune=False):
         templates_to_use.append(mm_template)
 

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -629,6 +629,10 @@ def tuned_addmm(inp, mat1, mat2, *, alpha=1, beta=1, layout=None):
     kernel_inputs = MMKernelInputs(
         [inp_expanded, mat1, mat2], scalars=dict(alpha=alpha, beta=beta)
     )
+    kernel_inputs_aten = MMKernelInputs(
+        [inp, mat1, mat2], scalars=dict(alpha=alpha, beta=beta)
+    )
+
     choices: list[ChoiceCaller] = []
 
     # below is for getting an overview logging info of inductor mms
@@ -645,15 +649,9 @@ def tuned_addmm(inp, mat1, mat2, *, alpha=1, beta=1, layout=None):
     if (not is_nonzero) or (
         not (inductor_config.max_autotune or inductor_config.max_autotune_gemm)
     ):
-        # TODO(coconutruben): combine this with the main flow of addmm through
-        # a subgraph or something as inp vs inp_expanded causes some slight numeric
-        # differences
-        kernel_inputs = MMKernelInputs(
-            [inp, mat1, mat2], scalars=dict(alpha=alpha, beta=beta)
-        )
         choices.extend(
             V.choices.get_template_configs(
-                kernel_inputs,
+                kernel_inputs_aten,
                 [aten_addmm],
                 name,
             )
@@ -663,16 +661,21 @@ def tuned_addmm(inp, mat1, mat2, *, alpha=1, beta=1, layout=None):
         )
         return node
 
-    # Collect all templates for unified call
-    templates_to_use: list[ExternKernelChoice | KernelTemplate] = []
+    # Separate Aten template and Triton template due to they have different kernel inputs
+    templates_to_use_aten: list[ExternKernelChoice | KernelTemplate] = []
     if use_aten_gemm_kernels():
-        templates_to_use.append(aten_addmm)
+        templates_to_use_aten.append(aten_addmm)
         if (
             inp_expanded.get_stride()[0] == 0
             and inductor_config.triton.autotune_cublasLt
         ):
-            templates_to_use.append(aten_bias_addmm)
+            templates_to_use_aten.append(aten_bias_addmm)
+        choices.extend(
+            V.choices.get_template_configs(kernel_inputs_aten, templates_to_use_aten, name)
+        )
 
+
+    templates_to_use: list[ExternKernelChoice | KernelTemplate] = []
     if is_nonzero and use_triton_template(layout, check_max_autotune=False):
         templates_to_use.append(mm_template)
 

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -665,12 +665,12 @@ def tuned_addmm(inp, mat1, mat2, *, alpha=1, beta=1, layout=None):
 
     if use_aten_gemm_kernels():
         is_rocm = torch.version.hip is not None
-        #For Aten on rocm, Separate Aten template and Triton template due to they have different kernel inputs
+        # For Aten on rocm, Separate Aten template and Triton template due to they have different kernel inputs
         if is_rocm:
             templates_to_use_aten: list[ExternKernelChoice | KernelTemplate] = []
             templates_to_use_aten.append(aten_addmm)
             if (
-                inp_expanded.get_stride()[0] == 0 
+                inp_expanded.get_stride()[0] == 0
                 and inductor_config.triton.autotune_cublasLt
             ):
                 templates_to_use_aten.append(aten_bias_addmm)
@@ -686,7 +686,7 @@ def tuned_addmm(inp, mat1, mat2, *, alpha=1, beta=1, layout=None):
                 and inductor_config.triton.autotune_cublasLt
             ):
                 templates_to_use.append(aten_bias_addmm)
-    
+
     if is_nonzero and use_triton_template(layout, check_max_autotune=False):
         templates_to_use.append(mm_template)
 

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -664,9 +664,8 @@ def tuned_addmm(inp, mat1, mat2, *, alpha=1, beta=1, layout=None):
     templates_to_use: list[ExternKernelChoice | KernelTemplate] = []
 
     if use_aten_gemm_kernels():
-        is_rocm = torch.version.hip is not None
         # For Aten on rocm, Separate Aten template and Triton template due to they have different kernel inputs
-        if is_rocm:
+        if torch.version.hip:
             templates_to_use_aten: list[ExternKernelChoice | KernelTemplate] = []
             templates_to_use_aten.append(aten_addmm)
             if (

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -664,27 +664,20 @@ def tuned_addmm(inp, mat1, mat2, *, alpha=1, beta=1, layout=None):
     templates_to_use: list[ExternKernelChoice | KernelTemplate] = []
 
     if use_aten_gemm_kernels():
-        # For Aten on rocm, Separate Aten template and Triton template due to they have different kernel inputs
+        aten_templates: list[ExternKernelChoice | KernelTemplate] = [aten_addmm]
+        if (
+            inp_expanded.get_stride()[0] == 0
+            and inductor_config.triton.autotune_cublasLt
+        ):
+            aten_templates.append(aten_bias_addmm)
+
+        # On ROCm, ATen choices use original bias input; non-ROCm keeps unified inputs.
         if torch.version.hip:
-            templates_to_use_aten: list[ExternKernelChoice | KernelTemplate] = []
-            templates_to_use_aten.append(aten_addmm)
-            if (
-                inp_expanded.get_stride()[0] == 0
-                and inductor_config.triton.autotune_cublasLt
-            ):
-                templates_to_use_aten.append(aten_bias_addmm)
             choices.extend(
-                V.choices.get_template_configs(
-                    kernel_inputs_aten, templates_to_use_aten, name
-                )
+                V.choices.get_template_configs(kernel_inputs_aten, aten_templates, name)
             )
         else:
-            templates_to_use.append(aten_addmm)
-            if (
-                inp_expanded.get_stride()[0] == 0
-                and inductor_config.triton.autotune_cublasLt
-            ):
-                templates_to_use.append(aten_bias_addmm)
+            templates_to_use.extend(aten_templates)
 
     if is_nonzero and use_triton_template(layout, check_max_autotune=False):
         templates_to_use.append(mm_template)


### PR DESCRIPTION
##Motivation

We found that in some GEMM with bias cases, we got poorer performance with torch compile and max autotune than without it. And the root cause is that when we turn on max autotune, inductor cannot call hipblaslt bias fused kernels. And if it doesn't call fused kernel, it will call a triton fused kerenl or a separate Aten solution (a single GEMM kernel + an elementwise kernel). And the separate Aten solution has a worse perf than hipblaslt fused kernels.

##Technical Details

In the current code, inductor will use inp_expanded as the bias argument for addmm lowering kernel inputs. Inp_expanded is the bias argument expanded from 1D to 2D after arg processing. Hipblaslt bias fused kernel cannot support 2D bias input, so inductor cannot call hipblaslt bias fused kernels now.
This PR use original 1D bias argument as the kernel input for aten addmm to enable hipblaslt bias fused kernel in inductor

##Test Result

In my case, mnk is [4352 , 1024 , 1024]
Without the PR, inductor will run two kernels, and the perf is GEMM 71.659us, elementwise 13.619us, the total execution time is 95us.
With the PR, inductor will choose a hipblaslt bias fused kernel, the execution time is 63.504us.


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @mlazos