### PR TITLE
Fail the workflow if a viable/strict candidate is not found

### DIFF
--- a/.github/workflows/update-viablestrict.yml
+++ b/.github/workflows/update-viablestrict.yml
@@ -45,7 +45,8 @@ jobs:
           if [ "$PUSH_RESULT" = "Everything up-to-date" ]; then
             echo "No update pushed"
           elif [ "${LATEST_SHA}" == "None" ]; then
-            echo "No viable/strict candidate found"
+            echo "❌ No viable/strict candidate found"
+            exit 1
           else
             echo "{\"sha\": \"${LATEST_SHA}\", \"repository\":\"pytorch/pytorch\", \"timestamp\": ${TIME}}" > "/tmp/${LATEST_SHA}.json"
             pip install awscli==1.29.40


### PR DESCRIPTION
It's not immediately obvious whether the viable/strict branch was updated or not by looking at https://github.com/pytorch/pytorch/actions/workflows/update-viablestrict.yml. 

I can understand the philosophical reason of "this really shouldn't be an error because the workflow actually succeeded", but from a devx perspective this might be better?