### PR TITLE
[inductor] Preserve mutation ordering deps in recompute_size_and_body

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -8198,6 +8198,26 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
             self.common(fn, (inp, False))
             self.common(fn, (inp, True))
 
+    def test_sort_after_noop_pad_and_mutation(self):
+        # https://github.com/pytorch/pytorch/issues/177631
+        # When a no-op pad creates an alias that is later sorted, and the
+        # original tensor is mutated via index_put, the mutation must be
+        # scheduled after the sort. A bug in recompute_size_and_body was
+        # dropping the WeakDep that enforced this ordering.
+        def fn(a):
+            b = torch.nn.functional.pad(a, (0, 0))
+            a[0] = 1
+            sorted_tensor, _ = torch.sort(b)
+            return sorted_tensor
+
+        x1 = torch.zeros((2, 2), dtype=torch.float32, device=self.device)
+        x2 = x1.clone()
+
+        cfunc = torch.compile(fn, backend="inductor")
+        expected = fn(x1)
+        actual = cfunc(x2)
+        self.assertEqual(actual, expected)
+
     def test_topk(self):
         def fn(a):
             return torch.topk(a, 2, -1)

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -1575,10 +1575,19 @@ class SchedulerNode(BaseSchedulerNode):
         extra_indexing_constraints: tuple[dict[Any, Any], list[Any]] | None = None,
         recompute_sizes_body_func: Callable[..., Any] | None = None,
     ) -> None:
+        # Preserve fake dependencies (WeakDep, StarDep) that were added manually
+        # by compute_dependencies (e.g., mutation ordering deps). These cannot be
+        # recovered from extract_read_writes since they are not natural data-flow
+        # dependencies. See https://github.com/pytorch/pytorch/issues/177631
+        fake_deps: OrderedSet[Dep] = OrderedSet(
+            dep for dep in self.read_writes.reads if isinstance(dep, (WeakDep, StarDep))
+        )
         self._compute_attrs(
             extra_indexing_constraints=extra_indexing_constraints,
             recompute_sizes_body_func=recompute_sizes_body_func,
         )
+        if fake_deps:
+            self.set_read_writes(self.read_writes.with_read(fake_deps))
 
     def refresh_dependencies(
         self, normalize: bool, need_clear_tiling_cache: bool


### PR DESCRIPTION
## Summary

Fixes https://github.com/pytorch/pytorch/issues/177631

`SchedulerNode.recompute_size_and_body()` calls `_compute_attrs()` which recomputes `read_writes` from scratch via `extract_read_writes()`. This only discovers natural data-flow dependencies and silently drops manually-added fake dependencies (`WeakDep`, `StarDep`) that were added by `compute_dependencies()` for mutation ordering.

When the CPU backend's `fuse()` method calls `recompute_size_and_body()` to reconcile loop ranges before fusion, the `WeakDep` that enforces "sort must run before the mutation of its input" is lost. The fused mutation kernel then gets scheduled before the sort, causing the sort to read already-mutated data and produce incorrect results.

### Root cause chain

1. `remove_noop_ops` eliminates no-op `constant_pad_nd(a, [0,0])`, making `sort(b)` become `sort(arg0_1)` — both sort and the input mutation now target the same buffer
2. `compute_dependencies()` correctly adds `WeakDep('buf0')` to the mutation node, ensuring it runs after the sort's `FallbackKernel`
3. During fusion, the CPU backend calls `recompute_size_and_body()` on the mutation node to reconcile loop ranges — this recomputes `read_writes` from scratch, **dropping the WeakDep**
4. The fused mutation kernel now has no ordering constraint relative to the sort, and gets scheduled first
5. Sort reads the already-mutated input, producing `[[1,1],[0,0]]` instead of `[[0,0],[0,0]]`

### Fix

Save and restore fake dependencies (`WeakDep`, `StarDep`) across `_compute_attrs()`, following the same pattern already used in `refresh_dependencies()`.

## Test plan

- Added `test_sort_after_noop_pad_and_mutation` to `test/inductor/test_torchinductor.py`
- Verified passing on both CPU and CUDA
- All existing sort tests pass (no regressions)
- All existing input mutation tests pass (no regressions)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @ezyang