### PR TITLE
Default backward_pass_autocast to "off" to match eager autocast semantics

### DIFF
--- a/docs/source/user_guide/torch_compiler/torch.compiler_backward.md
+++ b/docs/source/user_guide/torch_compiler/torch.compiler_backward.md
@@ -31,7 +31,18 @@ to control that assumption; an incorrect assumption may lead to silent
 incorrectness.
 
 The options are either:
-- `"same_as_forward"` (default).
+- `"off"` (default). We assume that the backward of the torch.compile'd region will
+  not be run under any autocast context managers.
+  This matches the recommended PyTorch usage where autocast wraps only the forward
+  pass. Use this if your code looks like the following:
+  ```py
+  with torch.amp.autocast(...):
+      y = torch.compile(region)(x)
+      ...
+  # Backward pass runs under no autocast.
+  z.backward()
+  ```
+- `"same_as_forward"`.
   We assume that the backward of the ``torch.compile``'ed region
   will be run under the same autocast context manager that the region was run
   under (if any). Use this if your code looks like the following:
@@ -41,16 +52,6 @@ The options are either:
       ...
       # backward pass run under the same autocast context as the compiled region
       z.backward()
-  ```
-- `"off"`. We assume that the backward of the torch.compile'd region will
-  not be run under any autocast context managers.
-  Use this if your code looks like the following:
-  ```py
-  with torch.amp.autocast(...):
-      y = torch.compile(region)(x)
-      ...
-  # Backward pass runs under no autocast.
-  z.backward()
   ```
 - There is a third option. If you set ``torch._functorch.config.backward_pass_autocast``
   to a list of kwargs, we will assume the backward pass runs under an autocast context

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -790,6 +790,39 @@ def forward(self, primals_1):
                 self.assertEqual(out, torch.zeros_like(out))
                 self.assertEqual(grad, torch.ones_like(grad))
 
+    @unittest.skipIf(not torch.cuda.is_available(), "requires CUDA")
+    def test_backward_pass_autocast_default_matches_eager(self):
+        # Regression test for https://github.com/pytorch/pytorch/issues/153044
+        # When autocast wraps a compiled region from the outside, the backward
+        # pass should NOT inherit the forward's autocast context (matching eager
+        # behavior, per PyTorch docs).
+        w = torch.ones(4, 4, device="cuda")
+        linear = torch.nn.Linear(4, 1, device="cuda")
+
+        def model(x):
+            y = x @ w
+            with torch.amp.autocast(device_type="cuda", enabled=False):
+                y = y.float()
+                y = linear(y)
+            return y
+
+        x = torch.ones(1, 4, device="cuda")
+
+        # Eager reference
+        with torch.amp.autocast(device_type="cuda"):
+            eager_out = model(x)
+        (eager_out * 16384).sum().backward()
+        eager_grad = linear.weight.grad.clone()
+        linear.weight.grad.zero_()
+
+        # Compiled
+        with torch.amp.autocast(device_type="cuda"):
+            compiled_out = torch.compile(model, backend="aot_eager")(x)
+        (compiled_out * 16384).sum().backward()
+        compiled_grad = linear.weight.grad.clone()
+
+        self.assertEqual(eager_grad, compiled_grad)
+
     @skipIfDynamoInput(
         "Test doesn't make sense with dynamo, which changes order of mutations"
     )

--- a/torch/_functorch/config.py
+++ b/torch/_functorch/config.py
@@ -323,7 +323,7 @@ fake_tensor_propagate_real_tensors = False
 #   ...
 #   with torch.amp.autocast(device="cuda"):
 #       z.backward()
-backward_pass_autocast = "same_as_forward"
+backward_pass_autocast = "off"
 
 # This controls whether we collect donated buffers. This flag must be set
 # False if a user wants to retain_graph=True for backward.


### PR DESCRIPTION
## Human Note
Changes the default value of torch._functorch.config.backward_pass_autocast from "same_as_forward" to "off", fixing silent gradient overflow when torch.amp.autocast wraps a torch.compile region from the outside. This matches PyTorch's documented recommendation that autocast should only wrap the forward pass, and aligns compiled backward behavior with eager mode. Adds a regression test for the reported issue (#153044).

## Agent Report
# Fix: Unexpected float32 overflow for amp training with torch.compile

## Summary

When `torch.amp.autocast` wraps a `torch.compile`'d region from the outside, the backward pass incorrectly inherits the forward's autocast context, causing float16 computation where float32 is expected. This leads to silent overflow (`inf` gradients) that does not occur in eager mode.

## Root Cause

`torch._functorch.config.backward_pass_autocast` defaults to `"same_as_forward"`, which tells AOTAutograd to trace the backward graph under the same autocast context active during the forward. In eager PyTorch, autocast only applies to the forward pass — backward runs without it. This mismatch causes compiled backward to use float16 where eager uses float32, producing overflow on large gradient values.

## Fix

Changed the default value of `backward_pass_autocast` from `"same_as_forward"` to `"off"` in `torch/_functorch/config.py`. This matches the PyTorch documentation recommendation that autocast should wrap only the forward pass. Updated the docs to reflect the new default.

**Files changed:**
- `torch/_functorch/config.py` — default `"same_as_forward"` → `"off"`
- `docs/source/user_guide/torch_compiler/torch.compiler_backward.md` — reordered docs to list `"off"` as default
- `test/functorch/test_aotdispatch.py` — added regression test

## Risks

- **BC-breaking**: Users who rely on `"same_as_forward"` behavior (backward under autocast) will see changed numerics. They can restore the old behavior with `torch._functorch.config.patch(backward_pass_autocast="same_as_forward")`.
- Existing tests all explicitly set `backward_pass_autocast` via `config.patch`, so they are unaffected.

<details>
<summary>Repro Script</summary>

```python
import torch

w = torch.ones(4, 4, device="cuda")
linear = torch.nn.Linear(4, 1, device="cuda")

def model(x):
    y = x @ w
    with torch.amp.autocast(device_type="cuda", enabled=False):
        y = y.float()
        y = linear(y)
    return y

x = torch.ones(1, 4, device="cuda")

# Eager reference
with torch.amp.autocast(device_type="cuda"):
    eager_out = model(x)
(eager_out * 16384).sum().backward()
eager_grad = linear.weight.grad.clone()
linear.weight.grad.zero_()

# Compiled
with torch.amp.autocast(device_type="cuda"):
    compiled_out = torch.compile(model)(x)
(compiled_out * 16384).sum().backward()
compiled_grad = linear.weight.grad.clone()

print(f"eager: {eager_grad}, compiled: {compiled_grad}")
assert torch.allclose(eager_grad, compiled_grad), \
    f"Gradient mismatch: eager={eager_grad}, compiled={compiled_grad}"
print("PASS: eager and compiled gradients match")
```

**Before fix:**
```
eager: tensor([[65536., 65536., 65536., 65536.]], device='cuda:0'), compiled: tensor([[inf, inf, inf, inf]], device='cuda:0')
AssertionError: Gradient mismatch: eager=tensor([[65536., ...]], compiled=tensor([[inf, ...]])
```

**After fix:**
```
eager: tensor([[65536., 65536., 65536., 65536.]], device='cuda:0'), compiled: tensor([[65536., 65536., 65536., 65536.]], device='cuda:0')
PASS: eager and compiled gradients match
```

</details>

## Test Results

- **New test** `test_backward_pass_autocast_default_matches_eager`: PASS (3/3 variants)
- **Existing autocast tests**: 15/15 PASS, 1 skipped (torchvision)
- **Pre-dispatch autocast test**: PASS


Fixes #153044


<details>
<summary>Repro Script</summary>

```python
import torch

w = torch.ones(4, 4, device="cuda")
linear = torch.nn.Linear(4, 1, device="cuda")

def model(x):
    y = x @ w
    with torch.amp.autocast(device_type="cuda", enabled=False):
        y = y.float()
        y = linear(y)
    return y

x = torch.ones(1, 4, device="cuda")

# Eager reference
with torch.amp.autocast(device_type="cuda"):
    eager_out = model(x)
(eager_out * 16384).sum().backward()
eager_grad = linear.weight.grad.clone()
linear.weight.grad.zero_()

# Compiled
with torch.amp.autocast(device_type="cuda"):
    compiled_out = torch.compile(model)(x)
(compiled_out * 16384).sum().backward()
compiled_grad = linear.weight.grad.clone()

print(f"eager: {eager_grad}, compiled: {compiled_grad}")
assert torch.allclose(eager_grad, compiled_grad), \
    f"Gradient mismatch: eager={eager_grad}, compiled={compiled_grad}"
print("PASS: eager and compiled gradients match")
```

</details>


<details>
<summary>Agent Worklog</summary>

## Run 1

> **User:** Investigate this issue in diagnosis-and-plan mode.

You may inspect code, compare versions, and create throwaway helpers inside the job directory, but you may not modify product source files or prepare a patch yet.

Use subagents early for parallel exploration. Prefer read-only subagents. Good subagent tasks include:
- finding related kernels or codepaths
- comparing behavior across versions or backends
- locating similar bugs or existing tests
- checking whether the first hypothesis actually matches the runtime evidence

Your goal:
- gather evidence
- produce a minimal repro or a clear non-repro conclusion
- rank the top root-cause hypotheses
- propose the smallest plausible fix plan
- identify unknowns and risks

Rules:
- do not generate a diff
- do not broaden scope mid-run
- do not treat mathematical plausibility or static inspection as sufficient proof
- if runtime evidence and code inspection disagree, trust runtime evidence and report the disagreement

Output:
- repro status
- strongest evidence
- ranked hypotheses with confidence
- likely files involved
- proposed fix plan
- open questions
- recommended next action for user approval

Stop after the plan and wait.

### Reproduction confirmed
Ran minimized repro script. Bug confirmed:
- Eager grad: `[[65536., 65536., 65536., 65536.]]` (correct)
- Compiled grad: `[[inf, inf, inf, inf]]` (overflow, incorrect)
- The issue is that `torch.compile` causes float16 to be used in backward even though autocast is disabled for backward.

### Root cause confirmed
- `torch._functorch.config.backward_pass_autocast` defaults to `"same_as_forward"` (in config.py:326)
- When AOTAutograd traces the joint forward+backward graph, the backward tracing inherits the ambient autocast context
- In eager, autocast is only active for forward; backward runs without it
- Setting `backward_pass_autocast="off"` makes compiled grad match eager grad exactly

### Verified fix
- `backward_pass_autocast="off"` produces correct gradients: `[[65536., ...]]` vs `[[inf, ...]]`
- Bug also reproduces with `backend="aot_eager"` — confirms it's an AOTAutograd issue, not inductor
- Existing tests in test_aotdispatch.py all explicitly patch the config, so flipping the default won't break them
- `test_autocast_simple` in test_pre_dispatch.py places autocast INSIDE the compiled fn, unaffected

### Proposed fix
Change default from `"same_as_forward"` to `"off"` in `torch/_functorch/config.py`
- This matches PyTorch documentation recommendation that autocast wraps only forward
- This is BC-breaking but fixes a silent correctness issue
- May need a FutureWarning or deprecation period



## Run 2

> **User:** I agree with the reproduction and the proposed solution. Implement and verify it.

Your job:
- write the smallest fix that explains the reproduced failure
- add or update a focused regression test
- demonstrate that the test would fail before the fix
- demonstrate that the same test passes with the fix
- keep scope tight to the approved diagnosis and plan

Rules:
- no speculative cleanup or unrelated refactors
- if the test does not fail before the fix, stop and report that the evidence is insufficient
- if the fix requires a broader change than planned, stop and ask before expanding scope
- prefer the narrowest test that captures the reported failure mode

Output:
- patch summary
- regression test added or updated
- evidence that it fails before the fix
- evidence that it passes after the fix
- any remaining risks or gaps

### Regression test written
Added `test_backward_pass_autocast_default_matches_eager` to `test/functorch/test_aotdispatch.py` (after existing autocast tests). The test reproduces the exact issue: autocast outside `torch.compile`, backward produces `inf` where eager produces finite values.

### Test fails before fix
Ran the new test with the old default (`"same_as_forward"`): all 3 test class variants (TestAOTAutograd, TestAOTAutogradWithCache, TestAOTAutogradWithDynamo) fail with `AssertionError: Greatest absolute difference: inf`.

### Fix applied
Changed `backward_pass_autocast` default from `"same_as_forward"` to `"off"` in `torch/_functorch/config.py:326`. Updated docs in `torch.compiler_backward.md` to reflect new default ordering.

### Test passes after fix
All 3 variants of the new test pass. All 15 existing autocast tests pass (1 skipped for torchvision). Pre-dispatch autocast test passes. Original repro script passes.

### Artifacts generated
- `fix.diff` — 3 files changed (config.py, test_aotdispatch.py, docs)
- `report.md` — full report with repro and results
- `pr_suggestion.json` — suggested PR title and summary

</details>

---
*This PR was generated by [ptq](https://github.com/drisspg/pt_job_queue) with human review.*