### PR TITLE
[aotautograd] Clean up AOT autograd subclass handling

### DIFF
--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -114,7 +114,7 @@ except ModuleNotFoundError:
 
 if TYPE_CHECKING:
     from torch._dynamo.symbolic_convert import InstructionTranslator
-    from torch._library.opaque_object import OpaqueType
+    from torch._opaque_base import OpaqueBase
     from torch.utils._pytree import TreeSpec
 
 
@@ -285,7 +285,7 @@ def _collect_all_grad_fns(tensor: torch.Tensor) -> set[torch.autograd.graph.Node
 
     grad_fns: set[torch.autograd.graph.Node] = set()
 
-    plain_tensors: list[torch.SymInt | torch.Tensor | int | OpaqueType] = []
+    plain_tensors: list[torch.SymInt | torch.Tensor | int | OpaqueBase] = []
     # Get all plain tensors (handles nested subclasses)
     if is_traceable_wrapper_subclass(tensor):
         get_plain_tensors(tensor, out=plain_tensors)

--- a/torch/_functorch/_aot_autograd/collect_metadata_analysis.py
+++ b/torch/_functorch/_aot_autograd/collect_metadata_analysis.py
@@ -870,6 +870,12 @@ from a multi-output view call"
                 grad_enabled_mutation,
             )
 
+        subclass_inp_meta = create_subclass_meta(flat_args)
+        subclass_fw_graph_out_meta = create_subclass_meta(fw_graph_outs)
+        subclass_tangent_meta = create_subclass_meta(
+            traced_tangents, count_symints=False, with_memory_format=True
+        )
+
         metadata = ViewAndMutationMeta(
             input_info=input_info,
             output_info=output_info,
@@ -877,13 +883,9 @@ from a multi-output view call"
             keep_input_mutations=keep_input_mutations,
             traced_tangents=traced_tangents,
             traced_tangents_descs=traced_tangents_descs,
-            subclass_inp_meta=create_subclass_meta(flat_args),
-            subclass_fw_graph_out_meta=create_subclass_meta(fw_graph_outs),
-            subclass_tangent_meta=create_subclass_meta(
-                traced_tangents,
-                count_symints=False,
-                with_memory_format=True,
-            ),
+            subclass_inp_meta=subclass_inp_meta,
+            subclass_fw_graph_out_meta=subclass_fw_graph_out_meta,
+            subclass_tangent_meta=subclass_tangent_meta,
             is_train=is_train,
             grad_enabled_mutation=grad_enabled_mutation,
             static_input_indices=static_input_indices,

--- a/torch/_functorch/_aot_autograd/graph_capture_wrappers.py
+++ b/torch/_functorch/_aot_autograd/graph_capture_wrappers.py
@@ -10,6 +10,7 @@ It does so by:
 4. dispatching subclasses
 """
 
+import typing
 import warnings
 from collections.abc import Callable, Generator
 from contextlib import AbstractContextManager, contextmanager, ExitStack, nullcontext
@@ -1356,11 +1357,15 @@ def aot_dispatch_subclass(
             # Add extra symints as outputs to the forward/backward graphs
             # ignore nested ints here
             forward_outs, forward_outs_descs = unwrap_tensor_subclasses(
-                wrapped_outs[0], wrapped_outs_descs[0], append_symints=True
+                wrapped_outs[0],
+                wrapped_outs_descs[0],
+                append_symints=True,
             )
             # ignore nested ints here
             backward_outs, backward_outs_descs = unwrap_tensor_subclasses(
-                wrapped_outs[1], wrapped_outs_descs[1], append_symints=True
+                wrapped_outs[1],
+                wrapped_outs_descs[1],
+                append_symints=True,
             )
             return (
                 (forward_outs, backward_outs),
@@ -1394,42 +1399,53 @@ def aot_dispatch_subclass(
         return inner_fn(inner_fw_only, primals, use_trace_joint=False)
 
     if is_joint_structure:
+        primals_wrapped: list[FxValue] = typing.cast(list[FxValue], args[0])
+        primals_wrapped_descs: list[AOTInput] = typing.cast(
+            list[AOTInput], args_descs[0]
+        )
+        tangents_wrapped: list[FxValue] = typing.cast(list[FxValue], args[1])
+        tangents_wrapped_descs: list[AOTInput] = typing.cast(
+            list[AOTInput], args_descs[1]
+        )
+
         # Add extra symints (size/strides) as input to the forward graph
         primals_unwrapped_pair = unwrap_tensor_subclasses(
-            args[0],  # type: ignore[arg-type]
-            args_descs[0],  # type: ignore[arg-type]
+            primals_wrapped,
+            primals_wrapped_descs,
             append_symints=True,
         )
         # We pass append_symints=False here because the partitioner will
         # capture and add any extra argument.
         tangents_unwrapped_pair = unwrap_tensor_subclasses(
-            args[1],  # type: ignore[arg-type]
-            args_descs[1],  # type: ignore[arg-type]
+            tangents_wrapped,
+            tangents_wrapped_descs,
             append_symints=False,
         )
 
         args_unwrapped = (primals_unwrapped_pair[0], tangents_unwrapped_pair[0])
         args_descs_unwrapped = (primals_unwrapped_pair[1], tangents_unwrapped_pair[1])
         remapped_static_indices = remap_unwrapped_subclass_arg_indices(
-            args[0],  # type: ignore[arg-type]
-            meta.static_input_indices,  # type: ignore[arg-type]
-        )
-    else:
-        args_unwrapped, args_descs_unwrapped = unwrap_tensor_subclasses(  # type: ignore[assignment]
-            args,  # type: ignore[arg-type]
-            args_descs,  # type: ignore[arg-type]
-            append_symints=True,
-        )
-        remapped_static_indices = remap_unwrapped_subclass_arg_indices(
-            args,  # type: ignore[arg-type]
+            primals_wrapped,
             meta.static_input_indices,  # type: ignore[arg-type]
         )
 
-    if is_joint_structure:
         primals_unwrapped = args_unwrapped[0]  # type: ignore[assignment]
         primals_unwrapped_descs = args_descs_unwrapped[0]  # type: ignore[assignment]
         fn_to_trace = joint_fn  # type: ignore[assignment]
     else:
+        primals_wrapped: list[FxValue] = typing.cast(list[FxValue], args)
+        primals_wrapped_descs: list[AOTInput] = typing.cast(list[AOTInput], args_descs)
+
+        args_unwrapped, args_descs_unwrapped = unwrap_tensor_subclasses(  # type: ignore[assignment]
+            primals_wrapped,
+            primals_wrapped_descs,
+            append_symints=True,
+        )
+        remapped_static_indices = remap_unwrapped_subclass_arg_indices(
+            primals_wrapped,
+            meta.static_input_indices,  # type: ignore[arg-type]
+        )
+
         primals_unwrapped = args_unwrapped  # type: ignore[assignment]
         primals_unwrapped_descs = args_descs_unwrapped  # type: ignore[assignment]
         fn_to_trace = fw_fn  # type: ignore[assignment]

--- a/torch/_functorch/_aot_autograd/runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/runtime_wrappers.py
@@ -114,12 +114,12 @@ def _describe_arg_for_logging(arg: object) -> str:
     from torch._library import opaque_object
 
     try:
-        is_dtensor = isinstance(arg, torch.distributed._tensor.DTensor)
+        is_dtensor = isinstance(arg, torch.distributed.tensor.DTensor)
     except AttributeError:
         is_dtensor = False
 
     if is_dtensor:
-        arg = typing.cast(torch.distributed._tensor.DTensor, arg)
+        arg = typing.cast(torch.distributed.tensor.DTensor, arg)
         mesh = arg.device_mesh
         return (
             f"DTensor(shape={arg.shape}, dtype={arg.dtype}, "

--- a/torch/_functorch/_aot_autograd/subclass_utils.py
+++ b/torch/_functorch/_aot_autograd/subclass_utils.py
@@ -7,7 +7,7 @@ and this includes tensor subclasses that implement __torch_dispatch__.
 import collections
 import typing
 from collections.abc import Callable, Iterable, Sequence
-from typing import Any, TYPE_CHECKING, TypeGuard, TypeVar
+from typing import Any, TypeGuard, TypeVar
 
 import torch
 import torch.utils._pytree as pytree
@@ -40,10 +40,6 @@ from .schemas import (
     ViewAndMutationMeta,
 )
 from .utils import strict_zip
-
-
-if TYPE_CHECKING:
-    from torch._library.opaque_object import OpaqueType
 
 
 zip = strict_zip
@@ -328,16 +324,21 @@ def runtime_unwrap_tensor_subclasses(
     *,
     append_symints: bool,
     subclass_metas: list[PlainTensorMeta | SubclassCreationMeta] | None = None,
-) -> list[Any]:
+) -> list[int | Tensor | SymInt | OpaqueBase]:
     def flatten_subclass(
-        x: Tensor, meta: SubclassCreationMeta | None, *, out: list[Any]
-    ) -> list[Any]:
+        x: Tensor,
+        subclass_meta: PlainTensorMeta | SubclassCreationMeta | OpaqueMeta | None,
+        *,
+        out: list[OpaqueBase | SymInt | Tensor | int],
+    ) -> list[OpaqueBase | SymInt | Tensor | int]:
         if not is_traceable_wrapper_subclass(x):
             out.append(x)
             return out
 
         if not isinstance(x, Tensor):
             raise AssertionError(f"expected Tensor, got {type(x)}")
+        if not isinstance(subclass_meta, SubclassCreationMeta):
+            raise AssertionError("subclass_meta should be a SubclassCreationMeta")
 
         attrs, _ = x.__tensor_flatten__()
 
@@ -347,8 +348,7 @@ def runtime_unwrap_tensor_subclasses(
                 case OpaqueBase():
                     out.append(inner_value)
                 case Tensor():
-                    # pyrefly: ignore [missing-attribute]
-                    inner_meta = meta.attrs.get(attr)
+                    inner_meta = subclass_meta.attrs.get(attr)
                     flatten_subclass(inner_value, inner_meta, out=out)
                 case _:
                     raise AssertionError(
@@ -356,11 +356,9 @@ def runtime_unwrap_tensor_subclasses(
                     )
 
         if append_symints:
-            if not isinstance(meta, SubclassCreationMeta):
-                raise AssertionError(f"expected SubclassCreationMeta, got {type(meta)}")
             # outer_size
             size = x.size()
-            symint_placeholders = compute_symint_placeholders(meta.outer_size)
+            symint_placeholders = compute_symint_placeholders(subclass_meta.outer_size)
             if len(size) != len(symint_placeholders):
                 raise AssertionError(
                     f"size length mismatch: {len(size)} != {len(symint_placeholders)}"
@@ -371,7 +369,9 @@ def runtime_unwrap_tensor_subclasses(
 
             # outer_stride
             stride = x.stride()
-            symint_placeholders = compute_symint_placeholders(meta.outer_stride)
+            symint_placeholders = compute_symint_placeholders(
+                subclass_meta.outer_stride
+            )
             if len(stride) != len(symint_placeholders):
                 raise AssertionError(
                     f"stride length mismatch: {len(stride)} != {len(symint_placeholders)}"
@@ -381,7 +381,7 @@ def runtime_unwrap_tensor_subclasses(
             )
         return out
 
-    xs_inner: list[int | Tensor | SymInt | OpaqueType] = []
+    xs_inner: list[int | Tensor | SymInt | OpaqueBase] = []
 
     if append_symints:
         if subclass_metas is None:
@@ -397,10 +397,12 @@ def runtime_unwrap_tensor_subclasses(
         if subclass_metas is None:
             get_plain_tensors(typing.cast(Tensor, x), out=xs_inner)
         else:
-            meta = subclass_metas[idx]
-            if not isinstance(meta, SubclassCreationMeta):
-                raise AssertionError(f"expected SubclassCreationMeta, got {type(meta)}")
-            flatten_subclass(typing.cast(Tensor, x), meta, out=xs_inner)
+            subclass_meta = subclass_metas[idx]
+            if not isinstance(subclass_meta, SubclassCreationMeta):
+                raise AssertionError(
+                    f"expected SubclassCreationMeta, got {type(subclass_meta)}"
+                )
+            flatten_subclass(typing.cast(Tensor, x), subclass_meta, out=xs_inner)
 
     return xs_inner
 

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -57,7 +57,6 @@ if TYPE_CHECKING:
     from types import TracebackType
 
     from torch._guards import Source
-    from torch._library.opaque_object import OpaqueType
     from torch._ops import OpOverload
     from torch.fx.experimental.symbolic_shapes import ShapeEnv, SymbolicContext
 
@@ -183,8 +182,8 @@ def disable_fake_tensor_cache(fake_mode: FakeTensorMode) -> Generator[None, None
 
 
 def get_plain_tensors(
-    subclass: Tensor, *, out: list[Tensor | int | SymInt | OpaqueType]
-) -> list[Tensor | int | SymInt | OpaqueType]:
+    subclass: Tensor, *, out: list[Tensor | int | SymInt | OpaqueBase]
+) -> list[Tensor | int | SymInt | OpaqueBase]:
     # This function is used in Runtime, do not add redundant asserts
     todo = [subclass]
     while todo:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #178117
* #178116
* #178115
* #178114
* #178113
* #178112
* #178111
* #178110
* #178109
* #178108
* __->__ #178107

Tighten type annotations across AOT autograd's subclass utilities to
eliminate pyrefly suppressions and type: ignore comments. The main
structural change is in flatten_subclass, where the SubclassCreationMeta
assertion is moved before the attrs access that already required it
(previously suppressed with a pyrefly ignore). The rest is mechanical:
replacing OpaqueType with OpaqueBase, using the public DTensor import
path, and casting args to typed locals instead of using type: ignore.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo