### PR TITLE
Fix torch.export DDE in run_decompositions (#178076)

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -10609,6 +10609,28 @@ def forward(self, p_conv_weight, p_conv_bias, p_conv1d_weight, p_conv1d_bias, c_
         )
         self.assertTrue(torch.allclose(core_aten_ep.module()(*inp), m(*inp)))
 
+    def test_export_decomps_isin_dynamic(self):
+        class M(torch.nn.Module):
+            def forward(self, elements, test_elements):
+                return torch.isin(elements, test_elements)
+
+        m = M()
+        elements = torch.tensor([1, 2, 3, 4, 5])
+        test_elements = torch.tensor([2, 4])
+        inp = (elements, test_elements)
+
+        ep = export(
+            m,
+            inp,
+            dynamic_shapes={
+                "elements": {0: Dim("n_elements")},
+                "test_elements": {0: Dim("n_test")},
+            },
+        )
+        decomposed = ep.run_decompositions()
+
+        self.assertEqual(decomposed.module()(*inp), m(*inp))
+
     def test_where_broadcast_preserves_symint(self):
         import torch.fx.experimental._config as config
         from torch._dynamo.source import ConstantSource

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -5387,7 +5387,9 @@ def isin(elements, test_elements, *, assume_unique=False, invert=False):
         else:
             return torch.eq(elements, test_elements)
 
-    if test_elements.numel() < 10.0 * pow(elements.numel(), 0.145):
+    from torch.fx.experimental.symbolic_shapes import guard_or_false
+
+    if guard_or_false(test_elements.numel() < 10.0 * pow(elements.numel(), 0.145)):
         return isin_default(elements, test_elements, invert=invert)
     else:
         return isin_sorting(


### PR DESCRIPTION
Summary:

Fix torch.export DDE in isin decomposition

The isin decomposition was causing a Data-Dependent Error during torch.export
because it directly compared tensor numel() values in a conditional statement.
When using symbolic shapes, this comparison cannot be resolved at trace time.

Wrapped the conditional check with guard_or_false() to properly handle symbolic
shape comparisons. This allows the condition to safely evaluate to False when
dealing with symbolic shapes, ensuring torch.export compatibility.

Changes:
- Import guard_or_false from torch.fx.experimental.symbolic_shapes
- Wrap the numel comparison in guard_or_false() to handle symbolic shapes

Test Plan:
full publish:
```
cd fbsource/fbcode/minimal_viable_ai/models/blue_reels_vdd/v5 && make local-publish-decouple-di
```
unit test:
```
buck2 test --write-build-id /tmp/.tmpO6Ip00 --client-metadata language=python --client-metadata session_id=d0d44823-b61c-4804-992a-b2cacd61d22c --client-metadata id=testify.codelens fbcode//caffe2/test:test_export -- --regex caffe2/test:test_export \- (?:test_export_decomps_isin_dynamic \(.*TestExport\)$|.*TestExport: test_export_decomps_isin_dynamic$) --run-disabled

Reviewed By: varun2784

Differential Revision: D97621895


