### PR TITLE
[sigrid] Fix double-exception → std::terminate in TGIF GPU executor on sticky CUDA error

### DIFF
--- a/aten/src/ATen/cuda/CachingHostAllocator.cpp
+++ b/aten/src/ATen/cuda/CachingHostAllocator.cpp
@@ -3,6 +3,7 @@
 #include <ATen/cuda/CUDAEvent.h>
 #include <c10/core/thread_pool.h>
 #include <c10/cuda/CUDAAllocatorConfig.h>
+#include <c10/cuda/CUDAMiscFunctions.h>
 
 #include <cuda_runtime_api.h>
 #include <future>
@@ -117,7 +118,22 @@ struct CUDACachingHostAllocatorImpl
       std::optional<std::vector<CUDAEventPool::Event>>& events,
       CUDAStream stream) override {
     auto event = create_event_internal(stream.device_index());
-    event->record(stream);
+    try {
+      event->record(stream);
+    } catch (const c10::Error& e) {
+      // record_stream is called from tensor destructors. In a sticky CUDA error
+      // state (e.g., device-side assert, illegal memory access), event->record()
+      // also fails with the sticky error. Letting this exception escape a
+      // destructor causes std::terminate via the implicit noexcept on ~IValue()
+      // and ~StorageImpl().
+      //
+      // Suppress sticky GPU errors; re-throw non-sticky ones (e.g., invalid
+      // argument).
+      if (c10::cuda::isStickyGpuError(e.what())) {
+        return;
+      }
+      throw;
+    }
     events->push_back(std::move(event));
   }
 

--- a/c10/cuda/CUDAMiscFunctions.cpp
+++ b/c10/cuda/CUDAMiscFunctions.cpp
@@ -1,6 +1,7 @@
 #include <c10/cuda/CUDAMiscFunctions.h>
 #include <c10/util/env.h>
 #include <string>
+#include <string_view>
 
 namespace c10::cuda {
 
@@ -45,6 +46,15 @@ const char* get_cuda_check_suffix() noexcept {
 std::mutex* getFreeMutex() {
   static std::mutex cuda_free_mutex;
   return &cuda_free_mutex;
+}
+
+// NOLINTNEXTLINE(bugprone-exception-escape,-warnings-as-errors)
+bool isStickyGpuError(std::string_view msg) noexcept {
+  auto contains = [&](std::string_view sub) {
+    return msg.find(sub) != std::string_view::npos;
+  };
+  return (contains("CUDA error") || contains("HIP error:")) &&
+      !contains("invalid argument");
 }
 
 } // namespace c10::cuda

--- a/c10/cuda/CUDAMiscFunctions.h
+++ b/c10/cuda/CUDAMiscFunctions.h
@@ -7,9 +7,14 @@
 
 #include <mutex>
 #include <string>
+#include <string_view>
 
 namespace c10::cuda {
 C10_CUDA_API std::string get_cuda_error_help(cudaError_t /*error*/) noexcept;
 C10_CUDA_API const char* get_cuda_check_suffix() noexcept;
 C10_CUDA_API std::mutex* getFreeMutex();
+// Returns true if the error message indicates a sticky GPU error (one that
+// requires cudaDeviceReset to recover from). A "CUDA error" or "HIP error"
+// that is NOT an "invalid argument" error is considered sticky.
+C10_CUDA_API bool isStickyGpuError(std::string_view msg) noexcept;
 } // namespace c10::cuda


### PR DESCRIPTION
Summary:
## Problem

When a sticky CUDA error occurs (e.g., device-side assert from OOB embedding
lookup) during merge net execution in the TGIF GPU serving path, the predictor
crashes immediately via `std::terminate` instead of propagating the error to
the caller.

The root cause is a **double-exception** pattern:

1. The primary `c10::AcceleratorError` (sticky CUDA error) is thrown during
   inference.
2. During stack unwinding, tensor destructors call
   `CUDACachingHostAllocatorImpl::record_stream()` → `CUDAEvent::record()`,
   which also throws (GPU is still in sticky state) — the **secondary**
   exception.
3. C++ calls `std::terminate` when a second exception is thrown during stack
   unwinding. The secondary cannot be caught by surrounding try/catch blocks
   because `IValue::~IValue()` and `StorageImpl::~StorageImpl()` are implicitly
   `noexcept(true)` — the secondary terminates inside the destructor before
   any surrounding catch can intercept it.

## Fix

In `CUDACachingHostAllocatorImpl::record_stream()`, wrap `event->record()` in a
try/catch. Suppress the exception only for sticky CUDA errors (message contains
`"CUDA error"` but not `"invalid argument"`) — using the same heuristic as
`BadRequestLoggerImpl::checkStickyGPUError()`. Non-sticky errors (e.g.,
invalid argument) are re-thrown normally.

## Result

After the fix:
- The primary CUDA error propagates cleanly to the thrift handler.
- `LoggingPredictorService` detects the sticky CUDA error and triggers a
  controlled `LOG(FATAL)` restart instead of `std::terminate`.
- `BadRequestLogger` logs the event to scuba `sigrid_predictor_bad_requests`.
- The server returns the error to the client before the graceful restart.

Test Plan:
Model 2133239133 snapshot 15, bad_request_cco_1.recordio (OOB embedding lookup that triggers a CUDA device-side assert).

**Before fix** (P2239011149):
- Server: crashes with `std::terminate` — secondary exception thrown from
  `CachingHostAllocator.cpp:120` inside `~StorageImpl()` during stack unwinding:
  ```
  E0316 09:50:38 ExceptionTracer.cpp:251] terminate() called, exception stack follows
  E0316 09:50:38 ExceptionTracer.cpp:253] Exception type: c10::AcceleratorError (27 frames)
      @ CUDACachingHostAllocatorImpl::record_stream(...)
                         ./fbcode/caffe2/aten/src/ATen/cuda/CachingHostAllocator.cpp:120
      @ at::CachingHostAllocatorImpl<...>::free(void*)
      @ c10::StorageImpl::~StorageImpl()
      ...
      @ caffe2::GPUPredictorExecutor::run(...)
      @ facebook::sigrid::predictor::PyTorchMRSGIFTask::runMergeMethod(int)
  terminate called after throwing an instance of 'c10::AcceleratorError'
    what():  CUDA error: device-side assert triggered
  *** Signal 6 (SIGABRT) received by PID ... ***
  ```
- Replayer: no error response (server process dead)

**After fix** (P2239435424):
- Server:
  ```
  E0316 13:28:25 service_tcc.h:152] Service handler threw an uncaught exception
      in method runModelMethod: c10::AcceleratorError: CUDA error: device-side assert triggered
  ...
  F0316 13:33:51 LoggingPredictorService.cpp:1286] Restarting task because
      LoggingPredictorService encountered CUDA error: CUDA error: device-side assert triggered
  ```
- Replayer: receives `c10::AcceleratorError` returned cleanly from the server:
  ```
  Service handler threw an uncaught exception in method runModelMethod:
      c10::AcceleratorError: CUDA error: device-side assert triggered
  ```
- `grep -c "terminate called" predictor.log` → **0**

**Graceful shutdown after 2-minute ErrorRatioMonitor window:**

Also validated that the `ErrorRatioMonitor` path in `LoggingPredictorService::logDeferError`
triggers a `LOG(FATAL)` graceful shutdown after the 2-minute window elapses
(`sticky_error_ratio_monitor_window_minutes=2`, threshold `stop_gpu_server_critical_cuda_error_ratio=0.8`):

1. Bad request sent at T=0 → CUDA error returned to client (no `terminate`), sticky GPU state set
2. Good request sent at T+28min (well past the 2-minute window) → triggers another CUDA error
   in the sticky GPU state; `ErrorRatioMonitor::reportErrorAndGetRatio()` returns ratio > 0.8:
   ```
   F0318 13:47:41 LoggingPredictorService.cpp:1295] Restarting task because
       LoggingPredictorService encountered CUDA error: CUDA error: device-side assert triggered
   ```
3. Server process confirmed dead after `LOG(FATAL)` (SIGABRT)

This confirms the full end-to-end flow: double-exception suppressed → CUDA error propagated
to client → server self-terminates via controlled `LOG(FATAL)` after the error ratio window.

Differential Revision: D96399936


