### PR TITLE
fix: fix all_to_all_single crash with uneven split sizes in LocalTens…

### DIFF
--- a/test/distributed/test_local_tensor.py
+++ b/test/distributed/test_local_tensor.py
@@ -567,6 +567,108 @@ class TestLocalTensorRankWorld3(LocalTensorRankTest):
             expected_output = torch.tensor([0.0, 0.0, 1.0, 1.0, 2.0, 2.0])
             self.assertEqual(result._local_tensors[self.rank], expected_output)
 
+    def test_all_to_all_single_uneven_splits(self):
+        """Test that all_to_all_single works correctly with uneven split sizes.
+
+        Regression test for https://github.com/pytorch/pytorch/issues/177371.
+        Previously this would crash with "shape '[N, C]' is invalid for input of
+        size M" because _local_alltoall_base_ incorrectly used view() to reshape
+        the source tensor into the output section when the two had incompatible
+        first-dimension sizes.
+        """
+        # world_size = 3
+        # Each rank has a (6, 4) tensor.  We send 2 rows to each rank
+        # (input_split_sizes = [2, 2, 2]) but receive different amounts:
+        #   rank 0 expects [3, 2, 1] rows from ranks [0, 1, 2]  -> output 6 rows
+        #   rank 1 expects [2, 2, 2] rows from ranks [0, 1, 2]  -> output 6 rows
+        #   rank 2 expects [1, 2, 3] rows from ranks [0, 1, 2]  -> output 6 rows
+        #
+        # In a consistent all_to_all_single, rank_i's input_split_sizes[j] must
+        # equal rank_j's output_split_sizes[i], so the split sizes above satisfy:
+        #   rank_0.input_split_sizes = [2, 2, 2]
+        #   rank_1.input_split_sizes = [3, 2, 1]  (sent to ranks 0, 1, 2)
+        #   rank_2.input_split_sizes = [1, 2, 3]
+
+        # Build the per-rank input tensors (6 rows, 4 cols, values = rank*10 + row)
+        local_tensors = {
+            r: torch.arange(24, dtype=torch.float).reshape(6, 4) + r * 100
+            for r in range(self.world_size)
+        }
+
+        fake_pg = torch.distributed.distributed_c10d._get_default_group()
+
+        with LocalTensorMode(self.world_size):
+            lt_input = LocalTensor(local_tensors)
+
+            # output_split_sizes for each rank
+            output_split_sizes_per_rank = {
+                0: [2, 2, 2],  # rank 0 receives 2 rows from each rank
+                1: [3, 2, 1],  # rank 1 receives 3 from rank0, 2 from rank1, 1 from rank2
+                2: [1, 2, 3],  # rank 2 receives 1 from rank0, 2 from rank1, 3 from rank2
+            }
+            # input_split_sizes for each rank (must be consistent with output)
+            # rank_i sends input_split_sizes[j] rows to rank_j
+            # = output_split_sizes_per_rank[j][i]
+            input_split_sizes_per_rank = {
+                0: [2, 3, 1],  # rank 0 sends 2->rank0, 3->rank1, 1->rank2
+                1: [2, 2, 2],  # rank 1 sends 2->rank0, 2->rank1, 2->rank2
+                2: [2, 1, 3],  # rank 2 sends 2->rank0, 1->rank1, 3->rank2
+            }
+
+            # Use rank_map to create LocalInt split sizes so each rank sees its own
+            # split sizes via the LocalTensorMode machinery.
+            from torch.distributed._local_tensor import LocalIntNode
+
+            def _make_local_int_list(per_rank_dict):
+                """Build a list of SymInts where each position across ranks
+                corresponds to the per-rank split sizes list."""
+                n = len(next(iter(per_rank_dict.values())))
+                result = []
+                for pos in range(n):
+                    node = LocalIntNode({r: per_rank_dict[r][pos] for r in per_rank_dict})
+                    result.append(torch.SymInt(node))
+                return result
+
+            out_splits = _make_local_int_list(output_split_sizes_per_rank)
+            in_splits = _make_local_int_list(input_split_sizes_per_rank)
+
+            # Allocate the output LocalTensor with the correct per-rank sizes
+            lt_output = LocalTensor(
+                {
+                    r: torch.zeros(sum(output_split_sizes_per_rank[r]), 4)
+                    for r in range(self.world_size)
+                }
+            )
+
+            dist.all_to_all_single(
+                lt_output,
+                lt_input,
+                output_split_sizes=out_splits,
+                input_split_sizes=in_splits,
+                group=fake_pg,
+            )
+
+            # Verify: rank r's output should contain rows from each src rank that
+            # were sent to rank r.  For src rank s, the rows sent to rank r are:
+            # rows [sum(in_split[:r]) : sum(in_split[:r+1])] of src's local tensor.
+            for dst_rank in range(self.world_size):
+                out_split = output_split_sizes_per_rank[dst_rank]
+                actual = lt_output._local_tensors[dst_rank]
+                row_offset = 0
+                for src_rank in range(self.world_size):
+                    in_split = input_split_sizes_per_rank[src_rank]
+                    # src sends in_split[dst_rank] rows to dst_rank
+                    src_start = sum(in_split[:dst_rank])
+                    src_end = src_start + in_split[dst_rank]
+                    expected_chunk = local_tensors[src_rank][src_start:src_end]
+                    actual_chunk = actual[row_offset : row_offset + out_split[src_rank]]
+                    self.assertEqual(
+                        actual_chunk,
+                        expected_chunk,
+                        msg=f"dst_rank={dst_rank}, src_rank={src_rank}: mismatch",
+                    )
+                    row_offset += out_split[src_rank]
+
 
 class TestLocalTensorWorld3(LocalTensorWorldTest):
     world_size = 3

--- a/test/distributed/test_local_tensor.py
+++ b/test/distributed/test_local_tensor.py
@@ -603,8 +603,16 @@ class TestLocalTensorRankWorld3(LocalTensorRankTest):
             # output_split_sizes for each rank
             output_split_sizes_per_rank = {
                 0: [2, 2, 2],  # rank 0 receives 2 rows from each rank
-                1: [3, 2, 1],  # rank 1 receives 3 from rank0, 2 from rank1, 1 from rank2
-                2: [1, 2, 3],  # rank 2 receives 1 from rank0, 2 from rank1, 3 from rank2
+                1: [
+                    3,
+                    2,
+                    1,
+                ],  # rank 1 receives 3 from rank0, 2 from rank1, 1 from rank2
+                2: [
+                    1,
+                    2,
+                    3,
+                ],  # rank 2 receives 1 from rank0, 2 from rank1, 3 from rank2
             }
             # input_split_sizes for each rank (must be consistent with output)
             # rank_i sends input_split_sizes[j] rows to rank_j
@@ -625,7 +633,9 @@ class TestLocalTensorRankWorld3(LocalTensorRankTest):
                 n = len(next(iter(per_rank_dict.values())))
                 result = []
                 for pos in range(n):
-                    node = LocalIntNode({r: per_rank_dict[r][pos] for r in per_rank_dict})
+                    node = LocalIntNode(
+                        {r: per_rank_dict[r][pos] for r in per_rank_dict}
+                    )
                     result.append(torch.SymInt(node))
                 return result
 

--- a/torch/distributed/_local_tensor/_c10d.py
+++ b/torch/distributed/_local_tensor/_c10d.py
@@ -881,15 +881,24 @@ def _local_alltoall_base_(
                 if j < len(input_splits):
                     split_tensor = input_splits[j]
 
-                    # Determine where to place this split in the output tensor
+                    # Determine where to place this split in the output tensor.
+                    # rank_i's contribution to rank_j's output occupies the i-th
+                    # segment of rank_j's output buffer.  The size of that segment
+                    # is determined by how much rank_i actually sends to rank_j,
+                    # i.e. split_tensor.size(0).  When output_split_sizes are
+                    # provided we use them to compute the starting offset; when
+                    # they are absent we fall back to evenly-spaced offsets.
                     if output_split_sizes is not None and len(output_split_sizes) > 0:
-                        # Calculate offset based on output split sizes
+                        # output_split_sizes[k] is how much rank_j receives from
+                        # the k-th group rank (i.e. group_ranks[k]).  The
+                        # contribution from rank_i (group index i) therefore
+                        # starts at sum(output_split_sizes[:i]).
                         output_offset = sum(output_split_sizes[:i]) if i > 0 else 0
-                        end_offset = (
-                            output_offset + output_split_sizes[i]
-                            if i < len(output_split_sizes)
-                            else output_tensor._local_tensors[rank_j].size(0)
-                        )
+                        # Use the actual split tensor size instead of
+                        # output_split_sizes[i] so that we never attempt an
+                        # invalid reshape when input and output split sizes differ.
+                        actual_send_size = split_tensor.size(0)
+                        end_offset = output_offset + actual_send_size
                     else:
                         # No output split sizes, use even splits
                         split_size = output_tensor._local_tensors[rank_j].size(
@@ -901,14 +910,14 @@ def _local_alltoall_base_(
                             output_tensor._local_tensors[rank_j].size(0),
                         )
 
-                    # Copy the split to the appropriate section of the output tensor
+                    # Copy the split directly into the appropriate section of the
+                    # output tensor.  We must not use view()/reshape() here because
+                    # the source and destination may have different first-dimension
+                    # sizes when uneven split sizes are in use.
                     output_section = output_tensor._local_tensors[rank_j][
                         output_offset:end_offset
                     ]
                     if output_section.numel() > 0:
-                        # Reshape split_tensor to match output_section if necessary
-                        if split_tensor.size() != output_section.size():
-                            split_tensor = split_tensor.view(output_section.size())
                         output_section.copy_(split_tensor)
 
     work = FakeWork()


### PR DESCRIPTION
fix(distributed): fix all_to_all_single crash with uneven split sizes in LocalTensorMode

_local_alltoall_base_ incorrectly used output_split_sizes[i] to
compute the destination slice end offset, and then attempted to
view() the source tensor into that (potentially incompatible) shape.
When input_split_sizes and output_split_sizes are uneven, the source
and destination slices have different first-dimension sizes, causing:

  RuntimeError: shape '[N, C]' is invalid for input of size M

Fix: derive end_offset from split_tensor.size(0) (the actual number
of rows rank_i sends to rank_j) instead of output_split_sizes[i],
and remove the unsafe view() call — a direct copy_() is sufficient
because the shapes already match by construction.

Add a regression test (test_all_to_all_single_uneven_splits) in
TestLocalTensorRankWorld3 that reproduces the scenario from issue
#177371 (world_size=3, asymmetric split sizes [3,2,1]/[2,2,2]/[1,2,3])
and verifies the correct data exchange for every dst/src rank pair.

cc @dzmitry-huba @ezyang for local tensor model bug report
cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell

Fixes #177371