### PR TITLE
[inductor] Fix epilogue fusion crash when same tensor returned twice

### DIFF
--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -2050,8 +2050,11 @@ class ExternalTritonTemplateKernel(TritonTemplateKernel):
         """
         from torch._inductor.dependencies import MemoryDep
 
-        # Filter eligible epilogues
+        # Filter eligible epilogues.  Only one epilogue per output_param
+        # (store site) is allowed — the template has a single store per param
+        # and can only emit one <STORE_OUTPUT_{i}> placeholder for it.
         epilogues = []
+        seen_params: set[str] = set()
         for epilogue_node in epilogue_nodes:
             if isinstance(epilogue_node.node, ir.MultiOutput):
                 continue
@@ -2063,13 +2066,17 @@ class ExternalTritonTemplateKernel(TritonTemplateKernel):
             if len(dep_names) != 1:
                 continue
             output_buf = next(iter(dep_names))
+            output_param = output_param_mapping[output_buf]
+            if output_param in seen_params:
+                continue
+            seen_params.add(output_param)
             epilogue_writes = epilogue_node.read_writes.writes
             raw_st = next(iter(epilogue_writes)).name if epilogue_writes else None
             epilogues.append(
                 (
                     epilogue_node,
                     output_buf,
-                    output_param_mapping[output_buf],
+                    output_param,
                     raw_st if raw_st != output_buf else None,
                 )
             )


### PR DESCRIPTION
## Summary

Fixes a bug in `ExternalTritonTemplateKernel._find_eligible_epilogues` where returning the same tensor twice from an external template kernel (e.g. Helion's `return out, out`) causes a `SyntaxError: invalid syntax` at module load time.

**Root cause**: `build_multi_outputs` deduplicates by tensor identity, creating a single `MultiOutput` buffer. But that buffer can have multiple reader nodes (e.g. `relu(x)+1` and `relu(x)+2`), causing `_find_eligible_epilogues` to create more epilogue entries than render hooks. This makes `_epilogue_idx_by_param` overwrite with an out-of-range index, leaving an unreplaced `<STORE_OUTPUT_{i}>` placeholder in the generated Triton code.

**Fix**: Deduplicate eligible epilogues by `output_param` — only one epilogue per store site is allowed since the template has a single store per param and can only emit one `<STORE_OUTPUT_{i}>` placeholder. The second reader stays unfused and gets its own kernel.

## Test plan

- Tested with Helion's `test_kernel_returns_same_tensor_twice` (was failing with `SyntaxError`, now passes)
- Tested with Helion's `test_same_tensor_as_two_different_args` (continues to pass)
- Full Helion torch.compile test suite: 226 passed, 18 skipped, 0 failures (was 224 passed, 2 failures)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @jansel @eellison