### PR TITLE
[ONNX] Fix torchvision roi_align export with 7-arg schema

### DIFF
--- a/test/onnx/exporter/test_small_models_e2e.py
+++ b/test/onnx/exporter/test_small_models_e2e.py
@@ -969,5 +969,57 @@ class DynamoExporterNewOpsetsTest(common_utils.TestCase, _WithExport):
         onnx_testing.assert_onnx_program(onnx_program, args=(x, y))
 
 
+try:
+    import torchvision  # noqa: F401
+
+    HAS_TORCHVISION = True
+except ImportError:
+    HAS_TORCHVISION = False
+
+
+@common_utils.instantiate_parametrized_tests
+class TorchVisionExporterTest(common_utils.TestCase, _WithExport):
+    @common_utils.skipIfNoDynamoSupport
+    @pytest.mark.skipif(not HAS_TORCHVISION, reason="torchvision not available")
+    def test_torchvision_roi_align(self):
+        """Regression test for https://github.com/pytorch/pytorch/issues/175732."""
+
+        class RoiAlignModel(torch.nn.Module):
+            def forward(self, input: torch.Tensor, rois: torch.Tensor) -> torch.Tensor:
+                return torchvision.ops.roi_align(
+                    input, rois, output_size=(5, 5), spatial_scale=1.0, sampling_ratio=2
+                )
+
+        model = RoiAlignModel()
+        input = torch.rand(1, 1, 10, 10, dtype=torch.float32)
+        rois = torch.tensor([[0, 0, 0, 4, 4]], dtype=torch.float32)
+
+        onnx_program = self.export(model, (input, rois))
+        onnx_testing.assert_onnx_program(onnx_program)
+
+    @common_utils.skipIfNoDynamoSupport
+    @pytest.mark.skipif(not HAS_TORCHVISION, reason="torchvision not available")
+    def test_torchvision_roi_align_aligned(self):
+        """Verify roi_align with aligned=True uses coordinate_transformation_mode=half_pixel."""
+
+        class RoiAlignAlignedModel(torch.nn.Module):
+            def forward(self, input: torch.Tensor, rois: torch.Tensor) -> torch.Tensor:
+                return torchvision.ops.roi_align(
+                    input,
+                    rois,
+                    output_size=(5, 5),
+                    spatial_scale=1.0,
+                    sampling_ratio=2,
+                    aligned=True,
+                )
+
+        model = RoiAlignAlignedModel()
+        input = torch.rand(1, 1, 10, 10, dtype=torch.float32)
+        rois = torch.tensor([[0, 1.5, 1.5, 3, 3]], dtype=torch.float32)
+
+        onnx_program = self.export(model, (input, rois))
+        onnx_testing.assert_onnx_program(onnx_program)
+
+
 if __name__ == "__main__":
     common_utils.run_tests()

--- a/torch/onnx/_internal/exporter/_torchlib/ops/__init__.py
+++ b/torch/onnx/_internal/exporter/_torchlib/ops/__init__.py
@@ -1,6 +1,13 @@
 from __future__ import annotations
 
 
-__all__ = ["core", "hop", "nn", "symbolic", "symops"]
+__all__ = ["core", "hop", "nn", "symbolic", "symops", "vision"]
 
-from torch.onnx._internal.exporter._torchlib.ops import core, hop, nn, symbolic, symops
+from torch.onnx._internal.exporter._torchlib.ops import (
+    core,
+    hop,
+    nn,
+    symbolic,
+    symops,
+    vision,
+)

--- a/torch/onnx/_internal/exporter/_torchlib/ops/vision.py
+++ b/torch/onnx/_internal/exporter/_torchlib/ops/vision.py
@@ -1,0 +1,72 @@
+"""torchvision operators for ONNX export."""
+
+# mypy: disable-error-code="misc,arg-type,type-arg,valid-type,assignment,return-value,type-var,operator,no-untyped-def,index"
+# pyrefly: ignore-errors
+# ruff: noqa: TCH001,TCH002
+
+from __future__ import annotations
+
+import importlib.util
+import logging
+
+from onnxscript.onnx_opset import opset18 as op
+
+import torch
+from torch.onnx._internal.exporter._torchlib._tensor_typing import INT64, TReal
+from torch.onnx._internal.exporter._torchlib._torchlib_registry import onnx_impl
+
+
+logger = logging.getLogger(__name__)
+
+
+if importlib.util.find_spec("torchvision") is not None:
+    try:
+        import torchvision  # noqa: F401 -- triggers torchvision op registration
+
+        @onnx_impl(torch.ops.torchvision.roi_align.default, trace_only=True)
+        def torchvision_roi_align(
+            input: TReal,
+            rois: TReal,
+            spatial_scale: float,
+            output_height: int,
+            output_width: int,
+            sampling_ratio: int,
+            aligned: bool,
+        ) -> TReal:
+            """torchvision::roi_align(Tensor input, Tensor rois, float spatial_scale, int output_height, int output_width, int sampling_ratio, bool aligned) -> Tensor"""
+
+            # The torchvision rois tensor has shape [num_rois, 5] where column 0
+            # is the batch index. ONNX RoiAlign expects batch_indices as a
+            # separate 1-D int64 input and rois as [num_rois, 4].
+            batch_indices = op.Cast(
+                op.Squeeze(
+                    op.Slice(rois, starts=[0], ends=[1], axes=[1]),
+                    axes=[1],
+                ),
+                to=INT64.dtype,
+            )
+            rois_coords = op.Slice(rois, starts=[1], ends=[5], axes=[1])
+
+            # torchvision aligned=True  -> ONNX "half_pixel"
+            # torchvision aligned=False -> ONNX "output_half_pixel"
+            coordinate_transformation_mode = (
+                "half_pixel" if aligned else "output_half_pixel"
+            )
+
+            # ONNX sampling_ratio=0 means adaptive; torchvision uses negative values
+            if sampling_ratio < 0:
+                sampling_ratio = 0
+
+            return op.RoiAlign(
+                input,
+                rois_coords,
+                batch_indices,
+                coordinate_transformation_mode=coordinate_transformation_mode,
+                spatial_scale=spatial_scale,
+                output_height=output_height,
+                output_width=output_width,
+                sampling_ratio=sampling_ratio,
+            )
+
+    except Exception:
+        logger.debug("Failed to register torchvision ONNX ops", exc_info=True)


### PR DESCRIPTION
## Summary
- Add `torchvision_roi_align` implementation to PyTorch's torchlib that handles the full 7-argument schema of `torch.ops.torchvision.roi_align.default`
- The new implementation takes priority over the outdated onnxscript function during ONNX export dispatch

## Motivation
`torch.ops.torchvision.roi_align.default` now passes 7 positional arguments `(input, rois, spatial_scale, output_height, output_width, sampling_ratio, aligned)`, but the existing onnxscript conversion function only accepts up to 6 — it uses a bundled `output_size: Sequence[int]` instead of separate `output_height`/`output_width`, and doesn't account for the `aligned` parameter at the correct position. This causes a `TypeError` during `torch.onnx.export` for any model using `torchvision.ops.roi_align`.

Fixes #175732

## Changes
- **New file `torch/onnx/_internal/exporter/_torchlib/ops/vision.py`**: Adds a `torchvision_roi_align` function registered via `@onnx_impl` that matches the exact op schema. The function:
  - Extracts `batch_indices` (column 0, cast to int64) and roi coordinates (columns 1–4) from the combined rois tensor
  - Maps `aligned=True` → `coordinate_transformation_mode="half_pixel"` and `aligned=False` → `"output_half_pixel"` for the ONNX `RoiAlign` op
  - Converts negative `sampling_ratio` to 0 (ONNX's convention for adaptive sampling)
  - Guards registration behind `importlib.util.find_spec("torchvision")` so it's safely skipped when torchvision isn't installed
- **Modified `ops/__init__.py`**: Imports the new `vision` module alongside existing torchlib ops
- **Test additions in `test_small_models_e2e.py`**: Two e2e tests covering both `aligned=False` (default) and `aligned=True` variants

## Test Plan
- [x] Added `test_torchvision_roi_align` — exports a model using `torchvision.ops.roi_align` and validates ONNX output matches PyTorch
- [x] Added `test_torchvision_roi_align_aligned` — same with `aligned=True`
- Both tests are skipped if torchvision is not installed
- `ruff check` and `ruff format --check` pass on all changed files

cc @justinchuby