### PR TITLE
[DCP] Preserve original exception in metadata read failure for better debuggability (#177739)

### DIFF
--- a/torch/distributed/checkpoint/state_dict_loader.py
+++ b/torch/distributed/checkpoint/state_dict_loader.py
@@ -228,11 +228,15 @@ def _load_state_dict(
         nonlocal metadata
 
         # Use global metadata if available, otherwise fallback to rank local metadata
+        global_metadata_exc: Exception | None = None
+        rank_metadata_exc: Exception | None = None
         try:
             metadata = storage_reader.read_metadata()
-        except Exception:
-            logger.info(
-                "Global metadata is not found. Falling back to rank local metadata."
+        except Exception as e:
+            global_metadata_exc = e
+            logger.warning(
+                "Global metadata is not found. Falling back to rank local metadata.",
+                exc_info=True,
             )
 
         if (
@@ -242,13 +246,23 @@ def _load_state_dict(
             try:
                 metadata = storage_reader.read_metadata(rank=distW.rank)  # noqa: F841
                 use_collectives = False
-            except Exception:
-                logger.info("Rank local metadata is not found.")
+            except Exception as e:
+                rank_metadata_exc = e
+                logger.warning("Rank local metadata is not found.", exc_info=True)
 
         if planner is None:
             raise AssertionError("planner is None")
         if metadata is None:
-            raise AssertionError("metadata is None")
+            error_parts = ["metadata is None"]
+            if global_metadata_exc is not None:
+                error_parts.append(
+                    f"global metadata read failed: {global_metadata_exc}"
+                )
+            if rank_metadata_exc is not None:
+                error_parts.append(
+                    f"rank local metadata read failed: {rank_metadata_exc}"
+                )
+            raise AssertionError("; ".join(error_parts))
         planner.set_up_planner(state_dict, metadata, distW.is_coordinator)
 
         if (


### PR DESCRIPTION
Summary:

When `storage_reader.read_metadata()` fails during checkpoint loading, the current
code silently catches the exception and only logs at INFO level. If both global and
rank-local metadata reads fail, a bare `AssertionError("metadata is None")` is raised
with no context about the actual underlying failure.

This makes it extremely difficult to debug checkpoint loading failures because the
actual root cause (e.g., corrupt checkpoint, missing manifest, storage errors) is
hidden behind an opaque "metadata is None" message.

This diff:
1. Captures the original exceptions from `read_metadata()` calls
2. Includes the original error messages in the AssertionError when metadata is None
3. Upgrades logging from INFO to WARNING since a metadata read failure is noteworthy

Test Plan:
- Existing DCP tests continue to pass (no behavior change for success paths)
- On metadata read failure, the error message now includes the original exception:
  `AssertionError: metadata is None; global metadata read failed: <original error>`
  instead of the opaque `AssertionError: metadata is None`

Reviewed By: ankitageorge, mayankgarg1990

Differential Revision: D96940144
