### PR TITLE
[On-call] Fix MI300X conveyor build failure (#177503)

### DIFF
--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -459,9 +459,15 @@ struct ExpandableSegment {
       if (enable_ipc_handles) {
         if (CUDAAllocatorConfig::expandable_segments_handle_type() !=
             Expandable_Segments_Handle_Type::FABRIC_HANDLE) {
+#ifdef USE_ROCM
+          prop.requestedHandleType = hipMemHandleTypePosixFileDescriptor;
+#else
           prop.requestedHandleTypes = CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
+#endif
         } else {
+#ifndef USE_ROCM
           prop.requestedHandleTypes = CU_MEM_HANDLE_TYPE_FABRIC;
+#endif
         }
       }
       int flag = 0;


### PR DESCRIPTION
Summary:

Two HIP/ROCm 6.2.1 build fixes for the MI300X conveyor: https://www.internalfb.com/conveyor/admarket/sigrid_predictor_hip/releases

**1. `CUDACachingAllocator.cpp`**

D96556656 ("[ROCm] Enable expandable segments") introduced `prop.requestedHandleTypes` (plural) in `CUDACachingAllocator.cpp`, which is the correct CUDA API field name. However, the HIP/ROCm 6.2.1 equivalent is `requestedHandleType` (singular), causing a compilation failure when the file is hipified.

This fix adds `#ifdef USE_ROCM` guards to:
1. Use `prop.requestedHandleType = hipMemHandleTypePosixFileDescriptor` for ROCm (singular field, HIP constant)
2. Use `prop.requestedHandleTypes = CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR` for CUDA (plural field, CUDA constant)
3. Skip the `CU_MEM_HANDLE_TYPE_FABRIC` assignment entirely on ROCm, as `hipMemHandleTypeFabric` does not exist in HIP

**2. `CtranGpeImpl.cc`**

D95253327 ("[ctran] GPE cudagraph support") added `hipEventWaitExternal` and `hipEventWaitDefault` under a `__HIP_PLATFORM_AMD__` guard, but these symbols are not available across all ROCm versions. The fix replaces them with raw flag values (`0x01` for wait-external, `0x00` for wait-default) for all HIP builds.

Test Plan:
- `buck build fbcode//caffe2/c10/cuda:hip` — BUILD SUCCEEDED
- `buck build fbcode//comms/ctran:hetero_ctran_lib` — BUILD SUCCEEDED
- `fbpkg build sigrid.predictor.hip` — BUILD SUCCEEDED (package: sigrid.predictor.hip:984b3e84a970b3bcabb21ccfcae723ab)

Reviewed By: dolpm

Differential Revision: D96652342


