### PR TITLE
Fix context-parallel SDPA on CPU for is_causal=True

### DIFF
--- a/test/distributed/tensor/test_attention.py
+++ b/test/distributed/tensor/test_attention.py
@@ -1204,6 +1204,59 @@ class TestContextParallelStyleSDPA(DTensorTestBase):
         self.assertEqual(out_kwargs["key"].placements, [Shard(2)])
         self.assertEqual(out_kwargs["value"].placements, [Shard(2)])
 
+    @with_comms
+    def test_context_parallel_sdpa_math_is_causal_on_cpu(self):
+        if self.device_type != "cpu":
+            self.skipTest("This regression only reproduces on CPU math SDPA.")
+
+        self.run_subtests(
+            {
+                "batch_size": [1, 2],
+                "n_heads": [2, 4],
+                "seq_len": [8, 16],
+                "load_balance": [False, True],
+            },
+            self._test_context_parallel_sdpa_math_is_causal_on_cpu,
+        )
+
+    def _test_context_parallel_sdpa_math_is_causal_on_cpu(
+        self,
+        batch_size: int,
+        n_heads: int,
+        seq_len: int,
+        load_balance: bool,
+    ) -> None:
+        if load_balance and seq_len % (2 * self.world_size) != 0:
+            return
+
+        head_dim = 1
+        mesh = DeviceMesh(self.device_type, torch.arange(0, self.world_size))
+
+        q = torch.rand(batch_size, n_heads, seq_len, head_dim, device=self.device_type)
+        k = torch.rand(batch_size, n_heads, seq_len, head_dim, device=self.device_type)
+        v = torch.rand(batch_size, n_heads, seq_len, head_dim, device=self.device_type)
+        for tensor in (q, k, v):
+            dist.broadcast(tensor, src=0)
+
+        with sdpa_kernel(SDPBackend.MATH):
+            out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+
+        prev_enable_load_balance = _cp_options.enable_load_balance
+        _cp_options.enable_load_balance = load_balance
+        try:
+            with torch.no_grad():
+                with context_parallel(
+                    mesh,
+                    buffers=(q, k, v),
+                    buffer_seq_dims=(2, 2, 2),
+                ):
+                    cp_out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+            (cp_out,) = context_parallel_unshard(mesh, [cp_out], [2])
+        finally:
+            _cp_options.enable_load_balance = prev_enable_load_balance
+
+        torch.testing.assert_close(out, cp_out)
+
 
 RingAttentionTestWithLocalTensor = create_local_tensor_test_class(
     RingAttentionTest,

--- a/torch/distributed/tensor/experimental/_context_parallel/_attention.py
+++ b/torch/distributed/tensor/experimental/_context_parallel/_attention.py
@@ -955,6 +955,65 @@ OutputFnType = Callable[[nn.Module | None, Any, Any, DeviceMesh], Any]
 _replaced_functions: dict[Callable, tuple[str, Callable]] = {}
 
 
+def _call_context_parallel_sdpa(
+    target_fn: Callable,
+    args: ArgsType,
+    kwargs: KwargsType,
+) -> Any:
+    query = args[0] if len(args) > 0 else kwargs.get("query")
+    key = args[1] if len(args) > 1 else kwargs.get("key")
+    value = args[2] if len(args) > 2 else kwargs.get("value")
+    attn_mask = args[3] if len(args) > 3 else kwargs.get("attn_mask")
+    dropout_p = args[4] if len(args) > 4 else kwargs.get("dropout_p", 0.0)
+    is_causal = args[5] if len(args) > 5 else kwargs.get("is_causal", False)
+    scale = args[6] if len(args) > 6 else kwargs.get("scale")
+    enable_gqa = args[7] if len(args) > 7 else kwargs.get("enable_gqa", False)
+
+    if (
+        isinstance(query, DTensor)
+        and isinstance(key, DTensor)
+        and isinstance(value, DTensor)
+        and query.device.type == "cpu"
+    ):
+        local_query = query.to_local()
+        full_key = key.full_tensor()
+        full_value = value.full_tensor()
+        local_attn_mask = attn_mask
+        local_is_causal = is_causal
+
+        if is_causal and attn_mask is None:
+            group = query.device_mesh.get_group()
+            rank = dist.get_rank(group)
+            local_len = local_query.size(-2)
+            seq_len = full_key.size(-2)
+            load_balancer = _create_default_load_balancer(
+                seq_len, query.device_mesh.size(), local_query.device
+            )
+            positions = (
+                load_balancer._generate_indices(restore=False).reshape(-1)
+                if load_balancer is not None
+                else torch.arange(seq_len, device=local_query.device)
+            )
+            seq_start = rank * local_len
+            q_positions = positions[seq_start : seq_start + local_len]
+            k_positions = positions
+            local_attn_mask = k_positions.unsqueeze(0) <= q_positions.unsqueeze(1)
+            local_is_causal = False
+
+        return target_fn(
+            local_query,
+            full_key,
+            full_value,
+            attn_mask=local_attn_mask,
+            dropout_p=dropout_p,
+            is_causal=local_is_causal,
+            scale=scale,
+            enable_gqa=enable_gqa,
+        )
+
+    return target_fn(*args, **kwargs)
+
+
 def _distribute_function(
     fn: Callable,
     fn_module: types.ModuleType,
@@ -974,7 +1033,11 @@ def _distribute_function(
     ) -> Callable:
         def inner_fn(*args: ArgsType, **kwargs: KwargsType) -> Any:
             args, kwargs = input_fn(None, args, kwargs, device_mesh)
-            outputs = target_fn(*args, **kwargs)
+            outputs = (
+                _call_context_parallel_sdpa(target_fn, args, kwargs)
+                if target_fn.__name__ == "scaled_dot_product_attention"
+                else target_fn(*args, **kwargs)
+            )
             return output_fn(None, (args, kwargs), outputs, device_mesh)
 
         return inner_fn


### PR DESCRIPTION
## Summary

In the CP monkey-patched scaled_dot_product_attention path, q/k/v are converted to DTensor, but the CPU math SDPA path still materializes regular tensors for causal masking. That leads to a mixed Tensor/DTensor add and fails with:

aten.add.Tensor got mixed torch.Tensor and DTensor

This change avoids that path on CPU by:

 - materializing local q
 - materializing full k/v
 - reconstructing the effective sequence order used by CP load balancing
 - building the causal mask in that reordered space
 - calling the original SDPA API on local tensors

This preserves correct SDPA behavior for both load-balanced and non-load-balanced context parallelism.

## Testing

Added a CPU regression test in test/distributed/tensor/test_attention.py that compares unsharded SDPA output against context-parallel output after unsharding.

The test covers:

 - batch_size: 1, 2
 - n_heads: 2, 4
 - seq_len: 8, 16
 - load_balance: False, True

To test it run:

```
GLOO_SOCKET_IFNAME=lo python test/distributed/tensor/test_attention.py -v TestContextParallelStyleSDPA.test_context_parallel_sdpa_math_is_causal_on_cpu
```

Fixes https://github.com/pytorch/pytorch/issues/147793