### PR TITLE
[DTensor] Enable Dijkstra search in sharding propagation

### DIFF
--- a/test/distributed/tensor/test_single_dim_strategy.py
+++ b/test/distributed/tensor/test_single_dim_strategy.py
@@ -1843,6 +1843,46 @@ class TestDijkstraExpandSingleDimStrategy(TestCase):
             + "\n".join(wrong_strategy[:20]),
         )
 
+    def test_dijkstra_inplace_op(self):
+        """Verify Dijkstra respects inplace constraints: output == self placement."""
+        mesh = DeviceMesh("cpu", mesh=torch.arange(4))
+        meta = TensorMeta(shape=torch.Size([8, 8]), stride=(8, 1), dtype=torch.float32)
+        add_strategy_fn = _common_pointwise_single_dim_strategy(
+            _BINARY_ADDITIVE_RULES  # pyrefly: ignore[bad-argument-type]
+        )
+        add_strategy_info = _SingleDimStrategyInfo(
+            add_strategy_fn, allow_uneven_sharding=True, allow_unbacked_sharding=True
+        )
+
+        # add_(Replicate, Partial(avg)): out-of-place rule gives P(avg) output,
+        # but inplace requires output == self == Replicate. Dijkstra must reject
+        # the zero-cost P(avg) match and find (R, R) -> R with redistribution.
+        self_spec = DTensorSpec(mesh, (Replicate(),), tensor_meta=meta)
+        other_spec = DTensorSpec(mesh, (Partial("avg"),), tensor_meta=meta)
+        op_schema = OpSchema(
+            op=torch.ops.aten.add_.Tensor,
+            args_schema=(
+                OpStrategy([OpSpec(self_spec)]),
+                OpStrategy([OpSpec(other_spec)]),
+            ),
+            kwargs_schema={},
+        )
+
+        strategy = _dijkstra_expand_single_dim_strategy_to_mesh(
+            mesh, op_schema, add_strategy_info, output_tensor_meta=meta
+        )
+        self.assertIsNotNone(strategy)
+        spec = strategy.strategies[0]
+        # Output must be Replicate (matching self)
+        self.assertEqual(spec.output_spec.placements, (Replicate(),))
+        # Self input must stay Replicate (not redistributed)
+        self.assertEqual(spec.input_specs[0].placements, (Replicate(),))
+        # Other input must be redistributed to Replicate
+        self.assertEqual(spec.input_specs[1].placements, (Replicate(),))
+        # Redistribution cost should be non-zero (P(avg) -> R requires allreduce)
+        total_cost = sum(chain.from_iterable(spec.redistribute_cost))
+        self.assertGreater(total_cost, 0)
+
 
 @torch.library.custom_op("mylib::dummy_add", mutates_args=())
 def dummy_add(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:

--- a/torch/distributed/tensor/_ops/single_dim_strategy.py
+++ b/torch/distributed/tensor/_ops/single_dim_strategy.py
@@ -45,6 +45,12 @@ def _is_sharding(p: Placement) -> TypeIs[Shard | _StridedShard]:
     return isinstance(p, (Shard, _StridedShard))
 
 
+def _is_inplace_op(op: OpOverload) -> bool:
+    """Detect inplace ops by checking if the base op name ends with '_'."""
+    base_name = op.name().split("::")[1].split(".")[0]
+    return base_name.endswith("_")
+
+
 class _ShardingPlaceholder:
     """
     A placeholder for a sharding placement that has a specified tensor dim, but the other
@@ -452,17 +458,12 @@ def _expand_single_dim_strategy_to_mesh(
                 strategy_info, op_schema, output_tensor_meta
             )
 
-            # Detect inplace ops by checking if the base op name ends with '_'
-            op_name = op.name()
-            base_name = op_name.split("::")[1].split(".")[0]
-            is_inplace = base_name.endswith("_")
-
             return expand_to_full_mesh_op_strategy(
                 mesh,
                 op_schema,
                 cast(list[PlacementList], prepared_strategy.expanded_strategies),
                 output_tensor_meta=output_tensor_meta,
-                inplace_op=is_inplace,
+                inplace_op=_is_inplace_op(op),
                 input_index=prepared_strategy.num_outputs,
                 allow_unbacked_sharding=prepared_strategy.allow_unbacked_sharding,
                 allow_uneven_sharding=prepared_strategy.allow_uneven_sharding,
@@ -786,12 +787,26 @@ def _dijkstra_expand_single_dim_strategy_to_mesh(
         single_dim_strategy, op_schema, output_tensor_meta, num_inputs=num_inputs
     )
 
+    # Inplace ops: self cannot be redistributed and output must match
+    # self's placement (mirrors the check in _expand_single_dim_strategy_to_mesh).
+    is_inplace = _is_inplace_op(op_schema.op)
+
     initial_placements = tuple(spec.placements for spec in input_specs)
     first_result: OpStrategy | None = None
 
+    def _inplace_output_matches(result: OpStrategy) -> bool:
+        """For inplace ops, check that output placement == self's initial placement."""
+        if not is_inplace:
+            return True
+        spec = result.strategies[0]
+        output_specs = spec.output_specs
+        if isinstance(output_specs, DTensorSpec):
+            return output_specs.placements == initial_placements[0]
+        return True
+
     # Fast path: if initial placements already match a strategy, skip search
     fast_result = prepared_strategy.try_propagate(mesh, initial_placements, input_specs)
-    if fast_result is not None:
+    if fast_result is not None and _inplace_output_matches(fast_result):
         fast_result._pq_transitions = []  # type: ignore[attr-defined]
         if _collect_all_matches is not None:
             _collect_all_matches.add(initial_placements)
@@ -905,7 +920,7 @@ def _dijkstra_expand_single_dim_strategy_to_mesh(
         match_result = prepared_strategy.try_propagate(
             mesh, candidate.placements, input_specs
         )
-        if match_result is not None:
+        if match_result is not None and _inplace_output_matches(match_result):
             # Use pre-computed per-input costs from the PQ search instead of
             # recomputing via generate_redistribute_costs -> _gen_transform_infos.
             match_spec = match_result.strategies[0]
@@ -938,6 +953,9 @@ def _dijkstra_expand_single_dim_strategy_to_mesh(
         # Generate neighbor states
         for mesh_dim in range(mesh.ndim):
             for input_idx in range(len(candidate.placements)):
+                # Inplace ops: self (input 0) can't be redistributed
+                if is_inplace and input_idx == 0:
+                    continue
                 current_p = candidate.placements[input_idx][mesh_dim]
                 for neighbor_p in _get_neighbor_placements(
                     prepared_strategy.allowed_sharding_per_input[input_idx],

--- a/torch/distributed/tensor/_sharding_prop.py
+++ b/torch/distributed/tensor/_sharding_prop.py
@@ -28,6 +28,7 @@ from torch.distributed.tensor._op_schema import (
     TupleStrategy,
 )
 from torch.distributed.tensor._ops.single_dim_strategy import (
+    _dijkstra_expand_single_dim_strategy_to_mesh,
     _expand_single_dim_strategy_to_mesh,
     _SingleDimStrategyInfo,
 )
@@ -41,6 +42,10 @@ from torch.utils._pytree import tree_map
 
 
 aten = torch.ops.aten
+
+# Disables the Dijkstra-based mincost search optimization for single-dim
+# strategy propagation, falling back to full O(S^N) strategy expansion.
+FORCE_FULLY_EXPAND_SINGLE_DIM: bool = False
 
 log = logging.getLogger(__name__)
 
@@ -678,14 +683,39 @@ class ShardingPropagator:
                 mesh = try_find_mesh_from_args(op_schema.op, op_schema.args_schema)
                 if not isinstance(mesh, DeviceMesh):
                     raise AssertionError("Expected to find a valid mesh")
-                # expand to generate the full set of strategy combinations, each one
-                # with a redistribute cost, and then find the min strategy over those costs.
-                _expanded_strategy_fn = _expand_single_dim_strategy_to_mesh(
-                    mesh, strategy_schema, single_dim_strategy_info, out_tensor_meta
-                )
-                op_strategy = _expanded_strategy_fn(
-                    op_schema.op, strategy_schema.args_meta, strategy_schema.kwargs_meta
-                )
+                # Try PQ search first: fast path when inputs already match a
+                # strategy, otherwise Dijkstra over placement transitions.
+                # Computes redistribute costs directly via per-dim
+                # _compute_placement_transition_cost, avoiding the overhead of
+                # generate_redistribute_costs / _gen_transform_infos planning.
+                # Returns None for StridedShard/symbolic/TupleStrategy inputs.
+                # Note: we know the optimal sequence of operations needed to perform redistribution
+                # after the PQ search, and we could plumb this information through the OutputSharding
+                # so the subsequent redistribute() call can skip doing another graph-based transforminfo search,
+                # but this is not implemented now.
+                op_strategy = None
+                if not FORCE_FULLY_EXPAND_SINGLE_DIM:
+                    op_strategy = _dijkstra_expand_single_dim_strategy_to_mesh(
+                        mesh,
+                        strategy_schema,
+                        single_dim_strategy_info,
+                        out_tensor_meta,
+                    )
+                if op_strategy is None:
+                    # Fall back to full O(S^N) expansion
+                    # to generate the full set of strategy combinations, each one
+                    # with a redistribute cost, and then find the min strategy over those costs.
+                    _expanded_strategy_fn = _expand_single_dim_strategy_to_mesh(
+                        mesh,
+                        strategy_schema,
+                        single_dim_strategy_info,
+                        out_tensor_meta,
+                    )
+                    op_strategy = _expanded_strategy_fn(
+                        op_schema.op,
+                        strategy_schema.args_meta,
+                        strategy_schema.kwargs_meta,
+                    )
             else:
                 if op_strategy_func is None:
                     raise AssertionError


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #177799
* #177798

Wire _dijkstra_expand_single_dim_strategy_to_mesh into the sharding
propagation path. For ops with single-dim strategies, try the PQ search
first; fall back to full O(S^N) expansion when it returns None
(StridedShard, symbolic shapes, or TupleStrategy inputs).

Copy of https://github.com/pytorch/pytorch/pull/175999 which got ghstack corrupted

Authored with Claude.