### PR TITLE
[MPS] Fix SDPA meta shapes to avoid dynamic seq guards

### DIFF
--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -21,6 +21,7 @@ import itertools
 from collections import defaultdict
 from torch import inf
 from torch.nn import Buffer, Parameter
+from torch.export import Dim, export
 from torch.testing._internal import opinfo
 from torch.testing._internal.common_utils import \
     (gradcheck, gradgradcheck, parametrize, run_tests, TestCase, download_file, MACOS_VERSION, IS_CI,
@@ -9745,6 +9746,38 @@ class TestSDPA(TestCaseMPS):
     def test_sdpa_no_mask_causal_fp16(self):
         self._test_sdpa_no_mask(True, torch.float16)
 
+    def test_sdpa_export_dynamic_seq_len(self):
+        # Regression test for https://github.com/pytorch/pytorch/issues/177603
+        class M(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.register_buffer("k", torch.zeros(1, 4, 64, 128))
+                self.register_buffer("v", torch.zeros(1, 4, 64, 128))
+
+            def forward(self, q, mask):
+                out, _ = torch.ops.aten._scaled_dot_product_attention_math_for_mps(
+                    q, self.k, self.v, mask, 0.0, False, None
+                )
+                return out
+
+        model = M().to(device="mps", dtype=torch.float32).eval()
+        seq = Dim("seq", min=1, max=64)
+
+        q = torch.randn(1, 4, 4, 128, device="mps", dtype=torch.float32)
+        mask = torch.zeros(4, 64, device="mps", dtype=torch.bool)
+
+        ep = export(
+            model,
+            (q, mask),
+            dynamic_shapes={"q": {2: seq}, "mask": {0: seq}},
+            strict=True,
+        )
+
+        q2 = torch.randn(1, 4, 7, 128, device="mps", dtype=torch.float32)
+        mask2 = torch.zeros(7, 64, device="mps", dtype=torch.bool)
+        out = ep.module()(q2, mask2)
+        self.assertEqual(out.shape, (1, 4, 7, 128))
+
     def test_sdpa_no_mask_causal_fp16_L7(self):
         self._test_sdpa_no_mask(True, torch.float16, 7)
 
@@ -10098,8 +10131,10 @@ class TestSDPAMetaDispatchMode(TorchDispatchMode):
                 for t in pytree.tree_flatten(res)[0]
             ]
 
-        # Format the output so that we only look at the tensor metadata
-        self.test.assertEqual(format_res(res), format_res(meta_res))
+        # Format the output so that we only look at the tensor metadata.
+        # Only compare the first returned value for this op; the second output
+        # is not consumed and inconsistent across paths.
+        self.test.assertEqual(format_res(res)[0], format_res(meta_res)[0])
         return res
 
 

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -6129,37 +6129,9 @@ def meta__scaled_dot_product_attention_math_for_mps(
     q_, unsqueezed = ensure_4d(query)
     k_, _ = ensure_4d(key)
     v_, _ = ensure_4d(value)
-    mask_ = None
-    if attn_mask is not None:
-        mask_expanded_dims = list(query.shape)
-        mask_expanded_dims[-1] = k_.size(2)
-        mask_ = attn_mask.expand(mask_expanded_dims)
-        mask_, _ = ensure_4d(mask_)
 
-    batch_size, num_head, q_size, query_head_size = q_.shape
-    _, k_size, max_seq_length, value_head_size = v_.shape
-
-    def sdpa_vector_fast_mps():
-        out = q_.new_empty(q_.shape)
-        if unsqueezed:
-            out = out.view_as(query)
-
-        attn = q_.new_empty((batch_size, num_head, q_size, max_seq_length))
-        if unsqueezed:
-            if query.dim() == 3:
-                attn = attn.squeeze(0)
-            else:
-                shape = list(query.shape[:-3]) + attn.shape[1:4]
-                attn = attn.view(shape)
-        return out, attn
-
-    def sdpa_vector_2pass_mps():
-        blocks = 32
-        out = q_.new_empty(q_.shape)
-        intermediate = q_.new_empty(
-            (batch_size, num_head, q_size, blocks, query_head_size)
-        )
-        return out, intermediate
+    batch_size, num_head, q_size, _ = q_.shape
+    _, _, max_seq_length, value_head_size = v_.shape
 
     def sdpa_general_mps():
         out = q_.new_empty((batch_size, num_head, q_size, value_head_size))
@@ -6175,26 +6147,9 @@ def meta__scaled_dot_product_attention_math_for_mps(
                 attn = attn.view(attn_shape)
         return out, attn
 
-    query_head_dim = q_.size(3)
-    value_head_dim = v_.size(3)
-    sdpa_vector_supported_head_dim = (query_head_dim == value_head_dim) and (
-        query_head_dim == 64 or query_head_dim == 96 or query_head_dim == 128
-    )
-    query_seq_len = q_.size(2)
-    supports_sdpa_vector = (
-        (query_seq_len <= 8)
-        and (query_seq_len <= k_.size(2))
-        and ((mask_ is None) or (mask_.dtype == torch.bool))
-        and sdpa_vector_supported_head_dim
-    )
-    supports_fast_sdpa = (not is_causal) and supports_sdpa_vector
-
-    if not supports_fast_sdpa:
-        return sdpa_general_mps()
-    elif (max_seq_length >= 1024) or (k_size < q_size and max_seq_length >= 4096):
-        return sdpa_vector_2pass_mps()
-    else:
-        return sdpa_vector_fast_mps()
+    # sdpa_vector_2pass_mps and sdpa_vector_fast_mps are intentionally left out.
+    # See https://github.com/pytorch/pytorch/issues/177603 for additional context.
+    return sdpa_general_mps()
 
 
 @register_meta([aten._scaled_dot_product_efficient_attention])


### PR DESCRIPTION
Fix proposed by @mergennachin in #177603. The issue was introduced in #176843.

Remove data-dependent branching in the MPS SDPA meta kernel so export supports dynamic seq.

Update meta-dispatch test to compare only the first output and add an export regression test.

@angelayi, you wrote the original meta registration and tests in #159695. Does this LGTY?

Fixes #177603