### PR TITLE
Fix deterministic empty allocation paths in Inductor

### DIFF
--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -3426,8 +3426,8 @@ class PythonWrapperCodegen(CodeGen):
         codegen_stride_tuple = self.codegen_python_shape_tuple(stride)
 
         is_deterministic = (
-            torch.are_deterministic_algorithms_enabled()
-            and torch.utils.deterministic.fill_uninitialized_memory  # type: ignore[attr-defined]
+            "torch.are_deterministic_algorithms_enabled() and "
+            "torch.utils.deterministic.fill_uninitialized_memory"
         )
 
         if torch._inductor.config.test_configs.track_memory_lifecycle:
@@ -3439,20 +3439,30 @@ class PythonWrapperCodegen(CodeGen):
                 f"device='{device.type}', "
                 f"name='{name}')"
             )
-        elif device.type == "cpu" and is_pinned and not is_deterministic:
+        elif device.type == "cpu" and is_pinned:
             out = (
-                f"{name} = empty_strided_cpu_pinned("
+                f"{name} = (empty_strided("
                 f"{codegen_allocation_shape_tuple}, "
                 f"{codegen_stride_tuple}, "
-                f"{dtype})"
+                f"device='{device.type}', dtype={dtype}, pin_memory={is_pinned}) "
+                f"if {is_deterministic} else "
+                f"empty_strided_cpu_pinned("
+                f"{codegen_allocation_shape_tuple}, "
+                f"{codegen_stride_tuple}, "
+                f"{dtype}))"
             )
-        elif device.type in ("cpu", "cuda", "xpu", "mtia") and not is_deterministic:
+        elif device.type in ("cpu", "cuda", "xpu", "mtia"):
             # optimized path for faster allocations, saving ~2us versus the stuff below
             out = (
-                f"{name} = empty_strided_{device.type}("
+                f"{name} = (empty_strided("
                 f"{codegen_allocation_shape_tuple}, "
                 f"{codegen_stride_tuple}, "
-                f"{dtype})"
+                f"device='{device.type}', dtype={dtype}, pin_memory={is_pinned}) "
+                f"if {is_deterministic} else "
+                f"empty_strided_{device.type}("
+                f"{codegen_allocation_shape_tuple}, "
+                f"{codegen_stride_tuple}, "
+                f"{dtype}))"
             )
         # all other devices (or deterministic mode):
         # NOTE: For deterministic mode, fallback to the slower path which correctly fills the buffer with NaN or MAX_INT

--- a/torch/csrc/inductor/aoti_torch/shim_common.cpp
+++ b/torch/csrc/inductor/aoti_torch/shim_common.cpp
@@ -462,16 +462,10 @@ AOTITorchError aoti_torch_empty_strided(
   AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
     c10::IntArrayRef sizes(sizes_ptr, ndim);
     c10::IntArrayRef strides(strides_ptr, ndim);
-    if (c10::DeviceType(device_type) == c10::DeviceType::CPU) {
-      *ret_new_tensor = new_tensor_handle(at::detail::empty_strided_cpu(
-          sizes, strides, static_cast<c10::ScalarType>(dtype)));
-    } else {
-      c10::Device device = c10_device(device_type, device_index);
-      c10::TensorOptions options = c10::TensorOptions().device(device).dtype(
-          static_cast<c10::ScalarType>(dtype));
-      *ret_new_tensor =
-          new_tensor_handle(at::empty_strided(sizes, strides, options));
-    }
+    c10::Device device = c10_device(device_type, device_index);
+    c10::TensorOptions options =
+        c10::TensorOptions().device(device).dtype(static_cast<c10::ScalarType>(dtype));
+    *ret_new_tensor = new_tensor_handle(at::empty_strided(sizes, strides, options));
   });
 }
 
@@ -489,11 +483,13 @@ AOTITorchError aoti_torch_empty_strided_pinned(
     TORCH_CHECK(
         c10::DeviceType(device_type) == c10::DeviceType::CPU,
         "only CPU tensors can be pinned");
-    *ret_new_tensor = new_tensor_handle(at::detail::empty_strided_cpu(
-        sizes,
-        strides,
-        static_cast<c10::ScalarType>(dtype),
-        /*is_pinned=*/true));
+    c10::Device device = c10_device(device_type, device_index);
+    c10::TensorOptions options =
+        c10::TensorOptions()
+            .device(device)
+            .dtype(static_cast<c10::ScalarType>(dtype))
+            .pinned_memory(true);
+    *ret_new_tensor = new_tensor_handle(at::empty_strided(sizes, strides, options));
   });
 }
 


### PR DESCRIPTION
## Summary

Fix Inductor CPU deterministic `empty` behavior on Windows so compiled results match eager when deterministic fill of uninitialized memory is enabled.

## Root cause

On Windows, some Inductor CPU allocation paths used optimized internals that did not consistently preserve eager deterministic-fill semantics, causing mismatches in `test_empty_deterministic_*_cpu`.

## Changes

- `torch/_inductor/codegen/wrapper.py`  
  Emit runtime deterministic checks and fall back to `torch.empty_strided(...)` in deterministic mode.
- `torch/csrc/inductor/aoti_torch/shim_common.cpp`  
  Route AOTI `empty_strided` (including pinned CPU) through `at::empty_strided(..., TensorOptions)`.

## Validation

`pytest -v test/inductor/test_torchinductor.py::CpuTests -k empty_deterministic`  
→ `8 passed, 1 skipped`.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo