### PR TITLE
[inductor] Reject complex LayerNorm inputs during tracing

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -6124,24 +6124,21 @@ class CommonTemplate:
 
     def test_layer_norm_rejects_complex_inputs(self):
         if self.device not in ("cpu", "cuda"):
-            raise unittest.SkipTest("Only validated against eager CPU/CUDA errors")
+            raise unittest.SkipTest("Only validated on CPU/CUDA")
 
         m = torch.nn.LayerNorm(10).to(self.device)
         x = torch.randn(1, 1, 10, device=self.device, dtype=torch.complex64)
 
-        with self.assertRaises(RuntimeError) as eager_error:
+        with self.assertRaises(RuntimeError):
             m(x)
-
-        expected_message = str(eager_error.exception).splitlines()[0]
 
         with self.assertRaises(RuntimeError) as compiled_error:
             torch.compile(m)(x)
 
-        compiled_message = (
-            str(compiled_error.exception).replace('\\"', '"').replace("\\'", "'")
+        self.assertIn(
+            "native_layer_norm does not support complex inputs",
+            str(compiled_error.exception),
         )
-
-        self.assertIn(expected_message, compiled_message)
 
     @torch._functorch.config.patch("donated_buffer", True)
     def test_matmul_layer_norm(self):

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -6137,7 +6137,11 @@ class CommonTemplate:
         with self.assertRaises(RuntimeError) as compiled_error:
             torch.compile(m)(x)
 
-        self.assertIn(expected_message, str(compiled_error.exception))
+        compiled_message = str(compiled_error.exception).replace('\\"', '"').replace(
+            "\\'", "'"
+        )
+
+        self.assertIn(expected_message, compiled_message)
 
     @torch._functorch.config.patch("donated_buffer", True)
     def test_matmul_layer_norm(self):

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -6137,8 +6137,8 @@ class CommonTemplate:
         with self.assertRaises(RuntimeError) as compiled_error:
             torch.compile(m)(x)
 
-        compiled_message = str(compiled_error.exception).replace('\\"', '"').replace(
-            "\\'", "'"
+        compiled_message = (
+            str(compiled_error.exception).replace('\\"', '"').replace("\\'", "'")
         )
 
         self.assertIn(expected_message, compiled_message)

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -6132,10 +6132,12 @@ class CommonTemplate:
         with self.assertRaises(RuntimeError) as eager_error:
             m(x)
 
-        with self.assertRaisesRegex(
-            RuntimeError, re.escape(str(eager_error.exception))
-        ):
+        expected_message = str(eager_error.exception).splitlines()[0]
+
+        with self.assertRaises(RuntimeError) as compiled_error:
             torch.compile(m)(x)
+
+        self.assertIn(expected_message, str(compiled_error.exception))
 
     @torch._functorch.config.patch("donated_buffer", True)
     def test_matmul_layer_norm(self):

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -6122,6 +6122,21 @@ class CommonTemplate:
         if self.device != "cpu":
             assertGeneratedKernelCountEqual(self, 1)
 
+    def test_layer_norm_rejects_complex_inputs(self):
+        if self.device not in ("cpu", "cuda"):
+            raise unittest.SkipTest("Only validated against eager CPU/CUDA errors")
+
+        m = torch.nn.LayerNorm(10).to(self.device)
+        x = torch.randn(1, 1, 10, device=self.device, dtype=torch.complex64)
+
+        with self.assertRaises(RuntimeError) as eager_error:
+            m(x)
+
+        with self.assertRaisesRegex(
+            RuntimeError, re.escape(str(eager_error.exception))
+        ):
+            torch.compile(m)(x)
+
     @torch._functorch.config.patch("donated_buffer", True)
     def test_matmul_layer_norm(self):
         batch_size = 32

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -3329,6 +3329,28 @@ def _unsqueeze_multiple(x: TensorLikeType, dimensions: list[int]) -> TensorLikeT
     return x
 
 
+_layer_norm_complex_dtype_names = {
+    torch.complex32: "ComplexHalf",
+    torch.complex64: "ComplexFloat",
+    torch.complex128: "ComplexDouble",
+}
+
+
+def _native_layer_norm_complex_error(
+    input: Tensor, weight: Tensor | None, bias: Tensor | None
+) -> str:
+    # Match eager layer_norm dtype validation so tracing rejects unsupported
+    # complex inputs with the same backend-specific error.
+    if input.device.type == "cpu" and any(
+        parameter is not None and parameter.dtype != input.dtype
+        for parameter in (weight, bias)
+    ):
+        return "mixed dtype (CPU): all inputs must share same datatype."
+
+    dtype_name = _layer_norm_complex_dtype_names.get(input.dtype, str(input.dtype))
+    return f"\"LayerNormKernelImpl\" not implemented for '{dtype_name}'"
+
+
 @register_decomposition(aten.native_group_norm.default)
 def native_group_norm(
     input: Tensor,
@@ -3452,6 +3474,10 @@ def native_layer_norm(
         + str(normalized_shape)
         + ", but got input of size "
         + str(input.shape),
+    )
+    torch._check(
+        not input.is_complex(),
+        lambda: _native_layer_norm_complex_error(input, weight, bias),
     )
 
     input = contiguous(input)

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -3341,11 +3341,20 @@ def _native_layer_norm_complex_error(
 ) -> str:
     # Match eager layer_norm dtype validation so tracing rejects unsupported
     # complex inputs with the same backend-specific error.
-    if input.device.type == "cpu" and any(
-        parameter is not None and parameter.dtype != input.dtype
-        for parameter in (weight, bias)
-    ):
-        return "mixed dtype (CPU): all inputs must share same datatype."
+    if input.device.type == "cpu":
+        mixed_type = False
+        for parameter in (weight, bias):
+            if parameter is not None:
+                mixed_type = parameter.dtype != input.dtype
+                break
+
+        if mixed_type:
+            for parameter in (weight, bias):
+                if parameter is not None and parameter.dtype != torch.float:
+                    return (
+                        "mixed dtype (CPU): expect parameter to have scalar type of Float"
+                    )
+            return "mixed dtype (CPU): all inputs must share same datatype."
 
     dtype_name = _layer_norm_complex_dtype_names.get(input.dtype, str(input.dtype))
     return f"\"LayerNormKernelImpl\" not implemented for '{dtype_name}'"

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -3351,9 +3351,7 @@ def _native_layer_norm_complex_error(
         if mixed_type:
             for parameter in (weight, bias):
                 if parameter is not None and parameter.dtype != torch.float:
-                    return (
-                        "mixed dtype (CPU): expect parameter to have scalar type of Float"
-                    )
+                    return "mixed dtype (CPU): expect parameter to have scalar type of Float"
             return "mixed dtype (CPU): all inputs must share same datatype."
 
     dtype_name = _layer_norm_complex_dtype_names.get(input.dtype, str(input.dtype))

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -3329,35 +3329,6 @@ def _unsqueeze_multiple(x: TensorLikeType, dimensions: list[int]) -> TensorLikeT
     return x
 
 
-_layer_norm_complex_dtype_names = {
-    torch.complex32: "ComplexHalf",
-    torch.complex64: "ComplexFloat",
-    torch.complex128: "ComplexDouble",
-}
-
-
-def _native_layer_norm_complex_error(
-    input: Tensor, weight: Tensor | None, bias: Tensor | None
-) -> str:
-    # Match eager layer_norm dtype validation so tracing rejects unsupported
-    # complex inputs with the same backend-specific error.
-    if input.device.type == "cpu":
-        mixed_type = False
-        for parameter in (weight, bias):
-            if parameter is not None:
-                mixed_type = parameter.dtype != input.dtype
-                break
-
-        if mixed_type:
-            for parameter in (weight, bias):
-                if parameter is not None and parameter.dtype != torch.float:
-                    return "mixed dtype (CPU): expect parameter to have scalar type of Float"
-            return "mixed dtype (CPU): all inputs must share same datatype."
-
-    dtype_name = _layer_norm_complex_dtype_names.get(input.dtype, str(input.dtype))
-    return f"\"LayerNormKernelImpl\" not implemented for '{dtype_name}'"
-
-
 @register_decomposition(aten.native_group_norm.default)
 def native_group_norm(
     input: Tensor,
@@ -3484,7 +3455,7 @@ def native_layer_norm(
     )
     torch._check(
         not input.is_complex(),
-        lambda: _native_layer_norm_complex_error(input, weight, bias),
+        lambda: "native_layer_norm does not support complex inputs",
     )
 
     input = contiguous(input)


### PR DESCRIPTION
Fix #147256

## Summary
1) What is the root cause problem?
Compiled `LayerNorm` reaches the Python reference decomposition for `aten.native_layer_norm`, but that path only validates shapes. Because it never rejects complex inputs, tracing can proceed and execute successfully even though eager `LayerNorm` errors out.

2) What is the proposed fix?
Add a direct complex-input guard to `torch._refs.native_layer_norm` and keep the regression test focused on the behavior that matters here: compiled `LayerNorm` must reject complex inputs instead of running through successfully.

3) Why is the proposed fix the right long term fix?
`torch._refs.native_layer_norm` is the shared tracing/decomposition entry point used by compiled execution, so enforcing the unsupported-complex contract there fixes the bug at the source without duplicating backend-specific eager error construction that can drift over time.

## Testing
- `python3 -m py_compile torch/_refs/__init__.py`
- `python3 -m py_compile test/inductor/test_torchinductor.py`

Drafted via @codex, published after manual review by @bobrenjc93

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo