### PR TITLE
Fix Inductor bmm mixed-dtype error handling

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -4214,9 +4214,7 @@ class CommonTemplate:
             return torch.bmm(a, b)
 
         lowp_dtype = (
-            torch.float16
-            if self.is_dtype_supported(torch.float16)
-            else torch.bfloat16
+            torch.float16 if self.is_dtype_supported(torch.float16) else torch.bfloat16
         )
         if not self.is_dtype_supported(lowp_dtype):
             raise unittest.SkipTest("requires float16 or bfloat16 support")
@@ -4224,11 +4222,15 @@ class CommonTemplate:
         t1 = torch.randn((2, 3, 4), dtype=lowp_dtype, device=self.device)
         t2 = torch.randn((2, 4, 5), dtype=torch.float32, device=self.device)
 
-        msg = "expected .* and .* to have the same dtype, but got: .* != .*"
+        msg = (
+            "expected scalar type .* but found .*|"
+            "expected .* and .* to have the same dtype, but got: .* != .*|"
+            "batch1 and batch2 must have the same dtype"
+        )
         with self.assertRaisesRegex(RuntimeError, msg):
             fn(t1, t2)
         if config.cpp_wrapper:
-            msg = f"({msg})|(aoti_torch_.* API call failed at .*)"
+            msg = f"(?:{msg})|(aoti_torch_.* API call failed at .*)"
         with self.assertRaisesRegex(RuntimeError, msg):
             torch.compile(fn)(t1, t2)
 
@@ -4237,9 +4239,7 @@ class CommonTemplate:
             return torch.matmul(a, b)
 
         lowp_dtype = (
-            torch.float16
-            if self.is_dtype_supported(torch.float16)
-            else torch.bfloat16
+            torch.float16 if self.is_dtype_supported(torch.float16) else torch.bfloat16
         )
         if not self.is_dtype_supported(lowp_dtype):
             raise unittest.SkipTest("requires float16 or bfloat16 support")
@@ -4247,11 +4247,15 @@ class CommonTemplate:
         t1 = torch.randn((2, 3, 4, 5), dtype=lowp_dtype, device=self.device)
         t2 = torch.randn((2, 3, 5, 6), dtype=torch.float32, device=self.device)
 
-        msg = "expected .* and .* to have the same dtype, but got: .* != .*"
+        msg = (
+            "expected scalar type .* but found .*|"
+            "expected .* and .* to have the same dtype, but got: .* != .*|"
+            "batch1 and batch2 must have the same dtype"
+        )
         with self.assertRaisesRegex(RuntimeError, msg):
             fn(t1, t2)
         if config.cpp_wrapper:
-            msg = f"({msg})|(aoti_torch_.* API call failed at .*)"
+            msg = f"(?:{msg})|(aoti_torch_.* API call failed at .*)"
         with self.assertRaisesRegex(RuntimeError, msg):
             torch.compile(fn)(t1, t2)
 

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -4209,6 +4209,52 @@ class CommonTemplate:
         with self.assertRaisesRegex(RuntimeError, msg):
             torch.compile(fn)(t1, t2)
 
+    def test_bmm_mixed_dtype(self):
+        def fn(a, b):
+            return torch.bmm(a, b)
+
+        lowp_dtype = (
+            torch.float16
+            if self.is_dtype_supported(torch.float16)
+            else torch.bfloat16
+        )
+        if not self.is_dtype_supported(lowp_dtype):
+            raise unittest.SkipTest("requires float16 or bfloat16 support")
+
+        t1 = torch.randn((2, 3, 4), dtype=lowp_dtype, device=self.device)
+        t2 = torch.randn((2, 4, 5), dtype=torch.float32, device=self.device)
+
+        msg = "expected .* and .* to have the same dtype, but got: .* != .*"
+        with self.assertRaisesRegex(RuntimeError, msg):
+            fn(t1, t2)
+        if config.cpp_wrapper:
+            msg = f"({msg})|(aoti_torch_.* API call failed at .*)"
+        with self.assertRaisesRegex(RuntimeError, msg):
+            torch.compile(fn)(t1, t2)
+
+    def test_matmul_batched_mixed_dtype(self):
+        def fn(a, b):
+            return torch.matmul(a, b)
+
+        lowp_dtype = (
+            torch.float16
+            if self.is_dtype_supported(torch.float16)
+            else torch.bfloat16
+        )
+        if not self.is_dtype_supported(lowp_dtype):
+            raise unittest.SkipTest("requires float16 or bfloat16 support")
+
+        t1 = torch.randn((2, 3, 4, 5), dtype=lowp_dtype, device=self.device)
+        t2 = torch.randn((2, 3, 5, 6), dtype=torch.float32, device=self.device)
+
+        msg = "expected .* and .* to have the same dtype, but got: .* != .*"
+        with self.assertRaisesRegex(RuntimeError, msg):
+            fn(t1, t2)
+        if config.cpp_wrapper:
+            msg = f"({msg})|(aoti_torch_.* API call failed at .*)"
+        with self.assertRaisesRegex(RuntimeError, msg):
+            torch.compile(fn)(t1, t2)
+
     @xfail_if_mps_unimplemented  # linear for non-float inputs
     def test_linear_mixed_dtype(self):
         class Net(nn.Module):

--- a/torch/_inductor/kernel/bmm.py
+++ b/torch/_inductor/kernel/bmm.py
@@ -3,6 +3,7 @@ import logging
 from typing import TYPE_CHECKING
 
 import torch
+from torch._prims_common import ELEMENTWISE_TYPE_PROMOTION_KIND
 from torch._dynamo.utils import counters
 from torch._inductor.codegen.rocm.ck_universal_gemm_template import CKGemmTemplate
 from torch._inductor.kernel.mm_common import load_kernel_template
@@ -69,7 +70,7 @@ aten_baddbmm = ExternKernelChoice(
 )
 
 
-def _check_bmm_dtypes(mat1, mat2, out_dtype) -> None:
+def _check_bmm_input_dtypes(mat1, mat2) -> None:
     input_dtype = mat1.get_dtype()
     other_dtype = mat2.get_dtype()
     torch._check(
@@ -79,7 +80,11 @@ def _check_bmm_dtypes(mat1, mat2, out_dtype) -> None:
             f"{input_dtype} != {other_dtype}"
         ),
     )
+
+
+def _check_bmm_out_dtype(mat1, out_dtype) -> None:
     if out_dtype is not None:
+        input_dtype = mat1.get_dtype()
         torch._check(
             mat1.get_device().type in ("cuda", "xpu"),
             lambda: "out_dtype is only supported for CUDA or XPU",
@@ -94,12 +99,32 @@ def _check_bmm_dtypes(mat1, mat2, out_dtype) -> None:
         )
 
 
+def _should_enforce_bmm_input_dtypes() -> bool:
+    original_aten = V.graph.current_node.meta.get("original_aten")
+    return (
+        isinstance(original_aten, torch._ops.OpOverload)
+        and original_aten._overloadpacket in (aten.bmm, aten.matmul)
+    )
+
+
 @L.register_lowering(aten.bmm, type_promotion_kind=None)
 def tuned_bmm(mat1, mat2, out_dtype=None, *, layout=None):
     """
     Lowering for autotuning aten.bmm with different backends (Aten, Triton, CUTLASS, etc.)
     """
-    _check_bmm_dtypes(mat1, mat2, out_dtype)
+    if _should_enforce_bmm_input_dtypes():
+        _check_bmm_input_dtypes(mat1, mat2)
+    else:
+        # Preserve eager promotion for higher-level ops like einsum that decompose through bmm.
+        args, _ = transform_args(
+            args=[mat1, mat2],
+            kwargs={},
+            broadcast=False,
+            type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT,
+            convert_input_to_bool=False,
+        )
+        mat1, mat2 = args
+    _check_bmm_out_dtype(mat1, out_dtype)
 
     if all(x.get_device().type == "cpu" for x in [mat1, mat2]):
         # decompose to small ops when memory bound

--- a/torch/_inductor/kernel/bmm.py
+++ b/torch/_inductor/kernel/bmm.py
@@ -6,7 +6,6 @@ import torch
 from torch._dynamo.utils import counters
 from torch._inductor.codegen.rocm.ck_universal_gemm_template import CKGemmTemplate
 from torch._inductor.kernel.mm_common import load_kernel_template
-from torch._prims_common import ELEMENTWISE_TYPE_PROMOTION_KIND
 
 from .. import config as inductor_config, ir, lowering as L
 from ..kernel_inputs import MMKernelInputs
@@ -70,73 +69,11 @@ aten_baddbmm = ExternKernelChoice(
 )
 
 
-def _check_bmm_input_dtypes(mat1, mat2) -> None:
-    input_dtype = mat1.get_dtype()
-    other_dtype = mat2.get_dtype()
-    torch._check(
-        other_dtype == input_dtype,
-        lambda: (
-            f"expected mat1 and mat2 to have the same dtype, but got: "
-            f"{input_dtype} != {other_dtype}"
-        ),
-    )
-
-
-def _check_bmm_out_dtype(mat1, out_dtype) -> None:
-    if out_dtype is not None:
-        input_dtype = mat1.get_dtype()
-        torch._check(
-            mat1.get_device().type in ("cuda", "xpu"),
-            lambda: "out_dtype is only supported for CUDA or XPU",
-        )
-        torch._check(
-            out_dtype == input_dtype
-            or (
-                out_dtype == torch.float32
-                and input_dtype in (torch.float16, torch.bfloat16)
-            ),
-            lambda: "out_dtype must be the same as input dtype or fp32 for fp16/bf16 inputs",
-        )
-
-
-def _should_enforce_bmm_input_dtypes() -> bool:
-    for key in ("source_fn_stack", "fwd_source_fn_stack"):
-        source_fn_stack = V.graph.current_node.meta.get(key)
-        if not source_fn_stack:
-            continue
-        source_fn = source_fn_stack[-1][1]
-        source_fn_name = (
-            source_fn
-            if isinstance(source_fn, str)
-            else getattr(source_fn, "__name__", None)
-        )
-        return source_fn_name in ("bmm", "matmul")
-
-    original_aten = V.graph.current_node.meta.get("original_aten")
-    return isinstance(
-        original_aten, torch._ops.OpOverload
-    ) and original_aten._overloadpacket in (aten.bmm, aten.matmul)
-
-
-@L.register_lowering(aten.bmm, type_promotion_kind=None)
+@L.register_lowering(aten.bmm)
 def tuned_bmm(mat1, mat2, out_dtype=None, *, layout=None):
     """
     Lowering for autotuning aten.bmm with different backends (Aten, Triton, CUTLASS, etc.)
     """
-    if _should_enforce_bmm_input_dtypes():
-        _check_bmm_input_dtypes(mat1, mat2)
-    else:
-        # Preserve eager promotion for higher-level ops like einsum that decompose through bmm.
-        args, _ = transform_args(
-            args=[mat1, mat2],
-            kwargs={},
-            broadcast=False,
-            type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT,
-            convert_input_to_bool=False,
-        )
-        mat1, mat2 = args
-    _check_bmm_out_dtype(mat1, out_dtype)
-
     if all(x.get_device().type == "cpu" for x in [mat1, mat2]):
         # decompose to small ops when memory bound
         if mat1.get_size()[1] == 1 or mat2.get_size()[2] == 1:
@@ -226,6 +163,9 @@ def tuned_bmm(mat1, mat2, out_dtype=None, *, layout=None):
     aten_handler: ExternKernelChoice = aten_bmm
     aten_extra_kwargs = {}
     if out_dtype:
+        assert mat1.get_device().type in ("cuda", "xpu"), (
+            "out_dtype is only supported for CUDA or XPU"
+        )
         aten_handler = aten_bmm_dtype
         aten_extra_kwargs = {"out_dtype": out_dtype}
 

--- a/torch/_inductor/kernel/bmm.py
+++ b/torch/_inductor/kernel/bmm.py
@@ -3,10 +3,10 @@ import logging
 from typing import TYPE_CHECKING
 
 import torch
-from torch._prims_common import ELEMENTWISE_TYPE_PROMOTION_KIND
 from torch._dynamo.utils import counters
 from torch._inductor.codegen.rocm.ck_universal_gemm_template import CKGemmTemplate
 from torch._inductor.kernel.mm_common import load_kernel_template
+from torch._prims_common import ELEMENTWISE_TYPE_PROMOTION_KIND
 
 from .. import config as inductor_config, ir, lowering as L
 from ..kernel_inputs import MMKernelInputs
@@ -101,10 +101,9 @@ def _check_bmm_out_dtype(mat1, out_dtype) -> None:
 
 def _should_enforce_bmm_input_dtypes() -> bool:
     original_aten = V.graph.current_node.meta.get("original_aten")
-    return (
-        isinstance(original_aten, torch._ops.OpOverload)
-        and original_aten._overloadpacket in (aten.bmm, aten.matmul)
-    )
+    return isinstance(
+        original_aten, torch._ops.OpOverload
+    ) and original_aten._overloadpacket in (aten.bmm, aten.matmul)
 
 
 @L.register_lowering(aten.bmm, type_promotion_kind=None)

--- a/torch/_inductor/kernel/bmm.py
+++ b/torch/_inductor/kernel/bmm.py
@@ -100,6 +100,18 @@ def _check_bmm_out_dtype(mat1, out_dtype) -> None:
 
 
 def _should_enforce_bmm_input_dtypes() -> bool:
+    for key in ("source_fn_stack", "fwd_source_fn_stack"):
+        source_fn_stack = V.graph.current_node.meta.get(key)
+        if not source_fn_stack:
+            continue
+        source_fn = source_fn_stack[-1][1]
+        source_fn_name = (
+            source_fn
+            if isinstance(source_fn, str)
+            else getattr(source_fn, "__name__", None)
+        )
+        return source_fn_name in ("bmm", "matmul")
+
     original_aten = V.graph.current_node.meta.get("original_aten")
     return isinstance(
         original_aten, torch._ops.OpOverload

--- a/torch/_inductor/kernel/bmm.py
+++ b/torch/_inductor/kernel/bmm.py
@@ -94,7 +94,7 @@ def _check_bmm_dtypes(mat1, mat2, out_dtype) -> None:
         )
 
 
-@L.register_lowering(aten.bmm)
+@L.register_lowering(aten.bmm, type_promotion_kind=None)
 def tuned_bmm(mat1, mat2, out_dtype=None, *, layout=None):
     """
     Lowering for autotuning aten.bmm with different backends (Aten, Triton, CUTLASS, etc.)

--- a/torch/_inductor/kernel/bmm.py
+++ b/torch/_inductor/kernel/bmm.py
@@ -69,11 +69,38 @@ aten_baddbmm = ExternKernelChoice(
 )
 
 
+def _check_bmm_dtypes(mat1, mat2, out_dtype) -> None:
+    input_dtype = mat1.get_dtype()
+    other_dtype = mat2.get_dtype()
+    torch._check(
+        other_dtype == input_dtype,
+        lambda: (
+            f"expected mat1 and mat2 to have the same dtype, but got: "
+            f"{input_dtype} != {other_dtype}"
+        ),
+    )
+    if out_dtype is not None:
+        torch._check(
+            mat1.get_device().type in ("cuda", "xpu"),
+            lambda: "out_dtype is only supported for CUDA or XPU",
+        )
+        torch._check(
+            out_dtype == input_dtype
+            or (
+                out_dtype == torch.float32
+                and input_dtype in (torch.float16, torch.bfloat16)
+            ),
+            lambda: "out_dtype must be the same as input dtype or fp32 for fp16/bf16 inputs",
+        )
+
+
 @L.register_lowering(aten.bmm)
 def tuned_bmm(mat1, mat2, out_dtype=None, *, layout=None):
     """
     Lowering for autotuning aten.bmm with different backends (Aten, Triton, CUTLASS, etc.)
     """
+    _check_bmm_dtypes(mat1, mat2, out_dtype)
+
     if all(x.get_device().type == "cpu" for x in [mat1, mat2]):
         # decompose to small ops when memory bound
         if mat1.get_size()[1] == 1 or mat2.get_size()[2] == 1:
@@ -163,9 +190,6 @@ def tuned_bmm(mat1, mat2, out_dtype=None, *, layout=None):
     aten_handler: ExternKernelChoice = aten_bmm
     aten_extra_kwargs = {}
     if out_dtype:
-        assert mat1.get_device().type in ("cuda", "xpu"), (
-            "out_dtype is only supported for CUDA or XPU"
-        )
         aten_handler = aten_bmm_dtype
         aten_extra_kwargs = {"out_dtype": out_dtype}
 

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -4583,21 +4583,26 @@ def meta_index_put_(self, indices, values, accumulate=False):
     return self
 
 
+def _get_source_fn_name(source_fn) -> str | None:
+    if isinstance(source_fn, str):
+        return source_fn
+    return getattr(source_fn, "__name__", None)
+
+
 def _should_enforce_bmm_input_dtypes() -> bool:
     current_meta = fx_traceback.get_current_meta()
+    original_aten = current_meta.get("original_aten")
+    if isinstance(original_aten, OpOverload):
+        return original_aten._overloadpacket in (aten.bmm, aten.matmul)
+
     for key in ("source_fn_stack", "fwd_source_fn_stack"):
         source_fn_stack = current_meta.get(key)
         if not source_fn_stack:
             continue
-        source_fn = source_fn_stack[-1][1]
-        source_fn_name = (
-            source_fn if isinstance(source_fn, str) else getattr(source_fn, "__name__", None)
-        )
-        return source_fn_name in ("bmm", "matmul")
-
-    original_aten = current_meta.get("original_aten")
-    if isinstance(original_aten, OpOverload):
-        return original_aten._overloadpacket in (aten.bmm, aten.matmul)
+        for _, source_fn in source_fn_stack:
+            source_fn_name = _get_source_fn_name(source_fn)
+            if source_fn_name in ("bmm", "matmul", "einsum"):
+                return source_fn_name in ("bmm", "matmul")
 
     return True
 

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -8,6 +8,7 @@ from typing_extensions import ParamSpec
 
 import torch
 import torch._prims_common as utils
+import torch.fx.traceback as fx_traceback
 from torch import SymBool, SymFloat, Tensor
 from torch._decomp import (
     _add_op_to_registry,
@@ -4582,6 +4583,35 @@ def meta_index_put_(self, indices, values, accumulate=False):
     return self
 
 
+def _should_enforce_bmm_input_dtypes() -> bool:
+    current_meta = fx_traceback.get_current_meta()
+    for key in ("source_fn_stack", "fwd_source_fn_stack"):
+        source_fn_stack = current_meta.get(key)
+        if not source_fn_stack:
+            continue
+        source_fn = source_fn_stack[-1][1]
+        source_fn_name = (
+            source_fn if isinstance(source_fn, str) else getattr(source_fn, "__name__", None)
+        )
+        return source_fn_name in ("bmm", "matmul")
+
+    original_aten = current_meta.get("original_aten")
+    if isinstance(original_aten, OpOverload):
+        return original_aten._overloadpacket in (aten.bmm, aten.matmul)
+
+    return True
+
+
+def _check_bmm_input_dtypes(batch1, batch2) -> None:
+    torch._check(
+        batch2.dtype == batch1.dtype,
+        lambda: (
+            f"expected mat1 and mat2 to have the same dtype, but got: "
+            f"{batch1.dtype} != {batch2.dtype}"
+        ),
+    )
+
+
 def common_meta_baddbmm_bmm(batch1, batch2, is_bmm, self_baddbmm=None, out_dtype=None):
     from torch.fx.experimental.symbolic_shapes import sym_and, sym_eq
 
@@ -4602,6 +4632,16 @@ def common_meta_baddbmm_bmm(batch1, batch2, is_bmm, self_baddbmm=None, out_dtype
         lambda: f"Expected size for first two dimensions of batch2 tensor to be: [{bs}"
         f", {contraction_size}] but got: [{batch2_sizes[0]}, {batch2_sizes[1]}].",
     )
+    result_dtype = batch2.dtype
+    if is_bmm and batch1.dtype != batch2.dtype:
+        if _should_enforce_bmm_input_dtypes():
+            _check_bmm_input_dtypes(batch1, batch2)
+        else:
+            _, result_dtype = utils.elementwise_dtypes(
+                batch1,
+                batch2,
+                type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT,
+            )
     if out_dtype:
         supported_out_dtype = (
             batch1.dtype == torch.float16 or batch1.dtype == torch.bfloat16
@@ -4613,7 +4653,7 @@ def common_meta_baddbmm_bmm(batch1, batch2, is_bmm, self_baddbmm=None, out_dtype
         output = batch2.new_empty(output_size).to(out_dtype)
     else:
         # TODO: handle out
-        output = batch2.new_empty(output_size)
+        output = batch2.new_empty(output_size).to(result_dtype)
 
     if not is_bmm and self_baddbmm is not None:
         torch._check(self_baddbmm.dim() == 3, lambda: "self must be a 3D tensor")

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -4590,13 +4590,20 @@ def _get_source_fn_name(source_fn) -> str | None:
 
 
 def _get_torch_fn_name(current_meta: dict[str, object]) -> str | None:
+    # Dynamo's top-level frame trace does not preserve FX node metadata yet, but
+    # proxy tensor still tracks the outermost torch function being decomposed.
+    from torch.fx.experimental import proxy_tensor
+
+    torch_fn_name = _get_source_fn_name(proxy_tensor.ORIGINAL_TORCH_FN)
+    if torch_fn_name is not None:
+        return torch_fn_name
+
     torch_fn = current_meta.get("torch_fn")
-    if not isinstance(torch_fn, tuple) or len(torch_fn) != 2:
-        return None
-    source_fn = torch_fn[1]
-    if not isinstance(source_fn, str):
-        return None
-    return source_fn.rsplit(".", 1)[-1]
+    if isinstance(torch_fn, tuple) and len(torch_fn) == 2:
+        source_fn = torch_fn[1]
+        if isinstance(source_fn, str):
+            return source_fn.rsplit(".", 1)[-1]
+    return None
 
 
 def _iter_source_fn_entries(
@@ -4669,15 +4676,12 @@ def _should_enforce_bmm_input_dtypes() -> bool:
     torch_fn_name = _get_torch_fn_name(current_meta)
     from_node_targets = tuple(_iter_from_node_targets(current_meta))
 
-    if not preserve_node_meta and original_aten is None:
+    if not preserve_node_meta and original_aten is None and torch_fn_name is None:
         return True
 
     # Preserve promotion for einsum decompositions even when they route through
     # intermediate matmul/bmm nodes that also leave provenance behind.
-    if (
-        original_aten is not None
-        and original_aten._overloadpacket is aten.einsum
-    ) or (
+    if (original_aten is not None and original_aten._overloadpacket is aten.einsum) or (
         torch_fn_name == "einsum"
         or "einsum" in source_fn_names
         or any("einsum" in target for target in from_node_targets)

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -4648,6 +4648,9 @@ def _stack_trace_mentions(current_meta: dict[str, object], op_name: str) -> bool
 
 
 def _should_enforce_bmm_input_dtypes() -> bool:
+    if not fx_traceback.has_preserved_node_meta():
+        return True
+
     current_meta = fx_traceback.get_current_meta()
     original_aten = current_meta.get("original_aten")
     source_fn_names = tuple(_iter_source_fn_names(current_meta))
@@ -4676,7 +4679,11 @@ def _should_enforce_bmm_input_dtypes() -> bool:
     if any(source_fn_name in ("bmm", "matmul") for source_fn_name in source_fn_names):
         return True
 
-    return True
+    # Traced higher-level ops like einsum can lose structured provenance as they
+    # decompose through intermediate bmm nodes. If we cannot positively
+    # attribute the traced call to user-visible bmm/matmul, preserve the
+    # promoted result instead of manufacturing a direct bmm dtype error.
+    return False
 
 
 def _check_bmm_input_dtypes(batch1, batch2) -> None:

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -4647,20 +4647,35 @@ def _stack_trace_mentions(current_meta: dict[str, object], op_name: str) -> bool
     return isinstance(stack_trace, str) and f"{op_name}(" in stack_trace
 
 
-def _should_enforce_bmm_input_dtypes() -> bool:
-    if not fx_traceback.has_preserved_node_meta():
-        return True
-
-    current_meta = fx_traceback.get_current_meta()
+def _get_current_original_aten(current_meta: dict[str, object]) -> OpOverload | None:
     original_aten = current_meta.get("original_aten")
+    if isinstance(original_aten, OpOverload):
+        return original_aten
+
+    # Dynamo's top-level frame trace does not preserve FX node metadata yet, but
+    # proxy tensor still tracks the outermost aten op being decomposed.
+    from torch.fx.experimental import proxy_tensor
+
+    if isinstance(proxy_tensor.ORIGINAL_ATEN, OpOverload):
+        return proxy_tensor.ORIGINAL_ATEN
+    return None
+
+
+def _should_enforce_bmm_input_dtypes() -> bool:
+    preserve_node_meta = fx_traceback.has_preserved_node_meta()
+    current_meta = fx_traceback.get_current_meta() if preserve_node_meta else {}
+    original_aten = _get_current_original_aten(current_meta)
     source_fn_names = tuple(_iter_source_fn_names(current_meta))
     torch_fn_name = _get_torch_fn_name(current_meta)
     from_node_targets = tuple(_iter_from_node_targets(current_meta))
 
+    if not preserve_node_meta and original_aten is None:
+        return True
+
     # Preserve promotion for einsum decompositions even when they route through
     # intermediate matmul/bmm nodes that also leave provenance behind.
     if (
-        isinstance(original_aten, OpOverload)
+        original_aten is not None
         and original_aten._overloadpacket is aten.einsum
     ) or (
         torch_fn_name == "einsum"
@@ -4671,7 +4686,7 @@ def _should_enforce_bmm_input_dtypes() -> bool:
         return False
 
     if (
-        isinstance(original_aten, OpOverload)
+        original_aten is not None
         and original_aten._overloadpacket in (aten.bmm, aten.matmul)
     ) or torch_fn_name in ("bmm", "matmul"):
         return True

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -4589,20 +4589,49 @@ def _get_source_fn_name(source_fn) -> str | None:
     return getattr(source_fn, "__name__", None)
 
 
-def _should_enforce_bmm_input_dtypes() -> bool:
-    current_meta = fx_traceback.get_current_meta()
-    original_aten = current_meta.get("original_aten")
-    if isinstance(original_aten, OpOverload):
-        return original_aten._overloadpacket in (aten.bmm, aten.matmul)
+def _get_torch_fn_name(current_meta: dict[str, object]) -> str | None:
+    torch_fn = current_meta.get("torch_fn")
+    if not isinstance(torch_fn, tuple) or len(torch_fn) != 2:
+        return None
+    source_fn = torch_fn[1]
+    if not isinstance(source_fn, str):
+        return None
+    return source_fn.rsplit(".", 1)[-1]
 
+
+def _iter_source_fn_names(current_meta: dict[str, object]):
     for key in ("source_fn_stack", "fwd_source_fn_stack"):
         source_fn_stack = current_meta.get(key)
         if not source_fn_stack:
             continue
         for _, source_fn in source_fn_stack:
             source_fn_name = _get_source_fn_name(source_fn)
-            if source_fn_name in ("bmm", "matmul", "einsum"):
-                return source_fn_name in ("bmm", "matmul")
+            if source_fn_name is not None:
+                yield source_fn_name
+
+
+def _should_enforce_bmm_input_dtypes() -> bool:
+    current_meta = fx_traceback.get_current_meta()
+    original_aten = current_meta.get("original_aten")
+    source_fn_names = tuple(_iter_source_fn_names(current_meta))
+    torch_fn_name = _get_torch_fn_name(current_meta)
+
+    # Preserve promotion for einsum decompositions even when they route through
+    # intermediate matmul/bmm nodes that also leave provenance behind.
+    if (
+        isinstance(original_aten, OpOverload)
+        and original_aten._overloadpacket is aten.einsum
+    ) or torch_fn_name == "einsum" or "einsum" in source_fn_names:
+        return False
+
+    if (
+        isinstance(original_aten, OpOverload)
+        and original_aten._overloadpacket in (aten.bmm, aten.matmul)
+    ) or torch_fn_name in ("bmm", "matmul"):
+        return True
+
+    if any(source_fn_name in ("bmm", "matmul") for source_fn_name in source_fn_names):
+        return True
 
     return True
 

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -1,6 +1,6 @@
 # mypy: allow-untyped-defs
 import math
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Iterator, Sequence
 from enum import Enum
 from functools import wraps
 from typing import TypeVar
@@ -4599,15 +4599,45 @@ def _get_torch_fn_name(current_meta: dict[str, object]) -> str | None:
     return source_fn.rsplit(".", 1)[-1]
 
 
-def _iter_source_fn_names(current_meta: dict[str, object]):
+def _iter_source_fn_entries(
+    current_meta: dict[str, object],
+) -> Iterator[tuple[object, object]]:
     for key in ("source_fn_stack", "fwd_source_fn_stack"):
         source_fn_stack = current_meta.get(key)
-        if not source_fn_stack:
+        if not isinstance(source_fn_stack, (list, tuple)):
             continue
-        for _, source_fn in source_fn_stack:
-            source_fn_name = _get_source_fn_name(source_fn)
-            if source_fn_name is not None:
-                yield source_fn_name
+        for source_fn_entry in source_fn_stack:
+            if isinstance(source_fn_entry, tuple) and len(source_fn_entry) == 2:
+                yield source_fn_entry
+
+
+def _iter_source_fn_names(current_meta: dict[str, object]) -> Iterator[str]:
+    for _, source_fn in _iter_source_fn_entries(current_meta):
+        source_fn_name = _get_source_fn_name(source_fn)
+        if source_fn_name is not None:
+            yield source_fn_name
+
+
+def _iter_from_node_sources(
+    current_meta: dict[str, object],
+) -> Iterator[fx_traceback.NodeSource]:
+    from_node = current_meta.get("from_node")
+    if not isinstance(from_node, (list, tuple)):
+        return
+
+    worklist = list(from_node)
+    while worklist:
+        node_source = worklist.pop()
+        if not isinstance(node_source, fx_traceback.NodeSource):
+            continue
+        yield node_source
+        worklist.extend(node_source.from_node)
+
+
+def _iter_from_node_targets(current_meta: dict[str, object]) -> Iterator[str]:
+    for node_source in _iter_from_node_sources(current_meta):
+        if node_source.target:
+            yield node_source.target
 
 
 def _should_enforce_bmm_input_dtypes() -> bool:
@@ -4615,13 +4645,18 @@ def _should_enforce_bmm_input_dtypes() -> bool:
     original_aten = current_meta.get("original_aten")
     source_fn_names = tuple(_iter_source_fn_names(current_meta))
     torch_fn_name = _get_torch_fn_name(current_meta)
+    from_node_targets = tuple(_iter_from_node_targets(current_meta))
 
     # Preserve promotion for einsum decompositions even when they route through
     # intermediate matmul/bmm nodes that also leave provenance behind.
     if (
         isinstance(original_aten, OpOverload)
         and original_aten._overloadpacket is aten.einsum
-    ) or torch_fn_name == "einsum" or "einsum" in source_fn_names:
+    ) or (
+        torch_fn_name == "einsum"
+        or "einsum" in source_fn_names
+        or any("einsum" in target for target in from_node_targets)
+    ):
         return False
 
     if (

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -4668,6 +4668,25 @@ def _get_current_original_aten(current_meta: dict[str, object]) -> OpOverload | 
     return None
 
 
+def _get_current_dynamo_target_name() -> str | None:
+    try:
+        from torch._dynamo.utils import get_current_node
+    except ImportError:
+        return None
+
+    current_node = get_current_node()
+    if current_node is None:
+        return None
+
+    if current_node.op == "call_method" and isinstance(current_node.target, str):
+        return current_node.target
+
+    if current_node.op != "call_function":
+        return None
+
+    return _get_source_fn_name(current_node.target)
+
+
 def _should_enforce_bmm_input_dtypes() -> bool:
     preserve_node_meta = fx_traceback.has_preserved_node_meta()
     current_meta = fx_traceback.get_current_meta() if preserve_node_meta else {}
@@ -4675,14 +4694,23 @@ def _should_enforce_bmm_input_dtypes() -> bool:
     source_fn_names = tuple(_iter_source_fn_names(current_meta))
     torch_fn_name = _get_torch_fn_name(current_meta)
     from_node_targets = tuple(_iter_from_node_targets(current_meta))
+    dynamo_target_name = (
+        _get_current_dynamo_target_name() if not preserve_node_meta else None
+    )
 
-    if not preserve_node_meta and original_aten is None and torch_fn_name is None:
+    if (
+        not preserve_node_meta
+        and original_aten is None
+        and torch_fn_name is None
+        and dynamo_target_name is None
+    ):
         return True
 
     # Preserve promotion for einsum decompositions even when they route through
     # intermediate matmul/bmm nodes that also leave provenance behind.
     if (original_aten is not None and original_aten._overloadpacket is aten.einsum) or (
         torch_fn_name == "einsum"
+        or dynamo_target_name == "einsum"
         or "einsum" in source_fn_names
         or any("einsum" in target for target in from_node_targets)
         or _stack_trace_mentions(current_meta, "einsum")
@@ -4692,7 +4720,10 @@ def _should_enforce_bmm_input_dtypes() -> bool:
     if (
         original_aten is not None
         and original_aten._overloadpacket in (aten.bmm, aten.matmul)
-    ) or torch_fn_name in ("bmm", "matmul"):
+    ) or torch_fn_name in ("bmm", "matmul") or dynamo_target_name in (
+        "bmm",
+        "matmul",
+    ):
         return True
 
     if any(source_fn_name in ("bmm", "matmul") for source_fn_name in source_fn_names):

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -4628,6 +4628,8 @@ def _iter_from_node_sources(
     worklist = list(from_node)
     while worklist:
         node_source = worklist.pop()
+        if isinstance(node_source, dict):
+            node_source = fx_traceback.NodeSource._from_dict(node_source)
         if not isinstance(node_source, fx_traceback.NodeSource):
             continue
         yield node_source
@@ -4638,6 +4640,11 @@ def _iter_from_node_targets(current_meta: dict[str, object]) -> Iterator[str]:
     for node_source in _iter_from_node_sources(current_meta):
         if node_source.target:
             yield node_source.target
+
+
+def _stack_trace_mentions(current_meta: dict[str, object], op_name: str) -> bool:
+    stack_trace = current_meta.get("stack_trace")
+    return isinstance(stack_trace, str) and f"{op_name}(" in stack_trace
 
 
 def _should_enforce_bmm_input_dtypes() -> bool:
@@ -4656,6 +4663,7 @@ def _should_enforce_bmm_input_dtypes() -> bool:
         torch_fn_name == "einsum"
         or "einsum" in source_fn_names
         or any("einsum" in target for target in from_node_targets)
+        or _stack_trace_mentions(current_meta, "einsum")
     ):
         return False
 

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -4718,11 +4718,12 @@ def _should_enforce_bmm_input_dtypes() -> bool:
         return False
 
     if (
-        original_aten is not None
-        and original_aten._overloadpacket in (aten.bmm, aten.matmul)
-    ) or torch_fn_name in ("bmm", "matmul") or dynamo_target_name in (
-        "bmm",
-        "matmul",
+        (
+            original_aten is not None
+            and original_aten._overloadpacket in (aten.bmm, aten.matmul)
+        )
+        or torch_fn_name in ("bmm", "matmul")
+        or dynamo_target_name in ("bmm", "matmul")
     ):
         return True
 

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -1648,16 +1648,20 @@ def set_original_aten_op(
     func: OpOverload | torch._ops.HigherOrderOperator,
 ) -> Generator[None, None, None]:
     global ORIGINAL_ATEN
-    if ORIGINAL_ATEN is None and fx_traceback.has_preserved_node_meta():
-        ORIGINAL_ATEN = func
-        fx_traceback.current_meta["original_aten"] = func
-        try:
-            yield
-        finally:
-            ORIGINAL_ATEN = None
-            fx_traceback.current_meta["original_aten"] = None
-    else:
+    if ORIGINAL_ATEN is not None:
         yield
+        return
+
+    ORIGINAL_ATEN = func
+    preserve_node_meta = fx_traceback.has_preserved_node_meta()
+    if preserve_node_meta:
+        fx_traceback.current_meta["original_aten"] = func
+    try:
+        yield
+    finally:
+        ORIGINAL_ATEN = None
+        if preserve_node_meta:
+            fx_traceback.current_meta["original_aten"] = None
 
 
 class TorchFunctionMetadataMode(TorchFunctionMode):

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -1641,6 +1641,7 @@ def wrap_key(
 
 # TODO: Make downstream users of this work with OperatorBase
 ORIGINAL_ATEN: object | None = None
+ORIGINAL_TORCH_FN: object | None = None
 
 
 @contextmanager
@@ -1664,6 +1665,20 @@ def set_original_aten_op(
             fx_traceback.current_meta["original_aten"] = None
 
 
+@contextmanager
+def set_original_torch_fn(func: object) -> Generator[None, None, None]:
+    global ORIGINAL_TORCH_FN
+    if ORIGINAL_TORCH_FN is not None:
+        yield
+        return
+
+    ORIGINAL_TORCH_FN = func
+    try:
+        yield
+    finally:
+        ORIGINAL_TORCH_FN = None
+
+
 class TorchFunctionMetadataMode(TorchFunctionMode):
     def __init__(self, tracer: _ProxyTracer) -> None:
         self.tracer = tracer
@@ -1675,11 +1690,14 @@ class TorchFunctionMetadataMode(TorchFunctionMode):
         args: tuple[object, ...] = (),
         kwargs: dict[str, object] | None = None,
     ) -> object:
-        kwargs = kwargs or {}
-        # pyrefly: ignore [bad-assignment]
-        self.tracer.torch_fn_metadata = func
-        self.tracer.torch_fn_counts[func] = self.tracer.torch_fn_counts.get(func, 0) + 1
-        return func(*args, **kwargs)
+        with set_original_torch_fn(func):
+            kwargs = kwargs or {}
+            # pyrefly: ignore [bad-assignment]
+            self.tracer.torch_fn_metadata = func
+            self.tracer.torch_fn_counts[func] = (
+                self.tracer.torch_fn_counts.get(func, 0) + 1
+            )
+            return func(*args, **kwargs)
 
 
 _temp_remove_metadata_torch_function_mode = _make_temp_remove_mode_context_manager(

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -1666,7 +1666,7 @@ def set_original_aten_op(
 
 
 @contextmanager
-def set_original_torch_fn(func: object) -> Generator[None, None, None]:
+def _set_original_torch_fn(func: object) -> Generator[None, None, None]:
     global ORIGINAL_TORCH_FN
     if ORIGINAL_TORCH_FN is not None:
         yield
@@ -1690,7 +1690,7 @@ class TorchFunctionMetadataMode(TorchFunctionMode):
         args: tuple[object, ...] = (),
         kwargs: dict[str, object] | None = None,
     ) -> object:
-        with set_original_torch_fn(func):
+        with _set_original_torch_fn(func):
             kwargs = kwargs or {}
             # pyrefly: ignore [bad-assignment]
             self.tracer.torch_fn_metadata = func


### PR DESCRIPTION
Fix #177630

## Summary

### Root cause
Inductor's custom `aten.bmm` lowering did not enforce the same-dtype contract that eager `bmm` and batched `matmul` require. That let the native matmul and autotuned kernel paths normalize mixed low-precision inputs and silently succeed where eager raises.

### Proposed fix
Add an explicit dtype validation at the start of the Inductor `aten.bmm` lowering, along with the existing `out_dtype` contract checks, before selecting any backend. Add regression coverage for direct compiled `bmm` and decomposed higher-rank `matmul` with mixed dtypes.

### Why this is the right long term fix
Higher-rank `torch.matmul` already decomposes through `aten.bmm`, so restoring eager's dtype contract in the shared `bmm` lowering fixes both user-visible surfaces at the point where Inductor diverged. The regression tests keep that contract pinned without changing unrelated matmul behavior.

Drafted via Codex, published after manual review by @bobrenjc93

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo