### PR TITLE
fix(func): raise explicit error for grad/vjp/jvp in inference_mode

### DIFF
--- a/test/functorch/test_eager_transforms.py
+++ b/test/functorch/test_eager_transforms.py
@@ -1174,6 +1174,52 @@ class TestGradTransform(TestCase):
         ft.pop_dynamic_layer_stack_and_undo_to_depth(0)
         self.assertEqual(ft.get_dynamic_layer_stack_depth(), 0)
 
+    def test_inference_mode_gradient_transforms(self, device):
+        def h(x):
+            return x**2
+
+        def g(x):
+            return x.sum()
+
+        @torch._dynamo.disable
+        def run_jvp():
+            with torch.inference_mode():
+                jvp(h, (x,), (ones,))
+
+        @torch._dynamo.disable
+        def run_grad():
+            with torch.inference_mode():
+                grad(g)(x)
+
+        @torch._dynamo.disable
+        def run_vjp():
+            with torch.inference_mode():
+                vjp(h, x)
+
+        err_msg = "not supported in torch.inference_mode()"
+        x = torch.randn(3, device=device)
+        ones = torch.ones(3, device=device)
+
+        with self.assertRaisesRegex(RuntimeError, err_msg):
+            run_jvp()
+
+        with self.assertRaisesRegex(RuntimeError, err_msg):
+            run_grad()
+
+        with self.assertRaisesRegex(RuntimeError, err_msg):
+            run_vjp()
+
+        with torch.inference_mode(False):
+            _, jvp_result = jvp(h, (x,), (ones,))
+            self.assertTrue(torch.allclose(jvp_result, 2 * x))
+
+            grad_result = grad(g)(x)
+            self.assertTrue(torch.allclose(grad_result, ones))
+
+            _, vjp_fn = vjp(h, x)
+            vjp_result = vjp_fn(ones)[0]
+            self.assertTrue(torch.allclose(vjp_result, 2 * x))
+
 
 @markDynamoStrictTest
 class TestAutogradFunction(TestCase):

--- a/torch/csrc/functorch/init.cpp
+++ b/torch/csrc/functorch/init.cpp
@@ -19,6 +19,7 @@
 #include <ATen/functorch/PlumbingHelper.h>
 #include <ATen/functorch/TensorWrapper.h>
 #include <c10/core/AutogradState.h>
+#include <c10/core/InferenceMode.h>
 
 #include <iostream>
 
@@ -243,7 +244,17 @@ static RandomnessType get_randomness_enum(const std::string& randomness) {
   }
 }
 
+static void check_inference_mode() {
+  if (c10::InferenceMode::is_enabled()) {
+    TORCH_CHECK(
+        false,
+        "torch.func.{grad, vjp, jvp} are not supported in torch.inference_mode(). ",
+        "Please exit inference_mode before calling these transforms, as autograd is required for differentiation.");
+  }
+}
+
 static int64_t _grad_increment_nesting() {
+  check_inference_mode();
   // See NOTE [grad and vjp interaction with no_grad]
   bool prev_grad_mode = c10::GradMode::is_enabled();
   return initAndPushDynamicLayer(
@@ -251,12 +262,14 @@ static int64_t _grad_increment_nesting() {
 }
 
 static int64_t _grad_decrement_nesting() {
+  check_inference_mode();
   auto layer = popDynamicLayerAndDeleteMetadata();
   TORCH_INTERNAL_ASSERT(layer.key() == TransformType::Grad);
   return layer.layerId();
 }
 
 static int64_t _jvp_increment_nesting() {
+  check_inference_mode();
   // See NOTE [grad and vjp interaction with no_grad]
   bool prev_fwd_grad_mode =
       c10::AutogradState::get_tls_state().get_fw_grad_mode();
@@ -269,6 +282,7 @@ static int64_t _jvp_increment_nesting() {
 }
 
 static int64_t _jvp_decrement_nesting() {
+  check_inference_mode();
   auto layer = popDynamicLayerAndDeleteMetadata();
   TORCH_INTERNAL_ASSERT(layer.key() == TransformType::Jvp);
   return layer.layerId();


### PR DESCRIPTION
## Summary
Prevent `torch.func.{grad, vjp, jvp}` from silently returning incorrect zero results when called under `torch.inference_mode()` by raising an explicit error.

## What does this PR do?
### Background
Currently, gradient transforms (grad/vjp/jvp) in `torch.func` fail silently (return zeros) when run in `inference_mode()`:
- Root cause: `inference_mode()` excludes autograd dispatch keys from TLS, and functorch's internal `enable_grad()` does not undo this exclusion
- This behavior is unsafe (hard to debug) and inconsistent with PyTorch's "fail fast" philosophy

### Solution
Add a check at the C++ entry of `grad`/`vjp`/`jvp` transforms:
1. Detect if the current context is `inference_mode()` (via `c10::InferenceMode::is_enabled()`)
2. Raise a `TORCH_CHECK` with clear error message if true (instead of silent failure)
3. Error message example: 
   `torch.func.{grad, vjp, jvp} are not supported in torch.inference_mode(). 
     Please exit inference_mode before calling these transforms, as autograd is required for differentiation.`

### Rationale
- `inference_mode()` is explicitly designed for non-differentiable inference workloads — allowing gradient transforms to run here is semantically inconsistent
- Explicit error > silent failure: aligns with PyTorch's design principles and avoids hard-to-debug user issues
- Consistent with existing handling of `no_grad()` (functorch already handles `no_grad()` correctly, this extends the same "fail fast" logic to `inference_mode()`)

## Test Plan
### Unit Test
- Unit test for `grad`/`vjp`/`jvp` under `inference_mode()`: verify that an error is raised (not zeros returned) and whether results are correct without inference_mode()
- Test location: `test/functorch/test_eager_transforms.py`
- add new test function named `test_inference_mode_gradient_transforms` in class `TestGradTransform`

### User Test
<img width="945" height="118" alt="result" src="https://github.com/user-attachments/assets/bdb05c53-d442-4596-ae95-906f0f0d29b1" />

## Related Issues
Fixes #177318