### PR TITLE
Fix SAC FIFO mismatch for inductor_compiled_code HOP

### DIFF
--- a/test/dynamo/test_wrap_inductor_compiled_regions.py
+++ b/test/dynamo/test_wrap_inductor_compiled_regions.py
@@ -1,6 +1,7 @@
 # Owner(s): ["module: dynamo"]
 
 import functools
+import unittest
 
 import torch
 import torch._dynamo.test_case
@@ -1218,6 +1219,79 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         result = traced(inp)
         expected = inp + 1
         torch.testing.assert_close(result, expected)
+
+    @unittest.skipIf(not torch.distributed.is_available(), "requires torch.distributed")
+    def test_sac_cached_value_fifo_mismatch(self):
+        """
+        Regression test for https://github.com/pytorch/pytorch/issues/175258
+
+        When SAC is used with wrap_inductor_compiled_regions=True and a global
+        cache causes different op sequences between forward and recompute, the
+        SAC FIFO queue should not return the wrong cached value.
+
+        The bug: all inductor_compiled_code HOP calls share one FIFO queue keyed
+        by func identity. If a compiled region is skipped during recompute
+        (because its result was cached in a global dict during forward), the queue
+        returns the wrong entry, causing DTensor.__tensor_unflatten__ to receive
+        int tensors when it expects float tensors.
+        """
+        import torch.distributed as dist
+        from torch.distributed.device_mesh import init_device_mesh
+        from torch.distributed.tensor import DTensor, Replicate
+        from torch.testing._internal.distributed.fake_pg import FakeStore
+
+        fake_store = FakeStore()
+        dist.init_process_group(backend="fake", store=fake_store, rank=0, world_size=1)
+
+        try:
+            mesh = init_device_mesh("cpu", mesh_shape=(1,), mesh_dim_names=("dp",))
+
+            @torch.compile(dynamic=False, fullgraph=True)
+            def compute_int_stuff(n):
+                return torch.arange(n, dtype=torch.int32)
+
+            @torch.compile(dynamic=False, fullgraph=True)
+            def compute_float(q, cached_ints):
+                ql = q.to_local()
+                out = ql * cached_ints.float().sum()
+                return DTensor.from_local(
+                    out, device_mesh=q.device_mesh, placements=q.placements
+                )
+
+            _cache: dict = {}
+
+            def outer_fn(x):
+                # Forward: cache miss, compute_int_stuff runs as inductor_compiled_code.
+                # Recompute: cache hit, compute_int_stuff is skipped; only compute_float
+                # runs. With a single shared FIFO queue this would pop the int-tensor
+                # entry and feed it to compute_float.
+                if "data" not in _cache:
+                    _cache["data"] = compute_int_stuff(x.shape[-1])
+                return compute_float(x, _cache["data"])
+
+            def policy_fn(ctx, op, *args, **kwargs):
+                if isinstance(op, torch._ops.HigherOrderOperator):
+                    if op.name() == "inductor_compiled_code":
+                        return CheckpointPolicy.MUST_SAVE
+                return CheckpointPolicy.PREFER_RECOMPUTE
+
+            context_fn = functools.partial(
+                create_selective_checkpoint_contexts, policy_fn
+            )
+
+            x = DTensor.from_local(
+                torch.randn(4, 4, dtype=torch.float32, requires_grad=True),
+                mesh,
+                (Replicate(),),
+            )
+
+            with inductor_config.patch({"wrap_inductor_compiled_regions": True}):
+                out = checkpoint(
+                    outer_fn, x, use_reentrant=False, context_fn=context_fn
+                )
+                out.sum().backward()
+        finally:
+            dist.destroy_process_group()
 
 
 if __name__ == "__main__":

--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -1319,6 +1319,23 @@ SAC_IGNORED_OPS = {
 } | set(torch._subclasses.functional_tensor.FunctionalTensor.metadata_fns)  # type: ignore[has-type]
 
 
+def _sac_storage_key(func, args):
+    """Compute the SAC storage key for a given op.
+
+    For inductor_compiled_code, each compiled region gets its own FIFO queue
+    keyed by the callable's unique idx.  Without this, all compiled regions
+    share one queue and a cache-hit that skips a region during recompute
+    causes the queue to return the wrong entry (see gh-175258).
+    """
+    from torch._higher_order_ops.wrap import (
+        _resolve_inductor_callable,
+        inductor_compiled_code as _inductor_compiled_code,
+    )
+    if func is _inductor_compiled_code and args:
+        return (func, _resolve_inductor_callable(args[0]).idx)
+    return func
+
+
 class _CachingTorchDispatchMode(TorchDispatchMode):
     @classmethod
     def ignore_compile_internals(cls):
@@ -1352,8 +1369,9 @@ class _CachingTorchDispatchMode(TorchDispatchMode):
 
         out = func(*args, **kwargs)
 
-        idx = self.func_counter[func]
-        self.func_counter[func] += 1
+        key = _sac_storage_key(func, args)
+        idx = self.func_counter[key]
+        self.func_counter[key] += 1
 
         policy = self.policy_fn(SelectiveCheckpointContext(is_recompute=False, op_output=out),
                                 func, *args, **kwargs)
@@ -1368,9 +1386,9 @@ class _CachingTorchDispatchMode(TorchDispatchMode):
                     node.meta["recompute"] = policy
 
         if policy in (CheckpointPolicy.MUST_SAVE, CheckpointPolicy.PREFER_SAVE) or is_compiling:
-            self.storage[func][idx] = tree_map(lambda x: _VersionWrapper(_detach_helper(x)), out)
+            self.storage[key][idx] = tree_map(lambda x: _VersionWrapper(_detach_helper(x)), out)
         else:
-            self.storage[func][idx] = _RECOMPUTE
+            self.storage[key][idx] = _RECOMPUTE
         return out
 
 _RECOMPUTE = object()
@@ -1404,10 +1422,11 @@ class _CachedTorchDispatchMode(TorchDispatchMode):
         if func in SAC_IGNORED_OPS:
             return func(*args, **kwargs)
 
-        idx = self.func_counter[func]
-        self.func_counter[func] += 1
+        key = _sac_storage_key(func, args)
+        idx = self.func_counter[key]
+        self.func_counter[key] += 1
 
-        func_storage = self.storage.get(func)
+        func_storage = self.storage.get(key)
         if func_storage is None:
             raise RuntimeError(
                 f"{func} encountered during backward but not found in "


### PR DESCRIPTION
## Human Note
Use per-callable storage keys in SAC's dispatch modes so that each inductor_compiled_code region gets its own FIFO queue. Previously all compiled regions shared one queue keyed by the HOP identity, causing wrong cached values to be returned when a region was skipped during recompute due to global cache state. Fixes #175258.

## Agent Report
# Fix: SAC FIFO queue mismatch with `inductor_compiled_code` (gh-175258)

## Summary

When `wrap_inductor_compiled_regions=True` and SAC (Selective Activation Checkpointing) is used, all `inductor_compiled_code` HOP calls shared a single FIFO queue keyed only by the HOP identity. If a compiled region was skipped during SAC recompute (e.g. due to a cache hit on a global dict), the queue returned the wrong cached value, causing `DTensor.__tensor_unflatten__` to fail with `RuntimeError: Only Tensors of floating point and complex dtype can require gradients`.

## Root Cause

SAC stores cached op outputs in a `defaultdict(list)` keyed by `func`. All `inductor_compiled_code` calls—regardless of which compiled region they wrap—shared one queue entry under the same key.

**Forward** (cache miss): two `inductor_compiled_code` calls fire → queue has `[int32_output, float_dtensor_output]`.

**Recompute** (cache hit): first compiled region is skipped → only one `inductor_compiled_code` call fires → pops `int32_output` instead of `float_dtensor_output` → crash.

## Fix

Added `_sac_storage_key(func, args)` in `torch/utils/checkpoint.py` that returns `(func, callable.idx)` for `inductor_compiled_code` and plain `func` for everything else. Each compiled region now gets its own FIFO queue, so skipping one region during recompute doesn't corrupt another's queue.

**Files changed:**
- `torch/utils/checkpoint.py` — Added `_sac_storage_key()`, used it in both `_CachingTorchDispatchMode` and `_CachedTorchDispatchMode`
- `test/dynamo/test_wrap_inductor_compiled_regions.py` — Added `test_sac_cached_value_fifo_mismatch` regression test

<details>
<summary>Repro Script</summary>

```python
"""Minimal self-contained repro for DTensor int tensor + SAC + compile bug."""

import os
os.environ["RANK"] = "0"
os.environ["WORLD_SIZE"] = "1"
os.environ["LOCAL_RANK"] = "0"
os.environ["MASTER_ADDR"] = "localhost"
os.environ["MASTER_PORT"] = "29500"

import torch
import torch.distributed as dist
import torch.utils.checkpoint
from functools import partial
from torch.distributed.device_mesh import init_device_mesh
from torch.distributed.tensor import DTensor, Replicate
from torch.nn.attention.flex_attention import create_block_mask, flex_attention
from torch.utils.checkpoint import CheckpointPolicy

torch._inductor.config.wrap_inductor_compiled_regions = True
dist.init_process_group(backend="fake", init_method="env://", world_size=1, rank=0)
device = "cuda" if torch.cuda.is_available() else "cpu"
mesh = init_device_mesh(device, mesh_shape=(1,), mesh_dim_names=("fsdp",))

_SAVE = {torch.ops.higher_order.flex_attention.name(): None, "inductor_compiled_code": None}

def ac_policy(ctx, op, *args, **kwargs):
    if (isinstance(op, torch._ops.HigherOrderOperator) and op.name() in _SAVE) or op in _SAVE:
        return CheckpointPolicy.MUST_SAVE
    return CheckpointPolicy.PREFER_RECOMPUTE

L = 64
_compiled_create_block_mask = torch.compile(create_block_mask, dynamic=False, fullgraph=True)
_compiled_flex_attention = torch.compile(flex_attention, mode="default", fullgraph=True, dynamic=False)

def causal(b, h, q, k):
    return q >= k

_mask_cache = {}

def inner_fn(q, mask):
    ql = q.to_local()
    out = _compiled_flex_attention(query=ql, key=ql, value=ql, block_mask=mask)
    return DTensor.from_local(out, device_mesh=q.device_mesh, placements=q.placements)

inner_fn = torch.compile(inner_fn, mode="default", fullgraph=True, dynamic=False)

def outer_fn(x):
    if "m" not in _mask_cache:
        _mask_cache["m"] = _compiled_create_block_mask(
            mask_mod=causal, B=None, H=None,
            Q_LEN=L, KV_LEN=L, BLOCK_SIZE=128, device=x.device,
        )
    return inner_fn(x, _mask_cache["m"])

context_fn = partial(torch.utils.checkpoint.create_selective_checkpoint_contexts, ac_policy)

x = DTensor.from_local(
    torch.randn(1, 1, L, L, device=device, dtype=torch.bfloat16, requires_grad=True),
    mesh, (Replicate(),),
)

try:
    out = torch.utils.checkpoint.checkpoint(
        outer_fn, x, use_reentrant=False, context_fn=context_fn,
    )
    out.sum().backward()
    print("PASS - no error")
except RuntimeError as e:
    import traceback
    traceback.print_exc()
    if "Only Tensors of floating point and complex dtype" in str(e):
        print("\nFAIL - DTensor constructor error reproduced!")
    else:
        print(f"\nDifferent error: {e}")
finally:
    dist.destroy_process_group()
```

**Before fix:**
```
RuntimeError: Only Tensors of floating point and complex dtype can require gradients
FAIL - DTensor constructor error reproduced!
```

**After fix:**
```
PASS - no error
```

</details>

## Test Results

- **Regression test fails before fix:** Yes — `RuntimeError: Only Tensors of floating point and complex dtype can require gradients`
- **Regression test passes after fix:** Yes
- **All 21 existing tests in `test_wrap_inductor_compiled_regions.py` pass:** Yes
- **Original CUDA repro script passes:** Yes

## Remaining Risks

- This fix only handles `inductor_compiled_code`. Other HOPs that branch on global state could still cause FIFO mismatches. For a fully general solution, users would need a "recompute tape" mechanism (record decisions during forward, replay during recompute). This is an additive feature that can be built separately.
- The fix relies on `InductorCompiledCallable.idx` being stable between forward and recompute. This is guaranteed because dynamo caches the compiled callable object.


Fixes #175258


<details>
<summary>Repro Script</summary>

```python
"""Minimal self-contained repro for DTensor int tensor + SAC + compile bug.

No sixlib dependencies. Triggers:
  RuntimeError: Only Tensors of floating point and complex dtype can require gradients
in DTensor.__tensor_unflatten__ during SAC recomputation of a compiled region.

Root cause: A compiled create_block_mask produces a BlockMask containing int tensors.
When this BlockMask is cached and reused during SAC recomputation inside a compiled
function that operates on DTensors, aot_autograd's wrap_tensor_subclasses incorrectly
tries to reconstruct a DTensor from the int tensor with requires_grad=True.

Essential ingredients (removing any one makes the bug disappear):
1. wrap_inductor_compiled_regions = True
2. Compiled create_block_mask (BlockMask cached across forward/recompute)
3. Compiled inner function wrapping DTensor -> to_local -> compiled flex_attention -> DTensor
4. SAC (selective activation checkpointing) around the outer function
5. SAC policy that saves both flex_attention and inductor_compiled_code outputs
"""

import os

os.environ["RANK"] = "0"
os.environ["WORLD_SIZE"] = "1"
os.environ["LOCAL_RANK"] = "0"
os.environ["MASTER_ADDR"] = "localhost"
os.environ["MASTER_PORT"] = "29500"

import torch
import torch.distributed as dist
import torch.utils.checkpoint
from functools import partial
from torch.distributed.device_mesh import init_device_mesh
from torch.distributed.tensor import DTensor, Replicate
from torch.nn.attention.flex_attention import create_block_mask, flex_attention
from torch.utils.checkpoint import CheckpointPolicy

torch._inductor.config.wrap_inductor_compiled_regions = True
dist.init_process_group(backend="fake", init_method="env://", world_size=1, rank=0)
device = "cuda" if torch.cuda.is_available() else "cpu"
mesh = init_device_mesh(device, mesh_shape=(1,), mesh_dim_names=("fsdp",))

# SAC policy: save flex_attention and inductor_compiled_code outputs
_SAVE = {torch.ops.higher_order.flex_attention.name(): None, "inductor_compiled_code": None}


def ac_policy(ctx, op, *args, **kwargs):
    if (isinstance(op, torch._ops.HigherOrderOperator) and op.name() in _SAVE) or op in _SAVE:
        return CheckpointPolicy.MUST_SAVE
    return CheckpointPolicy.PREFER_RECOMPUTE


L = 64

_compiled_create_block_mask = torch.compile(create_block_mask, dynamic=False, fullgraph=True)
_compiled_flex_attention = torch.compile(flex_attention, mode="default", fullgraph=True, dynamic=False)


def causal(b, h, q, k):
    return q >= k


_mask_cache = {}


def inner_fn(q, mask):
    """Compiled function: DTensor -> to_local -> flex_attention -> DTensor."""
    ql = q.to_local()
    out = _compiled_flex_attention(query=ql, key=ql, value=ql, block_mask=mask)
    return DTensor.from_local(out, device_mesh=q.device_mesh, placements=q.placements)


inner_fn = torch.compile(inner_fn, mode="default", fullgraph=True, dynamic=False)


def outer_fn(x):
    """Builds/caches BlockMask, calls compiled inner."""
    if "m" not in _mask_cache:
        _mask_cache["m"] = _compiled_create_block_mask(
            mask_mod=causal, B=None, H=None,
            Q_LEN=L, KV_LEN=L, BLOCK_SIZE=128, device=x.device,
        )
    return inner_fn(x, _mask_cache["m"])


context_fn = partial(torch.utils.checkpoint.create_selective_checkpoint_contexts, ac_policy)

# Input shape: [batch, num_heads, seq_len, head_dim]
x = DTensor.from_local(
    torch.randn(1, 1, L, L, device=device, dtype=torch.bfloat16, requires_grad=True),
    mesh, (Replicate(),),
)

try:
    out = torch.utils.checkpoint.checkpoint(
        outer_fn, x, use_reentrant=False, context_fn=context_fn,
    )
    out.sum().backward()
    print("PASS - no error")
except RuntimeError as e:
    import traceback
    traceback.print_exc()
    if "Only Tensors of floating point and complex dtype" in str(e):
        print("\nFAIL - DTensor constructor error reproduced!")
    else:
        print(f"\nDifferent error: {e}")
finally:
    dist.destroy_process_group()
```

</details>


<details>
<summary>Agent Worklog</summary>

## Run 1

> **User:** Investigate this issue in diagnosis-and-plan mode.

You may inspect code, compare versions, and create throwaway helpers inside the job directory, but you may not modify product source files or prepare a patch yet.

Use subagents early for parallel exploration. Prefer read-only subagents. Good subagent tasks include:
- finding related kernels or codepaths
- comparing behavior across versions or backends
- locating similar bugs or existing tests
- checking whether the first hypothesis actually matches the runtime evidence

Your goal:
- gather evidence
- produce a minimal repro or a clear non-repro conclusion
- rank the top root-cause hypotheses
- propose the smallest plausible fix plan
- identify unknowns and risks

Rules:
- do not generate a diff
- do not broaden scope mid-run
- do not treat mathematical plausibility or static inspection as sufficient proof
- if runtime evidence and code inspection disagree, trust runtime evidence and report the disagreement

Output:
- repro status
- strongest evidence
- ranked hypotheses with confidence
- likely files involved
- proposed fix plan
- open questions
- recommended next action for user approval

Stop after the plan and wait.

---

## 2026-03-11: Initial Investigation

### Code Exploration (Parallel)
Read all critical code paths:
- `torch/utils/checkpoint.py`: SAC modes (`_CachingTorchDispatchMode`, `_CachedTorchDispatchMode`)
- `torch/_functorch/_aot_autograd/schemas.py`: `SubclassCreationMeta.creation_fn`
- `torch/_functorch/_aot_autograd/subclass_utils.py`: `wrap_tensor_subclasses`
- `torch/_higher_order_ops/wrap.py`: `inductor_compiled_code` HOP
- `torch/distributed/tensor/_api.py`: DTensor `__tensor_unflatten__`

### Root Cause Analysis
The bug is caused by SAC's FIFO queue storage getting out of sync when forward and recompute execute different op sequences due to global mutable state (block mask cache).

**Forward pass** (cache miss):
1. `inductor_compiled_code` fires for `create_block_mask` → SAC stores output (int32 tensors)
2. `inductor_compiled_code` fires for `inner_fn` → SAC stores output (bfloat16 DTensor)

**Recompute pass** (cache hit, mask already cached):
1. `create_block_mask` skipped (cache hit)
2. `inductor_compiled_code` fires for `inner_fn` → SAC pops from FIFO → gets create_block_mask's int32 output!

This causes `wrap_tensor_subclasses` to reconstruct a DTensor from int32 tensors with requires_grad=True, which fails.

### Build & Repro
Built PyTorch in the job's venv (CPU with Eigen BLAS, then CUDA rebuild in progress).
Reproduced the bug on CPU with a simplified repro that removes flex_attention dependency.
The CPU repro confirms the core mechanism: SAC FIFO queue returns wrong cached values when forward/recompute op sequences diverge due to global mutable cache state.

**CPU repro output:**
```
RuntimeError: Only Tensors of floating point and complex dtype can require gradients
FAIL - DTensor constructor error reproduced (FIFO mismatch)!
```


## Run 2

### Reproduction
- CUDA repro (`repro.py`) reproduces the bug: `RuntimeError: Only Tensors of floating point and complex dtype can require gradients`

### Fix Implemented: Per-callable SAC storage keys
Added `_sac_storage_key(func, args)` in `torch/utils/checkpoint.py`. For `inductor_compiled_code`, it returns `(func, callable.idx)` so each compiled region gets its own FIFO queue. For all other ops, it returns `func` (unchanged behavior).

### Regression Test
Added `test_sac_cached_value_fifo_mismatch` to `test/dynamo/test_wrap_inductor_compiled_regions.py`. Uses DTensor + fake distributed backend + two compiled functions (one int-producing, one float-producing) with a global cache that causes forward/recompute op sequence divergence.

### Results
- Test fails before fix: YES (exact error from the issue)
- Test passes after fix: YES
- All 21 existing tests pass: YES
- Original repro script passes: YES

</details>

---
*This PR was generated by [ptq](https://github.com/drisspg/pt_job_queue) with human review.*

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98 @Lucaskabela