### PR TITLE
Reland [fx] Fix quadratic name generation in create_name

### DIFF
--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -190,7 +190,10 @@ class _Namespace:
 
         base, num = match.group(1, 2)
         if num is None or candidate in self._used_names:
-            num = self._base_count.get(candidate, 0)
+            # Look up `base` to match the key used in the store on line below;
+            # using `candidate` misses when it has a numeric suffix, making
+            # the while-loop quadratic.
+            num = self._base_count.get(base, 0)
             if _illegal_names.get(candidate, obj) is not obj:
                 num += 1
                 candidate = f"{base}_{num}"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #177217

reland of https://github.com/pytorch/pytorch/pull/176515 but earlier the file already moved to C++, so sending a python only change.