### PR TITLE
[CD] Update triton xpu release branch naming convention

### DIFF
--- a/.github/scripts/build_triton_wheel.py
+++ b/.github/scripts/build_triton_wheel.py
@@ -81,9 +81,16 @@ def build_triton(
         check_call(["git", "clone", triton_repo, "triton"], cwd=tmpdir)
         if release:
             ver, rev, patch = version.split(".")
-            check_call(
-                ["git", "checkout", f"release/{ver}.{rev}.x"], cwd=triton_basedir
-            )
+            if device == "xpu":
+                # XPU uses the patch version in the release branch name
+                check_call(
+                    ["git", "checkout", f"release/{ver}.{rev}.{patch}"],
+                    cwd=triton_basedir,
+                )
+            else:
+                check_call(
+                    ["git", "checkout", f"release/{ver}.{rev}.x"], cwd=triton_basedir
+                )
         else:
             check_call(["git", "fetch", "origin", commit_hash], cwd=triton_basedir)
             check_call(["git", "checkout", commit_hash], cwd=triton_basedir)


### PR DESCRIPTION
As the triton xpu has standalone repo, and the update cadence in pytorch is different with upstream triton. To mitigate the version gap between those 2 kinds of triton, consider patch version into release branch naming for triton xpu. It just impact release wheel build.