### PR TITLE
[aot_autograd] Deprecate backward_pass_autocast="same_as_forward" default

### DIFF
--- a/docs/source/user_guide/torch_compiler/torch.compiler_backward.md
+++ b/docs/source/user_guide/torch_compiler/torch.compiler_backward.md
@@ -30,8 +30,17 @@ Use ``torch._functorch.config.backward_pass_autocast``
 to control that assumption; an incorrect assumption may lead to silent
 incorrectness.
 
+```{note}
+The default value of `backward_pass_autocast` will change from
+`"same_as_forward"` to `"off"` in a future release. `"off"` matches the
+recommended PyTorch usage where autocast wraps only the forward pass.
+If you rely on `"same_as_forward"` behavior, set it explicitly to silence
+the deprecation warning.
+See [#153044](https://github.com/pytorch/pytorch/issues/153044) for details.
+```
+
 The options are either:
-- `"same_as_forward"` (default).
+- `"same_as_forward"`.
   We assume that the backward of the ``torch.compile``'ed region
   will be run under the same autocast context manager that the region was run
   under (if any). Use this if your code looks like the following:

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -795,6 +795,30 @@ def forward(self, primals_1):
                 self.assertEqual(out, torch.zeros_like(out))
                 self.assertEqual(grad, torch.ones_like(grad))
 
+    def test_backward_pass_autocast_default_warns(self):
+        # When autocast is active and backward_pass_autocast is at its default,
+        # a FutureWarning should be emitted about the upcoming default change.
+        for device in ["cpu"] + (["cuda"] if torch.cuda.is_available() else []):
+            with self.assertWarnsRegex(FutureWarning, "backward_pass_autocast"):
+                self._compile_autocast(device, forward_autocast=True)
+
+    @torch._functorch.config.patch(backward_pass_autocast="same_as_forward")
+    def test_backward_pass_autocast_explicit_no_warn(self):
+        # When backward_pass_autocast is explicitly set (even to the same value
+        # as the current default), no warning should be emitted.
+        for device in ["cpu"] + (["cuda"] if torch.cuda.is_available() else []):
+            with warnings.catch_warnings():
+                warnings.simplefilter("error", FutureWarning)
+                self._compile_autocast(device, forward_autocast=True)
+
+    def test_backward_pass_autocast_no_autocast_no_warn(self):
+        # When no autocast is active, no warning should be emitted regardless
+        # of the config default.
+        for device in ["cpu"] + (["cuda"] if torch.cuda.is_available() else []):
+            with warnings.catch_warnings():
+                warnings.simplefilter("error", FutureWarning)
+                self._compile_autocast(device, forward_autocast=False)
+
     @skipIfDynamoInput(
         "Test doesn't make sense with dynamo, which changes order of mutations"
     )

--- a/torch/_functorch/_aot_autograd/graph_capture_wrappers.py
+++ b/torch/_functorch/_aot_autograd/graph_capture_wrappers.py
@@ -416,6 +416,22 @@ def create_joint(
                 ExitStack() as stack,
             ):
                 backward_pass_autocast = torch._functorch.config.backward_pass_autocast
+                if backward_pass_autocast == "default":
+                    if torch._C._is_any_autocast_enabled():
+                        warnings.warn(
+                            "The default value of torch._functorch.config.backward_pass_autocast "
+                            "is changing from 'same_as_forward' to 'off' in a future version of "
+                            "PyTorch. This means the backward pass of torch.compile'd regions "
+                            "will no longer inherit the forward pass's autocast context. "
+                            "To silence this warning, explicitly set "
+                            "torch._functorch.config.backward_pass_autocast to "
+                            "'same_as_forward' (current behavior) or 'off' (future default, "
+                            "recommended). See https://github.com/pytorch/pytorch/issues/153044",
+                            FutureWarning,
+                            stacklevel=2,
+                        )
+                    backward_pass_autocast = "same_as_forward"
+
                 if backward_pass_autocast == "same_as_forward":
                     # Use the ambient autocast mode(s)
                     pass

--- a/torch/_functorch/config.py
+++ b/torch/_functorch/config.py
@@ -323,7 +323,12 @@ fake_tensor_propagate_real_tensors = False
 #   ...
 #   with torch.amp.autocast(device="cuda"):
 #       z.backward()
-backward_pass_autocast = "same_as_forward"
+#
+# NOTE: The default "default" currently behaves like "same_as_forward" but will
+# change to "off" in a future release. "off" matches eager PyTorch behavior
+# where autocast wraps only the forward pass.
+# See https://github.com/pytorch/pytorch/issues/153044
+backward_pass_autocast = "default"
 
 # This controls whether we collect donated buffers. This flag must be set
 # False if a user wants to retain_graph=True for backward.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #177287
* __->__ #177286

The current default of `backward_pass_autocast="same_as_forward"` causes
the backward pass of `torch.compile`'d regions to inherit the forward's
autocast context. This doesn't match eager PyTorch behavior, where autocast
conventionally wraps only the forward pass, and can cause silent numerical
issues like gradient overflow (#153044).

This change introduces a deprecation warning (FutureWarning) for users who
have autocast active during compilation without explicitly setting
`backward_pass_autocast`. The default config value is changed to `"default"`,
which currently behaves like `"same_as_forward"` but will change to `"off"`
in a future release.

To silence the warning, users should set:
  torch._functorch.config.backward_pass_autocast = "off"   # recommended
  torch._functorch.config.backward_pass_autocast = "same_as_forward"

## Release note:
The default behavior of `backward_pass_autocast` in
`torch._functorch.config` is deprecated and will change in a future release.
Currently, the backward pass of `torch.compile`'d regions inherits the
forward pass's autocast context (`"same_as_forward"`). In a future release,
the default will change to `"off"`, matching eager PyTorch behavior where
autocast wraps only the forward pass. Users who rely on the current behavior
should explicitly set `torch._functorch.config.backward_pass_autocast =
"same_as_forward"`. Users who want the new behavior now can set it to `"off"`.

[bc-breaking][deprecation]

Authored with Claude.

cc @ezyang @gchanan