### PR TITLE
[xpu][fix] Fix tensorwise scaling settings

### DIFF
--- a/aten/src/ATen/native/mkldnn/xpu/detail/QMatmul.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/QMatmul.cpp
@@ -345,8 +345,14 @@ struct ScaleSpec {
       int64_t outer_dim,
       int64_t inner_dim,
       const std::string& arg_type) const {
-    if (groups == dnnl::memory::dims{1, 1})
+    // TensorWise: mask=0, groups={} -> single scale
+    if (groups.empty()) {
+      TORCH_INTERNAL_ASSERT(
+          mask == 0,
+          "Empty groups only valid for TensorWise (mask=0), got mask=",
+          mask);
       return 1; // tensorwise scaling
+    }
 
     TORCH_CHECK(
         arg_type == "src" || arg_type == "wei",
@@ -399,8 +405,8 @@ inline ScaleSpec make_scale_spec(
   if (scaling_type == at::blas::ScalingType::TensorWise) {
     // Scale tensorwise. The same as `--attr-scales=common`.
     // mask=0 : scale whole tensor
-    // groups={1, 1}: indicates that there is only one group for scaling
-    return {0, {1, 1}, dnnl::memory::data_type::f32};
+    // groups={}: indicates that there is only one group for scaling
+    return {0, {}, dnnl::memory::data_type::f32};
   } else {
     // (scaling_type == at::blas::ScalingType::RowWise)
     // Scale RowWise. The same as `--attr-scales=per_dim_01`.

--- a/aten/src/ATen/native/mkldnn/xpu/detail/QMatmul.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/QMatmul.cpp
@@ -485,7 +485,7 @@ sycl::event scaled_matmul(
   // scale_result tensor currently only supports scalar(TensorWise Scaling).
   bool with_dst_scale = scale_result && scale_result->defined();
   if (with_dst_scale) {
-    op_attr.set_scales(DNNL_ARG_DST, 0, {1}, dnnl::memory::data_type::f32);
+    op_attr.set_scales(DNNL_ARG_DST, 0, {}, dnnl::memory::data_type::f32);
   }
 
   op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);


### PR DESCRIPTION
Fixes: https://github.com/intel/torch-xpu-ops/issues/3075 and https://github.com/intel/torch-xpu-ops/issues/3085
After oneDNN upgrade, the tensorwise scaling factor settings should be changed, otherwise, it would throw `could not create primitive`.

According to the latest oneDNN doc: https://uxlfoundation.github.io/oneDNN/v3.10/dev_guide_attributes_quantization.html

We need to change the primitive settings to `groups={}` accordingly. 

**Test Plan:**
We reuse the previous UT like `test_float8_scale` in https://github.com/pytorch/pytorch/blob/41eefa92f9889ccbed3dd7e22c18144f15fc71c5/test/test_scaled_matmul_cuda.py#L692



cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01 @gujinghui @EikanWang @fengyuan14 @guangyey