### PR TITLE
[do not review] Add tensor/storage ref count introspection for alias detection

### DIFF
--- a/test/test_tensor_ref_info.py
+++ b/test/test_tensor_ref_info.py
@@ -1,0 +1,91 @@
+# Owner(s): ["module: unknown"]
+
+import torch
+from torch.testing._internal.common_utils import run_tests, skipIfTorchDynamo, TestCase
+from torch.utils._tensor_ref_info import is_safe_to_inplace, tensor_ref_info, TensorRefInfo
+
+
+@skipIfTorchDynamo("Refcount introspection is not meaningful under Dynamo")
+class TestTensorRefInfo(TestCase):
+    def test_basic_counts(self):
+        t = torch.randn(10)
+        info = tensor_ref_info(t)
+        self.assertIsInstance(info, TensorRefInfo)
+        self.assertEqual(info.tensor_use_count, 1)
+        self.assertGreaterEqual(info.tensor_weak_use_count, 1)
+        self.assertEqual(info.storage_use_count, 1)
+        self.assertGreaterEqual(info.storage_weak_use_count, 1)
+        self.assertFalse(info.is_view)
+        self.assertFalse(info.is_cow)
+        self.assertEqual(info.storage_offset, 0)
+        self.assertEqual(info.data_ptr, t.data_ptr())
+
+    def test_view_increases_storage_use_count(self):
+        t = torch.randn(10)
+        base_count = t._storage_use_count()
+        v = t.view(2, 5)
+        self.assertEqual(t._storage_use_count(), base_count + 1)
+        info = tensor_ref_info(v)
+        self.assertTrue(info.is_view)
+        del v
+        self.assertEqual(t._storage_use_count(), base_count)
+
+    def test_slice_is_view_with_offset(self):
+        t = torch.randn(10)
+        v = t[3:]
+        info = tensor_ref_info(v)
+        self.assertTrue(info.is_view)
+        self.assertGreater(info.storage_offset, 0)
+        self.assertEqual(info.data_ptr, t.data_ptr() + 3 * t.element_size())
+
+    def test_clone_does_not_share_storage(self):
+        t = torch.randn(10)
+        c = t.clone()
+        self.assertEqual(t._storage_use_count(), 1)
+        self.assertEqual(c._storage_use_count(), 1)
+        self.assertNotEqual(t.data_ptr(), c.data_ptr())
+
+    def test_cow_detection(self):
+        t = torch.randn(10)
+        c = t._lazy_clone()
+        self.assertTrue(torch._C._is_cow_tensor(t))
+        self.assertTrue(torch._C._is_cow_tensor(c))
+        info = tensor_ref_info(t)
+        self.assertTrue(info.is_cow)
+
+    def test_safe_to_inplace_standalone(self):
+        t = torch.randn(10)
+        self.assertTrue(is_safe_to_inplace(t))
+
+    def test_not_safe_with_view(self):
+        t = torch.randn(10)
+        v = t.view(2, 5)  # noqa: F841
+        self.assertFalse(is_safe_to_inplace(t))
+
+    def test_not_safe_cow(self):
+        t = torch.randn(10)
+        c = t._lazy_clone()  # noqa: F841
+        self.assertFalse(is_safe_to_inplace(t))
+
+    def test_safe_after_view_deleted(self):
+        t = torch.randn(10)
+        v = t.view(2, 5)
+        self.assertFalse(is_safe_to_inplace(t))
+        del v
+        self.assertTrue(is_safe_to_inplace(t))
+
+    def test_multiple_views(self):
+        t = torch.randn(10)
+        v1 = t[:]  # noqa: F841
+        v2 = t.view(2, 5)  # noqa: F841
+        self.assertEqual(t._storage_use_count(), 3)
+        self.assertFalse(is_safe_to_inplace(t))
+
+    def test_weak_use_count_method(self):
+        t = torch.randn(10)
+        self.assertGreaterEqual(t._weak_use_count(), 1)
+        self.assertGreaterEqual(t._storage_weak_use_count(), 1)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -3368,6 +3368,34 @@ static PyObject* THPVariable__use_count(PyObject* self, PyObject* noargs) {
   END_HANDLE_TH_ERRORS
 }
 
+static PyObject* THPVariable__weak_use_count(
+    PyObject* self,
+    PyObject* noargs) {
+  HANDLE_TH_ERRORS
+  const auto& t = THPVariable_Unpack(self);
+  return THPUtils_packUInt64(t.weak_use_count());
+  END_HANDLE_TH_ERRORS
+}
+
+static PyObject* THPVariable__storage_use_count(
+    PyObject* self,
+    PyObject* noargs) {
+  HANDLE_TH_ERRORS
+  const auto& t = THPVariable_Unpack(self);
+  return THPUtils_packUInt64(t.storage().use_count());
+  END_HANDLE_TH_ERRORS
+}
+
+static PyObject* THPVariable__storage_weak_use_count(
+    PyObject* self,
+    PyObject* noargs) {
+  HANDLE_TH_ERRORS
+  const auto& t = THPVariable_Unpack(self);
+  return THPUtils_packUInt64(
+      t.storage().unsafeGetStorageImpl()->weakcount());
+  END_HANDLE_TH_ERRORS
+}
+
 // properties are registered here because we are currently only able to bind
 // them manually. TODO: make declarable in native_functions
 // NOLINTNEXTLINE(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays,cppcoreguidelines-avoid-non-const-global-variables)
@@ -3529,6 +3557,15 @@ static PyMethodDef extra_methods[] = {
      METH_O,
      nullptr},
     {"_use_count", THPVariable__use_count, METH_NOARGS, nullptr},
+    {"_weak_use_count", THPVariable__weak_use_count, METH_NOARGS, nullptr},
+    {"_storage_use_count",
+     THPVariable__storage_use_count,
+     METH_NOARGS,
+     nullptr},
+    {"_storage_weak_use_count",
+     THPVariable__storage_weak_use_count,
+     METH_NOARGS,
+     nullptr},
     {nullptr}};
 
 // NOLINTNEXTLINE(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays,cppcoreguidelines-avoid-non-const-global-variables)

--- a/torch/utils/_tensor_ref_info.py
+++ b/torch/utils/_tensor_ref_info.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import dataclasses
+import sys
+
+import torch
+
+
+@dataclasses.dataclass(frozen=True)
+class TensorRefInfo:
+    """Reference count and alias information for a tensor.
+
+    Weak counts include a +1 when the strong count is > 0 (intrusive_ptr
+    convention).  Subtract 1 to get the number of external weak references.
+    """
+
+    # TensorImpl refcounts
+    tensor_use_count: int
+    tensor_weak_use_count: int
+
+    # StorageImpl refcounts
+    storage_use_count: int
+    storage_weak_use_count: int
+
+    # Python object refcount (via sys.getrefcount, includes the call's own ref)
+    python_refcount: int
+
+    # Alias / view information
+    is_view: bool
+    is_cow: bool
+    data_ptr: int
+    storage_offset: int
+
+
+def tensor_ref_info(tensor: torch.Tensor) -> TensorRefInfo:
+    """Collect reference count and alias information for a tensor."""
+    return TensorRefInfo(
+        tensor_use_count=tensor._use_count(),
+        tensor_weak_use_count=tensor._weak_use_count(),
+        storage_use_count=tensor._storage_use_count(),
+        storage_weak_use_count=tensor._storage_weak_use_count(),
+        python_refcount=sys.getrefcount(tensor),
+        is_view=tensor._is_view(),
+        is_cow=torch._C._is_cow_tensor(tensor),
+        data_ptr=tensor.data_ptr(),
+        storage_offset=tensor.storage_offset(),
+    )
+
+
+def is_safe_to_inplace(tensor: torch.Tensor) -> bool:
+    """Check whether an in-place mutation of ``tensor`` is safe.
+
+    "Safe" means no other tensor will observe the side effects.  This requires:
+    - The storage is not shared (storage_use_count == 1).
+    - The data is not copy-on-write shared.
+
+    Weak references do not prevent mutation.  Autograd safety (leaf tensors,
+    requires_grad) is a separate concern handled by autograd itself and is
+    not checked here.
+    """
+    if torch._C._is_cow_tensor(tensor):
+        return False
+    return tensor._storage_use_count() == 1


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #177806
* #177070
* #174079
* #176234

Expose `_weak_use_count()`, `_storage_use_count()`, and
`_storage_weak_use_count()` on tensors, and add a Python utility
(`torch.utils._tensor_ref_info`) with `tensor_ref_info()` and
`is_safe_to_inplace()` for diagnosing aliasing and deciding whether
in-place mutation is safe.

Authored with Claude.