### PR TITLE
[Inductor][FP8][AMD] Enable exhaustive autotuning on ROCm (#177797)

### DIFF
--- a/torch/_inductor/template_heuristics/triton.py
+++ b/torch/_inductor/template_heuristics/triton.py
@@ -2856,11 +2856,10 @@ class ROCmScaledMMTemplateConfigHeuristic(ScaledMMConfigMixin, ROCmConfigHeurist
         super().__init__()
         # Override mm_configs to use scaled_mm_configs
         self.mm_configs = self.scaled_mm_configs
-        # NOTE: overriding exhaustive configs here to be the same as mm_configs
-        # as we haven't validated exhaustive support here yet
-        # TODO(coconutruben): remove this once we have validated exhaustive support
-        # for scaled_mm
-        self.exhaustive_configs = self.scaled_mm_configs
+
+    def _filter_configs(self, configs: list[BaseConfig]) -> list[BaseConfig]:
+        configs = [c for c in configs if c.block_k >= 32]
+        return super()._filter_configs(configs)
 
 
 @register_template_heuristic(


### PR DESCRIPTION
Summary:

Enable exhaustive autotuning on ROCm for `scaled_mm`. ROCm requires `BLOCK_K >= 32`, since the FP8 dot product can't be lowered to any corresponding valid MFMA instruction that allows for `BLOCK_K = 16`.

Test Plan:
e.g.
```
TORCHINDUCTOR_MAX_AUTOTUNE_GEMM_SEARCH_SPACE=EXHAUSTIVE TORCHINDUCTOR_FORCE_DISABLE_CACHES=1 TRITON_PRINT_AUTOTUNING=1 ENABLE_PERSISTENT_TMA_MATMUL=1 TORCHINDUCTOR_MAX_AUTOTUNE_GEMM=1 buck2 run -m rocm70 mode/{opt,inplace,opt-amd-gpu} //pytorch/tritonbench:run -c fbcode.enable_gpu_sections=true -c fbcode.rocm_arch=mi350 -- --op fp8_gemm --only pt2_fp8_gemm --force --m 4096 --n 4096 --k 4096
```

Reviewed By: PaulZhang12

Differential Revision: D97211405




cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben