### PR TITLE
[Bugfix] Fix a bug when 0 dim linalg det backwards

### DIFF
--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -1055,7 +1055,7 @@ class TestLinalg(TestCase):
         for shape in [(0, 3, 3), (2, 0, 0)]:
             A = torch.randn(shape, device=device, dtype=dtype, requires_grad=True)
             det = torch.linalg.det(A)
-            det.sum().backward()
+            det.backward(torch.ones_like(det))
             self.assertIsNotNone(A.grad)
             self.assertEqual(A.grad.shape, A.shape)
             self.assertEqual(A.grad, torch.zeros_like(A))

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -1050,6 +1050,16 @@ class TestLinalg(TestCase):
         input = torch.tensor([[0.]], device=device, dtype=dtype, requires_grad=True)
         self.assertTrue(torch.autograd.gradcheck(torch.det, inputs=input))
 
+        # When A has 0 elements (e.g. empty batch), backward should return a
+        # zeros tensor with the same shape as A, not an undefined tensor.
+        for shape in [(0, 3, 3), (2, 0, 0)]:
+            A = torch.randn(shape, device=device, dtype=dtype, requires_grad=True)
+            det = torch.linalg.det(A)
+            det.sum().backward()
+            self.assertIsNotNone(A.grad)
+            self.assertEqual(A.grad.shape, A.shape)
+            self.assertEqual(A.grad, torch.zeros_like(A))
+
     @skipCUDAIfNoMagma
     @skipCPUIfNoLapack
     @dtypes(*floating_and_complex_types())

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -4312,9 +4312,11 @@ Tensor linalg_det_backward(
     const Tensor& LU,
     const Tensor& pivots) {
   at::NoTF32Guard disable_tf32;
-  // A.numel() == 0 necessary for the singular case
-  if (!grad.defined() || A.sym_numel() == 0) {
+  if (!grad.defined()) {
     return {};
+  }
+  if (A.sym_numel() == 0) {
+    return at::zeros_like(A);
   }
 
   // Special case handling for 1 x 1 matrix, to ensure mathematically correct.


### PR DESCRIPTION
Zero strided tensor should have gradients be a zero stride tensor, not an undefined Tensor (implicitly 1). This can cause issues with 2nd order and higher derivatives. It also violates the invariants that grad.shape == tensor.shape