### PR TITLE
Disable slice optimization for make_fx tensor indexing

### DIFF
--- a/aten/src/ATen/TensorIndexing.h
+++ b/aten/src/ATen/TensorIndexing.h
@@ -625,8 +625,8 @@ inline Tensor dispatch_index_put_(
 //      return sliced;
 //    }
 //    ```)
-// 2. When we are doing JIT tracing or ProxyTensor tracing, including
-//    pre-dispatch ProxyTensor tracing.
+// 2. When we are doing JIT tracing or Python-dispatch-based ProxyTensor
+//    tracing, i.e. symbolic tracing or pre-dispatch ProxyTensor tracing.
 //    Reason: tracing needs the `self.slice(...)` call to properly trace the
 //    slice operation instead of optimizing it away.
 

--- a/aten/src/ATen/TensorIndexing.h
+++ b/aten/src/ATen/TensorIndexing.h
@@ -625,7 +625,8 @@ inline Tensor dispatch_index_put_(
 //      return sliced;
 //    }
 //    ```)
-// 2. When we are doing JIT tracing or ProxyTensor tracing.
+// 2. When we are doing JIT tracing or ProxyTensor tracing, including
+//    pre-dispatch ProxyTensor tracing.
 //    Reason: tracing needs the `self.slice(...)` call to properly trace the
 //    slice operation instead of optimizing it away.
 

--- a/aten/src/ATen/TensorIndexing.h
+++ b/aten/src/ATen/TensorIndexing.h
@@ -625,9 +625,9 @@ inline Tensor dispatch_index_put_(
 //      return sliced;
 //    }
 //    ```)
-// 2. When we are doing JIT tracing.
-//    Reason: JIT tracing needs the `self.slice(...)` call to properly trace the
-//    slice operation.
+// 2. When we are doing JIT tracing or ProxyTensor tracing.
+//    Reason: tracing needs the `self.slice(...)` call to properly trace the
+//    slice operation instead of optimizing it away.
 
 // This mirrors `THPVariable_getitem` in
 // torch/csrc/autograd/python_variable_indexing.cpp See NOTE [ Setting

--- a/aten/src/ATen/TensorIndexing.h
+++ b/aten/src/ATen/TensorIndexing.h
@@ -625,10 +625,13 @@ inline Tensor dispatch_index_put_(
 //      return sliced;
 //    }
 //    ```)
-// 2. When we are doing JIT tracing or Python-dispatch-based ProxyTensor
-//    tracing, i.e. symbolic tracing or pre-dispatch ProxyTensor tracing.
-//    Reason: tracing needs the `self.slice(...)` call to properly trace the
+// 2. When we are doing JIT tracing.
+//    Reason: JIT tracing needs the `self.slice(...)` call to properly trace the
 //    slice operation instead of optimizing it away.
+// 3. When we are doing symbolic or pre-dispatch ProxyTensor tracing on a
+//    Python slice with symbolic bounds.
+//    Reason: the symbolic bound needs the `self.slice(...)` call to survive
+//    tracing instead of being optimized into an alias.
 
 // This mirrors `THPVariable_getitem` in
 // torch/csrc/autograd/python_variable_indexing.cpp See NOTE [ Setting

--- a/test/test_proxy_tensor.py
+++ b/test/test_proxy_tensor.py
@@ -1429,10 +1429,13 @@ def forward(self, crop_camera_1, mask_1):
             x = x[m]
             return x[slice(None, None, None), slice(None, None, None), slice(None, 2, None)]
 
-        make_fx(f, tracing_mode="symbolic")(
+        gm = make_fx(f, tracing_mode="symbolic")(
             torch.randn((12, 3, 3)),
             torch.randint(0, 2, (12,), dtype=torch.bool)
         )
+        guards = show_guards(gm)
+        self.assertIn("2 <= L['x'].size()[2]", guards)
+        self.assertNotIn("L['x'].size()[2] != 2", guards)
 
     @unittest.skipIf(not USE_TORCHVISION, "test requires torchvision")
     def test_unbacked_batch_resnet(self):

--- a/test/test_proxy_tensor.py
+++ b/test/test_proxy_tensor.py
@@ -958,6 +958,19 @@ def forward(self, x_1):
     alias = torch.ops.aten.alias.default(x_1);  x_1 = None
     return alias""")
 
+    def test_noop_slice_keeps_alias_for_concrete_tracing(self):
+        if self.tracing_mode == "symbolic":
+            self.skipTest("symbolic tracing must materialize the slice op")
+
+        def f(x):
+            return x[:, :x.shape[1]]
+
+        traced = make_fx(f, tracing_mode=self.tracing_mode)(torch.randn(2, 3))
+        self.assertExpectedInline(traced.code.strip(), """\
+def forward(self, x_1):
+    alias = torch.ops.aten.alias.default(x_1);  x_1 = None
+    return alias""")
+
     def test_meta(self):
         def f(x):
             a = x.cos()

--- a/test/test_proxy_tensor.py
+++ b/test/test_proxy_tensor.py
@@ -1429,13 +1429,18 @@ def forward(self, crop_camera_1, mask_1):
             x = x[m]
             return x[slice(None, None, None), slice(None, None, None), slice(None, 2, None)]
 
-        gm = make_fx(f, tracing_mode="symbolic")(
-            torch.randn((12, 3, 3)),
-            torch.randint(0, 2, (12,), dtype=torch.bool)
-        )
-        guards = show_guards(gm)
-        self.assertIn("2 <= L['x'].size()[2]", guards)
-        self.assertNotIn("L['x'].size()[2] != 2", guards)
+        for make_fx_kwargs in (
+            {"tracing_mode": "symbolic"},
+            {"tracing_mode": "symbolic", "pre_dispatch": True},
+        ):
+            with self.subTest(make_fx_kwargs=make_fx_kwargs):
+                gm = make_fx(f, **make_fx_kwargs)(
+                    torch.randn((12, 3, 3)),
+                    torch.randint(0, 2, (12,), dtype=torch.bool)
+                )
+                guards = show_guards(gm)
+                self.assertIn("2 <= L['x'].size()[2]", guards)
+                self.assertNotIn("L['x'].size()[2] != 2", guards)
 
     @unittest.skipIf(not USE_TORCHVISION, "test requires torchvision")
     def test_unbacked_batch_resnet(self):

--- a/test/test_proxy_tensor.py
+++ b/test/test_proxy_tensor.py
@@ -817,6 +817,19 @@ def forward(self, x_1):
             gm, (sample,), options={"fx_wrapper": True, "compile_threads": 1}
         )
 
+    def test_noop_slice_keeps_alias_for_concrete_tracing(self):
+        if self.tracing_mode == "symbolic":
+            self.skipTest("symbolic tracing must materialize the slice op")
+
+        def f(x):
+            return x[:, :x.shape[1]]
+
+        traced = make_fx(f, tracing_mode=self.tracing_mode)(torch.randn(2, 3))
+        self.assertExpectedInline(traced.code.strip(), """\
+def forward(self, x_1):
+    alias = torch.ops.aten.alias.default(x_1);  x_1 = None
+    return alias""")
+
 
 class TestGenericProxyTensorReal(TestGenericProxyTensor):
     tracing_mode = "real"
@@ -954,19 +967,6 @@ class TestFakeProxyTensor(TestCase):
         r = str(make_fx(f, tracing_mode="fake")(torch.randn(2)).code).strip()
         # NB: this should not have a detach call
         self.assertExpectedInline(r, """\
-def forward(self, x_1):
-    alias = torch.ops.aten.alias.default(x_1);  x_1 = None
-    return alias""")
-
-    def test_noop_slice_keeps_alias_for_concrete_tracing(self):
-        if self.tracing_mode == "symbolic":
-            self.skipTest("symbolic tracing must materialize the slice op")
-
-        def f(x):
-            return x[:, :x.shape[1]]
-
-        traced = make_fx(f, tracing_mode=self.tracing_mode)(torch.randn(2, 3))
-        self.assertExpectedInline(traced.code.strip(), """\
 def forward(self, x_1):
     alias = torch.ops.aten.alias.default(x_1);  x_1 = None
     return alias""")

--- a/torch/csrc/autograd/python_variable_indexing.cpp
+++ b/torch/csrc/autograd/python_variable_indexing.cpp
@@ -226,14 +226,13 @@ static PyObject* get_dispatch_mode_pre_dispatch() {
     throw python_error();
   }
 
-  auto get_dispatch_mode_pre_dispatch =
-      PyObject_GetAttrString(torch_ops.get(), "_get_dispatch_mode_pre_dispatch");
+  auto get_dispatch_mode_pre_dispatch = PyObject_GetAttrString(
+      torch_ops.get(), "_get_dispatch_mode_pre_dispatch");
   if (!get_dispatch_mode_pre_dispatch) {
     throw python_error();
   }
 
-  THPVariable_get_dispatch_mode_pre_dispatch =
-      get_dispatch_mode_pre_dispatch;
+  THPVariable_get_dispatch_mode_pre_dispatch = get_dispatch_mode_pre_dispatch;
   return THPVariable_get_dispatch_mode_pre_dispatch;
 }
 
@@ -247,8 +246,8 @@ static PyObject* get_proxy_mode_key() {
     throw python_error();
   }
 
-  auto torch_dispatch_mode_key =
-      THPObjectPtr(PyObject_GetAttrString(torch_C.get(), "_TorchDispatchModeKey"));
+  auto torch_dispatch_mode_key = THPObjectPtr(
+      PyObject_GetAttrString(torch_C.get(), "_TorchDispatchModeKey"));
   if (!torch_dispatch_mode_key) {
     throw python_error();
   }
@@ -272,6 +271,14 @@ static bool isPreDispatchProxyTracingModeActive() {
     throw python_error();
   }
   return maybe_mode.get() != Py_None;
+}
+
+static bool sliceHasSymbolicBounds(PyObject* obj) {
+  auto* sliceobj = reinterpret_cast<PySliceObject*>(obj);
+  return (
+      torch::is_symint(sliceobj->start) ||
+      torch::is_symint(sliceobj->stop) ||
+      torch::is_symint(sliceobj->step));
 }
 
 static bool shouldDisableSliceOptimizationForProxyMode(PyObject* mode) {
@@ -319,7 +326,7 @@ static Variable applySlicing(
     PyObject* index,
     variable_list& outIndices,
     bool is_tracing,
-    bool disable_slice_optimization,
+    bool symbolic_or_predispatch_proxy_tracing,
     const at::Device& self_device,
     const std::optional<int64_t>& self_ndim,
     int64_t specified_dims) {
@@ -337,6 +344,9 @@ static Variable applySlicing(
   Variable result = self;
   for (const auto i : c10::irange(size)) {
     PyObject* obj = PyTuple_GET_ITEM(index, i);
+    bool disable_slice_optimization =
+        is_tracing || (symbolic_or_predispatch_proxy_tracing &&
+                       PySlice_Check(obj) && sliceHasSymbolicBounds(obj));
     // NOTE [nested tensor size for indexing]
     // nested tensor does not have a size (yet) so for now we represent its size
     // as null may need to be changed after we reach a better solution for
@@ -510,8 +520,8 @@ PyObject* THPVariable_getitem(PyObject* self, PyObject* index) {
   }
 
   bool is_tracing = torch::jit::tracer::isTracing();
-  bool disable_slice_optimization =
-      is_tracing || isSymbolicOrPreDispatchProxyTracingModeActive();
+  bool symbolic_or_predispatch_proxy_tracing =
+      isSymbolicOrPreDispatchProxyTracingModeActive();
 
   // handle simple types: integers, slices, bool
   if (THPUtils_checkLong(index)) {
@@ -549,8 +559,8 @@ PyObject* THPVariable_getitem(PyObject* self, PyObject* index) {
       self_,
       holder.get(),
       variableIndices,
-      /*is_tracing=*/is_tracing,
-      /*disable_slice_optimization=*/disable_slice_optimization,
+      is_tracing,
+      symbolic_or_predispatch_proxy_tracing,
       self_.device(),
       self_.ndimension(),
       specified_dims);
@@ -639,8 +649,8 @@ int THPVariable_setitem(PyObject* self, PyObject* index, PyObject* py_value) {
   }
 
   bool is_tracing = torch::jit::tracer::isTracing();
-  bool disable_slice_optimization =
-      is_tracing || isSymbolicOrPreDispatchProxyTracingModeActive();
+  bool symbolic_or_predispatch_proxy_tracing =
+      isSymbolicOrPreDispatchProxyTracingModeActive();
 
   // handle simple types: integers, slices
   if (THPUtils_checkLong(index) || torch::is_symint(index)) {
@@ -656,6 +666,9 @@ int THPVariable_setitem(PyObject* self, PyObject* index, PyObject* py_value) {
     if (is_tracing) {
       recordSliceTrace(index);
     }
+    bool disable_slice_optimization =
+        is_tracing || (symbolic_or_predispatch_proxy_tracing &&
+                       sliceHasSymbolicBounds(index));
     // See NOTE [ Setting `disable_slice_optimization` when calling C++ tensor
     // indexing functions from Python ]
     dispatch_set_item(
@@ -681,8 +694,8 @@ int THPVariable_setitem(PyObject* self, PyObject* index, PyObject* py_value) {
       self_,
       holder.get(),
       variableIndices,
-      /*is_tracing=*/is_tracing,
-      /*disable_slice_optimization=*/disable_slice_optimization,
+      is_tracing,
+      symbolic_or_predispatch_proxy_tracing,
       self_device,
       self_.ndimension(),
       specified_dims);

--- a/torch/csrc/autograd/python_variable_indexing.cpp
+++ b/torch/csrc/autograd/python_variable_indexing.cpp
@@ -25,6 +25,7 @@
 #include <ATen/TracerMode.h>
 #include <ATen/core/LegacyTypeDispatch.h>
 #include <c10/core/TensorOptions.h>
+#include <c10/core/impl/LocalDispatchKeySet.h>
 #include <c10/core/impl/TorchDispatchModeTLS.h>
 #include <c10/util/Exception.h>
 #include <c10/util/irange.h>
@@ -211,10 +212,79 @@ static void recordSelectTrace(const Tensor& index_tensor) {
       std::string("index"), 1, index_tensor, torch::jit::IntType::get());
 }
 
+static PyObject* THPVariable_get_dispatch_mode_pre_dispatch = nullptr;
+static PyObject* THPVariable_proxy_mode_key = nullptr;
+
+static PyObject* get_dispatch_mode_pre_dispatch() {
+  if (THPVariable_get_dispatch_mode_pre_dispatch != nullptr) {
+    return THPVariable_get_dispatch_mode_pre_dispatch;
+  }
+
+  auto torch_ops = THPObjectPtr(PyImport_ImportModule("torch._ops"));
+  if (!torch_ops) {
+    throw python_error();
+  }
+
+  auto get_dispatch_mode_pre_dispatch =
+      PyObject_GetAttrString(torch_ops.get(), "_get_dispatch_mode_pre_dispatch");
+  if (!get_dispatch_mode_pre_dispatch) {
+    throw python_error();
+  }
+
+  THPVariable_get_dispatch_mode_pre_dispatch =
+      get_dispatch_mode_pre_dispatch;
+  return THPVariable_get_dispatch_mode_pre_dispatch;
+}
+
+static PyObject* get_proxy_mode_key() {
+  if (THPVariable_proxy_mode_key != nullptr) {
+    return THPVariable_proxy_mode_key;
+  }
+
+  auto torch_C = THPObjectPtr(PyImport_ImportModule("torch._C"));
+  if (!torch_C) {
+    throw python_error();
+  }
+
+  auto torch_dispatch_mode_key =
+      THPObjectPtr(PyObject_GetAttrString(torch_C.get(), "_TorchDispatchModeKey"));
+  if (!torch_dispatch_mode_key) {
+    throw python_error();
+  }
+
+  auto proxy_mode_key =
+      PyObject_GetAttrString(torch_dispatch_mode_key.get(), "PROXY");
+  if (!proxy_mode_key) {
+    throw python_error();
+  }
+
+  THPVariable_proxy_mode_key = proxy_mode_key;
+  return THPVariable_proxy_mode_key;
+}
+
+static bool isPreDispatchProxyTracingModeActive() {
+  auto get_mode_pre_dispatch = get_dispatch_mode_pre_dispatch();
+  auto proxy_mode_key = get_proxy_mode_key();
+  THPObjectPtr maybe_mode(
+      PyObject_CallOneArg(get_mode_pre_dispatch, proxy_mode_key));
+  if (!maybe_mode) {
+    throw python_error();
+  }
+  return maybe_mode.get() != Py_None;
+}
+
 static bool isProxyTracingModeActive() {
-  return c10::impl::TorchDispatchModeTLS::get_mode(
-             c10::impl::TorchDispatchModeKey::PROXY)
-      .has_value();
+  if (c10::impl::TorchDispatchModeTLS::get_mode(
+          c10::impl::TorchDispatchModeKey::PROXY)
+          .has_value()) {
+    return true;
+  }
+
+  if (!c10::impl::tls_is_dispatch_key_included(c10::DispatchKey::PreDispatch)) {
+    return false;
+  }
+
+  return isPreDispatchProxyTracingModeActive();
 }
 
 static Variable applySlicing(

--- a/torch/csrc/autograd/python_variable_indexing.cpp
+++ b/torch/csrc/autograd/python_variable_indexing.cpp
@@ -3,6 +3,7 @@
 #include <torch/csrc/DynamicTypes.h>
 #include <torch/csrc/Exceptions.h>
 #include <torch/csrc/Export.h>
+#include <torch/csrc/PyInterpreter.h>
 #include <torch/csrc/autograd/function.h>
 #include <torch/csrc/autograd/utils/wrap_outputs.h>
 #include <torch/csrc/autograd/variable.h>
@@ -273,11 +274,37 @@ static bool isPreDispatchProxyTracingModeActive() {
   return maybe_mode.get() != Py_None;
 }
 
-static bool isProxyTracingModeActive() {
-  if (c10::impl::TorchDispatchModeTLS::get_mode(
-          c10::impl::TorchDispatchModeKey::PROXY)
-          .has_value()) {
+static bool shouldDisableSliceOptimizationForProxyMode(PyObject* mode) {
+  THPObjectPtr pre_dispatch(PyObject_GetAttrString(mode, "pre_dispatch"));
+  if (!pre_dispatch) {
+    throw python_error();
+  }
+  int is_pre_dispatch = PyObject_IsTrue(pre_dispatch.get());
+  if (is_pre_dispatch < 0) {
+    throw python_error();
+  }
+  if (is_pre_dispatch) {
     return true;
+  }
+
+  THPObjectPtr tracing_mode(PyObject_GetAttrString(mode, "tracing_mode"));
+  if (!tracing_mode) {
+    throw python_error();
+  }
+  int tracing_mode_cmp =
+      PyUnicode_CompareWithASCIIString(tracing_mode.get(), "symbolic");
+  if (tracing_mode_cmp == -1 && PyErr_Occurred()) {
+    throw python_error();
+  }
+  return tracing_mode_cmp == 0;
+}
+
+static bool isSymbolicOrPreDispatchProxyTracingModeActive() {
+  if (auto maybe_mode = c10::impl::TorchDispatchModeTLS::get_mode(
+          c10::impl::TorchDispatchModeKey::PROXY);
+      maybe_mode.has_value()) {
+    return shouldDisableSliceOptimizationForProxyMode(
+        maybe_mode.value()->ptr(getPyInterpreter()));
   }
 
   if (!c10::impl::tls_is_dispatch_key_included(c10::DispatchKey::PreDispatch)) {
@@ -484,7 +511,7 @@ PyObject* THPVariable_getitem(PyObject* self, PyObject* index) {
 
   bool is_tracing = torch::jit::tracer::isTracing();
   bool disable_slice_optimization =
-      is_tracing || isProxyTracingModeActive();
+      is_tracing || isSymbolicOrPreDispatchProxyTracingModeActive();
 
   // handle simple types: integers, slices, bool
   if (THPUtils_checkLong(index)) {
@@ -613,7 +640,7 @@ int THPVariable_setitem(PyObject* self, PyObject* index, PyObject* py_value) {
 
   bool is_tracing = torch::jit::tracer::isTracing();
   bool disable_slice_optimization =
-      is_tracing || isProxyTracingModeActive();
+      is_tracing || isSymbolicOrPreDispatchProxyTracingModeActive();
 
   // handle simple types: integers, slices
   if (THPUtils_checkLong(index) || torch::is_symint(index)) {

--- a/torch/csrc/autograd/python_variable_indexing.cpp
+++ b/torch/csrc/autograd/python_variable_indexing.cpp
@@ -25,6 +25,7 @@
 #include <ATen/TracerMode.h>
 #include <ATen/core/LegacyTypeDispatch.h>
 #include <c10/core/TensorOptions.h>
+#include <c10/core/impl/TorchDispatchModeTLS.h>
 #include <c10/util/Exception.h>
 #include <c10/util/irange.h>
 
@@ -210,11 +211,18 @@ static void recordSelectTrace(const Tensor& index_tensor) {
       std::string("index"), 1, index_tensor, torch::jit::IntType::get());
 }
 
+static bool isProxyTracingModeActive() {
+  return c10::impl::TorchDispatchModeTLS::get_mode(
+             c10::impl::TorchDispatchModeKey::PROXY)
+      .has_value();
+}
+
 static Variable applySlicing(
     const Variable& self,
     PyObject* index,
     variable_list& outIndices,
     bool is_tracing,
+    bool disable_slice_optimization,
     const at::Device& self_device,
     const std::optional<int64_t>& self_ndim,
     int64_t specified_dims) {
@@ -293,7 +301,7 @@ static Variable applySlicing(
         /*outIndices=*/outIndices,
         // See NOTE [ Setting `disable_slice_optimization` when calling C++
         // tensor indexing functions from Python ]
-        /*disable_slice_optimization=*/is_tracing,
+        /*disable_slice_optimization=*/disable_slice_optimization,
         /*original_tensor_device=*/self_device,
         /*prev_dim_result_sizes=*/result_sizes);
   }
@@ -405,6 +413,8 @@ PyObject* THPVariable_getitem(PyObject* self, PyObject* index) {
   }
 
   bool is_tracing = torch::jit::tracer::isTracing();
+  bool disable_slice_optimization =
+      is_tracing || isProxyTracingModeActive();
 
   // handle simple types: integers, slices, bool
   if (THPUtils_checkLong(index)) {
@@ -443,6 +453,7 @@ PyObject* THPVariable_getitem(PyObject* self, PyObject* index) {
       holder.get(),
       variableIndices,
       /*is_tracing=*/is_tracing,
+      /*disable_slice_optimization=*/disable_slice_optimization,
       self_.device(),
       self_.ndimension(),
       specified_dims);
@@ -531,6 +542,8 @@ int THPVariable_setitem(PyObject* self, PyObject* index, PyObject* py_value) {
   }
 
   bool is_tracing = torch::jit::tracer::isTracing();
+  bool disable_slice_optimization =
+      is_tracing || isProxyTracingModeActive();
 
   // handle simple types: integers, slices
   if (THPUtils_checkLong(index) || torch::is_symint(index)) {
@@ -553,7 +566,7 @@ int THPVariable_setitem(PyObject* self, PyObject* index, PyObject* py_value) {
         {at::indexing::TensorIndex(
             at::indexing::Slice(val.start, val.stop, val.step))},
         value,
-        /*disable_slice_optimization=*/is_tracing);
+        /*disable_slice_optimization=*/disable_slice_optimization);
     return 0;
   }
 
@@ -572,6 +585,7 @@ int THPVariable_setitem(PyObject* self, PyObject* index, PyObject* py_value) {
       holder.get(),
       variableIndices,
       /*is_tracing=*/is_tracing,
+      /*disable_slice_optimization=*/disable_slice_optimization,
       self_device,
       self_.ndimension(),
       specified_dims);


### PR DESCRIPTION
Fix #96123

## Summary
- Root cause: Python tensor indexing only disabled slice optimization when JIT tracing was active. `make_fx(..., tracing_mode="symbolic")` traces under ProxyTensor dispatch instead, so multidimensional slices could still take the size-dependent no-op path and add a spurious `!= 2` guard.
- Proposed fix: detect active ProxyTensor dispatch mode in `python_variable_indexing.cpp`, thread a dedicated `disable_slice_optimization` flag through multidimensional getitem/setitem handling, and keep the JIT-only trace bookkeeping unchanged.
- Why this is the right long term fix: it aligns Python indexing with the tracing modes that need emitted slice ops, removes the shape-specializing branch from the tracing path itself, and adds regression coverage for the guard shape we expect to keep.

Drafted via @codex, published after manual review by @bobrenjc93