### PR TITLE
[dynamo][refactor] Extract vt_identity_compare into object_protocol.py

### DIFF
--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -850,43 +850,15 @@ class BuiltinVariable(VariableTracker):
                     left: VariableTracker,
                     right: VariableTracker,
                 ) -> VariableTracker | None:
-                    # VT identity → Python identity
-                    if left is right:
-                        return VariableTracker.build(tx, op.__name__ == "is_")
+                    from .object_protocol import vt_identity_compare
 
-                    # Compare underlying Python objects via hook
-                    left_val = left.get_real_python_backed_value()
-                    right_val = right.get_real_python_backed_value()
-
-                    left_known = left_val is not NO_SUCH_SUBOBJ
-                    right_known = right_val is not NO_SUCH_SUBOBJ
-
-                    if left_known and right_known:
-                        result = left_val is right_val
-                        return VariableTracker.build(
-                            tx, result if op.__name__ == "is_" else not result
-                        )
-
-                    # One side has a concrete value, the other doesn't — they
-                    # can't be identical (if they were the same object, both
-                    # sides would resolve).
-                    if left_known != right_known:
-                        return VariableTracker.build(tx, op.__name__ != "is_")
-
-                    # Mutable containers created during tracing: VT identity
-                    # = Python identity. Already False from `left is right`.
-                    if isinstance(left, (ConstDictVariable, ListVariable)):
-                        return VariableTracker.build(tx, op.__name__ != "is_")
-
-                    # Different exception types are never identical
-                    if (
-                        istype(left, variables.ExceptionVariable)
-                        and istype(right, variables.ExceptionVariable)
-                        and left.exc_type is not right.exc_type
-                    ):
-                        return VariableTracker.build(tx, op.__name__ != "is_")
-
-                    return None
+                    result = vt_identity_compare(tx, left, right)
+                    if result is None:
+                        return None
+                    is_same = result.as_python_constant()
+                    return VariableTracker.build(
+                        tx, is_same if op.__name__ == "is_" else not is_same
+                    )
 
                 result.append(((VariableTracker, VariableTracker), handle_is))  # type: ignore[arg-type]
 

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -852,7 +852,7 @@ class BuiltinVariable(VariableTracker):
                 ) -> VariableTracker | None:
                     from .object_protocol import vt_identity_compare
 
-                    result = vt_identity_compare(tx, left, right)
+                    result = vt_identity_compare(left, right)
                     if result is None:
                         return None
                     is_same = result.as_python_constant()

--- a/torch/_dynamo/variables/object_protocol.py
+++ b/torch/_dynamo/variables/object_protocol.py
@@ -6,20 +6,14 @@ comparison dispatch machinery that is independent of any specific type.
 Per-type richcompare_impl hooks live in their respective VT files.
 """
 
-from typing import TYPE_CHECKING
-
 from ..utils import istype
 from .base import NO_SUCH_SUBOBJ, VariableTracker
-
-
-if TYPE_CHECKING:
-    from ..symbolic_convert import InstructionTranslator
+from .constant import CONSTANT_VARIABLE_FALSE, CONSTANT_VARIABLE_TRUE
 
 
 def vt_identity_compare(
-    tx: "InstructionTranslator",
-    left: "VariableTracker",
-    right: "VariableTracker",
+    left: VariableTracker,
+    right: VariableTracker,
 ) -> "VariableTracker | None":
     """Try to determine Python identity (left is right) at trace time.
 
@@ -27,7 +21,7 @@ def vt_identity_compare(
     Mirrors the logic in BuiltinVariable's handle_is handler.
     """
     if left is right:
-        return VariableTracker.build(tx, True)
+        return CONSTANT_VARIABLE_TRUE
 
     left_val = left.get_real_python_backed_value()
     right_val = right.get_real_python_backed_value()
@@ -35,24 +29,26 @@ def vt_identity_compare(
     right_known = right_val is not NO_SUCH_SUBOBJ
 
     if left_known and right_known:
-        return VariableTracker.build(tx, left_val is right_val)
+        return (
+            CONSTANT_VARIABLE_TRUE if left_val is right_val else CONSTANT_VARIABLE_FALSE
+        )
 
     # One side has a concrete backing object, the other doesn't — they can't
     # be the same object.
     if left_known != right_known:
-        return VariableTracker.build(tx, False)
+        return CONSTANT_VARIABLE_FALSE
 
     # Mutable containers created during tracing: VT identity = Python identity.
     from .dicts import ConstDictVariable
     from .lists import ListVariable
 
     if isinstance(left, (ConstDictVariable, ListVariable)):
-        return VariableTracker.build(tx, False)
+        return CONSTANT_VARIABLE_FALSE
 
     # Different Python types can never be the same object.
     try:
         if left.python_type() is not right.python_type():
-            return VariableTracker.build(tx, False)
+            return CONSTANT_VARIABLE_FALSE
     except NotImplementedError:
         pass
 
@@ -64,6 +60,6 @@ def vt_identity_compare(
         and istype(right, variables.ExceptionVariable)
         and left.exc_type is not right.exc_type  # type: ignore[attr-defined]
     ):
-        return VariableTracker.build(tx, False)
+        return CONSTANT_VARIABLE_FALSE
 
     return None

--- a/torch/_dynamo/variables/object_protocol.py
+++ b/torch/_dynamo/variables/object_protocol.py
@@ -1,0 +1,69 @@
+"""
+Dynamo implementations of CPython's PyObject_* default slot algorithms.
+
+Analogous to CPython's Objects/object.c, this module holds the general
+comparison dispatch machinery that is independent of any specific type.
+Per-type richcompare_impl hooks live in their respective VT files.
+"""
+
+from typing import TYPE_CHECKING
+
+from ..utils import istype
+from .base import NO_SUCH_SUBOBJ, VariableTracker
+
+
+if TYPE_CHECKING:
+    from ..symbolic_convert import InstructionTranslator
+
+
+def vt_identity_compare(
+    tx: "InstructionTranslator",
+    left: "VariableTracker",
+    right: "VariableTracker",
+) -> "VariableTracker | None":
+    """Try to determine Python identity (left is right) at trace time.
+
+    Returns ConstantVariable(True/False) if determinable, else None.
+    Mirrors the logic in BuiltinVariable's handle_is handler.
+    """
+    if left is right:
+        return VariableTracker.build(tx, True)
+
+    left_val = left.get_real_python_backed_value()
+    right_val = right.get_real_python_backed_value()
+    left_known = left_val is not NO_SUCH_SUBOBJ
+    right_known = right_val is not NO_SUCH_SUBOBJ
+
+    if left_known and right_known:
+        return VariableTracker.build(tx, left_val is right_val)
+
+    # One side has a concrete backing object, the other doesn't — they can't
+    # be the same object.
+    if left_known != right_known:
+        return VariableTracker.build(tx, False)
+
+    # Mutable containers created during tracing: VT identity = Python identity.
+    from .dicts import ConstDictVariable
+    from .lists import ListVariable
+
+    if isinstance(left, (ConstDictVariable, ListVariable)):
+        return VariableTracker.build(tx, False)
+
+    # Different Python types can never be the same object.
+    try:
+        if left.python_type() is not right.python_type():
+            return VariableTracker.build(tx, False)
+    except NotImplementedError:
+        pass
+
+    # Different exception types are never identical.
+    from .. import variables
+
+    if (
+        istype(left, variables.ExceptionVariable)
+        and istype(right, variables.ExceptionVariable)
+        and left.exc_type is not right.exc_type  # type: ignore[attr-defined]
+    ):
+        return VariableTracker.build(tx, False)
+
+    return None


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #177943
* __->__ #178118

Create torch/_dynamo/variables/object_protocol.py, analogous to
CPython's Objects/object.c, to hold general PyObject_* algorithm
implementations independent of any specific type.

Move the identity-comparison logic from BuiltinVariable's inline
handle_is closure into vt_identity_compare() in this new module.
handle_is now delegates to vt_identity_compare and adjusts the result
for is/is-not polarity.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo