### PR TITLE
[torchTLX] [retry]Consolidate TLX knobs + TLXInductorChoices subclass (#177748)

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1866,10 +1866,6 @@ class triton:
         os.environ.get("TORCHINDUCTOR_MIX_ORDER_REDUCTION_ALLOW_MULTI_STAGES") == "1"
     )
 
-    enable_tlx_templates: bool = (
-        os.environ.get("TORCHINDUCTOR_ENABLE_TLX_TEMPLATES", "0") == "1"
-    )
-
     # Map for storing the amount of kernel runs with dumped input tensors
     # Based on hash of Triton source code to avoid bloating the folder
     debug_dump_kernel_inputs: dict[str, int] = {}

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -424,14 +424,6 @@ def tuned_mm(mat1, mat2, out_dtype=None, *, layout=None):
             elif use_triton_tma_template(mat1, mat2, output_layout=layout):
                 templates_to_use.append(persistent_tma_mm_template)
 
-            if (
-                inductor_config.is_fbcode()
-                and inductor_config.triton.enable_tlx_templates
-            ):
-                from torch._inductor.fb.tlx_templates.mm_templates import append_tlx
-
-                templates_to_use = append_tlx(templates_to_use)
-
         templates_to_use.append(mm_contiguous_subgraph_template)
 
     choices.extend(

--- a/torch/_inductor/template_heuristics/tlx.py
+++ b/torch/_inductor/template_heuristics/tlx.py
@@ -3,5 +3,3 @@ from torch._inductor import config
 
 if config.is_fbcode():
     import torch._inductor.fb.tlx_templates.registry  # noqa: F401  # type: ignore[import-not-used]
-
-# TODO. Move the registry to this file once the TLX template is more complete.

--- a/torch/_inductor/template_heuristics/triton.py
+++ b/torch/_inductor/template_heuristics/triton.py
@@ -780,6 +780,12 @@ class BaseConfigHeuristic(metaclass=BaseHeuristicSingleton):
             for num_warps in [2, 4, 8]
         ]
 
+    def _get_extra_config_key_and_kwargs(
+        self, conf: BaseConfig
+    ) -> tuple[tuple[int | None, ...], dict[str, Any]]:
+        """Hook for subclasses to extend config dedup key and kwargs."""
+        return (), {}
+
     def _finalize_mm_configs(
         self,
         configs: list[BaseConfig],
@@ -814,16 +820,8 @@ class BaseConfigHeuristic(metaclass=BaseHeuristicSingleton):
             if isinstance(conf, BlackwellGPUGemmConfig):
                 key += (conf.epilogue_subtile, conf.warp_specialize, conf.flatten)
 
-            # Add TlxGemmConfig specific fields to key if present
-            if config.is_fbcode() and config.triton.enable_tlx_templates:
-                from torch._inductor.fb.tlx_templates.registry import (
-                    get_tlx_config_key_and_kwargs,
-                )
-
-                tlx_key_fields, tlx_kwargs = get_tlx_config_key_and_kwargs(conf)
-                key += tlx_key_fields
-            else:
-                tlx_kwargs = {}
+            extra_key, extra_kwargs = self._get_extra_config_key_and_kwargs(conf)
+            key += extra_key
 
             if key not in used and (
                 max_mm_configs is None or len(used) < max_mm_configs
@@ -844,8 +842,7 @@ class BaseConfigHeuristic(metaclass=BaseHeuristicSingleton):
                     kwargs["WARP_SPECIALIZE"] = conf.warp_specialize
                     kwargs["FLATTEN"] = conf.flatten
 
-                # Add TlxGemmConfig specific fields if present
-                kwargs.update(tlx_kwargs)
+                kwargs.update(extra_kwargs)
 
                 yield self.triton_config(conf.num_stages, num_warps, **kwargs)
 


### PR DESCRIPTION
to be sync with D97141049 (which is landed internally)

Summary:

Merges two previously reverted changes (D94837369, D96747830) into a single clean diff.

Consolidates TLX configuration into a unified `tlx_mode` config with three modes:
- "default": TLX not considered (standard inductor behavior)
- "allow": TLX templates compete with other backends via autotuning
- "force": only TLX templates used + forced epilogue fusion

Creates `TLXInductorChoices(InductorChoices)` subclass that handles all TLX template injection, filtering, and layout logic. This moves TLX-specific code out of OSS files (kernel/mm.py, choices.py) into fb/tlx_templates/choices.py following the Diode pattern.

The old `enable_tlx_templates` config and `TORCHINDUCTOR_FORCE_TLX_EPILOGUE_FUSION` env var are removed.

Authored with Claude.

Test Plan:
## Unit tests

mm template:
```
buck2 run @//mode/opt -c fbcode.platform010_cuda_version=12.8 //caffe2/test/inductor/fb/tlx:test_templates
```
Result: 2/2 passed

fusion:
```
buck2 run @//mode/opt -c fbcode.platform010_cuda_version=12.8 //caffe2/test/inductor/fb/tlx:test_fusions
```
Result: 2/2 passed

Differential Revision: D97141049

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo