### PR TITLE
[Inductor] Add max_autotune for combo kernels

### DIFF
--- a/test/inductor/test_combo_kernels.py
+++ b/test/inductor/test_combo_kernels.py
@@ -2,6 +2,7 @@
 
 import contextlib
 import json
+import logging
 import sys
 import tempfile
 import unittest
@@ -1171,6 +1172,83 @@ class ComboKernelPDLTests(TestCase):
         out_compiled = torch.compile(fn)(*inps)
 
         self.assertEqual(out_eager, out_compiled)
+
+
+class ComboKernelTestsMaxAutotune(TestCase):
+    def setUp(self):
+        super().setUp()
+        torch._inductor.metrics.reset()
+        self._test_stack = contextlib.ExitStack()
+        self._test_stack.enter_context(
+            torch._inductor.config.patch(
+                {
+                    "combo_kernels": True,
+                    "benchmark_combo_kernel": False,
+                    "combo_kernel_per_subkernel_blocks": True,
+                    "max_autotune": True,
+                    "autotune_local_cache": False,
+                }
+            )
+        )
+
+    def tearDown(self):
+        self._test_stack.close()
+        torch._inductor.metrics.reset()
+        super().tearDown()
+
+    @requires_gpu_and_triton
+    def test_combo_kernel_max_autotune(self):
+        def fn(a, b, c):
+            a1 = torch.nn.functional.relu(a)
+            b1 = torch.nn.functional.sigmoid(b)
+            c1 = torch.nn.functional.tanh(c)
+            return a1, b1, c1
+
+        inps = [
+            torch.rand(32, 1024, device=GPU_TYPE),
+            torch.rand(64, 512, device=GPU_TYPE),
+            torch.rand(16, 2048, device=GPU_TYPE),
+        ]
+
+        out_eager = fn(*inps)
+        fn_c = torch.compile(fn)
+
+        logger = logging.getLogger("torch._inductor.runtime.triton_heuristics")
+        with self.assertLogs(logger, level=logging.DEBUG) as cm:
+            out_compiled, code = run_and_get_code(fn_c, *inps)
+        best_config_logs = [msg for msg in cm.output if "Best config" in msg]
+        self.assertGreater(
+            len(best_config_logs),
+            0,
+            "autotune_to_one_config was not invoked — no 'Best config' log found",
+        )
+        self.assertEqual(out_eager, out_compiled)
+        self.assertEqual(torch._inductor.metrics.generated_kernel_count, 1)
+
+    @requires_gpu_and_triton
+    def test_combo_kernel_max_autotune_with_reduction(self):
+        def fn(x, y):
+            return x.sum(dim=-1), y.mean(dim=-1)
+
+        inps = [
+            torch.rand(128, 256, device=GPU_TYPE),
+            torch.rand(128, 256, device=GPU_TYPE),
+        ]
+
+        out_eager = fn(*inps)
+        fn_c = torch.compile(fn)
+
+        logger = logging.getLogger("torch._inductor.runtime.triton_heuristics")
+        with self.assertLogs(logger, level=logging.DEBUG) as cm:
+            out_compiled, code = run_and_get_code(fn_c, *inps)
+        best_config_logs = [msg for msg in cm.output if "Best config" in msg]
+        self.assertGreater(
+            len(best_config_logs),
+            0,
+            "autotune_to_one_config was not invoked — no 'Best config' log found",
+        )
+        self.assertEqual(out_eager, out_compiled)
+        self.assertEqual(torch._inductor.metrics.generated_kernel_count, 1)
 
 
 if __name__ == "__main__":

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -2811,10 +2811,6 @@ def _handle_combo_kernel_per_subkernel_blocks(
 
     unique_warp_stage_pairs.add((max(all_num_warps), max(all_num_stages)))
 
-    # Generate phase configs: vary one sub-kernel's block sizes at a time.
-    # Each heuristic (pointwise/reduction/etc.) returns multiple configs only
-    # when its max autotune flag is enabled, so len(phase_cfgs) <= 1
-    # naturally skips sub-kernels that shouldn't be autotuned.
     phase_configs: list[Config] = []
     base_num_warps = max(all_num_warps)
     base_num_stages = max(all_num_stages)
@@ -2843,7 +2839,7 @@ def _handle_combo_kernel_per_subkernel_blocks(
 
     base_configs = [
         triton.Config(
-            dict(combined_kwargs),
+            combined_kwargs,
             num_warps=num_warps,
             num_stages=num_stages,
         )

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -2732,6 +2732,10 @@ def _handle_combo_kernel_per_subkernel_blocks(
     using the same heuristics as standalone Triton kernels. The final config uses
     the maximum num_warps and num_stages across all sub-kernels.
 
+    When autotuning is enabled (i.e. the heuristic returns multiple configs),
+    generates O(N*K) phase configs that vary one sub-kernel's block sizes at a
+    time, feeding into the standard autotune_to_one_config path.
+
     Returns:
         List of configs if combo kernel with combo_grid_meta and per-subkernel
         blocks enabled, None otherwise.
@@ -2750,12 +2754,15 @@ def _handle_combo_kernel_per_subkernel_blocks(
     all_num_stages: list[int] = []
     unique_warp_stage_pairs: OrderedSet[tuple[int, int]] = OrderedSet()
 
+    all_subkernel_cfgs: list[list[Config]] = []
+    all_skip_rblock: list[bool] = []
+
     for i in range(num_kernels):
         subkernel_heuristic = combo_meta[f"heuristic_{i}"]
         size_hints_i = combo_meta[f"size_hints_{i}"]
 
         if subkernel_heuristic == "pointwise":
-            cfg = pointwise(
+            cfgs = pointwise(
                 size_hints_i,
                 triton_meta=triton_meta,
                 tile_hint=TileHint.SQUARE
@@ -2765,31 +2772,32 @@ def _handle_combo_kernel_per_subkernel_blocks(
                 min_elem_per_thread=min_elem_per_thread,
                 inductor_meta=inductor_meta_clean,
                 return_configs=True,
-            )[0]
+            )
             skip_rblock = False
         elif subkernel_heuristic == "reduction":
-            cfg = reduction(
+            cfgs = reduction(
                 size_hints_i,
                 reduction_hint=reduction_hint,
                 triton_meta=triton_meta,
                 filename=filename,
                 inductor_meta=inductor_meta_clean,
                 return_configs=True,
-            )[0]
+            )
             skip_rblock = False
         elif subkernel_heuristic == "persistent_reduction":
-            cfg = persistent_reduction(
+            cfgs = persistent_reduction(
                 size_hints_i,
                 reduction_hint=reduction_hint,
                 triton_meta=triton_meta,
                 filename=filename,
                 inductor_meta=inductor_meta_clean,
                 return_configs=True,
-            )[0]
+            )
             skip_rblock = True  # persistent reduction embeds RBLOCK in kernel body
         else:
             raise ValueError(f"Unknown heuristic: {subkernel_heuristic}")
 
+        cfg = cfgs[0]
         for key, value in cfg.kwargs.items():
             if skip_rblock and key.startswith("R") and "BLOCK" in key:
                 continue
@@ -2798,17 +2806,50 @@ def _handle_combo_kernel_per_subkernel_blocks(
         all_num_warps.append(cfg.num_warps)
         all_num_stages.append(cfg.num_stages)
         unique_warp_stage_pairs.add((cfg.num_warps, cfg.num_stages))
+        all_subkernel_cfgs.append(cfgs)
+        all_skip_rblock.append(skip_rblock)
 
     unique_warp_stage_pairs.add((max(all_num_warps), max(all_num_stages)))
 
-    return [
+    # Generate phase configs: vary one sub-kernel's block sizes at a time.
+    # Each heuristic (pointwise/reduction/etc.) returns multiple configs only
+    # when its max autotune flag is enabled, so len(phase_cfgs) <= 1
+    # naturally skips sub-kernels that shouldn't be autotuned.
+    phase_configs: list[Config] = []
+    base_num_warps = max(all_num_warps)
+    base_num_stages = max(all_num_stages)
+
+    for phase_idx in range(num_kernels):
+        phase_cfgs = all_subkernel_cfgs[phase_idx]
+        skip_rblock = all_skip_rblock[phase_idx]
+
+        if len(phase_cfgs) <= 1:
+            continue
+
+        for cfg in phase_cfgs[1:]:
+            phase_kwargs = dict(combined_kwargs)
+            for key, value in cfg.kwargs.items():
+                if skip_rblock and key.startswith("R") and "BLOCK" in key:
+                    continue
+                phase_kwargs[f"{key}_{phase_idx}"] = value
+
+            phase_configs.append(
+                triton.Config(
+                    phase_kwargs,
+                    num_warps=base_num_warps,
+                    num_stages=base_num_stages,
+                )
+            )
+
+    base_configs = [
         triton.Config(
-            combined_kwargs,
+            dict(combined_kwargs),
             num_warps=num_warps,
             num_stages=num_stages,
         )
         for num_warps, num_stages in unique_warp_stage_pairs
     ]
+    return base_configs + phase_configs
 
 
 def triton_config_tiled_reduction(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #177725
* __->__ #177715

Previously, combo kernels with per-subkernel block sizes only used heuristic configs, `max_autotune` had no effect. This PR extends the autotuning pipeline to generate and benchmark multiple configs for combo kernels.

When autotuning is enabled, `_handle_combo_kernel_per_subkernel_blocks` generates O(N×K) "phase configs" that vary one sub-kernel's block sizes at a time while keeping others at the heuristic default. These feed into the
existing `autotune_to_one_config` path. 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos