### PR TITLE
Preserve requires_grad on AOTAutograd saved inputs

### DIFF
--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -3003,7 +3003,11 @@ def forward(self, add, tangents_1):
         def mm_fwd_fake(input, weight):
             return torch.matmul(input, weight)
 
-        @torch.library.custom_op("_test::mm_bwd_163716", mutates_args=())
+        @torch.library.custom_op(
+            "_test::mm_bwd_163716",
+            mutates_args=(),
+            schema="(Tensor grad_output, Tensor input, Tensor weight) -> (Tensor, Tensor?)",
+        )
         def mm_bwd(
             grad_output: torch.Tensor,
             input: torch.Tensor,
@@ -3037,7 +3041,13 @@ def forward(self, add, tangents_1):
 
         def bw_compiler(gm, example_inputs):
             nonlocal seen_bw_requires_grad
-            seen_bw_requires_grad = example_inputs[1].requires_grad
+            saved_weight, = [
+                example_input
+                for example_input in example_inputs
+                if isinstance(example_input, torch.Tensor)
+                and tuple(example_input.shape) == tuple(weight.shape)
+            ]
+            seen_bw_requires_grad = saved_weight.requires_grad
             return gm.forward
 
         def fn(input, weight):

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -2994,6 +2994,67 @@ def forward(self, add, tangents_1):
             torch.autograd.grad(loss, inp_x, create_graph=True)
         # Not checking equality of ref and x as Exception is expected
 
+    def test_custom_op_backward_fake_preserves_requires_grad(self):
+        @torch.library.custom_op("_test::mm_fwd_163716", mutates_args=())
+        def mm_fwd(input: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
+            return torch.matmul(input, weight)
+
+        @mm_fwd.register_fake
+        def mm_fwd_fake(input, weight):
+            return torch.matmul(input, weight)
+
+        @torch.library.custom_op("_test::mm_bwd_163716", mutates_args=())
+        def mm_bwd(
+            grad_output: torch.Tensor,
+            input: torch.Tensor,
+            weight: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor | None]:
+            grad_weight = (
+                torch.matmul(input.mT, grad_output) if weight.requires_grad else None
+            )
+            grad_input = torch.matmul(grad_output, weight.mT)
+            return grad_input, grad_weight
+
+        @mm_bwd.register_fake
+        def mm_bwd_fake(grad_output, input, weight):
+            grad_weight = (
+                torch.matmul(input.mT, grad_output) if weight.requires_grad else None
+            )
+            grad_input = torch.matmul(grad_output, weight.mT)
+            return grad_input, grad_weight
+
+        def backward(ctx, grad_output):
+            input, weight = ctx.saved_tensors
+            return mm_bwd(grad_output, input, weight)
+
+        def setup_context(ctx, inputs, output):
+            input, weight = inputs
+            ctx.save_for_backward(input, weight)
+
+        mm_fwd.register_autograd(backward, setup_context=setup_context)
+
+        seen_bw_requires_grad = None
+
+        def bw_compiler(gm, example_inputs):
+            nonlocal seen_bw_requires_grad
+            seen_bw_requires_grad = example_inputs[1].requires_grad
+            return gm.forward
+
+        def fn(input, weight):
+            return mm_fwd(input, weight)
+
+        compiled_fn = aot_function(fn, nop, bw_compiler=bw_compiler)
+
+        input = torch.randn(16, 8)
+        weight = torch.randn(8, 4, requires_grad=True)
+        ref_weight = weight.detach().clone().requires_grad_(True)
+
+        compiled_fn(input, weight).sum().backward()
+        fn(input, ref_weight).sum().backward()
+
+        self.assertTrue(seen_bw_requires_grad)
+        self.assertEqual(weight.grad, ref_weight.grad)
+
     # Partially addresses https://github.com/pytorch/pytorch/issues/106457
     def test_input_mutation_false_aliasing(self):
         def f(a, b):

--- a/torch/_functorch/_aot_autograd/graph_capture.py
+++ b/torch/_functorch/_aot_autograd/graph_capture.py
@@ -12,7 +12,7 @@ import torch
 import torch.utils._pytree as pytree
 import torch.utils.dlpack
 from torch._dispatch.python import enable_python_dispatcher
-from torch._dynamo.utils import detect_fake_mode, lazy_format_graph_code
+from torch._dynamo.utils import lazy_format_graph_code
 from torch._logging import getArtifactLogger, trace_structured
 from torch._subclasses.functional_tensor import FunctionalTensorMode
 from torch.fx.experimental.proxy_tensor import make_fx
@@ -185,6 +185,7 @@ def _create_graph(
 # TODO: Refactor the following code so detach() persists item_memo
 def _detach_and_copy_item_memo(t: torch.Tensor) -> torch.Tensor:
     detached_t = t.detach()
+    detached_t.requires_grad_(t.requires_grad)
     if hasattr(t, "item_memo"):
         # pyrefly: ignore[missing-attribute]
         detached_t.item_memo = t.item_memo
@@ -278,17 +279,11 @@ def aot_dispatch_base_graph(
             mod_when_exporting_non_strict, assigned_buffers
         )
 
-    fake_mode = detect_fake_mode()
-    if fake_mode:
-        saved_updated_flat_args_subclasses_desugared = pytree.tree_map_only(
-            torch.Tensor,
-            _detach_and_copy_item_memo,
-            updated_flat_args_subclasses_desugared,
-        )
-    else:
-        saved_updated_flat_args_subclasses_desugared = pytree.tree_map_only(
-            torch.Tensor, lambda t: t.detach(), updated_flat_args_subclasses_desugared
-        )
+    saved_updated_flat_args_subclasses_desugared = pytree.tree_map_only(
+        torch.Tensor,
+        _detach_and_copy_item_memo,
+        updated_flat_args_subclasses_desugared,
+    )
     saved_updated_flat_args_subclasses_desugared_descs = (
         updated_flat_args_subclasses_desugared_descs
     )
@@ -498,19 +493,11 @@ def aot_dispatch_autograd_graph(
     # we make aliases of all the inputs to make sure we have a copy that
     # doesn't get modified.
     #
-    # This destroys requires_grad/grad_fn information.  However, backends
-    # beneath AOTAutograd are indifferent to this information, so it doesn't
-    # matter.
-
-    fake_mode = detect_fake_mode()
-    if fake_mode:
-        saved_updated_joint_inputs = pytree.tree_map_only(
-            torch.Tensor, _detach_and_copy_item_memo, updated_joint_inputs
-        )
-    else:
-        saved_updated_joint_inputs = pytree.tree_map_only(
-            torch.Tensor, lambda t: t.detach(), updated_joint_inputs
-        )
+    # This still drops grad_fn information, but preserves requires_grad for
+    # later compiler passes that branch on it (for example, custom op fake impls).
+    saved_updated_joint_inputs = pytree.tree_map_only(
+        torch.Tensor, _detach_and_copy_item_memo, updated_joint_inputs
+    )
     maybe_subclass_meta = subclass_tracing_info.maybe_subclass_meta
 
     fx_g = _create_graph(


### PR DESCRIPTION
Fix #163716

## Root cause
AOTAutograd detached the saved example inputs that it later hands to downstream compilers. That dropped `requires_grad`, so backward custom-op fake implementations could see `False` for parameter inputs that still required grad.

## Proposed fix
Preserve `requires_grad` when building those detached saved inputs, and add a regression in `test_aotdispatch` that asserts the backward compiler still sees `requires_grad=True` for the weight input.

## Why this is the right long term fix
These saved tensors are only aliases used for later compilation, so they should still drop `grad_fn`, but they need to retain semantic metadata that backends and fake implementations branch on. Preserving `requires_grad` at this handoff fixes the custom-op failure without changing the traced graph structure.

Drafted via Codex, published after manual review by @bobrenjc93