### PR TITLE
[dynamo] Register fake impls for streams::sync_dealloc and fix streams::record_stream

### DIFF
--- a/test/dynamo/test_streams.py
+++ b/test/dynamo/test_streams.py
@@ -1527,7 +1527,6 @@ class GraphModule(torch.nn.Module):
             "Expected control_deps nodes in backward graph for stream synchronization",
         )
 
-
     def test_sync_dealloc_has_fake_impl(self):
         """Test that sync_dealloc has a registered fake impl.
 

--- a/test/dynamo/test_streams.py
+++ b/test/dynamo/test_streams.py
@@ -1528,6 +1528,29 @@ class GraphModule(torch.nn.Module):
         )
 
 
+    def test_sync_dealloc_has_fake_impl(self):
+        """Test that sync_dealloc has a registered fake impl.
+
+        Without a fake impl, Inductor's backward compilation crashes when the
+        backward graph contains cross-stream sync_dealloc ops.
+        """
+        from torch._subclasses.fake_tensor import FakeTensorMode
+
+        with FakeTensorMode():
+            t = torch.randn(4)
+            # Should not raise "no fake impl registered"
+            torch.ops.streams.sync_dealloc.default(0, 1, t)
+
+    def test_record_stream_has_fake_impl(self):
+        """Test that record_stream's fake impl has the correct signature."""
+        from torch._subclasses.fake_tensor import FakeTensorMode
+
+        with FakeTensorMode():
+            t = torch.randn(4)
+            # Should not raise due to signature mismatch
+            torch.ops.streams.record_stream.default(t, 0)
+
+
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests
 

--- a/torch/_dynamo/variables/streams.py
+++ b/torch/_dynamo/variables/streams.py
@@ -188,6 +188,15 @@ def sync_dealloc(
     torch.ops.streams.wait_event.default(wait_event_index, src_stream_index)
 
 
+@sync_dealloc.register_fake
+def _(
+    wait_event_index: int,
+    src_stream_index: int,
+    to_dealloc: torch.Tensor,
+) -> None:
+    pass
+
+
 has_side_effect(torch.ops.streams.sync_dealloc.default)
 
 
@@ -198,9 +207,8 @@ def record_stream(tensor: torch.Tensor, stream_index: int) -> None:
 
 @record_stream.register_fake
 def _(
-    src_stream_index: int,
-    wait_event_index: int,
-    to_dealloc: torch.Tensor,
+    tensor: torch.Tensor,
+    stream_index: int,
 ) -> None:
     pass
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #177555
* __->__ #177564

The streams::sync_dealloc custom op was missing a register_fake
implementation, causing Inductor's backward compilation to crash when
the backward graph contains cross-stream synchronization ops. Also
fixes streams::record_stream's fake impl which had incorrect parameter
names copied from another op.

Found by TorchFuzz streams template. Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo