### PR TITLE
Add magma build for cuda 13.2

### DIFF
--- a/.ci/magma/Makefile
+++ b/.ci/magma/Makefile
@@ -16,6 +16,7 @@ DOCKER_RUN = set -eou pipefail; ${DOCKER_CMD} run --rm -i \
 	magma/build_magma.sh
 
 .PHONY: all
+all: magma-cuda132
 all: magma-cuda130
 all: magma-cuda129
 all: magma-cuda128
@@ -25,6 +26,12 @@ all: magma-cuda126
 clean:
 	$(RM) -r magma-*
 	$(RM) -r output
+
+.PHONY: magma-cuda132
+magma-cuda132: DESIRED_CUDA := 13.2
+magma-cuda132: CUDA_ARCH_LIST := -gencode arch=compute_80,code=sm_80 -gencode arch=compute_86,code=sm_86 -gencode arch=compute_90,code=sm_90 -gencode arch=compute_100,code=sm_100 -gencode arch=compute_120,code=sm_120
+magma-cuda132:
+	$(DOCKER_RUN)
 
 .PHONY: magma-cuda130
 magma-cuda130: DESIRED_CUDA := 13.0

--- a/.github/workflows/build-magma-linux.yml
+++ b/.github/workflows/build-magma-linux.yml
@@ -34,7 +34,7 @@ jobs:
       id-token: write
     strategy:
       matrix:
-        cuda_version: ["130", "129", "128", "126"]
+        cuda_version: ["132", "130", "129", "128", "126"]
     steps:
       - name: Checkout PyTorch
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
Add magma build for CUDA 13.2 after almalinux docker is available

https://github.com/pytorch/pytorch/issues/177067

cc @atalman 