### PR TITLE
Add device check in jiterator for non-CUDA tensors (#177477)

### DIFF
--- a/test/test_jiterator.py
+++ b/test/test_jiterator.py
@@ -155,6 +155,20 @@ class TestPythonJiterator(TestCase):
         for i in range(num_outputs):
             self.assertEqual(expected[i], result[i])
 
+    def test_cpu_tensors_error(self, device):
+        a = torch.rand(3, device='cpu')
+        b = torch.rand(3, device='cpu')
+        with self.assertRaisesRegex(RuntimeError, "Jiterator is only supported on CUDA and ROCm GPUs"):
+            jitted_fn(a, b)
+
+    def test_cpu_tensors_error_multi_output(self, device):
+        code_string = "template <typename T> void my_kernel(T x, T y, T& out1, T& out2) { out1 = x + y; out2 = x * y; }"
+        multi_jitted_fn = create_multi_output_jit_fn(code_string, num_outputs=2)
+        a = torch.rand(3, device='cpu')
+        b = torch.rand(3, device='cpu')
+        with self.assertRaisesRegex(RuntimeError, "Jiterator is only supported on CUDA and ROCm GPUs"):
+            multi_jitted_fn(a, b)
+
     @parametrize("code_string", [
         "template <typename T> T my _kernel(T x) { return x; }",
         "template <typename T> Tmy_kernel(T x) { return x; }",

--- a/torch/cuda/jiterator.py
+++ b/torch/cuda/jiterator.py
@@ -76,6 +76,13 @@ class _JittedFunction:
                 "Jiterator is only supported on CUDA and ROCm GPUs, none are available."
             )
 
+        for i, tensor in enumerate(tensors):
+            if not tensor.is_cuda:
+                raise RuntimeError(
+                    f"Jiterator is only supported on CUDA and ROCm GPUs, "
+                    f"but input tensor {i} is on device: {tensor.device}"
+                )
+
         if len(tensors) > 8:
             raise AssertionError(
                 f"jiterator only supports up to 8 tensor inputs, got {len(tensors)}"


### PR DESCRIPTION
Fixes #177477

Passing CPU tensors to jiterator functions previously triggered a cryptic `INTERNAL ASSERT FAILED` error from C++. This adds a Python-level check that raises a clear `RuntimeError` telling the user which tensor is on the wrong device.

Authored with the help of Claude.