### PR TITLE
[DTensor] Fix double-shard validation in propagate_shape_and_sharding 

### DIFF
--- a/test/distributed/tensor/test_view_ops.py
+++ b/test/distributed/tensor/test_view_ops.py
@@ -248,6 +248,31 @@ class TestViewOps(DTensorTestBase):
         with self.assertRaisesRegex(RuntimeError, "Sharding propagation failed"):
             shard.view(8, 2, -1)
 
+    def test_double_shard_split_validation(self):
+        """[Shard(0), Shard(0)] through Split correctly validates divisibility."""
+        # Compatible: reshape (24,)→(6,4) with [Shard(0), Shard(0)] on mesh (2,3)
+        # submesh_size = 2*3 = 6, split_id=0 out_size=6, 6%6==0 → passes
+        result = propagate_shape_and_sharding(
+            [Shard(0), Shard(0)],
+            (24,),
+            dim_maps[torch.Tensor.view](torch.empty(24), [6, 4]),
+            (2, 3),
+        )
+        self.assertEqual(len(result), 2)
+        input_tgt, output = result
+        self.assertEqual(list(input_tgt), [Shard(0), Shard(0)])
+        self.assertEqual(list(output), [Shard(0), Shard(0)])
+
+        # Incompatible: reshape (12,)→(3,4) with [Shard(0), Shard(0)] on mesh (2,3)
+        # submesh_size = 2*3 = 6, split_id=0 out_size=3, 3%6!=0 → error
+        with self.assertRaisesRegex(AssertionError, "not divisible by its mesh"):
+            propagate_shape_and_sharding(
+                [Shard(0), Shard(0)],
+                (12,),
+                dim_maps[torch.Tensor.view](torch.empty(12), [3, 4]),
+                (2, 3),
+            )
+
     @with_comms
     def test_view_ops(self):
         mesh_shape = (dist.get_world_size() // 2, 2)

--- a/torch/distributed/tensor/_ops/_view_ops.py
+++ b/torch/distributed/tensor/_ops/_view_ops.py
@@ -618,8 +618,8 @@ def propagate_shape_and_sharding(
                     can_shard_dim = False
                     if strict_view and input_sharded:
                         raise RuntimeError(
-                            f"Attempted to flatten multiple dimensions, with dimension {dim.input_dim} being sharded. ",
-                            "It cannot be performed without redistribution, which is disallowed by the current operator.",
+                            f"Attempted to flatten multiple dimensions, with dimension {dim.input_dim} being sharded. "
+                            "It cannot be performed without redistribution, which is disallowed by the current operator."
                         )
                 elif input_sharded:
                     if not (shard_placement is not None and shard_mesh_dim is not None):
@@ -666,14 +666,17 @@ def propagate_shape_and_sharding(
                 if strict_view and shard_mesh_dim is not None:
                     if not shardable_dims[in_dim.input_dim][shard_mesh_dim]:
                         raise RuntimeError(
-                            f"Attempted to split the sharded dimension {in_dim.input_dim} into multiple subdimensions. ",
-                            "It cannot be performed without redistribution, which is disallowed by the current operator.",
+                            f"Attempted to split the sharded dimension {in_dim.input_dim} into multiple subdimensions. "
+                            "It cannot be performed without redistribution, which is disallowed by the current operator."
                         )
 
                 # 2. here we special case things like [Shard(0), Shard(0)]
                 submesh_size = 1
                 for size, shard in zip(mesh_sizes, input_src_placements):
-                    if isinstance(shard, Shard | _StridedShard) and shard.dim == in_dim:
+                    if (
+                        isinstance(shard, Shard | _StridedShard)
+                        and shard.dim == in_dim.input_dim
+                    ):
                         submesh_size *= size
                 if guard_or_true(out_size % submesh_size != 0):
                     raise AssertionError(


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/177972.

 `shard.dim == in_dim` compares an int (Shard.dim) to an InputDim dataclass, which is always False. This makes the [Shard(0), Shard(0)] double-sharding submesh_size calculation dead code in the Split handler. Fix: compare against in_dim.input_dim. This activates previously-dead validation that correctly rejects incompatible double-sharding configs (e.g. reshape (12,)→(3,4) with [Shard(0), Shard(0)] on mesh (2,3)) which were previously silently producing incorrect sharding.
 
 Also remove trailing commas so that the error messages are treated as strings and not tuples. 
 
