### PR TITLE
release notes categorize: make torchtext dependency optional

### DIFF
--- a/scripts/release_notes/categorize.py
+++ b/scripts/release_notes/categorize.py
@@ -4,20 +4,8 @@ import textwrap
 from pathlib import Path
 
 import common
-
-# Imports for working with classi
-from classifier import (
-    CategoryConfig,
-    CommitClassifier,
-    CommitClassifierInputs,
-    get_author_map,
-    get_file_map,
-    XLMR_BASE,
-)
 from commitlist import CommitList
 from common import get_commit_data_cache, topics
-
-import torch
 
 
 class Categorizer:
@@ -25,6 +13,16 @@ class Categorizer:
         self.cache = get_commit_data_cache()
         self.commits = CommitList.from_existing(path)
         if use_classifier:
+            from classifier import (
+                CategoryConfig,
+                CommitClassifier,
+                get_author_map,
+                get_file_map,
+                XLMR_BASE,
+            )
+
+            import torch
+
             print("Using a classifier to aid with categorization.")
             device = "cuda" if torch.cuda.is_available() else "cpu"
             classifier_config = CategoryConfig(common.categories)
@@ -108,6 +106,8 @@ class Categorizer:
 
         features = self.features(commit)
         if self.classifier is not None:
+            from classifier import CommitClassifierInputs
+
             # Some commits don't have authors:
             author = features.author if features.author else "Unknown"
             files = " ".join(features.files_changed)


### PR DESCRIPTION
Summary:

Moves torchtext from a required dependency to optional run-time dependency for the part of release note generation which categorizes commits.

torchtext is archived and having it as a dependency makes it hard to use recent PyTorch versions. For now, make the dependency optional. In the future we can probably just remove the classifier (only 5 commits need classification for 2.11, faster to just manually do it) or replace it with a more recent general model.

Test Plan:

```bash
python categorize.py
```