### PR TITLE
Operator Benchmark: Fix backward benchmark timing to measure actual GPU execution time

### DIFF
--- a/benchmarks/operator_benchmark/benchmark_core.py
+++ b/benchmarks/operator_benchmark/benchmark_core.py
@@ -388,12 +388,10 @@ class BenchmarkRunner:
         if cuda_sync:
             torch.cuda.synchronize()
 
-        func = test_case.run_backward
-        # Stable timing with Timer
         timer = Timer(
-            stmt="func(iters, print_per_iter, cuda_sync)",
+            stmt="test_case.run_backward(iters, print_per_iter, cuda_sync)",
             globals={
-                "func": func,
+                "test_case": test_case,
                 "iters": iters,
                 "print_per_iter": print_per_iter,
                 "cuda_sync": cuda_sync,

--- a/benchmarks/operator_benchmark/benchmark_core.py
+++ b/benchmarks/operator_benchmark/benchmark_core.py
@@ -382,16 +382,24 @@ class BenchmarkRunner:
         """This function runs forward path of an op to get an output. Then the backward path is executed
         and the execution time is reported
         """
-        test_case.run_forward(num_runs=1, print_per_iter=False, cuda_sync=False)
+        test_case.run_forward(num_runs=1, print_per_iter=False, cuda_sync=True)
         test_case._output_mean()
-        backward_time = timeit.timeit(
-            lambda: (
-                test_case.run_backward(iters, print_per_iter),
-                torch.cuda.synchronize(),
-            ),
-            number=1,
+        if torch.cuda.is_available():
+            torch.cuda.synchronize()
+
+        func = test_case.run_backward
+        # Stable timing with Timer
+        timer = Timer(
+            stmt="func(iters, print_per_iter, cuda_sync)",
+            globals={
+                "func": func,
+                "iters": iters,
+                "print_per_iter": print_per_iter,
+                "cuda_sync": True,
+            },
         )
-        return backward_time
+        result = timer.adaptive_autorange(min_run_time=0.0001)
+        return result.median * iters
 
     def _measure_metrics(self, launch_test, test_case, iters, print_per_iter):
         """

--- a/benchmarks/operator_benchmark/benchmark_core.py
+++ b/benchmarks/operator_benchmark/benchmark_core.py
@@ -382,9 +382,10 @@ class BenchmarkRunner:
         """This function runs forward path of an op to get an output. Then the backward path is executed
         and the execution time is reported
         """
-        test_case.run_forward(num_runs=1, print_per_iter=False, cuda_sync=True)
+        cuda_sync = "cuda" in test_case.test_config.test_name
+        test_case.run_forward(num_runs=1, print_per_iter=False, cuda_sync=cuda_sync)
         test_case._output_mean()
-        if torch.cuda.is_available():
+        if cuda_sync:
             torch.cuda.synchronize()
 
         func = test_case.run_backward
@@ -395,7 +396,7 @@ class BenchmarkRunner:
                 "func": func,
                 "iters": iters,
                 "print_per_iter": print_per_iter,
-                "cuda_sync": True,
+                "cuda_sync": cuda_sync,
             },
         )
         result = timer.adaptive_autorange(min_run_time=0.0001)

--- a/benchmarks/operator_benchmark/benchmark_core.py
+++ b/benchmarks/operator_benchmark/benchmark_core.py
@@ -385,8 +385,6 @@ class BenchmarkRunner:
         cuda_sync = "cuda" in test_case.test_config.test_name
         test_case.run_forward(num_runs=1, print_per_iter=False, cuda_sync=cuda_sync)
         test_case._output_mean()
-        if cuda_sync:
-            torch.cuda.synchronize()
 
         timer = Timer(
             stmt="test_case.run_backward(iters, print_per_iter, cuda_sync)",

--- a/benchmarks/operator_benchmark/benchmark_core.py
+++ b/benchmarks/operator_benchmark/benchmark_core.py
@@ -385,7 +385,7 @@ class BenchmarkRunner:
         test_case.run_forward(num_runs=1, print_per_iter=False, cuda_sync=False)
         test_case._output_mean()
         backward_time = timeit.timeit(
-            functools.partial(test_case.run_backward, iters, print_per_iter), number=1
+            lambda: (test_case.run_backward(iters, print_per_iter), torch.cuda.synchronize()), number=1
         )
         return backward_time
 

--- a/benchmarks/operator_benchmark/benchmark_core.py
+++ b/benchmarks/operator_benchmark/benchmark_core.py
@@ -385,7 +385,11 @@ class BenchmarkRunner:
         test_case.run_forward(num_runs=1, print_per_iter=False, cuda_sync=False)
         test_case._output_mean()
         backward_time = timeit.timeit(
-            lambda: (test_case.run_backward(iters, print_per_iter), torch.cuda.synchronize()), number=1
+            lambda: (
+                test_case.run_backward(iters, print_per_iter),
+                torch.cuda.synchronize(),
+            ),
+            number=1,
         )
         return backward_time
 

--- a/benchmarks/operator_benchmark/benchmark_pytorch.py
+++ b/benchmarks/operator_benchmark/benchmark_pytorch.py
@@ -244,11 +244,13 @@ class PyTorchOperatorTestCase:
         """
         self.mean = self.output.mean()
 
-    def run_backward(self, num_runs, print_per_iter=False):
+    def run_backward(self, num_runs, print_per_iter=False, cuda_sync=False):
         """Run the backward path of an op in many iterations"""
         # TODO: can we use JIT here to reduce python overhead?
         for _ in range(num_runs):
             self.mean.backward(retain_graph=True)
+        if cuda_sync:
+            torch.cuda.synchronize()
 
 
 def create_pytorch_op_test_case(op_bench, test_config):


### PR DESCRIPTION
# Fix: `_launch_backward` measures CPU scheduling time instead of GPU execution time

## Problem

`_launch_backward` used `timeit` without a GPU sync, so it only measured CPU kernel-launch overhead — effectively zero. The significance check in `_measure_metrics` never triggered, causing the adaptive loop to keep doubling `iters` indefinitely:

```
# round    iters    duration
1          100      54 min   ← should have stopped here
2          200      54 min
3          400      107 min
4          800      211 min
...                 12+ hours for a single test
```

## Fix

Two changes:

**1. `benchmark_core.py` — `_launch_backward`:** replace `timeit` with `torch.utils.benchmark.Timer` (consistent with `_launch_forward`). Add a sync before the timer starts to flush any GPU work from `_output_mean()`, and pass `cuda_sync=True` into the timed call so the GPU drains before the timer stops.

**2. `benchmark_pytorch.py` — `run_backward`:** add `cuda_sync=False` parameter. When `True`, call `torch.cuda.synchronize()` after all iterations complete (not per-iteration, to avoid serializing each backward pass).

**After fix — exits after one round:**
```
# round    iters    duration
1          100      54 min   ← significant, done
```

## Notes

- Reproduced on AMD MI350, but affects any CUDA/ROCm device.
- `_launch_forward` already used `Timer`; this makes `_launch_backward` consistent.
