### PR TITLE
[Inductor] Fix CompiledFunctionBackward shape mismatch in mix order reduction

### DIFF
--- a/test/inductor/test_mix_order_reduction.py
+++ b/test/inductor/test_mix_order_reduction.py
@@ -1073,6 +1073,27 @@ class MixOrderReductionTest(TestBase):
             "Mix order reduction should be triggered",
         )
 
+    def test_multi_dim_reduction_output_shape(self):
+        """
+        Regression test for https://github.com/pytorch/pytorch/issues/178080:
+        two reductions over different dims in the same compiled function must
+        produce correctly-shaped outputs.
+
+        x.sum(dim=(1, 2)) over [32768, 512, 2] -> [32768]
+        x.sum(dim=0)      over [32768, 512, 2] -> [512, 2]
+        """
+
+        def f(x):
+            return x.sum(dim=(1, 2)), x.sum(dim=0)
+
+        x = torch.randn(32768, 512, 2, device=GPU_TYPE)
+        ref = f(x)
+        act = torch.compile(f)(x)
+
+        self.assertEqual(list(act[0].shape), list(ref[0].shape))
+        self.assertEqual(list(act[1].shape), list(ref[1].shape))
+        self.assertTrue(same(ref, act, tol=1e-3))
+
 
 class OverFusionTest(TestBase):
     """

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -1794,13 +1794,21 @@ class SIMDScheduling(BaseScheduling):
             opname = reduction_type2op.get(
                 partial_accum.reduction_type, partial_accum.reduction_type
             )
-
             # Check if the original reduction used keepdim=True by comparing dimensions.
             # Without keepdim, reduction produces [rnumel]; with keepdim, [1, rnumel].
             buffer = V.graph.get_buffer(buffer_name)
-            keepdim = buffer is not None and len(buffer.get_layout().size) > 1
+            if buffer is not None:
+                final_shape = [
+                    V.graph.wrapper_code.codegen_python_sizevar(s)
+                    for s in buffer.get_layout().size
+                ]
+                final_shape_str = f"[{', '.join(final_shape)}]"
+                # We use .view() at the end to ensure the exact original shape is restored,
+                # which is more robust than guessing keepdim.
+                final_reduce = f"{buffer_name} = {ws_name}[{start} : {end}].view({nsplit}, {rnumel}).{opname}(dim=0).view({final_shape_str})"
+            else:
+                final_reduce = f"{buffer_name} = {ws_name}[{start} : {end}].view({nsplit}, {rnumel}).{opname}(dim=0)"
 
-            final_reduce = f"{buffer_name} = {ws_name}[{start} : {end}].view({nsplit}, {rnumel}).{opname}(dim=0, keepdim={keepdim})"
 
             # The workspace tensor is in torch.float, need a cast if the buffer is
             # not.

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -1794,8 +1794,10 @@ class SIMDScheduling(BaseScheduling):
             opname = reduction_type2op.get(
                 partial_accum.reduction_type, partial_accum.reduction_type
             )
-            # Check if the original reduction used keepdim=True by comparing dimensions.
-            # Without keepdim, reduction produces [rnumel]; with keepdim, [1, rnumel].
+            final_reduce = f"{buffer_name} = {ws_name}[{start} : {end}].view({nsplit}, {rnumel}).{opname}(dim=0)"
+
+            # Restore the exact original shape via .view() to handle keepdim
+            # and multi-dimensional reductions correctly.
             buffer = V.graph.get_buffer(buffer_name)
             if buffer is not None:
                 final_shape = [
@@ -1803,12 +1805,7 @@ class SIMDScheduling(BaseScheduling):
                     for s in buffer.get_layout().size
                 ]
                 final_shape_str = f"[{', '.join(final_shape)}]"
-                # We use .view() at the end to ensure the exact original shape is restored,
-                # which is more robust than guessing keepdim.
-                final_reduce = f"{buffer_name} = {ws_name}[{start} : {end}].view({nsplit}, {rnumel}).{opname}(dim=0).view({final_shape_str})"
-            else:
-                final_reduce = f"{buffer_name} = {ws_name}[{start} : {end}].view({nsplit}, {rnumel}).{opname}(dim=0)"
-
+                final_reduce += f".view({final_shape_str})"
 
             # The workspace tensor is in torch.float, need a cast if the buffer is
             # not.


### PR DESCRIPTION
This PR fixes a RuntimeError occurring during the backward pass of compiled models that use "mix order reduction".
The fix ensures that Inductor correctly restores the expected tensor shapes using .view() in the generated Python wrapper, preventing gradient shape mismatches in autograd.
Fixes #178080


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo