### PR TITLE
Mark TestSparseCSR test cases XFAIL on XPU same as CPU and CUDA.

### DIFF
--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -12276,6 +12276,14 @@ op_db: list[OpInfo] = [
                            unittest.expectedFailure, 'TestSparseCSR', 'test_sparse_csr_unary_out',
                            device_type='cuda', dtypes=(torch.complex64,)
                        ),
+                       DecorateInfo(
+                           unittest.expectedFailure, 'TestSparseCSR', 'test_sparse_csr_unary_inplace',
+                           device_type='xpu', dtypes=(torch.complex64,)
+                       ),
+                       DecorateInfo(
+                           unittest.expectedFailure, 'TestSparseCSR', 'test_sparse_csr_unary_out',
+                           device_type='xpu', dtypes=(torch.complex64,)
+                       ),
                        # AssertionError: Tensor-likes are not close!
                        DecorateInfo(
                            unittest.expectedFailure, 'TestOutputConsistencyFullGraph', 'test_complex_output_match_opinfo_',


### PR DESCRIPTION
Some test cases are failing after introduction of https://github.com/pytorch/pytorch/commit/c41320d0e936ce8e7826d96c2559918644c16bc4 
This commit introduced XFAILs for CPU and CUDA, but didn't include XPU, which is now failing the test.

Apply the same XFAIL to XPU tests as for CPU and CUDA.

Fixes: https://github.com/intel/torch-xpu-ops/issues/2921