### PR TITLE
[dynamo] always return self.value for TorchScriptObjectVariable.as_python_constant()

### DIFF
--- a/test/dynamo/test_reconstruct.py
+++ b/test/dynamo/test_reconstruct.py
@@ -559,54 +559,60 @@ class ReconstructTest(torch._dynamo.test_case.TestCase):
                 opt_gn = torch.compile(gn, backend="eager", fullgraph=True)
                 opt_gn(torch.ones(3))
 
-    def test_as_python_constant_super_delegation_no_false_positive(self):
-        """Passing a reference-type opaque object to a value-type constructor
-        should NOT produce a false 'self-referential' error.
-
-        When OpaqueObjectClassVariable.call_function evaluates constructor args
-        via as_python_constant(), a reference-type TorchScriptObjectVariable's
-        as_python_constant delegates to UserDefinedObjectVariable's via super().
-        The _add_call_once_guard must key on id(original_method) rather than the
-        method name string, so that this super() delegation is not mistaken for
-        a self-referential call.
+    def test_opaque_reference_as_python_constant(self):
+        """TSOV.as_python_constant must succeed for reference-type opaque
+        objects. Without this, __eq__ between two opaque objects graph breaks.
         """
-        from torch._library.opaque_object import OpaqueBase, register_opaque_type
+        import torch._library.opaque_object
+        import torch._opaque_base
 
-        class _Counter(OpaqueBase):
-            def __init__(self, start, end):
-                self.start = start
-                self.end = end
+        class Config(torch._opaque_base.OpaqueBase):
+            def __init__(self, v):
+                self.v = v
 
-        register_opaque_type(_Counter, typ="reference")
-
-        class _ValueWrapper(OpaqueBase):
-            def __init__(self, inner):
-                self.inner = inner
+            def __bool__(self):
+                return True
 
             def __eq__(self, other):
-                return isinstance(other, _ValueWrapper) and self.inner == other.inner
+                return isinstance(other, Config) and self.v == other.v
 
             def __hash__(self):
-                return hash(id(self.inner))
+                return hash(self.v)
 
-            def __fx_repr__(self):
-                return "_ValueWrapper(inner=None)", {"_ValueWrapper": _ValueWrapper}
+        torch._library.opaque_object.register_opaque_type(Config, typ="reference")
 
-        register_opaque_type(_ValueWrapper, typ="value")
+        cfg = Config(42)
 
-        counter = _Counter(0, 10)
+        def fn(x, cfg):
+            if cfg:
+                return x + 1
+            return x
 
-        @torch.compile(backend="eager", fullgraph=False)
-        def f(c):
-            return _ValueWrapper(c)
+        opt = torch.compile(fn, backend="eager", fullgraph=True)
+        result = opt(torch.ones(4), cfg)
+        self.assertEqual(result, torch.ones(4) + 1)
 
-        # Counter is a reference-type opaque object. Passing it to a value-type
-        # constructor triggers as_python_constant() on the TSOV, which delegates
-        # via super() to UDOV. This should fail because reference types are not
-        # constants, but the error must NOT be "self-referential".
-        with self.assertRaises(RuntimeError) as ctx:
-            f(counter)
-        self.assertNotIn("self-referential", str(ctx.exception))
+    def test_call_once_guard_allows_super_delegation(self):
+        """_add_call_once_guard must key on (id(self), id(original_method))
+        so that super().as_python_constant() between VT subclasses is not
+        mistaken for a self-referential call.
+        """
+        from torch._dynamo.variables.base import VariableTracker
+
+        class _Parent(VariableTracker):
+            def as_python_constant(self):
+                return 42
+
+        class _Child(_Parent):
+            def as_python_constant(self):
+                return super().as_python_constant()
+
+        child = _Child()
+        # With name-based keying, _Child and _Parent share the same key
+        # (id(self), "as_python_constant"), causing a false
+        # AsPythonConstantNotImplementedError("self-referential").
+        self.assertEqual(child.as_python_constant(), 42)
+        self.assertTrue(child.is_python_constant())
 
 
 if __name__ == "__main__":

--- a/torch/_dynamo/variables/script_object.py
+++ b/torch/_dynamo/variables/script_object.py
@@ -209,6 +209,8 @@ class OpaqueObjectClassVariable(UserDefinedVariable):
 class TorchScriptObjectVariable(UserDefinedObjectVariable):
     _fake_script_object_cache: dict[int, "TorchScriptObjectVariable"] = {}
 
+    value: FakeScriptObject
+
     @classmethod
     def is_matching_cls(cls, user_cls: type) -> bool:
         return (
@@ -220,7 +222,7 @@ class TorchScriptObjectVariable(UserDefinedObjectVariable):
     @staticmethod
     def create(
         proxy: Proxy,
-        value: Any,
+        value: FakeScriptObject,
         ctor_args_kwargs: Any = None,
         ctor_arg_sources: tuple[Source | None, ...] | None = None,
         **options: Any,
@@ -232,7 +234,7 @@ class TorchScriptObjectVariable(UserDefinedObjectVariable):
     def __init__(
         self,
         proxy: Proxy,
-        value: Any,
+        value: FakeScriptObject,
         ctor_args_kwargs: Any = None,
         source: Source | None = None,
         ctor_arg_sources: tuple[Source | None, ...] | None = None,
@@ -276,12 +278,7 @@ class TorchScriptObjectVariable(UserDefinedObjectVariable):
         return self.proxy
 
     def __str__(self) -> str:
-        value = (
-            self.value.real_obj
-            if isinstance(self.value, FakeScriptObject)
-            else self.value
-        )
-        return f"{self.__class__.__name__}({value})"
+        return f"{self.__class__.__name__}({self.value.real_obj})"
 
     __repr__ = __str__
 
@@ -296,7 +293,7 @@ class TorchScriptObjectVariable(UserDefinedObjectVariable):
         if hasattr(self.value, "script_class_name") and is_opaque_type(
             self.value.script_class_name
         ):
-            real_obj = self.value.real_obj  # pyrefly: ignore[missing-attribute]
+            real_obj = self.value.real_obj
 
             member_type = get_member_type(
                 type(real_obj),
@@ -392,7 +389,7 @@ class TorchScriptObjectVariable(UserDefinedObjectVariable):
         if hasattr(self.value, "script_class_name") and is_opaque_type(
             self.value.script_class_name
         ):
-            real_obj = self.value.real_obj  # pyrefly: ignore[missing-attribute]
+            real_obj = self.value.real_obj
             value_type = type(real_obj)
 
             member_type = get_member_type(
@@ -489,43 +486,22 @@ class TorchScriptObjectVariable(UserDefinedObjectVariable):
         )
 
     def as_python_constant(self) -> Any:
-        if is_opaque_value_type(
-            type(self.value.real_obj)  # pyrefly: ignore[missing-attribute]
-        ):
-            return self.value.real_obj  # pyrefly: ignore[missing-attribute]
-        return super().as_python_constant()
+        return self.value.real_obj
 
     def is_python_hashable(self) -> bool:
         try:
-            hash(self.value.real_obj)  # pyrefly: ignore[missing-attribute]
+            hash(self.value.real_obj)
             return True
         except TypeError:
             return False
 
     def get_python_hash(self) -> int:
-        real_obj = (
-            self.value.real_obj
-            if isinstance(self.value, FakeScriptObject)
-            else self.value
-        )
-        return hash(real_obj)
+        return hash(self.value.real_obj)
 
     def is_python_equal(self, other: object) -> bool:
         if not isinstance(other, TorchScriptObjectVariable):
             return False
-        real_self = (
-            self.value.real_obj
-            if isinstance(self.value, FakeScriptObject)
-            else self.value
-        )
-        real_other = (
-            other.value.real_obj
-            if isinstance(other.value, FakeScriptObject)
-            else other.value
-        )
-        return real_self == real_other
+        return self.value.real_obj == other.value.real_obj
 
     def get_real_value(self) -> Any:
-        if isinstance(self.value, FakeScriptObject):
-            return self.value.real_obj
-        return self.as_python_constant()
+        return self.value.real_obj


### PR DESCRIPTION
Summary: Fix for https://www.internalfb.com/sandcastle/workflow/1310547491578920728

Test Plan: Local pytest, failing tests in https://www.internalfb.com/sandcastle/workflow/1310547491578920728 should start passing

Differential Revision: D96031735




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo