### PR TITLE
[inductor] Parallelize PTX-to-fatbin compilation

### DIFF
--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -2542,6 +2542,7 @@ end
 
             cubins_o = []
             asm_files = []
+            fatbin_cmds: list[tuple[str, str]] = []
             if not _IS_WINDOWS:
                 cubins_to_embed: list[tuple[str, str]] = []
                 ld, objcopy = get_ld_and_objcopy(use_relative_path)
@@ -2561,30 +2562,7 @@ end
                         and device_type == "cuda"
                     ):
                         if torch.version.hip is None:
-                            current_arch = (
-                                cuda_compile_utils._nvcc_arch_as_compile_option()
-                            )
-                            cmd = (
-                                # pyrefly: ignore [unbound-name]
-                                f"{cuda_compile_utils._cuda_compiler()} -fatbin {asm_file} -o {cubin_file} "
-                                # Triton only allows generating PTX version as same as the current arch
-                                f"-gencode arch=compute_{current_arch},code=compute_{current_arch} "
-                                # Include SASS for the current specific arch
-                                f"-gencode arch=compute_{current_arch},code=sm_{current_arch} "
-                            )
-                            try:
-                                subprocess.run(
-                                    cmd.split(),
-                                    capture_output=True,
-                                    text=True,
-                                    check=True,
-                                )
-                            except subprocess.CalledProcessError as e:
-                                print(
-                                    f"{cmd} failed with:\nstdout:\n{e.stdout}\nstderr:\n{e.stderr}",
-                                    file=sys.stderr,
-                                )
-                                raise
+                            fatbin_cmds.append((asm_file, cubin_file))
 
                         else:
                             # ROCm multi-arch: compile LLVM IR to multi-arch bundle
@@ -2619,6 +2597,35 @@ end
 
                     if config.aot_inductor.embed_kernel_binary:
                         cubins_to_embed.append((cubin_file, kernel_name))
+
+                # Compile PTX → fatbin in parallel (each nvcc call is independent).
+                # Must complete before cubin embedding below.
+                if fatbin_cmds:
+                    from concurrent.futures import ThreadPoolExecutor
+
+                    current_arch = cuda_compile_utils._nvcc_arch_as_compile_option()
+                    nvcc = cuda_compile_utils._cuda_compiler()
+
+                    def _compile_fatbin(asm_and_cubin: tuple[str, str]) -> None:
+                        asm_f, cubin_f = asm_and_cubin
+                        cmd = (
+                            f"{nvcc} -fatbin {asm_f} -o {cubin_f} "
+                            f"-gencode arch=compute_{current_arch},code=compute_{current_arch} "
+                            f"-gencode arch=compute_{current_arch},code=sm_{current_arch} "
+                        )
+                        try:
+                            subprocess.run(
+                                cmd.split(), capture_output=True, text=True, check=True
+                            )
+                        except subprocess.CalledProcessError as e:
+                            print(
+                                f"{cmd} failed with:\nstdout:\n{e.stdout}\nstderr:\n{e.stderr}",
+                                file=sys.stderr,
+                            )
+                            raise
+
+                    with ThreadPoolExecutor() as pool:
+                        list(pool.map(_compile_fatbin, fatbin_cmds))
 
                 if cubins_to_embed:
                     # Batch all cubins into a single .o using .incbin assembly.


### PR DESCRIPTION
When emit_multi_arch_kernel is enabled, each Triton kernel's PTX is
compiled to a fatbin via nvcc. The previous code used subprocess.run()
inside the kernel loop — a blocking call that starts nvcc, waits for
it to exit, then starts the next one. Each nvcc ran alone.

For a 40-layer MoE model with 86 kernels at ~6s each, this serial
pattern adds ~9 minutes. Since each nvcc call operates on independent
files with no shared state, they can run concurrently.

Collect all (ptx, fatbin) pairs during the loop, then dispatch them
via ThreadPoolExecutor (already used elsewhere in this file). Each
subprocess.run() releases the GIL, so nvcc processes truly run in
parallel.

Validation script: https://gist.github.com/mergennachin/b8a9db40ad588935dd23d3a54c2fb68b

Creates 20 dummy PTX files, compiles to fatbin both serial and
parallel, verifies output is bit-identical (MD5 match) and measures
speedup:

```
$ python test_parallel_fatbin.py
nvcc: /usr/local/cuda/bin/nvcc
arch: sm_80
kernels: 20

Serial:   1.43s (71ms per kernel)
Parallel: 0.35s (18ms per kernel)
Speedup:  4.1x

Sizes match:  True
Hashes match: True

PASS
```


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo