### PR TITLE
aoti kernel capture (#177452)

### DIFF
--- a/test/cpp/aoti_inference/CMakeLists.txt
+++ b/test/cpp/aoti_inference/CMakeLists.txt
@@ -55,3 +55,25 @@ if(INSTALL_TEST)
     install(FILES $<TARGET_PDB_FILE:test_aoti_inference> DESTINATION bin OPTIONAL)
   endif()
 endif()
+
+# Build kernel_capture unit tests (CPU-only, no model data needed).
+add_executable(test_aoti_kernel_capture
+  ${TORCH_ROOT}/test/cpp/common/main.cpp
+  ${AOT_INDUCTOR_TEST_ROOT}/test_kernel_capture.cpp
+)
+
+target_compile_definitions(test_aoti_kernel_capture PRIVATE USE_GTEST)
+
+target_link_libraries(test_aoti_kernel_capture PRIVATE
+  torch
+  gtest_main
+)
+
+target_compile_options_if_supported(test_aoti_kernel_capture -Wno-unused-variable)
+
+if(INSTALL_TEST)
+  install(TARGETS test_aoti_kernel_capture DESTINATION bin)
+  if(MSVC AND BUILD_SHARED_LIBS)
+    install(FILES $<TARGET_PDB_FILE:test_aoti_kernel_capture> DESTINATION bin OPTIONAL)
+  endif()
+endif()

--- a/test/cpp/aoti_inference/test_kernel_capture.cpp
+++ b/test/cpp/aoti_inference/test_kernel_capture.cpp
@@ -1,0 +1,305 @@
+#include <torch/csrc/inductor/aoti_runtime/kernel_capture.h>
+#include <torch/csrc/inductor/aoti_runtime/utils.h>
+#include <torch/csrc/inductor/aoti_torch/utils.h>
+
+#include <ATen/ATen.h>
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <filesystem>
+#include <thread>
+
+using torch::aot_inductor::ConstantHandle;
+using torch::aot_inductor::RAIIAtenTensorHandle;
+
+// ===== Type Traits =====
+
+TEST(KernelCaptureTypeTraits, TensorLike) {
+  static_assert(
+      aoti_kernel_capture::is_tensor_like<AtenTensorHandle>::value,
+      "AtenTensorHandle should be tensor-like");
+  static_assert(
+      aoti_kernel_capture::is_tensor_like<RAIIAtenTensorHandle>::value,
+      "RAIIAtenTensorHandle should be tensor-like");
+  static_assert(
+      aoti_kernel_capture::is_tensor_like<ConstantHandle>::value,
+      "ConstantHandle should be tensor-like");
+
+  static_assert(
+      !aoti_kernel_capture::is_tensor_like<int64_t>::value,
+      "int64_t should not be tensor-like");
+  static_assert(
+      !aoti_kernel_capture::is_tensor_like<double>::value,
+      "double should not be tensor-like");
+  static_assert(
+      !aoti_kernel_capture::is_tensor_like<const char*>::value,
+      "const char* should not be tensor-like");
+}
+
+TEST(KernelCaptureTypeTraits, IntScalar) {
+  static_assert(aoti_kernel_capture::is_int_scalar<int64_t>::value);
+  static_assert(aoti_kernel_capture::is_int_scalar<int32_t>::value);
+  static_assert(aoti_kernel_capture::is_int_scalar<bool>::value);
+
+  static_assert(!aoti_kernel_capture::is_int_scalar<double>::value);
+  static_assert(!aoti_kernel_capture::is_int_scalar<float>::value);
+  static_assert(!aoti_kernel_capture::is_int_scalar<uint32_t>::value);
+}
+
+TEST(KernelCaptureTypeTraits, FloatScalar) {
+  static_assert(aoti_kernel_capture::is_float_scalar<double>::value);
+  static_assert(aoti_kernel_capture::is_float_scalar<float>::value);
+
+  static_assert(!aoti_kernel_capture::is_float_scalar<int64_t>::value);
+  static_assert(!aoti_kernel_capture::is_float_scalar<int32_t>::value);
+}
+
+// ===== CaptureArgs accumulation =====
+
+TEST(KernelCaptureCaptureArgs, TensorAccumulation) {
+  aoti_kernel_capture::CaptureArgs args;
+  at::Tensor t = at::zeros({2, 3});
+  AtenTensorHandle handle =
+      torch::aot_inductor::tensor_pointer_to_tensor_handle(&t);
+  aoti_kernel_capture::maybe_append(args, handle);
+
+  EXPECT_EQ(args.tensor_handles.size(), 1u);
+  EXPECT_EQ(args.tensor_handles[0], handle);
+  EXPECT_EQ(args.tensor_positions.size(), 1u);
+  EXPECT_EQ(args.tensor_positions[0], 0);
+  EXPECT_EQ(args.next_pos, 1);
+}
+
+TEST(KernelCaptureCaptureArgs, IntScalarAccumulation) {
+  aoti_kernel_capture::CaptureArgs args;
+  int64_t i64 = 42;
+  int32_t i32 = 7;
+  bool b = true;
+  aoti_kernel_capture::maybe_append(args, i64);
+  aoti_kernel_capture::maybe_append(args, i32);
+  aoti_kernel_capture::maybe_append(args, b);
+
+  ASSERT_EQ(args.int_values.size(), 3u);
+  EXPECT_EQ(args.int_values[0], 42);
+  EXPECT_EQ(args.int_values[1], 7);
+  EXPECT_EQ(args.int_values[2], 1); // true -> 1
+  EXPECT_EQ(args.int_positions[0], 0);
+  EXPECT_EQ(args.int_positions[1], 1);
+  EXPECT_EQ(args.int_positions[2], 2);
+}
+
+TEST(KernelCaptureCaptureArgs, FloatScalarAccumulation) {
+  aoti_kernel_capture::CaptureArgs args;
+  double d = 3.14;
+  float f = 2.5f;
+  aoti_kernel_capture::maybe_append(args, d);
+  aoti_kernel_capture::maybe_append(args, f);
+
+  ASSERT_EQ(args.float_values.size(), 2u);
+  EXPECT_DOUBLE_EQ(args.float_values[0], 3.14);
+  EXPECT_DOUBLE_EQ(args.float_values[1], static_cast<double>(2.5f));
+  EXPECT_EQ(args.float_positions[0], 0);
+  EXPECT_EQ(args.float_positions[1], 1);
+}
+
+TEST(KernelCaptureCaptureArgs, MixedPositions) {
+  aoti_kernel_capture::CaptureArgs args;
+  at::Tensor t = at::ones({4});
+  AtenTensorHandle handle =
+      torch::aot_inductor::tensor_pointer_to_tensor_handle(&t);
+
+  // Interleave: tensor, int, float, tensor
+  aoti_kernel_capture::maybe_append(args, handle);     // pos 0
+  aoti_kernel_capture::maybe_append(args, int64_t{5}); // pos 1
+  aoti_kernel_capture::maybe_append(args, double{1.0});// pos 2
+  aoti_kernel_capture::maybe_append(args, handle);     // pos 3
+
+  EXPECT_EQ(args.tensor_positions[0], 0);
+  EXPECT_EQ(args.int_positions[0], 1);
+  EXPECT_EQ(args.float_positions[0], 2);
+  EXPECT_EQ(args.tensor_positions[1], 3);
+  EXPECT_EQ(args.next_pos, 4);
+}
+
+TEST(KernelCaptureCaptureArgs, InfrastructureArgsSkipped) {
+  aoti_kernel_capture::CaptureArgs args;
+  const char* str = "cubin_dir";
+  uint64_t u64 = 99;
+
+  // These should all be silently skipped (no-op).
+  aoti_kernel_capture::maybe_append(args, str);
+  aoti_kernel_capture::maybe_append(args, u64);
+
+  EXPECT_EQ(args.tensor_handles.size(), 0u);
+  EXPECT_EQ(args.int_values.size(), 0u);
+  EXPECT_EQ(args.float_values.size(), 0u);
+  EXPECT_EQ(args.next_pos, 0);
+}
+
+// ===== Request ID (thread safety fixes) =====
+
+TEST(KernelCaptureRequestId, NextRequestIdIncrementing) {
+  int id1 = aoti_kernel_capture::next_request_id();
+  int id2 = aoti_kernel_capture::next_request_id();
+  int id3 = aoti_kernel_capture::next_request_id();
+  EXPECT_LT(id1, id2);
+  EXPECT_LT(id2, id3);
+}
+
+TEST(KernelCaptureRequestId, BeginCaptureRequestSetsCurrentId) {
+  aoti_kernel_capture::begin_capture_request();
+  int id1 = aoti_kernel_capture::current_request_id();
+
+  aoti_kernel_capture::begin_capture_request();
+  int id2 = aoti_kernel_capture::current_request_id();
+
+  // Each call to begin_capture_request advances the ID.
+  EXPECT_NE(id1, id2);
+  // current_request_id() should persist until next begin_capture_request().
+  EXPECT_EQ(aoti_kernel_capture::current_request_id(), id2);
+}
+
+TEST(KernelCaptureRequestId, ThreadLocalRequestIdIsolation) {
+  // Verify that current_request_id() is thread-local: two threads can hold
+  // independent request IDs simultaneously.
+  std::atomic<bool> thread1_ready{false};
+  std::atomic<bool> proceed{false};
+
+  int thread1_id = -1;
+  int thread2_id = -1;
+  int thread1_id_after = -1;
+  int thread2_id_after = -1;
+
+  std::thread t1([&] {
+    aoti_kernel_capture::begin_capture_request();
+    thread1_id = aoti_kernel_capture::current_request_id();
+    thread1_ready.store(true);
+    // Spin until thread 2 has also set its ID.
+    while (!proceed.load()) {}
+    // After thread 2 set its ID, our thread-local should be unchanged.
+    thread1_id_after = aoti_kernel_capture::current_request_id();
+  });
+
+  std::thread t2([&] {
+    // Wait until thread 1 has its ID.
+    while (!thread1_ready.load()) {}
+    aoti_kernel_capture::begin_capture_request();
+    thread2_id = aoti_kernel_capture::current_request_id();
+    proceed.store(true);
+    thread2_id_after = aoti_kernel_capture::current_request_id();
+  });
+
+  t1.join();
+  t2.join();
+
+  // The two threads should have different request IDs.
+  EXPECT_NE(thread1_id, thread2_id);
+  // Thread 1's ID should not have been overwritten by thread 2.
+  EXPECT_EQ(thread1_id, thread1_id_after);
+  // Thread 2's ID should remain stable too.
+  EXPECT_EQ(thread2_id, thread2_id_after);
+}
+
+// ===== should_capture default =====
+
+TEST(KernelCaptureShouldCapture, DefaultFalse) {
+  if (std::getenv("AOTI_KERNEL_CAPTURE_DIR") != nullptr) {
+    GTEST_SKIP() << "AOTI_KERNEL_CAPTURE_DIR is set; skipping";
+  }
+  EXPECT_FALSE(aoti_kernel_capture::should_capture("any_kernel"));
+}
+
+// ===== Null tensor handle (fix #2) =====
+
+TEST(KernelCaptureSaveKernel, NullTensorHandleNoCrash) {
+  auto tmpdir = std::filesystem::temp_directory_path() /
+      "aoti_capture_test_null_tensor";
+  std::filesystem::create_directories(tmpdir);
+  std::string filepath = (tmpdir / "test.pt").string();
+
+  AtenTensorHandle handles[] = {nullptr};
+  int32_t positions[] = {0};
+
+  EXPECT_NO_THROW(aoti_torch_save_kernel_capture(
+      filepath.c_str(),
+      "test_kernel",
+      "0",
+      /*num_tensors=*/1,
+      handles,
+      positions,
+      /*num_int_scalars=*/0,
+      nullptr,
+      nullptr,
+      /*num_float_scalars=*/0,
+      nullptr,
+      nullptr));
+
+  std::filesystem::remove_all(tmpdir);
+}
+
+// ===== End-to-end save with valid tensors (fix #3) =====
+
+TEST(KernelCaptureSaveKernel, SaveValidTensors) {
+  auto tmpdir = std::filesystem::temp_directory_path() /
+      "aoti_capture_test_valid";
+  std::filesystem::create_directories(tmpdir);
+  std::string filepath = (tmpdir / "test.pt").string();
+
+  at::Tensor t1 = at::ones({2, 3});
+  at::Tensor t2 = at::zeros({4});
+  AtenTensorHandle handles[] = {
+      torch::aot_inductor::tensor_pointer_to_tensor_handle(&t1),
+      torch::aot_inductor::tensor_pointer_to_tensor_handle(&t2),
+  };
+  int32_t tensor_positions[] = {0, 2};
+
+  int64_t int_vals[] = {42};
+  int32_t int_positions[] = {1};
+
+  double float_vals[] = {3.14};
+  int32_t float_positions[] = {3};
+
+  aoti_torch_save_kernel_capture(
+      filepath.c_str(),
+      "my_kernel",
+      "tag1",
+      /*num_tensors=*/2,
+      handles,
+      tensor_positions,
+      /*num_int_scalars=*/1,
+      int_vals,
+      int_positions,
+      /*num_float_scalars=*/1,
+      float_vals,
+      float_positions);
+
+  EXPECT_TRUE(std::filesystem::exists(filepath));
+  EXPECT_GT(std::filesystem::file_size(filepath), 0u);
+
+  std::filesystem::remove_all(tmpdir);
+}
+
+TEST(KernelCaptureSaveKernel, SaveZeroArgs) {
+  auto tmpdir = std::filesystem::temp_directory_path() /
+      "aoti_capture_test_zero";
+  std::filesystem::create_directories(tmpdir);
+  std::string filepath = (tmpdir / "test.pt").string();
+
+  EXPECT_NO_THROW(aoti_torch_save_kernel_capture(
+      filepath.c_str(),
+      "empty_kernel",
+      "0",
+      /*num_tensors=*/0,
+      nullptr,
+      nullptr,
+      /*num_int_scalars=*/0,
+      nullptr,
+      nullptr,
+      /*num_float_scalars=*/0,
+      nullptr,
+      nullptr));
+
+  EXPECT_TRUE(std::filesystem::exists(filepath));
+
+  std::filesystem::remove_all(tmpdir);
+}

--- a/torch/csrc/inductor/aoti_runtime/kernel_capture.h
+++ b/torch/csrc/inductor/aoti_runtime/kernel_capture.h
@@ -1,0 +1,257 @@
+#pragma once
+
+// Debugging utility for capturing AOTI kernel call inputs.
+//
+// Wrap any call_* kernel invocation with AOTI_CAPTURE_CALL to save all tensor
+// and scalar arguments into a single .pt file per call, loadable via
+// torch.load(). Infrastructure args (stream, kernels struct, cubin_dir) are
+// automatically skipped.
+//
+// This header uses only the stable C ABI (shim.h) so it can be compiled into
+// standalone AOTI .so builds without libtorch.
+//
+// Activation (env vars):
+//   AOTI_KERNEL_CAPTURE_DIR=/path   — enable capture, set output directory
+//   AOTI_KERNEL_CAPTURE_FILTER=name — optional: only capture matching kernels
+//
+// Usage:
+//   #include <torch/csrc/inductor/aoti_runtime/kernel_capture.h>
+//
+//   // For call_* kernel wrappers (variadic args):
+//   AOTI_CAPTURE_CALL(call_my_kernel, tensor_arg, scalar_arg, ...);
+//
+//   // With explicit provenance tag (e.g. debug handle):
+//   AOTI_CAPTURE_CALL_TAG("4", call_my_kernel, tensor_arg, scalar_arg, ...);
+//
+//   // For proxy executor calls (flattened arrays):
+//   AOTI_CAPTURE_PROXY(proxy_executor, extern_node_index, num_ints,
+//       int_args, num_tensors, tensor_args);
+//
+//   // With explicit provenance tag:
+//   AOTI_CAPTURE_PROXY_TAG("4", proxy_executor, extern_node_index,
+//       num_ints, int_args, num_tensors, tensor_args);
+
+#include <torch/csrc/inductor/aoti_torch/c/shim.h>
+
+#include <atomic>
+#include <cstdlib>
+#include <filesystem>
+#include <iostream>
+#include <string>
+#include <type_traits>
+#include <vector>
+
+namespace aoti_kernel_capture {
+
+// --- Type traits for argument classification ---
+
+// Tensor-like: anything implicitly convertible to AtenTensorHandle
+// (RAIIAtenTensorHandle, ConstantHandle, etc.)
+template <typename T, typename = void>
+struct is_tensor_like : std::false_type {};
+template <typename T>
+struct is_tensor_like<
+    T,
+    std::void_t<decltype(static_cast<AtenTensorHandle>(std::declval<const T&>()))>>
+    : std::true_type {};
+
+// Numeric scalar types we want to capture.
+template <typename T>
+struct is_int_scalar
+    : std::bool_constant<
+          std::is_same_v<std::decay_t<T>, int64_t> ||
+          std::is_same_v<std::decay_t<T>, int32_t> ||
+          std::is_same_v<std::decay_t<T>, bool>> {};
+
+template <typename T>
+struct is_float_scalar
+    : std::bool_constant<
+          std::is_same_v<std::decay_t<T>, double> ||
+          std::is_same_v<std::decay_t<T>, float>> {};
+
+// --- Capture argument accumulator (C ABI compatible) ---
+
+struct CaptureArgs {
+  std::vector<AtenTensorHandle> tensor_handles;
+  std::vector<int32_t> tensor_positions;
+  std::vector<int64_t> int_values;
+  std::vector<int32_t> int_positions;
+  std::vector<double> float_values;
+  std::vector<int32_t> float_positions;
+  int32_t next_pos = 0;
+};
+
+// Tensor-like args — record the handle and its position.
+template <typename T>
+auto maybe_append(CaptureArgs& args, const T& val)
+    -> std::enable_if_t<is_tensor_like<T>::value> {
+  AtenTensorHandle handle = val;
+  args.tensor_handles.push_back(handle);
+  args.tensor_positions.push_back(args.next_pos++);
+}
+
+// Integer scalar args.
+template <typename T>
+auto maybe_append(CaptureArgs& args, const T& val)
+    -> std::enable_if_t<is_int_scalar<T>::value> {
+  args.int_values.push_back(static_cast<int64_t>(val));
+  args.int_positions.push_back(args.next_pos++);
+}
+
+// Float scalar args.
+template <typename T>
+auto maybe_append(CaptureArgs& args, const T& val)
+    -> std::enable_if_t<is_float_scalar<T>::value> {
+  args.float_values.push_back(static_cast<double>(val));
+  args.float_positions.push_back(args.next_pos++);
+}
+
+// Infrastructure args (stream, kernels struct, cubin_dir, etc.) — skip.
+template <typename T>
+auto maybe_append(CaptureArgs&, const T&)
+    -> std::enable_if_t<
+        !is_tensor_like<T>::value &&
+        !is_int_scalar<T>::value &&
+        !is_float_scalar<T>::value> {}
+
+// --- Request-scoped capture ID ---
+
+// Globally unique request ID (atomic for cross-thread uniqueness).
+inline int next_request_id() {
+  static std::atomic<int> id{0};
+  return id++;
+}
+
+// Per-thread request ID (thread_local avoids races between concurrent requests).
+inline int& current_request_id() {
+  static thread_local int req_id{0};
+  return req_id;
+}
+
+// Call at the start of each forward pass to begin a new capture request.
+inline void begin_capture_request() {
+  current_request_id() = next_request_id();
+}
+
+// --- Shared save logic ---
+
+inline const char* capture_dir() {
+  static const char* dir = std::getenv("AOTI_KERNEL_CAPTURE_DIR");
+  return dir;
+}
+
+inline const char* capture_filter() {
+  static const char* filter = std::getenv("AOTI_KERNEL_CAPTURE_FILTER");
+  return filter;
+}
+
+inline bool should_capture(const std::string& kernel_name) {
+  if (!capture_dir()) {
+    return false;
+  }
+  const char* filter = capture_filter();
+  return !filter || kernel_name.find(filter) != std::string::npos;
+}
+
+inline void save_capture(
+    const std::string& kernel_name,
+    const std::string& tag,
+    const CaptureArgs& args) {
+  int req_id = current_request_id();
+
+  std::string filepath = std::string(capture_dir()) + "/" + kernel_name + "_" +
+      tag + "_req" + std::to_string(req_id) + ".pt";
+  std::filesystem::create_directories(
+      std::filesystem::path(filepath).parent_path());
+
+  aoti_torch_save_kernel_capture(
+      filepath.c_str(),
+      kernel_name.c_str(),
+      tag.c_str(),
+      static_cast<int32_t>(args.tensor_handles.size()),
+      args.tensor_handles.data(),
+      args.tensor_positions.data(),
+      static_cast<int32_t>(args.int_values.size()),
+      args.int_values.data(),
+      args.int_positions.data(),
+      static_cast<int32_t>(args.float_values.size()),
+      args.float_values.data(),
+      args.float_positions.data());
+}
+
+// --- Capture for call_* kernel wrappers (variadic individual args) ---
+
+template <typename... Args>
+void maybe_capture(
+    const std::string& kernel_name,
+    const std::string& tag,
+    const Args&... args) {
+  if (!should_capture(kernel_name)) {
+    return;
+  }
+
+  CaptureArgs capture_args;
+  (maybe_append(capture_args, args), ...);
+  save_capture(kernel_name, tag, capture_args);
+}
+
+// --- Capture + call for proxy executor (flattened arrays) ---
+
+inline void capture_and_call_proxy_impl(
+    const std::string& tag,
+    AOTIProxyExecutorHandle proxy_executor,
+    int extern_node_index,
+    int num_ints,
+    int64_t* flatten_int_args,
+    int num_tensors,
+    AtenTensorHandle* flatten_tensor_args) {
+  std::string name = "proxy_executor_" + std::to_string(extern_node_index);
+  if (should_capture(name)) {
+    CaptureArgs capture_args;
+    for (int i = 0; i < num_ints; ++i) {
+      capture_args.int_values.push_back(flatten_int_args[i]);
+      capture_args.int_positions.push_back(capture_args.next_pos++);
+    }
+    for (int i = 0; i < num_tensors; ++i) {
+      capture_args.tensor_handles.push_back(flatten_tensor_args[i]);
+      capture_args.tensor_positions.push_back(capture_args.next_pos++);
+    }
+    save_capture(name, tag, capture_args);
+  }
+  aoti_torch_proxy_executor_call_function(
+      proxy_executor, extern_node_index, num_ints, flatten_int_args,
+      num_tensors, flatten_tensor_args);
+}
+
+} // namespace aoti_kernel_capture
+
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#define AOTI_STRINGIFY_(x) #x
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#define AOTI_STRINGIFY(x) AOTI_STRINGIFY_(x)
+
+// Capture + call with explicit provenance tag (e.g. debug handle "4").
+// Note: __VA_ARGS__ is evaluated twice (once for capture, once for the call).
+// Callers must ensure arguments have no side effects.
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#define AOTI_CAPTURE_CALL_TAG(tag, func, ...)                            \
+  do {                                                                   \
+    ::aoti_kernel_capture::maybe_capture(#func, tag, __VA_ARGS__);       \
+    func(__VA_ARGS__);                                                   \
+  } while (0)
+
+// Capture + call using __LINE__ as the default tag.
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#define AOTI_CAPTURE_CALL(func, ...)                                     \
+  AOTI_CAPTURE_CALL_TAG(AOTI_STRINGIFY(__LINE__), func, __VA_ARGS__)
+
+// Proxy executor capture + call using __LINE__ as the default tag.
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#define AOTI_CAPTURE_PROXY(...)                                          \
+  ::aoti_kernel_capture::capture_and_call_proxy_impl(                    \
+      AOTI_STRINGIFY(__LINE__), __VA_ARGS__)
+
+// Proxy executor capture + call with explicit provenance tag.
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#define AOTI_CAPTURE_PROXY_TAG(tag, ...)                                 \
+  ::aoti_kernel_capture::capture_and_call_proxy_impl(tag, __VA_ARGS__)

--- a/torch/csrc/inductor/aoti_torch/c/shim.h
+++ b/torch/csrc/inductor/aoti_torch/c/shim.h
@@ -481,6 +481,23 @@ AOTI_TORCH_EXPORT void aoti_torch_save_tensor_handle(
     const char* launch_prefix,
     const char* kernel_name);
 
+// Save captured kernel call inputs as a .pt file for debugging.
+// Tensors, int scalars, and float scalars are passed as flat arrays with
+// position indices to reconstruct the original argument order.
+AOTI_TORCH_EXPORT void aoti_torch_save_kernel_capture(
+    const char* filepath,
+    const char* kernel_name,
+    const char* tag,
+    int32_t num_tensors,
+    const AtenTensorHandle* tensor_handles,
+    const int32_t* tensor_positions,
+    int32_t num_int_scalars,
+    const int64_t* int_scalar_values,
+    const int32_t* int_scalar_positions,
+    int32_t num_float_scalars,
+    const double* float_scalar_values,
+    const int32_t* float_scalar_positions);
+
 // helpers for converting between StableIValue and actual IValues
 using StableIValue = uint64_t;
 

--- a/torch/csrc/inductor/aoti_torch/shim_common.cpp
+++ b/torch/csrc/inductor/aoti_torch/shim_common.cpp
@@ -1259,6 +1259,76 @@ void aoti_torch_save_tensor_handle(
 #endif // !defined(C10_MOBILE)
 }
 
+void aoti_torch_save_kernel_capture(
+    const char* filepath,
+    const char* kernel_name,
+    const char* tag,
+    int32_t num_tensors,
+    const AtenTensorHandle* tensor_handles,
+    const int32_t* tensor_positions,
+    int32_t num_int_scalars,
+    const int64_t* int_scalar_values,
+    const int32_t* int_scalar_positions,
+    int32_t num_float_scalars,
+    const double* float_scalar_values,
+    const int32_t* float_scalar_positions) {
+#ifndef C10_MOBILE
+  try {
+    // Determine total arg count from max position across all arrays.
+    int32_t total_args = 0;
+    for (int32_t i = 0; i < num_tensors; ++i) {
+      total_args = std::max(total_args, tensor_positions[i] + 1);
+    }
+    for (int32_t i = 0; i < num_int_scalars; ++i) {
+      total_args = std::max(total_args, int_scalar_positions[i] + 1);
+    }
+    for (int32_t i = 0; i < num_float_scalars; ++i) {
+      total_args = std::max(total_args, float_scalar_positions[i] + 1);
+    }
+
+    // Build ordered args list by position.
+    c10::impl::GenericList args_list(c10::AnyType::get());
+    args_list.reserve(total_args);
+    for (int32_t i = 0; i < total_args; ++i) {
+      args_list.push_back(c10::IValue());
+    }
+    for (int32_t i = 0; i < num_tensors; ++i) {
+      at::Tensor* t = tensor_handle_to_tensor_pointer(tensor_handles[i]);
+      if (!t || !t->defined()) {
+        continue;
+      }
+      args_list.set(tensor_positions[i], c10::IValue(t->cpu()));
+    }
+    for (int32_t i = 0; i < num_int_scalars; ++i) {
+      args_list.set(int_scalar_positions[i], c10::IValue(int_scalar_values[i]));
+    }
+    for (int32_t i = 0; i < num_float_scalars; ++i) {
+      args_list.set(
+          float_scalar_positions[i], c10::IValue(float_scalar_values[i]));
+    }
+
+    c10::impl::GenericDict data(c10::StringType::get(), c10::AnyType::get());
+    data.insert("kernel", std::string(kernel_name));
+    data.insert("tag", std::string(tag));
+    data.insert("args", std::move(args_list));
+
+    auto bytes = torch::jit::pickle_save(c10::IValue(data));
+    std::ofstream fout(filepath, std::ios::out | std::ios::binary);
+    fout.write(bytes.data(), static_cast<std::streamsize>(bytes.size()));
+    fout.close();
+    if (!fout) {
+      std::cerr << "aoti_kernel_capture: failed to write " << filepath << '\n';
+      return;
+    }
+
+    std::cout << "aoti_kernel_capture: saved " << filepath << '\n';
+  } catch (const std::exception& e) {
+    std::cerr << "aoti_kernel_capture: failed to save " << filepath << ": "
+              << e.what() << '\n';
+  }
+#endif // !defined(C10_MOBILE)
+}
+
 void aoti_torch_print_tensor_handle(AtenTensorHandle self, const char* msg) {
   at::Tensor* t = tensor_handle_to_tensor_pointer(self);
 


### PR DESCRIPTION
Summary:

## Debugging utility for capturing AOTI kernel call inputs.

First version for manual/reactive debugging without needing to re-lower with AOTI. Enables after the fact saving of all kernel parameters to help debug issues like IMAs. It can also serve as a quick way to capture inputs to explore custom triton kernels and/or triton tuning parameters.

These APIs can later be integrated into the AOTI codgen as well.

### `call_*` kernel wrappers

Use `AOTI_CAPTURE_CALL` to wrap any variadic `call_*` invocation.
Infrastructure arguments (stream, kernels struct, cubin_dir) are automatically
skipped; tensor arguments are copied to CPU before serialization.

```cpp
// Basic — uses __LINE__ as the call-site tag automatically
AOTI_CAPTURE_CALL(call_my_kernel, tensor1, tensor2, scalar1);
```

To attach a **provenance tag** (e.g. a debug handle from the graph) use
`AOTI_CAPTURE_CALL_TAG`:

```cpp
// Explicit tag "4" (from e.g. concat_2D_jagged_0:4)
AOTI_CAPTURE_CALL_TAG("4", call_concat_2D_jagged_0, t1, t2, t3);
```

### Proxy executor calls

Replace direct calls to `aoti_torch_proxy_executor_call_function` with the
capture-aware wrappers:

```cpp
// Basic — uses __LINE__ as the tag
capture_and_call_proxy(
    proxy_executor, extern_node_index,
    num_ints, flatten_int_args,
    num_tensors, flatten_tensor_args);

// With explicit provenance tag
capture_and_call_proxy_tag("7",
    proxy_executor, extern_node_index,
    num_ints, flatten_int_args,
    num_tensors, flatten_tensor_args);
```

Test Plan: Unit test and local recompilation of cpp_wrapper with manual instrumentation.

Differential Revision: D95832368


