### PR TITLE
[CUDA][CUDA 13.2][FP8] Work around NaNs in `float32` -> `fp8` casts via intrinsics

### DIFF
--- a/aten/src/ATen/native/cuda/Copy.cu
+++ b/aten/src/ATen/native/cuda/Copy.cu
@@ -22,6 +22,10 @@
 #include <ATen/cuda/CUDAGraphsUtils.cuh>
 
 // TODO(NS): Investigate why FP8 conversion intrinsics end up being slower
+// or in CUDA 13.2 which has numerical issues with the non-intrinsic path
+#if defined(CUDA_VERSION) && CUDA_VERSION >= 13020
+#define AT_USE_NV_CVT_INTRINSICS
+#endif
 #ifdef AT_USE_NV_CVT_INTRINSICS
 #include <cuda_fp8.h>
 #endif
@@ -76,7 +80,12 @@ void float8_copy_kernel_cuda(TensorIteratorBase &iter) {
     switch (other_dtype) {
       case kFloat:
          gpu_kernel_nocast(iter, [] GPU_LAMBDA(float value) {
+#ifdef AT_USE_NV_CVT_INTRINSICS
+             const auto x =  __nv_cvt_float_to_fp8(value, __NV_NOSAT, __NV_E4M3);
+             return Float8_e4m3fn(x);
+#else
              return Float8_e4m3fn(value);
+#endif
          });
          break;
       case kHalf:

--- a/aten/src/ATen/native/cuda/Copy.cu
+++ b/aten/src/ATen/native/cuda/Copy.cu
@@ -81,7 +81,7 @@ void float8_copy_kernel_cuda(TensorIteratorBase &iter) {
       case kFloat:
          gpu_kernel_nocast(iter, [] GPU_LAMBDA(float value) {
 #ifdef AT_USE_NV_CVT_INTRINSICS
-             const auto x =  __nv_cvt_float_to_fp8(value, __NV_NOSAT, __NV_E4M3);
+             const auto x =  __nv_cvt_float_to_fp8(value, __NV_SATFINITE, __NV_E4M3);
              return Float8_e4m3fn(x);
 #else
              return Float8_e4m3fn(value);


### PR DESCRIPTION
Otherwise we are observing NaN values from casts with the vec8 path enabled.
Currently does cause a slowdown in cast kernel speed though

Thinking about where to add the test case :/ 