### PR TITLE
Fix stale recursive dict-tag tensor guards

### DIFF
--- a/test/dynamo/test_modules.py
+++ b/test/dynamo/test_modules.py
@@ -3377,6 +3377,35 @@ class OptimizedModuleTest(torch._dynamo.test_case.TestCase):
         self.assertEqual(cnt.frame_count, 2)
         self.assertIsNotNone(model.linear.weight.grad)
 
+    @torch._dynamo.config.patch(skip_tensor_guards_with_matching_dict_tags=True)
+    @torch._dynamo.config.patch("use_recursive_dict_tags_for_guards", True)
+    def test_param_dtype_change_recompiles_with_recursive_dict_tags(self):
+        class MyModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.scale = torch.nn.Parameter(torch.randn(4))
+
+            def forward(self, x):
+                return x * self.scale
+
+        model = MyModule()
+        x = torch.randn(4)
+
+        cnt = torch._dynamo.testing.CompileCounter()
+        compiled = torch.compile(model, backend=cnt, fullgraph=True)
+
+        self.assertTrue(torch._dynamo.testing.same(model(x), compiled(x)))
+        self.assertEqual(cnt.frame_count, 1)
+
+        model.to(dtype=torch.float64)
+
+        recompiled = torch.compile(model, backend=cnt, fullgraph=True)
+        result = recompiled(x)
+
+        self.assertEqual(result.dtype, torch.float64)
+        self.assertTrue(torch._dynamo.testing.same(model(x), result))
+        self.assertEqual(cnt.frame_count, 2)
+
     @torch._dynamo.config.patch("inline_inbuilt_nn_modules", True)
     def test_param_requires_grad_submodule(self):
         class Inner(torch.nn.Module):

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -2724,9 +2724,7 @@ void stop_recording_dict_pointers(
 bool is_recording_dict_pointers(RootGuardManager* root);
 void record_dict_pointer(RootGuardManager* root, PyObject* dict_pointer);
 void record_tensor_pointer(RootGuardManager* root, PyObject* tensor_pointer);
-void record_tensor_requires_grad(
-    RootGuardManager* root,
-    PyObject* tensor_pointer);
+void record_tensor_metadata(RootGuardManager* root, PyObject* tensor_pointer);
 
 GuardManager* clone_guard_manager(
     GuardManager* from,
@@ -2743,6 +2741,74 @@ struct WeakEntry {
   PyObject* wr; // weakref
   PyObject* cap; // capsule whose m_self is used by the callback
 };
+
+struct CachedTensorMetadata {
+  explicit CachedTensorMetadata(const LocalState& state, const at::Tensor& tensor)
+      : dispatch_key_(state.apply(tensor.key_set()).raw_repr()),
+        dtype_(tensor.scalar_type()),
+        device_(tensor.device()),
+        requires_grad_(tensor.requires_grad()),
+        sizes_(tensor.sizes().vec()),
+        supports_stride_(supports_stride(tensor)),
+        strides_(
+            supports_stride_ ? tensor.strides().vec() : std::vector<int64_t>{}) {}
+
+  static bool supports_stride(const at::Tensor& tensor) {
+    auto layout = tensor.layout();
+    return layout != c10::kSparseCsr && layout != c10::kSparseCsc &&
+        layout != c10::kSparseBsc && layout != c10::kSparseBsr;
+  }
+
+  bool check(const LocalState& state, const at::Tensor& tensor) const {
+    if (dispatch_key_ != state.apply(tensor.key_set()).raw_repr() ||
+        dtype_ != tensor.scalar_type() || device_ != tensor.device() ||
+        requires_grad_ != tensor.requires_grad()) {
+      return false;
+    }
+
+    auto sizes = tensor.sizes();
+    if (sizes.size() != sizes_.size()) {
+      return false;
+    }
+    for (const auto i : c10::irange(sizes.size())) {
+      if (sizes_[i] != sizes[i]) {
+        return false;
+      }
+    }
+
+    if (supports_stride_ != supports_stride(tensor)) {
+      return false;
+    }
+    if (supports_stride_) {
+      auto strides = tensor.strides();
+      if (strides.size() != strides_.size()) {
+        return false;
+      }
+      for (const auto i : c10::irange(strides.size())) {
+        if (strides_[i] != strides[i]) {
+          return false;
+        }
+      }
+    }
+
+    return true;
+  }
+
+ private:
+  uint64_t dispatch_key_;
+  at::ScalarType dtype_;
+  c10::Device device_;
+  bool requires_grad_;
+  std::vector<int64_t> sizes_;
+  bool supports_stride_;
+  std::vector<int64_t> strides_;
+};
+
+struct RecordedTensorMetadata {
+  PyObject* tensor_ptr;
+  CachedTensorMetadata metadata;
+};
+
 /**
  * Base class representing a pair of accessor and the associated guard
  * manager. The accessor defines how to access the child value from the
@@ -3012,10 +3078,10 @@ class GuardManager {
     _tensor_pointers[value] = tensor_pointers;
   }
 
-  void stash_tensor_requires_grad(
+  void stash_tensor_metadata(
       PyObject* value,
-      std::vector<std::pair<PyObject*, bool>>&& tensor_requires_grad) {
-    _tensor_requires_grad_pointers[value] = std::move(tensor_requires_grad);
+      std::vector<RecordedTensorMetadata>&& tensor_metadata) {
+    _tensor_metadata_pointers[value] = std::move(tensor_metadata);
   }
 
   void disable_recursive_dict_tag_optimization() {
@@ -3144,15 +3210,16 @@ class GuardManager {
     return true;
   }
 
-  bool check_tensor_requires_grad_fast(PyObject* value) const {
-    auto it = _tensor_requires_grad_pointers.find(value);
-    if (it == _tensor_requires_grad_pointers.end()) {
+  bool check_tensor_metadata_fast(PyObject* value) const {
+    auto it = _tensor_metadata_pointers.find(value);
+    if (it == _tensor_metadata_pointers.end()) {
       return true;
     }
-    for (const auto& [tensor_ptr, expected_requires_grad] : it->second) {
-      if (THPVariable_Check(tensor_ptr) &&
-          THPVariable_Unpack(tensor_ptr).requires_grad() !=
-              expected_requires_grad) {
+    for (const auto& recorded_tensor : it->second) {
+      if (!THPVariable_Check(recorded_tensor.tensor_ptr) ||
+          !recorded_tensor.metadata.check(
+              _root->_local_state,
+              THPVariable_Unpack(recorded_tensor.tensor_ptr))) {
         return false;
       }
     }
@@ -3185,15 +3252,17 @@ class GuardManager {
     // For a `tag_safe_root`, the input pointer called `value`, the object the
     // guard is inspecting, serves as a proxy for the entire nested dictionary
     // structure beneath that node.  If this `value` pointer is one we have
-    // already recorded, then verifying each dictionary’s tag is sufficient to
-    // prove that nothing inside the subtree has changed.
+    // already recorded, then verifying each dictionary’s tag plus the cached
+    // tensor metadata is sufficient to prove that nothing inside the subtree
+    // has changed.
     //
     // Runtime flow
     // -------------
     // 1) Previously‑seen `value` pointer
     //    • Look up the current `value` pointer in our cache.
-    //    • If found, perform a recursive tag comparison on the cached subtree.
-    //      All tags match means guard passes with no further traversal.
+    //    • If found, perform a recursive tag comparison on the cached subtree
+    //      and revalidate recorded tensor metadata.
+    //      All checks passing means guard passes with no further traversal.
     //
     // 2) First‑time `value` pointer
     //    • Enter recording mode; walk the subtree, each tag safe root collects
@@ -3236,7 +3305,7 @@ class GuardManager {
           // Check for fast path
           // if (is_weakref_valid(value) && check_dict_pointer_tags(value)) {
           if (check_dict_pointer_tags(value) &&
-              check_tensor_requires_grad_fast(value)) {
+              check_tensor_metadata_fast(value)) {
             if (check_no_tensor_aliasing_guards_fast(value)) {
               return true;
             } else {
@@ -3266,9 +3335,9 @@ class GuardManager {
         } else if (_has_no_tensor_aliasing_guard) {
           record_tensor_pointer(_root, value);
         }
-        // Record tensor requires_grad for all tensors in the subtree.
+        // Tensor metadata can mutate in-place without changing dict tags.
         if (_is_immutable && THPVariable_Check(value)) {
-          record_tensor_requires_grad(_root, value);
+          record_tensor_metadata(_root, value);
         }
       }
     }
@@ -3674,8 +3743,8 @@ class GuardManager {
   std::unordered_map<PyObject*, std::vector<std::pair<PyObject*, uint64_t>>>
       _dict_pointers;
   std::unordered_map<PyObject*, std::vector<PyObject*>> _tensor_pointers;
-  std::unordered_map<PyObject*, std::vector<std::pair<PyObject*, bool>>>
-      _tensor_requires_grad_pointers;
+  std::unordered_map<PyObject*, std::vector<RecordedTensorMetadata>>
+      _tensor_metadata_pointers;
   std::vector<WeakEntry> _tag_safe_entries;
 
   // 3.12+ related helper
@@ -3944,7 +4013,7 @@ class RootGuardManager : public GuardManager {
     _current_tag_safe_root = nullptr;
     _recorded_dict_pointers.clear();
     _recorded_tensor_pointers.clear();
-    _recorded_tensor_requires_grad.clear();
+    _recorded_tensor_metadata.clear();
   }
 
   void stop_recording_dict_pointers(PyObject* value, bool result) {
@@ -3954,8 +4023,8 @@ class RootGuardManager : public GuardManager {
           value, _recorded_dict_pointers);
       _current_tag_safe_root->stash_tensor_pointers(
           value, _recorded_tensor_pointers);
-      _current_tag_safe_root->stash_tensor_requires_grad(
-          value, std::move(_recorded_tensor_requires_grad));
+      _current_tag_safe_root->stash_tensor_metadata(
+          value, std::move(_recorded_tensor_metadata));
     }
     reset_dict_tag_recording_variables();
   }
@@ -3973,9 +4042,11 @@ class RootGuardManager : public GuardManager {
     _recorded_tensor_pointers.push_back(tensor_pointer);
   }
 
-  void record_tensor_requires_grad(PyObject* tensor_pointer) {
-    bool rg = THPVariable_Unpack(tensor_pointer).requires_grad();
-    _recorded_tensor_requires_grad.emplace_back(tensor_pointer, rg);
+  void record_tensor_metadata(PyObject* tensor_pointer) {
+    _recorded_tensor_metadata.push_back(RecordedTensorMetadata{
+        tensor_pointer,
+        CachedTensorMetadata(_local_state, THPVariable_Unpack(tensor_pointer)),
+    });
   }
 
  public:
@@ -4034,7 +4105,7 @@ class RootGuardManager : public GuardManager {
   GuardManager* _current_tag_safe_root{nullptr};
   std::vector<std::pair<PyObject*, uint64_t>> _recorded_dict_pointers;
   std::vector<PyObject*> _recorded_tensor_pointers;
-  std::vector<std::pair<PyObject*, bool>> _recorded_tensor_requires_grad;
+  std::vector<RecordedTensorMetadata> _recorded_tensor_metadata;
 };
 
 /*
@@ -4481,10 +4552,8 @@ void record_tensor_pointer(RootGuardManager* root, PyObject* tensor_pointer) {
   root->record_tensor_pointer(tensor_pointer);
 }
 
-void record_tensor_requires_grad(
-    RootGuardManager* root,
-    PyObject* tensor_pointer) {
-  root->record_tensor_requires_grad(tensor_pointer);
+void record_tensor_metadata(RootGuardManager* root, PyObject* tensor_pointer) {
+  root->record_tensor_metadata(tensor_pointer);
 }
 
 std::shared_ptr<RelationalGuard> get_no_tensor_aliasing_guard(
@@ -5003,10 +5072,7 @@ class FrameLocalsGuardAccessor : public GuardAccessor {
         _key(key[0].ptr()),
         _framelocals_idx(key[1].cast<int>()),
         _is_immutable_object(is_immutable_object(example_value)),
-        _is_tensor(THPVariable_Check(example_value.ptr())),
-        _tensor_requires_grad(
-            _is_tensor ? THPVariable_Unpack(example_value.ptr()).requires_grad()
-                       : false) {}
+        _is_tensor(THPVariable_Check(example_value.ptr())) {}
 
   // Run as a result of calling run_root_guard_manager/check_nopybind
   // NB: Intentional duplication between check_nopybind and
@@ -5014,18 +5080,8 @@ class FrameLocalsGuardAccessor : public GuardAccessor {
   bool check_nopybind(
       FrameLocalsMapping* obj,
       bool matches_dict_tag = false) override { // borrowed ref
-    if (matches_dict_tag && _is_immutable_object) {
-      // Tensors are treated as immutable for the dict-tag optimization, but
-      // their metadata (e.g. requires_grad) can be mutated in-place without
-      // changing the parent dict's version tag. For now we only check
-      // requires_grad since it is the most common mutation; other metadata
-      // changes (dtype, device, etc.) are possible but rare in practice.
-      if (!_is_tensor) {
-        return true;
-      }
-      if (!tensor_requires_grad_changed(obj->get(_framelocals_idx))) {
-        return true;
-      }
+    if (matches_dict_tag && _is_immutable_object && !_is_tensor) {
+      return true;
     }
 
     PyObject* x = obj->get(_framelocals_idx);
@@ -5047,19 +5103,8 @@ class FrameLocalsGuardAccessor : public GuardAccessor {
         PyDict_Check(obj),
         "FrameLocalsGuardAccessor check expected dict() input");
 
-    if (matches_dict_tag && _is_immutable_object) {
-      // Tensors are treated as immutable for the dict-tag optimization, but
-      // their metadata (e.g. requires_grad) can be mutated in-place without
-      // changing the parent dict's version tag. For now we only check
-      // requires_grad since it is the most common mutation; other metadata
-      // changes (dtype, device, etc.) are possible but rare in practice.
-      if (!_is_tensor) {
-        return true;
-      }
-      PyObject* x = PyDict_GetItem(obj, _key); // borrowed ref
-      if (!tensor_requires_grad_changed(x)) {
-        return true;
-      }
+    if (matches_dict_tag && _is_immutable_object && !_is_tensor) {
+      return true;
     }
 
     PyObject* x = PyDict_GetItem(obj, _key); // borrowed ref
@@ -5116,15 +5161,9 @@ class FrameLocalsGuardAccessor : public GuardAccessor {
     to->_framelocals_idx = _framelocals_idx;
     to->_is_immutable_object = _is_immutable_object;
     to->_is_tensor = _is_tensor;
-    to->_tensor_requires_grad = _tensor_requires_grad;
   }
 
  private:
-  bool tensor_requires_grad_changed(PyObject* x) const {
-    return x != nullptr && THPVariable_Check(x) &&
-        THPVariable_Unpack(x).requires_grad() != _tensor_requires_grad;
-  }
-
   PyObject* _key{nullptr};
   int _framelocals_idx{-1};
 
@@ -5132,7 +5171,6 @@ class FrameLocalsGuardAccessor : public GuardAccessor {
   // return true.
   bool _is_immutable_object{false};
   bool _is_tensor{false};
-  bool _tensor_requires_grad{false};
 };
 
 /**
@@ -5156,30 +5194,16 @@ class DictGetItemGuardAccessor : public GuardAccessor {
             guard_manager_enum),
         _key(key.ptr()),
         _is_immutable_object(is_immutable_object(example_value)),
-        _is_tensor(THPVariable_Check(example_value.ptr())),
-        _tensor_requires_grad(
-            _is_tensor ? THPVariable_Unpack(example_value.ptr()).requires_grad()
-                       : false) {}
+        _is_tensor(THPVariable_Check(example_value.ptr())) {}
 
   // NB: Intentional duplication between check_nopybind and
   // check_verbose_nopybind.
   bool check_nopybind(PyObject* obj, bool matches_dict_tag = false) override {
     if (matches_dict_tag && _is_immutable_object &&
+        !_is_tensor &&
         !is_recording_dict_pointers(get_guard_manager()->get_root()) &&
         _guard_manager->has_no_accessors()) {
-      // Tensors are treated as immutable for the dict-tag optimization, but
-      // their metadata (e.g. requires_grad) can be mutated in-place without
-      // changing the parent dict's version tag. For now we only check
-      // requires_grad since it is the most common mutation; other metadata
-      // changes (dtype, device, etc.) are possible but rare in practice.
-      if (!_is_tensor) {
-        return true;
-      }
-      PyObject* x = PyDict_GetItem(obj, _key); // borrowed ref
-      if (!tensor_requires_grad_changed(x)) {
-        return true;
-      }
-      // Fall through to full check - requires_grad changed.
+      return true;
     }
 
     PyObject* x = PyDict_GetItem(obj, _key); // borrowed ref
@@ -5226,22 +5250,15 @@ class DictGetItemGuardAccessor : public GuardAccessor {
     to->_key = _key;
     to->_is_immutable_object = _is_immutable_object;
     to->_is_tensor = _is_tensor;
-    to->_tensor_requires_grad = _tensor_requires_grad;
   }
 
  private:
-  bool tensor_requires_grad_changed(PyObject* x) const {
-    return x != nullptr && THPVariable_Check(x) &&
-        THPVariable_Unpack(x).requires_grad() != _tensor_requires_grad;
-  }
-
   PyObject* _key{nullptr};
 
   // If immutable object and dict tag matches, we can skip the guard subtree and
   // return true.
   bool _is_immutable_object{false};
   bool _is_tensor{false};
-  bool _tensor_requires_grad{false};
 };
 
 /**

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -2743,74 +2743,43 @@ struct WeakEntry {
   PyObject* cap; // capsule whose m_self is used by the callback
 };
 
-struct CachedTensorMetadata {
-  explicit CachedTensorMetadata(
-      const LocalState& state,
-      const at::Tensor& tensor)
-      : dispatch_key_(state.apply(tensor.key_set()).raw_repr()),
-        dtype_(tensor.scalar_type()),
-        device_(tensor.device()),
-        requires_grad_(tensor.requires_grad()),
-        sizes_(tensor.sizes().vec()),
-        supports_stride_(supports_stride(tensor)),
-        strides_(
-            supports_stride_ ? tensor.strides().vec()
-                             : std::vector<int64_t>{}) {}
-
-  static bool supports_stride(const at::Tensor& tensor) {
-    auto layout = tensor.layout();
-    return layout != c10::kSparseCsr && layout != c10::kSparseCsc &&
-        layout != c10::kSparseBsc && layout != c10::kSparseBsr;
+// Convert concrete sizes/strides to the optional<SymInt> vectors that
+// TensorCheck expects.  All dimensions are treated as static (no nullopt).
+inline std::vector<std::optional<c10::SymInt>> to_opt_symint(
+    c10::IntArrayRef vals) {
+  std::vector<std::optional<c10::SymInt>> out;
+  out.reserve(vals.size());
+  for (auto v : vals) {
+    out.emplace_back(c10::SymInt(v));
   }
+  return out;
+}
 
-  bool check(const LocalState& state, const at::Tensor& tensor) const {
-    if (dispatch_key_ != state.apply(tensor.key_set()).raw_repr() ||
-        dtype_ != tensor.scalar_type() || device_ != tensor.device() ||
-        requires_grad_ != tensor.requires_grad()) {
-      return false;
-    }
-
-    auto sizes = tensor.sizes();
-    if (sizes.size() != sizes_.size()) {
-      return false;
-    }
-    for (const auto i : c10::irange(sizes.size())) {
-      if (sizes_[i] != sizes[i]) {
-        return false;
-      }
-    }
-
-    if (supports_stride_ != supports_stride(tensor)) {
-      return false;
-    }
-    if (supports_stride_) {
-      auto strides = tensor.strides();
-      if (strides.size() != strides_.size()) {
-        return false;
-      }
-      for (const auto i : c10::irange(strides.size())) {
-        if (strides_[i] != strides[i]) {
-          return false;
-        }
-      }
-    }
-
-    return true;
-  }
-
- private:
-  uint64_t dispatch_key_;
-  at::ScalarType dtype_;
-  c10::Device device_;
-  bool requires_grad_;
-  std::vector<int64_t> sizes_;
-  bool supports_stride_;
-  std::vector<int64_t> strides_;
-};
+// Build a TensorCheck that validates all concrete metadata (dispatch key,
+// dtype, device, requires_grad, sizes, strides) for the dict-tag fast path.
+inline TensorCheck make_tensor_check(
+    const LocalState& state,
+    const at::Tensor& tensor) {
+  auto layout = tensor.layout();
+  bool sparse = layout == c10::kSparseCsr || layout == c10::kSparseCsc ||
+      layout == c10::kSparseBsc || layout == c10::kSparseBsr;
+  // Sparse layouts don't support strides; use nullopt per dim so
+  // TensorCheck skips stride comparison for each dimension.
+  auto strides = sparse
+      ? std::vector<std::optional<c10::SymInt>>(tensor.dim(), std::nullopt)
+      : to_opt_symint(tensor.strides());
+  return TensorCheck(
+      state,
+      /*pt=*/nullptr,
+      tensor,
+      tensor.key_set(),
+      to_opt_symint(tensor.sizes()),
+      std::move(strides));
+}
 
 struct RecordedTensorMetadata {
   PyObject* tensor_ptr;
-  CachedTensorMetadata metadata;
+  TensorCheck check;
 };
 
 /**
@@ -3214,14 +3183,14 @@ class GuardManager {
     return true;
   }
 
-  bool check_tensor_metadata_fast(PyObject* value) const {
+  bool check_tensor_metadata_fast(PyObject* value) {
     auto it = _tensor_metadata_pointers.find(value);
     if (it == _tensor_metadata_pointers.end()) {
       return true;
     }
-    for (const auto& recorded_tensor : it->second) {
+    for (auto& recorded_tensor : it->second) {
       if (!THPVariable_Check(recorded_tensor.tensor_ptr) ||
-          !recorded_tensor.metadata.check(
+          !recorded_tensor.check.check(
               get_local_state(_root),
               THPVariable_Unpack(recorded_tensor.tensor_ptr))) {
         return false;
@@ -4049,7 +4018,7 @@ class RootGuardManager : public GuardManager {
   void record_tensor_metadata(PyObject* tensor_pointer) {
     _recorded_tensor_metadata.push_back(RecordedTensorMetadata{
         tensor_pointer,
-        CachedTensorMetadata(_local_state, THPVariable_Unpack(tensor_pointer)),
+        make_tensor_check(_local_state, THPVariable_Unpack(tensor_pointer)),
     });
   }
 

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -2735,6 +2735,7 @@ void add_relational_guard_resetter_to_cloned_root(
     std::shared_ptr<RelationalGuard> guard);
 std::shared_ptr<RelationalGuard> get_no_tensor_aliasing_guard(
     RootGuardManager* _root);
+const LocalState& get_local_state(RootGuardManager* root);
 // std::string get_compile_id(RootGuardManager* root);
 
 struct WeakEntry {
@@ -3218,7 +3219,7 @@ class GuardManager {
     for (const auto& recorded_tensor : it->second) {
       if (!THPVariable_Check(recorded_tensor.tensor_ptr) ||
           !recorded_tensor.metadata.check(
-              _root->_local_state,
+              get_local_state(_root),
               THPVariable_Unpack(recorded_tensor.tensor_ptr))) {
         return false;
       }
@@ -4559,6 +4560,10 @@ void record_tensor_metadata(RootGuardManager* root, PyObject* tensor_pointer) {
 std::shared_ptr<RelationalGuard> get_no_tensor_aliasing_guard(
     RootGuardManager* _root) {
   return _root->get_no_tensor_aliasing_guard();
+}
+
+const LocalState& get_local_state(RootGuardManager* root) {
+  return root->_local_state;
 }
 
 // std::string get_compile_id(RootGuardManager* root) {

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -5207,8 +5207,7 @@ class DictGetItemGuardAccessor : public GuardAccessor {
   // NB: Intentional duplication between check_nopybind and
   // check_verbose_nopybind.
   bool check_nopybind(PyObject* obj, bool matches_dict_tag = false) override {
-    if (matches_dict_tag && _is_immutable_object &&
-        !_is_tensor &&
+    if (matches_dict_tag && _is_immutable_object && !_is_tensor &&
         !is_recording_dict_pointers(get_guard_manager()->get_root()) &&
         _guard_manager->has_no_accessors()) {
       return true;

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -2744,7 +2744,9 @@ struct WeakEntry {
 };
 
 struct CachedTensorMetadata {
-  explicit CachedTensorMetadata(const LocalState& state, const at::Tensor& tensor)
+  explicit CachedTensorMetadata(
+      const LocalState& state,
+      const at::Tensor& tensor)
       : dispatch_key_(state.apply(tensor.key_set()).raw_repr()),
         dtype_(tensor.scalar_type()),
         device_(tensor.device()),
@@ -2752,7 +2754,8 @@ struct CachedTensorMetadata {
         sizes_(tensor.sizes().vec()),
         supports_stride_(supports_stride(tensor)),
         strides_(
-            supports_stride_ ? tensor.strides().vec() : std::vector<int64_t>{}) {}
+            supports_stride_ ? tensor.strides().vec()
+                             : std::vector<int64_t>{}) {}
 
   static bool supports_stride(const at::Tensor& tensor) {
     auto layout = tensor.layout();


### PR DESCRIPTION
Fix #163064

## Summary

### Root cause
Dynamo's recursive dict-tag fast path only cached `requires_grad` for tensors it skipped. When `Module.to(...)` mutated parameter metadata in place, guards could accept a stale compiled graph even though tensor device, dtype, dispatch key, or stride metadata had changed.

### Proposed fix
- Cache and revalidate full tensor metadata before taking the recursive dict-tag fast path.
- Remove the tensor-only accessor shortcut that only compared `requires_grad`, so metadata changes fall through to the normal tensor guards and trigger recompilation.
- Add a regression that mutates a parameter dtype in place on the same module instance and verifies Dynamo recompiles.

### Why this is the right long term fix
This keeps the recursive dict-tag optimization for unchanged modules, but makes the fast path sound for in-place parameter metadata mutations such as device moves that reuse the same `Parameter` object.

Drafted via @codex, published after manual review by @bobrenjc93

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo