### PR TITLE
[dynamo] Extract vt_identity_compare; add CPython permalinks to richcompare_impl

### DIFF
--- a/torch/_dynamo/variables/base.py
+++ b/torch/_dynamo/variables/base.py
@@ -878,7 +878,11 @@ class VariableTracker(metaclass=VariableTrackerMeta):
         other: "VariableTracker",
         op: str,
     ) -> "VariableTracker":
-        """Hook for generic_richcompare. Return result VT or ConstantVariable(NotImplemented)."""
+        """Hook for generic_richcompare. Return result VT or ConstantVariable(NotImplemented).
+
+        CPython: object_richcompare in Objects/typeobject.c
+        https://github.com/python/cpython/blob/main/Objects/typeobject.c
+        """
         if (
             self.is_python_constant()
             and other.is_python_constant()

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -850,43 +850,15 @@ class BuiltinVariable(VariableTracker):
                     left: VariableTracker,
                     right: VariableTracker,
                 ) -> VariableTracker | None:
-                    # VT identity → Python identity
-                    if left is right:
-                        return VariableTracker.build(tx, op.__name__ == "is_")
+                    from .user_defined import vt_identity_compare
 
-                    # Compare underlying Python objects via hook
-                    left_val = left.get_real_python_backed_value()
-                    right_val = right.get_real_python_backed_value()
-
-                    left_known = left_val is not NO_SUCH_SUBOBJ
-                    right_known = right_val is not NO_SUCH_SUBOBJ
-
-                    if left_known and right_known:
-                        result = left_val is right_val
-                        return VariableTracker.build(
-                            tx, result if op.__name__ == "is_" else not result
-                        )
-
-                    # One side has a concrete value, the other doesn't — they
-                    # can't be identical (if they were the same object, both
-                    # sides would resolve).
-                    if left_known != right_known:
-                        return VariableTracker.build(tx, op.__name__ != "is_")
-
-                    # Mutable containers created during tracing: VT identity
-                    # = Python identity. Already False from `left is right`.
-                    if isinstance(left, (ConstDictVariable, ListVariable)):
-                        return VariableTracker.build(tx, op.__name__ != "is_")
-
-                    # Different exception types are never identical
-                    if (
-                        istype(left, variables.ExceptionVariable)
-                        and istype(right, variables.ExceptionVariable)
-                        and left.exc_type is not right.exc_type
-                    ):
-                        return VariableTracker.build(tx, op.__name__ != "is_")
-
-                    return None
+                    result = vt_identity_compare(tx, left, right)
+                    if result is None:
+                        return None
+                    is_same = result.as_python_constant()
+                    return VariableTracker.build(
+                        tx, is_same if op.__name__ == "is_" else not is_same
+                    )
 
                 result.append(((VariableTracker, VariableTracker), handle_is))  # type: ignore[arg-type]
 

--- a/torch/_dynamo/variables/dicts.py
+++ b/torch/_dynamo/variables/dicts.py
@@ -1004,6 +1004,8 @@ class ConstDictVariable(VariableTracker):
         other: VariableTracker,
         op: str,
     ) -> VariableTracker:
+        # CPython: dict_richcompare in Objects/dictobject.c
+        # https://github.com/python/cpython/blob/main/Objects/dictobject.c
         from .builder import SourcelessBuilder
 
         if op in ("__eq__", "__ne__"):
@@ -1529,6 +1531,8 @@ class SetVariable(ConstDictVariable):
         other: VariableTracker,
         op: str,
     ) -> VariableTracker:
+        # CPython: set_richcompare in Objects/setobject.c
+        # https://github.com/python/cpython/blob/main/Objects/setobject.c
         if not isinstance(other, (SetVariable, variables.UserDefinedSetVariable)):
             return ConstantVariable.create(NotImplemented)
         if op == "__eq__":
@@ -1905,6 +1909,8 @@ class DictKeysVariable(DictViewVariable):
         other: VariableTracker,
         op: str,
     ) -> VariableTracker:
+        # CPython: dictviews_richcompare in Objects/dictobject.c
+        # https://github.com/python/cpython/blob/main/Objects/dictobject.c
         if not isinstance(other, (SetVariable, DictKeysVariable)):
             return ConstantVariable.create(NotImplemented)
         return VariableTracker.build(
@@ -1980,9 +1986,11 @@ class DictItemsVariable(DictViewVariable):
         other: VariableTracker,
         op: str,
     ) -> VariableTracker:
+        # CPython: dictviews_richcompare in Objects/dictobject.c
+        # https://github.com/python/cpython/blob/main/Objects/dictobject.c
         if op == "__eq__":
             if isinstance(other, DictItemsVariable):
-                return self.dv_dict.call_method(tx, "__eq__", [other.dv_dict], {})
+                return self.dv_dict.richcompare_impl(tx, other.dv_dict, "__eq__")
             return ConstantVariable.create(NotImplemented)
         return ConstantVariable.create(NotImplemented)
 

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -380,6 +380,8 @@ class BaseListVariable(VariableTracker):
         other: VariableTracker,
         op: str,
     ) -> VariableTracker:
+        # CPython: list_richcompare / tuplerichcompare in Objects/listobject.c, Objects/tupleobject.c
+        # https://github.com/python/cpython/blob/main/Objects/listobject.c
         from .builder import SourcelessBuilder
 
         if not isinstance(other, BaseListVariable):
@@ -672,6 +674,8 @@ class RangeVariable(BaseListVariable):
         other: VariableTracker,
         op: str,
     ) -> VariableTracker:
+        # CPython: range_richcompare in Objects/rangeobject.c
+        # https://github.com/python/cpython/blob/main/Objects/rangeobject.c
         from .builder import SourcelessBuilder
 
         if op not in ("__eq__", "__ne__"):

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -553,8 +553,9 @@ class TracebackVariable(VariableTracker):
         other: VariableTracker,
         op: str,
     ) -> VariableTracker:
+        # CPython: tracebacks use identity-based comparison (object_richcompare)
+        # https://github.com/python/cpython/blob/main/Objects/typeobject.c
         if op == "__eq__":
-            # Two traceback variables are only equal if they are the same object
             return VariableTracker.build(tx, self is other)
         return ConstantVariable.create(NotImplemented)
 
@@ -1666,6 +1667,8 @@ class TypingVariable(VariableTracker):
         other: VariableTracker,
         op: str,
     ) -> VariableTracker:
+        # CPython: _GenericAlias.__eq__ in Lib/typing.py
+        # https://github.com/python/cpython/blob/main/Lib/typing.py
         if op == "__eq__":
             result = istype(other, TypingVariable) and self.value == other.value  # type: ignore[attr-defined]
             return variables.ConstantVariable.create(result)

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -207,6 +207,56 @@ def _type_overrides_richcompare(tp: type, op: str) -> bool:
     return method is not None and method is not obj_method
 
 
+def vt_identity_compare(
+    tx: "InstructionTranslator",
+    left: "VariableTracker",
+    right: "VariableTracker",
+) -> "VariableTracker | None":
+    """Try to determine Python identity (left is right) at trace time.
+
+    Returns ConstantVariable(True/False) if determinable, else None.
+    Mirrors the logic in BuiltinVariable's handle_is handler.
+    """
+    if left is right:
+        return VariableTracker.build(tx, True)
+
+    left_val = left.get_real_python_backed_value()
+    right_val = right.get_real_python_backed_value()
+    left_known = left_val is not NO_SUCH_SUBOBJ
+    right_known = right_val is not NO_SUCH_SUBOBJ
+
+    if left_known and right_known:
+        return VariableTracker.build(tx, left_val is right_val)
+
+    # One side has a concrete backing object, the other doesn't — they can't
+    # be the same object.
+    if left_known != right_known:
+        return VariableTracker.build(tx, False)
+
+    # Mutable containers created during tracing: VT identity = Python identity.
+    from .lists import ListVariable
+
+    if isinstance(left, (ConstDictVariable, ListVariable)):
+        return VariableTracker.build(tx, False)
+
+    # Different Python types can never be the same object.
+    try:
+        if left.python_type() is not right.python_type():
+            return VariableTracker.build(tx, False)
+    except NotImplementedError:
+        pass
+
+    # Different exception types are never identical.
+    if (
+        istype(left, variables.ExceptionVariable)
+        and istype(right, variables.ExceptionVariable)
+        and left.exc_type is not right.exc_type  # type: ignore[attr-defined]
+    ):
+        return VariableTracker.build(tx, False)
+
+    return None
+
+
 def generic_richcompare(
     tx: "InstructionTranslator",
     lhs: "VariableTracker",
@@ -255,19 +305,21 @@ def generic_richcompare(
     # Step 4: fallback
     if op in ("__eq__", "__ne__"):
         # CPython: fall back to identity (a is b)
-        # Compute identity at trace time: VT identity implies Python identity.
-        from .base import NO_SUCH_SUBOBJ
+        identity = vt_identity_compare(tx, lhs, rhs)
+        if identity is None:
+            from ..exc import unimplemented
+            from .. import graph_break_hints
 
-        are_same = lhs is rhs
-        if not are_same:
-            lhs_val = lhs.get_real_python_backed_value()
-            rhs_val = rhs.get_real_python_backed_value()
-            if lhs_val is not NO_SUCH_SUBOBJ and rhs_val is not NO_SUCH_SUBOBJ:
-                are_same = lhs_val is rhs_val
+            unimplemented(
+                gb_type="Cannot determine object identity at trace time",
+                context=f"comparing {type(lhs).__name__} and {type(rhs).__name__}",
+                explanation="Dynamo cannot resolve identity of these objects at trace time.",
+                hints=[*graph_break_hints.FUNDAMENTAL],
+            )
+        is_same = identity.as_python_constant()
         from .constant import ConstantVariable
 
-        result = are_same if op == "__eq__" else not are_same
-        return ConstantVariable.create(result)
+        return ConstantVariable.create(is_same if op == "__eq__" else not is_same)
     else:
         from ..utils import cmp_name_to_op_str_mapping
 
@@ -3100,6 +3152,8 @@ class UserDefinedTupleVariable(UserDefinedObjectVariable):
         other: "VariableTracker",
         op: str,
     ) -> "VariableTracker":
+        # CPython: tuple_richcompare in Objects/tupleobject.c
+        # https://github.com/python/cpython/blob/main/Objects/tupleobject.c
         assert self._tuple_vt is not None
         if op in ("__eq__", "__ne__"):
             result = self.is_python_equal(other)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #178025
* #177943

Extract the handle_is identity logic from BuiltinVariable into a shared
vt_identity_compare() helper in user_defined.py, and use it from both
handle_is and generic_richcompare's step-4 identity fallback. The shared
version adds a missing case: objects with different Python types can never
be identical.

Also add CPython cross-reference comments to each richcompare_impl pointing
to the corresponding C/Python implementation (list_richcompare,
range_richcompare, dict_richcompare, set_richcompare, dictviews_richcompare,
object_richcompare, _GenericAlias.__eq__, tuple_richcompare).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo