### PR TITLE
[dynamo] Use .shape instead of .size() in graph size telemetry

### DIFF
--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -2269,7 +2269,7 @@ class OutputGraph(OutputGraphCommon):
         for node in self.graph.nodes:
             example_value = node.meta.get("example_value", None)
             if isinstance(example_value, torch._subclasses.FakeTensor):
-                size = example_value.size()
+                size = example_value.shape
                 ret[node.name] = [s if isinstance(s, int) else repr(s) for s in size]
         return ret
 
@@ -2279,7 +2279,7 @@ class OutputGraph(OutputGraphCommon):
         for node in self.graph.nodes:
             example_value = node.meta.get("example_value", None)
             if isinstance(example_value, torch._subclasses.FakeTensor):
-                size = example_value.size()
+                size = example_value.shape
                 graph_sizes_str += f"{node.name}: {tuple(size)}\n"
                 concrete_size = []
                 has_symint = False


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/162677

Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #177151

Fix flaky TypeError in get_graph_sizes_structured on free-threaded
Python 3.14t. The .size() method has dual behavior (.size() returns
torch.Size, .size(dim) returns int) and goes through __torch_function__
dispatch, which can produce an int instead of torch.Size in rare cases.
The .shape property directly reads the stored sizes from C++ without
method dispatch, avoiding this issue.

These functions run in a finally block during compilation where
exceptions can crash compilation and suppress telemetry.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo