### PR TITLE
Handle FakeTensor add_ with meta rhs during tracing

### DIFF
--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -1218,6 +1218,21 @@ class ReproTests(torch._dynamo.test_case.TestCase):
         compiled_out = compiled_fn(x)
         self.assertEqual(eager_out, compiled_out)
 
+    # https://github.com/pytorch/pytorch/issues/166626
+    def test_inplace_add_from_meta_tensor_factory(self):
+        def fn(x):
+            log_det = torch.zeros(x.size(0), device=x.device)
+            log_det += torch.zeros(x.size(0), device="meta")
+            return log_det
+
+        x = torch.randn(2, 4)
+        eager_out = fn(x)
+        compiled_fn = torch.compile(fn, backend="eager", fullgraph=True)
+        compiled_out = compiled_fn(x)
+
+        self.assertEqual(eager_out.device, compiled_out.device)
+        self.assertEqual(eager_out, compiled_out)
+
     # https://github.com/pytorch/pytorch/issues/109053
     def test_view_dtype_overload(self):
         def f(x):

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -2862,13 +2862,20 @@ class FakeTensorPreferDeviceType(TestCase):
 
 
 class FakeTensorMetaDevicePropagation(TestCase):
-    def test_inplace_add_with_meta_rhs_keeps_destination_device(self):
+    @parametrize("device", ["cpu", "cuda"])
+    def test_inplace_add_with_meta_rhs_keeps_destination_device(self, device):
+        if device == "cuda" and not RUN_CUDA:
+            self.skipTest("requires cuda")
+
         with FakeTensorMode():
-            log_det = torch.zeros(2)
+            log_det = torch.zeros(2, device=device)
             log_det += torch.zeros(2, device="meta")
 
-            self.assertEqual(log_det.device, torch.device("cpu"))
+            self.assertEqual(log_det.device.type, device)
             self.assertTrue(isinstance(log_det, FakeTensor))
+
+
+instantiate_parametrized_tests(FakeTensorMetaDevicePropagation)
 
 
 class FakeTensorViewCopy(TestCase):

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -2861,6 +2861,16 @@ class FakeTensorPreferDeviceType(TestCase):
                 self.assertTrue(isinstance(result, FakeTensor))
 
 
+class FakeTensorMetaDevicePropagation(TestCase):
+    def test_inplace_add_with_meta_rhs_keeps_destination_device(self):
+        with FakeTensorMode():
+            log_det = torch.zeros(2)
+            log_det += torch.zeros(2, device="meta")
+
+            self.assertEqual(log_det.device, torch.device("cpu"))
+            self.assertTrue(isinstance(log_det, FakeTensor))
+
+
 class FakeTensorViewCopy(TestCase):
     def test_expand_then_view_copy_matches_eager_mode(self):
         x = torch.arange(7)

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -976,14 +976,14 @@ class FakeTensor(Tensor):
             aten.nextafter.default,
         )
 
-        def check_cpu_device(device: torch.device) -> bool:
+        def is_device_cpu(device: torch.device) -> bool:
             return device.type == "cpu"
 
-        def check_meta_device(device: torch.device) -> bool:
+        def is_device_meta(device: torch.device) -> bool:
             return device.type == "meta"
 
         def cpu_zero_dim(t: Tensor) -> bool:
-            return check_cpu_device(t.device) and t.dim() == 0
+            return is_device_cpu(t.device) and t.dim() == 0
 
         def merge_devices(t: object) -> None:
             nonlocal common_device
@@ -1022,11 +1022,11 @@ class FakeTensor(Tensor):
             # device must be cpu in this case we will return from here without
             # throwing an error
             if func in mixed_device_fns:
-                if any(map(check_cpu_device, (common_device, t.device))):
+                if any(map(is_device_cpu, (common_device, t.device))):
                     return
 
             if func in meta_rhs_mixed_device_fns:
-                if any(map(check_meta_device, (common_device, t.device))):
+                if any(map(is_device_meta, (common_device, t.device))):
                     return
 
             # if prefer_device_type is set, prefer that device type over others

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -965,6 +965,12 @@ class FakeTensor(Tensor):
             aten._foreach_copy.default,
         )
 
+        # These in-place ops keep the destination tensor's device even if the
+        # rhs was explicitly constructed on meta.
+        meta_rhs_mixed_device_fns = ordered_set(
+            aten.add_.Tensor,
+        )
+
         # list of ops not using zero dim cpu tensor logic to align with the eager mode.
         bypass_zero_dim_cpu_tensor_check_ops = ordered_set(
             aten.nextafter.default,
@@ -972,6 +978,9 @@ class FakeTensor(Tensor):
 
         def check_cpu_device(device: torch.device) -> bool:
             return device.type == "cpu"
+
+        def check_meta_device(device: torch.device) -> bool:
+            return device.type == "meta"
 
         def cpu_zero_dim(t: Tensor) -> bool:
             return check_cpu_device(t.device) and t.dim() == 0
@@ -1014,6 +1023,10 @@ class FakeTensor(Tensor):
             # throwing an error
             if func in mixed_device_fns:
                 if any(map(check_cpu_device, (common_device, t.device))):
+                    return
+
+            if func in meta_rhs_mixed_device_fns:
+                if any(map(check_meta_device, (common_device, t.device))):
                     return
 
             # if prefer_device_type is set, prefer that device type over others


### PR DESCRIPTION
Fix #166626

## Root cause
FakeTensor device propagation treated `aten.add_.Tensor` with a `meta` rhs as a hard cross-device mismatch during tracing, even though the in-place op should preserve the destination tensor's device.

## Proposed fix
Allow FakeTensor common-device resolution to accept a `meta` rhs for `aten.add_.Tensor`, and add regression coverage for both the low-level FakeTensor path and the `torch.compile` repro.

## Why this is the right long term fix
This keeps tracing aligned with the in-place operator's actual device behavior while preserving strict device-mismatch errors for unrelated operators.

Drafted via @codex, published after manual review by @bobrenjc93

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo