### PR TITLE
[CI] Add riscv64 manywheel Docker image

### DIFF
--- a/.ci/docker/common/patch_libstdc.sh
+++ b/.ci/docker/common/patch_libstdc.sh
@@ -6,4 +6,6 @@ set -xe
 # see: https://github.com/pytorch/pytorch/issues/133437
 LIBNONSHARED=$(gcc -print-file-name=libstdc++_nonshared.a)
 nm -g $LIBNONSHARED | grep " T " | grep recursive_directory_iterator | cut -c 20-  > weaken-symbols.txt
-objcopy --weaken-symbols weaken-symbols.txt $LIBNONSHARED $LIBNONSHARED
+if [ $(wc -l weaken-symbols.txt | cut -d ' ' -f 1) != "0" ]; then
+    objcopy --weaken-symbols weaken-symbols.txt $LIBNONSHARED $LIBNONSHARED
+fi

--- a/.ci/docker/manywheel/Dockerfile_2_39_riscv64
+++ b/.ci/docker/manywheel/Dockerfile_2_39_riscv64
@@ -1,0 +1,121 @@
+ARG GPU_IMAGE=almalinux:10-kitten
+FROM quay.io/pypa/manylinux_2_39_riscv64 as base
+
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
+ENV LANGUAGE=C.UTF-8
+
+ARG DEVTOOLSET_VERSION=15
+RUN yum install -y sudo wget curl perl util-linux xz bzip2 git patch which perl zlib-devel yum-utils gcc-toolset-${DEVTOOLSET_VERSION}-gcc gcc-toolset-${DEVTOOLSET_VERSION}-gcc-c++ gcc-toolset-${DEVTOOLSET_VERSION}-gcc-gfortran
+ENV PATH=/opt/rh/gcc-toolset-${DEVTOOLSET_VERSION}/root/usr/bin:$PATH
+ENV LD_LIBRARY_PATH=/opt/rh/gcc-toolset-${DEVTOOLSET_VERSION}/root/usr/lib64:/opt/rh/gcc-toolset-${DEVTOOLSET_VERSION}/root/usr/lib:$LD_LIBRARY_PATH
+
+# Add RISE PyPI index for binary packages already built on RISC-V
+ENV PIP_INDEX_URL=https://gitlab.com/api/v4/projects/riseproject%2Fpython%2Fwheel_builder/packages/pypi/simple
+
+# cmake-3.31.6 from pip
+RUN yum install -y python3-pip && \
+    python3 -mpip install --upgrade pip && \
+    python3 -mpip install cmake==3.31.6 && \
+    ln -s /usr/local/bin/cmake /usr/bin/cmake3
+
+FROM base as openssl
+# Install openssl (this must precede `build python` step)
+# (In order to have a proper SSL module, Python is compiled
+# against a recent openssl [see env vars above], which is linked
+# statically. We delete openssl afterwards.)
+ADD ./common/install_openssl.sh install_openssl.sh
+RUN bash ./install_openssl.sh && rm install_openssl.sh
+
+
+# OpenBLAS fails to build because gcc-toolset-${DEVTOOLSET_VERSION}-gcc is missing riscv_vector.h. Use
+# the distribution openblas-devel for now
+# FROM base as openblas
+# # Install openblas
+# ARG OPENBLAS_VERSION
+# ADD ./common/install_openblas.sh install_openblas.sh
+# RUN bash ./install_openblas.sh && rm install_openblas.sh
+
+FROM base as jni
+# Install java jni header
+ADD ./common/install_jni.sh install_jni.sh
+ADD ./java/jni.h jni.h
+RUN bash ./install_jni.sh && rm install_jni.sh
+
+FROM base as libpng
+# Install libpng
+ADD ./common/install_libpng.sh install_libpng.sh
+RUN bash ./install_libpng.sh && rm install_libpng.sh
+
+FROM ${GPU_IMAGE} as common
+ARG DEVTOOLSET_VERSION=15
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
+ENV LANGUAGE=C.UTF-8
+RUN yum -y update
+RUN yum install -y \
+        autoconf \
+        automake \
+        bison \
+        bzip2 \
+        curl \
+        diffutils \
+        file \
+        git \
+        make \
+        openblas-devel \
+        patch \
+        perl \
+        unzip \
+        util-linux \
+        wget \
+        which \
+        xz \
+        glibc-langpack-en \
+        gcc-toolset-${DEVTOOLSET_VERSION}-gcc \
+        gcc-toolset-${DEVTOOLSET_VERSION}-gcc-c++ \
+        gcc-toolset-${DEVTOOLSET_VERSION}-gcc-gfortran
+
+# git236+ would refuse to run git commands in repos owned by other users
+# Which causes version check to fail, as pytorch repo is bind-mounted into the image
+# Override this behaviour by treating every folder as safe
+# For more details see https://github.com/pytorch/pytorch/issues/78659#issuecomment-1144107327
+RUN git config --global --add safe.directory "*"
+
+# Add RISE PyPI index for binary packages already built on RISC-V
+ENV PIP_INDEX_URL=https://gitlab.com/api/v4/projects/riseproject%2Fpython%2Fwheel_builder/packages/pypi/simple
+
+ENV SSL_CERT_FILE=/opt/_internal/certs.pem
+# Install LLVM version
+COPY --from=openssl            /opt/openssl                          /opt/openssl
+COPY --from=base               /opt/python                           /opt/python
+COPY --from=base               /usr/local/lib/                       /usr/local/lib/
+COPY --from=base               /opt/_internal                        /opt/_internal
+COPY --from=base               /usr/local/bin/auditwheel             /usr/local/bin/auditwheel
+# COPY --from=openblas           /opt/OpenBLAS                         /opt/OpenBLAS
+COPY --from=base               /usr/local/bin/patchelf               /usr/local/bin/patchelf
+COPY --from=libpng             /usr/local/bin/png*                   /usr/local/bin/
+COPY --from=libpng             /usr/local/bin/libpng*                /usr/local/bin/
+COPY --from=libpng             /usr/local/include/png*               /usr/local/include/
+COPY --from=libpng             /usr/local/include/libpng*            /usr/local/include/
+COPY --from=libpng             /usr/local/lib/libpng*                /usr/local/lib/
+COPY --from=libpng             /usr/local/lib/pkgconfig              /usr/local/lib/pkgconfig
+COPY --from=jni                /usr/local/include/jni.h              /usr/local/include/jni.h
+
+FROM common as cpu_final
+ARG DEVTOOLSET_VERSION=15
+# Ensure the expected devtoolset is used
+ENV PATH=/opt/rh/gcc-toolset-${DEVTOOLSET_VERSION}/root/usr/bin:$PATH
+ENV LD_LIBRARY_PATH=/opt/rh/gcc-toolset-${DEVTOOLSET_VERSION}/root/usr/lib64:/opt/rh/gcc-toolset-${DEVTOOLSET_VERSION}/root/usr/lib:$LD_LIBRARY_PATH
+# Install setuptools and wheel for python 3.12/3.13
+RUN for cpython_version in "cp312-cp312" "cp313-cp313" "cp313-cp313t"; do \
+    /opt/python/${cpython_version}/bin/python -m pip install setuptools wheel; \
+    done;
+ADD ./common/patch_libstdc.sh patch_libstdc.sh
+RUN bash ./patch_libstdc.sh && rm patch_libstdc.sh
+
+# cmake-3.31.6 from pip; force in case cmake3 already exists
+RUN yum install -y python3-pip && \
+    python3 -mpip install --upgrade pip && \
+    python3 -mpip install cmake==3.31.6 && \
+    ln -sf /usr/local/bin/cmake /usr/bin/cmake3

--- a/.ci/docker/manywheel/build.sh
+++ b/.ci/docker/manywheel/build.sh
@@ -43,6 +43,12 @@ case ${image} in
         DOCKER_GPU_BUILD_ARG=" --build-arg DEVTOOLSET_VERSION=13 --build-arg NINJA_VERSION=1.12.1"
         MANY_LINUX_VERSION="2_28_aarch64"
         ;;
+    manylinux2_39_riscv64-builder:cpu-riscv64)
+        TARGET=cpu_final
+        GPU_IMAGE=almalinux:10-kitten
+        DOCKER_GPU_BUILD_ARG=" --build-arg DEVTOOLSET_VERSION=15"
+        MANY_LINUX_VERSION="2_39_riscv64"
+        ;;
     manylinuxs390x-builder:cpu-s390x)
         TARGET=final
         GPU_IMAGE=s390x/almalinux:8
@@ -110,7 +116,7 @@ if [[ -n ${MANY_LINUX_VERSION} && -z ${DOCKERFILE_SUFFIX} ]]; then
     DOCKERFILE_SUFFIX=_${MANY_LINUX_VERSION}
 fi
 # Only activate this if in CI
-if [ "$(uname -m)" != "s390x" ] && [ -v CI ]; then
+if [ "$(uname -m)" != "s390x" ] && [ "$(uname -m)" != "riscv64" ] && [ -v CI ]; then
     # TODO: Remove LimitNOFILE=1048576 patch once https://github.com/pytorch/test-infra/issues/5712
     # is resolved. This patch is required in order to fix timing out of Docker build on Amazon Linux 2023.
     sudo sed -i s/LimitNOFILE=infinity/LimitNOFILE=1048576/ /usr/lib/systemd/system/docker.service

--- a/.ci/manywheel/build.sh
+++ b/.ci/manywheel/build.sh
@@ -11,7 +11,7 @@ case "${GPU_ARCH_TYPE:-BLANK}" in
     rocm)
         bash "${SCRIPTPATH}/build_rocm.sh"
         ;;
-    cpu | cpu-cxx11-abi | cpu-aarch64 | cpu-s390x)
+    cpu | cpu-cxx11-abi | cpu-aarch64 | cpu-s390x | cpu-riscv64)
         bash "${SCRIPTPATH}/build_cpu.sh"
         ;;
     xpu)

--- a/.github/workflows/build-manywheel-images.yml
+++ b/.github/workflows/build-manywheel-images.yml
@@ -62,6 +62,7 @@ jobs:
           { name: "manylinux2_28-builder",          tag: "cpu",               runner: "linux.9xlarge.ephemeral" },
           { name: "manylinux2_28_aarch64-builder",  tag: "cpu-aarch64",       runner: "linux.arm64.2xlarge.ephemeral" },
           { name: "manylinux2_28-builder",          tag: "xpu",               runner: "linux.9xlarge.ephemeral" },
+          { name: "manylinux2_39_riscv64-builder",  tag: "cpu-riscv64",       runner: "linux.riscv64.2xlarge.ephemeral" },
         ]
     runs-on: ${{ needs.get-label-type.outputs.label-type }}${{ matrix.runner }}
     name: ${{ matrix.name }}:${{ matrix.tag }}


### PR DESCRIPTION
The RISC-V runners are made available through https://github.com/apps/rise-risc-v-runners. cc @malfet 

As part of the broader effort to bring PyTorch to RISC-V, this adds the
CI infrastructure to build manywheel Docker images for riscv64.

The Dockerfile is based on AlmaLinux Kitten 10 and gcc-toolset-15. Binary
Python dependencies (e.g. cmake, ninja) are sourced from the RISE PyPI
index at `gitlab.com/riseproject/python/wheel_builder`.

Notable riscv64-specific changes in the shared build scripts:
- `patch_libstdc.sh` now skips `objcopy --weaken-symbols` when no
  matching symbols are found, which is the case on riscv64.