### PR TITLE
Infer device_type in fork_rng from devices argument

### DIFF
--- a/torch/random.py
+++ b/torch/random.py
@@ -159,7 +159,7 @@ def fork_rng(
     enabled=True,
     _caller="fork_rng",
     _devices_kw="devices",
-    device_type="cuda",
+    device_type=None,
 ) -> Generator:
     """
     Forks the RNG, so that when you return, the RNG is reset
@@ -174,9 +174,19 @@ def fork_rng(
         enabled (bool): if ``False``, the RNG is not forked.  This is a convenience
             argument for easily disabling the context manager without having
             to delete it and unindent your Python code under it.
-        device_type (str): device type str, default is `cuda`. As for supported device,
-            see details in :ref:`accelerator<accelerators>`
+        device_type (str): device type str, default is `cuda`. If ``devices`` is
+            provided and ``device_type`` is not, the device type is inferred from
+            the first device in the list. As for supported device, see details
+            in :ref:`accelerator<accelerators>`
     """
+
+    # Infer device_type from devices when not explicitly provided.
+    if device_type is None:
+        if devices is not None:
+            devices = list(devices)
+            device_type = torch.device(devices[0]).type
+        else:
+            device_type = "cuda"
 
     if device_type == "meta":
         yield


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #177438

fork_rng defaulted device_type to "cuda", so callers like
test_randperm that pass devices=["openreg:0"] without an explicit
device_type would incorrectly try to initialize CUDA. When devices
is provided but device_type is not, infer it from the first device
in the list. Falls back to "cuda" when neither is provided.

Co-authored-by: Claude <noreply@anthropic.com>