### PR TITLE
Use safe_load in lint native functions

### DIFF
--- a/.github/scripts/lint_native_functions.py
+++ b/.github/scripts/lint_native_functions.py
@@ -33,7 +33,7 @@ yaml = ruamel.yaml.YAML()  # type: ignore[attr-defined]
 yaml.preserve_quotes = True  # type: ignore[assignment]
 yaml.width = 1000  # type: ignore[assignment]
 yaml.boolean_representation = ["False", "True"]  # type: ignore[attr-defined]
-r = yaml.load(contents)
+r = yaml.safe_load(contents)
 
 # Cuz ruamel's author intentionally didn't include conversion to string
 # https://stackoverflow.com/questions/47614862/best-way-to-use-ruamel-yaml-to-dump-to-string-not-to-stream

--- a/functorch/op_analysis/gen_data.py
+++ b/functorch/op_analysis/gen_data.py
@@ -25,7 +25,7 @@ def gen_data(special_op_lists, analysis_name):
     composite_ops = get_ops_for_key("CompositeImplicitAutograd")
     noncomposite_ops = all_ops - composite_ops
     with open("../../aten/src/ATen/native/native_functions.yaml") as f:
-        ops = yaml.load(f.read(), Loader=yaml.CLoader)
+        ops = yaml.safe_load(f.read(), Loader=yaml.CLoader)
 
     with open("annotated_ops") as f:
         annotated_ops = {a.strip(): b.strip() for a, b in csv.reader(f)}


### PR DESCRIPTION
Upon reviewing .github/scripts/lint_native_functions.py, I noticed an opportunity for improvement. Use safe_load in lint native functions. yaml.load on untrusted input can construct arbitrary Python objects. I kept the patch small and re-ran syntax checks after applying it.