### PR TITLE
Fix DCP bug for Python>=3.13 where pickling code objects are no longer supported

### DIFF
--- a/torch/distributed/checkpoint/api.py
+++ b/torch/distributed/checkpoint/api.py
@@ -8,7 +8,11 @@ __all__ = ["CheckpointException"]
 
 
 def _wrap_exception(exc: BaseException) -> WRAPPED_EXCEPTION:
-    return (exc, tb.extract_tb(exc.__traceback__))
+    frames = tb.extract_tb(exc.__traceback__)
+    safe_summary = tb.StackSummary.from_list(
+        [(f.filename, f.lineno, f.name, f.line or '') for f in frames]
+    )
+    return (exc.with_traceback(None), safe_summary)
 
 
 def _is_wrapped_exception(obj: Any) -> bool:


### PR DESCRIPTION
Fix for https://github.com/pytorch/pytorch/issues/174669

Python 3.13 forbids pickling FrameSummary objects (contain code refs), which causes DCP's exception-gathering mechanism to fail with a misleading "cannot pickle code objects" error instead of the real underlying error. The corrected _wrap_execption function builds a StackSummary from plain tuple data, with no live frame/code refs, so it pickles cleanly while remaining compatible with `CheckpointException.__str__` and `_is_wrapped_exception` logic in DCP utils.