### PR TITLE
Update the SDPA error modes to be much cleaner

### DIFF
--- a/aten/src/ATen/native/mkldnn/xpu/Attention.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/Attention.cpp
@@ -8,56 +8,76 @@
 #include <torch/library.h>
 
 namespace {
-bool check_head_dim_size_xpu(sdp::sdp_params const& params, bool debug) {
+bool check_head_dim_size_xpu(
+    sdp::sdp_params const& params,
+    c10::OptionalRef<sdp::SDPDiagnostics> diagnostics) {
   const auto query_size_last = params.query.sym_size(-1);
   const auto key_size_last = params.key.sym_size(-1);
   const auto value_size_last = params.value.sym_size(-1);
   if (query_size_last != key_size_last) {
-    if (debug) {
-      TORCH_WARN(
-          "OneDNN attention requires q,k to have the same last dimension.",
-          " Got Query.size(-1): ",
-          query_size_last,
-          ", Key.size(-1): ",
-          key_size_last,
-          " instead.");
-    }
+    sdp::report_failure(
+        diagnostics,
+        "OneDNN attention requires q,k to have the same last dimension.",
+        " Got Query.size(-1): ",
+        query_size_last,
+        ", Key.size(-1): ",
+        key_size_last,
+        " instead.");
     return false;
   }
 
   constexpr int MAX_HEAD_DIM = 576;
   const auto max_size_last = query_size_last.max(value_size_last);
   if (max_size_last > MAX_HEAD_DIM) {
-    if (debug) {
-      TORCH_WARN(
-          "OneDNN attention requires q,k,v to have head dimension less than ",
-          MAX_HEAD_DIM,
-          ". Got ",
-          max_size_last,
-          " instead.");
-    }
+    sdp::report_failure(
+        diagnostics,
+        "OneDNN attention requires q,k,v to have head dimension less than ",
+        MAX_HEAD_DIM,
+        ". Got ",
+        max_size_last,
+        " instead.");
     return false;
   }
   return true;
 }
 
-bool check_no_grad(sdp::sdp_params const& params, bool debug) {
+bool check_head_dim_size_xpu(sdp::sdp_params const& params, bool debug) {
+  if (!debug) {
+    return check_head_dim_size_xpu(
+        params, c10::OptionalRef<sdp::SDPDiagnostics>{});
+  }
+  sdp::SDPDiagnostics diagnostics(true);
+  return check_head_dim_size_xpu(params, diagnostics);
+}
+
+bool check_no_grad(
+    sdp::sdp_params const& params,
+    c10::OptionalRef<sdp::SDPDiagnostics> diagnostics) {
   const bool any_inputs_require_grad = params.query.requires_grad() ||
       params.key.requires_grad() || params.value.requires_grad();
   const bool gradmode_enabled = at::GradMode::is_enabled();
-  if (debug && any_inputs_require_grad && gradmode_enabled) {
-    TORCH_WARN("Backward or grad to be supported.");
+  if (any_inputs_require_grad && gradmode_enabled) {
+    sdp::report_failure(diagnostics, "Backward or grad to be supported.");
   }
   return !any_inputs_require_grad || !gradmode_enabled;
 }
 
-bool can_use_overrideable_attention(sdp::sdp_params const& params, bool debug) {
+bool check_no_grad(sdp::sdp_params const& params, bool debug) {
+  if (!debug) {
+    return check_no_grad(params, c10::OptionalRef<sdp::SDPDiagnostics>{});
+  }
+  sdp::SDPDiagnostics diagnostics(true);
+  return check_no_grad(params, diagnostics);
+}
+
+bool can_use_overrideable_attention(
+    sdp::sdp_params const& params,
+    c10::OptionalRef<sdp::SDPDiagnostics> diagnostics) {
   constexpr auto supported_dtypes = c10::array_of<at::ScalarType>(
       at::kFloat, at::kBFloat16, at::kHalf); // double is not supported
 
-  // Define gate functions that determine if a flash kernel can be run
   constexpr auto constraints = c10::array_of<bool (*)(
-      sdp::sdp_params const&, bool)>(
+      sdp::sdp_params const&, c10::OptionalRef<sdp::SDPDiagnostics>)>(
       sdp::check_nested_tensor,
       sdp::check_for_dropout,
       sdp::check_tensor_shapes,
@@ -67,19 +87,38 @@ bool can_use_overrideable_attention(sdp::sdp_params const& params, bool debug) {
       sdp::check_last_dim_stride_equals_1_dense<false /*ignore_singleton_dim*/>,
       check_head_dim_size_xpu,
       check_no_grad);
-  for (auto& constraint : constraints) {
-    if (!constraint(params, debug)) {
+  for (const auto& constraint : constraints) {
+    if (!constraint(params, diagnostics)) {
       return false;
     }
   }
-  return sdp::check_tensor_dtype(params, supported_dtypes, debug);
+  return sdp::check_tensor_dtype(params, supported_dtypes, diagnostics);
+}
+
+bool can_use_overrideable_attention(sdp::sdp_params const& params, bool debug) {
+  if (!debug) {
+    return can_use_overrideable_attention(
+        params, c10::OptionalRef<sdp::SDPDiagnostics>{});
+  }
+  sdp::SDPDiagnostics diagnostics(true);
+  return can_use_overrideable_attention(params, diagnostics);
+}
+
+bool can_use_cudnn_attention(
+    sdp::sdp_params const& params,
+    c10::OptionalRef<sdp::SDPDiagnostics> diagnostics) {
+  sdp::report_failure(
+      diagnostics, "XPU don't support SDPA cudnn attention backend.");
+  return false;
 }
 
 bool can_use_cudnn_attention(sdp::sdp_params const& params, bool debug) {
-  if (debug) {
-    TORCH_WARN("XPU don't support SDPA cudnn attention backend.");
+  if (!debug) {
+    return can_use_cudnn_attention(
+        params, c10::OptionalRef<sdp::SDPDiagnostics>{});
   }
-  return false;
+  sdp::SDPDiagnostics diagnostics(true);
+  return can_use_cudnn_attention(params, diagnostics);
 }
 
 int64_t minimum_gemm_alignment(sdp::sdp_params const& params) {
@@ -94,27 +133,77 @@ int64_t minimum_gemm_alignment(sdp::sdp_params const& params) {
 
 bool check_head_dim_size_mem_efficient(
     sdp::sdp_params const& params,
-    bool debug) {
+    c10::OptionalRef<sdp::SDPDiagnostics> diagnostics) {
   const auto query_size_last = params.query.sym_size(-1);
   const auto value_size_last = params.value.sym_size(-1);
   const int64_t alignment = minimum_gemm_alignment(params);
   if (!(query_size_last == params.key.sym_size(-1) &&
         query_size_last % alignment == 0 && query_size_last > 0 &&
         value_size_last % alignment == 0 && value_size_last > 0)) {
-    if (debug) {
-      TORCH_WARN(
-          "Mem efficient attention requires last dimension of inputs to be divisible by ",
-          alignment,
-          ". ",
-          "Got Query.size(-1): ",
-          query_size_last,
-          ", Key.size(-1): ",
-          params.key.sym_size(-1),
-          ", Value.size(-1): ",
-          params.value.sym_size(-1),
-          " instead.");
-    }
+    sdp::report_failure(
+        diagnostics,
+        "Mem efficient attention requires last dimension of inputs to be divisible by ",
+        alignment,
+        ". ",
+        "Got Query.size(-1): ",
+        query_size_last,
+        ", Key.size(-1): ",
+        params.key.sym_size(-1),
+        ", Value.size(-1): ",
+        params.value.sym_size(-1),
+        " instead.");
     return false;
+  }
+  return true;
+}
+
+bool check_head_dim_size_mem_efficient(
+    sdp::sdp_params const& params,
+    bool debug) {
+  if (!debug) {
+    return check_head_dim_size_mem_efficient(
+        params, c10::OptionalRef<sdp::SDPDiagnostics>{});
+  }
+  sdp::SDPDiagnostics diagnostics(true);
+  return check_head_dim_size_mem_efficient(params, diagnostics);
+}
+
+bool can_use_mem_efficient_attention(
+    sdp::sdp_params const& params,
+    c10::OptionalRef<sdp::SDPDiagnostics> diagnostics) {
+  constexpr auto general_constraints = c10::array_of<bool (*)(
+      sdp::sdp_params const&, c10::OptionalRef<sdp::SDPDiagnostics>)>(
+      sdp::check_runtime_disabled_mem_efficient,
+      sdp::check_tensor_shapes,
+      check_head_dim_size_mem_efficient);
+  for (const auto& constraint : general_constraints) {
+    if (!constraint(params, diagnostics)) {
+      return false;
+    }
+  }
+  if (has_for_nested_inputs(params)) {
+    constexpr auto nested_constraints = c10::array_of<bool (*)(
+        sdp::sdp_params const&, c10::OptionalRef<sdp::SDPDiagnostics>)>(
+        sdp::check_requires_grad_and_nested,
+        sdp::check_batch_size_nested,
+        sdp::check_for_seq_len_0_nested_tensor);
+    for (const auto& constraint : nested_constraints) {
+      if (!constraint(params, diagnostics)) {
+        return false;
+      }
+    }
+  }
+  if (has_only_dense_inputs(params)) {
+    constexpr auto dense_constraints = c10::array_of<bool (*)(
+        sdp::sdp_params const&, c10::OptionalRef<sdp::SDPDiagnostics>)>(
+        sdp::check_nonzero_sequence_lengths_dense,
+        sdp::check_last_dim_stride_equals_1_dense<false>,
+        sdp::check_batch_size_and_num_heads_dense<false>);
+    for (const auto& constraint : dense_constraints) {
+      if (!constraint(params, diagnostics)) {
+        return false;
+      }
+    }
   }
   return true;
 }
@@ -122,42 +211,12 @@ bool check_head_dim_size_mem_efficient(
 bool can_use_mem_efficient_attention(
     sdp::sdp_params const& params,
     bool debug) {
-  // Define gate functions that determine if a mem efficient can be run
-  constexpr auto general_constraints =
-      c10::array_of<bool (*)(sdp::sdp_params const&, bool)>(
-          sdp::check_runtime_disabled_mem_efficient,
-          sdp::check_tensor_shapes,
-          check_head_dim_size_mem_efficient);
-  for (auto& constraint : general_constraints) {
-    if (!constraint(params, debug)) {
-      return false;
-    }
+  if (!debug) {
+    return can_use_mem_efficient_attention(
+        params, c10::OptionalRef<sdp::SDPDiagnostics>{});
   }
-  if (has_for_nested_inputs(params)) {
-    constexpr auto nested_constraints =
-        c10::array_of<bool (*)(sdp::sdp_params const&, bool)>(
-            sdp::check_requires_grad_and_nested,
-            sdp::check_batch_size_nested,
-            sdp::check_for_seq_len_0_nested_tensor);
-    for (auto& constraint : nested_constraints) {
-      if (!constraint(params, debug)) {
-        return false;
-      }
-    }
-  }
-  if (has_only_dense_inputs(params)) {
-    constexpr auto dense_constraints =
-        c10::array_of<bool (*)(sdp::sdp_params const&, bool)>(
-            sdp::check_nonzero_sequence_lengths_dense,
-            sdp::check_last_dim_stride_equals_1_dense<false>,
-            sdp::check_batch_size_and_num_heads_dense<false>);
-    for (auto& constraint : dense_constraints) {
-      if (!constraint(params, debug)) {
-        return false;
-      }
-    }
-  }
-  return true;
+  sdp::SDPDiagnostics diagnostics(true);
+  return can_use_mem_efficient_attention(params, diagnostics);
 }
 
 bool priority_order_init = false;
@@ -182,23 +241,17 @@ sdp::SDPBackend select_sdp_backend_xpu(sdp::sdp_params const& kernel_params) {
   // 1. Flash Attention
   // 2. Math fallback
   auto& ctx = at::globalContext();
-  // use overridable linked to onednn as overridable implementation
-  if (!ctx.userEnabledMathSDP() && !ctx.userEnabledOverrideableSDP() &&
-      !ctx.userEnabledFlashSDP() && !ctx.userEnabledMemEfficientSDP()) {
-    return sdp::SDPBackend::error;
-  }
 
   // Get ideal kernel ordering
   const auto ordering = priority_order(kernel_params);
 
   // Because TORCHCHECK checks if condition is true we negate debug so that
   // The statements will be printed when debug is true
-  bool print_debug = false;
-  for (auto& backend : ordering) {
+  for (const auto& backend : ordering) {
     switch (backend) {
       case sdp::SDPBackend::overrideable:
         if (ctx.userEnabledOverrideableSDP() &&
-            can_use_overrideable_attention(kernel_params, print_debug)) {
+            can_use_overrideable_attention(kernel_params, false)) {
           return sdp::SDPBackend::overrideable;
         }
         break;
@@ -209,19 +262,19 @@ sdp::SDPBackend select_sdp_backend_xpu(sdp::sdp_params const& kernel_params) {
         break;
       case sdp::SDPBackend::flash_attention:
         if (ctx.userEnabledFlashSDP() &&
-            sdp::can_use_flash_attention(kernel_params, print_debug)) {
+            sdp::can_use_flash_attention(kernel_params, false)) {
           return sdp::SDPBackend::flash_attention;
         }
         break;
       case sdp::SDPBackend::cudnn_attention:
         if (ctx.userEnabledCuDNNSDP() &&
-            can_use_cudnn_attention(kernel_params, print_debug)) {
+            can_use_cudnn_attention(kernel_params, false)) {
           TORCH_CHECK(false, "Invalid backend");
         }
         break;
       case sdp::SDPBackend::efficient_attention:
         if (ctx.userEnabledMemEfficientSDP() &&
-            can_use_mem_efficient_attention(kernel_params, print_debug)) {
+            can_use_mem_efficient_attention(kernel_params, false)) {
           TORCH_WARN_ONCE(
               "SDPA Memory Efficient Attention backend is not supported on XPU, falling back to math backend.");
           return sdp::SDPBackend::math;
@@ -231,22 +284,36 @@ sdp::SDPBackend select_sdp_backend_xpu(sdp::sdp_params const& kernel_params) {
         TORCH_CHECK(false, "Invalid backend");
     }
   }
-  // If we have gotten to this point then two things have happened:
-  // 1. can_use_overridable_attention did not satisfy the constraints to be ran
-  // 2. The user has explicitly disabled the math kernel
-  // We then re-run the kernel checks with debug enabled to print out the
-  // reason why the kernel was not selected
-
-  print_debug = true;
-  TORCH_WARN("Flash attention kernel not used because:");
-  sdp::can_use_flash_attention(kernel_params, print_debug);
-  TORCH_WARN("Overrideable attention kernel not used because:");
-  can_use_overrideable_attention(kernel_params, print_debug);
-  TORCH_WARN("CuDNN attention kernel not used because:");
-  can_use_cudnn_attention(kernel_params, print_debug);
-  TORCH_WARN("Memory Efficient attention kernel not used because:");
-  can_use_mem_efficient_attention(kernel_params, print_debug);
-  TORCH_CHECK(!print_debug, "No available kernel. Aborting execution.")
+  sdp::SDPDiagnostics diagnostics(false);
+  diagnostics.set_current_backend("Flash attention");
+  if (ctx.userEnabledFlashSDP()) {
+    sdp::can_use_flash_attention(kernel_params, diagnostics);
+  } else {
+    sdp::report_failure(
+        diagnostics, "Flash attention has been runtime disabled.");
+  }
+  diagnostics.set_current_backend("OneDNN attention");
+  if (ctx.userEnabledOverrideableSDP()) {
+    can_use_overrideable_attention(kernel_params, diagnostics);
+  } else {
+    sdp::report_failure(
+        diagnostics, "OneDNN attention has been runtime disabled.");
+  }
+  diagnostics.set_current_backend("Math attention");
+  if (!ctx.userEnabledMathSDP()) {
+    sdp::report_failure(
+        diagnostics, "Math attention has been runtime disabled.");
+  }
+  diagnostics.set_current_backend("cuDNN attention");
+  if (ctx.userEnabledCuDNNSDP()) {
+    can_use_cudnn_attention(kernel_params, diagnostics);
+  } else {
+    sdp::report_failure(
+        diagnostics, "cuDNN attention has been runtime disabled.");
+  }
+  diagnostics.set_current_backend("Memory efficient attention");
+  can_use_mem_efficient_attention(kernel_params, diagnostics);
+  diagnostics.raise_error();
   return sdp::SDPBackend::error;
 }
 } // namespace

--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
@@ -51,11 +51,11 @@
 * the SDP parameters. If all filters pass, the backend can be used and use_<backend>
 * returns true. If any filter fails, then use_<backend> returns false.
 *
-* In order to aid in debugging, each filter takes sdp_params and a debug flag.
-* If the debug flag is set, the filter will print a warning message if it fails.
-* The behavior of select_sdp_backend is to return the first backend that
-* succeeds. If no backend is viable then it will run each use_<backend> function
-* with debug=true and return SDPBackend::error.
+* Diagnostics are optional. When the public can_use_<backend>(..., debug=true)
+* APIs are used, the failing filters emit warnings immediately. When
+* select_sdp_backend reaches terminal failure, it re-runs the candidate
+* backends with an SDPDiagnostics context that records rejection reasons in
+* backend priority order and then raises one aggregated error.
 */
 
 namespace sdp {

--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
@@ -144,7 +144,9 @@ int64_t minimum_gemm_alignment(sdp_params const& params) {
 // function for fundamental limitations by the GPU kernel
 // caller_is_meff is added to make the TORCH_WARN message showing the correct result
 template<bool caller_is_meff = false>
-bool check_head_dim_size_flash(sdp_params const& params, bool debug) {
+bool check_head_dim_size_flash(
+    sdp_params const& params,
+    c10::OptionalRef<SDPDiagnostics> diagnostics = {}) {
 #if USE_ROCM_ATTENTION
   if (at::cuda::device_count() == 0) {
     return false;
@@ -176,18 +178,17 @@ bool check_head_dim_size_flash(sdp_params const& params, bool debug) {
   bool same_head_dim_size =
       query_size_last == key_size_last && query_size_last == value_size_last;
   if (!(same_head_dim_size && (query_size_last <= max_size))) {
-    if (debug) {
-      TORCH_WARN(
-          caller_is_meff ? "Efficient attention on ROCM" : "Flash attention",
-          " requires q,k,v to have the same last dimension and to be less than or equal to 256.",
-          " Got Query.size(-1): ",
-          query_size_last,
-          ", Key.size(-1): ",
-          key_size_last,
-          ", Value.size(-1): ",
-          value_size_last,
-          " instead.");
-    }
+    report_failure(
+        diagnostics,
+        caller_is_meff ? "Efficient attention on ROCM" : "Flash attention",
+        " requires q,k,v to have the same last dimension and to be less than or equal to 256.",
+        " Got Query.size(-1): ",
+        query_size_last,
+        ", Key.size(-1): ",
+        key_size_last,
+        ", Value.size(-1): ",
+        value_size_last,
+        " instead.");
     return false;
   }
   if constexpr(caller_is_meff) {
@@ -196,19 +197,18 @@ bool check_head_dim_size_flash(sdp_params const& params, bool debug) {
     const int64_t alignment = is_half ? 8 : 4;
     if (!(query_size_last % alignment == 0 && query_size_last > 0 &&
           value_size_last % alignment == 0 && value_size_last > 0)) {
-      if (debug) {
-        TORCH_WARN(
-            "Mem efficient attention requires last dimension of inputs to be divisible by ",
-            alignment,
-            ". ",
-            "Got Query.size(-1): ",
-            query_size_last,
-            ", Key.size(-1): ",
-            params.key.sym_size(-1),
-            ", Value.size(-1): ",
-            params.value.sym_size(-1),
-            " instead.");
-      }
+      report_failure(
+          diagnostics,
+          "Mem efficient attention requires last dimension of inputs to be divisible by ",
+          alignment,
+          ". ",
+          "Got Query.size(-1): ",
+          query_size_last,
+          ", Key.size(-1): ",
+          key_size_last,
+          ", Value.size(-1): ",
+          value_size_last,
+          " instead.");
       return false;
     }
   }
@@ -217,7 +217,9 @@ bool check_head_dim_size_flash(sdp_params const& params, bool debug) {
 
 // See check_head_dim_size_flash above for the purpose of caller_is_meff
 template<bool caller_is_meff = false>
-bool check_head_dim_size_flash_nested(sdp_params const& params, bool debug) {
+bool check_head_dim_size_flash_nested(
+    sdp_params const& params,
+    c10::OptionalRef<SDPDiagnostics> diagnostics = {}) {
   const auto max_size = c10::SymInt(256);
   const auto query_size_last = params.query.sym_size(-1);
   const auto key_size_last = params.key.sym_size(-1);
@@ -226,44 +228,45 @@ bool check_head_dim_size_flash_nested(sdp_params const& params, bool debug) {
       query_size_last == key_size_last && query_size_last == value_size_last;
   if (!(same_head_dim_size && (query_size_last % 8 == 0) &&
         (query_size_last <= max_size))) {
-    if (debug) {
-      TORCH_WARN(
-          "For NestedTensor inputs,",
-          caller_is_meff ? " Efficient attention on ROCM " : " Flash attention",
-          " requires q,k,v to have the same last dimension and to be a multiple of 8 and less than or equal to 256.",
-          " Got Query.size(-1): ",
-          query_size_last,
-          ", Key.size(-1): ",
-          params.key.sym_size(-1),
-          ", Value.size(-1): ",
-          params.value.sym_size(-1),
-          " instead.");
-    }
+    report_failure(
+        diagnostics,
+        "For NestedTensor inputs,",
+        caller_is_meff ? " Efficient attention on ROCM " : " Flash attention",
+        " requires q,k,v to have the same last dimension and to be a multiple of 8 and less than or equal to 256.",
+        " Got Query.size(-1): ",
+        query_size_last,
+        ", Key.size(-1): ",
+        key_size_last,
+        ", Value.size(-1): ",
+        value_size_last,
+        " instead.");
     return false;
   }
   return true;
 }
 
-bool check_head_dim_size_mem_efficient(sdp_params const& params, bool debug) {
+bool check_head_dim_size_mem_efficient(
+    sdp_params const& params,
+    c10::OptionalRef<SDPDiagnostics> diagnostics = {}) {
   const auto query_size_last = params.query.sym_size(-1);
+  const auto key_size_last = params.key.sym_size(-1);
   const auto value_size_last = params.value.sym_size(-1);
   const int64_t alignment = minimum_gemm_alignment(params);
-  if (!(query_size_last == params.key.sym_size(-1) &&
+  if (!(query_size_last == key_size_last &&
         query_size_last % alignment == 0 && query_size_last > 0 &&
         value_size_last % alignment == 0 && value_size_last > 0)) {
-    if (debug) {
-      TORCH_WARN(
-          "Mem efficient attention requires last dimension of inputs to be divisible by ",
-          alignment,
-          ". ",
-          "Got Query.size(-1): ",
-          query_size_last,
-          ", Key.size(-1): ",
-          params.key.sym_size(-1),
-          ", Value.size(-1): ",
-          params.value.sym_size(-1),
-          " instead.");
-    }
+    report_failure(
+        diagnostics,
+        "Mem efficient attention requires last dimension of inputs to be divisible by ",
+        alignment,
+        ". ",
+        "Got Query.size(-1): ",
+        query_size_last,
+        ", Key.size(-1): ",
+        key_size_last,
+        ", Value.size(-1): ",
+        value_size_last,
+        " instead.");
     return false;
   }
   return true;
@@ -295,7 +298,9 @@ bool check_sm_version(cudaDeviceProp * dprops) {
   return is_gte_lower_bound && is_lte_upper_bound;
 }
 
-bool check_flash_attention_hardware_support(sdp_params const& params, bool debug) {
+bool check_flash_attention_hardware_support(
+    sdp_params const& params,
+    c10::OptionalRef<SDPDiagnostics> diagnostics = {}) {
   // Check that the gpu is capable of running flash attention
   using sm80 = SMVersion<8, 0>;
   using sm121 = SMVersion<12, 1>;
@@ -309,17 +314,19 @@ bool check_flash_attention_hardware_support(sdp_params const& params, bool debug
     auto stream = at::cuda::getCurrentCUDAStream().stream();
     if (hipSuccess != aotriton::v2::flash::check_gpu(stream)) {
         auto dprops = at::cuda::getCurrentDeviceProperties();
-        if (debug) {
-            TORCH_WARN(
-                    "Flash attention was not compiled for current AMD GPU architecture. Attempting to run on architecture ", dprops->gcnArchName);
-        }
+        report_failure(
+            diagnostics,
+            "Flash attention was not compiled for current AMD GPU architecture. Attempting to run on architecture ",
+            dprops->gcnArchName);
         return false;
     }
 #if AOTRITON_VERSION_MINOR >= 9
     if (aotriton::isArchExperimentallySupported(stream)) {
       static const bool enable_experimental = c10::utils::check_env("TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL") == true;
       if (!enable_experimental) {
-        TORCH_WARN_ONCE("Flash Efficient attention on Current AMD GPU is still experimental."
+        report_failure_once(
+            diagnostics,
+            "Flash Efficient attention on Current AMD GPU is still experimental."
             " Enable it with TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL=1.");
         return false;
       }
@@ -331,28 +338,27 @@ bool check_flash_attention_hardware_support(sdp_params const& params, bool debug
 #endif
 #else
   if (!at::cuda::is_available()) {
-    if (debug) {
-      TORCH_WARN("flash attention requires a CUDA device, which is not available.");
-    }
+    report_failure(diagnostics, "flash attention requires a CUDA device, which is not available.");
     return false;
   }
   auto dprops = at::cuda::getCurrentDeviceProperties();
   if (!check_sm_version<sm80, sm121>(dprops)) {
-    if (debug) {
-      TORCH_WARN(
-          "Flash attention only supports gpu architectures in the range [sm80, sm121]. Attempting to run on a sm ",
-          dprops->major,
-          ".",
-          dprops->minor,
-          " gpu.");
-    }
+    report_failure(
+        diagnostics,
+        "Flash attention only supports gpu architectures in the range [sm80, sm121]. Attempting to run on a sm ",
+        dprops->major,
+        ".",
+        dprops->minor,
+        " gpu.");
     return false;
   }
 #endif
   return true;
 }
 
-bool check_mem_efficient_hardware_support(sdp_params const& params, bool debug) {
+bool check_mem_efficient_hardware_support(
+    sdp_params const& params,
+    c10::OptionalRef<SDPDiagnostics> diagnostics = {}) {
   // Mem Efficient attention supports hardware in the range [sm_50, sm_90]
   using sm50 = SMVersion<5, 0>;
   using sm121 = SMVersion<12, 1>;
@@ -369,17 +375,19 @@ bool check_mem_efficient_hardware_support(sdp_params const& params, bool debug) 
     auto stream = at::cuda::getCurrentCUDAStream().stream();
     if (hipSuccess != aotriton::v2::flash::check_gpu(stream)) {
         auto dprops = at::cuda::getCurrentDeviceProperties();
-        if (debug) {
-            TORCH_WARN(
-                    "Mem Efficient attention was not compiled for current AMD GPU architecture. Attempting to run on architecture ", dprops->gcnArchName);
-        }
+        report_failure(
+            diagnostics,
+            "Mem Efficient attention was not compiled for current AMD GPU architecture. Attempting to run on architecture ",
+            dprops->gcnArchName);
         return false;
     }
 #if AOTRITON_VERSION_MINOR >= 9
     if (aotriton::isArchExperimentallySupported(stream)) {
       static const bool enable_experimental = c10::utils::check_env("TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL") == true;
       if (!enable_experimental) {
-        TORCH_WARN_ONCE("Mem Efficient attention on Current AMD GPU is still experimental."
+        report_failure_once(
+            diagnostics,
+            "Mem Efficient attention on Current AMD GPU is still experimental."
             " Enable it with TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL=1.");
         return false;
       }
@@ -391,21 +399,18 @@ bool check_mem_efficient_hardware_support(sdp_params const& params, bool debug) 
 #endif
 #else
   if (!at::cuda::is_available()) {
-    if (debug) {
-      TORCH_WARN("Mem Efficient attention requires a CUDA device, which is not available.");
-    }
+    report_failure(diagnostics, "Mem Efficient attention requires a CUDA device, which is not available.");
     return false;
   }
   auto dprops = at::cuda::getCurrentDeviceProperties();
   if (!check_sm_version<sm50, sm121>(dprops)) {
-    if (debug) {
-      TORCH_WARN(
-          "Mem Efficient Attention only supports gpu architectures in the range [sm50, sm121]. Attempting to run on a sm ",
-          dprops->major,
-          ".",
-          dprops->minor,
-          " gpu.");
-    }
+    report_failure(
+        diagnostics,
+        "Mem Efficient Attention only supports gpu architectures in the range [sm50, sm121]. Attempting to run on a sm ",
+        dprops->major,
+        ".",
+        dprops->minor,
+        " gpu.");
     return false;
   }
 #endif
@@ -414,7 +419,7 @@ bool check_mem_efficient_hardware_support(sdp_params const& params, bool debug) 
 
 bool check_requires_grad_and_head_dim_gt192_constraints_on_sm86_89_or_120(
     sdp_params const& params,
-    bool debug) {
+    c10::OptionalRef<SDPDiagnostics> diagnostics = {}) {
   // Flash Attention will raise an error in the backward pass if the head_dim
   // size is greater than 192 And the device is between in the range [sm86, sm89]
   using sm86 = SMVersion<8, 6>;
@@ -432,85 +437,94 @@ bool check_requires_grad_and_head_dim_gt192_constraints_on_sm86_89_or_120(
   // head_dim size > 224 and is_dropout is not supported on sm86 and sm89
   bool cond2 = params.query.sym_size(-1) > 224 && is_dropout;
   if (input_requires_grad(params) && (is_sm86_or_sm89 || is_sm120_or_sm121) && (cond1 || cond2)) {
-    if (debug) {
-      TORCH_WARN(
-          "Flash attention currently doesn't support training with head_dim ∈ (192, 224] or "
-          "(head_dim ∈ (224, 256] and dropout > 0.0) on gpu architectures in the range[sm86, sm89].",
-          "Attempting to run with dropout set to: ", params.dropout,
-          "and head_dim: ",
-          params.query.sym_size(-1), " on a sm ", dprops->major, ".",
-          dprops->minor, " gpu.");
-    }
+    report_failure(
+        diagnostics,
+        "Flash attention currently doesn't support training with head_dim ∈ (192, 224] or "
+        "(head_dim ∈ (224, 256] and dropout > 0.0) on gpu architectures in the range[sm86, sm89].",
+        "Attempting to run with dropout set to: ",
+        params.dropout,
+        "and head_dim: ",
+        params.query.sym_size(-1),
+        " on a sm ",
+        dprops->major,
+        ".",
+        dprops->minor,
+        " gpu.");
     return false;
   }
   return true;
 }
 
-bool check_flash_causal_non_square_seqlens(sdp_params const& params, bool debug) {
+bool check_flash_causal_non_square_seqlens(
+    sdp_params const& params,
+    c10::OptionalRef<SDPDiagnostics> diagnostics = {}) {
   // FlashAttention 2 updated the default mask meaning for causal in this PR:
   // 9e5e8bc91e it is now aligned to lower_right which would be a BC break
   // for non-square masks. We will not support non-square masks for causal w/ FAV2
   if (params.is_causal &&
       !params.query.is_nested() && !params.key.is_nested() &&
       params.query.sym_size(-2) != params.key.sym_size(-2)) {
-    if (debug) {
-      TORCH_WARN(
-          "Flash attention does not support the is_causal flag when seqlen_q != seqlen_k. ",
-          "Got seqlen_q: ", params.query.sym_size(-2), " seqlen_k: ",
-          params.key.sym_size(-2), ". If you would like to use causal attention with non-square masks, please see CausalAttnMask.");
-    }
+    report_failure(
+        diagnostics,
+        "Flash attention does not support the is_causal flag when seqlen_q != seqlen_k. ",
+        "Got seqlen_q: ",
+        params.query.sym_size(-2),
+        " seqlen_k: ",
+        params.key.sym_size(-2),
+        ". If you would like to use causal attention with non-square masks, please see CausalAttnMask.");
     return false;
   }
   return true;
 }
 
-bool check_all_tensors_on_device(sdp_params const& params, bool debug) {
+bool check_all_tensors_on_device(
+    sdp_params const& params,
+    c10::OptionalRef<SDPDiagnostics> diagnostics = {}) {
   // Check that all tensors are on the GPU device
   // This should be handled by the stub dispatch, but we call can_use_*_attention
   // directly from python we need to ensure that the tensors are on cuda
   if (params.query.device().type() != at::DeviceType::CUDA) {
-    if (debug) {
-      TORCH_WARN(
-          "All tensors need to be on cuda device. Got query on device: ",
-          params.query.device(),
-          ", key on device: ",
-          params.key.device(),
-          ", value on device: ",
-          params.value.device());
-    }
+    report_failure(
+        diagnostics,
+        "All tensors need to be on cuda device. Got query on device: ",
+        params.query.device(),
+        ", key on device: ",
+        params.key.device(),
+        ", value on device: ",
+        params.value.device());
     return false;
   }
   return true;
 }
 
-bool check_cudnn_dropout(sdp_params const& params, bool debug) {
+bool check_cudnn_dropout(
+    sdp_params const& params,
+    c10::OptionalRef<SDPDiagnostics> diagnostics = {}) {
   if (params.dropout * 16.0 != std::floor(params.dropout * 16.0)) {
-    if (debug) {
-      TORCH_WARN("cuDNN dropout probability resolution is limited to 1/16."
-                 "Use a dropout probability that is a multiple of 1/16 to "
-                 "select the cuDNN backend");
-    }
+    report_failure(
+        diagnostics,
+        "cuDNN dropout probability resolution is limited to 1/16."
+        "Use a dropout probability that is a multiple of 1/16 to "
+        "select the cuDNN backend");
     return false;
   }
   return true;
 }
 
-bool check_cudnn_tensor_shapes(sdp_params const& params, bool debug) {
+bool check_cudnn_tensor_shapes(
+    sdp_params const& params,
+    c10::OptionalRef<SDPDiagnostics> diagnostics = {}) {
   const auto s_q = params.query.sym_size(2);
   const auto s_k = params.key.sym_size(2);
   const auto d_qk = params.query.sym_size(3);
   const auto d_v = params.value.sym_size(3);
   long cudnn_version = at::detail::getCUDAHooks().versionRuntimeCuDNN();
   if (cudnn_version < 8903) {
-    if (debug) {
-      TORCH_WARN("SDPA fprop requires cudnn 8.9.3 or higher");
-    }
+    report_failure(diagnostics, "SDPA fprop requires cudnn 8.9.3 or higher");
     return false;
   }
   if (cudnn_version < 8906 && params.dropout != 0.0) {
-    if (debug) {
-      TORCH_WARN("Dropout reference is only supported on 8.9.6 onwards.");
-    }
+    report_failure(diagnostics, "Dropout reference is only supported on 8.9.6 onwards.");
     return false;
   }
   auto head_dim_limit = 128;
@@ -530,54 +544,43 @@ bool check_cudnn_tensor_shapes(sdp_params const& params, bool debug) {
     }
   }
   if (d_qk > head_dim_limit || d_v > head_dim_limit) {
-    if (debug) {
-      TORCH_WARN("head_dim should be no more than ", head_dim_limit);
-    }
+    report_failure(diagnostics, "head_dim should be no more than ", head_dim_limit);
     return false;
   }
   if (d_qk % 8 != 0 || d_v % 8 != 0) {
-    if (debug) {
-      TORCH_WARN("head_dim should be a multiple of 8");
-    }
+    report_failure(diagnostics, "head_dim should be a multiple of 8");
     return false;
   }
   if (cudnn_version < 8906 && s_k % 64 != 0 ) {
-    if (debug) {
-      TORCH_WARN("not-multiple-of-64 seq_kv is not supported below 8.9.6");
-    }
+    report_failure(diagnostics, "not-multiple-of-64 seq_kv is not supported below 8.9.6");
     return false;
   }
   if (cudnn_version < 90000) {
     if (s_q < 64) {
-      if (debug) {
-        TORCH_WARN("s_q less than 64 is not supported before cudnn 9.0.0");
-      }
+      report_failure(diagnostics, "s_q less than 64 is not supported before cudnn 9.0.0");
       return false;
     }
     if (params.dropout != 0.0 && (s_q % 64 != 0 || s_k % 64 != 0)) {
-      if (debug) {
-        TORCH_WARN(
-            "s_q not a multiple of 64 with padding/dropout is not supported with cudnn version 9.0.0");
-      }
+      report_failure(
+          diagnostics,
+          "s_q not a multiple of 64 with padding/dropout is not supported with cudnn version 9.0.0");
       return false;
     }
   }
   if (s_k == 1) {
-    if (debug) {
-      TORCH_WARN_ONCE("cudnn SDPA does not support key/value sequence length 1.");
-    }
+    report_failure_once(diagnostics, "cudnn SDPA does not support key/value sequence length 1.");
     return false;
   }
   if (s_q == 1 && params.dropout != 0.0) {
-    if (debug) {
-      TORCH_WARN_ONCE("cudnn SDPA does not support query sequence length 1 with dropout.");
-    }
+    report_failure_once(diagnostics, "cudnn SDPA does not support query sequence length 1 with dropout.");
     return false;
   }
   return true;
 }
 
-bool check_cudnn_layout(sdp_params const& params, bool debug) {
+bool check_cudnn_layout(
+    sdp_params const& params,
+    c10::OptionalRef<SDPDiagnostics> diagnostics = {}) {
   const int64_t h = params.query.size(1);
   const int64_t s_q = params.query.size(2);
   const int64_t d = params.query.size(3);
@@ -615,27 +618,27 @@ bool check_cudnn_layout(sdp_params const& params, bool debug) {
   const bool layout_ok = query_layout_ok && key_layout_ok && value_layout_ok;
 
   if (!packed_value_layout_ok && !layout_ok) {
-    if (debug) {
+    if (diagnostics.has_value()) {
       if (!packed_layout_ok) {
         if (!packed_query_layout_ok) {
-          TORCH_WARN("Query tensor was not in cuDNN-supported packed QKV layout", params.query.strides());
+          report_failure(diagnostics, "Query tensor was not in cuDNN-supported packed QKV layout", params.query.strides());
         }
         if (!packed_key_layout_ok) {
-          TORCH_WARN("Key tensor was not in cuDNN-supported packed QKV layout", params.key.strides());
+          report_failure(diagnostics, "Key tensor was not in cuDNN-supported packed QKV layout", params.key.strides());
         }
         if (!packed_value_layout_ok) {
-          TORCH_WARN("Value tensor was not in cuDNN-supported packed QKV layout", params.value.strides());
+          report_failure(diagnostics, "Value tensor was not in cuDNN-supported packed QKV layout", params.value.strides());
         }
       }
       if (!layout_ok) {
         if (!query_layout_ok) {
-          TORCH_WARN("Query tensor was not in cuDNN-supported unpacked QKV layout", params.query.strides());
+          report_failure(diagnostics, "Query tensor was not in cuDNN-supported unpacked QKV layout", params.query.strides());
         }
         if (!key_layout_ok) {
-          TORCH_WARN("Key tensor was not in cuDNN-supported unpacked QKV layout", params.key.strides());
+          report_failure(diagnostics, "Key tensor was not in cuDNN-supported unpacked QKV layout", params.key.strides());
         }
         if (!value_layout_ok) {
-          TORCH_WARN("Value tensor was not in cuDNN-supported unpacked QKV layout", params.value.strides());
+          report_failure(diagnostics, "Value tensor was not in cuDNN-supported unpacked QKV layout", params.value.strides());
         }
       }
     }
@@ -644,91 +647,90 @@ bool check_cudnn_layout(sdp_params const& params, bool debug) {
   return true;
 }
 
-bool check_cudnn_hardware_support(sdp_params const& params, bool debug) {
+bool check_cudnn_hardware_support(
+    sdp_params const& params,
+    c10::OptionalRef<SDPDiagnostics> diagnostics = {}) {
   using sm80 = SMVersion<8, 0>;
   using sm121 = SMVersion<12, 1>;
   if (!at::cuda::is_available()) {
-    if (debug) {
-      TORCH_WARN("cuDNN SDPA requires a CUDA device, which is not available.");
-    }
+    report_failure(diagnostics, "cuDNN SDPA requires a CUDA device, which is not available.");
     return false;
   }
   auto dprops = at::cuda::getCurrentDeviceProperties();
   if (!check_sm_version<sm80, sm121>(dprops)) {
-    if (debug) {
-      TORCH_WARN(
-          "cuDNN MHA only supports gpu architectures in the range [sm80, sm121]. Attempting to run on a sm ",
-          dprops->major,
-          ".",
-          dprops->minor,
-          " gpu.");
-    }
+    report_failure(
+        diagnostics,
+        "cuDNN MHA only supports gpu architectures in the range [sm80, sm121]. Attempting to run on a sm ",
+        dprops->major,
+        ".",
+        dprops->minor,
+        " gpu.");
     return false;
   }
   return true;
 }
 
-bool check_for_nested_inputs(sdp_params const& params, bool debug) {
+bool check_for_nested_inputs(
+    sdp_params const& params,
+    c10::OptionalRef<SDPDiagnostics> diagnostics = {}) {
   static const bool enable_cudnn_nested = c10::utils::check_env("TORCH_CUDNN_SDPA_NESTED_TENSOR_ENABLED") == true;
   if (has_for_nested_inputs(params) && !enable_cudnn_nested) {
-    if (debug) {
-      TORCH_WARN("Experimental cuDNN SDPA nested tensor support is not enabled.");
-    }
+    report_failure(diagnostics, "Experimental cuDNN SDPA nested tensor support is not enabled.");
     return false;
   }
   const auto dprop = at::cuda::getCurrentDeviceProperties();
   // Check that the input is nested
   if (!(dprop->major == 9 || dprop->major == 10) && has_for_nested_inputs(params)) {
-    if (debug) {
-      TORCH_WARN("cuDNN SDPA supports nested tensors on SM 9.0, SM 10.0.");
-    }
+    report_failure(diagnostics, "cuDNN SDPA supports nested tensors on SM 9.0, SM 10.0.");
     return false;
   }
   return true;
 }
 
-bool check_dtypes_low_precision(sdp_params const& params, bool debug) {
+bool check_dtypes_low_precision(
+    sdp_params const& params,
+    c10::OptionalRef<SDPDiagnostics> diagnostics = {}) {
   auto dprop = at::cuda::getCurrentDeviceProperties();
   if (dprop->major >= 8) {
     constexpr auto sm80_dtypes =
         c10::array_of<at::ScalarType>(at::kHalf, at::kBFloat16);
-    return check_tensor_dtype(params, sm80_dtypes, debug);
-  } else {
-    constexpr auto default_dtypes = c10::array_of<at::ScalarType>(at::kHalf);
-    return check_tensor_dtype(params, default_dtypes, debug);
+    return check_tensor_dtype(params, sm80_dtypes, diagnostics);
   }
+  constexpr auto default_dtypes = c10::array_of<at::ScalarType>(at::kHalf);
+  return check_tensor_dtype(params, default_dtypes, diagnostics);
 }
 
-bool check_dtypes_flash_attention(sdp_params const& params, bool debug) {
+bool check_dtypes_flash_attention(
+    sdp_params const& params,
+    c10::OptionalRef<SDPDiagnostics> diagnostics = {}) {
   auto dprop = at::cuda::getCurrentDeviceProperties();
   if (dprop->major >= 9 and at::globalContext().userEnabledFA3SDP()) {
     constexpr auto fa3_dtypes =
         c10::array_of<at::ScalarType>(at::kFloat8_e4m3fn, at::kHalf, at::kBFloat16);
-    return check_tensor_dtype(params, fa3_dtypes, debug);
-  } else {
-    return check_dtypes_low_precision(params, debug);
+    return check_tensor_dtype(params, fa3_dtypes, diagnostics);
   }
+  return check_dtypes_low_precision(params, diagnostics);
 }
 
-bool check_runtime_disabled_cudnn(sdp_params const& params, bool debug) {
+bool check_runtime_disabled_cudnn(
+    sdp_params const& params,
+    c10::OptionalRef<SDPDiagnostics> diagnostics = {}) {
   // We check the global context to see if user has explicitly turned of cudnn
   // sdp kernels
   if (!at::globalContext().userEnabledCuDNNSDP()) {
-    if (debug) {
-      TORCH_WARN("cuDNN attention has been runtime disabled.");
-    }
+    report_failure(diagnostics, "cuDNN attention has been runtime disabled.");
     return false;
   }
   return true;
 }
 
-bool check_cudnn_deterministic(const sdp_params& params, bool debug) {
+bool check_cudnn_deterministic(
+    const sdp_params& params,
+    c10::OptionalRef<SDPDiagnostics> diagnostics = {}) {
   auto& ctx = at::globalContext();
   if (ctx.deterministicAlgorithms()) {
     if (!ctx.deterministicAlgorithmsWarnOnly()) {
-      if (debug) {
-        TORCH_WARN("cuDNN SDPA is not deterministic.");
-      }
+      report_failure(diagnostics, "cuDNN SDPA is not deterministic.");
       return false;
     }
   }
@@ -737,32 +739,34 @@ bool check_cudnn_deterministic(const sdp_params& params, bool debug) {
 
 } // namespace
 
-bool can_use_cudnn_attention(const sdp_params& params, bool debug) {
+bool can_use_cudnn_attention(
+    const sdp_params& params,
+    c10::OptionalRef<SDPDiagnostics> diagnostics) {
 #if defined(USE_ROCM) || !AT_CUDNN_ENABLED() || !defined(CUDNN_VERSION)
-  if (debug) {
-    TORCH_WARN("Torch was not compiled with cuDNN attention.");
-  }
+  report_failure(diagnostics, "Torch was not compiled with cuDNN attention.");
   return false;
 #endif
 #if defined(CUDNN_VERSION) && CUDNN_VERSION < 90000
-  if (debug) {
-    TORCH_WARN(CUDNN_VERSION, " cuDNN version too old to use cuDNN Attention (< v9.0.0)");
-  }
+  report_failure(
+      diagnostics,
+      CUDNN_VERSION,
+      " cuDNN version too old to use cuDNN Attention (< v9.0.0)");
   return false;
 #endif
 #if defined(CUDNN_VERSION)
   static auto cudnn_version = at::detail::getCUDAHooks().versionRuntimeCuDNN();
   if (params.dropout > 0.0 && cudnn_version > 91100 && cudnn_version < 91400) {
-    if (debug) {
-      TORCH_WARN(CUDNN_VERSION, " cuDNN version does not support droppout in SDPA (9.11 - 9.13).");
-    }
+    report_failure(
+        diagnostics,
+        CUDNN_VERSION,
+        " cuDNN version does not support droppout in SDPA (9.11 - 9.13).");
     return false;
   }
 #endif
   // Define gate functions that determine if a flash kernel can be ran
   // Replace with std::to_array when we migrate to c++20
   constexpr auto general_constraints =
-      c10::array_of<bool (*)(sdp_params const&, bool)>(
+      c10::array_of<bool (*)(sdp_params const&, c10::OptionalRef<SDPDiagnostics>)>(
           check_runtime_disabled_cudnn,
           check_for_nested_inputs,
           check_all_tensors_on_device,
@@ -773,13 +777,13 @@ bool can_use_cudnn_attention(const sdp_params& params, bool debug) {
           check_cudnn_hardware_support,
           check_cudnn_dropout
           );
-  for (auto& constraint : general_constraints) {
-    if (!constraint(params, debug)) {
+  for (const auto& constraint : general_constraints) {
+    if (!constraint(params, diagnostics)) {
       return false;
     }
   }
   constexpr auto dense_constraints =
-      c10::array_of<bool (*)(sdp_params const&, bool)>(
+      c10::array_of<bool (*)(sdp_params const&, c10::OptionalRef<SDPDiagnostics>)>(
       check_nonzero_sequence_lengths_dense,
       check_last_dim_stride_equals_1_dense<true /*ignore_singleton_dim=*/>,
       check_batch_size_and_num_heads_dense<true /*enable_gqa*/, false /*requires_same_num_heads*/>,
@@ -787,13 +791,21 @@ bool can_use_cudnn_attention(const sdp_params& params, bool debug) {
   );
 
   if (has_only_dense_inputs(params)) {
-    for (auto& constraint : dense_constraints) {
-      if (!constraint(params, debug)) {
+    for (const auto& constraint : dense_constraints) {
+      if (!constraint(params, diagnostics)) {
         return false;
       }
     }
   }
   return true;
+}
+
+bool can_use_cudnn_attention(const sdp_params& params, bool debug) {
+  if (!debug) {
+    return can_use_cudnn_attention(params, c10::OptionalRef<SDPDiagnostics>{});
+  }
+  SDPDiagnostics diagnostics(true);
+  return can_use_cudnn_attention(params, diagnostics);
 }
 
 bool is_flash_attention_available() {
@@ -804,16 +816,17 @@ bool is_flash_attention_available() {
 #endif
 }
 
-bool can_use_flash_attention(sdp_params const& params, bool debug) {
+bool can_use_flash_attention(
+    sdp_params const& params,
+    c10::OptionalRef<SDPDiagnostics> diagnostics) {
 #ifndef USE_FLASH_ATTENTION
-  if (debug) {
-    TORCH_WARN("Torch was not compiled with flash attention.");
-  }
+  report_failure(diagnostics, "Torch was not compiled with flash attention.");
   return false;
 #else // defined(USE_FLASH_ATTENTION)
   // Define gate functions that determine if a flash kernel can be ran
   // Replace with std::to_array when we migrate to c++20
-  constexpr auto general_constraints = c10::array_of<bool (*)(sdp_params const&, bool)>(
+  constexpr auto general_constraints =
+      c10::array_of<bool (*)(sdp_params const&, c10::OptionalRef<SDPDiagnostics>)>(
       check_runtime_disabled_flash,
       check_all_tensors_on_device,
       check_tensor_shapes,
@@ -823,31 +836,33 @@ bool can_use_flash_attention(sdp_params const& params, bool debug) {
       check_requires_grad_and_head_dim_gt192_constraints_on_sm86_89_or_120,
       check_flash_causal_non_square_seqlens,
       check_dtypes_flash_attention);
-  for (auto& constraint : general_constraints) {
-    if (!constraint(params, debug)) {
+  for (const auto& constraint : general_constraints) {
+    if (!constraint(params, diagnostics)) {
       return false;
     }
   }
 
   if (has_for_nested_inputs(params)) {
-    constexpr auto nested_constraints = c10::array_of<bool (*)(sdp_params const&, bool)>(
+    constexpr auto nested_constraints =
+        c10::array_of<bool (*)(sdp_params const&, c10::OptionalRef<SDPDiagnostics>)>(
         check_batch_size_nested,
         check_head_dim_size_flash_nested<false /*caller_is_meff*/>,
         check_for_seq_len_0_nested_tensor);
-    for (auto& constraint : nested_constraints) {
-      if (!constraint(params, debug)) {
+    for (const auto& constraint : nested_constraints) {
+      if (!constraint(params, diagnostics)) {
         return false;
       }
     }
   }
   constexpr bool backend_supports_grouped_query_attention = true;
   if (has_only_dense_inputs(params)) {
-    constexpr auto dense_constraints = c10::array_of<bool (*)(sdp_params const&, bool)>(
+    constexpr auto dense_constraints =
+        c10::array_of<bool (*)(sdp_params const&, c10::OptionalRef<SDPDiagnostics>)>(
         check_batch_size_and_num_heads_dense<backend_supports_grouped_query_attention>,
         check_nonzero_sequence_lengths_dense,
         check_last_dim_stride_equals_1_dense<true /*ignore_singleton_dim=*/>);
-    for (auto& constraint : dense_constraints) {
-      if (!constraint(params, debug)) {
+    for (const auto& constraint : dense_constraints) {
+      if (!constraint(params, diagnostics)) {
         return false;
       }
     }
@@ -856,9 +871,19 @@ bool can_use_flash_attention(sdp_params const& params, bool debug) {
 #endif // defined(USE_FLASH_ATTENTION)
 }
 
-bool can_use_mem_efficient_attention(sdp_params const& params, bool debug) {
+bool can_use_flash_attention(sdp_params const& params, bool debug) {
+  if (!debug) {
+    return can_use_flash_attention(params, c10::OptionalRef<SDPDiagnostics>{});
+  }
+  SDPDiagnostics diagnostics(true);
+  return can_use_flash_attention(params, diagnostics);
+}
+
+bool can_use_mem_efficient_attention(
+    sdp_params const& params,
+    c10::OptionalRef<SDPDiagnostics> diagnostics) {
 #ifndef USE_MEM_EFF_ATTENTION
-  TORCH_WARN_ONCE(!debug, "Torch was not compiled with memory efficient attention.");
+  report_failure_once(diagnostics, "Torch was not compiled with memory efficient attention.");
   return false;
 #endif
   // Constraints specific to mem efficient attention
@@ -875,7 +900,8 @@ bool can_use_mem_efficient_attention(sdp_params const& params, bool debug) {
 #endif
 
   //  Define gate functions that determine if a mem efficient kernel can be ran
-  constexpr auto general_constraints = c10::array_of<bool (*)(sdp_params const&, bool)>(
+  constexpr auto general_constraints =
+      c10::array_of<bool (*)(sdp_params const&, c10::OptionalRef<SDPDiagnostics>)>(
       check_runtime_disabled_mem_efficient,
       check_all_tensors_on_device,
       check_mem_efficient_hardware_support,
@@ -886,14 +912,15 @@ bool can_use_mem_efficient_attention(sdp_params const& params, bool debug) {
       check_head_dim_size_mem_efficient
 #endif
   );
-  for (auto& constraint : general_constraints) {
-    if (!constraint(params, debug)) {
+  for (const auto& constraint : general_constraints) {
+    if (!constraint(params, diagnostics)) {
       return false;
     }
   }
 
   if (has_for_nested_inputs(params)) {
-    constexpr auto nested_constraints = c10::array_of<bool (*)(sdp_params const&, bool)>(
+    constexpr auto nested_constraints =
+        c10::array_of<bool (*)(sdp_params const&, c10::OptionalRef<SDPDiagnostics>)>(
 #ifndef USE_ROCM  // ME and FA shares backend on ROCM and thus supports training
         check_requires_grad_and_nested,
 #else // Meanwhile ME on ROCM share the limits of FA about head dimensions
@@ -901,19 +928,20 @@ bool can_use_mem_efficient_attention(sdp_params const& params, bool debug) {
 #endif
         check_batch_size_nested,
         check_for_seq_len_0_nested_tensor);
-    for (auto& constraint : nested_constraints) {
-      if (!constraint(params, debug)) {
+    for (const auto& constraint : nested_constraints) {
+      if (!constraint(params, diagnostics)) {
         return false;
       }
     }
   }
   if (has_only_dense_inputs(params)) {
-    constexpr auto dense_constraints = c10::array_of<bool (*)(sdp_params const&, bool)>(
+    constexpr auto dense_constraints =
+        c10::array_of<bool (*)(sdp_params const&, c10::OptionalRef<SDPDiagnostics>)>(
         check_nonzero_sequence_lengths_dense,
         check_last_dim_stride_equals_1_dense<false /*ignore_singleton_dim=*/>,
         check_batch_size_and_num_heads_dense<false /*supports_grouped_query_attention=*/>);
-    for (auto& constraint : dense_constraints) {
-      if (!constraint(params, debug)) {
+    for (const auto& constraint : dense_constraints) {
+      if (!constraint(params, diagnostics)) {
         return false;
       }
     }
@@ -924,21 +952,31 @@ bool can_use_mem_efficient_attention(sdp_params const& params, bool debug) {
     const auto q_dtype = params.query.dtype();
     const auto bias_dtype = params.attn_mask.value().dtype();
     if (bias_dtype != at::kBool && bias_dtype != q_dtype) {
-      TORCH_WARN("Efficient attention on ROCM requires attn_mask be boolean, or has the same datatype as of q,k,v");
+      report_failure(
+          diagnostics,
+          "Efficient attention on ROCM requires attn_mask be boolean, or has the same datatype as of q,k,v");
       return false;
     }
   }
   if(at::globalContext().getROCmFAPreferredBackend() == at::ROCmFABackend::Ck) {
-    return check_tensor_dtype(params, ck_mem_efficient_dtypes, debug);
+    return check_tensor_dtype(params, ck_mem_efficient_dtypes, diagnostics);
   }
-  return check_tensor_dtype(params, aotriton_mem_efficient_dtypes, debug);
+  return check_tensor_dtype(params, aotriton_mem_efficient_dtypes, diagnostics);
 #else
   auto dprop = at::cuda::getCurrentDeviceProperties();
   if (dprop->major >= 8) {
-    return check_tensor_dtype(params, greater_than_or_equal_sm80_mem_efficient_dtypes, debug);
+    return check_tensor_dtype(params, greater_than_or_equal_sm80_mem_efficient_dtypes, diagnostics);
   }
 #endif
-  return check_tensor_dtype(params, less_than_sm80_mem_efficient_dtypes, debug);
+  return check_tensor_dtype(params, less_than_sm80_mem_efficient_dtypes, diagnostics);
+}
+
+bool can_use_mem_efficient_attention(sdp_params const& params, bool debug) {
+  if (!debug) {
+    return can_use_mem_efficient_attention(params, c10::OptionalRef<SDPDiagnostics>{});
+  }
+  SDPDiagnostics diagnostics(true);
+  return can_use_mem_efficient_attention(params, diagnostics);
 }
 
 SDPBackend select_sdp_backend(sdp_params const& kernel_params) {
@@ -947,30 +985,22 @@ SDPBackend select_sdp_backend(sdp_params const& kernel_params) {
   // 2. Mem Efficient Attention
   // 3. Math fallback
   auto& ctx = at::globalContext();
-  if (!ctx.userEnabledMathSDP() && !ctx.userEnabledFlashSDP() &&
-      !ctx.userEnabledMemEfficientSDP() && !ctx.userEnabledCuDNNSDP()) {
-    return SDPBackend::error;
-  }
   // Get ideal kernel ordering
   const auto ordering = priority_order(kernel_params);
-
-  // Because TORCHCHECK checks if condition is true we negate debug so that
-  // The statements will be printed when debug is true
-  bool print_debug = false;
-  for (auto& backend : ordering) {
+  for (const auto& backend : ordering) {
     switch (backend) {
       case SDPBackend::cudnn_attention:
-        if (sdp::can_use_cudnn_attention(kernel_params, print_debug)) {
+        if (sdp::can_use_cudnn_attention(kernel_params, false)) {
               return SDPBackend::cudnn_attention;
         }
         break;
       case SDPBackend::flash_attention:
-        if (sdp::can_use_flash_attention(kernel_params, print_debug)) {
+        if (sdp::can_use_flash_attention(kernel_params, false)) {
           return SDPBackend::flash_attention;
         }
         break;
       case SDPBackend::efficient_attention:
-        if (sdp::can_use_mem_efficient_attention(kernel_params, print_debug)) {
+        if (sdp::can_use_mem_efficient_attention(kernel_params, false)) {
           return SDPBackend::efficient_attention;
         }
         break;
@@ -992,21 +1022,22 @@ SDPBackend select_sdp_backend(sdp_params const& kernel_params) {
   // 1. use_flash_attention or use_mem_efficient did not satisfy the
   // constraints to be ran
   // 2. The user has explicitly disabled the math kernel
-  // We then re-run the kernel checks with debug enabled to print out the
-  // reason why the kernel was not selected
-
-  print_debug = true;
-  TORCH_WARN("Memory efficient kernel not used because:");
-  sdp::can_use_mem_efficient_attention(kernel_params, print_debug);
-  TORCH_WARN("Flash attention kernel not used because:");
-  sdp::can_use_flash_attention(kernel_params, print_debug);
-  TORCH_WARN("cuDNN attention kernel not used because:");
-  sdp::can_use_cudnn_attention(kernel_params, print_debug);
-  TORCH_CHECK(!print_debug, "No available kernel. Aborting execution.")
+  // We then re-run the kernel checks with deferred diagnostics to aggregate
+  // the reason why the kernel was not selected.
+  SDPDiagnostics diagnostics(false);
+  diagnostics.set_current_backend("Memory efficient attention");
+  sdp::can_use_mem_efficient_attention(kernel_params, diagnostics);
+  diagnostics.set_current_backend("Flash attention");
+  sdp::can_use_flash_attention(kernel_params, diagnostics);
+  diagnostics.set_current_backend("cuDNN attention");
+  sdp::can_use_cudnn_attention(kernel_params, diagnostics);
+  diagnostics.raise_error();
   return SDPBackend::error;
 }
 
-bool check_for_seq_len_1_nested_tensor(sdp_params const& params, bool debug) {
+bool check_for_seq_len_1_nested_tensor(
+    sdp_params const& params,
+    c10::OptionalRef<SDPDiagnostics> diagnostics = {}) {
   // When this function is called we are assured that the nt is dim==4
   if (!params.query.is_nested()) {
     return true;
@@ -1022,15 +1053,26 @@ bool check_for_seq_len_1_nested_tensor(sdp_params const& params, bool debug) {
   // This is being called inside sdp with shape [batch, heads, {seq_len}, dim]
   for (const auto i : c10::irange(n_tensors)) {
     if (sizes_ptr[(i * size_tensor_stride) + 1] <= 1) {
-      if (debug) {
-        TORCH_WARN(
-            "Packed projection for fused kernels does not support sequence_length <= 1");
-      }
+      report_failure(
+          diagnostics,
+          "Packed projection for fused kernels does not support sequence_length <= 1");
       return false;
     }
   }
 
   return true;
+}
+
+bool check_for_seq_len_1_nested_tensor(
+    sdp_params const& params,
+    bool debug) {
+  if (!debug) {
+    return check_for_seq_len_1_nested_tensor(
+        params,
+        c10::OptionalRef<SDPDiagnostics>{});
+  }
+  SDPDiagnostics diagnostics(true);
+  return check_for_seq_len_1_nested_tensor(params, diagnostics);
 }
 
 } // namespace sdp

--- a/aten/src/ATen/native/transformers/sdp_utils_cpp.cpp
+++ b/aten/src/ATen/native/transformers/sdp_utils_cpp.cpp
@@ -11,34 +11,38 @@ std::array<SDPBackend, num_backends> priority_order_cpp(sdp_params const& params
   return default_order;
 }
 
-bool check_head_dim_size_cpp(sdp_params const& params, bool debug) {
+bool check_head_dim_size_cpp(
+    sdp_params const& params,
+    c10::OptionalRef<SDPDiagnostics> diagnostics = {}) {
   const auto query_size_last = params.query.sym_size(-1);
   const auto key_size_last = params.key.sym_size(-1);
   const auto value_size_last = params.value.sym_size(-1);
   if (!(query_size_last == key_size_last &&
         query_size_last == value_size_last)) {
-    if (debug) {
-      TORCH_WARN(
-          "Flash attention requires q,k,v to have the same last dimension.",
-          " Got Query.size(-1): ",
-          query_size_last,
-          ", Key.size(-1): ",
-          params.key.sym_size(-1),
-          ", Value.size(-1): ",
-          params.value.sym_size(-1),
-          " instead.");
-    }
+    report_failure(
+        diagnostics,
+        "Flash attention requires q,k,v to have the same last dimension.",
+        " Got Query.size(-1): ",
+        query_size_last,
+        ", Key.size(-1): ",
+        key_size_last,
+        ", Value.size(-1): ",
+        value_size_last,
+        " instead.");
     return false;
   }
   return true;
 }
 
-bool use_flash_attention_cpp(sdp_params const& params, bool debug) {
+bool use_flash_attention_cpp(
+    sdp_params const& params,
+    c10::OptionalRef<SDPDiagnostics> diagnostics = {}) {
   constexpr auto cpp_supported_flash_dtypes =
       c10::array_of<at::ScalarType>(at::kFloat, at::kDouble, at::kBFloat16, at::kHalf);
 
   // Define gate functions that determine if a flash kernel can be run
-  constexpr auto constraints = c10::array_of<bool (*)(sdp_params const&, bool)>(
+  constexpr auto constraints =
+      c10::array_of<bool (*)(sdp_params const&, c10::OptionalRef<SDPDiagnostics>)>(
       check_runtime_disabled_flash,
       check_nested_tensor,
       check_for_dropout,
@@ -48,13 +52,13 @@ bool use_flash_attention_cpp(sdp_params const& params, bool debug) {
       check_head_dim_size_cpp,
       check_nonzero_sequence_lengths_dense,
       check_last_dim_stride_equals_1_dense<false /*ignore_singleton_dim*/>);
-  for (auto& constraint : constraints) {
-    if (!constraint(params, debug)) {
+  for (const auto& constraint : constraints) {
+    if (!constraint(params, diagnostics)) {
       return false;
     }
   }
 
-  return check_tensor_dtype(params, cpp_supported_flash_dtypes, debug);
+  return check_tensor_dtype(params, cpp_supported_flash_dtypes, diagnostics);
 }
 } // namespace
 
@@ -63,19 +67,12 @@ SDPBackend select_sdp_backend_cpp(sdp_params const& kernel_params) {
   // 1. Flash Attention
   // 2. Math fallback
   auto& ctx = at::globalContext();
-  if (!ctx.userEnabledMathSDP() && !ctx.userEnabledFlashSDP()) {
-    return SDPBackend::error;
-  }
   // Get ideal kernel ordering
   const auto ordering = priority_order_cpp(kernel_params);
-
-  // Because TORCHCHECK checks if condition is true we negate debug so that
-  // The statements will be printed when debug is true
-  bool print_debug = false;
-  for (auto& backend : ordering) {
+  for (const auto& backend : ordering) {
     switch (backend) {
       case SDPBackend::flash_attention:
-        if (use_flash_attention_cpp(kernel_params, print_debug)) {
+        if (use_flash_attention_cpp(kernel_params)) {
           return SDPBackend::flash_attention;
         }
         break;
@@ -92,13 +89,12 @@ SDPBackend select_sdp_backend_cpp(sdp_params const& kernel_params) {
   // 1. use_flash_attention did not satisfy the
   // constraints to be ran
   // 2. The user has explicitly disabled the math kernel
-  // We then re-run the kernel checks with debug enabled to print out the
-  // reason why the kernel was not selected
-
-  print_debug = true;
-  TORCH_WARN("Flash attention kernel not used because:");
-  use_flash_attention_cpp(kernel_params, print_debug);
-  TORCH_CHECK(!print_debug, "No available kernel.  Aborting execution.")
+  // We then re-run the kernel checks with deferred diagnostics to aggregate
+  // the reason why the kernel was not selected.
+  SDPDiagnostics diagnostics(false);
+  diagnostics.set_current_backend("Flash attention");
+  use_flash_attention_cpp(kernel_params, diagnostics);
+  diagnostics.raise_error();
   return SDPBackend::error;
 }
 } // namespace sdp

--- a/aten/src/ATen/native/transformers/sdp_utils_cpp.h
+++ b/aten/src/ATen/native/transformers/sdp_utils_cpp.h
@@ -6,6 +6,7 @@
 #include <ATen/core/Tensor.h>
 #include <ATen/core/grad_mode.h>
 #include <ATen/native/DispatchStub.h>
+#include <c10/core/OptionalRef.h>
 #include <c10/core/DeviceType.h>
 #include <c10/core/ScalarType.h>
 
@@ -15,15 +16,104 @@
 
 #include <c10/core/SymInt.h>
 #include <c10/core/SymFloat.h>
+#include <algorithm>
 #include <cmath>
 #include <cstdint>
 #include <functional>
+#include <sstream>
+#include <string>
+#include <vector>
 #include <string_view>
 
 namespace sdp {
 
 constexpr int32_t num_backends = at::num_sdp_backends;
 using SDPBackend = at::SDPBackend;
+
+struct SDPDiagnostics {
+  explicit SDPDiagnostics(bool emit_warnings) : emit_warnings(emit_warnings) {}
+
+  void set_current_backend(std::string_view backend) const {
+    if (emit_warnings) {
+      return;
+    }
+    backend_failures.emplace_back(std::string(backend), std::vector<std::string>{});
+    current_backend_index = backend_failures.size() - 1;
+  }
+
+  template <typename... Args>
+  void report_failure(Args&&... args) const {
+    if (emit_warnings) {
+      TORCH_WARN(std::forward<Args>(args)...);
+      return;
+    }
+    add_failure(format(std::forward<Args>(args)...), false);
+  }
+
+  template <typename... Args>
+  void report_failure_once(Args&&... args) const {
+    if (emit_warnings) {
+      TORCH_WARN_ONCE(std::forward<Args>(args)...);
+      return;
+    }
+    add_failure(format(std::forward<Args>(args)...), true);
+  }
+
+  [[noreturn]] void raise_error() const {
+    std::ostringstream message;
+    message << "No available kernel. Aborting execution.\nRejected backends:";
+    for (const auto& [backend, reasons] : backend_failures) {
+      if (reasons.empty()) {
+        continue;
+      }
+      message << "\n" << backend << ": " << reasons.front();
+      for (const auto reason_index : c10::irange<size_t>(1, reasons.size())) {
+        message << "\n  - " << reasons[reason_index];
+      }
+    }
+    TORCH_CHECK(false, message.str());
+  }
+
+ private:
+  template <typename... Args>
+  static std::string format(Args&&... args) {
+    std::ostringstream message;
+    (message << ... << std::forward<Args>(args));
+    return message.str();
+  }
+
+  void add_failure(std::string message, bool once) const {
+    TORCH_INTERNAL_ASSERT(current_backend_index < backend_failures.size());
+    auto& reasons = backend_failures[current_backend_index].second;
+    if (once && std::find(reasons.begin(), reasons.end(), message) != reasons.end()) {
+      return;
+    }
+    reasons.push_back(std::move(message));
+  }
+
+ public:
+  bool emit_warnings;
+  mutable std::vector<std::pair<std::string, std::vector<std::string>>> backend_failures;
+  mutable size_t current_backend_index = 0;
+};
+
+template <typename... Args>
+inline void report_failure(
+    c10::OptionalRef<SDPDiagnostics> diagnostics,
+    Args&&... args) {
+  if (diagnostics.has_value()) {
+    diagnostics.get().report_failure(std::forward<Args>(args)...);
+  }
+}
+
+template <typename... Args>
+inline void report_failure_once(
+    c10::OptionalRef<SDPDiagnostics> diagnostics,
+    Args&&... args) {
+  if (diagnostics.has_value()) {
+    diagnostics.get().report_failure_once(std::forward<Args>(args)...);
+  }
+}
 
 // Note that if this changed make sure to update
 // the templated enum in mem_eff/kernel_forward.h and mem_eff/kernel_backward.h
@@ -81,25 +171,24 @@ template <typename dtype_vector>
 inline bool check_tensor_dtype(
     sdp_params const& params,
     dtype_vector allowed_dtypes,
-    bool debug) {
+    c10::OptionalRef<SDPDiagnostics> diagnostics = {}) {
   auto query_dtype = params.query.dtype();
   if (!(query_dtype == params.key.dtype() &&
         query_dtype == params.value.dtype() &&
         (std::find(allowed_dtypes.begin(), allowed_dtypes.end(), query_dtype) !=
          allowed_dtypes.end()))) {
-    if (debug) {
-      TORCH_WARN(
-          "Expected query, key and value to all be of dtype: {",
-          c10::Join(", ", allowed_dtypes),
-          "}. Got ",
-          "Query dtype: ",
-          params.query.dtype(),
-          ", Key dtype: ",
-          params.key.dtype(),
-          ", and Value dtype: ",
-          params.value.dtype(),
-          " instead.");
-    }
+    report_failure(
+        diagnostics,
+        "Expected query, key and value to all be of dtype: {",
+        c10::Join(", ", allowed_dtypes),
+        "}. Got ",
+        "Query dtype: ",
+        params.query.dtype(),
+        ", Key dtype: ",
+        params.key.dtype(),
+        ", and Value dtype: ",
+        params.value.dtype(),
+        " instead.");
     return false;
   }
   return true;
@@ -111,26 +200,25 @@ inline bool try_broadcast_param_size(
     const c10::SymInt k_size,
     const c10::SymInt v_size,
     std::string_view param_name,
-    bool debug) {
+    c10::OptionalRef<SDPDiagnostics> diagnostics = {}) {
   auto max_size = std::max({q_size, k_size, v_size});
   if ((q_size != max_size && q_size != 1) ||
       (k_size != max_size && k_size != 1) ||
       (v_size != max_size && v_size != 1)) {
-    if (debug) {
-      TORCH_WARN(
-          "Both fused kernels require query, key and value to have broadcastable ",
-          param_name,
-          "got Query ",
-          param_name,
-          q_size,
-          ", Key ",
-          param_name,
-          k_size,
-          ", Value ",
-          param_name,
-          v_size,
-          " instead.");
-    }
+    report_failure(
+        diagnostics,
+        "Both fused kernels require query, key and value to have broadcastable ",
+        param_name,
+        "got Query ",
+        param_name,
+        q_size,
+        ", Key ",
+        param_name,
+        k_size,
+        ", Value ",
+        param_name,
+        v_size,
+        " instead.");
     return false;
   }
   return true;
@@ -139,18 +227,16 @@ inline bool try_broadcast_param_size(
 inline bool check_for_seq_len_0_and_consistent_head_dim_nested_tensor_helper(
     at::Tensor const& param,
     std::string_view param_name,
-    bool debug) {
+    c10::OptionalRef<SDPDiagnostics> diagnostics = {}) {
   const auto nt_tensor_impl = at::native::get_nested_tensor_impl(param);
   const at::Tensor& sizes = nt_tensor_impl->get_nested_sizes();
   auto num_head_dims = nt_tensor_impl->opt_size(1);
   if (!num_head_dims.has_value()) {
-    // num_head_dims is ragged
-    if (debug) {
-      TORCH_WARN(
-          "Fused kernels do not support ragged num_head_dims, ",
-          param_name,
-          "has a ragged num_heads.");
-    }
+    report_failure(
+        diagnostics,
+        "Fused kernels do not support ragged num_head_dims, ",
+        param_name,
+        "has a ragged num_heads.");
     return false;
   }
 
@@ -161,23 +247,24 @@ inline bool check_for_seq_len_0_and_consistent_head_dim_nested_tensor_helper(
   // This is being called inside sdp with shape [batch, heads, {seq_len}, dim]
   for (const auto i : c10::irange(n_tensors)) {
     if (sizes_ptr[(i * size_tensor_stride) + 1] == 0) {
-      if (debug) {
-        TORCH_WARN(
-            "Fused kernels do not support seq_len == 0, ",
-            param_name,
-            "has a seq len of 0.");
-      }
+      report_failure(
+          diagnostics,
+          "Fused kernels do not support seq_len == 0, ",
+          param_name,
+          "has a seq len of 0.");
       return false;
     }
   }
   return true;
 }
 
-inline bool check_for_seq_len_0_nested_tensor(sdp_params const& params, bool debug) {
+inline bool check_for_seq_len_0_nested_tensor(
+    sdp_params const& params,
+    c10::OptionalRef<SDPDiagnostics> diagnostics = {}) {
   // When this function is called we are assured that the nt is dim==4
   bool q_is_safe = params.query.is_nested()
       ? check_for_seq_len_0_and_consistent_head_dim_nested_tensor_helper(
-            params.query, "query ", debug)
+            params.query, "query ", diagnostics)
       : true;
   // short circuit if any is unsafe
   if (!q_is_safe) {
@@ -186,7 +273,7 @@ inline bool check_for_seq_len_0_nested_tensor(sdp_params const& params, bool deb
 
   bool k_is_safe = params.key.is_nested()
       ? check_for_seq_len_0_and_consistent_head_dim_nested_tensor_helper(
-            params.key, "key ", debug)
+            params.key, "key ", diagnostics)
       : true;
   if (!k_is_safe) {
     return false;
@@ -194,7 +281,7 @@ inline bool check_for_seq_len_0_nested_tensor(sdp_params const& params, bool deb
 
   bool v_is_safe = params.value.is_nested()
       ? check_for_seq_len_0_and_consistent_head_dim_nested_tensor_helper(
-            params.value, "value ", debug)
+            params.value, "value ", diagnostics)
       : true;
   if (!v_is_safe) {
     return false;
@@ -210,63 +297,66 @@ inline bool check_for_seq_len_0_nested_tensor(sdp_params const& params, bool deb
 
   if (!same_num_heads) {
     if (input_requires_grad(params)){
-      if (debug) {
-        TORCH_WARN(
-              "Both fused kernels do not support training with broadcasted NT inputs.");
-      }
+      report_failure(
+          diagnostics,
+          "Both fused kernels do not support training with broadcasted NT inputs.");
       return false;
     }
     return try_broadcast_param_size(
-        q_num_heads, k_num_heads, v_num_heads, "num heads ", debug);
+        q_num_heads, k_num_heads, v_num_heads, "num heads ", diagnostics);
   }
 
   return true;
 }
 
-inline bool check_nested_tensor(sdp_params const& params, bool debug) {
+inline bool check_nested_tensor(
+    sdp_params const& params,
+    c10::OptionalRef<SDPDiagnostics> diagnostics = {}) {
   // Return false if have nested tensor
   if (!has_only_dense_inputs(params)) {
-    if (debug) {
-      TORCH_WARN(
-          "Both fused kernels of cpp version currently do not support Nested Tensor inputs.");
-    }
+    report_failure(
+        diagnostics,
+        "Both fused kernels of cpp version currently do not support Nested Tensor inputs.");
     return false;
   }
   return true;
 }
 
-inline bool check_for_dropout(sdp_params const& params, bool debug) {
+inline bool check_for_dropout(
+    sdp_params const& params,
+    c10::OptionalRef<SDPDiagnostics> diagnostics = {}) {
   if (params.dropout > 0.0) {
-    if (debug) {
-      TORCH_WARN("Both fused kernels do not support non-zero dropout.");
-    }
+    report_failure(diagnostics, "Both fused kernels do not support non-zero dropout.");
     return false;
   }
   return true;
 }
 
-inline bool check_requires_grad_and_nested(sdp_params const& params, bool debug) {
+inline bool check_requires_grad_and_nested(
+    sdp_params const& params,
+    c10::OptionalRef<SDPDiagnostics> diagnostics = {}) {
   if (input_requires_grad(params)) {
-    if (debug) {
-      TORCH_WARN(
-          "Memory efficient attention currently doesn't support training with NT inputs.");
-    }
+    report_failure(
+        diagnostics,
+        "Memory efficient attention currently doesn't support training with NT inputs.");
     return false;
   }
   return true;
 }
 
-inline bool check_for_attn_mask(sdp_params const& params, bool debug) {
+inline bool check_for_attn_mask(
+    sdp_params const& params,
+    c10::OptionalRef<SDPDiagnostics> diagnostics = {}) {
   if (params.attn_mask.has_value()) {
-    if (debug) {
-      TORCH_WARN("Flash Attention does not support non-null attn_mask.");
-    }
+    report_failure(diagnostics, "Flash Attention does not support non-null attn_mask.");
     return false;
   }
   return true;
 }
 
-inline bool check_attn_mask_shape(sdp_params const& params, bool debug) {
+inline bool check_attn_mask_shape(
+    sdp_params const& params,
+    c10::OptionalRef<SDPDiagnostics> diagnostics = {}) {
   auto attn_mask = params.attn_mask;
   if (!attn_mask.has_value()) {
     return true;
@@ -292,90 +382,92 @@ inline bool check_attn_mask_shape(sdp_params const& params, bool debug) {
       return true;
     }
   }
-  if (debug) {
-    TORCH_WARN("Please use the following attn mask shapes: ",
+  report_failure(diagnostics, "Please use the following attn mask shapes: ",
         "2d - ({Q_seq_len, 1}  x {KV_seq_len, 1}); ",
         "4d - ({Batch, 1} x {Num_heads, 1} x {Q_seq_len, 1}  x {KV_seq_len, 1})");
-  }
   return false;
 }
 
-inline bool check_tensor_shapes(sdp_params const& params, bool debug) {
+inline bool check_tensor_shapes(
+    sdp_params const& params,
+    c10::OptionalRef<SDPDiagnostics> diagnostics = {}) {
   auto query_dim = params.query.dim();
   if (!(query_dim == params.key.dim() && query_dim == params.value.dim() &&
         (query_dim == 4))) {
-    if (debug) {
-      TORCH_WARN(
-          "All fused kernels requires query, key and value to be 4 dimensional, but got Query dim: ",
-          query_dim,
-          ", Key dim: ",
-          params.key.dim(),
-          ", Value dim: ",
-          params.value.dim(),
-          " instead.");
-    }
+    report_failure(
+        diagnostics,
+        "All fused kernels requires query, key and value to be 4 dimensional, but got Query dim: ",
+        query_dim,
+        ", Key dim: ",
+        params.key.dim(),
+        ", Value dim: ",
+        params.value.dim(),
+        " instead.");
     return false;
   }
   return true;
 }
 
-inline bool check_safe_kv_broadcast(at::Tensor const& param, bool debug) {
+inline bool check_safe_kv_broadcast(
+    at::Tensor const& param,
+    c10::OptionalRef<SDPDiagnostics> diagnostics = {}) {
   const auto nt_tensor_impl = at::native::get_nested_tensor_impl(param);
   auto seq_len = nt_tensor_impl->opt_size(2);
   if (!seq_len.has_value()) {
-    if (debug) {
-      TORCH_WARN(
-          "For both fused kernels, if one of key/value batch_size requires "
-          "broadcasting and the other does not, then the other must have a ",
-          "consistent seq_len dim.")
-    }
+    report_failure(
+        diagnostics,
+        "For both fused kernels, if one of key/value batch_size requires "
+        "broadcasting and the other does not, then the other must have a ",
+        "consistent seq_len dim.");
     return false;
   }
   return true;
 }
 
 template <bool requires_same_num_heads=true>
-inline bool check_grouped_query_attention(sdp_params const& params, bool debug) {
+inline bool check_grouped_query_attention(
+    sdp_params const& params,
+    c10::OptionalRef<SDPDiagnostics> diagnostics = {}) {
   const auto q_num_heads = params.query.sym_size(-3);
   const auto k_num_heads = params.key.sym_size(-3);
   const auto v_num_heads = params.value.sym_size(-3);
   const bool same_kv_heads = k_num_heads == v_num_heads;
 
   if (requires_same_num_heads && !same_kv_heads){
-    if (debug) {
-      TORCH_WARN(
-          "Both fused kernels require key and value to have the same num_heads and batch_size but got: ",
-          "Key sizes: ",
-          params.key.sizes(),
-          ", Value sizes: ",
-          params.value.sizes(),
-          ", Query sizes: ",
-          params.query.sizes(),
-          " instead.");
-    }
+    report_failure(
+        diagnostics,
+        "Both fused kernels require key and value to have the same num_heads and batch_size but got: ",
+        "Key sizes: ",
+        params.key.sizes(),
+        ", Value sizes: ",
+        params.value.sizes(),
+        ", Query sizes: ",
+        params.query.sizes(),
+        " instead.");
     return false;
   }
   // Check if grouped query attention is supported and validate the number of
   // heads
   if (q_num_heads % k_num_heads != 0 || (!requires_same_num_heads && (q_num_heads % v_num_heads != 0))) {
-    if (debug) {
-      TORCH_WARN(
-          "The number of heads in key/value must divide number of heads in query.",
-          "Got input Key sizes(): ",
-          params.key.sym_size(-3),
-          ", Value sizes(): ",
-          params.value.sym_size(-3),
-          ", Query sizes(): ",
-          params.query.sym_size(-3),
-          " instead.");
-    }
+    report_failure(
+        diagnostics,
+        "The number of heads in key/value must divide number of heads in query.",
+        "Got input Key sizes(): ",
+        params.key.sym_size(-3),
+        ", Value sizes(): ",
+        params.value.sym_size(-3),
+        ", Query sizes(): ",
+        params.query.sym_size(-3),
+        " instead.");
     return false;
   }
   return true;
 }
 
 template <bool supports_gqa, bool requires_same_num_heads=true>
-inline bool check_batch_size_and_num_heads_dense(sdp_params const& params, bool debug) {
+inline bool check_batch_size_and_num_heads_dense(
+    sdp_params const& params,
+    c10::OptionalRef<SDPDiagnostics> diagnostics = {}) {
   // This is expected to be called after check_tensor_shapes ensuring that the
   // size() calls won't error since the inputs are all 4 dimensional
 
@@ -394,44 +486,44 @@ inline bool check_batch_size_and_num_heads_dense(sdp_params const& params, bool 
       q_num_heads == k_num_heads && q_num_heads == v_num_heads;
 
   if (!same_batch_size){
-    if(debug) {
-      TORCH_WARN(
-          "For dense inputs, both fused kernels require query, key and value to have the same batch_size. ",
-          "Query.sizes(): ",
-          params.query.sizes(),
-          ", Key.sizes(): ",
-          params.key.sizes(),
-          ", Value.sizes(): ",
-          params.value.sizes(),
-          " instead. To broadcast dense inputs, try using unsqueeze and expand_to before passing them into the kernel.");
-    }
+    report_failure(
+        diagnostics,
+        "For dense inputs, both fused kernels require query, key and value to have the same batch_size. ",
+        "Query.sizes(): ",
+        params.query.sizes(),
+        ", Key.sizes(): ",
+        params.key.sizes(),
+        ", Value.sizes(): ",
+        params.value.sizes(),
+        " instead. To broadcast dense inputs, try using unsqueeze and expand_to before passing them into the kernel.");
     return false;
   }
 
   if(params.enable_gqa && supports_gqa){
-    return check_grouped_query_attention<requires_same_num_heads>(params, debug);
+    return check_grouped_query_attention<requires_same_num_heads>(params, diagnostics);
   }
 
   // same num heads condition for non-gqa case
   if (!same_num_heads){
-    if (debug) {
-      TORCH_WARN(
-          "For dense input, both fused kernels require query, key and value to have the same num_heads. ",
-          "Query.sizes(): ",
-          params.query.sizes(),
-          ", Key sizes(): ",
-          params.key.sizes(),
-          ", Value sizes(): ",
-          params.value.sizes(),
-          " instead. To broadcast dense inputs, try using unsqueeze and expand_to before passing them into the kernel.");
-    }
+    report_failure(
+        diagnostics,
+        "For dense input, both fused kernels require query, key and value to have the same num_heads. ",
+        "Query.sizes(): ",
+        params.query.sizes(),
+        ", Key sizes(): ",
+        params.key.sizes(),
+        ", Value sizes(): ",
+        params.value.sizes(),
+        " instead. To broadcast dense inputs, try using unsqueeze and expand_to before passing them into the kernel.");
     return false;
   }
   // If all checks pass, return true
   return true;
 }
 
-inline bool check_batch_size_nested(sdp_params const& params, bool debug) {
+inline bool check_batch_size_nested(
+    sdp_params const& params,
+    c10::OptionalRef<SDPDiagnostics> diagnostics = {}) {
   // This is expected to be called after check_tensor_shapes ensuring that the
   // size() calls won't error since the inputs are all 4 dimensional
   auto q_batch_size = params.query.sym_size(0);
@@ -447,25 +539,24 @@ inline bool check_batch_size_nested(sdp_params const& params, bool debug) {
   bool broadcastable_batch_size = true;
   if (!same_batch_size) {
     if (input_requires_grad(params)){
-      if (debug) {
-        TORCH_WARN(
-            "Both fused kernels do not support training with broadcasted NT inputs.");
-      }
+      report_failure(
+          diagnostics,
+          "Both fused kernels do not support training with broadcasted NT inputs.");
       return false;
     }
     // try to broadcast batchsize
     broadcastable_batch_size = try_broadcast_param_size(
-        q_batch_size, k_batch_size, v_batch_size, "batch size ", debug);
+        q_batch_size, k_batch_size, v_batch_size, "batch size ", diagnostics);
 
     // if only one of k or v require broadcasting of batch size, the other
     // must have a consistent seq_len dim
     if (broadcastable_batch_size) {
       if (k_batch_size == 1 && v_batch_size != 1 &&
-          !check_safe_kv_broadcast(params.value, debug)) {
+          !check_safe_kv_broadcast(params.value, diagnostics)) {
         return false;
       }
       if (v_batch_size == 1 && k_batch_size != 1 &&
-          !check_safe_kv_broadcast(params.key, debug)) {
+          !check_safe_kv_broadcast(params.key, diagnostics)) {
         return false;
       }
     }
@@ -473,23 +564,26 @@ inline bool check_batch_size_nested(sdp_params const& params, bool debug) {
   return broadcastable_batch_size;
 }
 
-inline bool check_nonzero_sequence_lengths_dense(sdp_params const& params, bool debug) {
+inline bool check_nonzero_sequence_lengths_dense(
+    sdp_params const& params,
+    c10::OptionalRef<SDPDiagnostics> diagnostics = {}) {
   // In some cases people will pass in 0 sized tensors, this will
   // cause the fused path to error with unaligned mask
   bool zero_seq_len_q = params.query.sym_size(-2) == 0;
   bool zero_seq_len_k = params.key.sym_size(-2) == 0;
   if (zero_seq_len_q || zero_seq_len_k) {
-    if (debug) {
-      TORCH_WARN(
-          "All fused kernels do not support zero seq_len_q or seq_len_kv.");
-    }
+    report_failure(
+        diagnostics,
+        "All fused kernels do not support zero seq_len_q or seq_len_kv.");
     return false;
   }
   return true;
 }
 
 template<bool ignore_singleton_dim>
-inline bool check_last_dim_stride_equals_1_dense(sdp_params const& params, bool debug) {
+inline bool check_last_dim_stride_equals_1_dense(
+    sdp_params const& params,
+    c10::OptionalRef<SDPDiagnostics> diagnostics = {}) {
   // The stride checking for NestedTensors is done within the kernel
   // And .contiguous will be called if needed
 
@@ -510,7 +604,7 @@ inline bool check_last_dim_stride_equals_1_dense(sdp_params const& params, bool 
       : true;
   bool mask_stride_valid = is_cpu ? true : mask_stride_equal_1;
   if (!(qkv_strides_equal_1 && mask_stride_valid)) {
-    if (debug) {
+    if (diagnostics.has_value()) {
       std::ostringstream message;
       message
           << "All fused kernels require the last dimension of the input to have stride 1. ";
@@ -524,7 +618,7 @@ inline bool check_last_dim_stride_equals_1_dense(sdp_params const& params, bool 
             << params.attn_mask.value().sym_stride(-1)
             << " (GPU backends require attn_mask's last dimension to have stride 1 while the CPU does not).";
       }
-      TORCH_WARN(message.str());
+      diagnostics.get().report_failure(message.str());
     }
 
     return false;
@@ -532,25 +626,25 @@ inline bool check_last_dim_stride_equals_1_dense(sdp_params const& params, bool 
   return true;
 }
 
-inline bool check_runtime_disabled_flash(sdp_params const& params, bool debug) {
+inline bool check_runtime_disabled_flash(
+    sdp_params const& params,
+    c10::OptionalRef<SDPDiagnostics> diagnostics = {}) {
   // We check the global context to see if user has explicitly turned of flash
   // sdp kernels
   if (!at::globalContext().userEnabledFlashSDP()) {
-    if (debug) {
-      TORCH_WARN("Flash attention has been runtime disabled.");
-    }
+    report_failure(diagnostics, "Flash attention has been runtime disabled.");
     return false;
   }
   return true;
 }
 
-inline bool check_runtime_disabled_mem_efficient(sdp_params const& params, bool debug) {
+inline bool check_runtime_disabled_mem_efficient(
+    sdp_params const& params,
+    c10::OptionalRef<SDPDiagnostics> diagnostics = {}) {
   // We check the global context to see if user has explicitly turned of
   // mem_efficient sdp kernels
   if (!at::globalContext().userEnabledMemEfficientSDP()) {
-    if (debug) {
-      TORCH_WARN("Memory Efficient attention has been runtime disabled.");
-    }
+    report_failure(diagnostics, "Memory Efficient attention has been runtime disabled.");
     return false;
   }
   return true;

--- a/aten/src/ATen/native/transformers/xpu/sdp_utils.cpp
+++ b/aten/src/ATen/native/transformers/xpu/sdp_utils.cpp
@@ -8,19 +8,28 @@ bool is_flash_attention_available() {
   return sycltla::is_flash_attention_available();
 }
 
-inline bool is_flash_attention_available(sdp_params const& params, bool debug) {
+inline bool is_flash_attention_available(
+    sdp_params const& params,
+    c10::OptionalRef<SDPDiagnostics> diagnostics) {
   if (!is_flash_attention_available()) {
-    if (debug) {
-      TORCH_WARN("Torch XPU was not compiled with flash attention.");
-    }
+    report_failure(diagnostics, "Torch XPU was not compiled with flash attention.");
     return false;
   }
   return true;
 }
 
+inline bool is_flash_attention_available(sdp_params const& params, bool debug) {
+  if (!debug) {
+    return is_flash_attention_available(
+        params, c10::OptionalRef<SDPDiagnostics>{});
+  }
+  SDPDiagnostics diagnostics(true);
+  return is_flash_attention_available(params, diagnostics);
+}
+
 bool check_flash_attention_hardware_support(
     sdp_params const& params,
-    bool debug) {
+    c10::OptionalRef<SDPDiagnostics> diagnostics) {
   if (!at::xpu::is_available()) {
     TORCH_CHECK(false, "FlashAttentionXPU: XPU device is not available.");
   }
@@ -37,19 +46,29 @@ bool check_flash_attention_hardware_support(
           supported_architectures.begin(),
           supported_architectures.end(),
           device_architecture) == supported_architectures.end()) {
-    if (debug) {
-      TORCH_WARN(
-          "XPU device architecture does not support flash attention. Supported architectures are: intel_gpu_pvc, intel_gpu_pvc_vg, intel_gpu_bmg_g21.");
-    }
+    report_failure(
+        diagnostics,
+        "XPU device architecture does not support flash attention. Supported architectures are: intel_gpu_pvc, intel_gpu_pvc_vg, intel_gpu_bmg_g21.");
     return false;
   }
 
   return true;
 }
 
-inline bool check_flash_attention_datatype(
+bool check_flash_attention_hardware_support(
     sdp_params const& params,
     bool debug) {
+  if (!debug) {
+    return check_flash_attention_hardware_support(
+        params, c10::OptionalRef<SDPDiagnostics>{});
+  }
+  SDPDiagnostics diagnostics(true);
+  return check_flash_attention_hardware_support(params, diagnostics);
+}
+
+inline bool check_flash_attention_datatype(
+    sdp_params const& params,
+    c10::OptionalRef<SDPDiagnostics> diagnostics) {
   constexpr auto supported_dtypes =
       c10::array_of<at::ScalarType>(at::kBFloat16, at::kHalf);
 
@@ -59,19 +78,67 @@ inline bool check_flash_attention_datatype(
         (std::find(
              supported_dtypes.begin(), supported_dtypes.end(), query_dtype) !=
          supported_dtypes.end()))) {
-    if (debug) {
-      TORCH_WARN(
-          "FlashAttentionXPU expected query, key, and value to all be of dtype: {",
-          "bfloat16, half",
-          "}. Got ",
-          "Query dtype: ",
-          params.query.dtype(),
-          ", Key dtype: ",
-          params.key.dtype(),
-          ", and Value dtype: ",
-          params.value.dtype(),
-          " instead.");
-    }
+    report_failure(
+        diagnostics,
+        "FlashAttentionXPU expected query, key, and value to all be of dtype: {",
+        "bfloat16, half",
+        "}. Got ",
+        "Query dtype: ",
+        params.query.dtype(),
+        ", Key dtype: ",
+        params.key.dtype(),
+        ", and Value dtype: ",
+        params.value.dtype(),
+        " instead.");
+    return false;
+  }
+  return true;
+}
+
+inline bool check_flash_attention_datatype(
+    sdp_params const& params,
+    bool debug) {
+  if (!debug) {
+    return check_flash_attention_datatype(
+        params, c10::OptionalRef<SDPDiagnostics>{});
+  }
+  SDPDiagnostics diagnostics(true);
+  return check_flash_attention_datatype(params, diagnostics);
+}
+
+inline bool check_flash_attention_head_dim_size(
+    sdp_params const& params,
+    c10::OptionalRef<SDPDiagnostics> diagnostics) {
+  const int query_size_last = params.query.size(3);
+  const int key_size_last = params.key.size(3);
+  const int value_size_last = params.value.size(3);
+
+  const bool head_dims_equal = (query_size_last == key_size_last) &&
+      (query_size_last == value_size_last);
+  if (!head_dims_equal) {
+    report_failure(
+        diagnostics,
+        "FlashAttentionXPU requires q,k,v to have the same last dimension.",
+        " Got Query.size(-1): ",
+        query_size_last,
+        ", Key.size(-1): ",
+        key_size_last,
+        ", Value.size(-1): ",
+        value_size_last,
+        " instead.");
+    return false;
+  }
+
+  constexpr auto max_supported_headdim = 192;
+  if (query_size_last > max_supported_headdim) {
+    report_failure(
+        diagnostics,
+        "FlashAttentionXPU supports head dimension up to ",
+        max_supported_headdim,
+        ". ",
+        "Got head dimension: ",
+        query_size_last,
+        " instead.");
     return false;
   }
   return true;
@@ -80,50 +147,33 @@ inline bool check_flash_attention_datatype(
 inline bool check_flash_attention_head_dim_size(
     sdp_params const& params,
     bool debug) {
-  const int query_size_last = params.query.size(3);
-  const int key_size_last = params.key.size(3);
-  const int value_size_last = params.value.size(3);
-
-  const bool head_dims_equal = (query_size_last == key_size_last) &&
-      (query_size_last == value_size_last);
-  if (!head_dims_equal) {
-    if (debug) {
-      TORCH_WARN(
-          "FlashAttentionXPU requires q,k,v to have the same last dimension.",
-          " Got Query.size(-1): ",
-          query_size_last,
-          ", Key.size(-1): ",
-          key_size_last,
-          ", Value.size(-1): ",
-          value_size_last,
-          " instead.");
-    }
-    return false;
+  if (!debug) {
+    return check_flash_attention_head_dim_size(
+        params, c10::OptionalRef<SDPDiagnostics>{});
   }
+  SDPDiagnostics diagnostics(true);
+  return check_flash_attention_head_dim_size(params, diagnostics);
+}
 
-  constexpr auto max_supported_headdim = 192;
-  if (query_size_last > max_supported_headdim) {
-    if (debug) {
-      TORCH_WARN(
-          "FlashAttentionXPU supports head dimension up to ",
-          max_supported_headdim,
-          ". ",
-          "Got head dimension: ",
-          query_size_last,
-          " instead.");
-    }
-    return false;
-  }
-  return true;
+inline bool check_flash_attention_layout(
+    sdp_params const& params,
+    c10::OptionalRef<SDPDiagnostics> diagnostics) {
+  return sycltla::check_flash_attention_layout(
+      params, diagnostics.has_value() && diagnostics->emit_warnings);
 }
 
 inline bool check_flash_attention_layout(sdp_params const& params, bool debug) {
-  return sycltla::check_flash_attention_layout(params, debug);
+  if (!debug) {
+    return check_flash_attention_layout(
+        params, c10::OptionalRef<SDPDiagnostics>{});
+  }
+  SDPDiagnostics diagnostics(true);
+  return check_flash_attention_layout(params, diagnostics);
 }
 
 inline bool check_flash_causal_non_square_seqlens(
     sdp_params const& params,
-    bool debug) {
+    c10::OptionalRef<SDPDiagnostics> diagnostics) {
   // FlashAttention 2 updated the default mask meaning for causal in this PR:
   // 9e5e8bc91e it is now aligned to lower_right which would be a BC break
   // for non-square masks. We will not support non-square masks for causal w/
@@ -131,15 +181,36 @@ inline bool check_flash_causal_non_square_seqlens(
   if (params.is_causal && !params.query.is_nested() &&
       !params.key.is_nested() &&
       params.query.sym_size(-2) != params.key.sym_size(-2)) {
-    if (debug) {
-      TORCH_WARN(
-          "Flash attention XPU does not support the is_causal flag when seqlen_q != seqlen_k. ",
-          "Got seqlen_q: ",
-          params.query.sym_size(-2),
-          " seqlen_k: ",
-          params.key.sym_size(-2),
-          ". If you would like to use causal attention with non-square masks, please see CausalAttnMask.");
-    }
+    report_failure(
+        diagnostics,
+        "Flash attention XPU does not support the is_causal flag when seqlen_q != seqlen_k. ",
+        "Got seqlen_q: ",
+        params.query.sym_size(-2),
+        " seqlen_k: ",
+        params.key.sym_size(-2),
+        ". If you would like to use causal attention with non-square masks, please see CausalAttnMask.");
+    return false;
+  }
+  return true;
+}
+
+inline bool check_flash_causal_non_square_seqlens(
+    sdp_params const& params,
+    bool debug) {
+  if (!debug) {
+    return check_flash_causal_non_square_seqlens(
+        params, c10::OptionalRef<SDPDiagnostics>{});
+  }
+  SDPDiagnostics diagnostics(true);
+  return check_flash_causal_non_square_seqlens(params, diagnostics);
+}
+
+inline bool check_flash_attention_deterministic(
+    const sdp_params& params,
+    c10::OptionalRef<SDPDiagnostics> diagnostics) {
+  auto& ctx = at::globalContext();
+  if (ctx.deterministicAlgorithms()) {
+    report_failure(diagnostics, "Flash attention XPU is not deterministic.");
     return false;
   }
   return true;
@@ -148,19 +219,21 @@ inline bool check_flash_causal_non_square_seqlens(
 inline bool check_flash_attention_deterministic(
     const sdp_params& params,
     bool debug) {
-  auto& ctx = at::globalContext();
-  if (ctx.deterministicAlgorithms()) {
-    if (debug) {
-      TORCH_WARN("Flash attention XPU is not deterministic.");
-    }
-    return false;
+  if (!debug) {
+    return check_flash_attention_deterministic(
+        params, c10::OptionalRef<SDPDiagnostics>{});
   }
-  return true;
+  SDPDiagnostics diagnostics(true);
+  return check_flash_attention_deterministic(params, diagnostics);
 }
 
-bool can_use_flash_attention(sdp_params const& params, bool debug) {
+bool can_use_flash_attention(
+    sdp_params const& params,
+    c10::OptionalRef<SDPDiagnostics> diagnostics) {
   constexpr auto constraints =
-      std::array<bool (*)(sdp_params const&, bool), 14>{
+      std::array<
+          bool (*)(sdp_params const&, c10::OptionalRef<SDPDiagnostics>),
+          14>{
           is_flash_attention_available,
           check_flash_attention_hardware_support,
           check_for_attn_mask,
@@ -175,12 +248,20 @@ bool can_use_flash_attention(sdp_params const& params, bool debug) {
           check_flash_attention_head_dim_size,
           check_flash_attention_layout,
           check_flash_attention_deterministic};
-  for (auto& constraint : constraints) {
-    if (!constraint(params, debug)) {
+  for (const auto& constraint : constraints) {
+    if (!constraint(params, diagnostics)) {
       return false;
     }
   }
   return true;
+}
+
+bool can_use_flash_attention(sdp_params const& params, bool debug) {
+  if (!debug) {
+    return can_use_flash_attention(params, c10::OptionalRef<SDPDiagnostics>{});
+  }
+  SDPDiagnostics diagnostics(true);
+  return can_use_flash_attention(params, diagnostics);
 }
 
 } // namespace sdp

--- a/aten/src/ATen/native/transformers/xpu/sdp_utils.h
+++ b/aten/src/ATen/native/transformers/xpu/sdp_utils.h
@@ -9,6 +9,9 @@
 namespace sdp {
 
 C10_EXPORT bool is_flash_attention_available();
+C10_EXPORT bool can_use_flash_attention(
+    sdp_params const& params,
+    c10::OptionalRef<SDPDiagnostics> diagnostics);
 C10_EXPORT bool can_use_flash_attention(sdp_params const& params, bool debug);
 C10_EXPORT bool check_flash_attention_hardware_support(
     sdp_params const& params,

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -1553,6 +1553,29 @@ class TestSDPAFailureModes(NNTestCase):
             "Flash attention: All fused kernels requires query, key and value to be 4 dimensional",
         )
 
+    def test_no_backend_aggregates_rejections_nested_math_cpu(self):
+        q = torch.nested.nested_tensor(
+            [torch.randn(4, 2, 8), torch.randn(3, 2, 8)],
+            layout=torch.jagged,
+        ).transpose(1, 2)
+        k = torch.nested.nested_tensor(
+            [torch.randn(4, 2, 8), torch.randn(5, 2, 8)],
+            layout=torch.jagged,
+        ).transpose(1, 2)
+        v = torch.nested.nested_tensor(
+            [torch.randn(4, 2, 8), torch.randn(5, 2, 8)],
+            layout=torch.jagged,
+        ).transpose(1, 2)
+
+        with sdpa_kernel(backends=[SDPBackend.MATH]):
+            with self.assertRaises(RuntimeError) as error:
+                F.scaled_dot_product_attention(q, k, v, is_causal=True)
+
+        self.assert_rejected_backends_error(
+            error,
+            "Math attention: Nested tensors for query / key are not supported when is_causal=True.",
+        )
+
     @onlyCUDA
     @unittest.skipIf(not PLATFORM_SUPPORTS_FUSED_ATTENTION, "Does not support fused scaled dot product attention")
     def test_no_backend_aggregates_rejections_cuda(self, device):

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -1981,9 +1981,12 @@ class TestSDPAFailureModes(NNTestCase):
         make_tensor = partial(torch.rand, size, device=device, dtype=dtype)
         q, k, v = make_tensor(), make_tensor(), make_tensor()
         with sdpa_kernel(backends=[SDPBackend.EFFICIENT_ATTENTION]):
-            with self.assertWarnsRegex(UserWarning, "Expected query, key and value to all be of dtype: {Half, Float}"):
-                self.assertRaises(RuntimeError, lambda: torch.nn.functional.scaled_dot_product_attention(
-                    q, k, v, None, 0.0, False))
+            with self.assertRaises(RuntimeError) as error:
+                torch.nn.functional.scaled_dot_product_attention(q, k, v, None, 0.0, False)
+            self.assert_rejected_backends_error(
+                error,
+                "Memory efficient attention: Expected query, key and value to all be of dtype: {Half, Float}",
+            )
 
     @onlyCUDA
     @unittest.skipIf(not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Does not support flash attention")

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -1532,6 +1532,51 @@ class TestSDPAFailureModes(NNTestCase):
     _do_cuda_memory_leak_check = True
     _do_cuda_non_default_stream = True
 
+    def assert_rejected_backends_error(self, error, *expected_substrings):
+        message = str(error.exception)
+        self.assertIn("No available kernel. Aborting execution.", message)
+        self.assertIn("Rejected backends:", message)
+        for expected_substring in expected_substrings:
+            self.assertIn(expected_substring, message)
+
+    def test_no_backend_aggregates_rejections_cpu(self):
+        q = torch.randn((2, 3, 8), dtype=torch.float32)
+        k = torch.randn((2, 3, 8), dtype=torch.float32)
+        v = torch.randn((2, 3, 8), dtype=torch.float32)
+
+        with sdpa_kernel(backends=[SDPBackend.FLASH_ATTENTION]):
+            with self.assertRaises(RuntimeError) as error:
+                F.scaled_dot_product_attention(q, k, v)
+
+        self.assert_rejected_backends_error(
+            error,
+            "Flash attention: All fused kernels requires query, key and value to be 4 dimensional",
+        )
+
+    @onlyCUDA
+    @unittest.skipIf(not PLATFORM_SUPPORTS_FUSED_ATTENTION, "Does not support fused scaled dot product attention")
+    def test_no_backend_aggregates_rejections_cuda(self, device):
+        dtype = torch.float16
+        q = torch.randn((2, 3, 8), device=device, dtype=dtype)
+        k = torch.randn((2, 3, 8), device=device, dtype=dtype)
+        v = torch.randn((2, 3, 8), device=device, dtype=dtype)
+
+        with sdpa_kernel(backends=[SDPBackend.FLASH_ATTENTION, SDPBackend.CUDNN_ATTENTION]):
+            with self.assertRaises(RuntimeError) as error:
+                F.scaled_dot_product_attention(q, k, v)
+
+        expected_cudnn_reason = (
+            "cuDNN attention: All fused kernels requires query, key and value to be 4 dimensional"
+            if PLATFORM_SUPPORTS_CUDNN_ATTENTION
+            else "cuDNN attention: Torch was not compiled with cuDNN attention."
+        )
+        self.assert_rejected_backends_error(
+            error,
+            "Memory efficient attention: Memory Efficient attention has been runtime disabled.",
+            "Flash attention: All fused kernels requires query, key and value to be 4 dimensional",
+            expected_cudnn_reason,
+        )
+
     @onlyCUDA
     @unittest.skipIf(
         not PLATFORM_SUPPORTS_FLASH_ATTENTION or not isSM8XDevice or not isSM120Device,
@@ -1578,10 +1623,22 @@ class TestSDPAFailureModes(NNTestCase):
             q = torch.randn(size, device=device, dtype=dtype)
             k = torch.randn(size, device=device, dtype=dtype)
             v = torch.randn(size, device=device, dtype=dtype)
-            self.assertRaisesRegex(RuntimeError, "No viable backend for scaled_dot_product_attention was found.",
-                                   lambda: torch._fused_sdp_choice(q, k, v))
-            self.assertRaisesRegex(RuntimeError, "No viable backend for scaled_dot_product_attention was found.",
-                                   lambda: torch.nn.functional.scaled_dot_product_attention(q, k, v))
+            with self.assertRaises(RuntimeError) as error:
+                torch._fused_sdp_choice(q, k, v)
+            self.assert_rejected_backends_error(
+                error,
+                "Memory efficient attention:",
+                "Flash attention:",
+                "cuDNN attention:",
+            )
+            with self.assertRaises(RuntimeError) as error:
+                torch.nn.functional.scaled_dot_product_attention(q, k, v)
+            self.assert_rejected_backends_error(
+                error,
+                "Memory efficient attention:",
+                "Flash attention:",
+                "cuDNN attention:",
+            )
 
     @onlyCUDA
     @unittest.skipIf(not PLATFORM_SUPPORTS_FUSED_ATTENTION, "Does not support fused scaled dot product attention")
@@ -1597,9 +1654,12 @@ class TestSDPAFailureModes(NNTestCase):
             q = torch.randn(size, device=device, dtype=dtype)
             k = torch.randn(size, device=device, dtype=dtype)
             v = torch.randn(size, device=device, dtype=dtype)
-            with self.assertWarnsRegex(UserWarning, "All fused kernels requires query, key and value to be 4 dimensional"):
-                self.assertRaises(RuntimeError, lambda: torch.nn.functional.scaled_dot_product_attention(
-                    q, k, v, None, 0.0, False))
+            with self.assertRaises(RuntimeError) as error:
+                torch.nn.functional.scaled_dot_product_attention(q, k, v, None, 0.0, False)
+            self.assert_rejected_backends_error(
+                error,
+                "All fused kernels requires query, key and value to be 4 dimensional",
+            )
 
     @onlyCUDA
     @unittest.skipIf(not PLATFORM_SUPPORTS_FUSED_ATTENTION, "Does not support fused scaled dot product attention")
@@ -1692,9 +1752,12 @@ class TestSDPAFailureModes(NNTestCase):
             size = SdpaShape(2, 2, 8, 8)
             q, k, v = make_tensor(size), make_tensor(size), make_tensor(size)
             q.as_strided_(size, [2, 2, 2, 2])
-            with self.assertWarnsRegex(UserWarning, "All fused kernels require the last dimension of the input to have stride 1."):
-                self.assertRaises(RuntimeError, lambda: torch.nn.functional.scaled_dot_product_attention(
-                    q, k, v, None, 0.0, False))
+            with self.assertRaises(RuntimeError) as error:
+                torch.nn.functional.scaled_dot_product_attention(q, k, v, None, 0.0, False)
+            self.assert_rejected_backends_error(
+                error,
+                "All fused kernels require the last dimension of the input to have stride 1.",
+            )
 
     @onlyCUDA
     @unittest.skipIf(
@@ -1713,16 +1776,12 @@ class TestSDPAFailureModes(NNTestCase):
             # Passing in a attn_mask with last dim stride not equal to 1 will error
             attn_mask.as_strided_(size, [2, 2, 2, 2])
 
-            with self.assertWarnsRegex(
-                UserWarning,
+            with self.assertRaises(RuntimeError) as error:
+                torch.nn.functional.scaled_dot_product_attention(q, k, v, attn_mask, 0.0, False)
+            self.assert_rejected_backends_error(
+                error,
                 "GPU backends require attn_mask's last dimension to have stride 1 while the CPU does not",
-            ):
-                self.assertRaises(
-                    RuntimeError,
-                    lambda: torch.nn.functional.scaled_dot_product_attention(
-                        q, k, v, attn_mask, 0.0, False
-                    ),
-                )
+            )
 
     @onlyCUDA
     @unittest.skipIf(not PLATFORM_SUPPORTS_MEM_EFF_ATTENTION, "Does not support SDPA or pre-SM80 hardware")
@@ -1733,11 +1792,19 @@ class TestSDPAFailureModes(NNTestCase):
         rand_value = torch.rand(8, 4, 64, 64, device=device, dtype=torch.float16, requires_grad=True)
 
         with sdpa_kernel(fused_kernel):
-            with self.assertRaisesRegex(RuntimeError, "No available kernel"):
-                with self.assertWarnsRegex(UserWarning, "For dense inputs, both fused kernels require query, "
-                                           "key and value to have"):
-                    F.scaled_dot_product_attention(rand_query, rand_key, rand_value, dropout_p=0.0,
-                                                   is_causal=False, enable_gqa=True)
+            with self.assertRaises(RuntimeError) as error:
+                F.scaled_dot_product_attention(
+                    rand_query,
+                    rand_key,
+                    rand_value,
+                    dropout_p=0.0,
+                    is_causal=False,
+                    enable_gqa=True,
+                )
+            self.assert_rejected_backends_error(
+                error,
+                "For dense input, both fused kernels require query, key and value to have the same num_heads.",
+            )
 
     @onlyCUDA
     @unittest.skipIf(not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Does not flash_attention fused scaled dot product attention")
@@ -1804,9 +1871,12 @@ class TestSDPAFailureModes(NNTestCase):
         make_tensor = partial(torch.rand, size, device=device, dtype=dtype)
         q, k, v = make_tensor(), make_tensor(), make_tensor()
         with sdpa_kernel(backends=[SDPBackend.FLASH_ATTENTION]):
-            with self.assertWarnsRegex(UserWarning, "Expected query, key and value to all be of dtype: {Half, BFloat16}"):
-                self.assertRaises(RuntimeError, lambda: torch.nn.functional.scaled_dot_product_attention(
-                    q, k, v, None, 0.0, False))
+            with self.assertRaises(RuntimeError) as error:
+                torch.nn.functional.scaled_dot_product_attention(q, k, v, None, 0.0, False)
+            self.assert_rejected_backends_error(
+                error,
+                "Expected query, key and value to all be of dtype: {Half, BFloat16}",
+            )
 
     @onlyCUDA
     @unittest.skipIf(not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Does not support SDPA or pre-SM80 hardware")
@@ -1895,9 +1965,12 @@ class TestSDPAFailureModes(NNTestCase):
         q, k, v = make_tensor().transpose(1, 2), make_tensor().transpose(1, 2), make_tensor().transpose(1, 2)
 
         with sdpa_kernel(backends=[SDPBackend.FLASH_ATTENTION]):
-            with self.assertWarnsRegex(UserWarning, "For NestedTensor inputs, Flash attention requires"):
-                self.assertRaises(RuntimeError, lambda: torch.nn.functional.scaled_dot_product_attention(
-                    q, k, v, None, 0.0, False))
+            with self.assertRaises(RuntimeError) as error:
+                torch.nn.functional.scaled_dot_product_attention(q, k, v, None, 0.0, False)
+            self.assert_rejected_backends_error(
+                error,
+                "For NestedTensor inputs, Flash attention requires",
+            )
 
     @onlyCUDA
     @unittest.skipIf(not PLATFORM_SUPPORTS_FUSED_ATTENTION or not isLessThanSM80Device,
@@ -1971,10 +2044,14 @@ class TestSDPAFailureModes(NNTestCase):
         value = value.transpose(1, 2)
 
         with sdpa_kernel(backends=[SDPBackend.FLASH_ATTENTION]):
-            with self.assertWarnsRegex(UserWarning, "Both fused kernels do not support training with broadcasted NT inputs"):
-                with self.assertRaisesRegex(RuntimeError, "No available kernel"):
-                    torch.nn.functional.scaled_dot_product_attention(
-                        query, key, value, attn_mask=None, dropout_p=0.0, is_causal=False)
+            with self.assertRaises(RuntimeError) as error:
+                torch.nn.functional.scaled_dot_product_attention(
+                    query, key, value, attn_mask=None, dropout_p=0.0, is_causal=False
+                )
+            self.assert_rejected_backends_error(
+                error,
+                "Both fused kernels do not support training with broadcasted NT inputs",
+            )
 
     @onlyCUDA
     @unittest.skipIf(not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Does not support flash attention")
@@ -1985,11 +2062,13 @@ class TestSDPAFailureModes(NNTestCase):
         make_q = partial(torch.rand, q_shape, device=device, dtype=dtype)
         make_kv = partial(torch.rand, kv_shape, device=device, dtype=dtype)
         q, k, v = make_q(), make_kv(), make_kv()
-        warning_str = "Flash attention does not support the is_causal flag when seqlen_q != seqlen_k."
         with sdpa_kernel(backends=[SDPBackend.FLASH_ATTENTION]):
-            with self.assertWarnsRegex(UserWarning, warning_str):
-                self.assertRaises(RuntimeError, lambda: torch.nn.functional.scaled_dot_product_attention(
-                    q, k, v, None, 0.0, is_causal=True))
+            with self.assertRaises(RuntimeError) as error:
+                torch.nn.functional.scaled_dot_product_attention(q, k, v, None, 0.0, is_causal=True)
+            self.assert_rejected_backends_error(
+                error,
+                "Flash attention does not support the is_causal flag when seqlen_q != seqlen_k.",
+            )
 
     @onlyCUDA
     @unittest.skipIf(not PLATFORM_SUPPORTS_MEM_EFF_ATTENTION, "Does not support Efficient Attention")

--- a/torch/nested/_internal/sdpa.py
+++ b/torch/nested/_internal/sdpa.py
@@ -22,6 +22,61 @@ from .nested_tensor import NestedTensor
 log = logging.getLogger(__name__)
 
 
+def _record_sdp_failure(
+    message: str, debug: bool, reason_collector: list[str] | None
+) -> None:
+    if reason_collector is not None:
+        reason_collector.append(message)
+        return
+    if debug:
+        log.warning(message)
+
+
+def _raise_rejected_backends_error(
+    rejected_backends: list[tuple[str, list[str]]],
+) -> None:
+    message = "No available kernel. Aborting execution.\nRejected backends:"
+    for backend_name, reasons in rejected_backends:
+        if not reasons:
+            continue
+        message = f"{message}\n{backend_name}: {reasons[0]}"
+        for reason in reasons[1:]:
+            message = f"{message}\n  - {reason}"
+    raise RuntimeError(message)
+
+
+def _raise_nested_sdp_backend_error(params: SDPAParams) -> None:
+    efficient_reasons = []
+    if not mem_efficient_sdp_enabled():
+        efficient_reasons.append(
+            "Memory Efficient attention has been runtime disabled."
+        )
+    _can_use_efficient_sdpa_jagged(params, reason_collector=efficient_reasons)
+
+    flash_reasons = []
+    if not flash_sdp_enabled():
+        flash_reasons.append("Flash attention has been runtime disabled.")
+    _can_use_flash_sdpa_jagged(params, reason_collector=flash_reasons)
+
+    math_reasons = []
+    if not math_sdp_enabled():
+        math_reasons.append("Math attention has been runtime disabled.")
+    _can_use_math_sdpa_jagged(params, reason_collector=math_reasons)
+
+    cudnn_reasons = []
+    if not cudnn_sdp_enabled():
+        cudnn_reasons.append("cuDNN attention has been runtime disabled.")
+
+    _raise_rejected_backends_error(
+        [
+            ("Memory efficient attention", efficient_reasons),
+            ("Flash attention", flash_reasons),
+            ("Math attention", math_reasons),
+            ("cuDNN attention", cudnn_reasons),
+        ]
+    )
+
+
 def _validate_sdpa_input(
     query: torch.Tensor,
     key: torch.Tensor,
@@ -73,7 +128,9 @@ def _validate_sdpa_input(
             )
 
 
-def _check_batch_size_nested(params: SDPAParams, debug=False) -> bool:
+def _check_batch_size_nested(
+    params: SDPAParams, debug=False, reason_collector: list[str] | None = None
+) -> bool:
     # This is expected to be called after check_tensor_shapes ensuring that the
     # size() calls won't error since the inputs are all 4 dimensional
     q_batch_size = params.query.size(0)
@@ -83,10 +140,22 @@ def _check_batch_size_nested(params: SDPAParams, debug=False) -> bool:
     # num_heads logic for nested input is checked in
     # check_for_seq_len_0_nested_tensor as there is handling there to make sure
     # num_heads is not ragged
-    return q_batch_size == k_batch_size and q_batch_size == v_batch_size
+    same_batch_size = q_batch_size == k_batch_size and q_batch_size == v_batch_size
+    if not same_batch_size:
+        _record_sdp_failure(
+            "For NestedTensor inputs, query, key, and value must have the same batch size. "
+            f"Got query batch size: {q_batch_size}, key batch size: {k_batch_size}, "
+            f"value batch size: {v_batch_size} instead.",
+            debug,
+            reason_collector,
+        )
+        return False
+    return True
 
 
-def _check_head_dim_size_flash_nested(params: SDPAParams, debug=False) -> bool:
+def _check_head_dim_size_flash_nested(
+    params: SDPAParams, debug=False, reason_collector: list[str] | None = None
+) -> bool:
     max_size = 256
     query_size_last = params.query.size(-1)
     key_size_last = params.key.size(-1)
@@ -99,15 +168,14 @@ def _check_head_dim_size_flash_nested(params: SDPAParams, debug=False) -> bool:
         and (query_size_last % 8 == 0)
         and (query_size_last <= max_size)
     ):
-        if debug:
-            log.warning(
-                "For NestedTensor inputs, Flash attention requires q,k,v to have the same "
-                "last dimension and to be a multiple of 8 and less than or equal to 256. "
-                "Got Query.size(-1): %d, Key.size(-1): %d, Value.size(-1): %d instead.",
-                query_size_last,
-                key_size_last,
-                value_size_last,
-            )
+        _record_sdp_failure(
+            "For NestedTensor inputs, Flash attention requires q,k,v to have the same "
+            "last dimension and to be a multiple of 8 and less than or equal to 256. "
+            f"Got Query.size(-1): {query_size_last}, Key.size(-1): {key_size_last}, "
+            f"Value.size(-1): {value_size_last} instead.",
+            debug,
+            reason_collector,
+        )
         return False
     return True
 
@@ -139,60 +207,64 @@ def _check_head_dim_size_cudnn_nested(params: SDPAParams, debug=False) -> bool:
 
 
 def _check_for_seq_len_0_and_consistent_head_dim_nested_helper(
-    param: torch.Tensor, param_name: str, debug=False
+    param: torch.Tensor,
+    param_name: str,
+    debug=False,
+    reason_collector: list[str] | None = None,
 ) -> bool:
     if not isinstance(param, NestedTensor):
         raise AssertionError("param should be a jagged NT")
 
     if param._ragged_idx == 1:
-        # num_head_dims is ragged
-        if debug:
-            log.warning(
-                "Fused kernels do not support ragged num_head_dims, %s has a ragged num_heads.",
-                param_name,
-            )
+        _record_sdp_failure(
+            f"Fused kernels do not support ragged num_head_dims, {param_name} has a ragged num_heads.",
+            debug,
+            reason_collector,
+        )
         return False
 
-    # This is being called inside sdp with shape [batch, heads, {seq_len}, dim]
     if param._get_min_seqlen() == 0:
-        if debug:
-            log.warning(
-                "Fused kernels do not support seq_len == 0, %s has a seq len of 0.",
-                param_name,
-            )
+        _record_sdp_failure(
+            f"Fused kernels do not support seq_len == 0, {param_name} has a seq len of 0.",
+            debug,
+            reason_collector,
+        )
         return False
 
     return True
 
 
-def _try_broadcast_param_size(q_size, k_size, v_size, param_name, debug=False) -> bool:
+def _try_broadcast_param_size(
+    q_size,
+    k_size,
+    v_size,
+    param_name,
+    debug=False,
+    reason_collector: list[str] | None = None,
+) -> bool:
     max_size = max(q_size, k_size, v_size)
     if (
         (q_size != max_size and q_size != 1)
         or (k_size != max_size and k_size != 1)
         or (v_size != max_size and v_size != 1)
     ):
-        if debug:
-            log.warning(
-                "Both fused kernels require query, key and value to have broadcastable %s, "
-                "got Query %s %d, Key %s %d, Value %s %d instead.",
-                param_name,
-                param_name,
-                q_size,
-                param_name,
-                k_size,
-                param_name,
-                v_size,
-            )
+        _record_sdp_failure(
+            "Both fused kernels require query, key and value to have broadcastable "
+            f"{param_name}, got Query {param_name} {q_size}, Key {param_name} {k_size}, "
+            f"Value {param_name} {v_size} instead.",
+            debug,
+            reason_collector,
+        )
         return False
     return True
 
 
-def _check_for_seq_len_0_nested(params: SDPAParams, debug=False) -> bool:
-    # When this function is called we are assured that the nt is dim==4
+def _check_for_seq_len_0_nested(
+    params: SDPAParams, debug=False, reason_collector: list[str] | None = None
+) -> bool:
     q_is_safe = (
         _check_for_seq_len_0_and_consistent_head_dim_nested_helper(
-            params.query, "query", debug
+            params.query, "query", debug, reason_collector
         )
         if params.query.is_nested
         else True
@@ -203,7 +275,7 @@ def _check_for_seq_len_0_nested(params: SDPAParams, debug=False) -> bool:
 
     k_is_safe = (
         _check_for_seq_len_0_and_consistent_head_dim_nested_helper(
-            params.key, "key", debug
+            params.key, "key", debug, reason_collector
         )
         if params.key.is_nested
         else True
@@ -214,7 +286,7 @@ def _check_for_seq_len_0_nested(params: SDPAParams, debug=False) -> bool:
 
     v_is_safe = (
         _check_for_seq_len_0_and_consistent_head_dim_nested_helper(
-            params.value, "value", debug
+            params.value, "value", debug, reason_collector
         )
         if params.value.is_nested
         else True
@@ -242,50 +314,63 @@ def _check_for_seq_len_0_nested(params: SDPAParams, debug=False) -> bool:
                 )
             return False
         return _try_broadcast_param_size(
-            q_num_heads, k_num_heads, v_num_heads, "num heads", debug
+            q_num_heads,
+            k_num_heads,
+            v_num_heads,
+            "num heads",
+            debug,
+            reason_collector,
         )
     return True
 
 
-def _can_use_flash_sdpa_jagged(params: SDPAParams, debug=False) -> bool:
+def _can_use_flash_sdpa_jagged(
+    params: SDPAParams, debug=False, reason_collector: list[str] | None = None
+) -> bool:
     constraints = (
         _check_batch_size_nested,
         _check_head_dim_size_flash_nested,
         _check_for_seq_len_0_nested,
     )
     for constraint in constraints:
-        if not constraint(params, debug):
+        if not constraint(params, debug, reason_collector):
             return False
     return True
 
 
-def _can_use_efficient_sdpa_jagged(params: SDPAParams, debug=False) -> bool:
+def _can_use_efficient_sdpa_jagged(
+    params: SDPAParams, debug=False, reason_collector: list[str] | None = None
+) -> bool:
     constraints = (
         _check_batch_size_nested,
         _check_for_seq_len_0_nested,
     )
     for constraint in constraints:
-        if not constraint(params, debug):
+        if not constraint(params, debug, reason_collector):
             return False
     return True
 
 
-def _can_use_math_sdpa_jagged(params: SDPAParams, debug=False) -> bool:
+def _can_use_math_sdpa_jagged(
+    params: SDPAParams, debug=False, reason_collector: list[str] | None = None
+) -> bool:
     if (
         not params.query.transpose(1, 2).is_contiguous()
         or not params.key.transpose(1, 2).is_contiguous()
         or not params.value.transpose(1, 2).is_contiguous()
     ):
-        if debug:
-            log.warning(
-                "If inputs are nested tensors they must be contiguous after transposing."
-            )
+        _record_sdp_failure(
+            "If inputs are nested tensors they must be contiguous after transposing.",
+            debug,
+            reason_collector,
+        )
         return False
     if params.is_causal:
-        if debug:
-            log.warning(
-                "Nested tensors for query / key are not supported when is_causal=True."
-            )
+        _record_sdp_failure(
+            "Nested tensors for query / key are not supported when is_causal=True.",
+            debug,
+            reason_collector,
+        )
         return False
     return True
 
@@ -324,16 +409,6 @@ def _select_sdp_backend(query, key, value, attn_mask, dropout, is_causal, enable
             if math_sdp_enabled() and _can_use_math_sdpa_jagged(params):
                 return SDPBackend.MATH
 
-    log.warning("Memory efficient kernel not used because:")
-    can_use_efficient_attention(params, debug=True)
-    _can_use_efficient_sdpa_jagged(params, debug=True)
-    log.warning("Flash attention kernel not used because:")
-    can_use_flash_attention(params, debug=True)
-    _can_use_flash_sdpa_jagged(params, debug=True)
-    log.warning("Math attention kernel not used because:")
-    _can_use_math_sdpa_jagged(params, debug=True)
-    log.warning("cuDNN attention kernel not used because:")
-    can_use_cudnn_attention(params, debug=True)
     return SDPBackend.ERROR
 
 
@@ -931,6 +1006,6 @@ def jagged_scaled_dot_product_attention(
 
         return attn_out
     else:
-        raise RuntimeError(
-            "No viable backend for scaled_dot_product_attention was found."
+        _raise_nested_sdp_backend_error(
+            SDPAParams(query, key, value, attn_mask, dropout_p, is_causal, enable_gqa)
         )


### PR DESCRIPTION
## Human Note
This is something I have wanted to do for a while but wasn't high enough pri for me to deal with all the c++ templates. This brings the older error message from 
```Py
❯ python repro_sdpa_no_backend.py
/home/drisspg/.ptq_workspace/jobs/20260311-adhoc-e9e0a9/repro_sdpa_no_backend.py:40: UserWarning: Memory efficient kernel not used because: (Triggered internally at /pytorch/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp:999.)
  F.scaled_dot_product_attention(q, k, v)
/home/drisspg/.ptq_workspace/jobs/20260311-adhoc-e9e0a9/repro_sdpa_no_backend.py:40: UserWarning: Memory Efficient attention has been runtime disabled. (Triggered internally at /pytorch/aten/src/ATen/native/transformers/sdp_utils_cpp.h:552.)
  F.scaled_dot_product_attention(q, k, v)
/home/drisspg/.ptq_workspace/jobs/20260311-adhoc-e9e0a9/repro_sdpa_no_backend.py:40: UserWarning: Flash attention kernel not used because: (Triggered internally at /pytorch/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp:1001.)
  F.scaled_dot_product_attention(q, k, v)
/home/drisspg/.ptq_workspace/jobs/20260311-adhoc-e9e0a9/repro_sdpa_no_backend.py:40: UserWarning: All fused kernels requires query, key and value to be 4 dimensional, but got Query dim: 3, Key dim: 3, Value dim: 3 instead. (Triggered internally at /pytorch/aten/src/ATen/native/transformers/sdp_utils_cpp.h:308.)
  F.scaled_dot_product_attention(q, k, v)
/home/drisspg/.ptq_workspace/jobs/20260311-adhoc-e9e0a9/repro_sdpa_no_backend.py:40: UserWarning: cuDNN attention kernel not used because: (Triggered internally at /pytorch/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp:1003.)
  F.scaled_dot_product_attention(q, k, v)
Traceback (most recent call last):
  File "/home/drisspg/.ptq_workspace/jobs/20260311-adhoc-e9e0a9/repro_sdpa_no_backend.py", line 64, in <module>
    cuda_repro()
    ~~~~~~~~~~^^
  File "/home/drisspg/.ptq_workspace/jobs/20260311-adhoc-e9e0a9/repro_sdpa_no_backend.py", line 40, in cuda_repro
    F.scaled_dot_product_attention(q, k, v)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
RuntimeError: No available kernel. Aborting execution.
```

To
```Py
❯ python repro_sdpa_no_backend.py
Traceback (most recent call last):
  File "/home/drisspg/.ptq_workspace/jobs/20260311-adhoc-e9e0a9/repro_sdpa_no_backend.py", line 64, in <module>
    cuda_repro()
  File "/home/drisspg/.ptq_workspace/jobs/20260311-adhoc-e9e0a9/repro_sdpa_no_backend.py", line 40, in cuda_repro
    F.scaled_dot_product_attention(q, k, v)
RuntimeError: No available kernel. Aborting execution.
Rejected backends:
Memory efficient attention: Memory Efficient attention has been runtime disabled.
Flash attention: All fused kernels requires query, key and value to be 4 dimensional, but got Query dim: 3, Key dim: 3, Value dim: 3 instead.
cuDNN attention: Torch was not compiled with cuDNN attention.

```

Which pleases me

## Agent Report
# SDPA No-Backend Failure Refactor

## Summary

Implemented a fresh SDPA selector diagnostics refactor that keeps the successful selector path side-effect free while replacing terminal warning spam with one aggregated error message containing backend rejection reasons.

The shared helper path now uses an optional `SDPDiagnostics` context carried via `c10::OptionalRef`. Public `can_use_*(_, debug)` APIs remain stable and still support immediate warning emission, while CPU and CUDA selector terminal failures now defer diagnostics collection and raise a single aggregated exception.

## Code Changes

- Added `SDPDiagnostics` and `report_failure` / `report_failure_once` helpers in `aten/src/ATen/native/transformers/sdp_utils_cpp.h`.
- Updated shared SDPA helper checks to accept optional diagnostics instead of raw `bool debug`.
- Refactored CPU selector failure handling in `aten/src/ATen/native/transformers/sdp_utils_cpp.cpp`.
- Refactored CUDA selector failure handling in `aten/src/ATen/native/transformers/cuda/sdp_utils.cpp`.
- Added focused regression coverage in `test/test_transformers.py`.
- Added standalone runtime repro `repro_sdpa_no_backend.py`.

## Runtime Verification

Observed rebuilt CUDA runtime error:

```text
No available kernel. Aborting execution.
Rejected backends:
Memory efficient attention: Memory Efficient attention has been runtime disabled.
Flash attention: All fused kernels requires query, key and value to be 4 dimensional, but got Query dim: 3, Key dim: 3, Value dim: 3 instead.
cuDNN attention: Torch was not compiled with cuDNN attention.
```

## Validation

- `bash ~/.ptq_workspace/scripts/rebuild.sh ~/.ptq_workspace/jobs/20260311-adhoc-e9e0a9/pytorch`
- `~/.ptq_workspace/jobs/20260311-adhoc-e9e0a9/.venv/bin/python repro_sdpa_no_backend.py`
- `~/.ptq_workspace/jobs/20260311-adhoc-e9e0a9/.venv/bin/pytest pytorch/test/test_transformers.py -k 'no_backend_aggregates_rejections' -xvs`
- `~/.ptq_workspace/jobs/20260311-adhoc-e9e0a9/.venv/bin/python -m spin fixlint`

Focused test result: `3 passed, 1 skipped`.

## Full Suite Status

The full `pytorch/test/test_transformers.py` rerun that was started on March 12, 2026 is not confirmed complete in the saved artifacts.

- `agent_logs/codex-3.log` shows the rerun command was launched with the job interpreter.
- The log includes progress updates indicating the run had advanced deep into the CUDA-heavy section without a recorded failure.
- The same log does not include a pytest completion summary or exit code for that command.
- A process check during this run found no active `pytest` process, so the previous run is no longer executing, but its final result was not captured.

Current status: not confirmed green.

## Run 6 - Warn enum usage audit

I checked whether `SDPDiagnosticMode::warn` is dead after the SDPA diagnostics refactor.

It is still used:
- CUDA `can_use_cudnn_attention(params, bool debug)` constructs `SDPDiagnostics(SDPDiagnosticMode::warn)` when `debug` is true.
- CUDA `can_use_flash_attention(params, bool debug)` constructs `SDPDiagnostics(SDPDiagnosticMode::warn)` when `debug` is true.
- CUDA `can_use_mem_efficient_attention(params, bool debug)` constructs `SDPDiagnostics(SDPDiagnosticMode::warn)` when `debug` is true.
- Those wrappers back the public Python APIs in `torch.backends.cuda.can_use_*`, which explicitly expose `debug: bool = False`.
- PyTorch Python code still calls the warning path directly, for example `torch/nn/attention/__init__.py` invokes `can_use_efficient_attention(params, True)` and `can_use_flash_attention(params, True)` when `WARN_FOR_UNFUSED_KERNELS` is enabled.
- CPU and CUDA selector terminal failure paths construct `SDPDiagnostics(SDPDiagnosticMode::raise)` to aggregate backend rejection reasons before throwing.

Recommendation: keep the two-mode behavior unless we also refactor the public `debug=true` API path. If we want to simplify the implementation shape, the enum could be replaced with a boolean like `emit_warnings` or with two narrower helper types, but `warn` itself is not unused.

## Run 7 - Boolean diagnostics cleanup

Replaced the internal `SDPDiagnosticMode` enum with a single `bool emit_warnings` field on `SDPDiagnostics`.

- `true` now represents the existing debug-warning path used by the public `can_use_*(_, debug)` wrappers.
- `false` now represents the deferred aggregation path used by CPU and CUDA terminal selector failures.
- No external API shape changed; this only simplified the internal representation of the two-state diagnostics behavior.

Validation after the cleanup:

- `bash ~/.ptq_workspace/scripts/rebuild.sh ~/.ptq_workspace/jobs/20260311-adhoc-e9e0a9/pytorch`
- `~/.ptq_workspace/jobs/20260311-adhoc-e9e0a9/.venv/bin/python repro_sdpa_no_backend.py`
- `~/.ptq_workspace/jobs/20260311-adhoc-e9e0a9/.venv/bin/python -m pytest pytorch/test/test_transformers.py -k 'no_backend_aggregates_rejections' -xvs`
- `~/.ptq_workspace/jobs/20260311-adhoc-e9e0a9/.venv/bin/python -m spin fixlint`

Results:

- `repro_sdpa_no_backend.py`: `cpu_repro: ok`, `cuda_repro: ok`
- Focused pytest run: `3 passed, 1 skipped`
- `spin fixlint`: passed with no lint issues

## Run 8 - Benchmark removal

Removed `pytorch/benchmarks/transformer/sdpa_selector.py`.

Reasoning:

- The benchmark was a temporary investigation artifact used to sanity-check the selector debug path during the refactor.
- It is not needed to preserve or verify the shipped behavior change, which is the aggregated no-backend error and the retained public `debug` warning path.
- Keeping it would add maintenance surface without a clear ongoing need.

Validation:

- `~/.ptq_workspace/jobs/20260311-adhoc-e9e0a9/.venv/bin/python -m spin fixlint`

<details>
<summary>Agent Worklog</summary>

## Run 1

> **User:** Recreate the SDPA no-backend failure refactor and final cleanup pass as a fresh, self-contained implementation.

Do not rely on prior job artifacts or old reports. Treat everything you need as being in this prompt plus the codebase itself.

Goal:
Replace the current warning-then-throw behavior in the SDPA backend selectors with a design that preserves a minimal-overhead hot path but, on terminal failure, raises one aggregated error containing the backend rejection reasons.

User intent and scope:
- Research outcome is already approved.
- Implement the fix.
- Rebuild and verify it actually runs.
- Add focused regression coverage and a standalone repro for the improved error message shape.
- Add a focused performance check for the non-debug path.
- Then do a final simplification pass that preserves exact behavior.
- Keep scope tight to this SDPA error-path work only.

Target source areas:
- `aten/src/ATen/native/transformers/cuda/sdp_utils.cpp`
- `aten/src/ATen/native/transformers/sdp_utils_cpp.cpp`
- `aten/src/ATen/native/transformers/sdp_utils_cpp.h`
- `test/test_transformers.py`
- If needed for the perf check: `benchmarks/transformer/sdpa_selector.py`

Required design constraints:
- Keep the successful selector path side-effect free and as cheap as possible.
- Do not emit multiple warnings before throwing on the final no-backend path.
- Replace the old `bool debug` warning plumbing in the shared helpers with a safer optional diagnostics type.
- Prefer `c10::OptionalRef<...>` for the optional diagnostics path.
- Keep the exported `can_use_*` public bool-debug API stable if possible.
- Support two behaviors through the same diagnostic mechanism:
  - immediate warning emission for APIs that still want warnings
  - deferred failure aggregation for terminal selector failure
- Normalize any `TORCH_WARN_ONCE`-style edge cases under the new diagnostic flow.
- The thrown terminal error should start with `No available kernel. Aborting execution.` and then include a `Rejected backends:` section with backend-specific reasons.
- Preserve backend ordering semantics.
- Avoid speculative cleanup outside this change.

Implementation shape to aim for:
- Introduce a diagnostic context type in the shared SDPA header, with an explicit mode for warn-vs-raise behavior.
- Thread an optional borrowed reference to that context through the shared helper checks.
- Add small helper entry points like `report_failure(...)` and `report_failure_once(...)` so the existing checks can either warn or collect strings.
- Update both CPU and CUDA selector codepaths to use the new mechanism.
- Ensure the richer selector error is not overwritten later by a generic follow-up throw.

Expected runtime behavior after the fix:
- Instead of warning spam followed by a generic error, runtime should raise one aggregated error.
- On this machine, a representative CUDA failure should include lines like:
  - `No available kernel. Aborting execution.`
  - `Rejected backends:`
  - `Memory efficient attention: Memory Efficient attention has been runtime disabled.`
  - `Flash attention: All fused kernels requires query, key and value to be 4 dimensional, but got Query dim: 3, Key dim: 3, Value dim: 3 instead.`
  - `cuDNN attention: Torch was not compiled with cuDNN attention.`

Regression coverage to add or update:
- A focused CPU test that asserts the aggregated message contains:
  - the `No available kernel. Aborting execution.` header
  - `Rejected backends:`
  - the flash backend rejection reason
- A focused CUDA test that asserts the aggregated message contains:
  - the same header
  - `Rejected backends:`
  - memory-efficient, flash, and cuDNN backend rejection reasons

Standalone repro to produce:
- Add a standalone repro script in the job artifacts directory that exercises the improved error message shape.
- It should fail if the aggregated substrings are missing.
- It should be suitable for quickly checking the runtime behavior after rebuilds.

Performance requirement:
- Add a focused performance check for the selector eligibility helpers so we can confirm no measurable slowdown on the non-debug path.
- A good shape is a microbenchmark around:
  - `torch.backends.cuda.can_use_flash_attention`
  - `torch.backends.cuda.can_use_efficient_attention`
  - `torch.backends.cuda.can_use_cudnn_attention`
- Compare `debug=False` vs `debug=True` on an eligible CUDA configuration.
- If you create a benchmark script, include an option that can fail on a non-debug/debug regression ratio threshold.

Validation checklist you must complete:
- Run `python -m spin fixlint` with the job interpreter from the system prompt.
- Rebuild using the job rebuild script from the system prompt.
- Run the standalone repro script with the job interpreter.
- Run focused unittests for the CPU and CUDA aggregated-error coverage.
- If you add the benchmark script, run it too.

Important runtime verification detail:
- Do not stop at source inspection or syntax checks.
- Verify the rebuilt runtime actually shows the new aggregated error directly.
- If the runtime still shows the old multi-warning behavior, investigate the active loaded libraries and fix the rebuild/install mismatch rather than assuming the source change failed.
- Final expected state is that the rebuild flow itself is sufficient and no manual library copy step is needed.

Final simplification pass requirements:
After the main implementation is working, do a small semantics-preserving cleanup limited to the touched SDPA files. Desired final shape includes:
- inline single-use temporaries where it clearly improves clarity
- reuse existing local head-dimension values instead of re-reading tensor sizes
- prefer `const auto&` in selector loops where appropriate
- fix small formatting or indentation inconsistencies only if behavior is unchanged

Deliverables:
- working code changes
- focused regression tests
- standalone repro script in the job artifacts directory
- focused perf check or benchmark
- `report.md`, `fix.diff`, and `worklog.md`
- run `spin fixlint` on the diff before finishing

## Exploration
- Inspected SDPA CPU/CUDA selector codepaths and shared helper signatures in `pytorch/aten/src/ATen/native/transformers/{sdp_utils_cpp.h,sdp_utils_cpp.cpp,cuda/sdp_utils.cpp}`.
- Confirmed current terminal failure path reruns backend checks with `debug=true`, emits warnings, then throws a generic `No available kernel` error.
- Located existing transformer failure tests that currently assert warning behavior or generic no-backend errors.

## Design Direction
- Implement a shared diagnostics context carried via `c10::OptionalRef` so the hot path stays side-effect free when no diagnostics are requested.
- Use the same context for immediate warning emission and deferred backend rejection aggregation in selector terminal failure paths.

## Implementation
- Added a shared `SDPDiagnostics` context to `sdp_utils_cpp.h` with warn-vs-raise modes and helper entry points for normal and once-style failures.
- Threaded `c10::OptionalRef<SDPDiagnostics>` through the shared SDPA helper checks and both CPU/CUDA selector codepaths while keeping the public `can_use_*(_, debug)` API shape intact.
- Replaced selector warning spam with deferred backend-specific aggregation on terminal failure.

## Regression Coverage
- Added focused CPU and CUDA tests in `pytorch/test/test_transformers.py` for the aggregated `Rejected backends:` error shape.
- Added `repro_sdpa_no_backend.py` in the job directory and `pytorch/benchmarks/transformer/sdpa_selector.py` for runtime verification and selector microbenchmarking.

## Validation
- Rebuilt the job worktree successfully with `bash ~/.ptq_workspace/scripts/rebuild.sh ~/.ptq_workspace/jobs/20260311-adhoc-e9e0a9/pytorch`.
- Verified the rebuilt runtime with `repro_sdpa_no_backend.py`; observed a direct aggregated CUDA error containing the memory-efficient, flash, and cuDNN rejection reasons with no warning spam before the throw.
- Ran focused transformer coverage: `~/.ptq_workspace/jobs/20260311-adhoc-e9e0a9/.venv/bin/pytest pytorch/test/test_transformers.py -k 'no_backend_aggregates_rejections' -xvs` -> 3 passed, 1 skipped.
- Ran selector microbenchmark: flash ratio 1.002, efficient ratio 1.011, cuDNN skipped as ineligible on this runtime.
- Ran `~/.ptq_workspace/jobs/20260311-adhoc-e9e0a9/.venv/bin/python -m spin fixlint` successfully.



## Run 2

> **User:** Run the full pytorch/test/test_transformers.py suite, fix any failing tests caused by this change, update tests/implementation as needed to preserve the new aggregated SDPA failure behavior, then rerun until green.

### Run 2 - Environment preflight
- Checked `which python` and `which pytest`; both resolved outside the job environment.
- Using `~/.ptq_workspace/jobs/20260311-adhoc-e9e0a9/.venv/bin/python -m pytest` for all Python and test commands in this run.
- Starting the full `pytorch/test/test_transformers.py` suite to find regressions from the SDPA diagnostics change.
### Run 2 - Full suite first failure
- Ran `~/.ptq_workspace/jobs/20260311-adhoc-e9e0a9/.venv/bin/python -m pytest pytorch/test/test_transformers.py -xvs`.
- Suite reached CUDA SDPA failure-mode coverage before the first regression.
- `TestSDPAFailureModesCUDA.test_dispatch_fails_no_backend_cuda` still expected the old `No viable backend for scaled_dot_product_attention was found.` string.
- Actual runtime now raises the aggregated selector failure message beginning with `No available kernel. Aborting execution.` and a `Rejected backends:` section.
### Run 2 - Updated stale CUDA expectation
- Updated `TestSDPAFailureModes.test_dispatch_fails_no_backend` in `pytorch/test/test_transformers.py`.
- Replaced the stale regex for the old generic no-backend message with direct assertions against the aggregated error via `assert_rejected_backends_error`.
- The test now checks both `torch._fused_sdp_choice` and `scaled_dot_product_attention` for the new `Rejected backends:` failure shape.
### Run 2 - Second full-suite regression
- Reran the full suite after fixing `test_dispatch_fails_no_backend`.
- Next failure is `TestSDPAFailureModesCUDA.test_flash_attention_fail_with_non_square_causal_attention_cuda`.
- The test still expects `UserWarning` emission for a terminal flash-attention rejection, but the selector now defers that reason into the raised aggregated error instead of warning first.
### Run 2 - Updated non-square causal flash failure test
- Reproduced the flash-only non-square causal failure directly to inspect the new runtime message.
- Confirmed the failure now raises an aggregated error with `Rejected backends:` and the flash-specific non-square causal rejection reason.
- Updated `test_flash_attention_fail_with_non_square_causal_attention` to assert that aggregated error instead of requiring a pre-throw warning.
### Run 2 - Third full-suite regression
- Full-suite rerun progressed further and found another stale CUDA expectation: `test_flash_fail_fp32_cuda`.
- This test also required a pre-throw `UserWarning` for a flash-only terminal rejection.
- The new diagnostics flow instead carries the dtype rejection reason in the aggregated runtime error, so I am auditing similar flash-only warning assertions in this section together.
### Run 2 - Converted more flash-only terminal warning tests
- Focused flash-only rerun showed `test_fused_kernels_nested_broadcasting_requires_grad_failure_cuda` also expected a warning that is now deferred into the aggregated exception.
- Updated that test and `test_nested_fails_on_padding_head_dim` to assert the backend rejection text via `assert_rejected_backends_error`.
- `test_flash_fail_fp32` was updated in the same style for flash-only dtype rejection.
### Run 2 - Converted remaining terminal warning assertions in early failure-mode coverage
- The next full-suite failure showed the same issue for `test_invalid_fused_inputs_dim_3`.
- Updated additional terminal rejection tests to assert aggregated backend reasons instead of warning side effects: invalid 3D fused inputs, invalid last-dimension stride, invalid mask stride, and grouped-query rejection.
- These changes keep backend-specific rejection coverage while matching the new selector behavior.
### Run 2 - Tightened grouped-query assertion
- Focused rerun showed the grouped-query rejection text differs slightly from the previous warning string.
- Updated the expected substring to match the aggregated backend rejection wording (`For dense input ... same num_heads.`).
- Returning to full-suite validation.


## Run 3

> **User:** lets double check if it ran green


### Agent Summary (auto-extracted)
The run is deep into the CUDA-heavy section and still hasn’t hit a failure. I’m waiting for pytest’s final summary now rather than inferring from partial progress.



## Run 4

> **User:** Has it finished?

### Run 4 - Status check
- Checked for an active `pytest` or `test_transformers.py` process; none is running now.
- Inspected `agent_logs/codex-3.log`, which shows the full-suite rerun was started with `~/.ptq_workspace/jobs/20260311-adhoc-e9e0a9/.venv/bin/python -m pytest pytorch/test/test_transformers.py -xvs`.
- That log contains progress updates through the CUDA-heavy portion of the file but does not contain a completion record, pytest terminal summary, or exit code for the rerun command.
- Conclusion: the full `pytorch/test/test_transformers.py` suite is not confirmed green from the recorded artifacts. The last verified state is that it was still progressing without a seen failure when logging stopped.


## Run 5

> **User:** re-run but in a way that will we save the toutptu sos that we can ensure it rusn to completion as it will take a long time to run

### Run 5 - Logged rerun plan
- Preparing a new full-suite rerun of `pytorch/test/test_transformers.py` with persistent output capture.
- The run will use the job interpreter and save combined stdout/stderr to a timestamped log in `agent_logs/` via `tee`, so completion status and final pytest summary are preserved.

### Run 5 - Logged rerun started
- Started the full rerun in a persistent shell session with:
  `~/.ptq_workspace/jobs/20260311-adhoc-e9e0a9/.venv/bin/python -m pytest pytorch/test/test_transformers.py -xvs 2>&1 | tee agent_logs/test_transformers_full_20260312_124231.log`
- Confirmed the pytest process is active and that output is being written to `agent_logs/test_transformers_full_20260312_124231.log`.


## Run 6

> **User:** Do we actuallly need the warn enum like is that even used anywehre?


## Run 6 - Warn enum usage audit
- Searched the SDPA diagnostics refactor call sites to verify whether `SDPDiagnosticMode::warn` is live or dead.
- Confirmed `warn` is constructed in the CUDA public `can_use_*(_, debug)` wrappers, where `debug=true` preserves warning-emission behavior.
- Confirmed the Python surface still exposes and uses that warning path via `torch.backends.cuda.can_use_*` and `torch/nn/attention/__init__.py`.
- Confirmed `raise` is constructed in the CPU and CUDA selector terminal-failure paths to aggregate backend rejection reasons before throwing.
- Conclusion from source inspection: the enum is used today. It could be collapsed to a boolean or split API if we want a smaller type, but removing the warn mode outright would break the public debug-warning path.


## Run 7

> **User:** Yeah lets replace wih a boolean as there are only 2 states

### Run 7 - Replaced diagnostics mode enum with boolean
- Narrowed `SDPDiagnostics` in `pytorch/aten/src/ATen/native/transformers/sdp_utils_cpp.h` from a two-value enum to a single `bool emit_warnings` field.
- Updated CPU and CUDA construction sites so debug-warning paths pass `true` and deferred aggregation paths pass `false`.
- No API behavior change is intended; this is a representation simplification only.
### Run 7 - Validation after boolean cleanup
- Rebuilt the job worktree with `bash ~/.ptq_workspace/scripts/rebuild.sh ~/.ptq_workspace/jobs/20260311-adhoc-e9e0a9/pytorch` after the C++ header/callsite update.
- Ran `~/.ptq_workspace/jobs/20260311-adhoc-e9e0a9/.venv/bin/python repro_sdpa_no_backend.py`; both CPU and CUDA repro paths passed.
- Ran `~/.ptq_workspace/jobs/20260311-adhoc-e9e0a9/.venv/bin/python -m pytest pytorch/test/test_transformers.py -k 'no_backend_aggregates_rejections' -xvs`; result was 3 passed, 1 skipped.
- Ran `~/.ptq_workspace/jobs/20260311-adhoc-e9e0a9/.venv/bin/python -m spin fixlint`; it completed cleanly with no lint issues.


## Run 8

> **User:** benchmarks/transformer/sdpa_selector.py lets remove this I belive that there is no overhead

### Run 8 - Removed selector microbenchmark artifact
- Deleted `pytorch/benchmarks/transformer/sdpa_selector.py`.
- The benchmark was only added as a one-off validation artifact for the earlier refactor and is not required to preserve the aggregated SDPA failure behavior.
- Keeping it would leave extra benchmark surface area without an ongoing product need, so the deliverable is now limited to the runtime repro and test coverage.

### Run 8 - Lint refresh after benchmark removal
- Ran `~/.ptq_workspace/jobs/20260311-adhoc-e9e0a9/.venv/bin/python -m spin fixlint` from `pytorch/`.
- The lint run completed cleanly and did not surface issues related to removing the benchmark file.


## Run 9

> **User:** for (const auto reason_index : c10::irange<size_t>(1, reasons.size())) {
        message << "\n  - " << reasons[reason_index];
      } 
why do we needot use an index cant we do auto loosps and jsut add them to the message?

### Run 9 - Reason-index formatting audit
- Inspected `pytorch/aten/src/ATen/native/transformers/sdp_utils_cpp.h` where the aggregated `Rejected backends:` message is assembled.
- The index is not required for correctness by itself; it is only being used to skip `reasons.front()`, which is emitted inline with the backend label as `Backend: first reason`.
- The remaining reasons are then emitted as indented bullet lines, so the current loop shape avoids duplicating the first entry.
- A range-based loop would also work if we changed the formatting strategy, for example by tracking a `bool first_reason` or by rendering every reason in a uniform bullet format.

</details>

---
*This PR was generated by [ptq](https://github.com/drisspg/pt_job_queue) with human review.*

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01 @liangel-02 @howardzhang-cv