### PR TITLE
fix potential multiple definition in ComplexHelper.h

### DIFF
--- a/aten/src/ATen/native/ComplexHelper.h
+++ b/aten/src/ATen/native/ComplexHelper.h
@@ -57,7 +57,7 @@ inline Tensor _view_as_real_physical(const Tensor& self) {
 // expects as input a complex tensor and returns back a tensor
 // with corresponding real dtype containing the complex values
 // in the last two dimensions
-Tensor view_as_real(const Tensor& self) {
+inline Tensor view_as_real(const Tensor& self) {
   TORCH_CHECK(!self.is_conj(), "view_as_real doesn't work on unresolved conjugated tensors.  To resolve the conjugate tensor so you can view it as real, use self.resolve_conj(); however, be warned that the resulting tensor will NOT alias the original.");
   return _view_as_real_physical(self);
 }
@@ -82,7 +82,7 @@ inline SymDimVector computeStrideForViewAsComplex(
 
 // expects as input a float or double tensor with last dimension of size 2
 // and returns back a tensor with corresponding complex dtype
-Tensor view_as_complex(const Tensor& self) {
+inline Tensor view_as_complex(const Tensor& self) {
   TORCH_CHECK(
     self.scalar_type() == kFloat || self.scalar_type() == kDouble || self.scalar_type() == kHalf,
     "view_as_complex is only supported for half, float and double tensors, but got a tensor of scalar type: ", self.scalar_type());


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #177526

# Motivation
We are encountering a LNK2005 multiple definition error during linking on Windows:
```bash
torch_cpu.lib(torch_cpu.dll) : error LNK2005:
at::native::view_as_complex(const at::Tensor&)
already defined in torch_xpu_ops.lib(Blas.cpp.obj)

torch_cpu.lib(torch_cpu.dll) : error LNK2005:
at::native::view_as_real(const at::Tensor&)
already defined in torch_xpu_ops.lib(Blas.cpp.obj)
```

The root cause is: The functions: `at::native::view_as_complex` and `at::native::view_as_real` are already defined in torch_cpu. However, if we include `ComplexHelper.h` in another cpp file, it results in duplicate global symbols.
On Windows, the linker does not allow multiple definitions of the same symbol across libraries, which leads to the LNK2005 error.

