### PR TITLE
[lu_unpack] Fix segfault when LU_pivots is empty tensor

### DIFF
--- a/aten/src/ATen/native/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebra.cpp
@@ -771,18 +771,32 @@ TORCH_META_FUNC(_linalg_svd)(const Tensor& A,
 }
 
 TORCH_META_FUNC(lu_unpack)(const Tensor& LU, const Tensor& pivots, bool unpack_data, bool unpack_pivots) {
-  TORCH_CHECK(LU.dim() >= 2, "torch.lu_unpack: Expected tensor with 2 or more dimensions. Got size: ", LU.sizes(), " instead");
+  const auto lu_dim = LU.dim();
+  const auto lu_sizes = LU.sizes();
+  TORCH_CHECK(lu_dim >= 2, "torch.lu_unpack: Expected tensor with 2 or more dimensions. Got size: ", lu_sizes, " instead");
+
+  const auto m = lu_sizes[lu_dim - 2];
+  const auto n = lu_sizes[lu_dim - 1];
+  const auto k = std::min(m, n);
+
   if (unpack_pivots) {
     TORCH_CHECK(pivots.scalar_type() == at::kInt,
         "torch.lu_unpack: LU_pivots is expected to be a contiguous tensor of torch.int32 dtype.\n"
         "Note: this function is intended to be used with the output produced by torch.linalg.lu_factor");
+
+    const auto pivots_dim = pivots.dim();
+    const auto expected_batch_dims = lu_sizes.slice(0, lu_dim - 2);
+    const bool is_pivots_shape_correct = (pivots_dim == lu_dim - 1) && (pivots.size(-1) == k) &&
+      (pivots.sizes().slice(0, pivots_dim - 1).equals(expected_batch_dims));
+    if (!is_pivots_shape_correct) {
+      c10::DimVector expected_pivots_shape(expected_batch_dims);
+      expected_pivots_shape.emplace_back(k);
+      TORCH_CHECK(false,
+          "torch.lu_unpack: Expected LU_pivots shape to be ", expected_pivots_shape, ", but got ", pivots.sizes());
+    }
   }
 
-  auto sizes = LU.sizes().vec();
-  const auto m = sizes.cend()[-2];
-  const auto n = sizes.cend()[-1];
-  const auto k = std::min(m, n);
-
+  auto sizes = lu_sizes.vec();
   // P.shape[-2:] == (m, m) (or size zero if pivot == False)
   sizes.end()[-1] = m;
   if (unpack_pivots) {

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -7279,6 +7279,19 @@ class TestLinalg(TestCase):
         p, l, u = torch.lu_unpack(lu_data, lu_pivots, unpack_data=False, unpack_pivots=False)
         self.assertTrue(p.numel() == 0 and l.numel() == 0 and u.numel() == 0)
 
+        # invalid pivots shape should be rejected with error, not segfault
+        wrong_dim_pivots = torch.empty((0,), dtype=torch.int32, device=device)
+        with self.assertRaisesRegex(RuntimeError, r"Expected LU_pivots shape to be \[5, 5\], but got \[0\]"):
+            torch.lu_unpack(lu_data, wrong_dim_pivots)
+
+        wrong_size_pivots = torch.ones(5, 3, dtype=torch.int32, device=device)
+        with self.assertRaisesRegex(RuntimeError, r"Expected LU_pivots shape to be \[5, 5\], but got \[5, 3\]"):
+            torch.lu_unpack(lu_data, wrong_size_pivots)
+
+        wrong_batch_pivots = torch.ones(6, 5, dtype=torch.int32, device=device)
+        with self.assertRaisesRegex(RuntimeError, r"Expected LU_pivots shape to be \[5, 5\], but got \[6, 5\]"):
+            torch.lu_unpack(lu_data, wrong_batch_pivots)
+
     @skipCUDAIfNoMagmaAndNoLinalgsolver
     @skipCPUIfNoLapack
     @dtypes(torch.double)

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -1583,10 +1583,17 @@ def lu_unpack_meta(
     unpack_data: bool = True,
     unpack_pivots: bool = True,
 ) -> tuple[Tensor, Tensor, Tensor]:
+    lu_dim = LU.ndim
+    lu_shape = LU.shape
     torch._check(
-        LU.ndim >= 2,
-        lambda: f"torch.lu_unpack: Expected tensor with 2 or more dimensions. Got size: {LU.shape} instead",
+        lu_dim >= 2,
+        lambda: f"torch.lu_unpack: Expected tensor with 2 or more dimensions. Got size: {lu_shape} instead",
     )
+
+    m = lu_shape[-2]
+    n = lu_shape[-1]
+    k = sym_min(m, n)
+
     if unpack_pivots:
         torch._check(
             pivots.dtype == torch.int32,
@@ -1595,10 +1602,21 @@ def lu_unpack_meta(
                 "Note: this function is intended to be used with the output produced by torch.linalg.lu_factor"
             ),
         )
-    sizes = list(LU.shape)
-    m = sizes[-2]
-    n = sizes[-1]
-    k = sym_min(m, n)
+
+        is_pivots_shape_correct = (
+            (pivots.ndim == lu_dim - 1)
+            and (pivots.shape[-1] == k)
+            and (pivots.shape[:-1] == lu_shape[:-2])
+        )
+        if not is_pivots_shape_correct:
+            expected_pivots_shape = lu_shape[:-2] + (k,)
+            torch._check(
+                False,
+                lambda: (
+                    f"torch.lu_unpack: Expected LU_pivots shape to be {expected_pivots_shape}, but got {pivots.shape}"
+                ),
+            )
+    sizes = list(lu_shape)
     sizes[-1] = m
     if unpack_pivots:
         P = LU.new_empty(sizes)


### PR DESCRIPTION
## What does this PR do?
Fixes a segmentation fault in `torch.lu_unpack` that occurs when the `LU_pivots` tensor is empty (has no elements) while `LU_data` has a valid non-empty shape. 

### Root Cause
The original code did not validate the shape of `LU_pivots` before accessing its elements, leading to out-of-bounds memory access (segmentation fault) when `LU_pivots` is empty.

### Solution
Added shape validation for `LU_pivots` using `TORCH_CHECK`:
- Calculate the expected shape of `LU_pivots` (LU_data's first N-2 dimensions + min(m, n), where m/n are the last two dimensions of LU_data)
- Check if `LU_pivots`' shape matches the expected shape; if not (e.g., empty tensor), throw a clear error message instead of crashing.

### Related Issue
Fixes #177829

## Test Cases
Updated a unit test to verify the fix (in `test/test_linalg.py/test_lu_unpack_check_input`):
```
        # invalid pivots shape should be rejected with error, not segfault
        wrong_dim_pivots = torch.empty((0,), dtype=torch.int32, device=device)
        with self.assertRaisesRegex(RuntimeError, r"Expected LU_pivots shape to be \[5, 5\], but got \[0\]"):
            torch.lu_unpack(lu_data, wrong_dim_pivots)

        wrong_size_pivots = torch.ones(5, 3, dtype=torch.int32, device=device)
        with self.assertRaisesRegex(RuntimeError, r"Expected LU_pivots shape to be \[5, 5\], but got \[5, 3\]"):
            torch.lu_unpack(lu_data, wrong_size_pivots)

        wrong_batch_pivots = torch.ones(6, 5, dtype=torch.int32, device=device)
        with self.assertRaisesRegex(RuntimeError, r"Expected LU_pivots shape to be \[5, 5\], but got \[6, 5\]"):
            torch.lu_unpack(lu_data, wrong_batch_pivots)
```

```
import torch
LU_data = torch.tensor([[2., 3., 1.],
                        [0.5, 1., 2.],
                        [0.25, 0.5, 1.]])
LU_pivots = torch.tensor([], dtype=torch.int32)
P, L, U = torch.lu_unpack(LU_data, LU_pivots)

Traceback (most recent call last):
  File "/Users/lillian/Desktop/Python/pytorch/test/test_issue.py", line 11, in <module>
    P, L, U = torch.lu_unpack(LU_data, LU_pivots)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: torch.lu_unpack: Expected LU_pivots shape to be [3], but got [0]
```