### PR TITLE
[xpu] Add conv3d tolerance override for TestCompositeCompliance::test_backward UT.

### DIFF
--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -16236,6 +16236,10 @@ op_db: list[OpInfo] = [
                    'TestCompositeCompliance', 'test_backward', device_type="cuda"
                ),
                DecorateInfo(
+                   toleranceOverride({torch.float32: tol(atol=5e-5, rtol=5e-5)}),
+                   'TestCompositeCompliance', 'test_backward', device_type="xpu"
+               ),
+               DecorateInfo(
                    toleranceOverride({torch.float16: tol(atol=5e-3, rtol=1e-3)}),
                    'TestInductorOpInfo', 'test_comprehensive',
                ),


### PR DESCRIPTION
Fix for https://github.com/intel/torch-xpu-ops/issues/3103

This PR fixes 1 XPU test case:
- op_ut,third_party.torch-xpu-ops.test.xpu.test_ops_xpu.TestCompositeComplianceXPU,test_backward_nn_functional_conv3d_xpu_float32

### Note

This change is very similar to https://github.com/pytorch/pytorch/pull/177069 and the root cause is the same.
It touches the same operator but not in the `functorch` test scope.

Please let me know if I should merge those two PRs or leave them separate.

## Root Cause

This failure comes from comparing two XPU computations that follow different execution paths inside composite compliance backward validation:

The baseline gradients are computed first.
Then gradients are recomputed with wrapped tensor-subclass inputs in composite compliance mode.
The results are compared for closeness.
For nn.functional.conv3d on XPU, both paths rely on oneDNN convolution kernels, which are non-deterministic by default. Because conv3d is accumulation-heavy, this non-determinism can produce small numeric drift between runs of the same kernel with identical inputs. In composite backward checks, this drift is enough to fail strict tolerances even though the implementation is functionally correct.

As a sanity check, I forced deterministic oneDNN convolution behavior. That made the test pass every time. So basically the difference we observe comes from non-deterministic oneDNN behavior, where even for identical inputs, it produces slightly different results.

## Proposed solution

Relax tolerance for this specific test target by adding an XPU-specific override in conv3d OpInfo decorators.
CUDA also have precision override for this test case. Proposed override introduces same `atol` value as for CUDA but bigger `rtol` value for XPU.


### Why this approach

Making oneDNN conv deterministic would impact performance due to oneDNN [DOCUMENTATION](https://www.intel.com/content/www/us/en/docs/onednn/developer-guide-reference/2024-1/primitive-attributes-deterministic.html)
This fix is scoped to one flaky validation surface and one device/test combination while preserving the oneDNN conv3d optimized performance on XPU devices.
