### PR TITLE
Add torch.pdist to documentation (#49426)

### DIFF
--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -550,6 +550,7 @@ Other Operations
     bucketize
     cartesian_prod
     cdist
+    pdist
     clone
     combinations
     corrcoef


### PR DESCRIPTION
## Summary
Adds `torch.pdist` to the main torch module documentation. The function was mentioned in TorchScript Builtins but had no doc entry in `docs/source/torch.rst`.

## Changes
- Added `pdist` to the autosummary in `docs/source/torch.rst` alongside the related `cdist` function

Fixes #49426

Made with [Cursor](https://cursor.com)