### PR TITLE
[PowerPC] Fix double rounding in Half fmadd/fmsub/fnmsub

### DIFF
--- a/aten/src/ATen/cpu/vec/vec256/vsx/vec256_common_vsx.h
+++ b/aten/src/ATen/cpu/vec/vec256/vsx/vec256_common_vsx.h
@@ -69,6 +69,66 @@ Vectorized<int16_t> C10_ALWAYS_INLINE fmadd(
       a.vec0() * b.vec0() + c.vec0(), a.vec1() * b.vec1() + c.vec1()};
 }
 
+template <>
+Vectorized<c10::Half> C10_ALWAYS_INLINE fmadd(
+    const Vectorized<c10::Half>& a,
+    const Vectorized<c10::Half>& b,
+    const Vectorized<c10::Half>& c) {
+  constexpr int size = Vectorized<c10::Half>::size();
+  Vectorized<c10::Half> result;
+
+  for (int i = 0; i < size; i++) {
+    float af = static_cast<float>(a[i]);
+    float bf = static_cast<float>(b[i]);
+    float cf = static_cast<float>(c[i]);
+
+    float ab = af * bf;
+    float rf = ab + cf;
+    result[i] = c10::Half(rf);
+  }
+  return result;
+}
+
+template <>
+Vectorized<c10::Half> C10_ALWAYS_INLINE fmsub(
+    const Vectorized<c10::Half>& a,
+    const Vectorized<c10::Half>& b,
+    const Vectorized<c10::Half>& c) {
+  constexpr int size = Vectorized<c10::Half>::size();
+  Vectorized<c10::Half> result;
+
+  for (int i = 0; i < size; i++) {
+    float af = static_cast<float>(a[i]);
+    float bf = static_cast<float>(b[i]);
+    float cf = static_cast<float>(c[i]);
+
+    float ab = af * bf;
+    float rf = ab - cf;
+    result[i] = c10::Half(rf);
+  }
+  return result;
+}
+
+template <>
+Vectorized<c10::Half> C10_ALWAYS_INLINE fnmsub(
+    const Vectorized<c10::Half>& a,
+    const Vectorized<c10::Half>& b,
+    const Vectorized<c10::Half>& c) {
+  constexpr int size = Vectorized<c10::Half>::size();
+  Vectorized<c10::Half> result;
+
+  for (int i = 0; i < size; i++) {
+    float af = static_cast<float>(a[i]);
+    float bf = static_cast<float>(b[i]);
+    float cf = static_cast<float>(c[i]);
+
+    float ab = -(af * bf);
+    float rf = ab - cf;
+    result[i] = c10::Half(rf);
+  }
+  return result;
+}
+
 DEFINE_REINTERPRET_CAST_TO_ALL_FUNCS(float)
 DEFINE_REINTERPRET_CAST_TO_ALL_FUNCS(double)
 DEFINE_REINTERPRET_CAST_TO_ALL_FUNCS(int64_t)


### PR DESCRIPTION
### Summary
Fix incorrect rounding behavior in fmadd, fmsub, and fnmsub implementations
for Vectorized<c10::Half> on PowerPC.

### Problem
The previous implementation performed an intermediate rounding step when computing fused multiply-add style operations.


Instead of performing the entire computation in fp32 and rounding once when converting back to fp16, the multiplication result was first rounded to fp16 and then added to `output`.

**Previous behavior:**

out = a * b + c
tmp = fp16(fp32(a) * fp32(b))
out = fp16(fp32(tmp) + fp32(c))

This introduced **two rounding steps**:
1. fp32 → fp16 after multiplication
2. fp32 → fp16 after addition

### Correct behavior

The fused operation should perform the computation in fp32 and only convert back to fp16 once at the end:

out = fp16(fp32(a) * fp32(b) + fp32(c))

This avoids intermediate rounding and matches the expected fused multiply-add semantics.

### Fix
The implementation was updated so that both multiplication and addition are performed in fp32 before converting the final result to `c10::Half`.

### Test Failures Before Fix

Example failure:

Expected:
-2308

Actual:
-2306

Failing tests:

BitwiseFloatsAdditional/3.Fmadd
BitwiseFloatsAdditional/3.Fmsub
BitwiseFloatsAdditional/3.FmaddVecN

### After Fix
All vector tests pass:

[==========] 360 tests from 134 test suites ran
[ PASSED ] 360 tests

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01