### PR TITLE
[python/3.10 removal] Remove CPython 3.10 holdback for caffe2/test/distributed/elastic/rendezvous (#178071)

### DIFF
--- a/test/distributed/elastic/rendezvous/dynamic_rendezvous_test.py
+++ b/test/distributed/elastic/rendezvous/dynamic_rendezvous_test.py
@@ -1829,7 +1829,7 @@ class IntegrationTest(TestCase):
             def set(self, key, value):
                 pass
 
-        prefix_store = CustomPrefixStore(spec=dist.PrefixStore)
+        prefix_store = CustomPrefixStore()
         prefix_store_class_mock.return_value = prefix_store
         tcp_store = Mock(spec=dist.TCPStore)
         original_addr = "original_addr"


### PR DESCRIPTION
Summary:

Remove CPython 3.10 pin for the 8 rendezvous test targets owned by aml_ai_platform oncall, upgrading them to Python 3.12.

Changes:
- Remove `"python": "3.10"` pin from `caffe2/test/distributed/elastic/rendezvous/PACKAGE`
- Remove 8 entries from `CPYTHON310_HOLDBACK_TARGETS_ALLOWLISTS` in `cpython310_allowlist.bzl`
- Fix Python 3.12 compatibility issue in `dynamic_rendezvous_test.py`: remove `spec=dist.PrefixStore` from `CustomPrefixStore()` call, since `dist.PrefixStore` is already mocked by `patch.object` decorator and Python 3.12 raises `InvalidSpecError` when spec-ing a Mock with another Mock

Test Plan: Ran `buck test fbcode//caffe2/test/distributed/elastic/rendezvous:` — non-etcd tests pass on Python 3.12. Remaining failures are pre-existing (etcd binary missing in sandbox, ASAN heap-use-after-free in C++ teardown, timedelta bug in test_redundancy_transition_to_wait_list_then_join_rendezvous).

Reviewed By: d4l3k, dcci

Differential Revision: D97058526
