### PR TITLE
[BE][Ez]: Fuse empty strided_as call to empty_strided op

### DIFF
--- a/aten/src/ATen/native/transformers/sdp_utils.h
+++ b/aten/src/ATen/native/transformers/sdp_utils.h
@@ -37,9 +37,7 @@ void alloc_with_matching_layout(
     ordered_strides[dim_idx] = current_stride;
     current_stride *= shape[dim_idx];
   }
-  output = at::empty(at::IntArrayRef(shape), q.options())
-               .as_strided(
-                   at::IntArrayRef(shape), at::IntArrayRef(ordered_strides), 0);
+  output = at::empty_strided(at::IntArrayRef(shape), at::IntArrayRef(ordered_strides), q.options());
 }
 
 void permute_to_matching_layout(const Tensor& output, Tensor& grad_output) {


### PR DESCRIPTION
These two calls can be fused into single empty_strided op, ensuring better argument checking and lower dispatch cost.