### PR TITLE
Fix set_stack_trace

### DIFF
--- a/torch/fx/traceback.py
+++ b/torch/fx/traceback.py
@@ -287,8 +287,11 @@ def _preserve_node_seq_nr(preserve_seq_nr=True):
 def set_stack_trace(stack: list[str]):
     global current_meta
 
-    if should_preserve_node_meta and stack:
-        current_meta["stack_trace"] = "".join(stack)
+    if should_preserve_node_meta:
+        if stack:
+            current_meta["stack_trace"] = "".join(stack)
+        else:
+            current_meta.pop("stack_trace", None)
 
 
 @compatibility(is_backward_compatible=False)

--- a/torch/fx/traceback.py
+++ b/torch/fx/traceback.py
@@ -291,6 +291,8 @@ def set_stack_trace(stack: list[str]):
         if stack:
             current_meta["stack_trace"] = "".join(stack)
         else:
+            # when the stack is empty, we explicitly clear the stack_trace to avoid
+            # propagating it to future node.˙
             current_meta.pop("stack_trace", None)
 
 


### PR DESCRIPTION
When make_fx tracing over autograd.grad() call, all the backward node ended up with "stack trace not found". 
This fixes that.

      152 -            # set_stack_trace is a no-op when stack_ is empty (the guard                                                                                                                                                
      153 -            # `if ... and stack:` skips it). During make_fx tracing, autograd                                                                                                                                           
      154 -            # nodes don't have "traceback_" metadata, so stack_ is always [].                                                                                                                                           
      155 -            # Without an explicit clear, the posthook's GRADIENT_ACC_SPECIAL_STACK                                                                                                                                      
      156 -            # from the previous node persists into current_meta, causing all                                                                                                                                            
      157 -            # backward FX nodes to be tagged is_gradient_acc=True. 

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #177332

