### PR TITLE
[TEST]Add 'eager_numerics.use_pytorch_libdevice' option for bitwise identical tests in `test_unary_ufunc`

### DIFF
--- a/test/inductor/test_torchinductor_opinfo_properties.py
+++ b/test/inductor/test_torchinductor_opinfo_properties.py
@@ -241,6 +241,7 @@ INDUCTOR_NUMERICS_OPTIONS = {
     "emulate_precision_casts": True,
     "eager_numerics.division_rounding": True,
     "eager_numerics.disable_ftz": True,
+    "eager_numerics.use_pytorch_libdevice": True,
 }
 
 


### PR DESCRIPTION
authored with claude code

otherwise we see 1ulp divergence in e.g.,
`python test/inductor/test_torchinductor_opinfo_properties.py -k TestOpInfoPropertiesCUDA.test_unary_ufunc_numerical_expm1_backend_inductor_numerics_cuda_float32`

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo