### PR TITLE
[dynamo] [recompile] make dynamo not guard on typing.cast

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -8753,6 +8753,98 @@ not ___dict_contains('cccccccc', G['sys'].modules)""",
 
         self.assertTrue(same(ref, res))
 
+    def test_cast_with_different_module_types(self):
+        # typing.cast works correctly when used in a mixin pattern with
+        # different module types, producing correct results without
+        # graph breaks.
+        from typing import cast
+
+        class Mixin:
+            def get_self_as_module(self):
+                return cast(torch.nn.Module, self)
+
+        class ModuleA(Mixin, torch.nn.Module):
+            def forward(self, x):
+                self.get_self_as_module()
+                return x + 1
+
+        class ModuleB(Mixin, torch.nn.Module):
+            def forward(self, x):
+                self.get_self_as_module()
+                return x + 2
+
+        cnt = torch._dynamo.testing.CompileCounter()
+
+        @torch.compile(backend=cnt)
+        def fn(mod, x):
+            mod.get_self_as_module()
+            return x + 1
+
+        x = torch.randn(4)
+        ref_a = fn.__wrapped__(ModuleA(), x)
+        ref_b = fn.__wrapped__(ModuleB(), x)
+        res_a = fn(ModuleA(), x)
+        res_b = fn(ModuleB(), x)
+
+        self.assertEqual(ref_a, res_a)
+        self.assertEqual(ref_b, res_b)
+        self.assertEqual(cnt.frame_count, 2)
+
+    def test_cast_fullgraph_with_non_tensor(self):
+        # Verify typing.cast works with non-tensor values under fullgraph=True
+        from typing import cast
+
+        def fn(x):
+            val = cast(int, x.shape[0])
+            return x + val
+
+        opt_fn = torch.compile(backend="eager", fullgraph=True)(fn)
+
+        ref = fn(torch.ones(3, 4))
+        res = opt_fn(torch.ones(3, 4))
+
+        self.assertTrue(same(ref, res))
+
+    def test_cast_no_recompile_after_graph_break(self):
+        # In FSDP, cast(nn.Module, self) can be called after a
+        # graph break. Without the polyfill + skip_code fix, PEP 523 compiles
+        # typing.cast as a standalone frame with TYPE_MATCH guards on val,
+        # causing recompilation when different module types pass through.
+        # https://github.com/pytorch/pytorch/blob/0feb90404fbeb9b1594ae194f8fd47bbe7f5f245/torch/distributed/fsdp/_fully_shard/_fully_shard.py#L376
+        from typing import cast
+
+        from torch._dynamo.utils import counters
+
+        counters.clear()
+
+        class Base(torch.nn.Module):
+            def get_state(self):
+                torch._dynamo.decorators.graph_break()
+                return cast(torch.nn.Module, self)
+
+        class ModuleA(Base):
+            pass
+
+        class ModuleB(Base):
+            pass
+
+        cnt = torch._dynamo.testing.CompileCounter()
+        a, b = ModuleA(), ModuleB()
+
+        @torch.compile(backend=cnt)
+        def fn(mod, x):
+            mod.get_state()
+            return x + 1
+
+        x = torch.randn(4)
+        fn(a, x)
+        fn(b, x)
+        self.assertEqual(cnt.frame_count, 1)
+        # 5 frames: fn (x2), get_state before graph_break (x2),
+        # get_state resume after graph_break (x1, no recompile).
+        # Without skip_code, typing.cast would add 2 more frames (7 total).
+        self.assertEqual(counters["frames"]["total"], 5)
+
     def test_T_tensor_attribute(self):
         def fn(x, y):
             a = x.T

--- a/test/dynamo/test_structured_trace.py
+++ b/test/dynamo/test_structured_trace.py
@@ -537,20 +537,18 @@ class StructuredTraceTest(TestCase):
 {"artifact": {"name": "torch_dynamo_resume_in_example_training_fn_at_45_MODIFIED_BYTECODE", "encoding": "string"}, "frame_id": 2, "frame_compile_id": 0, "attempt": 1, "has_payload": "HASH"}
 {"dynamo_cpp_guards_str": {}, "frame_id": 2, "frame_compile_id": 0, "attempt": 1, "has_payload": "HASH"}
 {"compilation_metrics": "METRICS", "frame_id": 2, "frame_compile_id": 0, "attempt": 1}
-{"dynamo_start": {"stack": "STACK"}, "frame_id": 3, "frame_compile_id": 0, "attempt": 0}
-{"compilation_metrics": "METRICS", "frame_id": 3, "frame_compile_id": 0, "attempt": 0}
 {"artifact": {"name": "fx_graph_runnable", "encoding": "string"}, "frame_id": 2, "frame_compile_id": 0, "attempt": 1, "has_payload": "HASH"}
 {"artifact": {"name": "before_post_grad_graph", "encoding": "string"}, "frame_id": 2, "frame_compile_id": 0, "attempt": 1, "has_payload": "HASH"}
 {"artifact": {"name": "inductor_post_grad_graph", "encoding": "string"}, "frame_id": 2, "frame_compile_id": 0, "attempt": 1, "has_payload": "HASH"}
 {"inductor_output_code": {"filename": "FILENAME", "file_path": "FILENAME"}, "frame_id": 2, "frame_compile_id": 0, "attempt": 1, "has_payload": "HASH"}
 {"artifact": {"name": "fx_graph_cache_miss", "encoding": "json"}, "frame_id": 2, "frame_compile_id": 0, "attempt": 1, "has_payload": "HASH"}
 {"bwd_compilation_metrics": "METRICS", "frame_id": 2, "frame_compile_id": 0, "attempt": 1}
-{"dynamo_start": {"stack": "STACK"}, "frame_id": 4, "frame_compile_id": 0, "attempt": 0}
-{"artifact": {"name": "torch_dynamo_resume_in_example_training_fn_at_47_ORIGINAL_BYTECODE", "encoding": "string"}, "frame_id": 4, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
-{"describe_storage": {"id": 0, "describer_id": "ID", "size": 4000000}, "frame_id": 4, "frame_compile_id": 0, "attempt": 0}
-{"describe_tensor": {"id": 0, "ndim": 2, "dtype": "torch.float32", "device": "device(type='cpu')", "size": [1000, 1000], "dynamo_hint_overrides": {}, "requires_grad": true, "stride": [1000, 1], "storage": 0, "view_func": "VIEW_FUNC", "describer_id": "ID"}, "frame_id": 4, "frame_compile_id": 0, "attempt": 0}
-{"describe_source": {"describer_id": "ID", "id": 0, "source": "L['output']"}, "frame_id": 4, "frame_compile_id": 0, "attempt": 0}
-{"compilation_metrics": "METRICS", "frame_id": 4, "frame_compile_id": 0, "attempt": 0}
+{"dynamo_start": {"stack": "STACK"}, "frame_id": 3, "frame_compile_id": 0, "attempt": 0}
+{"artifact": {"name": "torch_dynamo_resume_in_example_training_fn_at_47_ORIGINAL_BYTECODE", "encoding": "string"}, "frame_id": 3, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
+{"describe_storage": {"id": 0, "describer_id": "ID", "size": 4000000}, "frame_id": 3, "frame_compile_id": 0, "attempt": 0}
+{"describe_tensor": {"id": 0, "ndim": 2, "dtype": "torch.float32", "device": "device(type='cpu')", "size": [1000, 1000], "dynamo_hint_overrides": {}, "requires_grad": true, "stride": [1000, 1], "storage": 0, "view_func": "VIEW_FUNC", "describer_id": "ID"}, "frame_id": 3, "frame_compile_id": 0, "attempt": 0}
+{"describe_source": {"describer_id": "ID", "id": 0, "source": "L['output']"}, "frame_id": 3, "frame_compile_id": 0, "attempt": 0}
+{"compilation_metrics": "METRICS", "frame_id": 3, "frame_compile_id": 0, "attempt": 0}
 """,  # noqa: B950
         )
 
@@ -1047,7 +1045,7 @@ def forward(self, x_1: "f32[2][1]cpu"):
                 '"attempt": 0, "has_payload": "HASH"}'
             ),
             (
-                '{"chromium_event": {}, "compiled_autograd_id": 0, "frame_id": 2, "frame_compile_id": 0, '
+                '{"chromium_event": {}, "compiled_autograd_id": 0, "frame_id": 1, "frame_compile_id": 0, '
                 '"attempt": 0, "has_payload": "HASH"}'
             ),
         ]
@@ -1089,13 +1087,13 @@ def forward(self, x_1: "f32[2][1]cpu"):
             '{"dynamo_start": {"stack": "STACK"}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0}',
             '{"dynamo_start": {"stack": "STACK"}, "frame_id": 1, "frame_compile_id": 0, "attempt": 0}',
             '{"dynamo_start": {"stack": "STACK"}, "frame_id": 2, "frame_compile_id": 0, "attempt": 0}',
+            '{"dynamo_start": {"stack": "STACK"}, "compiled_autograd_id": 0, "frame_id": 3, "frame_compile_id": 0, "attempt": 0}',
             '{"dynamo_start": {"stack": "STACK"}, "compiled_autograd_id": 0, "frame_id": 4, "frame_compile_id": 0, "attempt": 0}',
             '{"dynamo_start": {"stack": "STACK"}, "compiled_autograd_id": 0, "frame_id": 5, "frame_compile_id": 0, "attempt": 0}',
             '{"dynamo_start": {"stack": "STACK"}, "compiled_autograd_id": 0, "frame_id": 6, "frame_compile_id": 0, "attempt": 0}',
             '{"dynamo_start": {"stack": "STACK"}, "compiled_autograd_id": 0, "frame_id": 7, "frame_compile_id": 0, "attempt": 0}',
             '{"dynamo_start": {"stack": "STACK"}, "compiled_autograd_id": 0, "frame_id": 8, "frame_compile_id": 0, "attempt": 0}',
-            '{"dynamo_start": {"stack": "STACK"}, "compiled_autograd_id": 0, "frame_id": 9, "frame_compile_id": 0, "attempt": 0}',
-            '{"dynamo_start": {"stack": "STACK"}, "compiled_autograd_id": 1, "frame_id": 12, "frame_compile_id": 1, "attempt": 0}',
+            '{"dynamo_start": {"stack": "STACK"}, "compiled_autograd_id": 1, "frame_id": 10, "frame_compile_id": 1, "attempt": 0}',
         ]
         logs = self.buffer.getvalue()
         self.assertTrue(all(event in logs for event in expected))

--- a/torch/_dynamo/polyfills/builtins.py
+++ b/torch/_dynamo/polyfills/builtins.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import builtins
 import functools
 import operator
+import typing
 from collections.abc import Callable
 from typing import TYPE_CHECKING, TypeVar
 
@@ -20,6 +21,7 @@ if TYPE_CHECKING:
 __all__ = [
     "all",
     "any",
+    "cast",
     "enumerate",
     "sum",
 ]
@@ -120,3 +122,8 @@ def iter_(fn_or_iterable, sentinel=_sentinel_missing, /):  # type: ignore[no-unt
             raise TypeError("iter(v, w): v must be a callable")
 
         return _CallableIterator(fn, sentinel)
+
+
+@substitute_in_graph(typing.cast, can_constant_fold_through=True)
+def cast(typ: type, val: _T) -> _T:  # type: ignore[type-var]
+    return val

--- a/torch/_dynamo/trace_rules.py
+++ b/torch/_dynamo/trace_rules.py
@@ -34,11 +34,12 @@ import random
 import re
 import sys
 import types
+import typing
 import unittest
 from collections import defaultdict
 from collections.abc import Callable, Iterator
 from pathlib import Path
-from typing import Any, cast
+from typing import Any
 
 import torch
 import torch._inductor.test_operators
@@ -3180,11 +3181,6 @@ def _builtin_function_ids() -> dict[int, str]:
             if not k.startswith("_") and callable(v)
         }
     )
-    rv.update(
-        {
-            id(cast): "typing.cast",
-        }
-    )
     return rv
 
 
@@ -3904,6 +3900,12 @@ def check_verbose(
         filename = getfile(obj)
         assert filename is not None
         fi = FunctionInfo(obj, None, filename, None)
+
+    # typing.cast is a polyfilled no-op, but unlike C builtins it has a code
+    # object that PEP 523 can intercept as a standalone frame after a graph
+    # break. Skip it at the top level to avoid installing unnecessary guards.
+    if fi.code is not None and fi.code is typing.cast.__code__:
+        return SkipResult(True, "typing.cast is a no-op, skip at top level")
 
     # Consulte the central trace rules defined in torch._dynamo.trace_rules.
     reasons: set[str] = set()


### PR DESCRIPTION
Summary: make dynamo not guard on `typing.cast`, it's purely for type hinting. 


  typing.cast is a no-op identity function used purely for type checking. In production FSDP workloads, cast(nn.Module, self) is called after a graph break (e.g., in _get_fsdp_state). Without this fix, PEP 523 compiles typing.cast as a standalone frame with TYPE_MATCH guards on val, causing unnecessary recompilations when different module types (e.g. FSDPSimpleWHENLayer, FSDPSeqSummarizationLayer) pass through the same cast call.

It's mainly to make the recompile cleaner and confirm what's happening with the FSDP recompile. It doesn't save too much recompile each. Each recompile is `51ms`.

  The fix has three parts:

  1. Register typing.cast as a polyfill (polyfills/builtins.py): A substitute_in_graph polyfill replaces cast with an identity function during tracing. Adding "cast" to `__all__` ensures the loader removes it from _builtin_function_ids, so it's dispatched as PolyfilledFunctionVariable instead of BuiltinVariable (which would graph-break due to having no handler).
  2. Skip typing.cast at the PEP 523 level (polyfills/loader.py): Unlike C builtins (all, any, etc.), typing.cast is a Python function with a code object that PEP 523 can intercept as a standalone frame after a graph break. skip_code(typing.cast.__code__) tells the frame evaluator to skip it entirely.
  3. Remove manual registration (trace_rules.py): The id(cast
  

Before change:

```
V0320 14:24:30.578000 3304883 /data/users/shangdiy/pytorch/torch/_dynamo/guards.py:5120] [0/1] [__recompiles] Recompiling function fn in /data/users/shangdiy/pytorch/test/dynamo/test_misc.py:8811
V0320 14:24:30.578000 3304883 /data/users/shangdiy/pytorch/torch/_dynamo/guards.py:5120] [0/1] [__recompiles]     triggered by the following guard failure(s):
V0320 14:24:30.578000 3304883 /data/users/shangdiy/pytorch/torch/_dynamo/guards.py:5120] [0/1] [__recompiles]     - 0/0: ___check_type_id(mod, 213480752), type=<class '__main__.MiscTests.test_cast_no_recompile_after_graph_break.<locals>.ModuleA'>  # mod.get_state()  # test/dynamo/test_misc.py:8813 in fn (HINT: type MiscTests.test_cast_no_recompile_after_graph_break.<locals>.ModuleA)
V0320 14:24:30.578000 3304883 /data/users/shangdiy/pytorch/torch/_dynamo/guards.py:5120] [0/1] [__recompiles]     - User stack trace:
V0320 14:24:30.578000 3304883 /data/users/shangdiy/pytorch/torch/_dynamo/guards.py:5120] [0/1] [__recompiles]     -   File "/data/users/shangdiy/pytorch/test/dynamo/test_misc.py", line 8813, in fn
V0320 14:24:30.578000 3304883 /data/users/shangdiy/pytorch/torch/_dynamo/guards.py:5120] [0/1] [__recompiles]     -     mod.get_state()
V0320 14:24:30.607000 3304883 /data/users/shangdiy/pytorch/torch/_dynamo/guards.py:5120] [3/1] [__recompiles] Recompiling function cast in /home/shangdiy/.conda/envs/pytorch-3.12/lib/python3.12/typing.py:2187
V0320 14:24:30.607000 3304883 /data/users/shangdiy/pytorch/torch/_dynamo/guards.py:5120] [3/1] [__recompiles]     triggered by the following guard failure(s):
V0320 14:24:30.607000 3304883 /data/users/shangdiy/pytorch/torch/_dynamo/guards.py:5120] [3/1] [__recompiles]     - 3/0: ___check_type_id(val, 213480752), type=<class '__main__.MiscTests.test_cast_no_recompile_after_graph_break.<locals>.ModuleA'>  # return val  # ome/shangdiy/.conda/envs/pytorch-3.12/lib/python3.12/typing.py:2195 in cast (HINT: type MiscTests.test_cast_no_recompile_after_graph_break.<locals>.ModuleA)
V0320 14:24:30.607000 3304883 /data/users/shangdiy/pytorch/torch/_dynamo/guards.py:5120] [3/1] [__recompiles]     - User stack trace:
V0320 14:24:30.607000 3304883 /data/users/shangdiy/pytorch/torch/_dynamo/guards.py:5120] [3/1] [__recompiles]     -   File "/home/shangdiy/.conda/envs/pytorch-3.12/lib/python3.12/typing.py", line 2195, in cast
V0320 14:24:30.607000 3304883 /data/users/shangdiy/pytorch/torch/_dynamo/guards.py:5120] [3/1] [__recompiles]     -     return val
```

After change:

```
V0320 14:24:09.597000 3261121 /data/users/shangdiy/pytorch/torch/_dynamo/guards.py:5120] [0/1] [__recompiles] Recompiling function fn in /data/users/shangdiy/pytorch/test/dynamo/test_misc.py:8811
V0320 14:24:09.597000 3261121 /data/users/shangdiy/pytorch/torch/_dynamo/guards.py:5120] [0/1] [__recompiles]     triggered by the following guard failure(s):
V0320 14:24:09.597000 3261121 /data/users/shangdiy/pytorch/torch/_dynamo/guards.py:5120] [0/1] [__recompiles]     - 0/0: ___check_type_id(mod, 213619408), type=<class '__main__.MiscTests.test_cast_no_recompile_after_graph_break.<locals>.ModuleA'>  # mod.get_state()  # test/dynamo/test_misc.py:8813 in fn (HINT: type MiscTests.test_cast_no_recompile_after_graph_break.<locals>.ModuleA)
V0320 14:24:09.597000 3261121 /data/users/shangdiy/pytorch/torch/_dynamo/guards.py:5120] [0/1] [__recompiles]     - User stack trace:
V0320 14:24:09.597000 3261121 /data/users/shangdiy/pytorch/torch/_dynamo/guards.py:5120] [0/1] [__recompiles]     -   File "/data/users/shangdiy/pytorch/test/dynamo/test_misc.py", line 8813, in fn
V0320 14:24:09.597000 3261121 /data/users/shangdiy/pytorch/torch/_dynamo/guards.py:5120] [0/1] [__recompiles]     -     mod.get_state()
```

Test Plan:
```
python test/dynamo/test_misc.py -k test_cast_no_recompile_after_graph_break
```

D97407484

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @mlazos