### PR TITLE
fix(linalg): validate lu_unpack pivot shape before unpack kernel

### DIFF
--- a/aten/src/ATen/native/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebra.cpp
@@ -776,6 +776,20 @@ TORCH_META_FUNC(lu_unpack)(const Tensor& LU, const Tensor& pivots, bool unpack_d
     TORCH_CHECK(pivots.scalar_type() == at::kInt,
         "torch.lu_unpack: LU_pivots is expected to be a contiguous tensor of torch.int32 dtype.\n"
         "Note: this function is intended to be used with the output produced by torch.linalg.lu_factor");
+    TORCH_CHECK(
+        pivots.dim() == LU.dim() - 1,
+        "torch.lu_unpack: Expected LU_pivots to have one fewer dimension than LU_data, but got LU_data with shape ",
+        LU.sizes(),
+        " and LU_pivots with shape ",
+        pivots.sizes(),
+        " instead");
+    TORCH_CHECK(
+        LU.sizes().slice(0, LU.dim() - 2).equals(pivots.sizes().slice(0, pivots.dim() - 1)),
+        "torch.lu_unpack: Expected LU_pivots.shape[:-1] to match LU_data.shape[:-2], but got LU_data with shape ",
+        LU.sizes(),
+        " and LU_pivots with shape ",
+        pivots.sizes(),
+        " instead");
   }
 
   auto sizes = LU.sizes().vec();
@@ -786,6 +800,14 @@ TORCH_META_FUNC(lu_unpack)(const Tensor& LU, const Tensor& pivots, bool unpack_d
   // P.shape[-2:] == (m, m) (or size zero if pivot == False)
   sizes.end()[-1] = m;
   if (unpack_pivots) {
+    TORCH_CHECK(
+        pivots.size(-1) == k,
+        "torch.lu_unpack: Number of pivots per batch should be min(LU_data.size(-2), LU_data.size(-1)). ",
+        "Expected ",
+        k,
+        ", but got ",
+        pivots.size(-1),
+        " instead");
     set_output_raw_strided(0, sizes, {}, LU.options(), {});
   } else {
     set_output_raw_strided(0, {0}, {}, LU.options(), {});

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -7241,6 +7241,11 @@ class TestLinalg(TestCase):
 
         with self.assertRaisesRegex(RuntimeError, "torch.int32 dtype"):
             torch.lu_unpack(lu_data, lu_pivots.long())
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "Number of pivots per batch should be min\\(LU_data.size\\(-2\\), LU_data.size\\(-1\\)\\)",
+        ):
+            torch.lu_unpack(lu_data, lu_pivots[..., :0])
 
         # check that once flags are unset, Nones are returned
         p, l, u = torch.lu_unpack(lu_data, lu_pivots, unpack_data=False)

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -1468,12 +1468,33 @@ def lu_unpack_meta(
                 "Note: this function is intended to be used with the output produced by torch.linalg.lu_factor"
             ),
         )
+        torch._check(
+            pivots.ndim == LU.ndim - 1,
+            lambda: (
+                "torch.lu_unpack: Expected LU_pivots to have one fewer dimension than LU_data, "
+                f"but got LU_data with shape {LU.shape} and LU_pivots with shape {pivots.shape} instead"
+            ),
+        )
+        torch._check(
+            pivots.shape[:-1] == LU.shape[:-2],
+            lambda: (
+                "torch.lu_unpack: Expected LU_pivots.shape[:-1] to match LU_data.shape[:-2], "
+                f"but got LU_data with shape {LU.shape} and LU_pivots with shape {pivots.shape} instead"
+            ),
+        )
     sizes = list(LU.shape)
     m = sizes[-2]
     n = sizes[-1]
     k = min(m, n)
     sizes[-1] = m
     if unpack_pivots:
+        torch._check(
+            pivots.size(-1) == k,
+            lambda: (
+                "torch.lu_unpack: Number of pivots per batch should be min(LU_data.size(-2), "
+                f"LU_data.size(-1)). Expected {k}, but got {pivots.size(-1)} instead"
+            ),
+        )
         P = LU.new_empty(sizes)
     else:
         P = LU.new_empty([0])


### PR DESCRIPTION
## Summary
- add shape validation for `torch.lu_unpack` pivots in C++ meta to prevent out-of-bounds reads
- mirror the same validation in Python meta registration to keep fake/meta behavior aligned
- add a regression test in `test_linalg.py` for empty pivots

## Root cause
`lu_unpack` validated pivot dtype but not pivot shape. When `LU_pivots` is empty (or otherwise too short), the unpack kernel indexed past the pivot buffer and could segfault.

## Testing
- `/mnt/d/ubuntu/27/OSS_1/pytorch/.venv/bin/python -m compileall /mnt/d/ubuntu/27/OSS_1/pytorch/torch/_meta_registrations.py /mnt/d/ubuntu/27/OSS_1/pytorch/test/test_linalg.py`
- `/mnt/d/ubuntu/27/OSS_1/pytorch/.venv/bin/python /mnt/d/ubuntu/27/OSS_1/pytorch/test/test_linalg.py -k test_lu_unpack_check_input -v` (on current upstream wheel, this test reproduces the pre-fix crash path and terminates at the lu_unpack empty-pivots case)

Fixes #177829