### PR TITLE
[MTIA] Add dilation support for max_pool2d_with_indices_backward lowering (#177568)

### DIFF
--- a/test/inductor/pallas_expected_failures/CpuTests.test_max_pool2d_with_indices_backward6_cpu
+++ b/test/inductor/pallas_expected_failures/CpuTests.test_max_pool2d_with_indices_backward6_cpu
@@ -1,0 +1,4 @@
+ERROR
+  Pallas backend does not support indirect_indexing patterns used by
+  max_pool2d_with_indices_backward lowering (dilation=[1,2] variant).
+  Same root cause as backward/backward2/backward3/backward4.

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -10683,7 +10683,7 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         # Correctness is validated by self.common() above.
         # MPS: decomposition falls back to native kernel, so no inductor kernels generated
         if self.device != "mps":
-            self.assertGreater(torch._inductor.metrics.generated_kernel_count, 0)
+            self.assertGreater(torch._inductor.metrics.generated_kernel_count, 1)
 
     def test_issue102546(self):
         def fn(x):

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -5410,14 +5410,10 @@ def max_pool2d_with_indices_backward(
     else:
         x_stride = x.maybe_get_stride()
 
-    is_channels_last = (x_stride is not None and x_stride[1] == 1) or (
-        gO_stride is not None and gO_stride[1] == 1
+    is_channels_last = len(x.get_size()) == 4 and (
+        (x_stride is not None and x_stride[1] == 1)
+        or (gO_stride is not None and gO_stride[1] == 1)
     )
-    if any(d != 1 for d in dilation):
-        # dilation NYI
-        return fallback_max_pool2d_with_indices_backward(
-            grad_output, x, kernel_size, stride, padding, dilation, ceil_mode, indices
-        )
 
     *_batch, _height, width = x.get_size()
     *_, pooled_height, pooled_width = grad_output.get_size()
@@ -5426,13 +5422,17 @@ def max_pool2d_with_indices_backward(
     grad_loader = grad_output.make_loader()
     new_size = list(x.get_size())
 
+    # Effective kernel size accounts for dilation
+    effective_kh = (kernel_size[0] - 1) * dilation[0] + 1
+    effective_kw = (kernel_size[1] - 1) * dilation[1] + 1
+
     h_window_size = max(
-        max(FloorDiv(h, stride[0]) - max(0, FloorDiv(h - kernel_size[0], stride[0])), 1)
-        for h in range(kernel_size[0] * 2)
+        max(FloorDiv(h, stride[0]) - max(0, FloorDiv(h - effective_kh, stride[0])), 1)
+        for h in range(effective_kh * 2)
     )
     w_window_size = max(
-        max(FloorDiv(w, stride[1]) - max(0, FloorDiv(w - kernel_size[1], stride[1])), 1)
-        for w in range(kernel_size[1] * 2)
+        max(FloorDiv(w, stride[1]) - max(0, FloorDiv(w - effective_kw, stride[1])), 1)
+        for w in range(effective_kw * 2)
     )
 
     window_size = h_window_size * w_window_size
@@ -5451,10 +5451,10 @@ def max_pool2d_with_indices_backward(
         h = h + padding[0]
         w = w + padding[1]
         phstart = ops.index_expr(
-            FloorDiv(h - kernel_size[0] + stride[0], stride[0]), torch.int32
+            FloorDiv(h - effective_kh + stride[0], stride[0]), torch.int32
         )
         pwstart = ops.index_expr(
-            FloorDiv(w - kernel_size[1] + stride[1], stride[1]), torch.int32
+            FloorDiv(w - effective_kw + stride[1], stride[1]), torch.int32
         )
         phend = ops.index_expr(FloorDiv(h, stride[0]) + 1, torch.int32)
         pwend = ops.index_expr(FloorDiv(w, stride[1]) + 1, torch.int32)


### PR DESCRIPTION
Summary:


Re-land of D95566134 (reverted in D96091876, D96273115) with a fix for the 3D tensor regression.

The Inductor lowering for `aten.max_pool2d_with_indices_backward` fell
back to `FallbackKernel` when dilation != 1 (marked as "NYI"). This
caused compilation failures on the target backend since the fallback op
is unsupported.

Fix: Use the effective kernel size `(kernel_size - 1) * dilation + 1`
instead of `kernel_size` in the window size computation and the
phstart/pwstart calculation. The index comparison logic (`ops.eq` on
stored argmax indices) remains unchanged since the forward pass already
computes correct flat indices accounting for dilation.

Also adds `aten.max_pool2d_with_indices_backward` to
`SAFE_AND_PERFORMANT_INDUCTOR_OPS` so it is not force-overridden with
`make_fallback()` on the target backend, and adds the passing test to CI.

Additionally fixes the root cause of the first revert: the `is_channels_last`
detection at `lowering.py:5153` incorrectly evaluated to `True` for 3D
(unbatched) tensors. When a 3D input with `dilation > 1` was passed,
`gO_stride[1] == 1` was `True` for a 3D tensor (e.g. shape `[2, 1, 1]`
with stride `[1, 1, 1]`), causing `require_channels_last()` to apply
`NHWC_STRIDE_ORDER = [3, 0, 2, 1]` (4 elements) to a 3D tensor (3
elements), crashing with `AssertionError` at `ir.py:4181`. The fix guards
`is_channels_last` with `len(x.get_size()) == 4` so channels-last layout
is only considered for 4D (NCHW) tensors, matching the forward
`max_pool2d_with_indices` lowering pattern.

Test Plan:
OPINFO_START_INDEX=6437 OPINFO_END_INDEX=6438 \
  OPINFO_LOWERING_MODE=AFG_INDUCTOR_COMPILE OPINFO_AUTO_DS=1 \
  buck2 run fbcode//mtia/compiler/graph_compiler/test_library/afg_opinfo_e2e_tests:test_afg_opinfo_e2e

Differential Revision: D96785001


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo