### PR TITLE
Update deprecated torch.norm doc reference to torch.linalg.norm

### DIFF
--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -900,7 +900,7 @@ class Tensor(torch._C.TensorBase):
         keepdim=False,
         dtype=None,
     ):
-        r"""See :func:`torch.norm`"""
+        r"""See :func:`torch.linalg.norm`"""
         if has_torch_function_unary(self):
             return handle_torch_function(
                 Tensor.norm, (self,), self, p=p, dim=dim, keepdim=keepdim, dtype=dtype


### PR DESCRIPTION
Fixes #156005

This PR updates documentation references that still pointed to the deprecated
`torch.norm` function.

The reference has been updated to `torch.linalg.norm` to reflect the recommended API.

This change only affects documentation and does not modify functionality.