### PR TITLE
[CI] Allow configuring pytest reruns via PYTORCH_NUM_PYTEST_RERUNS env var

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -64,9 +64,6 @@ NUM_TEST_SHARDS="${NUM_TEST_SHARDS:=1}"
 # enable debug asserts in serialization
 export TORCH_SERIALIZATION_DEBUG=1
 
-# Temporarily set to 0 to verify PYTORCH_NUM_PYTEST_RERUNS env var works (will be reverted)
-export PYTORCH_NUM_PYTEST_RERUNS=0
-
 export VALGRIND=ON
 # export TORCH_INDUCTOR_INSTALL_GXX=ON
 if [[ "$BUILD_ENVIRONMENT" == *clang9* || "$BUILD_ENVIRONMENT" == *xpu* ]]; then

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -64,6 +64,9 @@ NUM_TEST_SHARDS="${NUM_TEST_SHARDS:=1}"
 # enable debug asserts in serialization
 export TORCH_SERIALIZATION_DEBUG=1
 
+# Temporarily set to 0 to verify PYTORCH_NUM_PYTEST_RERUNS env var works (will be reverted)
+export PYTORCH_NUM_PYTEST_RERUNS=0
+
 export VALGRIND=ON
 # export TORCH_INDUCTOR_INSTALL_GXX=ON
 if [[ "$BUILD_ENVIRONMENT" == *clang9* || "$BUILD_ENVIRONMENT" == *xpu* ]]; then

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -104,6 +104,7 @@ HAVE_TEST_SELECTION_TOOLS = True
 TEST_CONFIG = os.getenv("TEST_CONFIG", "")
 BUILD_ENVIRONMENT = os.getenv("BUILD_ENVIRONMENT", "")
 RERUN_DISABLED_TESTS = os.getenv("PYTORCH_TEST_RERUN_DISABLED_TESTS", "0") == "1"
+NUM_PYTEST_RERUNS = int(os.getenv("PYTORCH_NUM_PYTEST_RERUNS", "2"))
 DISTRIBUTED_TEST_PREFIX = "distributed"
 INDUCTOR_TEST_PREFIX = "inductor"
 IS_SLOW = "slow" in TEST_CONFIG or "slow" in BUILD_ENVIRONMENT
@@ -1266,9 +1267,9 @@ def get_pytest_args(options, is_cpp_test=False, is_distributed_test=False):
         # flakiness status. Default to 50 re-runs
         rerun_options = ["--flake-finder", f"--flake-runs={count}"]
     else:
-        # When under the normal mode, retry a failed test 2 more times. -x means stop at the first
-        # failure
-        rerun_options = ["-x", "--reruns=2"]
+        # When under the normal mode, retry a failed test NUM_PYTEST_RERUNS more times.
+        # -x means stop at the first failure. Set PYTORCH_NUM_PYTEST_RERUNS=0 to disable.
+        rerun_options = ["-x", f"--reruns={NUM_PYTEST_RERUNS}"]
 
     pytest_args = [
         "-vv",


### PR DESCRIPTION
The number of pytest reruns for failed tests in run_test.py is currently hardcoded to 2, making it impossible for downstream consumers (e.g. ROCm CI) to adjust or disable reruns without patching the file. This adds a PYTORCH_NUM_PYTEST_RERUNS environment variable that defaults to 2 (preserving existing behavior) and can be set to 0 to disable reruns entirely.

### Verification

Temporarily set `PYTORCH_NUM_PYTEST_RERUNS=0` in `test.sh` to confirm the env var takes effect. CI log from [linux-jammy-rocm-py3.10 / test (default, 1, 6)](https://github.com/pytorch/pytorch/actions/runs/23419053468/job/68122075702) shows:

```
+ export PYTORCH_NUM_PYTEST_RERUNS=0
+ PYTORCH_NUM_PYTEST_RERUNS=0

Executing ['.../python', '-bb', 'test_cuda.py', ..., '-x', '--reruns=0', ...] 
Executing ['.../python', '-bb', 'test_ops.py', ..., '-x', '--reruns=0', ...]
Executing ['.../python', '-bb', 'inductor/test_torchinductor.py', ..., '-x', '--reruns=0', ...]
```

The temporary `test.sh` change has been reverted.
