### PR TITLE
[inductor] Cast symbolic integer scalar exponents for Triton pow

### DIFF
--- a/test/inductor/test_codegen_triton.py
+++ b/test/inductor/test_codegen_triton.py
@@ -8,6 +8,7 @@ import torch._inductor.config as inductor_config
 from torch._inductor.codegen import triton_utils
 from torch._inductor.codegen.common import CSEVariable, SizeArg
 from torch._inductor.codegen.triton import TritonKernelOverrides
+from torch._inductor.dtype_propagation import DtypePropagationOpsHandler, promote_types
 from torch._inductor.graph import GraphLowering
 from torch._inductor.test_case import TestCase as InductorTestCase
 from torch._inductor.virtualized import V
@@ -127,6 +128,14 @@ class TestCodegenTriton(InductorTestCase):
         self.assertEqual(
             TestTritonKernelOverrides.pow(2, exponent),
             "libdevice.pow(custom_constant(2, torch.float64), (ks0).to(tl.float64))",
+        )
+
+    def test_pow_preserves_integer_dtype_for_unsigned_scalar_exponents(self):
+        exponent = CSEVariable("ks0", ValueRanges.unknown(), torch.uint32)
+
+        self.assertEqual(
+            DtypePropagationOpsHandler().pow(2, exponent),
+            promote_types([2, exponent]),
         )
 
 

--- a/test/inductor/test_codegen_triton.py
+++ b/test/inductor/test_codegen_triton.py
@@ -6,11 +6,13 @@ import sympy
 import torch
 import torch._inductor.config as inductor_config
 from torch._inductor.codegen import triton_utils
-from torch._inductor.codegen.common import SizeArg
+from torch._inductor.codegen.common import CSEVariable, SizeArg
+from torch._inductor.codegen.triton import TritonKernelOverrides
 from torch._inductor.graph import GraphLowering
 from torch._inductor.test_case import TestCase as InductorTestCase
 from torch._inductor.virtualized import V
 from torch.testing._internal.inductor_utils import HAS_CPU, HAS_GPU
+from torch.utils._sympy.value_ranges import ValueRanges
 
 
 class TestCodegenTriton(InductorTestCase):
@@ -112,6 +114,19 @@ class TestCodegenTriton(InductorTestCase):
 
         self.assertTrue(
             V.graph.sizevars.statically_known_multiple_of(s2, 16),
+        )
+
+    def test_pow_uses_active_override_constant_lowering(self):
+        exponent = CSEVariable("ks0", ValueRanges.unknown(), torch.int64)
+
+        class TestTritonKernelOverrides(TritonKernelOverrides):
+            @classmethod
+            def constant(cls, value, dtype):
+                return f"custom_constant({value}, {dtype})"
+
+        self.assertEqual(
+            TestTritonKernelOverrides.pow(2, exponent),
+            "libdevice.pow(custom_constant(2, torch.float64), (ks0).to(tl.float64))",
         )
 
 

--- a/test/inductor/test_codegen_triton.py
+++ b/test/inductor/test_codegen_triton.py
@@ -148,7 +148,7 @@ class TestCodegenTriton(InductorTestCase):
 
         self.assertEqual(
             TestTritonKernelOverrides.pow(3, exponent),
-            "triton_helpers.pow_integer(custom_constant(3, torch.int64), ks0)",
+            "triton_helpers.pow_integer(custom_constant(3, torch.uint32), ks0)",
         )
 
 

--- a/test/inductor/test_codegen_triton.py
+++ b/test/inductor/test_codegen_triton.py
@@ -138,6 +138,19 @@ class TestCodegenTriton(InductorTestCase):
             promote_types([2, exponent]),
         )
 
+    def test_pow_uses_integer_helper_for_unsigned_scalar_exponents(self):
+        exponent = CSEVariable("ks0", ValueRanges.unknown(), torch.uint32)
+
+        class TestTritonKernelOverrides(TritonKernelOverrides):
+            @classmethod
+            def constant(cls, value, dtype):
+                return f"custom_constant({value}, {dtype})"
+
+        self.assertEqual(
+            TestTritonKernelOverrides.pow(3, exponent),
+            "triton_helpers.pow_integer(custom_constant(3, torch.int64), ks0)",
+        )
+
 
 if __name__ == "__main__":
     from torch._inductor.test_case import run_tests

--- a/test/inductor/test_unbacked_symints.py
+++ b/test/inductor/test_unbacked_symints.py
@@ -757,6 +757,22 @@ class TestUnbackedSymints(InductorTestCase):
         expected = fn(*example_inputs)
         torch.testing.assert_close(actual, expected)
 
+    @skipCPUIf(True, "Triton codegen bug only affects GPU")
+    @skipGPUIf(not HAS_GPU, "requires gpu and triton")
+    @dynamo_config.patch({"capture_scalar_outputs": True})
+    def test_triton_pow_symbolic_negative_int_exponent(self, device):
+        def fn(x, exponent_src):
+            exponent = exponent_src.max().to(torch.int64) - 1
+            return x * (2**exponent)
+
+        example_inputs = (
+            torch.randn(128, device=device, dtype=torch.float16),
+            torch.tensor([0], device=device, dtype=torch.int64),
+        )
+        actual = torch.compile(fn, fullgraph=True, dynamic=True)(*example_inputs)
+        expected = fn(*example_inputs)
+        torch.testing.assert_close(actual, expected)
+
 
 instantiate_device_type_tests(TestUnbackedSymints, globals(), allow_xpu=True)
 

--- a/test/inductor/test_unbacked_symints.py
+++ b/test/inductor/test_unbacked_symints.py
@@ -720,6 +720,43 @@ class TestUnbackedSymints(InductorTestCase):
         expected = fn(*example_inputs)
         torch.testing.assert_close(actual, expected)
 
+    @skipCPUIf(True, "Triton codegen bug only affects GPU")
+    @skipGPUIf(not HAS_GPU, "requires gpu and triton")
+    @dynamo_config.patch({"capture_scalar_outputs": True})
+    def test_triton_pow_symbolic_int_exponent(self, device):
+        """
+        Test that symbolic integer scalar exponents are cast before libdevice.pow.
+
+        Reproducer from https://github.com/pytorch/pytorch/issues/177131:
+        capture_scalar_outputs=True can pass a scalar like num_bits as an int64 ks*
+        kernel argument, which previously led Triton to reject libdevice.pow(2.0, ks0).
+        """
+
+        def calculate_range(num_bits, device):
+            bit_range = 2**num_bits
+            q_max = torch.tensor(bit_range / 2 - 1, device=device)
+            q_min = torch.tensor(-bit_range / 2, device=device)
+            return q_min, q_max
+
+        def fn(x, num_bits):
+            q_min, q_max = calculate_range(num_bits, x.device)
+            bit_range = q_max - q_min
+            max_val = torch.max(torch.abs(x))
+            scale = max_val / (float(bit_range) / 2)
+            scale = torch.where(
+                scale == 0,
+                torch.tensor(1e-10, device=x.device, dtype=x.dtype),
+                scale,
+            )
+            x_q = torch.clamp(torch.round(x / scale), q_min, q_max)
+            x_dq = x_q * scale
+            return (x_dq - x).abs().pow(2.4).sum(), scale, scale
+
+        example_inputs = (torch.randn(1, 1, 128, device=device, dtype=torch.float16), 8)
+        actual = torch.compile(fn, fullgraph=True, dynamic=True)(*example_inputs)
+        expected = fn(*example_inputs)
+        torch.testing.assert_close(actual, expected)
+
 
 instantiate_device_type_tests(TestUnbackedSymints, globals(), allow_xpu=True)
 

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -1885,6 +1885,7 @@ class TritonOverrides(OpOverrides):
     def ceil(x):
         return f"libdevice.ceil({x})"
 
+
 # Register the custom pow override after class creation so type checkers see
 # a plain callable instead of the class-body staticmethod descriptor.
 OpDtypeSupport.register_upcast(TritonOverrides.pow, True)

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -1784,6 +1784,15 @@ class TritonOverrides(OpOverrides):
     @classmethod
     def pow(cls, a, b):
         result_dtype = get_dtype_handler().pow(a, b)
+        if result_dtype is not None and is_integer_dtype(result_dtype):
+            base = cls._cast_libdevice_arg(a, result_dtype)
+            exponent = (
+                cls.constant(b, torch.int64)
+                if isinstance(b, torch._prims_common.Number)
+                else f"{b}"
+            )
+            return f"triton_helpers.pow_integer({base}, {exponent})"
+
         any_needs_upcast = needs_upcast_to_float32(a) or needs_upcast_to_float32(b)
         pow_dtype = result_dtype
         if pow_dtype not in (torch.float32, torch.float64):

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -1807,8 +1807,6 @@ class TritonOverrides(OpOverrides):
                 result = f"{result}.to({triton_type(result_dtype)})"
         return result
 
-    OpDtypeSupport.register_upcast(pow.__func__, True)
-
     @staticmethod
     @maybe_upcast_float32()
     def log(x):
@@ -1878,7 +1876,9 @@ class TritonOverrides(OpOverrides):
     def ceil(x):
         return f"libdevice.ceil({x})"
 
-
+# Register the custom pow override after class creation so type checkers see
+# a plain callable instead of the class-body staticmethod descriptor.
+OpDtypeSupport.register_upcast(TritonOverrides.pow, True)
 TritonOverrides._initialize_pointwise_overrides("triton")
 
 

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -1781,8 +1781,8 @@ class TritonOverrides(OpOverrides):
     def fmod(a, b):
         return f"libdevice.fmod({a}, {b})"
 
-    @staticmethod
-    def pow(a, b):
+    @classmethod
+    def pow(cls, a, b):
         result_dtype = get_dtype_handler().pow(a, b)
         any_needs_upcast = needs_upcast_to_float32(a) or needs_upcast_to_float32(b)
         pow_dtype = result_dtype
@@ -1796,8 +1796,8 @@ class TritonOverrides(OpOverrides):
                 else torch.float64
             )
 
-        cast_a = TritonOverrides._cast_libdevice_arg(a, pow_dtype)
-        cast_b = TritonOverrides._cast_libdevice_arg(b, pow_dtype)
+        cast_a = cls._cast_libdevice_arg(a, pow_dtype)
+        cast_b = cls._cast_libdevice_arg(b, pow_dtype)
         result = f"libdevice.pow({cast_a}, {cast_b})"
         if result_dtype is not None and result_dtype != pow_dtype:
             if low_precision_fp(result_dtype):

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -26,7 +26,7 @@ import torch._logging
 import torch.utils._pytree as pytree
 from torch._dynamo.device_interface import get_interface_for_device
 from torch._dynamo.utils import identity, preserve_rng_state
-from torch._prims_common import is_integer_dtype
+from torch._prims_common import is_integer_dtype, type_to_dtype
 from torch.utils._ordered_set import OrderedSet
 from torch.utils._sympy.functions import CeilDiv, FloorDiv, ModularIndexing
 from torch.utils._triton import (
@@ -1018,6 +1018,22 @@ def low_precision_fp_var(var: CSEVariable | Any) -> bool:
     return low_precision_fp(dtype) if isinstance(dtype, torch.dtype) else False
 
 
+def triton_arg_dtype(arg: Any) -> torch.dtype | None:
+    if isinstance(arg, CSEVariable):
+        return arg.dtype
+    if isinstance(arg, torch._prims_common.Number):
+        return type_to_dtype(type(arg))
+    return None
+
+
+def needs_upcast_to_float32(arg: Any) -> bool:
+    return (
+        not config.triton.codegen_upcast_to_fp32
+        and isinstance(arg, CSEVariable)
+        and arg.dtype in (torch.float16, torch.bfloat16)
+    )
+
+
 class TritonCSEVariable(CSEVariable):
     def __init__(
         self,
@@ -1058,15 +1074,8 @@ def maybe_upcast_float32(convert_output: bool = True) -> Callable[[_T], _T]:
     This decorates tl.math/libdevice codegen functions.
     """
 
-    def needs_upcast(var) -> bool:
-        return (
-            not config.triton.codegen_upcast_to_fp32
-            and isinstance(var, CSEVariable)
-            and var.dtype in (torch.float16, torch.bfloat16)
-        )
-
     def maybe_upcast_arg(var) -> str:
-        upcast_string = ".to(tl.float32)" if needs_upcast(var) else ""
+        upcast_string = ".to(tl.float32)" if needs_upcast_to_float32(var) else ""
         return f"{var}{upcast_string}"
 
     def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
@@ -1081,7 +1090,8 @@ def maybe_upcast_float32(convert_output: bool = True) -> Callable[[_T], _T]:
             # Call the decorated function, optionally downcasting the result.
             result = func(*upcast_args, **upcast_kwargs)
             any_needs_upcast = convert_output and any(
-                needs_upcast(var) for var in itertools.chain(args, kwargs.values())
+                needs_upcast_to_float32(var)
+                for var in itertools.chain(args, kwargs.values())
             )
             result_dtype = (
                 None
@@ -1210,6 +1220,14 @@ class TritonOverrides(OpOverrides):
     @classmethod
     def constant(cls, value, dtype):
         return cls._shaped_constant(value, dtype, shape=[])
+
+    @classmethod
+    def _cast_libdevice_arg(cls, arg, dtype: torch.dtype) -> str:
+        if isinstance(arg, torch._prims_common.Number):
+            return cls.constant(arg, dtype)
+        if triton_arg_dtype(arg) == dtype:
+            return f"{arg}"
+        return f"({arg}).to({triton_type(dtype)})"
 
     @staticmethod
     @maybe_upcast_float32()
@@ -1764,9 +1782,32 @@ class TritonOverrides(OpOverrides):
         return f"libdevice.fmod({a}, {b})"
 
     @staticmethod
-    @maybe_upcast_float32()
     def pow(a, b):
-        return f"libdevice.pow({a}, {b})"
+        result_dtype = get_dtype_handler().pow(a, b)
+        any_needs_upcast = needs_upcast_to_float32(a) or needs_upcast_to_float32(b)
+        pow_dtype = result_dtype
+        if pow_dtype not in (torch.float32, torch.float64):
+            # libdevice.pow only accepts fp32/fp64. Keep low-precision floating
+            # cases on the existing fp32 path, and otherwise fall back to fp64
+            # for symbolic integer scalar pow expressions like 2 ** ks0.
+            pow_dtype = (
+                torch.float32
+                if low_precision_fp(result_dtype) or any_needs_upcast
+                else torch.float64
+            )
+
+        cast_a = TritonOverrides._cast_libdevice_arg(a, pow_dtype)
+        cast_b = TritonOverrides._cast_libdevice_arg(b, pow_dtype)
+        result = f"libdevice.pow({cast_a}, {cast_b})"
+        if result_dtype is not None and result_dtype != pow_dtype:
+            if low_precision_fp(result_dtype):
+                if any_needs_upcast:
+                    result = f"{result}.to({triton_type(result_dtype)})"
+            else:
+                result = f"{result}.to({triton_type(result_dtype)})"
+        return result
+
+    OpDtypeSupport.register_upcast(pow.__func__, True)
 
     @staticmethod
     @maybe_upcast_float32()

--- a/torch/_inductor/dtype_propagation.py
+++ b/torch/_inductor/dtype_propagation.py
@@ -20,12 +20,14 @@ from .virtualized import OpsValue, V
 
 T = TypeVar("T")
 _MISSING_SHAPE = object()
-_UNSIGNED_INT_DTYPES = {
-    torch.uint8,
-    torch.uint16,
-    torch.uint32,
-    torch.uint64,
-}
+_UNSIGNED_INT_DTYPES: frozenset[torch.dtype] = frozenset(
+    {
+        torch.uint8,
+        torch.uint16,
+        torch.uint32,
+        torch.uint64,
+    }
+)
 
 
 class DTypeVar(Protocol):
@@ -112,7 +114,12 @@ def _is_scalar_dtype_arg(arg: DTypeArg) -> bool:
     if shape is _MISSING_SHAPE:
         return False
 
-    return shape is None or len(shape) == 0
+    if shape is None:
+        return True
+    if not isinstance(shape, Sequence):
+        return False
+
+    return len(shape) == 0
 
 
 def _has_known_nonnegative_scalar_int_value(arg: DTypeArg) -> bool:

--- a/torch/_inductor/dtype_propagation.py
+++ b/torch/_inductor/dtype_propagation.py
@@ -21,12 +21,12 @@ from .virtualized import OpsValue, V
 T = TypeVar("T")
 _MISSING_SHAPE = object()
 _UNSIGNED_INT_DTYPES: frozenset[torch.dtype] = frozenset(
-    {
+    (
         torch.uint8,
         torch.uint16,
         torch.uint32,
         torch.uint64,
-    }
+    )
 )
 
 

--- a/torch/_inductor/dtype_propagation.py
+++ b/torch/_inductor/dtype_propagation.py
@@ -6,7 +6,11 @@ from typing import Any, Optional, Protocol, TYPE_CHECKING, TypeVar
 import sympy
 
 import torch
-from torch._prims_common import ELEMENTWISE_TYPE_PROMOTION_KIND, type_to_dtype
+from torch._prims_common import (
+    ELEMENTWISE_TYPE_PROMOTION_KIND,
+    is_integer_dtype,
+    type_to_dtype,
+)
 from torch.utils._ordered_set import OrderedSet
 
 from .ops_handler import OP_NAMES, OpsHandler
@@ -77,6 +81,44 @@ def promote_types(
     )
 
     return dtype
+
+
+def _unwrap_dtype_arg(arg: DTypeArg) -> DTypeVar | torch.types.Number | str:
+    if isinstance(arg, OpsValue):
+        return arg.value
+    return arg
+
+
+def _is_scalar_dtype_arg(arg: DTypeArg) -> bool:
+    arg = _unwrap_dtype_arg(arg)
+    if isinstance(arg, torch._prims_common.Number):
+        return True
+
+    shape = getattr(arg, "shape", None)
+    if shape is None:
+        return False
+
+    return len(shape) == 0
+
+
+def _has_known_nonnegative_scalar_int_value(arg: DTypeArg) -> bool:
+    arg = _unwrap_dtype_arg(arg)
+
+    if isinstance(arg, bool):
+        return True
+    if isinstance(arg, int):
+        return arg >= 0
+
+    dtype = getattr(arg, "dtype", None)
+    if dtype is None or not is_integer_dtype(dtype):
+        return False
+
+    lower = getattr(getattr(arg, "bounds", None), "lower", None)
+    if lower is None:
+        return False
+    if isinstance(lower, sympy.Expr):
+        return lower.is_nonnegative is True
+    return lower >= 0
 
 
 class DtypePropagationOpsHandler:
@@ -217,7 +259,18 @@ class DtypePropagationOpsHandler:
 
     @staticmethod
     def pow(a: DTypeArg, b: DTypeArg) -> torch.dtype:
-        return promote_types([a, b])
+        dtype = promote_types([a, b])
+        if (
+            is_integer_dtype(dtype)
+            and _is_scalar_dtype_arg(a)
+            and _is_scalar_dtype_arg(b)
+            and not _has_known_nonnegative_scalar_int_value(b)
+        ):
+            # Scalar integer pow follows Python semantics: negative exponents
+            # produce a floating result, even though tensor integer pow stays
+            # integral or errors out in separate lowering paths.
+            return torch.float64
+        return dtype
 
     @staticmethod
     def mod(a: DTypeArg, b: DTypeArg) -> torch.dtype:

--- a/torch/_inductor/dtype_propagation.py
+++ b/torch/_inductor/dtype_propagation.py
@@ -19,6 +19,13 @@ from .virtualized import OpsValue, V
 
 
 T = TypeVar("T")
+_MISSING_SHAPE = object()
+_UNSIGNED_INT_DTYPES = {
+    torch.uint8,
+    torch.uint16,
+    torch.uint32,
+    torch.uint64,
+}
 
 
 class DTypeVar(Protocol):
@@ -94,11 +101,18 @@ def _is_scalar_dtype_arg(arg: DTypeArg) -> bool:
     if isinstance(arg, torch._prims_common.Number):
         return True
 
-    shape = getattr(arg, "shape", None)
-    if shape is None:
+    is_scalar = getattr(arg, "is_scalar", False)
+    if callable(is_scalar):
+        if is_scalar():
+            return True
+    elif is_scalar:
+        return True
+
+    shape = getattr(arg, "shape", _MISSING_SHAPE)
+    if shape is _MISSING_SHAPE:
         return False
 
-    return len(shape) == 0
+    return shape is None or len(shape) == 0
 
 
 def _has_known_nonnegative_scalar_int_value(arg: DTypeArg) -> bool:
@@ -112,6 +126,8 @@ def _has_known_nonnegative_scalar_int_value(arg: DTypeArg) -> bool:
     dtype = getattr(arg, "dtype", None)
     if dtype is None or not is_integer_dtype(dtype):
         return False
+    if dtype in _UNSIGNED_INT_DTYPES:
+        return True
 
     lower = getattr(getattr(arg, "bounds", None), "lower", None)
     if lower is None:

--- a/torch/_inductor/runtime/triton_helpers.py
+++ b/torch/_inductor/runtime/triton_helpers.py
@@ -89,6 +89,23 @@ def remainder_integer(a, b):
 
 
 @triton.jit
+def pow_integer(base, exponent):
+    # Triton has no exact integer pow primitive; use repeated squaring for
+    # nonnegative integer exponents so integral scalar pow does not round
+    # through libdevice.pow before casting back to int.
+    exponent_dtype: tl.constexpr = tl.core.get_int_dtype(
+        exponent.dtype.primitive_bitwidth, signed=False
+    )
+    exp = exponent.to(exponent_dtype)
+    result = tl.full(base.shape, 1, base.dtype)
+    for _ in tl.static_range(exponent_dtype.primitive_bitwidth):
+        result = tl.where((exp & 1) != 0, result * base, result)
+        exp = exp >> 1
+        base = base * base
+    return result
+
+
+@triton.jit
 def is_floating(x):
     return promote_to_tensor(x).dtype.is_floating()
 


### PR DESCRIPTION
## Summary

### Root cause problem
- Scalar `pow` was relying on generic dtype propagation, so symbolic integer scalar exponents could stay on an integer path even when the exponent was not provably non-negative.
- That left Triton lowering to patch over integer-vs-floating `pow` semantics late, and one literal-casting helper also hard-coded the base `constant()` path instead of respecting the active override class.
- Even after that, the remaining integral scalar `pow` path still used `libdevice.pow` in floating point and cast the result back to an integer, which can silently round large exact integer results.

### Proposed fix
- Make scalar `pow` dtype propagation scalar-aware and sign-aware: treat shape-less scalar-like values as scalars, preserve integral results only for provably non-negative scalar integer exponents, and otherwise propagate as `float64`.
- In Triton `pow`, cast literal operands through the active override class so backend-specific `constant()` lowering is preserved.
- For integral scalar `pow` results in Triton, lower through an exact repeated-squaring integer helper instead of `libdevice.pow(...).to(int)`.
- Add focused regressions for the original `capture_scalar_outputs=True` repro, symbolic negative exponents, unsigned scalar exponents, override-specific constant lowering, and the exact integer helper path.

### Why this is the right long term fix
- `pow` result semantics should be decided in shared dtype propagation and override dispatch, not by ad hoc casts after lowering has already committed to an integer result.
- Keeping integral scalar `pow` on an exact integer helper avoids silent float round-trips while preserving backend-specific constant lowering and future override subclasses.
- This keeps symbolic scalar `pow` on the same path as future backends and override subclasses, including ROCm-specific constant lowering, instead of accumulating one-off codegen special cases.

Co-authored with Codex,  reviewed and published by @bobrenjc93

Fix #177131

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo