### PR TITLE
[DTensor] fix scaled_mm sharding strategy

### DIFF
--- a/test/distributed/tensor/test_matrix_ops.py
+++ b/test/distributed/tensor/test_matrix_ops.py
@@ -17,7 +17,6 @@ from torch.distributed.tensor import (
     Replicate,
     Shard,
 )
-from torch.distributed.tensor._dtensor_spec import DTensorSpec
 from torch.distributed.tensor._ops._matrix_ops import (
     gen_single_dim_einsum_strategies,
     mm_single_dim_strategy,
@@ -528,66 +527,68 @@ class DistMatrixOpsTest(DTensorTestBase):
 
             self.assertEqual(comm_mode.get_total_counts(), 0)
 
-    @with_comms
-    def test_scaled_mm_blockwise_1d_scale_spec(self):
-        """Test that _scaled_mm_scale_spec handles 1D blockwise scales correctly.
+    def test_scaled_mm_blockwise_1d_scale_placement(self):
+        """Test that _scaled_mm_scale_placement handles 1D blockwise scales correctly.
 
         1D blockwise scales arise in MX (microscaling) formats where a data
         tensor [M, K] has a flattened scale of shape [M * K / block_size].
         Shard(>=1) is invalid on a 1D tensor, so the strategy must map
         non-contracting shards to Shard(0) and reject contracting-dim shards.
         """
-        from torch.distributed.tensor._ops._matrix_ops import _scaled_mm_scale_spec
-
-        device_mesh = self.build_device_mesh()
+        from torch.distributed.tensor._ops._matrix_ops import _scaled_mm_scale_placement
 
         # --- Tensor-wise scale (single element) -> always Replicate ---
-        data_spec = DTensorSpec(device_mesh, (Shard(0),))
-        result = _scaled_mm_scale_spec(data_spec, torch.Size([1]), contracting_dim=1)
-        self.assertEqual(result.placements, (Replicate(),))
-        result = _scaled_mm_scale_spec(data_spec, torch.Size([]), contracting_dim=1)
-        self.assertEqual(result.placements, (Replicate(),))
-
-        # --- 2D scale -> copy data spec directly (existing row-wise behavior) ---
-        result = _scaled_mm_scale_spec(
-            data_spec, torch.Size([16, 1]), contracting_dim=1
+        result = _scaled_mm_scale_placement(
+            Shard(0), torch.Size([1]), contracting_dim=1
         )
-        self.assertEqual(result.placements, (Shard(0),))
+        self.assertEqual(result, Replicate())
+        result = _scaled_mm_scale_placement(Shard(0), torch.Size([]), contracting_dim=1)
+        self.assertEqual(result, Replicate())
+
+        # --- 2D scale -> copy data placement directly (row-wise) ---
+        result = _scaled_mm_scale_placement(
+            Shard(0), torch.Size([16, 1]), contracting_dim=1
+        )
+        self.assertEqual(result, Shard(0))
 
         # --- 1D blockwise + non-contracting shard -> Shard(0) ---
         # A (mk): dim 0 = m (non-contracting), dim 1 = k (contracting)
-        spec_shard0 = DTensorSpec(device_mesh, (Shard(0),))
-        result = _scaled_mm_scale_spec(spec_shard0, torch.Size([64]), contracting_dim=1)
+        result = _scaled_mm_scale_placement(
+            Shard(0), torch.Size([64]), contracting_dim=1
+        )
         self.assertIsNotNone(result)
-        self.assertEqual(result.placements, (Shard(0),))
+        self.assertEqual(result, Shard(0))
 
         # B_t (kn): dim 1 = n (non-contracting), dim 0 = k (contracting)
-        spec_shard1 = DTensorSpec(device_mesh, (Shard(1),))
-        result = _scaled_mm_scale_spec(spec_shard1, torch.Size([64]), contracting_dim=0)
+        result = _scaled_mm_scale_placement(
+            Shard(1), torch.Size([64]), contracting_dim=0
+        )
         self.assertIsNotNone(result)
-        self.assertEqual(result.placements, (Shard(0),))
+        self.assertEqual(result, Shard(0))
 
         # --- 1D blockwise + contracting shard -> None (unsupported) ---
-        # A with Shard(1) = shard on k (contracting for A)
-        result = _scaled_mm_scale_spec(spec_shard1, torch.Size([64]), contracting_dim=1)
+        result = _scaled_mm_scale_placement(
+            Shard(1), torch.Size([64]), contracting_dim=1
+        )
         self.assertIsNone(result)
-        # B_t with Shard(0) = shard on k (contracting for B_t)
-        result = _scaled_mm_scale_spec(spec_shard0, torch.Size([64]), contracting_dim=0)
+        result = _scaled_mm_scale_placement(
+            Shard(0), torch.Size([64]), contracting_dim=0
+        )
         self.assertIsNone(result)
 
         # --- 1D blockwise + Replicate -> Replicate ---
-        spec_repl = DTensorSpec(device_mesh, (Replicate(),))
-        result = _scaled_mm_scale_spec(spec_repl, torch.Size([64]), contracting_dim=1)
-        self.assertIsNotNone(result)
-        self.assertEqual(result.placements, (Replicate(),))
-
-        # --- 1D blockwise + Partial -> Replicate ---
-        spec_partial = DTensorSpec(device_mesh, (Partial(),))
-        result = _scaled_mm_scale_spec(
-            spec_partial, torch.Size([64]), contracting_dim=0
+        result = _scaled_mm_scale_placement(
+            Replicate(), torch.Size([64]), contracting_dim=1
         )
         self.assertIsNotNone(result)
-        self.assertEqual(result.placements, (Replicate(),))
+        self.assertEqual(result, Replicate())
+
+        # --- 1D blockwise + Partial -> Replicate ---
+        result = _scaled_mm_scale_placement(
+            Partial(), torch.Size([64]), contracting_dim=0
+        )
+        self.assertIsNotNone(result)
+        self.assertEqual(result, Replicate())
 
     @with_comms
     def test_matmul(self):

--- a/test/distributed/tensor/test_matrix_ops.py
+++ b/test/distributed/tensor/test_matrix_ops.py
@@ -17,6 +17,7 @@ from torch.distributed.tensor import (
     Replicate,
     Shard,
 )
+from torch.distributed.tensor._dtensor_spec import DTensorSpec
 from torch.distributed.tensor._ops._matrix_ops import (
     gen_single_dim_einsum_strategies,
     mm_single_dim_strategy,
@@ -526,6 +527,67 @@ class DistMatrixOpsTest(DTensorTestBase):
             self.assertEqual(full_dist_res, full_ref_res, atol=1.5, rtol=7e-2)
 
             self.assertEqual(comm_mode.get_total_counts(), 0)
+
+    @with_comms
+    def test_scaled_mm_blockwise_1d_scale_spec(self):
+        """Test that _scaled_mm_scale_spec handles 1D blockwise scales correctly.
+
+        1D blockwise scales arise in MX (microscaling) formats where a data
+        tensor [M, K] has a flattened scale of shape [M * K / block_size].
+        Shard(>=1) is invalid on a 1D tensor, so the strategy must map
+        non-contracting shards to Shard(0) and reject contracting-dim shards.
+        """
+        from torch.distributed.tensor._ops._matrix_ops import _scaled_mm_scale_spec
+
+        device_mesh = self.build_device_mesh()
+
+        # --- Tensor-wise scale (single element) -> always Replicate ---
+        data_spec = DTensorSpec(device_mesh, (Shard(0),))
+        result = _scaled_mm_scale_spec(data_spec, torch.Size([1]), contracting_dim=1)
+        self.assertEqual(result.placements, (Replicate(),))
+        result = _scaled_mm_scale_spec(data_spec, torch.Size([]), contracting_dim=1)
+        self.assertEqual(result.placements, (Replicate(),))
+
+        # --- 2D scale -> copy data spec directly (existing row-wise behavior) ---
+        result = _scaled_mm_scale_spec(
+            data_spec, torch.Size([16, 1]), contracting_dim=1
+        )
+        self.assertEqual(result.placements, (Shard(0),))
+
+        # --- 1D blockwise + non-contracting shard -> Shard(0) ---
+        # A (mk): dim 0 = m (non-contracting), dim 1 = k (contracting)
+        spec_shard0 = DTensorSpec(device_mesh, (Shard(0),))
+        result = _scaled_mm_scale_spec(spec_shard0, torch.Size([64]), contracting_dim=1)
+        self.assertIsNotNone(result)
+        self.assertEqual(result.placements, (Shard(0),))
+
+        # B_t (kn): dim 1 = n (non-contracting), dim 0 = k (contracting)
+        spec_shard1 = DTensorSpec(device_mesh, (Shard(1),))
+        result = _scaled_mm_scale_spec(spec_shard1, torch.Size([64]), contracting_dim=0)
+        self.assertIsNotNone(result)
+        self.assertEqual(result.placements, (Shard(0),))
+
+        # --- 1D blockwise + contracting shard -> None (unsupported) ---
+        # A with Shard(1) = shard on k (contracting for A)
+        result = _scaled_mm_scale_spec(spec_shard1, torch.Size([64]), contracting_dim=1)
+        self.assertIsNone(result)
+        # B_t with Shard(0) = shard on k (contracting for B_t)
+        result = _scaled_mm_scale_spec(spec_shard0, torch.Size([64]), contracting_dim=0)
+        self.assertIsNone(result)
+
+        # --- 1D blockwise + Replicate -> Replicate ---
+        spec_repl = DTensorSpec(device_mesh, (Replicate(),))
+        result = _scaled_mm_scale_spec(spec_repl, torch.Size([64]), contracting_dim=1)
+        self.assertIsNotNone(result)
+        self.assertEqual(result.placements, (Replicate(),))
+
+        # --- 1D blockwise + Partial -> Replicate ---
+        spec_partial = DTensorSpec(device_mesh, (Partial(),))
+        result = _scaled_mm_scale_spec(
+            spec_partial, torch.Size([64]), contracting_dim=0
+        )
+        self.assertIsNotNone(result)
+        self.assertEqual(result.placements, (Replicate(),))
 
     @with_comms
     def test_matmul(self):

--- a/torch/distributed/tensor/_ops/_matrix_ops.py
+++ b/torch/distributed/tensor/_ops/_matrix_ops.py
@@ -177,6 +177,53 @@ def _addmm_like_strategy(
     return mm_strategy
 
 
+def _scaled_mm_scale_spec(
+    data_spec: DTensorSpec,
+    scale_shape: torch.Size,
+    contracting_dim: int,
+) -> DTensorSpec | None:
+    """
+    Compute DTensorSpec for a _scaled_mm scale tensor given its data operand's spec.
+
+    Handles three cases:
+
+    1. Tensor-wise scale (single element): always Replicate.
+    2. 2D (or higher) scale, e.g. row-wise [M,1]: copy data spec directly.
+    3. 1D blockwise scale, e.g. MX format [M*K/block_size]: map
+       non-contracting shard to Shard(0), and filter out contracting-dim
+       shards (returns None) since 1D block scales can't be split along the
+       contracting dimension.
+    """
+    if prod(scale_shape) == 1:
+        # Tensor-wise: always replicate
+        return DTensorSpec(
+            data_spec.mesh,
+            tuple(Replicate() for _ in data_spec.placements),
+        )
+
+    if len(scale_shape) != 1:
+        # 2D (or higher) scale: copy data spec directly (e.g. row-wise)
+        return data_spec
+
+    # 1D blockwise scale: Shard(>=1) is invalid on a 1D tensor, so we need
+    # to map the data operand's placement to a valid 1D placement.
+    new_placements: list[Placement] = []
+    for p in data_spec.placements:
+        if isinstance(p, Replicate | Partial):
+            new_placements.append(Replicate())
+        elif isinstance(p, Shard):
+            if p.dim == contracting_dim:
+                # Can't shard a 1D blockwise scale on the contracting dim
+                return None
+            else:
+                # Non-contracting dim: scale's row-blocks are split
+                new_placements.append(Shard(0))
+        else:
+            new_placements.append(p)
+
+    return DTensorSpec(data_spec.mesh, tuple(new_placements))
+
+
 def _scaled_mm_like_strategy(
     mm_equation: str, mesh: DeviceMesh, op_schema: OpSchema
 ) -> OpStrategy:
@@ -202,6 +249,19 @@ def _scaled_mm_like_strategy(
         raise AssertionError("_scaled_mm on DTensors doesn't support bias")
     if scale_result_strategy is not None:
         raise AssertionError("_scaled_mm on DTensors doesn't support scale_result")
+
+    # Derive contracting dimensions from the einsum equation.
+    # For "mk,kn->mn": contracting char is 'k', self_dim=1, mat2_dim=0.
+    inputs, output = mm_equation.split("->")
+    input_terms = inputs.split(",")
+    contracting_chars = set(input_terms[0]) & set(input_terms[1]) - set(output)
+    self_contracting_dim = next(
+        i for i, c in enumerate(input_terms[0]) if c in contracting_chars
+    )
+    mat2_contracting_dim = next(
+        i for i, c in enumerate(input_terms[1]) if c in contracting_chars
+    )
+
     # generate all possible strategies for mm
     mm_strategy = gen_einsum_strategies(mm_equation, mesh)
     # filter out invalid strategies and associate costs
@@ -214,19 +274,18 @@ def _scaled_mm_like_strategy(
             )
         self_spec = strtg.input_specs[0]
         mat2_spec = strtg.input_specs[1]
-        # propagate the operands' specs to their scales, except for tensor-wise
-        # scaling which can have any numbers of dims (legacy...), hence sharding
-        # dims won't map. for tensor-wise, anyways, we can only do replication.
-        scale_self_spec = (
-            DTensorSpec(self_spec.mesh, (Replicate(),))
-            if prod(scale_self_strategy.shape) == 1
-            else self_spec
+        # Propagate the operands' specs to their scales. For tensor-wise
+        # scales we always replicate. For 2D scales (e.g. row-wise) we copy
+        # the data spec. For 1D blockwise scales (e.g. MX format) we map
+        # non-contracting shards to Shard(0) and filter out contracting shards.
+        scale_self_spec = _scaled_mm_scale_spec(
+            self_spec, scale_self_strategy.shape, self_contracting_dim
         )
-        scale_mat2_spec = (
-            DTensorSpec(mat2_spec.mesh, (Replicate(),))
-            if prod(scale_mat2_strategy.shape) == 1
-            else mat2_spec
+        scale_mat2_spec = _scaled_mm_scale_spec(
+            mat2_spec, scale_mat2_strategy.shape, mat2_contracting_dim
         )
+        if scale_self_spec is None or scale_mat2_spec is None:
+            continue
         strtg.input_specs = list(strtg.input_specs) + [scale_self_spec, scale_mat2_spec]
         if (
             is_tensor_shardable(

--- a/torch/distributed/tensor/_ops/_matrix_ops.py
+++ b/torch/distributed/tensor/_ops/_matrix_ops.py
@@ -177,142 +177,41 @@ def _addmm_like_strategy(
     return mm_strategy
 
 
-def _scaled_mm_scale_spec(
-    data_spec: DTensorSpec,
+def _scaled_mm_scale_placement(
+    data_placement: Placement | _ShardingPlaceholder,
     scale_shape: torch.Size,
     contracting_dim: int,
-) -> DTensorSpec | None:
+) -> Placement | _ShardingPlaceholder | None:
     """
-    Compute DTensorSpec for a _scaled_mm scale tensor given its data operand's spec.
+    Derive scale placement from data operand placement for _scaled_mm.
 
     Handles three cases:
 
     1. Tensor-wise scale (single element): always Replicate.
-    2. 2D (or higher) scale, e.g. row-wise [M,1]: copy data spec directly.
+    2. 2D (or higher) scale, e.g. row-wise [M,1]: copy data placement directly.
     3. 1D blockwise scale, e.g. MX format [M*K/block_size]: map
-       non-contracting shard to Shard(0), and filter out contracting-dim
-       shards (returns None) since 1D block scales can't be split along the
-       contracting dimension.
+       non-contracting shard to Shard(0)/_ShardingPlaceholder(0), and reject
+       contracting-dim shards (returns None).
     """
     if prod(scale_shape) == 1:
-        # Tensor-wise: always replicate
-        return DTensorSpec(
-            data_spec.mesh,
-            tuple(Replicate() for _ in data_spec.placements),
-        )
+        return Replicate()
 
     if len(scale_shape) != 1:
-        # 2D (or higher) scale: copy data spec directly (e.g. row-wise)
-        return data_spec
+        return data_placement
 
     # 1D blockwise scale: Shard(>=1) is invalid on a 1D tensor, so we need
     # to map the data operand's placement to a valid 1D placement.
-    new_placements: list[Placement] = []
-    for p in data_spec.placements:
-        if isinstance(p, Replicate | Partial):
-            new_placements.append(Replicate())
-        elif isinstance(p, Shard):
-            if p.dim == contracting_dim:
-                # Can't shard a 1D blockwise scale on the contracting dim
-                return None
-            else:
-                # Non-contracting dim: scale's row-blocks are split
-                new_placements.append(Shard(0))
-        else:
-            new_placements.append(p)
-
-    return DTensorSpec(data_spec.mesh, tuple(new_placements))
-
-
-def _scaled_mm_like_strategy(
-    mm_equation: str, mesh: DeviceMesh, op_schema: OpSchema
-) -> OpStrategy:
-    (
-        self_strategy,
-        mat2_strategy,
-        scale_self_strategy,
-        scale_mat2_strategy,
-        bias_strategy,
-        scale_result_strategy,
-        *_,
-    ) = op_schema.args_schema
-    if not isinstance(self_strategy, OpStrategy):
-        raise AssertionError(f"Expected OpStrategy, got {type(self_strategy)}")
-    if not isinstance(mat2_strategy, OpStrategy):
-        raise AssertionError(f"Expected OpStrategy, got {type(mat2_strategy)}")
-    if not isinstance(scale_self_strategy, OpStrategy):
-        raise AssertionError(f"Expected OpStrategy, got {type(scale_self_strategy)}")
-    if not isinstance(scale_mat2_strategy, OpStrategy):
-        raise AssertionError(f"Expected OpStrategy, got {type(scale_mat2_strategy)}")
-    # TODO: add support for these later
-    if bias_strategy is not None:
-        raise AssertionError("_scaled_mm on DTensors doesn't support bias")
-    if scale_result_strategy is not None:
-        raise AssertionError("_scaled_mm on DTensors doesn't support scale_result")
-
-    # Derive contracting dimensions from the einsum equation.
-    # For "mk,kn->mn": contracting char is 'k', self_dim=1, mat2_dim=0.
-    inputs, output = mm_equation.split("->")
-    input_terms = inputs.split(",")
-    contracting_chars = set(input_terms[0]) & set(input_terms[1]) - set(output)
-    self_contracting_dim = next(
-        i for i, c in enumerate(input_terms[0]) if c in contracting_chars
-    )
-    mat2_contracting_dim = next(
-        i for i, c in enumerate(input_terms[1]) if c in contracting_chars
-    )
-
-    # generate all possible strategies for mm
-    mm_strategy = gen_einsum_strategies(mm_equation, mesh)
-    # filter out invalid strategies and associate costs
-    strategies = mm_strategy.strategies
-    filtered_strategies = []
-    for strtg in strategies:
-        if strtg.input_specs is None:
-            raise AssertionError(
-                f"Expected input_specs to be not None, got {strtg.input_specs}"
-            )
-        self_spec = strtg.input_specs[0]
-        mat2_spec = strtg.input_specs[1]
-        # Propagate the operands' specs to their scales. For tensor-wise
-        # scales we always replicate. For 2D scales (e.g. row-wise) we copy
-        # the data spec. For 1D blockwise scales (e.g. MX format) we map
-        # non-contracting shards to Shard(0) and filter out contracting shards.
-        scale_self_spec = _scaled_mm_scale_spec(
-            self_spec, scale_self_strategy.shape, self_contracting_dim
-        )
-        scale_mat2_spec = _scaled_mm_scale_spec(
-            mat2_spec, scale_mat2_strategy.shape, mat2_contracting_dim
-        )
-        if scale_self_spec is None or scale_mat2_spec is None:
-            continue
-        strtg.input_specs = list(strtg.input_specs) + [scale_self_spec, scale_mat2_spec]
-        if (
-            is_tensor_shardable(
-                self_strategy.shape, self_spec, allow_unbacked_sharding=True
-            )
-            and is_tensor_shardable(
-                mat2_strategy.shape, mat2_spec, allow_unbacked_sharding=True
-            )
-            and is_tensor_shardable(
-                scale_self_strategy.shape, scale_self_spec, allow_unbacked_sharding=True
-            )
-            and is_tensor_shardable(
-                scale_mat2_strategy.shape, scale_mat2_spec, allow_unbacked_sharding=True
-            )
-        ):
-            redistribute_cost = [
-                generate_redistribute_costs(self_strategy, self_spec),
-                generate_redistribute_costs(mat2_strategy, mat2_spec),
-                generate_redistribute_costs(scale_self_strategy, scale_self_spec),
-                generate_redistribute_costs(scale_mat2_strategy, scale_mat2_spec),
-            ]
-            strtg.redistribute_cost = redistribute_cost
-            filtered_strategies.append(strtg)
-
-    mm_strategy.strategies = filtered_strategies
-
-    return mm_strategy
+    if isinstance(data_placement, _ShardingPlaceholder):
+        if data_placement.dim == contracting_dim:
+            return None
+        return _ShardingPlaceholder(0)
+    elif isinstance(data_placement, Shard):
+        if data_placement.dim == contracting_dim:
+            return None
+        return Shard(0)
+    elif isinstance(data_placement, (Replicate, Partial)):
+        return Replicate()
+    return data_placement
 
 
 @register_op_strategy(aten.dot.default)
@@ -548,10 +447,36 @@ def baddbmm_single_dim_strategy(
     return gen_single_dim_einsum_strategies("bmk,bkn->bmn", bias_shape=bias_meta.shape)
 
 
-@register_op_strategy(aten._scaled_mm.default)
-def scaled_mm_strategy(op_schema: OpSchema) -> OpStrategy:
-    mesh = op_schema.get_mesh_from_args()
-    return _scaled_mm_like_strategy("mk,kn->mn", mesh, op_schema)
+@register_single_dim_strategy(aten._scaled_mm.default, allow_unbacked_sharding=True)
+def scaled_mm_single_dim_strategy(
+    op: OpOverload, args_schema: ArgsType, kwargs_schema: KwargsType
+) -> list[list[Placement | _ShardingPlaceholder]]:
+    scale_self_meta = args_schema[2]
+    scale_mat2_meta = args_schema[3]
+    if not isinstance(scale_self_meta, TensorMeta):
+        raise AssertionError
+    if not isinstance(scale_mat2_meta, TensorMeta):
+        raise AssertionError
+    if args_schema[4] is not None:
+        raise AssertionError("_scaled_mm on DTensors doesn't support bias")
+    if args_schema[5] is not None:
+        raise AssertionError("_scaled_mm on DTensors doesn't support scale_result")
+
+    # "mk,kn->mn": self_contracting_dim=1, mat2_contracting_dim=0
+    base_strategies = gen_single_dim_einsum_strategies("mk,kn->mn")
+    result = []
+    for strat in base_strategies:
+        # strat is [output, self, mat2]; derive scale placements
+        scale_self_p = _scaled_mm_scale_placement(
+            strat[1], scale_self_meta.shape, contracting_dim=1
+        )
+        scale_mat2_p = _scaled_mm_scale_placement(
+            strat[2], scale_mat2_meta.shape, contracting_dim=0
+        )
+        if scale_self_p is None or scale_mat2_p is None:
+            continue
+        result.append(strat + [scale_self_p, scale_mat2_p])
+    return result
 
 
 def _scaled_dot_product_flash_attention_base_strategies(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #177235
* __->__ #177234

For https://github.com/pytorch/ao/pull/4010, the existing strategy incorrect copies scaled_mm input strategies (2d) onto the scale tensor (1d)