### PR TITLE
[dynamo] Honor patched forward after in-graph setattr

### DIFF
--- a/test/dynamo/test_modules.py
+++ b/test/dynamo/test_modules.py
@@ -3245,6 +3245,26 @@ class OptimizedModuleTest(torch._dynamo.test_case.TestCase):
         with torch._dynamo.config.patch(inline_inbuilt_nn_modules=True):
             helper()
 
+    def test_monkeypatching_forward_inside_compiled_region(self):
+        class Mod(torch.nn.Module):
+            def forward(self, x):
+                return x - 1
+
+        @torch.compile(backend="eager", fullgraph=True)
+        def fn(mod, x, y):
+            def patch(x):
+                return x + y
+
+            mod.forward = patch
+            return mod(x)
+
+        inp0 = torch.ones(3)
+        inp1 = torch.ones(3)
+        mod = Mod()
+
+        self.assertEqual(fn(mod, inp0, inp1), inp0 + inp1)
+        self.assertEqual(mod(inp0), inp0 + inp1)
+
     def test_user_defined_nn_module_dynamic(self):
         class Conv2d(torch.nn.Conv2d):
             def __init__(self, *args, **kwargs):

--- a/torch/_dynamo/variables/nn_module.py
+++ b/torch/_dynamo/variables/nn_module.py
@@ -1092,7 +1092,9 @@ class UnspecializedNNModuleVariable(UserDefinedObjectVariable):
             and istype(mod._call_impl, types.MethodType)  # type: ignore[attr-defined]
             and mod.__call__.__func__ is unpatched_nn_module_call  # type: ignore[operator]
             and mod._call_impl.__func__ is unpatched_nn_module_call_impl  # type: ignore[attr-defined]
-            and "forward" not in mod.__dict__
+            # Consult pending STORE_ATTR side effects too. During tracing the
+            # patched forward may not be visible in mod.__dict__ yet.
+            and not self.has_key_in_generic_dict(tx, "forward")
         ):
             forward_method = inspect.getattr_static(mod, "forward")
             if isinstance(forward_method, types.FunctionType):
@@ -1167,7 +1169,7 @@ class UnspecializedNNModuleVariable(UserDefinedObjectVariable):
             fn_vt = VariableTracker.build(tx, fn, source=source, realize=True)
             return fn_vt.call_function(tx, [self] + list(args), kwargs)
 
-        if name not in getattr(self.value, "__dict__", {}):
+        if not self.has_key_in_generic_dict(tx, name):
             try:
                 method = inspect.getattr_static(type(self.value), name)
             except AttributeError:


### PR DESCRIPTION
Fix #167400

## Summary
- Root cause: `UnspecializedNNModuleVariable.call_function()` short-circuits `nn.Module._call_impl` directly to the type-level `forward` when `mod.__dict__` does not contain `forward`, but an in-graph `setattr(mod, "forward", ...)` is only tracked as a pending side effect during tracing, so the patched forward is skipped.
- Proposed fix: consult `has_key_in_generic_dict()` before taking the forward fast path, and use the same pending-mutation-aware lookup in `call_method()` so instance-level method patches are visible during tracing.
- Why this is the right long term fix: it keeps the existing fast path for the common unpatched case while making unspecialized module dispatch consistent with Dynamo's side-effect model for traced attribute mutations.
- Tests: add a regression test that patches `mod.forward` inside a compiled fullgraph function before calling the module.

Drafted via @codex, published after manual review by @bobrenjc93

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo