### PR TITLE
[Dynamo][cache]Update region_recompile_limit to override global recompile_limit

### DIFF
--- a/test/dynamo/test_recompile_ux.py
+++ b/test/dynamo/test_recompile_ux.py
@@ -539,6 +539,92 @@ class RegionRecompileLimitTests(torch._dynamo.test_case.TestCase):
                 f"{code.co_name} has {len(entries)} entries, exceeds limit of 2",
             )
 
+    @torch._dynamo.config.patch(recompile_limit=1)
+    def test_region_recompile_limit_overrides_global(self):
+        """region_recompile_limit overrides config.recompile_limit. Multiple
+        torch.compile() calls on the same function can each compile
+        independently even when the shared code object's total entries
+        exceed config.recompile_limit. This is the factory pattern fix."""
+        cnt1 = torch._dynamo.testing.CompileCounter()
+        cnt2 = torch._dynamo.testing.CompileCounter()
+
+        def f(x):
+            return x.sin()
+
+        opt_f = torch.compile(f, backend=cnt1, region_recompile_limit=2)
+        opt_g = torch.compile(f, backend=cnt2, region_recompile_limit=2)
+
+        # opt_f compiles twice (under region limit of 2, over global limit of 1)
+        opt_f(torch.randn(3))
+        opt_f(torch.randn(3, dtype=torch.float64))
+        self.assertEqual(cnt1.frame_count, 2)
+
+        # opt_g can still compile despite f.__code__ having 2+ entries
+        # (global recompile_limit=1 would block this without the override)
+        opt_g(torch.randn(4))
+        self.assertEqual(cnt2.frame_count, 1)
+
+        # opt_f hits its own region limit
+        opt_f(torch.randn(3, dtype=torch.float16))
+        self.assertEqual(cnt1.frame_count, 2)
+
+        # opt_g can compile once more (under its region limit of 2)
+        opt_g(torch.randn(4, dtype=torch.float64))
+        self.assertEqual(cnt2.frame_count, 2)
+
+        # opt_g hits its own region limit
+        opt_g(torch.randn(4, dtype=torch.float16))
+        self.assertEqual(cnt2.frame_count, 2)
+
+    @torch._dynamo.config.patch(recompile_limit=1, fail_on_recompile_limit_hit=True)
+    def test_region_recompile_limit_factory_pattern(self):
+        """Reproduces the factory pattern from the workplace post: a cached
+        factory creates torch.compile wrappers around the same inner function.
+        Without region_recompile_limit, the third factory instance hits the
+        global recompile_limit. With region_recompile_limit, each instance
+        gets its own budget."""
+        from functools import cache
+
+        def core(x):
+            return x.sum()
+
+        @cache
+        def factory(key):
+            @torch.compile(
+                fullgraph=True,
+                dynamic=False,
+                region_recompile_limit=1,
+            )
+            def frontend(x, n):
+                return core(x) + n
+
+            return frontend
+
+        # Each factory instance can compile once with its own budget,
+        # even though global recompile_limit=1 and fail_on_recompile_limit_hit=True
+        factory("foo")(torch.ones(3), 3)
+        factory("bar")(torch.ones(4), 3)
+        factory("baz")(torch.ones(5), 3)
+
+    @torch._dynamo.config.patch(accumulated_recompile_limit=3)
+    def test_region_recompile_limit_accumulated_still_applies(self):
+        """accumulated_recompile_limit still applies as a hard safety cap
+        even when region_recompile_limit is set."""
+        cnt = torch._dynamo.testing.CompileCounter()
+
+        def f(x):
+            return x.sin()
+
+        # region limit is high, but accumulated limit is low
+        opt_f = torch.compile(f, backend=cnt, region_recompile_limit=10)
+
+        opt_f(torch.randn(3))
+        opt_f(torch.randn(3, dtype=torch.float64))
+        opt_f(torch.randn(3, dtype=torch.float16))
+        # accumulated_recompile_limit=3 should cap here
+        opt_f(torch.randn(3, dtype=torch.bfloat16))
+        self.assertLessEqual(cnt.frame_count, 3)
+
     def test_region_recompile_limit_resume_exceeds_max_budget(self):
         """Resume function recompiles independently via global changes.
         With region_recompile_limit=3, f compiles once but the resume function

--- a/torch/_dynamo/cache_size.py
+++ b/torch/_dynamo/cache_size.py
@@ -199,7 +199,13 @@ def exceeds_recompile_limit(
     cache_size: CacheSizeRelevantForFrame, compile_id: CompileId
 ) -> tuple[bool, str]:
     """
-    Checks if we are exceeding the cache size limit.
+    Checks if we are exceeding the global cache size limit.
+
+    The global recompile_limit is per-code-object: each code object (including
+    resume functions from graph breaks) independently gets up to N recompilations.
+    The region_recompile_limit iterates on this by using the max recompilations
+    among all code objects in the region, so that once any code object in the
+    region hits the limit, all compilation in the region stops.
     """
     if cache_size.will_compilation_exceed_accumulated_limit():
         return True, "accumulated_recompile_limit"

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -1809,6 +1809,13 @@ def _compile(
 
         if cache_size.exceeds_region_recompile_limit:
             exceeded, limit_type = True, "region_recompile_limit"
+        elif cache_size.region_recompile_limit is not None:
+            # region_recompile_limit overrides config.recompile_limit, but
+            # accumulated_recompile_limit still applies as a hard safety cap.
+            if cache_size.will_compilation_exceed_accumulated_limit():
+                exceeded, limit_type = True, "accumulated_recompile_limit"
+            else:
+                exceeded, limit_type = False, ""
         else:
             exceeded, limit_type = exceeds_recompile_limit(cache_size, compile_id)
         if exceeded:
@@ -2245,7 +2252,13 @@ class ConvertFrame:
                 isinstance(e, exc.TorchDynamoException)
                 and e.frame_exec_strategy is not None
             ):
-                return ConvertFrameReturn(frame_exec_strategy=e.frame_exec_strategy)
+                return ConvertFrameReturn(
+                    frame_exec_strategy=e.frame_exec_strategy,
+                    # Don't apply strategy to the code object when
+                    # region_recompile_limit is set — other regions sharing
+                    # this code object should still be able to compile.
+                    apply_to_code=self._region_recompile_limit is None,
+                )
 
         return ConvertFrameReturn()
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #178307
* __->__ #177895
* #177894
* #177399
* #177355

## Summary

With previous PR giving per-region cache isolation, this PR makes `region_recompile_limit` a true
override of the global `config.recompile_limit`. Previously, even with per-region tracking,
the global limit would block compilation when the total cache entries on the shared code
object exceeded `config.recompile_limit`. This broke the factory pattern where multiple
`torch.compile()` wrappers around the same inner function would exhaust the global limit.

When `region_recompile_limit` is set:
1. The per-region limit is checked first (max across all code objects in the region)
2. If not exceeded, `config.recompile_limit` is **skipped** — only `accumulated_recompile_limit` (default 256) applies as a hard safety cap
3. `FrameExecStrategy` (RUN_ONLY) is not applied to the code object (`apply_to_code=False`), so one region hitting its limit doesn't poison other regions

## Factory pattern (from workplace post)

```python
@cache
def factory(key):
    @torch.compile(fullgraph=True, dynamic=False, region_recompile_limit=1)
    def frontend(x, n):
        return core(x) + n
    return frontend

# Each factory instance compiles independently, even with recompile_limit=1
factory("foo")(torch.ones(3), 3)  # compiles
factory("bar")(torch.ones(4), 3)  # compiles (separate region)
factory("baz")(torch.ones(5), 3)  # compiles (separate region)
```

## Test Plan

- `test_region_recompile_limit_overrides_global` — single region compiles past `config.recompile_limit` when `region_recompile_limit` is set higher
- `test_region_recompile_limit_factory_pattern` — reproduces the workplace post factory pattern with `fail_on_recompile_limit_hit=True`
- `test_region_recompile_limit_accumulated_still_applies` — `accumulated_recompile_limit` still caps even with `region_recompile_limit`



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo