### PR TITLE
[CUDA] [Green Context] Add support for workqueue limit

### DIFF
--- a/aten/src/ATen/cuda/CUDAGreenContext.cpp
+++ b/aten/src/ATen/cuda/CUDAGreenContext.cpp
@@ -11,10 +11,27 @@
 C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wunused-private-field")
 #endif
 
+#if defined(CUDA_VERSION) && CUDA_VERSION >= 13010 && HAS_CUDA_GREEN_CONTEXT()
+#define HAS_CUDA_WORKQUEUE_SUPPORT() 1
+#else
+#define HAS_CUDA_WORKQUEUE_SUPPORT() 0
+#endif
+
 namespace at::cuda {
 
-GreenContext::GreenContext(uint32_t device_id, uint32_t num_sms) {
+GreenContext::GreenContext(
+    uint32_t device_id,
+    std::optional<uint32_t> num_sms,
+    std::optional<int32_t> workqueue_scope,
+    std::optional<uint32_t> workqueue_concurrency_limit) {
 #if HAS_CUDA_GREEN_CONTEXT()
+  TORCH_CHECK(
+      num_sms.has_value() || workqueue_scope.has_value(),
+      "At least one of num_sms or workqueue_scope must be specified");
+  TORCH_CHECK(
+      !workqueue_concurrency_limit.has_value() || workqueue_scope.has_value(),
+      "workqueue_concurrency_limit requires workqueue_scope to be set");
+
   int driver_version;
   C10_CUDA_CHECK(cudaDriverGetVersion(&driver_version));
   TORCH_CHECK(
@@ -29,46 +46,71 @@ GreenContext::GreenContext(uint32_t device_id, uint32_t num_sms) {
     cudaFree(nullptr);
   }
 
-   CUdevice device;
+  CUdevice device;
   device_id_ = device_id;
   C10_CUDA_DRIVER_CHECK(
       c10::cuda::DriverAPI::get()->cuDeviceGet_(&device, device_id));
 
-  // Get device resources
-  CUdevResource device_resource;
-  C10_CUDA_DRIVER_CHECK(c10::cuda::DriverAPI::get()->cuDeviceGetDevResource_(
-      device, &device_resource, CU_DEV_RESOURCE_TYPE_SM));
+  std::vector<CUdevResource> resources;
 
-  TORCH_CHECK(
-      num_sms > 0 && num_sms <= device_resource.sm.smCount,
-      "Invalid number of SMs requested for green context: ",
-      num_sms,
-      " (device has ",
-      device_resource.sm.smCount,
-      " SMs)");
+  // --- SM resource ---
+  if (num_sms.has_value()) {
+    CUdevResource sm_resource;
+    C10_CUDA_DRIVER_CHECK(c10::cuda::DriverAPI::get()->cuDeviceGetDevResource_(
+        device, &sm_resource, CU_DEV_RESOURCE_TYPE_SM));
 
-  // Split resources
-  std::vector<CUdevResource> result(1);
-  auto result_data = result.data();
-  unsigned int nb_groups = 1;
-  CUdevResource remaining;
+    TORCH_CHECK(
+        *num_sms > 0 && *num_sms <= sm_resource.sm.smCount,
+        "Invalid number of SMs requested for green context: ",
+        *num_sms,
+        " (device has ",
+        sm_resource.sm.smCount,
+        " SMs)");
 
-  C10_CUDA_DRIVER_CHECK(
-      c10::cuda::DriverAPI::get()->cuDevSmResourceSplitByCount_(
-          result_data,
-          &nb_groups,
-          &device_resource,
-          &remaining,
-          0, // default flags
-          num_sms));
+    // Split resources
+    std::vector<CUdevResource> split_result(1);
+    unsigned int nb_groups = 1;
+    CUdevResource remaining;
 
-  TORCH_CHECK(nb_groups == 1, "Failed to create single resource group");
+    C10_CUDA_DRIVER_CHECK(
+        c10::cuda::DriverAPI::get()->cuDevSmResourceSplitByCount_(
+            split_result.data(),
+            &nb_groups,
+            &sm_resource,
+            &remaining,
+            0, // default flags
+            *num_sms));
+    TORCH_CHECK(nb_groups == 1, "Failed to create single SM resource group");
+    resources.push_back(split_result[0]);
+  }
+
+  // --- Workqueue config resource ---
+  if (workqueue_scope.has_value()) {
+#if HAS_CUDA_WORKQUEUE_SUPPORT()
+    CUdevResource wq_resource{};
+    C10_CUDA_DRIVER_CHECK(c10::cuda::DriverAPI::get()->cuDeviceGetDevResource_(
+        device, &wq_resource, CU_DEV_RESOURCE_TYPE_WORKQUEUE_CONFIG));
+
+    wq_resource.wqConfig.sharingScope =
+        static_cast<CUdevWorkqueueConfigScope>(*workqueue_scope);
+    if (workqueue_concurrency_limit.has_value()) {
+      wq_resource.wqConfig.wqConcurrencyLimit = *workqueue_concurrency_limit;
+    }
+    resources.push_back(wq_resource);
+#else
+    TORCH_CHECK(
+        false,
+        "Workqueue configuration for green contexts requires CUDA 13.1+!");
+#endif
+  }
 
   // Generate resource descriptor
   CUdevResourceDesc desc;
   C10_CUDA_DRIVER_CHECK(
       c10::cuda::DriverAPI::get()->cuDevResourceGenerateDesc_(
-          &desc, result_data, 1));
+          &desc,
+          resources.data(),
+          static_cast<unsigned int>(resources.size())));
 
   // Create green context
   // CU_GREEN_CTX_DEFAULT_STREAM is required per docs:
@@ -83,20 +125,41 @@ GreenContext::GreenContext(uint32_t device_id, uint32_t num_sms) {
 #else
   TORCH_CHECK(false, "Green Context is only supported on CUDA 12.8+!");
 #endif
-  }
+}
 
-  std::unique_ptr<GreenContext> GreenContext::create(
-      uint32_t num_sms,
-      std::optional<uint32_t> device_id) {
+std::unique_ptr<GreenContext> GreenContext::create(
+    std::optional<uint32_t> device_id,
+    std::optional<uint32_t> num_sms,
+    std::optional<int32_t> workqueue_scope,
+    std::optional<uint32_t> workqueue_concurrency_limit) {
 #if HAS_CUDA_GREEN_CONTEXT()
-    if (!device_id.has_value()) {
-      device_id = at::cuda::current_device();
-    }
-    return std::unique_ptr<GreenContext>(new GreenContext(device_id.value(), num_sms));
-#else
-    TORCH_CHECK(false, "Green Context is only supported on CUDA 12.8+!");
-#endif
+  if (!device_id.has_value()) {
+    device_id = at::cuda::current_device();
   }
+  return std::unique_ptr<GreenContext>(new GreenContext(
+      device_id.value(), num_sms, workqueue_scope, workqueue_concurrency_limit));
+#else
+  TORCH_CHECK(false, "Green Context is only supported on CUDA 12.8+!");
+#endif
+}
+
+uint32_t GreenContext::max_workqueue_concurrency(
+    std::optional<uint32_t> device_id) {
+#if HAS_CUDA_WORKQUEUE_SUPPORT()
+  if (!device_id.has_value()) {
+    device_id = at::cuda::current_device();
+  }
+  CUdevice device;
+  C10_CUDA_DRIVER_CHECK(
+      c10::cuda::DriverAPI::get()->cuDeviceGet_(&device, device_id.value()));
+  CUdevResource wq_resource;
+  C10_CUDA_DRIVER_CHECK(c10::cuda::DriverAPI::get()->cuDeviceGetDevResource_(
+      device, &wq_resource, CU_DEV_RESOURCE_TYPE_WORKQUEUE_CONFIG));
+  return wq_resource.wqConfig.wqConcurrencyLimit;
+#else
+  TORCH_CHECK(false, "Workqueue configuration requires CUDA 13.1+!");
+#endif
+}
 
   // Implement move operations
 #if HAS_CUDA_GREEN_CONTEXT()

--- a/aten/src/ATen/cuda/CUDAGreenContext.cpp
+++ b/aten/src/ATen/cuda/CUDAGreenContext.cpp
@@ -87,6 +87,8 @@ GreenContext::GreenContext(
   // --- Workqueue config resource ---
   if (workqueue_scope.has_value()) {
 #if HAS_CUDA_WORKQUEUE_SUPPORT()
+    TORCH_CHECK(
+        driver_version >= 13010, "cuda driver too old to use workqueue configuration!");
     CUdevResource wq_resource{};
     C10_CUDA_DRIVER_CHECK(c10::cuda::DriverAPI::get()->cuDeviceGetDevResource_(
         device, &wq_resource, CU_DEV_RESOURCE_TYPE_WORKQUEUE_CONFIG));
@@ -146,6 +148,10 @@ std::unique_ptr<GreenContext> GreenContext::create(
 uint32_t GreenContext::max_workqueue_concurrency(
     std::optional<uint32_t> device_id) {
 #if HAS_CUDA_WORKQUEUE_SUPPORT()
+  int driver_version;
+  C10_CUDA_CHECK(cudaDriverGetVersion(&driver_version));
+  TORCH_CHECK(
+      driver_version >= 13010, "cuda driver too old to use workqueue configuration!");
   if (!device_id.has_value()) {
     device_id = at::cuda::current_device();
   }

--- a/aten/src/ATen/cuda/CUDAGreenContext.h
+++ b/aten/src/ATen/cuda/CUDAGreenContext.h
@@ -48,7 +48,7 @@ class TORCH_CUDA_CPP_API GreenContext {
     std::optional<uint32_t> num_sms,
     std::optional<int32_t> workqueue_scope,
     std::optional<uint32_t> workqueue_concurrency_limit);
-  
+
   // Implement move operations
   GreenContext(GreenContext&& other) noexcept;
   GreenContext& operator=(GreenContext&& other) noexcept;

--- a/aten/src/ATen/cuda/CUDAGreenContext.h
+++ b/aten/src/ATen/cuda/CUDAGreenContext.h
@@ -11,12 +11,24 @@ namespace {
   constexpr int kStreamPerGreenContextPool = 32;
 }
 
+// Workqueue sharing scope for green contexts.
+// Values match the CUDA driver API's CUdevWorkqueueConfigScope enum.
+enum class WorkqueueScope : int32_t {
+  DeviceCtx = 0,
+  Balanced = 1,
+};
+
 class TORCH_CUDA_CPP_API GreenContext {
  public:
-  // Green context creation
   static std::unique_ptr<GreenContext> create(
-      uint32_t num_sms,
-      std::optional<uint32_t> device_id);
+    std::optional<uint32_t> device_id,
+    std::optional<uint32_t> num_sms,
+    std::optional<int32_t> workqueue_scope = std::nullopt,
+    std::optional<uint32_t> workqueue_concurrency_limit = std::nullopt);
+
+  static uint32_t max_workqueue_concurrency(
+      std::optional<uint32_t> device_id = std::nullopt);
+
   ~GreenContext() noexcept;
 
   // Delete copy constructor and assignment
@@ -31,7 +43,12 @@ class TORCH_CUDA_CPP_API GreenContext {
   CUDAStream Stream();
 
  private:
-  GreenContext(uint32_t device_id, uint32_t num_sms);
+  GreenContext(
+    uint32_t device_id,
+    std::optional<uint32_t> num_sms,
+    std::optional<int32_t> workqueue_scope,
+    std::optional<uint32_t> workqueue_concurrency_limit);
+  
   // Implement move operations
   GreenContext(GreenContext&& other) noexcept;
   GreenContext& operator=(GreenContext&& other) noexcept;

--- a/c10/cuda/driver_api.h
+++ b/c10/cuda/driver_api.h
@@ -73,6 +73,7 @@
 #define C10_LIBCUDA_DRIVER_API_OPTIONAL(_) \
   _(cuCtxFromGreenCtx, 12080)              \
   _(cuCtxGetCurrent, 12080)                \
+  _(cuCtxGetDevResource, 12080)            \
   _(cuCtxPopCurrent, 12080)                \
   _(cuCtxPushCurrent, 12080)               \
   _(cuCtxSetCurrent, 12080)                \

--- a/c10/cuda/driver_api.h
+++ b/c10/cuda/driver_api.h
@@ -73,7 +73,6 @@
 #define C10_LIBCUDA_DRIVER_API_OPTIONAL(_) \
   _(cuCtxFromGreenCtx, 12080)              \
   _(cuCtxGetCurrent, 12080)                \
-  _(cuCtxGetDevResource, 12080)            \
   _(cuCtxPopCurrent, 12080)                \
   _(cuCtxPushCurrent, 12080)               \
   _(cuCtxSetCurrent, 12080)                \

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -8582,7 +8582,9 @@ class TestFXMemoryProfiler(TestCase):
                 self.assertIn("e = self.relu(d)", frame["fx_original_trace"])
 
 
-@unittest.skipIf(not PLATFORM_SUPPORTS_GREEN_CONTEXT, "Green contexts are not supported")
+@unittest.skipIf(
+    not PLATFORM_SUPPORTS_GREEN_CONTEXT, "Green contexts are not supported"
+)
 class TestCudaGreenContexts(TestCase):
     def setUp(self):
         super().setUp()
@@ -8593,7 +8595,7 @@ class TestCudaGreenContexts(TestCase):
     @serialTest()
     def test_greencontext_carveout(self):
         # By default, everything is performed on the current device
-        a = torch.randn(4096, 4096, device='cuda', dtype=torch.bfloat16)
+        a = torch.randn(4096, 4096, device="cuda", dtype=torch.bfloat16)
         ctx = torch.cuda.green_contexts.GreenContext.create(num_sms=1)
         ctx.set_context()
         torch.matmul(a, a)
@@ -8615,7 +8617,7 @@ class TestCudaGreenContexts(TestCase):
     @serialTest()
     def test_greencontext_stream_carveout(self):
         # By default, everything is performed on the current device
-        a = torch.randn(4096, 4096, device='cuda', dtype=torch.bfloat16)
+        a = torch.randn(4096, 4096, device="cuda", dtype=torch.bfloat16)
         ctx = torch.cuda.green_contexts.GreenContext.create(num_sms=1)
         ctx_stream = ctx.Stream()
         with torch.cuda.stream(ctx_stream):
@@ -8637,7 +8639,7 @@ class TestCudaGreenContexts(TestCase):
     @serialTest()
     def test_greencontext_graphs(self):
         # By default, everything is performed on the current device
-        a = torch.randn(4096, 4096, device='cuda', dtype=torch.bfloat16)
+        a = torch.randn(4096, 4096, device="cuda", dtype=torch.bfloat16)
         ctx = torch.cuda.green_contexts.GreenContext.create(num_sms=1)
         ctx.set_context()
         partial_res = torch.matmul(a, a)
@@ -8656,7 +8658,9 @@ class TestCudaGreenContexts(TestCase):
         g.replay()
         self.assertEqual(partial_res, full_res)
 
-    @unittest.skipIf(not PLATFORM_SUPPORTS_WORKQUEUE_CONFIG, "Workqueue config is not supported")
+    @unittest.skipIf(
+        not PLATFORM_SUPPORTS_WORKQUEUE_CONFIG, "Workqueue config is not supported"
+    )
     @serialTest()
     def test_greencontext_workqueue_concurrency_limit(self):
         # By default, everything is performed on the current device
@@ -8664,7 +8668,9 @@ class TestCudaGreenContexts(TestCase):
         GreenContext = torch.cuda.green_contexts.GreenContext
         max_wq = GreenContext.max_workqueue_concurrency()
         if max_wq < n_streams:
-            self.skipTest(f"Device has {max_wq} workqueue(s), need >{n_streams} to test concurrency limiting")
+            self.skipTest(
+                f"Device has {max_wq} workqueue(s), need >{n_streams} to test concurrency limiting"
+            )
 
         wq_events = [torch.cuda.Event(enable_timing=True) for _ in range(n_streams * 2)]
 

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -8579,7 +8579,7 @@ class TestCudaGreenContexts(TestCase):
         s = torch.cuda.Stream()
         with torch.cuda.stream(s):
             start_stream = torch.cuda.current_stream()
-            ctx = torch.cuda.green_contexts.GreenContext.create(n_sms=1)
+            ctx = torch.cuda.green_contexts.GreenContext.create(num_sms=1)
             ctx.set_context()
             context_stream = torch.cuda.current_stream()
             ctx.pop_context()

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -7245,25 +7245,6 @@ class TestCudaOptims(TestCase):
             self.assertEqual(scaler._growth_tracker, growth_tracker)
 
 
-@unittest.skipIf(
-    not PLATFORM_SUPPORTS_GREEN_CONTEXT, "Green context not available, skipping tests"
-)
-class TestGreenContext(TestCase):
-    def test_greencontext_restores_stream(self):
-        # need to start on a side stream as we are comparing pointers and want to avoid
-        # two NULL streams...
-        s = torch.cuda.Stream()
-        with torch.cuda.stream(s):
-            start_stream = torch.cuda.current_stream()
-            ctx = torch.cuda.green_contexts.GreenContext.create(1, 0)
-            ctx.set_context()
-            context_stream = torch.cuda.current_stream()
-            ctx.pop_context()
-            end_stream = torch.cuda.current_stream()
-            self.assertEqual(start_stream.cuda_stream, end_stream.cuda_stream)
-            self.assertNotEqual(start_stream.cuda_stream, context_stream.cuda_stream)
-
-
 @unittest.skipIf(not TEST_CUDA, "CUDA not available, skipping tests")
 class TestGDS(TestCase):
     def _get_tmp_dir_fs_type(self):
@@ -8591,6 +8572,20 @@ class TestCudaGreenContexts(TestCase):
 
     def tearDown(self):
         super().tearDown()
+
+    def test_greencontext_restores_stream(self):
+        # need to start on a side stream as we are comparing pointers and want to avoid
+        # two NULL streams...
+        s = torch.cuda.Stream()
+        with torch.cuda.stream(s):
+            start_stream = torch.cuda.current_stream()
+            ctx = torch.cuda.green_contexts.GreenContext.create(n_sms=1)
+            ctx.set_context()
+            context_stream = torch.cuda.current_stream()
+            ctx.pop_context()
+            end_stream = torch.cuda.current_stream()
+            self.assertEqual(start_stream.cuda_stream, end_stream.cuda_stream)
+            self.assertNotEqual(start_stream.cuda_stream, context_stream.cuda_stream)
 
     @serialTest()
     def test_greencontext_carveout(self):

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -38,6 +38,7 @@ from torch.testing._internal.common_cuda import (
     _get_torch_cuda_version,
     blas_library_context,
     PLATFORM_SUPPORTS_GREEN_CONTEXT,
+    PLATFORM_SUPPORTS_WORKQUEUE_CONFIG,
     SM70OrLater,
     TEST_CUDNN,
     TEST_MULTIGPU,
@@ -8581,12 +8582,143 @@ class TestFXMemoryProfiler(TestCase):
                 self.assertIn("e = self.relu(d)", frame["fx_original_trace"])
 
 
+@unittest.skipIf(not PLATFORM_SUPPORTS_GREEN_CONTEXT, "Green contexts are not supported")
+class TestCudaGreenContexts(TestCase):
+    def setUp(self):
+        super().setUp()
+
+    def tearDown(self):
+        super().tearDown()
+
+    @serialTest()
+    def test_greencontext_carveout(self):
+        # By default, everything is performed on the current device
+        a = torch.randn(4096, 4096, device='cuda', dtype=torch.bfloat16)
+        ctx = torch.cuda.green_contexts.GreenContext.create(num_sms=1)
+        ctx.set_context()
+        torch.matmul(a, a)
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+        partial_res = torch.matmul(a, a)
+        torch.cuda.synchronize()
+        t1 = time.perf_counter()
+        ctx.pop_context()
+        torch.matmul(a, a)
+        torch.cuda.synchronize()
+        t2 = time.perf_counter()
+        full_res = torch.matmul(a, a)
+        torch.cuda.synchronize()
+        t3 = time.perf_counter()
+        self.assertEqual(partial_res, full_res)
+        self.assertGreater(t1 - t0, t3 - t2)
+
+    @serialTest()
+    def test_greencontext_stream_carveout(self):
+        # By default, everything is performed on the current device
+        a = torch.randn(4096, 4096, device='cuda', dtype=torch.bfloat16)
+        ctx = torch.cuda.green_contexts.GreenContext.create(num_sms=1)
+        ctx_stream = ctx.Stream()
+        with torch.cuda.stream(ctx_stream):
+            torch.matmul(a, a)
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+            partial_res = torch.matmul(a, a)
+            torch.cuda.synchronize()
+            t1 = time.perf_counter()
+        torch.matmul(a, a)
+        torch.cuda.synchronize()
+        t2 = time.perf_counter()
+        full_res = torch.matmul(a, a)
+        torch.cuda.synchronize()
+        t3 = time.perf_counter()
+        self.assertEqual(partial_res, full_res)
+        self.assertGreater(t1 - t0, t3 - t2)
+
+    @serialTest()
+    def test_greencontext_graphs(self):
+        # By default, everything is performed on the current device
+        a = torch.randn(4096, 4096, device='cuda', dtype=torch.bfloat16)
+        ctx = torch.cuda.green_contexts.GreenContext.create(num_sms=1)
+        ctx.set_context()
+        partial_res = torch.matmul(a, a)
+        ctx.pop_context()
+        full_res = torch.matmul(a, a)
+        full_res.zero_()
+        partial_res.zero_()
+        torch.cuda.synchronize()
+
+        g = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(g):
+            ctx.set_context()
+            partial_res = torch.matmul(a, a)
+            ctx.pop_context()
+            full_res = torch.matmul(a, a)
+        g.replay()
+        self.assertEqual(partial_res, full_res)
+
+    @unittest.skipIf(not PLATFORM_SUPPORTS_WORKQUEUE_CONFIG, "Workqueue config is not supported")
+    @serialTest()
+    def test_greencontext_workqueue_concurrency_limit(self):
+        # By default, everything is performed on the current device
+        n_streams = 4
+        GreenContext = torch.cuda.green_contexts.GreenContext
+        max_wq = GreenContext.max_workqueue_concurrency()
+        if max_wq < n_streams:
+            self.skipTest(f"Device has {max_wq} workqueue(s), need >{n_streams} to test concurrency limiting")
+
+        wq_events = [torch.cuda.Event(enable_timing=True) for _ in range(n_streams * 2)]
+
+        def run_multi_stream_sleep(streams):
+            for i, s in enumerate(streams):
+                with torch.cuda.stream(s):
+                    # note we need to record timing events to ensure that the
+                    # workqueue is actually used
+                    wq_events[i * 2].record(s)
+                    # 100M cycles is enough on all currently supported GPUs
+                    # to ensure that the test runs significantly longer than
+                    # host overhead to 1) activate the different streams,
+                    # 2) record timing events, and 3) synchronize with the GPU.
+                    torch.cuda._sleep(100_000_000)
+                    wq_events[i * 2 + 1].record(s)
+            torch.cuda.synchronize()
+
+        # Note: in case we have lazy module loading, ensure that we called the
+        # sleep kernel at least once s.t. it is loaded in memory.
+        torch.cuda._sleep(1_000)
+
+        # Baseline: n_streams streams from default context, full workqueue concurrency
+        baseline_streams = [torch.cuda.Stream() for _ in range(n_streams)]
+        # note: torch.cuda.synchronize() will wait for all kernels on all streams
+        # so we can safely use CPU based timing here.
+        t0 = time.perf_counter()
+        run_multi_stream_sleep(baseline_streams)
+        t1 = time.perf_counter()
+        baseline_time = t1 - t0
+
+        # Green context with workqueue concurrency limited to 1
+        ctx = GreenContext.create(
+            workqueue_scope="balanced",
+            workqueue_concurrency_limit=1,
+        )
+        ctx.set_context()
+        green_streams = [ctx.Stream() for _ in range(n_streams)]
+        t2 = time.perf_counter()
+        run_multi_stream_sleep(green_streams)
+        t3 = time.perf_counter()
+        ctx.pop_context()
+        limited_time = t3 - t2
+
+        self.assertGreater(limited_time, baseline_time)
+
+
 instantiate_parametrized_tests(TestCuda)
 instantiate_parametrized_tests(TestCudaAllocator)
 instantiate_parametrized_tests(TestCompileKernel)
 instantiate_parametrized_tests(TestCachingHostAllocatorCudaGraph)
 instantiate_device_type_tests(TestCudaOptims, globals())
 instantiate_device_type_tests(TestCudaDeviceParametrized, globals())
+instantiate_device_type_tests(TestCudaGreenContexts, globals(), except_for="cpu")
+
 
 if __name__ == "__main__":
     run_tests()

--- a/test/test_matmul_cuda.py
+++ b/test/test_matmul_cuda.py
@@ -22,6 +22,7 @@ from torch.testing._internal.common_cuda import (
     blas_library_context,
     PLATFORM_SUPPORTS_BF16,
     PLATFORM_SUPPORTS_GREEN_CONTEXT,
+    PLATFORM_SUPPORTS_WORKQUEUE_CONFIG,
     SM80OrLater,
     SM90OrLater,
     SM100OrLater,
@@ -1009,7 +1010,7 @@ class TestMatmulCuda(InductorTestCase):
     @serialTest()
     def test_greencontext_carveout(self):
         a = torch.randn(4096, 4096, device='cuda', dtype=torch.bfloat16)
-        ctx = torch.cuda.green_contexts.GreenContext.create(1, 0)
+        ctx = torch.cuda.green_contexts.GreenContext.create(num_sms=1, device_id=0)
         ctx.set_context()
         torch.matmul(a, a)
         torch.cuda.synchronize()
@@ -1031,7 +1032,7 @@ class TestMatmulCuda(InductorTestCase):
     @serialTest()
     def test_greencontext_stream_carveout(self):
         a = torch.randn(4096, 4096, device='cuda', dtype=torch.bfloat16)
-        ctx = torch.cuda.green_contexts.GreenContext.create(1, 0)
+        ctx = torch.cuda.green_contexts.GreenContext.create(num_sms=1, device_id=0)
         ctx_stream = ctx.Stream()
         with torch.cuda.stream(ctx_stream):
             torch.matmul(a, a)
@@ -1053,7 +1054,7 @@ class TestMatmulCuda(InductorTestCase):
     @serialTest()
     def test_greencontext_graphs(self):
         a = torch.randn(4096, 4096, device='cuda', dtype=torch.bfloat16)
-        ctx = torch.cuda.green_contexts.GreenContext.create(1, 0)
+        ctx = torch.cuda.green_contexts.GreenContext.create(num_sms=1, device_id=0)
         ctx.set_context()
         partial_res = torch.matmul(a, a)
         ctx.pop_context()
@@ -1070,6 +1071,54 @@ class TestMatmulCuda(InductorTestCase):
             full_res = torch.matmul(a, a)
         g.replay()
         self.assertEqual(partial_res, full_res)
+
+    @unittest.skipIf(not PLATFORM_SUPPORTS_WORKQUEUE_CONFIG, "Workqueue config is not supported")
+    @serialTest()
+    def test_greencontext_workqueue_concurrency_limit(self):
+        GreenContext = torch.cuda.green_contexts.GreenContext
+        max_wq = GreenContext.max_workqueue_concurrency(device_id=0)
+        if max_wq <= 1:
+            self.skipTest(f"Device has {max_wq} workqueue(s), need >1 to test concurrency limiting")
+
+        n_streams = 8
+        inputs = [torch.randn(256, 256, device='cuda', dtype=torch.bfloat16) for _ in range(n_streams)]
+
+        def run_multi_stream_matmuls(streams):
+            results = [None] * n_streams
+            for i, s in enumerate(streams):
+                with torch.cuda.stream(s):
+                    results[i] = torch.matmul(inputs[i], inputs[i])
+            torch.cuda.synchronize()
+            return results
+
+        # Baseline: 8 streams from default context, full workqueue concurrency
+        baseline_streams = [torch.cuda.Stream() for _ in range(n_streams)]
+        run_multi_stream_matmuls(baseline_streams)  # warmup
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+        baseline_results = run_multi_stream_matmuls(baseline_streams)
+        t1 = time.perf_counter()
+        baseline_time = t1 - t0
+
+        # Green context with workqueue concurrency limited to 1
+        ctx = GreenContext.create(
+            workqueue_scope="balanced",
+            workqueue_concurrency_limit=1,
+            device_id=0,
+        )
+        ctx.set_context()
+        green_streams = [ctx.Stream() for _ in range(n_streams)]
+        run_multi_stream_matmuls(green_streams)  # warmup
+        torch.cuda.synchronize()
+        t2 = time.perf_counter()
+        limited_results = run_multi_stream_matmuls(green_streams)
+        t3 = time.perf_counter()
+        ctx.pop_context()
+        limited_time = t3 - t2
+
+        for baseline_r, limited_r in zip(baseline_results, limited_results):
+            self.assertEqual(baseline_r, limited_r)
+        self.assertGreater(limited_time, baseline_time)
 
 
 @unittest.skipIf(TEST_WITH_ROCM, "ROCm doesn't support CUTLASS")

--- a/test/test_matmul_cuda.py
+++ b/test/test_matmul_cuda.py
@@ -2,7 +2,6 @@
 
 import contextlib
 import os
-import time
 import unittest
 from itertools import product
 from functools import partial
@@ -21,8 +20,6 @@ from torch.testing import make_tensor
 from torch.testing._internal.common_cuda import (
     blas_library_context,
     PLATFORM_SUPPORTS_BF16,
-    PLATFORM_SUPPORTS_GREEN_CONTEXT,
-    PLATFORM_SUPPORTS_WORKQUEUE_CONFIG,
     SM80OrLater,
     SM90OrLater,
     SM100OrLater,
@@ -1004,126 +1001,6 @@ class TestMatmulCuda(InductorTestCase):
                     op(c, a, mismatch_batch_dim_b, out_dtype=torch.float32)
                 else:
                     op(a, mismatch_batch_dim_b, out_dtype=torch.float32)
-
-
-    @unittest.skipIf(not PLATFORM_SUPPORTS_GREEN_CONTEXT, "Green contexts are not supported")
-    @serialTest()
-    def test_greencontext_carveout(self):
-        a = torch.randn(4096, 4096, device='cuda', dtype=torch.bfloat16)
-        ctx = torch.cuda.green_contexts.GreenContext.create(num_sms=1, device_id=0)
-        ctx.set_context()
-        torch.matmul(a, a)
-        torch.cuda.synchronize()
-        t0 = time.perf_counter()
-        partial_res = torch.matmul(a, a)
-        torch.cuda.synchronize()
-        t1 = time.perf_counter()
-        ctx.pop_context()
-        torch.matmul(a, a)
-        torch.cuda.synchronize()
-        t2 = time.perf_counter()
-        full_res = torch.matmul(a, a)
-        torch.cuda.synchronize()
-        t3 = time.perf_counter()
-        self.assertEqual(partial_res, full_res)
-        self.assertGreater(t1 - t0, t3 - t2)
-
-    @unittest.skipIf(not PLATFORM_SUPPORTS_GREEN_CONTEXT, "Green contexts are not supported")
-    @serialTest()
-    def test_greencontext_stream_carveout(self):
-        a = torch.randn(4096, 4096, device='cuda', dtype=torch.bfloat16)
-        ctx = torch.cuda.green_contexts.GreenContext.create(num_sms=1, device_id=0)
-        ctx_stream = ctx.Stream()
-        with torch.cuda.stream(ctx_stream):
-            torch.matmul(a, a)
-            torch.cuda.synchronize()
-            t0 = time.perf_counter()
-            partial_res = torch.matmul(a, a)
-            torch.cuda.synchronize()
-            t1 = time.perf_counter()
-        torch.matmul(a, a)
-        torch.cuda.synchronize()
-        t2 = time.perf_counter()
-        full_res = torch.matmul(a, a)
-        torch.cuda.synchronize()
-        t3 = time.perf_counter()
-        self.assertEqual(partial_res, full_res)
-        self.assertGreater(t1 - t0, t3 - t2)
-
-    @unittest.skipIf(not PLATFORM_SUPPORTS_GREEN_CONTEXT, "Green contexts are not supported")
-    @serialTest()
-    def test_greencontext_graphs(self):
-        a = torch.randn(4096, 4096, device='cuda', dtype=torch.bfloat16)
-        ctx = torch.cuda.green_contexts.GreenContext.create(num_sms=1, device_id=0)
-        ctx.set_context()
-        partial_res = torch.matmul(a, a)
-        ctx.pop_context()
-        full_res = torch.matmul(a, a)
-        full_res.zero_()
-        partial_res.zero_()
-        torch.cuda.synchronize()
-
-        g = torch.cuda.CUDAGraph()
-        with torch.cuda.graph(g):
-            ctx.set_context()
-            partial_res = torch.matmul(a, a)
-            ctx.pop_context()
-            full_res = torch.matmul(a, a)
-        g.replay()
-        self.assertEqual(partial_res, full_res)
-
-    @unittest.skipIf(not PLATFORM_SUPPORTS_WORKQUEUE_CONFIG, "Workqueue config is not supported")
-    @serialTest()
-    def test_greencontext_workqueue_concurrency_limit(self):
-        # Note: this test simply tests green context workqueue concurrency limiting,
-        # It doesn't test matmuls specifically, but is kept here along with other
-        # green context functional tests.
-        n_streams = 4
-        GreenContext = torch.cuda.green_contexts.GreenContext
-        max_wq = GreenContext.max_workqueue_concurrency(device_id=0)
-        if max_wq < n_streams:
-            self.skipTest(f"Device has {max_wq} workqueue(s), need >{n_streams} to test concurrency limiting")
-
-        wq_events = [torch.cuda.Event(enable_timing=True) for _ in range(n_streams * 2)]
-
-        def run_multi_stream_sleep(streams):
-            for i, s in enumerate(streams):
-                with torch.cuda.stream(s):
-                    # note we need to record timing events to ensure that the
-                    # workqueue is actually used
-                    wq_events[i * 2].record(s)
-                    # 100M cycles is enough on all currently supported GPUs
-                    # to ensure that the test runs significantly longer than
-                    # host overhead to 1) activate the different streams,
-                    # 2) record timing events, and 3) synchronize with the GPU.
-                    torch.cuda._sleep(100_000_000)
-                    wq_events[i * 2 + 1].record(s)
-            torch.cuda.synchronize()
-
-        # Baseline: n_streams streams from default context, full workqueue concurrency
-        baseline_streams = [torch.cuda.Stream() for _ in range(n_streams)]
-        # note: torch.cuda.synchronize() will wait for all kernels on all streams
-        # so we can safely use CPU based timing here.
-        t0 = time.perf_counter()
-        run_multi_stream_sleep(baseline_streams)
-        t1 = time.perf_counter()
-        baseline_time = t1 - t0
-
-        # Green context with workqueue concurrency limited to 1
-        ctx = GreenContext.create(
-            workqueue_scope="balanced",
-            workqueue_concurrency_limit=1,
-            device_id=0,
-        )
-        ctx.set_context()
-        green_streams = [ctx.Stream() for _ in range(n_streams)]
-        t2 = time.perf_counter()
-        run_multi_stream_sleep(green_streams)
-        t3 = time.perf_counter()
-        ctx.pop_context()
-        limited_time = t3 - t2
-
-        self.assertGreater(limited_time, baseline_time)
 
 
 @unittest.skipIf(TEST_WITH_ROCM, "ROCm doesn't support CUTLASS")

--- a/test/test_matmul_cuda.py
+++ b/test/test_matmul_cuda.py
@@ -1092,6 +1092,10 @@ class TestMatmulCuda(InductorTestCase):
                     # note we need to record timing events to ensure that the
                     # workqueue is actually used
                     wq_events[i * 2].record(s)
+                    # 100M cycles is enough on all currently supported GPUs
+                    # to ensure that the test runs significantly longer than
+                    # host overhead to 1) activate the different streams,
+                    # 2) record timing events, and 3) synchronize with the GPU.
                     torch.cuda._sleep(100_000_000)
                     wq_events[i * 2 + 1].record(s)
             torch.cuda.synchronize()

--- a/test/test_matmul_cuda.py
+++ b/test/test_matmul_cuda.py
@@ -1075,28 +1075,33 @@ class TestMatmulCuda(InductorTestCase):
     @unittest.skipIf(not PLATFORM_SUPPORTS_WORKQUEUE_CONFIG, "Workqueue config is not supported")
     @serialTest()
     def test_greencontext_workqueue_concurrency_limit(self):
+        # Note: this test simply tests green context workqueue concurrency limiting,
+        # It doesn't test matmuls specifically, but is kept here along with other
+        # green context functional tests.
+        n_streams = 4
         GreenContext = torch.cuda.green_contexts.GreenContext
         max_wq = GreenContext.max_workqueue_concurrency(device_id=0)
-        if max_wq <= 1:
-            self.skipTest(f"Device has {max_wq} workqueue(s), need >1 to test concurrency limiting")
+        if max_wq < n_streams:
+            self.skipTest(f"Device has {max_wq} workqueue(s), need >{n_streams} to test concurrency limiting")
 
-        n_streams = 8
-        inputs = [torch.randn(256, 256, device='cuda', dtype=torch.bfloat16) for _ in range(n_streams)]
+        wq_events = [torch.cuda.Event(enable_timing=True) for _ in range(n_streams * 2)]
 
-        def run_multi_stream_matmuls(streams):
-            results = [None] * n_streams
+        def run_multi_stream_sleep(streams):
             for i, s in enumerate(streams):
                 with torch.cuda.stream(s):
-                    results[i] = torch.matmul(inputs[i], inputs[i])
+                    # note we need to record timing events to ensure that the
+                    # workqueue is actually used
+                    wq_events[i * 2].record(s)
+                    torch.cuda._sleep(100_000_000)
+                    wq_events[i * 2 + 1].record(s)
             torch.cuda.synchronize()
-            return results
 
-        # Baseline: 8 streams from default context, full workqueue concurrency
+        # Baseline: n_streams streams from default context, full workqueue concurrency
         baseline_streams = [torch.cuda.Stream() for _ in range(n_streams)]
-        run_multi_stream_matmuls(baseline_streams)  # warmup
-        torch.cuda.synchronize()
+        # note: torch.cuda.synchronize() will wait for all kernels on all streams
+        # so we can safely use CPU based timing here.
         t0 = time.perf_counter()
-        baseline_results = run_multi_stream_matmuls(baseline_streams)
+        run_multi_stream_sleep(baseline_streams)
         t1 = time.perf_counter()
         baseline_time = t1 - t0
 
@@ -1108,16 +1113,12 @@ class TestMatmulCuda(InductorTestCase):
         )
         ctx.set_context()
         green_streams = [ctx.Stream() for _ in range(n_streams)]
-        run_multi_stream_matmuls(green_streams)  # warmup
-        torch.cuda.synchronize()
         t2 = time.perf_counter()
-        limited_results = run_multi_stream_matmuls(green_streams)
+        run_multi_stream_sleep(green_streams)
         t3 = time.perf_counter()
         ctx.pop_context()
         limited_time = t3 - t2
 
-        for baseline_r, limited_r in zip(baseline_results, limited_results):
-            self.assertEqual(baseline_r, limited_r)
         self.assertGreater(limited_time, baseline_time)
 
 

--- a/torch/csrc/cuda/GreenContext.cpp
+++ b/torch/csrc/cuda/GreenContext.cpp
@@ -6,8 +6,45 @@
 
 void THCPGreenContext_init(PyObject* module) {
   auto m = py::handle(module).cast<py::module>();
+
+  py::enum_<at::cuda::WorkqueueScope>(m, "_WorkqueueScope")
+      .value("device_ctx", at::cuda::WorkqueueScope::DeviceCtx)
+      .value("balanced", at::cuda::WorkqueueScope::Balanced);
+
   py::class_<at::cuda::GreenContext>(m, "_CUDAGreenContext")
-      .def_static("create", &::at::cuda::GreenContext::create)
+      .def_static(
+          "create",
+          [](std::optional<uint32_t> device_id,
+             std::optional<uint32_t> num_sms,
+             std::optional<std::string> workqueue_scope,
+             std::optional<uint32_t> workqueue_concurrency_limit) {
+            std::optional<int32_t> scope;
+            if (workqueue_scope.has_value()) {
+              const auto& s = *workqueue_scope;
+              if (s == "device_ctx") {
+                scope = static_cast<int32_t>(
+                  at::cuda::WorkqueueScope::DeviceCtx);
+              } else if (s == "balanced") {
+                scope = static_cast<int32_t>(
+                  at::cuda::WorkqueueScope::Balanced);
+              } else {
+                throw std::invalid_argument(
+                    "workqueue_scope must be 'device_ctx' or 'balanced', got '" +
+                    s + "'");
+              }
+            }
+            return at::cuda::GreenContext::create(
+                device_id, num_sms, scope, workqueue_concurrency_limit);
+          },
+          py::kw_only(),
+          py::arg("device_id") = py::none(),
+          py::arg("num_sms") = py::none(),
+          py::arg("workqueue_scope") = py::none(),
+          py::arg("workqueue_concurrency_limit") = py::none())
+      .def_static(
+          "max_workqueue_concurrency",
+          &at::cuda::GreenContext::max_workqueue_concurrency,
+          py::arg("device_id") = py::none())
       .def("set_context", &::at::cuda::GreenContext::setContext)
       .def("pop_context", &::at::cuda::GreenContext::popContext)
       .def("Stream", [](at::cuda::GreenContext& self) {

--- a/torch/csrc/cuda/GreenContext.cpp
+++ b/torch/csrc/cuda/GreenContext.cpp
@@ -22,11 +22,11 @@ void THCPGreenContext_init(PyObject* module) {
             if (workqueue_scope.has_value()) {
               const auto& s = *workqueue_scope;
               if (s == "device_ctx") {
-                scope = static_cast<int32_t>(
-                  at::cuda::WorkqueueScope::DeviceCtx);
+                scope =
+                    static_cast<int32_t>(at::cuda::WorkqueueScope::DeviceCtx);
               } else if (s == "balanced") {
-                scope = static_cast<int32_t>(
-                  at::cuda::WorkqueueScope::Balanced);
+                scope =
+                    static_cast<int32_t>(at::cuda::WorkqueueScope::Balanced);
               } else {
                 throw std::invalid_argument(
                     "workqueue_scope must be 'device_ctx' or 'balanced', got '" +

--- a/torch/cuda/green_contexts.py
+++ b/torch/cuda/green_contexts.py
@@ -1,4 +1,3 @@
-
 import torch
 
 

--- a/torch/cuda/green_contexts.py
+++ b/torch/cuda/green_contexts.py
@@ -2,6 +2,9 @@ from typing import Optional
 
 import torch
 
+__all__ = [
+    "GreenContext",
+]
 
 _GreenContext = object
 SUPPORTED = False

--- a/torch/cuda/green_contexts.py
+++ b/torch/cuda/green_contexts.py
@@ -89,6 +89,6 @@ class GreenContext(_GreenContext):
         """
         return super().pop_context()  # type: ignore[misc]
 
-    def Stream(self) -> torch.cuda.Stream:
+    def Stream(self) -> "torch.cuda.Stream":
         r"""Return the CUDA Stream used by the green context."""
         return super().Stream()

--- a/torch/cuda/green_contexts.py
+++ b/torch/cuda/green_contexts.py
@@ -1,4 +1,3 @@
-from typing import Optional
 
 import torch
 
@@ -27,10 +26,10 @@ class GreenContext(_GreenContext):
     @staticmethod
     def create(
         *,
-        num_sms: Optional[int] = None,
-        workqueue_scope: Optional[str] = None,
-        workqueue_concurrency_limit: Optional[int] = None,
-        device_id: Optional[int] = None,
+        num_sms: int | None = None,
+        workqueue_scope: str | None = None,
+        workqueue_concurrency_limit: int | None = None,
+        device_id: int | None = None,
     ) -> _GreenContext:
         r"""Create a CUDA green context.
 
@@ -62,7 +61,7 @@ class GreenContext(_GreenContext):
         )
 
     @staticmethod
-    def max_workqueue_concurrency(device_id: Optional[int] = None) -> int:
+    def max_workqueue_concurrency(device_id: int | None = None) -> int:
         r"""Return the maximum workqueue concurrency limit for the device.
 
         This queries the device for the default number of concurrent

--- a/torch/cuda/green_contexts.py
+++ b/torch/cuda/green_contexts.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 import torch
 
+
 __all__ = [
     "GreenContext",
 ]
@@ -88,6 +89,6 @@ class GreenContext(_GreenContext):
         """
         return super().pop_context()  # type: ignore[misc]
 
-    def Stream(self) -> torch.Stream:
+    def Stream(self) -> torch.cuda.Stream:
         r"""Return the CUDA Stream used by the green context."""
         return super().Stream()

--- a/torch/cuda/green_contexts.py
+++ b/torch/cuda/green_contexts.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import torch
 
 
@@ -19,18 +21,59 @@ class GreenContext(_GreenContext):
     """
 
     @staticmethod
-    def create(num_sms: int, device_id: int = 0) -> _GreenContext:
+    def create(
+        *,
+        num_sms: Optional[int] = None,
+        workqueue_scope: Optional[str] = None,
+        workqueue_concurrency_limit: Optional[int] = None,
+        device_id: Optional[int] = None,
+    ) -> _GreenContext:
         r"""Create a CUDA green context.
 
+        At least one of ``num_sms`` or ``workqueue_scope`` must be specified.
+        Both can be combined to partition SMs and configure workqueues in the
+        same green context.
+
         Arguments:
-            num_sms (int): The number of SMs to use in the green context.
+            num_sms (int, optional): The number of SMs to use in the green
+                context. When ``None``, SMs are not partitioned.
+            workqueue_scope (str, optional): Workqueue sharing scope. One of
+                ``"device_ctx"`` (shared across all contexts, default driver
+                behaviour) or ``"balanced"`` (non-overlapping workqueues with
+                other balanced green contexts). When ``None``, no workqueue
+                configuration is applied.
+            workqueue_concurrency_limit (int, optional): Maximum number of
+                concurrent stream-ordered workloads for the workqueue. Requires
+                ``workqueue_scope`` to be set.
             device_id (int, optional): The device index of green context.
+                When ``None``, the current device is used.
         """
         if not SUPPORTED:
             raise RuntimeError("PyTorch was not built with Green Context support!")
-        return _GreenContext.create(num_sms, device_id)  # type: ignore[attr-defined]
+        return _GreenContext.create(  # type: ignore[attr-defined]
+            device_id=device_id,
+            num_sms=num_sms,
+            workqueue_scope=workqueue_scope,
+            workqueue_concurrency_limit=workqueue_concurrency_limit,
+        )
 
-    # Note that these functions are bypassed by we define them here
+    @staticmethod
+    def max_workqueue_concurrency(device_id: Optional[int] = None) -> int:
+        r"""Return the maximum workqueue concurrency limit for the device.
+
+        This queries the device for the default number of concurrent
+        stream-ordered workloads supported by workqueue configuration
+        resources.
+
+        Arguments:
+            device_id (int, optional): The device index to query. When
+                ``None``, the current device is used.
+        """
+        if not SUPPORTED:
+            raise RuntimeError("PyTorch was not built with Green Context support!")
+        return _GreenContext.max_workqueue_concurrency(device_id=device_id)  # type: ignore[attr-defined]
+
+    # Note that these functions are bypassed but we define them here
     # for Sphinx documentation purposes
     def set_context(self) -> None:  # pylint: disable=useless-parent-delegation
         r"""Make the green context the current context."""

--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -148,7 +148,7 @@ def evaluate_platform_supports_workqueue_config():
     driver_version = torch.utils.collect_env.get_nvidia_driver_version(torch.utils.collect_env.run)
     if driver_version is None:
         return False
-    return int(driver_version.split('.')[0]) >= 575
+    return int(driver_version.split('.')[0]) >= 590
 
 PLATFORM_SUPPORTS_WORKQUEUE_CONFIG: bool = LazyVal(lambda: evaluate_platform_supports_workqueue_config())
 

--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -140,6 +140,18 @@ PLATFORM_SUPPORTS_HALF_ATOMICS: bool = LazyVal(lambda: evaluate_platform_support
 
 PLATFORM_SUPPORTS_GREEN_CONTEXT: bool = LazyVal(lambda: evaluate_platform_supports_green_context())
 
+def evaluate_platform_supports_workqueue_config():
+    if IS_WINDOWS:
+        return False
+    if not _get_torch_cuda_version() >= (13, 1):
+        return False
+    driver_version = torch.utils.collect_env.get_nvidia_driver_version(torch.utils.collect_env.run)
+    if driver_version is None:
+        return False
+    return int(driver_version.split('.')[0]) >= 575
+
+PLATFORM_SUPPORTS_WORKQUEUE_CONFIG: bool = LazyVal(lambda: evaluate_platform_supports_workqueue_config())
+
 def evaluate_platform_supports_fp8():
     if torch.cuda.is_available():
         if torch.version.hip:


### PR DESCRIPTION
This PR adds experimental support for specifying a workqueue limit for CUDA green contexts, see issue https://github.com/pytorch/pytorch/issues/176582