### PR TITLE
Fix scalar-only add/sub alpha out refs in torch.compile

### DIFF
--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -4342,16 +4342,18 @@ class ReproTests(torch._dynamo.test_case.TestCase):
         self.assertTrue(same(fn(x), opt_fn(x)))
 
     def test_add_sub_alpha_out(self):
-        inp = torch.randn(2, 3, 4)
-        other = 1
-        alpha = 2
+        test_cases = (
+            (torch.randn(2, 3, 4), 1, 2, torch.zeros(2, 3, 4)),
+            (2, 1.1, 0.4, torch.tensor(0.0)),
+        )
         for op in [torch.add, torch.sub]:
-            out = torch.zeros(2, 3, 4)
-            compile_out = torch.zeros(2, 3, 4)
-            op(inp, other, alpha=alpha, out=out)
-            compiled_fn = torch.compile(op, dynamic=True, backend="eager")
-            compiled_fn(inp, other, alpha=alpha, out=compile_out)
-            self.assertTrue(same(out, compile_out))
+            for inp, other, alpha, out in test_cases:
+                compiled_fn = torch.compile(op, dynamic=True, backend="eager")
+                eager_out = out.clone()
+                compiled_out = out.clone()
+                op(inp, other, alpha=alpha, out=eager_out)
+                compiled_fn(inp, other, alpha=alpha, out=compiled_out)
+                self.assertTrue(same(eager_out, compiled_out))
 
     def test_negative_shape_guard(self):
         def fn(x):

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -1183,6 +1183,15 @@ def _make_elementwise_binary_reference(
 
     return inner
 
+def _binary_op_dtype(
+    a: TensorLikeType | NumberType, b: TensorLikeType | NumberType
+) -> torch.dtype:
+    if isinstance(a, TensorLike):
+        return a.dtype
+    if isinstance(b, TensorLike):
+        return b.dtype
+    return utils.type_to_dtype(type(a))
+
 
 # Add has its own implementation because it has an alpha argument
 @register_decomposition(aten.add)
@@ -1204,7 +1213,7 @@ def add(
     a, b = _maybe_broadcast(a, b)
 
     if alpha is not None:
-        dtype = a.dtype if isinstance(a, TensorLike) else b.dtype  # type: ignore[union-attr]
+        dtype = _binary_op_dtype(a, b)
         python_type = utils.dtype_to_type(dtype)
         if python_type is not bool and not utils.is_weakly_lesser_type(
             type(alpha), python_type
@@ -1854,7 +1863,7 @@ def sub(
         )
 
     if alpha != 1:
-        dtype = a.dtype if isinstance(a, TensorLike) else b.dtype  # type: ignore[union-attr]
+        dtype = _binary_op_dtype(a, b)
         python_type = utils.dtype_to_type(dtype)
         if not utils.is_weakly_lesser_type(type(alpha), python_type):
             msg = f"alpha argument of type {type(alpha)} cannot be safely cast to type {python_type}!"

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -1183,6 +1183,7 @@ def _make_elementwise_binary_reference(
 
     return inner
 
+
 def _binary_op_dtype(
     a: TensorLikeType | NumberType, b: TensorLikeType | NumberType
 ) -> torch.dtype:


### PR DESCRIPTION
Fix #145598

## Summary

1. What is the root cause problem
The `torch._refs.add` and `torch._refs.sub` alpha-validation path assumes at least one promoted operand is tensor-like and reads `.dtype` from it. Under `torch.compile`, scalar-only `add/sub(..., alpha=..., out=...)` calls for the `aten.add.out` / `aten.sub.out` path reach the ref decomposition with two promoted Python scalars and an `out` tensor, so fake/meta execution raises when it tries to read `b.dtype` from a scalar.

2. What is the proposed fix
Teach the shared alpha-validation path to derive its dtype from a tensor operand when one exists, and otherwise fall back to the promoted scalar type when both operands are Python scalars. The PR also extends the existing Dynamo `add/sub alpha out` regression coverage to include scalar-only inputs.

3. Why the proposed fix is the right long term fix
This keeps dtype validation aligned with the post-promotion operands that the ref decomposition already operates on, without special-casing Dynamo or the out variant. It fixes the reported compile failure at the decomposition boundary and covers the same shared add/sub logic with a targeted regression.

Drafted via @codex, published after manual review by @bobrenjc93

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo