### PR TITLE
[CUDA] Fix maximum/minimum incorrect output on mixed-dtype out= promotion

### DIFF
--- a/aten/src/ATen/native/cuda/MaxMinElementwiseKernel.cu
+++ b/aten/src/ATen/native/cuda/MaxMinElementwiseKernel.cu
@@ -12,20 +12,20 @@
 namespace at::native {
 
 void maximum_kernel_cuda(TensorIteratorBase& iter) {
-  if (iter.dtype() == ScalarType::Bool) {
+  if (iter.common_dtype() == ScalarType::Bool) {
     opmath_symmetric_gpu_kernel_with_scalars<bool>(
         iter, []GPU_LAMBDA(bool a, bool b) -> bool {
       return a || b;
     });
-  } else if (isIntegralType(iter.dtype(), /*includeBool=*/ false)) {
-    AT_DISPATCH_INTEGRAL_TYPES(iter.dtype(), "max_elementwise_cuda", [&]() {
+  } else if (isIntegralType(iter.common_dtype(), /*includeBool=*/ false)) {
+    AT_DISPATCH_INTEGRAL_TYPES(iter.common_dtype(), "max_elementwise_cuda", [&]() {
       opmath_symmetric_gpu_kernel_with_scalars<scalar_t>(
           iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
         return ::max(a, b);
       });
     });
   } else {
-    AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, iter.dtype(), "max_elementwise_cuda", [&]() {
+    AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, iter.common_dtype(), "max_elementwise_cuda", [&]() {
       opmath_symmetric_gpu_kernel_with_scalars<scalar_t>(
           iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
         if (a != a) {
@@ -41,18 +41,18 @@ void maximum_kernel_cuda(TensorIteratorBase& iter) {
 }
 
 void minimum_kernel_cuda(TensorIteratorBase& iter) {
-  if (iter.dtype() == ScalarType::Bool) {
+  if (iter.common_dtype() == ScalarType::Bool) {
     opmath_symmetric_gpu_kernel_with_scalars<bool>(iter, []GPU_LAMBDA(bool a, bool b) -> bool {
       return a && b;
     });
-  } else if (isIntegralType(iter.dtype(), /*includeBool=*/ false)) {
-    AT_DISPATCH_INTEGRAL_TYPES(iter.dtype(), "minimum_cuda", [&]() {
+  } else if (isIntegralType(iter.common_dtype(), /*includeBool=*/ false)) {
+    AT_DISPATCH_INTEGRAL_TYPES(iter.common_dtype(), "minimum_cuda", [&]() {
       opmath_symmetric_gpu_kernel_with_scalars<scalar_t>(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
         return ::min(a, b);
       });
     });
   } else {
-    AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, iter.dtype(), "min_elementwise_cuda", [&]() {
+    AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, iter.common_dtype(), "min_elementwise_cuda", [&]() {
       opmath_symmetric_gpu_kernel_with_scalars<scalar_t>(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
         if (a != a) {
           return a;

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -2155,6 +2155,17 @@ class TestBinaryUfuncs(TestCase):
             result = op(a, b)
             self.assertEqual(result.dtype, torch.result_type(a, b))
 
+    def test_maximum_minimum_mixed_sign_out(self, device):
+        # Regression test for https://github.com/pytorch/pytorch/issues/173110
+        b0 = torch.tensor([1], dtype=torch.uint8, device=device)
+        l0 = torch.tensor([-9], dtype=torch.int64, device=device)
+
+        for op in (torch.maximum, torch.minimum, torch.fmax, torch.fmin):
+            expected = op(b0, l0)
+            out = torch.empty_like(b0)
+            op(b0, l0, out=out)
+            self.assertEqual(out.to(expected.dtype), expected)
+
     @dtypes(*integral_types_and(torch.bool))
     def test_maximum_minimum_int_and_bool(self, device, dtype):
         ops = (


### PR DESCRIPTION
## Issue

Fixes #173110

## Summary

`torch.maximum` and `torch.minimum` CUDA kernels dispatch on `iter.dtype()` (the **output** tensor's dtype) instead of `iter.common_dtype()` (the type-promoted computation dtype). When an `out=` tensor has a different dtype than the promoted computation dtype, `gpu_kernel_impl`'s `fetch_and_cast` loads inputs as the wrong type, producing silently incorrect results.

**Reproducer** (from the issue):
```python
>>> b0 = torch.tensor([1], dtype=torch.uint8, device='cuda')
>>> l0 = torch.tensor([-9], dtype=torch.int64, device='cuda')
>>> torch.maximum(b0, l0, out=b0)
tensor([247], device='cuda:0', dtype=torch.uint8)  # expected: tensor([1])
```

What happens: `common_dtype` is `int64`, but with `out=b0` the output dtype is `uint8`. The kernel dispatches as `uint8`, so `fetch_and_cast` loads `-9_i64` as `247_u8`, and `max(1, 247) = 247`.

**Root cause**: Unlike CPU, CUDA's TensorIterator does **not** pre-cast inputs to `common_dtype`. Instead, `gpu_kernel_impl` handles casting dynamically via `fetch_and_cast` — but only if the kernel tells it the correct computation type.

**Fix**: Replace `iter.dtype()` with `iter.common_dtype()` in `maximum_kernel_cuda` and `minimum_kernel_cuda`. This is exactly what `fmax_kernel_cuda`/`fmin_kernel_cuda` already do for their floating-point dispatch paths (and they delegate to `maximum`/`minimum` for integral types, so those were also affected).

| Scenario | `iter.dtype()` | `iter.common_dtype()` | Behavior change? |
|---|---|---|---|
| Same-dtype inputs, no `out=` | int64 | int64 | No |
| Same-dtype inputs, `out=` same dtype | int64 | int64 | No |
| Mixed dtypes, no `out=` | int64 (promoted) | int64 | No |
| **Mixed dtypes, `out=` narrower dtype** | **uint8 (output)** | **int64 (promoted)** | **Yes — bug fix** |

## Checklist

- [x] Added/updated tests
- [ ] Passes lint (`spin fixlint`)
- [ ] Updated documentation (if applicable) — N/A
- [ ] Included benchmark results (for PRs impacting perf) — N/A, correctness-only fix

## BC-breaking?

No. The only changed behavior is the buggy case (mixed-dtype with narrower `out=`), which previously returned silently wrong results.

cc @soulitzer