### PR TITLE
[Storage] Add swap_data_ptr for safe storage data pointer transfer

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -78,7 +78,7 @@ jobs:
       docker-image-name: ci-image:pytorch-linux-jammy-cuda12.8-cudnn9-py3-gcc11
       build-generates-artifacts: false
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
-      runner: "linux.c7i.4xlarge"
+      runner: "linux.r7i.4xlarge"
       test-matrix: |
         { include: [
           { config: "default", shard: 1, num_shards: 1 },

--- a/c10/core/Storage.h
+++ b/c10/core/Storage.h
@@ -152,6 +152,10 @@ struct C10_API Storage {
     storage_impl_->set_data_ptr_noswap(std::move(data_ptr));
   }
 
+  void swap_data_ptr(Storage& other) const {
+    storage_impl_->swap_data_ptr(*other.storage_impl_);
+  }
+
   DeviceType device_type() const {
     return storage_impl_->device_type();
   }

--- a/c10/core/StorageImpl.h
+++ b/c10/core/StorageImpl.h
@@ -186,7 +186,15 @@ struct C10_API StorageImpl : public c10::intrusive_ptr_target {
     other.maybe_materialize_cow();
     std::swap(data_ptr_, other.data_ptr_);
     std::swap(size_bytes_, other.size_bytes_);
-    std::swap(size_bytes_is_heap_allocated_, other.size_bytes_is_heap_allocated_);
+    std::swap(
+        size_bytes_is_heap_allocated_, other.size_bytes_is_heap_allocated_);
+    std::swap(resizable_, other.resizable_);
+    std::swap(allocator_, other.allocator_);
+    std::swap(throw_on_immutable_data_ptr_, other.throw_on_immutable_data_ptr_);
+    std::swap(throw_on_mutable_data_ptr_, other.throw_on_mutable_data_ptr_);
+    std::swap(
+        warn_deprecated_on_mutable_data_ptr_,
+        other.warn_deprecated_on_mutable_data_ptr_);
     refresh_has_data_ptr_check();
     other.refresh_has_data_ptr_check();
   }

--- a/c10/core/StorageImpl.h
+++ b/c10/core/StorageImpl.h
@@ -181,6 +181,16 @@ struct C10_API StorageImpl : public c10::intrusive_ptr_target {
     refresh_has_data_ptr_check();
   }
 
+  void swap_data_ptr(StorageImpl& other) {
+    maybe_materialize_cow();
+    other.maybe_materialize_cow();
+    std::swap(data_ptr_, other.data_ptr_);
+    std::swap(size_bytes_, other.size_bytes_);
+    std::swap(size_bytes_is_heap_allocated_, other.size_bytes_is_heap_allocated_);
+    refresh_has_data_ptr_check();
+    other.refresh_has_data_ptr_check();
+  }
+
   const void* data() const {
     if (C10_UNLIKELY(throw_on_immutable_data_ptr_)) {
       throw_data_ptr_access_error();

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -6354,6 +6354,60 @@ class TestTorchDeviceType(TestCase):
         result = grad_f(x)
         self.assertEqual(result.tolist() , [1.0, 1.0, 1.0])
 
+    def test_swap_data_ptr_with_empty(self, device):
+        x = torch.randn(4, device=device)
+        y = torch.randn(4, device=device)
+        y_data = y.clone()
+        x_storage = x.untyped_storage()
+        y_storage = y.untyped_storage()
+        x_storage.resize_(0)
+        self.assertEqual(x_storage.nbytes(), 0)
+        x_storage._swap_data_ptr_(y_storage)
+        self.assertEqual(x, y_data)
+        self.assertEqual(y_storage.nbytes(), 0)
+
+    def test_swap_data_ptr_non_empty(self, device):
+        x = torch.randn(4, device=device)
+        y = torch.randn(4, device=device)
+        x_data = x.clone()
+        y_data = y.clone()
+        x_storage = x.untyped_storage()
+        y_storage = y.untyped_storage()
+        x_storage._swap_data_ptr_(y_storage)
+        self.assertEqual(x, y_data)
+        self.assertEqual(y, x_data)
+
+    def test_swap_data_ptr_preserves_views(self, device):
+        x = torch.randn(4, 4, device=device)
+        x_view = x[1:3]
+        y = torch.randn(4, 4, device=device)
+        y_data = y.clone()
+        x_storage = x.untyped_storage()
+        y_storage = y.untyped_storage()
+        x_storage.resize_(0)
+        x_storage._swap_data_ptr_(y_storage)
+        self.assertEqual(x, y_data)
+        self.assertEqual(x_view, y_data[1:3])
+
+    def test_swap_data_ptr_self(self, device):
+        x = torch.randn(4, device=device)
+        x_data = x.clone()
+        s = x.untyped_storage()
+        s._swap_data_ptr_(s)
+        self.assertEqual(x, x_data)
+
+    def test_swap_data_ptr_device_mismatch(self, device):
+        x = torch.randn(4, device=device)
+        y = torch.randn(4, device="meta")
+        with self.assertRaisesRegex(RuntimeError, "same device"):
+            x.untyped_storage()._swap_data_ptr_(y.untyped_storage())
+
+    def test_swap_data_ptr_nbytes_mismatch(self, device):
+        x = torch.randn(4, device=device)
+        y = torch.randn(8, device=device)
+        with self.assertRaisesRegex(RuntimeError, "same nbytes"):
+            x.untyped_storage()._swap_data_ptr_(y.untyped_storage())
+
 
 # Tests that compare a device's computation with the (gold-standard) CPU's.
 class TestDevicePrecision(TestCase):
@@ -10661,38 +10715,6 @@ tensor([[[1.+1.j, 1.+1.j, 1.+1.j,  ..., 1.+1.j, 1.+1.j, 1.+1.j],
         self.assertNotEqual(t.data_ptr(), 0)
         t2 = t[0:0].view(0, 1)
         self.assertEqual(t2.data_ptr(), 0)
-
-    def test_swap_data_ptr(self):
-        x = torch.randn(4)
-        y = torch.randn(4)
-        y_data = y.clone()
-        x_storage = x.untyped_storage()
-        y_storage = y.untyped_storage()
-        x_storage.resize_(0)
-        self.assertEqual(x_storage.nbytes(), 0)
-        # Swap: x gets y's data and nbytes, y gets x's empty state
-        x_storage._swap_data_ptr(y_storage)
-        self.assertEqual(x, y_data)
-        self.assertEqual(y_storage.nbytes(), 0)
-
-    def test_swap_data_ptr_preserves_views(self):
-        x = torch.randn(4, 4)
-        x_view = x[1:3]
-        y = torch.randn(4, 4)
-        y_data = y.clone()
-        x_storage = x.untyped_storage()
-        y_storage = y.untyped_storage()
-        x_storage.resize_(0)
-        x_storage._swap_data_ptr(y_storage)
-        # x's view chain should now see y's data
-        self.assertEqual(x, y_data)
-        self.assertEqual(x_view, y_data[1:3])
-
-    def test_swap_data_ptr_device_mismatch(self):
-        x = torch.randn(4)
-        y = torch.randn(4, device="meta")
-        with self.assertRaisesRegex(RuntimeError, "same device"):
-            x.untyped_storage()._swap_data_ptr(y.untyped_storage())
 
     def test_size_stride(self) -> None:
         t = torch.rand(2, 3, dtype=torch.float32)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -10662,6 +10662,38 @@ tensor([[[1.+1.j, 1.+1.j, 1.+1.j,  ..., 1.+1.j, 1.+1.j, 1.+1.j],
         t2 = t[0:0].view(0, 1)
         self.assertEqual(t2.data_ptr(), 0)
 
+    def test_swap_data_ptr(self):
+        x = torch.randn(4)
+        y = torch.randn(4)
+        y_data = y.clone()
+        x_storage = x.untyped_storage()
+        y_storage = y.untyped_storage()
+        x_storage.resize_(0)
+        self.assertEqual(x_storage.nbytes(), 0)
+        # Swap: x gets y's data and nbytes, y gets x's empty state
+        x_storage._swap_data_ptr(y_storage)
+        self.assertEqual(x, y_data)
+        self.assertEqual(y_storage.nbytes(), 0)
+
+    def test_swap_data_ptr_preserves_views(self):
+        x = torch.randn(4, 4)
+        x_view = x[1:3]
+        y = torch.randn(4, 4)
+        y_data = y.clone()
+        x_storage = x.untyped_storage()
+        y_storage = y.untyped_storage()
+        x_storage.resize_(0)
+        x_storage._swap_data_ptr(y_storage)
+        # x's view chain should now see y's data
+        self.assertEqual(x, y_data)
+        self.assertEqual(x_view, y_data[1:3])
+
+    def test_swap_data_ptr_device_mismatch(self):
+        x = torch.randn(4)
+        y = torch.randn(4, device="meta")
+        with self.assertRaisesRegex(RuntimeError, "same device"):
+            x.untyped_storage()._swap_data_ptr(y.untyped_storage())
+
     def test_size_stride(self) -> None:
         t = torch.rand(2, 3, dtype=torch.float32)
         self.assertEqual(t.size(0), 2)

--- a/torch/csrc/StorageMethods.cpp
+++ b/torch/csrc/StorageMethods.cpp
@@ -524,19 +524,26 @@ static PyObject* THPStorage_swapDataPtr(PyObject* self, PyObject* other) {
   THPStorage_assertNotNull(self);
   TORCH_CHECK(
       THPStorage_Check(other),
-      "swap_data_ptr expects an UntypedStorage, but got ",
+      "_swap_data_ptr_ expects an UntypedStorage, but got ",
       THPUtils_typename(other));
   THPStorage_assertNotNull(other);
   auto& self_storage = THPStorage_Unpack(self);
   auto& other_storage = THPStorage_Unpack(other);
   TORCH_CHECK(
       self_storage.device() == other_storage.device(),
-      "swap_data_ptr: storages must be on the same device, got ",
+      "_swap_data_ptr_: storages must be on the same device, got ",
       self_storage.device(),
       " and ",
       other_storage.device());
-  self_storage.swap_data_ptr(
-      const_cast<c10::Storage&>(other_storage));
+  size_t self_nbytes = self_storage.nbytes();
+  size_t other_nbytes = other_storage.nbytes();
+  TORCH_CHECK(
+      self_nbytes == other_nbytes || self_nbytes == 0 || other_nbytes == 0,
+      "_swap_data_ptr_: storages must have the same nbytes or one must have 0, got ",
+      self_nbytes,
+      " and ",
+      other_nbytes);
+  self_storage.swap_data_ptr(const_cast<c10::Storage&>(other_storage));
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
 }
@@ -652,7 +659,7 @@ static PyMethodDef THPStorage_methods[] = {
      castPyCFunctionWithKeywords(THPStorage_fromFile),
      METH_VARARGS | METH_KEYWORDS | METH_STATIC,
      nullptr},
-    {"_swap_data_ptr", THPStorage_swapDataPtr, METH_O, nullptr},
+    {"_swap_data_ptr_", THPStorage_swapDataPtr, METH_O, nullptr},
     {"_set_cdata", THPStorage__setCdata, METH_O, nullptr},
     {"_byteswap", THPStorage_byteswap, METH_VARARGS, nullptr},
     {"_fix_weakref", THPStorage_fix_weakref, METH_NOARGS, nullptr},

--- a/torch/csrc/StorageMethods.cpp
+++ b/torch/csrc/StorageMethods.cpp
@@ -519,6 +519,28 @@ static PyObject* THPStorage_setFromFile(PyObject* self, PyObject* args) {
   END_HANDLE_TH_ERRORS
 }
 
+static PyObject* THPStorage_swapDataPtr(PyObject* self, PyObject* other) {
+  HANDLE_TH_ERRORS
+  THPStorage_assertNotNull(self);
+  TORCH_CHECK(
+      THPStorage_Check(other),
+      "swap_data_ptr expects an UntypedStorage, but got ",
+      THPUtils_typename(other));
+  THPStorage_assertNotNull(other);
+  auto& self_storage = THPStorage_Unpack(self);
+  auto& other_storage = THPStorage_Unpack(other);
+  TORCH_CHECK(
+      self_storage.device() == other_storage.device(),
+      "swap_data_ptr: storages must be on the same device, got ",
+      self_storage.device(),
+      " and ",
+      other_storage.device());
+  self_storage.swap_data_ptr(
+      const_cast<c10::Storage&>(other_storage));
+  Py_RETURN_NONE;
+  END_HANDLE_TH_ERRORS
+}
+
 static PyObject* THPStorage__setCdata(PyObject* _self, PyObject* new_cdata) {
   HANDLE_TH_ERRORS
   auto self = reinterpret_cast<THPStorage*>(_self);
@@ -630,6 +652,7 @@ static PyMethodDef THPStorage_methods[] = {
      castPyCFunctionWithKeywords(THPStorage_fromFile),
      METH_VARARGS | METH_KEYWORDS | METH_STATIC,
      nullptr},
+    {"_swap_data_ptr", THPStorage_swapDataPtr, METH_O, nullptr},
     {"_set_cdata", THPStorage__setCdata, METH_O, nullptr},
     {"_byteswap", THPStorage_byteswap, METH_VARARGS, nullptr},
     {"_fix_weakref", THPStorage_fix_weakref, METH_NOARGS, nullptr},


### PR DESCRIPTION
Expose a swap_data_ptr method on UntypedStorage that atomically swaps the DataPtr and nbytes between two StorageImpl instances. This enables patterns like reassigning a tensor's underlying memory while preserving its view chain, without invalidating the source storage's ownership (which std::move in set_data_ptr_noswap would do).

Co-authored-by: Claude <noreply@anthropic.com>