### PR TITLE
[xpu] Enable GPU ARCH filter to FlashAttention Unit Test in CI

### DIFF
--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -55,6 +55,7 @@ from torch.testing._internal.common_cuda import (
     tf32_on_and_off,
     tf32_enabled,
 )
+from torch.testing._internal.common_device_type import skipXPUIf
 from torch.testing._internal.common_xpu import PLATFORM_SUPPORTS_FLASH_ATTENTION_XPU
 
 if TEST_FAIRSEQ:
@@ -4883,7 +4884,7 @@ class TestSDPAXpuOnly(NNTestCase):
 
         self.assertEqual(actual.float(), math_ref, atol=tol.atol, rtol=tol.rtol)
 
-    @unittest.skipIf(not PLATFORM_SUPPORTS_FLASH_ATTENTION_XPU, "XPU Flash Attention is not supported")
+    @skipXPUIf(not PLATFORM_SUPPORTS_FLASH_ATTENTION_XPU, "XPU Flash Attention is not supported")
     @parametrize("dtype", [torch.float32, torch.float64])
     def test_flash_attention_unsupport_dtypes(self, device, dtype):
         make_tensor = partial(torch.rand, device=device, dtype=dtype, requires_grad=False)
@@ -4901,7 +4902,7 @@ class TestSDPAXpuOnly(NNTestCase):
             with self.assertRaisesRegex(RuntimeError, "No available kernel"):
                 F.scaled_dot_product_attention(q, k, v)
 
-    @unittest.skipIf(not PLATFORM_SUPPORTS_FLASH_ATTENTION_XPU, "XPU Flash Attention is not supported")
+    @skipXPUIf(not PLATFORM_SUPPORTS_FLASH_ATTENTION_XPU, "XPU Flash Attention is not supported")
     def test_flash_attention_unsupport_dropout(self, device):
         dtype = torch.bfloat16
         make_tensor = partial(torch.rand, device=device, dtype=dtype, requires_grad=False)
@@ -4919,7 +4920,7 @@ class TestSDPAXpuOnly(NNTestCase):
             with self.assertRaisesRegex(RuntimeError, "No available kernel"):
                 F.scaled_dot_product_attention(q, k, v, dropout_p=0.1)
 
-    @unittest.skipIf(not PLATFORM_SUPPORTS_FLASH_ATTENTION_XPU, "XPU Flash Attention is not supported")
+    @skipXPUIf(not PLATFORM_SUPPORTS_FLASH_ATTENTION_XPU, "XPU Flash Attention is not supported")
     def test_flash_attention_headdim_size(self, device):
         dtype = torch.bfloat16
         make_tensor = partial(torch.rand, device=device, dtype=dtype, requires_grad=False)
@@ -4943,7 +4944,7 @@ class TestSDPAXpuOnly(NNTestCase):
             with self.assertRaisesRegex(RuntimeError, "No available kernel"):
                 F.scaled_dot_product_attention(q, k, v)
 
-    @unittest.skipIf(not PLATFORM_SUPPORTS_FLASH_ATTENTION_XPU, "XPU Flash Attention is not supported")
+    @skipXPUIf(not PLATFORM_SUPPORTS_FLASH_ATTENTION_XPU, "XPU Flash Attention is not supported")
     def test_flash_attention_fail_with_non_square_causal_attention(self, device):
         dtype = torch.bfloat16
         q_shape = SdpaShape(1, 1, 8, 16)
@@ -4957,7 +4958,7 @@ class TestSDPAXpuOnly(NNTestCase):
                 self.assertRaises(RuntimeError, lambda: torch.nn.functional.scaled_dot_product_attention(
                     q, k, v, None, 0.0, is_causal=True))
 
-    @unittest.skipIf(not PLATFORM_SUPPORTS_FLASH_ATTENTION_XPU, "XPU Flash Attention is not supported")
+    @skipXPUIf(not PLATFORM_SUPPORTS_FLASH_ATTENTION_XPU, "XPU Flash Attention is not supported")
     @parametrize("fused_kernel", [SDPBackend.FLASH_ATTENTION])
     @parametrize("dtype", [torch.half, torch.bfloat16])
     @parametrize("batch_size", [1, 2, 4])
@@ -5123,7 +5124,7 @@ class TestAttnBias(NNTestCase):
         "shape",
         [(16, 16, 128, 128, 16), (16, 16, 128, 256, 32), (16, 16, 256, 128, 32), (1, 1, 23, 56, 15)],
     )
-    @unittest.skipIf(TEST_XPU and not PLATFORM_SUPPORTS_FLASH_ATTENTION_XPU, "XPU Flash Attention is not supported")
+    @skipXPUIf(not PLATFORM_SUPPORTS_FLASH_ATTENTION_XPU, "XPU Flash Attention is not supported")
     def test_causal_variants(self, device, causal_variant: CausalVariant, shape: list[tuple[int]]):
         make_tensor = partial(
             torch.rand, device=device, dtype=torch.float16, requires_grad=True
@@ -5156,7 +5157,7 @@ class TestAttnBias(NNTestCase):
         [(16, 16, 128, 128, 16), (16, 16, 128, 256, 32), (16, 16, 256, 128, 32), (1, 1, 23, 56, 15)],
     )
     @skipIfTorchDynamo("This function already calls torch.compile.")
-    @unittest.skipIf(TEST_XPU and not PLATFORM_SUPPORTS_FLASH_ATTENTION_XPU, "XPU Flash Attention is not supported")
+    @skipXPUIf(not PLATFORM_SUPPORTS_FLASH_ATTENTION_XPU, "XPU Flash Attention is not supported")
     def test_causal_variants_compile(self, device, causal_variant: CausalVariant, shape: list[tuple[int]]):
         cnts = CompileCounterWithBackend("aot_eager")
         make_tensor = partial(

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -5123,7 +5123,7 @@ class TestAttnBias(NNTestCase):
         "shape",
         [(16, 16, 128, 128, 16), (16, 16, 128, 256, 32), (16, 16, 256, 128, 32), (1, 1, 23, 56, 15)],
     )
-    @unittest.skipIf(not PLATFORM_SUPPORTS_FLASH_ATTENTION_XPU, "XPU Flash Attention is not supported")
+    @unittest.skipIf(TEST_XPU and not PLATFORM_SUPPORTS_FLASH_ATTENTION_XPU, "XPU Flash Attention is not supported")
     def test_causal_variants(self, device, causal_variant: CausalVariant, shape: list[tuple[int]]):
         make_tensor = partial(
             torch.rand, device=device, dtype=torch.float16, requires_grad=True
@@ -5156,7 +5156,7 @@ class TestAttnBias(NNTestCase):
         [(16, 16, 128, 128, 16), (16, 16, 128, 256, 32), (16, 16, 256, 128, 32), (1, 1, 23, 56, 15)],
     )
     @skipIfTorchDynamo("This function already calls torch.compile.")
-    @unittest.skipIf(not PLATFORM_SUPPORTS_FLASH_ATTENTION_XPU, "XPU Flash Attention is not supported")
+    @unittest.skipIf(TEST_XPU and not PLATFORM_SUPPORTS_FLASH_ATTENTION_XPU, "XPU Flash Attention is not supported")
     def test_causal_variants_compile(self, device, causal_variant: CausalVariant, shape: list[tuple[int]]):
         cnts = CompileCounterWithBackend("aot_eager")
         make_tensor = partial(

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -55,6 +55,7 @@ from torch.testing._internal.common_cuda import (
     tf32_on_and_off,
     tf32_enabled,
 )
+from torch.testing._internal.common_xpu import PLATFORM_SUPPORTS_FLASH_ATTENTION_XPU
 
 if TEST_FAIRSEQ:
     import fairseq.models.transformer as fairseq_transformer
@@ -4576,7 +4577,6 @@ class TestSDPAXpuOnly(NNTestCase):
     Mostly migrate from TestSDPACudaOnly in test/test_transformers.py
     """
 
-    PLATFORM_SUPPORTS_XPU_FLASH_ATTENTION = torch.xpu.is_available() and torch._C._is_flash_attention_available()
 
     @parametrize("type", ["dense"])
     @parametrize("dropout", [0.0, 0.7])
@@ -4883,7 +4883,7 @@ class TestSDPAXpuOnly(NNTestCase):
 
         self.assertEqual(actual.float(), math_ref, atol=tol.atol, rtol=tol.rtol)
 
-    @unittest.skipIf(not PLATFORM_SUPPORTS_XPU_FLASH_ATTENTION, "XPU Flash Attention is not supported")
+    @unittest.skipIf(not PLATFORM_SUPPORTS_FLASH_ATTENTION_XPU, "XPU Flash Attention is not supported")
     @parametrize("dtype", [torch.float32, torch.float64])
     def test_flash_attention_unsupport_dtypes(self, device, dtype):
         make_tensor = partial(torch.rand, device=device, dtype=dtype, requires_grad=False)
@@ -4901,7 +4901,7 @@ class TestSDPAXpuOnly(NNTestCase):
             with self.assertRaisesRegex(RuntimeError, "No available kernel"):
                 F.scaled_dot_product_attention(q, k, v)
 
-    @unittest.skipIf(not PLATFORM_SUPPORTS_XPU_FLASH_ATTENTION, "XPU Flash Attention is not supported")
+    @unittest.skipIf(not PLATFORM_SUPPORTS_FLASH_ATTENTION_XPU, "XPU Flash Attention is not supported")
     def test_flash_attention_unsupport_dropout(self, device):
         dtype = torch.bfloat16
         make_tensor = partial(torch.rand, device=device, dtype=dtype, requires_grad=False)
@@ -4919,7 +4919,7 @@ class TestSDPAXpuOnly(NNTestCase):
             with self.assertRaisesRegex(RuntimeError, "No available kernel"):
                 F.scaled_dot_product_attention(q, k, v, dropout_p=0.1)
 
-    @unittest.skipIf(not PLATFORM_SUPPORTS_XPU_FLASH_ATTENTION, "XPU Flash Attention is not supported")
+    @unittest.skipIf(not PLATFORM_SUPPORTS_FLASH_ATTENTION_XPU, "XPU Flash Attention is not supported")
     def test_flash_attention_headdim_size(self, device):
         dtype = torch.bfloat16
         make_tensor = partial(torch.rand, device=device, dtype=dtype, requires_grad=False)
@@ -4943,7 +4943,7 @@ class TestSDPAXpuOnly(NNTestCase):
             with self.assertRaisesRegex(RuntimeError, "No available kernel"):
                 F.scaled_dot_product_attention(q, k, v)
 
-    @unittest.skipIf(not PLATFORM_SUPPORTS_XPU_FLASH_ATTENTION, "XPU Flash Attention is not supported")
+    @unittest.skipIf(not PLATFORM_SUPPORTS_FLASH_ATTENTION_XPU, "XPU Flash Attention is not supported")
     def test_flash_attention_fail_with_non_square_causal_attention(self, device):
         dtype = torch.bfloat16
         q_shape = SdpaShape(1, 1, 8, 16)
@@ -4957,7 +4957,7 @@ class TestSDPAXpuOnly(NNTestCase):
                 self.assertRaises(RuntimeError, lambda: torch.nn.functional.scaled_dot_product_attention(
                     q, k, v, None, 0.0, is_causal=True))
 
-    @unittest.skipIf(not PLATFORM_SUPPORTS_XPU_FLASH_ATTENTION, "XPU Flash Attention is not supported")
+    @unittest.skipIf(not PLATFORM_SUPPORTS_FLASH_ATTENTION_XPU, "XPU Flash Attention is not supported")
     @parametrize("fused_kernel", [SDPBackend.FLASH_ATTENTION])
     @parametrize("dtype", [torch.half, torch.bfloat16])
     @parametrize("batch_size", [1, 2, 4])
@@ -5123,6 +5123,7 @@ class TestAttnBias(NNTestCase):
         "shape",
         [(16, 16, 128, 128, 16), (16, 16, 128, 256, 32), (16, 16, 256, 128, 32), (1, 1, 23, 56, 15)],
     )
+    @unittest.skipIf(not PLATFORM_SUPPORTS_FLASH_ATTENTION_XPU, "XPU Flash Attention is not supported")
     def test_causal_variants(self, device, causal_variant: CausalVariant, shape: list[tuple[int]]):
         make_tensor = partial(
             torch.rand, device=device, dtype=torch.float16, requires_grad=True
@@ -5155,6 +5156,7 @@ class TestAttnBias(NNTestCase):
         [(16, 16, 128, 128, 16), (16, 16, 128, 256, 32), (16, 16, 256, 128, 32), (1, 1, 23, 56, 15)],
     )
     @skipIfTorchDynamo("This function already calls torch.compile.")
+    @unittest.skipIf(not PLATFORM_SUPPORTS_FLASH_ATTENTION_XPU, "XPU Flash Attention is not supported")
     def test_causal_variants_compile(self, device, causal_variant: CausalVariant, shape: list[tuple[int]]):
         cnts = CompileCounterWithBackend("aot_eager")
         make_tensor = partial(

--- a/torch/testing/_internal/common_xpu.py
+++ b/torch/testing/_internal/common_xpu.py
@@ -15,8 +15,9 @@ class XPUCodename(enum.Enum):
 
 
 class XPUArch(enum.Enum):
-    Xe = "Xe"  # Xe HPC
-    Xe2 = "Xe2"
+    Unknown = 0
+    Xe = 1  # Xe HPC
+    Xe2 = 2
 
 
 # device_id -> GPU codename
@@ -47,32 +48,19 @@ _CODENAME_TO_ARCH = {
 
 
 @functools.lru_cache(1)
-def get_xpu_device_id() -> int | None:
-    try:
-        return torch.xpu.get_device_capability()["device_id"]
-    except Exception:
-        log.exception("Error in getting xpu device_id.")
-        return None
-
-
-@functools.lru_cache(1)
 def get_xpu_codename() -> XPUCodename | None:
-    device_id = get_xpu_device_id()
-    if device_id is None:
-        return None
+    device_id = torch.xpu.get_device_capability()["device_id"]
     return _DEVICE_ID_TO_CODENAME.get(device_id)
 
 
 @functools.lru_cache(1)
 def get_xpu_arch() -> XPUArch | None:
     codename = get_xpu_codename()
-    if codename is None:
-        return None
-    return _CODENAME_TO_ARCH.get(codename)
+    return _CODENAME_TO_ARCH.get(codename, XPUArch.Unknown)
 
 
 Xe2_Or_Later = LazyVal(
-    lambda: torch.xpu.is_available() and get_xpu_arch() in (XPUArch.Xe2,)
+    lambda: torch.xpu.is_available() and get_xpu_arch() >= XPUArch.Xe2
 )
 
 

--- a/torch/testing/_internal/common_xpu.py
+++ b/torch/testing/_internal/common_xpu.py
@@ -14,7 +14,7 @@ class XPUCodename(enum.Enum):
     BMG = "BMG"  # Intel® Arc™ Pro Battlemage Graphics
 
 
-class XPUArch(enum.Enum):
+class XPUArch(enum.IntEnum):
     Unknown = 0
     Xe = 1  # Xe HPC
     Xe2 = 2

--- a/torch/testing/_internal/common_xpu.py
+++ b/torch/testing/_internal/common_xpu.py
@@ -1,19 +1,21 @@
+import enum
+import functools
+
 import torch
 import torch.xpu
-from torch.testing._internal.common_utils import LazyVal, TEST_XPU, IS_WINDOWS
-import enum, functools, logging
+from torch.testing._internal.common_utils import IS_WINDOWS, LazyVal, TEST_XPU
 
 
 XPU_ALREADY_INITIALIZED_ON_IMPORT = torch.xpu.is_initialized()
 
 
 class XPUCodename(enum.Enum):
-    PVC = "PVC"     # Intel® Data Center GPU Max Series
-    BMG = "BMG"     # Intel® Arc™ Pro Battlemage Graphics
+    PVC = "PVC"  # Intel® Data Center GPU Max Series
+    BMG = "BMG"  # Intel® Arc™ Pro Battlemage Graphics
 
 
 class XPUArch(enum.Enum):
-    Xe = "Xe"       # Xe HPC
+    Xe = "Xe"  # Xe HPC
     Xe2 = "Xe2"
 
 
@@ -43,6 +45,7 @@ _CODENAME_TO_ARCH = {
     XPUCodename.BMG: XPUArch.Xe2,
 }
 
+
 @functools.lru_cache(1)
 def get_xpu_device_id() -> int | None:
     try:
@@ -51,12 +54,14 @@ def get_xpu_device_id() -> int | None:
         log.exception("Error in getting xpu device_id.")
         return None
 
+
 @functools.lru_cache(1)
 def get_xpu_codename() -> XPUCodename | None:
     device_id = get_xpu_device_id()
     if device_id is None:
         return None
     return _DEVICE_ID_TO_CODENAME.get(device_id)
+
 
 @functools.lru_cache(1)
 def get_xpu_arch() -> XPUArch | None:
@@ -66,14 +71,20 @@ def get_xpu_arch() -> XPUArch | None:
     return _CODENAME_TO_ARCH.get(codename)
 
 
-Xe2_Or_Later = LazyVal(lambda: torch.xpu.is_available() and get_xpu_arch() in (XPUArch.Xe2,))
+Xe2_Or_Later = LazyVal(
+    lambda: torch.xpu.is_available() and get_xpu_arch() in (XPUArch.Xe2,)
+)
+
 
 def evaluate_platform_supports_flash_attention():
     if TEST_XPU:
         return not IS_WINDOWS and Xe2_Or_Later
     return False
 
-PLATFORM_SUPPORTS_FLASH_ATTENTION_XPU: bool = LazyVal(lambda: evaluate_platform_supports_flash_attention())
+
+PLATFORM_SUPPORTS_FLASH_ATTENTION_XPU: bool = LazyVal(
+    lambda: evaluate_platform_supports_flash_attention()
+)
 
 # Importing this module should NOT eagerly initialize XPU
 if not XPU_ALREADY_INITIALIZED_ON_IMPORT:

--- a/torch/testing/_internal/common_xpu.py
+++ b/torch/testing/_internal/common_xpu.py
@@ -21,8 +21,10 @@ class XPUArch(enum.Enum):
 
 
 # device_id -> GPU codename
+# From https://github.com/intel/intel-graphics-compiler/blob/master/inc/common/igfxfmid.h
 _DEVICE_ID_TO_CODENAME = {
     0x0BD0: XPUCodename.PVC,
+    0x0BD4: XPUCodename.PVC,
     0x0BD5: XPUCodename.PVC,
     0x0BD6: XPUCodename.PVC,
     0x0BD7: XPUCodename.PVC,
@@ -32,12 +34,18 @@ _DEVICE_ID_TO_CODENAME = {
     0x0BDB: XPUCodename.PVC,
     0x0B69: XPUCodename.PVC,
     0x0B6E: XPUCodename.PVC,
+    0xE202: XPUCodename.BMG,
     0xE20B: XPUCodename.BMG,
     0xE20C: XPUCodename.BMG,
-    0xE211: XPUCodename.BMG,
+    0xE20D: XPUCodename.BMG,
+    0xE210: XPUCodename.BMG,
     0xE212: XPUCodename.BMG,
-    0xE223: XPUCodename.BMG,
+    0xE215: XPUCodename.BMG,
+    0xE216: XPUCodename.BMG,
+    0xE220: XPUCodename.BMG,
+    0xE221: XPUCodename.BMG,
     0xE222: XPUCodename.BMG,
+    0xE223: XPUCodename.BMG,
 }
 
 # GPU codename -> architecture

--- a/torch/testing/_internal/common_xpu.py
+++ b/torch/testing/_internal/common_xpu.py
@@ -1,0 +1,81 @@
+import torch
+import torch.xpu
+from torch.testing._internal.common_utils import LazyVal, TEST_XPU, IS_WINDOWS
+import enum, functools, logging
+
+
+XPU_ALREADY_INITIALIZED_ON_IMPORT = torch.xpu.is_initialized()
+
+
+class XPUCodename(enum.Enum):
+    PVC = "PVC"     # Intel® Data Center GPU Max Series
+    BMG = "BMG"     # Intel® Arc™ Pro Battlemage Graphics
+
+
+class XPUArch(enum.Enum):
+    Xe = "Xe"       # Xe HPC
+    Xe2 = "Xe2"
+
+
+# device_id -> GPU codename
+_DEVICE_ID_TO_CODENAME = {
+    0x0BD0: XPUCodename.PVC,
+    0x0BD5: XPUCodename.PVC,
+    0x0BD6: XPUCodename.PVC,
+    0x0BD7: XPUCodename.PVC,
+    0x0BD8: XPUCodename.PVC,
+    0x0BD9: XPUCodename.PVC,
+    0x0BDA: XPUCodename.PVC,
+    0x0BDB: XPUCodename.PVC,
+    0x0B69: XPUCodename.PVC,
+    0x0B6E: XPUCodename.PVC,
+    0xE20B: XPUCodename.BMG,
+    0xE20C: XPUCodename.BMG,
+    0xE211: XPUCodename.BMG,
+    0xE212: XPUCodename.BMG,
+    0xE223: XPUCodename.BMG,
+    0xE222: XPUCodename.BMG,
+}
+
+# GPU codename -> architecture
+_CODENAME_TO_ARCH = {
+    XPUCodename.PVC: XPUArch.Xe,
+    XPUCodename.BMG: XPUArch.Xe2,
+}
+
+@functools.lru_cache(1)
+def get_xpu_device_id() -> int | None:
+    try:
+        return torch.xpu.get_device_capability()["device_id"]
+    except Exception:
+        log.exception("Error in getting xpu device_id.")
+        return None
+
+@functools.lru_cache(1)
+def get_xpu_codename() -> XPUCodename | None:
+    device_id = get_xpu_device_id()
+    if device_id is None:
+        return None
+    return _DEVICE_ID_TO_CODENAME.get(device_id)
+
+@functools.lru_cache(1)
+def get_xpu_arch() -> XPUArch | None:
+    codename = get_xpu_codename()
+    if codename is None:
+        return None
+    return _CODENAME_TO_ARCH.get(codename)
+
+
+Xe2_Or_Later = LazyVal(lambda: torch.xpu.is_available() and get_xpu_arch() in (XPUArch.Xe2,))
+
+def evaluate_platform_supports_flash_attention():
+    if TEST_XPU:
+        return not IS_WINDOWS and Xe2_Or_Later
+    return False
+
+PLATFORM_SUPPORTS_FLASH_ATTENTION_XPU: bool = LazyVal(lambda: evaluate_platform_supports_flash_attention())
+
+# Importing this module should NOT eagerly initialize XPU
+if not XPU_ALREADY_INITIALIZED_ON_IMPORT:
+    if torch.xpu.is_initialized():
+        raise AssertionError("XPU should not be initialized on import")


### PR DESCRIPTION
Currently, Pytorch XPU is using **Intel Data Center GPU Max** in CI/CD. 

However, SYCLTLA(SYCL Templates for Linear Algebra) only formally supports B580/B60 now. The LTS2 driver on **Intel Data Center GPU Max** may cause accuracy issue in SYCLTLA.

Hence, XPU will skip Unit Test for the kernels imlemented by SYCLTLA on **Intel Data Center GPU Max** and runs the UT on B60 instead. See https://github.com/pytorch/pytorch/pull/174188

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo