### PR TITLE
[dcp][oss] Fix Metadata.storage_meta regression from dataclasses.replace() (#178001)

### DIFF
--- a/torch/distributed/checkpoint/filesystem.py
+++ b/torch/distributed/checkpoint/filesystem.py
@@ -756,7 +756,7 @@ class _FileSystemWriter(StorageWriter):
             return fut
 
     def finish(self, metadata: Metadata, results: list[list[WriteResult]]) -> None:
-        metadata = dataclasses.replace(metadata, version=CURRENT_DCP_VERSION)
+        metadata.version = CURRENT_DCP_VERSION
 
         storage_md = {}
         for wr_list in results:


### PR DESCRIPTION
Summary:

`_FileSystemWriter.finish()` used `dataclasses.replace(metadata, version=CURRENT_DCP_VERSION)` which creates a new `Metadata` object and rebinds the local variable. Since `finish()` returns `None`, the caller (`_save_state_dict`) still holds the original object, which never gets `storage_meta`, `storage_data`, or `version` updated. The on-disk metadata is correct (the new copy is pickled), but the in-memory `Metadata` returned by `dcp.save()` has `None` for these fields.

Fix by mutating the passed-in metadata in-place (`metadata.version = CURRENT_DCP_VERSION`) instead of creating a new copy. `Metadata` is not a frozen dataclass, so in-place mutation is safe and consistent with the subsequent `storage_data` and `storage_meta` assignments.

Fixes https://github.com/pytorch/pytorch/issues/177887

Test Plan:
```
import tempfile
import torch
import torch.distributed.checkpoint as dcp
from torch.distributed.checkpoint._fsspec_filesystem import FsspecWriter

state_dict = {"weight": torch.randn(4, 4)}

with tempfile.TemporaryDirectory() as tmpdir:
    writer = FsspecWriter(tmpdir)
    meta = dcp.save(state_dict, storage_writer=writer, no_dist=True)
    assert meta.storage_meta is not None
    assert meta.storage_data is not None
    assert meta.version is not None
    print(f"storage_meta: {meta.storage_meta}")
    print(f"version: {meta.version}")
```

Before the fix, `meta.storage_meta` is `None`. After the fix, it contains the expected `StorageMeta` with `checkpoint_id` and `save_id`.

Differential Revision: D97535692
