### PR TITLE
Introduce test skip markers for Sandcastle

### DIFF
--- a/test/benchmark_utils/test_benchmark_utils.py
+++ b/test/benchmark_utils/test_benchmark_utils.py
@@ -15,9 +15,9 @@ import numpy as np
 import torch
 import torch.utils.benchmark as benchmark_utils
 from torch.testing._internal.common_utils import (
-    IS_SANDCASTLE,
     IS_WINDOWS,
     run_tests,
+    skipIfSandcastle,
     slowTest,
     TEST_WITH_ASAN,
     TestCase,
@@ -189,7 +189,7 @@ class TestBenchmarkUtils(TestCase):
         self.assertIsInstance(sample, float)
 
     @slowTest
-    @unittest.skipIf(IS_SANDCASTLE, "C++ timing is OSS only.")
+    @skipIfSandcastle("C++ timing is OSS only.")
     @unittest.skipIf(True, "Failing on clang, see 74398")
     def test_timer_tiny_fast_snippet(self):
         timer = benchmark_utils.Timer(
@@ -201,7 +201,7 @@ class TestBenchmarkUtils(TestCase):
         self.assertIsInstance(median, float)
 
     @slowTest
-    @unittest.skipIf(IS_SANDCASTLE, "C++ timing is OSS only.")
+    @skipIfSandcastle("C++ timing is OSS only.")
     @unittest.skipIf(True, "Failing on clang, see 74398")
     def test_cpp_timer(self):
         timer = benchmark_utils.Timer(
@@ -495,7 +495,7 @@ class TestBenchmarkUtils(TestCase):
 
     @slowTest
     @unittest.skipIf(IS_WINDOWS, "Valgrind is not supported on Windows.")
-    @unittest.skipIf(IS_SANDCASTLE, "Valgrind is OSS only.")
+    @skipIfSandcastle("Valgrind is OSS only.")
     @unittest.skipIf(TEST_WITH_ASAN, "fails on asan")
     def test_collect_callgrind(self):
         with self.assertRaisesRegex(
@@ -577,7 +577,7 @@ class TestBenchmarkUtils(TestCase):
 
     @slowTest
     @unittest.skipIf(IS_WINDOWS, "Valgrind is not supported on Windows.")
-    @unittest.skipIf(IS_SANDCASTLE, "Valgrind is OSS only.")
+    @skipIfSandcastle("Valgrind is OSS only.")
     @unittest.skipIf(True, "Failing on clang, see 74398")
     def test_collect_cpp_callgrind(self):
         timer = benchmark_utils.Timer(

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -80,7 +80,6 @@ from torch.testing._internal.common_utils import (
     find_library_location,
     IS_FBCODE,
     IS_MACOS,
-    IS_SANDCASTLE,
     IS_WINDOWS,
     run_tests,
     skipIfCrossRef,

--- a/test/jit/test_backends.py
+++ b/test/jit/test_backends.py
@@ -3,7 +3,6 @@
 import io
 import os
 import sys
-import unittest
 
 import torch
 import torch._C
@@ -11,11 +10,10 @@ from torch.jit.mobile import _load_for_lite_interpreter
 from torch.testing import FileCheck
 from torch.testing._internal.common_utils import (
     find_library_location,
-    IS_FBCODE,
     IS_MACOS,
-    IS_SANDCASTLE,
     IS_WINDOWS,
     raise_on_run_directly,
+    skipIfMetaOr,
 )
 from torch.testing._internal.jit_utils import JitTestCase
 
@@ -58,8 +56,8 @@ class BasicModule(torch.nn.Module):
 
 
 # This is ignored in IS_WINDOWS or IS_MACOS cases. Hence we need the one in TestBackends.
-@unittest.skipIf(
-    IS_SANDCASTLE or IS_WINDOWS or IS_MACOS or IS_FBCODE,
+@skipIfMetaOr(
+    IS_WINDOWS or IS_MACOS,
     "Non-portable load_library call used in test",
 )
 class JitBackendTestCase(JitTestCase):
@@ -442,8 +440,8 @@ class SelectiveLoweringTest(JitBackendTestCase):
 
 
 # This is needed for IS_WINDOWS or IS_MACOS to skip the tests.
-@unittest.skipIf(
-    IS_SANDCASTLE or IS_WINDOWS or IS_MACOS or IS_FBCODE,
+@skipIfMetaOr(
+    IS_WINDOWS or IS_MACOS,
     "Non-portable load_library call used in test",
 )
 class TestBackends(JitTestCase):
@@ -501,8 +499,8 @@ class BasicModuleAdd(torch.nn.Module):
 
 
 # This is ignored in IS_WINDOWS or IS_MACOS cases. Hence we need the one in TestBackends.
-@unittest.skipIf(
-    IS_SANDCASTLE or IS_WINDOWS or IS_MACOS or IS_FBCODE,
+@skipIfMetaOr(
+    IS_WINDOWS or IS_MACOS,
     "Non-portable load_library call used in test",
 )
 class JitBackendTestCaseWithCompiler(JitTestCase):
@@ -684,8 +682,8 @@ class CompModuleTestWithCompiler(JitBackendTestCase):
 
 
 # This is needed for IS_WINDOWS or IS_MACOS to skip the tests.
-@unittest.skipIf(
-    IS_SANDCASTLE or IS_WINDOWS or IS_MACOS or IS_FBCODE,
+@skipIfMetaOr(
+    IS_WINDOWS or IS_MACOS,
     "Non-portable load_library call used in test",
 )
 class TestBackendsWithCompiler(JitTestCase):

--- a/test/jit/test_class_type.py
+++ b/test/jit/test_class_type.py
@@ -4,7 +4,6 @@
 import io
 import os
 import sys
-import unittest
 from typing import Any
 
 import torch
@@ -19,8 +18,8 @@ from typing import Dict, Iterable, List, Optional, Tuple
 
 import torch.testing._internal.jit_utils
 from torch.testing._internal.common_utils import (
-    IS_SANDCASTLE,
     raise_on_run_directly,
+    skipIfSandcastle,
     skipIfTorchDynamo,
 )
 from torch.testing._internal.jit_utils import JitTestCase, make_global
@@ -542,7 +541,7 @@ class TestClassType(JitTestCase):
             sc = torch.jit.script(fun)
 
     @skipIfTorchDynamo("Test does not work with TorchDynamo")
-    @unittest.skipIf(IS_SANDCASTLE, "Importing like this doesn't work in fbcode")
+    @skipIfSandcastle("Importing like this doesn't work in fbcode")
     def test_imported_classes(self):
         import jit._imported_class_test.bar
         import jit._imported_class_test.foo

--- a/test/jit/test_tracer.py
+++ b/test/jit/test_tracer.py
@@ -28,10 +28,10 @@ from torch import Tensor
 from torch.testing._internal.common_cuda import with_tf32_off
 from torch.testing._internal.common_utils import (
     enable_profiling_mode_for_profiling_tests,
-    IS_SANDCASTLE,
     raise_on_run_directly,
     skipIfCompiledWithoutNumpy,
     skipIfCrossRef,
+    skipIfSandcastle,
     skipIfTorchDynamo,
     suppress_warnings,
     TemporaryFileName,
@@ -943,7 +943,7 @@ class TestTracer(JitTestCase):
     def test_ge_unoptimized(self):
         self.run_ge_tests(False, False)
 
-    @unittest.skipIf(IS_SANDCASTLE, "NYI: fuser support for Sandcastle")
+    @skipIfSandcastle("NYI: fuser support for Sandcastle")
     @enable_cpu_fuser
     def test_ge_optimized(self):
         with enable_profiling_mode_for_profiling_tests():

--- a/test/jit/test_tracer.py
+++ b/test/jit/test_tracer.py
@@ -28,10 +28,10 @@ from torch import Tensor
 from torch.testing._internal.common_cuda import with_tf32_off
 from torch.testing._internal.common_utils import (
     enable_profiling_mode_for_profiling_tests,
-    IS_SANDCASTLE,
     raise_on_run_directly,
     skipIfCompiledWithoutNumpy,
     skipIfCrossRef,
+    skipIfSandcastle,
     skipIfTorchDynamo,
     suppress_warnings,
     TemporaryFileName,
@@ -945,7 +945,7 @@ class TestTracer(JitTestCase):
     def test_ge_unoptimized(self):
         self.run_ge_tests(False, False)
 
-    @unittest.skipIf(IS_SANDCASTLE, "NYI: fuser support for Sandcastle")
+    @skipIfSandcastle("NYI: fuser support for Sandcastle")
     @enable_cpu_fuser
     def test_ge_optimized(self):
         with enable_profiling_mode_for_profiling_tests():

--- a/test/package/test_directory_reader.py
+++ b/test/package/test_directory_reader.py
@@ -9,12 +9,7 @@ from unittest import skipIf
 
 import torch
 from torch.package import PackageExporter, PackageImporter
-from torch.testing._internal.common_utils import (
-    IS_FBCODE,
-    IS_SANDCASTLE,
-    IS_WINDOWS,
-    run_tests,
-)
+from torch.testing._internal.common_utils import IS_WINDOWS, run_tests, skipIfMetaOr
 
 
 try:
@@ -38,8 +33,8 @@ from pathlib import Path
 packaging_directory = Path(__file__).parent
 
 
-@skipIf(
-    IS_FBCODE or IS_SANDCASTLE or IS_WINDOWS,
+@skipIfMetaOr(
+    IS_WINDOWS,
     "Tests that use temporary files are disabled in fbcode",
 )
 class DirectoryReaderTest(PackageTestCase):

--- a/test/package/test_load_bc_packages.py
+++ b/test/package/test_load_bc_packages.py
@@ -1,10 +1,9 @@
 # Owner(s): ["oncall: package/deploy"]
 
 from pathlib import Path
-from unittest import skipIf
 
 from torch.package import PackageImporter
-from torch.testing._internal.common_utils import IS_FBCODE, IS_SANDCASTLE, run_tests
+from torch.testing._internal.common_utils import run_tests, skipIfMeta
 
 
 try:
@@ -19,28 +18,19 @@ packaging_directory = f"{Path(__file__).parent}/package_bc"
 class TestLoadBCPackages(PackageTestCase):
     """Tests for checking loading has backwards compatibility"""
 
-    @skipIf(
-        IS_FBCODE or IS_SANDCASTLE,
-        "Tests that use temporary files are disabled in fbcode",
-    )
+    @skipIfMeta("Tests that use temporary files are disabled in fbcode")
     def test_load_bc_packages_nn_module(self):
         """Tests for backwards compatible nn module"""
         importer1 = PackageImporter(f"{packaging_directory}/test_nn_module.pt")
         importer1.load_pickle("nn_module", "nn_module.pkl")
 
-    @skipIf(
-        IS_FBCODE or IS_SANDCASTLE,
-        "Tests that use temporary files are disabled in fbcode",
-    )
+    @skipIfMeta("Tests that use temporary files are disabled in fbcode")
     def test_load_bc_packages_torchscript_module(self):
         """Tests for backwards compatible torchscript module"""
         importer2 = PackageImporter(f"{packaging_directory}/test_torchscript_module.pt")
         importer2.load_pickle("torchscript_module", "torchscript_module.pkl")
 
-    @skipIf(
-        IS_FBCODE or IS_SANDCASTLE,
-        "Tests that use temporary files are disabled in fbcode",
-    )
+    @skipIfMeta("Tests that use temporary files are disabled in fbcode")
     def test_load_bc_packages_fx_module(self):
         """Tests for backwards compatible fx module"""
         importer3 = PackageImporter(f"{packaging_directory}/test_fx_module.pt")

--- a/test/package/test_load_bc_packages.py
+++ b/test/package/test_load_bc_packages.py
@@ -1,10 +1,9 @@
 # Owner(s): ["module: package/deploy"]
 
 from pathlib import Path
-from unittest import skipIf
 
 from torch.package import PackageImporter
-from torch.testing._internal.common_utils import IS_FBCODE, IS_SANDCASTLE, run_tests
+from torch.testing._internal.common_utils import run_tests, skipIfMeta
 
 
 try:
@@ -19,28 +18,19 @@ packaging_directory = f"{Path(__file__).parent}/package_bc"
 class TestLoadBCPackages(PackageTestCase):
     """Tests for checking loading has backwards compatibility"""
 
-    @skipIf(
-        IS_FBCODE or IS_SANDCASTLE,
-        "Tests that use temporary files are disabled in fbcode",
-    )
+    @skipIfMeta("Tests that use temporary files are disabled in fbcode")
     def test_load_bc_packages_nn_module(self):
         """Tests for backwards compatible nn module"""
         importer1 = PackageImporter(f"{packaging_directory}/test_nn_module.pt")
         importer1.load_pickle("nn_module", "nn_module.pkl")
 
-    @skipIf(
-        IS_FBCODE or IS_SANDCASTLE,
-        "Tests that use temporary files are disabled in fbcode",
-    )
+    @skipIfMeta("Tests that use temporary files are disabled in fbcode")
     def test_load_bc_packages_torchscript_module(self):
         """Tests for backwards compatible torchscript module"""
         importer2 = PackageImporter(f"{packaging_directory}/test_torchscript_module.pt")
         importer2.load_pickle("torchscript_module", "torchscript_module.pkl")
 
-    @skipIf(
-        IS_FBCODE or IS_SANDCASTLE,
-        "Tests that use temporary files are disabled in fbcode",
-    )
+    @skipIfMeta("Tests that use temporary files are disabled in fbcode")
     def test_load_bc_packages_fx_module(self):
         """Tests for backwards compatible fx module"""
         importer3 = PackageImporter(f"{packaging_directory}/test_fx_module.pt")

--- a/test/package/test_misc.py
+++ b/test/package/test_misc.py
@@ -7,14 +7,12 @@ import sys
 from io import BytesIO
 from pathlib import Path
 from textwrap import dedent
-from unittest import skipIf
 
 from torch.package import is_from_package, PackageExporter, PackageImporter
 from torch.package.package_exporter import PackagingError
 from torch.testing._internal.common_utils import (
-    IS_FBCODE,
-    IS_SANDCASTLE,
     run_tests,
+    skipIfMeta,
     skipIfTorchDynamo,
 )
 
@@ -194,10 +192,7 @@ class TestMisc(PackageTestCase):
 
         self.assertEqual(hi.python_version(), platform.python_version())
 
-    @skipIf(
-        IS_FBCODE or IS_SANDCASTLE,
-        "Tests that use temporary files are disabled in fbcode",
-    )
+    @skipIfMeta("Tests that use temporary files are disabled in fbcode")
     def test_load_python_version_from_package(self):
         """Tests loading a package with a python version embedded"""
         importer1 = PackageImporter(

--- a/test/package/test_model.py
+++ b/test/package/test_model.py
@@ -6,7 +6,7 @@ from unittest import skipIf
 
 import torch
 from torch.package import PackageExporter, PackageImporter, sys_importer
-from torch.testing._internal.common_utils import IS_FBCODE, IS_SANDCASTLE, run_tests
+from torch.testing._internal.common_utils import run_tests, skipIfMeta
 
 
 try:
@@ -32,10 +32,7 @@ except ImportError:
 class ModelTest(PackageTestCase):
     """End-to-end tests packaging an entire model."""
 
-    @skipIf(
-        IS_FBCODE or IS_SANDCASTLE,
-        "Tests that use temporary files are disabled in fbcode",
-    )
+    @skipIfMeta("Tests that use temporary files are disabled in fbcode")
     def test_resnet(self):
         resnet = resnet18()
 

--- a/test/package/test_package_script.py
+++ b/test/package/test_package_script.py
@@ -7,9 +7,8 @@ from unittest import skipIf
 import torch
 from torch.package import PackageExporter, PackageImporter
 from torch.testing._internal.common_utils import (
-    IS_FBCODE,
-    IS_SANDCASTLE,
     run_tests,
+    skipIfMeta,
     skipIfTorchDynamo,
 )
 
@@ -196,10 +195,7 @@ class TestPackageScript(PackageTestCase):
         input = torch.rand(1, 2, 3)
         self.assertEqual(loaded_mod(input), scripted_mod(input))
 
-    @skipIf(
-        IS_FBCODE or IS_SANDCASTLE,
-        "Tests that use temporary files are disabled in fbcode",
-    )
+    @skipIfMeta("Tests that use temporary files are disabled in fbcode")
     def test_save_scriptmodule_file(self):
         """
         Test basic saving of ScriptModule in file.

--- a/test/test_cuda_multigpu.py
+++ b/test/test_cuda_multigpu.py
@@ -27,11 +27,11 @@ from torch.testing._internal.common_utils import (
     IS_JETSON,
     IS_LINUX,
     IS_REMOTE_GPU,
-    IS_SANDCASTLE,
     NoTest,
     run_tests,
     serialTest,
     skipCUDANonDefaultStreamIf,
+    skipIfSandcastle,
     TEST_CUDA,
     TestCase,
 )
@@ -1122,7 +1122,8 @@ class TestCudaMultiGPU(TestCase):
         self.assertTrue(b.grad.sum().item() == 4 * size)
 
     @unittest.skipIf(not TEST_MULTIGPU, "only one GPU detected")
-    @unittest.skipIf(IS_SANDCASTLE or IS_REMOTE_GPU, "Does not work on Sandcastle")
+    @skipIfSandcastle("Does not work on sandcastle")
+    @unittest.skipIf(IS_REMOTE_GPU, "Does not work with remote GPU")
     def test_cuda_init_race(self):
         # See https://github.com/pytorch/pytorch/issues/16559
         import subprocess

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -32,12 +32,12 @@ from torch.testing._internal.common_utils import (
     IS_LINUX,
     IS_MACOS,
     IS_S390X,
-    IS_SANDCASTLE,
     IS_WINDOWS,
     load_tests,
     parametrize,
     run_tests,
     skipIfNoDill,
+    skipIfSandcastle,
     skipIfRocm,
     skipIfXpu,
     slowTest,
@@ -1321,7 +1321,7 @@ class TestDataLoader(TestCase):
         def _create_dataloader(is_train: bool) -> DataLoader[list[torch.Tensor]]:
             pass
 
-    @unittest.skipIf(IS_SANDCASTLE, "subprocess doesn't work in FB internal CI")
+    @skipIfSandcastle("subprocess doesn't work in FB internal CI")
     @unittest.skipIf(IS_WINDOWS, "No 'resource' module on Windows")
     def test_fd_limit_exceeded(self):
         # See NOTE [ DataLoader on Linux and open files limit ]
@@ -3374,7 +3374,7 @@ class TestDataLoaderPersistentWorkers(TestDataLoader):
         super().setUp()
         self.persistent_workers = True
 
-    @unittest.skipIf(IS_SANDCASTLE, "subprocess doesn't work in FB internal CI")
+    @skipIfSandcastle("subprocess doesn't work in FB internal CI")
     @unittest.skipIf(IS_WINDOWS, "No 'resource' module on Windows")
     def test_fd_limit_exceeded(self):
         # See NOTE [ DataLoader on Linux and open files limit ]
@@ -3540,7 +3540,7 @@ except RuntimeError as e:
                 # and can cache values safely
                 dataset.start = i
 
-    @unittest.skipIf(IS_SANDCASTLE, "subprocess doesn't work in FB internal CI")
+    @skipIfSandcastle("subprocess doesn't work in FB internal CI")
     @unittest.skipIf(IS_WINDOWS, "Needs fork")
     def test_early_exit(self):
         import subprocess

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -33,13 +33,13 @@ from torch.testing._internal.common_utils import (
     IS_LINUX,
     IS_MACOS,
     IS_S390X,
-    IS_SANDCASTLE,
     IS_WINDOWS,
     load_tests,
     parametrize,
     run_tests,
     skipIfNoDill,
     skipIfRocm,
+    skipIfSandcastle,
     skipIfXpu,
     slowTest,
     TEST_CUDA,
@@ -1332,7 +1332,7 @@ class TestDataLoader(TestCase):
         def _create_dataloader(is_train: bool) -> DataLoader[list[torch.Tensor]]:
             pass
 
-    @unittest.skipIf(IS_SANDCASTLE, "subprocess doesn't work in FB internal CI")
+    @skipIfSandcastle("subprocess doesn't work in FB internal CI")
     @unittest.skipIf(IS_WINDOWS, "No 'resource' module on Windows")
     def test_fd_limit_exceeded(self):
         # See NOTE [ DataLoader on Linux and open files limit ]
@@ -3289,7 +3289,7 @@ class TestDataLoaderPersistentWorkers(TestDataLoader):
         super().setUp()
         self.persistent_workers = True
 
-    @unittest.skipIf(IS_SANDCASTLE, "subprocess doesn't work in FB internal CI")
+    @skipIfSandcastle("subprocess doesn't work in FB internal CI")
     @unittest.skipIf(IS_WINDOWS, "No 'resource' module on Windows")
     def test_fd_limit_exceeded(self):
         # See NOTE [ DataLoader on Linux and open files limit ]
@@ -3455,7 +3455,7 @@ except RuntimeError as e:
                 # and can cache values safely
                 dataset.start = i
 
-    @unittest.skipIf(IS_SANDCASTLE, "subprocess doesn't work in FB internal CI")
+    @skipIfSandcastle("subprocess doesn't work in FB internal CI")
     @unittest.skipIf(IS_WINDOWS, "Needs fork")
     def test_early_exit(self):
         import subprocess

--- a/test/test_hub.py
+++ b/test/test_hub.py
@@ -2,7 +2,6 @@
 
 import os
 import tempfile
-import unittest
 import warnings
 import zipfile
 from unittest.mock import patch
@@ -10,9 +9,9 @@ from unittest.mock import patch
 import torch
 import torch.hub as hub
 from torch.testing._internal.common_utils import (
-    IS_SANDCASTLE,
     retry,
     run_tests,
+    skipIfSandcastle,
     skipIfTorchDynamo,
     TestCase,
 )
@@ -31,7 +30,7 @@ TORCHHUB_EXAMPLE_RELEASE_URL = (
 )
 
 
-@unittest.skipIf(IS_SANDCASTLE, "Sandcastle cannot ping external")
+@skipIfSandcastle("Sandcastle cannot ping external")
 class TestHub(TestCase):
     def setUp(self):
         super().setUp()

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -104,10 +104,10 @@ import torch.nn.functional as F
 from torch.testing._internal import jit_utils
 from torch.testing._internal.common_jit import check_against_reference
 from torch.testing._internal.common_utils import run_tests, IS_WINDOWS, \
-    GRAPH_EXECUTOR, suppress_warnings, IS_SANDCASTLE, ProfilingMode, \
+    GRAPH_EXECUTOR, suppress_warnings, ProfilingMode, \
     TestCase, freeze_rng_state, slowTest, TemporaryFileName, \
     enable_profiling_mode_for_profiling_tests, requires_mkl, set_default_dtype, num_profiled_runs, \
-    skipIfCrossRef, skipIfTorchDynamo
+    skipIfCrossRef, skipIfSandcastle, skipIfTorchDynamo
 from torch.testing._internal.jit_utils import JitTestCase, enable_cpu_fuser, disable_autodiff_subgraph_inlining, \
     _trace, do_input_map, get_execution_plan, make_global, \
     execWrapper, _inline_everything, _tmp_donotuse_dont_inline_everything, \
@@ -1791,7 +1791,7 @@ graph(%Ra, %Rb):
         for node in g.nodes():
             self.assertTrue(g2.findNode(node.kind()) is not None)
 
-    @unittest.skipIf(IS_SANDCASTLE, "gtest runs these in sandcastle")
+    @skipIfSandcastle("gtest runs these in sandcastle")
     @unittest.skipIf(RUN_CUDA, "covered by test_cpp_cuda")
     @unittest.skipIf(not torch._C._jit_has_cpp_tests(), "Tests were not built, use BUILD_TEST=1")
     def test_cpp(self):
@@ -5726,7 +5726,7 @@ a")
         self.assertEqual(cu.test_integral_shape_inference(*inputs), outputs)
 
     @unittest.skipIf(RUN_CUDA, 'This tests the CPU fuser')
-    @unittest.skipIf(IS_SANDCASTLE, "NYI: fuser support for Sandcastle")
+    @skipIfSandcastle("NYI: fuser support for Sandcastle")
     @enable_cpu_fuser
     def test_batchnorm_fuser_cpu(self):
         code = '''
@@ -5756,7 +5756,7 @@ a")
 
     @slowTest
     @unittest.skipIf(RUN_CUDA, 'This tests the CPU fuser')
-    @unittest.skipIf(IS_SANDCASTLE, "NYI: fuser support for Sandcastle")
+    @skipIfSandcastle("NYI: fuser support for Sandcastle")
     @enable_cpu_fuser
     def test_fuser_double_float_codegen(self):
         fns = ['log', 'log10', 'log1p', 'log2', 'lgamma', 'exp', 'expm1', 'erf',
@@ -5807,7 +5807,7 @@ a")
             test_dispatch(fn, lookup_c_equivalent_fn(fn) + 'f(', torch.float, binary=True)
 
     @unittest.skipIf(RUN_CUDA, 'This tests the CPU fuser')
-    @unittest.skipIf(IS_SANDCASTLE, "NYI: fuser support for Sandcastle")
+    @skipIfSandcastle("NYI: fuser support for Sandcastle")
     @enable_cpu_fuser
     def test_fuser_double_literal_precision(self):
         code = '''
@@ -13656,7 +13656,7 @@ dedent """
             self.checkScript(test_oct, (n,))
             self.checkScript(test_hex, (n,))
 
-    @unittest.skipIf(IS_SANDCASTLE, "NYI: TemporaryFileName support for Sandcastle")
+    @skipIfSandcastle("NYI: TemporaryFileName support for Sandcastle")
     def test_get_set_state(self):
         class Root(torch.jit.ScriptModule):
             __constants__ = ['number']
@@ -15387,7 +15387,7 @@ dedent """
             return 1
         self.assertEqual(fun(), 1)
 
-    @unittest.skipIf(IS_SANDCASTLE, "NYI: TemporaryFileName support for Sandcastle")
+    @skipIfSandcastle("NYI: TemporaryFileName support for Sandcastle")
     def test_attribute_unpickling(self):
         tensor = torch.randn(2, 2)
         tester = self

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -104,10 +104,10 @@ import torch.nn.functional as F
 from torch.testing._internal import jit_utils
 from torch.testing._internal.common_jit import check_against_reference
 from torch.testing._internal.common_utils import run_tests, IS_WINDOWS, \
-    GRAPH_EXECUTOR, suppress_warnings, IS_SANDCASTLE, ProfilingMode, \
+    GRAPH_EXECUTOR, suppress_warnings, ProfilingMode, \
     TestCase, freeze_rng_state, slowTest, TemporaryFileName, \
     enable_profiling_mode_for_profiling_tests, requires_mkl, set_default_dtype, num_profiled_runs, \
-    skipIfCrossRef, skipIfTorchDynamo
+    skipIfCrossRef, skipIfSandcastle, skipIfTorchDynamo
 from torch.testing._internal.jit_utils import JitTestCase, enable_cpu_fuser, disable_autodiff_subgraph_inlining, \
     _trace, do_input_map, get_execution_plan, make_global, \
     execWrapper, _inline_everything, _tmp_donotuse_dont_inline_everything, \
@@ -1791,7 +1791,7 @@ graph(%Ra, %Rb):
         for node in g.nodes():
             self.assertTrue(g2.findNode(node.kind()) is not None)
 
-    @unittest.skipIf(IS_SANDCASTLE, "gtest runs these in sandcastle")
+    @skipIfSandcastle("gtest runs these in sandcastle")
     @unittest.skipIf(RUN_CUDA, "covered by test_cpp_cuda")
     @unittest.skipIf(not torch._C._jit_has_cpp_tests(), "Tests were not built, use BUILD_TEST=1")
     def test_cpp(self):
@@ -5733,7 +5733,7 @@ a")
         self.assertEqual(cu.test_integral_shape_inference(*inputs), outputs)
 
     @unittest.skipIf(RUN_CUDA, 'This tests the CPU fuser')
-    @unittest.skipIf(IS_SANDCASTLE, "NYI: fuser support for Sandcastle")
+    @skipIfSandcastle("NYI: fuser support for Sandcastle")
     @enable_cpu_fuser
     def test_batchnorm_fuser_cpu(self):
         code = '''
@@ -5763,7 +5763,7 @@ a")
 
     @slowTest
     @unittest.skipIf(RUN_CUDA, 'This tests the CPU fuser')
-    @unittest.skipIf(IS_SANDCASTLE, "NYI: fuser support for Sandcastle")
+    @skipIfSandcastle("NYI: fuser support for Sandcastle")
     @enable_cpu_fuser
     def test_fuser_double_float_codegen(self):
         fns = ['log', 'log10', 'log1p', 'log2', 'lgamma', 'exp', 'expm1', 'erf',
@@ -5814,7 +5814,7 @@ a")
             test_dispatch(fn, lookup_c_equivalent_fn(fn) + 'f(', torch.float, binary=True)
 
     @unittest.skipIf(RUN_CUDA, 'This tests the CPU fuser')
-    @unittest.skipIf(IS_SANDCASTLE, "NYI: fuser support for Sandcastle")
+    @skipIfSandcastle("NYI: fuser support for Sandcastle")
     @enable_cpu_fuser
     def test_fuser_double_literal_precision(self):
         code = '''
@@ -13663,7 +13663,7 @@ dedent """
             self.checkScript(test_oct, (n,))
             self.checkScript(test_hex, (n,))
 
-    @unittest.skipIf(IS_SANDCASTLE, "NYI: TemporaryFileName support for Sandcastle")
+    @skipIfSandcastle("NYI: TemporaryFileName support for Sandcastle")
     def test_get_set_state(self):
         class Root(torch.jit.ScriptModule):
             __constants__ = ['number']
@@ -15397,7 +15397,7 @@ dedent """
             return 1
         self.assertEqual(fun(), 1)
 
-    @unittest.skipIf(IS_SANDCASTLE, "NYI: TemporaryFileName support for Sandcastle")
+    @skipIfSandcastle("NYI: TemporaryFileName support for Sandcastle")
     def test_attribute_unpickling(self):
         tensor = torch.randn(2, 2)
         tester = self

--- a/test/test_jit_fuser.py
+++ b/test/test_jit_fuser.py
@@ -16,8 +16,8 @@ if __name__ == "__main__":
     # before instantiating tests.
     parse_cmd_line_args()
 
-from torch.testing._internal.common_utils import run_tests, IS_SANDCASTLE, ProfilingMode, GRAPH_EXECUTOR, \
-    enable_profiling_mode_for_profiling_tests, IS_WINDOWS, TemporaryDirectoryName, shell
+from torch.testing._internal.common_utils import run_tests, ProfilingMode, GRAPH_EXECUTOR, \
+    enable_profiling_mode_for_profiling_tests, IS_WINDOWS, TemporaryDirectoryName, shell, skipIfSandcastle
 from torch.testing._internal.jit_utils import JitTestCase, enable_cpu_fuser, _inline_everything, \
     RUN_CUDA, RUN_CUDA_HALF, RUN_CUDA_MULTI_GPU, warmup_backward
 from textwrap import dedent
@@ -68,13 +68,13 @@ class TestFuser(JitTestCase):
         scripted = self.checkScript(func, (a,))
         self.assertAllFused(scripted.graph_for(a))
 
-    @unittest.skipIf(IS_SANDCASTLE, "NYI: fuser CPU support for Sandcastle")
+    @skipIfSandcastle("NYI: fuser CPU support for Sandcastle")
     @enable_cpu_fuser
     def test_abs_cpu(self):
         self._test_fused_abs()
 
     @unittest.skipIf(not IS_WINDOWS, "This is meant to be Windows-specific")
-    @unittest.skipIf(IS_SANDCASTLE, "NYI: fuser CPU support for Sandcastle")
+    @skipIfSandcastle("NYI: fuser CPU support for Sandcastle")
     @enable_cpu_fuser
     def test_abs_cpu_unicode_temp_dir(self):
         with TemporaryDirectoryName(suffix='\u4e2d\u6587') as dname:
@@ -248,7 +248,7 @@ class TestFuser(JitTestCase):
             for fn in fns:
                 self.checkScript(fn, [tensor])
 
-    @unittest.skipIf(IS_SANDCASTLE, "NYI: fuser CPU support for Sandcastle")
+    @skipIfSandcastle("NYI: fuser CPU support for Sandcastle")
     @enable_cpu_fuser
     def test_chunk_correctness(self):
         return self._test_chunk_correctness(self, 'cpu')
@@ -598,7 +598,7 @@ class TestFuser(JitTestCase):
         self.assertAllFused(scripted.graph_for(x, p), except_for=("aten::size", "prim::BroadcastSizes",
                                                                   "aten::_size_if_not_equal"))
 
-    @unittest.skipIf(IS_SANDCASTLE, "NYI: fuser CPU support for Sandcastle")
+    @skipIfSandcastle("NYI: fuser CPU support for Sandcastle")
     @unittest.skip("deduplicating introduces aliasing in backward graph's outputs")
     @enable_cpu_fuser
     def test_fuser_deduplication(self):
@@ -621,7 +621,7 @@ class TestFuser(JitTestCase):
         # check that a, b share storage, i.e. were generated as a single output in the fuser
         self.assertEqual(ga2.data_ptr(), gb2.data_ptr())
 
-    @unittest.skipIf(IS_SANDCASTLE, "NYI: fuser CPU support for Sandcastle")
+    @skipIfSandcastle("NYI: fuser CPU support for Sandcastle")
     @enable_cpu_fuser
     @unittest.skip("temporarily disabled because fusion was restricted in fixing #22833")
     def test_fuser_iou(self):
@@ -792,7 +792,7 @@ class TestFuser(JitTestCase):
             .check_not("aten::tanh").check("FusionGroup").check_next("TupleConstruct") \
             .check_next("return").check_not("FusionGroup_2").run(str(graph))
 
-    @unittest.skipIf(IS_SANDCASTLE, "NYI: fuser CPU support for Sandcastle")
+    @skipIfSandcastle("NYI: fuser CPU support for Sandcastle")
     @unittest.skip("Test is flaky, see https://github.com/pytorch/pytorch/issues/8746")
     @enable_cpu_fuser
     def test_lstm_traced_cpu(self):
@@ -894,7 +894,7 @@ class TestFuser(JitTestCase):
         out = script_f(x, y)
         self.assertEqual(out[0], out[1])
 
-    @unittest.skipIf(IS_SANDCASTLE, "NYI: fuser CPU support for Sandcastle")
+    @skipIfSandcastle("NYI: fuser CPU support for Sandcastle")
     @enable_cpu_fuser
     def test_scalar(self):
         def fn(x, y):
@@ -940,7 +940,7 @@ class TestFuser(JitTestCase):
         self.assertGraphContainsExactly(
             ge.graph_for(*inputs), 'prim::FusionGroup', 0, consider_subgraphs=True)
 
-    @unittest.skipIf(IS_SANDCASTLE, "NYI: fuser CPU support for Sandcastle")
+    @skipIfSandcastle("NYI: fuser CPU support for Sandcastle")
     @enable_cpu_fuser
     def test_where_and_typing(self):
         def f(x, y):

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -25,8 +25,8 @@ from torch.testing._internal.common_device_type import (
 from torch.testing._internal.common_utils import \
     (TestCase, run_tests, TEST_SCIPY, IS_MACOS, IS_WINDOWS, slowTest,
      TEST_WITH_ROCM, IS_FBCODE, IS_REMOTE_GPU, iter_indices,
-     make_fullrank_matrices_with_distinct_singular_values,
-     freeze_rng_state, IS_ARM64, IS_SANDCASTLE, TEST_OPT_EINSUM, isRocmArchAnyOf, parametrize, skipIfTorchDynamo,
+     make_fullrank_matrices_with_distinct_singular_values, skipIfMeta,
+     freeze_rng_state, IS_ARM64, TEST_OPT_EINSUM, isRocmArchAnyOf, parametrize, skipIfTorchDynamo,
      skipIfRocmArch, setBlasBackendsToDefaultFinally, setLinalgBackendsToDefaultFinally, serialTest, skipIfRocm,
      runOnRocmArch, MI200_ARCH, MI300_ARCH, MI350_ARCH, NAVI_ARCH, TEST_CUDA,
      skipIfNoNvmath)
@@ -3301,7 +3301,7 @@ class TestLinalg(TestCase):
             run_test_singular_input(*params)
 
     @skipIfRocm(msg="Skipping test for ROCm due to HipBlas error.")
-    @unittest.skipIf(IS_FBCODE or IS_SANDCASTLE, "Test fails for float64 on GPU (P100, V100) on Meta infra")
+    @skipIfMeta("Test fails for float64 on GPU (P100, V100) on Meta infra")
     @skipCUDAIfNoMagmaAndNoLinalgsolver
     @skipCPUIfNoLapack
     @onlyNativeDeviceTypes   # TODO: XLA doesn't raise exception
@@ -4838,7 +4838,7 @@ class TestLinalg(TestCase):
 
     @unittest.skipIf(IS_LINUX or TEST_WITH_SLOW, "https://github.com/pytorch/pytorch/issues/150959")
     @slowTest
-    @unittest.skipIf(IS_FBCODE or IS_SANDCASTLE, "Test fails for float64 on GPU (P100, V100) on Meta infra")
+    @skipIfMeta("Test fails for float64 on GPU (P100, V100) on Meta infra")
     @onlyCUDA
     @dtypes(*floating_and_complex_types())
     @precisionOverride({torch.float32: 1e-2, torch.complex64: 1e-2,

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -26,8 +26,8 @@ from torch.testing._internal.common_device_type import (
 from torch.testing._internal.common_utils import \
     (TestCase, run_tests, TEST_SCIPY, IS_MACOS, IS_WINDOWS, slowTest,
      TEST_WITH_ROCM, IS_FBCODE, IS_REMOTE_GPU, iter_indices,
-     make_fullrank_matrices_with_distinct_singular_values,
-     freeze_rng_state, IS_ARM64, IS_SANDCASTLE, TEST_OPT_EINSUM, isRocmArchAnyOf, parametrize, skipIfTorchDynamo,
+     make_fullrank_matrices_with_distinct_singular_values, skipIfMeta,
+     freeze_rng_state, IS_ARM64, TEST_OPT_EINSUM, isRocmArchAnyOf, parametrize, skipIfTorchDynamo,
      skipIfRocmArch, skipIfRocmVersionAtLeast, setBlasBackendsToDefaultFinally, setLinalgBackendsToDefaultFinally, serialTest, skipIfRocm,
      runOnRocmArch, MI200_ARCH, MI300_ARCH, MI350_ARCH, NAVI_ARCH, TEST_CUDA,
      skipIfNoNvmath)
@@ -3367,7 +3367,7 @@ class TestLinalg(TestCase):
         for params in [(1, 0), (2, 0), (2, 1), (4, 0), (4, 2), (10, 2)]:
             run_test_singular_input(*params)
 
-    @unittest.skipIf(IS_FBCODE or IS_SANDCASTLE, "Test fails for float64 on GPU (P100, V100) on Meta infra")
+    @skipIfMeta("Test fails for float64 on GPU (P100, V100) on Meta infra")
     @skipCUDAIfNoMagmaAndNoLinalgsolver
     @skipCPUIfNoLapack
     @onlyNativeDeviceTypes   # TODO: XLA doesn't raise exception
@@ -4877,7 +4877,7 @@ class TestLinalg(TestCase):
 
     @unittest.skipIf(IS_LINUX or TEST_WITH_SLOW, "https://github.com/pytorch/pytorch/issues/150959")
     @slowTest
-    @unittest.skipIf(IS_FBCODE or IS_SANDCASTLE, "Test fails for float64 on GPU (P100, V100) on Meta infra")
+    @skipIfMeta("Test fails for float64 on GPU (P100, V100) on Meta infra")
     @onlyCUDA
     @dtypes(*floating_and_complex_types())
     @precisionOverride({torch.float32: 1e-2, torch.complex64: 1e-2,

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -59,14 +59,13 @@ from torch.testing._internal.common_utils import (
     clone_input_helper,
     first_sample,
     IS_CI,
-    IS_FBCODE,
     is_iterable_of_tensors,
-    IS_SANDCASTLE,
     MACOS_VERSION,
     noncontiguous_like,
     parametrize,
     run_tests,
     set_default_dtype,
+    skipIfMeta,
     skipIfTorchDynamo,
     skipIfTorchInductor,
     suppress_warnings,
@@ -1907,9 +1906,7 @@ class TestCompositeCompliance(TestCase):
     # Checks if the operator (if it is composite) is written to support most
     # backends and Tensor subclasses. See "CompositeImplicitAutograd Compliance"
     # in aten/src/ATen/native/README.md for more details
-    @unittest.skipIf(
-        IS_FBCODE or IS_SANDCASTLE, "__torch_dispatch__ does not work in fbcode"
-    )
+    @skipIfMeta("__torch_dispatch__ does not work in fbcode")
     @skipOps(
         {
             xfail("item"),
@@ -1952,9 +1949,7 @@ class TestCompositeCompliance(TestCase):
                 op, args, kwargs, self.assertEqual
             )
 
-    @unittest.skipIf(
-        IS_FBCODE or IS_SANDCASTLE, "__torch_dispatch__ does not work in fbcode"
-    )
+    @skipIfMeta("__torch_dispatch__ does not work in fbcode")
     @skipOps(
         {
             xfail("istft"),
@@ -1989,9 +1984,7 @@ class TestCompositeCompliance(TestCase):
                 self.assertEqual,
             )
 
-    @unittest.skipIf(
-        IS_FBCODE or IS_SANDCASTLE, "__torch_dispatch__ does not work in fbcode"
-    )
+    @skipIfMeta("__torch_dispatch__ does not work in fbcode")
     @skipOps(
         {
             xfail("narrow"),

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -59,14 +59,13 @@ from torch.testing._internal.common_utils import (
     first_sample,
     HardwareClassification,
     IS_CI,
-    IS_FBCODE,
     is_iterable_of_tensors,
-    IS_SANDCASTLE,
     MACOS_VERSION,
     noncontiguous_like,
     parametrize,
     run_tests,
     set_default_dtype,
+    skipIfMeta,
     skipIfMPS,
     skipIfTorchDynamo,
     skipIfTorchInductor,
@@ -1883,9 +1882,7 @@ class TestCompositeCompliance(TestCase):
     # Checks if the operator (if it is composite) is written to support most
     # backends and Tensor subclasses. See "CompositeImplicitAutograd Compliance"
     # in aten/src/ATen/native/README.md for more details
-    @unittest.skipIf(
-        IS_FBCODE or IS_SANDCASTLE, "__torch_dispatch__ does not work in fbcode"
-    )
+    @skipIfMeta("__torch_dispatch__ does not work in fbcode")
     @skipOps(
         {
             xfail("item"),
@@ -1928,9 +1925,7 @@ class TestCompositeCompliance(TestCase):
                 op, args, kwargs, self.assertEqual
             )
 
-    @unittest.skipIf(
-        IS_FBCODE or IS_SANDCASTLE, "__torch_dispatch__ does not work in fbcode"
-    )
+    @skipIfMeta("__torch_dispatch__ does not work in fbcode")
     @skipOps(
         {
             xfail("istft"),
@@ -1965,9 +1960,7 @@ class TestCompositeCompliance(TestCase):
                 self.assertEqual,
             )
 
-    @unittest.skipIf(
-        IS_FBCODE or IS_SANDCASTLE, "__torch_dispatch__ does not work in fbcode"
-    )
+    @skipIfMeta("__torch_dispatch__ does not work in fbcode")
     @skipOps(
         {
             xfail("narrow"),

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -20,7 +20,7 @@ import torch
 
 from torch.testing import make_tensor
 from torch.testing._internal.common_utils import (
-    IS_FBCODE, IS_JETSON, IS_MACOS, IS_SANDCASTLE, IS_WINDOWS, TestCase, run_tests, slowTest,
+    IS_JETSON, IS_MACOS, IS_WINDOWS, TestCase, run_tests, slowTest, skipIfMeta, skipIfSandcastle,
     parametrize, reparametrize, subtest, instantiate_parametrized_tests, dtype_name,
     TEST_WITH_ROCM, decorateIf, skipIfXpu
 )
@@ -206,7 +206,7 @@ class TestTesting(TestCase):
 
         self._isclose_helper(tests, device, dtype, True)
 
-    @unittest.skipIf(IS_SANDCASTLE, "Skipping because doesn't work on sandcastle")
+    @skipIfSandcastle("Skipping because doesn't work on sandcastle")
     @dtypes(torch.complex64, torch.complex128)
     def test_isclose_complex(self, device, dtype):
         tests = (
@@ -560,7 +560,7 @@ instantiate_device_type_tests(TestTesting, globals())
 class TestFrameworkUtils(TestCase):
 
     @unittest.skipIf(IS_WINDOWS, "Skipping because doesn't work for windows")
-    @unittest.skipIf(IS_SANDCASTLE, "Skipping because doesn't work on sandcastle")
+    @skipIfSandcastle("Skipping because doesn't work on sandcastle")
     def test_filtering_env_var(self):
         # Test environment variable selected device type test generator.
         test_filter_file_template = """\
@@ -1317,7 +1317,7 @@ class TestAssertCloseSparseCOO(TestCase):
                 fn()
 
 
-@unittest.skipIf(IS_FBCODE or IS_SANDCASTLE, "Not all sandcastle jobs support CSR testing")
+@skipIfMeta("Not all sandcastle jobs support CSR testing")
 class TestAssertCloseSparseCSR(TestCase):
     def test_matching(self):
         crow_indices = (0, 1, 2)
@@ -1375,7 +1375,7 @@ class TestAssertCloseSparseCSR(TestCase):
                 fn()
 
 
-@unittest.skipIf(IS_FBCODE or IS_SANDCASTLE, "Not all sandcastle jobs support CSC testing")
+@skipIfMeta("Not all sandcastle jobs support CSC testing")
 class TestAssertCloseSparseCSC(TestCase):
     def test_matching(self):
         ccol_indices = (0, 1, 2)
@@ -1433,7 +1433,7 @@ class TestAssertCloseSparseCSC(TestCase):
                 fn()
 
 
-@unittest.skipIf(IS_FBCODE or IS_SANDCASTLE, "Not all sandcastle jobs support BSR testing")
+@skipIfMeta("Not all sandcastle jobs support BSR testing")
 class TestAssertCloseSparseBSR(TestCase):
     def test_matching(self):
         crow_indices = (0, 1, 2)
@@ -1491,7 +1491,7 @@ class TestAssertCloseSparseBSR(TestCase):
                 fn()
 
 
-@unittest.skipIf(IS_FBCODE or IS_SANDCASTLE, "Not all sandcastle jobs support BSC testing")
+@skipIfMeta("Not all sandcastle jobs support BSC testing")
 class TestAssertCloseSparseBSC(TestCase):
     def test_matching(self):
         ccol_indices = (0, 1, 2)

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -22,7 +22,7 @@ import torch
 
 from torch.testing import make_tensor
 from torch.testing._internal.common_utils import (
-    IS_FBCODE, IS_JETSON, IS_MACOS, IS_SANDCASTLE, IS_WINDOWS, TestCase, run_tests, slowTest,
+    IS_FBCODE, IS_JETSON, IS_MACOS, IS_WINDOWS, TestCase, run_tests, slowTest, skipIfMeta, skipIfSandcastle,
     parametrize, reparametrize, subtest, instantiate_parametrized_tests, dtype_name,
     TEST_WITH_PERIODIC, TEST_WITH_ROCM, decorateIf, periodic, skipIfTorchDynamo, skipIfXpu,
     TemporaryFileName, getRocmVersion,
@@ -210,7 +210,7 @@ class TestTesting(TestCase):
 
         self._isclose_helper(tests, device, dtype, True)
 
-    @unittest.skipIf(IS_SANDCASTLE, "Skipping because doesn't work on sandcastle")
+    @skipIfSandcastle("Skipping because doesn't work on sandcastle")
     @dtypes(torch.complex64, torch.complex128)
     def test_isclose_complex(self, device, dtype):
         tests = (
@@ -578,7 +578,7 @@ class TestFrameworkUtils(TestCase):
             self.assertEqual(getRocmVersion(), (7, 15, 26306))
 
     @unittest.skipIf(IS_WINDOWS, "Skipping because doesn't work for windows")
-    @unittest.skipIf(IS_SANDCASTLE, "Skipping because doesn't work on sandcastle")
+    @skipIfSandcastle("Skipping because doesn't work on sandcastle")
     def test_filtering_env_var(self):
         # Test environment variable selected device type test generator.
         test_filter_file_template = """\
@@ -1618,7 +1618,7 @@ class TestAssertCloseSparseCOO(TestCase):
                 fn()
 
 
-@unittest.skipIf(IS_FBCODE or IS_SANDCASTLE, "Not all sandcastle jobs support CSR testing")
+@skipIfMeta("Not all sandcastle jobs support CSR testing")
 class TestAssertCloseSparseCSR(TestCase):
     def test_matching(self):
         crow_indices = (0, 1, 2)
@@ -1676,7 +1676,7 @@ class TestAssertCloseSparseCSR(TestCase):
                 fn()
 
 
-@unittest.skipIf(IS_FBCODE or IS_SANDCASTLE, "Not all sandcastle jobs support CSC testing")
+@skipIfMeta("Not all sandcastle jobs support CSC testing")
 class TestAssertCloseSparseCSC(TestCase):
     def test_matching(self):
         ccol_indices = (0, 1, 2)
@@ -1734,7 +1734,7 @@ class TestAssertCloseSparseCSC(TestCase):
                 fn()
 
 
-@unittest.skipIf(IS_FBCODE or IS_SANDCASTLE, "Not all sandcastle jobs support BSR testing")
+@skipIfMeta("Not all sandcastle jobs support BSR testing")
 class TestAssertCloseSparseBSR(TestCase):
     def test_matching(self):
         crow_indices = (0, 1, 2)
@@ -1792,7 +1792,7 @@ class TestAssertCloseSparseBSR(TestCase):
                 fn()
 
 
-@unittest.skipIf(IS_FBCODE or IS_SANDCASTLE, "Not all sandcastle jobs support BSC testing")
+@skipIfMeta("Not all sandcastle jobs support BSC testing")
 class TestAssertCloseSparseBSC(TestCase):
     def test_matching(self):
         ccol_indices = (0, 1, 2)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -36,7 +36,7 @@ from torch.testing._internal.common_optimizers import (
 from torch.testing._internal.common_utils import (  # type: ignore[attr-defined]
     MI200_ARCH, TEST_WITH_TORCHINDUCTOR, TEST_WITH_ROCM, run_tests, IS_JETSON,
     IS_FILESYSTEM_UTF8_ENCODING,
-    IS_SANDCASTLE, IS_FBCODE, IS_REMOTE_GPU, skipIfRocmArch, skipIfTorchInductor, load_tests, slowTest, slowTestIf,
+    IS_FBCODE, IS_REMOTE_GPU, skipIfRocmArch, skipIfSandcastle, skipIfTorchInductor, load_tests, slowTest, slowTestIf,
     skipIfCrossRef, TEST_WITH_CROSSREF, skipIfTorchDynamo, set_default_dtype,
     skipCUDAMemoryLeakCheckIf, BytesIOContext,
     skipIfRocm, skipIfNoSciPy, TemporaryFileName, TemporaryDirectoryName,
@@ -8798,7 +8798,8 @@ tensor([[[1.+1.j, 1.+1.j, 1.+1.j,  ..., 1.+1.j, 1.+1.j, 1.+1.j],
 
     # NB: we must not be built with CUDA; if we are built with CUDA but no CUDA
     # is available, we get a different error.
-    @unittest.skipIf(torch.backends.cuda.is_built() or IS_SANDCASTLE, "CUDA is built, can't test CUDA not built error")
+    @unittest.skipIf(torch.backends.cuda.is_built(), "CUDA is built, can't test CUDA not built error")
+    @skipIfSandcastle("Can't test CUDA not built error on sandcastle")
     def test_cuda_not_built(self):
         msg = "Torch not compiled with CUDA enabled"
         self.assertRaisesRegex(AssertionError, msg, lambda: torch.cuda.current_device())

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -36,7 +36,7 @@ from torch.testing._internal.common_optimizers import (
 from torch.testing._internal.common_utils import (  # type: ignore[attr-defined]
     MI200_ARCH, TEST_WITH_TORCHINDUCTOR, TEST_WITH_ROCM, run_tests, IS_JETSON,
     IS_FILESYSTEM_UTF8_ENCODING,
-    IS_SANDCASTLE, IS_FBCODE, IS_REMOTE_GPU, skipIfRocmArch, skipIfTorchInductor, load_tests, slowTest, slowTestIf,
+    IS_FBCODE, IS_REMOTE_GPU, skipIfRocmArch, skipIfSandcastle, skipIfTorchInductor, load_tests, slowTest, slowTestIf,
     skipIfCrossRef, TEST_WITH_CROSSREF, skipIfTorchDynamo, set_default_dtype,
     skipCUDAMemoryLeakCheckIf, BytesIOContext,
     skipIfRocm, skipIfNoSciPy, TemporaryFileName, TemporaryDirectoryName,
@@ -8995,7 +8995,8 @@ tensor([[[1.+1.j, 1.+1.j, 1.+1.j,  ..., 1.+1.j, 1.+1.j, 1.+1.j],
 
     # NB: we must not be built with CUDA; if we are built with CUDA but no CUDA
     # is available, we get a different error.
-    @unittest.skipIf(torch.backends.cuda.is_built() or IS_SANDCASTLE, "CUDA is built, can't test CUDA not built error")
+    @unittest.skipIf(torch.backends.cuda.is_built(), "CUDA is built, can't test CUDA not built error")
+    @skipIfSandcastle("Can't test CUDA not built error on sandcastle")
     def test_cuda_not_built(self):
         msg = "Torch not compiled with CUDA enabled"
         self.assertRaisesRegex(AssertionError, msg, lambda: torch.cuda.current_device())

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -31,9 +31,9 @@ from torch.testing._internal.common_device_type import (
 from torch.testing._internal.common_methods_invocations import op_db
 from torch.testing._internal.common_utils import (  # type: ignore[attr-defined]
     IS_FBCODE,
-    IS_SANDCASTLE,
     IS_WINDOWS,
     load_tests,
+    skipIfSandcastle,
     skipIfTorchDynamo,
     TEST_WITH_ASAN,
 )
@@ -779,7 +779,7 @@ class TestAssert(TestCase):
             ms(torch.tensor([False], dtype=torch.bool))
 
 
-@unittest.skipIf(IS_SANDCASTLE, "cpp_extension is OSS only")
+@skipIfSandcastle("cpp_extension is OSS only")
 class TestStandaloneCPPJIT(TestCase):
     def test_load_standalone(self):
         build_dir = tempfile.mkdtemp()

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -34,9 +34,9 @@ from torch.testing._internal.common_device_type import (
 from torch.testing._internal.common_methods_invocations import op_db
 from torch.testing._internal.common_utils import (  # type: ignore[attr-defined]
     IS_FBCODE,
-    IS_SANDCASTLE,
     IS_WINDOWS,
     load_tests,
+    skipIfSandcastle,
     skipIfTorchDynamo,
     TEST_WITH_ASAN,
 )
@@ -785,7 +785,7 @@ class TestAssert(TestCase):
             ms(torch.tensor([False], dtype=torch.bool))
 
 
-@unittest.skipIf(IS_SANDCASTLE, "cpp_extension is OSS only")
+@skipIfSandcastle("cpp_extension is OSS only")
 class TestStandaloneCPPJIT(TestCase):
     def test_load_standalone(self):
         build_dir = tempfile.mkdtemp()

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -5755,6 +5755,34 @@ def xfail_inherited_tests(tests):
     return deco
 
 
+def skipIfSandcastle(reason):
+    """
+    Decorator to skip the test if run in sandcastle
+    """
+    return skipIfSandcastleOr(True, reason)
+
+
+def skipIfSandcastleOr(condition, reason):
+    """
+    Decorator to skip the test if run in sandcastle and condition matches
+    """
+    return unittest.skipIf(IS_SANDCASTLE or condition, reason)
+
+
+def skipIfMeta(reason):
+    """
+    Decorator to skip the test if run on Meta infrastructure
+    """
+    return skipIfMetaOr(True, reason)
+
+
+def skipIfMetaOr(condition, reason):
+    """
+    Decorator to skip the test if run on Meta infrastructure and condition matches
+    """
+    return skipIfSandcastleOr(IS_FBCODE or condition, reason)
+
+
 def skip_but_pass_in_sandcastle_if(condition, reason):
     """
     Similar to unittest.skipIf, however in the sandcastle environment it just

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -6083,6 +6083,34 @@ def xfail_inherited_tests(tests):
     return deco
 
 
+def skipIfSandcastle(reason):
+    """
+    Decorator to skip the test if run in sandcastle
+    """
+    return skipIfSandcastleOr(True, reason)
+
+
+def skipIfSandcastleOr(condition, reason):
+    """
+    Decorator to skip the test if run in sandcastle and condition matches
+    """
+    return unittest.skipIf(IS_SANDCASTLE or condition, reason)
+
+
+def skipIfMeta(reason):
+    """
+    Decorator to skip the test if run on Meta infrastructure
+    """
+    return skipIfMetaOr(True, reason)
+
+
+def skipIfMetaOr(condition, reason):
+    """
+    Decorator to skip the test if run on Meta infrastructure and condition matches
+    """
+    return skipIfSandcastleOr(IS_FBCODE or condition, reason)
+
+
 def skip_but_pass_in_sandcastle_if(condition, reason):
     """
     Similar to unittest.skipIf, however in the sandcastle environment it just

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -1324,9 +1324,10 @@ class DistributedTest:
         # Coalescing manager (sync mode)
         @skip_if_no_gpu
         @skip_but_pass_in_sandcastle_if(
-            BACKEND != "nccl" or IS_FBCODE or IS_SANDCASTLE,
-            "Coalescing manager currently tests with NCCL only; internal test flaky",
+            BACKEND != "nccl" or IS_FBCODE,
+            "Coalescing manager currently tests with NCCL only",
         )
+        @skip_but_pass_in_sandcastle("internal test flaky")
         def test_coalescing_manager(self):
             self._barrier()
             rank = dist.get_rank()
@@ -1358,9 +1359,10 @@ class DistributedTest:
         # Coalescing manager (async mode)
         @skip_if_no_gpu
         @skip_but_pass_in_sandcastle_if(
-            BACKEND != "nccl" or IS_FBCODE or IS_SANDCASTLE,
-            "Coalescing manager currently tests with NCCL only; internal test flaky",
+            BACKEND != "nccl" or IS_FBCODE,
+            "Coalescing manager currently tests with NCCL only",
         )
+        @skip_but_pass_in_sandcastle("internal test flaky")
         def test_coalescing_manager_async(self):
             self._barrier()
             rank = dist.get_rank()

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -1313,9 +1313,10 @@ class DistributedTest:
         # Coalescing manager (sync mode)
         @skip_if_no_gpu
         @skip_but_pass_in_sandcastle_if(
-            BACKEND != "nccl" or IS_FBCODE or IS_SANDCASTLE,
-            "Coalescing manager currently tests with NCCL only; internal test flaky",
+            BACKEND != "nccl" or IS_FBCODE,
+            "Coalescing manager currently tests with NCCL only",
         )
+        @skip_but_pass_in_sandcastle("internal test flaky")
         def test_coalescing_manager(self):
             self._barrier()
             rank = dist.get_rank()
@@ -1347,9 +1348,10 @@ class DistributedTest:
         # Coalescing manager (async mode)
         @skip_if_no_gpu
         @skip_but_pass_in_sandcastle_if(
-            BACKEND != "nccl" or IS_FBCODE or IS_SANDCASTLE,
-            "Coalescing manager currently tests with NCCL only; internal test flaky",
+            BACKEND != "nccl" or IS_FBCODE,
+            "Coalescing manager currently tests with NCCL only",
         )
+        @skip_but_pass_in_sandcastle("internal test flaky")
         def test_coalescing_manager_async(self):
             self._barrier()
             rank = dist.get_rank()


### PR DESCRIPTION
Simplify the markers a bit to make them more expressive

It also makes it easier to skip those tests "manually" by changing the single definition of the skip marker.
This is important to reduce potential false positives (of failed tests) in some environments, such as HPC clusters