### PR TITLE
Fix SDPA flop counter to support Grouped Query Attention (GQA) 

### DIFF
--- a/test/test_flop_counter.py
+++ b/test/test_flop_counter.py
@@ -1069,6 +1069,41 @@ class TestFlopCounter(TestCase):
         ]
         self.assertEqual(layer1_conv_flops_standard, layer1_conv_flops_inference)
 
+    def test_sdpa_flop_count_gqa(self):
+        from torch.utils.flop_counter import sdpa_backward_flop_count, sdpa_flop_count
+
+        b, h, h_kv, s_q, s_k, d_q, d_v = 2, 8, 2, 128, 256, 64, 64
+
+        # Forward: GQA flops should equal MHA flops with the same Q head count,
+        # since K/V are broadcast to match Q's heads.
+        gqa_flops = sdpa_flop_count(
+            (b, h, s_q, d_q), (b, h_kv, s_k, d_q), (b, h_kv, s_k, d_v)
+        )
+        mha_flops = sdpa_flop_count(
+            (b, h, s_q, d_q), (b, h, s_k, d_q), (b, h, s_k, d_v)
+        )
+        self.assertEqual(gqa_flops, mha_flops)
+
+        # Backward
+        grad_out_shape = (b, h, s_q, d_v)
+        gqa_bw = sdpa_backward_flop_count(
+            grad_out_shape, (b, h, s_q, d_q), (b, h_kv, s_k, d_q), (b, h_kv, s_k, d_v)
+        )
+        mha_bw = sdpa_backward_flop_count(
+            grad_out_shape, (b, h, s_q, d_q), (b, h, s_k, d_q), (b, h, s_k, d_v)
+        )
+        self.assertEqual(gqa_bw, mha_bw)
+
+        # MQA (single KV head) should also work
+        mqa_flops = sdpa_flop_count(
+            (b, h, s_q, d_q), (b, 1, s_k, d_q), (b, 1, s_k, d_v)
+        )
+        self.assertEqual(mqa_flops, mha_flops)
+
+        # Incompatible head counts should raise
+        with self.assertRaises(AssertionError):
+            sdpa_flop_count((b, 7, s_q, d_q), (b, 3, s_k, d_q), (b, 3, s_k, d_v))
+
     @unittest.skipIf(not HAS_CUDA, "CUDA not available")
     @unittest.skipIf(
         not PLATFORM_SUPPORTS_FP8,

--- a/torch/utils/flop_counter.py
+++ b/torch/utils/flop_counter.py
@@ -282,12 +282,20 @@ def sdpa_flop_count(query_shape, key_shape, value_shape):
     """
     Count flops for self-attention.
 
-    NB: We can assume that value_shape == key_shape
+    NB: We can assume that value_shape == key_shape.
+    Supports GQA where K/V heads are broadcast to match Q's head count.
     """
     b, h, s_q, d_q = query_shape
-    _b2, _h2, s_k, _d2 = key_shape
+    _b2, h_kv, s_k, _d2 = key_shape
     _b3, _h3, _s3, d_v = value_shape
-    if not b == _b2 == _b3 or not h == _h2 == _h3 or not d_q == _d2 or not s_k == _s3 or not d_q == _d2:
+    if (
+        not b == _b2 == _b3
+        or not h_kv == _h3
+        or not h >= h_kv
+        or (h_kv > 0 and h % h_kv != 0)
+        or not d_q == _d2
+        or not s_k == _s3
+    ):
         raise AssertionError("sdpa_flop_count: query/key/value shapes are incompatible")
     total_flops = 0
     # q: [b, h, s_q, d_q] @ k: [b, h, d_q, s_k] -> scores: [b, h, s_q, s_k]
@@ -490,12 +498,19 @@ def _efficient_attention_forward_flop(
 
 
 def sdpa_backward_flop_count(grad_out_shape, query_shape, key_shape, value_shape):
-    total_flops = 0
+    """Count flops for self-attention backward. Supports GQA."""
     b, h, s_q, d_q = query_shape
-    _b2, _h2, s_k, _d2 = key_shape
+    _b2, h_kv, s_k, _d2 = key_shape
     _b3, _h3, _s3, d_v = value_shape
     _b4, _h4, _s4, _d4 = grad_out_shape
-    if not b == _b2 == _b3 == _b4 or not h == _h2 == _h3 == _h4 or not d_q == _d2:
+    if (
+        not b == _b2 == _b3 == _b4
+        or not h_kv == _h3
+        or not h == _h4
+        or not h >= h_kv
+        or (h_kv > 0 and h % h_kv != 0)
+        or not d_q == _d2
+    ):
         raise AssertionError("sdpa_backward_flop_count: batch/heads/dimension mismatch among tensors")
     if not d_v == _d4 or not s_k == _s3 or not s_q == _s4:
         raise AssertionError("sdpa_backward_flop_count: grad_out/value/key/query shapes are incompatible")


### PR DESCRIPTION
The SDPA flop counter previously required Q, K, and V to have identical head counts, causing it to reject valid GQA (grouped query attention) patterns. This fixes the validation to allow K/V to have fewer heads than Q (where `h_q % h_kv == 0`), matching how GQA works in practice — K/V heads are broadcast to match Q's head count, so the flop count is the same as equivalent MHA.

Added unit-test:
```
python test/test_flop_counter.py -k test_sdpa_flop_count_gqa
```

Also fixes https://github.com/pytorch/torchtitan/issues/2055
```
MODULE=graph_trainer.llama3 CONFIG=graph_trainer_llama3_8b  ./run_train.sh --parallelism.data_parallel_shard_degree=2 --parallelism.tensor_parallel_degree=4 --compile.passes auto_bucketing --debug.seed=0 --debug.deterministic
```