### PR TITLE
[Bugfix][Export] Fix frozen dataclass slot issue for Python3.10 + LeafSpec

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -16039,6 +16039,21 @@ def forward(self, x):
         for node in decomposed_program.graph.nodes:
             self.assertEqual(node.meta["custom"]["my_field"], "dummy")
 
+    def test_run_decompositions_leafspec_deepcopy(self):
+        # Regression test: run_decompositions internally deepcopies the module
+        # call graph which contains TreeSpec objects with LeafSpec nodes.
+        # and has uninitialized slots on Python 3.10
+        class SimpleModel(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = torch.nn.Linear(10, 5)
+
+            def forward(self, x):
+                return self.linear(x)
+
+        ep = export(SimpleModel(), (torch.randn(1, 10),))
+        ep.run_decompositions({})
+
     @testing.expectedFailureStrictV2
     def test_run_decompositions_keep_tensor_constant_metadata(self):
         """Make sure the metadata of tensor constants are kept after run_decompositions."""

--- a/test/test_pytree.py
+++ b/test/test_pytree.py
@@ -1,8 +1,10 @@
 # Owner(s): ["module: pytree"]
 
+import copy
 import enum
 import inspect
 import os
+import pickle
 import re
 import subprocess
 import sys
@@ -817,6 +819,38 @@ class TestGenericPytree(TestCase):
         deserialized_spec = pytree.treespec_loads(serialized)
         self.assertEqual(spec, deserialized_spec)
 
+    @parametrize_pytree_module
+    def test_treespec_deepcopy_roundtrip(self, pytree):
+        cases = [
+            1,
+            (1, 2),
+            [1, 2, 3],
+            {"a": 1, "b": 2},
+            (1, [2, {"a": 3}]),
+            {"a": [1, 2], "b": (3, 4)},
+        ]
+
+        for tree in cases:
+            treespec = pytree.tree_structure(tree)
+            reconstructed = copy.deepcopy(treespec)
+            self.assertEqual(treespec, reconstructed)
+
+    @parametrize_pytree_module
+    def test_treespec_pickle_roundtrip(self, pytree):
+        cases = [
+            1,
+            (1, 2),
+            [1, 2, 3],
+            {"a": 1, "b": 2},
+            (1, [2, {"a": 3}]),
+            {"a": [1, 2], "b": (3, 4)},
+        ]
+
+        for tree in cases:
+            treespec = pytree.tree_structure(tree)
+            reconstructed = pickle.loads(pickle.dumps(treespec))
+            self.assertEqual(treespec, reconstructed)
+
 
 class TestPythonPytree(TestCase):
     def test_deprecated_register_pytree_node(self):
@@ -891,31 +925,6 @@ if "optree" in sys.modules:
             python_pytree.TreeSpec(tuple, None, [])
             != python_pytree.TreeSpec(list, None, []),
         )
-
-    def test_treespec_leaf_deepcopy(self):
-        # Regression test: on Python 3.10.0, frozen+slots dataclasses with
-        # init=False fields and simple defaults (default=None) don't populate
-        # the slots, so copy.deepcopy calls _dataclass_getstate which hits
-        # an uninitialized slot and raises AttributeError.
-        import copy
-
-        spec = python_pytree.treespec_leaf()
-        self.assertTrue(spec.is_leaf())
-        copy.deepcopy(spec)
-
-    def test_leafspec_post_init_initializes_all_slots(self):
-        # Simulate previous failure by bypassing __init__ with
-        # object.__new__ and verify __post_init__ initializes all fields
-        import dataclasses
-        import warnings
-
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", category=FutureWarning)
-            spec = object.__new__(python_pytree.LeafSpec)
-        object.__setattr__(spec, "_children", [])
-        spec.__post_init__()
-        for f in dataclasses.fields(spec):
-            getattr(spec, f.name)
 
     def test_treespec_repr(self):
         # Check that it looks sane

--- a/test/test_pytree.py
+++ b/test/test_pytree.py
@@ -892,6 +892,31 @@ if "optree" in sys.modules:
             != python_pytree.TreeSpec(list, None, []),
         )
 
+    def test_treespec_leaf_deepcopy(self):
+        # Regression test: on Python 3.10.0, frozen+slots dataclasses with
+        # init=False fields and simple defaults (default=None) don't populate
+        # the slots, so copy.deepcopy calls _dataclass_getstate which hits
+        # an uninitialized slot and raises AttributeError.
+        import copy
+
+        spec = python_pytree.treespec_leaf()
+        self.assertTrue(spec.is_leaf())
+        copy.deepcopy(spec)
+
+    def test_leafspec_post_init_initializes_all_slots(self):
+        # Simulate previous failure by bypassing __init__ with
+        # object.__new__ and verify __post_init__ initializes all fields
+        import dataclasses
+        import warnings
+
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=FutureWarning)
+            spec = object.__new__(python_pytree.LeafSpec)
+        object.__setattr__(spec, "_children", [])
+        spec.__post_init__()
+        for f in dataclasses.fields(spec):
+            getattr(spec, f.name)
+
     def test_treespec_repr(self):
         # Check that it looks sane
         tree = (0, [0, 0, [0]])

--- a/torch/utils/_pytree.py
+++ b/torch/utils/_pytree.py
@@ -1344,7 +1344,11 @@ class LeafSpec(TreeSpec):
     _children: list[Self] = dataclasses.field(default_factory=list, init=False)
 
     def __post_init__(self) -> None:
-        # Override `__post_init__` for `num_leaves` derivation.
+        # Explicitly initialize all slots as simple defaults
+        # don't populate the slots on Python 3.10.0, causing
+        # copy.deepcopy to fail.
+        object.__setattr__(self, "type", None)
+        object.__setattr__(self, "_context", None)
         object.__setattr__(self, "num_nodes", 1)
         object.__setattr__(self, "num_leaves", 1)
         object.__setattr__(self, "num_children", 0)

--- a/torch/utils/_pytree.py
+++ b/torch/utils/_pytree.py
@@ -1337,18 +1337,20 @@ PyTreeSpec: TypeAlias = TreeSpec
     "use `isinstance(treespec, TreeSpec) and treespec.is_leaf()` instead.",
     category=FutureWarning,
 )
-@dataclasses.dataclass(init=True, frozen=True, eq=False, repr=False, slots=True)
+@dataclasses.dataclass(init=False, frozen=True, eq=False, repr=False, slots=True)
 class LeafSpec(TreeSpec):
     type: Any = dataclasses.field(default=None, init=False)
     _context: Context = dataclasses.field(default=None, init=False)
     _children: list[Self] = dataclasses.field(default_factory=list, init=False)
 
-    def __post_init__(self) -> None:
-        # Explicitly initialize all slots as simple defaults
-        # don't populate the slots on Python 3.10.0, causing
-        # copy.deepcopy to fail.
+    def __init__(self) -> None:
+        # On Python 3.10.0, the dataclass-generated __init__ for frozen+slots
+        # dataclasses doesn't populate init=False fields with simple defaults,
+        # causing copy.deepcopy to fail with AttributeError. Avoid the bug by
+        # providing a custom __init__ (init=False above) instead.
         object.__setattr__(self, "type", None)
         object.__setattr__(self, "_context", None)
+        object.__setattr__(self, "_children", [])
         object.__setattr__(self, "num_nodes", 1)
         object.__setattr__(self, "num_leaves", 1)
         object.__setattr__(self, "num_children", 0)


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/177045 

## Summary:
Adds explicit initialization which is needed for deep copy LeafSpec in Python3.10


### Test Plan
```bash
python test/test_pytree.py
```
and 
```
python -m pytest test/export/test_export.py::TestExport::test_run_decompositions_leafspec_deepcopy -xvs 
```

authored with Claude Opus 4.6