### PR TITLE
[Test] Make dynamo/test_backends.py device-type tests generic for out-of-tree backends

### DIFF
--- a/test/dynamo/test_backends.py
+++ b/test/dynamo/test_backends.py
@@ -464,8 +464,7 @@ class TestDefaultBackend(torch._dynamo.test_case.TestCase):
         self.assertEqual(len(eager_and_record.graphs), 0)
 
 
-devices = ["cpu", "cuda", "hpu", "xpu"]
-instantiate_device_type_tests(TestOptimizations, globals(), only_for=devices)
+instantiate_device_type_tests(TestOptimizations, globals())
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests


### PR DESCRIPTION
Remove only_for restriction from instantiate_device_type_tests for TestOptimizations. This allows the tests to run on all registered device types, including out-of-tree backends like PrivateUse1.

Files changed:

- test/dynamo/test_backends.py

cc: @mikaylagawarecki @fffrog @mansiag05 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98