### PR TITLE
[DCP] Fix unpicklable FrameSummary._code on Python 3.13+ (#177754)

### DIFF
--- a/test/distributed/checkpoint/test_utils.py
+++ b/test/distributed/checkpoint/test_utils.py
@@ -2,6 +2,7 @@
 
 import io
 import sys
+import traceback
 
 import torch
 import torch.distributed as dist
@@ -13,6 +14,7 @@ from torch.distributed._shard.sharded_tensor import (
 )
 from torch.distributed._shard.sharded_tensor.metadata import TensorProperties
 from torch.distributed.c10d_logger import _c10d_logger
+from torch.distributed.checkpoint.api import _wrap_exception
 from torch.distributed.checkpoint.logger import _dcp_logger
 from torch.distributed.checkpoint.metadata import MetadataIndex
 from torch.distributed.checkpoint.utils import (
@@ -20,6 +22,7 @@ from torch.distributed.checkpoint.utils import (
     _DistWrapper,
     find_state_dict_object,
 )
+from torch.distributed.distributed_c10d import _object_to_tensor, _tensor_to_object
 from torch.testing._internal.common_utils import (
     run_tests,
     TEST_WITH_DEV_DBG_ASAN,
@@ -137,6 +140,44 @@ class TestMedatadaIndex(TestCase):
     def test_dcp_logger(self):
         self.assertTrue(_c10d_logger is not _dcp_logger)
         self.assertEqual(1, len(_c10d_logger.handlers))
+
+
+class TestWrapException(TestCase):
+    def test_wrap_exception_serializable_via_object_to_tensor(self):
+        """Verify _wrap_exception produces a result that _object_to_tensor can serialize.
+
+        Python 3.13+ adds a _code attribute to FrameSummary containing
+        bytecode objects that cannot be pickled. _wrap_exception must
+        clear these so that _object_to_tensor (used by gather_object and
+        scatter_object_list) succeeds instead of raising
+        "TypeError: cannot pickle code objects".
+        """
+        try:
+            raise ValueError("test error")
+        except ValueError as e:
+            wrapped = _wrap_exception(e)
+
+        # _object_to_tensor / _tensor_to_object are what gather_object
+        # and scatter_object_list use to serialize objects across ranks.
+        # This would raise "TypeError: cannot pickle code objects"
+        # on Python 3.13+ without the fix.
+        byte_tensor, size = _object_to_tensor(wrapped, torch.device("cpu"), None)
+        restored = _tensor_to_object(byte_tensor, size.item(), None)
+
+        self.assertIsInstance(restored[0], ValueError)
+        self.assertEqual(str(restored[0]), "test error")
+        self.assertIsInstance(restored[1], traceback.StackSummary)
+        self.assertGreater(len(restored[1]), 0)
+
+    def test_wrap_exception_preserves_traceback_formatting(self):
+        """Verify that clearing _code does not break traceback formatting."""
+        try:
+            raise RuntimeError("format test")
+        except RuntimeError as e:
+            wrapped = _wrap_exception(e)
+
+        formatted = "".join(traceback.format_list(wrapped[1]))
+        self.assertIn("raise RuntimeError", formatted)
 
 
 class TestReaderView(TestCase):

--- a/torch/distributed/checkpoint/api.py
+++ b/torch/distributed/checkpoint/api.py
@@ -8,7 +8,15 @@ __all__ = ["CheckpointException"]
 
 
 def _wrap_exception(exc: BaseException) -> WRAPPED_EXCEPTION:
-    return (exc, tb.extract_tb(exc.__traceback__))
+    summary = tb.extract_tb(exc.__traceback__)
+    # Python 3.13+ stores bytecode objects in FrameSummary._code,
+    # which cannot be pickled. Clear them so gather_object succeeds
+    # and the real exception is reported instead of a misleading
+    # "cannot pickle code objects" TypeError.
+    for frame in summary:
+        if hasattr(frame, "_code"):
+            object.__setattr__(frame, "_code", None)
+    return (exc, summary)
 
 
 def _is_wrapped_exception(obj: Any) -> bool:


### PR DESCRIPTION
Summary:

RE: user post: https://fb.workplace.com/groups/319878845696681/permalink/1657362868614932/

In Python 3.13+, `traceback.extract_tb()` produces `FrameSummary` objects
with a `_code` attribute containing actual bytecode objects. These cannot
be pickled, so when DCP's `_wrap_exception` wraps an error and later
`gather_object` tries to pickle it across ranks, it fails with a misleading
`TypeError: cannot pickle code objects` — hiding the real error.

Fix this by clearing the `_code` attribute on each frame after extracting
the traceback. The attribute is not needed for formatting since
`FrameSummary` already stores filename, line number, function name, and
source text as strings.

Test Plan: buck test fbcode//caffe2/test/distributed/checkpoint:test_utils -m opt -- test_wrap_exception_serializable_via_object_to_tensor test_wrap_exception_preserves_traceback_formatting

Differential Revision: D97143556
