### PR TITLE
Fix scalar scale attribute setup for oneDNN API compatibility

### DIFF
--- a/aten/src/ATen/native/mkldnn/xpu/detail/QMatmul.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/QMatmul.cpp
@@ -399,8 +399,8 @@ inline ScaleSpec make_scale_spec(
   if (scaling_type == at::blas::ScalingType::TensorWise) {
     // Scale tensorwise. The same as `--attr-scales=common`.
     // mask=0 : scale whole tensor
-    // groups={1, 1}: indicates that there is only one group for scaling
-    return {0, {1, 1}, dnnl::memory::data_type::f32};
+    // groups={}: no groups needed for scalar scaling (group_ndims must be 0 when mask=0)
+    return {0, {}, dnnl::memory::data_type::f32};
   } else {
     // (scaling_type == at::blas::ScalingType::RowWise)
     // Scale RowWise. The same as `--attr-scales=per_dim_01`.
@@ -479,7 +479,7 @@ sycl::event scaled_matmul(
   // scale_result tensor currently only supports scalar(TensorWise Scaling).
   bool with_dst_scale = scale_result && scale_result->defined();
   if (with_dst_scale) {
-    op_attr.set_scales(DNNL_ARG_DST, 0, {1}, dnnl::memory::data_type::f32);
+    op_attr.set_scales(DNNL_ARG_DST, 0, {}, dnnl::memory::data_type::f32);
   }
 
   op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);


### PR DESCRIPTION
## Fix scalar scale attribute setup for oneDNN API compatibility

### Summary
Fixes `scaled_mm` failure with newer oneDNN versions by using empty groups `{}` when `mask=0` (TensorWise/scalar scaling).

### Issue
`TestCommonXPU::test_out_warning_torch__scaled_mm_v2_xpu` fails with:
```
RuntimeError: could not set scales primitive attribute
```

### Root Cause
oneDNN commit [68d8e5e0fb](https://github.com/oneapi-src/oneDNN/commit/68d8e5e0fb) added validation that rejects `mask=0` with non-empty groups:
```cpp
VCHECK_ATTR(IMPLICATION(group_ndims > 0, mask > 0), VERBOSE_BAD_PARAM,
        "mask incompatible with group_dims");
```

The current code passes `groups={1,1}` or `{1}` when using scalar scaling (`mask=0`), which is now invalid.

### Changes
In `aten/src/ATen/native/mkldnn/xpu/detail/QMatmul.cpp`:

1. **`make_scale_spec()` (~line 403)**: Changed `{1, 1}` to `{}` for TensorWise scaling
2. **`scaled_matmul()` (~line 482)**: Changed `{1}` to `{}` for DST scale

When `mask=0` (scalar/common scale), `group_ndims` must be 0 (empty groups), as there is no need to specify group dimensions for whole-tensor scaling.

### Test Plan
- [ ] `test_out_warning_torch__scaled_mm_v2_xpu` passes with both old and new oneDNN
- [ ] Verified with benchdnn that the fix produces correct oneDNN verbose output

```bash
# Reproduction command
cd pytorch/third_party/torch-xpu-ops/test/xpu
PYTORCH_OPINFO_SAMPLE_INPUT_INDEX=0 PYTORCH_TEST_WITH_SLOW=1 \
    python ../../test/test_ops.py TestCommonXPU.test_out_warning_torch__scaled_mm_v2_xpu
```


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01