### PR TITLE
[memoryviz] Add a tab to show private pool memory view

### DIFF
--- a/torch/utils/viz/MemoryViz.js
+++ b/torch/utils/viz/MemoryViz.js
@@ -56,6 +56,12 @@ function Block(addr, size, requested_size, frames, free_requested, version, user
   return {addr, size, requested_size, frames, free_requested, version, user_metadata};
 }
 
+function isPrivatePool(seg) {
+  const id = seg.segment_pool_id;
+  if (!id) return false;
+  return !(id[0] === 0 && id[1] === 0);
+}
+
 function EventSelector(outer, events, stack_info, memory_view) {
   const events_div = outer
     .append('div')
@@ -238,16 +244,16 @@ function MemoryView(outer, stack_info, snapshot, device) {
     if (seg.device !== device) {
       continue;
     }
-    sorted_segments.push(
-      Segment(
+    const s = Segment(
         seg.address,
         seg.total_size,
         seg.stream,
         seg.frames || [],
         seg.version,
         seg.user_metadata,
-      ),
     );
+    s.segment_pool_id = seg.segment_pool_id;
+    sorted_segments.push(s);
     for (const b of seg.blocks) {
       if (b.state !== 'active_pending_free' && b.state !== 'active_allocated') {
         continue;
@@ -490,13 +496,17 @@ function MemoryView(outer, stack_info, snapshot, device) {
           const user_metadata_str = format_user_metadata(t.user_metadata);
           const frames_str = format_frames(t.frames);
           const forward_frames_str = format_forward_frames(t.forward_frames);
+          let pool_str = '';
+          if (t.segment_pool_id && !(t.segment_pool_id[0] === 0 && t.segment_pool_id[1] === 0)) {
+            pool_str = `, pool_id (${t.segment_pool_id[0]}, ${t.segment_pool_id[1]})`;
+          }
           return (
             `s${t.addr.toString(16)}_${t.version}: segment ${formatSize(
               t.size,
             )} allocated, ` +
             `${formatSize(free)} free${internal} (stream ${
               t.stream
-            })\n` +
+            }${pool_str})\n` +
             (user_metadata_str ? user_metadata_str + '\n' : '') +
             frames_str +
             forward_frames_str
@@ -564,11 +574,15 @@ function MemoryView(outer, stack_info, snapshot, device) {
           const user_metadata_str = format_user_metadata(t.user_metadata);
           const frames_str = format_frames(t.frames);
           const forward_frames_str = format_forward_frames(t.forward_frames);
+          let pool_str = '';
+          if (t.segment && t.segment.segment_pool_id && !(t.segment.segment_pool_id[0] === 0 && t.segment.segment_pool_id[1] === 0)) {
+            pool_str = `, pool_id (${t.segment.segment_pool_id[0]}, ${t.segment.segment_pool_id[1]})`;
+          }
           return (
             `b${t.addr.toString(16)}_${t.version} ` +
             `${formatSize(t.requested_size)} allocation${requested} (stream ${
               t.segment.stream
-            })\n` +
+            }${pool_str})\n` +
             (user_metadata_str ? user_metadata_str + '\n' : '') +
             frames_str +
             forward_frames_str
@@ -778,6 +792,7 @@ function annotate_snapshot(snapshot) {
         }
       }
       b.version = snapshot.block_version(b.addr, false);
+      b.segment_pool_id = seg.segment_pool_id;
       // Note [BigInt and Number Safe Arithmetic]
       // Device pointer addresses may be represented as either Number or BigInt.
       // Use explicit conversions to perform arithmetic safely and avoid mixing
@@ -924,11 +939,37 @@ function format_frames(frames) {
   return elideRepeats(frame_strings).join('\n');
 }
 
-function process_alloc_data(snapshot, device, plot_segments, max_entries) {
+function process_alloc_data(snapshot, device, plot_segments, max_entries, include_private_inactive = false) {
   const elements = [];
   const initially_allocated = [];
   const actions = [];
   const addr_to_alloc = {};
+
+  // Build sorted segment list for pool_id lookups by address
+  const device_segments = snapshot.segments
+    .filter(s => s.device === device)
+    .sort((a, b) => {
+      if (a.address === b.address) return 0;
+      return a.address < b.address ? -1 : 1;
+    });
+
+  function find_pool_id(addr) {
+    let left = 0;
+    let right = device_segments.length - 1;
+    while (left <= right) {
+      const mid = Math.floor((left + right) / 2);
+      const seg = device_segments[mid];
+      const seg_end = seg.address + (typeof seg.address === "bigint" ? BigInt(seg.total_size) : seg.total_size);
+      if (addr < seg.address) {
+        right = mid - 1;
+      } else if (addr >= seg_end) {
+        left = mid + 1;
+      } else {
+        return seg.segment_pool_id;
+      }
+    }
+    return null;
+  }
 
   const alloc = plot_segments ? 'segment_alloc' : 'alloc';
   const [free, free_completed] = plot_segments
@@ -974,8 +1015,11 @@ function process_alloc_data(snapshot, device, plot_segments, max_entries) {
         initially_allocated.push(elements.length - 1);
       }
     } else {
+      const seg_is_private = isPrivatePool(seg);
       for (const b of seg.blocks) {
-        if (b.state === 'active_allocated' && !(b.addr in addr_to_alloc)) {
+        const is_active = b.state === 'active_allocated';
+        const is_private_inactive = include_private_inactive && seg_is_private && b.state === 'inactive';
+        if ((is_active || is_private_inactive) && !(b.addr in addr_to_alloc)) {
           const element = {
             action: 'alloc',
             addr: b.addr,
@@ -983,6 +1027,7 @@ function process_alloc_data(snapshot, device, plot_segments, max_entries) {
             frames: b.frames,
             stream: seg.stream,
             version: b.version,
+            segment_pool_id: seg.segment_pool_id,
           };
           elements.push(element);
           initially_allocated.push(elements.length - 1);
@@ -990,6 +1035,13 @@ function process_alloc_data(snapshot, device, plot_segments, max_entries) {
       }
     }
   }
+  // Resolve segment_pool_id for elements from trace events
+  for (const elem of elements) {
+    if (!elem.segment_pool_id) {
+      elem.segment_pool_id = find_pool_id(elem.addr);
+    }
+  }
+
   initially_allocated.reverse();
   // if there are no actions, the graph will be blank,
   // but if there are existing allocations we do not want to hide them
@@ -1058,7 +1110,65 @@ function process_alloc_data(snapshot, device, plot_segments, max_entries) {
     element_obj.max_allocated_mem = total_mem + total_summarized_mem;
   }
 
+  // Pool state tracking (only active when include_private_inactive)
+  // Each pool is a single variable-size element in the global stack whose
+  // height = high-water mark of active block sizes. It never shrinks.
+  const pools = {};
+  const pool_active_elems = {};
+
+  function get_pool_key(elem_idx) {
+    const pid = elements[elem_idx].segment_pool_id;
+    if (!pid || (pid[0] === 0 && pid[1] === 0)) return null;
+    return `${pid[0]},${pid[1]}`;
+  }
+
+  function get_or_create_pool(pool_key) {
+    if (!(pool_key in pools)) {
+      pools[pool_key] = { max: 0, active: 0, envelope_data: null };
+    }
+    return pools[pool_key];
+  }
+
+  // Shift global stack elements starting at idx by delta
+  function shift_elements_above(idx, delta) {
+    for (let j = idx; j < current.length; j++) {
+      const e = current_data[j];
+      e.timesteps.push(timestep);
+      e.offsets.push(e.offsets.at(-1));
+      e.timesteps.push(timestep + 3);
+      e.offsets.push(e.offsets.at(-1) + delta);
+      if (Array.isArray(e.size)) {
+        e.size.push(e.size.at(-1));
+        e.size.push(e.size.at(-1));
+      }
+    }
+  }
+
+  // Grow the pool envelope from its current max to a new max
+  function grow_pool_envelope(pool, pool_key, new_active) {
+    if (new_active <= pool.max) return;
+    const delta = new_active - pool.max;
+    pool.max = new_active;
+    const env = pool.envelope_data;
+    env.timesteps.push(timestep);
+    env.offsets.push(env.offsets.at(-1));
+    env.size.push(env.size.at(-1));
+    env.timesteps.push(timestep + 3);
+    env.offsets.push(env.offsets.at(-1));
+    env.size.push(pool.max);
+    const pidx = current.indexOf(`pool:${pool_key}`);
+    if (pidx >= 0) {
+      shift_elements_above(pidx + 1, delta);
+    }
+    total_mem += delta;
+    advance(3);
+  }
+
   for (const elem of initially_allocated) {
+    // Skip private pool blocks — they're handled by the pool envelope
+    if (include_private_inactive && get_pool_key(elem)) {
+      continue;
+    }
     if (elem in draw_elem) {
       add_allocation(elem);
     } else {
@@ -1069,6 +1179,48 @@ function process_alloc_data(snapshot, device, plot_segments, max_entries) {
 
   for (const elem of actions) {
     const size = elements[elem].size;
+    const pool_key = include_private_inactive ? get_pool_key(elem) : null;
+
+    if (pool_key) {
+      // Private pool element — absorbed into pool envelope
+      if (!(elem in pool_active_elems)) {
+        // Pool alloc
+        pool_active_elems[elem] = pool_key;
+        const pool = get_or_create_pool(pool_key);
+
+        // Create envelope on first alloc
+        if (pool.envelope_data === null) {
+          const env = {
+            elem: `pool:${pool_key}`,
+            timesteps: [timestep],
+            offsets: [total_mem],
+            size: [0],
+            color: 9,
+          };
+          pool.envelope_data = env;
+          current.push(`pool:${pool_key}`);
+          current_data.push(env);
+          data.push(env);
+        }
+
+        pool.active += size;
+        if (pool.active > pool.max) {
+          grow_pool_envelope(pool, pool_key, pool.active);
+        } else {
+          advance(1);
+        }
+      } else {
+        // Pool free — envelope stays at max, just update active tracking
+        const pool = pools[pool_key];
+        pool.active -= size;
+        delete pool_active_elems[elem];
+        advance(1);
+      }
+      max_size = Math.max(total_mem + total_summarized_mem, max_size);
+      continue;
+    }
+
+    // Non-pool element (existing logic)
     if (!(elem in draw_elem)) {
       if (elem in summarized_elems) {
         advance(1);
@@ -1082,8 +1234,6 @@ function process_alloc_data(snapshot, device, plot_segments, max_entries) {
       continue;
     }
     const idx = current.findLastIndex(x => x === elem);
-    // first time we see an action we add it
-    // second time we remove it
     if (idx === -1) {
       add_allocation(elem);
       advance(1);
@@ -1096,13 +1246,7 @@ function process_alloc_data(snapshot, device, plot_segments, max_entries) {
       current_data.splice(idx, 1);
 
       if (idx < current.length) {
-        for (let j = idx; j < current.length; j++) {
-          const e = current_data[j];
-          e.timesteps.push(timestep);
-          e.offsets.push(e.offsets.at(-1));
-          e.timesteps.push(timestep + 3);
-          e.offsets.push(e.offsets.at(-1) - size);
-        }
+        shift_elements_above(idx, -size);
         advance(3);
       }
       total_mem -= size;
@@ -1110,9 +1254,13 @@ function process_alloc_data(snapshot, device, plot_segments, max_entries) {
     max_size = Math.max(total_mem + total_summarized_mem, max_size);
   }
 
+  // Finalize: close all active elements
   for (const elem of current_data) {
     elem.timesteps.push(timestep);
     elem.offsets.push(elem.offsets.at(-1));
+    if (Array.isArray(elem.size)) {
+      elem.size.push(elem.size.at(-1));
+    }
   }
   data.push(summarized_mem);
 
@@ -1133,6 +1281,11 @@ function process_alloc_data(snapshot, device, plot_segments, max_entries) {
       text = `${text}, Compile context: ${context}`;
       if (elem.stream !== null) {
         text = `${text}, stream ${elem.stream}`;
+      }
+      if (elem.segment_pool_id) {
+        text = `${text}, pool_id (${elem.segment_pool_id[0]}, ${elem.segment_pool_id[1]})`;
+      } else {
+        text = `${text}, pool_id unknown`;
       }
       if (elem.timestamp !== null) {
         var d = new Date(elem.time_us / 1000);
@@ -1287,6 +1440,10 @@ function ContextViewer(text, data) {
             'Small tensors that were not plotted to cutdown on render time.\n' +
               'Use detail slider to see smaller allocations.',
           );
+        } else if (typeof dd.elem === 'string' && dd.elem.startsWith('pool:')) {
+          const pool_key = dd.elem.slice(5);
+          const capacity = Array.isArray(dd.size) ? dd.size.at(-1) : dd.size;
+          text.text(`Private Pool (${pool_key}): capacity ${formatSize(capacity)}`);
         } else {
           text.text(`${dd.elem} ${data.context_for_id(dd.elem)}`);
         }
@@ -1387,13 +1544,20 @@ function create_trace_view(
   device,
   plot_segments = false,
   max_entries = 15000,
+  include_private_inactive = false,
 ) {
   const left_pad = 70;
-  const data = process_alloc_data(snapshot, device, plot_segments, max_entries);
+  const data = process_alloc_data(snapshot, device, plot_segments, max_entries, include_private_inactive);
   dst.selectAll('svg').remove();
   dst.selectAll('div').remove();
 
   max_entries = Math.min(max_entries, data.elements_length);
+  if (include_private_inactive) {
+    dst.append('div')
+      .attr('style', 'padding: 4px 8px; background: #fff3cd; border: 1px solid #ffc107; font-size: 13px; margin-bottom: 4px;')
+      .text('Note: Private pool memory is shown as allocated until the pool\'s segment is freed. '
+          + 'This view requires that MemPools are not deleted before torch.cuda.memory._snapshot() is called.');
+  }
   const d = dst.append('div');
   d.append('input')
     .attr('type', 'range')
@@ -1401,7 +1565,7 @@ function create_trace_view(
     .attr('max', data.elements_length)
     .attr('value', max_entries)
     .on('change', function () {
-      create_trace_view(dst, snapshot, device, plot_segments, this.value);
+      create_trace_view(dst, snapshot, device, plot_segments, this.value, include_private_inactive);
     });
   d.append('label').text(
     `Detail: ${max_entries} of ${data.elements_length} entries`,
@@ -1764,6 +1928,8 @@ function decode_base64(input) {
 
 const kinds = {
   'Active Memory Timeline': create_trace_view,
+  'Allocated Memory (incl. Private Pools)': (dst, snapshot, device) =>
+    create_trace_view(dst, snapshot, device, false, 15000, true),
   'Allocator State History': create_segment_view,
   'Active Cached Segment Timeline': (dst, snapshot, device) =>
     create_trace_view(dst, snapshot, device, true),

--- a/torch/utils/viz/MemoryViz.js
+++ b/torch/utils/viz/MemoryViz.js
@@ -48,18 +48,16 @@ function version_space() {
   };
 }
 
-function Segment(addr, size, stream, frames, version, user_metadata) {
-  return {addr, size, stream, version, frames, user_metadata};
+function Segment(addr, size, stream, frames, version, user_metadata, segment_pool_id) {
+  return {addr, size, stream, version, frames, user_metadata, segment_pool_id};
 }
 
 function Block(addr, size, requested_size, frames, free_requested, version, user_metadata) {
   return {addr, size, requested_size, frames, free_requested, version, user_metadata};
 }
 
-function isPrivatePool(seg) {
-  const id = seg.segment_pool_id;
-  if (!id) return false;
-  return !(id[0] === 0 && id[1] === 0);
+function isPrivatePoolId(pool_id) {
+  return pool_id && !(pool_id[0] === 0 && pool_id[1] === 0);
 }
 
 function EventSelector(outer, events, stack_info, memory_view) {
@@ -244,16 +242,17 @@ function MemoryView(outer, stack_info, snapshot, device) {
     if (seg.device !== device) {
       continue;
     }
-    const s = Segment(
+    sorted_segments.push(
+      Segment(
         seg.address,
         seg.total_size,
         seg.stream,
         seg.frames || [],
         seg.version,
         seg.user_metadata,
+        seg.segment_pool_id,
+      ),
     );
-    s.segment_pool_id = seg.segment_pool_id;
-    sorted_segments.push(s);
     for (const b of seg.blocks) {
       if (b.state !== 'active_pending_free' && b.state !== 'active_allocated') {
         continue;
@@ -497,7 +496,7 @@ function MemoryView(outer, stack_info, snapshot, device) {
           const frames_str = format_frames(t.frames);
           const forward_frames_str = format_forward_frames(t.forward_frames);
           let pool_str = '';
-          if (t.segment_pool_id && !(t.segment_pool_id[0] === 0 && t.segment_pool_id[1] === 0)) {
+          if (isPrivatePoolId(t.segment_pool_id)) {
             pool_str = `, pool_id (${t.segment_pool_id[0]}, ${t.segment_pool_id[1]})`;
           }
           return (
@@ -575,7 +574,7 @@ function MemoryView(outer, stack_info, snapshot, device) {
           const frames_str = format_frames(t.frames);
           const forward_frames_str = format_forward_frames(t.forward_frames);
           let pool_str = '';
-          if (t.segment && t.segment.segment_pool_id && !(t.segment.segment_pool_id[0] === 0 && t.segment.segment_pool_id[1] === 0)) {
+          if (isPrivatePoolId(t.segment?.segment_pool_id)) {
             pool_str = `, pool_id (${t.segment.segment_pool_id[0]}, ${t.segment.segment_pool_id[1]})`;
           }
           return (
@@ -953,6 +952,8 @@ function process_alloc_data(snapshot, device, plot_segments, max_entries, includ
       return a.address < b.address ? -1 : 1;
     });
 
+  // Binary search device_segments to find which segment contains addr,
+  // returning that segment's pool_id (or null if not found).
   function find_pool_id(addr) {
     let left = 0;
     let right = device_segments.length - 1;
@@ -1015,7 +1016,7 @@ function process_alloc_data(snapshot, device, plot_segments, max_entries, includ
         initially_allocated.push(elements.length - 1);
       }
     } else {
-      const seg_is_private = isPrivatePool(seg);
+      const seg_is_private = isPrivatePoolId(seg.segment_pool_id);
       for (const b of seg.blocks) {
         const is_active = b.state === 'active_allocated';
         const is_private_inactive = include_private_inactive && seg_is_private && b.state === 'inactive';
@@ -1111,22 +1112,43 @@ function process_alloc_data(snapshot, device, plot_segments, max_entries, includ
   }
 
   // Pool state tracking (only active when include_private_inactive)
-  // Each pool is a single variable-size element in the global stack whose
-  // height = high-water mark of active block sizes. It never shrinks.
+  // Each pool is a single variable-size envelope in the global stack whose
+  // height = high-water mark. Colored stripes inside show active blocks.
   const pools = {};
   const pool_active_elems = {};
 
   function get_pool_key(elem_idx) {
     const pid = elements[elem_idx].segment_pool_id;
-    if (!pid || (pid[0] === 0 && pid[1] === 0)) return null;
+    if (!isPrivatePoolId(pid)) return null;
     return `${pid[0]},${pid[1]}`;
   }
 
   function get_or_create_pool(pool_key) {
     if (!(pool_key in pools)) {
-      pools[pool_key] = { max: 0, active: 0, envelope_data: null };
+      pools[pool_key] = {
+        max: 0, active: 0, envelope_data: null,
+        block_stack: [],  // [{elem, size, inner_offset, stripe_data}]
+      };
     }
     return pools[pool_key];
+  }
+
+  function elem_color(elem_idx) {
+    if (snapshot.categories.length > 0) {
+      return snapshot.categories.indexOf(elements[elem_idx].category || 'unknown');
+    }
+    return elem_idx;
+  }
+
+  // Shift all active stripes in a pool by delta
+  function shift_pool_stripes(pool, delta) {
+    for (const block of pool.block_stack) {
+      const s = block.stripe_data;
+      s.timesteps.push(timestep);
+      s.offsets.push(s.offsets.at(-1));
+      s.timesteps.push(timestep + 3);
+      s.offsets.push(s.offsets.at(-1) + delta);
+    }
   }
 
   // Shift global stack elements starting at idx by delta
@@ -1140,6 +1162,12 @@ function process_alloc_data(snapshot, device, plot_segments, max_entries, includ
       if (Array.isArray(e.size)) {
         e.size.push(e.size.at(-1));
         e.size.push(e.size.at(-1));
+      }
+      // If this is a pool envelope, also shift its stripes
+      const pk = typeof current[j] === 'string' && current[j].startsWith('pool:')
+        ? current[j].slice(5) : null;
+      if (pk && pk in pools) {
+        shift_pool_stripes(pools[pk], delta);
       }
     }
   }
@@ -1182,7 +1210,7 @@ function process_alloc_data(snapshot, device, plot_segments, max_entries, includ
     const pool_key = include_private_inactive ? get_pool_key(elem) : null;
 
     if (pool_key) {
-      // Private pool element — absorbed into pool envelope
+      // Private pool element
       if (!(elem in pool_active_elems)) {
         // Pool alloc
         pool_active_elems[elem] = pool_key;
@@ -1203,18 +1231,59 @@ function process_alloc_data(snapshot, device, plot_segments, max_entries, includ
           data.push(env);
         }
 
+        const inner_offset = pool.active;
         pool.active += size;
+
+        // Grow envelope first if needed (animates, shifts elements above)
         if (pool.active > pool.max) {
           grow_pool_envelope(pool, pool_key, pool.active);
+        }
+
+        // Create stripe after growth so elements above have already shifted
+        const stripe = {
+          elem,
+          timesteps: [timestep],
+          offsets: [pool.envelope_data.offsets.at(-1) + inner_offset],
+          size,
+          color: elem_color(elem),
+          opacity: 0.5,
+        };
+        pool.block_stack.push({elem, size, inner_offset, stripe_data: stripe});
+        data.push(stripe);
+        advance(1);
+        elements[elem].max_allocated_mem = total_mem + total_summarized_mem;
+      } else {
+        // Pool free — envelope stays at max, end stripe, shift stripes above
+        const pool = pools[pool_key];
+        const block_idx = pool.block_stack.findIndex(b => b.elem === elem);
+        if (block_idx >= 0) {
+          advance(1);
+          const block = pool.block_stack[block_idx];
+          // End stripe
+          block.stripe_data.timesteps.push(timestep);
+          block.stripe_data.offsets.push(block.stripe_data.offsets.at(-1));
+
+          pool.block_stack.splice(block_idx, 1);
+          pool.active -= size;
+
+          // Shift stripes above the freed block down within the pool
+          if (block_idx < pool.block_stack.length) {
+            for (let j = block_idx; j < pool.block_stack.length; j++) {
+              const b = pool.block_stack[j];
+              b.inner_offset -= size;
+              const s = b.stripe_data;
+              s.timesteps.push(timestep);
+              s.offsets.push(s.offsets.at(-1));
+              s.timesteps.push(timestep + 3);
+              s.offsets.push(pool.envelope_data.offsets.at(-1) + b.inner_offset);
+            }
+            advance(3);
+          }
         } else {
+          pool.active -= size;
           advance(1);
         }
-      } else {
-        // Pool free — envelope stays at max, just update active tracking
-        const pool = pools[pool_key];
-        pool.active -= size;
         delete pool_active_elems[elem];
-        advance(1);
       }
       max_size = Math.max(total_mem + total_summarized_mem, max_size);
       continue;
@@ -1260,6 +1329,14 @@ function process_alloc_data(snapshot, device, plot_segments, max_entries, includ
     elem.offsets.push(elem.offsets.at(-1));
     if (Array.isArray(elem.size)) {
       elem.size.push(elem.size.at(-1));
+    }
+  }
+  // Close active pool stripes
+  for (const pk in pools) {
+    for (const block of pools[pk].block_stack) {
+      const s = block.stripe_data;
+      s.timesteps.push(timestep);
+      s.offsets.push(s.offsets.at(-1));
     }
   }
   data.push(summarized_mem);
@@ -1366,7 +1443,8 @@ function MemoryPlot(
     .enter()
     .append('polygon')
     .attr('points', format_points)
-    .attr('fill', d => colors[d.color % colors.length]);
+    .attr('fill', d => colors[d.color % colors.length])
+    .attr('opacity', d => d.opacity ?? 1);
 
   const axis = plot_coordinate_space.append('g').call(yaxis);
 
@@ -1555,7 +1633,7 @@ function create_trace_view(
   if (include_private_inactive) {
     dst.append('div')
       .attr('style', 'padding: 4px 8px; background: #fff3cd; border: 1px solid #ffc107; font-size: 13px; margin-bottom: 4px;')
-      .text('Note: Private pool memory is shown as allocated until the pool\'s segment is freed. '
+      .text('Note: Private pool memory (the gray bar) is shown as allocated until the pool\'s segment is freed. '
           + 'This view requires that MemPools are not deleted before torch.cuda.memory._snapshot() is called.');
   }
   const d = dst.append('div');


### PR DESCRIPTION
## Summary

Adds a new **"Allocated Memory (incl. Private Pools)"** tab to the CUDA Memory
Visualizer (`MemoryViz.js`). This tab visualizes memory from both the default
allocator pool and private `MemPool`s in a single stacked-area timeline.

This should be useful for view CUDA Graph memory because those memory are allocated in private pools.

perf: tried on an 80Mb pickle file with  241384 entries, loads in ~3 sec on my macbook air.

### Problem

The existing "Active Memory Timeline" tab treats every allocation independently.
When using private `MemPool`s, individual blocks are freed and reallocated
within the pool, but the pool's reserved memory is never returned to the
system. The existing view doesn't show this — freed pool blocks simply
disappear, making it hard to understand actual memory pressure from private
pools.

### Solution

Each private pool is rendered as a single **envelope** — a gray band whose
height equals the pool's high-water mark. The envelope only grows (never
shrinks), reflecting that private pool memory is reserved until the pool's
segment is explicitly freed. Individual block allocations within the pool are
shown as **colored stripes** (at 50% opacity) inside the envelope, appearing
when active and disappearing when freed.

Default-pool allocations are rendered exactly as before (full-opacity colored
blocks in the stacked area chart).

### How to review

All changes are in `torch/utils/viz/MemoryViz.js`. The two commits can be
reviewed in order:

1. **`Add a tab to show private pool memory view`** — Adds the tab entry,
   `include_private_inactive` parameter plumbing, `isPrivatePool` helper,
   `find_pool_id` binary search for mapping block addresses to pool IDs,
   `segment_pool_id` propagation through the data model, and pool_id display
   in segment/block hover text.

2. **`add activities inside the pool`** — Adds the pool envelope and stripe
   logic inside `process_alloc_data`: per-pool state tracking (`max`, `active`,
   `block_stack`), envelope creation/growth with animated transitions,
   stripe lifecycle (create on alloc, close on free, shift on repack),
   and stripe-envelope synchronization when the global stack shifts.

### Detailed behavior

Given this sequence (from `test.py`):

```python
torch.cuda.memory._record_memory_history()

# 1. Default-pool allocation
x = torch.empty(1024, device="cuda", dtype=torch.uint8)

# 2. Private-pool allocation
m = torch.cuda.MemPool()
with torch.cuda.use_mem_pool(m):
    y = torch.empty(1024, device="cuda", dtype=torch.uint8)

# 3-4. Free tensors — y's memory becomes inactive in the private pool
del x
del y

# 5. Another default-pool allocation
z = torch.empty(1024, device="cuda", dtype=torch.uint8)

# 6-7. More private-pool allocations — w reuses y's space, w2 forces growth
with torch.cuda.use_mem_pool(m):
    w = torch.empty(1024, device="cuda", dtype=torch.uint8)
    w2 = torch.empty(1024, device="cuda", dtype=torch.uint8)

snapshot = torch.cuda.memory._snapshot()
```

The visualization shows:
1. `alloc x` (default pool) → x appears as a normal colored block
2. `alloc y` (pool (0,1)) → pool envelope appears, grows to 1024; y stripe inside
3. `free x` → x disappears, pool envelope shifts down
4. `free y` → y stripe disappears; envelope stays at 1024 (gray unused space)
5. `alloc z` (default pool) → z appears on top of the pool envelope
6. `alloc w` (pool (0,1)) → w stripe appears inside pool (reuses space, no growth)
7. `alloc w2` (pool (0,1)) → pool envelope grows from 1024 to 2048; z shifts up; w2 stripe appears

Key design decisions:
- Pool envelope height = high-water mark of active block sizes (monotonically non-decreasing)
- Pool stripes use the same color scheme as regular allocations but at 50% opacity
- Hovering the gray envelope shows `"Private Pool (x,y): capacity {size}"`
- Hovering a stripe shows the normal block context (address, size, stack trace, pool_id)
- Growth animations shift elements above the pool over 3 timesteps; stripes are created after the shift completes to avoid visual overlap
- A yellow banner warns that MemPools must not be deleted before `torch.cuda.memory._snapshot()` is called

This PR was authored with Claude.

Example tab view:

gray bar starts when mem pool is allocated. 

<img width="1467" height="612" alt="Screenshot 2026-03-12 at 3 46 51 PM" src="https://github.com/user-attachments/assets/929315a1-c1c3-42cb-b349-c52012a8591d" />


and from a real workload: 

The gray bar at the bottom is the private pool that cuda graph use. The colored striped inside are the activities inside the private pool. 

<img width="1367" height="472" alt="Screenshot 2026-03-12 at 2 37 46 PM" src="https://github.com/user-attachments/assets/177c85dd-0364-4013-a45b-56434d66bc07" />


## Test plan

- Manual testing with `test.py` which exercises both default and private pool
  allocations, frees, reuse, and pool growth
- Verified in browser that:
  - Pool envelope appears on first private pool allocation
  - Envelope grows when active blocks exceed high-water mark
  - Envelope never shrinks when blocks are freed
  - Stripes appear/disappear correctly on alloc/free
  - Default-pool blocks stack correctly above/below the pool envelope
  - No visual overlap between pool stripes and default-pool blocks
  - Hover context shows pool info for envelopes, block info for stripes
  - Detail slider and minimap work correctly with pool data
  - Other tabs ("Active Memory Timeline", "Allocator State History", etc.)
    are unaffected
