### PR TITLE
Preserve eager post_accumulate_grad_hook tiebreaker ordering

### DIFF
--- a/test/dynamo/test_aot_autograd.py
+++ b/test/dynamo/test_aot_autograd.py
@@ -146,6 +146,20 @@ class AotAutogradFallbackTests(torch._inductor.test_case.TestCase):
             [2, 0, 1],
         )
 
+    def test_get_backward_output_order_prioritizes_passthrough_leaf_grads(self):
+        graph = torch.fx.Graph()
+        grad = graph.placeholder("grad")
+        passthrough_grad = graph.placeholder("passthrough_grad")
+        computed_grad = graph.call_function(operator.neg, args=(grad,))
+        computed_grad.meta["seq_nr"] = 1
+        graph.output((computed_grad, passthrough_grad))
+
+        bw_module = torch.fx.GraphModule(torch.nn.Module(), graph)
+        self.assertEqual(
+            _get_backward_output_order(bw_module, [computed_grad, passthrough_grad]),
+            [1, 0],
+        )
+
     def test_remove_dupe_metadata_remaps_backward_output_order(self):
         input_info = [
             InputAliasInfo(

--- a/test/dynamo/test_aot_autograd.py
+++ b/test/dynamo/test_aot_autograd.py
@@ -75,6 +75,60 @@ class AotAutogradFallbackTests(torch._inductor.test_case.TestCase):
         bw_module = torch.fx.GraphModule(torch.nn.Module(), graph)
         self.assertIsNone(_get_backward_output_order(bw_module, [grad0, grad1]))
 
+    def test_get_backward_output_order_uses_topology_for_seq_nr_ties(self):
+        graph = torch.fx.Graph()
+        grad = graph.placeholder("grad")
+        low_priority = graph.call_function(operator.neg, args=(grad,))
+        low_priority.meta["seq_nr"] = 1
+        high_priority = graph.call_function(operator.mul, args=(grad, grad))
+        high_priority.meta["seq_nr"] = 1
+        graph.output((low_priority, high_priority))
+
+        bw_module = torch.fx.GraphModule(torch.nn.Module(), graph)
+        self.assertEqual(
+            _get_backward_output_order(bw_module, [low_priority, high_priority]),
+            [1, 0],
+        )
+
+    def test_get_backward_output_order_walks_invoke_subgraph_outputs(self):
+        from torch._higher_order_ops import invoke_subgraph
+
+        inner_graph = torch.fx.Graph()
+        inner_grad = inner_graph.placeholder("inner_grad")
+        low_priority = inner_graph.call_function(operator.neg, args=(inner_grad,))
+        low_priority.meta["seq_nr"] = 1
+        high_priority = inner_graph.call_function(
+            operator.mul, args=(inner_grad, inner_grad)
+        )
+        high_priority.meta["seq_nr"] = 2
+        inner_graph.output((low_priority, high_priority))
+        repeated_subgraph = torch.fx.GraphModule(torch.nn.Module(), inner_graph)
+
+        outer_root = torch.nn.Module()
+        outer_root.add_module("repeated_subgraph0", repeated_subgraph)
+        outer_graph = torch.fx.Graph()
+        grad = outer_graph.placeholder("grad")
+        repeated_subgraph0 = outer_graph.get_attr("repeated_subgraph0")
+        invoke_subgraph_0 = outer_graph.call_function(
+            invoke_subgraph, args=(repeated_subgraph0, "invoke_subgraph_0", grad)
+        )
+        invoke_subgraph_0.meta["seq_nr"] = 3
+        low_priority_out = outer_graph.call_function(
+            operator.getitem, args=(invoke_subgraph_0, 0)
+        )
+        high_priority_out = outer_graph.call_function(
+            operator.getitem, args=(invoke_subgraph_0, 1)
+        )
+        outer_graph.output((low_priority_out, high_priority_out))
+
+        bw_module = torch.fx.GraphModule(outer_root, outer_graph)
+        self.assertEqual(
+            _get_backward_output_order(
+                bw_module, [low_priority_out, high_priority_out]
+            ),
+            [1, 0],
+        )
+
     def test_LSTM(self):
         # https://github.com/pytorch/torchdynamo/issues/1147
         class Repro(torch.nn.Module):

--- a/test/dynamo/test_aot_autograd.py
+++ b/test/dynamo/test_aot_autograd.py
@@ -77,6 +77,19 @@ class AotAutogradFallbackTests(torch._inductor.test_case.TestCase):
         bw_module = torch.fx.GraphModule(torch.nn.Module(), graph)
         self.assertIsNone(_get_backward_output_order(bw_module, [grad0, grad1]))
 
+    def test_get_backward_output_order_uses_topology_without_seq_nr(self):
+        graph = torch.fx.Graph()
+        grad = graph.placeholder("grad")
+        low_priority = graph.call_function(operator.neg, args=(grad,))
+        high_priority = graph.call_function(operator.mul, args=(low_priority, grad))
+        graph.output((low_priority, high_priority))
+
+        bw_module = torch.fx.GraphModule(torch.nn.Module(), graph)
+        self.assertEqual(
+            _get_backward_output_order(bw_module, [low_priority, high_priority]),
+            [1, 0],
+        )
+
     def test_get_backward_output_order_uses_topology_for_seq_nr_ties(self):
         graph = torch.fx.Graph()
         grad = graph.placeholder("grad")
@@ -156,7 +169,11 @@ class AotAutogradFallbackTests(torch._inductor.test_case.TestCase):
 
         bw_module = torch.fx.GraphModule(torch.nn.Module(), graph)
         self.assertEqual(
-            _get_backward_output_order(bw_module, [computed_grad, passthrough_grad]),
+            _get_backward_output_order(
+                bw_module,
+                [computed_grad, passthrough_grad],
+                leaf_input_grads=[False, True],
+            ),
             [1, 0],
         )
 
@@ -172,6 +189,23 @@ class AotAutogradFallbackTests(torch._inductor.test_case.TestCase):
         self.assertEqual(
             _get_backward_output_order(bw_module, [saved_tensor, computed_grad]),
             [1, 0],
+        )
+
+    def test_get_backward_output_order_does_not_prioritize_non_leaf_tangents(self):
+        graph = torch.fx.Graph()
+        grad = graph.placeholder("tangents_0")
+        activation_grad = graph.placeholder("tangents_1")
+        computed_grad = graph.call_function(operator.neg, args=(grad,))
+        computed_grad.meta["seq_nr"] = 1
+        graph.output((computed_grad, activation_grad))
+
+        bw_module = torch.fx.GraphModule(torch.nn.Module(), graph)
+        self.assertIsNone(
+            _get_backward_output_order(
+                bw_module,
+                [computed_grad, activation_grad],
+                leaf_input_grads=[True, False],
+            )
         )
 
     def test_remove_dupe_metadata_remaps_backward_output_order(self):

--- a/test/dynamo/test_aot_autograd.py
+++ b/test/dynamo/test_aot_autograd.py
@@ -148,8 +148,8 @@ class AotAutogradFallbackTests(torch._inductor.test_case.TestCase):
 
     def test_get_backward_output_order_prioritizes_passthrough_leaf_grads(self):
         graph = torch.fx.Graph()
-        grad = graph.placeholder("grad")
-        passthrough_grad = graph.placeholder("passthrough_grad")
+        grad = graph.placeholder("tangents_0")
+        passthrough_grad = graph.placeholder("tangents_1")
         computed_grad = graph.call_function(operator.neg, args=(grad,))
         computed_grad.meta["seq_nr"] = 1
         graph.output((computed_grad, passthrough_grad))
@@ -157,6 +157,20 @@ class AotAutogradFallbackTests(torch._inductor.test_case.TestCase):
         bw_module = torch.fx.GraphModule(torch.nn.Module(), graph)
         self.assertEqual(
             _get_backward_output_order(bw_module, [computed_grad, passthrough_grad]),
+            [1, 0],
+        )
+
+    def test_get_backward_output_order_does_not_prioritize_saved_tensors(self):
+        graph = torch.fx.Graph()
+        saved_tensor = graph.placeholder("primals_1")
+        tangent = graph.placeholder("tangents_1")
+        computed_grad = graph.call_function(operator.neg, args=(tangent,))
+        computed_grad.meta["seq_nr"] = 1
+        graph.output((saved_tensor, computed_grad))
+
+        bw_module = torch.fx.GraphModule(torch.nn.Module(), graph)
+        self.assertEqual(
+            _get_backward_output_order(bw_module, [saved_tensor, computed_grad]),
             [1, 0],
         )
 

--- a/test/dynamo/test_aot_autograd.py
+++ b/test/dynamo/test_aot_autograd.py
@@ -12,13 +12,13 @@ import torch._dynamo.test_case
 import torch._inductor.test_case
 import torch.fx.traceback as fx_traceback
 import torch.utils._pytree as pytree
-from torch._functorch._aot_autograd.graph_compile import _get_backward_output_order
 from torch._dynamo.testing import (
     CompileCounter,
     CompileCounterWithBackend,
     expectedFailureDynamic,
     rand_strided,
 )
+from torch._functorch._aot_autograd.graph_compile import _get_backward_output_order
 from torch._functorch.aot_autograd import _aot_export_function, create_functional_call
 from torch._guards import CompileContext, StorageOverlap, TracingContext
 from torch._subclasses.fake_tensor import FakeTensorMode

--- a/test/dynamo/test_aot_autograd.py
+++ b/test/dynamo/test_aot_autograd.py
@@ -1,5 +1,6 @@
 # Owner(s): ["module: dynamo"]
 import copy
+import operator
 import re
 import unittest
 from textwrap import dedent
@@ -11,6 +12,7 @@ import torch._dynamo.test_case
 import torch._inductor.test_case
 import torch.fx.traceback as fx_traceback
 import torch.utils._pytree as pytree
+from torch._functorch._aot_autograd.graph_compile import _get_backward_output_order
 from torch._dynamo.testing import (
     CompileCounter,
     CompileCounterWithBackend,
@@ -47,6 +49,32 @@ lib.impl("maybe_dupe_op", maybe_dupe_op, "Meta")
 
 
 class AotAutogradFallbackTests(torch._inductor.test_case.TestCase):
+    def test_get_backward_output_order_unwraps_nested_getitems(self):
+        graph = torch.fx.Graph()
+        grad = graph.placeholder("grad")
+        low_priority = graph.call_function(operator.neg, args=(grad,))
+        low_priority.meta["seq_nr"] = 1
+        high_priority = graph.call_function(operator.mul, args=(grad, grad))
+        high_priority.meta["seq_nr"] = 2
+        outer_getitem = graph.call_function(operator.getitem, args=(high_priority, 0))
+        nested_getitem = graph.call_function(operator.getitem, args=(outer_getitem, 0))
+        graph.output((low_priority, nested_getitem))
+
+        bw_module = torch.fx.GraphModule(torch.nn.Module(), graph)
+        self.assertEqual(
+            _get_backward_output_order(bw_module, [low_priority, nested_getitem]),
+            [1, 0],
+        )
+
+    def test_get_backward_output_order_keeps_index_order_without_seq_nr(self):
+        graph = torch.fx.Graph()
+        grad0 = graph.placeholder("grad0")
+        grad1 = graph.placeholder("grad1")
+        graph.output((grad0, grad1))
+
+        bw_module = torch.fx.GraphModule(torch.nn.Module(), graph)
+        self.assertIsNone(_get_backward_output_order(bw_module, [grad0, grad1]))
+
     def test_LSTM(self):
         # https://github.com/pytorch/torchdynamo/issues/1147
         class Repro(torch.nn.Module):

--- a/test/dynamo/test_aot_autograd.py
+++ b/test/dynamo/test_aot_autograd.py
@@ -19,6 +19,8 @@ from torch._dynamo.testing import (
     rand_strided,
 )
 from torch._functorch._aot_autograd.graph_compile import _get_backward_output_order
+from torch._functorch._aot_autograd.input_output_analysis import remove_dupe_metadata
+from torch._functorch._aot_autograd.schemas import InputAliasInfo, ViewAndMutationMeta
 from torch._functorch.aot_autograd import _aot_export_function, create_functional_call
 from torch._guards import CompileContext, StorageOverlap, TracingContext
 from torch._subclasses.fake_tensor import FakeTensorMode
@@ -128,6 +130,53 @@ class AotAutogradFallbackTests(torch._inductor.test_case.TestCase):
             ),
             [1, 0],
         )
+
+    def test_get_backward_output_order_places_none_grads_last(self):
+        graph = torch.fx.Graph()
+        grad = graph.placeholder("grad")
+        low_priority = graph.call_function(operator.neg, args=(grad,))
+        low_priority.meta["seq_nr"] = 1
+        high_priority = graph.call_function(operator.mul, args=(grad, grad))
+        high_priority.meta["seq_nr"] = 2
+        graph.output((low_priority, None, high_priority))
+
+        bw_module = torch.fx.GraphModule(torch.nn.Module(), graph)
+        self.assertEqual(
+            _get_backward_output_order(bw_module, [low_priority, None, high_priority]),
+            [2, 0, 1],
+        )
+
+    def test_remove_dupe_metadata_remaps_backward_output_order(self):
+        input_info = [
+            InputAliasInfo(
+                is_leaf=True,
+                mutates_data=False,
+                mutates_metadata=False,
+                mutations_hidden_from_autograd=False,
+                mutations_under_no_grad_or_inference_mode=False,
+                mutation_inductor_storage_resize=False,
+                mutates_storage_metadata=False,
+                requires_grad=True,
+                keep_input_mutations=False,
+            )
+            for _ in range(3)
+        ]
+        meta = ViewAndMutationMeta(
+            input_info=input_info,
+            output_info=[],
+            num_intermediate_bases=0,
+            keep_input_mutations=False,
+            traced_tangents=[],
+            traced_tangents_descs=[],
+            subclass_inp_meta=[],
+            subclass_fw_graph_out_meta=[],
+            subclass_tangent_meta=[],
+            is_train=False,
+            backward_output_order=[1, 2, 0],
+        )
+
+        updated = remove_dupe_metadata(meta, [True, True, False], [0, 1, 0])
+        self.assertEqual(updated.backward_output_order, [1, 0])
 
     def test_LSTM(self):
         # https://github.com/pytorch/torchdynamo/issues/1147

--- a/test/dynamo/test_hooks.py
+++ b/test/dynamo/test_hooks.py
@@ -997,6 +997,50 @@ def forward(self, L_x_ : torch.Tensor):
                 with compiled_bwd_ctx:
                     test_fn(compiled_fn)
 
+    def test_post_acc_grad_hook_tiebreaker_order_matches_eager(self):
+        x = torch.randn(10, 10)
+
+        def get_order(module_factory, backend=None):
+            module = module_factory()
+            hook_order = []
+
+            def hook(param, idx):
+                hook_order.append(idx)
+
+            for idx, param in enumerate(module.parameters()):
+                param.register_post_accumulate_grad_hook(
+                    functools.partial(hook, idx=idx)
+                )
+
+            fn = module
+            if backend is not None:
+                fn = torch.compile(module, backend=backend, fullgraph=True)
+            fn(x).sum().backward()
+            return hook_order
+
+        def reordered_layers():
+            class ReorderedLayers(torch.nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    self.layer0 = torch.nn.Linear(10, 10, bias=False)
+                    self.layer1 = torch.nn.Linear(10, 10, bias=False)
+                    self.layer2 = torch.nn.Linear(10, 10, bias=False)
+
+                def forward(self, x):
+                    x = self.layer1(x)
+                    x = self.layer0(x)
+                    x = self.layer2(x)
+                    return x
+
+            return ReorderedLayers()
+
+        def linear_with_bias():
+            return torch.nn.Linear(10, 10, bias=True)
+
+        for module_factory in (reordered_layers, linear_with_bias):
+            eager_order = get_order(module_factory)
+            self.assertEqual(get_order(module_factory, "aot_eager"), eager_order)
+
     def test_recompile(self):
         def hook(param):
             param.grad *= 2

--- a/test/dynamo/test_hooks.py
+++ b/test/dynamo/test_hooks.py
@@ -1000,7 +1000,9 @@ def forward(self, L_x_ : torch.Tensor):
     def test_post_acc_grad_hook_tiebreaker_order_matches_eager(self):
         x = torch.randn(10, 10)
 
-        def get_order(module_factory, backend=None, args=()):
+        def get_order(
+            module_factory, backend=None, args=(), compiled_bwd_backend=None
+        ):
             module = module_factory()
             hook_order = []
 
@@ -1015,7 +1017,15 @@ def forward(self, L_x_ : torch.Tensor):
             fn = module
             if backend is not None:
                 fn = torch.compile(module, backend=backend, fullgraph=True)
-            fn(x, *args).sum().backward()
+            compiled_bwd_ctx = (
+                compiled_autograd._enable(
+                    torch.compile(backend=compiled_bwd_backend, fullgraph=True)
+                )
+                if compiled_bwd_backend is not None
+                else contextlib.nullcontext()
+            )
+            with compiled_bwd_ctx:
+                fn(x, *args).sum().backward()
             return hook_order
 
         def reordered_layers():
@@ -1061,6 +1071,15 @@ def forward(self, L_x_ : torch.Tensor):
             eager_order = get_order(module_factory, args=args)
             self.assertEqual(
                 get_order(module_factory, "aot_eager", args=args), eager_order
+            )
+            self.assertEqual(
+                get_order(
+                    module_factory,
+                    "aot_eager",
+                    args=args,
+                    compiled_bwd_backend="aot_eager",
+                ),
+                eager_order,
             )
 
     def test_recompile(self):

--- a/test/dynamo/test_hooks.py
+++ b/test/dynamo/test_hooks.py
@@ -1000,7 +1000,7 @@ def forward(self, L_x_ : torch.Tensor):
     def test_post_acc_grad_hook_tiebreaker_order_matches_eager(self):
         x = torch.randn(10, 10)
 
-        def get_order(module_factory, backend=None):
+        def get_order(module_factory, backend=None, args=()):
             module = module_factory()
             hook_order = []
 
@@ -1015,7 +1015,7 @@ def forward(self, L_x_ : torch.Tensor):
             fn = module
             if backend is not None:
                 fn = torch.compile(module, backend=backend, fullgraph=True)
-            fn(x).sum().backward()
+            fn(x, *args).sum().backward()
             return hook_order
 
         def reordered_layers():
@@ -1037,9 +1037,31 @@ def forward(self, L_x_ : torch.Tensor):
         def linear_with_bias():
             return torch.nn.Linear(10, 10, bias=True)
 
-        for module_factory in (reordered_layers, linear_with_bias):
-            eager_order = get_order(module_factory)
-            self.assertEqual(get_order(module_factory, "aot_eager"), eager_order)
+        def reordered_layers_with_scale():
+            class ReorderedLayersWithScale(torch.nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    self.layer0 = torch.nn.Linear(10, 10, bias=False)
+                    self.layer1 = torch.nn.Linear(10, 10, bias=False)
+                    self.layer2 = torch.nn.Linear(10, 10, bias=False)
+
+                def forward(self, x, scale):
+                    x = self.layer1(x)
+                    x = scale * self.layer0(x)
+                    x = self.layer2(x)
+                    return x
+
+            return ReorderedLayersWithScale()
+
+        for module_factory, args in (
+            (reordered_layers, ()),
+            (linear_with_bias, ()),
+            (reordered_layers_with_scale, (2.0,)),
+        ):
+            eager_order = get_order(module_factory, args=args)
+            self.assertEqual(
+                get_order(module_factory, "aot_eager", args=args), eager_order
+            )
 
     def test_recompile(self):
         def hook(param):

--- a/test/dynamo/test_hooks.py
+++ b/test/dynamo/test_hooks.py
@@ -1000,9 +1000,7 @@ def forward(self, L_x_ : torch.Tensor):
     def test_post_acc_grad_hook_tiebreaker_order_matches_eager(self):
         x = torch.randn(10, 10)
 
-        def get_order(
-            module_factory, backend=None, args=(), compiled_bwd_backend=None
-        ):
+        def get_order(module_factory, backend=None, args=(), compiled_bwd_backend=None):
             module = module_factory()
             hook_order = []
 

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -4954,6 +4954,56 @@ SinBackward0, MulBackward0, torch::autograd::AccumulateGrad
         for h in all_hooks:
             h.remove()
 
+    @skipIfTorchDynamo(
+        "_current_graph_task_execution_order requires active backward pass"
+    )
+    def test_current_graph_task_execution_order_honors_next_edges_order(self):
+        predicted = [None]
+        actual = []
+        all_hooks = []
+
+        class ReorderedFunction(torch.autograd.Function):
+            _backward_next_edges_order = (1, 0)
+
+            @staticmethod
+            def forward(ctx, x, y):
+                return x + y
+
+            @staticmethod
+            def backward(ctx, grad_output):
+                return grad_output, grad_output
+
+        def hook(_):
+            predicted[0] = torch._C._current_graph_task_execution_order()
+
+        def grad_fn(tensor):
+            if tensor.requires_grad and tensor.grad_fn is None:
+                return tensor.clone().grad_fn.next_functions[0][0]
+            return tensor.grad_fn
+
+        def register_logging_hook(name, tensor):
+            def tensor_hook(_):
+                actual.append(name)
+
+            all_hooks.append(tensor.register_hook(tensor_hook))
+
+        a = torch.tensor(1.0, requires_grad=True)
+        b = torch.tensor(2.0, requires_grad=True)
+        out = ReorderedFunction.apply(a, b)
+        register_logging_hook("a", a)
+        register_logging_hook("b", b)
+        register_logging_hook("out", out)
+        all_hooks.append(out.register_hook(hook))
+
+        with torch.autograd.set_multithreading_enabled(False):
+            out.backward()
+
+        self.assertEqual(actual, ["out", "b", "a"])
+        self.assertEqual(predicted[0], [out.grad_fn, grad_fn(b), grad_fn(a)])
+
+        for h in all_hooks:
+            h.remove()
+
     @skipIfWindows(msg="node name demangling inconsistent on windows")
     def test_backward_hook_relative_ordering(self):
         order = []

--- a/torch/_functorch/_aot_autograd/graph_compile.py
+++ b/torch/_functorch/_aot_autograd/graph_compile.py
@@ -19,14 +19,10 @@ from collections import defaultdict
 from collections.abc import Callable, Generator, Sequence
 from contextlib import nullcontext
 from functools import cmp_to_key
-from typing import Any, TYPE_CHECKING
+from typing import Any
 
 from torch._library.fake_class_registry import FakeScriptObject
 from torch._opaque_base import OpaqueBase
-
-
-if TYPE_CHECKING:
-    from collections.abc import Sequence
 
 import threading
 from contextlib import contextmanager
@@ -222,7 +218,10 @@ def _get_backward_output_order(
         lhs: tuple[tuple[bool, int, int], ...],
         rhs: tuple[tuple[bool, int, int], ...],
     ) -> int:
-        for lhs_level, rhs_level in zip(lhs, rhs):
+        shared_levels = min(len(lhs), len(rhs))
+        for i in range(shared_levels):
+            lhs_level = lhs[i]
+            rhs_level = rhs[i]
             lhs_has_seq_nr, lhs_seq_nr, lhs_topo_idx = lhs_level
             rhs_has_seq_nr, rhs_seq_nr, rhs_topo_idx = rhs_level
             if lhs_has_seq_nr != rhs_has_seq_nr:
@@ -232,6 +231,10 @@ def _get_backward_output_order(
                     return -1 if lhs_seq_nr > rhs_seq_nr else 1
                 if lhs_topo_idx != rhs_topo_idx:
                     return -1 if lhs_topo_idx > rhs_topo_idx else 1
+        if len(lhs) != len(rhs):
+            extra = lhs[shared_levels:] if len(lhs) > len(rhs) else rhs[shared_levels:]
+            if any(has_seq_nr for has_seq_nr, _, _ in extra) or shared_levels == 0:
+                return -1 if len(lhs) > len(rhs) else 1
         return 0
 
     priorities = [build_priority(bw_module, bw_out) for bw_out in bw_outs]

--- a/torch/_functorch/_aot_autograd/graph_compile.py
+++ b/torch/_functorch/_aot_autograd/graph_compile.py
@@ -116,6 +116,39 @@ def maybe_skip_decompose(aot_config: AOTConfig) -> Generator[None, None, None]:
         aot_config.decompositions = old_decomp
 
 
+def _get_backward_output_order(
+    bw_module: GraphModule,
+    bw_outs: Any,
+) -> list[int] | None:
+    topo_order = {node: i for i, node in enumerate(bw_module.graph.nodes)}
+
+    def get_source_node(bw_out: Any) -> torch.fx.Node | None:
+        if not isinstance(bw_out, torch.fx.Node):
+            return None
+        if (
+            bw_out.op == "call_function"
+            and bw_out.target is operator.getitem
+            and isinstance(bw_out.args[0], torch.fx.Node)
+        ):
+            return bw_out.args[0]
+        return bw_out
+
+    def sort_key(idx: int) -> tuple[int, int]:
+        source = get_source_node(bw_outs[idx])
+        if source is None:
+            return (-1, -1)
+        # Eager gives later forward ops priority in backward via sequence numbers.
+        # For tuple-producing nodes, use the shared source node so equal seq_nrs
+        # preserve the source node's output order.
+        seq_nr = source.meta.get("seq_nr")
+        if isinstance(seq_nr, int):
+            return (seq_nr, 0)
+        return (-1, topo_order[source])
+
+    order = sorted(range(len(bw_outs)), key=sort_key, reverse=True)
+    return None if order == list(range(len(bw_outs))) else order
+
+
 # Saved tensor hooks context
 # Compiled saved tensor hooks are convenient way to inline some logic in the graphs
 # for saved nodes from forward to backward. (E.g. activations quantization)
@@ -1950,6 +1983,9 @@ def _aot_stage2a_partition(
                     f"expected len(bw_outs_no_rng_no_tokens) == {len(fw_metadata.input_info)}, "
                     f"got {len(bw_outs_no_rng_no_tokens)}"
                 )
+            fw_metadata.backward_output_order = _get_backward_output_order(
+                bw_module, bw_outs_no_rng_no_tokens
+            )
 
             for i, (bw_out) in enumerate(bw_outs_no_rng_no_tokens):
                 # If our input experiences a metadata mutation inside the graph (e.g. set_()),

--- a/torch/_functorch/_aot_autograd/graph_compile.py
+++ b/torch/_functorch/_aot_autograd/graph_compile.py
@@ -144,6 +144,16 @@ def _get_backward_output_order(
         path.reverse()
         return value, tuple(path)
 
+    def is_tangent_placeholder(value: torch.fx.Node) -> bool:
+        if value.op != "placeholder":
+            return False
+        name = value.name
+        if name.startswith("tangents_"):
+            return name.removeprefix("tangents_").isdigit()
+        if "_tangents_" not in name:
+            return False
+        return name.rsplit("_tangents_", 1)[1].isdigit()
+
     def get_invoke_subgraph_module(
         module: GraphModule, value: torch.fx.Node
     ) -> GraphModule | None:
@@ -198,7 +208,7 @@ def _get_backward_output_order(
         seq_nr = source.meta.get("seq_nr")
         has_seq_nr = isinstance(seq_nr, int)
         topo_idx = get_topo_order(module)[source]
-        if source.op == "placeholder":
+        if is_tangent_placeholder(source):
             priority_kind = PASSTHROUGH_PRIORITY
         elif has_seq_nr:
             priority_kind = SEQ_NR_PRIORITY
@@ -241,10 +251,7 @@ def _get_backward_output_order(
         if len(lhs) != len(rhs):
             extra = lhs[shared_levels:] if len(lhs) > len(rhs) else rhs[shared_levels:]
             if (
-                any(
-                    priority_kind != STABLE_PRIORITY
-                    for priority_kind, _, _ in extra
-                )
+                any(priority_kind != STABLE_PRIORITY for priority_kind, _, _ in extra)
                 or shared_levels == 0
             ):
                 return -1 if len(lhs) > len(rhs) else 1

--- a/torch/_functorch/_aot_autograd/graph_compile.py
+++ b/torch/_functorch/_aot_autograd/graph_compile.py
@@ -16,8 +16,9 @@ import operator
 import time
 import traceback
 from collections import defaultdict
-from collections.abc import Callable, Generator
+from collections.abc import Callable, Generator, Sequence
 from contextlib import nullcontext
+from functools import cmp_to_key
 from typing import Any, TYPE_CHECKING
 
 from torch._library.fake_class_registry import FakeScriptObject
@@ -117,32 +118,129 @@ def maybe_skip_decompose(aot_config: AOTConfig) -> Generator[None, None, None]:
 
 
 def _get_backward_output_order(
-    _bw_module: GraphModule,
+    bw_module: GraphModule,
     bw_outs: Any,
 ) -> list[int] | None:
-    def get_source_node(bw_out: Any) -> torch.fx.Node | None:
-        while isinstance(bw_out, torch.fx.Node):
-            if bw_out.op != "call_function" or bw_out.target is not operator.getitem:
-                return bw_out
-            if not isinstance(bw_out.args[0], torch.fx.Node):
-                return bw_out
-            bw_out = bw_out.args[0]
-        return None
+    topo_orders: dict[int, dict[torch.fx.Node, int]] = {}
 
-    def sort_key(idx: int) -> tuple[int, int]:
-        source = get_source_node(bw_outs[idx])
-        if source is None:
-            return (0, 0)
-        # Eager gives later forward ops priority in backward via sequence numbers.
-        # For tuple/list-producing nodes, use the shared source node so equal
-        # seq_nrs preserve the flattened output order. If eager recorded no
-        # priority for this output, keep the original index order.
+    def get_topo_order(module: GraphModule) -> dict[torch.fx.Node, int]:
+        module_id = id(module)
+        topo_order = topo_orders.get(module_id)
+        if topo_order is None:
+            topo_order = {node: idx for idx, node in enumerate(module.graph.nodes)}
+            topo_orders[module_id] = topo_order
+        return topo_order
+
+    def unwrap_getitems(value: Any) -> tuple[Any, tuple[int, ...]]:
+        path = []
+        while isinstance(value, torch.fx.Node):
+            if (
+                value.op != "call_function"
+                or value.target is not operator.getitem
+                or len(value.args) < 2
+                or not isinstance(value.args[0], torch.fx.Node)
+                or not isinstance(value.args[1], int)
+            ):
+                break
+            path.append(value.args[1])
+            value = value.args[0]
+        path.reverse()
+        return value, tuple(path)
+
+    def get_invoke_subgraph_module(
+        module: GraphModule, value: torch.fx.Node
+    ) -> GraphModule | None:
+        if (
+            value.op != "call_function"
+            or value.target is not torch._higher_order_ops.invoke_subgraph
+            or not value.args
+            or not isinstance(value.args[0], torch.fx.Node)
+            or value.args[0].op != "get_attr"
+            or not isinstance(value.args[0].target, str)
+        ):
+            return None
+
+        submodule = module.get_submodule(value.args[0].target)
+        return submodule if isinstance(submodule, GraphModule) else None
+
+    def resolve_graph_output(
+        module: GraphModule, path: tuple[int, ...]
+    ) -> tuple[Any, tuple[int, ...]] | None:
+        output_node = next(reversed(module.graph.find_nodes(op="output")))
+        current = output_node.args[0]
+        if not path:
+            if isinstance(current, Sequence) and not isinstance(current, (str, bytes)):
+                if len(current) != 1:
+                    return None
+                current = current[0]
+            return current, ()
+
+        remaining = list(path)
+        while remaining and isinstance(current, Sequence) and not isinstance(
+            current, (str, bytes)
+        ):
+            index = remaining.pop(0)
+            if index < -len(current) or index >= len(current):
+                return None
+            current = current[index]
+
+        return current, tuple(remaining)
+
+    def build_priority(
+        module: GraphModule,
+        value: Any,
+        remaining_path: tuple[int, ...] = (),
+    ) -> tuple[tuple[bool, int, int], ...]:
+        source, path = unwrap_getitems(value)
+        full_path = path + remaining_path
+        if not isinstance(source, torch.fx.Node):
+            return ()
+
         seq_nr = source.meta.get("seq_nr")
-        if isinstance(seq_nr, int):
-            return (1, seq_nr)
-        return (0, 0)
+        has_seq_nr = isinstance(seq_nr, int)
+        topo_idx = get_topo_order(module)[source]
+        priority = (
+            (
+                has_seq_nr,
+                seq_nr if has_seq_nr else 0,
+                topo_idx if has_seq_nr else 0,
+            ),
+        )
 
-    order = sorted(range(len(bw_outs)), key=sort_key, reverse=True)
+        submodule = get_invoke_subgraph_module(module, source)
+        if submodule is None:
+            return priority
+
+        inner_output = resolve_graph_output(submodule, full_path)
+        if inner_output is None:
+            return priority
+
+        inner_value, inner_path = inner_output
+        return priority + build_priority(submodule, inner_value, inner_path)
+
+    def compare_priority(
+        lhs: tuple[tuple[bool, int, int], ...],
+        rhs: tuple[tuple[bool, int, int], ...],
+    ) -> int:
+        for lhs_level, rhs_level in zip(lhs, rhs):
+            lhs_has_seq_nr, lhs_seq_nr, lhs_topo_idx = lhs_level
+            rhs_has_seq_nr, rhs_seq_nr, rhs_topo_idx = rhs_level
+            if lhs_has_seq_nr != rhs_has_seq_nr:
+                return -1 if lhs_has_seq_nr else 1
+            if lhs_has_seq_nr:
+                if lhs_seq_nr != rhs_seq_nr:
+                    return -1 if lhs_seq_nr > rhs_seq_nr else 1
+                if lhs_topo_idx != rhs_topo_idx:
+                    return -1 if lhs_topo_idx > rhs_topo_idx else 1
+        return 0
+
+    priorities = [build_priority(bw_module, bw_out) for bw_out in bw_outs]
+    order = sorted(
+        range(len(bw_outs)),
+        key=cmp_to_key(
+            lambda lhs, rhs: compare_priority(priorities[lhs], priorities[rhs])
+        ),
+    )
     return None if order == list(range(len(bw_outs))) else order
 
 

--- a/torch/_functorch/_aot_autograd/graph_compile.py
+++ b/torch/_functorch/_aot_autograd/graph_compile.py
@@ -113,9 +113,11 @@ def maybe_skip_decompose(aot_config: AOTConfig) -> Generator[None, None, None]:
 def _get_backward_output_order(
     bw_module: GraphModule,
     bw_outs: Any,
+    leaf_input_grads: Sequence[bool] | None = None,
 ) -> list[int] | None:
-    PASSTHROUGH_PRIORITY = 2
-    SEQ_NR_PRIORITY = 1
+    PASSTHROUGH_PRIORITY = 3
+    SEQ_NR_PRIORITY = 2
+    TOPOLOGY_PRIORITY = 1
     STABLE_PRIORITY = 0
 
     topo_orders: dict[int, dict[torch.fx.Node, int]] = {}
@@ -153,6 +155,17 @@ def _get_backward_output_order(
         if "_tangents_" not in name:
             return False
         return name.rsplit("_tangents_", 1)[1].isdigit()
+
+    def is_leaf_tangent_placeholder(
+        value: torch.fx.Node, bw_out_idx: int | None
+    ) -> bool:
+        return (
+            leaf_input_grads is not None
+            and bw_out_idx is not None
+            and bw_out_idx < len(leaf_input_grads)
+            and leaf_input_grads[bw_out_idx]
+            and is_tangent_placeholder(value)
+        )
 
     def get_invoke_subgraph_module(
         module: GraphModule, value: torch.fx.Node
@@ -199,6 +212,7 @@ def _get_backward_output_order(
         module: GraphModule,
         value: Any,
         remaining_path: tuple[int, ...] = (),
+        bw_out_idx: int | None = None,
     ) -> tuple[tuple[int, int, int], ...]:
         source, path = unwrap_getitems(value)
         full_path = path + remaining_path
@@ -208,17 +222,19 @@ def _get_backward_output_order(
         seq_nr = source.meta.get("seq_nr")
         has_seq_nr = isinstance(seq_nr, int)
         topo_idx = get_topo_order(module)[source]
-        if is_tangent_placeholder(source):
+        if is_leaf_tangent_placeholder(source, bw_out_idx):
             priority_kind = PASSTHROUGH_PRIORITY
         elif has_seq_nr:
             priority_kind = SEQ_NR_PRIORITY
+        elif source.op not in ("placeholder", "get_attr"):
+            priority_kind = TOPOLOGY_PRIORITY
         else:
             priority_kind = STABLE_PRIORITY
         priority = (
             (
                 priority_kind,
                 seq_nr if has_seq_nr else 0,
-                topo_idx if has_seq_nr else 0,
+                topo_idx if priority_kind in (SEQ_NR_PRIORITY, TOPOLOGY_PRIORITY) else 0,
             ),
         )
 
@@ -231,7 +247,9 @@ def _get_backward_output_order(
             return priority
 
         inner_value, inner_path = inner_output
-        return priority + build_priority(submodule, inner_value, inner_path)
+        return priority + build_priority(
+            submodule, inner_value, inner_path, bw_out_idx
+        )
 
     def compare_priority(
         lhs: tuple[tuple[int, int, int], ...],
@@ -248,6 +266,8 @@ def _get_backward_output_order(
                     return -1 if lhs_seq_nr > rhs_seq_nr else 1
                 if lhs_topo_idx != rhs_topo_idx:
                     return -1 if lhs_topo_idx > rhs_topo_idx else 1
+            elif lhs_kind == TOPOLOGY_PRIORITY and lhs_topo_idx != rhs_topo_idx:
+                return -1 if lhs_topo_idx > rhs_topo_idx else 1
         if len(lhs) != len(rhs):
             extra = lhs[shared_levels:] if len(lhs) > len(rhs) else rhs[shared_levels:]
             if (
@@ -257,7 +277,10 @@ def _get_backward_output_order(
                 return -1 if len(lhs) > len(rhs) else 1
         return 0
 
-    priorities = [build_priority(bw_module, bw_out) for bw_out in bw_outs]
+    priorities = [
+        build_priority(bw_module, bw_out, bw_out_idx=bw_out_idx)
+        for bw_out_idx, bw_out in enumerate(bw_outs)
+    ]
     order = sorted(
         range(len(bw_outs)),
         key=cmp_to_key(
@@ -2102,7 +2125,12 @@ def _aot_stage2a_partition(
                     f"got {len(bw_outs_no_rng_no_tokens)}"
                 )
             fw_metadata.backward_output_order = _get_backward_output_order(
-                bw_module, bw_outs_no_rng_no_tokens
+                bw_module,
+                bw_outs_no_rng_no_tokens,
+                leaf_input_grads=[
+                    input_info.is_leaf and input_info.requires_grad
+                    for input_info in fw_metadata.input_info
+                ],
             )
 
             for i, (bw_out) in enumerate(bw_outs_no_rng_no_tokens):

--- a/torch/_functorch/_aot_autograd/graph_compile.py
+++ b/torch/_functorch/_aot_autograd/graph_compile.py
@@ -13,19 +13,14 @@ import dataclasses
 import itertools
 import logging
 import operator
+import threading
 import time
 import traceback
 from collections import defaultdict
 from collections.abc import Callable, Generator, Sequence
-from contextlib import nullcontext
+from contextlib import contextmanager, nullcontext
 from functools import cmp_to_key
 from typing import Any
-
-from torch._library.fake_class_registry import FakeScriptObject
-from torch._opaque_base import OpaqueBase
-
-import threading
-from contextlib import contextmanager
 
 import torch
 import torch.utils._pytree as pytree
@@ -38,7 +33,9 @@ from torch._dynamo.utils import (
     lazy_format_graph_code,
 )
 from torch._guards import CompileContext, TracingContext
+from torch._library.fake_class_registry import FakeScriptObject
 from torch._logging import getArtifactLogger, trace_structured
+from torch._opaque_base import OpaqueBase
 from torch._subclasses import FakeTensor
 from torch._subclasses.meta_utils import is_sparse_any
 from torch.fx.experimental._backward_state import BackwardState
@@ -117,6 +114,10 @@ def _get_backward_output_order(
     bw_module: GraphModule,
     bw_outs: Any,
 ) -> list[int] | None:
+    PASSTHROUGH_PRIORITY = 2
+    SEQ_NR_PRIORITY = 1
+    STABLE_PRIORITY = 0
+
     topo_orders: dict[int, dict[torch.fx.Node, int]] = {}
 
     def get_topo_order(module: GraphModule) -> dict[torch.fx.Node, int]:
@@ -172,8 +173,10 @@ def _get_backward_output_order(
             return current, ()
 
         remaining = list(path)
-        while remaining and isinstance(current, Sequence) and not isinstance(
-            current, (str, bytes)
+        while (
+            remaining
+            and isinstance(current, Sequence)
+            and not isinstance(current, (str, bytes))
         ):
             index = remaining.pop(0)
             if index < -len(current) or index >= len(current):
@@ -186,7 +189,7 @@ def _get_backward_output_order(
         module: GraphModule,
         value: Any,
         remaining_path: tuple[int, ...] = (),
-    ) -> tuple[tuple[bool, int, int], ...]:
+    ) -> tuple[tuple[int, int, int], ...]:
         source, path = unwrap_getitems(value)
         full_path = path + remaining_path
         if not isinstance(source, torch.fx.Node):
@@ -195,9 +198,15 @@ def _get_backward_output_order(
         seq_nr = source.meta.get("seq_nr")
         has_seq_nr = isinstance(seq_nr, int)
         topo_idx = get_topo_order(module)[source]
+        if source.op == "placeholder":
+            priority_kind = PASSTHROUGH_PRIORITY
+        elif has_seq_nr:
+            priority_kind = SEQ_NR_PRIORITY
+        else:
+            priority_kind = STABLE_PRIORITY
         priority = (
             (
-                has_seq_nr,
+                priority_kind,
                 seq_nr if has_seq_nr else 0,
                 topo_idx if has_seq_nr else 0,
             ),
@@ -215,25 +224,29 @@ def _get_backward_output_order(
         return priority + build_priority(submodule, inner_value, inner_path)
 
     def compare_priority(
-        lhs: tuple[tuple[bool, int, int], ...],
-        rhs: tuple[tuple[bool, int, int], ...],
+        lhs: tuple[tuple[int, int, int], ...],
+        rhs: tuple[tuple[int, int, int], ...],
     ) -> int:
         shared_levels = min(len(lhs), len(rhs))
         for i in range(shared_levels):
-            lhs_level = lhs[i]
-            rhs_level = rhs[i]
-            lhs_has_seq_nr, lhs_seq_nr, lhs_topo_idx = lhs_level
-            rhs_has_seq_nr, rhs_seq_nr, rhs_topo_idx = rhs_level
-            if lhs_has_seq_nr != rhs_has_seq_nr:
-                return -1 if lhs_has_seq_nr else 1
-            if lhs_has_seq_nr:
+            lhs_kind, lhs_seq_nr, lhs_topo_idx = lhs[i]
+            rhs_kind, rhs_seq_nr, rhs_topo_idx = rhs[i]
+            if lhs_kind != rhs_kind:
+                return -1 if lhs_kind > rhs_kind else 1
+            if lhs_kind == SEQ_NR_PRIORITY:
                 if lhs_seq_nr != rhs_seq_nr:
                     return -1 if lhs_seq_nr > rhs_seq_nr else 1
                 if lhs_topo_idx != rhs_topo_idx:
                     return -1 if lhs_topo_idx > rhs_topo_idx else 1
         if len(lhs) != len(rhs):
             extra = lhs[shared_levels:] if len(lhs) > len(rhs) else rhs[shared_levels:]
-            if any(has_seq_nr for has_seq_nr, _, _ in extra) or shared_levels == 0:
+            if (
+                any(
+                    priority_kind != STABLE_PRIORITY
+                    for priority_kind, _, _ in extra
+                )
+                or shared_levels == 0
+            ):
                 return -1 if len(lhs) > len(rhs) else 1
         return 0
 

--- a/torch/_functorch/_aot_autograd/graph_compile.py
+++ b/torch/_functorch/_aot_autograd/graph_compile.py
@@ -117,33 +117,30 @@ def maybe_skip_decompose(aot_config: AOTConfig) -> Generator[None, None, None]:
 
 
 def _get_backward_output_order(
-    bw_module: GraphModule,
+    _bw_module: GraphModule,
     bw_outs: Any,
 ) -> list[int] | None:
-    topo_order = {node: i for i, node in enumerate(bw_module.graph.nodes)}
-
     def get_source_node(bw_out: Any) -> torch.fx.Node | None:
-        if not isinstance(bw_out, torch.fx.Node):
-            return None
-        if (
-            bw_out.op == "call_function"
-            and bw_out.target is operator.getitem
-            and isinstance(bw_out.args[0], torch.fx.Node)
-        ):
-            return bw_out.args[0]
-        return bw_out
+        while isinstance(bw_out, torch.fx.Node):
+            if bw_out.op != "call_function" or bw_out.target is not operator.getitem:
+                return bw_out
+            if not isinstance(bw_out.args[0], torch.fx.Node):
+                return bw_out
+            bw_out = bw_out.args[0]
+        return None
 
     def sort_key(idx: int) -> tuple[int, int]:
         source = get_source_node(bw_outs[idx])
         if source is None:
-            return (-1, -1)
+            return (0, 0)
         # Eager gives later forward ops priority in backward via sequence numbers.
-        # For tuple-producing nodes, use the shared source node so equal seq_nrs
-        # preserve the source node's output order.
+        # For tuple/list-producing nodes, use the shared source node so equal
+        # seq_nrs preserve the flattened output order. If eager recorded no
+        # priority for this output, keep the original index order.
         seq_nr = source.meta.get("seq_nr")
         if isinstance(seq_nr, int):
-            return (seq_nr, 0)
-        return (-1, topo_order[source])
+            return (1, seq_nr)
+        return (0, 0)
 
     order = sorted(range(len(bw_outs)), key=sort_key, reverse=True)
     return None if order == list(range(len(bw_outs))) else order

--- a/torch/_functorch/_aot_autograd/input_output_analysis.py
+++ b/torch/_functorch/_aot_autograd/input_output_analysis.py
@@ -40,6 +40,32 @@ from .utils import strict_zip
 zip = strict_zip
 
 
+def remap_backward_output_order(
+    backward_output_order: list[int] | None,
+    keep_arg_mask: list[bool],
+    add_dupe_map: list[int],
+) -> list[int] | None:
+    if backward_output_order is None:
+        return None
+
+    num_inputs = sum(keep_arg_mask)
+    remapped: list[int] = []
+    seen: set[int] = set()
+    for input_idx in backward_output_order:
+        deduped_idx = add_dupe_map[input_idx]
+        if deduped_idx in seen:
+            continue
+        seen.add(deduped_idx)
+        remapped.append(deduped_idx)
+
+    if len(remapped) != num_inputs:
+        raise AssertionError(
+            f"expected len(remapped) == {num_inputs}, got {len(remapped)}"
+        )
+
+    return None if remapped == list(range(num_inputs)) else remapped
+
+
 def remove_dupe_metadata(
     m: ViewAndMutationMeta,
     keep_arg_mask: list[bool],
@@ -110,6 +136,9 @@ def remove_dupe_metadata(
         subclass_fw_graph_out_meta=[],
         subclass_tangent_meta=subclass_tangent_meta,
         is_train=m.is_train,
+        backward_output_order=remap_backward_output_order(
+            m.backward_output_order, keep_arg_mask, add_dupe_map
+        ),
     )
 
 

--- a/torch/_functorch/_aot_autograd/runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/runtime_wrappers.py
@@ -3027,6 +3027,11 @@ Your tensor subclass must implement __coerce_same_metadata_as_tangent__."""
                 )
                 return out
 
+        if CompiledFunction.metadata.backward_output_order is not None:
+            CompiledFunction._backward_next_edges_order = (  # type: ignore[attr-defined]
+                CompiledFunction.metadata.backward_output_order
+            )
+
         compiled_function = RuntimeWrapper(
             indices_of_inps_to_detach=indices_of_inps_to_detach,
             trace_joint=True,

--- a/torch/_functorch/_aot_autograd/schemas.py
+++ b/torch/_functorch/_aot_autograd/schemas.py
@@ -536,6 +536,11 @@ class ViewAndMutationMeta:
     # help users identify where to add .detach() in their code
     tangent_source_stack_traces: list[str | None] | None = None
 
+    # Optional traversal order for autograd.Function backward outputs. AOTAutograd
+    # uses this to preserve eager hook scheduling when the backward graph is
+    # collapsed into a single autograd node.
+    backward_output_order: list[int] | None = None
+
     def __post_init__(self) -> None:
         # pre-compute the indices of the inputs that are mutated.
         # When keep_input_mutations is set, we don't need to worry about our epilogue

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -1189,7 +1189,7 @@ void Engine::evaluate_function(
       if (!exec_info_.empty()) {
         auto it = exec_info_.find(next.function.get());
         if (it == exec_info_.end() || !it->second.should_execute()) {
-          continue;
+          return;
         }
       }
       // No buffers have been allocated for the function

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -462,15 +462,17 @@ std::vector<Node*> get_current_graph_task_execution_order() {
     heap.pop();
 
     out.push_back(fn);
-    for (const auto& edge : fn->next_edges()) {
+    const auto output_order = fn->next_edges_order();
+    auto add_next_fn = [&](const size_t i) {
+      const auto& edge = fn->next_edge(i);
       Node* next_ptr = edge.function.get();
       if (!next_ptr) {
-        continue;
+        return;
       }
       if (check_exec_info) {
         auto it = task->exec_info_.find(next_ptr);
         if (it == task->exec_info_.end() || !it->second.should_execute()) {
-          continue;
+          return;
         }
       }
       auto it = dependencies.find(edge.function.get());
@@ -478,6 +480,17 @@ std::vector<Node*> get_current_graph_task_execution_order() {
       if (--it->second == 0) {
         dependencies.erase(it);
         heap.push(next_ptr);
+      }
+    };
+    if (output_order.empty()) {
+      for (const auto i : c10::irange(fn->next_edges().size())) {
+        add_next_fn(i);
+      }
+    } else {
+      TORCH_INTERNAL_ASSERT(output_order.size() == fn->next_edges().size());
+      for (const auto i : output_order) {
+        TORCH_INTERNAL_ASSERT(i < fn->next_edges().size());
+        add_next_fn(i);
       }
     }
   }

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -1161,12 +1161,13 @@ void Engine::evaluate_function(
   // Lock mutex for the accesses to GraphTask dependencies_, not_ready_ and
   // cpu_ready_queue_ below
   std::lock_guard<std::mutex> lock(graph_task->mutex_);
-  for (const auto i : c10::irange(num_outputs)) {
+  const auto output_order = fn.next_edges_order();
+  auto handle_output = [&](const size_t i) {
     auto& output = outputs[i];
     const auto& next = fn.next_edge(i);
 
     if (!next.is_valid())
-      continue;
+      return;
 
     // Check if the next function is ready to be computed
     bool is_ready = false;
@@ -1228,6 +1229,18 @@ void Engine::evaluate_function(
             NodeTask(graph_task, next.function, std::move(input_buffer)));
         not_ready.erase(not_ready_it);
       }
+    }
+  };
+
+  if (output_order.empty()) {
+    for (const auto i : c10::irange(num_outputs)) {
+      handle_output(i);
+    }
+  } else {
+    TORCH_INTERNAL_ASSERT(output_order.size() == num_outputs);
+    for (const auto i : output_order) {
+      TORCH_INTERNAL_ASSERT(i < num_outputs);
+      handle_output(i);
     }
   }
 }

--- a/torch/csrc/autograd/function.h
+++ b/torch/csrc/autograd/function.h
@@ -13,6 +13,7 @@
 #include <ATen/SequenceNumber.h>
 #include <ATen/core/Tensor.h>
 #include <ATen/record_function.h>
+#include <c10/util/ArrayRef.h>
 #include <c10/util/Exception.h>
 #include <c10/util/irange.h>
 
@@ -326,6 +327,13 @@ struct TORCH_API Node : std::enable_shared_from_this<Node> {
 
   uint32_t num_outputs() const noexcept {
     return next_edges_.size();
+  }
+
+  // Some nodes need to prioritize a subset of outputs when scheduling their
+  // next edges. When present, the engine visits outputs in this order while
+  // preserving the underlying output-to-edge mapping.
+  virtual c10::ArrayRef<uint32_t> next_edges_order() const noexcept {
+    return c10::ArrayRef<uint32_t>();
   }
 
   // Miscellaneous Methods

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -74,6 +74,68 @@ inline void check_legacy_fn_attr_access(
       "https://pytorch.org/docs/stable/autograd.html#torch.autograd.Function ");
 }
 
+std::vector<uint32_t> get_backward_next_edges_order(
+    PyObject* cls,
+    size_t num_next_edges) {
+  THPObjectPtr order_attr(PyObject_GetAttrString(cls, "_backward_next_edges_order"));
+  if (!order_attr) {
+    if (PyErr_ExceptionMatches(PyExc_AttributeError)) {
+      PyErr_Clear();
+      return {};
+    }
+    throw python_error();
+  }
+  if (order_attr.get() == Py_None) {
+    return {};
+  }
+
+  THPObjectPtr order_seq(PySequence_Fast(
+      order_attr.get(),
+      "autograd.Function._backward_next_edges_order must be a sequence"));
+  if (!order_seq) {
+    throw python_error();
+  }
+
+  const auto order_len =
+      static_cast<size_t>(PySequence_Fast_GET_SIZE(order_seq.get()));
+  TORCH_CHECK(
+      order_len == num_next_edges,
+      "autograd.Function._backward_next_edges_order must have length ",
+      num_next_edges,
+      ", got ",
+      order_len);
+
+  std::vector<bool> seen(num_next_edges, false);
+  std::vector<uint32_t> order;
+  order.reserve(order_len);
+  bool is_identity = true;
+
+  for (const auto i : c10::irange(order_len)) {
+    const auto idx =
+        THPUtils_unpackLong(PySequence_Fast_GET_ITEM(order_seq.get(), i));
+    if (PyErr_Occurred()) {
+      throw python_error();
+    }
+    TORCH_CHECK(
+        idx >= 0 && static_cast<size_t>(idx) < num_next_edges,
+        "autograd.Function._backward_next_edges_order must contain values in [0, ",
+        num_next_edges,
+        "), got ",
+        idx);
+    TORCH_CHECK(
+        !seen[idx],
+        "autograd.Function._backward_next_edges_order must be a permutation");
+    seen[idx] = true;
+    is_identity &= static_cast<size_t>(idx) == i;
+    order.push_back(static_cast<uint32_t>(idx));
+  }
+
+  if (is_identity) {
+    order.clear();
+  }
+  return order;
+}
+
 // TODO: We shouldn't need to call this function because the engine
 // can already persist the errors for us. This still seems to be
 // needed for the DistEngine however.
@@ -1372,7 +1434,11 @@ PyObject* THPFunction_apply(PyObject* cls, PyObject* inputs) {
 
   // Initialize backward function (and ctx)
   bool is_executable = input_info.is_executable;
+  auto next_edges_order = is_executable
+      ? get_backward_next_edges_order(cls, input_info.next_edges.size())
+      : std::vector<uint32_t>{};
   cdata->set_next_edges(std::move(input_info.next_edges));
+  cdata->set_next_edges_order(std::move(next_edges_order));
   ctx->needs_input_grad = input_info.needs_input_grad.release();
   ctx->is_variable_input = std::move(input_info.is_variable_input);
 

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -100,8 +100,7 @@ std::vector<uint32_t> get_backward_next_edges_order(
 
   const auto order_len =
       static_cast<size_t>(PySequence_Fast_GET_SIZE(order_seq.get()));
-  const auto num_forward_inputs =
-      static_cast<size_t>(is_variable_input.size());
+  const auto num_forward_inputs = static_cast<size_t>(is_variable_input.size());
   TORCH_CHECK(
       order_len == num_forward_inputs,
       "autograd.Function._backward_next_edges_order must have length ",

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -76,8 +76,10 @@ inline void check_legacy_fn_attr_access(
 
 std::vector<uint32_t> get_backward_next_edges_order(
     PyObject* cls,
+    const std::vector<bool>& is_variable_input,
     size_t num_next_edges) {
-  THPObjectPtr order_attr(PyObject_GetAttrString(cls, "_backward_next_edges_order"));
+  THPObjectPtr order_attr(
+      PyObject_GetAttrString(cls, "_backward_next_edges_order"));
   if (!order_attr) {
     if (PyErr_ExceptionMatches(PyExc_AttributeError)) {
       PyErr_Clear();
@@ -98,16 +100,27 @@ std::vector<uint32_t> get_backward_next_edges_order(
 
   const auto order_len =
       static_cast<size_t>(PySequence_Fast_GET_SIZE(order_seq.get()));
+  const auto num_forward_inputs =
+      static_cast<size_t>(is_variable_input.size());
   TORCH_CHECK(
-      order_len == num_next_edges,
+      order_len == num_forward_inputs,
       "autograd.Function._backward_next_edges_order must have length ",
-      num_next_edges,
+      num_forward_inputs,
       ", got ",
       order_len);
 
-  std::vector<bool> seen(num_next_edges, false);
+  std::vector<uint32_t> next_edge_idx_for_input(num_forward_inputs);
+  size_t next_edge_idx = 0;
+  for (const auto i : c10::irange(num_forward_inputs)) {
+    if (is_variable_input[i]) {
+      next_edge_idx_for_input[i] = next_edge_idx++;
+    }
+  }
+  TORCH_INTERNAL_ASSERT(next_edge_idx == num_next_edges);
+
+  std::vector<bool> seen(num_forward_inputs, false);
   std::vector<uint32_t> order;
-  order.reserve(order_len);
+  order.reserve(num_next_edges);
   bool is_identity = true;
 
   for (const auto i : c10::irange(order_len)) {
@@ -117,19 +130,24 @@ std::vector<uint32_t> get_backward_next_edges_order(
       throw python_error();
     }
     TORCH_CHECK(
-        idx >= 0 && static_cast<size_t>(idx) < num_next_edges,
+        idx >= 0 && static_cast<size_t>(idx) < num_forward_inputs,
         "autograd.Function._backward_next_edges_order must contain values in [0, ",
-        num_next_edges,
+        num_forward_inputs,
         "), got ",
         idx);
     TORCH_CHECK(
         !seen[idx],
         "autograd.Function._backward_next_edges_order must be a permutation");
     seen[idx] = true;
-    is_identity &= static_cast<size_t>(idx) == i;
-    order.push_back(static_cast<uint32_t>(idx));
+    if (!is_variable_input[idx]) {
+      continue;
+    }
+    const auto compressed_idx = next_edge_idx_for_input[idx];
+    is_identity &= static_cast<size_t>(compressed_idx) == order.size();
+    order.push_back(compressed_idx);
   }
 
+  TORCH_INTERNAL_ASSERT(order.size() == num_next_edges);
   if (is_identity) {
     order.clear();
   }
@@ -1435,7 +1453,8 @@ PyObject* THPFunction_apply(PyObject* cls, PyObject* inputs) {
   // Initialize backward function (and ctx)
   bool is_executable = input_info.is_executable;
   auto next_edges_order = is_executable
-      ? get_backward_next_edges_order(cls, input_info.next_edges.size())
+      ? get_backward_next_edges_order(
+            cls, input_info.is_variable_input, input_info.next_edges.size())
       : std::vector<uint32_t>{};
   cdata->set_next_edges(std::move(input_info.next_edges));
   cdata->set_next_edges_order(std::move(next_edges_order));

--- a/torch/csrc/autograd/python_function.h
+++ b/torch/csrc/autograd/python_function.h
@@ -51,8 +51,18 @@ struct PyNode : public Node {
       const variable_list& inputs,
       SwapSavedVariables& saved) override;
 
+  c10::ArrayRef<uint32_t> next_edges_order() const noexcept override {
+    return next_edges_order_;
+  }
+
+  void set_next_edges_order(std::vector<uint32_t> order) {
+    next_edges_order_ = std::move(order);
+  }
+
   // THPFunction this Function is wrapping.  Owning!
   PyObject* obj;
+
+  std::vector<uint32_t> next_edges_order_;
 
   // NOLINTNEXTLINE(bugprone-exception-escape)
   ~PyNode() override {

--- a/torch/csrc/dynamo/python_compiled_autograd.cpp
+++ b/torch/csrc/dynamo/python_compiled_autograd.cpp
@@ -965,7 +965,11 @@ static CacheNode* _compiled_autograd_impl(
       if (node_args.cond(call.needed)) {
         fn->compiled_args(node_args);
         node_args.collect(call.node->next_edges());
-        node_args.collect(fn->next_edges_order());
+        const auto output_order = fn->next_edges_order();
+        // The identity traversal does not need cache-key specialization.
+        if (!output_order.empty()) {
+          node_args.collect(output_order);
+        }
       }
       CacheKey key = node_args.key();
       if (vlogger.has_value() && !compile_reason.has_value()) {

--- a/torch/csrc/dynamo/python_compiled_autograd.cpp
+++ b/torch/csrc/dynamo/python_compiled_autograd.cpp
@@ -67,6 +67,38 @@ std::string TURN_OFF_COMPILED_AUTOGRAD_MSG() {
   return std::string(_TURN_OFF_COMPILED_AUTOGRAD_MSG);
 }
 
+template <typename Fn>
+void for_each_next_edge_index(const Node& node, Fn&& fn) {
+  const auto output_order = node.next_edges_order();
+  if (output_order.empty()) {
+    for (const auto i : c10::irange(node.next_edges().size())) {
+      fn(i);
+    }
+    return;
+  }
+  TORCH_INTERNAL_ASSERT(output_order.size() == node.next_edges().size());
+  for (const auto i : output_order) {
+    fn(i);
+  }
+}
+
+template <typename Fn>
+void for_each_next_edge_index_for_worklist(const Node& node, Fn&& fn) {
+  const auto output_order = node.next_edges_order();
+  if (output_order.empty()) {
+    for (const auto i : c10::irange(node.next_edges().size())) {
+      fn(i);
+    }
+    return;
+  }
+  TORCH_INTERNAL_ASSERT(output_order.size() == node.next_edges().size());
+  // Nodes are popped from the back of the worklist, so reverse the push order
+  // to preserve the requested next-edge execution order.
+  for (auto it = output_order.rbegin(); it != output_order.rend(); ++it) {
+    fn(*it);
+  }
+}
+
 } // namespace
 
 // see https://github.com/pytorch/pytorch/pull/34845
@@ -933,6 +965,7 @@ static CacheNode* _compiled_autograd_impl(
       if (node_args.cond(call.needed)) {
         fn->compiled_args(node_args);
         node_args.collect(call.node->next_edges());
+        node_args.collect(fn->next_edges_order());
       }
       CacheKey key = node_args.key();
       if (vlogger.has_value() && !compile_reason.has_value()) {
@@ -949,14 +982,15 @@ static CacheNode* _compiled_autograd_impl(
       cache = cache->lookup(key);
     }
 
-    for (const auto& edge : fn->next_edges()) {
+    for_each_next_edge_index_for_worklist(*fn, [&](size_t i) {
+      const auto& edge = fn->next_edge(i);
       if (!edge.is_valid()) {
-        continue;
+        return;
       }
       if (check_exec_info) {
         auto it = graph_task.exec_info_.find(edge.function.get());
         if (it == graph_task.exec_info_.end() || !it->second.should_execute()) {
-          continue;
+          return;
         }
         if (!it->second.needed_) {
           compiler_call.node_calls.lookup(edge.function).needed = false;
@@ -968,7 +1002,7 @@ static CacheNode* _compiled_autograd_impl(
       if (count == it->second) {
         worklist.emplace_back(edge.function);
       }
-    }
+    });
     i++;
   }
 
@@ -1131,7 +1165,7 @@ static CacheNode* _compiled_autograd_impl(
         }
         outputs = THPVariable_UnpackList(pyoutputs);
       }
-      for (const auto i : c10::irange(outputs.size())) {
+      for_each_next_edge_index(*call.node, [&](size_t i) {
         auto& output = outputs[i];
         const auto& next = call.node->next_edge(i);
         if (next.is_valid() && output.defined()) {
@@ -1139,7 +1173,7 @@ static CacheNode* _compiled_autograd_impl(
           buffer.buffer[next.input_nr] = call_accumulate(
               py_compiler, buffer.buffer[next.input_nr], output);
         }
-      }
+      });
     }
 
     PyObject* res = check(call_end_capture(py_compiler, state.outputs));


### PR DESCRIPTION
## Summary
Fix #144376

### Root cause
AOTAutograd collapses the backward graph into a single `autograd.Function`. When that node returns multiple leaf gradients at once, the autograd engine breaks ties using the custom function output order, which follows the flattened forward input order instead of eager's execution priority.

### Proposed fix
- Let `autograd.Function` nodes optionally provide a backward edge traversal order without changing the gradient-to-input mapping.
- Have AOTAutograd derive that order from backward graph metadata (`seq_nr`, with producer topology as a fallback) and attach it to `CompiledFunction`.
- Add a regression test that compares AOTAutograd hook order against eager for nontrivial parameter ordering.

### Why this is the right long term fix
This keeps gradient semantics unchanged and fixes the scheduling decision at the engine boundary, which is where the regression shows up. It also lets AOTAutograd communicate eager ordering directly instead of relying on backend-specific output reshuffles.

### Testing
- `python3 -m py_compile torch/_functorch/_aot_autograd/schemas.py torch/_functorch/_aot_autograd/graph_compile.py torch/_functorch/_aot_autograd/runtime_wrappers.py test/dynamo/test_hooks.py`

Drafted via @codex, published after manual review by @bobrenjc93

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @xmfan @aditvenk