### PR TITLE
[inductor] Fix nan_asserts for FP8 dtypes

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -17738,11 +17738,10 @@ if RUN_GPU:
                 self.assertIn("aoti_torch_check_inf_and_nan", code)
             else:
                 self.assertIn("# make sure graph inputs are not nan/inf", code)
+                self.assertIn("_assert_no_nan_or_inf(", code)
                 self.assertRegex(code, r"return_vars = (.*)")
                 self.assertIn("for var in return_vars:", code)
                 self.assertIn("if isinstance(var, torch.Tensor):", code)
-                self.assertRegex(code, r"assert not .*\.isnan\(\)\.any\(\).item\(\)")
-                self.assertRegex(code, r"assert not .*\.isinf\(\)\.any\(\).item\(\)")
 
         @config.patch("nan_asserts", True)
         def test_nan_checker_fail(self):
@@ -17755,6 +17754,15 @@ if RUN_GPU:
                 AssertionError if not config.cpp_wrapper else RuntimeError
             ):
                 torch.compile(f)(x)
+
+        @config.patch("nan_asserts", True)
+        def test_nan_checker_fp8(self):
+            def f(x):
+                return x.half() + 1
+
+            x = torch.randn(10, device=GPU_TYPE).to(torch.float8_e4m3fn)
+            # Should not raise RuntimeError for isinf/isnan on FP8
+            torch.compile(f, fullgraph=True)(x)
 
 
 if RUN_CPU:

--- a/torch/_inductor/codegen/multi_kernel.py
+++ b/torch/_inductor/codegen/multi_kernel.py
@@ -257,10 +257,7 @@ class MultiKernel:
                     continue
                 seen.add(arg)
                 if isinstance(precompile_arg, TensorArg):
-                    line = f"assert not {arg}.isnan().any().item()"
-                    wrapper.writeline(line)
-                    line = f"assert not {arg}.isinf().any().item()"
-                    wrapper.writeline(line)
+                    wrapper.writeline(f"_assert_no_nan_or_inf({arg})")
 
     @property
     def removed_buffers(self):

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -5972,10 +5972,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                         f'AOTI_TORCH_ERROR_CODE_CHECK(aoti_torch_check_inf_and_nan("{arg}", {arg}));'
                     )
                 else:
-                    line = f"assert not {arg}.isnan().any().item()"
-                    wrapper.writeline(line)
-                    line = f"assert not {arg}.isinf().any().item()"
-                    wrapper.writeline(line)
+                    wrapper.writeline(f"_assert_no_nan_or_inf({arg})")
 
     def create_cse_var(self, *args, **kwargs) -> TritonCSEVariable:
         return TritonCSEVariable(*args, **kwargs)

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -1341,6 +1341,9 @@ class PythonWrapperCodegen(CodeGen):
             inductor_debug_utils = "from torch._inductor.codegen.debug_utils import _print_debugging_tensor_value_info"
         elif torch._inductor.config.test_configs.track_memory_lifecycle:
             inductor_debug_utils = "from torch._inductor.runtime.debug_utils import tracked_empty_strided\n"
+        nan_assert_import = ""
+        if config.nan_asserts:
+            nan_assert_import = "from torch._inductor.runtime.runtime_utils import _assert_no_nan_or_inf"
 
         self.imports.splice(
             f"""
@@ -1360,6 +1363,7 @@ class PythonWrapperCodegen(CodeGen):
                 from {async_compile.__name__} import AsyncCompile
                 from torch._inductor.select_algorithm import extern_kernels
                 {inductor_debug_utils}
+                {nan_assert_import}
             """,
             strip=True,
         )
@@ -1562,10 +1566,7 @@ class PythonWrapperCodegen(CodeGen):
             if isinstance(buf, (sympy.Expr, ir.TorchBindObject)):
                 continue
 
-            line = f"assert not {name}.isnan().any().item()"
-            self.prefix.writeline(line)
-            line = f"assert not {name}.isinf().any().item()"
-            self.prefix.writeline(line)
+            self.prefix.writeline(f"_assert_no_nan_or_inf({name})")
 
     def write_async_compile_wait(self) -> None:
         self.prefix.splice(
@@ -1767,8 +1768,7 @@ class PythonWrapperCodegen(CodeGen):
                 self.wrapper_call.do_indent()
                 self.wrapper_call.writeline("if isinstance(var, torch.Tensor):")
                 self.wrapper_call.do_indent()
-                self.wrapper_call.writeline("assert not var.isnan().any().item()")
-                self.wrapper_call.writeline("assert not var.isinf().any().item()")
+                self.wrapper_call.writeline("_assert_no_nan_or_inf(var)")
                 self.wrapper_call.do_unindent(2)
 
             self.wrapper_call.writeline("return (" + ", ".join(output_refs) + ", )")

--- a/torch/_inductor/runtime/runtime_utils.py
+++ b/torch/_inductor/runtime/runtime_utils.py
@@ -52,6 +52,14 @@ def last_power_of_2(n: int) -> int:
     return next_pow2 // 2 if next_pow2 > n else next_pow2
 
 
+def _assert_no_nan_or_inf(t: torch.Tensor) -> None:
+    # FP8 types don't support isnan/isinf, upcast to float first
+    if t.is_floating_point() and t.element_size() == 1:
+        t = t.float()
+    assert not t.isnan().any().item()
+    assert not t.isinf().any().item()
+
+
 def get_num_bytes(*args: torch.Tensor, num_in_out_args: int = 0) -> int:
     """
     Return the total number of bytes the arguments of tensor type takes.


### PR DESCRIPTION
## Summary
- Fix `nan_asserts` crashing with `RuntimeError: "isinf" not implemented for 'Float8_e4m3fn'` when inductor encounters FP8 tensors
- Extract nan/inf checks into `_assert_no_nan_or_inf()` helper that upcasts FP8 tensors to float32 before calling `isnan()`/`isinf()`
- Cover all four Python codegen sites that emit nan/inf assertions

## Motivation
Fixes #149002

When `torch._inductor.config.nan_asserts = True`, the inductor generates `assert not tensor.isnan().any().item()` / `assert not tensor.isinf().any().item()` for graph inputs, outputs, and kernel arguments. FP8 dtypes (`float8_e4m3fn`, `float8_e5m2`, `float8_e4m3fnuz`, `float8_e5m2fnuz`) don't implement `isnan`/`isinf`, so any compiled graph involving FP8 tensors crashes at runtime.

The fix follows the approach suggested in #149002: upcast FP8 tensors prior to the check.

## Changes
- **`torch/_inductor/runtime/runtime_utils.py`**: Add `_assert_no_nan_or_inf()` — detects FP8 via `is_floating_point() and element_size() == 1` and upcasts to float32 before asserting.
- **`torch/_inductor/codegen/wrapper.py`**: Import the helper when `nan_asserts` is enabled; use it in `codegen_input_nan_asserts()` (input checks) and `generate_return()` (output checks).
- **`torch/_inductor/codegen/triton.py`**: Use the helper in `codegen_nan_check()` for the Python wrapper path (C++ path unchanged).
- **`torch/_inductor/codegen/multi_kernel.py`**: Use the helper in `codegen_nan_check()`.
- **`test/inductor/test_torchinductor.py`**: Update assertions in `test_nan_checker_pass` for new codegen pattern; add `test_nan_checker_fp8` reproducing the original crash.

## Test Plan
- `test_nan_checker_pass` — verifies generated code includes `_assert_no_nan_or_inf` calls
- `test_nan_checker_fail` — verifies NaN detection still works end-to-end
- `test_nan_checker_fp8` — reproduces the original issue (FP8 input with `nan_asserts=True`)

```
python -m pytest test/inductor/test_torchinductor.py -xvs -k "NanChecker"
```

cc @henrylhtsang @eellison