### PR TITLE
[inductor] Fix nan_asserts for FP8 dtypes

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -17745,6 +17745,14 @@ if RUN_GPU:
             ):
                 torch.compile(f)(x)
 
+        @config.patch("nan_asserts", True)
+        def test_nan_checker_fp8(self):
+            def f(x):
+                return x.half() + 1
+
+            x = torch.randn(10, device=GPU_TYPE).to(torch.float8_e4m3fn)
+            torch.compile(f, fullgraph=True)(x)
+
 
 if RUN_CPU:
 

--- a/torch/_inductor/codegen/multi_kernel.py
+++ b/torch/_inductor/codegen/multi_kernel.py
@@ -6,6 +6,7 @@ import os
 import pathlib
 from typing import Any
 
+import torch
 from torch._inductor.ir import MultiTemplateBuffer
 from torch._inductor.metrics import get_metric_table, is_metric_table_enabled
 from torch.utils._ordered_set import OrderedSet
@@ -257,9 +258,19 @@ class MultiKernel:
                     continue
                 seen.add(arg)
                 if isinstance(precompile_arg, TensorArg):
-                    line = f"assert not {arg}.isnan().any().item()"
+                    # FP8 dtypes don't support isnan/isinf, upcast to float first
+                    if precompile_arg.dtype in (
+                        torch.float8_e4m3fn,
+                        torch.float8_e4m3fnuz,
+                        torch.float8_e5m2,
+                        torch.float8_e5m2fnuz,
+                    ):
+                        check_arg = f"{arg}.float()"
+                    else:
+                        check_arg = arg
+                    line = f"assert not {check_arg}.isnan().any().item()"
                     wrapper.writeline(line)
-                    line = f"assert not {arg}.isinf().any().item()"
+                    line = f"assert not {check_arg}.isinf().any().item()"
                     wrapper.writeline(line)
 
     @property

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -5972,9 +5972,19 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                         f'AOTI_TORCH_ERROR_CODE_CHECK(aoti_torch_check_inf_and_nan("{arg}", {arg}));'
                     )
                 else:
-                    line = f"assert not {arg}.isnan().any().item()"
+                    # FP8 dtypes don't support isnan/isinf, upcast to float first
+                    if arg_signature.dtype in (
+                        torch.float8_e4m3fn,
+                        torch.float8_e4m3fnuz,
+                        torch.float8_e5m2,
+                        torch.float8_e5m2fnuz,
+                    ):
+                        check_arg = f"{arg}.float()"
+                    else:
+                        check_arg = arg
+                    line = f"assert not {check_arg}.isnan().any().item()"
                     wrapper.writeline(line)
-                    line = f"assert not {arg}.isinf().any().item()"
+                    line = f"assert not {check_arg}.isinf().any().item()"
                     wrapper.writeline(line)
 
     def create_cse_var(self, *args, **kwargs) -> TritonCSEVariable:

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -1555,9 +1555,19 @@ class PythonWrapperCodegen(CodeGen):
             if isinstance(buf, (sympy.Expr, ir.TorchBindObject)):
                 continue
 
-            line = f"assert not {name}.isnan().any().item()"
+            # FP8 dtypes don't support isnan/isinf, upcast to float first
+            if buf.get_dtype() in (
+                torch.float8_e4m3fn,
+                torch.float8_e4m3fnuz,
+                torch.float8_e5m2,
+                torch.float8_e5m2fnuz,
+            ):
+                check_name = f"{name}.float()"
+            else:
+                check_name = name
+            line = f"assert not {check_name}.isnan().any().item()"
             self.prefix.writeline(line)
-            line = f"assert not {name}.isinf().any().item()"
+            line = f"assert not {check_name}.isinf().any().item()"
             self.prefix.writeline(line)
 
     def write_async_compile_wait(self) -> None:
@@ -1753,8 +1763,14 @@ class PythonWrapperCodegen(CodeGen):
                 self.wrapper_call.do_indent()
                 self.wrapper_call.writeline("if isinstance(var, torch.Tensor):")
                 self.wrapper_call.do_indent()
-                self.wrapper_call.writeline("assert not var.isnan().any().item()")
-                self.wrapper_call.writeline("assert not var.isinf().any().item()")
+                # FP8 dtypes don't support isnan/isinf, upcast to float first
+                self.wrapper_call.writeline(
+                    "check_var = var.float() if var.dtype in "
+                    "(torch.float8_e4m3fn, torch.float8_e4m3fnuz, "
+                    "torch.float8_e5m2, torch.float8_e5m2fnuz) else var"
+                )
+                self.wrapper_call.writeline("assert not check_var.isnan().any().item()")
+                self.wrapper_call.writeline("assert not check_var.isinf().any().item()")
                 self.wrapper_call.do_unindent(2)
 
             self.wrapper_call.writeline("return (" + ", ".join(output_refs) + ", )")


### PR DESCRIPTION
## Summary
- Upcast FP8 tensors to float32 before calling `isnan()`/`isinf()` in `nan_asserts` debug checks, since these operations are not implemented for Float8 types (`Float8_e4m3fn`, `Float8_e4m3fnuz`, `Float8_e5m2`, `Float8_e5m2fnuz`).

Fixes #149002

## Motivation
When `config.nan_asserts = True`, the inductor generates code that calls `.isnan()` and `.isinf()` on kernel inputs and graph outputs. This crashes with `RuntimeError: "isinf" not implemented for 'Float8_e4m3fn'` when any tensor has an FP8 dtype.

The suggested fix from @eellison was to upcast FP8 tensors prior to the check.

## Changes
Four codegen sites emit nan/inf assert checks and all needed the FP8 upcast:

1. **`wrapper.py:codegen_input_nan_asserts`** — graph input checks (dtype known at compile time via `buf.get_dtype()`)
2. **`wrapper.py:generate_return`** — graph output checks (runtime loop, dtype checked dynamically in generated code)
3. **`triton.py:codegen_nan_check`** — per-kernel Triton argument checks (dtype from `TensorArg.dtype`)
4. **`multi_kernel.py:codegen_nan_check`** — multi-kernel argument checks (same pattern as triton.py)

For sites where the dtype is known at codegen time (1, 3, 4), the generated code emits `{arg}.float().isnan()...` directly for FP8 args. For the runtime loop (2), the generated Python conditionally upcasts based on `var.dtype`.

## Test Plan
- Added `test_nan_checker_fp8` in `NanCheckerTest` that reproduces the exact scenario from the issue: compiling a model with FP8 input when `nan_asserts=True`
- Existing `test_nan_checker_pass` and `test_nan_checker_fail` ensure no regressions for non-FP8 paths

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @eellison @henrylhtsang