### PR TITLE
[DTensor] Restore subclass __torch_dispatch__ fallback

### DIFF
--- a/test/distributed/tensor/test_dtensor.py
+++ b/test/distributed/tensor/test_dtensor.py
@@ -645,6 +645,62 @@ class DTensorTest(DTensorTestBase):
         self.assertIsNone(op_info.schema.schema_info)
 
     @with_comms
+    def test_dtensor_nested_subclass_inherits_ancestor_default_reset(self):
+        device_mesh = self.build_device_mesh()
+        local_input = torch.arange(
+            16, device=self.device_type, dtype=torch.float32
+        ).reshape(1, 1, 4, 4)
+        local_weight = torch.ones(
+            1, 1, 1, 1, device=self.device_type, dtype=torch.float32
+        )
+        input_dt = distribute_tensor(local_input, device_mesh, [Replicate()])
+        base_weight = distribute_tensor(local_weight, device_mesh, [Replicate()])
+
+        class GrandParentDTensor(DTensor):
+            _op_dispatcher = type(DTensor._op_dispatcher)()
+
+        op = torch.ops.aten.convolution.default
+        grandparent_dispatcher = GrandParentDTensor._op_dispatcher
+        default_conv_handler = grandparent_dispatcher._custom_op_handlers[op]
+        grandparent_handler_calls = []
+
+        def overriding_grandparent_conv_handler(
+            op_call, args, kwargs, *, dtensor_type=None
+        ):
+            grandparent_handler_calls.append(dtensor_type)
+            return default_conv_handler(
+                op_call,
+                args,
+                kwargs,
+                dtensor_type=dtensor_type,
+            )
+
+        grandparent_dispatcher._custom_op_handlers[op] = (
+            overriding_grandparent_conv_handler
+        )
+        try:
+            class ParentDTensor(GrandParentDTensor):
+                _op_dispatcher = type(DTensor._op_dispatcher)()
+
+            ParentDTensor._op_dispatcher._custom_op_handlers[op] = default_conv_handler
+
+            class ChildDTensor(ParentDTensor):
+                _op_dispatcher = type(DTensor._op_dispatcher)()
+
+            weight = ChildDTensor(
+                base_weight._local_tensor,
+                base_weight._spec,
+                requires_grad=base_weight.requires_grad,
+            )
+            result = F.conv2d(input_dt, weight)
+        finally:
+            grandparent_dispatcher._custom_op_handlers[op] = default_conv_handler
+
+        self.assertEqual(grandparent_handler_calls, [])
+        self.assertEqual(type(result), ChildDTensor)
+        self.assertEqual(result.to_local(), F.conv2d(local_input, local_weight))
+
+    @with_comms
     def test_from_local_backward(self):
         """Test that from_local backward gives the correct gradient placements.
 

--- a/test/distributed/tensor/test_dtensor.py
+++ b/test/distributed/tensor/test_dtensor.py
@@ -291,15 +291,44 @@ class DTensorTest(DTensorTestBase):
             base._spec,
             requires_grad=base.requires_grad,
         )
+        base_prop = DTensor._op_dispatcher.sharding_propagator
+        subclass_prop = MyDTensor._op_dispatcher.sharding_propagator
+        base_meta_calls = []
+        subclass_meta_calls = []
+        base_propagate_tensor_meta = base_prop._propagate_tensor_meta
+        subclass_propagate_tensor_meta = subclass_prop._propagate_tensor_meta
+
+        def record_base_tensor_meta(op_schema):
+            base_meta_calls.append(op_schema.op)
+            return base_propagate_tensor_meta(op_schema)
+
+        def record_subclass_tensor_meta(op_schema):
+            subclass_meta_calls.append(op_schema.op)
+            return subclass_propagate_tensor_meta(op_schema)
+
+        base_prop._propagate_tensor_meta = record_base_tensor_meta
+        subclass_prop._propagate_tensor_meta = record_subclass_tensor_meta
         expected = F.cross_entropy(local_tensor, target)
-        with loss_parallel():
-            with comm_mode:
-                result = F.cross_entropy(my_dt, dist_target)
+        try:
+            with loss_parallel():
+                with comm_mode:
+                    result = F.cross_entropy(my_dt, dist_target)
+        finally:
+            base_prop._propagate_tensor_meta = base_propagate_tensor_meta
+            subclass_prop._propagate_tensor_meta = subclass_propagate_tensor_meta
 
         self.assertEqual(comm_mode.get_total_counts(), 3)
         self.assertEqual(
             comm_mode.get_comm_counts()[c10d_functional.all_reduce],
             3,
+        )
+        self.assertEqual(base_meta_calls, [])
+        self.assertEqual(
+            subclass_meta_calls,
+            [
+                torch.ops.aten._log_softmax.default,
+                torch.ops.aten.nll_loss_forward.default,
+            ],
         )
         self.assertEqual(type(result), MyDTensor)
         self.assertEqual(result.to_local(), expected)
@@ -335,6 +364,8 @@ class DTensorTest(DTensorTestBase):
         lib.define("base_strategy(Tensor input) -> Tensor")
         lib.define("subclass_rule(Tensor input) -> Tensor")
         lib.define("subclass_strategy(Tensor input) -> Tensor")
+        lib.define("child_rule(Tensor input) -> Tensor")
+        lib.define("child_strategy(Tensor input) -> Tensor")
 
         base_rule_op = torch.ops.dtensor_subclass_dispatch_test.base_rule.default
         base_strategy_op = (
@@ -346,12 +377,20 @@ class DTensorTest(DTensorTestBase):
         subclass_strategy_op = (
             torch.ops.dtensor_subclass_dispatch_test.subclass_strategy.default
         )
+        child_rule_op = torch.ops.dtensor_subclass_dispatch_test.child_rule.default
+        child_strategy_op = (
+            torch.ops.dtensor_subclass_dispatch_test.child_strategy.default
+        )
 
         class MyDTensor(DTensor):
             _op_dispatcher = type(DTensor._op_dispatcher)()
 
+        class ChildDTensor(MyDTensor):
+            _op_dispatcher = type(DTensor._op_dispatcher)()
+
         base_prop = DTensor._op_dispatcher.sharding_propagator
         subclass_prop = MyDTensor._op_dispatcher.sharding_propagator
+        child_prop = ChildDTensor._op_dispatcher.sharding_propagator
 
         def base_rule(op_schema):
             raise AssertionError(f"unexpected call: {op_schema}")
@@ -365,7 +404,14 @@ class DTensorTest(DTensorTestBase):
         def subclass_strategy(op_schema):
             raise AssertionError(f"unexpected call: {op_schema}")
 
+        def child_rule(op_schema):
+            raise AssertionError(f"unexpected call: {op_schema}")
+
+        def child_strategy(op_schema):
+            raise AssertionError(f"unexpected call: {op_schema}")
+
         self.assertIsNot(base_prop, subclass_prop)
+        self.assertIsNot(subclass_prop, child_prop)
         base_rule_backup = base_prop.op_to_rules.get(base_rule_op)
         base_strategy_backup = base_prop.op_strategy_funcs.get(base_strategy_op)
         try:
@@ -374,6 +420,11 @@ class DTensorTest(DTensorTestBase):
             self.assertIs(subclass_prop.op_to_rules.get(base_rule_op), base_rule)
             self.assertIs(
                 subclass_prop.op_strategy_funcs.get(base_strategy_op),
+                base_strategy,
+            )
+            self.assertIs(child_prop.op_to_rules.get(base_rule_op), base_rule)
+            self.assertIs(
+                child_prop.op_strategy_funcs.get(base_strategy_op),
                 base_strategy,
             )
 
@@ -388,8 +439,25 @@ class DTensorTest(DTensorTestBase):
                 subclass_prop.op_strategy_funcs.get(subclass_strategy_op),
                 subclass_strategy,
             )
+            self.assertIs(child_prop.op_to_rules.get(subclass_rule_op), subclass_rule)
+            self.assertIs(
+                child_prop.op_strategy_funcs.get(subclass_strategy_op),
+                subclass_strategy,
+            )
             self.assertIsNone(base_prop.op_to_rules.get(subclass_rule_op))
             self.assertIsNone(base_prop.op_strategy_funcs.get(subclass_strategy_op))
+
+            child_prop.register_sharding_prop_rule(child_rule_op, child_rule)
+            child_prop.register_op_strategy(child_strategy_op, child_strategy)
+            self.assertIs(child_prop.op_to_rules.get(child_rule_op), child_rule)
+            self.assertIs(
+                child_prop.op_strategy_funcs.get(child_strategy_op),
+                child_strategy,
+            )
+            self.assertIsNone(subclass_prop.op_to_rules.get(child_rule_op))
+            self.assertIsNone(subclass_prop.op_strategy_funcs.get(child_strategy_op))
+            self.assertIsNone(base_prop.op_to_rules.get(child_rule_op))
+            self.assertIsNone(base_prop.op_strategy_funcs.get(child_strategy_op))
         finally:
             if base_rule_backup is None:
                 base_prop.op_to_rules.pop(base_rule_op, None)

--- a/test/distributed/tensor/test_dtensor.py
+++ b/test/distributed/tensor/test_dtensor.py
@@ -26,13 +26,8 @@ from torch.distributed.tensor._dtensor_spec import (
     ShardOrderEntry,
     TensorMeta,
 )
-from torch.distributed.tensor._op_schema import (
-    OutputSharding,
-    RuntimeSchemaInfo,
-)
-from torch.distributed.tensor._ops.single_dim_strategy import (
-    _SingleDimStrategyInfo,
-)
+from torch.distributed.tensor._op_schema import OutputSharding, RuntimeSchemaInfo
+from torch.distributed.tensor._ops.single_dim_strategy import _SingleDimStrategyInfo
 from torch.distributed.tensor._redistribute import redistribute_local_tensor
 from torch.distributed.tensor.debug import CommDebugMode
 from torch.distributed.tensor.experimental import implicit_replication
@@ -509,6 +504,44 @@ class DTensorTest(DTensorTestBase):
         self.assertIs(base_dispatcher._custom_op_handlers[op], default_conv_handler)
         self.assertIs(child_dispatcher._get_custom_op_handler(op, ChildDTensor), marker)
 
+    def test_dtensor_subclass_inherited_dispatcher_is_cloned_before_class_body_mutation(
+        self,
+    ):
+        op = torch.ops.aten.convolution.default
+        marker = object()
+
+        class ParentDTensor(DTensor):
+            pass
+
+        parent_dispatcher = ParentDTensor._op_dispatcher
+
+        class ChildDTensor(ParentDTensor):
+            _op_dispatcher._custom_op_handlers[op] = marker
+
+        self.assertIsNot(ChildDTensor._op_dispatcher, parent_dispatcher)
+        self.assertIs(ChildDTensor._op_dispatcher._custom_op_handlers[op], marker)
+        self.assertIsNot(parent_dispatcher._custom_op_handlers[op], marker)
+
+    def test_dtensor_default_custom_handler_map_is_dict_backed(self):
+        self.assertIsInstance(DTensor._op_dispatcher._custom_op_handlers, dict)
+
+    def test_dtensor_subclass_inherits_parent_random_ops(self):
+        lib = torch.library.Library("dtensor_subclass_random_ops_test", "FRAGMENT")
+        lib.define("custom_random(Tensor input) -> Tensor")
+        random_op = torch.ops.dtensor_subclass_random_ops_test.custom_random.default
+
+        class ParentDTensor(DTensor):
+            _op_dispatcher = type(DTensor._op_dispatcher)()
+
+        ParentDTensor._op_dispatcher._random_ops.add(random_op)
+
+        class ChildDTensor(ParentDTensor):
+            _op_dispatcher = type(DTensor._op_dispatcher)()
+
+        self.assertIn(random_op, ParentDTensor._op_dispatcher._random_ops)
+        self.assertIn(random_op, ChildDTensor._op_dispatcher._random_ops)
+        self.assertNotIn(random_op, DTensor._op_dispatcher._random_ops)
+
     def test_dtensor_subclass_inherits_runtime_cp_custom_handlers(self):
         from torch.distributed.tensor.experimental._context_parallel import (
             _attention as cp_attention,
@@ -603,9 +636,7 @@ class DTensorTest(DTensorTestBase):
             )
 
             subclass_prop.register_sharding_prop_rule(subclass_rule_op, subclass_rule)
-            subclass_prop.register_op_strategy(
-                subclass_strategy_op, subclass_strategy
-            )
+            subclass_prop.register_op_strategy(subclass_strategy_op, subclass_strategy)
             self.assertIs(
                 subclass_prop.op_to_rules.get(subclass_rule_op), subclass_rule
             )
@@ -716,9 +747,7 @@ class DTensorTest(DTensorTestBase):
         parent_conv_handler = parent_dispatcher._custom_op_handlers[op]
         parent_handler_calls = []
 
-        def overriding_parent_conv_handler(
-            op_call, args, kwargs, *, dtensor_type=None
-        ):
+        def overriding_parent_conv_handler(op_call, args, kwargs, *, dtensor_type=None):
             parent_handler_calls.append(dtensor_type)
             return parent_conv_handler(
                 op_call,
@@ -729,6 +758,7 @@ class DTensorTest(DTensorTestBase):
 
         parent_dispatcher._custom_op_handlers[op] = overriding_parent_conv_handler
         try:
+
             class ChildDTensor(ParentDTensor):
                 _op_dispatcher = type(DTensor._op_dispatcher)()
 
@@ -765,9 +795,7 @@ class DTensorTest(DTensorTestBase):
         default_conv_handler = parent_dispatcher._custom_op_handlers[op]
         parent_handler_calls = []
 
-        def overriding_parent_conv_handler(
-            op_call, args, kwargs, *, dtensor_type=None
-        ):
+        def overriding_parent_conv_handler(op_call, args, kwargs, *, dtensor_type=None):
             parent_handler_calls.append(dtensor_type)
             return default_conv_handler(
                 op_call,
@@ -778,6 +806,7 @@ class DTensorTest(DTensorTestBase):
 
         parent_dispatcher._custom_op_handlers[op] = overriding_parent_conv_handler
         try:
+
             class ChildDTensor(ParentDTensor):
                 _op_dispatcher = type(DTensor._op_dispatcher)()
 
@@ -815,9 +844,7 @@ class DTensorTest(DTensorTestBase):
         default_conv_handler = parent_dispatcher._custom_op_handlers[op]
         parent_handler_calls = []
 
-        def overriding_parent_conv_handler(
-            op_call, args, kwargs, *, dtensor_type=None
-        ):
+        def overriding_parent_conv_handler(op_call, args, kwargs, *, dtensor_type=None):
             parent_handler_calls.append(dtensor_type)
             return default_conv_handler(
                 op_call,
@@ -828,6 +855,7 @@ class DTensorTest(DTensorTestBase):
 
         parent_dispatcher._custom_op_handlers[op] = overriding_parent_conv_handler
         try:
+
             class ChildDTensor(ParentDTensor):
                 _op_dispatcher = type(DTensor._op_dispatcher)()
 
@@ -893,15 +921,10 @@ class DTensorTest(DTensorTestBase):
     @with_comms
     def test_dtensor_subclass_rule_shadows_inherited_strategy_registration(self):
         device_mesh = self.build_device_mesh()
-        lib = torch.library.Library(
-            "dtensor_subclass_registry_shadow_test", "FRAGMENT"
-        )
+        lib = torch.library.Library("dtensor_subclass_registry_shadow_test", "FRAGMENT")
         lib.define("rule_overrides_strategy(Tensor input) -> Tensor")
         lib.impl("rule_overrides_strategy", lambda input: input.clone(), "Meta")
-        op = (
-            torch.ops.dtensor_subclass_registry_shadow_test
-            .rule_overrides_strategy.default
-        )
+        op = torch.ops.dtensor_subclass_registry_shadow_test.rule_overrides_strategy.default
 
         class ParentDTensor(DTensor):
             _op_dispatcher = type(DTensor._op_dispatcher)()
@@ -951,10 +974,7 @@ class DTensorTest(DTensorTestBase):
             "dtensor_subclass_cross_registry_schema_info_test", "FRAGMENT"
         )
         lib.define("cross_registry_schema_override(Tensor input, int dim) -> Tensor")
-        op = (
-            torch.ops.dtensor_subclass_cross_registry_schema_info_test
-            .cross_registry_schema_override.default
-        )
+        op = torch.ops.dtensor_subclass_cross_registry_schema_info_test.cross_registry_schema_override.default
 
         class ParentDTensor(DTensor):
             _op_dispatcher = type(DTensor._op_dispatcher)()
@@ -973,9 +993,7 @@ class DTensorTest(DTensorTestBase):
 
         parent_prop = ParentDTensor._op_dispatcher.sharding_propagator
         child_prop = ChildDTensor._op_dispatcher.sharding_propagator
-        parent_prop.register_op_strategy(
-            op, parent_strategy, schema_info=schema_info
-        )
+        parent_prop.register_op_strategy(op, parent_strategy, schema_info=schema_info)
         child_prop.register_single_dim_op_strategy(op, child_single_dim_strategy)
 
         base = distribute_tensor(
@@ -1030,6 +1048,7 @@ class DTensorTest(DTensorTestBase):
             overriding_grandparent_conv_handler
         )
         try:
+
             class ParentDTensor(GrandParentDTensor):
                 _op_dispatcher = type(DTensor._op_dispatcher)()
 

--- a/test/distributed/tensor/test_dtensor.py
+++ b/test/distributed/tensor/test_dtensor.py
@@ -509,6 +509,29 @@ class DTensorTest(DTensorTestBase):
         self.assertIs(base_dispatcher._custom_op_handlers[op], default_conv_handler)
         self.assertIs(child_dispatcher._get_custom_op_handler(op, ChildDTensor), marker)
 
+    def test_dtensor_subclass_inherits_runtime_cp_custom_handlers(self):
+        from torch.distributed.tensor.experimental._context_parallel import (
+            _attention as cp_attention,
+        )
+
+        class ChildDTensor(DTensor):
+            _op_dispatcher = type(DTensor._op_dispatcher)()
+
+        op = torch.ops.aten._scaled_dot_product_flash_attention.default
+        child_dispatcher = ChildDTensor._op_dispatcher
+        self.assertIsNone(child_dispatcher._get_custom_op_handler(op, ChildDTensor))
+
+        cp_attention._enable_cp_dtensor_dispatcher()
+        try:
+            self.assertIs(
+                child_dispatcher._get_custom_op_handler(op, ChildDTensor),
+                cp_attention.custom_ops[op],
+            )
+        finally:
+            cp_attention._disable_cp_dtensor_dispatcher()
+
+        self.assertIsNone(child_dispatcher._get_custom_op_handler(op, ChildDTensor))
+
     def test_dtensor_subclass_sharding_propagator_inherits_base_without_aliasing(self):
         lib = torch.library.Library("dtensor_subclass_dispatch_test", "FRAGMENT")
         lib.define("base_rule(Tensor input) -> Tensor")
@@ -618,6 +641,60 @@ class DTensorTest(DTensorTestBase):
                 base_prop.op_strategy_funcs.pop(base_strategy_op, None)
             else:
                 base_prop.op_strategy_funcs[base_strategy_op] = base_strategy_backup
+
+    @with_comms
+    def test_dtensor_subclass_inherited_sharding_cache_invalidates_on_parent_update(
+        self,
+    ):
+        from torch.distributed.tensor._op_schema import OpSchema
+
+        lib = torch.library.Library(
+            "dtensor_subclass_cache_invalidation_test", "FRAGMENT"
+        )
+        lib.define("runtime_override(Tensor input) -> Tensor")
+        op = torch.ops.dtensor_subclass_cache_invalidation_test.runtime_override.default
+
+        class ParentDTensor(DTensor):
+            _op_dispatcher = type(DTensor._op_dispatcher)()
+
+        class ChildDTensor(ParentDTensor):
+            _op_dispatcher = type(DTensor._op_dispatcher)()
+
+        device_mesh = self.build_device_mesh()
+        local_tensor = torch.randn(8, device=self.device_type)
+        tensor_meta = TensorMeta(
+            local_tensor.shape,
+            local_tensor.stride(),
+            local_tensor.dtype,
+        )
+        input_spec = DTensorSpec(device_mesh, (Replicate(),), tensor_meta=tensor_meta)
+        replicated_output_spec = DTensorSpec(
+            device_mesh, (Replicate(),), tensor_meta=tensor_meta
+        )
+        sharded_output_spec = DTensorSpec(
+            device_mesh, (Shard(0),), tensor_meta=tensor_meta
+        )
+        op_schema = OpSchema(op=op, args_schema=(input_spec,), kwargs_schema={})
+        parent_prop = ParentDTensor._op_dispatcher.sharding_propagator
+        child_prop = ChildDTensor._op_dispatcher.sharding_propagator
+
+        def replicated_rule(op_schema):
+            return OutputSharding(replicated_output_spec)
+
+        def sharded_rule(op_schema):
+            return OutputSharding(sharded_output_spec)
+
+        parent_prop.register_sharding_prop_rule(op, replicated_rule)
+        self.assertEqual(
+            child_prop.propagate_op_sharding(op_schema).output_spec.placements,
+            (Replicate(),),
+        )
+
+        parent_prop.register_sharding_prop_rule(op, sharded_rule)
+        self.assertEqual(
+            child_prop.propagate_op_sharding(op_schema).output_spec.placements,
+            (Shard(0),),
+        )
 
     @with_comms
     def test_dtensor_nested_subclass_inherits_custom_handler_overrides(self):

--- a/test/distributed/tensor/test_dtensor.py
+++ b/test/distributed/tensor/test_dtensor.py
@@ -280,6 +280,40 @@ class DTensorTest(DTensorTestBase):
         self.assertEqual(result.to_local(), local_tensor + local_tensor)
 
     @with_comms
+    def test_dtensor_subclass_legacy_dispatcher_signature(self):
+        device_mesh = self.build_device_mesh()
+        local_tensor = torch.arange(
+            16, device=self.device_type, dtype=torch.float32
+        ).reshape(4, 4)
+        base = DTensor.from_local(local_tensor, device_mesh, [Replicate()])
+
+        dispatcher_calls = []
+
+        class LegacyDispatcher(type(DTensor._op_dispatcher)):
+            def dispatch(self, op_call, args, kwargs):
+                dispatcher_calls.append(op_call)
+                return super().dispatch(
+                    op_call,
+                    args,
+                    kwargs,
+                    dtensor_type=MyDTensor,
+                )
+
+        class MyDTensor(DTensor):
+            _op_dispatcher = LegacyDispatcher()
+
+        my_dt = MyDTensor(
+            base._local_tensor,
+            base._spec,
+            requires_grad=base.requires_grad,
+        )
+        result = my_dt + my_dt
+
+        self.assertEqual(dispatcher_calls, [torch.ops.aten.add.Tensor])
+        self.assertEqual(type(result), MyDTensor)
+        self.assertEqual(result.to_local(), local_tensor + local_tensor)
+
+    @with_comms
     def test_dtensor_subclass_tensor_unflatten_preserves_type(self):
         device_mesh = self.build_device_mesh()
         local_tensor = torch.arange(
@@ -436,8 +470,13 @@ class DTensorTest(DTensorTestBase):
         self.assertEqual(result.to_local(), F.conv2d(local_input, local_weight))
 
     def test_dtensor_subclass_inherited_dispatcher_is_cloned(self):
+        class ConfigurableDispatcher(type(DTensor._op_dispatcher)):
+            def __init__(self, label):
+                super().__init__()
+                self.label = label
+
         class ParentDTensor(DTensor):
-            pass
+            _op_dispatcher = ConfigurableDispatcher("parent")
 
         class ChildDTensor(ParentDTensor):
             pass
@@ -451,6 +490,8 @@ class DTensorTest(DTensorTestBase):
 
         self.assertIsNot(parent_dispatcher, base_dispatcher)
         self.assertIsNot(child_dispatcher, parent_dispatcher)
+        self.assertEqual(parent_dispatcher.label, "parent")
+        self.assertEqual(child_dispatcher.label, "parent")
         self.assertIsNot(
             parent_dispatcher.sharding_propagator,
             base_dispatcher.sharding_propagator,
@@ -460,8 +501,11 @@ class DTensorTest(DTensorTestBase):
             parent_dispatcher.sharding_propagator,
         )
 
+        child_dispatcher.label = "child"
         parent_dispatcher._custom_op_handlers[op] = marker
 
+        self.assertEqual(parent_dispatcher.label, "parent")
+        self.assertEqual(child_dispatcher.label, "child")
         self.assertIs(base_dispatcher._custom_op_handlers[op], default_conv_handler)
         self.assertIs(child_dispatcher._get_custom_op_handler(op, ChildDTensor), marker)
 

--- a/test/distributed/tensor/test_dtensor.py
+++ b/test/distributed/tensor/test_dtensor.py
@@ -393,6 +393,78 @@ class DTensorTest(DTensorTestBase):
         self.assertEqual(type(result), MyDTensor)
         self.assertEqual(result.to_local(), F.conv2d(local_input, local_weight))
 
+    @with_comms
+    def test_dtensor_subclass_legacy_custom_handler_signature(self):
+        device_mesh = self.build_device_mesh()
+        local_input = torch.arange(
+            16, device=self.device_type, dtype=torch.float32
+        ).reshape(1, 1, 4, 4)
+        local_weight = torch.ones(
+            1, 1, 1, 1, device=self.device_type, dtype=torch.float32
+        )
+        input_dt = distribute_tensor(local_input, device_mesh, [Replicate()])
+        base_weight = distribute_tensor(local_weight, device_mesh, [Replicate()])
+
+        class MyDTensor(DTensor):
+            _op_dispatcher = type(DTensor._op_dispatcher)()
+
+        op = torch.ops.aten.convolution.default
+        dispatcher = MyDTensor._op_dispatcher
+        default_conv_handler = dispatcher._custom_op_handlers[op]
+        legacy_handler_calls = []
+
+        def legacy_conv_handler(op_call, args, kwargs):
+            legacy_handler_calls.append(op_call)
+            return default_conv_handler(
+                op_call,
+                args,
+                kwargs,
+                dtensor_type=MyDTensor,
+            )
+
+        dispatcher._custom_op_handlers[op] = legacy_conv_handler
+
+        weight = MyDTensor(
+            base_weight._local_tensor,
+            base_weight._spec,
+            requires_grad=base_weight.requires_grad,
+        )
+        result = F.conv2d(input_dt, weight)
+
+        self.assertEqual(legacy_handler_calls, [op])
+        self.assertEqual(type(result), MyDTensor)
+        self.assertEqual(result.to_local(), F.conv2d(local_input, local_weight))
+
+    def test_dtensor_subclass_inherited_dispatcher_is_cloned(self):
+        class ParentDTensor(DTensor):
+            pass
+
+        class ChildDTensor(ParentDTensor):
+            pass
+
+        op = torch.ops.aten.convolution.default
+        base_dispatcher = DTensor._op_dispatcher
+        parent_dispatcher = ParentDTensor._op_dispatcher
+        child_dispatcher = ChildDTensor._op_dispatcher
+        default_conv_handler = base_dispatcher._custom_op_handlers[op]
+        marker = object()
+
+        self.assertIsNot(parent_dispatcher, base_dispatcher)
+        self.assertIsNot(child_dispatcher, parent_dispatcher)
+        self.assertIsNot(
+            parent_dispatcher.sharding_propagator,
+            base_dispatcher.sharding_propagator,
+        )
+        self.assertIsNot(
+            child_dispatcher.sharding_propagator,
+            parent_dispatcher.sharding_propagator,
+        )
+
+        parent_dispatcher._custom_op_handlers[op] = marker
+
+        self.assertIs(base_dispatcher._custom_op_handlers[op], default_conv_handler)
+        self.assertIs(child_dispatcher._get_custom_op_handler(op, ChildDTensor), marker)
+
     def test_dtensor_subclass_sharding_propagator_inherits_base_without_aliasing(self):
         lib = torch.library.Library("dtensor_subclass_dispatch_test", "FRAGMENT")
         lib.define("base_rule(Tensor input) -> Tensor")

--- a/test/distributed/tensor/test_dtensor.py
+++ b/test/distributed/tensor/test_dtensor.py
@@ -27,6 +27,8 @@ from torch.distributed.tensor._dtensor_spec import (
     TensorMeta,
 )
 from torch.distributed.tensor._op_schema import RuntimeSchemaInfo
+from torch.distributed.tensor._op_schema import OutputSharding
+from torch.distributed.tensor._ops.single_dim_strategy import _SingleDimStrategyInfo
 from torch.distributed.tensor._redistribute import redistribute_local_tensor
 from torch.distributed.tensor.debug import CommDebugMode
 from torch.distributed.tensor.experimental import implicit_replication
@@ -626,6 +628,109 @@ class DTensorTest(DTensorTestBase):
         child_prop = ChildDTensor._op_dispatcher.sharding_propagator
         parent_prop.register_sharding_prop_rule(op, parent_rule, schema_info=schema_info)
         child_prop.register_sharding_prop_rule(op, child_rule)
+
+        base = distribute_tensor(
+            torch.arange(4, device=self.device_type, dtype=torch.float32),
+            device_mesh,
+            [Replicate()],
+        )
+        child_dt = ChildDTensor(
+            base._local_tensor,
+            base._spec,
+            requires_grad=base.requires_grad,
+        )
+        op_info = ChildDTensor._op_dispatcher.unwrap_to_op_info(op, (child_dt, 1), {})
+
+        self.assertIs(parent_prop.get_schema_info(op), schema_info)
+        self.assertIsNone(child_prop.get_schema_info(op))
+        self.assertIsNotNone(op_info.schema)
+        self.assertIsNone(op_info.schema.schema_info)
+
+    @with_comms
+    def test_dtensor_subclass_rule_shadows_inherited_strategy_registration(self):
+        device_mesh = self.build_device_mesh()
+        lib = torch.library.Library(
+            "dtensor_subclass_registry_shadow_test", "FRAGMENT"
+        )
+        lib.define("rule_overrides_strategy(Tensor input) -> Tensor")
+        lib.impl("rule_overrides_strategy", lambda input: input.clone(), "Meta")
+        op = (
+            torch.ops.dtensor_subclass_registry_shadow_test.rule_overrides_strategy.default
+        )
+
+        class ParentDTensor(DTensor):
+            _op_dispatcher = type(DTensor._op_dispatcher)()
+
+        class ChildDTensor(ParentDTensor):
+            _op_dispatcher = type(DTensor._op_dispatcher)()
+
+        def parent_strategy(op_schema):
+            raise AssertionError(f"unexpected inherited strategy: {op_schema}")
+
+        child_rule_calls = []
+
+        def child_rule(op_schema):
+            child_rule_calls.append(op_schema.op)
+            input_spec = op_schema.args_schema[0]
+            if not isinstance(input_spec, DTensorSpec):
+                raise AssertionError
+            return OutputSharding(input_spec)
+
+        parent_prop = ParentDTensor._op_dispatcher.sharding_propagator
+        child_prop = ChildDTensor._op_dispatcher.sharding_propagator
+        parent_prop.register_op_strategy(op, parent_strategy)
+        child_prop.register_sharding_prop_rule(op, child_rule)
+
+        base = distribute_tensor(
+            torch.arange(4, device=self.device_type, dtype=torch.float32),
+            device_mesh,
+            [Replicate()],
+        )
+        child_dt = ChildDTensor(
+            base._local_tensor,
+            base._spec,
+            requires_grad=base.requires_grad,
+        )
+        op_info = ChildDTensor._op_dispatcher.unwrap_to_op_info(op, (child_dt,), {})
+
+        self.assertIsNotNone(op_info.schema)
+        output_sharding = child_prop.propagate_op_sharding_non_cached(op_info.schema)
+        self.assertEqual(child_rule_calls, [op])
+        self.assertIsInstance(output_sharding.output_spec, DTensorSpec)
+        self.assertEqual(output_sharding.output_spec.placements, child_dt.placements)
+
+    @with_comms
+    def test_dtensor_subclass_cross_registry_override_masks_parent_schema_info(self):
+        device_mesh = self.build_device_mesh()
+        lib = torch.library.Library(
+            "dtensor_subclass_cross_registry_schema_info_test", "FRAGMENT"
+        )
+        lib.define("cross_registry_schema_override(Tensor input, int dim) -> Tensor")
+        op = (
+            torch.ops.dtensor_subclass_cross_registry_schema_info_test.cross_registry_schema_override.default
+        )
+
+        class ParentDTensor(DTensor):
+            _op_dispatcher = type(DTensor._op_dispatcher)()
+
+        class ChildDTensor(ParentDTensor):
+            _op_dispatcher = type(DTensor._op_dispatcher)()
+
+        schema_info = RuntimeSchemaInfo(static_argnum=1)
+
+        def parent_strategy(op_schema):
+            raise AssertionError(f"unexpected call: {op_schema}")
+
+        child_single_dim_strategy = _SingleDimStrategyInfo(
+            lambda op_overload, args, kwargs: [[Replicate(), Replicate()]]
+        )
+
+        parent_prop = ParentDTensor._op_dispatcher.sharding_propagator
+        child_prop = ChildDTensor._op_dispatcher.sharding_propagator
+        parent_prop.register_op_strategy(
+            op, parent_strategy, schema_info=schema_info
+        )
+        child_prop.register_single_dim_op_strategy(op, child_single_dim_strategy)
 
         base = distribute_tensor(
             torch.arange(4, device=self.device_type, dtype=torch.float32),

--- a/test/distributed/tensor/test_dtensor.py
+++ b/test/distributed/tensor/test_dtensor.py
@@ -31,6 +31,7 @@ from torch.distributed.tensor.debug import CommDebugMode
 from torch.distributed.tensor.experimental import implicit_replication
 from torch.distributed.tensor.parallel import (
     ColwiseParallel,
+    loss_parallel,
     parallelize_module,
     RowwiseParallel,
 )
@@ -270,6 +271,38 @@ class DTensorTest(DTensorTestBase):
         self.assertEqual(dispatcher_calls, [(torch.ops.aten.add.Tensor, MyDTensor)])
         self.assertEqual(type(result), MyDTensor)
         self.assertEqual(result.to_local(), local_tensor + local_tensor)
+
+    @with_comms
+    def test_dtensor_subclass_loss_parallel_custom_handlers(self):
+        device_mesh = self.build_device_mesh()
+        comm_mode = CommDebugMode()
+        local_tensor = torch.rand(
+            8, 16, device=self.device_type, dtype=torch.float32, requires_grad=True
+        )
+        target = torch.randint(16, (8,), device=self.device_type)
+        base = distribute_tensor(local_tensor, device_mesh, [Shard(1)])
+        dist_target = distribute_tensor(target, device_mesh, [Replicate()])
+
+        class MyDTensor(DTensor):
+            _op_dispatcher = type(DTensor._op_dispatcher)()
+
+        my_dt = MyDTensor(
+            base._local_tensor,
+            base._spec,
+            requires_grad=base.requires_grad,
+        )
+        expected = F.cross_entropy(local_tensor, target)
+        with loss_parallel():
+            with comm_mode:
+                result = F.cross_entropy(my_dt, dist_target)
+
+        self.assertEqual(comm_mode.get_total_counts(), 3)
+        self.assertEqual(
+            comm_mode.get_comm_counts()[c10d_functional.all_reduce],
+            3,
+        )
+        self.assertEqual(type(result), MyDTensor)
+        self.assertEqual(result.to_local(), expected)
 
     @with_comms
     def test_from_local_backward(self):

--- a/test/distributed/tensor/test_dtensor.py
+++ b/test/distributed/tensor/test_dtensor.py
@@ -26,9 +26,13 @@ from torch.distributed.tensor._dtensor_spec import (
     ShardOrderEntry,
     TensorMeta,
 )
-from torch.distributed.tensor._op_schema import RuntimeSchemaInfo
-from torch.distributed.tensor._op_schema import OutputSharding
-from torch.distributed.tensor._ops.single_dim_strategy import _SingleDimStrategyInfo
+from torch.distributed.tensor._op_schema import (
+    OutputSharding,
+    RuntimeSchemaInfo,
+)
+from torch.distributed.tensor._ops.single_dim_strategy import (
+    _SingleDimStrategyInfo,
+)
 from torch.distributed.tensor._redistribute import redistribute_local_tensor
 from torch.distributed.tensor.debug import CommDebugMode
 from torch.distributed.tensor.experimental import implicit_replication
@@ -515,9 +519,8 @@ class DTensorTest(DTensorTestBase):
             _op_dispatcher = type(DTensor._op_dispatcher)()
 
         parent_dispatcher = ParentDTensor._op_dispatcher
-        parent_conv_handler = parent_dispatcher._custom_op_handlers[
-            torch.ops.aten.convolution.default
-        ]
+        op = torch.ops.aten.convolution.default
+        parent_conv_handler = parent_dispatcher._custom_op_handlers[op]
         parent_handler_calls = []
 
         def overriding_parent_conv_handler(
@@ -531,9 +534,7 @@ class DTensorTest(DTensorTestBase):
                 dtensor_type=dtensor_type,
             )
 
-        parent_dispatcher._custom_op_handlers[torch.ops.aten.convolution.default] = (
-            overriding_parent_conv_handler
-        )
+        parent_dispatcher._custom_op_handlers[op] = overriding_parent_conv_handler
         try:
             class ChildDTensor(ParentDTensor):
                 _op_dispatcher = type(DTensor._op_dispatcher)()
@@ -545,9 +546,7 @@ class DTensorTest(DTensorTestBase):
             )
             result = F.conv2d(input_dt, weight)
         finally:
-            parent_dispatcher._custom_op_handlers[torch.ops.aten.convolution.default] = (
-                parent_conv_handler
-            )
+            parent_dispatcher._custom_op_handlers[op] = parent_conv_handler
 
         self.assertEqual(parent_handler_calls, [ChildDTensor])
         self.assertEqual(type(result), ChildDTensor)
@@ -626,7 +625,9 @@ class DTensorTest(DTensorTestBase):
 
         parent_prop = ParentDTensor._op_dispatcher.sharding_propagator
         child_prop = ChildDTensor._op_dispatcher.sharding_propagator
-        parent_prop.register_sharding_prop_rule(op, parent_rule, schema_info=schema_info)
+        parent_prop.register_sharding_prop_rule(
+            op, parent_rule, schema_info=schema_info
+        )
         child_prop.register_sharding_prop_rule(op, child_rule)
 
         base = distribute_tensor(
@@ -655,7 +656,8 @@ class DTensorTest(DTensorTestBase):
         lib.define("rule_overrides_strategy(Tensor input) -> Tensor")
         lib.impl("rule_overrides_strategy", lambda input: input.clone(), "Meta")
         op = (
-            torch.ops.dtensor_subclass_registry_shadow_test.rule_overrides_strategy.default
+            torch.ops.dtensor_subclass_registry_shadow_test
+            .rule_overrides_strategy.default
         )
 
         class ParentDTensor(DTensor):
@@ -707,7 +709,8 @@ class DTensorTest(DTensorTestBase):
         )
         lib.define("cross_registry_schema_override(Tensor input, int dim) -> Tensor")
         op = (
-            torch.ops.dtensor_subclass_cross_registry_schema_info_test.cross_registry_schema_override.default
+            torch.ops.dtensor_subclass_cross_registry_schema_info_test
+            .cross_registry_schema_override.default
         )
 
         class ParentDTensor(DTensor):

--- a/test/distributed/tensor/test_dtensor.py
+++ b/test/distributed/tensor/test_dtensor.py
@@ -305,6 +305,102 @@ class DTensorTest(DTensorTestBase):
         self.assertEqual(result.to_local(), expected)
 
     @with_comms
+    def test_dtensor_subclass_custom_handler_uses_selected_type(self):
+        device_mesh = self.build_device_mesh()
+        local_input = torch.arange(
+            16, device=self.device_type, dtype=torch.float32
+        ).reshape(1, 1, 4, 4)
+        local_weight = torch.ones(
+            1, 1, 1, 1, device=self.device_type, dtype=torch.float32
+        )
+        input_dt = distribute_tensor(local_input, device_mesh, [Replicate()])
+        base_weight = distribute_tensor(local_weight, device_mesh, [Replicate()])
+
+        class MyDTensor(DTensor):
+            _op_dispatcher = type(DTensor._op_dispatcher)()
+
+        weight = MyDTensor(
+            base_weight._local_tensor,
+            base_weight._spec,
+            requires_grad=base_weight.requires_grad,
+        )
+        result = F.conv2d(input_dt, weight)
+
+        self.assertEqual(type(result), MyDTensor)
+        self.assertEqual(result.to_local(), F.conv2d(local_input, local_weight))
+
+    def test_dtensor_subclass_sharding_propagator_inherits_base_without_aliasing(self):
+        lib = torch.library.Library("dtensor_subclass_dispatch_test", "FRAGMENT")
+        lib.define("base_rule(Tensor input) -> Tensor")
+        lib.define("base_strategy(Tensor input) -> Tensor")
+        lib.define("subclass_rule(Tensor input) -> Tensor")
+        lib.define("subclass_strategy(Tensor input) -> Tensor")
+
+        base_rule_op = torch.ops.dtensor_subclass_dispatch_test.base_rule.default
+        base_strategy_op = (
+            torch.ops.dtensor_subclass_dispatch_test.base_strategy.default
+        )
+        subclass_rule_op = (
+            torch.ops.dtensor_subclass_dispatch_test.subclass_rule.default
+        )
+        subclass_strategy_op = (
+            torch.ops.dtensor_subclass_dispatch_test.subclass_strategy.default
+        )
+
+        class MyDTensor(DTensor):
+            _op_dispatcher = type(DTensor._op_dispatcher)()
+
+        base_prop = DTensor._op_dispatcher.sharding_propagator
+        subclass_prop = MyDTensor._op_dispatcher.sharding_propagator
+
+        def base_rule(op_schema):
+            raise AssertionError(f"unexpected call: {op_schema}")
+
+        def base_strategy(op_schema):
+            raise AssertionError(f"unexpected call: {op_schema}")
+
+        def subclass_rule(op_schema):
+            raise AssertionError(f"unexpected call: {op_schema}")
+
+        def subclass_strategy(op_schema):
+            raise AssertionError(f"unexpected call: {op_schema}")
+
+        self.assertIsNot(base_prop, subclass_prop)
+        base_rule_backup = base_prop.op_to_rules.get(base_rule_op)
+        base_strategy_backup = base_prop.op_strategy_funcs.get(base_strategy_op)
+        try:
+            base_prop.register_sharding_prop_rule(base_rule_op, base_rule)
+            base_prop.register_op_strategy(base_strategy_op, base_strategy)
+            self.assertIs(subclass_prop.op_to_rules.get(base_rule_op), base_rule)
+            self.assertIs(
+                subclass_prop.op_strategy_funcs.get(base_strategy_op),
+                base_strategy,
+            )
+
+            subclass_prop.register_sharding_prop_rule(subclass_rule_op, subclass_rule)
+            subclass_prop.register_op_strategy(
+                subclass_strategy_op, subclass_strategy
+            )
+            self.assertIs(
+                subclass_prop.op_to_rules.get(subclass_rule_op), subclass_rule
+            )
+            self.assertIs(
+                subclass_prop.op_strategy_funcs.get(subclass_strategy_op),
+                subclass_strategy,
+            )
+            self.assertIsNone(base_prop.op_to_rules.get(subclass_rule_op))
+            self.assertIsNone(base_prop.op_strategy_funcs.get(subclass_strategy_op))
+        finally:
+            if base_rule_backup is None:
+                base_prop.op_to_rules.pop(base_rule_op, None)
+            else:
+                base_prop.op_to_rules[base_rule_op] = base_rule_backup
+            if base_strategy_backup is None:
+                base_prop.op_strategy_funcs.pop(base_strategy_op, None)
+            else:
+                base_prop.op_strategy_funcs[base_strategy_op] = base_strategy_backup
+
+    @with_comms
     def test_from_local_backward(self):
         """Test that from_local backward gives the correct gradient placements.
 

--- a/test/distributed/tensor/test_dtensor.py
+++ b/test/distributed/tensor/test_dtensor.py
@@ -273,6 +273,34 @@ class DTensorTest(DTensorTestBase):
         self.assertEqual(result.to_local(), local_tensor + local_tensor)
 
     @with_comms
+    def test_dtensor_subclass_tensor_unflatten_preserves_type(self):
+        device_mesh = self.build_device_mesh()
+        local_tensor = torch.arange(
+            16, device=self.device_type, dtype=torch.float32
+        ).reshape(4, 4)
+        base = DTensor.from_local(local_tensor, device_mesh, [Replicate()])
+
+        class MyDTensor(DTensor):
+            _op_dispatcher = type(DTensor._op_dispatcher)()
+
+        my_dt = MyDTensor(
+            base._local_tensor,
+            base._spec,
+            requires_grad=base.requires_grad,
+        )
+        inner_tensors, flatten_spec = my_dt.__tensor_flatten__()
+        rebuilt = type(my_dt).__tensor_unflatten__(
+            {"_local_tensor": my_dt._local_tensor},
+            flatten_spec,
+            my_dt.size(),
+            my_dt.stride(),
+        )
+
+        self.assertEqual(inner_tensors, ["_local_tensor"])
+        self.assertEqual(type(rebuilt), MyDTensor)
+        self.assertEqual(rebuilt.to_local(), my_dt.to_local())
+
+    @with_comms
     def test_dtensor_subclass_loss_parallel_custom_handlers(self):
         device_mesh = self.build_device_mesh()
         comm_mode = CommDebugMode()
@@ -467,6 +495,60 @@ class DTensorTest(DTensorTestBase):
                 base_prop.op_strategy_funcs.pop(base_strategy_op, None)
             else:
                 base_prop.op_strategy_funcs[base_strategy_op] = base_strategy_backup
+
+    @with_comms
+    def test_dtensor_nested_subclass_inherits_custom_handler_overrides(self):
+        device_mesh = self.build_device_mesh()
+        local_input = torch.arange(
+            16, device=self.device_type, dtype=torch.float32
+        ).reshape(1, 1, 4, 4)
+        local_weight = torch.ones(
+            1, 1, 1, 1, device=self.device_type, dtype=torch.float32
+        )
+        input_dt = distribute_tensor(local_input, device_mesh, [Replicate()])
+        base_weight = distribute_tensor(local_weight, device_mesh, [Replicate()])
+
+        class ParentDTensor(DTensor):
+            _op_dispatcher = type(DTensor._op_dispatcher)()
+
+        parent_dispatcher = ParentDTensor._op_dispatcher
+        parent_conv_handler = parent_dispatcher._custom_op_handlers[
+            torch.ops.aten.convolution.default
+        ]
+        parent_handler_calls = []
+
+        def overriding_parent_conv_handler(
+            op_call, args, kwargs, *, dtensor_type=None
+        ):
+            parent_handler_calls.append(dtensor_type)
+            return parent_conv_handler(
+                op_call,
+                args,
+                kwargs,
+                dtensor_type=dtensor_type,
+            )
+
+        parent_dispatcher._custom_op_handlers[torch.ops.aten.convolution.default] = (
+            overriding_parent_conv_handler
+        )
+        try:
+            class ChildDTensor(ParentDTensor):
+                _op_dispatcher = type(DTensor._op_dispatcher)()
+
+            weight = ChildDTensor(
+                base_weight._local_tensor,
+                base_weight._spec,
+                requires_grad=base_weight.requires_grad,
+            )
+            result = F.conv2d(input_dt, weight)
+        finally:
+            parent_dispatcher._custom_op_handlers[torch.ops.aten.convolution.default] = (
+                parent_conv_handler
+            )
+
+        self.assertEqual(parent_handler_calls, [ChildDTensor])
+        self.assertEqual(type(result), ChildDTensor)
+        self.assertEqual(result.to_local(), F.conv2d(local_input, local_weight))
 
     @with_comms
     def test_from_local_backward(self):

--- a/test/distributed/tensor/test_dtensor.py
+++ b/test/distributed/tensor/test_dtensor.py
@@ -719,6 +719,56 @@ class DTensorTest(DTensorTestBase):
         self.assertEqual(result.to_local(), F.conv2d(local_input, local_weight))
 
     @with_comms
+    def test_dtensor_nested_subclass_can_disable_inherited_custom_handler(self):
+        device_mesh = self.build_device_mesh()
+        local_input = torch.arange(
+            16, device=self.device_type, dtype=torch.float32
+        ).reshape(1, 1, 4, 4)
+        local_weight = torch.ones(
+            1, 1, 1, 1, device=self.device_type, dtype=torch.float32
+        )
+        input_dt = distribute_tensor(local_input, device_mesh, [Replicate()])
+        base_weight = distribute_tensor(local_weight, device_mesh, [Replicate()])
+
+        class ParentDTensor(DTensor):
+            _op_dispatcher = type(DTensor._op_dispatcher)()
+
+        op = torch.ops.aten.convolution.default
+        parent_dispatcher = ParentDTensor._op_dispatcher
+        default_conv_handler = parent_dispatcher._custom_op_handlers[op]
+        parent_handler_calls = []
+
+        def overriding_parent_conv_handler(
+            op_call, args, kwargs, *, dtensor_type=None
+        ):
+            parent_handler_calls.append(dtensor_type)
+            return default_conv_handler(
+                op_call,
+                args,
+                kwargs,
+                dtensor_type=dtensor_type,
+            )
+
+        parent_dispatcher._custom_op_handlers[op] = overriding_parent_conv_handler
+        try:
+            class ChildDTensor(ParentDTensor):
+                _op_dispatcher = type(DTensor._op_dispatcher)()
+
+            ChildDTensor._op_dispatcher._custom_op_handlers.pop(op)
+            weight = ChildDTensor(
+                base_weight._local_tensor,
+                base_weight._spec,
+                requires_grad=base_weight.requires_grad,
+            )
+            result = F.conv2d(input_dt, weight)
+        finally:
+            parent_dispatcher._custom_op_handlers[op] = default_conv_handler
+
+        self.assertEqual(parent_handler_calls, [])
+        self.assertEqual(type(result), ChildDTensor)
+        self.assertEqual(result.to_local(), F.conv2d(local_input, local_weight))
+
+    @with_comms
     def test_dtensor_subclass_sharding_override_can_clear_inherited_schema_info(self):
         device_mesh = self.build_device_mesh()
         lib = torch.library.Library("dtensor_subclass_schema_info_test", "FRAGMENT")

--- a/test/distributed/tensor/test_dtensor.py
+++ b/test/distributed/tensor/test_dtensor.py
@@ -231,6 +231,47 @@ class DTensorTest(DTensorTestBase):
             DTensor.from_local(dtensor, device_mesh, shard_spec)
 
     @with_comms
+    def test_dtensor_subclass_torch_dispatch(self):
+        device_mesh = self.build_device_mesh()
+        local_tensor = torch.arange(
+            16, device=self.device_type, dtype=torch.float32
+        ).reshape(4, 4)
+        base = DTensor.from_local(local_tensor, device_mesh, [Replicate()])
+
+        torch_dispatch_calls = []
+        dispatcher_calls = []
+
+        class LoggingDispatcher(type(DTensor._op_dispatcher)):
+            def dispatch(self, op_call, args, kwargs, *, dtensor_type=DTensor):
+                dispatcher_calls.append((op_call, dtensor_type))
+                return super().dispatch(
+                    op_call,
+                    args,
+                    kwargs,
+                    dtensor_type=dtensor_type,
+                )
+
+        class MyDTensor(DTensor):
+            _op_dispatcher = LoggingDispatcher()
+
+            @classmethod
+            def __torch_dispatch__(cls, func, types, args=(), kwargs=None):
+                torch_dispatch_calls.append((cls, func))
+                return super().__torch_dispatch__(func, types, args, kwargs)
+
+        my_dt = MyDTensor(
+            base._local_tensor,
+            base._spec,
+            requires_grad=base.requires_grad,
+        )
+        result = my_dt + my_dt
+
+        self.assertEqual(torch_dispatch_calls, [(MyDTensor, torch.ops.aten.add.Tensor)])
+        self.assertEqual(dispatcher_calls, [(torch.ops.aten.add.Tensor, MyDTensor)])
+        self.assertEqual(type(result), MyDTensor)
+        self.assertEqual(result.to_local(), local_tensor + local_tensor)
+
+    @with_comms
     def test_from_local_backward(self):
         """Test that from_local backward gives the correct gradient placements.
 

--- a/test/distributed/tensor/test_dtensor.py
+++ b/test/distributed/tensor/test_dtensor.py
@@ -26,6 +26,7 @@ from torch.distributed.tensor._dtensor_spec import (
     ShardOrderEntry,
     TensorMeta,
 )
+from torch.distributed.tensor._op_schema import RuntimeSchemaInfo
 from torch.distributed.tensor._redistribute import redistribute_local_tensor
 from torch.distributed.tensor.debug import CommDebugMode
 from torch.distributed.tensor.experimental import implicit_replication
@@ -549,6 +550,99 @@ class DTensorTest(DTensorTestBase):
         self.assertEqual(parent_handler_calls, [ChildDTensor])
         self.assertEqual(type(result), ChildDTensor)
         self.assertEqual(result.to_local(), F.conv2d(local_input, local_weight))
+
+    @with_comms
+    def test_dtensor_nested_subclass_can_restore_default_custom_handler(self):
+        device_mesh = self.build_device_mesh()
+        local_input = torch.arange(
+            16, device=self.device_type, dtype=torch.float32
+        ).reshape(1, 1, 4, 4)
+        local_weight = torch.ones(
+            1, 1, 1, 1, device=self.device_type, dtype=torch.float32
+        )
+        input_dt = distribute_tensor(local_input, device_mesh, [Replicate()])
+        base_weight = distribute_tensor(local_weight, device_mesh, [Replicate()])
+
+        class ParentDTensor(DTensor):
+            _op_dispatcher = type(DTensor._op_dispatcher)()
+
+        op = torch.ops.aten.convolution.default
+        parent_dispatcher = ParentDTensor._op_dispatcher
+        default_conv_handler = parent_dispatcher._custom_op_handlers[op]
+        parent_handler_calls = []
+
+        def overriding_parent_conv_handler(
+            op_call, args, kwargs, *, dtensor_type=None
+        ):
+            parent_handler_calls.append(dtensor_type)
+            return default_conv_handler(
+                op_call,
+                args,
+                kwargs,
+                dtensor_type=dtensor_type,
+            )
+
+        parent_dispatcher._custom_op_handlers[op] = overriding_parent_conv_handler
+        try:
+            class ChildDTensor(ParentDTensor):
+                _op_dispatcher = type(DTensor._op_dispatcher)()
+
+            ChildDTensor._op_dispatcher._custom_op_handlers[op] = default_conv_handler
+            weight = ChildDTensor(
+                base_weight._local_tensor,
+                base_weight._spec,
+                requires_grad=base_weight.requires_grad,
+            )
+            result = F.conv2d(input_dt, weight)
+        finally:
+            parent_dispatcher._custom_op_handlers[op] = default_conv_handler
+
+        self.assertEqual(parent_handler_calls, [])
+        self.assertEqual(type(result), ChildDTensor)
+        self.assertEqual(result.to_local(), F.conv2d(local_input, local_weight))
+
+    @with_comms
+    def test_dtensor_subclass_sharding_override_can_clear_inherited_schema_info(self):
+        device_mesh = self.build_device_mesh()
+        lib = torch.library.Library("dtensor_subclass_schema_info_test", "FRAGMENT")
+        lib.define("schema_override(Tensor input, int dim) -> Tensor")
+        op = torch.ops.dtensor_subclass_schema_info_test.schema_override.default
+
+        class ParentDTensor(DTensor):
+            _op_dispatcher = type(DTensor._op_dispatcher)()
+
+        class ChildDTensor(ParentDTensor):
+            _op_dispatcher = type(DTensor._op_dispatcher)()
+
+        schema_info = RuntimeSchemaInfo(static_argnum=1)
+
+        def parent_rule(op_schema):
+            raise AssertionError(f"unexpected call: {op_schema}")
+
+        def child_rule(op_schema):
+            raise AssertionError(f"unexpected call: {op_schema}")
+
+        parent_prop = ParentDTensor._op_dispatcher.sharding_propagator
+        child_prop = ChildDTensor._op_dispatcher.sharding_propagator
+        parent_prop.register_sharding_prop_rule(op, parent_rule, schema_info=schema_info)
+        child_prop.register_sharding_prop_rule(op, child_rule)
+
+        base = distribute_tensor(
+            torch.arange(4, device=self.device_type, dtype=torch.float32),
+            device_mesh,
+            [Replicate()],
+        )
+        child_dt = ChildDTensor(
+            base._local_tensor,
+            base._spec,
+            requires_grad=base.requires_grad,
+        )
+        op_info = ChildDTensor._op_dispatcher.unwrap_to_op_info(op, (child_dt, 1), {})
+
+        self.assertIs(parent_prop.get_schema_info(op), schema_info)
+        self.assertIsNone(child_prop.get_schema_info(op))
+        self.assertIsNotNone(op_info.schema)
+        self.assertIsNone(op_info.schema.schema_info)
 
     @with_comms
     def test_from_local_backward(self):

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -1506,18 +1506,24 @@ py::object dispatchDTensorOp(
   {
     const auto custom_op_handlers =
         op_dispatcher.attr(dtensor_interned_strings._custom_op_handlers);
-    TORCH_CHECK(
-        PyDict_Check(custom_op_handlers.ptr()),
-        "_custom_op_handlers must be a dict!");
-    PyObject* custom_op_handler =
-        PyDict_GetItemWithError(custom_op_handlers.ptr(), py_op.ptr());
-    if (custom_op_handler) {
+    py::object custom_op_handler = py::none();
+    if (PyDict_Check(custom_op_handlers.ptr())) {
+      PyObject* handler =
+          PyDict_GetItemWithError(custom_op_handlers.ptr(), py_op.ptr());
+      if (handler) {
+        custom_op_handler = py::reinterpret_borrow<py::object>(handler);
+      } else if (PyErr_Occurred()) {
+        throw py::error_already_set();
+      }
+    } else {
+      // DTensor subclasses may install an inheritance-aware custom handler map.
+      custom_op_handler = custom_op_handlers.attr("get")(py_op, py::none());
+    }
+    if (!custom_op_handler.is_none()) {
       auto result = checked_vectorcall(
-          custom_op_handler, py_op.ptr(), args.ptr(), kwargs.ptr());
+          custom_op_handler.ptr(), py_op.ptr(), args.ptr(), kwargs.ptr());
       stack->clear();
       return result;
-    } else if (PyErr_Occurred()) {
-      throw py::error_already_set();
     }
   }
 

--- a/torch/csrc/utils/python_arg_parser.cpp
+++ b/torch/csrc/utils/python_arg_parser.cpp
@@ -302,8 +302,10 @@ static py::object maybe_get_registered_torch_dispatch_rule(
 static bool is_dtensor(PyObject* obj) {
 #ifdef USE_DISTRIBUTED
   const py::handle dtensor = get_dtensor_class();
-  return (PyObject*)Py_TYPE(obj) == dtensor.ptr() ||
-      py::isinstance(py::handle(obj), dtensor);
+  // Reserve the DTensor C++ fast path for the exact DTensor type so
+  // subclasses can participate in the normal Python __torch_dispatch__
+  // protocol.
+  return (PyObject*)Py_TYPE(obj) == dtensor.ptr();
 #else
   return false;
 #endif

--- a/torch/distributed/tensor/_api.py
+++ b/torch/distributed/tensor/_api.py
@@ -54,6 +54,18 @@ __all__ = [
 aten = torch.ops.aten
 
 
+class _DTensorMeta(type(torch.Tensor)):
+    @classmethod
+    def __prepare__(mcls, name, bases, **kwargs):
+        namespace = super().__prepare__(name, bases, **kwargs)
+        for base in bases:
+            candidate = getattr(base, "_op_dispatcher", None)
+            if isinstance(candidate, op_dispatch.OpDispatcher):
+                namespace["_op_dispatcher"] = candidate.clone()
+                break
+        return namespace
+
+
 def _normalize_placements_for_grad(
     placements: tuple[Placement, ...],
 ) -> tuple[Placement, ...]:
@@ -287,7 +299,7 @@ class _FromTorchTensor(torch.autograd.Function):
         return grad_output.to_local(), None, None, None, None, None, None
 
 
-class DTensor(torch.Tensor):
+class DTensor(torch.Tensor, metaclass=_DTensorMeta):
     """
     ``DTensor`` (Distributed Tensor) is a subclass of ``torch.Tensor`` that provides single-device like
     abstraction to program with multi-device ``torch.Tensor``. It describes the distributed tensor sharding
@@ -370,6 +382,7 @@ class DTensor(torch.Tensor):
             return
 
         if dispatcher is not base_dispatcher:
+            dispatcher.rebase_random_ops(base_dispatcher)
             dispatcher.rebase_sharding_propagator(base_dispatcher)
             dispatcher.rebase_custom_op_handlers(base_dispatcher)
 

--- a/torch/distributed/tensor/_api.py
+++ b/torch/distributed/tensor/_api.py
@@ -371,6 +371,7 @@ class DTensor(torch.Tensor):
 
         if dispatcher is not base_dispatcher:
             dispatcher.rebase_sharding_propagator(base_dispatcher)
+            dispatcher.rebase_custom_op_handlers(base_dispatcher)
 
     # pyre-fixme[14]: `__repr__` overrides method defined in `DTensor` inconsistently.
     # pyre-fixme[3]: Return type must be annotated.

--- a/torch/distributed/tensor/_api.py
+++ b/torch/distributed/tensor/_api.py
@@ -349,6 +349,20 @@ class DTensor(torch.Tensor):
         """
         super().__init__()
 
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+
+        dispatcher = cls.__dict__.get("_op_dispatcher")
+        if not isinstance(dispatcher, op_dispatch.OpDispatcher):
+            return
+
+        for base_type in cls.__mro__[1:]:
+            base_dispatcher = getattr(base_type, "_op_dispatcher", None)
+            if isinstance(base_dispatcher, op_dispatch.OpDispatcher):
+                if dispatcher is not base_dispatcher:
+                    dispatcher.rebase_sharding_propagator(base_dispatcher)
+                return
+
     # pyre-fixme[14]: `__repr__` overrides method defined in `DTensor` inconsistently.
     # pyre-fixme[3]: Return type must be annotated.
     def __repr__(self):  # type: ignore[override]

--- a/torch/distributed/tensor/_api.py
+++ b/torch/distributed/tensor/_api.py
@@ -408,14 +408,16 @@ class DTensor(torch.Tensor):
         )
 
     @classmethod
+    @torch._disable_dynamo
     def __torch_dispatch__(cls, func, types, args=(), kwargs=None):  # type: ignore[override]
-        # We just need to have an implementation here; the __torch_dispatch__ machinery
-        # calls into a specific C++ fast path that doesn't call here.
-        # See #167051 for details
-        # python_arg_parser.cpp: dispatch_on_subclass()
-        # -> python_variable.cpp: dispatchDTensorOp()
-        raise NotImplementedError(
-            "DTensor.__torch_dispatch__ should not actually get called"
+        # Exact DTensor instances use the C++ fast path. DTensor subclasses
+        # still need the Python entrypoint so they can override
+        # __torch_dispatch__ or _op_dispatcher and delegate back here.
+        return cls._op_dispatcher.dispatch(
+            func,
+            args,
+            kwargs or {},
+            dtensor_type=cls,
         )
 
     @staticmethod

--- a/torch/distributed/tensor/_api.py
+++ b/torch/distributed/tensor/_api.py
@@ -364,7 +364,7 @@ class DTensor(torch.Tensor):
 
         dispatcher = cls.__dict__.get("_op_dispatcher")
         if dispatcher is None:
-            dispatcher = type(base_dispatcher)()
+            dispatcher = base_dispatcher.clone()
             cls._op_dispatcher = dispatcher
         elif not isinstance(dispatcher, op_dispatch.OpDispatcher):
             return
@@ -438,7 +438,8 @@ class DTensor(torch.Tensor):
         # Exact DTensor instances use the C++ fast path. DTensor subclasses
         # still need the Python entrypoint so they can override
         # __torch_dispatch__ or _op_dispatcher and delegate back here.
-        return cls._op_dispatcher.dispatch(
+        return op_dispatch._call_with_optional_dtensor_type_kwarg(
+            cls._op_dispatcher.dispatch,
             func,
             args,
             kwargs or {},

--- a/torch/distributed/tensor/_api.py
+++ b/torch/distributed/tensor/_api.py
@@ -352,16 +352,25 @@ class DTensor(torch.Tensor):
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
 
-        dispatcher = cls.__dict__.get("_op_dispatcher")
-        if not isinstance(dispatcher, op_dispatch.OpDispatcher):
+        base_dispatcher = None
+        for base_type in cls.__mro__[1:]:
+            candidate = getattr(base_type, "_op_dispatcher", None)
+            if isinstance(candidate, op_dispatch.OpDispatcher):
+                base_dispatcher = candidate
+                break
+
+        if base_dispatcher is None:
             return
 
-        for base_type in cls.__mro__[1:]:
-            base_dispatcher = getattr(base_type, "_op_dispatcher", None)
-            if isinstance(base_dispatcher, op_dispatch.OpDispatcher):
-                if dispatcher is not base_dispatcher:
-                    dispatcher.rebase_sharding_propagator(base_dispatcher)
-                return
+        dispatcher = cls.__dict__.get("_op_dispatcher")
+        if dispatcher is None:
+            dispatcher = type(base_dispatcher)()
+            cls._op_dispatcher = dispatcher
+        elif not isinstance(dispatcher, op_dispatch.OpDispatcher):
+            return
+
+        if dispatcher is not base_dispatcher:
+            dispatcher.rebase_sharding_propagator(base_dispatcher)
 
     # pyre-fixme[14]: `__repr__` overrides method defined in `DTensor` inconsistently.
     # pyre-fixme[3]: Return type must be annotated.

--- a/torch/distributed/tensor/_api.py
+++ b/torch/distributed/tensor/_api.py
@@ -376,8 +376,10 @@ class DTensor(torch.Tensor):
         """
         return ["_local_tensor"], (self._spec, self.requires_grad)
 
-    @staticmethod
-    def __tensor_unflatten__(inner_tensors, flatten_spec, outer_size, outer_stride):
+    @classmethod
+    def __tensor_unflatten__(
+        cls, inner_tensors, flatten_spec, outer_size, outer_stride
+    ):
         if flatten_spec is None:
             raise AssertionError(
                 "Expecting spec to be not None from `__tensor_flatten__` return value!"
@@ -395,7 +397,7 @@ class DTensor(torch.Tensor):
             tensor_meta=unflatten_tensor_meta,
         )
         # pyrefly: ignore [bad-argument-type]
-        return DTensor(
+        return cls(
             # pyrefly: ignore [bad-argument-count]
             local_tensor,
             unflatten_spec,

--- a/torch/distributed/tensor/_decompositions.py
+++ b/torch/distributed/tensor/_decompositions.py
@@ -97,11 +97,7 @@ class PlacementTrackingMode(TorchDispatchMode):
 
         # Set schema_info so the LRU cache key includes static args
         op_schema = OpSchema(func, args_schema, kwargs_schema)
-        schema_info = self.sharding_prop.op_to_schema_info.get(func)
-        if schema_info is None:
-            schema_info = (
-                self.sharding_prop.op_to_schema_info_for_single_dim_strategy.get(func)
-            )
+        schema_info = self.sharding_prop.get_schema_info(func)
         if schema_info is not None:
             op_schema.schema_info = schema_info
             op_schema._recompute_comparison_key()

--- a/torch/distributed/tensor/_dispatch.py
+++ b/torch/distributed/tensor/_dispatch.py
@@ -167,8 +167,8 @@ class OpDispatcher:
     """
 
     def __init__(self) -> None:
-        # DTensor subclasses should inherit the base dispatcher registrations,
-        # including runtime installs, without aliasing mutable propagator state.
+        # DTensor subclasses seed from the base dispatcher here and then rebase
+        # onto their nearest DTensor ancestor after class creation.
         base_dispatcher = getattr(
             getattr(dtensor, "DTensor", None), "_op_dispatcher", None
         )
@@ -204,6 +204,11 @@ class OpDispatcher:
             aten.argmin.default: argminmax_handler,
             aten.argmax.default: argminmax_handler,
         }
+
+    def rebase_sharding_propagator(self, base_dispatcher: "OpDispatcher") -> None:
+        if base_dispatcher is self:
+            return
+        self.sharding_propagator.rebase(base_dispatcher.sharding_propagator)
 
     # ********************************************************************************************
     # def dispatch(...)

--- a/torch/distributed/tensor/_dispatch.py
+++ b/torch/distributed/tensor/_dispatch.py
@@ -159,7 +159,17 @@ class OpDispatcher:
     """
 
     def __init__(self) -> None:
-        self.sharding_propagator = ShardingPropagator()
+        # DTensor op strategies and propagation rules are registered on the
+        # base DTensor dispatcher. Fresh subclass dispatchers should reuse
+        # that propagator so they inherit the same global registrations and
+        # any runtime extensions (for example CP sharding rules).
+        base_dispatcher = getattr(
+            getattr(dtensor, "DTensor", None), "_op_dispatcher", None
+        )
+        if isinstance(base_dispatcher, OpDispatcher):
+            self.sharding_propagator = base_dispatcher.sharding_propagator
+        else:
+            self.sharding_propagator = ShardingPropagator()
         # NOTE: must stay in sync with is_random_op in
         # torch/csrc/autograd/python_variable.cpp
         self._random_ops = {

--- a/torch/distributed/tensor/_dispatch.py
+++ b/torch/distributed/tensor/_dispatch.py
@@ -1,8 +1,10 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
 import contextlib
+import inspect
 import logging
 import warnings
 from collections.abc import Sequence
+from functools import lru_cache
 from typing import cast
 
 import torch
@@ -207,6 +209,33 @@ def _is_explicit_default_handler(
     )
 
 
+def _handler_accepts_dtensor_type_kwarg(handler: object) -> bool:
+    try:
+        return _handler_accepts_dtensor_type_kwarg_cached(handler)
+    except TypeError:
+        return _handler_accepts_dtensor_type_kwarg_uncached(handler)
+
+
+@lru_cache(maxsize=None)
+def _handler_accepts_dtensor_type_kwarg_cached(handler: object) -> bool:
+    return _handler_accepts_dtensor_type_kwarg_uncached(handler)
+
+
+def _handler_accepts_dtensor_type_kwarg_uncached(handler: object) -> bool:
+    try:
+        signature = inspect.signature(handler)
+    except (TypeError, ValueError):
+        return False
+
+    if "dtensor_type" in signature.parameters:
+        return True
+
+    return any(
+        parameter.kind is inspect.Parameter.VAR_KEYWORD
+        for parameter in signature.parameters.values()
+    )
+
+
 class OpDispatcher:
     """
     Op dispatching class instance to handle args/kwargs pre-processing (un-wrapping), sharding
@@ -335,12 +364,14 @@ class OpDispatcher:
         dtensor_type = dtensor.DTensor if dtensor_type is None else dtensor_type
         handler = self._get_custom_op_handler(op_call, dtensor_type)
         if handler is not None:
-            return handler(  # type: ignore[operator]
-                op_call,
-                args,
-                kwargs,
-                dtensor_type=dtensor_type,
-            )
+            if _handler_accepts_dtensor_type_kwarg(handler):
+                return handler(  # type: ignore[operator]
+                    op_call,
+                    args,
+                    kwargs,
+                    dtensor_type=dtensor_type,
+                )
+            return handler(op_call, args, kwargs)  # type: ignore[operator]
 
         op_info = self.unwrap_to_op_info(op_call, args, kwargs)
 

--- a/torch/distributed/tensor/_dispatch.py
+++ b/torch/distributed/tensor/_dispatch.py
@@ -103,7 +103,10 @@ def found_inf_reduce_handler(
     args: tuple[object, ...],
     kwargs: dict[str, object],
 ) -> None:
-    op_info = dtensor.DTensor._op_dispatcher.unwrap_to_op_info(op_call, args, kwargs)
+    grad_dtensor = cast(list[dtensor.DTensor], args[0])[0]
+    op_info = grad_dtensor.__class__._op_dispatcher.unwrap_to_op_info(
+        op_call, args, kwargs
+    )
     local_tensor_args = pytree.tree_unflatten(
         cast(list[object], op_info.local_args),
         op_info.args_tree_spec,  # type: ignore[arg-type]
@@ -111,7 +114,6 @@ def found_inf_reduce_handler(
     local_tensor_args = cast(tuple[object, ...], local_tensor_args)
     op_call(*local_tensor_args, **op_info.local_kwargs)
 
-    grad_dtensor = cast(list[dtensor.DTensor], args[0])[0]
     grad_placements = grad_dtensor.placements
     mesh = grad_dtensor.device_mesh
 
@@ -207,6 +209,105 @@ class OpDispatcher:
     @_allow_implicit_replication.setter
     def _allow_implicit_replication(self, value: bool) -> None:
         return torch._C._set_dtensor_allow_implicit_replication(value)
+
+    def dispatch(
+        self,
+        op_call: torch._ops.OpOverload,
+        args: tuple[object, ...],
+        kwargs: dict[str, object],
+        *,
+        dtensor_type: type[dtensor.DTensor] = dtensor.DTensor,
+    ) -> object:
+        """
+        Python DTensor dispatch entrypoint used by DTensor subclasses.
+
+        Exact DTensor instances are handled by the C++ fast path, but
+        subclasses still rely on Python __torch_dispatch__ so they can
+        customize dispatch and delegate back to the base implementation.
+        """
+        if op_call in self._custom_op_handlers:
+            return self._custom_op_handlers[op_call](op_call, args, kwargs)  # type: ignore[operator]
+
+        op_info = self.unwrap_to_op_info(op_call, args, kwargs)
+
+        sharding = self._propagate_op_sharding_dispatch_slow_path(
+            op_call,
+            args,
+            kwargs,
+            op_info,
+            try_cache=not _are_we_tracing(),
+        )
+        if not isinstance(sharding, OutputSharding):
+            return sharding
+        op_info.output_sharding = sharding
+
+        local_results = self._dispatch_get_local_results_slow_path(
+            op_call, args, op_info
+        )
+        output_sharding = op_info.output_sharding
+        if output_sharding is None:
+            raise AssertionError("output sharding should not be None")
+
+        participating = op_info.compute_mesh._is_current_rank_part_of_mesh()
+        if output_sharding.output_spec is None and op_call == aten.equal.default:
+            if not (local_results is None or isinstance(local_results, bool)):
+                raise AssertionError
+            reduced = torch.tensor(
+                int(local_results) if local_results is not None else 1,
+                device=op_info.compute_mesh.device_type,
+            )
+            dist.all_reduce(reduced, op=dist.ReduceOp.MIN)
+            local_results = bool(reduced.item())
+
+        if op_info.schema is None:
+            raise AssertionError("op_info.schema should not be None")
+
+        if op_info.schema.is_inplace_op():
+            if output_sharding.output_spec is not None:
+                output_spec = output_sharding.output_spec
+                if not isinstance(output_spec, DTensorSpec):
+                    raise AssertionError
+                if not isinstance(args[0], dtensor.DTensor):
+                    raise AssertionError
+
+                if op_call == aten.squeeze_.dim:
+                    args[0]._spec = output_spec
+                    return return_and_correct_aliasing(op_call, args, kwargs, args[0])
+
+                if args[0]._spec.placements != output_spec.placements:
+                    raise RuntimeError(
+                        f"{op_call}: in-place operations that require placement changes "
+                        f"are not supported. The operation would change placement from "
+                        f"{args[0]._spec.placements} to {output_spec.placements}, "
+                        f"which requires redistribution and breaks aliasing semantics. "
+                        f"Please use the out-of-place version of this operation instead."
+                    )
+                return args[0]
+            return None
+
+        if op_info.schema.is_out_variant_op():
+            output_specs = (
+                (output_sharding.output_spec,)
+                if not isinstance(output_sharding.output_spec, tuple)
+                else output_sharding.output_spec
+            )
+            out_dts = []
+            spec_idx = 0
+            for argument in op_call._schema.arguments:
+                if argument.is_out:
+                    out_dt = cast(dtensor.DTensor, kwargs[argument.name])
+                    out_dt._spec = cast(DTensorSpec, output_specs[spec_idx])
+                    out_dts.append(out_dt)
+                    spec_idx += 1
+
+            if len(out_dts) < 1:
+                raise AssertionError("out variant should have at least one out arg")
+            return tuple(out_dts) if len(out_dts) > 1 else out_dts[0]
+
+        ret = self.wrap(local_results, output_sharding.output_spec, dtensor_type)
+        if participating and op_info.schema.is_view_op():
+            return return_and_correct_aliasing(op_call, args, kwargs, ret)
+        return ret
 
     def _propagate_op_sharding_dispatch_slow_path(
         self,
@@ -720,7 +821,11 @@ class OpDispatcher:
         return op_info
 
     @staticmethod
-    def wrap(res: object, spec: OutputSpecType) -> object:
+    def wrap(
+        res: object,
+        spec: OutputSpecType,
+        dtensor_type: type[dtensor.DTensor] = dtensor.DTensor,
+    ) -> object:
         if isinstance(res, torch.Tensor):
             if spec is not None:
                 if not isinstance(spec, DTensorSpec):
@@ -728,7 +833,7 @@ class OpDispatcher:
                         f"output spec does not match with output! Expected DTensorSpec, got {spec}."
                     )
                 # pyrefly: ignore [bad-argument-type, bad-argument-count, unexpected-keyword]
-                return dtensor.DTensor(res, spec, requires_grad=res.requires_grad)
+                return dtensor_type(res, spec, requires_grad=res.requires_grad)
             else:
                 # if output does not have a DTensorSpec due to specific ops, it must be a scalar tensor
                 if res.ndim != 0:
@@ -742,7 +847,7 @@ class OpDispatcher:
             res_list = []
             for e, s in zip(res, spec):
                 # pyrefly: ignore [bad-argument-type]
-                res_list.append(OpDispatcher.wrap(e, s))
+                res_list.append(OpDispatcher.wrap(e, s, dtensor_type))
 
             return tuple(res_list) if isinstance(res, tuple) else res_list
         else:

--- a/torch/distributed/tensor/_dispatch.py
+++ b/torch/distributed/tensor/_dispatch.py
@@ -4,8 +4,8 @@ import copy
 import inspect
 import logging
 import warnings
-from collections.abc import Sequence
-from functools import lru_cache
+from collections.abc import Callable, Iterator, Mapping, MutableMapping, Sequence
+from functools import cache
 from typing import cast
 
 import torch
@@ -167,47 +167,138 @@ DEFAULT_CUSTOM_OP_HANDLERS = {
 }
 
 
-class _CustomOpHandlerMap(dict[torch._ops.OpOverload, object]):
+class _CustomOpHandlerMap(MutableMapping[torch._ops.OpOverload, object]):
     _missing = object()
+    _masked = object()
 
-    def __init__(self, *args, explicit_keys=None, **kwargs) -> None:
-        super().__init__(*args, **kwargs)
+    def __init__(
+        self,
+        initial: Mapping[torch._ops.OpOverload, object] | None = None,
+        *,
+        explicit_keys: set[torch._ops.OpOverload] | None = None,
+        base_handlers: "_CustomOpHandlerMap | None" = None,
+    ) -> None:
+        self._handlers: dict[torch._ops.OpOverload, object] = (
+            {} if initial is None else dict(initial)
+        )
         self._explicit_keys: set[torch._ops.OpOverload] = (
             set() if explicit_keys is None else set(explicit_keys)
         )
+        self._base_handlers = base_handlers
+
+    def _resolve_from_base(self, key: torch._ops.OpOverload) -> object:
+        if self._base_handlers is None:
+            return self._missing
+        return self._base_handlers._resolve(key)
+
+    def _resolve(self, key: torch._ops.OpOverload) -> object:
+        local_value = self._handlers.get(key, self._missing)
+        if local_value is self._masked:
+            return self._missing
+
+        if local_value is not self._missing:
+            default_handler = DEFAULT_CUSTOM_OP_HANDLERS.get(key)
+            if local_value is default_handler and key not in self._explicit_keys:
+                inherited_value = self._resolve_from_base(key)
+                if inherited_value is not self._missing:
+                    return inherited_value
+            return local_value
+
+        inherited_value = self._resolve_from_base(key)
+        if inherited_value is not self._missing:
+            return inherited_value
+
+        return DEFAULT_CUSTOM_OP_HANDLERS.get(key, self._missing)
+
+    def _resolve_without_local(self, key: torch._ops.OpOverload) -> object:
+        inherited_value = self._resolve_from_base(key)
+        if inherited_value is not self._missing:
+            return inherited_value
+        return DEFAULT_CUSTOM_OP_HANDLERS.get(key, self._missing)
+
+    def rebase(self, base_handlers: "_CustomOpHandlerMap") -> None:
+        self._base_handlers = base_handlers
+
+    def __getitem__(self, key: torch._ops.OpOverload) -> object:
+        value = self._resolve(key)
+        if value is self._missing:
+            raise KeyError(key)
+        return value
 
     def __setitem__(self, key: torch._ops.OpOverload, value: object) -> None:
         self._explicit_keys.add(key)
-        super().__setitem__(key, value)
+        self._handlers[key] = value
+
+    def __delitem__(self, key: torch._ops.OpOverload) -> None:
+        self.pop(key)
+
+    def __iter__(self) -> Iterator[torch._ops.OpOverload]:
+        seen: set[torch._ops.OpOverload] = set()
+        for key in self._handlers:
+            seen.add(key)
+            if self._resolve(key) is not self._missing:
+                yield key
+
+        if self._base_handlers is not None:
+            for key in self._base_handlers:
+                if key in seen:
+                    continue
+                seen.add(key)
+                if self._resolve(key) is not self._missing:
+                    yield key
+
+        for key in DEFAULT_CUSTOM_OP_HANDLERS:
+            if key in seen:
+                continue
+            if self._resolve(key) is not self._missing:
+                yield key
+
+    def __len__(self) -> int:
+        return sum(1 for _ in self)
+
+    def __contains__(self, key: object) -> bool:
+        if not isinstance(key, torch._ops.OpOverload):
+            return False
+        return self._resolve(key) is not self._missing
+
+    def get(
+        self,
+        key: torch._ops.OpOverload,
+        default: object | None = None,
+    ) -> object | None:
+        value = self._resolve(key)
+        if value is self._missing:
+            return default
+        return value
 
     def pop(self, key, default=_missing):
-        self._explicit_keys.discard(key)
-        if default is self._missing:
-            return super().pop(key)
-        return super().pop(key, default)
+        current_value = self._resolve(key)
+        if current_value is self._missing:
+            if default is self._missing:
+                raise KeyError(key)
+            return default
 
-    def update(self, *args, **kwargs) -> None:
-        updates = dict(*args, **kwargs)
-        self._explicit_keys.update(updates)
-        super().update(updates)
+        self._handlers.pop(key, None)
+        self._explicit_keys.discard(key)
+        if self._resolve_without_local(key) is not self._missing:
+            self._handlers[key] = self._masked
+            self._explicit_keys.add(key)
+
+        return current_value
+
+    def update(self, other: Mapping[torch._ops.OpOverload, object]) -> None:
+        for key, value in other.items():
+            self[key] = value
 
     def copy(self):
-        return type(self)(self, explicit_keys=self._explicit_keys)
+        return type(self)(
+            self._handlers,
+            explicit_keys=self._explicit_keys,
+            base_handlers=self._base_handlers,
+        )
 
     def is_explicit(self, key: torch._ops.OpOverload) -> bool:
         return key in self._explicit_keys
-
-
-def _is_explicit_default_handler(
-    handlers: dict[torch._ops.OpOverload, object],
-    op_call: torch._ops.OpOverload,
-    handler: object,
-) -> bool:
-    return (
-        handler is DEFAULT_CUSTOM_OP_HANDLERS.get(op_call)
-        and isinstance(handlers, _CustomOpHandlerMap)
-        and handlers.is_explicit(op_call)
-    )
 
 
 def _handler_accepts_dtensor_type_kwarg(handler: object) -> bool:
@@ -217,14 +308,14 @@ def _handler_accepts_dtensor_type_kwarg(handler: object) -> bool:
         return _handler_accepts_dtensor_type_kwarg_uncached(handler)
 
 
-@lru_cache(maxsize=None)
+@cache
 def _handler_accepts_dtensor_type_kwarg_cached(handler: object) -> bool:
     return _handler_accepts_dtensor_type_kwarg_uncached(handler)
 
 
 def _handler_accepts_dtensor_type_kwarg_uncached(handler: object) -> bool:
     try:
-        signature = inspect.signature(handler)
+        signature = inspect.signature(cast(Callable[..., object], handler))
     except (TypeError, ValueError):
         return False
 
@@ -298,12 +389,14 @@ class OpDispatcher:
             aten.bernoulli.default,
             aten.bernoulli_.float,
         }
-        self._custom_op_handlers = _CustomOpHandlerMap(DEFAULT_CUSTOM_OP_HANDLERS)
+        self._custom_op_handlers = _CustomOpHandlerMap()
 
     def clone(self) -> "OpDispatcher":
         cloned = copy.copy(self)
         cloned._random_ops = set(self._random_ops)
-        cloned._custom_op_handlers = self._custom_op_handlers.copy()
+        cloned._custom_op_handlers = _CustomOpHandlerMap(
+            base_handlers=self._custom_op_handlers
+        )
         cloned.sharding_propagator = ShardingPropagator(self.sharding_propagator)
         return cloned
 
@@ -311,6 +404,11 @@ class OpDispatcher:
         if base_dispatcher is self:
             return
         self.sharding_propagator.rebase(base_dispatcher.sharding_propagator)
+
+    def rebase_custom_op_handlers(self, base_dispatcher: "OpDispatcher") -> None:
+        if base_dispatcher is self:
+            return
+        self._custom_op_handlers.rebase(base_dispatcher._custom_op_handlers)
 
     # ********************************************************************************************
     # def dispatch(...)
@@ -338,40 +436,9 @@ class OpDispatcher:
     def _get_custom_op_handler(
         self,
         op_call: torch._ops.OpOverload,
-        dtensor_type: "type[dtensor.DTensor]",
+        _dtensor_type: "type[dtensor.DTensor]",
     ):
-        handler = self._custom_op_handlers.get(op_call)
-        default_handler = DEFAULT_CUSTOM_OP_HANDLERS.get(op_call)
-        if handler is not None:
-            if handler is not default_handler:
-                return handler
-            if _is_explicit_default_handler(
-                self._custom_op_handlers,
-                op_call,
-                handler,
-            ):
-                return handler
-
-        inherited_handler = None
-        for base_type in dtensor_type.__mro__[1:]:
-            dispatcher = getattr(base_type, "_op_dispatcher", None)
-            if not isinstance(dispatcher, OpDispatcher) or dispatcher is self:
-                continue
-            base_handler = dispatcher._custom_op_handlers.get(op_call)
-            if base_handler is None:
-                continue
-            if inherited_handler is None:
-                inherited_handler = base_handler
-            if base_handler is not DEFAULT_CUSTOM_OP_HANDLERS.get(op_call) or (
-                _is_explicit_default_handler(
-                    dispatcher._custom_op_handlers,
-                    op_call,
-                    base_handler,
-                )
-            ):
-                return base_handler
-
-        return handler if handler is not None else inherited_handler
+        return self._custom_op_handlers.get(op_call)
 
     def dispatch(
         self,

--- a/torch/distributed/tensor/_dispatch.py
+++ b/torch/distributed/tensor/_dispatch.py
@@ -195,6 +195,18 @@ class _CustomOpHandlerMap(dict[torch._ops.OpOverload, object]):
         return key in self._explicit_keys
 
 
+def _is_explicit_default_handler(
+    handlers: dict[torch._ops.OpOverload, object],
+    op_call: torch._ops.OpOverload,
+    handler: object,
+) -> bool:
+    return (
+        handler is DEFAULT_CUSTOM_OP_HANDLERS.get(op_call)
+        and isinstance(handlers, _CustomOpHandlerMap)
+        and handlers.is_explicit(op_call)
+    )
+
+
 class OpDispatcher:
     """
     Op dispatching class instance to handle args/kwargs pre-processing (un-wrapping), sharding
@@ -277,9 +289,12 @@ class OpDispatcher:
         if handler is not None:
             if handler is not default_handler:
                 return handler
-            if isinstance(self._custom_op_handlers, _CustomOpHandlerMap):
-                if self._custom_op_handlers.is_explicit(op_call):
-                    return handler
+            if _is_explicit_default_handler(
+                self._custom_op_handlers,
+                op_call,
+                handler,
+            ):
+                return handler
 
         inherited_handler = None
         for base_type in dtensor_type.__mro__[1:]:
@@ -291,7 +306,13 @@ class OpDispatcher:
                 continue
             if inherited_handler is None:
                 inherited_handler = base_handler
-            if base_handler is not DEFAULT_CUSTOM_OP_HANDLERS.get(op_call):
+            if base_handler is not DEFAULT_CUSTOM_OP_HANDLERS.get(op_call) or (
+                _is_explicit_default_handler(
+                    dispatcher._custom_op_handlers,
+                    op_call,
+                    base_handler,
+                )
+            ):
                 return base_handler
 
         return handler if handler is not None else inherited_handler

--- a/torch/distributed/tensor/_dispatch.py
+++ b/torch/distributed/tensor/_dispatch.py
@@ -210,13 +210,31 @@ class OpDispatcher:
     def _allow_implicit_replication(self, value: bool) -> None:
         return torch._C._set_dtensor_allow_implicit_replication(value)
 
+    def _get_custom_op_handler(
+        self,
+        op_call: torch._ops.OpOverload,
+        dtensor_type: "type[dtensor.DTensor]",
+    ):
+        handler = self._custom_op_handlers.get(op_call)
+        if handler is not None:
+            return handler
+
+        for base_type in dtensor_type.__mro__[1:]:
+            dispatcher = getattr(base_type, "_op_dispatcher", None)
+            if not isinstance(dispatcher, OpDispatcher) or dispatcher is self:
+                continue
+            handler = dispatcher._custom_op_handlers.get(op_call)
+            if handler is not None:
+                return handler
+        return None
+
     def dispatch(
         self,
         op_call: torch._ops.OpOverload,
         args: tuple[object, ...],
         kwargs: dict[str, object],
         *,
-        dtensor_type: type[dtensor.DTensor] = dtensor.DTensor,
+        dtensor_type: "type[dtensor.DTensor] | None" = None,
     ) -> object:
         """
         Python DTensor dispatch entrypoint used by DTensor subclasses.
@@ -225,8 +243,10 @@ class OpDispatcher:
         subclasses still rely on Python __torch_dispatch__ so they can
         customize dispatch and delegate back to the base implementation.
         """
-        if op_call in self._custom_op_handlers:
-            return self._custom_op_handlers[op_call](op_call, args, kwargs)  # type: ignore[operator]
+        dtensor_type = dtensor.DTensor if dtensor_type is None else dtensor_type
+        handler = self._get_custom_op_handler(op_call, dtensor_type)
+        if handler is not None:
+            return handler(op_call, args, kwargs)  # type: ignore[operator]
 
         op_info = self.unwrap_to_op_info(op_call, args, kwargs)
 
@@ -824,8 +844,9 @@ class OpDispatcher:
     def wrap(
         res: object,
         spec: OutputSpecType,
-        dtensor_type: type[dtensor.DTensor] = dtensor.DTensor,
+        dtensor_type: "type[dtensor.DTensor] | None" = None,
     ) -> object:
+        dtensor_type = dtensor.DTensor if dtensor_type is None else dtensor_type
         if isinstance(res, torch.Tensor):
             if spec is not None:
                 if not isinstance(spec, DTensorSpec):

--- a/torch/distributed/tensor/_dispatch.py
+++ b/torch/distributed/tensor/_dispatch.py
@@ -65,6 +65,8 @@ def as_strided_handler(
     op_call: torch._ops.OpOverload,
     args: tuple[object, ...],
     kwargs: dict[str, object],
+    *,
+    dtensor_type: "type[dtensor.DTensor] | None" = None,
 ):
     args, kwargs = fill_defaults(op_call._schema, args, kwargs)
     if kwargs:
@@ -83,6 +85,8 @@ def is_same_size_handler(
     op_call: torch._ops.OpOverload,
     args: tuple[object, ...],
     kwargs: dict[str, object],
+    *,
+    dtensor_type: "type[dtensor.DTensor] | None" = None,
 ) -> bool:
     lhs = cast(torch.Tensor, args[0])
     rhs = cast(torch.Tensor, args[1])
@@ -93,6 +97,8 @@ def is_pinned_handler(
     op_call: torch._ops.OpOverload,
     args: tuple[object, ...],
     kwargs: dict[str, object],
+    *,
+    dtensor_type: "type[dtensor.DTensor] | None" = None,
 ) -> bool:
     tensor = cast(dtensor.DTensor, args[0])
     return tensor._local_tensor.is_pinned()
@@ -102,6 +108,8 @@ def found_inf_reduce_handler(
     op_call: torch._ops.OpOverload,
     args: tuple[object, ...],
     kwargs: dict[str, object],
+    *,
+    dtensor_type: "type[dtensor.DTensor] | None" = None,
 ) -> None:
     grad_dtensor = cast(list[dtensor.DTensor], args[0])[0]
     op_info = grad_dtensor.__class__._op_dispatcher.unwrap_to_op_info(
@@ -159,17 +167,17 @@ class OpDispatcher:
     """
 
     def __init__(self) -> None:
-        # DTensor op strategies and propagation rules are registered on the
-        # base DTensor dispatcher. Fresh subclass dispatchers should reuse
-        # that propagator so they inherit the same global registrations and
-        # any runtime extensions (for example CP sharding rules).
+        # DTensor subclasses should inherit the base dispatcher registrations,
+        # including runtime installs, without aliasing mutable propagator state.
         base_dispatcher = getattr(
             getattr(dtensor, "DTensor", None), "_op_dispatcher", None
         )
-        if isinstance(base_dispatcher, OpDispatcher):
-            self.sharding_propagator = base_dispatcher.sharding_propagator
-        else:
-            self.sharding_propagator = ShardingPropagator()
+        base_propagator = (
+            base_dispatcher.sharding_propagator
+            if isinstance(base_dispatcher, OpDispatcher)
+            else None
+        )
+        self.sharding_propagator = ShardingPropagator(base_propagator)
         # NOTE: must stay in sync with is_random_op in
         # torch/csrc/autograd/python_variable.cpp
         self._random_ops = {
@@ -256,7 +264,12 @@ class OpDispatcher:
         dtensor_type = dtensor.DTensor if dtensor_type is None else dtensor_type
         handler = self._get_custom_op_handler(op_call, dtensor_type)
         if handler is not None:
-            return handler(op_call, args, kwargs)  # type: ignore[operator]
+            return handler(  # type: ignore[operator]
+                op_call,
+                args,
+                kwargs,
+                dtensor_type=dtensor_type,
+            )
 
         op_info = self.unwrap_to_op_info(op_call, args, kwargs)
 

--- a/torch/distributed/tensor/_dispatch.py
+++ b/torch/distributed/tensor/_dispatch.py
@@ -4,7 +4,8 @@ import copy
 import inspect
 import logging
 import warnings
-from collections.abc import Callable, Iterator, Mapping, MutableMapping, Sequence
+import weakref
+from collections.abc import Callable, Mapping, Sequence
 from functools import cache
 from typing import cast
 
@@ -167,7 +168,23 @@ DEFAULT_CUSTOM_OP_HANDLERS = {
 }
 
 
-class _CustomOpHandlerMap(MutableMapping[torch._ops.OpOverload, object]):
+DEFAULT_RANDOM_OPS = {
+    aten.native_dropout.default,
+    aten.normal_.default,
+    aten.rand.default,
+    aten.rand_like.default,
+    aten.randn.default,
+    aten.randn_like.default,
+    aten.randint_like.default,
+    aten.randint_like.low_dtype,
+    aten.randint_like.low_dtype_out,
+    aten.uniform_.default,
+    aten.bernoulli.default,
+    aten.bernoulli_.float,
+}
+
+
+class _CustomOpHandlerMap(dict[torch._ops.OpOverload, object]):
     _missing = object()
     _masked = object()
 
@@ -178,117 +195,102 @@ class _CustomOpHandlerMap(MutableMapping[torch._ops.OpOverload, object]):
         explicit_keys: set[torch._ops.OpOverload] | None = None,
         base_handlers: "_CustomOpHandlerMap | None" = None,
     ) -> None:
-        self._handlers: dict[torch._ops.OpOverload, object] = (
+        super().__init__()
+        self._local_handlers: dict[torch._ops.OpOverload, object] = (
             {} if initial is None else dict(initial)
         )
         self._explicit_keys: set[torch._ops.OpOverload] = (
             set() if explicit_keys is None else set(explicit_keys)
         )
+        self._base_handlers: _CustomOpHandlerMap | None = None
+        self._child_maps: weakref.WeakSet[_CustomOpHandlerMap] = weakref.WeakSet()
+        if base_handlers is not None:
+            self._set_base_handlers(base_handlers)
+        self._refresh_effective_handlers()
+
+    def _set_base_handlers(self, base_handlers: "_CustomOpHandlerMap") -> None:
+        if self._base_handlers is base_handlers:
+            return
+        if self._base_handlers is not None:
+            self._base_handlers._child_maps.discard(self)
         self._base_handlers = base_handlers
+        base_handlers._child_maps.add(self)
 
     def _resolve_from_base(self, key: torch._ops.OpOverload) -> object:
         if self._base_handlers is None:
-            return self._missing
-        return self._base_handlers._resolve(key)
-
-    def _resolve(self, key: torch._ops.OpOverload) -> object:
-        local_value = self._handlers.get(key, self._missing)
-        if local_value is self._masked:
-            return self._missing
-
-        if local_value is not self._missing:
-            default_handler = DEFAULT_CUSTOM_OP_HANDLERS.get(key)
-            if local_value is default_handler and key not in self._explicit_keys:
-                inherited_value = self._resolve_from_base(key)
-                if inherited_value is not self._missing:
-                    return inherited_value
-            return local_value
-
-        inherited_value = self._resolve_from_base(key)
-        if inherited_value is not self._missing:
-            return inherited_value
-
-        return DEFAULT_CUSTOM_OP_HANDLERS.get(key, self._missing)
+            return DEFAULT_CUSTOM_OP_HANDLERS.get(key, self._missing)
+        return self._base_handlers.get(key, self._missing)
 
     def _resolve_without_local(self, key: torch._ops.OpOverload) -> object:
         inherited_value = self._resolve_from_base(key)
-        if inherited_value is not self._missing:
-            return inherited_value
-        return DEFAULT_CUSTOM_OP_HANDLERS.get(key, self._missing)
+        return inherited_value
+
+    def _refresh_effective_handlers(self) -> None:
+        effective_handlers = dict(
+            DEFAULT_CUSTOM_OP_HANDLERS
+            if self._base_handlers is None
+            else self._base_handlers.items()
+        )
+        for key, value in self._local_handlers.items():
+            if value is self._masked:
+                effective_handlers.pop(key, None)
+                continue
+
+            default_handler = DEFAULT_CUSTOM_OP_HANDLERS.get(key)
+            if value is default_handler and key not in self._explicit_keys:
+                inherited_value = self._resolve_from_base(key)
+                if inherited_value is not self._missing:
+                    effective_handlers[key] = inherited_value
+                    continue
+
+            effective_handlers[key] = value
+
+        super().clear()
+        super().update(effective_handlers)
+
+    def _refresh_self_and_descendants(self) -> None:
+        self._refresh_effective_handlers()
+        for child in list(self._child_maps):
+            child._refresh_self_and_descendants()
 
     def rebase(self, base_handlers: "_CustomOpHandlerMap") -> None:
-        self._base_handlers = base_handlers
+        if base_handlers is self:
+            return
+        self._set_base_handlers(base_handlers)
+        self._refresh_self_and_descendants()
 
-    def __getitem__(self, key: torch._ops.OpOverload) -> object:
-        value = self._resolve(key)
-        if value is self._missing:
-            raise KeyError(key)
-        return value
-
-    def __setitem__(self, key: torch._ops.OpOverload, value: object) -> None:
+    def __setitem__(self, key: torch._ops.OpOverload, value: object) -> None:  # type: ignore[override]
         self._explicit_keys.add(key)
-        self._handlers[key] = value
+        self._local_handlers[key] = value
+        self._refresh_self_and_descendants()
 
-    def __delitem__(self, key: torch._ops.OpOverload) -> None:
+    def __delitem__(self, key: torch._ops.OpOverload) -> None:  # type: ignore[override]
         self.pop(key)
 
-    def __iter__(self) -> Iterator[torch._ops.OpOverload]:
-        seen: set[torch._ops.OpOverload] = set()
-        for key in self._handlers:
-            seen.add(key)
-            if self._resolve(key) is not self._missing:
-                yield key
+    def update(self, *args, **kwargs) -> None:  # type: ignore[override]
+        other = dict(*args, **kwargs)
+        for key, value in other.items():
+            self[key] = value
 
-        if self._base_handlers is not None:
-            for key in self._base_handlers:
-                if key in seen:
-                    continue
-                seen.add(key)
-                if self._resolve(key) is not self._missing:
-                    yield key
-
-        for key in DEFAULT_CUSTOM_OP_HANDLERS:
-            if key in seen:
-                continue
-            if self._resolve(key) is not self._missing:
-                yield key
-
-    def __len__(self) -> int:
-        return sum(1 for _ in self)
-
-    def __contains__(self, key: object) -> bool:
-        if not isinstance(key, torch._ops.OpOverload):
-            return False
-        return self._resolve(key) is not self._missing
-
-    def get(
-        self,
-        key: torch._ops.OpOverload,
-        default: object | None = None,
-    ) -> object | None:
-        value = self._resolve(key)
-        if value is self._missing:
-            return default
-        return value
-
-    def pop(self, key, default=_missing):
-        current_value = self._resolve(key)
+    def pop(self, key, default=_missing):  # type: ignore[override]
+        current_value = super().get(key, self._missing)
         if current_value is self._missing:
             if default is self._missing:
                 raise KeyError(key)
             return default
 
-        self._handlers.pop(key, None)
+        self._local_handlers.pop(key, None)
         self._explicit_keys.discard(key)
         if self._resolve_without_local(key) is not self._missing:
-            self._handlers[key] = self._masked
+            self._local_handlers[key] = self._masked
             self._explicit_keys.add(key)
+        self._refresh_self_and_descendants()
 
         return current_value
 
     def copy(self):
         return type(self)(
-            self._handlers,
+            self._local_handlers,
             explicit_keys=self._explicit_keys,
             base_handlers=self._base_handlers,
         )
@@ -299,9 +301,9 @@ class _CustomOpHandlerMap(MutableMapping[torch._ops.OpOverload, object]):
     def _snapshot_local_entry(
         self, key: torch._ops.OpOverload
     ) -> tuple[bool, object, bool]:
-        if key not in self._handlers:
+        if key not in self._local_handlers:
             return False, self._missing, False
-        return True, self._handlers[key], key in self._explicit_keys
+        return True, self._local_handlers[key], key in self._explicit_keys
 
     def _restore_local_entry(
         self,
@@ -310,15 +312,17 @@ class _CustomOpHandlerMap(MutableMapping[torch._ops.OpOverload, object]):
     ) -> None:
         present, value, explicit = entry
         if not present:
-            self._handlers.pop(key, None)
+            self._local_handlers.pop(key, None)
             self._explicit_keys.discard(key)
+            self._refresh_self_and_descendants()
             return
 
-        self._handlers[key] = value
+        self._local_handlers[key] = value
         if explicit:
             self._explicit_keys.add(key)
         else:
             self._explicit_keys.discard(key)
+        self._refresh_self_and_descendants()
 
 
 def _handler_accepts_dtensor_type_kwarg(handler: object) -> bool:
@@ -395,20 +399,7 @@ class OpDispatcher:
         self.sharding_propagator = ShardingPropagator(base_propagator)
         # NOTE: must stay in sync with is_random_op in
         # torch/csrc/autograd/python_variable.cpp
-        self._random_ops = {
-            aten.native_dropout.default,
-            aten.normal_.default,
-            aten.rand.default,
-            aten.rand_like.default,
-            aten.randn.default,
-            aten.randn_like.default,
-            aten.randint_like.default,
-            aten.randint_like.low_dtype,
-            aten.randint_like.low_dtype_out,
-            aten.uniform_.default,
-            aten.bernoulli.default,
-            aten.bernoulli_.float,
-        }
+        self._random_ops = set(DEFAULT_RANDOM_OPS)
         self._custom_op_handlers = _CustomOpHandlerMap()
 
     def clone(self) -> "OpDispatcher":
@@ -429,6 +420,11 @@ class OpDispatcher:
         if base_dispatcher is self:
             return
         self._custom_op_handlers.rebase(base_dispatcher._custom_op_handlers)
+
+    def rebase_random_ops(self, base_dispatcher: "OpDispatcher") -> None:
+        if base_dispatcher is self:
+            return
+        self._random_ops.update(base_dispatcher._random_ops)
 
     # ********************************************************************************************
     # def dispatch(...)

--- a/torch/distributed/tensor/_dispatch.py
+++ b/torch/distributed/tensor/_dispatch.py
@@ -1,5 +1,6 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
 import contextlib
+import copy
 import inspect
 import logging
 import warnings
@@ -236,6 +237,25 @@ def _handler_accepts_dtensor_type_kwarg_uncached(handler: object) -> bool:
     )
 
 
+def _call_with_optional_dtensor_type_kwarg(
+    callable_obj: object,
+    op_call: torch._ops.OpOverload,
+    args: tuple[object, ...],
+    kwargs: dict[str, object],
+    *,
+    dtensor_type: "type[dtensor.DTensor]",
+) -> object:
+    signature_target = getattr(callable_obj, "__func__", callable_obj)
+    if _handler_accepts_dtensor_type_kwarg(signature_target):
+        return callable_obj(  # type: ignore[operator]
+            op_call,
+            args,
+            kwargs,
+            dtensor_type=dtensor_type,
+        )
+    return callable_obj(op_call, args, kwargs)  # type: ignore[operator]
+
+
 class OpDispatcher:
     """
     Op dispatching class instance to handle args/kwargs pre-processing (un-wrapping), sharding
@@ -279,6 +299,13 @@ class OpDispatcher:
             aten.bernoulli_.float,
         }
         self._custom_op_handlers = _CustomOpHandlerMap(DEFAULT_CUSTOM_OP_HANDLERS)
+
+    def clone(self) -> "OpDispatcher":
+        cloned = copy.copy(self)
+        cloned._random_ops = set(self._random_ops)
+        cloned._custom_op_handlers = self._custom_op_handlers.copy()
+        cloned.sharding_propagator = ShardingPropagator(self.sharding_propagator)
+        return cloned
 
     def rebase_sharding_propagator(self, base_dispatcher: "OpDispatcher") -> None:
         if base_dispatcher is self:
@@ -364,14 +391,13 @@ class OpDispatcher:
         dtensor_type = dtensor.DTensor if dtensor_type is None else dtensor_type
         handler = self._get_custom_op_handler(op_call, dtensor_type)
         if handler is not None:
-            if _handler_accepts_dtensor_type_kwarg(handler):
-                return handler(  # type: ignore[operator]
-                    op_call,
-                    args,
-                    kwargs,
-                    dtensor_type=dtensor_type,
-                )
-            return handler(op_call, args, kwargs)  # type: ignore[operator]
+            return _call_with_optional_dtensor_type_kwarg(
+                handler,
+                op_call,
+                args,
+                kwargs,
+                dtensor_type=dtensor_type,
+            )
 
         op_info = self.unwrap_to_op_info(op_call, args, kwargs)
 

--- a/torch/distributed/tensor/_dispatch.py
+++ b/torch/distributed/tensor/_dispatch.py
@@ -152,6 +152,18 @@ def found_inf_reduce_handler(
     target_tensor.copy_(found_inf)
 
 
+DEFAULT_CUSTOM_OP_HANDLERS = {
+    aten.is_same_size.default: is_same_size_handler,
+    aten.is_pinned.default: is_pinned_handler,
+    aten.convolution.default: convolution_handler,
+    aten.convolution_backward.default: convolution_backward_handler,
+    aten._amp_foreach_non_finite_check_and_unscale_.default: found_inf_reduce_handler,
+    aten.as_strided.default: as_strided_handler,
+    aten.argmin.default: argminmax_handler,
+    aten.argmax.default: argminmax_handler,
+}
+
+
 class OpDispatcher:
     """
     Op dispatching class instance to handle args/kwargs pre-processing (un-wrapping), sharding
@@ -194,16 +206,7 @@ class OpDispatcher:
             aten.bernoulli.default,
             aten.bernoulli_.float,
         }
-        self._custom_op_handlers = {
-            aten.is_same_size.default: is_same_size_handler,
-            aten.is_pinned.default: is_pinned_handler,
-            aten.convolution.default: convolution_handler,
-            aten.convolution_backward.default: convolution_backward_handler,
-            aten._amp_foreach_non_finite_check_and_unscale_.default: found_inf_reduce_handler,
-            aten.as_strided.default: as_strided_handler,
-            aten.argmin.default: argminmax_handler,
-            aten.argmax.default: argminmax_handler,
-        }
+        self._custom_op_handlers = dict(DEFAULT_CUSTOM_OP_HANDLERS)
 
     def rebase_sharding_propagator(self, base_dispatcher: "OpDispatcher") -> None:
         if base_dispatcher is self:
@@ -239,17 +242,24 @@ class OpDispatcher:
         dtensor_type: "type[dtensor.DTensor]",
     ):
         handler = self._custom_op_handlers.get(op_call)
-        if handler is not None:
+        default_handler = DEFAULT_CUSTOM_OP_HANDLERS.get(op_call)
+        if handler is not None and handler is not default_handler:
             return handler
 
+        inherited_handler = None
         for base_type in dtensor_type.__mro__[1:]:
             dispatcher = getattr(base_type, "_op_dispatcher", None)
             if not isinstance(dispatcher, OpDispatcher) or dispatcher is self:
                 continue
-            handler = dispatcher._custom_op_handlers.get(op_call)
-            if handler is not None:
-                return handler
-        return None
+            base_handler = dispatcher._custom_op_handlers.get(op_call)
+            if base_handler is None:
+                continue
+            if inherited_handler is None:
+                inherited_handler = base_handler
+            if base_handler is not DEFAULT_CUSTOM_OP_HANDLERS.get(op_call):
+                return base_handler
+
+        return handler if handler is not None else inherited_handler
 
     def dispatch(
         self,

--- a/torch/distributed/tensor/_dispatch.py
+++ b/torch/distributed/tensor/_dispatch.py
@@ -164,6 +164,37 @@ DEFAULT_CUSTOM_OP_HANDLERS = {
 }
 
 
+class _CustomOpHandlerMap(dict[torch._ops.OpOverload, object]):
+    _missing = object()
+
+    def __init__(self, *args, explicit_keys=None, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._explicit_keys: set[torch._ops.OpOverload] = (
+            set() if explicit_keys is None else set(explicit_keys)
+        )
+
+    def __setitem__(self, key: torch._ops.OpOverload, value: object) -> None:
+        self._explicit_keys.add(key)
+        super().__setitem__(key, value)
+
+    def pop(self, key, default=_missing):
+        self._explicit_keys.discard(key)
+        if default is self._missing:
+            return super().pop(key)
+        return super().pop(key, default)
+
+    def update(self, *args, **kwargs) -> None:
+        updates = dict(*args, **kwargs)
+        self._explicit_keys.update(updates)
+        super().update(updates)
+
+    def copy(self):
+        return type(self)(self, explicit_keys=self._explicit_keys)
+
+    def is_explicit(self, key: torch._ops.OpOverload) -> bool:
+        return key in self._explicit_keys
+
+
 class OpDispatcher:
     """
     Op dispatching class instance to handle args/kwargs pre-processing (un-wrapping), sharding
@@ -206,7 +237,7 @@ class OpDispatcher:
             aten.bernoulli.default,
             aten.bernoulli_.float,
         }
-        self._custom_op_handlers = dict(DEFAULT_CUSTOM_OP_HANDLERS)
+        self._custom_op_handlers = _CustomOpHandlerMap(DEFAULT_CUSTOM_OP_HANDLERS)
 
     def rebase_sharding_propagator(self, base_dispatcher: "OpDispatcher") -> None:
         if base_dispatcher is self:
@@ -243,8 +274,12 @@ class OpDispatcher:
     ):
         handler = self._custom_op_handlers.get(op_call)
         default_handler = DEFAULT_CUSTOM_OP_HANDLERS.get(op_call)
-        if handler is not None and handler is not default_handler:
-            return handler
+        if handler is not None:
+            if handler is not default_handler:
+                return handler
+            if isinstance(self._custom_op_handlers, _CustomOpHandlerMap):
+                if self._custom_op_handlers.is_explicit(op_call):
+                    return handler
 
         inherited_handler = None
         for base_type in dtensor_type.__mro__[1:]:
@@ -775,15 +810,7 @@ class OpDispatcher:
         create_schema: bool,
     ) -> OpInfo:
         # get runtime schema info to determine whether to use pytree to flatten inputs
-        runtime_schema_info = self.sharding_propagator.op_to_schema_info.get(
-            op_call, None
-        )
-        if runtime_schema_info is None:
-            runtime_schema_info = (
-                self.sharding_propagator.op_to_schema_info_for_single_dim_strategy.get(
-                    op_call, None
-                )
-            )
+        runtime_schema_info = self.sharding_propagator.get_schema_info(op_call)
 
         # Auto-detect needs_pytree if any arg is a list/tuple containing tensors
         def _contains_tensor(arg: object) -> bool:

--- a/torch/distributed/tensor/_dispatch.py
+++ b/torch/distributed/tensor/_dispatch.py
@@ -286,10 +286,6 @@ class _CustomOpHandlerMap(MutableMapping[torch._ops.OpOverload, object]):
 
         return current_value
 
-    def update(self, other: Mapping[torch._ops.OpOverload, object]) -> None:
-        for key, value in other.items():
-            self[key] = value
-
     def copy(self):
         return type(self)(
             self._handlers,
@@ -299,6 +295,30 @@ class _CustomOpHandlerMap(MutableMapping[torch._ops.OpOverload, object]):
 
     def is_explicit(self, key: torch._ops.OpOverload) -> bool:
         return key in self._explicit_keys
+
+    def _snapshot_local_entry(
+        self, key: torch._ops.OpOverload
+    ) -> tuple[bool, object, bool]:
+        if key not in self._handlers:
+            return False, self._missing, False
+        return True, self._handlers[key], key in self._explicit_keys
+
+    def _restore_local_entry(
+        self,
+        key: torch._ops.OpOverload,
+        entry: tuple[bool, object, bool],
+    ) -> None:
+        present, value, explicit = entry
+        if not present:
+            self._handlers.pop(key, None)
+            self._explicit_keys.discard(key)
+            return
+
+        self._handlers[key] = value
+        if explicit:
+            self._explicit_keys.add(key)
+        else:
+            self._explicit_keys.discard(key)
 
 
 def _handler_accepts_dtensor_type_kwarg(handler: object) -> bool:

--- a/torch/distributed/tensor/_nonlinear_redux.py
+++ b/torch/distributed/tensor/_nonlinear_redux.py
@@ -29,8 +29,10 @@ def _get_output_sharding(
     kwargs: dict[str, object],
 ) -> OutputSharding:
     """Get the output sharding for the given op."""
-    op_info = dtensor.DTensor._op_dispatcher.unwrap_to_op_info(op_call, args, kwargs)
-    dtensor.DTensor._op_dispatcher.sharding_propagator.propagate(op_info)
+    input_dtensor = cast(dtensor.DTensor, args[0])
+    dispatcher = input_dtensor.__class__._op_dispatcher
+    op_info = dispatcher.unwrap_to_op_info(op_call, args, kwargs)
+    dispatcher.sharding_propagator.propagate(op_info)
     output_sharding = op_info.output_sharding
     if output_sharding is None:
         raise AssertionError("output sharding should not be None")
@@ -213,6 +215,7 @@ def argminmax_handler(
         str(op_call), args, kwargs
     )
     output_sharding = _get_output_sharding(op_call, args, kwargs)
+    dtensor_type = cast(dtensor.DTensor, args[0]).__class__
 
     expected_shape = _get_expected_shape(local_tensor, dim, keepdim)
     shard_mesh_dims = _collect_shard_mesh_dims(
@@ -230,7 +233,7 @@ def argminmax_handler(
         local_redux, local_idx = val_op(local_tensor, dim=dim, keepdim=True)
 
     if not shard_mesh_dims:
-        return dtensor.DTensor._op_dispatcher.wrap(
+        return dtensor_type._op_dispatcher.wrap(
             local_idx.reshape(expected_shape), output_sharding.output_spec
         )
 
@@ -246,7 +249,7 @@ def argminmax_handler(
     rank_winner = op_call(gathered_redux, select_dim, True)
     final_idx = torch.gather(gather_idxs, dim=gather_dim, index=rank_winner)
 
-    return dtensor.DTensor._op_dispatcher.wrap(
+    return dtensor_type._op_dispatcher.wrap(
         final_idx.reshape(expected_shape), output_sharding.output_spec
     )
 
@@ -265,6 +268,7 @@ def minmax_dim_handler(
         str(op_call), args, kwargs
     )
     output_sharding = _get_output_sharding(op_call, args, kwargs)
+    dtensor_type = cast(dtensor.DTensor, args[0]).__class__
 
     expected_shape = _get_expected_shape(local_tensor, dim, keepdim)
     shard_mesh_dims = _collect_shard_mesh_dims(
@@ -277,7 +281,7 @@ def minmax_dim_handler(
     local_redux, local_idx = op_call(local_tensor, dim=dim, keepdim=True)
 
     if not shard_mesh_dims:
-        return dtensor.DTensor._op_dispatcher.wrap(
+        return dtensor_type._op_dispatcher.wrap(
             (
                 local_redux.reshape(expected_shape),
                 local_idx.reshape(expected_shape),
@@ -296,7 +300,7 @@ def minmax_dim_handler(
     final_redux, rank_winner = op_call(gathered_redux, dim, True)
     final_idx = torch.gather(gather_idxs, dim=gather_dim, index=rank_winner)
 
-    return dtensor.DTensor._op_dispatcher.wrap(
+    return dtensor_type._op_dispatcher.wrap(
         (
             final_redux.reshape(expected_shape),
             final_idx.reshape(expected_shape),

--- a/torch/distributed/tensor/_nonlinear_redux.py
+++ b/torch/distributed/tensor/_nonlinear_redux.py
@@ -218,9 +218,7 @@ def argminmax_handler(
     )
     output_sharding = _get_output_sharding(op_call, args, kwargs)
     dtensor_type = (
-        type(cast(dtensor.DTensor, args[0]))
-        if dtensor_type is None
-        else dtensor_type
+        type(cast(dtensor.DTensor, args[0])) if dtensor_type is None else dtensor_type
     )
 
     expected_shape = _get_expected_shape(local_tensor, dim, keepdim)
@@ -281,9 +279,7 @@ def minmax_dim_handler(
     )
     output_sharding = _get_output_sharding(op_call, args, kwargs)
     dtensor_type = (
-        type(cast(dtensor.DTensor, args[0]))
-        if dtensor_type is None
-        else dtensor_type
+        type(cast(dtensor.DTensor, args[0])) if dtensor_type is None else dtensor_type
     )
 
     expected_shape = _get_expected_shape(local_tensor, dim, keepdim)

--- a/torch/distributed/tensor/_nonlinear_redux.py
+++ b/torch/distributed/tensor/_nonlinear_redux.py
@@ -202,6 +202,8 @@ def argminmax_handler(
     op_call: torch._ops.OpOverload,
     args: tuple[object, ...],
     kwargs: dict[str, object],
+    *,
+    dtensor_type: "type[dtensor.DTensor] | None" = None,
 ) -> object:
     """
     Handler for aten.argmin.default and aten.argmax.default ops.
@@ -215,7 +217,11 @@ def argminmax_handler(
         str(op_call), args, kwargs
     )
     output_sharding = _get_output_sharding(op_call, args, kwargs)
-    dtensor_type = cast(dtensor.DTensor, args[0]).__class__
+    dtensor_type = (
+        cast(type[dtensor.DTensor], cast(dtensor.DTensor, args[0]).__class__)
+        if dtensor_type is None
+        else dtensor_type
+    )
 
     expected_shape = _get_expected_shape(local_tensor, dim, keepdim)
     shard_mesh_dims = _collect_shard_mesh_dims(
@@ -234,7 +240,9 @@ def argminmax_handler(
 
     if not shard_mesh_dims:
         return dtensor_type._op_dispatcher.wrap(
-            local_idx.reshape(expected_shape), output_sharding.output_spec
+            local_idx.reshape(expected_shape),
+            output_sharding.output_spec,
+            dtensor_type=dtensor_type,
         )
 
     gather_dim, gathered_idxs = _convert_to_global_idxs(
@@ -250,7 +258,9 @@ def argminmax_handler(
     final_idx = torch.gather(gather_idxs, dim=gather_dim, index=rank_winner)
 
     return dtensor_type._op_dispatcher.wrap(
-        final_idx.reshape(expected_shape), output_sharding.output_spec
+        final_idx.reshape(expected_shape),
+        output_sharding.output_spec,
+        dtensor_type=dtensor_type,
     )
 
 
@@ -258,6 +268,8 @@ def minmax_dim_handler(
     op_call: torch._ops.OpOverload,
     args: tuple[object, ...],
     kwargs: dict[str, object],
+    *,
+    dtensor_type: "type[dtensor.DTensor] | None" = None,
 ) -> object:
     """
     Handler for aten.min.dim and aten.max.dim ops.
@@ -268,7 +280,11 @@ def minmax_dim_handler(
         str(op_call), args, kwargs
     )
     output_sharding = _get_output_sharding(op_call, args, kwargs)
-    dtensor_type = cast(dtensor.DTensor, args[0]).__class__
+    dtensor_type = (
+        cast(type[dtensor.DTensor], cast(dtensor.DTensor, args[0]).__class__)
+        if dtensor_type is None
+        else dtensor_type
+    )
 
     expected_shape = _get_expected_shape(local_tensor, dim, keepdim)
     shard_mesh_dims = _collect_shard_mesh_dims(
@@ -287,6 +303,7 @@ def minmax_dim_handler(
                 local_idx.reshape(expected_shape),
             ),
             output_sharding.output_spec,
+            dtensor_type=dtensor_type,
         )
 
     gather_dim, gathered_idxs = _convert_to_global_idxs(
@@ -306,4 +323,5 @@ def minmax_dim_handler(
             final_idx.reshape(expected_shape),
         ),
         output_sharding.output_spec,
+        dtensor_type=dtensor_type,
     )

--- a/torch/distributed/tensor/_nonlinear_redux.py
+++ b/torch/distributed/tensor/_nonlinear_redux.py
@@ -218,7 +218,7 @@ def argminmax_handler(
     )
     output_sharding = _get_output_sharding(op_call, args, kwargs)
     dtensor_type = (
-        cast(type[dtensor.DTensor], cast(dtensor.DTensor, args[0]).__class__)
+        type(cast(dtensor.DTensor, args[0]))
         if dtensor_type is None
         else dtensor_type
     )
@@ -281,7 +281,7 @@ def minmax_dim_handler(
     )
     output_sharding = _get_output_sharding(op_call, args, kwargs)
     dtensor_type = (
-        cast(type[dtensor.DTensor], cast(dtensor.DTensor, args[0]).__class__)
+        type(cast(dtensor.DTensor, args[0]))
         if dtensor_type is None
         else dtensor_type
     )

--- a/torch/distributed/tensor/_sharding_prop.py
+++ b/torch/distributed/tensor/_sharding_prop.py
@@ -81,6 +81,71 @@ def _lookup_schema_info_entry(
     return True, None if schema_info is _NO_SCHEMA_INFO else schema_info
 
 
+_SHARDING_RULE_REGISTRATION = "rule"
+_OP_STRATEGY_REGISTRATION = "strategy"
+_SINGLE_DIM_STRATEGY_REGISTRATION = "single_dim_strategy"
+
+
+def _get_base_mapping(mapping: MutableMapping[K, V]) -> MutableMapping[K, V] | None:
+    if not isinstance(mapping, ChainMap) or len(mapping.maps) == 1:
+        return None
+    if len(mapping.maps) == 2:
+        return cast(MutableMapping[K, V], mapping.maps[1])
+    return cast(MutableMapping[K, V], ChainMap(*mapping.maps[1:]))
+
+
+def _resolve_op_registration(
+    op_overload: OpOverload,
+    rule_mapping: MutableMapping[
+        OpOverload, Callable[[OpSchema], OutputSharding]
+    ],
+    strategy_mapping: MutableMapping[
+        OpOverload, Callable[[OpSchema], StrategyType]
+    ],
+    single_dim_strategy_mapping: MutableMapping[
+        OpOverload,
+        _SingleDimStrategyInfo,
+    ],
+) -> tuple[str, object] | None:
+    # Resolve registrations one inheritance level at a time so a child class can
+    # shadow an inherited registration even when it switches registry type.
+    local_single_dim_strategy_mapping = _get_local_overrides(single_dim_strategy_mapping)
+    if op_overload in local_single_dim_strategy_mapping:
+        return (
+            _SINGLE_DIM_STRATEGY_REGISTRATION,
+            local_single_dim_strategy_mapping[op_overload],
+        )
+
+    local_strategy_mapping = _get_local_overrides(strategy_mapping)
+    if op_overload in local_strategy_mapping:
+        return (_OP_STRATEGY_REGISTRATION, local_strategy_mapping[op_overload])
+
+    local_rule_mapping = _get_local_overrides(rule_mapping)
+    if op_overload in local_rule_mapping:
+        return (_SHARDING_RULE_REGISTRATION, local_rule_mapping[op_overload])
+
+    base_rule_mapping = _get_base_mapping(rule_mapping)
+    base_strategy_mapping = _get_base_mapping(strategy_mapping)
+    base_single_dim_strategy_mapping = _get_base_mapping(single_dim_strategy_mapping)
+    if (
+        base_rule_mapping is None
+        and base_strategy_mapping is None
+        and base_single_dim_strategy_mapping is None
+    ):
+        return None
+
+    return _resolve_op_registration(
+        op_overload,
+        {} if base_rule_mapping is None else base_rule_mapping,
+        {} if base_strategy_mapping is None else base_strategy_mapping,
+        (
+            {}
+            if base_single_dim_strategy_mapping is None
+            else base_single_dim_strategy_mapping
+        ),
+    )
+
+
 def _set_schema_info_entry(
     mapping: MutableMapping[OpOverload, SchemaInfoEntry],
     op_overload: OpOverload,
@@ -518,14 +583,30 @@ class ShardingPropagator:
         _set_schema_info_entry(self.op_to_schema_info, op_overload, schema_info)
 
     def get_schema_info(self, op_overload: OpOverload) -> RuntimeSchemaInfo | None:
-        found, schema_info = _lookup_schema_info_entry(
-            self.op_to_schema_info, op_overload
+        registration = _resolve_op_registration(
+            op_overload,
+            self.op_to_rules,
+            self.op_strategy_funcs,
+            self.op_single_dim_strategy_funcs,
         )
-        if found:
+        if registration is None:
+            found, schema_info = _lookup_schema_info_entry(
+                self.op_to_schema_info, op_overload
+            )
+            if found:
+                return schema_info
+            _, schema_info = _lookup_schema_info_entry(
+                self.op_to_schema_info_for_single_dim_strategy, op_overload
+            )
             return schema_info
-        _, schema_info = _lookup_schema_info_entry(
-            self.op_to_schema_info_for_single_dim_strategy, op_overload
+
+        registration_type, _ = registration
+        schema_mapping = (
+            self.op_to_schema_info_for_single_dim_strategy
+            if registration_type == _SINGLE_DIM_STRATEGY_REGISTRATION
+            else self.op_to_schema_info
         )
+        _, schema_info = _lookup_schema_info_entry(schema_mapping, op_overload)
         return schema_info
 
     def _propagate_tensor_meta_non_cached(
@@ -753,8 +834,29 @@ class ShardingPropagator:
 
         out_tensor_meta = self._propagate_tensor_meta_non_cached(op_schema)
 
-        single_dim_strategy_info = self.op_single_dim_strategy_funcs.get(op_schema.op)
-        op_strategy_func = self.op_strategy_funcs.get(op_schema.op)
+        registration = _resolve_op_registration(
+            op_schema.op,
+            self.op_to_rules,
+            self.op_strategy_funcs,
+            self.op_single_dim_strategy_funcs,
+        )
+        single_dim_strategy_info = None
+        op_strategy_func = None
+        sharding_prop_func = None
+        if registration is not None:
+            registration_type, registration_impl = registration
+            if registration_type == _SINGLE_DIM_STRATEGY_REGISTRATION:
+                single_dim_strategy_info = cast(
+                    _SingleDimStrategyInfo, registration_impl
+                )
+            elif registration_type == _OP_STRATEGY_REGISTRATION:
+                op_strategy_func = cast(
+                    Callable[[OpSchema], StrategyType], registration_impl
+                )
+            else:
+                sharding_prop_func = cast(
+                    Callable[[OpSchema], OutputSharding], registration_impl
+                )
         decomp_exception = None
         if single_dim_strategy_info is not None or op_strategy_func is not None:
             # Validate that tensor_meta count matches expected outputs from op schema.
@@ -974,10 +1076,8 @@ class ShardingPropagator:
             )
             output_sharding.output_spec = new_output_spec
             return output_sharding
-        elif op_schema.op in self.op_to_rules:
+        elif sharding_prop_func is not None:
             # propagate the sharding with rule
-            sharding_prop_func = self.op_to_rules[op_schema.op]
-
             # step 1. there's sharding propagation rule, run
             # sharding propagation to get the output sharding
             try:

--- a/torch/distributed/tensor/_sharding_prop.py
+++ b/torch/distributed/tensor/_sharding_prop.py
@@ -418,12 +418,10 @@ class ShardingPropagator:
     _fake_mode_lock = nullcontext()
 
     def __init__(self, base_propagator: "ShardingPropagator | None" = None) -> None:
-        self._base_propagator_ref: (
-            weakref.ReferenceType[ShardingPropagator] | None
-        ) = None
-        self._child_propagators: weakref.WeakSet[ShardingPropagator] = (
-            weakref.WeakSet()
+        self._base_propagator_ref: weakref.ReferenceType[ShardingPropagator] | None = (
+            None
         )
+        self._child_propagators: weakref.WeakSet[ShardingPropagator] = weakref.WeakSet()
         op_to_rules: MutableMapping[OpOverload, Callable[[OpSchema], OutputSharding]]
         op_strategy_funcs: MutableMapping[
             OpOverload,
@@ -501,9 +499,7 @@ class ShardingPropagator:
 
     def _attach_to_base(self, base_propagator: "ShardingPropagator") -> None:
         current_base = (
-            None
-            if self._base_propagator_ref is None
-            else self._base_propagator_ref()
+            None if self._base_propagator_ref is None else self._base_propagator_ref()
         )
         if current_base is base_propagator:
             return

--- a/torch/distributed/tensor/_sharding_prop.py
+++ b/torch/distributed/tensor/_sharding_prop.py
@@ -6,7 +6,7 @@ from collections.abc import Callable, MutableMapping, Sequence
 from contextlib import nullcontext
 from functools import lru_cache
 from itertools import chain
-from typing import cast
+from typing import cast, TypeVar
 
 import torch
 from torch._guards import detect_fake_mode
@@ -43,6 +43,9 @@ from torch.utils._pytree import tree_map
 
 aten = torch.ops.aten
 
+K = TypeVar("K")
+V = TypeVar("V")
+
 log = logging.getLogger(__name__)
 
 
@@ -52,6 +55,12 @@ def _length(obj) -> int:
     if not isinstance(obj, Sequence):
         return 1
     return len(obj)
+
+
+def _get_local_overrides(mapping: MutableMapping[K, V]) -> MutableMapping[K, V]:
+    if isinstance(mapping, ChainMap):
+        return cast(MutableMapping[K, V], mapping.maps[0])
+    return mapping
 
 
 def _get_expected_num_tensor_outputs(op: OpOverload) -> int:
@@ -365,6 +374,33 @@ class ShardingPropagator:
             aten.select_backward.default: 1,
             aten.slice_backward.default: 1,
         }
+
+    def rebase(self, base_propagator: "ShardingPropagator | None") -> None:
+        if base_propagator is None:
+            return
+
+        self.op_to_rules = ChainMap(
+            _get_local_overrides(self.op_to_rules),
+            base_propagator.op_to_rules,
+        )
+        self.op_strategy_funcs = ChainMap(
+            _get_local_overrides(self.op_strategy_funcs),
+            base_propagator.op_strategy_funcs,
+        )
+        self.op_single_dim_strategy_funcs = ChainMap(
+            _get_local_overrides(self.op_single_dim_strategy_funcs),
+            base_propagator.op_single_dim_strategy_funcs,
+        )
+        self.op_to_schema_info = ChainMap(
+            _get_local_overrides(self.op_to_schema_info),
+            base_propagator.op_to_schema_info,
+        )
+        self.op_to_schema_info_for_single_dim_strategy = ChainMap(
+            _get_local_overrides(self.op_to_schema_info_for_single_dim_strategy),
+            base_propagator.op_to_schema_info_for_single_dim_strategy,
+        )
+        self.propagate_op_sharding.cache_clear()
+        self._propagate_tensor_meta_cached.cache_clear()
 
     def register_sharding_prop_rule(
         self,

--- a/torch/distributed/tensor/_sharding_prop.py
+++ b/torch/distributed/tensor/_sharding_prop.py
@@ -1,6 +1,7 @@
 # mypy: allow-untyped-defs
 import logging
 import threading
+import weakref
 from collections import ChainMap
 from collections.abc import Callable, MutableMapping, Sequence
 from contextlib import nullcontext
@@ -98,12 +99,8 @@ def _get_base_mapping(mapping: MutableMapping[K, V]) -> MutableMapping[K, V] | N
 
 def _resolve_op_registration(
     op_overload: OpOverload,
-    rule_mapping: MutableMapping[
-        OpOverload, Callable[[OpSchema], OutputSharding]
-    ],
-    strategy_mapping: MutableMapping[
-        OpOverload, Callable[[OpSchema], StrategyType]
-    ],
+    rule_mapping: MutableMapping[OpOverload, Callable[[OpSchema], OutputSharding]],
+    strategy_mapping: MutableMapping[OpOverload, Callable[[OpSchema], StrategyType]],
     single_dim_strategy_mapping: MutableMapping[
         OpOverload,
         _SingleDimStrategyInfo,
@@ -306,9 +303,7 @@ def _select_min_redistribute_cost(
 
     # Figure out heuristic hints for unbacked shapes.
     # If available, use shape upper bound. If not, fallback to some integer (inductor size-hinting style).
-    symbolic_cost = cast(
-        Any, next(iter(x for x in costs if not is_concrete_float(x)))
-    )
+    symbolic_cost = cast(Any, next(iter(x for x in costs if not is_concrete_float(x))))
     shape_env = symbolic_cost.node.shape_env
     replacements = {}
     for sym in free_unbacked:
@@ -423,9 +418,13 @@ class ShardingPropagator:
     _fake_mode_lock = nullcontext()
 
     def __init__(self, base_propagator: "ShardingPropagator | None" = None) -> None:
-        op_to_rules: MutableMapping[
-            OpOverload, Callable[[OpSchema], OutputSharding]
-        ]
+        self._base_propagator_ref: (
+            weakref.ReferenceType[ShardingPropagator] | None
+        ) = None
+        self._child_propagators: weakref.WeakSet[ShardingPropagator] = (
+            weakref.WeakSet()
+        )
+        op_to_rules: MutableMapping[OpOverload, Callable[[OpSchema], OutputSharding]]
         op_strategy_funcs: MutableMapping[
             OpOverload,
             Callable[[OpSchema], StrategyType],
@@ -468,9 +467,9 @@ class ShardingPropagator:
         ] = op_single_dim_strategy_funcs
         # op map to save static argnum to decide to reuse sharding prop cache or
         # re-run sharding prop
-        self.op_to_schema_info: MutableMapping[
-            OpOverload, SchemaInfoEntry
-        ] = op_to_schema_info
+        self.op_to_schema_info: MutableMapping[OpOverload, SchemaInfoEntry] = (
+            op_to_schema_info
+        )
         self.op_to_schema_info_for_single_dim_strategy: MutableMapping[
             OpOverload, SchemaInfoEntry
         ] = op_to_schema_info_for_single_dim_strategy
@@ -497,11 +496,33 @@ class ShardingPropagator:
             aten.select_backward.default: 1,
             aten.slice_backward.default: 1,
         }
+        if base_propagator is not None:
+            self._attach_to_base(base_propagator)
+
+    def _attach_to_base(self, base_propagator: "ShardingPropagator") -> None:
+        current_base = (
+            None
+            if self._base_propagator_ref is None
+            else self._base_propagator_ref()
+        )
+        if current_base is base_propagator:
+            return
+        if current_base is not None:
+            current_base._child_propagators.discard(self)
+        self._base_propagator_ref = weakref.ref(base_propagator)
+        base_propagator._child_propagators.add(self)
+
+    def invalidate_caches(self) -> None:
+        self.propagate_op_sharding.cache_clear()
+        self._propagate_tensor_meta_cached.cache_clear()
+        for child in list(self._child_propagators):
+            child.invalidate_caches()
 
     def rebase(self, base_propagator: "ShardingPropagator | None") -> None:
         if base_propagator is None:
             return
 
+        self._attach_to_base(base_propagator)
         self.op_to_rules = ChainMap(
             _get_local_overrides(self.op_to_rules),
             base_propagator.op_to_rules,
@@ -522,8 +543,7 @@ class ShardingPropagator:
             _get_local_overrides(self.op_to_schema_info_for_single_dim_strategy),
             base_propagator.op_to_schema_info_for_single_dim_strategy,
         )
-        self.propagate_op_sharding.cache_clear()
-        self._propagate_tensor_meta_cached.cache_clear()
+        self.invalidate_caches()
 
     def register_sharding_prop_rule(
         self,
@@ -536,6 +556,7 @@ class ShardingPropagator:
         """
         self.op_to_rules[op_overload] = rule_func
         _set_schema_info_entry(self.op_to_schema_info, op_overload, schema_info)
+        self.invalidate_caches()
 
     def register_single_dim_op_strategy(
         self,
@@ -552,6 +573,7 @@ class ShardingPropagator:
             op_overload,
             schema_info,
         )
+        self.invalidate_caches()
 
     def register_op_strategy(
         self,
@@ -606,6 +628,7 @@ class ShardingPropagator:
         """
         self.op_strategy_funcs[op_overload] = strategy_func
         _set_schema_info_entry(self.op_to_schema_info, op_overload, schema_info)
+        self.invalidate_caches()
 
     def get_schema_info(self, op_overload: OpOverload) -> RuntimeSchemaInfo | None:
         registration = _resolve_op_registration(

--- a/torch/distributed/tensor/_sharding_prop.py
+++ b/torch/distributed/tensor/_sharding_prop.py
@@ -67,7 +67,7 @@ def _length(obj) -> int:
 
 def _get_local_overrides(mapping: MutableMapping[K, V]) -> MutableMapping[K, V]:
     if isinstance(mapping, ChainMap):
-        return cast(MutableMapping[K, V], mapping.maps[0])
+        return mapping.maps[0]
     return mapping
 
 
@@ -78,7 +78,9 @@ def _lookup_schema_info_entry(
     if op_overload not in mapping:
         return False, None
     schema_info = mapping[op_overload]
-    return True, None if schema_info is _NO_SCHEMA_INFO else schema_info
+    if schema_info is _NO_SCHEMA_INFO:
+        return True, None
+    return True, schema_info
 
 
 _SHARDING_RULE_REGISTRATION = "rule"
@@ -90,8 +92,8 @@ def _get_base_mapping(mapping: MutableMapping[K, V]) -> MutableMapping[K, V] | N
     if not isinstance(mapping, ChainMap) or len(mapping.maps) == 1:
         return None
     if len(mapping.maps) == 2:
-        return cast(MutableMapping[K, V], mapping.maps[1])
-    return cast(MutableMapping[K, V], ChainMap(*mapping.maps[1:]))
+        return mapping.maps[1]
+    return ChainMap(*mapping.maps[1:])
 
 
 def _resolve_op_registration(
@@ -109,7 +111,9 @@ def _resolve_op_registration(
 ) -> tuple[str, object] | None:
     # Resolve registrations one inheritance level at a time so a child class can
     # shadow an inherited registration even when it switches registry type.
-    local_single_dim_strategy_mapping = _get_local_overrides(single_dim_strategy_mapping)
+    local_single_dim_strategy_mapping = _get_local_overrides(
+        single_dim_strategy_mapping
+    )
     if op_overload in local_single_dim_strategy_mapping:
         return (
             _SINGLE_DIM_STRATEGY_REGISTRATION,
@@ -302,7 +306,9 @@ def _select_min_redistribute_cost(
 
     # Figure out heuristic hints for unbacked shapes.
     # If available, use shape upper bound. If not, fallback to some integer (inductor size-hinting style).
-    shape_env = next(iter(x for x in costs if not is_concrete_float(x))).node.shape_env  # type: ignore[arg-type]
+    shape_env = next(
+        iter(x for x in costs if not is_concrete_float(x))
+    ).node.shape_env  # type: ignore[arg-type]
     replacements = {}
     for sym in free_unbacked:
         # TODO(laithsakka): unify with optimization_hint API
@@ -416,39 +422,57 @@ class ShardingPropagator:
     _fake_mode_lock = nullcontext()
 
     def __init__(self, base_propagator: "ShardingPropagator | None" = None) -> None:
+        op_to_rules: MutableMapping[
+            OpOverload, Callable[[OpSchema], OutputSharding]
+        ]
+        op_strategy_funcs: MutableMapping[
+            OpOverload,
+            Callable[[OpSchema], StrategyType],
+        ]
+        op_single_dim_strategy_funcs: MutableMapping[
+            OpOverload,
+            _SingleDimStrategyInfo,
+        ]
+        op_to_schema_info: MutableMapping[OpOverload, SchemaInfoEntry]
+        op_to_schema_info_for_single_dim_strategy: MutableMapping[
+            OpOverload, SchemaInfoEntry
+        ]
+
         if base_propagator is None:
-            self.op_to_rules = {}
-            self.op_strategy_funcs = {}
-            self.op_single_dim_strategy_funcs = {}
-            self.op_to_schema_info = {}
-            self.op_to_schema_info_for_single_dim_strategy = {}
+            op_to_rules = {}
+            op_strategy_funcs = {}
+            op_single_dim_strategy_funcs = {}
+            op_to_schema_info = {}
+            op_to_schema_info_for_single_dim_strategy = {}
         else:
-            self.op_to_rules = ChainMap({}, base_propagator.op_to_rules)
-            self.op_strategy_funcs = ChainMap({}, base_propagator.op_strategy_funcs)
-            self.op_single_dim_strategy_funcs = ChainMap(
+            op_to_rules = ChainMap({}, base_propagator.op_to_rules)
+            op_strategy_funcs = ChainMap({}, base_propagator.op_strategy_funcs)
+            op_single_dim_strategy_funcs = ChainMap(
                 {}, base_propagator.op_single_dim_strategy_funcs
             )
-            self.op_to_schema_info = ChainMap({}, base_propagator.op_to_schema_info)
-            self.op_to_schema_info_for_single_dim_strategy = ChainMap(
+            op_to_schema_info = ChainMap({}, base_propagator.op_to_schema_info)
+            op_to_schema_info_for_single_dim_strategy = ChainMap(
                 {}, base_propagator.op_to_schema_info_for_single_dim_strategy
             )
         self.op_to_rules: MutableMapping[
             OpOverload, Callable[[OpSchema], OutputSharding]
-        ]
+        ] = op_to_rules
         self.op_strategy_funcs: MutableMapping[
             OpOverload,
             Callable[[OpSchema], StrategyType],
-        ]
+        ] = op_strategy_funcs
         self.op_single_dim_strategy_funcs: MutableMapping[
             OpOverload,
             _SingleDimStrategyInfo,
-        ]
+        ] = op_single_dim_strategy_funcs
         # op map to save static argnum to decide to reuse sharding prop cache or
         # re-run sharding prop
-        self.op_to_schema_info: MutableMapping[OpOverload, SchemaInfoEntry]
+        self.op_to_schema_info: MutableMapping[
+            OpOverload, SchemaInfoEntry
+        ] = op_to_schema_info
         self.op_to_schema_info_for_single_dim_strategy: MutableMapping[
             OpOverload, SchemaInfoEntry
-        ]
+        ] = op_to_schema_info_for_single_dim_strategy
         self.propagate_op_sharding = LocalLRUCache(
             self.propagate_op_sharding_non_cached
         )

--- a/torch/distributed/tensor/_sharding_prop.py
+++ b/torch/distributed/tensor/_sharding_prop.py
@@ -49,6 +49,14 @@ V = TypeVar("V")
 log = logging.getLogger(__name__)
 
 
+class _NoSchemaInfo:
+    pass
+
+
+_NO_SCHEMA_INFO = _NoSchemaInfo()
+SchemaInfoEntry = RuntimeSchemaInfo | _NoSchemaInfo
+
+
 def _length(obj) -> int:
     if obj is None:
         return 0
@@ -61,6 +69,31 @@ def _get_local_overrides(mapping: MutableMapping[K, V]) -> MutableMapping[K, V]:
     if isinstance(mapping, ChainMap):
         return cast(MutableMapping[K, V], mapping.maps[0])
     return mapping
+
+
+def _lookup_schema_info_entry(
+    mapping: MutableMapping[OpOverload, SchemaInfoEntry],
+    op_overload: OpOverload,
+) -> tuple[bool, RuntimeSchemaInfo | None]:
+    if op_overload not in mapping:
+        return False, None
+    schema_info = mapping[op_overload]
+    return True, None if schema_info is _NO_SCHEMA_INFO else schema_info
+
+
+def _set_schema_info_entry(
+    mapping: MutableMapping[OpOverload, SchemaInfoEntry],
+    op_overload: OpOverload,
+    schema_info: RuntimeSchemaInfo | None,
+) -> None:
+    local_overrides = _get_local_overrides(mapping)
+    local_overrides.pop(op_overload, None)
+    if schema_info is not None:
+        local_overrides[op_overload] = schema_info
+    elif isinstance(mapping, ChainMap) and any(
+        op_overload in base for base in mapping.maps[1:]
+    ):
+        local_overrides[op_overload] = _NO_SCHEMA_INFO
 
 
 def _get_expected_num_tensor_outputs(op: OpOverload) -> int:
@@ -347,9 +380,9 @@ class ShardingPropagator:
         ]
         # op map to save static argnum to decide to reuse sharding prop cache or
         # re-run sharding prop
-        self.op_to_schema_info: MutableMapping[OpOverload, RuntimeSchemaInfo]
+        self.op_to_schema_info: MutableMapping[OpOverload, SchemaInfoEntry]
         self.op_to_schema_info_for_single_dim_strategy: MutableMapping[
-            OpOverload, RuntimeSchemaInfo
+            OpOverload, SchemaInfoEntry
         ]
         self.propagate_op_sharding = LocalLRUCache(
             self.propagate_op_sharding_non_cached
@@ -412,8 +445,7 @@ class ShardingPropagator:
         Register a sharding propagation rule for an operator.
         """
         self.op_to_rules[op_overload] = rule_func
-        if schema_info is not None:
-            self.op_to_schema_info[op_overload] = schema_info
+        _set_schema_info_entry(self.op_to_schema_info, op_overload, schema_info)
 
     def register_single_dim_op_strategy(
         self,
@@ -425,8 +457,11 @@ class ShardingPropagator:
         Register a strategy over a single mesh-dim, relying on infra to automatically expand to the full mesh.
         """
         self.op_single_dim_strategy_funcs[op_overload] = strategy_info
-        if schema_info is not None:
-            self.op_to_schema_info_for_single_dim_strategy[op_overload] = schema_info
+        _set_schema_info_entry(
+            self.op_to_schema_info_for_single_dim_strategy,
+            op_overload,
+            schema_info,
+        )
 
     def register_op_strategy(
         self,
@@ -480,8 +515,18 @@ class ShardingPropagator:
         `RuntimeSchemaInfo(static_argnum=2)`.
         """
         self.op_strategy_funcs[op_overload] = strategy_func
-        if schema_info is not None:
-            self.op_to_schema_info[op_overload] = schema_info
+        _set_schema_info_entry(self.op_to_schema_info, op_overload, schema_info)
+
+    def get_schema_info(self, op_overload: OpOverload) -> RuntimeSchemaInfo | None:
+        found, schema_info = _lookup_schema_info_entry(
+            self.op_to_schema_info, op_overload
+        )
+        if found:
+            return schema_info
+        _, schema_info = _lookup_schema_info_entry(
+            self.op_to_schema_info_for_single_dim_strategy, op_overload
+        )
+        return schema_info
 
     def _propagate_tensor_meta_non_cached(
         self, op_schema: OpSchema

--- a/torch/distributed/tensor/_sharding_prop.py
+++ b/torch/distributed/tensor/_sharding_prop.py
@@ -6,7 +6,7 @@ from collections.abc import Callable, MutableMapping, Sequence
 from contextlib import nullcontext
 from functools import lru_cache
 from itertools import chain
-from typing import cast, TypeVar
+from typing import Any, cast, TypeVar
 
 import torch
 from torch._guards import detect_fake_mode
@@ -80,7 +80,7 @@ def _lookup_schema_info_entry(
     schema_info = mapping[op_overload]
     if schema_info is _NO_SCHEMA_INFO:
         return True, None
-    return True, schema_info
+    return True, cast(RuntimeSchemaInfo, schema_info)
 
 
 _SHARDING_RULE_REGISTRATION = "rule"
@@ -306,9 +306,10 @@ def _select_min_redistribute_cost(
 
     # Figure out heuristic hints for unbacked shapes.
     # If available, use shape upper bound. If not, fallback to some integer (inductor size-hinting style).
-    shape_env = next(
-        iter(x for x in costs if not is_concrete_float(x))
-    ).node.shape_env  # type: ignore[arg-type]
+    symbolic_cost = cast(
+        Any, next(iter(x for x in costs if not is_concrete_float(x)))
+    )
+    shape_env = symbolic_cost.node.shape_env
     replacements = {}
     for sym in free_unbacked:
         # TODO(laithsakka): unify with optimization_hint API

--- a/torch/distributed/tensor/_sharding_prop.py
+++ b/torch/distributed/tensor/_sharding_prop.py
@@ -1,7 +1,8 @@
 # mypy: allow-untyped-defs
 import logging
 import threading
-from collections.abc import Callable, Sequence
+from collections import ChainMap
+from collections.abc import Callable, MutableMapping, Sequence
 from contextlib import nullcontext
 from functools import lru_cache
 from itertools import chain
@@ -307,22 +308,40 @@ class ShardingPropagator:
     # when multiple threads enter different FakeTensorMode contexts.
     _fake_mode_lock = nullcontext()
 
-    def __init__(self) -> None:
-        self.op_to_rules: dict[OpOverload, Callable[[OpSchema], OutputSharding]] = {}
-        self.op_strategy_funcs: dict[
+    def __init__(self, base_propagator: "ShardingPropagator | None" = None) -> None:
+        if base_propagator is None:
+            self.op_to_rules = {}
+            self.op_strategy_funcs = {}
+            self.op_single_dim_strategy_funcs = {}
+            self.op_to_schema_info = {}
+            self.op_to_schema_info_for_single_dim_strategy = {}
+        else:
+            self.op_to_rules = ChainMap({}, base_propagator.op_to_rules)
+            self.op_strategy_funcs = ChainMap({}, base_propagator.op_strategy_funcs)
+            self.op_single_dim_strategy_funcs = ChainMap(
+                {}, base_propagator.op_single_dim_strategy_funcs
+            )
+            self.op_to_schema_info = ChainMap({}, base_propagator.op_to_schema_info)
+            self.op_to_schema_info_for_single_dim_strategy = ChainMap(
+                {}, base_propagator.op_to_schema_info_for_single_dim_strategy
+            )
+        self.op_to_rules: MutableMapping[
+            OpOverload, Callable[[OpSchema], OutputSharding]
+        ]
+        self.op_strategy_funcs: MutableMapping[
             OpOverload,
             Callable[[OpSchema], StrategyType],
-        ] = {}
-        self.op_single_dim_strategy_funcs: dict[
+        ]
+        self.op_single_dim_strategy_funcs: MutableMapping[
             OpOverload,
             _SingleDimStrategyInfo,
-        ] = {}
+        ]
         # op map to save static argnum to decide to reuse sharding prop cache or
         # re-run sharding prop
-        self.op_to_schema_info: dict[OpOverload, RuntimeSchemaInfo] = {}
-        self.op_to_schema_info_for_single_dim_strategy: dict[
+        self.op_to_schema_info: MutableMapping[OpOverload, RuntimeSchemaInfo]
+        self.op_to_schema_info_for_single_dim_strategy: MutableMapping[
             OpOverload, RuntimeSchemaInfo
-        ] = {}
+        ]
         self.propagate_op_sharding = LocalLRUCache(
             self.propagate_op_sharding_non_cached
         )

--- a/torch/distributed/tensor/_tp_conv.py
+++ b/torch/distributed/tensor/_tp_conv.py
@@ -254,9 +254,7 @@ def convolution_handler(
     dtensor_type: "type[dtensor.DTensor] | None" = None,
 ) -> object:
     input_dtensor = cast(dtensor.DTensor, args[0])
-    dtensor_type = (
-        input_dtensor.__class__ if dtensor_type is None else dtensor_type
-    )
+    dtensor_type = input_dtensor.__class__ if dtensor_type is None else dtensor_type
     # extract local tensor and sharding infos to a OpInfo
     op_info = dtensor_type._op_dispatcher.unwrap_to_op_info(op_call, args, kwargs)
 

--- a/torch/distributed/tensor/_tp_conv.py
+++ b/torch/distributed/tensor/_tp_conv.py
@@ -253,10 +253,9 @@ def convolution_handler(
     *,
     dtensor_type: "type[dtensor.DTensor] | None" = None,
 ) -> object:
+    input_dtensor = cast(dtensor.DTensor, args[0])
     dtensor_type = (
-        cast(type[dtensor.DTensor], cast(dtensor.DTensor, args[0]).__class__)
-        if dtensor_type is None
-        else dtensor_type
+        input_dtensor.__class__ if dtensor_type is None else dtensor_type
     )
     # extract local tensor and sharding infos to a OpInfo
     op_info = dtensor_type._op_dispatcher.unwrap_to_op_info(op_call, args, kwargs)
@@ -300,10 +299,9 @@ def convolution_backward_handler(
     # pyrefly: ignore [unsupported-operation]
     args[0] = args[0].redistribute(args[1].device_mesh, args[1].placements)
     args = tuple(args)
+    grad_output_dtensor = cast(dtensor.DTensor, args[0])
     dtensor_type = (
-        cast(type[dtensor.DTensor], cast(dtensor.DTensor, args[0]).__class__)
-        if dtensor_type is None
-        else dtensor_type
+        grad_output_dtensor.__class__ if dtensor_type is None else dtensor_type
     )
 
     # extract local tensor and sharding infos to a OpInfo

--- a/torch/distributed/tensor/_tp_conv.py
+++ b/torch/distributed/tensor/_tp_conv.py
@@ -250,8 +250,14 @@ def convolution_handler(
     op_call: torch._ops.OpOverload,
     args: tuple[object, ...],
     kwargs: dict[str, object],
+    *,
+    dtensor_type: "type[dtensor.DTensor] | None" = None,
 ) -> object:
-    dtensor_type = cast(dtensor.DTensor, args[0]).__class__
+    dtensor_type = (
+        cast(type[dtensor.DTensor], cast(dtensor.DTensor, args[0]).__class__)
+        if dtensor_type is None
+        else dtensor_type
+    )
     # extract local tensor and sharding infos to a OpInfo
     op_info = dtensor_type._op_dispatcher.unwrap_to_op_info(op_call, args, kwargs)
 
@@ -272,13 +278,17 @@ def convolution_handler(
         output_spec.dim_map,
     )
 
-    return dtensor_type._op_dispatcher.wrap(local_results, output_spec)
+    return dtensor_type._op_dispatcher.wrap(
+        local_results, output_spec, dtensor_type=dtensor_type
+    )
 
 
 def convolution_backward_handler(
     op_call: torch._ops.OpOverload,
     args: tuple[object, ...],
     kwargs: dict[str, object],
+    *,
+    dtensor_type: "type[dtensor.DTensor] | None" = None,
 ) -> object:
     # Redistribute grad_output tensor to the same placement as input tensor
     # pyrefly: ignore [bad-assignment]
@@ -290,7 +300,11 @@ def convolution_backward_handler(
     # pyrefly: ignore [unsupported-operation]
     args[0] = args[0].redistribute(args[1].device_mesh, args[1].placements)
     args = tuple(args)
-    dtensor_type = cast(dtensor.DTensor, args[0]).__class__
+    dtensor_type = (
+        cast(type[dtensor.DTensor], cast(dtensor.DTensor, args[0]).__class__)
+        if dtensor_type is None
+        else dtensor_type
+    )
 
     # extract local tensor and sharding infos to a OpInfo
     op_info = dtensor_type._op_dispatcher.unwrap_to_op_info(op_call, args, kwargs)
@@ -311,4 +325,8 @@ def convolution_backward_handler(
         op_info.flat_args_schema[0].dim_map,
     )
 
-    return dtensor_type._op_dispatcher.wrap(local_results, output_sharding.output_spec)
+    return dtensor_type._op_dispatcher.wrap(
+        local_results,
+        output_sharding.output_spec,
+        dtensor_type=dtensor_type,
+    )

--- a/torch/distributed/tensor/_tp_conv.py
+++ b/torch/distributed/tensor/_tp_conv.py
@@ -251,11 +251,12 @@ def convolution_handler(
     args: tuple[object, ...],
     kwargs: dict[str, object],
 ) -> object:
+    dtensor_type = cast(dtensor.DTensor, args[0]).__class__
     # extract local tensor and sharding infos to a OpInfo
-    op_info = dtensor.DTensor._op_dispatcher.unwrap_to_op_info(op_call, args, kwargs)
+    op_info = dtensor_type._op_dispatcher.unwrap_to_op_info(op_call, args, kwargs)
 
     # sharding propagation
-    dtensor.DTensor._op_dispatcher.sharding_propagator.propagate(op_info)
+    dtensor_type._op_dispatcher.sharding_propagator.propagate(op_info)
     output_sharding = op_info.output_sharding
     if output_sharding is None:
         raise AssertionError("output sharding should not be None")
@@ -271,7 +272,7 @@ def convolution_handler(
         output_spec.dim_map,
     )
 
-    return dtensor.DTensor._op_dispatcher.wrap(local_results, output_spec)
+    return dtensor_type._op_dispatcher.wrap(local_results, output_spec)
 
 
 def convolution_backward_handler(
@@ -289,12 +290,13 @@ def convolution_backward_handler(
     # pyrefly: ignore [unsupported-operation]
     args[0] = args[0].redistribute(args[1].device_mesh, args[1].placements)
     args = tuple(args)
+    dtensor_type = cast(dtensor.DTensor, args[0]).__class__
 
     # extract local tensor and sharding infos to a OpInfo
-    op_info = dtensor.DTensor._op_dispatcher.unwrap_to_op_info(op_call, args, kwargs)
+    op_info = dtensor_type._op_dispatcher.unwrap_to_op_info(op_call, args, kwargs)
 
     # sharding propagation
-    dtensor.DTensor._op_dispatcher.sharding_propagator.propagate(op_info)
+    dtensor_type._op_dispatcher.sharding_propagator.propagate(op_info)
     output_sharding = op_info.output_sharding
     if output_sharding is None:
         raise AssertionError("output sharding should not be None")
@@ -309,6 +311,4 @@ def convolution_backward_handler(
         op_info.flat_args_schema[0].dim_map,
     )
 
-    return dtensor.DTensor._op_dispatcher.wrap(
-        local_results, output_sharding.output_spec
-    )
+    return dtensor_type._op_dispatcher.wrap(local_results, output_sharding.output_spec)

--- a/torch/distributed/tensor/debug/__init__.py
+++ b/torch/distributed/tensor/debug/__init__.py
@@ -35,9 +35,7 @@ def _clear_python_sharding_prop_cache():
     """
     from torch.distributed.tensor._api import DTensor
 
-    return (
-        DTensor._op_dispatcher.sharding_propagator.propagate_op_sharding.cache_clear()  # type:ignore[attr-defined]
-    )
+    return DTensor._op_dispatcher.sharding_propagator.invalidate_caches()  # type:ignore[attr-defined]
 
 
 def _clear_fast_path_sharding_prop_cache():

--- a/torch/distributed/tensor/experimental/_context_parallel/_attention.py
+++ b/torch/distributed/tensor/experimental/_context_parallel/_attention.py
@@ -902,9 +902,7 @@ def _sdpa_handler(
     dtensor_type: type[DTensor] | None = None,
 ) -> object:
     dtensor_type = (
-        cast(type[DTensor], cast(DTensor, args[0]).__class__)
-        if dtensor_type is None
-        else dtensor_type
+        type(cast(DTensor, args[0])) if dtensor_type is None else dtensor_type
     )
     dispatcher = dtensor_type._op_dispatcher
     # extract local tensor and sharding infos to a OpInfo
@@ -923,12 +921,24 @@ def _sdpa_handler(
         raise AssertionError("inputs need to be redistributed")
 
     call_maps: dict[torch._ops.OpOverload, Callable] = {
-        aten._scaled_dot_product_flash_attention.default: _scaled_dot_product_ring_flash_attention,
-        aten._scaled_dot_product_efficient_attention.default: _scaled_dot_product_ring_efficient_attention,
-        aten._scaled_dot_product_cudnn_attention.default: _scaled_dot_product_ring_cudnn_attention,
-        aten._scaled_dot_product_flash_attention_backward.default: _scaled_dot_product_ring_flash_attention_backward,
-        aten._scaled_dot_product_efficient_attention_backward.default: _scaled_dot_product_ring_efficient_attention_backward,
-        aten._scaled_dot_product_cudnn_attention_backward.default: _scaled_dot_product_ring_cudnn_attention_backward,
+        aten._scaled_dot_product_flash_attention.default: (
+            _scaled_dot_product_ring_flash_attention
+        ),
+        aten._scaled_dot_product_efficient_attention.default: (
+            _scaled_dot_product_ring_efficient_attention
+        ),
+        aten._scaled_dot_product_cudnn_attention.default: (
+            _scaled_dot_product_ring_cudnn_attention
+        ),
+        aten._scaled_dot_product_flash_attention_backward.default: (
+            _scaled_dot_product_ring_flash_attention_backward
+        ),
+        aten._scaled_dot_product_efficient_attention_backward.default: (
+            _scaled_dot_product_ring_efficient_attention_backward
+        ),
+        aten._scaled_dot_product_cudnn_attention_backward.default: (
+            _scaled_dot_product_ring_cudnn_attention_backward
+        ),
     }
     if op_call in call_maps:
         local_results = call_maps[op_call](

--- a/torch/distributed/tensor/experimental/_context_parallel/_attention.py
+++ b/torch/distributed/tensor/experimental/_context_parallel/_attention.py
@@ -899,15 +899,17 @@ def _sdpa_handler(
     args: tuple[object, ...],
     kwargs: dict[str, object],
 ) -> object:
+    dtensor_type = cast(DTensor, args[0]).__class__
+    dispatcher = dtensor_type._op_dispatcher
     # extract local tensor and sharding infos to a OpInfo
-    op_info = DTensor._op_dispatcher.unwrap_to_op_info(op_call, args, kwargs)
+    op_info = dispatcher.unwrap_to_op_info(op_call, args, kwargs)
     logger.debug("Dispatching op_call: %s", op_info.schema or op_call)
 
     # sharding propagation
     # TODO: remove the context parallel strategy from the default propagation
     # rule. Either figure out how to dynamically enable it or just don't call
     # propagate.
-    DTensor._op_dispatcher.sharding_propagator.propagate(op_info)
+    dispatcher.sharding_propagator.propagate(op_info)
     output_sharding = op_info.output_sharding
     if output_sharding is None:
         raise AssertionError("output sharding should not be None")
@@ -933,7 +935,9 @@ def _sdpa_handler(
             "CP only supports flash attention and memory efficient attention now."
         )
 
-    return DTensor._op_dispatcher.wrap(local_results, output_sharding.output_spec)
+    return dispatcher.wrap(
+        local_results, output_sharding.output_spec, dtensor_type=dtensor_type
+    )
 
 
 custom_ops = {

--- a/torch/distributed/tensor/experimental/_context_parallel/_attention.py
+++ b/torch/distributed/tensor/experimental/_context_parallel/_attention.py
@@ -965,6 +965,7 @@ custom_ops = {
     aten._scaled_dot_product_cudnn_attention_backward.default: _sdpa_handler,
 }
 existing_custom_ops = DTensor._op_dispatcher._custom_op_handlers
+_cp_custom_op_snapshots: dict[torch._ops.OpOverload, tuple[bool, object, bool]] = {}
 
 
 ArgsType = tuple[Any, ...]
@@ -1020,25 +1021,41 @@ def _restore_function(fn: Callable, fn_module: types.ModuleType) -> None:
 
 def _enable_cp_dtensor_dispatcher() -> None:
     """Enables DTensor dispatcher to dispatch SDPA to CP."""
-    # Enable custom op handlers for CP
-    updated_custom_ops = existing_custom_ops.copy()
-    updated_custom_ops.update(custom_ops)
-    DTensor._op_dispatcher._custom_op_handlers = updated_custom_ops
+    global _cp_custom_op_snapshots
+
+    if _cp_custom_op_snapshots:
+        return
+
+    for op_overload, handler in custom_ops.items():
+        _cp_custom_op_snapshots[op_overload] = (
+            existing_custom_ops._snapshot_local_entry(op_overload)
+        )
+        existing_custom_ops[op_overload] = handler
+
     # Register CP-specific sharding rules
     from ._sharding_rules import register_cp_sharding_rules
 
-    register_cp_sharding_rules()
+    try:
+        register_cp_sharding_rules()
+    except Exception:
+        for op_overload, entry in _cp_custom_op_snapshots.items():
+            existing_custom_ops._restore_local_entry(op_overload, entry)
+        _cp_custom_op_snapshots = {}
+        raise
 
 
 def _disable_cp_dtensor_dispatcher() -> None:
     """Disables DTensor dispatcher to dispatch SDPA to CP."""
-    # Restore original custom op handlers
-    DTensor._op_dispatcher._custom_op_handlers = existing_custom_ops
+    global _cp_custom_op_snapshots
 
-    # TODO: unregister_cp_sharding_rules(clear_the_cache=True) will cause
-    # all DTensor sharding propagation cache being invalidated. It is not
-    # easy to achieve selectively invalidating lru cache without rewriting
-    # the sharding propagation wrapper.
+    if _cp_custom_op_snapshots:
+        for op_overload, entry in _cp_custom_op_snapshots.items():
+            existing_custom_ops._restore_local_entry(op_overload, entry)
+        _cp_custom_op_snapshots = {}
+
+    # unregister_cp_sharding_rules() already invalidates the Python sharding
+    # caches through the registration hooks below. Avoid clearing the global
+    # C++ fast-path cache unless the caller explicitly asks for it.
 
     from ._sharding_rules import unregister_cp_sharding_rules
 

--- a/torch/distributed/tensor/experimental/_context_parallel/_attention.py
+++ b/torch/distributed/tensor/experimental/_context_parallel/_attention.py
@@ -898,8 +898,14 @@ def _sdpa_handler(
     op_call: torch._ops.OpOverload,
     args: tuple[object, ...],
     kwargs: dict[str, object],
+    *,
+    dtensor_type: type[DTensor] | None = None,
 ) -> object:
-    dtensor_type = cast(DTensor, args[0]).__class__
+    dtensor_type = (
+        cast(type[DTensor], cast(DTensor, args[0]).__class__)
+        if dtensor_type is None
+        else dtensor_type
+    )
     dispatcher = dtensor_type._op_dispatcher
     # extract local tensor and sharding infos to a OpInfo
     op_info = dispatcher.unwrap_to_op_info(op_call, args, kwargs)

--- a/torch/distributed/tensor/experimental/_context_parallel/_attention.py
+++ b/torch/distributed/tensor/experimental/_context_parallel/_attention.py
@@ -1011,10 +1011,9 @@ def _restore_function(fn: Callable, fn_module: types.ModuleType) -> None:
 def _enable_cp_dtensor_dispatcher() -> None:
     """Enables DTensor dispatcher to dispatch SDPA to CP."""
     # Enable custom op handlers for CP
-    DTensor._op_dispatcher._custom_op_handlers = {
-        **existing_custom_ops,
-        **custom_ops,
-    }
+    updated_custom_ops = existing_custom_ops.copy()
+    updated_custom_ops.update(custom_ops)
+    DTensor._op_dispatcher._custom_op_handlers = updated_custom_ops
     # Register CP-specific sharding rules
     from ._sharding_rules import register_cp_sharding_rules
 

--- a/torch/distributed/tensor/experimental/_context_parallel/_sharding_rules.py
+++ b/torch/distributed/tensor/experimental/_context_parallel/_sharding_rules.py
@@ -74,9 +74,7 @@ def _op_strategy_context(op_overload, strategy_func, schema_info=None):
         else:
             propagator.op_to_schema_info[op_overload] = _origin_op_strategy_schema
 
-        # Ideally, we should clear the cache, but it is too expensive.
-        # _clear_python_sharding_prop_cache()
-        # _clear_fast_path_sharding_prop_cache()
+        propagator.invalidate_caches()
 
 
 # ==================== Flash Attention Strategies ====================

--- a/torch/distributed/tensor/parallel/loss.py
+++ b/torch/distributed/tensor/parallel/loss.py
@@ -161,9 +161,13 @@ def _log_softmax_handler(
     op_call: torch._ops.OpOverload,
     args: tuple[object, ...],
     kwargs: dict[str, object],
+    *,
+    dtensor_type: type[DTensor] | None = None,
 ) -> object:
     x = cast(DTensor, args[0])
-    dtensor_type = x.__class__
+    dtensor_type = (
+        cast(type[DTensor], x.__class__) if dtensor_type is None else dtensor_type
+    )
     dim = cast(int, args[1])
     half_to_float = cast(bool, args[2])
 
@@ -197,6 +201,8 @@ def _log_softmax_backward_handler(
     op_call: torch._ops.OpOverload,
     args: tuple[object, ...],
     kwargs: dict[str, object],
+    *,
+    dtensor_type: type[DTensor] | None = None,
 ) -> object:
     grad_output = cast(DTensor, args[0])
     input_dtype = cast(torch.dtype, args[3])
@@ -284,9 +290,13 @@ def _nll_loss_forward_handler(
     op_call: torch._ops.OpOverload,
     args: tuple[object, ...],
     kwargs: dict[str, object],
+    *,
+    dtensor_type: type[DTensor] | None = None,
 ) -> object:
     x = cast(DTensor, args[0])
-    dtensor_type = x.__class__
+    dtensor_type = (
+        cast(type[DTensor], x.__class__) if dtensor_type is None else dtensor_type
+    )
     target = args[1]
     weight = args[2]
     reduction = cast(int, args[3])
@@ -436,10 +446,14 @@ def _nll_loss_backward_handler(
     op_call: torch._ops.OpOverload,
     args: tuple[object, ...],
     kwargs: dict[str, object],
+    *,
+    dtensor_type: type[DTensor] | None = None,
 ) -> object:
     grad_output = cast(DTensor, args[0])
     x = cast(DTensor, args[1])
-    dtensor_type = x.__class__
+    dtensor_type = (
+        cast(type[DTensor], x.__class__) if dtensor_type is None else dtensor_type
+    )
     target = args[2]
     weight = args[3]
     reduction = cast(int, args[4])

--- a/torch/distributed/tensor/parallel/loss.py
+++ b/torch/distributed/tensor/parallel/loss.py
@@ -114,9 +114,7 @@ def _propagate_tensor_meta(
     dtensor_type: type[DTensor] | None = None,
 ) -> TensorMeta:
     input_dtensor = cast(DTensor, args[0])
-    dtensor_type = (
-        input_dtensor.__class__ if dtensor_type is None else dtensor_type
-    )
+    dtensor_type = input_dtensor.__class__ if dtensor_type is None else dtensor_type
     dispatcher = dtensor_type._op_dispatcher
     op_info = dispatcher.unwrap_to_op_info(op_call, args, kwargs)
     if op_info.schema is None:

--- a/torch/distributed/tensor/parallel/loss.py
+++ b/torch/distributed/tensor/parallel/loss.py
@@ -113,10 +113,9 @@ def _propagate_tensor_meta(
     *,
     dtensor_type: type[DTensor] | None = None,
 ) -> TensorMeta:
+    input_dtensor = cast(DTensor, args[0])
     dtensor_type = (
-        cast(type[DTensor], cast(DTensor, args[0]).__class__)
-        if dtensor_type is None
-        else dtensor_type
+        input_dtensor.__class__ if dtensor_type is None else dtensor_type
     )
     dispatcher = dtensor_type._op_dispatcher
     op_info = dispatcher.unwrap_to_op_info(op_call, args, kwargs)
@@ -171,9 +170,7 @@ def _log_softmax_handler(
     dtensor_type: type[DTensor] | None = None,
 ) -> object:
     x = cast(DTensor, args[0])
-    dtensor_type = (
-        cast(type[DTensor], x.__class__) if dtensor_type is None else dtensor_type
-    )
+    dtensor_type = x.__class__ if dtensor_type is None else dtensor_type
     dim = cast(int, args[1])
     half_to_float = cast(bool, args[2])
 
@@ -302,9 +299,7 @@ def _nll_loss_forward_handler(
     dtensor_type: type[DTensor] | None = None,
 ) -> object:
     x = cast(DTensor, args[0])
-    dtensor_type = (
-        cast(type[DTensor], x.__class__) if dtensor_type is None else dtensor_type
-    )
+    dtensor_type = x.__class__ if dtensor_type is None else dtensor_type
     target = args[1]
     weight = args[2]
     reduction = cast(int, args[3])
@@ -461,9 +456,7 @@ def _nll_loss_backward_handler(
 ) -> object:
     grad_output = cast(DTensor, args[0])
     x = cast(DTensor, args[1])
-    dtensor_type = (
-        cast(type[DTensor], x.__class__) if dtensor_type is None else dtensor_type
-    )
+    dtensor_type = x.__class__ if dtensor_type is None else dtensor_type
     target = args[2]
     weight = args[3]
     reduction = cast(int, args[4])

--- a/torch/distributed/tensor/parallel/loss.py
+++ b/torch/distributed/tensor/parallel/loss.py
@@ -110,15 +110,21 @@ def _propagate_tensor_meta(
     op_call: torch._ops.OpOverload,
     args: tuple[object, ...],
     kwargs: dict[str, object],
+    *,
+    dtensor_type: type[DTensor] | None = None,
 ) -> TensorMeta:
-    op_info = DTensor._op_dispatcher.unwrap_to_op_info(op_call, args, kwargs)
+    dtensor_type = (
+        cast(type[DTensor], cast(DTensor, args[0]).__class__)
+        if dtensor_type is None
+        else dtensor_type
+    )
+    dispatcher = dtensor_type._op_dispatcher
+    op_info = dispatcher.unwrap_to_op_info(op_call, args, kwargs)
     if op_info.schema is None:
         raise AssertionError(
             "op_info.schema should not be None after unwrap_to_op_info"
         )
-    tensor_meta = DTensor._op_dispatcher.sharding_propagator._propagate_tensor_meta(
-        op_info.schema
-    )
+    tensor_meta = dispatcher.sharding_propagator._propagate_tensor_meta(op_info.schema)
     if isinstance(tensor_meta, TensorMeta):
         return tensor_meta
     elif isinstance(tensor_meta, tuple):
@@ -175,7 +181,9 @@ def _log_softmax_handler(
     dim = normalize_dim(dim, x.dim())
     mesh_dim = _find_all_reduce_mesh_dim(spec.placements, dim)
 
-    output_tensor_meta = _propagate_tensor_meta(op_call, args, kwargs)
+    output_tensor_meta = _propagate_tensor_meta(
+        op_call, args, kwargs, dtensor_type=dtensor_type
+    )
 
     res = _log_softmax(x._local_tensor, dim, half_to_float, spec.mesh, mesh_dim)
 
@@ -336,7 +344,9 @@ def _nll_loss_forward_handler(
     args = list(args)
     # pyrefly: ignore [unsupported-operation]
     args[1], args[2] = target, weight
-    output_tensor_meta = _propagate_tensor_meta(op_call, tuple(args), kwargs)
+    output_tensor_meta = _propagate_tensor_meta(
+        op_call, tuple(args), kwargs, dtensor_type=dtensor_type
+    )
 
     result, total_weight = _nll_loss_forward(
         x._local_tensor,
@@ -480,7 +490,9 @@ def _nll_loss_backward_handler(
     args[2], args[3] = target, weight
     # pyrefly: ignore [unsupported-operation]
     args[6] = _cast_to_dtensor(total_weight, all_replicate_placements, spec.mesh)
-    output_tensor_meta = _propagate_tensor_meta(op_call, tuple(args), kwargs)
+    output_tensor_meta = _propagate_tensor_meta(
+        op_call, tuple(args), kwargs, dtensor_type=dtensor_type
+    )
 
     result = _nll_loss_and_log_softmax_backward(
         grad_output._local_tensor,

--- a/torch/distributed/tensor/parallel/loss.py
+++ b/torch/distributed/tensor/parallel/loss.py
@@ -163,6 +163,7 @@ def _log_softmax_handler(
     kwargs: dict[str, object],
 ) -> object:
     x = cast(DTensor, args[0])
+    dtensor_type = x.__class__
     dim = cast(int, args[1])
     half_to_float = cast(bool, args[2])
 
@@ -181,7 +182,7 @@ def _log_softmax_handler(
     )
 
     # pyrefly: ignore [bad-argument-type]
-    return DTensor(
+    return dtensor_type(
         # pyrefly: ignore [bad-argument-count]
         res,
         res_spec,
@@ -285,6 +286,7 @@ def _nll_loss_forward_handler(
     kwargs: dict[str, object],
 ) -> object:
     x = cast(DTensor, args[0])
+    dtensor_type = x.__class__
     target = args[1]
     weight = args[2]
     reduction = cast(int, args[3])
@@ -342,7 +344,7 @@ def _nll_loss_forward_handler(
 
     return (
         # pyrefly: ignore [bad-argument-type]
-        DTensor(
+        dtensor_type(
             # pyrefly: ignore [bad-argument-count]
             result,
             out_spec,
@@ -437,6 +439,7 @@ def _nll_loss_backward_handler(
 ) -> object:
     grad_output = cast(DTensor, args[0])
     x = cast(DTensor, args[1])
+    dtensor_type = x.__class__
     target = args[2]
     weight = args[3]
     reduction = cast(int, args[4])
@@ -486,7 +489,7 @@ def _nll_loss_backward_handler(
     )
 
     # pyrefly: ignore [bad-argument-type]
-    return DTensor(
+    return dtensor_type(
         # pyrefly: ignore [bad-argument-count]
         result,
         out_spec,


### PR DESCRIPTION
Fix #177716

## Summary
1. What is the root cause problem
   The DTensor C++ fast path started treating DTensor subclasses the same as the exact `DTensor` type, so subclass `__torch_dispatch__` overrides were skipped entirely. At the same time, the Python DTensor fallback and Python-side custom handlers hardcoded the base `DTensor`, so delegating with `super().__torch_dispatch__()` or a subclass `_op_dispatcher` could not preserve subclass behavior.

2. What is the proposed fix
   Keep the C++ fast path limited to the exact `DTensor` type, restore the Python `DTensor.__torch_dispatch__` path for subclasses, thread the runtime subclass through Python rewrapping and custom handlers, and add a regression test that exercises a DTensor subclass delegating with `super().__torch_dispatch__()`.

3. Why the proposed fix is the right long term fix
   This preserves the C++ optimization for the common base-DTensor case while restoring the expected tensor-subclass dispatch contract for DTensor subclasses without introducing a second subclass-specific C++ dispatch path.

Drafted via @codex, published after manual review by @bobrenjc93