### PR TITLE
[Claude] Update labels and skill rubric for pt2

### DIFF
--- a/.claude/skills/triaging-issues/labels.json
+++ b/.claude/skills/triaging-issues/labels.json
@@ -105,7 +105,7 @@
     },
     {
       "name": "module: aotdispatch",
-      "description": "umbrella label for AOTAutograd issues"
+      "description": "Issues in the AOTAutograd subsystem (torch/_functorch/aot_autograd.py, torch/_functorch/_aot_autograd/). Covers tracing of the forward+backward graph, partitioning, runtime wrappers, and autograd cache serialization. If a traceback includes _aot_autograd/runtime_wrappers.py or _aot_autograd/functional_utils.py, this label applies. Prefer this over 'module: inductor' when the crash is in the autograd dispatch layer, not in code generation."
     },
     {
       "name": "module: aotinductor",
@@ -117,7 +117,7 @@
     },
     {
       "name": "module: autograd",
-      "description": "Related to torch.autograd, and the autograd engine in general"
+      "description": "Issues in the eager-mode autograd engine (torch/autograd/, torch/csrc/autograd/). Covers gradient computation, autograd functions, hooks, and the backward pass in eager mode. Do NOT apply when the issue is about torch.compile silently dropping or mishandling an autograd operation — if the bug only reproduces under torch.compile (not in eager), the root cause is likely in Dynamo tracing ('module: dynamo') or AOTAutograd ('module: aotdispatch'), not in the eager autograd engine."
     },
     {
       "name": "module: backend",
@@ -177,7 +177,7 @@
     },
     {
       "name": "module: compiled autograd",
-      "description": "compiled_autograd"
+      "description": "Issues in the compiled autograd subsystem (torch/csrc/autograd/compiled_autograd.*, torch/_dynamo/compiled_autograd.py). This is the system that compiles the autograd backward graph with Dynamo+Inductor. Do NOT apply just because 'autograd' appears in the issue — use 'module: aotdispatch' for AOTAutograd tracing/partitioning issues, and 'module: autograd' for eager autograd issues."
     },
     {
       "name": "module: complex",
@@ -269,7 +269,7 @@
     },
     {
       "name": "module: decompositions",
-      "description": "Topics related to decomposition (excluding PrimTorch)"
+      "description": "Issues with operator decompositions (torch/_decomp/). Decompositions rewrite higher-level ops into lower-level ones for tracing/compilation. Apply when traced/compiled results diverge from eager due to a decomposition producing wrong gradients, numerically incorrect results, or missing higher-order derivative support. Key signal: 'eager vs traced results diverge' + a specific op (e.g., sqrt, layer_norm) suggests a bad decomposition."
     },
     {
       "name": "module: dependency bug",
@@ -345,7 +345,7 @@
     },
     {
       "name": "module: dynamo",
-      "description": "Related to TorchDynamo (torch.compile frontend/tracing)"
+      "description": "Issues in TorchDynamo, the torch.compile frontend/tracing system (torch/_dynamo/). Covers graph capture, graph breaks, symbolic tracing of Python bytecode, and variable tracking. Key signal: if torch.compile silently drops, ignores, or mishandles an operation that works correctly in eager mode (e.g., in-place mutations like detach_() being silently skipped, side-effects not captured), the root cause is almost always Dynamo's tracing."
     },
     {
       "name": "module: edge cases",
@@ -365,7 +365,7 @@
     },
     {
       "name": "module: error checking",
-      "description": "Bugs related to incorrect/lacking error checking"
+      "description": "Bugs where PyTorch fails to validate inputs or raises a wrong/missing error message at a validation boundary (e.g., shape checks, dtype checks, device checks). Do NOT apply just because the user complains about a bad error message — if the root cause is a bug in a specific feature, use the feature-specific label instead."
     },
     {
       "name": "module: expecttest",
@@ -417,7 +417,7 @@
     },
     {
       "name": "module: fx",
-      "description": ""
+      "description": "Issues in torch.fx (torch/fx/) — the graph IR, symbolic tracing, graph transforms, and make_fx. Note: make_fx with symbolic tracing is PT2 infrastructure, so issues involving make_fx should also get 'oncall: pt2'."
     },
     {
       "name": "module: fx.passes",
@@ -453,7 +453,7 @@
     },
     {
       "name": "module: inductor",
-      "description": "Related to TorchInductor (torch.compile codegen backend)"
+      "description": "Issues in the TorchInductor code generation backend (torch/_inductor/). Covers kernel codegen, scheduling, fusion, and inductor-specific caching (TORCHINDUCTOR_* env vars). Do NOT apply just because the user mentions 'inductor cache' or 'torch.compile' — if the traceback points to _aot_autograd/ or _functorch/, use 'module: aotdispatch' instead."
     },
     {
       "name": "module: infallible views",
@@ -769,7 +769,7 @@
     },
     {
       "name": "module: pt2-dispatcher",
-      "description": "PT2  dispatcher-related issues (e.g., aotdispatch, functionalization, faketensor, custom-op,"
+      "description": "Umbrella label for PT2 dispatcher-layer issues: aotdispatch, functionalization, FakeTensor, custom-op registration, proxy tensor tracing. Apply alongside the more specific label (e.g., 'module: aotdispatch') when the issue touches the dispatcher layer. If unsure whether a PT2 issue is inductor vs dispatcher, check the traceback: _functorch/ and _aot_autograd/ paths mean dispatcher, _inductor/ paths mean inductor."
     },
     {
       "name": "module: pybind",
@@ -789,7 +789,7 @@
     },
     {
       "name": "module: python version",
-      "description": "Issues related to specific Python versions"
+      "description": "Issues where behavior differs across Python versions or where a specific Python version causes breakage (e.g., 'works on 3.11 but fails on 3.12'). Do NOT apply just because the reporter mentions a Python version in their environment info, test path, or conformance test name — the bug must be specifically about Python version compatibility."
     },
     {
       "name": "module: pytree",

--- a/.claude/skills/triaging-issues/pt2-triage-rubric.md
+++ b/.claude/skills/triaging-issues/pt2-triage-rubric.md
@@ -33,6 +33,29 @@ When component isn't clear from the issue body:
 
 **This is critical** when you have identified an issue as inductor, and the failing device is "cpu" ONLY, then this is a CPU inductor issue, and should be redirected to `oncall: cpu inductor`
 
+### Silently Dropped Operations = Dynamo
+
+If torch.compile silently drops or ignores an operation that works in eager, the bug is in Dynamo's tracing.
+
+| Signal | Label |
+|--------|-------|
+| In-place mutation skipped under compile (`detach_()`, `requires_grad_()`) | `module: dynamo` |
+| Side-effect not captured (global state, tensor metadata) | `module: dynamo` |
+
+Don't apply `module: autograd` just because the dropped operation involves autograd. If eager works fine, the autograd engine is fine.
+
+### Decomposition Bugs
+
+If eager and traced results diverge numerically for a specific op, suspect a bad decomposition.
+
+| Signal | Label |
+|--------|-------|
+| Eager vs traced diverge for a specific op | `module: decompositions` |
+| Higher-order gradients wrong under tracing | `module: decompositions` |
+| `make_fx` symbolic tracing diverges from eager | `module: fx` + `module: decompositions` + `oncall: pt2` |
+
+---
+
 ## 3. Don't Over-Tag pt2-dispatcher
 
 `module: pt2-dispatcher` is for bugs **IN** the dispatcher code, not just when it appears in a stack trace.


### PR DESCRIPTION
### summary

Using scripts in ciforge in the following loop to update skills:

```bash
python scripts/fetch_mislabeled_issues.py --oncall pt2
```
pulled https://github.com/pytorch/pytorch/issues?q=sort%3Aupdated-desc%20state%3Aopen%20label%3Abot-mislabeled%20label%3A%22oncall%3A%20pt2%22

Then loop like
```bash
python .claude/skills/debug-mislabeled-issues/scripts/collect_issue_debug_context.py 177633 
```
And finally after testing/validating and iterating
```bash
pyton scripts/sync_triage_skill.py to-pytorch
```

### Test
See https://github.com/pytorch/ciforge/issues/202 for mirrored and correct 