### PR TITLE
[Dynamo][Cache]Add per-region compile() id to cache for isolation

### DIFF
--- a/torch/_dynamo/cache_size.py
+++ b/torch/_dynamo/cache_size.py
@@ -199,13 +199,7 @@ def exceeds_recompile_limit(
     cache_size: CacheSizeRelevantForFrame, compile_id: CompileId
 ) -> tuple[bool, str]:
     """
-    Checks if we are exceeding the global cache size limit.
-
-    The global recompile_limit is per-code-object: each code object (including
-    resume functions from graph breaks) independently gets up to N recompilations.
-    The region_recompile_limit iterates on this by using the max recompilations
-    among all code objects in the region, so that once any code object in the
-    region hits the limit, all compilation in the region stops.
+    Checks if we are exceeding the cache size limit.
     """
     if cache_size.will_compilation_exceed_accumulated_limit():
         return True, "accumulated_recompile_limit"

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -576,6 +576,9 @@ def get_compile_id(
     )
 
 
+_next_region_id = 0
+
+
 class ConvertFrameAssert:
     def __init__(
         self,
@@ -595,6 +598,12 @@ class ConvertFrameAssert:
         self._package = package
         self._region_recompile_limit = region_recompile_limit
         self._region_compilation_counts: dict[CodeType, int] = {}
+        if region_recompile_limit is not None:
+            global _next_region_id
+            self._region_id = _next_region_id
+            _next_region_id += 1
+        else:
+            self._region_id = -1
         self._box = ConvertFrameBox()
 
     @property
@@ -747,6 +756,7 @@ class ConvertFrameAssert:
                     skip=skip + 1,
                     package=self._package,
                     convert_frame_box=self._box,
+                    region_id=self._region_id,
                 )
         finally:
             # Restore the previous initial_global_state for nested compilation handling
@@ -1486,6 +1496,7 @@ def _compile(
     # Can be used to record things for the caller, both
     # in the case of normal and exception code paths
     convert_frame_box: ConvertFrameBox | None = None,
+    region_id: int = -1,
 ) -> ConvertFrameReturn:
     from torch.fx.experimental.validator import (
         BisectValidationException,
@@ -1714,6 +1725,7 @@ def _compile(
             check_fn.guard_manager,  # type: ignore[arg-type]
             compile_id,
             annotation_str,
+            region_id=region_id,
         )
 
         if not output.is_empty_graph() and hooks.guard_export_fn is not None:

--- a/torch/_dynamo/types.py
+++ b/torch/_dynamo/types.py
@@ -69,6 +69,8 @@ class GuardedCode:
     guard_manager: GuardFn
     compile_id: CompileId
     trace_annotation: str = "Unknown"
+    # Per-region ID for cache isolation (-1 = no region, shared cache)
+    region_id: int = -1
 
 
 @dataclasses.dataclass

--- a/torch/csrc/dynamo/cache_entry.cpp
+++ b/torch/csrc/dynamo/cache_entry.cpp
@@ -16,6 +16,9 @@ CacheEntry::CacheEntry(const py::handle& guarded_code, PyObject* backend)
   } else {
     this->trace_annotation = "Unknown";
   }
+  if (py::hasattr(guarded_code, "region_id")) {
+    this->region_id = guarded_code.attr("region_id").cast<int64_t>();
+  }
   this->root_mgr = torch::dynamo::convert_to_root_guard_manager(
       this->guard_manager.attr("root"));
   this->diff_guard_root_mgr = torch::dynamo::convert_to_root_guard_manager(
@@ -81,4 +84,18 @@ PyObject* get_backend(PyObject* callback) {
     handle = handle.attr("_torchdynamo_orig_backend");
   }
   return handle.ptr();
+}
+
+int64_t get_region_id(PyObject* callback) {
+  py::handle handle = py::handle(callback);
+  while (py::hasattr(handle, "_torchdynamo_orig_backend")) {
+    if (py::hasattr(handle, "_region_id")) {
+      return handle.attr("_region_id").cast<int64_t>();
+    }
+    handle = handle.attr("_torchdynamo_orig_backend");
+  }
+  if (py::hasattr(handle, "_region_id")) {
+    return handle.attr("_region_id").cast<int64_t>();
+  }
+  return -1;
 }

--- a/torch/csrc/dynamo/cache_entry.h
+++ b/torch/csrc/dynamo/cache_entry.h
@@ -54,6 +54,8 @@ typedef struct VISIBILITY_HIDDEN CacheEntry {
   void* diff_guard_root_mgr{nullptr};
   // backend used to create this cache entry
   py::object backend;
+  // region_id for per-torch.compile() cache isolation (-1 = no region)
+  int64_t region_id{-1};
   // Reference to owning ExtraState
   ExtraState* _owner{nullptr};
   // Reference to this CacheEntry's location in owner's linked list

--- a/torch/csrc/dynamo/eval_frame_cpp.cpp
+++ b/torch/csrc/dynamo/eval_frame_cpp.cpp
@@ -478,6 +478,7 @@ PyObject* dynamo__custom_eval_frame(
   std::unique_ptr<FrameLocalsMapping> locals =
       std::make_unique<FrameLocalsMapping>(frame);
   PyObject* backend = get_backend(callback.ptr()); // borrowed
+  int64_t region_id = get_region_id(callback.ptr());
 
   // We don't run the current custom_eval_frame behavior for guards.
   // So we temporarily set the callback to Py_None to drive the correct behavior
@@ -494,6 +495,7 @@ PyObject* dynamo__custom_eval_frame(
       extra,
       locals.get(),
       backend,
+      region_id,
       &maybe_cached_code,
       &trace_annotation,
       is_skip_guard_eval_unsafe);

--- a/torch/csrc/dynamo/extra_state.cpp
+++ b/torch/csrc/dynamo/extra_state.cpp
@@ -141,6 +141,7 @@ void lookup(
     ExtraState* extra_state,
     FrameLocalsMapping* f_locals,
     PyObject* backend,
+    int64_t region_id,
     PyObject** maybe_cached_code,
     const char** trace_annotation,
     bool is_skip_guard_eval_unsafe) {
@@ -159,6 +160,14 @@ void lookup(
 
     bool valid = backend == Py_False ||
         backend_match(cache_entry.backend.ptr(), backend);
+
+    // Filter by region_id: when region_id >= 0, only match entries from
+    // the same region. Entries with region_id -1 (no region) are visible
+    // to all, and callers with region_id -1 see all entries.
+    if (valid && region_id >= 0 && cache_entry.region_id >= 0 &&
+        cache_entry.region_id != region_id) {
+      valid = false;
+    }
 
     if (valid) {
       try {

--- a/torch/csrc/dynamo/extra_state.h
+++ b/torch/csrc/dynamo/extra_state.h
@@ -171,6 +171,7 @@ void lookup(
     ExtraState* extra_state,
     FrameLocalsMapping* f_locals,
     PyObject* backend,
+    int64_t region_id,
     PyObject** maybe_cached_code,
     const char** trace_annotation,
     bool is_skip_guard_eval_unsafe);
@@ -189,6 +190,9 @@ CacheEntry* create_cache_entry(
 
 // Extracts the backend fn from the callback.
 PyObject* get_backend(PyObject* callback);
+
+// Extracts the region_id from the callback chain (-1 = no region).
+int64_t get_region_id(PyObject* callback);
 
 #ifdef __cplusplus
 

--- a/torch/csrc/dynamo/init.cpp
+++ b/torch/csrc/dynamo/init.cpp
@@ -218,6 +218,7 @@ void initDynamoBindings(PyObject* torch) {
       .def_readonly("compile_id", &CacheEntry::compile_id)
       .def_readonly("trace_annotation", &CacheEntry::trace_annotation)
       .def_readonly("backend", &CacheEntry::backend)
+      .def_readonly("region_id", &CacheEntry::region_id)
       .def_property_readonly("next", &CacheEntry::next)
       .def(
           "update_diff_guard_root_manager",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #178307
* #177895
* __->__ #177894
* #177399
* #177355



## Summary

Cache entries in Dynamo are stored per code object. When multiple `torch.compile()` calls
target the same function, their cache entries are interleaved on the same linked list. This
causes cross-region interference: one region's compilations affect another region's cache
lookup, recompile limit checks, and `FrameExecStrategy`.

This PR adds a `region_id` tag to each `CacheEntry` in C++ and filters by it during
`lookup()`. Each `torch.compile()` call with `region_recompile_limit` gets a unique
`region_id` (monotonic counter on `ConvertFrameAssert`). The C++ cache only returns entries
matching the current region, giving true per-region isolation without copying code objects.

Regions without `region_recompile_limit` (region_id = -1) use the shared cache as before.

## Visualization
```
ExtraState (per code object)
    └── cache_entry_list
          ├── CacheEntry { guards, code, backend, region_id=0 }  ← from opt_f
          ├── CacheEntry { guards, code, backend, region_id=0 }  ← from opt_f
          ├── CacheEntry { guards, code, backend, region_id=1 }  ← from opt_g
          └── CacheEntry { guards, code, backend, region_id=-1 } ← no region set
```

```
def test_region_id_cache_entries_visual(self):
      cnt1 = torch._dynamo.testing.CompileCounter()
      cnt2 = torch._dynamo.testing.CompileCounter()

      def f(x):
          return x.sin()

      opt_f = torch.compile(f, backend=cnt1, region_recompile_limit=2)
      opt_g = torch.compile(f, backend=cnt2, region_recompile_limit=2)

      opt_f(torch.randn(3))
      opt_f(torch.randn(3, dtype=torch.float64))
      opt_g(torch.randn(4))

      # Print cache entries showing region_id
      entries = torch._dynamo.eval_frame._debug_get_cache_entry_list(f)
      for i, entry in enumerate(entries):
          print(f"CacheEntry[{i}]: region_id={entry.region_id}, compile_id={entry.compile_id}")
```

  This would output something like:
  CacheEntry[0]: region_id=0, compile_id=0/0  ← from opt_f
  CacheEntry[1]: region_id=0, compile_id=0/1  ← from opt_f
  CacheEntry[2]: region_id=1, compile_id=0/2  ← from opt_g


## Changes

**C++:**
- `cache_entry.h/cpp`: `region_id` field on `CacheEntry`, extracted from `GuardedCode` in constructor. `get_region_id()` helper to extract region_id from the callback chain.
- `extra_state.h/cpp`: `lookup()` takes `region_id` param, filters entries where `region_id >= 0` and doesn't match.
- `eval_frame_cpp.cpp`: Calls `get_region_id()` and passes to `lookup()`.

**Python:**
- `types.py`: `region_id` field on `GuardedCode` (default -1).
- `convert_frame.py`: `_next_region_id` counter, `_region_id` on `ConvertFrameAssert`, threaded through `_compile` to `GuardedCode`.


## Test Plan

- Existing `RegionRecompileLimitTests` suite passes
- `test_region_recompile_limit_same_function_different_regions` — two regions on the same function with different backends have fully isolated caches
