### PR TITLE
[Pytorch][Kineto] Expose comms id in traces (#177405)

### DIFF
--- a/test/cpp/profiler/CMakeLists.txt
+++ b/test/cpp/profiler/CMakeLists.txt
@@ -22,4 +22,24 @@ if(USE_KINETO)
     set_target_properties(test_privateuse1_profiler PROPERTIES INSTALL_RPATH "${CMAKE_INSTALL_RPATH}:${_rpath_portable_origin}/../lib")
     install(TARGETS test_privateuse1_profiler DESTINATION bin)
   endif()
+
+  if(USE_DISTRIBUTED)
+    add_executable(test_comms_id
+      ${TORCH_ROOT}/test/cpp/common/main.cpp
+      ${PROFILER_TEST_ROOT}/comms_id.cpp
+    )
+
+    target_compile_definitions(test_comms_id PRIVATE USE_GTEST USE_KINETO USE_DISTRIBUTED)
+
+    target_link_libraries(test_comms_id PRIVATE ${PROFILER_TEST_DEPENDENCIES})
+    target_include_directories(test_comms_id PRIVATE
+      ${ATen_CPU_INCLUDE}
+      ${KINETO_SOURCE_DIR}/include
+    )
+
+    if(INSTALL_TEST)
+      set_target_properties(test_comms_id PROPERTIES INSTALL_RPATH "${CMAKE_INSTALL_RPATH}:${_rpath_portable_origin}/../lib")
+      install(TARGETS test_comms_id DESTINATION bin)
+    endif()
+  endif()
 endif()

--- a/test/cpp/profiler/comms_id.cpp
+++ b/test/cpp/profiler/comms_id.cpp
@@ -1,0 +1,184 @@
+#include <gtest/gtest.h>
+
+#include <c10/util/ThreadLocalDebugInfo.h>
+#include <c10/util/hash.h>
+#include <torch/csrc/distributed/c10d/ParamCommsUtils.hpp>
+#include <torch/csrc/profiler/util.h>
+
+using torch::ParamCommsDebugInfo;
+using namespace torch::profiler::impl;
+
+namespace {
+
+ParamCommsDebugInfo makeDebugInfo(
+    const std::string& pgName,
+    const std::string& pgDesc,
+    int rank,
+    std::string collName,
+    int worldSize,
+    int64_t seqNumber,
+    bool isP2P,
+    int globalRankStart = 0,
+    int globalRankStride = 1) {
+  return ParamCommsDebugInfo(
+      std::make_tuple(pgName, pgDesc),
+      rank,
+      std::move(collName),
+      /*inNelems=*/1024,
+      /*outNelems=*/1024,
+      /*dType=*/at::kFloat,
+      /*inSplitSizes=*/std::vector<int64_t>{},
+      /*outSplitSizes=*/std::vector<int64_t>{},
+      globalRankStart,
+      globalRankStride,
+      worldSize,
+      /*isAsynchronizedOp=*/true,
+      seqNumber,
+      isP2P);
+}
+
+size_t computeExpectedCommsId(
+    const std::string& pgName,
+    int64_t seqNumber,
+    bool isP2P,
+    int globalRankStart = 0,
+    int globalRankStride = 1,
+    int worldSize = 8) {
+  return c10::get_hash(
+      pgName, seqNumber, isP2P, globalRankStart, globalRankStride, worldSize);
+}
+
+} // namespace
+
+TEST(CommsIdTest, ParamCommsDebugInfoStoresSeqNumberAndIsP2P) {
+  auto info =
+      makeDebugInfo("pg_uid_123", "default_pg", 0, "allreduce", 8, 42, false);
+
+  EXPECT_EQ(info.getSeqNumber(), 42);
+  EXPECT_FALSE(info.isP2P());
+  EXPECT_EQ(info.getProcessGroupName(), "pg_uid_123");
+  EXPECT_EQ(info.getCollectiveName(), "allreduce");
+  EXPECT_EQ(info.getWorldSize(), 8);
+}
+
+TEST(CommsIdTest, ParamCommsDebugInfoP2PFlag) {
+  auto info = makeDebugInfo("pg_uid_456", "custom_pg", 3, "send", 4, 7, true);
+
+  EXPECT_EQ(info.getSeqNumber(), 7);
+  EXPECT_TRUE(info.isP2P());
+}
+
+TEST(CommsIdTest, ParamCommsDebugInfoDefaultSeqNumberAndIsP2P) {
+  auto info = ParamCommsDebugInfo(
+      std::make_tuple(std::string("pg_uid_789"), std::string("default_pg")),
+      /*rank=*/1,
+      /*collName=*/std::string("allgather"),
+      /*inNelems=*/256,
+      /*outNelems=*/512,
+      /*dType=*/at::kFloat,
+      /*inSplitSizes=*/std::vector<int64_t>{},
+      /*outSplitSizes=*/std::vector<int64_t>{},
+      /*globalRankStart=*/0,
+      /*globalRankStride=*/1,
+      /*worldSize=*/2);
+
+  EXPECT_EQ(info.getSeqNumber(), 0);
+  EXPECT_FALSE(info.isP2P());
+}
+
+TEST(CommsIdTest, SaveNcclMetaEmitsCommsId) {
+  auto debugInfo = std::make_shared<ParamCommsDebugInfo>(
+      std::make_tuple(std::string("pg_uid_123"), std::string("default_pg")),
+      /*rank=*/0,
+      /*collName=*/std::string("allreduce"),
+      /*inNelems=*/1024,
+      /*outNelems=*/1024,
+      /*dType=*/at::kFloat,
+      /*inSplitSizes=*/std::vector<int64_t>{},
+      /*outSplitSizes=*/std::vector<int64_t>{},
+      /*globalRankStart=*/0,
+      /*globalRankStride=*/1,
+      /*worldSize=*/8,
+      /*isAsynchronizedOp=*/true,
+      /*seqNumber=*/int64_t(42),
+      /*isP2P=*/false);
+
+  c10::DebugInfoGuard guard(c10::DebugInfoKind::PARAM_COMMS_INFO, debugInfo);
+
+  // Create a dummy RecordFunction to pass to saveNcclMeta
+  at::RecordFunction fn(at::RecordScope::USER_SCOPE);
+  fn._setAsync();
+
+  auto meta = saveNcclMeta(fn);
+
+  // Verify comms_id is in the metadata
+  ASSERT_TRUE(meta.count(kCommsId) > 0);
+
+  // Verify the comms_id value matches
+  // hash(pg_name, seqNumber, isP2P, globalRankStart, globalRankStride,
+  // worldSize)
+  size_t expected_comms_id = computeExpectedCommsId(
+      "pg_uid_123",
+      int64_t(42),
+      false,
+      /*globalRankStart=*/0,
+      /*globalRankStride=*/1,
+      /*worldSize=*/8);
+  EXPECT_EQ(meta.at(kCommsId), std::to_string(expected_comms_id));
+}
+
+TEST(CommsIdTest, CommsIdDeterministicAcrossInstances) {
+  std::string pg_name = "pg_uid_shared";
+  int64_t seq = 100;
+
+  size_t comms_id_1 = computeExpectedCommsId(pg_name, seq, false);
+  size_t comms_id_2 = computeExpectedCommsId(pg_name, seq, false);
+
+  EXPECT_EQ(comms_id_1, comms_id_2);
+}
+
+TEST(CommsIdTest, CommsIdDiffersForDifferentSeqNumbers) {
+  std::string pg_name = "pg_uid_shared";
+
+  size_t comms_id_seq1 = computeExpectedCommsId(pg_name, int64_t(1), false);
+  size_t comms_id_seq2 = computeExpectedCommsId(pg_name, int64_t(2), false);
+
+  EXPECT_NE(comms_id_seq1, comms_id_seq2);
+}
+
+TEST(CommsIdTest, CommsIdDiffersForDifferentPGNames) {
+  int64_t seq = 42;
+
+  size_t comms_id_pg1 = computeExpectedCommsId("pg_uid_A", seq, false);
+  size_t comms_id_pg2 = computeExpectedCommsId("pg_uid_B", seq, false);
+
+  EXPECT_NE(comms_id_pg1, comms_id_pg2);
+}
+
+TEST(CommsIdTest, CommsIdDiffersForP2PvsCollective) {
+  std::string pg_name = "pg_uid_shared";
+  int64_t seq = 42;
+
+  size_t comms_id_collective = computeExpectedCommsId(pg_name, seq, false);
+  size_t comms_id_p2p = computeExpectedCommsId(pg_name, seq, true);
+
+  EXPECT_NE(comms_id_collective, comms_id_p2p);
+}
+
+TEST(CommsIdTest, CommsIdDiffersForDifferentCommunicatorTopology) {
+  std::string pg_name = "pg_uid_shared";
+  int64_t seq = 42;
+
+  // Same PG name and seq, but different communicator topology
+  // (e.g., after comm split producing different rank subsets)
+  size_t comms_id_full = computeExpectedCommsId(pg_name, seq, false, 0, 1, 8);
+  size_t comms_id_split = computeExpectedCommsId(pg_name, seq, false, 0, 1, 4);
+
+  EXPECT_NE(comms_id_full, comms_id_split);
+
+  // Different globalRankStart (different subset of ranks)
+  size_t comms_id_start0 = computeExpectedCommsId(pg_name, seq, false, 0, 2, 4);
+  size_t comms_id_start1 = computeExpectedCommsId(pg_name, seq, false, 1, 2, 4);
+
+  EXPECT_NE(comms_id_start0, comms_id_start1);
+}

--- a/test/distributed/test_comms_id_trace.py
+++ b/test/distributed/test_comms_id_trace.py
@@ -1,0 +1,147 @@
+# Owner(s): ["oncall: distributed"]
+
+"""
+End-to-end verification that "Comms Id" appears in PyTorch profiler Chrome
+trace JSON for NCCL collectives.
+
+Usage:
+    pytest test/distributed/test_comms_id_trace.py
+"""
+
+import json
+import os
+import tempfile
+
+import torch
+import torch.distributed as dist
+from torch.testing._internal.common_distributed import (
+    MultiProcContinuousTest,
+    requires_nccl,
+    skip_if_lt_x_gpu,
+)
+from torch.testing._internal.common_utils import run_tests
+
+
+class TestCommsIdTrace(MultiProcContinuousTest):
+    @classmethod
+    def backend_str(cls):
+        return "nccl"
+
+    @property
+    def device(self):
+        return torch.device("cuda", self.rank)
+
+    @requires_nccl()
+    @skip_if_lt_x_gpu(2)
+    def test_comms_id_in_trace(self):
+        """Verify that Comms Id appears in profiler trace for NCCL collectives."""
+        device = self.device
+
+        with torch.profiler.profile(
+            activities=[
+                torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA,
+            ],
+        ) as prof:
+            tensor = torch.ones(4, 4, device=device) * self.rank
+            dist.all_reduce(tensor)
+            dist.all_reduce(tensor)
+            torch.cuda.synchronize()
+
+        trace_dir = tempfile.mkdtemp(prefix="comms_id_trace_")
+        trace_path = os.path.join(trace_dir, f"trace_rank{self.rank}.json")
+        prof.export_chrome_trace(trace_path)
+
+        with open(trace_path) as f:
+            trace = json.load(f)
+
+        comms_ids = []
+        for event in trace.get("traceEvents", []):
+            args = event.get("args", {})
+            if "Comms Id" in args:
+                comms_ids.append(args["Comms Id"])
+
+        self.assertGreater(len(comms_ids), 0, "No 'Comms Id' found in trace events")
+
+    @requires_nccl()
+    @skip_if_lt_x_gpu(2)
+    def test_comms_id_consistent_across_ranks(self):
+        """Verify that the same collective has the same Comms Id on all ranks."""
+        device = self.device
+
+        with torch.profiler.profile(
+            activities=[
+                torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA,
+            ],
+        ) as prof:
+            tensor = torch.ones(4, 4, device=device) * self.rank
+            dist.all_reduce(tensor)
+            torch.cuda.synchronize()
+
+        trace_dir = tempfile.mkdtemp(prefix="comms_id_trace_")
+        trace_path = os.path.join(trace_dir, f"trace_rank{self.rank}.json")
+        prof.export_chrome_trace(trace_path)
+
+        with open(trace_path) as f:
+            trace = json.load(f)
+
+        comms_ids = []
+        for event in trace.get("traceEvents", []):
+            args = event.get("args", {})
+            if "Comms Id" in args:
+                comms_ids.append(args["Comms Id"])
+
+        # Gather comms_ids from all ranks to rank 0 for comparison
+        gathered = [None] * self.world_size
+        dist.all_gather_object(gathered, comms_ids)
+
+        # All ranks should have the same set of comms_ids
+        if self.rank == 0:
+            self.assertGreater(len(gathered[0]), 0, "No Comms Id found on rank 0")
+            for r in range(1, self.world_size):
+                self.assertEqual(
+                    sorted(gathered[0]),
+                    sorted(gathered[r]),
+                    f"Comms Ids differ between rank 0 and rank {r}",
+                )
+
+    @requires_nccl()
+    @skip_if_lt_x_gpu(2)
+    def test_comms_id_differs_across_operations(self):
+        """Verify that different collectives get different Comms Ids."""
+        device = self.device
+
+        with torch.profiler.profile(
+            activities=[
+                torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA,
+            ],
+        ) as prof:
+            tensor = torch.ones(4, 4, device=device) * self.rank
+            dist.all_reduce(tensor)
+            dist.all_reduce(tensor)
+            torch.cuda.synchronize()
+
+        trace_dir = tempfile.mkdtemp(prefix="comms_id_trace_")
+        trace_path = os.path.join(trace_dir, f"trace_rank{self.rank}.json")
+        prof.export_chrome_trace(trace_path)
+
+        with open(trace_path) as f:
+            trace = json.load(f)
+
+        comms_ids = []
+        for event in trace.get("traceEvents", []):
+            args = event.get("args", {})
+            if "Comms Id" in args:
+                comms_ids.append(args["Comms Id"])
+
+        # Two allreduce ops should produce at least 2 distinct comms_ids
+        unique_ids = set(comms_ids)
+        self.assertGreaterEqual(
+            len(unique_ids), 2, "Expected different Comms Ids for different operations"
+        )
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/csrc/distributed/c10d/ParamCommsUtils.cpp
+++ b/torch/csrc/distributed/c10d/ParamCommsUtils.cpp
@@ -19,7 +19,9 @@ ParamCommsDebugInfo::ParamCommsDebugInfo(
     int globalRankStart,
     int globalRankStride,
     int worldSize,
-    bool isAsynchronizedOp)
+    bool isAsynchronizedOp,
+    int64_t seqNumber,
+    bool isP2P)
     : pgName_(std::move(pgName)),
       rank_(rank),
       worldSize_(worldSize),
@@ -31,6 +33,8 @@ ParamCommsDebugInfo::ParamCommsDebugInfo(
       outputSplitSizes_(std::move(outSplitSizes)),
       globalRankStart_(globalRankStart),
       globalRankStride_(globalRankStride),
+      seqNumber_(seqNumber),
+      isP2P_(isP2P),
       isAsynchronizedOp_(isAsynchronizedOp) {
   if (globalRankStride > 0) {
     for (int i = 0; i < worldSize; i++) {

--- a/torch/csrc/distributed/c10d/ParamCommsUtils.hpp
+++ b/torch/csrc/distributed/c10d/ParamCommsUtils.hpp
@@ -25,7 +25,9 @@ class TORCH_API ParamCommsDebugInfo : public c10::DebugInfoBase {
       int globalRankStart,
       int globalRankStride,
       int worldSize,
-      bool isAsynchronizedOp = true);
+      bool isAsynchronizedOp = true,
+      int64_t seqNumber = 0,
+      bool isP2P = false);
 
   ~ParamCommsDebugInfo() override = default;
 
@@ -98,6 +100,14 @@ class TORCH_API ParamCommsDebugInfo : public c10::DebugInfoBase {
     isP2P_ = isP2P;
   }
 
+  int64_t getSeqNumber() const {
+    return seqNumber_;
+  }
+
+  bool isP2P() const {
+    return isP2P_;
+  }
+
  private:
   std::tuple<std::string, std::string> pgName_; // <group_name, group_desc>
   int rank_{};
@@ -110,10 +120,11 @@ class TORCH_API ParamCommsDebugInfo : public c10::DebugInfoBase {
   std::vector<int64_t> outputSplitSizes_;
   int globalRankStart_{};
   int globalRankStride_{};
+  int64_t seqNumber_{0};
+  bool isP2P_{false};
   std::vector<int64_t> groupRanks_;
   bool isAsynchronizedOp_{};
   int64_t sequenceNumber_{-1};
-  bool isP2P_{false};
 };
 
 // Helper to set sequence info from tuple-typed seq arguments (NCCL backend).
@@ -129,6 +140,28 @@ template <typename T>
 inline void maybeSetSequenceInfo(
     const std::shared_ptr<ParamCommsDebugInfo>&,
     const T&) {}
+
+// Helpers to extract seqNumber/isP2P from tuple-typed seq (NCCL backend).
+// Return defaults for backends that pass non-tuple seq types (e.g., XPU/XCCL).
+template <typename A, typename B>
+inline int64_t maybeGetSeqNumber(const std::tuple<A, B>& seq) {
+  return static_cast<int64_t>(std::get<0>(seq));
+}
+
+template <typename T>
+inline int64_t maybeGetSeqNumber(const T& seq) {
+  return static_cast<int64_t>(seq);
+}
+
+template <typename A, typename B>
+inline bool maybeGetIsP2P(const std::tuple<A, B>& seq) {
+  return static_cast<bool>(std::get<1>(seq));
+}
+
+template <typename T>
+inline bool maybeGetIsP2P(const T&) {
+  return false;
+}
 
 #define RECORD_PARAM_COMMS(                                                    \
     seq,                                                                       \
@@ -155,7 +188,9 @@ inline void maybeSetSequenceInfo(
       globalRankStart,                                                         \
       globalRankStride,                                                        \
       worldSize,                                                               \
-      false);                                                                  \
+      false,                                                                   \
+      torch::maybeGetSeqNumber(seq),                                           \
+      torch::maybeGetIsP2P(seq));                                              \
   torch::maybeSetSequenceInfo(paramCommsInfo, seq);                            \
   c10::DebugInfoGuard g(c10::DebugInfoKind::PARAM_COMMS_INFO, paramCommsInfo); \
   std::initializer_list<const c10::IValue> paramList = {                       \
@@ -232,7 +267,9 @@ inline void maybeSetSequenceInfo(
       globalRankStart,                                                         \
       globalRankStride,                                                        \
       worldSize,                                                               \
-      isAsyncOp);                                                              \
+      isAsyncOp,                                                               \
+      torch::maybeGetSeqNumber(seq),                                           \
+      torch::maybeGetIsP2P(seq));                                              \
   torch::maybeSetSequenceInfo(paramCommsInfo, seq);                            \
   c10::DebugInfoGuard g(c10::DebugInfoKind::PARAM_COMMS_INFO, paramCommsInfo); \
   std::initializer_list<const c10::IValue> paramList = {                       \

--- a/torch/csrc/profiler/util.cpp
+++ b/torch/csrc/profiler/util.cpp
@@ -514,6 +514,18 @@ std::unordered_map<std::string, std::string> saveNcclMeta(
     if (seqNum >= 0) {
       map.emplace(kSeqNum, std::to_string(seqNum));
     }
+
+    auto seqNumber = debugInfo->getSeqNumber();
+    auto isP2P = debugInfo->isP2P();
+    const auto& group_name_for_hash = debugInfo->getProcessGroupName();
+    size_t comms_id = c10::get_hash(
+        group_name_for_hash,
+        seqNumber,
+        isP2P,
+        globalRankStart,
+        globalRankStride,
+        debugInfo->getWorldSize());
+    map.emplace(kCommsId, std::to_string(comms_id));
   }
 
   map.emplace(

--- a/torch/csrc/profiler/util.h
+++ b/torch/csrc/profiler/util.h
@@ -205,6 +205,7 @@ constexpr auto kSeqNum = "Seq";
 constexpr auto kInTensorsStart = "Input Tensors start";
 constexpr auto kOutTensorsStart = "Output Tensors start";
 constexpr auto kIsAsynchronizedOp = "Is asynchronized op";
+constexpr auto kCommsId = "Comms Id";
 #endif // USE_DISTRIBUTED
 
 } // namespace torch::profiler::impl


### PR DESCRIPTION
Summary:

# Context

There is not a way to connect the same comms operations across multiple gpus. This makes debugging based on traces tricky and time consuming. This diff added a comms_id to PyTorch profiler traces that uniquely identifies each collective/P2P communication operation across all ranks. This enables trace analysis tools to correlate the same operation across different ranks for debugging distributed training performance.

How comms_id is computed

comms_id = hash(pg_name, seqNumber, isP2P, globalRankStart, globalRankStride, worldSize)

  - pg_name — identifies the process group
  - seqNumber — per-PG operation counter, identifies which operation within the PG
  - isP2P — distinguishes P2P ops (send/recv) from collectives (allreduce, etc.), since they use separate sequence number counters
- globalRankStart, globalRankStride, worldSize — encodes the communicator topology,
  disambiguating cases where one PG creates multiple communicators (e.g., comm splits)

 Changes by layer

 1. Data model (ParamCommsUtils.hpp/.cpp) — Added seqNumber, isP2P fields to ParamCommsDebugInfo, the class that carries communication metadata through the profiling stack.
 2. Hash computation (profiler/util.cpp/.h) — In saveNcclMeta(), computes comms_id from the 6 fields above and emits it as "Comms Id" in the profiler metadata map.
3. Trace output (output_json.cpp) — Kineto reads "Comms Id" from the metadata and writes it into the Chrome trace JSON, making it visible in trace viewers.
4. Tests (comms_id.cpp, CuptiActivityProfilerTest.cpp) — 9 unit tests covering:
  - Storage/retrieval of seqNumber and isP2P
  - Default values
  - End-to-end: comms_id appears in saveNcclMeta() output with correct hash
  - Determinism across instances
  - Uniqueness across different PG names, sequence numbers, P2P vs collective, and communicator topologies

Test Plan:
Added unit tests
```
buck test fbcode//caffe2/test/cpp/profiler:test_comms_id
```

Run end to end test to issue 2 allreduce 
```
buck run fbcode//mode/dev-nosan fbcode//caffe2/test/distributed:verify_comms_id_trace
P2235024803
```
Verify Rank0 and Rank1 both has the same comm_id for the same allreduce op

Rank0, first all reduce  comm_id --> 2297668046887139027
 {F1986699614} 

Rank0, second all reduce comm_id --> 2297668046887139088
 {F1986699629} 

Rank1, first all reduce comm_id --> 2297668046887139027
 {F1986699634} 

Rank1, second all reduce comm_id -->2297668046887139088
 {F1986699650}


Land plan,
**Landing the diff only when the pytorch is updated to have the kineto hash.**

Differential Revision: D96499426


