### PR TITLE
[inductor][estimations] profile guided runtime estimations

### DIFF
--- a/test/distributed/test_overlap_bucketing_unit.py
+++ b/test/distributed/test_overlap_bucketing_unit.py
@@ -19,6 +19,7 @@ from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
+    TestCase,
 )
 from torch.testing._internal.inductor_utils import HAS_GPU
 from torch.utils._ordered_set import OrderedSet
@@ -1461,6 +1462,322 @@ class TestForeachGroupsUnit(InductorTestCase):
             ag_ins, 2, "default", torch.float32, out_dtype_ints, 0, None
         )
         self.assertTrue(torch.allclose(result_with, result_without))
+
+
+# ---------------------------------------------------------------------------
+# Profile-Guided Latency Estimation (PGLE) unit tests — no GPU required
+# ---------------------------------------------------------------------------
+
+import json
+import os
+import tempfile
+
+from torch._inductor.fx_passes.profile_guided_estimation import (
+    _normalize_profile_dtype,
+    _normalize_profile_indices,
+    _rank_stride,
+    ProfileData,
+)
+
+
+def _make_pgle_trace(
+    collectives=None,
+    matmuls=None,
+    sdpa_ops=None,
+    pg_config=None,
+):
+    """Build a minimal Chrome Trace JSON dict for PGLE testing."""
+    events = []
+    eid = 1000
+
+    for coll in collectives or []:
+        events.append(
+            {
+                "cat": "kernel",
+                "dur": coll["dur"],
+                "name": "nccl_kernel",
+                "args": {
+                    "Collective name": coll["name"],
+                    "Process Group Name": coll.get("pg_name", "0"),
+                    "Process Group Ranks": coll.get("ranks", "[0, 1]"),
+                    "Group size": coll.get("group_size", 2),
+                    "In msg nelems": coll.get("nelems", 1024),
+                    "dtype": coll.get("dtype", "Float"),
+                },
+            }
+        )
+
+    for mm in matmuls or []:
+        eid += 1
+        events.append(
+            {
+                "cat": "cpu_op",
+                "name": "aten::mm",
+                "dur": 0,
+                "args": {
+                    "External id": eid,
+                    "Input Dims": mm["shapes"],
+                    "Input type": mm.get("dtypes", ["Float", "Float"]),
+                },
+            }
+        )
+        events.append(
+            {
+                "cat": "kernel",
+                "dur": mm["dur"],
+                "name": "sm80_xmma_gemm",
+                "args": {"External id": eid},
+            }
+        )
+
+    for sdpa in sdpa_ops or []:
+        eid += 1
+        op_name = sdpa.get("op_name", "aten::_scaled_dot_product_flash_attention")
+        events.append(
+            {
+                "cat": "cpu_op",
+                "name": op_name,
+                "dur": 0,
+                "args": {
+                    "External id": eid,
+                    "Input Dims": sdpa["input_dims"],
+                    "Input type": sdpa.get("dtypes", ["BFloat16"]),
+                },
+            }
+        )
+        events.append(
+            {
+                "cat": "kernel",
+                "dur": sdpa["dur"],
+                "name": "flash_fwd_kernel",
+                "args": {"External id": eid},
+            }
+        )
+
+    dist_info = {}
+    if pg_config is not None:
+        dist_info["pg_config"] = pg_config
+    else:
+        dist_info["pg_config"] = {"0": {"ranks": [0, 1]}}
+
+    return {"traceEvents": events, "distributedInfo": dist_info}
+
+
+def _load_pgle_profile(data):
+    """Write trace dict to a temp file and load via ProfileData."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+        json.dump(data, f)
+        f.flush()
+        path = f.name
+    try:
+        profile = ProfileData()
+        profile.load(path)
+        return profile
+    finally:
+        os.unlink(path)
+
+
+class TestProfileGuidedEstimation(TestCase):
+    def test_collective_lookup_and_interpolation(self):
+        """Parse collectives, exact lookup, interpolation, stride fallback, name normalization, edge cases."""
+        # _rank_stride
+        self.assertEqual(_rank_stride((0, 2, 4, 6)), 2)
+        self.assertEqual(_rank_stride((0, 1, 2, 3)), 1)
+        self.assertIsNone(_rank_stride((0, 1, 4, 5)))
+        self.assertIsNone(_rank_stride((0,)))
+        self.assertIsNone(_rank_stride(()))
+
+        # Collective name normalization
+        norm = ProfileData._normalize_collective_name
+        self.assertEqual(norm("_allgather_base"), "all_gather")
+        self.assertEqual(norm("allreduce"), "all_reduce")
+        self.assertEqual(norm("reduce_scatter_tensor_coalesced"), "reduce_scatter")
+        self.assertEqual(norm("all_to_all_single"), "all_to_all")
+        self.assertEqual(norm("barrier"), "barrier")
+
+        # Load trace with two data points for interpolation + stride fallback
+        trace = _make_pgle_trace(
+            collectives=[
+                {
+                    "name": "allreduce",
+                    "dur": 100.0,
+                    "nelems": 1000,
+                    "dtype": "Float",
+                    "ranks": "[0, 2, 4, 6]",
+                    "group_size": 4,
+                },
+                {
+                    "name": "allreduce",
+                    "dur": 800.0,
+                    "nelems": 8000,
+                    "dtype": "Float",
+                    "ranks": "[0, 2, 4, 6]",
+                    "group_size": 4,
+                },
+            ],
+            pg_config={"0": {"ranks": [0, 2, 4, 6]}},
+        )
+        profile = _load_pgle_profile(trace)
+        _normalize_profile_indices(profile)
+
+        self.assertEqual(len(profile.collectives), 2)
+
+        # Exact match: 100 us -> 0.1 ms
+        result = profile.lookup_collective("all_reduce", (0, 2, 4, 6), 1000, "Float")
+        self.assertAlmostEqual(result, 0.1, places=4)
+
+        # Interpolation between 1000 and 8000 nelems
+        result = profile.lookup_collective("all_reduce", (0, 2, 4, 6), 4000, "Float")
+        self.assertIsNotNone(result)
+        self.assertGreater(result, 0.1)
+        self.assertLess(result, 0.8)
+
+        # Stride fallback: different ranks, same stride=2 size=4
+        result = profile.lookup_collective("all_reduce", (1, 3, 5, 7), 1000, "Float")
+        self.assertAlmostEqual(result, 0.1, places=4)
+
+        # Miss: wrong collective name
+        self.assertIsNone(
+            profile.lookup_collective("all_to_all", (0, 2, 4, 6), 1000, "Float")
+        )
+
+        # Single-point extrapolation
+        result = profile.lookup_collective("all_reduce", (0, 2, 4, 6), 16000, "Float")
+        self.assertIsNotNone(result)
+        self.assertGreater(result, 0.8)
+
+        # Zero-duration events skipped
+        trace_zero = _make_pgle_trace(
+            collectives=[
+                {"name": "allreduce", "dur": 0.0, "nelems": 1024, "dtype": "Float"}
+            ]
+        )
+        self.assertEqual(len(_load_pgle_profile(trace_zero).collectives), 0)
+
+        # Empty trace
+        empty = _load_pgle_profile({"traceEvents": []})
+        self.assertEqual(len(empty.collectives), 0)
+        self.assertEqual(len(empty.matmuls), 0)
+
+    def test_matmul_and_sdpa_lookup(self):
+        """Matmul and SDPA: exact match, FLOP-ratio interpolation, backward, dtype miss."""
+        trace = _make_pgle_trace(
+            matmuls=[
+                {
+                    "shapes": [[128, 256], [256, 512]],
+                    "dur": 50.0,
+                    "dtypes": ["Float", "Float"],
+                },
+                {
+                    "shapes": [[64, 128], [128, 64]],
+                    "dur": 10.0,
+                    "dtypes": ["Float", "Float"],
+                },
+            ],
+            sdpa_ops=[
+                {
+                    "input_dims": [[2, 8, 1024, 64]],
+                    "dur": 300.0,
+                    "dtypes": ["BFloat16"],
+                },
+                {
+                    "input_dims": [[2, 8, 512, 64]],
+                    "dur": 100.0,
+                    "dtypes": ["BFloat16"],
+                },
+                {
+                    "input_dims": [[2, 8, 1024, 64]],
+                    "dur": 500.0,
+                    "dtypes": ["BFloat16"],
+                    "op_name": "aten::_scaled_dot_product_flash_attention_backward",
+                },
+            ],
+        )
+        profile = _load_pgle_profile(trace)
+        _normalize_profile_indices(profile)
+
+        # Matmul exact match: 50 us -> 0.05 ms
+        self.assertAlmostEqual(
+            profile.lookup_mm(((128, 256), (256, 512)), "Float"), 0.05, places=4
+        )
+
+        # Matmul FLOP-ratio interpolation
+        result = profile.lookup_mm(((128, 128), (128, 128)), "Float")
+        self.assertIsNotNone(result)
+        ref_flops = 2 * 64 * 64 * 128
+        target_flops = 2 * 128 * 128 * 128
+        self.assertAlmostEqual(
+            result, 10.0 * (target_flops / ref_flops) / 1e3, places=4
+        )
+
+        # Matmul dtype miss
+        self.assertIsNone(profile.lookup_mm(((128, 256), (256, 512)), "Half"))
+
+        # SDPA exact match: 300 us -> 0.3 ms
+        self.assertAlmostEqual(
+            profile.lookup_sdpa(2, 8, 1024, 64, "BFloat16", is_backward=False),
+            0.3,
+            places=4,
+        )
+
+        # SDPA interpolation from 512 data point to a new shape
+        result = profile.lookup_sdpa(2, 8, 2048, 64, "BFloat16", is_backward=False)
+        self.assertIsNotNone(result)
+        self.assertGreater(result, 0.3)
+
+        # SDPA backward
+        self.assertAlmostEqual(
+            profile.lookup_sdpa(2, 8, 1024, 64, "BFloat16", is_backward=True),
+            0.5,
+            places=4,
+        )
+
+    def test_dtype_normalization_and_collision(self):
+        """Dtype normalization, c10:: prefix handling, and collision averaging for matmul/SDPA."""
+        self.assertEqual(_normalize_profile_dtype("c10::Float"), "Float")
+        self.assertEqual(_normalize_profile_dtype("c10::BFloat16"), "BFloat16")
+        self.assertEqual(_normalize_profile_dtype("Float"), "Float")
+        self.assertEqual(_normalize_profile_dtype("CustomType"), "CustomType")
+
+        # Matmul dtype collision: two raw dtypes normalize to same key -> averaged
+        profile = ProfileData()
+        profile._matmul_index = {
+            ((128, 256), (256, 512), "c10::BFloat16"): 100.0,
+            ((128, 256), (256, 512), "BFloat16"): 200.0,
+        }
+        _normalize_profile_indices(profile)
+        key = ((128, 256), (256, 512), "BFloat16")
+        self.assertIn(key, profile._matmul_index)
+        self.assertAlmostEqual(profile._matmul_index[key], 150.0)
+
+        # SDPA dtype collision
+        profile2 = ProfileData()
+        profile2._sdpa_index = {
+            (2, 8, 1024, 64, "c10::BFloat16", False): 100.0,
+            (2, 8, 1024, 64, "BFloat16", False): 300.0,
+        }
+        _normalize_profile_indices(profile2)
+        key2 = (2, 8, 1024, 64, "BFloat16", False)
+        self.assertIn(key2, profile2._sdpa_index)
+        self.assertAlmostEqual(profile2._sdpa_index[key2], 200.0)
+
+        # PG config parsing: dict format
+        trace = _make_pgle_trace(
+            pg_config={"0": {"ranks": [0, 1, 2, 3]}, "1": {"ranks": [0, 2]}},
+        )
+        profile3 = _load_pgle_profile(trace)
+        self.assertEqual(profile3.pg_configs["0"], (0, 1, 2, 3))
+        self.assertEqual(profile3.pg_configs["1"], (0, 2))
+
+        # PG config parsing: list format
+        trace_list = {
+            "traceEvents": [],
+            "distributedInfo": {
+                "pg_config": [{"pg_name": "default", "ranks": [0, 1, 2, 3]}]
+            },
+        }
+        profile4 = _load_pgle_profile(trace_list)
+        self.assertEqual(profile4.pg_configs["default"], (0, 1, 2, 3))
 
 
 if __name__ == "__main__":

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1096,6 +1096,12 @@ class aten_distributed_optimizations:
     # In deterministic mode, this setting is ignored and "analytical" is used.
     compute_estimator: Literal["analytical", "benchmark"] = "benchmark"
 
+    # Path to Chrome Trace JSON for profile-guided latency estimation (PGLE).
+    # When set, kernel runtimes (collectives, matmuls, attention) are looked up
+    # from the profile trace, falling back to analytical if no match found.
+    # Same profile on all ranks => deterministic estimates, no cross-rank sync.
+    profile_guided_estimation_path: str | None = None
+
     # Maximum memory increase above baseline for prefetch operations
     # Uses minimum of absolute cap and ratio of baseline
     max_memory_increase_gb: float | None = None  # Absolute cap in GB

--- a/torch/_inductor/fx_passes/node_runtime_estimation.py
+++ b/torch/_inductor/fx_passes/node_runtime_estimation.py
@@ -1,5 +1,5 @@
 """
-Collective runtime estimation using CUDA events and power-of-2 rounding.
+Node runtime estimation: CUDA events benchmarking and profile-guided estimation.
 """
 
 from __future__ import annotations
@@ -8,7 +8,7 @@ import functools
 import itertools
 import operator
 from functools import lru_cache
-from typing import Any
+from typing import Any, TYPE_CHECKING
 
 import torch
 import torch.fx as fx
@@ -16,6 +16,10 @@ from torch._inductor.fx_passes.bucketing import _schedulable_wait_node
 from torch._inductor.utils import clear_on_fresh_cache
 from torch._logging import getArtifactLogger, trace_structured
 from torch.fx.operator_schemas import normalize_function
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 def _format_csv(headers: list[str], rows: list[list[str]]) -> str:
@@ -426,3 +430,366 @@ def _log_collective_benchmarks(
         },
         payload_fn=lambda: log_str,
     )
+
+
+# ---------------------------------------------------------------------------
+# Profile-Guided Latency Estimation (PGLE)
+# ---------------------------------------------------------------------------
+
+
+def make_profile_guided_estimator(
+    trace_path: str,
+) -> Callable[[fx.Node, int | None], float | None]:
+    """Create a custom_runtime_estimation function from a Chrome Trace profile.
+
+    Parses the profile and builds lookup tables for collectives, matmuls, and
+    attention kernels. Returns a callable matching the custom_runtime_estimation
+    interface: (fx.Node, int | None) -> float | None (ms or None for fallback).
+
+    The trace_path supports a ``{rank}`` placeholder that is replaced with the
+    current rank so each rank loads its own profile (exact PG rank match).
+    Example: ``/traces/iteration_5/rank{rank}_trace.json``
+
+    This is a generic API usable by any pass that needs runtime estimates.
+    """
+    from torch._inductor.fx_passes.profile_guided_estimation import (
+        _get_collective_info,
+        _get_mm_shapes,
+        _get_node_dtype_str,
+        _get_sdpa_key,
+        _is_collective_node,
+        _is_mm_node,
+        _is_sdpa_node,
+        _normalize_profile_indices,
+        _rank_stride,
+        ProfileData,
+    )
+
+    # Resolve {rank} placeholder
+    resolved_path = trace_path
+    if "{rank}" in trace_path:
+        import torch.distributed as dist
+
+        if dist.is_initialized():
+            resolved_path = trace_path.replace("{rank}", str(dist.get_rank()))
+        else:
+            log.warning("PGLE: {rank} in path but dist not initialized, using rank 0")
+            resolved_path = trace_path.replace("{rank}", "0")
+
+    profile = ProfileData()
+    profile.load(resolved_path)
+    _normalize_profile_indices(profile)
+
+    estimation_log: list[dict[str, Any]] = []
+    miss_log: list[dict[str, Any]] = []
+
+    def estimator(node: fx.Node, override_size: int | None = None) -> float | None:
+        # Collectives
+        if _is_collective_node(node):
+            info = _get_collective_info(node)
+            if info is None:
+                miss_log.append(
+                    {
+                        "node": node.name,
+                        "target": str(node.target),
+                        "reason": "get_collective_info returned None",
+                    }
+                )
+                return None
+            coll_name, pg_ranks, nelems, dtype = info
+            if override_size is not None:
+                # override_size=0 means "startup latency only" — profiles don't
+                # separate startup from transfer, so return 0 to let the caller
+                # use the full estimated time as the exposed portion.
+                if override_size == 0:
+                    return 0.0
+                val = node.meta.get("val")
+                if isinstance(val, torch.Tensor):
+                    elem_size = val.element_size()
+                    if elem_size > 0:
+                        nelems = override_size // elem_size
+            # Get bytes per element for bandwidth calculation
+            dtype_bytes = 0
+            val = node.meta.get("val")
+            if isinstance(val, torch.Tensor):
+                dtype_bytes = val.element_size()
+            est = profile.lookup_collective(coll_name, pg_ranks, nelems, dtype)
+            if est is not None:
+                estimation_log.append(
+                    {
+                        "node": node.name,
+                        "op": coll_name,
+                        "nelems": nelems,
+                        "dtype": dtype,
+                        "dtype_bytes": dtype_bytes,
+                        "group_size": len(pg_ranks),
+                        "stride": _rank_stride(pg_ranks),
+                        "pgle_ms": est,
+                        "source": "profile",
+                    }
+                )
+            else:
+                miss_log.append(
+                    {
+                        "node": node.name,
+                        "op": coll_name,
+                        "nelems": nelems,
+                        "dtype": dtype,
+                        "group_size": len(pg_ranks),
+                        "reason": "no match in profile",
+                    }
+                )
+            return est
+
+        # Matmul
+        if _is_mm_node(node):
+            shapes = _get_mm_shapes(node)
+            if shapes is None:
+                miss_log.append(
+                    {
+                        "node": node.name,
+                        "target": str(node.target),
+                        "reason": "get_mm_shapes returned None",
+                    }
+                )
+                return None
+            dtype = _get_node_dtype_str(node)
+            est = profile.lookup_mm(shapes, dtype)
+            if est is not None:
+                estimation_log.append(
+                    {
+                        "node": node.name,
+                        "op": "mm",
+                        "shapes": [list(s) for s in shapes],
+                        "dtype": dtype,
+                        "pgle_ms": est,
+                        "source": "profile",
+                    }
+                )
+            else:
+                miss_log.append(
+                    {
+                        "node": node.name,
+                        "op": "mm",
+                        "shapes": [list(s) for s in shapes],
+                        "dtype": dtype,
+                        "reason": "no match in profile",
+                    }
+                )
+            return est
+
+        # SDPA
+        if _is_sdpa_node(node):
+            sdpa_key = _get_sdpa_key(node)
+            if sdpa_key is None:
+                miss_log.append(
+                    {
+                        "node": node.name,
+                        "target": str(node.target),
+                        "reason": "get_sdpa_key returned None",
+                    }
+                )
+                return None
+            batch, heads, seq_len, head_dim, dtype, is_bwd = sdpa_key
+            est = profile.lookup_sdpa(batch, heads, seq_len, head_dim, dtype, is_bwd)
+            if est is not None:
+                estimation_log.append(
+                    {
+                        "node": node.name,
+                        "op": "sdpa_bwd" if is_bwd else "sdpa_fwd",
+                        "shape": [batch, heads, seq_len, head_dim],
+                        "dtype": dtype,
+                        "pgle_ms": est,
+                        "source": "profile",
+                    }
+                )
+            else:
+                miss_log.append(
+                    {
+                        "node": node.name,
+                        "op": "sdpa",
+                        "shape": [batch, heads, seq_len, head_dim],
+                        "dtype": dtype,
+                        "reason": "no match in profile",
+                    }
+                )
+            return est
+
+        return None
+
+    estimator.estimation_log = estimation_log  # type: ignore[attr-defined]
+    estimator.miss_log = miss_log  # type: ignore[attr-defined]
+    estimator.profile = profile  # type: ignore[attr-defined]
+
+    return estimator
+
+
+def log_pgle_estimations(
+    estimator: Callable[..., Any],
+    analytical_estimates: dict[str, float] | None = None,
+) -> None:
+    """Dump PGLE estimation results via trace_structured for tlparse."""
+    estimation_log = getattr(estimator, "estimation_log", None) or []
+    miss_log = getattr(estimator, "miss_log", None) or []
+
+    rows = []
+    for entry in estimation_log:
+        row = dict(entry)
+        node_name = entry.get("node", "")
+        if analytical_estimates and node_name in analytical_estimates:
+            analytical_ms = analytical_estimates[node_name]
+            row["analytical_ms"] = analytical_ms
+            pgle_ms = entry.get("pgle_ms", 0)
+            if analytical_ms > 0:
+                row["pgle_vs_analytical_pct"] = round(
+                    (pgle_ms - analytical_ms) / analytical_ms * 100, 1
+                )
+        rows.append(row)
+
+    # Single combined table: estimations + misses at the bottom
+    table = _format_pgle_table(rows, miss_log)
+    trace_structured(
+        "artifact",
+        metadata_fn=lambda: {
+            "name": "pgle_estimations_table",
+            "encoding": "string",
+        },
+        payload_fn=lambda: table,
+    )
+
+    log.info(
+        "PGLE: %d estimations, %d misses logged to trace_structured",
+        len(rows),
+        len(miss_log),
+    )
+
+
+def _format_bytes(nbytes: int) -> str:
+    """Format byte count as human-readable K/M/G string."""
+    if nbytes >= 1 << 30:
+        return f"{nbytes / (1 << 30):.1f}G"
+    if nbytes >= 1 << 20:
+        return f"{nbytes / (1 << 20):.1f}M"
+    if nbytes >= 1 << 10:
+        return f"{nbytes / (1 << 10):.0f}K"
+    return f"{nbytes}B"
+
+
+def _format_pgle_table(
+    rows: list[dict[str, Any]],
+    miss_log: list[dict[str, Any]] | None = None,
+) -> str:
+    """Format PGLE estimations + misses as a single aligned text table."""
+    misses: list[dict[str, Any]] = list(miss_log) if miss_log is not None else []
+    # GPU info header
+    lines: list[str] = []
+    try:
+        gpu_name = torch.cuda.get_device_name(0)
+        gpu_count = torch.cuda.device_count()
+        lines.append(f"GPU: {gpu_name} x{gpu_count}")
+    except Exception:
+        lines.append("GPU: unknown")
+    lines.append("")
+
+    has_analytical = any("analytical_ms" in r for r in rows)
+
+    # Header
+    if has_analytical:
+        header = (
+            f"{'node':<45} {'op':<30} {'size':>8} {'gs':>4} {'st':>3}"
+            f" {'pgle_ms':>10} {'analytical_ms':>15} {'diff%':>8} {'':>3}"
+            f" {'pgle_GB/s':>10} {'analytical_GB/s':>15}"
+        )
+    else:
+        header = (
+            f"{'node':<45} {'op':<30} {'size':>8} {'gs':>4} {'st':>3} {'pgle_ms':>10}"
+        )
+    lines.append(header)
+    lines.append("-" * len(header))
+
+    for row in rows:
+        node = row.get("node", "")[:44]
+        op = row.get("op", "")[:29]
+        gs = row.get("group_size", "")
+        stride = row.get("stride", "")
+        stride_str = str(stride) if stride is not None else "-"
+        pgle_ms = row.get("pgle_ms", 0)
+        dtype_bytes = row.get("dtype_bytes", 0)
+        n = row.get("nelems", 0) if isinstance(row.get("nelems"), int) else 0
+        size_str = _format_bytes(n * dtype_bytes) if dtype_bytes > 0 and n > 0 else "-"
+
+        if has_analytical:
+            anal_ms = row.get("analytical_ms", None)
+            diff_pct = row.get("pgle_vs_analytical_pct", None)
+            anal_str = f"{anal_ms:.4f}" if anal_ms is not None else "-"
+            diff_str = f"{diff_pct:+.1f}%" if diff_pct is not None else "-"
+            flag = ""
+            if diff_pct is not None:
+                adp = abs(diff_pct)
+                if adp > 50:
+                    flag = "***"
+                elif adp > 15:
+                    flag = "**"
+            # Bandwidth in GB/s for comm ops
+            pgle_bw_str = ""
+            anal_bw_str = ""
+            if dtype_bytes > 0 and n > 0:
+                data_bytes = n * dtype_bytes
+                if pgle_ms > 0:
+                    pgle_bw = data_bytes / (pgle_ms * 1e-3) / 1e9
+                    pgle_bw_str = f"{pgle_bw:.1f}"
+                if anal_ms is not None and anal_ms > 0:
+                    anal_bw = data_bytes / (anal_ms * 1e-3) / 1e9
+                    anal_bw_str = f"{anal_bw:.1f}"
+            line = (
+                f"{node:<45} {op:<30} {size_str:>8} {gs:>4} {stride_str:>3}"
+                f" {pgle_ms:>10.4f} {anal_str:>15} {diff_str:>8} {flag:>3}"
+                f" {pgle_bw_str:>10} {anal_bw_str:>15}"
+            )
+        else:
+            line = (
+                f"{node:<45} {op:<30} {size_str:>8} {gs:>4} {stride_str:>3}"
+                f" {pgle_ms:>10.4f}"
+            )
+        lines.append(line.rstrip())
+
+    # Summary
+    lines.append("")
+    lines.append(f"Total: {len(rows)} estimations")
+    if has_analytical:
+        f1 = sum(
+            1
+            for r in rows
+            if r.get("pgle_vs_analytical_pct") is not None
+            and abs(r["pgle_vs_analytical_pct"]) > 50
+        )
+        f2 = sum(
+            1
+            for r in rows
+            if r.get("pgle_vs_analytical_pct") is not None
+            and 15 < abs(r["pgle_vs_analytical_pct"]) <= 50
+        )
+        lines.append(f"Flagged: {f2} ** (>15%), {f1} *** (>50%)")
+
+    # Misses section
+    if misses:
+        lines.append("")
+        lines.append(f"=== MISSES ({len(misses)}) ===")
+        miss_header = f"{'node':<45} {'op':<30} {'reason'}"
+        lines.append(miss_header)
+        lines.append("-" * len(miss_header))
+        for m in misses:  # pyrefly: ignore[unsupported-operation]
+            node = m.get("node", "")[:44]
+            op = (m.get("op") or m.get("target") or "")[:29]
+            reason = m.get("reason", "")
+            # Show shape info if available
+            shapes = m.get("shapes")
+            shape_info = m.get("shape")
+            extra = ""
+            if shapes:
+                extra = f" shapes={shapes}"
+            elif shape_info:
+                extra = f" shape={shape_info}"
+            lines.append(f"{node:<45} {op:<30} {reason}{extra}".rstrip())
+
+    return "\n".join(lines)

--- a/torch/_inductor/fx_passes/overlap_scheduling.py
+++ b/torch/_inductor/fx_passes/overlap_scheduling.py
@@ -1,6 +1,7 @@
 import functools
 import heapq
 import itertools
+import json
 import logging
 import sys
 from collections import Counter, defaultdict
@@ -1719,6 +1720,50 @@ def align_estimations_across_ranks(
     return dict(zip(nodes, medians))
 
 
+def _collect_analytical_estimates(
+    gm: torch.fx.GraphModule,
+    pgle_estimator: Callable[[fx.Node, int | None], float | None],
+) -> dict[str, float]:
+    """Collect analytical runtime estimates for nodes that PGLE matched.
+
+    Runs the analytical estimator (no custom override) over the same nodes
+    to enable PGLE vs analytical comparison.
+    """
+    estimation_log = getattr(pgle_estimator, "estimation_log", [])
+    matched_names = OrderedSet([e["node"] for e in estimation_log])
+    if not matched_names:
+        return {}
+
+    analytical: dict[str, float] = {}
+    for node in gm.graph.nodes:
+        if node.name not in matched_names:
+            continue
+        # Collective: use analytical NCCL estimator
+        if _schedulable_wait_node(node):
+            start = node.args[0]
+            if isinstance(start, fx.Node) and start.name in matched_names:
+                est = torch._inductor.comm_analysis.estimate_nccl_collective_runtime_from_fx_node(
+                    start
+                )
+                analytical[start.name] = est
+        elif node.target in (
+            torch.ops._c10d_functional.all_gather_into_tensor.default,
+            torch.ops._c10d_functional.reduce_scatter_tensor.default,
+            torch.ops._c10d_functional.all_reduce.default,
+            torch.ops._c10d_functional.all_to_all_single.default,
+        ):
+            est = torch._inductor.comm_analysis.estimate_nccl_collective_runtime_from_fx_node(
+                node
+            )
+            analytical[node.name] = est
+        # Compute: use roofline estimation
+        elif is_compute_node(node) and node.name in matched_names:
+            est = estimate_roofline_runtime_ms(node)
+            if est is not None:
+                analytical[node.name] = est
+    return analytical
+
+
 def schedule_overlap_bucketing(
     gm: torch.fx.GraphModule,
     max_in_flight_gb: float = 5,
@@ -1769,6 +1814,49 @@ def schedule_overlap_bucketing(
     if not any(is_wait_tensor(n) for n in gm.graph.nodes):
         return gm
 
+    # Auto-load PGLE if configured and no custom estimation provided
+    if custom_runtime_estimation is None:
+        from torch._inductor import config as inductor_config
+
+        pgle_path = inductor_config.aten_distributed_optimizations.profile_guided_estimation_path
+        if pgle_path:
+            from torch._inductor.fx_passes.node_runtime_estimation import (
+                make_profile_guided_estimator,
+            )
+            from torch._inductor.fx_passes.profile_guided_estimation import _rank_stride
+
+            custom_runtime_estimation = make_profile_guided_estimator(pgle_path)
+            log.info("PGLE: using profile-guided estimation from %s", pgle_path)
+            # Log profile stats
+            profile = custom_runtime_estimation.profile  # type: ignore[union-attr]
+            coll_keys = list(profile._collective_index.keys())
+            mm_count = len(profile._matmul_index)
+            sdpa_count = len(profile._sdpa_index)
+            trace_structured(
+                "artifact",
+                metadata_fn=lambda: {
+                    "name": "pgle_profile_loaded",
+                    "encoding": "json",
+                },
+                payload_fn=lambda: json.dumps(
+                    {
+                        "path": pgle_path,
+                        "collective_keys": [
+                            {
+                                "name": k[0],
+                                "ranks": list(k[1]),
+                                "group_size": len(k[1]),
+                                "stride": _rank_stride(k[1]),
+                                "dtype": k[2],
+                            }
+                            for k in coll_keys
+                        ],
+                        "matmul_count": mm_count,
+                        "sdpa_count": sdpa_count,
+                    }
+                ),
+            )
+
     trace_structured(
         "artifact",
         metadata_fn=lambda: {
@@ -1805,6 +1893,19 @@ def schedule_overlap_bucketing(
         },
         payload_fn=lambda: ret.print_readable(False),
     )
+
+    # Log PGLE estimations to trace_structured for tlparse
+    if custom_runtime_estimation is not None and hasattr(
+        custom_runtime_estimation, "estimation_log"
+    ):
+        from torch._inductor.fx_passes.node_runtime_estimation import (
+            log_pgle_estimations,
+        )
+
+        # Collect analytical estimates for comparison
+        analytical = _collect_analytical_estimates(ret, custom_runtime_estimation)
+        log_pgle_estimations(custom_runtime_estimation, analytical)
+
     return ret
 
 
@@ -1846,5 +1947,16 @@ def schedule_overlap_bucketing_from_inductor_configs(
     for key in config_keys:
         if (val := getattr(dist_opts, key, None)) is not None:
             kwargs[key] = val
+
+    # Profile-guided latency estimation: load profile and set as custom estimator
+    pgle_path = dist_opts.profile_guided_estimation_path
+    if pgle_path and "custom_runtime_estimation" not in kwargs:
+        from torch._inductor.fx_passes.node_runtime_estimation import (
+            make_profile_guided_estimator,
+        )
+
+        pgle_estimator = make_profile_guided_estimator(pgle_path)
+        kwargs["custom_runtime_estimation"] = pgle_estimator
+        log.info("PGLE: using profile-guided estimation from %s", pgle_path)
 
     return schedule_overlap_bucketing(gm, **kwargs)  # type: ignore[arg-type]

--- a/torch/_inductor/fx_passes/profile_guided_estimation.py
+++ b/torch/_inductor/fx_passes/profile_guided_estimation.py
@@ -1,0 +1,761 @@
+"""
+Profile-Guided Latency Estimation (PGLE) for overlap scheduling.
+
+Parses a Chrome Trace JSON (from torch.profiler) and builds lookup tables
+for collective, matmul, and attention kernel runtimes. These are used as
+a custom_runtime_estimation hook in the overlap scheduler.
+
+When the same profile is loaded on all ranks, estimates are deterministic
+and no cross-rank synchronization is needed.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import Any
+
+import torch
+import torch.fx as fx
+from torch.utils._ordered_set import OrderedSet
+
+
+log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Mesh dimension identification via rank stride patterns
+# ---------------------------------------------------------------------------
+
+
+def _rank_stride(ranks: tuple[int, ...]) -> int | None:
+    """Compute the stride of a sorted rank tuple, or None if non-uniform.
+
+    Examples:
+        (0, 2, 4, 6) → stride 2
+        (0, 1)       → stride 1
+        (1, 3, 5, 7) → stride 2
+        (0, 1, 4, 5) → None (non-uniform)
+    """
+    if len(ranks) <= 1:
+        return None
+    stride = ranks[1] - ranks[0]
+    if stride <= 0:
+        return None
+    for i in range(2, len(ranks)):
+        if ranks[i] - ranks[i - 1] != stride:
+            return None
+    return stride
+
+
+# ---------------------------------------------------------------------------
+# Data classes for profile records
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CollectiveRecord:
+    """A single collective kernel observation from the profile."""
+
+    collective_name: str  # "all_gather_into_tensor", "reduce_scatter_tensor", etc.
+    pg_ranks: tuple[int, ...]  # sorted rank tuple
+    group_size: int
+    nelems: int
+    dtype: str  # "Float", "BFloat16", etc.
+    duration_us: float
+
+
+@dataclass
+class MatmulRecord:
+    """A single aten::mm observation from the profile."""
+
+    # input shapes: ((M, K), (K, N))
+    input_shapes: tuple[tuple[int, ...], tuple[int, ...]]
+    dtype: str
+    duration_us: float  # sum of all GPU kernels for this CPU op
+
+
+@dataclass
+class SdpaRecord:
+    """A single SDPA (scaled dot product attention) observation."""
+
+    batch: int
+    num_heads: int
+    seq_len: int
+    head_dim: int
+    dtype: str
+    is_backward: bool
+    duration_us: float  # sum of all GPU kernels for this CPU op
+
+
+# ---------------------------------------------------------------------------
+# Profile data loader and lookup
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ProfileData:
+    """Parse Chrome Trace JSON and build lookup tables for kernel runtimes."""
+
+    collectives: list[CollectiveRecord] = field(default_factory=list)
+    matmuls: list[MatmulRecord] = field(default_factory=list)
+    sdpa_records: list[SdpaRecord] = field(default_factory=list)
+    pg_configs: dict[str, tuple[int, ...]] = field(default_factory=dict)
+
+    # Lookup indices built after loading
+    _collective_index: dict[
+        tuple[str, tuple[int, ...], str], list[tuple[int, float]]
+    ] = field(default_factory=dict)
+    # Fallback index by (name, stride, group_size, dtype) — matches PGs
+    # belonging to the same mesh dimension regardless of specific ranks.
+    # E.g. (0,2,4,6) and (1,3,5,7) both have stride=2, size=4.
+    _collective_index_by_stride: dict[
+        tuple[str, int, int, str], list[tuple[int, float]]
+    ] = field(default_factory=dict)
+    # Count of distinct strides per (stride, group_size) — used for
+    # ambiguity check (skip fallback if multiple PGs share stride+size).
+    _pg_count_by_stride: dict[tuple[int, int], int] = field(default_factory=dict)
+    _matmul_index: dict[tuple[tuple[int, ...], tuple[int, ...], str], float] = field(
+        default_factory=dict
+    )
+    _sdpa_index: dict[tuple[int, int, int, int, str, bool], float] = field(
+        default_factory=dict
+    )
+
+    def load(self, trace_path: str) -> None:
+        """Load and parse a Chrome Trace JSON file."""
+        with open(trace_path) as f:
+            data = json.load(f)
+
+        self._parse_pg_configs(data)
+        self._parse_events(data.get("traceEvents", []))
+        self._build_indices()
+
+        log.info(
+            "PGLE loaded: %d collectives, %d matmuls, %d sdpa records, %d PGs",
+            len(self.collectives),
+            len(self.matmuls),
+            len(self.sdpa_records),
+            len(self.pg_configs),
+        )
+
+    def _parse_pg_configs(self, data: dict[str, Any]) -> None:
+        dist_info = data.get("distributedInfo", {})
+        pg_config = dist_info.get("pg_config", {})
+        # pg_config can be a list of dicts or a dict of dicts
+        if isinstance(pg_config, list):
+            for pg_info in pg_config:
+                pg_name = str(pg_info.get("pg_name", ""))
+                ranks = pg_info.get("ranks", [])
+                if ranks:
+                    self.pg_configs[pg_name] = tuple(sorted(ranks))
+        elif isinstance(pg_config, dict):
+            for pg_name, pg_info in pg_config.items():
+                ranks = pg_info.get("ranks", [])
+                if ranks:
+                    self.pg_configs[pg_name] = tuple(sorted(ranks))
+
+    def _parse_events(self, events: list[dict[str, Any]]) -> None:
+        # Build External id -> CPU op mapping
+        cpu_ops: dict[int, dict[str, Any]] = {}
+        for ev in events:
+            cat = ev.get("cat", "")
+            if cat == "cpu_op":
+                eid = ev.get("args", {}).get("External id")
+                if eid is not None:
+                    cpu_ops[eid] = ev
+
+        # Build External id -> list of GPU kernel durations
+        gpu_kernels: dict[int, list[tuple[str, float]]] = defaultdict(list)
+        for ev in events:
+            if ev.get("cat") != "kernel":
+                continue
+            args = ev.get("args", {})
+            eid = args.get("External id")
+            dur = ev.get("dur", 0.0)
+            name = ev.get("name", "")
+            if eid is not None and dur > 0:
+                gpu_kernels[eid].append((name, dur))
+
+        # Parse collectives from GPU kernel events directly
+        # (NCCL kernels carry collective metadata in args)
+        for ev in events:
+            if ev.get("cat") != "kernel":
+                continue
+            args = ev.get("args", {})
+            coll_name = args.get("Collective name")
+            if coll_name is None:
+                continue
+            pg_name = args.get("Process Group Name", "")
+            pg_ranks_str = args.get("Process Group Ranks", "")
+            group_size = args.get("Group size", 0)
+            nelems = args.get("In msg nelems", 0)
+            dtype = args.get("dtype", "")
+            dur = ev.get("dur", 0.0)
+            if dur <= 0:
+                continue
+
+            # Parse ranks from string like "[0, 1, 2, 3]"
+            pg_ranks = self._parse_ranks(pg_ranks_str, pg_name)
+
+            self.collectives.append(
+                CollectiveRecord(
+                    collective_name=coll_name,
+                    pg_ranks=pg_ranks,
+                    group_size=group_size,
+                    nelems=nelems,
+                    dtype=dtype,
+                    duration_us=dur,
+                )
+            )
+
+        # Parse matmuls and SDPA from CPU ops correlated to GPU kernels
+        for eid, cpu_ev in cpu_ops.items():
+            name = cpu_ev.get("name", "")
+            cpu_args = cpu_ev.get("args", {})
+            kernels = gpu_kernels.get(eid, [])
+            if not kernels:
+                continue
+            total_dur = sum(dur for _, dur in kernels)
+
+            if name == "aten::mm":
+                self._parse_mm(cpu_args, total_dur)
+            elif "attention" in name.lower() or "sdpa" in name.lower():
+                self._parse_sdpa(name, cpu_args, total_dur)
+
+    def _parse_ranks(self, ranks_str: str, pg_name: str) -> tuple[int, ...]:
+        """Parse rank list from profile string or fall back to pg_configs."""
+        if isinstance(ranks_str, str) and ranks_str.startswith("["):
+            try:
+                ranks = json.loads(ranks_str)
+                return tuple(sorted(ranks))
+            except (json.JSONDecodeError, TypeError):
+                pass
+        # Fall back to pg_configs
+        if pg_name in self.pg_configs:
+            return self.pg_configs[pg_name]
+        return ()
+
+    def _parse_mm(self, args: dict[str, Any], total_dur: float) -> None:
+        input_dims = args.get("Input Dims", [])
+        input_types = args.get("Input type", [])
+        if len(input_dims) < 2:
+            return
+        dtype = input_types[0] if input_types else ""
+        shapes = (tuple(input_dims[0]), tuple(input_dims[1]))
+        self.matmuls.append(
+            MatmulRecord(input_shapes=shapes, dtype=dtype, duration_us=total_dur)
+        )
+
+    def _parse_sdpa(self, op_name: str, args: dict[str, Any], total_dur: float) -> None:
+        input_dims = args.get("Input Dims", [])
+        input_types = args.get("Input type", [])
+        if not input_dims or not input_dims[0]:
+            return
+        # Q tensor shape: [batch, num_heads, seq_len, head_dim]
+        q_shape = input_dims[0]
+        if len(q_shape) != 4:
+            return
+        dtype = input_types[0] if input_types else ""
+        is_backward = "backward" in op_name.lower()
+        self.sdpa_records.append(
+            SdpaRecord(
+                batch=q_shape[0],
+                num_heads=q_shape[1],
+                seq_len=q_shape[2],
+                head_dim=q_shape[3],
+                dtype=dtype,
+                is_backward=is_backward,
+                duration_us=total_dur,
+            )
+        )
+
+    def _build_indices(self) -> None:
+        """Build lookup indices from parsed records."""
+        coll_idx: dict[tuple[str, tuple[int, ...], str], list[tuple[int, float]]] = (
+            defaultdict(list)
+        )
+        coll_idx_by_stride: dict[tuple[str, int, int, str], list[tuple[int, float]]] = (
+            defaultdict(list)
+        )
+        # Track distinct PG rank sets per (stride, group_size) for ambiguity check
+        pg_sets_by_stride: dict[tuple[int, int], OrderedSet[tuple[int, ...]]] = (
+            defaultdict(OrderedSet)
+        )
+        for rec in self.collectives:
+            norm_name = self._normalize_collective_name(rec.collective_name)
+            gs = len(rec.pg_ranks) if rec.pg_ranks else rec.group_size
+            coll_idx[(norm_name, rec.pg_ranks, rec.dtype)].append(
+                (rec.nelems, rec.duration_us)
+            )
+            stride = _rank_stride(rec.pg_ranks)
+            if stride is not None:
+                coll_idx_by_stride[(norm_name, stride, gs, rec.dtype)].append(
+                    (rec.nelems, rec.duration_us)
+                )
+                pg_sets_by_stride[(stride, gs)].add(rec.pg_ranks)
+        # Sort by nelems for interpolation
+        self._collective_index = {
+            k: sorted(v, key=lambda x: x[0]) for k, v in coll_idx.items()
+        }
+        self._collective_index_by_stride = {
+            k: sorted(v, key=lambda x: x[0]) for k, v in coll_idx_by_stride.items()
+        }
+        self._pg_count_by_stride = {k: len(pgs) for k, pgs in pg_sets_by_stride.items()}
+
+        # Matmul index: (shape_a, shape_b, dtype) -> avg_dur_us
+        mm_groups: dict[tuple[tuple[int, ...], tuple[int, ...], str], list[float]] = (
+            defaultdict(list)
+        )
+        for rec in self.matmuls:
+            key = (rec.input_shapes[0], rec.input_shapes[1], rec.dtype)
+            mm_groups[key].append(rec.duration_us)
+        self._matmul_index = {k: sum(v) / len(v) for k, v in mm_groups.items()}
+
+        # SDPA index: (batch, heads, seq_len, head_dim, dtype, is_bwd) -> avg_dur_us
+        sdpa_groups: dict[tuple[int, int, int, int, str, bool], list[float]] = (
+            defaultdict(list)
+        )
+        for rec in self.sdpa_records:
+            key = (
+                rec.batch,
+                rec.num_heads,
+                rec.seq_len,
+                rec.head_dim,
+                rec.dtype,
+                rec.is_backward,
+            )
+            sdpa_groups[key].append(rec.duration_us)
+        self._sdpa_index = {k: sum(v) / len(v) for k, v in sdpa_groups.items()}
+
+    @staticmethod
+    def _normalize_collective_name(name: str) -> str:
+        """Normalize collective name between profile and FX conventions.
+
+        Profile uses: _allgather_base, allreduce, reduce_scatter_tensor_coalesced
+        FX uses: all_gather_into_tensor, all_reduce, reduce_scatter_tensor
+        """
+        n = name.lower()
+        if "allgather" in n or "all_gather" in n:
+            return "all_gather"
+        if "reduce_scatter" in n:
+            return "reduce_scatter"
+        if "allreduce" in n or "all_reduce" in n:
+            return "all_reduce"
+        if "all_to_all" in n or "alltoall" in n:
+            return "all_to_all"
+        return name
+
+    # -----------------------------------------------------------------------
+    # Lookup methods (return ms or None)
+    # -----------------------------------------------------------------------
+
+    def lookup_collective(
+        self,
+        collective_name: str,
+        pg_ranks: tuple[int, ...],
+        nelems: int,
+        dtype: str,
+    ) -> float | None:
+        """Look up collective duration in ms. Interpolates by nelems in log-log space.
+
+        Tries exact rank match first, then falls back to stride-based match
+        (same mesh dimension across ranks: e.g. (0,2,4,6) and (1,3,5,7) both
+        have stride=2, size=4 → same dimension).
+        """
+        norm_name = self._normalize_collective_name(collective_name)
+        # Try exact rank match first
+        key = (norm_name, pg_ranks, dtype)
+        entries = self._collective_index.get(key)
+        if not entries:
+            # Fall back to stride-based match: same mesh dimension
+            gs = len(pg_ranks)
+            stride = _rank_stride(pg_ranks)
+            if (
+                stride is not None
+                and self._pg_count_by_stride.get((stride, gs), 0) == 1
+            ):
+                stride_key = (norm_name, stride, gs, dtype)
+                entries = self._collective_index_by_stride.get(stride_key)
+            if not entries:
+                return None
+
+        # Exact match
+        for n, dur in entries:
+            if n == nelems:
+                return dur / 1e3  # us -> ms
+
+        # Interpolation in log-log space
+        return self._interpolate_log_log(entries, nelems)
+
+    def _interpolate_log_log(
+        self, entries: list[tuple[int, float]], target_nelems: int
+    ) -> float | None:
+        """Interpolate duration in log-log space (log(nelems) vs log(dur))."""
+        if not entries or target_nelems <= 0:
+            return None
+
+        log_target = math.log(target_nelems)
+
+        # Find bracketing entries
+        lower: tuple[int, float] | None = None
+        upper: tuple[int, float] | None = None
+        for n, dur in entries:
+            if n <= 0 or dur <= 0:
+                continue
+            if n <= target_nelems:
+                lower = (n, dur)
+            if n >= target_nelems and upper is None:
+                upper = (n, dur)
+
+        if lower is not None and upper is not None:
+            log_n0, log_d0 = math.log(lower[0]), math.log(lower[1])
+            log_n1, log_d1 = math.log(upper[0]), math.log(upper[1])
+            if log_n1 == log_n0:
+                return lower[1] / 1e3
+            t = (log_target - log_n0) / (log_n1 - log_n0)
+            log_dur = log_d0 + t * (log_d1 - log_d0)
+            return math.exp(log_dur) / 1e3  # us -> ms
+        elif lower is not None:
+            # Extrapolate from nearest lower (scale proportionally)
+            return (lower[1] * target_nelems / lower[0]) / 1e3
+        elif upper is not None:
+            # Extrapolate from nearest upper
+            return (upper[1] * target_nelems / upper[0]) / 1e3
+
+        return None
+
+    def lookup_mm(
+        self,
+        input_shapes: tuple[tuple[int, ...], tuple[int, ...]],
+        dtype: str,
+    ) -> float | None:
+        """Look up matmul duration in ms.
+
+        Tries exact shape match first, then interpolates by FLOP ratio from
+        the nearest matmul with the same dtype.
+        """
+        key = (input_shapes[0], input_shapes[1], dtype)
+        dur_us = self._matmul_index.get(key)
+        if dur_us is not None:
+            return dur_us / 1e3  # us -> ms
+        # Interpolate: scale by FLOP ratio from nearest same-dtype matmul
+        target_flops = self._mm_flops(input_shapes[0], input_shapes[1])
+        if target_flops <= 0:
+            return None
+        best_ratio = float("inf")
+        best_dur: float | None = None
+        for (sa, sb, dt), d in self._matmul_index.items():
+            if dt != dtype:
+                continue
+            ref_flops = self._mm_flops(sa, sb)
+            if ref_flops <= 0:
+                continue
+            ratio = max(target_flops / ref_flops, ref_flops / target_flops)
+            if ratio < best_ratio:
+                best_ratio = ratio
+                best_dur = d * (target_flops / ref_flops)
+        if best_dur is not None:
+            return best_dur / 1e3
+        return None
+
+    @staticmethod
+    def _mm_flops(a: tuple[int, ...], b: tuple[int, ...]) -> int:
+        """Compute 2*M*N*K for a matmul (A=[M,K] @ B=[K,N])."""
+        if len(a) >= 2 and len(b) >= 2:
+            return 2 * a[-2] * b[-1] * a[-1]
+        return 0
+
+    def lookup_sdpa(
+        self,
+        batch: int,
+        num_heads: int,
+        seq_len: int,
+        head_dim: int,
+        dtype: str,
+        is_backward: bool,
+    ) -> float | None:
+        """Look up SDPA duration in ms.
+
+        Tries exact shape match first, then interpolates by FLOP ratio from
+        the nearest SDPA with the same dtype and direction (fwd/bwd).
+        """
+        key = (batch, num_heads, seq_len, head_dim, dtype, is_backward)
+        dur_us = self._sdpa_index.get(key)
+        if dur_us is not None:
+            return dur_us / 1e3  # us -> ms
+        # Interpolate: SDPA FLOPs ~ batch * heads * seq_len^2 * head_dim
+        target_flops = batch * num_heads * seq_len * seq_len * head_dim
+        if target_flops <= 0:
+            return None
+        best_ratio = float("inf")
+        best_dur: float | None = None
+        for (b2, h2, s2, d2, dt2, bwd2), dur in self._sdpa_index.items():
+            if dt2 != dtype or bwd2 != is_backward:
+                continue
+            ref_flops = b2 * h2 * s2 * s2 * d2
+            if ref_flops <= 0:
+                continue
+            ratio = max(target_flops / ref_flops, ref_flops / target_flops)
+            if ratio < best_ratio:
+                best_ratio = ratio
+                best_dur = dur * (target_flops / ref_flops)
+        if best_dur is not None:
+            return best_dur / 1e3
+        return None
+
+
+# ---------------------------------------------------------------------------
+# FX node inspection helpers
+# ---------------------------------------------------------------------------
+
+# Mapping from torch dtype to profile dtype strings
+_DTYPE_TO_PROFILE_STR: dict[torch.dtype, str] = {
+    torch.float32: "Float",
+    torch.float16: "Half",
+    torch.bfloat16: "BFloat16",
+    torch.float64: "Double",
+    torch.int32: "Int",
+    torch.int64: "Long",
+    torch.int8: "Char",
+    torch.uint8: "Byte",
+}
+
+# Also map C10 type strings to normalized form
+_C10_DTYPE_TO_PROFILE_STR: dict[str, str] = {
+    "c10::Float": "Float",
+    "c10::Half": "Half",
+    "c10::BFloat16": "BFloat16",
+    "c10::Double": "Double",
+    "c10::Int": "Int",
+    "c10::Long": "Long",
+    "c10::Char": "Char",
+    "c10::Byte": "Byte",
+}
+
+
+def _dtype_to_profile_str(dtype: torch.dtype) -> str:
+    return _DTYPE_TO_PROFILE_STR.get(dtype, str(dtype))
+
+
+def _normalize_profile_dtype(dtype_str: str) -> str:
+    """Normalize profile dtype string (may be 'c10::BFloat16' or 'BFloat16')."""
+    return _C10_DTYPE_TO_PROFILE_STR.get(dtype_str, dtype_str)
+
+
+def _get_node_dtype_str(node: fx.Node) -> str:
+    """Extract dtype string from FX node metadata."""
+    val = node.meta.get("val")
+    if isinstance(val, torch.Tensor):
+        return _dtype_to_profile_str(val.dtype)
+    if isinstance(val, (list, tuple)) and val:
+        first = val[0]
+        if isinstance(first, torch.Tensor):
+            return _dtype_to_profile_str(first.dtype)
+    return ""
+
+
+def _is_mm_node(node: fx.Node) -> bool:
+    """Check if node is a matrix multiplication."""
+    return node.target in (
+        torch.ops.aten.mm.default,
+        torch.ops.aten.mm.out,
+    )
+
+
+def _is_sdpa_node(node: fx.Node) -> bool:
+    """Check if node is a scaled dot-product attention op."""
+    target = node.target
+    if not hasattr(target, "__name__"):
+        return False
+    name = target.__name__ if hasattr(target, "__name__") else str(target)
+    return any(
+        kw in name.lower()
+        for kw in ("scaled_dot_product", "cudnn_attention", "flash_attention", "sdpa")
+    )
+
+
+def _is_sdpa_backward(node: fx.Node) -> bool:
+    """Check if SDPA node is a backward op."""
+    target = node.target
+    name = target.__name__ if hasattr(target, "__name__") else str(target)
+    return "backward" in name.lower()
+
+
+def _get_mm_shapes(
+    node: fx.Node,
+) -> tuple[tuple[int, ...], tuple[int, ...]] | None:
+    """Extract (A_shape, B_shape) from mm node metadata."""
+    if len(node.args) < 2:
+        return None
+    a_node, b_node = node.args[0], node.args[1]
+    if not isinstance(a_node, fx.Node) or not isinstance(b_node, fx.Node):
+        return None
+    a_val = a_node.meta.get("val")
+    b_val = b_node.meta.get("val")
+    if not isinstance(a_val, torch.Tensor) or not isinstance(b_val, torch.Tensor):
+        return None
+
+    def _resolve_shape(t: torch.Tensor) -> tuple[int, ...] | None:
+        from torch._inductor.fx_passes.node_runtime_estimation import get_hint
+
+        shape = [get_hint(s) for s in t.shape]
+        if any(s is None for s in shape):
+            log.debug("PGLE: unresolved symbolic dims in shape %s", t.shape)
+            return None
+        return tuple(shape)  # type: ignore[arg-type]
+
+    a_shape = _resolve_shape(a_val)
+    b_shape = _resolve_shape(b_val)
+    if a_shape is None or b_shape is None:
+        return None
+    return (a_shape, b_shape)
+
+
+def _get_sdpa_key(
+    node: fx.Node,
+) -> tuple[int, int, int, int, str, bool] | None:
+    """Extract (batch, heads, seq_len, head_dim, dtype, is_bwd) from SDPA node."""
+    # Q is first input
+    if not node.args:
+        return None
+    q_node = node.args[0]
+    if not isinstance(q_node, fx.Node):
+        return None
+    q_val = q_node.meta.get("val")
+    if not isinstance(q_val, torch.Tensor):
+        return None
+    shape = q_val.shape
+    if len(shape) != 4:
+        return None
+    try:
+        batch, heads, seq_len, head_dim = (int(s) for s in shape)
+    except (TypeError, ValueError):
+        return None
+    dtype = _dtype_to_profile_str(q_val.dtype)
+    is_bwd = _is_sdpa_backward(node)
+    return (batch, heads, seq_len, head_dim, dtype, is_bwd)
+
+
+def _is_collective_node(node: fx.Node) -> bool:
+    """Check if node is a collective communication op."""
+    return node.target in (
+        torch.ops._c10d_functional.all_gather_into_tensor.default,
+        torch.ops._c10d_functional.all_gather_into_tensor_out.default,
+        torch.ops._c10d_functional.reduce_scatter_tensor.default,
+        torch.ops._c10d_functional.all_reduce.default,
+        torch.ops._c10d_functional.all_to_all_single.default,
+    )
+
+
+def _get_collective_info(
+    node: fx.Node,
+) -> tuple[str, tuple[int, ...], int, str] | None:
+    """Extract (collective_name, pg_ranks, nelems, dtype) from collective node."""
+    from torch.fx.operator_schemas import normalize_function
+
+    try:
+        target = node.target
+        assert isinstance(target, torch._ops.OpOverload)
+        collective_name = target.name().split("::")[-1].split(".")[0]
+
+        opt = normalize_function(
+            target,
+            args=node.args,
+            kwargs=node.kwargs,
+            normalize_to_only_use_kwargs=True,
+        )
+        if opt is None:
+            return None
+        _, kwargs = opt
+        group_name = kwargs.get("group_name", "")
+
+        from torch.distributed.distributed_c10d import (
+            _resolve_process_group,
+            get_process_group_ranks,
+        )
+
+        pg = _resolve_process_group(group_name)
+        pg_ranks = tuple(sorted(get_process_group_ranks(pg)))
+
+        # Get nelems from input tensor
+        val = node.meta.get("val")
+        if isinstance(val, torch.Tensor):
+            nelems = 1
+            for s in val.shape:
+                nelems *= int(s)
+            dtype = _dtype_to_profile_str(val.dtype)
+        else:
+            # Try first arg
+            if node.args and isinstance(node.args[0], fx.Node):
+                inp_val = node.args[0].meta.get("val")
+                if isinstance(inp_val, torch.Tensor):
+                    nelems = 1
+                    for s in inp_val.shape:
+                        nelems *= int(s)
+                    dtype = _dtype_to_profile_str(inp_val.dtype)
+                else:
+                    return None
+            else:
+                return None
+
+        return (collective_name, pg_ranks, nelems, dtype)
+    except Exception:
+        log.debug(
+            "PGLE: failed to extract collective info for %s", node.name, exc_info=True
+        )
+        return None
+
+
+def _normalize_profile_indices(profile: ProfileData) -> None:
+    """Normalize dtype strings in profile indices to match profile format."""
+    # Rebuild collective indices with normalized dtypes
+    new_coll: dict[tuple[str, tuple[int, ...], str], list[tuple[int, float]]] = {}
+    for (coll_name, pg_ranks, dtype), entries in profile._collective_index.items():
+        norm_dtype = _normalize_profile_dtype(dtype)
+        key = (coll_name, pg_ranks, norm_dtype)
+        if key in new_coll:
+            new_coll[key].extend(entries)
+        else:
+            new_coll[key] = list(entries)
+    profile._collective_index = {
+        k: sorted(v, key=lambda x: x[0]) for k, v in new_coll.items()
+    }
+
+    new_coll_by_stride: dict[tuple[str, int, int, str], list[tuple[int, float]]] = {}
+    for (
+        coll_name,
+        stride,
+        gs,
+        dtype,
+    ), entries in profile._collective_index_by_stride.items():
+        norm_dtype = _normalize_profile_dtype(dtype)
+        key = (coll_name, stride, gs, norm_dtype)
+        if key in new_coll_by_stride:
+            new_coll_by_stride[key].extend(entries)
+        else:
+            new_coll_by_stride[key] = list(entries)
+    profile._collective_index_by_stride = {
+        k: sorted(v, key=lambda x: x[0]) for k, v in new_coll_by_stride.items()
+    }
+
+    # Rebuild matmul index with normalized dtypes (average on collision)
+    mm_groups: dict[tuple[tuple[int, ...], tuple[int, ...], str], list[float]] = (
+        defaultdict(list)
+    )
+    for (sa, sb, dtype), dur in profile._matmul_index.items():
+        norm_dtype = _normalize_profile_dtype(dtype)
+        mm_groups[(sa, sb, norm_dtype)].append(dur)
+    profile._matmul_index = {k: sum(v) / len(v) for k, v in mm_groups.items()}
+
+    # Rebuild sdpa index with normalized dtypes (average on collision)
+    sdpa_groups: dict[tuple[int, int, int, int, str, bool], list[float]] = defaultdict(
+        list
+    )
+    for (b, h, s, d, dtype, bwd), dur in profile._sdpa_index.items():
+        norm_dtype = _normalize_profile_dtype(dtype)
+        sdpa_groups[(b, h, s, d, norm_dtype, bwd)].append(dur)
+    profile._sdpa_index = {k: sum(v) / len(v) for k, v in sdpa_groups.items()}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #177988


  Add profile-guided latency estimation (PGLE) to the overlap scheduler. 
Uses actual kernel durations from torch.profiler Chrome Trace files instead of  analytical models for overlap scheduling decisions.

This will be deterministic behavior without benchmarking and having real timings from profile.




  Supported
  - Collectives: exact rank+nelems match, log-log interpolation by size, stride-based PG fallback (same mesh dimension)
  - Matmul (aten::mm): exact shape+dtype match, FLOP-ratio interpolation
  - SDPA (flash/cudnn attention): exact shape match, FLOP-ratio interpolation, fwd/bwd separation


```
  torch._inductor.config.aten_distributed_optimizations.profile_guided_estimation_path = (
      "/path/to/traces/iteration_5/rank{rank}_trace.json"
  )
```


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo