### PR TITLE
Refactor platform support utilities

### DIFF
--- a/test/distributed/tensor/parallel/test_micro_pipeline_tp.py
+++ b/test/distributed/tensor/parallel/test_micro_pipeline_tp.py
@@ -27,8 +27,8 @@ from torch.distributed.tensor.parallel import (
     parallelize_module,
     RowwiseParallel,
 )
-from torch.testing._internal.common_cuda import PLATFORM_SUPPORTS_FP8
 from torch.testing._internal.common_device_type import e4m3_type
+from torch.testing._internal.common_gpu import PLATFORM_SUPPORTS_FP8
 from torch.testing._internal.common_utils import (  # type: ignore[attr-defined]
     instantiate_parametrized_tests,
     IS_LINUX,

--- a/test/distributed/tensor/test_attention.py
+++ b/test/distributed/tensor/test_attention.py
@@ -50,8 +50,9 @@ from torch.nn.attention.flex_attention import (
     create_block_mask,
     flex_attention,
 )
-from torch.testing._internal.common_cuda import (
-    PLATFORM_SUPPORTS_CUDNN_ATTENTION,
+from torch.testing._internal.common_cuda import PLATFORM_SUPPORTS_CUDNN_ATTENTION
+from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
+from torch.testing._internal.common_gpu import (
     PLATFORM_SUPPORTS_FLASH_ATTENTION,
     PLATFORM_SUPPORTS_FUSED_ATTENTION,
     PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,

--- a/test/distributed/tensor/test_matrix_ops.py
+++ b/test/distributed/tensor/test_matrix_ops.py
@@ -29,11 +29,11 @@ from torch.distributed.tensor.debug import CommDebugMode
 from torch.distributed.tensor.placement_types import _StridedShard
 from torch.testing._internal.common_cuda import (
     _get_torch_cuda_version,
-    PLATFORM_SUPPORTS_FP8,
     SM90OrLater,
 )
 from torch.testing._internal.common_device_type import E4M3_MAX_POS, e4m3_type
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
+from torch.testing._internal.common_gpu import PLATFORM_SUPPORTS_FP8
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,

--- a/test/distributed/test_c10d_functional_native.py
+++ b/test/distributed/test_c10d_functional_native.py
@@ -20,13 +20,13 @@ from torch.distributed._functional_collectives import (
     reduce_scatter_single,
     reduce_scatter_single_coalesced,
 )
-from torch.testing._internal.common_cuda import PLATFORM_SUPPORTS_FP8
 from torch.testing._internal.common_device_type import e4m3_type
 from torch.testing._internal.common_distributed import (
     DistributedTestBase,
     requires_accelerator_dist_backend,
     skip_if_lt_x_gpu,
 )
+from torch.testing._internal.common_gpu import PLATFORM_SUPPORTS_FP8
 from torch.testing._internal.common_utils import (  # type: ignore[attr-defined]
     IS_LINUX,
     run_tests,

--- a/test/distributed/test_c10d_ops_nccl.py
+++ b/test/distributed/test_c10d_ops_nccl.py
@@ -23,13 +23,14 @@ if not c10d.is_available() or not c10d.is_nccl_available():
 
 
 import torch.distributed as dist
-from torch.testing._internal.common_cuda import PLATFORM_SUPPORTS_FP8, TEST_MULTIGPU
+from torch.testing._internal.common_cuda import TEST_MULTIGPU
 from torch.testing._internal.common_distributed import (
     init_multigpu_helper,
     MultiProcContinuousTest,
     requires_nccl,
     requires_nccl_version,
 )
+from torch.testing._internal.common_gpu import PLATFORM_SUPPORTS_FP8
 from torch.testing._internal.common_utils import (
     IS_LINUX,
     run_tests,

--- a/test/distributed/test_dynamo_distributed.py
+++ b/test/distributed/test_dynamo_distributed.py
@@ -38,11 +38,7 @@ from torch.distributed.fsdp.wrap import (
 )
 from torch.nn.attention.flex_attention import flex_attention
 from torch.nn.parallel import DistributedDataParallel as DDP
-from torch.testing._internal.common_cuda import (
-    PLATFORM_SUPPORTS_FLASH_ATTENTION,
-    PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
-    TEST_MULTIGPU,
-)
+from torch.testing._internal.common_cuda import TEST_MULTIGPU
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_distributed import (
     _dynamo_dist_per_rank_init,
@@ -51,6 +47,10 @@ from torch.testing._internal.common_distributed import (
     import_transformers_or_skip,
     requires_accelerator_dist_backend,
     skip_if_lt_x_gpu,
+)
+from torch.testing._internal.common_gpu import (
+    PLATFORM_SUPPORTS_FLASH_ATTENTION,
+    PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
 )
 from torch.testing._internal.common_utils import (
     MI350_ARCH,

--- a/test/dynamo/test_activation_checkpointing.py
+++ b/test/dynamo/test_activation_checkpointing.py
@@ -34,10 +34,12 @@ from torch.fx.experimental.sym_node import SymNode
 from torch.fx.experimental.symbolic_shapes import DimDynamic, ShapeEnv
 from torch.testing._internal.common_cuda import (
     PLATFORM_SUPPORTS_CUDNN_ATTENTION,
+)
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_gpu import (
     PLATFORM_SUPPORTS_FLASH_ATTENTION,
     PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
 )
-from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import IS_WINDOWS, parametrize, skipIfHpu
 from torch.testing._internal.inductor_utils import HAS_CUDA_AND_TRITON
 from torch.testing._internal.triton_utils import requires_cuda_and_triton

--- a/test/dynamo/test_ctx_manager.py
+++ b/test/dynamo/test_ctx_manager.py
@@ -16,11 +16,11 @@ from torch._dynamo.testing import (
 )
 from torch._dynamo.utils import counters
 from torch.nn import functional as F
-from torch.testing._internal.common_cuda import PLATFORM_SUPPORTS_FLASH_ATTENTION
 from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
     onlyCUDA,
 )
+from torch.testing._internal.common_gpu import PLATFORM_SUPPORTS_FLASH_ATTENTION
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -78,16 +78,13 @@ from torch.fx.experimental.symbolic_shapes import (
 )
 from torch.nn import functional as F
 from torch.testing import make_tensor
-from torch.testing._internal.common_cuda import (
-    PLATFORM_SUPPORTS_FLASH_ATTENTION,
-    SM80OrLater,
-    TEST_CUDA,
-)
+from torch.testing._internal.common_cuda import SM80OrLater, TEST_CUDA
 from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
     onlyCUDA,
     PYTORCH_CUDA_MEMCHECK,
 )
+from torch.testing._internal.common_gpu import PLATFORM_SUPPORTS_FLASH_ATTENTION
 from torch.testing._internal.common_methods_invocations import (
     sample_inputs_take_along_dim,
 )

--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -64,17 +64,17 @@ from torch.nn.attention.flex_attention import (
     flex_attention,
 )
 from torch.profiler import profile, ProfilerActivity
-from torch.testing._internal.common_cuda import (
-    PLATFORM_SUPPORTS_BF16,
-    PLATFORM_SUPPORTS_FLASH_ATTENTION,
-    PLATFORM_SUPPORTS_FP8,
-    SM70OrLater,
-)
+from torch.testing._internal.common_cuda import SM70OrLater
 from torch.testing._internal.common_device_type import (
     E4M3_MAX_POS,
     e4m3_type,
     instantiate_device_type_tests,
     onlyAccelerator,
+)
+from torch.testing._internal.common_gpu import (
+    PLATFORM_SUPPORTS_BF16,
+    PLATFORM_SUPPORTS_FLASH_ATTENTION,
+    PLATFORM_SUPPORTS_FP8,
 )
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,

--- a/test/dynamo/test_unspec.py
+++ b/test/dynamo/test_unspec.py
@@ -12,8 +12,8 @@ import torch._dynamo.testing
 import torch.nn.functional as F
 from torch._dynamo.comptime import comptime
 from torch._dynamo.testing import CompileCounter, CompileCounterWithBackend, same
-from torch.testing._internal.common_cuda import PLATFORM_SUPPORTS_MEM_EFF_ATTENTION
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_gpu import PLATFORM_SUPPORTS_MEM_EFF_ATTENTION
 from torch.testing._internal.common_utils import skipIfWindows
 from torch.testing._internal.logging_utils import logs_to_string
 

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -72,10 +72,8 @@ from torch.export.passes import move_to_device_pass
 from torch.fx.experimental.proxy_tensor import make_fx
 from torch.fx.experimental.symbolic_shapes import ShapeEnv
 from torch.testing import FileCheck
-from torch.testing._internal.common_cuda import (
-    PLATFORM_SUPPORTS_FLASH_ATTENTION,
-    xfailIfDistributedNotSupported,
-)
+from torch.testing._internal.common_cuda import xfailIfDistributedNotSupported
+from torch.testing._internal.common_gpu import PLATFORM_SUPPORTS_FLASH_ATTENTION
 from torch.testing._internal.common_utils import (
     find_library_location,
     IS_FBCODE,

--- a/test/functorch/test_vmap.py
+++ b/test/functorch/test_vmap.py
@@ -47,8 +47,6 @@ from torch.nn.attention import sdpa_kernel, SDPBackend
 from torch.testing._internal.autograd_function_db import autograd_function_db
 from torch.testing._internal.common_cuda import (
     PLATFORM_SUPPORTS_CUDNN_ATTENTION,
-    PLATFORM_SUPPORTS_FLASH_ATTENTION,
-    PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
     TEST_CUDNN_VERSION,
     tf32_on_and_off,
     with_tf32_off,
@@ -61,6 +59,10 @@ from torch.testing._internal.common_device_type import (
     skipOps,
     tol,
     toleranceOverride,
+)
+from torch.testing._internal.common_gpu import (
+    PLATFORM_SUPPORTS_FLASH_ATTENTION,
+    PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
 )
 from torch.testing._internal.common_methods_invocations import op_db
 from torch.testing._internal.common_utils import (

--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -48,10 +48,6 @@ from torch.testing._internal import common_utils
 from torch.testing._internal.common_cuda import (
     CDNA2OrLater,
     CDNA5OrLater,
-    PLATFORM_SUPPORTS_FLASH_ATTENTION,
-    PLATFORM_SUPPORTS_FP8,
-    PLATFORM_SUPPORTS_FP8_GROUPED_GEMM,
-    PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
     requires_triton_ptxas_compat,
     SM80OrLater,
     SM90OrLater,
@@ -66,6 +62,12 @@ from torch.testing._internal.common_device_type import (
 from torch.testing._internal.common_dtype import (
     highest_precision_complex,
     highest_precision_float,
+)
+from torch.testing._internal.common_gpu import (
+    PLATFORM_SUPPORTS_FLASH_ATTENTION,
+    PLATFORM_SUPPORTS_FP8,
+    PLATFORM_SUPPORTS_FP8_GROUPED_GEMM,
+    PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
 )
 from torch.testing._internal.common_quantization import (
     _group_quantize_tensor,

--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -30,12 +30,14 @@ from torch.fx.experimental.proxy_tensor import make_fx
 from torch.nn.attention import sdpa_kernel, SDPBackend
 from torch.testing import FileCheck
 from torch.testing._internal.common_cuda import (
-    PLATFORM_SUPPORTS_FLASH_ATTENTION,
-    PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
     SM80OrLater,
     SM90OrLater,
     TEST_MULTIGPU,
     tf32_on_and_off,
+)
+from torch.testing._internal.common_gpu import (
+    PLATFORM_SUPPORTS_FLASH_ATTENTION,
+    PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
 )
 from torch.testing._internal.common_utils import (
     DeterministicGuard,

--- a/test/inductor/test_cutlass_backend.py
+++ b/test/inductor/test_cutlass_backend.py
@@ -76,7 +76,6 @@ from torch._inductor.utils import fresh_cache
 from torch.sparse import SparseSemiStructuredTensor, to_sparse_semi_structured
 from torch.testing import FileCheck
 from torch.testing._internal.common_cuda import (
-    PLATFORM_SUPPORTS_FP8,
     skipIfSM103,
     SM100OrLater,
     SM120OrLater,
@@ -85,6 +84,7 @@ from torch.testing._internal.common_cuda import (
     xfailIfSM120OrLater,
 )
 from torch.testing._internal.common_device_type import skipCUDAIf, skipXPUIf
+from torch.testing._internal.common_gpu import PLATFORM_SUPPORTS_FP8
 from torch.testing._internal.common_utils import (
     IN_RE_WORKER,
     instantiate_parametrized_tests,

--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -50,11 +50,7 @@ from torch.nn.attention.flex_attention import (
 )
 from torch.testing import FileCheck
 from torch.testing._internal import common_utils
-from torch.testing._internal.common_cuda import (
-    PLATFORM_SUPPORTS_BF16,
-    PLATFORM_SUPPORTS_FP8,
-    TEST_MULTIGPU,
-)
+from torch.testing._internal.common_cuda import TEST_MULTIGPU
 from torch.testing._internal.common_device_type import (
     dtypes,
     dtypesIfCUDA,
@@ -71,6 +67,10 @@ from torch.testing._internal.common_device_type import (
     skipCUDAIf,
     skipMPSIf,
     skipXPUIf,
+)
+from torch.testing._internal.common_gpu import (
+    PLATFORM_SUPPORTS_BF16,
+    PLATFORM_SUPPORTS_FP8,
 )
 from torch.testing._internal.common_quantized import _snr
 from torch.testing._internal.common_utils import (  # noqa: F401

--- a/test/inductor/test_flex_decoding.py
+++ b/test/inductor/test_flex_decoding.py
@@ -23,11 +23,7 @@ from torch.nn.attention.flex_attention import (
 )
 from torch.testing import FileCheck
 from torch.testing._internal import common_utils
-from torch.testing._internal.common_cuda import (
-    PLATFORM_SUPPORTS_BF16,
-    PLATFORM_SUPPORTS_FP8,
-    with_tf32_off,
-)
+from torch.testing._internal.common_cuda import with_tf32_off
 from torch.testing._internal.common_device_type import (
     E4M3_MAX_POS,
     e4m3_type,
@@ -40,6 +36,10 @@ from torch.testing._internal.common_device_type import (
     skipCPUIf,
     skipCUDAIf,
     skipXPUIf,
+)
+from torch.testing._internal.common_gpu import (
+    PLATFORM_SUPPORTS_BF16,
+    PLATFORM_SUPPORTS_FP8,
 )
 from torch.testing._internal.common_quantized import _snr
 from torch.testing._internal.common_utils import IS_CI, IS_WINDOWS

--- a/test/inductor/test_flex_flash.py
+++ b/test/inductor/test_flex_flash.py
@@ -27,7 +27,6 @@ from torch.nn.attention.flex_attention import (
 from torch.profiler import profile, ProfilerActivity
 from torch.testing._internal.common_cuda import (
     IS_SM90,
-    PLATFORM_SUPPORTS_FP8,
     SM120OrLater,
     SM80OrLater,
     SM90OrLater,
@@ -39,6 +38,7 @@ from torch.testing._internal.common_device_type import (
     e4m3_type,
     instantiate_device_type_tests,
 )
+from torch.testing._internal.common_gpu import PLATFORM_SUPPORTS_FP8
 from torch.testing._internal.common_utils import (
     decorateIf,
     DeterministicGuard,

--- a/test/inductor/test_fp8.py
+++ b/test/inductor/test_fp8.py
@@ -18,14 +18,16 @@ from torch.nn.functional import scaled_mm, ScalingType  # type: ignore[attr-defi
 from torch.testing._internal.common_cuda import (
     _get_torch_cuda_version,
     IS_SM90,
-    PLATFORM_SUPPORTS_FP8,
-    PLATFORM_SUPPORTS_MX_GEMM,
 )
 from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
     onlyCUDA,
     onlyOn,
     skipCUDAIf,
+)
+from torch.testing._internal.common_gpu import (
+    PLATFORM_SUPPORTS_FP8,
+    PLATFORM_SUPPORTS_MX_GEMM,
 )
 from torch.testing._internal.common_quantized import ceil_div, to_blocked
 from torch.testing._internal.common_utils import (

--- a/test/inductor/test_fused_attention.py
+++ b/test/inductor/test_fused_attention.py
@@ -13,10 +13,8 @@ from torch._dynamo.debug_utils import aot_graph_input_parser
 from torch._dynamo.utils import counters
 from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.utils import run_and_get_code
-from torch.testing._internal.common_cuda import (
-    PLATFORM_SUPPORTS_FUSED_ATTENTION,
-    SM80OrLater,
-)
+from torch.testing._internal.common_cuda import SM80OrLater
+from torch.testing._internal.common_gpu import PLATFORM_SUPPORTS_FUSED_ATTENTION
 from torch.testing._internal.common_utils import IS_LINUX, skipIfXpu, TEST_WITH_ROCM
 from torch.testing._internal.inductor_utils import (
     GPU_TYPE,

--- a/test/inductor/test_graph_transform_observer.py
+++ b/test/inductor/test_graph_transform_observer.py
@@ -9,7 +9,7 @@ import torch
 import torch._dynamo
 import torch._inductor.config as inductor_config
 from torch._inductor.test_case import run_tests, TestCase
-from torch.testing._internal.common_cuda import PLATFORM_SUPPORTS_FUSED_ATTENTION
+from torch.testing._internal.common_gpu import PLATFORM_SUPPORTS_FUSED_ATTENTION
 from torch.testing._internal.common_utils import IS_LINUX
 from torch.testing._internal.inductor_utils import HAS_CUDA_AND_TRITON
 

--- a/test/inductor/test_loop_ordering.py
+++ b/test/inductor/test_loop_ordering.py
@@ -23,7 +23,7 @@ from torch._inductor.test_operators import realize
 from torch._inductor.utils import is_big_gpu, run_and_get_code, sympy_index_symbol
 from torch._inductor.virtualized import ops, V
 from torch.testing import FileCheck
-from torch.testing._internal.common_cuda import PLATFORM_SUPPORTS_FP8, SM90OrLater
+from torch.testing._internal.common_gpu import PLATFORM_SUPPORTS_FP8, SM90OrLater
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,

--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -74,8 +74,9 @@ from torch._inductor.select_algorithm import (
     TritonTemplate,
     TritonTemplateCaller,
 )
-from torch.testing._internal.common_cuda import PLATFORM_SUPPORTS_FP8, SM90OrLater
+from torch.testing._internal.common_cuda import SM90OrLater
 from torch.testing._internal.common_device_type import largeTensorTest
+from torch.testing._internal.common_gpu import PLATFORM_SUPPORTS_FP8
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     IS_WINDOWS,

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -80,9 +80,6 @@ from torch.testing._internal.common_cuda import (
     _get_torch_cuda_version,
     _get_torch_rocm_version,
     IS_SM90,
-    PLATFORM_SUPPORTS_FLASH_ATTENTION,
-    PLATFORM_SUPPORTS_FP8,
-    PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
     SM80OrLater,
     SM90OrLater,
     TEST_CUDNN,
@@ -98,6 +95,11 @@ from torch.testing._internal.common_dtype import (
     all_types,
     get_all_dtypes,
     highest_precision_float,
+)
+from torch.testing._internal.common_gpu import (
+    PLATFORM_SUPPORTS_FLASH_ATTENTION,
+    PLATFORM_SUPPORTS_FP8,
+    PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
 )
 from torch.testing._internal.common_quantization import (
     _dynamically_quantize_per_channel,

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -59,13 +59,13 @@ from torch.fx.experimental.symbolic_shapes import (
 from torch.fx.passes.fake_tensor_prop import FakeTensorProp
 from torch.nn.attention import sdpa_kernel, SDPBackend
 from torch.testing import FileCheck
-from torch.testing._internal.common_cuda import PLATFORM_SUPPORTS_FLASH_ATTENTION
 from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
     OpDTypes,
     ops,
 )
 from torch.testing._internal.common_dtype import all_types_complex_float8_and
+from torch.testing._internal.common_gpu import PLATFORM_SUPPORTS_FLASH_ATTENTION
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     IS_LINUX,

--- a/test/test_flop_counter.py
+++ b/test/test_flop_counter.py
@@ -7,13 +7,13 @@ import torch
 import torch.nn.functional as F
 import torch.utils.flop_counter
 from torch._subclasses.fake_tensor import FakeTensorMode
-from torch.testing._internal.common_cuda import (
-    PLATFORM_SUPPORTS_CUDNN_ATTENTION,
+from torch.testing._internal.common_cuda import PLATFORM_SUPPORTS_CUDNN_ATTENTION
+from torch.testing._internal.common_device_type import e4m3_type
+from torch.testing._internal.common_gpu import (
     PLATFORM_SUPPORTS_FLASH_ATTENTION,
     PLATFORM_SUPPORTS_FP8,
     PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
 )
-from torch.testing._internal.common_device_type import e4m3_type
 from torch.testing._internal.common_utils import (
     run_tests,
     TEST_WITH_TORCHDYNAMO,

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -42,7 +42,8 @@ from torch.testing._internal.common_dtype import (
     floating_and_complex_types_and, floating_types_and, complex_types,
 )
 from torch.testing._internal.common_cuda import CDNA2OrLater, CDNA5OrLater, SM80OrLater, SM90OrLater, tf32_on_and_off, _get_magma_version, \
-    _get_torch_cuda_version, TEST_MULTIGPU, PLATFORM_SUPPORTS_FP8, blas_library_context
+    _get_torch_cuda_version, TEST_MULTIGPU, blas_library_context
+from torch.testing._internal.common_gpu import PLATFORM_SUPPORTS_FP8
 from torch.testing._internal.common_quantization import _group_quantize_tensor, _dynamically_quantize_per_channel, \
     _group_quantize_tensor_symmetric
 from torch.testing._internal.common_mkldnn import reduced_f32_on_and_off

--- a/test/test_matmul_cuda.py
+++ b/test/test_matmul_cuda.py
@@ -24,12 +24,12 @@ from torch.testing._internal.common_cuda import (
     _get_torch_cuda_version,
     blas_library_context,
     IS_SM90,
-    PLATFORM_SUPPORTS_BF16,
     SM80OrLater,
     SM90OrLater,
     SM100OrLater,
     SM120OrLater,
 )
+from torch.testing._internal.common_gpu import PLATFORM_SUPPORTS_BF16
 from torch.testing._internal.common_device_type import (
     dtypes,
     instantiate_device_type_tests,

--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -26,7 +26,6 @@ from torch.nested._internal.nested_tensor import (
     ViewNestedFromBuffer,
 )
 from torch.testing._internal.common_cuda import (
-    PLATFORM_SUPPORTS_FUSED_ATTENTION,
     SM70OrLater,
     SM80OrLater,
     tf32_on_and_off,
@@ -45,6 +44,7 @@ from torch.testing._internal.common_device_type import (
     skipMeta,
 )
 from torch.testing._internal.common_dtype import floating_types_and_half
+from torch.testing._internal.common_gpu import PLATFORM_SUPPORTS_FUSED_ATTENTION
 from torch.testing._internal.common_utils import (
     decorateIf,
     freeze_rng_state,

--- a/test/test_scaled_matmul_cuda.py
+++ b/test/test_scaled_matmul_cuda.py
@@ -21,16 +21,18 @@ from torch.nn.functional import (
 )
 from torch.testing._internal.common_cuda import (
     IS_SM90,
-    _get_torch_cuda_version,
-    PLATFORM_SUPPORTS_FP8,
-    PLATFORM_SUPPORTS_FP8_GROUPED_GEMM,
-    PLATFORM_SUPPORTS_MX_GEMM,
-    PLATFORM_SUPPORTS_MXFP8_GROUPED_GEMM,
     SM100OrLater,
     SM120OrLater,
     SM89OrLater,
     SM90OrLater,
+    _get_torch_cuda_version,
     with_tf32_off,
+)
+from torch.testing._internal.common_gpu import (
+    PLATFORM_SUPPORTS_FP8,
+    PLATFORM_SUPPORTS_FP8_GROUPED_GEMM,
+    PLATFORM_SUPPORTS_MXFP8_GROUPED_GEMM,
+    PLATFORM_SUPPORTS_MX_GEMM,
 )
 from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,

--- a/test/test_sparse_csr.py
+++ b/test/test_sparse_csr.py
@@ -9,8 +9,6 @@ import unittest
 import functools
 from contextlib import redirect_stderr
 from torch.testing import make_tensor, FileCheck
-from torch.testing._internal.common_cuda import (
-    PLATFORM_SUPPORTS_BF16, PLATFORM_SUPPORTS_BF16_ATOMICS, PLATFORM_SUPPORTS_HALF_ATOMICS)
 from torch.testing._internal.common_utils import \
     (TEST_WITH_TORCHINDUCTOR, TEST_WITH_ROCM, TEST_CUDA_CUDSS, TEST_SCIPY, TEST_NUMPY, TEST_MKL, IS_WINDOWS, TestCase,
      run_tests, load_tests, coalescedonoff, parametrize, subtest, skipIfTorchDynamo,
@@ -21,6 +19,11 @@ from torch.testing._internal.common_device_type import \
 from torch.testing._internal.common_methods_invocations import \
     (op_db, sparse_csr_unary_ufuncs, ReductionOpInfo)
 from torch.testing._internal.common_cuda import TEST_CUDA
+from torch.testing._internal.common_gpu import (
+    PLATFORM_SUPPORTS_BF16,
+    PLATFORM_SUPPORTS_BF16_ATOMICS,
+    PLATFORM_SUPPORTS_HALF_ATOMICS,
+)
 from torch.testing._internal.common_dtype import (
     floating_types, all_types_and_complex_and, floating_and_complex_types, floating_types_and,
     all_types_and_complex, floating_and_complex_types_and)

--- a/test/test_sparse_semi_structured.py
+++ b/test/test_sparse_semi_structured.py
@@ -21,16 +21,14 @@ from torch.sparse._semi_structured_conversions import (
     sparse_semi_structured_from_dense_cutlass,
 )
 from torch.testing import make_tensor
-from torch.testing._internal.common_cuda import (
-    PLATFORM_SUPPORTS_FP8,
-    PLATFORM_SUPPORTS_FP8_SPARSE,
-    xfailIfSM89PreCUDA13,
-)
+from torch.testing._internal.common_cuda import xfailIfSM89PreCUDA13
+from torch.testing._internal.common_gpu import PLATFORM_SUPPORTS_FP8_SPARSE
 from torch.testing._internal.common_device_type import (
     dtypes,
     instantiate_device_type_tests,
 )
 from torch.testing._internal.common_dtype import all_types_and_complex
+from torch.testing._internal.common_gpu import PLATFORM_SUPPORTS_FP8
 from torch.testing._internal.common_utils import (
     IS_WINDOWS,
     parametrize,

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -46,15 +46,17 @@ from torch._dynamo.testing import CompileCounterWithBackend
 from torch.testing._internal.common_methods_invocations import wrapper_set_seed
 from torch.testing._internal.common_cuda import (
     IS_JETSON,
-    SM80OrLater,
-    PLATFORM_SUPPORTS_FLASH_ATTENTION,
-    PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
-    PLATFORM_SUPPORTS_FUSED_ATTENTION,
     PLATFORM_SUPPORTS_CUDNN_ATTENTION,
     PLATFORM_SUPPORTS_CK_SDPA,
+    SM80OrLater,
+    tf32_enabled,
     tf32_off,
     tf32_on_and_off,
-    tf32_enabled,
+)
+from torch.testing._internal.common_gpu import (
+    PLATFORM_SUPPORTS_FLASH_ATTENTION,
+    PLATFORM_SUPPORTS_FUSED_ATTENTION,
+    PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
 )
 from torch.testing._internal.common_device_type import skipXPUIf
 from torch.testing._internal.common_xpu import PLATFORM_SUPPORTS_FLASH_ATTENTION_XPU

--- a/test/test_varlen_attention.py
+++ b/test/test_varlen_attention.py
@@ -17,12 +17,12 @@ from torch.testing._internal.common_cuda import (
     IS_SM90,
     PLATFORM_SUPPORTS_CK_SDPA,
     PLATFORM_SUPPORTS_CUDNN_ATTENTION,
-    PLATFORM_SUPPORTS_FLASH_ATTENTION,
     SM100OrLater,
     SM120OrLater,
     SM90OrLater,
 )
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_gpu import PLATFORM_SUPPORTS_FLASH_ATTENTION
 from torch.testing._internal.common_nn import NNTestCase
 from torch.testing._internal.common_utils import (
     decorateIf,

--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -5,7 +5,7 @@ r"""This file is allowed to initialize CUDA context when imported."""
 import functools
 import torch
 import torch.cuda
-from torch.testing._internal.common_utils import LazyVal, TEST_NUMBA, TEST_WITH_ROCM, TEST_CUDA, IS_WINDOWS, IS_MACOS, TEST_XPU
+from torch.testing._internal.common_utils import LazyVal, TEST_NUMBA, TEST_WITH_ROCM, TEST_CUDA, IS_WINDOWS, IS_MACOS
 from torch.utils._import_utils import _check_module_exists
 import inspect
 import contextlib
@@ -111,50 +111,16 @@ def CDNA2OrLater():
 def gfx_arch_supports_opportunistic_fastatomics():
     return evaluate_gfx_arch_within(["gfx942", "gfx950"])
 
-def evaluate_platform_supports_flash_attention():
-    if TEST_WITH_ROCM:
-        # NOTE: gfx1250 is omitted until flash-attention artifacts ship for it.
-        # The AOTriton path needs the gfx1250 GPU image from AOTriton 0.12.1b,
-        # which is wired up by PR #188242 (which also adds gfx1250 to this list);
-        # this gate-only PR leaves it out so the two changes do not conflict
-        # (see cmake/External/aotriton.cmake). The CK FAv3/AITER codegen is
-        # separately not yet wired for gfx1250
-        # (see aten/src/ATen/native/transformers/hip/flash_attn/ck/fav_v3/CMakeLists.txt).
-        arch_list = ["gfx90a", "gfx942", "gfx1100", "gfx1201", "gfx950"]
-        if os.environ.get("TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL", "0") != "0":
-            arch_list += ["gfx1101", "gfx1102", "gfx1150", "gfx1151", "gfx1200"]
-        return evaluate_gfx_arch_within(arch_list)
-    if TEST_CUDA:
-        return not IS_WINDOWS and SM80OrLater
-    if TEST_XPU:
-        return True
-    return False
+def evaluate_platform_supports_cudnn_attention():
+    return (not TEST_WITH_ROCM) and SM80OrLater and (TEST_CUDNN_VERSION >= 90000)
+
+PLATFORM_SUPPORTS_CUDNN_ATTENTION: bool = LazyVal(lambda: evaluate_platform_supports_cudnn_attention())
 
 def evaluate_platform_supports_ck_sdpa():
     if TEST_WITH_ROCM:
         return torch.backends.cuda.is_ck_sdpa_available()
     else:
         return False
-
-def evaluate_platform_supports_efficient_attention():
-    if TEST_WITH_ROCM:
-        # NOTE: gfx1250 is omitted until mem-efficient-attention artifacts ship
-        # for it. The AOTriton gfx1250 image (from AOTriton 0.12.1b) is wired up
-        # by PR #188242, which also adds gfx1250 here; this gate-only PR leaves
-        # it out to avoid conflicting with that change. The CK FAv3/AITER codegen
-        # is separately not yet wired for gfx1250.
-        arch_list = ["gfx90a", "gfx942", "gfx1100", "gfx1201", "gfx950"]
-        if os.environ.get("TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL", "0") != "0":
-            arch_list += ["gfx1101", "gfx1102", "gfx1150", "gfx1151", "gfx1200"]
-        return evaluate_gfx_arch_within(arch_list)
-    if TEST_CUDA:
-        return True
-    if TEST_XPU:
-        return True
-    return False
-
-def evaluate_platform_supports_cudnn_attention():
-    return (not TEST_WITH_ROCM) and SM80OrLater and (TEST_CUDNN_VERSION >= 90000)
 
 def evaluate_platform_supports_green_context():
     from torch.cuda.green_contexts import _ensure_supported
@@ -164,48 +130,9 @@ def evaluate_platform_supports_green_context():
     except RuntimeError:
         return False
 
-PLATFORM_SUPPORTS_FLASH_ATTENTION: bool = LazyVal(lambda: evaluate_platform_supports_flash_attention())
-PLATFORM_SUPPORTS_MEM_EFF_ATTENTION: bool = LazyVal(lambda: evaluate_platform_supports_efficient_attention())
-PLATFORM_SUPPORTS_CUDNN_ATTENTION: bool = LazyVal(lambda: evaluate_platform_supports_cudnn_attention())
-# This condition always evaluates to PLATFORM_SUPPORTS_MEM_EFF_ATTENTION but for logical clarity we keep it separate
-PLATFORM_SUPPORTS_FUSED_ATTENTION: bool = LazyVal(lambda: PLATFORM_SUPPORTS_FLASH_ATTENTION or
-                                                  PLATFORM_SUPPORTS_CUDNN_ATTENTION or
-                                                  PLATFORM_SUPPORTS_MEM_EFF_ATTENTION)
-
-PLATFORM_SUPPORTS_FUSED_SDPA: bool = TEST_CUDA and not TEST_WITH_ROCM
+PLATFORM_SUPPORTS_GREEN_CONTEXT: bool = LazyVal(lambda: evaluate_platform_supports_green_context())
 
 PLATFORM_SUPPORTS_CK_SDPA: bool = LazyVal(lambda: evaluate_platform_supports_ck_sdpa())
-
-
-def evaluate_platform_supports_bf16():
-    if torch.version.cuda:
-        return SM80OrLater
-    elif torch.version.hip:
-        return True
-    elif TEST_XPU:
-        return True
-    return False
-
-
-def evaluate_platform_supports_bf16_atomics():
-    if torch.version.cuda:
-        return SM80OrLater
-    elif torch.version.hip:
-        return ROCM_VERSION >= (8, 0)
-    return False
-
-
-def evaluate_platform_supports_half_atomics():
-    if torch.version.hip:
-        return ROCM_VERSION >= (8, 0)
-    return True
-
-
-PLATFORM_SUPPORTS_BF16: bool = LazyVal(lambda: evaluate_platform_supports_bf16())
-PLATFORM_SUPPORTS_BF16_ATOMICS: bool = LazyVal(lambda: evaluate_platform_supports_bf16_atomics())
-PLATFORM_SUPPORTS_HALF_ATOMICS: bool = LazyVal(lambda: evaluate_platform_supports_half_atomics())
-
-PLATFORM_SUPPORTS_GREEN_CONTEXT: bool = LazyVal(lambda: evaluate_platform_supports_green_context())
 
 def evaluate_platform_supports_workqueue_config():
     from torch.cuda.green_contexts import _ensure_supported, _ensure_workqueue_supported
@@ -217,78 +144,6 @@ def evaluate_platform_supports_workqueue_config():
         return False
 
 PLATFORM_SUPPORTS_WORKQUEUE_CONFIG: bool = LazyVal(lambda: evaluate_platform_supports_workqueue_config())
-
-def evaluate_platform_supports_fp8():
-    if torch.cuda.is_available():
-        if torch.version.hip:
-            archs = ['gfx94']
-            if ROCM_VERSION >= (6, 3):
-                archs.extend(['gfx120'])
-            if ROCM_VERSION >= (6, 5):
-                archs.append('gfx95')
-            if ROCM_VERSION >= (7, 14):
-                archs.append('gfx1250')
-            for arch in archs:
-                if arch in torch.cuda.get_device_properties(0).gcnArchName:
-                    return True
-            return False
-        else:
-            return SM90OrLater or torch.cuda.get_device_capability() == (8, 9)
-    if torch.xpu.is_available():
-        return True
-    # As CPU supports FP8 and is always available, return True.
-    return True
-
-def evaluate_platform_supports_fp8_grouped_gemm():
-    if torch.cuda.is_available():
-        if torch.version.hip:
-            if "USE_MSLK" not in torch.__config__.show():
-                return False
-            # gfx1250 omitted: MSLK only builds gfx942/gfx950 kernels (see the arch
-            # filter in aten/src/ATen/CMakeLists.txt). Add gfx1250 here once MSLK does.
-            archs = ['gfx942', 'gfx950']
-            for arch in archs:
-                if arch in torch.cuda.get_device_properties(0).gcnArchName:
-                    return True
-        else:
-            return SM90OrLater and not SM100OrLater
-    return False
-
-def evaluate_platform_supports_mx_gemm():
-    if torch.cuda.is_available():
-        if torch.version.hip:
-            if ROCM_VERSION >= (7, 0):
-                gcn_name = torch.cuda.get_device_properties(0).gcnArchName
-                return 'gfx950' in gcn_name or ('gfx1250' in gcn_name and ROCM_VERSION >= (7, 14))
-        else:
-            return SM100OrLater
-    if torch.xpu.is_available():
-        return True
-    return False
-
-def evaluate_platform_supports_mxfp8_grouped_gemm():
-    if torch.cuda.is_available() and not torch.version.hip:
-        built_with_mslk = "USE_MSLK" in torch.__config__.show()
-        return built_with_mslk and IS_SM100
-    return False
-
-def evaluate_platform_supports_fp8_sparse():
-    if torch.cuda.is_available():
-        if torch.version.hip:
-            return 'gfx950' in torch.cuda.get_device_properties(0).gcnArchName
-        else:
-            return (
-                (SM90OrLater or torch.cuda.get_device_capability() == (8, 9))
-                and torch.backends.cusparselt.is_available()
-                and torch.backends.cusparselt.version() >= 602
-            )
-    return False
-
-PLATFORM_SUPPORTS_MX_GEMM: bool = LazyVal(lambda: evaluate_platform_supports_mx_gemm())
-PLATFORM_SUPPORTS_FP8: bool = LazyVal(lambda: evaluate_platform_supports_fp8())
-PLATFORM_SUPPORTS_FP8_SPARSE: bool = LazyVal(lambda: evaluate_platform_supports_fp8_sparse())
-PLATFORM_SUPPORTS_FP8_GROUPED_GEMM: bool = LazyVal(lambda: evaluate_platform_supports_fp8_grouped_gemm())
-PLATFORM_SUPPORTS_MXFP8_GROUPED_GEMM: bool = LazyVal(lambda: evaluate_platform_supports_mxfp8_grouped_gemm())
 
 if TEST_NUMBA:
     try:

--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -11,6 +11,7 @@ import inspect
 import contextlib
 import os
 import unittest
+import warnings
 
 
 CUDA_ALREADY_INITIALIZED_ON_IMPORT = torch.cuda.is_initialized()
@@ -439,6 +440,49 @@ requires_triton_ptxas_compat = unittest.skipIf(not torch.version.xpu
                                                and torch.version.hip is None
                                                and _get_torch_cuda_version() < TRITON_PTXAS_VERSION,
                                                "Requires CUDA {}.{} to match Tritons ptxas version".format(*TRITON_PTXAS_VERSION))
+
+# These platform-capability symbols were moved to
+# torch.testing._internal.common_gpu. Re-export them here for backward
+# compatibility, warning that the common_cuda location is deprecated.
+_MOVED_TO_COMMON_GPU = frozenset({
+    "evaluate_platform_supports_flash_attention",
+    "evaluate_platform_supports_efficient_attention",
+    "evaluate_platform_supports_fp8",
+    "evaluate_platform_supports_bf16",
+    "evaluate_platform_supports_bf16_atomics",
+    "evaluate_platform_supports_half_atomics",
+    "evaluate_platform_supports_fp8_grouped_gemm",
+    "evaluate_platform_supports_mx_gemm",
+    "evaluate_platform_supports_mxfp8_grouped_gemm",
+    "evaluate_platform_supports_fp8_sparse",
+    "PLATFORM_SUPPORTS_FLASH_ATTENTION",
+    "PLATFORM_SUPPORTS_MEM_EFF_ATTENTION",
+    "PLATFORM_SUPPORTS_FUSED_ATTENTION",
+    "PLATFORM_SUPPORTS_FUSED_SDPA",
+    "PLATFORM_SUPPORTS_FP8",
+    "PLATFORM_SUPPORTS_BF16",
+    "PLATFORM_SUPPORTS_BF16_ATOMICS",
+    "PLATFORM_SUPPORTS_HALF_ATOMICS",
+    "PLATFORM_SUPPORTS_MX_GEMM",
+    "PLATFORM_SUPPORTS_FP8_GROUPED_GEMM",
+    "PLATFORM_SUPPORTS_MXFP8_GROUPED_GEMM",
+    "PLATFORM_SUPPORTS_FP8_SPARSE",
+})
+
+
+def __getattr__(name):
+    if name in _MOVED_TO_COMMON_GPU:
+        from torch.testing._internal import common_gpu
+        warnings.warn(
+            f"'{name}' has moved from torch.testing._internal.common_cuda to "
+            f"torch.testing._internal.common_gpu. Importing it from common_cuda "
+            f"is deprecated and will be removed in a future release.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return getattr(common_gpu, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 # Importing this module should NOT eagerly initialize CUDA
 if not CUDA_ALREADY_INITIALIZED_ON_IMPORT:

--- a/torch/testing/_internal/common_gpu.py
+++ b/torch/testing/_internal/common_gpu.py
@@ -1,0 +1,182 @@
+import os
+
+import torch
+from torch.testing._internal.common_cuda import (
+    evaluate_gfx_arch_within,
+    IS_SM100,
+    PLATFORM_SUPPORTS_CUDNN_ATTENTION,
+    ROCM_VERSION,
+    SM100OrLater,
+    SM80OrLater,
+    SM90OrLater,
+)
+from torch.testing._internal.common_utils import (
+    IS_WINDOWS,
+    LazyVal,
+    TEST_CUDA,
+    TEST_WITH_ROCM,
+    TEST_XPU,
+)
+
+
+def evaluate_platform_supports_flash_attention():
+    if TEST_WITH_ROCM:
+        # NOTE: gfx1250 is omitted until flash-attention artifacts ship for it.
+        # The AOTriton path needs the gfx1250 GPU image from AOTriton 0.12.1b,
+        # which is wired up by PR #188242 (which also adds gfx1250 to this list);
+        # this gate-only PR leaves it out so the two changes do not conflict
+        # (see cmake/External/aotriton.cmake). The CK FAv3/AITER codegen is
+        # separately not yet wired for gfx1250
+        # (see aten/src/ATen/native/transformers/hip/flash_attn/ck/fav_v3/CMakeLists.txt).
+        arch_list = ["gfx90a", "gfx942", "gfx1100", "gfx1201", "gfx950"]
+        if os.environ.get("TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL", "0") != "0":
+            arch_list += ["gfx1101", "gfx1102", "gfx1150", "gfx1151", "gfx1200"]
+        return evaluate_gfx_arch_within(arch_list)
+    if TEST_CUDA:
+        return not IS_WINDOWS and SM80OrLater
+    if TEST_XPU:
+        return True
+    return False
+
+
+def evaluate_platform_supports_efficient_attention():
+    if TEST_WITH_ROCM:
+        # NOTE: gfx1250 is omitted until mem-efficient-attention artifacts ship
+        # for it. The AOTriton gfx1250 image (from AOTriton 0.12.1b) is wired up
+        # by PR #188242, which also adds gfx1250 here; this gate-only PR leaves
+        # it out to avoid conflicting with that change. The CK FAv3/AITER codegen
+        # is separately not yet wired for gfx1250.
+        arch_list = ["gfx90a", "gfx942", "gfx1100", "gfx1201", "gfx950"]
+        if os.environ.get("TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL", "0") != "0":
+            arch_list += ["gfx1101", "gfx1102", "gfx1150", "gfx1151", "gfx1200"]
+        return evaluate_gfx_arch_within(arch_list)
+    if TEST_CUDA:
+        return True
+    if TEST_XPU:
+        return True
+    return False
+
+
+PLATFORM_SUPPORTS_FLASH_ATTENTION: bool = LazyVal(
+    lambda: evaluate_platform_supports_flash_attention()
+)
+PLATFORM_SUPPORTS_MEM_EFF_ATTENTION: bool = LazyVal(
+    lambda: evaluate_platform_supports_efficient_attention()
+)
+# This condition always evaluates to PLATFORM_SUPPORTS_MEM_EFF_ATTENTION but for logical clarity we keep it separate
+PLATFORM_SUPPORTS_FUSED_ATTENTION: bool = LazyVal(
+    lambda: PLATFORM_SUPPORTS_FLASH_ATTENTION
+    or PLATFORM_SUPPORTS_CUDNN_ATTENTION
+    or PLATFORM_SUPPORTS_MEM_EFF_ATTENTION
+)
+PLATFORM_SUPPORTS_FUSED_SDPA: bool = TEST_CUDA and not TEST_WITH_ROCM
+
+
+def evaluate_platform_supports_fp8():
+    if torch.cuda.is_available():
+        if torch.version.hip:
+            archs = ['gfx94']
+            if ROCM_VERSION >= (6, 3):
+                archs.extend(['gfx120'])
+            if ROCM_VERSION >= (6, 5):
+                archs.append('gfx95')
+            if ROCM_VERSION >= (7, 14):
+                archs.append('gfx1250')
+            for arch in archs:
+                if arch in torch.cuda.get_device_properties(0).gcnArchName:
+                    return True
+            return False
+        else:
+            return SM90OrLater or torch.cuda.get_device_capability() == (8, 9)
+    if torch.xpu.is_available():
+        return True
+    # As CPU supports FP8 and is always available, return True.
+    return True
+
+
+def evaluate_platform_supports_bf16():
+    if torch.version.cuda:
+        return SM80OrLater
+    elif torch.version.hip:
+        return True
+    elif TEST_XPU:
+        return True
+    return False
+
+
+def evaluate_platform_supports_bf16_atomics():
+    if torch.version.cuda:
+        return SM80OrLater
+    elif torch.version.hip:
+        return ROCM_VERSION >= (8, 0)
+    return False
+
+
+def evaluate_platform_supports_half_atomics():
+    if torch.version.hip:
+        return ROCM_VERSION >= (8, 0)
+    return True
+
+
+PLATFORM_SUPPORTS_FP8: bool = LazyVal(lambda: evaluate_platform_supports_fp8())
+PLATFORM_SUPPORTS_BF16: bool = LazyVal(lambda: evaluate_platform_supports_bf16())
+PLATFORM_SUPPORTS_BF16_ATOMICS: bool = LazyVal(
+    lambda: evaluate_platform_supports_bf16_atomics()
+)
+PLATFORM_SUPPORTS_HALF_ATOMICS: bool = LazyVal(
+    lambda: evaluate_platform_supports_half_atomics()
+)
+
+
+def evaluate_platform_supports_fp8_grouped_gemm():
+    if torch.cuda.is_available():
+        if torch.version.hip:
+            if "USE_MSLK" not in torch.__config__.show():
+                return False
+            # gfx1250 omitted: MSLK only builds gfx942/gfx950 kernels (see the arch
+            # filter in aten/src/ATen/CMakeLists.txt). Add gfx1250 here once MSLK does.
+            archs = ['gfx942', 'gfx950']
+            for arch in archs:
+                if arch in torch.cuda.get_device_properties(0).gcnArchName:
+                    return True
+        else:
+            return SM90OrLater and not SM100OrLater
+    return False
+
+
+def evaluate_platform_supports_mx_gemm():
+    if torch.cuda.is_available():
+        if torch.version.hip:
+            if ROCM_VERSION >= (7, 0):
+                gcn_name = torch.cuda.get_device_properties(0).gcnArchName
+                return 'gfx950' in gcn_name or ('gfx1250' in gcn_name and ROCM_VERSION >= (7, 14))
+        else:
+            return SM100OrLater
+    if torch.xpu.is_available():
+        return True
+    return False
+
+
+def evaluate_platform_supports_mxfp8_grouped_gemm():
+    if torch.cuda.is_available() and not torch.version.hip:
+        built_with_mslk = "USE_MSLK" in torch.__config__.show()
+        return built_with_mslk and IS_SM100
+    return False
+
+
+def evaluate_platform_supports_fp8_sparse():
+    if torch.cuda.is_available():
+        if torch.version.hip:
+            return 'gfx950' in torch.cuda.get_device_properties(0).gcnArchName
+        else:
+            return (
+                (SM90OrLater or torch.cuda.get_device_capability() == (8, 9))
+                and torch.backends.cusparselt.is_available()
+                and torch.backends.cusparselt.version() >= 602
+            )
+    return False
+
+PLATFORM_SUPPORTS_MX_GEMM: bool = LazyVal(lambda: evaluate_platform_supports_mx_gemm())
+PLATFORM_SUPPORTS_FP8_GROUPED_GEMM: bool = LazyVal(lambda: evaluate_platform_supports_fp8_grouped_gemm())
+PLATFORM_SUPPORTS_MXFP8_GROUPED_GEMM: bool = LazyVal(lambda: evaluate_platform_supports_mxfp8_grouped_gemm())
+PLATFORM_SUPPORTS_FP8_SPARSE: bool = LazyVal(lambda: evaluate_platform_supports_fp8_sparse())


### PR DESCRIPTION
This pull request refactors where platform capability constants (such as `PLATFORM_SUPPORTS_FP8` and `PLATFORM_SUPPORTS_FLASH_ATTENTION`). The main change is moving the evaluation logic and constant definitions from `common_cuda.py` to a new file, `common_gpu.py`, and updating all test files to import these constants from the new location. This improves code organization by separating CUDA-specific logic from general GPU capability checks.

Key changes include:

**Refactoring and Code Organization:**

* Moved all platform support evaluation logic and constants (e.g., `PLATFORM_SUPPORTS_FP8`, `PLATFORM_SUPPORTS_FLASH_ATTENTION`, `PLATFORM_SUPPORTS_BF16`, etc.) from `torch/testing/_internal/common_cuda.py` to a new file, `torch/testing/_internal/common_gpu.py`.

* Updated all test files to import platform support constants from `common_gpu.py` instead of `common_cuda.py`.

This change improves maintainability by clearly separating GPU capability checks from CUDA-specific logic, making it easier to manage and extend platform support in the future for device agnostic capabilities.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Lucaskabela @azahed98