### PR TITLE
[inductor] Handle Triton cluster_dims metadata from both binary and metadata layouts

### DIFF
--- a/test/inductor/test_triton_cluster_dims.py
+++ b/test/inductor/test_triton_cluster_dims.py
@@ -1,0 +1,44 @@
+# Owner(s): ["module: inductor"]
+
+from types import SimpleNamespace
+
+from torch._inductor.runtime.triton_heuristics import _get_binary_cta_args
+from torch._inductor.test_case import run_tests, TestCase
+
+
+class TestTritonClusterDims(TestCase):
+    def test_cluster_dims_from_binary(self):
+        binary = SimpleNamespace(num_ctas=4, cluster_dims=(1, 2, 3))
+
+        self.assertEqual(_get_binary_cta_args(binary), (4, 1, 2, 3))
+
+    def test_cluster_dims_from_metadata(self):
+        binary = SimpleNamespace(
+            num_ctas=4,
+            metadata=SimpleNamespace(cluster_dims=(1, 2, 3)),
+        )
+
+        self.assertEqual(_get_binary_cta_args(binary), (4, 1, 2, 3))
+
+    def test_cluster_dims_from_mixed_binary_and_metadata_layouts(self):
+        binary = SimpleNamespace(
+            cluster_dims=(1, 2, 3),
+            metadata=SimpleNamespace(num_ctas=4),
+        )
+
+        self.assertEqual(_get_binary_cta_args(binary), (4, 1, 2, 3))
+
+    def test_cluster_dims_from_legacy_metadata_name(self):
+        binary = SimpleNamespace(
+            num_ctas=4,
+            metadata=SimpleNamespace(clusterDims=(1, 2, 3)),
+        )
+
+        self.assertEqual(_get_binary_cta_args(binary), (4, 1, 2, 3))
+
+    def test_cluster_dims_returns_empty_tuple_without_cluster_info(self):
+        self.assertEqual(_get_binary_cta_args(SimpleNamespace()), ())
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -1774,6 +1774,27 @@ class StaticTritonCompileResult(CompileResult[StaticallyLaunchedCudaKernel]):
         return launcher
 
 
+def _get_binary_cta_args(binary: Any) -> tuple[int, ...]:
+    """Read cluster launch metadata from either the binary or metadata object."""
+
+    metadata = getattr(binary, "metadata", None)
+    num_ctas = getattr(binary, "num_ctas", None)
+    if num_ctas is None and metadata is not None:
+        num_ctas = getattr(metadata, "num_ctas", None)
+
+    if num_ctas is None:
+        return ()
+
+    for owner in (binary, metadata):
+        if owner is None:
+            continue
+        for attr in ("cluster_dims", "clusterDims"):
+            if hasattr(owner, attr):
+                return (num_ctas, *getattr(owner, attr))
+
+    return ()
+
+
 class TritonCompileResult(CompileResult[CompiledKernel]):
     """
     Upstream Triton CompileKernel can not be pickled.  This is a wrapper
@@ -1900,20 +1921,7 @@ class TritonCompileResult(CompileResult[CompiledKernel]):
                 if hasattr(binary, "num_warps")
                 else binary.metadata.num_warps
             ),
-            "cta_args": (
-                (
-                    binary.num_ctas,
-                    *get_first_attr(binary, "cluster_dims", "clusterDims"),
-                )
-                if hasattr(binary, "num_ctas")
-                else (
-                    (binary.metadata.num_ctas, *binary.metadata.cluster_dims)
-                    if hasattr(binary, "metadata")
-                    and hasattr(binary.metadata, "num_ctas")
-                    and hasattr(binary.metadata, "cluster_dims")
-                    else ()
-                )
-            ),
+            "cta_args": _get_binary_cta_args(binary),
             "function": get_first_attr(binary, "function", "cu_function"),
             "runner": get_first_attr(binary, "run", "c_wrapper"),
             "math": math_lib,


### PR DESCRIPTION
## Summary

Handle Triton `cluster_dims` metadata from both binary and metadata layouts.

## Problem

Some Triton versions expose cluster dims on the compiled binary, while others
surface them on metadata. Inductor currently assumes a single layout, which can
break launcher construction when `num_ctas` and `cluster_dims` come from
separate objects.

## Fix

Add a small compatibility helper that reads cluster launch metadata from either
`binary` or `binary.metadata` before constructing `cta_args`.

## Testing

- added targeted unit/regression coverage for:
  - `cluster_dims` on the compiled binary
  - `cluster_dims` on metadata
  - mixed layouts where `num_ctas` and `cluster_dims` come from different objects
  - legacy `clusterDims` metadata
  - kernels with no cluster launch metadata
- suggested local verification:
  - `python -m pytest test/inductor/test_triton_cluster_dims.py -k cluster_dims -v`
  - `python -m pytest test/inductor -k triton -v`
  - `python -m lintrunner`


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo