### PR TITLE
[ROCm] Add sequence-length-aware flex attention tile configs for RDNA3

### DIFF
--- a/benchmarks/transformer/score_mod.py
+++ b/benchmarks/transformer/score_mod.py
@@ -737,6 +737,8 @@ def generate_score_mod(attn_type: str, shape: tuple[int, ...]) -> Callable | Non
     def head_bias(score, b, h, m, n):
         return score + 2 * h
 
+    on_cuda = torch.cuda.is_available() and torch.version.hip is None
+
     function_dict = {
         "noop": None,
         "causal": None,
@@ -746,7 +748,8 @@ def generate_score_mod(attn_type: str, shape: tuple[int, ...]) -> Callable | Non
         "sliding_window": None,
         "document_mask": None,
         "prefix_lm": None,
-        "softcap": generate_tanh_softcap(softcap_value, approx=True),
+        # approx=True is only supported by CUDA. It uses inline PTX
+        "softcap": generate_tanh_softcap(softcap_value, approx=on_cuda),
     }
 
     score_mod = function_dict[attn_type]

--- a/torch/_inductor/choices.py
+++ b/torch/_inductor/choices.py
@@ -159,10 +159,14 @@ class InductorChoices:
     # Flex attention configs
     # TODO(coconutruben): break out flexattention/decode configs into the new retrieval mechanism
     def get_flex_attention_fwd_configs(
-        self, head_dim: int, dtype: torch.dtype, device_type: str | None = "cuda"
+        self,
+        head_dim: int,
+        seq_len: sympy.Expr,
+        dtype: torch.dtype,
+        device_type: str | None = "cuda",
     ) -> list[Any]:
         flex_heuristics = self.get_config_heuristics(device_type)
-        return flex_heuristics.get_flex_attn_fwd_configs(head_dim, dtype)
+        return flex_heuristics.get_flex_attn_fwd_configs(head_dim, seq_len, dtype)
 
     def get_flex_attention_bwd_configs(
         self, head_dim: int, dtype: torch.dtype, device_type: str | None = "cuda"

--- a/torch/_inductor/kernel/flex/flex_attention.py
+++ b/torch/_inductor/kernel/flex/flex_attention.py
@@ -436,7 +436,7 @@ def flex_attention(
     dtype = query.get_dtype()
     head_dim = V.graph.sizevars.guard_int(query.get_size()[-1])
     configs: list[FlexConfig] = V.choices.get_flex_attention_fwd_configs(
-        head_dim, dtype, query.get_device().type
+        head_dim, seq_len_q, dtype, query.get_device().type
     )
 
     # Mark SPARSE_KV_BLOCK_SIZE & SPARSE_Q_BLOCK_SIZE as static shapes and add guards.

--- a/torch/_inductor/template_heuristics/triton.py
+++ b/torch/_inductor/template_heuristics/triton.py
@@ -40,6 +40,7 @@ from ..utils import (
     TMA_DESCRIPTOR_SIZE,
     triton_type,
     using_b200,
+    using_rocm_rdna3,
 )
 from ..virtualized import V
 from .gemm import GemmMaxAutotuneTemplateConfigHeuristics
@@ -1181,7 +1182,9 @@ class BaseConfigHeuristic(metaclass=BaseHeuristicSingleton):
         ]
 
     # Flex attn helpers
-    def get_flex_attn_fwd_configs(self, head_dim: int, dtype: Any) -> list[FlexConfig]:
+    def get_flex_attn_fwd_configs(
+        self, head_dim: int, seq_len: sympy.Expr, dtype: Any
+    ) -> list[FlexConfig]:
         flex_attn_fwd_configs: list[FlexConfig] = []
 
         if config.max_autotune:
@@ -1390,7 +1393,9 @@ class CUDAConfigHeuristic(BaseConfigHeuristic):
             if BLOCK_N % BLOCK_M == 0
         ]
 
-    def get_flex_attn_fwd_configs(self, head_dim: int, dtype: Any) -> list[FlexConfig]:
+    def get_flex_attn_fwd_configs(
+        self, head_dim: int, seq_len: sympy.Expr, dtype: Any
+    ) -> list[FlexConfig]:
         capability = torch.cuda.get_device_capability()
         flex_attn_fwd_configs: list[FlexConfig] = []
 
@@ -1654,6 +1659,28 @@ class ROCmConfigHeuristic(BaseConfigHeuristic):
             (torch.float16, 256): ROCmFlexConfig(32, 32, 1, 8, kpack=default_kpack),
         }
 
+        # RDNA3 (gfx11xx) optimal configs profiled on gfx1151 (head_dim=256).
+        # Three seq_len tiers to match CU occupancy on 16-CU RDNA3:
+        #   short  (seq < 128): BLOCK_M=16, tiny tiles keep all CUs busy
+        #   medium (128 <= seq < 512): BLOCK_M=32, transitional tile size
+        #   long   (seq >= 512): BLOCK_M=64, enough seq rows to fill all CUs
+        self.rdna3_short_seq_flex_config = {
+            (torch.bfloat16, 256): ROCmFlexConfig(16, 16, 1, 4, waves_per_eu=2),
+            (torch.float16, 256): ROCmFlexConfig(16, 16, 1, 4, waves_per_eu=2),
+        }
+        self.rdna3_medium_seq_flex_config = {
+            (torch.bfloat16, 256): ROCmFlexConfig(
+                32, 16, 1, 4, matrix_instr_nonkdim=16, waves_per_eu=2
+            ),
+            (torch.float16, 256): ROCmFlexConfig(
+                32, 16, 1, 4, matrix_instr_nonkdim=16, waves_per_eu=2
+            ),
+        }
+        self.rdna3_default_flex_config = {
+            (torch.bfloat16, 256): ROCmFlexConfig(64, 16, 1, 4, waves_per_eu=2),
+            (torch.float16, 256): ROCmFlexConfig(64, 16, 1, 4, waves_per_eu=2),
+        }
+
         self.flex_attn_fwd_autotune_configs: list[FlexConfig] = [
             ROCmFlexConfig(BLOCK1, BLOCK2, 1, w, kpack=default_kpack)
             for BLOCK1 in [16, 64, 128]
@@ -1828,7 +1855,9 @@ class ROCmConfigHeuristic(BaseConfigHeuristic):
                     kwargs["GROUP_M"] = group_m
                 yield self.triton_config(**kwargs)
 
-    def get_flex_attn_fwd_configs(self, head_dim: int, dtype: Any) -> list[FlexConfig]:
+    def get_flex_attn_fwd_configs(
+        self, head_dim: int, seq_len: sympy.Expr, dtype: Any
+    ) -> list[FlexConfig]:
         flex_attn_fwd_configs: list[FlexConfig] = []
 
         if config.max_autotune:
@@ -1844,7 +1873,21 @@ class ROCmConfigHeuristic(BaseConfigHeuristic):
                 default_config = ROCmFlexConfig(64, 64, 1, 4, kpack=default_kpack)
             else:
                 default_config = ROCmFlexConfig(128, 64, 1, 4, kpack=default_kpack)
-            if capability >= (9, 5):  # gfx950 (MI350X/MI355X)
+            if using_rocm_rdna3():
+                sizevars = V.graph.sizevars
+                if sizevars.statically_known_lt(seq_len, 128):
+                    default_config = self.rdna3_short_seq_flex_config.get(
+                        (dtype, head_dim), default_config
+                    )
+                elif sizevars.statically_known_lt(seq_len, 512):
+                    default_config = self.rdna3_medium_seq_flex_config.get(
+                        (dtype, head_dim), default_config
+                    )
+                else:
+                    default_config = self.rdna3_default_flex_config.get(
+                        (dtype, head_dim), default_config
+                    )
+            elif capability >= (9, 5):  # gfx950 (MI350X/MI355X)
                 default_config = self.gfx950_default_flex_config.get(
                     (dtype, head_dim), default_config
                 )
@@ -1976,7 +2019,9 @@ class XPUConfigHeuristic(BaseConfigHeuristic):
                 FlexDecodeConfig(64, 2, 1),
             ]
 
-    def get_flex_attn_fwd_configs(self, head_dim: int, dtype: Any) -> list[FlexConfig]:
+    def get_flex_attn_fwd_configs(
+        self, head_dim: int, seq_len: sympy.Expr, dtype: Any
+    ) -> list[FlexConfig]:
         flex_attn_fwd_configs: list[FlexConfig] = []
 
         if config.max_autotune:

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -2692,6 +2692,14 @@ def _rocm_native_device_arch_name(device: str) -> str:
     return torch.cuda.get_device_properties(device).gcnArchName
 
 
+@functools.lru_cache
+def using_rocm_rdna3() -> bool:
+    """Returns true if the device is based on RDNA3, otherwise returns false."""
+    return torch.cuda.is_available() and _rocm_native_device_arch_name(
+        "cuda"
+    ).startswith("gfx11")
+
+
 @functools.cache
 def try_import_ck_lib() -> tuple[
     str | None, Callable[[], list[Any]], Callable[[], list[Any]], type[Any]


### PR DESCRIPTION
## Summary

- **Plumbs `seq_len_q` through the flex attention forward config pipeline.**
  `flex_attention.py` now passes `seq_len_q` -> `choices.get_flex_attention_fwd_configs` -> each backend's `get_flex_attn_fwd_configs`. CUDA and XPU accept the new parameter but do not use it; ROCm uses it to select architecture-specific tile sizes.

- **Adds sequence-length-tiered default configs for RDNA3 (gfx11xx) GPUs.**
  Three BLOCK_M tiers (16 / 32 / 64), profiled on gfx1151 (head_dim=256, bf16/fp16), scale tile sizes to CU occupancy on RDNA3 parts. When `seq_len` is not statically known the largest tile (BLOCK_M=64) is used as a safe default.

- **Adds `using_rocm_rdna3()` cached utility** in `torch/_inductor/utils.py` that returns `True` when the device GCN arch name starts with `gfx11`.

- **Classifies sequence length with `V.graph.sizevars.statically_known_lt`** (guard-free) to select the tier, so a symbolic-but-static length is handled correctly and a genuinely dynamic length falls through to the largest tile. The forward-config signatures are typed `seq_len: sympy.Expr` rather than `Any`.

## Results (gfx1151)
seq len | Before (us) | After (us) | Speedup
-- | -- | -- | --
50 | 27 | 27 | 1x
100 | 71 | 29 | 2.4x
286 | 247 | 65 | 3.8x
336 | 461 | 85 | 5.4x
512 | 670 | 141 | 4.8x
1024 | 2,602 | 510 | 5.1x
2048 | 9,616 | 2,067 | 4.7x
4096 | 38,157 | 8,348 | 4.6x



cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben