### PR TITLE
dynamo: allow local out tensors to resize in graph

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -10453,7 +10453,8 @@ def ___make_guard_fn():
 
             @torch.compile(backend="eager", fullgraph=True)
             def f2(tensors, dim, num_chunks, out):
-                return torch.ops.mylib.chunk_cat(tensors, dim, num_chunks, out=out)
+                torch.ops.mylib.chunk_cat(tensors, dim, num_chunks, out=out)
+                return out.size(), out
 
             x = torch.zeros(100, dtype=torch.int64)
             tensors = [
@@ -10464,8 +10465,10 @@ def ___make_guard_fn():
             ]
             dim = 0
             num_chunks = 2
-            out = torch.empty(2, 272)
-            f2(tensors, dim, num_chunks, out)
+            out = torch.empty(1)
+            out_size, out_value = f2(tensors, dim, num_chunks, out)
+            self.assertEqual(out_size, torch.Size([2, 272]))
+            self.assertEqual(out_value.shape, torch.Size([2, 272]))
 
     @torch._dynamo.config.patch(capture_scalar_outputs=True)
     def test_runtime_assert_replacement(self):

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -10452,7 +10452,8 @@ def ___make_guard_fn():
                 torch._chunk_cat(tensors, dim, num_chunks, out=out)
 
             @torch.compile(backend="eager", fullgraph=True)
-            def f2(tensors, dim, num_chunks, out):
+            def f2(tensors, dim, num_chunks):
+                out = torch.empty(1)
                 torch.ops.mylib.chunk_cat(tensors, dim, num_chunks, out=out)
                 return out.size(), out
 
@@ -10465,8 +10466,7 @@ def ___make_guard_fn():
             ]
             dim = 0
             num_chunks = 2
-            out = torch.empty(1)
-            out_size, out_value = f2(tensors, dim, num_chunks, out)
+            out_size, out_value = f2(tensors, dim, num_chunks)
             self.assertEqual(out_size, torch.Size([2, 272]))
             self.assertEqual(out_value.shape, torch.Size([2, 272]))
 

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -10470,6 +10470,39 @@ def ___make_guard_fn():
             self.assertEqual(out_size, torch.Size([2, 272]))
             self.assertEqual(out_value.shape, torch.Size([2, 272]))
 
+    def test_out_variant_custom_callable_checks_actual_out(self):
+        @allow_in_graph
+        def resize_out_return_view(x, out):
+            torch.diff(x, n=0, out=out)
+            return out[:1]
+
+        @allow_in_graph
+        def resize_out_list_return_partial(x, out):
+            torch.split_with_sizes_copy(x, [1, 2], out=out)
+            return [out[0]]
+
+        @torch.compile(backend="eager", fullgraph=True)
+        def f_single(x, out):
+            resize_out_return_view(x, out=out)
+            return out
+
+        @torch.compile(backend="eager", fullgraph=True)
+        def f_list(x, out):
+            resize_out_list_return_partial(x, out=out)
+            return out
+
+        with self.assertRaisesRegex(
+            torch._dynamo.exc.Unsupported,
+            "Shape mismatch with out= tensor variant",
+        ):
+            f_single(torch.tensor([0.0, 2.0]), torch.empty(1))
+
+        with self.assertRaisesRegex(
+            torch._dynamo.exc.Unsupported,
+            "Shape mismatch with out= list of tensor variants",
+        ):
+            f_list(torch.tensor([0.0, 1.0, 2.0]), [torch.empty(1), torch.empty(1)])
+
     @torch._dynamo.config.patch(capture_scalar_outputs=True)
     def test_runtime_assert_replacement(self):
         @torch.compile(backend="eager")

--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -2460,6 +2460,22 @@ class ReproTests(torch._dynamo.test_case.TestCase):
         res = fn()
         self.assertEqual(((3, 5), (3, 5)), res)
 
+    def test_diff_out_local_clone_dynamic_shape_change(self):
+        @torch.compile(backend="eager", fullgraph=True, dynamic=True)
+        def fn(a, b):
+            a = a.clone()
+            b = b.clone()
+            torch.diff(a, n=0, out=b)
+            return b.size(), b
+
+        size0, out0 = fn(torch.tensor([0, 2]), torch.tensor([1]))
+        self.assertEqual(torch.Size([2]), size0)
+        self.assertEqual(torch.tensor([0, 2]), out0)
+
+        size1, out1 = fn(torch.tensor([0, 3, 4]), torch.tensor([1, 2]))
+        self.assertEqual(torch.Size([3]), size1)
+        self.assertEqual(torch.tensor([0, 3, 4]), out1)
+
     def test_slice_into_list_mutable(self):
         class Mod(torch.nn.Module):
             def forward(self, listy):

--- a/torch/_dynamo/graph_break_registry.json
+++ b/torch/_dynamo/graph_break_registry.json
@@ -2908,6 +2908,14 @@
     {
       "Gb_type": "Shape mismatch with out= list of tensor variants",
       "Context": "fn={self.value}, args={args}, kwargs={kwargs}",
+      "Explanation": "Shape mismatch when calling {self.value} with `out=`. Provided `out=` shape: {saved_out_shape}. Actual shape: {fake_out.shape}.",
+      "Hints": [
+        "It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues."
+      ]
+    },
+    {
+      "Gb_type": "Shape mismatch with out= list of tensor variants",
+      "Context": "fn={self.value}, args={args}, kwargs={kwargs}",
       "Explanation": "Shape mismatch when calling {self.value} with `out=`. Provided `out=` shape: {saved_out_shape}. Actual shape: {resize_checked_fake_out.shape}.",
       "Hints": [
         "It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues."

--- a/torch/_dynamo/graph_break_registry.json
+++ b/torch/_dynamo/graph_break_registry.json
@@ -2908,6 +2908,14 @@
     {
       "Gb_type": "Shape mismatch with out= list of tensor variants",
       "Context": "fn={self.value}, args={args}, kwargs={kwargs}",
+      "Explanation": "Shape mismatch when calling {self.value} with `out=`. Provided `out=` shape: {saved_out_shape}. Actual shape: {resize_checked_fake_out.shape}.",
+      "Hints": [
+        "It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues."
+      ]
+    },
+    {
+      "Gb_type": "Shape mismatch with out= list of tensor variants",
+      "Context": "fn={self.value}, args={args}, kwargs={kwargs}",
       "Explanation": "Shape mismatch when calling {self.value} with `out=`. Provided `out=` shape: {saved_out_shape}. Actual shape: {fake_out.shape}.",
       "Hints": [
         "It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues."

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -282,6 +282,13 @@ class TensorVariable(VariableTracker):
             "is_quantized": value.is_quantized,
             "is_sparse": value.is_sparse,
             "class_type": type(value),
+            # Shape-derived metadata is only valid when specialize() can
+            # recompute it from the current fake tensor. Setting these to None
+            # lets synchronize_attributes() clear stale cached values after an
+            # out= resize updates the proxy to a symbolic-shape fake tensor.
+            "_size": None,
+            "stride": None,
+            "is_contiguous": None,
         }
         try:
             props["has_grad_fn"] = value.grad_fn is not None

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -2352,32 +2352,29 @@ For now, dynamo will explicitly graph break when it encounters user code with th
             # out variants of torch operators like torch.sort and torch.sigmoid
             # mutate the tensors in the out field.
             #
-            # However, it's non-trivial to update all references of the old
-            # `TensorVariable` to the new one returned (`result_var`), so we
-            # take the conservative approach to graph break on size changes, and
-            # assume other cases can fall through soundly.
+            # For source-tracked `out=` tensors, we still take the conservative
+            # approach and graph break on size changes. For local/intermediate
+            # `out=` tensors, reproxify the passed tensor VTs to the returned
+            # result so subsequent reads see the updated value/metadata.
             #
             # Note that although these tensor variables would hold different
             # proxies, the in-place mutation semantics is preserved in the FX
             # graph, so we won't have correctness issues.
             if isinstance(saved_out_shapes, list):
-                for out_tensor_vt, saved_out_shape, saved_out_version in zip(
+                assert isinstance(
+                    tensor_variable, (TupleVariable, ListVariable, NamedTupleVariable)
+                )
+                for out_tensor_vt, result_out_vt, saved_out_shape, saved_out_version in zip(
                     out_kwarg_vt.items,  # type: ignore[union-attr]
+                    tensor_variable.items,
                     saved_out_shapes,
                     saved_out_versions,  # type: ignore[arg-type]
                 ):
                     if saved_out_shape is None:
-                        # This out tensor is not shape-guarded, but it may still
-                        # need its metadata synchronized if fake propagation
-                        # resized it in place.
-                        if not out_tensor_vt.is_tensor():
+                        if not out_tensor_vt.is_tensor() or not result_out_vt.is_tensor():
                             continue
-                        fake_out = out_tensor_vt.proxy.node.meta["example_value"]
-                        if (
-                            saved_out_version is not None
-                            and fake_out._version > saved_out_version
-                        ):
-                            out_tensor_vt.synchronize_attributes(tx)  # type: ignore[attr-defined]
+                        out_tensor_vt.proxy = result_out_vt.proxy  # type: ignore[attr-defined]
+                        out_tensor_vt.synchronize_attributes(tx)  # type: ignore[attr-defined]
                         continue
 
                     assert out_tensor_vt.is_tensor()
@@ -2414,35 +2411,40 @@ For now, dynamo will explicitly graph break when it encounters user code with th
                         )
             else:
                 assert out_kwarg_vt is not None and out_kwarg_vt.is_tensor()
-                assert "example_value" in out_kwarg_vt.as_proxy().node.meta
-                fake_out = out_kwarg_vt.as_proxy().node.meta["example_value"]
-                if fake_out._version > saved_out_versions:
+                if saved_out_shapes is None:
+                    assert tensor_variable.is_tensor()
+                    out_kwarg_vt.proxy = tensor_variable.proxy  # type: ignore[attr-defined]
                     out_kwarg_vt.synchronize_attributes(tx)  # type: ignore[attr-defined]
-                if saved_out_shapes is not None and saved_out_shapes != fake_out.shape:
-                    # It's hard to get out variants with resizing on graph inputs work
-                    # properly across dynamo/aot/inductor, just fall back.
-                    unimplemented(
-                        gb_type="Shape mismatch with out= tensor variant",
-                        context=f"fn={self.value}, args={args}, kwargs={kwargs}",
-                        explanation=(
-                            f"Shape mismatch when calling {self.value} with `out=`. "
-                            f"Provided `out=` shape: {saved_out_shapes}. Actual shape: {fake_out.shape}."
-                        ),
-                        hints=[
-                            *graph_break_hints.SUPPORTABLE,
-                        ],
-                    )
-                if not torch._prims_common.is_contiguous_or_false(fake_out):
-                    # It's difficult to handle strides correctly in functionalization
-                    # when calling an out= op with a non-contiguous out argument
-                    unimplemented(
-                        gb_type="Attempted to call op with non-contiguous `out=` tensor",
-                        context=f"self.value={self.value}, args={args}, kwargs={kwargs}",
-                        explanation="Dynamo does not support this.",
-                        hints=[
-                            *graph_break_hints.SUPPORTABLE,
-                        ],
-                    )
+                else:
+                    assert "example_value" in out_kwarg_vt.as_proxy().node.meta
+                    fake_out = out_kwarg_vt.as_proxy().node.meta["example_value"]
+                    if fake_out._version > saved_out_versions:
+                        out_kwarg_vt.synchronize_attributes(tx)  # type: ignore[attr-defined]
+                    if saved_out_shapes != fake_out.shape:
+                        # It's hard to get out variants with resizing on graph inputs work
+                        # properly across dynamo/aot/inductor, just fall back.
+                        unimplemented(
+                            gb_type="Shape mismatch with out= tensor variant",
+                            context=f"fn={self.value}, args={args}, kwargs={kwargs}",
+                            explanation=(
+                                f"Shape mismatch when calling {self.value} with `out=`. "
+                                f"Provided `out=` shape: {saved_out_shapes}. Actual shape: {fake_out.shape}."
+                            ),
+                            hints=[
+                                *graph_break_hints.SUPPORTABLE,
+                            ],
+                        )
+                    if not torch._prims_common.is_contiguous_or_false(fake_out):
+                        # It's difficult to handle strides correctly in functionalization
+                        # when calling an out= op with a non-contiguous out argument
+                        unimplemented(
+                            gb_type="Attempted to call op with non-contiguous `out=` tensor",
+                            context=f"self.value={self.value}, args={args}, kwargs={kwargs}",
+                            explanation="Dynamo does not support this.",
+                            hints=[
+                                *graph_break_hints.SUPPORTABLE,
+                            ],
+                        )
 
         return tensor_variable
 

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -2374,7 +2374,9 @@ For now, dynamo will explicitly graph break when it encounters user code with th
                         )
                         if should_sync_out:
                             out_tensor_vt.synchronize_attributes(tx)  # type: ignore[attr-defined]
-                            fake_out = out_tensor_vt.as_proxy().node.meta["example_value"]
+                            fake_out = out_tensor_vt.as_proxy().node.meta[
+                                "example_value"
+                            ]
 
                         # Keep resize and contiguity checks attached to the
                         # actual `out=` slots. `@allow_in_graph` and other

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -2242,10 +2242,12 @@ For now, dynamo will explicitly graph break when it encounters user code with th
 
         # Calling fake tensor propagation can mutate graph-input out= tensors.
         # Mutating their fake metadata destroys the pre-call shape information
-        # needed for the conservative graph-break path, so only out tensors
-        # backed by actual graphargs save their shape for a later check.
-        # Local/intermediate out tensors are handled after fake propagation
-        # instead.
+        # needed for the conservative graph-break path.
+        #
+        # When graph breaks are allowed we keep the same conservative behavior
+        # for local/intermediate out tensors so eager fallback still preserves
+        # resize-warning semantics. Only fullgraph/error_on_graph_break tracing
+        # relaxes that and updates local out metadata after fake propagation.
         saved_out_shapes = None
         saved_out_versions = None
         out_kwarg_vt = None
@@ -2253,7 +2255,9 @@ For now, dynamo will explicitly graph break when it encounters user code with th
             out_kwarg_vt = kwargs["out"]
 
             def should_guard_out_shape(out_vt: VariableTracker) -> bool:
-                return out_vt.as_proxy().node.meta.get("grapharg") is not None
+                return out_vt.as_proxy().node.meta.get("grapharg") is not None or (
+                    not tx.one_graph and not tx.error_on_graph_break
+                )
 
             # e.g., out=(t1, t2, ...)
             if isinstance(out_kwarg_vt, (TupleVariable, ListVariable)):
@@ -2348,29 +2352,55 @@ For now, dynamo will explicitly graph break when it encounters user code with th
             # mutate the tensors in the out field.
             #
             # For guard-tracked `out=` tensors, we still take the conservative
-            # approach and graph break on size changes. For local/intermediate
-            # `out=` tensors, fake propagation mutates the existing fake tensor
-            # in place, so synchronize the original VT metadata afterward.
+            # approach and graph break on size changes. In fullgraph mode,
+            # local/intermediate `out=` tensors instead update their original
+            # VTs after fake propagation so later local uses see the resized
+            # metadata without graph breaking.
             #
             # Note that although these tensor variables would hold different
             # metadata after fake propagation, the in-place mutation semantics
             # is preserved in the FX graph, so we won't have correctness issues.
             if isinstance(saved_out_shapes, list):
-                for out_tensor_vt, saved_out_shape, saved_out_version in zip(
+                result_out_vts = (
+                    tensor_variable.items
+                    if isinstance(
+                        tensor_variable,
+                        (TupleVariable, ListVariable, NamedTupleVariable),
+                    )
+                    else [None] * len(saved_out_shapes)
+                )
+                for (
+                    out_tensor_vt,
+                    result_out_vt,
+                    saved_out_shape,
+                    saved_out_version,
+                ) in zip(
                     out_kwarg_vt.items,  # type: ignore[union-attr]
+                    result_out_vts,
                     saved_out_shapes,
                     saved_out_versions,  # type: ignore[arg-type]
                 ):
                     if not out_tensor_vt.is_tensor():
                         continue
 
+                    if saved_out_shape is None:
+                        if result_out_vt is not None and result_out_vt.is_tensor():
+                            out_tensor_vt.proxy = result_out_vt.as_proxy()  # type: ignore[attr-defined]
+                        out_tensor_vt.synchronize_attributes(tx)  # type: ignore[attr-defined]
+                    else:
+                        fake_out = out_tensor_vt.as_proxy().node.meta["example_value"]
+                        if (
+                            saved_out_version is not None
+                            and fake_out._version > saved_out_version
+                        ):
+                            out_tensor_vt.synchronize_attributes(tx)  # type: ignore[attr-defined]
                     fake_out = out_tensor_vt.as_proxy().node.meta["example_value"]
                     if (
-                        saved_out_version is not None
-                        and fake_out._version > saved_out_version
+                        saved_out_shape is not None
+                        and result_out_vt is not None
+                        and result_out_vt.is_tensor()
                     ):
-                        out_tensor_vt.synchronize_attributes(tx)  # type: ignore[attr-defined]
-                        fake_out = out_tensor_vt.as_proxy().node.meta["example_value"]
+                        fake_out = result_out_vt.as_proxy().node.meta["example_value"]
                     if (
                         saved_out_shape is not None
                         and saved_out_shape != fake_out.shape
@@ -2401,14 +2431,21 @@ For now, dynamo will explicitly graph break when it encounters user code with th
                         )
             else:
                 assert out_kwarg_vt is not None and out_kwarg_vt.is_tensor()
-                assert "example_value" in out_kwarg_vt.as_proxy().node.meta
-                fake_out = out_kwarg_vt.as_proxy().node.meta["example_value"]
-                if (
-                    saved_out_versions is not None
-                    and fake_out._version > saved_out_versions
-                ):
+                if saved_out_shapes is None:
+                    if tensor_variable.is_tensor():
+                        out_kwarg_vt.proxy = tensor_variable.as_proxy()  # type: ignore[attr-defined]
                     out_kwarg_vt.synchronize_attributes(tx)  # type: ignore[attr-defined]
+                else:
+                    assert "example_value" in out_kwarg_vt.as_proxy().node.meta
                     fake_out = out_kwarg_vt.as_proxy().node.meta["example_value"]
+                    if (
+                        saved_out_versions is not None
+                        and fake_out._version > saved_out_versions
+                    ):
+                        out_kwarg_vt.synchronize_attributes(tx)  # type: ignore[attr-defined]
+                fake_out = out_kwarg_vt.as_proxy().node.meta["example_value"]
+                if saved_out_shapes is not None and tensor_variable.is_tensor():
+                    fake_out = tensor_variable.as_proxy().node.meta["example_value"]
                 if saved_out_shapes is not None and saved_out_shapes != fake_out.shape:
                     # It's hard to get out variants with resizing on graph inputs work
                     # properly across dynamo/aot/inductor, just fall back.

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -2240,24 +2240,20 @@ For now, dynamo will explicitly graph break when it encounters user code with th
         # defined `@allow_in_graph` function as well, which doesn't have the
         # same semantics as the torch ops.
 
-        # Calling fake tensor propagation can mutate the out= tensor in
-        # tx.output.tracked_fakes. tracked_fakes are used to apply
-        # symbolic_shape guards. Mutating them destroys the information
-        # prior to tracing, which is essential for creating right
-        # guards. So only out tensors whose current fake is itself tracked
-        # save their shape for a later graph-break check; local/intermediate
-        # out tensors are handled after fake propagation instead.
+        # Calling fake tensor propagation can mutate graph-input out= tensors.
+        # Mutating their fake metadata destroys the pre-call shape information
+        # needed for the conservative graph-break path, so only out tensors
+        # backed by actual graphargs save their shape for a later check.
+        # Local/intermediate out tensors are handled after fake propagation
+        # instead.
         saved_out_shapes = None
         saved_out_versions = None
         out_kwarg_vt = None
         if "out" in kwargs:
             out_kwarg_vt = kwargs["out"]
 
-            def should_guard_out_shape(fake_out: object) -> bool:
-                return any(
-                    tracked_fake.fake is fake_out
-                    for tracked_fake in tx.output.tracked_fakes
-                )
+            def should_guard_out_shape(out_vt: VariableTracker) -> bool:
+                return out_vt.as_proxy().node.meta.get("grapharg") is not None
 
             # e.g., out=(t1, t2, ...)
             if isinstance(out_kwarg_vt, (TupleVariable, ListVariable)):
@@ -2266,9 +2262,7 @@ For now, dynamo will explicitly graph break when it encounters user code with th
                 for vt in out_kwarg_vt.items:
                     if vt.is_tensor():
                         fake_out = vt.as_proxy().node.meta["example_value"]
-                        shape = (
-                            fake_out.shape if should_guard_out_shape(fake_out) else None
-                        )
+                        shape = fake_out.shape if should_guard_out_shape(vt) else None
                         version = fake_out._version
                     else:
                         shape = None
@@ -2280,7 +2274,7 @@ For now, dynamo will explicitly graph break when it encounters user code with th
             if out_kwarg_vt.is_tensor():
                 fake_out = out_kwarg_vt.as_proxy().node.meta["example_value"]
                 saved_out_shapes = (
-                    fake_out.shape if should_guard_out_shape(fake_out) else None
+                    fake_out.shape if should_guard_out_shape(out_kwarg_vt) else None
                 )
                 saved_out_versions = fake_out._version
 

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -2349,51 +2349,28 @@ For now, dynamo will explicitly graph break when it encounters user code with th
             #
             # For guard-tracked `out=` tensors, we still take the conservative
             # approach and graph break on size changes. For local/intermediate
-            # `out=` tensors, prefer the returned proxy when the op produces
-            # one, but still handle custom ops that mutate `out` and return
-            # None by synchronizing the original VT metadata.
+            # `out=` tensors, fake propagation mutates the existing fake tensor
+            # in place, so synchronize the original VT metadata afterward.
             #
             # Note that although these tensor variables would hold different
             # metadata after fake propagation, the in-place mutation semantics
             # is preserved in the FX graph, so we won't have correctness issues.
             if isinstance(saved_out_shapes, list):
-                result_out_vts = (
-                    tensor_variable.items
-                    if isinstance(
-                        tensor_variable,
-                        (TupleVariable, ListVariable, NamedTupleVariable),
-                    )
-                    else [None] * len(saved_out_shapes)
-                )
-                for (
-                    out_tensor_vt,
-                    result_out_vt,
-                    saved_out_shape,
-                    saved_out_version,
-                ) in zip(
+                for out_tensor_vt, saved_out_shape, saved_out_version in zip(
                     out_kwarg_vt.items,  # type: ignore[union-attr]
-                    result_out_vts,
                     saved_out_shapes,
                     saved_out_versions,  # type: ignore[arg-type]
                 ):
                     if not out_tensor_vt.is_tensor():
                         continue
 
-                    if saved_out_shape is None:
-                        if result_out_vt is not None and result_out_vt.is_tensor():
-                            out_tensor_vt.proxy = (  # type: ignore[attr-defined]
-                                result_out_vt.as_proxy()
-                            )
-                        out_tensor_vt.synchronize_attributes(tx)  # type: ignore[attr-defined]
-                    else:
-                        fake_out = out_tensor_vt.as_proxy().node.meta["example_value"]
-                        if (
-                            saved_out_version is not None
-                            and fake_out._version > saved_out_version
-                        ):
-                            out_tensor_vt.synchronize_attributes(tx)  # type: ignore[attr-defined]
-
                     fake_out = out_tensor_vt.as_proxy().node.meta["example_value"]
+                    if (
+                        saved_out_version is not None
+                        and fake_out._version > saved_out_version
+                    ):
+                        out_tensor_vt.synchronize_attributes(tx)  # type: ignore[attr-defined]
+                        fake_out = out_tensor_vt.as_proxy().node.meta["example_value"]
                     if (
                         saved_out_shape is not None
                         and saved_out_shape != fake_out.shape
@@ -2424,19 +2401,14 @@ For now, dynamo will explicitly graph break when it encounters user code with th
                         )
             else:
                 assert out_kwarg_vt is not None and out_kwarg_vt.is_tensor()
-                if saved_out_shapes is None:
-                    if tensor_variable.is_tensor():
-                        out_kwarg_vt.proxy = tensor_variable.as_proxy()  # type: ignore[attr-defined]
-                    out_kwarg_vt.synchronize_attributes(tx)  # type: ignore[attr-defined]
-                else:
-                    assert "example_value" in out_kwarg_vt.as_proxy().node.meta
-                    fake_out = out_kwarg_vt.as_proxy().node.meta["example_value"]
-                    if (
-                        saved_out_versions is not None
-                        and fake_out._version > saved_out_versions
-                    ):
-                        out_kwarg_vt.synchronize_attributes(tx)  # type: ignore[attr-defined]
+                assert "example_value" in out_kwarg_vt.as_proxy().node.meta
                 fake_out = out_kwarg_vt.as_proxy().node.meta["example_value"]
+                if (
+                    saved_out_versions is not None
+                    and fake_out._version > saved_out_versions
+                ):
+                    out_kwarg_vt.synchronize_attributes(tx)  # type: ignore[attr-defined]
+                    fake_out = out_kwarg_vt.as_proxy().node.meta["example_value"]
                 if saved_out_shapes is not None and saved_out_shapes != fake_out.shape:
                     # It's hard to get out variants with resizing on graph inputs work
                     # properly across dynamo/aot/inductor, just fall back.

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -2354,37 +2354,28 @@ For now, dynamo will explicitly graph break when it encounters user code with th
             #
             # For source-tracked `out=` tensors, we still take the conservative
             # approach and graph break on size changes. For local/intermediate
-            # `out=` tensors, reproxify the passed tensor VTs to the returned
-            # result so subsequent reads see the updated value/metadata.
+            # `out=` tensors, synchronize metadata from the fake tensor after
+            # propagation, while preserving the existing contiguity checks.
             #
             # Note that although these tensor variables would hold different
             # proxies, the in-place mutation semantics is preserved in the FX
             # graph, so we won't have correctness issues.
             if isinstance(saved_out_shapes, list):
-                assert isinstance(
-                    tensor_variable, (TupleVariable, ListVariable, NamedTupleVariable)
-                )
-                for out_tensor_vt, result_out_vt, saved_out_shape, saved_out_version in zip(
+                for out_tensor_vt, saved_out_shape, saved_out_version in zip(
                     out_kwarg_vt.items,  # type: ignore[union-attr]
-                    tensor_variable.items,
                     saved_out_shapes,
                     saved_out_versions,  # type: ignore[arg-type]
                 ):
-                    if saved_out_shape is None:
-                        if not out_tensor_vt.is_tensor() or not result_out_vt.is_tensor():
-                            continue
-                        out_tensor_vt.proxy = result_out_vt.proxy  # type: ignore[attr-defined]
-                        out_tensor_vt.synchronize_attributes(tx)  # type: ignore[attr-defined]
+                    if not out_tensor_vt.is_tensor():
                         continue
 
-                    assert out_tensor_vt.is_tensor()
                     fake_out = out_tensor_vt.proxy.node.meta["example_value"]
                     if (
                         saved_out_version is not None
                         and fake_out._version > saved_out_version
                     ):
                         out_tensor_vt.synchronize_attributes(tx)  # type: ignore[attr-defined]
-                    if saved_out_shape != fake_out.shape:
+                    if saved_out_shape is not None and saved_out_shape != fake_out.shape:
                         # It's hard to get out variants with resizing on graph inputs work
                         # properly across dynamo/aot/inductor, just fall back.
                         unimplemented(
@@ -2411,40 +2402,35 @@ For now, dynamo will explicitly graph break when it encounters user code with th
                         )
             else:
                 assert out_kwarg_vt is not None and out_kwarg_vt.is_tensor()
-                if saved_out_shapes is None:
-                    assert tensor_variable.is_tensor()
-                    out_kwarg_vt.proxy = tensor_variable.proxy  # type: ignore[attr-defined]
+                assert "example_value" in out_kwarg_vt.as_proxy().node.meta
+                fake_out = out_kwarg_vt.as_proxy().node.meta["example_value"]
+                if fake_out._version > saved_out_versions:
                     out_kwarg_vt.synchronize_attributes(tx)  # type: ignore[attr-defined]
-                else:
-                    assert "example_value" in out_kwarg_vt.as_proxy().node.meta
-                    fake_out = out_kwarg_vt.as_proxy().node.meta["example_value"]
-                    if fake_out._version > saved_out_versions:
-                        out_kwarg_vt.synchronize_attributes(tx)  # type: ignore[attr-defined]
-                    if saved_out_shapes != fake_out.shape:
-                        # It's hard to get out variants with resizing on graph inputs work
-                        # properly across dynamo/aot/inductor, just fall back.
-                        unimplemented(
-                            gb_type="Shape mismatch with out= tensor variant",
-                            context=f"fn={self.value}, args={args}, kwargs={kwargs}",
-                            explanation=(
-                                f"Shape mismatch when calling {self.value} with `out=`. "
-                                f"Provided `out=` shape: {saved_out_shapes}. Actual shape: {fake_out.shape}."
-                            ),
-                            hints=[
-                                *graph_break_hints.SUPPORTABLE,
-                            ],
-                        )
-                    if not torch._prims_common.is_contiguous_or_false(fake_out):
-                        # It's difficult to handle strides correctly in functionalization
-                        # when calling an out= op with a non-contiguous out argument
-                        unimplemented(
-                            gb_type="Attempted to call op with non-contiguous `out=` tensor",
-                            context=f"self.value={self.value}, args={args}, kwargs={kwargs}",
-                            explanation="Dynamo does not support this.",
-                            hints=[
-                                *graph_break_hints.SUPPORTABLE,
-                            ],
-                        )
+                if saved_out_shapes is not None and saved_out_shapes != fake_out.shape:
+                    # It's hard to get out variants with resizing on graph inputs work
+                    # properly across dynamo/aot/inductor, just fall back.
+                    unimplemented(
+                        gb_type="Shape mismatch with out= tensor variant",
+                        context=f"fn={self.value}, args={args}, kwargs={kwargs}",
+                        explanation=(
+                            f"Shape mismatch when calling {self.value} with `out=`. "
+                            f"Provided `out=` shape: {saved_out_shapes}. Actual shape: {fake_out.shape}."
+                        ),
+                        hints=[
+                            *graph_break_hints.SUPPORTABLE,
+                        ],
+                    )
+                if not torch._prims_common.is_contiguous_or_false(fake_out):
+                    # It's difficult to handle strides correctly in functionalization
+                    # when calling an out= op with a non-contiguous out argument
+                    unimplemented(
+                        gb_type="Attempted to call op with non-contiguous `out=` tensor",
+                        context=f"self.value={self.value}, args={args}, kwargs={kwargs}",
+                        explanation="Dynamo does not support this.",
+                        hints=[
+                            *graph_break_hints.SUPPORTABLE,
+                        ],
+                    )
 
         return tensor_variable
 

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -2384,7 +2384,10 @@ For now, dynamo will explicitly graph break when it encounters user code with th
                         continue
 
                     if saved_out_shape is None:
+                        # Local/intermediate `out=` tensors skip shape guards,
+                        # but they still need the contiguity check below.
                         out_tensor_vt.synchronize_attributes(tx)  # type: ignore[attr-defined]
+                        fake_out = out_tensor_vt.as_proxy().node.meta["example_value"]
                     else:
                         fake_out = out_tensor_vt.as_proxy().node.meta["example_value"]
                         if (
@@ -2392,17 +2395,10 @@ For now, dynamo will explicitly graph break when it encounters user code with th
                             and fake_out._version > saved_out_version
                         ):
                             out_tensor_vt.synchronize_attributes(tx)  # type: ignore[attr-defined]
-                    fake_out = out_tensor_vt.as_proxy().node.meta["example_value"]
-                    if (
-                        saved_out_shape is not None
-                        and result_out_vt is not None
-                        and result_out_vt.is_tensor()
-                    ):
-                        fake_out = result_out_vt.as_proxy().node.meta["example_value"]
-                    if (
-                        saved_out_shape is not None
-                        and saved_out_shape != fake_out.shape
-                    ):
+                            fake_out = out_tensor_vt.as_proxy().node.meta["example_value"]
+                        if result_out_vt is not None and result_out_vt.is_tensor():
+                            fake_out = result_out_vt.as_proxy().node.meta["example_value"]
+                    if saved_out_shape is not None and saved_out_shape != fake_out.shape:
                         # It's hard to get out variants with resizing on graph inputs work
                         # properly across dynamo/aot/inductor, just fall back.
                         unimplemented(

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -2380,58 +2380,56 @@ For now, dynamo will explicitly graph break when it encounters user code with th
                     saved_out_shapes,
                     saved_out_versions,  # type: ignore[arg-type]
                 ):
-                    if not out_tensor_vt.is_tensor():
-                        continue
-
-                    fake_out = out_tensor_vt.as_proxy().node.meta["example_value"]
-                    should_sync_out = saved_out_shape is None or (
-                        saved_out_version is not None
-                        and fake_out._version > saved_out_version
-                    )
-                    if should_sync_out:
-                        out_tensor_vt.synchronize_attributes(tx)  # type: ignore[attr-defined]
+                    if out_tensor_vt.is_tensor():
                         fake_out = out_tensor_vt.as_proxy().node.meta["example_value"]
+                        should_sync_out = saved_out_shape is None or (
+                            saved_out_version is not None
+                            and fake_out._version > saved_out_version
+                        )
+                        if should_sync_out:
+                            out_tensor_vt.synchronize_attributes(tx)  # type: ignore[attr-defined]
+                            fake_out = out_tensor_vt.as_proxy().node.meta["example_value"]
 
-                    # Local/intermediate `out=` tensors skip only the resize
-                    # guard; they still flow through the shared contiguity
-                    # safeguard below.
-                    resize_checked_fake_out = fake_out
-                    if (
-                        saved_out_shape is not None
-                        and result_out_vt is not None
-                        and result_out_vt.is_tensor()
-                    ):
-                        resize_checked_fake_out = result_out_vt.as_proxy().node.meta[
-                            "example_value"
-                        ]
-                    if (
-                        saved_out_shape is not None
-                        and saved_out_shape != resize_checked_fake_out.shape
-                    ):
-                        # It's hard to get out variants with resizing on graph inputs work
-                        # properly across dynamo/aot/inductor, just fall back.
-                        unimplemented(
-                            gb_type="Shape mismatch with out= list of tensor variants",
-                            context=f"fn={self.value}, args={args}, kwargs={kwargs}",
-                            explanation=(
-                                f"Shape mismatch when calling {self.value} with `out=`. "
-                                f"Provided `out=` shape: {saved_out_shape}. Actual shape: {resize_checked_fake_out.shape}."
-                            ),
-                            hints=[
-                                *graph_break_hints.SUPPORTABLE,
-                            ],
-                        )
-                    if not torch._prims_common.is_contiguous(fake_out):
-                        # It's difficult to handle strides correctly in functionalization
-                        # when calling an out= op with a non-contiguous out argument
-                        unimplemented(
-                            gb_type="Attempted to call op with non-contiguous `out=` list of tensors",
-                            context=f"self.value={self.value}, args={args}, kwargs={kwargs}",
-                            explanation="Dynamo does not support this.",
-                            hints=[
-                                *graph_break_hints.SUPPORTABLE,
-                            ],
-                        )
+                        # Local/intermediate `out=` tensors skip only the resize
+                        # guard; they still flow through the shared contiguity
+                        # safeguard below.
+                        resize_checked_fake_out = fake_out
+                        if (
+                            saved_out_shape is not None
+                            and result_out_vt is not None
+                            and result_out_vt.is_tensor()
+                        ):
+                            resize_checked_fake_out = result_out_vt.as_proxy().node.meta[
+                                "example_value"
+                            ]
+                        if (
+                            saved_out_shape is not None
+                            and saved_out_shape != resize_checked_fake_out.shape
+                        ):
+                            # It's hard to get out variants with resizing on graph inputs work
+                            # properly across dynamo/aot/inductor, just fall back.
+                            unimplemented(
+                                gb_type="Shape mismatch with out= list of tensor variants",
+                                context=f"fn={self.value}, args={args}, kwargs={kwargs}",
+                                explanation=(
+                                    f"Shape mismatch when calling {self.value} with `out=`. "
+                                    f"Provided `out=` shape: {saved_out_shape}. Actual shape: {resize_checked_fake_out.shape}."
+                                ),
+                                hints=[
+                                    *graph_break_hints.SUPPORTABLE,
+                                ],
+                            )
+                        if not torch._prims_common.is_contiguous(fake_out):
+                            # It's difficult to handle strides correctly in functionalization
+                            # when calling an out= op with a non-contiguous out argument
+                            unimplemented(
+                                gb_type="Attempted to call op with non-contiguous `out=` list of tensors",
+                                context=f"self.value={self.value}, args={args}, kwargs={kwargs}",
+                                explanation="Dynamo does not support this.",
+                                hints=[
+                                    *graph_break_hints.SUPPORTABLE,
+                                ],
+                            )
             else:
                 assert out_kwarg_vt is not None and out_kwarg_vt.is_tensor()
                 if saved_out_shapes is None:

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -2384,31 +2384,29 @@ For now, dynamo will explicitly graph break when it encounters user code with th
                         continue
 
                     fake_out = out_tensor_vt.as_proxy().node.meta["example_value"]
-                    if saved_out_shape is None:
-                        # Local/intermediate `out=` tensors skip only the resize
-                        # guard; they still flow through the shared contiguity
-                        # safeguard below.
-                        out_tensor_vt.synchronize_attributes(tx)  # type: ignore[attr-defined]
-                        fake_out = out_tensor_vt.as_proxy().node.meta["example_value"]
-                    elif (
+                    should_sync_out = saved_out_shape is None or (
                         saved_out_version is not None
                         and fake_out._version > saved_out_version
-                    ):
+                    )
+                    if should_sync_out:
                         out_tensor_vt.synchronize_attributes(tx)  # type: ignore[attr-defined]
                         fake_out = out_tensor_vt.as_proxy().node.meta["example_value"]
 
-                    shape_checked_fake_out = fake_out
+                    # Local/intermediate `out=` tensors skip only the resize
+                    # guard; they still flow through the shared contiguity
+                    # safeguard below.
+                    resize_checked_fake_out = fake_out
                     if (
                         saved_out_shape is not None
                         and result_out_vt is not None
                         and result_out_vt.is_tensor()
                     ):
-                        shape_checked_fake_out = result_out_vt.as_proxy().node.meta[
+                        resize_checked_fake_out = result_out_vt.as_proxy().node.meta[
                             "example_value"
                         ]
                     if (
                         saved_out_shape is not None
-                        and saved_out_shape != shape_checked_fake_out.shape
+                        and saved_out_shape != resize_checked_fake_out.shape
                     ):
                         # It's hard to get out variants with resizing on graph inputs work
                         # properly across dynamo/aot/inductor, just fall back.
@@ -2417,7 +2415,7 @@ For now, dynamo will explicitly graph break when it encounters user code with th
                             context=f"fn={self.value}, args={args}, kwargs={kwargs}",
                             explanation=(
                                 f"Shape mismatch when calling {self.value} with `out=`. "
-                                f"Provided `out=` shape: {saved_out_shape}. Actual shape: {shape_checked_fake_out.shape}."
+                                f"Provided `out=` shape: {saved_out_shape}. Actual shape: {resize_checked_fake_out.shape}."
                             ),
                             hints=[
                                 *graph_break_hints.SUPPORTABLE,

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -2246,7 +2246,7 @@ For now, dynamo will explicitly graph break when it encounters user code with th
         # prior to tracing, which is essential for creating right
         # guards. So only source-tracked out tensors save their shape
         # for a later graph-break check; local/intermediate out tensors
-        # only need their metadata synchronized after fake propagation.
+        # are reproxied to the returned result after fake propagation.
         saved_out_shapes = None
         saved_out_versions = None
         out_kwarg_vt = None
@@ -2354,21 +2354,30 @@ For now, dynamo will explicitly graph break when it encounters user code with th
             #
             # For source-tracked `out=` tensors, we still take the conservative
             # approach and graph break on size changes. For local/intermediate
-            # `out=` tensors, synchronize metadata from the fake tensor after
-            # propagation, while preserving the existing contiguity checks.
+            # `out=` tensors, reproxify the passed tensor VTs to the returned
+            # result so subsequent reads see the updated value/metadata.
             #
             # Note that although these tensor variables would hold different
             # proxies, the in-place mutation semantics is preserved in the FX
             # graph, so we won't have correctness issues.
             if isinstance(saved_out_shapes, list):
-                for out_tensor_vt, saved_out_shape, saved_out_version in zip(
+                assert isinstance(
+                    tensor_variable, (TupleVariable, ListVariable, NamedTupleVariable)
+                )
+                for out_tensor_vt, result_out_vt, saved_out_shape, saved_out_version in zip(
                     out_kwarg_vt.items,  # type: ignore[union-attr]
+                    tensor_variable.items,
                     saved_out_shapes,
                     saved_out_versions,  # type: ignore[arg-type]
                 ):
-                    if not out_tensor_vt.is_tensor():
+                    if saved_out_shape is None:
+                        if not out_tensor_vt.is_tensor() or not result_out_vt.is_tensor():
+                            continue
+                        out_tensor_vt.proxy = result_out_vt.proxy  # type: ignore[attr-defined]
+                        out_tensor_vt.synchronize_attributes(tx)  # type: ignore[attr-defined]
                         continue
 
+                    assert out_tensor_vt.is_tensor()
                     fake_out = out_tensor_vt.proxy.node.meta["example_value"]
                     if (
                         saved_out_version is not None
@@ -2402,24 +2411,30 @@ For now, dynamo will explicitly graph break when it encounters user code with th
                         )
             else:
                 assert out_kwarg_vt is not None and out_kwarg_vt.is_tensor()
-                assert "example_value" in out_kwarg_vt.as_proxy().node.meta
-                fake_out = out_kwarg_vt.as_proxy().node.meta["example_value"]
-                if fake_out._version > saved_out_versions:
+                if saved_out_shapes is None:
+                    assert tensor_variable.is_tensor()
+                    out_kwarg_vt.proxy = tensor_variable.proxy  # type: ignore[attr-defined]
                     out_kwarg_vt.synchronize_attributes(tx)  # type: ignore[attr-defined]
-                if saved_out_shapes is not None and saved_out_shapes != fake_out.shape:
-                    # It's hard to get out variants with resizing on graph inputs work
-                    # properly across dynamo/aot/inductor, just fall back.
-                    unimplemented(
-                        gb_type="Shape mismatch with out= tensor variant",
-                        context=f"fn={self.value}, args={args}, kwargs={kwargs}",
-                        explanation=(
-                            f"Shape mismatch when calling {self.value} with `out=`. "
-                            f"Provided `out=` shape: {saved_out_shapes}. Actual shape: {fake_out.shape}."
-                        ),
-                        hints=[
-                            *graph_break_hints.SUPPORTABLE,
-                        ],
-                    )
+                    fake_out = out_kwarg_vt.as_proxy().node.meta["example_value"]
+                else:
+                    assert "example_value" in out_kwarg_vt.as_proxy().node.meta
+                    fake_out = out_kwarg_vt.as_proxy().node.meta["example_value"]
+                    if fake_out._version > saved_out_versions:
+                        out_kwarg_vt.synchronize_attributes(tx)  # type: ignore[attr-defined]
+                    if saved_out_shapes != fake_out.shape:
+                        # It's hard to get out variants with resizing on graph inputs work
+                        # properly across dynamo/aot/inductor, just fall back.
+                        unimplemented(
+                            gb_type="Shape mismatch with out= tensor variant",
+                            context=f"fn={self.value}, args={args}, kwargs={kwargs}",
+                            explanation=(
+                                f"Shape mismatch when calling {self.value} with `out=`. "
+                                f"Provided `out=` shape: {saved_out_shapes}. Actual shape: {fake_out.shape}."
+                            ),
+                            hints=[
+                                *graph_break_hints.SUPPORTABLE,
+                            ],
+                        )
                 if not torch._prims_common.is_contiguous_or_false(fake_out):
                     # It's difficult to handle strides correctly in functionalization
                     # when calling an out= op with a non-contiguous out argument

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -2385,9 +2385,11 @@ For now, dynamo will explicitly graph break when it encounters user code with th
 
                     if saved_out_shape is None:
                         # Local/intermediate `out=` tensors skip shape guards,
-                        # but they still need the contiguity check below.
+                        # but they still flow into the shared contiguity check.
                         out_tensor_vt.synchronize_attributes(tx)  # type: ignore[attr-defined]
-                        fake_out = out_tensor_vt.as_proxy().node.meta["example_value"]
+                        fake_out = out_tensor_vt.as_proxy().node.meta[
+                            "example_value"
+                        ]
                     else:
                         fake_out = out_tensor_vt.as_proxy().node.meta["example_value"]
                         if (
@@ -2395,10 +2397,17 @@ For now, dynamo will explicitly graph break when it encounters user code with th
                             and fake_out._version > saved_out_version
                         ):
                             out_tensor_vt.synchronize_attributes(tx)  # type: ignore[attr-defined]
-                            fake_out = out_tensor_vt.as_proxy().node.meta["example_value"]
+                            fake_out = out_tensor_vt.as_proxy().node.meta[
+                                "example_value"
+                            ]
                         if result_out_vt is not None and result_out_vt.is_tensor():
-                            fake_out = result_out_vt.as_proxy().node.meta["example_value"]
-                    if saved_out_shape is not None and saved_out_shape != fake_out.shape:
+                            fake_out = result_out_vt.as_proxy().node.meta[
+                                "example_value"
+                            ]
+                    if (
+                        saved_out_shape is not None
+                        and saved_out_shape != fake_out.shape
+                    ):
                         # It's hard to get out variants with resizing on graph inputs work
                         # properly across dynamo/aot/inductor, just fall back.
                         unimplemented(

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -2244,28 +2244,44 @@ For now, dynamo will explicitly graph break when it encounters user code with th
         # tx.output.tracked_fakes. tracked_fakes are used to apply
         # symbolic_shape guards. Mutating them destroys the information
         # prior to tracing, which is essential for creating right
-        # guards. So save the shape now, and check later if it has
-        # changed. If it has, graph break.
+        # guards. So only source-tracked out tensors save their shape
+        # for a later graph-break check; local/intermediate out tensors
+        # only need their metadata synchronized after fake propagation.
         saved_out_shapes = None
+        saved_out_versions = None
         out_kwarg_vt = None
         if "out" in kwargs:
             out_kwarg_vt = kwargs["out"]
 
+            def should_guard_out_shape(out_vt: VariableTracker) -> bool:
+                source = out_vt.source
+                return source is not None and any(
+                    tracked_fake.source == source
+                    for tracked_fake in tx.output.tracked_fakes
+                )
+
             # e.g., out=(t1, t2, ...)
             if isinstance(out_kwarg_vt, (TupleVariable, ListVariable)):
                 saved_out_shapes = []
+                saved_out_versions = []
                 for vt in out_kwarg_vt.items:
                     if vt.is_tensor():
-                        shape = vt.as_proxy().node.meta["example_value"].shape
+                        fake_out = vt.as_proxy().node.meta["example_value"]
+                        shape = fake_out.shape if should_guard_out_shape(vt) else None
+                        version = fake_out._version
                     else:
                         shape = None
+                        version = None
                     saved_out_shapes.append(shape)
+                    saved_out_versions.append(version)
 
             # e.g., out=output_tensor
             if out_kwarg_vt.is_tensor():
+                fake_out = out_kwarg_vt.as_proxy().node.meta["example_value"]
                 saved_out_shapes = (
-                    out_kwarg_vt.as_proxy().node.meta["example_value"].shape
+                    fake_out.shape if should_guard_out_shape(out_kwarg_vt) else None
                 )
+                saved_out_versions = fake_out._version
 
         # Ops that consume scalar values from tensors (via .item()) for computation only,
         # not for output shapes. When capture_scalar_outputs is enabled, these ops would
@@ -2332,7 +2348,7 @@ For now, dynamo will explicitly graph break when it encounters user code with th
             )
 
         # Handle e.g., `torch.add(a, b, out=result)`
-        if saved_out_shapes is not None:
+        if saved_out_versions is not None:
             # out variants of torch operators like torch.sort and torch.sigmoid
             # mutate the tensors in the out field.
             #
@@ -2345,18 +2361,32 @@ For now, dynamo will explicitly graph break when it encounters user code with th
             # proxies, the in-place mutation semantics is preserved in the FX
             # graph, so we won't have correctness issues.
             if isinstance(saved_out_shapes, list):
-                for out_tensor_vt, saved_out_shape in zip(
+                for out_tensor_vt, saved_out_shape, saved_out_version in zip(
                     out_kwarg_vt.items,  # type: ignore[union-attr]
                     saved_out_shapes,
+                    saved_out_versions,  # type: ignore[arg-type]
                 ):
                     if saved_out_shape is None:
-                        # This should be extremely rare, but it's kept for now
-                        # until we invest in enforcing the `out=` kwarg for only
-                        # torch methods.
+                        # This out tensor is not shape-guarded, but it may still
+                        # need its metadata synchronized if fake propagation
+                        # resized it in place.
+                        if not out_tensor_vt.is_tensor():
+                            continue
+                        fake_out = out_tensor_vt.proxy.node.meta["example_value"]
+                        if (
+                            saved_out_version is not None
+                            and fake_out._version > saved_out_version
+                        ):
+                            out_tensor_vt.synchronize_attributes(tx)  # type: ignore[attr-defined]
                         continue
 
                     assert out_tensor_vt.is_tensor()
                     fake_out = out_tensor_vt.proxy.node.meta["example_value"]
+                    if (
+                        saved_out_version is not None
+                        and fake_out._version > saved_out_version
+                    ):
+                        out_tensor_vt.synchronize_attributes(tx)  # type: ignore[attr-defined]
                     if saved_out_shape != fake_out.shape:
                         # It's hard to get out variants with resizing on graph inputs work
                         # properly across dynamo/aot/inductor, just fall back.
@@ -2386,7 +2416,9 @@ For now, dynamo will explicitly graph break when it encounters user code with th
                 assert out_kwarg_vt is not None and out_kwarg_vt.is_tensor()
                 assert "example_value" in out_kwarg_vt.as_proxy().node.meta
                 fake_out = out_kwarg_vt.as_proxy().node.meta["example_value"]
-                if saved_out_shapes != fake_out.shape:
+                if fake_out._version > saved_out_versions:
+                    out_kwarg_vt.synchronize_attributes(tx)  # type: ignore[attr-defined]
+                if saved_out_shapes is not None and saved_out_shapes != fake_out.shape:
                     # It's hard to get out variants with resizing on graph inputs work
                     # properly across dynamo/aot/inductor, just fall back.
                     unimplemented(

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -2361,22 +2361,8 @@ For now, dynamo will explicitly graph break when it encounters user code with th
             # metadata after fake propagation, the in-place mutation semantics
             # is preserved in the FX graph, so we won't have correctness issues.
             if isinstance(saved_out_shapes, list):
-                result_out_vts = (
-                    tensor_variable.items
-                    if isinstance(
-                        tensor_variable,
-                        (TupleVariable, ListVariable, NamedTupleVariable),
-                    )
-                    else [None] * len(saved_out_shapes)
-                )
-                for (
-                    out_tensor_vt,
-                    result_out_vt,
-                    saved_out_shape,
-                    saved_out_version,
-                ) in zip(
+                for out_tensor_vt, saved_out_shape, saved_out_version in zip(
                     out_kwarg_vt.items,  # type: ignore[union-attr]
-                    result_out_vts,
                     saved_out_shapes,
                     saved_out_versions,  # type: ignore[arg-type]
                 ):
@@ -2390,21 +2376,13 @@ For now, dynamo will explicitly graph break when it encounters user code with th
                             out_tensor_vt.synchronize_attributes(tx)  # type: ignore[attr-defined]
                             fake_out = out_tensor_vt.as_proxy().node.meta["example_value"]
 
-                        # Local/intermediate `out=` tensors skip only the resize
-                        # guard; they still flow through the shared contiguity
-                        # safeguard below.
-                        resize_checked_fake_out = fake_out
+                        # Keep resize and contiguity checks attached to the
+                        # actual `out=` slots. `@allow_in_graph` and other
+                        # custom callables can mutate `out=` but return
+                        # something that does not mirror that container.
                         if (
                             saved_out_shape is not None
-                            and result_out_vt is not None
-                            and result_out_vt.is_tensor()
-                        ):
-                            resize_checked_fake_out = result_out_vt.as_proxy().node.meta[
-                                "example_value"
-                            ]
-                        if (
-                            saved_out_shape is not None
-                            and saved_out_shape != resize_checked_fake_out.shape
+                            and saved_out_shape != fake_out.shape
                         ):
                             # It's hard to get out variants with resizing on graph inputs work
                             # properly across dynamo/aot/inductor, just fall back.
@@ -2413,7 +2391,7 @@ For now, dynamo will explicitly graph break when it encounters user code with th
                                 context=f"fn={self.value}, args={args}, kwargs={kwargs}",
                                 explanation=(
                                     f"Shape mismatch when calling {self.value} with `out=`. "
-                                    f"Provided `out=` shape: {saved_out_shape}. Actual shape: {resize_checked_fake_out.shape}."
+                                    f"Provided `out=` shape: {saved_out_shape}. Actual shape: {fake_out.shape}."
                                 ),
                                 hints=[
                                     *graph_break_hints.SUPPORTABLE,
@@ -2443,8 +2421,6 @@ For now, dynamo will explicitly graph break when it encounters user code with th
                     ):
                         out_kwarg_vt.synchronize_attributes(tx)  # type: ignore[attr-defined]
                 fake_out = out_kwarg_vt.as_proxy().node.meta["example_value"]
-                if saved_out_shapes is not None and tensor_variable.is_tensor():
-                    fake_out = tensor_variable.as_proxy().node.meta["example_value"]
                 if saved_out_shapes is not None and saved_out_shapes != fake_out.shape:
                     # It's hard to get out variants with resizing on graph inputs work
                     # properly across dynamo/aot/inductor, just fall back.

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -2354,31 +2354,22 @@ For now, dynamo will explicitly graph break when it encounters user code with th
             #
             # For source-tracked `out=` tensors, we still take the conservative
             # approach and graph break on size changes. For local/intermediate
-            # `out=` tensors, reproxify the passed tensor VTs to the returned
-            # result so subsequent reads see the updated value/metadata.
+            # `out=` tensors, fake propagation mutates the existing fake tensor
+            # in place, so synchronize the original VT metadata afterward.
             #
             # Note that although these tensor variables would hold different
-            # proxies, the in-place mutation semantics is preserved in the FX
-            # graph, so we won't have correctness issues.
+            # metadata after fake propagation, the in-place mutation semantics
+            # is preserved in the FX graph, so we won't have correctness issues.
             if isinstance(saved_out_shapes, list):
-                assert isinstance(
-                    tensor_variable, (TupleVariable, ListVariable, NamedTupleVariable)
-                )
-                for out_tensor_vt, result_out_vt, saved_out_shape, saved_out_version in zip(
+                for out_tensor_vt, saved_out_shape, saved_out_version in zip(
                     out_kwarg_vt.items,  # type: ignore[union-attr]
-                    tensor_variable.items,
                     saved_out_shapes,
                     saved_out_versions,  # type: ignore[arg-type]
                 ):
-                    if saved_out_shape is None:
-                        if not out_tensor_vt.is_tensor() or not result_out_vt.is_tensor():
-                            continue
-                        out_tensor_vt.proxy = result_out_vt.proxy  # type: ignore[attr-defined]
-                        out_tensor_vt.synchronize_attributes(tx)  # type: ignore[attr-defined]
+                    if not out_tensor_vt.is_tensor():
                         continue
 
-                    assert out_tensor_vt.is_tensor()
-                    fake_out = out_tensor_vt.proxy.node.meta["example_value"]
+                    fake_out = out_tensor_vt.as_proxy().node.meta["example_value"]
                     if (
                         saved_out_version is not None
                         and fake_out._version > saved_out_version
@@ -2411,30 +2402,24 @@ For now, dynamo will explicitly graph break when it encounters user code with th
                         )
             else:
                 assert out_kwarg_vt is not None and out_kwarg_vt.is_tensor()
-                if saved_out_shapes is None:
-                    assert tensor_variable.is_tensor()
-                    out_kwarg_vt.proxy = tensor_variable.proxy  # type: ignore[attr-defined]
+                assert "example_value" in out_kwarg_vt.as_proxy().node.meta
+                fake_out = out_kwarg_vt.as_proxy().node.meta["example_value"]
+                if fake_out._version > saved_out_versions:
                     out_kwarg_vt.synchronize_attributes(tx)  # type: ignore[attr-defined]
-                    fake_out = out_kwarg_vt.as_proxy().node.meta["example_value"]
-                else:
-                    assert "example_value" in out_kwarg_vt.as_proxy().node.meta
-                    fake_out = out_kwarg_vt.as_proxy().node.meta["example_value"]
-                    if fake_out._version > saved_out_versions:
-                        out_kwarg_vt.synchronize_attributes(tx)  # type: ignore[attr-defined]
-                    if saved_out_shapes != fake_out.shape:
-                        # It's hard to get out variants with resizing on graph inputs work
-                        # properly across dynamo/aot/inductor, just fall back.
-                        unimplemented(
-                            gb_type="Shape mismatch with out= tensor variant",
-                            context=f"fn={self.value}, args={args}, kwargs={kwargs}",
-                            explanation=(
-                                f"Shape mismatch when calling {self.value} with `out=`. "
-                                f"Provided `out=` shape: {saved_out_shapes}. Actual shape: {fake_out.shape}."
-                            ),
-                            hints=[
-                                *graph_break_hints.SUPPORTABLE,
-                            ],
-                        )
+                if saved_out_shapes is not None and saved_out_shapes != fake_out.shape:
+                    # It's hard to get out variants with resizing on graph inputs work
+                    # properly across dynamo/aot/inductor, just fall back.
+                    unimplemented(
+                        gb_type="Shape mismatch with out= tensor variant",
+                        context=f"fn={self.value}, args={args}, kwargs={kwargs}",
+                        explanation=(
+                            f"Shape mismatch when calling {self.value} with `out=`. "
+                            f"Provided `out=` shape: {saved_out_shapes}. Actual shape: {fake_out.shape}."
+                        ),
+                        hints=[
+                            *graph_break_hints.SUPPORTABLE,
+                        ],
+                    )
                 if not torch._prims_common.is_contiguous_or_false(fake_out):
                     # It's difficult to handle strides correctly in functionalization
                     # when calling an out= op with a non-contiguous out argument

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -2244,19 +2244,18 @@ For now, dynamo will explicitly graph break when it encounters user code with th
         # tx.output.tracked_fakes. tracked_fakes are used to apply
         # symbolic_shape guards. Mutating them destroys the information
         # prior to tracing, which is essential for creating right
-        # guards. So only source-tracked out tensors save their shape
-        # for a later graph-break check; local/intermediate out tensors
-        # are reproxied to the returned result after fake propagation.
+        # guards. So only out tensors whose current fake is itself tracked
+        # save their shape for a later graph-break check; local/intermediate
+        # out tensors are handled after fake propagation instead.
         saved_out_shapes = None
         saved_out_versions = None
         out_kwarg_vt = None
         if "out" in kwargs:
             out_kwarg_vt = kwargs["out"]
 
-            def should_guard_out_shape(out_vt: VariableTracker) -> bool:
-                source = out_vt.source
-                return source is not None and any(
-                    tracked_fake.source == source
+            def should_guard_out_shape(fake_out: object) -> bool:
+                return any(
+                    tracked_fake.fake is fake_out
                     for tracked_fake in tx.output.tracked_fakes
                 )
 
@@ -2267,7 +2266,9 @@ For now, dynamo will explicitly graph break when it encounters user code with th
                 for vt in out_kwarg_vt.items:
                     if vt.is_tensor():
                         fake_out = vt.as_proxy().node.meta["example_value"]
-                        shape = fake_out.shape if should_guard_out_shape(vt) else None
+                        shape = (
+                            fake_out.shape if should_guard_out_shape(fake_out) else None
+                        )
                         version = fake_out._version
                     else:
                         shape = None
@@ -2279,7 +2280,7 @@ For now, dynamo will explicitly graph break when it encounters user code with th
             if out_kwarg_vt.is_tensor():
                 fake_out = out_kwarg_vt.as_proxy().node.meta["example_value"]
                 saved_out_shapes = (
-                    fake_out.shape if should_guard_out_shape(out_kwarg_vt) else None
+                    fake_out.shape if should_guard_out_shape(fake_out) else None
                 )
                 saved_out_versions = fake_out._version
 
@@ -2352,7 +2353,7 @@ For now, dynamo will explicitly graph break when it encounters user code with th
             # out variants of torch operators like torch.sort and torch.sigmoid
             # mutate the tensors in the out field.
             #
-            # For source-tracked `out=` tensors, we still take the conservative
+            # For guard-tracked `out=` tensors, we still take the conservative
             # approach and graph break on size changes. For local/intermediate
             # `out=` tensors, prefer the returned proxy when the op produces
             # one, but still handle custom ops that mutate `out` and return
@@ -2387,7 +2388,7 @@ For now, dynamo will explicitly graph break when it encounters user code with th
                     if saved_out_shape is None:
                         if result_out_vt is not None and result_out_vt.is_tensor():
                             out_tensor_vt.proxy = (  # type: ignore[attr-defined]
-                                result_out_vt.proxy
+                                result_out_vt.as_proxy()
                             )
                         out_tensor_vt.synchronize_attributes(tx)  # type: ignore[attr-defined]
                     else:
@@ -2431,7 +2432,7 @@ For now, dynamo will explicitly graph break when it encounters user code with th
                 assert out_kwarg_vt is not None and out_kwarg_vt.is_tensor()
                 if saved_out_shapes is None:
                     if tensor_variable.is_tensor():
-                        out_kwarg_vt.proxy = tensor_variable.proxy  # type: ignore[attr-defined]
+                        out_kwarg_vt.proxy = tensor_variable.as_proxy()  # type: ignore[attr-defined]
                     out_kwarg_vt.synchronize_attributes(tx)  # type: ignore[attr-defined]
                 else:
                     assert "example_value" in out_kwarg_vt.as_proxy().node.meta

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -2354,28 +2354,55 @@ For now, dynamo will explicitly graph break when it encounters user code with th
             #
             # For source-tracked `out=` tensors, we still take the conservative
             # approach and graph break on size changes. For local/intermediate
-            # `out=` tensors, fake propagation mutates the existing fake tensor
-            # in place, so synchronize the original VT metadata afterward.
+            # `out=` tensors, prefer the returned proxy when the op produces
+            # one, but still handle custom ops that mutate `out` and return
+            # None by synchronizing the original VT metadata.
             #
             # Note that although these tensor variables would hold different
             # metadata after fake propagation, the in-place mutation semantics
             # is preserved in the FX graph, so we won't have correctness issues.
             if isinstance(saved_out_shapes, list):
-                for out_tensor_vt, saved_out_shape, saved_out_version in zip(
+                result_out_vts = (
+                    tensor_variable.items
+                    if isinstance(
+                        tensor_variable,
+                        (TupleVariable, ListVariable, NamedTupleVariable),
+                    )
+                    else [None] * len(saved_out_shapes)
+                )
+                for (
+                    out_tensor_vt,
+                    result_out_vt,
+                    saved_out_shape,
+                    saved_out_version,
+                ) in zip(
                     out_kwarg_vt.items,  # type: ignore[union-attr]
+                    result_out_vts,
                     saved_out_shapes,
                     saved_out_versions,  # type: ignore[arg-type]
                 ):
                     if not out_tensor_vt.is_tensor():
                         continue
 
+                    if saved_out_shape is None:
+                        if result_out_vt is not None and result_out_vt.is_tensor():
+                            out_tensor_vt.proxy = (  # type: ignore[attr-defined]
+                                result_out_vt.proxy
+                            )
+                        out_tensor_vt.synchronize_attributes(tx)  # type: ignore[attr-defined]
+                    else:
+                        fake_out = out_tensor_vt.as_proxy().node.meta["example_value"]
+                        if (
+                            saved_out_version is not None
+                            and fake_out._version > saved_out_version
+                        ):
+                            out_tensor_vt.synchronize_attributes(tx)  # type: ignore[attr-defined]
+
                     fake_out = out_tensor_vt.as_proxy().node.meta["example_value"]
                     if (
-                        saved_out_version is not None
-                        and fake_out._version > saved_out_version
+                        saved_out_shape is not None
+                        and saved_out_shape != fake_out.shape
                     ):
-                        out_tensor_vt.synchronize_attributes(tx)  # type: ignore[attr-defined]
-                    if saved_out_shape is not None and saved_out_shape != fake_out.shape:
                         # It's hard to get out variants with resizing on graph inputs work
                         # properly across dynamo/aot/inductor, just fall back.
                         unimplemented(
@@ -2402,10 +2429,19 @@ For now, dynamo will explicitly graph break when it encounters user code with th
                         )
             else:
                 assert out_kwarg_vt is not None and out_kwarg_vt.is_tensor()
-                assert "example_value" in out_kwarg_vt.as_proxy().node.meta
-                fake_out = out_kwarg_vt.as_proxy().node.meta["example_value"]
-                if fake_out._version > saved_out_versions:
+                if saved_out_shapes is None:
+                    if tensor_variable.is_tensor():
+                        out_kwarg_vt.proxy = tensor_variable.proxy  # type: ignore[attr-defined]
                     out_kwarg_vt.synchronize_attributes(tx)  # type: ignore[attr-defined]
+                else:
+                    assert "example_value" in out_kwarg_vt.as_proxy().node.meta
+                    fake_out = out_kwarg_vt.as_proxy().node.meta["example_value"]
+                    if (
+                        saved_out_versions is not None
+                        and fake_out._version > saved_out_versions
+                    ):
+                        out_kwarg_vt.synchronize_attributes(tx)  # type: ignore[attr-defined]
+                fake_out = out_kwarg_vt.as_proxy().node.meta["example_value"]
                 if saved_out_shapes is not None and saved_out_shapes != fake_out.shape:
                     # It's hard to get out variants with resizing on graph inputs work
                     # properly across dynamo/aot/inductor, just fall back.

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -2383,30 +2383,32 @@ For now, dynamo will explicitly graph break when it encounters user code with th
                     if not out_tensor_vt.is_tensor():
                         continue
 
+                    fake_out = out_tensor_vt.as_proxy().node.meta["example_value"]
                     if saved_out_shape is None:
-                        # Local/intermediate `out=` tensors skip shape guards,
-                        # but they still flow into the shared contiguity check.
+                        # Local/intermediate `out=` tensors skip only the resize
+                        # guard; they still flow through the shared contiguity
+                        # safeguard below.
                         out_tensor_vt.synchronize_attributes(tx)  # type: ignore[attr-defined]
-                        fake_out = out_tensor_vt.as_proxy().node.meta[
-                            "example_value"
-                        ]
-                    else:
                         fake_out = out_tensor_vt.as_proxy().node.meta["example_value"]
-                        if (
-                            saved_out_version is not None
-                            and fake_out._version > saved_out_version
-                        ):
-                            out_tensor_vt.synchronize_attributes(tx)  # type: ignore[attr-defined]
-                            fake_out = out_tensor_vt.as_proxy().node.meta[
-                                "example_value"
-                            ]
-                        if result_out_vt is not None and result_out_vt.is_tensor():
-                            fake_out = result_out_vt.as_proxy().node.meta[
-                                "example_value"
-                            ]
+                    elif (
+                        saved_out_version is not None
+                        and fake_out._version > saved_out_version
+                    ):
+                        out_tensor_vt.synchronize_attributes(tx)  # type: ignore[attr-defined]
+                        fake_out = out_tensor_vt.as_proxy().node.meta["example_value"]
+
+                    shape_checked_fake_out = fake_out
                     if (
                         saved_out_shape is not None
-                        and saved_out_shape != fake_out.shape
+                        and result_out_vt is not None
+                        and result_out_vt.is_tensor()
+                    ):
+                        shape_checked_fake_out = result_out_vt.as_proxy().node.meta[
+                            "example_value"
+                        ]
+                    if (
+                        saved_out_shape is not None
+                        and saved_out_shape != shape_checked_fake_out.shape
                     ):
                         # It's hard to get out variants with resizing on graph inputs work
                         # properly across dynamo/aot/inductor, just fall back.
@@ -2415,7 +2417,7 @@ For now, dynamo will explicitly graph break when it encounters user code with th
                             context=f"fn={self.value}, args={args}, kwargs={kwargs}",
                             explanation=(
                                 f"Shape mismatch when calling {self.value} with `out=`. "
-                                f"Provided `out=` shape: {saved_out_shape}. Actual shape: {fake_out.shape}."
+                                f"Provided `out=` shape: {saved_out_shape}. Actual shape: {shape_checked_fake_out.shape}."
                             ),
                             hints=[
                                 *graph_break_hints.SUPPORTABLE,

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -2353,7 +2353,7 @@ For now, dynamo will explicitly graph break when it encounters user code with th
             #
             # For guard-tracked `out=` tensors, we still take the conservative
             # approach and graph break on size changes. In fullgraph mode,
-            # local/intermediate `out=` tensors instead update their original
+            # local/intermediate `out=` tensors instead refresh their original
             # VTs after fake propagation so later local uses see the resized
             # metadata without graph breaking.
             #
@@ -2384,8 +2384,6 @@ For now, dynamo will explicitly graph break when it encounters user code with th
                         continue
 
                     if saved_out_shape is None:
-                        if result_out_vt is not None and result_out_vt.is_tensor():
-                            out_tensor_vt.proxy = result_out_vt.as_proxy()  # type: ignore[attr-defined]
                         out_tensor_vt.synchronize_attributes(tx)  # type: ignore[attr-defined]
                     else:
                         fake_out = out_tensor_vt.as_proxy().node.meta["example_value"]
@@ -2432,8 +2430,6 @@ For now, dynamo will explicitly graph break when it encounters user code with th
             else:
                 assert out_kwarg_vt is not None and out_kwarg_vt.is_tensor()
                 if saved_out_shapes is None:
-                    if tensor_variable.is_tensor():
-                        out_kwarg_vt.proxy = tensor_variable.as_proxy()  # type: ignore[attr-defined]
                     out_kwarg_vt.synchronize_attributes(tx)  # type: ignore[attr-defined]
                 else:
                     assert "example_value" in out_kwarg_vt.as_proxy().node.meta


### PR DESCRIPTION
Fix #111580

## Summary

### Root cause
Dynamo treated every `out=` tensor resize as a guarded input mutation. For local/intermediate `out` tensors, fake propagation still resized the tensor, but the post-trace shape mismatch fallback forced a graph break even though those tensors are not used to generate shape guards.

### Proposed fix
Limit the resize shape-mismatch fallback to source-tracked `out=` tensors that participate in shape guards, and resynchronize local/intermediate `out=` tensor metadata after fake propagation mutates them in place. Add a regression test for the dynamic `torch.diff(..., n=0, out=...)` fullgraph repro.

### Why this is the right long term fix
This keeps the existing conservative behavior for shape-guarded `out=` tensors while fixing the safe local-tensor case that regressed. It also updates Dynamo's local tensor metadata directly, which is the actual missing bookkeeping needed for later uses of the resized `out` tensor inside the same graph.

Drafted via @codex, published after manual review by @bobrenjc93

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo