### PR TITLE
[autograd] Replace unordered_map with SmallVector in ForwardGrad

### DIFF
--- a/torch/csrc/autograd/forward_grad.cpp
+++ b/torch/csrc/autograd/forward_grad.cpp
@@ -67,8 +67,8 @@ ForwardADLevel::~ForwardADLevel() {
 
 const at::Tensor& ForwardGrad::value(uint64_t level) const {
   std::lock_guard<std::mutex> lock(mutex_);
-  const auto& it = content_.find(level);
-  return it == content_.end() ? singleton_undefined_tensor : (*it).second;
+  auto it = find_level(level);
+  return it == content_.end() ? singleton_undefined_tensor : it->second;
 }
 
 const at::Tensor& ForwardGrad::undef_grad() {

--- a/torch/csrc/autograd/forward_grad.h
+++ b/torch/csrc/autograd/forward_grad.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <ATen/core/Tensor.h>
+#include <c10/util/SmallVector.h>
+#include <algorithm>
 #include <unordered_set>
 
 namespace torch::autograd {
@@ -165,7 +167,7 @@ struct TORCH_API ForwardGrad : std::enable_shared_from_this<ForwardGrad> {
     forward_level->insert(shared_from_this());
 
     std::lock_guard<std::mutex> lock(mutex_);
-    content_.insert({level, value});
+    content_.push_back({level, value});
   }
 
   // This function removes the tangent for a given level from this ForwardGrad
@@ -177,14 +179,14 @@ struct TORCH_API ForwardGrad : std::enable_shared_from_this<ForwardGrad> {
     }
 
     std::unique_lock<std::mutex> lock(mutex_);
-    const auto& it = content_.find(level);
+    auto it = find_level(level);
     TORCH_INTERNAL_ASSERT(
         it != content_.end(), "Resetting a non-existent level.");
     // Keep the Tensor alive until we have released the lock
     // This is needed as we can be in a case where this function is called by
     // ForwardADLevel destructor
-    auto t = (*it).second;
-    content_.erase(level);
+    auto t = std::move(it->second);
+    content_.erase(it);
     lock.unlock();
   }
 
@@ -192,7 +194,7 @@ struct TORCH_API ForwardGrad : std::enable_shared_from_this<ForwardGrad> {
 
   bool contains(uint64_t level) {
     std::lock_guard<std::mutex> lock(mutex_);
-    return content_.count(level) > 0;
+    return find_level(level) != content_.end();
   }
 
   bool empty() const {
@@ -202,8 +204,17 @@ struct TORCH_API ForwardGrad : std::enable_shared_from_this<ForwardGrad> {
   static const at::Tensor& undef_grad();
 
  private:
-  // TODO(albanD): replace this with a SmallVector
-  std::unordered_map<uint64_t, at::Tensor> content_;
+  auto find_level(uint64_t level) {
+    return std::find_if(content_.begin(), content_.end(),
+        [level](const auto& p) { return p.first == level; });
+  }
+  auto find_level(uint64_t level) const {
+    return std::find_if(content_.begin(), content_.end(),
+        [level](const auto& p) { return p.first == level; });
+  }
+
+  c10::SmallVector<std::pair<uint64_t, at::Tensor>, EXPECTED_MAX_LEVEL>
+      content_;
   mutable std::mutex mutex_;
 };
 


### PR DESCRIPTION
## Summary

Resolves the TODO at `torch/csrc/autograd/forward_grad.h:205` (`// TODO(albanD): replace this with a SmallVector`) by replacing `std::unordered_map<uint64_t, at::Tensor>` with `c10::SmallVector<std::pair<uint64_t, at::Tensor>, EXPECTED_MAX_LEVEL>` in `ForwardGrad::content_`.

## Motivation

`ForwardGrad` is allocated per dual tensor during forward-mode AD. The previous `unordered_map` heap-allocates internal hash table state (buckets array, node pointers) even for a single entry. Since:

- `EXPECTED_MAX_LEVEL` is 2 (`forward_grad.h:100`)
- Nested forward AD is not currently supported (`forward_grad.cpp:19`: `TORCH_CHECK(next_idx == 0, "Nested forward mode AD is not supported at the moment")`)
- In practice the map contains exactly **1 entry**

...the hash table overhead is pure waste. A `SmallVector` with inline storage for 2 elements eliminates the per-instance heap allocation entirely.

For workloads that create many short-lived dual tensors (e.g., per-sample JVP computations), this reduces allocator pressure. Linear scan on 1–2 elements is also faster than hash lookup due to cache locality, though mutex acquisition dominates per-operation cost — the win here is allocation avoidance, not lookup speed.

## Changes

**`torch/csrc/autograd/forward_grad.h`:**
- Added `#include <c10/util/SmallVector.h>` and `#include <algorithm>`
- Replaced `std::unordered_map<uint64_t, at::Tensor> content_` with `c10::SmallVector<std::pair<uint64_t, at::Tensor>, EXPECTED_MAX_LEVEL> content_`
- Added private `find_level()` helpers (mutable and const) using `std::find_if` for linear scan
- `set_value`: `content_.insert({level, value})` → `content_.push_back({level, value})`
- `reset`: `content_.find(level)` → `find_level(level)`, `content_.erase(level)` → `content_.erase(it)`, copy → `std::move`
- `contains`: `content_.count(level) > 0` → `find_level(level) != content_.end()`
- `clear()` and `empty()`: unchanged (iteration and `.empty()` work identically on SmallVector)

**`torch/csrc/autograd/forward_grad.cpp`:**
- `value()`: `content_.find(level)` → `find_level(level)`, `(*it).second` → `it->second`

## Correctness argument

### Behavioral equivalence

Every `unordered_map` operation has been mapped to a semantically equivalent `SmallVector` operation:

| Operation | Old (`unordered_map`) | New (`SmallVector`) | Equivalent? |
|---|---|---|---|
| Insert | `insert({k,v})` (no-op if exists) | `push_back({k,v})` | Yes — duplicates cannot occur (see below) |
| Lookup | `find(k)` → iterator | `find_if(begin, end, pred)` → iterator | Yes |
| Delete | `erase(key)` | `erase(iterator)` | Yes |
| Membership | `count(k) > 0` | `find_if != end` | Yes |
| Iteration | range-for over `pair` | range-for over `pair` | Yes |
| Empty check | `.empty()` | `.empty()` | Yes |

### Why duplicates cannot occur in `push_back`

The old code used `unordered_map::insert`, which is a no-op when the key already exists. The new code uses `push_back`, which would create duplicates if called twice with the same level. This is safe because:

1. **Nested forward AD is unsupported**: `ForwardADLevel::get_next_idx()` enforces `next_idx == 0` (`forward_grad.cpp:19`), so only level 0 exists at any time.
2. **`set_value` is called once per level per tensor**: It is called from `AutogradMeta::set_fw_grad` which checks `if (fw_grad_->contains(level))` and throws before reaching `set_value` if a tangent already exists for that level. The call path is `Tensor::_set_fw_grad` → `AutogradMeta::set_fw_grad` → `ForwardGrad::set_value`.

### Concurrency

All access to `content_` remains protected by `mutex_`. The locking protocol is unchanged. `SmallVector` operations (push_back, erase, iteration) have the same thread-safety guarantees as `unordered_map` operations under external synchronization.

## Precedent in the codebase

`c10::SmallVector` is widely used throughout PyTorch for small, fixed-capacity collections:

- `c10::DimVector` = `SmallVector<int64_t, kDimVectorStaticSize>` (`c10/util/DimVector.h`)
- `c10::SymDimVector` = `SmallVector<c10::SymInt, kDimVectorStaticSize>` (`c10/util/DimVector.h`)
- `SmallVector<std::pair<int, int>, 3>` in SmallVector tests (`c10/test/util/small_vector_test.cpp:1412`)
- `SmallVector<int64_t, 5>` for permutation tracking (`c10/core/Contiguity.h:281`)
- `SmallVector<uint64_t, EXPECTED_MAX_LEVEL>` already used in `ForwardGrad::clear()` in this same file (`forward_grad.h:140`)

## Test plan

- No API change; `content_` is private with all access through existing methods
- Existing forward AD tests cover all code paths through `ForwardGrad`:
  - `test/test_autograd.py`: ~40 forward AD tests covering `make_dual`/`unpack_dual` packing/unpacking, level management, cleanup, views, inplace ops, custom functions, gradcheck
  - `test/test_ops_fwd_gradients.py`: forward-mode AD for all ops with `supports_forward_ad=True`
  - Key tests exercising each modified method:
    - **`set_value`** (via `make_dual`): `test_basic_packing_unpacking`, `test_advanced_packing_unpacking`, `test_make_dual_*`
    - **`value`** (via `unpack_dual`): all unpacking tests, `test_basic_packing_unpacking`
    - **`reset`** (via level exit): `test_forward_level_cleanup`, `test_grad_cleanup`
    - **`contains`** (via `_set_fw_grad` guard): `test_set_fw_grad_having_own_fw_grad_at_same_level`
    - **`clear`** (via `AutogradMeta`/`SavedVariable` destructor): `test_forward_level_cleanup`, `test_detach_view_tracking`

## BC-breaking?

No. `content_` is a private member of `ForwardGrad`. No public API changes.

cc @albanD