### PR TITLE
[opinfo] Fix Inductor _split_iteration_ranges silently dropping dimensions

### DIFF
--- a/test/inductor/test_loop_ordering.py
+++ b/test/inductor/test_loop_ordering.py
@@ -1337,6 +1337,70 @@ class TestTiling(TestCase):
         self.assertEqual(out, expected)
 
 
+class TestSplitIterationRanges(MockSchedulerTest):
+    """Unit tests for SIMDKernel._split_iteration_ranges."""
+
+    def test_exact_match(self):
+        """Groups exactly match lengths — no splitting needed."""
+        from torch._inductor.codegen.simd import SIMDKernel
+
+        new_ranges, getters = SIMDKernel._split_iteration_ranges(
+            [sympy.Integer(4), sympy.Integer(8)],
+            [[sympy.Integer(4)], [sympy.Integer(8)]],
+        )
+        self.assertEqual(len(new_ranges), 2)
+        self.assertEqual(len(new_ranges[0]), 1)
+        self.assertEqual(len(new_ranges[1]), 1)
+
+    def test_two_way_split(self):
+        """A single large dimension splits across two groups."""
+        from torch._inductor.codegen.simd import SIMDKernel
+
+        new_ranges, getters = SIMDKernel._split_iteration_ranges(
+            [sympy.Integer(4), sympy.Integer(8)],
+            [[sympy.Integer(32)], []],
+        )
+        # 32 should split into 4 * 8 across the two groups
+        self.assertEqual(len(new_ranges), 2)
+
+    def test_groups_exhausted_raises_cant_split(self):
+        """When all groups are consumed but sizes remain, CantSplit is raised."""
+        from torch._inductor.codegen.simd import CantSplit, SIMDKernel
+
+        # groups=[1, 2, 2] can only absorb 2 sizes of 2 (consuming groups 1 and 2),
+        # leaving the third size=2 with no group to map to.
+        with self.assertRaises(CantSplit):
+            SIMDKernel._split_iteration_ranges(
+                [sympy.Integer(1), sympy.Integer(2), sympy.Integer(2)],
+                [[], [sympy.Integer(2), sympy.Integer(2), sympy.Integer(2)]],
+            )
+
+    def test_single_group_multiple_sizes(self):
+        """Multiple sizes fitting within a single group."""
+        from torch._inductor.codegen.simd import SIMDKernel
+
+        # groups=[8], lengths=[[2, 2, 2], []] — all 3 sizes fit in group 0
+        new_ranges, getters = SIMDKernel._split_iteration_ranges(
+            [sympy.Integer(8)],
+            [[sympy.Integer(2), sympy.Integer(2), sympy.Integer(2)], []],
+        )
+        self.assertEqual(len(new_ranges), 1)
+        self.assertEqual(len(new_ranges[0]), 3)
+
+    def test_size_one_skipped(self):
+        """Dimensions of size 1 produce a zero-constant getter."""
+        from torch._inductor.codegen.simd import SIMDKernel
+
+        new_ranges, getters = SIMDKernel._split_iteration_ranges(
+            [sympy.Integer(4)],
+            [[sympy.Integer(1), sympy.Integer(4)], []],
+        )
+        # Size-1 dim should not consume any range
+        self.assertEqual(len(getters[0]), 2)
+        # The first getter should return 0 for any input
+        self.assertEqual(getters[0][0]([sympy.Integer(99)]), sympy.Integer(0))
+
+
 class TestIndexInversion(TestCase):
     @classmethod
     def setUpClass(cls):

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -856,11 +856,12 @@ class SIMDKernel(Kernel[CSEVariableType], Generic[CSEVariableType]):
                         )
                     )
                 else:
-                    if current_group < len(remaining):
-                        return_getters.append(
-                            # pyrefly: ignore [bad-argument-type]
-                            operator.itemgetter(add_range(current_group, size))
-                        )
+                    if current_group >= len(remaining):
+                        raise CantSplit(size, 0)
+                    return_getters.append(
+                        # pyrefly: ignore [bad-argument-type]
+                        operator.itemgetter(add_range(current_group, size))
+                    )
             return_getters_groups.append(return_getters)
 
         assert all(


### PR DESCRIPTION
Summary:
Fixed a bug in [`_split_iteration_ranges`](https://www.internalfb.com/code/fbsource/[09fcaa3d6bbbc4b2c6589c5541963c701b4bf256]/fbcode/caffe2/torch/_inductor/codegen/simd.py?lines=858) where exhausting all range groups would silently skip remaining dimension sizes instead of raising `CantSplit`.

When the target backend enables `triton.tile_reductions=True`, the reduction tiling can split into 2 groups (r0_, r1_). For `nll_loss` with `reduction='mean'` on a 4D input `[2,3,2,2]`, the decomposed `sum()` creates a Reduction node with 3 reduction dims `[2,2,2]` (total=8). The tiling `{'x': 1, 'r0_': 2, 'r1_': 2}` (product=4) is incompatible because `4 != 8`.

The compatibility check [`is_compatible()`](https://www.internalfb.com/code/fbsource/[09fcaa3d6bbbc4b2c6589c5541963c701b4bf256]/fbcode/caffe2/torch/_inductor/codegen/simd.py?lines=893) calls `_split_iteration_ranges()` to verify. When mapping 3 sizes `[2,2,2]` into 3 groups `[1,2,2]`, the algorithm consumed the first two groups but ran out of groups for the third size. The old code at line 859 (`if current_group < len(remaining)`) silently skipped the third dimension instead of raising `CantSplit`, causing `is_compatible()` to incorrectly return `True`. This led to an `AssertionError` during codegen when `indexing_from_args` received 2 index vars but expected 3.

The fix raises `CantSplit` when all groups are exhausted, so the incompatible tiling is properly rejected and the system falls back to the default tiling `{'x': 1, 'r0_': 8}`.

Test Plan:
Unit tests for `_split_iteration_ranges`:
```
buck2 test fbcode//caffe2/test/inductor:loop_ordering -- TestSplitIterationRanges
```
https://www.internalfb.com/intern/testinfra/testrun/3377700078761727

E2E opinfo test:
```
OPINFO_START_INDEX=20737 OPINFO_END_INDEX=20738 OPINFO_LOWERING_MODE=AFG_INDUCTOR_COMPILE OPINFO_AUTO_DS=1 buck2 run fbcode//mtia/compiler/graph_compiler/test_library/afg_opinfo_e2e_tests:test_afg_opinfo_e2e
```

```
Graph fallback classification: success (inductor=1, manual=0)
test_opinfo_20737_afg_inductor_compile_ds PASSED
error_msg=success
```

Differential Revision: D96940583




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo