### PR TITLE
Add GEMM configs to XPU autotuning heuristic

### DIFF
--- a/torch/_inductor/template_heuristics/triton.py
+++ b/torch/_inductor/template_heuristics/triton.py
@@ -1802,6 +1802,10 @@ class XPUConfigHeuristic(BaseConfigHeuristic):
 
     def __init__(self) -> None:
         super().__init__()
+        self.mm_configs = self.mm_configs + [
+            GemmConfig(32, 64, 128, 2, 2),
+            GemmConfig(64, 64, 32, 2, 8),
+        ]
         self.xpu_default_flex_config = {
             (torch.float32, 64): FlexConfig(128, 32, 1, 16),
             (torch.float32, 128): FlexConfig(128, 32, 1, 16),


### PR DESCRIPTION
Add two XPU-specific mm configs to improve autotuning for tall-skinny GEMM shapes (e.g. M=10000, N=64, K=64, fp16).

Benchmarked on BMG. The new configs cover BLOCK_N=64 which matches the N dimension exactly, reducing workgroup count and improving GPU occupancy.

Fixes: https://github.com/intel/intel-xpu-backend-for-triton/issues/6012


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo