### PR TITLE
Accelerate SDPA: Implement fast exp in SVE vectorizer

### DIFF
--- a/aten/src/ATen/cpu/vec/sve/vec_float.h
+++ b/aten/src/ATen/cpu/vec/sve/vec_float.h
@@ -285,8 +285,56 @@ class Vectorized<float> {
     svfloat32_t poly = svmla_x(svptrue_b32(), r, r2, c1);
     return svmla_x(svptrue_b32(), scale, scale, poly);
   }
+  // Implementation from Arm Optimized Routines:
+  // https://github.com/ARM-software/optimized-routines/blob/v26.01/math/aarch64/experimental/sve/sv_expf_inline.h
   Vectorized<float> fexp_u20() const {
-    return exp_u20();
+    // fast exponential intended for cases where outputs will be downcasted to
+    // FP16 / BF16 (e.g. attention softmax).
+    // Accurate within 1 ULP for FP16
+    // Accurate within 1 ULP for BF16 for inputs in [-87.346, max_float] &
+    // clamps
+    //  inputs < -87.346 to zero.
+    // Implementation is similar to exp_u20, but:
+    // - approximates exp(r) - 1 as r instead of r + 0.5 r^2
+    // - does not split natural log (ln) into high / low parts
+    // - avoids special case code by clamping exp(x) to 0 for x < -87.346 and
+    // inf for x > 88.717
+
+    constexpr float upper_bound = 0x1.62dea4p+6f;
+    constexpr float lower_bound = -0x1.5d619ap+6f;
+
+    const svfloat32_t ln2 = svdup_n_f32(0x1.62e43p-1f);
+    const svfloat32_t inv_ln2 = svdup_n_f32(0x1.715476p+0f);
+
+    constexpr float shift = 0x1.803f8p17f;
+
+    // exp(x) = 2^n (1 + poly(r)), with 1 + poly(r) in [1/sqrt(2),sqrt(2)]
+    // x = ln2*n + r, with r in [-ln2/2, ln2/2] and poly(r) ~= r.
+
+    // n = round(x/(ln2/N))
+    svfloat32_t z = svmad_x(svptrue_b32(), inv_ln2, values, shift);
+    svfloat32_t n = svsub_x(svptrue_b32(), z, shift);
+
+    // n = round(x/(ln2/N))
+    svfloat32_t r = svmls_x(svptrue_b32(), values, n, ln2);
+
+    // scale = 2^(n/N)
+    svfloat32_t scale = svexpa(svreinterpret_u32(z));
+
+    // poly(r) = exp(r) - 1 ~= r
+    svfloat32_t y = svmla_x(svptrue_b32(), scale, scale, r);
+
+    // clamp to 0, inf
+    y = svsel_f32(
+        svcmplt_f32(svptrue_b32(), values, svdup_n_f32(lower_bound)),
+        svdup_n_f32(0.0f),
+        y);
+    y = svsel_f32(
+        svcmpgt_f32(svptrue_b32(), values, svdup_n_f32(upper_bound)),
+        svdup_n_f32(INFINITY),
+        y);
+
+    return y;
   }
   Vectorized<float> fmod(const Vectorized<float>& q) const {
     USE_SLEEF(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #177645

Similar to #176881 and #151441 this PR adds an SVE fast exponential implementation, intended for cases where outputs will be downcasted to FP16 / BF16 (e.g. attention softmax).

Implementation is similar to exp_u20, but:
  - approximates exp(r) - 1 as r instead of r + 0.5 r^2
  - does not split natural log (ln) into high / low parts
  - avoids special case code by clamping exp(x) to 0 for x < -87.346 and inf for x > 88.717


## Accuracy

Tested in a similar fashion to #17688 by iterating over all possible FP32 bit patterns and calculates ULP between:
- `fexp_u20` with inputs in FP32, outputs converted to BF16/FP16
- `std::exp` with inputs in FP32, outputs converted to BF16/FP16  

From the accuracy study above, this exp is:
- Accurate within a maximum of 1 ULP for FP16
- Accurate within a maximum of 1 ULP for BF16 for inputs in [-87.346, max_float] & clamps inputs < -87.346 to zero.

## Performance

Using [this SDPA benchmark](https://gist.github.com/fadara01/5357a52299a3722587f6691d145e71e9), here are the scaled-dot-production-attention speedups achieved with 16 Neoverse-V1 cores (with SVE256):

| B | Hq | Hkv | Lq | Lk | D | causal | gqa | Speedup vs current |
|---:|---:|---:|---:|---:|---:|---|---|---:|
| 1 | 32 | 8 | 2048 | 2048 | 128 | True | True | +7.20% |
| 1 | 32 | 8 | 1 | 2048 | 128 | False | True | +0.38% (noise) |
| 1 | 16 | 16 | 6400 | 6400 | 80 | False | False | +4.32% |
| 1 | 20 | 20 | 1500 | 1500 | 64 | False | False | +3.38% |
| 8 | 20 | 20 | 1500 | 1500 | 64 | False | False | +6.35% |


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01