### PR TITLE
Add CSAN awareness of NCCL collective operations

### DIFF
--- a/c10/core/impl/PyInterpreter.cpp
+++ b/c10/core/impl/PyInterpreter.cpp
@@ -138,6 +138,12 @@ struct NoopPyInterpreterVTable final : public PyInterpreterVTable {
   void trace_gpu_event_synchronization(
       c10::DeviceType device_type,
       uintptr_t event) const override {}
+  void trace_gpu_collective_launch(
+      uintptr_t stream,
+      const uintptr_t* input_data_ptrs,
+      size_t num_inputs,
+      const uintptr_t* output_data_ptrs,
+      size_t num_outputs) const override {}
 
   void reset_backward_hooks(const TensorImpl* self) const override {
     PANIC(reset_backward_hooks);

--- a/c10/core/impl/PyInterpreter.h
+++ b/c10/core/impl/PyInterpreter.h
@@ -223,6 +223,17 @@ struct C10_API PyInterpreterVTable {
       c10::DeviceType device_type,
       uintptr_t event) const = 0;
 
+  // Notify tracing tools (e.g. CSAN) that an NCCL collective was launched on
+  // `stream`, reading from `input_data_ptrs` and writing to
+  // `output_data_ptrs`.  This lets the sanitizer model happens-before edges
+  // through the otherwise-invisible NCCL internal stream.
+  virtual void trace_gpu_collective_launch(
+      uintptr_t stream,
+      const uintptr_t* input_data_ptrs,
+      size_t num_inputs,
+      const uintptr_t* output_data_ptrs,
+      size_t num_outputs) const = 0;
+
   virtual void reset_backward_hooks(const TensorImpl* self) const = 0;
 };
 

--- a/torch/csrc/PyInterpreter.cpp
+++ b/torch/csrc/PyInterpreter.cpp
@@ -150,6 +150,35 @@ struct ConcretePyInterpreterVTable final
     CONCRETE_GPU_TRACE(device_type, "EventSynchronizationCallbacks", event);
   }
 
+  void trace_gpu_collective_launch(
+      uintptr_t stream,
+      const uintptr_t* input_data_ptrs,
+      size_t num_inputs,
+      const uintptr_t* output_data_ptrs,
+      size_t num_outputs) const override {
+    at::impl::MaybeSetTLSOnEntryGuard guard;
+    if (Py_IsInitialized()) {
+      pybind11::gil_scoped_acquire gil;
+      try {
+        py::module mod = py::module::import("torch.cuda._gpu_trace");
+        py::object hook =
+            mod.attr("CollectiveLaunchCallbacks").attr("fire_callbacks");
+        py::list inputs;
+        py::list outputs;
+        for (size_t i = 0; i < num_inputs; i++) {
+          inputs.append(input_data_ptrs[i]);
+        }
+        for (size_t i = 0; i < num_outputs; i++) {
+          outputs.append(output_data_ptrs[i]);
+        }
+        hook(stream, inputs, outputs);
+      } catch (const std::exception& e) {
+        LOG(ERROR) << "CUDA collective trace hook execution failed: "
+                   << e.what();
+      }
+    }
+  }
+
   void reset_backward_hooks(const c10::TensorImpl* self) const override;
 
   static ConcretePyInterpreterVTable* instance() {

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -35,6 +35,7 @@
 #include <torch/csrc/distributed/c10d/Utils.hpp>
 #include <torch/csrc/distributed/c10d/cuda/utils.hpp>
 #include <torch/torch.h>
+#include <c10/core/impl/GPUTrace.h>
 #include <optional>
 
 namespace c10d {
@@ -2474,9 +2475,11 @@ void ProcessGroupNCCL::Watchdog::runLoop() {
         // structure owned by the PG.
         if (!work.stashed_for_allocator_safety_->empty()) {
           std::lock_guard<std::mutex> lock(pg_->shelvesMutex_);
-          // We are just pushing back a shared_ptr here, so the cost should be
-          // minimal
-          pg_->shelvesToUnstash_.push_back(work.stashed_for_allocator_safety_);
+          // Pair the shelf with its NCCL end event so that workEnqueue can
+          // block the current stream on the event before unstashing.  This
+          // ensures the CUDA caching allocator sees the NCCL completion.
+          pg_->shelvesToUnstash_.emplace_back(
+              work.stashed_for_allocator_safety_, work.ncclEndEvent_);
         }
 
         if (pg_->enableTiming_ && logger) {
@@ -3580,7 +3583,15 @@ void ProcessGroupNCCL::workEnqueue(
   // that would be triggered by a next user call.
   {
     std::lock_guard<std::mutex> lock(shelvesMutex_);
-    for (auto& shelf : shelvesToUnstash_) {
+    for (auto& [shelf, endEvent] : shelvesToUnstash_) {
+      // Block the current stream on the NCCL end event before releasing
+      // tensors.  This ensures the CUDA caching allocator knows the NCCL
+      // operation has completed and won't recycle memory prematurely.
+      if (endEvent) {
+        auto currentStream = at::cuda::getCurrentCUDAStream(
+            endEvent->device_index());
+        endEvent->block(currentStream);
+      }
       shelf->unstash();
     }
     shelvesToUnstash_.clear();
@@ -3693,6 +3704,26 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::endCoalescing(OpType optype) {
   // Record end after ncclGroupEnd
   // TODO(eqy): is this still necessary if avoidRecordStreams_ is set?
   work->ncclEndEvent_->record(ncclStream);
+
+  // Notify GPU trace (e.g. CSAN) about tensor accesses on the NCCL stream
+  // for the coalesced group.  We treat all stashed tensors as read-write since
+  // we don't have per-op input/output separation for the coalesced group.
+  {
+    const c10::impl::PyInterpreter* interp =
+        c10::impl::GPUTrace::get_trace();
+    if (C10_UNLIKELY(interp)) {
+      std::vector<uintptr_t> dataPtrs;
+      for (const auto& t : coalescedTensors_.get()) {
+        dataPtrs.push_back(reinterpret_cast<uintptr_t>(t.data_ptr()));
+      }
+      (*interp)->trace_gpu_collective_launch(
+          reinterpret_cast<uintptr_t>(ncclStream.stream()),
+          dataPtrs.data(),
+          dataPtrs.size(),
+          dataPtrs.data(),
+          dataPtrs.size());
+    }
+  }
 
   if (enqueue) {
     workEnqueue(work);
@@ -3910,6 +3941,30 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::collective(
   // End event should only be recorded after the ncclGroupEnd()
   if (!coalescing_state_) {
     work->ncclEndEvent_->record(ncclStream);
+
+    // Notify GPU trace (e.g. CSAN) about tensor accesses on the NCCL stream
+    // so that the sanitizer can model the happens-before relationship through
+    // the otherwise-invisible NCCL internal stream.
+    const c10::impl::PyInterpreter* interp =
+        c10::impl::GPUTrace::get_trace();
+    if (C10_UNLIKELY(interp)) {
+      std::vector<uintptr_t> inputPtrs;
+      std::vector<uintptr_t> outputPtrs;
+      inputPtrs.reserve(inputs.size());
+      outputPtrs.reserve(outputs.size());
+      for (const auto& t : inputs) {
+        inputPtrs.push_back(reinterpret_cast<uintptr_t>(t.data_ptr()));
+      }
+      for (const auto& t : outputs) {
+        outputPtrs.push_back(reinterpret_cast<uintptr_t>(t.data_ptr()));
+      }
+      (*interp)->trace_gpu_collective_launch(
+          reinterpret_cast<uintptr_t>(ncclStream.stream()),
+          inputPtrs.data(),
+          inputPtrs.size(),
+          outputPtrs.data(),
+          outputPtrs.size());
+    }
   }
   work->ncclComm_ = ncclComm;
 
@@ -4080,6 +4135,31 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::collectiveCoalesced(
   }
 
   work->ncclEndEvent_->record(ncclStream);
+
+  // Notify GPU trace (e.g. CSAN) about tensor accesses on the NCCL stream
+  {
+    const c10::impl::PyInterpreter* interp =
+        c10::impl::GPUTrace::get_trace();
+    if (C10_UNLIKELY(interp)) {
+      std::vector<uintptr_t> inputPtrs;
+      std::vector<uintptr_t> outputPtrs;
+      inputPtrs.reserve(inputs.size());
+      outputPtrs.reserve(outputs.size());
+      for (const auto& t : inputs) {
+        inputPtrs.push_back(reinterpret_cast<uintptr_t>(t.data_ptr()));
+      }
+      for (const auto& t : outputs) {
+        outputPtrs.push_back(reinterpret_cast<uintptr_t>(t.data_ptr()));
+      }
+      (*interp)->trace_gpu_collective_launch(
+          reinterpret_cast<uintptr_t>(ncclStream.stream()),
+          inputPtrs.data(),
+          inputPtrs.size(),
+          outputPtrs.data(),
+          outputPtrs.size());
+    }
+  }
+
   work->ncclComm_ = ncclComm;
 
   {

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -263,7 +263,6 @@ class TensorShelf {
   // Clear the shelf.
   void clear();
 
- protected:
   // Get the inner tensor vector. Use with caution as it is not protected by
   // mutex.
   std::vector<at::Tensor>& get();
@@ -1436,7 +1435,13 @@ class TORCH_API ProcessGroupNCCL : public Backend {
   // on main thread, we clear the `shelves` in one shot. This is mainly because
   // watchdog (a side thread) unstashing the shelf directly seems to cause some
   // problem.
-  std::vector<std::shared_ptr<TensorShelf>> shelvesToUnstash_;
+  // Each entry pairs a tensor shelf with the NCCL end event that marks
+  // completion of the collective that produced those tensors.  Before
+  // unstashing, we block the current stream on the end event so that the
+  // CUDA caching allocator sees the NCCL completion.
+  std::vector<
+      std::pair<std::shared_ptr<TensorShelf>, std::shared_ptr<at::cuda::CUDAEvent>>>
+      shelvesToUnstash_;
   std::mutex shelvesMutex_;
 
   // Whether or not wait() and synchronize() are blocking operations that wait

--- a/torch/cuda/_gpu_trace.py
+++ b/torch/cuda/_gpu_trace.py
@@ -31,6 +31,9 @@ StreamSynchronizationCallbacks: "CallbackRegistry[int]" = CallbackRegistry(
 EventSynchronizationCallbacks: "CallbackRegistry[int]" = CallbackRegistry(
     "CUDA event synchronization"
 )
+CollectiveLaunchCallbacks: "CallbackRegistry[int, list[int], list[int]]" = (
+    CallbackRegistry("CUDA collective launch")
+)
 
 
 def register_callback_for_event_creation(cb: Callable[[int], None]) -> None:
@@ -71,3 +74,9 @@ def register_callback_for_stream_synchronization(cb: Callable[[int], None]) -> N
 
 def register_callback_for_event_synchronization(cb: Callable[[int], None]) -> None:
     EventSynchronizationCallbacks.add_callback(cb)
+
+
+def register_callback_for_collective_launch(
+    cb: Callable[[int, list[int], list[int]], None],
+) -> None:
+    CollectiveLaunchCallbacks.add_callback(cb)

--- a/torch/cuda/_sanitizer.py
+++ b/torch/cuda/_sanitizer.py
@@ -464,6 +464,34 @@ class EventHandler:
     def _handle_event_synchronization(self, event: EventId) -> None:
         self.syncs.all_streams_wait_for_event(event)
 
+    def _handle_collective_launch(
+        self,
+        stream: StreamId,
+        input_data_ptrs: list[int],
+        output_data_ptrs: list[int],
+    ) -> None:
+        """Register tensor accesses for an NCCL collective on the NCCL stream.
+
+        This is called from the C++ GPUTrace callback when ProcessGroupNCCL
+        launches a collective.  It records reads of input tensors and writes of
+        output tensors on the NCCL stream so that CSAN's vector-clock algorithm
+        can properly model the happens-before relationship.
+        """
+        input_set = set(input_data_ptrs)
+        output_set = set(output_data_ptrs)
+        read_only = {p for p in input_set if p != 0} - output_set
+        read_write = {p for p in output_set if p != 0}
+        outputs = read_write.copy()
+        tensor_aliases: dict[int, list[str]] = {
+            ptr: [] for ptr in read_only | read_write
+        }
+        errors = self._handle_kernel_launch(
+            stream, read_only, read_write, outputs, "nccl::collective", tensor_aliases
+        )
+        if errors:
+            for error in errors:
+                logger.warning("CSAN detected potential race in NCCL collective:\n%s", error)
+
 
 def zip_by_key(a: dict[TK, TVa], b: dict[TK, TVb]) -> Iterator[tuple[TK, TVa, TVb]]:
     for arg, value in a.items():
@@ -589,6 +617,9 @@ class CUDASanitizerDispatchMode(TorchDispatchMode):
         )
         gpu_trace.register_callback_for_event_synchronization(
             self.event_handler._handle_event_synchronization
+        )
+        gpu_trace.register_callback_for_collective_launch(
+            self.event_handler._handle_collective_launch
         )
 
     def __torch_dispatch__(self, func, types, args=(), kwargs=None):


### PR DESCRIPTION
CSAN (CUDA Sanitizer) could not previously detect or correctly model NCCL collective operations because they execute on internal NCCL streams invisible to CSAN's aten-dispatch-level tracing.  This caused false positive race reports for legitimate pipelined training patterns (e.g. torchrec's TrainPipelineSparseDist).

This change adds two fixes:

1. New GPUTrace callback `trace_gpu_collective_launch`: fired from ProcessGroupNCCL after each collective (in `collective()`, `collectiveCoalesced()`, and `endCoalescing()`), passing the NCCL stream ID and input/output tensor data pointers to CSAN.  CSAN registers these as read/write accesses on the NCCL stream, allowing its vector-clock algorithm to properly model the happens-before relationship through NCCL's internal streams.

2. Fix watchdog tensor unstash path: when the watchdog detects NCCL work completion and transfers stashed tensors to `shelvesToUnstash_` for cleanup on the main thread, the NCCL end event is now paired with the shelf.  Before unstashing, `workEnqueue()` blocks the current stream on the end event, ensuring the CUDA caching allocator sees the NCCL completion before recycling memory.

Claude Sonnet 4.6 assisted this analysis and fix.