### PR TITLE
negative mem alloc size error raised for  torch.cuda.memory.caching_allocator_alloc

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -364,6 +364,10 @@ print(t.is_pinned())
                 torch.cuda.caching_allocator_delete(mem)
                 self.assertEqual(torch.cuda.memory_allocated(), prev)
 
+    def test_caching_allocator_alloc_negative_size(self):
+        with self.assertRaisesRegex(ValueError, "Invalid memory size"):
+            torch.cuda.memory.caching_allocator_alloc(-1024)
+
     def test_memory_stats(self):
         gc.collect()
         torch.cuda.empty_cache()

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -365,7 +365,7 @@ print(t.is_pinned())
                 self.assertEqual(torch.cuda.memory_allocated(), prev)
 
     def test_caching_allocator_alloc_negative_size(self):
-        with self.assertRaisesRegex(RuntimeError, "Invalid memory size"):
+        with self.assertRaisesRegex(ValueError, "Invalid memory size"):
             torch.cuda.memory.caching_allocator_alloc(-1024)
 
     def test_memory_stats(self):

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -365,7 +365,7 @@ print(t.is_pinned())
                 self.assertEqual(torch.cuda.memory_allocated(), prev)
 
     def test_caching_allocator_alloc_negative_size(self):
-        with self.assertRaisesRegex(ValueError, "Invalid memory size"):
+        with self.assertRaisesRegex(RuntimeError, "Invalid memory size"):
             torch.cuda.memory.caching_allocator_alloc(-1024)
 
     def test_memory_stats(self):

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -297,6 +297,11 @@ PyObject* THCPModule_cudaCachingAllocator_raw_alloc(
     return nullptr;
   }
   auto size = PyLong_AsSsize_t(size_o);
+  TORCH_CHECK(
+      size >= 0,
+      "Invalid memory size: ",
+      size,
+      ". caching_allocator_alloc requires a non-negative size.");
   cudaStream_t stream = static_cast<cudaStream_t>(PyLong_AsVoidPtr(stream_o));
   void* mem = nullptr;
   {

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -297,7 +297,7 @@ PyObject* THCPModule_cudaCachingAllocator_raw_alloc(
     return nullptr;
   }
   auto size = PyLong_AsSsize_t(size_o);
-  TORCH_CHECK(
+  TORCH_CHECK_VALUE(
       size >= 0,
       "Invalid memory size: ",
       size,

--- a/torch/cuda/memory.py
+++ b/torch/cuda/memory.py
@@ -139,11 +139,6 @@ def caching_allocator_alloc(size, device: "Device" = None, stream=None):
             "`torch.cuda.Stream` or `int` representing a pointer "
             "to a existing stream"
         )
-    if size < 0:
-        raise ValueError(
-            f"Invalid memory size: {size}. "
-            "caching_allocator_alloc requires a non-negative size."
-        )
     with torch.cuda.device(device):
         return torch._C._cuda_cudaCachingAllocator_raw_alloc(size, stream)
 

--- a/torch/cuda/memory.py
+++ b/torch/cuda/memory.py
@@ -139,7 +139,7 @@ def caching_allocator_alloc(size, device: "Device" = None, stream=None):
             "`torch.cuda.Stream` or `int` representing a pointer "
             "to a existing stream"
         )
-    pip install ninja    if size < 0:
+    if size < 0:
         raise ValueError(
             f"Invalid memory size: {size}. "
             "caching_allocator_alloc requires a non-negative size."

--- a/torch/cuda/memory.py
+++ b/torch/cuda/memory.py
@@ -139,6 +139,11 @@ def caching_allocator_alloc(size, device: "Device" = None, stream=None):
             "`torch.cuda.Stream` or `int` representing a pointer "
             "to a existing stream"
         )
+    pip install ninja    if size < 0:
+        raise ValueError(
+            f"Invalid memory size: {size}. "
+            "caching_allocator_alloc requires a non-negative size."
+        )
     with torch.cuda.device(device):
         return torch._C._cuda_cudaCachingAllocator_raw_alloc(size, stream)
 


### PR DESCRIPTION
 in PyTorch when using the API torch.cuda.memory.caching_allocator_alloc. The crash is triggered by an internal C++ assertion failure when a negative integer (e.g., -1024) is passed as the memory allocation size.

Raises clear value error 

Fixes [177827](https://github.com/pytorch/pytorch/issues/177827)