### PR TITLE
[Inductor] Preserve float truncation when materializing scalar tensors

### DIFF
--- a/test/inductor/test_codegen_triton.py
+++ b/test/inductor/test_codegen_triton.py
@@ -170,6 +170,12 @@ class TestCodegenTriton(InductorTestCase):
             integer_expr,
         )
 
+        predicate_expr = sympy.Eq(trunc_expr, sympy.Integer(9007199254740993))
+        self.assertEqual(
+            _materialize_trunc_to_float_expr(predicate_expr, torch.float64),
+            predicate_expr,
+        )
+
         float_expr = sympy.Float(0.5) + trunc_expr
         self.assertEqual(
             _materialize_trunc_to_float_expr(float_expr, torch.float64),

--- a/test/inductor/test_codegen_triton.py
+++ b/test/inductor/test_codegen_triton.py
@@ -7,12 +7,16 @@ import torch
 import torch._inductor.config as inductor_config
 from torch._inductor.codegen import triton_utils
 from torch._inductor.codegen.common import CSEVariable, SizeArg
-from torch._inductor.codegen.triton import TritonKernelOverrides
+from torch._inductor.codegen.triton import (
+    _materialize_trunc_to_float_expr,
+    TritonKernelOverrides,
+)
 from torch._inductor.dtype_propagation import DtypePropagationOpsHandler, promote_types
 from torch._inductor.graph import GraphLowering
 from torch._inductor.test_case import TestCase as InductorTestCase
 from torch._inductor.virtualized import V
 from torch.testing._internal.inductor_utils import HAS_CPU, HAS_GPU
+from torch.utils._sympy.functions import FloorDiv, TruncToFloat, TruncToInt
 from torch.utils._sympy.value_ranges import ValueRanges
 
 
@@ -149,6 +153,27 @@ class TestCodegenTriton(InductorTestCase):
         self.assertEqual(
             TestTritonKernelOverrides.pow(3, exponent),
             "triton_helpers.pow_integer(custom_constant(3, torch.uint32), ks0)",
+        )
+
+    def test_materialize_trunc_to_float_expr_preserves_integer_subexpressions(self):
+        s0 = sympy.Symbol("s0")
+
+        trunc_expr = TruncToInt(s0)
+        self.assertEqual(
+            _materialize_trunc_to_float_expr(trunc_expr, torch.float64),
+            TruncToFloat(s0),
+        )
+
+        integer_expr = FloorDiv(trunc_expr, sympy.Integer(5))
+        self.assertEqual(
+            _materialize_trunc_to_float_expr(integer_expr, torch.float64),
+            integer_expr,
+        )
+
+        float_expr = sympy.Float(0.5) + trunc_expr
+        self.assertEqual(
+            _materialize_trunc_to_float_expr(float_expr, torch.float64),
+            sympy.Float(0.5) + TruncToFloat(s0),
         )
 
 

--- a/test/inductor/test_unbacked_symints.py
+++ b/test/inductor/test_unbacked_symints.py
@@ -723,6 +723,23 @@ class TestUnbackedSymints(InductorTestCase):
     @skipCPUIf(True, "Triton codegen bug only affects GPU")
     @skipGPUIf(not HAS_GPU, "requires gpu and triton")
     @dynamo_config.patch({"capture_scalar_outputs": True})
+    def test_triton_trunc_large_float_scalar_tensor(self, device):
+        import math
+
+        def fn(x):
+            r = math.sqrt(x.size(0))
+            r = r**70
+            return torch.tensor(math.trunc(r), dtype=torch.float64, device=device)
+
+        example_inputs = (torch.randn(4, device=device),)
+        torch._dynamo.mark_dynamic(example_inputs[0], 0)
+        actual = torch.compile(fn, fullgraph=True, dynamic=True)(*example_inputs)
+        expected = fn(*example_inputs)
+        torch.testing.assert_close(actual, expected)
+
+    @skipCPUIf(True, "Triton codegen bug only affects GPU")
+    @skipGPUIf(not HAS_GPU, "requires gpu and triton")
+    @dynamo_config.patch({"capture_scalar_outputs": True})
     def test_triton_pow_symbolic_int_exponent(self, device):
         """
         Test that symbolic integer scalar exponents are cast before libdevice.pow.

--- a/test/inductor/test_unbacked_symints.py
+++ b/test/inductor/test_unbacked_symints.py
@@ -740,6 +740,24 @@ class TestUnbackedSymints(InductorTestCase):
     @skipCPUIf(True, "Triton codegen bug only affects GPU")
     @skipGPUIf(not HAS_GPU, "requires gpu and triton")
     @dynamo_config.patch({"capture_scalar_outputs": True})
+    def test_triton_trunc_float_scalar_tensor_preserves_positive_zero(self, device):
+        import math
+
+        def fn(x):
+            r = math.sqrt(x.size(0)) - 2.5
+            return torch.signbit(
+                torch.tensor(math.trunc(r), dtype=torch.float64, device=device)
+            )
+
+        example_inputs = (torch.randn(4, device=device),)
+        torch._dynamo.mark_dynamic(example_inputs[0], 0)
+        actual = torch.compile(fn, fullgraph=True, dynamic=True)(*example_inputs)
+        expected = fn(*example_inputs)
+        self.assertEqual(actual, expected)
+
+    @skipCPUIf(True, "Triton codegen bug only affects GPU")
+    @skipGPUIf(not HAS_GPU, "requires gpu and triton")
+    @dynamo_config.patch({"capture_scalar_outputs": True})
     def test_triton_pow_symbolic_int_exponent(self, device):
         """
         Test that symbolic integer scalar exponents are cast before libdevice.pow.

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -181,17 +181,23 @@ def _materialize_trunc_to_float_expr(
     if expr.func is TruncToInt:
         return TruncToFloat(*expr.args)
 
+    def is_predicate_expr(node: sympy.Basic) -> bool:
+        return bool(
+            getattr(node, "is_Boolean", False)
+            or getattr(node, "is_Relational", False)
+        )
+
     def rewrite_float_subexpr(node: sympy.Expr) -> sympy.Expr:
         if not node.has(TruncToInt):
             return node
         if node.func is TruncToInt:
             return TruncToFloat(*node.args)
-        if getattr(node, "is_Boolean", False) or node.is_integer:
+        if is_predicate_expr(node) or node.is_integer:
             return node
 
         new_args = tuple(
             rewrite_float_subexpr(arg)
-            if isinstance(arg, sympy.Expr) and not getattr(arg, "is_Boolean", False)
+            if isinstance(arg, sympy.Expr) and not is_predicate_expr(arg)
             else arg
             for arg in node.args
         )

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -176,8 +176,8 @@ def _materialize_trunc_to_float_expr(
     # into floating tensors. Casting to the kernel index dtype first can
     # overflow before the requested floating-point conversion happens. Only
     # rewrite truncations that are already participating in floating-point
-    # computation; integer subexpressions must keep exact integer semantics
-    # until the final materialization cast.
+    # computation; integer subexpressions and predicates must keep exact
+    # integer semantics until the final materialization cast.
     if expr.func is TruncToInt:
         return TruncToFloat(*expr.args)
 
@@ -186,11 +186,13 @@ def _materialize_trunc_to_float_expr(
             return node
         if node.func is TruncToInt:
             return TruncToFloat(*node.args)
-        if node.is_integer:
+        if getattr(node, "is_Boolean", False) or node.is_integer:
             return node
 
         new_args = tuple(
-            rewrite_float_subexpr(arg) if isinstance(arg, sympy.Expr) else arg
+            rewrite_float_subexpr(arg)
+            if isinstance(arg, sympy.Expr) and not getattr(arg, "is_Boolean", False)
+            else arg
             for arg in node.args
         )
         if new_args == node.args:

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -183,8 +183,7 @@ def _materialize_trunc_to_float_expr(
 
     def is_predicate_expr(node: sympy.Basic) -> bool:
         return bool(
-            getattr(node, "is_Boolean", False)
-            or getattr(node, "is_Relational", False)
+            getattr(node, "is_Boolean", False) or getattr(node, "is_Relational", False)
         )
 
     def rewrite_float_subexpr(node: sympy.Expr) -> sympy.Expr:

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -810,8 +810,11 @@ class TritonPrinter(PythonPrinter):  # noqa: docstring_linter
 
     def _print_TruncToFloat(self, expr: sympy.Expr) -> str:
         assert len(expr.args) == 1
+        value = self._print(expr.args[0])
+        # Adding +0.0 preserves large floating results while canonicalizing
+        # libdevice.trunc(-0.0) back to Python's +0.0 materialization behavior.
         # pyrefly: ignore [missing-attribute]
-        return f"libdevice.trunc({self._print(expr.args[0])})"
+        return f"(libdevice.trunc({value}) + tl.zeros_like({value}))"
 
     def _print_Float(self, expr: sympy.Expr) -> str:
         if expr.is_integer:

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -28,7 +28,13 @@ from torch._dynamo.device_interface import get_interface_for_device
 from torch._dynamo.utils import identity, preserve_rng_state
 from torch._prims_common import is_integer_dtype, type_to_dtype
 from torch.utils._ordered_set import OrderedSet
-from torch.utils._sympy.functions import CeilDiv, FloorDiv, ModularIndexing
+from torch.utils._sympy.functions import (
+    CeilDiv,
+    FloorDiv,
+    ModularIndexing,
+    TruncToFloat,
+    TruncToInt,
+)
 from torch.utils._triton import (
     get_triton_version,
     has_triton_package,
@@ -157,6 +163,20 @@ def is_sympy_integer_like(expr: object):
         return False
     return isinstance(expr, sympy.Integer) or (
         expr.is_integer and len(expr.free_symbols) == 0
+    )
+
+
+def _materialize_trunc_to_float_expr(
+    expr: sympy.Expr, dtype: torch.dtype
+) -> sympy.Expr:
+    if not dtype.is_floating_point or not expr.has(TruncToInt):
+        return expr
+
+    # Preserve float truncation semantics when materializing symbolic scalars
+    # into floating tensors. Casting to the kernel index dtype first can
+    # overflow before the requested floating-point conversion happens.
+    return expr.xreplace(
+        {node: TruncToFloat(*node.args) for node in expr.atoms(TruncToInt)}
     )
 
 
@@ -767,6 +787,11 @@ class TritonPrinter(PythonPrinter):  # noqa: docstring_linter
             # pyrefly: ignore [missing-attribute]
             f"libdevice.trunc({self._print(expr.args[0])}).to({V.kernel.index_dtype})"
         )
+
+    def _print_TruncToFloat(self, expr: sympy.Expr) -> str:
+        assert len(expr.args) == 1
+        # pyrefly: ignore [missing-attribute]
+        return f"libdevice.trunc({self._print(expr.args[0])})"
 
     def _print_Float(self, expr: sympy.Expr) -> str:
         if expr.is_integer:
@@ -1956,6 +1981,7 @@ class TritonKernelOverrides(TritonOverrides):
 
     @classmethod
     def index_expr(cls, expr, dtype):
+        expr = _materialize_trunc_to_float_expr(expr, dtype)
         indexing = V.kernel.indexing(
             expr, block_ptr=False, tma_compatibility_checker=None
         )

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -810,6 +810,7 @@ class TritonPrinter(PythonPrinter):  # noqa: docstring_linter
 
     def _print_TruncToFloat(self, expr: sympy.Expr) -> str:
         assert len(expr.args) == 1
+        # pyrefly: ignore [missing-attribute]
         value = self._print(expr.args[0])
         # Adding +0.0 preserves large floating results while canonicalizing
         # libdevice.trunc(-0.0) back to Python's +0.0 materialization behavior.

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -174,10 +174,30 @@ def _materialize_trunc_to_float_expr(
 
     # Preserve float truncation semantics when materializing symbolic scalars
     # into floating tensors. Casting to the kernel index dtype first can
-    # overflow before the requested floating-point conversion happens.
-    return expr.xreplace(
-        {node: TruncToFloat(*node.args) for node in expr.atoms(TruncToInt)}
-    )
+    # overflow before the requested floating-point conversion happens. Only
+    # rewrite truncations that are already participating in floating-point
+    # computation; integer subexpressions must keep exact integer semantics
+    # until the final materialization cast.
+    if expr.func is TruncToInt:
+        return TruncToFloat(*expr.args)
+
+    def rewrite_float_subexpr(node: sympy.Expr) -> sympy.Expr:
+        if not node.has(TruncToInt):
+            return node
+        if node.func is TruncToInt:
+            return TruncToFloat(*node.args)
+        if node.is_integer:
+            return node
+
+        new_args = tuple(
+            rewrite_float_subexpr(arg) if isinstance(arg, sympy.Expr) else arg
+            for arg in node.args
+        )
+        if new_args == node.args:
+            return node
+        return node.func(*new_args)
+
+    return rewrite_float_subexpr(expr)
 
 
 class OpDtypeSupport:


### PR DESCRIPTION
## Summary
Fix #126537

### Root cause
When Triton materializes a symbolic `math.trunc(...)` result into a floating scalar tensor, `index_expr` still lowers `TruncToInt` through the kernel index dtype first. Large values can overflow there before the requested floating-point cast happens.

### Proposed fix
Rewrite `TruncToInt` to `TruncToFloat` when Triton `index_expr` is materializing a floating-point dtype, and teach the Triton SymPy printer to emit `TruncToFloat` with `libdevice.trunc(...)`. Add a regression test for the reported dynamic-shape reproducer.

### Why this is the right long term fix
This keeps true integer/indexing codegen unchanged while making floating scalar materialization respect the requested output dtype instead of an incidental kernel index dtype. That matches the semantics of `torch.tensor(..., dtype=torch.float64)` and removes the overflow at the point it is introduced.

## Testing
- `python3 -m compileall torch/_inductor/codegen/triton.py test/inductor/test_unbacked_symints.py`

Drafted via @codex, published after manual review by @bobrenjc93

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo