### PR TITLE
test(inductor): add regression test for symbolic product divisibility propagation

### DIFF
--- a/test/inductor/test_utils.py
+++ b/test/inductor/test_utils.py
@@ -1,6 +1,7 @@
 # Owner(s): ["module: inductor"]
 
 import unittest
+import sympy
 
 from sympy import I, Max, Min, Symbol, sympify
 
@@ -14,6 +15,7 @@ from torch.testing._internal.common_device_type import (
 )
 from torch.testing._internal.common_utils import run_tests, TestCase
 from torch.utils._sympy.functions import Identity
+from torch._inductor.sizevars import SizeVarAllocator
 
 
 class TestUtils(TestCase):
@@ -222,6 +224,51 @@ class TestUtils(TestCase):
     def test_get_device_tflops(self, dtype):
         ret = get_device_tflops(dtype)
         self.assertTrue(type(ret) is float)
+
+    def test_symbolic_multiplication_divisibility_propagation(self):
+        """
+        Verifies that divisibility is correctly propagated through symbolic products.
+        This ensures that if a single factor is known to be divisible by N, 
+        the entire product is also recognized as divisible by N.
+        Ref: https://github.com/pytorch/pytorch/issues/177146
+        """
+
+        # Initialize allocator with a dummy shape environment symbol
+        allocator = SizeVarAllocator(Symbol("dummy_env"))
+
+        # Define symbols representing dimensions
+        s0 = Symbol("s0", integer=True)
+        s1 = Symbol("s1", integer=True)
+        denominator = 16
+
+        # Mock statically_known_true to simulate: torch._check(s1 % 16 == 0)
+        def mock_known_true(expr):
+            return isinstance(expr, sympy.Equality) and \
+                   expr.lhs == sympy.Mod(s1, denominator) and \
+                   expr.rhs == 0
+
+        allocator.statically_known_true = mock_known_true
+
+        # Test Case 1: Simple product (s0 * s1) -> should be divisible by 16
+        product_expr = s0 * s1
+        self.assertTrue(
+            allocator.statically_known_multiple_of(product_expr, denominator),
+            f"Failed to propagate divisibility of {s1} to the product {product_expr}"
+        )
+
+        # Test Case 2: Multi-factor product (s0 * s1 * 2) -> should be divisible by 16
+        complex_product = s0 * s1 * 2
+        self.assertTrue(
+            allocator.statically_known_multiple_of(complex_product, denominator),
+            "Failed to propagate divisibility in a multi-factor product"
+        )
+
+        # Test Case 3: Constant factor divisibility (s0 * 32) -> 32 % 16 == 0
+        constant_multiple = s0 * 32
+        self.assertTrue(
+            allocator.statically_known_multiple_of(constant_multiple, denominator),
+            "Failed to recognize constant factor divisibility directly"
+        )
 
 
 instantiate_device_type_tests(TestUtils, globals(), allow_xpu=True)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -7641,26 +7641,23 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
             test_rnn_cell(cell_fn, gate_count)
 
     def test_conv3d_initialization_consistency(self):
-        # Verify Conv3d initialization parity across different memory formats
-        # to address inconsistency in non-contiguous layouts (e.g., channels_last_3d)
+        # 1. Conv3d layer create karein
         m = torch.nn.Conv3d(3, 6, kernel_size=3)
         
-        # Scenario 1: Default contiguous initialization
+        # 2. Contiguous (Default) format test karein
         torch.manual_seed(42)
         m.reset_parameters()
         weights_default = m.weight.clone().detach()
         
-        # Scenario 2: Non-contiguous (channels_last_3d) initialization
+        # 3. Channels Last 3D format test karein
         m.to(memory_format=torch.channels_last_3d)
         torch.manual_seed(42)
         m.reset_parameters()
         weights_channels_last = m.weight.clone().detach()
         
-        # Assert bit-wise parity between the two layouts
-        self.assertTrue(
-            torch.allclose(weights_default, weights_channels_last),
-            "Conv3d initialization is inconsistent between contiguous and non-contiguous layouts"
-        )
+        # 4. Compare karein ke dono identical hain
+        self.assertEqual(weights_default, weights_channels_last, 
+                         msg="Conv3d initialization is inconsistent between memory formats")
 
 class TestFusionEval(TestCase):
     @set_default_dtype(torch.double)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -7641,21 +7641,21 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
             test_rnn_cell(cell_fn, gate_count)
 
     def test_conv3d_initialization_consistency(self):
-        # 1. Conv3d layer create karein
+        # 1. Create a Conv3d layer
         m = torch.nn.Conv3d(3, 6, kernel_size=3)
         
-        # 2. Contiguous (Default) format test karein
+        # 2. Test initialization in default (contiguous) format
         torch.manual_seed(42)
         m.reset_parameters()
         weights_default = m.weight.clone().detach()
         
-        # 3. Channels Last 3D format test karein
+        # 3. Test initialization in channels_last_3d format
         m.to(memory_format=torch.channels_last_3d)
         torch.manual_seed(42)
         m.reset_parameters()
         weights_channels_last = m.weight.clone().detach()
         
-        # 4. Compare karein ke dono identical hain
+        # 4. Verify both initializations are identical
         self.assertEqual(weights_default, weights_channels_last, 
                          msg="Conv3d initialization is inconsistent between memory formats")
 


### PR DESCRIPTION
### Summary
Added a comprehensive unit test in `test_utils.py` to verify the fix for symbolic divisibility propagation in `SizeVarAllocator`.

### Test Coverage
- **Simple Products:** Confirms divisibility is identified when a single symbolic factor is known to be divisible.
- **Multi-factor Products:** Verifies propagation through complex symbolic expressions (e.g., `s0 * s1 * 2`).
- **Constant Factors:** Ensures direct constant divisibility (e.g., `s0 * 32`) is still correctly handled without regression.

This ensures that optimizations for pointwise kernels, particularly in RMS Norm scenarios, are reliably triggered.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo