### PR TITLE
[dynamo] Skip clone for frozen traceable wrapper subclass tensors

### DIFF
--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -2423,6 +2423,10 @@ def clone_input(x: torch.Tensor, *, dtype: torch.dtype | None = None) -> torch.T
                 layout=x.layout,
             )
         elif is_traceable_wrapper_subclass(x):
+            if not x.requires_grad:
+                # Frozen weights (e.g., quantized) are never mutated.
+                # Cloning them through __torch_dispatch__ is slow.
+                return x
             # Questionable - but this is required to not fail executorch related
             # torchao tests.
             return torch_clone(x)


### PR DESCRIPTION
Cloning torchao quantized tensors goes through __torch_dispatch__,
~3ms each. For large quantized models (1,671 weights), this adds
minutes to export. Frozen weights are never mutated, so skip the
clone.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98 @mlazos @Lucaskabela