### PR TITLE
inductor: Fix invalid tiling for >=3D reductions w/max_tiles

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -17606,6 +17606,43 @@ if RUN_GPU:
             self.assertIn("0x80000000", code[0])
             torch.testing.assert_close(result, fn(inp))
 
+        def test_3d_reductions_with_max_tiles_3(self):
+            # Inductor only supports at most two reduction iteration ranges, R0 and R1.
+            # When max_tiles=3, SIMDScheduling.create_tiling incorrectly allows the tiling of
+            # the reduction in 3D, spreading one of the reduction dimensions over X, despite there
+            # being no pointwise component of the kernel. This leads to a valid kernel that
+            # generates an invalid result.
+
+            @torch._inductor.config.patch(
+                {
+                    "triton.prefer_nd_tiling": True,
+                    "triton.max_tiles": 3,
+                    "triton.tile_reductions": True,
+                    "triton.use_tensor_descriptor": True,
+                }
+            )
+            @torch.compile
+            def sum(x):
+                return torch.sum(x, [0, 1, 2])
+
+            shape = (2, 2, 4)
+            strides = (32, 8, 1)
+
+            arg0_1_orig = torch.arange(math.prod(shape), device=GPU_TYPE, dtype=torch.int32).view(shape)
+            arg0_1 = torch.empty_strided(shape, strides, device=GPU_TYPE, dtype=torch.int32)
+            arg0_1.copy_(arg0_1_orig)
+
+            actual, code = run_and_get_code(sum, arg0_1)
+            expected = torch.sum(arg0_1, [0, 1, 2])
+
+            torch.testing.assert_close(actual=actual, expected=expected)
+
+            fc = FileCheck()
+            # There's no pointwise work to do, so xnumel should be 1...
+            fc.check("xnumel = 1")
+            fc.run(code[0])
+
+
     class RNNTest(TestCase):
         device_type = GPU_TYPE
 

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -17607,11 +17607,11 @@ if RUN_GPU:
             torch.testing.assert_close(result, fn(inp))
 
         def test_3d_reductions_with_max_tiles_3(self):
-            # Inductor only supports at most two reduction iteration ranges, R0 and R1.
-            # When max_tiles=3, SIMDScheduling.create_tiling incorrectly allows the tiling of
-            # the reduction in 3D, spreading one of the reduction dimensions over X, despite there
-            # being no pointwise component of the kernel. This leads to a valid kernel that
-            # generates an invalid result.
+            # Inductor only supports at most two reduction iteration ranges, R0 and R1, which the
+            # reduction component of the kernel can be tiled across.
+            # When max_tiles>=3, SIMDScheduling.create_tiling would previously incorrectly allow the
+            # tiling of the kernel in three dimensions, despite there being no pointwise component
+            # of the kernel.
 
             @torch._inductor.config.patch(
                 {

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -17628,8 +17628,12 @@ if RUN_GPU:
             shape = (2, 2, 4)
             strides = (32, 8, 1)
 
-            arg0_1_orig = torch.arange(math.prod(shape), device=GPU_TYPE, dtype=torch.int32).view(shape)
-            arg0_1 = torch.empty_strided(shape, strides, device=GPU_TYPE, dtype=torch.int32)
+            arg0_1_orig = torch.arange(
+                math.prod(shape), device=GPU_TYPE, dtype=torch.int32
+            ).view(shape)
+            arg0_1 = torch.empty_strided(
+                shape, strides, device=GPU_TYPE, dtype=torch.int32
+            )
             arg0_1.copy_(arg0_1_orig)
 
             actual, code = run_and_get_code(sum, arg0_1)
@@ -17641,7 +17645,6 @@ if RUN_GPU:
             # There's no pointwise work to do, so xnumel should be 1...
             fc.check("xnumel = 1")
             fc.run(code[0])
-
 
     class RNNTest(TestCase):
         device_type = GPU_TYPE

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -2610,10 +2610,16 @@ class SIMDScheduling(BaseScheduling):
         """
         Create a tiling dict from pointwise and reduction splits.
         """
-        pw_prefixes = ["z", "y", "x"][-len(pw_tiling) :]
-        reduction_prefixes = ["r0_", "r1_"][: len(reduction_tiling)]
+        pw_prefixes = ("z", "y", "x")
+        reduction_prefixes = ("r0_", "r1_")
+        assert len(pw_tiling) <= len(pw_prefixes)
+        assert len(reduction_tiling) <= len(reduction_prefixes)
+
         return immutable_dict(
-            [*zip(pw_prefixes, pw_tiling), *zip(reduction_prefixes, reduction_tiling)]
+            [
+                *zip(pw_prefixes[-len(pw_tiling) :], pw_tiling, strict=False),
+                *zip(reduction_prefixes, reduction_tiling, strict=False),
+            ]
         )
 
     @classmethod
@@ -2671,6 +2677,12 @@ class SIMDScheduling(BaseScheduling):
             if not dims:
                 return (fallback_numel,)
             max_tiles = get_max_tiles(2)
+            if V.graph.sizevars.statically_known_equals(
+                pointwise_numel, 1
+            ) and V.graph.sizevars.statically_known_gt(reduction_numel, 1):
+                # We only have at most two dimensions to tile over when emitting a
+                # reduction-only kernel.
+                max_tiles = min(max_tiles, 2)
             num_leading_dims = max(0, len(dims) - max_tiles)
             first_trailing_dim = num_leading_dims + 1
             collapsed_leading_dim = sympy_product(dims[:first_trailing_dim])


### PR DESCRIPTION
Inductor only supports at most two reduction iteration ranges, `r0` and `r1`. When `max_tiles>=3`, `SIMDScheduling.create_nd_tiling` would incorrectly allow the tiling of the reduction in more than two dimensions, resulting in some of the tiling going in to the `x`/`y`/`z` dimensions despite there being no pointwise component of the kernel.

To resolve this, I've capped the max_tiles at this case to at most two dimensions, and added asserts to make sure that the code doesn't silently allow a mismatch of tiling configuration and iteration range prefixes.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo