### PR TITLE
[Inductor] Gate addmm unfuse for half dtypes behind config flag

### DIFF
--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -1216,6 +1216,12 @@ class TestPatternMatcher(TestCase):
         FileCheck().check_not("extern_kernels.addmm(").run(code[0])
 
     @parametrize("dtype", [torch.bfloat16, torch.float16])
+    @inductor_config.patch(
+        {
+            "fx_graph_remote_cache": False,
+            "keep_addmm_fused_for_half_dtypes": True,
+        }
+    )
     def test_unfuse_bias_addmm_half_dtypes(self, dtype):
         args = [
             torch.randn(20, device=GPU_TYPE, dtype=dtype),
@@ -1231,6 +1237,27 @@ class TestPatternMatcher(TestCase):
 
         _, (code) = run_and_get_code(fn, args[0], args[1], args[2])
         FileCheck().check("extern_kernels.addmm(").run(code[0])
+
+    @parametrize("dtype", [torch.bfloat16, torch.float16])
+    @inductor_config.patch(
+        {
+            "fx_graph_remote_cache": False,
+            "keep_addmm_fused_for_half_dtypes": False,
+        }
+    )
+    def test_unfuse_bias_addmm_half_dtypes_when_flag_disabled(self, dtype):
+        args = [
+            torch.randn(20, device=GPU_TYPE, dtype=dtype),
+            torch.randn(10, 15, device=GPU_TYPE, dtype=dtype),
+            torch.randn(15, 20, device=GPU_TYPE, dtype=dtype),
+        ]
+
+        @torch.compile()
+        def fn(inp, a, b):
+            return torch.nn.functional.gelu(torch.ops.aten.addmm(inp, a, b))
+
+        _, (code) = run_and_get_code(fn, args[0], args[1], args[2])
+        FileCheck().check_not("extern_kernels.addmm(").run(code[0])
 
     def test_addmm_alpha_beta_with_pointwise(self):
         # Test that addmm with alpha/beta != 1 is unfused correctly with pointwise ops

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -2026,10 +2026,6 @@ def compile_fx_aot(
             "aot_inductor.output_path": code_hash(model_.code),
         }
 
-    # AOTI defaults to allowing addmm unfusing for half dtypes (perf) unless
-    # callers explicitly opt in to the accuracy-preserving behavior.
-    config_patches.setdefault("keep_addmm_fused_for_half_dtypes", False)
-
     from .utils import maybe_aoti_standalone_config
 
     config_patches = maybe_aoti_standalone_config(config_patches)

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -2026,6 +2026,10 @@ def compile_fx_aot(
             "aot_inductor.output_path": code_hash(model_.code),
         }
 
+    # AOTI defaults to allowing addmm unfusing for half dtypes (perf) unless
+    # callers explicitly opt in to the accuracy-preserving behavior.
+    config_patches.setdefault("keep_addmm_fused_for_half_dtypes", False)
+
     from .utils import maybe_aoti_standalone_config
 
     config_patches = maybe_aoti_standalone_config(config_patches)

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -373,6 +373,11 @@ dynamic_scale_rblock = os.environ.get("TORCHINDUCTOR_DYNAMIC_SCALE_RBLOCK", "1")
 # but the mul gets fused with other pointwise ops instead.
 force_fuse_int_mm_with_mul = False
 
+# Prevent unfusing addmm into mm+add for bf16/fp16 to avoid precision loss
+# from extra truncation at the mm output. Set to False to allow unfusing
+# (may improve perf at the cost of accuracy for some models).
+keep_addmm_fused_for_half_dtypes = True
+
 # DEPRECATED. This setting is ignored.
 use_mixed_mm = True
 

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -376,7 +376,6 @@ force_fuse_int_mm_with_mul = False
 # Prevent unfusing addmm into mm+add for bf16/fp16 to avoid precision loss
 # from extra truncation at the mm output. Set to False to allow unfusing
 # (may improve perf at the cost of accuracy for some models).
-# Note: AOTI defaults this to False for perf (see compile_fx_aot).
 keep_addmm_fused_for_half_dtypes = True
 
 # DEPRECATED. This setting is ignored.

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -376,6 +376,7 @@ force_fuse_int_mm_with_mul = False
 # Prevent unfusing addmm into mm+add for bf16/fp16 to avoid precision loss
 # from extra truncation at the mm output. Set to False to allow unfusing
 # (may improve perf at the cost of accuracy for some models).
+# Note: AOTI defaults this to False for perf (see compile_fx_aot).
 keep_addmm_fused_for_half_dtypes = True
 
 # DEPRECATED. This setting is ignored.

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -1530,9 +1530,10 @@ def should_prefer_unfused_addmm(match):
     extra_check=should_prefer_unfused_addmm,
 )
 def unfuse_bias_add_to_pointwise(match: Match, mat1, mat2, *, inp, alpha, beta):
-    # Unfusing addmm introduces an extra bf16/fp16 truncation at the mm output
-    # that compounds through deep models and causes accuracy failures.
-    if inp.meta["val"].dtype in (torch.bfloat16, torch.float16):
+    if config.keep_addmm_fused_for_half_dtypes and inp.meta["val"].dtype in (
+        torch.bfloat16,
+        torch.float16,
+    ):
         return
 
     def repl(inp, x1, x2, alpha, beta):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #177579
* #176848



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo