### PR TITLE
FakeTensor: fix bool() on constant scalar outputs

### DIFF
--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -1303,6 +1303,18 @@ class FakeTensorConstHandling(TestCase):
             self.assertTrue(torch.all(mask == 1))
             self.assertFalse(torch.all(mask == 0))
 
+    def test_bool_storage_escape_then_set_data_invalidates_scalar(self):
+        with FakeTensorMode():
+            mask = torch.tensor(1, dtype=torch.int64)
+            mask.untyped_storage()
+            self.assertTrue(bool(mask))
+            torch.ops.aten.set_data.default(mask, torch.tensor(0, dtype=torch.int64))
+            self.assertIsNone(mask.constant_scalar)
+            with self.assertRaises(
+                torch._subclasses.fake_tensor.DataDependentOutputException
+            ):
+                bool(mask)
+
     def test_inplace_add(self):
         with FakeTensorMode():
             x = torch.tensor(4.0)

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -1291,6 +1291,18 @@ class FakeTensorConstHandling(TestCase):
             self.assertTrue(torch.all(mask == 1))
             self.assertFalse(torch.all(mask == 0))
 
+    def test_bool_with_nested_dispatch_mode_inference(self):
+        class TrackingMode(TorchDispatchMode):
+            def __torch_dispatch__(self, func, types, args=(), kwargs=None):
+                res = func(*args, **kwargs)
+                pytree.tree_map_only(torch.Tensor, lambda t: t.untyped_storage(), res)
+                return res
+
+        with torch.inference_mode(), FakeTensorMode(), TrackingMode():
+            mask = torch.tensor([[1, 1, 1]], dtype=torch.int64)
+            self.assertTrue(torch.all(mask == 1))
+            self.assertFalse(torch.all(mask == 0))
+
     def test_inplace_add(self):
         with FakeTensorMode():
             x = torch.tensor(4.0)

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -1315,6 +1315,19 @@ class FakeTensorConstHandling(TestCase):
             ):
                 bool(mask)
 
+    def test_bool_storage_escape_then_alias_write_invalidates_scalar(self):
+        with FakeTensorMode():
+            base = torch.tensor([1], dtype=torch.int64)
+            scalar = base[0]
+            scalar.untyped_storage()
+            self.assertTrue(bool(scalar))
+            base.fill_(0)
+            self.assertIsNone(scalar.constant_scalar)
+            with self.assertRaises(
+                torch._subclasses.fake_tensor.DataDependentOutputException
+            ):
+                bool(scalar)
+
     def test_inplace_add(self):
         with FakeTensorMode():
             x = torch.tensor(4.0)

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -1303,32 +1303,6 @@ class FakeTensorConstHandling(TestCase):
             self.assertTrue(torch.all(mask == 1))
             self.assertFalse(torch.all(mask == 0))
 
-    def test_bool_storage_escape_then_set_data_invalidates_scalar(self):
-        with FakeTensorMode():
-            mask = torch.tensor(1, dtype=torch.int64)
-            mask.untyped_storage()
-            self.assertTrue(bool(mask))
-            self.assertEqual(mask.item(), 1)
-            torch.ops.aten.set_data.default(mask, torch.tensor(0, dtype=torch.int64))
-            self.assertIsNone(mask.constant_scalar)
-            with self.assertRaises(
-                torch._subclasses.fake_tensor.DataDependentOutputException
-            ):
-                bool(mask)
-
-    def test_bool_storage_escape_then_alias_write_invalidates_scalar(self):
-        with FakeTensorMode():
-            base = torch.tensor([1], dtype=torch.int64)
-            scalar = base[0]
-            scalar.untyped_storage()
-            self.assertTrue(bool(scalar))
-            base.fill_(0)
-            self.assertIsNone(scalar.constant_scalar)
-            with self.assertRaises(
-                torch._subclasses.fake_tensor.DataDependentOutputException
-            ):
-                bool(scalar)
-
     def test_inplace_add(self):
         with FakeTensorMode():
             x = torch.tensor(4.0)

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -1279,6 +1279,18 @@ class FakeTensorConstHandling(TestCase):
             x = torch.tensor(4.0)
             self.assertEqual(x.item(), 4.0)
 
+    def test_bool_with_nested_dispatch_mode(self):
+        class TrackingMode(TorchDispatchMode):
+            def __torch_dispatch__(self, func, types, args=(), kwargs=None):
+                res = func(*args, **kwargs)
+                pytree.tree_map_only(torch.Tensor, lambda t: t.untyped_storage(), res)
+                return res
+
+        with FakeTensorMode(), TrackingMode():
+            mask = torch.tensor([[1, 1, 1]], dtype=torch.int64)
+            self.assertTrue(torch.all(mask == 1))
+            self.assertFalse(torch.all(mask == 0))
+
     def test_inplace_add(self):
         with FakeTensorMode():
             x = torch.tensor(4.0)

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -1303,6 +1303,19 @@ class FakeTensorConstHandling(TestCase):
             self.assertTrue(torch.all(mask == 1))
             self.assertFalse(torch.all(mask == 0))
 
+    def test_bool_preserves_is_nonzero_cardinality_checks(self):
+        with FakeTensorMode():
+            with self.assertRaisesRegex(
+                RuntimeError, "Boolean value of Tensor with no values is ambiguous"
+            ):
+                bool(torch.tensor([]))
+
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "Boolean value of Tensor with more than one value is ambiguous",
+            ):
+                bool(torch.tensor([1, 1]))
+
     def test_inplace_add(self):
         with FakeTensorMode():
             x = torch.tensor(4.0)

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -1308,6 +1308,7 @@ class FakeTensorConstHandling(TestCase):
             mask = torch.tensor(1, dtype=torch.int64)
             mask.untyped_storage()
             self.assertTrue(bool(mask))
+            self.assertEqual(mask.item(), 1)
             torch.ops.aten.set_data.default(mask, torch.tensor(0, dtype=torch.int64))
             self.assertIsNone(mask.constant_scalar)
             with self.assertRaises(

--- a/torch/_subclasses/fake_impls.py
+++ b/torch/_subclasses/fake_impls.py
@@ -866,7 +866,11 @@ def is_nonzero(
     if arg.constant is not None:
         with no_python_dispatcher():
             return torch.ops.aten.is_nonzero.default(arg.constant)
-    return (arg != 0).item()
+    if (scalar := arg.item_memo) is not None:
+        if isinstance(scalar, torch.SymBool):
+            return typing_cast(bool | torch.SymBool, scalar)
+        return typing_cast(bool | torch.SymBool, scalar != 0)
+    raise DataDependentOutputException(func)
 
 
 @register_op_impl(torch.ops.aten.nonzero_numpy.default)

--- a/torch/_subclasses/fake_impls.py
+++ b/torch/_subclasses/fake_impls.py
@@ -851,6 +851,24 @@ def local_scalar_dense(
     return r
 
 
+@register_op_impl(torch.ops.aten.is_nonzero.default)
+def is_nonzero(
+    fake_mode: FakeTensorMode, func: OpOverload, arg: FakeTensor
+) -> bool | torch.SymBool:
+    torch._check(
+        arg.numel() != 0,
+        lambda: "Boolean value of Tensor with no values is ambiguous",
+    )
+    torch._check(
+        arg.numel() < 2,
+        lambda: "Boolean value of Tensor with more than one value is ambiguous",
+    )
+    if arg.constant is not None:
+        with no_python_dispatcher():
+            return torch.ops.aten.is_nonzero.default(arg.constant)
+    return (arg != 0).item()
+
+
 @register_op_impl(torch.ops.aten.nonzero_numpy.default)
 def nonzero_numpy(
     fake_mode: FakeTensorMode, func: OpOverload, arg: FakeTensor

--- a/torch/_subclasses/fake_impls.py
+++ b/torch/_subclasses/fake_impls.py
@@ -855,22 +855,7 @@ def local_scalar_dense(
 def is_nonzero(
     fake_mode: FakeTensorMode, func: OpOverload, arg: FakeTensor
 ) -> bool | torch.SymBool:
-    torch._check(
-        arg.numel() != 0,
-        lambda: "Boolean value of Tensor with no values is ambiguous",
-    )
-    torch._check(
-        arg.numel() < 2,
-        lambda: "Boolean value of Tensor with more than one value is ambiguous",
-    )
-    if arg.constant is not None:
-        with no_python_dispatcher():
-            return torch.ops.aten.is_nonzero.default(arg.constant)
-    if (scalar := arg.item_memo) is not None:
-        if isinstance(scalar, torch.SymBool):
-            return typing_cast(bool | torch.SymBool, scalar)
-        return typing_cast(bool | torch.SymBool, scalar != 0)
-    raise DataDependentOutputException(func)
+    return arg._is_nonzero()
 
 
 @register_op_impl(torch.ops.aten.nonzero_numpy.default)

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -328,7 +328,6 @@ class FakeTensorConverter:
 
     meta_converter: MetaConverter[FakeTensor]
     constant_storage_mapping: dict[StorageWeakRef, list[ReferenceType[FakeTensor]]]
-    constant_storage_refs: WeakTensorKeyDictionary
     export: bool
 
     def __init__(self, *, copy_data: bool = False, export: bool = False) -> None:
@@ -736,7 +735,7 @@ class SymNumberMemoDescriptor:
 
 
 def _constant_scalar_tensor(t: Tensor | None) -> Tensor | None:
-    if t is None or not _is_plain_tensor(t) or t.dim() != 0 or t.device.type != "cpu":
+    if t is None or not _is_plain_tensor(t) or t.dim() != 0:
         return None
     return t
 
@@ -764,7 +763,13 @@ class FakeTensor(Tensor):
     _fake_device: torch.device
     fake_mode: FakeTensorMode
     constant: Tensor | None
-    constant_scalar: Tensor | None
+    _constant_scalar: Tensor | None
+    _constant_scalar_vc: int | None
+    _constant_scalar_epoch: int | None
+    _constant_scalar_ref: StorageWeakRef | None
+    _constant_scalar_offset: object | None
+    _constant_scalar_size: tuple[object, ...] | None
+    _constant_scalar_stride: tuple[object, ...] | None
     real_tensor: Tensor | None
 
     # TODO: Generalize this as needed, e.g., into a trie of memos, if
@@ -811,6 +816,60 @@ class FakeTensor(Tensor):
     @fake_device.setter
     def fake_device(self, device: torch.device) -> None:
         self._fake_device = self._normalize_fake_device(device)
+
+    def _version_counter(self) -> int | None:
+        try:
+            return self._version
+        except RuntimeError:
+            return None
+
+    @property
+    def constant_scalar(self) -> Tensor | None:
+        r = getattr(self, "_constant_scalar", None)
+        if r is None:
+            return None
+
+        version = getattr(self, "_constant_scalar_vc", None)
+        epoch = getattr(self, "_constant_scalar_epoch", None)
+        storage_ref = getattr(self, "_constant_scalar_ref", None)
+        storage_offset = getattr(self, "_constant_scalar_offset", None)
+        size = getattr(self, "_constant_scalar_size", None)
+        stride = getattr(self, "_constant_scalar_stride", None)
+        if (
+            (version is not None and version != self._version_counter())
+            or (epoch is not None and epoch != self.fake_mode.epoch)
+            or storage_ref != self.fake_mode.fake_tensor_converter._constant_storage_ref(self)
+            or storage_offset != self.storage_offset()
+            or size != tuple(self.size())
+            or stride != tuple(self.stride())
+        ):
+            self.constant_scalar = None
+            return None
+        return r
+
+    @constant_scalar.setter
+    def constant_scalar(self, value: Tensor | None) -> None:
+        self._constant_scalar = value
+        if value is None:
+            self._constant_scalar_vc = None
+            self._constant_scalar_epoch = None
+            self._constant_scalar_ref = None
+            self._constant_scalar_offset = None
+            self._constant_scalar_size = None
+            self._constant_scalar_stride = None
+            return
+
+        # Track both the version counter and the current storage/view state so
+        # `set_data()`-style mutations invalidate the fallback even when they
+        # do not reenter FakeTensor dispatch.
+        self._constant_scalar_vc = self._version_counter()
+        self._constant_scalar_epoch = self.fake_mode.epoch
+        self._constant_scalar_ref = self.fake_mode.fake_tensor_converter._constant_storage_ref(
+            self
+        )
+        self._constant_scalar_offset = self.storage_offset()
+        self._constant_scalar_size = tuple(self.size())
+        self._constant_scalar_stride = tuple(self.stride())
 
     # Note: [Fake Tensor Dispatch Keys]
     # In order to model the behavior of device-specific autocast
@@ -3256,6 +3315,9 @@ class FakeTensorMode(TorchDispatchMode):
         if not same_storage:
             return False
 
+        if func is getattr(aten.set_, "source_Storage", None):
+            return True
+
         if func is not aten.set_.source_Storage_storage_offset:
             return False
 
@@ -3328,11 +3390,11 @@ class FakeTensorMode(TorchDispatchMode):
         if func is aten.set_data.default:
             fake_self = None
             if len(args) > 0 and self.is_our_fake(args[0]):
-                fake_self = cast(FakeTensor, args[0])
+                fake_self = args[0]
             else:
                 maybe_self = kwargs.get("self", kwargs.get("input"))
                 if self.is_our_fake(maybe_self):
-                    fake_self = cast(FakeTensor, maybe_self)
+                    fake_self = maybe_self
 
             if fake_self is not None:
                 if (

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -3161,6 +3161,42 @@ class FakeTensorMode(TorchDispatchMode):
         if op is not None
     )
 
+    def _preserves_constant_scalar_on_write(
+        self,
+        func: OpOverload,
+        kwargs: Mapping[str, object],
+        real_constant: Tensor,
+    ) -> bool:
+        if func not in self._preserve_constant_scalar_ops:
+            return False
+
+        source = kwargs.get("source")
+        if source is None:
+            return False
+
+        try:
+            same_storage = StorageWeakRef(source) == StorageWeakRef(
+                real_constant.untyped_storage()
+            )
+        except TypeError:
+            return False
+        if not same_storage:
+            return False
+
+        if func is not aten.set_.source_Storage_storage_offset:
+            return False
+
+        # Rebinding the exact same scalar view keeps the cached scalar valid;
+        # swapping to different storage or metadata (for example via set_data)
+        # must clear it.
+        return (
+            kwargs.get("storage_offset") == real_constant.storage_offset()
+            and tuple(cast(Sequence[object], kwargs.get("size", ())))
+            == tuple(real_constant.size())
+            and tuple(cast(Sequence[object], kwargs.get("stride", ())))
+            == tuple(real_constant.stride())
+        )
+
     _unbacked_special_fake_handling_ops = ordered_set(
         aten.view.default,
         aten._unsafe_view.default,
@@ -3195,7 +3231,6 @@ class FakeTensorMode(TorchDispatchMode):
         )
         schema_info = get_schema_info(func)
         if any_constant and schema_info.is_mutable():
-            clear_constant_scalar = func not in self._preserve_constant_scalar_ops
             _, new_kwargs = normalize_function(  # type: ignore[misc]
                 func,
                 args=args,  # type: ignore[arg-type]
@@ -3213,6 +3248,9 @@ class FakeTensorMode(TorchDispatchMode):
                     )
                     if real_constant is None:
                         continue
+                    clear_constant_scalar = not self._preserves_constant_scalar_on_write(
+                        func, new_kwargs, real_constant
+                    )
                     self.fake_tensor_converter.invalidate_constant_aliases(
                         real_constant, clear_constant_scalar=clear_constant_scalar
                     )

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -358,6 +358,8 @@ class FakeTensorConverter:
         if is_sparse_any(tensor):
             return None
         try:
+            if isinstance(tensor, FakeTensor):
+                return StorageWeakRef(tensor._raw_untyped_storage())
             return StorageWeakRef(tensor._typed_storage())
         except TypeError:
             return None
@@ -740,13 +742,15 @@ def _constant_scalar_tensor(t: Tensor | None) -> Tensor | None:
     return t
 
 
-def _extract_constant_scalar(t: Tensor | None) -> bool | int | float | None:
+def _extract_constant_scalar(
+    t: Tensor | None,
+) -> bool | int | float | complex | None:
     if (t := _constant_scalar_tensor(t)) is None:
         return None
 
     with no_dispatch():
         value = t.item()
-    if isinstance(value, (bool, int, float)):
+    if isinstance(value, (bool, int, float, complex)):
         return value
     return None
 
@@ -838,7 +842,8 @@ class FakeTensor(Tensor):
         if (
             (version is not None and version != self._version_counter())
             or (epoch is not None and epoch != self.fake_mode.epoch)
-            or storage_ref != self.fake_mode.fake_tensor_converter._constant_storage_ref(self)
+            or storage_ref
+            != self.fake_mode.fake_tensor_converter._constant_storage_ref(self)
             or storage_offset != self.storage_offset()
             or size != tuple(self.size())
             or stride != tuple(self.stride())
@@ -1212,6 +1217,21 @@ class FakeTensor(Tensor):
         else:
             return [elem.tolist() for elem in self]
 
+    def _raw_untyped_storage(self):
+        return super().untyped_storage()
+
+    def _typed_storage(self):
+        return torch.TypedStorage(
+            wrap_storage=self._raw_untyped_storage(),
+            dtype=self.dtype,
+            _internal=True,
+        )
+
+    def storage(self):
+        torch.storage._warn_typed_storage_removal(stacklevel=2)
+        self._invalidate_constant_on_storage_access()
+        return self._typed_storage()
+
     def _invalidate_constant_on_storage_access(self) -> None:
         # Storage inspection exposes aliasing, so later writes must stop
         # treating the touched constant storage as tensor-wide immutable.
@@ -1226,7 +1246,7 @@ class FakeTensor(Tensor):
 
     def untyped_storage(self):
         self._invalidate_constant_on_storage_access()
-        return super().untyped_storage()
+        return self._raw_untyped_storage()
 
     def item(self):
         if self.constant is not None:
@@ -1319,7 +1339,13 @@ def extract_tensor_metadata(t: Tensor) -> TensorMetadata:
         memory_format,
         storage_offset,
         # Only set storage_bytes for tensors that have storage (not sparse)
-        t.untyped_storage().nbytes() if not is_sparse_any(t) else None,
+        (
+            t._raw_untyped_storage().nbytes()
+            if isinstance(t, FakeTensor)
+            else t.untyped_storage().nbytes()
+        )
+        if not is_sparse_any(t)
+        else None,
         t.requires_grad,
         t.is_quantized,
         t.is_conj(),
@@ -2288,7 +2314,7 @@ class FakeTensorMode(TorchDispatchMode):
             view_arg = args[cast(int, entry.view_idx)]
             if not isinstance(view_arg, FakeTensor):
                 raise AssertionError("view_arg must be a FakeTensor")
-            storage = view_arg.untyped_storage()
+            storage = view_arg._raw_untyped_storage()
             with in_kernel_invocation_manager(self), maybe_suppress():
                 empty.set_(storage, storage_offset, shape, stride)
 

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -13,7 +13,6 @@ import types
 import typing
 import weakref
 from collections import defaultdict
-from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any, cast, Literal, TYPE_CHECKING, TypeGuard, TypeVar, Union
 from typing_extensions import Self
@@ -49,13 +48,12 @@ from torch.utils._python_dispatch import (
 from torch.utils._pytree import KeyPath, keystr, PyTree, tree_map, tree_map_, TreeSpec
 from torch.utils._stats import count
 from torch.utils._traceback import CapturedTraceback
-from torch.utils.weak import WeakTensorKeyDictionary
 
 from ._fake_tensor_utils import _CacheKeyState, _PySymInputStub, _SymIntOutputStub
 
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Generator, Iterable, Mapping
+    from collections.abc import Callable, Generator, Iterable, Mapping, Sequence
     from types import TracebackType
 
     from torch._guards import Source
@@ -336,7 +334,6 @@ class FakeTensorConverter:
 
         # map from to storage to corresponding constant tensors
         self.constant_storage_mapping = {}
-        self.constant_storage_refs = WeakTensorKeyDictionary()
 
     def add_constant_storage_mapping(self, fake_tensor: FakeTensor) -> None:
         # when you have a constant, aliased tensor:
@@ -352,78 +349,23 @@ class FakeTensorConverter:
         if weak_st not in self.constant_storage_mapping:
             self.constant_storage_mapping[weak_st] = []
         self.constant_storage_mapping[weak_st].append(weakref.ref(fake_tensor))
-        self.constant_storage_refs[fake_tensor] = weak_st
 
-    def _constant_storage_ref(self, tensor: Tensor) -> StorageWeakRef | None:
-        if is_sparse_any(tensor):
-            return None
-        try:
-            if isinstance(tensor, FakeTensor):
-                return StorageWeakRef(tensor._raw_untyped_storage())
-            return StorageWeakRef(tensor._typed_storage())
-        except TypeError:
-            return None
+    def invalidate_constant_aliases(self, tensor: Tensor) -> None:
+        if isinstance(tensor, FakeTensor):
+            raise AssertionError("Expected a real tensor, not a FakeTensor")
 
-    def has_constant_alias(self, fake_tensor: FakeTensor) -> bool:
-        return fake_tensor in self.constant_storage_refs
-
-    def _invalidate_constant_aliases_by_ref(
-        self, weak_st: StorageWeakRef, *, clear_constant_scalar: bool = True
-    ) -> None:
+        weak_st = StorageWeakRef(tensor._typed_storage())
         if weak_st not in self.constant_storage_mapping:
             return
 
-        live_refs: list[ReferenceType[FakeTensor]] = []
-        live_tensors: list[FakeTensor] = []
-        keep_tracking_scalar = False
         for weak_tensor_ref in self.constant_storage_mapping[weak_st]:
             ten = weak_tensor_ref()
             if ten is not None:
                 # pyrefly: ignore [missing-attribute]
                 ten._fix_weakref()
                 ten.constant = None
-                if clear_constant_scalar:
-                    ten.constant_scalar = None
-                elif ten.constant_scalar is not None:
-                    keep_tracking_scalar = True
-                live_tensors.append(ten)
-                live_refs.append(weak_tensor_ref)
 
-        if clear_constant_scalar or not keep_tracking_scalar:
-            for ten in live_tensors:
-                self.constant_storage_refs.pop(ten, None)
-            del self.constant_storage_mapping[weak_st]
-        else:
-            # Storage exposure clears tensor-wide constness, but later tensor
-            # writes must still be able to find and clear the scalar fallback.
-            for ten in live_tensors:
-                self.constant_storage_refs[ten] = weak_st
-            self.constant_storage_mapping[weak_st] = live_refs
-
-    def invalidate_constant_aliases(
-        self, tensor: Tensor, *, clear_constant_scalar: bool = True
-    ) -> None:
-        if isinstance(tensor, FakeTensor):
-            raise AssertionError("Expected a real tensor, not a FakeTensor")
-
-        weak_st = self._constant_storage_ref(tensor)
-        if weak_st is None:
-            return
-
-        self._invalidate_constant_aliases_by_ref(
-            weak_st, clear_constant_scalar=clear_constant_scalar
-        )
-
-    def invalidate_constant_aliases_of_fake(
-        self, fake_tensor: FakeTensor, *, clear_constant_scalar: bool = True
-    ) -> None:
-        weak_st = self.constant_storage_refs.get(fake_tensor)
-        if weak_st is None:
-            return
-
-        self._invalidate_constant_aliases_by_ref(
-            weak_st, clear_constant_scalar=clear_constant_scalar
-        )
+        del self.constant_storage_mapping[weak_st]
 
     def _get_memo(self, t: Tensor) -> FakeTensor | None:
         tid = self.meta_converter.describer.lookup_tensor.get(t)
@@ -736,25 +678,6 @@ class SymNumberMemoDescriptor:
             setattr(obj, self._memo_epoch(obj), obj.fake_mode.epoch)
 
 
-def _constant_scalar_tensor(t: Tensor | None) -> Tensor | None:
-    if t is None or not _is_plain_tensor(t) or t.dim() != 0:
-        return None
-    return t
-
-
-def _extract_constant_scalar(
-    t: Tensor | None,
-) -> bool | int | float | complex | None:
-    if (t := _constant_scalar_tensor(t)) is None:
-        return None
-
-    with no_dispatch():
-        value = t.item()
-    if isinstance(value, (bool, int, float, complex)):
-        return value
-    return None
-
-
 class FakeTensor(Tensor):
     """
     Meta tensors give you the ability to run PyTorch code without having to
@@ -767,13 +690,6 @@ class FakeTensor(Tensor):
     _fake_device: torch.device
     fake_mode: FakeTensorMode
     constant: Tensor | None
-    _constant_scalar: Tensor | None
-    _constant_scalar_vc: int | None
-    _constant_scalar_epoch: int | None
-    _constant_scalar_ref: StorageWeakRef | None
-    _constant_scalar_offset: object | None
-    _constant_scalar_size: tuple[object, ...] | None
-    _constant_scalar_stride: tuple[object, ...] | None
     real_tensor: Tensor | None
 
     # TODO: Generalize this as needed, e.g., into a trie of memos, if
@@ -820,61 +736,6 @@ class FakeTensor(Tensor):
     @fake_device.setter
     def fake_device(self, device: torch.device) -> None:
         self._fake_device = self._normalize_fake_device(device)
-
-    def _version_counter(self) -> int | None:
-        try:
-            return self._version
-        except RuntimeError:
-            return None
-
-    @property
-    def constant_scalar(self) -> Tensor | None:
-        r = getattr(self, "_constant_scalar", None)
-        if r is None:
-            return None
-
-        version = getattr(self, "_constant_scalar_vc", None)
-        epoch = getattr(self, "_constant_scalar_epoch", None)
-        storage_ref = getattr(self, "_constant_scalar_ref", None)
-        storage_offset = getattr(self, "_constant_scalar_offset", None)
-        size = getattr(self, "_constant_scalar_size", None)
-        stride = getattr(self, "_constant_scalar_stride", None)
-        if (
-            (version is not None and version != self._version_counter())
-            or (epoch is not None and epoch != self.fake_mode.epoch)
-            or storage_ref
-            != self.fake_mode.fake_tensor_converter._constant_storage_ref(self)
-            or storage_offset != self.storage_offset()
-            or size != tuple(self.size())
-            or stride != tuple(self.stride())
-        ):
-            self.constant_scalar = None
-            return None
-        return r
-
-    @constant_scalar.setter
-    def constant_scalar(self, value: Tensor | None) -> None:
-        self._constant_scalar = value
-        if value is None:
-            self._constant_scalar_vc = None
-            self._constant_scalar_epoch = None
-            self._constant_scalar_ref = None
-            self._constant_scalar_offset = None
-            self._constant_scalar_size = None
-            self._constant_scalar_stride = None
-            return
-
-        # Track both the version counter and the current storage/view state so
-        # `set_data()`-style mutations invalidate the fallback even when they
-        # do not reenter FakeTensor dispatch.
-        self._constant_scalar_vc = self._version_counter()
-        self._constant_scalar_epoch = self.fake_mode.epoch
-        self._constant_scalar_ref = self.fake_mode.fake_tensor_converter._constant_storage_ref(
-            self
-        )
-        self._constant_scalar_offset = self.storage_offset()
-        self._constant_scalar_size = tuple(self.size())
-        self._constant_scalar_stride = tuple(self.stride())
 
     # Note: [Fake Tensor Dispatch Keys]
     # In order to model the behavior of device-specific autocast
@@ -968,7 +829,6 @@ class FakeTensor(Tensor):
         self.real_tensor = real_tensor
         self.nonzero_memo = None
         self.item_memo = None
-        self.constant_scalar = _constant_scalar_tensor(constant)
         self.unique_memo = None
         self.unique_consecutive_memo = None
         self.nested_int_memo = None
@@ -1217,52 +1077,8 @@ class FakeTensor(Tensor):
         else:
             return [elem.tolist() for elem in self]
 
-    def _raw_untyped_storage(self):
-        return super().untyped_storage()
-
-    def _typed_storage(self):
-        return torch.TypedStorage(
-            wrap_storage=self._raw_untyped_storage(),
-            dtype=self.dtype,
-            _internal=True,
-        )
-
-    def storage(self):
-        torch.storage._warn_typed_storage_removal(stacklevel=2)
-        self._invalidate_constant_on_storage_access()
-        return self._typed_storage()
-
-    def _invalidate_constant_on_storage_access(self) -> None:
-        # Storage inspection exposes aliasing, so later writes must stop
-        # treating the touched constant storage as tensor-wide immutable.
-        if self.constant is not None:
-            self.fake_mode.fake_tensor_converter.invalidate_constant_aliases(
-                self.constant, clear_constant_scalar=False
-            )
-        elif self.fake_mode.fake_tensor_converter.has_constant_alias(self):
-            self.fake_mode.fake_tensor_converter.invalidate_constant_aliases_of_fake(
-                self, clear_constant_scalar=False
-            )
-
-    def untyped_storage(self):
-        self._invalidate_constant_on_storage_access()
-        return self._raw_untyped_storage()
-
-    def item(self):
-        if self.constant is not None:
-            with no_dispatch():
-                return self.constant.item()
-        if (scalar := _extract_constant_scalar(self.constant_scalar)) is not None:
-            return scalar
-        return super().item()
-
     def __bool__(self):
-        if self.constant is not None:
-            with no_dispatch():
-                return bool(self.constant)
-        if (scalar := _extract_constant_scalar(self.constant_scalar)) is not None:
-            return bool(scalar)
-        return super().__bool__()
+        return bool(self.item())
 
 
 _MetadataIntLike = Union[IntLikeType, "_PySymInputStub", "_SymIntOutputStub"]
@@ -1339,13 +1155,7 @@ def extract_tensor_metadata(t: Tensor) -> TensorMetadata:
         memory_format,
         storage_offset,
         # Only set storage_bytes for tensors that have storage (not sparse)
-        (
-            t._raw_untyped_storage().nbytes()
-            if isinstance(t, FakeTensor)
-            else t.untyped_storage().nbytes()
-        )
-        if not is_sparse_any(t)
-        else None,
+        t.untyped_storage().nbytes() if not is_sparse_any(t) else None,
         t.requires_grad,
         t.is_quantized,
         t.is_conj(),
@@ -1624,13 +1434,6 @@ class FakeTensorMode(TorchDispatchMode):
         if self._stack is None:
             self._stack = "".join(traceback.format_list(self._stack_trace))
         return self._stack
-
-    def _has_constant_tracking(self, fake_tensor: FakeTensor) -> bool:
-        return (
-            fake_tensor.constant is not None
-            or fake_tensor.constant_scalar is not None
-            or self.fake_tensor_converter.has_constant_alias(fake_tensor)
-        )
 
     @count
     # pyrefly: ignore [bad-override]
@@ -1976,9 +1779,7 @@ class FakeTensorMode(TorchDispatchMode):
             if isinstance(arg, FakeTensor):
                 if not self.is_our_fake(arg):
                     raise _BypassDispatchCache("not our fake")
-                # Constant tracking carries side effects that the cache does not
-                # replay, so mutable ops must re-enter normal dispatch.
-                if self._has_constant_tracking(arg):
+                if arg.constant is not None:
                     raise _BypassDispatchCache("constant attribute")
                 if is_sparse_any(arg):
                     raise _BypassDispatchCache(f"{arg.layout} tensor")
@@ -2044,7 +1845,7 @@ class FakeTensorMode(TorchDispatchMode):
 
         # Avoid caching FakeTensors with constants attached since those
         # can be invalidated.
-        if self._has_constant_tracking(output):
+        if output.constant is not None:
             raise _BypassDispatchCache("constant attribute")
 
         # TODO: support caching sparse outputs?
@@ -2314,7 +2115,7 @@ class FakeTensorMode(TorchDispatchMode):
             view_arg = args[cast(int, entry.view_idx)]
             if not isinstance(view_arg, FakeTensor):
                 raise AssertionError("view_arg must be a FakeTensor")
-            storage = view_arg._raw_untyped_storage()
+            storage = view_arg.untyped_storage()
             with in_kernel_invocation_manager(self), maybe_suppress():
                 empty.set_(storage, storage_offset, shape, stride)
 
@@ -3306,84 +3107,6 @@ class FakeTensorMode(TorchDispatchMode):
         aten.set_.source_Storage_storage_offset,
         aten._sparse_coo_tensor_with_dims_and_tensors.default,
     )
-    # Storage-backed set_ exposes aliasing without overwriting the scalar
-    # payload yet, so keep scalar tracking alive until a later tensor write.
-    _preserve_constant_scalar_ops = ordered_set(
-        op
-        for op in (
-            getattr(aten.set_, "source_Storage", None),
-            aten.set_.source_Storage_storage_offset,
-        )
-        if op is not None
-    )
-
-    def _preserves_constant_scalar_on_write(
-        self,
-        func: OpOverload,
-        kwargs: Mapping[str, object],
-        real_constant: Tensor,
-    ) -> bool:
-        if func not in self._preserve_constant_scalar_ops:
-            return False
-
-        source = kwargs.get("source")
-        if source is None:
-            return False
-        if not isinstance(source, (torch.TypedStorage, torch.UntypedStorage)):
-            return False
-
-        try:
-            same_storage = StorageWeakRef(source) == StorageWeakRef(
-                real_constant.untyped_storage()
-            )
-        except TypeError:
-            return False
-        if not same_storage:
-            return False
-
-        if func is getattr(aten.set_, "source_Storage", None):
-            return True
-
-        if func is not aten.set_.source_Storage_storage_offset:
-            return False
-
-        # Rebinding the exact same scalar view keeps the cached scalar valid;
-        # swapping to different storage or metadata (for example via set_data)
-        # must clear it.
-        return (
-            kwargs.get("storage_offset") == real_constant.storage_offset()
-            and tuple(cast(Sequence[object], kwargs.get("size", ())))
-            == tuple(real_constant.size())
-            and tuple(cast(Sequence[object], kwargs.get("stride", ())))
-            == tuple(real_constant.stride())
-        )
-
-    def _invalidate_fake_tensor_constant(
-        self,
-        fake_tensor: FakeTensor,
-        *,
-        real_constant: Tensor | None = None,
-        clear_constant_scalar: bool = True,
-    ) -> None:
-        if real_constant is None:
-            real_constant = (
-                fake_tensor.constant
-                if fake_tensor.constant is not None
-                else fake_tensor.constant_scalar
-            )
-
-        fake_tensor.constant = None
-        if clear_constant_scalar:
-            fake_tensor.constant_scalar = None
-
-        if real_constant is not None:
-            self.fake_tensor_converter.invalidate_constant_aliases(
-                real_constant, clear_constant_scalar=clear_constant_scalar
-            )
-        elif self.fake_tensor_converter.has_constant_alias(fake_tensor):
-            self.fake_tensor_converter.invalidate_constant_aliases_of_fake(
-                fake_tensor, clear_constant_scalar=clear_constant_scalar
-            )
 
     _unbacked_special_fake_handling_ops = ordered_set(
         aten.view.default,
@@ -3413,30 +3136,7 @@ class FakeTensorMode(TorchDispatchMode):
         args: Sequence[object],
         kwargs: Mapping[str, object],
     ) -> None:
-        if func is aten.set_data.default:
-            fake_self = None
-            if len(args) > 0 and self.is_our_fake(args[0]):
-                fake_self = args[0]
-            else:
-                maybe_self = kwargs.get("self", kwargs.get("input"))
-                if self.is_our_fake(maybe_self):
-                    fake_self = maybe_self
-
-            if fake_self is not None:
-                if (
-                    fake_self.constant is not None
-                    or fake_self.constant_scalar is not None
-                    or self.fake_tensor_converter.has_constant_alias(fake_self)
-                ):
-                    self._invalidate_fake_tensor_constant(fake_self)
-                return
-
-        any_constant = any(
-            e.constant is not None
-            or e.constant_scalar is not None
-            or self.fake_tensor_converter.has_constant_alias(e)
-            for e in flat_arg_fake_tensors
-        )
+        any_constant = any(e.constant is not None for e in flat_arg_fake_tensors)
         schema_info = get_schema_info(func)
         if any_constant and schema_info.is_mutable():
             _, new_kwargs = normalize_function(  # type: ignore[misc]
@@ -3447,24 +3147,12 @@ class FakeTensorMode(TorchDispatchMode):
             )
             for k, v in new_kwargs.items():
                 k = k if (k != "input" or schema_info.has_argument(k)) else "self"
-                if self.is_our_fake(v) and schema_info.is_mutable(k):
-                    real_constant = (
-                        v.constant if v.constant is not None else v.constant_scalar
-                    )
-                    clear_constant_scalar = (
-                        real_constant is None
-                        or not self._preserves_constant_scalar_on_write(
-                            func, new_kwargs, real_constant
-                        )
-                    )
-
-                    # Clear the mutated tensor first, then invalidate any
-                    # tracked aliases that still point at the same storage.
-                    self._invalidate_fake_tensor_constant(
-                        v,
-                        real_constant=real_constant,
-                        clear_constant_scalar=clear_constant_scalar,
-                    )
+                if (
+                    self.is_our_fake(v)
+                    and schema_info.is_mutable(k)
+                    and v.constant is not None
+                ):
+                    self.fake_tensor_converter.invalidate_constant_aliases(v.constant)
 
     def from_tensor(
         self,

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -327,6 +327,7 @@ class FakeTensorConverter:
 
     meta_converter: MetaConverter[FakeTensor]
     constant_storage_mapping: dict[StorageWeakRef, list[ReferenceType[FakeTensor]]]
+    constant_storage_refs: weakref.WeakKeyDictionary[FakeTensor, StorageWeakRef]
     export: bool
 
     def __init__(self, *, copy_data: bool = False, export: bool = False) -> None:
@@ -335,6 +336,7 @@ class FakeTensorConverter:
 
         # map from to storage to corresponding constant tensors
         self.constant_storage_mapping = {}
+        self.constant_storage_refs = weakref.WeakKeyDictionary()
 
     def add_constant_storage_mapping(self, fake_tensor: FakeTensor) -> None:
         # when you have a constant, aliased tensor:
@@ -350,6 +352,7 @@ class FakeTensorConverter:
         if weak_st not in self.constant_storage_mapping:
             self.constant_storage_mapping[weak_st] = []
         self.constant_storage_mapping[weak_st].append(weakref.ref(fake_tensor))
+        self.constant_storage_refs[fake_tensor] = weak_st
 
     def _constant_storage_ref(self, tensor: Tensor) -> StorageWeakRef | None:
         if is_sparse_any(tensor):
@@ -359,9 +362,8 @@ class FakeTensorConverter:
         except TypeError:
             return None
 
-    def has_constant_alias(self, tensor: Tensor) -> bool:
-        weak_st = self._constant_storage_ref(tensor)
-        return weak_st is not None and weak_st in self.constant_storage_mapping
+    def has_constant_alias(self, fake_tensor: FakeTensor) -> bool:
+        return fake_tensor in self.constant_storage_refs
 
     def _invalidate_constant_aliases_by_ref(
         self, weak_st: StorageWeakRef, *, clear_constant_scalar: bool = True
@@ -370,6 +372,7 @@ class FakeTensorConverter:
             return
 
         live_refs: list[ReferenceType[FakeTensor]] = []
+        live_tensors: list[FakeTensor] = []
         keep_tracking_scalar = False
         for weak_tensor_ref in self.constant_storage_mapping[weak_st]:
             ten = weak_tensor_ref()
@@ -381,13 +384,18 @@ class FakeTensorConverter:
                     ten.constant_scalar = None
                 elif ten.constant_scalar is not None:
                     keep_tracking_scalar = True
+                live_tensors.append(ten)
                 live_refs.append(weak_tensor_ref)
 
         if clear_constant_scalar or not keep_tracking_scalar:
+            for ten in live_tensors:
+                self.constant_storage_refs.pop(ten, None)
             del self.constant_storage_mapping[weak_st]
         else:
             # Storage exposure clears tensor-wide constness, but later tensor
             # writes must still be able to find and clear the scalar fallback.
+            for ten in live_tensors:
+                self.constant_storage_refs[ten] = weak_st
             self.constant_storage_mapping[weak_st] = live_refs
 
     def invalidate_constant_aliases(
@@ -407,7 +415,7 @@ class FakeTensorConverter:
     def invalidate_constant_aliases_of_fake(
         self, fake_tensor: FakeTensor, *, clear_constant_scalar: bool = True
     ) -> None:
-        weak_st = self._constant_storage_ref(fake_tensor)
+        weak_st = self.constant_storage_refs.get(fake_tensor)
         if weak_st is None:
             return
 

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -1068,10 +1068,25 @@ class FakeTensor(Tensor):
             )
         return self.nested_int_memo * coeff
 
+    def _is_nonzero(self) -> bool | SymBool:
+        torch._check(
+            self.numel() != 0,
+            lambda: "Boolean value of Tensor with no values is ambiguous",
+        )
+        torch._check(
+            self.numel() < 2,
+            lambda: "Boolean value of Tensor with more than one value is ambiguous",
+        )
+        if self.constant is not None:
+            with no_dispatch():
+                return bool(self.constant)
+        scalar = aten._local_scalar_dense.default(self)
+        if isinstance(scalar, SymBool):
+            return cast(bool | SymBool, scalar)
+        return cast(bool | SymBool, scalar != 0)
+
     def __bool__(self) -> bool:
-        # Route FakeTensor truthiness through aten.is_nonzero instead of the
-        # default local-scalar path so fake-specific scalar handling applies.
-        return bool(aten.is_nonzero.default(self))
+        return bool(self._is_nonzero())
 
     # Similar to FunctionalTensor.tolist
     def tolist(self) -> Any:

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -350,7 +350,9 @@ class FakeTensorConverter:
             self.constant_storage_mapping[weak_st] = []
         self.constant_storage_mapping[weak_st].append(weakref.ref(fake_tensor))
 
-    def invalidate_constant_aliases(self, tensor: Tensor) -> None:
+    def invalidate_constant_aliases(
+        self, tensor: Tensor, *, clear_constant_scalar: bool = True
+    ) -> None:
         if isinstance(tensor, FakeTensor):
             raise AssertionError("Expected a real tensor, not a FakeTensor")
 
@@ -364,6 +366,8 @@ class FakeTensorConverter:
                 # pyrefly: ignore [missing-attribute]
                 ten._fix_weakref()
                 ten.constant = None
+                if clear_constant_scalar:
+                    ten.constant_scalar = None
 
         del self.constant_storage_mapping[weak_st]
 
@@ -678,53 +682,19 @@ class SymNumberMemoDescriptor:
             setattr(obj, self._memo_epoch(obj), obj.fake_mode.epoch)
 
 
-class PythonScalarMemoDescriptor:
-    _name: str
-
-    def __set_name__(self, owner: str, name: str) -> None:
-        self._name = name
-
-    def _memo(self, obj: FakeTensor) -> str:
-        return f"_{self._name}"
-
-    def _memo_vc(self, obj: FakeTensor) -> str:
-        return f"_{self._name}_vc"
-
-    def _memo_epoch(self, obj: FakeTensor) -> str:
-        return f"_{self._name}_epoch"
-
-    def __get__(
-        self, obj: FakeTensor, objtype: type[FakeTensor] | None = None
-    ) -> bool | int | float | None:
-        if (r := getattr(obj, self._memo(obj))) is None:
-            return None
-
-        if (
-            getattr(obj, self._memo_vc(obj)) != obj._version
-            or getattr(obj, self._memo_epoch(obj)) != obj.fake_mode.epoch
-        ):
-            setattr(obj, self._memo(obj), None)
-            return None
-        return r
-
-    def __set__(self, obj: FakeTensor, value: bool | int | float | None) -> None:
-        if value is None:
-            setattr(obj, self._memo(obj), None)
-            setattr(obj, self._memo_vc(obj), None)
-            setattr(obj, self._memo_epoch(obj), None)
-        elif not obj.is_inference():
-            setattr(obj, self._memo(obj), value)
-            setattr(obj, self._memo_vc(obj), obj._version)
-            setattr(obj, self._memo_epoch(obj), obj.fake_mode.epoch)
-
-
-def _extract_constant_scalar(t: Tensor | None) -> bool | int | float | None:
+def _constant_scalar_tensor(t: Tensor | None) -> Tensor | None:
     if (
         t is None
         or not _is_plain_tensor(t)
         or t.dim() != 0
         or t.device.type != "cpu"
     ):
+        return None
+    return t
+
+
+def _extract_constant_scalar(t: Tensor | None) -> bool | int | float | None:
+    if (t := _constant_scalar_tensor(t)) is None:
         return None
 
     with no_dispatch():
@@ -746,6 +716,7 @@ class FakeTensor(Tensor):
     _fake_device: torch.device
     fake_mode: FakeTensorMode
     constant: Tensor | None
+    constant_scalar: Tensor | None
     real_tensor: Tensor | None
 
     # TODO: Generalize this as needed, e.g., into a trie of memos, if
@@ -753,7 +724,6 @@ class FakeTensor(Tensor):
     # memo mechanism here won't work)
     nonzero_memo: SymNumberMemoDescriptor | int | None = SymNumberMemoDescriptor()
     item_memo = SymNumberMemoDescriptor()
-    constant_scalar_memo = PythonScalarMemoDescriptor()
     unique_memo: SymNumberMemoDescriptor | int | None = SymNumberMemoDescriptor()
     unique_consecutive_memo: SymNumberMemoDescriptor | int | None = (
         SymNumberMemoDescriptor()
@@ -886,7 +856,7 @@ class FakeTensor(Tensor):
         self.real_tensor = real_tensor
         self.nonzero_memo = None
         self.item_memo = None
-        self.constant_scalar_memo = _extract_constant_scalar(constant)
+        self.constant_scalar = _constant_scalar_tensor(constant)
         self.unique_memo = None
         self.unique_consecutive_memo = None
         self.nested_int_memo = None
@@ -1139,7 +1109,7 @@ class FakeTensor(Tensor):
         if self.constant is not None:
             with no_dispatch():
                 return bool(self.constant)
-        if (scalar := self.constant_scalar_memo) is not None:
+        if (scalar := _extract_constant_scalar(self.constant_scalar)) is not None:
             return bool(scalar)
         return super().__bool__()
 
@@ -3202,6 +3172,12 @@ class FakeTensorMode(TorchDispatchMode):
         any_constant = any(e.constant is not None for e in flat_arg_fake_tensors)
         schema_info = get_schema_info(func)
         if any_constant and schema_info.is_mutable():
+            # Storage escapes invalidate tensor-wide constness, but a scalar can
+            # still be read from its live backing tensor until a real tensor write
+            # invalidates that source as well.
+            clear_constant_scalar = any(
+                isinstance(ret.type, torch.TensorType) for ret in func._schema.returns
+            )
             _, new_kwargs = normalize_function(  # type: ignore[misc]
                 func,
                 args=args,  # type: ignore[arg-type]
@@ -3215,7 +3191,9 @@ class FakeTensorMode(TorchDispatchMode):
                     and schema_info.is_mutable(k)
                     and v.constant is not None
                 ):
-                    self.fake_tensor_converter.invalidate_constant_aliases(v.constant)
+                    self.fake_tensor_converter.invalidate_constant_aliases(
+                        v.constant, clear_constant_scalar=clear_constant_scalar
+                    )
 
     def from_tensor(
         self,

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -1153,6 +1153,22 @@ class FakeTensor(Tensor):
         else:
             return [elem.tolist() for elem in self]
 
+    def _invalidate_constant_on_storage_access(self) -> None:
+        # Storage inspection exposes aliasing, so later writes must stop
+        # treating the touched constant storage as tensor-wide immutable.
+        if self.constant is not None:
+            self.fake_mode.fake_tensor_converter.invalidate_constant_aliases(
+                self.constant, clear_constant_scalar=False
+            )
+        elif self.fake_mode.fake_tensor_converter.has_constant_alias(self):
+            self.fake_mode.fake_tensor_converter.invalidate_constant_aliases_of_fake(
+                self, clear_constant_scalar=False
+            )
+
+    def untyped_storage(self):
+        self._invalidate_constant_on_storage_access()
+        return super().untyped_storage()
+
     def __bool__(self):
         if self.constant is not None:
             with no_dispatch():

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -360,6 +360,8 @@ class FakeTensorConverter:
         if weak_st not in self.constant_storage_mapping:
             return
 
+        live_refs: list[ReferenceType[FakeTensor]] = []
+        keep_tracking_scalar = False
         for weak_tensor_ref in self.constant_storage_mapping[weak_st]:
             ten = weak_tensor_ref()
             if ten is not None:
@@ -368,8 +370,16 @@ class FakeTensorConverter:
                 ten.constant = None
                 if clear_constant_scalar:
                     ten.constant_scalar = None
+                elif ten.constant_scalar is not None:
+                    keep_tracking_scalar = True
+                live_refs.append(weak_tensor_ref)
 
-        del self.constant_storage_mapping[weak_st]
+        if clear_constant_scalar or not keep_tracking_scalar:
+            del self.constant_storage_mapping[weak_st]
+        else:
+            # Storage exposure clears tensor-wide constness, but later tensor
+            # writes must still be able to find and clear the scalar fallback.
+            self.constant_storage_mapping[weak_st] = live_refs
 
     def _get_memo(self, t: Tensor) -> FakeTensor | None:
         tid = self.meta_converter.describer.lookup_tensor.get(t)
@@ -3140,6 +3150,16 @@ class FakeTensorMode(TorchDispatchMode):
         aten.set_.source_Storage_storage_offset,
         aten._sparse_coo_tensor_with_dims_and_tensors.default,
     )
+    # Storage-backed set_ exposes aliasing without overwriting the scalar
+    # payload yet, so keep scalar tracking alive until a later tensor write.
+    _preserve_constant_scalar_ops = ordered_set(
+        op
+        for op in (
+            getattr(aten.set_, "source_Storage", None),
+            aten.set_.source_Storage_storage_offset,
+        )
+        if op is not None
+    )
 
     _unbacked_special_fake_handling_ops = ordered_set(
         aten.view.default,
@@ -3169,15 +3189,13 @@ class FakeTensorMode(TorchDispatchMode):
         args: Sequence[object],
         kwargs: Mapping[str, object],
     ) -> None:
-        any_constant = any(e.constant is not None for e in flat_arg_fake_tensors)
+        any_constant = any(
+            e.constant is not None or e.constant_scalar is not None
+            for e in flat_arg_fake_tensors
+        )
         schema_info = get_schema_info(func)
         if any_constant and schema_info.is_mutable():
-            # Storage escapes invalidate tensor-wide constness, but a scalar can
-            # still be read from its live backing tensor until a real tensor write
-            # invalidates that source as well.
-            clear_constant_scalar = any(
-                isinstance(ret.type, torch.TensorType) for ret in func._schema.returns
-            )
+            clear_constant_scalar = func not in self._preserve_constant_scalar_ops
             _, new_kwargs = normalize_function(  # type: ignore[misc]
                 func,
                 args=args,  # type: ignore[arg-type]
@@ -3189,10 +3207,14 @@ class FakeTensorMode(TorchDispatchMode):
                 if (
                     self.is_our_fake(v)
                     and schema_info.is_mutable(k)
-                    and v.constant is not None
                 ):
+                    real_constant = (
+                        v.constant if v.constant is not None else v.constant_scalar
+                    )
+                    if real_constant is None:
+                        continue
                     self.fake_tensor_converter.invalidate_constant_aliases(
-                        v.constant, clear_constant_scalar=clear_constant_scalar
+                        real_constant, clear_constant_scalar=clear_constant_scalar
                     )
 
     def from_tensor(

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -1077,9 +1077,6 @@ class FakeTensor(Tensor):
         else:
             return [elem.tolist() for elem in self]
 
-    def __bool__(self):
-        return bool(self.item())
-
 
 _MetadataIntLike = Union[IntLikeType, "_PySymInputStub", "_SymIntOutputStub"]
 

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -12,8 +12,8 @@ import traceback
 import types
 import typing
 import weakref
-from collections.abc import Sequence
 from collections import defaultdict
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any, cast, Literal, TYPE_CHECKING, TypeGuard, TypeVar, Union
 from typing_extensions import Self
@@ -49,6 +49,7 @@ from torch.utils._python_dispatch import (
 from torch.utils._pytree import KeyPath, keystr, PyTree, tree_map, tree_map_, TreeSpec
 from torch.utils._stats import count
 from torch.utils._traceback import CapturedTraceback
+from torch.utils.weak import WeakTensorKeyDictionary
 
 from ._fake_tensor_utils import _CacheKeyState, _PySymInputStub, _SymIntOutputStub
 
@@ -327,7 +328,7 @@ class FakeTensorConverter:
 
     meta_converter: MetaConverter[FakeTensor]
     constant_storage_mapping: dict[StorageWeakRef, list[ReferenceType[FakeTensor]]]
-    constant_storage_refs: weakref.WeakKeyDictionary[FakeTensor, StorageWeakRef]
+    constant_storage_refs: WeakTensorKeyDictionary
     export: bool
 
     def __init__(self, *, copy_data: bool = False, export: bool = False) -> None:
@@ -336,7 +337,7 @@ class FakeTensorConverter:
 
         # map from to storage to corresponding constant tensors
         self.constant_storage_mapping = {}
-        self.constant_storage_refs = weakref.WeakKeyDictionary()
+        self.constant_storage_refs = WeakTensorKeyDictionary()
 
     def add_constant_storage_mapping(self, fake_tensor: FakeTensor) -> None:
         # when you have a constant, aliased tensor:
@@ -735,12 +736,7 @@ class SymNumberMemoDescriptor:
 
 
 def _constant_scalar_tensor(t: Tensor | None) -> Tensor | None:
-    if (
-        t is None
-        or not _is_plain_tensor(t)
-        or t.dim() != 0
-        or t.device.type != "cpu"
-    ):
+    if t is None or not _is_plain_tensor(t) or t.dim() != 0 or t.device.type != "cpu":
         return None
     return t
 

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -1078,7 +1078,10 @@ class FakeTensor(Tensor):
             return [elem.tolist() for elem in self]
 
     def __bool__(self):
-        return bool(self.item())
+        if self.constant is not None:
+            with no_dispatch():
+                return bool(self.constant)
+        return super().__bool__()
 
 
 _MetadataIntLike = Union[IntLikeType, "_PySymInputStub", "_SymIntOutputStub"]

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -1169,6 +1169,14 @@ class FakeTensor(Tensor):
         self._invalidate_constant_on_storage_access()
         return super().untyped_storage()
 
+    def item(self):
+        if self.constant is not None:
+            with no_dispatch():
+                return self.constant.item()
+        if (scalar := _extract_constant_scalar(self.constant_scalar)) is not None:
+            return scalar
+        return super().item()
+
     def __bool__(self):
         if self.constant is not None:
             with no_dispatch():
@@ -3251,6 +3259,33 @@ class FakeTensorMode(TorchDispatchMode):
             == tuple(real_constant.stride())
         )
 
+    def _invalidate_fake_tensor_constant(
+        self,
+        fake_tensor: FakeTensor,
+        *,
+        real_constant: Tensor | None = None,
+        clear_constant_scalar: bool = True,
+    ) -> None:
+        if real_constant is None:
+            real_constant = (
+                fake_tensor.constant
+                if fake_tensor.constant is not None
+                else fake_tensor.constant_scalar
+            )
+
+        fake_tensor.constant = None
+        if clear_constant_scalar:
+            fake_tensor.constant_scalar = None
+
+        if real_constant is not None:
+            self.fake_tensor_converter.invalidate_constant_aliases(
+                real_constant, clear_constant_scalar=clear_constant_scalar
+            )
+        elif self.fake_tensor_converter.has_constant_alias(fake_tensor):
+            self.fake_tensor_converter.invalidate_constant_aliases_of_fake(
+                fake_tensor, clear_constant_scalar=clear_constant_scalar
+            )
+
     _unbacked_special_fake_handling_ops = ordered_set(
         aten.view.default,
         aten._unsafe_view.default,
@@ -3279,6 +3314,24 @@ class FakeTensorMode(TorchDispatchMode):
         args: Sequence[object],
         kwargs: Mapping[str, object],
     ) -> None:
+        if func is aten.set_data.default:
+            fake_self = None
+            if len(args) > 0 and self.is_our_fake(args[0]):
+                fake_self = cast(FakeTensor, args[0])
+            else:
+                maybe_self = kwargs.get("self", kwargs.get("input"))
+                if self.is_our_fake(maybe_self):
+                    fake_self = cast(FakeTensor, maybe_self)
+
+            if fake_self is not None:
+                if (
+                    fake_self.constant is not None
+                    or fake_self.constant_scalar is not None
+                    or self.fake_tensor_converter.has_constant_alias(fake_self)
+                ):
+                    self._invalidate_fake_tensor_constant(fake_self)
+                return
+
         any_constant = any(
             e.constant is not None
             or e.constant_scalar is not None
@@ -3308,18 +3361,11 @@ class FakeTensorMode(TorchDispatchMode):
 
                     # Clear the mutated tensor first, then invalidate any
                     # tracked aliases that still point at the same storage.
-                    v.constant = None
-                    if clear_constant_scalar:
-                        v.constant_scalar = None
-
-                    if real_constant is not None:
-                        self.fake_tensor_converter.invalidate_constant_aliases(
-                            real_constant, clear_constant_scalar=clear_constant_scalar
-                        )
-                    elif self.fake_tensor_converter.has_constant_alias(v):
-                        self.fake_tensor_converter.invalidate_constant_aliases_of_fake(
-                            v, clear_constant_scalar=clear_constant_scalar
-                        )
+                    self._invalidate_fake_tensor_constant(
+                        v,
+                        real_constant=real_constant,
+                        clear_constant_scalar=clear_constant_scalar,
+                    )
 
     def from_tensor(
         self,

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -527,6 +527,16 @@ class FakeTensorConverter:
                         hint=value,
                         source=item_source,
                     )
+        if (
+            out.item_memo is None
+            and make_constant
+            and _is_plain_tensor(t)
+            and t.dim() == 0
+            and t.device.type == "cpu"
+        ):
+            value = t.item()
+            if isinstance(value, (bool, int, float)):
+                out.item_memo = value
         if make_constant:
             self.add_constant_storage_mapping(out)
         # NB: meta_converter set the memo
@@ -1081,13 +1091,9 @@ class FakeTensor(Tensor):
         if self.constant is not None:
             with no_dispatch():
                 return bool(self.constant)
+        if isinstance((item := self.item_memo), (bool, int, float)):
+            return bool(item)
         return super().__bool__()
-
-    def untyped_storage(self):
-        # Nested dispatch modes may inspect storages for alias or memory
-        # tracking. That read should not perturb FakeTensor constant state.
-        with no_dispatch():
-            return super().untyped_storage()
 
 
 _MetadataIntLike = Union[IntLikeType, "_PySymInputStub", "_SymIntOutputStub"]

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -1068,6 +1068,11 @@ class FakeTensor(Tensor):
             )
         return self.nested_int_memo * coeff
 
+    def __bool__(self) -> bool:
+        # Route FakeTensor truthiness through aten.is_nonzero instead of the
+        # default local-scalar path so fake-specific scalar handling applies.
+        return bool(aten.is_nonzero.default(self))
+
     # Similar to FunctionalTensor.tolist
     def tolist(self) -> Any:
         if self.dim() == 0:

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -1083,6 +1083,12 @@ class FakeTensor(Tensor):
                 return bool(self.constant)
         return super().__bool__()
 
+    def untyped_storage(self):
+        # Nested dispatch modes may inspect storages for alias or memory
+        # tracking. That read should not perturb FakeTensor constant state.
+        with no_dispatch():
+            return super().untyped_storage()
+
 
 _MetadataIntLike = Union[IntLikeType, "_PySymInputStub", "_SymIntOutputStub"]
 

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -1077,6 +1077,9 @@ class FakeTensor(Tensor):
         else:
             return [elem.tolist() for elem in self]
 
+    def __bool__(self):
+        return bool(self.item())
+
 
 _MetadataIntLike = Union[IntLikeType, "_PySymInputStub", "_SymIntOutputStub"]
 

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -12,6 +12,7 @@ import traceback
 import types
 import typing
 import weakref
+from collections.abc import Sequence
 from collections import defaultdict
 from dataclasses import dataclass
 from typing import Any, cast, Literal, TYPE_CHECKING, TypeGuard, TypeVar, Union
@@ -53,7 +54,7 @@ from ._fake_tensor_utils import _CacheKeyState, _PySymInputStub, _SymIntOutputSt
 
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Generator, Iterable, Mapping, Sequence
+    from collections.abc import Callable, Generator, Iterable, Mapping
     from types import TracebackType
 
     from torch._guards import Source
@@ -350,13 +351,21 @@ class FakeTensorConverter:
             self.constant_storage_mapping[weak_st] = []
         self.constant_storage_mapping[weak_st].append(weakref.ref(fake_tensor))
 
-    def invalidate_constant_aliases(
-        self, tensor: Tensor, *, clear_constant_scalar: bool = True
-    ) -> None:
-        if isinstance(tensor, FakeTensor):
-            raise AssertionError("Expected a real tensor, not a FakeTensor")
+    def _constant_storage_ref(self, tensor: Tensor) -> StorageWeakRef | None:
+        if is_sparse_any(tensor):
+            return None
+        try:
+            return StorageWeakRef(tensor._typed_storage())
+        except TypeError:
+            return None
 
-        weak_st = StorageWeakRef(tensor._typed_storage())
+    def has_constant_alias(self, tensor: Tensor) -> bool:
+        weak_st = self._constant_storage_ref(tensor)
+        return weak_st is not None and weak_st in self.constant_storage_mapping
+
+    def _invalidate_constant_aliases_by_ref(
+        self, weak_st: StorageWeakRef, *, clear_constant_scalar: bool = True
+    ) -> None:
         if weak_st not in self.constant_storage_mapping:
             return
 
@@ -380,6 +389,31 @@ class FakeTensorConverter:
             # Storage exposure clears tensor-wide constness, but later tensor
             # writes must still be able to find and clear the scalar fallback.
             self.constant_storage_mapping[weak_st] = live_refs
+
+    def invalidate_constant_aliases(
+        self, tensor: Tensor, *, clear_constant_scalar: bool = True
+    ) -> None:
+        if isinstance(tensor, FakeTensor):
+            raise AssertionError("Expected a real tensor, not a FakeTensor")
+
+        weak_st = self._constant_storage_ref(tensor)
+        if weak_st is None:
+            return
+
+        self._invalidate_constant_aliases_by_ref(
+            weak_st, clear_constant_scalar=clear_constant_scalar
+        )
+
+    def invalidate_constant_aliases_of_fake(
+        self, fake_tensor: FakeTensor, *, clear_constant_scalar: bool = True
+    ) -> None:
+        weak_st = self._constant_storage_ref(fake_tensor)
+        if weak_st is None:
+            return
+
+        self._invalidate_constant_aliases_by_ref(
+            weak_st, clear_constant_scalar=clear_constant_scalar
+        )
 
     def _get_memo(self, t: Tensor) -> FakeTensor | None:
         tid = self.meta_converter.describer.lookup_tensor.get(t)
@@ -3226,7 +3260,9 @@ class FakeTensorMode(TorchDispatchMode):
         kwargs: Mapping[str, object],
     ) -> None:
         any_constant = any(
-            e.constant is not None or e.constant_scalar is not None
+            e.constant is not None
+            or e.constant_scalar is not None
+            or self.fake_tensor_converter.has_constant_alias(e)
             for e in flat_arg_fake_tensors
         )
         schema_info = get_schema_info(func)
@@ -3239,21 +3275,31 @@ class FakeTensorMode(TorchDispatchMode):
             )
             for k, v in new_kwargs.items():
                 k = k if (k != "input" or schema_info.has_argument(k)) else "self"
-                if (
-                    self.is_our_fake(v)
-                    and schema_info.is_mutable(k)
-                ):
+                if self.is_our_fake(v) and schema_info.is_mutable(k):
                     real_constant = (
                         v.constant if v.constant is not None else v.constant_scalar
                     )
-                    if real_constant is None:
-                        continue
-                    clear_constant_scalar = not self._preserves_constant_scalar_on_write(
-                        func, new_kwargs, real_constant
+                    clear_constant_scalar = (
+                        real_constant is None
+                        or not self._preserves_constant_scalar_on_write(
+                            func, new_kwargs, real_constant
+                        )
                     )
-                    self.fake_tensor_converter.invalidate_constant_aliases(
-                        real_constant, clear_constant_scalar=clear_constant_scalar
-                    )
+
+                    # Clear the mutated tensor first, then invalidate any
+                    # tracked aliases that still point at the same storage.
+                    v.constant = None
+                    if clear_constant_scalar:
+                        v.constant_scalar = None
+
+                    if real_constant is not None:
+                        self.fake_tensor_converter.invalidate_constant_aliases(
+                            real_constant, clear_constant_scalar=clear_constant_scalar
+                        )
+                    elif self.fake_tensor_converter.has_constant_alias(v):
+                        self.fake_tensor_converter.invalidate_constant_aliases_of_fake(
+                            v, clear_constant_scalar=clear_constant_scalar
+                        )
 
     def from_tensor(
         self,

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -527,16 +527,6 @@ class FakeTensorConverter:
                         hint=value,
                         source=item_source,
                     )
-        if (
-            out.item_memo is None
-            and make_constant
-            and _is_plain_tensor(t)
-            and t.dim() == 0
-            and t.device.type == "cpu"
-        ):
-            value = t.item()
-            if isinstance(value, (bool, int, float)):
-                out.item_memo = value
         if make_constant:
             self.add_constant_storage_mapping(out)
         # NB: meta_converter set the memo
@@ -688,6 +678,62 @@ class SymNumberMemoDescriptor:
             setattr(obj, self._memo_epoch(obj), obj.fake_mode.epoch)
 
 
+class PythonScalarMemoDescriptor:
+    _name: str
+
+    def __set_name__(self, owner: str, name: str) -> None:
+        self._name = name
+
+    def _memo(self, obj: FakeTensor) -> str:
+        return f"_{self._name}"
+
+    def _memo_vc(self, obj: FakeTensor) -> str:
+        return f"_{self._name}_vc"
+
+    def _memo_epoch(self, obj: FakeTensor) -> str:
+        return f"_{self._name}_epoch"
+
+    def __get__(
+        self, obj: FakeTensor, objtype: type[FakeTensor] | None = None
+    ) -> bool | int | float | None:
+        if (r := getattr(obj, self._memo(obj))) is None:
+            return None
+
+        if (
+            getattr(obj, self._memo_vc(obj)) != obj._version
+            or getattr(obj, self._memo_epoch(obj)) != obj.fake_mode.epoch
+        ):
+            setattr(obj, self._memo(obj), None)
+            return None
+        return r
+
+    def __set__(self, obj: FakeTensor, value: bool | int | float | None) -> None:
+        if value is None:
+            setattr(obj, self._memo(obj), None)
+            setattr(obj, self._memo_vc(obj), None)
+            setattr(obj, self._memo_epoch(obj), None)
+        elif not obj.is_inference():
+            setattr(obj, self._memo(obj), value)
+            setattr(obj, self._memo_vc(obj), obj._version)
+            setattr(obj, self._memo_epoch(obj), obj.fake_mode.epoch)
+
+
+def _extract_constant_scalar(t: Tensor | None) -> bool | int | float | None:
+    if (
+        t is None
+        or not _is_plain_tensor(t)
+        or t.dim() != 0
+        or t.device.type != "cpu"
+    ):
+        return None
+
+    with no_dispatch():
+        value = t.item()
+    if isinstance(value, (bool, int, float)):
+        return value
+    return None
+
+
 class FakeTensor(Tensor):
     """
     Meta tensors give you the ability to run PyTorch code without having to
@@ -707,6 +753,7 @@ class FakeTensor(Tensor):
     # memo mechanism here won't work)
     nonzero_memo: SymNumberMemoDescriptor | int | None = SymNumberMemoDescriptor()
     item_memo = SymNumberMemoDescriptor()
+    constant_scalar_memo = PythonScalarMemoDescriptor()
     unique_memo: SymNumberMemoDescriptor | int | None = SymNumberMemoDescriptor()
     unique_consecutive_memo: SymNumberMemoDescriptor | int | None = (
         SymNumberMemoDescriptor()
@@ -839,6 +886,7 @@ class FakeTensor(Tensor):
         self.real_tensor = real_tensor
         self.nonzero_memo = None
         self.item_memo = None
+        self.constant_scalar_memo = _extract_constant_scalar(constant)
         self.unique_memo = None
         self.unique_consecutive_memo = None
         self.nested_int_memo = None
@@ -1091,8 +1139,8 @@ class FakeTensor(Tensor):
         if self.constant is not None:
             with no_dispatch():
                 return bool(self.constant)
-        if isinstance((item := self.item_memo), (bool, int, float)):
-            return bool(item)
+        if (scalar := self.constant_scalar_memo) is not None:
+            return bool(scalar)
         return super().__bool__()
 
 

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -1540,6 +1540,13 @@ class FakeTensorMode(TorchDispatchMode):
             self._stack = "".join(traceback.format_list(self._stack_trace))
         return self._stack
 
+    def _has_constant_tracking(self, fake_tensor: FakeTensor) -> bool:
+        return (
+            fake_tensor.constant is not None
+            or fake_tensor.constant_scalar is not None
+            or self.fake_tensor_converter.has_constant_alias(fake_tensor)
+        )
+
     @count
     # pyrefly: ignore [bad-override]
     def __torch_dispatch__(
@@ -1884,7 +1891,9 @@ class FakeTensorMode(TorchDispatchMode):
             if isinstance(arg, FakeTensor):
                 if not self.is_our_fake(arg):
                     raise _BypassDispatchCache("not our fake")
-                if arg.constant is not None:
+                # Constant tracking carries side effects that the cache does not
+                # replay, so mutable ops must re-enter normal dispatch.
+                if self._has_constant_tracking(arg):
                     raise _BypassDispatchCache("constant attribute")
                 if is_sparse_any(arg):
                     raise _BypassDispatchCache(f"{arg.layout} tensor")
@@ -1950,7 +1959,7 @@ class FakeTensorMode(TorchDispatchMode):
 
         # Avoid caching FakeTensors with constants attached since those
         # can be invalidated.
-        if output.constant is not None:
+        if self._has_constant_tracking(output):
             raise _BypassDispatchCache("constant attribute")
 
         # TODO: support caching sparse outputs?
@@ -3234,6 +3243,8 @@ class FakeTensorMode(TorchDispatchMode):
 
         source = kwargs.get("source")
         if source is None:
+            return False
+        if not isinstance(source, (torch.TypedStorage, torch.UntypedStorage)):
             return False
 
         try:


### PR DESCRIPTION
Fix #126738

## Root cause

`FakeTensor` already supports constant scalar `item()` calls, but Python truthiness still falls back to the generic tensor bool path. In patterns like `if torch.all(mask == 1)`, that path re-enters `_local_scalar_dense` and raises `DataDependentOutputException` even when the reduced fake scalar is constant.

## Proposed fix

Override `FakeTensor.__bool__` to delegate to `self.item()`, and add a regression test that exercises `torch.all(mask == 1)` under a nested `TorchDispatchMode`, matching the reported attention-mask pattern.

## Why this is the right long term fix

The bug is at the FakeTensor Python truthiness boundary, not in any model-specific attention code. Fixing that boundary keeps FakeTensor consistent with its existing constant-scalar `item()` behavior and covers the broader class of constant fake boolean checks that appear in eager Python control flow.

Drafted via @codex, published after manual review by @bobrenjc93