### PR TITLE
[Triton][cuBLAS] Fix `triton_main_loop_scaled_mm` template to use correct scale recipe

### DIFF
--- a/torch/_inductor/kernel/templates/triton_main_loop_scaled_mm.py.jinja
+++ b/torch/_inductor/kernel/templates/triton_main_loop_scaled_mm.py.jinja
@@ -80,7 +80,7 @@
             )
             {%- endif %}
 
-            {%- if SCALE_RECIPE_A == 5 %}  # ScalingType.Blockwise128x128
+            {%- if SCALE_RECIPE_B == 5 %}  # ScalingType.Blockwise128x128
             scale_b_block = blockwise128x128_scaling(
                 pid_n,
                 B_inverse_scale,


### PR DESCRIPTION
[mostly debugged by Claude]

This one was a fun one, as originally it seemed to be caused by the cuBLAS unified workspace PR https://github.com/pytorch/pytorch/pull/175879 that finally enabled cuBLAS workspace handling.

Claude's summary: `The wrong scaling function indexes the B scale tensor as if it has per-row scales (128 rows × k_blocks columns), but the actual tensor is only 32×32 (one scale per 128×128 block). This produces an out-of-bounds read of ~12 KiB past the 4 KiB scale tensor.`

However, the underlying issue seemed to be that the triton kernel was reading invalid memory, and without unified workspaces the eagerly allocated workspace would have the right garbage data for the generated kernel. Otherwise the test fails with 
```
======================================================================
FAIL: test_main_loop_scaling_shape2_use_fast_accum_False_scaling_block_sizes0_cuda (__main__.TestFP8LoweringCUDA.test_main_loop_scaling_shape2_use_fast_accum_False_scaling_block_sizes0_cuda)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/pytorch/pytorch/torch/testing/_internal/common_utils.py", line 3362, in wrapper
    method(*args, **kwargs)
  File "/opt/pytorch/pytorch/torch/testing/_internal/common_utils.py", line 3362, in wrapper
    method(*args, **kwargs)
  File "/opt/pytorch/pytorch/torch/testing/_internal/common_device_type.py", line 430, in instantiated_test
    result = test(self, **param_kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/pytorch/pytorch/torch/testing/_internal/common_device_type.py", line 1458, in only_fn
    return fn(slf, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/pytorch/pytorch/test/inductor/test_fp8.py", line 989, in test_main_loop_scaling
    torch.testing.assert_close(y_eager, y_compiled, rtol=1e-2, atol=0.05)
  File "/opt/pytorch/pytorch/torch/testing/_comparison.py", line 1598, in assert_close
    raise error_metas[0].to_error(msg)
AssertionError: Tensor-likes are not close!

Mismatched elements: 8645814 / 134217728 (6.4%)
Greatest absolute difference: 4.806931076065446e+33 at index (7757, 296) (up to 0.05 allowed)
Greatest relative difference: 1.0 at index (0, 296) (up to 0.01 allowed)
```
We can control the behavior of different cases via `TORCH_CUBLASLT_UNIFIED_WORKSPACE` and `CUBLASLT_WORKSPACE_SIZE` which paints a clear picture:
```
  ┌───────────────────┬────────────────────┬─────────────────────────────────┬───────────┬───────────────┐
  │ UNIFIED_WORKSPACE │   WORKSPACE_SIZE   │      Adjacent 1 MiB alloc?      │ OOB reads │    Result     │
  ├───────────────────┼────────────────────┼─────────────────────────────────┼───────────┼───────────────┤
  │ default (unified) │ default            │ No (reuses cuBLAS ws elsewhere) │ Garbage   │ FAIL          │
  ├───────────────────┼────────────────────┼─────────────────────────────────┼───────────┼───────────────┤
  │ 0 (non-unified)   │ default (1024 KiB) │ Yes                             │ Zeros     │ PASS (masked) │
  ├───────────────────┼────────────────────┼─────────────────────────────────┼───────────┼───────────────┤
  │ 0 (non-unified)   │ 0                  │ No (zero-size alloc)            │ Garbage   │ FAIL          │
  └───────────────────┴────────────────────┴─────────────────────────────────┴───────────┴───────────────┘
  ```
  
`INDUCTOR_TEST_DISABLE_FRESH_CACHE=1` is another way to mask the failure regardless of cuBLAS workspace settings
  

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos