### PR TITLE
[Native DSL] Add CODEOWNER

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -236,3 +236,6 @@ torch/backends/cudnn/ @eqy @syed-ahmed @Aidyn-A
 /torch/sparse/ @amjames @pearu @nikitaved
 /test/test_sparse.py @amjames @pearu @nikitaved
 /test/test_sparse_csr.py @amjames @pearu @nikitaved
+
+# Python/DSL native ops
+/torch/_native/ @slayton58

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -238,4 +238,4 @@ torch/backends/cudnn/ @eqy @syed-ahmed @Aidyn-A
 /test/test_sparse_csr.py @amjames @pearu @nikitaved
 
 # Python/DSL native ops
-/torch/_native/ @slayton58
+/torch/_native/ @slayton58 @drisspg


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #177139

Summary:

Add @slayton58 as code-owner for `torch/_native`

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags:
Signed-off-by: Simon Layton <simonlayton@meta.com>