### PR TITLE
[ROCm] Move fmod xfail to CUDA-only in test_torchinductor_opinfo_properties

### DIFF
--- a/test/inductor/test_torchinductor_opinfo_properties.py
+++ b/test/inductor/test_torchinductor_opinfo_properties.py
@@ -420,7 +420,6 @@ UNARY_NUMERICAL_XFAILS = {
 
 BINARY_NUMERICAL_XFAILS = {
     "inductor_default": {
-        "fmod": {bf16, fp32},
         "remainder": {ALL},
     },
     "inductor_numerics": {
@@ -446,17 +445,34 @@ ROCM_XFAILS = {
     },
 }
 
+# Additional expected failures that only apply on CUDA (not ROCm).
+# fmod numerical tests fail on CUDA but pass on ROCm (MI300).
+CUDA_ONLY_XFAILS = {
+    "binary_numerical": {
+        "inductor_default": {
+            "fmod": {bf16, fp32},
+        },
+    },
+}
+
 
 def is_expected_failure(device_type, op_name, backend, test_type, dtype=None):
     """Check if a test is expected to fail."""
     xfails = XFAIL_DICTS.get(test_type, {}).get(backend, {}).get(op_name, set())
     is_xfail = dtype in xfails or ALL in xfails
 
-    if not is_xfail and torch.version.hip is not None:
-        rocm_xfails = (
-            ROCM_XFAILS.get(test_type, {}).get(backend, {}).get(op_name, set())
-        )
-        is_xfail = dtype in rocm_xfails or ALL in rocm_xfails
+    if torch.version.hip is not None:
+        if not is_xfail:
+            rocm_xfails = (
+                ROCM_XFAILS.get(test_type, {}).get(backend, {}).get(op_name, set())
+            )
+            is_xfail = dtype in rocm_xfails or ALL in rocm_xfails
+    else:
+        if not is_xfail:
+            cuda_xfails = (
+                CUDA_ONLY_XFAILS.get(test_type, {}).get(backend, {}).get(op_name, set())
+            )
+            is_xfail = dtype in cuda_xfails or ALL in cuda_xfails
 
     return is_xfail
 


### PR DESCRIPTION
## Problem

After enabling `test_torchinductor_opinfo_properties` on ROCm (#177544), the
`fmod` binary numerical test unexpectedly **passes** on ROCm MI300, triggering
an XPASS failure that aborts the entire test suite at 27% due to `pytest -x`.
This leaves ~824 of 1134 tests as MISSED on the
[HUD](https://hud.pytorch.org/pytorch/pytorch/commit/67f1ccf46a966e75f37facd497a03f7d1bd72982#rocm-mi300).

The `fmod` xfail was in the global `BINARY_NUMERICAL_XFAILS` dict which applies
to both CUDA and ROCm. These xfails were written when ROCm was blanket-skipped,
so they were effectively CUDA-only. Now that ROCm is enabled, `fmod` passes on
ROCm MI300 which triggers an unexpected XPASS.

## What happens on each platform

**ROCm MI300** ([job log](https://github.com/pytorch/pytorch/actions/runs/23402823076/job/68078127276),
commit [`67f1ccf`](https://github.com/pytorch/pytorch/commit/67f1ccf46a966e75f37facd497a03f7d1bd72982)):

The `fmod/inductor_default/bfloat16` test passes on ROCm, but the xfail dict
expects it to fail. This causes an XPASS which pytest treats as a failure. With
`-x` (stop on first failure), the entire suite aborts at 27%:

```
test_binary_ufunc_numerical_fmod_backend_inductor_default_cuda_bfloat16 ('RERUN') [ 27%]
test_binary_ufunc_numerical_fmod_backend_inductor_default_cuda_bfloat16 ('RERUN') [ 27%]
test_binary_ufunc_numerical_fmod_backend_inductor_default_cuda_bfloat16 FAILED    [ 27%]

AssertionError: XPASS: fmod/inductor_default/torch.bfloat16 - remove from binary_numerical xfails

= 1 failed, 281 passed, 18 skipped, 10 xfailed, 2 rerun in 1003.05s =
```

Only 310 of 1134 tests completed. The remaining ~824 were never executed and
show as **MISSED** on the HUD. The `fmod/fp32` test was also never reached
(alphabetically after `bfloat16`), but is expected to also pass on ROCm.

**CUDA**: `fmod` still genuinely fails on CUDA, so the xfail correctly applies
and the test is marked as `xfail` (counts as passed). The full suite runs to
completion and tests show as **PASSED** on the HUD. Note: target determination
currently deprioritizes this test file on CUDA trunk, so CUDA results on the HUD
may be from historical runs.

## Fix

Move `fmod: {bf16, fp32}` from the global `BINARY_NUMERICAL_XFAILS` to a new
`CUDA_ONLY_XFAILS` dict. Update `is_expected_failure()` to check
`CUDA_ONLY_XFAILS` only on non-ROCm (CUDA) platforms, mirroring the existing
`ROCM_XFAILS` pattern for ROCm-only failures.

- **CUDA**: `fmod` remains xfailed → no behavior change
- **ROCm**: `fmod` is no longer xfailed → passes normally → suite continues past 27%

_Root cause analysis helped by Claude._

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben
