### PR TITLE
[inductor] Preserve cat input reads across index_put mutation

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -8975,6 +8975,22 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         self.common(fn, (a, idx))
         assertGeneratedKernelCountEqual(self, 1)
 
+    def test_index_put_after_cat_preserves_cat_input(self):
+        # https://github.com/pytorch/pytorch/issues/177821
+        def fn(x, y):
+            x = 2 * x
+            c = torch.cat([x, y], dim=1)
+            c[:, [1, 0]] = c[:, [0, 1]]
+            return c[:, :2] + x
+
+        self.common(
+            fn,
+            (
+                torch.arange(4, device=self.device).reshape(2, 2),
+                torch.arange(4, device=self.device).reshape(2, 2),
+            ),
+        )
+
     def test_index_put_failed_reinplace(self):
         def fn(x, idx):
             src = torch.ones(idx.size(0), device=x.device)

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -471,6 +471,7 @@ class GraphLowering(torch.fx.Interpreter):
         self.mutated_input_idxs: list[int] = []
         self.name_to_buffer: dict[str, ir.Buffer] = {}
         self.name_to_users: defaultdict[str, list[ir.IRNode]] = defaultdict(list)
+        self.name_to_aliases: defaultdict[str, list[ir.StorageBox]] = defaultdict(list)
         self.name_to_op: dict[str, ir.Operation] = {}
         self.creation_time = time.time()
         self.name = name  # type: ignore[assignment]
@@ -1076,12 +1077,46 @@ class GraphLowering(torch.fx.Interpreter):
 
         register(node_output)
 
+    def register_buffer_alias(self, name: str, box: ir.StorageBox) -> None:
+        aliases = self.name_to_aliases[name]
+        if not any(existing is box for existing in aliases):
+            aliases.append(box)
+
+    def detach_buffer_aliases(self, name: str) -> None:
+        if name not in self.name_to_aliases:
+            return
+
+        for alias_box in self.name_to_aliases[name]:
+            alias_buffer = alias_box.data
+            if not isinstance(alias_buffer, ir.Buffer):
+                continue
+            if not isinstance(alias_buffer.layout, ir.NonOwningLayout):
+                continue
+            if name not in alias_buffer.get_inputs_that_alias_output():
+                continue
+
+            device = alias_buffer.get_device()
+            assert device is not None
+            detached = ir.Pointwise.create(
+                device=device,
+                dtype=alias_buffer.get_dtype(),
+                inner_fn=alias_buffer.make_loader(),
+                ranges=alias_buffer.get_size(),
+                origin_node=alias_buffer.get_origin_node(),
+                traceback=alias_buffer.get_traceback(),
+            )
+            detached.realize()
+            assert isinstance(detached.data, ir.StorageBox), type(detached.data)
+            assert isinstance(detached.data.data, ir.Buffer), type(detached.data.data)
+            alias_box.data = detached.data.data
+
     def mark_buffer_mutated(self, name: str) -> None:
         """
         When a buffer is mutated we need to make sure all the reads to
         the old version are realized before the mutation happens.
         """
         assert isinstance(name, str)
+        self.detach_buffer_aliases(name)
         self.mutated_buffers.add(name)
 
         if name not in self.name_to_users:

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -4679,6 +4679,8 @@ class Buffer(IRNode, CodegenSymbol):
         return ()
 
     def get_read_names(self) -> OrderedSet[str]:
+        if isinstance(self.layout, NonOwningLayout):
+            return OrderedSet([self.layout.view.get_name()])
         return OrderedSet([self.get_name()])
 
     @cache_on_self_and_args("Buffer")
@@ -6136,6 +6138,7 @@ class ConcatKernel(NopKernel):
             if cls.can_realize_into_without_copy(src, dst):
                 # pyrefly: ignore [missing-attribute]
                 src.data.layout = NonOwningLayout(dst)
+                V.graph.register_buffer_alias(dst.get_name(), src)
                 return src.data
         # introduce a copy
         pw = Pointwise.create(

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -4652,7 +4652,13 @@ class Buffer(IRNode, CodegenSymbol):
 
         def loader(index: Sequence[Expr]) -> OpsValue:
             indexer = self.make_indexer()
-            return ops.load(self.name or "unnamed", indexer(index))
+            load_name = self.name or "unnamed"
+            if isinstance(self.layout, NonOwningLayout):
+                # NonOwningLayout is an alias into another buffer. Loading from the
+                # underlying storage keeps mutation dependencies attached to the
+                # aliased buffer instead of hiding them behind this alias name.
+                load_name = self.layout.view.get_name()
+            return ops.load(load_name, indexer(index))
 
         return loader
 


### PR DESCRIPTION
@/tmp/repos/pytorch_pr_177821_body.md

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo