### PR TITLE
Instruct Claude to preserve ghstack trailers in commit messages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,10 @@ entirely.
 
 Disclose that the PR was authored with Claude.
 
+If a commit message contains `ghstack-source-id` or `Pull-Request` trailers,
+you MUST preserve them when rewriting or splitting commit messages. ghstack
+will update the source id automatically when needed.
+
 # Coding Style Guidelines
 
 Follow these rules for all code changes in this repository:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #177536

