### PR TITLE
docs: add gitcgr code graph badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ![PyTorch Logo](https://github.com/pytorch/pytorch/raw/main/docs/source/_static/img/pytorch-logo-dark.png)
 
+[![gitcgr](https://gitcgr.com/badge/pytorch/pytorch.svg)](https://gitcgr.com/pytorch/pytorch)
+
 --------------------------------------------------------------------------------
 
 PyTorch is a Python package that provides two high-level features:


### PR DESCRIPTION
Adds a [gitcgr](https://gitcgr.com) badge to the README showing code graph statistics for this repository.

**Badge preview:**

[![gitcgr](https://gitcgr.com/badge/pytorch/pytorch.svg)](https://gitcgr.com/pytorch/pytorch)

---

[gitcgr.com](https://gitcgr.com) visualizes any GitHub repo as an interactive code graph — just change `hub` to `cgr` in the URL.

Generated automatically by [gitcgr](https://gitcgr.com).