### PR TITLE
Make get_source_partitions() return deterministic node ordering

### DIFF
--- a/test/fx/test_source_matcher_utils.py
+++ b/test/fx/test_source_matcher_utils.py
@@ -531,6 +531,44 @@ class TestSourceMatcher(JitTestCase):
         )
 
 
+    @unittest.skipIf(not is_dynamo_supported(), "Dynamo not supported")
+    def test_source_partition_input_nodes_deterministic_order(self):
+        """input_nodes ordering should be deterministic (graph traversal order)."""
+
+        class M(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.linear = torch.nn.Linear(3, 3)
+
+            def forward(self, x, y):
+                # linear uses both x and the module's weight/bias,
+                # then add brings in y as a second external input
+                return self.linear(x) + y
+
+        inputs = (torch.randn(3, 3), torch.randn(3, 3))
+        gm, _ = torch._dynamo.export(M(), aten_graph=True)(*inputs)
+        gm.graph.eliminate_dead_code()
+
+        module_partitions = get_source_partitions(gm.graph, [torch.nn.Linear])
+        self.assertEqual(len(module_partitions[torch.nn.Linear]), 1)
+        partition = module_partitions[torch.nn.Linear][0]
+
+        # Run the same partitioning many times and verify the ordering is stable
+        expected_input_names = [n.name for n in partition.input_nodes]
+        expected_output_names = [n.name for n in partition.output_nodes]
+        for _ in range(50):
+            partitions = get_source_partitions(gm.graph, [torch.nn.Linear])
+            p = partitions[torch.nn.Linear][0]
+            self.assertEqual(
+                [n.name for n in p.input_nodes],
+                expected_input_names,
+            )
+            self.assertEqual(
+                [n.name for n in p.output_nodes],
+                expected_output_names,
+            )
+
+
 instantiate_parametrized_tests(TestSourceMatcher)
 
 if __name__ == "__main__":

--- a/torch/fx/passes/utils/source_matcher_utils.py
+++ b/torch/fx/passes/utils/source_matcher_utils.py
@@ -128,22 +128,25 @@ def get_source_partitions(
                 add_to_partition(source_fn[1], source_fn[0], node)
 
     def make_partition(nodes: list[Node], module_type: type) -> SourcePartition:
-        input_nodes = set()
-        output_nodes = set()
-        params = set()
+        # Use dicts to preserve insertion order (graph traversal order) while
+        # deduplicating, so that input_nodes/output_nodes/params ordering is
+        # deterministic across runs. See https://github.com/pytorch/pytorch/issues/147170
+        input_nodes: dict[Node, None] = {}
+        output_nodes: dict[Node, None] = {}
+        params: dict[Node, None] = {}
         for node in nodes:
             for arg in node.args:
                 if isinstance(arg, Node) and arg not in nodes and arg.op != "get_attr":
-                    input_nodes.add(arg)
+                    input_nodes[arg] = None
 
             if node.op == "get_attr":
-                params.add(node)
+                params[node] = None
                 # get_attr nodes won't be output nodes
                 continue
 
             for user in node.users:
                 if user not in nodes:
-                    output_nodes.add(node)
+                    output_nodes[node] = None
 
         return SourcePartition(
             nodes,


### PR DESCRIPTION
## Summary
- Replace `set()` with `dict()` in `make_partition()` to preserve insertion order (graph traversal order) when collecting `input_nodes`, `output_nodes`, and `params`
- Add a test that verifies the ordering is stable across repeated calls

## Motivation
Fixes #147170

`get_source_partitions()` returns `SourcePartition` objects where `input_nodes`, `output_nodes`, and `params` have non-deterministic ordering across runs. This is because `make_partition()` collects these into Python `set()` objects before converting to lists — and set iteration order is not guaranteed. Downstream quantization code that indexes into `input_nodes` by position (e.g. `input_nodes[0]` vs `input_nodes[1]`) gets different nodes on different runs, causing intermittent failures.

## Changes
**`torch/fx/passes/utils/source_matcher_utils.py`**: In `make_partition()`, replace `set()` with `dict[Node, None]` for `input_nodes`, `output_nodes`, and `params`. Python dicts preserve insertion order (guaranteed since 3.7), so `list(dict)` produces a deterministic list reflecting the graph traversal order. The deduplication behavior is preserved since dict keys are unique.

**`test/fx/test_source_matcher_utils.py`**: Add `test_source_partition_input_nodes_deterministic_order` which partitions a Linear module and verifies that `input_nodes` and `output_nodes` ordering is stable across 50 repeated calls.

## Test Plan
- New test `test_source_partition_input_nodes_deterministic_order` validates ordering stability
- All existing `TestSourceMatcher` tests should continue to pass (the change preserves the same set of nodes, only guaranteeing their order)

cc @angelayi @jerryzh168