### PR TITLE
[MPS] expand the current export unit test for SDPA

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -1697,6 +1697,36 @@ class AOTInductorTestsTemplate:
         )
         self.check_model(Model(), example_inputs)
 
+    def test_sdpa_dynamic_seq_len(self):
+        # Regression test for https://github.com/pytorch/pytorch/issues/177603
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.register_buffer("k", torch.zeros(1, 4, 64, 128))
+                self.register_buffer("v", torch.zeros(1, 4, 64, 128))
+
+            def forward(self, q, mask):
+                return torch.nn.functional.scaled_dot_product_attention(
+                    q, self.k, self.v, attn_mask=mask
+                )
+
+        for mask_dtype in [torch.bool, torch.float32]:
+            model = Model()
+            seq = torch.export.Dim("seq", min=1, max=64)
+            dynamic_shapes = {"q": {2: seq}, "mask": {0: seq}}
+            list_example_inputs = [
+                (
+                    torch.randn(1, 4, sl, 128, device=self.device),
+                    torch.zeros(sl, 64, device=self.device, dtype=mask_dtype),
+                )
+                for sl in [1, 8, 9, 32]
+            ]
+            self.check_model_with_multiple_inputs(
+                model,
+                list_example_inputs,
+                dynamic_shapes=dynamic_shapes,
+            )
+
     @skipIfNoFBGEMM
     def test_quantized_linear(self):
         class Model(torch.nn.Module):

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -21,7 +21,6 @@ import itertools
 from collections import defaultdict
 from torch import inf
 from torch.nn import Buffer, Parameter
-from torch.export import Dim, export
 from torch.testing._internal import opinfo
 from torch.testing._internal.common_utils import \
     (gradcheck, gradgradcheck, parametrize, run_tests, TestCase, download_file, MACOS_VERSION, IS_CI,
@@ -9766,38 +9765,6 @@ class TestSDPA(TestCaseMPS):
 
     def test_sdpa_no_mask_causal_fp16(self):
         self._test_sdpa_no_mask(True, torch.float16)
-
-    def test_sdpa_export_dynamic_seq_len(self):
-        # Regression test for https://github.com/pytorch/pytorch/issues/177603
-        class M(nn.Module):
-            def __init__(self):
-                super().__init__()
-                self.register_buffer("k", torch.zeros(1, 4, 64, 128))
-                self.register_buffer("v", torch.zeros(1, 4, 64, 128))
-
-            def forward(self, q, mask):
-                out, _ = torch.ops.aten._scaled_dot_product_attention_math_for_mps(
-                    q, self.k, self.v, mask, 0.0, False, None
-                )
-                return out
-
-        model = M().to(device="mps", dtype=torch.float32).eval()
-        seq = Dim("seq", min=1, max=64)
-
-        q = torch.randn(1, 4, 4, 128, device="mps", dtype=torch.float32)
-        mask = torch.zeros(4, 64, device="mps", dtype=torch.bool)
-
-        ep = export(
-            model,
-            (q, mask),
-            dynamic_shapes={"q": {2: seq}, "mask": {0: seq}},
-            strict=True,
-        )
-
-        q2 = torch.randn(1, 4, 7, 128, device="mps", dtype=torch.float32)
-        mask2 = torch.zeros(7, 64, device="mps", dtype=torch.bool)
-        out = ep.module()(q2, mask2)
-        self.assertEqual(out.shape, (1, 4, 7, 128))
 
     def test_sdpa_no_mask_causal_fp16_L7(self):
         self._test_sdpa_no_mask(True, torch.float16, 7)

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -6151,29 +6151,23 @@ def meta__scaled_dot_product_attention_math_for_mps(
             return x, False
 
     q_, unsqueezed = ensure_4d(query)
-    k_, _ = ensure_4d(key)
     v_, _ = ensure_4d(value)
 
     batch_size, num_head, q_size, _ = q_.shape
     _, _, max_seq_length, value_head_size = v_.shape
 
-    def sdpa_general_mps():
-        out = q_.new_empty((batch_size, num_head, q_size, value_head_size))
-        attn = q_.new_empty((batch_size, num_head, q_size, max_seq_length))
-        if unsqueezed:
-            if query.dim() == 3:
-                out = out.squeeze(0)
-                attn = attn.squeeze(0)
-            else:
-                out_shape = list(query.shape[:-3]) + list(out.shape[1:4])
-                attn_shape = list(query.shape[:-3]) + list(attn.shape[1:4])
-                out = out.view(out_shape)
-                attn = attn.view(attn_shape)
-        return out, attn
-
-    # sdpa_vector_2pass_mps and sdpa_vector_fast_mps are intentionally left out.
-    # See https://github.com/pytorch/pytorch/issues/177603 for additional context.
-    return sdpa_general_mps()
+    out = q_.new_empty((batch_size, num_head, q_size, value_head_size))
+    attn = q_.new_empty((batch_size, num_head, q_size, max_seq_length))
+    if unsqueezed:
+        if query.dim() == 3:
+            out = out.squeeze(0)
+            attn = attn.squeeze(0)
+        else:
+            out_shape = list(query.shape[:-3]) + list(out.shape[1:4])
+            attn_shape = list(query.shape[:-3]) + list(attn.shape[1:4])
+            out = out.view(out_shape)
+            attn = attn.view(attn_shape)
+    return out, attn
 
 
 @register_meta([aten._scaled_dot_product_efficient_attention])


### PR DESCRIPTION
Summary

Move the SDPA dynamic seq len export test from `test_mps.py` to `test_aot_inductor.py` so it runs on all devices (cpu, gpu, mps), using `F.scaled_dot_product_attention` instead of the MPS-specific op.

Also clean up the meta registration for `_scaled_dot_product_attention_math_for_mps`: inline the single-use `sdpa_general_mps()` helper and remove the dead `ensure_4d(key)` call, both left over from the branching logic removed in #177620.

Regression test for #177603.

Test plan

- `python test/inductor/test_aot_inductor.py -k test_sdpa_dynamic_seq_len`

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @hvaara