### PR TITLE
Preserve cumulative out dtype semantics during functionalization

### DIFF
--- a/test/inductor/test_auto_functionalize.py
+++ b/test/inductor/test_auto_functionalize.py
@@ -477,6 +477,34 @@ def forward(self, arg0_1: "f32[3][1]cpu", arg1_1: "f32[3][1]cpu", arg2_1: "f32[3
 
         return [compiled_args, result, graph]
 
+    def test_cumulative_out_preserves_out_dtype_under_compile(self):
+        test_cases = [
+            (torch.cumsum, torch.tensor([0.9201, 0.1166], dtype=torch.float32)),
+            (torch.cumprod, torch.tensor([2.0, 0.6], dtype=torch.float32)),
+        ]
+
+        for op, x in test_cases:
+            with self.subTest(op=op.__name__):
+                def f(out, x):
+                    return op(x, 0, out=out)
+
+                eager_out = torch.tensor([0, 0], dtype=torch.int32)
+                aot_eager_out = eager_out.clone()
+                inductor_out = eager_out.clone()
+
+                eager_ret = f(eager_out, x)
+                aot_eager_ret = torch.compile(
+                    f, backend="aot_eager", fullgraph=True
+                )(aot_eager_out, x)
+                inductor_ret = torch.compile(
+                    f, backend="inductor", fullgraph=True
+                )(inductor_out, x)
+
+                self.assertEqual(aot_eager_out, eager_out)
+                self.assertEqual(inductor_out, eager_out)
+                self.assertEqual(aot_eager_ret, eager_ret)
+                self.assertEqual(inductor_ret, eager_ret)
+
     @torch._inductor.config.patch(enable_auto_functionalized_v2=True)
     def test_auto_functionalize_with_returns_v2(self):
         with torch.library._scoped_library("mylib", "FRAGMENT") as lib:

--- a/test/inductor/test_auto_functionalize.py
+++ b/test/inductor/test_auto_functionalize.py
@@ -485,6 +485,7 @@ def forward(self, arg0_1: "f32[3][1]cpu", arg1_1: "f32[3][1]cpu", arg2_1: "f32[3
 
         for op, x in test_cases:
             with self.subTest(op=op.__name__):
+
                 def f(out, x):
                     return op(x, 0, out=out)
 
@@ -493,12 +494,12 @@ def forward(self, arg0_1: "f32[3][1]cpu", arg1_1: "f32[3][1]cpu", arg2_1: "f32[3
                 inductor_out = eager_out.clone()
 
                 eager_ret = f(eager_out, x)
-                aot_eager_ret = torch.compile(
-                    f, backend="aot_eager", fullgraph=True
-                )(aot_eager_out, x)
-                inductor_ret = torch.compile(
-                    f, backend="inductor", fullgraph=True
-                )(inductor_out, x)
+                aot_eager_ret = torch.compile(f, backend="aot_eager", fullgraph=True)(
+                    aot_eager_out, x
+                )
+                inductor_ret = torch.compile(f, backend="inductor", fullgraph=True)(
+                    inductor_out, x
+                )
 
                 self.assertEqual(aot_eager_out, eager_out)
                 self.assertEqual(inductor_out, eager_out)

--- a/torchgen/gen_functionalization_type.py
+++ b/torchgen/gen_functionalization_type.py
@@ -37,6 +37,7 @@ from torchgen.model import (
     NativeFunction,
     NativeFunctionsGroup,
     NativeFunctionsViewGroup,
+    OperatorName,
     Return,
     SchemaKind,
     SelfArgument,
@@ -80,10 +81,10 @@ MUTABLE_OPS_NOT_USING_FUNCTIONALIZATION = (
 # Functionalization normally lowers mutable ops through their functional variants,
 # so these need to thread the out dtype explicitly to preserve eager semantics.
 CUMULATIVE_OUT_OPS_PRESERVING_OUT_DTYPE = {
-    "cumsum.out",
-    "cumprod.out",
-    "cumsum.dimname_out",
-    "cumprod.dimname_out",
+    OperatorName.parse("cumsum.out"),
+    OperatorName.parse("cumprod.out"),
+    OperatorName.parse("cumsum.dimname_out"),
+    OperatorName.parse("cumprod.dimname_out"),
 }
 
 # This file contains codegen that relates to the functionalization pass.
@@ -624,7 +625,7 @@ def maybe_replace_cumulative_out_dtype_exprs(
 ) -> list[str]:
     if (
         f.func.kind() != SchemaKind.out
-        or str(f.func.name) not in CUMULATIVE_OUT_OPS_PRESERVING_OUT_DTYPE
+        or f.func.name not in CUMULATIVE_OUT_OPS_PRESERVING_OUT_DTYPE
     ):
         return functional_exprs
 

--- a/torchgen/gen_functionalization_type.py
+++ b/torchgen/gen_functionalization_type.py
@@ -631,7 +631,7 @@ def maybe_replace_cumulative_out_dtype_exprs(
 
     if len(f.func.arguments.out) != 1:
         raise AssertionError(
-            f"Expected a single out argument for cumulative out op: {f.func}"
+            f"Expected a single out argument for cumulative out op: {f.func.name}"
         )
 
     dtype_arg_idx = next(
@@ -639,7 +639,7 @@ def maybe_replace_cumulative_out_dtype_exprs(
         None,
     )
     if dtype_arg_idx is None:
-        raise AssertionError(f"Expected dtype argument for cumulative out op: {f.func}")
+        raise AssertionError(f"Expected dtype argument for cumulative out op: {f.func.name}")
 
     adjusted_exprs = functional_exprs.copy()
     dtype_expr = adjusted_exprs[dtype_arg_idx]

--- a/torchgen/gen_functionalization_type.py
+++ b/torchgen/gen_functionalization_type.py
@@ -639,7 +639,9 @@ def maybe_replace_cumulative_out_dtype_exprs(
         None,
     )
     if dtype_arg_idx is None:
-        raise AssertionError(f"Expected dtype argument for cumulative out op: {f.func.name}")
+        raise AssertionError(
+            f"Expected dtype argument for cumulative out op: {f.func.name}"
+        )
 
     adjusted_exprs = functional_exprs.copy()
     dtype_expr = adjusted_exprs[dtype_arg_idx]

--- a/torchgen/gen_functionalization_type.py
+++ b/torchgen/gen_functionalization_type.py
@@ -76,6 +76,16 @@ MUTABLE_OPS_NOT_USING_FUNCTIONALIZATION = (
     ]
 )
 
+# Eager cumulative out variants compute in the out dtype when dtype is omitted.
+# Functionalization normally lowers mutable ops through their functional variants,
+# so these need to thread the out dtype explicitly to preserve eager semantics.
+CUMULATIVE_OUT_OPS_PRESERVING_OUT_DTYPE = {
+    "cumsum.out",
+    "cumprod.out",
+    "cumsum.dimname_out",
+    "cumprod.dimname_out",
+}
+
 # This file contains codegen that relates to the functionalization pass.
 # It includes:
 # - gen_functionalization_definition
@@ -607,6 +617,38 @@ def wrap_propagate_mutations_and_return(
     {returns_str}"""
 
 
+def maybe_replace_cumulative_out_dtype_exprs(
+    f: NativeFunction,
+    functional_sig: DispatcherSignature,
+    functional_exprs: list[str],
+) -> list[str]:
+    if (
+        f.func.kind() != SchemaKind.out
+        or str(f.func.name) not in CUMULATIVE_OUT_OPS_PRESERVING_OUT_DTYPE
+    ):
+        return functional_exprs
+
+    if len(f.func.arguments.out) != 1:
+        raise AssertionError(
+            f"Expected a single out argument for cumulative out op: {f.func}"
+        )
+
+    dtype_arg_idx = next(
+        (i for i, arg in enumerate(functional_sig.arguments()) if arg.name == "dtype"),
+        None,
+    )
+    if dtype_arg_idx is None:
+        raise AssertionError(f"Expected dtype argument for cumulative out op: {f.func}")
+
+    adjusted_exprs = functional_exprs.copy()
+    dtype_expr = adjusted_exprs[dtype_arg_idx]
+    adjusted_exprs[dtype_arg_idx] = (
+        f"{dtype_expr}.has_value() ? {dtype_expr} : "
+        f"std::optional<at::ScalarType>({f.func.arguments.out[0].name}_.scalar_type())"
+    )
+    return adjusted_exprs
+
+
 # Generates the Functionalization kernel for:
 # - mutation ops (inplace and out= ops)
 @with_native_function_and
@@ -678,6 +720,9 @@ def emit_inplace_functionalization_body(
         e.expr
         for e in translate(unwrapped_args_ctx, functional_sig.arguments(), method=False)
     ]
+    functional_exprs = maybe_replace_cumulative_out_dtype_exprs(
+        f, functional_sig, functional_exprs
+    )
 
     meta_conversion_str, meta_call_ctx = convert_to_meta_tensors(dispatcher_sig)
     # We don't want to run the inplace meta func for ops like .set_(), because:


### PR DESCRIPTION
Fix #117623

## Summary

1. What is the root cause problem
Functionalization lowers cumulative out variants through their functional forms and then propagates the mutation back to `out`. For `cumsum` and `cumprod`, eager `out=` behavior uses the `out` dtype as the computation dtype when `dtype=None`, so the lowered path was computing in the input dtype and only converting later.

2. What is the proposed fix
Teach functionalization codegen to thread `out.scalar_type()` into cumulative functional calls when lowering `cumsum` and `cumprod` out variants without an explicit `dtype`, and add a regression test covering eager, `aot_eager`, and `inductor`.

3. Why is the proposed fix the right long term fix
It preserves the existing eager contract at the functionalization boundary where the semantic mismatch is introduced, without changing eager kernels or broadening dtype rules for non-`out` variants.

Drafted via @codex, published after manual review by @bobrenjc93

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo