### PR TITLE
[opinfo] Implement igamma and digamma for Inductor/Triton

### DIFF
--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -1254,6 +1254,7 @@ pointwise_overrides_data: dict[str, OverridesData] = dict(
         type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT,
         cpp=lambda x: f"calc_digamma({x})",
         cppvec=lambda x: f"{x}.digamma()",
+        triton=lambda x: f"libdevice.digamma({x})",
         name="digamma",
     ),
     # no cpp nor triton implementation for entr, it is defined as decomposition
@@ -1293,6 +1294,7 @@ pointwise_overrides_data: dict[str, OverridesData] = dict(
     igamma=OverridesData(
         type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT,
         cpp=lambda x, y: f"calc_igamma({x}, {y})",
+        triton=lambda x, y: f"libdevice.igamma({x}, {y})",
         name="igamma",
     ),
     igammac=OverridesData(


### PR DESCRIPTION
Summary:
Add implementations of `igamma` (regularized lower incomplete gamma function)
and `digamma` (psi function) for the Inductor/Triton compilation path.

**igamma** (`igamma_impl`):
Uses the power series (DLMF 8.11.4) with 100 iterations via
`igamma_series`.
Computes the prefactor `x^a * exp(-x) / Gamma(a)` in log space using
`lgamma_impl`.

**digamma** (`digamma_impl`):
Uses asymptotic expansion for x >= 10, recurrence relation to shift smaller
values, and reflection formula for negative values (following ATen
calc_digamma).

**Pipeline wiring:**
- Added `triton=` lambdas to `OverridesData` for both ops to prevent Inductor's `triton_fallback` from ejecting them from Triton kernels.
- Added both ops to `SAFE_AND_PERFORMANT_INDUCTOR_OPS` so they pass the whitelist and are not force-fallbacked.
- Added Triton kernel overrides for both ops to route codegen to the compute_helpers implementations.

**sinpi fix in lgamma_impl:**
Replaced the arch-conditional `libdevice.sinpi` / `tl.sin(PI * x)` with
unconditional `tl.sin(PI * x)` in `lgamma_impl`.
The `sinpi` op fails to legalize in AOT compilation when called on scalar
operands (from binary dispatcher scalar-broadcast kernel variants), because
`MathUnaryOpConversion` in the structured-to-kernel pass only supports
`RankedTensorType`. The existing comment already stated this was the intent.

Test Plan:
Ran all 4 igamma opinfo e2e tests covering f16, bf16, f32, f64 dtypes. All passed with `Graph fallback classification: success (inductor=1, manual=0)`.

```
test_opinfo_18967_afg_inductor_compile_ds PASSED  (f16)
test_opinfo_18975_afg_inductor_compile_ds PASSED  (bf16)
test_opinfo_18983_afg_inductor_compile_ds PASSED  (f32)
test_opinfo_18991_afg_inductor_compile_ds PASSED  (f64)
```

Differential Revision: D96400244




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo