### PR TITLE
[Inductor] Fix floor_divide precision for floating-point types

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -3673,10 +3673,9 @@ class CommonTemplate:
             self.common(fn, (a, b_neg))
 
     def test_floor_divide_float_precision(self):
-        # Regression test: naive floor(a / b) can give wrong results for float16
-        # due to rounding errors in the division step. The correct algorithm
+        # Regression test: naive floor(a / b) can give wrong results for low-precision
+        # floats due to rounding errors in the division step. The correct algorithm
         # (CPython's floordiv) uses fmod-based computation to avoid this.
-        # See https://github.com/pytorch/pytorch/issues/<floor_divide_bug>
         def fn(a, b):
             return torch.floor_divide(a, b)
 
@@ -3687,7 +3686,7 @@ class CommonTemplate:
             t1 = torch.tensor([21.078125], dtype=torch.float64).to(dtype)
             self.common(fn, (t0.to(self.device), t1.to(self.device)), check_lowp=False)
 
-        # Additional cases with negative values to verify sign handling.
+        # Negative values: verify the sign-correction branch in the fmod algorithm.
         for dtype in (torch.float16, torch.float32):
             t0 = torch.tensor([-84.3125], dtype=torch.float64).to(dtype)
             t1 = torch.tensor([21.078125], dtype=torch.float64).to(dtype)
@@ -3697,23 +3696,21 @@ class CommonTemplate:
             t1 = torch.tensor([-21.078125], dtype=torch.float64).to(dtype)
             self.common(fn, (t0.to(self.device), t1.to(self.device)), check_lowp=False)
 
-        # Very small divisor: result should be a large integer (or inf for float16 overflow).
-        # Exercises the fmod and quotient-adjustment paths with extreme values.
+        # Very small divisor: exercises the fmod and quotient-adjustment paths
+        # with extreme magnitude differences. float16 excluded as result overflows to inf.
         for dtype in (torch.float32, torch.float64):
             t0 = torch.tensor([1.0, -1.0, 3.5], dtype=dtype)
             t1 = torch.tensor([1e-6, 1e-6, 1e-6], dtype=dtype)
             self.common(fn, (t0.to(self.device), t1.to(self.device)), check_lowp=False)
 
-        # Mixed-precision inputs: PyTorch promotes to the higher dtype before dividing.
-        # Verify floor divide with promotion matches eager.
+        # Mixed-precision inputs: TensorIterator promotes to the higher dtype,
+        # so inductor and eager should agree on the promoted type and result.
         t0_fp16 = torch.tensor([84.3125], dtype=torch.float16)
         t1_fp32 = torch.tensor([21.078125], dtype=torch.float32)
-        # floor_divide promotes both to float32
         self.common(fn, (t0_fp16.to(self.device), t1_fp32.to(self.device)), check_lowp=False)
 
         t0_bf16 = torch.tensor([84.3125], dtype=torch.bfloat16)
         t1_fp16 = torch.tensor([21.078125], dtype=torch.float16)
-        # floor_divide promotes both to float32
         self.common(fn, (t0_bf16.to(self.device), t1_fp16.to(self.device)), check_lowp=False)
 
     def test_div_precision(self):

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -3707,11 +3707,15 @@ class CommonTemplate:
         # so inductor and eager should agree on the promoted type and result.
         t0_fp16 = torch.tensor([84.3125], dtype=torch.float16)
         t1_fp32 = torch.tensor([21.078125], dtype=torch.float32)
-        self.common(fn, (t0_fp16.to(self.device), t1_fp32.to(self.device)), check_lowp=False)
+        self.common(
+            fn, (t0_fp16.to(self.device), t1_fp32.to(self.device)), check_lowp=False
+        )
 
         t0_bf16 = torch.tensor([84.3125], dtype=torch.bfloat16)
         t1_fp16 = torch.tensor([21.078125], dtype=torch.float16)
-        self.common(fn, (t0_bf16.to(self.device), t1_fp16.to(self.device)), check_lowp=False)
+        self.common(
+            fn, (t0_bf16.to(self.device), t1_fp16.to(self.device)), check_lowp=False
+        )
 
     def test_div_precision(self):
         # Reproducer for https://github.com/pytorch/pytorch/issues/101039

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -3672,6 +3672,50 @@ class CommonTemplate:
             b_neg = torch.full_like(a, -divisor)
             self.common(fn, (a, b_neg))
 
+    def test_floor_divide_float_precision(self):
+        # Regression test: naive floor(a / b) can give wrong results for float16
+        # due to rounding errors in the division step. The correct algorithm
+        # (CPython's floordiv) uses fmod-based computation to avoid this.
+        # See https://github.com/pytorch/pytorch/issues/<floor_divide_bug>
+        def fn(a, b):
+            return torch.floor_divide(a, b)
+
+        # 84.3125 / 21.078125 = exactly 4.0, but naive floor(a/b) may give 3
+        # due to floating point rounding in the division.
+        for dtype in (torch.float16, torch.bfloat16, torch.float32):
+            t0 = torch.tensor([84.3125], dtype=torch.float64).to(dtype)
+            t1 = torch.tensor([21.078125], dtype=torch.float64).to(dtype)
+            self.common(fn, (t0.to(self.device), t1.to(self.device)), check_lowp=False)
+
+        # Additional cases with negative values to verify sign handling.
+        for dtype in (torch.float16, torch.float32):
+            t0 = torch.tensor([-84.3125], dtype=torch.float64).to(dtype)
+            t1 = torch.tensor([21.078125], dtype=torch.float64).to(dtype)
+            self.common(fn, (t0.to(self.device), t1.to(self.device)), check_lowp=False)
+
+            t0 = torch.tensor([84.3125], dtype=torch.float64).to(dtype)
+            t1 = torch.tensor([-21.078125], dtype=torch.float64).to(dtype)
+            self.common(fn, (t0.to(self.device), t1.to(self.device)), check_lowp=False)
+
+        # Very small divisor: result should be a large integer (or inf for float16 overflow).
+        # Exercises the fmod and quotient-adjustment paths with extreme values.
+        for dtype in (torch.float32, torch.float64):
+            t0 = torch.tensor([1.0, -1.0, 3.5], dtype=dtype)
+            t1 = torch.tensor([1e-6, 1e-6, 1e-6], dtype=dtype)
+            self.common(fn, (t0.to(self.device), t1.to(self.device)), check_lowp=False)
+
+        # Mixed-precision inputs: PyTorch promotes to the higher dtype before dividing.
+        # Verify floor divide with promotion matches eager.
+        t0_fp16 = torch.tensor([84.3125], dtype=torch.float16)
+        t1_fp32 = torch.tensor([21.078125], dtype=torch.float32)
+        # floor_divide promotes both to float32
+        self.common(fn, (t0_fp16.to(self.device), t1_fp32.to(self.device)), check_lowp=False)
+
+        t0_bf16 = torch.tensor([84.3125], dtype=torch.bfloat16)
+        t1_fp16 = torch.tensor([21.078125], dtype=torch.float16)
+        # floor_divide promotes both to float32
+        self.common(fn, (t0_bf16.to(self.device), t1_fp16.to(self.device)), check_lowp=False)
+
     def test_div_precision(self):
         # Reproducer for https://github.com/pytorch/pytorch/issues/101039
 

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -6772,13 +6772,21 @@ def div_floor_floating(a, b):
 
     Implements the CPython floordiv algorithm to avoid rounding errors from
     naive floor(a / b). See c10/util/generic_math.h:div_floor_floating.
+
+    Constants are typed to match the compute dtype of `a` (a CSEVariable in
+    Triton/CPP backends) to avoid int32/float type mismatches in generated code.
     """
-    zero = ops.constant(0, torch.int32)
-    one = ops.constant(1, torch.int32)
-    half = ops.constant(0.5, torch.float32)
+    # In Triton (codegen_upcast_to_fp32=True, the default), float16/bfloat16
+    # inputs are already upcast to float32 at load time, so a.dtype is float32
+    # or float64.  In CPP, a.dtype similarly reflects the compute type.
+    compute_dtype = getattr(a, "dtype", torch.float32)
+    zero = ops.constant(0.0, compute_dtype)
+    one = ops.constant(1.0, compute_dtype)
+    half = ops.constant(0.5, compute_dtype)
     mod = ops.fmod(a, b)
     # (a - mod) / b is more numerically accurate than a / b directly.
-    # Since fmod(a, b) has the same sign as a, sign(mod) != sign(b) iff sign(a) != sign(b).
+    # Since fmod(a, b) has the same sign as a, sign(mod) != sign(b) iff
+    # the inputs have opposite signs.
     adj_div = ops.truediv(ops.sub(a, mod), b)
     nonzero_mod = ops.ne(mod, zero)
     diff_signs = ops.ne(ops.signbit(mod), ops.signbit(b))
@@ -6793,11 +6801,10 @@ def div_floor_floating(a, b):
     )
     # When adj_div == 0, preserve the sign from true division.
     basic_div = ops.truediv(a, b)
-    zero_fp = ops.constant(0.0, torch.float32)
     floor_div = ops.where(
         ops.ne(adj_div, zero),
         floor_div,
-        ops.copysign(zero_fp, basic_div),
+        ops.copysign(zero, basic_div),
     )
     # When b == 0, return the IEEE 754 result from true division.
     return ops.where(ops.ne(b, zero), floor_div, basic_div)

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -6771,8 +6771,7 @@ def div_floor_floating(a, b):
     """Numerically correct floor division for floating-point types.
 
     Implements the CPython floordiv algorithm to avoid rounding errors from
-    naive floor(a / b). See c10/util/generic_math.h:div_floor_floating.
-
+    naive floor(a / b). Took inspiration from c10/util/generic_math.h:div_floor_floating.
     Constants are typed to match the compute dtype of `a` (a CSEVariable in
     Triton/CPP backends) to avoid int32/float type mismatches in generated code.
     """

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -6766,6 +6766,43 @@ def truncdiv(a, b):
     return ops.truncdiv(a, b)
 
 
+@make_pointwise
+def div_floor_floating(a, b):
+    """Numerically correct floor division for floating-point types.
+
+    Implements the CPython floordiv algorithm to avoid rounding errors from
+    naive floor(a / b). See c10/util/generic_math.h:div_floor_floating.
+    """
+    zero = ops.constant(0, torch.int32)
+    one = ops.constant(1, torch.int32)
+    half = ops.constant(0.5, torch.float32)
+    mod = ops.fmod(a, b)
+    # (a - mod) / b is more numerically accurate than a / b directly.
+    # Since fmod(a, b) has the same sign as a, sign(mod) != sign(b) iff sign(a) != sign(b).
+    adj_div = ops.truediv(ops.sub(a, mod), b)
+    nonzero_mod = ops.ne(mod, zero)
+    diff_signs = ops.ne(ops.signbit(mod), ops.signbit(b))
+    adj_div = ops.where(
+        ops.and_(nonzero_mod, diff_signs), ops.sub(adj_div, one), adj_div
+    )
+    floor_div = ops.floor(adj_div)
+    floor_div = ops.where(
+        ops.gt(ops.sub(adj_div, floor_div), half),
+        ops.add(floor_div, one),
+        floor_div,
+    )
+    # When adj_div == 0, preserve the sign from true division.
+    basic_div = ops.truediv(a, b)
+    zero_fp = ops.constant(0.0, torch.float32)
+    floor_div = ops.where(
+        ops.ne(adj_div, zero),
+        floor_div,
+        ops.copysign(zero_fp, basic_div),
+    )
+    # When b == 0, return the IEEE 754 result from true division.
+    return ops.where(ops.ne(b, zero), floor_div, basic_div)
+
+
 @register_lowering(aten.div, broadcast=True)
 def div_mode(a, b, rounding_mode=None):
     both_integer = is_integer_type(a) and is_integer_type(b)
@@ -6775,7 +6812,7 @@ def div_mode(a, b, rounding_mode=None):
     # see the discussion at https://github.com/triton-lang/triton/issues/605
     if rounding_mode == "floor":
         assert not both_boolean, "floordiv operands can not be boolean at the same time"
-        return floordiv(a, b) if both_integer else floor(div(a, b))
+        return floordiv(a, b) if both_integer else div_floor_floating(a, b)
     if rounding_mode == "trunc":
         assert not both_boolean, "truncdiv operands can not be boolean at the same time"
         return truncdiv(a, b) if both_integer else trunc(div(a, b))


### PR DESCRIPTION
Fixes [177740](https://github.com/pytorch/pytorch/issues/177740)

Replaced floor(div(a, b)) with a numerically correct div_floor_floating pointwise kernel in lowering.py, 
implementing the same CPython/PyTorch eager algorithm from c10/util/generic_math.h:div_floor_floating

Added rigorous testing to track variations.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo