### PR TITLE
test: adds setUp to TestMemPool

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -5897,7 +5897,9 @@ class TestMemPool(TestCase):
         super().setUp()
         # Ensure a clean state for memory pool tests. Some tests in this class or
         # previous classes might have changed allocator settings.
-        torch.cuda.memory._set_allocator_settings("expandable_segments:False,graph_capture_record_stream_reuse:False")
+        torch.cuda.memory._set_allocator_settings(
+            "expandable_segments:False,graph_capture_record_stream_reuse:False"
+        )
         gc.collect()
         torch.cuda.synchronize()
         torch.cuda.empty_cache()

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -5893,6 +5893,15 @@ class TestCachingHostAllocatorCudaGraph(TestCase):
 
 @unittest.skipIf(not TEST_CUDA, "CUDA not available, skipping tests")
 class TestMemPool(TestCase):
+    def setUp(self):
+        super().setUp()
+        # Ensure a clean state for memory pool tests. Some tests in this class or
+        # previous classes might have changed allocator settings.
+        torch.cuda.memory._set_allocator_settings("expandable_segments:False,graph_capture_record_stream_reuse:False")
+        gc.collect()
+        torch.cuda.synchronize()
+        torch.cuda.empty_cache()
+
     def _setup_mempool_limited_memory_test(self, additional_allowed_memory_in_mb):
         device = torch.device("cuda:0")
 


### PR DESCRIPTION
This change is needed to clean up allocator settings of previous test cases.
```python
File "third_party/py/torch/test/test_cuda.py", 6148, in test_mempool_no_split
    raise AssertionError(
AssertionError: Expected no_split pool to have more segments, but got 1 vs 1
```