### PR TITLE
Handle SymPy boolean graph inputs in Inductor

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -4451,6 +4451,33 @@ class AOTInductorTestsTemplate:
         inputs = (torch.tensor([0], dtype=torch.bool, device=self.device),)
         self.check_model(Model(), inputs)
 
+    def test_aot_load_accepts_symbool_placeholder_input(self):
+        if self.device != "cpu":
+            raise unittest.SkipTest("CPU-only SymBool AOT loader regression")
+
+        from torch.fx.experimental.symbolic_shapes import ShapeEnv
+
+        class Model(torch.nn.Module):
+            def forward(self, pred, x):
+                def true_fn(t):
+                    return t + 1
+
+                def false_fn(t):
+                    return t - 1
+
+                return torch.cond(pred, true_fn, false_fn, (x,))
+
+        shape_env = ShapeEnv()
+        pred = shape_env.create_unbacked_symbool()
+        x = torch.ones(4, device=self.device)
+
+        with torch.no_grad():
+            ep = torch.export.export(Model(), (pred, x), strict=False)
+            so_path = torch._inductor.aot_compile(ep.module(), (pred, x))
+            optimized = torch._export.aot_load(so_path, self.device)
+
+        self.assertTrue(same(ep.module()(pred, x), optimized(pred, x)))
+
     def test_symfloat_item(self):
         class Model(torch.nn.Module):
             def forward(self, tensor):

--- a/test/inductor/test_fxir_backend.py
+++ b/test/inductor/test_fxir_backend.py
@@ -1124,8 +1124,8 @@ def forward(self, arg0_1, arg1_1, arg2_1):
 
                 return torch.cond(pred, true_fn, false_fn, (x,))
 
-        # AOT partition boundaries can present symbolic compares such as
-        # `EP > 1` to the FX wrapper as explicit SymBool placeholders.
+        # AOT partition boundaries can lift symbolic compares such as `EP > 1`
+        # into the partition signature as explicit SymBool placeholders.
         shape_env = ShapeEnv()
         pred = shape_env.create_unbacked_symbool()
         x = torch.ones(4, device=self.device)
@@ -1147,6 +1147,23 @@ def forward(self, arg0_1, arg1_1, arg2_1):
         )
         self.assertEqual(len(gm.graph.find_nodes(op="placeholder")), 2)
         self.assertTrue(same(ep.module()(pred, x), gm(pred, x)))
+
+    def test_aoti_specializes_python_int_metadata_input(self):
+        class M(torch.nn.Module):
+            def forward(self, x, dim: int):
+                return torch.sum(x, dim)
+
+        x = torch.randn(4, 5, device=self.device)
+        dim = 1
+
+        ep = torch.export.export(M(), (x, dim), strict=False)
+        gm = torch._inductor.aot_compile(
+            ep.module(),
+            (x, dim),
+            options={"fx_wrapper": True, **test_config},
+        )
+
+        self.assertTrue(same(ep.module()(x, dim), gm(x, dim)))
 
     @parametrize("dynamic", (False, True))
     @parametrize("input_", (1.5, 2, False))

--- a/test/inductor/test_fxir_backend.py
+++ b/test/inductor/test_fxir_backend.py
@@ -1259,6 +1259,23 @@ class TestReplaceFloorDiv(InductorTestCase):
     Tests for floor -> FloorDiv conversion.
     """
 
+    def test_generate_sym_node_accepts_boolean_graph_input(self):
+        pred = sympy.Eq(sympy.Symbol("u0", integer=True), 1)
+        converter = FxConverter(
+            lines=[],
+            prologue="",
+            graph_inputs={"pred": pred},
+            graph_outputs=[],
+            subgms={},
+            is_subgraph=False,
+        )
+
+        converter._generate_graph_inputs()
+
+        pred_node = converter._generate_sym_node(pred)
+        assert isinstance(pred_node, torch.fx.Node)
+        self.assertEqual(pred_node.name, "pred")
+
     def _check(self, expr: sympy.Expr) -> sympy.Expr:
         # Check that we started with floor's.
         num_floors = expr.count(sympy.floor)

--- a/test/inductor/test_fxir_backend.py
+++ b/test/inductor/test_fxir_backend.py
@@ -1111,6 +1111,43 @@ def forward(self, arg0_1, arg1_1, arg2_1):
         x = torch.randn(7, device=self.device)
         self.check(M(), (x,), dynamic_shapes=({0: Dim.DYNAMIC},))
 
+    def test_aoti_fx_symbool_placeholder_input(self):
+        from torch.fx.experimental.symbolic_shapes import ShapeEnv
+
+        class M(torch.nn.Module):
+            def forward(self, pred, x):
+                def true_fn(t):
+                    return t + 1
+
+                def false_fn(t):
+                    return t - 1
+
+                return torch.cond(pred, true_fn, false_fn, (x,))
+
+        # AOT partition boundaries can present symbolic compares such as
+        # `EP > 1` to the FX wrapper as explicit SymBool placeholders.
+        shape_env = ShapeEnv()
+        pred = shape_env.create_unbacked_symbool()
+        x = torch.ones(4, device=self.device)
+
+        ep = torch.export.export(M(), (pred, x), strict=False)
+        gm = torch._inductor.aot_compile(
+            ep.module(),
+            (pred, x),
+            options={"fx_wrapper": True, **test_config},
+        )
+
+        self.assertEqual(
+            len(
+                gm.graph.find_nodes(
+                    op="call_function", target=torch.ops.higher_order.cond
+                )
+            ),
+            1,
+        )
+        self.assertEqual(len(gm.graph.find_nodes(op="placeholder")), 2)
+        self.assertTrue(same(ep.module()(pred, x), gm(pred, x)))
+
     @parametrize("dynamic", (False, True))
     @parametrize("input_", (1.5, 2, False))
     def test_item(self, input_, dynamic: bool):

--- a/test/inductor/test_fxir_backend.py
+++ b/test/inductor/test_fxir_backend.py
@@ -1273,7 +1273,7 @@ class TestReplaceFloorDiv(InductorTestCase):
         converter._generate_graph_inputs()
 
         pred_node = converter._generate_sym_node(pred)
-        assert isinstance(pred_node, torch.fx.Node)
+        self.assertIsInstance(pred_node, torch.fx.Node)
         self.assertEqual(pred_node.name, "pred")
 
     def _check(self, expr: sympy.Expr) -> sympy.Expr:

--- a/test/inductor/test_fxir_backend.py
+++ b/test/inductor/test_fxir_backend.py
@@ -1148,6 +1148,32 @@ def forward(self, arg0_1, arg1_1, arg2_1):
         self.assertEqual(len(gm.graph.find_nodes(op="placeholder")), 2)
         self.assertTrue(same(ep.module()(pred, x), gm(pred, x)))
 
+    def test_aoti_fx_symbool_placeholder_input_with_graph_partition(self):
+        from torch.fx.experimental.symbolic_shapes import ShapeEnv
+
+        class M(torch.nn.Module):
+            def forward(self, pred, x):
+                def true_fn(t):
+                    return t + 1
+
+                def false_fn(t):
+                    return t - 1
+
+                return torch.cond(pred, true_fn, false_fn, (x,))
+
+        shape_env = ShapeEnv()
+        pred = shape_env.create_unbacked_symbool()
+        x = torch.ones(4, device=self.device)
+
+        ep = torch.export.export(M(), (pred, x), strict=False)
+        gm = torch._inductor.aot_compile(
+            ep.module(),
+            (pred, x),
+            options={"fx_wrapper": True, "graph_partition": True, **test_config},
+        )
+
+        self.assertTrue(same(ep.module()(pred, x), gm(pred, x)))
+
     def test_aoti_specializes_python_int_metadata_input(self):
         class M(torch.nn.Module):
             def forward(self, x, dim: int):
@@ -1164,6 +1190,8 @@ def forward(self, arg0_1, arg1_1, arg2_1):
         )
 
         self.assertTrue(same(ep.module()(x, dim), gm(x, dim)))
+        with self.assertRaisesRegex(AssertionError, "specialized int input"):
+            gm(x, 0)
 
     @parametrize("dynamic", (False, True))
     @parametrize("input_", (1.5, 2, False))

--- a/test/inductor/test_fxir_backend.py
+++ b/test/inductor/test_fxir_backend.py
@@ -1276,6 +1276,24 @@ class TestReplaceFloorDiv(InductorTestCase):
         self.assertIsInstance(pred_node, torch.fx.Node)
         self.assertEqual(pred_node.name, "pred")
 
+    def test_generate_graph_inputs_preserves_symbolic_scalar_placeholder_name(self):
+        symint = sympy.Symbol("arg0_symint", integer=True)
+        converter = FxConverter(
+            lines=[],
+            prologue="",
+            graph_inputs={"arg0": symint},
+            graph_outputs=[],
+            subgms={},
+            is_subgraph=False,
+        )
+
+        converter._generate_graph_inputs()
+
+        (placeholder_node,) = converter.gm.graph.find_nodes(op="placeholder")
+        self.assertEqual(placeholder_node.name, "arg0")
+        self.assertIs(converter.buffer_to_node[str(symint)], placeholder_node)
+        self.assertIs(converter._generate_sym_node(symint), placeholder_node)
+
     def _check(self, expr: sympy.Expr) -> sympy.Expr:
         # Check that we started with floor's.
         num_floors = expr.count(sympy.floor)

--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -4,11 +4,11 @@ import importlib
 import math
 import operator
 import os
-import sympy
 import sys
 import unittest
 from functools import partial
 
+import sympy
 import torch
 import torch.library
 from torch._dynamo.testing import CompileCounterWithBackend, make_test_cls_with_patches

--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -229,6 +229,43 @@ if HAS_CPU:
                 wrapper_code, _ = graph_lowering.codegen()
                 self.assertIn(", pred, )", wrapper_code.value)
 
+        def test_graph_lowering_avoids_int_placeholder_name_collisions(self):
+            from torch._inductor.debug import DebugContext
+            from torch._inductor.graph import GraphLowering
+            from torch.fx.experimental.symbolic_shapes import ShapeEnv
+
+            shape_env = ShapeEnv()
+            x_input = torch.randn(2, 3)
+            fake_mode = torch._subclasses.FakeTensorMode(shape_env=shape_env)
+            with fake_mode:
+                fake_x = fake_mode.from_tensor(x_input)
+                fake_y = torch.ops.aten.neg.default(fake_x)
+
+            graph = torch.fx.Graph()
+            scalar = graph.placeholder("x")
+            tensor = graph.placeholder("x_symint")
+            y = graph.call_function(torch.ops.aten.neg.default, (tensor,))
+            graph.output((y,))
+
+            gm = torch.fx.GraphModule({}, graph)
+            scalar.meta["val"] = 4
+            tensor.meta["val"] = fake_x
+            y.meta["val"] = fake_y
+            gm.graph.lint()
+            gm.recompile()
+
+            graph_lowering = GraphLowering(gm, shape_env=shape_env)
+            with (
+                V.set_fake_mode(fake_mode),
+                V.set_graph_handler(graph_lowering),
+                V.set_debug_handler(DebugContext()),
+            ):
+                graph_lowering.run(4, x_input)
+                scalar_expr = graph_lowering.graph_inputs["x"]
+                self.assertIsInstance(scalar_expr, sympy.Symbol)
+                self.assertNotEqual(str(scalar_expr), "x_symint")
+                self.assertIn("x_symint", graph_lowering.graph_inputs)
+
 
 class TestInductorDynamic(TestCase):
     compile_fn = partial(torch.compile, dynamic=True)

--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -151,14 +151,14 @@ if HAS_CPU:
             self.assertIs(may_get_constant_buffer_dtype(symint), torch.int64)
             self.assertIs(may_get_constant_buffer_dtype(symbool), torch.bool)
 
-        def _make_graph_with_symbool_input(self):
+        def _make_graph_with_symbool_input(self, device="cpu"):
             from torch.fx.experimental.symbolic_shapes import ShapeEnv
 
             shape_env = ShapeEnv()
             pred_input = shape_env.create_unbacked_symbool()
             self.assertIsInstance(pred_input.node.expr, sympy.Equality)
 
-            x_input = torch.randn(2, 3)
+            x_input = torch.randn(2, 3, device=device)
             fake_mode = torch._subclasses.FakeTensorMode(shape_env=shape_env)
             with fake_mode:
                 fake_x = fake_mode.from_tensor(x_input)
@@ -236,24 +236,29 @@ if HAS_CPU:
             from torch._inductor.debug import DebugContext
             from torch._inductor.graph import may_get_constant_buffer_dtype
 
-            gm, shape_env, fake_mode, x_input, pred_input = (
-                self._make_graph_with_symbool_input()
-            )
-            graph_lowering = self._make_graph_lowering(
-                gm, shape_env, x_input, pred_input
-            )
-            with (
-                V.set_fake_mode(fake_mode),
-                V.set_graph_handler(graph_lowering),
-                V.set_debug_handler(DebugContext()),
-            ):
-                graph_lowering.run(x_input, pred_input)
-                pred_expr = graph_lowering.graph_inputs["pred"]
-                self.assertIsInstance(pred_expr, sympy.Equality)
-                self.assertIs(may_get_constant_buffer_dtype(pred_expr), torch.bool)
+            devices = ["cpu"]
+            if HAS_GPU:
+                devices.append(GPU_TYPE)
 
-                wrapper_code, _ = graph_lowering.codegen()
-                self.assertIn(", pred, )", wrapper_code.value)
+            for device in devices:
+                gm, shape_env, fake_mode, x_input, pred_input = (
+                    self._make_graph_with_symbool_input(device=device)
+                )
+                graph_lowering = self._make_graph_lowering(
+                    gm, shape_env, x_input, pred_input
+                )
+                with (
+                    V.set_fake_mode(fake_mode),
+                    V.set_graph_handler(graph_lowering),
+                    V.set_debug_handler(DebugContext()),
+                ):
+                    graph_lowering.run(x_input, pred_input)
+                    pred_expr = graph_lowering.graph_inputs["pred"]
+                    self.assertIsInstance(pred_expr, sympy.Equality)
+                    self.assertIs(may_get_constant_buffer_dtype(pred_expr), torch.bool)
+
+                    wrapper_code, _ = graph_lowering.codegen()
+                    self.assertIn(", pred, )", wrapper_code.value)
 
         def test_graph_lowering_aot_cpp_wrapper_accepts_unbacked_symbool_graph_input(
             self,
@@ -282,7 +287,7 @@ if HAS_CPU:
                     "aoti_torch_item_bool(inputs[1], &pred)", wrapper_code.value
                 )
 
-        def test_graph_lowering_avoids_int_placeholder_name_collisions(self):
+        def test_graph_lowering_specializes_python_int_metadata_inputs(self):
             from torch._inductor.debug import DebugContext
             from torch._inductor.graph import GraphLowering
             from torch.fx.experimental.symbolic_shapes import ShapeEnv
@@ -292,17 +297,20 @@ if HAS_CPU:
             fake_mode = torch._subclasses.FakeTensorMode(shape_env=shape_env)
             with fake_mode:
                 fake_x = fake_mode.from_tensor(x_input)
-                fake_y = torch.ops.aten.neg.default(fake_x)
+                fake_y = torch.ops.aten.sum.dim_IntList(fake_x, [1], False)
 
             graph = torch.fx.Graph()
-            scalar = graph.placeholder("x")
-            tensor = graph.placeholder("x_symint")
-            y = graph.call_function(torch.ops.aten.neg.default, (tensor,))
+            x = graph.placeholder("x")
+            axis = graph.placeholder("axis")
+            y = graph.call_function(
+                torch.ops.aten.sum.dim_IntList,
+                (x, [axis], False),
+            )
             graph.output((y,))
 
             gm = torch.fx.GraphModule({}, graph)
-            scalar.meta["val"] = 4
-            tensor.meta["val"] = fake_x
+            x.meta["val"] = fake_x
+            axis.meta["val"] = 1
             y.meta["val"] = fake_y
             gm.graph.lint()
             gm.recompile()
@@ -313,11 +321,9 @@ if HAS_CPU:
                 V.set_graph_handler(graph_lowering),
                 V.set_debug_handler(DebugContext()),
             ):
-                graph_lowering.run(4, x_input)
-                scalar_expr = graph_lowering.graph_inputs["x"]
-                self.assertIsInstance(scalar_expr, sympy.Symbol)
-                self.assertNotEqual(str(scalar_expr), "x_symint")
-                self.assertIn("x_symint", graph_lowering.graph_inputs)
+                graph_lowering.run(x_input, 1)
+                self.assertNotIn("axis", graph_lowering.graph_inputs)
+                graph_lowering.codegen()
 
 
 class TestInductorDynamic(TestCase):

--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -223,7 +223,7 @@ if HAS_CPU:
             ):
                 graph_lowering.run(x_input, pred_input)
                 pred_expr = graph_lowering.graph_inputs["pred"]
-                assert isinstance(pred_expr, sympy.Equality)
+                self.assertIsInstance(pred_expr, sympy.Equality)
                 self.assertIs(may_get_constant_buffer_dtype(pred_expr), torch.bool)
 
                 wrapper_code, _ = graph_lowering.codegen()

--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -9,6 +9,7 @@ import unittest
 from functools import partial
 
 import sympy
+
 import torch
 import torch.library
 from torch._dynamo.testing import CompileCounterWithBackend, make_test_cls_with_patches

--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -4,6 +4,7 @@ import importlib
 import math
 import operator
 import os
+import sympy
 import sys
 import unittest
 from functools import partial
@@ -135,6 +136,52 @@ if (HAS_GPU or HAS_MPS) and not TEST_WITH_ASAN:
     copy_tests(
         DynamicShapesCommonTemplate, DynamicShapesGPUTests, GPU_TYPE, test_failures
     )
+
+
+if HAS_CPU:
+
+    class TestInductorDynamicLowering(TestCase):
+        def test_graph_lowering_accepts_sympy_eq_graph_input(self):
+            from torch._inductor.debug import DebugContext
+            from torch._inductor.graph import GraphLowering
+            from torch.fx.experimental.symbolic_shapes import ShapeEnv
+
+            shape_env = ShapeEnv()
+            lhs = shape_env.create_unbacked_symint()
+            rhs = shape_env.create_unbacked_symint()
+            eq_pred = lhs == rhs
+            self.assertIsInstance(eq_pred.node.expr, sympy.Equality)
+
+            x_input = torch.randn(2, 3)
+            fake_mode = torch._subclasses.FakeTensorMode(shape_env=shape_env)
+            with fake_mode:
+                fake_x = fake_mode.from_tensor(x_input)
+                fake_y = torch.ops.aten.neg.default(fake_x)
+
+            graph = torch.fx.Graph()
+            x = graph.placeholder("x")
+            pred = graph.placeholder("pred")
+            y = graph.call_function(torch.ops.aten.neg.default, (x,))
+            graph.output((y,))
+
+            gm = torch.fx.GraphModule({}, graph)
+            x.meta["val"] = fake_x
+            pred.meta["val"] = eq_pred
+            y.meta["val"] = fake_y
+            gm.graph.lint()
+            gm.recompile()
+
+            graph_lowering = GraphLowering(gm, shape_env=shape_env)
+            with (
+                V.set_fake_mode(fake_mode),
+                V.set_graph_handler(graph_lowering),
+                V.set_debug_handler(DebugContext()),
+            ):
+                graph_lowering.run(x_input, eq_pred)
+                self.assertIsInstance(
+                    graph_lowering.graph_inputs["pred"], sympy.Equality
+                )
+                graph_lowering.codegen()
 
 
 class TestInductorDynamic(TestCase):

--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -142,6 +142,15 @@ if (HAS_GPU or HAS_MPS) and not TEST_WITH_ASAN:
 if HAS_CPU:
 
     class TestInductorDynamicLowering(TestCase):
+        def test_may_get_constant_buffer_dtype_distinguishes_ints_from_bools(self):
+            from torch._inductor.graph import may_get_constant_buffer_dtype
+
+            symint = sympy.Symbol("s77", integer=True)
+            symbool = sympy.Eq(sympy.Symbol("u0", integer=True), 1)
+
+            self.assertIs(may_get_constant_buffer_dtype(symint), torch.int64)
+            self.assertIs(may_get_constant_buffer_dtype(symbool), torch.bool)
+
         def test_graph_lowering_accepts_sympy_eq_graph_input(self):
             from torch._inductor.debug import DebugContext
             from torch._inductor.graph import GraphLowering

--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -184,6 +184,51 @@ if HAS_CPU:
                 )
                 graph_lowering.codegen()
 
+        def test_graph_lowering_codegen_preserves_unbacked_symbool_graph_input(self):
+            from torch._inductor.debug import DebugContext
+            from torch._inductor.graph import (
+                GraphLowering,
+                may_get_constant_buffer_dtype,
+            )
+            from torch.fx.experimental.symbolic_shapes import ShapeEnv
+
+            shape_env = ShapeEnv()
+            pred_input = shape_env.create_unbacked_symbool()
+            self.assertIsInstance(pred_input.node.expr, sympy.Equality)
+
+            x_input = torch.randn(2, 3)
+            fake_mode = torch._subclasses.FakeTensorMode(shape_env=shape_env)
+            with fake_mode:
+                fake_x = fake_mode.from_tensor(x_input)
+                fake_y = torch.ops.aten.neg.default(fake_x)
+
+            graph = torch.fx.Graph()
+            x = graph.placeholder("x")
+            pred = graph.placeholder("pred")
+            y = graph.call_function(torch.ops.aten.neg.default, (x,))
+            graph.output((y, pred))
+
+            gm = torch.fx.GraphModule({}, graph)
+            x.meta["val"] = fake_x
+            pred.meta["val"] = pred_input
+            y.meta["val"] = fake_y
+            gm.graph.lint()
+            gm.recompile()
+
+            graph_lowering = GraphLowering(gm, shape_env=shape_env)
+            with (
+                V.set_fake_mode(fake_mode),
+                V.set_graph_handler(graph_lowering),
+                V.set_debug_handler(DebugContext()),
+            ):
+                graph_lowering.run(x_input, pred_input)
+                pred_expr = graph_lowering.graph_inputs["pred"]
+                assert isinstance(pred_expr, sympy.Equality)
+                self.assertIs(may_get_constant_buffer_dtype(pred_expr), torch.bool)
+
+                wrapper_code, _ = graph_lowering.codegen()
+                self.assertIn(", pred, )", wrapper_code.value)
+
 
 class TestInductorDynamic(TestCase):
     compile_fn = partial(torch.compile, dynamic=True)

--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -151,6 +151,45 @@ if HAS_CPU:
             self.assertIs(may_get_constant_buffer_dtype(symint), torch.int64)
             self.assertIs(may_get_constant_buffer_dtype(symbool), torch.bool)
 
+        def _make_graph_with_symbool_input(self):
+            from torch.fx.experimental.symbolic_shapes import ShapeEnv
+
+            shape_env = ShapeEnv()
+            pred_input = shape_env.create_unbacked_symbool()
+            self.assertIsInstance(pred_input.node.expr, sympy.Equality)
+
+            x_input = torch.randn(2, 3)
+            fake_mode = torch._subclasses.FakeTensorMode(shape_env=shape_env)
+            with fake_mode:
+                fake_x = fake_mode.from_tensor(x_input)
+                fake_y = torch.ops.aten.neg.default(fake_x)
+
+            graph = torch.fx.Graph()
+            x = graph.placeholder("x")
+            pred = graph.placeholder("pred")
+            y = graph.call_function(torch.ops.aten.neg.default, (x,))
+            graph.output((y, pred))
+
+            gm = torch.fx.GraphModule({}, graph)
+            x.meta["val"] = fake_x
+            pred.meta["val"] = pred_input
+            y.meta["val"] = fake_y
+            gm.graph.lint()
+            gm.recompile()
+            return gm, shape_env, fake_mode, x_input, pred_input
+
+        def _make_graph_lowering(
+            self, gm, shape_env, x_input, pred_input, **graph_kwargs
+        ):
+            from torch._inductor.graph import GraphLowering
+
+            return GraphLowering(
+                gm,
+                example_inputs=(x_input, pred_input),
+                shape_env=shape_env,
+                **graph_kwargs,
+            )
+
         def test_graph_lowering_accepts_sympy_eq_graph_input(self):
             from torch._inductor.debug import DebugContext
             from torch._inductor.graph import GraphLowering
@@ -195,36 +234,14 @@ if HAS_CPU:
 
         def test_graph_lowering_codegen_preserves_unbacked_symbool_graph_input(self):
             from torch._inductor.debug import DebugContext
-            from torch._inductor.graph import (
-                GraphLowering,
-                may_get_constant_buffer_dtype,
+            from torch._inductor.graph import may_get_constant_buffer_dtype
+
+            gm, shape_env, fake_mode, x_input, pred_input = (
+                self._make_graph_with_symbool_input()
             )
-            from torch.fx.experimental.symbolic_shapes import ShapeEnv
-
-            shape_env = ShapeEnv()
-            pred_input = shape_env.create_unbacked_symbool()
-            self.assertIsInstance(pred_input.node.expr, sympy.Equality)
-
-            x_input = torch.randn(2, 3)
-            fake_mode = torch._subclasses.FakeTensorMode(shape_env=shape_env)
-            with fake_mode:
-                fake_x = fake_mode.from_tensor(x_input)
-                fake_y = torch.ops.aten.neg.default(fake_x)
-
-            graph = torch.fx.Graph()
-            x = graph.placeholder("x")
-            pred = graph.placeholder("pred")
-            y = graph.call_function(torch.ops.aten.neg.default, (x,))
-            graph.output((y, pred))
-
-            gm = torch.fx.GraphModule({}, graph)
-            x.meta["val"] = fake_x
-            pred.meta["val"] = pred_input
-            y.meta["val"] = fake_y
-            gm.graph.lint()
-            gm.recompile()
-
-            graph_lowering = GraphLowering(gm, shape_env=shape_env)
+            graph_lowering = self._make_graph_lowering(
+                gm, shape_env, x_input, pred_input
+            )
             with (
                 V.set_fake_mode(fake_mode),
                 V.set_graph_handler(graph_lowering),
@@ -237,6 +254,33 @@ if HAS_CPU:
 
                 wrapper_code, _ = graph_lowering.codegen()
                 self.assertIn(", pred, )", wrapper_code.value)
+
+        def test_graph_lowering_aot_cpp_wrapper_accepts_unbacked_symbool_graph_input(
+            self,
+        ):
+            from torch._inductor.debug import DebugContext
+
+            gm, shape_env, fake_mode, x_input, pred_input = (
+                self._make_graph_with_symbool_input()
+            )
+            graph_lowering = self._make_graph_lowering(
+                gm,
+                shape_env,
+                x_input,
+                pred_input,
+                cpp_wrapper=True,
+                aot_mode=True,
+            )
+            with (
+                V.set_fake_mode(fake_mode),
+                V.set_graph_handler(graph_lowering),
+                V.set_debug_handler(DebugContext()),
+            ):
+                graph_lowering.run(x_input, pred_input)
+                wrapper_code, _ = graph_lowering.codegen_with_cpp_wrapper()
+                self.assertIn(
+                    "aoti_torch_item_bool(inputs[1], &pred)", wrapper_code.value
+                )
 
         def test_graph_lowering_avoids_int_placeholder_name_collisions(self):
             from torch._inductor.debug import DebugContext

--- a/torch/_export/__init__.py
+++ b/torch/_export/__init__.py
@@ -27,7 +27,7 @@ import torch.utils._pytree as pytree
 from torch._dispatch.python import enable_python_dispatcher
 from torch._guards import compile_context
 from torch._utils_internal import log_export_usage
-from torch.export._tree_utils import reorder_kwargs
+from torch.export._tree_utils import flatten_aoti_runtime_inputs
 from torch.export.graph_signature import (
     ArgumentSpec,
     ConstantArgument,
@@ -181,8 +181,7 @@ def aot_load(so_path: str, device: str) -> Callable:
         call_spec = runner.get_call_spec()
         in_spec = pytree.treespec_loads(call_spec[0])
         out_spec = pytree.treespec_loads(call_spec[1])
-        flat_inputs = pytree.tree_flatten((args, reorder_kwargs(kwargs, in_spec)))[0]
-        flat_inputs = [x for x in flat_inputs if isinstance(x, torch.Tensor)]
+        flat_inputs = flatten_aoti_runtime_inputs(args, kwargs, in_spec)
         flat_outputs = runner.run(flat_inputs)
         return pytree.tree_unflatten(flat_outputs, out_spec)
 

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -1575,6 +1575,9 @@ class CppWrapperCpu(PythonWrapperCodegen):
     def codegen_cpp_symbolic_scalar(self, x: sympy.Expr | SympyBoolean) -> str:
         return cexpr(self.replace_symbolic_scalar_graph_inputs(x))
 
+    def codegen_symbolic_scalar(self, x: sympy.Expr | SympyBoolean) -> str:
+        return self.codegen_cpp_symbolic_scalar(x)
+
     def codegen_sizevar(self, x: sympy.Expr | SympyBoolean) -> str:
         return self.codegen_cpp_sizevar(x)
 
@@ -1605,14 +1608,19 @@ class CppWrapperCpu(PythonWrapperCodegen):
             "linux",
             "win32",
         ]
+        expr = (
+            self.codegen_cpp_sizevar(arg.inner_expr)
+            if symbol_is_type(arg.inner, SymT.PRECOMPUTED_SIZE)
+            else self.codegen_cpp_symbolic_scalar(arg.inner_expr)
+        )
         if enable_kernel_profile or (arg.inner, graph) not in self.kernel_numel_expr:
             # When enable_kernel_profile is on, each kernel call is wrapped in
             # its own {} scope block, so we must redeclare the variable each
             # time since prior declarations are no longer visible.
             self.kernel_numel_expr.add((arg.inner, graph))
-            self.writeline(f"int64_t {arg.inner} = {cexpr(arg.inner_expr)};")
+            self.writeline(f"int64_t {arg.inner} = {expr};")
         else:
-            self.writeline(f"{arg.inner} = {cexpr(arg.inner_expr)};")
+            self.writeline(f"{arg.inner} = {expr};")
 
     def _codegen_dynamic_scalar(self, node):
         (data,) = (t.codegen_reference() for t in node.inputs)

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -35,6 +35,7 @@ from ..utils import (
     is_sympy_boolean,
     LineContext,
     normalize_name,
+    SYMBOLIC_SCALAR_TYPES,
 )
 from ..virtualized import V
 from .aoti_hipify_utils import maybe_hipify_code_wrapper
@@ -62,10 +63,6 @@ if TYPE_CHECKING:
 
 class HasWriteLine(Protocol):
     def writeline(self, line: LineContext | DeferredLineBase | str) -> None: ...
-
-
-SYMBOLIC_SCALAR_TYPES = (sympy.Expr, sympy.logic.boolalg.Boolean)
-
 
 class CppWrapperCpu(PythonWrapperCodegen):
     """

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -1567,7 +1567,7 @@ class CppWrapperCpu(PythonWrapperCodegen):
                 self.writeline(
                     f'AOTI_TORCH_CHECK({divisor_str} != 0, "Integer {op_name} by zero");'
                 )
-        return cexpr(maybe_simplified_x)
+        return cexpr(self.replace_symbolic_scalar_graph_inputs(maybe_simplified_x))
 
     def codegen_sizevar(self, x: sympy.Expr | SympyBoolean) -> str:
         return self.codegen_cpp_sizevar(x)
@@ -2557,7 +2557,7 @@ if (!custom_op_wrapper) {
                     imag = self.generate_float_value(scalar.imag)
                     return f"PyComplex_FromDoubles({real}, {imag})"
                 if isinstance(scalar, SymTypes):
-                    scalar_var = cexpr(scalar.node.expr)
+                    scalar_var = self.codegen_sizevar(scalar.node.expr)
                     if isinstance(scalar, torch.SymBool):
                         return f"PyBool_FromLong({scalar_var})"
                     if isinstance(scalar, torch.SymFloat):
@@ -2940,9 +2940,9 @@ if (!custom_op_wrapper) {
             # FIXME: This happens because type_ is not always properly set to torch.ListType
             return f"{{{', '.join(self.val_to_arg_str(x, None) for x in val)}}}"
         elif isinstance(val, SymTypes):
-            return cexpr(val.node.expr)
+            return self.codegen_sizevar(val.node.expr)
         elif isinstance(val, SYMBOLIC_SCALAR_TYPES):
-            return cexpr(val)
+            return self.codegen_sizevar(val)
         else:
             return repr(val)
 

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -369,6 +369,11 @@ class CppWrapperCpu(PythonWrapperCodegen):
         if isinstance(value, SYMBOLIC_SCALAR_TYPES):
             if not isinstance(value, sympy.Symbol) or value in bound_vars:
                 return
+            if str(value) == name:
+                # The extracted runtime scalar input already uses the symbol's
+                # name, so reusing it avoids a colliding redeclaration.
+                bound_vars.add(value)
+                return
             if getattr(value, "is_Boolean", False):
                 decl = "bool"
             elif value.is_integer:

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -314,7 +314,7 @@ class CppWrapperCpu(PythonWrapperCodegen):
     def codegen_input_symbol_assignment(
         self,
         name: str,
-        value: ir.TensorBox,
+        value: ir.TensorBox | ir.TorchBindObject | sympy.Expr | SympyBoolean,
         bound_vars: OrderedSet[sympy.Symbol],
     ):
         code = self.prefix
@@ -629,7 +629,9 @@ class CppWrapperCpu(PythonWrapperCodegen):
             if inputs_len != 0:
                 for idx, input_key in enumerate(V.graph.graph_inputs.keys()):
                     # unwrap input tensor back to scalar
-                    if isinstance(V.graph.graph_inputs[input_key], SYMBOLIC_SCALAR_TYPES):
+                    if isinstance(
+                        V.graph.graph_inputs[input_key], SYMBOLIC_SCALAR_TYPES
+                    ):
                         from ..graph import may_get_constant_buffer_dtype
 
                         dtype = may_get_constant_buffer_dtype(

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -1557,7 +1557,10 @@ class CppWrapperCpu(PythonWrapperCodegen):
     def codegen_cpp_sizevar(
         self, x: sympy.Expr | SympyBoolean, *, simplify: bool = True
     ) -> str:
-        maybe_simplified_x = V.graph.sizevars.simplify(x) if simplify else x
+        replaced_x = self.replace_symbolic_scalar_graph_inputs(x)
+        maybe_simplified_x = (
+            V.graph.sizevars.simplify(replaced_x) if simplify else replaced_x
+        )
         # In AOT mode, emit runtime checks for potential division/modulo by zero
         # to prevent SIGFPE crashes when symbolic tensor shapes can be 0
         if V.graph.aot_mode:
@@ -1567,7 +1570,10 @@ class CppWrapperCpu(PythonWrapperCodegen):
                 self.writeline(
                     f'AOTI_TORCH_CHECK({divisor_str} != 0, "Integer {op_name} by zero");'
                 )
-        return cexpr(self.replace_symbolic_scalar_graph_inputs(maybe_simplified_x))
+        return cexpr(maybe_simplified_x)
+
+    def codegen_cpp_symbolic_scalar(self, x: sympy.Expr | SympyBoolean) -> str:
+        return cexpr(self.replace_symbolic_scalar_graph_inputs(x))
 
     def codegen_sizevar(self, x: sympy.Expr | SympyBoolean) -> str:
         return self.codegen_cpp_sizevar(x)
@@ -2557,7 +2563,7 @@ if (!custom_op_wrapper) {
                     imag = self.generate_float_value(scalar.imag)
                     return f"PyComplex_FromDoubles({real}, {imag})"
                 if isinstance(scalar, SymTypes):
-                    scalar_var = self.codegen_sizevar(scalar.node.expr)
+                    scalar_var = self.codegen_cpp_symbolic_scalar(scalar.node.expr)
                     if isinstance(scalar, torch.SymBool):
                         return f"PyBool_FromLong({scalar_var})"
                     if isinstance(scalar, torch.SymFloat):
@@ -2940,9 +2946,9 @@ if (!custom_op_wrapper) {
             # FIXME: This happens because type_ is not always properly set to torch.ListType
             return f"{{{', '.join(self.val_to_arg_str(x, None) for x in val)}}}"
         elif isinstance(val, SymTypes):
-            return self.codegen_sizevar(val.node.expr)
+            return self.codegen_cpp_symbolic_scalar(val.node.expr)
         elif isinstance(val, SYMBOLIC_SCALAR_TYPES):
-            return self.codegen_sizevar(val)
+            return self.codegen_cpp_symbolic_scalar(val)
         else:
             return repr(val)
 

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -317,6 +317,7 @@ class CppWrapperCpu(PythonWrapperCodegen):
         value: ir.TensorBox | ir.TorchBindObject | sympy.Expr | SympyBoolean,
         bound_vars: OrderedSet[sympy.Symbol],
     ):
+        """Bind graph input metadata to the symbolic values used in generated C++."""
         code = self.prefix
 
         @functools.cache
@@ -368,11 +369,6 @@ class CppWrapperCpu(PythonWrapperCodegen):
 
         if isinstance(value, SYMBOLIC_SCALAR_TYPES):
             if not isinstance(value, sympy.Symbol) or value in bound_vars:
-                return
-            if str(value) == name:
-                # The extracted runtime scalar input already uses the symbol's
-                # name, so reusing it avoids a colliding redeclaration.
-                bound_vars.add(value)
                 return
             if getattr(value, "is_Boolean", False):
                 decl = "bool"

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -29,7 +29,13 @@ from torch.utils._sympy.symbol import symbol_is_type, SymT
 
 from .. import config, cpp_builder, ir
 from ..ir import ExternKernel
-from ..utils import _align, DeferredLineBase, LineContext, normalize_name
+from ..utils import (
+    _align,
+    DeferredLineBase,
+    is_sympy_boolean,
+    LineContext,
+    normalize_name,
+)
 from ..virtualized import V
 from .aoti_hipify_utils import maybe_hipify_code_wrapper
 from .common import get_device_op_overrides, IndentedBuffer, Kernel
@@ -370,7 +376,7 @@ class CppWrapperCpu(PythonWrapperCodegen):
         if isinstance(value, SYMBOLIC_SCALAR_TYPES):
             if not isinstance(value, sympy.Symbol) or value in bound_vars:
                 return
-            if getattr(value, "is_Boolean", False):
+            if is_sympy_boolean(value):
                 decl = "bool"
             elif value.is_integer:
                 decl = "int64_t"

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -402,6 +402,12 @@ class CppWrapperCpu(PythonWrapperCodegen):
         """
 
         def gen_check(handle_kind, idx, name, tensor):
+            if not isinstance(tensor, ir.TensorBox):
+                # Symbolic scalar inputs are tensorized by the Python AOT
+                # loaders, but these runtime checks are only defined for real
+                # tensor graph inputs with size/stride metadata.
+                return
+
             # Wrap AtenTensorHandle with ConstantHandle for cleaner utility function access
             self.prefix.writeline(
                 f"ConstantHandle {name} = ConstantHandle({handle_kind}[{idx}]);"

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -17,7 +17,12 @@ import torch._higher_order_ops.torchbind
 import torch._inductor.async_compile  # noqa: F401 required to warm up AsyncCompile pools
 import torch._ops
 from torch._inductor.runtime.runtime_utils import dynamo_timed
-from torch.fx.experimental.symbolic_shapes import ConvertIntKey, DivideByKey, SymTypes
+from torch.fx.experimental.symbolic_shapes import (
+    ConvertIntKey,
+    DivideByKey,
+    SympyBoolean,
+    SymTypes,
+)
 from torch.utils._ordered_set import OrderedSet
 from torch.utils._sympy.functions import CleanDiv, FloorDiv, Mod, ModularIndexing
 from torch.utils._sympy.symbol import symbol_is_type, SymT
@@ -51,6 +56,9 @@ if TYPE_CHECKING:
 
 class HasWriteLine(Protocol):
     def writeline(self, line: LineContext | DeferredLineBase | str) -> None: ...
+
+
+SYMBOLIC_SCALAR_TYPES = (sympy.Expr, sympy.logic.boolalg.Boolean)
 
 
 class CppWrapperCpu(PythonWrapperCodegen):
@@ -358,10 +366,12 @@ class CppWrapperCpu(PythonWrapperCodegen):
                         str(sympy.Eq(sym_or_exp, size_symbol)) + " is not solvable"
                     )
 
-        if isinstance(value, sympy.Expr):
+        if isinstance(value, SYMBOLIC_SCALAR_TYPES):
             if not isinstance(value, sympy.Symbol) or value in bound_vars:
                 return
-            if value.is_integer:
+            if getattr(value, "is_Boolean", False):
+                decl = "bool"
+            elif value.is_integer:
                 decl = "int64_t"
             elif value.is_float:
                 decl = "double"
@@ -619,14 +629,14 @@ class CppWrapperCpu(PythonWrapperCodegen):
             if inputs_len != 0:
                 for idx, input_key in enumerate(V.graph.graph_inputs.keys()):
                     # unwrap input tensor back to scalar
-                    if isinstance(V.graph.graph_inputs[input_key], sympy.Expr):
+                    if isinstance(V.graph.graph_inputs[input_key], SYMBOLIC_SCALAR_TYPES):
                         from ..graph import may_get_constant_buffer_dtype
 
                         dtype = may_get_constant_buffer_dtype(
                             V.graph.graph_inputs[input_key]  # type: ignore[arg-type]
                         )
                         assert dtype is not None, (
-                            "Fails to get the dtype of the sympy.Expr"
+                            "Fails to get the dtype of the symbolic scalar input"
                         )
                         self.codegen_tensor_item(
                             dtype, f"inputs[{idx}]", input_key, self.prefix
@@ -1493,7 +1503,7 @@ class CppWrapperCpu(PythonWrapperCodegen):
         super().add_benchmark_harness(output)
 
     def _extract_divisors_from_expr(
-        self, expr: sympy.Expr
+        self, expr: sympy.Expr | SympyBoolean
     ) -> list[tuple[sympy.Expr, str]]:
         """
         Walk the sympy expression and extract all divisors/modulos from
@@ -1521,7 +1531,7 @@ class CppWrapperCpu(PythonWrapperCodegen):
                     seen.add(key)
                     divisors.append((divisor, op_name))
 
-        def walk(e: sympy.Expr) -> None:
+        def walk(e: sympy.Expr | SympyBoolean) -> None:
             if isinstance(e, (FloorDiv, CleanDiv)):
                 _, div = e.args
                 maybe_add_divisor(div, "floor division")
@@ -1536,13 +1546,15 @@ class CppWrapperCpu(PythonWrapperCodegen):
             # Recurse into arguments
             if hasattr(e, "args"):
                 for arg in e.args:
-                    if isinstance(arg, sympy.Expr):
+                    if isinstance(arg, SYMBOLIC_SCALAR_TYPES):
                         walk(arg)
 
         walk(expr)
         return divisors
 
-    def codegen_cpp_sizevar(self, x: sympy.Expr, *, simplify: bool = True) -> str:
+    def codegen_cpp_sizevar(
+        self, x: sympy.Expr | SympyBoolean, *, simplify: bool = True
+    ) -> str:
         maybe_simplified_x = V.graph.sizevars.simplify(x) if simplify else x
         # In AOT mode, emit runtime checks for potential division/modulo by zero
         # to prevent SIGFPE crashes when symbolic tensor shapes can be 0
@@ -1555,7 +1567,7 @@ class CppWrapperCpu(PythonWrapperCodegen):
                 )
         return cexpr(maybe_simplified_x)
 
-    def codegen_sizevar(self, x: sympy.Expr) -> str:
+    def codegen_sizevar(self, x: sympy.Expr | SympyBoolean) -> str:
         return self.codegen_cpp_sizevar(x)
 
     def codegen_tuple_access(self, basename: str, name: str, index: str) -> str:
@@ -2927,7 +2939,7 @@ if (!custom_op_wrapper) {
             return f"{{{', '.join(self.val_to_arg_str(x, None) for x in val)}}}"
         elif isinstance(val, SymTypes):
             return cexpr(val.node.expr)
-        elif isinstance(val, sympy.Expr):
+        elif isinstance(val, SYMBOLIC_SCALAR_TYPES):
             return cexpr(val)
         else:
             return repr(val)

--- a/torch/_inductor/codegen/cpp_wrapper_cpu_array_ref.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu_array_ref.py
@@ -317,7 +317,9 @@ class CppWrapperCpuArrayRef(CppWrapperCpu):
                         )
                         continue
                     # unwrap input tensor back to scalar
-                    if isinstance(V.graph.graph_inputs[input_key], SYMBOLIC_SCALAR_TYPES):
+                    if isinstance(
+                        V.graph.graph_inputs[input_key], SYMBOLIC_SCALAR_TYPES
+                    ):
                         from ..graph import may_get_constant_buffer_dtype
 
                         dtype = may_get_constant_buffer_dtype(

--- a/torch/_inductor/codegen/cpp_wrapper_cpu_array_ref.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu_array_ref.py
@@ -2,14 +2,12 @@
 from collections.abc import Callable, Sequence
 from typing import Any
 
-import sympy
-
 import torch
 import torch._inductor.async_compile  # noqa: F401 required to warm up AsyncCompile pools
 import torch._ops
 
 from .. import config, ir
-from ..utils import sympy_product
+from ..utils import sympy_product, SYMBOLIC_SCALAR_TYPES
 from ..virtualized import V
 from .cpp_utils import DTYPE_TO_CPP
 from .cpp_wrapper_cpu import CppWrapperCpu
@@ -31,7 +29,6 @@ BufferName = str
 # - Windows: 1 MB
 # Just pick something comfortably smaller than the smallest for now.
 MAX_STACK_ALLOCATION_SIZE = 1024 * 100
-SYMBOLIC_SCALAR_TYPES = (sympy.Expr, sympy.logic.boolalg.Boolean)
 
 
 class CppWrapperCpuArrayRef(CppWrapperCpu):

--- a/torch/_inductor/codegen/cpp_wrapper_cpu_array_ref.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu_array_ref.py
@@ -31,6 +31,7 @@ BufferName = str
 # - Windows: 1 MB
 # Just pick something comfortably smaller than the smallest for now.
 MAX_STACK_ALLOCATION_SIZE = 1024 * 100
+SYMBOLIC_SCALAR_TYPES = (sympy.Expr, sympy.logic.boolalg.Boolean)
 
 
 class CppWrapperCpuArrayRef(CppWrapperCpu):
@@ -62,11 +63,13 @@ class CppWrapperCpuArrayRef(CppWrapperCpu):
     def get_input_cpp_type(input):
         assert config.aot_inductor.use_minimal_arrayref_interface
 
-        if isinstance(input, sympy.Expr):
+        if isinstance(input, SYMBOLIC_SCALAR_TYPES):
             from ..graph import may_get_constant_buffer_dtype
 
             dtype = may_get_constant_buffer_dtype(input)
-            assert dtype is not None, f"Failed to get the dtype of sympy.Expr: {input}"
+            assert dtype is not None, (
+                f"Failed to get the dtype of symbolic scalar input: {input}"
+            )
             return DTYPE_TO_CPP[dtype]
         return f"ArrayRefTensor<{DTYPE_TO_CPP[input.get_dtype()]}>"
 
@@ -79,7 +82,7 @@ class CppWrapperCpuArrayRef(CppWrapperCpu):
 
     def codegen_input_numel_asserts(self):
         for name, buf in V.graph.graph_inputs.items():
-            if isinstance(buf, sympy.Expr):
+            if isinstance(buf, SYMBOLIC_SCALAR_TYPES):
                 continue
 
             # comparing strides for 0 size tensor is tricky. Ignore them for now.
@@ -314,14 +317,14 @@ class CppWrapperCpuArrayRef(CppWrapperCpu):
                         )
                         continue
                     # unwrap input tensor back to scalar
-                    if isinstance(V.graph.graph_inputs[input_key], sympy.Expr):
+                    if isinstance(V.graph.graph_inputs[input_key], SYMBOLIC_SCALAR_TYPES):
                         from ..graph import may_get_constant_buffer_dtype
 
                         dtype = may_get_constant_buffer_dtype(
                             V.graph.graph_inputs[input_key]  # type: ignore[arg-type]
                         )
                         assert dtype is not None, (
-                            "Fails to get the dtype of the sympy.Expr"
+                            "Fails to get the dtype of the symbolic scalar input"
                         )
                         self.codegen_tensor_item(
                             dtype, f"inputs[{idx}]", input_key, self.prefix

--- a/torch/_inductor/codegen/cpp_wrapper_gpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_gpu.py
@@ -1292,9 +1292,8 @@ static struct TritonKernelCompileInit {{
             call_args_str = ", ".join(casted)
             self.writeline(f"kernels.{kernel_name}({call_args_str}, {stream});")
 
-    @staticmethod
     def prepare_triton_wrapper_args(
-        call_args: list[Any], arg_types: list[Any]
+        self, call_args: list[Any], arg_types: list[Any]
     ) -> tuple[list[Any], list[Any]]:
         assert len(call_args) == len(arg_types), (call_args, arg_types)
         new_args = []
@@ -1309,6 +1308,8 @@ static struct TritonKernelCompileInit {{
                 new_args.append(str(arg).lower())
             elif isinstance(arg, (int, float, SymbolicCallArg)):
                 new_args.append(str(arg))
+            elif isinstance(arg, (sympy.Expr, sympy.logic.boolalg.Boolean)):
+                new_args.append(self.codegen_cpp_symbolic_scalar(arg))
             else:
                 new_args.append(cexpr(V.graph.sizevars.simplify(arg)))
             new_args_types.append(arg_type)

--- a/torch/_inductor/codegen/cpp_wrapper_gpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_gpu.py
@@ -264,6 +264,8 @@ class DeferredTritonCallWrapper:
             return f"const {name}_type_& {name}"
         elif issubclass(arg_type, (SymbolicCallArg, sympy.Expr, int)):
             return f"int64_t {name}"
+        elif issubclass(arg_type, sympy.logic.boolalg.Boolean):
+            return f"bool {name}"
         elif arg_type is float:
             return f"float {name}"
         elif arg_type is bool:

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -1581,6 +1581,9 @@ class PythonWrapperCodegen(CodeGen):
             self.prefix.writeline(line)
 
     def codegen_specialized_graph_input_asserts(self) -> None:
+        if not V.graph.fx_wrapper:
+            return
+
         graph_input_names = set(self.get_graph_input_names())
         for name, value in self.get_specialized_graph_input_values().items():
             if name not in graph_input_names:

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -57,6 +57,7 @@ from ..utils import (
     get_dtype_size,
     IndentedBuffer,
     is_codegen_graph_partition_subgraph,
+    is_sympy_boolean,
     is_using_cudagraph_partition,
     LineContext,
     sympy_product,
@@ -1526,7 +1527,7 @@ class PythonWrapperCodegen(CodeGen):
 
             # Boolean graph-input relations, such as Eq(u0, 1), need to be
             # materialized as standalone placeholders at graph boundaries.
-            if isinstance(value, sympy.logic.boolalg.Boolean):
+            if is_sympy_boolean(value):
                 assert isinstance(value, sympy.Basic)
                 if not value.is_Atom:
                     replacements[value] = sympy.Symbol(name)

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -1518,6 +1518,7 @@ class PythonWrapperCodegen(CodeGen):
             for name, value in self.get_graph_inputs().items()
             if isinstance(value, SYMBOLIC_SCALAR_TYPES)
             and not isinstance(value, sympy.Symbol)
+            and not value.is_Atom
         }
 
     def replace_symbolic_scalar_graph_inputs(
@@ -2264,9 +2265,7 @@ class PythonWrapperCodegen(CodeGen):
     def codegen_python_sizevar(
         self, x: Expr | SympyBoolean, *, simplify: bool = True
     ) -> str:
-        return pexpr(
-            self.replace_symbolic_scalar_graph_inputs(x), simplify=simplify
-        )
+        return pexpr(self.replace_symbolic_scalar_graph_inputs(x), simplify=simplify)
 
     def codegen_sizevar(self, x: Expr | SympyBoolean) -> str:
         return self.codegen_python_sizevar(x)

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -1516,23 +1516,20 @@ class PythonWrapperCodegen(CodeGen):
         replacements: dict[sympy.Basic, sympy.Symbol] = {}
         for name, value in self.get_graph_inputs().items():
             # Numeric sympy.Expr inputs are already handled correctly by the
-            # existing wrapper paths, except for renamed scalar placeholders:
-            # these use an internal sympy.Symbol like "arg0_symint" while the
-            # runtime wrapper argument is still named "arg0".
-            if isinstance(value, sympy.Symbol) and str(value) != name:
+            # existing wrapper paths, except for synthetic placeholder symbols
+            # introduced to avoid collisions with tensor graph input names.
+            if isinstance(value, sympy.Symbol) and str(value).startswith(
+                f"{name}_symint"
+            ):
                 replacements[value] = sympy.Symbol(name, **value.assumptions0)
                 continue
 
             # Boolean graph-input relations, such as Eq(u0, 1), need to be
             # materialized as standalone placeholders at graph boundaries.
-            if (
-                (
-                    isinstance(value, sympy.logic.boolalg.Boolean)
-                    or getattr(value, "is_Boolean", False)
-                )
-                and not value.is_Atom
-            ):
-                replacements[value] = sympy.Symbol(name)
+            if isinstance(value, sympy.logic.boolalg.Boolean):
+                assert isinstance(value, sympy.Basic)
+                if not value.is_Atom:
+                    replacements[value] = sympy.Symbol(name)
 
         return replacements
 

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -60,6 +60,7 @@ from ..utils import (
     is_sympy_boolean,
     is_using_cudagraph_partition,
     LineContext,
+    SYMBOLIC_SCALAR_TYPES,
     sympy_product,
     sympy_str,
     sympy_subs,
@@ -93,7 +94,6 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 pexpr = PythonPrinter().doprint
-SYMBOLIC_SCALAR_TYPES = (sympy.Expr, sympy.logic.boolalg.Boolean)
 
 
 ReuseKey = tuple[torch.device, torch.dtype, str, bool]
@@ -1525,8 +1525,11 @@ class PythonWrapperCodegen(CodeGen):
                 replacements[value] = sympy.Symbol(name, **value.assumptions0)
                 continue
 
-            # Boolean graph-input relations, such as Eq(u0, 1), need to be
-            # materialized as standalone placeholders at graph boundaries.
+            # torch.compile commonly materializes SymBool placeholders as
+            # relations like Eq(u0, 1) rather than standalone Symbol nodes.
+            # When those relations cross a graph boundary, rewrite the whole
+            # relation to the runtime placeholder name so wrapper-emitted
+            # expressions do not leak internal unbacked symbols such as u0/u1.
             if is_sympy_boolean(value):
                 assert isinstance(value, sympy.Basic)
                 if not value.is_Atom:
@@ -2512,24 +2515,17 @@ class PythonWrapperCodegen(CodeGen):
                         output.writeline("import pickle")
                     output.writeline(f"global {name}")
                     add_torchbind_input(name, value.get_real_obj())
-                elif isinstance(value, sympy.Expr):  # Don't need to add symbolic
+                elif isinstance(value, SYMBOLIC_SCALAR_TYPES):  # Don't need to add symbolic
                     # TODO: this fallback and those below actually will generate possibly
                     # invalid benchmark code, because it's not guaranteed 42
                     # is actually a valid value for the kernel in question.
                     # See https://github.com/pytorch/pytorch/issues/124686
-                    if getattr(value, "is_Boolean", False):
-                        add_expr_input(
-                            name,
-                            V.graph.sizevars.evaluate_expr(value, fallback_value=False),
-                        )
-                    else:
-                        add_expr_input(
-                            name, V.graph.sizevars.optimization_hint(value, fallback=42)
-                        )
-                elif isinstance(value, sympy.logic.boolalg.Boolean):
                     add_expr_input(
                         name,
-                        V.graph.sizevars.evaluate_expr(value, fallback_value=False),
+                        V.graph.sizevars.optimization_hint(
+                            value,
+                            fallback=False if is_sympy_boolean(value) else 42,
+                        ),
                     )
                 elif isinstance(value, ir.GeneratorState):
                     add_expr_input(

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -1506,9 +1506,7 @@ class PythonWrapperCodegen(CodeGen):
 
     def get_graph_inputs(
         self,
-    ) -> dict[
-        str, ir.TensorBox | ir.TorchBindObject | sympy.Expr | SympyBoolean
-    ]:
+    ) -> dict[str, ir.TensorBox | ir.TorchBindObject | sympy.Expr | SympyBoolean]:
         return V.graph.graph_inputs
 
     def get_graph_outputs(self) -> list[IRNode]:
@@ -2485,10 +2483,7 @@ class PythonWrapperCodegen(CodeGen):
                     # See https://github.com/pytorch/pytorch/issues/124686
                     if getattr(value, "is_Boolean", False):
                         add_expr_input(
-                            name,
-                            V.graph.sizevars.evaluate_expr(
-                                value, fallback_value=False
-                            ),
+                            name, V.graph.sizevars.evaluate_expr(value, fallback_value=False)
                         )
                     else:
                         add_expr_input(

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -35,6 +35,7 @@ from torch.fx.experimental.symbolic_shapes import (
     ConvertIntKey,
     DivideByKey,
     resolve_unbacked_bindings,
+    SympyBoolean,
     SymTypes,
 )
 from torch.fx.node import _get_qualified_name
@@ -91,6 +92,7 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 pexpr = PythonPrinter().doprint
+SYMBOLIC_SCALAR_TYPES = (sympy.Expr, sympy.logic.boolalg.Boolean)
 
 
 ReuseKey = tuple[torch.device, torch.dtype, str, bool]
@@ -1504,7 +1506,9 @@ class PythonWrapperCodegen(CodeGen):
 
     def get_graph_inputs(
         self,
-    ) -> dict[str, ir.TensorBox | ir.TorchBindObject | sympy.Expr]:
+    ) -> dict[
+        str, ir.TensorBox | ir.TorchBindObject | sympy.Expr | SympyBoolean
+    ]:
         return V.graph.graph_inputs
 
     def get_graph_outputs(self) -> list[IRNode]:
@@ -1512,7 +1516,7 @@ class PythonWrapperCodegen(CodeGen):
 
     def codegen_input_size_asserts(self) -> None:
         for name, buf in self.get_graph_inputs().items():
-            if isinstance(buf, (sympy.Expr, ir.TorchBindObject)):
+            if isinstance(buf, (*SYMBOLIC_SCALAR_TYPES, ir.TorchBindObject)):
                 continue
 
             # a graph partition may take an IRNode output from a previous partition
@@ -1531,7 +1535,7 @@ class PythonWrapperCodegen(CodeGen):
     def codegen_input_nan_asserts(self) -> None:
         self.prefix.writeline("# make sure graph inputs are not nan/inf")
         for name, buf in self.get_graph_inputs().items():
-            if isinstance(buf, (sympy.Expr, ir.TorchBindObject)):
+            if isinstance(buf, (*SYMBOLIC_SCALAR_TYPES, ir.TorchBindObject)):
                 continue
 
             line = f"assert not {name}.isnan().any().item()"
@@ -2143,7 +2147,7 @@ class PythonWrapperCodegen(CodeGen):
     def codegen_input_symbol_assignment(
         self,
         name: str,
-        value: ir.TensorBox,
+        value: ir.TensorBox | ir.TorchBindObject | sympy.Expr | SympyBoolean,
         bound_vars: OrderedSet[sympy.Symbol],
     ):
         code = self.prefix
@@ -2158,7 +2162,7 @@ class PythonWrapperCodegen(CodeGen):
             code.writeline(f"{name}_stride = {name}.stride()")
             return f"{name}_stride"
 
-        if isinstance(value, sympy.Expr):
+        if isinstance(value, SYMBOLIC_SCALAR_TYPES):
             if not isinstance(value, sympy.Symbol) or value in bound_vars:
                 return
             code.writeline(f"{value} = {name}")
@@ -2235,13 +2239,17 @@ class PythonWrapperCodegen(CodeGen):
     def finalize_prefix(self):
         pass
 
-    def codegen_cpp_sizevar(self, x: Expr, *, simplify: bool = True) -> str:
+    def codegen_cpp_sizevar(
+        self, x: Expr | SympyBoolean, *, simplify: bool = True
+    ) -> str:
         raise RuntimeError("codegen_cpp_sizevar is only implemented for cpp_wrapper!")
 
-    def codegen_python_sizevar(self, x: Expr, *, simplify: bool = True) -> str:
+    def codegen_python_sizevar(
+        self, x: Expr | SympyBoolean, *, simplify: bool = True
+    ) -> str:
         return pexpr(x, simplify=simplify)
 
-    def codegen_sizevar(self, x: Expr) -> str:
+    def codegen_sizevar(self, x: Expr | SympyBoolean) -> str:
         return self.codegen_python_sizevar(x)
 
     def codegen_tuple_access(self, basename: str, name: str, index: str) -> str:
@@ -2475,8 +2483,21 @@ class PythonWrapperCodegen(CodeGen):
                     # invalid benchmark code, because it's not guaranteed 42
                     # is actually a valid value for the kernel in question.
                     # See https://github.com/pytorch/pytorch/issues/124686
+                    if getattr(value, "is_Boolean", False):
+                        add_expr_input(
+                            name,
+                            V.graph.sizevars.evaluate_expr(
+                                value, fallback_value=False
+                            ),
+                        )
+                    else:
+                        add_expr_input(
+                            name, V.graph.sizevars.optimization_hint(value, fallback=42)
+                        )
+                elif isinstance(value, sympy.logic.boolalg.Boolean):
                     add_expr_input(
-                        name, V.graph.sizevars.optimization_hint(value, fallback=42)
+                        name,
+                        V.graph.sizevars.evaluate_expr(value, fallback_value=False),
                     )
                 elif isinstance(value, ir.GeneratorState):
                     add_expr_input(
@@ -3362,7 +3383,7 @@ class PythonWrapperCodegen(CodeGen):
 
         if isinstance(s, SymTypes):
             return pexpr(s.node.expr)
-        elif isinstance(s, sympy.Expr):
+        elif isinstance(s, SYMBOLIC_SCALAR_TYPES):
             return pexpr(s)
         elif isinstance(s, (tuple, list)):
 
@@ -4146,7 +4167,10 @@ class SubgraphPythonWrapperCodegen(PythonWrapperCodegen):
 
     def get_graph_inputs(
         self,
-    ) -> dict[str, ir.TensorBox | ir.TorchBindObject | sympy.Expr | None]:
+    ) -> dict[
+        str,
+        ir.TensorBox | ir.TorchBindObject | sympy.Expr | SympyBoolean | None,
+    ]:
         if signature := self.partition_signatures:
             inputs = signature.input_nodes | {
                 str(s): s for s in signature.symbol_inputs

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -1516,8 +1516,10 @@ class PythonWrapperCodegen(CodeGen):
         return {
             value: sympy.Symbol(name)
             for name, value in self.get_graph_inputs().items()
-            if isinstance(value, SYMBOLIC_SCALAR_TYPES)
-            and not isinstance(value, sympy.Symbol)
+            # Numeric sympy.Expr inputs are already handled correctly by the
+            # existing wrapper paths. Only boolean graph-input relations need to
+            # be materialized as standalone placeholders at graph boundaries.
+            if getattr(value, "is_Boolean", False)
             and not value.is_Atom
         }
 

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -1513,15 +1513,28 @@ class PythonWrapperCodegen(CodeGen):
     def get_symbolic_scalar_graph_input_replacements(
         self,
     ) -> dict[sympy.Basic, sympy.Symbol]:
-        return {
-            value: sympy.Symbol(name)
-            for name, value in self.get_graph_inputs().items()
+        replacements: dict[sympy.Basic, sympy.Symbol] = {}
+        for name, value in self.get_graph_inputs().items():
             # Numeric sympy.Expr inputs are already handled correctly by the
-            # existing wrapper paths. Only boolean graph-input relations need to
-            # be materialized as standalone placeholders at graph boundaries.
-            if getattr(value, "is_Boolean", False)
-            and not value.is_Atom
-        }
+            # existing wrapper paths, except for renamed scalar placeholders:
+            # these use an internal sympy.Symbol like "arg0_symint" while the
+            # runtime wrapper argument is still named "arg0".
+            if isinstance(value, sympy.Symbol) and str(value) != name:
+                replacements[value] = sympy.Symbol(name, **value.assumptions0)
+                continue
+
+            # Boolean graph-input relations, such as Eq(u0, 1), need to be
+            # materialized as standalone placeholders at graph boundaries.
+            if (
+                (
+                    isinstance(value, sympy.logic.boolalg.Boolean)
+                    or getattr(value, "is_Boolean", False)
+                )
+                and not value.is_Atom
+            ):
+                replacements[value] = sympy.Symbol(name)
+
+        return replacements
 
     def replace_symbolic_scalar_graph_inputs(
         self, expr: Expr | SympyBoolean

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -1509,6 +1509,25 @@ class PythonWrapperCodegen(CodeGen):
     ) -> dict[str, ir.TensorBox | ir.TorchBindObject | sympy.Expr | SympyBoolean]:
         return V.graph.graph_inputs
 
+    @cache_on_self
+    def get_symbolic_scalar_graph_input_replacements(
+        self,
+    ) -> dict[sympy.Basic, sympy.Symbol]:
+        return {
+            value: sympy.Symbol(name)
+            for name, value in self.get_graph_inputs().items()
+            if isinstance(value, SYMBOLIC_SCALAR_TYPES)
+            and not isinstance(value, sympy.Symbol)
+        }
+
+    def replace_symbolic_scalar_graph_inputs(
+        self, expr: Expr | SympyBoolean
+    ) -> Expr | SympyBoolean:
+        replacements = self.get_symbolic_scalar_graph_input_replacements()
+        if not replacements:
+            return expr
+        return sympy.sympify(expr).xreplace(replacements)
+
     def get_graph_outputs(self) -> list[IRNode]:
         return V.graph.graph_outputs
 
@@ -2245,7 +2264,9 @@ class PythonWrapperCodegen(CodeGen):
     def codegen_python_sizevar(
         self, x: Expr | SympyBoolean, *, simplify: bool = True
     ) -> str:
-        return pexpr(x, simplify=simplify)
+        return pexpr(
+            self.replace_symbolic_scalar_graph_inputs(x), simplify=simplify
+        )
 
     def codegen_sizevar(self, x: Expr | SympyBoolean) -> str:
         return self.codegen_python_sizevar(x)
@@ -3378,9 +3399,9 @@ class PythonWrapperCodegen(CodeGen):
             import triton
 
         if isinstance(s, SymTypes):
-            return pexpr(s.node.expr)
+            return self.codegen_sizevar(s.node.expr)
         elif isinstance(s, SYMBOLIC_SCALAR_TYPES):
-            return pexpr(s)
+            return self.codegen_sizevar(s)
         elif isinstance(s, (tuple, list)):
 
             @dataclasses.dataclass

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -2484,9 +2484,7 @@ class PythonWrapperCodegen(CodeGen):
                     if getattr(value, "is_Boolean", False):
                         add_expr_input(
                             name,
-                            V.graph.sizevars.evaluate_expr(
-                                value, fallback_value=False
-                            ),
+                            V.graph.sizevars.evaluate_expr(value, fallback_value=False),
                         )
                     else:
                         add_expr_input(

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -2267,6 +2267,9 @@ class PythonWrapperCodegen(CodeGen):
     ) -> str:
         return pexpr(self.replace_symbolic_scalar_graph_inputs(x), simplify=simplify)
 
+    def codegen_symbolic_scalar(self, x: Expr | SympyBoolean) -> str:
+        return pexpr(self.replace_symbolic_scalar_graph_inputs(x), simplify=False)
+
     def codegen_sizevar(self, x: Expr | SympyBoolean) -> str:
         return self.codegen_python_sizevar(x)
 
@@ -2955,7 +2958,12 @@ class PythonWrapperCodegen(CodeGen):
     def _generate_symbolic_call_arg_helper(
         self, arg: SymbolicCallArg, graph: GraphLowering
     ) -> None:
-        self.writeline(f"{arg.inner} = {pexpr(arg.inner_expr)}")
+        expr = (
+            self.codegen_sizevar(arg.inner_expr)
+            if symbol_is_type(arg.inner, SymT.PRECOMPUTED_SIZE)
+            else self.codegen_symbolic_scalar(arg.inner_expr)
+        )
+        self.writeline(f"{arg.inner} = {expr}")
 
     def generate_workspace_allocation(self, ws: WorkspaceArg):
         name = ws.get_name()
@@ -3064,6 +3072,8 @@ class PythonWrapperCodegen(CodeGen):
                 return arg + ".item()" if should_unwrap_unspec_arg(arg) else arg
             elif isinstance(arg, (int, float, bool, SymbolicCallArg)):
                 return str(arg)
+            elif isinstance(arg, SYMBOLIC_SCALAR_TYPES):
+                return self.codegen_symbolic_scalar(arg)
             else:
                 return pexpr(V.graph.sizevars.simplify(arg))
 

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -2483,7 +2483,10 @@ class PythonWrapperCodegen(CodeGen):
                     # See https://github.com/pytorch/pytorch/issues/124686
                     if getattr(value, "is_Boolean", False):
                         add_expr_input(
-                            name, V.graph.sizevars.evaluate_expr(value, fallback_value=False)
+                            name,
+                            V.graph.sizevars.evaluate_expr(
+                                value, fallback_value=False
+                            ),
                         )
                     else:
                         add_expr_input(

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -3399,9 +3399,9 @@ class PythonWrapperCodegen(CodeGen):
             import triton
 
         if isinstance(s, SymTypes):
-            return self.codegen_sizevar(s.node.expr)
+            return self.codegen_python_sizevar(s.node.expr, simplify=False)
         elif isinstance(s, SYMBOLIC_SCALAR_TYPES):
-            return self.codegen_sizevar(s)
+            return self.codegen_python_sizevar(s, simplify=False)
         elif isinstance(s, (tuple, list)):
 
             @dataclasses.dataclass

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -1510,6 +1510,9 @@ class PythonWrapperCodegen(CodeGen):
     ) -> dict[str, ir.TensorBox | ir.TorchBindObject | sympy.Expr | SympyBoolean]:
         return V.graph.graph_inputs
 
+    def get_specialized_graph_input_values(self) -> dict[str, int]:
+        return V.graph.specialized_graph_input_values
+
     @cache_on_self
     def get_symbolic_scalar_graph_input_replacements(
         self,
@@ -1577,6 +1580,17 @@ class PythonWrapperCodegen(CodeGen):
             line = f"assert not {name}.isinf().any().item()"
             self.prefix.writeline(line)
 
+    def codegen_specialized_graph_input_asserts(self) -> None:
+        graph_input_names = set(self.get_graph_input_names())
+        for name, value in self.get_specialized_graph_input_values().items():
+            if name not in graph_input_names:
+                continue
+            msg = (
+                f"specialized int input {name!r} must match its traced value "
+                f"{value!r}"
+            )
+            self.prefix.writeline(f"assert {name} == {value!r}, {msg!r}")
+
     def write_async_compile_wait(self) -> None:
         self.prefix.splice(
             """
@@ -1640,6 +1654,7 @@ class PythonWrapperCodegen(CodeGen):
 
             if graph_input_names := self.get_graph_input_names():
                 self.write_args(graph_input_names)
+                self.codegen_specialized_graph_input_asserts()
 
             self.codegen_inputs()
 
@@ -3825,9 +3840,14 @@ class PythonWrapperCodegen(CodeGen):
         input_deallocation = partition_signatures.input_deallocation
         output_nodes = partition_signatures.output_nodes
 
-        input_names = list(input_deallocation.keys()) + [
-            symbol_input.name for symbol_input in partition_signatures.symbol_inputs
-        ]
+        input_names = (
+            list(input_deallocation.keys())
+            + list(partition_signatures.scalar_inputs.keys())
+            + [
+                symbol_input.name
+                for symbol_input in partition_signatures.symbol_inputs
+            ]
+        )
 
         inputs = ", ".join(input_names) + ("," if len(input_names) == 1 else "")
 
@@ -4207,18 +4227,22 @@ class SubgraphPythonWrapperCodegen(PythonWrapperCodegen):
         ir.TensorBox | ir.TorchBindObject | sympy.Expr | SympyBoolean | None,
     ]:
         if signature := self.partition_signatures:
-            inputs = signature.input_nodes | {
-                str(s): s for s in signature.symbol_inputs
-            }
+            inputs = (
+                signature.input_nodes
+                | signature.scalar_inputs
+                | {str(s): s for s in signature.symbol_inputs}
+            )
         else:
             inputs = V.graph.graph_inputs
         return inputs
 
     def get_graph_input_names(self) -> list[str]:
         if signature := self.partition_signatures:
-            names = list(signature.input_nodes.keys()) + [
-                symbol_input.name for symbol_input in signature.symbol_inputs
-            ]
+            names = (
+                list(signature.input_nodes.keys())
+                + list(signature.scalar_inputs.keys())
+                + [symbol_input.name for symbol_input in signature.symbol_inputs]
+            )
         else:
             names = V.graph.graph_input_names
         return names

--- a/torch/_inductor/codegen/wrapper_fxir.py
+++ b/torch/_inductor/codegen/wrapper_fxir.py
@@ -661,7 +661,9 @@ class FxConverter:
         )
         return self.expr_to_proxy[expr]
 
-    def _generate_sym_node(self, s: int | sympy.Expr) -> int | torch.fx.Node:
+    def _generate_sym_node(
+        self, s: int | sympy.Expr | SympyBoolean
+    ) -> int | torch.fx.Node:
         if isinstance(s, (int, sympy.Integer)):
             return int(s)
         elif isinstance(s, sympy.Symbol):
@@ -669,7 +671,9 @@ class FxConverter:
                 f"Could not find a node corresponding to the symbol {s}"
             )
             return self.expr_to_proxy[s].node
-        elif isinstance(s, sympy.Expr):
+        elif isinstance(s, (sympy.Expr, sympy.logic.boolalg.Boolean)):
+            if s in self.expr_to_proxy:
+                return self.expr_to_proxy[s].node
             return self._sympy_interp(s).node
 
         elif isinstance(s, torch.fx.Node):
@@ -679,7 +683,7 @@ class FxConverter:
             raise ValueError(f"{s} of type {type(s)} is not a valid input")
 
     def _generate_sym_nodes(
-        self, shape: Sequence[sympy.Expr]
+        self, shape: Sequence[sympy.Expr | SympyBoolean]
     ) -> list[int | torch.fx.Node]:
         return [self._generate_sym_node(s) for s in shape]
 

--- a/torch/_inductor/codegen/wrapper_fxir.py
+++ b/torch/_inductor/codegen/wrapper_fxir.py
@@ -30,6 +30,7 @@ from torch.fx.experimental.symbolic_shapes import (
     CallMethodKey,
     ConvertIntKey,
     DivideByKey,
+    SympyBoolean,
 )
 from torch.utils import _pytree as pytree
 from torch.utils._ordered_set import OrderedSet
@@ -181,7 +182,9 @@ class WrapperFxCodegen(PythonWrapperCodegen):
 
     def get_fx_graph_inputs(
         self,
-    ) -> dict[str, ir.TensorBox | ir.TorchBindObject | sympy.Expr | None]:
+    ) -> dict[
+        str, ir.TensorBox | ir.TorchBindObject | sympy.Expr | SympyBoolean | None
+    ]:
         """
         Get the input nodes corresponding to FX graph placeholders.
         """
@@ -274,7 +277,9 @@ class FxConverter:
 
     lines: list[Line]
     prologue: str
-    graph_inputs: dict[str, ir.TensorBox | ir.TorchBindObject | sympy.Expr | None]
+    graph_inputs: dict[
+        str, ir.TensorBox | ir.TorchBindObject | sympy.Expr | SympyBoolean | None
+    ]
     graph_outputs: list[ir.IRNode]
     subgms: dict[str, torch.fx.GraphModule]
     is_subgraph: bool
@@ -288,7 +293,7 @@ class FxConverter:
         self.kernels: dict[str, TritonKernel] = {}  # Table to store Triton kernels.
         self._unique_symbol_ids: Counter[str] = Counter()
         self.tracer = torch.fx.proxy.GraphAppendingTracer(graph)
-        self.expr_to_proxy: dict[sympy.Expr, torch.fx.Proxy] = {}
+        self.expr_to_proxy: dict[sympy.Basic, torch.fx.Proxy] = {}
 
     def _import_kernel(self, code: str, kernel_name: str) -> CachingAutotuner:
         """
@@ -370,7 +375,7 @@ class FxConverter:
             raise NotImplementedError(f"Unable to extract buffer from node: {node}")
 
     def _generate_size_proxy(
-        self, node: torch.fx.Node, expr: sympy.Expr
+        self, node: torch.fx.Node, expr: sympy.Expr | SympyBoolean
     ) -> torch.fx.Proxy:
         proxy = torch.fx.Proxy(node, tracer=self.tracer)
         self.expr_to_proxy[expr] = proxy
@@ -385,6 +390,12 @@ class FxConverter:
             if ir_node is None:
                 # Create dummy input nodes to match the input signature
                 self.gm.graph.placeholder(name)
+                continue
+
+            if isinstance(ir_node, sympy.logic.boolalg.Boolean):
+                placeholder_node = self.gm.graph.placeholder(name)
+                placeholder_node.meta["val"] = ir_node
+                self._generate_size_proxy(placeholder_node, ir_node)
                 continue
 
             # Introduce a new symbol for constant inputs.
@@ -618,7 +629,7 @@ class FxConverter:
         self.gm.recompile()
         return self.gm
 
-    def _sympy_interp(self, expr: sympy.Expr) -> torch.fx.Proxy:
+    def _sympy_interp(self, expr: sympy.Expr | SympyBoolean) -> torch.fx.Proxy:
         # hash cons
         if expr in self.expr_to_proxy:
             return self.expr_to_proxy[expr]

--- a/torch/_inductor/codegen/wrapper_fxir.py
+++ b/torch/_inductor/codegen/wrapper_fxir.py
@@ -6,8 +6,7 @@ import logging
 import operator
 import textwrap
 from collections import Counter
-from collections.abc import Callable, Sequence
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import sympy
 
@@ -42,7 +41,6 @@ from torch.utils._sympy.reference import OptimizedPythonReferenceAnalysis
 from torch.utils._sympy.solve import try_solve
 
 from .. import config, ir
-from ..runtime.triton_compat import Config
 from ..utils import cache_property_on_self, LineContext, ValueWithLineMap
 from .common import (
     CodegenSymbol,
@@ -80,6 +78,11 @@ from .wrapper import (
     UnbackedSymbolDefsLine,
     WrapperLine,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+
+    from ..runtime.triton_compat import Config
 
 
 aten = torch.ops.aten
@@ -239,12 +242,12 @@ class WrapperFxCodegen(PythonWrapperCodegen):
 
     @classmethod
     def create(
-        cls: type["WrapperFxCodegen"],
+        cls: type[WrapperFxCodegen],
         is_subgraph: bool,
         subgraph_name: str | None,
         parent_wrapper: PythonWrapperCodegen | None,
         partition_signatures: ir.GraphPartitionSignature | None = None,
-    ) -> "WrapperFxCodegen":
+    ) -> WrapperFxCodegen:
         if is_subgraph:
             assert subgraph_name is not None
             assert parent_wrapper is not None

--- a/torch/_inductor/codegen/wrapper_fxir.py
+++ b/torch/_inductor/codegen/wrapper_fxir.py
@@ -411,7 +411,10 @@ class FxConverter:
                 if is_constant
                 else self._get_buffer(ir_node)
             )
-            placeholder_node = self.gm.graph.placeholder(buffer.get_name())
+            placeholder_name = (
+                name if isinstance(ir_node, sympy.Symbol) else buffer.get_name()
+            )
+            placeholder_node = self.gm.graph.placeholder(placeholder_name)
             placeholder_node.meta["val"] = (
                 ir_node if is_constant else buffer.get_example()
             )

--- a/torch/_inductor/codegen/wrapper_fxir.py
+++ b/torch/_inductor/codegen/wrapper_fxir.py
@@ -41,7 +41,12 @@ from torch.utils._sympy.reference import OptimizedPythonReferenceAnalysis
 from torch.utils._sympy.solve import try_solve
 
 from .. import config, ir
-from ..utils import cache_property_on_self, LineContext, ValueWithLineMap
+from ..utils import (
+    cache_property_on_self,
+    is_sympy_boolean,
+    LineContext,
+    ValueWithLineMap,
+)
 from .common import (
     CodegenSymbol,
     FileBackedGraphModule,
@@ -398,7 +403,7 @@ class FxConverter:
                 self.gm.graph.placeholder(name)
                 continue
 
-            if isinstance(ir_node, sympy.logic.boolalg.Boolean):
+            if is_sympy_boolean(ir_node):
                 placeholder_node = self.gm.graph.placeholder(name)
                 placeholder_node.meta["val"] = ir_node
                 self._generate_size_proxy(placeholder_node, ir_node)

--- a/torch/_inductor/codegen/wrapper_fxir.py
+++ b/torch/_inductor/codegen/wrapper_fxir.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import dataclasses
 import functools
 import logging

--- a/torch/_inductor/codegen/wrapper_fxir.py
+++ b/torch/_inductor/codegen/wrapper_fxir.py
@@ -6,7 +6,7 @@ import logging
 import operator
 import textwrap
 from collections import Counter
-from typing import TYPE_CHECKING, Any
+from typing import Any, TYPE_CHECKING
 
 import sympy
 
@@ -78,6 +78,7 @@ from .wrapper import (
     UnbackedSymbolDefsLine,
     WrapperLine,
 )
+
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -1189,31 +1189,6 @@ class GraphLowering(torch.fx.Interpreter):
 
             return non_dup_const_name
 
-    @functools.cached_property
-    def _reserved_int_placeholder_names(self) -> OrderedSet[str]:
-        reserved_names = OrderedSet(
-            self.qualify_name(node.target)
-            for node in self.module.graph.nodes  # type: ignore[union-attr]
-            if node.op == "placeholder"
-        )
-        reserved_names.update(
-            str(value)
-            for value in self.graph_inputs.values()
-            if isinstance(value, sympy.Symbol)
-        )
-        return reserved_names
-
-    def _allocate_int_placeholder_symbol(self, target: str) -> sympy.Symbol:
-        base_name = f"{target}_symint"
-        symbol_name = base_name
-        counter = 0
-        while symbol_name in self._reserved_int_placeholder_names:
-            counter += 1
-            symbol_name = f"{base_name}_{counter}"
-
-        self._reserved_int_placeholder_names.add(symbol_name)
-        return sympy.Symbol(symbol_name, integer=True)
-
     # pyrefly: ignore [bad-override]
     def placeholder(
         self,
@@ -1241,14 +1216,11 @@ class GraphLowering(torch.fx.Interpreter):
             self.graph_input_names.append(target)
             return expr
         elif isinstance(example, int):
-            # Keep runtime scalar integer inputs symbolic instead of specializing
-            # them to the example value seen during tracing. Use a distinct
-            # internal symbol so wrapper codegen can bind the symbolic value to
-            # the extracted runtime scalar without colliding on the same name.
-            expr = self._allocate_int_placeholder_symbol(target)
-            self.graph_inputs[target] = expr
+            # Plain Python ints are generally compile-time metadata inputs
+            # such as reduction axes. Keep them specialized to the traced
+            # value so downstream lowerings continue to receive concrete ints.
             self.graph_input_names.append(target)
-            return expr
+            return example
         elif isinstance(example, float):
             expr = sympy.sympify(example)
             self.graph_inputs[target] = expr

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -1231,10 +1231,10 @@ class GraphLowering(torch.fx.Interpreter):
             return expr
         elif isinstance(example, int):
             # Keep runtime scalar integer inputs symbolic instead of specializing
-            # them to the example value seen during tracing. Preserve the FX
-            # placeholder name as the symbolic identifier so downstream wrapper
-            # and FXIR signatures stay stable.
-            expr = sympy.Symbol(target, integer=True)
+            # them to the example value seen during tracing. Use a distinct
+            # internal symbol so wrapper codegen can bind the symbolic value to
+            # the extracted runtime scalar without colliding on the same name.
+            expr = sympy.Symbol(f"{target}_symint", integer=True)
             self.graph_inputs[target] = expr
             self.graph_input_names.append(target)
             return expr

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -152,14 +152,25 @@ else:
         pass
 
 
-def may_get_constant_buffer_dtype(constant_buffer: sympy.Expr) -> torch.dtype | None:
+def may_get_constant_buffer_dtype(
+    constant_buffer: sympy.Expr | SympyBoolean,
+) -> torch.dtype | None:
     assert isinstance(
-        constant_buffer, (sympy.Symbol, sympy.Expr, sympy.core.numbers.Integer)
+        constant_buffer,
+        (
+            sympy.Symbol,
+            sympy.Expr,
+            sympy.logic.boolalg.Boolean,
+            sympy.core.numbers.Integer,
+        ),
     ), (
-        "get_constant_buffer_dtype only supports input of sympy.Symbol, sympy.Expr or sympy.core.numbers.Integer"
+        "get_constant_buffer_dtype only supports symbolic scalar inputs"
     )
     if isinstance(constant_buffer, sympy.core.numbers.Integer):
         return torch.int64
+
+    if getattr(constant_buffer, "is_Boolean", False):
+        return torch.bool
 
     if isinstance(constant_buffer, sympy.Expr):
         return get_sympy_Expr_dtype(constant_buffer)
@@ -399,7 +410,10 @@ class GraphLowering(torch.fx.Interpreter):
 
         self.sizevars = SizeVarAllocator(shape_env)
         self.graph_input_names: list[str] = []
-        self.graph_inputs: dict[str, TensorBox | TorchBindObject | sympy.Expr] = {}
+        self.graph_inputs: dict[
+            str,
+            TensorBox | TorchBindObject | sympy.Expr | SympyBoolean | ir.GeneratorState,
+        ] = {}
         self.graph_inputs_original: dict[str, InputBuffer] = {}
         self.partition_maps: list[GraphPartitionMap] | None = None
         self.zero_dim_cpu_tensor_list: OrderedSet[str] = OrderedSet()
@@ -1192,7 +1206,7 @@ class GraphLowering(torch.fx.Interpreter):
         target: str,  # type: ignore[override]
         args: tuple[object],  # type: ignore[override]
         kwargs: dict[str, object],
-    ) -> Expr | TensorBox | None:
+    ) -> Expr | SympyBoolean | TensorBox | ir.GeneratorState | None:
         self.placeholder_idx += 1
         example = super().placeholder(target, args, kwargs)  # type: ignore[arg-type]
         target = self.qualify_name(target)
@@ -1577,7 +1591,13 @@ class GraphLowering(torch.fx.Interpreter):
             if isinstance(value, TorchBindObject):
                 continue
             assert isinstance(
-                value, (TensorBox, sympy.Expr, torch._inductor.ir.GeneratorState)
+                value,
+                (
+                    TensorBox,
+                    sympy.Expr,
+                    sympy.logic.boolalg.Boolean,
+                    torch._inductor.ir.GeneratorState,
+                ),
             ), f"Unsupported inductor graph input type: {type(value)}"
             if not isinstance(value, TensorBox):
                 continue

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -1205,7 +1205,11 @@ class GraphLowering(torch.fx.Interpreter):
 
     def _allocate_int_placeholder_symbol(self, target: str) -> sympy.Symbol:
         base_name = f"{target}_symint"
-        existing_names = set(self.graph_inputs)
+        existing_names = {
+            self.qualify_name(node.target)
+            for node in self.module.graph.nodes  # type: ignore[union-attr]
+            if node.op == "placeholder"
+        }
         existing_names.update(
             str(value)
             for value in self.graph_inputs.values()

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -167,7 +167,9 @@ def may_get_constant_buffer_dtype(
     if isinstance(constant_buffer, sympy.core.numbers.Integer):
         return torch.int64
 
-    if getattr(constant_buffer, "is_Boolean", False):
+    if isinstance(constant_buffer, sympy.logic.boolalg.Boolean) or getattr(
+        constant_buffer, "is_Boolean", False
+    ):
         return torch.bool
 
     if isinstance(constant_buffer, sympy.Expr):

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -163,9 +163,7 @@ def may_get_constant_buffer_dtype(
             sympy.logic.boolalg.Boolean,
             sympy.core.numbers.Integer,
         ),
-    ), (
-        "get_constant_buffer_dtype only supports symbolic scalar inputs"
-    )
+    ), "get_constant_buffer_dtype only supports symbolic scalar inputs"
     if isinstance(constant_buffer, sympy.core.numbers.Integer):
         return torch.int64
 
@@ -984,7 +982,10 @@ class GraphLowering(torch.fx.Interpreter):
         if buffer_name in self.name_to_buffer:
             return self.name_to_buffer[buffer_name]
         if buffer_name in self.graph_inputs:
-            return self.graph_inputs[buffer_name]
+            graph_input = self.graph_inputs[buffer_name]
+            if isinstance(graph_input, (ir.TensorBox, ir.TorchBindObject)):
+                return graph_input
+            return None
         if buffer_name in self.constants:
             data = V.graph.constants[buffer_name]
             return ir.ConstantBuffer(

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -1203,6 +1203,7 @@ class GraphLowering(torch.fx.Interpreter):
 
             return non_dup_const_name
 
+    # pyrefly: ignore [bad-override]
     def placeholder(
         self,
         target: str,  # type: ignore[override]
@@ -1230,10 +1231,10 @@ class GraphLowering(torch.fx.Interpreter):
             return expr
         elif isinstance(example, int):
             # Keep runtime scalar integer inputs symbolic instead of specializing
-            # them to the example value seen during tracing. Use a distinct
-            # symbol name so wrapper codegen can bind the symbolic value to the
-            # runtime scalar input without shadowing the extracted input local.
-            expr = sympy.Symbol(f"{target}_symint", integer=True)
+            # them to the example value seen during tracing. Preserve the FX
+            # placeholder name as the symbolic identifier so downstream wrapper
+            # and FXIR signatures stay stable.
+            expr = sympy.Symbol(target, integer=True)
             self.graph_inputs[target] = expr
             self.graph_input_names.append(target)
             return expr

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -396,6 +396,7 @@ class GraphLowering(torch.fx.Interpreter):
 
         self.sizevars = SizeVarAllocator(shape_env)
         self.graph_input_names: list[str] = []
+        self.specialized_graph_input_values: dict[str, int] = {}
         self.graph_inputs: dict[
             str,
             TensorBox | TorchBindObject | sympy.Expr | SympyBoolean | ir.GeneratorState,
@@ -1219,6 +1220,7 @@ class GraphLowering(torch.fx.Interpreter):
             # Plain Python ints are generally compile-time metadata inputs
             # such as reduction axes. Keep them specialized to the traced
             # value so downstream lowerings continue to receive concrete ints.
+            self.specialized_graph_input_values[target] = example
             self.graph_input_names.append(target)
             return example
         elif isinstance(example, float):

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -1223,7 +1223,19 @@ class GraphLowering(torch.fx.Interpreter):
             self.graph_inputs[target] = expr
             self.graph_input_names.append(target)
             return expr
-        elif isinstance(example, (int, bool, float)):
+        elif isinstance(example, bool):
+            expr = sympy.sympify(example)
+            self.graph_inputs[target] = expr
+            self.graph_input_names.append(target)
+            return expr
+        elif isinstance(example, int):
+            # Keep runtime scalar integer inputs symbolic instead of specializing
+            # them to the example value seen during tracing.
+            expr = sympy.Symbol(target, integer=True)
+            self.graph_inputs[target] = expr
+            self.graph_input_names.append(target)
+            return expr
+        elif isinstance(example, float):
             expr = sympy.sympify(example)
             self.graph_inputs[target] = expr
             self.graph_input_names.append(target)

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -1203,13 +1203,13 @@ class GraphLowering(torch.fx.Interpreter):
 
             return non_dup_const_name
 
-    # pyrefly: ignore [bad-override]
     def placeholder(
         self,
         target: str,  # type: ignore[override]
         args: tuple[object],  # type: ignore[override]
         kwargs: dict[str, object],
     ) -> Expr | SympyBoolean | TensorBox | ir.GeneratorState | None:
+        """Lower an FX placeholder into an inductor graph input."""
         self.placeholder_idx += 1
         example = super().placeholder(target, args, kwargs)  # type: ignore[arg-type]
         target = self.qualify_name(target)
@@ -1230,8 +1230,10 @@ class GraphLowering(torch.fx.Interpreter):
             return expr
         elif isinstance(example, int):
             # Keep runtime scalar integer inputs symbolic instead of specializing
-            # them to the example value seen during tracing.
-            expr = sympy.Symbol(target, integer=True)
+            # them to the example value seen during tracing. Use a distinct
+            # symbol name so wrapper codegen can bind the symbolic value to the
+            # runtime scalar input without shadowing the extracted input local.
+            expr = sympy.Symbol(f"{target}_symint", integer=True)
             self.graph_inputs[target] = expr
             self.graph_input_names.append(target)
             return expr

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -1203,6 +1203,23 @@ class GraphLowering(torch.fx.Interpreter):
 
             return non_dup_const_name
 
+    def _allocate_int_placeholder_symbol(self, target: str) -> sympy.Symbol:
+        base_name = f"{target}_symint"
+        existing_names = set(self.graph_inputs)
+        existing_names.update(
+            str(value)
+            for value in self.graph_inputs.values()
+            if isinstance(value, sympy.Symbol)
+        )
+
+        symbol_name = base_name
+        counter = 0
+        while symbol_name in existing_names:
+            counter += 1
+            symbol_name = f"{base_name}_{counter}"
+
+        return sympy.Symbol(symbol_name, integer=True)
+
     # pyrefly: ignore [bad-override]
     def placeholder(
         self,
@@ -1234,7 +1251,7 @@ class GraphLowering(torch.fx.Interpreter):
             # them to the example value seen during tracing. Use a distinct
             # internal symbol so wrapper codegen can bind the symbolic value to
             # the extracted runtime scalar without colliding on the same name.
-            expr = sympy.Symbol(f"{target}_symint", integer=True)
+            expr = self._allocate_int_placeholder_symbol(target)
             self.graph_inputs[target] = expr
             self.graph_input_names.append(target)
             return expr

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -109,10 +109,12 @@ from .utils import (
     get_donated_idxs,
     get_sympy_Expr_dtype,
     GraphPartitionMap,
+    is_symbolic_scalar,
     is_same_tensor,
     is_sympy_boolean,
     maybe_get_suppress_shape_guards_ctx,
     normalize_name,
+    SYMBOLIC_SCALAR_TYPES,
     should_assume_input_aligned,
     should_fallback_by_default,
     SUPPORTED_MKLDNN_DEVICES,
@@ -156,30 +158,15 @@ else:
 def may_get_constant_buffer_dtype(
     constant_buffer: sympy.Expr | SympyBoolean,
 ) -> torch.dtype | None:
-    assert isinstance(
-        constant_buffer,
-        (
-            sympy.Symbol,
-            sympy.Expr,
-            sympy.logic.boolalg.Boolean,
-            sympy.core.numbers.Integer,
-        ),
-    ), "get_constant_buffer_dtype only supports symbolic scalar inputs"
-    if isinstance(constant_buffer, sympy.core.numbers.Integer):
-        return torch.int64
+    assert is_symbolic_scalar(constant_buffer), (
+        "get_constant_buffer_dtype only supports symbolic scalar inputs"
+    )
 
     if is_sympy_boolean(constant_buffer):
         return torch.bool
 
-    if isinstance(constant_buffer, sympy.Expr):
-        return get_sympy_Expr_dtype(constant_buffer)
-
-    if constant_buffer.is_integer:
-        return torch.int64
-    elif constant_buffer.is_float:
-        return torch.float32
-    else:
-        return None
+    assert isinstance(constant_buffer, sympy.Expr)
+    return get_sympy_Expr_dtype(constant_buffer)
 
 
 def is_magic_method(op: Any) -> bool:
@@ -1202,25 +1189,29 @@ class GraphLowering(torch.fx.Interpreter):
 
             return non_dup_const_name
 
-    def _allocate_int_placeholder_symbol(self, target: str) -> sympy.Symbol:
-        base_name = f"{target}_symint"
-        existing_names = OrderedSet(
+    @functools.cached_property
+    def _reserved_int_placeholder_names(self) -> OrderedSet[str]:
+        reserved_names = OrderedSet(
             self.qualify_name(node.target)
             for node in self.module.graph.nodes  # type: ignore[union-attr]
             if node.op == "placeholder"
         )
-        existing_names.update(
+        reserved_names.update(
             str(value)
             for value in self.graph_inputs.values()
             if isinstance(value, sympy.Symbol)
         )
+        return reserved_names
 
+    def _allocate_int_placeholder_symbol(self, target: str) -> sympy.Symbol:
+        base_name = f"{target}_symint"
         symbol_name = base_name
         counter = 0
-        while symbol_name in existing_names:
+        while symbol_name in self._reserved_int_placeholder_names:
             counter += 1
             symbol_name = f"{base_name}_{counter}"
 
+        self._reserved_int_placeholder_names.add(symbol_name)
         return sympy.Symbol(symbol_name, integer=True)
 
     # pyrefly: ignore [bad-override]
@@ -1582,8 +1573,7 @@ class GraphLowering(torch.fx.Interpreter):
                     ir.Constant,
                     type(None),
                     ir.ConstantBuffer,
-                    sympy.Expr,
-                    sympy.logic.boolalg.Boolean,
+                    *SYMBOLIC_SCALAR_TYPES,
                     int,
                     ir.EffectfulKernel,
                     ir.ShapeAsConstantBuffer,
@@ -1632,8 +1622,7 @@ class GraphLowering(torch.fx.Interpreter):
                 value,
                 (
                     TensorBox,
-                    sympy.Expr,
-                    sympy.logic.boolalg.Boolean,
+                    *SYMBOLIC_SCALAR_TYPES,
                     torch._inductor.ir.GeneratorState,
                 ),
             ), f"Unsupported inductor graph input type: {type(value)}"

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -110,6 +110,7 @@ from .utils import (
     get_sympy_Expr_dtype,
     GraphPartitionMap,
     is_same_tensor,
+    is_sympy_boolean,
     maybe_get_suppress_shape_guards_ctx,
     normalize_name,
     should_assume_input_aligned,
@@ -167,9 +168,7 @@ def may_get_constant_buffer_dtype(
     if isinstance(constant_buffer, sympy.core.numbers.Integer):
         return torch.int64
 
-    if isinstance(constant_buffer, sympy.logic.boolalg.Boolean) or getattr(
-        constant_buffer, "is_Boolean", False
-    ):
+    if is_sympy_boolean(constant_buffer):
         return torch.bool
 
     if isinstance(constant_buffer, sympy.Expr):
@@ -1205,11 +1204,11 @@ class GraphLowering(torch.fx.Interpreter):
 
     def _allocate_int_placeholder_symbol(self, target: str) -> sympy.Symbol:
         base_name = f"{target}_symint"
-        existing_names = {
+        existing_names = OrderedSet(
             self.qualify_name(node.target)
             for node in self.module.graph.nodes  # type: ignore[union-attr]
             if node.op == "placeholder"
-        }
+        )
         existing_names.update(
             str(value)
             for value in self.graph_inputs.values()

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -218,9 +218,10 @@ class GraphPartitionSignature:
     # symbol inputs that are necessary for codegen
     symbol_inputs: OrderedSet[sympy.Symbol]
 
-    # mapping from partition input name to IRNode or Expr. Need the name str since
+    # mapping from partition input name to IRNode or symbolic scalar. Need the
+    # name str since
     # we cannot get name from Expr.
-    input_nodes: dict[str, IRNode | sympy.Expr | TorchBindObject]
+    input_nodes: dict[str, IRNode | sympy.Expr | SympyBoolean | TorchBindObject]
     output_nodes: list[IRNode]
 
     # mapping from partition input name to a boolean for whether deallocating it
@@ -4745,7 +4746,7 @@ class NoneAsConstantBuffer(IRNode):
 
 @ir_dataclass
 class ShapeAsConstantBuffer(IRNode):
-    expr: Expr
+    expr: Expr | SympyBoolean
 
     @cache_on_self_and_args("ShapeAsConstantBuffer")
     def get_free_symbol_uses(

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -218,10 +218,12 @@ class GraphPartitionSignature:
     # symbol inputs that are necessary for codegen
     symbol_inputs: OrderedSet[sympy.Symbol]
 
-    # mapping from partition input name to IRNode or symbolic scalar. Need the
-    # name str since
-    # we cannot get name from Expr.
+    # mapping from partition input name to a runtime argument carried directly
+    # by the partition call.
     input_nodes: dict[str, IRNode | sympy.Expr | SympyBoolean | TorchBindObject]
+    # explicit symbolic scalar graph inputs that need their original runtime
+    # placeholder name across graph-partition boundaries.
+    scalar_inputs: dict[str, sympy.Expr | SympyBoolean]
     output_nodes: list[IRNode]
 
     # mapping from partition input name to a boolean for whether deallocating it

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -82,6 +82,7 @@ from .utils import (
     is_collective,
     is_cudagraph_unsafe_op,
     is_gpu,
+    is_symbolic_scalar,
     is_multi_outputs_template,
     is_output_of_multi_outputs_template,
     is_wait,
@@ -6788,6 +6789,34 @@ class Scheduler:
 
         return OrderedSet(sorted(res, key=operator.attrgetter("name")))
 
+    def get_graph_partition_scalar_inputs(
+        self, symbol_inputs: OrderedSet[sympy.Symbol]
+    ) -> tuple[
+        dict[str, sympy.Expr | sympy.logic.boolalg.Boolean],
+        OrderedSet[sympy.Symbol],
+    ]:
+        scalar_inputs: dict[str, sympy.Expr | sympy.logic.boolalg.Boolean] = {}
+        symbol_inputs = OrderedSet(symbol_inputs)
+        bound_scalar_symbols: OrderedSet[sympy.Symbol] = OrderedSet()
+
+        for name, value in V.graph.graph_inputs.items():
+            if not isinstance(value, sympy.Symbol):
+                continue
+            if value in symbol_inputs and name != value.name:
+                scalar_inputs[name] = value
+                symbol_inputs.discard(value)
+                bound_scalar_symbols.add(value)
+
+        available_symbols = symbol_inputs | bound_scalar_symbols
+        for name, value in V.graph.graph_inputs.items():
+            if not is_symbolic_scalar(value) or isinstance(value, sympy.Symbol):
+                continue
+            if isinstance(value, sympy.Basic) and not value.is_Atom:
+                if value.free_symbols <= available_symbols:
+                    scalar_inputs[name] = value
+
+        return scalar_inputs, symbol_inputs
+
     def get_graph_partition_signature(
         self, partitions: list[PartitionType], skip_cudagraphs: list[bool]
     ) -> list[GraphPartitionSignature]:
@@ -6911,10 +6940,14 @@ class Scheduler:
             symbol_inputs = self.get_graph_partition_symbol_inputs(
                 partition, input_nodes
             )
+            scalar_inputs, symbol_inputs = self.get_graph_partition_scalar_inputs(
+                symbol_inputs
+            )
 
             partition_signature = GraphPartitionSignature(
                 symbol_inputs,
                 input_nodes,
+                scalar_inputs,
                 output_nodes,
                 input_deallocation,
                 skip_cudagraph,
@@ -6941,6 +6974,11 @@ class Scheduler:
             for name, buffer in signature.input_nodes.items()
             if name not in V.graph.removed_buffers
         }
+        scalar_inputs = {
+            name: value
+            for name, value in signature.scalar_inputs.items()
+            if name not in V.graph.removed_buffers
+        }
         input_deallocation = {
             name: val
             for name, val in signature.input_deallocation.items()
@@ -6959,6 +6997,7 @@ class Scheduler:
         return GraphPartitionSignature(
             signature.symbol_inputs,
             input_nodes,
+            scalar_inputs,
             output_nodes,
             input_deallocation,
             signature.skip_cudagraph,

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -1115,7 +1115,12 @@ class BaseSchedulerNode:
             if buf_name in V.graph.name_to_buffer:
                 buf = V.graph.name_to_buffer[buf_name]
             elif buf_name in V.graph.graph_inputs:
-                buf = V.graph.graph_inputs[buf_name]
+                graph_input = V.graph.graph_inputs[buf_name]
+                if not isinstance(
+                    graph_input, (ir.Buffer, ir.TensorBox, ir.TorchBindObject)
+                ):
+                    continue
+                buf = graph_input
             else:
                 continue
 

--- a/torch/_inductor/sizevars.py
+++ b/torch/_inductor/sizevars.py
@@ -29,6 +29,7 @@ from . import config
 from .runtime.runtime_utils import is_power_of_2
 from .utils import (
     has_free_symbols,
+    is_sympy_boolean,
     sympy_index_symbol,
     sympy_index_symbol_with_prefix,
     sympy_subs,
@@ -711,9 +712,13 @@ class SizeVarAllocator:
 
         return None
 
-    def optimization_hint(self, expr: Expr | int, fallback: int | None = None) -> int:
+    def optimization_hint(
+        self,
+        expr: Expr | sympy.logic.boolalg.Boolean | int | bool,
+        fallback: int | bool | None = None,
+    ) -> int:
         """
-        Return a concrete integer hint for an expression.
+        Return a concrete integer or boolean hint for an expression.
 
         This function should be used for non-guarding based optimizations. If you
         want a hint that you can guard on, use the guarding_hint API instead.
@@ -723,11 +728,20 @@ class SizeVarAllocator:
         that try to maximize consistency with the shape environment.
 
         Special cases:
+        - Boolean relations: evaluates them with a boolean fallback.
         - Complex numbers (containing sympy.I): raises an error since tensor
           dimensions cannot be complex.
         - Infinity (int_oo, sympy.oo): returns sys.maxsize.
         - NaN (sympy.nan): returns the fallback value.
         """
+        if isinstance(expr, bool):
+            return expr
+        if is_sympy_boolean(expr):
+            return self.evaluate_expr(
+                expr,
+                fallback_value=False if fallback is None else bool(fallback),
+            )
+
         # Read config at call time to respect runtime patches (e.g., in tests)
         if fallback is None:
             fallback = config.unbacked_symint_fallback

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -2814,6 +2814,15 @@ def get_sympy_Expr_dtype(val: sympy.Expr) -> torch.dtype:
         return torch.float64
 
 
+SYMBOLIC_SCALAR_TYPES = (sympy.Expr, sympy.logic.boolalg.Boolean)
+
+
+def is_symbolic_scalar(
+    expr: object,
+) -> TypeGuard[sympy.Expr | sympy.logic.boolalg.Boolean]:
+    return isinstance(expr, SYMBOLIC_SCALAR_TYPES)
+
+
 def is_sympy_boolean(expr: sympy.Basic) -> TypeGuard[sympy.logic.boolalg.Boolean]:
     # SymPy symbols are also instances of Boolean at runtime, so guard on
     # non-Expr booleans to distinguish actual relations/boolean atoms.

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -2814,6 +2814,14 @@ def get_sympy_Expr_dtype(val: sympy.Expr) -> torch.dtype:
         return torch.float64
 
 
+def is_sympy_boolean(expr: sympy.Basic) -> TypeGuard[sympy.logic.boolalg.Boolean]:
+    # SymPy symbols are also instances of Boolean at runtime, so guard on
+    # non-Expr booleans to distinguish actual relations/boolean atoms.
+    return isinstance(expr, sympy.logic.boolalg.Boolean) and not isinstance(
+        expr, sympy.Expr
+    )
+
+
 @contextlib.contextmanager
 def maybe_profile(should_profile: bool, *args: Any, **kwargs: Any) -> Iterator[Any]:
     if should_profile:

--- a/torch/export/_tree_utils.py
+++ b/torch/export/_tree_utils.py
@@ -56,7 +56,9 @@ def flatten_aoti_runtime_inputs(
         if isinstance(
             value, (bool, float, torch.SymInt, torch.SymFloat, torch.SymBool)
         ):
-            runtime_inputs.append(torch.tensor(value, device="cpu"))
+            # Use the refs tensor constructor so symbolic scalars avoid the
+            # eager tensor_new path, which would guard unbacked Sym* inputs.
+            runtime_inputs.append(torch._refs.tensor(value, device="cpu"))
 
     return runtime_inputs
 

--- a/torch/export/_tree_utils.py
+++ b/torch/export/_tree_utils.py
@@ -1,7 +1,9 @@
 from collections.abc import Callable
 from typing import Any
 
-from torch.utils._pytree import Context, TreeSpec
+import torch
+
+from torch.utils._pytree import Context, TreeSpec, tree_flatten
 
 
 def reorder_kwargs(user_kwargs: dict[str, Any], spec: TreeSpec) -> dict[str, Any]:
@@ -36,6 +38,27 @@ def reorder_kwargs(user_kwargs: dict[str, Any], spec: TreeSpec) -> dict[str, Any
         reordered_kwargs[kw] = user_kwargs[kw]
 
     return reordered_kwargs
+
+
+def flatten_aoti_runtime_inputs(
+    args: tuple[Any, ...], user_kwargs: dict[str, Any], spec: TreeSpec
+) -> list[torch.Tensor]:
+    flat_inputs = tree_flatten((args, reorder_kwargs(user_kwargs, spec)))[0]
+    runtime_inputs: list[torch.Tensor] = []
+    for value in flat_inputs:
+        if isinstance(value, torch.Tensor):
+            runtime_inputs.append(value)
+            continue
+
+        # Keep plain Python ints filtered here: AOT wrappers still specialize
+        # some metadata ints out of the runtime ABI, so blindly tensorizing
+        # every int would misalign later tensor inputs.
+        if isinstance(
+            value, (bool, float, torch.SymInt, torch.SymFloat, torch.SymBool)
+        ):
+            runtime_inputs.append(torch.tensor(value, device="cpu"))
+
+    return runtime_inputs
 
 
 def is_equivalent(

--- a/torch/export/pt2_archive/_package.py
+++ b/torch/export/pt2_archive/_package.py
@@ -27,7 +27,7 @@ from torch._export.serde.serialize import (
 from torch._inductor.cpp_builder import normalize_path_separator
 from torch._subclasses.fake_tensor import FakeTensor
 from torch.export import ExportedProgram
-from torch.export._tree_utils import reorder_kwargs
+from torch.export._tree_utils import flatten_aoti_runtime_inputs
 from torch.export.pt2_archive._package_weights import (
     get_complete_tensor,
     group_weights,
@@ -728,8 +728,7 @@ class AOTICompiledModel:
         call_spec = self.loader.get_call_spec()
         in_spec = pytree.treespec_loads(call_spec[0])
         out_spec = pytree.treespec_loads(call_spec[1])
-        flat_inputs = pytree.tree_flatten((args, reorder_kwargs(kwargs, in_spec)))[0]
-        flat_inputs = [x for x in flat_inputs if isinstance(x, torch.Tensor)]
+        flat_inputs = flatten_aoti_runtime_inputs(args, kwargs, in_spec)
         flat_outputs = self.loader.boxed_run(flat_inputs)
         return pytree.tree_unflatten(flat_outputs, out_spec)
 


### PR DESCRIPTION
Fix #167070.

## Summary
- Root cause: Inductor's graph input plumbing only treated `sympy.Expr` values as supported symbolic scalars, but selective-checkpoint flows can surface `SymBool` placeholders backed by `sympy.Eq`, which is a SymPy boolean relation rather than an `Expr`.
- Proposed fix: accept SymPy boolean relations anywhere Inductor already accepts symbolic scalar graph inputs, materialize them as `torch.bool` when wrapper code needs a dtype, and add a regression test that lowers a graph with a `SymBool` placeholder backed by `sympy.Eq`.
- Why this is the right long term fix: `SympyBoolean` is already a first-class symbolic shape type in PyTorch, and the rest of Inductor already handles boolean symbolic scalars in outputs and constant buffers. Extending the graph-input and wrapper codegen boundaries to the same symbolic scalar family keeps the behavior consistent instead of special-casing one producer.

## Testing
- Added a regression test covering `GraphLowering` with a `sympy.Eq` graph input.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo