### PR TITLE
[export] Fix dynamic_lstm test

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -1174,192 +1174,196 @@ graph():
         export(Foo(), inputs, dynamic_shapes=dynamic_shapes)
 
     def test_dynamic_lstm(self):
-        from torch.export._patches import (
-            register_gru_while_loop_decomposition,
-            register_lstm_while_loop_decomposition,
-        )
-
-        # Test 1: Basic single-layer LSTM with dynamic sequence length
-        seqlen = 32
-        bs = 16
-        h = 512
-
-        class LSTM(torch.nn.Module):
-            def __init__(self, h):
-                super().__init__()
-                self.lstm = torch.nn.LSTM(h, h)
-
-            def forward(self, x, h0, c0):
-                out, (_, _) = self.lstm(x, (h0, c0))
-                return out
-
-        x = torch.randn(seqlen, bs, h)
-        h0, c0 = torch.randn(1, bs, h), torch.randn(1, bs, h)
-
-        model = LSTM(h)
-        eager_out = model(x, h0, c0)
-        dynamic_shapes = {
-            "x": {0: Dim.DYNAMIC},
-            "h0": None,
-            "c0": None,
-        }
-
-        with register_lstm_while_loop_decomposition():
-            ep = export(model, (x, h0, c0), dynamic_shapes=dynamic_shapes)
-        ep_out = ep.module()(x, h0, c0)
-        self.assertEqual(eager_out, ep_out)
-        # test dynamic output with different sequence length
-        x_ = torch.randn(64, bs, h)
-        ep_out_dynamic = ep.module()(x_, h0, c0)
-        self.assertEqual(ep_out_dynamic, model(x_, h0, c0))
-
-        # Test 2: Bidirectional LSTM
-        class BiLSTM(torch.nn.Module):
-            def __init__(self, h):
-                super().__init__()
-                self.lstm = torch.nn.LSTM(h, h, bidirectional=True)
-
-            def forward(self, x, h0, c0):
-                out, (_, _) = self.lstm(x, (h0, c0))
-                return out
-
-        h0_bi = torch.randn(2, bs, h)
-        c0_bi = torch.randn(2, bs, h)
-        model_bi = BiLSTM(h)
-        eager_out_bi = model_bi(x, h0_bi, c0_bi)
-        dynamic_shapes_bi = {
-            "x": {0: Dim.DYNAMIC},
-            "h0": None,
-            "c0": None,
-        }
-
-        with register_lstm_while_loop_decomposition():
-            ep_bi = export(
-                model_bi, (x, h0_bi, c0_bi), dynamic_shapes=dynamic_shapes_bi
+        # Disable mkldnn so eager uses the same pure-PyTorch LSTM/GRU as the
+        # while-loop decomposition, avoiding numerical divergence from the
+        # fused mkldnn kernel.
+        with torch.backends.mkldnn.flags(enabled=False):
+            from torch.export._patches import (
+                register_gru_while_loop_decomposition,
+                register_lstm_while_loop_decomposition,
             )
-        ep_out_bi = ep_bi.module()(x, h0_bi, c0_bi)
-        self.assertEqual(eager_out_bi, ep_out_bi)
-        # test with different sequence length
-        ep_out_bi_dynamic = ep_bi.module()(x_, h0_bi, c0_bi)
-        self.assertEqual(ep_out_bi_dynamic, model_bi(x_, h0_bi, c0_bi))
 
-        # Test 3: Multi-layer LSTM
-        class MultiLayerLSTM(torch.nn.Module):
-            def __init__(self, h, num_layers=2):
-                super().__init__()
-                self.lstm = torch.nn.LSTM(h, h, num_layers=num_layers)
+            # Test 1: Basic single-layer LSTM with dynamic sequence length
+            seqlen = 32
+            bs = 16
+            h = 512
 
-            def forward(self, x, h0, c0):
-                out, (_, _) = self.lstm(x, (h0, c0))
-                return out
+            class LSTM(torch.nn.Module):
+                def __init__(self, h):
+                    super().__init__()
+                    self.lstm = torch.nn.LSTM(h, h)
 
-        num_layers = 2
-        h0_multi = torch.randn(num_layers, bs, h)
-        c0_multi = torch.randn(num_layers, bs, h)
-        model_multi = MultiLayerLSTM(h, num_layers)
-        eager_out_multi = model_multi(x, h0_multi, c0_multi)
-        dynamic_shapes_multi = {
-            "x": {0: Dim.DYNAMIC},
-            "h0": None,
-            "c0": None,
-        }
+                def forward(self, x, h0, c0):
+                    out, (_, _) = self.lstm(x, (h0, c0))
+                    return out
 
-        with register_lstm_while_loop_decomposition():
-            ep_multi = export(
-                model_multi,
-                (x, h0_multi, c0_multi),
-                dynamic_shapes=dynamic_shapes_multi,
+            x = torch.randn(seqlen, bs, h)
+            h0, c0 = torch.randn(1, bs, h), torch.randn(1, bs, h)
+
+            model = LSTM(h)
+            eager_out = model(x, h0, c0)
+            dynamic_shapes = {
+                "x": {0: Dim.DYNAMIC},
+                "h0": None,
+                "c0": None,
+            }
+
+            with register_lstm_while_loop_decomposition():
+                ep = export(model, (x, h0, c0), dynamic_shapes=dynamic_shapes)
+            ep_out = ep.module()(x, h0, c0)
+            self.assertEqual(eager_out, ep_out)
+            # test dynamic output with different sequence length
+            x_ = torch.randn(64, bs, h)
+            ep_out_dynamic = ep.module()(x_, h0, c0)
+            self.assertEqual(ep_out_dynamic, model(x_, h0, c0))
+
+            # Test 2: Bidirectional LSTM
+            class BiLSTM(torch.nn.Module):
+                def __init__(self, h):
+                    super().__init__()
+                    self.lstm = torch.nn.LSTM(h, h, bidirectional=True)
+
+                def forward(self, x, h0, c0):
+                    out, (_, _) = self.lstm(x, (h0, c0))
+                    return out
+
+            h0_bi = torch.randn(2, bs, h)
+            c0_bi = torch.randn(2, bs, h)
+            model_bi = BiLSTM(h)
+            eager_out_bi = model_bi(x, h0_bi, c0_bi)
+            dynamic_shapes_bi = {
+                "x": {0: Dim.DYNAMIC},
+                "h0": None,
+                "c0": None,
+            }
+
+            with register_lstm_while_loop_decomposition():
+                ep_bi = export(
+                    model_bi, (x, h0_bi, c0_bi), dynamic_shapes=dynamic_shapes_bi
+                )
+            ep_out_bi = ep_bi.module()(x, h0_bi, c0_bi)
+            self.assertEqual(eager_out_bi, ep_out_bi)
+            # test with different sequence length
+            ep_out_bi_dynamic = ep_bi.module()(x_, h0_bi, c0_bi)
+            self.assertEqual(ep_out_bi_dynamic, model_bi(x_, h0_bi, c0_bi))
+
+            # Test 3: Multi-layer LSTM
+            class MultiLayerLSTM(torch.nn.Module):
+                def __init__(self, h, num_layers=2):
+                    super().__init__()
+                    self.lstm = torch.nn.LSTM(h, h, num_layers=num_layers)
+
+                def forward(self, x, h0, c0):
+                    out, (_, _) = self.lstm(x, (h0, c0))
+                    return out
+
+            num_layers = 2
+            h0_multi = torch.randn(num_layers, bs, h)
+            c0_multi = torch.randn(num_layers, bs, h)
+            model_multi = MultiLayerLSTM(h, num_layers)
+            eager_out_multi = model_multi(x, h0_multi, c0_multi)
+            dynamic_shapes_multi = {
+                "x": {0: Dim.DYNAMIC},
+                "h0": None,
+                "c0": None,
+            }
+
+            with register_lstm_while_loop_decomposition():
+                ep_multi = export(
+                    model_multi,
+                    (x, h0_multi, c0_multi),
+                    dynamic_shapes=dynamic_shapes_multi,
+                )
+            ep_out_multi = ep_multi.module()(x, h0_multi, c0_multi)
+            self.assertEqual(eager_out_multi, ep_out_multi)
+            ep_out_multi_dynamic = ep_multi.module()(x_, h0_multi, c0_multi)
+            self.assertEqual(ep_out_multi_dynamic, model_multi(x_, h0_multi, c0_multi))
+
+            # Test 4: batch_first=True
+            class BatchFirstLSTM(torch.nn.Module):
+                def __init__(self, h):
+                    super().__init__()
+                    self.lstm = torch.nn.LSTM(h, h, batch_first=True)
+
+                def forward(self, x, h0, c0):
+                    out, (_, _) = self.lstm(x, (h0, c0))
+                    return out
+
+            x_batch_first = torch.randn(bs, seqlen, h)
+            model_batch_first = BatchFirstLSTM(h)
+            eager_out_batch_first = model_batch_first(x_batch_first, h0, c0)
+            dynamic_shapes_batch_first = {
+                "x": {1: Dim.DYNAMIC},  # dynamic dimension is now dim 1
+                "h0": None,
+                "c0": None,
+            }
+
+            with register_lstm_while_loop_decomposition():
+                ep_batch_first = export(
+                    model_batch_first,
+                    (x_batch_first, h0, c0),
+                    dynamic_shapes=dynamic_shapes_batch_first,
+                )
+            ep_out_batch_first = ep_batch_first.module()(x_batch_first, h0, c0)
+            self.assertEqual(eager_out_batch_first, ep_out_batch_first)
+            x_batch_first_dynamic = torch.randn(bs, 64, h)
+            ep_out_batch_first_dynamic = ep_batch_first.module()(
+                x_batch_first_dynamic, h0, c0
             )
-        ep_out_multi = ep_multi.module()(x, h0_multi, c0_multi)
-        self.assertEqual(eager_out_multi, ep_out_multi)
-        ep_out_multi_dynamic = ep_multi.module()(x_, h0_multi, c0_multi)
-        self.assertEqual(ep_out_multi_dynamic, model_multi(x_, h0_multi, c0_multi))
-
-        # Test 4: batch_first=True
-        class BatchFirstLSTM(torch.nn.Module):
-            def __init__(self, h):
-                super().__init__()
-                self.lstm = torch.nn.LSTM(h, h, batch_first=True)
-
-            def forward(self, x, h0, c0):
-                out, (_, _) = self.lstm(x, (h0, c0))
-                return out
-
-        x_batch_first = torch.randn(bs, seqlen, h)
-        model_batch_first = BatchFirstLSTM(h)
-        eager_out_batch_first = model_batch_first(x_batch_first, h0, c0)
-        dynamic_shapes_batch_first = {
-            "x": {1: Dim.DYNAMIC},  # dynamic dimension is now dim 1
-            "h0": None,
-            "c0": None,
-        }
-
-        with register_lstm_while_loop_decomposition():
-            ep_batch_first = export(
-                model_batch_first,
-                (x_batch_first, h0, c0),
-                dynamic_shapes=dynamic_shapes_batch_first,
+            self.assertEqual(
+                ep_out_batch_first_dynamic,
+                model_batch_first(x_batch_first_dynamic, h0, c0),
             )
-        ep_out_batch_first = ep_batch_first.module()(x_batch_first, h0, c0)
-        self.assertEqual(eager_out_batch_first, ep_out_batch_first)
-        x_batch_first_dynamic = torch.randn(bs, 64, h)
-        ep_out_batch_first_dynamic = ep_batch_first.module()(
-            x_batch_first_dynamic, h0, c0
-        )
-        self.assertEqual(
-            ep_out_batch_first_dynamic,
-            model_batch_first(x_batch_first_dynamic, h0, c0),
-        )
 
-        # Test 5: GRU with dynamic sequence length
-        class GRU(torch.nn.Module):
-            def __init__(self, h):
-                super().__init__()
-                self.gru = torch.nn.GRU(h, h)
+            # Test 5: GRU with dynamic sequence length
+            class GRU(torch.nn.Module):
+                def __init__(self, h):
+                    super().__init__()
+                    self.gru = torch.nn.GRU(h, h)
 
-            def forward(self, x, h0):
-                out, _ = self.gru(x, h0)
-                return out
+                def forward(self, x, h0):
+                    out, _ = self.gru(x, h0)
+                    return out
 
-        model_gru = GRU(h)
-        eager_out_gru = model_gru(x, h0)
-        dynamic_shapes_gru = {
-            "x": {0: Dim.DYNAMIC},
-            "h0": None,
-        }
+            model_gru = GRU(h)
+            eager_out_gru = model_gru(x, h0)
+            dynamic_shapes_gru = {
+                "x": {0: Dim.DYNAMIC},
+                "h0": None,
+            }
 
-        with register_gru_while_loop_decomposition():
-            ep_gru = export(model_gru, (x, h0), dynamic_shapes=dynamic_shapes_gru)
-        ep_out_gru = ep_gru.module()(x, h0)
-        self.assertEqual(eager_out_gru, ep_out_gru)
-        ep_out_gru_dynamic = ep_gru.module()(x_, h0)
-        self.assertEqual(ep_out_gru_dynamic, model_gru(x_, h0))
+            with register_gru_while_loop_decomposition():
+                ep_gru = export(model_gru, (x, h0), dynamic_shapes=dynamic_shapes_gru)
+            ep_out_gru = ep_gru.module()(x, h0)
+            self.assertEqual(eager_out_gru, ep_out_gru)
+            ep_out_gru_dynamic = ep_gru.module()(x_, h0)
+            self.assertEqual(ep_out_gru_dynamic, model_gru(x_, h0))
 
-        # Test 6: Bidirectional GRU
-        class BiGRU(torch.nn.Module):
-            def __init__(self, h):
-                super().__init__()
-                self.gru = torch.nn.GRU(h, h, bidirectional=True)
+            # Test 6: Bidirectional GRU
+            class BiGRU(torch.nn.Module):
+                def __init__(self, h):
+                    super().__init__()
+                    self.gru = torch.nn.GRU(h, h, bidirectional=True)
 
-            def forward(self, x, h0):
-                out, _ = self.gru(x, h0)
-                return out
+                def forward(self, x, h0):
+                    out, _ = self.gru(x, h0)
+                    return out
 
-        model_bigru = BiGRU(h)
-        eager_out_bigru = model_bigru(x, h0_bi)
-        dynamic_shapes_bigru = {
-            "x": {0: Dim.DYNAMIC},
-            "h0": None,
-        }
+            model_bigru = BiGRU(h)
+            eager_out_bigru = model_bigru(x, h0_bi)
+            dynamic_shapes_bigru = {
+                "x": {0: Dim.DYNAMIC},
+                "h0": None,
+            }
 
-        with register_gru_while_loop_decomposition():
-            ep_bigru = export(
-                model_bigru, (x, h0_bi), dynamic_shapes=dynamic_shapes_bigru
-            )
-        ep_out_bigru = ep_bigru.module()(x, h0_bi)
-        self.assertEqual(eager_out_bigru, ep_out_bigru)
-        ep_out_bigru_dynamic = ep_bigru.module()(x_, h0_bi)
-        self.assertEqual(ep_out_bigru_dynamic, model_bigru(x_, h0_bi))
+            with register_gru_while_loop_decomposition():
+                ep_bigru = export(
+                    model_bigru, (x, h0_bi), dynamic_shapes=dynamic_shapes_bigru
+                )
+            ep_out_bigru = ep_bigru.module()(x, h0_bi)
+            self.assertEqual(eager_out_bigru, ep_out_bigru)
+            ep_out_bigru_dynamic = ep_bigru.module()(x_, h0_bi)
+            self.assertEqual(ep_out_bigru_dynamic, model_bigru(x_, h0_bi))
 
     @testing.expectedFailureStrictV2
     def test_no_tensor_computation(self):


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/176995

When we export we disable mkldnn, which causes some numerical discrepancies when we compare it against the eager path which uses mkldnn. This PR just adds a decorator so that we compare the eager path w/o mkldnn