### PR TITLE
Enable B018 and B019 flake8-bugbear lint rules (#106571)

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -12,7 +12,7 @@ ignore =
     # to line this up with executable bit
     EXE001,
     # these ignores are from flake8-bugbear; please fix!
-    B007,B008,B017,B019,B023,B028,B903,B905,B906,B907,B908,B910
+    B007,B008,B017,B023,B028,B903,B905,B906,B907,B908,B910
     # these ignores are from flake8-simplify. please fix or ignore with commented reason
     SIM105,SIM108,SIM110,SIM111,SIM113,SIM114,SIM115,SIM116,SIM117,SIM118,SIM119,SIM12,
     # SIM104 is already covered by pyupgrade ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,7 +157,6 @@ external = [
 ignore = [
     # these ignores are from flake8-bugbear; please fix!
     "B007", "B008", "B017",
-    "B018", # Useless expression
     "B023",
     "B028", # No explicit `stacklevel` keyword argument found
     "E402",
@@ -340,6 +339,9 @@ select = [
 "tools/linter/**" = [
     "LOG015" # please fix
 ]
+
+# test/ folders still needing B018 migration
+"test/**" = ["B018"]
 
 # torch/ folders still needing S101 migration
 "torch/_dynamo/**" = ["S101"]

--- a/torch/_dynamo/resume_execution.py
+++ b/torch/_dynamo/resume_execution.py
@@ -105,7 +105,7 @@ def _try_except_tf_mode_template(dummy: Any, stack_var_name: Any) -> None:
     # pyrefly: ignore [unknown-name]
     global __import_torch_dot__dynamo_dot_utils
     try:
-        dummy
+        dummy  # noqa: B018
     except:  # noqa: E722, B001
         __import_torch_dot__dynamo_dot_utils.set_torch_function_mode_stack(  # type: ignore[name-defined]
             stack_var_name
@@ -179,7 +179,7 @@ class ReenterWith:
         def _template(ctx: AbstractContextManager[Any], dummy: Any) -> None:
             ctx.__enter__()
             try:
-                dummy
+                dummy  # noqa: B018
             finally:
                 ctx.__exit__(None, None, None)
 
@@ -216,7 +216,7 @@ class ReenterWith:
 
         def _template(ctx: AbstractContextManager[Any], dummy: Any) -> None:
             with ctx:
-                dummy
+                dummy  # noqa: B018
 
         setup_with, epilogue = _bytecode_from_template_with_split(
             _template, self.stack_index

--- a/torch/_inductor/comm_lowering.py
+++ b/torch/_inductor/comm_lowering.py
@@ -187,9 +187,7 @@ def register_comm_lowerings():
     """
     Register lowerings for the comm subsystem.
     """
-    try:
-        torch.ops._c10d_functional.all_reduce
-    except AttributeError:
+    if not hasattr(torch.ops._c10d_functional, "all_reduce"):
         log.info(
             "Inductor support for distributed collectives depends on building "
             "torch.distributed"
@@ -472,14 +470,12 @@ def register_symm_mem_lowerings():
     """
     Register lowerings for symmetric memory (symm_mem) operations.
     """
-    try:
-        symm_mem = torch.ops.symm_mem
-        # Check for an actual operation, not just the namespace.
-        # torch.ops.symm_mem is a lazy namespace that always exists,
-        # but the operations may not exist on non-CUDA platforms or
-        # when USE_DISTRIBUTED is disabled.
-        symm_mem.one_shot_all_reduce
-    except AttributeError:
+    symm_mem = torch.ops.symm_mem
+    # Check for an actual operation, not just the namespace.
+    # torch.ops.symm_mem is a lazy namespace that always exists,
+    # but the operations may not exist on non-CUDA platforms or
+    # when USE_DISTRIBUTED is disabled.
+    if not hasattr(symm_mem, "one_shot_all_reduce"):
         log.info("symm_mem ops not available, skipping symm_mem lowerings")
         return
 

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -2176,7 +2176,7 @@ def _find_names(obj):
 
     frame = inspect.currentframe()
     while frame is not None:
-        frame.f_locals
+        frame.f_locals  # noqa: B018
         frame = frame.f_back
     obj_names = []
     for referrer in gc.get_referrers(obj):

--- a/torch/distributed/_symmetric_memory/_nvshmem_triton.py
+++ b/torch/distributed/_symmetric_memory/_nvshmem_triton.py
@@ -167,7 +167,7 @@ def _nvshmem_init_hook(*args, **kwargs) -> None:  # type: ignore[no-untyped-def]
         kernel_cache = jit_function.device_caches[device][0]
         kernel = kernel_cache.get(key, None)
         if kernel is not None:
-            kernel.run
+            kernel.run  # noqa: B018
             # Initialize NVSHMEM for the CU module
             _nvshmemx_cumodule_init(kernel.module)
         else:

--- a/torch/fx/experimental/unification/core.py
+++ b/torch/fx/experimental/unification/core.py
@@ -21,15 +21,9 @@ def _reify(t, s):
     # return (reify(arg, s) for arg in t)
 
 
-_reify
-
-
 @dispatch(tuple, dict)  # type: ignore[no-redef]
 def _reify(t, s):
     return tuple(reify(iter(t), s))
-
-
-_reify
 
 
 @dispatch(list, dict)  # type: ignore[no-redef]
@@ -37,15 +31,9 @@ def _reify(t, s):
     return list(reify(iter(t), s))
 
 
-_reify
-
-
 @dispatch(dict, dict)  # type: ignore[no-redef]
 def _reify(d, s):
     return {k: reify(v, s) for k, v in d.items()}
-
-
-_reify
 
 
 @dispatch(object, dict)  # type: ignore[no-redef]
@@ -131,9 +119,6 @@ def unify(u, v, s):  # no check at the moment
     if isvar(v):
         return assoc(s, v, u)
     return _unify(u, v, s)
-
-
-unify
 
 
 @dispatch(object, object)  # type: ignore[no-redef]

--- a/torch/fx/experimental/unification/variable.py
+++ b/torch/fx/experimental/unification/variable.py
@@ -50,9 +50,6 @@ def isvar(v):
     return True
 
 
-isvar
-
-
 @dispatch(object)  # type: ignore[no-redef]
 def isvar(o):
     return _glv and hashable(o) and o in _glv

--- a/torch/package/package_importer.py
+++ b/torch/package/package_importer.py
@@ -483,15 +483,12 @@ class PackageImporter(Importer):
                 return self.modules[name]
             parent_module = self.modules[parent]
 
-            try:
-                parent_module.__path__  # type: ignore[attr-defined]
-
-            except AttributeError:
+            if not hasattr(parent_module, "__path__"):
                 # when we attempt to import a package only containing pybinded files,
                 # the parent directory isn't always a package as defined by python,
                 # so we search if the package is actually there or not before calling the error.
                 if isinstance(
-                    parent_module.__loader__,
+                    parent_module.__loader__,  # type: ignore[attr-defined]
                     importlib.machinery.ExtensionFileLoader,
                 ):
                     if name not in self.extern_modules:

--- a/torch/profiler/_pattern_matcher.py
+++ b/torch/profiler/_pattern_matcher.py
@@ -428,7 +428,7 @@ class SynchronizedDataLoaderPattern(Pattern):
         # actually point to an already freed string when the even is a PyCall.
         # Just silently skip this to unblock testing.
         try:
-            event.name
+            event.name  # noqa: B018
         except UnicodeDecodeError:
             return False
 


### PR DESCRIPTION
## Summary
Enable B018 and B019 lint rules. Fix all torch/ violations —
dead code removal, noqa for intentional side-effects,
hasattr() refactor. test/ deferred via per-file-ignore.

Partial fix for #106571 (B018, B019)

## Test plan
- ruff check --select=B018,B019 torch/ → 0 violations
- No behavioral changes

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98 @Lucaskabela