### PR TITLE
[user-streams] Fix check that didn't include torch.Event subclasses

### DIFF
--- a/test/dynamo/test_streams.py
+++ b/test/dynamo/test_streams.py
@@ -1702,6 +1702,26 @@ class GraphModule(torch.nn.Module):
                 torch.ones(2, 2, device="cuda")
             )
 
+    @requires_cuda
+    def test_cuda_event_tracing(self):
+        """torch.cuda.Event (a subclass of torch.Event) should work through tracing."""
+
+        def fn(x):
+            e = torch.cuda.Event()
+            with torch.cuda.stream(torch.cuda.Stream()):
+                y = x + 1
+                e.record()
+
+            with torch.cuda.stream(torch.cuda.Stream()):
+                e.wait()
+                z = y * 2
+
+            return z
+
+        inp = (torch.ones(2, 2, device="cuda"),)
+        result = torch.compile(fn, backend="eager", fullgraph=True)(*inp)
+        self.assertEqual(result, torch.ones(2, 2, device="cuda") * 4)
+
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/test/dynamo/test_streams.py
+++ b/test/dynamo/test_streams.py
@@ -1703,24 +1703,12 @@ class GraphModule(torch.nn.Module):
             )
 
     @requires_cuda
-    def test_cuda_event_tracing(self):
-        """torch.cuda.Event (a subclass of torch.Event) should work through tracing."""
-
-        def fn(x):
-            e = torch.cuda.Event()
-            with torch.cuda.stream(torch.cuda.Stream()):
-                y = x + 1
-                e.record()
-
-            with torch.cuda.stream(torch.cuda.Stream()):
-                e.wait()
-                z = y * 2
-
-            return z
-
-        inp = (torch.ones(2, 2, device="cuda"),)
-        result = torch.compile(fn, backend="eager", fullgraph=True)(*inp)
-        self.assertEqual(result, torch.ones(2, 2, device="cuda") * 4)
+    def test_cuda_event_record_on_stream(self):
+        """torch.cuda.Event should be accepted by torch.Stream.record_event (C++ type check)."""
+        s = torch.Stream(device="cuda")
+        e = torch.cuda.Event()
+        # This hits THPStream_record_event in Stream.cpp which does a type check
+        s.record_event(e)
 
 
 if __name__ == "__main__":

--- a/torch/csrc/Event.cpp
+++ b/torch/csrc/Event.cpp
@@ -215,8 +215,7 @@ static PyObject* THPEvent_elapsed_time(PyObject* _self, PyObject* _other) {
   auto self = reinterpret_cast<THPEvent*>(_self);
   // We expect it to be an explicit torch.Event instance.
   TORCH_CHECK(
-      Py_TYPE(_other) == THPEventClass,
-      "expected other to be a torch.Event object");
+      THPEvent_Check(_other), "expected other to be a torch.Event object");
   auto other = reinterpret_cast<THPEvent*>(_other);
   return PyFloat_FromDouble(self->event.elapsedTime(other->event));
   END_HANDLE_TH_ERRORS

--- a/torch/csrc/Stream.cpp
+++ b/torch/csrc/Stream.cpp
@@ -227,8 +227,7 @@ static PyObject* THPStream_record_event(
   if (_event != Py_None) {
     // We expect it to be an explicit torch.Event instance.
     TORCH_CHECK(
-        Py_TYPE(_event) == THPEventClass,
-        "expected event to be a torch.Event object");
+        THPEvent_Check(_event), "expected event to be a torch.Event object");
     // Increase the refcount of the event to avoid it being destroyed.
     Py_INCREF(_event);
     _new_event = _event;

--- a/torch/csrc/cuda/Event.cpp
+++ b/torch/csrc/cuda/Event.cpp
@@ -47,6 +47,12 @@ static PyObject* THCPEvent_pynew(
   }
 
   THCPEvent* self = (THCPEvent*)ptr.get();
+  self->weakreflist = nullptr;
+  new (&self->event) c10::Event(
+      c10::DeviceType::CUDA,
+      (enable_timing ? c10::EventFlag::BACKEND_DEFAULT
+                     : c10::EventFlag::PYTORCH_DEFAULT));
+
   unsigned int flags = (blocking ? cudaEventBlockingSync : cudaEventDefault) |
       (enable_timing ? cudaEventDefault : cudaEventDisableTiming) |
       (interprocess ? cudaEventInterprocess : cudaEventDefault) |


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/177771

Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #177701



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo