### PR TITLE
Add target range validation to binary_cross_entropy_with_logits

### DIFF
--- a/aten/src/ATen/native/Loss.cpp
+++ b/aten/src/ATen/native/Loss.cpp
@@ -347,6 +347,10 @@ Tensor& binary_cross_entropy_backward_out_cpu(const Tensor& grad, const Tensor& 
 }
 
 Tensor binary_cross_entropy_with_logits(const Tensor& input, const Tensor& target, const std::optional<Tensor>& weight_opt, const std::optional<Tensor>& pos_weight_opt, int64_t reduction) {
+  TORCH_CHECK(
+      at::all(target >= 0).item<bool>() && at::all(target <= 1).item<bool>(),
+      "all elements of target should be between 0 and 1");
+
   auto log_sigmoid_input = at::log_sigmoid(input);
   if (pos_weight_opt.has_value() && pos_weight_opt->defined()) {
       // pos_weight need to be broadcasted, thus mul(target) is not inplace.

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4894,6 +4894,18 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         out2 = nn.BCEWithLogitsLoss(pos_weight=pos_weight)(output, target)
         self.assertTrue(torch.isfinite(out2).all().item())
 
+    def test_bce_with_logits_target_range(self):
+        output = torch.randn(25, 25)
+        target_valid = torch.rand(25, 25)
+        target_too_negative = target_valid - 1.0
+        target_too_positive = target_valid + 1.0
+
+        loss_valid = nn.BCEWithLogitsLoss()(output, target_valid)
+        with self.assertRaisesRegex(RuntimeError, 'between 0 and 1'):
+            nn.BCEWithLogitsLoss()(output, target_too_negative)
+        with self.assertRaisesRegex(RuntimeError, 'between 0 and 1'):
+            nn.BCEWithLogitsLoss()(output, target_too_positive)
+
     def test_bce_loss_broadcasts_weights(self):
         sigmoid = nn.Sigmoid()
         target = torch.rand(16, 4)


### PR DESCRIPTION
Fixes #110865

## Summary

`BCEWithLogitsLoss` currently does not validate that `target` values lie within `[0, 1]`, silently producing meaningless loss values when given out-of-range targets. This can mask subtle bugs in user code (e.g., accidentally passing multi-class integer labels to a binary loss).

`BCELoss` already validates this with a `TORCH_CHECK` in the CPU and CUDA kernels. This PR adds the same validation to `binary_cross_entropy_with_logits`.

### Changes
- Added `TORCH_CHECK` in `aten/src/ATen/native/Loss.cpp` to validate target is in `[0, 1]`
- Added `test_bce_with_logits_target_range` regression test in `test/test_nn.py`

### Note
This uses `at::all(target >= 0)` / `at::all(target <= 1)` which is a single-pass scan of the target tensor. For typical loss computation workloads, this overhead is negligible compared to the `log_sigmoid` and multiplication operations that follow.

This PR was authored with Claude.

cc @mikaylagawarecki