### PR TITLE
Simplify registry code in C++20

### DIFF
--- a/aten/src/ATen/detail/CUDAHooksInterface.h
+++ b/aten/src/ATen/detail/CUDAHooksInterface.h
@@ -246,8 +246,6 @@ struct TORCH_API CUDAHooksInterface : AcceleratorHooksInterface {
   }
 };
 
-// NB: dummy argument to suppress "ISO C++11 requires at least one argument
-// for the "..." in a variadic macro"
 struct TORCH_API CUDAHooksArgs {};
 
 TORCH_DECLARE_REGISTRY(CUDAHooksRegistry, CUDAHooksInterface, CUDAHooksArgs);

--- a/aten/src/ATen/detail/HIPHooksInterface.h
+++ b/aten/src/ATen/detail/HIPHooksInterface.h
@@ -52,8 +52,6 @@ struct TORCH_API HIPHooksInterface : AcceleratorHooksInterface {
   }
 };
 
-// NB: dummy argument to suppress "ISO C++11 requires at least one argument
-// for the "..." in a variadic macro"
 struct TORCH_API HIPHooksArgs {};
 
 TORCH_DECLARE_REGISTRY(HIPHooksRegistry, HIPHooksInterface, HIPHooksArgs);

--- a/aten/src/ATen/detail/IPUHooksInterface.cpp
+++ b/aten/src/ATen/detail/IPUHooksInterface.cpp
@@ -5,7 +5,7 @@ namespace detail {
 
 const IPUHooksInterface& getIPUHooks() {
   auto create_impl = [] {
-    auto hooks = IPUHooksRegistry()->Create("IPUHooks", IPUHooksArgs{});
+    auto hooks = IPUHooksRegistry()->Create("IPUHooks");
     if (hooks) {
       return hooks;
     }
@@ -17,6 +17,6 @@ const IPUHooksInterface& getIPUHooks() {
 
 } // namespace detail
 
-C10_DEFINE_REGISTRY(IPUHooksRegistry, IPUHooksInterface, IPUHooksArgs)
+C10_DEFINE_REGISTRY(IPUHooksRegistry, IPUHooksInterface)
 
 } // namespace at

--- a/aten/src/ATen/detail/IPUHooksInterface.h
+++ b/aten/src/ATen/detail/IPUHooksInterface.h
@@ -31,9 +31,10 @@ struct TORCH_API IPUHooksInterface : AcceleratorHooksInterface {
   }
 };
 
+// Deprecated: no longer used internally, kept for ABI compatibility.
 struct TORCH_API IPUHooksArgs {};
 
-TORCH_DECLARE_REGISTRY(IPUHooksRegistry, IPUHooksInterface, IPUHooksArgs);
+TORCH_DECLARE_REGISTRY(IPUHooksRegistry, IPUHooksInterface);
 #define REGISTER_IPU_HOOKS(clsname) \
   C10_REGISTER_CLASS(IPUHooksRegistry, clsname, clsname)
 

--- a/aten/src/ATen/detail/MAIAHooksInterface.cpp
+++ b/aten/src/ATen/detail/MAIAHooksInterface.cpp
@@ -6,7 +6,7 @@ namespace detail {
 // See getCUDAHooks for some more commentary
 const MAIAHooksInterface& getMAIAHooks() {
   auto create_impl = [] {
-    auto hooks = MAIAHooksRegistry()->Create("MAIAHooks", {});
+    auto hooks = MAIAHooksRegistry()->Create("MAIAHooks");
     if (hooks) {
       return hooks;
     }
@@ -18,6 +18,6 @@ const MAIAHooksInterface& getMAIAHooks() {
 } // namespace detail
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-C10_DEFINE_REGISTRY(MAIAHooksRegistry, MAIAHooksInterface, MAIAHooksArgs)
+C10_DEFINE_REGISTRY(MAIAHooksRegistry, MAIAHooksInterface)
 
 } // namespace at

--- a/aten/src/ATen/detail/MAIAHooksInterface.h
+++ b/aten/src/ATen/detail/MAIAHooksInterface.h
@@ -27,11 +27,10 @@ struct TORCH_API MAIAHooksInterface : AcceleratorHooksInterface {
   }
 };
 
-// NB: dummy argument to suppress "ISO C++11 requires at least one argument
-// for the "..." in a variadic macro"
+// Deprecated: no longer used internally, kept for ABI compatibility.
 struct TORCH_API MAIAHooksArgs {};
 
-TORCH_DECLARE_REGISTRY(MAIAHooksRegistry, MAIAHooksInterface, MAIAHooksArgs);
+TORCH_DECLARE_REGISTRY(MAIAHooksRegistry, MAIAHooksInterface);
 #define REGISTER_MAIA_HOOKS(clsname) \
   C10_REGISTER_CLASS(MAIAHooksRegistry, clsname, clsname)
 

--- a/aten/src/ATen/detail/MPSHooksInterface.cpp
+++ b/aten/src/ATen/detail/MPSHooksInterface.cpp
@@ -8,7 +8,7 @@ namespace detail {
 const MPSHooksInterface& getMPSHooks() {
   auto create_impl = [] {
 #if !defined C10_MOBILE
-    auto hooks = MPSHooksRegistry()->Create("MPSHooks", MPSHooksArgs{});
+    auto hooks = MPSHooksRegistry()->Create("MPSHooks");
     if (hooks) {
       return hooks;
     }
@@ -20,6 +20,6 @@ const MPSHooksInterface& getMPSHooks() {
 }
 } // namespace detail
 
-C10_DEFINE_REGISTRY(MPSHooksRegistry, MPSHooksInterface, MPSHooksArgs)
+C10_DEFINE_REGISTRY(MPSHooksRegistry, MPSHooksInterface)
 
 } // namespace at

--- a/aten/src/ATen/detail/MPSHooksInterface.h
+++ b/aten/src/ATen/detail/MPSHooksInterface.h
@@ -111,9 +111,10 @@ struct TORCH_API MPSHooksInterface : AcceleratorHooksInterface {
   #undef FAIL_MPSHOOKS_FUNC
 };
 
+// Deprecated: no longer used internally, kept for ABI compatibility.
 struct TORCH_API MPSHooksArgs {};
 
-TORCH_DECLARE_REGISTRY(MPSHooksRegistry, MPSHooksInterface, MPSHooksArgs);
+TORCH_DECLARE_REGISTRY(MPSHooksRegistry, MPSHooksInterface);
 #define REGISTER_MPS_HOOKS(clsname) \
   C10_REGISTER_CLASS(MPSHooksRegistry, clsname, clsname)
 

--- a/aten/src/ATen/detail/MTIAHooksInterface.cpp
+++ b/aten/src/ATen/detail/MTIAHooksInterface.cpp
@@ -5,7 +5,7 @@ namespace detail {
 
 const MTIAHooksInterface& getMTIAHooks() {
   auto create_impl = [] {
-    auto hooks = MTIAHooksRegistry()->Create("MTIAHooks", MTIAHooksArgs{});
+    auto hooks = MTIAHooksRegistry()->Create("MTIAHooks");
     if (hooks) {
       return hooks;
     }
@@ -25,6 +25,6 @@ bool MTIAHooksInterface::isAvailable() const {
   return detail::isMTIAHooksBuilt() && detail::getMTIAHooks().deviceCount() > 0;
 }
 
-C10_DEFINE_REGISTRY(MTIAHooksRegistry, MTIAHooksInterface, MTIAHooksArgs)
+C10_DEFINE_REGISTRY(MTIAHooksRegistry, MTIAHooksInterface)
 
 } // namespace at

--- a/aten/src/ATen/detail/MTIAHooksInterface.h
+++ b/aten/src/ATen/detail/MTIAHooksInterface.h
@@ -201,9 +201,10 @@ struct TORCH_API MTIAHooksInterface : AcceleratorHooksInterface {
   }
 };
 
+// Deprecated: no longer used internally, kept for ABI compatibility.
 struct TORCH_API MTIAHooksArgs {};
 
-TORCH_DECLARE_REGISTRY(MTIAHooksRegistry, MTIAHooksInterface, MTIAHooksArgs);
+TORCH_DECLARE_REGISTRY(MTIAHooksRegistry, MTIAHooksInterface);
 #define REGISTER_MTIA_HOOKS(clsname) C10_REGISTER_CLASS(MTIAHooksRegistry, clsname, clsname)
 
 namespace detail {

--- a/aten/src/ATen/detail/XLAHooksInterface.cpp
+++ b/aten/src/ATen/detail/XLAHooksInterface.cpp
@@ -6,7 +6,7 @@ namespace detail {
 const XLAHooksInterface& getXLAHooks() {
   auto create_impl = [] {
     // Create XLA hooks using the registry
-    auto hooks = XLAHooksRegistry()->Create("torch_xla::detail::XLAHooks", XLAHooksArgs{});
+    auto hooks = XLAHooksRegistry()->Create("torch_xla::detail::XLAHooks");
     if (hooks) {
       return hooks;
     }
@@ -18,6 +18,6 @@ const XLAHooksInterface& getXLAHooks() {
 }
 } // namespace detail
 
-C10_DEFINE_REGISTRY(XLAHooksRegistry, XLAHooksInterface, XLAHooksArgs)
+C10_DEFINE_REGISTRY(XLAHooksRegistry, XLAHooksInterface)
 
 } // namespace at

--- a/aten/src/ATen/detail/XLAHooksInterface.h
+++ b/aten/src/ATen/detail/XLAHooksInterface.h
@@ -66,9 +66,10 @@ struct TORCH_API XLAHooksInterface : AcceleratorHooksInterface {
 
 };
 
+// Deprecated: no longer used internally, kept for ABI compatibility.
 struct TORCH_API XLAHooksArgs {};
 
-TORCH_DECLARE_REGISTRY(XLAHooksRegistry, XLAHooksInterface, XLAHooksArgs);
+TORCH_DECLARE_REGISTRY(XLAHooksRegistry, XLAHooksInterface);
 #define REGISTER_XLA_HOOKS(clsname) \
   C10_REGISTER_CLASS(XLAHooksRegistry, clsname, clsname)
 

--- a/aten/src/ATen/detail/XPUHooksInterface.cpp
+++ b/aten/src/ATen/detail/XPUHooksInterface.cpp
@@ -5,7 +5,7 @@ namespace detail {
 
 const XPUHooksInterface& getXPUHooks() {
   auto create_impl = [] {
-    auto hooks = XPUHooksRegistry()->Create("XPUHooks", XPUHooksArgs{});
+    auto hooks = XPUHooksRegistry()->Create("XPUHooks");
     if (hooks) {
       return hooks;
     }
@@ -16,6 +16,6 @@ const XPUHooksInterface& getXPUHooks() {
 }
 } // namespace detail
 
-C10_DEFINE_REGISTRY(XPUHooksRegistry, XPUHooksInterface, XPUHooksArgs)
+C10_DEFINE_REGISTRY(XPUHooksRegistry, XPUHooksInterface)
 
 } // namespace at

--- a/aten/src/ATen/detail/XPUHooksInterface.h
+++ b/aten/src/ATen/detail/XPUHooksInterface.h
@@ -81,9 +81,10 @@ struct TORCH_API XPUHooksInterface : AcceleratorHooksInterface{
   }
 };
 
+// Deprecated: no longer used internally, kept for ABI compatibility.
 struct TORCH_API XPUHooksArgs {};
 
-TORCH_DECLARE_REGISTRY(XPUHooksRegistry, XPUHooksInterface, XPUHooksArgs);
+TORCH_DECLARE_REGISTRY(XPUHooksRegistry, XPUHooksInterface);
 #define REGISTER_XPU_HOOKS(clsname) \
   C10_REGISTER_CLASS(XPUHooksRegistry, clsname, clsname)
 

--- a/aten/src/ATen/mps/MPSHooks.h
+++ b/aten/src/ATen/mps/MPSHooks.h
@@ -11,7 +11,7 @@ namespace at::mps {
 
 // The real implementation of MPSHooksInterface
 struct MPSHooks : public at::MPSHooksInterface {
-  MPSHooks(at::MPSHooksArgs) {}
+  MPSHooks() {}
   void init() const override;
 
   // MPSDevice interface

--- a/aten/src/ATen/xpu/detail/XPUHooks.h
+++ b/aten/src/ATen/xpu/detail/XPUHooks.h
@@ -6,7 +6,7 @@ namespace at::xpu::detail {
 
 // The real implementation of XPUHooksInterface
 struct XPUHooks : public at::XPUHooksInterface {
-  XPUHooks(at::XPUHooksArgs) {}
+  XPUHooks() {}
   void init() const override;
   bool hasXPU() const override;
   std::string showConfig() const override;

--- a/c10/core/impl/PyInterpreterHooks.cpp
+++ b/c10/core/impl/PyInterpreterHooks.cpp
@@ -3,16 +3,12 @@
 namespace c10::impl {
 
 // Define the registry
-C10_DEFINE_REGISTRY(
-    PyInterpreterHooksRegistry,
-    PyInterpreterHooksInterface,
-    PyInterpreterHooksArgs)
+C10_DEFINE_REGISTRY(PyInterpreterHooksRegistry, PyInterpreterHooksInterface)
 
 const PyInterpreterHooksInterface& getPyInterpreterHooks() {
   auto create_impl = [] {
 #if !defined C10_MOBILE
-    auto hooks = PyInterpreterHooksRegistry()->Create(
-        "PyInterpreterHooks", PyInterpreterHooksArgs{});
+    auto hooks = PyInterpreterHooksRegistry()->Create("PyInterpreterHooks");
     if (hooks) {
       return hooks;
     }

--- a/c10/core/impl/PyInterpreterHooks.h
+++ b/c10/core/impl/PyInterpreterHooks.h
@@ -21,12 +21,10 @@ struct C10_API PyInterpreterHooksInterface {
   }
 };
 
+// Deprecated: no longer used internally, kept for ABI compatibility.
 struct C10_API PyInterpreterHooksArgs{};
 
-C10_DECLARE_REGISTRY(
-    PyInterpreterHooksRegistry,
-    PyInterpreterHooksInterface,
-    PyInterpreterHooksArgs);
+C10_DECLARE_REGISTRY(PyInterpreterHooksRegistry, PyInterpreterHooksInterface);
 
 #define REGISTER_PYTHON_HOOKS(clsname) \
   C10_REGISTER_CLASS(PyInterpreterHooksRegistry, clsname, clsname)

--- a/test/cpp_extensions/mtia_extension.cpp
+++ b/test/cpp_extensions/mtia_extension.cpp
@@ -138,7 +138,7 @@ struct MTIAGuardImpl final : public c10::impl::DeviceGuardImplInterface {
 };
 
 struct MTIAHooks : public at::MTIAHooksInterface {
-  explicit MTIAHooks(at::MTIAHooksArgs) {}
+  MTIAHooks() {}
   void init() const override {}
 
   bool hasMTIA() const override {

--- a/torch/csrc/PyInterpreterHooks.cpp
+++ b/torch/csrc/PyInterpreterHooks.cpp
@@ -3,8 +3,7 @@
 
 namespace torch::detail {
 
-PyInterpreterHooks::PyInterpreterHooks(
-    c10::impl::PyInterpreterHooksArgs /*unused*/) {}
+PyInterpreterHooks::PyInterpreterHooks() {}
 
 c10::impl::PyInterpreter* PyInterpreterHooks::getPyInterpreter() const {
   // Delegate to the existing implementation

--- a/torch/csrc/PyInterpreterHooks.h
+++ b/torch/csrc/PyInterpreterHooks.h
@@ -7,7 +7,7 @@ namespace torch::detail {
 // Concrete implementation of PyInterpreterHooks
 class PyInterpreterHooks : public c10::impl::PyInterpreterHooksInterface {
  public:
-  explicit PyInterpreterHooks(c10::impl::PyInterpreterHooksArgs /*unused*/);
+  PyInterpreterHooks();
 
   c10::impl::PyInterpreter* getPyInterpreter() const override;
 };


### PR DESCRIPTION
This PR contains the following fixes:
  - Remove dummy *HooksArgs from registry usage where no external consumers exist (IPU, MPS, MTIA, XPU, XLA,
  MAIA, PyInterpreter)
  - Keep *HooksArgs structs and registry usage for CUDA, HIP, HPU, and PrivateUse1 which have external
  consumers (e.g. HabanaAI/gaudi-pytorch-bridge, Cambricon/torch_mlu, Ascend/pytorch)
  - Unused *HooksArgs structs are kept as deprecated for ABI compatibility

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo