### PR TITLE
[AutoAC] Add memory budget and activation size fields to min_cut structured trace (#177756)

### DIFF
--- a/test/functorch/test_ac_logging.py
+++ b/test/functorch/test_ac_logging.py
@@ -41,6 +41,12 @@ class TestAcLogging(TestCase):
         self.normalized_memories_banned_nodes: list[float] = [0.10344827586206896]
         self.runtimes_banned_nodes: list[int] = [10]
         self.min_cut_saved_values: list[Node] = [self.node1]
+        self.memory_budget: float = 0.5
+        self.min_act_size: float = 0.001
+        self.max_act_size: float = 0.01
+        self.saved_values_act_size: float = 0.005
+        self.more_aggressive_saved_values_mem_ratio: float = 0.9
+        self.aggressive_recomputation_saved_values_mem_ratio: float = 0.8
 
     def test_create_joint_graph_node_information(self) -> None:
         recomputable_node_info: dict[str, int] = {"node1": 0}
@@ -99,6 +105,12 @@ class TestAcLogging(TestCase):
             "Absolute Memories": self.memories_banned_nodes,
             "Knapsack Input Runtimes": self.runtimes_banned_nodes,
             "Min Cut Solution Saved Values": ["node1"],
+            "Memory Budget": self.memory_budget,
+            "Min Activation Size (GB)": self.min_act_size,
+            "Max Activation Size (GB)": self.max_act_size,
+            "Saved Values Activation Size (GB)": self.saved_values_act_size,
+            "More Aggressive Saved Values Mem Ratio": self.more_aggressive_saved_values_mem_ratio,
+            "Aggressive Recomputation Saved Values Mem Ratio": self.aggressive_recomputation_saved_values_mem_ratio,
         }
         result = create_activation_checkpointing_logging_structure_payload(
             joint_graph=self.graph,
@@ -112,6 +124,12 @@ class TestAcLogging(TestCase):
             normalized_memories_banned_nodes=self.normalized_memories_banned_nodes,
             runtimes_banned_nodes=self.runtimes_banned_nodes,
             min_cut_saved_values=self.min_cut_saved_values,
+            memory_budget=self.memory_budget,
+            min_act_size=self.min_act_size,
+            max_act_size=self.max_act_size,
+            saved_values_act_size=self.saved_values_act_size,
+            more_aggressive_saved_values_mem_ratio=self.more_aggressive_saved_values_mem_ratio,
+            aggressive_recomputation_saved_values_mem_ratio=self.aggressive_recomputation_saved_values_mem_ratio,
         )
         self.assertEqual(result, expected_payload)
 
@@ -132,6 +150,12 @@ class TestAcLogging(TestCase):
             normalized_memories_banned_nodes=self.normalized_memories_banned_nodes,
             runtimes_banned_nodes=self.runtimes_banned_nodes,
             min_cut_saved_values=self.min_cut_saved_values,
+            memory_budget=self.memory_budget,
+            min_act_size=self.min_act_size,
+            max_act_size=self.max_act_size,
+            saved_values_act_size=self.saved_values_act_size,
+            more_aggressive_saved_values_mem_ratio=self.more_aggressive_saved_values_mem_ratio,
+            aggressive_recomputation_saved_values_mem_ratio=self.aggressive_recomputation_saved_values_mem_ratio,
         )
 
         self.assertEqual(mock_trace_structured.call_count, 1)

--- a/torch/_functorch/_activation_checkpointing/ac_logging_utils.py
+++ b/torch/_functorch/_activation_checkpointing/ac_logging_utils.py
@@ -65,6 +65,12 @@ def create_activation_checkpointing_logging_structure_payload(
     normalized_memories_banned_nodes: list[float],
     runtimes_banned_nodes: list[float],
     min_cut_saved_values: list[Node],
+    memory_budget: float,
+    min_act_size: float,
+    max_act_size: float,
+    saved_values_act_size: float,
+    more_aggressive_saved_values_mem_ratio: float,
+    aggressive_recomputation_saved_values_mem_ratio: float,
 ) -> dict[str, Any]:
     """
     Creates a structured payload for logging activation checkpointing information.
@@ -83,6 +89,12 @@ def create_activation_checkpointing_logging_structure_payload(
         runtimes_banned_nodes: Runtime values for banned nodes, used as input to the
             knapsack algorithm.
         min_cut_saved_values: List of nodes saved by the min-cut algorithm.
+        memory_budget: The memory budget ratio (0 to 1) used for activation checkpointing.
+        min_act_size: Minimum activation size in GB (size when saving only inputs).
+        max_act_size: Maximum activation size in GB (size when saving all runtime-optimized values).
+        saved_values_act_size: Estimated activation size in GB for the saved values.
+        more_aggressive_saved_values_mem_ratio: Memory ratio for more aggressive recomputation strategy.
+        aggressive_recomputation_saved_values_mem_ratio: Memory ratio for fully aggressive recomputation strategy.
 
     Returns:
         A dictionary containing structured logging information for activation checkpointing.
@@ -104,6 +116,12 @@ def create_activation_checkpointing_logging_structure_payload(
         "Knapsack Input Memories": normalized_memories_banned_nodes,
         "Knapsack Input Runtimes": runtimes_banned_nodes,
         "Min Cut Solution Saved Values": [node.name for node in min_cut_saved_values],
+        "Memory Budget": memory_budget,
+        "Min Activation Size (GB)": min_act_size,
+        "Max Activation Size (GB)": max_act_size,
+        "Saved Values Activation Size (GB)": saved_values_act_size,
+        "More Aggressive Saved Values Mem Ratio": more_aggressive_saved_values_mem_ratio,
+        "Aggressive Recomputation Saved Values Mem Ratio": aggressive_recomputation_saved_values_mem_ratio,
     }
     return activation_checkpointing_logging_structure_payload
 
@@ -118,6 +136,12 @@ def create_structured_trace_for_min_cut_info(
     normalized_memories_banned_nodes: list[float],
     runtimes_banned_nodes: list[float],
     min_cut_saved_values: list[Node],
+    memory_budget: float,
+    min_act_size: float,
+    max_act_size: float,
+    saved_values_act_size: float,
+    more_aggressive_saved_values_mem_ratio: float,
+    aggressive_recomputation_saved_values_mem_ratio: float,
 ) -> None:
     """
     Creates a structured trace for minimum cut information in the graph.
@@ -133,6 +157,12 @@ def create_structured_trace_for_min_cut_info(
             (typically scaled between 0 and 1 for relative comparison).
         runtimes_banned_nodes: Runtime costs associated with each banned node.
         min_cut_saved_values: Nodes that are saved as part of the minimum cut solution.
+        memory_budget: The memory budget ratio (0 to 1) used for activation checkpointing.
+        min_act_size: Minimum activation size in GB (size when saving only inputs).
+        max_act_size: Maximum activation size in GB (size when saving all runtime-optimized values).
+        saved_values_act_size: Estimated activation size in GB for the saved values.
+        more_aggressive_saved_values_mem_ratio: Memory ratio for more aggressive recomputation strategy.
+        aggressive_recomputation_saved_values_mem_ratio: Memory ratio for fully aggressive recomputation strategy.
     """
     # Create a dictionary to store recomputable node information
     recomputable_node_info: dict[str, int] = {
@@ -178,6 +208,12 @@ def create_structured_trace_for_min_cut_info(
             normalized_memories_banned_nodes=normalized_memories_banned_nodes,
             runtimes_banned_nodes=runtimes_banned_nodes,
             min_cut_saved_values=min_cut_saved_values,
+            memory_budget=memory_budget,
+            min_act_size=min_act_size,
+            max_act_size=max_act_size,
+            saved_values_act_size=saved_values_act_size,
+            more_aggressive_saved_values_mem_ratio=more_aggressive_saved_values_mem_ratio,
+            aggressive_recomputation_saved_values_mem_ratio=aggressive_recomputation_saved_values_mem_ratio,
         )
     )
 

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -3129,7 +3129,8 @@ def choose_saved_values_set(
     more_aggressive_saved_values, _ = solve_min_cut(
         joint_graph, node_info, more_aggressive_options
     )
-    if get_mem_ratio(more_aggressive_saved_values) < memory_budget:
+    more_aggressive_saved_values_mem_ratio = get_mem_ratio(more_aggressive_saved_values)
+    if more_aggressive_saved_values_mem_ratio < memory_budget:
         return more_aggressive_saved_values
 
     aggressive_options = replace(
@@ -3140,7 +3141,8 @@ def choose_saved_values_set(
         joint_graph, node_info, aggressive_options
     )
 
-    if get_mem_ratio(aggressive_recomputation_saved_values) < memory_budget:
+    aggressive_recomputation_saved_values_mem_ratio = get_mem_ratio(aggressive_recomputation_saved_values)
+    if aggressive_recomputation_saved_values_mem_ratio < memory_budget:
         return aggressive_recomputation_saved_values
 
     from torch._inductor.fx_utils import get_node_storage
@@ -3238,6 +3240,12 @@ def choose_saved_values_set(
                 normalized_memories_banned_nodes=memories_banned_nodes,
                 runtimes_banned_nodes=runtimes_banned_nodes,
                 min_cut_saved_values=saved_values,
+                memory_budget=memory_budget,
+                min_act_size=min_act_size,
+                max_act_size=max_act_size,
+                saved_values_act_size=estimate_activations_size(saved_values),
+                more_aggressive_saved_values_mem_ratio=more_aggressive_saved_values_mem_ratio,
+                aggressive_recomputation_saved_values_mem_ratio=aggressive_recomputation_saved_values_mem_ratio,
             )
         return saved_values, expected_runtime
 


### PR DESCRIPTION
Summary:

Adds six diagnostic fields to the `min_cut_information` structured trace artifact emitted by the activation checkpointing partitioner. These fields give visibility into the partitioner decision context when analyzing tlparse reports:

- `memory_budget`: the budget ratio (0-1) that drives the save-vs-recompute trade-off
- `min_act_size` / `max_act_size`: activation size bounds in GB (inputs-only vs all-runtime-optimized)
- `saved_values_act_size`: estimated activation size for the chosen saved values
- `more_aggressive_saved_values_mem_ratio`: memory ratio after relaxing ban heuristics
- `aggressive_recomputation_saved_values_mem_ratio`: memory ratio after fully aggressive recomputation

In `partitioners.py`, the `get_mem_ratio()` results for the two aggressive strategies are extracted into named variables so they can be passed through to the logging call without recomputation.

Test Plan:
```
buck test fbcode//caffe2/test/functorch:test_ac_logging 
```

Differential Revision: D96555961


