### PR TITLE
[Inductor] Cap num_warps for non-1x1 Triton conv kernels to fix incorrect results

### DIFF
--- a/torch/_inductor/kernel/conv.py
+++ b/torch/_inductor/kernel/conv.py
@@ -650,6 +650,13 @@ def convolution(
             in_chan,
             dtype_size=dtype_size,
         ):
+            # Workaround for triton#1254: the flattened single-loop used
+            # for non-1x1 kernels (UNROLL=False) triggers a Triton compiler
+            # bug when num_warps >= 8, producing incorrect results. Cap at
+            # 4 warps for non-1x1 kernels until the upstream fix lands.
+            unroll = is_ones(kernel_shape)
+            num_warps = cfg.num_warps if unroll else min(cfg.num_warps, 4)
+
             if ndim == 2:
                 conv2d_template.maybe_append_choice(
                     choices,
@@ -664,10 +671,10 @@ def convolution(
                     GROUPS=groups,
                     # TODO(jansel): try unroll for bigger kernels once fixed:
                     #               https://github.com/triton-lang/triton/issues/1254
-                    UNROLL=is_ones(kernel_shape),
+                    UNROLL=unroll,
                     ALLOW_TF32=torch.backends.cudnn.fp32_precision == "tf32",
                     num_stages=cfg.num_stages,
-                    num_warps=cfg.num_warps,
+                    num_warps=num_warps,
                     **cfg.kwargs,
                 )
             elif ndim == 3:
@@ -687,10 +694,10 @@ def convolution(
                     GROUPS=groups,
                     # TODO(jansel): try unroll for bigger kernels once fixed:
                     #               https://github.com/triton-lang/triton/issues/1254
-                    UNROLL=is_ones(kernel_shape),
+                    UNROLL=unroll,
                     ALLOW_TF32=torch.backends.cudnn.fp32_precision == "tf32",
                     num_stages=cfg.num_stages,
-                    num_warps=cfg.num_warps,
+                    num_warps=num_warps,
                     **cfg.kwargs,
                 )
     if use_ck_conv_template(layout):


### PR DESCRIPTION
## Summary

Fixes https://github.com/pytorch/pytorch/issues/173068

Non-1x1 convolution kernels use a flattened single-loop pattern (`UNROLL=False`) that triggers a Triton compiler bug ([triton-lang/triton#1254](https://github.com/triton-lang/triton/issues/1254)) when `num_warps >= 8`, producing incorrect results (max_diff=132+ with 84.7% mismatched elements).

The root cause is in Triton's code generation for the flattened loop:
```python
for ijk in range(KERNEL_H * KERNEL_W * BLOCK_K_COUNT):
    k = (ijk % BLOCK_K_COUNT) * BLOCK_K
    ij = ijk // BLOCK_K_COUNT
    i = ij // KERNEL_W
    j = ij % KERNEL_W
    ...
```

When compiled with `num_warps=8`, Triton generates incorrect GPU code for this loop pattern. The same kernel produces correct results with `num_warps <= 4`.

This PR caps `num_warps` at 4 for non-1x1 conv kernels (both 2D and 3D) until the upstream Triton fix lands. 1x1 kernels (`UNROLL=True`) are unaffected since they use Jinja2-unrolled loops that don't trigger the bug.

## Test plan

- `test_convolution1` in `test/inductor/test_select_algorithm.py` now passes (previously failed with `max_diff=132.32`, 84.7% mismatched elements)
- 1x1 convolutions still work correctly and can use `num_warps=8`
- All other conv configs continue to produce correct results

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo