### PR TITLE
[ROCm][CI] fix batch_norm decomp for negative running_var

### DIFF
--- a/test/test_jit_fuser_te.py
+++ b/test/test_jit_fuser_te.py
@@ -61,7 +61,6 @@ from torch.testing._internal.common_utils import (
     skipIfTorchDynamo,
     slowTest,
     TEST_WITH_ASAN,
-    TEST_WITH_ROCM,
 )
 from torch.testing._internal.jit_metaprogramming_utils import create_traced_fn
 from torch.testing._internal.jit_utils import (
@@ -2406,32 +2405,34 @@ class TestTEFuser(JitTestCase):
 
     @skipIfTorchDynamo("too slow")
     @unittest.skipIf(TEST_WITH_ASAN, "takes 10+ minutes on asan")
-    @unittest.skipIf(TEST_WITH_ROCM, "Tensor-likes are not close for nans")
     def test_batch_norm(self):
         def test(fn, args):
             trace = torch.jit.trace(fn, args)
             self.assertAllFused(trace.graph_for(*args))
-            # TODO: Are `NaN`'s actually ok here or did this pass silently before, because `equal_nan=True` was the
-            #  default?
             torch.testing.assert_close(fn(*args), trace(*args), equal_nan=True)
 
-        def bn(i, x):
-            return torch.batch_norm(i, x, x, x, x, False, 0.1, 1e-4, False).relu()
+        def bn(i, x, rv):
+            return torch.batch_norm(i, x, x, x, rv, False, 0.1, 1e-4, False).relu()
 
-        def bn_no_weight(i, x):
-            return torch.batch_norm(i, None, x, x, x, False, 0.1, 1e-4, False).relu()
+        def bn_no_weight(i, x, rv):
+            return torch.batch_norm(i, None, x, x, rv, False, 0.1, 1e-4, False).relu()
 
-        def bn_no_bias(i, x):
-            return torch.batch_norm(i, x, None, x, x, False, 0.1, 1e-4, False).relu()
+        def bn_no_bias(i, x, rv):
+            return torch.batch_norm(i, x, None, x, rv, False, 0.1, 1e-4, False).relu()
 
-        def bn_neither(i, x):
-            return torch.batch_norm(i, None, None, x, x, False, 0.1, 1e-4, False).relu()
+        def bn_neither(i, x, rv):
+            return torch.batch_norm(
+                i, None, None, x, rv, False, 0.1, 1e-4, False
+            ).relu()
 
         for device in self.devices:
             i = torch.randn(4, 16, 32, 40, device=device)
             x = torch.randn(16, device=device)
+            rv = torch.randn(
+                16, device=device
+            ).abs()  # running_var must be non-negative
             for fn in [bn, bn_no_weight, bn_no_bias, bn_neither]:
-                test(fn, (i, x))
+                test(fn, (i, x, rv))
 
     def test_profiler(self):
         @torch.jit.script


### PR DESCRIPTION
Fixes #168755

All tests performed on an MI300X machine with ROCm version 7.2.26015. 

### Before fix: 
```
$ PYTHONWARNINGS="ignore" PYTORCH_PRINT_REPRO_ON_FAILURE=0 PYTORCH_TEST_WITH_ROCM=1 python test/test_jit_fuser_te.py TestTEFuserStatic.test_batch_norm
monkeytype is not installed. Skipping tests for Profile-Directed Typing
F
======================================================================
FAIL: test_batch_norm (__main__.TestTEFuserStatic.test_batch_norm)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/conda/envs/py_3.12/lib/python3.12/site-packages/torch/testing/_internal/common_utils.py", line 1766, in wrapper
    fn(*args, **kwargs)
  File "/var/lib/jenkins/pytorch/test/test_jit_fuser_te.py", line 2434, in test_batch_norm
    test(fn, (i, x))
  File "/var/lib/jenkins/pytorch/test/test_jit_fuser_te.py", line 2416, in test
    torch.testing.assert_close(fn(*args), trace(*args), equal_nan=True)
  File "/opt/conda/envs/py_3.12/lib/python3.12/site-packages/torch/testing/_comparison.py", line 1600, in assert_close
    raise error_metas[0].to_error(msg)
AssertionError: Tensor-likes are not close!

Mismatched elements: 25600 / 81920 (31.2%)
Greatest absolute difference: nan at index (0, 2, 0, 0) (up to 1e-05 allowed)
Greatest relative difference: nan at index (0, 2, 0, 0) (up to 1.3e-06 allowed)

----------------------------------------------------------------------
Ran 1 test in 13.574s

FAILED (failures=1)
```

### Experiments:

<html xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:dt="uuid:C2F41010-65B3-11d1-A29F-00AA00C14882"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=OneNote.File>
<meta name=Generator content="Microsoft OneNote 15">
</head>

<body lang=en-US style='font-family:Calibri;font-size:11.0pt'>
<!--StartFragment-->

<div style='direction:ltr'>


Test | NaN in Eager mode | NaN in JIT trace   mode | Mismatches   between eager and JIT trace
-- | -- | -- | --
Bn | False | False | 0
ReLU | False | False | 0
Bn + ReLU | False | True | 35,840



</div>

<!--EndFragment-->
</body>

</html>

<html xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:dt="uuid:C2F41010-65B3-11d1-A29F-00AA00C14882"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=OneNote.File>
<meta name=Generator content="Microsoft OneNote 15">
</head>

<body lang=en-US style='font-family:Calibri;font-size:11.0pt'>
<!--StartFragment-->

<div style='direction:ltr'>


Test | NaN in JIT trace   mode
-- | --
Bn + ReLU   (compiler fusion disabled) | False
Bn + ReLU   (compiler fusion enabled) | True



</div>

<!--EndFragment-->
</body>

</html>

<html xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:dt="uuid:C2F41010-65B3-11d1-A29F-00AA00C14882"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=OneNote.File>
<meta name=Generator content="Microsoft OneNote 15">
</head>

<body lang=en-US style='font-family:Calibri;font-size:11.0pt'>
<!--StartFragment-->

<div style='direction:ltr'>


Test | NaN
-- | --
Bn (with negative   running_var) + ReLU (compiler fusion enabled) | True
Bn (with positive   running_var) + ReLU (compiler fusion enabled) | False



</div>

<!--EndFragment-->
</body>

</html>

Root cause: for this test, running_var is initialized via torch.randn, causing there to be negative values. In Torch Jit trace mode, for Bn + ReLU fusion, incorrect handling of these negative values in running_var leads to sqrt of negative numbers, which results in imaginary numbers or NaNs. 

### The fix: 
-- modify batch_norm decomposition to handle erroneous negative running_var
-- modify the test so running_var is non-negative (negative variance is mathematically invalid)

### After fix:

```
$ PYTHONWARNINGS="ignore" PYTORCH_PRINT_REPRO_ON_FAILURE=0 PYTORCH_TEST_WITH_ROCM=1 python test/test_jit_fuser_te.py TestTEFuserStatic.test_batch_norm
monkeytype is not installed. Skipping tests for Profile-Directed Typing
.
----------------------------------------------------------------------
Ran 1 test in 14.185s

OK
```




cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @EikanWang @jgong5