### PR TITLE
[XPU] Remove @expectedFailureXPU from test_max_pool2d_with_indices_backward5

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -10491,7 +10491,6 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         # Correctness is validated by self.common() above.
         self.assertGreater(torch._inductor.metrics.generated_kernel_count, 0)
 
-    @expectedFailureXPU
     def test_max_pool2d_with_indices_backward5(self):
         # Large window size - decomposition handles via scatter_add
         def fn(a, b, c):


### PR DESCRIPTION
## Summary
Remove the `@expectedFailureXPU` decorator from `test_max_pool2d_with_indices_backward5` since the test now passes on XPU.

## Root Cause
PR #167318 added a `scatter_add`-based decomposition for `max_pool2d_with_indices_backward` that correctly handles all configurations (including large kernel sizes like 13x13). This decomposition works correctly on XPU, but the `@expectedFailureXPU` decorator was not removed.

Since `@expectedFailureXPU` expects the test to **fail**, a passing test triggers an "unexpected success" error, which is reported as a test failure.

## Fixes
- `test/inductor/test_torchinductor.py::GPUTests::test_max_pool2d_with_indices_backward5_xpu`
- `test/inductor/test_torchinductor_dynamic_shapes.py::DynamicShapesGPUTests::test_max_pool2d_with_indices_backward5_dynamic_shapes_xpu`
- `test/inductor/test_torchinductor_codegen_dynamic_shapes.py::DynamicShapesCodegenGPUTests::test_max_pool2d_with_indices_backward5_dynamic_shapes_xpu`
- `test/inductor/test_compile_subprocess.py::GPUTests::test_max_pool2d_with_indices_backward5_xpu`

All four test files share the same `CommonTemplate` via `copy_tests()`, so the single decorator removal fixes all four.

## Verification
Tested locally on Intel GPU (BMG) with XPU + Triton: the `scatter_add` decomposition produces correct results with max diff ~6.7e-06 vs eager reference.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @isuruf @smcgover