### PR TITLE
[C10] Fix incorrect channels-last contiguity flag handling in `c10/core/SymbolicShapeMeta.h`

### DIFF
--- a/c10/core/SymbolicShapeMeta.h
+++ b/c10/core/SymbolicShapeMeta.h
@@ -141,7 +141,7 @@ class C10_API SymbolicShapeMeta {
     available_.fetch_or(is_contiguous_avail);
   }
   void assume_channels_last_contiguous(SymBool val = true) {
-    is_contiguous_ = std::move(val);
+    is_channels_last_contiguous_ = std::move(val);
     available_.fetch_or(is_channels_last_contiguous_avail);
   }
   void assume_channels_last_3d_contiguous(SymBool val = true) {


### PR DESCRIPTION
# Summary
This pull request fixes #178102 by correcting a bug in `c10/core/SymbolicShapeMeta.h` where `assume_channels_last_contiguous` that consistet of an incorrect change `is_contiguous_` instead of `is_channels_last_contiguous_`. This caused inconsistent state and may have leaded to wrong contiguity information for channels-last tensors.

# Change(s)
- Replaced assignment `is_contiguous_ = std::move(val);` with `is_channels_last_contiguous_ = std::move(val);`

# Impact
- Corrects the internal state of `SymbolicShapeMeta` when a tensor is assumed to be channels-last contiguous.
- Prevents potential incorrect optimizations and ensures proper propagation of contiguity flags in symbolic shape handling.

Contributed by **Benedikt Johannes**

cc @ezyang @penguinwu @bobrenjc93 @aditvenk @laithsakka