### PR TITLE
[test] Pass a tuple of 2 `SwizzleType` to nvfp4 `scaled_mm_v2` with two scales

### DIFF
--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -9110,10 +9110,10 @@ def sample_inputs_scaled_mm_v2(op_info, device, dtype, requires_grad, **kwargs):
                     mat2_fp4,
                     [scale1, global_scale1],
                     [ScalingType.BlockWise1x16, ScalingType.TensorWise],
-                    [SwizzleType.SWIZZLE_32_4_4, ],
+                    [SwizzleType.SWIZZLE_32_4_4, SwizzleType.NO_SWIZZLE],
                     [scale2, global_scale2],
                     [ScalingType.BlockWise1x16, ScalingType.TensorWise],
-                    [SwizzleType.SWIZZLE_32_4_4, ],
+                    [SwizzleType.SWIZZLE_32_4_4, SwizzleType.NO_SWIZZLE],
                     None,  # bias
                     torch.bfloat16,  # out_dtype
                 )


### PR DESCRIPTION
According to
https://github.com/pytorch/pytorch/blob/557a55ab4d63d644a3e5cd234ca55917b8dc9344/aten/src/ATen/native/cuda/ScaledBlas.cpp#L1236-L1242, both `swizzle_a` and `swizzle_b` should be a tuple of 2 `SwizzleType`.

Currently, 4th input causes some relevant tests such as `TestDecompCUDA.test_comprehensive_torch__scaled_mm_v2_cuda_float8_e4m3fn` and `TestCommonCUDA.test_out_warning_torch__scaled_mm_v2_cuda` to fail:
```
ValueError: swizzle_a must have 2 values, got 1
Exception raised from check_swizzle_lengths at /path/to/pytorch/aten/src/ATen/native/cuda/ScaledBlas.cpp:1252

Caused by sample input at index 4:
SampleInput(input=Tensor[size=(256, 256), device="cuda:0", dtype=torch.float4_e2m1fn_x2],
  args=(
    Tensor[size=(256, 768), dtype=torch.float4_e2m1fn_x2, contiguous=False],
    TensorList[Tensor[size=(256, 32), dtype=torch.float8_e4m3fn], Tensor[size=(1,), dtype=torch.float32]],
    (<_ScalingType.BlockWise1x16: 2>, <_ScalingType.TensorWise: 0>),
    (<_SwizzleType.SWIZZLE_32_4_4: 1>),   # <-- only 1 value, kernel expects 2
    ...
  )
)
```