### PR TITLE
RFC : WIP warmup compile with fake tensor with dynamic dims then run with real

### DIFF
--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -1367,6 +1367,74 @@ class TestInductorDynamic(TestCase):
         # Test backward pass as well - this is where the bug manifested
         out_compiled.sum().backward()
 
+    def test_compile_with_fake_tensor_dynamic_shapes(self, device):
+        """
+        Test that torch.compile works with FakeTensors that have dynamic shapes.
+        
+        This tests the JIT compilation flow where:
+        1. A FakeTensor with symbolic dim0 (dynamic) and static dim1 is passed
+        2. Compilation happens, but kernel execution is short-circuited for FakeTensors
+        3. Real tensors can then use the cached compiled code
+        """
+        from torch._subclasses.fake_tensor import FakeTensorMode
+        from torch.fx.experimental.symbolic_shapes import (
+            ShapeEnv,
+            DimDynamic,
+            StatelessSymbolicContext,
+        )
+        from torch._dynamo.source import ConstantSource
+
+        @torch.compile(backend="inductor", dynamic=True)
+        def fn1(x):
+            if x.size()[0] > 10:
+                return x.sum(dim=0) + x.mean()
+            else:
+                return x * 100
+
+        @torch.compile(backend="inductor", dynamic=True)
+        def fn2(x, y):
+            return x + y * 100
+
+        def program(x):
+            # eager code
+            fake_x = x + 100
+            tmp1 = fn1(fake_x)
+            # more eager
+            tmp2 = tmp1.contiguous()
+            tmp3 = fn2(tmp1, tmp1)
+            return tmp3
+
+        shape_env = ShapeEnv()
+
+        with FakeTensorMode(shape_env=shape_env) as mode:
+            source = ConstantSource("test_input")
+            # Create symbolic sizes: dim0 is DYNAMIC, dim1 is STATIC
+            sym_sizes, sym_strides, _ = shape_env.create_symbolic_sizes_strides_storage_offset(
+                torch.empty(10, 10, device=device),
+                source=source,
+                symbolic_context=StatelessSymbolicContext(
+                    dynamic_sizes=[DimDynamic.DYNAMIC, DimDynamic.STATIC],
+                ),
+            )
+
+            # Create fake tensor with symbolic shape directly on device
+            fake_x = torch.empty_strided(sym_sizes, sym_strides, device=device)
+
+            # Warm up with fake tensor with batch size marked dynamic
+            result_fake = program(fake_x)
+            # FakeTensor output should have symbolic shape
+            self.assertTrue(hasattr(result_fake.shape[0], '__sym_int__') or 
+                          str(result_fake.shape[0]).startswith('s'))
+
+            # Run with real tensors - should use cached compiled code
+            result_real1 = program(torch.rand(100, 10, device=device))
+            # With size > 10, fn1 returns sum(dim=0) which has shape [10]
+            self.assertEqual(result_real1.shape, torch.Size([10]))
+
+            # Run with different batch size - dynamic shapes should handle this
+            result_real2 = program(torch.rand(200, 10, device=device))
+            self.assertEqual(result_real2.shape, torch.Size([10]))
+
 
 instantiate_device_type_tests(TestInductorDynamic, globals(), allow_xpu=True)
 

--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -1410,7 +1410,7 @@ class TestInductorDynamic(TestCase):
             source = ConstantSource("test_input")
             # Create symbolic sizes: dim0 is DYNAMIC, dim1 is STATIC
             sym_sizes, sym_strides, _ = shape_env.create_symbolic_sizes_strides_storage_offset(
-                torch.empty(10, 10, device=device),
+                torch.empty(30, 10, device=device),
                 source=source,
                 symbolic_context=StatelessSymbolicContext(
                     dynamic_sizes=[DimDynamic.DYNAMIC, DimDynamic.STATIC],
@@ -1426,14 +1426,14 @@ class TestInductorDynamic(TestCase):
             self.assertTrue(hasattr(result_fake.shape[0], '__sym_int__') or 
                           str(result_fake.shape[0]).startswith('s'))
 
-            # Run with real tensors - should use cached compiled code
-            result_real1 = program(torch.rand(100, 10, device=device))
-            # With size > 10, fn1 returns sum(dim=0) which has shape [10]
-            self.assertEqual(result_real1.shape, torch.Size([10]))
+        # Run with real tensors - should use cached compiled code
+        result_real1 = program(torch.rand(100, 10, device=device))
+        # With size > 10, fn1 returns sum(dim=0) which has shape [10]
+        self.assertEqual(result_real1.shape, torch.Size([10]))
 
-            # Run with different batch size - dynamic shapes should handle this
-            result_real2 = program(torch.rand(200, 10, device=device))
-            self.assertEqual(result_real2.shape, torch.Size([10]))
+        # Run with different batch size - dynamic shapes should handle this
+        result_real2 = program(torch.rand(200, 10, device=device))
+        self.assertEqual(result_real2.shape, torch.Size([10]))
 
 
 instantiate_device_type_tests(TestInductorDynamic, globals(), allow_xpu=True)

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -1592,6 +1592,9 @@ class PythonWrapperCodegen(CodeGen):
         prefix_indent = self.write_launcher_fn_call_get_indent()
 
         with self.prefix.indent(prefix_indent):
+            # Add FakeTensor short-circuit at the beginning
+            self._write_fake_tensor_shortcircuit()
+
             if config.triton.debug_sync_graph:
                 self.prefix.writeline(V.graph.device_ops.synchronize())
             phase = V.graph.get_training_phase()
@@ -1612,6 +1615,15 @@ class PythonWrapperCodegen(CodeGen):
                 and (not is_codegen_graph_partition_subgraph(self))
             ):
                 self.codegen_input_size_and_nan_asserts()
+
+    def _write_fake_tensor_shortcircuit(self) -> None:
+        """
+        Generate code to detect FakeTensor inputs and short-circuit kernel execution.
+        Returns FakeTensor outputs with correct shapes instead of running real kernels.
+        """
+        # This is now handled in output_code.py at runtime, not in codegen
+        # Keeping this method for potential future use
+        pass
 
     def codegen_input_size_and_nan_asserts(self) -> None:
         if config.size_asserts:

--- a/torch/_inductor/output_code.py
+++ b/torch/_inductor/output_code.py
@@ -622,16 +622,67 @@ class CompiledFxGraph(OutputCode):
         # This is set at compile time to avoid runtime overhead
         self._wrap_compiled_regions = config.wrap_inductor_compiled_regions
 
-        if self._wrap_compiled_regions:
-            # Store a metadata-stripped copy of the FX graph. Running this
-            # under FakeTensorMode re-derives output shapes and aliasing
-            # from the input fake tensors.
-            import copy
+        # Always store the FX graph for FakeTensor execution support
+        import copy
+        gm_copy = copy.deepcopy(gm)
+        for node in gm_copy.graph.nodes:
+            node.meta.clear()
+        self._original_gm = gm_copy
 
-            gm_copy = copy.deepcopy(gm)
-            for node in gm_copy.graph.nodes:
-                node.meta.clear()
-            self._original_gm = gm_copy
+    def _fake_tensor_execute(self, inputs: Sequence[Any]) -> Any:
+        """
+        Execute with FakeTensor inputs by running the original FX graph under FakeTensorMode.
+        This allows JIT compilation to complete without actually running CUDA kernels.
+        """
+        from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode
+
+        # Find the first FakeTensor input to get the fake_mode
+        fake_mode = None
+        fake_inputs = []
+        for inp in inputs:
+            if isinstance(inp, FakeTensor):
+                fake_mode = inp.fake_mode
+                fake_inputs.append(inp)
+            elif isinstance(inp, torch.Tensor):
+                fake_inputs.append(inp)
+            else:
+                # SymInt or other type - pass through
+                fake_inputs.append(inp)
+
+        if fake_mode is None:
+            # Shouldn't happen, but fallback
+            raise RuntimeError("No FakeTensor found in inputs")
+
+        # Run the original graph with FakeTensors to get output shapes
+        # We use the stored _original_gm and run it under the fake_mode context
+        if hasattr(self, '_original_gm') and self._original_gm is not None:
+            with fake_mode:
+                # The graph module's forward may have symbolic shape references
+                # We need to run it in a way that resolves those shapes from inputs
+                try:
+                    result = self._original_gm(*fake_inputs)
+                    if isinstance(result, (list, tuple)):
+                        return tuple(result)
+                    return (result,)
+                except (NameError, RuntimeError):
+                    # Fallback: the graph has unresolvable symbols
+                    # Create output based on first FakeTensor input
+                    pass
+
+        # Fallback: create fake outputs based on first FakeTensor input
+        fake_input = None
+        for inp in inputs:
+            if isinstance(inp, FakeTensor):
+                fake_input = inp
+                break
+        
+        if fake_input is not None:
+            # Return a fake tensor with the same shape as input
+            # This is a simplified fallback for when we can't run the graph
+            out = fake_input.new_empty(fake_input.shape, dtype=fake_input.dtype, device=fake_input.device)
+            return (out,)
+        
+        raise RuntimeError("Cannot execute with FakeTensors: no FakeTensor found")
 
     def __del__(self) -> None:
         if self.compiled_fn_runner is not None:
@@ -644,6 +695,14 @@ class CompiledFxGraph(OutputCode):
 
     def __call__(self, inputs: Sequence[Any]) -> Any:
         assert self.current_callable is not None
+
+        # FakeTensor short-circuit: skip kernel execution for FakeTensors
+        # Return FakeTensor outputs with correct shapes instead of running real kernels
+        from torch._subclasses.fake_tensor import FakeTensor
+        # Check if any input is a FakeTensor
+        has_fake = any(isinstance(inp, FakeTensor) for inp in inputs if isinstance(inp, torch.Tensor))
+        if has_fake:
+            return self._fake_tensor_execute(inputs)
 
         if (
             torch._inductor.debug.RECORD_GRAPH_EXECUTION

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -3469,6 +3469,7 @@ def copy_misaligned_inputs(
     Clones misaligned tensors which we inferred were aligned. Returns a tuple of [old_tensors], [new_tensors] for every
     cloned tensor which is in `return_pair_idxs`.
     """
+    from torch._subclasses.fake_tensor import FakeTensor
 
     old_tensors: list[torch.Tensor] = []
     new_tensors: list[torch.Tensor] = []
@@ -3480,6 +3481,9 @@ def copy_misaligned_inputs(
         assert isinstance(_inp, torch.Tensor), (
             f"Expected tensors only, but got: {type(_inp)}"
         )
+        # Skip alignment check for FakeTensors (they don't have real data_ptr)
+        if isinstance(_inp, FakeTensor):
+            continue
         if _inp.data_ptr() % ALIGNMENT:
             new_inputs[i] = clone_preserve_strides(_inp)
 

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -482,7 +482,8 @@ PyObject* TensorGuards_check(
   for (auto i : c10::irange(len)) {
     PyObject* item = PyTuple_GET_ITEM(args, i);
 
-    if (Py_TYPE(item) != checks[i].pytype) {
+    // POC: Skip exact pytype check, just verify it's some tensor type
+    if (!THPVariable_Check(item)) {
       Py_RETURN_FALSE;
     }
     auto insertion = unique_tensors.insert({item, nullptr});
@@ -550,7 +551,8 @@ PyObject* TensorGuards_check_verbose(
   ska::flat_hash_map<PyObject*, std::nullptr_t> unique_tensors;
   for (auto i : c10::irange(len)) {
     PyObject* item = PyTuple_GET_ITEM(args, i);
-    if (Py_TYPE(item) != checks[i].pytype) {
+    // POC: Skip exact pytype check, just verify it's some tensor type
+    if (!THPVariable_Check(item)) {
       std::stringstream fail_reason;
       PyObject* type_str = PyObject_Str(PyObject_Type(item));
       fail_reason << "expected type of '" << tensor_check_names[i]
@@ -4607,7 +4609,8 @@ class TENSOR_MATCH : public LeafGuard {
   }
 
   bool check_nopybind(PyObject* value) override { // borrowed ref
-    if (Py_TYPE(value) != _tensor_check->pytype) {
+    // POC: Skip exact pytype check, just verify it's some tensor type
+    if (!THPVariable_Check(value)) {
       return false;
     }
     return _tensor_check->check(
@@ -4617,7 +4620,8 @@ class TENSOR_MATCH : public LeafGuard {
   GuardDebugInfo check_verbose_nopybind(
       PyObject* value) override { // borrowed ref
 
-    if (Py_TYPE(value) != _tensor_check->pytype) {
+    // POC: Skip exact pytype check, just verify it's some tensor type
+    if (!THPVariable_Check(value)) {
       std::stringstream fail_reason;
       PyObject* type_str = PyObject_Str(PyObject_Type(value));
       fail_reason << "expected type of '" << _tensor_name

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -206,8 +206,23 @@ bool TensorCheck::check(
     const c10::SymIntArrayRef& sym_sizes,
     const c10::SymIntArrayRef& sym_strides,
     const bool& requires_grad) {
-  if (dispatch_key_ != state.apply(dispatch_key_set).raw_repr() ||
-      dtype_ != dtype || device_index_ != device.index() ||
+  // For FakeTensors (which have Meta dispatch key), we need special handling:
+  // - Skip the exact dispatch key match (Meta vs CPU/CUDA)
+  // - But ensure the device TYPE matches by checking if both are CUDA or both are CPU
+  bool is_fake_tensor = dispatch_key_set.has(c10::DispatchKey::Meta);
+  if (is_fake_tensor) {
+    // For FakeTensors, check that the expected dispatch key's device type matches
+    // E.g., if compiled with CUDA FakeTensor, only allow CUDA FakeTensors
+    c10::DispatchKeySet expected_ks(c10::DispatchKeySet::RAW, dispatch_key_);
+    bool expected_cuda = expected_ks.has(c10::DispatchKey::CUDA);
+    bool actual_cuda = dispatch_key_set.has(c10::DispatchKey::CUDA);
+    if (expected_cuda != actual_cuda) {
+      return false;
+    }
+  } else if (dispatch_key_ != state.apply(dispatch_key_set).raw_repr()) {
+    return false;
+  }
+  if (dtype_ != dtype || device_index_ != device.index() ||
       requires_grad_ != requires_grad) {
     return false;
   }
@@ -966,6 +981,11 @@ static PyObject* assert_size_stride(PyObject* dummy, PyObject* args) {
     return nullptr;
   }
 
+  // Skip guard check for tensors with symbolic sizes/strides (e.g., FakeTensors)
+  if (tensor.unsafeGetTensorImpl()->has_symbolic_sizes_strides()) {
+    Py_RETURN_TRUE;
+  }
+
   // We may add the size/stride assert at compile time due to unbacked symint,
   // but at runtime, the tensor can be empty.
   if (tensor.numel() == 0) {
@@ -1036,6 +1056,11 @@ static PyObject* assert_alignment(PyObject* dummy, PyObject* args) {
   }
 
   at::Tensor tensor = THPVariable_Unpack(item);
+
+  // Skip alignment check for tensors with symbolic sizes/strides (e.g., FakeTensors)
+  if (tensor.unsafeGetTensorImpl()->has_symbolic_sizes_strides()) {
+    Py_RETURN_TRUE;
+  }
 
   int64_t storage_offset = tensor.storage_offset();
   size_t itemsize = tensor.itemsize();


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #177283

one possible way to address:

**I want to mark batch size dynamic but  get a single compilation even when there are graph breaks and/or eager code in between compile regions.**

is the following:

Warm up the model first using fake tensors that have dynamic-size inputs, and then run it with real inputs.

why this would work :
1. eager will propagate symbolic shapes of fake tensors. 
2. compile will make dynamic any fake tensor dim that is symbolic. 


Idea :
1. Create a FakeTensor with symbolic batch dimension:
```
# batch dim is symbolic (dynamic), other dims are static
fake_x = create_fake_tensor(shape=[DYNAMIC, 10], device="cuda")
```
2. Run the entire program with FakeTensor:
```
program(fake_x)  # Triggers compilation of ALL graphs
```

- Dynamo traces with symbolic shapes ( a fake tensor with symbolic dim will become dynamic in the input). 
- Eager code propagates dynamism - operations like x + 100, .contiguous() preserve the symbolic shape

3. Run with real tensors - uses cached compiled code:

```
program(torch.randn(32, 10))   # No recompile
program(torch.randn(64, 10))   # No recompile  
program(torch.randn(128, 10))  # No recompile
```
### Issues Faced When Compiling with FakeTensors [can be addressed not blockers ] 


1. C++ Guards crash on symbolic sizes
assert_size_stride and assert_alignment call numel() / storage_offset() which fail on symbolic tensors
Fix: Skip these checks when has_symbolic_sizes_strides() is true
2. Dispatch key mismatch in guards
FakeTensors have Meta dispatch key, but compiled code expects CUDA or CPU
Fix: Skip dispatch key check for FakeTensors, but still verify device type matches
3. Alignment check on FakeTensors
copy_misaligned_inputs checks data_ptr() % ALIGNMENT which crashes on FakeTensors (no real memory)
Fix: Skip alignment check for FakeTensors
4. Generated kernels can't execute with symbolic sizes
Inductor generates code like empty_strided_cuda((s77, 10), ...) - can't allocate real memory with symbolic size
Fix: Short-circuit in CompiledFxGraph.__call__ to run original FX graph instead of generated kernels when FakeTensor detected
5. Recompilation triggered when switching from fake tensor tracing to real tensor execution
Error message: "expected type of 'x' to be a tensor type, but found <class 'torch.Tensor'>"
Root cause: Guard was checking exact Python type (Py_TYPE(value) != _tensor_check->pytype), which failed when FakeTensor ≠ torch.Tensor

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98 @Lucaskabela