### PR TITLE
[docs] Add examples to reduce_scatter documentation

### DIFF
--- a/torch/distributed/_shard/sharded_tensor/api.py
+++ b/torch/distributed/_shard/sharded_tensor/api.py
@@ -859,7 +859,7 @@ class ShardedTensor(ShardedTensorBase):
         Examples:
             >>> # xdoctest: +SKIP
             >>> # All tensors below are of torch.int64 type.
-            >>> # We have 2 process groups, 2 ranks.
+            >>> # We have 2 ranks.
             >>> tensor = torch.arange(2, dtype=torch.int64) + 1 + 2 * rank
             >>> local_tensor = torch.unsqueeze(torch.cat([tensor, tensor + 2]))
             >>> local_tensor
@@ -1096,7 +1096,7 @@ class ShardedTensor(ShardedTensorBase):
 
         Examples:
             >>> # xdoctest: +SKIP
-            >>> # We have 2 process groups, 2 ranks.
+            >>> # We have 2 ranks.
             >>> tensor = torch.arange(4, dtype=torch.int64) + 1 + 2 * rank
             >>> tensor = torch.stack([tensor, tensor])
             >>> tensor

--- a/torch/distributed/nn/functional.py
+++ b/torch/distributed/nn/functional.py
@@ -132,7 +132,7 @@ def _all_gather_base(output_tensor, input_tensor, group=group.WORLD):
 
     Examples:
         >>> # All tensors below are of torch.int64 dtype.
-        >>> # We have 2 process groups, 2 ranks.
+        >>> # We have 2 ranks.
         >>> # xdoctest: +SKIP("incorrect want text")
         >>> output_tensor = torch.zeros(2, dtype=torch.int64)
         >>> output_tensor


### PR DESCRIPTION
Add Examples section to reduce_scatter function docstring, matching the
format used in all_gather. Includes examples for both int64 and complex
tensor types demonstrating the reduce-scatter operation across ranks.

Also fix misleading "We have 2 process groups, 2 ranks" comment to
"We have 2 ranks" across distributed module docstrings - there is only
1 process group with 2 ranks in these examples.


cc @svekars @sekyondaMeta @AlannaBurke