### PR TITLE
[xpu] Fix conv2d incorrect results and alignment errors for non-64-byte-aligned tensors on XPU.

### DIFF
--- a/aten/src/ATen/native/mkldnn/xpu/Conv.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/Conv.cpp
@@ -386,10 +386,10 @@ Tensor _convolution_out(
       : at::MemoryFormat::Contiguous;
 
   auto bias = bias_r.defined()
-      ? contiguous_if_needed_for_onednn(bias_r)
+      ? make_contiguous_and_aligned(bias_r)
       : bias_r;
-  input = contiguous_if_needed_for_onednn(input, mfmt);
-  weight = contiguous_if_needed_for_onednn(weight, mfmt);
+  input = make_contiguous_and_aligned(input, mfmt);
+  weight = make_contiguous_and_aligned(weight, mfmt);
   check_shape_forward(input, weight, bias, params, true);
 
   Tensor output;
@@ -594,9 +594,9 @@ std::tuple<Tensor, Tensor, Tensor> convolution_backward_overrideable(
   auto mfmt = is_channels_last_suggested
       ? get_cl_tag_by_ndim(input_.ndimension())
       : at::MemoryFormat::Contiguous;
-  grad_output_ = contiguous_if_needed_for_onednn(grad_output_, mfmt);
-  weight_ = contiguous_if_needed_for_onednn(weight_, mfmt);
-  input_ = contiguous_if_needed_for_onednn(input_, mfmt);
+  grad_output_ = make_contiguous_and_aligned(grad_output_, mfmt);
+  weight_ = make_contiguous_and_aligned(weight_, mfmt);
+  input_ = make_contiguous_and_aligned(input_, mfmt);
 
   auto opt = grad_output_.options();
   Tensor grad_input;

--- a/aten/src/ATen/native/mkldnn/xpu/Conv.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/Conv.cpp
@@ -384,9 +384,20 @@ Tensor _convolution_out(
   at::MemoryFormat mfmt = is_channels_last_suggested
       ? get_cl_tag_by_ndim(input.ndimension())
       : at::MemoryFormat::Contiguous;
-  auto bias = bias_r.defined() ? bias_r.contiguous() : bias_r;
-  input = input.contiguous(mfmt);
-  weight = weight.contiguous(mfmt);
+  auto make_zero_offset = [](const Tensor& t, std::optional<at::MemoryFormat> fmt) {
+    if (!t.defined()) {
+      return t;
+    }
+    auto out = fmt.has_value() ? t.contiguous(*fmt) : t.contiguous();
+    if (out.storage_offset() != 0) {
+      out = out.clone();
+    }
+    return out;
+  };
+
+  auto bias = make_zero_offset(bias_r, std::nullopt);
+  input = make_zero_offset(input, mfmt);
+  weight = make_zero_offset(weight, mfmt);
   check_shape_forward(input, weight, bias, params, true);
 
   Tensor output;
@@ -591,9 +602,16 @@ std::tuple<Tensor, Tensor, Tensor> convolution_backward_overrideable(
   auto mfmt = is_channels_last_suggested
       ? get_cl_tag_by_ndim(input_.ndimension())
       : at::MemoryFormat::Contiguous;
-  grad_output_ = grad_output_.contiguous(mfmt);
-  weight_ = weight_.contiguous(mfmt);
-  input_ = input_.contiguous(mfmt);
+  auto make_zero_offset = [](const Tensor& t, at::MemoryFormat fmt) {
+    auto out = t.contiguous(fmt);
+    if (out.storage_offset() != 0) {
+      out = out.clone();
+    }
+    return out;
+  };
+  grad_output_ = make_zero_offset(grad_output_, mfmt);
+  weight_ = make_zero_offset(weight_, mfmt);
+  input_ = make_zero_offset(input_, mfmt);
 
   auto opt = grad_output_.options();
   Tensor grad_input;

--- a/aten/src/ATen/native/mkldnn/xpu/Conv.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/Conv.cpp
@@ -384,20 +384,12 @@ Tensor _convolution_out(
   at::MemoryFormat mfmt = is_channels_last_suggested
       ? get_cl_tag_by_ndim(input.ndimension())
       : at::MemoryFormat::Contiguous;
-  auto make_zero_offset = [](const Tensor& t, std::optional<at::MemoryFormat> fmt) {
-    if (!t.defined()) {
-      return t;
-    }
-    auto out = fmt.has_value() ? t.contiguous(*fmt) : t.contiguous();
-    if (out.storage_offset() != 0) {
-      out = out.clone();
-    }
-    return out;
-  };
 
-  auto bias = make_zero_offset(bias_r, std::nullopt);
-  input = make_zero_offset(input, mfmt);
-  weight = make_zero_offset(weight, mfmt);
+  auto bias = bias_r.defined()
+      ? contiguous_if_needed_for_onednn(bias_r)
+      : bias_r;
+  input = contiguous_if_needed_for_onednn(input, mfmt);
+  weight = contiguous_if_needed_for_onednn(weight, mfmt);
   check_shape_forward(input, weight, bias, params, true);
 
   Tensor output;
@@ -602,16 +594,9 @@ std::tuple<Tensor, Tensor, Tensor> convolution_backward_overrideable(
   auto mfmt = is_channels_last_suggested
       ? get_cl_tag_by_ndim(input_.ndimension())
       : at::MemoryFormat::Contiguous;
-  auto make_zero_offset = [](const Tensor& t, at::MemoryFormat fmt) {
-    auto out = t.contiguous(fmt);
-    if (out.storage_offset() != 0) {
-      out = out.clone();
-    }
-    return out;
-  };
-  grad_output_ = make_zero_offset(grad_output_, mfmt);
-  weight_ = make_zero_offset(weight_, mfmt);
-  input_ = make_zero_offset(input_, mfmt);
+  grad_output_ = contiguous_if_needed_for_onednn(grad_output_, mfmt);
+  weight_ = contiguous_if_needed_for_onednn(weight_, mfmt);
+  input_ = contiguous_if_needed_for_onednn(input_, mfmt);
 
   auto opt = grad_output_.options();
   Tensor grad_input;

--- a/aten/src/ATen/native/mkldnn/xpu/Conv.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/Conv.cpp
@@ -385,9 +385,7 @@ Tensor _convolution_out(
       ? get_cl_tag_by_ndim(input.ndimension())
       : at::MemoryFormat::Contiguous;
 
-  auto bias = bias_r.defined()
-      ? make_contiguous_and_aligned(bias_r)
-      : bias_r;
+  auto bias = bias_r.defined() ? make_contiguous_and_aligned(bias_r) : bias_r;
   input = make_contiguous_and_aligned(input, mfmt);
   weight = make_contiguous_and_aligned(weight, mfmt);
   check_shape_forward(input, weight, bias, params, true);

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Utils.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Utils.cpp
@@ -287,6 +287,26 @@ void undo_broadcast(at::Tensor& tensor) {
   return;
 }
 
+bool is_aligned_for_onednn(const at::Tensor& tensor) {
+  constexpr uintptr_t alignment_byte = 64;
+  return reinterpret_cast<uintptr_t>(tensor.data_ptr()) % alignment_byte == 0;
+}
+
+at::Tensor contiguous_if_needed_for_onednn(
+    const at::Tensor& tensor,
+    std::optional<at::MemoryFormat> memory_format) {
+  at::Tensor out = memory_format.has_value()
+      ? tensor.contiguous(*memory_format)
+      : tensor.contiguous();
+
+  // oneDNN kernels can produce incorrect results for misaligned
+  // non-zero-offset tensors, so force a fresh allocation in this case.
+  if (out.storage_offset() > 0 && !is_aligned_for_onednn(out)) {
+    out = out.clone();
+  }
+  return out;
+}
+
 bool is_onednn_matmul_strides(const at::Tensor& tensor) {
   // https://oneapi-src.github.io/oneDNN/dev_guide_matmul.html
   // oneDNN matmul only support 2-dim and 3-dim
@@ -300,12 +320,8 @@ bool is_onednn_matmul_strides(const at::Tensor& tensor) {
   if (tensor.is_contiguous())
     return true;
 
-  if (tensor.storage_offset() > 0) {
-    // currently onednn asks 64 byte alignment
-    constexpr int alignment_byte = 64;
-    if (reinterpret_cast<uintptr_t>(tensor.data_ptr()) % alignment_byte > 0)
-      return false;
-  }
+  if (tensor.storage_offset() > 0 && !is_aligned_for_onednn(tensor))
+    return false;
 
   // the overlapped cases are not supported
   dnnl::memory::dims strides = get_onednn_strides(tensor);

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Utils.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Utils.cpp
@@ -287,23 +287,22 @@ void undo_broadcast(at::Tensor& tensor) {
   return;
 }
 
-bool is_aligned_for_onednn(const at::Tensor& tensor) {
+bool is_64_bytes_aligned(const at::Tensor& tensor) {
   constexpr uintptr_t alignment_byte = 64;
   return reinterpret_cast<uintptr_t>(tensor.data_ptr()) % alignment_byte == 0;
 }
 
-at::Tensor contiguous_if_needed_for_onednn(
+at::Tensor make_contiguous_and_aligned(
     const at::Tensor& tensor,
     std::optional<at::MemoryFormat> memory_format) {
   at::Tensor out = memory_format.has_value()
       ? tensor.contiguous(*memory_format)
       : tensor.contiguous();
 
-  // oneDNN kernels can produce incorrect results for misaligned
-  // non-zero-offset tensors, so force a fresh allocation in this case.
-  if (out.storage_offset() > 0 && !is_aligned_for_onednn(out)) {
+  if (out.storage_offset() > 0 && !is_64_bytes_aligned(out)) {
     out = out.clone();
   }
+
   return out;
 }
 
@@ -320,8 +319,9 @@ bool is_onednn_matmul_strides(const at::Tensor& tensor) {
   if (tensor.is_contiguous())
     return true;
 
-  if (tensor.storage_offset() > 0 && !is_aligned_for_onednn(tensor))
+  if (tensor.storage_offset() > 0 && !is_64_bytes_aligned(tensor)) {
     return false;
+  }
 
   // the overlapped cases are not supported
   dnnl::memory::dims strides = get_onednn_strides(tensor);

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Utils.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Utils.cpp
@@ -289,17 +289,21 @@ void undo_broadcast(at::Tensor& tensor) {
 
 bool is_64_bytes_aligned(const at::Tensor& tensor) {
   constexpr uintptr_t alignment_byte = 64;
-  return reinterpret_cast<uintptr_t>(tensor.data_ptr()) % alignment_byte == 0;
+  return reinterpret_cast<uintptr_t>(tensor.const_data_ptr()) %
+      alignment_byte ==
+      0;
 }
 
 at::Tensor make_contiguous_and_aligned(
     const at::Tensor& tensor,
     std::optional<at::MemoryFormat> memory_format) {
-  at::Tensor out = memory_format.has_value()
-      ? tensor.contiguous(*memory_format)
-      : tensor.contiguous();
+  at::Tensor out = memory_format.has_value() ? tensor.contiguous(*memory_format)
+                                             : tensor.contiguous();
 
   if (out.storage_offset() > 0 && !is_64_bytes_aligned(out)) {
+    TORCH_WARN(
+        "Tensor is not 64-byte aligned. Cloning to ensure alignment for oneDNN "
+        "operations, which incurs a device-to-device copy.");
     out = out.clone();
   }
 

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Utils.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Utils.cpp
@@ -298,7 +298,6 @@ at::Tensor make_contiguous_and_aligned(
     std::optional<at::MemoryFormat> memory_format) {
   at::Tensor out = memory_format.has_value() ? tensor.contiguous(*memory_format)
                                              : tensor.contiguous();
-
   if (!is_64_bytes_aligned(out)) {
     TORCH_WARN(
         "Tensor is not 64-byte aligned. Cloning to ensure alignment for oneDNN "

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Utils.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Utils.cpp
@@ -289,9 +289,8 @@ void undo_broadcast(at::Tensor& tensor) {
 
 bool is_64_bytes_aligned(const at::Tensor& tensor) {
   constexpr uintptr_t alignment_byte = 64;
-  return reinterpret_cast<uintptr_t>(tensor.const_data_ptr()) %
-      alignment_byte ==
-      0;
+  auto data_ptr = reinterpret_cast<uintptr_t>(tensor.const_data_ptr());
+  return (data_ptr % alignment_byte) == 0;
 }
 
 at::Tensor make_contiguous_and_aligned(
@@ -300,7 +299,7 @@ at::Tensor make_contiguous_and_aligned(
   at::Tensor out = memory_format.has_value() ? tensor.contiguous(*memory_format)
                                              : tensor.contiguous();
 
-  if (out.storage_offset() > 0 && !is_64_bytes_aligned(out)) {
+  if (!is_64_bytes_aligned(out)) {
     TORCH_WARN(
         "Tensor is not 64-byte aligned. Cloning to ensure alignment for oneDNN "
         "operations, which incurs a device-to-device copy.");

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Utils.h
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Utils.h
@@ -3,6 +3,7 @@
 #include <ATen/Tensor.h>
 #include <ATen/core/Tensor.h>
 #include <iostream>
+#include <optional>
 
 #include <ATen/core/grad_mode.h>
 #include <c10/core/MemoryFormat.h>
@@ -45,6 +46,12 @@ void undo_broadcast_on_batch(at::Tensor& m1, at::Tensor& m2);
 void undo_broadcast(at::Tensor& tensor);
 
 bool is_onednn_matmul_strides(const at::Tensor& tensor);
+
+bool is_aligned_for_onednn(const at::Tensor& tensor);
+
+at::Tensor contiguous_if_needed_for_onednn(
+  const at::Tensor& tensor,
+  std::optional<at::MemoryFormat> memory_format = std::nullopt);
 
 bool is_broadcast_from_other_to_self(
     const at::Tensor& self,

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Utils.h
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Utils.h
@@ -47,9 +47,9 @@ void undo_broadcast(at::Tensor& tensor);
 
 bool is_onednn_matmul_strides(const at::Tensor& tensor);
 
-bool is_aligned_for_onednn(const at::Tensor& tensor);
+bool is_64_bytes_aligned(const at::Tensor& tensor);
 
-at::Tensor contiguous_if_needed_for_onednn(
+at::Tensor make_contiguous_and_aligned(
   const at::Tensor& tensor,
   std::optional<at::MemoryFormat> memory_format = std::nullopt);
 

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Utils.h
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Utils.h
@@ -50,8 +50,8 @@ bool is_onednn_matmul_strides(const at::Tensor& tensor);
 bool is_64_bytes_aligned(const at::Tensor& tensor);
 
 at::Tensor make_contiguous_and_aligned(
-  const at::Tensor& tensor,
-  std::optional<at::MemoryFormat> memory_format = std::nullopt);
+    const at::Tensor& tensor,
+    std::optional<at::MemoryFormat> memory_format = std::nullopt);
 
 bool is_broadcast_from_other_to_self(
     const at::Tensor& self,

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -1157,30 +1157,30 @@ if(USE_XPU)
   # ATen XPU implementation
   set(TORCH_XPU_OPS_DIR ${TORCH_ROOT}/third_party/torch-xpu-ops)
   set(TORCH_XPU_OPS_REPO_URL https://github.com/intel/torch-xpu-ops.git)
-  file(READ "${TORCH_ROOT}/third_party/xpu.txt" TORCH_XPU_OPS_COMMIT)
-  string(REGEX REPLACE "\n$" "" TORCH_XPU_OPS_COMMIT "${TORCH_XPU_OPS_COMMIT}")
-  if(NOT EXISTS "${TORCH_XPU_OPS_DIR}/.git")
-    execute_process(
-      COMMAND git clone --quiet ${TORCH_XPU_OPS_REPO_URL} ${TORCH_XPU_OPS_DIR}
-      RESULT_VARIABLE _exitcode)
-    if(NOT _exitcode EQUAL 0)
-      message(FATAL_ERROR "Fail to clone ${TORCH_XPU_OPS_REPO_URL}")
-    endif()
-  endif()
-  execute_process(
-    COMMAND git fetch --quiet
-    WORKING_DIRECTORY ${TORCH_XPU_OPS_DIR}
-    RESULT_VARIABLE _exitcode)
-  if(NOT _exitcode EQUAL 0)
-    message(FATAL_ERROR "Fail to fetch ${TORCH_XPU_OPS_REPO_URL}")
-  endif()
-  execute_process(
-    COMMAND git checkout --quiet ${TORCH_XPU_OPS_COMMIT}
-    WORKING_DIRECTORY ${TORCH_XPU_OPS_DIR}
-    RESULT_VARIABLE _exitcode)
-  if(NOT _exitcode EQUAL 0)
-    message(FATAL_ERROR "Fail to checkout ${TORCH_XPU_OPS_REPO_URL} to ${TORCH_XPU_OPS_COMMIT}")
-  endif()
+  # file(READ "${TORCH_ROOT}/third_party/xpu.txt" TORCH_XPU_OPS_COMMIT)
+  # string(REGEX REPLACE "\n$" "" TORCH_XPU_OPS_COMMIT "${TORCH_XPU_OPS_COMMIT}")
+  # if(NOT EXISTS "${TORCH_XPU_OPS_DIR}/.git")
+  #   execute_process(
+  #     COMMAND git clone --quiet ${TORCH_XPU_OPS_REPO_URL} ${TORCH_XPU_OPS_DIR}
+  #     RESULT_VARIABLE _exitcode)
+  #   if(NOT _exitcode EQUAL 0)
+  #     message(FATAL_ERROR "Fail to clone ${TORCH_XPU_OPS_REPO_URL}")
+  #   endif()
+  # endif()
+  # execute_process(
+  #   COMMAND git fetch --quiet
+  #   WORKING_DIRECTORY ${TORCH_XPU_OPS_DIR}
+  #   RESULT_VARIABLE _exitcode)
+  # if(NOT _exitcode EQUAL 0)
+  #   message(FATAL_ERROR "Fail to fetch ${TORCH_XPU_OPS_REPO_URL}")
+  # endif()
+  # execute_process(
+  #   COMMAND git checkout --quiet ${TORCH_XPU_OPS_COMMIT}
+  #   WORKING_DIRECTORY ${TORCH_XPU_OPS_DIR}
+  #   RESULT_VARIABLE _exitcode)
+  # if(NOT _exitcode EQUAL 0)
+  #   message(FATAL_ERROR "Fail to checkout ${TORCH_XPU_OPS_REPO_URL} to ${TORCH_XPU_OPS_COMMIT}")
+  # endif()
 
   set(TORCH_XPU_OPS_INCLUDE_DIRS
       ${TORCH_SRC_DIR}/csrc/api

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -1157,30 +1157,30 @@ if(USE_XPU)
   # ATen XPU implementation
   set(TORCH_XPU_OPS_DIR ${TORCH_ROOT}/third_party/torch-xpu-ops)
   set(TORCH_XPU_OPS_REPO_URL https://github.com/intel/torch-xpu-ops.git)
-  # file(READ "${TORCH_ROOT}/third_party/xpu.txt" TORCH_XPU_OPS_COMMIT)
-  # string(REGEX REPLACE "\n$" "" TORCH_XPU_OPS_COMMIT "${TORCH_XPU_OPS_COMMIT}")
-  # if(NOT EXISTS "${TORCH_XPU_OPS_DIR}/.git")
-  #   execute_process(
-  #     COMMAND git clone --quiet ${TORCH_XPU_OPS_REPO_URL} ${TORCH_XPU_OPS_DIR}
-  #     RESULT_VARIABLE _exitcode)
-  #   if(NOT _exitcode EQUAL 0)
-  #     message(FATAL_ERROR "Fail to clone ${TORCH_XPU_OPS_REPO_URL}")
-  #   endif()
-  # endif()
-  # execute_process(
-  #   COMMAND git fetch --quiet
-  #   WORKING_DIRECTORY ${TORCH_XPU_OPS_DIR}
-  #   RESULT_VARIABLE _exitcode)
-  # if(NOT _exitcode EQUAL 0)
-  #   message(FATAL_ERROR "Fail to fetch ${TORCH_XPU_OPS_REPO_URL}")
-  # endif()
-  # execute_process(
-  #   COMMAND git checkout --quiet ${TORCH_XPU_OPS_COMMIT}
-  #   WORKING_DIRECTORY ${TORCH_XPU_OPS_DIR}
-  #   RESULT_VARIABLE _exitcode)
-  # if(NOT _exitcode EQUAL 0)
-  #   message(FATAL_ERROR "Fail to checkout ${TORCH_XPU_OPS_REPO_URL} to ${TORCH_XPU_OPS_COMMIT}")
-  # endif()
+  file(READ "${TORCH_ROOT}/third_party/xpu.txt" TORCH_XPU_OPS_COMMIT)
+  string(REGEX REPLACE "\n$" "" TORCH_XPU_OPS_COMMIT "${TORCH_XPU_OPS_COMMIT}")
+  if(NOT EXISTS "${TORCH_XPU_OPS_DIR}/.git")
+    execute_process(
+      COMMAND git clone --quiet ${TORCH_XPU_OPS_REPO_URL} ${TORCH_XPU_OPS_DIR}
+      RESULT_VARIABLE _exitcode)
+    if(NOT _exitcode EQUAL 0)
+      message(FATAL_ERROR "Fail to clone ${TORCH_XPU_OPS_REPO_URL}")
+    endif()
+  endif()
+  execute_process(
+    COMMAND git fetch --quiet
+    WORKING_DIRECTORY ${TORCH_XPU_OPS_DIR}
+    RESULT_VARIABLE _exitcode)
+  if(NOT _exitcode EQUAL 0)
+    message(FATAL_ERROR "Fail to fetch ${TORCH_XPU_OPS_REPO_URL}")
+  endif()
+  execute_process(
+    COMMAND git checkout --quiet ${TORCH_XPU_OPS_COMMIT}
+    WORKING_DIRECTORY ${TORCH_XPU_OPS_DIR}
+    RESULT_VARIABLE _exitcode)
+  if(NOT _exitcode EQUAL 0)
+    message(FATAL_ERROR "Fail to checkout ${TORCH_XPU_OPS_REPO_URL} to ${TORCH_XPU_OPS_COMMIT}")
+  endif()
 
   set(TORCH_XPU_OPS_INCLUDE_DIRS
       ${TORCH_SRC_DIR}/csrc/api

--- a/test/xpu/test_conv.py
+++ b/test/xpu/test_conv.py
@@ -1357,6 +1357,39 @@ class TestConvolutionNNDeviceType(NNTestCase):
         # input NHWC, output NHWC
         assert_size_stride(out, (2, 512, 7, 7), (25088, 1, 3584, 512))
 
+    @dtypes(torch.float16, torch.bfloat16, torch.float32, torch.float64)
+    def test_conv_misaligned_input(self, device, dtype):
+        N, C, OUT_CHANNELS = 2, 3, 4
+
+        def make_misaligned_tensor(tensor, shape):
+            numel = math.prod(shape)
+            base = torch.empty(numel + 1, device=device, dtype=dtype)
+            tensor_device = base[1:].reshape(shape)
+            tensor_device.copy_(tensor.to(device))
+            self.assertTrue(tensor_device.data_ptr() % 64 != 0)
+            return tensor_device
+
+        for conv_fn, spatial in [
+            (F.conv1d, (16,)),
+            (F.conv2d, (8, 8)),
+            (F.conv3d, (4, 4, 4)),
+        ]:
+            kernel = (3,) * len(spatial)
+            input_shape = (N, C) + spatial
+            weight_shape = (OUT_CHANNELS, C) + kernel
+
+            input_cpu = torch.randn(input_shape, dtype=dtype)
+            weight_cpu = torch.randn(weight_shape, dtype=dtype)
+            bias_cpu = torch.randn(OUT_CHANNELS, dtype=dtype)
+
+            input_device = make_misaligned_tensor(input_cpu, input_shape)
+            weight_device = make_misaligned_tensor(weight_cpu, weight_shape)
+            bias_device = make_misaligned_tensor(bias_cpu, (OUT_CHANNELS,))
+
+            output_cpu = conv_fn(input_cpu, weight_cpu, bias_cpu)
+            output_device = conv_fn(input_device, weight_device, bias_device)
+            self.assertEqual(output_device.cpu(), output_cpu)
+
     @onlyXPU
     def test_onednn_allow_tf32_get_set(self):
         with torch.backends.mkldnn.flags(


### PR DESCRIPTION
This PR is fix for: https://github.com/intel/torch-xpu-ops/issues/3105

## Problem description

oneDNN requires data pointers to be 64-byte aligned due to constraints on Intel Data Center GPU. When a tensor is freshly allocated, the allocator guarantees this alignment. However, when a tensor *view* is created (e.g., via slicing `A[1]`, indexing, or any op that produces a non-zero `storage_offset`), the effective data pointer (`base_ptr + offset * element_size`) may fall on a non-64-byte boundary.

When data pointer is not 64-byte aligned, then oneDNN conv2d kernels return wrong results.

## Proposed solution

Proposed solution is to apply the fix on the PyTorch side.

Since PyTorch knows the data pointer before invoking oneDNN, the simplest correct fix is to detect misaligned tensors on the PyTorch side and make sure that data is 64-byte aligned before invoking oneDNN kernel.


## Description of changes

The fix introduces two helpers in `Utils.cpp/h`:

- `is_64_bytes_aligned(tensor)` — checks whether `tensor.data_ptr()` is divisible by 64 using pointer-to-integer arithmetic (`reinterpret_cast<uintptr_t>`).
- `make_contiguous_and_aligned(tensor, memory_format)` — calls `.contiguous()` first (which may still produce a non-zero-offset view if the input already was contiguous), then calls `.clone()` only if the result has a non-zero storage offset **and** is not 64-byte aligned. The clone allocates a fresh buffer at a guaranteed-aligned address.

`Conv.cpp` is updated to call `make_contiguous_and_aligned` instead of plain `.contiguous()` for `input`, `weight`, and `bias` in both the forward and backward convolution paths.

The existing alignment guard in `is_onednn_matmul_strides()` is also simplified to use the new `is_64_bytes_aligned` helper, removing the inline duplication.

**Note:** The d2d copy introduced by `.clone()` only occurs in the uncommon case where a tensor slice with a misaligned pointer is passed directly into operator. Standard use of freshly-allocated tensors is unaffected.


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01