### PR TITLE
submodule init `third_party/cutlass` in `test_h100_cutlass_backend`

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -414,6 +414,7 @@ test_b200_symm_mem() {
 
 test_h100_cutlass_backend() {
   # cutlass backend tests for H100
+  git submodule update --init --depth 1 third_party/cutlass
   TORCHINDUCTOR_CUTLASS_DIR=$(realpath "./third_party/cutlass") python test/run_test.py --include inductor/test_cutlass_backend -k "not addmm" $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
   TORCHINDUCTOR_CUTLASS_DIR=$(realpath "./third_party/cutlass") python test/run_test.py --include inductor/test_cutlass_evt $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
 }


### PR DESCRIPTION
`inductor/test_cutlass_backend.py`'s `test_aoti_workspace_ptr` failed in some commits e.g. 719c659e7c7f8db1a973d9da5d054e64fcc0c6e0. Looking into [the job in question](https://github.com/pytorch/pytorch/actions/runs/23283286504/job/67704458771), the test failed to import CUTLASS lib
([ref](https://github.com/pytorch/pytorch/actions/runs/23283286504/job/67704458771#step:27:715)):
```
inductor/test_cutlass_backend.py::TestCutlassBackend::test_aoti_workspace_ptr W0319 07:39:18.937000 287 site-packages/torch/_inductor/utils.py:2157] [0/0] Failed to import CUTLASS lib. Please check whether _inductor.config.cutlass.cutlass_dir /var/lib/jenkins/workspace/third_party/cutlass is set correctly. Skipping CUTLASS backend for now.
('RERUN', {'yellow': True}) [1.8045s] [  0%]
```

Also, according to
https://github.com/pytorch/pytorch/actions/runs/23283286504/job/67704458771#step:3:231, it seems that submodules are not initialized in the test while `TORCHINDUCTOR_CUTLASS_DIR` seems to be correctly set. Thus I update `test_h100_cutlass_backend` to init `third_party/cutlass`.