### PR TITLE
[inductor] Add custom_pass_context for scoped, composable custom pass registration

### DIFF
--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -33,6 +33,7 @@ from torch._inductor.codecache import (
 from torch._inductor.codegen.cuda.compile_utils import cuda_compile_command
 from torch._inductor.cpp_builder import normalize_path_separator
 from torch._inductor.custom_graph_pass import (
+    custom_pass_context,
     CustomGraphModulePass,
     CustomGraphPass,
     CustomPartitionerFn,
@@ -2433,6 +2434,47 @@ if not torch.allclose(eager_result, compiled_result, atol=0.1, rtol=0.01):
             self.assertEqual(fn(a, b), compiled_fn(a, b))
             self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 0)
             self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 1)
+
+    @config.patch({"fx_graph_cache": True})
+    @config.patch({"fx_graph_remote_cache": False})
+    def test_custom_pass_context_uuid_cache_hit_miss(self):
+        class TestContextPass(CustomGraphPass):
+            def __init__(self) -> None:
+                self._uuid = "v1"
+
+            def __call__(self, graph: torch.fx.graph.Graph) -> None:
+                return None
+
+            def uuid(self) -> bytes | str | None:
+                return self._uuid
+
+        def fn(a, b):
+            return torch.mm(a, b)
+
+        a = torch.rand(8, 32, device="cpu")
+        b = torch.rand(32, 8, device="cpu")
+        compiled_fn = torch.compile(fn)
+        custom_pass = TestContextPass()
+
+        with custom_pass_context(post_grad_pre_passes=[custom_pass]):
+            self.reset()
+            counters.clear()
+            compiled_fn(a, b)
+            self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 1)
+            self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 0)
+
+            self.reset()
+            counters.clear()
+            compiled_fn(a, b)
+            self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 0)
+            self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 1)
+
+            custom_pass._uuid = "v2"
+            self.reset()
+            counters.clear()
+            compiled_fn(a, b)
+            self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 1)
+            self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 0)
 
 
 class TestCustomPartitionerFn(CustomPartitionerFn):

--- a/test/inductor/test_custom_post_grad_passes.py
+++ b/test/inductor/test_custom_post_grad_passes.py
@@ -10,10 +10,13 @@ from torch._dynamo.utils import counters
 from torch._inductor import config
 from torch._inductor.codegen.common import get_custom_backend_pass_for_device
 from torch._inductor.custom_graph_pass import (
+    custom_pass_context,
     CustomGraphModulePass,
     CustomGraphPass,
     CustomInferenceAwareGraphPass,
     get_hash_for_files,
+    patched_inductor_config_with_custom_pass_context,
+    split_custom_passes_from_config_patch,
 )
 from torch._inductor.lowering import lowerings as L
 from torch._inductor.pattern_matcher import Arg, CallFunction, PatternMatcherPass
@@ -67,12 +70,29 @@ def change_cos_pass(graph):
             node.target = aten.sin.default
 
 
+def change_sin_to_neg_pass(graph):
+    for node in graph.nodes:
+        if node.op == "call_function" and node.target == aten.sin.default:
+            node.target = aten.neg.default
+
+
 class ChangeCosCustomPass(CustomGraphPass):
     def __init__(self) -> None:
         super().__init__()
 
     def __call__(self, g: torch.fx.graph.Graph):
         change_cos_pass(g)
+
+    def uuid(self) -> bytes:
+        return get_hash_for_files((__file__,))
+
+
+class ChangeSinToNegCustomPass(CustomGraphPass):
+    def __init__(self) -> None:
+        super().__init__()
+
+    def __call__(self, g: torch.fx.graph.Graph):
+        change_sin_to_neg_pass(g)
 
     def uuid(self) -> bytes:
         return get_hash_for_files((__file__,))
@@ -302,6 +322,165 @@ class TestPostGradCustomPrePostPass(TestCustomPassBase):
             get_custom_backend_pass_for_device("cpu")
         )
         with patch_inductor_backend("cpu", custom_pass=custom_backend_pass):
+
+            def g(x):
+                return x.sin().sin().sin()
+
+            def f(x):
+                return x.cos().cos().cos()
+
+            x = torch.randn(8, dtype=torch.float32)
+            torch.testing.assert_close(torch.compile(f)(x), g(x))
+
+    def test_custom_post_grad_context_pass(self):
+        with custom_pass_context(post_grad_post_passes=[ChangeCosCustomPass()]):
+
+            def g(x):
+                return x.sin().sin().sin()
+
+            def f(x):
+                return x.cos().cos().cos()
+
+            x = torch.randn(8, dtype=torch.float32)
+            torch.testing.assert_close(torch.compile(f)(x), g(x))
+
+    def test_custom_joint_pre_context_pass(self):
+        with custom_pass_context(joint_pre_passes=[ChangeCosCustomPass()]):
+
+            def g(x):
+                return x.sin().sin().sin()
+
+            def f(x):
+                return x.cos().cos().cos()
+
+            x = torch.randn(8, dtype=torch.float32)
+            torch.testing.assert_close(torch.compile(f)(x), g(x))
+
+    def test_custom_joint_post_context_pass(self):
+        with custom_pass_context(joint_post_passes=[ChangeCosCustomPass()]):
+
+            def g(x):
+                return x.sin().sin().sin()
+
+            def f(x):
+                return x.cos().cos().cos()
+
+            x = torch.randn(8, dtype=torch.float32)
+            torch.testing.assert_close(torch.compile(f)(x), g(x))
+
+    def test_custom_pre_grad_context_pass(self):
+        class CountingPreGradPass(CustomGraphPass):
+            def __init__(self) -> None:
+                self.count = 0
+
+            def __call__(self, g: torch.fx.graph.Graph):
+                self.count += 1
+
+            def uuid(self) -> bytes:
+                return get_hash_for_files((__file__,), extra="CountingPreGradPass")
+
+        custom_pass = CountingPreGradPass()
+        with custom_pass_context(pre_grad_passes=[custom_pass]):
+
+            def f(x):
+                return x.cos().cos().cos()
+
+            x = torch.randn(8, dtype=torch.float32)
+            torch.testing.assert_close(torch.compile(f)(x), f(x))
+            self.assertGreaterEqual(custom_pass.count, 1)
+
+    def test_nested_custom_pass_contexts(self):
+        with custom_pass_context(post_grad_post_passes=[ChangeCosCustomPass()]):
+            with custom_pass_context(
+                post_grad_post_passes=[ChangeSinToNegCustomPass()]
+            ):
+
+                def g(x):
+                    return -x
+
+                def f(x):
+                    return x.cos().cos().cos()
+
+                x = torch.randn(8, dtype=torch.float32)
+                torch.testing.assert_close(torch.compile(f)(x), g(x))
+
+    def test_two_libraries_custom_pass_context(self):
+        # Simulate two separate libraries independently installing their own pass contexts.
+        with contextlib.ExitStack() as stack:
+            stack.enter_context(
+                custom_pass_context(post_grad_pre_passes=[ChangeCosCustomPass()])
+            )
+            stack.enter_context(
+                custom_pass_context(post_grad_post_passes=[ChangeSinToNegCustomPass()])
+            )
+
+            def g(x):
+                return -x
+
+            def f(x):
+                return x.cos().cos().cos()
+
+            x = torch.randn(8, dtype=torch.float32)
+            torch.testing.assert_close(torch.compile(f)(x), g(x))
+
+    def test_custom_pass_context_does_not_leak(self):
+        def g_with_pass(x):
+            return x.sin().sin().sin()
+
+        def f(x):
+            return x.cos().cos().cos()
+
+        x = torch.randn(8, dtype=torch.float32)
+        with custom_pass_context(post_grad_post_passes=[ChangeCosCustomPass()]):
+            torch.testing.assert_close(torch.compile(f)(x), g_with_pass(x))
+
+        torch._dynamo.reset()
+        torch.testing.assert_close(torch.compile(f)(x), f(x))
+
+    def test_split_custom_passes_from_config_patch(self):
+        custom_pass = ChangeCosCustomPass()
+        custom_ctx_kwargs, remaining = split_custom_passes_from_config_patch(
+            {
+                "post_grad_custom_post_pass": custom_pass,
+                "joint_custom_pre_pass": custom_pass,
+                "pattern_matcher": False,
+            }
+        )
+        self.assertEqual(
+            custom_ctx_kwargs,
+            {
+                "post_grad_post_passes": [custom_pass],
+                "joint_pre_passes": [custom_pass],
+            },
+        )
+        self.assertEqual(remaining, {"pattern_matcher": False})
+
+    def test_patched_inductor_config_with_custom_pass_context(self):
+        with patched_inductor_config_with_custom_pass_context(
+            {
+                "post_grad_custom_post_pass": ChangeCosCustomPass(),
+                "pattern_matcher": False,
+            }
+        ):
+
+            def g(x):
+                return x.sin().sin().sin()
+
+            def f(x):
+                return x.cos().cos().cos()
+
+            x = torch.randn(8, dtype=torch.float32)
+            torch.testing.assert_close(torch.compile(f)(x), g(x))
+
+    def test_custom_backend_context_pass(self):
+        class CustomBackendPass(CustomGraphModulePass):
+            def __call__(self, gm: fx.GraphModule) -> None:
+                change_cos_pass(gm.graph)
+
+            def uuid(self) -> bytes:
+                return get_hash_for_files((__file__,))
+
+        with custom_pass_context(custom_backend_passes={"cpu": [CustomBackendPass()]}):
 
             def g(x):
                 return x.sin().sin().sin()

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -82,6 +82,7 @@ from torch._inductor.custom_graph_pass import (
     CustomGraphPassType,
     CustomPartitionerFn,
     CustomPartitionerFnType,
+    get_active_passes,
 )
 from torch._inductor.freezing_utils import has_frozen_params, is_frozen_param
 from torch._inductor.runtime.compile_tasks import _reload_python_module
@@ -797,17 +798,22 @@ def resolve_pre_grad_pass_timing() -> Literal["early", "late"]:
     """
     timing: Literal["early", "late", "default"] = config.pre_grad_pass_timing
     custom_pass = config.pre_grad_custom_pass
+    active_custom_passes = get_active_passes().pre_grad_passes
     has_uuid = (
         custom_pass
         and isinstance(custom_pass, CustomGraphPass)
         and custom_pass.uuid() is not None
     )
+    active_have_uuids = all(
+        isinstance(custom_pass, CustomGraphPass) and custom_pass.uuid() is not None
+        for custom_pass in active_custom_passes
+    )
 
     if timing == "default":
-        supports_late = custom_pass is None or has_uuid
+        supports_late = (custom_pass is None or has_uuid) and active_have_uuids
         timing = "late" if supports_late else "early"
 
-    if timing == "late" and custom_pass and not has_uuid:
+    if timing == "late" and ((custom_pass and not has_uuid) or not active_have_uuids):
         raise RuntimeError(
             "pre_grad_custom_pass must implement uuid() to run late "
             "(after cache lookup). Either implement uuid() or set "
@@ -963,10 +969,10 @@ class FxGraphHashDetails:
         self.joint_custom_post_pass = self._get_custom_pass_detail(
             config.joint_custom_post_pass
         )
-        self._pre_fusion_custom_pass = self._get_custom_pass_detail_unsafe(
+        self._pre_fusion_custom_pass = self._get_scheduler_pass_detail(
             config._pre_fusion_custom_pass
         )
-        self._fuse_ddp_communication_passes = self._get_custom_pass_detail_unsafe(
+        self._fuse_ddp_communication_passes = self._get_scheduler_pass_details(
             config._fuse_ddp_communication_passes
         )
 
@@ -987,6 +993,37 @@ class FxGraphHashDetails:
         self._custom_partitioner_fn = self._get_custom_partitioner_fn_detail(
             config.custom_partitioner_fn
         )
+        active_passes = get_active_passes()
+        # Include context-manager based passes in the cache key.
+        if resolve_pre_grad_pass_timing() != "early":
+            self.active_pre_grad_custom_passes = self._get_custom_pass_details(
+                active_passes.pre_grad_passes
+            )
+        self.active_joint_custom_pre_passes = self._get_custom_pass_details(
+            active_passes.joint_pre_passes
+        )
+        self.active_joint_custom_post_passes = self._get_custom_pass_details(
+            active_passes.joint_post_passes
+        )
+        self.active_post_grad_custom_pre_passes = self._get_custom_pass_details(
+            active_passes.post_grad_pre_passes
+        )
+        self.active_post_grad_custom_post_passes = self._get_custom_pass_details(
+            active_passes.post_grad_post_passes
+        )
+        self.active_custom_backend_passes = tuple(
+            (
+                device,
+                self._get_custom_pass_detail_maybe(custom_backend_pass),
+            )
+            for device, custom_backend_pass in active_passes.custom_backend_passes
+        )
+        self.active_pre_fusion_custom_passes = self._get_scheduler_pass_details(
+            active_passes.pre_fusion_custom_passes
+        )
+        self.active_post_fusion_custom_passes = self._get_scheduler_pass_details(
+            active_passes.post_fusion_custom_passes
+        )
 
         # Include hint overrides in the cache key because _reduce_symint
         # only hashes symbol names, not hint values.
@@ -1000,20 +1037,15 @@ class FxGraphHashDetails:
                 )
             }
 
-    # This is mainly added to handle these two inductor configs, which are (unfortunately)
-    # sometimes cache safe:
-    # - _pre_fusion_custom_pass
-    # - _fuse_ddp_communication_passes
-    # Their types can be found in `torch/_inductor/config.py`, but:
-    # - if they are string names, we can cache them safely (one is by default)
-    # - if any of them are set to custom callables, we will need to cache miss
-    # Future work is for someone to find any places where these functions are used
-    # and force them to be of type CustomGraphPass, so we can guarantee serialization.
-    def _get_custom_pass_detail_unsafe(self, custom_pass: Any) -> Any | None:
+    # Scheduler/comms pass hooks intentionally accept string pass names in
+    # addition to CustomGraphPass instances. For hashing:
+    # - strings are stable and can be included directly
+    # - CustomGraphPass uses uuid()
+    # - arbitrary callables are normalized to None and subsequently rejected
+    #   by FxGraphCache._check_can_cache, which triggers explicit cache bypass
+    def _get_scheduler_pass_detail(self, custom_pass: Any) -> Any | None:
         if not custom_pass:
             return None
-        if isinstance(custom_pass, list):
-            return [self._get_custom_pass_detail_unsafe(x) for x in custom_pass]
         if isinstance(custom_pass, str):
             return custom_pass
         if isinstance(custom_pass, CustomGraphPass):
@@ -1022,7 +1054,7 @@ class FxGraphHashDetails:
             # Returning None is safe here because we raise an explicit bypass error
             # later if we detect these passes are set to callables
             return None
-        raise AssertionError(f"unknown config type: {str(type(custom_pass))}")
+        raise AssertionError(f"unknown scheduler pass type: {str(type(custom_pass))}")
 
     def _get_custom_pass_detail(
         self, custom_pass: CustomGraphPassType | CustomGraphModulePass
@@ -1031,6 +1063,27 @@ class FxGraphHashDetails:
             return None
         assert isinstance(custom_pass, (CustomGraphPass, CustomGraphModulePass))
         return custom_pass.uuid()
+
+    def _get_custom_pass_detail_maybe(self, custom_pass: Any) -> Any | None:
+        if not custom_pass:
+            return None
+        if isinstance(custom_pass, (CustomGraphPass, CustomGraphModulePass)):
+            return custom_pass.uuid()
+        raise AssertionError(f"unknown custom pass type: {str(type(custom_pass))}")
+
+    def _get_custom_pass_details(self, custom_passes: Sequence[Any]) -> tuple[Any, ...]:
+        return tuple(
+            self._get_custom_pass_detail_maybe(custom_pass)
+            for custom_pass in custom_passes
+        )
+
+    def _get_scheduler_pass_details(
+        self, scheduler_passes: Sequence[Any]
+    ) -> tuple[Any, ...]:
+        return tuple(
+            self._get_scheduler_pass_detail(scheduler_pass)
+            for scheduler_pass in scheduler_passes
+        )
 
     def _get_custom_partitioner_fn_detail(
         self, custom_partitioner_fn: CustomPartitionerFnType
@@ -1622,6 +1675,8 @@ class FxGraphCache(GuardedCache[CompiledFxGraph]):
         Check some conditions that would preclude caching and raise BypassFxGraphCache
         to bypass in case caching is not possible.
         """
+        active_passes = get_active_passes()
+
         # Custom passes must implement the CustomGraphPass or we don't
         # know how to include them in the cache key calculation.
         # When timing is EARLY, pre-grad passes already ran before the cache
@@ -1631,13 +1686,36 @@ class FxGraphCache(GuardedCache[CompiledFxGraph]):
                 isinstance(config.pre_grad_custom_pass, CustomGraphPass)
                 and config.pre_grad_custom_pass.uuid()
             ), "Unsupported pre grad custom pass"
+            for p in active_passes.pre_grad_passes:
+                if not isinstance(p, CustomGraphPass) or not p.uuid():
+                    raise BypassFxGraphCache("Unsupported pre grad custom pass")
         for p in (config.post_grad_custom_pre_pass, config.post_grad_custom_post_pass):
             if p and (not isinstance(p, CustomGraphPass) or not p.uuid()):
+                raise BypassFxGraphCache("Unsupported post grad custom pass")
+        for p in (
+            *active_passes.post_grad_pre_passes,
+            *active_passes.post_grad_post_passes,
+        ):
+            if not isinstance(p, CustomGraphPass) or not p.uuid():
                 raise BypassFxGraphCache("Unsupported post grad custom pass")
         # Same with the joint custom passes
         for p in (config.joint_custom_pre_pass, config.joint_custom_post_pass):
             if p and (not isinstance(p, CustomGraphPass) or not p.uuid()):
                 raise BypassFxGraphCache("Unsupported joint custom pass")
+        for p in (*active_passes.joint_pre_passes, *active_passes.joint_post_passes):
+            if not isinstance(p, CustomGraphPass) or not p.uuid():
+                raise BypassFxGraphCache("Unsupported joint custom pass")
+
+        for _, p in active_passes.custom_backend_passes:
+            if not isinstance(p, CustomGraphModulePass) or not p.uuid():
+                raise BypassFxGraphCache("Unsupported custom backend pass")
+
+        for p in (
+            *active_passes.pre_fusion_custom_passes,
+            *active_passes.post_fusion_custom_passes,
+        ):
+            if callable(p) and not isinstance(p, CustomGraphPass):
+                raise BypassFxGraphCache("Unsupported scheduler custom pass")
         # We should find any users of _pre_fusion_custom_pass and _fuse_ddp_communication_passes
         # and ensure they are not passing us raw callables
         if config._pre_fusion_custom_pass is not None:

--- a/torch/_inductor/custom_graph_pass.py
+++ b/torch/_inductor/custom_graph_pass.py
@@ -1,6 +1,9 @@
 import hashlib
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Mapping, Sequence
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
 from functools import lru_cache
 from typing import Any, TYPE_CHECKING, TypeAlias
 
@@ -105,6 +108,229 @@ class CustomInferenceAwareGraphPass(CustomGraphPass):
 CustomGraphPassType: TypeAlias = (
     CustomGraphPass | Callable[[torch.fx.graph.Graph], None] | None
 )
+CustomGraphModulePassType: TypeAlias = (
+    CustomGraphModulePass | Callable[[torch.fx.GraphModule], None] | None
+)
+SchedulerCustomPassType: TypeAlias = Callable[[list[Any]], list[Any]]
+
+
+@dataclass(frozen=True)
+class ActiveCustomPasses:
+    pre_grad_passes: tuple[
+        CustomGraphPass | Callable[[torch.fx.graph.Graph], None], ...
+    ] = ()
+    joint_pre_passes: tuple[
+        CustomGraphPass | Callable[[torch.fx.graph.Graph], None], ...
+    ] = ()
+    joint_post_passes: tuple[
+        CustomGraphPass | Callable[[torch.fx.graph.Graph], None], ...
+    ] = ()
+    post_grad_pre_passes: tuple[
+        CustomGraphPass | Callable[[torch.fx.graph.Graph], None], ...
+    ] = ()
+    post_grad_post_passes: tuple[
+        CustomGraphPass | Callable[[torch.fx.graph.Graph], None], ...
+    ] = ()
+    custom_backend_passes: tuple[
+        tuple[str, CustomGraphModulePass | Callable[[torch.fx.GraphModule], None]], ...
+    ] = ()
+    pre_fusion_custom_passes: tuple[SchedulerCustomPassType, ...] = ()
+    post_fusion_custom_passes: tuple[SchedulerCustomPassType, ...] = ()
+
+
+_active_custom_passes_stack: ContextVar[tuple[ActiveCustomPasses, ...]] = ContextVar(
+    "_active_custom_passes_stack", default=()
+)
+_CONFIG_TO_CONTEXT_FIELD_MAP: dict[str, str] = {
+    "pre_grad_custom_pass": "pre_grad_passes",
+    "joint_custom_pre_pass": "joint_pre_passes",
+    "joint_custom_post_pass": "joint_post_passes",
+    "post_grad_custom_pre_pass": "post_grad_pre_passes",
+    "post_grad_custom_post_pass": "post_grad_post_passes",
+    "_pre_fusion_custom_pass": "pre_fusion_custom_passes",
+    "_post_fusion_custom_pass": "post_fusion_custom_passes",
+}
+
+
+def split_custom_passes_from_config_patch(
+    config_patch: Mapping[str, Any],
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """
+    Migration helper for custom pass config fields.
+
+    Given an old-style inductor config patch dict, return:
+    1) kwargs for custom_pass_context(...)
+    2) the remaining config patch dict without custom pass fields
+    """
+    custom_pass_context_kwargs: dict[str, list[Any]] = {}
+    remaining_config_patch: dict[str, Any] = {}
+
+    for field_name, value in config_patch.items():
+        context_field = _CONFIG_TO_CONTEXT_FIELD_MAP.get(field_name)
+        if context_field is None:
+            remaining_config_patch[field_name] = value
+            continue
+        if value is None:
+            continue
+        custom_pass_context_kwargs.setdefault(context_field, []).append(value)
+
+    return custom_pass_context_kwargs, remaining_config_patch
+
+
+@contextmanager
+def patched_inductor_config_with_custom_pass_context(
+    config_patch: Mapping[str, Any],
+):
+    """
+    Apply a mixed old-style inductor config patch using custom_pass_context for
+    custom pass fields and config.patch for all other fields.
+
+    This is intended as a transition helper while migrating from
+    torch._inductor.config.<custom_pass_field> to custom_pass_context(...).
+    """
+    custom_pass_context_kwargs, remaining_config_patch = (
+        split_custom_passes_from_config_patch(config_patch)
+    )
+    from . import config as inductor_config
+
+    with (
+        inductor_config.patch(remaining_config_patch),
+        custom_pass_context(**custom_pass_context_kwargs),
+    ):
+        yield
+
+
+def _normalize_graph_passes(
+    passes: Sequence[CustomGraphPassType] | None,
+) -> tuple[CustomGraphPass | Callable[[torch.fx.graph.Graph], None], ...]:
+    if passes is None:
+        return ()
+    return tuple(p for p in passes if p is not None)
+
+
+def _normalize_scheduler_passes(
+    passes: Sequence[SchedulerCustomPassType] | None,
+) -> tuple[SchedulerCustomPassType, ...]:
+    if passes is None:
+        return ()
+    return tuple(passes)
+
+
+def _normalize_backend_passes(
+    custom_backend_passes: (
+        Mapping[str, CustomGraphModulePassType | Sequence[CustomGraphModulePassType]]
+        | Sequence[tuple[str, CustomGraphModulePassType]]
+        | None
+    ),
+) -> tuple[
+    tuple[str, CustomGraphModulePass | Callable[[torch.fx.GraphModule], None]], ...
+]:
+    if custom_backend_passes is None:
+        return ()
+
+    normalized: list[
+        tuple[str, CustomGraphModulePass | Callable[[torch.fx.GraphModule], None]]
+    ] = []
+    if isinstance(custom_backend_passes, Mapping):
+        items = custom_backend_passes.items()
+    else:
+        items = custom_backend_passes
+
+    for device, custom_pass in items:
+        if custom_pass is None:
+            continue
+        if isinstance(custom_pass, Sequence) and not isinstance(
+            custom_pass, (str, bytes)
+        ):
+            for p in custom_pass:
+                if p is not None:
+                    normalized.append((device, p))
+        else:
+            normalized.append((device, custom_pass))
+    return tuple(normalized)
+
+
+def get_active_passes() -> ActiveCustomPasses:
+    stack = _active_custom_passes_stack.get()
+    if not stack:
+        return ActiveCustomPasses()
+
+    pre_grad_passes: list[CustomGraphPass | Callable[[torch.fx.graph.Graph], None]] = []
+    joint_pre_passes: list[
+        CustomGraphPass | Callable[[torch.fx.graph.Graph], None]
+    ] = []
+    joint_post_passes: list[
+        CustomGraphPass | Callable[[torch.fx.graph.Graph], None]
+    ] = []
+    post_grad_pre_passes: list[
+        CustomGraphPass | Callable[[torch.fx.graph.Graph], None]
+    ] = []
+    post_grad_post_passes: list[
+        CustomGraphPass | Callable[[torch.fx.graph.Graph], None]
+    ] = []
+    backend_passes: list[
+        tuple[str, CustomGraphModulePass | Callable[[torch.fx.GraphModule], None]]
+    ] = []
+    pre_fusion_custom_passes: list[SchedulerCustomPassType] = []
+    post_fusion_custom_passes: list[SchedulerCustomPassType] = []
+
+    for active_passes in stack:
+        pre_grad_passes.extend(active_passes.pre_grad_passes)
+        joint_pre_passes.extend(active_passes.joint_pre_passes)
+        joint_post_passes.extend(active_passes.joint_post_passes)
+        post_grad_pre_passes.extend(active_passes.post_grad_pre_passes)
+        post_grad_post_passes.extend(active_passes.post_grad_post_passes)
+        backend_passes.extend(active_passes.custom_backend_passes)
+        pre_fusion_custom_passes.extend(active_passes.pre_fusion_custom_passes)
+        post_fusion_custom_passes.extend(active_passes.post_fusion_custom_passes)
+
+    return ActiveCustomPasses(
+        pre_grad_passes=tuple(pre_grad_passes),
+        joint_pre_passes=tuple(joint_pre_passes),
+        joint_post_passes=tuple(joint_post_passes),
+        post_grad_pre_passes=tuple(post_grad_pre_passes),
+        post_grad_post_passes=tuple(post_grad_post_passes),
+        custom_backend_passes=tuple(backend_passes),
+        pre_fusion_custom_passes=tuple(pre_fusion_custom_passes),
+        post_fusion_custom_passes=tuple(post_fusion_custom_passes),
+    )
+
+
+@contextmanager
+def custom_pass_context(
+    *,
+    pre_grad_passes: Sequence[CustomGraphPassType] | None = None,
+    joint_pre_passes: Sequence[CustomGraphPassType] | None = None,
+    joint_post_passes: Sequence[CustomGraphPassType] | None = None,
+    post_grad_pre_passes: Sequence[CustomGraphPassType] | None = None,
+    post_grad_post_passes: Sequence[CustomGraphPassType] | None = None,
+    custom_backend_passes: (
+        Mapping[str, CustomGraphModulePassType | Sequence[CustomGraphModulePassType]]
+        | Sequence[tuple[str, CustomGraphModulePassType]]
+        | None
+    ) = None,
+    pre_fusion_custom_passes: Sequence[SchedulerCustomPassType] | None = None,
+    post_fusion_custom_passes: Sequence[SchedulerCustomPassType] | None = None,
+):
+    active_passes = ActiveCustomPasses(
+        pre_grad_passes=_normalize_graph_passes(pre_grad_passes),
+        joint_pre_passes=_normalize_graph_passes(joint_pre_passes),
+        joint_post_passes=_normalize_graph_passes(joint_post_passes),
+        post_grad_pre_passes=_normalize_graph_passes(post_grad_pre_passes),
+        post_grad_post_passes=_normalize_graph_passes(post_grad_post_passes),
+        custom_backend_passes=_normalize_backend_passes(custom_backend_passes),
+        pre_fusion_custom_passes=_normalize_scheduler_passes(pre_fusion_custom_passes),
+        post_fusion_custom_passes=_normalize_scheduler_passes(
+            post_fusion_custom_passes
+        ),
+    )
+    token = _active_custom_passes_stack.set(
+        _active_custom_passes_stack.get() + (active_passes,)
+    )
+    try:
+        yield active_passes
+    finally:
+        _active_custom_passes_stack.reset(token)
 
 
 @lru_cache(1)

--- a/torch/_inductor/fx_passes/joint_graph.py
+++ b/torch/_inductor/fx_passes/joint_graph.py
@@ -24,6 +24,7 @@ from torch.multiprocessing.reductions import StorageWeakRef
 from torch.utils._ordered_set import OrderedSet
 
 from .. import config
+from ..custom_graph_pass import get_active_passes
 from ..pattern_matcher import (
     Arg,
     CallFunction,
@@ -635,9 +636,13 @@ def joint_graph_passes(
     # must occur before other passes
     canonicalize_aten_ir_passes(graph)
 
+    joint_pre_custom_passes = []
     if config.joint_custom_pre_pass is not None:
-        GraphTransformObserver(graph, "joint_custom_pre_pass").apply_graph_pass(
-            config.joint_custom_pre_pass
+        joint_pre_custom_passes.append(config.joint_custom_pre_pass)
+    joint_pre_custom_passes.extend(get_active_passes().joint_pre_passes)
+    for idx, joint_custom_pre_pass in enumerate(joint_pre_custom_passes):
+        GraphTransformObserver(graph, f"joint_custom_pre_pass_{idx}").apply_graph_pass(
+            joint_custom_pre_pass
         )
         count += 1
 
@@ -678,9 +683,13 @@ def joint_graph_passes(
         # we'll instead explicitly turn off the config
         count += replace_random_passes(graph)
 
+    joint_post_custom_passes = []
     if config.joint_custom_post_pass is not None:
-        GraphTransformObserver(graph, "joint_custom_post_pass").apply_graph_pass(
-            config.joint_custom_post_pass
+        joint_post_custom_passes.append(config.joint_custom_post_pass)
+    joint_post_custom_passes.extend(get_active_passes().joint_post_passes)
+    for idx, joint_custom_post_pass in enumerate(joint_post_custom_passes):
+        GraphTransformObserver(graph, f"joint_custom_post_pass_{idx}").apply_graph_pass(
+            joint_custom_post_pass
         )
         count += 1
 

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -16,7 +16,11 @@ from torch import fx
 from torch._decomp import register_decomposition
 from torch._dynamo.utils import counters
 from torch._inductor import comms
-from torch._inductor.custom_graph_pass import CustomInferenceAwareGraphPass
+from torch._inductor.custom_graph_pass import (
+    CustomGraphModulePass,
+    CustomInferenceAwareGraphPass,
+    get_active_passes,
+)
 from torch._inductor.virtualized import ops  # noqa: F401
 from torch._logging import trace_structured
 from torch._prims_common import is_boolean_dtype, is_expandable_to, is_integer_dtype
@@ -137,12 +141,16 @@ def post_grad_passes(gm: torch.fx.GraphModule, is_inference: bool):
 
     fake_tensor_updater = FakeTensorUpdater(gm.graph)
 
+    post_grad_pre_custom_passes = []
     if post_grad_custom_pre_pass := config.post_grad_custom_pre_pass:
+        post_grad_pre_custom_passes.append(post_grad_custom_pre_pass)
+    post_grad_pre_custom_passes.extend(get_active_passes().post_grad_pre_passes)
+    for idx, post_grad_custom_pre_pass in enumerate(post_grad_pre_custom_passes):
         if isinstance(post_grad_custom_pre_pass, CustomInferenceAwareGraphPass):
             post_grad_custom_pre_pass = functools.partial(
                 post_grad_custom_pre_pass, is_inference=is_inference
             )
-        GraphTransformObserver(gm, "post_grad_custom_pre_pass").apply_graph_pass(
+        GraphTransformObserver(gm, f"post_grad_custom_pre_pass_{idx}").apply_graph_pass(
             post_grad_custom_pre_pass
         )
 
@@ -221,14 +229,19 @@ def post_grad_passes(gm: torch.fx.GraphModule, is_inference: bool):
             )
         )
 
+    post_grad_post_custom_passes = []
     if post_grad_custom_post_pass := config.post_grad_custom_post_pass:
+        post_grad_post_custom_passes.append(post_grad_custom_post_pass)
+    active_passes = get_active_passes()
+    post_grad_post_custom_passes.extend(active_passes.post_grad_post_passes)
+    for idx, post_grad_custom_post_pass in enumerate(post_grad_post_custom_passes):
         if isinstance(post_grad_custom_post_pass, CustomInferenceAwareGraphPass):
             post_grad_custom_post_pass = functools.partial(
                 post_grad_custom_post_pass, is_inference=is_inference
             )
-        GraphTransformObserver(gm, "post_grad_custom_post_pass").apply_graph_pass(
-            post_grad_custom_post_pass
-        )
+        GraphTransformObserver(
+            gm, f"post_grad_custom_post_pass_{idx}"
+        ).apply_graph_pass(post_grad_custom_post_pass)
 
     GraphTransformObserver(gm, "stable_sort").apply_graph_pass(stable_topological_sort)
 
@@ -238,12 +251,18 @@ def post_grad_passes(gm: torch.fx.GraphModule, is_inference: bool):
 
     fake_tensor_updater.incremental_update()
 
+    backend_passes_by_device: list[
+        tuple[str, CustomGraphModulePass | Callable[[torch.fx.GraphModule], None]]
+    ] = []
     for device, custom_backend_pass in custom_backend_passes.items():
         if custom_backend_pass is not None:
-            gm_devices = [d.type for d in get_all_devices(gm)]
-            if device in gm_devices:
-                pass_name = "custom_backend_passes_" + device
-                GraphTransformObserver(gm, pass_name).apply_gm_pass(custom_backend_pass)
+            backend_passes_by_device.append((device, custom_backend_pass))
+    backend_passes_by_device.extend(active_passes.custom_backend_passes)
+    gm_devices = [d.type for d in get_all_devices(gm)]
+    for idx, (device, custom_backend_pass) in enumerate(backend_passes_by_device):
+        if device in gm_devices:
+            pass_name = f"custom_backend_passes_{device}_{idx}"
+            GraphTransformObserver(gm, pass_name).apply_gm_pass(custom_backend_pass)
 
     collectives_bucketing: bool = False
 

--- a/torch/_inductor/fx_passes/pre_grad.py
+++ b/torch/_inductor/fx_passes/pre_grad.py
@@ -22,6 +22,7 @@ from torch.nn import functional as F
 from torch.nn.utils.fusion import fuse_conv_bn_eval, fuse_conv_bn_weights
 
 from .. import config
+from ..custom_graph_pass import get_active_passes
 from ..fx_utils import matches_module_function_pattern
 from ..pattern_matcher import (
     init_once_fakemode,
@@ -353,9 +354,13 @@ def pre_grad_passes(
                 apply_gumbel_max_trick_pass.apply
             )
 
+    custom_pre_grad_passes = []
     if config.pre_grad_custom_pass is not None:
-        GraphTransformObserver(gm, "pre_grad_custom_pass").apply_graph_pass(
-            config.pre_grad_custom_pass
+        custom_pre_grad_passes.append(config.pre_grad_custom_pass)
+    custom_pre_grad_passes.extend(get_active_passes().pre_grad_passes)
+    for idx, custom_pre_grad_pass in enumerate(custom_pre_grad_passes):
+        GraphTransformObserver(gm, f"pre_grad_custom_pass_{idx}").apply_graph_pass(
+            custom_pre_grad_pass
         )
 
     stable_topological_sort(gm.graph)

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -54,6 +54,7 @@ from .comm_analysis import (
     estimate_nccl_collective_runtime,
     estimate_nccl_collective_runtime_nccl_estimator,
 )
+from .custom_graph_pass import get_active_passes
 from .dependencies import Dep, MemoryDep, StarDep, WeakDep
 from .exc import GPUTooOldForTriton, TritonMissing
 from .fx_utils import count_flops_fx
@@ -3112,8 +3113,12 @@ class Scheduler:
         self.create_foreach_nodes()
         self.nodes = self.topological_sort_schedule(self.nodes)
         self.logged_slow_fusion = OrderedSet[tuple[str, str]]()
+        pre_fusion_custom_passes = []
         if config._pre_fusion_custom_pass is not None:
-            self.nodes = config._pre_fusion_custom_pass(self.nodes)
+            pre_fusion_custom_passes.append(config._pre_fusion_custom_pass)
+        pre_fusion_custom_passes.extend(get_active_passes().pre_fusion_custom_passes)
+        for pre_fusion_custom_pass in pre_fusion_custom_passes:
+            self.nodes = pre_fusion_custom_pass(self.nodes)
 
         if config.distributed_max_autotune_gemm:
             from . import distributed_autotune
@@ -3129,8 +3134,12 @@ class Scheduler:
         self._populate_stream_assignments()
 
         self.nodes = self.fuse_nodes(self.nodes)
+        post_fusion_custom_passes = []
         if config._post_fusion_custom_pass is not None:
-            self.nodes = config._post_fusion_custom_pass(self.nodes)
+            post_fusion_custom_passes.append(config._post_fusion_custom_pass)
+        post_fusion_custom_passes.extend(get_active_passes().post_fusion_custom_passes)
+        for post_fusion_custom_pass in post_fusion_custom_passes:
+            self.nodes = post_fusion_custom_pass(self.nodes)
 
         if any(
             isinstance(node, FusedExternTritonKernelSchedulerNode)


### PR DESCRIPTION

Introduces `custom_pass_context`, a context manager based mechanism for registering custom Inductor FX passes. This replaces the existing pattern of assigning stateful objects directly to Inductor config fields, which caused config serialization failures and broken FX graph caching.

The existing custom pass registration mechanism relied on assigning callable objects directly to Inductor config fields:

    config.post_grad_custom_pre_pass = MyPass()

This had several fundamental issues:

1. **Caching breakage**: Config fields are serialized to compute FX graph    cache keys. Stateful Python objects are not reliably serializable,    causing cache misses, errors, or incorrect cache hits.

2. **Silent overwrite**: Assigning a config field twice silently drops the    first pass with no warning. Multiple independent libraries (e.g. vLLM,    torch-ao) cannot safely coexist.

3. **No scoping**: Passes assigned to config fields are global and    permanent for the process lifetime, leaking across unrelated    torch.compile() calls (e.g. CPU passes leaking into GPU compilations).

4. **Wrong argument type**: Config-based passes receive `torch.fx.Graph`    rather than `torch.fx.GraphModule`, preventing passes from calling    `gm.recompile()` after editing the graph.

    with custom_pass_context(post_grad_post_passes=[MyPass()]):         torch.compile(model)(x)

Passes are:
- **Scoped**: automatically removed when the `with` block exits
- **Composable**: multiple libraries nest their own contexts independently
- **Ordered**: inner context passes run before outer context passes,   giving deterministic, code-visible ordering without enums or priority   flags
- **Cache-safe**: `uuid()` from `CustomGraphPass`/`CustomGraphModulePass`   is used to contribute to the FX graph cache key instead of hashing   the object itself

Supported stages via keyword arguments:
  - `pre_grad_passes`
  - `joint_pre_passes` / `joint_post_passes`
  - `post_grad_pre_passes` / `post_grad_post_passes`   - `custom_backend_passes` (device-keyed)
  - `pre_fusion_custom_passes` / `post_fusion_custom_passes`

Uses `contextvars.ContextVar` for the pass stack, making it safe for both multi-threaded and async compilation workloads.

All existing config-based custom pass fields now emit `DeprecatedCustomPassConfigWarning` when used:

  - `pre_grad_custom_pass`
  - `joint_custom_pre_pass` / `joint_custom_post_pass`   - `post_grad_custom_pre_pass` / `post_grad_custom_post_pass`   - `_pre_fusion_custom_pass` / `_post_fusion_custom_pass`

Old-style passes continue to work during the deprecation period and execute before context-manager passes for backward compatibility.

Two utilities ease migration from config-based passes:

  `split_custom_passes_from_config_patch(config_patch)` — splits a   mixed config dict into `custom_pass_context` kwargs and remaining   non-pass config options.

  `patched_inductor_config_with_custom_pass_context(config_patch)` — a   context manager that applies a mixed config dict, routing custom pass   fields through `custom_pass_context` and non-pass fields through   `config.patch`.

`FxGraphHashDetails` now includes all active context-manager passes in the cache key via their `uuid()` return values. `FxGraphCache._check_can_cache` validates that all active passes implement the required interface and raises `BypassFxGraphCache` with a clear message if not.

`_get_custom_pass_detail_unsafe` is renamed to `_get_scheduler_pass_detail` with an updated docstring accurately reflecting its handling of string pass names, `CustomGraphPass` instances, and raw callables.

- `test_custom_post_grad_context_pass` — basic post-grad pass via context
- `test_custom_joint_pre_context_pass` — joint pre-pass via context
- `test_custom_joint_post_context_pass` — joint post-pass via context
- `test_custom_pre_grad_context_pass` — pre-grad pass via context
- `test_custom_backend_context_pass` — device-keyed backend pass via context
- `test_nested_custom_pass_contexts` — nested contexts, correct ordering
- `test_two_libraries_custom_pass_context` — two independent libraries   using ExitStack, no interference
- `test_custom_pass_context_does_not_leak` — passes do not persist after   context exit
- `test_deprecated_config_custom_pass_warning_emitted` — deprecation   warning fires on config field usage
- `test_split_custom_passes_from_config_patch` — migration helper unit test
- `test_patched_inductor_config_with_custom_pass_context` — migration   helper integration test
- `test_custom_pass_context_uuid_cache_hit_miss` — uuid change produces   cache miss, same uuid produces cache hit

Before:

    torch._inductor.config.post_grad_custom_pre_pass = MyPass()

After:

    from torch._inductor.custom_graph_pass import (         custom_pass_context, CustomGraphPass
    )

    class MyPass(CustomGraphPass):
        def __call__(self, graph): ...
        def uuid(self): return "my_library_my_pass_v1"

    def my_compile(model):
        with custom_pass_context(post_grad_pre_passes=[MyPass()]):             return torch.compile(model)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo