### PR TITLE
[DTensor] Fix compute_local_stride for unevenly-sharded tensors

### DIFF
--- a/test/distributed/tensor/test_tensor_ops.py
+++ b/test/distributed/tensor/test_tensor_ops.py
@@ -29,6 +29,7 @@ from torch.testing._internal.distributed._tensor.common_dtensor import (
     create_local_tensor_test_class,
     DTensorContinuousTestBase,
     DTensorConverter,
+    DTensorTestBase,
     LocalDTensorContinuousTestBase,
     LocalDTensorTestBase,
     with_comms,
@@ -507,16 +508,22 @@ class DistTensorOpsTest(DTensorContinuousTestBase):
         )
         self.assertTrue(new_empty_strided_dt.contiguous() is new_empty_strided_dt)
 
-        # output shape same as input shape, unevenly sharded input -> output replicated
+        # output shape same as input shape, unevenly sharded input -> output follows input
         global_tensor = torch.randn(12, 7)
         input_dt = distribute_tensor(global_tensor, device_mesh, placement)
         self.assertTrue(input_dt.shape[shard_dim] % self.world_size != 0)
         with comm_mode:
             new_empty_strided_dt = input_dt.new_empty_strided((12, 7), (7, 1))
             self.assertEqual(comm_mode.get_total_counts(), 0)
-        self.assertEqual(new_empty_strided_dt.placements, (Replicate(),))
-        self.assertEqual(new_empty_strided_dt._local_tensor.size(), (12, 7))
-        self.assertEqual(new_empty_strided_dt._local_tensor.stride(), (7, 1))
+        self.assertEqual(new_empty_strided_dt.placements, placement)
+        self.assertEqual(
+            new_empty_strided_dt._local_tensor.size(),
+            input_dt._local_tensor.size(),
+        )
+        self.assertEqual(
+            new_empty_strided_dt._local_tensor.stride(),
+            input_dt._local_tensor.stride(),
+        )
 
         # output shape different from input shape -> output replicated
         global_tensor = torch.randn(12, 8)
@@ -1358,6 +1365,26 @@ class DistTensorCppPyTree(DTensorContinuousTestBase):
             self.assertEqual(hits, 0)
             self.assertEqual(misses, 2)
             self.assertEqual(result.shape, torch.Size([8, 8]))
+
+
+class TestNewEmptyStridedUneven(DTensorTestBase):
+    @with_comms
+    def test_backward_no_allgather(self):
+        """Backward on unevenly-sharded DTensor should not allgather (issue #107661)."""
+        mesh = self.build_device_mesh()
+        placement = (Shard(1),)
+        x = torch.randn(12, self.world_size * 2 + 1, requires_grad=True)
+        dt = distribute_tensor(x, mesh, placement)
+        comm_mode = CommDebugMode()
+        with comm_mode:
+            (dt.to_local() * 2).sum().backward()
+        self.assertEqual(comm_mode.get_total_counts(), 0)
+        self.assertEqual(dt.grad.placements, placement)
+        self.assertTrue(dt.grad._local_tensor.is_contiguous())
+        self.assertEqual(
+            dt.grad._local_tensor,
+            torch.full_like(dt.grad._local_tensor, 2.0),
+        )
 
 
 if __name__ == "__main__":

--- a/test/distributed/tensor/test_tensor_ops.py
+++ b/test/distributed/tensor/test_tensor_ops.py
@@ -1386,6 +1386,30 @@ class TestNewEmptyStridedUneven(DTensorTestBase):
             torch.full_like(dt.grad._local_tensor, 2.0),
         )
 
+    @with_comms
+    def test_backward_channels_last(self):
+        """Backward preserves channels-last stride order for unevenly-sharded DTensor."""
+        mesh = self.build_device_mesh()
+        placement = (Shard(2),)
+        # H=2*world_size+1 ensures uneven sharding on dim 2
+        x = torch.randn(2, 3, self.world_size * 2 + 1, 4).to(
+            memory_format=torch.channels_last
+        )
+        x.requires_grad_(True)
+        dt = distribute_tensor(x, mesh, placement)
+        comm_mode = CommDebugMode()
+        with comm_mode:
+            (dt.to_local() * 2).sum().backward()
+        self.assertEqual(comm_mode.get_total_counts(), 0)
+        self.assertEqual(dt.grad.placements, placement)
+        self.assertTrue(
+            dt.grad._local_tensor.is_contiguous(memory_format=torch.channels_last)
+        )
+        self.assertEqual(
+            dt.grad._local_tensor,
+            torch.full_like(dt.grad._local_tensor, 2.0),
+        )
+
 
 if __name__ == "__main__":
     run_tests()

--- a/torch/distributed/tensor/_ops/_matrix_ops.py
+++ b/torch/distributed/tensor/_ops/_matrix_ops.py
@@ -1293,10 +1293,10 @@ def grouped_mm_strategy(op_schema: OpSchema) -> OpStrategy:
                     f"Expected TensorMeta, got {type(spec.output_specs.tensor_meta)}"
                 )
             meta: TensorMeta = spec.output_specs.tensor_meta
-            local_stride = compute_local_stride(meta.stride, mesh, placements)
             local_shape, _ = compute_local_shape_and_global_offset(
                 meta.shape, mesh, placements, skip_offset=True
             )
+            local_stride = compute_local_stride(meta.stride, local_shape)
             return TensorMeta(torch.Size(local_shape), local_stride, meta.dtype)
 
         # pyrefly: ignore [missing-attribute]

--- a/torch/distributed/tensor/_ops/_tensor_ops.py
+++ b/torch/distributed/tensor/_ops/_tensor_ops.py
@@ -29,7 +29,6 @@ from torch.distributed.tensor._ops.utils import (
     expand_to_full_mesh_op_strategy,
     generate_redistribute_costs,
     is_tensor_dim_sharded,
-    is_tensor_evenly_shardable,
     is_tensor_partial,
     normalize_dim,
     register_op_strategy,
@@ -254,14 +253,6 @@ def new_factory_strategy(op_schema: OpSchema) -> StrategyType:
         )
 
         if tuple(input_shape) == tuple(output_shape) and input_spec.is_sharded():
-            # NOTE: for new_empty_strided, currently the non-replicate sharding
-            #       is supported only when the shape is evenly shardable
-            if (
-                op_schema.op == aten.new_empty_strided.default
-                and not is_tensor_evenly_shardable(input_shape, input_spec)
-            ):
-                continue
-
             new_factory_strategy.strategies.append(
                 OpSpec(
                     output_specs=input_spec,

--- a/torch/distributed/tensor/_sharding_prop.py
+++ b/torch/distributed/tensor/_sharding_prop.py
@@ -939,14 +939,15 @@ class ShardingPropagator:
         expected_input_schema = list(schema.args_schema)
         # adjust shape to be the same as that of the _local_tensor
         # of the DTensor input arg at index 0, which is inferred
-        expected_input_schema[shape_idx], _ = compute_local_shape_and_global_offset(
+        local_shape, _ = compute_local_shape_and_global_offset(
             out_tensor_meta.shape, spec.mesh, spec.placements, skip_offset=True
         )
+        expected_input_schema[shape_idx] = local_shape
 
         # adjust the stride arg for aten.new_empty_strided.default
         if stride_idx:
             expected_input_schema[stride_idx] = compute_local_stride(
-                out_tensor_meta.stride, spec.mesh, spec.placements
+                out_tensor_meta.stride, local_shape
             )
 
         return OpSchema(schema.op, tuple(expected_input_schema), schema.kwargs_schema)

--- a/torch/distributed/tensor/_utils.py
+++ b/torch/distributed/tensor/_utils.py
@@ -446,25 +446,26 @@ def try_find_mesh_from_args(
 
 
 def compute_local_stride(
-    global_stride: ShapeType, mesh: DeviceMesh, placements: Sequence[Placement]
+    global_stride: ShapeType, local_shape: ShapeType
 ) -> tuple[int, ...]:
     """
-    Compute the stride of a local tensor shard, given the global stride of the DTensor.
-    NOTE: Currently this function is assuming the DTensor is evenly shardable.
+    Compute the stride of a local tensor shard, given the global stride and local shape.
+
+    Derives strides by preserving the memory layout (dimension ordering) implied
+    by the global strides, then computing contiguous strides for the local shape
+    in that order.  Assumes the global tensor is non-overlapping and dense.
     """
-    stride_divisors = [1] * len(global_stride)
-    for mesh_idx, p in enumerate(placements):
-        if p.is_shard():
-            i = cast(Shard, p).dim
-            # tensor dimension i is sharded on mesh dimension mesh_idx,
-            # so we need to divide all the strides larger than stride[i]
-            # (by the submesh size)
-            for j in range(len(global_stride)):
-                if global_stride[j] > global_stride[i]:
-                    stride_divisors[j] *= mesh.size(mesh_idx)
-    return tuple(
-        global_stride[i] // stride_divisors[i] for i in range(len(global_stride))
-    )
+    ndim = len(global_stride)
+    # Sort dims by global stride descending to recover memory layout order.
+    # Stable sort preserves original dim order for ties, which only occur
+    # on size-1 dims where the stride value is semantically irrelevant.
+    perm = sorted(range(ndim), key=lambda d: global_stride[d], reverse=True)
+    local_strides = [0] * ndim
+    s = 1
+    for d in reversed(perm):
+        local_strides[d] = s
+        s *= local_shape[d]
+    return tuple(local_strides)
 
 
 def normalize_to_torch_size(size) -> torch.Size:  # type: ignore[no-untyped-def]


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/107661

The old implementation divided global strides by mesh size, which only produced correct results for evenly-shardable tensors.  For uneven sharding (e.g. 7 rows across 4 ranks), the integer division gave wrong strides, so new_empty_strided was forced to fall back to Replicate — causing an unnecessary allgather during backward.

Replace the divisor approach with a permutation-based method: recover the memory layout order from global strides, then compute contiguous strides for the local shape in that order.  This naturally handles uneven sharding since it derives strides from each rank's actual local shape.

With the stride computation fixed, remove the is_tensor_evenly_shardable guard that was blocking the sharded strategy for new_empty_strided. Unevenly-sharded tensors now preserve their sharding through backward with zero communication overhead.

