### PR TITLE
Fix emulate_precision_casts for g_in(x).sigmoid()

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -15966,6 +15966,31 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
             check_lowp=False,
         )
 
+    @requires_gpu_and_triton
+    @config.patch(emulate_precision_casts=True)
+    def test_emulate_precision_casts_linear_gated(self):
+        # When emulate_precision_casts is enabled, compiled code should match
+        # eager numerics exactly for gated linear patterns like p_in(x) * g_in(x).sigmoid().
+        # Regression test for unfuse_bias_add_to_pointwise losing precision on the
+        # mm accumulator by storing to bf16 memory before bias addition.
+        torch.manual_seed(42)
+
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.p_in = torch.nn.Linear(64, 64)
+                self.g_in = torch.nn.Linear(64, 64)
+
+            def forward(self, x):
+                return self.p_in(x) * self.g_in(x).sigmoid()
+
+        model = Model().to(GPU_TYPE).to(torch.bfloat16).eval()
+        x = torch.randn(4, 64, device=GPU_TYPE, dtype=torch.bfloat16)
+        with torch.no_grad():
+            eager_result = model(x)
+            compiled_result = torch.compile(model)(x)
+        torch.testing.assert_close(compiled_result, eager_result, atol=0, rtol=0)
+
     # end of class CommonTemplate - add new tests here
 
 

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -1512,6 +1512,18 @@ def should_prefer_unfused_addmm(match):
     if not is_gpu(inp.meta["val"].device.type):
         return False
 
+    # When emulating precision casts for low-precision types, keep addmm fused
+    # so cuBLAS preserves the fp32 mm accumulator for bias addition. Unfusing
+    # would store the mm result to low-precision memory first, losing precision.
+    if config.emulate_precision_casts:
+        output = match.output_node()
+        val = output.meta.get("val")
+        if isinstance(val, torch.Tensor) and val.dtype in (
+            torch.bfloat16,
+            torch.float16,
+        ):
+            return False
+
     output = match.output_node()
     return all(is_pointwise_use(use) for use in output.users)
 


### PR DESCRIPTION
## Human Note
Fix precision cast issue found debugging #168126


<details>
<summary>Repro Script</summary>

```python
"""
Reproduce the bug in TORCHINDUCTOR_EMULATE_PRECISION_CASTS=1
with p_in(x) * g_in(x).sigmoid()
"""
import torch
import torch._inductor.config as inductor_config

# Enable emulate_precision_casts
inductor_config.emulate_precision_casts = True

torch.manual_seed(42)

class Model(torch.nn.Module):
    def __init__(self):
        super().__init__()
        self.p_in = torch.nn.Linear(64, 64)
        self.g_in = torch.nn.Linear(64, 64)

    def forward(self, x):
        return self.p_in(x) * self.g_in(x).sigmoid()

model = Model().to("cuda").to(torch.bfloat16).eval()
x = torch.randn(4, 64, device="cuda", dtype=torch.bfloat16)

with torch.no_grad():
    eager_result = model(x)
    compiled_model = torch.compile(model, backend="inductor")
    compiled_result = compiled_model(x)

print(f"Eager result:\n{eager_result[0, :8]}")
print(f"Compiled result:\n{compiled_result[0, :8]}")
print(f"Max abs diff: {(eager_result - compiled_result).abs().max().item()}")
print(f"All close: {torch.allclose(eager_result, compiled_result)}")

if not torch.allclose(eager_result, compiled_result):
    diff_mask = eager_result != compiled_result
    num_diff = diff_mask.sum().item()
    print(f"Number of different elements: {num_diff} / {eager_result.numel()}")
    if num_diff > 0:
        print(f"Eager  diffs: {eager_result[diff_mask][:10]}")
        print(f"Compiled diffs: {compiled_result[diff_mask][:10]}")
else:
    print("PASS: Results match exactly!")
```

</details>


<details>
<summary>Agent Worklog</summary>

## Run 1

> **User:** https://github.com/pytorch/pytorch/pull/177163 identifies a bug in TORCHINDUCTOR_EMULATE_PRECISION_CASTS=1 with p_in(x) * g_in(x).sigmoid() between eager and compiled. Fix it.

### Step 1: Reproduce the bug
- Created repro scripts with `Model(p_in, g_in)` doing `p_in(x) * g_in(x).sigmoid()` in bf16
- Confirmed: 76/256 elements differ between eager and compiled with `emulate_precision_casts=True`
- Narrowed down: bug appears whenever `nn.Linear` is involved, even without sigmoid
- `a * b.sigmoid()` (pure tensors, no linear) → PASS
- `g_in(x).sigmoid()` (with linear) → FAIL (9 diffs)
- `p_in(x) * g_in(x)` (with linear, no sigmoid) → FAIL (97 diffs)

### Step 2: Identify root cause
- The `unfuse_bias_add_to_pointwise` post-grad FX pass in `post_grad.py` decomposes `addmm(bias, x, W^T)` into `mm(x, W^T) + bias`
- This changes precision: mm outputs bf16 to memory, then bias is added in fp32 after loading back
- In eager, cuBLAS `addmm` keeps the mm accumulator in fp32 for bias addition before bf16 output
- Additionally, the new `add` nodes don't inherit `low_precision_pointwise_barrier` from original `addmm`

### Step 3: Fix approach
- When `emulate_precision_casts` is True, skip `unfuse_bias_add_to_pointwise`
- This keeps addmm as a single cuBLAS call preserving fp32 precision for mm+bias

</details>

---
*This PR was generated by [ptq](https://github.com/drisspg/pt_job_queue) with human review.*

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo