### PR TITLE
[inductor] Add inline_asm_elementwise higher-order operator

### DIFF
--- a/test/higher_order_ops/test_inline_asm_elementwise.py
+++ b/test/higher_order_ops/test_inline_asm_elementwise.py
@@ -1,0 +1,585 @@
+# Owner(s): ["module: higher order operators"]
+"""
+Tests for inline_asm_elementwise higher-order operator.
+
+Tests verify:
+1. Bitwise equivalence between eager (Jiterator) and compiled (Inductor) paths
+2. Correctness via approximate comparison with reference PyTorch ops
+"""
+
+import unittest
+from collections.abc import Callable
+from dataclasses import dataclass
+
+import torch
+from torch._higher_order_ops.inline_asm_elementwise import inline_asm_elementwise
+from torch.testing._internal.common_cuda import SM70OrLater
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+    run_tests,
+    TEST_CUDA,
+    TestCase,
+)
+
+
+@dataclass
+class AsmTestCase:
+    name: str
+    input_gen_fn: Callable
+    asm_str: str
+    constraints: str
+    dtype: torch.dtype
+    approx_fn: Callable
+    pack: int = 1
+    compile_only: bool = False
+    min_sm: int = 70
+
+
+TEST_CASES = [
+    # Basic float32 operations
+    AsmTestCase(
+        "identity_f32",
+        lambda: (torch.randn(100, device="cuda", dtype=torch.float32),),
+        "mov.f32 $0, $1;",
+        "=f,f",
+        torch.float32,
+        lambda x: x,
+    ),
+    AsmTestCase(
+        "add_f32",
+        lambda: (
+            torch.randn(100, device="cuda", dtype=torch.float32),
+            torch.randn(100, device="cuda", dtype=torch.float32),
+        ),
+        "add.f32 $0, $1, $2;",
+        "=f,f,f",
+        torch.float32,
+        lambda x, y: x + y,
+    ),
+    AsmTestCase(
+        "mul_f32",
+        lambda: (
+            torch.randn(100, device="cuda", dtype=torch.float32),
+            torch.randn(100, device="cuda", dtype=torch.float32),
+        ),
+        "mul.f32 $0, $1, $2;",
+        "=f,f,f",
+        torch.float32,
+        lambda x, y: x * y,
+    ),
+    AsmTestCase(
+        "fma_f32",
+        lambda: (
+            torch.randn(100, device="cuda", dtype=torch.float32),
+            torch.randn(100, device="cuda", dtype=torch.float32),
+            torch.randn(100, device="cuda", dtype=torch.float32),
+        ),
+        "fma.rn.f32 $0, $1, $2, $3;",
+        "=f,f,f,f",
+        torch.float32,
+        lambda a, b, c: a * b + c,
+    ),
+    # Multi-line PTX with curly braces
+    AsmTestCase(
+        "double_multiline",
+        lambda: (torch.randn(100, device="cuda", dtype=torch.float32),),
+        "{.reg .f32 tmp; mov.f32 tmp, $1; add.f32 $0, tmp, tmp;}",
+        "=f,f",
+        torch.float32,
+        lambda x: x * 2,
+    ),
+    # bf16/fp16 upcasting (compile-only: Jiterator can't handle dtype mismatch)
+    AsmTestCase(
+        "bf16_upcast",
+        lambda: (torch.randn(100, device="cuda", dtype=torch.bfloat16),),
+        "add.f32 $0, $1, $1;",
+        "=f,f",
+        torch.float32,
+        lambda x: x.float() * 2,
+        compile_only=True,
+        min_sm=80,
+    ),
+    AsmTestCase(
+        "fp16_upcast",
+        lambda: (torch.randn(100, device="cuda", dtype=torch.float16),),
+        "add.f32 $0, $1, $1;",
+        "=f,f",
+        torch.float32,
+        lambda x: x.float() * 2,
+        compile_only=True,
+    ),
+    # Integer operations
+    AsmTestCase(
+        "bitwise_and",
+        lambda: (
+            torch.randint(0, 2**16, (100,), device="cuda", dtype=torch.int32),
+            torch.randint(0, 2**16, (100,), device="cuda", dtype=torch.int32),
+        ),
+        "and.b32 $0, $1, $2;",
+        "=r,r,r",
+        torch.int32,
+        lambda x, y: x & y,
+    ),
+    AsmTestCase(
+        "bitwise_or",
+        lambda: (
+            torch.randint(0, 2**16, (100,), device="cuda", dtype=torch.int32),
+            torch.randint(0, 2**16, (100,), device="cuda", dtype=torch.int32),
+        ),
+        "or.b32 $0, $1, $2;",
+        "=r,r,r",
+        torch.int32,
+        lambda x, y: x | y,
+    ),
+    # Output dtype differs from input (compile-only: Jiterator returns input dtype)
+    AsmTestCase(
+        "exponent_extract",
+        lambda: (
+            torch.tensor([1.0, 2.0, 0.5, 16.0], device="cuda", dtype=torch.float32),
+        ),
+        "{.reg .b32 t; mov.b32 t,$1; shr.u32 t,t,23; and.b32 $0,t,0xFF;}",
+        "=r,f",
+        torch.int32,
+        lambda x: ((x.view(torch.int32) >> 23) & 0xFF).to(torch.int32),
+        compile_only=True,
+    ),
+    # Mixed constraint types: "r" input, "h" output (compile-only)
+    AsmTestCase(
+        "truncate_to_uint16",
+        lambda: (torch.randint(0, 256, (100,), device="cuda", dtype=torch.int32),),
+        "cvt.u16.u32 $0, $1;",
+        "=h,r",
+        torch.uint16,
+        lambda x: x.to(torch.uint16),
+        compile_only=True,
+    ),
+    # Broadcasting
+    AsmTestCase(
+        "broadcast_add",
+        lambda: (
+            torch.randn(4, 1, device="cuda", dtype=torch.float32),
+            torch.randn(1, 8, device="cuda", dtype=torch.float32),
+        ),
+        "add.f32 $0, $1, $2;",
+        "=f,f,f",
+        torch.float32,
+        lambda x, y: x + y,
+    ),
+    # Non-contiguous
+    AsmTestCase(
+        "noncontiguous",
+        lambda: (torch.randn(8, 16, device="cuda", dtype=torch.float32).t(),),
+        "mov.f32 $0, $1;",
+        "=f,f",
+        torch.float32,
+        lambda x: x,
+    ),
+    # fp16/bf16 native asm (compile-only: inductor computes in fp32, needs downcast)
+    AsmTestCase(
+        "add_fp16_native",
+        lambda: (
+            torch.randn(100, device="cuda", dtype=torch.float16),
+            torch.randn(100, device="cuda", dtype=torch.float16),
+        ),
+        "add.f16 $0, $1, $2;",
+        "=h,h,h",
+        torch.float16,
+        lambda x, y: x + y,
+        compile_only=True,
+    ),
+    AsmTestCase(
+        "add_bf16_native",
+        lambda: (
+            torch.randn(100, device="cuda", dtype=torch.bfloat16),
+            torch.randn(100, device="cuda", dtype=torch.bfloat16),
+        ),
+        "add.bf16 $0, $1, $2;",
+        "=h,h,h",
+        torch.bfloat16,
+        lambda x, y: x + y,
+        compile_only=True,
+        min_sm=90,
+    ),
+    # pack=2: each asm invocation processes 2 elements (compile-only)
+    AsmTestCase(
+        "identity_pack2",
+        lambda: (torch.randn(128, device="cuda", dtype=torch.float32),),
+        "mov.b32 $0, $2; mov.b32 $1, $3;",
+        "=r,=r,r,r",
+        torch.float32,
+        lambda x: x,
+        pack=2,
+        compile_only=True,
+    ),
+    AsmTestCase(
+        "add_pack2",
+        lambda: (
+            torch.randn(128, device="cuda", dtype=torch.float32),
+            torch.randn(128, device="cuda", dtype=torch.float32),
+        ),
+        "add.f32 $0, $2, $4; add.f32 $1, $3, $5;",
+        "=f,=f,f,f,f,f",
+        torch.float32,
+        lambda x, y: x + y,
+        pack=2,
+        compile_only=True,
+    ),
+]
+TEST_CASE_NAMES = [tc.name for tc in TEST_CASES]
+
+
+@unittest.skipIf(not TEST_CUDA, "CUDA not available")
+@unittest.skipIf(not SM70OrLater, "Requires SM70+")
+@instantiate_parametrized_tests
+class TestInlineAsmElementwise(TestCase):
+    """Parametrized tests for inline_asm_elementwise."""
+
+    @parametrize(
+        "case_idx", list(range(len(TEST_CASES))), name_fn=lambda i: TEST_CASE_NAMES[i]
+    )
+    def test_eager_vs_compiled_bitwise(self, case_idx):
+        """Verify eager and compiled produce bitwise identical results."""
+        tc = TEST_CASES[case_idx]
+        if torch.cuda.get_device_capability() < (tc.min_sm // 10, tc.min_sm % 10):
+            self.skipTest(f"Requires SM{tc.min_sm}+")
+        inputs = tc.input_gen_fn()
+
+        def fn(*args):
+            return inline_asm_elementwise(
+                *args,
+                asm_str=tc.asm_str,
+                constraints=tc.constraints,
+                dtype=tc.dtype,
+                pack=tc.pack,
+            )
+
+        torch._dynamo.reset()
+        compiled_result = torch.compile(fn, backend="inductor")(*inputs)
+
+        if tc.compile_only:
+            expected = tc.approx_fn(*inputs)
+            self.assertEqual(
+                compiled_result.float(), expected.float(), atol=1e-5, rtol=1e-5
+            )
+        else:
+            eager_result = fn(*inputs)
+            self.assertEqual(eager_result, compiled_result)
+
+    @parametrize(
+        "case_idx", list(range(len(TEST_CASES))), name_fn=lambda i: TEST_CASE_NAMES[i]
+    )
+    def test_correctness(self, case_idx):
+        """Verify result matches reference function."""
+        tc = TEST_CASES[case_idx]
+        if torch.cuda.get_device_capability() < (tc.min_sm // 10, tc.min_sm % 10):
+            self.skipTest(f"Requires SM{tc.min_sm}+")
+        inputs = tc.input_gen_fn()
+
+        def fn(*args):
+            return inline_asm_elementwise(
+                *args,
+                asm_str=tc.asm_str,
+                constraints=tc.constraints,
+                dtype=tc.dtype,
+                pack=tc.pack,
+            )
+
+        if tc.compile_only:
+            torch._dynamo.reset()
+            result = torch.compile(fn, backend="inductor")(*inputs)
+        else:
+            result = fn(*inputs)
+        expected = tc.approx_fn(*inputs)
+
+        self.assertEqual(result.float(), expected.float(), atol=1e-5, rtol=1e-5)
+
+
+@unittest.skipIf(not TEST_CUDA, "CUDA not available")
+class TestInlineAsmElementwiseErrors(TestCase):
+    """Tests for error handling."""
+
+    def test_error_no_inputs(self):
+        with self.assertRaises(ValueError):
+            inline_asm_elementwise(
+                asm_str="mov.f32 $0, 1.0;",
+                constraints="=f",
+                dtype=torch.float32,
+            )
+
+    def test_error_constraint_mismatch(self):
+        x = torch.randn(100, device="cuda", dtype=torch.float32)
+        y = torch.randn(100, device="cuda", dtype=torch.float32)
+        with self.assertRaises(ValueError):
+            inline_asm_elementwise(
+                x,
+                y,
+                asm_str="add.f32 $0, $1, $2;",
+                constraints="=f,f",
+                dtype=torch.float32,
+            )
+
+    def test_error_mixed_dtypes(self):
+        x = torch.randn(100, device="cuda", dtype=torch.float32)
+        y = torch.randint(0, 10, (100,), device="cuda", dtype=torch.int32)
+        with self.assertRaises(ValueError):
+            inline_asm_elementwise(
+                x,
+                y,
+                asm_str="add.f32 $0, $1, $2;",
+                constraints="=f,f,r",
+                dtype=torch.float32,
+            )
+
+    def test_error_cpu_tensor(self):
+        x = torch.randn(100, dtype=torch.float32)
+        with self.assertRaises(RuntimeError):
+            inline_asm_elementwise(
+                x,
+                asm_str="mov.f32 $0, $1;",
+                constraints="=f,f",
+                dtype=torch.float32,
+            )
+
+
+@unittest.skipIf(not TEST_CUDA, "CUDA not available")
+@unittest.skipIf(not SM70OrLater, "Requires SM70+")
+class TestInlineAsmElementwiseEdgeCases(TestCase):
+    """Tests for edge cases."""
+
+    def test_empty_tensor(self):
+        x = torch.empty(0, device="cuda", dtype=torch.float32)
+        result = inline_asm_elementwise(
+            x, asm_str="mov.f32 $0, $1;", constraints="=f,f", dtype=torch.float32
+        )
+        self.assertEqual(result.shape, torch.Size([0]))
+
+    def test_scalar_tensor(self):
+        x = torch.tensor(3.14, device="cuda", dtype=torch.float32)
+        result = inline_asm_elementwise(
+            x, asm_str="mov.f32 $0, $1;", constraints="=f,f", dtype=torch.float32
+        )
+        self.assertEqual(result.shape, torch.Size([]))
+        self.assertEqual(result, x)
+
+    def test_4d_tensor(self):
+        x = torch.randn(2, 3, 4, 5, device="cuda", dtype=torch.float32)
+        result = inline_asm_elementwise(
+            x, asm_str="mov.f32 $0, $1;", constraints="=f,f", dtype=torch.float32
+        )
+        self.assertEqual(result.shape, x.shape)
+        self.assertEqual(result, x)
+
+    def test_composition_with_pytorch_ops(self):
+        def fn(x, y):
+            z = x * 2
+            w = inline_asm_elementwise(
+                z,
+                y,
+                asm_str="add.f32 $0, $1, $2;",
+                constraints="=f,f,f",
+                dtype=torch.float32,
+            )
+            return w + 1.0
+
+        x = torch.randn(100, device="cuda", dtype=torch.float32)
+        y = torch.randn(100, device="cuda", dtype=torch.float32)
+
+        eager_result = fn(x, y)
+        compiled_fn = torch.compile(fn, backend="inductor")
+        compiled_result = compiled_fn(x, y)
+
+        self.assertEqual(eager_result, compiled_result)
+        self.assertEqual(eager_result, x * 2 + y + 1.0)
+
+    def test_output_strides_mixed_inputs(self):
+        """Verify fake mode output strides match eager (TensorIterator) strides."""
+        from torch._subclasses.fake_tensor import FakeTensorMode
+
+        # Two inputs with different strides: one contiguous, one transposed.
+        # This exercises TensorIterator's slow path for stride computation.
+        x = torch.randn(8, 16, device="cuda", dtype=torch.float32)
+        y = torch.randn(16, 8, device="cuda", dtype=torch.float32).t()
+
+        eager_result = inline_asm_elementwise(
+            x,
+            y,
+            asm_str="add.f32 $0, $1, $2;",
+            constraints="=f,f,f",
+            dtype=torch.float32,
+        )
+
+        with FakeTensorMode() as mode:
+            fake_x = mode.from_tensor(x)
+            fake_y = mode.from_tensor(y)
+            fake_result = inline_asm_elementwise(
+                fake_x,
+                fake_y,
+                asm_str="add.f32 $0, $1, $2;",
+                constraints="=f,f,f",
+                dtype=torch.float32,
+            )
+
+        self.assertEqual(eager_result.shape, fake_result.shape)
+        self.assertEqual(eager_result.stride(), fake_result.stride())
+
+    def test_dynamic_shapes(self):
+        def fn(x, y):
+            return inline_asm_elementwise(
+                x,
+                y,
+                asm_str="add.f32 $0, $1, $2;",
+                constraints="=f,f,f",
+                dtype=torch.float32,
+            )
+
+        compiled_fn = torch.compile(fn, backend="inductor", dynamic=True)
+
+        for size in [50, 100, 200]:
+            x = torch.randn(size, device="cuda", dtype=torch.float32)
+            y = torch.randn(size, device="cuda", dtype=torch.float32)
+            eager_result = fn(x, y)
+            compiled_result = compiled_fn(x, y)
+            self.assertEqual(eager_result, compiled_result)
+
+
+@unittest.skipIf(not TEST_CUDA, "CUDA not available")
+@unittest.skipIf(not SM70OrLater, "Requires SM70+")
+class TestInlineAsmPackPadding(TestCase):
+    """Test that pack padding works when block size < pack."""
+
+    def test_pack2_xblock1_padding(self):
+        """Force XBLOCK=1 with pack=2 so padding is needed."""
+        from torch._inductor.choices import InductorChoices
+        from torch._inductor.codegen.triton import FixedTritonConfig
+        from torch._inductor.utils import run_and_get_code
+        from torch.testing import FileCheck
+
+        class ForceXBlock1(InductorChoices):
+            def triton_kernel_kwargs(self, kernel_cls, features, groups, kernel_kwargs):
+                return {
+                    **kernel_kwargs,
+                    "fixed_config": FixedTritonConfig({"XBLOCK": 1}),
+                }
+
+        def fn(x):
+            return inline_asm_elementwise(
+                x,
+                asm_str="mov.b32 $0, $2; mov.b32 $1, $3;",
+                constraints="=r,=r,r,r",
+                dtype=torch.float32,
+                pack=2,
+            )
+
+        x = torch.randn(128, device="cuda", dtype=torch.float32)
+        with torch._inductor.virtualized.V.set_choices_handler(ForceXBlock1()):
+            torch._dynamo.reset()
+            result, (code,) = run_and_get_code(torch.compile(fn, backend="inductor"), x)
+
+        self.assertEqual(result, x)
+        # Verify padding helpers are emitted in the generated code
+        FileCheck().check("inline_asm_pack").check("inline_asm_unpack").run(code)
+
+    def test_pack4_xblock1_padding(self):
+        """Force XBLOCK=1 with pack=4 so padding is needed."""
+        from torch._inductor.choices import InductorChoices
+        from torch._inductor.codegen.triton import FixedTritonConfig
+        from torch._inductor.utils import run_and_get_code
+        from torch.testing import FileCheck
+
+        class ForceXBlock1(InductorChoices):
+            def triton_kernel_kwargs(self, kernel_cls, features, groups, kernel_kwargs):
+                return {
+                    **kernel_kwargs,
+                    "fixed_config": FixedTritonConfig({"XBLOCK": 1}),
+                }
+
+        def fn(x):
+            return inline_asm_elementwise(
+                x,
+                asm_str="mov.b32 $0, $4; mov.b32 $1, $5; mov.b32 $2, $6; mov.b32 $3, $7;",
+                constraints="=r,=r,=r,=r,r,r,r,r",
+                dtype=torch.float32,
+                pack=4,
+            )
+
+        x = torch.randn(128, device="cuda", dtype=torch.float32)
+        with torch._inductor.virtualized.V.set_choices_handler(ForceXBlock1()):
+            torch._dynamo.reset()
+            result, (code,) = run_and_get_code(torch.compile(fn, backend="inductor"), x)
+
+        self.assertEqual(result, x)
+        FileCheck().check("inline_asm_pack").check("inline_asm_unpack").run(code)
+
+    def test_pack4_xblock2_partial_padding(self):
+        """XBLOCK=2 < pack=4, so 1 round of padding is needed (not 2)."""
+        from torch._inductor.choices import InductorChoices
+        from torch._inductor.codegen.triton import FixedTritonConfig
+        from torch._inductor.utils import run_and_get_code
+        from torch.testing import FileCheck
+
+        class ForceXBlock2(InductorChoices):
+            def triton_kernel_kwargs(self, kernel_cls, features, groups, kernel_kwargs):
+                return {
+                    **kernel_kwargs,
+                    "fixed_config": FixedTritonConfig({"XBLOCK": 2}),
+                }
+
+        def fn(x):
+            return inline_asm_elementwise(
+                x,
+                asm_str="mov.b32 $0, $4; mov.b32 $1, $5; mov.b32 $2, $6; mov.b32 $3, $7;",
+                constraints="=r,=r,=r,=r,r,r,r,r",
+                dtype=torch.float32,
+                pack=4,
+            )
+
+        x = torch.randn(128, device="cuda", dtype=torch.float32)
+        with torch._inductor.virtualized.V.set_choices_handler(ForceXBlock2()):
+            torch._dynamo.reset()
+            result, (code,) = run_and_get_code(torch.compile(fn, backend="inductor"), x)
+
+        self.assertEqual(result, x)
+        FileCheck().check("inline_asm_pack").check("inline_asm_unpack").run(code)
+
+    def test_pack2_xblock1_yblock1_padding(self):
+        """Force XBLOCK=1, YBLOCK=1 with pack=2 on a 2D-tiled kernel."""
+        from torch._inductor.choices import InductorChoices
+        from torch._inductor.codegen.triton import FixedTritonConfig
+        from torch._inductor.utils import run_and_get_code
+        from torch.testing import FileCheck
+
+        class ForceXY1(InductorChoices):
+            def triton_kernel_kwargs(self, kernel_cls, features, groups, kernel_kwargs):
+                return {
+                    **kernel_kwargs,
+                    "fixed_config": FixedTritonConfig({"XBLOCK": 1, "YBLOCK": 1}),
+                }
+
+        def fn(x, y):
+            return inline_asm_elementwise(
+                x,
+                y,
+                asm_str="add.f32 $0, $2, $4; add.f32 $1, $3, $5;",
+                constraints="=f,=f,f,f,f,f",
+                dtype=torch.float32,
+                pack=2,
+            )
+
+        x = torch.randn(8, 16, device="cuda", dtype=torch.float32)
+        # Transposed input triggers 2D tiling (different stride patterns)
+        y = torch.randn(16, 8, device="cuda", dtype=torch.float32).T
+        with torch._inductor.virtualized.V.set_choices_handler(ForceXY1()):
+            torch._dynamo.reset()
+            result, (code,) = run_and_get_code(
+                torch.compile(fn, backend="inductor"), x, y
+            )
+
+        self.assertEqual(result, x + y)
+        FileCheck().check("YBLOCK").check("inline_asm_pack").check(
+            "inline_asm_unpack"
+        ).run(code)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -4003,6 +4003,31 @@ class RunWithRNGStateHigherOrderVariable(TorchHigherOrderOperatorVariable):
         )
 
 
+class InlineAsmElementwiseHigherOrderVariable(TorchHigherOrderOperatorVariable):
+    _HOP_NAME = "inline_asm_elementwise"
+
+    def _call_function(
+        self,
+        tx: "InstructionTranslator",
+        args: Sequence[VariableTracker],
+        kwargs: dict[str, VariableTracker],
+    ) -> VariableTracker:
+        from .builder import wrap_fx_proxy
+
+        p_args = tuple(arg.as_proxy() for arg in args)
+        p_kwargs = {key: arg.as_proxy() for key, arg in kwargs.items()}
+        return wrap_fx_proxy(
+            tx=tx,
+            proxy=tx.output.create_proxy(
+                "call_function",
+                self.value,
+                args=p_args,
+                kwargs=p_kwargs,
+            ),
+            example_value=None,
+        )
+
+
 class AutoFunctionalizeHigherOrderVariable(TorchHigherOrderOperatorVariable):
     _HOP_NAME = "torch.ops.higher_order.auto_functionalized"
 
@@ -5588,6 +5613,7 @@ _hop_name_to_variable_class = {
     "dynamo_bypassing_wrapper": DynamoBypassingWrapperHigherOrderVariable,
     "auto_functionalized": AutoFunctionalizeHigherOrderVariable,
     "auto_functionalized_v2": AutoFunctionalizeHigherOrderVariable,
+    "inline_asm_elementwise": InlineAsmElementwiseHigherOrderVariable,
     "invoke_subgraph": InvokeSubgraphHigherOrderVariable,
     "custom_function_call": CustomFunctionHigherOrderOperatorVariable,
     "local_map_hop": LocalMapWrappedHigherOrderVariable,

--- a/torch/_higher_order_ops/__init__.py
+++ b/torch/_higher_order_ops/__init__.py
@@ -20,6 +20,7 @@ from torch._higher_order_ops.flex_attention import (
 )
 from torch._higher_order_ops.foreach_map import _foreach_map, foreach_map
 from torch._higher_order_ops.hints_wrap import hints_wrapper
+from torch._higher_order_ops.inline_asm_elementwise import inline_asm_elementwise
 from torch._higher_order_ops.invoke_leaf_function import invoke_leaf_function
 from torch._higher_order_ops.invoke_subgraph import invoke_subgraph
 from torch._higher_order_ops.local_map import local_map_hop
@@ -81,4 +82,5 @@ __all__ = [
     "local_map_hop",
     "print",
     "inductor_compiled_code",
+    "inline_asm_elementwise",
 ]

--- a/torch/_higher_order_ops/inline_asm_elementwise.py
+++ b/torch/_higher_order_ops/inline_asm_elementwise.py
@@ -50,6 +50,7 @@ class InlineAsmElementwiseOp(HigherOrderOperator):
 
     Example::
 
+        >>> # xdoctest: +SKIP(requires CUDA)
         >>> # Float32 fused multiply-add via PTX
         >>> result = inline_asm_elementwise(
         ...     a, b, c,
@@ -58,6 +59,7 @@ class InlineAsmElementwiseOp(HigherOrderOperator):
         ...     dtype=torch.float32,
         ... )
 
+        >>> # xdoctest: +SKIP(requires CUDA)
         >>> # pack=2: each asm invocation processes two elements
         >>> result = inline_asm_elementwise(
         ...     x,

--- a/torch/_higher_order_ops/inline_asm_elementwise.py
+++ b/torch/_higher_order_ops/inline_asm_elementwise.py
@@ -1,0 +1,297 @@
+# mypy: allow-untyped-defs
+import functools
+import re
+
+import torch
+import torch.utils._pytree as pytree
+from torch._C import DispatchKey
+from torch._higher_order_ops.utils import autograd_not_implemented
+from torch._ops import HigherOrderOperator
+from torch._subclasses.fake_tensor import FakeTensorMode
+from torch.fx.experimental.proxy_tensor import ProxyTorchDispatchMode, track_tensor_tree
+
+
+__all__ = ["inline_asm_elementwise"]
+
+
+class InlineAsmElementwiseOp(HigherOrderOperator):
+    """Execute inline PTX assembly elementwise over tensors.
+
+    This is an elementwise map where the function body is inline assembly.
+    Input tensors are implicitly broadcast to the same shape.
+
+    Each invocation of the inline asm processes ``pack`` elements at a time.
+    Exactly which set of inputs a given invocation receives is unspecified.
+
+    Output strides follow PyTorch's standard pointwise striding propagation
+    rules.
+
+    In eager mode, the assembly is executed via the CUDA Jiterator.  Under
+    ``torch.compile`` the assembly is lowered to Triton's
+    ``tl.inline_asm_elementwise`` via Inductor, which allows fusion with
+    surrounding operators.
+
+    Args:
+        *inputs: Input tensors whose values are passed to the asm block.
+        asm_str: PTX assembly string. Operands use ``$N`` syntax
+            (e.g. ``$0`` for the first output, ``$1`` for the first input).
+        constraints: Inline-asm constraints in LLVM format. Output constraints
+            are prefixed with ``=`` (e.g. ``"=f,f,f"`` for one float output
+            and two float inputs).
+        dtype: Element type of the returned tensor.
+        is_pure: Must be ``True``. If true, the compiler may assume the asm
+            block has no side-effects.
+        pack: Number of elements processed per asm invocation.  When
+            ``pack > 1``, the constraint string must list ``pack`` outputs
+            and ``pack`` copies of each input.  Requires ``torch.compile``.
+
+    Returns:
+        A tensor with the broadcast shape of the inputs and the given dtype.
+
+    Example::
+
+        >>> # Float32 fused multiply-add via PTX
+        >>> result = inline_asm_elementwise(
+        ...     a, b, c,
+        ...     asm_str="fma.rn.f32 $0, $1, $2, $3;",
+        ...     constraints="=f,f,f,f",
+        ...     dtype=torch.float32,
+        ... )
+
+        >>> # pack=2: each asm invocation processes two elements
+        >>> result = inline_asm_elementwise(
+        ...     x,
+        ...     asm_str="mov.b32 $0, $2; mov.b32 $1, $3;",
+        ...     constraints="=r,=r,r,r",
+        ...     dtype=torch.float32,
+        ...     pack=2,
+        ... )
+    """
+
+    def __init__(self):
+        super().__init__("inline_asm_elementwise")
+
+    def __call__(
+        self,
+        *inputs: torch.Tensor,
+        asm_str: str,
+        constraints: str,
+        dtype: torch.dtype,
+        is_pure: bool = True,
+        pack: int = 1,
+    ) -> torch.Tensor:
+        if not is_pure:
+            raise ValueError("inline_asm_elementwise only supports is_pure=True")
+        # pyrefly: ignore [missing-attribute]
+        return super().__call__(
+            *inputs,
+            asm_str=asm_str,
+            constraints=constraints,
+            dtype=dtype,
+            is_pure=True,
+            pack=pack,
+        )
+
+
+inline_asm_elementwise = InlineAsmElementwiseOp()
+
+
+def _parse_constraints(constraints: str) -> tuple[int, int]:
+    parts = [p.strip() for p in constraints.split(",")]
+    n_outputs = sum(1 for p in parts if p.startswith("="))
+    n_inputs = len(parts) - n_outputs
+    return n_outputs, n_inputs
+
+
+_DTYPE_TO_CUDA_TYPE = {
+    torch.float32: "float",
+    torch.float64: "double",
+    torch.float16: "__half",
+    torch.bfloat16: "__nv_bfloat16",
+    torch.int32: "int",
+    torch.int64: "long long",
+    torch.int16: "short",
+    torch.int8: "signed char",
+    torch.uint8: "unsigned char",
+    torch.uint16: "unsigned short",
+    torch.uint32: "unsigned int",
+    torch.bool: "bool",
+}
+
+
+_TRITON_ARG_RE = re.compile(r"\$(\d+)")
+
+
+def _triton_asm_to_cuda_asm(asm_str: str) -> str:
+    return _TRITON_ARG_RE.sub(r"%\1", asm_str)
+
+
+@functools.lru_cache
+def _get_jiterator_fn(
+    asm_str: str,
+    constraints: str,
+    n_inputs: int,
+    input_dtype: torch.dtype,
+    output_dtype: torch.dtype,
+):
+    from torch.cuda.jiterator import _create_jit_fn
+
+    cuda_asm = _triton_asm_to_cuda_asm(asm_str)
+
+    constraint_parts = [p.strip() for p in constraints.split(",")]
+    output_constraints = [p.lstrip("=") for p in constraint_parts if p.startswith("=")]
+    input_constraints = [p for p in constraint_parts if not p.startswith("=")]
+
+    if input_dtype not in _DTYPE_TO_CUDA_TYPE:
+        raise ValueError(f"Unsupported input dtype for inline asm: {input_dtype}")
+    if output_dtype not in _DTYPE_TO_CUDA_TYPE:
+        raise ValueError(f"Unsupported output dtype for inline asm: {output_dtype}")
+
+    input_type = _DTYPE_TO_CUDA_TYPE[input_dtype]
+    output_type = _DTYPE_TO_CUDA_TYPE[output_dtype]
+
+    input_params = ", ".join(f"{input_type} in{i}" for i in range(n_inputs))
+    out_constraints_str = ", ".join(f'"={c}"(result)' for c in output_constraints)
+    in_constraints_str = ", ".join(
+        f'"{c}"(in{i})' for i, c in enumerate(input_constraints)
+    )
+    escaped_asm = (
+        cuda_asm.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
+    )
+
+    code = f"""
+template <typename T>
+{output_type} inline_asm_kernel({input_params}) {{
+    {output_type} result;
+    asm volatile (
+        "{escaped_asm}"
+        : {out_constraints_str}
+        : {in_constraints_str}
+    );
+    return result;
+}}
+"""
+
+    return _create_jit_fn(code)
+
+
+def _inline_asm_dense(*inputs, asm_str, constraints, dtype, is_pure, pack):
+    if not inputs:
+        raise ValueError("inline_asm_elementwise requires at least one input tensor")
+
+    inputs = torch.broadcast_tensors(*inputs)
+
+    if not inputs[0].is_cuda:
+        raise RuntimeError("inline_asm_elementwise only supports CUDA tensors")
+
+    if pack > 1:
+        raise RuntimeError(
+            "inline_asm_elementwise with pack > 1 requires torch.compile"
+        )
+
+    n_outputs, n_inputs = _parse_constraints(constraints)
+
+    if n_outputs != 1:
+        raise ValueError(f"Expected 1 output constraint, got {n_outputs}")
+
+    if n_inputs != len(inputs):
+        raise ValueError(
+            f"Constraint string specifies {n_inputs} inputs but got "
+            f"{len(inputs)} tensor(s)"
+        )
+
+    # Jiterator generates a single input type for all inputs — mixed dtypes
+    # would produce incorrect CUDA code.
+    input_dtypes = {inp.dtype for inp in inputs}
+    if len(input_dtypes) > 1:
+        raise ValueError(
+            f"All inputs must have the same dtype for eager execution, "
+            f"got {sorted(str(d) for d in input_dtypes)}"
+        )
+
+    jit_fn = _get_jiterator_fn(
+        asm_str=asm_str,
+        constraints=constraints,
+        n_inputs=len(inputs),
+        input_dtype=inputs[0].dtype,
+        output_dtype=dtype,
+    )
+
+    return jit_fn(*inputs)
+
+
+@inline_asm_elementwise.py_impl(DispatchKey.CompositeExplicitAutograd)
+def _(*inputs, asm_str, constraints, dtype, is_pure=True, pack=1):
+    return _inline_asm_dense(
+        *inputs,
+        asm_str=asm_str,
+        constraints=constraints,
+        dtype=dtype,
+        is_pure=is_pure,
+        pack=pack,
+    )
+
+
+inline_asm_elementwise.py_autograd_impl(
+    autograd_not_implemented(inline_asm_elementwise, deferred_error=True)
+)
+
+
+def _elementwise_output_like(*inputs, dtype):
+    from torch._prims_common import compute_elementwise_output_logical_to_physical_perm
+
+    broadcasted = torch.broadcast_tensors(*inputs)
+    l2p_perm, _ = compute_elementwise_output_logical_to_physical_perm(*broadcasted)
+    return torch.empty_permuted(
+        broadcasted[0].shape, l2p_perm, dtype=dtype, device=broadcasted[0].device
+    )
+
+
+@inline_asm_elementwise.py_impl(FakeTensorMode)
+def _(mode, *inputs, asm_str, constraints, dtype, is_pure=True, pack=1):
+    with mode:
+        return _elementwise_output_like(*inputs, dtype=dtype)
+
+
+@inline_asm_elementwise.py_impl(ProxyTorchDispatchMode)
+def _(mode, *inputs, asm_str, constraints, dtype, is_pure=True, pack=1):
+    proxy_args = pytree.tree_map(mode.tracer.unwrap_proxy, inputs)
+
+    out_proxy = mode.tracer.create_proxy(
+        "call_function",
+        inline_asm_elementwise,
+        proxy_args,
+        {
+            "asm_str": asm_str,
+            "constraints": constraints,
+            "dtype": dtype,
+            "is_pure": is_pure,
+            "pack": pack,
+        },
+        name="inline_asm_elementwise",
+    )
+
+    out = inline_asm_elementwise(
+        *inputs,
+        asm_str=asm_str,
+        constraints=constraints,
+        dtype=dtype,
+        is_pure=is_pure,
+        pack=pack,
+    )
+    return track_tensor_tree(out, out_proxy, constant=None, tracer=mode.tracer)
+
+
+@inline_asm_elementwise.py_functionalize_impl
+def _(ctx, *inputs, asm_str, constraints, dtype, is_pure=True, pack=1):
+    unwrapped_inputs = ctx.unwrap_tensors(inputs)
+
+    with ctx.redispatch_to_next():
+        res = inline_asm_elementwise(
+            *unwrapped_inputs,
+            asm_str=asm_str,
+            constraints=constraints,
+            dtype=dtype,
+            pack=pack,
+        )
+    return ctx.wrap_tensors(res)

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -1154,6 +1154,7 @@ class OpOverrides(BasicMathOpsMixin, OpDecompositions, OpsHandler[Any]):
         dtype: torch.dtype = torch.float32,
         is_pure: bool = True,
         pack: int = 1,
+        input_dtypes: tuple[torch.dtype, ...] | None = None,
     ) -> OpVarT:
         raise NotImplementedError(
             f"{type(self).__name__}: inline_asm_elementwise only implemented for Triton backend"

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -1602,13 +1602,58 @@ class TritonOverrides(OpOverrides):
 
     @staticmethod
     def inline_asm_elementwise(
-        *inputs, asm, constraints=None, dtype=torch.float32, is_pure=True, pack=1
+        *inputs,
+        asm,
+        constraints=None,
+        dtype=torch.float32,
+        is_pure=True,
+        pack=1,
+        input_dtypes=None,
     ):
-        triton_type = triton_compute_type(dtype)
-        input_refs = ", ".join([str(i) for i in inputs])
+        # Use the actual dtype, not the compute type — the asm operates on
+        # specific register types and Triton needs to know the real output type.
+        asm_triton_type = triton_type(dtype)
         if constraints is None:
             constraints = ", ".join(["=r"] + ["r" for _ in inputs])
-        return f"tl.inline_asm_elementwise('{asm}', '{constraints}', [{input_refs}], dtype={triton_type}, is_pure={is_pure}, pack={pack})"  # noqa: B950
+
+        # Inductor computes bf16/fp16 in fp32. For "h" (16-bit register)
+        # constraints, cast back to the original dtype so the asm sees the
+        # right register type.
+        constraint_parts = [p.strip() for p in constraints.split(",")]
+        input_constraints = [p for p in constraint_parts if not p.startswith("=")]
+        cast_inputs = []
+        for i, (inp, c) in enumerate(zip(inputs, input_constraints[: len(inputs)])):
+            if (
+                c == "h"
+                and input_dtypes is not None
+                and isinstance(inp, CSEVariable)
+                and inp.dtype != input_dtypes[i]
+            ):
+                cast_inputs.append(f"{inp}.to({triton_type(input_dtypes[i])})")
+            else:
+                cast_inputs.append(str(inp))
+
+        def asm_call(args):
+            return (
+                f"tl.inline_asm_elementwise('{asm}', '{constraints}', "
+                f"[{args}], dtype={asm_triton_type}, is_pure={is_pure}, pack={pack})"
+            )
+
+        if pack <= 1:
+            return asm_call(", ".join(cast_inputs))
+
+        first_input = inputs[0]
+        compute = V.kernel.compute
+        cse = V.kernel.cse
+        result = cse.newvar(dtype=dtype, shape=first_input.shape)
+        packed_args = ", ".join(
+            f"triton_helpers.inline_asm_pack({inp}, {pack})" for inp in cast_inputs
+        )
+        compute.writeline(f"{result} = {asm_call(packed_args)}")
+        compute.writeline(
+            f"{result} = triton_helpers.inline_asm_unpack({result}, {first_input}, {pack})"
+        )
+        return result
 
     @staticmethod
     @maybe_upcast_float32()

--- a/torch/_inductor/dtype_propagation.py
+++ b/torch/_inductor/dtype_propagation.py
@@ -444,7 +444,13 @@ class DtypePropagationOpsHandler:
 
     @staticmethod
     def inline_asm_elementwise(
-        *inputs, asm, constraints=None, dtype=torch.float32, is_pure=True, pack=1
+        *inputs,
+        asm,
+        constraints=None,
+        dtype=torch.float32,
+        is_pure=True,
+        pack=1,
+        input_dtypes=None,
     ):
         return dtype
 

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -8128,6 +8128,43 @@ def cvt_e8m0_rceil_lowering(inp):
     return to_dtype(result, torch.uint8)
 
 
+@register_lowering(
+    torch._higher_order_ops.inline_asm_elementwise, type_promotion_kind=None
+)
+def lower_inline_asm_elementwise(
+    *inputs, asm_str, constraints, dtype, is_pure=True, pack=1
+):
+    inputs = broadcast_tensors(*inputs)
+
+    input_dtypes = tuple(inp.get_dtype() for inp in inputs)
+    loaders = [inp.make_loader() for inp in inputs]
+
+    def inner_fn(idx):
+        vals = tuple(loader(idx) for loader in loaders)
+        result = ops.inline_asm_elementwise(
+            *vals,
+            asm=asm_str,
+            constraints=constraints,
+            dtype=dtype,
+            is_pure=is_pure,
+            pack=pack,
+            input_dtypes=input_dtypes,
+        )
+        # Inductor computes in fp32 for bf16/fp16. Upcast so fused downstream
+        # ops (reductions, etc.) see fp32 values. The Pointwise's storage dtype
+        # handles the final downcast on store.
+        if dtype in (torch.float16, torch.bfloat16):
+            result = ops.to_dtype(result, torch.float32)
+        return result
+
+    return ir.Pointwise.create(
+        device=inputs[0].get_device(),
+        dtype=dtype,
+        inner_fn=inner_fn,
+        ranges=list(inputs[0].get_size()),
+    )
+
+
 # populate lowerings defined in kernel/*
 from . import kernel
 

--- a/torch/_inductor/ops_handler.py
+++ b/torch/_inductor/ops_handler.py
@@ -735,6 +735,7 @@ class OpsHandler(Generic[T]):
         dtype: torch.dtype = torch.float32,
         is_pure: bool = True,
         pack: int = 1,
+        input_dtypes: tuple[torch.dtype, ...] | None = None,
     ) -> T:
         raise NotImplementedError
 

--- a/torch/_inductor/runtime/triton_helpers.py
+++ b/torch/_inductor/runtime/triton_helpers.py
@@ -779,3 +779,27 @@ def if_mask(mask: Any, val, *, _builder: object = None) -> tl.constexpr:
     if isinstance(mask, tl.constexpr) and mask.value is None:
         return tl.constexpr(None)
     return val
+
+
+@triton.jit
+def inline_asm_pack(x, pack: tl.constexpr):
+    """Ravel to 1D and pad (via join with zeros) so numel is divisible by pack."""
+    result = x.ravel()
+    # Only pad when the block size is smaller than pack. When block >= pack
+    # the numel is already divisible by pack (both are powers of 2).
+    n_pad: tl.constexpr = _log2(pack) - _log2(result.numel)
+    for _ in tl.static_range(n_pad):
+        result = tl.reshape(
+            tl.join(result, tl.zeros_like(result)), (result.shape[0] * 2,)
+        )
+    return result
+
+
+@triton.jit
+def inline_asm_unpack(x, orig, pack: tl.constexpr):
+    """Unpad and reshape back to orig's shape."""
+    result = x
+    n_pad: tl.constexpr = _log2(pack) - _log2(orig.numel)
+    for _ in tl.static_range(n_pad):
+        result, _ = tl.split(tl.reshape(result, (result.shape[0] // 2, 2)))
+    return tl.reshape(result, orig.shape)

--- a/torch/testing/_internal/hop_db.py
+++ b/torch/testing/_internal/hop_db.py
@@ -546,14 +546,6 @@ hop_db = [
         check_batched_forward_grad=False,
         check_inplace_batched_forward_grad=False,
         supports_autograd=False,
-        skips=(
-            DecorateInfo(unittest.expectedFailure, "TestHOP", "test_aot_export"),
-            DecorateInfo(
-                unittest.expectedFailure, "TestHOP", "test_pre_dispatch_export"
-            ),
-            DecorateInfo(unittest.expectedFailure, "TestHOP", "test_serialize_export"),
-            DecorateInfo(unittest.expectedFailure, "TestHOP", "test_retrace_export"),
-        ),
         decorators=[onlyCUDA],
     ),
 ]

--- a/torch/testing/_internal/hop_db.py
+++ b/torch/testing/_internal/hop_db.py
@@ -7,6 +7,7 @@ import torch
 from functorch.experimental.control_flow import map
 from torch.nn.attention.flex_attention import _create_empty_block_mask, flex_attention
 from torch.testing import make_tensor
+from torch._higher_order_ops.inline_asm_elementwise import inline_asm_elementwise
 from torch.testing._internal.common_device_type import onlyCUDA
 from torch.testing._internal.common_dtype import all_types_and, custom_types
 from torch.testing._internal.opinfo.core import DecorateInfo, OpInfo, SampleInput
@@ -292,6 +293,19 @@ def simple_invoke_quant_packed(x):
     return invoke_quant_packed(fn, x)[0] * 2.0
 
 
+def sample_inputs_inline_asm(opinfo, device, dtype, requires_grad, **kwargs):
+    make_arg = functools.partial(
+        make_tensor, device=device, dtype=dtype, requires_grad=requires_grad
+    )
+    yield SampleInput(make_arg(2, 2, 2, low=0.1, high=2))
+
+
+def simple_inline_asm(x):
+    return inline_asm_elementwise(
+        x, asm_str="mov.f32 $0, $1;", constraints="=f,f", dtype=torch.float32
+    )
+
+
 hop_db = [
     OpInfo(
         name="scan",
@@ -519,5 +533,27 @@ hop_db = [
                 not torch.distributed.is_available(), "requires distributed build"
             ),
         ],
+    ),
+    OpInfo(
+        name="inline_asm_elementwise",
+        variant_test_name="simple",
+        op=simple_inline_asm,
+        sample_inputs_func=sample_inputs_inline_asm,
+        dtypes=custom_types(torch.float32),
+        supports_out=False,
+        check_batched_grad=False,
+        check_batched_gradgrad=False,
+        check_batched_forward_grad=False,
+        check_inplace_batched_forward_grad=False,
+        supports_autograd=False,
+        skips=(
+            DecorateInfo(unittest.expectedFailure, "TestHOP", "test_aot_export"),
+            DecorateInfo(
+                unittest.expectedFailure, "TestHOP", "test_pre_dispatch_export"
+            ),
+            DecorateInfo(unittest.expectedFailure, "TestHOP", "test_serialize_export"),
+            DecorateInfo(unittest.expectedFailure, "TestHOP", "test_retrace_export"),
+        ),
+        decorators=[onlyCUDA],
     ),
 ]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #177922


Adds a higher-order operator for inline PTX assembly that works in both
eager and compiled modes:

- Eager: JIT compiles CUDA kernels via Jiterator with inline asm
- Compiled: Lowers to tl.inline_asm_elementwise in Triton via Inductor

This enables using PTX instructions not exposed through standard PyTorch
ops (e.g., cvt.rn.satfinite.e2m1x2.f32 for NVFP4 quantization) while
maintaining bitwise equivalence between eager and compiled execution.


Example usage:
```python
from torch._higher_order_ops import inline_asm_elementwise

result = inline_asm_elementwise(
    x, y,
    asm_str="add.f32 $0, $1, $2;",
    constraints="=f,f,f",
    dtype=torch.float32,
)
```

Notes:

jitterator has limited support for the following:
- multiple outputs
- different output dtype than input
- pack != 1

In these cases, today, we error in jitterator and succeed in inductor.

We inherit the output striding behavior from jitterator in inductor/compilation (which follows eager pointwise ops).

Inductor details:

- Block size is not guaranteed to be a multiple of pack. Particularly, at the end of a persistent reduction, it's possible that xblock == 1. For this case, i've added a triton helper to pad the triton tensor to a multiple of pack, and then split to the actual output after. I suspect this is unlikely to occur but it's better to handle anyway.

- Inductor computes bf16/fp16 inside the kernel. For asm targeting these dtypes, we cast prior to invoking the asm. (even with emulate precision casts, we still compute in fp32, just add extra casts).

Otherwise it works more or less as the existing lowering.

reland of https://github.com/pytorch/pytorch/pull/175814


Written with Claude Code.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Lucaskabela @mlazos