### PR TITLE
Collapse foreach input mutation copies into foreach_copy_

### DIFF
--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -5384,6 +5384,39 @@ def forward(self, s77 : torch.SymInt, s27 : torch.SymInt, L_x_ : torch.Tensor):
     #         )
     #         self.assertEqual(out_ref, out_test)
 
+    def test_foreach_input_mutation_emits_foreach_copy(self):
+        fw_graph[0] = None
+
+        @torch.compile(backend=aot_graph_capture_backend, fullgraph=True)
+        def fn(args):
+            torch._foreach_mul_(args, 2)
+            return args[0]
+
+        inps = [torch.ones(10) for _ in range(4)]
+        out = fn(inps)
+
+        self.assertEqual(out, torch.full((10,), 2.0))
+        self.assertIsNotNone(fw_graph[0])
+
+        foreach_copy_nodes = list(
+            fw_graph[0].graph.find_nodes(
+                op="call_function", target=torch.ops.aten._foreach_copy_.default
+            )
+        )
+        copy_nodes = list(
+            fw_graph[0].graph.find_nodes(
+                op="call_function", target=torch.ops.aten.copy_.default
+            )
+        )
+
+        self.assertEqual(len(foreach_copy_nodes), 1)
+        self.assertEqual(len(copy_nodes), 0)
+
+        foreach_copy = foreach_copy_nodes[0]
+        dsts, srcs = foreach_copy.args[:2]
+        self.assertEqual(len(dsts), len(inps))
+        self.assertEqual([src.args[1] for src in srcs], list(range(len(inps))))
+
     def test_super_in_staticmethod(self):
         class A:
             @staticmethod

--- a/torch/_functorch/_aot_autograd/functional_utils.py
+++ b/torch/_functorch/_aot_autograd/functional_utils.py
@@ -583,13 +583,12 @@ def _is_foreach_op(node: torch.fx.Node) -> bool:
 
 def _get_foreach_copy_candidate(
     node: torch.fx.Node,
-) -> tuple[torch.fx.Node, int, torch.fx.Node, torch.fx.Node] | None:
+) -> tuple[torch.fx.Node, torch.fx.Node, torch.fx.Node] | None:
     if (
         node.op != "call_function"
         or node.target is not torch.ops.aten.copy_.default
         or node.kwargs
         or len(node.args) != 2
-        or node.users
     ):
         return None
 
@@ -605,18 +604,27 @@ def _get_foreach_copy_candidate(
     if not _is_foreach_op(parent):
         return None
 
-    return parent, index, dst, src
+    return parent, dst, src
+
+
+def _is_getitem_from_parent(node: torch.fx.Node, parent: torch.fx.Node) -> bool:
+    return (
+        node.op == "call_function"
+        and node.target is operator.getitem
+        and len(node.args) == 2
+        and node.args[0] is parent
+        and isinstance(node.args[1], int)
+    )
 
 
 def fold_foreach_input_mutation_ops(fx_g: torch.fx.Graph) -> None:
     groups: list[
-        list[tuple[torch.fx.Node, torch.fx.Node, int, torch.fx.Node, torch.fx.Node]]
+        list[tuple[torch.fx.Node, torch.fx.Node, torch.fx.Node, torch.fx.Node]]
     ] = []
     current_group: list[
-        tuple[torch.fx.Node, torch.fx.Node, int, torch.fx.Node, torch.fx.Node]
+        tuple[torch.fx.Node, torch.fx.Node, torch.fx.Node, torch.fx.Node]
     ] = []
     current_key: tuple[torch.fx.Node, str | None] | None = None
-    seen_indices: set[int] = set()
 
     def flush() -> None:
         nonlocal current_key
@@ -624,31 +632,30 @@ def fold_foreach_input_mutation_ops(fx_g: torch.fx.Graph) -> None:
             groups.append(current_group.copy())
         current_group.clear()
         current_key = None
-        seen_indices.clear()
 
     for node in fx_g.nodes:
         candidate = _get_foreach_copy_candidate(node)
         if candidate is None:
+            if current_key is not None and _is_getitem_from_parent(node, current_key[0]):
+                continue
             flush()
             continue
 
-        parent, index, dst, src = candidate
+        parent, dst, src = candidate
         candidate_key = (parent, node.meta.get("partitioner_tag"))
-        if current_group and (candidate_key != current_key or index in seen_indices):
+        if current_group and candidate_key != current_key:
             flush()
 
         if current_key is None:
             current_key = candidate_key
-        current_group.append((node, parent, index, dst, src))
-        seen_indices.add(index)
+        current_group.append((node, parent, dst, src))
 
     flush()
 
     for group in groups:
-        sorted_group = sorted(group, key=lambda entry: entry[2])
-        first_copy = sorted_group[0][0]
-        dsts = [dst for _, _, _, dst, _ in sorted_group]
-        srcs = [src for _, _, _, _, src in sorted_group]
+        first_copy = group[0][0]
+        dsts = [dst for _, _, dst, _ in group]
+        srcs = [src for _, _, _, src in group]
 
         with fx_g.inserting_before(first_copy):
             foreach_copy = fx_g.call_function(
@@ -656,10 +663,22 @@ def fold_foreach_input_mutation_ops(fx_g: torch.fx.Graph) -> None:
             )
 
         foreach_copy.meta.update(first_copy.meta)
-        foreach_copy.meta["val"] = None
-        foreach_copy.meta.pop("tensor_meta", None)
+        foreach_copy.meta["val"] = first_copy.meta.get("val")
 
-        for copy_node, *_ in sorted_group:
+        insert_after = foreach_copy
+        for group_index, (copy_node, _, _, _) in enumerate(group):
+            if not copy_node.users:
+                continue
+
+            with fx_g.inserting_after(insert_after):
+                replacement = fx_g.call_function(
+                    operator.getitem, args=(foreach_copy, group_index)
+                )
+            replacement.meta.update(copy_node.meta)
+            copy_node.replace_all_uses_with(replacement)
+            insert_after = replacement
+
+        for copy_node, *_ in group:
             fx_g.erase_node(copy_node)
 
 

--- a/torch/_functorch/_aot_autograd/functional_utils.py
+++ b/torch/_functorch/_aot_autograd/functional_utils.py
@@ -636,7 +636,9 @@ def fold_foreach_input_mutation_ops(fx_g: torch.fx.Graph) -> None:
     for node in fx_g.nodes:
         candidate = _get_foreach_copy_candidate(node)
         if candidate is None:
-            if current_key is not None and _is_getitem_from_parent(node, current_key[0]):
+            if current_key is not None and _is_getitem_from_parent(
+                node, current_key[0]
+            ):
                 continue
             flush()
             continue
@@ -666,13 +668,13 @@ def fold_foreach_input_mutation_ops(fx_g: torch.fx.Graph) -> None:
         foreach_copy.meta["val"] = first_copy.meta.get("val")
 
         insert_after = foreach_copy
-        for group_index, (copy_node, _, _, _) in enumerate(group):
+        for copy_node, _, dst, _ in group:
             if not copy_node.users:
                 continue
 
             with fx_g.inserting_after(insert_after):
                 replacement = fx_g.call_function(
-                    operator.getitem, args=(foreach_copy, group_index)
+                    torch.ops.aten.alias.default, args=(dst,)
                 )
             replacement.meta.update(copy_node.meta)
             copy_node.replace_all_uses_with(replacement)

--- a/torch/_functorch/_aot_autograd/functional_utils.py
+++ b/torch/_functorch/_aot_autograd/functional_utils.py
@@ -9,6 +9,7 @@ This file contains utilities related to functionalization in AOTAutograd:
 from __future__ import annotations
 
 from dataclasses import dataclass
+import operator
 from typing import Any, TypeGuard
 
 import torch
@@ -556,10 +557,117 @@ def was_tensor_metadata_updated(arg: Any, new_arg: Any) -> bool:
         ) == StorageWeakRef(new_arg.untyped_storage())
 
 
+def _get_input_mutation_nodes(arg: Any) -> list[torch.fx.Node]:
+    if isinstance(arg, torch.fx.Node):
+        return [arg]
+    if isinstance(arg, (list, tuple)):
+        return [node for node in arg if isinstance(node, torch.fx.Node)]
+    return []
+
+
+def _get_input_mutation_sources(node: torch.fx.Node) -> list[torch.fx.Node]:
+    if node.target is torch.ops.aten.copy_.default:
+        return _get_input_mutation_nodes(node.args[1])
+    if node.target is torch.ops.aten._foreach_copy_.default:
+        return _get_input_mutation_nodes(node.args[1])
+    return []
+
+
+def _is_foreach_op(node: torch.fx.Node) -> bool:
+    return (
+        node.op == "call_function"
+        and isinstance(node.target, torch._ops.OpOverload)
+        and node.target.name().startswith("aten::_foreach_")
+    )
+
+
+def _get_foreach_copy_candidate(
+    node: torch.fx.Node,
+) -> tuple[torch.fx.Node, int, torch.fx.Node, torch.fx.Node] | None:
+    if (
+        node.op != "call_function"
+        or node.target is not torch.ops.aten.copy_.default
+        or node.kwargs
+        or len(node.args) != 2
+        or node.users
+    ):
+        return None
+
+    dst, src = node.args
+    if not (isinstance(dst, torch.fx.Node) and isinstance(src, torch.fx.Node)):
+        return None
+    if src.op != "call_function" or src.target is not operator.getitem:
+        return None
+
+    parent, index = src.args
+    if not (isinstance(parent, torch.fx.Node) and isinstance(index, int)):
+        return None
+    if not _is_foreach_op(parent):
+        return None
+
+    return parent, index, dst, src
+
+
+def fold_foreach_input_mutation_ops(fx_g: torch.fx.Graph) -> None:
+    groups: list[
+        list[tuple[torch.fx.Node, torch.fx.Node, int, torch.fx.Node, torch.fx.Node]]
+    ] = []
+    current_group: list[
+        tuple[torch.fx.Node, torch.fx.Node, int, torch.fx.Node, torch.fx.Node]
+    ] = []
+    current_key: tuple[torch.fx.Node, str | None] | None = None
+    seen_indices: set[int] = set()
+
+    def flush() -> None:
+        nonlocal current_key
+        if len(current_group) > 1:
+            groups.append(current_group.copy())
+        current_group.clear()
+        current_key = None
+        seen_indices.clear()
+
+    for node in fx_g.nodes:
+        candidate = _get_foreach_copy_candidate(node)
+        if candidate is None:
+            flush()
+            continue
+
+        parent, index, dst, src = candidate
+        candidate_key = (parent, node.meta.get("partitioner_tag"))
+        if current_group and (candidate_key != current_key or index in seen_indices):
+            flush()
+
+        if current_key is None:
+            current_key = candidate_key
+        current_group.append((node, parent, index, dst, src))
+        seen_indices.add(index)
+
+    flush()
+
+    for group in groups:
+        sorted_group = sorted(group, key=lambda entry: entry[2])
+        first_copy = sorted_group[0][0]
+        dsts = [dst for _, _, _, dst, _ in sorted_group]
+        srcs = [src for _, _, _, _, src in sorted_group]
+
+        with fx_g.inserting_before(first_copy):
+            foreach_copy = fx_g.call_function(
+                torch.ops.aten._foreach_copy_.default, args=(dsts, srcs)
+            )
+
+        foreach_copy.meta.update(first_copy.meta)
+        foreach_copy.meta["val"] = None
+        foreach_copy.meta.pop("tensor_meta", None)
+
+        for copy_node, *_ in sorted_group:
+            fx_g.erase_node(copy_node)
+
+
 # Returns the number of detected copy_
 def _is_functional_graph(fx_g: torch.fx.Graph) -> tuple[str | None, int]:
     allowed_mutation_ops = [
         torch.ops.aten.copy_.default,
+        torch.ops.aten._foreach_copy_.default,
         torch.ops.aten.set_.source_Tensor,
     ]
     if hasattr(torch.ops.fsdp, "copy_"):
@@ -579,10 +687,13 @@ def _is_functional_graph(fx_g: torch.fx.Graph) -> tuple[str | None, int]:
                 # Can only copy_/set_ into an input
                 # this is mostly a hack to avoid failing XLA tests.
                 # See https://github.com/pytorch/pytorch/pull/122434#issuecomment-2101012113
-                if "set_buffer_donor_" not in str(n.args[0]):
-                    if n.args[0] not in placeholders:
+                mutated_inputs = _get_input_mutation_nodes(n.args[0])
+                for mutated_input in mutated_inputs:
+                    if "set_buffer_donor_" in str(mutated_input):
+                        continue
+                    if mutated_input not in placeholders:
                         error = f"n={str(n)}, n.args[0]={str(n.args[0])}, placeholders={str(placeholders)}, graph={str(fx_g)}"
-                mutation_count += 1
+                mutation_count += len(mutated_inputs)
             else:
                 if n.target._schema.is_mutable:
                     error = f"aot_autograd expected to have an entirely functional graph, but found {n.format_node()}"
@@ -602,20 +713,26 @@ def propagate_input_mutation_stacktraces(fx_g: torch.fx.Graph) -> None:
         if n.op == "placeholder":
             placeholders.add(n)
         if isinstance(n.target, torch._ops.OpOverload):
-            if n.target is torch.ops.aten.copy_.default:
+            if n.target in (
+                torch.ops.aten.copy_.default,
+                torch.ops.aten._foreach_copy_.default,
+            ):
                 # Can only copy_ into an input, and can only do so once
-                if "set_buffer_donor_" not in str(n.args[0]):
-                    if n.args[0] not in placeholders:
+                for mutated_input in _get_input_mutation_nodes(n.args[0]):
+                    if "set_buffer_donor_" in str(mutated_input):
+                        continue
+                    if mutated_input not in placeholders:
                         raise AssertionError(
                             f"n={str(n)}, n.args[0]={str(n.args[0])}, placeholders={str(placeholders)}, graph={str(fx_g)}"
                         )
-                    placeholders.remove(n.args[0])
-                copy_from_node = n.args[1]
+                    placeholders.remove(mutated_input)
                 # Pre-condition: every node has a "stack_trace" field in its meta,
                 # but copy_() nodes do not (since we manually added them during functionalization).
                 # Instead, we manually propagate here.
-                if "stack_trace" in copy_from_node.meta:
-                    n.meta["stack_trace"] = copy_from_node.meta["stack_trace"]
+                for copy_from_node in _get_input_mutation_sources(n):
+                    if "stack_trace" in copy_from_node.meta:
+                        n.meta["stack_trace"] = copy_from_node.meta["stack_trace"]
+                        break
 
 
 def _check_if_mutation_can_be_in_graph(

--- a/torch/_functorch/_aot_autograd/graph_capture.py
+++ b/torch/_functorch/_aot_autograd/graph_capture.py
@@ -22,6 +22,7 @@ from .. import config
 from .descriptors import AOTInput, BackwardTokenAOTInput
 from .functional_utils import (
     assert_functional_graph,
+    fold_foreach_input_mutation_ops,
     propagate_input_mutation_stacktraces,
 )
 from .graph_capture_wrappers import (
@@ -299,6 +300,7 @@ def aot_dispatch_base_graph(
         updated_flat_args_subclasses_desugared_descs,
         aot_config=aot_config,
     )
+    fold_foreach_input_mutation_ops(fw_module.graph)
 
     if aot_config.is_export and mod_when_exporting_non_strict is not None:
         # We update metadata to consider any assigned buffers as buffer mutations.
@@ -519,6 +521,7 @@ def aot_dispatch_autograd_graph(
         updated_joint_inputs_descs,
         aot_config=aot_config,
     )
+    fold_foreach_input_mutation_ops(fx_g.graph)
 
     # Redundant with the check above, but worth having in case tracing introduced
     # a fake tensor. Unlikely.

--- a/torch/_functorch/_aot_autograd/streams.py
+++ b/torch/_functorch/_aot_autograd/streams.py
@@ -307,6 +307,19 @@ def assign_epilogue_copy_streams(gm: torch.fx.GraphModule) -> None:
         copy_stream = get_stream(epi_copy)
         if arg_stream != copy_stream:
             set_stream(epi_copy, get_stream_or_current_stream(epi_copy.args[1]))
+    for foreach_copy in gm.graph.find_nodes(
+        op="call_function", target=aten._foreach_copy_.default
+    ):
+        srcs = foreach_copy.args[1]
+        if not isinstance(srcs, (list, tuple)) or len(srcs) == 0:
+            continue
+        first_src = srcs[0]
+        if not isinstance(first_src, torch.fx.Node):
+            continue
+        arg_stream = get_stream(first_src)
+        copy_stream = get_stream(foreach_copy)
+        if arg_stream != copy_stream:
+            set_stream(foreach_copy, get_stream_or_current_stream(first_src))
 
 
 def populate_fw_metadata_with_stream_indices(

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -1548,9 +1548,12 @@ def reordering_to_mimic_autograd_engine(gm: fx.GraphModule) -> fx.GraphModule:
         return gm
 
     # Build the graph op-by-op by starting from the node all the way to the end
-    # copy_ can be not using tangents at all, we must copy it.
+    # copy_/foreach_copy_ can be not using tangents at all, we must copy them.
     for node in list(gm.graph.nodes)[: order[first_node_in_bwd]]:
-        if node.op == "call_function" and node.target is torch.ops.aten.copy_.default:
+        if node.op == "call_function" and node.target in (
+            torch.ops.aten.copy_.default,
+            torch.ops.aten._foreach_copy_.default,
+        ):
             insert_node_in_graph(node)
 
     for node in list(gm.graph.nodes)[order[first_node_in_bwd] :]:
@@ -1928,6 +1931,32 @@ def force_save_effectful_ops(joint_module: fx.GraphModule) -> None:
             mark_getitem_outputs(node)
 
 
+def _get_mutation_pairs(node: fx.Node) -> list[tuple[fx.Node, fx.Node]]:
+    if node.target is torch.ops.aten.copy_.default:
+        if (
+            len(node.args) >= 2
+            and isinstance(node.args[0], fx.Node)
+            and isinstance(node.args[1], fx.Node)
+        ):
+            return [(node.args[0], node.args[1])]
+        return []
+
+    if node.target is not torch.ops.aten._foreach_copy_.default or len(node.args) < 2:
+        return []
+
+    dsts, srcs = node.args[:2]
+    if not (isinstance(dsts, (list, tuple)) and isinstance(srcs, (list, tuple))):
+        return []
+    if len(dsts) != len(srcs):
+        return []
+
+    mutation_pairs = []
+    for dst, src in zip(dsts, srcs):
+        if isinstance(dst, fx.Node) and isinstance(src, fx.Node):
+            mutation_pairs.append((dst, src))
+    return mutation_pairs
+
+
 def force_save_bw_mutation_src(joint_module: fx.GraphModule) -> None:
     # If we have mutations of the same primal in forward and backward,
     # We must not recompute the source of mutation to not apply twice.
@@ -1936,16 +1965,19 @@ def force_save_bw_mutation_src(joint_module: fx.GraphModule) -> None:
         if node.op == "output":
             continue
 
-        is_copy_ = node.target is torch.ops.aten.copy_.default
-        if is_copy_:
+        mutation_pairs = _get_mutation_pairs(node)
+        if mutation_pairs:
             if _has_tag_must_be_in_backward(node):
-                has_mutation_in_bw.add(node.args[0])
+                for dst, _ in mutation_pairs:
+                    has_mutation_in_bw.add(dst)
 
-            if _has_tag_must_be_in_forward(node) and node.args[0] in has_mutation_in_bw:
-                node.args[1].meta["recompute"] = CheckpointPolicy.MUST_SAVE
+            if _has_tag_must_be_in_forward(node):
+                for dst, src in mutation_pairs:
+                    if dst in has_mutation_in_bw:
+                        src.meta["recompute"] = CheckpointPolicy.MUST_SAVE
         else:
             # We use invariant of aotdispatch joint graph,
-            # That we emit copy_ only in the end of it.
+            # That we emit copy_/foreach_copy_ only in the end of it.
             # We do not want to iterate through all the joint graph,
             # so break at the first non-output, non-copy_ node.
             break


### PR DESCRIPTION
## Summary
Fix #119191

1. What is the root cause problem
AOTAutograd keeps foreach input mutations functional by emitting one `aten.copy_` per mutated tensor, even when every copy comes from the same foreach result list.

2. What is the proposed fix
Fold consecutive foreach-derived epilogue `copy_` nodes into a single `aten._foreach_copy_` node after tracing, and update the AOT mutation validation, stream assignment, partitioner handling, and regression coverage to understand that grouped mutation node.

3. Why is the proposed fix the right long term fix
This preserves the existing functionalization semantics while shrinking the FX graph in the foreach case, and it keeps the optimization in AOTAutograd where the mutation epilogue is created instead of pushing the cleanup work onto downstream backends.

## Validation
- `python3 -m py_compile torch/_functorch/_aot_autograd/functional_utils.py torch/_functorch/_aot_autograd/graph_capture.py torch/_functorch/_aot_autograd/streams.py torch/_functorch/partitioners.py test/dynamo/test_repros.py`

Drafted via @codex, published after manual review by @bobrenjc93

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo