### PR TITLE
naviert: add missing <algorithm> includes in Placement.cpp

### DIFF
--- a/torch/nativert/executor/Placement.cpp
+++ b/torch/nativert/executor/Placement.cpp
@@ -1,6 +1,7 @@
 #include <torch/nativert/executor/Placement.h>
 
 #include <fmt/ostream.h>
+#include <algorithm>
 #include <ostream>
 
 namespace torch::nativert {


### PR DESCRIPTION
GCC 14+ no longer transitively includes <algorithm> through other standard library headers, causing build failure.

Please see: https://gcc.gnu.org/gcc-14/porting_to.html#header-dep-changes