### PR TITLE
Preserve scalar item() semantics for size-1 tensors

### DIFF
--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -4638,6 +4638,35 @@ class CPUReproTests(TestCase):
         torch.testing.assert_close(weight_cmp.grad, weight_ref.grad)
         torch.testing.assert_close(bias_cmp.grad, bias_ref.grad)
 
+    @torch._dynamo.config.patch(
+        capture_scalar_outputs=True, capture_dynamic_output_shape_ops=True
+    )
+    def test_backward_dynamic_item_from_size1_tensor(self):
+        def fn(x, w):
+            num = x.nonzero().numel()
+            num = x.new_tensor([num]).item()
+            y = w * x
+            return y.sum() / num
+
+        torch._dynamo.reset()
+        metrics.reset()
+
+        x = torch.tensor([0.0, 1.0, -1.0, 0.5])
+        w_ref = torch.tensor(0.0, requires_grad=True)
+        w_cmp = w_ref.detach().clone().requires_grad_(True)
+
+        eager_out = fn(x, w_ref)
+        eager_out.backward()
+
+        compiled = torch.compile(fn, backend="inductor", fullgraph=True, dynamic=True)
+        compiled_out = compiled(x, w_cmp)
+        compiled_out.backward()
+
+        self.assertEqual(eager_out.shape, torch.Size([]))
+        self.assertEqual(compiled_out.shape, eager_out.shape)
+        torch.testing.assert_close(compiled_out, eager_out)
+        torch.testing.assert_close(w_cmp.grad, w_ref.grad)
+
     @config.patch(emulate_precision_casts=True)
     def test_emulate_precision_casts_cpp_backend_no_error(self):
         """

--- a/torch/fx/passes/_tensorify_python_scalars.py
+++ b/torch/fx/passes/_tensorify_python_scalars.py
@@ -209,7 +209,8 @@ def tensorify_python_scalars(
                 and node.op == "call_function"
                 and node.target is torch.ops.aten._local_scalar_dense.default
             ):
-                dtype = node.args[0].meta["val"].dtype
+                source_tensor = node.args[0].meta["val"]
+                dtype = source_tensor.dtype
 
                 if not isinstance(node.args[0], fx.Node):
                     raise AssertionError(f"Expected fx.Node, got {node.args[0]}")
@@ -227,6 +228,15 @@ def tensorify_python_scalars(
                 expr_to_tensor_proxy[s] = MetaProxy(
                     node.args[0], tracer=tracer, fake_mode=fake_mode
                 )
+                if len(source_tensor.shape) != 0:
+                    # .item() always produces a scalar value, even when it is
+                    # called on a size-1 tensor with rank > 0. Preserve that 0-d
+                    # semantics before tensorifying the scalar expression so
+                    # later tensor math and autograd tangents do not keep an
+                    # accidental length-1 dimension.
+                    expr_to_tensor_proxy[s] = torch.ops.aten.reshape.default(
+                        expr_to_tensor_proxy[s], []
+                    )
                 # Upcast the float tensor to torch.float64 to avoid precision problem
                 expr_to_tensor_proxy[s] = torch.ops.prims.convert_element_type.default(
                     expr_to_tensor_proxy[s], torch.float64


### PR DESCRIPTION
## Summary
- preserve scalar `.item()` semantics when captured `.item()` originates from a size-1 but non-0d tensor
- add a CPU regression test for the dynamic `nonzero().numel() -> new_tensor([num]).item() -> backward()` case from #177252

## Root cause
- `_tensorify_python_scalars` reused the source tensor backing `_local_scalar_dense` without restoring `.item()`'s guaranteed 0-d shape. When `.item()` came from a size-1 tensor, the tensorified graph kept an accidental length-1 dimension and later produced the wrong tangent rank in backward.

## Proposed fix
- reshape tensorified `_local_scalar_dense` results to `[]` whenever the source tensor is not already 0-d, so captured `.item()` values re-enter the graph as true scalars
- add a regression test for the dynamic backward case from #177252

## Why this is the right long term fix
- it restores the invariant that `.item()` is scalar regardless of the source tensor rank
- it fixes the problem at the tensorify boundary instead of relying on downstream shape cleanup
- it adds coverage at the user-visible failure point, which is where future regressions should be caught

Fix #177252

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Lucaskabela

Drafted via @codex, published after manual review by @bobrenjc93