### PR TITLE
[release] Add release summary generation script

### DIFF
--- a/scripts/release/release_summary.sh
+++ b/scripts/release/release_summary.sh
@@ -3,8 +3,8 @@
 #   "This release is composed of 4160 commits from 536 contributors since PyTorch 2.9."
 #
 # Usage:
-#   ./scripts/release_summary.sh                    # auto-detect latest release
-#   ./scripts/release_summary.sh v2.10.0 v2.9.0     # explicit current and previous tags
+#   ./scripts/release/release_summary.sh                    # auto-detect latest release
+#   ./scripts/release/release_summary.sh v2.10.0 v2.9.0     # explicit current and previous tags
 
 set -euo pipefail
 

--- a/scripts/release_summary.sh
+++ b/scripts/release_summary.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Generate a release summary line like:
+#   "This release is composed of 4160 commits from 536 contributors since PyTorch 2.9."
+#
+# Usage:
+#   ./scripts/release_summary.sh                    # auto-detect latest release
+#   ./scripts/release_summary.sh v2.10.0 v2.9.0     # explicit current and previous tags
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+if [ $# -ge 2 ]; then
+    CURRENT_TAG="$1"
+    PREVIOUS_TAG="$2"
+elif [ $# -eq 1 ]; then
+    CURRENT_TAG="$1"
+    # Derive previous minor version tag
+    version="${CURRENT_TAG#v}"
+    major="${version%%.*}"
+    rest="${version#*.}"
+    minor="${rest%%.*}"
+    prev_minor=$((minor - 1))
+    PREVIOUS_TAG="v${major}.${prev_minor}.0"
+else
+    # Auto-detect: find the latest vX.Y.0 release tag
+    CURRENT_TAG=$(git tag -l 'v[0-9]*.[0-9]*.0' | sort -V | tail -1)
+    if [ -z "$CURRENT_TAG" ]; then
+        echo "Error: no release tags found" >&2
+        exit 1
+    fi
+    version="${CURRENT_TAG#v}"
+    major="${version%%.*}"
+    rest="${version#*.}"
+    minor="${rest%%.*}"
+    prev_minor=$((minor - 1))
+    PREVIOUS_TAG="v${major}.${prev_minor}.0"
+fi
+
+# Validate tags exist
+for tag in "$CURRENT_TAG" "$PREVIOUS_TAG"; do
+    if ! git rev-parse "$tag" >/dev/null 2>&1; then
+        echo "Error: tag '$tag' not found" >&2
+        exit 1
+    fi
+done
+
+commits=$(git log --oneline "${PREVIOUS_TAG}..${CURRENT_TAG}" | wc -l | tr -d ' ')
+contributors=$(git shortlog -sn "${PREVIOUS_TAG}..${CURRENT_TAG}" | wc -l | tr -d ' ')
+
+# Extract version number for display (e.g., v2.9.0 -> 2.9)
+prev_display="${PREVIOUS_TAG#v}"
+prev_display="${prev_display%.0}"
+
+echo "This release is composed of ${commits} commits from ${contributors} contributors since PyTorch ${prev_display}."


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #177282

Adds a convenience script to generate the release summary line used in
blog posts (e.g., "This release is composed of N commits from M
contributors since PyTorch X.Y.").

Supports auto-detection of the latest release tag, single-arg mode
(derives previous minor), and fully explicit two-arg mode.

Running for 2.11.0 final rc release:
```
./summary.sh v2.11.0-rc4 v2.10.0
This release is composed of 2723 commits from 432 contributors since PyTorch 2.10.
```