### PR TITLE
Sparse semi structured setup/teardown latency

### DIFF
--- a/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
+++ b/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
@@ -24,11 +24,10 @@ thread_local bool handle_initialized = false;
 /////////////////////////////////////////////////////////////////////
 
 struct SparseInputDescriptorCacheKey {
-  int m = 0;
-  int k = 0;
-  bool is_contiguous = true;
+  int dim0 = 0;
+  int dim1 = 0;
   bool is_dense = false;
-  int32_t input_type = 0;
+  int32_t cuda_type = 0;
 };
 
 using SparseInputDescriptorCacheKeyHash = ParamsHash<SparseInputDescriptorCacheKey>;
@@ -112,71 +111,51 @@ SparseInputDescriptorCache& getSparseInputDescriptorCache() {
   return *sparse_input_descriptor_cache;
 }
 
-static cusparseLtMatDescriptor_t* _get_sparse_input_descriptor_ptr(
+enum class MatDescriptorKind { Dense, Sparse };
+
+static cusparseLtMatDescriptor_t* _get_input_descriptor_ptr(
     cusparseLtHandle_t& handle,
-    int64_t m,
-    int64_t k,
-    cudaDataType input_type) {
+    MatDescriptorKind kind,
+    int64_t rows,
+    int64_t cols,
+    int64_t ld,
+    cudaDataType cuda_type,
+    int64_t alignment = 16,
+    cusparseOrder_t order = CUSPARSE_ORDER_ROW) {
   SparseInputDescriptorCacheKey key{};
-  key.m = m;
-  key.k = k;
-  key.is_contiguous = true;
-  key.is_dense = false;
-  key.input_type = static_cast<int32_t>(input_type);
+  key.dim0 = static_cast<int>(rows);
+  key.dim1 = static_cast<int>(cols);
+  key.is_dense = (kind == MatDescriptorKind::Dense);
+  key.cuda_type = static_cast<int32_t>(cuda_type);
   auto cached = getSparseInputDescriptorCache().lookup(key);
   if (cached.has_value()) {
     return *cached;
-  } 
-  cusparseLtMatDescriptor_t sparse_input_descriptor;
-  TORCH_CUDASPARSE_CHECK(cusparseLtStructuredDescriptorInit(
-      &handle,
-      &sparse_input_descriptor,
-      m,
-      k,
-      k,
-      16,
-      input_type,
-      CUSPARSE_ORDER_ROW,
-      CUSPARSELT_SPARSITY_50_PERCENT));
-      
+  }
+  cusparseLtMatDescriptor_t descriptor;
+  if (kind == MatDescriptorKind::Sparse) {
+    TORCH_CUDASPARSE_CHECK(cusparseLtStructuredDescriptorInit(
+        &handle,
+        &descriptor,
+        rows,
+        cols,
+        ld,
+        alignment,
+        cuda_type,
+        order,
+        CUSPARSELT_SPARSITY_50_PERCENT));
+  } else {
+    TORCH_CUDASPARSE_CHECK(cusparseLtDenseDescriptorInit(
+        &handle,
+        &descriptor,
+        rows,
+        cols,
+        ld,
+        alignment,
+        cuda_type,
+        order));
+  }
   CachedSparseInputDescriptor cached_descriptor;
-  cached_descriptor.descriptor = sparse_input_descriptor;
-  cached_descriptor.has_descriptor = true;
-  getSparseInputDescriptorCache().insert(std::move(key), std::move(cached_descriptor));
-  cached = getSparseInputDescriptorCache().lookup(key);
-  return *cached;
-}
-
-
-static cusparseLtMatDescriptor_t* _get_dense_input_descriptor_ptr(
-    cusparseLtHandle_t& handle,
-    int64_t k,
-    int64_t n,
-    bool is_contiguous,
-    cudaDataType input_type) {
-  SparseInputDescriptorCacheKey key{};
-  key.m = n;
-  key.k = k;
-  key.is_contiguous = is_contiguous;
-  key.is_dense = true;
-  key.input_type = static_cast<int32_t>(input_type);
-  auto cached = getSparseInputDescriptorCache().lookup(key);
-  if (cached.has_value()) {
-    return *cached;
-  } 
-  cusparseLtMatDescriptor_t dense_input_descriptor;
-  TORCH_CUDASPARSE_CHECK(cusparseLtDenseDescriptorInit(
-      &handle,
-      &dense_input_descriptor,
-      is_contiguous ? k : n,
-      is_contiguous ? n : k,
-      is_contiguous ? n : k,
-      16,
-      input_type,
-      CUSPARSE_ORDER_ROW));
-      
-  CachedSparseInputDescriptor cached_descriptor;
-  cached_descriptor.descriptor = dense_input_descriptor;
+  cached_descriptor.descriptor = descriptor;
   cached_descriptor.has_descriptor = true;
   getSparseInputDescriptorCache().insert(std::move(key), std::move(cached_descriptor));
   cached = getSparseInputDescriptorCache().lookup(key);
@@ -474,48 +453,51 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
   int64_t n = dense_B.size(1);
   int64_t m = compressed_A.size(0);
 
-  //////////////////////////////////////////////////////////////
-  // initialize sparse descriptor
-  // auto t3 = std::chrono::steady_clock::now();
+  // _get_input_descriptor_ptr(
+  //   cusparseLtHandle_t& handle,
+  //   MatDescriptorKind kind,
+  //   int64_t rows,
+  //   int64_t cols,
+  //   int64_t ld,
+  //   cudaDataType input_type,
+  //   int64_t alignment = 16,
+  //   cusparseOrder_t order = CUSPARSE_ORDER_ROW
+
   cusparseLtMatDescriptor_t* sparse_input_descriptor_ptr =
-    _get_sparse_input_descriptor_ptr(handle, m, k, input_type);
-  // auto t4 = std::chrono::steady_clock::now();
-  // double duration_sparse_input_descriptor = std::chrono::duration<double, std::milli>(t4 - t3).count();
-  // std::cout << "duration_sparse_input_descriptor = " << duration_sparse_input_descriptor << std::endl;
-  /////////////////////////////////////////////////////////////
+    _get_input_descriptor_ptr(handle, MatDescriptorKind::Sparse, m, k, k, input_type);
 
   // initialize dense input descriptor
-  cusparseLtMatDescriptor_t* dense_input_descriptor_ptr = 
-    _get_dense_input_descriptor_ptr(handle, k, n, dense_B.is_contiguous(), input_type);
-  
+  int64_t dense_rows = dense_B.is_contiguous() ? k : n;
+  int64_t dense_cols = dense_B.is_contiguous() ? n : k;
+  cusparseLtMatDescriptor_t* dense_input_descriptor_ptr =
+    _get_input_descriptor_ptr(handle, MatDescriptorKind::Dense, dense_rows, dense_cols, dense_cols, input_type);
+
   // create result tensor
   auto res_tensor_options =
       c10::TensorOptions().dtype(out_dtype).device(dense_B.device());
   at::Tensor res = (transpose_result) ? at::empty({n, m}, res_tensor_options)
                                       : at::empty({m, n}, res_tensor_options);
 
-  cusparseLtMatDescriptor_t res_descriptor;
-  TORCH_CUDASPARSE_CHECK(cusparseLtDenseDescriptorInit(
-      &handle,
-      &res_descriptor,
-      m,
-      n,
-      (transpose_result) ? m : n,
-      16,
-      output_type,
-      (transpose_result) ? CUSPARSE_ORDER_COL : CUSPARSE_ORDER_ROW));
-
+  cusparseLtMatDescriptor_t* res_descriptor_ptr =
+    _get_input_descriptor_ptr(handle,
+        MatDescriptorKind::Dense,
+        m,
+        n,
+        transpose_result ? m : n,
+        output_type,
+        16,
+        transpose_result ? CUSPARSE_ORDER_COL : CUSPARSE_ORDER_ROW);
+  
   // For float8, need fp16 C_descriptor, can't use FP8 for this matrix
-  cusparseLtMatDescriptor_t C_descriptor;
-  TORCH_CUDASPARSE_CHECK(cusparseLtDenseDescriptorInit(
-      &handle,
-      &C_descriptor,
-      m,
-      n,
-      (transpose_result) ? m : n,
-      16,
-      C_type,
-      (transpose_result) ? CUSPARSE_ORDER_COL : CUSPARSE_ORDER_ROW));
+  cusparseLtMatDescriptor_t*  C_descriptor_ptr =
+    _get_input_descriptor_ptr(handle,
+        MatDescriptorKind::Dense,
+        m,
+        n,
+        transpose_result ? m : n,
+        C_type,
+        16,
+        transpose_result ? CUSPARSE_ORDER_COL : CUSPARSE_ORDER_ROW);
 
   // initialize matmul
   TORCH_CUDASPARSE_CHECK(cusparseLtMatmulDescriptorInit(
@@ -526,8 +508,8 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
                                 : CUSPARSE_OPERATION_TRANSPOSE,
       sparse_input_descriptor_ptr,
       dense_input_descriptor_ptr,
-      &C_descriptor,
-      &res_descriptor,
+      C_descriptor_ptr,
+      res_descriptor_ptr,
       compute_type));
 
   // set bias pointer for matmul, need to assign to get location
@@ -675,7 +657,7 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
   //     cusparseLtMatDescriptorDestroy(&sparse_input_descriptor));
   // TORCH_CUDASPARSE_CHECK(
   //     cusparseLtMatDescriptorDestroy(&dense_input_descriptor));
-  TORCH_CUDASPARSE_CHECK(cusparseLtMatDescriptorDestroy(&res_descriptor));
+  // TORCH_CUDASPARSE_CHECK(cusparseLtMatDescriptorDestroy(&res_descriptor));
   // destroy plan
   TORCH_CUDASPARSE_CHECK(cusparseLtMatmulPlanDestroy(&plan));
 

--- a/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
+++ b/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
@@ -23,76 +23,107 @@ thread_local bool handle_initialized = false;
 
 /////////////////////////////////////////////////////////////////////
 
-struct SparseInputDescriptorCacheKey {
-  int dim0 = 0;
-  int dim1 = 0;
-  bool is_dense = false;
-  int32_t cuda_type = 0;
+// One cache key for the full matmul descriptor bundle (sparse_input, dense_input, res, C).
+struct MatDescriptorCacheKey {
+  int m = 0;
+  int k = 0;
+  int n = 0;
+  bool dense_is_contiguous = true;
+  bool transpose_result = false;
+  int32_t input_type = 0;
+  int32_t output_type = 0;
+  int32_t C_type = 0;
 };
 
-using SparseInputDescriptorCacheKeyHash = ParamsHash<SparseInputDescriptorCacheKey>;
-using SparseInputDescriptorCacheKeyEqual = ParamsEqual<SparseInputDescriptorCacheKey>;
+using MatDescriptorCacheKeyHash = ParamsHash<MatDescriptorCacheKey>;
+using MatDescriptorCacheKeyEqual = ParamsEqual<MatDescriptorCacheKey>;
 
-struct CachedSparseInputDescriptor {
-  cusparseLtMatDescriptor_t descriptor;
-  bool has_descriptor = false;
+// One cached entry holds all 4 descriptors for a matmul config.
+struct CachedMatDescriptor {
+  cusparseLtMatDescriptor_t sparse_input;
+  cusparseLtMatDescriptor_t dense_input;
+  cusparseLtMatDescriptor_t res;
+  cusparseLtMatDescriptor_t C;
+  bool has_descriptors = false;
 
-  CachedSparseInputDescriptor() = default;
-  ~CachedSparseInputDescriptor() {
-    if (has_descriptor) {
-      cusparseLtMatDescriptorDestroy(&descriptor);
-      has_descriptor = false;
+  CachedMatDescriptor() = default;
+  ~CachedMatDescriptor() {
+    if (has_descriptors) {
+      cusparseLtMatDescriptorDestroy(&sparse_input);
+      cusparseLtMatDescriptorDestroy(&dense_input);
+      cusparseLtMatDescriptorDestroy(&res);
+      cusparseLtMatDescriptorDestroy(&C);
+      has_descriptors = false;
     }
   }
-  CachedSparseInputDescriptor(CachedSparseInputDescriptor&& other) noexcept
-      : descriptor(other.descriptor),
-        has_descriptor(other.has_descriptor) {
-    other.has_descriptor = false;
+  CachedMatDescriptor(CachedMatDescriptor&& other) noexcept
+      : sparse_input(other.sparse_input),
+        dense_input(other.dense_input),
+        res(other.res),
+        C(other.C),
+        has_descriptors(other.has_descriptors) {
+    other.has_descriptors = false;
   }
-  CachedSparseInputDescriptor& operator=(CachedSparseInputDescriptor&& other) noexcept {
+  CachedMatDescriptor& operator=(CachedMatDescriptor&& other) noexcept {
     if (this != &other) {
-      if (has_descriptor) {
-        cusparseLtMatDescriptorDestroy(&descriptor);
+      if (has_descriptors) {
+        cusparseLtMatDescriptorDestroy(&sparse_input);
+        cusparseLtMatDescriptorDestroy(&dense_input);
+        cusparseLtMatDescriptorDestroy(&res);
+        cusparseLtMatDescriptorDestroy(&C);
       }
-      descriptor = other.descriptor;
-      has_descriptor = other.has_descriptor;
-      other.has_descriptor = false;
+      sparse_input = other.sparse_input;
+      dense_input = other.dense_input;
+      res = other.res;
+      C = other.C;
+      has_descriptors = other.has_descriptors;
+      other.has_descriptors = false;
     }
     return *this;
   }
-  CachedSparseInputDescriptor(const CachedSparseInputDescriptor&) = delete;
-  CachedSparseInputDescriptor& operator=(const CachedSparseInputDescriptor&) = delete;
+  CachedMatDescriptor(const CachedMatDescriptor&) = delete;
+  CachedMatDescriptor& operator=(const CachedMatDescriptor&) = delete;
 };
 
-constexpr size_t SparseInputDescriptorCacheMaxSize = 128;
+struct MatDescriptorPtrs {
+  cusparseLtMatDescriptor_t* sparse_input = nullptr;
+  cusparseLtMatDescriptor_t* dense_input = nullptr;
+  cusparseLtMatDescriptor_t* res = nullptr;
+  cusparseLtMatDescriptor_t* C = nullptr;
+};
 
-using SparseInputDescriptorLruList =
-    std::list<std::pair<SparseInputDescriptorCacheKey, CachedSparseInputDescriptor>>;
-using SparseInputDescriptorCacheMap = std::unordered_map<
-    SparseInputDescriptorCacheKey,
-    SparseInputDescriptorLruList::iterator,
-    SparseInputDescriptorCacheKeyHash,
-    SparseInputDescriptorCacheKeyEqual>;
+constexpr size_t MatDescriptorCacheMaxSize = 128;
 
+using MatDescriptorLruList =
+    std::list<std::pair<MatDescriptorCacheKey, CachedMatDescriptor>>;
+using MatDescriptorCacheMap = std::unordered_map<
+    MatDescriptorCacheKey,
+    MatDescriptorLruList::iterator,
+    MatDescriptorCacheKeyHash,
+    MatDescriptorCacheKeyEqual>;
 
-struct SparseInputDescriptorCache {
-  SparseInputDescriptorLruList lru_list;
-  SparseInputDescriptorCacheMap cache_map;
+// One cache for the 4-descriptor bundle (sparse_input, dense_input, res, C).
+struct MatDescriptorCache {
+  MatDescriptorLruList lru_list;
+  MatDescriptorCacheMap cache_map;
 
-  // Returns plan pointer and workspace_size if found; moves entry to front for LRU.
-  std::optional<cusparseLtMatDescriptor_t*> lookup(
-      const SparseInputDescriptorCacheKey& key) {
+  std::optional<MatDescriptorPtrs> lookup(const MatDescriptorCacheKey& key) {
     auto it = cache_map.find(key);
     if (it == cache_map.end()) {
       return std::nullopt;
     }
     lru_list.splice(lru_list.begin(), lru_list, it->second);
-    CachedSparseInputDescriptor& entry = it->second->second;
-    return &entry.descriptor;
+    CachedMatDescriptor& entry = it->second->second;
+    MatDescriptorPtrs ptrs;
+    ptrs.sparse_input = &entry.sparse_input;
+    ptrs.dense_input = &entry.dense_input;
+    ptrs.res = &entry.res;
+    ptrs.C = &entry.C;
+    return ptrs;
   }
 
-  void insert(SparseInputDescriptorCacheKey key, CachedSparseInputDescriptor descriptor) {
-    if (lru_list.size() >= SparseInputDescriptorCacheMaxSize) {
+  void insert(MatDescriptorCacheKey key, CachedMatDescriptor descriptor) {
+    if (lru_list.size() >= MatDescriptorCacheMaxSize) {
       auto& back = lru_list.back();
       cache_map.erase(back.first);
       lru_list.pop_back();
@@ -102,63 +133,98 @@ struct SparseInputDescriptorCache {
   }
 };
 
-thread_local std::unique_ptr<SparseInputDescriptorCache> sparse_input_descriptor_cache;
+thread_local std::unique_ptr<MatDescriptorCache> mat_descriptor_cache;
 
-SparseInputDescriptorCache& getSparseInputDescriptorCache() {
-  if (!sparse_input_descriptor_cache) {
-    sparse_input_descriptor_cache = std::make_unique<SparseInputDescriptorCache>();
+MatDescriptorCache& getMatDescriptorCache() {
+  if (!mat_descriptor_cache) {
+    mat_descriptor_cache = std::make_unique<MatDescriptorCache>();
   }
-  return *sparse_input_descriptor_cache;
+  return *mat_descriptor_cache;
 }
 
-enum class MatDescriptorKind { Dense, Sparse };
-
-static cusparseLtMatDescriptor_t* _get_input_descriptor_ptr(
+// Returns all 4 descriptor pointers for this matmul config from one cache key.
+static MatDescriptorPtrs _get_matmul_descriptor_ptrs(
     cusparseLtHandle_t& handle,
-    MatDescriptorKind kind,
-    int64_t rows,
-    int64_t cols,
-    int64_t ld,
-    cudaDataType cuda_type,
-    int64_t alignment = 16,
-    cusparseOrder_t order = CUSPARSE_ORDER_ROW) {
-  SparseInputDescriptorCacheKey key{};
-  key.dim0 = static_cast<int>(rows);
-  key.dim1 = static_cast<int>(cols);
-  key.is_dense = (kind == MatDescriptorKind::Dense);
-  key.cuda_type = static_cast<int32_t>(cuda_type);
-  auto cached = getSparseInputDescriptorCache().lookup(key);
+    int64_t m,
+    int64_t k,
+    int64_t n,
+    bool dense_is_contiguous,
+    bool transpose_result,
+    cudaDataType input_type,
+    cudaDataType output_type,
+    cudaDataType C_type) {
+  MatDescriptorCacheKey key{};
+  key.m = static_cast<int>(m);
+  key.k = static_cast<int>(k);
+  key.n = static_cast<int>(n);
+  key.dense_is_contiguous = dense_is_contiguous;
+  key.transpose_result = transpose_result;
+  key.input_type = static_cast<int32_t>(input_type);
+  key.output_type = static_cast<int32_t>(output_type);
+  key.C_type = static_cast<int32_t>(C_type);
+
+  auto cached = getMatDescriptorCache().lookup(key);
   if (cached.has_value()) {
     return *cached;
   }
-  cusparseLtMatDescriptor_t descriptor;
-  if (kind == MatDescriptorKind::Sparse) {
-    TORCH_CUDASPARSE_CHECK(cusparseLtStructuredDescriptorInit(
-        &handle,
-        &descriptor,
-        rows,
-        cols,
-        ld,
-        alignment,
-        cuda_type,
-        order,
-        CUSPARSELT_SPARSITY_50_PERCENT));
-  } else {
-    TORCH_CUDASPARSE_CHECK(cusparseLtDenseDescriptorInit(
-        &handle,
-        &descriptor,
-        rows,
-        cols,
-        ld,
-        alignment,
-        cuda_type,
-        order));
-  }
-  CachedSparseInputDescriptor cached_descriptor;
-  cached_descriptor.descriptor = descriptor;
-  cached_descriptor.has_descriptor = true;
-  getSparseInputDescriptorCache().insert(std::move(key), std::move(cached_descriptor));
-  cached = getSparseInputDescriptorCache().lookup(key);
+
+  int64_t dense_rows = dense_is_contiguous ? k : n;
+  int64_t dense_cols = dense_is_contiguous ? n : k;
+  int64_t res_ld = transpose_result ? m : n;
+  cusparseOrder_t res_order = transpose_result ? CUSPARSE_ORDER_COL : CUSPARSE_ORDER_ROW;
+
+  CachedMatDescriptor bundle;
+  TORCH_CUDASPARSE_CHECK(cusparseLtStructuredDescriptorInit(
+      &handle,
+      &bundle.sparse_input,
+      m,
+      k,
+      k,
+      16,
+      input_type,
+      CUSPARSE_ORDER_ROW,
+      CUSPARSELT_SPARSITY_50_PERCENT));
+  TORCH_CUDASPARSE_CHECK(cusparseLtDenseDescriptorInit(
+      &handle,
+      &bundle.dense_input,
+      dense_rows,
+      dense_cols,
+      dense_cols,
+      16,
+      input_type,
+      CUSPARSE_ORDER_ROW));
+  TORCH_CUDASPARSE_CHECK(cusparseLtDenseDescriptorInit(
+      &handle,
+      &bundle.res,
+      m,
+      n,
+      res_ld,
+      16,
+      output_type,
+      res_order));
+  TORCH_CUDASPARSE_CHECK(cusparseLtDenseDescriptorInit(
+      &handle,
+      &bundle.C,
+      m,
+      n,
+      res_ld,
+      16,
+      C_type,
+      res_order));
+  bundle.has_descriptors = true;
+
+  getMatDescriptorCache().insert(std::move(key), std::move(bundle));
+  // Rebuild key for lookup (key was moved into insert).
+  MatDescriptorCacheKey key_lookup{};
+  key_lookup.m = static_cast<int>(m);
+  key_lookup.k = static_cast<int>(k);
+  key_lookup.n = static_cast<int>(n);
+  key_lookup.dense_is_contiguous = dense_is_contiguous;
+  key_lookup.transpose_result = transpose_result;
+  key_lookup.input_type = static_cast<int32_t>(input_type);
+  key_lookup.output_type = static_cast<int32_t>(output_type);
+  key_lookup.C_type = static_cast<int32_t>(C_type);
+  cached = getMatDescriptorCache().lookup(key_lookup);
   return *cached;
 }
 
@@ -453,51 +519,22 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
   int64_t n = dense_B.size(1);
   int64_t m = compressed_A.size(0);
 
-  // _get_input_descriptor_ptr(
-  //   cusparseLtHandle_t& handle,
-  //   MatDescriptorKind kind,
-  //   int64_t rows,
-  //   int64_t cols,
-  //   int64_t ld,
-  //   cudaDataType input_type,
-  //   int64_t alignment = 16,
-  //   cusparseOrder_t order = CUSPARSE_ORDER_ROW
-
-  cusparseLtMatDescriptor_t* sparse_input_descriptor_ptr =
-    _get_input_descriptor_ptr(handle, MatDescriptorKind::Sparse, m, k, k, input_type);
-
-  // initialize dense input descriptor
-  int64_t dense_rows = dense_B.is_contiguous() ? k : n;
-  int64_t dense_cols = dense_B.is_contiguous() ? n : k;
-  cusparseLtMatDescriptor_t* dense_input_descriptor_ptr =
-    _get_input_descriptor_ptr(handle, MatDescriptorKind::Dense, dense_rows, dense_cols, dense_cols, input_type);
+  MatDescriptorPtrs desc_ptrs = _get_matmul_descriptor_ptrs(
+      handle,
+      m,
+      k,
+      n,
+      dense_B.is_contiguous(),
+      transpose_result,
+      input_type,
+      output_type,
+      C_type);
 
   // create result tensor
   auto res_tensor_options =
       c10::TensorOptions().dtype(out_dtype).device(dense_B.device());
   at::Tensor res = (transpose_result) ? at::empty({n, m}, res_tensor_options)
                                       : at::empty({m, n}, res_tensor_options);
-
-  cusparseLtMatDescriptor_t* res_descriptor_ptr =
-    _get_input_descriptor_ptr(handle,
-        MatDescriptorKind::Dense,
-        m,
-        n,
-        transpose_result ? m : n,
-        output_type,
-        16,
-        transpose_result ? CUSPARSE_ORDER_COL : CUSPARSE_ORDER_ROW);
-  
-  // For float8, need fp16 C_descriptor, can't use FP8 for this matrix
-  cusparseLtMatDescriptor_t*  C_descriptor_ptr =
-    _get_input_descriptor_ptr(handle,
-        MatDescriptorKind::Dense,
-        m,
-        n,
-        transpose_result ? m : n,
-        C_type,
-        16,
-        transpose_result ? CUSPARSE_ORDER_COL : CUSPARSE_ORDER_ROW);
 
   // initialize matmul
   TORCH_CUDASPARSE_CHECK(cusparseLtMatmulDescriptorInit(
@@ -506,10 +543,10 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
       CUSPARSE_OPERATION_NON_TRANSPOSE,
       (dense_B.is_contiguous()) ? CUSPARSE_OPERATION_NON_TRANSPOSE
                                 : CUSPARSE_OPERATION_TRANSPOSE,
-      sparse_input_descriptor_ptr,
-      dense_input_descriptor_ptr,
-      C_descriptor_ptr,
-      res_descriptor_ptr,
+      desc_ptrs.sparse_input,
+      desc_ptrs.dense_input,
+      desc_ptrs.C,
+      desc_ptrs.res,
       compute_type));
 
   // set bias pointer for matmul, need to assign to get location

--- a/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
+++ b/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
@@ -33,6 +33,7 @@ struct MatDescriptorCacheKey {
   int32_t C_type = 0;
   int32_t compute_type = 0;
   bool has_bias = false;
+  bool has_alpha = false;
   int32_t alg_id = 0;
   int32_t split_k = 1;
   int32_t split_k_mode = -1;
@@ -151,11 +152,11 @@ struct MatDescriptorCache {
       cudaDataType output_type,
       cudaDataType C_type,
       cusparseComputeType compute_type,
-      bool has_bias,
       int alg_id,
       int split_k,
       int split_k_mode,
-      const std::optional<Tensor>& bias_opt) {
+      const std::optional<Tensor>& bias_opt,
+      const std::optional<Tensor>& alpha_opt) {
     MatDescriptorCacheKey key{};
     key.m = static_cast<int>(m);
     key.k = static_cast<int>(k);
@@ -166,11 +167,13 @@ struct MatDescriptorCache {
     key.output_type = static_cast<int32_t>(output_type);
     key.C_type = static_cast<int32_t>(C_type);
     key.compute_type = static_cast<int32_t>(compute_type);
-    key.has_bias = has_bias;
+    key.has_bias = bias_opt.has_value();
+    key.has_alpha = alpha_opt.has_value() && alpha_opt.value().numel() != 1;
     key.alg_id = static_cast<int32_t>(alg_id);
     key.split_k = static_cast<int32_t>(split_k);
     key.split_k_mode = static_cast<int32_t>(split_k_mode);
     MatDescriptorPtrs* result = lookup(key);
+
     if (result == nullptr) {
       if (lru_list.size() >= MatDescriptorCacheMaxSize) {
         auto& back = lru_list.back();
@@ -178,17 +181,13 @@ struct MatDescriptorCache {
         lru_list.pop_back();
       }
       lru_list.push_front({key, CachedMatDescriptor{}});
-    }
-    // Both paths leave the target entry at the front of lru_list:
-    // lookup() splices a hit there; a miss push_front's the new entry.
-    CachedMatDescriptor& entry = lru_list.front().second;
-    if (result == nullptr) {
+      CachedMatDescriptor& entry = lru_list.front().second;
       int64_t dense_rows = dense_is_contiguous ? k : n;
       int64_t dense_cols = dense_is_contiguous ? n : k;
       int64_t res_ld = transpose_result ? m : n;
       cusparseOrder_t res_order =
           transpose_result ? CUSPARSE_ORDER_COL : CUSPARSE_ORDER_ROW;
-  
+
       TORCH_CUDASPARSE_CHECK(cusparseLtStructuredDescriptorInit(
           &handle,
           &entry.sparse_input,
@@ -242,7 +241,7 @@ struct MatDescriptorCache {
           &entry.alg_sel,
           &entry.matmul,
           CUSPARSELT_MATMUL_ALG_DEFAULT));
-  
+
       TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgSetAttribute(
           &handle,
           &entry.alg_sel,
@@ -267,30 +266,38 @@ struct MatDescriptorCache {
               sizeof(splitKMode)));
         }
       }
+
+      entry.ptrs.matmul = &entry.matmul;
+      entry.ptrs.alg_sel = &entry.alg_sel;
+      entry.ptrs.plan = &entry.plan;
+      entry.has_descriptors = true;
+      cache_map[lru_list.front().first] = lru_list.begin();
+      result = &entry.ptrs;
     }
-    
+
     if (bias_opt.has_value()) {
       auto& bias = bias_opt.value();
       void* dBias = bias.data_ptr();
       TORCH_CUDASPARSE_CHECK(cusparseLtMatmulDescSetAttribute(
           &handle,
-          &entry.matmul,
+          result->matmul,
           CUSPARSELT_MATMUL_BIAS_POINTER,
           &dBias,
           sizeof(dBias)));
     }
+    if (alpha_opt.has_value() && alpha_opt.value().numel() != 1) {
+      int tensor_alpha_mode = 1;
+      TORCH_CUDASPARSE_CHECK(cusparseLtMatmulDescSetAttribute(
+          &handle,
+          result->matmul,
+          CUSPARSELT_MATMUL_ALPHA_VECTOR_SCALING,
+          &tensor_alpha_mode,
+          sizeof(tensor_alpha_mode)));
+    }
 
     TORCH_CUDASPARSE_CHECK(cusparseLtMatmulPlanInit(
-        &handle, &entry.plan, &entry.matmul, &entry.alg_sel));
-
-    entry.ptrs.matmul = &entry.matmul;
-    entry.ptrs.alg_sel = &entry.alg_sel;
-    entry.ptrs.plan = &entry.plan;
-    entry.has_descriptors = true;
-    if (result == nullptr) {
-      cache_map[lru_list.front().first] = lru_list.begin();
-    }
-    return &entry.ptrs;
+        &handle, result->plan, result->matmul, result->alg_sel));
+    return result;
   }
 
   void insert(MatDescriptorCacheKey key, CachedMatDescriptor descriptor) {
@@ -607,41 +614,22 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
       output_type,
       C_type,
       compute_type,
-      bias_opt.has_value(),
       alg_id,
       split_k,
       split_k_mode,
-      bias_opt);
+      bias_opt,
+      alpha_opt);
   TORCH_CHECK(
       desc_ptrs != nullptr,
       "cuSPARSELt: mat descriptor cache getOrCreate failed");
 
-  // // set bias pointer for matmul, need to assign to get location
-  // if (bias_opt.has_value()) {
-  //   auto& bias = bias_opt.value();
-  //   void* dBias = bias.data_ptr();
-  //   TORCH_CUDASPARSE_CHECK(cusparseLtMatmulDescSetAttribute(
-  //       &handle,
-  //       desc_ptrs->matmul,
-  //       CUSPARSELT_MATMUL_BIAS_POINTER,
-  //       &dBias,
-  //       sizeof(dBias)));
-  // }
-
-  // set tensor_alpha_mode and alpha pointer for matmul
+  // set alpha pointer for matmul
   const auto alpha_tensor = alpha_opt.has_value() ? *alpha_opt : Tensor{};
   auto alpha_ptr = &alpha;
   if (alpha_opt.has_value()) {
     if (alpha_tensor.numel() == 1) {
       alpha = alpha_tensor.item<float>();
     } else {
-      int tensor_alpha_mode = 1;
-      TORCH_CUDASPARSE_CHECK(cusparseLtMatmulDescSetAttribute(
-          &handle,
-          desc_ptrs->matmul,
-          CUSPARSELT_MATMUL_ALPHA_VECTOR_SCALING,
-          &tensor_alpha_mode,
-          sizeof(tensor_alpha_mode)));
       alpha_ptr = static_cast<float*>(alpha_tensor.data_ptr());
     }
   }

--- a/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
+++ b/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
@@ -3,119 +3,12 @@
 #include <list>
 #include <optional>
 #include <unordered_map>
+#include <mutex>
+#include <string_view>
 #include <utility>
 #if AT_CUSPARSELT_ENABLED()
 
 namespace at::native {
-
-namespace {
-
-// Cache key for cuSPARSELt matmul plan. Must be standard layout for ParamsHash.
-struct CsltMatmulCacheKey {
-  int64_t m = 0;
-  int64_t n = 0;
-  int64_t k = 0;
-  int32_t input_type = 0;
-  int32_t output_type = 0;
-  int32_t C_type = 0;
-  int32_t compute_type = 0;
-  int32_t transpose_result = 0;
-  int32_t dense_contiguous = 0;
-  int32_t has_bias = 0;
-  int32_t tensor_alpha_mode = 0;
-  int32_t alg_id = 0;
-  int32_t split_k = 0;
-  int32_t split_k_mode = 0;
-};
-
-static_assert(std::is_standard_layout_v<CsltMatmulCacheKey>);
-
-using CsltMatmulCacheKeyHash = ParamsHash<CsltMatmulCacheKey>;
-using CsltMatmulCacheKeyEqual = ParamsEqual<CsltMatmulCacheKey>;
-
-// Cached plan and workspace size. Plan is destroyed when the cache entry is evicted.
-// Cache is only used when !has_bias (see comment at cache_enabled).
-struct CachedPlan {
-  cusparseLtMatmulPlan_t plan;
-  size_t workspace_size = 0;
-  bool has_plan = false;
-
-  CachedPlan() = default;
-  ~CachedPlan() {
-    if (has_plan) {
-      cusparseLtMatmulPlanDestroy(&plan);
-      has_plan = false;
-    }
-  }
-  CachedPlan(CachedPlan&& other) noexcept
-      : plan(other.plan),
-        workspace_size(other.workspace_size),
-        has_plan(other.has_plan) {
-    other.has_plan = false;
-  }
-  CachedPlan& operator=(CachedPlan&& other) noexcept {
-    if (this != &other) {
-      if (has_plan) {
-        cusparseLtMatmulPlanDestroy(&plan);
-      }
-      plan = other.plan;
-      workspace_size = other.workspace_size;
-      has_plan = other.has_plan;
-      other.has_plan = false;
-    }
-    return *this;
-  }
-  CachedPlan(const CachedPlan&) = delete;
-  CachedPlan& operator=(const CachedPlan&) = delete;
-};
-
-constexpr size_t kCsltMatmulPlanCacheMaxSize = 128;
-
-using CsltMatmulLruList =
-    std::list<std::pair<CsltMatmulCacheKey, CachedPlan>>;
-using CsltMatmulCacheMap = std::unordered_map<
-    CsltMatmulCacheKey,
-    CsltMatmulLruList::iterator,
-    CsltMatmulCacheKeyHash,
-    CsltMatmulCacheKeyEqual>;
-
-struct CsltMatmulPlanCache {
-  CsltMatmulLruList lru_list;
-  CsltMatmulCacheMap cache_map;
-
-  // Returns plan pointer and workspace_size if found; moves entry to front for LRU.
-  std::optional<std::pair<cusparseLtMatmulPlan_t*, size_t>> lookup(
-      const CsltMatmulCacheKey& key) {
-    auto it = cache_map.find(key);
-    if (it == cache_map.end()) {
-      return std::nullopt;
-    }
-    lru_list.splice(lru_list.begin(), lru_list, it->second);
-    CachedPlan& entry = it->second->second;
-    return std::make_pair(&entry.plan, entry.workspace_size);
-  }
-
-  void insert(CsltMatmulCacheKey key, CachedPlan plan) {
-    if (lru_list.size() >= kCsltMatmulPlanCacheMaxSize) {
-      auto& back = lru_list.back();
-      cache_map.erase(back.first);
-      lru_list.pop_back();
-    }
-    lru_list.push_front({std::move(key), std::move(plan)});
-    cache_map[lru_list.front().first] = lru_list.begin();
-  }
-};
-
-thread_local std::unique_ptr<CsltMatmulPlanCache> cslt_matmul_plan_cache;
-
-CsltMatmulPlanCache& getCsltMatmulPlanCache() {
-  if (!cslt_matmul_plan_cache) {
-    cslt_matmul_plan_cache = std::make_unique<CsltMatmulPlanCache>();
-  }
-  return *cslt_matmul_plan_cache;
-}
-
-} // namespace
 
 // Ideally we would use the same DeviceThreadHandlePool mechanism as used in
 // aten/src/ATen/cuda/CuSparseHandlePool.cpp which would handle this for us.
@@ -127,6 +20,132 @@ CsltMatmulPlanCache& getCsltMatmulPlanCache() {
 // DeviceThreadHandlePool.
 thread_local cusparseLtHandle_t handle;
 thread_local bool handle_initialized = false;
+
+/////////////////////////////////////////////////////////////////////
+
+struct SparseInputDescriptorCacheKey {
+  int m = 0;
+  int k = 0;
+  int32_t input_type = 0;
+};
+
+using SparseInputDescriptorCacheKeyHash = ParamsHash<SparseInputDescriptorCacheKey>;
+using SparseInputDescriptorCacheKeyEqual = ParamsEqual<SparseInputDescriptorCacheKey>;
+
+struct CachedSparseInputDescriptor {
+  cusparseLtMatDescriptor_t descriptor;
+  bool has_descriptor = false;
+
+  CachedSparseInputDescriptor() = default;
+  ~CachedSparseInputDescriptor() {
+    if (has_descriptor) {
+      cusparseLtMatDescriptorDestroy(&descriptor);
+      has_descriptor = false;
+    }
+  }
+  CachedSparseInputDescriptor(CachedSparseInputDescriptor&& other) noexcept
+      : descriptor(other.descriptor),
+        has_descriptor(other.has_descriptor) {
+    other.has_descriptor = false;
+  }
+  CachedSparseInputDescriptor& operator=(CachedSparseInputDescriptor&& other) noexcept {
+    if (this != &other) {
+      if (has_descriptor) {
+        cusparseLtMatDescriptorDestroy(&descriptor);
+      }
+      descriptor = other.descriptor;
+      has_descriptor = other.has_descriptor;
+      other.has_descriptor = false;
+    }
+    return *this;
+  }
+  CachedSparseInputDescriptor(const CachedSparseInputDescriptor&) = delete;
+  CachedSparseInputDescriptor& operator=(const CachedSparseInputDescriptor&) = delete;
+};
+
+constexpr size_t SparseInputDescriptorCacheMaxSize = 128;
+
+using SparseInputDescriptorLruList =
+    std::list<std::pair<SparseInputDescriptorCacheKey, CachedSparseInputDescriptor>>;
+using SparseInputDescriptorCacheMap = std::unordered_map<
+    SparseInputDescriptorCacheKey,
+    SparseInputDescriptorLruList::iterator,
+    SparseInputDescriptorCacheKeyHash,
+    SparseInputDescriptorCacheKeyEqual>;
+
+
+struct SparseInputDescriptorCache {
+  SparseInputDescriptorLruList lru_list;
+  SparseInputDescriptorCacheMap cache_map;
+
+  // Returns plan pointer and workspace_size if found; moves entry to front for LRU.
+  std::optional<cusparseLtMatDescriptor_t*> lookup(
+      const SparseInputDescriptorCacheKey& key) {
+    auto it = cache_map.find(key);
+    if (it == cache_map.end()) {
+      return std::nullopt;
+    }
+    lru_list.splice(lru_list.begin(), lru_list, it->second);
+    CachedSparseInputDescriptor& entry = it->second->second;
+    return &entry.descriptor;
+  }
+
+  void insert(SparseInputDescriptorCacheKey key, CachedSparseInputDescriptor descriptor) {
+    if (lru_list.size() >= SparseInputDescriptorCacheMaxSize) {
+      auto& back = lru_list.back();
+      cache_map.erase(back.first);
+      lru_list.pop_back();
+    }
+    lru_list.push_front({std::move(key), std::move(descriptor)});
+    cache_map[lru_list.front().first] = lru_list.begin();
+  }
+};
+
+thread_local std::unique_ptr<SparseInputDescriptorCache> sparse_input_descriptor_cache;
+
+SparseInputDescriptorCache& getSparseInputDescriptorCache() {
+  if (!sparse_input_descriptor_cache) {
+    sparse_input_descriptor_cache = std::make_unique<SparseInputDescriptorCache>();
+  }
+  return *sparse_input_descriptor_cache;
+}
+
+static cusparseLtMatDescriptor_t* _get_sparse_input_descriptor_ptr(
+    cusparseLtHandle_t& handle,
+    int64_t m,
+    int64_t k,
+    cudaDataType input_type) {
+  SparseInputDescriptorCacheKey key{};
+  key.m = m;
+  key.k = k;
+  key.input_type = static_cast<int32_t>(input_type);
+  auto cached = getSparseInputDescriptorCache().lookup(key);
+  if (cached.has_value()) {
+    return *cached;
+  } 
+  cusparseLtMatDescriptor_t sparse_input_descriptor;
+  TORCH_CUDASPARSE_CHECK(cusparseLtStructuredDescriptorInit(
+      &handle,
+      &sparse_input_descriptor,
+      m,
+      k,
+      k,
+      16,
+      input_type,
+      CUSPARSE_ORDER_ROW,
+      CUSPARSELT_SPARSITY_50_PERCENT));
+      
+  CachedSparseInputDescriptor cached_descriptor;
+  cached_descriptor.descriptor = sparse_input_descriptor;
+  cached_descriptor.has_descriptor = true;
+  getSparseInputDescriptorCache().insert(std::move(key), std::move(cached_descriptor));
+  cached = getSparseInputDescriptorCache().lookup(key);
+  return *cached;
+}
+
+
+//////////////////////////////////////////////////////////////////////
+
 
 #ifdef USE_ROCM
 // Single global flag for platform-wide hipSparseLt support
@@ -266,8 +285,11 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
     TORCH_CUDASPARSE_CHECK(cusparseLtInit(&handle));
     handle_initialized = true;
   }
+  // cuSPARSELt constructs
+  cusparseLtMatmulDescriptor_t matmul;
+  cusparseLtMatmulPlan_t plan;
+  cusparseLtMatmulAlgSelection_t alg_sel;
 
-  int tensor_alpha_mode = 0;
   float alpha = 1.0;
   float beta = 0.0;
   cudaDataType input_type;
@@ -406,107 +428,67 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
     }
   }
 
-  const auto alpha_tensor = alpha_opt.has_value() ? *alpha_opt : Tensor{};
-  if (alpha_opt.has_value()) {
-    if (alpha_tensor.numel() == 1) {
-      alpha = alpha_tensor.item<float>();
-    } else {
-      tensor_alpha_mode = 1;
-    }
-  }
-
   TORCH_INTERNAL_ASSERT(compressed_A.dim() == 2); // encoded M x S
   int64_t k = dense_B.size(0);
   int64_t n = dense_B.size(1);
   int64_t m = compressed_A.size(0);
 
-  const bool has_bias = bias_opt.has_value();
-  // Plan caching disabled: cusparseLtMatmulPlan_t is opaque and retains
-  // internal pointers to the matmul descriptor (and possibly others) passed at
-  // PlanInit. Copying the plan struct into the cache copies those pointers;
-  // the original descriptors are stack locals and go out of scope, so the
-  // cached plan becomes invalid and cusparseLtMatmul(plan_ptr) SIGSEGVs.
-  // Proper caching would require building the plan inside cache-owned memory
-  // so all referenced descriptors outlive the call (not yet implemented).
-  const bool cache_enabled = false;  // !has_bias && !search_alg_id;
+  //////////////////////////////////////////////////////////////
+  // // initialize sparse descriptor
+  // cusparseLtMatDescriptor_t sparse_input_descriptor;
+  // TORCH_CUDASPARSE_CHECK(cusparseLtStructuredDescriptorInit(
+  //     &handle,
+  //     &sparse_input_descriptor,
+  //     m,
+  //     k,
+  //     k,
+  //     16,
+  //     input_type,
+  //     CUSPARSE_ORDER_ROW,
+  //     CUSPARSELT_SPARSITY_50_PERCENT));
+  auto t3 = std::chrono::steady_clock::now();
+  cusparseLtMatDescriptor_t* sparse_input_descriptor_ptr =
+    _get_sparse_input_descriptor_ptr(handle, m, k, input_type);
+  auto t4 = std::chrono::steady_clock::now();
+  double duration_sparse_input_descriptor = std::chrono::duration<double, std::milli>(t4 - t3).count();
+  std::cout << "duration_sparse_input_descriptor = " << duration_sparse_input_descriptor << std::endl;
 
-  if (cache_enabled) {
-    CsltMatmulCacheKey key{};
-    key.m = m;
-    key.n = n;
-    key.k = k;
-    key.input_type = static_cast<int32_t>(input_type);
-    key.output_type = static_cast<int32_t>(output_type);
-    key.C_type = static_cast<int32_t>(C_type);
-    key.compute_type = static_cast<int32_t>(compute_type);
-    key.transpose_result = transpose_result ? 1 : 0;
-    key.dense_contiguous = dense_B.is_contiguous() ? 1 : 0;
-    key.has_bias = has_bias ? 1 : 0;
-    key.tensor_alpha_mode = tensor_alpha_mode;
-    key.alg_id = alg_id;
-    key.split_k = split_k;
-    key.split_k_mode = split_k_mode;
+  // auto t3 = std::chrono::steady_clock::now();
 
-    auto cached = getCsltMatmulPlanCache().lookup(key);
-    if (cached.has_value()) {
-      cusparseLtMatmulPlan_t* plan_ptr = cached->first;
-      size_t workspace_size = cached->second;
-      ScalarType out_dtype = dense_B.scalar_type();
-      if (out_dtype_opt.has_value()) {
-        out_dtype = out_dtype_opt.value();
-      }
-      auto res_tensor_options =
-          c10::TensorOptions().dtype(out_dtype).device(dense_B.device());
-      at::Tensor res = (transpose_result) ? at::empty({n, m}, res_tensor_options)
-                                          : at::empty({m, n}, res_tensor_options);
-      float* alpha_ptr = (tensor_alpha_mode == 1)
-          ? static_cast<float*>(alpha_tensor.data_ptr())
-          : &alpha;
-      auto& allocator = *::c10::cuda::CUDACachingAllocator::get();
-      auto workspacePtr = allocator.allocate(workspace_size);
-      cudaStream_t stream = at::cuda::getCurrentCUDAStream();
-      TORCH_CUDASPARSE_CHECK(cusparseLtMatmul(
-          &handle,
-          plan_ptr,
-          alpha_ptr,
-          compressed_A.data_ptr(),
-          dense_B.data_ptr(),
-          &beta,
-          res.data_ptr(),
-          res.data_ptr(),
-          workspacePtr.get(),
-          &stream,
-          1));
-      const int max_alg_id = 0;
-      cusparseLtSplitKMode_t splitKMode =
-          (split_k_mode > 0) ? static_cast<cusparseLtSplitKMode_t>(split_k_mode)
-                            : static_cast<cusparseLtSplitKMode_t>(-1);
-      return {
-          res,
-          alg_id,
-          split_k,
-          static_cast<int64_t>(splitKMode),
-          max_alg_id};
-    }
-  }
+  // SparseInputDescriptorCacheKey key{};
+  // key.m = m;
+  // key.k = k;
+  // key.input_type = static_cast<int32_t>(input_type);
+  // auto cached = getSparseInputDescriptorCache().lookup(key);
+  // cusparseLtMatDescriptor_t* sparse_input_descriptor_ptr = nullptr;
+  // if (cached.has_value()) {
+  //   sparse_input_descriptor_ptr = *cached;
+  // } else {
+  //   cusparseLtMatDescriptor_t sparse_input_descriptor;
+  //   TORCH_CUDASPARSE_CHECK(cusparseLtStructuredDescriptorInit(
+  //       &handle,
+  //       &sparse_input_descriptor,
+  //       m,
+  //       k,
+  //       k,
+  //       16,
+  //       input_type,
+  //       CUSPARSE_ORDER_ROW,
+  //       CUSPARSELT_SPARSITY_50_PERCENT));
+    
+  //   CachedSparseInputDescriptor cached_descriptor;
+  //   cached_descriptor.descriptor = sparse_input_descriptor;
+  //   cached_descriptor.has_descriptor = true;
+  //   getSparseInputDescriptorCache().insert(std::move(key), std::move(cached_descriptor));
+  //   cached = getSparseInputDescriptorCache().lookup(key);
+  //   sparse_input_descriptor_ptr = *cached;
+  // }
+  // auto t4 = std::chrono::steady_clock::now();
+  // double duration_sparse_input_descriptor = std::chrono::duration<double, std::milli>(t4 - t3).count();
+  // std::cout << "duration_sparse_input_descriptor = " << duration_sparse_input_descriptor << std::endl;
 
-  // Cache miss or cache disabled: build descriptors and plan
-  cusparseLtMatmulDescriptor_t matmul;
-  cusparseLtMatmulPlan_t plan;
-  cusparseLtMatmulAlgSelection_t alg_sel;
 
-  // initialize sparse descriptor
-  cusparseLtMatDescriptor_t sparse_input_descriptor;
-  TORCH_CUDASPARSE_CHECK(cusparseLtStructuredDescriptorInit(
-      &handle,
-      &sparse_input_descriptor,
-      m,
-      k,
-      k,
-      16,
-      input_type,
-      CUSPARSE_ORDER_ROW,
-      CUSPARSELT_SPARSITY_50_PERCENT));
+  /////////////////////////////////////////////////////////////
 
   // initialize dense input descriptor
   cusparseLtMatDescriptor_t dense_input_descriptor;
@@ -525,7 +507,7 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
       c10::TensorOptions().dtype(out_dtype).device(dense_B.device());
   at::Tensor res = (transpose_result) ? at::empty({n, m}, res_tensor_options)
                                       : at::empty({m, n}, res_tensor_options);
-  
+
   cusparseLtMatDescriptor_t res_descriptor;
   TORCH_CUDASPARSE_CHECK(cusparseLtDenseDescriptorInit(
       &handle,
@@ -556,7 +538,7 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
       CUSPARSE_OPERATION_NON_TRANSPOSE,
       (dense_B.is_contiguous()) ? CUSPARSE_OPERATION_NON_TRANSPOSE
                                 : CUSPARSE_OPERATION_TRANSPOSE,
-      &sparse_input_descriptor,
+      sparse_input_descriptor_ptr,
       &dense_input_descriptor,
       &C_descriptor,
       &res_descriptor,
@@ -574,8 +556,12 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
         sizeof(dBias)));
   }
 
+  auto t1 = std::chrono::steady_clock::now();
   TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgSelectionInit(
       &handle, &alg_sel, &matmul, CUSPARSELT_MATMUL_ALG_DEFAULT));
+  auto t2 = std::chrono::steady_clock::now();
+  double duration_plan_init = std::chrono::duration<double, std::milli>(t2 - t1).count();
+  std::cout << "duration_plan_init = " << duration_plan_init << std::endl;
 
   // set matmul search params
   TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgSetAttribute(
@@ -585,8 +571,8 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
       &alg_id,
       sizeof(alg_id)));
 
-  cusparseLtSplitKMode_t splitKMode = static_cast<cusparseLtSplitKMode_t>(-1);
-  int max_alg_id = 0;
+  cusparseLtSplitKMode_t splitKMode;
+  int max_alg_id;
   if (split_k != 1) {
     TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgSetAttribute(
         &handle,
@@ -606,17 +592,22 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
     }
   }
 
-  // set tensor_alpha_mode for matmul descriptor (alpha_ptr used at execution)
-  float* alpha_ptr = (tensor_alpha_mode == 1)
-      ? static_cast<float*>(alpha_tensor.data_ptr())
-      : &alpha;
-  if (tensor_alpha_mode == 1) {
-    TORCH_CUDASPARSE_CHECK(cusparseLtMatmulDescSetAttribute(
-        &handle,
-        &matmul,
-        CUSPARSELT_MATMUL_ALPHA_VECTOR_SCALING,
-        &tensor_alpha_mode,
-        sizeof(tensor_alpha_mode)));
+  // set tensor_alpha_mode and alpha pointer for matmul
+  const auto alpha_tensor = alpha_opt.has_value() ? *alpha_opt : Tensor{};
+  auto alpha_ptr = &alpha;
+  if (alpha_opt.has_value()) {
+    if (alpha_tensor.numel() == 1) {
+      alpha = alpha_tensor.item<float>();
+    } else {
+      int tensor_alpha_mode = 1;
+      TORCH_CUDASPARSE_CHECK(cusparseLtMatmulDescSetAttribute(
+          &handle,
+          &matmul,
+          CUSPARSELT_MATMUL_ALPHA_VECTOR_SCALING,
+          &tensor_alpha_mode,
+          sizeof(tensor_alpha_mode)));
+      alpha_ptr = static_cast<float*>(alpha_tensor.data_ptr());
+    }
   }
 
   TORCH_CUDASPARSE_CHECK(
@@ -625,6 +616,7 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
   size_t workspace_size;
   TORCH_CUDASPARSE_CHECK(
       cusparseLtMatmulGetWorkspace(&handle, &plan, &workspace_size));
+
 
   auto& allocator = *::c10::cuda::CUDACachingAllocator::get();
   auto workspacePtr = allocator.allocate(workspace_size);
@@ -687,43 +679,19 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
         res.data_ptr(),
         res.data_ptr(),
         workspacePtr.get(),
+        // jank because of the way we want this to be an array of streams
         &stream,
         1));
   }
 
   // destroy descriptors
-  TORCH_CUDASPARSE_CHECK(
-      cusparseLtMatDescriptorDestroy(&sparse_input_descriptor));
+  // TORCH_CUDASPARSE_CHECK(
+  //     cusparseLtMatDescriptorDestroy(&sparse_input_descriptor));
   TORCH_CUDASPARSE_CHECK(
       cusparseLtMatDescriptorDestroy(&dense_input_descriptor));
   TORCH_CUDASPARSE_CHECK(cusparseLtMatDescriptorDestroy(&res_descriptor));
-  TORCH_CUDASPARSE_CHECK(cusparseLtMatDescriptorDestroy(&C_descriptor));
-
-  if (cache_enabled) {
-    CsltMatmulCacheKey key{};
-    key.m = m;
-    key.n = n;
-    key.k = k;
-    key.input_type = static_cast<int32_t>(input_type);
-    key.output_type = static_cast<int32_t>(output_type);
-    key.C_type = static_cast<int32_t>(C_type);
-    key.compute_type = static_cast<int32_t>(compute_type);
-    key.transpose_result = transpose_result ? 1 : 0;
-    key.dense_contiguous = dense_B.is_contiguous() ? 1 : 0;
-    key.has_bias = has_bias ? 1 : 0;
-    key.tensor_alpha_mode = tensor_alpha_mode;
-    key.alg_id = alg_id;
-    key.split_k = split_k;
-    key.split_k_mode = split_k_mode;
-    CachedPlan cached_plan;
-    cached_plan.plan = plan;
-    cached_plan.workspace_size = workspace_size;
-    cached_plan.has_plan = true;
-    getCsltMatmulPlanCache().insert(std::move(key), std::move(cached_plan));
-    // Do not destroy plan; cache now owns it.
-  } else {
-    TORCH_CUDASPARSE_CHECK(cusparseLtMatmulPlanDestroy(&plan));
-  }
+  // destroy plan
+  TORCH_CUDASPARSE_CHECK(cusparseLtMatmulPlanDestroy(&plan));
 
   return {
       res,

--- a/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
+++ b/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
@@ -21,8 +21,6 @@ namespace at::native {
 thread_local cusparseLtHandle_t handle;
 thread_local bool handle_initialized = false;
 
-/////////////////////////////////////////////////////////////////////
-
 // One cache key for the full matmul descriptor bundle and plan.
 struct MatDescriptorCacheKey {
   int m = 0;
@@ -43,7 +41,15 @@ struct MatDescriptorCacheKey {
 using MatDescriptorCacheKeyHash = ParamsHash<MatDescriptorCacheKey>;
 using MatDescriptorCacheKeyEqual = ParamsEqual<MatDescriptorCacheKey>;
 
-// One cached entry holds all descriptors and plan for a matmul config (built in-place).
+struct MatDescriptorPtrs {
+  cusparseLtMatmulDescriptor_t* matmul = nullptr;
+  cusparseLtMatmulAlgSelection_t* alg_sel = nullptr;
+  cusparseLtMatmulPlan_t* plan = nullptr;
+};
+
+// Cached entry holds matmul, alg_sel, plan (exposed via ptrs) plus the operand
+// descriptors (sparse_input, dense_input, res, C) which must stay alive because
+// the library retains pointers to them; they are not exposed in MatDescriptorPtrs.
 struct CachedMatDescriptor {
   cusparseLtMatDescriptor_t sparse_input;
   cusparseLtMatDescriptor_t dense_input;
@@ -52,6 +58,7 @@ struct CachedMatDescriptor {
   cusparseLtMatmulDescriptor_t matmul;
   cusparseLtMatmulAlgSelection_t alg_sel;
   cusparseLtMatmulPlan_t plan;
+  MatDescriptorPtrs ptrs;
   bool has_descriptors = false;
 
   CachedMatDescriptor() = default;
@@ -74,6 +81,7 @@ struct CachedMatDescriptor {
         matmul(other.matmul),
         alg_sel(other.alg_sel),
         plan(other.plan),
+        ptrs(other.ptrs),
         has_descriptors(other.has_descriptors) {
     other.has_descriptors = false;
   }
@@ -94,6 +102,7 @@ struct CachedMatDescriptor {
       matmul = other.matmul;
       alg_sel = other.alg_sel;
       plan = other.plan;
+      ptrs = other.ptrs;
       has_descriptors = other.has_descriptors;
       other.has_descriptors = false;
     }
@@ -101,16 +110,6 @@ struct CachedMatDescriptor {
   }
   CachedMatDescriptor(const CachedMatDescriptor&) = delete;
   CachedMatDescriptor& operator=(const CachedMatDescriptor&) = delete;
-};
-
-struct MatDescriptorPtrs {
-  cusparseLtMatDescriptor_t* sparse_input = nullptr;
-  cusparseLtMatDescriptor_t* dense_input = nullptr;
-  cusparseLtMatDescriptor_t* res = nullptr;
-  cusparseLtMatDescriptor_t* C = nullptr;
-  cusparseLtMatmulDescriptor_t* matmul = nullptr;
-  cusparseLtMatmulAlgSelection_t* alg_sel = nullptr;
-  cusparseLtMatmulPlan_t* plan = nullptr;
 };
 
 constexpr size_t MatDescriptorCacheMaxSize = 128;
@@ -123,32 +122,25 @@ using MatDescriptorCacheMap = std::unordered_map<
     MatDescriptorCacheKeyHash,
     MatDescriptorCacheKeyEqual>;
 
-// One cache for the 4-descriptor bundle (sparse_input, dense_input, res, C).
+// Cache for matmul descriptor, alg selection, and plan (keyed by shape/dtype/alg).
 struct MatDescriptorCache {
   MatDescriptorLruList lru_list;
   MatDescriptorCacheMap cache_map;
 
-  std::optional<MatDescriptorPtrs> lookup(const MatDescriptorCacheKey& key) {
+  MatDescriptorPtrs* lookup(const MatDescriptorCacheKey& key) {
     auto it = cache_map.find(key);
     if (it == cache_map.end()) {
-      return std::nullopt;
+      return nullptr;
     }
     lru_list.splice(lru_list.begin(), lru_list, it->second);
     CachedMatDescriptor& entry = it->second->second;
-    MatDescriptorPtrs ptrs;
-    ptrs.sparse_input = &entry.sparse_input;
-    ptrs.dense_input = &entry.dense_input;
-    ptrs.res = &entry.res;
-    ptrs.C = &entry.C;
-    ptrs.matmul = &entry.matmul;
-    ptrs.alg_sel = &entry.alg_sel;
-    ptrs.plan = &entry.plan;
-    return ptrs;
+    entry.ptrs.matmul = &entry.matmul;
+    entry.ptrs.alg_sel = &entry.alg_sel;
+    entry.ptrs.plan = &entry.plan;
+    return &entry.ptrs;
   }
 
-  // Build a new cache entry in-place (no move); create plan once per entry.
-  std::optional<MatDescriptorPtrs> getOrCreate(
-      const MatDescriptorCacheKey& key,
+  MatDescriptorPtrs* getOrCreate(
       cusparseLtHandle_t& handle,
       int64_t m,
       int64_t k,
@@ -159,11 +151,26 @@ struct MatDescriptorCache {
       cudaDataType output_type,
       cudaDataType C_type,
       cusparseComputeType compute_type,
+      bool has_bias,
       int alg_id,
       int split_k,
       int split_k_mode) {
-    auto result = lookup(key);
-    if (result.has_value()) {
+    MatDescriptorCacheKey key{};
+    key.m = static_cast<int>(m);
+    key.k = static_cast<int>(k);
+    key.n = static_cast<int>(n);
+    key.dense_is_contiguous = dense_is_contiguous;
+    key.transpose_result = transpose_result;
+    key.input_type = static_cast<int32_t>(input_type);
+    key.output_type = static_cast<int32_t>(output_type);
+    key.C_type = static_cast<int32_t>(C_type);
+    key.compute_type = static_cast<int32_t>(compute_type);
+    key.has_bias = has_bias;
+    key.alg_id = static_cast<int32_t>(alg_id);
+    key.split_k = static_cast<int32_t>(split_k);
+    key.split_k_mode = static_cast<int32_t>(split_k_mode);
+    MatDescriptorPtrs* result = lookup(key);
+    if (result != nullptr) {
       return result;
     }
     if (lru_list.size() >= MatDescriptorCacheMaxSize) {
@@ -262,9 +269,12 @@ struct MatDescriptorCache {
     TORCH_CUDASPARSE_CHECK(cusparseLtMatmulPlanInit(
         &handle, &entry.plan, &entry.matmul, &entry.alg_sel));
 
+    entry.ptrs.matmul = &entry.matmul;
+    entry.ptrs.alg_sel = &entry.alg_sel;
+    entry.ptrs.plan = &entry.plan;
     entry.has_descriptors = true;
     cache_map[lru_list.front().first] = lru_list.begin();
-    return lookup(key);
+    return &lru_list.front().second.ptrs;
   }
 
   void insert(MatDescriptorCacheKey key, CachedMatDescriptor descriptor) {
@@ -286,63 +296,6 @@ MatDescriptorCache& getMatDescriptorCache() {
   }
   return *mat_descriptor_cache;
 }
-
-// Returns descriptor pointers and plan for this matmul config (cache built in-place).
-static MatDescriptorPtrs _get_matmul_descriptor_ptrs(
-    cusparseLtHandle_t& handle,
-    int64_t m,
-    int64_t k,
-    int64_t n,
-    bool dense_is_contiguous,
-    bool transpose_result,
-    cudaDataType input_type,
-    cudaDataType output_type,
-    cudaDataType C_type,
-    cusparseComputeType compute_type,
-    bool has_bias,
-    int alg_id,
-    int split_k,
-    int split_k_mode) {
-  MatDescriptorCacheKey key{};
-  key.m = static_cast<int>(m);
-  key.k = static_cast<int>(k);
-  key.n = static_cast<int>(n);
-  key.dense_is_contiguous = dense_is_contiguous;
-  key.transpose_result = transpose_result;
-  key.input_type = static_cast<int32_t>(input_type);
-  key.output_type = static_cast<int32_t>(output_type);
-  key.C_type = static_cast<int32_t>(C_type);
-  key.compute_type = static_cast<int32_t>(compute_type);
-  key.has_bias = has_bias;
-  key.alg_id = static_cast<int32_t>(alg_id);
-  key.split_k = static_cast<int32_t>(split_k);
-  key.split_k_mode = static_cast<int32_t>(split_k_mode);
-
-  auto result = getMatDescriptorCache().getOrCreate(
-      key,
-      handle,
-      m,
-      k,
-      n,
-      dense_is_contiguous,
-      transpose_result,
-      input_type,
-      output_type,
-      C_type,
-      compute_type,
-      alg_id,
-      split_k,
-      split_k_mode);
-  TORCH_CHECK(
-      result.has_value(),
-      "cuSPARSELt: mat descriptor cache getOrCreate failed");
-  return *result;
-}
-
-
-
-//////////////////////////////////////////////////////////////////////
-
 
 #ifdef USE_ROCM
 // Single global flag for platform-wide hipSparseLt support
@@ -626,7 +579,7 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
   int64_t n = dense_B.size(1);
   int64_t m = compressed_A.size(0);
 
-  MatDescriptorPtrs desc_ptrs = _get_matmul_descriptor_ptrs(
+  MatDescriptorPtrs* desc_ptrs = getMatDescriptorCache().getOrCreate(
       handle,
       m,
       k,
@@ -641,32 +594,9 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
       alg_id,
       split_k,
       split_k_mode);
-
-  // bool not_null_sparse_input = (desc_ptrs.sparse_input != nullptr);
-  // bool not_null_dense_input = (desc_ptrs.dense_input != nullptr);
-  // bool not_null_res = (desc_ptrs.res != nullptr);
-  // bool not_null_C = (desc_ptrs.C != nullptr);
-  // bool not_null_alg_sel = (desc_ptrs.alg_sel != nullptr);
-  // std::cout << "not_null_sparse_input=" << not_null_sparse_input
-  //           << " not_null_dense_input=" << not_null_dense_input
-  //           << " not_null_res=" << not_null_res
-  //           << " not_null_C=" << not_null_C
-  //           << " not_null_alg_sel=" << not_null_alg_sel
-  //           << std::endl;
-
-  // // initialize matmul
-  // TORCH_CUDASPARSE_CHECK(cusparseLtMatmulDescriptorInit(
-  //     &handle,
-  //     &matmul,
-  //     CUSPARSE_OPERATION_NON_TRANSPOSE,
-  //     (dense_B.is_contiguous()) ? CUSPARSE_OPERATION_NON_TRANSPOSE
-  //                               : CUSPARSE_OPERATION_TRANSPOSE,
-  //     desc_ptrs.sparse_input,
-  //     desc_ptrs.dense_input,
-  //     desc_ptrs.C,
-  //     desc_ptrs.res,
-  //     compute_type));
-
+  TORCH_CHECK(
+      desc_ptrs != nullptr,
+      "cuSPARSELt: mat descriptor cache getOrCreate failed");
 
   // set bias pointer for matmul, need to assign to get location
   if (bias_opt.has_value()) {
@@ -674,19 +604,11 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
     void* dBias = bias.data_ptr();
     TORCH_CUDASPARSE_CHECK(cusparseLtMatmulDescSetAttribute(
         &handle,
-        desc_ptrs.matmul,
+        desc_ptrs->matmul,
         CUSPARSELT_MATMUL_BIAS_POINTER,
         &dBias,
         sizeof(dBias)));
   }
-
-
-  // auto ta1 = std::chrono::steady_clock::now();  ~.285545
-  // TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgSelectionInit(
-  //     &handle, &alg_sel, &matmul, CUSPARSELT_MATMUL_ALG_DEFAULT));
-  // auto ta2 = std::chrono::steady_clock::now();
-  // double duration_alg_init = std::chrono::duration<double, std::milli>(ta2 - ta1).count();
-  // std::cout << "duration_alg_init = " << duration_alg_init << std::endl;
 
   cusparseLtSplitKMode_t splitKMode;
   int max_alg_id;
@@ -701,7 +623,7 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
       int tensor_alpha_mode = 1;
       TORCH_CUDASPARSE_CHECK(cusparseLtMatmulDescSetAttribute(
           &handle,
-          desc_ptrs.matmul,
+          desc_ptrs->matmul,
           CUSPARSELT_MATMUL_ALPHA_VECTOR_SCALING,
           &tensor_alpha_mode,
           sizeof(tensor_alpha_mode)));
@@ -711,7 +633,7 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
 
   size_t workspace_size;
   TORCH_CUDASPARSE_CHECK(
-      cusparseLtMatmulGetWorkspace(&handle, desc_ptrs.plan, &workspace_size));
+      cusparseLtMatmulGetWorkspace(&handle, desc_ptrs->plan, &workspace_size));
 
 
   auto& allocator = *::c10::cuda::CUDACachingAllocator::get();
@@ -728,7 +650,7 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
     // run matmul search
     TORCH_CUDASPARSE_CHECK(cusparseLtMatmulSearch(
         &handle,
-        desc_ptrs.plan,
+        desc_ptrs->plan,
         alpha_ptr,
         compressed_A.data_ptr(),
         dense_B.data_ptr(),
@@ -743,28 +665,28 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
     // get matmul params used
     TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgGetAttribute(
         &handle,
-        desc_ptrs.alg_sel,
+        desc_ptrs->alg_sel,
         CUSPARSELT_MATMUL_ALG_CONFIG_ID,
         &alg_id,
         sizeof(alg_id)));
 
     TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgGetAttribute(
         &handle,
-        desc_ptrs.alg_sel,
+        desc_ptrs->alg_sel,
         CUSPARSELT_MATMUL_SPLIT_K,
         &split_k,
         sizeof(split_k)));
 
     TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgGetAttribute(
         &handle,
-        desc_ptrs.alg_sel,
+        desc_ptrs->alg_sel,
         CUSPARSELT_MATMUL_SPLIT_K_MODE,
         &splitKMode,
         sizeof(splitKMode)));
 
     TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgGetAttribute(
         &handle,
-        desc_ptrs.alg_sel,
+        desc_ptrs->alg_sel,
         CUSPARSELT_MATMUL_ALG_CONFIG_MAX_ID,
         &max_alg_id,
         sizeof(max_alg_id)));
@@ -773,7 +695,7 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
     // do normal matmul
     TORCH_CUDASPARSE_CHECK(cusparseLtMatmul(
         &handle,
-        desc_ptrs.plan,
+        desc_ptrs->plan,
         alpha_ptr,
         compressed_A.data_ptr(),
         dense_B.data_ptr(),

--- a/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
+++ b/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
@@ -1,10 +1,121 @@
 #include <ATen/native/sparse/cuda/cuSPARSELtOps.h>
+#include <ATen/native/utils/ParamsHash.h>
+#include <list>
+#include <optional>
 #include <unordered_map>
-#include <mutex>
-#include <string_view>
+#include <utility>
 #if AT_CUSPARSELT_ENABLED()
 
 namespace at::native {
+
+namespace {
+
+// Cache key for cuSPARSELt matmul plan. Must be standard layout for ParamsHash.
+struct CsltMatmulCacheKey {
+  int64_t m = 0;
+  int64_t n = 0;
+  int64_t k = 0;
+  int32_t input_type = 0;
+  int32_t output_type = 0;
+  int32_t C_type = 0;
+  int32_t compute_type = 0;
+  int32_t transpose_result = 0;
+  int32_t dense_contiguous = 0;
+  int32_t has_bias = 0;
+  int32_t tensor_alpha_mode = 0;
+  int32_t alg_id = 0;
+  int32_t split_k = 0;
+  int32_t split_k_mode = 0;
+};
+
+static_assert(std::is_standard_layout_v<CsltMatmulCacheKey>);
+
+using CsltMatmulCacheKeyHash = ParamsHash<CsltMatmulCacheKey>;
+using CsltMatmulCacheKeyEqual = ParamsEqual<CsltMatmulCacheKey>;
+
+// Cached plan and workspace size. Plan is destroyed when the cache entry is evicted.
+// Cache is only used when !has_bias (see comment at cache_enabled).
+struct CachedPlan {
+  cusparseLtMatmulPlan_t plan;
+  size_t workspace_size = 0;
+  bool has_plan = false;
+
+  CachedPlan() = default;
+  ~CachedPlan() {
+    if (has_plan) {
+      cusparseLtMatmulPlanDestroy(&plan);
+      has_plan = false;
+    }
+  }
+  CachedPlan(CachedPlan&& other) noexcept
+      : plan(other.plan),
+        workspace_size(other.workspace_size),
+        has_plan(other.has_plan) {
+    other.has_plan = false;
+  }
+  CachedPlan& operator=(CachedPlan&& other) noexcept {
+    if (this != &other) {
+      if (has_plan) {
+        cusparseLtMatmulPlanDestroy(&plan);
+      }
+      plan = other.plan;
+      workspace_size = other.workspace_size;
+      has_plan = other.has_plan;
+      other.has_plan = false;
+    }
+    return *this;
+  }
+  CachedPlan(const CachedPlan&) = delete;
+  CachedPlan& operator=(const CachedPlan&) = delete;
+};
+
+constexpr size_t kCsltMatmulPlanCacheMaxSize = 128;
+
+using CsltMatmulLruList =
+    std::list<std::pair<CsltMatmulCacheKey, CachedPlan>>;
+using CsltMatmulCacheMap = std::unordered_map<
+    CsltMatmulCacheKey,
+    CsltMatmulLruList::iterator,
+    CsltMatmulCacheKeyHash,
+    CsltMatmulCacheKeyEqual>;
+
+struct CsltMatmulPlanCache {
+  CsltMatmulLruList lru_list;
+  CsltMatmulCacheMap cache_map;
+
+  // Returns plan pointer and workspace_size if found; moves entry to front for LRU.
+  std::optional<std::pair<cusparseLtMatmulPlan_t*, size_t>> lookup(
+      const CsltMatmulCacheKey& key) {
+    auto it = cache_map.find(key);
+    if (it == cache_map.end()) {
+      return std::nullopt;
+    }
+    lru_list.splice(lru_list.begin(), lru_list, it->second);
+    CachedPlan& entry = it->second->second;
+    return std::make_pair(&entry.plan, entry.workspace_size);
+  }
+
+  void insert(CsltMatmulCacheKey key, CachedPlan plan) {
+    if (lru_list.size() >= kCsltMatmulPlanCacheMaxSize) {
+      auto& back = lru_list.back();
+      cache_map.erase(back.first);
+      lru_list.pop_back();
+    }
+    lru_list.push_front({std::move(key), std::move(plan)});
+    cache_map[lru_list.front().first] = lru_list.begin();
+  }
+};
+
+thread_local std::unique_ptr<CsltMatmulPlanCache> cslt_matmul_plan_cache;
+
+CsltMatmulPlanCache& getCsltMatmulPlanCache() {
+  if (!cslt_matmul_plan_cache) {
+    cslt_matmul_plan_cache = std::make_unique<CsltMatmulPlanCache>();
+  }
+  return *cslt_matmul_plan_cache;
+}
+
+} // namespace
 
 // Ideally we would use the same DeviceThreadHandlePool mechanism as used in
 // aten/src/ATen/cuda/CuSparseHandlePool.cpp which would handle this for us.
@@ -155,10 +266,6 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
     TORCH_CUDASPARSE_CHECK(cusparseLtInit(&handle));
     handle_initialized = true;
   }
-  // cuSPARSELt constructs
-  cusparseLtMatmulDescriptor_t matmul;
-  cusparseLtMatmulPlan_t plan;
-  cusparseLtMatmulAlgSelection_t alg_sel;
 
   int tensor_alpha_mode = 0;
   float alpha = 1.0;
@@ -299,10 +406,94 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
     }
   }
 
+  const auto alpha_tensor = alpha_opt.has_value() ? *alpha_opt : Tensor{};
+  if (alpha_opt.has_value()) {
+    if (alpha_tensor.numel() == 1) {
+      alpha = alpha_tensor.item<float>();
+    } else {
+      tensor_alpha_mode = 1;
+    }
+  }
+
   TORCH_INTERNAL_ASSERT(compressed_A.dim() == 2); // encoded M x S
   int64_t k = dense_B.size(0);
   int64_t n = dense_B.size(1);
   int64_t m = compressed_A.size(0);
+
+  const bool has_bias = bias_opt.has_value();
+  // Plan caching disabled: cusparseLtMatmulPlan_t is opaque and retains
+  // internal pointers to the matmul descriptor (and possibly others) passed at
+  // PlanInit. Copying the plan struct into the cache copies those pointers;
+  // the original descriptors are stack locals and go out of scope, so the
+  // cached plan becomes invalid and cusparseLtMatmul(plan_ptr) SIGSEGVs.
+  // Proper caching would require building the plan inside cache-owned memory
+  // so all referenced descriptors outlive the call (not yet implemented).
+  const bool cache_enabled = false;  // !has_bias && !search_alg_id;
+
+  if (cache_enabled) {
+    CsltMatmulCacheKey key{};
+    key.m = m;
+    key.n = n;
+    key.k = k;
+    key.input_type = static_cast<int32_t>(input_type);
+    key.output_type = static_cast<int32_t>(output_type);
+    key.C_type = static_cast<int32_t>(C_type);
+    key.compute_type = static_cast<int32_t>(compute_type);
+    key.transpose_result = transpose_result ? 1 : 0;
+    key.dense_contiguous = dense_B.is_contiguous() ? 1 : 0;
+    key.has_bias = has_bias ? 1 : 0;
+    key.tensor_alpha_mode = tensor_alpha_mode;
+    key.alg_id = alg_id;
+    key.split_k = split_k;
+    key.split_k_mode = split_k_mode;
+
+    auto cached = getCsltMatmulPlanCache().lookup(key);
+    if (cached.has_value()) {
+      cusparseLtMatmulPlan_t* plan_ptr = cached->first;
+      size_t workspace_size = cached->second;
+      ScalarType out_dtype = dense_B.scalar_type();
+      if (out_dtype_opt.has_value()) {
+        out_dtype = out_dtype_opt.value();
+      }
+      auto res_tensor_options =
+          c10::TensorOptions().dtype(out_dtype).device(dense_B.device());
+      at::Tensor res = (transpose_result) ? at::empty({n, m}, res_tensor_options)
+                                          : at::empty({m, n}, res_tensor_options);
+      float* alpha_ptr = (tensor_alpha_mode == 1)
+          ? static_cast<float*>(alpha_tensor.data_ptr())
+          : &alpha;
+      auto& allocator = *::c10::cuda::CUDACachingAllocator::get();
+      auto workspacePtr = allocator.allocate(workspace_size);
+      cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+      TORCH_CUDASPARSE_CHECK(cusparseLtMatmul(
+          &handle,
+          plan_ptr,
+          alpha_ptr,
+          compressed_A.data_ptr(),
+          dense_B.data_ptr(),
+          &beta,
+          res.data_ptr(),
+          res.data_ptr(),
+          workspacePtr.get(),
+          &stream,
+          1));
+      const int max_alg_id = 0;
+      cusparseLtSplitKMode_t splitKMode =
+          (split_k_mode > 0) ? static_cast<cusparseLtSplitKMode_t>(split_k_mode)
+                            : static_cast<cusparseLtSplitKMode_t>(-1);
+      return {
+          res,
+          alg_id,
+          split_k,
+          static_cast<int64_t>(splitKMode),
+          max_alg_id};
+    }
+  }
+
+  // Cache miss or cache disabled: build descriptors and plan
+  cusparseLtMatmulDescriptor_t matmul;
+  cusparseLtMatmulPlan_t plan;
+  cusparseLtMatmulAlgSelection_t alg_sel;
 
   // initialize sparse descriptor
   cusparseLtMatDescriptor_t sparse_input_descriptor;
@@ -334,7 +525,7 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
       c10::TensorOptions().dtype(out_dtype).device(dense_B.device());
   at::Tensor res = (transpose_result) ? at::empty({n, m}, res_tensor_options)
                                       : at::empty({m, n}, res_tensor_options);
-
+  
   cusparseLtMatDescriptor_t res_descriptor;
   TORCH_CUDASPARSE_CHECK(cusparseLtDenseDescriptorInit(
       &handle,
@@ -394,8 +585,8 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
       &alg_id,
       sizeof(alg_id)));
 
-  cusparseLtSplitKMode_t splitKMode;
-  int max_alg_id;
+  cusparseLtSplitKMode_t splitKMode = static_cast<cusparseLtSplitKMode_t>(-1);
+  int max_alg_id = 0;
   if (split_k != 1) {
     TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgSetAttribute(
         &handle,
@@ -415,22 +606,17 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
     }
   }
 
-  // set tensor_alpha_mode and alpha pointer for matmul
-  const auto alpha_tensor = alpha_opt.has_value() ? *alpha_opt : Tensor{};
-  auto alpha_ptr = &alpha;
-  if (alpha_opt.has_value()) {
-    if (alpha_tensor.numel() == 1) {
-      alpha = alpha_tensor.item<float>();
-    } else {
-      tensor_alpha_mode = 1;
-      TORCH_CUDASPARSE_CHECK(cusparseLtMatmulDescSetAttribute(
-          &handle,
-          &matmul,
-          CUSPARSELT_MATMUL_ALPHA_VECTOR_SCALING,
-          &tensor_alpha_mode,
-          sizeof(tensor_alpha_mode)));
-      alpha_ptr = static_cast<float*>(alpha_tensor.data_ptr());
-    }
+  // set tensor_alpha_mode for matmul descriptor (alpha_ptr used at execution)
+  float* alpha_ptr = (tensor_alpha_mode == 1)
+      ? static_cast<float*>(alpha_tensor.data_ptr())
+      : &alpha;
+  if (tensor_alpha_mode == 1) {
+    TORCH_CUDASPARSE_CHECK(cusparseLtMatmulDescSetAttribute(
+        &handle,
+        &matmul,
+        CUSPARSELT_MATMUL_ALPHA_VECTOR_SCALING,
+        &tensor_alpha_mode,
+        sizeof(tensor_alpha_mode)));
   }
 
   TORCH_CUDASPARSE_CHECK(
@@ -501,7 +687,6 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
         res.data_ptr(),
         res.data_ptr(),
         workspacePtr.get(),
-        // jank because of the way we want this to be an array of streams
         &stream,
         1));
   }
@@ -512,8 +697,33 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
   TORCH_CUDASPARSE_CHECK(
       cusparseLtMatDescriptorDestroy(&dense_input_descriptor));
   TORCH_CUDASPARSE_CHECK(cusparseLtMatDescriptorDestroy(&res_descriptor));
-  // destroy plan
-  TORCH_CUDASPARSE_CHECK(cusparseLtMatmulPlanDestroy(&plan));
+  TORCH_CUDASPARSE_CHECK(cusparseLtMatDescriptorDestroy(&C_descriptor));
+
+  if (cache_enabled) {
+    CsltMatmulCacheKey key{};
+    key.m = m;
+    key.n = n;
+    key.k = k;
+    key.input_type = static_cast<int32_t>(input_type);
+    key.output_type = static_cast<int32_t>(output_type);
+    key.C_type = static_cast<int32_t>(C_type);
+    key.compute_type = static_cast<int32_t>(compute_type);
+    key.transpose_result = transpose_result ? 1 : 0;
+    key.dense_contiguous = dense_B.is_contiguous() ? 1 : 0;
+    key.has_bias = has_bias ? 1 : 0;
+    key.tensor_alpha_mode = tensor_alpha_mode;
+    key.alg_id = alg_id;
+    key.split_k = split_k;
+    key.split_k_mode = split_k_mode;
+    CachedPlan cached_plan;
+    cached_plan.plan = plan;
+    cached_plan.workspace_size = workspace_size;
+    cached_plan.has_plan = true;
+    getCsltMatmulPlanCache().insert(std::move(key), std::move(cached_plan));
+    // Do not destroy plan; cache now owns it.
+  } else {
+    TORCH_CUDASPARSE_CHECK(cusparseLtMatmulPlanDestroy(&plan));
+  }
 
   return {
       res,

--- a/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
+++ b/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
@@ -26,6 +26,8 @@ thread_local bool handle_initialized = false;
 struct SparseInputDescriptorCacheKey {
   int m = 0;
   int k = 0;
+  bool is_contiguous = true;
+  bool is_dense = false;
   int32_t input_type = 0;
 };
 
@@ -118,6 +120,8 @@ static cusparseLtMatDescriptor_t* _get_sparse_input_descriptor_ptr(
   SparseInputDescriptorCacheKey key{};
   key.m = m;
   key.k = k;
+  key.is_contiguous = true;
+  key.is_dense = false;
   key.input_type = static_cast<int32_t>(input_type);
   auto cached = getSparseInputDescriptorCache().lookup(key);
   if (cached.has_value()) {
@@ -142,6 +146,43 @@ static cusparseLtMatDescriptor_t* _get_sparse_input_descriptor_ptr(
   cached = getSparseInputDescriptorCache().lookup(key);
   return *cached;
 }
+
+
+static cusparseLtMatDescriptor_t* _get_dense_input_descriptor_ptr(
+    cusparseLtHandle_t& handle,
+    int64_t k,
+    int64_t n,
+    bool is_contiguous,
+    cudaDataType input_type) {
+  SparseInputDescriptorCacheKey key{};
+  key.m = n;
+  key.k = k;
+  key.is_contiguous = is_contiguous;
+  key.is_dense = true;
+  key.input_type = static_cast<int32_t>(input_type);
+  auto cached = getSparseInputDescriptorCache().lookup(key);
+  if (cached.has_value()) {
+    return *cached;
+  } 
+  cusparseLtMatDescriptor_t dense_input_descriptor;
+  TORCH_CUDASPARSE_CHECK(cusparseLtDenseDescriptorInit(
+      &handle,
+      &dense_input_descriptor,
+      is_contiguous ? k : n,
+      is_contiguous ? n : k,
+      is_contiguous ? n : k,
+      16,
+      input_type,
+      CUSPARSE_ORDER_ROW));
+      
+  CachedSparseInputDescriptor cached_descriptor;
+  cached_descriptor.descriptor = dense_input_descriptor;
+  cached_descriptor.has_descriptor = true;
+  getSparseInputDescriptorCache().insert(std::move(key), std::move(cached_descriptor));
+  cached = getSparseInputDescriptorCache().lookup(key);
+  return *cached;
+}
+
 
 
 //////////////////////////////////////////////////////////////////////
@@ -434,74 +475,19 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
   int64_t m = compressed_A.size(0);
 
   //////////////////////////////////////////////////////////////
-  // // initialize sparse descriptor
-  // cusparseLtMatDescriptor_t sparse_input_descriptor;
-  // TORCH_CUDASPARSE_CHECK(cusparseLtStructuredDescriptorInit(
-  //     &handle,
-  //     &sparse_input_descriptor,
-  //     m,
-  //     k,
-  //     k,
-  //     16,
-  //     input_type,
-  //     CUSPARSE_ORDER_ROW,
-  //     CUSPARSELT_SPARSITY_50_PERCENT));
-  auto t3 = std::chrono::steady_clock::now();
+  // initialize sparse descriptor
+  // auto t3 = std::chrono::steady_clock::now();
   cusparseLtMatDescriptor_t* sparse_input_descriptor_ptr =
     _get_sparse_input_descriptor_ptr(handle, m, k, input_type);
-  auto t4 = std::chrono::steady_clock::now();
-  double duration_sparse_input_descriptor = std::chrono::duration<double, std::milli>(t4 - t3).count();
-  std::cout << "duration_sparse_input_descriptor = " << duration_sparse_input_descriptor << std::endl;
-
-  // auto t3 = std::chrono::steady_clock::now();
-
-  // SparseInputDescriptorCacheKey key{};
-  // key.m = m;
-  // key.k = k;
-  // key.input_type = static_cast<int32_t>(input_type);
-  // auto cached = getSparseInputDescriptorCache().lookup(key);
-  // cusparseLtMatDescriptor_t* sparse_input_descriptor_ptr = nullptr;
-  // if (cached.has_value()) {
-  //   sparse_input_descriptor_ptr = *cached;
-  // } else {
-  //   cusparseLtMatDescriptor_t sparse_input_descriptor;
-  //   TORCH_CUDASPARSE_CHECK(cusparseLtStructuredDescriptorInit(
-  //       &handle,
-  //       &sparse_input_descriptor,
-  //       m,
-  //       k,
-  //       k,
-  //       16,
-  //       input_type,
-  //       CUSPARSE_ORDER_ROW,
-  //       CUSPARSELT_SPARSITY_50_PERCENT));
-    
-  //   CachedSparseInputDescriptor cached_descriptor;
-  //   cached_descriptor.descriptor = sparse_input_descriptor;
-  //   cached_descriptor.has_descriptor = true;
-  //   getSparseInputDescriptorCache().insert(std::move(key), std::move(cached_descriptor));
-  //   cached = getSparseInputDescriptorCache().lookup(key);
-  //   sparse_input_descriptor_ptr = *cached;
-  // }
   // auto t4 = std::chrono::steady_clock::now();
   // double duration_sparse_input_descriptor = std::chrono::duration<double, std::milli>(t4 - t3).count();
   // std::cout << "duration_sparse_input_descriptor = " << duration_sparse_input_descriptor << std::endl;
-
-
   /////////////////////////////////////////////////////////////
 
   // initialize dense input descriptor
-  cusparseLtMatDescriptor_t dense_input_descriptor;
-  TORCH_CUDASPARSE_CHECK(cusparseLtDenseDescriptorInit(
-      &handle,
-      &dense_input_descriptor,
-      (dense_B.is_contiguous()) ? k : n,
-      (dense_B.is_contiguous()) ? n : k,
-      (dense_B.is_contiguous()) ? n : k,
-      16,
-      input_type,
-      CUSPARSE_ORDER_ROW));
-
+  cusparseLtMatDescriptor_t* dense_input_descriptor_ptr = 
+    _get_dense_input_descriptor_ptr(handle, k, n, dense_B.is_contiguous(), input_type);
+  
   // create result tensor
   auto res_tensor_options =
       c10::TensorOptions().dtype(out_dtype).device(dense_B.device());
@@ -539,7 +525,7 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
       (dense_B.is_contiguous()) ? CUSPARSE_OPERATION_NON_TRANSPOSE
                                 : CUSPARSE_OPERATION_TRANSPOSE,
       sparse_input_descriptor_ptr,
-      &dense_input_descriptor,
+      dense_input_descriptor_ptr,
       &C_descriptor,
       &res_descriptor,
       compute_type));
@@ -556,12 +542,12 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
         sizeof(dBias)));
   }
 
-  auto t1 = std::chrono::steady_clock::now();
+  // auto t1 = std::chrono::steady_clock::now();
   TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgSelectionInit(
       &handle, &alg_sel, &matmul, CUSPARSELT_MATMUL_ALG_DEFAULT));
-  auto t2 = std::chrono::steady_clock::now();
-  double duration_plan_init = std::chrono::duration<double, std::milli>(t2 - t1).count();
-  std::cout << "duration_plan_init = " << duration_plan_init << std::endl;
+  // auto t2 = std::chrono::steady_clock::now();
+  // double duration_plan_init = std::chrono::duration<double, std::milli>(t2 - t1).count();
+  // std::cout << "duration_plan_init = " << duration_plan_init << std::endl;
 
   // set matmul search params
   TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgSetAttribute(
@@ -687,8 +673,8 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
   // destroy descriptors
   // TORCH_CUDASPARSE_CHECK(
   //     cusparseLtMatDescriptorDestroy(&sparse_input_descriptor));
-  TORCH_CUDASPARSE_CHECK(
-      cusparseLtMatDescriptorDestroy(&dense_input_descriptor));
+  // TORCH_CUDASPARSE_CHECK(
+  //     cusparseLtMatDescriptorDestroy(&dense_input_descriptor));
   TORCH_CUDASPARSE_CHECK(cusparseLtMatDescriptorDestroy(&res_descriptor));
   // destroy plan
   TORCH_CUDASPARSE_CHECK(cusparseLtMatmulPlanDestroy(&plan));

--- a/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
+++ b/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
@@ -579,6 +579,7 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
   int64_t n = dense_B.size(1);
   int64_t m = compressed_A.size(0);
 
+  // set up matmul descriptors and cache them or retrieve from cache.
   MatDescriptorPtrs* desc_ptrs = getMatDescriptorCache().getOrCreate(
       handle,
       m,
@@ -610,9 +611,6 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
         sizeof(dBias)));
   }
 
-  cusparseLtSplitKMode_t splitKMode;
-  int max_alg_id;
-
   // set tensor_alpha_mode and alpha pointer for matmul
   const auto alpha_tensor = alpha_opt.has_value() ? *alpha_opt : Tensor{};
   auto alpha_ptr = &alpha;
@@ -635,7 +633,6 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
   TORCH_CUDASPARSE_CHECK(
       cusparseLtMatmulGetWorkspace(&handle, desc_ptrs->plan, &workspace_size));
 
-
   auto& allocator = *::c10::cuda::CUDACachingAllocator::get();
   auto workspacePtr = allocator.allocate(workspace_size);
   cudaStream_t stream = at::cuda::getCurrentCUDAStream();
@@ -645,6 +642,10 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
   c10::TensorOptions().dtype(out_dtype).device(dense_B.device());
   at::Tensor res = (transpose_result) ? at::empty({n, m}, res_tensor_options)
                                     : at::empty({m, n}, res_tensor_options);
+
+  // these are not used unless search_alg_id == true.
+  cusparseLtSplitKMode_t splitKMode = (cusparseLtSplitKMode_t)0;
+  int max_alg_id = 0;
 
   if (search_alg_id) {
     // run matmul search
@@ -707,8 +708,6 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
         &stream,
         1));
   }
-
-  // plan and descriptors are cached; no destroy here
 
   return {
       res,

--- a/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
+++ b/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
@@ -69,7 +69,9 @@ struct CachedMatDescriptor {
       cusparseLtMatDescriptorDestroy(&dense_input);
       cusparseLtMatDescriptorDestroy(&res);
       cusparseLtMatDescriptorDestroy(&C);
+      #if defined(CUSPARSELT_VERSION) && CUSPARSELT_VERSION >= 800
       cusparseLtMatmulAlgSelectionDestroy(&alg_sel);
+      #endif
       cusparseLtMatmulPlanDestroy(&plan);
       has_descriptors = false;
     }
@@ -93,7 +95,9 @@ struct CachedMatDescriptor {
         cusparseLtMatDescriptorDestroy(&dense_input);
         cusparseLtMatDescriptorDestroy(&res);
         cusparseLtMatDescriptorDestroy(&C);
+        #if defined(CUSPARSELT_VERSION) && CUSPARSELT_VERSION >= 800
         cusparseLtMatmulAlgSelectionDestroy(&alg_sel);
+        #endif
         cusparseLtMatmulPlanDestroy(&plan);
       }
       sparse_input = other.sparse_input;

--- a/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
+++ b/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
@@ -23,7 +23,7 @@ thread_local bool handle_initialized = false;
 
 /////////////////////////////////////////////////////////////////////
 
-// One cache key for the full matmul descriptor bundle (sparse_input, dense_input, res, C).
+// One cache key for the full matmul descriptor bundle and plan.
 struct MatDescriptorCacheKey {
   int m = 0;
   int k = 0;
@@ -33,17 +33,25 @@ struct MatDescriptorCacheKey {
   int32_t input_type = 0;
   int32_t output_type = 0;
   int32_t C_type = 0;
+  int32_t compute_type = 0;
+  bool has_bias = false;
+  int32_t alg_id = 0;
+  int32_t split_k = 1;
+  int32_t split_k_mode = -1;
 };
 
 using MatDescriptorCacheKeyHash = ParamsHash<MatDescriptorCacheKey>;
 using MatDescriptorCacheKeyEqual = ParamsEqual<MatDescriptorCacheKey>;
 
-// One cached entry holds all 4 descriptors for a matmul config.
+// One cached entry holds all descriptors and plan for a matmul config (built in-place).
 struct CachedMatDescriptor {
   cusparseLtMatDescriptor_t sparse_input;
   cusparseLtMatDescriptor_t dense_input;
   cusparseLtMatDescriptor_t res;
   cusparseLtMatDescriptor_t C;
+  cusparseLtMatmulDescriptor_t matmul;
+  cusparseLtMatmulAlgSelection_t alg_sel;
+  cusparseLtMatmulPlan_t plan;
   bool has_descriptors = false;
 
   CachedMatDescriptor() = default;
@@ -53,6 +61,8 @@ struct CachedMatDescriptor {
       cusparseLtMatDescriptorDestroy(&dense_input);
       cusparseLtMatDescriptorDestroy(&res);
       cusparseLtMatDescriptorDestroy(&C);
+      cusparseLtMatmulAlgSelectionDestroy(&alg_sel);
+      cusparseLtMatmulPlanDestroy(&plan);
       has_descriptors = false;
     }
   }
@@ -61,6 +71,9 @@ struct CachedMatDescriptor {
         dense_input(other.dense_input),
         res(other.res),
         C(other.C),
+        matmul(other.matmul),
+        alg_sel(other.alg_sel),
+        plan(other.plan),
         has_descriptors(other.has_descriptors) {
     other.has_descriptors = false;
   }
@@ -71,11 +84,16 @@ struct CachedMatDescriptor {
         cusparseLtMatDescriptorDestroy(&dense_input);
         cusparseLtMatDescriptorDestroy(&res);
         cusparseLtMatDescriptorDestroy(&C);
+        cusparseLtMatmulAlgSelectionDestroy(&alg_sel);
+        cusparseLtMatmulPlanDestroy(&plan);
       }
       sparse_input = other.sparse_input;
       dense_input = other.dense_input;
       res = other.res;
       C = other.C;
+      matmul = other.matmul;
+      alg_sel = other.alg_sel;
+      plan = other.plan;
       has_descriptors = other.has_descriptors;
       other.has_descriptors = false;
     }
@@ -90,6 +108,9 @@ struct MatDescriptorPtrs {
   cusparseLtMatDescriptor_t* dense_input = nullptr;
   cusparseLtMatDescriptor_t* res = nullptr;
   cusparseLtMatDescriptor_t* C = nullptr;
+  cusparseLtMatmulDescriptor_t* matmul = nullptr;
+  cusparseLtMatmulAlgSelection_t* alg_sel = nullptr;
+  cusparseLtMatmulPlan_t* plan = nullptr;
 };
 
 constexpr size_t MatDescriptorCacheMaxSize = 128;
@@ -119,7 +140,131 @@ struct MatDescriptorCache {
     ptrs.dense_input = &entry.dense_input;
     ptrs.res = &entry.res;
     ptrs.C = &entry.C;
+    ptrs.matmul = &entry.matmul;
+    ptrs.alg_sel = &entry.alg_sel;
+    ptrs.plan = &entry.plan;
     return ptrs;
+  }
+
+  // Build a new cache entry in-place (no move); create plan once per entry.
+  std::optional<MatDescriptorPtrs> getOrCreate(
+      const MatDescriptorCacheKey& key,
+      cusparseLtHandle_t& handle,
+      int64_t m,
+      int64_t k,
+      int64_t n,
+      bool dense_is_contiguous,
+      bool transpose_result,
+      cudaDataType input_type,
+      cudaDataType output_type,
+      cudaDataType C_type,
+      cusparseComputeType compute_type,
+      int alg_id,
+      int split_k,
+      int split_k_mode) {
+    auto result = lookup(key);
+    if (result.has_value()) {
+      return result;
+    }
+    if (lru_list.size() >= MatDescriptorCacheMaxSize) {
+      auto& back = lru_list.back();
+      cache_map.erase(back.first);
+      lru_list.pop_back();
+    }
+    lru_list.push_front({key, CachedMatDescriptor{}});
+    CachedMatDescriptor& entry = lru_list.front().second;
+
+    int64_t dense_rows = dense_is_contiguous ? k : n;
+    int64_t dense_cols = dense_is_contiguous ? n : k;
+    int64_t res_ld = transpose_result ? m : n;
+    cusparseOrder_t res_order =
+        transpose_result ? CUSPARSE_ORDER_COL : CUSPARSE_ORDER_ROW;
+
+    TORCH_CUDASPARSE_CHECK(cusparseLtStructuredDescriptorInit(
+        &handle,
+        &entry.sparse_input,
+        m,
+        k,
+        k,
+        16,
+        input_type,
+        CUSPARSE_ORDER_ROW,
+        CUSPARSELT_SPARSITY_50_PERCENT));
+    TORCH_CUDASPARSE_CHECK(cusparseLtDenseDescriptorInit(
+        &handle,
+        &entry.dense_input,
+        dense_rows,
+        dense_cols,
+        dense_cols,
+        16,
+        input_type,
+        CUSPARSE_ORDER_ROW));
+    TORCH_CUDASPARSE_CHECK(cusparseLtDenseDescriptorInit(
+        &handle,
+        &entry.res,
+        m,
+        n,
+        res_ld,
+        16,
+        output_type,
+        res_order));
+    TORCH_CUDASPARSE_CHECK(cusparseLtDenseDescriptorInit(
+        &handle,
+        &entry.C,
+        m,
+        n,
+        res_ld,
+        16,
+        C_type,
+        res_order));
+    TORCH_CUDASPARSE_CHECK(cusparseLtMatmulDescriptorInit(
+        &handle,
+        &entry.matmul,
+        CUSPARSE_OPERATION_NON_TRANSPOSE,
+        dense_is_contiguous ? CUSPARSE_OPERATION_NON_TRANSPOSE
+                            : CUSPARSE_OPERATION_TRANSPOSE,
+        &entry.sparse_input,
+        &entry.dense_input,
+        &entry.C,
+        &entry.res,
+        compute_type));
+    TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgSelectionInit(
+        &handle,
+        &entry.alg_sel,
+        &entry.matmul,
+        CUSPARSELT_MATMUL_ALG_DEFAULT));
+
+    TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgSetAttribute(
+        &handle,
+        &entry.alg_sel,
+        CUSPARSELT_MATMUL_ALG_CONFIG_ID,
+        &alg_id,
+        sizeof(alg_id)));
+    if (split_k != 1) {
+      TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgSetAttribute(
+          &handle,
+          &entry.alg_sel,
+          CUSPARSELT_MATMUL_SPLIT_K,
+          &split_k,
+          sizeof(split_k)));
+      if (split_k_mode > 0) {
+        cusparseLtSplitKMode_t splitKMode =
+            static_cast<cusparseLtSplitKMode_t>(split_k_mode);
+        TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgSetAttribute(
+            &handle,
+            &entry.alg_sel,
+            CUSPARSELT_MATMUL_SPLIT_K_MODE,
+            &splitKMode,
+            sizeof(splitKMode)));
+      }
+    }
+
+    TORCH_CUDASPARSE_CHECK(cusparseLtMatmulPlanInit(
+        &handle, &entry.plan, &entry.matmul, &entry.alg_sel));
+
+    entry.has_descriptors = true;
+    cache_map[lru_list.front().first] = lru_list.begin();
+    return lookup(key);
   }
 
   void insert(MatDescriptorCacheKey key, CachedMatDescriptor descriptor) {
@@ -128,7 +273,7 @@ struct MatDescriptorCache {
       cache_map.erase(back.first);
       lru_list.pop_back();
     }
-    lru_list.push_front({std::move(key), std::move(descriptor)});
+    lru_list.push_front({key, std::move(descriptor)});
     cache_map[lru_list.front().first] = lru_list.begin();
   }
 };
@@ -142,7 +287,7 @@ MatDescriptorCache& getMatDescriptorCache() {
   return *mat_descriptor_cache;
 }
 
-// Returns all 4 descriptor pointers for this matmul config from one cache key.
+// Returns descriptor pointers and plan for this matmul config (cache built in-place).
 static MatDescriptorPtrs _get_matmul_descriptor_ptrs(
     cusparseLtHandle_t& handle,
     int64_t m,
@@ -152,7 +297,12 @@ static MatDescriptorPtrs _get_matmul_descriptor_ptrs(
     bool transpose_result,
     cudaDataType input_type,
     cudaDataType output_type,
-    cudaDataType C_type) {
+    cudaDataType C_type,
+    cusparseComputeType compute_type,
+    bool has_bias,
+    int alg_id,
+    int split_k,
+    int split_k_mode) {
   MatDescriptorCacheKey key{};
   key.m = static_cast<int>(m);
   key.k = static_cast<int>(k);
@@ -162,70 +312,31 @@ static MatDescriptorPtrs _get_matmul_descriptor_ptrs(
   key.input_type = static_cast<int32_t>(input_type);
   key.output_type = static_cast<int32_t>(output_type);
   key.C_type = static_cast<int32_t>(C_type);
+  key.compute_type = static_cast<int32_t>(compute_type);
+  key.has_bias = has_bias;
+  key.alg_id = static_cast<int32_t>(alg_id);
+  key.split_k = static_cast<int32_t>(split_k);
+  key.split_k_mode = static_cast<int32_t>(split_k_mode);
 
-  auto cached = getMatDescriptorCache().lookup(key);
-  if (cached.has_value()) {
-    return *cached;
-  }
-
-  int64_t dense_rows = dense_is_contiguous ? k : n;
-  int64_t dense_cols = dense_is_contiguous ? n : k;
-  int64_t res_ld = transpose_result ? m : n;
-  cusparseOrder_t res_order = transpose_result ? CUSPARSE_ORDER_COL : CUSPARSE_ORDER_ROW;
-
-  CachedMatDescriptor bundle;
-  TORCH_CUDASPARSE_CHECK(cusparseLtStructuredDescriptorInit(
-      &handle,
-      &bundle.sparse_input,
+  auto result = getMatDescriptorCache().getOrCreate(
+      key,
+      handle,
       m,
       k,
-      k,
-      16,
-      input_type,
-      CUSPARSE_ORDER_ROW,
-      CUSPARSELT_SPARSITY_50_PERCENT));
-  TORCH_CUDASPARSE_CHECK(cusparseLtDenseDescriptorInit(
-      &handle,
-      &bundle.dense_input,
-      dense_rows,
-      dense_cols,
-      dense_cols,
-      16,
-      input_type,
-      CUSPARSE_ORDER_ROW));
-  TORCH_CUDASPARSE_CHECK(cusparseLtDenseDescriptorInit(
-      &handle,
-      &bundle.res,
-      m,
       n,
-      res_ld,
-      16,
+      dense_is_contiguous,
+      transpose_result,
+      input_type,
       output_type,
-      res_order));
-  TORCH_CUDASPARSE_CHECK(cusparseLtDenseDescriptorInit(
-      &handle,
-      &bundle.C,
-      m,
-      n,
-      res_ld,
-      16,
       C_type,
-      res_order));
-  bundle.has_descriptors = true;
-
-  getMatDescriptorCache().insert(std::move(key), std::move(bundle));
-  // Rebuild key for lookup (key was moved into insert).
-  MatDescriptorCacheKey key_lookup{};
-  key_lookup.m = static_cast<int>(m);
-  key_lookup.k = static_cast<int>(k);
-  key_lookup.n = static_cast<int>(n);
-  key_lookup.dense_is_contiguous = dense_is_contiguous;
-  key_lookup.transpose_result = transpose_result;
-  key_lookup.input_type = static_cast<int32_t>(input_type);
-  key_lookup.output_type = static_cast<int32_t>(output_type);
-  key_lookup.C_type = static_cast<int32_t>(C_type);
-  cached = getMatDescriptorCache().lookup(key_lookup);
-  return *cached;
+      compute_type,
+      alg_id,
+      split_k,
+      split_k_mode);
+  TORCH_CHECK(
+      result.has_value(),
+      "cuSPARSELt: mat descriptor cache getOrCreate failed");
+  return *result;
 }
 
 
@@ -371,10 +482,6 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
     TORCH_CUDASPARSE_CHECK(cusparseLtInit(&handle));
     handle_initialized = true;
   }
-  // cuSPARSELt constructs
-  cusparseLtMatmulDescriptor_t matmul;
-  cusparseLtMatmulPlan_t plan;
-  cusparseLtMatmulAlgSelection_t alg_sel;
 
   float alpha = 1.0;
   float beta = 0.0;
@@ -528,26 +635,38 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
       transpose_result,
       input_type,
       output_type,
-      C_type);
+      C_type,
+      compute_type,
+      bias_opt.has_value(),
+      alg_id,
+      split_k,
+      split_k_mode);
 
-  // create result tensor
-  auto res_tensor_options =
-      c10::TensorOptions().dtype(out_dtype).device(dense_B.device());
-  at::Tensor res = (transpose_result) ? at::empty({n, m}, res_tensor_options)
-                                      : at::empty({m, n}, res_tensor_options);
+  // bool not_null_sparse_input = (desc_ptrs.sparse_input != nullptr);
+  // bool not_null_dense_input = (desc_ptrs.dense_input != nullptr);
+  // bool not_null_res = (desc_ptrs.res != nullptr);
+  // bool not_null_C = (desc_ptrs.C != nullptr);
+  // bool not_null_alg_sel = (desc_ptrs.alg_sel != nullptr);
+  // std::cout << "not_null_sparse_input=" << not_null_sparse_input
+  //           << " not_null_dense_input=" << not_null_dense_input
+  //           << " not_null_res=" << not_null_res
+  //           << " not_null_C=" << not_null_C
+  //           << " not_null_alg_sel=" << not_null_alg_sel
+  //           << std::endl;
 
-  // initialize matmul
-  TORCH_CUDASPARSE_CHECK(cusparseLtMatmulDescriptorInit(
-      &handle,
-      &matmul,
-      CUSPARSE_OPERATION_NON_TRANSPOSE,
-      (dense_B.is_contiguous()) ? CUSPARSE_OPERATION_NON_TRANSPOSE
-                                : CUSPARSE_OPERATION_TRANSPOSE,
-      desc_ptrs.sparse_input,
-      desc_ptrs.dense_input,
-      desc_ptrs.C,
-      desc_ptrs.res,
-      compute_type));
+  // // initialize matmul
+  // TORCH_CUDASPARSE_CHECK(cusparseLtMatmulDescriptorInit(
+  //     &handle,
+  //     &matmul,
+  //     CUSPARSE_OPERATION_NON_TRANSPOSE,
+  //     (dense_B.is_contiguous()) ? CUSPARSE_OPERATION_NON_TRANSPOSE
+  //                               : CUSPARSE_OPERATION_TRANSPOSE,
+  //     desc_ptrs.sparse_input,
+  //     desc_ptrs.dense_input,
+  //     desc_ptrs.C,
+  //     desc_ptrs.res,
+  //     compute_type));
+
 
   // set bias pointer for matmul, need to assign to get location
   if (bias_opt.has_value()) {
@@ -555,47 +674,22 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
     void* dBias = bias.data_ptr();
     TORCH_CUDASPARSE_CHECK(cusparseLtMatmulDescSetAttribute(
         &handle,
-        &matmul,
+        desc_ptrs.matmul,
         CUSPARSELT_MATMUL_BIAS_POINTER,
         &dBias,
         sizeof(dBias)));
   }
 
-  // auto t1 = std::chrono::steady_clock::now();
-  TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgSelectionInit(
-      &handle, &alg_sel, &matmul, CUSPARSELT_MATMUL_ALG_DEFAULT));
-  // auto t2 = std::chrono::steady_clock::now();
-  // double duration_plan_init = std::chrono::duration<double, std::milli>(t2 - t1).count();
-  // std::cout << "duration_plan_init = " << duration_plan_init << std::endl;
 
-  // set matmul search params
-  TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgSetAttribute(
-      &handle,
-      &alg_sel,
-      CUSPARSELT_MATMUL_ALG_CONFIG_ID,
-      &alg_id,
-      sizeof(alg_id)));
+  // auto ta1 = std::chrono::steady_clock::now();  ~.285545
+  // TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgSelectionInit(
+  //     &handle, &alg_sel, &matmul, CUSPARSELT_MATMUL_ALG_DEFAULT));
+  // auto ta2 = std::chrono::steady_clock::now();
+  // double duration_alg_init = std::chrono::duration<double, std::milli>(ta2 - ta1).count();
+  // std::cout << "duration_alg_init = " << duration_alg_init << std::endl;
 
   cusparseLtSplitKMode_t splitKMode;
   int max_alg_id;
-  if (split_k != 1) {
-    TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgSetAttribute(
-        &handle,
-        &alg_sel,
-        CUSPARSELT_MATMUL_SPLIT_K,
-        &split_k,
-        sizeof(split_k)));
-
-    if (split_k_mode > 0) {
-      splitKMode = static_cast<cusparseLtSplitKMode_t>(split_k_mode);
-      TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgSetAttribute(
-          &handle,
-          &alg_sel,
-          CUSPARSELT_MATMUL_SPLIT_K_MODE,
-          &splitKMode,
-          sizeof(splitKMode)));
-    }
-  }
 
   // set tensor_alpha_mode and alpha pointer for matmul
   const auto alpha_tensor = alpha_opt.has_value() ? *alpha_opt : Tensor{};
@@ -607,7 +701,7 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
       int tensor_alpha_mode = 1;
       TORCH_CUDASPARSE_CHECK(cusparseLtMatmulDescSetAttribute(
           &handle,
-          &matmul,
+          desc_ptrs.matmul,
           CUSPARSELT_MATMUL_ALPHA_VECTOR_SCALING,
           &tensor_alpha_mode,
           sizeof(tensor_alpha_mode)));
@@ -615,23 +709,26 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
     }
   }
 
-  TORCH_CUDASPARSE_CHECK(
-      cusparseLtMatmulPlanInit(&handle, &plan, &matmul, &alg_sel));
-
   size_t workspace_size;
   TORCH_CUDASPARSE_CHECK(
-      cusparseLtMatmulGetWorkspace(&handle, &plan, &workspace_size));
+      cusparseLtMatmulGetWorkspace(&handle, desc_ptrs.plan, &workspace_size));
 
 
   auto& allocator = *::c10::cuda::CUDACachingAllocator::get();
   auto workspacePtr = allocator.allocate(workspace_size);
   cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
+  // create result tensor
+  auto res_tensor_options =
+  c10::TensorOptions().dtype(out_dtype).device(dense_B.device());
+  at::Tensor res = (transpose_result) ? at::empty({n, m}, res_tensor_options)
+                                    : at::empty({m, n}, res_tensor_options);
+
   if (search_alg_id) {
     // run matmul search
     TORCH_CUDASPARSE_CHECK(cusparseLtMatmulSearch(
         &handle,
-        &plan,
+        desc_ptrs.plan,
         alpha_ptr,
         compressed_A.data_ptr(),
         dense_B.data_ptr(),
@@ -646,28 +743,28 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
     // get matmul params used
     TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgGetAttribute(
         &handle,
-        &alg_sel,
+        desc_ptrs.alg_sel,
         CUSPARSELT_MATMUL_ALG_CONFIG_ID,
         &alg_id,
         sizeof(alg_id)));
 
     TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgGetAttribute(
         &handle,
-        &alg_sel,
+        desc_ptrs.alg_sel,
         CUSPARSELT_MATMUL_SPLIT_K,
         &split_k,
         sizeof(split_k)));
 
     TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgGetAttribute(
         &handle,
-        &alg_sel,
+        desc_ptrs.alg_sel,
         CUSPARSELT_MATMUL_SPLIT_K_MODE,
         &splitKMode,
         sizeof(splitKMode)));
 
     TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgGetAttribute(
         &handle,
-        &alg_sel,
+        desc_ptrs.alg_sel,
         CUSPARSELT_MATMUL_ALG_CONFIG_MAX_ID,
         &max_alg_id,
         sizeof(max_alg_id)));
@@ -676,7 +773,7 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
     // do normal matmul
     TORCH_CUDASPARSE_CHECK(cusparseLtMatmul(
         &handle,
-        &plan,
+        desc_ptrs.plan,
         alpha_ptr,
         compressed_A.data_ptr(),
         dense_B.data_ptr(),
@@ -689,14 +786,7 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
         1));
   }
 
-  // destroy descriptors
-  // TORCH_CUDASPARSE_CHECK(
-  //     cusparseLtMatDescriptorDestroy(&sparse_input_descriptor));
-  // TORCH_CUDASPARSE_CHECK(
-  //     cusparseLtMatDescriptorDestroy(&dense_input_descriptor));
-  // TORCH_CUDASPARSE_CHECK(cusparseLtMatDescriptorDestroy(&res_descriptor));
-  // destroy plan
-  TORCH_CUDASPARSE_CHECK(cusparseLtMatmulPlanDestroy(&plan));
+  // plan and descriptors are cached; no destroy here
 
   return {
       res,

--- a/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
+++ b/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
@@ -154,7 +154,8 @@ struct MatDescriptorCache {
       bool has_bias,
       int alg_id,
       int split_k,
-      int split_k_mode) {
+      int split_k_mode,
+      const std::optional<Tensor>& bias_opt) {
     MatDescriptorCacheKey key{};
     key.m = static_cast<int>(m);
     key.k = static_cast<int>(k);
@@ -170,100 +171,113 @@ struct MatDescriptorCache {
     key.split_k = static_cast<int32_t>(split_k);
     key.split_k_mode = static_cast<int32_t>(split_k_mode);
     MatDescriptorPtrs* result = lookup(key);
-    if (result != nullptr) {
-      return result;
+    if (result == nullptr) {
+      if (lru_list.size() >= MatDescriptorCacheMaxSize) {
+        auto& back = lru_list.back();
+        cache_map.erase(back.first);
+        lru_list.pop_back();
+      }
+      lru_list.push_front({key, CachedMatDescriptor{}});
     }
-    if (lru_list.size() >= MatDescriptorCacheMaxSize) {
-      auto& back = lru_list.back();
-      cache_map.erase(back.first);
-      lru_list.pop_back();
-    }
-    lru_list.push_front({key, CachedMatDescriptor{}});
+    // Both paths leave the target entry at the front of lru_list:
+    // lookup() splices a hit there; a miss push_front's the new entry.
     CachedMatDescriptor& entry = lru_list.front().second;
-
-    int64_t dense_rows = dense_is_contiguous ? k : n;
-    int64_t dense_cols = dense_is_contiguous ? n : k;
-    int64_t res_ld = transpose_result ? m : n;
-    cusparseOrder_t res_order =
-        transpose_result ? CUSPARSE_ORDER_COL : CUSPARSE_ORDER_ROW;
-
-    TORCH_CUDASPARSE_CHECK(cusparseLtStructuredDescriptorInit(
-        &handle,
-        &entry.sparse_input,
-        m,
-        k,
-        k,
-        16,
-        input_type,
-        CUSPARSE_ORDER_ROW,
-        CUSPARSELT_SPARSITY_50_PERCENT));
-    TORCH_CUDASPARSE_CHECK(cusparseLtDenseDescriptorInit(
-        &handle,
-        &entry.dense_input,
-        dense_rows,
-        dense_cols,
-        dense_cols,
-        16,
-        input_type,
-        CUSPARSE_ORDER_ROW));
-    TORCH_CUDASPARSE_CHECK(cusparseLtDenseDescriptorInit(
-        &handle,
-        &entry.res,
-        m,
-        n,
-        res_ld,
-        16,
-        output_type,
-        res_order));
-    TORCH_CUDASPARSE_CHECK(cusparseLtDenseDescriptorInit(
-        &handle,
-        &entry.C,
-        m,
-        n,
-        res_ld,
-        16,
-        C_type,
-        res_order));
-    TORCH_CUDASPARSE_CHECK(cusparseLtMatmulDescriptorInit(
-        &handle,
-        &entry.matmul,
-        CUSPARSE_OPERATION_NON_TRANSPOSE,
-        dense_is_contiguous ? CUSPARSE_OPERATION_NON_TRANSPOSE
-                            : CUSPARSE_OPERATION_TRANSPOSE,
-        &entry.sparse_input,
-        &entry.dense_input,
-        &entry.C,
-        &entry.res,
-        compute_type));
-    TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgSelectionInit(
-        &handle,
-        &entry.alg_sel,
-        &entry.matmul,
-        CUSPARSELT_MATMUL_ALG_DEFAULT));
-
-    TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgSetAttribute(
-        &handle,
-        &entry.alg_sel,
-        CUSPARSELT_MATMUL_ALG_CONFIG_ID,
-        &alg_id,
-        sizeof(alg_id)));
-    if (split_k != 1) {
+    if (result == nullptr) {
+      int64_t dense_rows = dense_is_contiguous ? k : n;
+      int64_t dense_cols = dense_is_contiguous ? n : k;
+      int64_t res_ld = transpose_result ? m : n;
+      cusparseOrder_t res_order =
+          transpose_result ? CUSPARSE_ORDER_COL : CUSPARSE_ORDER_ROW;
+  
+      TORCH_CUDASPARSE_CHECK(cusparseLtStructuredDescriptorInit(
+          &handle,
+          &entry.sparse_input,
+          m,
+          k,
+          k,
+          16,
+          input_type,
+          CUSPARSE_ORDER_ROW,
+          CUSPARSELT_SPARSITY_50_PERCENT));
+      TORCH_CUDASPARSE_CHECK(cusparseLtDenseDescriptorInit(
+          &handle,
+          &entry.dense_input,
+          dense_rows,
+          dense_cols,
+          dense_cols,
+          16,
+          input_type,
+          CUSPARSE_ORDER_ROW));
+      TORCH_CUDASPARSE_CHECK(cusparseLtDenseDescriptorInit(
+          &handle,
+          &entry.res,
+          m,
+          n,
+          res_ld,
+          16,
+          output_type,
+          res_order));
+      TORCH_CUDASPARSE_CHECK(cusparseLtDenseDescriptorInit(
+          &handle,
+          &entry.C,
+          m,
+          n,
+          res_ld,
+          16,
+          C_type,
+          res_order));
+      TORCH_CUDASPARSE_CHECK(cusparseLtMatmulDescriptorInit(
+          &handle,
+          &entry.matmul,
+          CUSPARSE_OPERATION_NON_TRANSPOSE,
+          dense_is_contiguous ? CUSPARSE_OPERATION_NON_TRANSPOSE
+                              : CUSPARSE_OPERATION_TRANSPOSE,
+          &entry.sparse_input,
+          &entry.dense_input,
+          &entry.C,
+          &entry.res,
+          compute_type));
+      TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgSelectionInit(
+          &handle,
+          &entry.alg_sel,
+          &entry.matmul,
+          CUSPARSELT_MATMUL_ALG_DEFAULT));
+  
       TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgSetAttribute(
           &handle,
           &entry.alg_sel,
-          CUSPARSELT_MATMUL_SPLIT_K,
-          &split_k,
-          sizeof(split_k)));
-      if (split_k_mode > 0) {
-        cusparseLtSplitKMode_t splitKMode =
-            static_cast<cusparseLtSplitKMode_t>(split_k_mode);
+          CUSPARSELT_MATMUL_ALG_CONFIG_ID,
+          &alg_id,
+          sizeof(alg_id)));
+      if (split_k != 1) {
         TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgSetAttribute(
             &handle,
             &entry.alg_sel,
-            CUSPARSELT_MATMUL_SPLIT_K_MODE,
-            &splitKMode,
-            sizeof(splitKMode)));
+            CUSPARSELT_MATMUL_SPLIT_K,
+            &split_k,
+            sizeof(split_k)));
+        if (split_k_mode > 0) {
+          cusparseLtSplitKMode_t splitKMode =
+              static_cast<cusparseLtSplitKMode_t>(split_k_mode);
+          TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgSetAttribute(
+              &handle,
+              &entry.alg_sel,
+              CUSPARSELT_MATMUL_SPLIT_K_MODE,
+              &splitKMode,
+              sizeof(splitKMode)));
+        }
       }
+    }
+    
+    if (bias_opt.has_value()) {
+      auto& bias = bias_opt.value();
+      void* dBias = bias.data_ptr();
+      TORCH_CUDASPARSE_CHECK(cusparseLtMatmulDescSetAttribute(
+          &handle,
+          &entry.matmul,
+          CUSPARSELT_MATMUL_BIAS_POINTER,
+          &dBias,
+          sizeof(dBias)));
     }
 
     TORCH_CUDASPARSE_CHECK(cusparseLtMatmulPlanInit(
@@ -273,8 +287,10 @@ struct MatDescriptorCache {
     entry.ptrs.alg_sel = &entry.alg_sel;
     entry.ptrs.plan = &entry.plan;
     entry.has_descriptors = true;
-    cache_map[lru_list.front().first] = lru_list.begin();
-    return &lru_list.front().second.ptrs;
+    if (result == nullptr) {
+      cache_map[lru_list.front().first] = lru_list.begin();
+    }
+    return &entry.ptrs;
   }
 
   void insert(MatDescriptorCacheKey key, CachedMatDescriptor descriptor) {
@@ -594,22 +610,23 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
       bias_opt.has_value(),
       alg_id,
       split_k,
-      split_k_mode);
+      split_k_mode,
+      bias_opt);
   TORCH_CHECK(
       desc_ptrs != nullptr,
       "cuSPARSELt: mat descriptor cache getOrCreate failed");
 
-  // set bias pointer for matmul, need to assign to get location
-  if (bias_opt.has_value()) {
-    auto& bias = bias_opt.value();
-    void* dBias = bias.data_ptr();
-    TORCH_CUDASPARSE_CHECK(cusparseLtMatmulDescSetAttribute(
-        &handle,
-        desc_ptrs->matmul,
-        CUSPARSELT_MATMUL_BIAS_POINTER,
-        &dBias,
-        sizeof(dBias)));
-  }
+  // // set bias pointer for matmul, need to assign to get location
+  // if (bias_opt.has_value()) {
+  //   auto& bias = bias_opt.value();
+  //   void* dBias = bias.data_ptr();
+  //   TORCH_CUDASPARSE_CHECK(cusparseLtMatmulDescSetAttribute(
+  //       &handle,
+  //       desc_ptrs->matmul,
+  //       CUSPARSELT_MATMUL_BIAS_POINTER,
+  //       &dBias,
+  //       sizeof(dBias)));
+  // }
 
   // set tensor_alpha_mode and alpha pointer for matmul
   const auto alpha_tensor = alpha_opt.has_value() ? *alpha_opt : Tensor{};

--- a/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
+++ b/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
@@ -60,6 +60,8 @@ cusparseLtHandle_t& get_cusparselt_handle_for_current_device() {
 struct SparseInputDescriptorCacheKey {
   int m = 0;
   int k = 0;
+  bool is_contiguous = true;
+  bool is_dense = false;
   int32_t input_type = 0;
 };
 
@@ -152,6 +154,8 @@ static cusparseLtMatDescriptor_t* _get_sparse_input_descriptor_ptr(
   SparseInputDescriptorCacheKey key{};
   key.m = m;
   key.k = k;
+  key.is_contiguous = true;
+  key.is_dense = false;
   key.input_type = static_cast<int32_t>(input_type);
   auto cached = getSparseInputDescriptorCache().lookup(key);
   if (cached.has_value()) {
@@ -176,6 +180,43 @@ static cusparseLtMatDescriptor_t* _get_sparse_input_descriptor_ptr(
   cached = getSparseInputDescriptorCache().lookup(key);
   return *cached;
 }
+
+
+static cusparseLtMatDescriptor_t* _get_dense_input_descriptor_ptr(
+    cusparseLtHandle_t& handle,
+    int64_t k,
+    int64_t n,
+    bool is_contiguous,
+    cudaDataType input_type) {
+  SparseInputDescriptorCacheKey key{};
+  key.m = n;
+  key.k = k;
+  key.is_contiguous = is_contiguous;
+  key.is_dense = true;
+  key.input_type = static_cast<int32_t>(input_type);
+  auto cached = getSparseInputDescriptorCache().lookup(key);
+  if (cached.has_value()) {
+    return *cached;
+  } 
+  cusparseLtMatDescriptor_t dense_input_descriptor;
+  TORCH_CUDASPARSE_CHECK(cusparseLtDenseDescriptorInit(
+      &handle,
+      &dense_input_descriptor,
+      is_contiguous ? k : n,
+      is_contiguous ? n : k,
+      is_contiguous ? n : k,
+      16,
+      input_type,
+      CUSPARSE_ORDER_ROW));
+      
+  CachedSparseInputDescriptor cached_descriptor;
+  cached_descriptor.descriptor = dense_input_descriptor;
+  cached_descriptor.has_descriptor = true;
+  getSparseInputDescriptorCache().insert(std::move(key), std::move(cached_descriptor));
+  cached = getSparseInputDescriptorCache().lookup(key);
+  return *cached;
+}
+
 
 
 //////////////////////////////////////////////////////////////////////
@@ -523,74 +564,19 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
   int64_t m = compressed_A.size(0);
 
   //////////////////////////////////////////////////////////////
-  // // initialize sparse descriptor
-  // cusparseLtMatDescriptor_t sparse_input_descriptor;
-  // TORCH_CUDASPARSE_CHECK(cusparseLtStructuredDescriptorInit(
-  //     &handle,
-  //     &sparse_input_descriptor,
-  //     m,
-  //     k,
-  //     k,
-  //     16,
-  //     input_type,
-  //     CUSPARSE_ORDER_ROW,
-  //     CUSPARSELT_SPARSITY_50_PERCENT));
-  auto t3 = std::chrono::steady_clock::now();
+  // initialize sparse descriptor
+  // auto t3 = std::chrono::steady_clock::now();
   cusparseLtMatDescriptor_t* sparse_input_descriptor_ptr =
     _get_sparse_input_descriptor_ptr(handle, m, k, input_type);
-  auto t4 = std::chrono::steady_clock::now();
-  double duration_sparse_input_descriptor = std::chrono::duration<double, std::milli>(t4 - t3).count();
-  std::cout << "duration_sparse_input_descriptor = " << duration_sparse_input_descriptor << std::endl;
-
-  // auto t3 = std::chrono::steady_clock::now();
-
-  // SparseInputDescriptorCacheKey key{};
-  // key.m = m;
-  // key.k = k;
-  // key.input_type = static_cast<int32_t>(input_type);
-  // auto cached = getSparseInputDescriptorCache().lookup(key);
-  // cusparseLtMatDescriptor_t* sparse_input_descriptor_ptr = nullptr;
-  // if (cached.has_value()) {
-  //   sparse_input_descriptor_ptr = *cached;
-  // } else {
-  //   cusparseLtMatDescriptor_t sparse_input_descriptor;
-  //   TORCH_CUDASPARSE_CHECK(cusparseLtStructuredDescriptorInit(
-  //       &handle,
-  //       &sparse_input_descriptor,
-  //       m,
-  //       k,
-  //       k,
-  //       16,
-  //       input_type,
-  //       CUSPARSE_ORDER_ROW,
-  //       CUSPARSELT_SPARSITY_50_PERCENT));
-    
-  //   CachedSparseInputDescriptor cached_descriptor;
-  //   cached_descriptor.descriptor = sparse_input_descriptor;
-  //   cached_descriptor.has_descriptor = true;
-  //   getSparseInputDescriptorCache().insert(std::move(key), std::move(cached_descriptor));
-  //   cached = getSparseInputDescriptorCache().lookup(key);
-  //   sparse_input_descriptor_ptr = *cached;
-  // }
   // auto t4 = std::chrono::steady_clock::now();
   // double duration_sparse_input_descriptor = std::chrono::duration<double, std::milli>(t4 - t3).count();
   // std::cout << "duration_sparse_input_descriptor = " << duration_sparse_input_descriptor << std::endl;
-
-
   /////////////////////////////////////////////////////////////
 
   // initialize dense input descriptor
-  cusparseLtMatDescriptor_t dense_input_descriptor;
-  TORCH_CUDASPARSE_CHECK(cusparseLtDenseDescriptorInit(
-      &handle,
-      &dense_input_descriptor,
-      (dense_B.is_contiguous()) ? k : n,
-      (dense_B.is_contiguous()) ? n : k,
-      (dense_B.is_contiguous()) ? n : k,
-      16,
-      input_type,
-      CUSPARSE_ORDER_ROW));
-
+  cusparseLtMatDescriptor_t* dense_input_descriptor_ptr = 
+    _get_dense_input_descriptor_ptr(handle, k, n, dense_B.is_contiguous(), input_type);
+  
   // create result tensor
   auto res_tensor_options =
       c10::TensorOptions().dtype(out_dtype).device(dense_B.device());
@@ -628,7 +614,7 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
       (dense_B.is_contiguous()) ? CUSPARSE_OPERATION_NON_TRANSPOSE
                                 : CUSPARSE_OPERATION_TRANSPOSE,
       sparse_input_descriptor_ptr,
-      &dense_input_descriptor,
+      dense_input_descriptor_ptr,
       &C_descriptor,
       &res_descriptor,
       compute_type));
@@ -645,12 +631,12 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
         sizeof(dBias)));
   }
 
-  auto t1 = std::chrono::steady_clock::now();
+  // auto t1 = std::chrono::steady_clock::now();
   TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgSelectionInit(
       &handle, &alg_sel, &matmul, CUSPARSELT_MATMUL_ALG_DEFAULT));
-  auto t2 = std::chrono::steady_clock::now();
-  double duration_plan_init = std::chrono::duration<double, std::milli>(t2 - t1).count();
-  std::cout << "duration_plan_init = " << duration_plan_init << std::endl;
+  // auto t2 = std::chrono::steady_clock::now();
+  // double duration_plan_init = std::chrono::duration<double, std::milli>(t2 - t1).count();
+  // std::cout << "duration_plan_init = " << duration_plan_init << std::endl;
 
   // set matmul search params
   TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgSetAttribute(
@@ -779,8 +765,8 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
   // destroy descriptors
   // TORCH_CUDASPARSE_CHECK(
   //     cusparseLtMatDescriptorDestroy(&sparse_input_descriptor));
-  TORCH_CUDASPARSE_CHECK(
-      cusparseLtMatDescriptorDestroy(&dense_input_descriptor));
+  // TORCH_CUDASPARSE_CHECK(
+  //     cusparseLtMatDescriptorDestroy(&dense_input_descriptor));
   TORCH_CUDASPARSE_CHECK(cusparseLtMatDescriptorDestroy(&res_descriptor));
   // destroy plan
   TORCH_CUDASPARSE_CHECK(cusparseLtMatmulPlanDestroy(&plan));

--- a/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
+++ b/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
@@ -668,6 +668,7 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
   int64_t n = dense_B.size(1);
   int64_t m = compressed_A.size(0);
 
+  // set up matmul descriptors and cache them or retrieve from cache.
   MatDescriptorPtrs* desc_ptrs = getMatDescriptorCache().getOrCreate(
       handle,
       m,
@@ -699,9 +700,6 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
         sizeof(dBias)));
   }
 
-  cusparseLtSplitKMode_t splitKMode;
-  int max_alg_id;
-
   // set tensor_alpha_mode and alpha pointer for matmul
   const auto alpha_tensor = alpha_opt.has_value() ? *alpha_opt : Tensor{};
   auto alpha_ptr = &alpha;
@@ -724,7 +722,6 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
   TORCH_CUDASPARSE_CHECK(
       cusparseLtMatmulGetWorkspace(&handle, desc_ptrs->plan, &workspace_size));
 
-
   auto& allocator = *::c10::cuda::CUDACachingAllocator::get();
   auto workspacePtr = allocator.allocate(workspace_size);
   cudaStream_t stream = at::cuda::getCurrentCUDAStream();
@@ -734,6 +731,10 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
   c10::TensorOptions().dtype(out_dtype).device(dense_B.device());
   at::Tensor res = (transpose_result) ? at::empty({n, m}, res_tensor_options)
                                     : at::empty({m, n}, res_tensor_options);
+
+  // these are not used unless search_alg_id == true.
+  cusparseLtSplitKMode_t splitKMode = (cusparseLtSplitKMode_t)0;
+  int max_alg_id = 0;
 
   if (search_alg_id) {
     // run matmul search
@@ -800,9 +801,12 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
         1));
   }
 
-  // plan and descriptors are cached; no destroy here
-
-  return {res, alg_id, split_k, static_cast<int64_t>(splitKMode), max_alg_id};
+  return {
+      res,
+      alg_id,
+      split_k,
+      static_cast<int64_t>(splitKMode),
+      max_alg_id};
 }
 
 at::Tensor _cslt_sparse_mm(

--- a/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
+++ b/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
@@ -57,76 +57,107 @@ cusparseLtHandle_t& get_cusparselt_handle_for_current_device() {
 
 /////////////////////////////////////////////////////////////////////
 
-struct SparseInputDescriptorCacheKey {
-  int dim0 = 0;
-  int dim1 = 0;
-  bool is_dense = false;
-  int32_t cuda_type = 0;
+// One cache key for the full matmul descriptor bundle (sparse_input, dense_input, res, C).
+struct MatDescriptorCacheKey {
+  int m = 0;
+  int k = 0;
+  int n = 0;
+  bool dense_is_contiguous = true;
+  bool transpose_result = false;
+  int32_t input_type = 0;
+  int32_t output_type = 0;
+  int32_t C_type = 0;
 };
 
-using SparseInputDescriptorCacheKeyHash = ParamsHash<SparseInputDescriptorCacheKey>;
-using SparseInputDescriptorCacheKeyEqual = ParamsEqual<SparseInputDescriptorCacheKey>;
+using MatDescriptorCacheKeyHash = ParamsHash<MatDescriptorCacheKey>;
+using MatDescriptorCacheKeyEqual = ParamsEqual<MatDescriptorCacheKey>;
 
-struct CachedSparseInputDescriptor {
-  cusparseLtMatDescriptor_t descriptor;
-  bool has_descriptor = false;
+// One cached entry holds all 4 descriptors for a matmul config.
+struct CachedMatDescriptor {
+  cusparseLtMatDescriptor_t sparse_input;
+  cusparseLtMatDescriptor_t dense_input;
+  cusparseLtMatDescriptor_t res;
+  cusparseLtMatDescriptor_t C;
+  bool has_descriptors = false;
 
-  CachedSparseInputDescriptor() = default;
-  ~CachedSparseInputDescriptor() {
-    if (has_descriptor) {
-      cusparseLtMatDescriptorDestroy(&descriptor);
-      has_descriptor = false;
+  CachedMatDescriptor() = default;
+  ~CachedMatDescriptor() {
+    if (has_descriptors) {
+      cusparseLtMatDescriptorDestroy(&sparse_input);
+      cusparseLtMatDescriptorDestroy(&dense_input);
+      cusparseLtMatDescriptorDestroy(&res);
+      cusparseLtMatDescriptorDestroy(&C);
+      has_descriptors = false;
     }
   }
-  CachedSparseInputDescriptor(CachedSparseInputDescriptor&& other) noexcept
-      : descriptor(other.descriptor),
-        has_descriptor(other.has_descriptor) {
-    other.has_descriptor = false;
+  CachedMatDescriptor(CachedMatDescriptor&& other) noexcept
+      : sparse_input(other.sparse_input),
+        dense_input(other.dense_input),
+        res(other.res),
+        C(other.C),
+        has_descriptors(other.has_descriptors) {
+    other.has_descriptors = false;
   }
-  CachedSparseInputDescriptor& operator=(CachedSparseInputDescriptor&& other) noexcept {
+  CachedMatDescriptor& operator=(CachedMatDescriptor&& other) noexcept {
     if (this != &other) {
-      if (has_descriptor) {
-        cusparseLtMatDescriptorDestroy(&descriptor);
+      if (has_descriptors) {
+        cusparseLtMatDescriptorDestroy(&sparse_input);
+        cusparseLtMatDescriptorDestroy(&dense_input);
+        cusparseLtMatDescriptorDestroy(&res);
+        cusparseLtMatDescriptorDestroy(&C);
       }
-      descriptor = other.descriptor;
-      has_descriptor = other.has_descriptor;
-      other.has_descriptor = false;
+      sparse_input = other.sparse_input;
+      dense_input = other.dense_input;
+      res = other.res;
+      C = other.C;
+      has_descriptors = other.has_descriptors;
+      other.has_descriptors = false;
     }
     return *this;
   }
-  CachedSparseInputDescriptor(const CachedSparseInputDescriptor&) = delete;
-  CachedSparseInputDescriptor& operator=(const CachedSparseInputDescriptor&) = delete;
+  CachedMatDescriptor(const CachedMatDescriptor&) = delete;
+  CachedMatDescriptor& operator=(const CachedMatDescriptor&) = delete;
 };
 
-constexpr size_t SparseInputDescriptorCacheMaxSize = 128;
+struct MatDescriptorPtrs {
+  cusparseLtMatDescriptor_t* sparse_input = nullptr;
+  cusparseLtMatDescriptor_t* dense_input = nullptr;
+  cusparseLtMatDescriptor_t* res = nullptr;
+  cusparseLtMatDescriptor_t* C = nullptr;
+};
 
-using SparseInputDescriptorLruList =
-    std::list<std::pair<SparseInputDescriptorCacheKey, CachedSparseInputDescriptor>>;
-using SparseInputDescriptorCacheMap = std::unordered_map<
-    SparseInputDescriptorCacheKey,
-    SparseInputDescriptorLruList::iterator,
-    SparseInputDescriptorCacheKeyHash,
-    SparseInputDescriptorCacheKeyEqual>;
+constexpr size_t MatDescriptorCacheMaxSize = 128;
 
+using MatDescriptorLruList =
+    std::list<std::pair<MatDescriptorCacheKey, CachedMatDescriptor>>;
+using MatDescriptorCacheMap = std::unordered_map<
+    MatDescriptorCacheKey,
+    MatDescriptorLruList::iterator,
+    MatDescriptorCacheKeyHash,
+    MatDescriptorCacheKeyEqual>;
 
-struct SparseInputDescriptorCache {
-  SparseInputDescriptorLruList lru_list;
-  SparseInputDescriptorCacheMap cache_map;
+// One cache for the 4-descriptor bundle (sparse_input, dense_input, res, C).
+struct MatDescriptorCache {
+  MatDescriptorLruList lru_list;
+  MatDescriptorCacheMap cache_map;
 
-  // Returns plan pointer and workspace_size if found; moves entry to front for LRU.
-  std::optional<cusparseLtMatDescriptor_t*> lookup(
-      const SparseInputDescriptorCacheKey& key) {
+  std::optional<MatDescriptorPtrs> lookup(const MatDescriptorCacheKey& key) {
     auto it = cache_map.find(key);
     if (it == cache_map.end()) {
       return std::nullopt;
     }
     lru_list.splice(lru_list.begin(), lru_list, it->second);
-    CachedSparseInputDescriptor& entry = it->second->second;
-    return &entry.descriptor;
+    CachedMatDescriptor& entry = it->second->second;
+    MatDescriptorPtrs ptrs;
+    ptrs.sparse_input = &entry.sparse_input;
+    ptrs.dense_input = &entry.dense_input;
+    ptrs.res = &entry.res;
+    ptrs.C = &entry.C;
+    return ptrs;
   }
 
-  void insert(SparseInputDescriptorCacheKey key, CachedSparseInputDescriptor descriptor) {
-    if (lru_list.size() >= SparseInputDescriptorCacheMaxSize) {
+  void insert(MatDescriptorCacheKey key, CachedMatDescriptor descriptor) {
+    if (lru_list.size() >= MatDescriptorCacheMaxSize) {
       auto& back = lru_list.back();
       cache_map.erase(back.first);
       lru_list.pop_back();
@@ -136,63 +167,98 @@ struct SparseInputDescriptorCache {
   }
 };
 
-thread_local std::unique_ptr<SparseInputDescriptorCache> sparse_input_descriptor_cache;
+thread_local std::unique_ptr<MatDescriptorCache> mat_descriptor_cache;
 
-SparseInputDescriptorCache& getSparseInputDescriptorCache() {
-  if (!sparse_input_descriptor_cache) {
-    sparse_input_descriptor_cache = std::make_unique<SparseInputDescriptorCache>();
+MatDescriptorCache& getMatDescriptorCache() {
+  if (!mat_descriptor_cache) {
+    mat_descriptor_cache = std::make_unique<MatDescriptorCache>();
   }
-  return *sparse_input_descriptor_cache;
+  return *mat_descriptor_cache;
 }
 
-enum class MatDescriptorKind { Dense, Sparse };
-
-static cusparseLtMatDescriptor_t* _get_input_descriptor_ptr(
+// Returns all 4 descriptor pointers for this matmul config from one cache key.
+static MatDescriptorPtrs _get_matmul_descriptor_ptrs(
     cusparseLtHandle_t& handle,
-    MatDescriptorKind kind,
-    int64_t rows,
-    int64_t cols,
-    int64_t ld,
-    cudaDataType cuda_type,
-    int64_t alignment = 16,
-    cusparseOrder_t order = CUSPARSE_ORDER_ROW) {
-  SparseInputDescriptorCacheKey key{};
-  key.dim0 = static_cast<int>(rows);
-  key.dim1 = static_cast<int>(cols);
-  key.is_dense = (kind == MatDescriptorKind::Dense);
-  key.cuda_type = static_cast<int32_t>(cuda_type);
-  auto cached = getSparseInputDescriptorCache().lookup(key);
+    int64_t m,
+    int64_t k,
+    int64_t n,
+    bool dense_is_contiguous,
+    bool transpose_result,
+    cudaDataType input_type,
+    cudaDataType output_type,
+    cudaDataType C_type) {
+  MatDescriptorCacheKey key{};
+  key.m = static_cast<int>(m);
+  key.k = static_cast<int>(k);
+  key.n = static_cast<int>(n);
+  key.dense_is_contiguous = dense_is_contiguous;
+  key.transpose_result = transpose_result;
+  key.input_type = static_cast<int32_t>(input_type);
+  key.output_type = static_cast<int32_t>(output_type);
+  key.C_type = static_cast<int32_t>(C_type);
+
+  auto cached = getMatDescriptorCache().lookup(key);
   if (cached.has_value()) {
     return *cached;
   }
-  cusparseLtMatDescriptor_t descriptor;
-  if (kind == MatDescriptorKind::Sparse) {
-    TORCH_CUDASPARSE_CHECK(cusparseLtStructuredDescriptorInit(
-        &handle,
-        &descriptor,
-        rows,
-        cols,
-        ld,
-        alignment,
-        cuda_type,
-        order,
-        CUSPARSELT_SPARSITY_50_PERCENT));
-  } else {
-    TORCH_CUDASPARSE_CHECK(cusparseLtDenseDescriptorInit(
-        &handle,
-        &descriptor,
-        rows,
-        cols,
-        ld,
-        alignment,
-        cuda_type,
-        order));
-  }
-  CachedSparseInputDescriptor cached_descriptor;
-  cached_descriptor.descriptor = descriptor;
-  cached_descriptor.has_descriptor = true;
-  getSparseInputDescriptorCache().insert(std::move(key), std::move(cached_descriptor));
-  cached = getSparseInputDescriptorCache().lookup(key);
+
+  int64_t dense_rows = dense_is_contiguous ? k : n;
+  int64_t dense_cols = dense_is_contiguous ? n : k;
+  int64_t res_ld = transpose_result ? m : n;
+  cusparseOrder_t res_order = transpose_result ? CUSPARSE_ORDER_COL : CUSPARSE_ORDER_ROW;
+
+  CachedMatDescriptor bundle;
+  TORCH_CUDASPARSE_CHECK(cusparseLtStructuredDescriptorInit(
+      &handle,
+      &bundle.sparse_input,
+      m,
+      k,
+      k,
+      16,
+      input_type,
+      CUSPARSE_ORDER_ROW,
+      CUSPARSELT_SPARSITY_50_PERCENT));
+  TORCH_CUDASPARSE_CHECK(cusparseLtDenseDescriptorInit(
+      &handle,
+      &bundle.dense_input,
+      dense_rows,
+      dense_cols,
+      dense_cols,
+      16,
+      input_type,
+      CUSPARSE_ORDER_ROW));
+  TORCH_CUDASPARSE_CHECK(cusparseLtDenseDescriptorInit(
+      &handle,
+      &bundle.res,
+      m,
+      n,
+      res_ld,
+      16,
+      output_type,
+      res_order));
+  TORCH_CUDASPARSE_CHECK(cusparseLtDenseDescriptorInit(
+      &handle,
+      &bundle.C,
+      m,
+      n,
+      res_ld,
+      16,
+      C_type,
+      res_order));
+  bundle.has_descriptors = true;
+
+  getMatDescriptorCache().insert(std::move(key), std::move(bundle));
+  // Rebuild key for lookup (key was moved into insert).
+  MatDescriptorCacheKey key_lookup{};
+  key_lookup.m = static_cast<int>(m);
+  key_lookup.k = static_cast<int>(k);
+  key_lookup.n = static_cast<int>(n);
+  key_lookup.dense_is_contiguous = dense_is_contiguous;
+  key_lookup.transpose_result = transpose_result;
+  key_lookup.input_type = static_cast<int32_t>(input_type);
+  key_lookup.output_type = static_cast<int32_t>(output_type);
+  key_lookup.C_type = static_cast<int32_t>(C_type);
+  cached = getMatDescriptorCache().lookup(key_lookup);
   return *cached;
 }
 
@@ -542,51 +608,22 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
   int64_t n = dense_B.size(1);
   int64_t m = compressed_A.size(0);
 
-  // _get_input_descriptor_ptr(
-  //   cusparseLtHandle_t& handle,
-  //   MatDescriptorKind kind,
-  //   int64_t rows,
-  //   int64_t cols,
-  //   int64_t ld,
-  //   cudaDataType input_type,
-  //   int64_t alignment = 16,
-  //   cusparseOrder_t order = CUSPARSE_ORDER_ROW
-
-  cusparseLtMatDescriptor_t* sparse_input_descriptor_ptr =
-    _get_input_descriptor_ptr(handle, MatDescriptorKind::Sparse, m, k, k, input_type);
-
-  // initialize dense input descriptor
-  int64_t dense_rows = dense_B.is_contiguous() ? k : n;
-  int64_t dense_cols = dense_B.is_contiguous() ? n : k;
-  cusparseLtMatDescriptor_t* dense_input_descriptor_ptr =
-    _get_input_descriptor_ptr(handle, MatDescriptorKind::Dense, dense_rows, dense_cols, dense_cols, input_type);
+  MatDescriptorPtrs desc_ptrs = _get_matmul_descriptor_ptrs(
+      handle,
+      m,
+      k,
+      n,
+      dense_B.is_contiguous(),
+      transpose_result,
+      input_type,
+      output_type,
+      C_type);
 
   // create result tensor
   auto res_tensor_options =
       c10::TensorOptions().dtype(out_dtype).device(dense_B.device());
   at::Tensor res = (transpose_result) ? at::empty({n, m}, res_tensor_options)
                                       : at::empty({m, n}, res_tensor_options);
-
-  cusparseLtMatDescriptor_t* res_descriptor_ptr =
-    _get_input_descriptor_ptr(handle,
-        MatDescriptorKind::Dense,
-        m,
-        n,
-        transpose_result ? m : n,
-        output_type,
-        16,
-        transpose_result ? CUSPARSE_ORDER_COL : CUSPARSE_ORDER_ROW);
-  
-  // For float8, need fp16 C_descriptor, can't use FP8 for this matrix
-  cusparseLtMatDescriptor_t*  C_descriptor_ptr =
-    _get_input_descriptor_ptr(handle,
-        MatDescriptorKind::Dense,
-        m,
-        n,
-        transpose_result ? m : n,
-        C_type,
-        16,
-        transpose_result ? CUSPARSE_ORDER_COL : CUSPARSE_ORDER_ROW);
 
   // initialize matmul
   TORCH_CUDASPARSE_CHECK(cusparseLtMatmulDescriptorInit(
@@ -595,10 +632,10 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
       CUSPARSE_OPERATION_NON_TRANSPOSE,
       (dense_B.is_contiguous()) ? CUSPARSE_OPERATION_NON_TRANSPOSE
                                 : CUSPARSE_OPERATION_TRANSPOSE,
-      sparse_input_descriptor_ptr,
-      dense_input_descriptor_ptr,
-      C_descriptor_ptr,
-      res_descriptor_ptr,
+      desc_ptrs.sparse_input,
+      desc_ptrs.dense_input,
+      desc_ptrs.C,
+      desc_ptrs.res,
       compute_type));
 
   // set bias pointer for matmul, need to assign to get location

--- a/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
+++ b/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
@@ -55,8 +55,6 @@ cusparseLtHandle_t& get_cusparselt_handle_for_current_device() {
   return it->second;
 }
 
-/////////////////////////////////////////////////////////////////////
-
 // One cache key for the full matmul descriptor bundle and plan.
 struct MatDescriptorCacheKey {
   int m = 0;
@@ -77,7 +75,15 @@ struct MatDescriptorCacheKey {
 using MatDescriptorCacheKeyHash = ParamsHash<MatDescriptorCacheKey>;
 using MatDescriptorCacheKeyEqual = ParamsEqual<MatDescriptorCacheKey>;
 
-// One cached entry holds all descriptors and plan for a matmul config (built in-place).
+struct MatDescriptorPtrs {
+  cusparseLtMatmulDescriptor_t* matmul = nullptr;
+  cusparseLtMatmulAlgSelection_t* alg_sel = nullptr;
+  cusparseLtMatmulPlan_t* plan = nullptr;
+};
+
+// Cached entry holds matmul, alg_sel, plan (exposed via ptrs) plus the operand
+// descriptors (sparse_input, dense_input, res, C) which must stay alive because
+// the library retains pointers to them; they are not exposed in MatDescriptorPtrs.
 struct CachedMatDescriptor {
   cusparseLtMatDescriptor_t sparse_input;
   cusparseLtMatDescriptor_t dense_input;
@@ -86,6 +92,7 @@ struct CachedMatDescriptor {
   cusparseLtMatmulDescriptor_t matmul;
   cusparseLtMatmulAlgSelection_t alg_sel;
   cusparseLtMatmulPlan_t plan;
+  MatDescriptorPtrs ptrs;
   bool has_descriptors = false;
 
   CachedMatDescriptor() = default;
@@ -108,6 +115,7 @@ struct CachedMatDescriptor {
         matmul(other.matmul),
         alg_sel(other.alg_sel),
         plan(other.plan),
+        ptrs(other.ptrs),
         has_descriptors(other.has_descriptors) {
     other.has_descriptors = false;
   }
@@ -128,6 +136,7 @@ struct CachedMatDescriptor {
       matmul = other.matmul;
       alg_sel = other.alg_sel;
       plan = other.plan;
+      ptrs = other.ptrs;
       has_descriptors = other.has_descriptors;
       other.has_descriptors = false;
     }
@@ -135,16 +144,6 @@ struct CachedMatDescriptor {
   }
   CachedMatDescriptor(const CachedMatDescriptor&) = delete;
   CachedMatDescriptor& operator=(const CachedMatDescriptor&) = delete;
-};
-
-struct MatDescriptorPtrs {
-  cusparseLtMatDescriptor_t* sparse_input = nullptr;
-  cusparseLtMatDescriptor_t* dense_input = nullptr;
-  cusparseLtMatDescriptor_t* res = nullptr;
-  cusparseLtMatDescriptor_t* C = nullptr;
-  cusparseLtMatmulDescriptor_t* matmul = nullptr;
-  cusparseLtMatmulAlgSelection_t* alg_sel = nullptr;
-  cusparseLtMatmulPlan_t* plan = nullptr;
 };
 
 constexpr size_t MatDescriptorCacheMaxSize = 128;
@@ -157,32 +156,25 @@ using MatDescriptorCacheMap = std::unordered_map<
     MatDescriptorCacheKeyHash,
     MatDescriptorCacheKeyEqual>;
 
-// One cache for the 4-descriptor bundle (sparse_input, dense_input, res, C).
+// Cache for matmul descriptor, alg selection, and plan (keyed by shape/dtype/alg).
 struct MatDescriptorCache {
   MatDescriptorLruList lru_list;
   MatDescriptorCacheMap cache_map;
 
-  std::optional<MatDescriptorPtrs> lookup(const MatDescriptorCacheKey& key) {
+  MatDescriptorPtrs* lookup(const MatDescriptorCacheKey& key) {
     auto it = cache_map.find(key);
     if (it == cache_map.end()) {
-      return std::nullopt;
+      return nullptr;
     }
     lru_list.splice(lru_list.begin(), lru_list, it->second);
     CachedMatDescriptor& entry = it->second->second;
-    MatDescriptorPtrs ptrs;
-    ptrs.sparse_input = &entry.sparse_input;
-    ptrs.dense_input = &entry.dense_input;
-    ptrs.res = &entry.res;
-    ptrs.C = &entry.C;
-    ptrs.matmul = &entry.matmul;
-    ptrs.alg_sel = &entry.alg_sel;
-    ptrs.plan = &entry.plan;
-    return ptrs;
+    entry.ptrs.matmul = &entry.matmul;
+    entry.ptrs.alg_sel = &entry.alg_sel;
+    entry.ptrs.plan = &entry.plan;
+    return &entry.ptrs;
   }
 
-  // Build a new cache entry in-place (no move); create plan once per entry.
-  std::optional<MatDescriptorPtrs> getOrCreate(
-      const MatDescriptorCacheKey& key,
+  MatDescriptorPtrs* getOrCreate(
       cusparseLtHandle_t& handle,
       int64_t m,
       int64_t k,
@@ -193,11 +185,26 @@ struct MatDescriptorCache {
       cudaDataType output_type,
       cudaDataType C_type,
       cusparseComputeType compute_type,
+      bool has_bias,
       int alg_id,
       int split_k,
       int split_k_mode) {
-    auto result = lookup(key);
-    if (result.has_value()) {
+    MatDescriptorCacheKey key{};
+    key.m = static_cast<int>(m);
+    key.k = static_cast<int>(k);
+    key.n = static_cast<int>(n);
+    key.dense_is_contiguous = dense_is_contiguous;
+    key.transpose_result = transpose_result;
+    key.input_type = static_cast<int32_t>(input_type);
+    key.output_type = static_cast<int32_t>(output_type);
+    key.C_type = static_cast<int32_t>(C_type);
+    key.compute_type = static_cast<int32_t>(compute_type);
+    key.has_bias = has_bias;
+    key.alg_id = static_cast<int32_t>(alg_id);
+    key.split_k = static_cast<int32_t>(split_k);
+    key.split_k_mode = static_cast<int32_t>(split_k_mode);
+    MatDescriptorPtrs* result = lookup(key);
+    if (result != nullptr) {
       return result;
     }
     if (lru_list.size() >= MatDescriptorCacheMaxSize) {
@@ -296,9 +303,12 @@ struct MatDescriptorCache {
     TORCH_CUDASPARSE_CHECK(cusparseLtMatmulPlanInit(
         &handle, &entry.plan, &entry.matmul, &entry.alg_sel));
 
+    entry.ptrs.matmul = &entry.matmul;
+    entry.ptrs.alg_sel = &entry.alg_sel;
+    entry.ptrs.plan = &entry.plan;
     entry.has_descriptors = true;
     cache_map[lru_list.front().first] = lru_list.begin();
-    return lookup(key);
+    return &lru_list.front().second.ptrs;
   }
 
   void insert(MatDescriptorCacheKey key, CachedMatDescriptor descriptor) {
@@ -320,63 +330,6 @@ MatDescriptorCache& getMatDescriptorCache() {
   }
   return *mat_descriptor_cache;
 }
-
-// Returns descriptor pointers and plan for this matmul config (cache built in-place).
-static MatDescriptorPtrs _get_matmul_descriptor_ptrs(
-    cusparseLtHandle_t& handle,
-    int64_t m,
-    int64_t k,
-    int64_t n,
-    bool dense_is_contiguous,
-    bool transpose_result,
-    cudaDataType input_type,
-    cudaDataType output_type,
-    cudaDataType C_type,
-    cusparseComputeType compute_type,
-    bool has_bias,
-    int alg_id,
-    int split_k,
-    int split_k_mode) {
-  MatDescriptorCacheKey key{};
-  key.m = static_cast<int>(m);
-  key.k = static_cast<int>(k);
-  key.n = static_cast<int>(n);
-  key.dense_is_contiguous = dense_is_contiguous;
-  key.transpose_result = transpose_result;
-  key.input_type = static_cast<int32_t>(input_type);
-  key.output_type = static_cast<int32_t>(output_type);
-  key.C_type = static_cast<int32_t>(C_type);
-  key.compute_type = static_cast<int32_t>(compute_type);
-  key.has_bias = has_bias;
-  key.alg_id = static_cast<int32_t>(alg_id);
-  key.split_k = static_cast<int32_t>(split_k);
-  key.split_k_mode = static_cast<int32_t>(split_k_mode);
-
-  auto result = getMatDescriptorCache().getOrCreate(
-      key,
-      handle,
-      m,
-      k,
-      n,
-      dense_is_contiguous,
-      transpose_result,
-      input_type,
-      output_type,
-      C_type,
-      compute_type,
-      alg_id,
-      split_k,
-      split_k_mode);
-  TORCH_CHECK(
-      result.has_value(),
-      "cuSPARSELt: mat descriptor cache getOrCreate failed");
-  return *result;
-}
-
-
-
-//////////////////////////////////////////////////////////////////////
-
 
 #ifdef USE_ROCM
 // Single global flag for platform-wide hipSparseLt support
@@ -715,7 +668,7 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
   int64_t n = dense_B.size(1);
   int64_t m = compressed_A.size(0);
 
-  MatDescriptorPtrs desc_ptrs = _get_matmul_descriptor_ptrs(
+  MatDescriptorPtrs* desc_ptrs = getMatDescriptorCache().getOrCreate(
       handle,
       m,
       k,
@@ -730,32 +683,9 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
       alg_id,
       split_k,
       split_k_mode);
-
-  // bool not_null_sparse_input = (desc_ptrs.sparse_input != nullptr);
-  // bool not_null_dense_input = (desc_ptrs.dense_input != nullptr);
-  // bool not_null_res = (desc_ptrs.res != nullptr);
-  // bool not_null_C = (desc_ptrs.C != nullptr);
-  // bool not_null_alg_sel = (desc_ptrs.alg_sel != nullptr);
-  // std::cout << "not_null_sparse_input=" << not_null_sparse_input
-  //           << " not_null_dense_input=" << not_null_dense_input
-  //           << " not_null_res=" << not_null_res
-  //           << " not_null_C=" << not_null_C
-  //           << " not_null_alg_sel=" << not_null_alg_sel
-  //           << std::endl;
-
-  // // initialize matmul
-  // TORCH_CUDASPARSE_CHECK(cusparseLtMatmulDescriptorInit(
-  //     &handle,
-  //     &matmul,
-  //     CUSPARSE_OPERATION_NON_TRANSPOSE,
-  //     (dense_B.is_contiguous()) ? CUSPARSE_OPERATION_NON_TRANSPOSE
-  //                               : CUSPARSE_OPERATION_TRANSPOSE,
-  //     desc_ptrs.sparse_input,
-  //     desc_ptrs.dense_input,
-  //     desc_ptrs.C,
-  //     desc_ptrs.res,
-  //     compute_type));
-
+  TORCH_CHECK(
+      desc_ptrs != nullptr,
+      "cuSPARSELt: mat descriptor cache getOrCreate failed");
 
   // set bias pointer for matmul, need to assign to get location
   if (bias_opt.has_value()) {
@@ -763,19 +693,11 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
     void* dBias = bias.data_ptr();
     TORCH_CUDASPARSE_CHECK(cusparseLtMatmulDescSetAttribute(
         &handle,
-        desc_ptrs.matmul,
+        desc_ptrs->matmul,
         CUSPARSELT_MATMUL_BIAS_POINTER,
         &dBias,
         sizeof(dBias)));
   }
-
-
-  // auto ta1 = std::chrono::steady_clock::now();  ~.285545
-  // TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgSelectionInit(
-  //     &handle, &alg_sel, &matmul, CUSPARSELT_MATMUL_ALG_DEFAULT));
-  // auto ta2 = std::chrono::steady_clock::now();
-  // double duration_alg_init = std::chrono::duration<double, std::milli>(ta2 - ta1).count();
-  // std::cout << "duration_alg_init = " << duration_alg_init << std::endl;
 
   cusparseLtSplitKMode_t splitKMode;
   int max_alg_id;
@@ -790,7 +712,7 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
       int tensor_alpha_mode = 1;
       TORCH_CUDASPARSE_CHECK(cusparseLtMatmulDescSetAttribute(
           &handle,
-          desc_ptrs.matmul,
+          desc_ptrs->matmul,
           CUSPARSELT_MATMUL_ALPHA_VECTOR_SCALING,
           &tensor_alpha_mode,
           sizeof(tensor_alpha_mode)));
@@ -800,7 +722,7 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
 
   size_t workspace_size;
   TORCH_CUDASPARSE_CHECK(
-      cusparseLtMatmulGetWorkspace(&handle, desc_ptrs.plan, &workspace_size));
+      cusparseLtMatmulGetWorkspace(&handle, desc_ptrs->plan, &workspace_size));
 
 
   auto& allocator = *::c10::cuda::CUDACachingAllocator::get();
@@ -817,7 +739,7 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
     // run matmul search
     TORCH_CUDASPARSE_CHECK(cusparseLtMatmulSearch(
         &handle,
-        desc_ptrs.plan,
+        desc_ptrs->plan,
         alpha_ptr,
         compressed_A.data_ptr(),
         dense_B.data_ptr(),
@@ -832,7 +754,7 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
     // get matmul params used
     TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgGetAttribute(
         &handle,
-        desc_ptrs.alg_sel,
+        desc_ptrs->alg_sel,
         CUSPARSELT_MATMUL_ALG_CONFIG_ID,
         &alg_id,
         sizeof(alg_id)));
@@ -841,14 +763,14 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
     // hipSPARSELt does not support querying SPLIT_K attributes
     TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgGetAttribute(
         &handle,
-        desc_ptrs.alg_sel,
+        desc_ptrs->alg_sel,
         CUSPARSELT_MATMUL_SPLIT_K,
         &split_k,
         sizeof(split_k)));
 
     TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgGetAttribute(
         &handle,
-        desc_ptrs.alg_sel,
+        desc_ptrs->alg_sel,
         CUSPARSELT_MATMUL_SPLIT_K_MODE,
         &splitKMode,
         sizeof(splitKMode)));
@@ -856,7 +778,7 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
 
     TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgGetAttribute(
         &handle,
-        desc_ptrs.alg_sel,
+        desc_ptrs->alg_sel,
         CUSPARSELT_MATMUL_ALG_CONFIG_MAX_ID,
         &max_alg_id,
         sizeof(max_alg_id)));
@@ -865,7 +787,7 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
     // do normal matmul
     TORCH_CUDASPARSE_CHECK(cusparseLtMatmul(
         &handle,
-        desc_ptrs.plan,
+        desc_ptrs->plan,
         alpha_ptr,
         compressed_A.data_ptr(),
         dense_B.data_ptr(),

--- a/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
+++ b/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
@@ -188,7 +188,8 @@ struct MatDescriptorCache {
       bool has_bias,
       int alg_id,
       int split_k,
-      int split_k_mode) {
+      int split_k_mode,
+      const std::optional<Tensor>& bias_opt) {
     MatDescriptorCacheKey key{};
     key.m = static_cast<int>(m);
     key.k = static_cast<int>(k);
@@ -204,100 +205,113 @@ struct MatDescriptorCache {
     key.split_k = static_cast<int32_t>(split_k);
     key.split_k_mode = static_cast<int32_t>(split_k_mode);
     MatDescriptorPtrs* result = lookup(key);
-    if (result != nullptr) {
-      return result;
+    if (result == nullptr) {
+      if (lru_list.size() >= MatDescriptorCacheMaxSize) {
+        auto& back = lru_list.back();
+        cache_map.erase(back.first);
+        lru_list.pop_back();
+      }
+      lru_list.push_front({key, CachedMatDescriptor{}});
     }
-    if (lru_list.size() >= MatDescriptorCacheMaxSize) {
-      auto& back = lru_list.back();
-      cache_map.erase(back.first);
-      lru_list.pop_back();
-    }
-    lru_list.push_front({key, CachedMatDescriptor{}});
+    // Both paths leave the target entry at the front of lru_list:
+    // lookup() splices a hit there; a miss push_front's the new entry.
     CachedMatDescriptor& entry = lru_list.front().second;
-
-    int64_t dense_rows = dense_is_contiguous ? k : n;
-    int64_t dense_cols = dense_is_contiguous ? n : k;
-    int64_t res_ld = transpose_result ? m : n;
-    cusparseOrder_t res_order =
-        transpose_result ? CUSPARSE_ORDER_COL : CUSPARSE_ORDER_ROW;
-
-    TORCH_CUDASPARSE_CHECK(cusparseLtStructuredDescriptorInit(
-        &handle,
-        &entry.sparse_input,
-        m,
-        k,
-        k,
-        16,
-        input_type,
-        CUSPARSE_ORDER_ROW,
-        CUSPARSELT_SPARSITY_50_PERCENT));
-    TORCH_CUDASPARSE_CHECK(cusparseLtDenseDescriptorInit(
-        &handle,
-        &entry.dense_input,
-        dense_rows,
-        dense_cols,
-        dense_cols,
-        16,
-        input_type,
-        CUSPARSE_ORDER_ROW));
-    TORCH_CUDASPARSE_CHECK(cusparseLtDenseDescriptorInit(
-        &handle,
-        &entry.res,
-        m,
-        n,
-        res_ld,
-        16,
-        output_type,
-        res_order));
-    TORCH_CUDASPARSE_CHECK(cusparseLtDenseDescriptorInit(
-        &handle,
-        &entry.C,
-        m,
-        n,
-        res_ld,
-        16,
-        C_type,
-        res_order));
-    TORCH_CUDASPARSE_CHECK(cusparseLtMatmulDescriptorInit(
-        &handle,
-        &entry.matmul,
-        CUSPARSE_OPERATION_NON_TRANSPOSE,
-        dense_is_contiguous ? CUSPARSE_OPERATION_NON_TRANSPOSE
-                            : CUSPARSE_OPERATION_TRANSPOSE,
-        &entry.sparse_input,
-        &entry.dense_input,
-        &entry.C,
-        &entry.res,
-        compute_type));
-    TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgSelectionInit(
-        &handle,
-        &entry.alg_sel,
-        &entry.matmul,
-        CUSPARSELT_MATMUL_ALG_DEFAULT));
-
-    TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgSetAttribute(
-        &handle,
-        &entry.alg_sel,
-        CUSPARSELT_MATMUL_ALG_CONFIG_ID,
-        &alg_id,
-        sizeof(alg_id)));
-    if (split_k != 1) {
+    if (result == nullptr) {
+      int64_t dense_rows = dense_is_contiguous ? k : n;
+      int64_t dense_cols = dense_is_contiguous ? n : k;
+      int64_t res_ld = transpose_result ? m : n;
+      cusparseOrder_t res_order =
+          transpose_result ? CUSPARSE_ORDER_COL : CUSPARSE_ORDER_ROW;
+  
+      TORCH_CUDASPARSE_CHECK(cusparseLtStructuredDescriptorInit(
+          &handle,
+          &entry.sparse_input,
+          m,
+          k,
+          k,
+          16,
+          input_type,
+          CUSPARSE_ORDER_ROW,
+          CUSPARSELT_SPARSITY_50_PERCENT));
+      TORCH_CUDASPARSE_CHECK(cusparseLtDenseDescriptorInit(
+          &handle,
+          &entry.dense_input,
+          dense_rows,
+          dense_cols,
+          dense_cols,
+          16,
+          input_type,
+          CUSPARSE_ORDER_ROW));
+      TORCH_CUDASPARSE_CHECK(cusparseLtDenseDescriptorInit(
+          &handle,
+          &entry.res,
+          m,
+          n,
+          res_ld,
+          16,
+          output_type,
+          res_order));
+      TORCH_CUDASPARSE_CHECK(cusparseLtDenseDescriptorInit(
+          &handle,
+          &entry.C,
+          m,
+          n,
+          res_ld,
+          16,
+          C_type,
+          res_order));
+      TORCH_CUDASPARSE_CHECK(cusparseLtMatmulDescriptorInit(
+          &handle,
+          &entry.matmul,
+          CUSPARSE_OPERATION_NON_TRANSPOSE,
+          dense_is_contiguous ? CUSPARSE_OPERATION_NON_TRANSPOSE
+                              : CUSPARSE_OPERATION_TRANSPOSE,
+          &entry.sparse_input,
+          &entry.dense_input,
+          &entry.C,
+          &entry.res,
+          compute_type));
+      TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgSelectionInit(
+          &handle,
+          &entry.alg_sel,
+          &entry.matmul,
+          CUSPARSELT_MATMUL_ALG_DEFAULT));
+  
       TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgSetAttribute(
           &handle,
           &entry.alg_sel,
-          CUSPARSELT_MATMUL_SPLIT_K,
-          &split_k,
-          sizeof(split_k)));
-      if (split_k_mode > 0) {
-        cusparseLtSplitKMode_t splitKMode =
-            static_cast<cusparseLtSplitKMode_t>(split_k_mode);
+          CUSPARSELT_MATMUL_ALG_CONFIG_ID,
+          &alg_id,
+          sizeof(alg_id)));
+      if (split_k != 1) {
         TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgSetAttribute(
             &handle,
             &entry.alg_sel,
-            CUSPARSELT_MATMUL_SPLIT_K_MODE,
-            &splitKMode,
-            sizeof(splitKMode)));
+            CUSPARSELT_MATMUL_SPLIT_K,
+            &split_k,
+            sizeof(split_k)));
+        if (split_k_mode > 0) {
+          cusparseLtSplitKMode_t splitKMode =
+              static_cast<cusparseLtSplitKMode_t>(split_k_mode);
+          TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgSetAttribute(
+              &handle,
+              &entry.alg_sel,
+              CUSPARSELT_MATMUL_SPLIT_K_MODE,
+              &splitKMode,
+              sizeof(splitKMode)));
+        }
       }
+    }
+    
+    if (bias_opt.has_value()) {
+      auto& bias = bias_opt.value();
+      void* dBias = bias.data_ptr();
+      TORCH_CUDASPARSE_CHECK(cusparseLtMatmulDescSetAttribute(
+          &handle,
+          &entry.matmul,
+          CUSPARSELT_MATMUL_BIAS_POINTER,
+          &dBias,
+          sizeof(dBias)));
     }
 
     TORCH_CUDASPARSE_CHECK(cusparseLtMatmulPlanInit(
@@ -307,8 +321,10 @@ struct MatDescriptorCache {
     entry.ptrs.alg_sel = &entry.alg_sel;
     entry.ptrs.plan = &entry.plan;
     entry.has_descriptors = true;
-    cache_map[lru_list.front().first] = lru_list.begin();
-    return &lru_list.front().second.ptrs;
+    if (result == nullptr) {
+      cache_map[lru_list.front().first] = lru_list.begin();
+    }
+    return &entry.ptrs;
   }
 
   void insert(MatDescriptorCacheKey key, CachedMatDescriptor descriptor) {
@@ -683,22 +699,23 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
       bias_opt.has_value(),
       alg_id,
       split_k,
-      split_k_mode);
+      split_k_mode,
+      bias_opt);
   TORCH_CHECK(
       desc_ptrs != nullptr,
       "cuSPARSELt: mat descriptor cache getOrCreate failed");
 
-  // set bias pointer for matmul, need to assign to get location
-  if (bias_opt.has_value()) {
-    auto& bias = bias_opt.value();
-    void* dBias = bias.data_ptr();
-    TORCH_CUDASPARSE_CHECK(cusparseLtMatmulDescSetAttribute(
-        &handle,
-        desc_ptrs->matmul,
-        CUSPARSELT_MATMUL_BIAS_POINTER,
-        &dBias,
-        sizeof(dBias)));
-  }
+  // // set bias pointer for matmul, need to assign to get location
+  // if (bias_opt.has_value()) {
+  //   auto& bias = bias_opt.value();
+  //   void* dBias = bias.data_ptr();
+  //   TORCH_CUDASPARSE_CHECK(cusparseLtMatmulDescSetAttribute(
+  //       &handle,
+  //       desc_ptrs->matmul,
+  //       CUSPARSELT_MATMUL_BIAS_POINTER,
+  //       &dBias,
+  //       sizeof(dBias)));
+  // }
 
   // set tensor_alpha_mode and alpha pointer for matmul
   const auto alpha_tensor = alpha_opt.has_value() ? *alpha_opt : Tensor{};

--- a/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
+++ b/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
@@ -57,7 +57,7 @@ cusparseLtHandle_t& get_cusparselt_handle_for_current_device() {
 
 /////////////////////////////////////////////////////////////////////
 
-// One cache key for the full matmul descriptor bundle (sparse_input, dense_input, res, C).
+// One cache key for the full matmul descriptor bundle and plan.
 struct MatDescriptorCacheKey {
   int m = 0;
   int k = 0;
@@ -67,17 +67,25 @@ struct MatDescriptorCacheKey {
   int32_t input_type = 0;
   int32_t output_type = 0;
   int32_t C_type = 0;
+  int32_t compute_type = 0;
+  bool has_bias = false;
+  int32_t alg_id = 0;
+  int32_t split_k = 1;
+  int32_t split_k_mode = -1;
 };
 
 using MatDescriptorCacheKeyHash = ParamsHash<MatDescriptorCacheKey>;
 using MatDescriptorCacheKeyEqual = ParamsEqual<MatDescriptorCacheKey>;
 
-// One cached entry holds all 4 descriptors for a matmul config.
+// One cached entry holds all descriptors and plan for a matmul config (built in-place).
 struct CachedMatDescriptor {
   cusparseLtMatDescriptor_t sparse_input;
   cusparseLtMatDescriptor_t dense_input;
   cusparseLtMatDescriptor_t res;
   cusparseLtMatDescriptor_t C;
+  cusparseLtMatmulDescriptor_t matmul;
+  cusparseLtMatmulAlgSelection_t alg_sel;
+  cusparseLtMatmulPlan_t plan;
   bool has_descriptors = false;
 
   CachedMatDescriptor() = default;
@@ -87,6 +95,8 @@ struct CachedMatDescriptor {
       cusparseLtMatDescriptorDestroy(&dense_input);
       cusparseLtMatDescriptorDestroy(&res);
       cusparseLtMatDescriptorDestroy(&C);
+      cusparseLtMatmulAlgSelectionDestroy(&alg_sel);
+      cusparseLtMatmulPlanDestroy(&plan);
       has_descriptors = false;
     }
   }
@@ -95,6 +105,9 @@ struct CachedMatDescriptor {
         dense_input(other.dense_input),
         res(other.res),
         C(other.C),
+        matmul(other.matmul),
+        alg_sel(other.alg_sel),
+        plan(other.plan),
         has_descriptors(other.has_descriptors) {
     other.has_descriptors = false;
   }
@@ -105,11 +118,16 @@ struct CachedMatDescriptor {
         cusparseLtMatDescriptorDestroy(&dense_input);
         cusparseLtMatDescriptorDestroy(&res);
         cusparseLtMatDescriptorDestroy(&C);
+        cusparseLtMatmulAlgSelectionDestroy(&alg_sel);
+        cusparseLtMatmulPlanDestroy(&plan);
       }
       sparse_input = other.sparse_input;
       dense_input = other.dense_input;
       res = other.res;
       C = other.C;
+      matmul = other.matmul;
+      alg_sel = other.alg_sel;
+      plan = other.plan;
       has_descriptors = other.has_descriptors;
       other.has_descriptors = false;
     }
@@ -124,6 +142,9 @@ struct MatDescriptorPtrs {
   cusparseLtMatDescriptor_t* dense_input = nullptr;
   cusparseLtMatDescriptor_t* res = nullptr;
   cusparseLtMatDescriptor_t* C = nullptr;
+  cusparseLtMatmulDescriptor_t* matmul = nullptr;
+  cusparseLtMatmulAlgSelection_t* alg_sel = nullptr;
+  cusparseLtMatmulPlan_t* plan = nullptr;
 };
 
 constexpr size_t MatDescriptorCacheMaxSize = 128;
@@ -153,7 +174,131 @@ struct MatDescriptorCache {
     ptrs.dense_input = &entry.dense_input;
     ptrs.res = &entry.res;
     ptrs.C = &entry.C;
+    ptrs.matmul = &entry.matmul;
+    ptrs.alg_sel = &entry.alg_sel;
+    ptrs.plan = &entry.plan;
     return ptrs;
+  }
+
+  // Build a new cache entry in-place (no move); create plan once per entry.
+  std::optional<MatDescriptorPtrs> getOrCreate(
+      const MatDescriptorCacheKey& key,
+      cusparseLtHandle_t& handle,
+      int64_t m,
+      int64_t k,
+      int64_t n,
+      bool dense_is_contiguous,
+      bool transpose_result,
+      cudaDataType input_type,
+      cudaDataType output_type,
+      cudaDataType C_type,
+      cusparseComputeType compute_type,
+      int alg_id,
+      int split_k,
+      int split_k_mode) {
+    auto result = lookup(key);
+    if (result.has_value()) {
+      return result;
+    }
+    if (lru_list.size() >= MatDescriptorCacheMaxSize) {
+      auto& back = lru_list.back();
+      cache_map.erase(back.first);
+      lru_list.pop_back();
+    }
+    lru_list.push_front({key, CachedMatDescriptor{}});
+    CachedMatDescriptor& entry = lru_list.front().second;
+
+    int64_t dense_rows = dense_is_contiguous ? k : n;
+    int64_t dense_cols = dense_is_contiguous ? n : k;
+    int64_t res_ld = transpose_result ? m : n;
+    cusparseOrder_t res_order =
+        transpose_result ? CUSPARSE_ORDER_COL : CUSPARSE_ORDER_ROW;
+
+    TORCH_CUDASPARSE_CHECK(cusparseLtStructuredDescriptorInit(
+        &handle,
+        &entry.sparse_input,
+        m,
+        k,
+        k,
+        16,
+        input_type,
+        CUSPARSE_ORDER_ROW,
+        CUSPARSELT_SPARSITY_50_PERCENT));
+    TORCH_CUDASPARSE_CHECK(cusparseLtDenseDescriptorInit(
+        &handle,
+        &entry.dense_input,
+        dense_rows,
+        dense_cols,
+        dense_cols,
+        16,
+        input_type,
+        CUSPARSE_ORDER_ROW));
+    TORCH_CUDASPARSE_CHECK(cusparseLtDenseDescriptorInit(
+        &handle,
+        &entry.res,
+        m,
+        n,
+        res_ld,
+        16,
+        output_type,
+        res_order));
+    TORCH_CUDASPARSE_CHECK(cusparseLtDenseDescriptorInit(
+        &handle,
+        &entry.C,
+        m,
+        n,
+        res_ld,
+        16,
+        C_type,
+        res_order));
+    TORCH_CUDASPARSE_CHECK(cusparseLtMatmulDescriptorInit(
+        &handle,
+        &entry.matmul,
+        CUSPARSE_OPERATION_NON_TRANSPOSE,
+        dense_is_contiguous ? CUSPARSE_OPERATION_NON_TRANSPOSE
+                            : CUSPARSE_OPERATION_TRANSPOSE,
+        &entry.sparse_input,
+        &entry.dense_input,
+        &entry.C,
+        &entry.res,
+        compute_type));
+    TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgSelectionInit(
+        &handle,
+        &entry.alg_sel,
+        &entry.matmul,
+        CUSPARSELT_MATMUL_ALG_DEFAULT));
+
+    TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgSetAttribute(
+        &handle,
+        &entry.alg_sel,
+        CUSPARSELT_MATMUL_ALG_CONFIG_ID,
+        &alg_id,
+        sizeof(alg_id)));
+    if (split_k != 1) {
+      TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgSetAttribute(
+          &handle,
+          &entry.alg_sel,
+          CUSPARSELT_MATMUL_SPLIT_K,
+          &split_k,
+          sizeof(split_k)));
+      if (split_k_mode > 0) {
+        cusparseLtSplitKMode_t splitKMode =
+            static_cast<cusparseLtSplitKMode_t>(split_k_mode);
+        TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgSetAttribute(
+            &handle,
+            &entry.alg_sel,
+            CUSPARSELT_MATMUL_SPLIT_K_MODE,
+            &splitKMode,
+            sizeof(splitKMode)));
+      }
+    }
+
+    TORCH_CUDASPARSE_CHECK(cusparseLtMatmulPlanInit(
+        &handle, &entry.plan, &entry.matmul, &entry.alg_sel));
+
+    entry.has_descriptors = true;
+    cache_map[lru_list.front().first] = lru_list.begin();
+    return lookup(key);
   }
 
   void insert(MatDescriptorCacheKey key, CachedMatDescriptor descriptor) {
@@ -162,7 +307,7 @@ struct MatDescriptorCache {
       cache_map.erase(back.first);
       lru_list.pop_back();
     }
-    lru_list.push_front({std::move(key), std::move(descriptor)});
+    lru_list.push_front({key, std::move(descriptor)});
     cache_map[lru_list.front().first] = lru_list.begin();
   }
 };
@@ -176,7 +321,7 @@ MatDescriptorCache& getMatDescriptorCache() {
   return *mat_descriptor_cache;
 }
 
-// Returns all 4 descriptor pointers for this matmul config from one cache key.
+// Returns descriptor pointers and plan for this matmul config (cache built in-place).
 static MatDescriptorPtrs _get_matmul_descriptor_ptrs(
     cusparseLtHandle_t& handle,
     int64_t m,
@@ -186,7 +331,12 @@ static MatDescriptorPtrs _get_matmul_descriptor_ptrs(
     bool transpose_result,
     cudaDataType input_type,
     cudaDataType output_type,
-    cudaDataType C_type) {
+    cudaDataType C_type,
+    cusparseComputeType compute_type,
+    bool has_bias,
+    int alg_id,
+    int split_k,
+    int split_k_mode) {
   MatDescriptorCacheKey key{};
   key.m = static_cast<int>(m);
   key.k = static_cast<int>(k);
@@ -196,70 +346,31 @@ static MatDescriptorPtrs _get_matmul_descriptor_ptrs(
   key.input_type = static_cast<int32_t>(input_type);
   key.output_type = static_cast<int32_t>(output_type);
   key.C_type = static_cast<int32_t>(C_type);
+  key.compute_type = static_cast<int32_t>(compute_type);
+  key.has_bias = has_bias;
+  key.alg_id = static_cast<int32_t>(alg_id);
+  key.split_k = static_cast<int32_t>(split_k);
+  key.split_k_mode = static_cast<int32_t>(split_k_mode);
 
-  auto cached = getMatDescriptorCache().lookup(key);
-  if (cached.has_value()) {
-    return *cached;
-  }
-
-  int64_t dense_rows = dense_is_contiguous ? k : n;
-  int64_t dense_cols = dense_is_contiguous ? n : k;
-  int64_t res_ld = transpose_result ? m : n;
-  cusparseOrder_t res_order = transpose_result ? CUSPARSE_ORDER_COL : CUSPARSE_ORDER_ROW;
-
-  CachedMatDescriptor bundle;
-  TORCH_CUDASPARSE_CHECK(cusparseLtStructuredDescriptorInit(
-      &handle,
-      &bundle.sparse_input,
+  auto result = getMatDescriptorCache().getOrCreate(
+      key,
+      handle,
       m,
       k,
-      k,
-      16,
-      input_type,
-      CUSPARSE_ORDER_ROW,
-      CUSPARSELT_SPARSITY_50_PERCENT));
-  TORCH_CUDASPARSE_CHECK(cusparseLtDenseDescriptorInit(
-      &handle,
-      &bundle.dense_input,
-      dense_rows,
-      dense_cols,
-      dense_cols,
-      16,
-      input_type,
-      CUSPARSE_ORDER_ROW));
-  TORCH_CUDASPARSE_CHECK(cusparseLtDenseDescriptorInit(
-      &handle,
-      &bundle.res,
-      m,
       n,
-      res_ld,
-      16,
+      dense_is_contiguous,
+      transpose_result,
+      input_type,
       output_type,
-      res_order));
-  TORCH_CUDASPARSE_CHECK(cusparseLtDenseDescriptorInit(
-      &handle,
-      &bundle.C,
-      m,
-      n,
-      res_ld,
-      16,
       C_type,
-      res_order));
-  bundle.has_descriptors = true;
-
-  getMatDescriptorCache().insert(std::move(key), std::move(bundle));
-  // Rebuild key for lookup (key was moved into insert).
-  MatDescriptorCacheKey key_lookup{};
-  key_lookup.m = static_cast<int>(m);
-  key_lookup.k = static_cast<int>(k);
-  key_lookup.n = static_cast<int>(n);
-  key_lookup.dense_is_contiguous = dense_is_contiguous;
-  key_lookup.transpose_result = transpose_result;
-  key_lookup.input_type = static_cast<int32_t>(input_type);
-  key_lookup.output_type = static_cast<int32_t>(output_type);
-  key_lookup.C_type = static_cast<int32_t>(C_type);
-  cached = getMatDescriptorCache().lookup(key_lookup);
-  return *cached;
+      compute_type,
+      alg_id,
+      split_k,
+      split_k_mode);
+  TORCH_CHECK(
+      result.has_value(),
+      "cuSPARSELt: mat descriptor cache getOrCreate failed");
+  return *result;
 }
 
 
@@ -424,10 +535,6 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
     bool search_alg_id) {
   const c10::cuda::CUDAGuard device_guard{dense_B.device()};
   cusparseLtHandle_t& handle = get_cusparselt_handle_for_current_device();
-  // cuSPARSELt constructs
-  cusparseLtMatmulDescriptor_t matmul;
-  cusparseLtMatmulPlan_t plan;
-  cusparseLtMatmulAlgSelection_t alg_sel;
 
   float alpha = 1.0;
   float beta = 0.0;
@@ -617,26 +724,38 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
       transpose_result,
       input_type,
       output_type,
-      C_type);
+      C_type,
+      compute_type,
+      bias_opt.has_value(),
+      alg_id,
+      split_k,
+      split_k_mode);
 
-  // create result tensor
-  auto res_tensor_options =
-      c10::TensorOptions().dtype(out_dtype).device(dense_B.device());
-  at::Tensor res = (transpose_result) ? at::empty({n, m}, res_tensor_options)
-                                      : at::empty({m, n}, res_tensor_options);
+  // bool not_null_sparse_input = (desc_ptrs.sparse_input != nullptr);
+  // bool not_null_dense_input = (desc_ptrs.dense_input != nullptr);
+  // bool not_null_res = (desc_ptrs.res != nullptr);
+  // bool not_null_C = (desc_ptrs.C != nullptr);
+  // bool not_null_alg_sel = (desc_ptrs.alg_sel != nullptr);
+  // std::cout << "not_null_sparse_input=" << not_null_sparse_input
+  //           << " not_null_dense_input=" << not_null_dense_input
+  //           << " not_null_res=" << not_null_res
+  //           << " not_null_C=" << not_null_C
+  //           << " not_null_alg_sel=" << not_null_alg_sel
+  //           << std::endl;
 
-  // initialize matmul
-  TORCH_CUDASPARSE_CHECK(cusparseLtMatmulDescriptorInit(
-      &handle,
-      &matmul,
-      CUSPARSE_OPERATION_NON_TRANSPOSE,
-      (dense_B.is_contiguous()) ? CUSPARSE_OPERATION_NON_TRANSPOSE
-                                : CUSPARSE_OPERATION_TRANSPOSE,
-      desc_ptrs.sparse_input,
-      desc_ptrs.dense_input,
-      desc_ptrs.C,
-      desc_ptrs.res,
-      compute_type));
+  // // initialize matmul
+  // TORCH_CUDASPARSE_CHECK(cusparseLtMatmulDescriptorInit(
+  //     &handle,
+  //     &matmul,
+  //     CUSPARSE_OPERATION_NON_TRANSPOSE,
+  //     (dense_B.is_contiguous()) ? CUSPARSE_OPERATION_NON_TRANSPOSE
+  //                               : CUSPARSE_OPERATION_TRANSPOSE,
+  //     desc_ptrs.sparse_input,
+  //     desc_ptrs.dense_input,
+  //     desc_ptrs.C,
+  //     desc_ptrs.res,
+  //     compute_type));
+
 
   // set bias pointer for matmul, need to assign to get location
   if (bias_opt.has_value()) {
@@ -644,47 +763,22 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
     void* dBias = bias.data_ptr();
     TORCH_CUDASPARSE_CHECK(cusparseLtMatmulDescSetAttribute(
         &handle,
-        &matmul,
+        desc_ptrs.matmul,
         CUSPARSELT_MATMUL_BIAS_POINTER,
         &dBias,
         sizeof(dBias)));
   }
 
-  // auto t1 = std::chrono::steady_clock::now();
-  TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgSelectionInit(
-      &handle, &alg_sel, &matmul, CUSPARSELT_MATMUL_ALG_DEFAULT));
-  // auto t2 = std::chrono::steady_clock::now();
-  // double duration_plan_init = std::chrono::duration<double, std::milli>(t2 - t1).count();
-  // std::cout << "duration_plan_init = " << duration_plan_init << std::endl;
 
-  // set matmul search params
-  TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgSetAttribute(
-      &handle,
-      &alg_sel,
-      CUSPARSELT_MATMUL_ALG_CONFIG_ID,
-      &alg_id,
-      sizeof(alg_id)));
+  // auto ta1 = std::chrono::steady_clock::now();  ~.285545
+  // TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgSelectionInit(
+  //     &handle, &alg_sel, &matmul, CUSPARSELT_MATMUL_ALG_DEFAULT));
+  // auto ta2 = std::chrono::steady_clock::now();
+  // double duration_alg_init = std::chrono::duration<double, std::milli>(ta2 - ta1).count();
+  // std::cout << "duration_alg_init = " << duration_alg_init << std::endl;
 
   cusparseLtSplitKMode_t splitKMode;
   int max_alg_id;
-  if (split_k != 1) {
-    TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgSetAttribute(
-        &handle,
-        &alg_sel,
-        CUSPARSELT_MATMUL_SPLIT_K,
-        &split_k,
-        sizeof(split_k)));
-
-    if (split_k_mode > 0) {
-      splitKMode = static_cast<cusparseLtSplitKMode_t>(split_k_mode);
-      TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgSetAttribute(
-          &handle,
-          &alg_sel,
-          CUSPARSELT_MATMUL_SPLIT_K_MODE,
-          &splitKMode,
-          sizeof(splitKMode)));
-    }
-  }
 
   // set tensor_alpha_mode and alpha pointer for matmul
   const auto alpha_tensor = alpha_opt.has_value() ? *alpha_opt : Tensor{};
@@ -696,7 +790,7 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
       int tensor_alpha_mode = 1;
       TORCH_CUDASPARSE_CHECK(cusparseLtMatmulDescSetAttribute(
           &handle,
-          &matmul,
+          desc_ptrs.matmul,
           CUSPARSELT_MATMUL_ALPHA_VECTOR_SCALING,
           &tensor_alpha_mode,
           sizeof(tensor_alpha_mode)));
@@ -704,23 +798,26 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
     }
   }
 
-  TORCH_CUDASPARSE_CHECK(
-      cusparseLtMatmulPlanInit(&handle, &plan, &matmul, &alg_sel));
-
   size_t workspace_size;
   TORCH_CUDASPARSE_CHECK(
-      cusparseLtMatmulGetWorkspace(&handle, &plan, &workspace_size));
+      cusparseLtMatmulGetWorkspace(&handle, desc_ptrs.plan, &workspace_size));
 
 
   auto& allocator = *::c10::cuda::CUDACachingAllocator::get();
   auto workspacePtr = allocator.allocate(workspace_size);
   cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
+  // create result tensor
+  auto res_tensor_options =
+  c10::TensorOptions().dtype(out_dtype).device(dense_B.device());
+  at::Tensor res = (transpose_result) ? at::empty({n, m}, res_tensor_options)
+                                    : at::empty({m, n}, res_tensor_options);
+
   if (search_alg_id) {
     // run matmul search
     TORCH_CUDASPARSE_CHECK(cusparseLtMatmulSearch(
         &handle,
-        &plan,
+        desc_ptrs.plan,
         alpha_ptr,
         compressed_A.data_ptr(),
         dense_B.data_ptr(),
@@ -735,7 +832,7 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
     // get matmul params used
     TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgGetAttribute(
         &handle,
-        &alg_sel,
+        desc_ptrs.alg_sel,
         CUSPARSELT_MATMUL_ALG_CONFIG_ID,
         &alg_id,
         sizeof(alg_id)));
@@ -744,14 +841,14 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
     // hipSPARSELt does not support querying SPLIT_K attributes
     TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgGetAttribute(
         &handle,
-        &alg_sel,
+        desc_ptrs.alg_sel,
         CUSPARSELT_MATMUL_SPLIT_K,
         &split_k,
         sizeof(split_k)));
 
     TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgGetAttribute(
         &handle,
-        &alg_sel,
+        desc_ptrs.alg_sel,
         CUSPARSELT_MATMUL_SPLIT_K_MODE,
         &splitKMode,
         sizeof(splitKMode)));
@@ -759,7 +856,7 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
 
     TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgGetAttribute(
         &handle,
-        &alg_sel,
+        desc_ptrs.alg_sel,
         CUSPARSELT_MATMUL_ALG_CONFIG_MAX_ID,
         &max_alg_id,
         sizeof(max_alg_id)));
@@ -768,7 +865,7 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
     // do normal matmul
     TORCH_CUDASPARSE_CHECK(cusparseLtMatmul(
         &handle,
-        &plan,
+        desc_ptrs.plan,
         alpha_ptr,
         compressed_A.data_ptr(),
         dense_B.data_ptr(),
@@ -781,14 +878,7 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
         1));
   }
 
-  // destroy descriptors
-  // TORCH_CUDASPARSE_CHECK(
-  //     cusparseLtMatDescriptorDestroy(&sparse_input_descriptor));
-  // TORCH_CUDASPARSE_CHECK(
-  //     cusparseLtMatDescriptorDestroy(&dense_input_descriptor));
-  // TORCH_CUDASPARSE_CHECK(cusparseLtMatDescriptorDestroy(&res_descriptor));
-  // destroy plan
-  TORCH_CUDASPARSE_CHECK(cusparseLtMatmulPlanDestroy(&plan));
+  // plan and descriptors are cached; no destroy here
 
   return {res, alg_id, split_k, static_cast<int64_t>(splitKMode), max_alg_id};
 }

--- a/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
+++ b/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
@@ -5,6 +5,8 @@
 #include <list>
 #include <optional>
 #include <unordered_map>
+#include <mutex>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -19,115 +21,6 @@
 #if AT_CUSPARSELT_ENABLED()
 
 namespace at::native {
-
-namespace {
-
-// Cache key for cuSPARSELt matmul plan. Must be standard layout for ParamsHash.
-struct CsltMatmulCacheKey {
-  int64_t m = 0;
-  int64_t n = 0;
-  int64_t k = 0;
-  int32_t input_type = 0;
-  int32_t output_type = 0;
-  int32_t C_type = 0;
-  int32_t compute_type = 0;
-  int32_t transpose_result = 0;
-  int32_t dense_contiguous = 0;
-  int32_t has_bias = 0;
-  int32_t tensor_alpha_mode = 0;
-  int32_t alg_id = 0;
-  int32_t split_k = 0;
-  int32_t split_k_mode = 0;
-};
-
-static_assert(std::is_standard_layout_v<CsltMatmulCacheKey>);
-
-using CsltMatmulCacheKeyHash = ParamsHash<CsltMatmulCacheKey>;
-using CsltMatmulCacheKeyEqual = ParamsEqual<CsltMatmulCacheKey>;
-
-// Cached plan and workspace size. Plan is destroyed when the cache entry is evicted.
-// Cache is only used when !has_bias (see comment at cache_enabled).
-struct CachedPlan {
-  cusparseLtMatmulPlan_t plan;
-  size_t workspace_size = 0;
-  bool has_plan = false;
-
-  CachedPlan() = default;
-  ~CachedPlan() {
-    if (has_plan) {
-      cusparseLtMatmulPlanDestroy(&plan);
-      has_plan = false;
-    }
-  }
-  CachedPlan(CachedPlan&& other) noexcept
-      : plan(other.plan),
-        workspace_size(other.workspace_size),
-        has_plan(other.has_plan) {
-    other.has_plan = false;
-  }
-  CachedPlan& operator=(CachedPlan&& other) noexcept {
-    if (this != &other) {
-      if (has_plan) {
-        cusparseLtMatmulPlanDestroy(&plan);
-      }
-      plan = other.plan;
-      workspace_size = other.workspace_size;
-      has_plan = other.has_plan;
-      other.has_plan = false;
-    }
-    return *this;
-  }
-  CachedPlan(const CachedPlan&) = delete;
-  CachedPlan& operator=(const CachedPlan&) = delete;
-};
-
-constexpr size_t kCsltMatmulPlanCacheMaxSize = 128;
-
-using CsltMatmulLruList =
-    std::list<std::pair<CsltMatmulCacheKey, CachedPlan>>;
-using CsltMatmulCacheMap = std::unordered_map<
-    CsltMatmulCacheKey,
-    CsltMatmulLruList::iterator,
-    CsltMatmulCacheKeyHash,
-    CsltMatmulCacheKeyEqual>;
-
-struct CsltMatmulPlanCache {
-  CsltMatmulLruList lru_list;
-  CsltMatmulCacheMap cache_map;
-
-  // Returns plan pointer and workspace_size if found; moves entry to front for LRU.
-  std::optional<std::pair<cusparseLtMatmulPlan_t*, size_t>> lookup(
-      const CsltMatmulCacheKey& key) {
-    auto it = cache_map.find(key);
-    if (it == cache_map.end()) {
-      return std::nullopt;
-    }
-    lru_list.splice(lru_list.begin(), lru_list, it->second);
-    CachedPlan& entry = it->second->second;
-    return std::make_pair(&entry.plan, entry.workspace_size);
-  }
-
-  void insert(CsltMatmulCacheKey key, CachedPlan plan) {
-    if (lru_list.size() >= kCsltMatmulPlanCacheMaxSize) {
-      auto& back = lru_list.back();
-      cache_map.erase(back.first);
-      lru_list.pop_back();
-    }
-    lru_list.push_front({std::move(key), std::move(plan)});
-    cache_map[lru_list.front().first] = lru_list.begin();
-  }
-};
-
-thread_local std::unique_ptr<CsltMatmulPlanCache> cslt_matmul_plan_cache;
-
-CsltMatmulPlanCache& getCsltMatmulPlanCache() {
-  if (!cslt_matmul_plan_cache) {
-    cslt_matmul_plan_cache = std::make_unique<CsltMatmulPlanCache>();
-  }
-  return *cslt_matmul_plan_cache;
-}
-
-} // namespace
 
 // Ideally we would use the same DeviceThreadHandlePool mechanism as used in
 // aten/src/ATen/cuda/CuSparseHandlePool.cpp which would handle this for us.
@@ -161,6 +54,132 @@ cusparseLtHandle_t& get_cusparselt_handle_for_current_device() {
   }
   return it->second;
 }
+
+/////////////////////////////////////////////////////////////////////
+
+struct SparseInputDescriptorCacheKey {
+  int m = 0;
+  int k = 0;
+  int32_t input_type = 0;
+};
+
+using SparseInputDescriptorCacheKeyHash = ParamsHash<SparseInputDescriptorCacheKey>;
+using SparseInputDescriptorCacheKeyEqual = ParamsEqual<SparseInputDescriptorCacheKey>;
+
+struct CachedSparseInputDescriptor {
+  cusparseLtMatDescriptor_t descriptor;
+  bool has_descriptor = false;
+
+  CachedSparseInputDescriptor() = default;
+  ~CachedSparseInputDescriptor() {
+    if (has_descriptor) {
+      cusparseLtMatDescriptorDestroy(&descriptor);
+      has_descriptor = false;
+    }
+  }
+  CachedSparseInputDescriptor(CachedSparseInputDescriptor&& other) noexcept
+      : descriptor(other.descriptor),
+        has_descriptor(other.has_descriptor) {
+    other.has_descriptor = false;
+  }
+  CachedSparseInputDescriptor& operator=(CachedSparseInputDescriptor&& other) noexcept {
+    if (this != &other) {
+      if (has_descriptor) {
+        cusparseLtMatDescriptorDestroy(&descriptor);
+      }
+      descriptor = other.descriptor;
+      has_descriptor = other.has_descriptor;
+      other.has_descriptor = false;
+    }
+    return *this;
+  }
+  CachedSparseInputDescriptor(const CachedSparseInputDescriptor&) = delete;
+  CachedSparseInputDescriptor& operator=(const CachedSparseInputDescriptor&) = delete;
+};
+
+constexpr size_t SparseInputDescriptorCacheMaxSize = 128;
+
+using SparseInputDescriptorLruList =
+    std::list<std::pair<SparseInputDescriptorCacheKey, CachedSparseInputDescriptor>>;
+using SparseInputDescriptorCacheMap = std::unordered_map<
+    SparseInputDescriptorCacheKey,
+    SparseInputDescriptorLruList::iterator,
+    SparseInputDescriptorCacheKeyHash,
+    SparseInputDescriptorCacheKeyEqual>;
+
+
+struct SparseInputDescriptorCache {
+  SparseInputDescriptorLruList lru_list;
+  SparseInputDescriptorCacheMap cache_map;
+
+  // Returns plan pointer and workspace_size if found; moves entry to front for LRU.
+  std::optional<cusparseLtMatDescriptor_t*> lookup(
+      const SparseInputDescriptorCacheKey& key) {
+    auto it = cache_map.find(key);
+    if (it == cache_map.end()) {
+      return std::nullopt;
+    }
+    lru_list.splice(lru_list.begin(), lru_list, it->second);
+    CachedSparseInputDescriptor& entry = it->second->second;
+    return &entry.descriptor;
+  }
+
+  void insert(SparseInputDescriptorCacheKey key, CachedSparseInputDescriptor descriptor) {
+    if (lru_list.size() >= SparseInputDescriptorCacheMaxSize) {
+      auto& back = lru_list.back();
+      cache_map.erase(back.first);
+      lru_list.pop_back();
+    }
+    lru_list.push_front({std::move(key), std::move(descriptor)});
+    cache_map[lru_list.front().first] = lru_list.begin();
+  }
+};
+
+thread_local std::unique_ptr<SparseInputDescriptorCache> sparse_input_descriptor_cache;
+
+SparseInputDescriptorCache& getSparseInputDescriptorCache() {
+  if (!sparse_input_descriptor_cache) {
+    sparse_input_descriptor_cache = std::make_unique<SparseInputDescriptorCache>();
+  }
+  return *sparse_input_descriptor_cache;
+}
+
+static cusparseLtMatDescriptor_t* _get_sparse_input_descriptor_ptr(
+    cusparseLtHandle_t& handle,
+    int64_t m,
+    int64_t k,
+    cudaDataType input_type) {
+  SparseInputDescriptorCacheKey key{};
+  key.m = m;
+  key.k = k;
+  key.input_type = static_cast<int32_t>(input_type);
+  auto cached = getSparseInputDescriptorCache().lookup(key);
+  if (cached.has_value()) {
+    return *cached;
+  } 
+  cusparseLtMatDescriptor_t sparse_input_descriptor;
+  TORCH_CUDASPARSE_CHECK(cusparseLtStructuredDescriptorInit(
+      &handle,
+      &sparse_input_descriptor,
+      m,
+      k,
+      k,
+      16,
+      input_type,
+      CUSPARSE_ORDER_ROW,
+      CUSPARSELT_SPARSITY_50_PERCENT));
+      
+  CachedSparseInputDescriptor cached_descriptor;
+  cached_descriptor.descriptor = sparse_input_descriptor;
+  cached_descriptor.has_descriptor = true;
+  getSparseInputDescriptorCache().insert(std::move(key), std::move(cached_descriptor));
+  cached = getSparseInputDescriptorCache().lookup(key);
+  return *cached;
+}
+
+
+//////////////////////////////////////////////////////////////////////
+
 
 #ifdef USE_ROCM
 // Single global flag for platform-wide hipSparseLt support
@@ -319,8 +338,11 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
     bool search_alg_id) {
   const c10::cuda::CUDAGuard device_guard{dense_B.device()};
   cusparseLtHandle_t& handle = get_cusparselt_handle_for_current_device();
+  // cuSPARSELt constructs
+  cusparseLtMatmulDescriptor_t matmul;
+  cusparseLtMatmulPlan_t plan;
+  cusparseLtMatmulAlgSelection_t alg_sel;
 
-  int tensor_alpha_mode = 0;
   float alpha = 1.0;
   float beta = 0.0;
   cudaDataType input_type;
@@ -495,107 +517,67 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
     }
   }
 
-  const auto alpha_tensor = alpha_opt.has_value() ? *alpha_opt : Tensor{};
-  if (alpha_opt.has_value()) {
-    if (alpha_tensor.numel() == 1) {
-      alpha = alpha_tensor.item<float>();
-    } else {
-      tensor_alpha_mode = 1;
-    }
-  }
-
   TORCH_INTERNAL_ASSERT(compressed_A.dim() == 2); // encoded M x S
   int64_t k = dense_B.size(0);
   int64_t n = dense_B.size(1);
   int64_t m = compressed_A.size(0);
 
-  const bool has_bias = bias_opt.has_value();
-  // Plan caching disabled: cusparseLtMatmulPlan_t is opaque and retains
-  // internal pointers to the matmul descriptor (and possibly others) passed at
-  // PlanInit. Copying the plan struct into the cache copies those pointers;
-  // the original descriptors are stack locals and go out of scope, so the
-  // cached plan becomes invalid and cusparseLtMatmul(plan_ptr) SIGSEGVs.
-  // Proper caching would require building the plan inside cache-owned memory
-  // so all referenced descriptors outlive the call (not yet implemented).
-  const bool cache_enabled = false;  // !has_bias && !search_alg_id;
+  //////////////////////////////////////////////////////////////
+  // // initialize sparse descriptor
+  // cusparseLtMatDescriptor_t sparse_input_descriptor;
+  // TORCH_CUDASPARSE_CHECK(cusparseLtStructuredDescriptorInit(
+  //     &handle,
+  //     &sparse_input_descriptor,
+  //     m,
+  //     k,
+  //     k,
+  //     16,
+  //     input_type,
+  //     CUSPARSE_ORDER_ROW,
+  //     CUSPARSELT_SPARSITY_50_PERCENT));
+  auto t3 = std::chrono::steady_clock::now();
+  cusparseLtMatDescriptor_t* sparse_input_descriptor_ptr =
+    _get_sparse_input_descriptor_ptr(handle, m, k, input_type);
+  auto t4 = std::chrono::steady_clock::now();
+  double duration_sparse_input_descriptor = std::chrono::duration<double, std::milli>(t4 - t3).count();
+  std::cout << "duration_sparse_input_descriptor = " << duration_sparse_input_descriptor << std::endl;
 
-  if (cache_enabled) {
-    CsltMatmulCacheKey key{};
-    key.m = m;
-    key.n = n;
-    key.k = k;
-    key.input_type = static_cast<int32_t>(input_type);
-    key.output_type = static_cast<int32_t>(output_type);
-    key.C_type = static_cast<int32_t>(C_type);
-    key.compute_type = static_cast<int32_t>(compute_type);
-    key.transpose_result = transpose_result ? 1 : 0;
-    key.dense_contiguous = dense_B.is_contiguous() ? 1 : 0;
-    key.has_bias = has_bias ? 1 : 0;
-    key.tensor_alpha_mode = tensor_alpha_mode;
-    key.alg_id = alg_id;
-    key.split_k = split_k;
-    key.split_k_mode = split_k_mode;
+  // auto t3 = std::chrono::steady_clock::now();
 
-    auto cached = getCsltMatmulPlanCache().lookup(key);
-    if (cached.has_value()) {
-      cusparseLtMatmulPlan_t* plan_ptr = cached->first;
-      size_t workspace_size = cached->second;
-      ScalarType out_dtype = dense_B.scalar_type();
-      if (out_dtype_opt.has_value()) {
-        out_dtype = out_dtype_opt.value();
-      }
-      auto res_tensor_options =
-          c10::TensorOptions().dtype(out_dtype).device(dense_B.device());
-      at::Tensor res = (transpose_result) ? at::empty({n, m}, res_tensor_options)
-                                          : at::empty({m, n}, res_tensor_options);
-      float* alpha_ptr = (tensor_alpha_mode == 1)
-          ? static_cast<float*>(alpha_tensor.data_ptr())
-          : &alpha;
-      auto& allocator = *::c10::cuda::CUDACachingAllocator::get();
-      auto workspacePtr = allocator.allocate(workspace_size);
-      cudaStream_t stream = at::cuda::getCurrentCUDAStream();
-      TORCH_CUDASPARSE_CHECK(cusparseLtMatmul(
-          &handle,
-          plan_ptr,
-          alpha_ptr,
-          compressed_A.data_ptr(),
-          dense_B.data_ptr(),
-          &beta,
-          res.data_ptr(),
-          res.data_ptr(),
-          workspacePtr.get(),
-          &stream,
-          1));
-      const int max_alg_id = 0;
-      cusparseLtSplitKMode_t splitKMode =
-          (split_k_mode > 0) ? static_cast<cusparseLtSplitKMode_t>(split_k_mode)
-                            : static_cast<cusparseLtSplitKMode_t>(-1);
-      return {
-          res,
-          alg_id,
-          split_k,
-          static_cast<int64_t>(splitKMode),
-          max_alg_id};
-    }
-  }
+  // SparseInputDescriptorCacheKey key{};
+  // key.m = m;
+  // key.k = k;
+  // key.input_type = static_cast<int32_t>(input_type);
+  // auto cached = getSparseInputDescriptorCache().lookup(key);
+  // cusparseLtMatDescriptor_t* sparse_input_descriptor_ptr = nullptr;
+  // if (cached.has_value()) {
+  //   sparse_input_descriptor_ptr = *cached;
+  // } else {
+  //   cusparseLtMatDescriptor_t sparse_input_descriptor;
+  //   TORCH_CUDASPARSE_CHECK(cusparseLtStructuredDescriptorInit(
+  //       &handle,
+  //       &sparse_input_descriptor,
+  //       m,
+  //       k,
+  //       k,
+  //       16,
+  //       input_type,
+  //       CUSPARSE_ORDER_ROW,
+  //       CUSPARSELT_SPARSITY_50_PERCENT));
+    
+  //   CachedSparseInputDescriptor cached_descriptor;
+  //   cached_descriptor.descriptor = sparse_input_descriptor;
+  //   cached_descriptor.has_descriptor = true;
+  //   getSparseInputDescriptorCache().insert(std::move(key), std::move(cached_descriptor));
+  //   cached = getSparseInputDescriptorCache().lookup(key);
+  //   sparse_input_descriptor_ptr = *cached;
+  // }
+  // auto t4 = std::chrono::steady_clock::now();
+  // double duration_sparse_input_descriptor = std::chrono::duration<double, std::milli>(t4 - t3).count();
+  // std::cout << "duration_sparse_input_descriptor = " << duration_sparse_input_descriptor << std::endl;
 
-  // Cache miss or cache disabled: build descriptors and plan
-  cusparseLtMatmulDescriptor_t matmul;
-  cusparseLtMatmulPlan_t plan;
-  cusparseLtMatmulAlgSelection_t alg_sel;
 
-  // initialize sparse descriptor
-  cusparseLtMatDescriptor_t sparse_input_descriptor;
-  TORCH_CUDASPARSE_CHECK(cusparseLtStructuredDescriptorInit(
-      &handle,
-      &sparse_input_descriptor,
-      m,
-      k,
-      k,
-      16,
-      input_type,
-      CUSPARSE_ORDER_ROW,
-      CUSPARSELT_SPARSITY_50_PERCENT));
+  /////////////////////////////////////////////////////////////
 
   // initialize dense input descriptor
   cusparseLtMatDescriptor_t dense_input_descriptor;
@@ -645,7 +627,7 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
       CUSPARSE_OPERATION_NON_TRANSPOSE,
       (dense_B.is_contiguous()) ? CUSPARSE_OPERATION_NON_TRANSPOSE
                                 : CUSPARSE_OPERATION_TRANSPOSE,
-      &sparse_input_descriptor,
+      sparse_input_descriptor_ptr,
       &dense_input_descriptor,
       &C_descriptor,
       &res_descriptor,
@@ -663,8 +645,12 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
         sizeof(dBias)));
   }
 
+  auto t1 = std::chrono::steady_clock::now();
   TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgSelectionInit(
       &handle, &alg_sel, &matmul, CUSPARSELT_MATMUL_ALG_DEFAULT));
+  auto t2 = std::chrono::steady_clock::now();
+  double duration_plan_init = std::chrono::duration<double, std::milli>(t2 - t1).count();
+  std::cout << "duration_plan_init = " << duration_plan_init << std::endl;
 
   // set matmul search params
   TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgSetAttribute(
@@ -674,8 +660,8 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
       &alg_id,
       sizeof(alg_id)));
 
-  cusparseLtSplitKMode_t splitKMode = static_cast<cusparseLtSplitKMode_t>(-1);
-  int max_alg_id = 0;
+  cusparseLtSplitKMode_t splitKMode;
+  int max_alg_id;
   if (split_k != 1) {
     TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgSetAttribute(
         &handle,
@@ -695,17 +681,22 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
     }
   }
 
-  // set tensor_alpha_mode for matmul descriptor (alpha_ptr used at execution)
-  float* alpha_ptr = (tensor_alpha_mode == 1)
-      ? static_cast<float*>(alpha_tensor.data_ptr())
-      : &alpha;
-  if (tensor_alpha_mode == 1) {
-    TORCH_CUDASPARSE_CHECK(cusparseLtMatmulDescSetAttribute(
-        &handle,
-        &matmul,
-        CUSPARSELT_MATMUL_ALPHA_VECTOR_SCALING,
-        &tensor_alpha_mode,
-        sizeof(tensor_alpha_mode)));
+  // set tensor_alpha_mode and alpha pointer for matmul
+  const auto alpha_tensor = alpha_opt.has_value() ? *alpha_opt : Tensor{};
+  auto alpha_ptr = &alpha;
+  if (alpha_opt.has_value()) {
+    if (alpha_tensor.numel() == 1) {
+      alpha = alpha_tensor.item<float>();
+    } else {
+      int tensor_alpha_mode = 1;
+      TORCH_CUDASPARSE_CHECK(cusparseLtMatmulDescSetAttribute(
+          &handle,
+          &matmul,
+          CUSPARSELT_MATMUL_ALPHA_VECTOR_SCALING,
+          &tensor_alpha_mode,
+          sizeof(tensor_alpha_mode)));
+      alpha_ptr = static_cast<float*>(alpha_tensor.data_ptr());
+    }
   }
 
   TORCH_CUDASPARSE_CHECK(
@@ -714,6 +705,7 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
   size_t workspace_size;
   TORCH_CUDASPARSE_CHECK(
       cusparseLtMatmulGetWorkspace(&handle, &plan, &workspace_size));
+
 
   auto& allocator = *::c10::cuda::CUDACachingAllocator::get();
   auto workspacePtr = allocator.allocate(workspace_size);
@@ -779,43 +771,19 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
         res.data_ptr(),
         res.data_ptr(),
         workspacePtr.get(),
+        // jank because of the way we want this to be an array of streams
         &stream,
         1));
   }
 
   // destroy descriptors
-  TORCH_CUDASPARSE_CHECK(
-      cusparseLtMatDescriptorDestroy(&sparse_input_descriptor));
+  // TORCH_CUDASPARSE_CHECK(
+  //     cusparseLtMatDescriptorDestroy(&sparse_input_descriptor));
   TORCH_CUDASPARSE_CHECK(
       cusparseLtMatDescriptorDestroy(&dense_input_descriptor));
   TORCH_CUDASPARSE_CHECK(cusparseLtMatDescriptorDestroy(&res_descriptor));
-  TORCH_CUDASPARSE_CHECK(cusparseLtMatDescriptorDestroy(&C_descriptor));
-
-  if (cache_enabled) {
-    CsltMatmulCacheKey key{};
-    key.m = m;
-    key.n = n;
-    key.k = k;
-    key.input_type = static_cast<int32_t>(input_type);
-    key.output_type = static_cast<int32_t>(output_type);
-    key.C_type = static_cast<int32_t>(C_type);
-    key.compute_type = static_cast<int32_t>(compute_type);
-    key.transpose_result = transpose_result ? 1 : 0;
-    key.dense_contiguous = dense_B.is_contiguous() ? 1 : 0;
-    key.has_bias = has_bias ? 1 : 0;
-    key.tensor_alpha_mode = tensor_alpha_mode;
-    key.alg_id = alg_id;
-    key.split_k = split_k;
-    key.split_k_mode = split_k_mode;
-    CachedPlan cached_plan;
-    cached_plan.plan = plan;
-    cached_plan.workspace_size = workspace_size;
-    cached_plan.has_plan = true;
-    getCsltMatmulPlanCache().insert(std::move(key), std::move(cached_plan));
-    // Do not destroy plan; cache now owns it.
-  } else {
-    TORCH_CUDASPARSE_CHECK(cusparseLtMatmulPlanDestroy(&plan));
-  }
+  // destroy plan
+  TORCH_CUDASPARSE_CHECK(cusparseLtMatmulPlanDestroy(&plan));
 
   return {res, alg_id, split_k, static_cast<int64_t>(splitKMode), max_alg_id};
 }

--- a/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
+++ b/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
@@ -67,6 +67,7 @@ struct MatDescriptorCacheKey {
   int32_t C_type = 0;
   int32_t compute_type = 0;
   bool has_bias = false;
+  bool has_alpha = false;
   int32_t alg_id = 0;
   int32_t split_k = 1;
   int32_t split_k_mode = -1;
@@ -185,11 +186,11 @@ struct MatDescriptorCache {
       cudaDataType output_type,
       cudaDataType C_type,
       cusparseComputeType compute_type,
-      bool has_bias,
       int alg_id,
       int split_k,
       int split_k_mode,
-      const std::optional<Tensor>& bias_opt) {
+      const std::optional<Tensor>& bias_opt,
+      const std::optional<Tensor>& alpha_opt) {
     MatDescriptorCacheKey key{};
     key.m = static_cast<int>(m);
     key.k = static_cast<int>(k);
@@ -200,11 +201,13 @@ struct MatDescriptorCache {
     key.output_type = static_cast<int32_t>(output_type);
     key.C_type = static_cast<int32_t>(C_type);
     key.compute_type = static_cast<int32_t>(compute_type);
-    key.has_bias = has_bias;
+    key.has_bias = bias_opt.has_value();
+    key.has_alpha = alpha_opt.has_value() && alpha_opt.value().numel() != 1;
     key.alg_id = static_cast<int32_t>(alg_id);
     key.split_k = static_cast<int32_t>(split_k);
     key.split_k_mode = static_cast<int32_t>(split_k_mode);
     MatDescriptorPtrs* result = lookup(key);
+
     if (result == nullptr) {
       if (lru_list.size() >= MatDescriptorCacheMaxSize) {
         auto& back = lru_list.back();
@@ -212,17 +215,13 @@ struct MatDescriptorCache {
         lru_list.pop_back();
       }
       lru_list.push_front({key, CachedMatDescriptor{}});
-    }
-    // Both paths leave the target entry at the front of lru_list:
-    // lookup() splices a hit there; a miss push_front's the new entry.
-    CachedMatDescriptor& entry = lru_list.front().second;
-    if (result == nullptr) {
+      CachedMatDescriptor& entry = lru_list.front().second;
       int64_t dense_rows = dense_is_contiguous ? k : n;
       int64_t dense_cols = dense_is_contiguous ? n : k;
       int64_t res_ld = transpose_result ? m : n;
       cusparseOrder_t res_order =
           transpose_result ? CUSPARSE_ORDER_COL : CUSPARSE_ORDER_ROW;
-  
+
       TORCH_CUDASPARSE_CHECK(cusparseLtStructuredDescriptorInit(
           &handle,
           &entry.sparse_input,
@@ -276,7 +275,7 @@ struct MatDescriptorCache {
           &entry.alg_sel,
           &entry.matmul,
           CUSPARSELT_MATMUL_ALG_DEFAULT));
-  
+
       TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgSetAttribute(
           &handle,
           &entry.alg_sel,
@@ -301,30 +300,38 @@ struct MatDescriptorCache {
               sizeof(splitKMode)));
         }
       }
+
+      entry.ptrs.matmul = &entry.matmul;
+      entry.ptrs.alg_sel = &entry.alg_sel;
+      entry.ptrs.plan = &entry.plan;
+      entry.has_descriptors = true;
+      cache_map[lru_list.front().first] = lru_list.begin();
+      result = &entry.ptrs;
     }
-    
+
     if (bias_opt.has_value()) {
       auto& bias = bias_opt.value();
       void* dBias = bias.data_ptr();
       TORCH_CUDASPARSE_CHECK(cusparseLtMatmulDescSetAttribute(
           &handle,
-          &entry.matmul,
+          result->matmul,
           CUSPARSELT_MATMUL_BIAS_POINTER,
           &dBias,
           sizeof(dBias)));
     }
+    if (alpha_opt.has_value() && alpha_opt.value().numel() != 1) {
+      int tensor_alpha_mode = 1;
+      TORCH_CUDASPARSE_CHECK(cusparseLtMatmulDescSetAttribute(
+          &handle,
+          result->matmul,
+          CUSPARSELT_MATMUL_ALPHA_VECTOR_SCALING,
+          &tensor_alpha_mode,
+          sizeof(tensor_alpha_mode)));
+    }
 
     TORCH_CUDASPARSE_CHECK(cusparseLtMatmulPlanInit(
-        &handle, &entry.plan, &entry.matmul, &entry.alg_sel));
-
-    entry.ptrs.matmul = &entry.matmul;
-    entry.ptrs.alg_sel = &entry.alg_sel;
-    entry.ptrs.plan = &entry.plan;
-    entry.has_descriptors = true;
-    if (result == nullptr) {
-      cache_map[lru_list.front().first] = lru_list.begin();
-    }
-    return &entry.ptrs;
+        &handle, result->plan, result->matmul, result->alg_sel));
+    return result;
   }
 
   void insert(MatDescriptorCacheKey key, CachedMatDescriptor descriptor) {
@@ -696,41 +703,22 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
       output_type,
       C_type,
       compute_type,
-      bias_opt.has_value(),
       alg_id,
       split_k,
       split_k_mode,
-      bias_opt);
+      bias_opt,
+      alpha_opt);
   TORCH_CHECK(
       desc_ptrs != nullptr,
       "cuSPARSELt: mat descriptor cache getOrCreate failed");
 
-  // // set bias pointer for matmul, need to assign to get location
-  // if (bias_opt.has_value()) {
-  //   auto& bias = bias_opt.value();
-  //   void* dBias = bias.data_ptr();
-  //   TORCH_CUDASPARSE_CHECK(cusparseLtMatmulDescSetAttribute(
-  //       &handle,
-  //       desc_ptrs->matmul,
-  //       CUSPARSELT_MATMUL_BIAS_POINTER,
-  //       &dBias,
-  //       sizeof(dBias)));
-  // }
-
-  // set tensor_alpha_mode and alpha pointer for matmul
+  // set alpha pointer for matmul
   const auto alpha_tensor = alpha_opt.has_value() ? *alpha_opt : Tensor{};
   auto alpha_ptr = &alpha;
   if (alpha_opt.has_value()) {
     if (alpha_tensor.numel() == 1) {
       alpha = alpha_tensor.item<float>();
     } else {
-      int tensor_alpha_mode = 1;
-      TORCH_CUDASPARSE_CHECK(cusparseLtMatmulDescSetAttribute(
-          &handle,
-          desc_ptrs->matmul,
-          CUSPARSELT_MATMUL_ALPHA_VECTOR_SCALING,
-          &tensor_alpha_mode,
-          sizeof(tensor_alpha_mode)));
       alpha_ptr = static_cast<float*>(alpha_tensor.data_ptr());
     }
   }

--- a/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
+++ b/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
@@ -1,10 +1,12 @@
 #include <ATen/native/sparse/cuda/cuSPARSELtOps.h>
+#include <ATen/native/utils/ParamsHash.h>
 #include <c10/cuda/CUDAGuard.h>
-#include <mutex>
-#include <string_view>
-#include <unordered_map>
-#include <vector>
 #include <c10/util/StringUtil.h>
+#include <list>
+#include <optional>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/NativeFunctions.h>
@@ -17,6 +19,115 @@
 #if AT_CUSPARSELT_ENABLED()
 
 namespace at::native {
+
+namespace {
+
+// Cache key for cuSPARSELt matmul plan. Must be standard layout for ParamsHash.
+struct CsltMatmulCacheKey {
+  int64_t m = 0;
+  int64_t n = 0;
+  int64_t k = 0;
+  int32_t input_type = 0;
+  int32_t output_type = 0;
+  int32_t C_type = 0;
+  int32_t compute_type = 0;
+  int32_t transpose_result = 0;
+  int32_t dense_contiguous = 0;
+  int32_t has_bias = 0;
+  int32_t tensor_alpha_mode = 0;
+  int32_t alg_id = 0;
+  int32_t split_k = 0;
+  int32_t split_k_mode = 0;
+};
+
+static_assert(std::is_standard_layout_v<CsltMatmulCacheKey>);
+
+using CsltMatmulCacheKeyHash = ParamsHash<CsltMatmulCacheKey>;
+using CsltMatmulCacheKeyEqual = ParamsEqual<CsltMatmulCacheKey>;
+
+// Cached plan and workspace size. Plan is destroyed when the cache entry is evicted.
+// Cache is only used when !has_bias (see comment at cache_enabled).
+struct CachedPlan {
+  cusparseLtMatmulPlan_t plan;
+  size_t workspace_size = 0;
+  bool has_plan = false;
+
+  CachedPlan() = default;
+  ~CachedPlan() {
+    if (has_plan) {
+      cusparseLtMatmulPlanDestroy(&plan);
+      has_plan = false;
+    }
+  }
+  CachedPlan(CachedPlan&& other) noexcept
+      : plan(other.plan),
+        workspace_size(other.workspace_size),
+        has_plan(other.has_plan) {
+    other.has_plan = false;
+  }
+  CachedPlan& operator=(CachedPlan&& other) noexcept {
+    if (this != &other) {
+      if (has_plan) {
+        cusparseLtMatmulPlanDestroy(&plan);
+      }
+      plan = other.plan;
+      workspace_size = other.workspace_size;
+      has_plan = other.has_plan;
+      other.has_plan = false;
+    }
+    return *this;
+  }
+  CachedPlan(const CachedPlan&) = delete;
+  CachedPlan& operator=(const CachedPlan&) = delete;
+};
+
+constexpr size_t kCsltMatmulPlanCacheMaxSize = 128;
+
+using CsltMatmulLruList =
+    std::list<std::pair<CsltMatmulCacheKey, CachedPlan>>;
+using CsltMatmulCacheMap = std::unordered_map<
+    CsltMatmulCacheKey,
+    CsltMatmulLruList::iterator,
+    CsltMatmulCacheKeyHash,
+    CsltMatmulCacheKeyEqual>;
+
+struct CsltMatmulPlanCache {
+  CsltMatmulLruList lru_list;
+  CsltMatmulCacheMap cache_map;
+
+  // Returns plan pointer and workspace_size if found; moves entry to front for LRU.
+  std::optional<std::pair<cusparseLtMatmulPlan_t*, size_t>> lookup(
+      const CsltMatmulCacheKey& key) {
+    auto it = cache_map.find(key);
+    if (it == cache_map.end()) {
+      return std::nullopt;
+    }
+    lru_list.splice(lru_list.begin(), lru_list, it->second);
+    CachedPlan& entry = it->second->second;
+    return std::make_pair(&entry.plan, entry.workspace_size);
+  }
+
+  void insert(CsltMatmulCacheKey key, CachedPlan plan) {
+    if (lru_list.size() >= kCsltMatmulPlanCacheMaxSize) {
+      auto& back = lru_list.back();
+      cache_map.erase(back.first);
+      lru_list.pop_back();
+    }
+    lru_list.push_front({std::move(key), std::move(plan)});
+    cache_map[lru_list.front().first] = lru_list.begin();
+  }
+};
+
+thread_local std::unique_ptr<CsltMatmulPlanCache> cslt_matmul_plan_cache;
+
+CsltMatmulPlanCache& getCsltMatmulPlanCache() {
+  if (!cslt_matmul_plan_cache) {
+    cslt_matmul_plan_cache = std::make_unique<CsltMatmulPlanCache>();
+  }
+  return *cslt_matmul_plan_cache;
+}
+
+} // namespace
 
 // Ideally we would use the same DeviceThreadHandlePool mechanism as used in
 // aten/src/ATen/cuda/CuSparseHandlePool.cpp which would handle this for us.
@@ -208,10 +319,6 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
     bool search_alg_id) {
   const c10::cuda::CUDAGuard device_guard{dense_B.device()};
   cusparseLtHandle_t& handle = get_cusparselt_handle_for_current_device();
-  // cuSPARSELt constructs
-  cusparseLtMatmulDescriptor_t matmul;
-  cusparseLtMatmulPlan_t plan;
-  cusparseLtMatmulAlgSelection_t alg_sel;
 
   int tensor_alpha_mode = 0;
   float alpha = 1.0;
@@ -388,10 +495,94 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
     }
   }
 
+  const auto alpha_tensor = alpha_opt.has_value() ? *alpha_opt : Tensor{};
+  if (alpha_opt.has_value()) {
+    if (alpha_tensor.numel() == 1) {
+      alpha = alpha_tensor.item<float>();
+    } else {
+      tensor_alpha_mode = 1;
+    }
+  }
+
   TORCH_INTERNAL_ASSERT(compressed_A.dim() == 2); // encoded M x S
   int64_t k = dense_B.size(0);
   int64_t n = dense_B.size(1);
   int64_t m = compressed_A.size(0);
+
+  const bool has_bias = bias_opt.has_value();
+  // Plan caching disabled: cusparseLtMatmulPlan_t is opaque and retains
+  // internal pointers to the matmul descriptor (and possibly others) passed at
+  // PlanInit. Copying the plan struct into the cache copies those pointers;
+  // the original descriptors are stack locals and go out of scope, so the
+  // cached plan becomes invalid and cusparseLtMatmul(plan_ptr) SIGSEGVs.
+  // Proper caching would require building the plan inside cache-owned memory
+  // so all referenced descriptors outlive the call (not yet implemented).
+  const bool cache_enabled = false;  // !has_bias && !search_alg_id;
+
+  if (cache_enabled) {
+    CsltMatmulCacheKey key{};
+    key.m = m;
+    key.n = n;
+    key.k = k;
+    key.input_type = static_cast<int32_t>(input_type);
+    key.output_type = static_cast<int32_t>(output_type);
+    key.C_type = static_cast<int32_t>(C_type);
+    key.compute_type = static_cast<int32_t>(compute_type);
+    key.transpose_result = transpose_result ? 1 : 0;
+    key.dense_contiguous = dense_B.is_contiguous() ? 1 : 0;
+    key.has_bias = has_bias ? 1 : 0;
+    key.tensor_alpha_mode = tensor_alpha_mode;
+    key.alg_id = alg_id;
+    key.split_k = split_k;
+    key.split_k_mode = split_k_mode;
+
+    auto cached = getCsltMatmulPlanCache().lookup(key);
+    if (cached.has_value()) {
+      cusparseLtMatmulPlan_t* plan_ptr = cached->first;
+      size_t workspace_size = cached->second;
+      ScalarType out_dtype = dense_B.scalar_type();
+      if (out_dtype_opt.has_value()) {
+        out_dtype = out_dtype_opt.value();
+      }
+      auto res_tensor_options =
+          c10::TensorOptions().dtype(out_dtype).device(dense_B.device());
+      at::Tensor res = (transpose_result) ? at::empty({n, m}, res_tensor_options)
+                                          : at::empty({m, n}, res_tensor_options);
+      float* alpha_ptr = (tensor_alpha_mode == 1)
+          ? static_cast<float*>(alpha_tensor.data_ptr())
+          : &alpha;
+      auto& allocator = *::c10::cuda::CUDACachingAllocator::get();
+      auto workspacePtr = allocator.allocate(workspace_size);
+      cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+      TORCH_CUDASPARSE_CHECK(cusparseLtMatmul(
+          &handle,
+          plan_ptr,
+          alpha_ptr,
+          compressed_A.data_ptr(),
+          dense_B.data_ptr(),
+          &beta,
+          res.data_ptr(),
+          res.data_ptr(),
+          workspacePtr.get(),
+          &stream,
+          1));
+      const int max_alg_id = 0;
+      cusparseLtSplitKMode_t splitKMode =
+          (split_k_mode > 0) ? static_cast<cusparseLtSplitKMode_t>(split_k_mode)
+                            : static_cast<cusparseLtSplitKMode_t>(-1);
+      return {
+          res,
+          alg_id,
+          split_k,
+          static_cast<int64_t>(splitKMode),
+          max_alg_id};
+    }
+  }
+
+  // Cache miss or cache disabled: build descriptors and plan
+  cusparseLtMatmulDescriptor_t matmul;
+  cusparseLtMatmulPlan_t plan;
+  cusparseLtMatmulAlgSelection_t alg_sel;
 
   // initialize sparse descriptor
   cusparseLtMatDescriptor_t sparse_input_descriptor;
@@ -483,8 +674,8 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
       &alg_id,
       sizeof(alg_id)));
 
-  cusparseLtSplitKMode_t splitKMode;
-  int max_alg_id;
+  cusparseLtSplitKMode_t splitKMode = static_cast<cusparseLtSplitKMode_t>(-1);
+  int max_alg_id = 0;
   if (split_k != 1) {
     TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgSetAttribute(
         &handle,
@@ -504,22 +695,17 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
     }
   }
 
-  // set tensor_alpha_mode and alpha pointer for matmul
-  const auto alpha_tensor = alpha_opt.has_value() ? *alpha_opt : Tensor{};
-  auto alpha_ptr = &alpha;
-  if (alpha_opt.has_value()) {
-    if (alpha_tensor.numel() == 1) {
-      alpha = alpha_tensor.item<float>();
-    } else {
-      tensor_alpha_mode = 1;
-      TORCH_CUDASPARSE_CHECK(cusparseLtMatmulDescSetAttribute(
-          &handle,
-          &matmul,
-          CUSPARSELT_MATMUL_ALPHA_VECTOR_SCALING,
-          &tensor_alpha_mode,
-          sizeof(tensor_alpha_mode)));
-      alpha_ptr = static_cast<float*>(alpha_tensor.data_ptr());
-    }
+  // set tensor_alpha_mode for matmul descriptor (alpha_ptr used at execution)
+  float* alpha_ptr = (tensor_alpha_mode == 1)
+      ? static_cast<float*>(alpha_tensor.data_ptr())
+      : &alpha;
+  if (tensor_alpha_mode == 1) {
+    TORCH_CUDASPARSE_CHECK(cusparseLtMatmulDescSetAttribute(
+        &handle,
+        &matmul,
+        CUSPARSELT_MATMUL_ALPHA_VECTOR_SCALING,
+        &tensor_alpha_mode,
+        sizeof(tensor_alpha_mode)));
   }
 
   TORCH_CUDASPARSE_CHECK(
@@ -593,7 +779,6 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
         res.data_ptr(),
         res.data_ptr(),
         workspacePtr.get(),
-        // jank because of the way we want this to be an array of streams
         &stream,
         1));
   }
@@ -604,8 +789,33 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
   TORCH_CUDASPARSE_CHECK(
       cusparseLtMatDescriptorDestroy(&dense_input_descriptor));
   TORCH_CUDASPARSE_CHECK(cusparseLtMatDescriptorDestroy(&res_descriptor));
-  // destroy plan
-  TORCH_CUDASPARSE_CHECK(cusparseLtMatmulPlanDestroy(&plan));
+  TORCH_CUDASPARSE_CHECK(cusparseLtMatDescriptorDestroy(&C_descriptor));
+
+  if (cache_enabled) {
+    CsltMatmulCacheKey key{};
+    key.m = m;
+    key.n = n;
+    key.k = k;
+    key.input_type = static_cast<int32_t>(input_type);
+    key.output_type = static_cast<int32_t>(output_type);
+    key.C_type = static_cast<int32_t>(C_type);
+    key.compute_type = static_cast<int32_t>(compute_type);
+    key.transpose_result = transpose_result ? 1 : 0;
+    key.dense_contiguous = dense_B.is_contiguous() ? 1 : 0;
+    key.has_bias = has_bias ? 1 : 0;
+    key.tensor_alpha_mode = tensor_alpha_mode;
+    key.alg_id = alg_id;
+    key.split_k = split_k;
+    key.split_k_mode = split_k_mode;
+    CachedPlan cached_plan;
+    cached_plan.plan = plan;
+    cached_plan.workspace_size = workspace_size;
+    cached_plan.has_plan = true;
+    getCsltMatmulPlanCache().insert(std::move(key), std::move(cached_plan));
+    // Do not destroy plan; cache now owns it.
+  } else {
+    TORCH_CUDASPARSE_CHECK(cusparseLtMatmulPlanDestroy(&plan));
+  }
 
   return {res, alg_id, split_k, static_cast<int64_t>(splitKMode), max_alg_id};
 }

--- a/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
+++ b/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
@@ -58,11 +58,10 @@ cusparseLtHandle_t& get_cusparselt_handle_for_current_device() {
 /////////////////////////////////////////////////////////////////////
 
 struct SparseInputDescriptorCacheKey {
-  int m = 0;
-  int k = 0;
-  bool is_contiguous = true;
+  int dim0 = 0;
+  int dim1 = 0;
   bool is_dense = false;
-  int32_t input_type = 0;
+  int32_t cuda_type = 0;
 };
 
 using SparseInputDescriptorCacheKeyHash = ParamsHash<SparseInputDescriptorCacheKey>;
@@ -146,71 +145,51 @@ SparseInputDescriptorCache& getSparseInputDescriptorCache() {
   return *sparse_input_descriptor_cache;
 }
 
-static cusparseLtMatDescriptor_t* _get_sparse_input_descriptor_ptr(
+enum class MatDescriptorKind { Dense, Sparse };
+
+static cusparseLtMatDescriptor_t* _get_input_descriptor_ptr(
     cusparseLtHandle_t& handle,
-    int64_t m,
-    int64_t k,
-    cudaDataType input_type) {
+    MatDescriptorKind kind,
+    int64_t rows,
+    int64_t cols,
+    int64_t ld,
+    cudaDataType cuda_type,
+    int64_t alignment = 16,
+    cusparseOrder_t order = CUSPARSE_ORDER_ROW) {
   SparseInputDescriptorCacheKey key{};
-  key.m = m;
-  key.k = k;
-  key.is_contiguous = true;
-  key.is_dense = false;
-  key.input_type = static_cast<int32_t>(input_type);
+  key.dim0 = static_cast<int>(rows);
+  key.dim1 = static_cast<int>(cols);
+  key.is_dense = (kind == MatDescriptorKind::Dense);
+  key.cuda_type = static_cast<int32_t>(cuda_type);
   auto cached = getSparseInputDescriptorCache().lookup(key);
   if (cached.has_value()) {
     return *cached;
-  } 
-  cusparseLtMatDescriptor_t sparse_input_descriptor;
-  TORCH_CUDASPARSE_CHECK(cusparseLtStructuredDescriptorInit(
-      &handle,
-      &sparse_input_descriptor,
-      m,
-      k,
-      k,
-      16,
-      input_type,
-      CUSPARSE_ORDER_ROW,
-      CUSPARSELT_SPARSITY_50_PERCENT));
-      
+  }
+  cusparseLtMatDescriptor_t descriptor;
+  if (kind == MatDescriptorKind::Sparse) {
+    TORCH_CUDASPARSE_CHECK(cusparseLtStructuredDescriptorInit(
+        &handle,
+        &descriptor,
+        rows,
+        cols,
+        ld,
+        alignment,
+        cuda_type,
+        order,
+        CUSPARSELT_SPARSITY_50_PERCENT));
+  } else {
+    TORCH_CUDASPARSE_CHECK(cusparseLtDenseDescriptorInit(
+        &handle,
+        &descriptor,
+        rows,
+        cols,
+        ld,
+        alignment,
+        cuda_type,
+        order));
+  }
   CachedSparseInputDescriptor cached_descriptor;
-  cached_descriptor.descriptor = sparse_input_descriptor;
-  cached_descriptor.has_descriptor = true;
-  getSparseInputDescriptorCache().insert(std::move(key), std::move(cached_descriptor));
-  cached = getSparseInputDescriptorCache().lookup(key);
-  return *cached;
-}
-
-
-static cusparseLtMatDescriptor_t* _get_dense_input_descriptor_ptr(
-    cusparseLtHandle_t& handle,
-    int64_t k,
-    int64_t n,
-    bool is_contiguous,
-    cudaDataType input_type) {
-  SparseInputDescriptorCacheKey key{};
-  key.m = n;
-  key.k = k;
-  key.is_contiguous = is_contiguous;
-  key.is_dense = true;
-  key.input_type = static_cast<int32_t>(input_type);
-  auto cached = getSparseInputDescriptorCache().lookup(key);
-  if (cached.has_value()) {
-    return *cached;
-  } 
-  cusparseLtMatDescriptor_t dense_input_descriptor;
-  TORCH_CUDASPARSE_CHECK(cusparseLtDenseDescriptorInit(
-      &handle,
-      &dense_input_descriptor,
-      is_contiguous ? k : n,
-      is_contiguous ? n : k,
-      is_contiguous ? n : k,
-      16,
-      input_type,
-      CUSPARSE_ORDER_ROW));
-      
-  CachedSparseInputDescriptor cached_descriptor;
-  cached_descriptor.descriptor = dense_input_descriptor;
+  cached_descriptor.descriptor = descriptor;
   cached_descriptor.has_descriptor = true;
   getSparseInputDescriptorCache().insert(std::move(key), std::move(cached_descriptor));
   cached = getSparseInputDescriptorCache().lookup(key);
@@ -563,48 +542,51 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
   int64_t n = dense_B.size(1);
   int64_t m = compressed_A.size(0);
 
-  //////////////////////////////////////////////////////////////
-  // initialize sparse descriptor
-  // auto t3 = std::chrono::steady_clock::now();
+  // _get_input_descriptor_ptr(
+  //   cusparseLtHandle_t& handle,
+  //   MatDescriptorKind kind,
+  //   int64_t rows,
+  //   int64_t cols,
+  //   int64_t ld,
+  //   cudaDataType input_type,
+  //   int64_t alignment = 16,
+  //   cusparseOrder_t order = CUSPARSE_ORDER_ROW
+
   cusparseLtMatDescriptor_t* sparse_input_descriptor_ptr =
-    _get_sparse_input_descriptor_ptr(handle, m, k, input_type);
-  // auto t4 = std::chrono::steady_clock::now();
-  // double duration_sparse_input_descriptor = std::chrono::duration<double, std::milli>(t4 - t3).count();
-  // std::cout << "duration_sparse_input_descriptor = " << duration_sparse_input_descriptor << std::endl;
-  /////////////////////////////////////////////////////////////
+    _get_input_descriptor_ptr(handle, MatDescriptorKind::Sparse, m, k, k, input_type);
 
   // initialize dense input descriptor
-  cusparseLtMatDescriptor_t* dense_input_descriptor_ptr = 
-    _get_dense_input_descriptor_ptr(handle, k, n, dense_B.is_contiguous(), input_type);
-  
+  int64_t dense_rows = dense_B.is_contiguous() ? k : n;
+  int64_t dense_cols = dense_B.is_contiguous() ? n : k;
+  cusparseLtMatDescriptor_t* dense_input_descriptor_ptr =
+    _get_input_descriptor_ptr(handle, MatDescriptorKind::Dense, dense_rows, dense_cols, dense_cols, input_type);
+
   // create result tensor
   auto res_tensor_options =
       c10::TensorOptions().dtype(out_dtype).device(dense_B.device());
   at::Tensor res = (transpose_result) ? at::empty({n, m}, res_tensor_options)
                                       : at::empty({m, n}, res_tensor_options);
 
-  cusparseLtMatDescriptor_t res_descriptor;
-  TORCH_CUDASPARSE_CHECK(cusparseLtDenseDescriptorInit(
-      &handle,
-      &res_descriptor,
-      m,
-      n,
-      (transpose_result) ? m : n,
-      16,
-      output_type,
-      (transpose_result) ? CUSPARSE_ORDER_COL : CUSPARSE_ORDER_ROW));
-
+  cusparseLtMatDescriptor_t* res_descriptor_ptr =
+    _get_input_descriptor_ptr(handle,
+        MatDescriptorKind::Dense,
+        m,
+        n,
+        transpose_result ? m : n,
+        output_type,
+        16,
+        transpose_result ? CUSPARSE_ORDER_COL : CUSPARSE_ORDER_ROW);
+  
   // For float8, need fp16 C_descriptor, can't use FP8 for this matrix
-  cusparseLtMatDescriptor_t C_descriptor;
-  TORCH_CUDASPARSE_CHECK(cusparseLtDenseDescriptorInit(
-      &handle,
-      &C_descriptor,
-      m,
-      n,
-      (transpose_result) ? m : n,
-      16,
-      C_type,
-      (transpose_result) ? CUSPARSE_ORDER_COL : CUSPARSE_ORDER_ROW));
+  cusparseLtMatDescriptor_t*  C_descriptor_ptr =
+    _get_input_descriptor_ptr(handle,
+        MatDescriptorKind::Dense,
+        m,
+        n,
+        transpose_result ? m : n,
+        C_type,
+        16,
+        transpose_result ? CUSPARSE_ORDER_COL : CUSPARSE_ORDER_ROW);
 
   // initialize matmul
   TORCH_CUDASPARSE_CHECK(cusparseLtMatmulDescriptorInit(
@@ -615,8 +597,8 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
                                 : CUSPARSE_OPERATION_TRANSPOSE,
       sparse_input_descriptor_ptr,
       dense_input_descriptor_ptr,
-      &C_descriptor,
-      &res_descriptor,
+      C_descriptor_ptr,
+      res_descriptor_ptr,
       compute_type));
 
   // set bias pointer for matmul, need to assign to get location
@@ -767,7 +749,7 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
   //     cusparseLtMatDescriptorDestroy(&sparse_input_descriptor));
   // TORCH_CUDASPARSE_CHECK(
   //     cusparseLtMatDescriptorDestroy(&dense_input_descriptor));
-  TORCH_CUDASPARSE_CHECK(cusparseLtMatDescriptorDestroy(&res_descriptor));
+  // TORCH_CUDASPARSE_CHECK(cusparseLtMatDescriptorDestroy(&res_descriptor));
   // destroy plan
   TORCH_CUDASPARSE_CHECK(cusparseLtMatmulPlanDestroy(&plan));
 

--- a/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
+++ b/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
@@ -103,7 +103,9 @@ struct CachedMatDescriptor {
       cusparseLtMatDescriptorDestroy(&dense_input);
       cusparseLtMatDescriptorDestroy(&res);
       cusparseLtMatDescriptorDestroy(&C);
+      #if defined(CUSPARSELT_VERSION) && CUSPARSELT_VERSION >= 800
       cusparseLtMatmulAlgSelectionDestroy(&alg_sel);
+      #endif
       cusparseLtMatmulPlanDestroy(&plan);
       has_descriptors = false;
     }
@@ -127,7 +129,9 @@ struct CachedMatDescriptor {
         cusparseLtMatDescriptorDestroy(&dense_input);
         cusparseLtMatDescriptorDestroy(&res);
         cusparseLtMatDescriptorDestroy(&C);
+        #if defined(CUSPARSELT_VERSION) && CUSPARSELT_VERSION >= 800
         cusparseLtMatmulAlgSelectionDestroy(&alg_sel);
+        #endif
         cusparseLtMatmulPlanDestroy(&plan);
       }
       sparse_input = other.sparse_input;

--- a/test/test_sparse_semi_structured.py
+++ b/test/test_sparse_semi_structured.py
@@ -1311,6 +1311,36 @@ class TestSparseSemiStructuredCUSPARSELT(TestCase):
                     torch.mm(A_sparse, B), expected, **atol_rtol_kw[dtype]
                 )
 
+    @dtypes(torch.float16, torch.bfloat16)
+    def test_cusparselt_matmul_cache_bias(self, device, dtype):
+        m, k, n = 128, 64, 256
+        A = rand_sparse_semi_structured_mask(m, k, dtype=dtype, device=device)
+        A_compressed = torch._cslt_compress(A)
+        B = torch.rand(k, n, device=device, dtype=dtype)
+        for _ in range(4):
+            bias = torch.rand(m, device=device, dtype=dtype)
+            sparse_result = torch._cslt_sparse_mm(A_compressed, B, bias=bias)
+            dense_result = torch.mm(A.to(torch.float32), B.to(torch.float32))
+            dense_result = dense_result.to(dtype) + bias[:, None]
+            torch.testing.assert_close(sparse_result, dense_result, **atol_rtol_kw[dtype])
+
+    @dtypes(torch.float16, torch.bfloat16)
+    @unittest.skipIf(TEST_WITH_ROCM, "Not supported on ROCm")
+    def test_cusparselt_matmul_cache_alpha(self, device, dtype):
+        "cuSPARSELt v0.8.x does not support bfloat/float16 alpha scaling, torch.int8 matrices are used for this test"
+        m, k, n = 128, 64, 256
+        A = rand_sparse_semi_structured_mask(m, k, dtype=torch.int8, device=device)
+        A_compressed = torch._cslt_compress(A)
+        B = torch.ones((n, k), device=device, dtype=torch.int8).t()
+        for _ in range(4):
+            alpha = torch.rand(m, device=device)
+            sparse_result = torch._cslt_sparse_mm(A_compressed, B, alpha=alpha, out_dtype=dtype)
+            dense_result = alpha[:, None].cpu() * torch.mm(
+                A.to(torch.int64).cpu(), B.to(torch.int64).cpu()
+            )
+            dense_result = dense_result.to(dtype)
+            torch.testing.assert_close(sparse_result.cpu(), dense_result, rtol=1e-3, atol=1e-3)
+
     def test_cusparselt_backend(self):
         if not torch.backends.cusparselt.is_available():
             raise AssertionError("cusparselt backend should be available")

--- a/test/test_sparse_semi_structured.py
+++ b/test/test_sparse_semi_structured.py
@@ -1296,6 +1296,21 @@ class TestSparseSemiStructuredCUSPARSELT(TestCase):
         dense_result = dense_result.to(dtype)
         torch.testing.assert_close(sparse_result, dense_result, rtol=1e-3, atol=1e-3)
 
+    @dtypes(torch.float16, torch.bfloat16)
+    def test_cusparselt_matmul_cache_multiple_shapes(self, device, dtype):
+        configs = [(128, 64, 32), (256, 128, 64)]
+        triples = []
+        for m, k, n in configs:
+            A = rand_sparse_semi_structured_mask(m, k, dtype=dtype, device=device)
+            A_sparse = to_sparse_semi_structured(A)
+            B = torch.rand(k, n, device=device, dtype=dtype)
+            triples.append((A_sparse, B, torch.mm(A, B)))
+        for _ in range(4):
+            for A_sparse, B, expected in triples:
+                torch.testing.assert_close(
+                    torch.mm(A_sparse, B), expected, **atol_rtol_kw[dtype]
+                )
+
     def test_cusparselt_backend(self):
         if not torch.backends.cusparselt.is_available():
             raise AssertionError("cusparselt backend should be available")

--- a/test/test_sparse_semi_structured.py
+++ b/test/test_sparse_semi_structured.py
@@ -1684,6 +1684,25 @@ class TestSparseSemiStructuredCUSPARSELT(TestCase):
         torch.version.hip and not _IS_HIPSPARSELT_AVAILABLE,
         "HIPSPARSELt is not available for ROCm versions < 7.12"
     )
+    @dtypes(torch.float16, torch.bfloat16)
+    def test_cusparselt_matmul_cache_multiple_shapes(self, device, dtype):
+        configs = [(128, 64, 32), (256, 128, 64)]
+        triples = []
+        for m, k, n in configs:
+            A = rand_sparse_semi_structured_mask(m, k, dtype=dtype, device=device)
+            A_sparse = to_sparse_semi_structured(A)
+            B = torch.rand(k, n, device=device, dtype=dtype)
+            triples.append((A_sparse, B, torch.mm(A, B)))
+        for _ in range(4):
+            for A_sparse, B, expected in triples:
+                torch.testing.assert_close(
+                    torch.mm(A_sparse, B), expected, **atol_rtol_kw[dtype]
+                )
+
+    @unittest.skipIf(
+        torch.version.hip and not _IS_HIPSPARSELT_AVAILABLE,
+        "HIPSPARSELt is not available for ROCm versions < 7.12"
+    )
     def test_cusparselt_backend(self):
         if not torch.backends.cusparselt.is_available():
             raise AssertionError("cusparselt backend should be available")

--- a/test/test_sparse_semi_structured.py
+++ b/test/test_sparse_semi_structured.py
@@ -1703,6 +1703,40 @@ class TestSparseSemiStructuredCUSPARSELT(TestCase):
         torch.version.hip and not _IS_HIPSPARSELT_AVAILABLE,
         "HIPSPARSELt is not available for ROCm versions < 7.12"
     )
+    @dtypes(torch.float16, torch.bfloat16)
+    def test_cusparselt_matmul_cache_bias(self, device, dtype):
+        m, k, n = 128, 64, 256
+        A = rand_sparse_semi_structured_mask(m, k, dtype=dtype, device=device)
+        A_compressed = torch._cslt_compress(A)
+        B = torch.rand(k, n, device=device, dtype=dtype)
+        for _ in range(4):
+            bias = torch.rand(m, device=device, dtype=dtype)
+            sparse_result = torch._cslt_sparse_mm(A_compressed, B, bias=bias)
+            dense_result = torch.mm(A.to(torch.float32), B.to(torch.float32))
+            dense_result = dense_result.to(dtype) + bias[:, None]
+            torch.testing.assert_close(sparse_result, dense_result, **atol_rtol_kw[dtype])
+
+    @dtypes(torch.float16, torch.bfloat16)
+    @unittest.skipIf(TEST_WITH_ROCM, "Not supported on ROCm")
+    def test_cusparselt_matmul_cache_alpha(self, device, dtype):
+        "cuSPARSELt v0.8.x does not support bfloat/float16 alpha scaling, torch.int8 matrices are used for this test"
+        m, k, n = 128, 64, 256
+        A = rand_sparse_semi_structured_mask(m, k, dtype=torch.int8, device=device)
+        A_compressed = torch._cslt_compress(A)
+        B = torch.ones((n, k), device=device, dtype=torch.int8).t()
+        for _ in range(4):
+            alpha = torch.rand(m, device=device)
+            sparse_result = torch._cslt_sparse_mm(A_compressed, B, alpha=alpha, out_dtype=dtype)
+            dense_result = alpha[:, None].cpu() * torch.mm(
+                A.to(torch.int64).cpu(), B.to(torch.int64).cpu()
+            )
+            dense_result = dense_result.to(dtype)
+            torch.testing.assert_close(sparse_result.cpu(), dense_result, rtol=1e-3, atol=1e-3)
+
+    @unittest.skipIf(
+        torch.version.hip and not _IS_HIPSPARSELT_AVAILABLE,
+        "HIPSPARSELt is not available for ROCm versions < 7.12"
+    )
     def test_cusparselt_backend(self):
         if not torch.backends.cusparselt.is_available():
             raise AssertionError("cusparselt backend should be available")


### PR DESCRIPTION
Fixes #153825

Updated the sparse semi-structures mm implementation (`_cslt_sparse_mm_impl()` in  `pytorch/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp`) to cache matmul descriptors for matrices with specific parameters (size, dtyp, etc.). This helps reduce the runtime of subsequent matmul of the same kind of matrix by reducing setup/teardown latency. 

For example, let
```
linear = torch.nn.Linear(10240, 3072).half().cuda()
x = torch.rand(3072, 10240).half().cuda()

dense_output = linear(x)

linear.weight = torch.nn.Parameter(to_sparse_semi_structured(linear.weight))
sparse_output = linear(x)
```
Then we have the following median runtimes:
| | runtime (ms) | speedup
|---|---|---|
| dense_output| 0.248 | --  
| sparse_output (before update) | 0.603 | 0.412x
| sparse_output (after update) | 0.216 | 1.15x

This is due to the setup and deconstruction of these matmul descriptors and not due to any kernel computation as is evident by these images from NVIDIA Nsight before the update:

<img width="1424" height="158" alt="image" src="https://github.com/user-attachments/assets/44d58a16-fe8e-4493-b6d0-5fbcd4a0eb6c" />

where the time between kernel launches is about 0.460 ms.

and after the update:

<img width="1424" height="158" alt="image" src="https://github.com/user-attachments/assets/b268b8b7-8652-483d-9267-e1cfb4c8160e" />

where the time between kernel launches is about 0.015 ms.

Both of these images are from the launch of 
`sparse_t = Timer(stmt="linear(x)", globals={"linear": linear, "x": x}).timeit(n_runs).median * 1e3`
and the gap between kernel launches is due to setup/teardown times. 

It should be noted the the 'gap' is almost non existent on dense linear():

<img width="1399" height="186" alt="image" src="https://github.com/user-attachments/assets/4dc9b464-91a4-4180-9697-2eaa7ff8d9f0" />

Here is also the runtimes comparisons on different shapes before the updates
```
torch.nn.Linear(b, a).half().cuda()
x = torch.rand(a, b).half().cuda()
```

1. a,b=(3072, 10240) -> Dense:  0.444ms Sparse:  0.601ms | Speedup: 0.739x
2. a,b=(30720, 10240) -> Dense:  27.056ms Sparse:  19.409ms | Speedup: 1.394x
3. a,b=(3072, 102400) -> Dense:  2.308ms Sparse:  1.847ms | Speedup: 1.250x
4. a,b=(30720, 102400) -> Dense:  278.858ms Sparse:  205.539ms | Speedup: 1.357x
5. a,b=(4096, 11008) -> Dense:  0.471ms Sparse:  0.684ms | Speedup: 0.689x
6. a,b=(40960, 11008) -> Dense:  52.868ms Sparse:  37.216ms | Speedup: 1.421x
7. a,b=(4096, 110080) -> Dense:  4.584ms Sparse:  3.684ms | Speedup: 1.244x

and after the updates:

1. a,b=(3072, 10240) -> Dense:  0.238ms Sparse:  0.216ms | Speedup: 1.104x
2. a,b=(30720, 10240) -> Dense:  27.346ms Sparse:  19.419ms | Speedup: 1.408x
3. a,b=(3072, 102400) -> Dense:  2.304ms Sparse:  1.758ms | Speedup: 1.311x
4. a,b=(30720, 102400) -> Dense:  280.133ms Sparse:  204.429ms | Speedup: 1.370x
5. a,b=(4096, 11008) -> Dense:  0.471ms Sparse:  0.382ms | Speedup: 1.233x
6. a,b=(40960, 11008) -> Dense:  51.904ms Sparse:  37.111ms | Speedup: 1.399x
7. a,b=(4096, 110080) -> Dense:  4.702ms Sparse:  3.343ms | Speedup: 1.407x


Is should be noted that the speedup is much more evident when the matrix sizes are smaller since the setup/teardown time does not depend on matrix size.




