### PR TITLE
add missing to() operator which is called in benchmark (#178014)

### DIFF
--- a/test/test_sparse_semi_structured.py
+++ b/test/test_sparse_semi_structured.py
@@ -1322,6 +1322,75 @@ class TestSparseSemiStructuredCUSPARSELT(TestCase):
         self.assertNotEqual(A_sparse.packed.data_ptr, A_clone.packed.data_ptr)
         self.assertEqual(A_sparse.packed, A_clone.packed)
 
+    @inference_dtypes
+    def test_semi_sparse_to_device_cpu(self, dtype):
+        """Test .to('cpu') converts sparse semi-structured tensor to dense on CPU."""
+        A = rand_sparse_semi_structured_mask(128, 128, dtype=dtype).cuda()
+        A_sparse = to_sparse_semi_structured(A)
+        A_dense = A_sparse.to_dense()
+
+        result = A_sparse.to("cpu")
+        self.assertEqual(result.device.type, "cpu")
+        self.assertFalse(isinstance(result, SparseSemiStructuredTensor))
+        torch.testing.assert_close(result, A_dense.cpu(), rtol=1e-3, atol=1e-3)
+
+    @inference_dtypes
+    def test_semi_sparse_to_device_cuda(self, dtype):
+        """Test .to('cuda') / .to(device) raises NotImplementedError."""
+        A = rand_sparse_semi_structured_mask(128, 128, dtype=dtype).cuda()
+        A_sparse = to_sparse_semi_structured(A)
+
+        with self.assertRaises(NotImplementedError):
+            A_sparse.to(A_sparse.device)
+
+    @dtypes(torch.float16, torch.bfloat16)
+    def test_semi_sparse_to_dtype(self, dtype):
+        """Test .to(dtype) raises NotImplementedError (only to('cpu') is supported)."""
+        A = rand_sparse_semi_structured_mask(128, 128, dtype=dtype).cuda()
+        A_sparse = to_sparse_semi_structured(A)
+
+        with self.assertRaises(NotImplementedError):
+            A_sparse.to(torch.float32)
+
+    @dtypes(torch.float16, torch.bfloat16)
+    def test_semi_sparse_to_device_and_dtype(self, dtype):
+        """Test .to(device, dtype) converts both device and dtype."""
+        A = rand_sparse_semi_structured_mask(128, 128, dtype=dtype).cuda()
+        A_sparse = to_sparse_semi_structured(A)
+        A_dense = A_sparse.to_dense()
+
+        result = A_sparse.to("cpu", torch.float32)
+        self.assertEqual(result.device.type, "cpu")
+        self.assertEqual(result.dtype, torch.float32)
+        self.assertFalse(isinstance(result, SparseSemiStructuredTensor))
+        torch.testing.assert_close(
+            result, A_dense.to("cpu", torch.float32), rtol=1e-3, atol=1e-3
+        )
+
+    @dtypes(torch.float16, torch.bfloat16)
+    def test_semi_sparse_to_same_dtype_noop(self, dtype):
+        """Test .to(same_dtype) raises NotImplementedError (only to('cpu') is supported)."""
+        A = rand_sparse_semi_structured_mask(128, 128, dtype=dtype).cuda()
+        A_sparse = to_sparse_semi_structured(A)
+
+        with self.assertRaises(NotImplementedError):
+            A_sparse.to(dtype)
+
+    @dtypes(torch.float16, torch.bfloat16)
+    def test_semi_sparse_to_kwargs(self, dtype):
+        """Test .to() with keyword arguments (device=, dtype=)."""
+        A = rand_sparse_semi_structured_mask(128, 128, dtype=dtype).cuda()
+        A_sparse = to_sparse_semi_structured(A)
+        A_dense = A_sparse.to_dense()
+
+        result = A_sparse.to(device="cpu", dtype=torch.float32)
+        self.assertEqual(result.device.type, "cpu")
+        self.assertEqual(result.dtype, torch.float32)
+        self.assertFalse(isinstance(result, SparseSemiStructuredTensor))
+        torch.testing.assert_close(
+            result, A_dense.to(device="cpu", dtype=torch.float32), rtol=1e-3, atol=1e-3
+        )
+
 if len(SEMI_STRUCTURED_SUPPORTED_BACKENDS) > 0:
     instantiate_device_type_tests(TestSparseSemiStructured, globals(), only_for="cuda")
 if "cutlass" in SEMI_STRUCTURED_SUPPORTED_BACKENDS:

--- a/torch/sparse/_semi_structured_ops.py
+++ b/torch/sparse/_semi_structured_ops.py
@@ -16,6 +16,8 @@ __all__ = [
     "semi_sparse_linear",
     "semi_sparse_scaled_mm",
     "semi_sparse_clone",
+    "semi_sparse_to",
+    "semi_sparse_to_copy",
 ]
 
 
@@ -252,4 +254,47 @@ def semi_sparse_clone(func, types, args=(), kwargs=None) -> torch.Tensor:
         fuse_transpose_cusparselt=self.fuse_transpose_cusparselt,
         alg_id_cusparselt=self.alg_id_cusparselt,
         requires_grad=self.requires_grad,
+    )
+
+
+def semi_sparse_to_copy(func, types, args, kwargs=None) -> torch.Tensor:
+    self = args[0]
+    kwargs = kwargs or {}
+
+    device = kwargs.get("device", None)
+
+    if device is not None and torch.device(device).type == "cpu":
+        dense = self.to_dense()
+        return func(dense, **kwargs)
+
+    raise NotImplementedError(
+        f"`_to_copy()` with kwargs={kwargs} is not implemented "
+        "for SparseSemiStructuredTensor. Only converting to CPU is supported currently."
+    )
+
+
+def semi_sparse_to(func, types, args, kwargs=None) -> torch.Tensor:
+    self = args[0]
+    remaining_args = args[1:]
+    kwargs = kwargs or {}
+
+    # Determine the target device from args/kwargs
+    device = None
+    if remaining_args:
+        first_arg = remaining_args[0]
+        if isinstance(first_arg, (torch.device, str)):
+            try:
+                device = torch.device(first_arg)
+            except RuntimeError:
+                pass
+    if "device" in kwargs:
+        device = torch.device(kwargs["device"])
+
+    if device is not None and device.type == "cpu":
+        dense = self.to_dense()
+        return func(dense, *remaining_args, **kwargs)
+
+    raise NotImplementedError(
+        f"`to()` with args={remaining_args}, kwargs={kwargs} is not implemented "
+        "for SparseSemiStructuredTensor. Only `to('cpu')` is supported currently."
     )

--- a/torch/sparse/semi_structured.py
+++ b/torch/sparse/semi_structured.py
@@ -19,6 +19,8 @@ from torch.sparse._semi_structured_ops import (
     semi_sparse_mm,
     semi_sparse_scaled_mm,
     semi_sparse_t,
+    semi_sparse_to,
+    semi_sparse_to_copy,
     semi_sparse_values,
     semi_sparse_view,
 )
@@ -231,9 +233,10 @@ class SparseSemiStructuredTensor(torch.Tensor):
                 torch.ops.aten.matmul: semi_sparse_mm,
                 torch.ops.aten.addmm: semi_sparse_addmm,
                 torch.ops.aten.linear: semi_sparse_linear,
-                torch.ops.aten._to_copy: fallback_dispatcher,
+                torch.ops.aten._to_copy: semi_sparse_to_copy,
                 torch.ops.aten._scaled_mm: semi_sparse_scaled_mm,
                 torch.ops.aten.clone: semi_sparse_clone,
+                torch.ops.aten.to: semi_sparse_to,
             }
             if custom_dispatch_table is not None:
                 cls.SPARSE_DISPATCH.update(custom_dispatch_table)


### PR DESCRIPTION
Summary:

While running MTS benchmark, I notice a .cpu() operator is missing, this will be a blocking error in some workflows.


Note: only the fallback logic is implemented here. Optimization for cuda -> cuda is not in the scope of this change.

Test Plan: OSS CI: https://hud.pytorch.org/pr/178014

Reviewed By: jcaip

Differential Revision: D97000066


