### PR TITLE
[Inductor] Fix undefined identifier error in CppWrapper due to false …

### DIFF
--- a/test/inductor/test_cpu_cpp_wrapper.py
+++ b/test/inductor/test_cpu_cpp_wrapper.py
@@ -280,7 +280,9 @@ if RUN_CPU:
         BaseTest("test_reduction1"),  # Reduction
         BaseTest("test_relu"),  # multiple inputs
         BaseTest("test_repeat_interleave", "", test_cpu_repro.CPUReproTests()),
-        BaseTest("test_codegen_int_array_var_cache", "", test_cpu_repro.CPUReproTests()),
+        BaseTest(
+            "test_codegen_int_array_var_cache", "", test_cpu_repro.CPUReproTests()
+        ),
         BaseTest("test_scalar_input"),
         BaseTest("test_scalar_output"),
         BaseTest("test_scaled_dot_product_attention"),

--- a/test/inductor/test_cpu_cpp_wrapper.py
+++ b/test/inductor/test_cpu_cpp_wrapper.py
@@ -280,6 +280,7 @@ if RUN_CPU:
         BaseTest("test_reduction1"),  # Reduction
         BaseTest("test_relu"),  # multiple inputs
         BaseTest("test_repeat_interleave", "", test_cpu_repro.CPUReproTests()),
+        BaseTest("test_codegen_int_array_var_cache", "", test_cpu_repro.CPUReproTests()),
         BaseTest("test_scalar_input"),
         BaseTest("test_scalar_output"),
         BaseTest("test_scaled_dot_product_attention"),

--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -1088,6 +1088,52 @@ class CPUReproTests(TestCase):
             (a,),
         )
 
+    def test_codegen_int_array_var_cache(self):
+        """
+        Test for the bug in codegen_int_array_var where bound method ids could collide,
+        leading to undefined 'int_array_XXX' identifiers in generated C++ code.
+        """
+        from unittest.mock import MagicMock
+
+        from torch._inductor.codegen.cpp_wrapper_cpu import CppWrapperCpu
+        from torch._inductor.virtualized import V
+
+        class MockBuffer:
+            def __init__(self):
+                self.lines = []
+
+            def writeline(self, line):
+                self.lines.append(line)
+
+        # Mock V.graph to avoid needing to compile a real model
+        mock_graph = MagicMock()
+        mock_graph.cpp_wrapper = True
+        mock_graph.aot_mode = False
+        mock_graph.is_const_graph = False
+        mock_graph.device_types = []
+
+        with V.set_graph_handler(mock_graph):
+            wrapper = CppWrapperCpu()
+            buffer = MockBuffer()
+
+            # Bound methods in Python are instantiated on access.
+            # Storing them ensures they have different ids.
+            w1 = buffer.writeline
+            w2 = buffer.writeline
+
+            # The bug: without the fix, codegen_int_array_var uses id(writeline)
+            # as the cache key, which leads to cache misses for bound methods.
+            var1 = wrapper.codegen_int_array_var("{1, 2, 3}", w1)
+            var2 = wrapper.codegen_int_array_var("{1, 2, 3}", w2)
+
+            # They should return the same variable name because it's the same buffer
+            self.assertEqual(
+                var1,
+                var2,
+                "codegen_int_array_var should cache based on the bound method's __self__, "
+                "not the transient bound method id itself.",
+            )
+
     def test_inplace_squeeze_needed(self):
         mod = torch.nn.Sequential(
             torch.nn.Linear(10, 10),

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -2106,7 +2106,9 @@ class CppWrapperCpu(PythonWrapperCodegen):
     ) -> str:
         # Use id(graph) for caching to avoid circular references
         # Bound methods have transient IDs, so we use the ID of the bound object instead.
-        writeline_id = id(writeline.__self__) if hasattr(writeline, "__self__") else id(writeline)
+        writeline_id = (
+            id(writeline.__self__) if hasattr(writeline, "__self__") else id(writeline)
+        )
         cache_key = (
             int_array,
             writeline_id,

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -2105,9 +2105,11 @@ class CppWrapperCpu(PythonWrapperCodegen):
         graph=None,  # for per-graph caching
     ) -> str:
         # Use id(graph) for caching to avoid circular references
+        # Bound methods have transient IDs, so we use the ID of the bound object instead.
+        writeline_id = id(writeline.__self__) if hasattr(writeline, "__self__") else id(writeline)
         cache_key = (
             int_array,
-            id(writeline),
+            writeline_id,
             known_statically,
             id(graph) if graph else None,
         )


### PR DESCRIPTION
Description:                                                                                                                                                                  
                                                                                                                                                                            
When  cpp_wrapper=True  is enabled, the generated C++ code sometimes fails to compile with  error: use of undeclared identifier 'int_array_XXX' . This happens because an     
array variable is used in the C++ wrapper code, but its definition ( static constexpr int64_t int_array_XXX[] = ... ) is missing at that specific location.                   
                                                                                                                                                                            
Root Cause:                                                                                                                                                                   
In  torch/_inductor/codegen/cpp_wrapper_cpu.py , the  codegen_int_array_var  function uses  id(writeline)  as part of its cache key to avoid generating redundant array
definitions.                                                                                                                                                                  
However,  writeline  is usually passed as a bound method (e.g.,  self.wrapper_call.writeline ). In Python, accessing a bound method dynamically creates a temporary object.   
Once the function call returns, this temporary object is immediately destroyed. Due to Python's memory allocation mechanics, the next time another bound method like          
another_buffer.writeline  is dynamically created, it is highly likely to be allocated at the exact same memory address.                                                      
                                                                                                                                                                            
This causes a False Cache Hit:  codegen_int_array_var  incorrectly assumes the array has already been written to the current buffer and returns the cached variable name      
without actually generating the static constexpr  definition code.                                                                                                           
                                                                                                                                                                            
The Fix:                                                                                                                                                                      
Instead of using the transient  id  of the bound method directly, we extract the  id  of the underlying bound object ( __self__ ), or fallback to the function's  id  if it's 
a regular function:                                                                                                                                                           
                                                                                                                                                                            
writeline_id = id(writeline.__self__) if hasattr(writeline, "__self__") else id(writeline)                                                                                  
                                                                                                                                                                            
This guarantees uniqueness across different buffer objects (e.g.,  self.wrapper_call  vs  self.lines.append  vs temporary scope buffers) and correctly isolates the cache.    

a minimal reproduction is here 

```
class IndentedBuffer:
    def __init__(self, name):
        self.name = name
        self.lines = []

    def writeline(self, line):
        self.lines.append(line)


class MockCppWrapperCpu:
    def __init__(self, use_buggy_impl=True):
        self.codegen_int_array_var_cache = {}
        self.int_array_id = 0
        self.use_buggy_impl = use_buggy_impl

    def codegen_int_array_var(self, int_array: str, writeline) -> str:
        # ⚠️ This is the buggy line: using id(writeline) directly on a bound method
        if self.use_buggy_impl:
            cache_key = (int_array, id(writeline))
        else:
            wid = (
                id(writeline.__self__)
                if hasattr(writeline, "__self__")
                else id(writeline)
            )
            cache_key = (int_array, wid)

        if cache_key not in self.codegen_int_array_var_cache:
            var = f"int_array_{self.int_array_id}"
            self.int_array_id += 1
            writeline(f"static constexpr int64_t {var}[] = {int_array};")
            self.codegen_int_array_var_cache[cache_key] = var

        return self.codegen_int_array_var_cache[cache_key]


def test_cache_collision(use_buggy_impl=False):
    wrapper = MockCppWrapperCpu(use_buggy_impl)

    buf1 = IndentedBuffer("buf1")
    buf2 = IndentedBuffer("buf2")

    def call_codegen(buf):
        # When `buf.writeline` is passed, a temporary "bound method" object is dynamically created.
        # It gets destroyed when `call_codegen` returns.
        # Python's memory allocator will likely reuse the exact same memory address (id)
        # for the next `buf.writeline` object created in the subsequent call.
        return wrapper.codegen_int_array_var("{256L, 64L, 1L}", buf.writeline)

    # First call writes to buf1 and caches the result
    var1 = call_codegen(buf1)

    # Second call uses a DIFFERENT buffer (buf2)
    # but generates a false cache hit because id(buf1.writeline) == id(buf2.writeline)
    var2 = call_codegen(buf2)

    print(f"var1 from cache: {var1}")
    print(f"buf1 actual code: {buf1.lines}")
    print("-" * 40)
    print(f"var2 from cache: {var2}")
    print(f"buf2 actual code: {buf2.lines}")

    if not buf2.lines:
        print(
            "----^--- THIS IS EMPTY DUE TO BUG!"
            "❌ BUG REPRODUCED: var2 returned a cache hit, but nothing was written to buf2!"
        )


if __name__ == "__main__":
    test_cache_collision(use_buggy_impl=True)
    print("=" * 40)
    test_cache_collision(use_buggy_impl=False)
```

                                                                                                                                               

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo