### PR TITLE
OpenReg distributed transport layer.

### DIFF
--- a/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/distributed/OcclTransport.cpp
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/distributed/OcclTransport.cpp
@@ -96,6 +96,7 @@ static void setSocketTimeout(int fd, int timeoutSec) {
 }
 
 static constexpr int kDataTimeoutSec = 300; // 5 minutes
+static constexpr int kConnectTimeoutSec = 60; // 1 minute
 
 void OcclTransport::send(
     const void* data,
@@ -179,28 +180,40 @@ void OcclTransport::ensureConnected(int peerRank) {
     int fd = ::socket(AF_INET, SOCK_STREAM, 0);
     TORCH_CHECK(fd >= 0, "Failed to create socket: ", strerror(errno));
 
-    int optval = 1;
-    ::setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &optval, sizeof(optval));
+    try {
+      int optval = 1;
+      ::setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &optval, sizeof(optval));
 
-    struct sockaddr_in addr{};
-    addr.sin_family = AF_INET;
-    addr.sin_port = htons(static_cast<uint16_t>(conn.port));
-    TORCH_CHECK(
-        ::inet_pton(AF_INET, conn.host.c_str(), &addr.sin_addr) == 1,
-        "Invalid peer address: ", conn.host);
+      struct sockaddr_in addr{};
+      addr.sin_family = AF_INET;
+      addr.sin_port = htons(static_cast<uint16_t>(conn.port));
+      TORCH_CHECK(
+          ::inet_pton(AF_INET, conn.host.c_str(), &addr.sin_addr) == 1,
+          "Invalid peer address: ", conn.host);
 
-    TORCH_CHECK(
-        ::connect(fd, reinterpret_cast<struct sockaddr*>(&addr), sizeof(addr)) == 0,
-        "Failed to connect to rank ", peerRank, ": ", strerror(errno));
+      TORCH_CHECK(
+          ::connect(fd, reinterpret_cast<struct sockaddr*>(&addr), sizeof(addr)) == 0,
+          "Failed to connect to rank ", peerRank, ": ", strerror(errno));
 
-    // Handshake: send our rank so the peer knows who connected
-    int32_t myRank = rank_;
-    sendAll(fd, &myRank, sizeof(myRank));
+      // Handshake: send our rank so the peer knows who connected
+      int32_t myRank = rank_;
+      sendAll(fd, &myRank, sizeof(myRank));
+    } catch (...) {
+      ::close(fd);
+      throw;
+    }
 
     conn.fd = fd;
   } else {
     // Higher rank waits for the accept thread to fill in the fd
-    conn.cv.wait(lock, [&conn] { return conn.fd >= 0; });
+    bool connected = conn.cv.wait_for(
+        lock,
+        std::chrono::seconds(kConnectTimeoutSec),
+        [&conn] { return conn.fd >= 0; });
+    TORCH_CHECK(
+        connected,
+        "Timed out waiting for connection from rank ", peerRank,
+        " after ", kConnectTimeoutSec, "s");
   }
 }
 

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/distributed/OcclTransport.cpp
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/distributed/OcclTransport.cpp
@@ -235,6 +235,7 @@ void OcclTransport::acceptLoop() {
       if (stop_.load()) {
         break; // listenFd_ was closed during shutdown
       }
+      TORCH_WARN("OCCL acceptLoop: accept() failed: ", strerror(errno));
       break;
     }
 
@@ -263,15 +264,19 @@ void OcclTransport::sendAll(int fd, const void* buf, size_t len) {
   size_t sent = 0;
   while (sent < len) {
     auto n = ::send(fd, ptr + sent, len - sent, 0);
-    if (n <= 0) {
-      if (errno == EAGAIN || errno == EWOULDBLOCK) {
+    if (n > 0) {
+      sent += static_cast<size_t>(n);
+      continue;
+    }
+    if (n < 0 && errno == EINTR) {
+      continue;
+    }
+    if (n < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
         C10_THROW_ERROR(DistBackendError, "OCCL send timed out");
       }
       C10_THROW_ERROR(
           DistBackendError,
           std::string("OCCL send failed: ") + strerror(errno));
-    }
-    sent += static_cast<size_t>(n);
   }
 }
 
@@ -280,18 +285,22 @@ void OcclTransport::recvAll(int fd, void* buf, size_t len) {
   size_t received = 0;
   while (received < len) {
     auto n = ::recv(fd, ptr + received, len - received, 0);
-    if (n <= 0) {
+    if (n > 0) {
+      received += static_cast<size_t>(n);
+      continue;
+    }
       if (n == 0) {
         C10_THROW_ERROR(DistBackendError, "OCCL recv: peer closed connection");
       }
+    if (errno == EINTR) {
+      continue;
+    }
       if (errno == EAGAIN || errno == EWOULDBLOCK) {
         C10_THROW_ERROR(DistBackendError, "OCCL recv timed out");
       }
       C10_THROW_ERROR(
           DistBackendError,
           std::string("OCCL recv failed: ") + strerror(errno));
-    }
-    received += static_cast<size_t>(n);
   }
 }
 

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/distributed/OcclTransport.cpp
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/distributed/OcclTransport.cpp
@@ -24,7 +24,46 @@ OcclTransport::OcclTransport(
   TORCH_CHECK(rank >= 0 && rank < worldSize, "Invalid rank: ", rank);
   TORCH_CHECK(worldSize > 0, "Invalid worldSize: ", worldSize);
 
-  // TODO: Create listening socket, publish address, start accept thread
+  // Create listening socket on ephemeral port
+  listenFd_ = ::socket(AF_INET, SOCK_STREAM, 0);
+  TORCH_CHECK(listenFd_ >= 0, "Failed to create listen socket: ", strerror(errno));
+
+  int optval = 1;
+  ::setsockopt(listenFd_, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval));
+
+  struct sockaddr_in addr{};
+  addr.sin_family = AF_INET;
+  addr.sin_addr.s_addr = htonl(INADDR_ANY);
+  addr.sin_port = 0; // ephemeral port
+  TORCH_CHECK(
+      ::bind(listenFd_, reinterpret_cast<struct sockaddr*>(&addr), sizeof(addr)) == 0,
+      "Failed to bind listen socket: ", strerror(errno));
+
+  TORCH_CHECK(
+      ::listen(listenFd_, worldSize) == 0,
+      "Failed to listen: ", strerror(errno));
+
+  // Learn the assigned port
+  socklen_t addrLen = sizeof(addr);
+  TORCH_CHECK(
+      ::getsockname(listenFd_, reinterpret_cast<struct sockaddr*>(&addr), &addrLen) == 0,
+      "Failed to get listen port: ", strerror(errno));
+  listenPort_ = ntohs(addr.sin_port);
+
+  // Publish our address and read peers' addresses
+  publishAddress();
+  for (int i = 0; i < worldSize_; ++i) {
+    if (i == rank_) {
+      continue;
+    }
+    std::string peerAddr = getPeerAddress(i);
+    auto colonPos = peerAddr.rfind(':');
+    TORCH_CHECK(colonPos != std::string::npos, "Malformed peer address: ", peerAddr);
+    peers_[i].host = peerAddr.substr(0, colonPos);
+    peers_[i].port = std::stoi(peerAddr.substr(colonPos + 1));
+  }
+
+  // TODO: Start accept thread
 }
 
 OcclTransport::~OcclTransport() {
@@ -74,11 +113,16 @@ void OcclTransport::ensureConnected(int peerRank) {
 }
 
 void OcclTransport::publishAddress() {
-  TORCH_CHECK(false, "OcclTransport::publishAddress not yet implemented");
+  // Use localhost — OCCL is single-machine only
+  std::string addr = "127.0.0.1:" + std::to_string(listenPort_);
+  std::vector<uint8_t> data(addr.begin(), addr.end());
+  store_->set("addr/" + std::to_string(rank_), data);
 }
 
 std::string OcclTransport::getPeerAddress(int peerRank) {
-  TORCH_CHECK(false, "OcclTransport::getPeerAddress not yet implemented");
+  // Blocks until the peer has published its address
+  auto data = store_->get("addr/" + std::to_string(peerRank));
+  return std::string(data.begin(), data.end());
 }
 
 void OcclTransport::acceptLoop() {

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/distributed/OcclTransport.cpp
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/distributed/OcclTransport.cpp
@@ -63,7 +63,7 @@ OcclTransport::OcclTransport(
     peers_[i].port = std::stoi(peerAddr.substr(colonPos + 1));
   }
 
-  // TODO: Start accept thread
+  acceptThread_ = std::thread(&OcclTransport::acceptLoop, this);
 }
 
 OcclTransport::~OcclTransport() {
@@ -109,7 +109,41 @@ void OcclTransport::recv(
 }
 
 void OcclTransport::ensureConnected(int peerRank) {
-  TORCH_CHECK(false, "OcclTransport::ensureConnected not yet implemented");
+  auto& conn = peers_[peerRank];
+  std::unique_lock<std::mutex> lock(conn.mutex);
+
+  if (conn.fd >= 0) {
+    return;
+  }
+
+  if (rank_ < peerRank) {
+    // Lower rank initiates the connection
+    int fd = ::socket(AF_INET, SOCK_STREAM, 0);
+    TORCH_CHECK(fd >= 0, "Failed to create socket: ", strerror(errno));
+
+    int optval = 1;
+    ::setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &optval, sizeof(optval));
+
+    struct sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(static_cast<uint16_t>(conn.port));
+    TORCH_CHECK(
+        ::inet_pton(AF_INET, conn.host.c_str(), &addr.sin_addr) == 1,
+        "Invalid peer address: ", conn.host);
+
+    TORCH_CHECK(
+        ::connect(fd, reinterpret_cast<struct sockaddr*>(&addr), sizeof(addr)) == 0,
+        "Failed to connect to rank ", peerRank, ": ", strerror(errno));
+
+    // Handshake: send our rank so the peer knows who connected
+    int32_t myRank = rank_;
+    sendAll(fd, &myRank, sizeof(myRank));
+
+    conn.fd = fd;
+  } else {
+    // Higher rank waits for the accept thread to fill in the fd
+    conn.cv.wait(lock, [&conn] { return conn.fd >= 0; });
+  }
 }
 
 void OcclTransport::publishAddress() {
@@ -126,15 +160,64 @@ std::string OcclTransport::getPeerAddress(int peerRank) {
 }
 
 void OcclTransport::acceptLoop() {
-  // TODO: Accept incoming connections from peers
+  // Set a timeout on the listening socket so we can check stop_ periodically
+  struct timeval tv{};
+  tv.tv_sec = 1;
+  ::setsockopt(listenFd_, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+
+  while (!stop_.load()) {
+    struct sockaddr_in peerAddr{};
+    socklen_t peerAddrLen = sizeof(peerAddr);
+    int fd = ::accept(listenFd_, reinterpret_cast<struct sockaddr*>(&peerAddr), &peerAddrLen);
+
+    if (fd < 0) {
+      if (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR) {
+        continue; // timeout or interrupt — check stop_ and retry
+      }
+      if (stop_.load()) {
+        break; // listenFd_ was closed during shutdown
+      }
+      break;
+    }
+
+    int optval = 1;
+    ::setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &optval, sizeof(optval));
+
+    // Read handshake: the connecting rank's identity
+    int32_t connectingRank = -1;
+    recvAll(fd, &connectingRank, sizeof(connectingRank));
+
+    TORCH_CHECK(
+        connectingRank >= 0 && connectingRank < worldSize_,
+        "Invalid connecting rank in handshake: ", connectingRank);
+
+    auto& conn = peers_[connectingRank];
+    {
+      std::lock_guard<std::mutex> lock(conn.mutex);
+      conn.fd = fd;
+    }
+    conn.cv.notify_one();
+  }
 }
 
 void OcclTransport::sendAll(int fd, const void* buf, size_t len) {
-  TORCH_CHECK(false, "OcclTransport::sendAll not yet implemented");
+  auto ptr = static_cast<const char*>(buf);
+  size_t sent = 0;
+  while (sent < len) {
+    auto n = ::send(fd, ptr + sent, len - sent, 0);
+    TORCH_CHECK(n > 0, "sendAll failed: ", strerror(errno));
+    sent += static_cast<size_t>(n);
+  }
 }
 
 void OcclTransport::recvAll(int fd, void* buf, size_t len) {
-  TORCH_CHECK(false, "OcclTransport::recvAll not yet implemented");
+  auto ptr = static_cast<char*>(buf);
+  size_t received = 0;
+  while (received < len) {
+    auto n = ::recv(fd, ptr + received, len - received, 0);
+    TORCH_CHECK(n > 0, "recvAll failed: ", strerror(errno));
+    received += static_cast<size_t>(n);
+  }
 }
 
 } // namespace c10d::openreg

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/distributed/OcclTransport.cpp
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/distributed/OcclTransport.cpp
@@ -1,0 +1,96 @@
+#include "OcclTransport.h"
+
+#include <arpa/inet.h>
+#include <netinet/tcp.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <cstring>
+#include <sstream>
+
+#include <c10/util/Exception.h>
+#include <torch/csrc/distributed/c10d/PrefixStore.hpp>
+
+namespace c10d::openreg {
+
+OcclTransport::OcclTransport(
+    int rank,
+    int worldSize,
+    c10::intrusive_ptr<::c10d::Store> store)
+    : rank_(rank),
+      worldSize_(worldSize),
+      store_(c10::make_intrusive<::c10d::PrefixStore>("occl", std::move(store))),
+      peers_(static_cast<size_t>(worldSize)) {
+  TORCH_CHECK(rank >= 0 && rank < worldSize, "Invalid rank: ", rank);
+  TORCH_CHECK(worldSize > 0, "Invalid worldSize: ", worldSize);
+
+  // TODO: Create listening socket, publish address, start accept thread
+}
+
+OcclTransport::~OcclTransport() {
+  stop_.store(true);
+
+  // Close listening socket to unblock accept()
+  if (listenFd_ >= 0) {
+    ::close(listenFd_);
+    listenFd_ = -1;
+  }
+
+  if (acceptThread_.joinable()) {
+    acceptThread_.join();
+  }
+
+  // Close all peer connections
+  for (auto& conn : peers_) {
+    if (conn.fd >= 0) {
+      ::close(conn.fd);
+      conn.fd = -1;
+    }
+  }
+}
+
+void OcclTransport::send(
+    const void* data,
+    size_t nbytes,
+    int dstRank,
+    uint8_t dtype,
+    uint64_t numel,
+    uint32_t tag) {
+  TORCH_CHECK(false, "OcclTransport::send not yet implemented");
+}
+
+void OcclTransport::recv(
+    void* data,
+    size_t nbytes,
+    int srcRank,
+    uint8_t dtype,
+    uint64_t numel,
+    uint32_t tag) {
+  TORCH_CHECK(false, "OcclTransport::recv not yet implemented");
+}
+
+void OcclTransport::ensureConnected(int peerRank) {
+  TORCH_CHECK(false, "OcclTransport::ensureConnected not yet implemented");
+}
+
+void OcclTransport::publishAddress() {
+  TORCH_CHECK(false, "OcclTransport::publishAddress not yet implemented");
+}
+
+std::string OcclTransport::getPeerAddress(int peerRank) {
+  TORCH_CHECK(false, "OcclTransport::getPeerAddress not yet implemented");
+}
+
+void OcclTransport::acceptLoop() {
+  // TODO: Accept incoming connections from peers
+}
+
+void OcclTransport::sendAll(int fd, const void* buf, size_t len) {
+  TORCH_CHECK(false, "OcclTransport::sendAll not yet implemented");
+}
+
+void OcclTransport::recvAll(int fd, void* buf, size_t len) {
+  TORCH_CHECK(false, "OcclTransport::recvAll not yet implemented");
+}
+
+} // namespace c10d::openreg

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/distributed/OcclTransport.cpp
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/distributed/OcclTransport.cpp
@@ -88,6 +88,15 @@ OcclTransport::~OcclTransport() {
   }
 }
 
+static void setSocketTimeout(int fd, int timeoutSec) {
+  struct timeval tv{};
+  tv.tv_sec = timeoutSec;
+  ::setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
+  ::setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+}
+
+static constexpr int kDataTimeoutSec = 300; // 5 minutes
+
 void OcclTransport::send(
     const void* data,
     size_t nbytes,
@@ -95,7 +104,26 @@ void OcclTransport::send(
     uint8_t dtype,
     uint64_t numel,
     uint32_t tag) {
-  TORCH_CHECK(false, "OcclTransport::send not yet implemented");
+  TORCH_CHECK(
+      dstRank >= 0 && dstRank < worldSize_ && dstRank != rank_,
+      "Invalid dstRank: ", dstRank);
+
+  ensureConnected(dstRank);
+
+  auto& conn = peers_[dstRank];
+  std::lock_guard<std::mutex> lock(conn.mutex);
+
+  setSocketTimeout(conn.fd, kDataTimeoutSec);
+
+  WireHeader hdr{};
+  hdr.tag = tag;
+  hdr.dtype = dtype;
+  hdr.numel = numel;
+  sendAll(conn.fd, &hdr, sizeof(hdr));
+
+  if (nbytes > 0) {
+    sendAll(conn.fd, data, nbytes);
+  }
 }
 
 void OcclTransport::recv(
@@ -105,7 +133,37 @@ void OcclTransport::recv(
     uint8_t dtype,
     uint64_t numel,
     uint32_t tag) {
-  TORCH_CHECK(false, "OcclTransport::recv not yet implemented");
+  TORCH_CHECK(
+      srcRank >= 0 && srcRank < worldSize_ && srcRank != rank_,
+      "Invalid srcRank: ", srcRank);
+
+  ensureConnected(srcRank);
+
+  auto& conn = peers_[srcRank];
+  std::lock_guard<std::mutex> lock(conn.mutex);
+
+  setSocketTimeout(conn.fd, kDataTimeoutSec);
+
+  WireHeader hdr{};
+  recvAll(conn.fd, &hdr, sizeof(hdr));
+
+  TORCH_CHECK(
+      hdr.tag == tag,
+      "Tag mismatch from rank ", srcRank,
+      ": expected ", tag, " but got ", hdr.tag);
+  TORCH_CHECK(
+      hdr.dtype == dtype,
+      "Dtype mismatch from rank ", srcRank,
+      ": expected ", static_cast<int>(dtype),
+      " but got ", static_cast<int>(hdr.dtype));
+  TORCH_CHECK(
+      hdr.numel == numel,
+      "Numel mismatch from rank ", srcRank,
+      ": expected ", numel, " but got ", hdr.numel);
+
+  if (nbytes > 0) {
+    recvAll(conn.fd, data, nbytes);
+  }
 }
 
 void OcclTransport::ensureConnected(int peerRank) {
@@ -205,7 +263,14 @@ void OcclTransport::sendAll(int fd, const void* buf, size_t len) {
   size_t sent = 0;
   while (sent < len) {
     auto n = ::send(fd, ptr + sent, len - sent, 0);
-    TORCH_CHECK(n > 0, "sendAll failed: ", strerror(errno));
+    if (n <= 0) {
+      if (errno == EAGAIN || errno == EWOULDBLOCK) {
+        C10_THROW_ERROR(DistBackendError, "OCCL send timed out");
+      }
+      C10_THROW_ERROR(
+          DistBackendError,
+          std::string("OCCL send failed: ") + strerror(errno));
+    }
     sent += static_cast<size_t>(n);
   }
 }
@@ -215,7 +280,17 @@ void OcclTransport::recvAll(int fd, void* buf, size_t len) {
   size_t received = 0;
   while (received < len) {
     auto n = ::recv(fd, ptr + received, len - received, 0);
-    TORCH_CHECK(n > 0, "recvAll failed: ", strerror(errno));
+    if (n <= 0) {
+      if (n == 0) {
+        C10_THROW_ERROR(DistBackendError, "OCCL recv: peer closed connection");
+      }
+      if (errno == EAGAIN || errno == EWOULDBLOCK) {
+        C10_THROW_ERROR(DistBackendError, "OCCL recv timed out");
+      }
+      C10_THROW_ERROR(
+          DistBackendError,
+          std::string("OCCL recv failed: ") + strerror(errno));
+    }
     received += static_cast<size_t>(n);
   }
 }

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/distributed/OcclTransport.h
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/distributed/OcclTransport.h
@@ -75,6 +75,8 @@ class OcclTransport {
 
  private:
   struct Connection {
+    std::string host;
+    int port = 0;
     int fd = -1;
     std::mutex mutex;
   };

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/distributed/OcclTransport.h
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/distributed/OcclTransport.h
@@ -1,0 +1,112 @@
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <torch/csrc/distributed/c10d/Store.hpp>
+
+namespace c10d::openreg {
+
+// Fixed-size header preceding every message on the wire.
+// Layout: [tag:4][dtype:1][numel:8] = 13 bytes
+#pragma pack(push, 1)
+struct WireHeader {
+  uint32_t tag;
+  uint8_t dtype;
+  uint64_t numel;
+};
+#pragma pack(pop)
+static_assert(sizeof(WireHeader) == 13, "WireHeader must be 13 bytes");
+
+// TCP transport layer for OCCL.
+//
+// Manages a full mesh of TCP connections between ranks, with lazy
+// connection establishment. Each rank listens on a port and publishes
+// its address via the c10d Store; connections to peers are established
+// on first send/recv.
+//
+// This is the component vendors replace with their hardware-specific
+// transport (RDMA, NVLink, proprietary interconnect).
+class OcclTransport {
+ public:
+  OcclTransport(
+      int rank,
+      int worldSize,
+      c10::intrusive_ptr<::c10d::Store> store);
+
+  ~OcclTransport();
+
+  OcclTransport(const OcclTransport&) = delete;
+  OcclTransport& operator=(const OcclTransport&) = delete;
+
+  // Send tagged data to a peer rank.
+  // The caller provides the raw buffer, its size in bytes, the scalar
+  // type (for validation on the receiver side), element count, and a
+  // tag for matching send/recv pairs.
+  void send(
+      const void* data,
+      size_t nbytes,
+      int dstRank,
+      uint8_t dtype,
+      uint64_t numel,
+      uint32_t tag);
+
+  // Receive tagged data from a peer rank.
+  // Validates that the incoming message's dtype and numel match the
+  // expected values. Blocks until the message arrives.
+  void recv(
+      void* data,
+      size_t nbytes,
+      int srcRank,
+      uint8_t dtype,
+      uint64_t numel,
+      uint32_t tag);
+
+  int rank() const {
+    return rank_;
+  }
+  int worldSize() const {
+    return worldSize_;
+  }
+
+ private:
+  struct Connection {
+    int fd = -1;
+    std::mutex mutex;
+  };
+
+  // Ensure we have a connection to the given peer, establishing one
+  // lazily if needed.
+  void ensureConnected(int peerRank);
+
+  // Publish this rank's listen address to the Store so peers can
+  // connect.
+  void publishAddress();
+
+  // Retrieve a peer's listen address from the Store.
+  std::string getPeerAddress(int peerRank);
+
+  // Background thread: accepts incoming connections from peers.
+  void acceptLoop();
+
+  // Low-level helpers for exact-count socket I/O.
+  static void sendAll(int fd, const void* buf, size_t len);
+  static void recvAll(int fd, void* buf, size_t len);
+
+  int rank_;
+  int worldSize_;
+  c10::intrusive_ptr<::c10d::Store> store_;
+
+  int listenFd_ = -1;
+  int listenPort_ = 0;
+
+  std::vector<Connection> peers_;
+  std::thread acceptThread_;
+  std::atomic<bool> stop_{false};
+};
+
+} // namespace c10d::openreg

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/distributed/OcclTransport.h
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/distributed/OcclTransport.h
@@ -31,7 +31,7 @@ static_assert(sizeof(WireHeader) == 13, "WireHeader must be 13 bytes");
 // on first send/recv.
 //
 // This is the component vendors replace with their hardware-specific
-// transport (RDMA, NVLink, proprietary interconnect).
+// transport.
 class OcclTransport {
  public:
   OcclTransport(

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/distributed/OcclTransport.h
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/distributed/OcclTransport.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <atomic>
+#include <condition_variable>
 #include <cstdint>
 #include <mutex>
 #include <string>
@@ -79,6 +80,7 @@ class OcclTransport {
     int port = 0;
     int fd = -1;
     std::mutex mutex;
+    std::condition_variable cv;
   };
 
   // Ensure we have a connection to the given peer, establishing one


### PR DESCRIPTION
Add TCP transport layer (OcclTransport) to the OpenReg extension, showing vendors 
to implement custom data transport for distributed training with out-of-tree
devices. Manages a full mesh of lazy TCP connections between ranks, with address 
exchange via c10d Store. This is the component vendors replace with their 
hardware-specific transport layer.
A follow-up PR will add ProcessGroupOpenReg on top of this transport.

Note: This PR introduces the transport interface only. Tests will be added in a
subsequent PR along with ProcessGroupOpenReg, which provides the end-to-end
context needed for meaningful testing.

Description commit-by-commit:

0a98f2a - Skeleton: class definition, constructor/destructor, stub send/recv
557251e - Store-based address exchange
db2491f - Lazy TCP connections and background accept loop
393612e - Send/recv with WireHeader protocol and validation
861a916 - EINTR handling and error logging improvements

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com