### PR TITLE
[Helion + torch.compile] Normalize MultiOutput write deps for consistent fusion matching

### DIFF
--- a/test/inductor/test_cpu_select_algorithm.py
+++ b/test/inductor/test_cpu_select_algorithm.py
@@ -2436,6 +2436,7 @@ class TestSelectAlgorithm(BaseTestSelectAlgorithm):
             ["silu", "mul"],
         ),
     )
+    @parametrize("loop_ordering_after_fusion", (True, False))
     def test_grouped_linear_epilogue(
         self,
         batch_size,
@@ -2444,6 +2445,7 @@ class TestSelectAlgorithm(BaseTestSelectAlgorithm):
         input_3d,
         bias,
         epilogue,
+        loop_ordering_after_fusion,
     ):
         class M(torch.nn.Module):
             def __init__(self, in_feature, out_feature, bias, epilogue):
@@ -2484,6 +2486,9 @@ class TestSelectAlgorithm(BaseTestSelectAlgorithm):
                 verify(dtype) as (atol, rtol),
                 torch.autocast(device_type="cpu", dtype=dtype),
                 torch.no_grad(),
+                inductor_config.patch(
+                    {"loop_ordering_after_fusion": loop_ordering_after_fusion}
+                ),
             ):
                 self.common(mod, (v,), atol=atol, rtol=rtol)
             self.assertEqual(counters["inductor"]["cpp_grouped_gemm_template"], 1)

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -8850,6 +8850,8 @@ class MultiOutput(ExternKernel):
 
         # Writes: build proper MemoryDep from our FixedLayout so the
         # scheduler can match our write with downstream epilogue reads.
+        # Normalize using the same policy as SchedulerNode so that the
+        # index expressions are directly comparable during fusion checks.
         name = self.get_name()
         indexer = self.get_layout().make_indexer()
 
@@ -8857,7 +8859,15 @@ class MultiOutput(ExternKernel):
             assert len(rindex) == 0
             return ops.store(name, indexer(index), "fake")
 
-        write_rw = dependencies.extract_read_writes(dummy, self.get_size(), ())
+        device = self.get_device()
+        should_normalize = (
+            not config.loop_ordering_after_fusion
+            or device is None
+            or not is_gpu(device.type)
+        )
+        write_rw = dependencies.extract_read_writes(
+            dummy, self.get_size(), (), normalize=should_normalize
+        )
         return dependencies.ReadWrites(
             reads=reads,
             writes=write_rw.writes,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #177065
* #177064
* __->__ #177315
* #177063
* #177062

Normalize using the same policy as SchedulerNode so that the
index expressions are directly comparable during fusion checks.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo