### PR TITLE
no defer first rs_wait

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1121,6 +1121,11 @@ class aten_distributed_optimizations:
     # blocks the compute stream.  Supersedes manual_bucketing_rs_stream.
     manual_bucketing_comm_streams: bool = False
 
+    # Don't defer the first backward RS_wait in manual bucketing overlap.
+    # The first backward bucket has no prior compute to overlap with, so
+    # deferring its RS_wait only delays freeing the weight grad buffer.
+    manual_bucketing_no_defer_first_rs_wait: bool = False
+
     # Number of round-robin comm streams for auto-bucketed collectives.
     # 0 = disabled (default), 1 = single comm stream, 2+ = pool.
     comm_stream_pool_size: int = 0

--- a/torch/_inductor/fx_passes/overlap_manual_scheduling.py
+++ b/torch/_inductor/fx_passes/overlap_manual_scheduling.py
@@ -259,6 +259,8 @@ class ManualOverlapScheduler(OverlapScheduler):
         delayed_rs_wait_nodes: list[fx.Node] = []
         current_rs_start_nodes: list[fx.Node] = []
         overlap_deps: dict[fx.Node, OrderedSet[fx.Node]] = defaultdict(OrderedSet)
+        no_defer_first = config.aten_distributed_optimizations.manual_bucketing_no_defer_first_rs_wait
+        seen_rs_wait = False
 
         # Re-initialize after graph modification in _manual_bucket_collectives
         self.node_idx = {n: i for i, n in enumerate(self.nodes)}
@@ -289,7 +291,11 @@ class ManualOverlapScheduler(OverlapScheduler):
                             overlap_deps[delayed].add(rs_start)
                     delayed_rs_wait_nodes.clear()
                     current_rs_start_nodes.clear()
-                delayed_rs_wait_nodes.append(node)
+                # The first backward RS_wait has no prior compute to overlap
+                # with — deferring it only delays freeing the weight grad.
+                if seen_rs_wait or not no_defer_first:
+                    delayed_rs_wait_nodes.append(node)
+                seen_rs_wait = True
 
             self._schedule(node)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #178189
* #177863
* #177862
* __->__ #177861
* #177290
* #177173
* #177134
* #177025
* #176889
* #176886
* #176882
* #176479
* #176173
* #176172
* #173386



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo