### PR TITLE
[xpu][feature]Enhancing SYCL Toolkit Integration in CMake: Ensuring Proper Linking of Intel Runtime Library with Non-Intel Linkers

### DIFF
--- a/cmake/Modules/FindSYCLToolkit.cmake
+++ b/cmake/Modules/FindSYCLToolkit.cmake
@@ -125,6 +125,19 @@ find_library(
   NO_DEFAULT_PATH
 )
 
+# Find Intel runtime library (libintlc), required when linking SYCL objects
+# with a non-icpx linker (e.g. g++). icpx adds this automatically, but g++
+# does not, leading to undefined reference to '_intel_fast_memcpy' etc.
+find_library(
+  SYCL_INTLC_LIBRARY
+  NAMES intlc
+  HINTS ${SYCL_LIBRARY_DIR}
+  NO_DEFAULT_PATH
+)
+if(SYCL_INTLC_LIBRARY)
+  list(APPEND SYCL_LIBRARY ${SYCL_INTLC_LIBRARY})
+endif()
+
 if((NOT SYCL_LIBRARY) OR (NOT OCL_LIBRARY))
   set(SYCL_FOUND False)
   set(SYCL_REASON_FAILURE "SYCL library is incomplete!!")


### PR DESCRIPTION
This pull request improves the SYCL toolkit integration in the CMake build system by ensuring that the required Intel runtime library (`libintlc`) is correctly linked when using non-Intel linkers. This prevents build errors related to missing symbols such as `_intel_fast_memcpy`.

Build system enhancements:

* Added logic in `cmake/Modules/FindSYCLToolkit.cmake` to find and append the Intel runtime library (`libintlc`) to the `SYCL_LIBRARY` list when linking SYCL objects with non-Intel linkers. This fixes issues with undefined references that can occur when using linkers like `g++` instead of `icpx`.

cc @gujinghui @EikanWang @fengyuan14 @guangyey