### PR TITLE
[inductor][autotuning] add reduction autotune data collection pipeline and tests

### DIFF
--- a/test/inductor/test_reduction_autotune_logging.py
+++ b/test/inductor/test_reduction_autotune_logging.py
@@ -1,0 +1,362 @@
+# Owner(s): ["module: inductor"]
+
+"""Tests for the reduction autotune data collection pipeline (Step 1).
+
+Covers: compute_derived_features(), CachingAutotuner callback mechanism,
+_attach_logging_callback gating, and end-to-end callback firing through
+torch.compile for reduction/persistent_reduction decorator types.
+"""
+
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+import torch
+from torch._inductor.runtime.reduction_heuristic_utils import compute_derived_features
+from torch.testing._internal.common_utils import IS_LINUX
+from torch.testing._internal.inductor_utils import (
+    GPU_TYPE,
+    HAS_GPU_AND_TRITON,
+)
+
+
+try:
+    import triton  # noqa: F401  # @manual
+    import triton.language as tl  # @manual
+except ImportError:
+    if __name__ == "__main__":
+        sys.exit(0)
+    raise unittest.SkipTest("requires triton")  # noqa: B904
+
+
+from torch._inductor import config
+from torch._inductor.runtime.hints import (
+    AttrsDescriptorWrapper,
+    DeviceProperties,
+    HeuristicType,
+)
+from torch._inductor.runtime.triton_helpers import math as tl_math
+from torch._inductor.runtime.triton_heuristics import (
+    _attach_logging_callback,
+    CachingAutotuner,
+    triton_config,
+)
+from torch._inductor.test_case import run_tests, TestCase
+
+
+# ---------------------------------------------------------------------------
+# Tests for compute_derived_features — no GPU required
+# ---------------------------------------------------------------------------
+
+
+class TestComputeDerivedFeatures(TestCase):
+    def test_basic_known_values(self):
+        result = compute_derived_features(
+            xnumel=1024,
+            ynumel=0,
+            xblock=128,
+            yblock=0,
+            grid_size=8,
+            num_sms=108,
+        )
+        self.assertEqual(result["tile_utilization_x"], 1.0)
+        self.assertEqual(result["tile_utilization_y"], 1.0)
+        self.assertEqual(result["grid_size"], 8.0)
+        # 8 / 108 < 1, so num_waves = ceil(8/108) = 1
+        self.assertEqual(result["num_waves"], 1.0)
+        # wave_utilization = 8 / (1 * 108) = 8/108
+        self.assertAlmostEqual(result["wave_utilization"], 8.0 / 108.0)
+
+    def test_partial_tile_utilization(self):
+        result = compute_derived_features(
+            xnumel=100,
+            ynumel=0,
+            xblock=128,
+            yblock=0,
+            grid_size=1,
+            num_sms=108,
+        )
+        # ceil(100/128) = 1, so utilization = 100 / (1*128) = 100/128
+        self.assertAlmostEqual(result["tile_utilization_x"], 100.0 / 128.0)
+
+    def test_with_y_dimension(self):
+        result = compute_derived_features(
+            xnumel=1024,
+            ynumel=50,
+            xblock=128,
+            yblock=32,
+            grid_size=16,
+            num_sms=108,
+        )
+        # ceil(50/32) = 2, so utilization = 50 / (2*32) = 50/64
+        self.assertAlmostEqual(result["tile_utilization_y"], 50.0 / 64.0)
+
+    def test_multiple_waves(self):
+        result = compute_derived_features(
+            xnumel=1024,
+            ynumel=0,
+            xblock=128,
+            yblock=0,
+            grid_size=256,
+            num_sms=108,
+        )
+        # num_waves = ceil(256/108) = 3
+        self.assertEqual(result["num_waves"], 3.0)
+        # wave_utilization = 256 / (3 * 108) = 256/324
+        self.assertAlmostEqual(result["wave_utilization"], 256.0 / 324.0)
+
+    def test_xblock_zero(self):
+        result = compute_derived_features(
+            xnumel=1024,
+            ynumel=0,
+            xblock=0,
+            yblock=0,
+            grid_size=8,
+            num_sms=108,
+        )
+        self.assertEqual(result["tile_utilization_x"], 1.0)
+
+    def test_num_sms_zero(self):
+        result = compute_derived_features(
+            xnumel=1024,
+            ynumel=0,
+            xblock=128,
+            yblock=0,
+            grid_size=8,
+            num_sms=0,
+        )
+        self.assertEqual(result["num_waves"], 1.0)
+        self.assertEqual(result["wave_utilization"], 1.0)
+
+    def test_ynumel_zero(self):
+        result = compute_derived_features(
+            xnumel=1024,
+            ynumel=0,
+            xblock=128,
+            yblock=64,
+            grid_size=8,
+            num_sms=108,
+        )
+        self.assertEqual(result["tile_utilization_y"], 1.0)
+
+
+# ---------------------------------------------------------------------------
+# Helpers for creating CachingAutotuner instances in tests
+# ---------------------------------------------------------------------------
+
+
+def _make_cos_autotuner_args():
+    """Build kwargs for CachingAutotuner with a trivial cos kernel."""
+
+    @triton.jit
+    def triton_(in_ptr0, out_ptr0, xnumel, XBLOCK: tl.constexpr):
+        xnumel = 16
+        xoffset = tl.program_id(0) * XBLOCK
+        xindex = xoffset + tl.arange(0, XBLOCK)[:]
+        xmask = xindex < xnumel
+        x0 = xindex
+        tmp0 = tl.load(in_ptr0 + (x0), xmask)
+        tmp1 = tl_math.cos(tmp0)
+        tl.store(out_ptr0 + (x0), tmp1, xmask)
+
+    triton_meta = {
+        "signature": {"in_ptr0": "*fp32", "out_ptr0": "*fp32", "xnumel": "i32"},
+        "device": DeviceProperties.create(torch.device(GPU_TYPE)),
+        "constants": {},
+        "configs": [
+            AttrsDescriptorWrapper(divisible_by_16=(0, 1, 2), equal_to_1=())
+        ],
+    }
+    configs = [
+        triton_config({"x": 16}, 64),
+        triton_config({"x": 256}, 64),
+    ]
+    return {
+        "fn": triton_,
+        "triton_meta": triton_meta,
+        "configs": configs,
+        "save_cache_hook": False,
+        "mutated_arg_names": [],
+        "reset_to_zero_arg_names": [],
+        "optimize_mem": True,
+        "heuristic_type": HeuristicType.REDUCTION,
+        "size_hints": {"x": 1024, "r0_": 4096},
+        "inductor_meta": {
+            "reduction_hint": "INNER",
+            "dtype": "float32",
+            "num_load": 1,
+            "num_store": 1,
+            "num_reduction": 1,
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tests for _fire_autotune_callback — requires GPU+Triton
+# ---------------------------------------------------------------------------
+
+
+@unittest.skipUnless(HAS_GPU_AND_TRITON and IS_LINUX, "requires GPU+Triton on Linux")
+class TestFireAutotuneCallback(TestCase):
+    def test_callback_fires_once(self):
+        autotuner = CachingAutotuner(**_make_cos_autotuner_args())
+        mock_cb = MagicMock()
+        autotuner.on_autotune_complete = mock_cb
+
+        autotuner._fire_autotune_callback({"some": "timings"})
+        autotuner._fire_autotune_callback({"some": "timings"})
+
+        mock_cb.assert_called_once()
+
+    def test_callback_catches_exception(self):
+        autotuner = CachingAutotuner(**_make_cos_autotuner_args())
+        autotuner.on_autotune_complete = MagicMock(
+            side_effect=RuntimeError("boom")
+        )
+
+        # Should not raise
+        autotuner._fire_autotune_callback(None)
+
+        self.assertTrue(autotuner._autotune_callback_fired)
+
+    def test_callback_noop_when_none(self):
+        autotuner = CachingAutotuner(**_make_cos_autotuner_args())
+        autotuner.on_autotune_complete = None
+
+        autotuner._fire_autotune_callback(None)
+
+        self.assertFalse(autotuner._autotune_callback_fired)
+
+
+# ---------------------------------------------------------------------------
+# Tests for _attach_logging_callback — requires GPU+Triton
+# ---------------------------------------------------------------------------
+
+
+@unittest.skipUnless(HAS_GPU_AND_TRITON and IS_LINUX, "requires GPU+Triton on Linux")
+class TestAttachLoggingCallback(TestCase):
+    def test_not_attached_when_disabled(self):
+        autotuner = CachingAutotuner(**_make_cos_autotuner_args())
+        with config.patch({"learned_reduction_heuristic.log_autotune": False}):
+            _attach_logging_callback(autotuner)
+        self.assertIsNone(autotuner.on_autotune_complete)
+
+    def test_attached_when_enabled(self):
+        autotuner = CachingAutotuner(**_make_cos_autotuner_args())
+        mock_enqueue = MagicMock()
+        with config.patch({"learned_reduction_heuristic.log_autotune": True}):
+            with patch(
+                "torch._inductor.runtime.reduction_heuristic_utils.enqueue_autotune_log",
+                mock_enqueue,
+            ):
+                _attach_logging_callback(autotuner)
+        self.assertIs(autotuner.on_autotune_complete, mock_enqueue)
+
+    def test_noop_when_fb_unavailable(self):
+        from torch._inductor.runtime.reduction_heuristic_utils import (
+            _noop_autotune_log,
+        )
+
+        autotuner = CachingAutotuner(**_make_cos_autotuner_args())
+        with config.patch({"learned_reduction_heuristic.log_autotune": True}):
+            with patch.dict(
+                "sys.modules",
+                {"torch._inductor.fb.reduction_autotune_logging": None},
+            ):
+                # Re-import to pick up the stub
+                import torch._inductor.runtime.reduction_heuristic_utils as utils
+
+                with patch.object(utils, "enqueue_autotune_log", _noop_autotune_log):
+                    _attach_logging_callback(autotuner)
+        self.assertIs(autotuner.on_autotune_complete, _noop_autotune_log)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end tests through torch.compile — requires GPU+Triton
+# ---------------------------------------------------------------------------
+
+
+@unittest.skipUnless(HAS_GPU_AND_TRITON and IS_LINUX, "requires GPU+Triton on Linux")
+class TestEndToEndReductionLogging(TestCase):
+    def _compile_and_run(self, fn, args, extra_config=None):
+        """Compile and run fn, returning the mock enqueue function."""
+        mock_enqueue = MagicMock()
+        cfg = {"learned_reduction_heuristic.log_autotune": True}
+        if extra_config:
+            cfg.update(extra_config)
+
+        with config.patch(cfg):
+            with patch(
+                "torch._inductor.runtime.reduction_heuristic_utils.enqueue_autotune_log",
+                mock_enqueue,
+            ):
+                compiled = torch.compile(fn)
+                compiled(*args)
+
+        return mock_enqueue
+
+    def test_reduction_callback_fires(self):
+        def fn(x):
+            return x.sum(dim=-1)
+
+        x = torch.randn(32, 1024, device=GPU_TYPE)
+        mock_enqueue = self._compile_and_run(fn, (x,))
+        self.assertGreaterEqual(mock_enqueue.call_count, 1)
+
+    def test_persistent_reduction_callback_fires(self):
+        def fn(x):
+            return x.sum(dim=-1)
+
+        # Small reduction dim triggers persistent reduction
+        x = torch.randn(32, 64, device=GPU_TYPE)
+        mock_enqueue = self._compile_and_run(fn, (x,))
+        self.assertGreaterEqual(mock_enqueue.call_count, 1)
+
+    def test_single_config_timings_is_none(self):
+        def fn(x):
+            return x.sum(dim=-1)
+
+        x = torch.randn(32, 64, device=GPU_TYPE)
+        mock_enqueue = self._compile_and_run(fn, (x,))
+
+        if mock_enqueue.call_count > 0:
+            # At least one call should have timings=None (single-config)
+            # since without max_autotune there's typically one config
+            found_none = False
+            for call_args in mock_enqueue.call_args_list:
+                args, kwargs = call_args
+                # Second positional arg is timings
+                if len(args) >= 2 and args[1] is None:
+                    found_none = True
+                    break
+            self.assertTrue(
+                found_none,
+                "Expected at least one callback with timings=None",
+            )
+
+    def test_multi_config_timings_is_dict(self):
+        def fn(x):
+            return x.sum(dim=-1)
+
+        x = torch.randn(32, 1024, device=GPU_TYPE)
+        mock_enqueue = self._compile_and_run(
+            fn,
+            (x,),
+            extra_config={"max_autotune": True},
+        )
+
+        if mock_enqueue.call_count > 0:
+            found_dict = False
+            for call_args in mock_enqueue.call_args_list:
+                args, kwargs = call_args
+                if len(args) >= 2 and isinstance(args[1], dict):
+                    found_dict = True
+                    break
+            self.assertTrue(
+                found_dict,
+                "Expected at least one callback with timings as dict",
+            )
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -755,6 +755,37 @@ autoheuristic_log_path = os.environ.get(
     "TORCHINDUCTOR_AUTOHEURISTIC_LOG_PATH", "DEFAULT"
 )
 
+class learned_reduction_heuristic:
+    # Log reduction autotuning data (problem metadata, candidate configs,
+    # benchmark timings) for training learned heuristics.
+    # FB-internal: logs to Hive and uploads kernel reproducers to Manifold.
+    # OSS: no-op (logging module is FB-only).
+    log_autotune: bool = Config(
+        justknob="pytorch/learned_reduction_heuristic:log_autotune",
+        env_name_force="TORCHINDUCTOR_LOG_REDUCTION_AUTOTUNE",
+        default=False,
+    )
+
+    # When True, log to the production Hive table; otherwise use the
+    # experiments table.
+    log_to_prod: bool = Config(
+        justknob="pytorch/learned_reduction_heuristic:log_to_prod",
+        env_name_force="TORCHINDUCTOR_LOG_REDUCTION_AUTOTUNE_PROD",
+        default=False,
+    )
+
+    # Use the learned heuristic to score and prune candidate configs before
+    # autotuning.
+    enabled: bool = Config(
+        justknob="pytorch/learned_reduction_heuristic:enabled",
+        env_name_force="TORCHINDUCTOR_LEARNED_REDUCTION_HEURISTIC",
+        default=False,
+    )
+
+    # Number of top-scoring configs to keep when the learned heuristic is
+    # enabled.
+    top_k: int = 1
+
 # Disabled by default on ROCm, opt-in if model utilises NHWC convolutions
 layout_opt_default = "1" if not torch.version.hip else "0"
 layout_optimization = (

--- a/torch/_inductor/runtime/reduction_heuristic_utils.py
+++ b/torch/_inductor/runtime/reduction_heuristic_utils.py
@@ -1,0 +1,80 @@
+"""Shared utilities for learned reduction heuristics.
+
+Used by both the FB-internal logging module and the OSS inference path.
+"""
+
+from __future__ import annotations
+
+import functools
+import math
+
+import torch
+
+
+@functools.lru_cache(None)
+def get_gpu_family() -> str:
+    """Return a canonical GPU architecture string.
+
+    NVIDIA GPUs are identified by compute capability (e.g. ``"sm90"``).
+    AMD GPUs use the GCN architecture name.
+    """
+    assert torch.cuda.is_available(), "get_gpu_family requires a GPU"
+    if torch.version.hip:
+        return torch.cuda.get_device_properties(0).gcnArchName
+    major, minor = torch.cuda.get_device_capability()
+    return f"sm{major}{minor}"
+
+
+def _noop_autotune_log(autotuner: object, timings: object) -> None:
+    pass
+
+
+try:
+    from torch._inductor.fb.reduction_autotune_logging import (  # type: ignore[import-not-found]
+        enqueue_autotune_log,
+    )
+except ImportError:
+    enqueue_autotune_log = _noop_autotune_log
+
+
+def _ceildiv(a: int, b: int) -> int:
+    return (a + b - 1) // b
+
+
+def compute_derived_features(
+    xnumel: int,
+    ynumel: int,
+    xblock: int,
+    yblock: int,
+    grid_size: int,
+    num_sms: int,
+) -> dict[str, float]:
+    """Compute tile/wave quantization features from problem and config dims.
+
+    These features capture how well a config tiles the problem space and
+    utilises the GPU's streaming multiprocessors.  The same computation is
+    used during training (on Hive data) and inference (in the scoring path)
+    so the model sees identical features.
+    """
+    tile_utilization_x = (
+        xnumel / (_ceildiv(xnumel, xblock) * xblock) if xblock > 0 else 1.0
+    )
+    tile_utilization_y = (
+        ynumel / (_ceildiv(ynumel, yblock) * yblock)
+        if ynumel > 0 and yblock > 0
+        else 1.0
+    )
+    num_waves = _ceildiv(grid_size, num_sms) if num_sms > 0 else 1
+    wave_utilization = (
+        grid_size / (num_waves * num_sms) if num_sms > 0 and num_waves > 0 else 1.0
+    )
+
+    return {
+        "tile_utilization_x": tile_utilization_x,
+        "tile_utilization_y": tile_utilization_y,
+        "grid_size": float(grid_size),
+        "wave_utilization": wave_utilization,
+        "num_waves": float(num_waves),
+        "log_xnumel": math.log1p(xnumel),
+        "log_ynumel": math.log1p(ynumel),
+    }

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -441,6 +441,23 @@ class CachingAutotuner(KernelInterface):
         # Mode for launch grid calculation
         self.grid_mode: Literal["python", "cpp"] = "python"
 
+        # Per-instance callback fired once after autotuning completes (or is
+        # skipped for single-config kernels).  Set by decorator functions when
+        # data collection is enabled.
+        self.on_autotune_complete: Callable[[CachingAutotuner, dict[object, float] | None], None] | None = None
+        self._autotune_callback_fired: bool = False
+        self.timings: dict | None = None
+
+    def _fire_autotune_callback(self, timings: dict | None) -> None:
+        """Fire the on_autotune_complete callback at most once."""
+        if self.on_autotune_complete is None or self._autotune_callback_fired:
+            return
+        self._autotune_callback_fired = True
+        try:
+            self.on_autotune_complete(self, timings)
+        except Exception:
+            log.warning("on_autotune_complete callback failed", exc_info=True)
+
     def is_statically_launchable(self):
         """
         Checks if every compiled kernel is statically launchable, which
@@ -1259,6 +1276,7 @@ class CachingAutotuner(KernelInterface):
                 )
 
         self.launchers = [builtins.min(timings, key=timings.get)]
+        self.timings = timings
         self.autotune_time_taken_ns = (
             self.precompile_time_taken_ns + benchmark_time_taken_ns
         )
@@ -1532,6 +1550,11 @@ class CachingAutotuner(KernelInterface):
                 self.precompile_time_taken_ns = time.time_ns() - start_time
             if len(self.launchers) > 1:
                 self.autotune_to_one_config(*args, **kwargs)
+                self._fire_autotune_callback(self.timings)
+            else:
+                self._fire_autotune_callback(None)
+        else:
+            self._fire_autotune_callback(None)
 
         if not getattr(
             self.launchers[0].config, "found_by_coordesc", False
@@ -2371,7 +2394,7 @@ def cached_autotune(
                 filename=filename,
                 with_bandwidth_info=True,
             )
-        return caching_autotuner_cls(
+        autotuner = caching_autotuner_cls(
             fn,
             triton_meta=triton_meta,
             inductor_meta=inductor_meta,
@@ -2386,6 +2409,15 @@ def cached_autotune(
             filename=filename,
             autotune_cache_info=autotune_cache_info,
         )
+        # cooperative_reduction uses HeuristicType.REDUCTION so it is
+        # covered by the REDUCTION check below.
+        if heuristic_type in (
+            HeuristicType.REDUCTION,
+            HeuristicType.PERSISTENT_REDUCTION,
+            HeuristicType.SPLIT_SCAN,
+        ):
+            _attach_logging_callback(autotuner)
+        return autotuner
 
     return decorator
 
@@ -3564,6 +3596,21 @@ def filter_reduction_configs_for_determinism(
             log.debug("%s", c)
             log.debug("")
     return configs
+
+
+def _attach_logging_callback(autotuner: CachingAutotuner) -> None:
+    """Attach the reduction autotune logging callback when enabled."""
+    from torch._inductor import config as inductor_config
+
+    if not inductor_config.learned_reduction_heuristic.log_autotune:
+        return
+    if not torch.cuda.is_available():
+        return
+    from torch._inductor.runtime.reduction_heuristic_utils import (
+        enqueue_autotune_log,
+    )
+
+    autotuner.on_autotune_complete = enqueue_autotune_log
 
 
 def reduction(


### PR DESCRIPTION
Summary:
Step 1 of the learned reduction heuristics project. Instruments
`CachingAutotuner` to log autotuning data (problem metadata, candidate
configs, benchmark timings) for every reduction-related kernel across all
four decorator types (reduction, persistent_reduction,
cooperative_reduction, split_scan). Data is logged asynchronously to Hive
via DSI Logger with kernel reproducers uploaded to Manifold.

**Data collection infrastructure:**
- Thrift schema (`ReductionAutotuneLoggerConfig`) defining problem
  features, partition keys, per-config data, and debug metadata
- FB-internal logging module (`reduction_autotune_logging.py`) with
  async queue/worker, Manifold reproducer upload, and deduplication
- Per-instance `on_autotune_complete` callback on `CachingAutotuner`,
  fired once after autotuning (or skipped for single-config kernels)
- `_attach_logging_callback` wired into `cached_autotune()` for all
  reduction heuristic types
- `learned_reduction_heuristic` config class with JustKnob and env var
  gating (all off by default)
- Shared `compute_derived_features()` utility for tile/wave
  quantization features

**Tests:**
- OSS: `TestComputeDerivedFeatures` (7), `TestFireAutotuneCallback` (3),
  `TestAttachLoggingCallback` (3), `TestEndToEndReductionLogging` (4)
- FB: `TestBuildEntryFromConfig` (4), `TestEnqueueAutotuneLog` (3),
  `TestProcessEntry` (2), `TestUploadReproducer` (3),
  `TestLiveNullRowWrite` (1)

Authored with Claude.

Test Plan:
buck test fbcode//mode/opt caffe2/test/inductor:reduction_autotune_logging
buck test fbcode//mode/opt caffe2/test/inductor/fb:test_reduction_autotune_logging

Differential Revision: D96046174




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo