### PR TITLE
[AOTAutograd] preserve dropout aliasing in inference

### DIFF
--- a/test/dynamo/test_aot_autograd.py
+++ b/test/dynamo/test_aot_autograd.py
@@ -91,6 +91,20 @@ class AotAutogradFallbackTests(torch._inductor.test_case.TestCase):
         # This should not error: we mutated an autograd leaf under no_grad mode.
         aot_fn(x, y)
 
+    def test_dropout_inference_aliasing_matches_eager(self):
+        def dropout_training_false(x):
+            return torch.nn.functional.dropout(x, p=0.5, training=False)
+
+        def dropout_zero_probability(x):
+            return torch.nn.functional.dropout(x, p=0.0, training=True)
+
+        for fn in (dropout_training_false, dropout_zero_probability):
+            x = torch.randn(5)
+            self.assertIs(fn(x), x)
+
+            compiled_fn = torch.compile(fn, backend="aot_eager", fullgraph=True)
+            self.assertIs(compiled_fn(x), x)
+
     def test_mutation1(self):
         def fn(_stack0: torch.Tensor, diagonal_chunked_attention_scores: torch.Tensor):
             getitem = diagonal_chunked_attention_scores[

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -4804,8 +4804,7 @@ class TestAOTExport(AOTTestCase):
             str(gm.code).strip(),
             """\
 def forward(self, arg0_1, arg1_1):
-    clone = torch.ops.aten.clone.default(arg1_1);  arg1_1 = None
-    add = torch.ops.aten.add.Tensor(clone, 1);  clone = None
+    add = torch.ops.aten.add.Tensor(arg1_1, 1);  arg1_1 = None
     return (add,)""",
         )
 

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -4811,25 +4811,20 @@ def forward(self, arg0_1, arg1_1):
 
         fw_graph_cell = [None]
         bw_graph_cell = [None]
+        p, x = inp
 
-        aot_function(
+        compiled_outs = aot_function(
             fn,
             fw_compiler=partial(extract_graph, graph_cell=fw_graph_cell),
             bw_compiler=partial(extract_graph, graph_cell=bw_graph_cell),
             partition_fn=default_partition,
             decompositions=default_decompositions,
             dynamic=True,
-        )(*inp)
+        )(p, x)
         fw_graph = fw_graph_cell[0]
 
-        self.assertExpectedInline(
-            str(fw_graph.code).strip(),
-            """\
-def forward(self, arg0_1, arg1_1):
-    clone = torch.ops.aten.clone.default(arg1_1);  arg1_1 = None
-    add = torch.ops.aten.add.Tensor(clone, 1);  clone = None
-    return (add,)""",
-        )
+        self.assertIs(compiled_outs[0], x)
+        self.assertNotIn("torch.ops.aten.clone.default", str(fw_graph.code))
 
     def test_aot_export_predispatch_func_simple(self):
         def fn(p, x):

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -1182,7 +1182,7 @@ def dropout(input: Tensor, p: float, train: bool | None):
     if train and p != 0:
         return aten.native_dropout(input, p, train)[0]
     else:
-        return input.clone()
+        return input
 
 
 @register_decomposition(aten.native_dropout)

--- a/torch/_inductor/fx_passes/fuse_attention.py
+++ b/torch/_inductor/fx_passes/fuse_attention.py
@@ -1319,7 +1319,7 @@ def _get_sfdp_patterns(input_device: torch.device | None = None):
                     "pass_dicts": patterns,
                     "extra_check": extra_check,
                     "scalar_workaround": inference_workaround,
-                    # with dropout turned into clone, we end up with a number of
+                    # with dropout becoming a no-op in inference, we end up with a number of
                     # semantically identical graphs
                     "skip_duplicates": True,
                 },


### PR DESCRIPTION
Fix #115249

## Summary

### Root cause
`aten.dropout` is decomposed to `clone()` whenever `train=False` or `p==0`, so AOTAutograd loses eager aliasing semantics in inference and returns a different tensor object.

### Proposed fix
- return the original tensor from the non-training / zero-probability `aten.dropout` decomposition
- keep the existing Inductor duplicate-pattern handling for inference and update the nearby comment to match the current behavior
- add regressions for both `torch.compile(..., backend="aot_eager")` and the lower-level `aot_function` path

### Why this is the right long term fix
`aten.dropout` is already treated as a maybe-aliasing op, so non-export compilation should preserve eager aliasing semantics instead of forcing a clone. Export continues to use its separate dropout handling and mutation guards.

Drafted via @codex, published after manual review by @bobrenjc93

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Lucaskabela