### PR TITLE
[aot_autograd] Limit TracingContext fw metadata exposure

### DIFF
--- a/test/dynamo/test_backends.py
+++ b/test/dynamo/test_backends.py
@@ -400,6 +400,16 @@ class TestCustomBackendAPI(torch._dynamo.test_case.TestCase):
                 self.assertTrue(fw_metadata is not None)
                 self.assertTrue(params_flat is not None)
                 self.assertTrue(len(params_flat) == 2)
+                self.assertIsInstance(
+                    fw_metadata, torch._guards.TracingContextFwMetadata
+                )
+                self.assertFalse(hasattr(fw_metadata, "input_info"))
+                self.assertFalse(hasattr(fw_metadata, "output_info"))
+                self.assertEqual(fw_metadata.mutated_input_indices, [])
+                self.assertEqual(fw_metadata.output_base_indices, [])
+                self.assertEqual(fw_metadata.static_input_indices, [0, 1])
+                self.assertEqual(fw_metadata.num_mutated_inp_runtime_indices, 0)
+                self.assertIsNone(fw_metadata.bw_donated_idxs)
             backend_run = True
             return make_boxed_func(gm.forward)
 

--- a/test/dynamo/test_backends.py
+++ b/test/dynamo/test_backends.py
@@ -409,7 +409,7 @@ class TestCustomBackendAPI(torch._dynamo.test_case.TestCase):
                 self.assertEqual(fw_metadata.output_base_indices, [])
                 self.assertEqual(fw_metadata.static_input_indices, [0, 1])
                 self.assertEqual(fw_metadata.num_mutated_inp_runtime_indices, 0)
-                self.assertIsNone(fw_metadata.bw_donated_idxs)
+                self.assertEqual(fw_metadata.bw_donated_idxs, [1])
             backend_run = True
             return make_boxed_func(gm.forward)
 

--- a/torch/_dynamo/backends/distributed.py
+++ b/torch/_dynamo/backends/distributed.py
@@ -20,7 +20,7 @@ import logging
 import traceback
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Any, TYPE_CHECKING
+from typing import Any
 from unittest import mock
 
 import torch
@@ -30,10 +30,6 @@ from torch._dynamo.output_graph import GraphCompileReason
 from torch._dynamo.utils import deepcopy_to_fake_tensor, detect_fake_mode
 from torch._logging import trace_structured
 from torch.fx.node import Node
-
-
-if TYPE_CHECKING:
-    from torch._functorch._aot_autograd.schemas import ViewAndMutationMeta
 
 
 # Regular log messages should go through 'log'.
@@ -174,7 +170,7 @@ def propagate_dynamo_source(orig_gm: fx.GraphModule, split_gm: fx.GraphModule) -
 class DDPOptimizerContext:
     def __init__(self) -> None:
         self.curr_bucket: int = -1
-        self.metadata_per_bucket: list[ViewAndMutationMeta] = []
+        self.metadata_per_bucket: list[torch._guards.TracingContextFwMetadata] = []
 
 
 # compile each of the partitioned submodules using the user-provided compiler

--- a/torch/_functorch/_aot_autograd/graph_compile.py
+++ b/torch/_functorch/_aot_autograd/graph_compile.py
@@ -40,7 +40,7 @@ from torch._dynamo.utils import (
     dynamo_timed,
     lazy_format_graph_code,
 )
-from torch._guards import CompileContext, TracingContext
+from torch._guards import CompileContext, TracingContext, TracingContextFwMetadata
 from torch._logging import getArtifactLogger, trace_structured
 from torch._subclasses import FakeTensor
 from torch._subclasses.meta_utils import is_sparse_any
@@ -328,6 +328,30 @@ def _get_inner_meta(
     """
     return (
         fw_metadata if maybe_subclass_meta is None else maybe_subclass_meta.fw_metadata
+    )
+
+
+def _get_tracing_context_fw_metadata(
+    fw_metadata: ViewAndMutationMeta,
+) -> TracingContextFwMetadata:
+    return TracingContextFwMetadata(
+        mutated_input_indices=[
+            i
+            for i, input_info in enumerate(fw_metadata.input_info)
+            if input_info.mutation_type is not MutationType.NOT_MUTATED
+        ],
+        output_base_indices=[
+            output_info.base_idx
+            for output_info in fw_metadata.output_info
+            if output_info.base_idx is not None
+        ],
+        static_input_indices=list(fw_metadata.static_input_indices),
+        num_mutated_inp_runtime_indices=fw_metadata.num_mutated_inp_runtime_indices,
+        bw_donated_idxs=(
+            list(fw_metadata.bw_donated_idxs)
+            if fw_metadata.bw_donated_idxs is not None
+            else None
+        ),
     )
 
 
@@ -2506,8 +2530,8 @@ def _aot_stage2b_compile_forward_or_inference(
 
         # Set tracing context
         if tracing_context := torch._guards.TracingContext.try_get():
-            tracing_context.fw_metadata = _get_inner_meta(
-                maybe_subclass_meta, fw_metadata
+            tracing_context.fw_metadata = _get_tracing_context_fw_metadata(
+                _get_inner_meta(maybe_subclass_meta, fw_metadata)
             )
 
         with TracingContext.report_output_strides() as fwd_output_strides:

--- a/torch/_guards.py
+++ b/torch/_guards.py
@@ -36,7 +36,6 @@ if TYPE_CHECKING:
 
     from torch._dynamo.backends.distributed import DDPOptimizerContext
     from torch._dynamo.codegen import PyCodegen
-    from torch._functorch._aot_autograd.schemas import ViewAndMutationMeta
     from torch._subclasses.fake_tensor import FakeTensorMode
 
 
@@ -917,6 +916,22 @@ class InlinedCodeCache:
     code_options: dict[str, Any]
 
 
+@dataclass(eq=False)
+class TracingContextFwMetadata:
+    """
+    Backend-facing subset of AOTAutograd's forward metadata.
+
+    This intentionally contains only the fields that backends currently
+    consume through TracingContext.
+    """
+
+    mutated_input_indices: list[int]
+    output_base_indices: list[int]
+    static_input_indices: list[int]
+    num_mutated_inp_runtime_indices: int
+    bw_donated_idxs: list[int] | None = None
+
+
 class TracingContext:
     """
     Provides the currently installed TracingContext, or None.
@@ -955,7 +970,7 @@ class TracingContext:
         # progress)
         self.loc_in_frame: tuple[str, int, str] | None = None
         # this is only set after aot_autograd
-        self.fw_metadata: ViewAndMutationMeta | None = None
+        self.fw_metadata: TracingContextFwMetadata | None = None
         # this is only set when the DDPOptimizer is used
         self.ddp_optimizer_ctx: DDPOptimizerContext | None = None
         # this is only set after aot_autograd

--- a/torch/_inductor/freezing.py
+++ b/torch/_inductor/freezing.py
@@ -9,7 +9,6 @@ from typing import Any
 import torch
 import torch.utils._pytree as pytree
 from torch._dynamo.utils import dynamo_timed, lazy_format_graph_code
-from torch._functorch.aot_autograd import MutationType
 from torch._functorch.compile_utils import fx_graph_cse
 from torch._inductor.constant_folding import constant_fold, replace_node_with_constant
 from torch._inductor.freezing_utils import enter_freezing, record_has_frozen_params
@@ -28,7 +27,7 @@ log = logging.getLogger(__name__)
 def replace_params_with_constants(
     gm: torch.fx.GraphModule,
     flat_params: list[Any],
-    fw_metadata: torch._functorch.aot_autograd.ViewAndMutationMeta,
+    fw_metadata: torch._guards.TracingContextFwMetadata,
 ) -> list[int]:
     """
     Replaces the parameters of a PyTorch GraphModule with constants wherever possible.
@@ -37,20 +36,8 @@ def replace_params_with_constants(
     params = gm.graph.find_nodes(op="placeholder")
     fake_inp_nodes = params[: len(params)]
     preserved_arg_indices = []
-    aliased_input_args = [
-        out_info.base_idx
-        for out_info in fw_metadata.output_info
-        if out_info.base_idx is not None
-    ]
-
-    # TODO (tmanlaibaatar) figure out why this is different
-    # from mutated_inp_runtime_indices
-    mutated_inps = [
-        i
-        for i, m in enumerate(fw_metadata.input_info)
-        if m.mutation_type
-        in (MutationType.MUTATED_IN_GRAPH, MutationType.MUTATED_OUT_GRAPH)
-    ]
+    aliased_input_args = fw_metadata.output_base_indices
+    mutated_inps = fw_metadata.mutated_input_indices
 
     static_indices_new = []
     static_indices_offset = 0


### PR DESCRIPTION
Fix #114403

## Summary

1) What is the root cause problem
`TracingContext` exposed the full `ViewAndMutationMeta` object to backends even though Inductor only consumes a small subset of that state. That widened the backend-facing surface area and tied backend compatibility to internal AOTAutograd metadata details.

2) What is the proposed fix
Introduce a reduced `TracingContextFwMetadata` object on `TracingContext`, populate it from the finalized AOTAutograd metadata, and update Inductor/DDP handoff sites to use the reduced fields. Add a backend regression test that asserts the exposed object is the reduced subset rather than the full `ViewAndMutationMeta`.

3) Why the proposed fix is the right long term fix
This keeps the `TracingContext` contract aligned with the metadata that backends actually consume, so AOTAutograd can keep evolving `ViewAndMutationMeta` internally without unnecessarily expanding the backend-facing API surface.

Drafted via @codex, published after manual review by @bobrenjc93

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Lucaskabela