### PR TITLE
[DTensor] Coalesce collectives for multi-arg redistribution

### DIFF
--- a/test/distributed/tensor/test_tensor_ops.py
+++ b/test/distributed/tensor/test_tensor_ops.py
@@ -1384,6 +1384,281 @@ class DistTensorCppPyTree(DTensorContinuousTestBase):
             hits, misses = _get_fast_path_sharding_prop_cache_stats()
             self.assertEqual(hits, 1)
 
+    @skip_if_lt_x_gpu(2)
+    @with_comms
+    def test_foreach_redistribution_coalesced(self):
+        """Verify that foreach ops use coalesced collectives for redistribution."""
+        funcol_py = torch.ops.c10d_functional
+        mesh = self.build_device_mesh()
+        ws = self.world_size
+
+        # Same seed on all ranks so Partial local values are identical,
+        # making the expected global value = local_grad * world_size.
+        cases = [
+            # (label, state_placement, sizes, expected_coalesced_op)
+            (
+                "Partial→Shard(0) even: 1 reduce_scatter_coalesced",
+                Shard(0),
+                [(ws * 4, 8)] * 4,
+                funcol_py.reduce_scatter_tensor_coalesced,
+            ),
+            (
+                "Partial→Replicate: 1 all_reduce_coalesced",
+                Replicate(),
+                [(8, 8)] * 4,
+                funcol_py.all_reduce_coalesced,
+            ),
+            (
+                "Partial→Shard(0) uneven (padded): 1 reduce_scatter_coalesced",
+                Shard(0),
+                [(ws * 4 + 1, 8)] * 4,
+                funcol_py.reduce_scatter_tensor_coalesced,
+            ),
+        ]
+        for label, state_placement, sizes, expected_op in cases:
+            with self.subTest(label):
+                torch.manual_seed(42)
+                states, grads, expected = [], [], []
+                for size in sizes:
+                    global_state = torch.randn(size, device=self.device_type)
+                    states.append(
+                        distribute_tensor(global_state.clone(), mesh, [state_placement])
+                    )
+                    local_grad = torch.randn(size, device=self.device_type)
+                    grads.append(
+                        DTensor.from_local(
+                            local_grad, mesh, [Partial()], run_check=False
+                        )
+                    )
+                    expected.append(global_state + local_grad * ws)
+
+                comm_mode = CommDebugMode()
+                with comm_mode:
+                    torch._foreach_add_(states, grads)
+
+                self.assertEqual(comm_mode.get_comm_counts().get(expected_op, 0), 1)
+                self.assertEqual(comm_mode.get_total_counts(), 1)
+                for s, e in zip(states, expected):
+                    self.assertEqual(s.full_tensor(), e)
+
+    @skip_if_lt_x_gpu(2)
+    @with_comms
+    def test_foreach_redistribution_grouped(self):
+        """Mixed placements coalesce within groups sharing the same transform."""
+        funcol_py = torch.ops.c10d_functional
+        mesh = self.build_device_mesh()
+        ws = self.world_size
+
+        torch.manual_seed(42)
+        states, grads, expected = [], [], []
+        for i in range(4):
+            shard_dim = i % 2  # alternating Shard(0) and Shard(1) → 2 groups
+            size = (ws * 4, ws * 4)
+            global_state = torch.randn(size, device=self.device_type)
+            states.append(
+                distribute_tensor(global_state.clone(), mesh, [Shard(shard_dim)])
+            )
+            local_grad = torch.randn(size, device=self.device_type)
+            grads.append(
+                DTensor.from_local(local_grad, mesh, [Partial()], run_check=False)
+            )
+            expected.append(global_state + local_grad * ws)
+
+        comm_mode = CommDebugMode()
+        with comm_mode:
+            torch._foreach_add_(states, grads)
+
+        # 2 distinct (Partial→Shard(0), Partial→Shard(1)) groups, each coalesced
+        self.assertEqual(
+            comm_mode.get_comm_counts().get(
+                funcol_py.reduce_scatter_tensor_coalesced, 0
+            ),
+            2,
+        )
+        self.assertEqual(comm_mode.get_total_counts(), 2)
+        for s, e in zip(states, expected):
+            self.assertEqual(s.full_tensor(), e)
+
+    @skip_if_lt_x_gpu(2)
+    @with_comms
+    def test_coalesced_matches_per_tensor_redistribute(self):
+        """Coalesced and per-tensor redistribution must produce identical results.
+
+        This is the key invariant: if the per-tensor paths in placement_types
+        (Shard._reduce_shard_tensor, Shard._to_replicate_tensor) evolve,
+        this test catches any divergence from the coalesced paths.
+        """
+        from torch.distributed.tensor._dtensor_spec import DTensorSpec
+        from torch.distributed.tensor._redistribute import (
+            redistribute_local_tensor,
+            redistribute_local_tensors,
+        )
+
+        mesh = self.build_device_mesh()
+        ws = self.world_size
+
+        cases = [
+            # (label, src_placement, dst_placement, sizes)
+            (
+                "Partial→Replicate via all_reduce",
+                Partial(),
+                Replicate(),
+                [(8, 8), (4, 16), (16, 4)],
+            ),
+            (
+                "Partial→Shard(0) via reduce_scatter (even)",
+                Partial(),
+                Shard(0),
+                [(ws * 4, 8), (ws * 8, 4), (ws * 2, 16)],
+            ),
+            (
+                "Partial→Shard(0) via reduce_scatter (uneven, padded)",
+                Partial(),
+                Shard(0),
+                [(ws * 4 + 1, 8), (ws * 4 + 3, 8), (ws * 4 - 1, 8)],
+            ),
+            (
+                "Shard(0)→Replicate via allgather (even)",
+                Shard(0),
+                Replicate(),
+                [(8, 8), (4, 16), (16, 4)],
+            ),
+            (
+                "Shard(0)→Replicate via allgather (uneven)",
+                Shard(0),
+                Replicate(),
+                [(7, 8), (5, 16), (3, 4)],
+            ),
+            (
+                "Shard(1)→Replicate via allgather (non-zero gather dim)",
+                Shard(1),
+                Replicate(),
+                [(8, 8), (4, 16), (16, 4)],
+            ),
+        ]
+        for label, src_placement, dst_placement, sizes in cases:
+            with self.subTest(label):
+                torch.manual_seed(42)
+                dtensors = []
+                for size in sizes:
+                    t = torch.randn(size, device=self.device_type)
+                    dtensors.append(
+                        DTensor.from_local(t, mesh, [src_placement], run_check=False)
+                    )
+
+                items = []
+                for dt in dtensors:
+                    src_spec = dt._spec
+                    dst_spec = DTensorSpec(
+                        mesh,
+                        (dst_placement,),
+                        tensor_meta=src_spec.tensor_meta,
+                    )
+                    items.append((dt._local_tensor, src_spec, dst_spec))
+
+                coalesced = redistribute_local_tensors(items)
+                per_tensor = [redistribute_local_tensor(t, s, d) for t, s, d in items]
+
+                for c, p in zip(coalesced, per_tensor):
+                    self.assertEqual(c, p)
+
+    @skip_if_lt_x_gpu(2)
+    @with_comms
+    def test_foreach_redistribution_compiled(self):
+        """Coalesced redistribution works under torch.compile."""
+        funcol_py = torch.ops.c10d_functional
+        mesh = self.build_device_mesh()
+        ws = self.world_size
+
+        @torch.compile
+        def compiled_foreach_add(states, grads):
+            torch._foreach_add_(states, grads)
+
+        torch.manual_seed(42)
+        states, grads, expected = [], [], []
+        for _ in range(4):
+            global_state = torch.randn((ws * 4, 8), device=self.device_type)
+            states.append(distribute_tensor(global_state.clone(), mesh, [Shard(0)]))
+            local_grad = torch.randn((ws * 4, 8), device=self.device_type)
+            grads.append(
+                DTensor.from_local(local_grad, mesh, [Partial()], run_check=False)
+            )
+            expected.append(global_state + local_grad * ws)
+
+        comm_mode = CommDebugMode()
+        with comm_mode:
+            compiled_foreach_add(states, grads)
+
+        # Coalesced collectives work under compile: 1 coalesced call, not 4
+        self.assertEqual(
+            comm_mode.get_comm_counts().get(
+                funcol_py.reduce_scatter_tensor_coalesced, 0
+            ),
+            1,
+        )
+        self.assertEqual(comm_mode.get_total_counts(), 1)
+        for s, e in zip(states, expected):
+            self.assertEqual(s.full_tensor(), e)
+
+    @with_comms
+    def test_coalesced_skips_mask_partial(self):
+        """_MaskPartial (used by embedding ops) must not be coalesced — its
+        _reduce_shard_value applies a mask before reduction that the coalesced
+        path would skip."""
+        from torch.distributed.tensor._dtensor_spec import DTensorSpec, TensorMeta
+        from torch.distributed.tensor._redistribute import _try_coalesced_redistribute
+        from torch.distributed.tensor.placement_types import _MaskPartial
+
+        mesh = self.build_device_mesh()
+        mask_partial = _MaskPartial()
+
+        # Build items with _MaskPartial src placement → should return None
+        items = []
+        for size in [(8, 4), (4, 4)]:
+            t = torch.randn(size, device=self.device_type)
+            src_spec = DTensorSpec(
+                mesh,
+                (mask_partial,),
+                tensor_meta=TensorMeta(torch.Size(size), (size[1], 1), t.dtype),
+            )
+            dst_spec = DTensorSpec(
+                mesh,
+                (Replicate(),),
+                tensor_meta=TensorMeta(torch.Size(size), (size[1], 1), t.dtype),
+            )
+            items.append((t, src_spec, dst_spec))
+
+        # _MaskPartial is a Partial subclass; coalescing must reject it
+        result = _try_coalesced_redistribute(items)
+        self.assertIsNone(result, "_MaskPartial should not be coalesced")
+
+    @skip_if_lt_x_gpu(2)
+    @with_comms
+    def test_single_arg_redistribution_unchanged(self):
+        """Non-foreach ops with a single redistribution still work correctly."""
+        mesh = self.build_device_mesh()
+        ws = self.world_size
+
+        torch.manual_seed(42)
+        a = distribute_tensor(
+            torch.randn(ws * 4, 8, device=self.device_type), mesh, [Shard(0)]
+        )
+        b = DTensor.from_local(
+            torch.randn(ws * 4, 8, device=self.device_type),
+            mesh,
+            [Partial()],
+            run_check=False,
+        )
+        expected = a.full_tensor() + b.full_tensor()
+
+        comm_mode = CommDebugMode()
+        with comm_mode:
+            result = a + b
+
+        # Single redistribution, no coalescing — just 1 collective
+        self.assertEqual(comm_mode.get_total_counts(), 1)
+        self.assertEqual(result.full_tensor(), expected)
+
     def test_two_list_op_cache_collision(self):
         from torch.distributed.tensor._op_schema import RuntimeSchemaInfo
         from torch.distributed.tensor._ops.utils import replicate_op_strategy

--- a/test/distributed/tensor/test_tensor_ops.py
+++ b/test/distributed/tensor/test_tensor_ops.py
@@ -1660,6 +1660,184 @@ class DistTensorCppPyTree(DTensorContinuousTestBase):
         self.assertEqual(comm_mode.get_total_counts(), 1)
         self.assertEqual(result.full_tensor(), expected)
 
+    @skip_if_lt_x_gpu(2)
+    @with_comms
+    def test_foreach_redistribution_allgather_coalesced(self):
+        """Verify that _foreach_add_ coalesces allgather when grads are Shard(0)
+        and states are Replicate (inplace forces output = Replicate)."""
+        funcol_py = torch.ops.c10d_functional
+        mesh = self.build_device_mesh()
+
+        torch.manual_seed(42)
+        states, grads, expected = [], [], []
+        for size in [(8, 4), (4, 8), (12, 4), (8, 8)]:
+            global_state = torch.randn(size, device=self.device_type)
+            states.append(distribute_tensor(global_state.clone(), mesh, [Replicate()]))
+            global_grad = torch.randn(size, device=self.device_type)
+            grads.append(distribute_tensor(global_grad, mesh, [Shard(0)]))
+            expected.append(global_state + global_grad)
+
+        comm_mode = CommDebugMode()
+        with comm_mode:
+            torch._foreach_add_(states, grads)
+
+        # All grads need Shard(0)→Replicate → 1 coalesced allgather
+        self.assertEqual(
+            comm_mode.get_comm_counts().get(
+                funcol_py.all_gather_into_tensor_coalesced, 0
+            ),
+            1,
+        )
+        self.assertEqual(comm_mode.get_total_counts(), 1)
+        for s, e in zip(states, expected):
+            self.assertEqual(s.full_tensor(), e)
+
+    @skip_if_lt_x_gpu(4)
+    @with_comms
+    def test_coalesced_flattened_transform_2d_mesh(self):
+        """Coalesced redistribution through _FlattenedTransformInfo on a 2D mesh.
+
+        _optimize_transform_infos merges consecutive same-type transforms into
+        one using the flattened mesh. Tests both uniform Partial() and mixed
+        Partial("sum")/Partial("avg") (which exercises avg_scale).
+        """
+        from torch.distributed.tensor._dtensor_spec import DTensorSpec
+        from torch.distributed.tensor._redistribute import (
+            redistribute_local_tensor,
+            redistribute_local_tensors,
+        )
+
+        mesh_2d = init_device_mesh(
+            self.device_type, (2, 2), mesh_dim_names=("dp", "tp")
+        )
+        mesh_2d["dp", "tp"]._flatten("dp_tp")
+
+        cases = [
+            ("uniform Partial", (Partial(), Partial())),
+            ("mixed sum/avg", (Partial("sum"), Partial("avg"))),
+        ]
+        dst_placements = (Replicate(), Replicate())
+        sizes = [(8, 4), (4, 8), (12, 6)]
+
+        for label, src_placements in cases:
+            with self.subTest(label):
+                torch.manual_seed(42)
+                items = []
+                for size in sizes:
+                    t = torch.randn(size, device=self.device_type)
+                    src_spec = DTensorSpec(
+                        mesh_2d,
+                        src_placements,
+                        tensor_meta=TensorMeta(torch.Size(size), (size[1], 1), t.dtype),
+                    )
+                    dst_spec = DTensorSpec(
+                        mesh_2d,
+                        dst_placements,
+                        tensor_meta=TensorMeta(torch.Size(size), (size[1], 1), t.dtype),
+                    )
+                    items.append((t, src_spec, dst_spec))
+
+                coalesced = redistribute_local_tensors(items)
+                per_tensor = [redistribute_local_tensor(t, s, d) for t, s, d in items]
+
+                for c, p in zip(coalesced, per_tensor):
+                    self.assertEqual(c, p)
+
+    @skip_if_lt_x_gpu(2)
+    @with_comms
+    def test_coalesced_fallback_mixed_transform_types(self):
+        """When some tensors need coalesceable transforms and others don't,
+        redistribute_local_tensors must handle both correctly: coalescing
+        within compatible groups and falling back to per-tensor for the rest.
+
+        Shard(0)→Shard(1) requires all-to-all (not coalesceable), while
+        Partial→Replicate is coalesceable. Mixing them in a single call
+        exercises the fallback path where _try_coalesced_redistribute
+        returns None for the all-to-all group.
+        """
+        from torch.distributed.tensor._dtensor_spec import DTensorSpec
+        from torch.distributed.tensor._redistribute import (
+            redistribute_local_tensor,
+            redistribute_local_tensors,
+        )
+
+        mesh = self.build_device_mesh()
+        ws = self.world_size
+
+        torch.manual_seed(42)
+        items = []
+        # 2 tensors that need Partial→Replicate (coalesceable)
+        for size in [(8, 8), (4, 16)]:
+            t = torch.randn(size, device=self.device_type)
+            src_spec = DTensorSpec(
+                mesh,
+                (Partial(),),
+                tensor_meta=TensorMeta(torch.Size(size), (size[1], 1), t.dtype),
+            )
+            dst_spec = DTensorSpec(
+                mesh,
+                (Replicate(),),
+                tensor_meta=src_spec.tensor_meta,
+            )
+            items.append((t, src_spec, dst_spec))
+
+        # 1 tensor that needs Shard(0)→Shard(1) (all-to-all, not coalesceable)
+        size = (ws * 4, ws * 4)
+        t = torch.randn(size, device=self.device_type)
+        src_spec = DTensorSpec(
+            mesh,
+            (Shard(0),),
+            tensor_meta=TensorMeta(torch.Size(size), (size[1], 1), t.dtype),
+        )
+        dst_spec = DTensorSpec(
+            mesh,
+            (Shard(1),),
+            tensor_meta=src_spec.tensor_meta,
+        )
+        items.append((t, src_spec, dst_spec))
+
+        coalesced = redistribute_local_tensors(items)
+        per_tensor = [redistribute_local_tensor(t, s, d) for t, s, d in items]
+
+        for c, p in zip(coalesced, per_tensor):
+            self.assertEqual(c, p)
+
+    @skip_if_lt_x_gpu(2)
+    @with_comms
+    def test_coalesced_debug_trace_format(self):
+        """DebugMode trace for coalesced redistribution uses compact notation
+        (e.g. 'P->R') matching the per-tensor path, and reports the correct
+        per-group coalescing count."""
+        from torch.utils._debug_mode import DebugMode
+
+        mesh = self.build_device_mesh()
+
+        torch.manual_seed(42)
+        states, grads = [], []
+        for _ in range(3):
+            states.append(
+                distribute_tensor(
+                    torch.randn(8, 8, device=self.device_type), mesh, [Replicate()]
+                )
+            )
+            grads.append(
+                DTensor.from_local(
+                    torch.randn(8, 8, device=self.device_type),
+                    mesh,
+                    [Partial()],
+                    run_check=False,
+                )
+            )
+
+        with DebugMode(record_torchfunction=False) as debug_mode:
+            torch._foreach_add_(states, grads)
+
+        debug_str = debug_mode.debug_string()
+        # Each of the 3 tensors gets a redistribute_input entry with
+        # compact notation and the correct per-group count.
+        # Partial() renders as P(sum) via format_shard_order_str.
+        self.assertEqual(debug_str.count("trace: P(sum)->R (coalesced 3 tensors)"), 3)
+
     def test_two_list_op_cache_collision(self):
         from torch.distributed.tensor._op_schema import RuntimeSchemaInfo
         from torch.distributed.tensor._ops.utils import replicate_op_strategy

--- a/test/distributed/tensor/test_tensor_ops.py
+++ b/test/distributed/tensor/test_tensor_ops.py
@@ -1484,9 +1484,10 @@ class DistTensorCppPyTree(DTensorContinuousTestBase):
     def test_coalesced_matches_per_tensor_redistribute(self):
         """Coalesced and per-tensor redistribution must produce identical results.
 
-        This is the key invariant: if the per-tensor paths in placement_types
-        (Shard._reduce_shard_tensor, Shard._to_replicate_tensor) evolve,
-        this test catches any divergence from the coalesced paths.
+        Calls redistribute_local_tensors (which attempts coalescing) and
+        redistribute_local_tensor (per-tensor, no coalescing) on the same
+        inputs, then asserts the outputs match.  This catches bugs where
+        the coalesced collective paths drift from the per-tensor paths.
         """
         from torch.distributed.tensor._dtensor_spec import DTensorSpec
         from torch.distributed.tensor._redistribute import (

--- a/torch/distributed/tensor/_dispatch.py
+++ b/torch/distributed/tensor/_dispatch.py
@@ -23,7 +23,10 @@ from torch.distributed.tensor._op_schema import (
     OutputSpecType,
 )
 from torch.distributed.tensor._random import is_rng_supported_mesh
-from torch.distributed.tensor._redistribute import redistribute_local_tensor
+from torch.distributed.tensor._redistribute import (
+    redistribute_local_tensor,
+    redistribute_local_tensors,
+)
 from torch.distributed.tensor._sharding_prop import ShardingPropagator
 from torch.distributed.tensor._tp_conv import (
     convolution_backward_handler,
@@ -565,37 +568,25 @@ class OpDispatcher:
         else:
             flatten_args_schema_to_reshard = suggested_input_schema.args_schema
 
+        # First pass: identify args that need redistribution.
+        # Most ops need zero redistributions, so we keep the common path
+        # cheap by only allocating the requests list when needed.
         new_local_args: list[object] = []
+        reshard_requests: (
+            list[tuple[int, torch.Tensor, DTensorSpec, DTensorSpec]] | None
+        ) = None
+
         for i, arg_spec in enumerate(op_info.flat_args_schema):
             reshard_arg_spec = flatten_args_schema_to_reshard[i]
             if isinstance(arg_spec, DTensorSpec):
                 local_tensor = cast(torch.Tensor, op_info.local_args[i])
                 if arg_spec != reshard_arg_spec:
-                    redistribute_context = (
-                        debug_mode.record_redistribute_calls(  # type: ignore[union-attr]
-                            i, arg_spec, reshard_arg_spec
-                        )
-                        if debug_mode is not None
-                        else contextlib.nullcontext()
+                    if reshard_requests is None:
+                        reshard_requests = []
+                    reshard_requests.append(
+                        (i, local_tensor, arg_spec, cast(DTensorSpec, reshard_arg_spec))
                     )
-
-                    ExplicitRedistributionContext.observe_redistribution(
-                        arg_spec,
-                        # pyrefly: ignore [bad-argument-type]
-                        reshard_arg_spec,
-                        LazyString(
-                            _format_implicit_redistribution_msg,
-                            op_info.schema or suggested_input_schema.op,
-                        ),
-                    )
-                    with redistribute_context:
-                        resharded_local_tensor = redistribute_local_tensor(
-                            local_tensor,
-                            arg_spec,
-                            # pyrefly: ignore [bad-argument-type]
-                            reshard_arg_spec,
-                        )
-                    new_local_args.append(resharded_local_tensor)
+                    new_local_args.append(None)  # placeholder, filled below
                 else:
                     new_local_args.append(local_tensor)
             else:
@@ -612,6 +603,60 @@ class OpDispatcher:
                 len(op_info.flat_args_schema), len(flatten_args_schema_to_reshard)
             ):
                 new_local_args.append(flatten_args_schema_to_reshard[i])
+
+        if reshard_requests is None:
+            op_info.local_args = tuple(new_local_args)
+            return
+
+        lazy_msg = LazyString(
+            _format_implicit_redistribution_msg,
+            op_info.schema  # pyrefly: ignore [bad-argument-type]
+            or suggested_input_schema.op,
+        )
+
+        if len(reshard_requests) == 1:
+            # Single redistribution: preserve original debug nesting by running
+            # the redistribute inside the record_redistribute_calls context.
+            idx, local_tensor, arg_spec, reshard_arg_spec = reshard_requests[0]
+            ExplicitRedistributionContext.observe_redistribution(
+                arg_spec,
+                reshard_arg_spec,
+                lazy_msg,
+            )
+            redistribute_context = (
+                debug_mode.record_redistribute_calls(  # type: ignore[union-attr]
+                    idx, arg_spec, reshard_arg_spec
+                )
+                if debug_mode is not None
+                else contextlib.nullcontext()
+            )
+            with redistribute_context:
+                new_local_args[idx] = redistribute_local_tensor(
+                    local_tensor,
+                    arg_spec,
+                    reshard_arg_spec,
+                )
+        else:
+            resharded = redistribute_local_tensors(
+                [(t, src, dst) for _, t, src, dst in reshard_requests]
+            )
+            for (idx, _, arg_spec, reshard_arg_spec), result in zip(
+                reshard_requests, resharded
+            ):
+                ExplicitRedistributionContext.observe_redistribution(
+                    arg_spec,
+                    reshard_arg_spec,
+                    lazy_msg,
+                )
+                if debug_mode is not None:
+                    # Records that a redistribute happened (src→dst placements).
+                    # Collectives already executed inside redistribute_local_tensors,
+                    # so they won't appear nested under this entry.
+                    with debug_mode.record_redistribute_calls(  # type: ignore[union-attr]
+                        idx, arg_spec, reshard_arg_spec
+                    ):
+                        pass
+                new_local_args[idx] = result
 
         op_info.local_args = tuple(new_local_args)
 

--- a/torch/distributed/tensor/_dispatch.py
+++ b/torch/distributed/tensor/_dispatch.py
@@ -568,13 +568,15 @@ class OpDispatcher:
         else:
             flatten_args_schema_to_reshard = suggested_input_schema.args_schema
 
-        # First pass: identify args that need redistribution.
-        # Most ops need zero redistributions, so we keep the common path
-        # cheap by only allocating the requests list when needed.
+        # First pass: identify args that need redistribution and validate
+        # them eagerly.  observe_redistribution is called here (before any
+        # collective) so that ExplicitRedistributionContext errors stop on
+        # the first offending arg, matching pre-coalescing behaviour.
         new_local_args: list[object] = []
         reshard_requests: (
             list[tuple[int, torch.Tensor, DTensorSpec, DTensorSpec]] | None
         ) = None
+        lazy_msg: LazyString | None = None
 
         for i, arg_spec in enumerate(op_info.flat_args_schema):
             reshard_arg_spec = flatten_args_schema_to_reshard[i]
@@ -583,8 +585,19 @@ class OpDispatcher:
                 if arg_spec != reshard_arg_spec:
                     if reshard_requests is None:
                         reshard_requests = []
+                        lazy_msg = LazyString(
+                            _format_implicit_redistribution_msg,
+                            op_info.schema  # pyrefly: ignore [bad-argument-type]
+                            or suggested_input_schema.op,
+                        )
+                    reshard_arg_spec = cast(DTensorSpec, reshard_arg_spec)
+                    ExplicitRedistributionContext.observe_redistribution(
+                        arg_spec,
+                        reshard_arg_spec,
+                        lazy_msg,  # pyrefly: ignore [bad-argument-type]
+                    )
                     reshard_requests.append(
-                        (i, local_tensor, arg_spec, cast(DTensorSpec, reshard_arg_spec))
+                        (i, local_tensor, arg_spec, reshard_arg_spec)
                     )
                     new_local_args.append(None)  # placeholder, filled below
                 else:
@@ -608,21 +621,8 @@ class OpDispatcher:
             op_info.local_args = tuple(new_local_args)
             return
 
-        lazy_msg = LazyString(
-            _format_implicit_redistribution_msg,
-            op_info.schema  # pyrefly: ignore [bad-argument-type]
-            or suggested_input_schema.op,
-        )
-
         if len(reshard_requests) == 1:
-            # Single redistribution: preserve original debug nesting by running
-            # the redistribute inside the record_redistribute_calls context.
             idx, local_tensor, arg_spec, reshard_arg_spec = reshard_requests[0]
-            ExplicitRedistributionContext.observe_redistribution(
-                arg_spec,
-                reshard_arg_spec,
-                lazy_msg,
-            )
             redistribute_context = (
                 debug_mode.record_redistribute_calls(  # type: ignore[union-attr]
                     idx, arg_spec, reshard_arg_spec
@@ -637,23 +637,17 @@ class OpDispatcher:
                     reshard_arg_spec,
                 )
         else:
-            resharded = redistribute_local_tensors(
-                [(t, src, dst) for _, t, src, dst in reshard_requests]
-            )
+            items = [(t, src, dst) for _, t, src, dst in reshard_requests]
+            resharded = redistribute_local_tensors(items)
             for (idx, _, arg_spec, reshard_arg_spec), result in zip(
                 reshard_requests, resharded
             ):
-                ExplicitRedistributionContext.observe_redistribution(
-                    arg_spec,
-                    reshard_arg_spec,
-                    lazy_msg,
-                )
                 if debug_mode is not None:
-                    # Records that a redistribute happened (src→dst placements).
-                    # Collectives already executed inside redistribute_local_tensors,
-                    # so they won't appear nested under this entry.
                     with debug_mode.record_redistribute_calls(  # type: ignore[union-attr]
-                        idx, arg_spec, reshard_arg_spec
+                        idx,
+                        arg_spec,
+                        reshard_arg_spec,
+                        transform_info_str=f"coalesced {len(items)} tensors",
                     ):
                         pass
                 new_local_args[idx] = result

--- a/torch/distributed/tensor/_dispatch.py
+++ b/torch/distributed/tensor/_dispatch.py
@@ -640,7 +640,7 @@ class OpDispatcher:
             items = [(t, src, dst) for _, t, src, dst in reshard_requests]
             resharded = redistribute_local_tensors(items)
             for (idx, _, arg_spec, reshard_arg_spec), result in zip(
-                reshard_requests, resharded
+                reshard_requests, resharded, strict=True
             ):
                 if debug_mode is not None:
                     with debug_mode.record_redistribute_calls(  # type: ignore[union-attr]

--- a/torch/distributed/tensor/_dispatch.py
+++ b/torch/distributed/tensor/_dispatch.py
@@ -639,17 +639,40 @@ class OpDispatcher:
         else:
             items = [(t, src, dst) for _, t, src, dst in reshard_requests]
             resharded = redistribute_local_tensors(items)
+            # Compute per-group sizes so the debug annotation reflects how
+            # many tensors were actually coalesced together, not the total.
+            if debug_mode is not None:
+                group_sizes: dict[tuple, int] = {}
+                for _, _, s, d in reshard_requests:
+                    key = (s.mesh, s.placements, d.placements)
+                    group_sizes[key] = group_sizes.get(key, 0) + 1
             for (idx, _, arg_spec, reshard_arg_spec), result in zip(
                 reshard_requests, resharded, strict=True
             ):
                 if debug_mode is not None:
-                    with debug_mode.record_redistribute_calls(  # type: ignore[union-attr]
+                    gkey = (
+                        arg_spec.mesh,
+                        arg_spec.placements,
+                        reshard_arg_spec.placements,
+                    )
+                    # Use the same compact notation as the per-tensor path
+                    # (e.g. "P->R") so debug traces are directly comparable.
+                    src_str = DTensorSpec.format_shard_order_str(
+                        arg_spec.placements, arg_spec.shard_order
+                    )
+                    dst_str = DTensorSpec.format_shard_order_str(
+                        reshard_arg_spec.placements,
+                        reshard_arg_spec.shard_order,
+                    )
+                    debug_mode.log_redistribute(  # type: ignore[union-attr]
                         idx,
                         arg_spec,
                         reshard_arg_spec,
-                        transform_info_str=f"coalesced {len(items)} tensors",
-                    ):
-                        pass
+                        transform_info_str=(
+                            f"{src_str}->{dst_str}"
+                            f" (coalesced {group_sizes[gkey]} tensors)"  # type: ignore[possibly-undefined]
+                        ),
+                    )
                 new_local_args[idx] = result
 
         op_info.local_args = tuple(new_local_args)

--- a/torch/distributed/tensor/_redistribute.py
+++ b/torch/distributed/tensor/_redistribute.py
@@ -1502,8 +1502,14 @@ def _try_coalesced_redistribute(
     first_src, first_dst = items[0][1], items[0][2]
     assert_no_mixed_partial_types(first_src.placements)
     assert_no_mixed_partial_types(first_dst.placements)
+    # During tracing, SymInts in tensor_meta are not hashable, so we must
+    # use the non-cached version (same pattern as redistribute_local_tensor).
+    if _are_we_tracing():
+        transform_infos = _gen_transform_infos_non_cached(first_src, first_dst, None)
+    else:
+        transform_infos = _gen_transform_infos(first_src, first_dst, None)
     optimized = _optimize_transform_infos(
-        _gen_transform_infos(first_src, first_dst, None),
+        transform_infos,
         mesh,
         first_src.placements,
         first_dst.placements,

--- a/torch/distributed/tensor/_redistribute.py
+++ b/torch/distributed/tensor/_redistribute.py
@@ -1457,6 +1457,223 @@ def _gen_transform_infos(
     )
 
 
+def redistribute_local_tensors(
+    items: list[tuple[torch.Tensor, DTensorSpec, DTensorSpec]],
+) -> list[torch.Tensor]:
+    """Redistribute N tensors, coalescing collectives within groups that
+    share the same (mesh, src_placements, dst_placements)."""
+    n = len(items)
+    if n == 0:
+        return []
+    if n == 1:
+        t, src, dst = items[0]
+        return [redistribute_local_tensor(t, src, dst)]
+
+    results: list[torch.Tensor | None] = [None] * n
+    groups: defaultdict[tuple, list[int]] = defaultdict(list)
+    for i, (_, src, dst) in enumerate(items):
+        groups[(id(src.mesh), src.placements, dst.placements)].append(i)
+
+    # Dict insertion order ensures all ranks issue collectives in the same order.
+    for indices in groups.values():
+        if len(indices) > 1:
+            coalesced = _try_coalesced_redistribute([items[i] for i in indices])
+            if coalesced is not None:
+                for idx, result in zip(indices, coalesced):
+                    results[idx] = result
+                continue
+        for idx in indices:
+            t, src, dst = items[idx]
+            results[idx] = redistribute_local_tensor(t, src, dst)
+
+    return results  # type: ignore[return-value]
+
+
+def _try_coalesced_redistribute(
+    items: list[tuple[torch.Tensor, DTensorSpec, DTensorSpec]],
+) -> list[torch.Tensor] | None:
+    """Single coalesced collective for tensors sharing (mesh, placements).
+    Returns None to fall back to per-tensor redistribution."""
+    mesh = items[0][1].mesh
+    if not mesh._is_current_rank_part_of_mesh():
+        return None
+
+    # Transform depends on placements and mesh, not tensor shape.
+    first_src, first_dst = items[0][1], items[0][2]
+    assert_no_mixed_partial_types(first_src.placements)
+    assert_no_mixed_partial_types(first_dst.placements)
+    optimized = _optimize_transform_infos(
+        _gen_transform_infos(first_src, first_dst, None),
+        mesh,
+        first_src.placements,
+        first_dst.placements,
+    )
+    if len(optimized) != 1:
+        return None
+
+    ref = optimized[0]
+    comm_type = ref._comm_type_key()
+    if comm_type not in ("all_reduce", "reduce_scatter", "all_gather"):
+        return None
+    src_placement, dst_placement = ref.src_dst_placements
+    # Subclasses (e.g. _MaskPartial, _StridedShard) have custom reduction logic.
+    if comm_type in ("all_reduce", "reduce_scatter"):
+        if type(src_placement) is not Partial:
+            return None
+    elif comm_type == "all_gather":
+        if type(src_placement) is not Shard:
+            return None
+
+    if isinstance(ref, _FlattenedTransformInfo):
+        collective_mesh, avg_scale = ref.mesh, ref.avg_scale
+    else:
+        collective_mesh, avg_scale = mesh, None
+
+    num_chunks = collective_mesh.size(mesh_dim=ref.mesh_dim)
+    if num_chunks == 1:
+        return [tensor for tensor, _, _ in items]
+
+    if comm_type == "all_reduce":
+        results = funcol.all_reduce_coalesced(
+            [tensor for tensor, _, _ in items],
+            reduceOp=cast(Partial, src_placement).reduce_op,
+            group=(collective_mesh, ref.mesh_dim),
+        )
+        if avg_scale is not None:
+            results = [r / avg_scale for r in results]
+        return results
+
+    if comm_type == "all_gather":
+        # keep in sync with Shard._to_replicate_tensor
+        return _coalesced_allgather(
+            items,
+            cast(Shard, src_placement),
+            collective_mesh,
+            ref.mesh_dim,
+        )
+
+    # reduce_scatter — keep in sync with Shard._reduce_shard_tensor
+    return _coalesced_reduce_scatter(
+        items,
+        cast(Shard, dst_placement),
+        cast(Partial, src_placement),
+        collective_mesh,
+        ref.mesh_dim,
+        avg_scale,
+    )
+
+
+def _coalesced_allgather(
+    items: list[tuple[torch.Tensor, DTensorSpec, DTensorSpec]],
+    shard_spec: Shard,
+    collective_mesh: DeviceMesh,
+    mesh_dim: int,
+) -> list[torch.Tensor]:
+    """Coalesced allgather for Shard→Replicate. Keep in sync with
+    Shard._to_replicate_tensor."""
+    from torch._utils import _maybe_view_chunk_cat
+
+    shard_dim = shard_spec.dim
+    num_chunks = collective_mesh.size(mesh_dim=mesh_dim)
+
+    # Pad each tensor for uneven sharding, then make contiguous
+    padded_tensors: list[torch.Tensor] = []
+    logical_dim_sizes: list[int] = []
+    for tensor, src_spec, _ in items:
+        logical_dim_size = (
+            src_spec.tensor_meta.shape[  # pyrefly: ignore [missing-attribute]
+                shard_dim
+            ]
+        )
+        logical_dim_sizes.append(logical_dim_size)
+        padded_tensors.append(
+            shard_spec._maybe_pad_tensor(tensor, logical_dim_size, num_chunks)
+        )
+
+    results = funcol.all_gather_into_tensor_coalesced(
+        padded_tensors,
+        group=(collective_mesh, mesh_dim),
+    )
+
+    # all_gather_into_tensor_coalesced gathers on dim 0; reshuffle if needed.
+    # Match the AsyncCollectiveTensor handling in all_gather_tensor(): wait
+    # early if _maybe_view_chunk_cat can't use the view optimization.
+    if shard_dim != 0:
+        import math
+
+        from torch.distributed._functional_collectives import AsyncCollectiveTensor
+
+        reshuffled: list[torch.Tensor] = []
+        for r in results:
+            if isinstance(r, AsyncCollectiveTensor):
+                shape = list(r.shape)
+                numel_between = math.prod(shape[1:shard_dim]) if shard_dim > 1 else 1
+                if not (shape[0] == num_chunks and numel_between == 1):
+                    r = r.wait()  # type: ignore[assignment]
+            reshuffled.append(_maybe_view_chunk_cat(r, num_chunks, shard_dim))
+        results = reshuffled
+
+    # Unpad results with uneven sharding
+    for i, logical_dim_size in enumerate(logical_dim_sizes):
+        results[i] = shard_spec._maybe_unpad_tensor(
+            results[i],
+            logical_dim_size,
+            num_chunks,
+        )
+
+    return results
+
+
+def _coalesced_reduce_scatter(
+    items: list[tuple[torch.Tensor, DTensorSpec, DTensorSpec]],
+    shard_spec: Shard,
+    partial_spec: Partial,
+    collective_mesh: DeviceMesh,
+    mesh_dim: int,
+    avg_scale: int | None,
+) -> list[torch.Tensor]:
+    """Coalesced reduce_scatter for Partial→Shard. Keep in sync with
+    Shard._reduce_shard_tensor."""
+    from torch.fx.experimental.symbolic_shapes import guard_or_true
+
+    shard_dim = shard_spec.dim
+    num_chunks = collective_mesh.size(mesh_dim=mesh_dim)
+
+    padded_tensors: list[torch.Tensor] = []
+    pad_sizes_list: list[list[int] | None] = []
+    for tensor, _, _ in items:
+        if guard_or_true(tensor.size(shard_dim) % num_chunks != 0):
+            scattered_list, pad_sizes = shard_spec._split_tensor(
+                tensor, num_chunks, with_padding=True, contiguous=True
+            )
+            padded_tensors.append(torch.cat(scattered_list, dim=shard_dim))
+            pad_sizes_list.append(pad_sizes)
+        else:
+            padded_tensors.append(
+                tensor.contiguous() if not tensor.is_contiguous() else tensor
+            )
+            pad_sizes_list.append(None)
+
+    results = funcol.reduce_scatter_tensor_coalesced(
+        padded_tensors,
+        partial_spec.reduce_op,
+        [shard_dim] * len(padded_tensors),
+        group=(collective_mesh, mesh_dim),
+    )
+    for i, pad_sizes in enumerate(pad_sizes_list):
+        if pad_sizes is not None:
+            results[i] = Shard._maybe_unpad_tensor_with_sizes(
+                shard_dim,
+                results[i],
+                pad_sizes,
+                collective_mesh._sym_get_coordinate(mesh_dim),
+                False,
+            )
+    if avg_scale is not None:
+        results = [r / avg_scale for r in results]
+    return results
+
+
 def redistribute_local_tensor(
     local_tensor: torch.Tensor,
     current_spec: DTensorSpec,

--- a/torch/distributed/tensor/_redistribute.py
+++ b/torch/distributed/tensor/_redistribute.py
@@ -1472,7 +1472,7 @@ def redistribute_local_tensors(
     results: list[torch.Tensor | None] = [None] * n
     groups: defaultdict[tuple, list[int]] = defaultdict(list)
     for i, (_, src, dst) in enumerate(items):
-        groups[(id(src.mesh), src.placements, dst.placements)].append(i)
+        groups[(src.mesh, src.placements, dst.placements)].append(i)
 
     # Dict insertion order ensures all ranks issue collectives in the same order.
     for indices in groups.values():

--- a/torch/distributed/tensor/_redistribute.py
+++ b/torch/distributed/tensor/_redistribute.py
@@ -1479,7 +1479,7 @@ def redistribute_local_tensors(
         if len(indices) > 1:
             coalesced = _try_coalesced_redistribute([items[i] for i in indices])
             if coalesced is not None:
-                for idx, result in zip(indices, coalesced):
+                for idx, result in zip(indices, coalesced, strict=True):
                     results[idx] = result
                 continue
         for idx in indices:
@@ -1655,9 +1655,7 @@ def _coalesced_reduce_scatter(
             padded_tensors.append(torch.cat(scattered_list, dim=shard_dim))
             pad_sizes_list.append(pad_sizes)
         else:
-            padded_tensors.append(
-                tensor.contiguous() if not tensor.is_contiguous() else tensor
-            )
+            padded_tensors.append(tensor.contiguous())
             pad_sizes_list.append(None)
 
     results = funcol.reduce_scatter_tensor_coalesced(

--- a/torch/utils/_debug_mode/_mode.py
+++ b/torch/utils/_debug_mode/_mode.py
@@ -588,6 +588,30 @@ class DebugMode(TorchDispatchMode):
         finally:
             self.call_depth -= 1
 
+    def log_redistribute(
+        self,
+        arg,
+        src_placement,
+        dst_placement,
+        transform_info_str: str | None = None,
+    ):
+        """Record a redistribution that already happened (no call_depth nesting).
+
+        Use this instead of record_redistribute_calls when the redistribution
+        was performed externally (e.g. coalesced) and there are no nested
+        debug calls to track.
+        """
+        self._record_call(
+            _RedistributeCall(
+                arg,
+                src_placement=src_placement,
+                dst_placement=dst_placement,
+                transform_info_str=transform_info_str,
+                call_depth=self.call_depth + 1,
+                stack=self.record_stack_trace,
+            )
+        )
+
     def record_output_placements(self, output_spec) -> None:
         """Record output placements for a DTensor op as a separate line."""
         if not self.record_output:


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/170367

When multiple op arguments need the same redistribution (same mesh, same src/dst placements), batch them into a single coalesced collective call instead of issuing N separate NCCL kernel launches. This is most impactful for foreach/fused ops (e.g. _foreach_add_, _fused_adam_) during optimizer steps with many parameters, but applies to any multi-arg op.

Supports all_reduce, reduce_scatter, and allgather coalescing (all_to_all is not coalesced as there is no coalesced variant in funcol). Flattened mesh transforms (multi-dim mesh optimization) are also supported. Falls back to per-tensor redistribution for unsupported cases (e.g. _MaskPartial, multi-step transforms, subclassed placement types).

