### PR TITLE
[NCCL][Symmetric Memory] Use `get_group_info` instead of `resolve_process_group` in `make_peer_alloc_info`

### DIFF
--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.cu
@@ -1,8 +1,8 @@
-#include <torch/csrc/distributed/c10d/GroupRegistry.hpp>
 #include <torch/csrc/distributed/c10d/cuda/utils.hpp>
 #include <torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory-inl.cuh>
 #include <torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.hpp>
 #include <torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryUtils.hpp>
+#include <torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.hpp>
 
 #include <ATen/ceil_div.h>
 #include <ATen/cuda/CUDAContext.h>
@@ -638,10 +638,10 @@ c10::intrusive_ptr<CUDAPeerAllocInfo> make_peer_alloc_info(
     LOG(INFO) << "using fabric handle to import symmetric memory handles.";
   }
 
-  auto group = resolve_process_group(group_name);
-  auto rank = group->getRank();
-  auto world_size = group->getSize();
-  auto store = group->getStore();
+  auto& group_info = c10d::symmetric_memory::get_group_info(group_name);
+  auto rank = group_info.rank;
+  auto world_size = group_info.world_size;
+  auto store = group_info.store;
 
   // Currently, IpcChannel is using a file based socket for inter-process
   // communication


### PR DESCRIPTION
Setting as a draft because it currently is a partial revert of https://github.com/pytorch/pytorch/pull/172163 which I'm not sure is correct

Claude claims
```
● Now I have the complete picture. You're right — there shouldn't be two paths. Here's what happened:                                                                                                                                                                                                                                                                                                                                                                                                                                                                              

  The group_info_map (via set_group_info/get_group_info) is the original symmetric memory mechanism. It stores just {rank, world_size, store} — the minimal info needed for symmetric memory rendezvous. It exists because symmetric memory groups are a logical concept that can be set up independently of ProcessGroup objects (as the header comment on line 133-138 of SymmetricMemory.hpp explicitly says).

  Then CUDASymmetricMemory.cu's make_peer_alloc_info was changed to use resolve_process_group() from GroupRegistry instead. It only needs rank, world_size, and store from it — but it resolves an entire ProcessGroup object just to extract those three fields. This effectively broke the original contract that symmetric memory groups can be logical/independent of ProcessGroup.

  The right fix is the opposite direction from what I did — make_peer_alloc_info should use get_group_info as its primary path, not resolve_process_group. Let me check if anything actually needs the ProcessGroup object there.
  ```

authored with claude code
to fix failures like
```
RuntimeError: Could not resolve the process group registered under the name IntraNodeComm0
```
in  `python test/distributed/test_c10d_nccl.py CommTest.test_intra_node_comm_all_reduce`

