### PR TITLE
[AMD] Fix num_warps when max_autotune is enabled on HIP (#178023)

### DIFF
--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -3955,7 +3955,8 @@ def persistent_reduction(
                 # more warps for larger rows
                 new_configs.append(c)
 
-                if max_autotune_enabled and c.num_warps < 32:
+                max_warps_limit = 16 if torch.version.hip else 32
+                if max_autotune_enabled and c.num_warps < max_warps_limit:
                     newc = copy.deepcopy(c)
                     newc.num_warps *= 2
                     new_configs.append(newc)


### PR DESCRIPTION
Summary:

Fixes a launch failure on MI350 by capping the maximum `num_warps` to 16 for HIP/AMD platforms during persistent reduction autotune config expansion. On MI350 with 64-thread wavefronts, `num_warps=32` results in 2048 threads per workgroup, exceeding the hardware limit of 1024. The fix adds a platform-specific limit that respects AMD's hardware constraints while preserving existing CUDA behavior.

Original error message on MI350x:
```
Failed during launch triton_per_fused_native_layer_norm_native_layer_norm_backward_0 with config: XBLOCK: 1, RSPLIT_SIZE: 16, NUM_STAGES: 1, num_warps: 32, num_ctas: 1, num_stages: 1, maxnreg: None, minRegAutoWS: None, maxRegAutoWS: None, pingpongAutoWS: None, ctas_per_cga: None, preferred_ctas_per_cga: None (num_warps=32, num_stages=1, kwargs={'XBLOCK': 1, 'RSPLIT_SIZE': 16, 'NUM_STAGES': 1})
```

Test Plan:
before: https://fburl.com/mlhub/kzti8kr3
after: https://fburl.com/mlhub/qqsn1rs4

Reviewed By: ckluk2, joebos

Differential Revision: D97553925




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos