### PR TITLE
[inductor] Add structural divisibility analysis to statically_known_multiple_of 

### DIFF
--- a/test/inductor/test_codegen_triton.py
+++ b/test/inductor/test_codegen_triton.py
@@ -201,6 +201,47 @@ class TestCodegenTriton(InductorTestCase):
         _, code = run_and_get_code(torch.compile(fn), x)
         code_str = " ".join(code)
         self.assertIn("tt.pointer_range", code_str)
+    def test_is_multiple_of_rules(self):
+        """Test structural divisibility rules in _is_multiple_of."""
+        from torch.utils._sympy.functions import FloorDiv, Mod
+
+        sv = V.graph.sizevars
+        shape_env = sv.shape_env
+
+        s1 = sympy.Symbol("s1", positive=True, integer=True)
+        s2 = sympy.Symbol("s2", positive=True, integer=True)
+        s3 = sympy.Symbol("s3", positive=True, integer=True)
+
+        # Product: any factor divisible → product divisible
+        self.assertTrue(sv.statically_known_multiple_of(16 * s1, 16))
+        self.assertTrue(sv.statically_known_multiple_of(4 * 4 * s1, 16))
+        shape_env.axioms[sympy.Eq(Mod(s1, 16), 0)] = sympy.true
+        self.assertTrue(sv.statically_known_multiple_of(s1 * s2, 16))
+        self.assertFalse(sv.statically_known_multiple_of(s2 * s3, 16))
+
+        # Sum: all terms divisible → sum divisible
+        self.assertFalse(sv.statically_known_multiple_of(s1 + s2, 16))
+        shape_env.axioms[sympy.Eq(Mod(s2, 16), 0)] = sympy.true
+        self.assertTrue(sv.statically_known_multiple_of(s1 + s2, 16))
+        self.assertTrue(sv.statically_known_multiple_of(s1 + 32, 16))
+        self.assertFalse(sv.statically_known_multiple_of(s1 + 3, 16))
+
+        # FloorDiv(a, b): a must be multiple of b*n
+        self.assertFalse(sv.statically_known_multiple_of(FloorDiv(s1, 3), 16))
+        shape_env.axioms[sympy.Eq(Mod(s3, 48), 0)] = sympy.true
+        self.assertTrue(sv.statically_known_multiple_of(FloorDiv(s3, 3), 16))
+
+        # Mod(a, b): both a and b must be multiples of n
+        self.assertTrue(sv.statically_known_multiple_of(Mod(s1, 48), 16))
+        s_nodiv = sympy.Symbol("s_nodiv", positive=True, integer=True)
+        self.assertFalse(sv.statically_known_multiple_of(Mod(s_nodiv, 32), 16))
+        self.assertFalse(sv.statically_known_multiple_of(Mod(s1, 7), 16))
+
+        # Axiom fallback: bare symbol resolved via statically_known_true
+        s4 = sympy.Symbol("s4", positive=True, integer=True)
+        self.assertFalse(sv.statically_known_multiple_of(s4, 8))
+        shape_env.axioms[sympy.Eq(Mod(s4, 8), 0)] = sympy.true
+        self.assertTrue(sv.statically_known_multiple_of(s4, 8))
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_codegen_triton.py
+++ b/test/inductor/test_codegen_triton.py
@@ -201,6 +201,7 @@ class TestCodegenTriton(InductorTestCase):
         _, code = run_and_get_code(torch.compile(fn), x)
         code_str = " ".join(code)
         self.assertIn("tt.pointer_range", code_str)
+
     def test_is_multiple_of_rules(self):
         """Test structural divisibility rules in _is_multiple_of."""
         from torch.utils._sympy.functions import FloorDiv, Mod

--- a/torch/_inductor/sizevars.py
+++ b/torch/_inductor/sizevars.py
@@ -404,6 +404,54 @@ class SizeVarAllocator:
         expr = left > right
         return self.statically_known_true(expr)
 
+    def _is_multiple_of(self, numerator: Expr, denominator: int) -> bool:
+        """
+        Structural divisibility check: returns True only if numerator is
+        provably a multiple of denominator.  Recurses over sympy expression
+        structure before falling back to statically_known_true.
+        """
+        # Rule 1 — concrete value
+        if isinstance(numerator, (int, sympy.Integer)):
+            return int(numerator) % denominator == 0
+
+        # Rule 2 — product: any factor divisible → product divisible
+        if isinstance(numerator, sympy.Mul):
+            for factor in numerator.args:
+                if self._is_multiple_of(factor, denominator):
+                    return True
+            # Also check if combined constant factors are divisible
+            const = 1
+            for factor in numerator.args:
+                if isinstance(factor, (int, sympy.Integer)):
+                    const *= int(factor)
+            if const != 1 and const % denominator == 0:
+                return True
+
+        # Rule 3 — sum: all terms divisible → sum divisible
+        if isinstance(numerator, sympy.Add):
+            if all(self._is_multiple_of(term, denominator) for term in numerator.args):
+                return True
+
+        # Rule 4 — FloorDiv(a, b): if a is multiple of b*n
+        if isinstance(numerator, FloorDiv):
+            a, b = numerator.args
+            if isinstance(b, (int, sympy.Integer)):
+                if self._is_multiple_of(a, int(b) * denominator):
+                    return True
+
+        # Rule 5 — Mod(a, b): Mod(a,b) = a - b*floor(a/b), so if both a and b
+        # are multiples of n, then Mod(a,b) is too.
+        if isinstance(numerator, (Mod, sympy.Mod)):
+            a, b = numerator.args
+            if self._is_multiple_of(a, denominator) and self._is_multiple_of(
+                b, denominator
+            ):
+                return True
+
+        # Rule 6 — axiom fallback: ask ShapeEnv
+        expr = sympy.Eq(Mod(numerator, denominator), 0)
+        return self.statically_known_true(expr)
+
     def statically_known_multiple_of(
         self, numerator: Expr, denominator: Expr | int
     ) -> bool:
@@ -416,6 +464,10 @@ class SizeVarAllocator:
         if len(free_symbols(numerator)) > 20:
             return False
 
+        if isinstance(denominator, (int, sympy.Integer)):
+            return self._is_multiple_of(numerator, int(denominator))
+
+        # For symbolic denominators, fall back to direct sympy check
         expr = sympy.Eq(Mod(numerator, denominator), 0)
         return self.statically_known_true(expr)  # type: ignore[arg-type]
 


### PR DESCRIPTION
Add `_is_multiple_of()` that recurses over sympy expression structure (Mul, Add, FloorDiv, Mod) to prove divisibility, before falling back to statically_known_true. This is a demand-driven variant of the modular arithmetic analysis used in Halide and TVM.

Unlocks tt.divisibility hints for product expressions like `shape[0] * shape[1]` when `torch._check(shape[1] % 16 == 0)`.

Fixes https://github.com/pytorch/pytorch/issues/177146

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo