### PR TITLE
Default backward_pass_autocast to "off" to match eager autocast semantics

### DIFF
--- a/docs/source/user_guide/torch_compiler/torch.compiler_backward.md
+++ b/docs/source/user_guide/torch_compiler/torch.compiler_backward.md
@@ -40,6 +40,17 @@ See [#153044](https://github.com/pytorch/pytorch/issues/153044) for details.
 ```
 
 The options are either:
+- `"off"` (default). We assume that the backward of the torch.compile'd region will
+  not be run under any autocast context managers.
+  This matches the recommended PyTorch usage where autocast wraps only the forward
+  pass. Use this if your code looks like the following:
+  ```py
+  with torch.amp.autocast(...):
+      y = torch.compile(region)(x)
+      ...
+  # Backward pass runs under no autocast.
+  z.backward()
+  ```
 - `"same_as_forward"`.
   We assume that the backward of the ``torch.compile``'ed region
   will be run under the same autocast context manager that the region was run
@@ -50,16 +61,6 @@ The options are either:
       ...
       # backward pass run under the same autocast context as the compiled region
       z.backward()
-  ```
-- `"off"`. We assume that the backward of the torch.compile'd region will
-  not be run under any autocast context managers.
-  Use this if your code looks like the following:
-  ```py
-  with torch.amp.autocast(...):
-      y = torch.compile(region)(x)
-      ...
-  # Backward pass runs under no autocast.
-  z.backward()
   ```
 - There is a third option. If you set ``torch._functorch.config.backward_pass_autocast``
   to a list of kwargs, we will assume the backward pass runs under an autocast context

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -819,6 +819,39 @@ def forward(self, primals_1):
                 warnings.simplefilter("error", FutureWarning)
                 self._compile_autocast(device, forward_autocast=False)
 
+    @unittest.skipIf(not torch.cuda.is_available(), "requires CUDA")
+    def test_backward_pass_autocast_default_matches_eager(self):
+        # Regression test for https://github.com/pytorch/pytorch/issues/153044
+        # When autocast wraps a compiled region from the outside, the backward
+        # pass should NOT inherit the forward's autocast context (matching eager
+        # behavior, per PyTorch docs).
+        w = torch.ones(4, 4, device="cuda")
+        linear = torch.nn.Linear(4, 1, device="cuda")
+
+        def model(x):
+            y = x @ w
+            with torch.amp.autocast(device_type="cuda", enabled=False):
+                y = y.float()
+                y = linear(y)
+            return y
+
+        x = torch.ones(1, 4, device="cuda")
+
+        # Eager reference
+        with torch.amp.autocast(device_type="cuda"):
+            eager_out = model(x)
+        (eager_out * 16384).sum().backward()
+        eager_grad = linear.weight.grad.clone()
+        linear.weight.grad.zero_()
+
+        # Compiled
+        with torch.amp.autocast(device_type="cuda"):
+            compiled_out = torch.compile(model, backend="aot_eager")(x)
+        (compiled_out * 16384).sum().backward()
+        compiled_grad = linear.weight.grad.clone()
+
+        self.assertEqual(eager_grad, compiled_grad)
+
     @skipIfDynamoInput(
         "Test doesn't make sense with dynamo, which changes order of mutations"
     )

--- a/torch/_functorch/_aot_autograd/graph_capture_wrappers.py
+++ b/torch/_functorch/_aot_autograd/graph_capture_wrappers.py
@@ -417,20 +417,7 @@ def create_joint(
             ):
                 backward_pass_autocast = torch._functorch.config.backward_pass_autocast
                 if backward_pass_autocast == "default":
-                    if torch._C._is_any_autocast_enabled():
-                        warnings.warn(
-                            "The default value of torch._functorch.config.backward_pass_autocast "
-                            "is changing from 'same_as_forward' to 'off' in a future version of "
-                            "PyTorch. This means the backward pass of torch.compile'd regions "
-                            "will no longer inherit the forward pass's autocast context. "
-                            "To silence this warning, explicitly set "
-                            "torch._functorch.config.backward_pass_autocast to "
-                            "'same_as_forward' (current behavior) or 'off' (future default, "
-                            "recommended). See https://github.com/pytorch/pytorch/issues/153044",
-                            FutureWarning,
-                            stacklevel=2,
-                        )
-                    backward_pass_autocast = "same_as_forward"
+                    backward_pass_autocast = "off"
 
                 if backward_pass_autocast == "same_as_forward":
                     # Use the ambient autocast mode(s)

--- a/torch/_functorch/config.py
+++ b/torch/_functorch/config.py
@@ -323,11 +323,6 @@ fake_tensor_propagate_real_tensors = False
 #   ...
 #   with torch.amp.autocast(device="cuda"):
 #       z.backward()
-#
-# NOTE: The default "default" currently behaves like "same_as_forward" but will
-# change to "off" in a future release. "off" matches eager PyTorch behavior
-# where autocast wraps only the forward pass.
-# See https://github.com/pytorch/pytorch/issues/153044
 backward_pass_autocast = "default"
 
 # This controls whether we collect donated buffers. This flag must be set


### PR DESCRIPTION
*** DON'T LAND UNTIL https://github.com/pytorch/pytorch/pull/177286 HAS BEEN RELEASED (not just landed) (so this goes out in the next release) ***

The backward pass of torch.compile'd regions no longer inherits the
forward pass's autocast context by default. This matches eager PyTorch
behavior, where autocast conventionally wraps only the forward pass.

The previous default ("same_as_forward") could cause silent numerical
issues such as gradient overflow when autocast wrapped a compiled region
from the outside. See #153044.

To preserve the old behavior, explicitly set:
  torch._functorch.config.backward_pass_autocast = "same_as_forward"

Fixes #153044

## Release Note:

BC-BREAKING CHANGE: torch._functorch.config.backward_pass_autocast now
defaults to "off" instead of "same_as_forward". Users who intentionally
run backward under the same autocast context as forward must opt in
explicitly.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #177287
* #177286



cc @ezyang @gchanan
