### PR TITLE
[inductor][auto_chunker] Add gather/scatter propagation and generaliz…

### DIFF
--- a/test/inductor/test_auto_chunker.py
+++ b/test/inductor/test_auto_chunker.py
@@ -296,6 +296,85 @@ class AutoChunkerTest(TestCase):
         self.assertTrue(same(expect, actual, tol=1e-3))
         self.assertEqual(metrics.num_auto_chunking, 1)
 
+    @config.patch("auto_chunker.output_size_threshold", 1024)
+    @config.patch("auto_chunker.num_chunk", 2)
+    def test_propagate_gather(self):
+        M, K, N = 256, 4, 256
+        x = torch.randn(M, K, device=GPU_TYPE, requires_grad=True)
+        w = torch.randn(K, N, device=GPU_TYPE, requires_grad=True)
+        targets = torch.randint(0, N, (M,), device=GPU_TYPE)
+
+        def f(x, w, targets):
+            out = (x * 2) @ w
+            out = out.softmax(dim=-1)
+            selected = out.gather(1, targets.unsqueeze(1))
+            loss = selected.squeeze(1).sum()
+            loss.backward()
+            return loss
+
+        expect = (f(x, w, targets), x.grad, w.grad)
+        x.grad = None
+        w.grad = None
+        opt_f = torch.compile(f)
+        actual = (opt_f(x, w, targets), x.grad, w.grad)
+
+        self.assertTrue(same(expect, actual, tol=1e-3))
+        self.assertEqual(metrics.num_auto_chunking, 1)
+
+    @config.patch("auto_chunker.output_size_threshold", 1024)
+    @config.patch("auto_chunker.num_chunk", 2)
+    def test_propagate_scatter(self):
+        M, K, N = 256, 4, 256
+        x = torch.randn(M, K, device=GPU_TYPE, requires_grad=True)
+        w = torch.randn(K, N, device=GPU_TYPE, requires_grad=True)
+        targets = torch.randint(0, N, (M,), device=GPU_TYPE)
+
+        def f(x, w, targets):
+            out = (x * 2) @ w
+            out = out.softmax(dim=-1)
+            out = out.scatter(1, targets.unsqueeze(1), 0.0)
+            loss = out.sum()
+            loss.backward()
+            return loss
+
+        expect = (f(x, w, targets), x.grad, w.grad)
+        x.grad = None
+        w.grad = None
+        opt_f = torch.compile(f)
+        actual = (opt_f(x, w, targets), x.grad, w.grad)
+
+        self.assertTrue(same(expect, actual, tol=1e-3))
+        self.assertEqual(metrics.num_auto_chunking, 1)
+
+    @config.patch("auto_chunker.output_size_threshold", 1024)
+    @config.patch("auto_chunker.num_chunk", 2)
+    def test_propagate_manual_cross_entropy(self):
+        M, K, N = 256, 4, 256
+        x = torch.randn(M, K, device=GPU_TYPE, requires_grad=True)
+        w = torch.randn(K, N, device=GPU_TYPE, requires_grad=True)
+        targets = torch.randint(0, N, (M,), device=GPU_TYPE)
+
+        def f(x, w, targets):
+            logits = (x * 2) @ w
+            max_logits = logits.amax(dim=-1)
+            shifted = logits - max_logits.unsqueeze(-1)
+            exp_shifted = shifted.exp()
+            sum_exp = exp_shifted.sum(dim=-1)
+            log_probs = shifted - sum_exp.log().unsqueeze(-1)
+            target_log_probs = log_probs.gather(1, targets.unsqueeze(1))
+            loss = -target_log_probs.squeeze(1).sum() / M
+            loss.backward()
+            return loss
+
+        expect = (f(x, w, targets), x.grad, w.grad)
+        x.grad = None
+        w.grad = None
+        opt_f = torch.compile(f)
+        actual = (opt_f(x, w, targets), x.grad, w.grad)
+
+        self.assertTrue(same(expect, actual, tol=1e-3))
+        self.assertEqual(metrics.num_auto_chunking, 1)
+
     def test_set_num_chunk_with_compile_options(self):
         B = 32
         T = 1024

--- a/torch/_inductor/fx_passes/auto_chunker/applier.py
+++ b/torch/_inductor/fx_passes/auto_chunker/applier.py
@@ -258,11 +258,10 @@ class ChunkingApplier:
                     original_node.kwargs,
                 )
                 continue
-            # Chunk aten.expand a scalar
+            # Chunk aten.expand: adjust the target shape at the chunk dimension
             if (
                 original_node.target == aten.expand.default
                 and isinstance(original_node.args[0], torch.fx.Node)
-                and original_node.args[0].meta["val"].numel() == 1
                 and (meta := get_chunking_meta(original_node)) is not None
                 and meta.chunk_dim is not None
             ):

--- a/torch/_inductor/fx_passes/auto_chunker/propagate_scale_by.py
+++ b/torch/_inductor/fx_passes/auto_chunker/propagate_scale_by.py
@@ -172,6 +172,8 @@ def propagate_requires_no_scaling(out_node: Node) -> bool:
         aten.expand.default,
         aten.squeeze.dim,
         aten.unsqueeze.default,
+        aten.gather.default,
+        aten.scatter_add.default,
         aten.view.default,
     ]
 )
@@ -189,6 +191,16 @@ def propagate_general_copy(out_node: Node) -> bool:
     assert out_meta is not None
     out_meta.scale_by = scale_by
     return True
+
+
+@register_propagate_rule(aten.scatter.value)
+def propagate_scatter_value(out_node: Node) -> bool:
+    # The backward of scatter.value always has value=0 (gradient of a constant),
+    # so S * scatter(x, idx, 0) = scatter(S*x, idx, 0) holds.
+    value = out_node.args[3]
+    if value != 0:
+        return False
+    return propagate_general_copy(out_node)
 
 
 @register_propagate_rule(

--- a/torch/_inductor/fx_passes/auto_chunker/propagator.py
+++ b/torch/_inductor/fx_passes/auto_chunker/propagator.py
@@ -511,6 +511,7 @@ def propagate_general_copy_metadata(
         aten.squeeze.dim,
         aten.gather.default,
         aten.scatter.value,
+        aten.scatter_add.default,
     ]
 )
 def propagate_general_copy_metadata_ignore_broadcast(out_node: Node) -> _HandlerRetType:
@@ -759,15 +760,50 @@ def propagate_expand(expand_node: Node) -> _HandlerRetType:
     input_node = expand_node.args[0]
     assert isinstance(input_node, Node)
 
-    if input_node.meta["val"].numel() != 1:
-        return PropagateStatus.FAIL
+    input_ft = get_fake_tensor_from_node_arg(input_node)
+    assert input_ft is not None
+    output_ft = get_fake_tensor_from_node_arg(expand_node)
+    assert output_ft is not None
+    input_shape = list(input_ft.shape)
+    output_shape = list(output_ft.shape)
 
-    # Combined fwd/bwd rule
-    output_meta = get_chunking_meta(expand_node)
-    if output_meta is None:
-        return _bool_to_status(False)
+    if input_ft.numel() == 1:
+        # Scalar input: combined fwd/bwd rule
+        output_meta = get_chunking_meta(expand_node)
+        if output_meta is None:
+            return _bool_to_status(False)
+        return _bool_to_status(set_chunking_meta(input_node))
 
-    return _bool_to_status(set_chunking_meta(input_node))
+    # How many leading dims are added by expand
+    dim_offset = len(output_shape) - len(input_shape)
+
+    def is_expand_dim(out_dim: int) -> bool:
+        """Check if out_dim is a broadcast dimension (newly added or size 1 in input)."""
+        return out_dim < dim_offset or input_shape[out_dim - dim_offset] == 1
+
+    def fwd() -> PropagateStatus:
+        assert isinstance(input_node, Node)
+        input_meta = get_chunking_meta(input_node)
+        if input_meta is None:
+            return _bool_to_status(False)
+        # Fail if chunk_dim is an expand dimension (input size 1 broadcast to larger size)
+        if input_meta.chunk_dim is not None and is_expand_dim(
+            input_meta.chunk_dim + dim_offset
+        ):
+            return PropagateStatus.FAIL
+        return _bool_to_status(copy_chunking_meta(expand_node, input_meta))
+
+    def bwd() -> PropagateStatus:
+        assert isinstance(input_node, Node)
+        output_meta = get_chunking_meta(expand_node)
+        if output_meta is None:
+            return _bool_to_status(False)
+        # Fail if chunk_dim is an expand dimension (input size 1 broadcast to larger size)
+        if output_meta.chunk_dim is not None and is_expand_dim(output_meta.chunk_dim):
+            return PropagateStatus.FAIL
+        return _bool_to_status(copy_chunking_meta(input_node, output_meta))
+
+    return fwd(), bwd()
 
 
 @register_propagate_rule(


### PR DESCRIPTION
…e expand for non-scalar inputs

Extend auto_chunker to support manual cross-entropy patterns by adding gather, scatter, and scatter_add to the propagation rules, and generalizing expand propagation to handle non-scalar inputs where the chunk dimension size doesn't change.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo