### PR TITLE
[operator_benchmark] Fix CUDA forward timing inflation and missing ba…

### DIFF
--- a/benchmarks/operator_benchmark/benchmark_core.py
+++ b/benchmarks/operator_benchmark/benchmark_core.py
@@ -376,16 +376,18 @@ class BenchmarkRunner:
             },
         )
         result = timer.adaptive_autorange(min_run_time=0.0001)
-        return result.median * iters
+        return result.median
 
     def _launch_backward(self, test_case, iters, print_per_iter=False):
         """This function runs forward path of an op to get an output. Then the backward path is executed
         and the execution time is reported
         """
+        cuda_sync = "cuda" in test_case.test_config.test_name
         test_case.run_forward(num_runs=1, print_per_iter=False, cuda_sync=False)
         test_case._output_mean()
         backward_time = timeit.timeit(
-            functools.partial(test_case.run_backward, iters, print_per_iter), number=1
+            functools.partial(test_case.run_backward, iters, print_per_iter, cuda_sync),
+            number=1,
         )
         return backward_time
 

--- a/benchmarks/operator_benchmark/benchmark_pytorch.py
+++ b/benchmarks/operator_benchmark/benchmark_pytorch.py
@@ -244,11 +244,13 @@ class PyTorchOperatorTestCase:
         """
         self.mean = self.output.mean()
 
-    def run_backward(self, num_runs, print_per_iter=False):
+    def run_backward(self, num_runs, print_per_iter=False, cuda_sync=False):
         """Run the backward path of an op in many iterations"""
         # TODO: can we use JIT here to reduce python overhead?
         for _ in range(num_runs):
             self.mean.backward(retain_graph=True)
+        if cuda_sync:
+            torch.cuda.synchronize(torch.cuda.current_device())
 
 
 def create_pytorch_op_test_case(op_bench, test_config):


### PR DESCRIPTION
Fix two bugs in the operator benchmark framework:

1. CUDA forward timing was inflated by a factor of `iters`. `Timer.adaptive_autorange` runs the stmt (which internally loops `iters` times) and returns the median wall-clock time for one stmt invocation. Multiplying by `iters` again caused `_measure_metrics` to report total-loop time instead of per-op time after dividing by `iters`.

2. CUDA backward pass never called `torch.cuda.synchronize()`, so measured time only captured kernel launch overhead rather than actual GPU execution time. Add `cuda_sync` parameter to `run_backward` (matching `run_forward`) and pass it through from `_launch_backward`.