### PR TITLE
Speedup `F.interpolate` on NEON path for bilinear and bicubic modes

### DIFF
--- a/aten/src/ATen/native/cpu/UpSampleKernelNEONAntialias.h
+++ b/aten/src/ATen/native/cpu/UpSampleKernelNEONAntialias.h
@@ -111,6 +111,20 @@ void NeonResampleHorizontal(const at::Tensor& unpacked_output,
         acc_b = vmlal_s16(acc_b, vget_high_s16(b16), vget_high_s16(weights));
       }
 
+      // Block 4: handle 4 pixels that didn't fit in a block of 8
+      for (; i + 4 <= ids_size; i += 4) {
+        uint8x8x3_t rgb = vld3_u8(lineIn_min + num_channels * i);
+        int16x4_t weights4 = vld1_s16(&k[i]);
+
+        int16x4_t r16 = vget_low_s16(vreinterpretq_s16_u16(vmovl_u8(rgb.val[0])));
+        int16x4_t g16 = vget_low_s16(vreinterpretq_s16_u16(vmovl_u8(rgb.val[1])));
+        int16x4_t b16 = vget_low_s16(vreinterpretq_s16_u16(vmovl_u8(rgb.val[2])));
+
+        acc_r = vmlal_s16(acc_r, r16, weights4);
+        acc_g = vmlal_s16(acc_g, g16, weights4);
+        acc_b = vmlal_s16(acc_b, b16, weights4);
+      }
+
       // Horizontal reduction + rounding bias
       int32_t sum_r = vaddvq_s32(acc_r) + initial_val;
       int32_t sum_g = vaddvq_s32(acc_g) + initial_val;


### PR DESCRIPTION
This PR adds a "block of 4" path to the NEON implementation of `F.interpolate`, in-between the existing "block of 8" and "scalar cleanup" paths (see both parts surrounding the changes in the diff).

This accelerates configurations where the horizontal kernel size (`ids_size`) falls in the range [4, 8), which was previously handled entirely by scalar code. For bilinear this mainly benefits x0.5 downscaling (~1.35x speedup), while for bicubic it benefits a wider range including upscaling (~1.2-1.3x), since bicubic's larger base kernel means `ids_size` lands in that range more often.

### Benchmarks

**TL;DR** Improves speed by ~20%- 30% depending on configuration.

```
  Bilinear speedups (main / PR):

  ┌───────┬───────┬──────┬───────┬──────┬──────┬──────┐
  │       │ x0.25 │ x0.5 │ x0.75 │ x1.5 │ x2.0 │ x4.0 │
  ├───────┼───────┼──────┼───────┼──────┼──────┼──────┤
  │ 320p  │ 1.05  │ 1.36 │ 0.97  │ 1.01 │ 1.00 │ 1.00 │
  ├───────┼───────┼──────┼───────┼──────┼──────┼──────┤
  │ 720p  │ 1.05  │ 1.36 │ 0.96  │ 1.00 │ 1.00 │ 1.00 │
  ├───────┼───────┼──────┼───────┼──────┼──────┼──────┤
  │ 1080p │ 1.05  │ 1.36 │ 0.96  │ 1.00 │ 1.00 │ 1.00 │
  ├───────┼───────┼──────┼───────┼──────┼──────┼──────┤
  │ 4K    │ 1.04  │ 1.34 │ 0.96  │ 1.00 │ 1.00 │ 1.02 │
  └───────┴───────┴──────┴───────┴──────┴──────┴──────┘
```

```
  Bicubic speedups (main / PR):

  ┌───────┬───────┬──────┬───────┬──────┬──────┬──────┐
  │       │ x0.25 │ x0.5 │ x0.75 │ x1.5 │ x2.0 │ x4.0 │
  ├───────┼───────┼──────┼───────┼──────┼──────┼──────┤
  │ 320p  │ 1.00  │ 1.02 │ 1.23  │ 1.33 │ 1.22 │ 1.14 │
  ├───────┼───────┼──────┼───────┼──────┼──────┼──────┤
  │ 720p  │ 0.96  │ 0.99 │ 1.22  │ 1.28 │ 1.22 │ 1.14 │
  ├───────┼───────┼──────┼───────┼──────┼──────┼──────┤
  │ 1080p │ 0.96  │ 1.00 │ 1.24  │ 1.25 │ 1.21 │ 1.15 │
  ├───────┼───────┼──────┼───────┼──────┼──────┼──────┤
  │ 4K    │ 0.96  │ 1.00 │ 1.22  │ 1.28 │ 1.24 │ 1.16 │
  └───────┴───────┴──────┴───────┴──────┴──────┴──────┘
```

Note that this will also speedup the lanczos mode, provided https://github.com/pytorch/pytorch/pull/177320 gets merged.



<details>

```py
import torch
from time import perf_counter_ns
import torch.nn.functional as F


def bench(f, num_exp=15, warmup=3):
    for _ in range(warmup):
        f()
    times = []
    for _ in range(num_exp):
        t0 = perf_counter_ns()
        f()
        times.append(perf_counter_ns() - t0)
    return torch.tensor(times).float().median().item() * 1e-6  # ms


torch.set_num_threads(1)

resolutions = [
    ("64x64", (1, 3, 64, 64)),
    ("320p", (1, 3, 320, 480)),
    ("720p", (1, 3, 720, 1280)),
    ("1080p", (1, 3, 1080, 1920)),
    ("4K", (1, 3, 2160, 3840)),
]
scale_factors = [0.25, 0.5, 0.75, 1.5, 2.0, 4.0]
modes = ["bilinear", "bicubic"]

CL = torch.channels_last
col = 10
header = f"{'':>6}" + "".join(f"{'x' + str(sf):>{col}}" for sf in scale_factors)

for mode in modes:
    results = {}
    for name, shape in resolutions:
        x = torch.randint(0, 256, shape, dtype=torch.uint8).contiguous(memory_format=CL)
        for sf in scale_factors:
            oh = max(1, int(shape[2] * sf))
            ow = max(1, int(shape[3] * sf))
            size = (oh, ow)
            t = bench(lambda: F.interpolate(x, size=size, mode=mode, antialias=True))
            results[(name, sf)] = t
            print(f"{mode} aa | {name} x{sf}: {t:.2f}ms", flush=True)

    print(f"\n{mode} aa=True, channels_last NEON path (ms)")
    print(header)
    print("-" * len(header))
    for name, _ in resolutions:
        row = f"{name:>6}"
        for sf in scale_factors:
            row += f"{results[(name, sf)]:>{col}.2f}"
        print(row)
    print()
```


```
PR
bilinear aa=True, channels_last NEON path (ms)
           x0.25      x0.5     x0.75      x1.5      x2.0      x4.0
------------------------------------------------------------------
 64x64      0.01      0.02      0.03      0.05      0.07      0.17
  320p      0.20      0.36      0.66      1.40      2.06      5.59
  720p      1.12      2.06      3.85      8.24     12.33     33.91
 1080p      2.50      4.61      8.60     18.89     27.23     75.44
    4K      9.94     18.99     34.32     74.18    109.24    299.49
main
bilinear aa=True, channels_last NEON path (ms)
           x0.25      x0.5     x0.75      x1.5      x2.0      x4.0
------------------------------------------------------------------
 64x64      0.01      0.02      0.03      0.05      0.06      0.16
  320p      0.21      0.49      0.64      1.41      2.07      5.60
  720p      1.18      2.81      3.70      8.25     12.37     33.97
 1080p      2.62      6.28      8.25     18.81     27.22     75.15
    4K     10.36     25.49     32.94     74.16    109.21    305.38


PR
bicubic aa=True, channels_last NEON path (ms)
           x0.25      x0.5     x0.75      x1.5      x2.0      x4.0
------------------------------------------------------------------
 64x64      0.02      0.02      0.03      0.05      0.07      0.20
  320p      0.31      0.45      0.79      1.50      2.29      6.95
  720p      1.72      2.61      4.56      8.79     13.84     42.39
 1080p      3.81      5.83     10.24     20.38     31.25     93.74
    4K     15.44     23.76     40.86     79.09    121.86    373.10
main
bicubic aa=True, channels_last NEON path (ms)
           x0.25      x0.5     x0.75      x1.5      x2.0      x4.0
------------------------------------------------------------------
 64x64      0.02      0.02      0.04      0.06      0.09      0.23
  320p      0.31      0.46      0.97      1.99      2.80      7.95
  720p      1.65      2.59      5.57     11.24     16.85     48.48
 1080p      3.67      5.81     12.68     25.42     37.96    108.23
    4K     14.87     23.64     50.00    100.93    151.66    432.15



</detail>

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01