### PR TITLE
Addresses O(N^2) complexities in Dynamo export during decomposition

### DIFF
--- a/torch/_export/utils.py
+++ b/torch/_export/utils.py
@@ -256,15 +256,17 @@ def _populate_param_buffer_metadata_to_new_gm(
         metadata.pop("nn_module_stack", None)
         metadata.pop("stack_trace", None)
 
+    inputs_to_parameters = new_sig.inputs_to_parameters
+    inputs_to_buffers = new_sig.inputs_to_buffers
     for node in gm.graph.nodes:
         if node.op == "placeholder":
-            if node.target in new_sig.inputs_to_parameters:
-                param_name = new_sig.inputs_to_parameters[node.target]
+            if node.target in inputs_to_parameters:
+                param_name = inputs_to_parameters[node.target]
                 if param_name in params_buffers_to_node_meta:
                     for k, v in params_buffers_to_node_meta[param_name].items():
                         node.meta[k] = v
-            if node.target in new_sig.inputs_to_buffers:
-                buffer_name = new_sig.inputs_to_buffers[node.target]
+            if node.target in inputs_to_buffers:
+                buffer_name = inputs_to_buffers[node.target]
                 if buffer_name in params_buffers_to_node_meta:
                     for k, v in params_buffers_to_node_meta[buffer_name].items():
                         node.meta[k] = v

--- a/torch/_export/verifier.py
+++ b/torch/_export/verifier.py
@@ -529,41 +529,44 @@ def _verify_exported_program_signature(exported_program) -> None:
         )
 
     num_tokens = len(gs.output_tokens)
+    buffers_to_mutate = gs.buffers_to_mutate
+    parameters_to_mutate = gs.parameters_to_mutate
+    user_inputs_to_mutate = gs.user_inputs_to_mutate
     end = (
-        len(gs.buffers_to_mutate)
-        + len(gs.parameters_to_mutate)
-        + len(gs.user_inputs_to_mutate)
+        len(buffers_to_mutate)
+        + len(parameters_to_mutate)
+        + len(user_inputs_to_mutate)
         + num_tokens
     )
     mutate_nodes: list[str] = output_nodes[num_tokens:end]
     user_output_nodes = output_nodes[end : end + len(gs.user_outputs)]
 
     for mutation_node in mutate_nodes:
-        if mutation_node in gs.buffers_to_mutate:
-            if gs.buffers_to_mutate[mutation_node] not in gs.buffers:
+        if mutation_node in buffers_to_mutate:
+            if buffers_to_mutate[mutation_node] not in gs.buffers:
                 raise SpecViolationError(
                     f"Buffer output {mutation_node} does not point to a buffer that exists. \n"
-                    f"Dict of buffers that are mutated, in order: {gs.buffers_to_mutate} \n"
+                    f"Dict of buffers that are mutated, in order: {buffers_to_mutate} \n"
                     f"Buffer nodes available: {gs.buffers} \n"
                 )
-        elif mutation_node in gs.parameters_to_mutate:
-            if gs.parameters_to_mutate[mutation_node] not in gs.parameters:
+        elif mutation_node in parameters_to_mutate:
+            if parameters_to_mutate[mutation_node] not in gs.parameters:
                 raise SpecViolationError(
                     f"Parameter output {mutation_node} does not point to a parameter that exists. \n"
-                    f"Dict of parameters that are mutated, in order: {gs.parameters_to_mutate} \n"
+                    f"Dict of parameters that are mutated, in order: {parameters_to_mutate} \n"
                     f"Parameter nodes available: {gs.parameters} \n"
                 )
-        elif mutation_node in gs.user_inputs_to_mutate:
-            if gs.user_inputs_to_mutate[mutation_node] not in gs.user_inputs:
+        elif mutation_node in user_inputs_to_mutate:
+            if user_inputs_to_mutate[mutation_node] not in gs.user_inputs:
                 raise SpecViolationError(
                     f"User input output {mutation_node} does not point to a user input that exists. \n"
-                    f"Dict of user inputs that are mutated, in order: {gs.user_inputs_to_mutate} \n"
+                    f"Dict of user inputs that are mutated, in order: {user_inputs_to_mutate} \n"
                     f"User input nodes available: {gs.user_inputs} \n"
                 )
         else:
             raise SpecViolationError(
                 f"Mutation node {mutation_node} is neither a buffer nor a user input. "
-                f"Buffers to mutate: {gs.buffers_to_mutate}, User inputs to mutate: {gs.user_inputs_to_mutate}"
+                f"Buffers to mutate: {buffers_to_mutate}, User inputs to mutate: {user_inputs_to_mutate}"
             )
 
     for user_output_node, user_output_name in zip(user_output_nodes, gs.user_outputs):

--- a/torch/export/exported_program.py
+++ b/torch/export/exported_program.py
@@ -800,13 +800,15 @@ def _decompose_and_get_gm_with_new_signature_constants(
     # values; since these become specialized, we replace such metadata with
     # the original values.
     # Also, set the param/buffer metadata back to the placeholders.
+    inputs_to_parameters = new_graph_signature.inputs_to_parameters
+    inputs_to_buffers = new_graph_signature.inputs_to_buffers
     for old_node, new_node in zip(old_placeholders, new_placeholders):
         if not isinstance(old_node.meta["val"], torch.Tensor):
             new_node.meta["val"] = old_node.meta["val"]
 
         if (
-            new_node.target in new_graph_signature.inputs_to_parameters
-            or new_node.target in new_graph_signature.inputs_to_buffers
+            new_node.target in inputs_to_parameters
+            or new_node.target in inputs_to_buffers
         ):
             for k, v in old_node.meta.items():
                 new_node.meta[k] = v
@@ -819,14 +821,16 @@ def _remove_unnecessary_copy_op_pass(
     """
     Removes redundant copy_ node that was introduced due to mutated buffer.
     """
+    buffers_to_mutate = new_graph_signature.buffers_to_mutate
+    parameters_to_mutate = new_graph_signature.parameters_to_mutate
     with gm._set_replace_hook(new_graph_signature.get_replace_hook()):
         for node in gm.graph.nodes:
             if node.op == "output":
                 args, _ = pytree.tree_flatten(node.args)
                 for out in args:
                     if isinstance(out, torch.fx.Node) and (
-                        out.name in new_graph_signature.buffers_to_mutate
-                        or out.name in new_graph_signature.parameters_to_mutate
+                        out.name in buffers_to_mutate
+                        or out.name in parameters_to_mutate
                     ):
                         if (
                             out.op == "call_function"

--- a/torch/export/unflatten.py
+++ b/torch/export/unflatten.py
@@ -3,7 +3,6 @@ import abc
 import copy
 import logging
 import operator
-import re
 from collections import defaultdict
 from collections.abc import Callable
 from contextlib import contextmanager
@@ -101,11 +100,15 @@ def _assign_attr(
         for to_module in to_modules:
             if not hasattr(to_module, item):
                 setattr(to_module, item, torch.nn.Module())
-            ts.update(
-                t_call  # type: ignore[misc]
-                for k, t_call in to_module._modules.items()
-                if _is_call_name(k, item)
-            )
+            if item in to_module._modules:
+                ts.add(to_module._modules[item])
+            i = 1
+            while True:
+                variant = f"{item}@{i}"
+                if variant not in to_module._modules:
+                    break
+                ts.add(to_module._modules[variant])
+                i += 1
         to_modules = ts
 
     for to_module in to_modules:
@@ -1088,11 +1091,6 @@ def _call_name(base: str, n: int) -> str:
     # Given n >= 0, generate call names to a submodule `base` of the form
     # `base`, `base@1`, `base@2`, etc.
     return base if n == 1 else f"{base}@{n - 1}"
-
-
-def _is_call_name(call_name: str, base: str) -> bool:
-    # Recognize when call_name = _call_name(base, n) for some n >= 0.
-    return re.match(re.escape(base) + r"(@\d+)?$", call_name) is not None
 
 
 class _ModuleFrame:

--- a/torch/export/unflatten.py
+++ b/torch/export/unflatten.py
@@ -101,13 +101,17 @@ def _assign_attr(
             if not hasattr(to_module, item):
                 setattr(to_module, item, torch.nn.Module())
             if item in to_module._modules:
-                ts.add(to_module._modules[item])
+                module = to_module._modules[item]
+                if module is not None:
+                    ts.add(module)
             i = 1
             while True:
                 variant = f"{item}@{i}"
                 if variant not in to_module._modules:
                     break
-                ts.add(to_module._modules[variant])
+                module = to_module._modules[variant]
+                if module is not None:
+                    ts.add(module)
                 i += 1
         to_modules = ts
 


### PR DESCRIPTION
Note: This issue is mentioned here: https://github.com/pytorch/pytorch/issues/175872#issuecomment-3998960281. Not sure if there is an issue tracking it.

- Many properties are called for each node (N) in the graph, where each property iterates over IO specs (M) with conditions. This sets up a O(NM) time complexity that is entirely avoidable and can be O(N+M).
  - inputs_to_parameters
  - inputs_to_buffers
  - buffers_to_mutate
  - parameters_to_mutate
  - user_inputs_to_mutate
- Next fix is a O(to_module^2), where for each module it iterates all modules and calls _is_call_name. This function is expensive and compiles a regex each time. Instead, we can more directly iterate the numbered variants and quit when we run out. This assumes no holes exist in the numbering. The only use of _is_call_name is thus removed so the function is removed as well.

**Before fixes:**

| Layers | Export (s) | Decompose (s)  |
|--------|------------|----------------|
| 64     | 0.38       | 0.85           |
| 128    | 0.55       | 1.67           |
| 256    | 1.14       | 3.16           |
| 512    | 2.19       | 7.11           |
| 1024   | 4.45       | 17.31          |
| 2048   | 8.88       | 47.38          |
| 4096   | 17.0       | 143.6          |

Decompose: Grows super-linearly

**After fixes:**

| Layers | Export (s) | Decompose (s)  |
|--------|------------|----------------|
| 64     | 0.52       | 0.81           |
| 128    | 0.52       | 1.77           |
| 256    | 1.28       | 2.88           |
| 512    | 2.34       | 5.47           |
| 1024   | 4.62       | 10.84          |
| 2048   | 8.48       | 20.26          |
| 4096   | 16.08      | 40.14          |

Decompose: Grows linearly