### PR TITLE
[xpu] mark ConvTranspose2d complex32 parity as expected failure

### DIFF
--- a/torch/testing/_internal/common_modules.py
+++ b/torch/testing/_internal/common_modules.py
@@ -3885,6 +3885,8 @@ module_db: list[ModuleInfo] = [
                    # Not implemented for chalf on CPU
                    DecorateInfo(unittest.expectedFailure, 'TestModule', 'test_cpu_gpu_parity',
                                 dtypes=(torch.chalf,), device_type='cuda'),
+                   DecorateInfo(unittest.expectedFailure, 'TestModule', 'test_cpu_gpu_parity',
+                                dtypes=(torch.chalf, torch.complex32), device_type='xpu'),
                ),
                decorators=(
                    DecorateInfo(precisionOverride({torch.float32: 1e-04}), 'TestModule', 'test_memory_format'),


### PR DESCRIPTION
# Motivation
XPU CI failure mentioned in https://github.com/pytorch/pytorch/issues/176392 is because of the known numeric divergence.

# Solution
Add a targeted `expectedFailure` for `ConvTranspose2d cpu_gpu_parity` on XPU complex32/chalf to track known backend numeric divergence.

# Additional Context
Fix https://github.com/pytorch/pytorch/issues/176392
Fix https://github.com/intel/torch-xpu-ops/issues/3030