### PR TITLE
[ROCm] fix radixselect

### DIFF
--- a/aten/src/ATen/native/cuda/SortingRadixSelect.cuh
+++ b/aten/src/ATen/native/cuda/SortingRadixSelect.cuh
@@ -521,6 +521,7 @@ __device__ __forceinline__ void countRadixAggregateCounts(
   for (uint32_t i = 0; i < RadixSize; ++i) {
     counts[i] = smem[buffer_offset + i];
   }
+  __syncthreads(); // Wait for all threads to finish reading the final counts.
 }
 
 // This function counts the distribution of all input values in a


### PR DESCRIPTION
Summary:
https://github.com/pytorch/pytorch/pull/174837 (D94770109) introduced a race condition situation.
## symptom
 running it in reference service under high qps, the service will crash on such error: `HSA_STATUS_ERROR_EXCEPTION: An HSAIL operation resulted in a hardware exception. code: 0x1016`

## The Race

After countRadixAggregateCounts Stage 3 (line 514):
  counts[i] = smem[buffer_offset + i];   // ALL threads read, buffer_offset could be 0
  // NO __syncthreads() — function returns immediately

Then in the radixSelect main loop:
  buffer_index ^= 1;                      // line 966, toggle
  // ... bucket loop evaluates counts[] ...
  found_unique(i, count) fires →
    findPatternDataSmem((scalar_t*)smem)   // line 1014
      smem[0] = (scalar_t)0;              // line 689 — WRITE to smem[0]
      smem[1] = (scalar_t)0;              // line 690 — WRITE to smem[1]
      __syncthreads();                     // line 693

When buffer_index = 0 was used for counting, Stage 3 reads from smem[0..3]. Then findPatternDataSmem writes smem[0] and smem[1] (cast to scalar_t*, same physical memory). There is no __syncthreads()
 between these reads and writes.

Since warps execute independently, warp 0 (containing thread 0) can reach line 689 and write smem[0] while a lagging warp is still at line 514 reading smem[0].

## Why This Can Be Dangerous

The corruption writes scalar_t(0) (bit pattern 0x00000000 for float) over the int count values. If the lagging warp reads a corrupted counts[0] or counts[1] (now 0 instead of the real count):

1. Divergent control flow: The lagging warp's found_unique(i, count) check uses the corrupted count. If the corrupted bucket was the one that should have triggered found_unique (count was 1, now reads as 0), that warp skips it and falls through the bucket loop without returning.
2. Mismatched __ syncthreads(): Warp 0 is inside findPatternLoop which has __ syncthreads() at lines 646 and 652. The lagging warp is NOT in findPatternLoop — it continued to the next digitPos iteration, hitting __ syncthreads() inside fillDataSmem or countRadixAggregateCounts. Divergent __syncthreads() is undefined behavior on GPUs and can cause hangs or crashes.
3. Incorrect kth_value: Even if it doesn't hang, the lagging warp may compute a different kth_value entirely. When the kernel later uses this for the gather phases, it could:
    - Collect the wrong number of elements → CUDA_KERNEL_ASSERT(write_index < k) → ASSERT_TRAP (exactly matching the error in D94938108's description)
    - Or produce silently incorrect TopK results

When Can This Happen?

  ┌───────────────────────────────────────────────┬───────────────────────────────────────────────────────────────────────────┐
  │                   Condition                   │                                Likelihood                                 │
  ├───────────────────────────────────────────────┼───────────────────────────────────────────────────────────────────────────┤
  │ buffer_index = 0 during final counting        │ 50% per radixSelect call                                                  │
  ├───────────────────────────────────────────────┼───────────────────────────────────────────────────────────────────────────┤
  │ found_unique fires (count == 1, kToFind == 1) │ Common — happens in final radix iterations                                │
  ├───────────────────────────────────────────────┼───────────────────────────────────────────────────────────────────────────┤
  │ Sufficient warp skew (~100+ instructions)     │ Rare normally, but increases under GPU memory pressure / high utilization │
  └───────────────────────────────────────────────┴───────────────────────────────────────────────────────────────────────────┘

Test Plan:
hard to repro in single test case.
we run it in a service under high qps, it will crash after the qps reaches some high number.

with this fix, the job can succeed - https://www.internalfb.com/vanguard/serving_test_cases/909207988628161

Differential Revision: D96015407




cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang