### PR TITLE
[torchTLX] Rename fused TLX kernels with tlx prefix (#177590)

### DIFF
--- a/torch/_inductor/choices.py
+++ b/torch/_inductor/choices.py
@@ -347,6 +347,10 @@ class InductorChoices:
         """Hook to change the kwargs passed to TritonKernel, used to apply fixed configurations"""
         return kernel_kwargs
 
+    def customize_fused_kernel_name(self, fused_name: str, src_code: str) -> str:
+        """Hook to transform fused kernel names during codegen"""
+        return fused_name
+
     @staticmethod
     def should_use_cooperative_reduction(features: SIMDKernelFeatures) -> bool:
         """Heuristic to decide if a cooperative reduction should be used."""

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -6427,6 +6427,8 @@ class TritonScheduling(SIMDScheduling):
                 if config.triton.descriptive_names
                 else ""
             )
+            if fused_name:
+                fused_name = V.choices.customize_fused_kernel_name(fused_name, src_code)
             kernel_category = get_kernel_category_by_source_code(src_code)[:3]
             kernel_name = "_".join(
                 ["triton", kernel_category, fused_name, wrapper.next_kernel_suffix()]


### PR DESCRIPTION
Summary:

Add a customize_fused_kernel_name hook on InductorChoices and override
it in TLXInductorChoices to insert 'tlx' into fused kernel names when
the source uses TLX APIs (e.g. 'fused_mm' -> 'fused_tlx_mm').

This replaces the config-based approach from D95602337 with a
V.choices hook, minimizing non-fb changes.

Authored with Claude.

Test Plan: torchTLX unit tests

Reviewed By: PaulZhang12

Differential Revision: D96810349




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo