### PR TITLE
Add nn.SwiGLU activation function

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1767,6 +1767,39 @@ def glu(input: Tensor, dim: int = -1) -> Tensor:
     return torch._C._nn.glu(input, dim)
 
 
+def swiglu(input: Tensor, dim: int = -1) -> Tensor:  # noqa: D400,D402
+    r"""
+    swiglu(input, dim=-1) -> Tensor
+
+    Applies the SwiGLU gated activation function.
+
+    .. math ::
+        \text{SwiGLU}(a, b) = \text{SiLU}(a) \otimes b
+
+    where `input` is split in half along `dim` to form `a` and `b`, :math:`\text{SiLU}`
+    is the Sigmoid Linear Unit (swish) function, and :math:`\otimes` is the element-wise
+    product between matrices.
+
+    See `GLU Variants Improve Transformer <https://arxiv.org/abs/2002.05202>`_.
+
+    Args:
+        input (Tensor): input tensor
+        dim (int): dimension on which to split the input. Default: -1
+    """
+    if has_torch_function_unary(input):
+        return handle_torch_function(swiglu, (input,), input, dim=dim)
+    if input.dim() == 0:
+        raise RuntimeError(
+            "swiglu does not support scalars because halving size must be even"
+        )
+    if input.size(dim) % 2 != 0:
+        raise RuntimeError(
+            f"Halving size must be even, but dimension {dim} is {input.size(dim)}"
+        )
+    a, b = input.chunk(2, dim)
+    return a * torch.sigmoid(a) * b
+
+
 def hardtanh(
     input: Tensor,
     min_val: float = -1.0,

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1782,6 +1782,12 @@ def swiglu(input: Tensor, dim: int = -1) -> Tensor:  # noqa: D400,D402
 
     See `GLU Variants Improve Transformer <https://arxiv.org/abs/2002.05202>`_.
 
+    .. note::
+        The gated half differs from :func:`~torch.nn.functional.glu`. Following the
+        paper, SwiGLU applies the nonlinearity to the first half,
+        :math:`\text{SiLU}(a) \otimes b`, while :func:`~torch.nn.functional.glu`
+        applies it to the second half, :math:`a \otimes \sigma(b)`.
+
     Args:
         input (Tensor): input tensor
         dim (int): dimension on which to split the input. Default: -1

--- a/torch/nn/modules/__init__.py
+++ b/torch/nn/modules/__init__.py
@@ -21,6 +21,7 @@ from .activation import (
     SELU,
     Sigmoid,
     SiLU,
+    SwiGLU,
     Softmax,
     Softmax2d,
     Softmin,

--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -27,6 +27,7 @@ __all__ = [
     "CELU",
     "SELU",
     "GLU",
+    "SwiGLU",
     "GELU",
     "Hardshrink",
     "LeakyReLU",
@@ -771,6 +772,47 @@ class GLU(Module):
         """
         Return the extra representation of the module.
         """
+        return f"dim={self.dim}"
+
+
+class SwiGLU(Module):
+    r"""Applies the SwiGLU gated activation function.
+
+    .. math::
+        \text{SwiGLU}(a, b) = \text{SiLU}(a) \otimes b
+
+    where the input is split in half along ``dim`` to form ``a`` and ``b``,
+    :math:`\text{SiLU}` is the Sigmoid Linear Unit (swish) function,
+    and :math:`\otimes` is the element-wise product between matrices.
+
+    See `GLU Variants Improve Transformer <https://arxiv.org/abs/2002.05202>`_.
+
+    Args:
+        dim (int): the dimension on which to split the input. Default: -1
+
+    Shape:
+        - Input: :math:`(\ast_1, N, \ast_2)` where `*` means, any number of additional
+          dimensions
+        - Output: :math:`(\ast_1, M, \ast_2)` where :math:`M=N/2`
+
+    Examples::
+
+        >>> m = nn.SwiGLU()
+        >>> input = torch.randn(4, 2)
+        >>> output = m(input)
+    """
+
+    __constants__ = ["dim"]
+    dim: int
+
+    def __init__(self, dim: int = -1) -> None:
+        super().__init__()
+        self.dim = dim
+
+    def forward(self, input: Tensor) -> Tensor:
+        return F.swiglu(input, self.dim)
+
+    def extra_repr(self) -> str:
         return f"dim={self.dim}"
 
 

--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -787,6 +787,12 @@ class SwiGLU(Module):
 
     See `GLU Variants Improve Transformer <https://arxiv.org/abs/2002.05202>`_.
 
+    .. note::
+        The gated half differs from :class:`~torch.nn.GLU`. Following the paper,
+        SwiGLU applies the nonlinearity to the first half,
+        :math:`\text{SiLU}(a) \otimes b`, while :class:`~torch.nn.GLU` applies it
+        to the second half, :math:`a \otimes \sigma(b)`.
+
     Args:
         dim (int): the dimension on which to split the input. Default: -1
 


### PR DESCRIPTION
## Issue

Fixes #128712

## Summary

Adds `torch.nn.SwiGLU` and `torch.nn.functional.swiglu`, the SiLU-gated linear unit used in LLaMA, Mistral, Gemma, and most current transformer architectures.

```python
m = torch.nn.SwiGLU(dim=-1)
output = m(input)  # splits input in half, applies SiLU gating
```

The math: `SwiGLU(a, b) = SiLU(a) * b`, where input is split in half along `dim`.

Pure Python implementation using existing ops (`torch.chunk` + `torch.sigmoid`). The earlier attempt (#144465) went stale because it bundled C++ kernels, inductor lowering, and decompositions in one PR. This one keeps the surface small: get the API in first, leave a fused kernel for a follow-up.

Mirrors `nn.GLU`:
- Same class pattern (`__constants__`, `dim` parameter, `extra_repr`)
- Same functional API (scalar check, even-size check, `handle_torch_function`)
- Same docstring layout, with paper reference to [GLU Variants Improve Transformer](https://arxiv.org/abs/2002.05202)

Files touched:
- `torch/nn/modules/activation.py`: new `SwiGLU` class
- `torch/nn/functional.py`: new `swiglu()` function
- `torch/nn/modules/__init__.py`: re-export

## Checklist

- [ ] Passes lint (`spin fixlint`)
- [ ] Added/updated tests
- [ ] Updated documentation (if applicable)
- [ ] Included benchmark results (for PRs impacting perf)

## BC-breaking?

No. Adds a new public symbol, nothing existing changes behavior.

## Coordination

Commented on #128712 [here](https://github.com/pytorch/pytorch/issues/128712#issuecomment-4060966963).