### PR TITLE
[inductor] Skip redundant input asserts in subgraphs

### DIFF
--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -4182,6 +4182,10 @@ class SubgraphPythonWrapperCodegen(PythonWrapperCodegen):
             outputs = V.graph.graph_outputs
         return outputs
 
+    def codegen_input_size_asserts(self) -> None:
+        # Parent graph already asserted on all inputs it passes to this subgraph.
+        pass
+
     def codegen_allocation(self, buffer: ir.Buffer):
         name = buffer.get_name()
         if (signature := self.partition_signatures) and name in signature.input_nodes:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #177790
* #177789
* #177546

Subgraph inputs are always tensors that the parent graph already
validated via deferred assert_size_stride calls. Override
codegen_input_size_asserts() in SubgraphPythonWrapperCodegen to
skip re-asserting on them.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo