### PR TITLE
Warn when AOTAutograd materializes unused output grads

### DIFF
--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -970,6 +970,26 @@ def forward(self, primals_1):
         self.assertEqual(x_ref.grad, x_test.grad)
         self.assertEqual(x_ref_view.grad, x_test_view.grad)
 
+    def test_warn_on_unused_differentiable_outputs(self):
+        @torch.compile(backend="aot_eager", fullgraph=True)
+        def f(x):
+            return x.sin(), x.cos(), x.tan()
+
+        x_ref = torch.randn(4, requires_grad=True)
+        x_test = x_ref.detach().clone().requires_grad_()
+
+        out_ref = (x_ref.sin(), x_ref.cos(), x_ref.tan())
+        out_test = f(x_test)
+
+        out_ref[0].sum().backward()
+        with self.assertWarnsRegex(
+            UserWarning,
+            r"forward outputs \[1, 2\].*extra backward computation compared to eager",
+        ):
+            out_test[0].sum().backward()
+
+        self.assertEqual(x_ref.grad, x_test.grad)
+
     def test_nested_subclasses(self):
         @torch.compile(backend="aot_eager")
         def f(x):

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -990,6 +990,74 @@ def forward(self, primals_1):
 
         self.assertEqual(x_ref.grad, x_test.grad)
 
+    def test_warn_on_unused_subclass_outputs_without_detach_in_forward(self):
+        class NonRewrappingTensor(torch.Tensor):
+            @staticmethod
+            def __new__(cls, t, outer_size=None, outer_stride=None):
+                if outer_size is None:
+                    outer_size = t.size()
+                if outer_stride is None:
+                    outer_stride = t.stride()
+
+                return torch.Tensor._make_wrapper_subclass(
+                    cls,
+                    outer_size,
+                    strides=outer_stride,
+                    storage_offset=t.storage_offset(),
+                    device=t.device,
+                    layout=t.layout,
+                    requires_grad=t.requires_grad,
+                    dtype=t.dtype,
+                )
+
+            def __init__(self, t, outer_size=None, outer_stride=None):
+                self.tensor = t
+
+            def __tensor_flatten__(self):
+                return ["tensor"], None
+
+            @staticmethod
+            def __tensor_unflatten__(inner_tensors, meta, outer_size, outer_stride):
+                if meta is not None:
+                    raise AssertionError("Expected meta to be None")
+                return NonRewrappingTensor(
+                    inner_tensors["tensor"],
+                    outer_size,
+                    outer_stride,
+                )
+
+            @classmethod
+            def __torch_dispatch__(cls, func, types, args=(), kwargs=None):
+                if kwargs is None:
+                    kwargs = {}
+                return func(
+                    *pytree.tree_map_only(cls, lambda x: x.tensor, args),
+                    **pytree.tree_map_only(cls, lambda x: x.tensor, kwargs),
+                )
+
+        def inner_f(x):
+            return x.sin(), NonRewrappingTensor(x.cos())
+
+        f = torch.compile(inner_f, backend="aot_eager", fullgraph=True)
+
+        x_ref = torch.randn(4, requires_grad=True)
+        x_test = x_ref.detach().clone().requires_grad_()
+
+        out_ref = inner_f(x_ref)
+        out_test = f(x_test)
+
+        self.assertEqual(out_ref[0], out_test[0])
+        self.assertIsInstance(out_test[1], NonRewrappingTensor)
+
+        out_ref[0].sum().backward()
+        with self.assertWarnsRegex(
+            UserWarning,
+            r"forward outputs \[1\].*extra backward computation compared to eager",
+        ):
+            out_test[0].sum().backward()
+
+        self.assertEqual(x_ref.grad, x_test.grad)
+
     def test_nested_subclasses(self):
         @torch.compile(backend="aot_eager")
         def f(x):

--- a/torch/_functorch/_aot_autograd/runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/runtime_wrappers.py
@@ -1887,6 +1887,56 @@ def _raise_if_functorch_active() -> None:
     )
 
 
+def _materialize_undefined_grad_outputs(
+    flat_args: Sequence[Any],
+    grad_output_prototypes: Sequence[Tensor | None],
+    metadata: ViewAndMutationMeta,
+) -> tuple[list[Any], list[int]]:
+    num_intermediate_bases = metadata.num_intermediate_bases
+    num_mutated_runtime_inps = metadata.num_mutated_inp_runtime_indices
+    expected_grad_outs = (
+        metadata.num_outputs + num_mutated_runtime_inps + num_intermediate_bases
+    )
+
+    if len(flat_args) != expected_grad_outs:
+        raise AssertionError(
+            f"expected {expected_grad_outs} grad_outs, got {len(flat_args)}"
+        )
+    if len(grad_output_prototypes) != expected_grad_outs:
+        raise AssertionError(
+            "expected grad_output_prototypes to line up with backward grad outputs, "
+            f"got {len(grad_output_prototypes)} != {expected_grad_outs}"
+        )
+
+    output_tangents_start = num_mutated_runtime_inps
+    output_tangents_end = output_tangents_start + metadata.num_outputs
+    materialized_output_indices: list[int] = []
+    materialized_flat_args: list[Any] = []
+
+    for i, (grad_out, prototype) in enumerate(zip(flat_args, grad_output_prototypes)):
+        if grad_out is not None or prototype is None:
+            materialized_flat_args.append(grad_out)
+            continue
+
+        materialized_flat_args.append(torch.zeros_like(prototype))
+        if output_tangents_start <= i < output_tangents_end:
+            output_idx = i - output_tangents_start
+            info = metadata.output_info[output_idx]
+            if (
+                info.output_type
+                in [
+                    OutputType.non_alias,
+                    OutputType.unsafe_view_alias,
+                    OutputType.custom_function_view,
+                ]
+                and issubclass(info.raw_type, torch.Tensor)
+                and info.requires_grad_for_backward
+            ):
+                materialized_output_indices.append(output_idx)
+
+    return materialized_flat_args, materialized_output_indices
+
+
 # NOTE: this function must be torch._dynamo.allow_in_graph-able. Non tensor/symnode inputs must be constants.
 def _backward_prologue_functional(
     ctx_saved_tensors: Sequence[torch.Tensor],
@@ -2016,10 +2066,9 @@ def _backward_prologue_functional(
     #     *unless* the output is used in some subclass compute later in the forward graph,
     #     which will cause its grad_output to become a subclass
     # (2) If an output is a subclass, its grad_out will also be a subclass,
-    #     *unless* the output of the forward did not actually participate in the gradient computation,
-    #     in which case autograd will insert a plain tensor of zeros for the grad_output.
-    #     We could avoid this case with `torch.autograd.Function.set_materialize_grads`,
-    #     although this is not turned on today in AOTAutgrad and would require more work.
+    #     *unless* the user explicitly passes in a plain tensor as the grad_output.
+    #     Undefined gradients from calling backward() on only a subset of outputs are
+    #     handled earlier in Python by materializing zeros from saved output prototypes.
     #
     # Today, we make a guess on subclass-ness based on the above examples,
     # and hard-error in the backward if we guessed wrong.
@@ -2769,12 +2818,63 @@ Your tensor subclass must implement __coerce_same_metadata_as_tangent__."""
                     if isinstance(x, torch.Tensor)
                     and not raw_returns_meta[i].requires_grad
                 ]
+
+                def _needs_grad_output_prototype(i: int) -> bool:
+                    if i < num_mutated_runtime_inps:
+                        input_info_idx = (
+                            CompiledFunction.metadata.mutated_inp_runtime_indices[i]
+                        )
+                        input_info = CompiledFunction.metadata.input_info[input_info_idx]
+                        return input_info.mutates_data and input_info.requires_grad
+                    if i < num_mutated_runtime_inps + num_outputs:
+                        output_info = CompiledFunction.metadata.output_info[
+                            i - num_mutated_runtime_inps
+                        ]
+                        return (
+                            output_info.output_type
+                            in [
+                                OutputType.non_alias,
+                                OutputType.unsafe_view_alias,
+                                OutputType.custom_function_view,
+                            ]
+                            and issubclass(output_info.raw_type, torch.Tensor)
+                            and output_info.requires_grad_for_backward
+                        )
+                    return True
+
+                ctx._grad_output_prototypes = tuple(
+                    out.detach()
+                    if isinstance(out, torch.Tensor) and _needs_grad_output_prototype(i)
+                    else None
+                    for i, out in enumerate(raw_returns)
+                )
                 ctx.mark_non_differentiable(*fw_outs_not_requiring_grad)
+                ctx.set_materialize_grads(False)
                 ctx._materialize_non_diff_grads = False
                 return tuple(raw_returns)
 
             @staticmethod
             def backward(ctx: Any, *flat_args: Any) -> tuple[Any, ...]:
+                flat_args, materialized_output_indices = (
+                    _materialize_undefined_grad_outputs(
+                        flat_args,
+                        ctx._grad_output_prototypes,
+                        CompiledFunction.metadata,
+                    )
+                )
+                if materialized_output_indices:
+                    output_indices = ", ".join(
+                        str(i) for i in materialized_output_indices
+                    )
+                    warnings.warn(
+                        "AOTAutograd materialized undefined grad outputs as zeros "
+                        f"for compiled forward outputs [{output_indices}]. This can "
+                        "run extra backward computation compared to eager. "
+                        "Detach outputs that do not need gradients to avoid it.",
+                        UserWarning,
+                        stacklevel=3,
+                    )
+
                 # Combine tensors from both sources:
                 # 1. ctx.saved_tensors - tensors that went through save_for_backward (with VC check)
                 # 2. ctx._tensors_no_vc_check - tensors stashed directly on ctx (no VC check)

--- a/torch/_functorch/_aot_autograd/runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/runtime_wrappers.py
@@ -1887,9 +1887,86 @@ def _raise_if_functorch_active() -> None:
     )
 
 
+@dataclass(frozen=True)
+class _PlainTensorZeroSpec:
+    size: tuple[IntLikeType, ...]
+    dtype: torch.dtype
+    device: torch.device
+    layout: torch.layout
+
+
+@dataclass(frozen=True)
+class _SubclassZeroSpec:
+    subclass_type: type
+    meta: Any
+    outer_size: tuple[IntLikeType, ...]
+    outer_stride: tuple[IntLikeType, ...]
+    attrs: dict[str, object]
+
+
+def _make_runtime_zero_spec(
+    x: torch.Tensor,
+    *,
+    preserve_subclass: bool,
+) -> _PlainTensorZeroSpec | _SubclassZeroSpec:
+    if preserve_subclass and is_traceable_wrapper_subclass(x):
+        keys, meta = x.__tensor_flatten__()
+        attrs: dict[str, object] = {}
+        for key in keys:
+            attr = getattr(x, key)
+            attrs[key] = (
+                _make_runtime_zero_spec(attr, preserve_subclass=True)
+                if isinstance(attr, torch.Tensor)
+                else attr
+            )
+        return _SubclassZeroSpec(
+            subclass_type=type(x),
+            meta=meta,
+            outer_size=tuple(x.size()),
+            outer_stride=tuple(x.stride()),
+            attrs=attrs,
+        )
+
+    return _PlainTensorZeroSpec(
+        size=tuple(x.shape),
+        dtype=x.dtype,
+        device=x.device,
+        layout=x.layout,
+    )
+
+
+def _materialize_zero_from_spec(
+    spec: _PlainTensorZeroSpec | _SubclassZeroSpec,
+) -> torch.Tensor:
+    if isinstance(spec, _PlainTensorZeroSpec):
+        return torch.zeros(
+            spec.size,
+            dtype=spec.dtype,
+            device=spec.device,
+            layout=spec.layout,
+        )
+
+    inner_tensors = {
+        key: (
+            _materialize_zero_from_spec(attr)
+            if isinstance(attr, (_PlainTensorZeroSpec, _SubclassZeroSpec))
+            else attr
+        )
+        for key, attr in spec.attrs.items()
+    }
+    return spec.subclass_type.__tensor_unflatten__(
+        inner_tensors,
+        spec.meta,
+        spec.outer_size,
+        spec.outer_stride,
+    )
+
+
 def _materialize_undefined_grad_outputs(
     flat_args: Sequence[Any],
-    grad_output_prototypes: Sequence[Tensor | None],
+    grad_output_zero_specs: Sequence[
+        _PlainTensorZeroSpec | _SubclassZeroSpec | None
+    ],
     metadata: ViewAndMutationMeta,
 ) -> tuple[list[Any], list[int]]:
     num_intermediate_bases = metadata.num_intermediate_bases
@@ -1902,10 +1979,10 @@ def _materialize_undefined_grad_outputs(
         raise AssertionError(
             f"expected {expected_grad_outs} grad_outs, got {len(flat_args)}"
         )
-    if len(grad_output_prototypes) != expected_grad_outs:
+    if len(grad_output_zero_specs) != expected_grad_outs:
         raise AssertionError(
-            "expected grad_output_prototypes to line up with backward grad outputs, "
-            f"got {len(grad_output_prototypes)} != {expected_grad_outs}"
+            "expected grad_output_zero_specs to line up with backward grad outputs, "
+            f"got {len(grad_output_zero_specs)} != {expected_grad_outs}"
         )
 
     output_tangents_start = num_mutated_runtime_inps
@@ -1913,12 +1990,12 @@ def _materialize_undefined_grad_outputs(
     materialized_output_indices: list[int] = []
     materialized_flat_args: list[Any] = []
 
-    for i, (grad_out, prototype) in enumerate(zip(flat_args, grad_output_prototypes)):
-        if grad_out is not None or prototype is None:
+    for i, (grad_out, zero_spec) in enumerate(zip(flat_args, grad_output_zero_specs)):
+        if grad_out is not None or zero_spec is None:
             materialized_flat_args.append(grad_out)
             continue
 
-        materialized_flat_args.append(torch.zeros_like(prototype))
+        materialized_flat_args.append(_materialize_zero_from_spec(zero_spec))
         if output_tangents_start <= i < output_tangents_end:
             output_idx = i - output_tangents_start
             info = metadata.output_info[output_idx]
@@ -2068,7 +2145,7 @@ def _backward_prologue_functional(
     # (2) If an output is a subclass, its grad_out will also be a subclass,
     #     *unless* the user explicitly passes in a plain tensor as the grad_output.
     #     Undefined gradients from calling backward() on only a subset of outputs are
-    #     handled earlier in Python by materializing zeros from saved output prototypes.
+    #     handled earlier in Python by materializing zeros from lightweight runtime specs.
     #
     # Today, we make a guess on subclass-ness based on the above examples,
     # and hard-error in the backward if we guessed wrong.
@@ -2819,12 +2896,22 @@ Your tensor subclass must implement __coerce_same_metadata_as_tangent__."""
                     and not raw_returns_meta[i].requires_grad
                 ]
 
-                def _needs_grad_output_prototype(i: int) -> bool:
+                if len(raw_returns) != len(
+                    CompiledFunction.metadata.subclass_tangent_meta
+                ):
+                    raise AssertionError(
+                        "expected raw_returns and subclass_tangent_meta to have the same length, "
+                        f"got {len(raw_returns)} != {len(CompiledFunction.metadata.subclass_tangent_meta)}"
+                    )
+
+                def _needs_undefined_grad_materialization(i: int) -> bool:
                     if i < num_mutated_runtime_inps:
                         input_info_idx = (
                             CompiledFunction.metadata.mutated_inp_runtime_indices[i]
                         )
-                        input_info = CompiledFunction.metadata.input_info[input_info_idx]
+                        input_info = CompiledFunction.metadata.input_info[
+                            input_info_idx
+                        ]
                         return input_info.mutates_data and input_info.requires_grad
                     if i < num_mutated_runtime_inps + num_outputs:
                         output_info = CompiledFunction.metadata.output_info[
@@ -2842,9 +2929,16 @@ Your tensor subclass must implement __coerce_same_metadata_as_tangent__."""
                         )
                     return True
 
-                ctx._grad_output_prototypes = tuple(
-                    out.detach()
-                    if isinstance(out, torch.Tensor) and _needs_grad_output_prototype(i)
+                ctx._grad_output_zero_specs = tuple(
+                    _make_runtime_zero_spec(
+                        out,
+                        preserve_subclass=isinstance(
+                            CompiledFunction.metadata.subclass_tangent_meta[i],
+                            SubclassCreationMeta,
+                        ),
+                    )
+                    if isinstance(out, torch.Tensor)
+                    and _needs_undefined_grad_materialization(i)
                     else None
                     for i, out in enumerate(raw_returns)
                 )
@@ -2858,7 +2952,7 @@ Your tensor subclass must implement __coerce_same_metadata_as_tangent__."""
                 flat_args, materialized_output_indices = (
                     _materialize_undefined_grad_outputs(
                         flat_args,
-                        ctx._grad_output_prototypes,
+                        ctx._grad_output_zero_specs,
                         CompiledFunction.metadata,
                     )
                 )


### PR DESCRIPTION
Fix #131794

## Summary
- Root cause: AOTAutograd's custom autograd.Function let autograd eagerly materialize undefined grad outputs as zeros before backward saw them, so calling backward on only a subset of differentiable outputs silently ran extra backward work.
- Proposed fix: preserve undefined grad outputs with `set_materialize_grads(False)`, warn when compiled backward only receives a subset of differentiable outputs, and recreate zero tangents from saved forward-output prototypes before invoking the compiled backward.
- Why this is the right long term fix: it makes the eager-vs-compiled mismatch explicit, keeps existing gradients and subclass metadata stable, and avoids silently hard-coding plain-tensor zero grads in the compiled path.
- Tests: add a regression test covering the aot_eager warning and gradient parity when backward only uses one of several differentiable outputs.

Drafted via @codex, published after manual review by @bobrenjc93