### PR TITLE
[DDP] Clarify that output_device has no effect

### DIFF
--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -508,7 +508,7 @@ class DistributedDataParallel(Module, Joinable):
         >>> torch.distributed.init_process_group(
         >>>     backend=vendor_backend, world_size=N, init_method='...'
         >>> )
-        >>> model = DistributedDataParallel(model, device_ids=[i], output_device=i)
+        >>> model = DistributedDataParallel(model, device_ids=[i])
 
     Or you can use the latest API for initialization:
 
@@ -686,11 +686,8 @@ class DistributedDataParallel(Module, Joinable):
                    both the input data for the forward pass and the actual module
                    must be placed on the correct device.
                    (default: ``None``)
-        output_device (int or torch.device): Device location of output for
-                      single-device CUDA modules. For multi-device modules and
-                      CPU modules, it must be ``None``, and the module itself
-                      dictates the output location. (default: ``device_ids[0]``
-                      for single-device modules)
+        output_device (int or torch.device): This argument is deprecated and
+                      has no effect on DDP behavior.
         broadcast_buffers (bool): Flag that enables syncing (broadcasting)
                           buffers of the module at beginning of the ``forward``
                           function. (default: ``True``)
@@ -912,6 +909,15 @@ class DistributedDataParallel(Module, Joinable):
             )
 
         self.device_type = next(iter(distinct_device_types))
+
+        if output_device is not None:
+            warnings.warn(
+                "The `output_device` argument in `DistributedDataParallel` "
+                "is deprecated and has no effect. Please remove it from "
+                "your DDP constructor call.",
+                FutureWarning,
+                stacklevel=2,
+            )
 
         if (
             device_ids is None
@@ -2014,7 +2020,7 @@ class DistributedDataParallel(Module, Joinable):
             >>>     torch.cuda.set_device(rank)
             >>>     model = nn.Linear(1, 1, bias=False).to(rank)
             >>>     model = torch.nn.parallel.DistributedDataParallel(
-            >>>         model, device_ids=[rank], output_device=rank
+            >>>         model, device_ids=[rank]
             >>>     )
             >>>     # Rank 1 gets one more input than rank 0.
             >>>     inputs = [torch.tensor([1]).float() for _ in range(10 + rank)]

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -686,8 +686,11 @@ class DistributedDataParallel(Module, Joinable):
                    both the input data for the forward pass and the actual module
                    must be placed on the correct device.
                    (default: ``None``)
-        output_device (int or torch.device): This argument is deprecated and
-                      has no effect on DDP behavior.
+        output_device (int or torch.device): This argument has no effect on
+                      DDP behavior. Unlike ``DataParallel``, DDP does not
+                      perform scatter/gather and each process runs its own
+                      forward pass on its assigned device. Retained for
+                      backward compatibility. (default: ``None``)
         broadcast_buffers (bool): Flag that enables syncing (broadcasting)
                           buffers of the module at beginning of the ``forward``
                           function. (default: ``True``)
@@ -909,15 +912,6 @@ class DistributedDataParallel(Module, Joinable):
             )
 
         self.device_type = next(iter(distinct_device_types))
-
-        if output_device is not None:
-            warnings.warn(
-                "The `output_device` argument in `DistributedDataParallel` "
-                "is deprecated and has no effect. Please remove it from "
-                "your DDP constructor call.",
-                FutureWarning,
-                stacklevel=2,
-            )
 
         if (
             device_ids is None


### PR DESCRIPTION
## Summary
- Update `output_device` docstring to clarify it has no effect on DDP behavior
- Explain why: unlike `DataParallel`, DDP doesn't scatter/gather
- Note that the argument is retained for backward compatibility
- Remove `output_device` from docstring code examples where it was redundant

## Motivation
The `output_device` argument in DDP has no effect on behavior. Unlike `DataParallel`, DDP does not perform scatter/gather — each process runs its own forward pass on its assigned device. The only reference to `self.output_device` after construction is in DDP logging metadata.

Per maintainer feedback, a runtime deprecation warning would create unnecessary churn for existing users. This PR takes the lighter-touch approach of updating the documentation so new users aren't misled, without disrupting existing code.

Fixes #80420

## Changes
- Updated the `output_device` docstring to explain it has no effect, why, and that it's kept for backward compatibility
- Removed `output_device` from two docstring code examples where it was redundant with `device_ids`

## Test Plan
- Doc-only change, no runtime behavior affected
- Verified with `ruff check` — no new lint issues