### PR TITLE
Split _BackendWrapper import to torchcomms._backend_wrapper module

### DIFF
--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -145,6 +145,8 @@ _XCCL_AVAILABLE = True
 try:
     # pyrefly: ignore [missing-import]
     from torchcomms._backend_wrapper import _BackendWrapper
+
+    # pyrefly: ignore [missing-import]
     from torchcomms._comms import new_comm
 
     # pyrefly: ignore [missing-import]

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -144,7 +144,8 @@ _XCCL_AVAILABLE = True
 
 try:
     # pyrefly: ignore [missing-import]
-    from torchcomms._comms import _BackendWrapper, new_comm
+    from torchcomms._backend_wrapper import _BackendWrapper
+    from torchcomms._comms import new_comm
 
     # pyrefly: ignore [missing-import]
     from torchcomms.hooks import FlightRecorderHook


### PR DESCRIPTION
_BackendWrapper has been moved from torchcomms._comms to its own torchcomms._backend_wrapper module. Update the import in distributed_c10d.py to reflect this.
https://github.com/meta-pytorch/torchcomms/pull/895