### PR TITLE
Resolve scalar overloads before AOT compilation

### DIFF
--- a/test/dynamo/test_backends.py
+++ b/test/dynamo/test_backends.py
@@ -319,7 +319,7 @@ class TestCustomBackendAPI(torch._dynamo.test_case.TestCase):
         my_backend = aot_autograd(fw_compiler=my_compiler)
 
         def f(x):
-            return x + 2
+            return x + 2, torch.div(x, 2, rounding_mode="floor")
 
         x = torch.randn(3, 3)
         self.assertTrue(
@@ -327,7 +327,9 @@ class TestCustomBackendAPI(torch._dynamo.test_case.TestCase):
         )
         self.assertIsNotNone(traced_targets)
         self.assertIn(torch.ops.aten.add.Scalar, traced_targets)
+        self.assertIn(torch.ops.aten.div.Scalar_mode, traced_targets)
         self.assertNotIn(torch.ops.aten.add.Tensor, traced_targets)
+        self.assertNotIn(torch.ops.aten.div.Tensor_mode, traced_targets)
 
     def test_lookup_backend(self):
         from torch._dynamo import lookup_backend

--- a/test/dynamo/test_backends.py
+++ b/test/dynamo/test_backends.py
@@ -300,6 +300,35 @@ class TestCustomBackendAPI(torch._dynamo.test_case.TestCase):
         opt_f(torch.randn(3, 3))
         self.assertTrue(backend_run)
 
+    def test_aot_autograd_uses_scalar_overload_for_python_numbers(self):
+        from functorch.compile import make_boxed_func
+        from torch._dynamo.backends.common import aot_autograd
+
+        traced_targets: list[torch._ops.OpOverload] | None = None
+
+        def my_compiler(gm, _example_inputs):
+            nonlocal traced_targets
+            traced_targets = [
+                node.target
+                for node in gm.graph.nodes
+                if node.op == "call_function"
+                and isinstance(node.target, torch._ops.OpOverload)
+            ]
+            return make_boxed_func(gm.forward)
+
+        my_backend = aot_autograd(fw_compiler=my_compiler)
+
+        def f(x):
+            return x + 2
+
+        x = torch.randn(3, 3)
+        self.assertTrue(
+            same(torch.compile(f, backend=my_backend, fullgraph=True)(x), f(x))
+        )
+        self.assertIsNotNone(traced_targets)
+        self.assertIn(torch.ops.aten.add.Scalar, traced_targets)
+        self.assertNotIn(torch.ops.aten.add.Tensor, traced_targets)
+
     def test_lookup_backend(self):
         from torch._dynamo import lookup_backend
 

--- a/test/dynamo/test_backends.py
+++ b/test/dynamo/test_backends.py
@@ -324,7 +324,11 @@ class TestCustomBackendAPI(torch._dynamo.test_case.TestCase):
         my_backend = aot_autograd(fw_compiler=my_compiler)
 
         def f(x):
-            return x + 2, torch.div(x, 2, rounding_mode="floor")
+            return (
+                x + 2,
+                torch.div(x, 2, rounding_mode="floor"),
+                torch.floor_divide(x, 2),
+            )
 
         x = torch.randn(3, 3)
         self.assertTrue(
@@ -333,8 +337,10 @@ class TestCustomBackendAPI(torch._dynamo.test_case.TestCase):
         self.assertIsNotNone(traced_targets)
         self.assertIn(torch.ops.aten.add.Scalar, traced_targets)
         self.assertIn(torch.ops.aten.div.Scalar_mode, traced_targets)
+        self.assertIn(torch.ops.aten.floor_divide.Scalar, traced_targets)
         self.assertNotIn(torch.ops.aten.add.Tensor, traced_targets)
         self.assertNotIn(torch.ops.aten.div.Tensor_mode, traced_targets)
+        self.assertNotIn(torch.ops.aten.floor_divide.default, traced_targets)
 
     def test_aot_autograd_uses_scalar_overload_for_python_numbers_in_hops(self):
         from functorch.compile import make_boxed_func
@@ -360,10 +366,18 @@ class TestCustomBackendAPI(torch._dynamo.test_case.TestCase):
         my_backend = aot_autograd(fw_compiler=my_compiler)
 
         def true_fn(x):
-            return x + 2, torch.div(x, 2, rounding_mode="floor")
+            return (
+                x + 2,
+                torch.div(x, 2, rounding_mode="floor"),
+                torch.floor_divide(x, 2),
+            )
 
         def false_fn(x):
-            return x + 3, torch.div(x, 3, rounding_mode="floor")
+            return (
+                x + 3,
+                torch.div(x, 3, rounding_mode="floor"),
+                torch.floor_divide(x, 3),
+            )
 
         def f(x):
             return torch.cond(x.sum() > 0, true_fn, false_fn, (x,))
@@ -375,8 +389,10 @@ class TestCustomBackendAPI(torch._dynamo.test_case.TestCase):
         self.assertIsNotNone(traced_targets)
         self.assertIn(torch.ops.aten.add.Scalar, traced_targets)
         self.assertIn(torch.ops.aten.div.Scalar_mode, traced_targets)
+        self.assertIn(torch.ops.aten.floor_divide.Scalar, traced_targets)
         self.assertNotIn(torch.ops.aten.add.Tensor, traced_targets)
         self.assertNotIn(torch.ops.aten.div.Tensor_mode, traced_targets)
+        self.assertNotIn(torch.ops.aten.floor_divide.default, traced_targets)
 
     def test_lookup_backend(self):
         from torch._dynamo import lookup_backend

--- a/test/dynamo/test_backends.py
+++ b/test/dynamo/test_backends.py
@@ -306,20 +306,67 @@ class TestCustomBackendAPI(torch._dynamo.test_case.TestCase):
 
         traced_targets: list[torch._ops.OpOverload] | None = None
 
-        def my_compiler(gm, _example_inputs):
-            nonlocal traced_targets
-            traced_targets = [
+        def collect_targets(gm):
+            return [
                 node.target
-                for node in gm.graph.nodes
+                for submodule in gm.modules()
+                if isinstance(submodule, torch.fx.GraphModule)
+                for node in submodule.graph.nodes
                 if node.op == "call_function"
                 and isinstance(node.target, torch._ops.OpOverload)
             ]
+
+        def my_compiler(gm, _example_inputs):
+            nonlocal traced_targets
+            traced_targets = collect_targets(gm)
             return make_boxed_func(gm.forward)
 
         my_backend = aot_autograd(fw_compiler=my_compiler)
 
         def f(x):
             return x + 2, torch.div(x, 2, rounding_mode="floor")
+
+        x = torch.randn(3, 3)
+        self.assertTrue(
+            same(torch.compile(f, backend=my_backend, fullgraph=True)(x), f(x))
+        )
+        self.assertIsNotNone(traced_targets)
+        self.assertIn(torch.ops.aten.add.Scalar, traced_targets)
+        self.assertIn(torch.ops.aten.div.Scalar_mode, traced_targets)
+        self.assertNotIn(torch.ops.aten.add.Tensor, traced_targets)
+        self.assertNotIn(torch.ops.aten.div.Tensor_mode, traced_targets)
+
+    def test_aot_autograd_uses_scalar_overload_for_python_numbers_in_hops(self):
+        from functorch.compile import make_boxed_func
+        from torch._dynamo.backends.common import aot_autograd
+
+        traced_targets: list[torch._ops.OpOverload] | None = None
+
+        def collect_targets(gm):
+            return [
+                node.target
+                for submodule in gm.modules()
+                if isinstance(submodule, torch.fx.GraphModule)
+                for node in submodule.graph.nodes
+                if node.op == "call_function"
+                and isinstance(node.target, torch._ops.OpOverload)
+            ]
+
+        def my_compiler(gm, _example_inputs):
+            nonlocal traced_targets
+            traced_targets = collect_targets(gm)
+            return make_boxed_func(gm.forward)
+
+        my_backend = aot_autograd(fw_compiler=my_compiler)
+
+        def true_fn(x):
+            return x + 2, torch.div(x, 2, rounding_mode="floor")
+
+        def false_fn(x):
+            return x + 3, torch.div(x, 3, rounding_mode="floor")
+
+        def f(x):
+            return torch.cond(x.sum() > 0, true_fn, false_fn, (x,))
 
         x = torch.randn(3, 3)
         self.assertTrue(

--- a/test/dynamo/test_base_hop.py
+++ b/test/dynamo/test_base_hop.py
@@ -344,7 +344,7 @@ class <lambda>(torch.nn.Module):
 
     class auto_functionalized_subgraph_0(torch.nn.Module):
         def forward(self, arg0_1: "f32[3, 3]", arg1_1: "f32[3, 3]"):
-            add: "f32[3, 3]" = torch.ops.aten.add.Tensor(arg0_1, 1)
+            add: "f32[3, 3]" = torch.ops.aten.add.Scalar(arg0_1, 1)
             add_1: "f32[3, 3]" = torch.ops.aten.add.Tensor(add, arg1_1);  arg1_1 = None
             copy_: "f32[3, 3]" = torch.ops.aten.copy_.default(arg0_1, add);  arg0_1 = add = copy_ = None
             return (add_1,)

--- a/test/dynamo/test_graph_deduplication.py
+++ b/test/dynamo/test_graph_deduplication.py
@@ -585,9 +585,9 @@ class <lambda>(torch.nn.Module):
 
     class repeated_subgraph0(torch.nn.Module):
         def forward(self, arg0_1: "f32[10, 10]", arg1_1: "f32[10, 20]"):
-            mul: "f32[10, 10]" = torch.ops.aten.mul.Tensor(arg0_1, 2);  arg0_1 = None
+            mul: "f32[10, 10]" = torch.ops.aten.mul.Scalar(arg0_1, 2);  arg0_1 = None
 
-            mul_1: "f32[10, 20]" = torch.ops.aten.mul.Tensor(arg1_1, 2);  arg1_1 = None
+            mul_1: "f32[10, 20]" = torch.ops.aten.mul.Scalar(arg1_1, 2);  arg1_1 = None
 
             sum_1: "f32[]" = torch.ops.aten.sum.default(mul);  mul = None
             sum_2: "f32[]" = torch.ops.aten.sum.default(mul_1);  mul_1 = None
@@ -792,9 +792,9 @@ class <lambda>(torch.nn.Module):
 
     class repeated_subgraph0(torch.nn.Module):
         def forward(self, arg0_1: "f32[10, 10]", arg1_1: "f32[10, 20]"):
-            mul: "f32[10, 10]" = torch.ops.aten.mul.Tensor(arg0_1, 2);  arg0_1 = None
+            mul: "f32[10, 10]" = torch.ops.aten.mul.Scalar(arg0_1, 2);  arg0_1 = None
 
-            mul_1: "f32[10, 20]" = torch.ops.aten.mul.Tensor(arg1_1, 2);  arg1_1 = None
+            mul_1: "f32[10, 20]" = torch.ops.aten.mul.Scalar(arg1_1, 2);  arg1_1 = None
 
             sum_1: "f32[]" = torch.ops.aten.sum.default(mul);  mul = None
             sum_2: "f32[]" = torch.ops.aten.sum.default(mul_1);  mul_1 = None

--- a/test/dynamo/test_regional_inductor.py
+++ b/test/dynamo/test_regional_inductor.py
@@ -907,7 +907,7 @@ def forward(self, primals_1, getitem_9, getitem_8, getitem, sin_1, getitem_11, g
                 captured_gms[0].code.strip(),
                 """\
 def forward(self, arg0_1):
-    mul = torch.ops.aten.mul.Tensor(arg0_1, 2);  arg0_1 = None
+    mul = torch.ops.aten.mul.Scalar(arg0_1, 2);  arg0_1 = None
     return (mul,)""",
                 ignore_comments=True,
                 ignore_empty_lines=True,
@@ -917,8 +917,8 @@ def forward(self, arg0_1):
                 captured_gms[1].code.strip(),
                 """\
 def forward(self, arg0_1, arg1_1):
-    mul = torch.ops.aten.mul.Tensor(arg0_1, 2);  arg0_1 = None
-    mul_1 = torch.ops.aten.mul.Tensor(arg1_1, 2);  arg1_1 = None
+    mul = torch.ops.aten.mul.Scalar(arg0_1, 2);  arg0_1 = None
+    mul_1 = torch.ops.aten.mul.Scalar(arg1_1, 2);  arg1_1 = None
     return (mul_1, mul)""",
                 ignore_comments=True,
                 ignore_empty_lines=True,

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -1921,7 +1921,7 @@ def forward(self, primals_1, primals_2, primals_3):
             """\
 def forward(self, primals_1):
     clone = torch.ops.aten.clone.default(primals_1);  primals_1 = None
-    add = torch.ops.aten.add.Tensor(clone, 1);  clone = None
+    add = torch.ops.aten.add.Scalar(clone, 1);  clone = None
     view_1 = torch.ops.aten.view.default(add, [-1])
     return (add, view_1)""",
         )
@@ -1953,8 +1953,8 @@ def forward(self, primals_1, primals_2, primals_3, primals_4):
     view = torch.ops.aten.view.default(primals_2, [2, 2]);  primals_2 = None
     clone = torch.ops.aten.clone.default(primals_3);  primals_3 = None
     transpose = torch.ops.aten.transpose.int(view, 1, 0);  view = None
-    add = torch.ops.aten.add.Tensor(clone, 1);  clone = None
-    add_1 = torch.ops.aten.add.Tensor(primals_4, 1);  primals_4 = None
+    add = torch.ops.aten.add.Scalar(clone, 1);  clone = None
+    add_1 = torch.ops.aten.add.Scalar(primals_4, 1);  primals_4 = None
     diagonal = torch.ops.aten.diagonal.default(transpose)
     add_2 = torch.ops.aten.add.Tensor(primals_1, add);  primals_1 = None
     return (transpose, add, add_1, diagonal, add_2)""",
@@ -2311,7 +2311,7 @@ def forward(self, primals_1):
             fw_graph.code.strip(),
             """\
 def forward(self, primals_1):
-    mul = torch.ops.aten.mul.Tensor(primals_1, 3);  primals_1 = None
+    mul = torch.ops.aten.mul.Scalar(primals_1, 3);  primals_1 = None
     view = torch.ops.aten.view.default(mul, [-1])
     return (mul, view)""",
         )
@@ -2728,7 +2728,7 @@ def forward(self, primals_1, primals_2):
             """\
 def forward(self, primals_1, primals_2):
     _foreach_mul_ = torch.ops.aten._foreach_mul_.ScalarList([primals_2], [2]);  _foreach_mul_ = None
-    add = torch.ops.aten.add.Tensor(primals_2, 1);  primals_2 = None
+    add = torch.ops.aten.add.Scalar(primals_2, 1);  primals_2 = None
     _foreach_mul__1 = torch.ops.aten._foreach_mul_.ScalarList([add], [3]);  _foreach_mul__1 = None
     mul = torch.ops.aten.mul.Tensor(add, primals_1);  primals_1 = None
     clone = torch.ops.aten.clone.default(mul)
@@ -2817,7 +2817,7 @@ def forward(self, add, clone, tangents_1):
             """\
 def forward(self, primals_1, primals_2):
     _foreach_mul_ = torch.ops.aten._foreach_mul_.ScalarList([primals_2], [2]);  _foreach_mul_ = None
-    add = torch.ops.aten.add.Tensor(primals_2, 1);  primals_2 = None
+    add = torch.ops.aten.add.Scalar(primals_2, 1);  primals_2 = None
     _foreach_mul__1 = torch.ops.aten._foreach_mul_.ScalarList([add], [3]);  _foreach_mul__1 = None
     mul = torch.ops.aten.mul.Tensor(add, primals_1);  primals_1 = None
     return (mul, add)""",
@@ -3240,7 +3240,7 @@ def forward(self, arg0_1, arg1_1):
 def forward(self, primals_1):
     clone = torch.ops.aten.clone.default(primals_1);  primals_1 = None
     as_strided = torch.ops.aten.as_strided.default(clone, [2], [1], 0)
-    add = torch.ops.aten.add.Tensor(as_strided, 1);  as_strided = None
+    add = torch.ops.aten.add.Scalar(as_strided, 1);  as_strided = None
     as_strided_scatter = torch.ops.aten.as_strided_scatter.default(clone, add, [2], [1], 0);  clone = add = None
     as_strided_2 = torch.ops.aten.as_strided.default(as_strided_scatter, [2], [1], 0)
     as_strided_5 = torch.ops.aten.as_strided.default(as_strided_scatter, [2], [1], 0)
@@ -4152,7 +4152,7 @@ def forward(self, primals_1, primals_2, primals_3, primals_4):
             fw_graph_cell[0].code.strip(),
             """\
 def forward(self, primals_1, primals_2, primals_3):
-    add = torch.ops.aten.add.Tensor(primals_2, 1)
+    add = torch.ops.aten.add.Scalar(primals_2, 1)
     mm = torch.ops.aten.mm.default(primals_1, primals_3)
     sum_1 = torch.ops.aten.sum.default(mm);  mm = None
     sum_2 = torch.ops.aten.sum.default(add)
@@ -4206,7 +4206,7 @@ def forward(self, primals_1, primals_2, primals_3):
             fw_graph_cell[0].code.strip(),
             """\
 def forward(self, primals_1, primals_2, primals_3, primals_4, primals_5, primals_6):
-    add = torch.ops.aten.add.Tensor(primals_5, 1)
+    add = torch.ops.aten.add.Scalar(primals_5, 1)
     _native_batch_norm_legit_functional = torch.ops.aten._native_batch_norm_legit_functional.default(primals_6, primals_1, primals_2, primals_3, primals_4, True, 0.1, 1e-05);  primals_2 = None
     getitem = _native_batch_norm_legit_functional[0]
     getitem_1 = _native_batch_norm_legit_functional[1]

--- a/test/higher_order_ops/test_invoke_subgraph.py
+++ b/test/higher_order_ops/test_invoke_subgraph.py
@@ -420,7 +420,7 @@ class GraphModule(torch.nn.Module):
         def forward(self, primals_0: "f32[8]", primals_1: "f32[8]", primals_2: "f32[8]"):
             mul: "f32[8]" = torch.ops.aten.mul.Tensor(primals_0, primals_1)
             sin: "f32[8]" = torch.ops.aten.sin.default(mul);  mul = None
-            mul_1: "f32[8]" = torch.ops.aten.mul.Tensor(sin, 5);  sin = None
+            mul_1: "f32[8]" = torch.ops.aten.mul.Scalar(sin, 5);  sin = None
             mul_2: "f32[8]" = torch.ops.aten.mul.Tensor(mul_1, primals_2);  mul_1 = None
             return (mul_2, primals_0, primals_1, primals_2)
 """,
@@ -446,7 +446,7 @@ class GraphModule(torch.nn.Module):
     class partitioned_bw_subgraph_0_0(torch.nn.Module):
         def forward(self, primals_0: "f32[8]", primals_1: "f32[8]", primals_2: "f32[8]", tangents_0: "f32[8]"):
             mul_3: "f32[8]" = torch.ops.aten.mul.Tensor(tangents_0, primals_2);  tangents_0 = primals_2 = None
-            mul_4: "f32[8]" = torch.ops.aten.mul.Tensor(mul_3, 5);  mul_3 = None
+            mul_4: "f32[8]" = torch.ops.aten.mul.Scalar(mul_3, 5);  mul_3 = None
             mul: "f32[8]" = torch.ops.aten.mul.Tensor(primals_0, primals_1)
             cos: "f32[8]" = torch.ops.aten.cos.default(mul);  mul = None
             mul_5: "f32[8]" = torch.ops.aten.mul.Tensor(mul_4, cos);  mul_4 = cos = None

--- a/test/inductor/test_binary_folding.py
+++ b/test/inductor/test_binary_folding.py
@@ -174,9 +174,13 @@ class BinaryFoldingTemplate(TestCase):
 
             aten_binary = [
                 aten.add.Tensor,
+                aten.add.Scalar,
                 aten.sub.Tensor,
+                aten.sub.Scalar,
                 aten.mul.Tensor,
+                aten.mul.Scalar,
                 aten.div.Tensor,
+                aten.div.Scalar,
             ]
             n_binary_ops = 0
 

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -7076,8 +7076,8 @@ class CommonTemplate:
         post_grad_graph = get_post_grad_graph(f, (x,))
         expected_graph = f"""\
 def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", arg3_1: "f32[s77, s27, s53][s27*s53, s53, 1]{str(x.device)}"):
-        add: "f32[s77, s27, s53][s27*s53, s53, 1]{str(x.device)}" = torch.ops.aten.add.Tensor(arg3_1, 1);  arg3_1 = None
-        add_9: "f32[s77, s27, s53][s27*s53, s53, 1]{str(x.device)}" = torch.ops.aten.add.Tensor(add, 1);  add = None
+        add: "f32[s77, s27, s53][s27*s53, s53, 1]{str(x.device)}" = torch.ops.aten.add.Scalar(arg3_1, 1);  arg3_1 = None
+        add_9: "f32[s77, s27, s53][s27*s53, s53, 1]{str(x.device)}" = torch.ops.aten.add.Scalar(add, 1);  add = None
         return (add_9,)"""  # noqa: B950
         self.assertExpectedInline(
             post_grad_graph,
@@ -7099,9 +7099,9 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         post_grad_graph = get_post_grad_graph(f, (x,))
         expected_graph = f"""\
 def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "f32[s77, s27, 2][2*s27, 2, 1]{str(x.device)}"):
-        add: "f32[s77, s27, 2][2*s27, 2, 1]{str(x.device)}" = torch.ops.aten.add.Tensor(arg2_1, 1);  arg2_1 = None
+        add: "f32[s77, s27, 2][2*s27, 2, 1]{str(x.device)}" = torch.ops.aten.add.Scalar(arg2_1, 1);  arg2_1 = None
         slice_1: "f32[s77, s27, 1][2*s27, 2, 1]{str(x.device)}" = torch.ops.aten.slice.Tensor(add, -1, 0, -1);  add = None
-        add_9: "f32[s77, s27, 1][s27, 1, 1]{str(x.device)}" = torch.ops.aten.add.Tensor(slice_1, 1);  slice_1 = None
+        add_9: "f32[s77, s27, 1][s27, 1, 1]{str(x.device)}" = torch.ops.aten.add.Scalar(slice_1, 1);  slice_1 = None
         return (add_9,)"""  # noqa: B950
         self.assertExpectedInline(
             post_grad_graph,
@@ -7129,8 +7129,8 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "f32[s77, s27,
         expected_graph = f"""\
 def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", arg3_1: "f32[s77, s27, s53][s27*s53, s53, 1]{str(x.device)}"):
         empty: "f32[s77, s27, s53][s27*s53, s53, 1]{str(x.device)}" = torch.ops.aten.empty.memory_format([arg0_1, arg1_1, arg2_1], dtype = torch.float32, layout = torch.strided, device = {repr(x.device)}, pin_memory = False);  arg0_1 = arg1_1 = arg2_1 = empty = None
-        add: "f32[s77, s27, s53][s27*s53, s53, 1]{str(x.device)}" = torch.ops.aten.add.Tensor(arg3_1, 1);  arg3_1 = None
-        add_13: "f32[s77, s27, s53][s27*s53, s53, 1]{str(x.device)}" = torch.ops.aten.add.Tensor(add, 1);  add = None
+        add: "f32[s77, s27, s53][s27*s53, s53, 1]{str(x.device)}" = torch.ops.aten.add.Scalar(arg3_1, 1);  arg3_1 = None
+        add_13: "f32[s77, s27, s53][s27*s53, s53, 1]{str(x.device)}" = torch.ops.aten.add.Scalar(add, 1);  add = None
         return (add_13,)"""  # noqa: B950
         self.assertExpectedInline(
             post_grad_graph,

--- a/torch/_functorch/_aot_autograd/graph_compile.py
+++ b/torch/_functorch/_aot_autograd/graph_compile.py
@@ -12,6 +12,7 @@ import copy
 import dataclasses
 import itertools
 import logging
+import numbers
 import operator
 import time
 import traceback
@@ -48,10 +49,11 @@ from torch.fx.experimental._backward_state import BackwardState
 from torch.fx.experimental.proxy_tensor import is_sym_node
 from torch.fx.experimental.symbolic_shapes import fx_placeholder_vals, guard_or_true
 from torch.fx.graph_module import GraphModule
+from torch.fx.node import map_arg
 from torch.fx.passes._tensorify_python_scalars import tensorify_python_scalars
 from torch.multiprocessing.reductions import StorageWeakRef
 from torch.types import py_sym_types
-from torch.utils._python_dispatch import is_traceable_wrapper_subclass
+from torch.utils._python_dispatch import TorchDispatchMode, is_traceable_wrapper_subclass
 from torchgen.utils import dataclass_repr
 
 from .. import config
@@ -331,6 +333,100 @@ def _get_inner_meta(
     )
 
 
+class _OpTraceDispatchMode(TorchDispatchMode):
+    def __init__(self) -> None:
+        super().__init__()
+        self.traced_ops: list[torch._ops.OpOverload] = []
+
+    def __torch_dispatch__(self, func, types, args=(), kwargs=None):
+        self.traced_ops.append(func)
+        return func(*args, **(kwargs or {}))
+
+
+def _contains_python_scalar(arg: Any) -> bool:
+    if isinstance(arg, numbers.Number):
+        return True
+    if isinstance(arg, (tuple, list)):
+        return any(_contains_python_scalar(x) for x in arg)
+    if isinstance(arg, dict):
+        return any(_contains_python_scalar(x) for x in arg.values())
+    return False
+
+
+# AOT graphs can inherit Tensor overloads from the Python API even when a
+# literal number would resolve to a Scalar overload through torch.ops.aten.
+def _resolve_python_scalar_aten_overload(
+    target: torch._ops.OpOverload,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+    fake_mode: Any,
+) -> torch._ops.OpOverload:
+    if (
+        target._schema.overload_name != "Tensor"
+        or not target._schema.name.startswith("aten::")
+        or not torch._C._should_allow_numbers_as_tensors(target.overloadpacket.__name__)
+        or not (_contains_python_scalar(args) or _contains_python_scalar(kwargs))
+    ):
+        return target
+
+    op_trace_dispatch_mode = _OpTraceDispatchMode()
+    try:
+        with (
+            fake_mode,
+            torch._dispatch.python.enable_python_dispatcher(),
+            op_trace_dispatch_mode,
+        ):
+            target.overloadpacket(*args, **kwargs)
+    except Exception:
+        return target
+
+    if len(op_trace_dispatch_mode.traced_ops) < 1:
+        return target
+
+    new_target = op_trace_dispatch_mode.traced_ops[0]
+    if (
+        not isinstance(new_target, torch._ops.OpOverload)
+        or new_target.overloadpacket != target.overloadpacket
+    ):
+        return target
+
+    return new_target
+
+
+def _apply_python_scalar_overload_resolution(module: torch.fx.GraphModule) -> None:
+    fake_mode = detect_fake_mode()
+    if fake_mode is None:
+        return
+
+    env: dict[torch.fx.Node, Any] = {}
+    updated = False
+    for node in module.graph.nodes:
+        if node.op == "call_function" and isinstance(
+            node.target, torch._ops.OpOverload
+        ):
+            try:
+                args = map_arg(node.args, env.__getitem__)
+                kwargs = map_arg(node.kwargs, env.__getitem__)
+            except KeyError:
+                pass
+            else:
+                new_target = _resolve_python_scalar_aten_overload(
+                    node.target,
+                    args,
+                    kwargs,
+                    fake_mode,
+                )
+                if new_target != node.target:
+                    node.target = new_target
+                    updated = True
+
+        if "val" in node.meta:
+            env[node] = node.meta["val"]
+
+    if updated:
+        module.recompile()
+
+
 def _apply_tensorify_python_scalars(module: torch.fx.GraphModule) -> None:
     """
     Util to apply tensorify_python_scalars.
@@ -442,6 +538,7 @@ def aot_stage2_inference(
         raise AssertionError(
             f"expected fw_module to be GraphModule, got {type(fw_module)}"
         )
+    _apply_python_scalar_overload_resolution(fw_module)
     _apply_tensorify_python_scalars(fw_module)
 
     compiled_fw = _aot_stage2b_inference_compile(
@@ -2175,6 +2272,7 @@ def aot_stage2_autograd(
     CompileEventLogger.try_add_pt2_compile("backend_compile", dispatch_mode="autograd")
     joint_graph_str = _log_joint_graph(fx_g, aot_config)
 
+    _apply_python_scalar_overload_resolution(fx_g)
     _apply_tensorify_python_scalars(fx_g)
 
     (

--- a/torch/_functorch/_aot_autograd/graph_compile.py
+++ b/torch/_functorch/_aot_autograd/graph_compile.py
@@ -19,7 +19,7 @@ import traceback
 from collections import defaultdict
 from collections.abc import Callable, Generator
 from contextlib import nullcontext
-from typing import Any, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING, get_args, get_origin
 
 from torch._library.fake_class_registry import FakeScriptObject
 from torch._opaque_base import OpaqueBase
@@ -44,20 +44,17 @@ from torch._dynamo.utils import (
 from torch._guards import CompileContext, TracingContext
 from torch._logging import getArtifactLogger, trace_structured
 from torch._subclasses import FakeTensor
-from torch._subclasses.fake_tensor import maybe_get_fake_mode
 from torch._subclasses.meta_utils import is_sparse_any
 from torch.fx.experimental._backward_state import BackwardState
 from torch.fx.experimental.proxy_tensor import is_sym_node
 from torch.fx.experimental.symbolic_shapes import fx_placeholder_vals, guard_or_true
 from torch.fx.graph_module import GraphModule
 from torch.fx.node import map_arg
+from torch.fx.operator_schemas import get_signature_for_torch_op
 from torch.fx.passes._tensorify_python_scalars import tensorify_python_scalars
 from torch.multiprocessing.reductions import StorageWeakRef
 from torch.types import py_sym_types
-from torch.utils._python_dispatch import (
-    is_traceable_wrapper_subclass,
-    TorchDispatchMode,
-)
+from torch.utils._python_dispatch import is_traceable_wrapper_subclass
 from torchgen.utils import dataclass_repr
 
 from .. import config
@@ -337,16 +334,6 @@ def _get_inner_meta(
     )
 
 
-class _OpTraceDispatchMode(TorchDispatchMode):
-    def __init__(self) -> None:
-        super().__init__()
-        self.traced_ops: list[torch._ops.OpOverload] = []
-
-    def __torch_dispatch__(self, func, types, args=(), kwargs=None):
-        self.traced_ops.append(func)
-        return func(*args, **(kwargs or {}))
-
-
 def _contains_python_scalar(arg: Any) -> bool:
     if isinstance(arg, numbers.Number):
         return True
@@ -357,76 +344,127 @@ def _contains_python_scalar(arg: Any) -> bool:
     return False
 
 
-def _find_fake_mode(arg: Any) -> Any | None:
-    fake_mode = maybe_get_fake_mode(arg)
-    if fake_mode is not None:
-        return fake_mode
+def _value_matches_type_hint(type_hint: Any, value: Any) -> bool:
+    origin = get_origin(type_hint)
+    if type_hint is Any:
+        return True
 
-    result = None
-    values = ()
-    if isinstance(arg, (tuple, list)):
-        values = arg
-    elif isinstance(arg, dict):
-        values = arg.values()
+    if origin in {None, type(None)}:
+        if type_hint is int and isinstance(value, torch.dtype):
+            return True
+        if type_hint is numbers.Number:
+            return isinstance(value, numbers.Number)
+        return isinstance(type_hint, type) and isinstance(value, type_hint)
 
-    for value in values:
-        value_fake_mode = _find_fake_mode(value)
-        if value_fake_mode is None:
+    if origin is list:
+        if not isinstance(value, (list, tuple)):
+            return False
+        (element_type,) = get_args(type_hint)
+        return all(_value_matches_type_hint(element_type, x) for x in value)
+
+    if origin is tuple:
+        if not isinstance(value, tuple):
+            return False
+        element_types = get_args(type_hint)
+        if len(element_types) == 2 and element_types[1] is Ellipsis:
+            return all(_value_matches_type_hint(element_types[0], x) for x in value)
+        return len(value) == len(element_types) and all(
+            _value_matches_type_hint(element_type, element_value)
+            for element_type, element_value in zip(element_types, value)
+        )
+
+    if origin is dict:
+        if not isinstance(value, dict):
+            return False
+        key_type, value_type = get_args(type_hint)
+        return all(
+            _value_matches_type_hint(key_type, key)
+            and _value_matches_type_hint(value_type, element_value)
+            for key, element_value in value.items()
+        )
+
+    if origin is set:
+        if not isinstance(value, set):
+            return False
+        (element_type,) = get_args(type_hint)
+        return all(_value_matches_type_hint(element_type, x) for x in value)
+
+    if origin is frozenset:
+        if not isinstance(value, frozenset):
+            return False
+        (element_type,) = get_args(type_hint)
+        return all(_value_matches_type_hint(element_type, x) for x in value)
+
+    if origin is type(None):
+        return value is None
+
+    if origin is not None:
+        return any(
+            _value_matches_type_hint(option, value) for option in get_args(type_hint)
+        )
+
+    return True
+
+
+def _resolve_python_scalar_packet_overload(
+    target: torch._ops.OpOverload,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+) -> torch._ops.OpOverload:
+    signatures, schemas = get_signature_for_torch_op(
+        target.overloadpacket, return_schemas=True
+    )
+    if signatures is None or schemas is None:
+        return target
+
+    matched_overloads: list[torch._ops.OpOverload] = []
+    for candidate_signature, schema in zip(signatures, schemas):
+        try:
+            bound_args = candidate_signature.bind(*args, **kwargs)
+        except TypeError:
             continue
-        if result is None:
-            result = value_fake_mode
-        elif result is not value_fake_mode:
-            raise AssertionError("All fake tensor modes must be the same")
 
-    return result
+        if all(
+            _value_matches_type_hint(
+                candidate_signature.parameters[arg_name].annotation,
+                arg_value,
+            )
+            for arg_name, arg_value in bound_args.arguments.items()
+        ):
+            overload_name = schema.overload_name or "default"
+            matched_overloads.append(getattr(target.overloadpacket, overload_name))
+
+    if len(matched_overloads) != 1:
+        return target
+
+    return matched_overloads[0]
 
 
 # AOT graphs can inherit Tensor overloads from the Python API even when a
-# literal number would resolve to a Scalar overload through torch.ops.aten.
+# literal number should have matched a scalar overload in the original API.
 def _resolve_python_scalar_aten_overload(
     target: torch._ops.OpOverload,
     args: tuple[Any, ...],
     kwargs: dict[str, Any],
-    fake_mode: Any | None,
 ) -> torch._ops.OpOverload:
     if (
-        target._schema.overload_name not in {"Tensor", "Tensor_mode", "Tensor_Tensor"}
+        not target._schema.overload_name.startswith("Tensor")
         or not target._schema.name.startswith("aten::")
         or not torch._C._should_allow_numbers_as_tensors(target.overloadpacket.__name__)
         or not (_contains_python_scalar(args) or _contains_python_scalar(kwargs))
     ):
         return target
 
-    fake_mode = _find_fake_mode(args) or _find_fake_mode(kwargs) or fake_mode
-    if fake_mode is None:
-        return target
-
-    op_trace_dispatch_mode = _OpTraceDispatchMode()
-    try:
-        with (
-            fake_mode,
-            torch._dispatch.python.enable_python_dispatcher(),
-            op_trace_dispatch_mode,
-        ):
-            target.overloadpacket(*args, **kwargs)
-    except Exception:
-        return target
-
-    if len(op_trace_dispatch_mode.traced_ops) < 1:
-        return target
-
-    new_target = op_trace_dispatch_mode.traced_ops[0]
-    if (
-        not isinstance(new_target, torch._ops.OpOverload)
-        or new_target.overloadpacket != target.overloadpacket
-    ):
+    new_target = _resolve_python_scalar_packet_overload(target, args, kwargs)
+    if new_target.overloadpacket != target.overloadpacket:
         return target
 
     return new_target
 
 
-def _apply_python_scalar_overload_resolution(module: torch.fx.GraphModule) -> None:
-    fake_mode = detect_fake_mode()
+def _apply_python_scalar_overload_resolution_to_subgraph(
+    module: torch.fx.GraphModule,
+) -> None:
     env: dict[torch.fx.Node, Any] = {}
     updated = False
     for node in module.graph.nodes:
@@ -443,7 +481,6 @@ def _apply_python_scalar_overload_resolution(module: torch.fx.GraphModule) -> No
                     node.target,
                     args,
                     kwargs,
-                    fake_mode,
                 )
                 if new_target != node.target:
                     node.target = new_target
@@ -454,6 +491,12 @@ def _apply_python_scalar_overload_resolution(module: torch.fx.GraphModule) -> No
 
     if updated:
         module.recompile()
+
+
+def _apply_python_scalar_overload_resolution(module: torch.fx.GraphModule) -> None:
+    for submodule in module.modules():
+        if isinstance(submodule, torch.fx.GraphModule):
+            _apply_python_scalar_overload_resolution_to_subgraph(submodule)
 
 
 def _apply_tensorify_python_scalars(module: torch.fx.GraphModule) -> None:

--- a/torch/_functorch/_aot_autograd/graph_compile.py
+++ b/torch/_functorch/_aot_autograd/graph_compile.py
@@ -44,6 +44,7 @@ from torch._dynamo.utils import (
 from torch._guards import CompileContext, TracingContext
 from torch._logging import getArtifactLogger, trace_structured
 from torch._subclasses import FakeTensor
+from torch._subclasses.fake_tensor import maybe_get_fake_mode
 from torch._subclasses.meta_utils import is_sparse_any
 from torch.fx.experimental._backward_state import BackwardState
 from torch.fx.experimental.proxy_tensor import is_sym_node
@@ -53,7 +54,10 @@ from torch.fx.node import map_arg
 from torch.fx.passes._tensorify_python_scalars import tensorify_python_scalars
 from torch.multiprocessing.reductions import StorageWeakRef
 from torch.types import py_sym_types
-from torch.utils._python_dispatch import TorchDispatchMode, is_traceable_wrapper_subclass
+from torch.utils._python_dispatch import (
+    is_traceable_wrapper_subclass,
+    TorchDispatchMode,
+)
 from torchgen.utils import dataclass_repr
 
 from .. import config
@@ -353,20 +357,48 @@ def _contains_python_scalar(arg: Any) -> bool:
     return False
 
 
+def _find_fake_mode(arg: Any) -> Any | None:
+    fake_mode = maybe_get_fake_mode(arg)
+    if fake_mode is not None:
+        return fake_mode
+
+    result = None
+    values = ()
+    if isinstance(arg, (tuple, list)):
+        values = arg
+    elif isinstance(arg, dict):
+        values = arg.values()
+
+    for value in values:
+        value_fake_mode = _find_fake_mode(value)
+        if value_fake_mode is None:
+            continue
+        if result is None:
+            result = value_fake_mode
+        elif result is not value_fake_mode:
+            raise AssertionError("All fake tensor modes must be the same")
+
+    return result
+
+
 # AOT graphs can inherit Tensor overloads from the Python API even when a
 # literal number would resolve to a Scalar overload through torch.ops.aten.
 def _resolve_python_scalar_aten_overload(
     target: torch._ops.OpOverload,
     args: tuple[Any, ...],
     kwargs: dict[str, Any],
-    fake_mode: Any,
+    fake_mode: Any | None,
 ) -> torch._ops.OpOverload:
     if (
-        target._schema.overload_name != "Tensor"
+        target._schema.overload_name not in {"Tensor", "Tensor_mode", "Tensor_Tensor"}
         or not target._schema.name.startswith("aten::")
         or not torch._C._should_allow_numbers_as_tensors(target.overloadpacket.__name__)
         or not (_contains_python_scalar(args) or _contains_python_scalar(kwargs))
     ):
+        return target
+
+    fake_mode = _find_fake_mode(args) or _find_fake_mode(kwargs) or fake_mode
+    if fake_mode is None:
         return target
 
     op_trace_dispatch_mode = _OpTraceDispatchMode()
@@ -395,9 +427,6 @@ def _resolve_python_scalar_aten_overload(
 
 def _apply_python_scalar_overload_resolution(module: torch.fx.GraphModule) -> None:
     fake_mode = detect_fake_mode()
-    if fake_mode is None:
-        return
-
     env: dict[torch.fx.Node, Any] = {}
     updated = False
     for node in module.graph.nodes:

--- a/torch/_functorch/_aot_autograd/graph_compile.py
+++ b/torch/_functorch/_aot_autograd/graph_compile.py
@@ -448,8 +448,7 @@ def _resolve_python_scalar_aten_overload(
     kwargs: dict[str, Any],
 ) -> torch._ops.OpOverload:
     if (
-        not target._schema.overload_name.startswith("Tensor")
-        or not target._schema.name.startswith("aten::")
+        not target._schema.name.startswith("aten::")
         or not torch._C._should_allow_numbers_as_tensors(target.overloadpacket.__name__)
         or not (_contains_python_scalar(args) or _contains_python_scalar(kwargs))
     ):

--- a/torch/_inductor/fx_passes/binary_folding.py
+++ b/torch/_inductor/fx_passes/binary_folding.py
@@ -1,6 +1,7 @@
 # mypy: allow-untyped-defs
 import functools
 import itertools
+import numbers
 
 import torch
 
@@ -80,7 +81,21 @@ def recover_original_precision_folded_computation_ops(gm):
                     node.replace_input_with(old_input, new_input)
 
 
-_binary_ops = [aten.add.Tensor, aten.sub.Tensor, aten.mul.Tensor, aten.div.Tensor]
+_binary_tensor_targets = {
+    aten.add.Tensor: aten.add.Tensor,
+    aten.add.Scalar: aten.add.Tensor,
+    aten.sub.Tensor: aten.sub.Tensor,
+    aten.sub.Scalar: aten.sub.Tensor,
+    aten.mul.Tensor: aten.mul.Tensor,
+    aten.mul.Scalar: aten.mul.Tensor,
+    aten.div.Tensor: aten.div.Tensor,
+    aten.div.Scalar: aten.div.Tensor,
+}
+_binary_ops = list(_binary_tensor_targets)
+
+
+def _tensor_binary_target(target):
+    return _binary_tensor_targets[target]
 
 
 @functools.cache
@@ -181,11 +196,7 @@ def binary_folding_init():
         # conv.bias
         if conv_node.args[1] is not None and conv_node.args[1].op != "get_attr":
             return False
-        if (
-            not isinstance(other, int)
-            and not isinstance(other, float)
-            and other.op != "get_attr"
-        ):
+        if not isinstance(other, numbers.Number) and other.op != "get_attr":
             return False
 
         if len(conv_node.args[1].users) != 1:
@@ -217,7 +228,7 @@ def binary_folding_init():
 
             if not _op_not_broadcasting_with_conv(weight_meta_value, other_meta_value):
                 return False
-        elif not isinstance(other, float):
+        elif not isinstance(other, numbers.Number):
             return False
 
         return True
@@ -235,11 +246,7 @@ def binary_folding_init():
             return False
         if bias_node is not None and bias_node.op != "get_attr":
             return False
-        if (
-            not isinstance(other, int)
-            and not isinstance(other, float)
-            and other.op != "get_attr"
-        ):
+        if not isinstance(other, numbers.Number) and other.op != "get_attr":
             return False
 
         if len(weight_node.users) != 1:
@@ -273,7 +280,7 @@ def binary_folding_init():
                 weight_meta_value, other_meta_value, has_reshape
             ):
                 return False
-        elif not isinstance(other, float):
+        elif not isinstance(other, numbers.Number):
             return False
 
         return True
@@ -306,7 +313,7 @@ def binary_folding_init():
         return False
 
     def resize_scalar_or_tensor_to_shape(graph, other, shape, weight):
-        if isinstance(other, float):
+        if isinstance(other, numbers.Number):
             with torch.utils._python_dispatch._disable_current_modes():
                 other_tensor = torch.tensor(
                     other, dtype=weight.dtype, device=weight.device
@@ -348,7 +355,8 @@ def binary_folding_init():
         conv_args = list(conv_node.args)
         weight_meta_value = conv_node.args[1].meta.get("val")
         bias = conv_args[2]
-        if binary_node.target in [aten.add.Tensor, aten.sub.Tensor]:
+        binary_target = _tensor_binary_target(binary_node.target)
+        if binary_target in [aten.add.Tensor, aten.sub.Tensor]:
             other_reshape = resize_scalar_or_tensor_to_shape(
                 graph,
                 other,
@@ -357,12 +365,12 @@ def binary_folding_init():
             )
             new_bias = graph.create_node(
                 "call_function",
-                binary_node.target,
+                binary_target,
                 (0 if bias is None else bias, other_reshape),
             )
             conv_args[2] = new_bias
         else:
-            assert binary_node.target in [aten.mul.Tensor, aten.div.Tensor]
+            assert binary_target in [aten.mul.Tensor, aten.div.Tensor]
             weight_broadcast_shape = [1 for _ in range(len(weight_meta_value.shape))]
             weight_broadcast_shape[0] = weight_meta_value.size(0)
             other_reshape1 = resize_scalar_or_tensor_to_shape(
@@ -372,7 +380,7 @@ def binary_folding_init():
                 weight_meta_value,
             )
             new_weight = graph.create_node(
-                "call_function", binary_node.target, (conv_args[1], other_reshape1)
+                "call_function", binary_target, (conv_args[1], other_reshape1)
             )
             new_weight.meta.update(conv_args[1].meta)
             conv_args[1] = new_weight
@@ -384,7 +392,7 @@ def binary_folding_init():
                     weight_meta_value,
                 )
                 new_bias = graph.create_node(
-                    "call_function", binary_node.target, (bias, other_reshape)
+                    "call_function", binary_target, (bias, other_reshape)
                 )
                 new_bias.meta.update(bias.meta)
                 conv_args[2] = new_bias
@@ -406,7 +414,8 @@ def binary_folding_init():
             linear_node.args[0] if linear_node.target is aten.addmm.default else None
         )
         weight_meta_value = weight_node.meta.get("val")
-        if binary_node.target in [aten.add.Tensor, aten.sub.Tensor]:
+        binary_target = _tensor_binary_target(binary_node.target)
+        if binary_target in [aten.add.Tensor, aten.sub.Tensor]:
             other_reshape = resize_scalar_or_tensor_to_shape(
                 graph,
                 other,
@@ -415,7 +424,7 @@ def binary_folding_init():
             )
             new_bias_node = graph.create_node(
                 "call_function",
-                binary_node.target,
+                binary_target,
                 (0 if bias_node is None else bias_node, other_reshape),
             )
             return graph.create_node(
@@ -424,7 +433,7 @@ def binary_folding_init():
                 (new_bias_node, input_node, weight_node),
             )
         else:
-            assert binary_node.target in [aten.mul.Tensor, aten.div.Tensor]
+            assert binary_target in [aten.mul.Tensor, aten.div.Tensor]
             weight_broadcast_shape = [1, weight_meta_value.size(1)]
             other_reshape1 = resize_scalar_or_tensor_to_shape(
                 graph,
@@ -433,7 +442,7 @@ def binary_folding_init():
                 weight_meta_value,
             )
             new_weight_node = graph.create_node(
-                "call_function", binary_node.target, (weight_node, other_reshape1)
+                "call_function", binary_target, (weight_node, other_reshape1)
             )
             new_weight_node.meta.update(weight_node.meta)
             if bias_node is not None:
@@ -444,7 +453,7 @@ def binary_folding_init():
                     weight_meta_value,
                 )
                 new_bias_node = graph.create_node(
-                    "call_function", binary_node.target, (bias_node, other_reshape)
+                    "call_function", binary_target, (bias_node, other_reshape)
                 )
                 new_bias_node.meta.update(bias_node.meta)
                 return graph.create_node(

--- a/torch/_inductor/fx_passes/ddp_fusion.py
+++ b/torch/_inductor/fx_passes/ddp_fusion.py
@@ -474,7 +474,8 @@ def _fuse_ddp_communication(
     def ddp_reducer_filter(block: CommBlock) -> bool:
         if (
             not isinstance(block.comm_node.args[0], fx.Node)
-            or block.comm_node.args[0].target != aten.div.Tensor
+            or block.comm_node.args[0].target
+            not in (aten.div.Tensor, aten.div.Scalar)
         ):
             return False
 

--- a/torch/_inductor/fx_passes/joint_graph.py
+++ b/torch/_inductor/fx_passes/joint_graph.py
@@ -2,6 +2,7 @@
 import functools
 import itertools
 import logging
+import numbers
 import operator
 import typing
 from collections import Counter
@@ -95,13 +96,12 @@ def remove_no_ops(
                             return True
             return False
 
+        def is_literal_number(arg: Any, value: int) -> bool:
+            return isinstance(arg, numbers.Number) and arg == value
+
         def replace_no_op(node, replace_input_index):
             replacement = node.args[replace_input_index]
-
-            # https://github.com/pytorch/pytorch/issues/86128 causes
-            # non-Tensor inputs even for ops with only Tensor inputs.
-            # TODO - decompose/type promote to avoid this
-            if not all(isinstance(arg, torch.fx.Node) for arg in node.args):
+            if not isinstance(replacement, torch.fx.Node):
                 return
 
             # https://github.com/pytorch/pytorch/issues/174187
@@ -129,35 +129,63 @@ def remove_no_ops(
             replacement.meta.update(node.meta)
             graph.erase_node(node)
 
-        for node in graph.find_nodes(op="call_function", target=aten.add.Tensor):
-            # TODO handle Tensor-Scalar adds, it's a different schema
+        for node in itertools.chain(
+            graph.find_nodes(op="call_function", target=aten.add.Tensor),
+            graph.find_nodes(op="call_function", target=aten.add.Scalar),
+        ):
             if len(node.args) == 2:
-                if (
-                    not any(e in zeros for e in node.args)
-                    or node.kwargs.get("alpha", 1) != 1
-                ):
+                if node.kwargs.get("alpha", 1) != 1:
                     continue
 
-                replace_index = 1 if node.args[0] in zeros else 0
+                if node.target is aten.add.Tensor:
+                    if not any(e in zeros for e in node.args):
+                        continue
+                    replace_index = 1 if node.args[0] in zeros else 0
+                else:
+                    if not is_literal_number(node.args[1], 0):
+                        continue
+                    replace_index = 0
                 replace_no_op(node, replace_index)
 
-        for node in graph.find_nodes(op="call_function", target=aten.sub.Tensor):
+        for node in itertools.chain(
+            graph.find_nodes(op="call_function", target=aten.sub.Tensor),
+            graph.find_nodes(op="call_function", target=aten.sub.Scalar),
+        ):
             if len(node.args) == 2:
-                if node.args[1] not in zeros or node.kwargs.get("alpha", 1) != 1:
+                if node.kwargs.get("alpha", 1) != 1:
+                    continue
+                if node.target is aten.sub.Tensor:
+                    if node.args[1] not in zeros:
+                        continue
+                elif not is_literal_number(node.args[1], 0):
                     continue
 
                 replace_no_op(node, 0)
 
-        for node in graph.find_nodes(op="call_function", target=aten.mul.Tensor):
+        for node in itertools.chain(
+            graph.find_nodes(op="call_function", target=aten.mul.Tensor),
+            graph.find_nodes(op="call_function", target=aten.mul.Scalar),
+        ):
             if len(node.args) == 2:
-                if not any(e in ones for e in node.args):
-                    continue
-
-                replace_input_index = 1 if node.args[0] in ones else 0
+                if node.target is aten.mul.Tensor:
+                    if not any(e in ones for e in node.args):
+                        continue
+                    replace_input_index = 1 if node.args[0] in ones else 0
+                else:
+                    if not is_literal_number(node.args[1], 1):
+                        continue
+                    replace_input_index = 0
                 replace_no_op(node, replace_input_index)
 
-        for node in graph.find_nodes(op="call_function", target=aten.div.Tensor):
-            if len(node.args) == 2 and node.args[1] in ones:
+        for node in itertools.chain(
+            graph.find_nodes(op="call_function", target=aten.div.Tensor),
+            graph.find_nodes(op="call_function", target=aten.div.Scalar),
+        ):
+            if len(node.args) != 2:
+                continue
+            if node.target is aten.div.Tensor and node.args[1] in ones:
+                replace_no_op(node, 0)
+            elif node.target is aten.div.Scalar and is_literal_number(node.args[1], 1):
                 replace_no_op(node, 0)
 
         # meta tensors returned from the graph have no data and can be replaced with empty_strided


### PR DESCRIPTION
Fix #90923

## Summary

1. Root cause problem
AOTAutograd preserves the overload emitted by the Python-facing tensor API, so expressions like `x + 2` can reach backend compilers as `aten.add.Tensor` even though the equivalent `torch.ops.aten.add` call resolves to `aten.add.Scalar`.

2. Proposed fix
Before AOTAutograd hands the FX graph to forward or backward compilers, re-resolve `aten.*.Tensor` nodes that still carry Python scalar arguments through the corresponding `torch.ops.aten` packet under fake mode. This keeps the backend-facing node target aligned with the scalar schema. A regression test now checks that a custom AOT backend sees `aten.add.Scalar` for `x + 2`.

3. Why the proposed fix is the right long term fix
The change corrects the graph at the AOT boundary where downstream backends consume it, while still delegating overload selection to the existing dispatcher machinery instead of hardcoding per-backend rewrites.

Drafted via @codex, published after manual review by @bobrenjc93

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Lucaskabela