### PR TITLE
[dynamo] Re-enable einops tracing

### DIFF
--- a/test/dynamo/test_einops.py
+++ b/test/dynamo/test_einops.py
@@ -4,6 +4,7 @@ import os
 import subprocess
 import sys
 import unittest
+import warnings
 
 import torch
 from torch import nn
@@ -11,7 +12,6 @@ from torch._dynamo.test_case import TestCase
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
-    xfailIf,
 )
 
 
@@ -206,7 +206,6 @@ print(normalize_gm(graph.print_readable(print_output=False)))
             else:
                 self.assertIn(einops_method, output)
 
-    @xfailIf(einops_version == "0.8.2")
     @parametrize(
         "method",
         ["reduce", "repeat", "pack", "unpack", "einsum", "rearrange"],
@@ -240,13 +239,21 @@ print(normalize_gm(graph.print_readable(print_output=False)))
         self._run_in_subprocess(flag, method, einops_method, snippet)
 
     def test_no_warning(self):
-        # checks that this doesn't produce any warnings
+        # einops uses lru_cache internally for pure functions; since they don't
+        # mutate existing objects, the lru_cache side-effect warning should not
+        # be emitted.
         @torch.compile(backend="eager", fullgraph=True)
         def fn(x):
             return einops.rearrange(x, "... -> (...)")
 
         x = torch.randn(5)
-        self.assertNotWarn(lambda: fn(x))
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            fn(x)
+        lru_cache_warnings = [
+            warning for warning in w if "functools.lru_cache" in str(warning.message)
+        ]
+        self.assertEqual(lru_cache_warnings, [])
 
 
 instantiate_parametrized_tests(

--- a/torch/_dynamo/decorators.py
+++ b/torch/_dynamo/decorators.py
@@ -1382,13 +1382,14 @@ def _allow_in_graph_einops() -> None:
 
     # There is a lru_cache logspam issue with einops when allow_in_graph is not
     # used. Disabling this for now until the lru_cache issue is resolved.
-    # if einops.__version__ >= "0.8.2":
-    #     if hasattr(einops, "einops") and hasattr(einops.einops, "get_backend"):
-    #         # trigger backend registration up front to avoid a later guard failure
-    #         # that would otherwise cause a recompilation
-    #         einops.rearrange(torch.randn(1), "i -> i")
-    #     # einops 0.8.2+ don't need explicit allow_in_graph calls
-    #     return
+    # TODO(guilhermeleobas): wrap this in a config flag?
+    if einops.__version__ >= "0.8.2":
+        if hasattr(einops, "einops") and hasattr(einops.einops, "get_backend"):
+            # trigger backend registration up front to avoid a later guard failure
+            # that would otherwise cause a recompilation
+            einops.rearrange(torch.randn(1), "i -> i")
+        # einops 0.8.2+ don't need explicit allow_in_graph calls
+        return
 
     try:
         # requires einops > 0.6.1, torch >= 2.0


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #177361
* #177182

This PR tries to re-enable tracing into einops code with the guarantee Dynamo will not emit any warnings.

TODO: Maybe wrap the einops tracing in a dynamo config flag if things go south?

Related issues and pull requests:
* https://github.com/pytorch/pytorch/pull/175351
* https://github.com/pytorch/pytorch/pull/173611
* https://github.com/pytorch/pytorch/issues/157417

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo