### PR TITLE
Fix logspam from deprecated config warnings

### DIFF
--- a/test/test_utils_config_module.py
+++ b/test/test_utils_config_module.py
@@ -494,6 +494,34 @@ torch.testing._internal.fake_config_module3.e_func = _warnings.warn""",
             self.assertIn("e_deprecated_alias", str(w[0].message))
             self.assertIn("use something else instead", str(w[0].message))
 
+    def test_no_warnings_for_normal_user_code(self):
+        """Test that normal user operations don't produce deprecation warnings."""
+        import torch
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            # Simple user code - compile and run a function
+            @torch.compile(backend="eager")
+            def fn(x):
+                return x + 1
+
+            _ = fn(torch.ones(3))
+
+            # No deprecation warnings should be issued from config system
+            deprecation_warnings = [
+                warning
+                for warning in w
+                if issubclass(warning.category, FutureWarning)
+                and "deprecated" in str(warning.message).lower()
+                and "config" in str(warning.message).lower()
+            ]
+            self.assertEqual(
+                len(deprecation_warnings),
+                0,
+                f"Unexpected config deprecation warnings: {[str(x.message) for x in deprecation_warnings]}",
+            )
+
 
 if __name__ == "__main__":
     run_tests()

--- a/torch/utils/_config_module.py
+++ b/torch/utils/_config_module.py
@@ -443,16 +443,6 @@ class ConfigModule(ModuleType):
             # make hasattr() work properly
             raise AttributeError(f"{self.__name__}.{name} does not exist") from e
 
-    def _get_value_silent(self, key: str) -> Any:
-        """Get config value without triggering or consuming deprecation warning."""
-        config = self._config[key]
-        old_warned = config._deprecation_warned
-        config._deprecation_warned = True
-        try:
-            return getattr(self, key)
-        finally:
-            config._deprecation_warned = old_warned
-
     def __delattr__(self, name: str) -> None:
         self._is_dirty = True
         # must support delete because unittest.mock.patch deletes
@@ -547,7 +537,12 @@ class ConfigModule(ModuleType):
                 continue
             if self._config[key].alias is not None:
                 continue
-            config[key] = copy.deepcopy(self._get_value_silent(key))
+
+            curr_entry = self._config[key]
+            has_been_warned = curr_entry._deprecation_warned
+            curr_entry._deprecation_warned = True
+            config[key] = copy.deepcopy(getattr(self, key))
+            curr_entry._deprecation_warned = has_been_warned
 
         return config
 

--- a/torch/utils/_config_module.py
+++ b/torch/utils/_config_module.py
@@ -443,6 +443,16 @@ class ConfigModule(ModuleType):
             # make hasattr() work properly
             raise AttributeError(f"{self.__name__}.{name} does not exist") from e
 
+    def _get_value_silent(self, key: str) -> Any:
+        """Get config value without triggering or consuming deprecation warning."""
+        config = self._config[key]
+        old_warned = config._deprecation_warned
+        config._deprecation_warned = True
+        try:
+            return getattr(self, key)
+        finally:
+            config._deprecation_warned = old_warned
+
     def __delattr__(self, name: str) -> None:
         self._is_dirty = True
         # must support delete because unittest.mock.patch deletes
@@ -537,7 +547,7 @@ class ConfigModule(ModuleType):
                 continue
             if self._config[key].alias is not None:
                 continue
-            config[key] = copy.deepcopy(getattr(self, key))
+            config[key] = copy.deepcopy(self._get_value_silent(key))
 
         return config
 


### PR DESCRIPTION
Issue from #169837

Internal operations like `get_config_copy()` were triggering deprecation warnings during metrics collection when they iterated through all configs, including deprecated ones the user never touched. This also consumed the warning state, preventing users from seeing it later.

Added `_get_value_silent()` to temporarily suppress warnings during batch config reads while preserving the warning state for user code. 
 
Hope this addresses all the issues @williamwen42 


cc @mlazos