### PR TITLE
Add SAC regression test for scaled_mm inputs

### DIFF
--- a/test/dynamo/test_activation_checkpointing.py
+++ b/test/dynamo/test_activation_checkpointing.py
@@ -28,6 +28,7 @@ from torch._dynamo.testing import (
     normalize_gm,
 )
 from torch._higher_order_ops.wrap import tag_activation_checkpoint
+from torch.testing._internal.common_cuda import SM89OrLater
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import IS_WINDOWS, parametrize, skipIfHpu
 from torch.testing._internal.inductor_utils import HAS_CUDA_AND_TRITON
@@ -853,6 +854,117 @@ Non-primal fwd outputs from model w/o backward hook: {mod_no_hook_fwd_outputs_no
         self.assertEqual(len(cnt.graphs), 2)
         wrap_node = find_first_node(cnt.graphs[0], tag_activation_checkpoint)
         self.assertEqual(len(wrap_node.args), 3)
+
+    @requires_cuda_and_triton
+    @unittest.skipIf(not SM89OrLater, "requires SM89+ GPU")
+    @unittest.skipIf(IS_WINDOWS, "torch.compile doesn't work with windows")
+    @parametrize(
+        "partition_fn",
+        [
+            min_cut_rematerialization_partition,
+            default_partition,
+        ],
+    )
+    def test_compile_selective_checkpoint_scaled_mm_recomputes_inputs(
+        self, device, partition_fn
+    ):
+        float8_dtype = torch.float8_e4m3fn
+
+        def to_float8(x):
+            amax = torch.max(torch.abs(x))
+            scale = torch.finfo(float8_dtype).max / torch.clamp(
+                amax.float(), min=1e-12
+            )
+            x_fp8 = (x.float() * scale).to(float8_dtype)
+            return x_fp8, scale.reciprocal().reshape(1, 1)
+
+        @torch.compiler.allow_in_graph
+        class Fp8LinearFn(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, x, w_t):
+                x_fp8, scale_a = to_float8(x)
+                w_t_fp8, scale_b = to_float8(w_t)
+                out = torch._scaled_mm(
+                    x_fp8,
+                    w_t_fp8.t(),
+                    scale_a=scale_a,
+                    scale_b=scale_b,
+                    out_dtype=torch.bfloat16,
+                    use_fast_accum=False,
+                )
+                ctx.save_for_backward(x, w_t)
+                return out
+
+            @staticmethod
+            def backward(ctx, grad_out):
+                x, w_t = ctx.saved_tensors
+                grad_x = grad_out @ w_t
+                grad_w_t = grad_out.t() @ x
+                return grad_x, grad_w_t
+
+        def selective_checkpointing_context_fn():
+            def policy_fn(ctx, op, *args, **kwargs):
+                if op == torch.ops.aten._scaled_mm.default:
+                    return CheckpointPolicy.MUST_SAVE
+                return CheckpointPolicy.PREFER_RECOMPUTE
+
+            return create_selective_checkpoint_contexts(policy_fn)
+
+        def gn(x, w):
+            out = Fp8LinearFn.apply(x, w)
+            return x + torch.relu(out)
+
+        def fn(x, w):
+            return torch.utils.checkpoint.checkpoint(
+                gn,
+                x,
+                w,
+                use_reentrant=False,
+                context_fn=selective_checkpointing_context_fn,
+            )
+
+        x = torch.randn(32, 32, requires_grad=True, device=device, dtype=torch.bfloat16)
+        w = torch.randn(32, 32, requires_grad=True, device=device, dtype=torch.bfloat16)
+
+        fw_graphs = []
+
+        def record_graph(gm, _example_inputs):
+            fw_graphs.append(gm)
+            return gm.forward
+
+        backend = aot_autograd(
+            fw_compiler=record_graph,
+            bw_compiler=nop,
+            partition_fn=partition_fn,
+        )
+        self._validate(fn, backend, x, w)
+
+        fw_graph = fw_graphs[0]
+        scaled_mm_node = find_first_node(fw_graph, torch.ops.aten._scaled_mm.default)
+        self.assertIsNotNone(scaled_mm_node)
+
+        return_node = next(node for node in fw_graph.graph.nodes if node.op == "output")
+        saved_outputs = {
+            output.name
+            for output in return_node.args[0]
+            if isinstance(output, torch.fx.Node)
+            and not output.name.startswith("primals_")
+        }
+        scaled_mm_inputs = {
+            arg.name
+            for arg in scaled_mm_node.args
+            if isinstance(arg, torch.fx.Node) and not arg.name.startswith("primals_")
+        }
+        self.assertTrue(scaled_mm_inputs)
+        self.assertFalse(
+            saved_outputs & scaled_mm_inputs,
+            msg=(
+                "SAC should recompute non-primal _scaled_mm inputs instead of "
+                f"saving them in the forward graph outputs, but saved "
+                f"{saved_outputs & scaled_mm_inputs}. "
+                f"Forward outputs: {saved_outputs}. _scaled_mm inputs: {scaled_mm_inputs}."
+            ),
+        )
 
     @requires_cuda_and_triton
     @unittest.skipIf(IS_WINDOWS, "torch.compile doesn't work with windows")

--- a/test/dynamo/test_activation_checkpointing.py
+++ b/test/dynamo/test_activation_checkpointing.py
@@ -29,7 +29,10 @@ from torch._dynamo.testing import (
 )
 from torch._higher_order_ops.wrap import tag_activation_checkpoint
 from torch.testing._internal.common_cuda import PLATFORM_SUPPORTS_FP8
-from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_device_type import (
+    e4m3_type,
+    instantiate_device_type_tests,
+)
 from torch.testing._internal.common_utils import IS_WINDOWS, parametrize, skipIfHpu
 from torch.testing._internal.inductor_utils import HAS_CUDA_AND_TRITON
 from torch.testing._internal.triton_utils import requires_cuda_and_triton
@@ -869,7 +872,7 @@ Non-primal fwd outputs from model w/o backward hook: {mod_no_hook_fwd_outputs_no
     def test_compile_selective_checkpoint_scaled_mm_must_save(
         self, device, partition_fn
     ):
-        float8_dtype = torch.float8_e4m3fn
+        float8_dtype = e4m3_type
 
         def to_float8(x):
             amax = torch.max(torch.abs(x))
@@ -956,9 +959,13 @@ Non-primal fwd outputs from model w/o backward hook: {mod_no_hook_fwd_outputs_no
             and not output.name.startswith("primals_")
         }
         scaled_mm_inputs = {
-            arg.name
-            for arg in scaled_mm_node.args
-            if isinstance(arg, torch.fx.Node) and not arg.name.startswith("primals_")
+            input_node.name
+            for input_node in (
+                *scaled_mm_node.args,
+                *scaled_mm_node.kwargs.values(),
+            )
+            if isinstance(input_node, torch.fx.Node)
+            and not input_node.name.startswith("primals_")
         }
         self.assertTrue(scaled_mm_inputs)
         self.assertFalse(

--- a/test/dynamo/test_activation_checkpointing.py
+++ b/test/dynamo/test_activation_checkpointing.py
@@ -28,7 +28,7 @@ from torch._dynamo.testing import (
     normalize_gm,
 )
 from torch._higher_order_ops.wrap import tag_activation_checkpoint
-from torch.testing._internal.common_cuda import SM89OrLater
+from torch.testing._internal.common_cuda import PLATFORM_SUPPORTS_FP8
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import IS_WINDOWS, parametrize, skipIfHpu
 from torch.testing._internal.inductor_utils import HAS_CUDA_AND_TRITON
@@ -855,8 +855,9 @@ Non-primal fwd outputs from model w/o backward hook: {mod_no_hook_fwd_outputs_no
         wrap_node = find_first_node(cnt.graphs[0], tag_activation_checkpoint)
         self.assertEqual(len(wrap_node.args), 3)
 
-    @requires_cuda_and_triton
-    @unittest.skipIf(not SM89OrLater, "requires SM89+ GPU")
+    @unittest.skipIf(
+        not PLATFORM_SUPPORTS_FP8, "requires platform with fp8 _scaled_mm support"
+    )
     @unittest.skipIf(IS_WINDOWS, "torch.compile doesn't work with windows")
     @parametrize(
         "partition_fn",
@@ -865,16 +866,14 @@ Non-primal fwd outputs from model w/o backward hook: {mod_no_hook_fwd_outputs_no
             default_partition,
         ],
     )
-    def test_compile_selective_checkpoint_scaled_mm_recomputes_inputs(
+    def test_compile_selective_checkpoint_scaled_mm_must_save(
         self, device, partition_fn
     ):
         float8_dtype = torch.float8_e4m3fn
 
         def to_float8(x):
             amax = torch.max(torch.abs(x))
-            scale = torch.finfo(float8_dtype).max / torch.clamp(
-                amax.float(), min=1e-12
-            )
+            scale = torch.finfo(float8_dtype).max / torch.clamp(amax.float(), min=1e-12)
             x_fp8 = (x.float() * scale).to(float8_dtype)
             return x_fp8, scale.reciprocal().reshape(1, 1)
 
@@ -927,19 +926,25 @@ Non-primal fwd outputs from model w/o backward hook: {mod_no_hook_fwd_outputs_no
         w = torch.randn(32, 32, requires_grad=True, device=device, dtype=torch.bfloat16)
 
         fw_graphs = []
+        bw_graphs = []
 
-        def record_graph(gm, _example_inputs):
+        def record_fw_graph(gm, _example_inputs):
             fw_graphs.append(gm)
             return gm.forward
 
+        def record_bw_graph(gm, _example_inputs):
+            bw_graphs.append(gm)
+            return gm.forward
+
         backend = aot_autograd(
-            fw_compiler=record_graph,
-            bw_compiler=nop,
+            fw_compiler=record_fw_graph,
+            bw_compiler=record_bw_graph,
             partition_fn=partition_fn,
         )
         self._validate(fn, backend, x, w)
 
         fw_graph = fw_graphs[0]
+        bw_graph = bw_graphs[0]
         scaled_mm_node = find_first_node(fw_graph, torch.ops.aten._scaled_mm.default)
         self.assertIsNotNone(scaled_mm_node)
 
@@ -963,6 +968,14 @@ Non-primal fwd outputs from model w/o backward hook: {mod_no_hook_fwd_outputs_no
                 f"saving them in the forward graph outputs, but saved "
                 f"{saved_outputs & scaled_mm_inputs}. "
                 f"Forward outputs: {saved_outputs}. _scaled_mm inputs: {scaled_mm_inputs}."
+            ),
+        )
+        self.assertIsNone(
+            find_first_node(bw_graph, torch.ops.aten._scaled_mm.default),
+            msg=(
+                "CheckpointPolicy.MUST_SAVE for _scaled_mm should keep the op out of the "
+                "backward recompute graph, but backward still contains it:\n"
+                f"{bw_graph.print_readable(print_output=False)}"
             ),
         )
 

--- a/test/dynamo/test_activation_checkpointing.py
+++ b/test/dynamo/test_activation_checkpointing.py
@@ -160,6 +160,19 @@ def find_first_node(gm, func):
     return None
 
 
+def collect_non_primal_node_and_ancestors(nodes):
+    collected = set()
+    worklist = [node for node in nodes if isinstance(node, torch.fx.Node)]
+    while worklist:
+        node = worklist.pop()
+        if node in collected or node.name.startswith("primals_"):
+            continue
+        collected.add(node)
+        if node.op != "placeholder":
+            worklist.extend(node.all_input_nodes)
+    return {node.name for node in collected}
+
+
 def op_count(gm):
     result = 0
     for node in gm.graph.nodes:
@@ -958,8 +971,8 @@ Non-primal fwd outputs from model w/o backward hook: {mod_no_hook_fwd_outputs_no
             if isinstance(output, torch.fx.Node)
             and not output.name.startswith("primals_")
         }
-        scaled_mm_inputs = {
-            input_node.name
+        scaled_mm_input_nodes = {
+            input_node
             for input_node in (
                 *scaled_mm_node.args,
                 *scaled_mm_node.kwargs.values(),
@@ -967,14 +980,18 @@ Non-primal fwd outputs from model w/o backward hook: {mod_no_hook_fwd_outputs_no
             if isinstance(input_node, torch.fx.Node)
             and not input_node.name.startswith("primals_")
         }
-        self.assertTrue(scaled_mm_inputs)
+        scaled_mm_input_ancestors = collect_non_primal_node_and_ancestors(
+            scaled_mm_input_nodes
+        )
+        self.assertTrue(scaled_mm_input_ancestors)
         self.assertFalse(
-            saved_outputs & scaled_mm_inputs,
+            saved_outputs & scaled_mm_input_ancestors,
             msg=(
-                "SAC should recompute non-primal _scaled_mm inputs instead of "
-                f"saving them in the forward graph outputs, but saved "
-                f"{saved_outputs & scaled_mm_inputs}. "
-                f"Forward outputs: {saved_outputs}. _scaled_mm inputs: {scaled_mm_inputs}."
+                "SAC should recompute non-primal _scaled_mm inputs and their "
+                f"producer chains instead of saving them in the forward graph "
+                f"outputs, but saved {saved_outputs & scaled_mm_input_ancestors}. "
+                f"Forward outputs: {saved_outputs}. _scaled_mm input ancestors: "
+                f"{scaled_mm_input_ancestors}."
             ),
         )
         self.assertIsNone(


### PR DESCRIPTION
Fix #128730

## Summary

### Root cause
The original SAC bug was that AOTAutograd could save recomputable float8 `_scaled_mm` inputs in the forward graph outputs instead of only honoring the user's selective-checkpointing decision for the matmul itself. That bad runtime behavior no longer appears on `main`, but we had no regression coverage for this float8 SAC case.

### Proposed fix
Add a targeted activation-checkpointing test that runs a float8 `_scaled_mm` path under a selective checkpoint policy and asserts the forward graph does not save non-primal `_scaled_mm` inputs.

### Why this is the right long term fix
The partitioner behavior appears correct today, so the durable fix is to lock it in with coverage that fails if future changes start saving recomputable float8 matmul inputs again.

Drafted via @codex, published after manual review by @bobrenjc93

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo