### PR TITLE
DataPipes: prevent failing properties from masking invalid-iterator errors

### DIFF
--- a/test/test_datapipe.py
+++ b/test/test_datapipe.py
@@ -269,6 +269,26 @@ class TestStreamWrapper(TestCase):
             self.assertEqual(str(wrap_f), "StreamWrapper<" + str(f) + ">")
 
 
+class TestDataPipeHookIterator(TestCase):
+    def test_invalid_iterator_message_ignores_failing_property(self):
+        from torch.utils.data.datapipes._hook_iterator import _check_iterator_valid
+
+        class BadDataPipe:
+            def __init__(self, source):
+                self._valid_iterator_id = 1
+                self._source = source
+
+            @property
+            def source(self):
+                raise RuntimeError("property exploded")
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            r"This iterator has been invalidated because another iterator has been created",
+        ):
+            _check_iterator_valid(BadDataPipe([1, 2, 3]), iterator_id=0)
+
+
 class TestIterableDataPipeBasic(TestCase):
     def setUp(self):
         super().setUp()

--- a/torch/utils/data/datapipes/_hook_iterator.py
+++ b/torch/utils/data/datapipes/_hook_iterator.py
@@ -37,9 +37,15 @@ def _generate_input_args_string(obj):
     signature = inspect.signature(obj.__class__)
     input_param_names = set(signature.parameters.keys())
     result = []
-    for name, value in inspect.getmembers(obj):
-        if name in input_param_names:
-            result.append((name, _simplify_obj_name(value)))
+    for name in input_param_names:
+        if name == "self":
+            continue
+        try:
+            value = getattr(obj, name)
+        except Exception:
+            continue
+        result.append((name, _simplify_obj_name(value)))
+    result.sort()
     return ", ".join([f"{name}={value}" for name, value in result])
 
 


### PR DESCRIPTION
## Summary

- Make IterDataPipe diagnostic argument rendering robust when constructor-matching properties raise.
- Prevent unrelated property exceptions from masking the intended invalid-iterator `RuntimeError`.
- Add a regression test for this behavior.

### Root Cause

`_generate_input_args_string` in `torch/utils/data/datapipes/_hook_iterator.py` used `inspect.getmembers(obj)`, which eagerly evaluates descriptors/properties. If one such property raised, that exception escaped and replaced the expected invalid-iterator error.

### Implementation

Switched from `inspect.getmembers()` (evaluates all attributes) to targeted `getattr()` over constructor parameter names only. This avoids triggering unrelated properties. Chose `getattr` over `vars()` or `__dict__` because properties are not in `__dict__` and we want to capture computed attributes that match constructor params.

### Tradeoffs & Limitations

- Only addresses `_generate_input_args_string`; other `inspect.getmembers` usages in the codebase remain unchanged.
- Catches `Exception` broadly on `getattr` — this is intentional since any failure during diagnostic rendering should be silently skipped rather than mask the real error.

### Testing Performed

- `test_invalid_iterator_message_ignores_failing_property`: verifies that a DataPipe with a raising property still produces the correct invalidation error
- Ran: `python -m pytest test/test_datapipe.py::TestDataPipeHookIterator -q` → `1 passed`

### Files Changed

- `torch/utils/data/datapipes/_hook_iterator.py`
- `test/test_datapipe.py`