### PR TITLE
[FSDP2] Remove redundant event wait for all_gather_stream

### DIFF
--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
@@ -431,8 +431,6 @@ class FSDPParamGroup:
         # Calling `unshard` before lazy init means streams are not initialized
         if hasattr(self.comm_ctx, "all_gather_copy_in_stream") and event is not None:
             self.comm_ctx.all_gather_copy_in_stream.wait_event(event)
-        if hasattr(self.comm_ctx, "all_gather_stream") and event is not None:
-            self.comm_ctx.all_gather_stream.wait_event(event)
 
     def reshard(self):
         if self._training_state == TrainingState.FORWARD:


### PR DESCRIPTION
For implicit prefetch, making the all-gather stream waiting for the copy-out event is redundant because the all-gather stream  already waits for the copy-in stream and copy-in stream waits for the copy-out event.

From the memory perspective, the peak memory bound of parameter storage is 3x with or without this wait. From the performance perspective, less redundant wait will always perserve or improve performance.

The intuition is that the copy-in stream is the stream that allocates and owns the AG buffer and there is no mem alloc on all-gather stream. From the memory management perspective, having the copy-in stream waiting for the copy-out stream is enough and blocking the all-gather communication stream maybe redundant.

<img width="5770" height="3296" alt="fsdp2-forward-timeline-implicit" src="https://github.com/user-attachments/assets/ca6e7757-4478-4803-a924-5aa2aadbeb28" />