### PR TITLE
[ONNX] Support bilinear and _trilinear export

### DIFF
--- a/test/onnx/exporter/test_small_models_e2e.py
+++ b/test/onnx/exporter/test_small_models_e2e.py
@@ -80,6 +80,37 @@ class DynamoExporterTest(common_utils.TestCase, _WithExport):
         onnx_testing.assert_onnx_program(onnx_program)
         self.assertNotIn("Cast", [node.op_type for node in onnx_program.model.graph])
 
+    def test_export_aten_trilinear(self):
+        class Model(torch.nn.Module):
+            def forward(self, x1, weight, x2):
+                return torch.ops.aten._trilinear.default(
+                    x1, weight, x2, [1, 3], [0], [1, 2], [2, 3]
+                )
+
+        x1 = torch.randn(2, 4)
+        weight = torch.randn(3, 4, 5)
+        x2 = torch.randn(2, 5)
+
+        onnx_program = self.export(Model(), (x1, weight, x2))
+        self.assertIn("Einsum", [node.op_type for node in onnx_program.model.graph])
+        onnx_testing.assert_onnx_program(onnx_program)
+
+    def test_export_nn_bilinear(self):
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.bilinear = torch.nn.Bilinear(4, 5, 3)
+
+            def forward(self, x1, x2):
+                return self.bilinear(x1, x2)
+
+        x1 = torch.randn(2, 3, 4)
+        x2 = torch.randn(2, 3, 5)
+
+        onnx_program = self.export(Model(), (x1, x2))
+        self.assertIn("MatMul", [node.op_type for node in onnx_program.model.graph])
+        onnx_testing.assert_onnx_program(onnx_program)
+
     def test_onnx_export_conditional(self):
         class CondModel(torch.nn.Module):
             def forward(self, x):

--- a/torch/onnx/_internal/exporter/_torchlib/ops/core.py
+++ b/torch/onnx/_internal/exporter/_torchlib/ops/core.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import operator
+import string
 from typing import Sequence
 
 from onnxscript.onnx_opset import opset18 as op
@@ -17,7 +18,7 @@ from torch.onnx._internal.exporter._torchlib._torchlib_registry import onnx_impl
 
 aten = torch.ops.aten
 
-_EINSUM_SYMBOLS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+_EINSUM_SYMBOLS = string.ascii_letters
 
 
 def _get_einsum_symbol(dim: int) -> str:

--- a/torch/onnx/_internal/exporter/_torchlib/ops/core.py
+++ b/torch/onnx/_internal/exporter/_torchlib/ops/core.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import operator
+from typing import Sequence
 
 from onnxscript.onnx_opset import opset18 as op
 
@@ -15,6 +16,100 @@ from torch.onnx._internal.exporter._torchlib._torchlib_registry import onnx_impl
 
 
 aten = torch.ops.aten
+
+_EINSUM_SYMBOLS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+
+def _get_einsum_symbol(dim: int) -> str:
+    if dim >= len(_EINSUM_SYMBOLS):
+        raise AssertionError(
+            "ONNX export for aten._trilinear only supports up to 52 dimensions"
+        )
+    return _EINSUM_SYMBOLS[dim]
+
+
+def _build_trilinear_subscript(total_dim: int, expanded_dims: Sequence[int]) -> str:
+    expanded_dims_set = set(expanded_dims)
+    return "".join(
+        _get_einsum_symbol(dim)
+        for dim in range(total_dim)
+        if dim not in expanded_dims_set
+    )
+
+
+def _build_trilinear_equation(
+    total_dim: int,
+    expand1: Sequence[int],
+    expand2: Sequence[int],
+    expand3: Sequence[int],
+    sumdim: Sequence[int],
+) -> str:
+    sumdim_set = set(sumdim)
+    output_subscript = "".join(
+        _get_einsum_symbol(dim)
+        for dim in range(total_dim)
+        if dim not in sumdim_set
+    )
+    return (
+        f"{_build_trilinear_subscript(total_dim, expand1)},"
+        f"{_build_trilinear_subscript(total_dim, expand2)},"
+        f"{_build_trilinear_subscript(total_dim, expand3)}->{output_subscript}"
+    )
+
+
+@onnx_impl(aten._trilinear.default, trace_only=True)
+def aten__trilinear(
+    i1: TReal,
+    i2: TReal,
+    i3: TReal,
+    expand1: Sequence[int],
+    expand2: Sequence[int],
+    expand3: Sequence[int],
+    sumdim: Sequence[int],
+    unroll_dim: int = 1,
+) -> TReal:
+    """_trilinear(Tensor i1, Tensor i2, Tensor i3, int[] expand1, int[] expand2, int[] expand3, int[] sumdim, int unroll_dim=1) -> Tensor"""
+
+    del unroll_dim
+
+    total_dim = len(i1.shape) + len(expand1)
+    equation = _build_trilinear_equation(
+        total_dim, expand1, expand2, expand3, sumdim
+    )
+    return op.Einsum(i1, i2, i3, equation=equation)
+
+
+@onnx_impl(aten.bilinear.default, trace_only=True)
+def aten_bilinear(
+    input1: TReal,
+    input2: TReal,
+    weight: TReal,
+    bias: TReal | None = None,
+) -> TReal:
+    """bilinear(Tensor input1, Tensor input2, Tensor weight, Tensor? bias=None) -> Tensor"""
+
+    batch_shape = op.Shape(input1, start=0, end=-1)
+    input1_shape = op.Shape(input1, start=-1)
+    input2_shape = op.Shape(input2, start=-1)
+    output_shape = op.Shape(weight, start=0, end=1)
+    neg_1 = op.Constant(value_ints=[-1])
+
+    weight_permuted = op.Transpose(weight, perm=[1, 0, 2])
+    weight_flat = op.Reshape(
+        weight_permuted,
+        op.Concat(input1_shape, op.Mul(output_shape, input2_shape), axis=0),
+    )
+
+    result = op.MatMul(input1, weight_flat)
+    result = op.Reshape(
+        result,
+        op.Concat(batch_shape, output_shape, input2_shape, axis=0),
+    )
+    result = op.Squeeze(op.MatMul(result, op.Unsqueeze(input2, neg_1)), neg_1)
+
+    if bias is not None:
+        result = op.Add(result, bias)
+    return result
 
 
 @onnx_impl((aten.abs.default, operator.abs), trace_only=True)

--- a/torch/onnx/_internal/exporter/_torchlib/ops/nn.py
+++ b/torch/onnx/_internal/exporter/_torchlib/ops/nn.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 from typing import Sequence, TYPE_CHECKING  # noqa: UP035
 
 from onnxscript.onnx_opset import (  # type: ignore[attr-defined]
-    opset18 as op18,
     opset20 as op20,
     opset21 as op21,
     opset23 as op23,
@@ -25,98 +24,6 @@ if TYPE_CHECKING:
     from onnxscript.values import Opset
 
 aten = torch.ops.aten
-
-_EINSUM_SYMBOLS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
-
-
-def _get_einsum_symbol(dim: int) -> str:
-    if dim >= len(_EINSUM_SYMBOLS):
-        raise AssertionError(
-            "ONNX export for aten._trilinear only supports up to 52 dimensions"
-        )
-    return _EINSUM_SYMBOLS[dim]
-
-
-def _build_trilinear_subscript(total_dim: int, expanded_dims: Sequence[int]) -> str:
-    expanded_dims_set = set(expanded_dims)
-    return "".join(
-        _get_einsum_symbol(dim)
-        for dim in range(total_dim)
-        if dim not in expanded_dims_set
-    )
-
-
-def _build_trilinear_equation(
-    total_dim: int,
-    expand1: Sequence[int],
-    expand2: Sequence[int],
-    expand3: Sequence[int],
-    sumdim: Sequence[int],
-) -> str:
-    sumdim_set = set(sumdim)
-    output_subscript = "".join(
-        _get_einsum_symbol(dim)
-        for dim in range(total_dim)
-        if dim not in sumdim_set
-    )
-    return (
-        f"{_build_trilinear_subscript(total_dim, expand1)},"
-        f"{_build_trilinear_subscript(total_dim, expand2)},"
-        f"{_build_trilinear_subscript(total_dim, expand3)}->{output_subscript}"
-    )
-
-
-@onnx_impl(aten._trilinear.default, trace_only=True)
-def aten__trilinear(
-    i1: TReal,
-    i2: TReal,
-    i3: TReal,
-    expand1: Sequence[int],
-    expand2: Sequence[int],
-    expand3: Sequence[int],
-    sumdim: Sequence[int],
-    unroll_dim: int = 1,
-) -> TReal:
-    """_trilinear(Tensor i1, Tensor i2, Tensor i3, int[] expand1, int[] expand2, int[] expand3, int[] sumdim, int unroll_dim=1) -> Tensor"""
-
-    del unroll_dim
-
-    total_dim = len(i1.shape) + len(expand1)
-    equation = _build_trilinear_equation(total_dim, expand1, expand2, expand3, sumdim)
-    return op18.Einsum(i1, i2, i3, equation=equation)
-
-
-@onnx_impl(aten.bilinear.default, trace_only=True)
-def aten_bilinear(
-    input1: TReal,
-    input2: TReal,
-    weight: TReal,
-    bias: TReal | None = None,
-) -> TReal:
-    """bilinear(Tensor input1, Tensor input2, Tensor weight, Tensor? bias=None) -> Tensor"""
-
-    batch_shape = op18.Shape(input1, start=0, end=-1)
-    input1_shape = op18.Shape(input1, start=-1)
-    input2_shape = op18.Shape(input2, start=-1)
-    output_shape = op18.Shape(weight, start=0, end=1)
-    neg_1 = op18.Constant(value_ints=[-1])
-
-    weight_permuted = op18.Transpose(weight, perm=[1, 0, 2])
-    weight_flat = op18.Reshape(
-        weight_permuted,
-        op18.Concat(input1_shape, op18.Mul(output_shape, input2_shape), axis=0),
-    )
-
-    result = op18.MatMul(input1, weight_flat)
-    result = op18.Reshape(
-        result,
-        op18.Concat(batch_shape, output_shape, input2_shape, axis=0),
-    )
-    result = op18.Squeeze(op18.MatMul(result, op18.Unsqueeze(input2, neg_1)), neg_1)
-
-    if bias is not None:
-        result = op18.Add(result, bias)
-    return result
 
 
 @onnx_impl(aten.gelu.default, trace_only=True, opset_introduced=20)

--- a/torch/onnx/_internal/exporter/_torchlib/ops/nn.py
+++ b/torch/onnx/_internal/exporter/_torchlib/ops/nn.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from typing import Sequence, TYPE_CHECKING  # noqa: UP035
 
 from onnxscript.onnx_opset import (  # type: ignore[attr-defined]
+    opset18 as op18,
     opset20 as op20,
     opset21 as op21,
     opset23 as op23,
@@ -24,6 +25,98 @@ if TYPE_CHECKING:
     from onnxscript.values import Opset
 
 aten = torch.ops.aten
+
+_EINSUM_SYMBOLS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+
+def _get_einsum_symbol(dim: int) -> str:
+    if dim >= len(_EINSUM_SYMBOLS):
+        raise AssertionError(
+            "ONNX export for aten._trilinear only supports up to 52 dimensions"
+        )
+    return _EINSUM_SYMBOLS[dim]
+
+
+def _build_trilinear_subscript(total_dim: int, expanded_dims: Sequence[int]) -> str:
+    expanded_dims_set = set(expanded_dims)
+    return "".join(
+        _get_einsum_symbol(dim)
+        for dim in range(total_dim)
+        if dim not in expanded_dims_set
+    )
+
+
+def _build_trilinear_equation(
+    total_dim: int,
+    expand1: Sequence[int],
+    expand2: Sequence[int],
+    expand3: Sequence[int],
+    sumdim: Sequence[int],
+) -> str:
+    sumdim_set = set(sumdim)
+    output_subscript = "".join(
+        _get_einsum_symbol(dim)
+        for dim in range(total_dim)
+        if dim not in sumdim_set
+    )
+    return (
+        f"{_build_trilinear_subscript(total_dim, expand1)},"
+        f"{_build_trilinear_subscript(total_dim, expand2)},"
+        f"{_build_trilinear_subscript(total_dim, expand3)}->{output_subscript}"
+    )
+
+
+@onnx_impl(aten._trilinear.default, trace_only=True)
+def aten__trilinear(
+    i1: TReal,
+    i2: TReal,
+    i3: TReal,
+    expand1: Sequence[int],
+    expand2: Sequence[int],
+    expand3: Sequence[int],
+    sumdim: Sequence[int],
+    unroll_dim: int = 1,
+) -> TReal:
+    """_trilinear(Tensor i1, Tensor i2, Tensor i3, int[] expand1, int[] expand2, int[] expand3, int[] sumdim, int unroll_dim=1) -> Tensor"""
+
+    del unroll_dim
+
+    total_dim = len(i1.shape) + len(expand1)
+    equation = _build_trilinear_equation(total_dim, expand1, expand2, expand3, sumdim)
+    return op18.Einsum(i1, i2, i3, equation=equation)
+
+
+@onnx_impl(aten.bilinear.default, trace_only=True)
+def aten_bilinear(
+    input1: TReal,
+    input2: TReal,
+    weight: TReal,
+    bias: TReal | None = None,
+) -> TReal:
+    """bilinear(Tensor input1, Tensor input2, Tensor weight, Tensor? bias=None) -> Tensor"""
+
+    batch_shape = op18.Shape(input1, start=0, end=-1)
+    input1_shape = op18.Shape(input1, start=-1)
+    input2_shape = op18.Shape(input2, start=-1)
+    output_shape = op18.Shape(weight, start=0, end=1)
+    neg_1 = op18.Constant(value_ints=[-1])
+
+    weight_permuted = op18.Transpose(weight, perm=[1, 0, 2])
+    weight_flat = op18.Reshape(
+        weight_permuted,
+        op18.Concat(input1_shape, op18.Mul(output_shape, input2_shape), axis=0),
+    )
+
+    result = op18.MatMul(input1, weight_flat)
+    result = op18.Reshape(
+        result,
+        op18.Concat(batch_shape, output_shape, input2_shape, axis=0),
+    )
+    result = op18.Squeeze(op18.MatMul(result, op18.Unsqueeze(input2, neg_1)), neg_1)
+
+    if bias is not None:
+        result = op18.Add(result, bias)
+    return result
 
 
 @onnx_impl(aten.gelu.default, trace_only=True, opset_introduced=20)


### PR DESCRIPTION
Fixes #126774

## Summary
- add ONNX exporter torchlib lowerings for `aten._trilinear.default` and `aten.bilinear.default`
- lower `_trilinear` through a generated `Einsum` equation and keep bilinear on a `MatMul`-based path
- add exporter regression tests for direct `_trilinear` export and `nn.Bilinear`

## Testing
- python -m pytest -q test/onnx/exporter/test_small_models_e2e.py -k "test_export_aten_trilinear or test_export_nn_bilinear"
