### PR TITLE
[inductor] Fix ConstructorMoverPass replacing CPU placeholder in graph output (#177563)

### DIFF
--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -3923,14 +3923,7 @@ if HAS_CUDA_AND_TRITON:
             self.assertEqual(self.get_manager().new_graph_id().id, 3)
 
         @torch._inductor.config.patch("graph_partition", True)
-        def test_graph_partition_backward_cpu_scalar_saved_tensor(self):
-            """
-            With graph_partition, a CPU graph input (e.g. a scalar parameter)
-            may be device-copied to CUDA for CG partition triton kernels.
-            The graph output must still reference the original CPU tensor so
-            the backward's CPU C++ kernel can dereference it safely.
-            """
-
+        def test_graph_partition_cpu_scalar_used_in_cpu_op(self):
             class Mod(torch.nn.Module):
                 def __init__(self) -> None:
                     super().__init__()
@@ -3954,6 +3947,43 @@ if HAS_CUDA_AND_TRITON:
             FileCheck().check("2 cudagraphable, 1 non-cudagraphable").run(
                 log_stream.getvalue()
             )
+
+            criterion = torch.nn.CrossEntropyLoss()
+            optimizer = torch.optim.SGD(model.parameters(), lr=0.01)
+
+            for _ in range(5):
+                output = compiled_model(x)
+                loss = criterion(output, torch.randint(0, 4, (4,)).cuda())
+                optimizer.zero_grad()
+                loss.backward()
+                optimizer.step()
+
+            eager_out = model(x)
+            compiled_out = compiled_model(x)
+            self.assertEqual(compiled_out, eager_out)
+
+        @torch._inductor.config.patch("graph_partition", True)
+        def test_graph_partition_backward_cpu_scalar_saved_tensor(self):
+            """
+            When a CPU scalar placeholder is moved to GPU by ConstructorMoverPass,
+            the forward graph's output must NOT replace the CPU placeholder with
+            the GPU copy.
+            """
+
+            class Mod(torch.nn.Module):
+                def __init__(self) -> None:
+                    super().__init__()
+                    self.linear = torch.nn.Linear(4, 4, device="cuda")
+                    self.cpu_scale = torch.nn.Parameter(torch.tensor(1.0))
+
+                def forward(self, x):
+                    return self.linear(x) * self.cpu_scale
+
+            model = Mod()
+            x = torch.randn(4, 4, device="cuda")
+
+            compiled_model = torch.compile(model, mode="reduce-overhead")
+            compiled_model(x)
 
             criterion = torch.nn.CrossEntropyLoss()
             optimizer = torch.optim.SGD(model.parameters(), lr=0.01)

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -1876,7 +1876,8 @@ class ConstructorMoverPass:
                         lambda x: x
                         not in [cpu_concat, gpu_concat, gpu_split, gpu_node]
                         + unsqueezed_nodes
-                        and x.target != torch.ops.aten.copy_.default,
+                        and x.target != torch.ops.aten.copy_.default
+                        and x.target != "output",
                     )
                     last_node = gpu_node
 


### PR DESCRIPTION
Summary:

When ConstructorMoverPass moves a CPU scalar placeholder to GPU, `replace_all_uses_with` also replaces the reference in the output node. This causes the forward graph to output a GPU tensor where the backward expects a CPU tensor. The backward's CPU C++ kernel then segfaults trying to dereference a GPU pointer.

The fix excludes the output node from `replace_all_uses_with`, so the forward output preserves the original CPU placeholder.

Authored with Claude.

Differential Revision: D96779188




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos