### PR TITLE
[Inductor] Run first cudagraph warmup in eager pool (#177854)

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -551,6 +551,9 @@ test_inductor_shard() {
     --include inductor/test_torchinductor inductor/test_torchinductor_opinfo inductor/test_aot_inductor \
     --shard "$1" "$NUM_TEST_SHARDS" \
     --verbose
+
+  TORCHINDUCTOR_CUDAGRAPH_FIRST_WARMUP_IN_EAGER=1 python test/run_test.py \
+    --include inductor/test_cudagraph_trees
 }
 
 test_inductor_aoti_cpp() {

--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -212,7 +212,14 @@ if HAS_CUDA_AND_TRITON:
             )
 
         @staticmethod
+        def prime(fn, *args, **kwargs):
+            """Run fn once to complete the eager-pool warmup when enabled."""
+            if config.triton.cudagraph_first_warmup_in_eager:
+                fn(*args, **kwargs)
+
+        @staticmethod
         def run_twc(fn, *args, **kwargs):
+            CudaGraphTreeTests.prime(fn, *args, **kwargs)
             fn(*args, **kwargs)
             return fn(*args, **kwargs)
 
@@ -276,8 +283,10 @@ if HAS_CUDA_AND_TRITON:
             log_stream, ctx = logs_to_string(
                 "torch._inductor.cudagraph_utils", "cudagraphs"
             )
+            compiled = torch.compile(model.forward, mode="reduce-overhead")
             with ctx():
-                opt = torch.compile(model.forward, mode="reduce-overhead")(x, y, z)
+                self.prime(compiled, x, y, z)
+                opt = compiled(x, y, z)
 
             FileCheck().check(
                 "skipping cudagraphs due to mutated inputs (1 instances). Found from"
@@ -360,6 +369,7 @@ if HAS_CUDA_AND_TRITON:
             def inp():
                 return torch.ones([10], device="cuda")
 
+            self.prime(foo, inp())
             log_stream, ctx = logs_to_string(
                 "torch._inductor.cudagraph_utils", "cudagraphs"
             )
@@ -449,6 +459,13 @@ if HAS_CUDA_AND_TRITON:
 
             mut = get_compile_fn(backend)(mut)
             foo = get_compile_fn(backend)(foo)
+
+            if config.triton.cudagraph_first_warmup_in_eager:
+                # Prime past the first eager warmup
+                torch.compiler.cudagraph_mark_step_begin()
+                _tmp = foo(torch.rand([4], device="cuda"))
+                mut(_tmp)
+                del _tmp
 
             log_stream, ctx = logs_to_string(
                 "torch._inductor.cudagraph_utils", "cudagraphs"
@@ -797,6 +814,7 @@ if HAS_CUDA_AND_TRITON:
 
             inp.add_(1)
             out_eager = foo(inp)
+            self.prime(foo_opt, inp)
             out_warmup = foo_opt(inp)
             self.assertEqual(out_warmup, out_eager)
             # warmup should be have storage deallocator hooked on
@@ -1578,6 +1596,14 @@ if HAS_CUDA_AND_TRITON:
                 return x[2:]
 
             param_c = cdata(m.weight)
+            if config.triton.cudagraph_first_warmup_in_eager:
+                x = torch.rand([10, 10], device="cuda", requires_grad=True)
+                torch.compiler.cudagraph_mark_step_begin()
+                out1, _, _ = foo(m, x)
+                foo2(out1).sum().backward()
+                m.weight.grad = None
+                m.bias.grad = None
+
             for _ in range(3):
                 x = torch.rand([10, 10], device="cuda", requires_grad=True)
                 torch.compiler.cudagraph_mark_step_begin()
@@ -1650,6 +1676,10 @@ if HAS_CUDA_AND_TRITON:
             def foo2(x):
                 return x[0], x @ x
 
+            if config.triton.cudagraph_first_warmup_in_eager:
+                out = foo(inp())
+                _, _ = foo2(out)
+
             for i in range(2):
                 out = foo(inp())
 
@@ -1682,6 +1712,8 @@ if HAS_CUDA_AND_TRITON:
                 return (x[0],)
 
             foo_cg = self.cudagraphify_impl(foo, [inp], (0,))
+            if config.triton.cudagraph_first_warmup_in_eager:
+                foo_cg([inp])
 
             for _ in range(3):
                 out = foo_cg([inp])[0]
@@ -1859,6 +1891,8 @@ if HAS_CUDA_AND_TRITON:
                 return (x, x[0])
 
             foo_cg = self.cudagraphify_impl(foo, [inp], ())
+            if config.triton.cudagraph_first_warmup_in_eager:
+                foo_cg([inp])
 
             for _ in range(3):
                 out_1, out_2 = foo_cg([inp])
@@ -1878,6 +1912,7 @@ if HAS_CUDA_AND_TRITON:
                 )
 
             inp = torch.rand([4], device="cuda")
+            self.prime(foo, inp)
             for _ in range(3):
                 out = foo(inp)
                 node = self.curr_node()
@@ -1888,6 +1923,7 @@ if HAS_CUDA_AND_TRITON:
                 return (x + x + x), torch.rand([4], device="cuda") + 10
 
             inp = torch.rand([0], device="cuda")
+            self.prime(foo, inp)
             for _ in range(3):
                 out = foo(inp)
                 node = self.curr_node()
@@ -1947,6 +1983,7 @@ if HAS_CUDA_AND_TRITON:
                     return x @ x
 
                 inps = [torch.rand([400, 400], device="cuda") for _ in range(2)]
+                self.prime(foo, *inps)
 
                 thrown = False
                 try:
@@ -1975,15 +2012,19 @@ if HAS_CUDA_AND_TRITON:
             finally:
                 torch._C._cuda_clearCublasWorkspaces()
                 torch._inductor.cudagraph_trees.clear_cublas_manager = prev
-                torch._inductor.cudagraph_trees.get_container(
+                container = torch._inductor.cudagraph_trees.get_container(
                     self.device_idx
-                ).tree_manager = None
+                )
+                if container.tree_manager is not None:
+                    container.tree_manager.shutdown()
+                container.tree_manager = None
 
         def test_peristed_output_livenes(self):
             @torch.compile
             def foo(x):
                 return x + x
 
+            self.prime(foo, torch.rand([2, 2], device="cuda"))
             for _ in range(3):
                 foo(torch.rand([2, 2], device="cuda"))
 
@@ -2280,6 +2321,7 @@ if HAS_CUDA_AND_TRITON:
                 return x * x * x
 
             inp = torch.rand([4], device="cuda")
+            self.prime(foo, inp)
             out = foo(inp)
             out2 = foo(inp)
 
@@ -2297,6 +2339,7 @@ if HAS_CUDA_AND_TRITON:
                 return x * x * x
 
             inp = torch.rand([4], device="cuda")
+            self.prime(foo, inp)
             out = foo(inp).detach()
             out2 = foo(inp).detach()
 
@@ -2329,6 +2372,7 @@ if HAS_CUDA_AND_TRITON:
                     return x * x * x
 
                 inp = torch.rand([4], device="cuda")
+                self.prime(foo, inp)
                 out = foo(inp).detach()
                 out2 = foo(inp).detach()
 
@@ -2444,13 +2488,15 @@ if HAS_CUDA_AND_TRITON:
                 COUNTER += 1
                 return x * 2
 
+            extra = 1 if config.triton.cudagraph_first_warmup_in_eager else 0
+
             x = torch.randn(2, device="cuda")
             inp_list = [2, x]
             foo_cg = self.cudagraphify_impl(f, inp_list, ())
             foo_cg(inp_list)  # warmup
             foo_cg([2, x])  # record
             foo_cg([2, x])  # replay
-            self.assertEqual(COUNTER, 2)
+            self.assertEqual(COUNTER, 2 + extra)
 
             # Switching the size will require a warmup again
             x = torch.randn(3, device="cuda")
@@ -2458,7 +2504,7 @@ if HAS_CUDA_AND_TRITON:
             foo_cg(inp_list)  # warmup
             foo_cg([3, x])  # record
             foo_cg([3, x])  # replay
-            self.assertEqual(COUNTER, 4)
+            self.assertEqual(COUNTER, 4 + 2 * extra)
 
         def test_forward_generation(self):
             def foo(x):
@@ -2470,6 +2516,10 @@ if HAS_CUDA_AND_TRITON:
             foo_opt = torch.compile(foo)
             foo2_opt = torch.compile(foo2)
             ones = torch.ones([4, 4], device="cuda", requires_grad=True)
+
+            if config.triton.cudagraph_first_warmup_in_eager:
+                foo2_opt(foo_opt(ones)).sum().backward()
+                ones.grad = None
 
             out = foo_opt(ones)
             out2 = foo2_opt(out)
@@ -2496,6 +2546,8 @@ if HAS_CUDA_AND_TRITON:
             def foo(x):
                 return x * x * x
 
+            self.prime(foo, torch.rand([4, 4], device="cuda", requires_grad=True))
+
             out = foo(torch.rand([4, 4], device="cuda", requires_grad=True))
             out = foo(torch.rand([4, 4], device="cuda", requires_grad=True))
 
@@ -2512,6 +2564,8 @@ if HAS_CUDA_AND_TRITON:
             @torch.compile
             def foo(x):
                 return x * x * x
+
+            self.prime(foo, torch.rand([4, 4], device="cuda", requires_grad=True))
 
             torch.compiler.cudagraph_mark_step_begin()
             out = foo(torch.rand([4, 4], device="cuda", requires_grad=True))
@@ -3207,7 +3261,8 @@ if HAS_CUDA_AND_TRITON:
 
             inp = torch.randn(4, 4, device="cuda")
             compiled = torch.compile(model, mode="reduce-overhead")
-            # Warmup + record
+            # Prime + warmup + record
+            self.prime(compiled, inp)
             out = compiled(inp)
             out = compiled(inp)
 
@@ -3235,6 +3290,7 @@ if HAS_CUDA_AND_TRITON:
 
             inp = torch.randn(4, 4, device="cuda")
             compiled = torch.compile(model, mode="reduce-overhead")
+            self.prime(compiled, inp)
             out = compiled(inp)
             out = compiled(inp)
 
@@ -3283,6 +3339,7 @@ if HAS_CUDA_AND_TRITON:
 
             inp = torch.randn(4, 4, device="cuda")
             compiled = torch.compile(model, mode="reduce-overhead")
+            self.prime(compiled, inp)
             out = compiled(inp)
             out = compiled(inp)
 
@@ -5120,12 +5177,12 @@ if HAS_CUDA_AND_TRITON:
             def foo(x, y):
                 # partition 1
                 output1 = torch.empty_like(x)
-                add_kernel[(4,)](x, y, output1, n_elements=128, BLOCK_SIZE=16)
+                add_kernel[(8,)](x, y, output1, n_elements=128, BLOCK_SIZE=16)
                 output1_cpu = output1.cpu() + 1
                 # partition 2 should reuse the user-defined kernel
                 x2 = output1_cpu.to("cuda")
                 output2 = torch.empty_like(x)
-                add_kernel[(4,)](x2, y, output2, n_elements=128, BLOCK_SIZE=16)
+                add_kernel[(8,)](x2, y, output2, n_elements=128, BLOCK_SIZE=16)
                 return output1, output2
 
             compiled_foo = torch.compile(foo)
@@ -5239,6 +5296,7 @@ if HAS_CUDA_AND_TRITON:
 
             f = torch.compile(f, mode="reduce-overhead")
 
+            self.prime(f, torch.tensor(1, device="cuda"))
             with self.assertRaises(RuntimeError):
                 f(torch.tensor(1, device="cuda"))
 
@@ -5296,6 +5354,33 @@ if HAS_CUDA_AND_TRITON:
             run(20)
             run(10)
             run(25)
+
+        @torch._inductor.config.patch("triton.cudagraph_first_warmup_in_eager", True)
+        def test_lazy_init_persistent_state_survives_generation_change(self):
+            """Lazily-initialised persistent state (e.g. KV cache) allocated during
+            warmup must survive generation changes.  Without the eager-pool first
+            warmup, the cache lives in the private cudagraph pool and gets poisoned
+            when dealloc_current_path_weakrefs runs on a new generation."""
+
+            class LazyBuffer(nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    self.buf = None
+
+                def forward(self, x):
+                    if self.buf is None:
+                        # Lazy init: allocated on first forward call
+                        self.buf = torch.zeros(x.shape, device=x.device)
+                    return x + self.buf
+
+            model = LazyBuffer().cuda()
+            compiled = torch.compile(model, mode="reduce-overhead")
+            inp = torch.randn(4, 4, device="cuda")
+
+            # Progress through: eager warmup -> warmup -> record -> replay
+            for _ in range(4):
+                torch.compiler.cudagraph_mark_step_begin()
+                compiled(inp)
 
     class TestSAC(TestCase):
         def _make_observer_mode(self):

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1638,6 +1638,12 @@ class triton:
     # skip warmup for cudagraph trees
     skip_cudagraph_warmup = False
 
+    # Run the first cudagraph warmup in the eager (default) memory pool so
+    # lazily-initialized persistent state isn't allocated in the private pool.
+    cudagraph_first_warmup_in_eager = (
+        os.environ.get("TORCHINDUCTOR_CUDAGRAPH_FIRST_WARMUP_IN_EAGER", "0") == "1"
+    )
+
     # Synchronize before and after every compiled graph.
     debug_sync_graph = False
 

--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -2012,6 +2012,7 @@ class CUDAGraphTreeManager:
         self.ids_to_stack_traces: dict[FunctionID, StackTraces | None] = {}
 
         self.warmed_up_functions: OrderedSet[FunctionID] = OrderedSet()
+        self.eager_warmed_functions: OrderedSet[FunctionID] = OrderedSet()
         # if we fail to increment generation, and are stuck warming up,
         # only warn on each function once
         self.warned_functions: OrderedSet[FunctionID] = OrderedSet()
@@ -2178,6 +2179,19 @@ class CUDAGraphTreeManager:
         )
 
     def _run(self, new_inputs: list[InputType], function_id: FunctionID) -> OutputType:
+        # Bypass the manager entirely on the first call when
+        # cudagraph_first_warmup_in_eager is enabled.  This runs the model in
+        # the default memory pool so lazily-initialised persistent state
+        # (KV caches etc.) isn't allocated in the cudagraph private pool.
+        if (
+            function_id not in self.warmed_up_functions
+            and function_id not in self.eager_warmed_functions
+            and config.triton.cudagraph_first_warmup_in_eager
+            and not config.triton.skip_cudagraph_warmup
+        ):
+            self.eager_warmed_functions.add(function_id)
+            return self.ids_to_funcs[function_id].model(new_inputs)
+
         # we will try to end the current execution lazily, since
         # we dont want to do unnecessary checking of the existing outputs
         # on the hot path, but both recording and warmup only happen once
@@ -2315,6 +2329,9 @@ class CUDAGraphTreeManager:
         might reference a backward which invokes a CUDA Graph Node, we have to manually clear them on shutdown
         to avoid a reference cycle.
         """
+        if self.roots is None:
+            return
+
         nodes = []
         for roots in self.roots.values():
             nodes.extend(roots)


### PR DESCRIPTION
Summary:

Models that lazily initialize persistent state (e.g. KV caches) during
cudagraph warmup allocate those tensors in the cudagraph private pool.
On generation changes, dealloc_current_path_weakrefs() frees and poisons
them, causing "tensor output of CUDAGraphs has been overwritten" errors.

Fix: when `cudagraph_first_warmup_in_eager` is enabled,
CUDAGraphTreeManager directly calls `model(inputs)` for the first iteration,
completely skipping later node management.

Lifecycle without flag: warmup → record → execute
Lifecycle with flag: direct model (no state) → warmup (private pool) → record → execute

Differential Revision: D96920651


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo