### PR TITLE
[Bugfix] Keep builtin for serialization when used in dynamo

### DIFF
--- a/test/dynamo/test_aot_compile.py
+++ b/test/dynamo/test_aot_compile.py
@@ -1335,6 +1335,27 @@ from user code:
         actual = compiled_fn(*test_inputs)
         self.assertEqual(expected.x, actual.x)
 
+    def test_builtins_dict_survives_serialization(self):
+        """Test that __builtins_dict__ is preserved through serialize/deserialize."""
+
+        def fn(x):
+            return x + 1, type
+
+        x = torch.randn(4)
+        compiled_fn = torch.compile(fn, fullgraph=True).aot_compile(((x,), {}))
+
+        # Save and reload without f_globals
+        compiled_fn.save_compiled_function(self.path())
+        with open(self.path(), "rb") as f:
+            loaded_fn = torch.compiler.load_compiled_function(
+                f, f_globals=fn.__globals__
+            )
+
+        expected = fn(x)
+        actual = loaded_fn(x)
+        self.assertEqual(expected[0], actual[0])
+        self.assertEqual(expected[1], actual[1])
+
     @unittest.skipIf(not TEST_CUDA, "requires cuda")
     def test_cross_aot_compile(self):
         """Test cross-compilation using fake cuda tensors and backward correctness"""

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -1004,6 +1004,20 @@ class GraphRuntimeEnv:
             )
 
 
+def _safe_builtins_dict(builtins_dict: dict[str, Any]) -> dict[str, Any]:
+    """Filter a builtins dict to only picklable entries for serialization."""
+    import pickle
+
+    result = {}
+    for k, v in builtins_dict.items():
+        try:
+            pickle.dumps(v)
+            result[k] = v
+        except Exception:
+            pass
+    return result
+
+
 @dataclass
 class GraphCaptureOutput:
     """
@@ -1052,6 +1066,17 @@ class GraphCaptureOutput:
 
         # Scan bytecode for all external references
         external_refs = self._get_external_refs(self.bytecode)
+
+        # Best-effort serialization of builtins referenced by the bytecode.
+        # Similar to how guards prune __builtins_dict__ to only used entries.
+        import builtins as _builtins
+
+        for ref in external_refs:
+            if ref not in used_globals:
+                if ref.startswith("__builtins_dict__") and ref in self.f_globals:
+                    used_globals[ref] = _safe_builtins_dict(self.f_globals[ref])
+                elif hasattr(_builtins, ref):
+                    used_globals[ref] = getattr(_builtins, ref)
 
         return GraphRuntimeEnv(
             bytecode=self.bytecode,


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/177556

## Summary

When we have a builtin used in code dynamo is tracing that is not folded, we recieve an error when loading from the serialized function.

This is because the `__builtin_dict__` which dynamo uses is not captured; so in this PR, we update to selectively capture/preserve these so that loading succeeds

## Testing

```bash
python -m pytest test/dynamo/test_aot_compile.py::TestAOTCompile::test_builtins_dict_survives_serialization -xvs
```

Results in:
```bash
test/dynamo/test_aot_compile.py::TestAOTCompile::test_builtins_dict_survives_serialization PASSED [13.3021s]
```


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo