### PR TITLE
[torch.compile] Reject mixed-dtype ConvTranspose during fake conv tracing

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -4230,6 +4230,27 @@ class CommonTemplate:
         with self.assertRaisesRegex(RuntimeError, "Autograd not support dtype:.*"):
             torch.compile(fn)(t)
 
+    def test_conv_transpose_mixed_dtype(self):
+        if self.device not in ("cpu", "cuda"):
+            raise unittest.SkipTest(
+                "mixed-dtype conv_transpose regression is CPU/CUDA only"
+            )
+
+        class Net(nn.Module):
+            def __init__(self) -> None:
+                super(Net, self).__init__()  # noqa: UP008
+                self.deconv = nn.ConvTranspose2d(1, 1, kernel_size=1)
+
+            def forward(self, x):
+                return self.deconv(x)
+
+        fn = Net().to(self.device)
+        t = torch.randn(1, 1, 1, 1, device=self.device, dtype=torch.float16)
+
+        with self.assertRaisesRegex(RuntimeError, "should be the same"):
+            with torch.no_grad():
+                torch.compile(fn)(t)
+
     @unittest.skipIf(
         not IS_BIG_GPU, "Skipping triton backend only since not big GPU (not enough SM)"
     )

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -4247,7 +4247,9 @@ class CommonTemplate:
         fn = Net().to(self.device)
         t = torch.randn(1, 1, 1, 1, device=self.device, dtype=torch.float16)
 
-        with self.assertRaisesRegex(RuntimeError, "should be the same"):
+        with self.assertRaisesRegex(
+            RuntimeError, "should be the same|expected scalar type"
+        ):
             with torch.no_grad():
                 torch.compile(fn)(t)
 

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -1855,7 +1855,9 @@ class FakeTensorOperatorInvariants(TestCase):
             grad_output = torch.randn(2, 3, 4, 4, dtype=torch.float16)
             inp = torch.randn(2, 3, 4, 4, dtype=torch.float16)
             weight = torch.randn(3, 3, 1, 1, dtype=torch.float32)
-            error_regex = "should be the same|expected scalar type"
+            error_regex = (
+                "should be the same|expected scalar type|primitive descriptor"
+            )
 
             with self.assertRaisesRegex(RuntimeError, error_regex):
                 torch.ops.aten.convolution_backward(
@@ -1871,6 +1873,53 @@ class FakeTensorOperatorInvariants(TestCase):
                     1,
                     [True, True, False],
                 )
+
+    def test_conv_transpose_empty_input_skips_same_type_check(self):
+        with FakeTensorMode():
+            inp = torch.randn(0, 3, 4, 4, dtype=torch.float16)
+            weight = torch.randn(3, 3, 1, 1, dtype=torch.float32)
+
+            out = torch.ops.aten.convolution(
+                inp,
+                weight,
+                None,
+                [1, 1],
+                [0, 0],
+                [1, 1],
+                True,
+                [0, 0],
+                1,
+            )
+
+            self.assertEqual(out.shape, (0, 3, 4, 4))
+            self.assertEqual(out.dtype, torch.promote_types(inp.dtype, weight.dtype))
+
+    def test_conv_transpose_backward_empty_input_skips_same_type_check(self):
+        with FakeTensorMode():
+            grad_output = torch.randn(0, 3, 4, 4, dtype=torch.float16)
+            inp = torch.randn(0, 3, 4, 4, dtype=torch.float16)
+            weight = torch.randn(3, 3, 1, 1, dtype=torch.float32)
+
+            grad_input, grad_weight, grad_bias = torch.ops.aten.convolution_backward(
+                grad_output,
+                inp,
+                weight,
+                [3],
+                [1, 1],
+                [0, 0],
+                [1, 1],
+                True,
+                [0, 0],
+                1,
+                [True, True, True],
+            )
+
+            self.assertEqual(grad_input.shape, inp.shape)
+            self.assertEqual(grad_input.dtype, inp.dtype)
+            self.assertEqual(grad_weight.shape, weight.shape)
+            self.assertEqual(grad_weight.dtype, weight.dtype)
+            self.assertEqual(grad_bias.shape, (3,))
+            self.assertEqual(grad_bias.dtype, weight.dtype)
 
     @unittest.skipIf(not RUN_CUDA, "requires cuda")
     def test_conv_transpose_device_mismatch_errors(self):

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -1892,25 +1892,46 @@ class FakeTensorOperatorInvariants(TestCase):
             self.assertEqual(out.shape, (0, 3, 4, 4))
             self.assertEqual(out.dtype, inp.dtype)
 
-    def test_conv_transpose_empty_channel_promotes_dtype(self):
+    def test_conv_transpose_empty_batch_bias_cast_errors(self):
         with FakeTensorMode():
-            inp = torch.randn(2, 0, 4, 4, dtype=torch.float16)
-            weight = torch.randn(0, 3, 1, 1, dtype=torch.float32)
+            inp = torch.randn(0, 3, 4, 4, dtype=torch.float16)
+            weight = torch.randn(3, 3, 1, 1, dtype=torch.float32)
+            bias = torch.randn(3, dtype=torch.float64)
 
-            out = torch.ops.aten.convolution(
-                inp,
-                weight,
-                None,
-                [1, 1],
-                [0, 0],
-                [1, 1],
-                True,
-                [0, 0],
-                1,
-            )
+            with self.assertRaisesRegex(
+                RuntimeError, "can't be cast to the desired output type"
+            ):
+                torch.ops.aten.convolution(
+                    inp,
+                    weight,
+                    bias,
+                    [1, 1],
+                    [0, 0],
+                    [1, 1],
+                    True,
+                    [0, 0],
+                    1,
+                )
 
-            self.assertEqual(out.shape, (2, 0, 4, 4))
-            self.assertEqual(out.dtype, torch.promote_types(inp.dtype, weight.dtype))
+    def test_conv_transpose_empty_channel_shape_errors(self):
+        with FakeTensorMode():
+            inp = torch.randn(2, 0, 4, 4)
+            weight = torch.randn(0, 3, 1, 1)
+
+            with self.assertRaisesRegex(
+                RuntimeError, "expected weight to be at least 1 at dimension 0"
+            ):
+                torch.ops.aten.convolution(
+                    inp,
+                    weight,
+                    None,
+                    [1, 1],
+                    [0, 0],
+                    [1, 1],
+                    True,
+                    [0, 0],
+                    1,
+                )
 
     def test_conv_transpose_backward_empty_batch_skips_same_type_check(self):
         with FakeTensorMode():
@@ -1939,30 +1960,36 @@ class FakeTensorOperatorInvariants(TestCase):
             self.assertEqual(grad_bias.shape, (3,))
             self.assertEqual(grad_bias.dtype, weight.dtype)
 
+    def test_conv_transpose_backward_empty_batch_preserves_channels_last(self):
+        with FakeTensorMode():
+            grad_output = torch.randn(0, 3, 4, 4).to(memory_format=torch.channels_last)
+            inp = torch.randn(0, 3, 4, 4).to(memory_format=torch.channels_last)
+            weight = torch.randn(3, 3, 1, 1).to(memory_format=torch.channels_last)
+
+            grad_input, grad_weight, _ = torch.ops.aten.convolution_backward(
+                grad_output,
+                inp,
+                weight,
+                [3],
+                [1, 1],
+                [0, 0],
+                [1, 1],
+                True,
+                [0, 0],
+                1,
+                [True, True, False],
+            )
+
+            self.assertTrue(grad_input.is_contiguous(memory_format=torch.channels_last))
+            self.assertTrue(
+                grad_weight.is_contiguous(memory_format=torch.channels_last)
+            )
+
     @unittest.skipIf(not RUN_CUDA, "requires cuda")
     def test_conv_transpose_device_mismatch_errors(self):
         with FakeTensorMode():
             inp = torch.randn(2, 3, 4, 4, device="cuda")
             weight = torch.randn(3, 3, 1, 1, device="cpu")
-
-            with self.assertRaisesRegex(RuntimeError, "should be the same"):
-                torch.ops.aten.convolution(
-                    inp,
-                    weight,
-                    None,
-                    [1, 1],
-                    [0, 0],
-                    [1, 1],
-                    True,
-                    [0, 0],
-                    1,
-                )
-
-    @unittest.skipIf(not RUN_CUDA, "requires cuda")
-    def test_conv_transpose_empty_channel_device_mismatch_errors(self):
-        with FakeTensorMode():
-            inp = torch.randn(2, 0, 4, 4, device="cuda")
-            weight = torch.randn(0, 3, 1, 1, device="cpu")
 
             with self.assertRaisesRegex(RuntimeError, "should be the same"):
                 torch.ops.aten.convolution(

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -1850,6 +1850,25 @@ class FakeTensorOperatorInvariants(TestCase):
                     1,
                 )
 
+    @unittest.skipIf(not RUN_CUDA, "requires cuda")
+    def test_conv_transpose_device_mismatch_errors(self):
+        with FakeTensorMode():
+            inp = torch.randn(2, 3, 4, 4, device="cuda")
+            weight = torch.randn(3, 3, 1, 1, device="cpu")
+
+            with self.assertRaisesRegex(RuntimeError, "should be the same"):
+                torch.ops.aten.convolution(
+                    inp,
+                    weight,
+                    None,
+                    [1, 1],
+                    [0, 0],
+                    [1, 1],
+                    True,
+                    [0, 0],
+                    1,
+                )
+
     def test_no_dispatch_with_like_function(self):
         class CountingMode(TorchDispatchMode):
             def __init__(self) -> None:

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -1831,13 +1831,13 @@ class FakeTensorOperatorInvariants(TestCase):
             self.assertTrue(grad_input_c.is_contiguous())
             self.assertTrue(grad_weight_c.is_contiguous())
 
-    def test_convolution_dtype_mismatch_errors(self):
+    def test_conv_transpose_dtype_mismatch_errors(self):
         with FakeTensorMode():
             inp = torch.randn(2, 3, 4, 4, dtype=torch.float16)
-            grad_out = torch.randn(2, 3, 4, 4, dtype=torch.float16)
             weight = torch.randn(3, 3, 1, 1, dtype=torch.float32)
+            error_regex = "should be the same|expected scalar type"
 
-            with self.assertRaisesRegex(RuntimeError, "should be the same"):
+            with self.assertRaisesRegex(RuntimeError, error_regex):
                 torch.ops.aten.convolution(
                     inp,
                     weight,
@@ -1845,24 +1845,9 @@ class FakeTensorOperatorInvariants(TestCase):
                     [1, 1],
                     [0, 0],
                     [1, 1],
-                    False,
+                    True,
                     [0, 0],
                     1,
-                )
-
-            with self.assertRaisesRegex(RuntimeError, "should be the same"):
-                torch.ops.aten.convolution_backward(
-                    grad_out,
-                    inp,
-                    weight,
-                    None,
-                    [1, 1],
-                    [0, 0],
-                    [1, 1],
-                    False,
-                    [0, 0],
-                    1,
-                    [True, False, False],
                 )
 
     def test_no_dispatch_with_like_function(self):

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -1831,6 +1831,40 @@ class FakeTensorOperatorInvariants(TestCase):
             self.assertTrue(grad_input_c.is_contiguous())
             self.assertTrue(grad_weight_c.is_contiguous())
 
+    def test_convolution_dtype_mismatch_errors(self):
+        with FakeTensorMode():
+            inp = torch.randn(2, 3, 4, 4, dtype=torch.float16)
+            grad_out = torch.randn(2, 3, 4, 4, dtype=torch.float16)
+            weight = torch.randn(3, 3, 1, 1, dtype=torch.float32)
+
+            with self.assertRaisesRegex(RuntimeError, "should be the same"):
+                torch.ops.aten.convolution(
+                    inp,
+                    weight,
+                    None,
+                    [1, 1],
+                    [0, 0],
+                    [1, 1],
+                    False,
+                    [0, 0],
+                    1,
+                )
+
+            with self.assertRaisesRegex(RuntimeError, "should be the same"):
+                torch.ops.aten.convolution_backward(
+                    grad_out,
+                    inp,
+                    weight,
+                    None,
+                    [1, 1],
+                    [0, 0],
+                    [1, 1],
+                    False,
+                    [0, 0],
+                    1,
+                    [True, False, False],
+                )
+
     def test_no_dispatch_with_like_function(self):
         class CountingMode(TorchDispatchMode):
             def __init__(self) -> None:

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -1850,6 +1850,28 @@ class FakeTensorOperatorInvariants(TestCase):
                     1,
                 )
 
+    def test_conv_transpose_backward_dtype_mismatch_errors(self):
+        with FakeTensorMode():
+            grad_output = torch.randn(2, 3, 4, 4, dtype=torch.float16)
+            inp = torch.randn(2, 3, 4, 4, dtype=torch.float16)
+            weight = torch.randn(3, 3, 1, 1, dtype=torch.float32)
+            error_regex = "should be the same|expected scalar type"
+
+            with self.assertRaisesRegex(RuntimeError, error_regex):
+                torch.ops.aten.convolution_backward(
+                    grad_output,
+                    inp,
+                    weight,
+                    [3],
+                    [1, 1],
+                    [0, 0],
+                    [1, 1],
+                    True,
+                    [0, 0],
+                    1,
+                    [True, True, False],
+                )
+
     @unittest.skipIf(not RUN_CUDA, "requires cuda")
     def test_conv_transpose_device_mismatch_errors(self):
         with FakeTensorMode():
@@ -1867,6 +1889,28 @@ class FakeTensorOperatorInvariants(TestCase):
                     True,
                     [0, 0],
                     1,
+                )
+
+    @unittest.skipIf(not RUN_CUDA, "requires cuda")
+    def test_conv_transpose_backward_device_mismatch_errors(self):
+        with FakeTensorMode():
+            grad_output = torch.randn(2, 3, 4, 4, device="cuda")
+            inp = torch.randn(2, 3, 4, 4, device="cuda")
+            weight = torch.randn(3, 3, 1, 1, device="cpu")
+
+            with self.assertRaisesRegex(RuntimeError, "should be the same"):
+                torch.ops.aten.convolution_backward(
+                    grad_output,
+                    inp,
+                    weight,
+                    [3],
+                    [1, 1],
+                    [0, 0],
+                    [1, 1],
+                    True,
+                    [0, 0],
+                    1,
+                    [True, True, False],
                 )
 
     def test_no_dispatch_with_like_function(self):

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -1855,9 +1855,7 @@ class FakeTensorOperatorInvariants(TestCase):
             grad_output = torch.randn(2, 3, 4, 4, dtype=torch.float16)
             inp = torch.randn(2, 3, 4, 4, dtype=torch.float16)
             weight = torch.randn(3, 3, 1, 1, dtype=torch.float32)
-            error_regex = (
-                "should be the same|expected scalar type|primitive descriptor"
-            )
+            error_regex = "should be the same|expected scalar type|primitive descriptor"
 
             with self.assertRaisesRegex(RuntimeError, error_regex):
                 torch.ops.aten.convolution_backward(
@@ -1874,7 +1872,7 @@ class FakeTensorOperatorInvariants(TestCase):
                     [True, True, False],
                 )
 
-    def test_conv_transpose_empty_input_skips_same_type_check(self):
+    def test_conv_transpose_empty_batch_skips_same_type_check(self):
         with FakeTensorMode():
             inp = torch.randn(0, 3, 4, 4, dtype=torch.float16)
             weight = torch.randn(3, 3, 1, 1, dtype=torch.float32)
@@ -1892,9 +1890,29 @@ class FakeTensorOperatorInvariants(TestCase):
             )
 
             self.assertEqual(out.shape, (0, 3, 4, 4))
+            self.assertEqual(out.dtype, inp.dtype)
+
+    def test_conv_transpose_empty_channel_promotes_dtype(self):
+        with FakeTensorMode():
+            inp = torch.randn(2, 0, 4, 4, dtype=torch.float16)
+            weight = torch.randn(0, 3, 1, 1, dtype=torch.float32)
+
+            out = torch.ops.aten.convolution(
+                inp,
+                weight,
+                None,
+                [1, 1],
+                [0, 0],
+                [1, 1],
+                True,
+                [0, 0],
+                1,
+            )
+
+            self.assertEqual(out.shape, (2, 0, 4, 4))
             self.assertEqual(out.dtype, torch.promote_types(inp.dtype, weight.dtype))
 
-    def test_conv_transpose_backward_empty_input_skips_same_type_check(self):
+    def test_conv_transpose_backward_empty_batch_skips_same_type_check(self):
         with FakeTensorMode():
             grad_output = torch.randn(0, 3, 4, 4, dtype=torch.float16)
             inp = torch.randn(0, 3, 4, 4, dtype=torch.float16)
@@ -1926,6 +1944,25 @@ class FakeTensorOperatorInvariants(TestCase):
         with FakeTensorMode():
             inp = torch.randn(2, 3, 4, 4, device="cuda")
             weight = torch.randn(3, 3, 1, 1, device="cpu")
+
+            with self.assertRaisesRegex(RuntimeError, "should be the same"):
+                torch.ops.aten.convolution(
+                    inp,
+                    weight,
+                    None,
+                    [1, 1],
+                    [0, 0],
+                    [1, 1],
+                    True,
+                    [0, 0],
+                    1,
+                )
+
+    @unittest.skipIf(not RUN_CUDA, "requires cuda")
+    def test_conv_transpose_empty_channel_device_mismatch_errors(self):
+        with FakeTensorMode():
+            inp = torch.randn(2, 0, 4, 4, device="cuda")
+            weight = torch.randn(0, 3, 1, 1, device="cpu")
 
             with self.assertRaisesRegex(RuntimeError, "should be the same"):
                 torch.ops.aten.convolution(

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -2603,6 +2603,51 @@ def _check_conv_input_same_type_as_parameters(
         )
 
 
+def _is_empty_conv_input(input_tensor: torch.Tensor) -> bool:
+    from torch.fx.experimental.symbolic_shapes import guard_or_false
+
+    return guard_or_false(input_tensor.size(0) == 0) or guard_or_false(
+        input_tensor.size(1) == 0
+    )
+
+
+def _should_check_conv_input_same_type_as_parameters(
+    input_tensor: torch.Tensor,
+) -> bool:
+    if _is_empty_conv_input(input_tensor):
+        return False
+
+    # Eager skips the generic same-type checks for overrideable backends and
+    # lets the backend implementation decide how to handle mixed dtype/device
+    # ConvTranspose inputs.
+    input_device_type = _conv_device_or_fake_device(input_tensor).type
+    return input_tensor.is_mkldnn or input_device_type in (
+        "cpu",
+        "cuda",
+        "meta",
+        "mps",
+    )
+
+
+def _conv_empty_output_dtype(
+    input_tensor: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None = None,
+) -> torch.dtype:
+    if input_tensor.is_mkldnn:
+        return input_tensor.dtype
+
+    promote_args = [input_tensor, weight]
+    if bias is not None:
+        promote_args.append(bias)
+
+    _, result_dtype = utils.elementwise_dtypes(
+        *promote_args,
+        type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT,
+    )
+    return result_dtype
+
+
 @register_meta(aten.miopen_batch_norm.default)
 def meta_miopen_batch_norm(
     input_tensor: torch.Tensor,
@@ -2653,7 +2698,9 @@ def meta_conv(
     output_padding: list[int],
     groups: int,
 ):
-    if is_transposed:
+    if is_transposed and _should_check_conv_input_same_type_as_parameters(
+        input_tensor
+    ):
         # Keep fake/meta validation aligned with eager so invalid ConvTranspose
         # inputs fail during tracing instead of compiling incorrect kernels.
         _check_conv_input_same_type_as_parameters(input_tensor, weight, bias)
@@ -2675,6 +2722,12 @@ def meta_conv(
     output_channels_dim = 1
     if guard_or_false(input_tensor.size(input_channels_dim) == 0):
         shape_out[output_channels_dim] = 0
+
+    if is_transposed and _is_empty_conv_input(input_tensor):
+        return input_tensor.new_empty(
+            shape_out,
+            dtype=_conv_empty_output_dtype(input_tensor, weight, bias),
+        )
 
     out = input_tensor.new_empty(shape_out)
     return out
@@ -3754,7 +3807,16 @@ def meta_convolution_backward(
             return torch.channels_last_3d
         return torch.contiguous_format
 
-    if transposed:
+    if transposed and _is_empty_conv_input(input_):
+        if output_mask[0]:
+            backend_grad_input = input_.new_empty(input_.size())
+        if output_mask[1]:
+            backend_grad_weight = weight_.new_empty(weight_.size())
+        if output_mask[2]:
+            backend_grad_bias = weight_.new_empty(bias_sizes_opt)
+        return (backend_grad_input, backend_grad_weight, backend_grad_bias)
+
+    if transposed and _should_check_conv_input_same_type_as_parameters(input_):
         _check_conv_input_same_type_as_parameters(input_, weight_)
 
     if output_mask[0]:

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -2603,14 +2603,55 @@ def _check_conv_input_same_type_as_parameters(
         )
 
 
-def _check_empty_channel_conv_input_same_device(
-    input_tensor: torch.Tensor, weight: torch.Tensor
+def _check_transposed_conv_input_shape(
+    input_tensor: torch.Tensor,
+    weight: torch.Tensor,
+    groups: int,
+    bias: torch.Tensor | None = None,
 ) -> None:
     torch._check(
-        _conv_device_or_fake_device(input_tensor)
-        == _conv_device_or_fake_device(weight),
-        lambda: _conv_input_type_error_message(input_tensor, weight, "weight"),
+        groups > 0,
+        lambda: f"expected groups to be greater than 0, but got groups={groups}",
     )
+    torch._check(
+        weight.ndim == input_tensor.ndim,
+        lambda: (
+            f"Expected {weight.ndim}-dimensional input for {weight.ndim}-dimensional "
+            f"weight {list(weight.shape)}, but got {input_tensor.ndim}-dimensional "
+            f"input of size {list(input_tensor.shape)} instead"
+        ),
+    )
+    torch._check(
+        weight.shape[0] >= groups,
+        lambda: (
+            f"Given groups={groups}, expected weight to be at least {groups} "
+            f"at dimension 0, but got weight of size {list(weight.shape)} instead"
+        ),
+    )
+    torch._check(
+        weight.shape[0] % groups == 0,
+        lambda: (
+            f"Given groups={groups}, expected weight to be divisible by {groups} "
+            f"at dimension 0, but got weight of size {list(weight.shape)} instead"
+        ),
+    )
+    torch._check(
+        input_tensor.shape[1] == weight.shape[0],
+        lambda: (
+            f"Given transposed=True, weight of size {list(weight.shape)}, expected "
+            f"input{list(input_tensor.shape)} to have {weight.shape[0]} channels, "
+            f"but got {input_tensor.shape[1]} channels instead"
+        ),
+    )
+    if bias is not None:
+        torch._check(
+            bias.ndim == 1 and bias.shape[0] == weight.shape[1] * groups,
+            lambda: (
+                f"Given transposed=True, weight of size {list(weight.shape)}, expected "
+                f"bias to be 1-dimensional with {weight.shape[1] * groups} elements, "
+                f"but got bias of size {list(bias.shape)} instead"
+            ),
+        )
 
 
 def _is_empty_batch_conv_input(input_tensor: torch.Tensor) -> bool:
@@ -2619,27 +2660,15 @@ def _is_empty_batch_conv_input(input_tensor: torch.Tensor) -> bool:
     return guard_or_false(input_tensor.size(0) == 0)
 
 
-def _is_empty_channel_conv_input(input_tensor: torch.Tensor) -> bool:
-    from torch.fx.experimental.symbolic_shapes import guard_or_false
-
-    return guard_or_false(input_tensor.size(1) == 0)
-
-
-def _is_empty_conv_input(input_tensor: torch.Tensor) -> bool:
-    return _is_empty_batch_conv_input(input_tensor) or _is_empty_channel_conv_input(
-        input_tensor
-    )
-
-
 def _should_check_conv_input_same_type_as_parameters(
     input_tensor: torch.Tensor,
 ) -> bool:
-    if _is_empty_conv_input(input_tensor):
+    if _is_empty_batch_conv_input(input_tensor):
         return False
 
-    # Eager skips the generic same-type checks for overrideable backends and
-    # lets the backend implementation decide how to handle mixed dtype/device
-    # ConvTranspose inputs.
+    # Eager skips the generic same-type checks for batch-empty inputs because
+    # those select Empty/MkldnnEmpty before same-type validation, and it lets
+    # overrideable backends decide their own ConvTranspose dtype/device policy.
     input_device_type = _conv_device_or_fake_device(input_tensor).type
     return input_tensor.is_mkldnn or input_device_type in (
         "cpu",
@@ -2657,23 +2686,19 @@ def _conv_empty_output_dtype(
     if input_tensor.is_mkldnn:
         return input_tensor.dtype
 
-    # Eager's Empty backend uses a scalar weight/bias for zero-batch inputs but
-    # multiplies by the full weight tensor for zero-channel inputs.
-    if _is_empty_batch_conv_input(input_tensor) and not _is_empty_channel_conv_input(
-        input_tensor
-    ):
-        promote_args = [input_tensor, weight.new_empty(())]
-        if bias is not None:
-            promote_args.append(bias.new_empty(()))
-    else:
-        promote_args = [input_tensor, weight]
-        if bias is not None:
-            promote_args.append(bias)
-
     _, result_dtype = utils.elementwise_dtypes(
-        *promote_args,
+        input_tensor,
+        weight.new_empty(()),
         type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT,
     )
+    if bias is not None:
+        torch._check(
+            utils.can_safe_cast_to(cast_to=result_dtype, cast_from=bias.dtype),
+            lambda: (
+                f"result type {bias.dtype} can't be cast to the desired output "
+                f"type {result_dtype}"
+            ),
+        )
     return result_dtype
 
 
@@ -2727,9 +2752,10 @@ def meta_conv(
     output_padding: list[int],
     groups: int,
 ):
-    if is_transposed and _should_check_conv_input_same_type_as_parameters(
-        input_tensor
-    ):
+    if is_transposed:
+        _check_transposed_conv_input_shape(input_tensor, weight, groups, bias)
+
+    if is_transposed and _should_check_conv_input_same_type_as_parameters(input_tensor):
         # Keep fake/meta validation aligned with eager so invalid ConvTranspose
         # inputs fail during tracing instead of compiling incorrect kernels.
         _check_conv_input_same_type_as_parameters(input_tensor, weight, bias)
@@ -2752,10 +2778,7 @@ def meta_conv(
     if guard_or_false(input_tensor.size(input_channels_dim) == 0):
         shape_out[output_channels_dim] = 0
 
-    if is_transposed and _is_empty_channel_conv_input(input_tensor):
-        _check_empty_channel_conv_input_same_device(input_tensor, weight)
-
-    if is_transposed and _is_empty_conv_input(input_tensor):
+    if is_transposed and _is_empty_batch_conv_input(input_tensor):
         return input_tensor.new_empty(
             shape_out,
             dtype=_conv_empty_output_dtype(input_tensor, weight, bias),
@@ -3839,11 +3862,20 @@ def meta_convolution_backward(
             return torch.channels_last_3d
         return torch.contiguous_format
 
-    if transposed and _is_empty_conv_input(input_):
+    if transposed:
+        _check_transposed_conv_input_shape(input_, weight_, groups)
+
+    if transposed and _is_empty_batch_conv_input(input_):
         if output_mask[0]:
-            backend_grad_input = input_.new_empty(input_.size())
+            memory_format = _conv_memory_format(grad_output_, weight_)
+            backend_grad_input = input_.new_empty(input_.size()).to(
+                memory_format=memory_format
+            )
         if output_mask[1]:
-            backend_grad_weight = weight_.new_empty(weight_.size())
+            memory_format = _conv_memory_format(input_, grad_output_)
+            backend_grad_weight = weight_.new_empty(weight_.size()).to(
+                memory_format=memory_format
+            )
         if output_mask[2]:
             backend_grad_bias = weight_.new_empty(bias_sizes_opt)
         return (backend_grad_input, backend_grad_weight, backend_grad_bias)

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -2549,6 +2549,60 @@ def is_channels_last(ten):
     return torch._prims_common.suggest_memory_format(ten) == torch.channels_last
 
 
+def _conv_device_or_fake_device(tensor: torch.Tensor) -> torch.device:
+    if isinstance(tensor, torch._subclasses.FakeTensor):
+        return tensor.fake_device
+    return tensor.device
+
+
+def _has_same_type_as_conv_input(
+    input_tensor: torch.Tensor, other: torch.Tensor
+) -> bool:
+    other_device = _conv_device_or_fake_device(other)
+    if (
+        input_tensor.dtype == other.dtype
+        and _conv_device_or_fake_device(input_tensor) == other_device
+        and input_tensor.is_mkldnn == other.is_mkldnn
+    ):
+        return True
+    return (
+        input_tensor.is_mkldnn
+        and not other.is_mkldnn
+        and other_device.type == "cpu"
+        and other.dtype == torch.float
+    )
+
+
+def _conv_input_type_error_message(
+    input_tensor: torch.Tensor, other: torch.Tensor, other_name: str
+) -> str:
+    message = (
+        f"Input type ({input_tensor.type()}) and {other_name} type "
+        f"({other.type()}) should be the same"
+    )
+    if input_tensor.is_mkldnn:
+        message += (
+            f" or input should be a MKLDNN tensor and {other_name} is a dense tensor"
+        )
+    return message
+
+
+def _check_conv_input_same_type_as_parameters(
+    input_tensor: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None = None,
+) -> None:
+    torch._check(
+        _has_same_type_as_conv_input(input_tensor, weight),
+        lambda: _conv_input_type_error_message(input_tensor, weight, "weight"),
+    )
+    if bias is not None:
+        torch._check(
+            _has_same_type_as_conv_input(input_tensor, bias),
+            lambda: _conv_input_type_error_message(input_tensor, bias, "bias"),
+        )
+
+
 @register_meta(aten.miopen_batch_norm.default)
 def meta_miopen_batch_norm(
     input_tensor: torch.Tensor,
@@ -2600,48 +2654,9 @@ def meta_conv(
     groups: int,
 ):
     if is_transposed:
-        def _device_or_fake_device(tensor: torch.Tensor) -> torch.device:
-            if isinstance(tensor, torch._subclasses.FakeTensor):
-                return tensor.fake_device
-            return tensor.device
-
-        def _same_type_as_input(other: torch.Tensor) -> bool:
-            other_device = _device_or_fake_device(other)
-            if (
-                input_tensor.dtype == other.dtype
-                and _device_or_fake_device(input_tensor) == other_device
-                and input_tensor.is_mkldnn == other.is_mkldnn
-            ):
-                return True
-            return (
-                input_tensor.is_mkldnn
-                and not other.is_mkldnn
-                and other_device.type == "cpu"
-                and other.dtype == torch.float
-            )
-
-        def _error_message(other: torch.Tensor, other_name: str) -> str:
-            message = (
-                f"Input type ({input_tensor.type()}) and {other_name} type "
-                f"({other.type()}) should be the same"
-            )
-            if input_tensor.is_mkldnn:
-                message += (
-                    f" or input should be a MKLDNN tensor and {other_name} is a dense tensor"
-                )
-            return message
-
         # Keep fake/meta validation aligned with eager so invalid ConvTranspose
         # inputs fail during tracing instead of compiling incorrect kernels.
-        torch._check(
-            _same_type_as_input(weight),
-            lambda: _error_message(weight, "weight"),
-        )
-        if bias is not None:
-            torch._check(
-                _same_type_as_input(bias),
-                lambda: _error_message(bias, "bias"),
-            )
+        _check_conv_input_same_type_as_parameters(input_tensor, weight, bias)
 
     shape_out = calc_conv_nd_return_shape(
         input_tensor,
@@ -3738,6 +3753,9 @@ def meta_convolution_backward(
         if fmt1 == torch.channels_last_3d or fmt2 == torch.channels_last_3d:
             return torch.channels_last_3d
         return torch.contiguous_format
+
+    if transposed:
+        _check_conv_input_same_type_as_parameters(input_, weight_)
 
     if output_mask[0]:
         memory_format = _conv_memory_format(grad_output_, weight_)

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -2599,22 +2599,43 @@ def meta_conv(
     output_padding: list[int],
     groups: int,
 ):
-    def _check_same_type(
-        tensor: torch.Tensor, other: torch.Tensor, tensor_name: str, other_name: str
-    ) -> None:
-        # Keep fake/meta validation aligned with eager so invalid convolutions
-        # fail during tracing instead of compiling incorrect kernels.
-        torch._check(
-            tensor.dtype == other.dtype and tensor.device == other.device,
-            lambda: (
-                f"{tensor_name} type ({tensor.type()}) and {other_name} type "
-                f"({other.type()}) should be the same"
-            ),
-        )
+    if is_transposed:
+        def _same_type_as_input(other: torch.Tensor) -> bool:
+            if (
+                input_tensor.dtype == other.dtype
+                and input_tensor.device == other.device
+                and input_tensor.is_mkldnn == other.is_mkldnn
+            ):
+                return True
+            return (
+                input_tensor.is_mkldnn
+                and not other.is_mkldnn
+                and other.device.type == "cpu"
+                and other.dtype == torch.float
+            )
 
-    _check_same_type(input_tensor, weight, "Input", "weight")
-    if bias is not None:
-        _check_same_type(input_tensor, bias, "Input", "bias")
+        def _error_message(other: torch.Tensor, other_name: str) -> str:
+            message = (
+                f"Input type ({input_tensor.type()}) and {other_name} type "
+                f"({other.type()}) should be the same"
+            )
+            if input_tensor.is_mkldnn:
+                message += (
+                    f" or input should be a MKLDNN tensor and {other_name} is a dense tensor"
+                )
+            return message
+
+        # Keep fake/meta validation aligned with eager so invalid ConvTranspose
+        # inputs fail during tracing instead of compiling incorrect kernels.
+        torch._check(
+            _same_type_as_input(weight),
+            lambda: _error_message(weight, "weight"),
+        )
+        if bias is not None:
+            torch._check(
+                _same_type_as_input(bias),
+                lambda: _error_message(bias, "bias"),
+            )
 
     shape_out = calc_conv_nd_return_shape(
         input_tensor,
@@ -3711,20 +3732,6 @@ def meta_convolution_backward(
         if fmt1 == torch.channels_last_3d or fmt2 == torch.channels_last_3d:
             return torch.channels_last_3d
         return torch.contiguous_format
-
-    def _check_same_type(
-        tensor: torch.Tensor, other: torch.Tensor, tensor_name: str, other_name: str
-    ) -> None:
-        torch._check(
-            tensor.dtype == other.dtype and tensor.device == other.device,
-            lambda: (
-                f"{tensor_name} type ({tensor.type()}) and {other_name} type "
-                f"({other.type()}) should be the same"
-            ),
-        )
-
-    _check_same_type(input_, weight_, "Input", "weight")
-    _check_same_type(grad_output_, weight_, "grad_output", "weight")
 
     if output_mask[0]:
         memory_format = _conv_memory_format(grad_output_, weight_)

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -2600,17 +2600,23 @@ def meta_conv(
     groups: int,
 ):
     if is_transposed:
+        def _device_or_fake_device(tensor: torch.Tensor) -> torch.device:
+            if isinstance(tensor, torch._subclasses.FakeTensor):
+                return tensor.fake_device
+            return tensor.device
+
         def _same_type_as_input(other: torch.Tensor) -> bool:
+            other_device = _device_or_fake_device(other)
             if (
                 input_tensor.dtype == other.dtype
-                and input_tensor.device == other.device
+                and _device_or_fake_device(input_tensor) == other_device
                 and input_tensor.is_mkldnn == other.is_mkldnn
             ):
                 return True
             return (
                 input_tensor.is_mkldnn
                 and not other.is_mkldnn
-                and other.device.type == "cpu"
+                and other_device.type == "cpu"
                 and other.dtype == torch.float
             )
 

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -2603,11 +2603,31 @@ def _check_conv_input_same_type_as_parameters(
         )
 
 
-def _is_empty_conv_input(input_tensor: torch.Tensor) -> bool:
+def _check_empty_channel_conv_input_same_device(
+    input_tensor: torch.Tensor, weight: torch.Tensor
+) -> None:
+    torch._check(
+        _conv_device_or_fake_device(input_tensor)
+        == _conv_device_or_fake_device(weight),
+        lambda: _conv_input_type_error_message(input_tensor, weight, "weight"),
+    )
+
+
+def _is_empty_batch_conv_input(input_tensor: torch.Tensor) -> bool:
     from torch.fx.experimental.symbolic_shapes import guard_or_false
 
-    return guard_or_false(input_tensor.size(0) == 0) or guard_or_false(
-        input_tensor.size(1) == 0
+    return guard_or_false(input_tensor.size(0) == 0)
+
+
+def _is_empty_channel_conv_input(input_tensor: torch.Tensor) -> bool:
+    from torch.fx.experimental.symbolic_shapes import guard_or_false
+
+    return guard_or_false(input_tensor.size(1) == 0)
+
+
+def _is_empty_conv_input(input_tensor: torch.Tensor) -> bool:
+    return _is_empty_batch_conv_input(input_tensor) or _is_empty_channel_conv_input(
+        input_tensor
     )
 
 
@@ -2637,9 +2657,18 @@ def _conv_empty_output_dtype(
     if input_tensor.is_mkldnn:
         return input_tensor.dtype
 
-    promote_args = [input_tensor, weight]
-    if bias is not None:
-        promote_args.append(bias)
+    # Eager's Empty backend uses a scalar weight/bias for zero-batch inputs but
+    # multiplies by the full weight tensor for zero-channel inputs.
+    if _is_empty_batch_conv_input(input_tensor) and not _is_empty_channel_conv_input(
+        input_tensor
+    ):
+        promote_args = [input_tensor, weight.new_empty(())]
+        if bias is not None:
+            promote_args.append(bias.new_empty(()))
+    else:
+        promote_args = [input_tensor, weight]
+        if bias is not None:
+            promote_args.append(bias)
 
     _, result_dtype = utils.elementwise_dtypes(
         *promote_args,
@@ -2722,6 +2751,9 @@ def meta_conv(
     output_channels_dim = 1
     if guard_or_false(input_tensor.size(input_channels_dim) == 0):
         shape_out[output_channels_dim] = 0
+
+    if is_transposed and _is_empty_channel_conv_input(input_tensor):
+        _check_empty_channel_conv_input_same_device(input_tensor, weight)
 
     if is_transposed and _is_empty_conv_input(input_tensor):
         return input_tensor.new_empty(

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -2599,6 +2599,23 @@ def meta_conv(
     output_padding: list[int],
     groups: int,
 ):
+    def _check_same_type(
+        tensor: torch.Tensor, other: torch.Tensor, tensor_name: str, other_name: str
+    ) -> None:
+        # Keep fake/meta validation aligned with eager so invalid convolutions
+        # fail during tracing instead of compiling incorrect kernels.
+        torch._check(
+            tensor.dtype == other.dtype and tensor.device == other.device,
+            lambda: (
+                f"{tensor_name} type ({tensor.type()}) and {other_name} type "
+                f"({other.type()}) should be the same"
+            ),
+        )
+
+    _check_same_type(input_tensor, weight, "Input", "weight")
+    if bias is not None:
+        _check_same_type(input_tensor, bias, "Input", "bias")
+
     shape_out = calc_conv_nd_return_shape(
         input_tensor,
         weight,
@@ -3694,6 +3711,20 @@ def meta_convolution_backward(
         if fmt1 == torch.channels_last_3d or fmt2 == torch.channels_last_3d:
             return torch.channels_last_3d
         return torch.contiguous_format
+
+    def _check_same_type(
+        tensor: torch.Tensor, other: torch.Tensor, tensor_name: str, other_name: str
+    ) -> None:
+        torch._check(
+            tensor.dtype == other.dtype and tensor.device == other.device,
+            lambda: (
+                f"{tensor_name} type ({tensor.type()}) and {other_name} type "
+                f"({other.type()}) should be the same"
+            ),
+        )
+
+    _check_same_type(input_, weight_, "Input", "weight")
+    _check_same_type(grad_output_, weight_, "grad_output", "weight")
 
     if output_mask[0]:
         memory_format = _conv_memory_format(grad_output_, weight_)


### PR DESCRIPTION
Fix #142479

## Summary

1. Root cause problem
`torch.compile` can trace invalid `ConvTranspose` graphs because the fake/meta convolution path did not validate the input, weight, and bias tensor types the way eager convolution does.

2. Proposed fix
Add the missing convolution dtype/device checks to the fake/meta implementations for `aten.convolution` and `aten.convolution_backward`, and cover the regression with fake-tensor and inductor tests.

3. Why the proposed fix is the right long term fix
The compiler should reject the same invalid convolution signatures that eager rejects during tracing, so keeping the meta path aligned with eager prevents incorrect compiled kernels instead of relying on backend-specific runtime failures.

Drafted via @codex, published after manual review by @bobrenjc93

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo