### PR TITLE
[aten][autograd] Add narrow_scatter operator with autograd and torch.compile support

### DIFF
--- a/aten/src/ATen/functorch/BatchRulesScatterOps.cpp
+++ b/aten/src/ATen/functorch/BatchRulesScatterOps.cpp
@@ -940,6 +940,15 @@ Tensor slice_scatter_decomp(const Tensor &self, const Tensor &src,
   return at::scatter(self, dim, idx, src);
 }
 
+Tensor narrow_scatter_decomp(
+    const Tensor &self, const Tensor &src,
+    int64_t dim, c10::SymInt start, c10::SymInt length)
+{
+  c10::SymInt end = start + length;
+  return at::slice_scatter_symint(
+      self, src, dim, std::make_optional(start), std::make_optional(end), 1);
+}
+
 Tensor select_scatter_decomp(
     const Tensor &self, const Tensor &source,
     int64_t dim, int64_t index)
@@ -1286,6 +1295,7 @@ TORCH_LIBRARY_IMPL(aten, FuncTorchBatched, m) {
   m.impl("index_put", index_put_plumbing);
   m.impl("_index_put_impl_", _index_put_impl__plumbing);
   m.impl("slice_scatter", slice_scatter_decomp);
+  m.impl("narrow_scatter", narrow_scatter_decomp);
   m.impl("select_scatter", select_scatter_decomp);
   m.impl("index_copy", index_copy_decomp);
   m.impl("index_select", index_select_decomp);

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -136,6 +136,7 @@
 #include <ATen/ops/narrow_copy.h>
 #include <ATen/ops/narrow_copy_native.h>
 #include <ATen/ops/narrow_native.h>
+#include <ATen/ops/narrow_scatter_native.h>
 #include <ATen/ops/new_empty_native.h>
 #include <ATen/ops/new_ones_native.h>
 #include <ATen/ops/numpy_T_native.h>
@@ -158,6 +159,7 @@
 #include <ATen/ops/slice_copy_native.h>
 #include <ATen/ops/slice_inverse_native.h>
 #include <ATen/ops/slice_native.h>
+#include <ATen/ops/slice_scatter.h>
 #include <ATen/ops/slice_scatter_native.h>
 #include <ATen/ops/sparse_coo_tensor.h>
 #include <ATen/ops/sparse_coo_tensor_native.h>
@@ -4888,6 +4890,16 @@ at::Tensor select_scatter_symint(
       slice.sizes());
   slice.copy_(src);
   return output;
+}
+at::Tensor narrow_scatter_symint(
+    const at::Tensor& self,
+    const at::Tensor& src,
+    int64_t dim,
+    c10::SymInt start,
+    c10::SymInt length) {
+  c10::SymInt end = start + length;
+  return at::slice_scatter_symint(
+      self, src, dim, std::make_optional(start), std::make_optional(end), 1);
 }
 at::Tensor diagonal_scatter(
     const at::Tensor& self,

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -4484,6 +4484,14 @@
   dispatch:
     CPU: narrow_copy_dense_cpu_out
 
+- func: narrow_scatter(Tensor self, Tensor src, int dim, SymInt start, SymInt length) -> Tensor
+  variants: function, method
+  device_check: NoCheck
+  device_guard: False
+  dispatch:
+    CompositeExplicitAutograd: narrow_scatter_symint
+  tags: view_copy
+
 - func: narrow(Tensor(a) self, int dim, SymInt start, SymInt length) -> Tensor(a)
   variants: function, method
   device_check: NoCheck

--- a/docs/source/tensors.md
+++ b/docs/source/tensors.md
@@ -546,6 +546,7 @@ view of a storage and defines numeric operations on it.
     Tensor.nansum
     Tensor.narrow
     Tensor.narrow_copy
+    Tensor.narrow_scatter
     Tensor.ndimension
     Tensor.nan_to_num
     Tensor.nan_to_num_

--- a/docs/source/torch.md
+++ b/docs/source/torch.md
@@ -143,6 +143,7 @@ range of distributions.
     moveaxis
     narrow
     narrow_copy
+    narrow_scatter
     nonzero
     nonzero_static
     permute

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -3951,6 +3951,18 @@ class TestAutograd(TestCase):
         expected[3:5] = v_expanded
         self.assertEqual(result, expected)
 
+    def test_narrow_scatter_gradcheck(self):
+        x = torch.randn(10, 10, dtype=torch.double, requires_grad=True)
+        src = torch.randn(5, 10, dtype=torch.double, requires_grad=True)
+        self.assertTrue(
+            gradcheck(lambda x, s: torch.narrow_scatter(x, s, 0, 2, 5), (x, src))
+        )
+
+        src2 = torch.randn(10, 4, dtype=torch.double, requires_grad=True)
+        self.assertTrue(
+            gradcheck(lambda x, s: torch.narrow_scatter(x, s, 1, 3, 4), (x, src2))
+        )
+
     def test_unused_output(self):
         x = torch.randn(10, 10, requires_grad=True)
         outputs = x.chunk(5)

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -1583,6 +1583,11 @@
   src: grad.slice_symint(dim, start, end, step)
   result: auto_linear
 
+- name: narrow_scatter(Tensor self, Tensor src, int dim, SymInt start, SymInt length) -> Tensor
+  self: narrow_scatter_symint(grad, zeros_like(src), dim, start, length)
+  src: grad.narrow_symint(dim, start, length)
+  result: auto_linear
+
 - name: select_scatter(Tensor self, Tensor src, int dim, SymInt index) -> Tensor
   self: select_scatter_symint(grad, zeros_like(src), dim, index)
   src: grad.select_symint(dim, index)

--- a/torch/_dynamo/trace_rules.py
+++ b/torch/_dynamo/trace_rules.py
@@ -2161,6 +2161,7 @@ torch_c_binding_in_graph_functions = dict.fromkeys(
         "torch.nansum",
         "torch.narrow_copy",
         "torch.narrow",
+        "torch.narrow_scatter",
         "torch.native_batch_norm",
         "torch.native_channel_shuffle",
         "torch.native_dropout",

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -1147,6 +1147,19 @@ def slice_scatter_noop(self, src, dim=0, start=None, end=None, step=1):
     return False
 
 
+@register_noop_decomp(aten.narrow_scatter, 1)
+def narrow_scatter_noop(self, src, dim, start, length):
+    # If the narrow region covers the entire dimension, just return src
+    narrow_dim_size = self.shape[dim]
+    if (
+        self.shape == src.shape
+        and start == 0
+        and statically_known_true(length >= narrow_dim_size)
+    ):
+        return True
+    return False
+
+
 @register_noop_decomp(aten.repeat)
 def repeat_noop(self, repeats):
     return all(r == 1 for r in repeats)

--- a/torch/_inductor/fx_passes/reinplace.py
+++ b/torch/_inductor/fx_passes/reinplace.py
@@ -54,6 +54,7 @@ class InplaceableOp:
 
 _SCATTER_OP_TO_VIEW = {
     torch.ops.aten.diagonal_scatter.default: torch.ops.aten.diagonal.default,
+    torch.ops.aten.narrow_scatter.default: torch.ops.aten.narrow.default,
     torch.ops.aten.select_scatter.default: torch.ops.aten.select.int,
     torch.ops.aten.slice_scatter.default: torch.ops.aten.slice.Tensor,
     torch.ops.aten.as_strided_scatter.default: torch.ops.aten.as_strided.default,

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -3810,6 +3810,14 @@ def slice_scatter(x, src, dim=0, start=None, end=None, step=1):
     )
 
 
+@register_lowering(aten.narrow_scatter, type_promotion_kind=None)
+def narrow_scatter(x, src, dim, start, length):
+    # narrow_scatter(x, src, dim, start, length) is equivalent to
+    # slice_scatter(x, src, dim, start, start+length, step=1)
+    end = start + length
+    return slice_scatter(x, src, dim, start, end, step=1)
+
+
 def _unwrap(x):
     if isinstance(x, (list, tuple)) and len(x) > 0:
         return _unwrap(x[0])

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -8133,6 +8133,51 @@ Example::
 )
 
 add_docstr(
+    torch.narrow_scatter,
+    r"""
+narrow_scatter(input, src, dim, start, length) -> Tensor
+
+Embeds the values of the :attr:`src` tensor into :attr:`input` along
+dimension :attr:`dim` starting at index :attr:`start` for :attr:`length`
+elements.
+This function returns a tensor with fresh storage; it does not create a view.
+
+This is the reverse operation of :func:`torch.narrow`: where ``narrow``
+extracts a slice, ``narrow_scatter`` writes a slice back.
+
+Args:
+    {input}
+    src (Tensor): The tensor to embed into :attr:`input`. Must have the same
+        shape as ``torch.narrow(input, dim, start, length)``
+    dim (int): the dimension along which to scatter
+    start (int): index of the element to start the scatter from
+    length (int): length of the scattered dimension
+
+Example::
+
+    >>> a = torch.zeros(3, 3)
+    >>> b = torch.ones(2, 3)
+    >>> torch.narrow_scatter(a, b, 0, 0, 2)
+    tensor([[1., 1., 1.],
+            [1., 1., 1.],
+            [0., 0., 0.]])
+
+    >>> a = torch.zeros(3, 3)
+    >>> b = torch.ones(3, 1)
+    >>> torch.narrow_scatter(a, b, 1, 2, 1)
+    tensor([[0., 0., 1.],
+            [0., 0., 1.],
+            [0., 0., 1.]])
+
+.. seealso::
+
+        :func:`torch.narrow` for the reverse (extracting) operation,
+        :func:`torch.slice_scatter` for a similar operation with ``start``/``end``/``step`` semantics
+
+""".format(**common_args),
+)
+
+add_docstr(
     torch.nan_to_num,
     r"""
 nan_to_num(input, nan=0.0, posinf=None, neginf=None, *, out=None) -> Tensor

--- a/torch/distributed/tensor/_ops/_tensor_ops.py
+++ b/torch/distributed/tensor/_ops/_tensor_ops.py
@@ -545,6 +545,7 @@ def replicate_tensor_dim(
 
 
 @register_op_strategy(aten.slice_scatter.default, schema_info=RuntimeSchemaInfo(2))
+@register_op_strategy(aten.narrow_scatter.default, schema_info=RuntimeSchemaInfo(2))
 def gen_slice_scatter_strategy(op_schema: OpSchema) -> StrategyType:
     # 1. number of dimensions in input and src need to match.
     # 2. number of elements on all non-dim need to match between input and src.
@@ -553,6 +554,8 @@ def gen_slice_scatter_strategy(op_schema: OpSchema) -> StrategyType:
     # - We suggest for src to follow the sharding of input, except on the scatter dimension,
     #   where our best bet for now is to make them replicated as a fall-back.
     #   TODO: Ideally we'd like to make sure the output is re-sharded afterwards to keep input sharding.
+    # Note: narrow_scatter has the same sharding semantics as slice_scatter since it's
+    # implemented as a wrapper that calls slice_scatter_symint.
     mesh = op_schema.get_mesh_from_args()
     input_strategy = op_schema.args_schema[0]
     src_strategy = op_schema.args_schema[1]

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -5837,6 +5837,24 @@ def error_inputs_narrow_narrow_copy(op_info, device, *, is_narrow, is_ref):
                          error_regex=r"start must be an 0-dim integral Tensor\.")
 
 
+def sample_inputs_narrow_scatter(op_info, device, dtype, requires_grad, **kwargs):
+    make_arg = partial(make_tensor, dtype=dtype, device=device, requires_grad=requires_grad)
+
+    # (input_shape, src_shape, (dim, start, length))
+    # narrow_scatter(input, src, dim, start, length) where src.shape == input.narrow(dim, start, length).shape
+    cases = (((L, M, S), (L // 2, M, S), (0, L // 4, L // 2)),
+             ((L, M, S), (1, M, S), (0, L // 2, 1)),
+             ((L, M, S), (L, M // 2, S), (1, M // 4, M // 2)),
+             ((L, M, S), (L, M, S // 2), (2, S // 4, S // 2)),
+             ((L, M, S), (L, M, S), (0, 0, L)),
+             )
+
+    for input_shape, src_shape, args in cases:
+        input_ = make_arg(input_shape)
+        src = make_arg(src_shape)
+        yield SampleInput(input_, args=(src, *args))
+
+
 def sample_trapezoid(op_info, device, dtype, requires_grad, **kwargs):
     y_shape_x_shape_and_kwargs = [
         ((2, 3), (2, 3), {}),
@@ -18392,6 +18410,15 @@ op_db: list[OpInfo] = [
                             device_type='cuda'),
                DecorateInfo(unittest.expectedFailure, 'TestMeta', 'test_dispatch_symbolic_meta_outplace_all_strides'),
            )),
+    OpInfo('narrow_scatter',
+           dtypes=all_types_and(torch.bool, torch.bfloat16, torch.float16),
+           backward_dtypes=all_types_and(torch.bool, torch.bfloat16, torch.float16),
+           supports_out=False,
+           supports_forward_ad=True,
+           supports_fwgrad_bwgrad=True,
+           sample_inputs_func=sample_inputs_narrow_scatter,
+           # https://github.com/pytorch/pytorch/issues/80411
+           gradcheck_fast_mode=True),
     OpInfo('view_copy',
            dtypes=all_types_and_complex_and(torch.bool, torch.bfloat16, torch.float16),
            ref=lambda x, newshape: np.reshape(x, newshape).copy(),


### PR DESCRIPTION
Implements torch.narrow_scatter completing the *_copy/*_scatter family.

Implementation:
- Added definition in native_functions.yaml with SymInt support
- C++ implementation in TensorShape.cpp delegates to slice_scatter
- Autograd derivatives in derivatives.yaml
- torch.compile integration:
  - TorchDynamo tracing (trace_rules.py)
  - Inductor lowering (lowering.py)
  - Re-inplacing optimization (reinplace.py)
  - Noop optimization (post_grad.py)
- OpInfo tests with 54 automated test cases
- Gradcheck tests in test_autograd.py

Testing:
Verified with PYTORCH_TEST_WITH_DYNAMO=1, all tests passing.

Fixes #177372

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98 @Lucaskabela