### PR TITLE
[ROCm] Enable test_torchinductor_opinfo_properties on ROCm

### DIFF
--- a/test/inductor/test_torchinductor_opinfo_properties.py
+++ b/test/inductor/test_torchinductor_opinfo_properties.py
@@ -57,7 +57,6 @@ from torch.testing._internal.common_utils import (
     parametrize,
     skipIfTorchDynamo,
     TEST_WITH_ASAN,
-    TEST_WITH_ROCM,
 )
 from torch.testing._internal.inductor_utils import HAS_GPU
 
@@ -476,7 +475,6 @@ def compile_fn(fn, backend):
 
 @unittest.skipIf(IS_WINDOWS, "Skipped on Windows")
 @unittest.skipIf(TEST_WITH_ASAN, "Skipped under ASAN")
-@unittest.skipIf(TEST_WITH_ROCM, "Skipped on ROCm")
 @unittest.skipIf(not HAS_GPU, "Requires GPU")
 class TestOpInfoProperties(TestCase):
     """Test op properties under various inductor modes using OpInfo on CUDA."""


### PR DESCRIPTION
Seeing if ROCm can unskip the TestOpInfoPropertiesCUDA class
cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben