### PR TITLE
[dynamo] Fix torch.Size dict key lookup with TensorVariable elements

### DIFF
--- a/test/dynamo/test_dicts.py
+++ b/test/dynamo/test_dicts.py
@@ -2310,6 +2310,60 @@ class DunderDictVariableTests(torch._dynamo.test_case.TestCase):
         result = fn(obj)
         self.assertEqual(result, [("a", 1), ("b", 2), ("c", 3)])
 
+    def test_dict_torch_size_dynamic_key(self):
+        import torch
+        import torch.nn as nn
+
+        class DynamicShapeModel(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.layer_configs = {
+                    torch.Size([32, 64]): nn.Linear(32, 64),
+                    torch.Size([64, 128]): nn.Linear(64, 128),
+                    torch.Size([128, 256]): nn.Linear(128, 256),
+                }
+                self.activation_functions = {
+                    torch.Size([32]): nn.ReLU(),
+                    torch.Size([64]): nn.Tanh(),
+                    torch.Size([128]): nn.Sigmoid(),
+                }
+
+            def forward(self, x):
+                current_shape = torch.tensor(x.shape[1:])
+                shape_key = torch.Size([current_shape[0], 64])
+                if shape_key in self.layer_configs:
+                    x = self.layer_configs[shape_key](x)
+
+                activation_shape = torch.Size([x.shape[1]])
+                if activation_shape in self.activation_functions:
+                    x = self.activation_functions[activation_shape](x)
+                return x
+
+        model = DynamicShapeModel().eval()
+
+        for features in [32, 64, 128]:
+            x = torch.randn(4, features)
+            eager_out = model(x)
+
+            torch._dynamo.reset()
+            compiled_model = torch.compile(model, backend="eager")
+            with torch.no_grad():
+                compiled_out = compiled_model(x)
+
+            self.assertEqual(eager_out.shape, compiled_out.shape)
+            self.assertTrue(torch.allclose(eager_out, compiled_out, atol=1e-6))
+
+        x = torch.randn(4, 16)
+        eager_out = model(x)
+
+        torch._dynamo.reset()
+        compiled_model = torch.compile(model, backend="eager")
+        with torch.no_grad():
+            compiled_out = compiled_model(x)
+
+        self.assertEqual(eager_out.shape, compiled_out.shape)
+        self.assertEqual(compiled_out.shape, torch.Size([4, 16]))
+
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/test/dynamo/test_dicts.py
+++ b/test/dynamo/test_dicts.py
@@ -2392,6 +2392,32 @@ class DunderDictVariableTests(torch._dynamo.test_case.TestCase):
 
         self.assertEqual(fn(x), compiled_fn(x))
 
+    def test_dict_torch_size_dynamic_key_local_literal_dynamic_recompile(self):
+        def fn(x):
+            current_shape = torch.tensor(x.shape[1:])
+            shape_key = torch.Size([current_shape[0], 64])
+            literal_mapping = {
+                torch.Size([32, 64]): 1,
+                torch.Size([64, 64]): 2,
+            }
+
+            if shape_key in literal_mapping:
+                return x + literal_mapping[shape_key]
+            return x - 1
+
+        cnt = torch._dynamo.testing.CompileCounter()
+        compiled_fn = torch.compile(fn, backend=cnt, dynamic=True)
+
+        x32 = torch.randn(4, 32)
+        x64 = torch.randn(4, 64)
+
+        self.assertEqual(fn(x32), compiled_fn(x32))
+        self.assertEqual(fn(x64), compiled_fn(x64))
+        self.assertEqual(cnt.frame_count, 2)
+
+        self.assertEqual(fn(x32), compiled_fn(x32))
+        self.assertEqual(cnt.frame_count, 2)
+
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/test/dynamo/test_dicts.py
+++ b/test/dynamo/test_dicts.py
@@ -2364,6 +2364,34 @@ class DunderDictVariableTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(eager_out.shape, compiled_out.shape)
         self.assertEqual(compiled_out.shape, torch.Size([4, 16]))
 
+    def test_dict_torch_size_dynamic_key_local_literal(self):
+        def fn(x):
+            current_shape = torch.tensor(x.shape[1:])
+            shape_key = torch.Size([current_shape[0], 64])
+            literal_mapping = {
+                torch.Size([32, 64]): 1,
+                torch.Size([64, 64]): 2,
+            }
+
+            if shape_key in literal_mapping:
+                return x + literal_mapping[shape_key]
+            return x - 1
+
+        for features in [32, 64]:
+            x = torch.randn(4, features)
+
+            torch._dynamo.reset()
+            compiled_fn = torch.compile(fn, backend="eager")
+
+            self.assertEqual(fn(x), compiled_fn(x))
+
+        x = torch.randn(4, 16)
+
+        torch._dynamo.reset()
+        compiled_fn = torch.compile(fn, backend="eager")
+
+        self.assertEqual(fn(x), compiled_fn(x))
+
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/torch/_dynamo/variables/dicts.py
+++ b/torch/_dynamo/variables/dicts.py
@@ -151,6 +151,14 @@ class ConstDictVariable(VariableTracker):
             from .lists import SizeVariable
             from .tensor import TensorVariable
 
+            try:
+                python_constant = vt.as_python_constant()
+            except NotImplementedError:
+                python_constant = cls._MISSING
+
+            if isinstance(python_constant, torch.Size):
+                return python_constant
+
             if not isinstance(vt, SizeVariable):
                 return cls._MISSING
 

--- a/torch/_dynamo/variables/dicts.py
+++ b/torch/_dynamo/variables/dicts.py
@@ -25,6 +25,7 @@ import types
 from collections.abc import Callable, Iterable, Iterator, Sequence
 from typing import Any, Literal, Optional, TYPE_CHECKING, Union
 
+import torch
 from torch.utils._ordered_set import OrderedSet
 from torch.utils._pytree import MappingKey
 
@@ -129,6 +130,7 @@ class ConstDictVariable(VariableTracker):
     }
 
     class _HashableTracker:
+        _MISSING = object()
         """
         Auxiliary opaque internal class that wraps a VariableTracker and makes it hashable
         This should not be seen or touched by anything outside of ConstDictVariable and its children
@@ -143,6 +145,43 @@ class ConstDictVariable(VariableTracker):
             if not is_hashable(vt):
                 raise_unhashable(vt)
             self.vt = vt
+
+        @classmethod
+        def _maybe_constant_key(cls, vt: VariableTracker) -> object:
+            from .lists import SizeVariable
+            from .tensor import TensorVariable
+
+            if not isinstance(vt, SizeVariable):
+                return cls._MISSING
+
+            items = []
+            for item in vt.items:
+                if item.is_python_constant():
+                    items.append(item.as_python_constant())
+                    continue
+
+                if isinstance(item, TensorVariable):
+                    proxy = getattr(item, "proxy", None)
+                    node = getattr(proxy, "node", None)
+                    meta = getattr(node, "meta", None) if node is not None else None
+                    example_value = (
+                        meta.get("example_value") if isinstance(meta, dict) else None
+                    )
+
+                    if (
+                        isinstance(example_value, torch.Tensor)
+                        and example_value.numel() == 1
+                    ):
+                        items.append(example_value.item())
+                        continue
+
+                    if isinstance(example_value, (int, bool)):
+                        items.append(example_value)
+                        continue
+
+                return cls._MISSING
+
+            return torch.Size(items)
 
         def __hash__(self) -> int:
             """
@@ -161,6 +200,9 @@ class ConstDictVariable(VariableTracker):
                 and self.vt.is_hashable()
             ):
                 return hash(self.vt.original_value())
+            maybe_constant = self._maybe_constant_key(self.vt)
+            if maybe_constant is not self._MISSING:
+                return hash(maybe_constant)
             return self.vt.get_python_hash()
 
         def __eq__(self, other: object) -> bool:
@@ -180,6 +222,13 @@ class ConstDictVariable(VariableTracker):
                 return False
             if self.vt is other.vt:
                 return True
+            self_constant = self._maybe_constant_key(self.vt)
+            other_constant = self._maybe_constant_key(other.vt)
+            if (
+                self_constant is not self._MISSING
+                and other_constant is not self._MISSING
+            ):
+                return self_constant == other_constant
             return self.vt.is_python_equal(other.vt)
 
     def __init__(
@@ -267,10 +316,11 @@ class ConstDictVariable(VariableTracker):
     def __contains__(self, vt: VariableTracker) -> bool:
         assert isinstance(vt, VariableTracker)
         Hashable = ConstDictVariable._HashableTracker
-        return (
-            vt.is_python_hashable()
-            and Hashable(vt) in self.items
-            and not isinstance(self.items[Hashable(vt)], variables.DeletedVariable)
+        if not is_hashable(vt):
+            return False
+        key = Hashable(vt)
+        return key in self.items and not isinstance(
+            self.items[key], variables.DeletedVariable
         )
 
     def call_tree_map_branch(
@@ -773,12 +823,13 @@ class ConstDictVariable(VariableTracker):
                     f"{len(args)} args and {len(kwargs)} kwargs",
                 )
 
-            arg_hashable = args and is_hashable(args[0])
+            key = args[0]
+            arg_hashable = is_hashable(key)
             if not arg_hashable:
-                raise_unhashable(args[0], tx)
+                raise_unhashable(key, tx)
 
-            self.install_dict_contains_guard(tx, args)
-            contains = args[0] in self
+            self.install_dict_contains_guard(tx, [key])
+            contains = key in self
             return VariableTracker.build(tx, contains)
         elif name == "setdefault" and self.is_mutable():
             if len(args) not in (1, 2):

--- a/torch/_dynamo/variables/dicts.py
+++ b/torch/_dynamo/variables/dicts.py
@@ -156,6 +156,8 @@ class ConstDictVariable(VariableTracker):
             except NotImplementedError:
                 python_constant = cls._MISSING
 
+            # Dict literals keep torch.Size keys as Python constants rather than
+            # SizeVariables, so normalize that form before the symbolic fallback.
             if isinstance(python_constant, torch.Size):
                 return python_constant
 

--- a/torch/_dynamo/variables/dicts.py
+++ b/torch/_dynamo/variables/dicts.py
@@ -185,13 +185,34 @@ class ConstDictVariable(VariableTracker):
                         and example_value.numel() == 1
                     ):
                         item_memo = getattr(example_value, "item_memo", None)
-                        if guard and item_memo is not None:
-                            from torch.fx.experimental.symbolic_shapes import (
-                                guard_scalar,
-                            )
+                        if item_memo is not None:
+                            if guard:
+                                from torch.fx.experimental.symbolic_shapes import (
+                                    guard_scalar,
+                                )
 
-                            items.append(guard_scalar(item_memo))
+                                items.append(guard_scalar(item_memo))
+                                continue
+                            item_node = getattr(item_memo, "node", None)
+                            item_hint = getattr(item_node, "hint", None)
+                            if item_hint is not None:
+                                items.append(item_hint)
+                                continue
+                            return cls._MISSING
+
+                        constant = getattr(example_value, "constant", None)
+                        if (
+                            isinstance(constant, torch.Tensor)
+                            and constant.numel() == 1
+                        ):
+                            items.append(constant.item())
                             continue
+
+                        from torch._subclasses.fake_tensor import FakeTensor
+
+                        if isinstance(example_value, FakeTensor):
+                            return cls._MISSING
+
                         items.append(example_value.item())
                         continue
 

--- a/torch/_dynamo/variables/dicts.py
+++ b/torch/_dynamo/variables/dicts.py
@@ -151,7 +151,7 @@ class ConstDictVariable(VariableTracker):
             cls, vt: VariableTracker, *, guard: bool = False
         ) -> object:
             from .lists import SizeVariable
-            from .tensor import TensorVariable
+            from .tensor import SymNodeVariable, TensorVariable
 
             try:
                 python_constant = vt.as_python_constant()
@@ -171,6 +171,21 @@ class ConstDictVariable(VariableTracker):
                 if item.is_python_constant():
                     items.append(item.as_python_constant())
                     continue
+
+                if isinstance(item, SymNodeVariable):
+                    # dynamic=True size tracing can materialize torch.Size
+                    # elements as SymNodeVariables instead of scalar tensors.
+                    if guard:
+                        items.append(item.evaluate_expr())
+                        continue
+
+                    item_node = getattr(item.sym_num, "node", None)
+                    item_hint = getattr(item_node, "hint", None)
+                    if item_hint is not None:
+                        items.append(item_hint)
+                        continue
+
+                    return cls._MISSING
 
                 if isinstance(item, TensorVariable):
                     proxy = getattr(item, "proxy", None)

--- a/torch/_dynamo/variables/dicts.py
+++ b/torch/_dynamo/variables/dicts.py
@@ -147,7 +147,9 @@ class ConstDictVariable(VariableTracker):
             self.vt = vt
 
         @classmethod
-        def _maybe_constant_key(cls, vt: VariableTracker) -> object:
+        def _maybe_constant_key(
+            cls, vt: VariableTracker, *, guard: bool = False
+        ) -> object:
             from .lists import SizeVariable
             from .tensor import TensorVariable
 
@@ -182,6 +184,14 @@ class ConstDictVariable(VariableTracker):
                         isinstance(example_value, torch.Tensor)
                         and example_value.numel() == 1
                     ):
+                        item_memo = getattr(example_value, "item_memo", None)
+                        if guard and item_memo is not None:
+                            from torch.fx.experimental.symbolic_shapes import (
+                                guard_scalar,
+                            )
+
+                            items.append(guard_scalar(item_memo))
+                            continue
                         items.append(example_value.item())
                         continue
 
@@ -574,8 +584,11 @@ class ConstDictVariable(VariableTracker):
         # 1) The dict has been mutated. In this case, we would have already
         # inserted a DICT_KEYS_MATCH guard, so we can skip.
         #
-        # 2) args[0].source is None. This happens for const keys. Here, we
-        # have to insert the DICT_CONTAINS guard.
+        # 2) We can recover a concrete key (either from a Python constant or a
+        # source-less torch.Size assembled from tracked scalar values). Here,
+        # we insert a DICT_CONTAINS/DICT_NOT_CONTAINS guard and, for the
+        # recovered torch.Size case, also guard on the scalar values used to
+        # build the key.
         #
         # 3) args[0].source is not None. This can happen for non-const VTs.
         #   3a) contains=True. In this case, we can access the lazyVT from
@@ -591,7 +604,21 @@ class ConstDictVariable(VariableTracker):
             return
 
         contains = args[0] in self
-        if args[0].source is None and args[0].is_python_constant():
+        Hashable = ConstDictVariable._HashableTracker
+        constant_key = Hashable._maybe_constant_key(args[0], guard=True)
+        if constant_key is not Hashable._MISSING:
+            guard_fn = (
+                type(self).CONTAINS_GUARD if contains else type(self).NOT_CONTAINS_GUARD
+            )
+            install_guard(
+                self.make_guard(
+                    functools.partial(
+                        guard_fn,
+                        key=constant_key,
+                    )
+                )
+            )
+        elif args[0].source is None and args[0].is_python_constant():
             guard_fn = (
                 type(self).CONTAINS_GUARD if contains else type(self).NOT_CONTAINS_GUARD
             )


### PR DESCRIPTION
## Summary
Fix #176862

## Root cause problem
`torch.tensor(x.shape[1:])` produces `TensorVariable` elements inside a traced `SizeVariable`. `ConstDictVariable._HashableTracker` then hashes and compares that runtime `torch.Size` against concrete dictionary keys using variable-tracker equality, so `shape_key in self.layer_configs` misses and the compiled branch is silently skipped.

## Proposed fix
Teach `_HashableTracker` to recover a constant `torch.Size` when a `SizeVariable` is composed of Python constants or scalar `TensorVariable`s backed by FX `example_value` metadata. Use that recovered key for hashing and equality, keep `ConstDictVariable.__contains__` on the shared `is_hashable()` path, and add a regression test that covers both matching and non-matching dynamic shape lookups.

## Why this is the right long term fix
The bug lives in Dynamo's dictionary-key abstraction, not in a single model pattern. Normalizing traced `torch.Size` keys inside `_HashableTracker` keeps dict lookup semantics aligned with eager behavior anywhere these keys flow through `ConstDictVariable`, while the regression test guards the behavior going forward.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo