### PR TITLE
[inductor] Reverse mm padding while respecting strides

### DIFF
--- a/test/inductor/test_pad_mm.py
+++ b/test/inductor/test_pad_mm.py
@@ -55,7 +55,7 @@ class PadMMTest(TestCase):
             compiled_fn = torch.compile(fn)
             res2, (code,) = run_and_get_code(compiled_fn, a)
             FileCheck().check(f"K = {aligned_k}").run(code)
-        self.assertEqual(res1, res2)
+        self.assertEqual(res1, res2, exact_stride=True)
 
     @inductor_config.patch(
         max_autotune=True, max_autotune_gemm_backends="TRITON", force_shape_pad=True
@@ -92,7 +92,7 @@ class PadMMTest(TestCase):
             compiled_fn = torch.compile(fn)
             res2, (code,) = run_and_get_code(compiled_fn, a, b)
             FileCheck().check(f"K = {aligned_k}").run(code)
-        self.assertEqual(res1, res2)
+        self.assertEqual(res1, res2, exact_stride=True)
 
     @inductor_config.patch(
         max_autotune=True, max_autotune_gemm_backends="TRITON", force_shape_pad=True
@@ -121,7 +121,7 @@ class PadMMTest(TestCase):
             compiled_fn = torch.compile(fn)
             res2, (code,) = run_and_get_code(compiled_fn, a, b)
             FileCheck().check(f"K = {aligned_k}").run(code)
-        self.assertEqual(res1, res2)
+        self.assertEqual(res1, res2, exact_stride=True)
 
     @inductor_config.patch(
         max_autotune=True, max_autotune_gemm_backends="TRITON", force_shape_pad=True
@@ -153,7 +153,7 @@ class PadMMTest(TestCase):
             compiled_fn = torch.compile(fn)
             res2, (code,) = run_and_get_code(compiled_fn, a, b)
             FileCheck().check(f"M = {aligned_m}").run(code)
-        self.assertEqual(res1, res2)
+        self.assertEqual(res1, res2, exact_stride=True)
 
     def test_pad_mm_dyn_mnk(self):
         M = 20
@@ -180,7 +180,7 @@ class PadMMTest(TestCase):
             res1 = fn(a, b)
             compiled_fn = torch.compile(fn)
             res2, (_,) = run_and_get_code(compiled_fn, a, b)
-        self.assertEqual(res1, res2)
+        self.assertEqual(res1, res2, exact_stride=True)
 
     @inductor_config.patch(force_shape_pad=True)
     def test_zero_dim(self):
@@ -190,7 +190,9 @@ class PadMMTest(TestCase):
         x = torch.randn(100).to(GPU_TYPE)
         a = torch.randn(0, 10).to(GPU_TYPE)
         b = torch.randn(10, 100).to(GPU_TYPE)
-        self.assertEqual(torch.compile(addmm)(x, a, b), addmm(x, a, b))
+        self.assertEqual(
+            torch.compile(addmm)(x, a, b), addmm(x, a, b), exact_stride=True
+        )
 
     @inductor_config.patch(
         max_autotune=True, max_autotune_gemm_backends="TRITON", force_shape_pad=True
@@ -221,7 +223,7 @@ class PadMMTest(TestCase):
             compiled_fn = torch.compile(fn)
             res2, (code,) = run_and_get_code(compiled_fn, a, b)
             FileCheck().check(f"K = {aligned_k}").run(code)
-        self.assertEqual(res1, res2)
+        self.assertEqual(res1, res2, exact_stride=True)
 
     @inductor_config.patch(
         max_autotune=True, max_autotune_gemm_backends="TRITON", force_shape_pad=True
@@ -252,7 +254,7 @@ class PadMMTest(TestCase):
             compiled_fn = torch.compile(fn)
             res2, (code,) = run_and_get_code(compiled_fn, a, b)
             FileCheck().check(f"N = {aligned_n}").run(code)
-        self.assertEqual(res1, res2)
+        self.assertEqual(res1, res2, exact_stride=True)
 
     @inductor_config.patch(
         max_autotune=True, max_autotune_gemm_backends="TRITON", force_shape_pad=True
@@ -284,7 +286,7 @@ class PadMMTest(TestCase):
             compiled_fn = torch.compile(fn)
             res2, (code,) = run_and_get_code(compiled_fn, a, b)
             FileCheck().check(f"N = {aligned_n}").run(code)
-        self.assertEqual(res1, res2)
+        self.assertEqual(res1, res2, exact_stride=True)
 
     @inductor_config.patch(
         max_autotune=True, max_autotune_gemm_backends="TRITON", force_shape_pad=True
@@ -315,7 +317,7 @@ class PadMMTest(TestCase):
             compiled_fn = torch.compile(fn)
             res2, (code,) = run_and_get_code(compiled_fn, a, b, c)
             FileCheck().check(f"K = {aligned_k}").run(code)
-        self.assertEqual(res1, res2)
+        self.assertEqual(res1, res2, exact_stride=True)
 
     @inductor_config.patch(
         max_autotune=True, max_autotune_gemm_backends="TRITON", force_shape_pad=True
@@ -348,7 +350,7 @@ class PadMMTest(TestCase):
             res2, (code,) = run_and_get_code(compiled_fn, a, b, c)
             # no padding
             FileCheck().check(f"K = {K}").run(code)
-        self.assertEqual(res1, res2)
+        self.assertEqual(res1, res2, exact_stride=True)
 
     @inductor_config.patch(force_shape_pad=True)
     def test_pad_single_cat(self):
@@ -358,7 +360,7 @@ class PadMMTest(TestCase):
 
         inps = [torch.rand([5, 5], device=GPU_TYPE) for _ in range(2)]
         out = foo(*inps)
-        self.assertEqual(out, inps[0] @ inps[1])
+        self.assertEqual(out, inps[0] @ inps[1], exact_stride=True)
 
     @inductor_config.patch(force_shape_pad=True)
     @fresh_cache()
@@ -376,7 +378,7 @@ class PadMMTest(TestCase):
                 )
                 out = foo(*inps)
                 out_eager = torch.ops.aten.addmm(*inps)
-                self.assertEqual(out, out_eager)
+                self.assertEqual(out, out_eager, exact_stride=True)
 
         for a in [1, 6]:
             inps = (
@@ -386,7 +388,7 @@ class PadMMTest(TestCase):
             )
             out = foo(*inps)
             out_eager = torch.ops.aten.addmm(*inps)
-            self.assertEqual(out, out_eager)
+            self.assertEqual(out, out_eager, exact_stride=True)
 
     @inductor_config.patch(force_shape_pad=True)
     def test_pad_batch(self):

--- a/torch/_inductor/fx_passes/pad_mm.py
+++ b/torch/_inductor/fx_passes/pad_mm.py
@@ -251,10 +251,8 @@ def pad_addmm(
 
     res = aten.addmm(input, mat1, mat2, beta=beta, alpha=alpha)
 
-    if m_padded_length != 0:
-        res = res[:-m_padded_length, :]
-    if n_padded_length != 0:
-        res = res[:, :-n_padded_length]
+    if m_padded_length != 0 or n_padded_length != 0:
+        res = aten.constant_pad_nd(res, [0, -n_padded_length, 0, -m_padded_length])
     return res
 
 
@@ -843,10 +841,8 @@ def pad_mm(
             mat2, k_padded_length=k_padded_length, n_padded_length=n_padded_length
         )
     res = aten.mm(mat1, mat2)
-    if m_padded_length != 0:
-        res = res[:-m_padded_length, :]
-    if n_padded_length != 0:
-        res = res[:, :-n_padded_length]
+    if m_padded_length != 0 or n_padded_length != 0:
+        res = aten.constant_pad_nd(res, [0, -n_padded_length, 0, -m_padded_length])
     return res
 
 
@@ -896,10 +892,10 @@ def pad_bmm(
             is_bmm=True,
         )
     res = aten.bmm(mat1, mat2)
-    if m_padded_length != 0:
-        res = res[:, :-m_padded_length, :]
-    if n_padded_length != 0:
-        res = res[:, :, :-n_padded_length]
+    if m_padded_length != 0 or n_padded_length != 0:
+        res = aten.constant_pad_nd(
+            res, [0, -n_padded_length, 0, -m_padded_length, 0, 0]
+        )
     return res
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #177604

Prior to this PR, when padding certain matrix multiplies in Inductor, the padding was reversed with a slicing view.  This is correct in a sense, but can result in different striding when the matrix is returned directly.  This was causing flaky test failures in some OpInfo linalg function tests.

This problem was traced down with a combination of pytest-flakefinder and pytest-xdist, which made the flake reproduce relatively reliably on my local machine.

Fixes #152059
Fixes #168207
Fixes #176109
Fixes #176110

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo