### PR TITLE
[Dynamo][Cache]Add recompile_limit as torch.compile kwarg through plumbing

### DIFF
--- a/test/dynamo/test_recompile_ux.py
+++ b/test/dynamo/test_recompile_ux.py
@@ -372,22 +372,21 @@ class RecompileLimitKwargTests(torch._dynamo.test_case.TestCase):
             self._num_cache_entries(f), torch._dynamo.config.recompile_limit
         )
 
-    def test_recompile_limit_stricter_than_global(self):
-        """recompile_limit kwarg can be stricter than the global config."""
+    def test_recompile_limit_fullgraph_raises(self):
+        """With fullgraph=True, hitting the recompile_limit kwarg raises
+        FailOnRecompileLimitHit, consistent with the fullgraph contract."""
         cnt = torch._dynamo.testing.CompileCounter()
 
         def f(x):
             return x.sin()
 
-        # Global default is 8, but this region only allows 1
-        opt_f = torch.compile(f, backend=cnt, recompile_limit=1)
+        opt_f = torch.compile(f, backend=cnt, fullgraph=True, recompile_limit=1)
 
         opt_f(torch.randn(3))
         self.assertEqual(cnt.frame_count, 1)
 
-        # Should stop — recompile_limit=1 reached
-        opt_f(torch.randn(3, dtype=torch.float64))
-        self.assertEqual(cnt.frame_count, 1)
+        with self.assertRaises(FailOnRecompileLimitHit):
+            opt_f(torch.randn(3, dtype=torch.float64))
 
     @torch._dynamo.config.patch(automatic_dynamic_shapes=True)
     def test_recompile_limit_resume_function_auto_dynamic(self):

--- a/test/dynamo/test_recompile_ux.py
+++ b/test/dynamo/test_recompile_ux.py
@@ -321,6 +321,121 @@ class RecompileUxTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(res, inp + 3)
 
 
+class RecompileLimitKwargTests(torch._dynamo.test_case.TestCase):
+    @staticmethod
+    def _num_cache_entries(code):
+        return len(torch._dynamo.eval_frame._debug_get_cache_entry_list(code))
+
+    def test_recompile_limit_basic(self):
+        cnt = torch._dynamo.testing.CompileCounter()
+
+        def f(x, y):
+            return x + y
+
+        opt_f = torch.compile(f, backend=cnt, recompile_limit=2)
+
+        opt_f(torch.randn(3), torch.randn(3))
+        self.assertEqual(self._num_cache_entries(f), 1)
+
+        opt_f(torch.randn(3, dtype=torch.float64), torch.randn(3, dtype=torch.float64))
+        self.assertEqual(self._num_cache_entries(f), 2)
+
+        # Third dtype should NOT trigger recompilation (recompile_limit=2)
+        opt_f(torch.randn(3, dtype=torch.float16), torch.randn(3, dtype=torch.float16))
+        self.assertEqual(self._num_cache_entries(f), 2)
+
+    def test_recompile_limit_none_uses_global(self):
+        cnt = torch._dynamo.testing.CompileCounter()
+
+        def f(x, y):
+            return x + y
+
+        # Without recompile_limit kwarg, uses global config (default 8)
+        opt_f = torch.compile(f, backend=cnt)
+
+        for i in range(10):
+            dtype = [
+                torch.float32,
+                torch.float64,
+                torch.float16,
+                torch.bfloat16,
+                torch.int32,
+                torch.int64,
+                torch.int16,
+                torch.int8,
+                torch.uint8,
+                torch.complex64,
+            ][i]
+            opt_f(torch.ones(3, dtype=dtype), torch.ones(3, dtype=dtype))
+
+        self.assertEqual(
+            self._num_cache_entries(f), torch._dynamo.config.recompile_limit
+        )
+
+    def test_recompile_limit_stricter_than_global(self):
+        """recompile_limit kwarg can be stricter than the global config."""
+        cnt = torch._dynamo.testing.CompileCounter()
+
+        def f(x):
+            return x.sin()
+
+        # Global default is 8, but this region only allows 1
+        opt_f = torch.compile(f, backend=cnt, recompile_limit=1)
+
+        opt_f(torch.randn(3))
+        self.assertEqual(cnt.frame_count, 1)
+
+        # Should stop — recompile_limit=1 reached
+        opt_f(torch.randn(3, dtype=torch.float64))
+        self.assertEqual(cnt.frame_count, 1)
+
+    @torch._dynamo.config.patch(automatic_dynamic_shapes=True)
+    def test_recompile_limit_resume_function_auto_dynamic(self):
+        """With automatic dynamic shapes and recompile_limit=2, the resume
+        function recompiles via dimension changes on a global tensor while
+        the main function gets cache hits. The resume function should stop
+        at 2 entries and fall back to eager."""
+        cnt = torch._dynamo.testing.CompileCounter()
+
+        y_holder = {"tensor": torch.randn(4, 8, 2)}
+
+        def f(x):
+            x.sin()
+            print("graph break")
+            return y_holder["tensor"].cos()
+
+        opt_f = torch.compile(f, backend=cnt, recompile_limit=2)
+
+        # Call 1: static compile
+        y_holder["tensor"] = torch.randn(4, 8, 2)
+        opt_f(torch.randn(4, 8, 2))
+
+        # Call 2: y dim0 changes -> f cache hit, resume recompiles
+        y_holder["tensor"] = torch.randn(5, 8, 2)
+        opt_f(torch.randn(4, 8, 2))
+        frame_count_after_2 = cnt.frame_count
+
+        # Call 3: y dim1 changes -> resume should NOT recompile
+        # (resume already has 2 entries = recompile_limit)
+        y_holder["tensor"] = torch.randn(5, 9, 2)
+        opt_f(torch.randn(4, 8, 2))
+        self.assertEqual(cnt.frame_count, frame_count_after_2)
+
+        # Verify f has 1 entry, resume has 2
+        num_f_entries = len(torch._dynamo.eval_frame._debug_get_cache_entry_list(f))
+        self.assertEqual(num_f_entries, 1)
+
+        from torch._dynamo.resume_execution import ContinueExecutionCache
+
+        resume_codes = list(ContinueExecutionCache.cache[f.__code__].values())
+        self.assertTrue(len(resume_codes) > 0, "No resume functions found")
+        for resume_code in resume_codes:
+            num_resume_entries = len(
+                torch._dynamo.eval_frame._debug_get_cache_entry_list(resume_code)
+            )
+            self.assertEqual(num_resume_entries, 2)
+
+
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests
 

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -2593,6 +2593,7 @@ def compile(
     mode: str | None = None,
     options: dict[str, str | builtins.int | builtins.bool | _Callable] | None = None,
     disable: builtins.bool = False,
+    recompile_limit: builtins.int | None = None,
 ) -> (
     _Callable[[_Callable[_InputT, _RetT]], _Callable[_InputT, _RetT]]
     | _Callable[_InputT, _RetT]
@@ -2776,6 +2777,7 @@ def compile(
         dynamic=dynamic,
         disable=disable,
         guard_filter_fn=guard_filter_fn,
+        recompile_limit=recompile_limit,
     )(model)  # type: ignore[return-value]
 
 

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -584,6 +584,7 @@ class ConvertFrameAssert:
         export: bool = False,
         export_constraints: Any | None = None,
         package: CompilePackage | None = None,
+        recompile_limit: int | None = None,
     ) -> None:
         # assert export_constraints is None
         reset_graph_break_dup_checker()
@@ -592,6 +593,7 @@ class ConvertFrameAssert:
         self._export = export
         self._export_constraints = export_constraints
         self._package = package
+        self._recompile_limit = recompile_limit
         self._box = ConvertFrameBox()
 
     @property
@@ -601,6 +603,7 @@ class ConvertFrameAssert:
             self._one_graph,
             self._export,
             self._export_constraints,
+            recompile_limit=self._recompile_limit,
         )
 
     def __call__(
@@ -719,7 +722,15 @@ class ConvertFrameAssert:
             dynamo_tls.traced_frame_infos.append(info)
 
         try:
-            with compile_context(CompileContext(compile_id)):
+            compile_ctx = compile_context(CompileContext(compile_id))
+            # When recompile_limit is set, temporarily override the global
+            # config so the existing exceeds_recompile_limit check uses it.
+            recompile_ctx = (
+                config.patch(recompile_limit=self._recompile_limit)
+                if self._recompile_limit is not None
+                else contextlib.nullcontext()
+            )
+            with compile_ctx, recompile_ctx:
                 result = _compile(
                     frame.f_code,
                     frame.f_globals,
@@ -758,10 +769,16 @@ def convert_frame_assert(
     export: bool = False,
     export_constraints: Any | None = None,
     package: CompilePackage | None = None,
+    recompile_limit: int | None = None,
 ) -> ConvertFrameAssert:
     """Fully convert a frame into an FX graph, raising an exception if we fail."""
     return ConvertFrameAssert(
-        compiler_fn, one_graph, export, export_constraints, package
+        compiler_fn,
+        one_graph,
+        export,
+        export_constraints,
+        package,
+        recompile_limit,
     )
 
 
@@ -2068,18 +2085,24 @@ class ConvertFrame:
         compiler_fn: CompilerFn,
         hooks: Hooks,
         package: CompilePackage | None = None,
+        recompile_limit: int | None = None,
     ) -> None:
         self._torchdynamo_orig_backend = compiler_fn
         self._inner_convert = convert_frame_assert(
-            compiler_fn, one_graph=False, package=package
+            compiler_fn,
+            one_graph=False,
+            package=package,
+            recompile_limit=recompile_limit,
         )
         self._hooks = hooks
+        self._recompile_limit = recompile_limit
 
     @property
     def _clone_with_backend(self) -> Callable[[WrapBackendDebug], ConvertFrame]:
         return lambda backend: convert_frame(
             backend,
             self._hooks,
+            recompile_limit=self._recompile_limit,
         )
 
     def __call__(
@@ -2204,9 +2227,12 @@ def convert_frame(
     compiler_fn: CompilerFn,
     hooks: Hooks,
     package: CompilePackage | None = None,
+    recompile_limit: int | None = None,
 ) -> ConvertFrame:
     """Try to convert a frame into an FX graph, if error leave frame unmodified"""
-    return ConvertFrame(compiler_fn, hooks, package=package)
+    return ConvertFrame(
+        compiler_fn, hooks, package=package, recompile_limit=recompile_limit
+    )
 
 
 # TODO mlazos: add support for same args, or record them

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -1563,6 +1563,7 @@ def _optimize(
             hooks=hooks,
             rebuild_ctx=rebuild_ctx,
             package=package,
+            recompile_limit=recompile_limit,
         )
 
     backend = get_compiler_fn(backend)
@@ -2439,6 +2440,7 @@ def _optimize_assert(
     export_constraints: Any | None = None,
     dynamic: bool | None = None,
     package: CompilePackage | None = None,
+    recompile_limit: int | None = None,
 ) -> OptimizeContext:
     """
     Guarantees single-graph capture.
@@ -2469,6 +2471,7 @@ def _optimize_assert(
             export=export,
             export_constraints=export_constraints,
             package=package,
+            recompile_limit=recompile_limit,
         ),
         hooks,
         backend_ctx_ctor,

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -1504,6 +1504,7 @@ def _optimize(
     disable: bool = False,
     dynamic: bool | None = None,
     package: CompilePackage | None = None,
+    recompile_limit: int | None = None,
 ) -> OptimizeContext | _NullDecorator:
     """
     The main entrypoint of TorchDynamo.  Do graph capture and call
@@ -1585,6 +1586,7 @@ def _optimize(
             backend,
             hooks,
             package=package,
+            recompile_limit=recompile_limit,
         ),
         hooks,
         backend_ctx_ctor,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #177936

Testing the current config of recompile_limit and extending that as a kwarg input for ``torch.compile()``

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @mlazos