### PR TITLE
Upgrade submodule oneDNN to v3.11.2

### DIFF
--- a/cmake/Modules/FindMKLDNN.cmake
+++ b/cmake/Modules/FindMKLDNN.cmake
@@ -47,7 +47,7 @@ IF(NOT MKLDNN_FOUND)
     endif()
     ExternalProject_Add(xpu_mkldnn_proj
       GIT_REPOSITORY https://github.com/uxlfoundation/oneDNN
-      GIT_TAG v3.11.1
+      GIT_TAG v3.11.2
       PREFIX ${XPU_MKLDNN_DIR_PREFIX}
       BUILD_IN_SOURCE 0
       CMAKE_ARGS  -DCMAKE_C_COMPILER=icx

--- a/cmake/Modules/FindMKLDNN.cmake
+++ b/cmake/Modules/FindMKLDNN.cmake
@@ -47,7 +47,7 @@ IF(NOT MKLDNN_FOUND)
     endif()
     ExternalProject_Add(xpu_mkldnn_proj
       GIT_REPOSITORY https://github.com/uxlfoundation/oneDNN
-      GIT_TAG v3.10.2
+      GIT_TAG v3.11.1
       PREFIX ${XPU_MKLDNN_DIR_PREFIX}
       BUILD_IN_SOURCE 0
       CMAKE_ARGS  -DCMAKE_C_COMPILER=icx

--- a/third_party/mkl-dnn.BUILD
+++ b/third_party/mkl-dnn.BUILD
@@ -71,7 +71,7 @@ template_rule(
     substitutions = {
         "@DNNL_VERSION_MAJOR@": "3",
         "@DNNL_VERSION_MINOR@": "11",
-        "@DNNL_VERSION_PATCH@": "1",
+        "@DNNL_VERSION_PATCH@": "2",
     },
 )
 
@@ -86,7 +86,7 @@ template_rule(
     name = "include_dnnl_version_hash",
     src = "include/oneapi/dnnl/dnnl_version_hash.h.in",
     out = "include/oneapi/dnnl/dnnl_version_hash.h",
-    substitutions = {"@DNNL_VERSION_HASH@": "10dcd61798496fcacdf91bb9ecbe032e40246373",}
+    substitutions = {"@DNNL_VERSION_HASH@": "03c022d3ffdcee958cfacbe720048e725fdf644c",}
 )
 
 cc_library(

--- a/third_party/mkl-dnn.BUILD
+++ b/third_party/mkl-dnn.BUILD
@@ -18,6 +18,7 @@ _DNNL_RUNTIME_OMP = {
     "#cmakedefine ONEDNN_BUILD_GRAPH": "#undef ONEDNN_BUILD_GRAPH",
     "#cmakedefine DNNL_EXPERIMENTAL_PROFILING": "#undef DNNL_EXPERIMENTAL_PROFILING",
     "#cmakedefine DNNL_EXPERIMENTAL_LOGGING": "#undef DNNL_EXPERIMENTAL_LOGGING",
+    "#cmakedefine DNNL_SAFE_RBP": "#undef DNNL_SAFE_RBP",
     "#cmakedefine DNNL_EXPERIMENTAL_SYCL_KERNEL_COMPILER": "#undef DNNL_EXPERIMENTAL_SYCL_KERNEL_COMPILER",
     "#cmakedefine DNNL_DISABLE_GPU_REF_KERNELS": "#undef DNNL_DISABLE_GPU_REF_KERNELS",
     "#cmakedefine01 BUILD_TRAINING": "#define BUILD_TRAINING 1",
@@ -69,8 +70,8 @@ template_rule(
     out = "include/oneapi/dnnl/dnnl_version.h",
     substitutions = {
         "@DNNL_VERSION_MAJOR@": "3",
-        "@DNNL_VERSION_MINOR@": "10",
-        "@DNNL_VERSION_PATCH@": "2",
+        "@DNNL_VERSION_MINOR@": "11",
+        "@DNNL_VERSION_PATCH@": "1",
     },
 )
 
@@ -85,7 +86,7 @@ template_rule(
     name = "include_dnnl_version_hash",
     src = "include/oneapi/dnnl/dnnl_version_hash.h.in",
     out = "include/oneapi/dnnl/dnnl_version_hash.h",
-    substitutions = {"@DNNL_VERSION_HASH@": "f1d471933dc852f956fd05389f9313c7148783d5",}
+    substitutions = {"@DNNL_VERSION_HASH@": "10dcd61798496fcacdf91bb9ecbe032e40246373",}
 )
 
 cc_library(

--- a/torch/testing/_internal/common_modules.py
+++ b/torch/testing/_internal/common_modules.py
@@ -25,7 +25,7 @@ from torch.testing._internal.common_nn import (
     nllloss_reference, nlllossNd_reference, smoothl1loss_reference, softmarginloss_reference, get_reduction)
 from torch.testing._internal.common_utils import (
     freeze_rng_state, skipIfMPS, GRADCHECK_NONDET_TOL, TEST_WITH_ROCM, IS_WINDOWS,
-    skipIfTorchDynamo)
+    skipIfTorchDynamo, skipIfXpu)
 from types import ModuleType
 import operator
 
@@ -3977,6 +3977,8 @@ module_db: list[ModuleInfo] = [
                    # Not implemented for chalf on CPU
                    DecorateInfo(unittest.expectedFailure, 'TestModule', 'test_cpu_gpu_parity',
                                 dtypes=(torch.chalf,), device_type='cuda'),
+                   DecorateInfo(skipIfXpu, 'TestModule', 'test_cpu_gpu_parity',
+                                dtypes=(torch.chalf,), device_type='xpu'),
                ),
                decorators=(
                    DecorateInfo(precisionOverride({torch.float32: 1e-04}), 'TestModule', 'test_memory_format'),
@@ -3996,7 +3998,7 @@ module_db: list[ModuleInfo] = [
                    # Not implemented for chalf on CPU
                    DecorateInfo(unittest.expectedFailure, 'TestModule', 'test_cpu_gpu_parity',
                                 dtypes=(torch.chalf,), device_type='cuda'),
-                   DecorateInfo(unittest.expectedFailure, 'TestModule', 'test_cpu_gpu_parity',
+                   DecorateInfo(skipIfXpu, 'TestModule', 'test_cpu_gpu_parity',
                                 dtypes=(torch.chalf,), device_type='xpu'),
                ),
                decorators=(


### PR DESCRIPTION
This PR is to upgrade oneDNN to v3.11.2.

## Improvements
- Improved fp32 matmul performance with fp4 compressed weights.
- Improved fp32 matmul performance for cases when one of the tensors has a trivial dimension on processors with Intel AVX-512 instruction set support.
- Improved fp16/bf16 matmul performance for large tensor cases on Intel Graphics for Intel Core Ultra processor Series 3 (formerly Panther Lake).
- Improved matmul performance for cases with 4-byte alignment on Intel GPUs based on Xe2 architecture.
- Improved performance of fp16/bf16 matmul with mxfp4 weights.
- Introduced destination tensor [dynamic quantization](https://uxlfoundation.github.io/oneDNN/v3.11/dev_guide_attributes_quantization.html#dynamic-quantization) in matmul primitive following Open Compute Microscaling (MX) formats specification.
- Introduced support for NVFP4 quantization scheme. The changes include support for fp8_e4m3 grouped scales and dynamic quantization support for destination tensor with NVFP4-specific formula for scales computation.
- Introduced support for dropout as a primitive attribute for matmul, softmax and eltwise primitives.

## Validation results on Xeon CPU
1. Dynamo benchmarks

The test results are based on the 3 dynamo benchmark suites with three data types.

<img width="787" height="231" alt="image" src="https://github.com/user-attachments/assets/5e31dc94-4b36-4354-9aa4-3223888d126d" />


According to the local test results, we found that two torchbench models on AMP_BF16 show over 7% performance regression:

- `torch_multimodal_clip` has 9% e2e regression.
- `BERT_pytorch` has 22% e2e performance regression.

# Validation results on Intel B60

Suite | Precision | Shape | Eager Speedup | Inductor Speedup
-- | -- | -- | -- | --
Huggingface | BF16 | Static | 1.003 | 1.002
Timm | Bf16 | Static | 1.001 | 0.999
Torchbench | BF16 | Static | 1.003 | 1.000

## Validation results on AArch64


### Dynamo Suite: Geomean over latency - prev version vs new version (**Higher is better**) 
* for 16 Threads

Highlights for **Neoverse-V2** : 
* MobileNetV3  1.15x lower latency with BF16.
* Detectron2  **1.6x** lower latency with BF16.
* AlexNet **6.2x** lower latency with BF16.

| Suite       | Precision | Shape   | Neoverse-V1 Eager Geomean | Neoverse-V1 Inductor Geomean | Neoverse-V2 Eager Geomean | Neoverse-V2 Inductor Geomean |
|------------|-----------|---------|---------------------------|------------------------------|--------------------------|-----------------------------|
| HuggingFace         | f32       | static  | 0.992358837               | 0.995203121                  | 1.0062                   | 1.007                       |
| HuggingFace         | f32       | dynamic | 0.991266938               | 0.993936984                  | 1.0082                   | 1.0081                      |
| HuggingFace         | bf16      | static  | 1.002295256               | 0.987069391                  | 0.997                    | 1.0134                      |
| HuggingFace         | bf16      | dynamic | 0.999110791               | 0.993443274                  | 1.00108                  | 1.0089                      |
| Timm       | f32       | static  | 0.989609104               | 0.997575891                  | 0.9168                   | -                      |
| Timm       | f32       | dynamic | 0.988387827               | 0.998601957                  | 0.92156                  |  -                      |
| Timm       | bf16      | static  | 1.007171058               | 1.01461039                   | 0.9925                   | 0.9949                      |
| Timm       | bf16      | dynamic | 1.008969741               | 1.016053648                  | 0.9928                   | 1.0321                      |
| Torchbench | f32       | static  | 0.997158099               | 1.00775975                   | 0.96                     | -                           |
| Torchbench | f32       | dynamic | 0.998372653               | 1.005439427                  | -                        | -                           |
| Torchbench | bf16      | static  | 1.011766848               | 1.02951623                   | 0.9815                   | 0.98613                     |
| Torchbench | bf16      | dynamic | 1.017915309               | 1.028806584                  | 0.9759                   | 0.9831                      |

### Torchbenchmark - Geomean over speedup (Higher is better) 
* on 16 Threads 

| Suite       | Precision | Shape   | Neoverse-V1 Eager Geomean | Neoverse-V1 TorchScript Geomean | Neoverse-V2 Eager Geomean | Neoverse-V2 TorchScript Geomean |
|------------|-----------|---------|---------------------------|---------------------------------|--------------------------|---------------------------------|
| Torchbench | amp_bf16  | inference | 1.00043                 | 1.02446                         | 1.023                    | 1.059                           |
| Torchbench | amp_bf16  | training  | 1.03322                 | -                               | -                        | -                               |
| Torchbench | fp32      | inference | 1.00452                 | 1.00715                         | 1.0675                   | 1.1086                          |
| Torchbench | fp32      | training  | 1.00121                 | -                               | -                        | -                               |

### NLP - FP32 
* on 16 threads

| Suite | Neoverse-V1 Latency Geomean | Neoverse-V2 Latency Geomean |
|-------|-----------------------------|-----------------------------|
| NLP   | 0.996510961                 | 0.99651                     |

cc @gujinghui @PenghuiCheng @XiaobingSuper @jianyuh @jgong5 @mingfeima @sanchitintel @ashokei @jingxu10 @min-jean-cho @Guobing-Chen @Xia-Weiwen @snadampal