### PR TITLE
[Inductor] Add proper regression test for Voxtral compilation on MPS

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -15944,9 +15944,7 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
             if not self.is_dtype_supported(dtype):
                 continue
             self.common(
-                lambda x: torch.nn.functional.pad(
-                    torch.nn.functional.gelu(x), [1, 0]
-                ),
+                lambda x: torch.nn.functional.pad(torch.nn.functional.gelu(x), [1, 0]),
                 (torch.randn(8, 16, dtype=dtype, device=self.device),),
                 check_lowp=False,
             )

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -15938,33 +15938,18 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         result = torch.compile(fn)(x_base.clone()[:, 2:, :], index, source)
         self.assertEqual(result, expected)
 
-    def test_bfloat_constant(self):
-        if not self.is_dtype_supported(torch.bfloat16):
-            raise unittest.SkipTest("bfloat16 not supported")
-        self.common(
-            lambda x: x + 1.0,
-            (make_tensor(1024, dtype=torch.bfloat16, device=self.device),),
-        )
-
-    @parametrize("dtype", [torch.float16, torch.bfloat16])
-    def test_lowp_reduction(self, dtype):
-        if not self.is_dtype_supported(dtype):
-            raise unittest.SkipTest(f"{dtype} not supported")
-        self.common(
-            lambda x: x.sum(),
-            (make_tensor(1024, dtype=dtype, device=self.device),),
-            check_lowp=False,
-        )
-
-    @parametrize("dtype", [torch.float16, torch.bfloat16])
-    def test_lowp_where(self, dtype):
-        if not self.is_dtype_supported(dtype):
-            raise unittest.SkipTest(f"{dtype} not supported")
-        self.common(
-            lambda x: torch.where(x > 0.5, x, x.new_zeros(())),
-            (make_tensor(1024, dtype=dtype, device=self.device),),
-            check_lowp=False,
-        )
+    def test_pad_after_gelu(self):
+        # Regression test for Voxtral compilation on MPS
+        for dtype in [torch.float32, torch.float16, torch.bfloat16]:
+            if not self.is_dtype_supported(dtype):
+                continue
+            self.common(
+                lambda x: torch.nn.functional.pad(
+                    torch.nn.functional.gelu(x), [1, 0]
+                ),
+                (torch.randn(8, 16, dtype=dtype, device=self.device),),
+                check_lowp=False,
+            )
 
     # end of class CommonTemplate - add new tests here
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #177207

----

- Remove `test_bfloat_constant`, `test_lowp_reduction`, and `test_lowp_where` as they don't test for anything beyond what existing tests cover.
- Add `test_pad_after_gelu` as a regression test for Voxtral compilation on MPS, exercising pad(gelu(x)) across fp32, fp16, and bfloat16.

Before https://github.com/pytorch/pytorch/pull/176436 test will fail with
```
torch._inductor.exc.InductorError: SyntaxError: failed to compile
    #include <c10/metal/utils.h>
    #include <c10/metal/special_math.h>
    kernel void generated_kernel(
        device bfloat* out_ptr0,
        constant bfloat* in_ptr0,
        uint xindex [[thread_position_in_grid]]
    ) {
        int x0 = (xindex) % (17);
        int x1 = c10::metal::floor_divide(xindex, 17);
        int x2 = xindex;
        auto tmp0 = (-1) + x0;
        auto tmp1 = static_cast<long>(tmp0);
        auto tmp2 = 0;
        auto tmp3 = tmp1 >= tmp2;
        bfloat tmp4;
        if (tmp3) {
            auto tmp_scoped_0 = static_cast<float>(in_ptr0[(-1) + x0 + 16*x1]);
            auto tmp_scoped_1 = static_cast<float>(tmp_scoped_0);
            auto tmp_scoped_2 = 0.5;
            auto tmp_scoped_3 = tmp_scoped_1 * tmp_scoped_2;
            auto tmp_scoped_4 = 0.7071067811865476;
            auto tmp_scoped_5 = tmp_scoped_1 * tmp_scoped_4;
            auto tmp_scoped_6 = c10::metal::erf(tmp_scoped_5);
            auto tmp_scoped_7 = 1.0;
            auto tmp_scoped_8 = tmp_scoped_6 + tmp_scoped_7;
            auto tmp_scoped_9 = tmp_scoped_3 * tmp_scoped_8;
            auto tmp_scoped_10 = static_cast<bfloat>(tmp_scoped_9);
            tmp4 = tmp_scoped_10;
        } else tmp4 = 0.0;
        out_ptr0[x2] = static_cast<bfloat>(tmp4);
    }
 with program_source:4495:23: error: assigning to 'bfloat' from incompatible type 'float'
        } else tmp4 = 0.0;
                      ^~~
```

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo