### PR TITLE
In adfc/aggregates/aap_aggregates_scripts_common.py, remove... (#177462)

### DIFF
--- a/tools/stats/monitor.py
+++ b/tools/stats/monitor.py
@@ -168,7 +168,6 @@ class SharedResource:
 
     def add_log(self, log: str) -> None:
         with self._lock:
-            print("here log")
             self._data_logs.append(log)
 
 


### PR DESCRIPTION
Summary:

- In adfc/aggregates/aap_aggregates_scripts_common.py, remove redundant .keys() calls in dict membership checks at lines 51 ("UID_LABEL" in label_data.keys() and "MULTI_LABEL" in label_data.keys()) and 77 ("DROPPED_UID_LABEL" in label_data.keys()), since in dict is equivalent and more idiomatic.
- In spatial_ai/location/handler.py, remove the leftover debug statement logger.info("Debugging statement.") from the echo method.
- In caffe2/tools/stats/monitor.py, remove the leftover debug statement print("here log") from the add_log method.

AI Review:
- security: PASSED (1.00) — All three changes are safe: (1) replacing `in dict.keys()` with `in dict` is semantically identical, (2) removing debug `print("here log")` and `logger.info("Debugging statement.")` statements eliminates minor information leakage without affecting functionality.
- quality: PASSED (0.90) — All three changes are correct and safe:
- task_solution: PASSED (0.95) — The diff correctly addresses all three items in the task. The `.keys()` removals are semantically equivalent and more idiomatic. The debug statements are properly removed. The additional `.keys()` removals beyond the explicitly mentioned lines are consistent and appropriate.

Test Plan:
Changed files: `adfc/aggregates/aap_aggregates_scripts_common.py`, `caffe2/tools/stats/monitor.py`, `spatial_ai/location/handler.py`
lint: passed
passed
build: passed
Scope: confirmed that modified symbols have no external/dynamic callers outside the changed files' immediate modules.

Differential Revision: D96602795
