### PR TITLE
Fix detach_ autograd metadata tracking in Dynamo

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -14632,6 +14632,20 @@ fn
 
         self.assertEqual(x_ref.grad, x_test.grad)
 
+    def test_detach_inplace_on_intermediate_updates_metadata(self):
+        def fn(x):
+            y = x * 2
+            y.detach_()
+            return y + 1, y.requires_grad, y.grad_fn is None
+
+        x = torch.randn(3, 3, requires_grad=True)
+        ref = fn(x.clone())
+        result = torch.compile(fn, backend="eager", fullgraph=True)(x.clone())
+
+        self.assertEqual(ref, result)
+        self.assertFalse(result[1])
+        self.assertTrue(result[2])
+
     def test_requires_grad_on_intermediate(self):
         def fn(x):
             y = x * 2

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -1874,6 +1874,19 @@ class TensorVariable(VariableTracker):
                     )
         return self
 
+    def method_detach_(self, tx: "InstructionTranslator") -> VariableTracker:
+        from .builder import wrap_fx_proxy
+
+        proxy = tx.output.create_proxy(
+            "call_method",
+            "detach_",
+            (self.as_proxy(),),
+            {},
+        )
+        wrap_fx_proxy(tx, proxy)
+        self.synchronize_attributes(tx)
+        return self
+
     def method_share_memory_(self) -> NoReturn:
         unimplemented(
             gb_type="Unsupported Tensor.share_memory_() call",

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -1874,7 +1874,7 @@ class TensorVariable(VariableTracker):
                     )
         return self
 
-    def method_detach_(self, tx: "InstructionTranslator") -> VariableTracker:
+    def method_detach_(self, tx: "InstructionTranslator") -> "TensorVariable":
         from .builder import wrap_fx_proxy
 
         proxy = tx.output.create_proxy(

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -1883,6 +1883,7 @@ class TensorVariable(VariableTracker):
             (self.as_proxy(),),
             {},
         )
+        # Run the fake op so the proxy metadata reflects the detached tensor state.
         wrap_fx_proxy(tx, proxy)
         self.synchronize_attributes(tx)
         return self


### PR DESCRIPTION
## Summary
Fix #176854

### Root cause
Dynamo traces `Tensor.detach_()` into the FX graph, but it keeps using the pre-detach `TensorVariable` metadata for later attribute reads. Queries like `y.requires_grad` therefore observe stale autograd state even though the in-place detach has already been recorded.

### Proposed fix
Add a dedicated Dynamo `detach_()` handler for tensor variables. The handler traces the in-place op, runs fake propagation for it, and then synchronizes the tensor metadata from the mutated fake tensor so later reads reflect the detached state. Add a regression test that checks `requires_grad` and `grad_fn` after `detach_()` under `torch.compile(..., backend="eager")`.

### Why this is the right long term fix
The bug is in Dynamo's metadata bookkeeping, not in the underlying op execution. Refreshing the tensor variable metadata at the point where Dynamo traces `detach_()` keeps compile-time state aligned with the FX graph side effect and avoids patching over the mismatch later in the pipeline.

Drafted via Codex, published after manual review by @bobrenjc93

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo