### PR TITLE
[DTensor] Fix `None IValue == DTensorSpec` and cache key collision for ops with optional Tensor

### DIFF
--- a/test/distributed/tensor/test_tensor_ops.py
+++ b/test/distributed/tensor/test_tensor_ops.py
@@ -1270,6 +1270,18 @@ DistTensorOpsTestWithLocalTensor = create_local_tensor_test_class(
 )
 
 
+@torch.library.custom_op("testlib::optional_clamp_op", mutates_args=())
+def optional_clamp_op(
+    x: torch.Tensor, lo: torch.Tensor | None, hi: torch.Tensor | None
+) -> torch.Tensor:
+    return torch.clamp(x, lo, hi)
+
+
+@optional_clamp_op.register_fake
+def _optional_clamp_op_fake(x, lo, hi):
+    return torch.empty_like(x)
+
+
 @torch.library.custom_op("testlib::modified_cat_op", mutates_args=())
 def modified_cat_op(a: list[torch.Tensor], b: list[torch.Tensor]) -> torch.Tensor:
     return torch.cat(a, dim=0)
@@ -1372,6 +1384,65 @@ class DistTensorCppPyTree(DTensorContinuousTestBase):
             self.assertEqual(hits, 0)
             self.assertEqual(misses, 2)
             self.assertEqual(result.shape, torch.Size([8, 8]))
+
+    def test_optional_tensor_cache_key(self):
+        """Cache must distinguish op(t1, None, t2) from op(t1, t2, None).
+
+        Uses a custom op with high static_argnum so that None args for
+        optional Tensor? parameters would be dropped from the cache key
+        without the is_none_or_undefined fix in handle_non_dtensor_arg.
+        With same-spec DTensors the collision is deterministic.
+        """
+        from test_op_strategy import op_strategy_context
+
+        from torch.distributed.tensor._op_schema import RuntimeSchemaInfo
+        from torch.distributed.tensor._ops.utils import replicate_op_strategy
+        from torch.distributed.tensor.debug import (
+            _clear_fast_path_sharding_prop_cache,
+            _get_fast_path_sharding_prop_cache_stats,
+        )
+
+        mesh = self.build_device_mesh()
+        op = torch.ops.testlib.optional_clamp_op
+
+        with op_strategy_context(
+            op.default,
+            replicate_op_strategy,
+            schema_info=RuntimeSchemaInfo(static_argnum=3),
+        ):
+            _clear_fast_path_sharding_prop_cache()
+            a = distribute_tensor(torch.randn(4, 8), mesh, [Shard(0)])
+
+            op(a, a, None)  # miss 1: key should include None at position 2
+            op(a, None, a)  # miss 2: key should include None at position 1
+
+            hits, misses = _get_fast_path_sharding_prop_cache_stats()
+            self.assertEqual(hits, 0)
+            self.assertEqual(misses, 2)
+
+    def test_optional_tensor_cache_key_python_slow_path(self):
+        """Same as above but exercises the Python slow path via OpSchema directly.
+
+        DTensor_OpSchema_recompute_comparison_key_impl must include None
+        args for optional Tensor? parameters in the comparison key.
+        """
+        from torch.distributed.tensor._dtensor_spec import DTensorSpec
+        from torch.distributed.tensor._op_schema import OpSchema, RuntimeSchemaInfo
+
+        mesh = self.build_device_mesh()
+        spec = DTensorSpec(mesh, (Shard(0),))
+        op = torch.ops.testlib.optional_clamp_op.default
+
+        schema1 = OpSchema(op, (spec, None, spec), {})
+        schema1.schema_info = RuntimeSchemaInfo(static_argnum=3)
+        schema1._recompute_comparison_key()
+
+        schema2 = OpSchema(op, (spec, spec, None), {})
+        schema2.schema_info = RuntimeSchemaInfo(static_argnum=3)
+        schema2._recompute_comparison_key()
+
+        self.assertNotEqual(hash(schema1), hash(schema2))
+        self.assertNotEqual(schema1, schema2)
 
 
 class TestNewEmptyStridedUneven(DTensorTestBase):

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -1087,9 +1087,10 @@ struct IValueOrDTensorSpec {
   py::object dtensor_spec;
 
   bool operator==(const IValueOrDTensorSpec& rhs) const {
-    return dtensor_spec
-        ? (rhs.dtensor_spec && dtensor_spec.equal(rhs.dtensor_spec))
-        : (iv == rhs.iv);
+    if (dtensor_spec) {
+      return rhs.dtensor_spec && dtensor_spec.equal(rhs.dtensor_spec);
+    }
+    return !rhs.dtensor_spec && iv == rhs.iv;
   }
 };
 
@@ -1162,18 +1163,6 @@ class NativeOpSchema {
   // have no guarantees about its lifetime. This class is cheap anyway.
   c10::OperatorHandle op_;
   std::size_t hash_;
-  // Subtle point: consider clamp.Tensor(Tensor self, Tensor?
-  // min=None, Tensor? max=None). The invocations clamp(t1, None, t2)
-  // and clamp(t1, t2, None) have the same comparison key (t1, t2)
-  // because we drop non-static non-tensor args from comparison. The
-  // only way we happen to be able to tell them apart is that we omit
-  // trailing defaulted arguments from the args tuple passed to
-  // __torch_dispatch__ (and hence to DTensor dispatch as well), so
-  // they have different args_schema_len_.
-  //
-  // I am preserving this existing behavior, but I suspect we should
-  // make an algorithm change to be less brittle, such as including
-  // None defaults for Tensor arguments in the comparison.
   std::size_t args_schema_len_;
   // There is no particular justification for the choice of 8
   // here. Feel free to change it.
@@ -1842,7 +1831,7 @@ static bool DTensor_OpSchema_recompute_comparison_key_impl(
   size_t idx = 0;
   for (const auto& e : args_schema) {
     if (idx >= native_info.static_argnum ||
-        arg_type_tensor_or_tensor_list_like(e)) {
+        arg_type_tensor_or_tensor_list_like(e) || e.is_none()) {
       if (PyList_Check(e.ptr())) {
         args_to_hash.push_back(
             py::reinterpret_steal<py::object>(PyList_AsTuple(e.ptr())));
@@ -2304,7 +2293,9 @@ create_native_op_schema(
   const auto handle_non_dtensor_arg =
       [&comparison_key, &comparison_key_hash, &native_info](
           size_t idx, c10::IValue arg) {
-        if (idx >= native_info.static_argnum) {
+        bool is_none_or_undefined =
+            arg.isNone() || (arg.isTensor() && !arg.toTensor().defined());
+        if (idx >= native_info.static_argnum || is_none_or_undefined) {
           if (arg.isList()) {
             const auto& list = arg.toList();
             if (list.empty()) {


### PR DESCRIPTION
Two bugs in NativeShardingPropagatorCache:

1. IValueOrDTensorSpec::operator== returned true when comparing a None IValue against a DTensorSpec, because both have default iv=None. On hash bucket collisions this caused false-positive equality, leading to wrong OutputSharding results. Fixed by checking !rhs.dtensor_spec before comparing iv fields.

2. handle_non_dtensor_arg dropped None/undefined tensor args from the cache key when idx < static_argnum. For ops with optional Tensor? parameters at those positions, this made op(t1, t2, None) and op(t1, None, t2) produce identical keys. Fixed by always including None/undefined args regardless of static_argnum.

Note that Bug 1 was the root cause of the flaky 
test_dtensor_op_db_clamp_cpu_float32 failure (hash bucket collisions between different samples triggered the broken operator==). Bug 2 is a latent issue for any op registered with high static_argnum and optional Tensor? parameters.

Resolves https://github.com/pytorch/pytorch/issues/176974

Authored with Claude.