### PR TITLE
[CI] Fix bazel linter root user error in OSDC containers

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -225,6 +225,7 @@ load("@rules_python//python:repositories.bzl", "python_register_toolchains")
 
 python_register_toolchains(
     name = "python3_10",
+    ignore_root_user_error = True,
     python_version = "3.10",
 )
 


### PR DESCRIPTION
Add ignore_root_user_error to the bazel WORKSPACE python toolchain registration to fix the bazel_linter failing when running as root in the new OSDC container images.

Need to lint everything to see this error