### PR TITLE
fix: propagate channels_last/channels_last_3d memory format in meta_conv

### DIFF
--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -267,20 +267,54 @@ class FakeTensorTest(TestCase):
         # dim_order should be (0, 2, 3, 4, 1), not (0, 1, 2, 3, 4)
         self.assertEqual(fake_out.dim_order(), (0, 2, 3, 4, 1))
 
-    def test_conv_nhwc_channels_last_weight_only(self):
-        # channels_last format propagated from weight even when input is contiguous
-        x = torch.randn([1, 1024, 16, 16])
-        w = torch.randn([256, 1024, 4, 4]).to(memory_format=torch.channels_last)
+    def test_conv_nhwc_channels_last_propagation(self):
+        # Test memory format propagation under FakeTensorMode for conv2d.
+        # Cover:
+        #   1) weight only channels_last
+        #   2) activation only channels_last
+        #   3) both activation and weight contiguous (should stay contiguous)
+        x_base = torch.randn([1, 1024, 16, 16])
+        w_base = torch.randn([256, 1024, 4, 4])
         b = torch.randn([256])
+
+        cases = [
+            ("weight_only_channels_last", x_base, w_base.to(memory_format=torch.channels_last), torch.channels_last),
+            ("activation_only_channels_last", x_base.to(memory_format=torch.channels_last), w_base, torch.channels_last),
+            ("both_contiguous", x_base, w_base, torch.contiguous_format),
+        ]
+
+        for case, x, w, expected_fmt in cases:
+            with self.subTest(case=case):
+                with FakeTensorMode(allow_non_fake_inputs=True):
+                    fake_out = torch.ops.aten.convolution(
+                        x, w, b, [1, 1], [0, 0], [1, 1], False, [0, 0], 1
+                    )
+
+                self.assertTrue(
+                    fake_out.is_contiguous(memory_format=expected_fmt),
+                    f"Expected {expected_fmt} output, got strides {fake_out.stride()}",
+                )
+
+                if expected_fmt == torch.channels_last:
+                    # NHWC dim_order should be (0, 2, 3, 1), not (0, 1, 2, 3)
+                    self.assertEqual(fake_out.dim_order(), (0, 2, 3, 1))
+
+    def test_conv_ndhwc_channels_last_3d_activation_only(self):
+        # Additional coverage: activation-only channels_last_3d should still yield channels_last_3d output.
+        x = torch.randn([1, 2, 6, 6, 6]).to(memory_format=torch.channels_last_3d)
+        w = torch.randn([4, 2, 3, 3, 3])  # contiguous weight
+        b = torch.randn([4])
 
         with FakeTensorMode(allow_non_fake_inputs=True):
             fake_out = torch.ops.aten.convolution(
-                x, w, b, [1, 1], [0, 0], [1, 1], False, [0, 0], 1
+                x, w, b, [1, 1, 1], [0, 0, 0], [1, 1, 1], False, [0, 0, 0], 1
             )
+
         self.assertTrue(
-            fake_out.is_contiguous(memory_format=torch.channels_last),
-            f"Expected channels_last output, got strides {fake_out.stride()}",
+            fake_out.is_contiguous(memory_format=torch.channels_last_3d),
+            f"Expected channels_last_3d output, got strides {fake_out.stride()}",
         )
+        self.assertEqual(fake_out.dim_order(), (0, 2, 3, 4, 1))
 
     @unittest.skipIf(not RUN_CUDA, "requires cuda")
     def test_zero_dim(self):

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -247,6 +247,41 @@ class FakeTensorTest(TestCase):
         eager_out = model.forward(x, w, b)
         self.assertEqual(fake_out.stride(), eager_out.stride())
 
+    def test_conv_ndhwc(self):
+        # Regression test for https://github.com/pytorch/pytorch/issues/177277
+        # conv3d with channels_last_3d input should produce channels_last_3d output
+        # under FakeTensorMode (meta_conv must propagate the memory format).
+        x = torch.randn([1, 2, 6, 6, 6]).to(memory_format=torch.channels_last_3d)
+        w = torch.randn([4, 2, 3, 3, 3]).to(memory_format=torch.channels_last_3d)
+        b = torch.randn([4])
+
+        with FakeTensorMode(allow_non_fake_inputs=True):
+            fake_out = torch.ops.aten.convolution(
+                x, w, b, [1, 1, 1], [0, 0, 0], [1, 1, 1], False, [0, 0, 0], 1
+            )
+        # Output dim_order should match channels_last_3d: (0, 2, 3, 4, 1)
+        self.assertTrue(
+            fake_out.is_contiguous(memory_format=torch.channels_last_3d),
+            f"Expected channels_last_3d output, got strides {fake_out.stride()}",
+        )
+        # dim_order should be (0, 2, 3, 4, 1), not (0, 1, 2, 3, 4)
+        self.assertEqual(fake_out.dim_order(), (0, 2, 3, 4, 1))
+
+    def test_conv_nhwc_channels_last_weight_only(self):
+        # channels_last format propagated from weight even when input is contiguous
+        x = torch.randn([1, 1024, 16, 16])
+        w = torch.randn([256, 1024, 4, 4]).to(memory_format=torch.channels_last)
+        b = torch.randn([256])
+
+        with FakeTensorMode(allow_non_fake_inputs=True):
+            fake_out = torch.ops.aten.convolution(
+                x, w, b, [1, 1], [0, 0], [1, 1], False, [0, 0], 1
+            )
+        self.assertTrue(
+            fake_out.is_contiguous(memory_format=torch.channels_last),
+            f"Expected channels_last output, got strides {fake_out.stride()}",
+        )
+
     @unittest.skipIf(not RUN_CUDA, "requires cuda")
     def test_zero_dim(self):
         with FakeTensorMode() as mode:

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -2593,7 +2593,24 @@ def meta_conv(
     if guard_or_false(input_tensor.size(input_channels_dim) == 0):
         shape_out[output_channels_dim] = 0
 
+    # Propagate the memory format (channels_last / channels_last_3d) from the
+    # input and weight tensors to the output, matching the behaviour of the real
+    # convolution backends (cudnn, mkldnn, mps, etc.).  Without this, running
+    # convolution under FakeTensorMode on a channels_last_3d input produces a
+    # contiguous output whose dim_order does not match the input, causing
+    # incorrect data interpretation later in the graph.
+    # See: https://github.com/pytorch/pytorch/issues/177277
+    fmt1 = suggest_memory_format(input_tensor)
+    fmt2 = suggest_memory_format(weight)
+    if fmt1 == torch.channels_last or fmt2 == torch.channels_last:
+        memory_format = torch.channels_last
+    elif fmt1 == torch.channels_last_3d or fmt2 == torch.channels_last_3d:
+        memory_format = torch.channels_last_3d
+    else:
+        memory_format = torch.contiguous_format
+
     out = input_tensor.new_empty(shape_out)
+    out = out.to(memory_format=memory_format)
     return out
 
 

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -2609,8 +2609,7 @@ def meta_conv(
     else:
         memory_format = torch.contiguous_format
 
-    out = input_tensor.new_empty(shape_out)
-    out = out.to(memory_format=memory_format)
+    out = input_tensor.new_empty(shape_out, memory_format=memory_format)
     return out
 
 


### PR DESCRIPTION
fix(meta): propagate channels_last/channels_last_3d memory format in meta_conv

conv3d did not preserve channels_last_3d memory format under FakeTensorMode
because meta_conv always created the output via `new_empty(shape_out)`, which
defaults to contiguous format.

Mirror the logic already present in meta_convolution_backward: detect the
memory format from input_tensor and weight via suggest_memory_format, then
apply it to the output with `.to(memory_format=...)`.

Fixes: https://github.com/pytorch/pytorch/issues/177277

Test plan:
  python test/test_fake_tensor.py FakeTensorTest.test_conv_ndhwc
  python test/test_fake_tensor.py FakeTensorTest.test_conv_nhwc_channels_last_weight_only
  python test/test_fake_tensor.py FakeTensorTest.test_conv_nhwc

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell