### PR TITLE
Support negative index slicing with backed symints

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -1901,6 +1901,41 @@ class AOTInductorTestsTemplate:
         self.check_model(model, example_inputs, dynamic_shapes=spec)
         torch.cuda.caching_allocator_enable(True)
 
+    @skipIfMPS
+    @config.patch({"triton.autotune_at_compile_time": None})
+    @torch.fx.experimental._config.patch("backed_size_oblivious", True)
+    def test_slice_negative_index_backed_symints_no_unbacked(self):
+        # x[-s1:] where x.size(0) = s0-1 should produce Max(s0-1 - s1, 0),
+        # not an unbacked symint with a bad fallback value.
+        if self.device != GPU_TYPE:
+            raise unittest.SkipTest("requires triton")
+
+        INNER_DIM = 4224
+
+        class Repro(torch.nn.Module):
+            def forward(self, x, y):
+                x_trimmed = x[:-1]
+                sliced = x_trimmed[-y.size(0) :]
+                reshaped = sliced.reshape(-1, 128, 33)
+                expanded = reshaped.unsqueeze(3).expand(-1, 128, 33, 8)
+                shifts = torch.arange(0, 64, 8, device=x.device, dtype=torch.int64)
+                return (expanded >> shifts) & 255
+
+        torch.cuda.caching_allocator_enable(False)
+        model = Repro()
+        example_inputs = (
+            torch.randint(
+                0, 256, (200, INNER_DIM), device=self.device, dtype=torch.int64
+            ),
+            torch.randn(50, 8, device=self.device),
+        )
+        spec = {
+            "x": (Dim.DYNAMIC, Dim.STATIC),
+            "y": (Dim.DYNAMIC, Dim.STATIC),
+        }
+        self.check_model(model, example_inputs, dynamic_shapes=spec)
+        torch.cuda.caching_allocator_enable(True)
+
     @config.patch({"triton.autotune_at_compile_time": None})
     def test_stride_with_unbacked_expr(self):
         class Repro(torch.nn.Module):

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -3613,6 +3613,13 @@ class SliceView(View):
         if any(free_unbacked_symbols(x) for x in (start, end, dim_size)):
             min_func = sympy.Min
             max_func = sympy.Max
+        elif any(
+            x.has(sympy.Min, sympy.Max)
+            for x in (start, end, dim_size)
+            if isinstance(x, Expr)
+        ):
+            min_func = sympy.Min
+            max_func = sympy.Max
         else:
             min_func = sizevars.evaluate_min
             max_func = sizevars.evaluate_max

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -1338,6 +1338,8 @@ def slice_(x, dim=0, start=0, end=2**63, step=1, clamp=True):
         elif fn(sympy.Ge(index, 0)):
             # If index >= 0, the resolved index is at most min(index, size).
             return sympy.Min(index, size)
+        elif fn(sympy.Lt(index, 0)):
+            return sympy.Max(index + size, 0)
         return None
 
     start_index, end_index = None, None

--- a/torch/_inductor/sizevars.py
+++ b/torch/_inductor/sizevars.py
@@ -555,6 +555,13 @@ class SizeVarAllocator:
         for lhs, rhs in [(left, right), (right, left)]:
             if isinstance(lhs, sympy.Min) and rhs in lhs.args:
                 return lhs  # Min(Min(a, b), b) = Min(a, b)
+            if isinstance(lhs, sympy.Max) and rhs in lhs.args:
+                return rhs  # Min(Max(a, b), b) = b
+            # If lhs = Max(a1, a2, ...) and all ai <= rhs, then Max(...) <= rhs.
+            if isinstance(lhs, sympy.Max) and all(
+                self.guard_or_false(sympy.Le(a, rhs)) for a in lhs.args
+            ):
+                return lhs  # Min(Max(a, b), c) = Max(a, b) when a <= c and b <= c
 
         raise TypeError(
             f"evaluate_min({left}, {right}) with unbacked symints"

--- a/torch/_subclasses/fake_impls.py
+++ b/torch/_subclasses/fake_impls.py
@@ -946,6 +946,8 @@ def _compute_slice_index(size: IntLikeType, index: IntLikeType) -> IntLikeType |
         return size
     elif guard_or_false(index >= 0):
         return torch.sym_min(index, size)
+    elif guard_or_false(index < 0):
+        return torch.sym_max(index + size, 0)
 
     return None
 
@@ -991,6 +993,12 @@ def slice_forward(
             new_size = (end_index - start_index + step - 1) // step
         elif guard_or_false(start_index >= end_index):
             new_size = 0
+        else:
+            # Both indices are resolved but we can't statically determine their
+            # ordering (e.g., when they involve Min/Max). Compute the size via
+            # max(end - start, 0) to avoid creating an unbacked symint.
+            diff = torch.sym_max(end_index - start_index, 0)
+            new_size = (diff + step - 1) // step
 
     # create unbacked if case unknown
     if new_size is None:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #177280
* #175819

Add handling for negative slice indices (e.g., x[-s1:]) when the index
is a backed symint in size-oblivious mode. Previously this produced an
unbacked symint with a bad fallback value; now it produces
Max(index + size, 0).

Changes across three layers:
- fake_impls: resolve negative index via sym_max(index + size, 0) and
  compute slice size via sym_max(end - start, 0) when guard_or_false
  can't determine start/end ordering
- lowering: add the matching negative index branch
- sizevars: add Max reasoning to evaluate_min (arg-match and
  all-args-bounded cases)
- ir: use sympy.Min/Max instead of evaluate_min/max when expressions
  already contain Min/Max nodes

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo