### PR TITLE
Install `flash-attn-4` and `cutlass_api` w/o `-e` option

### DIFF
--- a/.ci/pytorch/common_utils.sh
+++ b/.ci/pytorch/common_utils.sh
@@ -320,7 +320,7 @@ function install_flash_attn_cute() {
   git checkout "${flash_attn_commit}"
 
   # Install only the 'cute' sub-directory
-  pip_install -e flash_attn/cute/
+  pip_install flash_attn/cute/
   popd
 
   # remove the local repo
@@ -367,7 +367,7 @@ function install_cutlass_api() {
   git checkout "${cutlass_commit}"
 
   # Install cutlass_api with torch extras
-  pip_install -e "python/cutlass_api[torch]"
+  pip_install "python/cutlass_api[torch]"
   popd
 
   rm -rf cutlass-build


### PR DESCRIPTION
Currently these two are editable installed but their source code is removed thus they can be unimportable in the end.

In [a recent B200 smoke test](https://github.com/pytorch/pytorch/actions/runs/22947720282/job/66607238074), `nn/attention/test_fa4` completed successfully, but it only took 0.04 min according to
https://github.com/pytorch/pytorch/actions/runs/22947720282/job/66607238074#step:27:2009, which I'm guessing indicates all the tests are actually skipped.