### PR TITLE
Fix attn_mask shape in scaled_dot_product_attention docs

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -6078,7 +6078,7 @@ scaled_dot_product_attention = _add_docstr(
         key (Tensor): Key tensor; shape :math:`(N, ..., H, S, E)`.
         value (Tensor): Value tensor; shape :math:`(N, ..., H, S, Ev)`.
         attn_mask (optional Tensor): Attention mask; shape must be broadcastable to the shape of attention weights,
-            which is :math:`(N,..., L, S)`. Two types of masks are supported.
+            which is :math:`(N,..., Hq, L, S)`. Two types of masks are supported.
             A boolean mask where a value of True indicates that the element *should* take part in attention.
             A float mask of the same type as query, key, value that is added to the attention score.
         dropout_p (float): Dropout probability; if greater than 0.0, dropout is applied


### PR DESCRIPTION
Fixes #177482

The docstring for `attn_mask` says its shape must be broadcastable to `(N, ..., L, S)`, but the actual attention weight shape is `(N, ..., Hq, L, S)` — the head dimension `Hq` is missing.

Every other tensor in the docstring (query, key, value, output) already includes the head dimension, so this was just an oversight. Updated the shape to `(N, ..., Hq, L, S)` to match the implementation and the rest of the docstring.