### PR TITLE
[CI] Work around H100 FabricManager failure causing multicast failure

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -388,6 +388,7 @@ test_h100_symm_mem() {
   export NVSHMEM_SYMMETRIC_SIZE=4G
   # Disable NVLink Switch features (not available on AWS H100 instances)
   export NVSHMEM_DISABLE_NVLS=1
+  export NCCL_NVLS_ENABLE=0
   _run_symm_mem_tests
 }
 

--- a/test/distributed/test_nccl.py
+++ b/test/distributed/test_nccl.py
@@ -1,5 +1,6 @@
 # Owner(s): ["oncall: distributed"]
 
+import os
 import sys
 
 import torch
@@ -513,6 +514,10 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
 
     @skip_but_pass_in_sandcastle_if(TEST_WITH_ROCM, "Skip NCCL tests for ROCm")
     @skip_but_pass_in_sandcastle_if(IS_WINDOWS, "NCCL doesn't support Windows")
+    @skip_but_pass_in_sandcastle_if(
+        os.environ.get("NCCL_NVLS_ENABLE", "1") == "0",
+        "NCCL_NVLS_ENABLE=0",
+    )
     @skip_if_lt_x_gpu(2)
     @requires_nccl_version(
         (2, 29), "NCCL Symmetric Memory multicast support from nccl 2.29"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #177473
* #177380
* #177463
* #177459
* __->__ #177472

Typical signature:
```
torch.distributed.DistBackendError: NCCL error in: /var/lib/jenkins/workspace/torch/csrc/distributed/c10d/NCCLUtils.cpp:93, unhandled cuda error (run with NCCL_DEBUG=INFO for details), NCCL version 2.29.3 
ncclUnhandledCudaError: Call to CUDA function failed. 
Last error: 
Failed to bind NVLink SHARP (NVLS) Multicast memory of size 2097152 : CUDA error 401 'the operation cannot be performed in the present state'. 
This is usually caused by a system or configuration error in the Fabric Manager or NVSwitches. 
Disable NVLS (NCCL_NVLS_ENABLE=0) if you wish to avoid this error in the future. 
```

This PR disables NCCL from using NVLink SHARP by setting  `NCCL_NVLS_ENABLE=0` as suggested.
Note that this is a short-term workaround. We need to restart or fix the machine.