### PR TITLE
[pt2 bug bash] Fix misleading cudagraph_mark_step_begin suggestion in overwrite error

### DIFF
--- a/docs/source/user_guide/torch_compiler/torch.compiler_cudagraph_trees.md
+++ b/docs/source/user_guide/torch_compiler/torch.compiler_cudagraph_trees.md
@@ -317,10 +317,13 @@ print(y1)
 In the Separate CUDA Graph implementation, the output from the first invocation will be overwritten by the second invocation. In CUDAGraph
 Trees, we don’t want to add unintended dependencies between iterations that would cause us to not hit the hot path, nor do we want we want
 to prematurely free memory from a prior invocation. Our heuristics are in inference we start a new iteration on each invocation for
-torch.compile, and in training we do the same so long as there is not a pending backward that has not been invoked. If those heuristics
-are wrong, you can mark the start of a new iteration with
-[torch.compiler.cudagraph_mark_step_begin()](https://pytorch.org/docs/stable/generated/torch.compiler.cudagraph_mark_step_begin.html), or clone
-tensors of a prior iteration (outside of torch.compile) before you begin the next run.
+torch.compile, and in training we do the same so long as there is not a pending backward that has not been invoked.
+
+If you need to keep tensors from a prior invocation alive, clone them outside of torch.compile before calling the next invocation.
+If those heuristics for detecting a new iteration are wrong (e.g. pending backwards prevent generation advancement), you can mark
+the start of a new iteration with
+[torch.compiler.cudagraph_mark_step_begin()](https://pytorch.org/docs/stable/generated/torch.compiler.cudagraph_mark_step_begin.html).
+Note that `cudagraph_mark_step_begin()` does not prevent memory reuse — it only helps the runtime correctly identify iteration boundaries.
 
 ### Comparisons
 

--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -2291,6 +2291,20 @@ if HAS_CUDA_AND_TRITON:
             with self.assertRaisesRegex(Exception, "overwritten by a subsequent"):
                 out2 + out2
 
+        def test_error_on_dealloc_use_with_mark_step(self):
+            @torch.compile(mode="reduce-overhead")
+            def foo(x):
+                return x * x * x
+
+            inp = torch.rand([4], device="cuda")
+            torch.compiler.cudagraph_mark_step_begin()
+            out = foo(inp)
+            torch.compiler.cudagraph_mark_step_begin()
+            out2 = foo(inp)
+
+            with self.assertRaisesRegex(Exception, "overwritten by a subsequent"):
+                out + out
+
         def test_error_on_dealloc_use2(self):
             @torch.compile()
             def foo(x):

--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -2600,8 +2600,7 @@ class CUDAGraphTreeManager:
         return (
             "Error: accessing tensor output of CUDAGraphs that has been overwritten by a subsequent run. "
             f"Stack trace: {stack_trace}. "
-            "To prevent overwriting, clone the tensor outside of torch.compile() "
-            "or call torch.compiler.cudagraph_mark_step_begin() before each model invocation."
+            "To prevent overwriting, clone the tensor outside of torch.compile() before the next invocation."
         )
 
     def dealloc_current_path_weakrefs(self) -> None:

--- a/torch/compiler/__init__.py
+++ b/torch/compiler/__init__.py
@@ -381,6 +381,12 @@ def cudagraph_mark_step_begin():
 
     If that heuristic is wrong, such as in the following example, manually mark it with this api.
 
+    .. note::
+
+        This function helps the runtime correctly identify iteration boundaries but does not prevent
+        memory reuse across invocations. If you need to keep output tensors from a prior invocation alive,
+        you must clone them outside of ``torch.compile`` before calling the next invocation.
+
     .. code-block:: python
 
         @torch.compile(mode="reduce-overhead")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #177192

The error message for accessing overwritten CUDAGraph tensor outputs
suggested calling cudagraph_mark_step_begin() as an alternative to
cloning. This is wrong — mark_step_begin() forces generation advancement
which *causes* the dealloc, never prevents it. The only fix for keeping
old outputs alive is cloning.

Updated the error message, docstring, and docs to clarify that
mark_step_begin() is for iteration boundary heuristics (e.g. pending
backwards), not for preventing memory reuse.

Fixes #170604

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo