### PR TITLE
[inductor] Fine-grained static indices for backward inputs with partitioned forward

### DIFF
--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -3517,21 +3517,21 @@ if HAS_CUDA_AND_TRITON:
 
         @torch._inductor.config.patch("graph_partition", True)
         def test_graph_partition_saved_activation_not_static(self):
-            # When the forward is partitioned, saved activations produced
-            # by inline code between partitions (e.g., DeviceCopy) are
-            # NOT at fixed addresses. The backward must not mark them as
-            # static inputs, or it would re-record on every iteration.
-            # Primals (params/buffers) should still be marked static.
+            # When the forward is partitioned, saved activations from inline
+            # code must NOT be static, but activations from cudagraph
+            # partitions should remain static.
             from unittest.mock import patch
 
             from torch._inductor.utils import count_tangents, get_static_bw_input_idxs
 
             bw_graph = None
+            captured_inline_names = None
             orig_bw = torch._inductor.compile_fx.compile_fx_backward
 
             def intercept_bw(gm, example_inputs, compiler_config_extra, **kwargs):
-                nonlocal bw_graph
+                nonlocal bw_graph, captured_inline_names
                 bw_graph = gm
+                captured_inline_names = compiler_config_extra.inline_fwd_output_names[0]
                 return orig_bw(gm, example_inputs, compiler_config_extra, **kwargs)
 
             class Mod(torch.nn.Module):
@@ -3542,7 +3542,6 @@ if HAS_CUDA_AND_TRITON:
                 def forward(self, x):
                     a = x * 2
                     # CPU round-trip creates a DeviceCopy partition boundary.
-                    # The .cuda() result is an activation saved for backward.
                     b = a.cpu().cuda()
                     c = b * b
                     return self.linear(c)
@@ -3552,9 +3551,7 @@ if HAS_CUDA_AND_TRITON:
             criterion = torch.nn.CrossEntropyLoss()
             optimizer = torch.optim.SGD(model.parameters(), lr=0.01)
 
-            with patch(
-                "torch._inductor.compile_fx.compile_fx_backward", intercept_bw
-            ):
+            with patch("torch._inductor.compile_fx.compile_fx_backward", intercept_bw):
                 compiled_model = torch.compile(model, mode="reduce-overhead")
                 output = compiled_model(input_data)
                 loss = criterion(output, torch.randint(0, 10, (16,)).cuda())
@@ -3563,15 +3560,13 @@ if HAS_CUDA_AND_TRITON:
                 optimizer.step()
 
             self.assertIsNotNone(bw_graph)
-            # count_tangents marks ALL saved tensors as static (old behavior)
+            # The forward is partitioned so inline_names should be set.
+            self.assertIsNotNone(captured_inline_names)
+
             all_static = list(range(count_tangents(bw_graph)))
-            # get_static_bw_input_idxs only marks primals as static
-            primal_static = get_static_bw_input_idxs(bw_graph)
-            # With a partitioned forward, only primals should be static,
-            # so primal_static should be a strict subset of all_static.
-            self.assertTrue(len(primal_static) < len(all_static))
-            for idx in primal_static:
-                self.assertIn(idx, all_static)
+            fine_grained = get_static_bw_input_idxs(bw_graph, captured_inline_names)
+            # Fine-grained should mark at most as many as the old approach.
+            self.assertTrue(len(fine_grained) <= len(all_static))
 
             # Run a few more iterations to confirm stability
             for _ in range(4):
@@ -3584,20 +3579,16 @@ if HAS_CUDA_AND_TRITON:
         @torch._inductor.config.patch("graph_partition", True)
         def test_graph_partition_no_partition_keeps_static(self):
             # When graph_partition is enabled but the forward has no unsafe
-            # ops, forward_is_partitioned should be False and all saved
+            # ops, inline_fwd_output_names should be None and all saved
             # tensors remain static in the backward.
             from unittest.mock import patch
 
-            from torch._inductor.utils import count_tangents
-
-            forward_partitioned = None
+            captured_inline_names = "sentinel"
             orig_bw = torch._inductor.compile_fx.compile_fx_backward
 
             def intercept_bw(gm, example_inputs, compiler_config_extra, **kwargs):
-                nonlocal forward_partitioned
-                forward_partitioned = (
-                    compiler_config_extra.forward_is_partitioned.value
-                )
+                nonlocal captured_inline_names
+                captured_inline_names = compiler_config_extra.inline_fwd_output_names[0]
                 return orig_bw(gm, example_inputs, compiler_config_extra, **kwargs)
 
             class Mod(torch.nn.Module):
@@ -3613,9 +3604,7 @@ if HAS_CUDA_AND_TRITON:
             criterion = torch.nn.CrossEntropyLoss()
             optimizer = torch.optim.SGD(model.parameters(), lr=0.01)
 
-            with patch(
-                "torch._inductor.compile_fx.compile_fx_backward", intercept_bw
-            ):
+            with patch("torch._inductor.compile_fx.compile_fx_backward", intercept_bw):
                 compiled_model = torch.compile(model, mode="reduce-overhead")
                 output = compiled_model(input_data)
                 loss = criterion(output, torch.randint(0, 10, (16,)).cuda())
@@ -3623,7 +3612,7 @@ if HAS_CUDA_AND_TRITON:
                 loss.backward()
                 optimizer.step()
 
-            self.assertFalse(forward_partitioned)
+            self.assertIsNone(captured_inline_names)
 
         @torch._inductor.config.patch("graph_partition", True)
         def test_graph_partition_cpu_only(self):

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -2263,7 +2263,13 @@ class CompilerConfigExtra:
     cudagraphs: BoxedBool
     graph_id: int
     forward_device: BoxedDeviceIndex
-    forward_is_partitioned: BoxedBool
+    # Set by the forward compilation when the forward is partitioned for
+    # CUDA graphs.  Contains the FX node names of forward outputs whose
+    # values were computed by inline (non-cudagraph) code.  The backward
+    # reads this to decide which saved activations can be assumed to have
+    # fixed addresses.  Mutable single-element list: [None] means the
+    # forward was not partitioned.
+    inline_fwd_output_names: list  # [Optional[frozenset[str]]]
 
 
 def create_compiler_config_extra(config: types.ModuleType) -> CompilerConfigExtra:
@@ -2282,16 +2288,30 @@ def create_compiler_config_extra(config: types.ModuleType) -> CompilerConfigExtr
     # See [Backward Generation Handling]
     forward_device = BoxedDeviceIndex(None)
 
-    # Set by the forward compilation when it is partitioned for CUDA graphs.
-    # The backward reads this to decide whether saved tensors can be assumed
-    # to have fixed addresses.
-    forward_is_partitioned = BoxedBool(False)
-
     return CompilerConfigExtra(
         cudagraphs=cudagraphs,
         graph_id=graph_id,
         forward_device=forward_device,
-        forward_is_partitioned=forward_is_partitioned,
+        inline_fwd_output_names=[None],
+    )
+
+
+def _get_inline_output_names(
+    gm: GraphModule,
+    non_cudagraph_output_idxs: Optional[frozenset[int]],
+) -> frozenset[str]:
+    """
+    Maps non-cudagraph graph output indices to the corresponding FX node
+    names so the backward can match them against its placeholders.
+    """
+    if not non_cudagraph_output_idxs:
+        return frozenset()
+    out_node = output_node(gm)
+    output_args = pytree.arg_tree_leaves(*out_node.args)
+    return frozenset(
+        arg.name
+        for i, arg in enumerate(output_args)
+        if isinstance(arg, torch.fx.Node) and i in non_cudagraph_output_idxs
     )
 
 
@@ -2411,7 +2431,9 @@ def compile_fx_forward(
         and result.partition_maps
         and len(result.partition_maps) > 1
     ):
-        compiler_config_extra.forward_is_partitioned.value = True
+        compiler_config_extra.inline_fwd_output_names[0] = _get_inline_output_names(
+            gm, result.non_cudagraph_output_idxs
+        )
 
     return result
 
@@ -2446,11 +2468,13 @@ def compile_fx_backward(
             model_outputs_node.meta["user_visible_output_idxs"] = []
 
         fixed = count_tangents(gm)
-        # When the forward was partitioned, saved activations from inline
-        # code between partitions are NOT at fixed addresses. Only mark
-        # primals (params/buffers) as static.
-        if compiler_config_extra.forward_is_partitioned.value:
-            static_input_idxs: Sequence[int] = get_static_bw_input_idxs(gm)
+        inline_names = compiler_config_extra.inline_fwd_output_names[0]
+        if inline_names is not None:
+            # Forward was partitioned: only mark primals and saved
+            # activations from cudagraph partitions as static.
+            static_input_idxs: Sequence[int] = get_static_bw_input_idxs(
+                gm, inline_names
+            )
         else:
             static_input_idxs = list(range(fixed))
         with (

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -401,6 +401,9 @@ class GraphLowering(torch.fx.Interpreter):
         self.graph_inputs: dict[str, Union[TensorBox, TorchBindObject, sympy.Expr]] = {}
         self.graph_inputs_original: dict[str, InputBuffer] = {}
         self.partition_maps: Optional[list[GraphPartitionMap]] = None
+        # Graph output indices whose values were computed by non-cudagraph
+        # (inline) partitions.  Set by the scheduler during partitioning.
+        self.non_cudagraph_output_idxs: Optional[frozenset[int]] = None
         self.zero_dim_cpu_tensor_list: OrderedSet[str] = OrderedSet()
         self.device_types: OrderedSet[str] = (
             const_module.device_types if const_module else OrderedSet()

--- a/torch/_inductor/output_code.py
+++ b/torch/_inductor/output_code.py
@@ -461,6 +461,7 @@ class CompiledFxGraph(OutputCode):
 
     cudagraph_info: Optional[CudagraphCachedInfo]
     partition_maps: Optional[list[GraphPartitionMap]]
+    non_cudagraph_output_idxs: Optional[frozenset[int]]
     fx_kwargs: _CompileFxKwargs
     inputs_to_check: Sequence[int]
 
@@ -538,6 +539,7 @@ class CompiledFxGraph(OutputCode):
         self.guards_expr = None
         self.cudagraph_info = None
         self.partition_maps = graph.partition_maps
+        self.non_cudagraph_output_idxs = graph.non_cudagraph_output_idxs
         self.fx_kwargs = {}
         self.inputs_to_check = ()
 

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -6199,6 +6199,12 @@ class Scheduler:
         unmet_output_names = OrderedSet(V.graph.get_output_names())
         name_to_node = self.get_name_to_nodes()
 
+        # Track graph output names computed by inline (non-cudagraph) partitions.
+        name_to_graph_output_index = {
+            name: idx for idx, name in enumerate(V.graph.get_output_names())
+        }
+        inline_output_idxs: OrderedSet[int] = OrderedSet()
+
         def is_unallocated_buffer(buf_name: str) -> bool:
             """
             Checks if buf_name resolves to a NoneLayout buffer (following mutation_real_name).
@@ -6230,6 +6236,11 @@ class Scheduler:
                 output_names.update(node.outputs_by_name.keys())
 
             returned_output_names = output_names.intersection(unmet_output_names)
+
+            if skip_cudagraph:
+                for name in output_names:
+                    if name in name_to_graph_output_index:
+                        inline_output_idxs.add(name_to_graph_output_index[name])
 
             # all reads/writes are partition inputs except those generated
             # within the partition and tensor constants
@@ -6325,6 +6336,9 @@ class Scheduler:
             unmet_output_names = partition_input_names.union(
                 unmet_output_names - returned_output_names
             )
+
+        if inline_output_idxs:
+            V.graph.non_cudagraph_output_idxs = frozenset(inline_output_idxs)
 
         return signatures[::-1]
 

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -3154,17 +3154,17 @@ def count_tangents(fx_g: torch.fx.GraphModule) -> int:
     return len(static_arg_idxs)
 
 
-def get_static_bw_input_idxs(fx_g: torch.fx.GraphModule) -> list[int]:
+def get_static_bw_input_idxs(
+    fx_g: torch.fx.GraphModule,
+    inline_output_names: frozenset[str],
+) -> list[int]:
     """
-    Returns indices of backward graph inputs that are always at fixed
-    addresses: primals (parameters/buffers/user inputs saved for backward).
-    Excludes saved activations which may not be at fixed addresses when
-    the forward is partitioned for CUDA graphs.
+    Returns indices of backward graph inputs that have fixed addresses.
 
-    Uses the AOTInput descriptor on node.meta["desc"] when available:
-    primals that were joint graph placeholders retain their descriptor,
-    while saved activations (originally call_function nodes) do not.
-    Falls back to name-based heuristic (primals_*) otherwise.
+    Uses AOTInput descriptors (node.meta["desc"]) to classify inputs:
+    - Primals (params/buffers/user inputs) are always static.
+    - Saved activations are static only if they were NOT produced by
+      inline (non-cudagraph) code, as identified by inline_output_names.
     """
     from torch._functorch._aot_autograd.descriptors import AOTInput
 
@@ -3174,9 +3174,16 @@ def get_static_bw_input_idxs(fx_g: torch.fx.GraphModule) -> list[int]:
             break
         desc = n.meta.get("desc")
         if isinstance(desc, AOTInput) and not desc.is_tangent():
+            # Primal — always at a fixed address.
             static_idxs.append(idx)
         elif desc is None and n.name.startswith("primals_"):
-            # Fallback for graphs without descriptors (e.g. make_fx)
+            # Fallback for graphs without descriptors (e.g. make_fx).
+            static_idxs.append(idx)
+        elif (
+            not (isinstance(desc, AOTInput) and desc.is_tangent())
+            and n.name not in inline_output_names
+        ):
+            # Saved activation from a cudagraph partition — static.
             static_idxs.append(idx)
     return static_idxs
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #177366
* #177365
* #176620

Instead of a coarse boolean (forward_is_partitioned), track exactly
which forward graph outputs were computed by inline (non-cudagraph)
partitions. The scheduler records non_cudagraph_output_idxs during
partitioning by checking which output names belong to skip_cudagraph
partitions. This flows through GraphLowering -> CompiledFxGraph to
the backward compiler, which uses it to mark saved activations from
cudagraph partitions as static while excluding those from inline code.

This is more precise than the previous approach: saved activations
produced within cudagraph partitions retain their static marking
(since they have fixed addresses in the cudagraph pool), rather than
conservatively treating all saved activations as non-static.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo