### PR TITLE
[CI] Add ARC experiment support to runner determinator

### DIFF
--- a/.github/scripts/runner_determinator.py
+++ b/.github/scripts/runner_determinator.py
@@ -79,12 +79,17 @@ WORKFLOW_LABEL_LF_CANARY = "lf.c."  # use canary runners from the linux foundati
 GITHUB_OUTPUT = os.getenv("GITHUB_OUTPUT", "")
 GH_OUTPUT_KEY_AMI = "runner-ami"
 GH_OUTPUT_KEY_LABEL_TYPE = "label-type"
+GH_OUTPUT_KEY_USE_ARC = "use-arc"
 OPT_OUT_LABEL = "no-runner-experiments"
 
 SETTING_EXPERIMENTS = "experiments"
 
 LF_FLEET_EXPERIMENT = "lf"
+ARC_FLEET_EXPERIMENT = "arc"
 CANARY_FLEET_SUFFIX = ".c"
+
+ARC_LABEL_PREFIX = "mt-"
+ARC_CANARY_LABEL_PREFIX = "c-"
 
 
 class Experiment(NamedTuple):
@@ -99,6 +104,11 @@ class Experiment(NamedTuple):
     )
 
     # Add more fields as needed
+
+
+class RunnerPrefixResult(NamedTuple):
+    prefix: str
+    use_arc: bool = False
 
 
 class Settings(NamedTuple):
@@ -439,12 +449,13 @@ def get_runner_prefix(
     eligible_experiments: frozenset[str] = frozenset(),
     opt_out_experiments: frozenset[str] = frozenset(),
     is_canary: bool = False,
-) -> str:
+) -> RunnerPrefixResult:
     settings = parse_settings(rollout_state)
     user_optins = parse_users(rollout_state)
 
     fleet_prefix = ""
     prefixes = []
+    use_arc = False
     for experiment_name, experiment_settings in settings.experiments.items():
         if not experiment_settings.all_branches and is_exception_branch(branch):
             log.info(
@@ -510,7 +521,12 @@ def get_runner_prefix(
 
         if enabled:
             label = experiment_name
-            if experiment_name == LF_FLEET_EXPERIMENT:
+            if experiment_name == ARC_FLEET_EXPERIMENT:
+                use_arc = True
+                log.info(
+                    f"ARC experiment enabled. Using ARC runner prefix ({'canary' if is_canary else 'production'})."
+                )
+            elif experiment_name == LF_FLEET_EXPERIMENT:
                 # We give some special treatment to the "lf" experiment since determines the fleet we use
                 #  - If it's enabled, then we always list it's prefix first
                 #  - If we're in the canary branch, then we append ".c" to the lf prefix
@@ -519,6 +535,11 @@ def get_runner_prefix(
                 fleet_prefix = label
             else:
                 prefixes.append(label)
+
+    # ARC experiment takes precedence: return a fixed label prefix
+    if use_arc:
+        arc_prefix = ARC_CANARY_LABEL_PREFIX + ARC_LABEL_PREFIX if is_canary else ARC_LABEL_PREFIX
+        return RunnerPrefixResult(prefix=arc_prefix, use_arc=True)
 
     if len(prefixes) > 1:
         log.error(
@@ -530,7 +551,8 @@ def get_runner_prefix(
     if fleet_prefix:
         prefixes.insert(0, fleet_prefix)
 
-    return ".".join(prefixes) + "." if prefixes else ""
+    prefix = ".".join(prefixes) + "." if prefixes else ""
+    return RunnerPrefixResult(prefix=prefix)
 
 
 def get_rollout_state_from_issue(github_token: str, repo: str, issue_num: int) -> str:
@@ -619,7 +641,7 @@ def main() -> None:
 
         is_canary = args.github_repo == "pytorch/pytorch-canary"
 
-        runner_label_prefix = get_runner_prefix(
+        result = get_runner_prefix(
             rollout_state,
             (args.github_issue_owner, username),
             args.github_branch,
@@ -627,6 +649,8 @@ def main() -> None:
             args.opt_out_experiments,
             is_canary,
         )
+        runner_label_prefix = result.prefix
+        set_github_output(GH_OUTPUT_KEY_USE_ARC, str(result.use_arc).lower())
 
     except Exception as e:
         log.error(

--- a/.github/scripts/test_runner_determinator.py
+++ b/.github/scripts/test_runner_determinator.py
@@ -183,8 +183,8 @@ class TestRunnerDeterminatorGetRunnerPrefix(TestCase):
         @User2,lf,otherExp
 
         """
-        prefix = rd.get_runner_prefix(settings_text, ["User1"], USER_BRANCH)
-        self.assertEqual("lf.", prefix, "Runner prefix not correct for User1")
+        result = rd.get_runner_prefix(settings_text, ["User1"], USER_BRANCH)
+        self.assertEqual("lf.", result.prefix, "Runner prefix not correct for User1")
 
     def test_explicitly_opted_out_user(self) -> None:
         settings_text = """
@@ -200,8 +200,8 @@ class TestRunnerDeterminatorGetRunnerPrefix(TestCase):
         @User2,lf,otherExp
 
         """
-        prefix = rd.get_runner_prefix(settings_text, ["User1"], USER_BRANCH)
-        self.assertEqual("", prefix, "Runner prefix not correct for User1")
+        result = rd.get_runner_prefix(settings_text, ["User1"], USER_BRANCH)
+        self.assertEqual("", result.prefix, "Runner prefix not correct for User1")
 
     def test_explicitly_opted_in_and_out_user_should_opt_out(self) -> None:
         settings_text = """
@@ -217,8 +217,8 @@ class TestRunnerDeterminatorGetRunnerPrefix(TestCase):
         @User2,lf,otherExp
 
         """
-        prefix = rd.get_runner_prefix(settings_text, ["User1"], USER_BRANCH)
-        self.assertEqual("", prefix, "Runner prefix not correct for User1")
+        result = rd.get_runner_prefix(settings_text, ["User1"], USER_BRANCH)
+        self.assertEqual("", result.prefix, "Runner prefix not correct for User1")
 
     def test_opted_in_user_two_experiments(self) -> None:
         settings_text = """
@@ -234,8 +234,8 @@ class TestRunnerDeterminatorGetRunnerPrefix(TestCase):
         @User2,lf,otherExp
 
         """
-        prefix = rd.get_runner_prefix(settings_text, ["User2"], USER_BRANCH)
-        self.assertEqual("lf.otherExp.", prefix, "Runner prefix not correct for User2")
+        result = rd.get_runner_prefix(settings_text, ["User2"], USER_BRANCH)
+        self.assertEqual("lf.otherExp.", result.prefix, "Runner prefix not correct for User2")
 
     def test_opted_in_user_two_experiments_default(self) -> None:
         settings_text = """
@@ -252,8 +252,8 @@ class TestRunnerDeterminatorGetRunnerPrefix(TestCase):
         @User2,lf,otherExp
 
         """
-        prefix = rd.get_runner_prefix(settings_text, ["User2"], USER_BRANCH)
-        self.assertEqual("lf.", prefix, "Runner prefix not correct for User2")
+        result = rd.get_runner_prefix(settings_text, ["User2"], USER_BRANCH)
+        self.assertEqual("lf.", result.prefix, "Runner prefix not correct for User2")
 
     def test_opted_in_user_two_experiments_default_exp(self) -> None:
         settings_text = """
@@ -270,10 +270,10 @@ class TestRunnerDeterminatorGetRunnerPrefix(TestCase):
         @User2,lf,otherExp
 
         """
-        prefix = rd.get_runner_prefix(
+        result = rd.get_runner_prefix(
             settings_text, ["User2"], USER_BRANCH, frozenset(["lf", "otherExp"])
         )
-        self.assertEqual("lf.otherExp.", prefix, "Runner prefix not correct for User2")
+        self.assertEqual("lf.otherExp.", result.prefix, "Runner prefix not correct for User2")
 
     def test_opted_in_user_two_experiments_default_exp_2(self) -> None:
         settings_text = """
@@ -290,10 +290,10 @@ class TestRunnerDeterminatorGetRunnerPrefix(TestCase):
         @User2,lf,otherExp
 
         """
-        prefix = rd.get_runner_prefix(
+        result = rd.get_runner_prefix(
             settings_text, ["User2"], USER_BRANCH, frozenset(["otherExp"])
         )
-        self.assertEqual("otherExp.", prefix, "Runner prefix not correct for User2")
+        self.assertEqual("otherExp.", result.prefix, "Runner prefix not correct for User2")
 
     @patch("random.uniform", return_value=50)
     def test_opted_out_user(self, mock_uniform: Mock) -> None:
@@ -310,8 +310,8 @@ class TestRunnerDeterminatorGetRunnerPrefix(TestCase):
         @User2,lf,otherExp
 
         """
-        prefix = rd.get_runner_prefix(settings_text, ["User3"], USER_BRANCH)
-        self.assertEqual("", prefix, "Runner prefix not correct for user")
+        result = rd.get_runner_prefix(settings_text, ["User3"], USER_BRANCH)
+        self.assertEqual("", result.prefix, "Runner prefix not correct for user")
 
     @patch("random.uniform", return_value=10)
     def test_opted_out_user_was_pulled_in_by_rollout(self, mock_uniform: Mock) -> None:
@@ -330,8 +330,8 @@ class TestRunnerDeterminatorGetRunnerPrefix(TestCase):
         """
 
         # User3 is opted out, but is pulled into both experiments by the 10% rollout
-        prefix = rd.get_runner_prefix(settings_text, ["User3"], USER_BRANCH)
-        self.assertEqual("lf.otherExp.", prefix, "Runner prefix not correct for user")
+        result = rd.get_runner_prefix(settings_text, ["User3"], USER_BRANCH)
+        self.assertEqual("lf.otherExp.", result.prefix, "Runner prefix not correct for user")
 
     @patch("random.uniform", return_value=10)
     def test_opted_out_user_was_pulled_in_by_rollout_excl_nondefault(
@@ -353,8 +353,8 @@ class TestRunnerDeterminatorGetRunnerPrefix(TestCase):
         """
 
         # User3 is opted out, but is pulled into default experiments by the 10% rollout
-        prefix = rd.get_runner_prefix(settings_text, ["User3"], USER_BRANCH)
-        self.assertEqual("lf.", prefix, "Runner prefix not correct for user")
+        result = rd.get_runner_prefix(settings_text, ["User3"], USER_BRANCH)
+        self.assertEqual("lf.", result.prefix, "Runner prefix not correct for user")
 
     @patch("random.uniform", return_value=10)
     def test_opted_out_user_was_pulled_in_by_rollout_filter_exp(
@@ -376,10 +376,10 @@ class TestRunnerDeterminatorGetRunnerPrefix(TestCase):
         """
 
         # User3 is opted out, but is pulled into default experiments by the 10% rollout
-        prefix = rd.get_runner_prefix(
+        result = rd.get_runner_prefix(
             settings_text, ["User3"], USER_BRANCH, frozenset(["otherExp"])
         )
-        self.assertEqual("otherExp.", prefix, "Runner prefix not correct for user")
+        self.assertEqual("otherExp.", result.prefix, "Runner prefix not correct for user")
 
     @patch("random.uniform", return_value=25)
     def test_opted_out_user_was_pulled_out_by_rollout_filter_exp(
@@ -401,8 +401,8 @@ class TestRunnerDeterminatorGetRunnerPrefix(TestCase):
         """
 
         # User3 is opted out, but is pulled into default experiments by the 10% rollout
-        prefix = rd.get_runner_prefix(settings_text, ["User3"], USER_BRANCH)
-        self.assertEqual("", prefix, "Runner prefix not correct for user")
+        result = rd.get_runner_prefix(settings_text, ["User3"], USER_BRANCH)
+        self.assertEqual("", result.prefix, "Runner prefix not correct for user")
 
     def test_lf_prefix_always_comes_first(self) -> None:
         settings_text = """
@@ -419,8 +419,8 @@ class TestRunnerDeterminatorGetRunnerPrefix(TestCase):
 
         """
 
-        prefix = rd.get_runner_prefix(settings_text, ["User2"], USER_BRANCH)
-        self.assertEqual("lf.otherExp.", prefix, "Runner prefix not correct for user")
+        result = rd.get_runner_prefix(settings_text, ["User2"], USER_BRANCH)
+        self.assertEqual("lf.otherExp.", result.prefix, "Runner prefix not correct for user")
 
     def test_ignores_commented_users(self) -> None:
         settings_text = """
@@ -437,8 +437,8 @@ class TestRunnerDeterminatorGetRunnerPrefix(TestCase):
 
         """
 
-        prefix = rd.get_runner_prefix(settings_text, ["User1"], USER_BRANCH)
-        self.assertEqual("", prefix, "Runner prefix not correct for user")
+        result = rd.get_runner_prefix(settings_text, ["User1"], USER_BRANCH)
+        self.assertEqual("", result.prefix, "Runner prefix not correct for user")
 
     def test_ignores_extra_experiments(self) -> None:
         settings_text = """
@@ -456,8 +456,8 @@ class TestRunnerDeterminatorGetRunnerPrefix(TestCase):
 
         """
 
-        prefix = rd.get_runner_prefix(settings_text, ["User1"], USER_BRANCH)
-        self.assertEqual("lf.otherExp.", prefix, "Runner prefix not correct for user")
+        result = rd.get_runner_prefix(settings_text, ["User1"], USER_BRANCH)
+        self.assertEqual("lf.otherExp.", result.prefix, "Runner prefix not correct for user")
 
     def test_disables_experiment_on_exception_branches_when_not_explicitly_opted_in(
         self,
@@ -473,8 +473,8 @@ class TestRunnerDeterminatorGetRunnerPrefix(TestCase):
 
         """
 
-        prefix = rd.get_runner_prefix(settings_text, ["User1"], EXCEPTION_BRANCH)
-        self.assertEqual("", prefix, "Runner prefix not correct for user")
+        result = rd.get_runner_prefix(settings_text, ["User1"], EXCEPTION_BRANCH)
+        self.assertEqual("", result.prefix, "Runner prefix not correct for user")
 
     def test_allows_experiment_on_exception_branches_when_explicitly_opted_in(
         self,
@@ -491,8 +491,136 @@ class TestRunnerDeterminatorGetRunnerPrefix(TestCase):
 
         """
 
-        prefix = rd.get_runner_prefix(settings_text, ["User1"], EXCEPTION_BRANCH)
-        self.assertEqual("lf.", prefix, "Runner prefix not correct for user")
+        result = rd.get_runner_prefix(settings_text, ["User1"], EXCEPTION_BRANCH)
+        self.assertEqual("lf.", result.prefix, "Runner prefix not correct for user")
+
+
+class TestRunnerDeterminatorArcExperiment(TestCase):
+    ARC_SETTINGS = """
+        experiments:
+            arc:
+                rollout_perc: 0
+        ---
+
+        Users:
+        @User1,arc
+        @User2,lf
+
+        """
+
+    def test_arc_opted_in_user_returns_mt_prefix(self) -> None:
+        result = rd.get_runner_prefix(self.ARC_SETTINGS, ["User1"], USER_BRANCH)
+        self.assertEqual("mt-", result.prefix)
+        self.assertTrue(result.use_arc)
+
+    def test_arc_opted_in_user_canary_returns_c_mt_prefix(self) -> None:
+        result = rd.get_runner_prefix(
+            self.ARC_SETTINGS, ["User1"], USER_BRANCH, is_canary=True
+        )
+        self.assertEqual("c-mt-", result.prefix)
+        self.assertTrue(result.use_arc)
+
+    def test_arc_not_enabled_returns_use_arc_false(self) -> None:
+        result = rd.get_runner_prefix(self.ARC_SETTINGS, ["User2"], USER_BRANCH)
+        self.assertFalse(result.use_arc)
+
+    def test_arc_not_enabled_no_experiments_returns_use_arc_false(self) -> None:
+        settings_text = """
+        experiments:
+            arc:
+                rollout_perc: 0
+        ---
+
+        Users:
+        @User1,arc
+
+        """
+        result = rd.get_runner_prefix(settings_text, ["User3"], USER_BRANCH)
+        self.assertEqual("", result.prefix)
+        self.assertFalse(result.use_arc)
+
+    @patch("random.uniform", return_value=10)
+    def test_arc_rollout_percentage(self, mock_uniform: Mock) -> None:
+        settings_text = """
+        experiments:
+            arc:
+                rollout_perc: 25
+        ---
+
+        Users:
+
+        """
+        result = rd.get_runner_prefix(settings_text, ["User3"], USER_BRANCH)
+        self.assertEqual("mt-", result.prefix)
+        self.assertTrue(result.use_arc)
+
+    @patch("random.uniform", return_value=50)
+    def test_arc_rollout_percentage_not_selected(self, mock_uniform: Mock) -> None:
+        settings_text = """
+        experiments:
+            arc:
+                rollout_perc: 25
+        ---
+
+        Users:
+
+        """
+        result = rd.get_runner_prefix(settings_text, ["User3"], USER_BRANCH)
+        self.assertEqual("", result.prefix)
+        self.assertFalse(result.use_arc)
+
+    def test_arc_opted_out_user(self) -> None:
+        settings_text = """
+        experiments:
+            arc:
+                rollout_perc: 100
+        ---
+
+        Users:
+        @User1,-arc
+
+        """
+        result = rd.get_runner_prefix(settings_text, ["User1"], USER_BRANCH)
+        self.assertEqual("", result.prefix)
+        self.assertFalse(result.use_arc)
+
+    def test_arc_exception_branch_not_enabled(self) -> None:
+        result = rd.get_runner_prefix(self.ARC_SETTINGS, ["User1"], EXCEPTION_BRANCH)
+        self.assertEqual("", result.prefix)
+        self.assertFalse(result.use_arc)
+
+    def test_arc_exception_branch_all_branches(self) -> None:
+        settings_text = """
+        experiments:
+            arc:
+                rollout_perc: 0
+                all_branches: true
+        ---
+
+        Users:
+        @User1,arc
+
+        """
+        result = rd.get_runner_prefix(settings_text, ["User1"], EXCEPTION_BRANCH)
+        self.assertEqual("mt-", result.prefix)
+        self.assertTrue(result.use_arc)
+
+    def test_arc_takes_precedence_over_lf(self) -> None:
+        settings_text = """
+        experiments:
+            lf:
+                rollout_perc: 0
+            arc:
+                rollout_perc: 0
+        ---
+
+        Users:
+        @User1,lf,arc
+
+        """
+        result = rd.get_runner_prefix(settings_text, ["User1"], USER_BRANCH)
+        self.assertEqual("mt-", result.prefix)
+        self.assertTrue(result.use_arc)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/_runner-determinator.yml
+++ b/.github/workflows/_runner-determinator.yml
@@ -41,6 +41,9 @@ on:
       label-type:
         description: Type of runners to use
         value: ${{ jobs.runner-determinator.outputs.label-type }}
+      use-arc:
+        description: Whether to use ARC runners
+        value: ${{ jobs.runner-determinator.outputs.use-arc }}
 
 jobs:
   runner-determinator:
@@ -49,6 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       label-type: ${{ steps.set-condition.outputs.label-type }}
+      use-arc: ${{ steps.set-condition.outputs.use-arc }}
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       ISSUE_NUMBER: ${{ inputs.issue_number }}
@@ -58,12 +62,6 @@ jobs:
       OPT_OUT_EXPERIMENTS: ${{ inputs.opt_out_experiments }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
     steps:
-      # - name: Checkout PyTorch
-      #   uses: pytorch/pytorch/.github/actions/checkout-pytorch@main
-      #   with:
-      #     fetch-depth: 1
-      #     submodules: true
-
       # TODO: Remove the hardcoded step below
       # Hardcoding below is temporary for testing ALI runners
       # This file below should match the script found in .github/scripts/runner_determinator.py
@@ -152,12 +150,17 @@ jobs:
           GITHUB_OUTPUT = os.getenv("GITHUB_OUTPUT", "")
           GH_OUTPUT_KEY_AMI = "runner-ami"
           GH_OUTPUT_KEY_LABEL_TYPE = "label-type"
+          GH_OUTPUT_KEY_USE_ARC = "use-arc"
           OPT_OUT_LABEL = "no-runner-experiments"
 
           SETTING_EXPERIMENTS = "experiments"
 
           LF_FLEET_EXPERIMENT = "lf"
+          ARC_FLEET_EXPERIMENT = "arc"
           CANARY_FLEET_SUFFIX = ".c"
+
+          ARC_LABEL_PREFIX = "mt-"
+          ARC_CANARY_LABEL_PREFIX = "c-"
 
 
           class Experiment(NamedTuple):
@@ -172,6 +175,11 @@ jobs:
               )
 
               # Add more fields as needed
+
+
+          class RunnerPrefixResult(NamedTuple):
+              prefix: str
+              use_arc: bool = False
 
 
           class Settings(NamedTuple):
@@ -335,7 +343,12 @@ jobs:
               """
               Branches that get opted out of experiments by default, until they're explicitly enabled.
               """
-              return branch.split("/")[0] in {"main", "nightly", "release", "landchecks"}
+              return branch.split("/", maxsplit=1)[0] in {
+                  "main",
+                  "nightly",
+                  "release",
+                  "landchecks",
+              }
 
 
           def load_yaml(yaml_text: str) -> Any:
@@ -507,12 +520,13 @@ jobs:
               eligible_experiments: frozenset[str] = frozenset(),
               opt_out_experiments: frozenset[str] = frozenset(),
               is_canary: bool = False,
-          ) -> str:
+          ) -> RunnerPrefixResult:
               settings = parse_settings(rollout_state)
               user_optins = parse_users(rollout_state)
 
               fleet_prefix = ""
               prefixes = []
+              use_arc = False
               for experiment_name, experiment_settings in settings.experiments.items():
                   if not experiment_settings.all_branches and is_exception_branch(branch):
                       log.info(
@@ -578,7 +592,12 @@ jobs:
 
                   if enabled:
                       label = experiment_name
-                      if experiment_name == LF_FLEET_EXPERIMENT:
+                      if experiment_name == ARC_FLEET_EXPERIMENT:
+                          use_arc = True
+                          log.info(
+                              f"ARC experiment enabled. Using ARC runner prefix ({'canary' if is_canary else 'production'})."
+                          )
+                      elif experiment_name == LF_FLEET_EXPERIMENT:
                           # We give some special treatment to the "lf" experiment since determines the fleet we use
                           #  - If it's enabled, then we always list it's prefix first
                           #  - If we're in the canary branch, then we append ".c" to the lf prefix
@@ -587,6 +606,11 @@ jobs:
                           fleet_prefix = label
                       else:
                           prefixes.append(label)
+
+              # ARC experiment takes precedence: return a fixed label prefix
+              if use_arc:
+                  arc_prefix = ARC_CANARY_LABEL_PREFIX + ARC_LABEL_PREFIX if is_canary else ARC_LABEL_PREFIX
+                  return RunnerPrefixResult(prefix=arc_prefix, use_arc=True)
 
               if len(prefixes) > 1:
                   log.error(
@@ -598,7 +622,8 @@ jobs:
               if fleet_prefix:
                   prefixes.insert(0, fleet_prefix)
 
-              return ".".join(prefixes) + "." if prefixes else ""
+              prefix = ".".join(prefixes) + "." if prefixes else ""
+              return RunnerPrefixResult(prefix=prefix)
 
 
           def get_rollout_state_from_issue(github_token: str, repo: str, issue_num: int) -> str:
@@ -687,7 +712,7 @@ jobs:
 
                   is_canary = args.github_repo == "pytorch/pytorch-canary"
 
-                  runner_label_prefix = get_runner_prefix(
+                  result = get_runner_prefix(
                       rollout_state,
                       (args.github_issue_owner, username),
                       args.github_branch,
@@ -695,6 +720,8 @@ jobs:
                       args.opt_out_experiments,
                       is_canary,
                   )
+                  runner_label_prefix = result.prefix
+                  set_github_output(GH_OUTPUT_KEY_USE_ARC, str(result.use_arc).lower())
 
               except Exception as e:
                   log.error(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #177804
* #177803

When the "arc" experiment is enabled via the rollout issue, the script
outputs use-arc=true and sets label-type to "mt-" (pytorch) or "c-mt-"
(pytorch-canary). When not enabled, use-arc defaults to false.

There is only `mt-` prefix for now as ARC is not available on LF fleet yet.

### Testing

I opt-in myself into the arc experiment on https://github.com/pytorch/test-infra/issues/5132 and run

```
python .github/scripts/runner_determinator.py \
  --github-token "<REDACTED>" \
  --github-issue 5132 \
  --github-branch main \
  --github-actor huydhn \
  --github-issue-owner "" \
  --github-ref-type branch \
  --github-repo "pytorch/pytorch" \
  --eligible-experiments "" \
  --opt-out-experiments "" \
  --pr-number ""

INFO    : Based on rollout percentage of 80%, enabling experiment lf.
INFO    : Branch main is an exception branch. Not enabling experiment ephemeral.
INFO    : Branch main is an exception branch. Not enabling experiment wincanary.
INFO    : Branch main is an exception branch. Not enabling experiment wincanarylf.
INFO    : huydhn have opted into experiment arc.
INFO    : ARC experiment enabled. Using ARC runner prefix (production).
WARNING : No env var found for GITHUB_OUTPUT, you must be running this code locally. Falling back to the deprecated print method.
::set-output name=use-arc::true
WARNING : No env var found for GITHUB_OUTPUT, you must be running this code locally. Falling back to the deprecated print method.
::set-output name=label-type::mt-
```

The label-type prefix `mt-` and `use-arc` are returned correctly

Another test case for opt-out users:

```
python .github/scripts/runner_determinator.py \
  --github-token "REDACTED" \
  --github-issue 5132 \
  --github-branch main \
  --github-actor malfet \
  --github-issue-owner "" \
  --github-ref-type branch \
  --github-repo "pytorch/pytorch" \
  --eligible-experiments "" \
  --opt-out-experiments "" \
  --pr-number ""
INFO    : malfet have opted out of experiment lf.
INFO    : Branch main is an exception branch. Not enabling experiment ephemeral.
INFO    : Branch main is an exception branch. Not enabling experiment wincanary.
INFO    : Branch main is an exception branch. Not enabling experiment wincanarylf.
WARNING : No env var found for GITHUB_OUTPUT, you must be running this code locally. Falling back to the deprecated print method.
::set-output name=use-arc::false
WARNING : No env var found for GITHUB_OUTPUT, you must be running this code locally. Falling back to the deprecated print method.
::set-output name=label-type::
```

Signed-off-by: Huy Do <huydhn@gmail.com>