### PR TITLE
[ROCm] simplify unrolling by leveraging compiler

### DIFF
--- a/aten/src/ATen/native/cuda/Reduce.cuh
+++ b/aten/src/ATen/native/cuda/Reduce.cuh
@@ -836,9 +836,9 @@ struct ReduceOp {
           }
         }
       } else {
+#if defined(USE_ROCM) && ROCM_VERSION <= 71300
         index_t input_offset = threadIdx.y;
         index_t step = blockDim.y;
-#ifdef USE_ROCM // Prefetch loads to better hide their latency
         #define PRFCH 4
         for (; input_offset < config.ctas_per_output; input_offset += step*PRFCH) {
          arg_vec_t next[PRFCH];
@@ -855,6 +855,14 @@ struct ReduceOp {
          }
         }
 #else
+#if defined(USE_ROCM)
+        int input_offset = threadIdx.y;
+        int step = blockDim.y;
+        #pragma unroll
+#else
+        index_t input_offset = threadIdx.y;
+        index_t step = blockDim.y;
+#endif
         for (; input_offset < config.ctas_per_output; input_offset += step) {
           index_t idx = config.staging_memory_offset(input_offset);
           arg_vec_t next = reduce_buffer[idx];


### PR DESCRIPTION
A recent change to LLVM (https://github.com/llvm/llvm-project/pull/181241) enables loop unrolling for loops with runtime-known loop count even when the trip count expression is expensive. This is the case for simple HIP loops based on the "blockDim.x" expression, which translates to a complex LLVM IR expression. With this change, we can simply obtain loop unrolling via compiler transformation using "pragma unroll" and without the need of hand-written specializations of the code. Therefore, this patch simplifies the pytorch code base across different targets, as much as possible given different compilation toolchains.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang