### PR TITLE
[PP][3/3] DTensor Pipeline Parallelism unit and integration tests

### DIFF
--- a/test/distributed/pipelining/test_dtensor_pp_integration.py
+++ b/test/distributed/pipelining/test_dtensor_pp_integration.py
@@ -1,0 +1,804 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates
+# Owner(s): ["oncall: distributed"]
+
+from __future__ import annotations
+
+import copy
+import functools
+from typing import cast, TYPE_CHECKING
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+from torch.distributed.device_mesh import DeviceMesh, init_device_mesh
+from torch.distributed.pipelining._utils import _DTensorMeta
+from torch.distributed.pipelining.schedules import (
+    Schedule1F1B,
+    ScheduleDualPipeV,
+    ScheduleInterleaved1F1B,
+    ScheduleZBVZeroBubble,
+)
+from torch.distributed.pipelining.stage import PipelineStage
+from torch.distributed.tensor import distribute_tensor, DTensor, Replicate, Shard
+from torch.distributed.tensor.parallel import (
+    ColwiseParallel,
+    parallelize_module,
+    RowwiseParallel,
+    SequenceParallel,
+)
+from torch.testing._internal.common_distributed import (
+    MultiProcContinuousTest,
+    requires_accelerator_dist_backend,
+)
+from torch.testing._internal.common_utils import (
+    run_tests,
+    skip_but_pass_in_sandcastle_if,
+    TEST_MULTIACCELERATOR,
+)
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+d_hid = 256
+batch_size = 64
+n_microbatches = 4
+
+StageStaticMeta = tuple[DTensor, DTensor, DTensor | None, DTensor | None]
+StageStaticMetaMap = dict[int, StageStaticMeta]
+
+MODEL_SEED = 0
+INPUT_SEED = 42
+TARGET_SEED = 123
+
+
+device_type = acc.type if (acc := torch.accelerator.current_accelerator()) else "cpu"
+backend = dist.get_default_backend_for_device(device_type)
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim: int, eps: float = 1e-6):
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(dim))
+        self.eps = eps
+
+    def reset_parameters(self) -> None:
+        torch.nn.init.ones_(self.weight)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return (
+            x
+            * torch.rsqrt(x.float().pow(2).mean(-1, keepdim=True) + self.eps)
+            * self.weight
+        )
+
+
+class NormMLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.norm = RMSNorm(dim)
+        self.fc1 = nn.Linear(dim, 4 * dim, bias=False)
+        self.act = nn.GELU()
+        self.fc2 = nn.Linear(4 * dim, dim, bias=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.fc2(self.act(self.fc1(self.norm(x))))
+
+
+class NormMLPStack(nn.Module):
+    def __init__(self, dim: int, n_layers: int):
+        super().__init__()
+        self.layers = nn.ModuleList([NormMLP(dim) for _ in range(n_layers)])
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        for layer in self.layers:
+            x = layer(x)
+        return x
+
+
+def apply_tp_replicate(block: NormMLP, tp_mesh: DeviceMesh) -> None:
+    parallelize_module(
+        block,
+        tp_mesh,
+        {
+            "fc1": ColwiseParallel(input_layouts=Replicate(), use_local_output=False),
+            "fc2": RowwiseParallel(output_layouts=Replicate(), use_local_output=False),
+        },
+    )
+    for name, param in block.norm.named_parameters():
+        block.norm.register_parameter(
+            name,
+            nn.Parameter(
+                DTensor.from_local(param, tp_mesh, [Replicate()], run_check=False)
+            ),
+        )
+
+
+def apply_tp_shard(block: NormMLP, tp_mesh: DeviceMesh) -> None:
+    parallelize_module(
+        block,
+        tp_mesh,
+        {
+            "norm": SequenceParallel(use_local_output=False),
+            "fc1": ColwiseParallel(
+                input_layouts=Shard(1),
+                use_local_output=False,  # type: ignore[arg-type]
+            ),
+            "fc2": RowwiseParallel(
+                output_layouts=Shard(1),
+                use_local_output=False,  # type: ignore[arg-type]
+            ),
+        },
+    )
+
+
+def _loss_fn(output: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+    return (output - target).pow(2).mean()
+
+
+def _requires_multi_gpu(func):
+    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @skip_but_pass_in_sandcastle_if(
+        not TEST_MULTIACCELERATOR, f"{backend} test requires 4+ GPUs"
+    )
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
+class DTensorPPIntegrationBase(MultiProcContinuousTest):
+    world_size = 4
+
+    @classmethod
+    def backend_str(cls) -> str:
+        return backend
+
+    @classmethod
+    def device_type(cls) -> str:
+        return device_type
+
+    @property
+    def device(self) -> torch.device:
+        return torch.device(device_type, self.rank)
+
+    def init_pg(self) -> None:
+        if device_type == "cuda":
+            torch.cuda.set_device(self.device)
+
+    def _make_mesh(self) -> DeviceMesh:
+        return init_device_mesh(device_type, (2, 2), mesh_dim_names=("pp", "tp"))
+
+    def _build_baseline_and_clones(
+        self,
+        n_layers: int,
+        tp_mesh: DeviceMesh,
+        apply_tp: Callable,
+    ) -> tuple[NormMLPStack, NormMLPStack]:
+        torch.manual_seed(MODEL_SEED)
+        with torch.device(self.device):
+            ref_model = NormMLPStack(d_hid, n_layers)
+
+        pp_model = copy.deepcopy(ref_model)
+
+        for layer in ref_model.layers:
+            apply_tp(layer, tp_mesh)
+        for layer in pp_model.layers:
+            apply_tp(layer, tp_mesh)
+
+        return ref_model, pp_model
+
+    def _make_full_batch_tensors(self) -> tuple[torch.Tensor, torch.Tensor]:
+        torch.manual_seed(INPUT_SEED)
+        input_full = torch.randn(batch_size, d_hid, device=self.device)
+        torch.manual_seed(TARGET_SEED)
+        target_full = torch.randn(batch_size, d_hid, device=self.device)
+        return input_full, target_full
+
+    def _run_reference_microbatched(
+        self,
+        ref_model: NormMLPStack,
+        input_dt: DTensor,
+        target_dt: DTensor,
+        *,
+        null_boundary_grads: bool = True,
+    ) -> tuple[
+        dict[str, torch.Tensor | None],
+        StageStaticMetaMap,
+    ]:
+        ref_model.zero_grad(set_to_none=True)
+
+        input_chunks = torch.tensor_split(input_dt, n_microbatches)
+        target_chunks = torch.tensor_split(target_dt, n_microbatches)
+
+        captured_io: dict[int, tuple[DTensor, DTensor]] = {}
+        captured_grads: dict[int, dict[str, DTensor | None]] = {}
+        hooks: list[torch.utils.hooks.RemovableHandle] = []
+
+        def _make_grad_hook(stage_idx: int, key: str) -> Callable[[torch.Tensor], None]:
+            def _hook(grad: torch.Tensor) -> None:
+                captured_grads[stage_idx][key] = self._clone_preserving_placement(grad)
+
+            return _hook
+
+        for stage_idx, stage_mod in enumerate(ref_model.layers):
+
+            def _capture_io(
+                _module: nn.Module,
+                args: tuple[torch.Tensor, ...],
+                output: torch.Tensor,
+                *,
+                idx: int = stage_idx,
+            ) -> None:
+                stage_input = cast(DTensor, args[0])
+                stage_output = cast(DTensor, output)
+                captured_io[idx] = (stage_input, stage_output)
+                captured_grads[idx] = {"input": None, "output": None}
+
+                for tensor, key in (
+                    (stage_input, "input"),
+                    (stage_output, "output"),
+                ):
+                    if tensor.requires_grad:
+                        hooks.append(tensor.register_hook(_make_grad_hook(idx, key)))
+
+            hooks.append(stage_mod.register_forward_hook(_capture_io))
+
+        static_stage_meta: StageStaticMetaMap = {}
+
+        for mb_idx, (input_chunk, target_chunk) in enumerate(
+            zip(input_chunks, target_chunks)
+        ):
+            output = ref_model(input_chunk)
+            loss = _loss_fn(output, target_chunk)
+            loss.backward()
+
+            if mb_idx == 0:
+                for stage_idx in range(len(ref_model.layers)):
+                    stage_input, stage_output = captured_io[stage_idx]
+                    input_args = self._empty_dt_from(
+                        stage_input,
+                        stage_input.requires_grad,
+                    )
+                    output_args = self._empty_dt_from(
+                        stage_output,
+                        stage_output.requires_grad,
+                    )
+                    input_grad_dt = captured_grads[stage_idx]["input"]
+                    output_grad_dt = captured_grads[stage_idx]["output"]
+                    input_grads = (
+                        self._empty_dt_from(cast(DTensor, input_grad_dt), False)
+                        if input_grad_dt is not None
+                        else None
+                    )
+                    output_grads = (
+                        self._empty_dt_from(cast(DTensor, output_grad_dt), False)
+                        if output_grad_dt is not None
+                        else None
+                    )
+
+                    if null_boundary_grads:
+                        if stage_idx == 0:
+                            input_grads = None
+                        if stage_idx == (len(ref_model.layers) - 1):
+                            output_grads = None
+
+                    static_stage_meta[stage_idx] = (
+                        input_args,
+                        output_args,
+                        input_grads,
+                        output_grads,
+                    )
+
+                for hook in hooks:
+                    hook.remove()
+                hooks = []
+
+        for param in ref_model.parameters():
+            if param.grad is not None:
+                param.grad.div_(n_microbatches)
+
+        ref_grads = {
+            name: self._clone_preserving_placement(grad) if grad is not None else grad
+            for name, grad in (
+                (param_name, param.grad)
+                for param_name, param in ref_model.named_parameters()
+            )
+        }
+        return ref_grads, static_stage_meta
+
+    @staticmethod
+    def _clone_preserving_placement(grad: torch.Tensor) -> torch.Tensor:
+        """Clone a gradient tensor, preserving DTensor placement.
+
+        ``DTensor.clone()`` triggers all-reduce for ``Partial`` placements,
+        converting them to ``Replicate``.  This helper clones only the local
+        tensor and reconstructs the DTensor with the original placement so
+        that downstream comparisons see the true placement.
+        """
+        if isinstance(grad, DTensor):
+            local_clone = grad.to_local().clone()
+            return DTensor.from_local(
+                local_clone,
+                grad.device_mesh,
+                list(grad.placements),
+                shape=grad.shape,
+                stride=grad.stride(),
+                run_check=False,
+            )
+        return grad.clone()
+
+    def _empty_dt_from(self, dt: DTensor, requires_grad: bool) -> DTensor:
+        meta = _DTensorMeta.from_dtensor(dt)
+        empty_local = torch.empty(meta.shape, dtype=meta.dtype, device=self.device)
+        result = DTensor.from_local(
+            empty_local,
+            dt.device_mesh,
+            list(meta.placements),
+            shape=meta.global_shape,
+            stride=meta.global_stride,
+            run_check=False,
+        )
+        if requires_grad:
+            result.requires_grad_(True)
+        return result
+
+    def _make_stage_for_pp_run(
+        self,
+        pp_model: NormMLPStack,
+        stage_index: int,
+        num_stages: int,
+        pp_group: dist.ProcessGroup,
+        tp_mesh: DeviceMesh,
+        static_stage_meta: StageStaticMetaMap | None,
+    ) -> PipelineStage:
+        stage_module = pp_model.get_submodule(f"layers.{stage_index}")
+        if static_stage_meta is None:
+            return PipelineStage(
+                submodule=stage_module,
+                stage_index=stage_index,
+                num_stages=num_stages,
+                device=self.device,
+                group=pp_group,
+                get_mesh=lambda _dim_names, _layout: tp_mesh,
+            )
+
+        input_args, output_args, input_grads, output_grads = static_stage_meta[
+            stage_index
+        ]
+
+        return PipelineStage(
+            submodule=stage_module,
+            stage_index=stage_index,
+            num_stages=num_stages,
+            device=self.device,
+            group=pp_group,
+            input_args=(input_args,),
+            output_args=(output_args,),
+            input_grads=(input_grads,),
+            output_grads=(output_grads,),
+            get_mesh=lambda _dim_names, _layout: tp_mesh,
+        )
+
+    def _assert_grad_close(
+        self,
+        pp_grad: torch.Tensor,
+        ref_grad: torch.Tensor,
+        param_fqn: str,
+    ) -> None:
+        pp_for_compare = pp_grad
+        ref_for_compare = ref_grad
+
+        if isinstance(pp_grad, DTensor) and isinstance(ref_grad, DTensor):
+            pp_meta = _DTensorMeta.from_dtensor(pp_grad)
+            ref_meta = _DTensorMeta.from_dtensor(ref_grad)
+            self.assertEqual(
+                pp_meta.get_diff(ref_meta),
+                [],
+                f"DTensor metadata mismatch for {param_fqn}",
+            )
+            pp_for_compare = pp_grad.to_local()
+            ref_for_compare = ref_grad.to_local()
+
+        torch.testing.assert_close(
+            pp_for_compare,
+            ref_for_compare,
+            msg=f"Gradient mismatch for {param_fqn}",
+        )
+
+    def _assert_stage_grad_parity(
+        self,
+        pp_model: NormMLPStack,
+        ref_grads: dict[str, torch.Tensor | None],
+        stage_index: int,
+    ) -> None:
+        stage_module = pp_model.get_submodule(f"layers.{stage_index}")
+        for name, param in stage_module.named_parameters():
+            param_fqn = f"layers.{stage_index}.{name}"
+            self.assertIsNotNone(param.grad, f"Missing PP grad for {param_fqn}")
+            self.assertIsNotNone(
+                ref_grads[param_fqn], f"Missing reference grad for {param_fqn}"
+            )
+            pp_grad = cast(torch.Tensor, param.grad)
+            ref_grad = cast(torch.Tensor, ref_grads[param_fqn])
+            self._assert_grad_close(pp_grad, ref_grad, param_fqn)
+
+    def _compute_stage_indices(
+        self,
+        schedule_class: type,
+        pp_rank: int,
+        pp_size: int,
+        num_stages: int,
+    ) -> list[int]:
+        if schedule_class is Schedule1F1B:
+            return [pp_rank]
+        if schedule_class is ScheduleInterleaved1F1B:
+            return [pp_rank + i * pp_size for i in range(num_stages // pp_size)]
+        return [pp_rank, num_stages - 1 - pp_rank]
+
+    def _execute_schedule_step(
+        self,
+        schedule,
+        stages: list[PipelineStage],
+        pp_input: DTensor,
+        pp_target: DTensor,
+    ) -> None:
+        has_first = any(stage.is_first for stage in stages)
+        has_last = any(stage.is_last for stage in stages)
+
+        if has_first and has_last:
+            losses: list[torch.Tensor] = []
+            schedule.step(pp_input, target=pp_target, losses=losses)
+        elif has_first:
+            schedule.step(pp_input)
+        elif has_last:
+            losses: list[torch.Tensor] = []
+            schedule.step(target=pp_target, losses=losses)
+        else:
+            schedule.step()
+
+    def _run_training_correctness(
+        self,
+        schedule_class: type,
+        apply_tp: Callable,
+        placements: list,
+        *,
+        use_static_metadata: bool = True,
+        null_boundary_grads: bool = False,
+    ) -> None:
+        self.init_pg()
+
+        mesh = self._make_mesh()
+        tp_mesh = mesh["tp"]
+        pp_mesh = mesh["pp"]
+        pp_group = pp_mesh.get_group()
+        pp_rank = pp_mesh.get_local_rank()
+        pp_size = pp_mesh.size()
+
+        n_layers = 2 if schedule_class is Schedule1F1B else 4
+
+        ref_model, pp_model = self._build_baseline_and_clones(
+            n_layers=n_layers,
+            tp_mesh=tp_mesh,
+            apply_tp=apply_tp,
+        )
+
+        input_full, target_full = self._make_full_batch_tensors()
+
+        ref_input = distribute_tensor(
+            input_full.clone(),
+            tp_mesh,
+            placements,
+        )
+        ref_input.requires_grad_(True)
+        ref_target = distribute_tensor(
+            target_full.clone(),
+            tp_mesh,
+            placements,
+        )
+
+        ref_grads, static_stage_meta = self._run_reference_microbatched(
+            ref_model,
+            ref_input,
+            ref_target,
+            null_boundary_grads=null_boundary_grads,
+        )
+
+        pp_static_stage_meta = static_stage_meta if use_static_metadata else None
+
+        pp_input = distribute_tensor(
+            input_full.clone(),
+            tp_mesh,
+            placements,
+        )
+        pp_input.requires_grad_(True)
+        pp_target = distribute_tensor(
+            target_full.clone(),
+            tp_mesh,
+            placements,
+        )
+
+        num_stages = n_layers
+        stage_indices = self._compute_stage_indices(
+            schedule_class,
+            pp_rank,
+            pp_size,
+            num_stages,
+        )
+
+        stages = [
+            self._make_stage_for_pp_run(
+                pp_model=pp_model,
+                stage_index=stage_index,
+                num_stages=num_stages,
+                pp_group=pp_group,
+                tp_mesh=tp_mesh,
+                static_stage_meta=pp_static_stage_meta,
+            )
+            for stage_index in stage_indices
+        ]
+
+        for stage in stages:
+            stage.submod.zero_grad(set_to_none=True)
+
+        if schedule_class is Schedule1F1B:
+            schedule = schedule_class(
+                stages[0],
+                n_microbatches=n_microbatches,
+                loss_fn=_loss_fn,
+            )
+        else:
+            schedule = schedule_class(
+                cast(list[PipelineStage], stages),  # type: ignore[arg-type]
+                n_microbatches=n_microbatches,
+                loss_fn=_loss_fn,
+            )
+
+        self._execute_schedule_step(schedule, stages, pp_input, pp_target)
+
+        for stage_index in stage_indices:
+            self._assert_stage_grad_parity(
+                pp_model=pp_model,
+                ref_grads=ref_grads,
+                stage_index=stage_index,
+            )
+
+    def _run_inference_only_equivalence(
+        self,
+        apply_tp: Callable,
+        placements: list,
+        *,
+        use_static_metadata: bool = False,
+    ) -> None:
+        self.init_pg()
+
+        mesh = self._make_mesh()
+        tp_mesh = mesh["tp"]
+        pp_mesh = mesh["pp"]
+        pp_group = pp_mesh.get_group()
+        pp_rank = pp_mesh.get_local_rank()
+
+        ref_model, pp_model = self._build_baseline_and_clones(
+            n_layers=2,
+            tp_mesh=tp_mesh,
+            apply_tp=apply_tp,
+        )
+
+        input_full, target_full = self._make_full_batch_tensors()
+
+        ref_input = distribute_tensor(
+            input_full.clone(),
+            tp_mesh,
+            placements,
+        )
+
+        static_stage_meta: StageStaticMetaMap | None = None
+
+        if use_static_metadata:
+            ref_input_for_meta = distribute_tensor(
+                input_full.clone(),
+                tp_mesh,
+                placements,
+            )
+            ref_input_for_meta.requires_grad_(True)
+            ref_target_for_meta = distribute_tensor(
+                target_full.clone(),
+                tp_mesh,
+                placements,
+            )
+            _, captured_meta = self._run_reference_microbatched(
+                ref_model,
+                ref_input_for_meta,
+                ref_target_for_meta,
+            )
+
+            static_stage_meta = {
+                stage_idx: (
+                    self._empty_dt_from(stage_meta[0], False),
+                    self._empty_dt_from(stage_meta[1], False),
+                    None,
+                    None,
+                )
+                for stage_idx, stage_meta in captured_meta.items()
+            }
+
+            with torch.no_grad():
+                ref_output = ref_model(ref_input)
+        else:
+            with torch.no_grad():
+                ref_output = ref_model(ref_input)
+
+        pp_input = distribute_tensor(
+            input_full.clone(),
+            tp_mesh,
+            placements,
+        )
+        pp_input.requires_grad_(False)
+
+        stage = self._make_stage_for_pp_run(
+            pp_model=pp_model,
+            stage_index=pp_rank,
+            num_stages=2,
+            pp_group=pp_group,
+            tp_mesh=tp_mesh,
+            static_stage_meta=static_stage_meta,
+        )
+        schedule = Schedule1F1B(
+            stage,
+            n_microbatches=n_microbatches,
+            loss_fn=None,
+        )
+
+        with torch.no_grad():
+            pp_output = schedule.eval(pp_input)
+
+        if stage.is_last:
+            self.assertIsNotNone(pp_output)
+            self.assertIsInstance(pp_output, DTensor)
+            self.assertIsInstance(ref_output, DTensor)
+            self._assert_grad_close(
+                cast(torch.Tensor, pp_output),
+                cast(torch.Tensor, ref_output),
+                "inference_output",
+            )
+
+
+class TestDTensorPPModes(DTensorPPIntegrationBase):
+    @_requires_multi_gpu
+    def test_static_mode_replicate(self):
+        self._run_training_correctness(
+            Schedule1F1B,
+            apply_tp_replicate,
+            [Replicate()],
+        )
+
+    @_requires_multi_gpu
+    def test_static_mode_none_grad_slots_replicate(self):
+        self._run_training_correctness(
+            Schedule1F1B,
+            apply_tp_replicate,
+            [Replicate()],
+            null_boundary_grads=True,
+        )
+
+    @_requires_multi_gpu
+    def test_static_mode_none_grad_slots_shard(self):
+        self._run_training_correctness(
+            Schedule1F1B,
+            apply_tp_shard,
+            [Shard(1)],
+            null_boundary_grads=True,
+        )
+
+    @_requires_multi_gpu
+    def test_static_mode_shard(self):
+        self._run_training_correctness(
+            Schedule1F1B,
+            apply_tp_shard,
+            [Shard(1)],
+        )
+
+    @_requires_multi_gpu
+    def test_dynamic_mode_inference_only_replicate(self):
+        self._run_inference_only_equivalence(
+            apply_tp_replicate,
+            [Replicate()],
+        )
+
+    @_requires_multi_gpu
+    def test_static_mode_inference_only_replicate(self):
+        self._run_inference_only_equivalence(
+            apply_tp_replicate,
+            [Replicate()],
+            use_static_metadata=True,
+        )
+
+    @_requires_multi_gpu
+    def test_dynamic_mode_inference_only_shard(self):
+        self._run_inference_only_equivalence(
+            apply_tp_shard,
+            [Shard(1)],
+        )
+
+    @_requires_multi_gpu
+    def test_static_mode_inference_only_shard(self):
+        self._run_inference_only_equivalence(
+            apply_tp_shard,
+            [Shard(1)],
+            use_static_metadata=True,
+        )
+
+    @_requires_multi_gpu
+    def test_dynamic_mode_replicate(self):
+        self._run_training_correctness(
+            Schedule1F1B,
+            apply_tp_replicate,
+            [Replicate()],
+            use_static_metadata=False,
+        )
+
+    @_requires_multi_gpu
+    def test_dynamic_mode_shard(self):
+        self._run_training_correctness(
+            Schedule1F1B,
+            apply_tp_shard,
+            [Shard(1)],
+            use_static_metadata=False,
+        )
+
+    @_requires_multi_gpu
+    def test_static_mode_interleaved1f1b_replicate(self):
+        self._run_training_correctness(
+            ScheduleInterleaved1F1B,
+            apply_tp_replicate,
+            [Replicate()],
+        )
+
+    @_requires_multi_gpu
+    def test_static_mode_zbv_zero_bubble_replicate(self):
+        self._run_training_correctness(
+            ScheduleZBVZeroBubble,
+            apply_tp_replicate,
+            [Replicate()],
+        )
+
+    @_requires_multi_gpu
+    def test_static_mode_dualpipev_replicate(self):
+        self._run_training_correctness(
+            ScheduleDualPipeV,
+            apply_tp_replicate,
+            [Replicate()],
+        )
+
+    @_requires_multi_gpu
+    def test_dynamic_mode_interleaved1f1b_shard(self):
+        self._run_training_correctness(
+            ScheduleInterleaved1F1B,
+            apply_tp_shard,
+            [Shard(1)],
+            use_static_metadata=False,
+        )
+
+    @_requires_multi_gpu
+    def test_dynamic_mode_zbv_zero_bubble_shard(self):
+        self._run_training_correctness(
+            ScheduleZBVZeroBubble,
+            apply_tp_shard,
+            [Shard(1)],
+            use_static_metadata=False,
+        )
+
+    @_requires_multi_gpu
+    def test_dynamic_mode_dualpipev_shard(self):
+        self._run_training_correctness(
+            ScheduleDualPipeV,
+            apply_tp_shard,
+            [Shard(1)],
+            use_static_metadata=False,
+        )
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/distributed/pipelining/test_dtensor_pp_unit_tests.py
+++ b/test/distributed/pipelining/test_dtensor_pp_unit_tests.py
@@ -1,0 +1,665 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates
+# Owner(s): ["oncall: distributed"]
+"""
+Unit tests for DTensor support in Pipeline Parallelism.
+
+Tests the _utils.py metadata infrastructure and microbatch DTensor operations:
+1. Metadata classes: _TensorMeta, _DTensorMeta, _MeshCache
+2. InferenceMode decision logic
+3. Validation functions: validate_metadata, validate_tensors_metadata,
+   validate_static_arg_grad_correspondence
+4. Helper functions: extract_tensor_metas, to_local_if_dtensor,
+   validate_and_normalize_to_tuple
+5. Microbatch DTensor operations: _split_tensor, merge_chunks
+"""
+
+import functools
+import warnings
+
+import torch
+import torch.distributed as dist
+from torch.distributed.device_mesh import init_device_mesh
+from torch.distributed.pipelining._utils import (
+    _DTensorMeta,
+    _MeshCache,
+    _StageMeta,
+    _TensorMeta,
+    extract_tensor_metas,
+    InferenceMode,
+    PipeliningMetadataError,
+    to_local_if_dtensor,
+    validate_and_normalize_to_tuple,
+    validate_metadata,
+    validate_static_arg_grad_correspondence,
+    validate_tensors_metadata,
+)
+from torch.distributed.pipelining.microbatch import (
+    _split_tensor,
+    merge_chunks,
+    TensorChunkSpec,
+)
+from torch.distributed.tensor import distribute_tensor, DTensor, Replicate, Shard
+from torch.testing._internal.common_distributed import (
+    MultiProcContinuousTest,
+    requires_accelerator_dist_backend,
+)
+from torch.testing._internal.common_utils import (
+    run_tests,
+    skip_but_pass_in_sandcastle_if,
+    TEST_MULTIACCELERATOR,
+)
+
+
+# =============================================================================
+# Test Constants
+# =============================================================================
+
+d_hid = 256
+batch_size = 64
+n_microbatches = 4
+microbatch_size = batch_size // n_microbatches
+
+device_type = acc.type if (acc := torch.accelerator.current_accelerator()) else "cpu"
+backend = dist.get_default_backend_for_device(device_type)
+
+
+def _requires_multi_gpu(fn):
+    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @skip_but_pass_in_sandcastle_if(
+        not TEST_MULTIACCELERATOR, f"{backend} test requires 4+ GPUs"
+    )
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        return fn(*args, **kwargs)
+
+    return wrapper
+
+
+# =============================================================================
+# All DTensor PP Unit Tests (single class → single PG initialization)
+# =============================================================================
+
+
+class TestDTensorPPUnitTests(MultiProcContinuousTest):
+    """Unit tests for DTensor PP metadata infrastructure.
+
+    All tests live in a single class so the process group is initialized once
+    rather than once per test category.
+    """
+
+    @classmethod
+    def backend_str(cls) -> str:
+        return backend
+
+    @classmethod
+    def device_type(cls) -> str:
+        return device_type
+
+    @property
+    def device(self) -> torch.device:
+        return torch.device(device_type, self.rank)
+
+    def init_pg(self):
+        if device_type == "cuda":
+            torch.cuda.set_device(self.device)
+
+    # -----------------------------------------------------------------
+    # Shared helpers
+    # -----------------------------------------------------------------
+
+    def _make_mesh(self, dim_names=("tp",)):
+        """Create a 1D device mesh spanning all ranks."""
+        return init_device_mesh(
+            device_type, (self.world_size,), mesh_dim_names=dim_names
+        )
+
+    def _make_dtensor(self, mesh, placements, shape=(8, 16), requires_grad=False):
+        """Create a DTensor with given properties."""
+        t = torch.randn(*shape, device=self.device, requires_grad=requires_grad)
+        return distribute_tensor(t, mesh, placements)
+
+    def _make_tensor_meta(
+        self,
+        shape: torch.Size = torch.Size([4, 8]),
+        stride: tuple[int, ...] = (8, 1),
+        dtype: torch.dtype = torch.float32,
+        requires_grad: bool = True,
+    ) -> _TensorMeta:
+        """Create a _TensorMeta with sensible defaults."""
+        return _TensorMeta(
+            shape=shape, stride=stride, dtype=dtype, requires_grad=requires_grad
+        )
+
+    def _make_dtensor_meta(self) -> _DTensorMeta:
+        """Create a _DTensorMeta with sensible defaults."""
+        return _DTensorMeta(
+            shape=torch.Size([4, 8]),
+            stride=(8, 1),
+            dtype=torch.float32,
+            requires_grad=True,
+            global_shape=torch.Size([8, 8]),
+            global_stride=(8, 1),
+            placements=(Shard(0),),
+            mesh_dim_names=("tp",),
+            mesh_layout=None,
+        )
+
+    # -----------------------------------------------------------------
+    # Category 1: Metadata Classes (_TensorMeta, _DTensorMeta, _MeshCache)
+    # -----------------------------------------------------------------
+
+    @_requires_multi_gpu
+    def test_tensor_meta_extraction_roundtrip_and_errors(self):
+        """Test _TensorMeta: extraction, roundtrip, DTensor rejection."""
+        self.init_pg()
+        mesh = self._make_mesh()
+
+        # Extraction and roundtrip for various shapes/dtypes/requires_grad
+        for shape in [(4, 8), (2, 3, 4)]:
+            for dtype in [torch.float32, torch.float16]:
+                for requires_grad in [True, False]:
+                    t = torch.randn(*shape, dtype=dtype, requires_grad=requires_grad)
+                    meta = _TensorMeta.from_tensor(t)
+                    self.assertEqual(meta.shape, t.shape)
+                    self.assertEqual(meta.stride, t.stride())
+                    self.assertEqual(meta.dtype, dtype)
+                    self.assertEqual(meta.requires_grad, requires_grad)
+
+                    # Roundtrip via tensor on device
+                    reconstructed = meta.to_tensor(self.device)
+                    reconstructed_meta = _TensorMeta(
+                        shape=reconstructed.shape,
+                        stride=reconstructed.stride(),
+                        dtype=reconstructed.dtype,
+                        requires_grad=reconstructed.requires_grad,
+                    )
+                    self.assertEqual(meta.get_diff(reconstructed_meta), [])
+
+        # DTensor rejection
+        dt = self._make_dtensor(mesh, [Shard(0)])
+        with self.assertRaises(PipeliningMetadataError) as ctx:
+            _TensorMeta.from_tensor(dt)
+        self.assertIn("DTensor", str(ctx.exception))
+
+    @_requires_multi_gpu
+    def test_dtensor_meta_extraction_and_roundtrip(self):
+        """Test _DTensorMeta: extraction and roundtrip for Shard/Replicate."""
+        self.init_pg()
+        mesh = self._make_mesh()
+
+        for placements in [[Shard(0)], [Replicate()]]:
+            dt = self._make_dtensor(mesh, placements)
+            meta = _DTensorMeta.from_dtensor(dt)
+
+            self.assertEqual(meta.global_shape, dt.shape)
+            self.assertEqual(meta.placements, tuple(placements))
+            self.assertEqual(meta.mesh_dim_names, ("tp",))
+            self.assertEqual(meta.mesh_cache_key, (("tp",), mesh._layout))
+
+            # Roundtrip
+            reconstructed = meta.to_dtensor(self.device, mesh)
+            reconstructed_meta = _DTensorMeta.from_dtensor(reconstructed)
+            self.assertEqual(meta.get_diff(reconstructed_meta), [])
+
+    @_requires_multi_gpu
+    def test_get_diff_detects_mismatches(self):
+        """Test get_diff() detects shape/dtype/placement/cross-type differences."""
+        self.init_pg()
+        mesh = self._make_mesh()
+
+        # _TensorMeta: shape
+        m1 = self._make_tensor_meta(shape=torch.Size([4, 8]), stride=(8, 1))
+        m2 = self._make_tensor_meta(shape=torch.Size([4, 16]), stride=(16, 1))
+        self.assertTrue(any("shape" in d for d in m1.get_diff(m2)))
+
+        # _TensorMeta: dtype
+        m3 = self._make_tensor_meta(dtype=torch.float16)
+        self.assertTrue(any("dtype" in d for d in m1.get_diff(m3)))
+
+        # _DTensorMeta: placement
+        dt_shard = self._make_dtensor(mesh, [Shard(0)])
+        dt_rep = self._make_dtensor(mesh, [Replicate()])
+        dm1 = _DTensorMeta.from_dtensor(dt_shard)
+        dm2 = _DTensorMeta.from_dtensor(dt_rep)
+        self.assertTrue(any("placements" in d for d in dm1.get_diff(dm2)))
+
+        # Cross-type: _DTensorMeta vs _TensorMeta
+        diffs = dm1.get_diff(m1)
+        self.assertTrue(any("type" in d.lower() or "_TensorMeta" in d for d in diffs))
+
+    @_requires_multi_gpu
+    def test_mesh_cache_operations(self):
+        """Test _MeshCache: __contains__/put/get_mesh/callback/update_from_tensors."""
+        self.init_pg()
+        mesh = self._make_mesh()
+        key = (("tp",), mesh._layout)
+
+        # --- __contains__ + put + get_mesh: basic cache hit ---
+        cache = _MeshCache()
+        self.assertFalse(key in cache)
+        cache.put(key, mesh)
+        self.assertTrue(key in cache)
+        self.assertIs(cache.get_mesh(key), mesh)
+
+        # --- get_mesh_cb: callback NOT called on cache hit ---
+        cb_called = [False]
+
+        def cb(mesh_dim_names, mesh_layout):
+            cb_called[0] = True
+            return mesh
+
+        cache_with_cb = _MeshCache(get_mesh_cb=cb)
+        cache_with_cb.put(key, mesh)
+        self.assertIs(cache_with_cb.get_mesh(key), mesh)
+        self.assertFalse(cb_called[0])
+
+        # --- get_mesh_cb: callback IS called on cache miss ---
+        cb2_called = [False]
+
+        def cb2(mesh_dim_names, mesh_layout):
+            cb2_called[0] = True
+            return mesh
+
+        cache_miss = _MeshCache(get_mesh_cb=cb2)
+        self.assertIs(cache_miss.get_mesh(key), mesh)
+        self.assertTrue(cb2_called[0])
+
+        # --- no callback: get_mesh on miss raises ---
+        cache_no_cb = _MeshCache()
+        with self.assertRaises(PipeliningMetadataError) as ctx:
+            cache_no_cb.get_mesh(key)
+        self.assertIn("get_mesh", str(ctx.exception))
+
+        # --- update_from_tensors: extracts mesh from DTensors ---
+        cache_upd = _MeshCache()
+        dt = self._make_dtensor(mesh, [Shard(0)], shape=(4, 4))
+        plain = torch.randn(4, 4, device=self.device)
+        cache_upd.update_from_tensors((dt, plain, None))
+        self.assertTrue(key in cache_upd)
+        self.assertIs(cache_upd.get_mesh(key), mesh)
+        self.assertEqual(len(cache_upd), 1)
+
+    # -----------------------------------------------------------------
+    # Category 2: InferenceMode Decision Logic
+    # -----------------------------------------------------------------
+
+    @_requires_multi_gpu
+    def test_needs_dynamic_all_cases(self):
+        """Test all 8 cases of the needs_dynamic() decision matrix."""
+        self.init_pg()
+        tm = self._make_tensor_meta()
+        dm = self._make_dtensor_meta()
+
+        cases = [
+            # (meta, has_backward, expected_needs_dynamic)
+            # Case 1: No forward metadata
+            (_StageMeta(inputs=None, outputs=None), True, True),
+            # Case 2: Partial forward (inputs only)
+            (_StageMeta(inputs=(tm,), outputs=None), True, True),
+            # Case 3: Plain tensors, complete forward, backward → STATIC
+            (_StageMeta(inputs=(tm,), outputs=(tm,)), True, False),
+            # Case 4: DTensors, no backward → STATIC
+            (_StageMeta(inputs=(dm,), outputs=(dm,)), False, False),
+            # Case 5: DTensors, backward, no grads → DYNAMIC
+            (_StageMeta(inputs=(dm,), outputs=(dm,)), True, True),
+            # Case 6: DTensors, backward, only input_grads → DYNAMIC
+            (
+                _StageMeta(
+                    inputs=(dm,), outputs=(dm,), input_grads=(dm,), output_grads=None
+                ),
+                True,
+                True,
+            ),
+            # Case 7: DTensors, backward, only output_grads → DYNAMIC
+            (
+                _StageMeta(
+                    inputs=(dm,), outputs=(dm,), input_grads=None, output_grads=(dm,)
+                ),
+                True,
+                True,
+            ),
+            # Case 8: DTensors, backward, complete grads → STATIC
+            (
+                _StageMeta(
+                    inputs=(dm,),
+                    outputs=(dm,),
+                    input_grads=(dm,),
+                    output_grads=(dm,),
+                ),
+                True,
+                False,
+            ),
+        ]
+        for i, (meta, has_bwd, expected) in enumerate(cases, 1):
+            with self.subTest(case=i):
+                self.assertEqual(
+                    InferenceMode.needs_dynamic(meta, has_bwd),
+                    expected,
+                    f"Case {i} failed",
+                )
+
+    # -----------------------------------------------------------------
+    # Category 3: Validation Functions
+    # -----------------------------------------------------------------
+
+    @_requires_multi_gpu
+    def test_validate_metadata(self):
+        """Test validate_metadata: match, raise, warn, type mismatch."""
+        self.init_pg()
+        mesh = self._make_mesh()
+
+        # Match → no diffs
+        dt = self._make_dtensor(mesh, [Shard(0)])
+        meta = _DTensorMeta.from_dtensor(dt)
+        self.assertEqual(validate_metadata("test", meta, dt), [])
+
+        # Mismatch with raise_on_mismatch
+        other = self._make_dtensor(mesh, [Replicate()])
+        with self.assertRaises(PipeliningMetadataError):
+            validate_metadata("test", meta, other, raise_on_mismatch=True)
+
+        # Mismatch with warn_on_mismatch
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            diffs = validate_metadata("test", meta, other, warn_on_mismatch=True)
+            self.assertTrue(len(diffs) > 0)
+            self.assertTrue(any("Metadata mismatch" in str(x.message) for x in w))
+
+        # Type mismatch: _DTensorMeta vs plain tensor
+        plain = torch.randn(8, 16, device=self.device)
+        diffs = validate_metadata("test", meta, plain)
+        self.assertTrue(any("type" in d for d in diffs))
+
+    @_requires_multi_gpu
+    def test_validate_tensors_metadata(self):
+        """Test validate_tensors_metadata: batch validation, length mismatch, None handling."""
+        self.init_pg()
+        mesh = self._make_mesh()
+
+        dt = self._make_dtensor(mesh, [Shard(0)])
+        meta = _DTensorMeta.from_dtensor(dt)
+
+        # Match
+        validate_tensors_metadata("test", (meta,), (dt,))
+
+        # Length mismatch raises
+        with self.assertRaises(PipeliningMetadataError):
+            validate_tensors_metadata("test", (meta, meta), (dt,))
+
+        # Length mismatch warns (raise disabled)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            validate_tensors_metadata(
+                "test",
+                (meta, meta),
+                (dt,),
+                raise_on_mismatch=False,
+                warn_on_mismatch=True,
+            )
+            self.assertTrue(len(w) > 0)
+
+        # None-None pair passes
+        validate_tensors_metadata("test", (None,), (None,))
+
+        # One-None mismatch raises (expected has metadata but actual is None)
+        with self.assertRaises(PipeliningMetadataError):
+            validate_tensors_metadata("test", (meta,), (None,))
+
+    @_requires_multi_gpu
+    def test_validate_static_arg_grad_correspondence(self):
+        """Test DTensor↔grad correspondence: all valid/invalid combos."""
+        self.init_pg()
+        mesh = self._make_mesh()
+
+        dt_grad = self._make_dtensor(mesh, [Shard(0)], requires_grad=True)
+        dt_nograd = self._make_dtensor(mesh, [Shard(0)], requires_grad=False)
+        dt_grad2 = self._make_dtensor(mesh, [Replicate()], requires_grad=True)
+        plain = torch.randn(8, 16, device=self.device)
+
+        # DTensor(requires_grad=True) + DTensor grad → OK
+        validate_static_arg_grad_correspondence(
+            0, (dt_grad,), (dt_grad2,), is_input=True
+        )
+
+        # DTensor(requires_grad=False) + None grad → OK
+        validate_static_arg_grad_correspondence(0, (dt_nograd,), (None,), is_input=True)
+
+        # Plain tensor + None grad → OK
+        validate_static_arg_grad_correspondence(0, (plain,), (None,), is_input=True)
+
+        # DTensor(requires_grad=True) + None grad → OK (boundary with no gradient)
+        validate_static_arg_grad_correspondence(0, (dt_grad,), (None,), is_input=True)
+
+        # DTensor(requires_grad=True) + plain tensor grad → ERROR
+        with self.assertRaises(PipeliningMetadataError):
+            validate_static_arg_grad_correspondence(
+                0, (dt_grad,), (plain,), is_input=True
+            )
+
+        # Length mismatch → ERROR
+        with self.assertRaises(PipeliningMetadataError):
+            validate_static_arg_grad_correspondence(
+                0, (dt_grad, dt_grad), (dt_grad2,), is_input=False
+            )
+
+    # -----------------------------------------------------------------
+    # Category 4: Helper Functions
+    # -----------------------------------------------------------------
+
+    @_requires_multi_gpu
+    def test_extract_tensor_metas(self):
+        """Test extract_tensor_metas: plain, DTensor, None handling."""
+        self.init_pg()
+        mesh = self._make_mesh()
+
+        dt = self._make_dtensor(mesh, [Shard(0)])
+        plain = torch.randn(4, 4, device=self.device)
+
+        # None input → None output
+        self.assertIsNone(extract_tensor_metas(None))
+
+        # Mixed DTensor + plain → correct meta types
+        metas = extract_tensor_metas((dt, plain))
+        self.assertIsNotNone(metas)
+        self.assertIsInstance(metas[0], _DTensorMeta)  # type: ignore[index]
+        self.assertIsInstance(metas[1], _TensorMeta)  # type: ignore[index]
+        self.assertNotIsInstance(metas[1], _DTensorMeta)  # type: ignore[index]
+
+        # allow_none=True preserves None
+        metas_with_none = extract_tensor_metas((dt, None), allow_none=True)
+        self.assertIsNotNone(metas_with_none)
+        self.assertIsInstance(metas_with_none[0], _DTensorMeta)  # type: ignore[index]
+        self.assertIsNone(metas_with_none[1])  # type: ignore[index]
+
+        # allow_none=False (default) rejects None
+        with self.assertRaises(PipeliningMetadataError):
+            extract_tensor_metas((dt, None))  # type: ignore[arg-type]
+
+    @_requires_multi_gpu
+    def test_to_local_if_dtensor(self):
+        """Test to_local_if_dtensor: DTensor→local, plain passthrough, detach."""
+        self.init_pg()
+        mesh = self._make_mesh()
+
+        dt = self._make_dtensor(mesh, [Shard(0)], requires_grad=True)
+        plain = torch.randn(4, 4, device=self.device, requires_grad=True)
+
+        # DTensor → local tensor (not DTensor)
+        local = to_local_if_dtensor(dt)
+        self.assertNotIsInstance(local, DTensor)
+        self.assertEqual(local.shape, dt._local_tensor.shape)
+
+        # Plain tensor → same tensor
+        result = to_local_if_dtensor(plain)
+        self.assertIs(result, plain)
+
+        # detach=True → result is detached
+        local_detached = to_local_if_dtensor(dt, detach=True)
+        self.assertNotIsInstance(local_detached, DTensor)
+        self.assertFalse(local_detached.requires_grad)
+
+    @_requires_multi_gpu
+    def test_validate_and_normalize_to_tuple(self):
+        """Test validate_and_normalize_to_tuple: single, tuple, list, None, errors."""
+        self.init_pg()
+        t = torch.randn(4, 4, device=self.device)
+
+        # None → None
+        self.assertIsNone(validate_and_normalize_to_tuple(None))
+
+        # Single tensor → 1-tuple
+        result = validate_and_normalize_to_tuple(t)
+        self.assertIsNotNone(result)
+        self.assertEqual(len(result), 1)  # type: ignore[arg-type]
+        self.assertIs(result[0], t)  # type: ignore[index]
+
+        # List → tuple
+        result = validate_and_normalize_to_tuple([t, t])
+        self.assertIsNotNone(result)
+        self.assertIsInstance(result, tuple)
+        self.assertEqual(len(result), 2)  # type: ignore[arg-type]
+
+        # Non-tensor element → error
+        with self.assertRaises(PipeliningMetadataError):
+            validate_and_normalize_to_tuple((t, "not_a_tensor"))  # type: ignore[arg-type]
+
+        # None in tuple without allow_none → error
+        with self.assertRaises(PipeliningMetadataError):
+            validate_and_normalize_to_tuple((t, None))  # type: ignore[arg-type]
+
+        # None in tuple with allow_none=True → OK
+        result_with_none = validate_and_normalize_to_tuple((t, None), allow_none=True)
+        self.assertIsNotNone(result_with_none)
+        self.assertEqual(len(result_with_none), 2)  # type: ignore[arg-type]
+        self.assertIsNone(result_with_none[1])  # type: ignore[index]
+
+        # Wrong type entirely → error
+        with self.assertRaises(PipeliningMetadataError):
+            validate_and_normalize_to_tuple(42)  # type: ignore[arg-type]
+
+    # -----------------------------------------------------------------
+    # Category 5: Microbatch DTensor Split & Merge
+    # -----------------------------------------------------------------
+
+    @_requires_multi_gpu
+    def test_split_tensor_dtensor_preserves_placements(self):
+        """Test _split_tensor splits a DTensor into chunks that are still DTensors
+        with the same placements, correct local shapes, and matching data."""
+        self.init_pg()
+        mesh = self._make_mesh()
+        num_chunks = 2
+        split_dim = 0
+        shape = (8, 16)
+
+        for placements in [[Shard(0)], [Replicate()]]:
+            dt = self._make_dtensor(mesh, placements, shape=shape)
+            spec = TensorChunkSpec(split_dim)
+            chunks = _split_tensor(dt, spec, num_chunks)
+
+            self.assertEqual(len(chunks), num_chunks)
+            for i, chunk in enumerate(chunks):
+                # Each chunk must be a DTensor with preserved placements
+                self.assertIsInstance(chunk, DTensor, f"chunk {i} is not a DTensor")
+                self.assertEqual(
+                    chunk.placements,
+                    tuple(placements),
+                    f"chunk {i} placements differ",
+                )
+                # Each chunk must have the same device mesh
+                self.assertIs(chunk.device_mesh, mesh)
+
+            # Local shard sizes along split_dim must sum to the original
+            local_split_sizes = [c._local_tensor.size(split_dim) for c in chunks]
+            self.assertEqual(
+                sum(local_split_sizes),
+                dt._local_tensor.size(split_dim),
+            )
+
+            # Full tensor data must be preserved: cat the chunks and compare
+            cat_fn = torch.cat([c._local_tensor for c in chunks], dim=split_dim)
+            self.assertTrue(
+                torch.equal(cat_fn, dt._local_tensor),
+                "Split chunks do not reconstruct the original local tensor",
+            )
+
+    @_requires_multi_gpu
+    def test_merge_chunks_dtensor_roundtrip(self):
+        """Test that split → merge is a roundtrip: merge_chunks reconstructs
+        the original DTensor data and preserves placements."""
+        self.init_pg()
+        mesh = self._make_mesh()
+        num_chunks = 2
+        split_dim = 0
+        shape = (8, 16)
+
+        for placements in [[Shard(0)], [Replicate()]]:
+            dt = self._make_dtensor(mesh, placements, shape=shape)
+            chunk_spec = TensorChunkSpec(split_dim)
+
+            # Split into chunks
+            chunks = list(_split_tensor(dt, chunk_spec, num_chunks))
+
+            # Merge chunks back
+            # merge_chunks expects a list of "outputs", each output is a tuple.
+            # For a single-tensor case, wrap each chunk as a 1-tuple.
+            merged = merge_chunks(
+                [(chunk,) for chunk in chunks],
+                (chunk_spec,),
+            )
+            # merged is a tuple of tensors (mirrors the tuple structure)
+            merged_dt = merged[0]
+
+            self.assertIsInstance(merged_dt, DTensor)
+            self.assertEqual(merged_dt.placements, tuple(placements))
+            self.assertIs(merged_dt.device_mesh, mesh)
+
+            # Data must match the original
+            self.assertTrue(
+                torch.equal(merged_dt._local_tensor, dt._local_tensor),
+                "Merged DTensor local data differs from original",
+            )
+            self.assertEqual(merged_dt.shape, dt.shape)
+
+    @_requires_multi_gpu
+    def test_merge_chunks_dtensor_placement_mismatch_raises(self):
+        """Test that merge_chunks raises when chunk placements don't match."""
+        self.init_pg()
+        mesh = self._make_mesh()
+        shape = (8, 16)
+
+        dt_shard = self._make_dtensor(mesh, [Shard(0)], shape=shape)
+        dt_rep = self._make_dtensor(mesh, [Replicate()], shape=shape)
+
+        chunk_spec = TensorChunkSpec(0)
+        with self.assertRaises(AssertionError) as ctx:
+            merge_chunks(
+                [(dt_shard,), (dt_rep,)],
+                (chunk_spec,),
+            )
+        self.assertIn("placement mismatch", str(ctx.exception))
+
+    @_requires_multi_gpu
+    def test_merge_chunks_dtensor_mixed_types_raises(self):
+        """Test that merge_chunks raises when mixing DTensors and plain tensors."""
+        self.init_pg()
+        mesh = self._make_mesh()
+        shape = (4, 8)
+
+        dt = self._make_dtensor(mesh, [Shard(0)], shape=shape)
+        plain = torch.randn(*shape, device=self.device)
+
+        chunk_spec = TensorChunkSpec(0)
+        with self.assertRaises(AssertionError) as ctx:
+            merge_chunks(
+                [(dt,), (plain,)],
+                (chunk_spec,),
+            )
+        self.assertIn("mix", str(ctx.exception))
+
+
+# =============================================================================
+# Run Tests
+# =============================================================================
+
+if __name__ == "__main__":
+    run_tests()


### PR DESCRIPTION
Stacked PRs:
 * __->__#177729


--- --- ---

### [PP][3/3] DTensor Pipeline Parallelism unit and integration tests


Summary:
Adds comprehensive test suites for DTensor-aware Pipeline Parallelism.

test_dtensor_pp_unit_tests.py:
- Tests for _TensorMeta, _DTensorMeta metadata validation
- Tests for _StageMeta, _StageForwardMeta, _StageBackwardMeta
- Tests for InferenceMode enum and _MeshCache
- Tests for _RecvInfo with is_root_arg
- Tests for validate_tensors_metadata with TensorMeta inputs
- Tests for _make_tensor_from_meta DTensor reconstruction

test_dtensor_pp_integration.py:
- Multi-process integration tests for DTensor PP
- Tests STATIC and DYNAMIC inference modes end-to-end
- Tests ScheduleGPipe, Schedule1F1B, ScheduleInterleaved1F1B
  with DTensor inputs across multiple ranks
- Tests DTensor microbatch splitting and gradient propagation
- Tests DeviceMesh integration with PP world groups

Test Plan:
python -m pytest test/distributed/pipelining/ -x
