### PR TITLE
dynamo: support next() on itertools.count inputs

### DIFF
--- a/test/dynamo/test_guard_serialization.py
+++ b/test/dynamo/test_guard_serialization.py
@@ -1,6 +1,7 @@
 # Owner(s): ["module: dynamo"]
 
 import dataclasses
+import itertools
 import pickle
 import sys
 import tempfile
@@ -944,6 +945,35 @@ class TestGuardSerialization(TestGuardSerializationBase):
         self._test_check_fn(ref, loaded, {"x": x, "r": iter(range(2, 15, 4))}, False)
         self._test_check_fn(
             ref, loaded, {"x": torch.randn(4), "r": iter(range(2, 15, 4))}, False
+        )
+
+    def test_count_iterator_match(self):
+        def fn(x, counter):
+            return x + next(counter)
+
+        x = torch.randn(3)
+
+        def _gen_kwargs(x=x):
+            return {"x": x, "counter": itertools.count(2, 3)}
+
+        ref, loaded = self._test_serialization(
+            "COUNT_ITERATOR_MATCH", fn, _gen_fn=_gen_kwargs
+        )
+
+        self._test_check_fn(
+            ref, loaded, {"x": x, "counter": itertools.count(2, 3)}, True
+        )
+        self._test_check_fn(
+            ref,
+            loaded,
+            {"x": torch.randn(4), "counter": itertools.count(2, 3)},
+            True,
+        )
+        self._test_check_fn(
+            ref, loaded, {"x": x, "counter": itertools.count(5, 3)}, False
+        )
+        self._test_check_fn(
+            ref, loaded, {"x": x, "counter": itertools.count(2, 4)}, False
         )
 
     def test_dict_version(self):

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -11602,6 +11602,21 @@ def ___make_guard_fn():
             self.assertEqual(list(eager), list(compiled))
             self.assertEqual(len(counters["graph_break"]), 0)
 
+    def test_itertools_count_from_uncompiled_region(self):
+        counters.clear()
+        counter = itertools.count()
+
+        def fn(x):
+            return x * (next(counter) + 1)
+
+        x = torch.randn([2, 5])
+        compiled_fn = torch.compile(fn, backend="eager", fullgraph=True)
+
+        self.assertEqual(compiled_fn(x), x)
+        self.assertEqual(compiled_fn(x), x * 2)
+        self.assertEqual(next(counter), 2)
+        self.assertEqual(len(counters["graph_break"]), 0)
+
     def test_itertools_infinite_cycle(self):
         counters.clear()
 

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -11617,6 +11617,24 @@ def ___make_guard_fn():
         self.assertEqual(next(counter), 2)
         self.assertEqual(len(counters["graph_break"]), 0)
 
+    def test_itertools_count_already_advanced(self):
+        counters.clear()
+        counter = itertools.count()
+        # Advance the counter before entering the compiled region
+        next(counter)  # 0
+        next(counter)  # 1
+
+        def fn(x):
+            return x * (next(counter) + 1)
+
+        x = torch.randn([2, 5])
+        compiled_fn = torch.compile(fn, backend="eager", fullgraph=True)
+
+        self.assertEqual(compiled_fn(x), x * 3)  # next(counter) = 2
+        self.assertEqual(compiled_fn(x), x * 4)  # next(counter) = 3
+        self.assertEqual(next(counter), 4)
+        self.assertEqual(len(counters["graph_break"]), 0)
+
     def test_itertools_infinite_cycle(self):
         counters.clear()
 

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -3830,7 +3830,7 @@ class GuardsStatePickler(pickle.Pickler):
         return dict.fromkeys(elems).keys()
 
     @classmethod
-    def _unpickle_count_iter(cls, item: int, step: int) -> itertools.count:
+    def _unpickle_count_iter(cls, item: int, step: int) -> itertools.count[int]:
         return itertools.count(item, step)
 
     @classmethod

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -202,6 +202,7 @@ if TYPE_CHECKING:
 
 
 guard_manager_testing_hook_fn: Callable[[Any, Any, Any], Any] | None = None
+_COUNT_ITERATOR_TYPE = type(itertools.count())
 
 try:
     import numpy as np
@@ -4015,7 +4016,7 @@ class GuardsStatePickler(pickle.Pickler):
         elif isinstance(obj, types.MappingProxyType):
             return type(self)._unpickle_mapping_proxy, (obj.copy(),)
 
-        elif type(obj) is type(itertools.count()):
+        elif type(obj) is _COUNT_ITERATOR_TYPE:
             item, step = normalize_count_iter(obj)
             if item is not NotImplemented and step is not NotImplemented:
                 return type(self)._unpickle_count_iter, (item, step)

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -185,6 +185,7 @@ from .utils import (
     istype,
     key_is_id,
     key_to_id,
+    normalize_count_iter,
     normalize_range_iter,
     orig_code_map,
     tensor_always_has_static_shape,
@@ -2814,6 +2815,30 @@ class GuardBuilder(GuardBuilderBase):
             obj_id,
             get_verbose_code_parts(code, guard),
             guard.user_stack,
+        )
+
+    @register_guard_check_spec(
+        get_metadata_fn=lambda guard, value: (type(value), normalize_count_iter(value)),
+        eval_fn=lambda value, metadata: (
+            type(value) is metadata[0] and normalize_count_iter(value) == metadata[1]
+        ),
+    )
+    def COUNT_ITERATOR_MATCH(self, guard: Guard) -> None:
+        ref = self.arg_ref(guard)
+        value = self.get(guard)
+        count_type = type(value)
+        normalized_count_iter = normalize_count_iter(value)
+
+        def guard_fn(x: Any) -> bool:
+            return (
+                type(x) is count_type
+                and normalize_count_iter(x) == normalized_count_iter
+            )
+
+        code = [f"___normalize_count_iter({ref}) == {normalized_count_iter}"]
+        self._set_guard_export_info(guard, code)
+        self.get_guard_manager(guard).add_lambda_guard(
+            guard_fn, get_verbose_code_parts(code, guard), guard.user_stack
         )
 
     # Multi-source guard (two inputs aliasing) — not expressible as a

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -752,6 +752,7 @@ def _get_closure_vars() -> dict[str, object]:
             "___dict_version": dict_version,
             "___dict_contains": lambda a, b: dict.__contains__(b, a),
             "___tuple_iterator_len": tuple_iterator_len,
+            "___normalize_count_iter": normalize_count_iter,
             "___normalize_range_iter": normalize_range_iter,
             "___tuple_iterator_getitem": tuple_iterator_getitem,
             "___dataclass_fields": dataclass_fields,

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -3830,7 +3830,7 @@ class GuardsStatePickler(pickle.Pickler):
         return dict.fromkeys(elems).keys()
 
     @classmethod
-    def _unpickle_count_iter(cls, item: Any, step: Any) -> Any:
+    def _unpickle_count_iter(cls, item: int, step: int) -> itertools.count:
         return itertools.count(item, step)
 
     @classmethod

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -25,6 +25,7 @@ import enum
 import functools
 import importlib
 import inspect
+import itertools
 import io
 import logging
 import math
@@ -3828,6 +3829,10 @@ class GuardsStatePickler(pickle.Pickler):
         return dict.fromkeys(elems).keys()
 
     @classmethod
+    def _unpickle_count_iter(cls, item: Any, step: Any) -> Any:
+        return itertools.count(item, step)
+
+    @classmethod
     def _unpickle_fsdp_module_type(
         cls, original_type: type[torch.nn.Module]
     ) -> type[torch.nn.Module]:
@@ -4009,6 +4014,11 @@ class GuardsStatePickler(pickle.Pickler):
 
         elif isinstance(obj, types.MappingProxyType):
             return type(self)._unpickle_mapping_proxy, (obj.copy(),)
+
+        elif type(obj) is type(itertools.count()):
+            item, step = normalize_count_iter(obj)
+            if item is not NotImplemented and step is not NotImplemented:
+                return type(self)._unpickle_count_iter, (item, step)
 
         elif isinstance(obj, torch._dynamo.utils.dict_keys):
             return type(self)._unpickle_dict_keys, (list(obj),)

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -25,8 +25,8 @@ import enum
 import functools
 import importlib
 import inspect
-import itertools
 import io
+import itertools
 import logging
 import math
 import pickle

--- a/torch/_dynamo/side_effects.py
+++ b/torch/_dynamo/side_effects.py
@@ -1315,6 +1315,15 @@ class SideEffects:
                     cg.call_function(1, False)
                     cg.pop_top()
                 _maybe_log_side_effect(var)
+            elif isinstance(var, variables.CountIteratorVariable):
+                for _ in range(var.advance_count):
+                    cg.add_push_null(
+                        lambda: cg.load_import_from(utils.__name__, "iter_next")
+                    )
+                    cg(var.source)  # type: ignore[attr-defined]
+                    cg.call_function(1, False)
+                    cg.pop_top()
+                _maybe_log_side_effect(var)
             elif isinstance(var, variables.RandomVariable):
                 # set correct random seed state
                 def gen_fn() -> None:

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -2961,7 +2961,7 @@ def normalize_count_iter(count_iter: Iterator[Any]) -> tuple[Any, Any]:
             return (NotImplemented, NotImplemented)
     if len(args) == 1:
         return (args[0], 1)
-    return args
+    return (args[0], args[1])
 
 
 def normalize_range_iter(range_iter: Any) -> tuple[int, int, int]:

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -2941,6 +2941,13 @@ def dataclass_fields(cls: Any) -> Any:
 iter_next = next
 
 
+def normalize_count_iter(count_iter: Any) -> tuple[Any, Any]:
+    _, args = count_iter.__reduce__()
+    if len(args) == 1:
+        return (args[0], 1)
+    return args
+
+
 def normalize_range_iter(range_iter: Any) -> tuple[int, int, int]:
     _, (range_obj,), maybe_idx = range_iter.__reduce__()
     # In 3.12+, `maybe_idx` could be None, and `range_obj.start` would've been

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -2942,7 +2942,23 @@ iter_next = next
 
 
 def normalize_count_iter(count_iter: Any) -> tuple[Any, Any]:
-    _, args = count_iter.__reduce__()
+    try:
+        _, args = count_iter.__reduce__()
+    except TypeError:
+        # Python 3.14 no longer pickles itertools.count, so fall back to the
+        # repr and only recover literal arguments. Non-literal arguments still
+        # fall back to user-defined handling via the NotImplemented sentinel.
+        import ast
+
+        count_repr = repr(count_iter)
+        if not count_repr.startswith("count(") or not count_repr.endswith(")"):
+            return (NotImplemented, NotImplemented)
+        try:
+            args = ast.literal_eval(f"({count_repr[6:-1]},)")
+        except (SyntaxError, ValueError):
+            return (NotImplemented, NotImplemented)
+        if not isinstance(args, tuple) or not 1 <= len(args) <= 2:
+            return (NotImplemented, NotImplemented)
     if len(args) == 1:
         return (args[0], 1)
     return args

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -45,7 +45,6 @@ import uuid
 import warnings
 import weakref
 from collections import Counter, OrderedDict
-from collections.abc import Iterator
 from contextlib import AbstractContextManager, contextmanager
 from dataclasses import is_dataclass
 from functools import lru_cache
@@ -2942,7 +2941,7 @@ def dataclass_fields(cls: Any) -> Any:
 iter_next = next
 
 
-def normalize_count_iter(count_iter: Iterator) -> tuple[Any, Any]:
+def normalize_count_iter(count_iter: Iterator[Any]) -> tuple[Any, Any]:
     try:
         _, args = count_iter.__reduce__()
     except TypeError:

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -45,6 +45,7 @@ import uuid
 import warnings
 import weakref
 from collections import Counter, OrderedDict
+from collections.abc import Iterator
 from contextlib import AbstractContextManager, contextmanager
 from dataclasses import is_dataclass
 from functools import lru_cache
@@ -2941,7 +2942,7 @@ def dataclass_fields(cls: Any) -> Any:
 iter_next = next
 
 
-def normalize_count_iter(count_iter: Any) -> tuple[Any, Any]:
+def normalize_count_iter(count_iter: Iterator) -> tuple[Any, Any]:
     try:
         _, args = count_iter.__reduce__()
     except TypeError:

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -52,6 +52,7 @@ from torch._dynamo.utils import (
     get_metrics_context,
     is_int_specialization_case,
     is_torch_sym,
+    normalize_count_iter,
     set_feature_use,
 )
 from torch._guards import TracingContext
@@ -594,6 +595,7 @@ class VariableBuilder:
                 (tuple, list, odict_values, collections.deque, torch.Size),
                 cls.wrap_listlike,
             ),
+            (itertools.count, cls.wrap_itertools_count),
             (tuple_iterator, cls.wrap_tuple_iterator),
             (range_iterator, cls.wrap_range_iterator),
             ((slice, range), cls.wrap_slice_range),
@@ -1973,6 +1975,22 @@ class VariableBuilder:
         # on items since `RANGE_ITERATOR_MATCH` guarantees the same items.
         items = [ConstantVariable.create(v) for v in copy.deepcopy(value)]
         result = ListIteratorVariable(items, source=self.source)
+        return self.tx.output.side_effects.track_mutable(value, result)
+
+    def wrap_itertools_count(self, value: itertools.count) -> VariableTracker:
+        current_item, step = normalize_count_iter(value)
+        if not (
+            ConstantVariable.is_literal(current_item)
+            and ConstantVariable.is_literal(step)
+        ):
+            return self.wrap_user_defined(value)
+
+        self.install_guards(GuardBuilder.COUNT_ITERATOR_MATCH)
+        result = CountIteratorVariable(
+            ConstantVariable.create(current_item),
+            ConstantVariable.create(step),
+            source=self.source,
+        )
         return self.tx.output.side_effects.track_mutable(value, result)
 
     def wrap_slice_range(self, value: slice | range) -> SliceVariable | RangeVariable:

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -1977,7 +1977,7 @@ class VariableBuilder:
         result = ListIteratorVariable(items, source=self.source)
         return self.tx.output.side_effects.track_mutable(value, result)
 
-    def wrap_itertools_count(self, value: itertools.count) -> VariableTracker:
+    def wrap_itertools_count(self, value: Any) -> VariableTracker:
         current_item, step = normalize_count_iter(value)
         if not (
             ConstantVariable.is_literal(current_item)

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -223,7 +223,7 @@ from .higher_order_ops import (
     LocalMapWrappedHigherOrderVariable,
     TorchHigherOrderOperatorVariable,
 )
-from .iter import ItertoolsVariable
+from .iter import CountIteratorVariable, ItertoolsVariable
 from .lazy import LazyConstantVariable, LazyVariableTracker
 from .lists import (
     BaseListVariable,

--- a/torch/_dynamo/variables/iter.py
+++ b/torch/_dynamo/variables/iter.py
@@ -346,6 +346,8 @@ class RepeatIteratorVariable(IteratorVariable):
 
 
 class CountIteratorVariable(IteratorVariable):
+    # advance_count tracks how many next() calls were made during tracing,
+    # used by side_effects.py to replay them on the real iterator post-execution.
     _nonvar_fields = {
         "advance_count",
         *IteratorVariable._nonvar_fields,

--- a/torch/_dynamo/variables/iter.py
+++ b/torch/_dynamo/variables/iter.py
@@ -195,10 +195,21 @@ class ItertoolsVariable(VariableTracker):
             return tx.inline_user_function_return(
                 VariableTracker.build(tx, polyfills.repeat), args, kwargs
             )
-        elif self.value is itertools.count:
-            return variables.CountIteratorVariable(
-                *args, mutation_type=ValueMutationNew()
-            )
+        elif self.value is itertools.count and not kwargs:
+            if len(args) == 0:
+                return variables.CountIteratorVariable(
+                    mutation_type=ValueMutationNew()
+                )
+            if len(args) == 1:
+                return variables.CountIteratorVariable(
+                    item=args[0], mutation_type=ValueMutationNew()
+                )
+            if len(args) == 2:
+                return variables.CountIteratorVariable(
+                    item=args[0],
+                    step=args[1],
+                    mutation_type=ValueMutationNew(),
+                )
         elif (
             self.value is itertools.permutations
             and (len(args) == 1 or (len(args) == 2 and args[1].is_python_constant()))

--- a/torch/_dynamo/variables/iter.py
+++ b/torch/_dynamo/variables/iter.py
@@ -197,9 +197,7 @@ class ItertoolsVariable(VariableTracker):
             )
         elif self.value is itertools.count and not kwargs:
             if len(args) == 0:
-                return variables.CountIteratorVariable(
-                    mutation_type=ValueMutationNew()
-                )
+                return variables.CountIteratorVariable(mutation_type=ValueMutationNew())
             if len(args) == 1:
                 return variables.CountIteratorVariable(
                     item=args[0], mutation_type=ValueMutationNew()
@@ -210,6 +208,7 @@ class ItertoolsVariable(VariableTracker):
                     step=args[1],
                     mutation_type=ValueMutationNew(),
                 )
+            return super().call_function(tx, args, kwargs)
         elif (
             self.value is itertools.permutations
             and (len(args) == 1 or (len(args) == 2 and args[1].is_python_constant()))

--- a/torch/_dynamo/variables/iter.py
+++ b/torch/_dynamo/variables/iter.py
@@ -336,10 +336,16 @@ class RepeatIteratorVariable(IteratorVariable):
 
 
 class CountIteratorVariable(IteratorVariable):
+    _nonvar_fields = {
+        "advance_count",
+        *IteratorVariable._nonvar_fields,
+    }
+
     def __init__(
         self,
         item: int | VariableTracker = 0,
         step: int | VariableTracker = 1,
+        advance_count: int = 0,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -349,12 +355,14 @@ class CountIteratorVariable(IteratorVariable):
             step = ConstantVariable.create(step)
         self.item = item
         self.step = step
+        self.advance_count = advance_count
 
     def next_variable(self, tx: "InstructionTranslator") -> VariableTracker:
         assert self.is_mutable()
         old_item = self.item
         tx.output.side_effects.mutation(self)
         self.item = self.item.call_method(tx, "__add__", [self.step], {})
+        self.advance_count += 1
         return old_item
 
     def reconstruct(self, codegen: "PyCodegen") -> None:


### PR DESCRIPTION
Fix #177196

1. Root cause
Dynamo wrapped pre-existing `itertools.count()` objects as generic user-defined objects, so `next(counter)` fell through to the unsupported `__next__` path. The existing iterator side-effect replay also had no way to keep a live `count()` object synchronized after compiled execution.

2. Proposed fix
Wrap pre-existing `itertools.count()` instances as `CountIteratorVariable`, guard them on their current iterator state, and replay consumed `next()` calls back onto the original iterator after the compiled region. Add regression tests for the external-counter fullgraph case and the new guard.

3. Why the proposed fix is the right long term fix
This keeps `itertools.count()` on Dynamo's existing iterator path instead of treating it like an opaque user object. That gives Dynamo the same three things it already needs for mutable iterators: a dedicated variable type during tracing, guard-based cache invalidation when iterator state changes, and side-effect replay that preserves the original Python object.

Drafted via Codex, published after manual review by @bobrenjc93

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo