### PR TITLE
implement branch free and guard free padding+mul operator (#177699)

### DIFF
--- a/torch/sparse/_semi_structured_ops.py
+++ b/torch/sparse/_semi_structured_ops.py
@@ -137,20 +137,14 @@ def semi_sparse_mm(func, types, args=(), kwargs=None) -> torch.Tensor:
             "`SparseSemiStructuredTensor` matmul: Broadcasting is not implemented"
         )
     if isinstance(A, torch.sparse.SparseSemiStructuredTensor):
-        row, col = B.shape
-        B_padded = A._pad_dense_input(B)
-        res = A._mm(B_padded)
-        return res[:, :col]
+        return A._mm(B)
     else:
         B_t = B.t()
         if not isinstance(B_t, torch.sparse.SparseSemiStructuredTensor):
             raise AssertionError(
                 f"expected SparseSemiStructuredTensor, got {type(B_t).__name__}"
             )
-        row, col = A.shape
-        A_padded = B._pad_dense_input(A)
-        res = B_t._mm(A_padded.t()).t()
-        return res[:row, :]
+        return B_t._mm(A, should_transpose_dense=True).t()
 
 
 def semi_sparse_addmm(func, types, args=(), kwargs=None) -> torch.Tensor:
@@ -175,9 +169,7 @@ def semi_sparse_addmm(func, types, args=(), kwargs=None) -> torch.Tensor:
             f"expected SparseSemiStructuredTensor, got {type(B_t).__name__}"
         )
     row, _col = A.shape
-    A_padded = B_t._pad_dense_input(A)
-    result = B_t._mm(A_padded.t(), bias=bias).t()
-    return result[:row, :]
+    return B_t._mm(A, bias=bias, should_transpose_dense=True).t()
 
 
 def semi_sparse_linear(func, types, args=(), kwargs=None) -> torch.Tensor:
@@ -188,7 +180,6 @@ def semi_sparse_linear(func, types, args=(), kwargs=None) -> torch.Tensor:
 
     shape = A.shape
     A_2d = A.view(-1, shape[-1])
-
     if bias is None:
         res = A_2d @ B.t()
     else:
@@ -197,7 +188,6 @@ def semi_sparse_linear(func, types, args=(), kwargs=None) -> torch.Tensor:
             types=None,
             args=[bias, A_2d, B.t()],
         )
-
     return res.view(*shape[:-1], -1)
 
 

--- a/torch/sparse/semi_structured.py
+++ b/torch/sparse/semi_structured.py
@@ -281,29 +281,6 @@ class SparseSemiStructuredTensor(torch.Tensor):
                 f"Both dimensions must be larger or equal than and a multiple of ({min_rows}, {min_cols})"
             )
 
-    @classmethod
-    def _pad_dense_input(cls, dense_input: torch.Tensor) -> torch.Tensor:
-        """
-        Calculates padding for dense tensor and pads tensor if necessary.
-        If padding is not required, this function returns the original tensor.
-        """
-        # only 2d matmul
-        if dense_input.dim() != 2:
-            raise AssertionError(f"dense_input must be 2D, got {dense_input.dim()}D")
-
-        # check shape
-        m, n = dense_input.shape
-        min_rows = cls._DTYPE_SHAPE_CONSTRAINTS[dense_input.dtype].dense_min_rows
-        min_cols = cls._DTYPE_SHAPE_CONSTRAINTS[dense_input.dtype].dense_min_cols
-
-        # calculate padding
-        to_pad_m = -m % min_rows if m < min_rows or m % min_rows else 0
-        to_pad_n = -n % min_cols if n < min_cols or n % min_rows else 0
-        if to_pad_m or to_pad_n:
-            return torch.nn.functional.pad(dense_input, (0, to_pad_n, 0, to_pad_m))
-        else:
-            return dense_input
-
     def to_dense(self):  # type:ignore[override]
         col = self.shape[-1]
         return torch.mm(self, torch.eye(col, dtype=self.dtype, device=self.device))
@@ -519,7 +496,12 @@ class SparseSemiStructuredTensorCUTLASS(SparseSemiStructuredTensor):
         )
 
     def _mm(
-        self, B: torch.Tensor, *, bias: torch.Tensor | None = None, **kwargs
+        self,
+        B: torch.Tensor,
+        *,
+        bias: torch.Tensor | None = None,
+        should_transpose_dense: bool = False,
+        **kwargs,
     ) -> torch.Tensor:
         if isinstance(B, SparseSemiStructuredTensor):
             raise ValueError(
@@ -535,13 +517,18 @@ class SparseSemiStructuredTensorCUTLASS(SparseSemiStructuredTensor):
                 f"`{cls_name}` matmul: operation is not supported"
             )
         else:
-            if bias is None:
-                res = torch._sparse_semi_structured_mm(self.packed, self.meta, B)
-            else:
-                res = torch._sparse_semi_structured_addmm(
-                    bias, self.packed, self.meta, B
-                )
-            return res[: self.shape[0]]
+            _ensure_cutlass_mm_registered()
+            constraints = self._DTYPE_SHAPE_CONSTRAINTS[B.dtype]
+            return torch.ops.semi_structured.cutlass_mm(
+                B,
+                self.packed,
+                self.meta,
+                bias,
+                self.shape[0],
+                constraints.dense_min_rows,
+                constraints.dense_min_cols,
+                should_transpose_dense,
+            )
 
 
 class SparseSemiStructuredTensorCUSPARSELT(SparseSemiStructuredTensor):
@@ -648,7 +635,12 @@ class SparseSemiStructuredTensorCUSPARSELT(SparseSemiStructuredTensor):
         )
 
     def _mm(
-        self, B: torch.Tensor, *, bias: torch.Tensor | None = None, **kwargs
+        self,
+        B: torch.Tensor,
+        *,
+        bias: torch.Tensor | None = None,
+        should_transpose_dense: bool = False,
+        **kwargs,
     ) -> torch.Tensor:
         if isinstance(B, SparseSemiStructuredTensor):
             raise ValueError(
@@ -682,11 +674,141 @@ class SparseSemiStructuredTensorCUSPARSELT(SparseSemiStructuredTensor):
                 f"`{self.__class__.__name__}` matmul: operation is not supported"
             )
         else:
-            res = torch._cslt_sparse_mm(
-                self.packed,
+            _ensure_cusparselt_mm_registered()
+            constraints = self._DTYPE_SHAPE_CONSTRAINTS[B.dtype]
+            return torch.ops.semi_structured.cusparselt_mm(
                 B,
-                bias=bias,
-                transpose_result=self.fuse_transpose_cusparselt,
-                alg_id=self.alg_id_cusparselt,
+                self.packed,
+                bias,
+                self.shape[0],
+                constraints.dense_min_rows,
+                constraints.dense_min_cols,
+                self.fuse_transpose_cusparselt,
+                self.alg_id_cusparselt,
+                should_transpose_dense,
             )
-            return res.t() if self.fuse_transpose_cusparselt else res
+
+
+_cutlass_mm_registered = False
+
+
+def _ensure_cutlass_mm_registered():
+    """Lazily register the cutlass_mm custom op.
+
+    Registration is deferred to avoid importing torch.library at module load
+    time, since torch.sparse is imported early during ``import torch``.
+    """
+    global _cutlass_mm_registered
+    if _cutlass_mm_registered:
+        return
+    _cutlass_mm_registered = True
+
+    from torch.library import custom_op
+
+    @custom_op("semi_structured::cutlass_mm", mutates_args=())
+    def cutlass_mm(
+        dense: torch.Tensor,
+        packed: torch.Tensor,
+        meta: torch.Tensor,
+        bias: torch.Tensor | None,
+        out_features: int,
+        min_rows: int,
+        min_cols: int,
+        transpose_dense: bool,
+    ) -> torch.Tensor:
+        m, n = dense.shape
+        to_pad_m = (-m) % min_rows
+        to_pad_n = (-n) % min_cols
+        dense_padded = torch.nn.functional.pad(dense, (0, to_pad_n, 0, to_pad_m))
+        mm_input = dense_padded.t() if transpose_dense else dense_padded
+        if bias is None:
+            res = torch._sparse_semi_structured_mm(packed, meta, mm_input)
+        else:
+            res = torch._sparse_semi_structured_addmm(bias, packed, meta, mm_input)
+        out_cols = m if transpose_dense else n
+        return (
+            res[:out_features]
+            .narrow(1, 0, out_cols)
+            .clone(memory_format=torch.contiguous_format)
+        )
+
+    @cutlass_mm.register_fake
+    def _cutlass_mm_fake(
+        dense: torch.Tensor,
+        packed: torch.Tensor,
+        meta: torch.Tensor,
+        bias: torch.Tensor | None,
+        out_features: int,
+        min_rows: int,
+        min_cols: int,
+        transpose_dense: bool,
+    ) -> torch.Tensor:
+        out_cols = dense.shape[0] if transpose_dense else dense.shape[1]
+        return torch.empty(
+            out_features,
+            out_cols,
+            dtype=dense.dtype,
+            device=dense.device,
+        )
+
+
+_cusparselt_mm_registered = False
+
+
+def _ensure_cusparselt_mm_registered():
+    """Lazily register the cusparselt_mm custom op."""
+    global _cusparselt_mm_registered
+    if _cusparselt_mm_registered:
+        return
+    _cusparselt_mm_registered = True
+
+    from torch.library import custom_op
+
+    @custom_op("semi_structured::cusparselt_mm", mutates_args=())
+    def cusparselt_mm(
+        dense: torch.Tensor,
+        packed: torch.Tensor,
+        bias: torch.Tensor | None,
+        out_features: int,
+        min_rows: int,
+        min_cols: int,
+        fuse_transpose: bool,
+        alg_id: int,
+        should_transpose_dense: bool = False,
+    ) -> torch.Tensor:
+        m, n = dense.shape
+        to_pad_m = (-m) % min_rows
+        to_pad_n = (-n) % min_cols
+        dense_padded = torch.nn.functional.pad(dense, (0, to_pad_n, 0, to_pad_m))
+        mm_input = dense_padded.t() if should_transpose_dense else dense_padded
+        res = torch._cslt_sparse_mm(
+            packed,
+            mm_input,
+            bias=bias,
+            transpose_result=fuse_transpose,
+            alg_id=alg_id,
+        )
+        if fuse_transpose:
+            res = res.t()
+        out_cols = m if should_transpose_dense else n
+        return res.narrow(1, 0, out_cols).clone(memory_format=torch.contiguous_format)
+
+    @cusparselt_mm.register_fake
+    def _cusparselt_mm_fake(
+        dense: torch.Tensor,
+        packed: torch.Tensor,
+        bias: torch.Tensor | None,
+        out_features: int,
+        min_rows: int,
+        min_cols: int,
+        fuse_transpose: bool,
+        alg_id: int,
+        should_transpose_dense: bool,
+    ) -> torch.Tensor:
+        out_cols = dense.shape[0] if should_transpose_dense else dense.shape[1]
+        return torch.empty(
+            out_features,
+            out_cols,
+            dtype=dense.dtype,
+            device=dense.device,
+        )


### PR DESCRIPTION
Summary:


When run AOTI lowering with fp16 2:4 sparsity enabled, we are getting a blocking error as follow:
…UserError(UserErrorType.CONSTRAINT_VIOLATION, str(e))...
Not all values of dynamic_dim_1_to_1024 = L['getitem_24'].size()[0] in the specified range dynamic_dim_1_to_1024 <= 1024 satisfy the generated guard (L['getitem_24'].size()[0] + (((-1)*L['getitem_24'].size()[0]) % \8)) != L['getitem_24'].size()[0]

It is caused by doing if-else branch on a SymInt algebra. In this case we have SymInt m = L['getitem_24'].size()[0]. Due to constraint on hardware, we need to ensure the mm op input is a multiple of 8 for fp16 2:4, thus we have a padding function to do so, see "_pad_dense_input" below. The padding must introduce m algebra in its logic. Once we have a if-else branch on m algebra, torch.export will generate a gurad e.g. m % 8 != 0 or ((m+(8-1)) / 8 ) * 8 >= m (depending on how to calculate padding) to ensure tracing will only enter one branch (e.g. need padding branch). 

Torch.export in general cannot handle complicated SymInt algebra math proof, and will throw in this case. For example it cannot ensure for m from 1 to 1024, ((m+(8-1)) / 8 ) * 8 >= m always holds (which is actually true).

The solution for this is to use a custom op to abstract the padding logic into a single node in static graph so Dynamo tracing will never go into it. It will only trace the registered fake implementation to calculate output size/shape. With appropriate abstraction, e.g. abstracting the mm op, we can ensure the output size is independent from SymInt(m) algebra -- shape(m, in_feature) --> shape(m, out_feature). In such case, tracing is guaranteed to not to generate any guard. 

For the semi_structure, we will abstract (padding + mm op) for CUTLASS and CUSPARSELT respectively. This diff implement the custom ops to ensure lowering workflow with fp16:24 enabled working well.

Test Plan: OSS CI: https://hud.pytorch.org/pr/177699

Reviewed By: jcaip

Differential Revision: D96874771


