### PR TITLE
[inductor] Support cpp-wrapper lazy compile in fbcode (#177502)

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -5383,7 +5383,6 @@ class CommonTemplate:
         for thread in threads:
             thread.join()
 
-    @unittest.skipIf(config.is_fbcode(), "fbcode triton error, needs debugging")
     @skip_if_triton_cpu("Flaky on Triton CPU")
     @skip_if_gpu_halide  # https://github.com/halide/Halide/issues/8311
     def test_adaptive_avg_pool2d_low_prec(self):
@@ -7318,8 +7317,6 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
 
     @config.patch(force_disable_caches=True)
     def test_deterministic_codegen(self):
-        if "cpu" in str(self.device) and config.is_fbcode():
-            raise unittest.SkipTest("cpp packaging is wacky in fbcode")
         if "cpu" in str(self.device) and config.cpp_wrapper:
             raise unittest.SkipTest(
                 "run_and_get_kernels can't extract kernels from CPU cpp_wrapper code"
@@ -7371,8 +7368,6 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
 
     @config.patch(force_disable_caches=True)
     def test_deterministic_codegen_on_graph_break(self):
-        if "cpu" in str(self.device) and config.is_fbcode():
-            raise unittest.SkipTest("cpp packaging is wacky in fbcode")
         if "cpu" in str(self.device) and config.cpp_wrapper:
             raise unittest.SkipTest(
                 "run_and_get_kernels can't extract kernels from CPU cpp_wrapper code"
@@ -7409,8 +7404,6 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         }
     )
     def test_deterministic_codegen_with_suffix(self):
-        if "cpu" in str(self.device) and config.is_fbcode():
-            raise unittest.SkipTest("cpp packaging is wacky in fbcode")
         if "cpu" in str(self.device) and config.cpp_wrapper:
             raise unittest.SkipTest(
                 "run_and_get_kernels can't extract kernels from CPU cpp_wrapper code"

--- a/torch/_inductor/codegen/cpp_wrapper_gpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_gpu.py
@@ -79,9 +79,7 @@ def signature_is_tma_desc(sig: str | None) -> bool:
 
 # Lazy compile helper code - only included in JIT mode
 LAZY_COMPILE_HELPER = """
-#include <torch/csrc/autograd/python_variable.h>
 #include <torch/csrc/inductor/aoti_torch/utils.h>
-#include <torch/csrc/utils/python_numbers.h>
 
 struct LazyKernelCompileResult {
     std::string cubin_path;
@@ -99,6 +97,9 @@ struct LazyKernelCompileResult {
     int profile_scratch;
 };
 
+static PyObject* (*_THPVariable_Wrap)(const at::TensorBase&) = nullptr;
+static int32_t (*_THPUtils_unpackInt)(PyObject*) = nullptr;
+
 // Cached module and function references
 static PyObject* triton_lazy_compile_module = nullptr;
 static PyObject* start_kernel_compile = nullptr;
@@ -114,6 +115,19 @@ static inline void loadLazyCompileFuncs() {
 
         run_triton_kernel_with_autotune = PyObject_GetAttrString(triton_lazy_compile_module, "run_triton_kernel_with_autotune");
         AOTI_TORCH_CHECK(run_triton_kernel_with_autotune, "Failed to get run_triton_kernel_with_autotune");
+
+        RAIIPyObject guards_mod = PyImport_ImportModule("torch._C._dynamo.guards");
+        AOTI_TORCH_CHECK(guards_mod, "Failed to import torch._C._dynamo.guards");
+
+        RAIIPyObject wrap_addr = PyObject_GetAttrString(guards_mod, "_torchinductor_thp_variable_wrap");
+        AOTI_TORCH_CHECK(wrap_addr, "Failed to get _torchinductor_thp_variable_wrap");
+        _THPVariable_Wrap = reinterpret_cast<decltype(_THPVariable_Wrap)>(PyLong_AsVoidPtr(wrap_addr));
+        AOTI_TORCH_CHECK(_THPVariable_Wrap, "THPVariable_Wrap not resolved");
+
+        RAIIPyObject unpack_addr = PyObject_GetAttrString(guards_mod, "_torchinductor_thputils_unpack_int");
+        AOTI_TORCH_CHECK(unpack_addr, "Failed to get _torchinductor_thputils_unpack_int");
+        _THPUtils_unpackInt = reinterpret_cast<decltype(_THPUtils_unpackInt)>(PyLong_AsVoidPtr(unpack_addr));
+        AOTI_TORCH_CHECK(_THPUtils_unpackInt, "THPUtils_unpackInt not resolved");
     }
 }
 
@@ -126,13 +140,13 @@ static inline std::string getStringAttr(PyObject* obj, const char* attr) {
 static inline int getIntAttr(PyObject* obj, const char* attr) {
     RAIIPyObject val = PyObject_GetAttrString(obj, attr);
     AOTI_TORCH_CHECK(val, "Failed to get attribute");
-    return THPUtils_unpackLong(val);
+    return _THPUtils_unpackInt(val);
 }
 
 static inline int getOptionalIntAttr(PyObject* obj, const char* attr, int sentinel = -1) {
     RAIIPyObject val = PyObject_GetAttrString(obj, attr);
     AOTI_TORCH_CHECK(val, "Failed to get attribute");
-    return (val.get() != Py_None) ? THPUtils_unpackLong(val) : sentinel;
+    return (val.get() != Py_None) ? _THPUtils_unpackInt(val) : sentinel;
 }
 
 static inline LazyKernelCompileResult extractCompileResult(PyObject* result) {
@@ -158,10 +172,10 @@ static inline PyObject* convertArgToPython(const T& arg) {
     using DecayedT = std::decay_t<T>;
     if constexpr (std::is_same_v<DecayedT, AtenTensorHandle>) {
         at::Tensor* tensor_ptr = torch::aot_inductor::tensor_handle_to_tensor_pointer(arg);
-        return THPVariable_Wrap(*tensor_ptr);
+        return _THPVariable_Wrap(*tensor_ptr);
     } else if constexpr (std::is_same_v<DecayedT, torch::aot_inductor::RAIIAtenTensorHandle>) {
         at::Tensor* tensor_ptr = torch::aot_inductor::tensor_handle_to_tensor_pointer(arg.get());
-        return THPVariable_Wrap(*tensor_ptr);
+        return _THPVariable_Wrap(*tensor_ptr);
     } else if constexpr (std::is_same_v<DecayedT, bool>) {
         PyObject* py_arg = arg ? Py_True : Py_False;
         Py_INCREF(py_arg);

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -6976,6 +6976,30 @@ PyObject* torch_c_dynamo_guards_init() {
     return nullptr;
   }
 
+  // Expose THPVariable_Wrap for cpp_wrapper inductor, for fbcode
+  {
+    using WrapFn = PyObject* (*)(const at::TensorBase&);
+    WrapFn fn = &THPVariable_Wrap;
+    if (PyModule_AddObject(
+            m,
+            "_torchinductor_thp_variable_wrap",
+            PyLong_FromVoidPtr(reinterpret_cast<void*>(fn))) < 0) {
+      return nullptr;
+    }
+  }
+
+  // Expose THPUtils_unpackInt for cpp_wrapper inductor, for fbcode
+  {
+    using UnpackFn = int32_t (*)(PyObject*);
+    UnpackFn fn = &THPUtils_unpackInt;
+    if (PyModule_AddObject(
+            m,
+            "_torchinductor_thputils_unpack_int",
+            PyLong_FromVoidPtr(reinterpret_cast<void*>(fn))) < 0) {
+      return nullptr;
+    }
+  }
+
   auto py_m = py::handle(m).cast<py::module>();
   py::class_<GuardDebugInfo, std::unique_ptr<GuardDebugInfo>>(
       py_m, "GuardDebugInfo")

--- a/torch/csrc/inductor/cpp_wrapper/common.h
+++ b/torch/csrc/inductor/cpp_wrapper/common.h
@@ -10,9 +10,6 @@
 #include <pybind11/gil_simple.h>
 #else
 // pybind11 < 3.0: gil_simple.h does not exist yet.
-// Use simple GIL management to avoid pulling in
-// pybind11::detail::get_internals() which requires linking against pybind11
-// symbols unavailable in JIT builds.
 #define PYBIND11_SIMPLE_GIL_MANAGEMENT
 #include <pybind11/gil.h>
 // Provide the _simple aliases so generated code works with either version.


### PR DESCRIPTION
Summary:

When enabling cpp-wrapper lazy compile in fbcode, THPVariable_Wrap and THPUtils_unpackLong need special dynamic symbol handling.

Differential Revision: D96662463




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Lucaskabela