### PR TITLE
Add blendv support for float8 vectorized types on AVX-512

### DIFF
--- a/aten/src/ATen/cpu/vec/vec512/vec512_float8.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_float8.h
@@ -377,6 +377,16 @@ class Vectorizedf8 {
     }
   }
 
+  static Vectorized<T> blendv(
+      const Vectorized<T>& a,
+      const Vectorized<T>& b,
+      const Vectorized<T>& mask) {
+    auto msb_one = _mm512_set1_epi8(0xFF);
+    auto mask_ = _mm512_cmp_epi8_mask(
+        __m512i(mask), msb_one, _MM_CMPINT_EQ);
+    return _mm512_mask_blend_epi8(mask_, __m512i(a), __m512i(b));
+  }
+
   Vectorized<T> abs() const {
     return _mm512_andnot_si512(_mm512_set1_epi8(0x80), values);
   }


### PR DESCRIPTION
## Summary
- Add `blendv` static method to `Vectorizedf8<T>` base class in `vec512_float8.h`
- Fixes compilation failure when Inductor generates C++ code that converts bool tensors to float8 dtypes (e.g. `float8_e4m3fn`)
- Follows the same pattern used by `Vectorized<int8_t>` and `Vectorized<uint8_t>` in `vec512_int.h`

## Test plan
- [ ] CI compilation passes on x86 AVX-512 targets
- [ ] Reproduction script from the issue runs successfully:
  ```python
  import torch
  def test(x):
      return x.to(dtype=torch.float8_e4m3fn)
  compiled = torch.compile(test, backend="inductor")
  x = torch.ones(64, dtype=torch.bool)
  output = compiled(x)
  print(output)
  ```

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01