### PR TITLE
Add NCCL collective sequence number (seq_num) to Kineto profiler traces

### DIFF
--- a/torch/csrc/distributed/c10d/ParamCommsUtils.hpp
+++ b/torch/csrc/distributed/c10d/ParamCommsUtils.hpp
@@ -5,6 +5,7 @@
 #include <c10/macros/Macros.h>
 #include <c10/util/ThreadLocalDebugInfo.h>
 #include <string>
+#include <tuple>
 #include <vector>
 
 namespace torch {
@@ -84,6 +85,19 @@ class TORCH_API ParamCommsDebugInfo : public c10::DebugInfoBase {
     return isAsynchronizedOp_;
   }
 
+  int64_t getSequenceNumber() const {
+    return sequenceNumber_;
+  }
+
+  bool getIsP2P() const {
+    return isP2P_;
+  }
+
+  void setSequenceInfo(int64_t seqNum, bool isP2P) {
+    sequenceNumber_ = seqNum;
+    isP2P_ = isP2P;
+  }
+
  private:
   std::tuple<std::string, std::string> pgName_; // <group_name, group_desc>
   int rank_{};
@@ -98,7 +112,23 @@ class TORCH_API ParamCommsDebugInfo : public c10::DebugInfoBase {
   int globalRankStride_{};
   std::vector<int64_t> groupRanks_;
   bool isAsynchronizedOp_{};
+  int64_t sequenceNumber_{-1};
+  bool isP2P_{false};
 };
+
+// Helper to set sequence info from tuple-typed seq arguments (NCCL backend).
+// No-op fallback for backends that pass non-tuple seq types (e.g., XPU/XCCL).
+template <typename A, typename B>
+inline void maybeSetSequenceInfo(
+    const std::shared_ptr<ParamCommsDebugInfo>& info,
+    const std::tuple<A, B>& seq) {
+  info->setSequenceInfo(std::get<0>(seq), std::get<1>(seq));
+}
+
+template <typename T>
+inline void maybeSetSequenceInfo(
+    const std::shared_ptr<ParamCommsDebugInfo>&,
+    const T&) {}
 
 #define RECORD_PARAM_COMMS(                                                    \
     seq,                                                                       \
@@ -126,6 +156,7 @@ class TORCH_API ParamCommsDebugInfo : public c10::DebugInfoBase {
       globalRankStride,                                                        \
       worldSize,                                                               \
       false);                                                                  \
+  torch::maybeSetSequenceInfo(paramCommsInfo, seq);                            \
   c10::DebugInfoGuard g(c10::DebugInfoKind::PARAM_COMMS_INFO, paramCommsInfo); \
   std::initializer_list<const c10::IValue> paramList = {                       \
       seq,                                                                     \
@@ -202,6 +233,7 @@ class TORCH_API ParamCommsDebugInfo : public c10::DebugInfoBase {
       globalRankStride,                                                        \
       worldSize,                                                               \
       isAsyncOp);                                                              \
+  torch::maybeSetSequenceInfo(paramCommsInfo, seq);                            \
   c10::DebugInfoGuard g(c10::DebugInfoKind::PARAM_COMMS_INFO, paramCommsInfo); \
   std::initializer_list<const c10::IValue> paramList = {                       \
       c10::IValue(InputTensors),                                               \

--- a/torch/csrc/profiler/util.cpp
+++ b/torch/csrc/profiler/util.cpp
@@ -509,6 +509,11 @@ std::unordered_map<std::string, std::string> saveNcclMeta(
         map.emplace(kP2pSrc, std::to_string(groupRanks[rank]));
       }
     }
+
+    auto seqNum = debugInfo->getSequenceNumber();
+    if (seqNum >= 0) {
+      map.emplace(kSeqNum, std::to_string(seqNum));
+    }
   }
 
   map.emplace(

--- a/torch/csrc/profiler/util.h
+++ b/torch/csrc/profiler/util.h
@@ -201,6 +201,7 @@ constexpr auto kGroupRanks = "Process Group Ranks";
 constexpr auto kRank = "Rank";
 constexpr auto kP2pSrc = "Src Rank";
 constexpr auto kP2pDst = "Dst Rank";
+constexpr auto kSeqNum = "Seq";
 constexpr auto kInTensorsStart = "Input Tensors start";
 constexpr auto kOutTensorsStart = "Output Tensors start";
 constexpr auto kIsAsynchronizedOp = "Is asynchronized op";


### PR DESCRIPTION
Summary:
Thread the per-process-group sequence number from ProcessGroupNCCL through
ParamCommsDebugInfo into the Kineto trace JSON output.

This enables cross-rank correlation of collective operations: all ranks
participating in the same collective instance share the same seq_num
within a process group. Without this, there is no way to match collective
events across ranks in production trace data.

Changes:
- ParamCommsUtils.hpp: Add sequenceNumber_/isP2P_ fields and setter to
  ParamCommsDebugInfo. Update RECORD_PARAM_COMMS and RECORD_PARAM_COMMS_DATA
  macros to populate them from the existing seq tuple.
- util.h: Add kSeqNum constant ("Seq")
- util.cpp: Emit seq_num in saveNcclMeta() when available
- test_c10d_nccl_seq_num_trace.py: Automated test verifying seq_num appears
  correctly in chrome trace output

Test Plan: buck2 test fbcode//mode/dev-nosan fbcode//caffe2/test/distributed/fb:test_c10d_nccl_seq_num_trace — 2/2 pass

Differential Revision: D96145503


