### PR TITLE
[inductor][cutedsl] Fix ssa_to_indexable crash when loading 0-dim tensor in mask_mod

### DIFF
--- a/test/inductor/test_flex_flash.py
+++ b/test/inductor/test_flex_flash.py
@@ -180,6 +180,21 @@ def create_score_mod_buffer(num_heads=4, dtype=torch.float16, device="cuda"):
     return score_with_buffer
 
 
+def create_mask_mod_scalar_tensor(device="cuda"):
+    """mask_mod that captures a 0-dim (scalar) tensor.
+
+    Regression test: loading a 0-dim tensor in CuTeDSL codegen produces a
+    constant index 0, which was incorrectly passed as a bare Python int to
+    ssa_to_indexable (expects TensorSSA).  See #177813.
+    """
+    offset = torch.tensor(5, dtype=torch.int32, device=device)
+
+    def mask_with_scalar_tensor(_b, _h, q_idx, kv_idx):
+        return (q_idx + offset) >= kv_idx
+
+    return mask_with_scalar_tensor
+
+
 def create_mask_mod_buffer(num_heads=4, dtype=torch.float16, device="cuda"):
     mask_bias = torch.randn(num_heads, device=device, dtype=dtype) * 0.1
 
@@ -598,6 +613,10 @@ DETERMINISTIC_SCORE_MOD_CASES = [case for case in SCORE_MOD_CASES if case.requir
 
 
 MASK_MOD_CASES = [
+    MaskModCase(
+        "mask_mod_scalar_tensor",
+        lambda _dtype, device: create_mask_mod_scalar_tensor(device=device),
+    ),
     MaskModCase("block_mask_causal", lambda _dtype, _device: _causal_mask),
     MaskModCase(
         "block_mask_causal_score_times_two",

--- a/torch/_inductor/codegen/cutedsl/cutedsl_kernel.py
+++ b/torch/_inductor/codegen/cutedsl/cutedsl_kernel.py
@@ -544,11 +544,19 @@ class ModificationWrapperCuteDSL(V.WrapperHandler):  # type: ignore[name-defined
         self, expr_str: str, cute_dtype: str, torch_dtype: torch.dtype
     ) -> str:
         """
-        Convert SSA expression to indexable scalar for tensor loads.
+        Convert expression to indexable scalar for tensor loads.
 
         Workaround for lack of gather support: SSA values cannot be used directly
-        as indices. This generates code to convert SSA → indexable scalar.
+        as indices in tensor loads. This generates code to convert SSA → indexable
+        scalar. Compile-time integer constants are already indexable and are
+        returned directly without the SSA round-trip.
         """
+        # Constant integer expressions (e.g. sympy-folded offsets like "0")
+        # are already valid indices — skip the ssa_to_indexable round-trip
+        # which only accepts TensorSSA, not bare Python ints.
+        if expr_str.lstrip("-").isdigit():
+            return expr_str
+
         result = self.kernel.cse.newvar(dtype=torch_dtype)
         self.kernel.body.writeline(
             f"{result} = ssa_to_indexable({expr_str}, {cute_dtype})"


### PR DESCRIPTION
## Summary

Fix `ValueError: Expected TensorSSA, but got <class 'int'>` when using `flex_attention` with `BACKEND="FLASH"` (FA4/CuTeDSL) and a `mask_mod` that captures a 0-dim tensor.

## Problem

`_emit_scalar_fragment` passes the string output of `kexpr()` directly to `ssa_to_indexable`. When a 0-dim tensor (scalar tensor) captured by `mask_mod` is preserved as a graph input by the `flex_attention` HOA, loading it requires index `0` (the only element). `kexpr()` renders this as `"0"`, producing:

```python
tmp8 = ssa_to_indexable(0, cutlass.Int32)
```

`ssa_to_indexable` calls `frag.store(0)`, which rejects the bare Python int because `frag.store()` only accepts `TensorSSA`.

## Fix

Integer constant strings (like `"0"`, `"-1"`) are already valid indices for CuTeDSL tensor element access — they don't need the SSA→fragment→scalar round-trip. Return them directly from `_emit_scalar_fragment`:

```python
if expr_str.lstrip("-").isdigit():
    return expr_str
```

## Reproducer

> Requires Blackwell GPU (SM100) with CuTeDSL support.

```python
import torch
from torch.nn.attention.flex_attention import flex_attention, create_block_mask

seq_len = 1024
B, H, D = 1, 1, 64

# A 0-dim (scalar) tensor captured by mask_mod.
# flex_attention's HOA preserves it as a graph input (primals_N with size=[]).
# Loading it in CuTeDSL codegen produces ssa_to_indexable(0, cutlass.Int32)
# because index into a 0-dim tensor is always the constant 0.
offset = torch.tensor(5, dtype=torch.int32, device="cuda")

def mask_mod(b, h, q_idx, kv_idx):
    # `offset` is a captured 0-dim tensor → graph input with size=[]
    # Loading it triggers: ssa_to_indexable(0, cutlass.Int32) → crash
    return (q_idx + offset) >= kv_idx

block_mask = create_block_mask(mask_mod, B, H, seq_len, seq_len, device="cuda", BLOCK_SIZE=(256,128))
flex_fa4 = torch.compile(flex_attention, dynamic=False)

q = torch.randn(B, H, seq_len, D, device="cuda", dtype=torch.bfloat16)
k = torch.randn(B, H, seq_len, D, device="cuda", dtype=torch.bfloat16)
v = torch.randn(B, H, seq_len, D, device="cuda", dtype=torch.bfloat16)

# Crashes: ValueError: Expected TensorSSA, but got <class 'int'>
out = flex_fa4(
    q, k, v,
    block_mask=block_mask,
    kernel_options={"BACKEND": "FLASH"},
)
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @drisspg @Chillee

This PR was authored with the help of Claude.
