### PR TITLE
[CI] Disable HF offline mode for nightly scheduled benchmark runs

### DIFF
--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -350,11 +350,12 @@ jobs:
           VLLM_TEST_HUGGING_FACE_TOKEN: ${{ secrets.VLLM_TEST_HUGGING_FACE_TOKEN }}
           HF_CACHE: /mnt/hf_cache
           # Use offline mode by default, only enable online mode to refresh the models
-          # from HF when the PR has a special ci-refresh-hf-cache label. This label is
+          # from HF when the PR has a special ci-refresh-hf-cache label or when the job
+          # is a nightly scheduled run on main. The ci-refresh-hf-cache label is
           # automatically added to the vLLM pinned commit hash update, which effectively
           # refreshes the cache daily
-          TRANSFORMERS_OFFLINE: ${{ contains(steps.keep-going.outputs.labels, 'ci-refresh-hf-cache') && '0' || '1' }}
-          HF_DATASETS_OFFLINE: ${{ contains(steps.keep-going.outputs.labels, 'ci-refresh-hf-cache') && '0' || '1' }}
+          TRANSFORMERS_OFFLINE: ${{ (github.event_name == 'schedule' || contains(steps.keep-going.outputs.labels, 'ci-refresh-hf-cache')) && '0' || '1' }}
+          HF_DATASETS_OFFLINE: ${{ (github.event_name == 'schedule' || contains(steps.keep-going.outputs.labels, 'ci-refresh-hf-cache')) && '0' || '1' }}
           HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}
           SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.SCRIBE_GRAPHQL_ACCESS_TOKEN }}
           ARTIFACTS_FILE_SUFFIX: ${{ github.job }}-${{ matrix.config }}-${{ matrix.shard }}-${{ matrix.num_shards }}-${{ matrix.runner }}_${{ steps.get-job-id.outputs.job-id }}


### PR DESCRIPTION
Nightly scheduled runs on main should download from HF to refresh the local model cache, matching the pattern used by the vLLM benchmark. Previously only the `ci-refresh-hf-cache` PR label could disable offline mode.

@eellison notices this issue today when all HF benchmarks have been failing since Mar 10th. The trigger was an infra change on that date to recreate all H100 runners. The new runners don't have HF cache setup locally.

### Testing

https://github.com/pytorch/pytorch/actions/runs/23209274722