### PR TITLE
[CUDA] Annotate elementwise kernel functors with a constexpr boolean indicating whether they are simple

### DIFF
--- a/aten/src/ATen/native/cuda/AbsKernel.cu
+++ b/aten/src/ATen/native/cuda/AbsKernel.cu
@@ -10,6 +10,15 @@ namespace at::native {
 
 template<typename scalar_t>
 struct AbsFunctor {
+  // only complex types are non-simple lambdas
+  // note: c10::Half is technically unnecessary here,
+  // but added in case opmath_type changes in the future.
+  template <int /*cc_major*/, int /*cc_minor*/>
+  static constexpr bool is_simple =
+    !(std::is_same_v<scalar_t, c10::complex<float>> ||
+    std::is_same_v<scalar_t, c10::complex<double>> ||
+    std::is_same_v<scalar_t, c10::complex<c10::Half>>);
+
   __device__ __forceinline__ scalar_t operator() (const scalar_t a) const {
     return std::abs(a);
   }

--- a/aten/src/ATen/native/cuda/ActivationHardshrinkKernel.cu
+++ b/aten/src/ATen/native/cuda/ActivationHardshrinkKernel.cu
@@ -19,6 +19,22 @@
 namespace at::native {
 namespace {
 
+template <typename scalar_t>
+struct HardshrinkFunctor {
+  // only double not simple + bf16 for SM 75-
+  template <int cc_major, int /*cc_minor*/>
+  static constexpr bool is_simple =
+    !(std::is_same_v<scalar_t, double> ||
+      (cc_major < 8 && std::is_same_v<scalar_t, c10::BFloat16>));
+
+  GPU_LAMBDA scalar_t operator() (const scalar_t a) const {
+    return (a >= -lambd && a <= lambd) ? scalar_t(0) : a;
+  }
+  HardshrinkFunctor(scalar_t lambd_) : lambd(lambd_) {}
+  private:
+  scalar_t lambd;
+};
+
 void hardshrink_kernel(TensorIteratorBase& iter, const Scalar& value) {
   AT_DISPATCH_FLOATING_TYPES_AND2(
       at::ScalarType::Half,
@@ -26,10 +42,8 @@ void hardshrink_kernel(TensorIteratorBase& iter, const Scalar& value) {
       iter.dtype(),
       "hardshrink_cuda",
       [&]() {
-        auto lambd = value.to<scalar_t>();
-        gpu_kernel(iter, [lambd] GPU_LAMBDA(scalar_t a) -> scalar_t {
-          return (a >= -lambd && a <= lambd) ? scalar_t(0) : a;
-        });
+        auto functor = HardshrinkFunctor<scalar_t>(value.to<scalar_t>());
+        gpu_kernel(iter, functor);
       });
 }
 } // namespace

--- a/aten/src/ATen/native/cuda/ActivationHardsigmoidKernel.cu
+++ b/aten/src/ATen/native/cuda/ActivationHardsigmoidKernel.cu
@@ -19,6 +19,24 @@
 namespace at::native {
 namespace {
 
+template <typename scalar_t, typename opmath_t>
+struct HardsigmoidFunctor {
+  // only double not simple + bf16 for SM 75-
+  template <int cc_major, int /*cc_minor*/>
+  static constexpr bool is_simple =
+    !(std::is_same_v<scalar_t, double> ||
+     (cc_major < 8 && std::is_same_v<scalar_t, c10::BFloat16>));
+
+  GPU_LAMBDA scalar_t operator() (const scalar_t self_val) const {
+    constexpr opmath_t zero = opmath_t(0.0f);
+    constexpr opmath_t one_sixth = opmath_t(1.0f / 6.0f);
+    constexpr opmath_t three = opmath_t(3.0f);
+    constexpr opmath_t six = opmath_t(6.0f);
+    opmath_t x = static_cast<opmath_t>(self_val);
+    return std::min<opmath_t>(std::max<opmath_t>(x + three, zero), six) * one_sixth;
+  }
+};
+
 void hardsigmoid_kernel(TensorIteratorBase& iter) {
   AT_DISPATCH_FLOATING_TYPES_AND2(
       at::ScalarType::Half,
@@ -27,19 +45,31 @@ void hardsigmoid_kernel(TensorIteratorBase& iter) {
       "hardsigmoid_cuda",
       [&]() {
         using opmath_t = at::opmath_type<scalar_t>;
-        const opmath_t zero(0.0f);
-        const opmath_t one_sixth(1.0f / 6.0f);
-        const opmath_t three(3.0f);
-        const opmath_t six(6.0f);
-        gpu_kernel(
-            iter,
-            [zero, one_sixth, three, six] GPU_LAMBDA(
-                scalar_t self_val) -> scalar_t {
-              opmath_t x = static_cast<opmath_t>(self_val);
-              return std::min<opmath_t>(std::max<opmath_t>(x + three, zero), six) * one_sixth;
-            });
+        auto functor = HardsigmoidFunctor<scalar_t, opmath_t>();
+        gpu_kernel(iter, functor);
       });
 }
+
+template <typename scalar_t, typename opmath_t>
+struct HardsigmoidBackwardFunctor {
+  // only double not simple + bf16 for SM 75-
+  template <int cc_major, int /*cc_minor*/>
+  static constexpr bool is_simple =
+    !(std::is_same_v<scalar_t, double> ||
+     (cc_major < 8 && std::is_same_v<scalar_t, c10::BFloat16>));
+
+  GPU_LAMBDA scalar_t operator() (const scalar_t grad_val_, const scalar_t self_val_) const {
+    constexpr opmath_t zero = opmath_t(0.0f);
+    constexpr opmath_t three = opmath_t(3.0f);
+    constexpr opmath_t neg_three = opmath_t(-3.0f);
+    constexpr opmath_t one_sixth = opmath_t(1.0f / 6.0f);
+    opmath_t grad_val = static_cast<opmath_t>(grad_val_);
+    opmath_t self_val = static_cast<opmath_t>(self_val_);
+    return (self_val > neg_three && self_val < three)
+        ? grad_val * one_sixth
+        : zero;
+  }
+};
 
 void hardsigmoid_backward_kernel(TensorIteratorBase& iter) {
   AT_DISPATCH_FLOATING_TYPES_AND2(
@@ -49,20 +79,8 @@ void hardsigmoid_backward_kernel(TensorIteratorBase& iter) {
       "hardsigmoid_backward_cuda",
       [&]() {
         using opmath_t = at::opmath_type<scalar_t>;
-        const opmath_t zero(0.0f);
-        const opmath_t three(3.0f);
-        const opmath_t neg_three(-3.0f);
-        const opmath_t one_sixth(1.0f / 6.0f);
-        gpu_kernel(
-            iter,
-            [zero, three, neg_three, one_sixth] GPU_LAMBDA(
-                scalar_t grad_val_, scalar_t self_val_) -> scalar_t {
-              opmath_t grad_val = static_cast<opmath_t>(grad_val_);
-              opmath_t self_val = static_cast<opmath_t>(self_val_);
-              return (self_val > neg_three && self_val < three)
-                  ? grad_val * one_sixth
-                  : zero;
-            });
+        auto functor = HardsigmoidBackwardFunctor<scalar_t, opmath_t>();
+        gpu_kernel(iter, functor);
       });
 }
 

--- a/aten/src/ATen/native/cuda/ActivationHardtanhKernel.cu
+++ b/aten/src/ATen/native/cuda/ActivationHardtanhKernel.cu
@@ -19,6 +19,25 @@
 namespace at::native {
 namespace {
 
+template <typename scalar_t, typename opmath_t>
+struct HardtanhBackwardFunctor {
+  // only double not simple + bf16 for SM 75-
+  template <int cc_major, int /*cc_minor*/>
+  static constexpr bool is_simple =
+    !(std::is_same_v<scalar_t, double> ||
+     (cc_major < 8 && std::is_same_v<scalar_t, c10::BFloat16>));
+
+  GPU_LAMBDA scalar_t operator()(scalar_t a, scalar_t b) const {
+    opmath_t aop = static_cast<opmath_t>(a);
+    opmath_t bop = static_cast<opmath_t>(b);
+    return (bop <= min_val) || (bop >= max_val) ? opmath_t(0) : aop;
+  }
+  HardtanhBackwardFunctor(opmath_t min_val_, opmath_t max_val_) : min_val(min_val_), max_val(max_val_) {}
+  private:
+  opmath_t min_val;
+  opmath_t max_val;
+};
+
 void hardtanh_backward_kernel(
     TensorIterator& iter,
     const Scalar& min,
@@ -27,15 +46,8 @@ void hardtanh_backward_kernel(
       at::ScalarType::Half, at::ScalarType::BFloat16,
       iter.dtype(), "hardtanh_backward_cuda", [&]() {
         using opmath_t = at::opmath_type<scalar_t>;
-        auto min_val = min.to<opmath_t>();
-        auto max_val = max.to<opmath_t>();
-        gpu_kernel(
-            iter,
-            [min_val, max_val] GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
-              opmath_t aop = static_cast<opmath_t>(a);
-              opmath_t bop = static_cast<opmath_t>(b);
-              return (bop <= min_val) || (bop >= max_val) ? opmath_t(0) : aop;
-            });
+        auto functor = HardtanhBackwardFunctor<scalar_t, opmath_t>(min.to<opmath_t>(), max.to<opmath_t>());
+        gpu_kernel(iter, functor);
       });
 }
 } // namespace

--- a/aten/src/ATen/native/cuda/ActivationLeakyReluKernel.cu
+++ b/aten/src/ATen/native/cuda/ActivationLeakyReluKernel.cu
@@ -19,6 +19,41 @@
 namespace at::native {
 namespace {
 
+template <typename scalar_t, typename opmath_t>
+struct LeakyReluFunctor {
+  // only double not simple + bf16 for SM 75-
+  template <int cc_major, int /*cc_minor*/>
+  static constexpr bool is_simple =
+    !(std::is_same_v<scalar_t, double> ||
+     (cc_major < 8 && std::is_same_v<scalar_t, c10::BFloat16>));
+
+  GPU_LAMBDA scalar_t operator()(scalar_t a) const {
+    opmath_t aop = static_cast<opmath_t>(a);
+    return aop > opmath_t(0) ? aop : aop * negval;
+  }
+  LeakyReluFunctor(opmath_t negval_) : negval(negval_) {}
+  private:
+  opmath_t negval;
+};
+
+template <typename scalar_t, typename opmath_t>
+struct LeakyReluBackwardFunctor {
+  // only double not simple + bf16 for SM 75-
+  template <int cc_major, int /*cc_minor*/>
+  static constexpr bool is_simple =
+    !(std::is_same_v<scalar_t, double> ||
+     (cc_major < 8 && std::is_same_v<scalar_t, c10::BFloat16>));
+
+  GPU_LAMBDA scalar_t operator()(scalar_t a, scalar_t b) const {
+    opmath_t aop = static_cast<opmath_t>(a);
+    opmath_t bop = static_cast<opmath_t>(b);
+    return aop > opmath_t(0) ? bop : bop * negval;
+  }
+  LeakyReluBackwardFunctor(opmath_t negval_) : negval(negval_) {}
+  private:
+  opmath_t negval;
+};
+
 void leaky_relu_kernel(TensorIteratorBase& iter, const Scalar& negval_) {
   AT_DISPATCH_FLOATING_TYPES_AND2(
       at::ScalarType::Half,
@@ -27,11 +62,8 @@ void leaky_relu_kernel(TensorIteratorBase& iter, const Scalar& negval_) {
       "leaky_relu_cuda",
       [&]() {
         using opmath_t = at::opmath_type<scalar_t>;
-        auto negval = negval_.to<opmath_t>();
-        gpu_kernel(iter, [negval] GPU_LAMBDA(scalar_t a) -> scalar_t {
-          opmath_t aop = static_cast<opmath_t>(a);
-          return aop > opmath_t(0) ? aop : aop * negval;
-        });
+        auto functor = LeakyReluFunctor<scalar_t, opmath_t>(negval_.to<opmath_t>());
+        gpu_kernel(iter, functor);
       });
 }
 
@@ -45,13 +77,8 @@ void leaky_relu_backward_kernel(
       "leaky_relu_backward_cuda",
       [&]() {
         using opmath_t = at::opmath_type<scalar_t>;
-        auto negval = negval_.to<opmath_t>();
-        gpu_kernel(
-            iter, [negval] GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
-              opmath_t aop = static_cast<opmath_t>(a);
-              opmath_t bop = static_cast<opmath_t>(b);
-              return aop > opmath_t(0) ? bop : bop * negval;
-            });
+        auto functor = LeakyReluBackwardFunctor<scalar_t, opmath_t>(negval_.to<opmath_t>());
+        gpu_kernel(iter, functor);
       });
 }
 } // namespace

--- a/aten/src/ATen/native/cuda/ActivationPreluKernel.cu
+++ b/aten/src/ATen/native/cuda/ActivationPreluKernel.cu
@@ -18,15 +18,25 @@
 
 namespace at::native {
 
+template <typename scalar_t>
+struct PreluFunctor {
+  // only half and float are simple
+  template <int /*cc_major*/, int /*cc_minor*/>
+  static constexpr bool is_simple = (
+    std::is_same_v<scalar_t, c10::Half> ||
+    std::is_same_v<scalar_t, float>);
+
+  GPU_LAMBDA scalar_t operator()(scalar_t input, scalar_t weight) const {
+    return (input > 0) ? input : weight * input;
+  }
+};
+
 // -----------------------------------
 // prelu
 // -----------------------------------
 void prelu_kernel(TensorIterator &iter) {
   AT_DISPATCH_FLOATING_TYPES_AND2(kBFloat16, kHalf, iter.dtype(), "prelu_cuda", [&] {
-    gpu_kernel(iter,
-      [] GPU_LAMBDA (scalar_t input, scalar_t weight) -> scalar_t {
-        return (input > 0) ? input : weight * input;
-      });
+    gpu_kernel(iter, PreluFunctor<scalar_t>());
   });
 }
 

--- a/aten/src/ATen/native/cuda/ActivationSoftshrinkKernel.cu
+++ b/aten/src/ATen/native/cuda/ActivationSoftshrinkKernel.cu
@@ -20,6 +20,37 @@
 namespace at::native {
 namespace {
 
+template <typename scalar_t>
+struct SoftshrinkFunctor {
+  // note: code-gen for softshrink seems non-optimal, generating a lot of branching.
+  // thus, this is never marked as simple.
+  template <int /*cc_major*/, int /*cc_minor*/>
+  static constexpr bool is_simple = false;
+
+  GPU_LAMBDA scalar_t operator()(scalar_t a) const {
+    return at::_isnan(a) ? a : (a > lambd ? a - lambd : (a < -lambd ? a + lambd : scalar_t(0)));
+  }
+  SoftshrinkFunctor(scalar_t lambd_) : lambd(lambd_) {}
+  private:
+  scalar_t lambd;
+};
+
+template <typename scalar_t>
+struct ShrinkBackwardFunctor {
+  // only double not simple + bf16 for SM 75-
+  template <int cc_major, int /*cc_minor*/>
+  static constexpr bool is_simple =
+    !(std::is_same_v<scalar_t, double> ||
+     (cc_major < 8 && std::is_same_v<scalar_t, c10::BFloat16>));
+
+  GPU_LAMBDA scalar_t operator()(scalar_t grad_val, scalar_t self_val) const {
+    return (self_val >= -lambd && self_val <= lambd) ? scalar_t(0) : grad_val;
+  }
+  ShrinkBackwardFunctor(scalar_t lambd_) : lambd(lambd_) {}
+  private:
+  scalar_t lambd;
+};
+
 void softshrink_kernel(TensorIteratorBase& iter, const Scalar& value) {
   AT_DISPATCH_FLOATING_TYPES_AND2(
       at::ScalarType::Half,
@@ -27,10 +58,8 @@ void softshrink_kernel(TensorIteratorBase& iter, const Scalar& value) {
       iter.dtype(),
       "softshrink_cuda",
       [&]() {
-        auto lambd = value.to<scalar_t>();
-        gpu_kernel(iter, [lambd] GPU_LAMBDA(scalar_t a) -> scalar_t {
-          return at::_isnan(a) ? a : (a > lambd ? a - lambd : (a < -lambd ? a + lambd : scalar_t(0)));
-        });
+        auto functor = SoftshrinkFunctor<scalar_t>(value.to<scalar_t>());
+        gpu_kernel(iter, functor);
       });
 }
 
@@ -41,14 +70,8 @@ void shrink_backward_kernel(TensorIteratorBase& iter, const Scalar& value) {
       iter.dtype(),
       "shrink_backward_cuda",
       [&]() {
-        auto lambd = value.to<scalar_t>();
-        gpu_kernel(
-            iter,
-            [lambd] GPU_LAMBDA(
-                scalar_t grad_val, scalar_t self_val) -> scalar_t {
-              return (self_val >= -lambd && self_val <= lambd) ? scalar_t(0)
-                                                               : grad_val;
-            });
+        auto functor = ShrinkBackwardFunctor<scalar_t>(value.to<scalar_t>());
+        gpu_kernel(iter, functor);
       });
 }
 } // namespace

--- a/aten/src/ATen/native/cuda/ActivationThresholdKernel.cu
+++ b/aten/src/ATen/native/cuda/ActivationThresholdKernel.cu
@@ -20,14 +20,26 @@ namespace at::native {
 namespace {
 
 template <typename scalar_t>
+struct ThresholdFunctor {
+  // always simple
+  template <int /*cc_major*/, int /*cc_minor*/, FunctorType /*functor_type*/>
+  static constexpr bool is_simple = true;
+
+  GPU_LAMBDA scalar_t operator()(scalar_t x, scalar_t other) const {
+    return x <= threshold ? value : other;
+  }
+  ThresholdFunctor(scalar_t threshold_, scalar_t value_) : threshold(threshold_), value(value_) {}
+  private:
+  scalar_t threshold;
+  scalar_t value;
+};
+
+template <typename scalar_t>
 void threshold_kernel_impl(
     TensorIteratorBase& iter,
     scalar_t threshold,
     scalar_t value) {
-  gpu_kernel_with_scalars(
-      iter, [=] GPU_LAMBDA(scalar_t x, scalar_t other) -> scalar_t {
-        return x <= threshold ? value : other;
-      });
+  gpu_kernel_with_scalars(iter, ThresholdFunctor<scalar_t>(threshold, value));
 }
 
 static void threshold_kernel_cuda(

--- a/aten/src/ATen/native/cuda/AmpKernels.cu
+++ b/aten/src/ATen/native/cuda/AmpKernels.cu
@@ -37,6 +37,29 @@ static __host__ __device__ __forceinline__ int isfinite_ensure_cuda_math(float v
 
 namespace at::native {
 
+template <typename scalar_t, typename opmath_t>
+struct AmpNonFiniteCheckAndUnscaleFunctor {
+  // only double is not simple
+  // note: if instantiations get extended to bf16, SM 75- will likely not be simple.
+  template <int /*cc_major*/, int /*cc_minor*/>
+  static constexpr bool is_simple = !(std::is_same_v<scalar_t, double>);
+
+  GPU_LAMBDA scalar_t operator()(scalar_t val_in) const {
+    auto val = static_cast<opmath_t>(val_in);
+    if (!isfinite_ensure_cuda_math(val)) {
+      *found_inf_ptr = 1.f;
+    }
+    // Every thread accesses inv_scale, but it will hit in cache.
+    const auto inv_scale_val = *inv_scale_ptr;
+    return static_cast<scalar_t>(inv_scale_val == 1.f ? val : val * inv_scale_val);
+  }
+  AmpNonFiniteCheckAndUnscaleFunctor(float* found_inf_ptr_, const float* inv_scale_ptr_)
+    : found_inf_ptr(found_inf_ptr_), inv_scale_ptr(inv_scale_ptr_) {}
+  private:
+  float* found_inf_ptr;
+  const float* inv_scale_ptr;
+};
+
 namespace {
 // Single-tensor fallback for _amp_foreach_non_finite_check_and_unscale_cuda_.
 // Handles individual tensors that are acceptable to unscale but not MTA-safe.
@@ -61,16 +84,7 @@ void _amp_non_finite_check_and_unscale_cuda_(Tensor& scaled_grad,
 
       using opmath_t = at::opmath_type<scalar_t>;
 
-      gpu_kernel(iter,
-                 [found_inf_ptr, inv_scale_ptr] GPU_LAMBDA (scalar_t val_in) -> scalar_t {
-                   auto val = static_cast<opmath_t>(val_in);
-                   if (!isfinite_ensure_cuda_math(val)) {
-                     *found_inf_ptr = 1.f;
-                   }
-                   // Every thread accesses inv_scale, but it will hit in cache.
-                   const auto inv_scale_val = *inv_scale_ptr;
-                   return static_cast<scalar_t>(inv_scale_val == 1.f ? val : val * inv_scale_val);
-                 });
+      gpu_kernel(iter, AmpNonFiniteCheckAndUnscaleFunctor<scalar_t, opmath_t>(found_inf_ptr, inv_scale_ptr));
     });
 }
 } // anonymous namespace

--- a/aten/src/ATen/native/cuda/BinaryBitwiseOpsKernels.cu
+++ b/aten/src/ATen/native/cuda/BinaryBitwiseOpsKernels.cu
@@ -12,6 +12,10 @@ namespace at::native {
 
 template<typename scalar_t>
 struct BitwiseAndFunctor {
+  // always simple
+  template <int /*cc_major*/, int /*cc_minor*/>
+  static constexpr bool is_simple = true;
+
   __device__ __forceinline__ scalar_t operator()(scalar_t a, scalar_t b) const {
     return a & b;
   }
@@ -19,6 +23,10 @@ struct BitwiseAndFunctor {
 
 template<>
 struct BitwiseAndFunctor<bool> {
+  // always simple
+  template <int /*cc_major*/, int /*cc_minor*/>
+  static constexpr bool is_simple = true;
+
   __device__ __forceinline__ bool operator()(bool a, bool b) const {
     return a && b;
   }
@@ -33,6 +41,10 @@ void bitwise_and_kernel_cuda(TensorIteratorBase& iter) {
 
 template<typename scalar_t>
 struct BitwiseOrFunctor {
+  // always simple
+  template <int /*cc_major*/, int /*cc_minor*/>
+  static constexpr bool is_simple = true;
+
   __device__ __forceinline__ scalar_t operator()(scalar_t a, scalar_t b) const {
     return a | b;
   }
@@ -40,6 +52,10 @@ struct BitwiseOrFunctor {
 
 template<>
 struct BitwiseOrFunctor<bool> {
+  // always simple
+  template <int /*cc_major*/, int /*cc_minor*/>
+  static constexpr bool is_simple = true;
+
   __device__ __forceinline__ bool operator()(bool a, bool b) const {
     return a || b;
   }
@@ -54,6 +70,10 @@ void bitwise_or_kernel_cuda(TensorIteratorBase& iter) {
 
 template<typename scalar_t>
 struct BitwiseXorFunctor {
+  // always simple
+  template <int /*cc_major*/, int /*cc_minor*/>
+  static constexpr bool is_simple = true;
+
   __device__ __forceinline__ scalar_t operator()(scalar_t a, scalar_t b) const {
     return a ^ b;
   }
@@ -61,6 +81,10 @@ struct BitwiseXorFunctor {
 
 template<>
 struct BitwiseXorFunctor<bool> {
+  // always simple
+  template <int /*cc_major*/, int /*cc_minor*/>
+  static constexpr bool is_simple = true;
+
   __device__ __forceinline__ bool operator()(bool a, bool b) const {
     return a != b;
   }

--- a/aten/src/ATen/native/cuda/BinaryDivTruncKernel.cu
+++ b/aten/src/ATen/native/cuda/BinaryDivTruncKernel.cu
@@ -15,6 +15,21 @@
 namespace at::native {
 namespace binary_internal {
 
+template <typename scalar_t, typename accscalar_t>
+struct DivTruncMulInvFunctor {
+  // only bf16 for SM 75- is not simple
+  template <int cc_major, int /*cc_minor*/>
+  static constexpr bool is_simple =
+    !(cc_major < 8 && std::is_same_v<scalar_t, c10::BFloat16>);
+
+  GPU_LAMBDA scalar_t operator()(scalar_t a) const {
+    return std::trunc(a * inv_b);
+  }
+  DivTruncMulInvFunctor(accscalar_t inv_b_) : inv_b(inv_b_) {}
+  private:
+  accscalar_t inv_b;
+};
+
 void div_trunc_kernel_cuda(TensorIteratorBase& iter) {
   auto dtype = iter.common_dtype();
   if (isIntegralType(dtype, /*includeBool*/ false)) {
@@ -32,9 +47,7 @@ void div_trunc_kernel_cuda(TensorIteratorBase& iter) {
           using accscalar_t = at::acc_type<scalar_t, true>;
           auto inv_b = accscalar_t(1.0) / iter.scalar_value<accscalar_t>(2);
           iter.remove_operand(2);
-          gpu_kernel(iter, [inv_b] GPU_LAMBDA(scalar_t a) -> scalar_t {
-            return std::trunc(a * inv_b);
-          });
+          gpu_kernel(iter, DivTruncMulInvFunctor<scalar_t, accscalar_t>(inv_b));
         });
   } else {
     AT_DISPATCH_FLOATING_TYPES_AND2(

--- a/aten/src/ATen/native/cuda/BinaryInternal.h
+++ b/aten/src/ATen/native/cuda/BinaryInternal.h
@@ -19,6 +19,12 @@ namespace at::native::binary_internal {
 
 template <typename scalar_t>
 struct DivFunctor {
+  // never simple (by default)
+  // note: may be used with or without scalars so we just use a default value
+  // for the functor type
+  template <int /*cc_major*/, int /*cc_minor*/, FunctorType /*functor_type*/ = FunctorType::Binary>
+  static constexpr bool is_simple = false;
+
   __device__ scalar_t operator()(scalar_t a, scalar_t b) const {
     return a / b;
   }
@@ -26,6 +32,13 @@ struct DivFunctor {
 
 template <typename T>
 struct MulFunctor {
+  // only complex double, complex half with binary functor and bf16 with SM 75- are not simple
+  template <int cc_major, int /*cc_minor*/, FunctorType functor_type>
+  static constexpr bool is_simple =
+    !(std::is_same_v<T, c10::complex<double>> ||
+      (std::is_same_v<T, c10::complex<c10::Half>> && functor_type == FunctorType::Binary) ||
+      (std::is_same_v<T, c10::BFloat16> && cc_major < 8));
+
   __device__ T operator()(T a, T b) const {
     return a * b;
   }
@@ -35,10 +48,15 @@ struct MulFunctor {
 // [-Werror=int-in-bool-context]
 template <>
 struct MulFunctor<bool> {
+  // always simple
+  template <int /*cc_major*/, int /*cc_minor*/, FunctorType /*functor_type*/>
+  static constexpr bool is_simple = true;
+
   __device__ bool operator()(bool a, bool b) const {
     return a && b;
   }
 };
+
 void div_true_kernel_cuda(TensorIteratorBase& iter);
 void div_trunc_kernel_cuda(TensorIteratorBase& iter);
 } // namespace at::native::binary_internal

--- a/aten/src/ATen/native/cuda/BinaryLogicalOpsKernels.cu
+++ b/aten/src/ATen/native/cuda/BinaryLogicalOpsKernels.cu
@@ -11,6 +11,51 @@
 
 namespace at::native {
 
+template <typename scalar_t>
+struct LogicalAndFunctor {
+  // only non-simple are: complex<double>, complex<float> with binary functor,
+  // and double with binary functor.
+  template <int /*cc_major*/, int /*cc_minor*/, FunctorType functor_type>
+  static constexpr bool is_simple =
+    !(std::is_same_v<scalar_t, c10::complex<double>> ||
+      (std::is_same_v<scalar_t, c10::complex<float>> && functor_type == FunctorType::Binary) ||
+      (std::is_same_v<scalar_t, double> && functor_type == FunctorType::Binary));
+
+  GPU_LAMBDA bool operator()(scalar_t a, scalar_t b) const {
+    return a && b;
+  }
+};
+
+template <typename scalar_t>
+struct LogicalOrFunctor {
+  // only non-simple are: complex<double>, complex<float> with binary functor,
+  // and double with binary functor.
+  template <int /*cc_major*/, int /*cc_minor*/, FunctorType functor_type>
+  static constexpr bool is_simple = 
+  !(std::is_same_v<scalar_t, c10::complex<double>> ||
+    (std::is_same_v<scalar_t, c10::complex<float>> && functor_type == FunctorType::Binary) ||
+    (std::is_same_v<scalar_t, double> && functor_type == FunctorType::Binary));
+
+  GPU_LAMBDA bool operator()(scalar_t a, scalar_t b) const {
+    return a || b;
+  }
+};
+
+template <typename scalar_t>
+struct LogicalXorFunctor {
+  // only non-simple are: complex<double>, complex<float> with binary functor,
+  // and double with binary functor.
+  template <int /*cc_major*/, int /*cc_minor*/, FunctorType functor_type>
+  static constexpr bool is_simple =
+    !(std::is_same_v<scalar_t, c10::complex<double>> ||
+      (std::is_same_v<scalar_t, c10::complex<float>> && functor_type == FunctorType::Binary) ||
+      (std::is_same_v<scalar_t, double> && functor_type == FunctorType::Binary));
+
+  GPU_LAMBDA bool operator()(scalar_t a, scalar_t b) const {
+    return bool(a) != bool(b);
+  }
+};
+
 constexpr char logical_and_name[] = "logical_and_kernel";
 void logical_and_kernel_cuda(TensorIterator& iter) {
   auto dtype = iter.common_dtype();
@@ -32,18 +77,14 @@ void logical_and_kernel_cuda(TensorIterator& iter) {
 #else
     AT_DISPATCH_COMPLEX_TYPES(dtype, "logical_and_cuda", [&]() {
       opmath_symmetric_gpu_kernel_with_scalars<scalar_t, bool>(
-          iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> bool {
-        return a && b;
-      });
+          iter, LogicalAndFunctor<scalar_t>());
     });
 #endif
   } else {
     AT_DISPATCH_ALL_TYPES_AND3(kHalf, kBool, ScalarType::BFloat16,
                                dtype, "logical_and_cuda", [&]() {
       opmath_symmetric_gpu_kernel_with_scalars<scalar_t, bool>(
-          iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> bool {
-        return a && b;
-      });
+          iter, LogicalAndFunctor<scalar_t>());
    });
   }
 }
@@ -68,18 +109,14 @@ void logical_or_kernel_cuda(TensorIterator& iter) {
     });
 #else
     AT_DISPATCH_COMPLEX_TYPES(dtype, "logical_or_cuda", [&]() {
-      gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> bool {
-        return a || b;
-      });
+      gpu_kernel_with_scalars(iter, LogicalOrFunctor<scalar_t>());
     });
 #endif
   } else {
   AT_DISPATCH_ALL_TYPES_AND3(kHalf, kBool, ScalarType::BFloat16,
                              dtype, "logical_or_cuda", [&]() {
     opmath_symmetric_gpu_kernel_with_scalars<scalar_t, bool>(
-        iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> bool {
-      return a || b;
-    });
+        iter, LogicalOrFunctor<scalar_t>());
   });
   }
 }
@@ -104,18 +141,14 @@ void logical_xor_kernel_cuda(TensorIterator& iter) {
     }); // logical_xor_string
 #else
     AT_DISPATCH_COMPLEX_TYPES(dtype, "logical_xor_cuda", [&]() {
-      gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> bool {
-        return bool(a) != bool(b);
-      });
+      gpu_kernel_with_scalars(iter, LogicalXorFunctor<scalar_t>());
     });
 #endif
   } else {
   AT_DISPATCH_ALL_TYPES_AND3(kHalf, kBool, ScalarType::BFloat16,
                              dtype, "logical_xor_cuda", [&]() {
     opmath_symmetric_gpu_kernel_with_scalars<scalar_t, bool>(
-        iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> bool {
-      return bool(a) != bool(b);
-    });
+        iter, LogicalXorFunctor<scalar_t>());
   });
   }
 }

--- a/aten/src/ATen/native/cuda/BinaryLogicalOpsKernels.cu
+++ b/aten/src/ATen/native/cuda/BinaryLogicalOpsKernels.cu
@@ -31,7 +31,7 @@ struct LogicalOrFunctor {
   // only non-simple are: complex<double>, complex<float> with binary functor,
   // and double with binary functor.
   template <int /*cc_major*/, int /*cc_minor*/, FunctorType functor_type>
-  static constexpr bool is_simple = 
+  static constexpr bool is_simple =
   !(std::is_same_v<scalar_t, c10::complex<double>> ||
     (std::is_same_v<scalar_t, c10::complex<float>> && functor_type == FunctorType::Binary) ||
     (std::is_same_v<scalar_t, double> && functor_type == FunctorType::Binary));

--- a/aten/src/ATen/native/cuda/BinaryMiscBackwardOpsKernels.cu
+++ b/aten/src/ATen/native/cuda/BinaryMiscBackwardOpsKernels.cu
@@ -15,6 +15,32 @@
 
 namespace at::native {
 
+template <typename scalar_t>
+struct SigmoidBackwardFunctor {
+  // only float and double are simple
+  template <int /*cc_major*/, int /*cc_minor*/>
+  static constexpr bool is_simple = (
+    std::is_same_v<scalar_t, float> ||
+    std::is_same_v<scalar_t, double>);
+
+  GPU_LAMBDA scalar_t operator()(scalar_t a, scalar_t b) const {
+    return a * (scalar_t(1.) - b) * b;
+  }
+};
+
+template <typename scalar_t>
+struct TanhBackwardFunctor {
+  // only float and double are simple
+  template <int /*cc_major*/, int /*cc_minor*/>
+  static constexpr bool is_simple = (
+    std::is_same_v<scalar_t, float> ||
+    std::is_same_v<scalar_t, double>);
+
+  GPU_LAMBDA scalar_t operator()(scalar_t a, scalar_t b) const {
+    return a * (scalar_t{1.} - b * b);
+  }
+};
+
 constexpr char sigmoid_backward_name[] = "sigmoid_backward";
 void sigmoid_backward_kernel_cuda(TensorIteratorBase& iter) {
   auto dtype = iter.dtype();
@@ -46,9 +72,7 @@ void sigmoid_backward_kernel_cuda(TensorIteratorBase& iter) {
 #endif
   } else {
     AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, dtype, "sigmoid_backward_cuda", [&]() {
-      gpu_kernel(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
-        return a * (scalar_t(1.) - b) * b;
-      });
+      gpu_kernel(iter, SigmoidBackwardFunctor<scalar_t>());
     });
   }
 }
@@ -117,9 +141,7 @@ void tanh_backward_kernel_cuda(TensorIteratorBase& iter) {
 #endif
   } else {
     AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, dtype, "tanh_backward_cuda", [&]() {
-      gpu_kernel(iter, [] GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
-        return a * (scalar_t{1.} - b * b);
-      });
+      gpu_kernel(iter, TanhBackwardFunctor<scalar_t>());
     });
   }
 }

--- a/aten/src/ATen/native/cuda/BinaryMiscOpsKernels.cu
+++ b/aten/src/ATen/native/cuda/BinaryMiscOpsKernels.cu
@@ -12,6 +12,34 @@
 
 namespace at::native {
 
+template <typename scalar_t>
+struct HuberFunctor {
+  // only float is simple
+  template <int /*cc_major*/, int /*cc_minor*/>
+  static constexpr bool is_simple = std::is_same_v<scalar_t, float>;
+
+  GPU_LAMBDA scalar_t operator()(scalar_t a, scalar_t b) const {
+    auto z = ::abs(a - b);
+    return z < delta_val ? scalar_t(0.5) * z * z : delta_val * (z - scalar_t(0.5) * delta_val);
+  }
+  HuberFunctor(scalar_t delta_val_) : delta_val(delta_val_) {}
+  private:
+  scalar_t delta_val;
+};
+
+template <typename scalar_t>
+struct MseFunctor {
+  // always simple except for bf16 for SM 75-
+  template <int cc_major, int /*cc_minor*/>
+  static constexpr bool is_simple =
+    !(cc_major < 8 && std::is_same_v<scalar_t, c10::BFloat16>);
+
+  GPU_LAMBDA scalar_t operator()(scalar_t a, scalar_t b) const {
+    auto diff = a - b;
+    return diff * diff;
+  }
+};
+
 void smooth_l1_kernel_cuda(TensorIteratorBase& iter, double beta) {
   AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, iter.dtype(), "smooth_l1_cuda", [&iter, beta]() {
     scalar_t beta_val(beta);
@@ -24,20 +52,13 @@ void smooth_l1_kernel_cuda(TensorIteratorBase& iter, double beta) {
 
 void huber_kernel_cuda(TensorIterator& iter, double delta) {
   AT_DISPATCH_FLOATING_TYPES_AND2(kBFloat16, kHalf, iter.dtype(), "huber_cuda", [&iter, delta] {
-    scalar_t delta_val(delta);
-    gpu_kernel(iter, [delta_val] GPU_LAMBDA (scalar_t a, scalar_t b) -> scalar_t {
-      auto z = ::abs(a - b);
-      return z < delta_val ? scalar_t(0.5) * z * z : delta_val * (z - scalar_t(0.5) * delta_val);
-    });
+    gpu_kernel(iter, HuberFunctor<scalar_t>(scalar_t(delta)));
   });
 }
 
 void mse_kernel_cuda(TensorIteratorBase& iter) {
   AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, iter.dtype(), "mse_cuda", [&]() {
-    gpu_kernel(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
-      auto diff = a - b;
-      return diff * diff;
-    });
+    gpu_kernel(iter, MseFunctor<scalar_t>());
   });
 }
 

--- a/aten/src/ATen/native/cuda/BinaryShiftOpsKernels.cu
+++ b/aten/src/ATen/native/cuda/BinaryShiftOpsKernels.cu
@@ -10,31 +10,49 @@
 
 namespace at::native {
 
+template <typename scalar_t>
+struct LshiftFunctor {
+  // only non-simple cases are: signed char with binary functor.
+  template <int /*cc_major*/, int /*cc_minor*/, FunctorType functor_type>
+  static constexpr bool is_simple = !(
+    std::is_same_v<scalar_t, signed char> && functor_type == FunctorType::Binary);
+
+  GPU_LAMBDA scalar_t operator()(scalar_t a, scalar_t b) const {
+    constexpr scalar_t max_shift = sizeof(scalar_t) * CHAR_BIT;
+    if ((static_cast<std::make_signed_t<scalar_t>>(b) < 0) || (b >= max_shift)) {
+      return 0;
+    }
+    return static_cast<std::make_unsigned_t<scalar_t>>(a) << b;
+  }
+};
+
+template <typename scalar_t>
+struct RshiftFunctor {
+  // only non-simple cases are: signed char with binary functor and SM 100+,
+  // unsigned char with binary functor.
+  template <int cc_major, int /*cc_minor*/, FunctorType functor_type>
+  static constexpr bool is_simple = !(
+    (std::is_same_v<scalar_t, signed char> && functor_type == FunctorType::Binary && cc_major >= 10) ||
+    (std::is_same_v<scalar_t, unsigned char> && functor_type == FunctorType::Binary));
+
+  GPU_LAMBDA scalar_t operator()(scalar_t a, scalar_t b) const {
+    constexpr scalar_t max_shift = sizeof(scalar_t) * CHAR_BIT - std::is_signed_v<scalar_t>;
+    if ((static_cast<std::make_signed_t<scalar_t>>(b) < 0) || (b >= max_shift)) {
+      return a >> max_shift;
+    }
+    return a >> b;
+  }
+};
 
 void lshift_kernel_cuda(TensorIteratorBase& iter) {
   AT_DISPATCH_INTEGRAL_TYPES(iter.dtype(), "lshift_cuda", [&]() {
-    gpu_kernel_with_scalars(iter,
-      []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
-        constexpr scalar_t max_shift = sizeof(scalar_t) * CHAR_BIT;
-        if ((static_cast<std::make_signed_t<scalar_t>>(b) < 0) || (b >= max_shift)) {
-          return 0;
-        }
-        return static_cast<std::make_unsigned_t<scalar_t>>(a) << b;
-    });
+    gpu_kernel_with_scalars(iter, LshiftFunctor<scalar_t>());
   });
 }
 
 void rshift_kernel_cuda(TensorIteratorBase& iter) {
   AT_DISPATCH_INTEGRAL_TYPES(iter.dtype(), "rshift_cuda", [&]() {
-    gpu_kernel_with_scalars(iter,
-      []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
-        // right shift value to retain sign bit for signed and no bits for unsigned
-        constexpr scalar_t max_shift = sizeof(scalar_t) * CHAR_BIT - std::is_signed_v<scalar_t>;
-        if ((static_cast<std::make_signed_t<scalar_t>>(b) < 0) || (b >= max_shift)) {
-          return a >> max_shift;
-        }
-        return a >> b;
-    });
+    gpu_kernel_with_scalars(iter, RshiftFunctor<scalar_t>());
   });
 }
 

--- a/aten/src/ATen/native/cuda/CUDALoops.cuh
+++ b/aten/src/ATen/native/cuda/CUDALoops.cuh
@@ -62,7 +62,7 @@ struct get_is_simple<func_t, cc_major, cc_minor, std::void_t<
     > {
   static constexpr bool value = func_t::template is_simple<cc_major, cc_minor>;
 };
-  
+
 #ifdef USE_ROCM
 // Custom configuration for vectorized elementwise kernel
 // with template instantiation.

--- a/aten/src/ATen/native/cuda/CUDALoops.cuh
+++ b/aten/src/ATen/native/cuda/CUDALoops.cuh
@@ -51,6 +51,18 @@
 
 namespace at::native {
 
+template <typename func_t, int cc_major, int cc_minor, typename = void>
+struct get_is_simple {
+  static constexpr bool value = false;
+};
+
+template <typename func_t, int cc_major, int cc_minor>
+struct get_is_simple<func_t, cc_major, cc_minor, std::void_t<
+      decltype(func_t::template is_simple<cc_major, cc_minor>)>
+    > {
+  static constexpr bool value = func_t::template is_simple<cc_major, cc_minor>;
+};
+  
 #ifdef USE_ROCM
 // Custom configuration for vectorized elementwise kernel
 // with template instantiation.

--- a/aten/src/ATen/native/cuda/CompareEQKernel.cu
+++ b/aten/src/ATen/native/cuda/CompareEQKernel.cu
@@ -16,6 +16,40 @@ enum class EqOpType {EQ, NE};
 
 template<typename scalar_t>
 struct CompareEqFunctor{
+  // only simple cases are:
+  // c10::Float4_e2m1fn_x2 with SM 100+,
+  // unsigned long with SM 100+,
+  // unsigned int,
+  // unsigned short,
+  // bool with SM 100+,
+  // bf16,
+  // half,
+  // complex float,
+  // float,
+  // double with non-binary functor,
+  // short,
+  // long with SM 100+,
+  // int,
+  // signed char with SM 100+,
+  // unsigned char with SM 100+,
+  template <int cc_major, int /*cc_minor*/, FunctorType functor_type>
+  static constexpr bool is_simple =
+    (std::is_same_v<scalar_t, c10::Float4_e2m1fn_x2> && cc_major >= 10) ||
+    (std::is_same_v<scalar_t, unsigned long> && cc_major >= 10) ||
+    (std::is_same_v<scalar_t, unsigned int>) ||
+    (std::is_same_v<scalar_t, unsigned short>) ||
+    (std::is_same_v<scalar_t, bool> && cc_major >= 10) ||
+    (std::is_same_v<scalar_t, c10::BFloat16>) ||
+    (std::is_same_v<scalar_t, c10::Half>) ||
+    (std::is_same_v<scalar_t, c10::complex<float>>) ||
+    (std::is_same_v<scalar_t, float>) ||
+    (std::is_same_v<scalar_t, double> && functor_type != FunctorType::Binary) ||
+    (std::is_same_v<scalar_t, short>) ||
+    (std::is_same_v<scalar_t, long> && cc_major >= 10) ||
+    (std::is_same_v<scalar_t, int>) ||
+    (std::is_same_v<scalar_t, signed char> && cc_major >= 10) ||
+    (std::is_same_v<scalar_t, unsigned char> && cc_major >= 10);
+
   CompareEqFunctor(EqOpType op): op_(op) {}
   const EqOpType op_;
   __device__ __forceinline__ bool operator() (scalar_t a, scalar_t b) const {

--- a/aten/src/ATen/native/cuda/ComplexKernel.cu
+++ b/aten/src/ATen/native/cuda/ComplexKernel.cu
@@ -8,14 +8,23 @@
 // of a __device__ lambda not have internal linkage.
 
 namespace at::native {
+
+template <typename scalar_t>
+struct ComplexFunctor {
+  // always simple
+  template <int /*cc_major*/, int /*cc_minor*/>
+  static constexpr bool is_simple = true;
+
+  GPU_LAMBDA c10::complex<scalar_t> operator()(scalar_t a, scalar_t b) const {
+    return c10::complex<scalar_t>(a, b);
+  }
+};
+
 namespace {
 
 void complex_kernel_cuda(TensorIterator& iter) {
   AT_DISPATCH_FLOATING_TYPES_AND(kHalf, iter.input_dtype(0), "complex_cuda", [&]() {
-    gpu_kernel(
-      iter, [] GPU_LAMBDA(scalar_t a, scalar_t b) -> c10::complex<scalar_t> {
-        return c10::complex<scalar_t>(a, b);
-      });
+    gpu_kernel(iter, ComplexFunctor<scalar_t>());
   });
 }
 

--- a/aten/src/ATen/native/cuda/Copy.cu
+++ b/aten/src/ATen/native/cuda/Copy.cu
@@ -44,28 +44,104 @@ at::cuda::CUDAEventPool::Event getEventFromPool(const at::DeviceIndex device_idx
 void neg_kernel_cuda(TensorIteratorBase &iter);
 void conj_kernel_cuda(TensorIteratorBase &iter);
 
+template <typename scalar_t>
+struct IdentityFunctor {
+  // always simple
+  template <int /*cc_major*/, int /*cc_minor*/>
+  static constexpr bool is_simple = true;
+
+  GPU_LAMBDA scalar_t operator()(scalar_t x) const {
+    return x;
+  }
+};
+
+template <typename src_t, typename dst_t>
+struct CastFunctor {
+  // non-simple cases are: dst_t any of Float8_e4m3fn, Float8_e4m3fnuz,
+  // Float8_e5m2fnuz, Float8_e8m0fnu,
+  template <int /*cc_major*/, int /*cc_minor*/>
+  static constexpr bool is_simple = !(
+    std::is_same_v<dst_t, Float8_e4m3fn> ||
+    std::is_same_v<dst_t, Float8_e4m3fnuz> ||
+    std::is_same_v<dst_t, Float8_e5m2fnuz> ||
+    std::is_same_v<dst_t, Float8_e8m0fnu>);
+
+  GPU_LAMBDA dst_t operator()(src_t value) const {
+    return static_cast<dst_t>(value);
+  }
+};
+
+struct Float8E5M2FromFloatFunctor {
+  // never simple
+  template <int /*cc_major*/, int /*cc_minor*/>
+  static constexpr bool is_simple = false;
+
+  GPU_LAMBDA Float8_e5m2 operator()(float value) const {
+#ifdef AT_USE_NV_CVT_INTRINSICS
+    const auto x = __nv_cvt_float_to_fp8(value, __NV_NOSAT, __NV_E5M2);
+    return Float8_e5m2(x, Float8_e5m2::from_bits());
+#else
+    return Float8_e5m2(value);
+#endif
+  }
+};
+
+struct Float8E5M2FromHalfFunctor {
+  // never simple
+  template <int /*cc_major*/, int /*cc_minor*/>
+  static constexpr bool is_simple = false;
+
+  GPU_LAMBDA Float8_e5m2 operator()(Half value) const {
+#ifdef AT_USE_NV_CVT_INTRINSICS
+    const auto x = __nv_cvt_halfraw_to_fp8(static_cast<__half>(value), __NV_NOSAT, __NV_E5M2);
+    return Float8_e5m2(x, Float8_e5m2::from_bits());
+#else
+    return Float8_e5m2(value);
+#endif
+  }
+};
+
+struct Float8E5M2FromBFloat16Functor {
+  // never simple
+  template <int /*cc_major*/, int /*cc_minor*/>
+  static constexpr bool is_simple = false;
+
+  GPU_LAMBDA Float8_e5m2 operator()(BFloat16 value) const {
+#ifdef AT_USE_NV_CVT_INTRINSICS
+    const auto x = __nv_cvt_bfloat16raw_to_fp8(static_cast<__nv_bfloat16>(value), __NV_NOSAT, __NV_E5M2);
+    return Float8_e5m2(x, Float8_e5m2::from_bits());
+#else
+    return Float8_e5m2(value);
+#endif
+  }
+};
+
+template <typename scalar_t>
+struct NegConjFunctor {
+  // only non-simple case are complex double with SM 90-
+  template <int cc_major, int /*cc_minor*/>
+  static constexpr bool is_simple = !(
+    std::is_same_v<scalar_t, c10::complex<double>> && cc_major <= 9);
+
+  GPU_LAMBDA scalar_t operator()(scalar_t x) const {
+    return -std::conj(x);
+  }
+};
+
 void float16_copy_kernel_cuda(TensorIteratorBase &iter) {
-    gpu_kernel_nocast(iter, [] GPU_LAMBDA(float value) {
-        return static_cast<at::Half>(value);
-    });
+    gpu_kernel_nocast(iter, CastFunctor<float, at::Half>());
 }
 
 void bfloat16_copy_kernel_cuda(TensorIteratorBase &iter) {
-    gpu_kernel_nocast(iter, [] GPU_LAMBDA(float value) {
-        return static_cast<at::BFloat16>(value);
-    });
+    gpu_kernel_nocast(iter, CastFunctor<float, at::BFloat16>());
 }
 
 #ifdef USE_ROCM
 void bfloat16tofloat32_copy_kernel_cuda(TensorIteratorBase &iter) {
-    gpu_kernel_nocast(iter, [] GPU_LAMBDA(at::BFloat16 value) {
-        return static_cast<float>(value);
-    });
+    gpu_kernel_nocast(iter, CastFunctor<at::BFloat16, float>());
 }
 void float16tofloat32_copy_kernel_cuda(TensorIteratorBase &iter) {
-    gpu_kernel_nocast(iter, [] GPU_LAMBDA(at::Half value) {
-        return static_cast<float>(value);
-    });
+    gpu_kernel_nocast(iter, CastFunctor<at::Half, float>());
 }
 #endif
 
@@ -75,122 +151,77 @@ void float8_copy_kernel_cuda(TensorIteratorBase &iter) {
   if (dtype == kFloat8_e4m3fn) {
     switch (other_dtype) {
       case kFloat:
-         gpu_kernel_nocast(iter, [] GPU_LAMBDA(float value) {
-             return Float8_e4m3fn(value);
-         });
+         gpu_kernel_nocast(iter, CastFunctor<float, Float8_e4m3fn>());
          break;
       case kHalf:
-         gpu_kernel_nocast(iter, [] GPU_LAMBDA(Half value) {
-             return Float8_e4m3fn(value);
-         });
+         gpu_kernel_nocast(iter, CastFunctor<Half, Float8_e4m3fn>());
          break;
       case kBFloat16:
-         gpu_kernel_nocast(iter, [] GPU_LAMBDA(BFloat16 value) {
-             return Float8_e4m3fn(value);
-         });
+         gpu_kernel_nocast(iter, CastFunctor<BFloat16, Float8_e4m3fn>());
          break;
       default:
-        gpu_kernel(iter, [] GPU_LAMBDA(Float8_e4m3fn x) { return x; });
+        gpu_kernel(iter, IdentityFunctor<Float8_e4m3fn>());
         break;
     }
   } else if (dtype == kFloat8_e5m2) {
     switch (other_dtype) {
       case kFloat:
-         gpu_kernel_nocast(iter, [] GPU_LAMBDA(float value) {
-#ifdef AT_USE_NV_CVT_INTRINSICS
-             const auto x =  __nv_cvt_float_to_fp8(value, __NV_NOSAT, __NV_E5M2);
-             return Float8_e5m2(x, Float8_e5m2::from_bits());
-#else
-             return Float8_e5m2(value);
-#endif
-         });
+         gpu_kernel_nocast(iter, Float8E5M2FromFloatFunctor());
          break;
       case kHalf:
-         gpu_kernel_nocast(iter, [] GPU_LAMBDA(Half value) {
-#ifdef AT_USE_NV_CVT_INTRINSICS
-             const auto x =  __nv_cvt_halfraw_to_fp8(static_cast<__half>(value), __NV_NOSAT, __NV_E5M2);
-             return Float8_e5m2(x, Float8_e5m2::from_bits());
-#else
-             return Float8_e5m2(value);
-#endif
-         });
+         gpu_kernel_nocast(iter, Float8E5M2FromHalfFunctor());
          break;
       case kBFloat16:
-         gpu_kernel_nocast(iter, [] GPU_LAMBDA(BFloat16 value) {
-#ifdef AT_USE_NV_CVT_INTRINSICS
-             const auto x =  __nv_cvt_bfloat16raw_to_fp8(static_cast<__nv_bfloat16>(value), __NV_NOSAT, __NV_E5M2);
-             return Float8_e5m2(x, Float8_e5m2::from_bits());
-#else
-             return Float8_e5m2(value);
-#endif
-         });
+         gpu_kernel_nocast(iter, Float8E5M2FromBFloat16Functor());
          break;
       default:
-         gpu_kernel(iter, [] GPU_LAMBDA(Float8_e5m2 x) { return x; });
+         gpu_kernel(iter, IdentityFunctor<Float8_e5m2>());
          break;
     }
   } else if (dtype == kFloat8_e4m3fnuz) {
     switch (other_dtype) {
       case kFloat:
-         gpu_kernel_nocast(iter, [] GPU_LAMBDA(float value) {
-             return Float8_e4m3fnuz(value);
-         });
+         gpu_kernel_nocast(iter, CastFunctor<float, Float8_e4m3fnuz>());
          break;
       case kHalf:
-         gpu_kernel_nocast(iter, [] GPU_LAMBDA(Half value) {
-             return Float8_e4m3fnuz(value);
-         });
+         gpu_kernel_nocast(iter, CastFunctor<Half, Float8_e4m3fnuz>());
          break;
       case kBFloat16:
-         gpu_kernel_nocast(iter, [] GPU_LAMBDA(BFloat16 value) {
-             return Float8_e4m3fnuz(value);
-         });
+         gpu_kernel_nocast(iter, CastFunctor<BFloat16, Float8_e4m3fnuz>());
          break;
       default:
-        gpu_kernel(iter, [] GPU_LAMBDA(Float8_e4m3fnuz x) { return x; });
+        gpu_kernel(iter, IdentityFunctor<Float8_e4m3fnuz>());
         break;
     }
   } else if (dtype == kFloat8_e5m2fnuz) {
     switch (other_dtype) {
       case kFloat:
-         gpu_kernel_nocast(iter, [] GPU_LAMBDA(float value) {
-             return Float8_e5m2fnuz(value);
-         });
+         gpu_kernel_nocast(iter, CastFunctor<float, Float8_e5m2fnuz>());
          break;
       case kHalf:
-         gpu_kernel_nocast(iter, [] GPU_LAMBDA(Half value) {
-             return Float8_e5m2fnuz(value);
-         });
+         gpu_kernel_nocast(iter, CastFunctor<Half, Float8_e5m2fnuz>());
          break;
       case kBFloat16:
-         gpu_kernel_nocast(iter, [] GPU_LAMBDA(BFloat16 value) {
-             return Float8_e5m2fnuz(value);
-         });
+         gpu_kernel_nocast(iter, CastFunctor<BFloat16, Float8_e5m2fnuz>());
          break;
       default:
-         gpu_kernel(iter, [] GPU_LAMBDA(Float8_e5m2fnuz x) { return x; });
+         gpu_kernel(iter, IdentityFunctor<Float8_e5m2fnuz>());
          break;
     }
   } else if (dtype == kFloat8_e8m0fnu) {
     // TODO(#146647): clean this up, too much copy-pasta
     switch (other_dtype) {
       case kFloat:
-         gpu_kernel_nocast(iter, [] GPU_LAMBDA(float value) {
-             return Float8_e8m0fnu(value);
-         });
+         gpu_kernel_nocast(iter, CastFunctor<float, Float8_e8m0fnu>());
          break;
       case kHalf:
-         gpu_kernel_nocast(iter, [] GPU_LAMBDA(Half value) {
-             return Float8_e8m0fnu(value);
-         });
+         gpu_kernel_nocast(iter, CastFunctor<Half, Float8_e8m0fnu>());
          break;
       case kBFloat16:
-         gpu_kernel_nocast(iter, [] GPU_LAMBDA(BFloat16 value) {
-             return Float8_e8m0fnu(value);
-         });
+         gpu_kernel_nocast(iter, CastFunctor<BFloat16, Float8_e8m0fnu>());
          break;
       default:
-         gpu_kernel(iter, [] GPU_LAMBDA(Float8_e8m0fnu x) { return x; });
+         gpu_kernel(iter, IdentityFunctor<Float8_e8m0fnu>());
          break;
     }
   } else {
@@ -204,7 +235,7 @@ void direct_copy_kernel_cuda(TensorIteratorBase &iter) {
   ScalarType dtype = iter.dtype(0);
   if (isQIntType(dtype)) {
     AT_DISPATCH_QINT_TYPES(dtype, "copy_", [&] {
-      gpu_kernel(iter, [] GPU_LAMBDA(scalar_t x) { return x; });
+      gpu_kernel(iter, IdentityFunctor<scalar_t>());
     });
   } else if (isFloat8Type(dtype)) {
      float8_copy_kernel_cuda(iter);
@@ -228,23 +259,23 @@ void direct_copy_kernel_cuda(TensorIteratorBase &iter) {
     TORCH_CHECK(dtype == iter.dtype(1), "copy_() does not support casting "
       "bits types to different bits types. Source dtype is ", iter.dtype(1), "target dtype is ", dtype);
     AT_DISPATCH_BIT_TYPES(dtype, "copy_", [&] {
-      gpu_kernel_nocast(iter, [] GPU_LAMBDA(scalar_t x) { return x; });
+      gpu_kernel_nocast(iter, IdentityFunctor<scalar_t>());
     });
   } else if (dtype == ScalarType::Float4_e2m1fn_x2) {
     TORCH_CHECK(dtype == iter.dtype(1), "copy_() does not support casting "
       "Float4_e2m1fn_x2 to different types. Source dtype is ", iter.dtype(1), "target dtype is ", dtype);
-    gpu_kernel_nocast(iter, [] GPU_LAMBDA(Float4_e2m1fn_x2 x) { return x; });
+    gpu_kernel_nocast(iter, IdentityFunctor<Float4_e2m1fn_x2>());
   } else {
     AT_DISPATCH_V2(
         dtype, "copy_", AT_WRAP([&] {
-          gpu_kernel(iter, [] GPU_LAMBDA(scalar_t x) { return x; });
+          gpu_kernel(iter, IdentityFunctor<scalar_t>());
     }), AT_EXPAND(AT_ALL_TYPES_AND_COMPLEX), kHalf, kBool, kBFloat16, kComplexHalf, AT_EXPAND(AT_BAREBONES_UNSIGNED_TYPES));
   }
 }
 
 void neg_conj_kernel_cuda(TensorIteratorBase &iter) {
   AT_DISPATCH_COMPLEX_TYPES(iter.common_dtype(), "neg_conj_cuda", [&] {
-    gpu_kernel(iter, [] GPU_LAMBDA(scalar_t x) { return -std::conj(x); });
+    gpu_kernel(iter, NegConjFunctor<scalar_t>());
   });
 }
 

--- a/aten/src/ATen/native/cuda/CopysignKernel.cu
+++ b/aten/src/ATen/native/cuda/CopysignKernel.cu
@@ -20,11 +20,21 @@
 
 namespace at::native {
 
+template <typename scalar_t>
+struct CopysignFunctor {
+  // only non-simple case is bf16 with SM 75-
+  template <int cc_major, int /*cc_minor*/>
+  static constexpr bool is_simple = !(
+    std::is_same_v<scalar_t, c10::BFloat16> && cc_major < 8);
+
+  GPU_LAMBDA scalar_t operator()(scalar_t a, scalar_t b) const {
+    return c10::cuda::compat::copysign(a, b);
+  }
+};
+
 void copysign_kernel_cuda(TensorIteratorBase& iter) {
   AT_DISPATCH_FLOATING_TYPES_AND2(kBFloat16, kHalf, iter.common_dtype(), "copysign_cuda", [&]() {
-    gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
-      return c10::cuda::compat::copysign(a, b);
-    });
+    gpu_kernel_with_scalars(iter, CopysignFunctor<scalar_t>());
   });
 }
 

--- a/aten/src/ATen/native/cuda/Dropout.cu
+++ b/aten/src/ATen/native/cuda/Dropout.cu
@@ -186,6 +186,23 @@ fused_dropout_kernel(cuda::detail::TensorInfo<const scalar_t, IndexType> a,
 }
 
 template<typename mask_t, typename scalar_t, typename accscalar_t>
+struct MaskedScaleFunctor {
+  // only non-simple case is bf16 with SM 75- and double with SM 10.3, 11.x, 12.x
+  template <int cc_major, int cc_minor>
+  static constexpr bool is_simple = !(
+    (std::is_same_v<scalar_t, c10::BFloat16> && cc_major < 8) ||
+    (std::is_same_v<scalar_t, double> && (
+      (cc_major == 10 && cc_minor == 3) || cc_major == 11 || cc_major == 12)));
+
+  GPU_LAMBDA scalar_t operator()(const scalar_t src_val, const mask_t mask_val) const {
+    return (float)mask_val * src_val * scale;
+  }
+  MaskedScaleFunctor(accscalar_t scale_) : scale(scale_) {}
+  private:
+  accscalar_t scale;
+};
+
+template<typename mask_t, typename scalar_t, typename accscalar_t>
 void masked_scale_kernel(at::Tensor& ret, const at::Tensor& src, const at::Tensor& mask, accscalar_t scale){
    auto iter = at::TensorIteratorConfig()
      .check_all_same_dtype(false)
@@ -194,11 +211,7 @@ void masked_scale_kernel(at::Tensor& ret, const at::Tensor& src, const at::Tenso
      .add_const_input(mask)
      .build();
 
-   at::native::gpu_kernel(
-       iter,
-       [=]GPU_LAMBDA(const scalar_t src_val, const mask_t mask_val) -> scalar_t {
-          return (float)mask_val * src_val * scale;
-       });
+   at::native::gpu_kernel(iter, MaskedScaleFunctor<mask_t, scalar_t, accscalar_t>(scale));
 }
 
 template <typename scalar_t>

--- a/aten/src/ATen/native/cuda/IndexKernel.cu
+++ b/aten/src/ATen/native/cuda/IndexKernel.cu
@@ -402,6 +402,24 @@ __global__ void masked_scatter_size_check(
 
 } // anonymous namespace
 
+template <typename scalar_t>
+struct MaskedScatterFunctor {
+  // only complex double is non-simple
+  template <int /*cc_major*/, int /*cc_minor*/>
+  static constexpr bool is_simple = !(
+    std::is_same_v<scalar_t, c10::complex<double>>);
+
+  GPU_LAMBDA scalar_t operator()(const scalar_t a, const bool mask, const int64_t maskPrefixSum) const {
+    if (mask) {
+      return source_ptr[maskPrefixSum];
+    }
+    return a;
+  }
+  MaskedScatterFunctor(const scalar_t* source_ptr_) : source_ptr(source_ptr_) {}
+  private:
+  const scalar_t* source_ptr;
+};
+
 void launch_masked_scatter_kernel(
     const TensorBase &self, const TensorBase &mask,
     const TensorBase &maskPrefixSum, const TensorBase &source) {
@@ -444,13 +462,7 @@ void launch_masked_scatter_kernel(
       "masked_scatter_",
       [&]() {
         auto source_ptr = source_contig.const_data_ptr<scalar_t>();
-        gpu_kernel(
-            iter, [=] GPU_LAMBDA(const scalar_t a, const bool mask, const int64_t maskPrefixSum) -> scalar_t {
-              if (mask) {
-                return source_ptr[maskPrefixSum];
-              }
-              return a;
-            });
+        gpu_kernel(iter, MaskedScatterFunctor<scalar_t>(source_ptr));
         AT_CUDA_CHECK(cudaGetLastError());
       });
 }

--- a/aten/src/ATen/native/cuda/Indexing.cu
+++ b/aten/src/ATen/native/cuda/Indexing.cu
@@ -1711,31 +1711,36 @@ Tensor index_select_quantized_cuda(const Tensor& self, int64_t dim, const Tensor
   return out;
 }
 
+template <typename scalar_t>
+struct MaskedFillFunctor {
+  // only complex double is non-simple
+  template <int /*cc_major*/, int /*cc_minor*/>
+  static constexpr bool is_simple = !(
+    std::is_same_v<scalar_t, c10::complex<double>>);
+
+  GPU_LAMBDA scalar_t operator()(scalar_t self, bool mask) const {
+    if (mask) {
+      return value_;
+    }
+    return self;
+  }
+  MaskedFillFunctor(scalar_t value) : value_(value) {}
+  private:
+  scalar_t value_;
+};
+
 namespace {
 
 void masked_fill_kernel(TensorIterator& iter, const Scalar& value) {
   AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND4(
       kBool, kHalf, kBFloat16, kComplexHalf, iter.common_dtype(), "masked_fill_", [&]() {
-        const auto value_ = value.to<scalar_t>();
-        gpu_kernel(
-            iter, [value_] GPU_LAMBDA(scalar_t self, bool mask) -> scalar_t {
-              if (mask) {
-                return value_;
-              }
-              return self;
-            });
+        gpu_kernel(iter, MaskedFillFunctor<scalar_t>(value.to<scalar_t>()));
       });
 }
 
 template <typename scalar_t>
 void cuda_masked_fill_kernel_quantized(TensorIterator& iter, scalar_t quantized_val) {
-    gpu_kernel(
-        iter, [quantized_val] GPU_LAMBDA(scalar_t self, bool mask) -> scalar_t {
-          if (mask) {
-            return quantized_val;
-          }
-          return self;
-    });
+    gpu_kernel(iter, MaskedFillFunctor<scalar_t>(quantized_val));
 }
 
 void masked_fill_kernel_quantized(TensorIterator& iter, const Scalar& value, double scale, int zero_point) {

--- a/aten/src/ATen/native/cuda/Lerp.cu
+++ b/aten/src/ATen/native/cuda/Lerp.cu
@@ -7,6 +7,34 @@
 #include <ATen/OpMathType.h>
 
 namespace at::native {
+
+template <typename scalar_t, typename opmath_t>
+struct LerpScalarFunctor {
+  // only non-simple cases is double and bf16 with SM 75-
+  template <int cc_major, int /*cc_minor*/>
+  static constexpr bool is_simple = !(
+    std::is_same_v<scalar_t, double> ||
+    (std::is_same_v<scalar_t, c10::BFloat16> && cc_major < 8));
+
+  GPU_LAMBDA scalar_t operator()(scalar_t self_val, scalar_t end_val) const {
+    return lerp(self_val, end_val, weight_val);
+  }
+  LerpScalarFunctor(opmath_t weight_val_) : weight_val(weight_val_) {}
+  private:
+  opmath_t weight_val;
+};
+
+template <typename scalar_t>
+struct LerpFunctor {
+  // only simple case is float
+  template <int /*cc_major*/, int /*cc_minor*/>
+  static constexpr bool is_simple = std::is_same_v<scalar_t, float>;
+
+  GPU_LAMBDA scalar_t operator()(scalar_t self_val, scalar_t end_val, scalar_t weight_val) const {
+    return lerp(self_val, end_val, weight_val);
+  }
+};
+
 namespace {
 
 void lerp_scalar_kernel(
@@ -74,13 +102,7 @@ void lerp_tensor_kernel(at::TensorIteratorBase& iter) {
         }
 
         at::native::gpu_kernel(
-          iter,
-          [] GPU_LAMBDA(
-              scalar_t self_val,
-              scalar_t end_val,
-              scalar_t weight_val) -> scalar_t {
-            return lerp(self_val, end_val, weight_val);
-          });
+          iter, LerpFunctor<scalar_t>());
       });
   }
 }
@@ -132,11 +154,7 @@ void lerp_scalar_kernel(at::TensorIteratorBase& iter, const c10::Scalar& weight)
       dtype, "lerp_cuda",
       [&]{
         using opmath_t = at::opmath_type<scalar_t>;
-        auto weight_val = weight.to<opmath_t>();
-        at::native::gpu_kernel(
-            iter, [=] GPU_LAMBDA(scalar_t self_val, scalar_t end_val) {
-              return lerp(self_val, end_val, weight_val);
-            });
+        at::native::gpu_kernel(iter, LerpScalarFunctor<scalar_t, opmath_t>(weight.to<opmath_t>()));
       });
     }
 }

--- a/aten/src/ATen/native/cuda/LinearAlgebra.cu
+++ b/aten/src/ATen/native/cuda/LinearAlgebra.cu
@@ -15,6 +15,72 @@ namespace at::native {
 
 namespace {
 
+template <typename scalar_t>
+struct AddrBoolBetaZeroFunctor {
+  // always simple
+  template <int /*cc_major*/, int /*cc_minor*/>
+  static constexpr bool is_simple = true;
+
+  GPU_LAMBDA scalar_t operator()(scalar_t /*self_val*/, scalar_t vec1_val, scalar_t vec2_val) const {
+    return alpha_val && vec1_val && vec2_val;
+  }
+  AddrBoolBetaZeroFunctor(scalar_t alpha_val_) : alpha_val(alpha_val_) {}
+ private:
+  scalar_t alpha_val;
+};
+
+template <typename scalar_t>
+struct AddrBoolFunctor {
+  // never simple
+  template <int /*cc_major*/, int /*cc_minor*/>
+  static constexpr bool is_simple = false;
+
+  GPU_LAMBDA scalar_t operator()(scalar_t self_val, scalar_t vec1_val, scalar_t vec2_val) const {
+    return (beta_val && self_val) || (alpha_val && vec1_val && vec2_val);
+  }
+  AddrBoolFunctor(scalar_t beta_val_, scalar_t alpha_val_)
+    : beta_val(beta_val_), alpha_val(alpha_val_) {}
+ private:
+  scalar_t beta_val;
+  scalar_t alpha_val;
+};
+
+template <typename scalar_t>
+struct AddrBetaZeroFunctor {
+  // only simple cases are float, double with SM 90- and int
+  template <int cc_major, int /*cc_minor*/>
+  static constexpr bool is_simple = (
+    std::is_same_v<scalar_t, float> ||
+    (std::is_same_v<scalar_t, double> && cc_major <= 9) ||
+    std::is_same_v<scalar_t, int>);
+
+  GPU_LAMBDA scalar_t operator()(scalar_t /*self_val*/, scalar_t vec1_val, scalar_t vec2_val) const {
+    return alpha_val * vec1_val * vec2_val;
+  }
+  AddrBetaZeroFunctor(scalar_t alpha_val_) : alpha_val(alpha_val_) {}
+ private:
+  scalar_t alpha_val;
+};
+
+template <typename scalar_t>
+struct AddrFunctor {
+  // only simple cases are float, double with SM 90- and int
+  template <int cc_major, int /*cc_minor*/>
+  static constexpr bool is_simple = (
+    std::is_same_v<scalar_t, float> ||
+    (std::is_same_v<scalar_t, double> && cc_major <= 9) ||
+    std::is_same_v<scalar_t, int>);
+
+  GPU_LAMBDA scalar_t operator()(scalar_t self_val, scalar_t vec1_val, scalar_t vec2_val) const {
+    return beta_val * self_val + alpha_val * vec1_val * vec2_val;
+  }
+  AddrFunctor(scalar_t beta_val_, scalar_t alpha_val_)
+    : beta_val(beta_val_), alpha_val(alpha_val_) {}
+ private:
+  scalar_t beta_val;
+  scalar_t alpha_val;
+};
+
 void addr_kernel_cuda(TensorIterator &iter, const Scalar& beta, const Scalar& alpha) {
   if (iter.dtype() == ScalarType::Bool) {
     using scalar_t = bool;
@@ -24,21 +90,9 @@ void addr_kernel_cuda(TensorIterator &iter, const Scalar& beta, const Scalar& al
     // when beta is false, values in self should be ignored,
     // nans and infs in self should not propagate.
     if (beta_val == false) {
-      gpu_kernel(
-        iter,
-        [=] GPU_LAMBDA (scalar_t self_val,
-                        scalar_t vec1_val, scalar_t vec2_val) -> scalar_t {
-          return alpha_val && vec1_val && vec2_val;
-        }
-      );
+      gpu_kernel(iter, AddrBoolBetaZeroFunctor<scalar_t>(alpha_val));
     } else {
-      gpu_kernel(
-        iter,
-        [=] GPU_LAMBDA (scalar_t self_val,
-                        scalar_t vec1_val, scalar_t vec2_val) -> scalar_t {
-          return (beta_val && self_val) || (alpha_val && vec1_val && vec2_val);
-        }
-      );
+      gpu_kernel(iter, AddrBoolFunctor<scalar_t>(beta_val, alpha_val));
     }
     return;
   }
@@ -52,21 +106,9 @@ void addr_kernel_cuda(TensorIterator &iter, const Scalar& beta, const Scalar& al
     // when beta==0, values in self should be ignored,
     // nans and infs in self should not propagate.
     if (beta_val == zero_val) {
-      gpu_kernel(
-        iter,
-        [=] GPU_LAMBDA (scalar_t self_val,
-                        scalar_t vec1_val, scalar_t vec2_val) -> scalar_t {
-          return alpha_val * vec1_val * vec2_val;
-        }
-      );
+      gpu_kernel(iter, AddrBetaZeroFunctor<scalar_t>(alpha_val));
     } else {
-      gpu_kernel(
-        iter,
-        [=] GPU_LAMBDA (scalar_t self_val,
-                        scalar_t vec1_val, scalar_t vec2_val) -> scalar_t {
-          return beta_val * self_val + alpha_val * vec1_val * vec2_val;
-        }
-      );
+      gpu_kernel(iter, AddrFunctor<scalar_t>(beta_val, alpha_val));
     }
   });
 }

--- a/aten/src/ATen/native/cuda/Loops.cuh
+++ b/aten/src/ATen/native/cuda/Loops.cuh
@@ -126,8 +126,28 @@ void gpu_kernel(TensorIteratorBase& iter, const func_t& f) {
   gpu_kernel_impl(iter, f);
 }
 
+enum class FunctorType : int {
+  AUnary = 0,
+  BUnary = 1,
+  Binary = 2,
+};
+
+template <typename func_t, int cc_major, int cc_minor, FunctorType functor_type, typename = void>
+struct get_is_simple_with_scalars : get_is_simple<func_t, cc_major, cc_minor> {};
+
+template <typename func_t, int cc_major, int cc_minor, FunctorType functor_type>
+struct get_is_simple_with_scalars<func_t, cc_major, cc_minor, functor_type, std::void_t<
+      decltype(func_t::template is_simple<cc_major, cc_minor, functor_type>)>
+    > {
+  static constexpr bool value = func_t::template is_simple<cc_major, cc_minor, functor_type>;
+};
+
 template<typename arg1_t, typename arg2_t, typename return_t, typename func_t>
 struct AUnaryFunctor {
+  template <int cc_major, int cc_minor>
+  static constexpr bool is_simple = get_is_simple_with_scalars<
+    func_t, cc_major, cc_minor, FunctorType::AUnary>::value;
+
   using traits = function_traits<func_t>;
   using opmath_arg1_t = typename traits::template arg<0>::type;
   __device__ return_t operator()(arg2_t b) const {
@@ -142,6 +162,10 @@ struct AUnaryFunctor {
 
 template<typename arg1_t, typename arg2_t, typename return_t, typename func_t>
 struct BUnaryFunctor {
+  template <int cc_major, int cc_minor>
+  static constexpr bool is_simple = get_is_simple_with_scalars<
+    func_t, cc_major, cc_minor, FunctorType::BUnary>::value;
+
   using traits = function_traits<func_t>;
   using opmath_arg2_t = typename traits::template arg<1>::type;
   __device__ return_t operator()(arg1_t a) const {
@@ -158,6 +182,10 @@ struct BUnaryFunctor {
 // (which may be higher precision), as well as casts to return_t
 template <typename arg1_t, typename arg2_t, typename return_t, typename func_t>
 struct BinaryFunctor {
+  template <int cc_major, int cc_minor>
+  static constexpr bool is_simple = get_is_simple_with_scalars<
+    func_t, cc_major, cc_minor, FunctorType::Binary>::value;
+
   __device__ return_t operator()(arg1_t a, arg2_t b) const {
     return f(a, b);
   }

--- a/aten/src/ATen/native/cuda/MaxMinElementwiseKernel.cu
+++ b/aten/src/ATen/native/cuda/MaxMinElementwiseKernel.cu
@@ -11,57 +11,132 @@
 
 namespace at::native {
 
+struct MaximumBoolFunctor {
+  // always simple
+  template <int /*cc_major*/, int /*cc_minor*/>
+  static constexpr bool is_simple = true;
+
+  GPU_LAMBDA bool operator()(bool a, bool b) const {
+    return a || b;
+  }
+};
+
+template <typename scalar_t>
+struct MaximumIntFunctor {
+  // always simple
+  template <int /*cc_major*/, int /*cc_minor*/>
+  static constexpr bool is_simple = true;
+
+  GPU_LAMBDA scalar_t operator()(scalar_t a, scalar_t b) const {
+    return ::max(a, b);
+  }
+};
+
+template <typename scalar_t>
+struct MaximumFloatFunctor {
+  // never simple: the below has too much branching
+  template <int /*cc_major*/, int /*cc_minor*/>
+  static constexpr bool is_simple = false;
+
+  GPU_LAMBDA scalar_t operator()(scalar_t a, scalar_t b) const {
+    if (a != a) {
+      return a;
+    } else if (b != b) {
+      return b;
+    } else {
+      return ::max(a, b);
+    }
+  }
+};
+
+struct MinimumBoolFunctor {
+  // always simple
+  template <int /*cc_major*/, int /*cc_minor*/>
+  static constexpr bool is_simple = true;
+
+  GPU_LAMBDA bool operator()(bool a, bool b) const {
+    return a && b;
+  }
+};
+
+template <typename scalar_t>
+struct MinimumIntFunctor {
+  // always simple
+  template <int /*cc_major*/, int /*cc_minor*/>
+  static constexpr bool is_simple = true;
+
+  GPU_LAMBDA scalar_t operator()(scalar_t a, scalar_t b) const {
+    return ::min(a, b);
+  }
+};
+
+template <typename scalar_t>
+struct MinimumFloatFunctor {
+  // never simple: the below has too much branching
+  template <int /*cc_major*/, int /*cc_minor*/>
+  static constexpr bool is_simple = false;
+
+  GPU_LAMBDA scalar_t operator()(scalar_t a, scalar_t b) const {
+    if (a != a) {
+      return a;
+    } else if (b != b) {
+      return b;
+    } else {
+      return ::min(a, b);
+    }
+  }
+};
+
+template <typename scalar_t>
+struct FmaxFunctor {
+  // only non-simple cases is double and bf16 with SM 75-
+  template <int cc_major, int /*cc_minor*/>
+  static constexpr bool is_simple = !(
+    std::is_same_v<scalar_t, double> ||
+    (std::is_same_v<scalar_t, c10::BFloat16> && cc_major < 8));
+
+  GPU_LAMBDA scalar_t operator()(scalar_t a, scalar_t b) const {
+    return ::fmax(a, b);
+  }
+};
+
+template <typename scalar_t>
+struct FminFunctor {
+  // only non-simple cases is double and bf16 with SM 75-
+  template <int cc_major, int /*cc_minor*/>
+  static constexpr bool is_simple = !(
+    std::is_same_v<scalar_t, double> ||
+    (std::is_same_v<scalar_t, c10::BFloat16> && cc_major < 8));
+
+  GPU_LAMBDA scalar_t operator()(scalar_t a, scalar_t b) const {
+    return ::fmin(a, b);
+  }
+};
+
 void maximum_kernel_cuda(TensorIteratorBase& iter) {
   if (iter.dtype() == ScalarType::Bool) {
-    opmath_symmetric_gpu_kernel_with_scalars<bool>(
-        iter, []GPU_LAMBDA(bool a, bool b) -> bool {
-      return a || b;
-    });
+    opmath_symmetric_gpu_kernel_with_scalars<bool>(iter, MaximumBoolFunctor());
   } else if (isIntegralType(iter.dtype(), /*includeBool=*/ false)) {
     AT_DISPATCH_INTEGRAL_TYPES(iter.dtype(), "max_elementwise_cuda", [&]() {
-      opmath_symmetric_gpu_kernel_with_scalars<scalar_t>(
-          iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
-        return ::max(a, b);
-      });
+      opmath_symmetric_gpu_kernel_with_scalars<scalar_t>(iter, MaximumIntFunctor<scalar_t>());
     });
   } else {
     AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, iter.dtype(), "max_elementwise_cuda", [&]() {
-      opmath_symmetric_gpu_kernel_with_scalars<scalar_t>(
-          iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
-        if (a != a) {
-          return a;
-        } else if (b != b) {
-          return b;
-        } else {
-          return ::max(a, b);
-        }
-      });
+      opmath_symmetric_gpu_kernel_with_scalars<scalar_t>(iter, MaximumFloatFunctor<scalar_t>());
     });
   }
 }
 
 void minimum_kernel_cuda(TensorIteratorBase& iter) {
   if (iter.dtype() == ScalarType::Bool) {
-    opmath_symmetric_gpu_kernel_with_scalars<bool>(iter, []GPU_LAMBDA(bool a, bool b) -> bool {
-      return a && b;
-    });
+    opmath_symmetric_gpu_kernel_with_scalars<bool>(iter, MinimumBoolFunctor());
   } else if (isIntegralType(iter.dtype(), /*includeBool=*/ false)) {
     AT_DISPATCH_INTEGRAL_TYPES(iter.dtype(), "minimum_cuda", [&]() {
-      opmath_symmetric_gpu_kernel_with_scalars<scalar_t>(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
-        return ::min(a, b);
-      });
+      opmath_symmetric_gpu_kernel_with_scalars<scalar_t>(iter, MinimumIntFunctor<scalar_t>());
     });
   } else {
     AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, iter.dtype(), "min_elementwise_cuda", [&]() {
-      opmath_symmetric_gpu_kernel_with_scalars<scalar_t>(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
-        if (a != a) {
-          return a;
-        } else if (b != b) {
-          return b;
-        } else {
-          return ::min(a, b);
-        }
-      });
+      opmath_symmetric_gpu_kernel_with_scalars<scalar_t>(iter, MinimumFloatFunctor<scalar_t>());
     });
   }
 }
@@ -69,9 +144,7 @@ void minimum_kernel_cuda(TensorIteratorBase& iter) {
 void fmax_kernel_cuda(TensorIteratorBase& iter) {
   if (isFloatingType(iter.common_dtype())) {
     AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, iter.common_dtype(), "fmax_cuda", [&]() {
-      opmath_symmetric_gpu_kernel_with_scalars<scalar_t>(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
-        return ::fmax(a, b);
-      });
+      opmath_symmetric_gpu_kernel_with_scalars<scalar_t>(iter, FmaxFunctor<scalar_t>());
     });
   } else {
     maximum_kernel_cuda(iter);
@@ -81,9 +154,7 @@ void fmax_kernel_cuda(TensorIteratorBase& iter) {
 void fmin_kernel_cuda(TensorIteratorBase& iter) {
   if (isFloatingType(iter.common_dtype())) {
     AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, iter.common_dtype(), "fmin_cuda", [&]() {
-      opmath_symmetric_gpu_kernel_with_scalars<scalar_t>(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
-        return ::fmin(a, b);
-      });
+      opmath_symmetric_gpu_kernel_with_scalars<scalar_t>(iter, FminFunctor<scalar_t>());
     });
   } else {
     minimum_kernel_cuda(iter);

--- a/aten/src/ATen/native/cuda/Normalization.cu
+++ b/aten/src/ATen/native/cuda/Normalization.cu
@@ -94,6 +94,18 @@ inline Impl batch_norm_choose_impl(const Tensor& in1, const Tensor& in2) {
   return imp1 == imp2 ? imp1 : Impl::General;
 }
 
+template <typename scalar_t, typename acc_t>
+struct BatchNormElementwiseFunctor {
+  // only simple case is float
+  template <int /*cc_major*/, int /*cc_minor*/>
+  static constexpr bool is_simple = std::is_same_v<scalar_t, float>;
+
+  GPU_LAMBDA scalar_t operator()(scalar_t input, acc_t weight, acc_t bias,
+                                  acc_t mean, acc_t invstd) const {
+    return (input - mean) * weight * invstd + bias;
+  }
+};
+
 void batch_norm_elementwise(
     const Tensor& out, const Tensor& self, const std::optional<Tensor>& weight_opt,
     const std::optional<Tensor>& bias_opt, const Tensor& mean_, const Tensor& invstd_) {
@@ -167,10 +179,7 @@ void batch_norm_elementwise(
     AT_DISPATCH_FLOATING_TYPES_AND2(kBFloat16, kHalf, self.scalar_type(),
                                     "batch_norm_elementwise_cuda", [&] {
       using acc_t = at::acc_type<scalar_t, true>;
-      gpu_kernel(iter, [] GPU_LAMBDA (scalar_t input, acc_t weight, acc_t bias,
-                                      acc_t mean, acc_t invstd) -> scalar_t {
-        return (input - mean) * weight * invstd + bias;
-      });
+      gpu_kernel(iter, BatchNormElementwiseFunctor<scalar_t, acc_t>());
     });
     return;
   }
@@ -252,6 +261,30 @@ Tensor batch_norm_elementwise_backward_train(
   TORCH_INTERNAL_ASSERT(false);
 }
 
+template <typename scalar_t, typename accscalar_t>
+struct BatchNormEvalBackwardWeightedFunctor {
+  // only non-simple case is bf16 with SM 75-
+  template <int cc_major, int /*cc_minor*/>
+  static constexpr bool is_simple = !(
+    std::is_same_v<scalar_t, c10::BFloat16> && cc_major < 8);
+
+  GPU_LAMBDA scalar_t operator()(scalar_t gO, accscalar_t invstd, accscalar_t weight) const {
+    return gO * weight * invstd;
+  }
+};
+
+template <typename scalar_t, typename accscalar_t>
+struct BatchNormEvalBackwardFunctor {
+  // only non-simple case is bf16 with SM 75-
+  template <int cc_major, int /*cc_minor*/>
+  static constexpr bool is_simple = !(
+    std::is_same_v<scalar_t, c10::BFloat16> && cc_major < 8);
+
+  GPU_LAMBDA scalar_t operator()(scalar_t gO, accscalar_t invstd) const {
+    return gO * invstd;
+  }
+};
+
 Tensor batch_norm_elementwise_backward_eval(
     const Tensor& grad_out, const Tensor& input,
     const Tensor& invstd, const Tensor& weight) {
@@ -277,10 +310,7 @@ Tensor batch_norm_elementwise_backward_eval(
     AT_DISPATCH_FLOATING_TYPES_AND2(kHalf, kBFloat16, grad_out.scalar_type(),
                                     "batch_norm_eval_backward", [&]{
       using accscalar_t = at::acc_type<scalar_t, true>;
-      gpu_kernel(iter, [] GPU_LAMBDA (scalar_t gO, accscalar_t invstd, accscalar_t weight)
-                 -> scalar_t {
-          return gO * weight * invstd;
-      });
+      gpu_kernel(iter, BatchNormEvalBackwardWeightedFunctor<scalar_t, accscalar_t>());
     });
   } else {
     auto iter = TensorIteratorConfig()
@@ -294,9 +324,7 @@ Tensor batch_norm_elementwise_backward_eval(
     AT_DISPATCH_FLOATING_TYPES_AND2(kHalf, kBFloat16, grad_out.scalar_type(),
                                     "batch_norm_eval_backward", [&]{
       using accscalar_t = at::acc_type<scalar_t, true>;
-      gpu_kernel(iter, [] GPU_LAMBDA (scalar_t gO, accscalar_t invstd) -> scalar_t {
-          return gO * invstd;
-      });
+      gpu_kernel(iter, BatchNormEvalBackwardFunctor<scalar_t, accscalar_t>());
     });
   }
   return grad_input;
@@ -414,6 +442,23 @@ void batch_norm_update_stats_and_invert(
   });
 }
 
+template <typename scalar_t, typename acc_t>
+struct BatchNormCalcInvstdFunctor {
+  // only simple cases are half and bf16
+  template <int /*cc_major*/, int /*cc_minor*/>
+  static constexpr bool is_simple = (
+    std::is_same_v<scalar_t, c10::Half> ||
+    std::is_same_v<scalar_t, c10::BFloat16>);
+
+  GPU_LAMBDA acc_t operator()(scalar_t var) const {
+    return c10::cuda::compat::rsqrt(var + eps_);
+  }
+
+  BatchNormCalcInvstdFunctor(acc_t eps) : eps_(eps) {}
+private:
+  acc_t eps_;
+};
+
 void batch_norm_calc_invstd(const Tensor& out_invstd, const Tensor& running_var, double epsilon) {
   auto iter = TensorIteratorConfig()
       .add_output(out_invstd)
@@ -425,9 +470,7 @@ void batch_norm_calc_invstd(const Tensor& out_invstd, const Tensor& running_var,
                                   "batch_norm_invert_std_cuda", [&] {
     using acc_t = at::acc_type<scalar_t, true>;
     auto eps = static_cast<acc_t>(epsilon);
-    gpu_kernel(iter, [eps] GPU_LAMBDA (scalar_t var) -> acc_t {
-      return c10::cuda::compat::rsqrt(var + eps);
-    });
+    gpu_kernel(iter, BatchNormCalcInvstdFunctor<scalar_t, acc_t>(eps));
   });
 }
 }

--- a/aten/src/ATen/native/cuda/PointwiseOpsKernel.cu
+++ b/aten/src/ATen/native/cuda/PointwiseOpsKernel.cu
@@ -12,6 +12,55 @@
 
 namespace at::native {
 
+template <typename scalar_t, typename accscalar_t>
+struct AddcmulFunctor {
+  // only simple cases are float, double with SM 90- and int
+  template <int cc_major, int /*cc_minor*/>
+  static constexpr bool is_simple = (
+    std::is_same_v<scalar_t, float> ||
+    (std::is_same_v<scalar_t, double> && cc_major <= 9) ||
+    std::is_same_v<scalar_t, int>);
+
+  GPU_LAMBDA scalar_t operator()(scalar_t a, scalar_t b, scalar_t c) const {
+    return pointwise_op_impl<accscalar_t>(a, b, c, alpha, std::multiplies<accscalar_t>());
+  }
+  AddcmulFunctor(accscalar_t alpha_) : alpha(alpha_) {}
+ private:
+  accscalar_t alpha;
+};
+
+template <typename scalar_t, typename accscalar_t>
+struct AddcmulScalarTensor2Functor {
+  // only non-simple case is bf16 with SM 75-
+  template <int cc_major, int /*cc_minor*/>
+  static constexpr bool is_simple = !(
+    std::is_same_v<scalar_t, c10::BFloat16> && cc_major < 8);
+
+  GPU_LAMBDA scalar_t operator()(scalar_t a, scalar_t b) const {
+    return pointwise_op_impl<accscalar_t>(a, b, c, alpha, std::multiplies<accscalar_t>());
+  }
+  AddcmulScalarTensor2Functor(accscalar_t alpha_, accscalar_t c_) : alpha(alpha_), c(c_) {}
+ private:
+  accscalar_t alpha;
+  accscalar_t c;
+};
+
+template <typename scalar_t>
+struct MseBackwardFunctor {
+  // only simple cases are float and double
+  template <int /*cc_major*/, int /*cc_minor*/>
+  static constexpr bool is_simple = (
+    std::is_same_v<scalar_t, float> ||
+    std::is_same_v<scalar_t, double>);
+
+  GPU_LAMBDA scalar_t operator()(scalar_t a, scalar_t b, scalar_t c) const {
+    return alpha * (a - b) * c;
+  }
+  MseBackwardFunctor(scalar_t alpha_) : alpha(alpha_) {}
+ private:
+  scalar_t alpha;
+};
+
 void addcmul_cuda_scalar_tensor2_kernel(
   TensorIteratorBase& iter,
   const Scalar& scalar_tensor2,
@@ -84,9 +133,7 @@ void addcmul_cuda_kernel(TensorIteratorBase& iter, const Scalar& value) {
       // and do math in fp32 for better accuracy.
       using accscalar_t = at::acc_type<scalar_t, true>;
       auto alpha = value.to<accscalar_t>();
-      gpu_kernel(iter, [alpha]GPU_LAMBDA(scalar_t a, scalar_t b, scalar_t c) -> scalar_t {
-        return pointwise_op_impl<accscalar_t>(a, b, c, alpha, std::multiplies<accscalar_t>());
-      });
+      gpu_kernel(iter, AddcmulFunctor<scalar_t, accscalar_t>(alpha));
     });
   }
 }
@@ -133,9 +180,7 @@ void addcmul_cuda_scalar_tensor2_kernel(TensorIteratorBase& iter, const Scalar& 
       using accscalar_t = at::acc_type<scalar_t, true>;
       auto c = scalar_tensor2.to<accscalar_t>();
       auto alpha = value.to<accscalar_t>();
-      gpu_kernel(iter, [alpha, c]GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
-        return pointwise_op_impl<accscalar_t>(a, b, c, alpha, std::multiplies<accscalar_t>());
-      });
+      gpu_kernel(iter, AddcmulScalarTensor2Functor<scalar_t, accscalar_t>(alpha, c));
     });
   }
 }
@@ -222,9 +267,7 @@ void huber_backward_cuda_kernel(TensorIterator& iter, const Scalar& norm, double
 void mse_backward_cuda_kernel(TensorIterator& iter, const Scalar& value) {
   AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, iter.dtype(), "mse_backward_cuda", [&]() {
     auto alpha = value.to<scalar_t>();
-    gpu_kernel(iter, [alpha]GPU_LAMBDA(scalar_t a, scalar_t b, scalar_t c) -> scalar_t {
-      return alpha * (a - b) * c;
-    });
+    gpu_kernel(iter, MseBackwardFunctor<scalar_t>(alpha));
   });
 }
 

--- a/aten/src/ATen/native/cuda/PowKernel.cu
+++ b/aten/src/ATen/native/cuda/PowKernel.cu
@@ -20,6 +20,61 @@ namespace {
 
 void pow_tensor_scalar_kernel(TensorIteratorBase& iter, const Scalar& exp_scalar);
 
+template <typename Base_type>
+struct PowSquareFunctor {
+  // only non-simple cases are unsigned char and complex double/float
+  template <int /*cc_major*/, int /*cc_minor*/>
+  static constexpr bool is_simple = !(
+    std::is_same_v<Base_type, unsigned char> ||
+    std::is_same_v<Base_type, c10::complex<double>> ||
+    std::is_same_v<Base_type, c10::complex<float>>);
+
+  GPU_LAMBDA Base_type operator()(Base_type base) const {
+    return base * base;
+  }
+};
+
+template <typename Base_type>
+struct PowCubeFunctor {
+  // only non-simple cases are long, double with SM 10.3 / 11.x / 12.x,
+  // bf16 with SM 75-
+  template <int cc_major, int cc_minor>
+  static constexpr bool is_simple = !(
+    std::is_same_v<Base_type, long> ||
+    (std::is_same_v<Base_type, double> && (
+      (cc_major >= 10 && cc_minor == 3) || cc_major == 11 || cc_major == 12) ||
+    (std::is_same_v<Base_type, c10::BFloat16> && cc_major < 8)));
+
+  GPU_LAMBDA Base_type operator()(Base_type base) const {
+    return base * base * base;
+  }
+};
+
+template <typename Base_type>
+struct PowInvSquareFunctor {
+  // never simple
+  template <int /*cc_major*/, int /*cc_minor*/>
+  static constexpr bool is_simple = false;
+
+  GPU_LAMBDA Base_type operator()(Base_type base) const {
+    return 1.0 / (base * base);
+  }
+};
+
+template <typename Base_type, typename Exp_type>
+struct PowTensorScalarFunctor {
+  // never simple
+  template <int /*cc_major*/, int /*cc_minor*/>
+  static constexpr bool is_simple = false;
+
+  GPU_LAMBDA Base_type operator()(Base_type base) const {
+    return pow_(base, exp);
+  }
+  PowTensorScalarFunctor(Exp_type exp_) : exp(exp_) {}
+ private:
+  Exp_type exp;
+};
+
 template <typename scalar_t>
 void pow_scalar_tensor_impl(TensorIteratorBase& iter, scalar_t base) {
   gpu_kernel(iter, [=]GPU_LAMBDA(scalar_t exp) -> scalar_t {
@@ -149,21 +204,13 @@ void pow_tensor_scalar_kernel_impl(TensorIteratorBase& iter,
   // .5 (sqrt), -.5 (rsqrt) and -1 (reciprocal) specializations are handled
   // in pow_tensor_scalar_kernel
   if (d_exp == 2) {
-    gpu_kernel(iter, [=]GPU_LAMBDA(Base_type base) -> Base_type {
-      return base * base;
-    });
+    gpu_kernel(iter, PowSquareFunctor<Base_type>());
   } else if (d_exp == 3) {
-    gpu_kernel(iter, [=]GPU_LAMBDA(Base_type base) -> Base_type {
-      return base * base * base;
-    });
+    gpu_kernel(iter, PowCubeFunctor<Base_type>());
   } else if (d_exp == -2) {
-    gpu_kernel(iter, [=]GPU_LAMBDA(Base_type base) -> Base_type {
-      return 1.0 / (base * base);
-    });
+    gpu_kernel(iter, PowInvSquareFunctor<Base_type>());
   } else {
-    gpu_kernel(iter, [=]GPU_LAMBDA(Base_type base) -> Base_type {
-      return pow_(base, exp);
-    });
+    gpu_kernel(iter, PowTensorScalarFunctor<Base_type, Exp_type>(exp));
   }
 }
 
@@ -186,9 +233,7 @@ void pow_tensor_scalar_kernel(TensorIteratorBase& iter, const Scalar& exp_scalar
     }
     AT_DISPATCH_COMPLEX_TYPES(iter.common_dtype(), "pow_cuda", [&]() {
       if (exp_scalar.equal(2.0)) {
-        gpu_kernel(iter, [=]GPU_LAMBDA(scalar_t base) -> scalar_t {
-          return base * base;
-        });
+        gpu_kernel(iter, PowSquareFunctor<scalar_t>());
         return;
       }
       const auto exp = exp_scalar.to<scalar_t>();

--- a/aten/src/ATen/native/cuda/StepKernel.cu
+++ b/aten/src/ATen/native/cuda/StepKernel.cu
@@ -11,19 +11,40 @@
 
 namespace at::native {
 
+template <typename scalar_t>
+struct NextafterFunctor {
+  // never simple
+  template <int /*cc_major*/, int /*cc_minor*/, FunctorType /*functor_type*/>
+  static constexpr bool is_simple = false;
+
+  GPU_LAMBDA scalar_t operator()(scalar_t a, scalar_t b) const {
+    return std::nextafter(a, b);
+  }
+};
+
+template <typename scalar_t>
+struct HeavisideFunctor {
+  // only non-simple cases are bf16 in SM 75-, double with SM 10.3 / 11.x / 12.x,
+  template <int cc_major, int cc_minor, FunctorType /*functor_type*/>
+  static constexpr bool is_simple = !(
+    (std::is_same_v<scalar_t, c10::BFloat16> && cc_major < 8) ||
+    (std::is_same_v<scalar_t, double> && (
+      (cc_major >= 10 && cc_minor == 3) || cc_major == 11 || cc_major == 12)));
+
+  GPU_LAMBDA scalar_t operator()(scalar_t a, scalar_t b) const {
+    return a == 0 ? b : static_cast<scalar_t>(a > 0);
+  }
+};
+
 void nextafter_kernel_cuda(TensorIteratorBase& iter) {
   AT_DISPATCH_FLOATING_TYPES_AND2(kBFloat16, kHalf, iter.common_dtype(), "nextafter_cuda", [&]() {
-    gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
-      return std::nextafter(a, b);
-    });
+    gpu_kernel_with_scalars(iter, NextafterFunctor<scalar_t>());
   });
 }
 
 void heaviside_kernel_cuda(TensorIteratorBase& iter) {
   AT_DISPATCH_ALL_TYPES_AND3(kHalf, kBool, kBFloat16, iter.dtype(), "heaviside_cuda", [&]() {
-    gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
-      return a == 0 ? b : static_cast<scalar_t>(a > 0);
-    });
+    gpu_kernel_with_scalars(iter, HeavisideFunctor<scalar_t>());
   });
 }
 

--- a/aten/src/ATen/native/cuda/TensorCompare.cu
+++ b/aten/src/ATen/native/cuda/TensorCompare.cu
@@ -10,48 +10,110 @@
 
 namespace at::native {
 
+template <typename scalar_t>
+struct WhereFunctor {
+  // only non simple cases are double and complex double with SM 90-
+  template <int cc_major, int /*cc_minor*/>
+  static constexpr bool is_simple = !(
+    (std::is_same_v<scalar_t, double> && cc_major <= 9) ||
+    std::is_same_v<scalar_t, c10::complex<double>>);
+
+  GPU_LAMBDA scalar_t operator()(bool cond_val, scalar_t self_val, scalar_t other_val) const {
+    return cond_val ? self_val : other_val;
+  }
+};
+
+template <typename scalar_t>
+struct IsPosInfFunctor {
+  // always simple
+  template <int /*cc_major*/, int /*cc_minor*/>
+  static constexpr bool is_simple = true;
+
+  GPU_LAMBDA bool operator()(scalar_t a) const {
+    return a == std::numeric_limits<scalar_t>::infinity();
+  }
+};
+
+template <typename scalar_t>
+struct IsNegInfFunctor {
+  // always simple
+  template <int /*cc_major*/, int /*cc_minor*/>
+  static constexpr bool is_simple = true;
+
+  GPU_LAMBDA bool operator()(scalar_t a) const {
+    return a == -std::numeric_limits<scalar_t>::infinity();
+  }
+};
+
+template <typename scalar_t>
+struct ClampFunctor {
+  // only simple cases are float, short and int
+  template <int /*cc_major*/, int /*cc_minor*/>
+  static constexpr bool is_simple = (
+    std::is_same_v<scalar_t, float> ||
+    std::is_same_v<scalar_t, short> ||
+    std::is_same_v<scalar_t, int>);
+
+  GPU_LAMBDA scalar_t operator()(scalar_t v, scalar_t lower, scalar_t upper) const {
+    scalar_t result = ::min(::max(v, lower), upper);
+
+    result = at::_isnan(upper) ? upper : result;
+    result = at::_isnan(lower) ? lower : result;
+    result = at::_isnan(v) ? v : result;
+
+    return result;
+  }
+};
+
+template <typename scalar_t, typename opmath_t>
+struct ClampScalarFunctor {
+  // never simple, note: too much branching
+  template <int /*cc_major*/, int /*cc_minor*/>
+  static constexpr bool is_simple = false;
+
+  GPU_LAMBDA scalar_t operator()(scalar_t v) const {
+    if (_isnan(static_cast<opmath_t>(v))) {
+      return v;
+    } else if (minmax==at::native::detail::ClampLimits::Min){
+      return ::max(static_cast<opmath_t>(v), lim0_val);
+    } else if (minmax==at::native::detail::ClampLimits::Max){
+      return ::min(static_cast<opmath_t>(v), lim0_val);
+    } else {
+      return ::min(::max(static_cast<opmath_t>(v), lim0_val), lim1_val);
+    }
+  }
+  ClampScalarFunctor(opmath_t lim0_val_, opmath_t lim1_val_, at::native::detail::ClampLimits minmax_)
+    : lim0_val(lim0_val_), lim1_val(lim1_val_), minmax(minmax_) {}
+ private:
+  opmath_t lim0_val;
+  opmath_t lim1_val;
+  at::native::detail::ClampLimits minmax;
+};
+
 namespace {
 
 void where_kernel_impl(TensorIterator &iter) {
   AT_DISPATCH_V2(iter.dtype(), "where_cuda", [&] {
-      gpu_kernel(
-        iter,
-        [=] GPU_LAMBDA (bool cond_val, scalar_t self_val, scalar_t other_val) -> scalar_t {
-          return cond_val ? self_val : other_val;
-        });
+      gpu_kernel(iter, WhereFunctor<scalar_t>());
   },
   kComplexHalf, kHalf, kBFloat16, kBool, AT_EXPAND(AT_ALL_TYPES_AND_COMPLEX), AT_EXPAND(AT_FLOAT8_TYPES));
 }
 
 void isposinf_kernel_impl(TensorIteratorBase &iter) {
   AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, iter.input_dtype(), "isposinf_cuda", [&]() {
-    gpu_kernel(
-      iter,
-      [] GPU_LAMBDA (scalar_t a) -> bool { return a == std::numeric_limits<scalar_t>::infinity(); }
-    );
+    gpu_kernel(iter, IsPosInfFunctor<scalar_t>());
   });
 }
 
 void isneginf_kernel_impl(TensorIteratorBase &iter) {
   AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, iter.input_dtype(), "isneginf_cuda", [&]() {
-    gpu_kernel(
-      iter,
-      [] GPU_LAMBDA (scalar_t a) -> bool { return a == -std::numeric_limits<scalar_t>::infinity(); }
-    );
+    gpu_kernel(iter, IsNegInfFunctor<scalar_t>());
   });
 }
 
 void clamp_kernel_impl(TensorIteratorBase& iter) {
   AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBFloat16, iter.common_dtype(), "clamp_cuda", [&] {
-    gpu_kernel(iter, []GPU_LAMBDA(scalar_t v, scalar_t lower, scalar_t upper) -> scalar_t {
-      scalar_t result = ::min(::max(v, lower), upper);
-
-      result = at::_isnan(upper) ? upper : result;
-      result = at::_isnan(lower) ? lower : result;
-      result = at::_isnan(v) ? v : result;
-
-      return result;
-    });
+    gpu_kernel(iter, ClampFunctor<scalar_t>());
   });
 }
 
@@ -61,18 +123,7 @@ void inline launch_clamp_scalar(TensorIteratorBase& iter, Scalar lim0, Scalar li
     auto lim0_val = lim0.to<opmath_t>();
     auto lim1_val = lim1.to<opmath_t>();
 
-    gpu_kernel(iter, [=]GPU_LAMBDA(scalar_t v) -> scalar_t {
-      // Propagate nan, which doesn't propagate automatically for ROCm
-      if (_isnan(static_cast<opmath_t>(v))) {
-        return v;
-      } else if (minmax==at::native::detail::ClampLimits::Min){
-        return ::max(static_cast<opmath_t>(v), lim0_val);
-      } else if (minmax==at::native::detail::ClampLimits::Max){
-        return ::min(static_cast<opmath_t>(v), lim0_val);
-      } else {
-        return ::min(::max(static_cast<opmath_t>(v), lim0_val), lim1_val);
-      }
-    });
+    gpu_kernel(iter, ClampScalarFunctor<scalar_t, opmath_t>(lim0_val, lim1_val, minmax));
   });
 }
 

--- a/aten/src/ATen/native/cuda/UnaryComplexKernels.cu
+++ b/aten/src/ATen/native/cuda/UnaryComplexKernels.cu
@@ -25,6 +25,28 @@ __host__ __device__ static inline c10::complex<T> angle_wrapper(c10::complex<T> 
   return c10::complex<T>{std::arg(v), 0};
 }
 
+template <typename scalar_t>
+struct AngleFunctor {
+  // only float is simple
+  template <int /*cc_major*/, int /*cc_minor*/>
+  static constexpr bool is_simple = std::is_same_v<scalar_t, float>;
+
+  GPU_LAMBDA scalar_t operator()(scalar_t a) const {
+    return angle_wrapper(a);
+  }
+};
+
+template <typename scalar_t>
+struct ConjFunctor {
+  // always simple
+  template <int /*cc_major*/, int /*cc_minor*/>
+  static constexpr bool is_simple = true;
+
+  GPU_LAMBDA scalar_t operator()(scalar_t a) const {
+    return std::conj(a);
+  }
+};
+
 #if AT_USE_JITERATOR()
 constexpr char angle_name[] = "angle_kernel";
 #endif
@@ -55,9 +77,7 @@ void angle_kernel_cuda(TensorIteratorBase& iter) {
 #endif
   } else {
     AT_DISPATCH_FLOATING_TYPES(dtype, "angle_cuda", [&]() {
-        gpu_kernel(iter, []GPU_LAMBDA(scalar_t a) -> scalar_t {
-          return angle_wrapper(a);
-        });
+        gpu_kernel(iter, AngleFunctor<scalar_t>());
     });
   }
 }
@@ -76,9 +96,7 @@ void conj_kernel_cuda(TensorIteratorBase& iter) {
       );
       jitted_gpu_kernel<conj_name, scalar_t, scalar_t, 1>(iter, conj_string);
     #else
-      gpu_kernel(iter, [] GPU_LAMBDA(scalar_t a) -> scalar_t {
-          return std::conj(a);
-      });
+      gpu_kernel(iter, ConjFunctor<scalar_t>());
     #endif
   };
 
@@ -88,9 +106,7 @@ void conj_kernel_cuda(TensorIteratorBase& iter) {
       direct_copy_kernel_cuda(iter);
     })
     AT_DISPATCH_CASE_COMPLEX_TYPES([&] {
-      gpu_kernel(iter, [] GPU_LAMBDA(scalar_t a) -> scalar_t {
-        return std::conj(a);
-      });
+      gpu_kernel(iter, ConjFunctor<scalar_t>());
     })
     AT_DISPATCH_CASE(kComplexHalf, conj_chalf)
   );

--- a/aten/src/ATen/native/cuda/UnaryFractionKernels.cu
+++ b/aten/src/ATen/native/cuda/UnaryFractionKernels.cu
@@ -21,14 +21,37 @@ __host__ __device__ static inline std::complex<T> ceil_wrapper(std::complex<T> v
   return std::complex<T>(std::ceil(v.real()), std::ceil(v.imag()));
 }
 
+template <typename scalar_t>
+struct CeilFunctor {
+  // always simple
+  template <int /*cc_major*/, int /*cc_minor*/>
+  static constexpr bool is_simple = true;
+
+  GPU_LAMBDA scalar_t operator()(scalar_t a) const {
+    return ceil_wrapper(a);
+  }
+};
+
+template <typename scalar_t>
+struct FracFunctor {
+  // only non-simple cases are bf16 in SM 75-, double with SM 10.3 / 11.x / 12.x,
+  template <int cc_major, int cc_minor>
+  static constexpr bool is_simple = !(
+    (std::is_same_v<scalar_t, c10::BFloat16> && cc_major < 8) ||
+    (std::is_same_v<scalar_t, double> && (
+      (cc_major >= 10 && cc_minor == 3) || cc_major == 11 || cc_major == 12)));
+
+  GPU_LAMBDA scalar_t operator()(scalar_t a) const {
+    return a - ::trunc(a);
+  }
+};
+
 void ceil_kernel_cuda(TensorIteratorBase& iter) {
   AT_DISPATCH_FLOATING_TYPES_AND2(
       ScalarType::Half, ScalarType::BFloat16,
       iter.dtype(), "ceil_cuda",
       [&]() {
-        gpu_kernel(iter, []GPU_LAMBDA(scalar_t a) -> scalar_t {
-          return ceil_wrapper(a);
-        });
+        gpu_kernel(iter, CeilFunctor<scalar_t>());
       });
 }
 
@@ -37,9 +60,7 @@ void frac_kernel_cuda(TensorIteratorBase& iter) {
       ScalarType::Half, ScalarType::BFloat16,
       iter.dtype(), "frac_cuda",
       [&]() {
-        gpu_kernel(iter, []GPU_LAMBDA(scalar_t a) -> scalar_t {
-          return a - ::trunc(a);
-        });
+        gpu_kernel(iter, FracFunctor<scalar_t>());
       });
 }
 
@@ -54,14 +75,23 @@ __host__ __device__ static inline std::complex<T> floor_wrapper(std::complex<T> 
   return std::complex<T>(std::floor(v.real()), std::floor(v.imag()));
 }
 
+template <typename scalar_t>
+struct FloorFunctor {
+  // always simple
+  template <int /*cc_major*/, int /*cc_minor*/>
+  static constexpr bool is_simple = true;
+
+  GPU_LAMBDA scalar_t operator()(scalar_t a) const {
+    return floor_wrapper(a);
+  }
+};
+
 void floor_kernel_cuda(TensorIteratorBase& iter) {
   AT_DISPATCH_FLOATING_TYPES_AND2(
       ScalarType::Half, ScalarType::BFloat16,
       iter.dtype(), "floor_cuda",
       [&]() {
-        gpu_kernel(iter, []GPU_LAMBDA(scalar_t a) -> scalar_t {
-          return floor_wrapper(a);
-        });
+        gpu_kernel(iter, FloorFunctor<scalar_t>());
       });
 }
 
@@ -128,15 +158,23 @@ __host__ __device__ static inline c10::complex<double> nearbyint_wrapper(c10::co
 }
 #pragma pop
 
+template <typename scalar_t>
+struct RoundFunctor {
+  // always simple
+  template <int /*cc_major*/, int /*cc_minor*/>
+  static constexpr bool is_simple = true;
+
+  GPU_LAMBDA scalar_t operator()(scalar_t a) const {
+    return nearbyint_wrapper(a);
+  }
+};
+
 void round_kernel_cuda(TensorIteratorBase& iter) {
   AT_DISPATCH_FLOATING_TYPES_AND2(
       ScalarType::Half, ScalarType::BFloat16,
       iter.dtype(), "round_cuda",
       [&]() {
-        gpu_kernel(iter, []GPU_LAMBDA(scalar_t a) -> scalar_t {
-          // We do not use std::round because we would like to round midway numbers to the nearest even integer.
-          return nearbyint_wrapper(a);
-        });
+        gpu_kernel(iter, RoundFunctor<scalar_t>());
       });
 }
 
@@ -177,14 +215,24 @@ __host__ __device__ static inline c10::complex<double> trunc_wrapper(c10::comple
   return c10::complex<double>(::trunc(static_cast<double>(a.real())), ::trunc(static_cast<double>(a.imag())));
 }
 
+template <typename scalar_t>
+struct TruncFunctor {
+  // only non-simple is double
+  template <int /*cc_major*/, int /*cc_minor*/>
+  static constexpr bool is_simple = !(std::is_same_v<scalar_t, double>);
+
+  GPU_LAMBDA scalar_t operator()(scalar_t a) const {
+    return trunc_wrapper(a);
+  }
+};
+
+
 void trunc_kernel_cuda(TensorIteratorBase& iter) {
   AT_DISPATCH_FLOATING_TYPES_AND2(
       ScalarType::Half, ScalarType::BFloat16,
       iter.dtype(), "trunc_cuda",
       [&]() {
-        gpu_kernel(iter, []GPU_LAMBDA(scalar_t a) -> scalar_t {
-          return trunc_wrapper(a);
-        });
+        gpu_kernel(iter, TruncFunctor<scalar_t>());
       });
 }
 

--- a/aten/src/ATen/native/cuda/UnaryOpsKernel.cu
+++ b/aten/src/ATen/native/cuda/UnaryOpsKernel.cu
@@ -20,16 +20,151 @@
 
 namespace at::native {
 
+struct BitwiseNotBoolFunctor {
+  // always simple
+  template <int /*cc_major*/, int /*cc_minor*/>
+  static constexpr bool is_simple = true;
+
+  GPU_LAMBDA bool operator()(bool a) const { return !a; }
+};
+
+template <typename scalar_t>
+struct BitwiseNotFunctor {
+  // always simple
+  template <int /*cc_major*/, int /*cc_minor*/>
+  static constexpr bool is_simple = true;
+
+  GPU_LAMBDA scalar_t operator()(scalar_t a) const { return ~a; }
+};
+
+// We manually overload rsqrt because std::rsqrt does not work with complex types.
+template<typename scalar_t>
+C10_HOST_DEVICE static inline scalar_t rsqrt_wrapper(scalar_t v) {
+  return ::rsqrt(v);
+}
+
+template<typename T>
+C10_HOST_DEVICE static inline c10::complex<T> rsqrt_wrapper(c10::complex<T> v) {
+  const c10::complex<T> one = c10::complex<T>(1.0, 0);
+  // std::sqrt for c10::complex is overloaded in c10/util/complex_math.h
+  return one / ::sqrt(v);
+}
+
+template <typename scalar_t>
+struct RsqrtFunctor {
+  // only simple cases are half and bf16 except SM 75-
+  template <int cc_major, int /*cc_minor*/>
+  static constexpr bool is_simple = (
+    (std::is_same_v<scalar_t, c10::BFloat16> && cc_major >= 8) ||
+    (std::is_same_v<scalar_t, at::Half>));
+
+  GPU_LAMBDA scalar_t operator()(scalar_t a) const {
+    // In CUDA, ::rsqrt is overloaded for float and at::Half here is implicitly cast to float.
+    // note(mjoux): I highly doubt the above note is correct.
+    return rsqrt_wrapper(a);
+  }
+};
+
+template <typename scalar_t>
+struct ClampFunctor {
+  // only simple cases are float, short, int and signed char
+  template <int /*cc_major*/, int /*cc_minor*/>
+  static constexpr bool is_simple = (
+    std::is_same_v<scalar_t, float> ||
+    std::is_same_v<scalar_t, short> ||
+    std::is_same_v<scalar_t, int> ||
+    std::is_same_v<scalar_t, signed char>);
+
+  GPU_LAMBDA scalar_t operator()(scalar_t v) const {
+    if (_isnan(v)) {
+      return v;
+    } else {
+      return ::min(::max(v, lower), upper);
+    }
+  }
+  ClampFunctor(scalar_t lower_, scalar_t upper_) : lower(lower_), upper(upper_) {}
+  private:
+  scalar_t lower;
+  scalar_t upper;
+};
+
+template <typename scalar_t>
+struct ClampMinFunctor {
+  // only non-simple cases are bf16 in SM 75-, double
+  template <int cc_major, int /*cc_minor*/>
+  static constexpr bool is_simple = !(
+    (std::is_same_v<scalar_t, c10::BFloat16> && cc_major < 8) ||
+    (std::is_same_v<scalar_t, double>));
+
+  GPU_LAMBDA scalar_t operator()(scalar_t v) const {
+    // Propagate nan, which doesn't propagate automatically for ROCm
+    if (_isnan(v)) {
+      return v;
+    } else {
+      return ::max(v, lower);
+    }
+  }
+  ClampMinFunctor(scalar_t lower_) : lower(lower_) {}
+  private:
+  scalar_t lower;
+};
+
+template <typename scalar_t>
+struct ClampMaxFunctor {
+  // only non-simple cases are bf16 in SM 75-, double
+  template <int cc_major, int /*cc_minor*/>
+  static constexpr bool is_simple = !(
+    (std::is_same_v<scalar_t, c10::BFloat16> && cc_major < 8) ||
+    (std::is_same_v<scalar_t, double>));
+
+  GPU_LAMBDA scalar_t operator()(scalar_t v) const {
+    // Propagate nan, which doesn't propagate automatically for ROCm
+    if (_isnan(v)) {
+      return v;
+    } else {
+      return ::min(v, upper);
+    }
+  }
+  ClampMaxFunctor(scalar_t upper_) : upper(upper_) {}
+  private:
+  scalar_t upper;
+};
+
+template<typename scalar_t>
+C10_HOST_DEVICE static inline scalar_t _nan_to_num_replace(scalar_t a, scalar_t nan_replacement, scalar_t pos_inf_replacement, scalar_t neg_inf_replacement) {
+  return at::_isnan(a)
+    ? nan_replacement
+    : (a == std::numeric_limits<scalar_t>::infinity()
+      ? pos_inf_replacement
+      : (a == -std::numeric_limits<scalar_t>::infinity()
+        ? neg_inf_replacement
+        : a));
+}
+
+template <typename scalar_t>
+struct NanToNumFunctor {
+  // only float is simple
+  template <int /*cc_major*/, int /*cc_minor*/>
+  static constexpr bool is_simple = std::is_same_v<scalar_t, float>;
+
+  GPU_LAMBDA scalar_t operator()(scalar_t a) const {
+    return _nan_to_num_replace(
+      a, nan_replacement, pos_inf_replacement, neg_inf_replacement);
+  }
+  NanToNumFunctor(scalar_t nan_r, scalar_t pos_r, scalar_t neg_r)
+    : nan_replacement(nan_r), pos_inf_replacement(pos_r), neg_inf_replacement(neg_r) {}
+  private:
+  scalar_t nan_replacement;
+  scalar_t pos_inf_replacement;
+  scalar_t neg_inf_replacement;
+};
+
 void bitwise_not_kernel_cuda(TensorIteratorBase& iter) {
   if (iter.dtype() == ScalarType::Bool) {
-    gpu_kernel(iter, []GPU_LAMBDA(bool a) {
-      return !a;
-    });
+    gpu_kernel(iter, BitwiseNotBoolFunctor());
   } else {
     AT_DISPATCH_INTEGRAL_TYPES(iter.dtype(), "bitwise_not_cuda", [&]() {
-      gpu_kernel(iter, []GPU_LAMBDA(scalar_t a) -> scalar_t {
-        return ~a;
-      });
+      gpu_kernel(iter, BitwiseNotFunctor<scalar_t>());
     });
   }
 }
@@ -79,19 +214,6 @@ void expm1_kernel_cuda(TensorIteratorBase& iter) {
       });
 }
 
-// We manually overload rsqrt because std::rsqrt does not work with complex types.
-template<typename scalar_t>
-C10_HOST_DEVICE static inline scalar_t rsqrt_wrapper(scalar_t v) {
-  return ::rsqrt(v);
-}
-
-template<typename T>
-C10_HOST_DEVICE static inline c10::complex<T> rsqrt_wrapper(c10::complex<T> v) {
-  const c10::complex<T> one = c10::complex<T>(1.0, 0);
-  // std::sqrt for c10::complex is overloaded in c10/util/complex_math.h
-  return one / ::sqrt(v);
-}
-
 constexpr char rsqrt_name[] = "rsqrt_kernel";
 void rsqrt_kernel_cuda(TensorIteratorBase& iter) {
   auto common_dtype = iter.common_dtype();
@@ -123,10 +245,7 @@ void rsqrt_kernel_cuda(TensorIteratorBase& iter) {
       ScalarType::BFloat16, ScalarType::Half,
       iter.common_dtype(), "rsqrt_cuda",
       [&]() {
-        gpu_kernel(iter, []GPU_LAMBDA(scalar_t a) -> scalar_t {
-          // In CUDA, ::rsqrt is overloaded for float and at::Half here is implicitly cast to float.
-          return rsqrt_wrapper(a);
-        });
+        gpu_kernel(iter, RsqrtFunctor<scalar_t>());
       });
   }
 }
@@ -169,54 +288,22 @@ void clamp_kernel_cuda(TensorIteratorBase& iter, const Scalar& min_value, const 
   AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBFloat16, iter.dtype(), "clamp_cuda", [&]() {
     auto lower = min_value.to<scalar_t>();
     auto upper = max_value.to<scalar_t>();
-    gpu_kernel(iter, [=]GPU_LAMBDA(scalar_t v) -> scalar_t {
-      // Propagate nan, which doesn't propagate automatically for ROCm
-      if (_isnan(v)) {
-        return v;
-      } else {
-        return ::min(::max(v, lower), upper);
-      }
-    });
+    gpu_kernel(iter, ClampFunctor<scalar_t>(lower, upper));
   });
 }
 
 void clamp_min_kernel_cuda(TensorIteratorBase& iter, const Scalar& min_value) {
   AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBFloat16, iter.dtype(), "clamp_min_cuda", [&]() {
     auto lower = min_value.to<scalar_t>();
-    gpu_kernel(iter, [=]GPU_LAMBDA(scalar_t v) -> scalar_t {
-      // Propagate nan, which doesn't propagate automatically for ROCm
-      if (_isnan(v)) {
-        return v;
-      } else {
-        return ::max(v, lower);
-      }
-    });
+    gpu_kernel(iter, ClampMinFunctor<scalar_t>(lower));
   });
 }
 
 void clamp_max_kernel_cuda(TensorIteratorBase& iter, const Scalar& max_value) {
   AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBFloat16, iter.dtype(), "clamp_max_cuda", [&]() {
     auto upper = max_value.to<scalar_t>();
-    gpu_kernel(iter, [=]GPU_LAMBDA(scalar_t v) -> scalar_t {
-      // Propagate nan, which doesn't propagate automatically for ROCm
-      if (_isnan(v)) {
-        return v;
-      } else {
-        return ::min(v, upper);
-      }
-    });
+    gpu_kernel(iter, ClampMaxFunctor<scalar_t>(upper));
   });
-}
-
-template<typename scalar_t>
-C10_HOST_DEVICE static inline scalar_t _nan_to_num_replace(scalar_t a, scalar_t nan_replacement, scalar_t pos_inf_replacement, scalar_t neg_inf_replacement) {
-  return at::_isnan(a)
-    ? nan_replacement
-    : (a == std::numeric_limits<scalar_t>::infinity()
-      ? pos_inf_replacement
-      : (a == -std::numeric_limits<scalar_t>::infinity()
-        ? neg_inf_replacement
-        : a));
 }
 
 void nan_to_num_kernel_cuda(
@@ -253,10 +340,8 @@ void nan_to_num_kernel_cuda(
           ? static_cast<scalar_t>(neg_inf.value())
           : std::numeric_limits<scalar_t>::lowest();
 
-      gpu_kernel(iter, [=] GPU_LAMBDA(scalar_t a) -> scalar_t {
-          return _nan_to_num_replace(
-            a, nan_replacement, pos_inf_replacement, neg_inf_replacement);
-      });
+      gpu_kernel(iter, NanToNumFunctor<scalar_t>(
+          nan_replacement, pos_inf_replacement, neg_inf_replacement));
     });
   }
 }

--- a/aten/src/ATen/native/cuda/UnarySignKernels.cu
+++ b/aten/src/ATen/native/cuda/UnarySignKernels.cu
@@ -14,13 +14,75 @@
 
 namespace at::native {
 
+template <typename scalar_t>
+struct LogicalNotFunctor {
+  // only non-simple case is complex double
+  template <int /*cc_major*/, int /*cc_minor*/>
+  static constexpr bool is_simple = !(
+    std::is_same_v<scalar_t, c10::complex<double>>);
+
+  GPU_LAMBDA bool operator()(scalar_t a) const { return !a; }
+};
+
+template <typename scalar_t>
+struct NegFunctor {
+  // only non-simple case is complex double
+  template <int /*cc_major*/, int /*cc_minor*/>
+  static constexpr bool is_simple = !(
+    std::is_same_v<scalar_t, c10::complex<double>>);
+
+  GPU_LAMBDA scalar_t operator()(scalar_t a) const { return -a; }
+};
+
+struct SignBoolFunctor {
+  // always simple
+  template <int /*cc_major*/, int /*cc_minor*/>
+  static constexpr bool is_simple = true;
+
+  GPU_LAMBDA bool operator()(bool a) const { return a; }
+};
+
+template <typename scalar_t>
+struct SignFunctor {
+  // only simple cases are float, short, long, int and unsigned char
+  template <int /*cc_major*/, int /*cc_minor*/>
+  static constexpr bool is_simple = (
+    std::is_same_v<scalar_t, float> ||
+    std::is_same_v<scalar_t, short> ||
+    std::is_same_v<scalar_t, long> ||
+    std::is_same_v<scalar_t, int> ||
+    std::is_same_v<scalar_t, unsigned char>);
+
+  GPU_LAMBDA scalar_t operator()(scalar_t a) const {
+    return c10::signum(a);
+  }
+};
+
+template <typename scalar_t>
+struct SignbitIntFunctor {
+  // always simple
+  template <int /*cc_major*/, int /*cc_minor*/>
+  static constexpr bool is_simple = true;
+
+  GPU_LAMBDA bool operator()(scalar_t a) const { return is_negative(a); }
+};
+
+template <typename scalar_t, typename opmath_t>
+struct SignbitFloatFunctor {
+  // always simple
+  template <int /*cc_major*/, int /*cc_minor*/>
+  static constexpr bool is_simple = true;
+
+  GPU_LAMBDA bool operator()(scalar_t a) const { return signbit(opmath_t{a}); }
+};
+
 void logical_not_kernel_cuda(TensorIteratorBase& iter) {
   // error check -- this is just ensuring we don't dispatch on types that aren't in ALL_TYPES_AND_COMPLEX_AND3(...)
   // so we don't have to maintain a separate list or to do double dispatch.
   AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(kBool, kHalf, kBFloat16, iter.dtype(0), "logical_not_cuda", [&]() {});
 
   AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(kBool, kHalf, kBFloat16, iter.dtype(1), "logical_not_cuda", [&]() {
-    gpu_kernel(iter, []GPU_LAMBDA(scalar_t a) -> bool { return !a; });
+    gpu_kernel(iter, LogicalNotFunctor<scalar_t>());
   });
 }
 
@@ -45,30 +107,22 @@ void neg_kernel_cuda(TensorIteratorBase& iter) {
   });
 #else
   AT_DISPATCH_COMPLEX_TYPES_AND(kComplexHalf, dtype, "neg_cuda", [&]() {
-      gpu_kernel(iter, []GPU_LAMBDA(scalar_t a) -> scalar_t {
-        return -a;
-      });
+      gpu_kernel(iter, NegFunctor<scalar_t>());
   });
 #endif
   } else {
   AT_DISPATCH_ALL_TYPES_AND2(ScalarType::Half, ScalarType::BFloat16, dtype, "neg_cuda", [&]() {
-    gpu_kernel(iter, []GPU_LAMBDA(scalar_t a) -> scalar_t {
-      return -a;
-    });
+    gpu_kernel(iter, NegFunctor<scalar_t>());
   });
   }
 }
 
 void sign_kernel_cuda(TensorIteratorBase& iter){
   if (iter.dtype() == ScalarType::Bool) {
-    gpu_kernel(iter, []GPU_LAMBDA(bool a){
-      return a;
-    });
+    gpu_kernel(iter, SignBoolFunctor());
   } else {
     AT_DISPATCH_ALL_TYPES_AND2(ScalarType::Half, ScalarType::BFloat16, iter.dtype(), "sign_cuda", [&]() {
-        gpu_kernel(iter, []GPU_LAMBDA(scalar_t a) -> scalar_t {
-            return c10::signum(a);
-        });
+        gpu_kernel(iter, SignFunctor<scalar_t>());
     });
   }
 }
@@ -77,12 +131,12 @@ void signbit_kernel_cuda(TensorIteratorBase& iter){
   // NOTE: signbit does not always support integral arguments.
   if (at::isIntegralType(iter.input_dtype(), /*includeBool=*/false)) {
     AT_DISPATCH_INTEGRAL_TYPES(iter.input_dtype(), "signbit_cuda", [&]() {
-      gpu_kernel(iter, []GPU_LAMBDA(scalar_t a) -> bool { return is_negative(a); });
+      gpu_kernel(iter, SignbitIntFunctor<scalar_t>());
     });
   } else {
     AT_DISPATCH_FLOATING_TYPES_AND2(kBFloat16, ScalarType::Half, iter.input_dtype(), "signbit_cuda", [&]() {
       using opmath_t = at::opmath_type<scalar_t>;
-      gpu_kernel(iter, []GPU_LAMBDA(scalar_t a) -> bool { return signbit(opmath_t{a}); });
+      gpu_kernel(iter, SignbitFloatFunctor<scalar_t, opmath_t>());
     });
   }
 }

--- a/aten/src/ATen/native/cuda/UnarySpecialOpsKernel.cu
+++ b/aten/src/ATen/native/cuda/UnarySpecialOpsKernel.cu
@@ -19,6 +19,20 @@
 
 namespace at::native {
 
+template <typename scalar_t>
+struct Exp2Functor {
+  // only simple cases are float, half and bf16 except SM 75-
+  template <int cc_major, int /*cc_minor*/>
+  static constexpr bool is_simple = (
+    std::is_same_v<scalar_t, float> ||
+    std::is_same_v<scalar_t, c10::Half> ||
+    (std::is_same_v<scalar_t, c10::BFloat16> && cc_major >= 8));
+
+  GPU_LAMBDA scalar_t operator()(scalar_t a) const {
+    return exp2_impl(a);
+  }
+};
+
 constexpr char exp2_name[] = "exp2_kernel";
 void exp2_kernel_cuda(TensorIteratorBase& iter) {
   #if AT_USE_JITERATOR()
@@ -34,9 +48,7 @@ void exp2_kernel_cuda(TensorIteratorBase& iter) {
         ScalarType::Half, ScalarType::BFloat16,
         iter.common_dtype(), "exp2_cuda",
         [&]() {
-          gpu_kernel(iter, [] GPU_LAMBDA(scalar_t a) -> scalar_t {
-            return exp2_impl(a);
-          });
+          gpu_kernel(iter, Exp2Functor<scalar_t>());
         });
   #endif
 }

--- a/aten/src/ATen/native/cuda/group_norm_kernel.cu
+++ b/aten/src/ATen/native/cuda/group_norm_kernel.cu
@@ -497,7 +497,7 @@ struct GroupNorm1dForwardGammaFunctor {
     std::is_same_v<T, float> ||
     (std::is_same_v<T, double> && !(
       (cc_major == 10 && cc_minor == 3) || cc_major == 11 || cc_major == 12)));
- 
+
   GPU_LAMBDA T operator()(T x, T mean, T rstd, T gamma) const {
     return (static_cast<T_ACC>(x) - static_cast<T_ACC>(mean)) *
         static_cast<T_ACC>(rstd) * static_cast<T_ACC>(gamma);

--- a/aten/src/ATen/native/cuda/group_norm_kernel.cu
+++ b/aten/src/ATen/native/cuda/group_norm_kernel.cu
@@ -475,6 +475,121 @@ __global__ void GammaBetaBackwardCUDAKernel2(
 }
 
 template <typename T>
+struct GroupNorm1dForwardGammaBetaFunctor {
+  // only simple case is float
+  using T_ACC = acc_type<T, true>;
+  template <int /*cc_major*/, int /*cc_minor*/>
+  static constexpr bool is_simple = std::is_same_v<T, float>;
+
+  GPU_LAMBDA T operator()(T x, T mean, T rstd, T gamma, T beta) const {
+    return (static_cast<T_ACC>(x) - static_cast<T_ACC>(mean)) *
+        static_cast<T_ACC>(rstd) * static_cast<T_ACC>(gamma) +
+        static_cast<T_ACC>(beta);
+  }
+};
+
+template <typename T>
+struct GroupNorm1dForwardGammaFunctor {
+  // only simple cases are float and double except SM 10.3 / 11.0 / 12.0
+  using T_ACC = acc_type<T, true>;
+  template <int cc_major, int cc_minor>
+  static constexpr bool is_simple = (
+    std::is_same_v<T, float> ||
+    (std::is_same_v<T, double> && !(
+      (cc_major == 10 && cc_minor == 3) || cc_major == 11 || cc_major == 12)));
+ 
+  GPU_LAMBDA T operator()(T x, T mean, T rstd, T gamma) const {
+    return (static_cast<T_ACC>(x) - static_cast<T_ACC>(mean)) *
+        static_cast<T_ACC>(rstd) * static_cast<T_ACC>(gamma);
+  }
+};
+
+template <typename T>
+struct GroupNorm1dForwardBetaFunctor {
+  // only simple cases are float and double except SM 10.3 / 11.x / 12.x
+  using T_ACC = acc_type<T, true>;
+  template <int cc_major, int cc_minor>
+  static constexpr bool is_simple = (
+    std::is_same_v<T, float> ||
+    (std::is_same_v<T, double> && !(
+      (cc_major == 10 && cc_minor == 3) || cc_major == 11 || cc_major == 12)));
+
+  GPU_LAMBDA T operator()(T x, T mean, T rstd, T beta) const {
+    return (static_cast<T_ACC>(x) - static_cast<T_ACC>(mean)) *
+        static_cast<T_ACC>(rstd) +
+        static_cast<T_ACC>(beta);
+  }
+};
+
+template <typename T>
+struct GroupNormForwardSimpleFunctor {
+  // only non-simple cases are bf16 for SM 75- and double for SM 10.3 / 11.x / 12.x
+  using T_ACC = acc_type<T, true>;
+  template <int cc_major, int cc_minor>
+  static constexpr bool is_simple = !(
+    (std::is_same_v<T, c10::BFloat16> && cc_major < 8) ||
+    (std::is_same_v<T, double> && (
+      (cc_major == 10 && cc_minor == 3) || cc_major == 11 || cc_major == 12)));
+
+  GPU_LAMBDA T operator()(T x, T mean, T rstd) const {
+    return (static_cast<T_ACC>(x) - static_cast<T_ACC>(mean)) *
+        static_cast<T_ACC>(rstd);
+  }
+};
+
+template <typename T>
+struct GroupNormForwardFusedFunctor {
+  // only non-simple case is bf16 for SM 75-
+  using T_ACC = acc_type<T, true>;
+  template <int cc_major, int /*cc_minor*/>
+  static constexpr bool is_simple = !(
+    (std::is_same_v<T, c10::BFloat16> && cc_major < 8));
+
+  GPU_LAMBDA T operator()(T x, T_ACC a, T_ACC b) const {
+    return a * static_cast<T_ACC>(x) + b;
+  }
+};
+
+template <typename T>
+struct GroupNorm1dBackwardDxFunctor {
+  // only simple case is float
+  using T_ACC = acc_type<T, true>;
+  template <int /*cc_major*/, int /*cc_minor*/>
+  static constexpr bool is_simple = std::is_same_v<T, float>;
+
+  GPU_LAMBDA T operator()(T dy, T x, T rstd, T_ACC c2, T_ACC c3) const {
+    const T_ACC c1 = static_cast<T_ACC>(rstd);
+    return c1 * static_cast<T_ACC>(dy) + c2 * static_cast<T_ACC>(x) +
+        c3;
+  }
+};
+
+template <typename T>
+struct GroupNormBackwardC1Functor {
+  // always simple
+  using T_ACC = acc_type<T, true>;
+  template <int /*cc_major*/, int /*cc_minor*/>
+  static constexpr bool is_simple = true;
+
+  GPU_LAMBDA T_ACC operator()(T rstd, T gamma) const {
+    return static_cast<T_ACC>(rstd) * static_cast<T_ACC>(gamma);
+  }
+};
+
+template <typename T>
+struct GroupNormBackwardDxFunctor {
+  // only simple case is float
+  using T_ACC = acc_type<T, true>;
+  template <int /*cc_major*/, int /*cc_minor*/>
+  static constexpr bool is_simple = std::is_same_v<T, float>;
+
+  GPU_LAMBDA T operator()(T dy, T x, T_ACC c1, T_ACC c2, T_ACC c3) const {
+    return c1 * static_cast<T_ACC>(dy) + c2 * static_cast<T_ACC>(x) +
+        c3;
+  }
+};
+
+template <typename T>
 void GroupNorm1dForward(
     const Tensor& X,
     const Tensor& mean,
@@ -498,11 +613,7 @@ void GroupNorm1dForward(
                     .add_owned_const_input(gamma.view({1, G, D}))
                     .add_owned_const_input(beta.view({1, G, D}))
                     .build();
-    gpu_kernel(iter, [] GPU_LAMBDA(T x, T mean, T rstd, T gamma, T beta) -> T {
-      return (static_cast<T_ACC>(x) - static_cast<T_ACC>(mean)) *
-          static_cast<T_ACC>(rstd) * static_cast<T_ACC>(gamma) +
-          static_cast<T_ACC>(beta);
-    });
+    gpu_kernel(iter, GroupNorm1dForwardGammaBetaFunctor<T>());
   } else if (gamma.defined()) {
     auto iter = TensorIteratorConfig()
                     .resize_outputs(false)
@@ -512,10 +623,7 @@ void GroupNorm1dForward(
                     .add_owned_input(rstd.view({N, G, 1}))
                     .add_owned_const_input(gamma.view({1, G, D}))
                     .build();
-    gpu_kernel(iter, [] GPU_LAMBDA(T x, T mean, T rstd, T gamma) -> T {
-      return (static_cast<T_ACC>(x) - static_cast<T_ACC>(mean)) *
-          static_cast<T_ACC>(rstd) * static_cast<T_ACC>(gamma);
-    });
+    gpu_kernel(iter, GroupNorm1dForwardGammaFunctor<T>());
   } else if (beta.defined()) {
     auto iter = TensorIteratorConfig()
                     .resize_outputs(false)
@@ -525,11 +633,7 @@ void GroupNorm1dForward(
                     .add_owned_input(rstd.view({N, G, 1}))
                     .add_owned_const_input(beta.view({1, G, D}))
                     .build();
-    gpu_kernel(iter, [] GPU_LAMBDA(T x, T mean, T rstd, T beta) -> T {
-      return (static_cast<T_ACC>(x) - static_cast<T_ACC>(mean)) *
-          static_cast<T_ACC>(rstd) +
-          static_cast<T_ACC>(beta);
-    });
+    gpu_kernel(iter, GroupNorm1dForwardBetaFunctor<T>());
   } else {
     auto iter = TensorIteratorConfig()
                     .resize_outputs(false)
@@ -538,10 +642,7 @@ void GroupNorm1dForward(
                     .add_owned_input(mean.view({N * G, 1}))
                     .add_owned_input(rstd.view({N * G, 1}))
                     .build();
-    gpu_kernel(iter, [] GPU_LAMBDA(T x, T mean, T rstd) -> T {
-      return (static_cast<T_ACC>(x) - static_cast<T_ACC>(mean)) *
-          static_cast<T_ACC>(rstd);
-    });
+    gpu_kernel(iter, GroupNormForwardSimpleFunctor<T>());
   }
   AT_CUDA_CHECK(cudaGetLastError());
 }
@@ -590,10 +691,7 @@ void GroupNormKernelImplInternal(
                     .add_owned_input(mean.view({N * G, 1}))
                     .add_owned_input(rstd.view({N * G, 1}))
                     .build();
-    gpu_kernel(iter, [] GPU_LAMBDA(T x, T mean, T rstd) -> T {
-      return (static_cast<T_ACC>(x) - static_cast<T_ACC>(mean)) *
-          static_cast<T_ACC>(rstd);
-    });
+    gpu_kernel(iter, GroupNormForwardSimpleFunctor<T>());
   } else {
     const auto kAccType =
         (X.scalar_type() == kHalf || X.scalar_type() == kBFloat16)
@@ -622,9 +720,7 @@ void GroupNormKernelImplInternal(
                     .add_owned_input(a.view({N * C, 1}))
                     .add_owned_input(b.view({N * C, 1}))
                     .build();
-    gpu_kernel(iter, [] GPU_LAMBDA(T x, T_ACC a, T_ACC b) -> T {
-      return a * static_cast<T_ACC>(x) + b;
-    });
+    gpu_kernel(iter, GroupNormForwardFusedFunctor<T>());
   }
   AT_CUDA_CHECK(cudaGetLastError());
 }
@@ -741,12 +837,7 @@ void GroupNorm1dBackward(
                       .add_owned_const_input(c2.view({N * G, 1}))
                       .add_owned_const_input(c3.view({N * G, 1}))
                       .build();
-      gpu_kernel(
-          iter, [] GPU_LAMBDA(T dy, T x, T rstd, T_ACC c2, T_ACC c3) -> T {
-            const T_ACC c1 = static_cast<T_ACC>(rstd);
-            return c1 * static_cast<T_ACC>(dy) + c2 * static_cast<T_ACC>(x) +
-                c3;
-          });
+      gpu_kernel(iter, GroupNorm1dBackwardDxFunctor<T>());
     }
   }
   if (dgamma.defined() || dbeta.defined()) {
@@ -864,9 +955,7 @@ void GroupNormBackwardKernelImplInternal(
                       .add_owned_const_input(rstd.view({N, G, 1}))
                       .add_owned_const_input(gamma.view({1, G, D}))
                       .build();
-      gpu_kernel(iter, [] GPU_LAMBDA(T rstd, T gamma) -> T_ACC {
-        return static_cast<T_ACC>(rstd) * static_cast<T_ACC>(gamma);
-      });
+      gpu_kernel(iter, GroupNormBackwardC1Functor<T>());
     }
 
     num_threads = (C / G) < cuda_utils::kCUDABlockReduceNumThreads
@@ -897,11 +986,7 @@ void GroupNormBackwardKernelImplInternal(
                       .add_owned_const_input(c2.view({N * G, 1, 1}))
                       .add_owned_const_input(c3.view({N * G, 1, 1}))
                       .build();
-      gpu_kernel(
-          iter, [] GPU_LAMBDA(T dy, T x, T_ACC c1, T_ACC c2, T_ACC c3) -> T {
-            return c1 * static_cast<T_ACC>(dy) + c2 * static_cast<T_ACC>(x) +
-                c3;
-          });
+      gpu_kernel(iter, GroupNormBackwardDxFunctor<T>());
     } else {
       auto iter = TensorIteratorConfig()
                       .check_all_same_dtype(std::is_same_v<T, T_ACC>)
@@ -913,11 +998,7 @@ void GroupNormBackwardKernelImplInternal(
                       .add_owned_const_input(c2.view({N * G, 1}))
                       .add_owned_const_input(c3.view({N * G, 1}))
                       .build();
-      gpu_kernel(
-          iter, [] GPU_LAMBDA(T dy, T x, T_ACC c1, T_ACC c2, T_ACC c3) -> T {
-            return c1 * static_cast<T_ACC>(dy) + c2 * static_cast<T_ACC>(x) +
-                c3;
-          });
+      gpu_kernel(iter, GroupNormBackwardDxFunctor<T>());
     }
   }
   if (dgamma.defined() || dbeta.defined()) {

--- a/aten/src/ATen/native/quantized/cuda/Activation.cu
+++ b/aten/src/ATen/native/quantized/cuda/Activation.cu
@@ -4,14 +4,26 @@
 
 namespace at::native {
 
+template <typename scalar_t, typename underlying_t>
+struct ReluQuantizedFunctor {
+  // always simple
+  template <int /*cc_major*/, int /*cc_minor*/>
+  static constexpr bool is_simple = true;
+
+  GPU_LAMBDA scalar_t operator()(scalar_t value) const {
+    return scalar_t(std::max<underlying_t>(value.val_, zero_point));
+  }
+  ReluQuantizedFunctor(int64_t zero_point_) : zero_point(zero_point_) {}
+  private:
+  int64_t zero_point;
+};
+
 Tensor& relu_quantized_cuda_(Tensor& self) {
   const auto zero_point = self.q_zero_point();
   AT_DISPATCH_QINT_TYPES(
     self.scalar_type(), "qrelu_cuda", [&]() {
       auto iter = TensorIterator::unary_op(self, self);
-      gpu_kernel(iter, [zero_point] GPU_LAMBDA(scalar_t value) -> scalar_t {
-        return scalar_t(std::max<underlying_t>(value.val_, zero_point));
-        });
+      gpu_kernel(iter, ReluQuantizedFunctor<scalar_t, underlying_t>(zero_point));
   });
   return self;
 }

--- a/aten/src/ATen/native/quantized/cuda/AffineQuantizer.cu
+++ b/aten/src/ATen/native/quantized/cuda/AffineQuantizer.cu
@@ -36,6 +36,35 @@ void check_zero_points_cuda(
     "zero_point is above upper bound.");
 }
 
+template <typename scalar_t>
+struct DequantizePerTensorFunctor {
+  // only non-simple cases are SM 10.3 / 11.x / 12.x
+  // note: this is due to scale being a double
+  template <int cc_major, int cc_minor>
+  static constexpr bool is_simple = !(
+    (cc_major == 10 && cc_minor == 3) || cc_major == 11 || cc_major == 12);
+
+  GPU_LAMBDA float operator()(scalar_t value) const {
+    return (static_cast<float>(value.val_) - zero_point) * scale;
+  }
+  DequantizePerTensorFunctor(double scale_, int64_t zero_point_)
+    : scale(scale_), zero_point(zero_point_) {}
+  private:
+  double scale;
+  int64_t zero_point;
+};
+
+template <typename scalar_t>
+struct DequantizePerChannelFloatQParamsFunctor {
+  // only non-simple case is c10::qint8
+  template <int /*cc_major*/, int /*cc_minor*/>
+  static constexpr bool is_simple = !std::is_same_v<scalar_t, c10::qint8>;
+
+  GPU_LAMBDA float operator()(scalar_t value, float scale, float zero_point) const {
+    return (static_cast<float>(value.val_) - zero_point) * scale;
+  }
+};
+
 void quantize_tensor_per_tensor_affine_cuda(
     const Tensor& rtensor,
     Tensor& qtensor,
@@ -77,9 +106,7 @@ void dequantize_tensor_per_tensor_affine_cuda(
                         .add_output(rtensor)
                         .add_input(qtensor)
                         .build();
-        gpu_kernel(iter, [=] GPU_LAMBDA(scalar_t value) -> float {
-          return (static_cast<float>(value.val_) - zero_point) * scale;
-        });
+        gpu_kernel(iter, DequantizePerTensorFunctor<scalar_t>(scale, zero_point));
       });
 }
 
@@ -237,12 +264,7 @@ void dequantize_tensor_per_channel_float_qparams_cuda(
                         .add_input(shaped_zero_points)
                         .build();
 
-        gpu_kernel(
-            iter,
-            [=] GPU_LAMBDA(
-                scalar_t value, float scale, float zero_point) -> float {
-              return (static_cast<float>(value.val_) - zero_point) * scale;
-            });
+        gpu_kernel(iter, DequantizePerChannelFloatQParamsFunctor<scalar_t>());
       });
 }
 

--- a/aten/src/ATen/native/quantized/cuda/IntReprQuant.cu
+++ b/aten/src/ATen/native/quantized/cuda/IntReprQuant.cu
@@ -14,6 +14,17 @@
 
 namespace at::native {
 
+template <typename scalar_t, typename underlying_t>
+struct IntReprFunctor {
+  // always simple
+  template <int /*cc_major*/, int /*cc_minor*/>
+  static constexpr bool is_simple = true;
+
+  GPU_LAMBDA underlying_t operator()(scalar_t value) const {
+    return value.val_;
+  }
+};
+
 Tensor int_repr_quantized_cuda(const Tensor& self) {
   Tensor dst;
   AT_DISPATCH_QINT_TYPES(self.scalar_type(), "int_repr_quantized_cuda", [&]() {
@@ -26,9 +37,7 @@ Tensor int_repr_quantized_cuda(const Tensor& self) {
       .add_output(dst)
       .add_input(self)
       .build();
-    gpu_kernel(iter, [] GPU_LAMBDA(scalar_t value) -> underlying_t {
-      return value.val_;
-    });
+    gpu_kernel(iter, IntReprFunctor<scalar_t, underlying_t>());
   });
   return dst;
 }

--- a/aten/src/ATen/native/quantized/cuda/MakePerTensorQuantizedTensor.cu
+++ b/aten/src/ATen/native/quantized/cuda/MakePerTensorQuantizedTensor.cu
@@ -17,6 +17,17 @@
 
 namespace at::native {
 
+template <typename scalar_t, typename underlying_t>
+struct AssignQuantizedFunctor {
+  // always simple
+  template <int /*cc_major*/, int /*cc_minor*/>
+  static constexpr bool is_simple = true;
+
+  GPU_LAMBDA scalar_t operator()(underlying_t value) const {
+    return scalar_t(value);
+  }
+};
+
 void assign_quantized_tensor_cuda(
   const Tensor& self, Tensor& dst) {
   AT_DISPATCH_QINT_TYPES(
@@ -26,9 +37,7 @@ void assign_quantized_tensor_cuda(
           .add_output(dst)
           .add_input(self)
           .build();
-        gpu_kernel(iter, [] GPU_LAMBDA(underlying_t value) -> scalar_t {
-          return scalar_t(value);
-        });
+        gpu_kernel(iter, AssignQuantizedFunctor<scalar_t, underlying_t>());
       });
 }
 

--- a/torchgen/dest/ufunc.py
+++ b/torchgen/dest/ufunc.py
@@ -209,7 +209,9 @@ def compute_ufunc_cuda_functors(
         if ufunc_name == "add":
             # for addition, non-simple cases are complex double,
             # complex half (except CUDAFunctorOnSelf), and bf16 on sm 75
-            complex_half_cond = "std::is_same_v<scalar_t, c10::complex<c10::Half>> ||\n    "
+            complex_half_cond = (
+                "std::is_same_v<scalar_t, c10::complex<c10::Half>> ||\n    "
+            )
             if k == UfuncKey.CUDAFunctorOnSelf:
                 complex_half_cond = ""
             is_simple_str = f"""template <int cc_major, int /*cc_minor*/>

--- a/torchgen/dest/ufunc.py
+++ b/torchgen/dest/ufunc.py
@@ -206,10 +206,26 @@ def compute_ufunc_cuda_functors(
             g, name=f"ufunc::{ufunc_name}", compute_t=BaseCType(opmath_t)
         )
         apply_ctx = ufunctor_sig.fields() + ufunctor_sig.arguments().apply
+        if ufunc_name == "add":
+            # for addition, non-simple cases are complex double,
+            # complex half (except CUDAFunctorOnSelf), and bf16 on sm 75
+            complex_half_cond = "std::is_same_v<scalar_t, c10::complex<c10::Half>> ||\n    "
+            if k == UfuncKey.CUDAFunctorOnSelf:
+                complex_half_cond = ""
+            is_simple_str = f"""template <int cc_major, int /*cc_minor*/>
+  static constexpr bool is_simple = !(
+    std::is_same_v<scalar_t, c10::complex<double>> ||
+    {complex_half_cond}(std::is_same_v<scalar_t, c10::BFloat16> && cc_major < 8));"""
+        else:
+            # all other ufuncs (currently none) are set to non-simple by default
+            is_simple_str = """template <int /*cc_major*/, int /*cc_minor*/>
+  static constexpr bool is_simple = false;"""
         ufunctors.append(
             f"""
 template <typename scalar_t>
 struct {ufunctor_sig.name} {{
+  {is_simple_str}
+
   using opmath_t = at::opmath_type<scalar_t>;
   {ufunctor_sig.decl_fields()}
   {ufunctor_sig.inline_defn_ctor()}


### PR DESCRIPTION
This PR changes all "simple" lambdas s.t. they become functors and have an annotation w.r.t. whether they are considered simple on the given compute capability.

This is useful information to improve performance of the element-wise kernel. See also https://github.com/pytorch/pytorch/pull/177266 as main PR for the larger context.

The changes here have been made primarily with automatic tooling, but everything has been manually verified.

Regarding maintenance of marking lambdas as "simple" : there are 3 situations which could cause issues and I want to discuss those a little here:

1. A new lambda is added: this is only an issue if that new lambda is "simple" and isn't marked as such, but I think it is unlikely that new "simple" lambdas are added because there are only that many useful things one can do in 4-5 instructions, most of which are already part of PyTorch. It is of course possible that new lambdas explicitly leverage a new hardware instruction, but this is likely as part of new hardware (see below) and whoever adds those lambdas likely knows that they are simple and can thus mark them as such.
2. New hardware is added: in this case, both simple lambdas might become non-simple and non-simple lambdas might become simple. However, it isn't a significant effort to run the tooling linked above once for the new hardware and simply compare what has changed. Only those lambdas that have changed would possibly be affected, and in most cases, I expect very few changes.
3. Compiler is updated: there are two possible cases
    a. a simple lambda becomes non-simple: it is highly likely that this is a compiler bug
    b. a non-simple lambda becomes simple: this is more likely because some new optimization might have been found, but the performance implication is not terrible (non-simple was the default anyway), and it should be caught at the latest when new hardware is added. I think this is still unlikely though because new optimizations for <5 instructions almost certainly require some new instruction, which then goes back to the point about new hardware above.

CC @ptrblck @eqy @ngimel @Aidyn-A @Skylion007