### PR TITLE
[Test] Make dynamo device-type tests generic for out-of-tree backends

### DIFF
--- a/test/dynamo/test_activation_checkpointing.py
+++ b/test/dynamo/test_activation_checkpointing.py
@@ -2475,9 +2475,8 @@ def forward(self, arg0_1):
         )
 
 
-devices = ["cuda", "hpu"]
 instantiate_device_type_tests(
-    ActivationCheckpointingViaTagsTests, globals(), only_for=devices
+    ActivationCheckpointingViaTagsTests, globals(), except_for="cpu"
 )
 
 if __name__ == "__main__":

--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -4668,8 +4668,7 @@ class ExportTestsDevice(torch._dynamo.test_case.TestCase):
 
 
 common_utils.instantiate_parametrized_tests(ExportTests)
-devices = ["cuda", "hpu"]
-instantiate_device_type_tests(ExportTestsDevice, globals(), only_for=devices)
+instantiate_device_type_tests(ExportTestsDevice, globals(), except_for="cpu")
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/test/dynamo/test_modules.py
+++ b/test/dynamo/test_modules.py
@@ -3637,9 +3637,8 @@ class OptimizedModuleTest(torch._dynamo.test_case.TestCase):
         self.assertTrue(torch.allclose(output_eager, output))
 
 
-devices = ["cuda", "hpu", "xpu"]
 instantiate_device_type_tests(
-    NNModuleTestsDevice, globals(), only_for=devices, allow_xpu=True
+    NNModuleTestsDevice, globals(), except_for="cpu", allow_xpu=True
 )
 
 if __name__ == "__main__":


### PR DESCRIPTION
Replace hardcoded device lists in only_for with except_for so that PrivateUse1 backends are automatically included without needing the PYTORCH_TESTING_DEVICE_FOR_CUSTOM environment variable.

Files changed:
 - test/dynamo/test_modules.py
 - test/dynamo/test_activation_checkpointing.py
 - test/dynamo/test_export.py

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98