### PR TITLE
Add Claude-powered autorevert AI advisor workflow

### DIFF
--- a/.github/workflows/claude-autorevert-advisor.yml
+++ b/.github/workflows/claude-autorevert-advisor.yml
@@ -1,0 +1,132 @@
+name: Claude Autorevert Advisor
+
+on:
+  workflow_dispatch:
+    inputs:
+      suspect_commit:
+        description: "SHA of the commit autorevert suspects caused the failure"
+        required: true
+        type: string
+      pr_number:
+        description: "PR number of the suspect commit"
+        required: true
+        type: string
+      signal_pattern:
+        description: "JSON object with signal metadata, failed partition (with job links/log URLs), and successful partition (baseline)"
+        required: true
+        type: string
+
+jobs:
+  analyze:
+    if: github.repository == 'pytorch/pytorch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: bedrock
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout pytorch/pytorch trunk
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 128
+
+      - name: Fetch suspect commit
+        run: |
+          git fetch origin ${{ inputs.suspect_commit }} --depth=32 || true
+
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::308535385114:role/gha_workflow_claude_code
+          aws-region: us-east-1
+
+      - name: Run AI Advisor
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          use_bedrock: "true"
+          claude_args: |
+            --model global.anthropic.claude-opus-4-6-v1
+            --allowedTools "Bash,Read,Glob,Grep,WebFetch"
+            --json-schema '{"type":"object","required":["verdict","confidence","summary","causal_reasoning"],"properties":{"verdict":{"type":"string","enum":["revert","unsure","not_related","garbage"]},"confidence":{"type":"number","minimum":0,"maximum":1},"summary":{"type":"string","description":"1-3 sentence explanation of the verdict"},"causal_reasoning":{"type":"string","description":"Detailed explanation of the causal chain (or lack thereof) between the code change and the observed failures"}}}'
+          settings: '{"alwaysThinkingEnabled": true}'
+          prompt: |
+            You are an AI advisor for PyTorch's autorevert system. Your job is to analyze a suspect commit and CI failures to determine whether the commit caused the failures.
+
+            ## Context
+
+            **Suspect commit:** ${{ inputs.suspect_commit }}
+            **PR:** https://github.com/pytorch/pytorch/pull/${{ inputs.pr_number }}
+
+            **Signal pattern (partition data from autorevert):**
+            ```json
+            ${{ inputs.signal_pattern }}
+            ```
+
+            The signal pattern contains:
+            - `signal_key`: the test or job name that defines this signal
+            - `signal_source`: "test" (individual test) or "job" (whole job)
+            - `workflow_name`: the CI workflow where this signal lives
+            - `failed_partition`: commits where this signal FAILS (newest first, suspect commit marked with `is_suspect: true`). Each has job links and log URLs.
+            - `successful_partition`: baseline commits where this signal was GREEN (most recent first). These prove the signal was passing before the suspect commit.
+
+            The partition is ground truth from CI data. The signal transitioned from SUCCESS to FAILURE at the suspect commit. Your job is to determine whether the CODE CHANGE caused the transition, or whether it's coincidence (upstream dependency change, flaky environment, infra issue).
+
+            ## Investigation Steps
+
+            1. **Read the suspect commit diff.** Run `git show ${{ inputs.suspect_commit }}` to understand what code changed. Read the modified files to understand the broader context around the changes.
+
+            2. **Analyze the PR.** Fetch the PR description and understand the intent of the change: `gh pr view ${{ inputs.pr_number }} --repo pytorch/pytorch --json title,body,files`
+
+            3. **Investigate the failed jobs.** For each job in the failed_partition:
+               - Fetch the job logs from the log_url to find error messages, stack traces, and assertion failures
+               - Identify the specific test(s) or build step(s) that failed
+               - Read the relevant test source code in this checkout to understand what the test exercises
+
+            4. **Trace the causal chain.** This is the critical step. Do NOT take shortcuts:
+               - Trace imports, function calls, class hierarchies, and runtime dispatch paths from the changed code to the failing tests
+               - Consider indirect dependencies: a change to a utility function may break tests through several layers of abstraction
+               - Consider runtime behavior: changes to tensor operations, kernel dispatch, autograd behavior, or compilation paths can have non-obvious downstream effects
+               - Check if the error message or stack trace references any of the changed code, even indirectly
+
+            5. **Check for alternative explanations:**
+               - Is this a known flaky test? (Look for skip/xfail decorators, recent similar failures on other commits)
+               - Is this an infrastructure issue? (OOM, timeout, network error, GPU driver issue)
+               - Did a different concurrent commit plausibly cause this? (Check the commit timestamp and other recent merges)
+               - Is this signal fundamentally unreliable? (Persistent timeouts, environment-dependent flakes, resource exhaustion not caused by any code change)
+
+            6. **Render your verdict:**
+               - `revert` — You found a plausible causal chain from the code change to the failure. Confidence should reflect how direct and clear the chain is.
+               - `not_related` — After thorough investigation, there is no plausible causal chain. The failure has a clear alternative explanation.
+               - `unsure` — The investigation is inconclusive. There may be a connection but you cannot confirm it with sufficient confidence.
+               - `garbage` — The signal itself is unreliable and should be temporarily suppressed. Use this when the failure is clearly not caused by ANY code change: persistent infra flakes (runner timeouts, network errors, GPU driver crashes), environment issues (disk full, dependency mirror outage), or tests so flaky that the signal has no diagnostic value. This tells autorevert to ignore this signal for ~2 hours.
+
+            When in doubt between `unsure` and `not_related`, prefer `unsure`. A false `not_related` verdict is more costly than an `unsure` (which just lets autorevert continue its normal restart-to-confirm flow).
+
+            Use `garbage` only when the failure clearly has nothing to do with any code change — it's a statement about the signal quality, not about the suspect commit.
+
+            IMPORTANT: Be thorough. Read actual code. Trace actual call paths. Do not guess based on file names alone.
+
+      - name: Save verdict artifact
+        if: always() && steps.claude.outputs.structured_output != ''
+        env:
+          VERDICT_JSON: ${{ steps.claude.outputs.structured_output }}
+        run: |
+          mkdir -p /tmp/verdict
+          printf '%s' "$VERDICT_JSON" > /tmp/verdict/verdict.json
+          cat /tmp/verdict/verdict.json
+
+      - name: Upload verdict artifact
+        if: always() && steps.claude.outputs.structured_output != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: autorevert-verdict
+          path: /tmp/verdict/verdict.json
+          retention-days: 30
+
+      - name: Upload usage metrics
+        if: always()
+        uses: pytorch/test-infra/.github/actions/upload-claude-usage@main


### PR DESCRIPTION
## Summary

Adds a `workflow_dispatch` workflow that the autorevert system can trigger when it detects an early failure pattern. Claude Opus 4.6 analyzes the suspect commit's diff, failed job logs, and PyTorch source code to determine whether the commit actually caused the CI failures.

Returns a structured JSON verdict as an artifact:
- **revert** — causal chain found, proceed to revert immediately
- **unsure** — inconclusive, continue with restart-to-confirm (default behavior unchanged)
- **not_related** — failures unrelated to the change, ignore this signal
- **garbage** — signal is unreliable (infra flake, driver crash), suppress for ~2 hours

Design doc: https://docs.google.com/document/d/1BA9B7cIIKiapI37fSFGDD7D0F-VwMyRKJW0PoS0KkbY/edit

## Evaluation Results (13/13 correct verdicts)

Prototyped and tested on [pytorch/ciforge](https://github.com/pytorch/ciforge). Results across diverse failure types:

### Round 1 (2026-03-12) — 4/4 correct

| Test Case | PR | Failure | Expected | Actual | Job |
|-----------|-----|---------|----------|--------|-----|
| Doc-only change | #177288 | pca_lowrank stride mismatch | not_related | **not_related @ 0.99** | [job](https://github.com/pytorch/ciforge/actions/runs/23016718498) |
| Dynamo einops fix | #177165 | detectron2 graph_breaks + test_is_nonzero_mps | not_related | **not_related @ 0.93** | [job](https://github.com/pytorch/ciforge/actions/runs/23016730498) |
| MPS cdouble guard | #176985 | test_is_nonzero_mps + pca_lowrank | revert | **revert @ 0.95** | [job](https://github.com/pytorch/ciforge/actions/runs/23016740133) |
| Lint missing import | #176613 | Lint / lintrunner-noclang-all | revert | **revert @ 0.95** | [job](https://github.com/pytorch/ciforge/actions/runs/23013529685) |

### Round 2 (2026-03-13, automated hourly loop) — 9/9 correct (1 cancelled)

| Timestamp | PR | Signal Key | Expected | Actual | Job |
|-----------|-----|-----------|----------|--------|-----|
| 03:12Z | #176613 | Lint / lintrunner-noclang-all | revert | **revert @ 0.98** | [job](https://github.com/pytorch/ciforge/actions/runs/23034497618) |
| 03:12Z | #176613 | fsdp/test_fully_shard_comm (test exec) | revert | **revert @ 0.98** | [job](https://github.com/pytorch/ciforge/actions/runs/23034499988) |
| 09:11Z | #177273 | test-timeout-270min (infra) | — | *cancelled* | [job](https://github.com/pytorch/ciforge/actions/runs/23043982417) |
| 10:12Z | #176019 | AllenaiLongformerBase fail_to_run (periodic) | garbage | **garbage @ 0.95** | [job](https://github.com/pytorch/ciforge/actions/runs/23046142800) |
| 10:12Z | #176019 | detectron2_fcos IMPROVED (periodic) | not_related | **not_related @ 0.95** | [job](https://github.com/pytorch/ciforge/actions/runs/23046144261) |
| 11:10Z | #176019 | functorch_dp_cifar10 fail_accuracy (periodic) | not_related | **not_related @ 0.93** | [job](https://github.com/pytorch/ciforge/actions/runs/23048173319) |
| 11:10Z | #176019 | basic_gnn_edgecnn IMPROVED (periodic) | not_related | **not_related @ 0.92** | [job](https://github.com/pytorch/ciforge/actions/runs/23048174698) |
| 15:09Z | #177096 | S3 PutObject IAM denied - ROCm gfx950 (infra) | garbage | **garbage @ 0.95** | [job](https://github.com/pytorch/ciforge/actions/runs/23057146500) |
| 16:09Z | #176019 | vit_base_patch16_siglip_256 fail_to_run (periodic) | not_related | **not_related @ 0.97** | [job](https://github.com/pytorch/ciforge/actions/runs/23059634364) |
| 16:09Z | #176019 | shufflenet_v2_x1_0 fail_accuracy (periodic) | not_related | **not_related @ 0.95** | [job](https://github.com/pytorch/ciforge/actions/runs/23059635765) |

### Summary by verdict type

| Verdict | Count | Correct | Avg Confidence |
|---------|-------|---------|----------------|
| revert | 4 | 4/4 | 0.97 |
| garbage | 2 | 2/2 | 0.95 |
| not_related | 7 | 7/7 | 0.94 |

## Test plan

- [x] Prototyped and tested on pytorch/ciforge with 13 real trunk failure cases
- [x] Verified structured JSON output matches schema
- [x] Verified verdict artifact uploads correctly
- [ ] Trigger via GitHub UI with `workflow_dispatch` on pytorch/pytorch to validate bedrock environment works
- [ ] Integrate dispatch call into autorevert lambda (follow-up)