### PR TITLE
Migrate copy_tests to instantiate_device_type_tests for 3 test files …

### DIFF
--- a/test/inductor/test_binary_folding.py
+++ b/test/inductor/test_binary_folding.py
@@ -19,18 +19,14 @@ sys.path.append(pytorch_test_dir)
 from inductor.test_inductor_freezing import (  # @manual=fbcode//caffe2/test/inductor:inductor_freezing-library
     TestCase,
 )
-from inductor.test_torchinductor import (  # @manual=fbcode//caffe2/test/inductor:test_inductor-library
-    check_model,
-    check_model_gpu,
-    copy_tests,
-)
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.inductor_utils import skipCUDAIf
 
 
 importlib.import_module("functorch")
 importlib.import_module("filelock")
 
-from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_CPU, HAS_GPU
+from torch.testing._internal.inductor_utils import HAS_CPU, HAS_GPU
 
 
 aten = torch.ops.aten
@@ -38,7 +34,7 @@ aten = torch.ops.aten
 
 class BinaryFoldingTemplate(TestCase):
     @skipCUDAIf(TEST_CUDNN, "CUDNN has accuracy issues for this test")
-    def test_conv_binary_folding(self):
+    def test_conv_binary_folding(self, device):
         @torch.no_grad()
         def test_conv_fusion(
             use_bias,
@@ -77,7 +73,7 @@ class BinaryFoldingTemplate(TestCase):
 
             torch._dynamo.reset()
             counters.clear()
-            mod_eager = ConvOp(3, 32, self.device, kernel_size=3, stride=2).eval()
+            mod_eager = ConvOp(3, 32, device, kernel_size=3, stride=2).eval()
             out_optimized = torch.compile(mod_eager)
 
             inps = [4, 3, 4]
@@ -88,7 +84,7 @@ class BinaryFoldingTemplate(TestCase):
                 inps.append(inps[-1])
 
             torch.manual_seed(1234)
-            inp = torch.rand(inps).to(self.device)
+            inp = torch.rand(inps).to(device)
             out_eager = mod_eager(inp)
             out_optimized = out_optimized(inp)
             self.assertEqual(out_optimized, out_eager, rtol=rtol, atol=atol)
@@ -124,7 +120,7 @@ class BinaryFoldingTemplate(TestCase):
                     32,
                     1,
                     32,
-                ).to(self.device),
+                ).to(device),
                 expect_success=False,
             )
 
@@ -134,7 +130,7 @@ class BinaryFoldingTemplate(TestCase):
                 nn.Conv2d,
                 pytorch_op,
                 False,
-                add_tensor=torch.rand(1, 1).to(self.device),
+                add_tensor=torch.rand(1, 1).to(device),
                 expect_success=True,
             )
 
@@ -144,7 +140,7 @@ class BinaryFoldingTemplate(TestCase):
                 nn.Conv2d,
                 pytorch_op,
                 False,
-                add_tensor=torch.tensor([2]).to(torch.float64).to(self.device),
+                add_tensor=torch.tensor([2]).to(torch.float64).to(device),
                 expect_success=False,
                 # This test is for float32 conv fusion with different dtype, like float64,
                 # which will not be fused. The tolerance of float64 is too tight
@@ -155,7 +151,7 @@ class BinaryFoldingTemplate(TestCase):
             )
 
     @inductor_config.patch({"freezing": True})
-    def test_conv_bn_folding(self):
+    def test_conv_bn_folding(self, device):
         @torch.no_grad()
         def test_conv_fusion(use_bias, module, expect_success):
             class ConvOp(nn.Module):
@@ -188,7 +184,7 @@ class BinaryFoldingTemplate(TestCase):
                 return out
 
             torch._dynamo.reset()
-            mod_eager = ConvOp(3, 32, self.device, kernel_size=3, stride=2).eval()
+            mod_eager = ConvOp(3, 32, device, kernel_size=3, stride=2).eval()
             out_optimized = torch.compile(
                 mod_eager,
                 backend=functools.partial(compile_fx, inner_compile=my_inner_compile),
@@ -201,7 +197,7 @@ class BinaryFoldingTemplate(TestCase):
                 inps.append(inps[-1])
                 inps.append(inps[-1])
 
-            inp = torch.rand(inps).to(self.device)
+            inp = torch.rand(inps).to(device)
             out_eager = mod_eager(inp)
             out_optimized = out_optimized(inp)
             self.assertEqual(out_optimized, out_eager, atol=2e-04, rtol=1e-5)
@@ -224,7 +220,7 @@ class BinaryFoldingTemplate(TestCase):
             )
 
     @inductor_config.patch({"enable_linear_binary_folding": True})
-    def test_linear_binary_folding(self):
+    def test_linear_binary_folding(self, device):
         @torch.no_grad()
         def test_linear_fusion(
             use_bias, op, scalar, add_tensor, expect_success, input_3d=False
@@ -257,14 +253,14 @@ class BinaryFoldingTemplate(TestCase):
 
             torch._dynamo.reset()
             counters.clear()
-            mod_eager = LinearOp(3, 32, self.device).eval()
+            mod_eager = LinearOp(3, 32, device).eval()
             out_optimized = torch.compile(mod_eager)
 
             torch.manual_seed(1234)
             if input_3d:
-                inp = torch.rand([2, 4, 3]).to(self.device)
+                inp = torch.rand([2, 4, 3]).to(device)
             else:
-                inp = torch.rand([4, 3]).to(self.device)
+                inp = torch.rand([4, 3]).to(device)
             out_eager = mod_eager(inp)
             out_optimized = out_optimized(inp)
             self.assertEqual(out_optimized, out_eager, atol=5e-05, rtol=5e-06)
@@ -293,7 +289,7 @@ class BinaryFoldingTemplate(TestCase):
                 use_bias,
                 pytorch_op,
                 scalar,
-                add_tensor=torch.rand(tensor_size).to(self.device),
+                add_tensor=torch.rand(tensor_size).to(device),
                 expect_success=True,
             )
 
@@ -305,7 +301,7 @@ class BinaryFoldingTemplate(TestCase):
                 use_bias,
                 pytorch_op,
                 scalar,
-                add_tensor=torch.rand(tensor_size).to(self.device),
+                add_tensor=torch.rand(tensor_size).to(device),
                 expect_success=True,
                 input_3d=True,
             )
@@ -320,7 +316,7 @@ class BinaryFoldingTemplate(TestCase):
                 add_tensor=torch.rand(
                     4,
                     32,
-                ).to(self.device),
+                ).to(device),
                 expect_success=False,
             )
 
@@ -331,31 +327,12 @@ class BinaryFoldingTemplate(TestCase):
                 add_tensor=torch.rand(
                     4,
                     1,
-                ).to(self.device),
+                ).to(device),
                 expect_success=False,
             )
 
 
-if HAS_CPU and not torch.backends.mps.is_available():
-
-    class FreezingCpuTests(TestCase):
-        common = check_model
-        device = "cpu"
-        autocast = torch.cpu.amp.autocast
-
-    copy_tests(BinaryFoldingTemplate, FreezingCpuTests, "cpu")
-
-if HAS_GPU:
-
-    class FreezingGpuTests(TestCase):
-        common = check_model_gpu
-        device = GPU_TYPE
-        autocast = torch.amp.autocast(device_type=GPU_TYPE)
-
-    copy_tests(BinaryFoldingTemplate, FreezingGpuTests, GPU_TYPE)
-
-
-del BinaryFoldingTemplate
+instantiate_device_type_tests(BinaryFoldingTemplate, globals())
 
 if __name__ == "__main__":
     from torch._inductor.test_case import run_tests

--- a/test/inductor/test_efficient_conv_bn_eval.py
+++ b/test/inductor/test_efficient_conv_bn_eval.py
@@ -18,15 +18,12 @@ from torch._functorch import config as functorch_config
 from torch._inductor import config as inductor_config
 from torch._inductor.test_case import TestCase
 from torch.testing._internal.common_cuda import tf32_on_and_off
-from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_CPU, HAS_GPU
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.inductor_utils import HAS_CPU, HAS_GPU
 
 
 importlib.import_module("functorch")
 importlib.import_module("filelock")
-
-from inductor.test_torchinductor import (  # @manual=fbcode//caffe2/test/inductor:test_inductor-library
-    copy_tests,
-)
 
 
 class ConvOp(nn.Module):
@@ -98,7 +95,7 @@ class EfficientConvBNEvalTemplate(TestCase):
     @tf32_on_and_off(0.003)
     @inductor_config.patch({"efficient_conv_bn_eval_fx_passes": True})
     @functorch_config.patch({"enable_autograd_cache": False})
-    def test_basic(self):
+    def test_basic(self, device):
         def test_conv_bn_eval(
             test_class, use_bias, module, sync_bn, decompose_nn_module
         ):
@@ -112,7 +109,7 @@ class EfficientConvBNEvalTemplate(TestCase):
                 use_bias,
                 3,
                 32,
-                self.device,
+                device,
                 **kwargs,
             ).eval()
             # Copy module to test backward
@@ -135,7 +132,7 @@ class EfficientConvBNEvalTemplate(TestCase):
                 inps += [spatial_d] * 2
             if module[0] is nn.Conv3d or module[0] is nn.ConvTranspose3d:
                 inps += [spatial_d] * 3
-            inp = torch.rand(inps).to(self.device)
+            inp = torch.rand(inps).to(device)
 
             if decompose_nn_module:
                 with enable_python_dispatcher():
@@ -203,21 +200,7 @@ class EfficientConvBNEvalTemplate(TestCase):
             )
 
 
-if HAS_CPU and not torch.backends.mps.is_available():
-
-    class EfficientConvBNEvalCpuTests(TestCase):
-        device = "cpu"
-
-    copy_tests(EfficientConvBNEvalTemplate, EfficientConvBNEvalCpuTests, "cpu")
-
-if HAS_GPU:
-
-    class EfficientConvBNEvalGpuTests(TestCase):
-        device = GPU_TYPE
-
-    copy_tests(EfficientConvBNEvalTemplate, EfficientConvBNEvalGpuTests, GPU_TYPE)
-
-del EfficientConvBNEvalTemplate
+instantiate_device_type_tests(EfficientConvBNEvalTemplate, globals())
 
 if __name__ == "__main__":
     from torch._inductor.test_case import run_tests

--- a/test/inductor/test_provenance_tracing.py
+++ b/test/inductor/test_provenance_tracing.py
@@ -27,6 +27,7 @@ from torch._inductor.fx_passes.post_grad import post_grad_passes
 from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.utils import run_and_get_code, run_and_get_cpp_code
 from torch._inductor.virtualized import V
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import IS_MACOS
 from torch.testing._internal.inductor_utils import GPU_TYPE
 from torch.testing._internal.triton_utils import (
@@ -37,12 +38,8 @@ from torch.testing._internal.triton_utils import (
 
 try:
     from .test_aot_inductor_utils import AOTIRunnerUtil
-    from .test_torchinductor import copy_tests
 except ImportError:
-    from test_aot_inductor_utils import AOTIRunnerUtil
-    from test_torchinductor import (
-        copy_tests,  # @manual=fbcode//caffe2/test/inductor:test_inductor-library
-    )
+    from test_aot_inductor_utils import AOTIRunnerUtil  # @manual=fbcode//caffe2/test/inductor:test_inductor-library
 
 
 trace_log = logging.getLogger("torch.__trace")
@@ -824,8 +821,8 @@ class TestProvenanceTracingStackTraces(TestCase):
             self.assertTrue("aoti_torch_cpu_convolution" in keys)
 
 
-class ProvenanceTracingKernelContextTemplate:
-    def test_jit_inductor_with_flag(self):
+class ProvenanceTracingKernelContextTemplate(TestCase):
+    def test_jit_inductor_with_flag(self, device):
         class Model(torch.nn.Module):
             def __init__(self):
                 super().__init__()
@@ -842,11 +839,11 @@ class ProvenanceTracingKernelContextTemplate:
                 z = torch.nn.functional.gelu(y)
                 return x, z
 
-        model = Model().to(self.device)
-        x = torch.randn(8, 10).to(self.device)
-        a = torch.randn(10, 20).to(self.device)
-        b = torch.randn(20, 30).to(self.device)
-        c = torch.randn(10, 30).to(self.device)
+        model = Model().to(device)
+        x = torch.randn(8, 10).to(device)
+        a = torch.randn(10, 20).to(device)
+        b = torch.randn(20, 30).to(device)
+        c = torch.randn(10, 30).to(device)
         example_inputs = (x, a, b, c)
 
         with config.patch(
@@ -857,7 +854,7 @@ class ProvenanceTracingKernelContextTemplate:
             torch.compile(model)(*example_inputs)
 
     @unittest.skipIf(sys.platform == "darwin", "Different kernel names on MacOS")
-    def test_aoti_python_stack_traces(self):
+    def test_aoti_python_stack_traces(self, device):
         class Model(torch.nn.Module):
             def __init__(self):
                 super().__init__()
@@ -874,12 +871,12 @@ class ProvenanceTracingKernelContextTemplate:
                 z = torch.nn.functional.gelu(y)
                 return x, z
 
-        x = torch.randn(8, 10).to(self.device)
-        a = torch.randn(10, 20).to(self.device)
-        b = torch.randn(20, 30).to(self.device)
-        c = torch.randn(10, 30).to(self.device)
+        x = torch.randn(8, 10).to(device)
+        a = torch.randn(10, 20).to(device)
+        b = torch.randn(20, 30).to(device)
+        c = torch.randn(10, 30).to(device)
         example_inputs = (x, a, b, c)
-        model = Model().to(self.device)
+        model = Model().to(device)
 
         ep = torch.export.export(model, example_inputs)
         _, code = run_and_get_cpp_code(torch._inductor.aoti_compile_and_package, ep)
@@ -902,7 +899,7 @@ class ProvenanceTracingKernelContextTemplate:
                 code
             )
 
-            if self.device == "cuda":
+            if device == "cuda":
                 FileCheck().check(
                     """KernelContextGuard _ctx("aoti_torch_cuda_mm_out", R"("""
                 ).check("AOTI_TORCH_ERROR_CODE_CHECK(aoti_torch_cuda_mm_out(").check(
@@ -930,28 +927,7 @@ class ProvenanceTracingKernelContextTemplate:
             self.assertEqual(result, model(*example_inputs))
 
 
-class TestProvenanceTracingKernelContextCpu(TestCase):
-    device = "cpu"
-
-
-copy_tests(
-    ProvenanceTracingKernelContextTemplate,
-    TestProvenanceTracingKernelContextCpu,
-    "cpu",
-)
-
-
-@unittest.skipIf(sys.platform == "darwin", "No CUDA on MacOS")
-@unittest.skipIf(not torch.cuda.is_available(), "No CUDA")
-class TestProvenanceTracingKernelContextGpu(TestCase):
-    device = "cuda"
-
-
-copy_tests(
-    ProvenanceTracingKernelContextTemplate,
-    TestProvenanceTracingKernelContextGpu,
-    "cuda",
-)
+instantiate_device_type_tests(ProvenanceTracingKernelContextTemplate, globals())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Issue

Part of #177260

## Summary

Migrates the 3 lowest-difficulty `copy_tests` call sites to `instantiate_device_type_tests`.

Files: `test_efficient_conv_bn_eval.py`, `test_binary_folding.py`, `test_provenance_tracing.py`

Co-authored-by: Claude (Anthropic)

## Checklist

- [ ] Passes lint (`spin fixlint`)
- [ ] Added/updated tests
- [ ] Updated documentation (if applicable)
- [ ] Included benchmark results (for PRs impacting perf)

## BC-breaking?

No


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo