### PR TITLE
[compile] force_bw_tangent_early_storage_release: resize_(0) tangent storage

### DIFF
--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -4806,6 +4806,29 @@ def forward(self, tangents_1):
         loss.backward()
 
     @unittest.skipIf(not torch.cuda.is_available(), "CUDA is unavailable")
+    def test_tangent_user_provided(self):
+        """Scenario: user provides tangents via out.backward(tangents).
+
+        Unlike torchtitan, user holds a Python ref to the tangent. The boxed
+        convention cannot free it — resize_(0) via
+        force_bw_tangent_early_storage_release is needed to reclaim memory."""
+        model, x, _labels = self._make_model_and_input()
+        compiled_model = torch.compile(model, backend="inductor")
+
+        out = compiled_model(x)
+        tangents = torch.randn_like(out)
+        tangent_storage = tangents.untyped_storage()
+        self.assertGreater(tangent_storage.nbytes(), 0)
+
+        out.backward(tangents)
+        # User still holds 'tangents' — TensorImpl alive, storage has data.
+        # Only resize_(0) in codegen can free CUDA memory in this case.
+        # Without resize_(0), storage keeps its original size.
+        del tangents
+        # After del, tensor is gone but storage object is still held by us.
+        # Storage nbytes stays at original size (no resize_(0) applied).
+
+    @unittest.skipIf(not torch.cuda.is_available(), "CUDA is unavailable")
     def test_tangent_refcount_during_backward(self):
         """Verify tangent refcount drops at model/loss boundary.
 
@@ -4849,6 +4872,31 @@ def forward(self, tangents_1):
             "expected <= 6 with boxed calling convention",
         )
 
+    @unittest.skipIf(not torch.cuda.is_available(), "CUDA is unavailable")
+    @torch._inductor.config.patch(force_bw_tangent_early_storage_release=True)
+    def test_tangent_storage_resize_zero(self):
+        """With force_bw_tangent_early_storage_release, tangent storage is
+        resized to 0 after last use even when user holds a ref.
+
+        Not needed for torchtitan simple_fsdp (boxed convention suffices),
+        but needed when user calls out.backward(user_tangent)."""
+        torch._dynamo.reset()
+        model, x, _labels = self._make_model_and_input()
+        compiled_model = torch.compile(model, backend="inductor")
+
+        out = compiled_model(x)
+        tangents = torch.randn_like(out)
+        tangent_storage = tangents.untyped_storage()
+        self.assertGreater(tangent_storage.nbytes(), 0)
+
+        out.backward(tangents)
+        del tangents
+
+        self.assertEqual(
+            tangent_storage.nbytes(),
+            0,
+            "Tangent storage should be resized to 0 with force_bw_tangent_early_storage_release",
+        )
 
 
 def extract_graph(fx_g, _, graph_cell):

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -3570,6 +3570,16 @@ class PythonWrapperCodegen(CodeGen):
 
         # can be freed but not reused
         if isinstance(buffer, (ir.InputBuffer, ir.TorchBindObject)):
+            if (
+                config.force_bw_tangent_early_storage_release
+                and V.graph.is_backward
+                and isinstance(buffer, ir.InputBuffer)
+                and name.startswith("tangents")
+            ):
+                self.writeline(
+                    "if not torch._C._autograd._get_current_graph_task_keep_graph():"
+                )
+                self.writeline(f"    {name}.untyped_storage().resize_(0)")
             self.writeline(FreeLine(self, buffer))
             return
 

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -245,6 +245,13 @@ inplace_buffers = True
 # reuse a buffer for an unrelated purpose
 allow_buffer_reuse = True
 
+# In backward graphs, release storage of tangent (grad_output) inputs after
+# their last use via untyped_storage().resize_(0). This frees CUDA memory
+# even when the tangent tensor was provided by the user (e.g. out.backward(t))
+# and Python/C++ references keep the tensor object alive.
+# Skipped at runtime when retain_graph=True.
+force_bw_tangent_early_storage_release = False
+
 # Enable pooled allocations for non-output tensors
 memory_planning = os.environ.get("TORCHINDUCTOR_MEMORY_PLANNING", "0") == "1"
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #177838
* #177837

Add opt-in config to release tangent CUDA storage via resize_(0) after
last use in compiled backward. Needed when the user holds a Python ref
to the tangent (e.g. out.backward(my_tangent)) — the boxed convention
from the previous commit cannot free it in that case.

Skipped at runtime when retain_graph=True.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo