### PR TITLE
[DTensor] Fix test_comm_mode_with_dtensor for Dijkstra sharding propagation

### DIFF
--- a/test/distributed/tensor/debug/test_comm_mode.py
+++ b/test/distributed/tensor/debug/test_comm_mode.py
@@ -5,6 +5,7 @@ import torch.distributed as dist
 import torch.distributed._functional_collectives as funcol
 import torch.nn as nn
 from torch.distributed.tensor import DeviceMesh, DTensor, Shard
+from torch.distributed.tensor._redistribute import use_min_cost_redistribution_plan
 from torch.distributed.tensor.debug import CommDebugMode
 from torch.testing._internal.common_distributed import requires_accelerator_dist_backend
 from torch.testing._internal.common_utils import run_tests, TestCase
@@ -105,7 +106,7 @@ class TestCommMode(TestCase):
         x_dtensor = DTensor.from_local(x, mesh, [Shard(0)], run_check=False)
         y_dtensor = DTensor.from_local(y, mesh, [Shard(0)], run_check=False)
 
-        with comm_mode:
+        with comm_mode, use_min_cost_redistribution_plan():
             f(x_dtensor, y_dtensor)
 
         comm_counts = comm_mode.get_comm_counts()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #177799
* __->__ #177798

The Dijkstra search in sharding propagation finds a different (lower-cost)
strategy than the old full expansion path for mm(Shard(0), Shard(0)). Dijkstra
explores multi-hop redistribution paths (S(0)->R->S(1), cost ~9.3) that avoid
the +1.0 shard-to-shard penalty in the cost model, while the full expansion's
_gen_transform_infos decomposes S(0)->S(1) as a single step that hits the
penalty (cost ~10.3). This causes Dijkstra to select S(1)xS(0)->Partial(sum)
over S(0)xR->S(0), changing the comm op from all_gather to alltoall.

Use use_min_cost_redistribution_plan() in the test so the runtime redistribute
planner uses the same graph-based search as Dijkstra, ensuring the redistribute
path matches the cost model's assumptions.

Copy of https://github.com/pytorch/pytorch/pull/177669 which got corrupted ghstack state 

Authored with Claude.