### PR TITLE
Expose more KinetoEvent Python bindings

### DIFF
--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -882,6 +882,77 @@ class TestProfiler(TestCase):
                                         f"Expected hierarchy '{hierarchy}' in {op_to_module_hierarchy[op_name]}"
                                     )
 
+    @unittest.skipIf(not kineto_available(), "Kineto is required")
+    def test_kineto_event_extra_bindings(self):
+        """Test module_hierarchy, activity_type, get_perf_event_counters,
+        debug_handle, and extra_meta bindings on KinetoEvent, verified
+        against Chrome JSON ground truth."""
+
+        class A(nn.Module):
+            def forward(self, x):
+                return x + 1
+
+        class B(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.A0 = A()
+
+            def forward(self, x):
+                return self.A0.forward(x) * 2
+
+        model = torch.jit.script(B())
+        x = torch.randn(4, 4)
+
+        with profile(
+            activities=[torch.profiler.ProfilerActivity.CPU],
+            with_modules=True,
+        ) as prof:
+            model(x)
+
+        # -- Verify bindings return correct types --
+        events = prof.profiler.kineto_results.events()
+        self.assertGreater(len(events), 0)
+
+        for event in events:
+            self.assertIsInstance(event.module_hierarchy(), list)
+            self.assertIsInstance(event.activity_type(), int)
+            self.assertIsInstance(event.get_perf_event_counters(), list)
+            self.assertIsInstance(event.debug_handle(), int)
+            self.assertIsInstance(event.extra_meta(), dict)
+
+        # -- Cross-check module_hierarchy against Chrome JSON --
+        # Build map from op name -> hierarchy from KinetoEvent binding
+        kineto_hierarchies = {}
+        for event in events:
+            h = event.module_hierarchy()
+            if h:
+                kineto_hierarchies.setdefault(event.name(), []).append(
+                    h[0] if len(h) == 1 else h
+                )
+
+        # Build same map from Chrome JSON export
+        with TemporaryFileName(mode="w+") as fname:
+            prof.export_chrome_trace(fname)
+            with open(fname) as f:
+                trace = json.load(f)
+
+        json_hierarchies = {}
+        for evt in trace.get("traceEvents", []):
+            if "args" in evt and "Module Hierarchy" in evt["args"]:
+                hierarchy = evt["args"]["Module Hierarchy"]
+                if hierarchy:
+                    json_hierarchies.setdefault(
+                        evt["name"], []
+                    ).append(hierarchy)
+
+        # Every hierarchy from the binding should appear in Chrome JSON
+        for op_name, hierarchies in kineto_hierarchies.items():
+            self.assertIn(
+                op_name, json_hierarchies,
+                f"Op '{op_name}' has module_hierarchy in binding but "
+                f"not in Chrome JSON",
+            )
+
     def test_high_level_trace(self):
         """Checks that python side high level events are recorded."""
 

--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -915,7 +915,10 @@ class TestProfiler(TestCase):
 
         for event in events:
             self.assertIsInstance(event.module_hierarchy(), list)
-            self.assertIsInstance(event.activity_type(), int)
+            self.assertIsInstance(
+                event.activity_type(),
+                torch._C._autograd._ActivityType,
+            )
             self.assertIsInstance(event.get_perf_event_counters(), list)
             self.assertIsInstance(event.debug_handle(), int)
             self.assertIsInstance(event.extra_meta(), dict)

--- a/torch/csrc/autograd/init.cpp
+++ b/torch/csrc/autograd/init.cpp
@@ -220,6 +220,34 @@ PyObject* THPAutograd_initExtension(PyObject* _unused, PyObject* unused) {
           "is_cpp_nested_tensor",
           &torch::autograd::InputMetadata::is_cpp_nested_tensor);
 
+  py::enum_<libkineto::ActivityType>(m, "_ActivityType")
+      .value("CPU_OP", libkineto::ActivityType::CPU_OP)
+      .value("USER_ANNOTATION", libkineto::ActivityType::USER_ANNOTATION)
+      .value("GPU_USER_ANNOTATION", libkineto::ActivityType::GPU_USER_ANNOTATION)
+      .value("GPU_MEMCPY", libkineto::ActivityType::GPU_MEMCPY)
+      .value("GPU_MEMSET", libkineto::ActivityType::GPU_MEMSET)
+      .value("CONCURRENT_KERNEL", libkineto::ActivityType::CONCURRENT_KERNEL)
+      .value("EXTERNAL_CORRELATION", libkineto::ActivityType::EXTERNAL_CORRELATION)
+      .value("CUDA_RUNTIME", libkineto::ActivityType::CUDA_RUNTIME)
+      .value("CUDA_DRIVER", libkineto::ActivityType::CUDA_DRIVER)
+      .value("CPU_INSTANT_EVENT", libkineto::ActivityType::CPU_INSTANT_EVENT)
+      .value("PYTHON_FUNCTION", libkineto::ActivityType::PYTHON_FUNCTION)
+      .value("OVERHEAD", libkineto::ActivityType::OVERHEAD)
+      .value("MTIA_RUNTIME", libkineto::ActivityType::MTIA_RUNTIME)
+      .value("MTIA_CCP_EVENTS", libkineto::ActivityType::MTIA_CCP_EVENTS)
+      .value("MTIA_INSIGHT", libkineto::ActivityType::MTIA_INSIGHT)
+      .value("CUDA_SYNC", libkineto::ActivityType::CUDA_SYNC)
+      .value("CUDA_EVENT", libkineto::ActivityType::CUDA_EVENT)
+      .value("MTIA_COUNTERS", libkineto::ActivityType::MTIA_COUNTERS)
+      .value("GLOW_RUNTIME", libkineto::ActivityType::GLOW_RUNTIME)
+      .value("CUDA_PROFILER_RANGE", libkineto::ActivityType::CUDA_PROFILER_RANGE)
+      .value("HPU_OP", libkineto::ActivityType::HPU_OP)
+      .value("XPU_RUNTIME", libkineto::ActivityType::XPU_RUNTIME)
+      .value("XPU_DRIVER", libkineto::ActivityType::XPU_DRIVER)
+      .value("COLLECTIVE_COMM", libkineto::ActivityType::COLLECTIVE_COMM)
+      .value("PRIVATEUSE1_RUNTIME", libkineto::ActivityType::PRIVATEUSE1_RUNTIME)
+      .value("PRIVATEUSE1_DRIVER", libkineto::ActivityType::PRIVATEUSE1_DRIVER);
+
   py::class_<KinetoEvent>(m, "_KinetoEvent")
       // name of the event
       .def("name", [](const KinetoEvent& e) { return e.name(); })
@@ -320,15 +348,14 @@ PyObject* THPAutograd_initExtension(PyObject* _unused, PyObject* unused) {
       .def("metadata_json", [](const KinetoEvent& e) {
         return e.metadataJson();
       })
-      // module hierarchy (e.g. "ResNet.layer1.0.conv1")
       .def(
           "module_hierarchy",
           [](const KinetoEvent& e) { return e.moduleHierarchy().vec(); })
-      // activity type (matches libkineto::ActivityType enum)
       .def(
           "activity_type",
-          [](const KinetoEvent& e) { return e.activityType(); })
-      // hardware performance counters (CUPTI)
+          [](const KinetoEvent& e) {
+            return static_cast<libkineto::ActivityType>(e.activityType());
+          })
       .def(
           "get_perf_event_counters",
           [](const KinetoEvent& e) {
@@ -336,11 +363,9 @@ PyObject* THPAutograd_initExtension(PyObject* _unused, PyObject* unused) {
             e.getPerfEventCounters(counters);
             return counters;
           })
-      // debug handle for module correlation
       .def(
           "debug_handle",
           [](const KinetoEvent& e) { return e.debugHandle(); })
-      // extra metadata as key-value pairs
       .def(
           "extra_meta",
           [](const KinetoEvent& e) { return e.extraMeta(); });

--- a/torch/csrc/autograd/init.cpp
+++ b/torch/csrc/autograd/init.cpp
@@ -319,7 +319,31 @@ PyObject* THPAutograd_initExtension(PyObject* _unused, PyObject* unused) {
       // KinetoEvent metadata
       .def("metadata_json", [](const KinetoEvent& e) {
         return e.metadataJson();
-      });
+      })
+      // module hierarchy (e.g. "ResNet.layer1.0.conv1")
+      .def(
+          "module_hierarchy",
+          [](const KinetoEvent& e) { return e.moduleHierarchy().vec(); })
+      // activity type (matches libkineto::ActivityType enum)
+      .def(
+          "activity_type",
+          [](const KinetoEvent& e) { return e.activityType(); })
+      // hardware performance counters (CUPTI)
+      .def(
+          "get_perf_event_counters",
+          [](const KinetoEvent& e) {
+            torch::profiler::perf_counters_t counters;
+            e.getPerfEventCounters(counters);
+            return counters;
+          })
+      // debug handle for module correlation
+      .def(
+          "debug_handle",
+          [](const KinetoEvent& e) { return e.debugHandle(); })
+      // extra metadata as key-value pairs
+      .def(
+          "extra_meta",
+          [](const KinetoEvent& e) { return e.extraMeta(); });
 
   m.def("_soft_assert_raises", &setSoftAssertRaises);
   m.def("_get_sequence_nr", &at::sequence_number::peek);


### PR DESCRIPTION
These methods already exist on the C++ KinetoEvent class but were not bound to Python. This makes them accessible for tools that consume profiler data directly from kineto_results.events() without going through export_chrome_trace().

New bindings:
- module_hierarchy() -> list[str]: nn.Module hierarchy path
- activity_type() -> int: libkineto ActivityType enum value
- get_perf_event_counters() -> list[int]: hardware perf counters
- debug_handle() -> int: module correlation handle
- extra_meta() -> dict[str, str]: additional key-value metadata

Follows the same lambda wrapper pattern used by existing bindings like shapes(), stack(), and metadata_json().

Fixes https://github.com/pytorch/pytorch/issues/178087

cc @robieta @chaekit @guotuofeng @guyang3532 @dzhulgakov @davidberard98 @briancoutinho @sraikund16 @sanrise @mwootton @divyanshk @jiannanWang @scotts @ryanzhang22