### PR TITLE
[dtensor] Register sharding strategy for inductor_prims.fma

### DIFF
--- a/test/distributed/tensor/test_math_ops.py
+++ b/test/distributed/tensor/test_math_ops.py
@@ -1258,6 +1258,39 @@ class DistMathOpsTest(DTensorTestBase):
             self.assertEqual(dtensor_result.full_tensor(), local_result)
 
     @with_comms
+    def test_prims_fma(self):
+        from torch._inductor import inductor_prims
+
+        device_mesh = self.build_device_mesh()
+        a = torch.randn(12, 8)
+        b = torch.randn(12, 8)
+        c = torch.randn(12, 8)
+        dt_a = distribute_tensor(a, device_mesh, [Shard(0)])
+        dt_b = distribute_tensor(b, device_mesh, [Shard(0)])
+        dt_c = distribute_tensor(c, device_mesh, [Shard(0)])
+
+        # All DTensor inputs
+        local_result = inductor_prims.fma(a, b, c)
+        dtensor_result = inductor_prims.fma(dt_a, dt_b, dt_c)
+        self.assertEqual(dtensor_result.full_tensor(), local_result)
+        self.assertTrue(dtensor_result.placements[0].is_shard(dim=0))
+
+        # Scalar tensor input (mimics the alpha argument in add_)
+        scalar = torch.tensor(2.0)
+        local_result = inductor_prims.fma(a, scalar, c)
+        dtensor_result = inductor_prims.fma(dt_a, scalar, dt_c)
+        self.assertEqual(dtensor_result.full_tensor(), local_result)
+        self.assertTrue(dtensor_result.placements[0].is_shard(dim=0))
+
+        # Replicate placement
+        dt_a_rep = distribute_tensor(a, device_mesh, [Replicate()])
+        dt_c_rep = distribute_tensor(c, device_mesh, [Replicate()])
+        local_result = inductor_prims.fma(a, scalar, c)
+        dtensor_result = inductor_prims.fma(dt_a_rep, scalar, dt_c_rep)
+        self.assertEqual(dtensor_result.full_tensor(), local_result)
+        self.assertTrue(dtensor_result.placements[0].is_replicate())
+
+    @with_comms
     def test_prims_view_of(self):
         device_mesh = self.build_device_mesh()
         x = torch.randn(12, 8)

--- a/torch/_inductor/inductor_prims.py
+++ b/torch/_inductor/inductor_prims.py
@@ -115,13 +115,12 @@ fma = make_prim(
     tags=(torch.Tag.pointwise,),
 )
 
-# Register DTensor sharding strategy for fma so it works with DTensor inputs.
-# This must happen after fma is created since DTensor's _pointwise_ops module
-# loads before inductor and cannot reference prims.fma at import time.
-from torch.distributed.tensor._ops._pointwise_ops import _register_single_dim_pointwise
+# Register DTensor sharding strategies for inductor prims ops.
+# This must happen here (not in _pointwise_ops.py) because the ops
+# don't exist until make_prim() is called above.
+from torch.distributed.tensor._ops._pointwise_ops import register_inductor_prims
 
-
-_register_single_dim_pointwise(fma)
+register_inductor_prims()
 
 prepare_softmax_online = make_prim(
     "prepare_softmax_online(Tensor a, int dim) -> (Tensor, Tensor)",

--- a/torch/_inductor/inductor_prims.py
+++ b/torch/_inductor/inductor_prims.py
@@ -120,6 +120,7 @@ fma = make_prim(
 # don't exist until make_prim() is called above.
 from torch.distributed.tensor._ops._pointwise_ops import register_inductor_prims
 
+
 register_inductor_prims()
 
 prepare_softmax_online = make_prim(

--- a/torch/_inductor/inductor_prims.py
+++ b/torch/_inductor/inductor_prims.py
@@ -118,10 +118,10 @@ fma = make_prim(
 # Register DTensor sharding strategies for inductor prims ops.
 # This must happen here (not in _pointwise_ops.py) because the ops
 # don't exist until make_prim() is called above.
-from torch.distributed.tensor._ops._pointwise_ops import register_inductor_prims
+if torch.distributed.is_available():
+    from torch.distributed.tensor._ops._pointwise_ops import register_inductor_prims
 
-
-register_inductor_prims()
+    register_inductor_prims()
 
 prepare_softmax_online = make_prim(
     "prepare_softmax_online(Tensor a, int dim) -> (Tensor, Tensor)",

--- a/torch/_inductor/inductor_prims.py
+++ b/torch/_inductor/inductor_prims.py
@@ -114,6 +114,15 @@ fma = make_prim(
     doc="Fused multiply add: fma(a, b, c) -> (a * b) + c without rounding after the multiplication",
     tags=(torch.Tag.pointwise,),
 )
+
+# Register DTensor sharding strategy for fma so it works with DTensor inputs.
+# This must happen after fma is created since DTensor's _pointwise_ops module
+# loads before inductor and cannot reference prims.fma at import time.
+from torch.distributed.tensor._ops._pointwise_ops import _register_single_dim_pointwise
+
+
+_register_single_dim_pointwise(fma)
+
 prepare_softmax_online = make_prim(
     "prepare_softmax_online(Tensor a, int dim) -> (Tensor, Tensor)",
     eager_prepare_softmax,

--- a/torch/distributed/tensor/_ops/_pointwise_ops.py
+++ b/torch/distributed/tensor/_ops/_pointwise_ops.py
@@ -1259,3 +1259,15 @@ for op in fused_ops:
     register_op_strategy(op, schema_info=RuntimeSchemaInfo(needs_pytree=True))(
         list_pointwise_strategy
     )
+
+
+def register_inductor_prims() -> None:
+    """Register DTensor sharding strategies for inductor prims ops.
+
+    Called lazily because inductor prims are created via make_prim() in
+    torch._inductor.inductor_prims, which is imported after this module.
+    """
+    # TODO: handle other inductor prims ops that may need DTensor sharding
+    # strategies (e.g. mul_rn, div_rn). Those are more complicated and not
+    # necessarily pointwise.
+    _register_single_dim_pointwise(prims.fma.default)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #177435
* __->__ #177424

This fixes a graph break when `torch.compile` decomposes `Tensor.add_`
with a tensor alpha into `inductor_prims.fma` on DTensor inputs.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo