### PR TITLE
Fix attn_mask shape in scaled_dot_product_attention docs

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -6078,7 +6078,7 @@ scaled_dot_product_attention = _add_docstr(
         key (Tensor): Key tensor; shape :math:`(N, ..., H, S, E)`.
         value (Tensor): Value tensor; shape :math:`(N, ..., H, S, Ev)`.
         attn_mask (optional Tensor): Attention mask; shape must be broadcastable to the shape of attention weights,
-            which is :math:`(N,..., L, S)`. Two types of masks are supported.
+            which is :math:`(N,..., Hq, L, S)`. Two types of masks are supported.
             A boolean mask where a value of True indicates that the element *should* take part in attention.
             A float mask of the same type as query, key, value that is added to the attention score.
         dropout_p (float): Dropout probability; if greater than 0.0, dropout is applied


### PR DESCRIPTION
## Summary

Fixes the incorrect `attn_mask` shape documentation in `torch.nn.functional.scaled_dot_product_attention`.

## Problem

The docs state that `attn_mask` must be broadcastable to the attention weight shape `(N, ..., L, S)`, but the actual attention weight shape includes the query head dimension: `(N, ..., Hq, L, S)`. This causes confusion especially when using `enable_gqa=True` where the number of query heads (`Hq`) differs from the number of key/value heads (`H`).

As demonstrated in #177482:
- A mask of shape `(N, L, S)` fails with RuntimeError when `Hq > 1`
- A mask of shape `(N, Hq, L, S)` works correctly

## Fix

Changed the documented shape from `(N,..., L, S)` to `(N,..., Hq, L, S)` in the `attn_mask` parameter description.

Fixes #177482