### PR TITLE
[ROCm] Skip test_cublas_addmm_no_reduced_precision

### DIFF
--- a/test/test_matmul_cuda.py
+++ b/test/test_matmul_cuda.py
@@ -250,6 +250,7 @@ class TestMatmulCuda(InductorTestCase):
 
 
     @onlyCUDA
+    @skipIfRocm(msg="ROCm doesn't support allow_fp16_reduced_precision_reduction flag")
     @dtypes(torch.float16)
     # m == 4 chooses OUTPUT_TYPE reduction on H200
     # m == 8 chooses OUTPUT_TYPE reduction on A100


### PR DESCRIPTION
The `allow_fp16_reduced_precision_reduction` flag is not defined for rocm in https://github.com/pytorch/pytorch/blob/a15c26b59c02fc34f37a693846601733385ea5f4/aten/src/ATen/cuda/CUDABlas.cpp#L1151-L1170 (xref https://rocm.docs.amd.com/en/latest/compatibility/ml-compatibility/pytorch-compatibility.html#known-issues-and-notes-for-pytorch-2-7-2-8-with-rocm-7-0-and-rocm-7-1) which leads to fp16 accumulate precision errors in the cublas_addmm_no_reduced_precision test:

```
test_matmul_cuda.py::TestMatmulCudaCUDA::test_cublas_addmm_no_reduced_precision_small_size_4_size_32768_backend_cublas_cuda_float16 - AssertionError: Scalars are not close!
2026-03-06T22:17:35.2428321Z
2026-03-06T22:17:35.2428419Z Expected 0.0 but got -0.0625.
2026-03-06T22:17:35.2428533Z Absolute difference: 0.0625 (up to 1e-05 allowed)
2026-03-06T22:17:35.2428610Z Relative difference: inf (up to 1.3e-06 allowed)
```

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang