### PR TITLE
fix(typing): add TypeGuard[Tensor] annotation to is_tensor_like

### DIFF
--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -31,7 +31,7 @@ import warnings
 from collections.abc import Callable, Iterable
 from functools import wraps
 from typing import Any, cast, TypeVar
-from typing_extensions import ParamSpec
+from typing_extensions import ParamSpec, TypeGuard
 
 import torch
 from torch._C import (
@@ -2012,7 +2012,7 @@ def is_tensor_method_or_property(func: Callable) -> bool:
     return func in _get_tensor_methods() or func.__name__ == "__get__"
 
 
-def is_tensor_like(inp):
+def is_tensor_like(inp: object) -> "TypeGuard[torch.Tensor]":
     """
     Returns ``True`` if the passed-in input is a Tensor-like.
 


### PR DESCRIPTION
## Summary

- Adds `TypeGuard[torch.Tensor]` as the return type annotation for `is_tensor_like`
- Changes the `inp` parameter type to `object` (the correct type for TypeGuard predicates)
- Imports `TypeGuard` from `typing_extensions` (already a dependency)

This allows type checkers (mypy, pyright, etc.) to automatically narrow the type of a variable after an `is_tensor_like` check, without requiring explicit `cast()` calls.

**Before:**
```python
def is_tensor_like(inp):
```

**After:**
```python
def is_tensor_like(inp: object) -> "TypeGuard[torch.Tensor]":
```

Fixes #175324

## Test plan

- [ ] No logic changes — existing tests cover correctness
- [ ] Type checking: `mypy torch/overrides.py` should pass without errors
- [ ] `TypeGuard` is already available via `typing_extensions` which is an existing dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)