### PR TITLE
[export] Preserve aten.hardtanh semantics when min_val > max_val

### DIFF
--- a/test/export/test_unflatten.py
+++ b/test/export/test_unflatten.py
@@ -27,6 +27,15 @@ class TestUnflatten(TestCase):
         unflattened_output = unflattened(*args)
         self.assertTrue(torch.allclose(orig_output, unflattened_output))
 
+    def test_export_allows_aten_hardtanh_with_inverted_bounds(self):
+        class M(torch.nn.Module):
+            def forward(self, x):
+                return torch.ops.aten.hardtanh(x, min_val=2, max_val=0)
+
+        x = torch.randn(3)
+        ep = export(M(), (x,), strict=True)
+        self.assertEqual(ep.module()(x), M()(x))
+
     def test_unflatten_nested(self):
         class NestedChild(torch.nn.Module):
             def forward(self, x):

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -4449,6 +4449,25 @@ def meta_zero(self):
     return self.new_empty(self.shape)
 
 
+def _check_hardtanh_limits(self, min_val, max_val) -> None:
+    if utils.is_boolean_dtype(self.dtype):
+        raise RuntimeError("Bool inputs not supported for hardtanh")
+
+    if utils.is_integer_dtype(self.dtype):
+        min_val = int(min_val)
+        max_val = int(max_val)
+        if self.dtype == torch.uint8 and (min_val < 0 or max_val < 0):
+            raise RuntimeError(
+                "cannot do hardtanh on an unsigned type with negative limits"
+            )
+
+
+@register_meta(aten.hardtanh.default)
+def meta_hardtanh(self, min_val=-1, max_val=1):
+    _check_hardtanh_limits(self, min_val, max_val)
+    return torch.empty_like(self)
+
+
 @register_meta([aten.fill_.Tensor, aten.fill_.Scalar])
 def meta_fill_(self, val):
     return self
@@ -4461,6 +4480,12 @@ def meta_fill(self, val):
 
 @register_meta(aten.relu_.default)
 def meta_relu_(self):
+    return self
+
+
+@register_meta(aten.hardtanh_.default)
+def meta_hardtanh_(self, min_val=-1, max_val=1):
+    _check_hardtanh_limits(self, min_val, max_val)
     return self
 
 


### PR DESCRIPTION
## Summary
- preserve `aten.hardtanh` export behavior when `min_val > max_val` by handling the Meta dispatch path separately from eager functional checks
- add an export regression test covering inverted hardtanh bounds

## Testing
- python test/export/test_unflatten.py -k hardtanh_with_inverted_bounds

Closes #161081