### PR TITLE
[Bugfix] Fix nll bug via decomposition handling

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -8633,6 +8633,26 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
                 (a, b, c),
             )
 
+    @xfail_if_mps  # dtypes mismatch
+    def test_nll_loss_backward_1d_input(self):
+        # 1D input with 1D target used to crash the decomposition because
+        # target.unsqueeze(0) produced a 2D index for a 1D scatter.
+        def fn(a, b, c):
+            return aten.nll_loss_backward(
+                a, b, c, None, 0, 10, torch.tensor(1.0, device=self.device)
+            )
+
+        # 1D target — validation requires target.size(0) == self.size(0)
+        self.common(
+            fn,
+            (torch.randn(1), torch.randn(3), torch.tensor([2, 0, 1])),
+        )
+        # scalar target (the no_batch_dim path in the C++ kernel)
+        self.common(
+            fn,
+            (torch.randn(1), torch.randn(3), torch.tensor(2)),
+        )
+
     def test_isinf(self):
         def fn(x):
             return x.isinf(), x.isnan()

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -506,6 +506,12 @@ def _nll_loss_backward(
     if reduction == Reduction.MEAN.value:
         grad_output = grad_output / total_weight
 
+    # When self is 1D (no batch dim), the C++ kernel only uses target[0].
+    # Reduce target to a scalar so the subsequent unsqueeze produces a 1D
+    # tensor matching self's dimensionality.
+    if self.dim() == 1 and target.dim() > 0:
+        target = target[0]
+
     target = target.unsqueeze(channel_dim)
     safe_target = torch.where(target != ignore_index, target, 0)
     grad_input = torch.zeros_like(self)


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/89630

## Summary
NLL backward was failing under compile with 1d input when self is 1D, where target.unsqueeze(0) produced 
  a 2D index for the subsequent 1D scatter. The fix mirrors the C++ kernel's behavior of only using         
  target[0]

## Test
```bash
python -m pytest test/inductor/test_torchinductor.py -xvs -k "test_nll_loss_backward_1d_input"
```



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo