### PR TITLE
Back out "[CUDA][cuBLASLt] set cuBLASLt as a default BLAS backend when available (#174594)" (#177703)

### DIFF
--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -456,15 +456,7 @@ at::BlasBackend Context::blasPreferredBackend() {
   // Rather than put logic for interpreting what Default means at every
   // call site for blasPreferredBackend(), we set it to an actual value.
   if (blas_preferred_backend == at::BlasBackend::Default) {
-#ifdef USE_ROCM
-    // ROCm - BLAS is default. May change to Lt in the code below.
     blas_preferred_backend = at::BlasBackend::Cublas;
-#else
-    // CUDA - Lt by default if available
-    blas_preferred_backend = hasCuBLASLt()
-      ? at::BlasBackend::Cublaslt
-      : at::BlasBackend::Cublas;
-#endif
     // This logic sits in the getter because it needs to validate
     // values set via env vars such as TORCH_BLAS_PREFER_CUBLASLT
     // which initialize the backend without calling the setter

--- a/benchmarks/dynamo/huggingface.yaml
+++ b/benchmarks/dynamo/huggingface.yaml
@@ -74,7 +74,6 @@ batch_size:
 tolerance:
   higher_training:
     - MT5ForConditionalGeneration
-    - BertForMaskedLM
 
   higher_max_autotune_training: []
 

--- a/benchmarks/dynamo/timm_models.py
+++ b/benchmarks/dynamo/timm_models.py
@@ -69,7 +69,6 @@ BATCH_SIZE_DIVISORS = {
 REQUIRE_HIGHER_TOLERANCE = {
     "inception_v3",
     "mobilenetv3_large_100",
-    "convnextv2_nano.fcmae_ft_in22k_in1k",
 }
 
 REQUIRE_HIGHER_TOLERANCE_FP16_XPU = {

--- a/test/inductor/test_custom_op_autotune.py
+++ b/test/inductor/test_custom_op_autotune.py
@@ -247,15 +247,8 @@ class TestCustomOpAutoTune(TestCase):
         """
         # Ensure k is divisible by all k_splits values: [2, 32, 64, 128, 256]
         k = ((k + 255) // 256) * 256  # Round up to nearest multiple of 256
-        sd = k**0.25
-        a = (
-            torch.randn(m, k, device=self.device, dtype=self.dtype, requires_grad=False)
-            / sd
-        )
-        b = (
-            torch.randn(k, n, device=self.device, dtype=self.dtype, requires_grad=False)
-            / sd
-        )
+        a = torch.randn(m, k, device=self.device, dtype=self.dtype, requires_grad=False)
+        b = torch.randn(k, n, device=self.device, dtype=self.dtype, requires_grad=False)
         bias = (
             torch.randn(n, device=self.device, dtype=self.dtype, requires_grad=False)
             * 0.1
@@ -378,9 +371,9 @@ class TestCustomOpAutoTune(TestCase):
             torch.testing.assert_close(
                 compiled_result,
                 expected,
-                rtol=2e-3,
-                atol=5e-3,
-                # msg=f"Failed for shape ({m}, {k}, {n})",
+                rtol=2e-1,
+                atol=5e-1,
+                msg=f"Failed for shape ({m}, {k}, {n})",
             )
 
     @skipIfXpu

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -653,7 +653,8 @@ print(t.is_pinned())
         def _check_default():
             default = torch.backends.cuda.preferred_blas_library()
             if torch.version.cuda:
-                self.assertTrue(default == torch._C._BlasBackend.Cublaslt)
+                # CUDA logic is easy, it's always cublas
+                self.assertTrue(default == torch._C._BlasBackend.Cublas)
             else:
                 # ROCm logic is less so, it's cublaslt for some Instinct, cublas for all else
                 gcn_arch = str(

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -1246,7 +1246,7 @@ def sample_inputs_mv(self, device, dtype, requires_grad, **kwargs):
     yield SampleInput(make_arg(S, M), make_arg(M))
 
 def sample_inputs_bmm(self, device, dtype, requires_grad, **kwargs):
-    make_arg = partial(make_tensor, dtype=dtype, device=device, low=-1, high=+1, requires_grad=requires_grad)
+    make_arg = partial(make_tensor, dtype=dtype, device=device, low=None, high=None, requires_grad=requires_grad)
     yield SampleInput(make_arg(M, S, M), make_arg(M, M, S))
 
 def sample_inputs_dot_vdot(self, device, dtype, requires_grad, **kwargs):


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/benchmark/pull/2674


Original commit changeset: dd82c6ba3b37910568b2a25674149c1653768ec2

This reverts D94545016.

Test Plan: IN CI

Reviewed By: huydhn

Differential Revision: D96365273


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Lucaskabela