### PR TITLE
[Fusion] RLLayer kernel fusion study - Inductor config tuning and SwiGLU benchmark (#178000)

### DIFF
--- a/test/inductor/benchmark_swiglu_fusion.py
+++ b/test/inductor/benchmark_swiglu_fusion.py
@@ -1,0 +1,606 @@
+"""
+Benchmark script for SwiGLU FFN epilogue fusion with Triton GEMM templates.
+
+Compares configurations at MRS-relevant shapes:
+1. Baseline: cuBLAS (ATEN backend)
+2. Triton GEMM only (no epilogue fusion)
+3. Triton GEMM + epilogue fusion
+4. Trunk autoWS TRITON-only: persistent TMA + upstream add_warp_specialize (Blackwell only)
+5. Trunk autoWS ATEN+TRITON: persistent TMA + cuBLAS competes (Blackwell only)
+6. Meta autoWS TRITON-only: persistent TMA + Meta WS passes (Blackwell only)
+7. Meta autoWS ATEN+TRITON: mixed backends + Meta WS (Blackwell only)
+
+Reports latency, peak memory, and runtime kernel launch count for each
+configuration. Blackwell WS configs automatically set Inductor config flags
+(triton.use_meta_ws, triton.use_meta_partition) - no env vars required.
+
+Usage:
+    # Default (MRS shape [5120, 4096]):
+    buck2 run @fbcode//mode/opt -c fbcode.enable_gpu_sections=true \
+        fbcode//caffe2/test/inductor:run_benchmark_swiglu_fusion
+
+    # RLLayer SwiGLU FFN shape [5120, 256] -> [5120, 512]:
+    buck2 run @fbcode//mode/opt -c fbcode.enable_gpu_sections=true \
+        fbcode//caffe2/test/inductor:run_benchmark_swiglu_fusion \
+        -- --shape-preset rllayer-ffn
+
+    # On Blackwell (autoWS set via Inductor config, no env vars needed):
+    buck2 run @fbcode//mode/opt \
+        -c fbcode.enable_gpu_sections=true \
+        -c fbcode.platform010_cuda_version=12.8 \
+        -c fbcode.nvcc_arch=b200a \
+        fbcode//caffe2/test/inductor:run_benchmark_swiglu_fusion \
+        -- --shape-preset rllayer-ffn --verbose
+"""
+
+import argparse
+import logging
+import math
+import os
+import time
+
+import torch
+import torch._inductor.config as inductor_config
+
+
+log: logging.Logger = logging.getLogger(__name__)
+
+
+def _print_diagnostics() -> dict[str, bool]:
+    """Print GPU capabilities and Triton template readiness diagnostics."""
+    print("\n" + "=" * 72)
+    print("DIAGNOSTICS")
+    print("=" * 72)
+
+    # GPU info
+    if torch.cuda.is_available():
+        dev = torch.cuda.current_device()
+        name = torch.cuda.get_device_name(dev)
+        major, minor = torch.cuda.get_device_capability(dev)
+        arch = major * 10 + minor
+        print(f"GPU:                    {name}")
+        print(f"Compute Capability:     {major}.{minor} (arch={arch})")
+    else:
+        print("GPU:                    CUDA not available!")
+        return {
+            "is_blackwell": False,
+            "has_tma_device": False,
+            "has_tensor_desc": False,
+        }
+
+    # Blackwell arch check
+    try:
+        from torch._inductor.codegen.cuda.cuda_env import is_datacenter_blackwell_arch
+
+        is_blackwell = is_datacenter_blackwell_arch()
+    except ImportError:
+        is_blackwell = False
+    print(f"is_datacenter_blackwell_arch(): {is_blackwell}")
+
+    # TMA support checks — can_use_tma() gates on has_triton_tma_device()
+    try:
+        from torch.utils._triton import has_triton_tma_device
+
+        has_tma_device = has_triton_tma_device()
+    except (ImportError, AttributeError):
+        has_tma_device = False
+    print(f"has_triton_tma_device():        {has_tma_device}")
+
+    # Check what TMA device APIs are actually importable
+    tma_old_api = False
+    try:
+        from triton.language.extra.cuda import (  # noqa: F401
+            experimental_device_tensormap_create2d,
+        )
+
+        tma_old_api = True
+    except ImportError:
+        pass
+    print(
+        f"  triton old TMA API (experimental_device_tensormap_create2d): {tma_old_api}"
+    )
+
+    tma_new_api = False
+    try:
+        from triton.language import make_tensor_descriptor  # noqa: F401
+
+        tma_new_api = True
+    except ImportError:
+        pass
+    print(f"  triton new TMA API (tl.make_tensor_descriptor): {tma_new_api}")
+
+    try:
+        from torch.utils._triton import has_triton_tensor_descriptor_host_tma
+
+        has_tensor_desc = has_triton_tensor_descriptor_host_tma()
+    except (ImportError, AttributeError):
+        has_tensor_desc = False
+    print(f"has_triton_tensor_descriptor_host_tma(): {has_tensor_desc}")
+
+    # Check the combined Blackwell check
+    try:
+        from torch.utils._triton import has_datacenter_blackwell_tma_device
+
+        has_bw_tma = has_datacenter_blackwell_tma_device()
+    except (ImportError, AttributeError):
+        has_bw_tma = False
+    print(f"has_datacenter_blackwell_tma_device(): {has_bw_tma}")
+
+    # Config state
+    print(
+        f"config.triton.enable_persistent_tma_matmul: "
+        f"{inductor_config.triton.enable_persistent_tma_matmul}"
+    )
+
+    # Environment variables
+    env_vars = [
+        "TRITON_USE_META_WS",
+        "TRITON_USE_META_PARTITION",
+        "ENABLE_PERSISTENT_TMA_MATMUL",
+        "TORCHINDUCTOR_AUTOTUNE_IN_SUBPROC",
+        "TORCH_LOGS",
+    ]
+    print("\nEnvironment variables:")
+    for var in env_vars:
+        val = os.environ.get(var, "<not set>")
+        print(f"  {var}={val}")
+
+    # Triton version
+    try:
+        import triton
+
+        print(f"\nTriton version: {triton.__version__}")
+    except (ImportError, AttributeError):
+        print("\nTriton version: <unavailable>")
+
+    # Template availability summary
+    print("\nTemplate readiness:")
+    print("  Basic Triton GEMM:          always available")
+    tma_ready = has_tma_device and inductor_config.triton.enable_persistent_tma_matmul
+    print(f"  Persistent TMA:             {'READY' if tma_ready else 'NOT READY'}")
+    if not tma_ready:
+        if not has_tma_device:
+            print("    -> Missing: has_triton_tma_device()=False")
+            print(
+                "       Need triton.language.make_tensor_descriptor or legacy TMA API"
+            )
+        if not inductor_config.triton.enable_persistent_tma_matmul:
+            print("    -> Missing: enable_persistent_tma_matmul=True")
+    bw_ready = tma_ready and has_tensor_desc and is_blackwell
+    print(f"  Blackwell WS + TMA:         {'READY' if bw_ready else 'NOT READY'}")
+    if not bw_ready and is_blackwell:
+        if not has_tensor_desc:
+            print("    -> Missing: triton.tools.tensor_descriptor.TensorDescriptor")
+        if not has_tma_device:
+            print("    -> Missing: has_triton_tma_device()=False (blocks can_use_tma)")
+        if not inductor_config.triton.enable_persistent_tma_matmul:
+            print("    -> Missing: enable_persistent_tma_matmul=True")
+    print("=" * 72 + "\n")
+
+    return {
+        "is_blackwell": is_blackwell,
+        "has_tma_device": has_tma_device,
+        "has_tensor_desc": has_tensor_desc,
+    }
+
+
+class SwiGLUFFN(torch.nn.Module):
+    """SwiGLU FFN: SiLU(x @ W_gate) * (x @ W_up) @ W_down"""
+
+    def __init__(self, input_dim: int, hidden_dim: int, bias: bool = False) -> None:
+        super().__init__()
+        self.w_gate = torch.nn.Linear(input_dim, hidden_dim, bias=bias)
+        self.w_up = torch.nn.Linear(input_dim, hidden_dim, bias=bias)
+        self.w_down = torch.nn.Linear(hidden_dim, input_dim, bias=bias)
+        self.silu = torch.nn.SiLU()
+        self._init_weights()
+
+    def _init_weights(self) -> None:
+        for name in ("w_gate", "w_up", "w_down"):
+            layer = getattr(self, name)
+            torch.nn.init.normal_(
+                layer.weight, mean=0.0, std=1.0 / math.sqrt(layer.in_features)
+            )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        gate = self.silu(self.w_gate(x))
+        up = self.w_up(x)
+        hidden = gate * up
+        return self.w_down(hidden)
+
+
+class SwiGLUFFNWithRMSNormResidual(torch.nn.Module):
+    """Full MRS pattern: RMSNorm -> SwiGLU FFN -> residual add."""
+
+    def __init__(self, input_dim: int, hidden_dim: int) -> None:
+        super().__init__()
+        self.norm = torch.nn.RMSNorm(input_dim)
+        self.ffn = SwiGLUFFN(input_dim, hidden_dim)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return x + self.ffn(self.norm(x))
+
+
+def _do_bench(fn, warmup=1000, rep=2000):
+    """Simple benchmark: run fn with warmup then measure rep iterations."""
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+
+    start = time.perf_counter()
+    for _ in range(rep):
+        fn()
+    torch.cuda.synchronize()
+    elapsed = time.perf_counter() - start
+    return elapsed / rep * 1000  # ms
+
+
+def _count_runtime_kernels(fn, verbose=False):
+    """Count actual CUDA kernel launches using profiler."""
+    torch.cuda.synchronize()
+    with torch.profiler.profile(
+        activities=[torch.profiler.ProfilerActivity.CUDA],
+    ) as prof:
+        fn()
+        torch.cuda.synchronize()
+
+    kernel_count = 0
+    kernel_names = []
+    for evt in prof.key_averages():
+        if evt.device_type == torch.autograd.DeviceType.CUDA and evt.count > 0:
+            kernel_count += evt.count
+            kernel_names.append((evt.key, evt.count))
+
+    if verbose:
+        print("    CUDA kernel trace:")
+        if kernel_names:
+            for name, count in sorted(kernel_names, key=lambda x: -x[1]):
+                tag = ""
+                if "triton" in name.lower():
+                    tag = " [TRITON]"
+                elif "gemm" in name.lower() or "cutlass" in name.lower():
+                    tag = " [cuBLAS/CUTLASS]"
+                print(f"      {name}: {count}x{tag}")
+        else:
+            print("      (no CUDA kernels detected)")
+    return kernel_count
+
+
+# Shape presets derived from RLLayer model config
+# (batch_size=512, num_targets=10, embedding_dim=256, ffn_hidden_dim=512)
+SHAPE_PRESETS: dict[str, tuple[int, int, int]] = {
+    # (batch_dim, input_dim, hidden_dim)
+    "mrs": (5120, 4096, 8192),  # Original D97188817 MRS region shape
+    "rllayer-ffn": (5120, 256, 512),  # Cross-attn SwiGLU FFN
+    "rllayer-mlp": (5120, 2048, 1024),  # Sparse module final_mlp mid-layer
+    "rllayer-attn": (81920, 256, 512),  # Cross-attn larger batch (5120*16)
+}
+
+
+def _benchmark_config(
+    model_cls,
+    input_shape,
+    hidden_dim,
+    dtype,
+    config_dict,
+    config_name,
+    include_backward,
+    verbose,
+):
+    """Compile model with given config and benchmark it."""
+    torch._dynamo.reset()
+    torch.cuda.empty_cache()
+    torch.cuda.reset_peak_memory_stats()
+
+    input_dim = input_shape[1]
+
+    model = model_cls(input_dim, hidden_dim).to(device="cuda", dtype=dtype)
+    x = torch.randn(*input_shape, device="cuda", dtype=dtype)
+
+    if verbose:
+        print(f"    Config dict: {config_dict}")
+
+    with inductor_config.patch(config_dict):
+        if verbose:
+            print(
+                f"    enable_persistent_tma_matmul="
+                f"{inductor_config.triton.enable_persistent_tma_matmul}"
+            )
+        compiled_model = torch.compile(model, fullgraph=True)
+
+        if include_backward:
+            x_grad = x.detach().clone().requires_grad_(True)
+
+            def fn():
+                out = compiled_model(x_grad)
+                out.sum().backward(retain_graph=True)
+        else:
+
+            def fn():
+                compiled_model(x)
+
+        # Warmup (includes compilation)
+        for _ in range(3):
+            fn()
+        torch.cuda.synchronize()
+
+    # Count actual runtime kernel launches
+    kernel_count = _count_runtime_kernels(fn, verbose=verbose)
+
+    # Measure peak memory
+    torch.cuda.reset_peak_memory_stats()
+    fn()
+    torch.cuda.synchronize()
+    peak_mem_mb = torch.cuda.max_memory_allocated() / (1024 * 1024)
+
+    # Benchmark latency
+    latency_ms = _do_bench(fn)
+
+    return {
+        "config": config_name,
+        "kernel_launches": kernel_count,
+        "latency_ms": latency_ms,
+        "peak_memory_mb": peak_mem_mb,
+    }
+
+
+# ---- Config definitions ----
+# Configs are run in order. Blackwell-specific configs are added dynamically
+# when a Blackwell GPU is detected (see main()).
+# All Triton configs use autotune_in_subproc=True to avoid compilation hangs
+# (Triton template compilation can get stuck in scheduling passes).
+
+CONFIGS = {
+    "cuBLAS (ATEN)": {
+        "max_autotune": False,
+        "epilogue_fusion": False,
+    },
+    "Triton GEMM (no fusion)": {
+        "max_autotune": True,
+        "max_autotune_gemm_backends": "TRITON",
+        "epilogue_fusion": False,
+        "autotune_in_subproc": True,
+    },
+    "Triton GEMM + epilogue fusion": {
+        "max_autotune": True,
+        "max_autotune_gemm_backends": "TRITON",
+        "epilogue_fusion": True,
+        "autotune_in_subproc": True,
+    },
+}
+
+BLACKWELL_CONFIGS = {
+    "Trunk autoWS (TRITON-only)": {
+        "max_autotune": True,
+        "max_autotune_gemm_backends": "TRITON",
+        "epilogue_fusion": True,
+        "triton.enable_persistent_tma_matmul": True,
+        "autotune_in_subproc": True,
+    },
+    "Trunk autoWS (ATEN+TRITON)": {
+        "max_autotune": True,
+        "max_autotune_gemm_backends": "ATEN,TRITON",
+        "epilogue_fusion": True,
+        "epilogue_fusion_first": True,
+        "coordinate_descent_tuning": True,
+        "triton.enable_persistent_tma_matmul": True,
+        "autotune_in_subproc": True,
+    },
+    "Meta autoWS (TRITON-only)": {
+        "max_autotune": True,
+        "max_autotune_gemm_backends": "TRITON",
+        "epilogue_fusion": True,
+        "triton.enable_persistent_tma_matmul": True,
+        "triton.use_meta_ws": True,
+        "triton.use_meta_partition": True,
+        "autotune_in_subproc": True,
+    },
+    "Meta autoWS (ATEN+TRITON)": {
+        "max_autotune": True,
+        "max_autotune_gemm_backends": "ATEN,TRITON",
+        "epilogue_fusion": True,
+        "epilogue_fusion_first": True,
+        "coordinate_descent_tuning": True,
+        "triton.enable_persistent_tma_matmul": True,
+        "triton.use_meta_ws": True,
+        "triton.use_meta_partition": True,
+        "autotune_in_subproc": True,
+    },
+}
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Benchmark SwiGLU FFN epilogue fusion")
+    parser.add_argument(
+        "--shape-preset",
+        type=str,
+        default=None,
+        choices=list(SHAPE_PRESETS.keys()),
+        help=(
+            "Use a predefined shape. Overrides --batch-dim/--input-dim/--hidden-dim. "
+            "Choices: mrs=[5120,4096,8192], rllayer-ffn=[5120,256,512], "
+            "rllayer-mlp=[5120,2048,1024], rllayer-attn=[81920,256,512]"
+        ),
+    )
+    parser.add_argument(
+        "--batch-dim",
+        type=int,
+        default=5120,
+        help="Batch dimension (default: 5120, matching MRS Region [11/0])",
+    )
+    parser.add_argument(
+        "--input-dim", type=int, default=4096, help="Input dimension (default: 4096)"
+    )
+    parser.add_argument(
+        "--hidden-dim",
+        type=int,
+        default=None,
+        help="Hidden dimension (default: input_dim * 2)",
+    )
+    parser.add_argument(
+        "--dtype",
+        type=str,
+        default="bf16",
+        choices=["bf16", "fp16", "fp32"],
+        help="Data type (default: bf16)",
+    )
+    parser.add_argument(
+        "--include-backward",
+        action="store_true",
+        help="Include backward pass in benchmark",
+    )
+    parser.add_argument(
+        "--with-rmsnorm",
+        action="store_true",
+        help="Include RMSNorm + residual (full MRS pattern)",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Print detailed diagnostics, kernel traces, and template selection info",
+    )
+    parser.add_argument(
+        "--only",
+        type=str,
+        default=None,
+        help="Run only configs whose name contains this substring (e.g. --only Blackwell)",
+    )
+    args = parser.parse_args()
+
+    # Enable TORCH_LOGS for template selection debugging when verbose
+    if args.verbose and not os.environ.get("TORCH_LOGS"):
+        os.environ["TORCH_LOGS"] = "autotuning"
+        logging.basicConfig(level=logging.DEBUG)
+
+    dtype_map = {"bf16": torch.bfloat16, "fp16": torch.float16, "fp32": torch.float32}
+    dtype = dtype_map[args.dtype]
+
+    # Resolve shape
+    if args.shape_preset:
+        batch_dim, input_dim, hidden_dim = SHAPE_PRESETS[args.shape_preset]
+        print(f"[INFO] Using shape preset '{args.shape_preset}'\n")
+    else:
+        batch_dim = args.batch_dim
+        input_dim = args.input_dim
+        hidden_dim = args.hidden_dim if args.hidden_dim else input_dim * 2
+
+    input_shape = (batch_dim, input_dim)
+    model_cls = SwiGLUFFNWithRMSNormResidual if args.with_rmsnorm else SwiGLUFFN
+
+    # Run diagnostics
+    diag = _print_diagnostics()
+
+    model_name = model_cls.__name__
+    print(f"{'=' * 72}")
+    print("SwiGLU FFN Epilogue Fusion Benchmark")
+    print(f"{'=' * 72}")
+    print(f"Model:      {model_name}")
+    print(
+        f"Shape:      [{batch_dim}, {input_dim}] -> hidden [{batch_dim}, {hidden_dim}]"
+    )
+    gemm_shapes = (
+        f"  GEMMs:      [{batch_dim},{input_dim}]@[{input_dim},{hidden_dim}] (gate+up), "
+        f"[{batch_dim},{hidden_dim}]@[{hidden_dim},{input_dim}] (down)"
+    )
+    print(gemm_shapes)
+    print(f"Dtype:      {args.dtype}")
+    print(f"Backward:   {args.include_backward}")
+    print(f"{'=' * 72}\n")
+
+    # Build config list: always include base configs, add Blackwell if detected
+    configs = dict(CONFIGS)
+    if diag["is_blackwell"] and diag["has_tensor_desc"]:
+        configs.update(BLACKWELL_CONFIGS)
+        print("[INFO] Blackwell detected — including Blackwell WS configs\n")
+    elif diag["is_blackwell"]:
+        print(
+            "[WARN] Blackwell GPU detected but tensor descriptor API unavailable.\n"
+            "       Blackwell WS configs will be SKIPPED.\n"
+            "       Check Triton version (need >= 3.3.2+fb).\n"
+        )
+    else:
+        print("[INFO] Non-Blackwell GPU — Blackwell WS configs skipped\n")
+
+    # Filter configs if --only is specified
+    if args.only:
+        filtered = {k: v for k, v in configs.items() if args.only.lower() in k.lower()}
+        if not filtered:
+            print(f"[ERROR] No configs match --only='{args.only}'")
+            print(f"Available configs: {list(configs.keys())}")
+            return
+        configs = filtered
+        print(f"[INFO] Running only: {list(configs.keys())}\n")
+
+    results = []
+    for config_name, config_dict in configs.items():
+        print(f"Benchmarking: {config_name}...")
+        try:
+            result = _benchmark_config(
+                model_cls=model_cls,
+                input_shape=input_shape,
+                hidden_dim=hidden_dim,
+                dtype=dtype,
+                config_dict=config_dict,
+                config_name=config_name,
+                include_backward=args.include_backward,
+                verbose=args.verbose,
+            )
+            results.append(result)
+            print(
+                f"  Kernel launches: {result['kernel_launches']:>3}  "
+                f"Latency: {result['latency_ms']:>8.3f} ms  "
+                f"Peak Mem: {result['peak_memory_mb']:>8.1f} MB"
+            )
+        except Exception as e:
+            print(f"  FAILED: {e}")
+            if args.verbose:
+                import traceback
+
+                traceback.print_exc()
+            results.append(
+                {
+                    "config": config_name,
+                    "kernel_launches": -1,
+                    "latency_ms": float("inf"),
+                    "peak_memory_mb": 0.0,
+                }
+            )
+
+    # Summary table
+    print(f"\n{'=' * 72}")
+    print(
+        f"{'Configuration':<35} {'Launches':>8} {'Latency(ms)':>12}"
+        f" {'Peak Mem(MB)':>13}"
+    )
+    print(f"{'-' * 72}")
+    for r in results:
+        launches = (
+            f"{r['kernel_launches']:>8}" if r["kernel_launches"] >= 0 else "  FAILED"
+        )
+        latency = (
+            f"{r['latency_ms']:>12.3f}"
+            if r["latency_ms"] != float("inf")
+            else "         N/A"
+        )
+        print(f"{r['config']:<35} {launches} {latency} {r['peak_memory_mb']:>13.1f}")
+    print(f"{'=' * 72}")
+
+    # Compute speedups relative to cuBLAS baseline
+    valid_results = [r for r in results if r["kernel_launches"] >= 0]
+    if len(valid_results) >= 2:
+        baseline = valid_results[0]
+        print(f"\nComparison vs {baseline['config']}:")
+        for r in valid_results[1:]:
+            speedup = baseline["latency_ms"] / r["latency_ms"]
+            kernel_diff = r["kernel_launches"] - baseline["kernel_launches"]
+            mem_saving = baseline["peak_memory_mb"] - r["peak_memory_mb"]
+            print(
+                f"  {r['config']}: "
+                f"{speedup:.2f}x latency, "
+                f"{kernel_diff:+d} kernel launches, "
+                f"{mem_saving:+.1f} MB memory"
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1857,6 +1857,24 @@ class triton:
     # If set to false, will never generate PDL code.
     enable_pdl = os.environ.get("TORCHINDUCTOR_ENABLE_PDL", "0") == "1"
 
+    # Enable Meta's warp specialization (autoWS) passes in the Triton compiler.
+    # Required for the Blackwell WS persistent TMA matmul template.
+    # When True, propagated to TRITON_USE_META_WS env var before Triton compilation.
+    # Can also be set via TRITON_USE_META_WS=1 env var directly.
+    use_meta_ws: bool = os.environ.get("TRITON_USE_META_WS", "0") == "1"
+
+    # Enable Meta's partition scheduling pass in the Triton compiler.
+    # Used together with use_meta_ws for Blackwell autoWS.
+    # When True, propagated to TRITON_USE_META_PARTITION env var before Triton compilation.
+    # Can also be set via TRITON_USE_META_PARTITION=1 env var directly.
+    use_meta_partition: bool = os.environ.get("TRITON_USE_META_PARTITION", "0") == "1"
+
+    # Force FLATTEN=False for Blackwell WS persistent TMA matmul templates.
+    # Default is True (OAI's default for WS). Setting to True may improve
+    # performance by allowing the WS pass to produce a better schedule
+    # without the flattening constraint.
+    blackwell_force_no_flatten: bool = False
+
     mix_order_reduction = (
         os.environ.get("TORCHINDUCTOR_MIX_ORDER_REDUCTION", "0" if is_fbcode() else "1")
         == "1"

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -397,6 +397,14 @@ class CachingAutotuner(KernelInterface):
             )
         log.debug("Triton cache dir: %s", os.environ["TRITON_CACHE_DIR"])
 
+        # NOTE: Do NOT propagate TRITON_USE_META_WS / TRITON_USE_META_PARTITION
+        # as global env vars here. These env vars affect ALL Triton compilations
+        # in the process, including hand-written kernels (e.g. hammer's attention
+        # kernels) that are not designed for Meta's WS and deadlock when the WS
+        # scheduling/partitioning passes are applied to them.
+        # Instead, these env vars are scoped per-kernel in _precompile_config()
+        # so only inductor-generated kernels see them.
+
         self.size_hints = size_hints
         self.is_mix_order_reduction = self.inductor_meta.get("RSPLIT_SIZE") is not None
         self.coordesc_tuner = CoordescTuner(
@@ -885,6 +893,24 @@ class CachingAutotuner(KernelInterface):
             "options": options,
         }
 
+        # Scope TRITON_USE_META_WS / TRITON_USE_META_PARTITION env vars to
+        # only this inductor kernel compilation. The Triton knobs system
+        # re-reads env vars on every access, so setting/unsetting here
+        # ensures only inductor-generated kernels see these flags.
+        # Hand-written kernels (e.g. hammer's attention) compile through
+        # Triton's own @triton.autotune, not through triton_heuristics,
+        # so they never see these env vars and avoid WS-related deadlocks.
+        from torch._inductor import config as inductor_config
+
+        _ws_env_backup = {}
+        if inductor_config.triton.use_meta_ws:
+            _ws_env_backup["TRITON_USE_META_WS"] = os.environ.get("TRITON_USE_META_WS")
+            os.environ["TRITON_USE_META_WS"] = "1"
+        if inductor_config.triton.use_meta_partition:
+            _ws_env_backup["TRITON_USE_META_PARTITION"] = os.environ.get(
+                "TRITON_USE_META_PARTITION"
+            )
+            os.environ["TRITON_USE_META_PARTITION"] = "1"
         try:
             binary = triton.compile(*compile_args, **compile_kwargs)
         except Exception:
@@ -895,6 +921,30 @@ class CachingAutotuner(KernelInterface):
                 compile_meta,
             )
             raise
+        finally:
+            # Restore env vars so non-inductor Triton compilations don't see them
+            for key, old_val in _ws_env_backup.items():
+                if old_val is None:
+                    os.environ.pop(key, None)
+                else:
+                    os.environ[key] = old_val
+            # Clear the Triton knobs cache for WS flags. The knobs.nvidia
+            # descriptor caches env var values in obj.__dict__ after first
+            # access. Restoring the env var alone is not enough -- the cached
+            # True value would leak to non-inductor Triton compilations
+            # (e.g. hammer's @triton.autotune kernels that compile lazily),
+            # causing Meta WS passes to be applied to kernels not designed
+            # for warp specialization (deadlocks / illegal memory access).
+            if _ws_env_backup:
+                try:
+                    from triton import knobs as _triton_knobs
+
+                    if "TRITON_USE_META_WS" in _ws_env_backup:
+                        _triton_knobs.nvidia.__dict__.pop("use_meta_ws", None)
+                    if "TRITON_USE_META_PARTITION" in _ws_env_backup:
+                        _triton_knobs.nvidia.__dict__.pop("use_meta_partition", None)
+                except (ImportError, AttributeError):
+                    pass
 
         # Simulate JIT Hook call
         if (

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -4451,7 +4451,10 @@ class AlgorithmSelectorCache(PersistentCache):
 
             if not use_pipelined_autotuning():
                 # pyrefly: ignore [missing-attribute]
-                executor.shutdown(wait=True)
+                # Use wait=False to avoid blocking forever if a compilation
+                # thread is hung (e.g. Meta WS scheduling pass infinite loop).
+                # The timed-out futures are already marked as failed above.
+                executor.shutdown(wait=False)
 
             # Build and return dict mapping choices to their precompilation times
             precompile_times: dict[ChoiceCaller, float] = {}

--- a/torch/_inductor/template_heuristics/triton.py
+++ b/torch/_inductor/template_heuristics/triton.py
@@ -2222,6 +2222,8 @@ class BlackwellTMATemplateConfigMixin(TMATemplateConfigMixin):
                 and not constraints_violated
             )
             flatten = template_kwargs.get("FLATTEN", True) and not constraints_violated
+            if config.triton.blackwell_force_no_flatten:
+                flatten = False
             yield {
                 **template_kwargs,
                 "NUM_SMS": get_num_sms(),


### PR DESCRIPTION
Summary:

## E2E RLLayer Benchmark Results (B200, ws-meta-mixed-noflatten)

| Config | Latency (s/iter) | Throughput (it/s) | vs baseline |
|--------|:-:|:-:|:-:|
| baseline | 0.08783 | 11.39 | 1.00x |
| fusion-aten-triton | 0.08623 | 11.60 | 1.02x |
| ws-meta-mixed-noflatten | 0.08724 | 11.46 | 1.01x |

## SwiGLU Fusion Benchmark Results (B200, forward only)

### Small Shape: rllayer-ffn [5120, 256] -> [5120, 512]

| Config | Kernel Launches | Latency (ms) | vs cuBLAS |
|--------|:-:|:-:|:-:|
| cuBLAS (ATEN) | 4 | 0.145 | 1.00x |
| Triton GEMM (no fusion) | 3 | 0.108 | 1.34x |
| Triton GEMM + epilogue fusion | 1 | 0.099 | 1.47x |
| Trunk autoWS (TRITON-only) | 0 | 0.097 | 1.49x |
| Trunk autoWS (ATEN+TRITON) | 0 | 0.137 | 1.06x |
| Meta autoWS (TRITON-only) | 0 | 0.101 | 1.44x |
| Meta autoWS (ATEN+TRITON) | 0 | 0.141 | 1.03x |

### Large Shape: MRS [5120, 4096] -> [5120, 8192]

| Config | Kernel Launches | Latency (ms) | vs cuBLAS |
|--------|:-:|:-:|:-:|
| cuBLAS (ATEN) | 4 | 1.014 | 1.00x |
| Triton GEMM (no fusion) | 3 | 1.399 | 0.72x |
| Triton GEMM + epilogue fusion | 2 | 1.361 | 0.74x |
| Trunk autoWS (TRITON-only) | 0 | 1.138 | 0.89x |
| Trunk autoWS (ATEN+TRITON) | 0 | 0.988 | 1.03x |
| Meta autoWS (TRITON-only) | 0 | 1.094 | 0.93x |
| Meta autoWS (ATEN+TRITON) | 0 | 0.993 | 1.02x |

### Key Findings

1. **Shape-dependent behavior**: At small shapes, Triton GEMM beats cuBLAS (1.34-1.49x). At large shapes, cuBLAS dominates (Triton is 0.72x).

2. **ATEN+TRITON autotuner limitation at small shapes**: ATEN+TRITON is worse (1.03-1.06x) than TRITON-only (1.44-1.49x). Root cause: the autotuner compares GEMM kernels in isolation -- it does not factor in the cost of the extra pointwise kernels (SiLU, mul, residual add) that cuBLAS would require. cuBLAS wins the per-GEMM race by a tiny margin, but the system loses epilogue fusion and ends up slower end-to-end. At large shapes this reverses -- cuBLAS truly is faster, so ATEN+TRITON correctly picks cuBLAS (1.02-1.03x).

3. **Epilogue fusion works**: Kernel launches drop from 3->1 (small) and 3->2 (large) with epilogue fusion, giving 9-3% speedup on top of Triton GEMM alone.

4. **autoWS helps close the gap at large shapes**: Trunk/Meta WS improve Triton-only from 0.72x->0.89-0.93x at large shapes, but still cannot beat cuBLAS.

5. **E2E uses ATEN+TRITON mixed backends**: ws-meta-mixed-noflatten achieves 11.46 it/s using ATEN+TRITON, where the autotuner picks the best backend per GEMM across the mix of small and large shapes in the model.

## Critical Fixes for Blackwell WS on RLLayer

Root cause: Inductor compilation threads temporarily set TRITON_USE_META_WS=1 in the process environment via _precompile_config(). With executor.shutdown(wait=False), these threads can still be running when hammer kernels compile lazily via triton.autotune, creating a race where hammer sees the WS env var.

### Fix 1 (primary) -- hammer/ops/triton/utils.py
TritonAutotuner.run() now defensively clears TRITON_USE_META_WS / TRITON_USE_META_PARTITION from both os.environ and the Triton knobs cache before compiling any hammer kernel, restoring them in finally.

### Fix 2 (defense-in-depth) -- triton_heuristics.py
_precompile_config() finally block now clears the Triton knobs cache alongside restoring env vars, preventing stale cached values from leaking to non-inductor compilations.

### Fix 3 -- select_algorithm.py
executor.shutdown(wait=False) prevents blocking forever if a compilation thread is hung (e.g. Meta WS scheduling pass infinite loop).

### New Inductor config knobs -- config.py
- triton.use_meta_ws: Propagated to TRITON_USE_META_WS env var per-kernel (scoped in _precompile_config)
- triton.use_meta_partition: Propagated to TRITON_USE_META_PARTITION env var per-kernel
- triton.blackwell_force_no_flatten: Forces FLATTEN=False for Blackwell WS persistent TMA matmul templates

Test Plan:
### 1. SwiGLU standalone benchmark - default MRS shape (B200)
```bash
CUDA_VISIBLE_DEVICES=0 buck2 run fbcode//mode/opt \
  -c fbcode.enable_gpu_sections=true \
  -c fbcode.platform010_cuda_version=12.8 \
  -c fbcode.nvcc_arch=b200a \
  fbcode//caffe2/test/inductor:run_benchmark_swiglu_fusion
```
Result: cuBLAS 4 launches 1.015ms, Triton+fusion 4 launches 1.399ms (0.73x), Blackwell WS (ATEN+TRITON) 2 launches 0.988ms (1.03x).

### 2. SwiGLU benchmark - rllayer-ffn shape preset (B200)
```bash
CUDA_VISIBLE_DEVICES=0 buck2 run fbcode//mode/opt \
  -c fbcode.enable_gpu_sections=true \
  -c fbcode.platform010_cuda_version=12.8 \
  -c fbcode.nvcc_arch=b200a \
  fbcode//caffe2/test/inductor:run_benchmark_swiglu_fusion \
  -- --shape-preset rllayer-ffn --verbose
```
Result: cuBLAS 4 launches 0.142ms, Triton+epilogue fusion 2 launches 0.113ms (1.26x), Persistent TMA 2 launches 0.115ms (1.23x), Blackwell WS (ATEN+TRITON) 3 launches 0.134ms (1.06x).

### 3. Blackwell WS via Inductor config (no env vars)
```bash
CUDA_VISIBLE_DEVICES=0 buck2 run fbcode//mode/opt \
  -c fbcode.enable_gpu_sections=true \
  -c fbcode.platform010_cuda_version=12.8 \
  -c fbcode.nvcc_arch=b200a \
  fbcode//caffe2/test/inductor:run_benchmark_swiglu_fusion \
  -- --shape-preset rllayer-ffn --only "Blackwell WS (ATEN"
```
Verified: `triton.use_meta_ws` and `triton.use_meta_partition` propagated from Inductor config to `os.environ` via `setdefault()`. cuBLAS-only config correctly shows `TRITON_USE_META_WS=<not set>`.

### 4. RLLayer E2E benchmark - all modes (B200)
```bash
CUDA_VISIBLE_DEVICES=0 TORCHINDUCTOR_FORCE_DISABLE_CACHES=1 \
  ~/fbsource/fbcode/triton/scripts/denoise.sh \
  buck2 run fbcode//mode/opt \
  -c fbcode.enable_gpu_sections=true \
  -c fbcode.platform010_cuda_version=12.8 \
  -c fbcode.nvcc_arch=b200a \
  fbcode//minimal_viable_ai/models/ig_ranking/lsr/nano_rl/benchmarks:rllayer_benchmark \
  -- --mode <mode_name>
```
Where `<mode_name>` is one of: `baseline`, `fusion-aten-triton`, `ws-trunk`, `ws-trunk-mixed`, `ws-meta`, `ws-meta-noflatten`, `ws-meta-mixed-noflatten`.

All 7 modes pass. See E2E results table in Summary.

Differential Revision: D97188817




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo