### PR TITLE
Update deprecated torch.norm references in tensor docs

### DIFF
--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -900,7 +900,7 @@ class Tensor(torch._C.TensorBase):
         keepdim=False,
         dtype=None,
     ):
-        r"""See :func:`torch.norm`"""
+        r"""See :func:`torch.linalg.norm`"""
         if has_torch_function_unary(self):
             return handle_torch_function(
                 Tensor.norm, (self,), self, p=p, dim=dim, keepdim=keepdim, dtype=dtype

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -3681,7 +3681,7 @@ add_docstr_all(
     r"""
 norm(p=2, dim=None, keepdim=False) -> Tensor
 
-See :func:`torch.norm`
+See :func:`torch.norm`. Note: `torch.norm` is deprecated, use :func:`torch.linalg.norm` instead.
 """,
 )
 


### PR DESCRIPTION
Fixes #156005

This PR updates documentation references related to `Tensor.norm`.

- Updated `_tensor.py` reference
- Updated `_tensor_docs.py` to reflect that `Tensor.norm` still calls `torch.norm`
- Added a deprecation note recommending `torch.linalg.norm`

This change improves consistency while preserving accurate behavior documentation.

Supersedes #177575