### PR TITLE
[Bugfix][Dynamo] Fix einops 0.6.1 with backwards patch

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -447,6 +447,8 @@ test_dynamo_wrapped_shard() {
 }
 
 test_einops() {
+  pip install einops==0.5.0
+  time python test/run_test.py --einops --verbose --upload-artifacts-while-running
   pip install einops==0.6.1
   time python test/run_test.py --einops --verbose --upload-artifacts-while-running
   pip install einops==0.7.0

--- a/test/dynamo/test_einops.py
+++ b/test/dynamo/test_einops.py
@@ -37,9 +37,6 @@ class TestEinops(TestCase):
     in PyTorch.
     """
 
-    @unittest.skipIf(
-        einops_version == "0.6.1", "https://github.com/pytorch/pytorch/issues/157417"
-    )
     @parametrize("version", [einops_version_sanitized])
     def test_functions(self, version):
         from einops import einsum, pack, rearrange, reduce, repeat, unpack

--- a/test/dynamo/test_einops.py
+++ b/test/dynamo/test_einops.py
@@ -24,6 +24,7 @@ if HAS_EINOPS:
 else:
     einops_version = "none"
 einops_version_sanitized = einops_version.replace(".", "_")
+HAS_EINOPS_PACK = HAS_EINOPS and hasattr(einops, "pack")
 
 
 @unittest.skipIf(not HAS_EINOPS, "these tests require einops")
@@ -39,7 +40,11 @@ class TestEinops(TestCase):
 
     @parametrize("version", [einops_version_sanitized])
     def test_functions(self, version):
-        from einops import einsum, pack, rearrange, reduce, repeat, unpack
+        from einops import einsum, rearrange, reduce, repeat
+
+        has_pack = HAS_EINOPS_PACK
+        if has_pack:
+            from einops import pack, unpack
 
         class TorchModuleWithOperations(nn.Module):
             def __init__(self) -> None:
@@ -58,11 +63,16 @@ class TestEinops(TestCase):
                 # by suf function
                 x_abcd = repeat(x_abc, suf("a b c -> a b c 4"))
                 x_abc = reduce(x_abcd, suf("a b c d -> a b c"), "min")
-                x_abdc, ps = pack([x_abc] * (2 + len(suffix)), suf("a b * c"))
-                x_array = unpack(
-                    rearrange(x_abdc, suf("a b d c -> (a b ) 1 c d")), ps, "ab one1 c *"
-                )
-                x1 = x_array[0] + len(x_array)
+                if has_pack:
+                    x_abdc, ps = pack([x_abc] * (2 + len(suffix)), suf("a b * c"))
+                    x_array = unpack(
+                        rearrange(x_abdc, suf("a b d c -> (a b ) 1 c d")),
+                        ps,
+                        "ab one1 c *",
+                    )
+                    x1 = x_array[0] + len(x_array)
+                else:
+                    x1 = rearrange(x_abc, suf("a b c -> (a b ) 1 c"))
                 x1 = rearrange(x1, suf("(a b ) 1 c -> a b c"), b=b)
                 addition = einsum(x_abc, x_abcd, suf("a b c , a b c d -> d"))[0]
                 return x1 + addition
@@ -110,7 +120,12 @@ class TestEinops(TestCase):
         script = """\
 import torch
 import torch.nn as nn
-from einops import einsum, pack, reduce, repeat, unpack, rearrange
+import einops
+from einops import einsum, reduce, repeat, rearrange
+
+has_pack = hasattr(einops, "pack")
+if has_pack:
+    from einops import pack, unpack
 
 class TorchModuleWithOperations(nn.Module):
     def __init__(self) -> None:
@@ -127,9 +142,12 @@ class TorchModuleWithOperations(nn.Module):
         # by suf function
         x_abcd = repeat(x_abc, suf("a b c -> a b c 4"))
         x_abc = reduce(x_abcd, suf("a b c d -> a b c"), "min")
-        x_abdc, ps = pack([x_abc] * (2 + len(suffix)), suf("a b * c"))
-        x_array = unpack(rearrange(x_abdc, suf("a b d c -> (a b ) 1 c d")), ps, "ab one1 c *")
-        x1 = x_array[0] + len(x_array)
+        if has_pack:
+            x_abdc, ps = pack([x_abc] * (2 + len(suffix)), suf("a b * c"))
+            x_array = unpack(rearrange(x_abdc, suf("a b d c -> (a b ) 1 c d")), ps, "ab one1 c *")
+            x1 = x_array[0] + len(x_array)
+        else:
+            x1 = rearrange(x_abc, suf("a b c -> (a b ) 1 c"))
         x1 = rearrange(x1, suf("(a b ) 1 c -> a b c"), b=b)
         addition = einsum(x_abc, x_abcd, suf("a b c , a b c d -> d"))[0]
         return x1 + addition

--- a/torch/_dynamo/decorators.py
+++ b/torch/_dynamo/decorators.py
@@ -1355,6 +1355,25 @@ def mark_static_address(t: Any, guard: bool = False) -> None:
         t._dynamo_static_input_type = "unguarded"  # type: ignore[attr-defined]
 
 
+def _patch_einops_symint_compat(einops_mod: Any) -> None:
+    """Backport the SymInt lru_cache fix from einops 0.7.0 into einops <= 0.6.1."""
+    for name in ("_reconstruct_from_shape", "_prepare_transformation_recipe"):
+        cached = getattr(einops_mod, name)
+        uncached = cached.__wrapped__
+
+        def make_wrapper(cached_fn: Any, uncached_fn: Any) -> Any:
+            @functools.wraps(cached_fn)
+            def wrapper(*args: Any, **kwargs: Any) -> Any:
+                try:
+                    return cached_fn(*args, **kwargs)
+                except TypeError:
+                    return uncached_fn(*args, **kwargs)
+
+            return wrapper
+
+        setattr(einops_mod, name, make_wrapper(cached, uncached))
+
+
 # One day, Dynamo will support tracing into einops directly (no allow_in_graph needed)
 # Note that PyTorch supports multiple versions of einops, so when that day comes,
 # we still need to be really careful about version matches.
@@ -1379,7 +1398,10 @@ def _allow_in_graph_einops() -> None:
 
         # einops > 0.6.1 will call the op registration logic as it is imported.
     except ImportError:
-        # einops <= 0.6.1
+        # einops <= 0.6.1 doesn't handle unhashable SymInt in its lru_cache'd
+        # helpers. Backport the try/except TypeError fallback from einops 0.7.0+
+        # so allow_in_graph works during fake tensor validation.
+        _patch_einops_symint_compat(einops.einops)  # type: ignore[attr-defined]
         allow_in_graph(einops.rearrange)
         allow_in_graph(einops.reduce)
         if hasattr(einops, "repeat"):


### PR DESCRIPTION
## Summary

Backports the fix from einops 0.7.0 into einops <=0.6.1 via monkeypatching

## Test
```bash
python test/dynamo/test_einops.py
```



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo