### PR TITLE
[CI] Install torchcomms nightly for torchtitan CI tests  

### DIFF
--- a/.ci/lumen_cli/cli/lib/core/torchtitan/torchtitan_test.py
+++ b/.ci/lumen_cli/cli/lib/core/torchtitan/torchtitan_test.py
@@ -21,11 +21,12 @@ class TorchtitanTestRunner(BaseRunner):
 
     def prepare(self):
         clone_torchtitan(dst=self.work_directory)
-        # torchao nightly is required by torchtitan
+        # torchao and torchcomms nightlies are required by torchtitan
         pip_install_packages(
             packages=[
                 "--pre",
                 "torchao",
+                "torchcomms",
                 "--index-url",
                 "https://download.pytorch.org/whl/nightly/cu129",
             ],


### PR DESCRIPTION
The `torchtitan-x-pytorch-test` CI job (torchtitan_features_integration) fails because `torchcomms` is not installed. Add `torchcomms` to the nightly package installation alongside `torchao` in the torchtitan test runner.
