### PR TITLE
[export] Fix dynamic-shape SDPA mask alignment

### DIFF
--- a/aten/src/ATen/native/transformers/attention.cpp
+++ b/aten/src/ATen/native/transformers/attention.cpp
@@ -550,30 +550,50 @@ std::optional<Tensor> convert_boolean_attn_mask(const std::optional<Tensor>& att
 }
 
 // Memory Efficient Attention requires aligned non-last strides for its bias.
-// We preserve the visible mask shape and copy it into fresh storage whose row
-// stride is rounded up to the requested alignment.
+// Two alignment strategies are used:
+//  1. pad_bias (pad + slice): used when strides are concrete. The slice view
+//     preserves aligned strides through autograd/inductor backward graphs.
+//  2. copy_to_aligned_bias (empty_strided + copy): used when strides are
+//     symbolic. The pad-and-slice approach creates modulo-dependent stride
+//     expressions that export turns into unsatisfiable shape guards, so we
+//     use an aligned-stride copy instead.
 
 template <int alignment>
 c10::SymInt round_up_to_multiple(const c10::SymInt& size) {
   return ((size + (alignment - 1)) / alignment) * alignment;
 }
 
+enum class AlignStatus { Aligned, ConcreteUnaligned, SymbolicUnaligned };
+
 template<int alignment>
-bool aligned_tensor(const at::Tensor& tensor){
+AlignStatus check_alignment(const at::Tensor& tensor){
   for(const auto i : c10::irange(tensor.dim() - 1)){
     auto stride = tensor.sym_stride(i).maybe_as_int();
-    // If the stride is unknown at compilation time, route through the
-    // aligned-copy path instead of guarding on the concrete alignment.
     if (!stride)
-      return false;
+      return AlignStatus::SymbolicUnaligned;
 
     if((*stride) % alignment != 0){
-      return false;
+      return AlignStatus::ConcreteUnaligned;
     }
   }
-  return tensor.sym_stride(-1) == 1;
+  if (tensor.sym_stride(-1) != 1)
+    return AlignStatus::ConcreteUnaligned;
+  return AlignStatus::Aligned;
 }
 
+// Pad the last dim to a multiple of alignment and slice back to the original
+// size. The resulting view has aligned strides that are preserved through
+// autograd and inductor backward graphs.
+template <int alignment>
+at::Tensor pad_bias(const at::Tensor& attn_bias) {
+  auto last_dim_size = attn_bias.sym_size(-1);
+  auto pad_count = alignment - (last_dim_size % alignment);
+  auto padded_bias = at::pad_symint(attn_bias, {c10::SymInt(0), pad_count});
+  return padded_bias.slice_symint(-1, 0, last_dim_size);
+}
+
+// Allocate fresh storage with aligned strides and copy the bias into it.
+// Avoids the modulo-dependent symbolic expressions that pad+slice creates.
 template <int alignment>
 at::Tensor copy_to_aligned_bias(const at::Tensor& attn_bias) {
   TORCH_INTERNAL_ASSERT(attn_bias.dim() > 0);
@@ -603,8 +623,11 @@ at::Tensor preprocess_mask(
     const at::Tensor& value) {
   constexpr int mem_eff_alignment = 8;
   at::Tensor result_mask = mask;
-  if (!aligned_tensor<mem_eff_alignment>(mask)) {
+  auto status = check_alignment<mem_eff_alignment>(mask);
+  if (status == AlignStatus::SymbolicUnaligned) {
     result_mask = copy_to_aligned_bias<mem_eff_alignment>(mask);
+  } else if (status == AlignStatus::ConcreteUnaligned) {
+    result_mask = pad_bias<mem_eff_alignment>(mask);
   }
   return result_mask.expand_symint(
       {query.sym_size(0),

--- a/aten/src/ATen/native/transformers/attention.cpp
+++ b/aten/src/ATen/native/transformers/attention.cpp
@@ -59,6 +59,7 @@
 #include <ATen/ops/cat.h>
 #include <ATen/ops/chunk_native.h>
 #include <ATen/ops/dropout.h>
+#include <ATen/ops/empty_strided.h>
 #include <ATen/ops/linear_native.h>
 #include <ATen/ops/matmul.h>
 #include <ATen/ops/matmul_native.h>
@@ -548,18 +549,21 @@ std::optional<Tensor> convert_boolean_attn_mask(const std::optional<Tensor>& att
   return attn_mask;
 }
 
-// Memory Efficient Attention requires a padded attn mask bias
-// This function pads the attn_mask bias to be a multiple of 16
-// Then slices the padded bias to the original size
-// We apply this function to the top level SDPA so that
-// if padding is done it will be tracked for backward automatically
+// Memory Efficient Attention requires aligned non-last strides for its bias.
+// We preserve the visible mask shape and copy it into fresh storage whose row
+// stride is rounded up to the requested alignment.
+
+template <int alignment>
+c10::SymInt round_up_to_multiple(const c10::SymInt& size) {
+  return ((size + (alignment - 1)) / alignment) * alignment;
+}
 
 template<int alignment>
 bool aligned_tensor(const at::Tensor& tensor){
   for(const auto i : c10::irange(tensor.dim() - 1)){
     auto stride = tensor.sym_stride(i).maybe_as_int();
-    // If the stride is unknown at compilation time, assume it is unaligned
-    // and always pad it. This is helpful to avoid unnecessary guards.
+    // If the stride is unknown at compilation time, route through the
+    // aligned-copy path instead of guarding on the concrete alignment.
     if (!stride)
       return false;
 
@@ -571,11 +575,25 @@ bool aligned_tensor(const at::Tensor& tensor){
 }
 
 template <int alignment>
-at::Tensor pad_bias(const at::Tensor& attn_bias) {
-  auto last_dim_size = attn_bias.sym_size(-1);
-  auto pad_count = alignment - (last_dim_size % alignment);
-  auto padded_bias = at::pad_symint(attn_bias, {c10::SymInt(0), pad_count});
-  return padded_bias.slice_symint(-1, 0, last_dim_size);
+at::Tensor copy_to_aligned_bias(const at::Tensor& attn_bias) {
+  TORCH_INTERNAL_ASSERT(attn_bias.dim() > 0);
+
+  c10::SymDimVector aligned_strides(attn_bias.dim());
+  aligned_strides.back() = c10::SymInt(1);
+
+  c10::SymInt next_stride =
+      round_up_to_multiple<alignment>(attn_bias.sym_size(-1));
+  for (int64_t dim = attn_bias.dim() - 1; dim-- > 0;) {
+    aligned_strides[dim] = next_stride;
+    next_stride = next_stride * attn_bias.sym_size(dim);
+  }
+
+  auto aligned_bias = at::empty_strided_symint(
+      attn_bias.sym_sizes(),
+      aligned_strides,
+      attn_bias.options());
+  aligned_bias.copy_(attn_bias);
+  return aligned_bias;
 }
 
 at::Tensor preprocess_mask(
@@ -586,7 +604,7 @@ at::Tensor preprocess_mask(
   constexpr int mem_eff_alignment = 8;
   at::Tensor result_mask = mask;
   if (!aligned_tensor<mem_eff_alignment>(mask)) {
-    result_mask = pad_bias<mem_eff_alignment>(mask);
+    result_mask = copy_to_aligned_bias<mem_eff_alignment>(mask);
   }
   return result_mask.expand_symint(
       {query.sym_size(0),

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -68,6 +68,7 @@ from torch.fx.experimental.symbolic_shapes import ShapeEnv
 from torch.testing import FileCheck
 from torch.testing._internal.common_cuda import (
     PLATFORM_SUPPORTS_FLASH_ATTENTION,
+    PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
     xfailIfDistributedNotSupported,
 )
 from torch.testing._internal.common_utils import (
@@ -17679,6 +17680,44 @@ def forward(self, q, k, v):
                 ep.graph_module.code.strip(),
                 code_str,
             )
+
+    @skipIfCrossRef
+    @unittest.skipIf(
+        not PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
+        "Can't run efficient SDPA on this platform",
+    )
+    def test_scaled_dot_product_attention_cuda_dynamic_shapes_with_mask(self):
+        class ScaledDotProductAttention(torch.nn.Module):
+            def forward(self, q, k, v, attn_mask):
+                return F.scaled_dot_product_attention(
+                    q, k, v, attn_mask=attn_mask, dropout_p=0.0
+                )
+
+        seq_len = Dim("seq_len", min=1, max=32)
+        q = torch.randn(2, 4, 8, 64, dtype=torch.float16, device="cuda")
+        k = torch.randn(2, 4, 8, 64, dtype=torch.float16, device="cuda")
+        v = torch.randn(2, 4, 8, 64, dtype=torch.float16, device="cuda")
+        attn_mask = torch.zeros(2, 1, 8, 8, dtype=torch.float16, device="cuda")
+
+        with torch.nn.attention.sdpa_kernel(
+            [torch.nn.attention.SDPBackend.EFFICIENT_ATTENTION]
+        ):
+            ep = torch.export.export(
+                ScaledDotProductAttention(),
+                (q, k, v, attn_mask),
+                dynamic_shapes=(
+                    {2: seq_len},
+                    {2: seq_len},
+                    {2: seq_len},
+                    {2: seq_len, 3: seq_len},
+                ),
+            ).run_decompositions()
+
+        ops = {node.target for node in ep.graph.nodes if node.op == "call_function"}
+        self.assertIn(
+            torch.ops.aten._scaled_dot_product_efficient_attention.default,
+            ops,
+        )
 
     def test_int_list_output(self):
         class M(torch.nn.Module):


### PR DESCRIPTION
Fix #124502

## Summary

1. Root cause
   Exporting CUDA SDPA with a dynamic explicit attention mask went through the efficient-attention mask alignment helper, which aligned the mask by padding and then slicing it back to the original logical shape. With symbolic sequence lengths, that pad-and-slice view introduced modulo-dependent stride/storage expressions that export turned into unsatisfiable shape guards.

2. Proposed fix
   Replace the pad-and-slice alignment path with an aligned-stride copy. The helper now allocates fresh storage whose non-last strides are rounded up to the required alignment, copies the mask into that storage, and preserves the original visible mask shape before calling efficient attention.

3. Why this is the right long term fix
   Efficient attention still receives the aligned bias layout it requires, but export no longer has to reason about aliasing a sliced padded view with symbolic dimensions. That removes the constraint-violation failure without forcing a fallback to the decomposed math path.

## Testing

- Added a CUDA export regression test that forces efficient attention, uses dynamic sequence lengths with an explicit mask, and checks that `_scaled_dot_product_efficient_attention` remains in the exported graph.

Drafted via @codex, published after manual review by @bobrenjc93

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo