### PR TITLE
[PP][2/3] DTensor-aware stage and schedule refactoring

### DIFF
--- a/test/distributed/pipelining/test_stage.py
+++ b/test/distributed/pipelining/test_stage.py
@@ -11,7 +11,7 @@ from torch.distributed.pipelining import (
     PipelineStage,
     ScheduleGPipe,
 )
-from torch.distributed.pipelining._utils import PipeliningShapeError
+from torch.distributed.pipelining._utils import PipeliningMetadataError
 from torch.testing._internal.common_distributed import (
     MultiProcContinuousTest,
     requires_accelerator_dist_backend,
@@ -368,6 +368,7 @@ class StageNegativeTest(MultiProcContinuousTest):
             self.world_size,
             self.device,
         )
+        stage._runtime_validate = True
 
         # Attach to a schedule
         schedule = ScheduleGPipe(stage, chunks)
@@ -382,20 +383,20 @@ class StageNegativeTest(MultiProcContinuousTest):
         _run_step(x)
 
         if self.rank == 0:
-            with self.assertRaisesRegex(PipeliningShapeError, "shape mismatch"):
+            with self.assertRaisesRegex(PipeliningMetadataError, "shape mismatch"):
                 _run_step(torch.randn(batch_size + 1, d_hid, device=self.device))
 
-            with self.assertRaisesRegex(PipeliningShapeError, "dtype mismatch"):
+            with self.assertRaisesRegex(PipeliningMetadataError, "dtype mismatch"):
                 _run_step(x.to(torch.int32))
 
             # output of stage's mlp layer will be flattened by this hook, the stage should err
             handle = stage_mod.register_forward_hook(get_flatten_hook())
-            with self.assertRaisesRegex(PipeliningShapeError, "shape mismatch"):
+            with self.assertRaisesRegex(PipeliningMetadataError, "shape mismatch"):
                 _run_step(x)
             handle.remove()
 
             stage_mod.register_forward_hook(get_dtype_change_hook(torch.bfloat16))
-            with self.assertRaisesRegex(PipeliningShapeError, "dtype mismatch"):
+            with self.assertRaisesRegex(PipeliningMetadataError, "dtype mismatch"):
                 _run_step(x)
 
     @requires_accelerator_dist_backend(["nccl", "xccl"])

--- a/torch/distributed/pipelining/_utils.py
+++ b/torch/distributed/pipelining/_utils.py
@@ -503,42 +503,6 @@ def flatten_args_detach(args):
     return flatten_args(args, detach=True)
 
 
-# Legacy validation functions (kept for backward compatibility with existing stage.py)
-# These will be removed in the next commit when stage.py is updated.
-class PipeliningShapeError(RuntimeError):
-    """Shape mismatch between configured and runtime values."""
-
-
-def validate_tensor_metadata(desc, expected, given):
-    if not expected.shape == given.shape:
-        raise PipeliningShapeError(
-            f"{desc} has a shape mismatch: expected {expected.shape} actual {given.shape}"
-        )
-    if not expected.dtype == given.dtype:
-        raise PipeliningShapeError(
-            f"{desc} has a dtype mismatch: expected {expected.dtype} actual {given.dtype}"
-        )
-    if not expected.stride() == given.stride():
-        raise PipeliningShapeError(
-            f"{desc} has a stride mismatch: expected {expected.stride()} actual {given.stride()}"
-        )
-
-
-def validate_tensors_metadata(
-    desc,
-    expected_tensors: list[torch.Tensor] | tuple[torch.Tensor, ...],
-    actual_tensors: list[torch.Tensor] | tuple[torch.Tensor, ...],
-):
-    if len(expected_tensors) != len(actual_tensors):
-        raise PipeliningShapeError(
-            f"{desc}: Number of values ({len(actual_tensors)}) does not match expected number ({len(expected_tensors)})"
-        )
-    for i in range(len(expected_tensors)):
-        validate_tensor_metadata(
-            f"{desc}: value {i}", expected_tensors[i], actual_tensors[i]
-        )
-
-
 def generate_stage_to_rank_mapping(
     pp_size: int, num_stages: int, style: str = "loop"
 ) -> dict[int, int]:
@@ -844,6 +808,63 @@ def validate_metadata(
             )
 
     return diffs
+
+
+def validate_tensors_metadata(
+    desc: str,
+    expected: tuple[TensorMeta | None, ...],
+    actual: tuple[torch.Tensor | TensorMeta | None, ...],
+    *,
+    raise_on_mismatch: bool = True,
+    warn_on_mismatch: bool = False,
+) -> list[str]:
+    """Validate metadata for a tuple of tensors element-wise.
+
+    Args:
+        desc: Description prefix for error/warning messages.
+        expected: Tuple of expected metadata (may include ``None`` for grads).
+        actual: Tuple of actual tensors or metadata to compare against.
+        raise_on_mismatch: If ``True``, raise on the first mismatch.
+        warn_on_mismatch: If ``True``, issue warnings for mismatches.
+
+    Returns:
+        Aggregated list of difference strings.
+
+    Raises:
+        PipeliningMetadataError: If lengths differ or on mismatch.
+    """
+    if len(expected) != len(actual):
+        msg = f"{desc}: expected {len(expected)} tensors, got {len(actual)}"
+        if raise_on_mismatch:
+            raise PipeliningMetadataError(msg)
+        if warn_on_mismatch:
+            warnings.warn(msg, UserWarning, stacklevel=2)
+        return [msg]
+
+    all_diffs: list[str] = []
+    for i, (exp, act) in enumerate(zip(expected, actual, strict=True)):
+        if exp is None and act is None:
+            continue
+        if exp is None or act is None:
+            msg = (
+                f"{desc}[{i}]: expected {'None' if exp is None else 'metadata'}, "
+                f"got {'None' if act is None else 'metadata'}"
+            )
+            if raise_on_mismatch:
+                raise PipeliningMetadataError(msg)
+            if warn_on_mismatch:
+                warnings.warn(msg, UserWarning, stacklevel=2)
+            all_diffs.append(msg)
+            continue
+        diffs = validate_metadata(
+            f"{desc}[{i}]",
+            exp,
+            act,
+            raise_on_mismatch=raise_on_mismatch,
+            warn_on_mismatch=warn_on_mismatch,
+        )
+        all_diffs.extend(diffs)
+    return all_diffs
 
 
 def validate_static_arg_grad_correspondence(

--- a/torch/distributed/pipelining/schedules.py
+++ b/torch/distributed/pipelining/schedules.py
@@ -21,9 +21,13 @@ from torch.distributed.fsdp import FSDPModule, UnshardHandle
 from torch.nn.modules.loss import _Loss
 from torch.profiler import record_function
 
-from ._utils import generate_rank_to_stage_mapping, generate_stage_to_rank_mapping
+from ._utils import (
+    generate_rank_to_stage_mapping,
+    generate_stage_to_rank_mapping,
+    InferenceMode,
+)
 from .microbatch import merge_chunks, split_args_kwargs_into_chunks, TensorChunkSpec
-from .stage import _PipelineStageBase
+from .stage import _PipelineStageBase, PipelineStage
 
 
 __all__ = [
@@ -320,6 +324,135 @@ class _PipelineSchedule(ABC):
 
         self._internal_losses.clear()
 
+    def _warmup_p2p(
+        self,
+        stages: list[_PipelineStageBase],
+        has_backward: bool,
+        p2p_done: bool,
+    ) -> None:
+        """Run the P2P warm-up protocol for the given stages.
+
+        For ``PipelineStage`` instances this executes the forward/backward vote
+        protocol (which warms up 2-rank sub-communicators) and sets each
+        stage's ``_inference_mode``.  For other stage types it falls back to
+        the legacy ``_get_init_p2p_neighbors_ops`` + ``_batch_p2p`` path.
+
+        Args:
+            stages: The pipeline stages owned by this rank.
+            has_backward: Whether the schedule includes a backward pass.
+            p2p_done: ``True`` if P2P neighbours have already been initialised
+                (avoids redundant init on eval↔train mode switches).
+        """
+        if all(isinstance(stage, PipelineStage) for stage in stages):
+            acc: torch.Tensor | None = None
+            for stage in cast(list[PipelineStage], stages):
+                acc = stage._warmup_forward_vote(has_backward, received_acc=acc)
+            result: torch.Tensor | None = acc
+            determined_mode: InferenceMode | None = None
+            for stage in reversed(cast(list[PipelineStage], stages)):
+                result = stage._warmup_backward_result(received_result=result)
+                if result is None:
+                    raise RuntimeError("P2P warm-up voting failed")
+                determined_mode = (
+                    InferenceMode.STATIC
+                    if result.item() == 1
+                    else InferenceMode.DYNAMIC
+                )
+                stage._inference_mode = determined_mode
+            logger.debug(
+                "Rank determined inference_mode=%s for %d stage(s)",
+                determined_mode.value if determined_mode else "None",
+                len(stages),
+            )
+        elif not p2p_done:
+            all_ops: list[dist.P2POp] = []
+            for stage in stages:
+                all_ops.extend(stage._get_init_p2p_neighbors_ops())
+            _wait_batch_p2p(_batch_p2p(all_ops))
+
+        # TODO: STATIC mode group communicator warm-up gap
+        # The vote protocol above warms up 2-rank sub-communicators
+        # (used by `_batch_p2p` homogeneous fast-path).  In DYNAMIC mode,
+        # `_send_meta`/`_recv_meta` (called during `_prepare_forward_infra` →
+        # `_forward_metadata_inference`) also warm up the *group* communicator
+        # (used by `_batch_p2p` mixed-op path).  In STATIC mode, metadata
+        # inference is skipped, so the group communicator is NOT warmed up —
+        # it will be lazily created on the first mixed `_batch_p2p` call
+        # (e.g., 1F1B steady-state with both sends and recvs).
+        # Fix: run `_get_init_p2p_neighbors_ops` + `_batch_p2p` after the
+        # vote, gated by `not p2p_done`.
+
+    def _initialize_pp_stages(
+        self,
+        stages: list[_PipelineStageBase],
+        args: tuple[Any, ...] | Any,
+        kwargs: dict[str, Any] | None,
+        target: Any,
+        fwd_initialized: bool,
+        bwd_initialized: bool,
+    ) -> tuple[bool, bool]:
+        """Common stage initialization shared by Single and Multi schedules.
+
+        Handles mode-change detection (eval↔train), P2P warm-up, RNG forking,
+        forward / backward metadata inference, and FSDP cleanup.
+
+        Returns the updated ``(fwd_initialized, bwd_initialized)`` flags.
+        """
+        # Detect eval↔train mode switch: if has_backward changed since last
+        # init, re-initialize both fwd (recv buffers need different
+        # requires_grad) and bwd.  p2p_done avoids redundant P2P warm-up.
+        p2p_done = fwd_initialized
+        if fwd_initialized and (self._has_backward != bwd_initialized):
+            fwd_initialized = False
+            bwd_initialized = False
+
+        needs_fwd = not fwd_initialized
+        needs_bwd = self._has_backward and not bwd_initialized
+
+        if not needs_fwd and not needs_bwd:
+            return fwd_initialized, bwd_initialized
+
+        if needs_fwd:
+            self._warmup_p2p(stages, self._has_backward, p2p_done)
+
+        # Fork RNG so metadata inference doesn't perturb training RNG.
+        devices = list(
+            {
+                torch.device(stage.device)
+                for stage in stages
+                if torch.device(stage.device).type != "cpu"
+            }
+        )
+        with torch.random.fork_rng(devices=devices):
+            if needs_fwd:
+                next_stage_args: Any = None
+                for stage in stages:
+                    stage_args = args if stage.is_first else next_stage_args
+                    next_stage_args = stage._prepare_forward_infra(
+                        self._n_microbatches,
+                        stage_args,
+                        kwargs,
+                        has_backward=self._has_backward,
+                    )
+                fwd_initialized = True
+
+            if needs_bwd:
+                prev_stage_grad_meta: Any = None
+                for stage in reversed(stages):
+                    prev_stage_grad_meta = stage._prepare_backward_infra(
+                        self._n_microbatches,
+                        loss_fn=self._loss_fn,
+                        target=target,
+                        received_grad_meta=prev_stage_grad_meta,
+                    )
+                bwd_initialized = True
+
+        for stage in stages:
+            if isinstance(stage, PipelineStage):
+                stage._post_metadata_inference_cleanup()
+
+        return fwd_initialized, bwd_initialized
+
     @abstractmethod
     def _step_microbatches(
         self,
@@ -560,21 +693,18 @@ class PipelineScheduleSingle(_PipelineSchedule):
             self._get_pipeline_order()
         )
 
-    def _initialize_stage(self, args, kwargs):
-        if not self._stage_forward_initialized:
-            # Prepare the communication needed for the pipeline schedule execution
-            # This is needed because during execution we always perform a series of batch P2P ops
-            # The first call of the batched P2P needs to involve the global group
-            all_ops: list[dist.P2POp] = []
-            all_ops.extend(self._stage._get_init_p2p_neighbors_ops())
-            _wait_batch_p2p(_batch_p2p(all_ops))
-
-            self._stage._prepare_forward_infra(self._n_microbatches, args, kwargs)
-            self._stage_forward_initialized = True
-
-        if self._has_backward and not self._stage_backward_initialized:
-            self._stage._prepare_backward_infra(self._n_microbatches)
-            self._stage_backward_initialized = True
+    def _initialize_stage(self, args, kwargs, target=None):
+        (
+            self._stage_forward_initialized,
+            self._stage_backward_initialized,
+        ) = self._initialize_pp_stages(
+            [self._stage],
+            args,
+            kwargs,
+            target,
+            self._stage_forward_initialized,
+            self._stage_backward_initialized,
+        )
 
     def step(
         self,
@@ -670,7 +800,8 @@ class _ScheduleForwardOnly(PipelineScheduleSingle):
             )
 
         arg_mbs, kwarg_mbs = self._check_inputs(arg_mbs, kwarg_mbs, target_mbs, losses)
-        self._initialize_stage(arg_mbs[0], kwarg_mbs[0])
+        maybe_first_target = target_mbs[0] if target_mbs is not None else None
+        self._initialize_stage(arg_mbs[0], kwarg_mbs[0], maybe_first_target)
 
         # Delay send waits
         fwd_sends_to_wait: list[list[dist.Work]] = []
@@ -721,7 +852,8 @@ class ScheduleGPipe(PipelineScheduleSingle):
             return_outputs: whether to return the outputs from the last stage.
         """
         arg_mbs, kwarg_mbs = self._check_inputs(arg_mbs, kwarg_mbs, target_mbs, losses)
-        self._initialize_stage(arg_mbs[0], kwarg_mbs[0])
+        maybe_first_target = target_mbs[0] if target_mbs is not None else None
+        self._initialize_stage(arg_mbs[0], kwarg_mbs[0], maybe_first_target)
 
         # Delay send waits
         fwd_sends_to_wait: list[list[dist.Work]] = []
@@ -865,7 +997,8 @@ or equal to the number of stages ({self._num_stages})."
             return_outputs: whether to return the outputs from the last stage.
         """
         arg_mbs, kwarg_mbs = self._check_inputs(arg_mbs, kwarg_mbs, target_mbs, losses)
-        self._initialize_stage(arg_mbs[0], kwarg_mbs[0])
+        maybe_first_target = target_mbs[0] if target_mbs is not None else None
+        self._initialize_stage(arg_mbs[0], kwarg_mbs[0], maybe_first_target)
 
         # Last stage has 1 warmup, second-to-last 2 warmups, ...
         # first stage `num_stages` warmups
@@ -1532,34 +1665,18 @@ class PipelineScheduleMulti(_PipelineSchedule):
                 "Simply stop passing it, and everything should still work fine."
             )
 
-    def _initialize_stages(self, args: tuple[Any, ...], kwargs):
-        if not self._stages_forward_initialized:
-            # Prepare the communication needed for the pipeline schedule execution
-            # This is needed because during execution we always perform a series of batch P2P ops
-            # The first call of the batched P2P needs to involve the global group
-            all_ops: list[dist.P2POp] = []
-            for stage in self._stages:
-                all_ops.extend(stage._get_init_p2p_neighbors_ops())
-            _wait_batch_p2p(_batch_p2p(all_ops))
-
-            # may be 'none' value (if this stage sends its output shapes to the next stage via P2P)
-            # or real value (if this stage and next stage are on the same device)
-            next_stage_args: tuple[Any, ...] = tuple()
-            for stage in self._stages:
-                if stage.is_first:
-                    next_stage_args = stage._prepare_forward_infra(
-                        self._n_microbatches, args, kwargs
-                    )
-                else:
-                    next_stage_args = stage._prepare_forward_infra(
-                        self._n_microbatches, next_stage_args, kwargs
-                    )
-            self._stages_forward_initialized = True
-
-        if self._has_backward and not self._stages_backward_initialized:
-            for stage in self._stages:
-                stage._prepare_backward_infra(self._n_microbatches)
-            self._stages_backward_initialized = True
+    def _initialize_stages(self, args: tuple[Any, ...], kwargs, target=None):
+        (
+            self._stages_forward_initialized,
+            self._stages_backward_initialized,
+        ) = self._initialize_pp_stages(
+            self._stages,
+            args,
+            kwargs,
+            target,
+            self._stages_forward_initialized,
+            self._stages_backward_initialized,
+        )
 
     def _validate_and_set_stage_mapping(
         self, actions: dict[int, list[_Action | None]]
@@ -1674,8 +1791,8 @@ class PipelineScheduleMulti(_PipelineSchedule):
         not support models with skip connections.
         """
         arg_mbs, kwarg_mbs = self._check_inputs(arg_mbs, kwarg_mbs, target_mbs, losses)
-
-        self._initialize_stages(arg_mbs[0], kwarg_mbs[0])
+        maybe_first_target = target_mbs[0] if target_mbs is not None else None
+        self._initialize_stages(arg_mbs[0], kwarg_mbs[0], maybe_first_target)
 
         # Based on the plan in Step 1 created in __init__:
         # 2. Perform communication based on the pipeline_order
@@ -2060,7 +2177,8 @@ class _PipelineScheduleRuntime(PipelineScheduleMulti):
         not support models with skip connections.
         """
         arg_mbs, kwarg_mbs = self._check_inputs(arg_mbs, kwarg_mbs, target_mbs, losses)
-        self._initialize_stages(arg_mbs[0], kwarg_mbs[0])
+        maybe_first_target = target_mbs[0] if target_mbs is not None else None
+        self._initialize_stages(arg_mbs[0], kwarg_mbs[0], maybe_first_target)
 
         # Based on the plan in Step 1 created in __init__:
         # 2. Perform communication based on the pipeline_order

--- a/torch/distributed/pipelining/stage.py
+++ b/torch/distributed/pipelining/stage.py
@@ -2,6 +2,7 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
 import logging
 import operator
+import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Callable
 from typing import Any, cast
@@ -13,13 +14,39 @@ import torch.nn as nn
 from torch._subclasses.fake_tensor import FakeTensor
 from torch.distributed._composable.replicate_with_fsdp import replicate, ReplicateModule
 from torch.distributed.fsdp import FSDPModule, fully_shard
+from torch.distributed.pipelining._utils import (
+    _derive_grad_metas,
+    _DTensorMeta,
+    _make_tensor_from_meta,
+    _MeshCache,
+    _StageBackwardMeta,
+    _StageForwardMeta,
+    _StageMeta,
+    _TensorMeta,
+    extract_tensor_meta,
+    extract_tensor_metas,
+    flatten_args,
+    GetMeshCallback,
+    InferenceMode,
+    PipeInfo,
+    PipeliningMetadataError,
+    TensorMeta,
+    to_local_if_dtensor,
+    validate_and_normalize_to_tuple,
+    validate_static_arg_grad_correspondence,
+    validate_tensors_metadata,
+)
+from torch.distributed.tensor import DTensor
 from torch.fx.node import Argument, map_aggregate
 from torch.nn.parallel import DistributedDataParallel
-from torch.utils._pytree import tree_map_only
 
-from ._backward import stage_backward, stage_backward_input, stage_backward_weight
+from ._backward import (
+    _autograd_grad_for_inputs,
+    stage_backward,
+    stage_backward_input,
+    stage_backward_weight,
+)
 from ._debug import map_debug_info
-from ._utils import flatten_args, PipeInfo, validate_tensors_metadata
 
 
 __all__ = [
@@ -63,61 +90,47 @@ def _normalize_model_output_as_tuple(output: Any) -> tuple[Any]:
     return output_tuple
 
 
-class _RootArgPlaceholder:
-    """
-    Placeholder for model-level inputs.
-    """
-
-    def __init__(self, tensor):
-        self.meta = tensor.to("meta")
-
-
 class _RecvInfo:
-    """
-    Represents a stage input.
+    """Input tensor descriptor for a pipeline stage.
+
+    Handles both received activations from a previous stage
+    (``is_root_arg=False``) and root-level model inputs provided
+    by the user (``is_root_arg=True``).
     """
 
     def __init__(
         self,
         input_name: str,
-        source: int,
-        buffer: torch.Tensor,
+        source: int | None,
+        buffer: torch.Tensor | None,
+        tensor_meta: TensorMeta | None,
+        *,
+        is_root_arg: bool = False,
     ):
         # Name of this input
         self.input_name = input_name
-        # Stage index of the source of this input
+        # Stage index of the source of this input (None for root args)
         self.source = source
-        # Buffer to receive the input into.
+        # Buffer to receive the input into (None for root args)
         self.buffer = buffer
+        # Tensor metadata for validation and DTensor reconstruction
+        self.tensor_meta = tensor_meta
+        # Whether this is a root-level model input (no recv needed)
+        self.is_root_arg = is_root_arg
 
     def __repr__(self):
-        return f"_RecvInfo(input={self.input_name}, source={self.source}, shape={self.buffer.size()})"
-
-
-# An input can be either a received activation or a model input
-InputInfo = _RecvInfo | _RootArgPlaceholder
-
-
-def _make_tensor_from_meta(
-    example: torch.Tensor | FakeTensor,
-    device: torch.device,
-) -> torch.Tensor:
-    """
-    Create a real tensor from a tensor.
-    """
-    return torch.empty(
-        example.size(),
-        dtype=example.dtype,
-        layout=example.layout,
-        device=device,
-    )
+        if self.is_root_arg:
+            return f"_RecvInfo(input={self.input_name}, root_arg=True)"
+        meta_type = type(self.tensor_meta).__name__ if self.tensor_meta else "None"
+        buffer_shape = self.buffer.size() if self.buffer is not None else "None"
+        return f"_RecvInfo(input={self.input_name}, source={self.source}, shape={buffer_shape}, meta={meta_type})"
 
 
 class _PipelineStageBase(ABC):
-    """
-    Base class for pipeline stages.
-    Defines or implements common methods used by the `_PipelineStage` used by
-    the tracing frontend and `PipelineStage` used by manual frontend.
+    """Base class for pipeline stages.
+
+    Defines common methods used by ``_PipelineStage`` (tracing frontend)
+    and ``PipelineStage`` (manual frontend).
     """
 
     def __init__(
@@ -131,20 +144,16 @@ class _PipelineStageBase(ABC):
     ):
         """
         Args:
-            submodule (torch.nn.Module): The module to be executed in this stage.
-            stage_index (int): The index of this stage.
-            num_stages (int): The total number of stages in this pipeline.
-            device (torch.device): The device to run this stage on.
-            group (Optional[dist.ProcessGroup]): The process group to use for communication.
-                If `None`, the default process group will be used.
-                Default: `None`.
-            dw_builder (Optional[Callable[[], Callable[..., None]]): If provided, dw_builder is a builder function
-                that will build a new dw_runner function that will run parts of module backward that were intentionally
-                skipped during the module's actual backward pass. The builder must be invoked by stage after stage runs
-                model backwards, and stage should save the latest dw_runner to run during weight pas (W).
-                If not provided, a dw_runner will be generated automatically by traversing the autograd graph.
-                When used with schedules that only have F and B steps, the fresh dw_runner function will be called as
-                part of I (input backwards). When used with F,I,W schedules, the dw_runner function implements 'W'.
+            submodule: The module to be executed in this stage.
+            stage_index: The index of this stage.
+            num_stages: The total number of stages in this pipeline.
+            device: The device to run this stage on.
+            group: Process group for communication. Defaults to the
+                default process group if ``None``.
+            dw_builder: Builder function that produces a ``dw_runner``
+                for deferred weight updates in F/I/W zero-bubble
+                schedules. If ``None``, a runner is generated
+                automatically via autograd graph traversal.
         """
         super().__init__()
         if stage_index >= num_stages:
@@ -175,7 +184,6 @@ class _PipelineStageBase(ABC):
             )
 
         # Run time states
-        self._outputs_meta: tuple[torch.Tensor, ...] | None = None
         # map microbatch ID to list of forward tensor args
         self.fwd_cache: dict[int, tuple[Any, list[torch.Tensor]]] = {}
         # map microbatch ID to list of backward grad tensor args
@@ -190,7 +198,7 @@ class _PipelineStageBase(ABC):
         self.log_prefix = f"[Stage {self.stage_index}]"
 
         # Forward infra
-        self.args_recv_info: dict[int, tuple[InputInfo, ...]] = {}
+        self.args_recv_info: dict[int, tuple[_RecvInfo, ...]] = {}
         self.act_send_info: dict[int, list] = {}
 
         # Backward infra will created lazily
@@ -202,6 +210,17 @@ class _PipelineStageBase(ABC):
         self.stage_index_to_group_rank: dict[int, int] = {
             i: i % self.group_size for i in range(self.num_stages)
         }
+
+        # DTensor support: mesh cache for looking up DeviceMesh by (dim_names, layout)
+        self._mesh_cache = _MeshCache()
+
+        # Per-chunk runtime validation is expensive; only enable under
+        # TORCH_DISTRIBUTED_DEBUG=DETAIL for debugging shape/dtype mismatches.
+        self._runtime_validate = dist.get_debug_level() == dist.DebugLevel.DETAIL
+
+        # DTensor support: consolidated stage metadata container
+        # Contains inputs, outputs, input_grads, output_grads metadata
+        self._stage_meta = _StageMeta()
 
     @property
     def has_backward(self) -> bool:
@@ -228,6 +247,21 @@ class _PipelineStageBase(ABC):
         """
         return self.stage_index == self.num_stages - 1
 
+    def _validate_stage_tensors(
+        self,
+        desc: str,
+        expected: tuple[TensorMeta | None, ...] | None,
+        actual: tuple[torch.Tensor | None, ...],
+    ) -> None:
+        """Validate actual tensors against expected metadata.
+
+        Raises:
+            PipeliningMetadataError: If metadata is missing or mismatched.
+        """
+        if expected is None:
+            raise PipeliningMetadataError(f"{desc}: no metadata available")
+        validate_tensors_metadata(desc, expected, actual)
+
     def _check_chunk_id(self, chunk_id: int):
         if self.chunks is None:
             raise RuntimeError(
@@ -237,27 +271,6 @@ class _PipelineStageBase(ABC):
             raise RuntimeError(
                 f"Chunk id {chunk_id} is out of range [0, {self.chunks})"
             )
-
-    def _configure_outputs_meta(self, outputs_meta: tuple[torch.Tensor, ...]):
-        """
-        Track the output shapes/dtype of this stage since they determine the send operation(s) which must match
-        recv operations of the next stage.  The next stage _will_ be freezing its recv buffers based on its initial
-        configuration, so it's important to also freeze/validate the output side to avoid any send/recv mismatches
-        which could show up as hangs, silent corruption, or other errors.
-        """
-        if self._outputs_meta is not None:
-            raise AssertionError(
-                "Attempting to reconfigure output_meta, which is not supported"
-            )
-        self._outputs_meta = tuple(outputs_meta)  # type: ignore[assignment]
-
-    def get_outputs_meta(self) -> tuple[torch.Tensor, ...]:
-        """Get the output metadata (meta tensors) reprensenting the outputs of this stage"""
-        if self._outputs_meta is None:
-            raise AssertionError(
-                "Attempted to get_outputs_meta() without configuring output meta"
-            )
-        return self._outputs_meta
 
     def _create_grad_send_info(
         self,
@@ -272,12 +285,13 @@ class _PipelineStageBase(ABC):
             # Note: we send gradients back to previous stage as long as in
             # forward it is a received input, regardless of whether it requires
             # grad. It is up to the previous stage to discard this gradient.
-            if isinstance(a, _RecvInfo):
-                grad_send_info.append(a.source)
-                return a.source
-            else:
+            if a.is_root_arg:
+                # Root args don't have a source stage to send gradients to
                 grad_send_info.append(None)
                 return None
+            else:
+                grad_send_info.append(a.source)
+                return a.source
 
         map_aggregate(args_recv_info, map_recv_to_send)
 
@@ -288,17 +302,30 @@ class _PipelineStageBase(ABC):
     def _prepare_forward_infra(
         self,
         num_microbatches: int,
-        args: tuple[Any, ...],
+        args: tuple[Any, ...] | _StageForwardMeta | None,
         kwargs: dict[str, Any] | None = None,
-    ) -> tuple[Any, ...]:
+        has_backward: bool = False,
+    ) -> _StageForwardMeta | None:
         raise NotImplementedError
 
-    def _prepare_backward_infra(self, num_microbatches: int):
+    @abstractmethod
+    def _prepare_backward_infra(
+        self,
+        num_microbatches: int,
+        loss_fn: Callable[..., torch.Tensor] | None = None,
+        target: torch.Tensor | None = None,
+        received_grad_meta: _StageBackwardMeta | None = None,
+    ) -> _StageBackwardMeta | None:
+        raise NotImplementedError
+
+    def _setup_backward_recv_info(self, num_microbatches: int):
         # TODO: this is needed for backward_maybe_with_nosync
         self.chunks = num_microbatches
 
+        # IMPORTANT: _create_grad_recv_info reads self._stage_meta.output_grads
+        # to attach DTensor metadata to _RecvInfo objects. The clear below MUST
+        # happen after all _create_grad_recv_info calls complete.
         for mb_index in range(num_microbatches):
-            # `grad_recv_info` is a mirror of `act_send_info`
             self.grad_recv_info[mb_index] = self._create_grad_recv_info(
                 self.act_send_info
             )
@@ -310,9 +337,17 @@ class _PipelineStageBase(ABC):
     ) -> tuple[_RecvInfo, ...]:
         raise NotImplementedError
 
+    def _resolve_peer_global_rank(self, stage_idx: int) -> int:
+        """Map a pipeline stage index to the corresponding global rank for P2P communication."""
+        peer_rank = self.stage_index_to_group_rank[stage_idx]
+        return dist.get_global_rank(
+            self.group or dist.distributed_c10d._get_default_group(),
+            peer_rank,
+        )
+
     def _get_recv_ops(
         self,
-        recv_infos: tuple[InputInfo, ...],
+        recv_infos: tuple[_RecvInfo, ...],
     ) -> list[dist.P2POp]:
         """
         Helper function shared by `get_fwd_recv_ops` and `get_bwd_recv_ops`.
@@ -320,15 +355,16 @@ class _PipelineStageBase(ABC):
         """
         ops: list[dist.P2POp] = []
         for info in recv_infos:
-            if not isinstance(info, _RecvInfo):
+            if info.is_root_arg:
+                # Root args don't need recv operations
                 continue
-
-            peer_rank = self.stage_index_to_group_rank[info.source]
-            peer_global_rank = (
-                peer_rank
-                if self.group is None
-                else dist.get_global_rank(self.group, peer_rank)
-            )
+            # Skip entries with None buffer (None gradients)
+            if info.buffer is None:
+                assert info.tensor_meta is None  # noqa: S101
+                continue
+            # At this point, source and buffer are guaranteed non-None
+            assert info.source is not None  # noqa: S101
+            peer_global_rank = self._resolve_peer_global_rank(info.source)
             ops.append(
                 dist.P2POp(dist.irecv, info.buffer, peer_global_rank, self.group)
             )
@@ -337,46 +373,42 @@ class _PipelineStageBase(ABC):
 
     """[Note: V-schedule special case]
 
-    V-Schedules have a special case where 2 stages with adjacent stage_id are on the same rank.
+    V-Schedules have a special case where 2 stages with adjacent stage_id
+    are on the same rank.
 
-    ex: 2 ranks, 4 stages forms a simple V:
-    rank0:  stage 0                   stage 3
-    rank1:          stage 1  stage 2
+    Example: 2 ranks, 4 stages forms a simple V::
 
-    stage 0,1 and 2,3 communicate activations using send/recv as usual, but stage 1,2 do not need to
-    use communication ops.  Instead, they should pass tensor data directly via function call.
+        rank0:  stage 0                   stage 3
+        rank1:          stage 1  stage 2
 
-    set_local_fwd_input and (get_local_bwd_output + set_local_bwd_input) facilitate this optimization, and
-    should be called at the appropriate time during the pipeline schedule (after forward or backward execution).
+    Stages 0/1 and 2/3 communicate via send/recv, but stages 1/2 pass
+    tensors directly via function call, avoiding communication ops.
     """
 
     def set_local_fwd_input(self, prev_stage_outputs: Any, mb_index: int) -> None:
+        """Pass outputs from a same-rank stage as forward inputs (V-schedule).
+
+        Detaches tensors and sets ``requires_grad`` so they serve as autograd
+        leaves. Handles DTensor activations transparently.
         """
-        Moves 'prev_stage_outputs' from another stage on the same rank into place as inputs for this stage. Avoids
-        copying tensor data or using send/recv op.  Detaches original tensor and sets requires_grad so the
-        tensor can serve as a leaf for autograd and gradients can be collected from it during backward.
-        """
-        recv_infos: tuple[InputInfo, ...] = self.args_recv_info[mb_index]
+        recv_infos: tuple[_RecvInfo, ...] = self.args_recv_info[mb_index]
 
         # See [Note: pipeline model output type]
         prev_stage_outputs = _normalize_model_output_as_tuple(prev_stage_outputs)
 
-        for info, tensor in zip(recv_infos, prev_stage_outputs):
+        for info, tensor in zip(recv_infos, prev_stage_outputs, strict=True):
             if not isinstance(tensor, torch.Tensor):
                 raise AssertionError(
                     f"expected tensor values as outputs from prev stage, got {type(tensor)}"
                 )
-            if not isinstance(info, _RecvInfo):
+            if info.is_root_arg:
                 raise AssertionError(
-                    "set_local_Fwd_input should only be called on non-first stage, which should always have RecvInfo"
+                    "set_local_fwd_input should only be called on non-first stage, which should always have non-root RecvInfo"
                 )
 
-            # We don't need to do a data copy here, since we can directly pass the activation tensor reference from
-            # one stage to the next.  However, we do need to mark the activation as a leaf tensor since it will serve
-            # as the input tensor for a fresh autograd graph, not part of the previous stage's autograd graph.
-            # TODO: confirm, do we use this activation as the root of the backward call for the previous stage? does
-            # detach have any affect on that?
-            info.buffer = tensor.detach().requires_grad_(True)
+            # Pass the activation tensor directly (same rank for local execution).
+            # Detach to create a new autograd leaf for the fresh autograd graph.
+            info.buffer = to_local_if_dtensor(tensor, detach=True)
 
     def get_local_bwd_output(self, mb_index):
         """
@@ -398,6 +430,7 @@ class _PipelineStageBase(ABC):
         """
         Moves 'grad input' tensors from the next stage to 'grad_output' on this stage, avoiding a copy or send/recv.
         Does not detach or set '_requires_grad'.
+        Handles DTensor gradients for V-schedule local passing.
         """
         if not isinstance(next_stage_bwd_outputs, tuple):
             raise AssertionError(f"Expected tuple, got {type(next_stage_bwd_outputs)}")
@@ -409,21 +442,27 @@ class _PipelineStageBase(ABC):
         if self.is_last:
             raise AssertionError("can't set bwd input if this stage is last")
         recv_infos = self.grad_recv_info[mb_index]
-        for info, tensor in zip(recv_infos, next_stage_bwd_outputs):
+        for info, tensor in zip(recv_infos, next_stage_bwd_outputs, strict=True):
+            if tensor is None:
+                continue
             if not isinstance(tensor, torch.Tensor):
                 raise AssertionError(
                     f"expected tensor values as outputs from prev stage, got {type(tensor)}"
                 )
-            if not isinstance(info, _RecvInfo):
-                raise AssertionError(f"Expected a recv info, got {type(info)}")
-            info.buffer = tensor
+            if info.is_root_arg:
+                raise AssertionError(
+                    "set_local_bwd_input should only be called with non-root RecvInfo"
+                )
+
+            # Extract local tensor for the buffer (handles DTensor or plain tensor)
+            info.buffer = to_local_if_dtensor(tensor)
 
     def get_fwd_recv_ops(self, fwd_chunk_id: int) -> list[dist.P2POp]:
         """
         Returns a list of ops that are needed to receive the input arguments
         for this stage.
         """
-        recv_infos: tuple[InputInfo, ...] = self.args_recv_info[fwd_chunk_id]
+        recv_infos: tuple[_RecvInfo, ...] = self.args_recv_info[fwd_chunk_id]
 
         return self._get_recv_ops(recv_infos)
 
@@ -441,6 +480,7 @@ class _PipelineStageBase(ABC):
     def get_fwd_send_ops(self, fwd_chunk_id: int) -> list[dist.P2POp]:
         """
         Get the activation send ops for current stage's forward.
+        Handles DTensor outputs by extracting local tensors.
         """
         output_tuple, _ = self.fwd_cache[fwd_chunk_id]
 
@@ -451,25 +491,25 @@ class _PipelineStageBase(ABC):
             for dst in dst_stages:
                 if dst is None:
                     continue
+                # Extract local tensor if DTensor
+                send_tensor = to_local_if_dtensor(out, detach=True)
                 logger.debug(
                     "%s Sending tensor to Stage %s: %s",
                     self.log_prefix,
                     dst,
-                    out.size(),
+                    send_tensor.size(),
                 )
-                peer_rank = self.stage_index_to_group_rank[dst]
-                peer_global_rank = (
-                    peer_rank
-                    if self.group is None
-                    else dist.get_global_rank(self.group, peer_rank)
+                peer_global_rank = self._resolve_peer_global_rank(dst)
+                ops.append(
+                    dist.P2POp(dist.isend, send_tensor, peer_global_rank, self.group)
                 )
-                ops.append(dist.P2POp(dist.isend, out, peer_global_rank, self.group))
 
         return ops
 
     def get_bwd_send_ops(self, bwd_chunk_id: int) -> list[dist.P2POp]:
         """
         Get the gradient send ops for current stage's backward.
+        Handles DTensor gradients by extracting local tensors.
         """
         if not self.has_backward or self.is_first:
             return []
@@ -485,24 +525,24 @@ class _PipelineStageBase(ABC):
 
         ops: list[dist.P2POp] = []
         grads_input = self.bwd_cache.pop(bwd_chunk_id)
-        for grad, grad_recv_stage in zip(grads_input, self.grad_send_info):
+
+        for grad, grad_recv_stage in zip(grads_input, self.grad_send_info, strict=True):
             if isinstance(grad, torch.Tensor) and grad_recv_stage is not None:
+                # Extract local tensor if DTensor
+                send_tensor = to_local_if_dtensor(grad)
                 logger.debug(
                     "%s Sending gradient to Stage %s: %s",
                     self.log_prefix,
                     grad_recv_stage,
-                    grad.size(),
+                    send_tensor.size(),
                 )
-                peer_rank = self.stage_index_to_group_rank[grad_recv_stage]
-                peer_global_rank = (
-                    peer_rank
-                    if self.group is None
-                    else dist.get_global_rank(self.group, peer_rank)
+                peer_global_rank = self._resolve_peer_global_rank(grad_recv_stage)
+                ops.append(
+                    dist.P2POp(dist.isend, send_tensor, peer_global_rank, self.group)
                 )
-                ops.append(dist.P2POp(dist.isend, grad, peer_global_rank, self.group))
             else:
                 if grad is not None or grad_recv_stage is not None:
-                    raise RuntimeError(
+                    raise PipeliningMetadataError(
                         f"[{self.stage_index}] for chunk {bwd_chunk_id} has gradients {grad} "
                         f"and is expecting to send gradients to stage {grad_recv_stage}"
                     )
@@ -523,34 +563,90 @@ class _PipelineStageBase(ABC):
         # don't want such accumulation.
         for recv_tuple in self.args_recv_info.values():  # iterate over all chunks
             for a in recv_tuple:  # iterate over all input args
-                if isinstance(a, _RecvInfo):
+                if not a.is_root_arg and a.buffer is not None:
                     # Set to None is the newer and recommended way to clear grads, compared to `zero_()`.
                     # See https://github.com/pytorch/pytorch/pull/92731
                     a.buffer.grad = None
 
     def _map_tensor_from_recv_info(
         self,
-        recv_infos: tuple[InputInfo, ...],
+        recv_infos: tuple[_RecvInfo, ...],
     ):
         """
         Map tensors from recv infos to a list.
         """
 
         def get_recv_tensor(info):
-            if isinstance(info, _RecvInfo):
-                return info.buffer
-            else:
-                raise AssertionError(f"Expected _RecvInfo but got {type(info)}")
+            if info.is_root_arg:
+                raise PipeliningMetadataError("Cannot get recv tensor from root arg")
+            return info.buffer
 
         return map_aggregate(cast(Argument, recv_infos), get_recv_tensor)
 
-    def _retrieve_recv_activations(self, fwd_chunk_id: int):
+    def _retrieve_recv_activations(
+        self,
+        fwd_chunk_id: int,
+    ):
         """
         Retrieve the activations received for the current stage during forward.
+        Reconstructs DTensors if the inputs were DTensors.
+        Also validates DTensor metadata against expected values.
         """
         recv_infos = self.args_recv_info[fwd_chunk_id]
-        activations = self._map_tensor_from_recv_info(recv_infos)
-        return activations
+
+        activations = []
+        for i, info in enumerate(recv_infos):
+            if not info.is_root_arg:
+                # Non-root args have valid buffer and tensor_meta
+                if info.buffer is None or info.tensor_meta is None:
+                    raise PipeliningMetadataError(
+                        f"Non-root arg '{info.input_name}' has None buffer or tensor_meta"
+                    )
+                # Effective requires_grad: metadata captures what the model
+                # produced, but the runtime context (has_backward, grad mode)
+                # determines whether we actually need gradients.
+                effective_requires_grad = (
+                    info.tensor_meta.requires_grad
+                    and self.has_backward
+                    and torch.is_grad_enabled()
+                )
+                if isinstance(info.tensor_meta, _DTensorMeta):
+                    # Buffer must not require grad so from_local stays out
+                    # of the autograd graph (no grad_placements needed).
+                    if info.buffer.requires_grad:
+                        raise PipeliningMetadataError(
+                            f"Stage {self.stage_index}: recv buffer "
+                            f"'{info.input_name}' unexpectedly requires grad "
+                            f"before DTensor reconstruction"
+                        )
+                    mesh = self._mesh_cache.get_mesh(info.tensor_meta.mesh_cache_key)
+                    activation = DTensor.from_local(
+                        info.buffer,
+                        device_mesh=mesh,
+                        placements=info.tensor_meta.placements,
+                        shape=info.tensor_meta.global_shape,
+                        stride=info.tensor_meta.global_stride,
+                        run_check=False,
+                    ).requires_grad_(effective_requires_grad)
+                else:
+                    activation = info.buffer.requires_grad_(effective_requires_grad)
+                # Activation must be a leaf so backward terminates here.
+                if effective_requires_grad and not activation.is_leaf:
+                    warnings.warn(
+                        f"Stage {self.stage_index}: activation "
+                        f"'{info.input_name}' is not a leaf "
+                        f"(grad_fn={activation.grad_fn}); using "
+                        f"retain_grad() as fallback",
+                        stacklevel=2,
+                    )
+                    activation.retain_grad()
+                activations.append(activation)
+            else:
+                raise PipeliningMetadataError(
+                    f"_retrieve_recv_activations expected non-root _RecvInfo but got root arg at index {i}"
+                )
+
+        return tuple(activations)
 
     def _retrieve_recv_grads(
         self,
@@ -558,10 +654,50 @@ class _PipelineStageBase(ABC):
     ):
         """
         Retrieve the gradients received for the current stage during backward.
+
+        Handles None gradients gracefully (for inputs that don't require grad).
         """
         recv_infos = self.grad_recv_info[bwd_chunk_id]
-        grads = self._map_tensor_from_recv_info(recv_infos)
-        return grads
+
+        grads: list[torch.Tensor | None] = []
+        for i, info in enumerate(recv_infos):
+            if not isinstance(info, _RecvInfo):
+                raise PipeliningMetadataError(
+                    f"Expected _RecvInfo but got {type(info)}"
+                )
+            if not info.is_root_arg:
+                # Gradients can be None for non-differentiable outputs
+                if info.buffer is None:
+                    if info.tensor_meta is not None:
+                        raise PipeliningMetadataError(
+                            f"Grad recv '{info.input_name}': buffer is None but tensor_meta is not None"
+                        )
+                    grads.append(None)
+                    continue
+                if info.tensor_meta is None:
+                    raise PipeliningMetadataError(
+                        f"Grad recv '{info.input_name}': buffer is not None but tensor_meta is None"
+                    )
+                if isinstance(info.tensor_meta, _DTensorMeta):
+                    # Reconstruct DTensor gradient from local tensor + metadata
+                    mesh = self._mesh_cache.get_mesh(info.tensor_meta.mesh_cache_key)
+                    grad = DTensor.from_local(
+                        info.buffer,
+                        device_mesh=mesh,
+                        placements=info.tensor_meta.placements,
+                        shape=info.tensor_meta.global_shape,
+                        stride=info.tensor_meta.global_stride,
+                        run_check=False,
+                    )
+                else:
+                    grad = info.buffer
+                grads.append(grad)
+            else:
+                raise PipeliningMetadataError(
+                    f"grad_recv_info should not contain root args, but found one at index {i}"
+                )
+
+        return tuple(grads)
 
     def forward_maybe_with_nosync(self, *args, **kwargs):
         # If submod is wrapped with DDP, we use the `no_sync` context manager to
@@ -691,7 +827,12 @@ class _PipelineStageBase(ABC):
 
         composite_kwargs = kwargs or {}
 
-        self._validate_fwd_input(args, kwargs)
+        if self._runtime_validate:
+            self._validate_stage_tensors(
+                f"Stage {self.stage_index} forward inputs",
+                self._stage_meta.inputs,
+                composite_args,
+            )
 
         # Compute forward
         try:
@@ -727,7 +868,14 @@ class _PipelineStageBase(ABC):
             fwd_chunk_id,
             map_debug_info(output),
         )
-        self._validate_fwd_outputs(output_tuple)
+        # Validate outputs before P2P send; skipped for last stage (outputs
+        # go to loss/user, not via send/recv).
+        if self._runtime_validate and not self.is_last:
+            self._validate_stage_tensors(
+                f"Stage {self.stage_index} forward outputs",
+                self._stage_meta.outputs,
+                output_tuple,
+            )
 
         # We return the original user-provided output, not normalized to tuple.
         # See [Note: pipeline model output type]
@@ -776,6 +924,13 @@ class _PipelineStageBase(ABC):
         else:
             # Otherwise, receive gradients from next stage
             grads_output = self._retrieve_recv_grads(bwd_chunk_id)
+            if self._runtime_validate:
+                # Validate backward input (output gradients) for DTensor metadata
+                self._validate_stage_tensors(
+                    f"Stage {self.stage_index} backward input (output_grads)",
+                    self._stage_meta.output_grads,
+                    grads_output,
+                )
             # If an input to the pipeline requires gradient,
             # `torch.autograd.backward` will accumulate the gradient into the
             # `.grad` field of such input
@@ -828,8 +983,18 @@ class _PipelineStageBase(ABC):
                 )
                 # Save a placeholder for the dw_runner
                 self.dw_runner[bwd_chunk_id] = lambda: None
-
-        self.bwd_cache[bwd_chunk_id] = grads_input
+        # Note: grads_input may contain gradients for both args and kwargs (from fwd_cache),
+        # Kwargs are local to each stage and don't need gradient transmission.
+        # Validate backward output (input gradients) for DTensor metadata
+        assert self._stage_meta.inputs is not None  # noqa: S101
+        num_fwd_args = len(self._stage_meta.inputs)
+        if self._runtime_validate and not self.is_first:
+            self._validate_stage_tensors(
+                f"Stage {self.stage_index} backward output (input_grads)",
+                self._stage_meta.input_grads,
+                grads_input[:num_fwd_args],
+            )
+        self.bwd_cache[bwd_chunk_id] = grads_input[:num_fwd_args]
 
         if self.is_last and not self.is_first:
             # Autograd dependencies:
@@ -886,48 +1051,6 @@ class _PipelineStageBase(ABC):
                 self.backward_maybe_with_nosync(
                     "full", bwd_kwargs, last_backward=last_backward
                 )
-
-    def _validate_fwd_input(self, args, kwargs):
-        """Raises a RuntimeError if shapes of input args/kwargs do not match the shapes configured for this stage."""
-
-        if self.is_first:
-            # TODO why is there a separate recv_info for each pipeline chunk?
-            # kwen2501: to avoid passing a `fwd_chunk_id` to this function, we
-            # check all chunks against args_recv_info[0]
-            expected_args = self.args_recv_info[0]
-        else:
-            # We don't check inputs for non-0 stages assuming they don't accept
-            # user inputs in canonical pipeline scenarios
-            return
-
-        if len(kwargs):
-            # TODO- need a mapping of kwarg to position in self.args_recv_info
-            # Without it, we are not 100% sure how to match the args and
-            # expected_args.
-            return
-
-        # TODO- need a mapping of kwarg to position in self.args_recv_info
-        # maybe it's impossible to tell whether the len mismatches because
-        # (a) the user passed an extra arg or missed an arg
-        # (b) the user did not pass a kwarg, which has a default value baked into expected_args
-        expected_tensors_meta = [
-            e.meta if isinstance(e, _RootArgPlaceholder) else e.buffer
-            for e in expected_args
-        ]
-        validate_tensors_metadata(
-            f"Stage {self.stage_index} forward inputs", expected_tensors_meta, args
-        )
-
-    def _validate_fwd_outputs(self, outputs: tuple[torch.Tensor, ...]):
-        """Raises a RuntimeError if this stage produces an output of unexpected shape/dtype.
-        Most likely, this could be cause either by incorrect user specification of output shapes, or because
-        shape inference was done on the original model but then at runtime the model is wrapped with something like
-        mixed precision which changes output dtype.
-        """
-        expected_tensors_meta = self.get_outputs_meta()
-        validate_tensors_metadata(
-            f"Stage {self.stage_index} forward outputs", expected_tensors_meta, outputs
-        )
 
     def _get_init_p2p_neighbors_ops(self) -> list[dist.P2POp]:
         """
@@ -1054,7 +1177,7 @@ class _PipelineStage(_PipelineStageBase):
             node for node in pipe_info.graph.nodes if node.op == "call_module"
         ]
         if len(submod_nodes) != self.num_stages:
-            raise AssertionError(
+            raise PipeliningMetadataError(
                 f"Number of submodules in pipe graph {len(submod_nodes)} does not match number of stages {self.num_stages}"
             )
 
@@ -1092,21 +1215,85 @@ class _PipelineStage(_PipelineStageBase):
     def _prepare_forward_infra(
         self,
         num_microbatches: int,
-        args: tuple[Any, ...],
+        args: tuple[Any, ...] | _StageForwardMeta | None,
         kwargs: dict[str, Any] | None = None,
-    ) -> tuple[Any, ...]:
+        has_backward: bool = False,
+    ) -> _StageForwardMeta | None:
         """
-        Create send/recv infrastructures for activations (during forward)
+        Prepare forward infrastructure for traced pipeline.
+
+        Metadata is created directly from graph placeholders with correct
+        ``requires_grad`` — received activations get ``requires_grad=True``
+        when ``has_backward`` is set, fixing the fact that ``torch.export``
+        traces under ``no_grad()``.
+
+        ``_stage_meta.inputs`` is derived from recv infos and aligned with
+        ``forward_one_chunk``'s ``composite_args``: positional root inputs
+        on the first stage, received activations only on subsequent stages.
         """
-        # TODO(whc)
-        # this method should be deleted once lazy buffer allocation is implemented
-        # for now, it ignores args/kwargs because it should not need to do shape inference
+        # Step 1: Create recv info for each microbatch.
+        # _create_act_recv_info is self-contained: it creates _TensorMeta
+        # directly from graph placeholder values with correct requires_grad.
         for chunk in range(num_microbatches):
             self.args_recv_info[chunk] = self._create_act_recv_info()
 
-        # Send info during forward for each activation
+        # Step 2: Derive _stage_meta.inputs from recv infos.
+        # forward_one_chunk builds composite_args as:
+        #   - First stage:     args (positional root inputs, excludes kwargs)
+        #   - Non-first stages: received activations only (no root kwargs)
+        # _stage_meta.inputs must match composite_args for validation.
+        recv_infos = self.args_recv_info[0]
+        if self.is_first:
+            # All placeholders are root args.  Only the first len(args)
+            # correspond to positional inputs (composite_args); the rest
+            # are kwargs passed separately via composite_kwargs.
+            # First stage always receives real tensor args, never _StageForwardMeta.
+            if not isinstance(args, tuple):
+                raise AssertionError("First stage requires real tensor args")
+            n_positional = len(args)
+            self._stage_meta.inputs = tuple(
+                info.tensor_meta  # type: ignore[misc]
+                for info in recv_infos[:n_positional]
+            )
+        else:
+            self._stage_meta.inputs = tuple(
+                info.tensor_meta  # type: ignore[misc]
+                for info in recv_infos
+                if not info.is_root_arg
+            )
+
+        # Step 3: Create send info and output metadata.
         self.act_send_info = self._create_act_send_info()
-        return tuple()
+
+        return None
+
+    def _prepare_backward_infra(
+        self,
+        num_microbatches: int,
+        loss_fn: Callable[..., torch.Tensor] | None = None,
+        target: torch.Tensor | None = None,
+        received_grad_meta: _StageBackwardMeta | None = None,
+    ) -> _StageBackwardMeta | None:
+        """
+        Prepare backward infrastructure for traced pipeline.
+        Derives input_grads metadata from inputs (plain tensors only).
+
+        Note: DTensors are NOT supported in the traced frontend.
+        """
+        # Derive input_grads from inputs (for plain tensors, grad shape == input shape)
+        if self._stage_meta.inputs is None:
+            raise PipeliningMetadataError(
+                f"Stage {self.stage_index}: inputs metadata required for backward inference."
+            )
+
+        self._stage_meta.input_grads = _derive_grad_metas(self._stage_meta.inputs)
+
+        # Setup backward recv info (calls _create_grad_recv_info which sets output_grads).
+        # Note: grad_send_info is created lazily in get_bwd_send_ops() since
+        # it mirrors args_recv_info (already populated during forward).
+        self._setup_backward_recv_info(num_microbatches)
+
+        return None
 
     def get_stage_index_of_submod(
         self,
@@ -1116,7 +1303,7 @@ class _PipelineStage(_PipelineStageBase):
         Given a submodule name, return the stage index of the submodule.
         """
         if submod_name not in self.submod_to_stage_index:
-            raise AssertionError(f"Stage id of {submod_name} not found")
+            raise PipeliningMetadataError(f"Stage id of {submod_name} not found")
 
         return self.submod_to_stage_index[submod_name]
 
@@ -1125,38 +1312,65 @@ class _PipelineStage(_PipelineStageBase):
     ):
         """
         Create a tuple of `_RecvInfo` for inputs to the stage.
+
+        Self-contained: creates ``_TensorMeta`` directly from graph
+        placeholder values with correct ``requires_grad``.
+        ``torch.export`` traces under ``no_grad()`` so traced metadata
+        always has ``requires_grad=False``; for received activations we
+        set ``requires_grad=True`` when ``has_backward`` is set.
+
+        Note: DTensors are NOT supported in the traced frontend.
         """
 
         def create_recv_tensor(placeholder, arg_node):
-            """
-            Create a receive buffer for a placeholder.
-            """
             example_value = placeholder.meta["val"]
-            if arg_node.op == "placeholder":
-                # This is a root level placeholder, thus an input argument to the entire model.
-                # We are likely at stage 0, hence no need to create a receive buffer.
-                return _RootArgPlaceholder(example_value)
 
-            # Figure out the source stage of this input
+            # Reject DTensors in traced frontend
+            if isinstance(example_value, DTensor):
+                raise PipeliningMetadataError(
+                    f"{self.log_prefix} DTensor detected in traced pipeline input "
+                    f"'{placeholder.name}'. DTensor metadata propagation is NOT "
+                    f"supported for the traced frontend (_PipelineStage). "
+                    f"Use the manual PipelineStage frontend for full DTensor support."
+                )
+
+            if arg_node.op == "placeholder":
+                # Root-level placeholder: an input argument to the entire
+                # model.  Keep original metadata from the trace.
+                return _RecvInfo(
+                    input_name=f"root_input_{placeholder.name}",
+                    source=None,
+                    buffer=None,
+                    tensor_meta=_TensorMeta.from_tensor(example_value),
+                    is_root_arg=True,
+                )
+
+            # Received activation from a previous stage.
             while arg_node.target is operator.getitem:
-                # If the input is a getitem, we need to go deeper
                 arg_node = arg_node.args[0]
 
             if arg_node.op != "call_module":
-                raise AssertionError(f"Expecting call_module, got {arg_node.op}")
+                raise PipeliningMetadataError(
+                    f"Expecting call_module, got {arg_node.op}"
+                )
             src_stage = self.get_stage_index_of_submod(arg_node.name)
 
-            # Create a receive buffer for this placeholder
+            # Create metadata directly with correct requires_grad.
+            tensor_meta = _TensorMeta(
+                shape=example_value.shape,
+                stride=example_value.stride(),
+                dtype=example_value.dtype,
+                requires_grad=self.has_backward,
+            )
+
             logger.debug(
                 "%s Creating recv buffer for input '%s' : %s, %s",
                 self.log_prefix,
                 placeholder.name,
-                example_value.shape,
-                example_value.dtype,
+                tensor_meta.shape,
+                tensor_meta.dtype,
             )
-            buffer = _make_tensor_from_meta(example_value, self.device)
-            # In case there is backward pass, set requires_grad for receive buffers
-            # before first forward
+            buffer = _make_tensor_from_meta(tensor_meta, self.device)
             if self.has_backward:
                 buffer.requires_grad_(True)
 
@@ -1164,10 +1378,10 @@ class _PipelineStage(_PipelineStageBase):
                 arg_node.name,
                 src_stage,
                 buffer,
+                tensor_meta,
             )
 
-        args_recv_info: list[InputInfo] = []
-        # Filter out placeholder nodes from `self.submod` (a GraphModule)
+        args_recv_info: list[_RecvInfo] = []
         placeholders = filter(  # type: ignore[var-annotated]
             lambda node: node.op == "placeholder",  # type: ignore[arg-type]
             self.submod.graph.nodes,  # type: ignore[arg-type,union-attr]
@@ -1175,15 +1389,12 @@ class _PipelineStage(_PipelineStageBase):
         # `placeholders` are nodes internal to submod.
         # `self.node.args` are dependency nodes in the outer graph.
         # The two are 1:1.
-        for placeholder, arg_node in zip(placeholders, self.node.args):
-            # Create a receive buffer for this placeholder
-            recv_info = create_recv_tensor(placeholder, arg_node)
-            args_recv_info.append(recv_info)
+        for placeholder, arg_node in zip(placeholders, self.node.args, strict=True):
+            args_recv_info.append(create_recv_tensor(placeholder, arg_node))
 
         logger.debug(
             "%s Activation recv / args info: %s", self.log_prefix, args_recv_info
         )
-        # `args` is a Tuple, hence we will return a Tuple[InputInfo]
         return tuple(args_recv_info)
 
     def find_dst_rank(
@@ -1207,14 +1418,12 @@ class _PipelineStage(_PipelineStageBase):
 
     def _create_act_send_info(self):
         """
-        Create a dict of send info for activations.
-        The dict is of the form:
-        {
-            output_index: [dst_rank_0, dst_rank_1, ...],
-            ...
-        }
-        where the list of `dst_rank`s covers the case where an output value may
-        be consumed by multiple stages.
+        Create a dict of send info for activations and output metadata.
+
+        Output metadata is created directly with correct ``requires_grad``
+        (``torch.export`` traces under ``no_grad()``, so traced values
+        always have ``requires_grad=False``; at runtime, stage outputs
+        carry ``requires_grad=True`` when training).
         """
         # Output index: List of receiver ranks
         act_send_info: dict[int, list] = {}
@@ -1222,16 +1431,13 @@ class _PipelineStage(_PipelineStageBase):
 
         for user in self.node.users:
             if user.target is operator.getitem:
-                # Recursively find the real destination
                 gi_dsts = act_send_info.setdefault(out_idx, [])
                 for gi_user in user.users:
                     dst_rank = self.find_dst_rank(gi_user)
                     if dst_rank is not None:
                         gi_dsts.append(dst_rank)
-                # Next `getitem` will point to the next output index
                 out_idx += 1
             else:
-                # In case of single output value, `out_idx` will not increase
                 dsts = act_send_info.setdefault(out_idx, [])
                 dst_rank = self.find_dst_rank(user)
                 if dst_rank is not None:
@@ -1241,7 +1447,25 @@ class _PipelineStage(_PipelineStageBase):
         output_vals: tuple[torch.Tensor] = tuple(
             v.meta["val"] for v in flatten_args(output_node.args)
         )
-        self._configure_outputs_meta(output_vals)
+        # Reject DTensors and create output metadata directly with
+        # correct requires_grad.
+        output_metas: list[_TensorMeta] = []
+        for i, val in enumerate(output_vals):
+            if isinstance(val, DTensor):
+                raise PipeliningMetadataError(
+                    f"{self.log_prefix} DTensor detected in traced pipeline output index {i}. "
+                    f"DTensor metadata propagation is NOT supported for the traced frontend "
+                    f"(_PipelineStage). Use the manual PipelineStage frontend for full DTensor support."
+                )
+            output_metas.append(
+                _TensorMeta(
+                    shape=val.shape,
+                    stride=val.stride(),
+                    dtype=val.dtype,
+                    requires_grad=self.has_backward,
+                )
+            )
+        self._stage_meta.outputs = tuple(output_metas)
 
         logger.debug("%s Send info: %s", self.log_prefix, act_send_info)
         return act_send_info
@@ -1249,50 +1473,79 @@ class _PipelineStage(_PipelineStageBase):
     def _get_output_node(self):
         output_nodes = [node for node in self.submod.graph.nodes if node.op == "output"]  # type: ignore[union-attr]
         if len(output_nodes) != 1:
-            raise AssertionError(f"Expected 1 output node, got {len(output_nodes)}")
+            raise PipeliningMetadataError(
+                f"Expected 1 output node, got {len(output_nodes)}"
+            )
         output_node = output_nodes[0]
         return output_node
 
-    def _create_grad_recv_info(
-        self,
-        act_send_info: dict,
-    ) -> tuple[_RecvInfo, ...]:
+    def _create_grad_recv_info(self, act_send_info: dict) -> tuple[_RecvInfo, ...]:
         """
         Create a tuple of `_RecvInfo` for gradients.
+        Reuses output metadata from _stage_meta.outputs (populated by _create_act_send_info).
         """
-        # Dict[output_index, _RecvInfo]
-        grad_recv_info: dict[int, _RecvInfo] = {}
-        output_node = self._get_output_node()
-
-        # The output node may take multiple args, meaning the submod having multiple output values.
-        output_vals = flatten_args(output_node.args)
-
-        for out_idx, dst_list in act_send_info.items():
-            if not dst_list:
-                # No actual receiver for activation so no grad coming back
-                continue
-
-            output = output_vals[out_idx]
-            example_value = output.meta["val"]
-            logger.debug(
-                f"{self.log_prefix} Creating grad recv buffer for output {output.name} "  # noqa: G004
-                f": {example_value.shape}, {example_value.dtype}"
+        if self._stage_meta.outputs is None:
+            raise PipeliningMetadataError(
+                f"Stage {self.stage_index}: outputs metadata required for grad recv info. "
+                f"Ensure _create_act_send_info is called first."
             )
 
-            # TODO: otherwise needs grad accumulation
-            if len(dst_list) != 1:
-                raise AssertionError("Backward of skip connections not supported yet")
-            grad_src = dst_list[0]
-            grad_recv_info[out_idx] = _RecvInfo(
-                f"{grad_src}",  # noqa: G004
-                grad_src,
-                _make_tensor_from_meta(example_value, self.device),
-            )
+        outputs_meta = self._stage_meta.outputs
+        output_grads_metas: list[TensorMeta | None] = []
+        grad_recv_infos: list[_RecvInfo] = []
 
-        # Convert to tuple for convenience in get_ops and retrieve tensor
-        grad_recv_info_tuple = tuple(grad_recv_info.values())
-        logger.debug("%s Grad recv info: %s", self.log_prefix, grad_recv_info_tuple)
-        return grad_recv_info_tuple
+        for out_idx, out_meta in enumerate(outputs_meta):
+            dst_list = act_send_info.get(out_idx, [])
+
+            # Determine the source stage for gradients
+            grad_src = dst_list[0] if dst_list else self.stage_index + 1
+
+            # Check if this output needs gradients
+            if not dst_list or not out_meta.requires_grad:
+                output_grads_metas.append(None)
+                grad_recv_infos.append(
+                    _RecvInfo(
+                        input_name=f"recv_grad_for_{self.stage_index}_none_{out_idx}",
+                        source=grad_src,
+                        buffer=None,
+                        tensor_meta=None,
+                    )
+                )
+            else:
+                # Derive grad metadata from output metadata (same shape, requires_grad=False)
+                grad_meta = _TensorMeta(
+                    shape=out_meta.shape,
+                    stride=out_meta.stride,
+                    dtype=out_meta.dtype,
+                    requires_grad=False,
+                )
+                output_grads_metas.append(grad_meta)
+
+                if len(dst_list) != 1:
+                    raise PipeliningMetadataError(
+                        "Backward of skip connections not supported yet"
+                    )
+
+                logger.debug(
+                    "%s Creating grad recv buffer for output %s : %s, %s",
+                    self.log_prefix,
+                    out_idx,
+                    grad_meta.shape,
+                    grad_meta.dtype,
+                )
+
+                grad_recv_infos.append(
+                    _RecvInfo(
+                        input_name=f"recv_grad_for_{self.stage_index}_from_{grad_src}",
+                        source=grad_src,
+                        buffer=_make_tensor_from_meta(grad_meta, self.device),
+                        tensor_meta=grad_meta,
+                    )
+                )
+
+        self._stage_meta.output_grads = tuple(output_grads_metas)
+        logger.debug("%s Grad recv info: %s", self.log_prefix, grad_recv_infos)
+        return tuple(grad_recv_infos)
 
 
 # A helper function to create a pipeline stage based on traced pipeline information
@@ -1327,26 +1580,33 @@ def build_stage(
 
 
 class PipelineStage(_PipelineStageBase):
-    """
-    A class representing a pipeline stage in a pipeline parallelism setup.
+    """A pipeline stage for pipeline parallelism with sequential model partitioning.
 
-    PipelineStage assumes sequential partitioning of the model, i.e. the model is split into chunks where outputs from
-    one chunk feed into inputs of the next chunk, with no skip connections.
+    Supports both **static** and **dynamic** metadata inference:
 
-    PipelineStage performs runtime shape/dtype inference automatically by propagating the outputs from stage0 to
-    stage1 and so forth, in linear order.  To bypass shape inference, pass the `input_args` and `output_args` to each
-    PipelineStage instance.
+    Static mode:
+        All of ``input_args``, ``output_args`` (and ``input_grads``/``output_grads``
+        when DTensors are present) are provided at construction time.
+
+    Dynamic mode:
+        Metadata is inferred from the first microbatch at runtime; any
+        statically provided args are used for validation only.
 
     Args:
-        submodule (nn.Module): The PyTorch module wrapped by this stage.
-        stage_index (int): The ID of this stage.
-        num_stages (int): The total number of stages.
-        device (torch.device): The device where this stage is located.
-        input_args (Union[torch.Tensor, Tuple[torch.tensor]], optional): The input arguments for the submodule.
-        output_args (Union[torch.Tensor, Tuple[torch.tensor]], optional): The output arguments for the submodule.
-        group (dist.ProcessGroup, optional): The process group for distributed training. If None, default group.
-        dw_builder (Optional[Callable[[], Callable[..., None]]): If provided, dw_builder will build a new dw_runner function
-            that will the W action (input weights) for F, I, W (Fwd, Input, Weight) zero bubble schedules.
+        submodule: The ``nn.Module`` wrapped by this stage.
+        stage_index: Zero-based stage ID.
+        num_stages: Total number of stages in the pipeline.
+        device: Device this stage runs on.
+        input_args: Example input tensors (single tensor or tuple). Optional.
+        output_args: Example output tensors. Optional.
+        output_grads: Example output gradients (received from next stage). Optional.
+        input_grads: Example input gradients (sent to previous stage). Optional.
+        group: Process group for P2P communication. Defaults to the
+            world process group.
+        dw_builder: Builder for deferred weight-update runners used by
+            zero-bubble (F/I/W) schedules.
+        get_mesh: `GetMeshCallback` used during
+            dynamic DTensor inference. Ignored in fully static DTensor mode.
     """
 
     def __init__(
@@ -1357,247 +1617,633 @@ class PipelineStage(_PipelineStageBase):
         device: torch.device,
         input_args: torch.Tensor | tuple[torch.Tensor, ...] | None = None,
         output_args: torch.Tensor | tuple[torch.Tensor, ...] | None = None,
+        output_grads: torch.Tensor | tuple[torch.Tensor | None, ...] | None = None,
+        input_grads: torch.Tensor | tuple[torch.Tensor | None, ...] | None = None,
         group: dist.ProcessGroup | None = None,
         dw_builder: Callable[[], Callable[..., None]] | None = None,
+        get_mesh: GetMeshCallback | None = None,
     ):
         super().__init__(submodule, stage_index, num_stages, device, group, dw_builder)
-        self.inputs: list[torch.Tensor] | None = None
-        self.inputs_meta: tuple[torch.Tensor, ...] | None = None
-        # Note: inputs and submod should ideally be on meta device. We decided not to assert this (yet) because it
-        # might be breaking for existing users.
-        if input_args is None:
-            if output_args is not None:
-                raise AssertionError(
-                    "If specifying output_args, input_args must also be specified. "
-                    "Otherwise, shape inference will be performed at runtime"
-                )
-        else:
-            self.inputs_meta = (
-                (input_args,) if isinstance(input_args, torch.Tensor) else input_args
-            )
-            if output_args is None:
-                logger.warning(
-                    "Deprecation warning: passing input_args and performing init-time shape inference is deprecated. "
-                    "PipelineStage now supports runtime shape inference using the real inputs provided to schedule step(). "
-                    "Either delete `input_args` arg to `PipelineStage` to opt-into runtime shape inference, "
-                    "or additionally pass `output_args` to `PipelineStage` to fully override shape inference. "
-                )
-                try:
-                    with torch.no_grad():
-                        output_args = submodule(*self.inputs_meta)
-                    output_args = tree_map_only(
-                        torch.Tensor, lambda x: x.to("meta"), output_args
-                    )
-                except Exception as e:
-                    raise RuntimeError(
-                        "Failed to perform pipeline shape inference- are your inputs on the same device as your module?"
-                    ) from e
-            if output_args is None:
-                raise AssertionError(
-                    "If passing input_args, also pass output_args to override shape inference"
-                )
-            self._configure_outputs_meta(
-                (output_args,) if isinstance(output_args, torch.Tensor) else output_args
-            )
 
-        # these are the buffers used in backwards send/recv, they are allocated later
-        self.outputs_grad: list[torch.Tensor] = []
+        self._mesh_cache = _MeshCache(get_mesh_cb=get_mesh)
+        self._inference_mode: InferenceMode | None = None
+        self._fwd_outputs_for_bwd_meta: tuple[torch.Tensor, ...] | None = None
+        self._fwd_inputs_for_bwd_meta: tuple[torch.Tensor, ...] | None = None
+        self._fwd_kwargs_tensors_for_bwd_meta: tuple[torch.Tensor, ...] | None = None
 
-        dbg_str = (
-            f"Finished pipeline stage init, {self.stage_index=}, {self.is_first=}, "  # noqa: G004
-            f"{self.is_last=}, {self.num_stages=}, "
+        # Validate and normalize args to tuples
+        inputs = validate_and_normalize_to_tuple(input_args)
+        outputs = validate_and_normalize_to_tuple(output_args)
+        in_grads = validate_and_normalize_to_tuple(input_grads, allow_none=True)
+        out_grads = validate_and_normalize_to_tuple(output_grads, allow_none=True)
+
+        self._user_meta = _StageMeta(
+            inputs=extract_tensor_metas(inputs),
+            outputs=extract_tensor_metas(outputs),
+            input_grads=extract_tensor_metas(in_grads, allow_none=True),
+            output_grads=extract_tensor_metas(out_grads, allow_none=True),
         )
-        if self.inputs_meta is not None:
-            dbg_str += (
-                f"inputs: {[inp.shape for inp in self.inputs_meta]}, "
-                f"output: {[output.shape for output in self.get_outputs_meta()]}"
+
+        # Cache meshes from user-provided DTensors
+        for args in (inputs, outputs, in_grads, out_grads):
+            if args is not None:
+                self._mesh_cache.update_from_tensors(args)
+
+        # Validate DTensor↔grad correspondence independently for inputs and outputs
+        if self._user_meta.has_dtensors():
+            if inputs and in_grads:
+                validate_static_arg_grad_correspondence(
+                    self.stage_index, inputs, in_grads, is_input=True
+                )
+            if outputs and out_grads:
+                validate_static_arg_grad_correspondence(
+                    self.stage_index, outputs, out_grads, is_input=False
+                )
+
+    def _recv_meta(self, src_stage: int) -> Any:
+        """Receive metadata object from a stage on a different rank via P2P."""
+        objects: list[Any] = [None]
+        dist.recv_object_list(
+            objects,
+            src=self._resolve_peer_global_rank(src_stage),
+            group=self.group,
+            device=self.device,
+            use_batch=True,
+        )
+        if len(objects) != 1:
+            raise PipeliningMetadataError(
+                f"Expected exactly one object to be received but got: {len(objects)}"
             )
+        return objects[0]
+
+    def _send_meta(self, meta: Any, dst_stage: int) -> None:
+        """Send metadata object to a stage on a different rank via P2P."""
+        dist.send_object_list(
+            [meta],
+            dst=self._resolve_peer_global_rank(dst_stage),
+            group=self.group,
+            device=self.device,
+            use_batch=True,
+        )
+
+    def _is_same_rank(self, other_stage: int) -> bool:
+        """Check if another stage is on the same rank as this stage."""
+        return self.stage_index_to_group_rank[other_stage] == self.group_rank
+
+    def _warmup_forward_vote(
+        self, has_backward: bool, received_acc: torch.Tensor | None = None
+    ) -> torch.Tensor:
+        """Forward phase of the warm-up vote protocol (stage 0 → N−1).
+
+        Each stage computes a vote (1 = STATIC, 0 = DYNAMIC) based on
+        ``InferenceMode.needs_dynamic``, multiplies it with the accumulated
+        product from the previous stage, and forwards the result to the next
+        stage.  The final product at stage N−1 is 1 iff *every* stage voted
+        STATIC.
+
+        Args:
+            has_backward: Whether the schedule includes a backward pass.
+            received_acc: Accumulated product tensor from the previous
+                same-rank stage (V-schedule), or ``None`` for the first
+                stage / cross-rank.
+
+        Returns:
+            The accumulated product tensor after this stage's vote.
+        """
+        my_vote = 0 if InferenceMode.needs_dynamic(self._user_meta, has_backward) else 1
+
+        my_vote_t = torch.tensor([my_vote], dtype=torch.int32, device=self.device)
+
+        if self.is_first:
+            acc = my_vote_t
+        elif self._is_same_rank(self.stage_index - 1):
+            assert received_acc is not None  # noqa: S101
+            acc = received_acc * my_vote_t
         else:
-            dbg_str += " running shape-inference at runtime"
+            peer_global = self._resolve_peer_global_rank(self.stage_index - 1)
+            acc = torch.zeros(1, dtype=torch.int32, device=self.device)
+            dist.recv(acc, src=peer_global, group=self.group)
+            acc = acc * my_vote_t
 
-        logger.debug(dbg_str)
+        if not self.is_last and not self._is_same_rank(self.stage_index + 1):
+            peer_global = self._resolve_peer_global_rank(self.stage_index + 1)
+            dist.send(acc, dst=peer_global, group=self.group)
 
-    def _shape_inference(
+        return acc
+
+    def _warmup_backward_result(
+        self, received_result: torch.Tensor | None = None
+    ) -> torch.Tensor:
+        """Backward phase of the warm-up vote protocol (stage N−1 → 0).
+
+        Propagates the final accumulated product (computed in the forward
+        phase) back through the pipeline so every stage learns the global
+        inference mode.
+
+        Args:
+            received_result: Result tensor from the next same-rank stage
+                (V-schedule), or ``None`` for the last stage / cross-rank.
+
+        Returns:
+            The global vote result tensor for this stage.
+        """
+        if self.is_last or self._is_same_rank(self.stage_index + 1):
+            assert received_result is not None  # noqa: S101
+            result = received_result
+        else:
+            peer_global = self._resolve_peer_global_rank(self.stage_index + 1)
+            result = torch.zeros(1, dtype=torch.int32, device=self.device)
+            dist.recv(result, src=peer_global, group=self.group)
+
+        if not self.is_first and not self._is_same_rank(self.stage_index - 1):
+            peer_global = self._resolve_peer_global_rank(self.stage_index - 1)
+            dist.send(result, dst=peer_global, group=self.group)
+
+        return result
+
+    def _compute_outputs(
         self,
-        args: tuple[Any, ...],
+        *args: torch.Tensor,
+        module: torch.nn.Module,
+        **kwargs: Any,
+    ) -> torch.Tensor | tuple[torch.Tensor, ...] | list[torch.Tensor] | None:
+        """Compute outputs of the submodule."""
+        return module(*args, **kwargs)
+
+    def _compute_input_grads(
+        self,
+        outputs: list[torch.Tensor],
+        all_fwd_inputs: list[torch.Tensor],
+        grad_outputs: list[torch.Tensor | None] | None = None,
+    ) -> tuple[torch.Tensor | None, ...]:
+        """Compute input gradients via :func:`_autograd_grad_for_inputs`."""
+        return _autograd_grad_for_inputs(
+            outputs,
+            all_fwd_inputs,
+            grad_outputs,
+        )
+
+    def _to_tensor(self, arg: torch.Tensor | TensorMeta) -> torch.Tensor:
+        """Convert a tensor or metadata to a real tensor on ``self.device``.
+
+        Real tensors are detached and re-set requires_grad to create a fresh
+        autograd leaf, isolating metadata inference from the user's graph.
+        TensorMeta is materialized as an empty tensor (or DTensor via mesh cache).
+        """
+        if isinstance(arg, torch.Tensor):
+            return arg.detach().requires_grad_(arg.requires_grad)
+        elif isinstance(arg, TensorMeta):
+            if isinstance(arg, _DTensorMeta):
+                mesh = self._mesh_cache.get_mesh(arg.mesh_cache_key)
+                return arg.to_dtensor(self.device, mesh)
+            else:
+                return arg.to_tensor(self.device)
+        else:
+            raise PipeliningMetadataError(
+                f"Unsupported type {type(arg)} for _to_tensor: {arg}"
+            )
+
+    def _ones_from_metadata(self, meta: TensorMeta) -> torch.Tensor:
+        """Create a ones tensor from metadata for backward inference grad_outputs."""
+        local_ones = torch.ones(
+            meta.shape,
+            dtype=meta.dtype,
+            device=self.device,
+        )
+        if isinstance(meta, _DTensorMeta):
+            mesh = self._mesh_cache.get_mesh(meta.mesh_cache_key)
+            return DTensor.from_local(
+                local_ones,
+                device_mesh=mesh,
+                placements=meta.placements,
+                shape=meta.global_shape,
+                stride=meta.global_stride,
+                run_check=False,
+            )
+        return local_ones
+
+    def _forward_metadata_inference(
+        self,
+        args: tuple[torch.Tensor, ...] | _StageForwardMeta | None,
         kwargs: dict[str, Any] | None = None,
-    ):
-        if kwargs is None:
-            kwargs = {}
-        if args is None:
-            raise AssertionError("Args may be an empty tuple but not None")
+        has_backward: bool = False,
+    ) -> _StageForwardMeta | None:
+        """Run forward metadata inference (Stage 0 → N).
 
-        # We skip recv communication if we're the first stage, but also if the previous stage is on the same rank
-        # and can pass its output shapes in as args instead of using send/recv.
-        if (
-            self.is_first
-            # if not first stage, then check if prev stage is on the same rank
-            or self.stage_index_to_group_rank[self.stage_index - 1] == self.group_rank
-        ):
-            logger.debug(
-                "Shape inference: stage %s skipping recv, because shape info passed in via `args`",
-                self.stage_index,
-            )
-            args = tree_map_only(torch.Tensor, lambda x: x.to("meta"), args)
-        else:
-            if len(args) != 0:
-                raise AssertionError(
-                    "Can't supply input args for shape inference on non-first stage"
+        Args:
+            args: Real tensors (first stage), ``_StageForwardMeta``
+                (same-rank), or ``None`` (cross-rank P2P).
+            kwargs: Keyword arguments forwarded to the submodule.
+            has_backward: Whether backward inference follows.
+
+        Returns:
+            ``_StageForwardMeta`` for the next stage, or ``None`` if sent via P2P.
+        """
+        kwargs = kwargs or {}
+
+        # === RECEIVE: Get input metadata and create meta tensors ===
+        if self.is_first:
+            # First stage: extract metadata from real tensors
+            if args is None or isinstance(args, _StageForwardMeta):
+                raise PipeliningMetadataError(
+                    f"Stage {self.stage_index}: First stage requires real tensors, "
+                    f"got {type(args).__name__}."
                 )
-            objects = [None]
-            logger.debug(
-                "Shape inference: stage %s receiving from stage %s",
-                self.stage_index,
-                self.stage_index - 1,
-            )
-            dist.recv_object_list(
-                objects,
-                src=dist.get_global_rank(
-                    self.group or dist.distributed_c10d._get_default_group(),
-                    self.stage_index_to_group_rank[self.stage_index - 1],
-                ),
-                group=self.group,
-                device=self.device,
-                use_batch=True,
-            )
-            recv_args = objects[0]
-            if not isinstance(recv_args, tuple):
-                raise AssertionError(f"Expected tuple, got {type(recv_args)}")
-            args = recv_args
-
-        # cache input shapes for use during recv buffer allocation
-        self.inputs_meta = args
-        args = tree_map_only(
-            torch.Tensor, lambda x: torch.zeros_like(x, device=self.device), args
-        )
-
-        # set attributes needed for forward
-        with torch.no_grad():
-            outputs = self.submod(*args, **kwargs)
-
-        # if single tensor, convert so it is always a list
-        if isinstance(outputs, torch.Tensor):
-            outputs = [outputs]
-
-        # communicate meta outputs not real outputs for two reasons
-        # 1 - its faster (esp. since obj coll pickles tensor data!)
-        # 2 - avoid activating a cuda context for the src rank when unpickling on the recv end!
-        outputs_meta = tuple(
-            tree_map_only(torch.Tensor, lambda x: x.to("meta"), outputs)
-        )
-        logger.debug(
-            "Shape inference: stage %s inputs %s, outputs %s",
-            self.stage_index,
-            self.inputs_meta,
-            outputs_meta,
-        )
-        self._configure_outputs_meta(outputs_meta)
-
-        # Passing outputs to the next stage:
-        # two cases-
-        # 1. Usually: use send/recv communication to pass the output
-        # 2. Special case: for V-schedules, 2 'adjacent' stages (e.g. stage 3, 4 in an 8-stage 4-rank V)
-        #    pass their shape info via return value and function args rather than send/recv.
-        if (
-            self.is_last
-            # if not last stage, then check if next stage is on the same rank
-            or self.stage_index_to_group_rank[self.stage_index + 1] == self.group_rank
-        ):
-            # Case (2) above: pass shape info via return value and caller passes it as args to next stage's
-            # _shape_inference call
-            logger.debug(
-                "Shape inference: stage %s skipping send to next stage",
-                self.stage_index,
-            )
-
+            tensor_args = validate_and_normalize_to_tuple(args)
+            assert tensor_args is not None  # noqa: S101
+            self._stage_meta.inputs = extract_tensor_metas(tensor_args)
+            inference_args = tuple(self._to_tensor(a) for a in tensor_args)
+        elif self._is_same_rank(self.stage_index - 1):
+            # Same-rank: _StageForwardMeta passed via argument
+            if not isinstance(args, _StageForwardMeta):
+                raise PipeliningMetadataError(
+                    f"Stage {self.stage_index}: Expected _StageForwardMeta from same-rank "
+                    f"previous stage, got {type(args).__name__}."
+                )
+            self._stage_meta.inputs = args.forward_metas
+            inference_args = tuple(self._to_tensor(m) for m in args.forward_metas)
         else:
-            # Case (1): send shapes via send operation, and ensure not to return it to the caller
-            logger.debug(
-                "Shape inference: stage %s sending to stage %s",
-                self.stage_index,
-                self.stage_index + 1,
-            )
-            dist.send_object_list(
-                [outputs_meta],
-                dst=dist.get_global_rank(
-                    self.group or dist.distributed_c10d._get_default_group(),
-                    self.stage_index_to_group_rank[self.stage_index + 1],
-                ),
-                group=self.group,
-                device=self.device,
-                use_batch=True,
-            )
-            outputs_meta = tuple()
+            # Cross-rank: receive _StageForwardMeta via P2P
+            recv_meta = self._recv_meta(self.stage_index - 1)
+            if not isinstance(recv_meta, _StageForwardMeta):
+                raise PipeliningMetadataError(
+                    f"Stage {self.stage_index}: Expected _StageForwardMeta from P2P, "
+                    f"got {type(recv_meta).__name__}."
+                )
+            self._stage_meta.inputs = recv_meta.forward_metas
+            inference_args = tuple(self._to_tensor(m) for m in recv_meta.forward_metas)
 
-        return outputs_meta
+        inference_kwargs = {
+            k: self._to_tensor(v) if isinstance(v, torch.Tensor) else v
+            for k, v in kwargs.items()
+        }
+
+        # Isolate metadata inference from user's grad context.
+        # has_backward → enable_grad() so backward tracing sees grad_fn;
+        # no backward → no_grad() for cross-rank consistency.
+        ctx = torch.enable_grad() if has_backward else torch.no_grad()
+        with ctx:
+            outputs = self._compute_outputs(
+                *inference_args, module=self.submod, **inference_kwargs
+            )
+
+        # Normalize outputs to tuple
+        outputs = validate_and_normalize_to_tuple(outputs)
+
+        self._stage_meta.outputs = extract_tensor_metas(outputs)
+
+        # Store for backward metadata inference (always, even during eval)
+        fwd_kwargs_tensors = tuple(
+            v for v in flatten_args(inference_kwargs) if isinstance(v, torch.Tensor)
+        )
+        self._fwd_outputs_for_bwd_meta = outputs
+        self._fwd_inputs_for_bwd_meta = inference_args
+        self._fwd_kwargs_tensors_for_bwd_meta = fwd_kwargs_tensors
+
+        # === SEND: Pass output metadata to next stage ===
+        if self._stage_meta.outputs is None:
+            raise PipeliningMetadataError(
+                f"Stage {self.stage_index}: output metadata is required for forward inference."
+            )
+        fwd_meta = _StageForwardMeta(forward_metas=self._stage_meta.outputs)
+
+        if self.is_last or self._is_same_rank(self.stage_index + 1):
+            # Same-rank or last: return for caller to pass
+            return fwd_meta
+        else:
+            # Cross-rank: send via P2P
+            self._send_meta(fwd_meta, self.stage_index + 1)
+            return None
+
+    def _backward_metadata_inference(
+        self,
+        loss_fn: Callable[..., torch.Tensor] | None = None,
+        target: torch.Tensor | None = None,
+        received_grad_meta: _StageBackwardMeta | None = None,
+    ) -> _StageBackwardMeta | None:
+        """Run backward metadata inference (Stage N → 0).
+
+        Args:
+            loss_fn: Loss function (required for the last stage).
+            target: Target tensor (required for the last stage).
+            received_grad_meta: Grad metadata from next same-rank stage
+                (V-schedule only).
+
+        Returns:
+            ``_StageBackwardMeta`` for the previous stage, or ``None`` if sent via P2P.
+        """
+        fwd_outputs = self._fwd_outputs_for_bwd_meta
+        fwd_inputs = self._fwd_inputs_for_bwd_meta
+        if fwd_outputs is None or fwd_inputs is None:
+            raise PipeliningMetadataError(
+                "Backward metadata inference requires forward metadata inference to run first"
+            )
+        kwargs_tensors = self._fwd_kwargs_tensors_for_bwd_meta or ()
+        all_fwd_inputs = list(fwd_inputs) + list(kwargs_tensors)
+        # Clear temporary storage early — local refs are sufficient from here
+        self._fwd_outputs_for_bwd_meta = None
+        self._fwd_inputs_for_bwd_meta = None
+        self._fwd_kwargs_tensors_for_bwd_meta = None
+        # === RECEIVE: Get output grad metadata (except last stage) ===
+        if self.is_last:
+            if loss_fn is None or target is None:
+                raise PipeliningMetadataError(
+                    f"Stage {self.stage_index}: loss_fn and target required for last stage"
+                )
+            inference_target = self._to_tensor(target)
+            loss = loss_fn(
+                fwd_outputs[0] if len(fwd_outputs) == 1 else fwd_outputs,
+                inference_target,
+            )
+            self._stage_meta.output_grads = None
+            all_input_grads = self._compute_input_grads(
+                [loss],
+                all_fwd_inputs,
+            )
+        else:
+            # Non-last stage: receive grad metadata from next stage
+            if self._is_same_rank(self.stage_index + 1):
+                # Same-rank: _StageBackwardMeta passed via argument
+                if not isinstance(received_grad_meta, _StageBackwardMeta):
+                    raise PipeliningMetadataError(
+                        f"Stage {self.stage_index}: Expected _StageBackwardMeta from same-rank "
+                        f"next stage, got {type(received_grad_meta).__name__}."
+                    )
+                self._stage_meta.output_grads = received_grad_meta.backward_metas
+            else:
+                # Cross-rank: receive _StageBackwardMeta via P2P
+                recv_meta = self._recv_meta(self.stage_index + 1)
+                if not isinstance(recv_meta, _StageBackwardMeta):
+                    raise PipeliningMetadataError(
+                        f"Stage {self.stage_index}: Expected _StageBackwardMeta from P2P, "
+                        f"got {type(recv_meta).__name__}."
+                    )
+                self._stage_meta.output_grads = recv_meta.backward_metas
+
+            # === COMPUTE: Build grad_outputs and compute input grads ===
+            # Extract output tensors and corresponding grad_outputs from metadata
+            # Must iterate together to maintain alignment
+            if self._stage_meta.output_grads is None:
+                raise PipeliningMetadataError(
+                    f"Stage {self.stage_index}: output_grads metadata is required for backward inference."
+                )
+            stage_output_grad_metas = self._stage_meta.output_grads
+
+            filtered_fwd_outputs: list[torch.Tensor] = []
+            filtered_output_grads: list[torch.Tensor | None] = []
+
+            for idx, (fwd_out, grad_meta) in enumerate(
+                zip(fwd_outputs, stage_output_grad_metas, strict=True)
+            ):
+                # Match _backward.py behavior: skip if output doesn't require grad AND has no grad_fn
+                if not fwd_out.requires_grad:
+                    if grad_meta is not None:
+                        raise PipeliningMetadataError(
+                            f"Stage {self.stage_index}: output {idx} requires_grad=False, "
+                            f"but output_grads metadata is provided: {grad_meta}."
+                        )
+                    continue
+                filtered_fwd_outputs.append(fwd_out)
+                # For outputs that require grad, include them even if grad_meta is None
+                # (runtime passes None grad_outputs to autograd.backward in this case)
+                filtered_output_grads.append(
+                    self._ones_from_metadata(grad_meta) if grad_meta else None
+                )
+
+            if filtered_fwd_outputs:
+                all_input_grads = self._compute_input_grads(
+                    filtered_fwd_outputs, all_fwd_inputs, filtered_output_grads
+                )
+                # Free intermediate references early
+                filtered_fwd_outputs.clear()
+                filtered_output_grads.clear()
+                all_fwd_inputs.clear()
+                # Only positional input grads flow to previous stage
+            else:
+                all_input_grads = tuple(None for _ in range(len(all_fwd_inputs)))
+
+        input_grads = all_input_grads[: len(fwd_inputs)]
+        self._stage_meta.input_grads = tuple(
+            extract_tensor_meta(g) if isinstance(g, torch.Tensor) else None
+            for g in input_grads
+        )
+
+        # === SEND: Pass input grad metadata to previous stage ===
+        bwd_meta = _StageBackwardMeta(backward_metas=self._stage_meta.input_grads)
+
+        if self.is_first or self._is_same_rank(self.stage_index - 1):
+            # First rank or Same-rank: return for caller to pass
+            return bwd_meta
+        else:
+            # Cross-rank: send via P2P
+            self._send_meta(bwd_meta, self.stage_index - 1)
+            return None
+
+    def _post_metadata_inference_cleanup(self) -> None:
+        """Clean up FSDP side effects (unsharded params, stale grads, stored
+        tensors) after metadata inference with real tensors.
+        """
+        # Clear stored inference tensors (frees autograd graph + activations)
+        self._fwd_outputs_for_bwd_meta = None
+        self._fwd_inputs_for_bwd_meta = None
+        self._fwd_kwargs_tensors_for_bwd_meta = None
+
+        # Metadata inference runs real fwd/bwd, which unshards FSDP params and
+        # accumulates grads.  Reshard to free memory and clear stale grads.
+        for module in self.submod.modules():
+            if isinstance(module, FSDPModule):
+                module.reshard()
+                for param in module.parameters():
+                    param.grad = None
+
+    def _prepare_backward_infra(
+        self,
+        num_microbatches: int,
+        loss_fn: Callable[..., torch.Tensor] | None = None,
+        target: torch.Tensor | None = None,
+        received_grad_meta: "_StageBackwardMeta | None" = None,
+    ) -> "_StageBackwardMeta | None":
+        """Run backward metadata inference and prepare backward infrastructure.
+
+        Returns:
+            ``_StageBackwardMeta`` for the previous same-rank stage, or ``None``.
+        """
+        grad_meta_result: _StageBackwardMeta | None = None
+        if self._inference_mode == InferenceMode.DYNAMIC:
+            # DYNAMIC mode: run backward metadata inference
+            # received_grad_meta is used for same-rank V-schedule stages
+            grad_meta_result = self._backward_metadata_inference(
+                loss_fn=loss_fn,
+                target=target,
+                received_grad_meta=received_grad_meta,
+            )
+            # Validate dynamically inferred metadata against user-provided metadata
+            self._validate_inferred_metadata()
+        else:
+            # STATIC mode: metadata comes from user inputs, no validation needed
+            self._stage_meta.input_grads = self._user_meta.input_grads
+            self._stage_meta.output_grads = self._user_meta.output_grads
+            # For STATIC mode with plain tensors, if output_grads is not set but
+            # we have outputs, derive output_grads from outputs.
+            # (gradient shape == output shape, but requires_grad=False for gradients)
+            if self._stage_meta.output_grads is None:
+                if self._stage_meta.outputs is None:
+                    raise PipeliningMetadataError(
+                        f"Stage {self.stage_index}: output metadata is required for backward inference."
+                    )
+                self._stage_meta.output_grads = _derive_grad_metas(
+                    self._stage_meta.outputs
+                )
+            # Similarly, derive input_grads from inputs if not provided
+            if self._stage_meta.input_grads is None:
+                if self._stage_meta.inputs is None:
+                    raise PipeliningMetadataError(
+                        f"Stage {self.stage_index}: input metadata is required for backward inference."
+                    )
+                self._stage_meta.input_grads = _derive_grad_metas(
+                    self._stage_meta.inputs
+                )
+
+        # Note: grad_send_info is created lazily in get_bwd_send_ops() since
+        # it mirrors args_recv_info (already populated during forward).
+        self._setup_backward_recv_info(num_microbatches)
+        return grad_meta_result
+
+    def _validate_inferred_metadata(self) -> None:
+        """Validate dynamically inferred metadata against user-provided metadata."""
+        pairs = [
+            (self._user_meta.inputs, self._stage_meta.inputs, "input"),
+            (self._user_meta.outputs, self._stage_meta.outputs, "output"),
+            (self._user_meta.input_grads, self._stage_meta.input_grads, "input_grad"),
+            (
+                self._user_meta.output_grads,
+                self._stage_meta.output_grads,
+                "output_grad",
+            ),
+        ]
+        for user_val, stage_val, label in pairs:
+            if user_val and stage_val:
+                validate_tensors_metadata(
+                    f"Stage {self.stage_index} {label}",
+                    user_val,
+                    stage_val,
+                    warn_on_mismatch=True,
+                )
 
     def _prepare_forward_infra(
         self,
         num_microbatches: int,
-        args: tuple[Any, ...],
+        args: tuple[Any, ...] | _StageForwardMeta | None,
         kwargs: dict[str, Any] | None = None,
-    ) -> tuple[Any, ...]:
-        # TODO move self.device to an argument from step API (from its input tensors)?
-        if num_microbatches is None:
-            raise AssertionError("TODO fix num_microbatches")
+        has_backward: bool = False,
+    ) -> _StageForwardMeta | None:
+        """Prepare the stage infrastructure for forward pass.
 
-        outputs: tuple[Any, ...] = tuple()
-        if self.inputs_meta is None:
-            outputs = self._shape_inference(args, kwargs)
+        Returns:
+            ``_StageForwardMeta`` for next stage (same-rank), or ``None`` if sent via P2P.
+        """
+        if self._inference_mode is None:
+            raise PipeliningMetadataError(
+                f"Stage {self.stage_index}: inference mode not set. "
+                f"Run warmup vote protocol first."
+            )
 
-        if self.inputs_meta is None:
-            raise AssertionError("Expected inputs_meta to be set after shape inference")
-        # Receive info during forward
-        # TODO: create args_recv_info lazily? (same needed for PipelineStage)
+        fwd_meta_output: _StageForwardMeta | None = None
+
+        if self._inference_mode == InferenceMode.DYNAMIC:
+            # DYNAMIC mode: run forward metadata inference
+            # args may be _StageForwardMeta for same-rank V-schedule stages
+            fwd_meta_output = self._forward_metadata_inference(
+                args, kwargs, has_backward
+            )
+            # Validate dynamically inferred metadata against user-provided metadata
+            self._validate_inferred_metadata()
+        # STATIC mode: metadata comes from user inputs, no validation needed
+        else:
+            self._stage_meta.inputs = self._user_meta.inputs
+            self._stage_meta.outputs = self._user_meta.outputs
+
+        # Setup recv and send info
+        self._setup_forward_recv_info(num_microbatches, has_backward)
+        self._setup_forward_send_info()
+
+        return fwd_meta_output
+
+    def _setup_forward_recv_info(
+        self, num_microbatches: int, has_backward: bool
+    ) -> None:
+        """Setup receive info for forward pass."""
+        if self._stage_meta.inputs is None:
+            raise PipeliningMetadataError(
+                f"Stage {self.stage_index}: inputs metadata required for recv info."
+            )
         for chunk_id in range(num_microbatches):
-            if not self.is_first:
-                # We assume that we always receive from stage - 1
-                recv_infos = tuple(
-                    _RecvInfo(
-                        f"recv_for_{self.stage_index}_from_{self.stage_index - 1}",
-                        self.stage_index - 1,
-                        _make_tensor_from_meta(inp, self.device),
-                    )
-                    for inp in self.inputs_meta
-                )
-                # In case there is backward pass, set requires_grad for receive buffers
-                if self.has_backward:
-                    for r in recv_infos:
-                        r.buffer.requires_grad_(True)
-
-                self.args_recv_info[chunk_id] = recv_infos
-            else:
+            if self.is_first:
+                # First stage: all inputs are root arguments (no recv needed)
                 self.args_recv_info[chunk_id] = tuple(
-                    _RootArgPlaceholder(i) for i in self.inputs_meta
+                    _RecvInfo(
+                        input_name=f"root_input_{idx}",
+                        source=None,
+                        buffer=None,
+                        tensor_meta=meta,
+                        is_root_arg=True,
+                    )
+                    for idx, meta in enumerate(self._stage_meta.inputs)
+                )
+            else:
+                # Non-first stages: receive from previous stage
+                self.args_recv_info[chunk_id] = tuple(
+                    _RecvInfo(
+                        input_name=f"recv_for_{self.stage_index}_from_{self.stage_index - 1}",
+                        source=self.stage_index - 1,
+                        buffer=_make_tensor_from_meta(meta, self.device),
+                        tensor_meta=meta,
+                    )
+                    for meta in self._stage_meta.inputs
                 )
 
-        # Send info during forward for each activation
-        # only need the rank that is being sent to
+    def _setup_forward_send_info(self) -> None:
+        """Setup send info for forward pass."""
         self.act_send_info: dict[int, list] = {}
-
-        for idx in range(len(self.get_outputs_meta())):
-            # We assume we always send to stage + 1
-            if not self.is_last:
-                self.act_send_info[idx] = [self.stage_index + 1]
-            else:
-                self.act_send_info[idx] = []
-
-        return outputs
+        if self._stage_meta.outputs is None:
+            raise PipeliningMetadataError(
+                f"Stage {self.stage_index}: outputs metadata required for recv info."
+            )
+        for idx in range(len(self._stage_meta.outputs)):
+            self.act_send_info[idx] = [self.stage_index + 1] if not self.is_last else []
 
     def _create_grad_recv_info(
         self,
         act_send_info: dict,
     ) -> tuple[_RecvInfo, ...]:
-        grad_recv_info: tuple[_RecvInfo, ...] = ()
+        grad_recv_infos: list[_RecvInfo] = []
         if not self.is_last:
+            # Ensure output_grads metadata is available
+            if self._stage_meta.output_grads is None:
+                raise PipeliningMetadataError(
+                    f"Stage {self.stage_index}: output_grads metadata is required for "
+                    f"creating grad recv info. Ensure backward metadata is populated."
+                )
+
             # Receiving gradients from multiple sources is not supported
             # hence we only take the first destination
-            grad_recv_info = tuple(
-                _RecvInfo(
-                    f"recv_grad_for_{self.stage_index}_from_{dst_list[0]}",
-                    dst_list[0],
-                    _make_tensor_from_meta(self.get_outputs_meta()[idx], self.device),
+            # Use a helper function to safely extract the metadata
+            output_grads = self._stage_meta.output_grads
+            for idx, dst_list in act_send_info.items():
+                if dst_list is None:
+                    raise PipeliningMetadataError(
+                        f"Stage {self.stage_index}: output {idx} is not sent to any stage."
+                    )
+                src = dst_list[0]
+                grad_meta = output_grads[idx]
+                grad_recv_infos.append(
+                    _RecvInfo(
+                        input_name=f"recv_grad_for_{self.stage_index}_from_{src}",
+                        source=src,
+                        buffer=_make_tensor_from_meta(grad_meta, self.device)
+                        if grad_meta
+                        else None,
+                        tensor_meta=grad_meta,
+                    )
                 )
-                for idx, dst_list in act_send_info.items()
-            )
-        return grad_recv_info
+        return tuple(grad_recv_infos)


### PR DESCRIPTION
Stacked PRs:
 * #177729
 * __->__#177728

Fixes #172419 
--- --- ---

### [PP][2/3] DTensor-aware stage and schedule refactoring


Summary:
Refactors PipelineStage and schedule infrastructure for DTensor-aware
Pipeline Parallelism, migrating to the new metadata utilities from [1/3].

Key changes in stage.py:
- Refactored _PipelineStageBase, _PipelineStage, PipelineStage for
  DTensor support with STATIC/DYNAMIC inference modes
- Replaced _RootArgPlaceholder with unified _RecvInfo.is_root_arg flag
- New _prepare_forward_infra/_prepare_backward_infra for metadata-driven
  initialization with DTensor shape/placement tracking
- Replaced PipeliningShapeError with PipeliningMetadataError
- Added _validate_fwd_inputs using new TensorMeta-based validation
- _make_tensor_from_meta moved from stage.py to _utils.py

Key changes in schedules.py:
- Added _determine_and_set_global_inference_mode() for cross-stage
  consensus on STATIC vs DYNAMIC mode
- Refactored _initialize_stage(s) with mode-change detection
- Updated step() callers to extract first_target from target_mbs

Key changes in _utils.py:
- Replaced old validate_tensors_metadata (torch.Tensor signature) with
  new TensorMeta-based version
- Removed legacy backward-compat shims: PipeliningShapeError,
  validate_tensor_metadata, old validate_tensors_metadata

Test fixes:
- test_stage.py: PipeliningShapeError -> PipeliningMetadataError

Test Plan:
python -m pytest test/distributed/pipelining/ -x
