### PR TITLE
Fix attn_mask shape in scaled_dot_product_attention docs

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -6078,7 +6078,7 @@ scaled_dot_product_attention = _add_docstr(
         key (Tensor): Key tensor; shape :math:`(N, ..., H, S, E)`.
         value (Tensor): Value tensor; shape :math:`(N, ..., H, S, Ev)`.
         attn_mask (optional Tensor): Attention mask; shape must be broadcastable to the shape of attention weights,
-            which is :math:`(N,..., L, S)`. Two types of masks are supported.
+            which is :math:`(N,..., Hq, L, S)`. Two types of masks are supported.
             A boolean mask where a value of True indicates that the element *should* take part in attention.
             A float mask of the same type as query, key, value that is added to the attention score.
         dropout_p (float): Dropout probability; if greater than 0.0, dropout is applied


### PR DESCRIPTION
## Summary

- Fix incorrect `attn_mask` shape in `torch.nn.functional.scaled_dot_product_attention` docstring
- Changed shape from `(N, ..., L, S)` to `(N, ..., Hq, L, S)` to include the missing head dimension `Hq`
- The attention weights shape includes the query head dimension, so `attn_mask` must be broadcastable to `(N, ..., Hq, L, S)`, not `(N, ..., L, S)`

Fixes #177482

## Test plan

- Documentation-only change, no functional code modified
- Verified the fix is consistent with the query shape `(N, ..., Hq, L, E)` and output shape `(N, ..., Hq, L, Ev)` already documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>