### PR TITLE
Prevent _pdist_forward segfault on non-2D input

### DIFF
--- a/aten/src/ATen/native/Distance.cpp
+++ b/aten/src/ATen/native/Distance.cpp
@@ -243,6 +243,11 @@ Tensor _cdist_backward(const Tensor& _grad, const Tensor& _x1, const Tensor& _x2
 }
 
 Tensor _pdist_forward(const Tensor& self, const double p) {
+  TORCH_CHECK(
+      self.dim() == 2,
+      "_pdist_forward only supports 2D tensors, got: ",
+      self.dim(),
+      "D");
   TORCH_CHECK(self.is_contiguous(), "_pdist_forward requires contiguous input");
   auto device = self.device().type();
   TORCH_CHECK(device == kCPU || device == kCUDA || device == kXPU, "_pdist_forward only supports CPU, XPU and CUDA devices, got: ", device);

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2495,6 +2495,14 @@ class TestTorchDeviceType(TestCase):
         x = torch.randn(shape, device=device)
         self.assertEqual(torch.zeros(3, device=device), torch.pdist(x))
 
+    @onlyNativeDeviceTypes
+    def test_pdist_forward_invalid_dim(self, device):
+        x = torch.randn((11, 15, 0), device=device)
+        with self.assertRaisesRegex(
+            RuntimeError, r"_pdist_forward only supports 2D tensors, got: 3D"
+        ):
+            torch.ops.aten._pdist_forward(x.contiguous(), p=2.0)
+
     def test_cdist_empty(self, device):
         x = torch.randn((0, 5), device=device)
         y = torch.randn((4, 5), device=device)

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -2223,6 +2223,10 @@ def meta_pad3d_backward(grad_output, input, padding):
 @out_wrapper()
 def meta__pdist_forward(self: Tensor, p: float = 2) -> Tensor:
     torch._check(
+        self.dim() == 2,
+        lambda: f"_pdist_forward only supports 2D tensors, got: {self.dim()}D",
+    )
+    torch._check(
         self.is_contiguous(), lambda: "_pdist_forward requires contiguous input"
     )
     n = self.size(0)


### PR DESCRIPTION
Fixes #145064

## Summary

Add a 2D dimensionality check to `torch.ops.aten._pdist_forward` in both the native and meta paths so invalid 3D inputs raise a `RuntimeError` instead of segfaulting. Add a regression test for the internal op while preserving the existing 2D empty-column behavior.

## Checklist

- [ ] Passes lint (`spin fixlint`)
- [x] Added/updated tests
- [ ] Updated documentation (if applicable)
- [ ] Included benchmark results (for PRs impacting perf)

## BC-breaking?

No
