### PR TITLE
[inductor] Avoid aliasing mutated cat results

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -4581,6 +4581,7 @@ class CommonTemplate:
 
         self.common(fn, (torch.randn(4, 2), torch.randn(4, 2)), check_lowp=False)
 
+    @skip_if_pallas
     def test_mutated_cat_does_not_alias_inputs(self):
         # Regression test for https://github.com/pytorch/pytorch/issues/177821
         def fn(x, y):
@@ -4593,6 +4594,9 @@ class CommonTemplate:
             torch.arange(4, device=self.device, dtype=torch.float32).reshape(2, 2),
             torch.arange(4, device=self.device, dtype=torch.float32).reshape(2, 2),
         )
+        if is_dynamic_shape_enabled():
+            torch._dynamo.mark_dynamic(args[0], 0)
+            torch._dynamo.mark_dynamic(args[1], 0)
         self.common(fn, args, check_lowp=False)
 
     def test_slice_view_with_graph_break(self):

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -4581,6 +4581,20 @@ class CommonTemplate:
 
         self.common(fn, (torch.randn(4, 2), torch.randn(4, 2)), check_lowp=False)
 
+    def test_mutated_cat_does_not_alias_inputs(self):
+        # Regression test for https://github.com/pytorch/pytorch/issues/177821
+        def fn(x, y):
+            x = 2 * x
+            c = torch.cat([x, y], dim=1)
+            c[:, [1, 0]] = c[:, [0, 1]]
+            return c[:, :2] + x
+
+        args = (
+            torch.arange(4, device=self.device, dtype=torch.float32).reshape(2, 2),
+            torch.arange(4, device=self.device, dtype=torch.float32).reshape(2, 2),
+        )
+        self.common(fn, args, check_lowp=False)
+
     def test_slice_view_with_graph_break(self):
         def fn():
             a = torch.tensor([1], device=self.device)

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -1995,7 +1995,9 @@ def cat(inputs, dim=0):
 
         return any(
             hasattr(arg, "users")
-            and any(user in downstream_nodes for user in arg.users if user is not cat_node)
+            and any(
+                user in downstream_nodes for user in arg.users if user is not cat_node
+            )
             for arg in fx_args
         )
 

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -1979,9 +1979,30 @@ def cat(inputs, dim=0):
     )
     inputs = [to_dtype(inp, dtype) for inp in inputs]
 
-    if current_node_has_downstream_mutation():
+    def any_cat_input_has_downstream_users() -> bool:
+        cat_node = V.current_node
+        if cat_node is None:
+            return False
+        fx_args = cat_node.args[0]  # aten.cat format: cat(input_list, dim)
+        if not isinstance(fx_args, (list, tuple)):
+            return False
+
+        downstream_nodes = OrderedSet()
+        current = cat_node.next
+        while current.op != "root":
+            downstream_nodes.add(current)
+            current = current.next
+
+        return any(
+            hasattr(arg, "users")
+            and any(user in downstream_nodes for user in arg.users if user is not cat_node)
+            for arg in fx_args
+        )
+
+    if any_cat_input_has_downstream_users() and current_node_has_downstream_mutation():
         # ConcatKernel rewires cat inputs into views of the concat output.
-        # That is only valid while the concat result stays immutable.
+        # That is only valid while downstream mutations cannot be observed
+        # through later reads of the original cat inputs.
         return fallback_handler(aten.cat.default)(inputs, dim)
 
     def unwrap_tensor(x: TensorBox | ir.StorageBox) -> ir.IRNode:

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -139,6 +139,34 @@ def cur_node_has_non_foreach_users() -> bool:
     return False
 
 
+def current_node_has_downstream_mutation() -> bool:
+    node = V.current_node
+    if node is None:
+        return False
+
+    worklist = [node]
+    seen = {node}
+    while worklist:
+        current = worklist.pop()
+        for user in current.users:
+            if user in seen or user.op != "call_function":
+                continue
+            seen.add(user)
+
+            target = user.target
+            if isinstance(target, torch._ops.OpOverload):
+                if target._schema.is_mutable:
+                    return True
+                if is_view(target):
+                    worklist.append(user)
+            elif target is triton_kernel_wrapper_mutation:
+                return True
+            elif target is operator.getitem:
+                worklist.append(user)
+
+    return False
+
+
 # group by device, whether any of the inputs are dynamic
 # note arg_pairs may or may not be a pair
 # foreach_map for example just passes output buffers here
@@ -1950,6 +1978,11 @@ def cat(inputs, dim=0):
         *inputs, type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT
     )
     inputs = [to_dtype(inp, dtype) for inp in inputs]
+
+    if current_node_has_downstream_mutation():
+        # ConcatKernel rewires cat inputs into views of the concat output.
+        # That is only valid while the concat result stays immutable.
+        return fallback_handler(aten.cat.default)(inputs, dim)
 
     def unwrap_tensor(x: TensorBox | ir.StorageBox) -> ir.IRNode:
         if isinstance(x, TensorBox):

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -145,7 +145,7 @@ def current_node_has_downstream_mutation() -> bool:
         return False
 
     worklist = [node]
-    seen = {node}
+    seen = OrderedSet([node])
     while worklist:
         current = worklist.pop()
         for user in current.users:


### PR DESCRIPTION
Fix #177821

## Summary
- Root cause: `ConcatKernel` rewires cat inputs into non-owning views of the concat output. That is only valid while the concat result stays immutable. When a later mutation like `index_put_` writes into the concat, subsequent uses of an input can incorrectly observe the mutated concat slice.
- Proposed fix: if an `aten.cat` result has downstream mutation, lower it through the normal `aten.cat` fallback instead of `ConcatKernel`, and add a regression test for the advanced-index assignment repro from the issue.
- Why this is the right long term fix: it keeps the concat aliasing optimization where it is semantically valid, but disables it exactly where mutation would make that optimization incorrect.

Drafted via Codex, published after manual review by @bobrenjc93

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo