### PR TITLE
Revert "[BE] Remove `Optional` and `Union` usage repo wide (#176918)"

### DIFF
--- a/.github/actions/reuse-old-whl/reuse_old_whl.py
+++ b/.github/actions/reuse-old-whl/reuse_old_whl.py
@@ -1,12 +1,10 @@
-from __future__ import annotations
-
 import argparse
 import os
 import subprocess
 import sys
 from functools import lru_cache
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, cast, Optional, Union
 
 import requests
 
@@ -102,7 +100,7 @@ def check_issue_open() -> bool:
         return False
 
 
-def get_workflow_id(run_id: str) -> str | None:
+def get_workflow_id(run_id: str) -> Optional[str]:
     # Get the workflow ID that corresponds to the file for the run ID
     url = f"https://api.github.com/repos/pytorch/pytorch/actions/runs/{run_id}"
     response = query_github_api(url)
@@ -230,13 +228,13 @@ def unzip_artifact_and_replace_files() -> None:
         old_version = f"+git{path.stem.split('+')[1].split('-')[0][3:]}"
         new_version = f"+git{head_sha[:7]}"
 
-        def rename_to_new_version(file: str | Path) -> None:
+        def rename_to_new_version(file: Union[str, Path]) -> None:
             # Rename file with old_version to new_version
             subprocess.check_output(
                 ["mv", file, str(file).replace(old_version, new_version)]
             )
 
-        def change_content_to_new_version(file: str | Path) -> None:
+        def change_content_to_new_version(file: Union[str, Path]) -> None:
             # Check if is a file
             if os.path.isdir(file):
                 return

--- a/.github/scripts/build_triton_wheel.py
+++ b/.github/scripts/build_triton_wheel.py
@@ -1,13 +1,12 @@
 #!/usr/bin/env python3
 
-from __future__ import annotations
-
 import os
 import shutil
 import sys
 from pathlib import Path
 from subprocess import check_call
 from tempfile import TemporaryDirectory
+from typing import Optional
 
 
 SCRIPT_DIR = Path(__file__).parent
@@ -38,7 +37,7 @@ def check_and_replace(inp: str, src: str, dst: str) -> str:
 
 
 def patch_init_py(
-    path: Path, *, version: str, expected_version: str | None = None
+    path: Path, *, version: str, expected_version: Optional[str] = None
 ) -> None:
     if not expected_version:
         expected_version = read_triton_version()
@@ -57,7 +56,7 @@ def build_triton(
     version: str,
     commit_hash: str,
     device: str = "cuda",
-    py_version: str | None = None,
+    py_version: Optional[str] = None,
     release: bool = False,
     with_clang_ldd: bool = False,
 ) -> Path:

--- a/.github/scripts/cherry_pick.py
+++ b/.github/scripts/cherry_pick.py
@@ -1,11 +1,9 @@
 #!/usr/bin/env python3
 
-from __future__ import annotations
-
 import json
 import os
 import re
-from typing import Any, cast
+from typing import Any, cast, Optional
 from urllib.error import HTTPError
 
 from github_utils import gh_fetch_url, gh_post_pr_comment, gh_query_issues_by_labels
@@ -50,7 +48,7 @@ def parse_args() -> Any:
     return parser.parse_args()
 
 
-def get_merge_commit_sha(repo: GitRepo, pr: GitHubPR) -> str | None:
+def get_merge_commit_sha(repo: GitRepo, pr: GitHubPR) -> Optional[str]:
     """
     Return the merge commit SHA iff the PR has been merged. For simplicity, we
     will only cherry pick PRs that have been merged into main
@@ -59,7 +57,7 @@ def get_merge_commit_sha(repo: GitRepo, pr: GitHubPR) -> str | None:
     return commit_sha if pr.is_closed() else None
 
 
-def get_release_version(onto_branch: str) -> str | None:
+def get_release_version(onto_branch: str) -> Optional[str]:
     """
     Return the release version if the target branch is a release branch
     """

--- a/.github/scripts/convert_lintrunner_annotations_to_github.py
+++ b/.github/scripts/convert_lintrunner_annotations_to_github.py
@@ -1,11 +1,9 @@
-from __future__ import annotations
-
 import json
 import subprocess
 import sys
 from enum import Enum
 from pathlib import Path
-from typing import NamedTuple
+from typing import NamedTuple, Optional
 
 
 # From: https://docs.github.com/en/rest/reference/checks
@@ -19,12 +17,12 @@ class GitHubAnnotation(NamedTuple):
     path: str
     start_line: int
     end_line: int
-    start_column: int | None
-    end_column: int | None
+    start_column: Optional[int]
+    end_column: Optional[int]
     annotation_level: GitHubAnnotationLevel
     message: str
-    title: str | None
-    raw_details: str | None
+    title: Optional[str]
+    raw_details: Optional[str]
 
 
 PYTORCH_ROOT = Path(

--- a/.github/scripts/filter_test_configs.py
+++ b/.github/scripts/filter_test_configs.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 # ruff: noqa: LOG015
-from __future__ import annotations
 
 import json
 import logging
@@ -9,17 +8,14 @@ import re
 import subprocess
 import sys
 import warnings
+from collections.abc import Callable
 from enum import Enum
 from functools import cache
 from logging import info
-from typing import Any, TYPE_CHECKING
+from typing import Any, Optional
 from urllib.request import Request, urlopen
 
 import yaml
-
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
 
 
 REENABLE_TEST_REGEX = "(?i)(Close(d|s)?|Resolve(d|s)?|Fix(ed|es)?) (#|https://github.com/pytorch/pytorch/issues/)([0-9]+)"
@@ -30,7 +26,7 @@ PREFIX = "test-config/"
 logging.basicConfig(level=logging.INFO)
 
 
-def is_cuda_or_rocm_job(job_name: str | None) -> bool:
+def is_cuda_or_rocm_job(job_name: Optional[str]) -> bool:
     if not job_name:
         return False
 
@@ -39,7 +35,7 @@ def is_cuda_or_rocm_job(job_name: str | None) -> bool:
 
 # Supported modes when running periodically. Only applying the mode when
 # its lambda condition returns true
-SUPPORTED_PERIODICAL_MODES: dict[str, Callable[[str | None], bool]] = {
+SUPPORTED_PERIODICAL_MODES: dict[str, Callable[[Optional[str]], bool]] = {
     # Memory leak check is only needed for CUDA and ROCm jobs which utilize GPU memory
     "mem_leak_check": is_cuda_or_rocm_job,
     "rerun_disabled_tests": lambda job_name: True,
@@ -214,7 +210,7 @@ def filter_selected_test_configs(
 
 
 def set_periodic_modes(
-    test_matrix: dict[str, list[Any]], job_name: str | None
+    test_matrix: dict[str, list[Any]], job_name: Optional[str]
 ) -> dict[str, list[Any]]:
     """
     Apply all periodic modes when running under a schedule
@@ -270,7 +266,7 @@ def remove_disabled_jobs(
 def _filter_jobs(
     test_matrix: dict[str, list[Any]],
     issue_type: IssueType,
-    target_cfg: str | None = None,
+    target_cfg: Optional[str] = None,
 ) -> dict[str, list[Any]]:
     """
     An utility function used to actually apply the job filter
@@ -470,7 +466,7 @@ def set_output(name: str, val: Any) -> None:
         print(f"::set-output name={name}::{val}")
 
 
-def parse_reenabled_issues(s: str | None) -> list[str]:
+def parse_reenabled_issues(s: Optional[str]) -> list[str]:
     # NB: When the PR body is empty, GitHub API returns a None value, which is
     # passed into this function
     if not s:
@@ -506,8 +502,8 @@ def perform_misc_tasks(
     test_matrix: dict[str, list[Any]],
     job_name: str,
     pr_body: str,
-    branch: str | None = None,
-    tag: str | None = None,
+    branch: Optional[str] = None,
+    tag: Optional[str] = None,
 ) -> None:
     """
     In addition to apply the filter logic, the script also does the following

--- a/.github/scripts/generate_binary_build_matrix.py
+++ b/.github/scripts/generate_binary_build_matrix.py
@@ -11,12 +11,11 @@ architectures:
     * Latest XPU
 """
 
-from __future__ import annotations
-
 import json
 import os
 import re
 from pathlib import Path
+from typing import Optional
 
 
 SCRIPT_DIR = Path(__file__).absolute().parent
@@ -300,8 +299,8 @@ def list_without(in_list: list[str], without: list[str]) -> list[str]:
 def generate_libtorch_matrix(
     os: str,
     release_type: str,
-    arches: list[str] | None = None,
-    libtorch_variants: list[str] | None = None,
+    arches: Optional[list[str]] = None,
+    libtorch_variants: Optional[list[str]] = None,
 ) -> list[dict[str, str]]:
     if arches is None:
         arches = ["cpu"]
@@ -360,8 +359,8 @@ def generate_libtorch_matrix(
 
 def generate_wheels_matrix(
     os: str,
-    arches: list[str] | None = None,
-    python_versions: list[str] | None = None,
+    arches: Optional[list[str]] = None,
+    python_versions: Optional[list[str]] = None,
 ) -> list[dict[str, str]]:
     package_type = "wheel"
     if os == "linux" or os == "linux-aarch64" or os == "linux-s390x":

--- a/.github/scripts/get_workflow_job_id.py
+++ b/.github/scripts/get_workflow_job_id.py
@@ -1,7 +1,6 @@
 # Helper to get the id of the currently running job in a GitHub Actions
 # workflow. GitHub does not provide this information to workflow runs, so we
 # need to figure it out based on what they *do* provide.
-from __future__ import annotations
 
 import argparse
 import json
@@ -12,12 +11,9 @@ import sys
 import time
 import urllib
 import urllib.parse
-from typing import Any, TYPE_CHECKING
+from collections.abc import Callable
+from typing import Any, Optional
 from urllib.request import Request, urlopen
-
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
 
 
 def parse_json_and_links(conn: Any) -> tuple[Any, dict[str, dict[str, str]]]:
@@ -47,9 +43,9 @@ def parse_json_and_links(conn: Any) -> tuple[Any, dict[str, dict[str, str]]]:
 def fetch_url(
     url: str,
     *,
-    headers: dict[str, str] | None = None,
+    headers: Optional[dict[str, str]] = None,
     reader: Callable[[Any], Any] = lambda x: x.read(),
-    retries: int | None = 3,
+    retries: Optional[int] = 3,
     backoff_timeout: float = 0.5,
 ) -> Any:
     if headers is None:

--- a/.github/scripts/github_utils.py
+++ b/.github/scripts/github_utils.py
@@ -1,19 +1,14 @@
 """GitHub Utilities"""
 
-from __future__ import annotations
-
 import json
 import os
 import warnings
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, cast, TYPE_CHECKING
+from typing import Any, cast, Optional, Union
 from urllib.error import HTTPError
 from urllib.parse import quote
 from urllib.request import Request, urlopen
-
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
 
 
 GITHUB_API_URL = "https://api.github.com"
@@ -24,9 +19,9 @@ class GitHubComment:
     body_text: str
     created_at: str
     author_login: str
-    author_url: str | None
+    author_url: Optional[str]
     author_association: str
-    editor_login: str | None
+    editor_login: Optional[str]
     database_id: int
     url: str
 
@@ -34,9 +29,9 @@ class GitHubComment:
 def gh_fetch_url_and_headers(
     url: str,
     *,
-    headers: dict[str, str] | None = None,
-    data: dict[str, Any] | None | str = None,
-    method: str | None = None,
+    headers: Optional[dict[str, str]] = None,
+    data: Union[Optional[dict[str, Any]], str] = None,
+    method: Optional[str] = None,
     reader: Callable[[Any], Any] = lambda x: x.read(),
 ) -> tuple[Any, Any]:
     if headers is None:
@@ -77,9 +72,9 @@ def gh_fetch_url_and_headers(
 def gh_fetch_url(
     url: str,
     *,
-    headers: dict[str, str] | None = None,
-    data: dict[str, Any] | None | str = None,
-    method: str | None = None,
+    headers: Optional[dict[str, str]] = None,
+    data: Union[Optional[dict[str, Any]], str] = None,
+    method: Optional[str] = None,
     reader: Callable[[Any], Any] = json.load,
 ) -> Any:
     return gh_fetch_url_and_headers(
@@ -89,9 +84,9 @@ def gh_fetch_url(
 
 def gh_fetch_json(
     url: str,
-    params: dict[str, Any] | None = None,
-    data: dict[str, Any] | None = None,
-    method: str | None = None,
+    params: Optional[dict[str, Any]] = None,
+    data: Optional[dict[str, Any]] = None,
+    method: Optional[str] = None,
 ) -> list[dict[str, Any]]:
     headers = {"Accept": "application/vnd.github.v3+json"}
     if params is not None and len(params) > 0:
@@ -106,8 +101,8 @@ def gh_fetch_json(
 
 def _gh_fetch_json_any(
     url: str,
-    params: dict[str, Any] | None = None,
-    data: dict[str, Any] | None = None,
+    params: Optional[dict[str, Any]] = None,
+    data: Optional[dict[str, Any]] = None,
 ) -> Any:
     headers = {"Accept": "application/vnd.github.v3+json"}
     if params is not None and len(params) > 0:
@@ -119,16 +114,16 @@ def _gh_fetch_json_any(
 
 def gh_fetch_json_list(
     url: str,
-    params: dict[str, Any] | None = None,
-    data: dict[str, Any] | None = None,
+    params: Optional[dict[str, Any]] = None,
+    data: Optional[dict[str, Any]] = None,
 ) -> list[dict[str, Any]]:
     return cast(list[dict[str, Any]], _gh_fetch_json_any(url, params, data))
 
 
 def gh_fetch_json_dict(
     url: str,
-    params: dict[str, Any] | None = None,
-    data: dict[str, Any] | None = None,
+    params: Optional[dict[str, Any]] = None,
+    data: Optional[dict[str, Any]] = None,
 ) -> dict[str, Any]:
     return cast(dict[str, Any], _gh_fetch_json_any(url, params, data))
 

--- a/.github/scripts/gitutils.py
+++ b/.github/scripts/gitutils.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 
-from __future__ import annotations
-
 import os
 import re
 import tempfile
@@ -9,7 +7,7 @@ from collections import defaultdict
 from collections.abc import Callable, Iterator
 from datetime import datetime
 from functools import wraps
-from typing import Any, cast, TypeVar
+from typing import Any, cast, Optional, TypeVar, Union
 
 
 T = TypeVar("T")
@@ -62,7 +60,7 @@ class GitCommit:
     body: str
     author: str
     author_date: datetime
-    commit_date: datetime | None
+    commit_date: Optional[datetime]
 
     def __init__(
         self,
@@ -71,7 +69,7 @@ class GitCommit:
         author_date: datetime,
         title: str,
         body: str,
-        commit_date: datetime | None = None,
+        commit_date: Optional[datetime] = None,
     ) -> None:
         self.commit_hash = commit_hash
         self.author = author
@@ -87,7 +85,7 @@ class GitCommit:
         return item in self.body or item in self.title
 
 
-def parse_fuller_format(lines: str | list[str]) -> GitCommit:
+def parse_fuller_format(lines: Union[str, list[str]]) -> GitCommit:
     """
     Expect commit message generated using `--format=fuller --date=unix` format, i.e.:
         commit <sha1>
@@ -165,7 +163,7 @@ class GitRepo:
         )
         return [x.strip() for x in rc.split("\n") if x.strip()] if len(rc) > 0 else []
 
-    def current_branch(self) -> str | None:
+    def current_branch(self) -> Optional[str]:
         try:
             return self._run_git("symbolic-ref", "--short", "HEAD").strip()
         except RuntimeError:
@@ -178,7 +176,7 @@ class GitRepo:
     def create_branch_and_checkout(self, branch: str) -> None:
         self._run_git("checkout", "-b", branch)
 
-    def fetch(self, ref: str | None = None, branch: str | None = None) -> None:
+    def fetch(self, ref: Optional[str] = None, branch: Optional[str] = None) -> None:
         if branch is None and ref is None:
             self._run_git("fetch", self.remote)
         elif branch is None:
@@ -198,7 +196,7 @@ class GitRepo:
     def get_merge_base(self, from_ref: str, to_ref: str) -> str:
         return self._run_git("merge-base", from_ref, to_ref).strip()
 
-    def patch_id(self, ref: str | list[str]) -> list[tuple[str, str]]:
+    def patch_id(self, ref: Union[str, list[str]]) -> list[tuple[str, str]]:
         is_list = isinstance(ref, list)
         if is_list:
             if len(ref) == 0:
@@ -336,7 +334,7 @@ class GitRepo:
     def amend_commit_message(self, msg: str) -> None:
         self._run_git("commit", "--amend", "-m", msg)
 
-    def diff(self, from_ref: str, to_ref: str | None = None) -> str:
+    def diff(self, from_ref: str, to_ref: Optional[str] = None) -> str:
         if to_ref is None:
             return self._run_git("diff", f"{from_ref}^!")
         return self._run_git("diff", f"{from_ref}..{to_ref}")
@@ -360,12 +358,12 @@ class PeekableIterator(Iterator[str]):
         self._val = val
         self._idx = -1
 
-    def peek(self) -> str | None:
+    def peek(self) -> Optional[str]:
         if self._idx + 1 >= len(self._val):
             return None
         return self._val[self._idx + 1]
 
-    def __iter__(self) -> PeekableIterator:
+    def __iter__(self) -> "PeekableIterator":
         return self
 
     def __next__(self) -> str:
@@ -429,7 +427,7 @@ def is_commit_hash(ref: str) -> bool:
 
 
 def are_ghstack_branches_in_sync(
-    repo: GitRepo, head_ref: str, base_ref: str | None = None
+    repo: GitRepo, head_ref: str, base_ref: Optional[str] = None
 ) -> bool:
     """Checks that diff between base and head is the same as diff between orig and its parent"""
     orig_ref = re.sub(r"/head$", "/orig", head_ref)

--- a/.github/scripts/label_utils.py
+++ b/.github/scripts/label_utils.py
@@ -1,10 +1,8 @@
 """GitHub Label Utilities."""
 
-from __future__ import annotations
-
 import json
 from functools import lru_cache
-from typing import Any, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING, Union
 
 from github_utils import gh_fetch_url_and_headers, GitHubComment
 
@@ -77,7 +75,7 @@ def gh_get_labels(org: str, repo: str) -> list[str]:
 
 
 def gh_add_labels(
-    org: str, repo: str, pr_num: int, labels: str | list[str], dry_run: bool
+    org: str, repo: str, pr_num: int, labels: Union[str, list[str]], dry_run: bool
 ) -> None:
     if dry_run:
         print(f"Dryrun: Adding labels {labels} to PR {pr_num}")
@@ -108,7 +106,7 @@ def get_release_notes_labels(org: str, repo: str) -> list[str]:
     ]
 
 
-def has_required_labels(pr: GitHubPR) -> bool:
+def has_required_labels(pr: "GitHubPR") -> bool:
     pr_labels = pr.get_labels()
     # Check if PR is not user facing
     is_not_user_facing_pr = any(

--- a/.github/scripts/test_trymerge.py
+++ b/.github/scripts/test_trymerge.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-
 # Tests implemented in this file are relying on GitHub GraphQL APIs
 # In order to avoid test flakiness, results of the queries
 # are cached in gql_mocks.json
@@ -8,14 +7,12 @@
 # GraphQL queries in trymerge.py, please make sure to delete `gql_mocks.json`
 # And re-run the test locally with ones PAT
 
-from __future__ import annotations
-
 import gzip
 import json
 import os
 import warnings
 from hashlib import sha256
-from typing import Any
+from typing import Any, Optional
 from unittest import main, mock, skip, TestCase
 from urllib.error import HTTPError
 
@@ -150,8 +147,8 @@ def mock_revert(
     pr: GitHubPR,
     *,
     dry_run: bool = False,
-    comment_id: int | None = None,
-    reason: str | None = None,
+    comment_id: Optional[int] = None,
+    reason: Optional[str] = None,
 ) -> None:
     pass
 

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -1,6 +1,14 @@
 #!/usr/bin/env python3
 
-from __future__ import annotations
+# NB: the following functions are used in Meta-internal workflows
+# (github_first_try_merge/my_handler.py) and thus have functionality limitations
+# (no `git` command access, no network access besides the strict allow list):
+#
+# find_matching_merge_rule
+# read_merge_rules
+#
+# Also any signature changes of these functions, as well as changes to the `GitHubPR`
+# class, will likely require corresponding changes for the internal workflows.
 
 import base64
 import json
@@ -9,11 +17,12 @@ import re
 import time
 import urllib.parse
 from collections import defaultdict
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from functools import cache
 from pathlib import Path
 from re import Pattern
-from typing import Any, cast, NamedTuple, TYPE_CHECKING
+from typing import Any, cast, NamedTuple, Optional
 from warnings import warn
 
 import yaml
@@ -45,10 +54,6 @@ from label_utils import (
 from trymerge_explainer import get_revert_message, TryMergeExplainer
 
 
-if TYPE_CHECKING:
-    from collections.abc import Callable, Iterable
-
-
 # labels
 MERGE_IN_PROGRESS_LABEL = "merging"
 MERGE_COMPLETE_LABEL = "merged"
@@ -57,22 +62,22 @@ MERGE_COMPLETE_LABEL = "merged"
 class JobCheckState(NamedTuple):
     name: str
     url: str
-    status: str | None
-    classification: str | None
-    job_id: int | None
-    title: str | None
-    summary: str | None
+    status: Optional[str]
+    classification: Optional[str]
+    job_id: Optional[int]
+    title: Optional[str]
+    summary: Optional[str]
 
 
 JobNameToStateDict = dict[str, JobCheckState]
 
 
 class WorkflowCheckState:
-    def __init__(self, name: str, url: str, run_id: int, status: str | None):
+    def __init__(self, name: str, url: str, run_id: int, status: Optional[str]):
         self.name: str = name
         self.url: str = url
         self.run_id: int = run_id
-        self.status: str | None = status
+        self.status: Optional[str] = status
         self.jobs: JobNameToStateDict = {}
 
 
@@ -484,12 +489,12 @@ def iter_issue_timeline_until_comment(
     )
 
 
-def sha_from_committed_event(ev: dict[str, Any]) -> str | None:
+def sha_from_committed_event(ev: dict[str, Any]) -> Optional[str]:
     """Extract SHA from committed event in timeline"""
     return ev.get("sha")
 
 
-def sha_from_force_push_after(ev: dict[str, Any]) -> str | None:
+def sha_from_force_push_after(ev: dict[str, Any]) -> Optional[str]:
     """Extract SHA from force push event in timeline"""
     # The current GitHub API format
     commit_id = ev.get("commit_id")
@@ -537,7 +542,7 @@ def get_check_run_name_prefix(workflow_run: Any) -> str:
         return f"{workflow_run['workflow']['name']} / "
 
 
-def is_passing_status(status: str | None) -> bool:
+def is_passing_status(status: Optional[str]) -> bool:
     return status is not None and status.upper() in ["SUCCESS", "SKIPPED", "NEUTRAL"]
 
 
@@ -659,7 +664,7 @@ def parse_args() -> Any:
     return parser.parse_args()
 
 
-def can_skip_internal_checks(pr: GitHubPR, comment_id: int | None = None) -> bool:
+def can_skip_internal_checks(pr: "GitHubPR", comment_id: Optional[int] = None) -> bool:
     if comment_id is None:
         return False
     comment = pr.get_comment_by_id(comment_id)
@@ -670,10 +675,10 @@ def can_skip_internal_checks(pr: GitHubPR, comment_id: int | None = None) -> boo
 
 def _revlist_to_prs(
     repo: GitRepo,
-    pr: GitHubPR,
+    pr: "GitHubPR",
     rev_list: Iterable[str],
-    should_skip: Callable[[int, GitHubPR], bool] | None = None,
-) -> list[tuple[GitHubPR, str]]:
+    should_skip: Optional[Callable[[int, "GitHubPR"], bool]] = None,
+) -> list[tuple["GitHubPR", str]]:
     rc: list[tuple[GitHubPR, str]] = []
     for idx, rev in enumerate(rev_list):
         msg = repo.commit_message(rev)
@@ -701,8 +706,8 @@ def _revlist_to_prs(
 
 
 def get_ghstack_prs(
-    repo: GitRepo, pr: GitHubPR, open_only: bool = True
-) -> list[tuple[GitHubPR, str]]:
+    repo: GitRepo, pr: "GitHubPR", open_only: bool = True
+) -> list[tuple["GitHubPR", str]]:
     """
     Get the PRs in the stack that are below this PR (inclusive).  Throws error if any of the open PRs are out of sync.
     @:param open_only: Only return open PRs
@@ -711,7 +716,7 @@ def get_ghstack_prs(
     orig_ref = f"{repo.remote}/{pr.get_ghstack_orig_ref()}"
     rev_list = repo.revlist(f"{pr.default_branch()}..{orig_ref}")
 
-    def skip_func(idx: int, candidate: GitHubPR) -> bool:
+    def skip_func(idx: int, candidate: "GitHubPR") -> bool:
         if not open_only or not candidate.is_closed():
             return False
         print(
@@ -756,14 +761,14 @@ class GitHubPR:
         self.project = project
         self.pr_num = pr_num
         self.info = gh_get_pr_info(org, project, pr_num)
-        self.changed_files: list[str] | None = None
-        self.labels: list[str] | None = None
-        self.conclusions: JobNameToStateDict | None = None
-        self.comments: list[GitHubComment] | None = None
-        self._authors: list[tuple[str, str]] | None = None
-        self._reviews: list[tuple[str, str]] | None = None
-        self.merge_base: str | None = None
-        self.submodules: list[str] | None = None
+        self.changed_files: Optional[list[str]] = None
+        self.labels: Optional[list[str]] = None
+        self.conclusions: Optional[JobNameToStateDict] = None
+        self.comments: Optional[list[GitHubComment]] = None
+        self._authors: Optional[list[tuple[str, str]]] = None
+        self._reviews: Optional[list[tuple[str, str]]] = None
+        self.merge_base: Optional[str] = None
+        self.submodules: Optional[list[str]] = None
 
     def is_closed(self) -> bool:
         return bool(self.info["closed"])
@@ -799,7 +804,7 @@ class GitHubPR:
     def last_commit(self) -> Any:
         return self.info["commits"]["nodes"][-1]["commit"]
 
-    def last_commit_sha(self, default: str | None = None) -> str:
+    def last_commit_sha(self, default: Optional[str] = None) -> str:
         # for commits, the oid is the sha
 
         if default is None:
@@ -905,7 +910,7 @@ class GitHubPR:
     def get_commit_count(self) -> int:
         return int(self.info["commits_with_authors"]["totalCount"])
 
-    def get_commit_sha_at_comment(self, comment_id: int) -> str | None:
+    def get_commit_sha_at_comment(self, comment_id: int) -> Optional[str]:
         """
         Get the PR head commit SHA that was present when a specific comment was posted.
         This ensures we only merge the state of the PR at the time the merge command was issued,
@@ -1083,7 +1088,7 @@ class GitHubPR:
     def get_body(self) -> str:
         return cast(str, self.info["body"])
 
-    def get_merge_commit(self) -> str | None:
+    def get_merge_commit(self) -> Optional[str]:
         mc = self.info["mergeCommit"]
         return mc["oid"] if mc is not None else None
 
@@ -1152,7 +1157,7 @@ class GitHubPR:
 
         raise RuntimeError(f"Comment with id {database_id} not found")
 
-    def get_diff_revision(self) -> str | None:
+    def get_diff_revision(self) -> Optional[str]:
         rc = RE_DIFF_REV.search(self.get_body())
         return rc.group(1) if rc is not None else None
 
@@ -1176,9 +1181,9 @@ class GitHubPR:
         self,
         repo: GitRepo,
         skip_mandatory_checks: bool,
-        comment_id: int | None = None,
+        comment_id: Optional[int] = None,
         skip_all_rule_checks: bool = False,
-    ) -> list[GitHubPR]:
+    ) -> list["GitHubPR"]:
         if not self.is_ghstack_pr():
             raise AssertionError(
                 f"merge_ghstack_into called on non-ghstack PR #{self.pr_num}"
@@ -1211,7 +1216,7 @@ class GitHubPR:
     def gen_commit_message(
         self,
         filter_ghstack: bool = False,
-        ghstack_deps: list[GitHubPR] | None = None,
+        ghstack_deps: Optional[list["GitHubPR"]] = None,
     ) -> str:
         """Fetches title and body from PR description
         adds reviewed by, pull request resolved and optionally
@@ -1263,7 +1268,7 @@ class GitHubPR:
         skip_mandatory_checks: bool = False,
         dry_run: bool = False,
         comment_id: int,
-        ignore_current_checks: list[str] | None = None,
+        ignore_current_checks: Optional[list[str]] = None,
     ) -> None:
         # Raises exception if matching rule is not found
         (
@@ -1332,10 +1337,10 @@ class GitHubPR:
         self,
         repo: GitRepo,
         skip_mandatory_checks: bool = False,
-        comment_id: int | None = None,
-        branch: str | None = None,
+        comment_id: Optional[int] = None,
+        branch: Optional[str] = None,
         skip_all_rule_checks: bool = False,
-    ) -> list[GitHubPR]:
+    ) -> list["GitHubPR"]:
         """
         :param skip_all_rule_checks: If true, skips all rule checks on ghstack PRs, useful for dry-running merge locally
         """
@@ -1397,7 +1402,7 @@ class GitHubPR:
 
 
 class MergeRuleFailedError(RuntimeError):
-    def __init__(self, message: str, rule: MergeRule | None = None) -> None:
+    def __init__(self, message: str, rule: Optional["MergeRule"] = None) -> None:
         super().__init__(message)
         self.rule = rule
 
@@ -1415,7 +1420,7 @@ class MergeRule:
     name: str
     patterns: list[str]
     approved_by: list[str]
-    mandatory_checks_name: list[str] | None
+    mandatory_checks_name: Optional[list[str]]
     ignore_flaky_failures: bool = True
 
 
@@ -1430,7 +1435,9 @@ def gen_new_issue_link(
     )
 
 
-def read_merge_rules(repo: GitRepo | None, org: str, project: str) -> list[MergeRule]:
+def read_merge_rules(
+    repo: Optional[GitRepo], org: str, project: str
+) -> list[MergeRule]:
     """Returns the list of all merge rules for the repo or project.
 
     NB: this function is used in Meta-internal workflows, see the comment
@@ -1457,14 +1464,14 @@ def read_merge_rules(repo: GitRepo | None, org: str, project: str) -> list[Merge
 
 def find_matching_merge_rule(
     pr: GitHubPR,
-    repo: GitRepo | None = None,
+    repo: Optional[GitRepo] = None,
     skip_mandatory_checks: bool = False,
     skip_internal_checks: bool = False,
-    ignore_current_checks: list[str] | None = None,
+    ignore_current_checks: Optional[list[str]] = None,
 ) -> tuple[
     MergeRule,
-    list[tuple[str, str | None, int | None]],
-    list[tuple[str, str | None, int | None]],
+    list[tuple[str, Optional[str], Optional[int]]],
+    list[tuple[str, Optional[str], Optional[int]]],
     dict[str, list[Any]],
 ]:
     """
@@ -1652,12 +1659,12 @@ def find_matching_merge_rule(
     raise MergeRuleFailedError(reject_reason, rule)
 
 
-def checks_to_str(checks: list[tuple[str, str | None]]) -> str:
+def checks_to_str(checks: list[tuple[str, Optional[str]]]) -> str:
     return ", ".join(f"[{c[0]}]({c[1]})" if c[1] is not None else c[0] for c in checks)
 
 
 def checks_to_markdown_bullets(
-    checks: list[tuple[str, str | None, int | None]],
+    checks: list[tuple[str, Optional[str], Optional[int]]],
 ) -> list[str]:
     return [
         f"- [{c[0]}]({c[1]})" if c[1] is not None else f"- {c[0]}" for c in checks[:5]
@@ -1669,7 +1676,9 @@ def post_starting_merge_comment(
     pr: GitHubPR,
     explainer: TryMergeExplainer,
     dry_run: bool,
-    ignore_current_checks_info: list[tuple[str, str | None, int | None]] | None = None,
+    ignore_current_checks_info: Optional[
+        list[tuple[str, Optional[str], Optional[int]]]
+    ] = None,
 ) -> None:
     """Post the initial merge starting message on the PR. Also post a short
     message on all PRs in the stack."""
@@ -1727,12 +1736,12 @@ def save_merge_record(
     owner: str,
     project: str,
     author: str,
-    pending_checks: list[tuple[str, str | None, int | None]],
-    failed_checks: list[tuple[str, str | None, int | None]],
-    ignore_current_checks: list[tuple[str, str | None, int | None]],
-    broken_trunk_checks: list[tuple[str, str | None, int | None]],
-    flaky_checks: list[tuple[str, str | None, int | None]],
-    unstable_checks: list[tuple[str, str | None, int | None]],
+    pending_checks: list[tuple[str, Optional[str], Optional[int]]],
+    failed_checks: list[tuple[str, Optional[str], Optional[int]]],
+    ignore_current_checks: list[tuple[str, Optional[str], Optional[int]]],
+    broken_trunk_checks: list[tuple[str, Optional[str], Optional[int]]],
+    flaky_checks: list[tuple[str, Optional[str], Optional[int]]],
+    unstable_checks: list[tuple[str, Optional[str], Optional[int]]],
     last_commit_sha: str,
     merge_base_sha: str,
     merge_commit_sha: str = "",
@@ -1865,7 +1874,7 @@ def is_flaky(
 
 def is_invalid_cancel(
     name: str,
-    conclusion: str | None,
+    conclusion: Optional[str],
     drci_classifications: Any,
 ) -> bool:
     """
@@ -1892,7 +1901,7 @@ def get_classifications(
     pr_num: int,
     project: str,
     checks: dict[str, JobCheckState],
-    ignore_current_checks: list[str] | None,
+    ignore_current_checks: Optional[list[str]],
 ) -> dict[str, JobCheckState]:
     # Get the failure classification from Dr.CI, which is the source of truth
     # going forward. It's preferable to try calling Dr.CI API directly first
@@ -2001,7 +2010,7 @@ def get_classifications(
 
 
 def filter_checks_with_lambda(
-    checks: JobNameToStateDict, status_filter: Callable[[str | None], bool]
+    checks: JobNameToStateDict, status_filter: Callable[[Optional[str]], bool]
 ) -> list[JobCheckState]:
     return [check for check in checks.values() if status_filter(check.status)]
 
@@ -2017,7 +2026,7 @@ def get_pr_commit_sha(repo: GitRepo, pr: GitHubPR) -> str:
 
 
 def validate_revert(
-    repo: GitRepo, pr: GitHubPR, *, comment_id: int | None = None
+    repo: GitRepo, pr: GitHubPR, *, comment_id: Optional[int] = None
 ) -> tuple[str, str]:
     comment = (
         pr.get_last_comment()
@@ -2148,8 +2157,8 @@ def try_revert(
     pr: GitHubPR,
     *,
     dry_run: bool = False,
-    comment_id: int | None = None,
-    reason: str | None = None,
+    comment_id: Optional[int] = None,
+    reason: Optional[str] = None,
 ) -> None:
     try:
         author_login, commit_sha = validate_revert(repo, pr, comment_id=comment_id)
@@ -2218,10 +2227,10 @@ def has_label(labels: list[str], pattern: Pattern[str] = CIFLOW_LABEL) -> bool:
 def categorize_checks(
     check_runs: JobNameToStateDict,
     required_checks: list[str],
-    ok_failed_checks_threshold: int | None = None,
+    ok_failed_checks_threshold: Optional[int] = None,
 ) -> tuple[
-    list[tuple[str, str | None, int | None]],
-    list[tuple[str, str | None, int | None]],
+    list[tuple[str, Optional[str], Optional[int]]],
+    list[tuple[str, Optional[str], Optional[int]]],
     dict[str, list[Any]],
 ]:
     """
@@ -2229,8 +2238,8 @@ def categorize_checks(
     failures and broken trunk are ignored by defaults when ok_failed_checks_threshold
     is not set (unlimited)
     """
-    pending_checks: list[tuple[str, str | None, int | None]] = []
-    failed_checks: list[tuple[str, str | None, int | None]] = []
+    pending_checks: list[tuple[str, Optional[str], Optional[int]]] = []
+    failed_checks: list[tuple[str, Optional[str], Optional[int]]] = []
 
     # failed_checks_categorization is used to keep track of all ignorable failures when saving the merge record on s3
     failed_checks_categorization: dict[str, list[Any]] = defaultdict(list)

--- a/.github/scripts/trymerge_explainer.py
+++ b/.github/scripts/trymerge_explainer.py
@@ -1,8 +1,7 @@
-from __future__ import annotations
-
 import os
 import re
 from re import Pattern
+from typing import Optional
 
 
 BOT_COMMANDS_WIKI = "https://github.com/pytorch/pytorch/wiki/Bot-commands"
@@ -48,7 +47,9 @@ class TryMergeExplainer:
 
     def _get_flag_msg(
         self,
-        ignore_current_checks: list[tuple[str, str | None, int | None]] | None = None,
+        ignore_current_checks: Optional[
+            list[tuple[str, Optional[str], Optional[int]]]
+        ] = None,
     ) -> str:
         if self.force:
             return (
@@ -67,7 +68,9 @@ class TryMergeExplainer:
 
     def get_merge_message(
         self,
-        ignore_current_checks: list[tuple[str, str | None, int | None]] | None = None,
+        ignore_current_checks: Optional[
+            list[tuple[str, Optional[str], Optional[int]]]
+        ] = None,
     ) -> str:
         title = "### Merge started"
         main_message = self._get_flag_msg(ignore_current_checks)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,7 +126,6 @@ standard_library = ["typing_extensions"]
 [tool.ruff]
 line-length = 88
 src = ["caffe2", "torch", "torchgen", "functorch", "test"]
-extend-exclude = ["third_party", "test/dynamo/cpython"]
 
 [tool.ruff.per-file-target-version]
 "**/py312_intrinsics.py" = "py312"
@@ -185,6 +184,8 @@ ignore = [
     "SIM116", # Disable Use a dictionary instead of consecutive `if` statements
     "SIM117",
     "SIM300", # Yoda condition detected
+    "UP007", # keep-runtime-typing
+    "UP045", # keep-runtime-typing
     "TC006",
     # TODO: Remove Python-3.10 specific suppressions
     "B905",
@@ -266,6 +267,10 @@ select = [
     "YTT",
     "S101",
 ]
+
+[tool.ruff.lint.pyupgrade]
+# Preserve types, even if a file imports `from __future__ import annotations`.
+keep-runtime-typing = true
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = [

--- a/torch/_custom_op/impl.py
+++ b/torch/_custom_op/impl.py
@@ -59,7 +59,9 @@ def warn_deprecated():
     )
 
 
-def custom_op(qualname: str, manual_schema: str | None = None) -> typing.Callable:
+def custom_op(
+    qualname: str, manual_schema: typing.Optional[str] = None
+) -> typing.Callable:
     r"""
     This API is deprecated, please use torch.library.custom_op instead
     """
@@ -153,7 +155,7 @@ class CustomOp:
         self.__name__ = None  # mypy requires this
         # NB: Some of these impls are registered as kernels to DispatchKeys.
         # Modifying the _impls dict directly won't do anything in that case.
-        self._impls: dict[str, FuncAndLocation | None] = {}
+        self._impls: dict[str, typing.Optional[FuncAndLocation]] = {}
         # See NOTE [CustomOp autograd kernel indirection]
         self._registered_autograd_kernel_indirection = False
 
@@ -218,7 +220,7 @@ class CustomOp:
 
     def impl(
         self,
-        device_types: str | typing.Iterable[str],
+        device_types: typing.Union[str, typing.Iterable[str]],
         _stacklevel=2,
     ) -> typing.Callable:
         r"""

--- a/torch/_dynamo/variables/dicts.py
+++ b/torch/_dynamo/variables/dicts.py
@@ -1918,7 +1918,7 @@ class DictItemsVariable(DictViewVariable):
         return False
 
 
-kV = ConstDictVariable._HashableTracker | str
+kV = Union[ConstDictVariable._HashableTracker, str]
 
 
 class SideEffectsProxyDict(collections.abc.MutableMapping[kV, VariableTracker]):
@@ -2042,7 +2042,7 @@ class DunderDictVariable(ConstDictVariable):
             return self.getitem(name)
         return super().getitem_const(tx, arg)
 
-    def maybe_getitem_const(self, arg: VariableTracker) -> VariableTracker | None:
+    def maybe_getitem_const(self, arg: VariableTracker) -> Optional[VariableTracker]:
         name = arg.as_python_constant()
         if self.contains(name):
             return self.getitem(name)

--- a/torch/_guards.py
+++ b/torch/_guards.py
@@ -14,7 +14,7 @@ from abc import abstractmethod
 from collections import defaultdict
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import Any, Generic, NamedTuple, overload, TYPE_CHECKING, TypeVar
+from typing import Any, Generic, NamedTuple, Optional, overload, TYPE_CHECKING, TypeVar
 from typing_extensions import dataclass_transform
 
 import torch
@@ -512,7 +512,7 @@ class GuardsCheckpointState:
     def __init__(self, dynamo_guards: OrderedSet[Guard]) -> None:
         self.dynamo_guards = dynamo_guards
 
-    def diff(self, other: GuardsCheckpointState) -> OrderedSet[Guard] | None:
+    def diff(self, other: GuardsCheckpointState) -> Optional[OrderedSet[Guard]]:
         """
         Produces a delta against another GuardsCheckpointState.
 
@@ -635,7 +635,7 @@ class GlobalContext(Checkpointable[GlobalContextCheckpointState]):
 # Like a Set[Guard] but will record the user stack on all guards at the
 # time they were installed at their destination
 class GuardsSet:
-    def __init__(self, inner: OrderedSet[Guard] | None = None) -> None:
+    def __init__(self, inner: Optional[OrderedSet[Guard]] = None) -> None:
         if inner is None:
             self.inner: OrderedSet[Guard] = OrderedSet()
         else:

--- a/torch/_higher_order_ops/triton_kernel_wrap.py
+++ b/torch/_higher_order_ops/triton_kernel_wrap.py
@@ -937,8 +937,8 @@ def analyze_kernel_access(
     }
     UNKNOWN_OPS = {"tt.elementwise_inline_asm"}
 
-    write_stack: list[Param | Intermediate] = []
-    read_stack: list[Param | Intermediate] = []
+    write_stack: list[Union[Param, Intermediate]] = []
+    read_stack: list[Union[Param, Intermediate]] = []
 
     ops = functions[fn_name]
     tma_stores = get_tma_stores(functions, fn_name)
@@ -998,7 +998,7 @@ def analyze_kernel_access(
                 read_stack.extend(op.args[idx] for idx in READ_OPS.get(op.name, []))
 
     def _find_arg_access_count(
-        initial_stack: list[Param | Intermediate],
+        initial_stack: list[Union[Param, Intermediate]],
         skip_loads: bool,
     ) -> dict[int, int]:
         """DFS traversal to find argument indices that are accessed (and how many times they are accessed)."""

--- a/torch/_inductor/__init__.py
+++ b/torch/_inductor/__init__.py
@@ -449,5 +449,5 @@ def standalone_compile(
 
 @dataclasses.dataclass
 class _CudagraphAnnotation:
-    fwd: bool | None
-    bwd: bool | None
+    fwd: Optional[bool]
+    bwd: Optional[bool]

--- a/torch/_library/infer_schema.py
+++ b/torch/_library/infer_schema.py
@@ -360,4 +360,4 @@ def tuple_to_list(tuple_type: type[tuple]) -> type[list]:
     elif len(type_args) == 2 and type_args[1] is Ellipsis:
         return list[type_args[0]]  # type: ignore[valid-type]
     else:
-        return list[typing.Union[tuple(type_args)]]  # type: ignore[misc, return-value]  # noqa: UP007
+        return list[typing.Union[tuple(type_args)]]  # type: ignore[misc, return-value]  # noqa: UP045

--- a/torch/backends/_nnapi/prepare.py
+++ b/torch/backends/_nnapi/prepare.py
@@ -21,7 +21,7 @@ class NnapiModule(torch.nn.Module):
     """
 
     # _nnapi.Compilation is defined
-    comp: Optional[torch.classes._nnapi.Compilation]  # type: ignore[name-defined]  # noqa: UP045
+    comp: Optional[torch.classes._nnapi.Compilation]  # type: ignore[name-defined]
     weights: list[torch.Tensor]
     out_templates: list[torch.Tensor]
 

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_common.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_common.py
@@ -4,7 +4,7 @@ import math
 import traceback
 from dataclasses import dataclass
 from enum import auto, Enum
-from typing import Any
+from typing import Any, Optional
 
 import torch
 import torch.distributed as dist
@@ -164,7 +164,7 @@ def is_bw() -> bool:
 
 @dataclass
 class ShardPlacementResult:
-    placement: Shard | None
+    placement: Optional[Shard]
     mesh_info: FSDPMeshInfo
 
 

--- a/torch/export/graph_signature.py
+++ b/torch/export/graph_signature.py
@@ -2,7 +2,7 @@
 import dataclasses
 from collections.abc import Collection, Mapping
 from enum import auto, Enum
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Union
 
 from torch._library.fake_class_registry import FakeScriptObject
 from torch._library.opaque_object import get_opaque_type_name, is_opaque_type
@@ -67,15 +67,15 @@ class ConstantArgument:
     value: int | float | bool | str | None
 
 
-ArgumentSpec = (
-    TensorArgument
-    | SymIntArgument
-    | SymFloatArgument
-    | SymBoolArgument
-    | ConstantArgument
-    | CustomObjArgument
-    | TokenArgument
-)
+ArgumentSpec = Union[
+    TensorArgument,
+    SymIntArgument,
+    SymFloatArgument,
+    SymBoolArgument,
+    ConstantArgument,
+    CustomObjArgument,
+    TokenArgument,
+]
 
 
 class InputKind(Enum):

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -42,10 +42,12 @@ from typing import (
     Generic,
     NamedTuple,
     NoReturn,
+    Optional,
     TYPE_CHECKING,
     TypeAlias,
     TypeGuard,
     TypeVar,
+    Union,
 )
 from typing_extensions import deprecated, ParamSpec
 

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -42,12 +42,10 @@ from typing import (
     Generic,
     NamedTuple,
     NoReturn,
-    Optional,
     TYPE_CHECKING,
     TypeAlias,
     TypeGuard,
     TypeVar,
-    Union,
 )
 from typing_extensions import deprecated, ParamSpec
 

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -160,7 +160,7 @@ class _Namespace:
         self._used_names: set[str] = set()
         self._base_count: dict[str, int] = {}
 
-    def create_name(self, candidate: str, obj: Any | None) -> str:
+    def create_name(self, candidate: str, obj: Optional[Any]) -> str:
         """Create a unique name.
 
         Arguments:

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -439,8 +439,8 @@ Args:
 def fractional_max_pool2d_with_indices(
     input: Tensor,
     kernel_size: BroadcastingList2[int],
-    output_size: Optional[BroadcastingList2[int]] = None,  # noqa: UP045
-    output_ratio: Optional[BroadcastingList2[float]] = None,  # noqa: UP045
+    output_size: Optional[BroadcastingList2[int]] = None,  # noqa: UP007
+    output_ratio: Optional[BroadcastingList2[float]] = None,  # noqa: UP007
     return_indices: bool = False,
     _random_samples: Tensor | None = None,
 ) -> tuple[Tensor, Tensor]:  # noqa: D400
@@ -517,8 +517,8 @@ def fractional_max_pool2d_with_indices(
 def _fractional_max_pool2d(
     input: Tensor,
     kernel_size: BroadcastingList2[int],
-    output_size: Optional[BroadcastingList2[int]] = None,  # noqa: UP045
-    output_ratio: Optional[BroadcastingList2[float]] = None,  # noqa: UP045
+    output_size: Optional[BroadcastingList2[int]] = None,  # noqa: UP007
+    output_ratio: Optional[BroadcastingList2[float]] = None,  # noqa: UP007
     return_indices: bool = False,
     _random_samples: Tensor | None = None,
 ) -> Tensor:
@@ -552,8 +552,8 @@ fractional_max_pool2d = boolean_dispatch(
 def fractional_max_pool3d_with_indices(
     input: Tensor,
     kernel_size: BroadcastingList3[int],
-    output_size: Optional[BroadcastingList3[int]] = None,  # noqa: UP045
-    output_ratio: Optional[BroadcastingList3[float]] = None,  # noqa: UP045
+    output_size: Optional[BroadcastingList3[int]] = None,  # noqa: UP007
+    output_ratio: Optional[BroadcastingList3[float]] = None,  # noqa: UP007
     return_indices: bool = False,
     _random_samples: Tensor | None = None,
 ) -> tuple[Tensor, Tensor]:  # noqa: D400
@@ -634,8 +634,8 @@ def fractional_max_pool3d_with_indices(
 def _fractional_max_pool3d(
     input: Tensor,
     kernel_size: BroadcastingList3[int],
-    output_size: Optional[BroadcastingList3[int]] = None,  # noqa: UP045
-    output_ratio: Optional[BroadcastingList3[float]] = None,  # noqa: UP045
+    output_size: Optional[BroadcastingList3[int]] = None,  # noqa: UP007
+    output_ratio: Optional[BroadcastingList3[float]] = None,  # noqa: UP007
     return_indices: bool = False,
     _random_samples: Tensor | None = None,
 ) -> Tensor:
@@ -669,7 +669,7 @@ fractional_max_pool3d = boolean_dispatch(
 def max_pool1d_with_indices(
     input: Tensor,
     kernel_size: BroadcastingList1[int],
-    stride: Optional[BroadcastingList1[int]] = None,  # noqa: UP045
+    stride: Optional[BroadcastingList1[int]] = None,  # noqa: UP007
     padding: BroadcastingList1[int] = 0,
     dilation: BroadcastingList1[int] = 1,
     ceil_mode: bool = False,
@@ -722,7 +722,7 @@ def max_pool1d_with_indices(
 def _max_pool1d(
     input: Tensor,
     kernel_size: BroadcastingList1[int],
-    stride: Optional[BroadcastingList1[int]] = None,  # noqa: UP045
+    stride: Optional[BroadcastingList1[int]] = None,  # noqa: UP007
     padding: BroadcastingList1[int] = 0,
     dilation: BroadcastingList1[int] = 1,
     ceil_mode: bool = False,
@@ -759,7 +759,7 @@ max_pool1d = boolean_dispatch(
 def max_pool2d_with_indices(
     input: Tensor,
     kernel_size: BroadcastingList2[int],
-    stride: Optional[BroadcastingList2[int]] = None,  # noqa: UP045
+    stride: Optional[BroadcastingList2[int]] = None,  # noqa: UP007
     padding: BroadcastingList2[int] = 0,
     dilation: BroadcastingList2[int] = 1,
     ceil_mode: bool = False,
@@ -812,7 +812,7 @@ def max_pool2d_with_indices(
 def _max_pool2d(
     input: Tensor,
     kernel_size: BroadcastingList2[int],
-    stride: Optional[BroadcastingList2[int]] = None,  # noqa: UP045
+    stride: Optional[BroadcastingList2[int]] = None,  # noqa: UP007
     padding: BroadcastingList2[int] = 0,
     dilation: BroadcastingList2[int] = 1,
     ceil_mode: bool = False,
@@ -849,7 +849,7 @@ max_pool2d = boolean_dispatch(
 def max_pool3d_with_indices(
     input: Tensor,
     kernel_size: BroadcastingList3[int],
-    stride: Optional[BroadcastingList3[int]] = None,  # noqa: UP045
+    stride: Optional[BroadcastingList3[int]] = None,  # noqa: UP007
     padding: BroadcastingList3[int] = 0,
     dilation: BroadcastingList3[int] = 1,
     ceil_mode: bool = False,
@@ -902,7 +902,7 @@ def max_pool3d_with_indices(
 def _max_pool3d(
     input: Tensor,
     kernel_size: BroadcastingList3[int],
-    stride: Optional[BroadcastingList3[int]] = None,  # noqa: UP045
+    stride: Optional[BroadcastingList3[int]] = None,  # noqa: UP007
     padding: BroadcastingList3[int] = 0,
     dilation: BroadcastingList3[int] = 1,
     ceil_mode: bool = False,
@@ -977,9 +977,9 @@ def max_unpool1d(
     input: Tensor,
     indices: Tensor,
     kernel_size: BroadcastingList1[int],
-    stride: Optional[BroadcastingList1[int]] = None,  # noqa: UP045
+    stride: Optional[BroadcastingList1[int]] = None,  # noqa: UP007
     padding: BroadcastingList1[int] = 0,
-    output_size: Optional[BroadcastingList1[int]] = None,  # noqa: UP045
+    output_size: Optional[BroadcastingList1[int]] = None,  # noqa: UP007
 ) -> Tensor:
     r"""Compute a partial inverse of :class:`MaxPool1d`.
 
@@ -1016,9 +1016,9 @@ def max_unpool2d(
     input: Tensor,
     indices: Tensor,
     kernel_size: BroadcastingList2[int],
-    stride: Optional[BroadcastingList2[int]] = None,  # noqa: UP045
+    stride: Optional[BroadcastingList2[int]] = None,  # noqa: UP007
     padding: BroadcastingList2[int] = 0,
-    output_size: Optional[BroadcastingList2[int]] = None,  # noqa: UP045
+    output_size: Optional[BroadcastingList2[int]] = None,  # noqa: UP007
 ) -> Tensor:
     r"""Compute a partial inverse of :class:`MaxPool2d`.
 
@@ -1049,9 +1049,9 @@ def max_unpool3d(
     input: Tensor,
     indices: Tensor,
     kernel_size: BroadcastingList3[int],
-    stride: Optional[BroadcastingList3[int]] = None,  # noqa: UP045
+    stride: Optional[BroadcastingList3[int]] = None,  # noqa: UP007
     padding: BroadcastingList3[int] = 0,
-    output_size: Optional[BroadcastingList3[int]] = None,  # noqa: UP045
+    output_size: Optional[BroadcastingList3[int]] = None,  # noqa: UP007
 ) -> Tensor:
     r"""Compute a partial inverse of :class:`MaxPool3d`.
 
@@ -1082,7 +1082,7 @@ def lp_pool3d(
     input: Tensor,
     norm_type: int | float,
     kernel_size: BroadcastingList3[int],
-    stride: Optional[BroadcastingList3[int]] = None,  # noqa: UP045
+    stride: Optional[BroadcastingList3[int]] = None,  # noqa: UP007
     ceil_mode: bool = False,
 ) -> Tensor:
     r"""
@@ -1123,7 +1123,7 @@ def lp_pool2d(
     input: Tensor,
     norm_type: int | float,
     kernel_size: BroadcastingList2[int],
-    stride: Optional[BroadcastingList2[int]] = None,  # noqa: UP045
+    stride: Optional[BroadcastingList2[int]] = None,  # noqa: UP007
     ceil_mode: bool = False,
 ) -> Tensor:
     r"""
@@ -1162,7 +1162,7 @@ def lp_pool1d(
     input: Tensor,
     norm_type: int | float,
     kernel_size: int,
-    stride: Optional[BroadcastingList1[int]] = None,  # noqa: UP045
+    stride: Optional[BroadcastingList1[int]] = None,  # noqa: UP007
     ceil_mode: bool = False,
 ) -> Tensor:
     r"""Apply a 1D power-average pooling over an input signal composed of several input planes.

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -72,7 +72,7 @@ _global_parameter_registration_hooks: dict[int, Callable] = OrderedDict()
 
 
 class _WrappedHook:
-    def __init__(self, hook: Callable, module: Optional["Module"] = None) -> None:  # noqa: UP045
+    def __init__(self, hook: Callable, module: Optional["Module"] = None) -> None:  # noqa: UP007
         self.hook: Callable = hook
         functools.update_wrapper(self, hook)
 
@@ -475,7 +475,7 @@ class Module:
     _load_state_dict_pre_hooks: dict[int, Callable]
     _state_dict_pre_hooks: dict[int, Callable]
     _load_state_dict_post_hooks: dict[int, Callable]
-    _modules: dict[str, Optional["Module"]]  # noqa: UP045
+    _modules: dict[str, Optional["Module"]]  # noqa: UP007
     call_super_init: bool = False
     _compiled_call_impl: Callable | None = None
 
@@ -639,7 +639,7 @@ class Module:
                     param = output
             self._parameters[name] = param
 
-    def add_module(self, name: str, module: Optional["Module"]) -> None:  # noqa: UP045
+    def add_module(self, name: str, module: Optional["Module"]) -> None:  # noqa: UP007
         r"""Add a child module to the current module.
 
         The module can be accessed as an attribute using the given name.
@@ -667,7 +667,7 @@ class Module:
                 module = output
         self._modules[name] = module
 
-    def register_module(self, name: str, module: Optional["Module"]) -> None:  # noqa: UP045
+    def register_module(self, name: str, module: Optional["Module"]) -> None:  # noqa: UP007
         r"""Alias for :func:`add_module`."""
         self.add_module(name, module)
 
@@ -2835,7 +2835,7 @@ class Module:
 
     def named_modules(
         self,
-        memo: set["Module"] | None = None,  # noqa: UP007
+        memo: Optional[set["Module"]] = None,  # noqa: UP007
         prefix: str = "",
         remove_duplicate: bool = True,
     ):

--- a/torch/onnx/_internal/exporter/_torchlib/_tensor_typing.py
+++ b/torch/onnx/_internal/exporter/_torchlib/_tensor_typing.py
@@ -24,7 +24,7 @@ from onnxscript import (
 # NOTE: We do not care about unsigned types beyond UINT8 because PyTorch does not us them.
 # More detail can be found: https://pytorch.org/docs/stable/tensors.html
 
-TensorType = Union[  # noqa: UP007
+TensorType = Union[
     BFLOAT16,
     BOOL,
     COMPLEX64,
@@ -38,9 +38,9 @@ TensorType = Union[  # noqa: UP007
     INT64,
     UINT8,
 ]
-_FloatType = Union[FLOAT16, FLOAT, DOUBLE, BFLOAT16]  # noqa: UP007
-IntType = Union[INT8, INT16, INT32, INT64]  # noqa: UP007
-RealType = Union[  # noqa: UP007
+_FloatType = Union[FLOAT16, FLOAT, DOUBLE, BFLOAT16]
+IntType = Union[INT8, INT16, INT32, INT64]
+RealType = Union[
     BFLOAT16,
     FLOAT16,
     FLOAT,
@@ -55,21 +55,19 @@ TTensor = TypeVar("TTensor", bound=TensorType)
 # Duplicate TTensor for inputs/outputs that accept the same set of types as TTensor
 # but do not constrain the type to be the same as the other inputs/outputs
 TTensor2 = TypeVar("TTensor2", bound=TensorType)
-TTensorOrString = TypeVar("TTensorOrString", bound=Union[TensorType, STRING])  # noqa: UP007
+TTensorOrString = TypeVar("TTensorOrString", bound=Union[TensorType, STRING])
 TFloat = TypeVar("TFloat", bound=_FloatType)
 TFloatOrUInt8 = TypeVar(
-    "TFloatOrUInt8",
-    bound=Union[FLOAT, FLOAT16, DOUBLE, INT8, UINT8],  # noqa: UP007
+    "TFloatOrUInt8", bound=Union[FLOAT, FLOAT16, DOUBLE, INT8, UINT8]
 )
 TInt = TypeVar("TInt", bound=IntType)
 TReal = TypeVar("TReal", bound=RealType)
 TRealUnlessInt16OrInt8 = TypeVar(
     "TRealUnlessInt16OrInt8",
-    bound=Union[FLOAT16, FLOAT, DOUBLE, BFLOAT16, INT32, INT64],  # noqa: UP007
+    bound=Union[FLOAT16, FLOAT, DOUBLE, BFLOAT16, INT32, INT64],
 )
 TRealUnlessFloat16OrInt8 = TypeVar(
-    "TRealUnlessFloat16OrInt8",
-    bound=Union[DOUBLE, FLOAT, INT16, INT32, INT64],  # noqa: UP007
+    "TRealUnlessFloat16OrInt8", bound=Union[DOUBLE, FLOAT, INT16, INT32, INT64]
 )
-TRealOrUInt8 = TypeVar("TRealOrUInt8", bound=Union[RealType, UINT8])  # noqa: UP007
-TFloatHighPrecision = TypeVar("TFloatHighPrecision", bound=Union[FLOAT, DOUBLE])  # noqa: UP007
+TRealOrUInt8 = TypeVar("TRealOrUInt8", bound=Union[RealType, UINT8])
+TFloatHighPrecision = TypeVar("TFloatHighPrecision", bound=Union[FLOAT, DOUBLE])

--- a/torch/random.py
+++ b/torch/random.py
@@ -2,7 +2,7 @@
 import contextlib
 import warnings
 from collections.abc import Generator
-from typing import TYPE_CHECKING
+from typing import Optional, TYPE_CHECKING
 
 import torch
 
@@ -234,7 +234,7 @@ def fork_rng(
             device_mod.set_rng_state(device_rng_state, device)
 
 
-def thread_safe_generator() -> torch.Generator | None:
+def thread_safe_generator() -> Optional[torch.Generator]:
     """Returns a thread-safe random number generator for use in DataLoader workers.
     This function provides a convenient way for transforms and user code to use
     thread-safe random number generation without manually checking worker context.

--- a/torch/types.py
+++ b/torch/types.py
@@ -12,7 +12,7 @@ from builtins import (  # noqa: F401
     str as _str,
 )
 from collections.abc import Sequence
-from typing import Any, IO, TYPE_CHECKING, TypeAlias, Union
+from typing import Any, IO, Optional, TYPE_CHECKING, TypeAlias, Union
 from typing_extensions import Self
 
 # `as` imports have better static analysis support than assignment `ExposedType: TypeAlias = HiddenType`
@@ -39,7 +39,7 @@ __all__ = ["Number", "Device", "FileLike", "Storage"]
 # Convenience aliases for common composite types that we need
 # to talk about in PyTorch
 _TensorOrTensors: TypeAlias = Tensor | Sequence[Tensor]  # noqa: PYI047
-_TensorOrOptionalTensors: TypeAlias = Tensor | Sequence[Tensor | None]  # noqa: PYI047
+_TensorOrOptionalTensors: TypeAlias = Union[Tensor, Sequence[Optional[Tensor]]]  # noqa: PYI047
 _TensorOrTensorsOrGradEdge: TypeAlias = Union[  # noqa: PYI047
     Tensor,
     Sequence[Tensor],

--- a/torchgen/api/types/types_base.py
+++ b/torchgen/api/types/types_base.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import auto, Enum
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Union
 
 
 if TYPE_CHECKING:
@@ -35,7 +35,7 @@ class SpecialArgName(Enum):
     possibly_redundant_memory_format = auto()
 
 
-ArgName = str | SpecialArgName
+ArgName = Union[str, SpecialArgName]
 
 
 # This class shouldn't be created directly; instead, use/create one of the singletons below.


### PR DESCRIPTION
This reverts commit b244229e2826c7139a15fc524fb8956dfa3d63a9.

This is needed to unblock diff train because https://github.com/pytorch/pytorch/pull/176918 has a merge conflict with https://github.com/pytorch/pytorch/pull/175497 and the latter has been reverted by https://github.com/pytorch/pytorch/pull/177113. The PRs and their reverts were landed in interlocking order in fbcode, so this is the only way to untangle them.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Lucaskabela @laithsakka As you both are updating these 2 files:

* `torch/fx/experimental/_size_hinting.py`
* `torch/fx/experimental/symbolic_shapes.py`

We probably to coordinate their landing later