### PR TITLE
[dynamo] Fix UserDefinedTupleVariable richcompare to use is_python_equal

### DIFF
--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -3103,9 +3103,10 @@ class UserDefinedTupleVariable(UserDefinedObjectVariable):
         other: "VariableTracker",
         op: str,
     ) -> "VariableTracker":
-        from .constant import ConstantVariable
-
         assert self._tuple_vt is not None
+        if op in ("__eq__", "__ne__"):
+            result = self.is_python_equal(other)
+            return VariableTracker.build(tx, result if op == "__eq__" else not result)
         other_vt = other._tuple_vt if isinstance(other, UserDefinedTupleVariable) else other  # type: ignore[attr-defined]
         return self._tuple_vt.richcompare_impl(tx, other_vt, op)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #177962
* #177943
* #177484
* #177720

Restore is_python_equal-based comparison for __eq__/__ne__ on
UserDefinedTupleVariable (and NamedTupleVariable), avoiding data-dependent
branching when namedtuples contain tensor fields.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo