### PR TITLE
[dtensor] Fix DecompSharding mesh discovery and add _unsafe_index support

### DIFF
--- a/test/distributed/tensor/test_decompositions.py
+++ b/test/distributed/tensor/test_decompositions.py
@@ -296,6 +296,87 @@ class TestDecompShardingWithComms(DTensorTestBase):
         self.assertTrue(torch.equal(result_dim1.min.full_tensor(), expected_dim1.min))
         self.assertTrue(torch.equal(result_dim1.max.full_tensor(), expected_dim1.max))
 
+    def _remove_strategy(self, op):
+        """Temporarily remove an op's explicit strategy to test DecompSharding fallback."""
+        prop = DTensor._op_dispatcher.sharding_propagator
+        saved = {}
+        for name, d in [
+            ("op_strategy", prop.op_strategy_funcs),
+            ("op_schema", prop.op_to_schema_info),
+            ("single_dim", prop.op_single_dim_strategy_funcs),
+            ("single_dim_schema", prop.op_to_schema_info_for_single_dim_strategy),
+        ]:
+            if op in d:
+                saved[name] = d.pop(op)
+        if hasattr(prop.propagate_op_sharding, "cache_clear"):
+            prop.propagate_op_sharding.cache_clear()
+        return saved
+
+    def _restore_strategy(self, op, saved):
+        prop = DTensor._op_dispatcher.sharding_propagator
+        mapping = {
+            "op_strategy": prop.op_strategy_funcs,
+            "op_schema": prop.op_to_schema_info,
+            "single_dim": prop.op_single_dim_strategy_funcs,
+            "single_dim_schema": prop.op_to_schema_info_for_single_dim_strategy,
+        }
+        for name, val in saved.items():
+            mapping[name][op] = val
+        if hasattr(prop.propagate_op_sharding, "cache_clear"):
+            prop.propagate_op_sharding.cache_clear()
+
+    def _test_decomp_fallback(self, op, run_fn):
+        """Remove explicit strategy, run op via DecompSharding, verify it returns DTensor."""
+        saved = self._remove_strategy(op)
+        try:
+            result = run_fn()
+            if isinstance(result, (tuple, list)):
+                self.assertTrue(any(isinstance(r, DTensor) for r in result))
+            else:
+                self.assertIsInstance(result, DTensor)
+        finally:
+            self._restore_strategy(op, saved)
+
+    @with_comms
+    def test_decomp_fallback_ops(self):
+        """Ops with decompositions that work via DecompSharding without explicit strategies."""
+        aten = torch.ops.aten
+        mesh = self.build_device_mesh()
+        dt = lambda t: DTensor.from_local(t, mesh, [Replicate()])
+
+        x = dt(torch.randn(4, 5, device=self.device_type))
+        idx = dt(torch.tensor([0, 2], device=self.device_type))
+        src = dt(torch.randn(2, 5, device=self.device_type))
+
+        self._test_decomp_fallback(
+            aten.index_add.default, lambda: aten.index_add(x, 0, idx, src)
+        )
+        self._test_decomp_fallback(
+            aten.index_copy.default, lambda: aten.index_copy(x, 0, idx, src)
+        )
+        val = dt(torch.tensor(3.14, device=self.device_type))
+        self._test_decomp_fallback(
+            aten.index_fill.int_Tensor,
+            lambda: aten.index_fill.int_Tensor(x, 0, idx, val),
+        )
+        self._test_decomp_fallback(
+            aten.isin.Tensor_Scalar,
+            lambda: aten.isin.Tensor_Scalar(
+                dt(torch.tensor([1, 2, 3], device=self.device_type)), 3
+            ),
+        )
+        self._test_decomp_fallback(
+            aten.renorm.default, lambda: aten.renorm(x, 2.0, 0, 1.0)
+        )
+        self._test_decomp_fallback(
+            aten.kron.default,
+            lambda: aten.kron(
+                dt(torch.randn(2, 3, device=self.device_type)),
+                dt(torch.randn(4, 5, device=self.device_type)),
+            ),
+        )
+
+
 
 if __name__ == "__main__":
     run_tests()

--- a/torch/distributed/tensor/_decompositions.py
+++ b/torch/distributed/tensor/_decompositions.py
@@ -18,7 +18,6 @@ from torch.distributed._functional_collectives import _are_we_tracing
 from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.tensor._dtensor_spec import DTensorSpec
 from torch.distributed.tensor._op_schema import OpSchema, OpStrategy, RuntimeSchemaInfo
-from torch.distributed.tensor._utils import try_find_mesh_from_args
 from torch.distributed.tensor.placement_types import (
     _StridedShard,
     Placement,
@@ -199,10 +198,7 @@ class DecompShardingStrategy:
             return None
 
         candidate_placements = self._get_candidate_placements(op_schema)
-        mesh = try_find_mesh_from_args(
-            op_schema.op,
-            op_schema.args_schema + tuple(op_schema.kwargs_schema.values()),
-        )
+        mesh = op_schema.get_mesh_from_args(validate=False)
 
         fake_mesh = self._get_fake_mesh(mesh.device_type)
         single_dim_strategies = []

--- a/torch/distributed/tensor/_ops/_tensor_ops.py
+++ b/torch/distributed/tensor/_ops/_tensor_ops.py
@@ -992,7 +992,8 @@ def index_select_single_dim_strategy(
 
 
 @register_single_dim_strategy(
-    aten.index.Tensor, schema_info=RuntimeSchemaInfo(needs_pytree=True)
+    [aten.index.Tensor, aten._unsafe_index.Tensor],
+    schema_info=RuntimeSchemaInfo(needs_pytree=True),
 )
 def index_single_dim_strategy(
     op: OpOverload, args_schema: ArgsType, kwargs_schema: KwargsType


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* #177939
* __->__ #177938

Use op_schema.get_mesh_from_args(validate=False) instead of
try_find_mesh_from_args to handle TupleStrategy inputs in
DecompShardingStrategy. Register aten._unsafe_index.Tensor alongside
aten.index.Tensor in prop_index so padding decompositions that use the
bounds-unchecked variant can propagate sharding.