### PR TITLE
Fix: Correct attn_mask shape documentation in scaled_dot_product_attention

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -6071,7 +6071,7 @@ scaled_dot_product_attention = _add_docstr(
         key (Tensor): Key tensor; shape :math:`(N, ..., H, S, E)`.
         value (Tensor): Value tensor; shape :math:`(N, ..., H, S, Ev)`.
         attn_mask (optional Tensor): Attention mask; shape must be broadcastable to the shape of attention weights,
-            which is :math:`(N,..., L, S)`. Two types of masks are supported.
+            which is :math:`(N, ..., Hq, L, S)`. Two types of masks are supported.
             A boolean mask where a value of True indicates that the element *should* take part in attention.
             A float mask of the same type as query, key, value that is added to the attention score.
         dropout_p (float): Dropout probability; if greater than 0.0, dropout is applied


### PR DESCRIPTION
## Summary
This PR fixes the `attn_mask` shape documentation for `torch.nn.functional.scaled_dot_product_attention`.

The docstring previously said the attention mask must be broadcastable to `(N, ..., L, S)`, which omits the query head dimension.

Updated it to:
- `(N, ..., Hq, L, S)`

where `Hq` is the number of query heads, matching the actual attention weights shape and expected usage.

Fixes #177482

## Notes
- Docs-only change
- No code behavior changes
- No tests required for this update
