### PR TITLE
[Helion + torch.compile] Fix prologue fusion dtype check for multi-output templates

### DIFF
--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -5257,6 +5257,14 @@ class TemplateBuffer(OperationBuffer):
             allowed_prologue_inps or OrderedSet()
         )
 
+    @property
+    def dtype(self) -> torch.dtype:
+        if isinstance(self.layout, MultiOutputLayout):
+            raise NotImplementedError(
+                "Multi-output templates do not have a single dtype"
+            )
+        return self.get_layout().dtype
+
     def get_read_writes(self) -> dependencies.ReadWrites:
         return self.extract_read_writes(normalize=True)
 

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -5593,8 +5593,10 @@ class Scheduler:
         def low_prec_fp(dtype: torch.dtype) -> bool:
             return dtype.itemsize <= 2 and dtype.is_floating_point
 
+        template_buf = template_node.get_template_node_or_throw()
         if (
-            low_prec_fp(template_node.get_template_node_or_throw().dtype)
+            not template_buf.is_multi_outputs_template()
+            and low_prec_fp(template_buf.dtype)
             and not prologue_node.can_codegen_in_low_precision()
         ):
             why(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #177598
* #177065
* #177492

TemplateBuffer subclasses with MultiOutputLayout (e.g. Helion kernels)
don't have a single dtype, so accessing .dtype crashes. Add an explicit
error in TemplateBuffer.dtype for MultiOutputLayout, and skip the
low-precision prologue heuristic for multi-output templates since the
bytes threshold check already guards against unprofitable fusions.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo