### PR TITLE
Fix ninja workdir collisions in BuildExtension

### DIFF
--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -1,6 +1,7 @@
 # mypy: allow-untyped-defs
 import copy
 import glob
+import hashlib
 import importlib
 import importlib.abc
 import os
@@ -113,6 +114,12 @@ def _nt_quote_args(args: list[str] | None) -> list[str]:
     if not args:
         return []
     return [f'"{arg}"' if ' ' in arg else arg for arg in args]
+
+def _get_ninja_build_directory(output_dir: str, objects) -> str:
+    object_paths = [os.path.abspath(obj) for obj in objects]
+    digest = hashlib.sha256("\0".join(object_paths).encode()).hexdigest()[:16]
+    return os.path.join(output_dir, '.ninja', digest)
+
 
 def _find_cuda_home() -> str | None:
     """Find the CUDA install path."""
@@ -932,7 +939,7 @@ class BuildExtension(build_ext):
                 sycl_cflags=sycl_cflags,
                 sycl_post_cflags=sycl_post_cflags,
                 sycl_dlink_post_cflags=sycl_dlink_post_cflags,
-                build_directory=output_dir,
+                build_directory=_get_ninja_build_directory(output_dir, objects),
                 verbose=True,
                 with_cuda=with_cuda,
                 with_sycl=with_sycl)
@@ -1161,7 +1168,7 @@ class BuildExtension(build_ext):
                 sycl_cflags=sycl_cflags,
                 sycl_post_cflags=sycl_post_cflags,
                 sycl_dlink_post_cflags=sycl_dlink_post_cflags,
-                build_directory=output_dir,
+                build_directory=_get_ninja_build_directory(output_dir, objects),
                 verbose=True,
                 with_cuda=with_cuda,
                 with_sycl=with_sycl)


### PR DESCRIPTION
## Summary
- isolate ninja manifests/workdirs for BuildExtension object compilation
- derive a per-compile ninja subdirectory from the object paths instead of writing directly into the shared setuptools output_dir
- keep object output paths unchanged so distutils/setuptools behavior stays intact

## Problem
When multiple `CppExtension`s are compiled in parallel with ninja, setuptools can hand them the same temporary `output_dir`. The current implementation writes `build.ninja` directly into that shared directory and runs ninja from there, so concurrent extension builds can overwrite each other's manifests.

## Testing
- `python3 -m py_compile torch/utils/cpp_extension.py`
- verified the helper yields stable workdirs for the same object set and distinct workdirs for different object sets

Fixes #177265