### PR TITLE
Re-enable as_strided_scatter test in aot_autograd_failures

### DIFF
--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -8659,7 +8659,6 @@ aot_autograd_failures = {
     skip("narrow"),
     xfail("istft"),
     xfail("linalg.eig"),
-    skip("as_strided_scatter"),
     skip("as_strided", "partial_views"),  # flaky
     # Given input size: (s0xs1x2). Calculated output size: ...
     skip("max_pool2d_with_indices_backward"),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #177203

The underlying bug (eager vs AOTDispatcher output mismatch for
as_strided_scatter) was fixed by #150543. Remove the stale skip.

Closes #85879