### PR TITLE
[ROCm] Use therock-7.11 rocprofiler-sdk instead of cherry-picking fix

### DIFF
--- a/.ci/docker/common/install_rocm.sh
+++ b/.ci/docker/common/install_rocm.sh
@@ -160,11 +160,7 @@ EOF
         pushd rocm-systems/
         git sparse-checkout init --cone
         git sparse-checkout set projects/rocprofiler-sdk shared/rocprofiler-compute
-        git checkout develop
-        git checkout rocm-7.2.0
-        git config --global user.email "you@example.com"
-        git config --global user.name "Your Name"
-        git cherry-pick a71cc3cc88ed68b24c40cefec77d764053044862
+        git checkout therock-7.11
         sudo apt install -y cmake libdw-dev libsqlite3-dev
         cmake                                         \
               -B rocprofiler-sdk-build                \


### PR DESCRIPTION
## Summary

- Bumps the `rocprofiler-sdk` checkout from `rocm-7.2.0` to `therock-7.11` in the ROCm 7.2 CI build
- `therock-7.11` already includes the fix that was previously being cherry-picked (`a71cc3cc`), so the cherry-pick is removed

## Changes

- `.ci/docker/common/install_rocm.sh`: replace `git checkout develop` + `git checkout rocm-7.2.0` + cherry-pick with `git checkout therock-7.11`

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang