### PR TITLE
Fix staged CUDA FFT meta strides

### DIFF
--- a/test/test_meta.py
+++ b/test/test_meta.py
@@ -1698,6 +1698,32 @@ class TestMeta(TestCase):
         )
         self.assertEqual(grad_weight.to('meta'), meta_grad_weight)
 
+    def _assert_fft_meta_stride_matches_eager(self, op, *args):
+        to_meta = MetaConverter()
+        meta_args = tree_map_only(torch.Tensor, to_meta, args)
+        ref_out = op(*args)
+        meta_out = op(*meta_args)
+        self.assertEqual(ref_out.size(), meta_out.size())
+        self.assertEqual(ref_out.stride(), meta_out.stride())
+
+    @onlyCUDA
+    @unittest.skipIf(torch.version.hip, "cuFFT-specific stride behavior")
+    def test_fft_multi_dim_cufft_stride_matches_meta(self, device):
+        self._assert_fft_meta_stride_matches_eager(
+            aten._fft_c2c.default,
+            torch.randn((5, 5, 5, 5, 5), device=device, dtype=torch.complex64),
+            [1, 2, 3, 4],
+            0,
+            True,
+        )
+        self._assert_fft_meta_stride_matches_eager(
+            aten._fft_c2r.default,
+            torch.randn((5, 5, 5, 5, 3), device=device, dtype=torch.complex64),
+            [0, 1, 2, 3, 4],
+            0,
+            5,
+        )
+
     # opinfo test is using aten.fill_, it's not testing aten.fill
     @onlyCUDA
     def test_fill_stride(self):

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -314,9 +314,33 @@ def meta_fft_c2c(self, dim, normalization, forward):
     if device_hint(self) == "cpu" and not torch.backends.mkl.is_available():
         return self.new_empty(self.size())
 
-    sorted_dims = _sort_dims(self, dim)
-    out = self.new_empty(self.size())
-    return _exec_fft(out, self, self.size(), sorted_dims, forward=forward)
+    out_sizes = self.size()
+    output = self.new_empty(out_sizes)
+    if device_hint(self) != "cuda":
+        sorted_dims = _sort_dims(self, dim)
+        return _exec_fft(output, self, out_sizes, sorted_dims, forward=forward)
+
+    # Match _fft_c2c_cufft, which re-sorts the remaining dimensions after each
+    # staged transform because _exec_fft restrides the output in place.
+    sorted_dims = list(dim)
+    working_tensor = self
+    while True:
+        strides = working_tensor.stride()
+        sorted_dims.sort(key=lambda i: strides[i], reverse=True)
+        max_dims = min(cufft_max_ndim, len(sorted_dims))
+        last_dims = sorted_dims[len(sorted_dims) - max_dims :]
+
+        _exec_fft(output, working_tensor, out_sizes, last_dims, forward=forward)
+        sorted_dims = sorted_dims[: len(sorted_dims) - max_dims]
+
+        if not sorted_dims:
+            return output
+
+        if working_tensor is self:
+            working_tensor = output
+            output = self.new_empty(out_sizes)
+        else:
+            output, working_tensor = working_tensor, output
 
 
 cufft_max_ndim = 3
@@ -490,7 +514,7 @@ def meta_fft_c2r(self: Tensor, dim: list[int], normalization: int, lastdim: int)
         else:
             # First complete any C2C transforms
             if len(dim) > 1:
-                temp = meta_fft_c2c(self, dim[:-1], 0, lastdim)  # fft_norm_mode::none
+                temp = meta_fft_c2c(self, dim[:-1], 0, forward=False)
             else:
                 temp = self.clone(memory_format=torch.contiguous_format)
             return _exec_fft(output, temp, out_sizes, [dim[-1]], forward=False)


### PR DESCRIPTION
Fix #106623

## Summary

1. What is the root cause problem
`meta_fft_c2c` modeled CUDA FFTs as a single `_exec_fft` call after one upfront sort. The real cuFFT path stages transforms in chunks of at most three dimensions and restrides the output after each stage, so meta/FakeTensor predicted the wrong output layout once more than three transformed dimensions were involved. `meta_fft_c2r` also depended on that same C2C metadata path for its intermediate transform.

2. What is the proposed fix
Mirror `_fft_c2c_cufft` in `torch/_meta_registrations.py` by looping over the remaining dimensions, re-sorting after each staged transform, and alternating the working/output buffers the same way eager CUDA does. Also route the CUDA `c2r` helper through that corrected C2C path with the explicit `forward=False` flag, and add a CUDA regression test in `test/test_meta.py` that compares eager and meta strides for multi-dimensional `_fft_c2c` and `_fft_c2r`.

3. Why is this the right long term fix
It keeps the meta kernel aligned with the real CUDA implementation instead of relying on fallbacks or special-case exclusions, so FakeTensor and compiled graphs see the same stride metadata that eager execution actually produces.

Co-authored with Codex, reviewed and published by @bobrenjc93