### PR TITLE
[Test] Add `bypass_device_restrictions` to allow `PrivateUse1` backends to run @onlyOn gated tests

### DIFF
--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_device.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_device.py
@@ -3,11 +3,6 @@
 import multiprocessing
 
 import torch
-from torch.testing._internal.common_device_type import (
-    instantiate_device_type_tests,
-    onlyCUDA,
-    onlyOn,
-)
 from torch.testing._internal.common_dtype import get_all_dtypes
 from torch.testing._internal.common_utils import run_tests, skipIfWindows, TestCase
 
@@ -131,35 +126,6 @@ class TestDevice(TestCase):
             ),
         ):
             raise exc
-
-
-class TestBypassDeviceRestrictions(TestCase):
-    """Verify that PrivateUse1 backends can run tests decorated with @onlyCUDA.
-
-    PrivateUse1TestBase sets bypass_device_restrictions = True, which causes
-    @onlyOn-based decorators to be bypassed. This allows out-of-tree backends
-    to run accelerator tests that are currently gated behind @onlyCUDA while
-    the long-term migration to device-generic tests is in progress.
-    """
-
-    @onlyCUDA
-    def test_bypass_only_cuda(self, device):
-        self.assertEqual(torch.device(device).type, "openreg")
-        x = torch.ones(4, device=device)
-        y = x + 1
-        self.assertEqual(y, torch.full((4,), 2.0, device=device))
-
-    @onlyOn(["cuda", "cpu"])
-    def test_bypass_only_on(self, device):
-        self.assertEqual(torch.device(device).type, "openreg")
-        x = torch.ones(4, device=device)
-        y = x + 1
-        self.assertEqual(y, torch.full((4,), 2.0, device=device))
-
-
-instantiate_device_type_tests(
-    TestBypassDeviceRestrictions, globals(), only_for="openreg"
-)
 
 
 if __name__ == "__main__":

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_device.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_device.py
@@ -3,6 +3,11 @@
 import multiprocessing
 
 import torch
+from torch.testing._internal.common_device_type import (
+    instantiate_device_type_tests,
+    onlyCUDA,
+    onlyOn,
+)
 from torch.testing._internal.common_dtype import get_all_dtypes
 from torch.testing._internal.common_utils import run_tests, skipIfWindows, TestCase
 
@@ -126,6 +131,33 @@ class TestDevice(TestCase):
             ),
         ):
             raise exc
+
+
+class TestBypassDeviceRestrictions(TestCase):
+    """Verify that PrivateUse1 backends can run tests decorated with @onlyCUDA.
+
+    PrivateUse1TestBase sets bypass_device_restrictions = True, which causes
+    @onlyOn-based decorators to be bypassed. This allows out-of-tree backends
+    to run accelerator tests that are currently gated behind @onlyCUDA while
+    the long-term migration to device-generic tests is in progress.
+    """
+
+    @onlyCUDA
+    def test_bypass_only_cuda(self, device):
+        self.assertEqual(torch.device(device).type, "openreg")
+        x = torch.ones(4, device=device)
+        y = x + 1
+        self.assertEqual(y, torch.full((4,), 2.0, device=device))
+
+    @onlyOn(["cuda", "cpu"])
+    def test_bypass_only_on(self, device):
+        self.assertEqual(torch.device(device).type, "openreg")
+        x = torch.ones(4, device=device)
+        y = x + 1
+        self.assertEqual(y, torch.full((4,), 2.0, device=device))
+
+
+instantiate_device_type_tests(TestBypassDeviceRestrictions, globals(), only_for="openreg")
 
 
 if __name__ == "__main__":

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_device.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_device.py
@@ -157,7 +157,9 @@ class TestBypassDeviceRestrictions(TestCase):
         self.assertEqual(y, torch.full((4,), 2.0, device=device))
 
 
-instantiate_device_type_tests(TestBypassDeviceRestrictions, globals(), only_for="openreg")
+instantiate_device_type_tests(
+    TestBypassDeviceRestrictions, globals(), only_for="openreg"
+)
 
 
 if __name__ == "__main__":

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
@@ -1,0 +1,50 @@
+# Owner(s): ["module: PrivateUse1"]
+
+import torch
+from torch.testing._internal.common_device_type import (
+    instantiate_device_type_tests,
+    onlyCUDA,
+    onlyOn,
+)
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+class TestBypassDeviceRestrictions(TestCase):
+    """Verify that PrivateUse1 backends can run tests decorated with @onlyCUDA.
+
+    PrivateUse1TestBase sets bypass_device_restrictions = True, which causes
+    @onlyOn-based decorators to be bypassed. This allows out-of-tree backends
+    to run accelerator tests that are currently gated behind @onlyCUDA while
+    the long-term migration to device-generic tests is in progress.
+    """
+
+    executed_count = 0
+
+    @onlyCUDA
+    def test_bypass_only_cuda(self, device):
+        type(self).executed_count += 1
+        self.assertEqual(torch.device(device).type, "openreg")
+
+    @onlyOn(["cuda"])
+    def test_bypass_only_on(self, device):
+        type(self).executed_count += 1
+        self.assertEqual(torch.device(device).type, "openreg")
+
+    def test_zzz_validate_bypass_execution(self, device):
+        expected_runs = 2
+        actual_runs = type(self).executed_count
+        self.assertEqual(
+            actual_runs,
+            expected_runs,
+            f"Bypass logic failed! "
+            f"Expected {expected_runs} tests to run, but only {actual_runs} executed.",
+        )
+
+
+instantiate_device_type_tests(
+    TestBypassDeviceRestrictions, globals(), only_for="openreg"
+)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
@@ -30,7 +30,7 @@ class TestBypassDeviceRestrictions(TestCase):
         type(self).executed_count += 1
         self.assertEqual(torch.device(device).type, "openreg")
 
-    def test_zzz_validate_bypass_execution(self, device):
+    def test_vaildate_bypass_execution(self, device):
         expected_runs = 2
         actual_runs = type(self).executed_count
         self.assertEqual(

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
@@ -12,13 +12,21 @@ from torch.testing._internal.common_utils import run_tests, TestCase
 class TestBypassDeviceRestrictions(TestCase):
     """Verify that PrivateUse1 backends can run tests decorated with @onlyCUDA.
 
-    PrivateUse1TestBase sets bypass_device_restrictions = True, which causes
-    @onlyOn-based decorators to be bypassed. This allows out-of-tree backends
-    to run accelerator tests that are currently gated behind @onlyCUDA while
-    the long-term migration to device-generic tests is in progress.
+    PrivateUse1TestBase sets bypass_device_restrictions = False by default.
+    Backends that are ready to run @onlyOn-gated tests must explicitly opt in
+    by setting bypass_device_restrictions = True in their setUp or subclass.
+    This allows out-of-tree backends to run accelerator tests that are
+    currently gated behind @onlyCUDA while the long-term migration to
+    device-generic tests is in progress.
     """
 
     executed_count = 0
+
+    def setUp(self):
+        # Explicitly opt-in: instance attribute shadows the False default on
+        # PrivateUse1TestBase so @onlyOn-based decorators allow this test to run.
+        self.bypass_device_restrictions = True
+        super().setUp()
 
     @onlyCUDA
     def test_bypass_only_cuda(self, device):
@@ -37,7 +45,8 @@ class TestBypassDeviceRestrictions(TestCase):
             actual_runs,
             expected_runs,
             f"Bypass logic failed! "
-            f"Expected {expected_runs} tests to run, but only {actual_runs} executed.",
+            f"Expected {expected_runs} tests to run, "
+            f"but only {actual_runs} executed.",
         )
 
 

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
@@ -39,6 +39,8 @@ class TestBypassDeviceRestrictions(TestCase):
         self.assertEqual(torch.device(device).type, "openreg")
 
     def test_vaildate_bypass_execution(self, device):
+        # Must run last. The 'v' prefix ensures this sorts after test_bypass_* ('b') alphabetically,
+        # so executed_count has been incremented by both bypass tests before we check it here.
         expected_runs = 2
         actual_runs = type(self).executed_count
         self.assertEqual(

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -679,7 +679,7 @@ class PrivateUse1TestBase(DeviceTypeTestBase):
     primary_device: ClassVar[str]
     device_mod = None
     device_type = "privateuse1"
-    bypass_device_restrictions = True
+    bypass_device_restrictions = False
 
     @classmethod
     def get_primary_device(cls):

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -318,6 +318,15 @@ def _update_param_kwargs(param_kwargs, name, value):
 class DeviceTypeTestBase(TestCase):
     device_type: str = "generic_device_type"
 
+    # When True, @onlyOn-based decorators (@onlyCUDA, @onlyMPS, etc.) will not
+    # skip tests for this device type. This is a pragmatic short-term solution to
+    # allow PrivateUse1 backends to run tests that are currently gated behind
+    # device-specific decorators. It is intended to be used together with the
+    # skip mechanism (see https://github.com/pytorch/pytorch/issues/177253).
+    # In the longer term, we are incrementally migrating accelerator tests to be
+    # device-generic and removing @onlyCUDA on tests that should be device-generic.
+    bypass_device_restrictions: bool = False
+
     # Flag to disable test suite early due to unrecoverable error such as CUDA error.
     _stop_test_suite = False
 
@@ -670,6 +679,7 @@ class PrivateUse1TestBase(DeviceTypeTestBase):
     primary_device: ClassVar[str]
     device_mod = None
     device_type = "privateuse1"
+    bypass_device_restrictions = True
 
     @classmethod
     def get_primary_device(cls):
@@ -1444,6 +1454,8 @@ class onlyOn:
         @wraps(fn)
         def only_fn(slf, *args, **kwargs):
             if slf.device_type not in self.device_type:
+                if getattr(slf, "bypass_device_restrictions", False):
+                    return fn(slf, *args, **kwargs)
                 reason = f"Only runs on {self.device_type}"
                 if IS_SANDCASTLE or IS_FBCODE:
                     print(


### PR DESCRIPTION
Fixes #177248 


Adds a `bypass_device_restrictions` flag to `DeviceTypeTestBase` that allows PrivateUse1 based out-of-tree backends to run tests currently gated behind `@onlyCUDA`, `@onlyOn` and related decorators without modifying any upstream
test files.

### Changes

**`torch/testing/_internal/common_device_type.py`**
- Add `bypass_device_restrictions: bool = False` class attribute to `DeviceTypeTestBase` (default `False` -- no impact on existing backends)
- Set `bypass_device_restrictions = True` on `PrivateUse1TestBase` so that registered PrivateUse1 backends opt in automatically
- In `onlyOn.__call__` check the flag before raising `SkipTest` — if `True` the test proceeds on the PrivateUse1 device instead of being skipped

**`test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_device.py`**
- Add `TestBypassDeviceRestrictions` exercising both `@onlyCUDA` and `@onlyOn(["cuda", "cpu"])` bypass via the openreg backend

cc @mruberry @NmomoN @mengpenghui @fwenguang @cdzhan @1274085042 @PHLens @albanD