### PR TITLE
Fix incorrect attn_mask shape in scaled_dot_product_attention docs

### DIFF
--- a/aten/src/ATen/native/transformers/attention.cpp
+++ b/aten/src/ATen/native/transformers/attention.cpp
@@ -676,11 +676,11 @@ Tensor _safe_softmax(
 // greater than 0.0 is specified.
 //
 // Args:
-//     query (Tensor): Query tensor; shape (N, ..., L, E)
-//     key (Tensor): Key tensor; shape (N, ..., S, E)
-//     value (Tensor): Value tensor; shape (N, ..., S, E)
+//     query (Tensor): Query tensor; shape (N, ..., Hq, L, E)
+//     key (Tensor): Key tensor; shape (N, ..., H, S, E)
+//     value (Tensor): Value tensor; shape (N, ..., H, S, Ev)
 //     attn_mask (optional Tensor): Attention mask; shape must be broadcastable to the shape of attention weights,
-//         which is (N,..., L, S). Two types of masks are supported.
+//         which is (N,..., Hq, L, S). Two types of masks are supported.
 //         A boolean mask where a value of True indicates that the element *should* take part in attention.
 //         A float mask of the same type as query, key, value that is added to the attention score.
 //     dropout_p (float): Dropout probability; if greater than 0.0, dropout is applied
@@ -692,14 +692,17 @@ Tensor _safe_softmax(
 //         sparse masks) via tensor subclassing, allowing for a leaner API.
 //
 // Returns a tensor:
-//     output (Tensor): Attention output; shape (N, ..., L, E)
+//     output (Tensor): Attention output; shape (N, ..., Hq, L, Ev)
 //
 // Shape legend:
 //     N: Batch size
 //     ...: Any number of other batch dimensions (optional)
 //     S: Source sequence length
 //     L: Target sequence length
-//     E: Embedding dimension
+//     E: Embedding dimension of the query and key
+//     Ev: Embedding dimension of the value
+//     Hq: Number of heads of query
+//     H: Number of heads of key and value
 Tensor scaled_dot_product_attention(
     const Tensor& query_,
     const Tensor& key,

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -6078,7 +6078,7 @@ scaled_dot_product_attention = _add_docstr(
         key (Tensor): Key tensor; shape :math:`(N, ..., H, S, E)`.
         value (Tensor): Value tensor; shape :math:`(N, ..., H, S, Ev)`.
         attn_mask (optional Tensor): Attention mask; shape must be broadcastable to the shape of attention weights,
-            which is :math:`(N,..., L, S)`. Two types of masks are supported.
+            which is :math:`(N,..., Hq, L, S)`. Two types of masks are supported.
             A boolean mask where a value of True indicates that the element *should* take part in attention.
             A float mask of the same type as query, key, value that is added to the attention score.
         dropout_p (float): Dropout probability; if greater than 0.0, dropout is applied


### PR DESCRIPTION
## Summary
- Fix the documented `attn_mask` shape in `scaled_dot_product_attention` from `(N, ..., L, S)` to `(N, ..., Hq, L, S)` — the head dimension `Hq` was missing.
- Update the C++ implementation comment to include head dimensions (`Hq`, `H`) and the value embedding dimension (`Ev`) across all tensor shapes, matching the Python docstring.

## Motivation
Fixes #177482

The `attn_mask` parameter docs state its shape must be broadcastable to `(N,..., L, S)`, but the actual attention weight tensor has shape `(N,..., Hq, L, S)` since it results from the query-key dot product across `Hq` heads. This causes confusion especially when using GQA (`enable_gqa=True`) where `Hq != H`:

```python
# Fails with RuntimeError despite matching old docs
mask = torch.ones(N, L, S, dtype=torch.bool)
F.scaled_dot_product_attention(q, k, v, attn_mask=mask, enable_gqa=True)
# RuntimeError: The size of tensor a (8) must match the size of tensor b (2)

# Works — correct shape includes Hq
mask = torch.ones(N, Hq, L, S, dtype=torch.bool)
F.scaled_dot_product_attention(q, k, v, attn_mask=mask, enable_gqa=True)  # OK
```

## Changes
- `torch/nn/functional.py`: Fix `attn_mask` shape in the public docstring from `:math:\`(N,..., L, S)\`` to `:math:\`(N,..., Hq, L, S)\``, consistent with the already-documented `query` shape `(N, ..., Hq, L, E)` and `output` shape `(N, ..., Hq, L, Ev)`.
- `aten/src/ATen/native/transformers/attention.cpp`: Update the C++ comment block to use GQA-aware shapes for all tensors (query, key, value, attn_mask, output) and expand the shape legend with `Ev`, `Hq`, `H` — matching the Python docstring.

## Test Plan
- Documentation-only change; no functional code modified.
- The `Hq` dimension is already defined in the Shape legend and used consistently across all other shape annotations in both files.
- The issue's code examples verify the correct runtime behavior.

cc @drisspg @josh-gleason