### PR TITLE
[DCP] Fix test_pg_transport timeout by adding class-level skip to PgTransportGPU (#177333)

### DIFF
--- a/test/distributed/checkpoint/test_pg_transport.py
+++ b/test/distributed/checkpoint/test_pg_transport.py
@@ -231,6 +231,7 @@ class PgTransportCPU(MultiProcContinuousTest):
         _test_pg_transport_with_sharded_tensor(self, self.device)
 
 
+@skip_but_pass_in_sandcastle_if(not at_least_x_gpu(2), "test requires 2+ accelerators")
 class PgTransportGPU(MultiProcContinuousTest):
     world_size = 2
     timeout: timedelta = timedelta(seconds=20)


### PR DESCRIPTION
Summary:

The test times out at 6000s despite all individual tests passing in ~16s. The hang occurs because PgTransportGPU's setUp() spawns worker processes even on CPU-only machines (no GPUs). The method-level skip decorators run after setUp, so workers are already spawned. When workers execute the skipped test, SkipTest is not handled as a SystemExit in the worker loop, causing raised_exception=True, which skips c10d.destroy_process_group().

Without cleanup, Gloo background threads prevent workers from exiting, and tearDownClass hangs indefinitely on process.join() (no timeout).

Fix: Add a class-level skip_but_pass_in_sandcastle_if decorator to PgTransportGPU so that setUp/tearDown never run and no worker processes are spawned when GPUs are unavailable.

Test Plan: buck test fbcode//mode/opt fbcode//caffe2/test/distributed/checkpoint:test_pg_transport -- --run-disabled

Reviewed By: ankitageorge

Differential Revision: D96233045
