### PR TITLE
Use _make_graph_module in split_module to support lazy recompile

### DIFF
--- a/test/test_fx_experimental.py
+++ b/test/test_fx_experimental.py
@@ -45,6 +45,7 @@ from torch.fx.operator_schemas import (
 from torch.fx.passes import graph_manipulation
 from torch.fx.passes.param_fetch import lift_lowering_attrs_to_nodes
 from torch.fx.passes.shape_prop import ShapeProp
+from torch.fx._lazy_graph_module import _use_lazy_graph_module
 from torch.fx.passes.split_module import split_module
 from torch.fx.passes.annotate_getitem_nodes import annotate_getitem_nodes
 from torch.testing._internal.common_device_type import (
@@ -54,7 +55,14 @@ from torch.testing._internal.common_device_type import (
 )
 from torch.testing._internal.common_methods_invocations import op_db
 from torch.testing._internal.common_nn import module_tests, get_new_module_tests
-from torch.testing._internal.common_utils import TEST_Z3, run_tests, TestCase, TEST_WITH_CROSSREF
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+    TEST_Z3,
+    run_tests,
+    TestCase,
+    TEST_WITH_CROSSREF,
+)
 from torch.testing._internal.jit_utils import JitTestCase
 import torch.utils._pytree as pytree
 
@@ -754,7 +762,8 @@ terrible spacing
         # Confirm that the output is correct
         self.assertEqual(traced(3, 3), m(3, 3))
 
-    def test_subgraph_creation(self):
+    @parametrize("use_lazy", [True, False])
+    def test_subgraph_creation(self, use_lazy):
         class MyModule(torch.nn.Module):
             def __init__(self) -> None:
                 super().__init__()
@@ -786,9 +795,10 @@ terrible spacing
             return partition
 
         # split module in module with submodules
-        module_with_submodules = split_module(
-            my_module_traced, my_module, mod_partition
-        )
+        with _use_lazy_graph_module(use_lazy):
+            module_with_submodules = split_module(
+                my_module_traced, my_module, mod_partition
+            )
 
         # Check that test_meta_info was still on all nodes.
         submodules = dict(module_with_submodules.named_modules())
@@ -2152,6 +2162,7 @@ if TEST_Z3:
                 self.assertEqual(z3str(expr), expected)
 
 
+instantiate_parametrized_tests(TestFXExperimental)
 instantiate_device_type_tests(TestNormalizeOperators, globals())
 
 if __name__ == "__main__":

--- a/torch/fx/passes/split_module.py
+++ b/torch/fx/passes/split_module.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import torch
 from torch.fx._compatibility import compatibility
+from torch.fx._lazy_graph_module import _make_graph_module
 from torch.fx._utils import lazy_format_graph_code
 from torch.fx.graph_module import GraphModule
 from torch.fx.node import Node
@@ -638,7 +639,7 @@ def split_module(
                 )
                 already_constructed_attr_nodes.add(node)
 
-        base_mod_attrs[partition.submod_name] = torch.fx.graph_module.GraphModule(
+        base_mod_attrs[partition.submod_name] = _make_graph_module(
             partition.targets, partition.graph
         )  # noqa: B950
 
@@ -674,7 +675,7 @@ def split_module(
                 torch.fx.graph.map_arg(node.args[0], lambda n: base_mod_env[n.name])
             )  # noqa: B950
 
-    ret = torch.fx.graph_module.GraphModule(base_mod_attrs, base_mod_graph)
+    ret = _make_graph_module(base_mod_attrs, base_mod_graph)
     log.debug(
         "%s",
         lazy_format_graph_code("post split_module", ret, colored=True),


### PR DESCRIPTION
Replace direct GraphModule() constructor calls with _make_graph_module() which respects the lazy graph module context (_use_lazy_graph_module). When lazy mode is active, this defers recompile() during GraphModule construction, avoiding expensive python_code() generation for each partition (~226ms savings for graphs with ~57 partitions).

Co-authored-by: Claude