### PR TITLE
[TD] Add mkldnn/onednn/ideep synonym to filepath heuristic

### DIFF
--- a/tools/test/heuristics/test_heuristics.py
+++ b/tools/test/heuristics/test_heuristics.py
@@ -185,6 +185,24 @@ class TestFilePath(TestTD):
         self.assertTrue(helper("test/test_amp.py", "torch/mixed_precision/t.py"))
         self.assertTrue(helper("test/idk/other/random.py", "torch/idk/t.py"))
 
+    def test_mkldnn_synonyms(self) -> None:
+        # mkldnn/onednn/ideep all share "module: mkldnn" in the autolabeler.
+        # The synonym works via sanitize_name: source files under onednn/ or
+        # ideep/ get their keywords normalized to "mkldnn", which then matches
+        # test_mkldnn.
+        self.assertEqual(
+            get_keywords("torch/csrc/jit/codegen/onednn/foo.py"),
+            ["csrc", "jit", "codegen", "mkldnn", "foo"],
+        )
+        self.assertEqual(
+            get_keywords("caffe2/ideep/bar.py"),
+            ["caffe2", "mkldnn", "bar"],
+        )
+        self.assertTrue(
+            file_matches_keyword("test/test_mkldnn.py", "mkldnn")
+        )
+
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/testing/target_determination/heuristics/filepath.py
+++ b/tools/testing/target_determination/heuristics/filepath.py
@@ -33,6 +33,7 @@ keyword_synonyms: dict[str, list[str]] = {
     "hop": ["higher_order_op"],
     "aot": ["flex_attention", "autograd"],
     "inductor": ["dynamo", "export"],  # not actually synonyms but they interact a lot
+    "mkldnn": ["onednn", "ideep"],
 }
 
 


### PR DESCRIPTION
## Summary

Add `"mkldnn": ["onednn", "ideep"]` to the filepath heuristic's keyword synonyms. These genuinely refer to the same Intel backend, confirmed by `.github/labeler.yml` which groups all three under a single `module: mkldnn` label:

```
"module: mkldnn":
  - third_party/ideep
  - caffe2/ideep/**
  - torch/csrc/jit/codegen/onednn/**
  - test/test_mkldnn.py
```

This means changes to source files under `onednn/` or `ideep/` directories will now correctly match `test_mkldnn.py` via the filepath heuristic.

## Test plan

- [x] All 8 existing heuristic tests pass
- [x] Added `test_mkldnn_synonyms` — verifies `onednn/` and `ideep/` paths normalize to `mkldnn` keyword