### PR TITLE
[Inductor] Clear CUTLASSCodeCache.write lru_cache on cache_clear

### DIFF
--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -3970,6 +3970,7 @@ class CUTLASSCodeCache:
     def cache_clear(cls) -> None:
         cls.cache.clear()
         cls.aot_kernels_o.clear()
+        cls.write.cache_clear()
 
     @staticmethod
     @lru_cache(maxsize=4)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #177153

The `write` classmethod on `CUTLASSCodeCache` is decorated with
`@lru_cache(None)`, but `cache_clear` only cleared the `cache` dict
and `aot_kernels_o` list. When `fresh_cache()` swaps the cache
directory (e.g. between tests), the stale lru_cache entries still
pointed to the old (now deleted) temp directory, causing
`FileNotFoundError` in `test_cuda_load`.

Fixes https://github.com/pytorch/pytorch/issues/138343

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo