### PR TITLE
[dynamo] Fix cleanup hook restoring wrong state in TorchFunctionDisableVariable

### DIFF
--- a/torch/_dynamo/variables/ctx_manager.py
+++ b/torch/_dynamo/variables/ctx_manager.py
@@ -843,7 +843,7 @@ class TorchFunctionDisableVariable(ContextWrappingVariable):
                 )
                 if not self.only_subclass:
                     tx.symbolic_torch_function_state.torch_function_mode_enabled = (
-                        self.initial_torch_function_subclass_enabled
+                        self.initial_torch_function_mode_enabled
                     )
 
         self.cleanup_fn = fn


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/162704

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #177204

Copy-paste bug: the cleanup hook for DisableTorchFunction was restoring
torch_function_mode_enabled from initial_torch_function_subclass_enabled
instead of initial_torch_function_mode_enabled, causing the disabled
state to persist after exiting the context manager under graph breaks.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo