### PR TITLE
[CPU][Inductor] Use VecMask::from for scalar masks in codegen

### DIFF
--- a/aten/src/ATen/cpu/vec/vec_mask.h
+++ b/aten/src/ATen/cpu/vec/vec_mask.h
@@ -127,7 +127,6 @@ class VecMask {
  public:
   VecMask() : mask_(static_cast<T>(0)) {}
   VecMask(const VectorizedN<T, N>& mask) : mask_(mask) {}
-  VecMask(const T mask) : mask_(VectorizedN<T, N>(VecMask<T, N>::from(mask))) {}
 
   template <int L = N, typename std::enable_if_t<L == 1, int> = 0>
   VecMask(const Vectorized<T>& mask) : mask_(mask) {}

--- a/aten/src/ATen/cpu/vec/vec_mask.h
+++ b/aten/src/ATen/cpu/vec/vec_mask.h
@@ -127,6 +127,7 @@ class VecMask {
  public:
   VecMask() : mask_(static_cast<T>(0)) {}
   VecMask(const VectorizedN<T, N>& mask) : mask_(mask) {}
+  VecMask(const T mask) : mask_(VectorizedN<T, N>(VecMask<T, N>::from(mask))) {}
 
   template <int L = N, typename std::enable_if_t<L == 1, int> = 0>
   VecMask(const Vectorized<T>& mask) : mask_(mask) {}

--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -5090,8 +5090,6 @@ class CPUReproTests(TestCase):
         positions = torch.tensor([[0, 0], [0, 0], [0, 0]], dtype=torch.int64)
         cache = torch.arange(3, dtype=torch.float32).reshape(1, 3)
 
-        torch._dynamo.reset()
-        metrics.reset()
         with config.patch({"cpp.enable_loop_tail_vec": True}):
             expected = fn(positions, cache)
             compiled_fn = torch.compile(fn, fullgraph=True)

--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -5077,6 +5077,28 @@ class CPUReproTests(TestCase):
                     "at::vec::VectorizedN<int64_t,2>::loadu", 2, exactly=True
                 ).run(code)
 
+    @requires_vectorization
+    def test_indirect_assert_scalar_mask_tail_vec_no_crash(self):
+        # https://github.com/pytorch/pytorch/issues/178136
+        def fn(positions, cache):
+            x = cache[positions]
+            y = x[0].clone()
+            y[..., 1::3] = x[1, ..., 1::3]
+            y[..., 2::3] = x[2, ..., 2::3]
+            return y
+
+        positions = torch.tensor([[0, 0], [0, 0], [0, 0]], dtype=torch.int64)
+        cache = torch.arange(3, dtype=torch.float32).reshape(1, 3)
+
+        torch._dynamo.reset()
+        metrics.reset()
+        with torch.no_grad(), config.patch({"cpp.enable_loop_tail_vec": True}):
+            expected = fn(positions, cache)
+            compiled_fn = torch.compile(fn, backend="inductor", fullgraph=True)
+            actual = compiled_fn(positions, cache)
+
+        torch.testing.assert_close(actual, expected)
+
     def test_uint64_pointwise_vec(self):
         def fn(x):
             return x * x

--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -5094,7 +5094,7 @@ class CPUReproTests(TestCase):
         metrics.reset()
         with torch.no_grad(), config.patch({"cpp.enable_loop_tail_vec": True}):
             expected = fn(positions, cache)
-            compiled_fn = torch.compile(fn, backend="inductor", fullgraph=True)
+            compiled_fn = torch.compile(fn, fullgraph=True)
             actual = compiled_fn(positions, cache)
 
         torch.testing.assert_close(actual, expected)

--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -5092,7 +5092,7 @@ class CPUReproTests(TestCase):
 
         torch._dynamo.reset()
         metrics.reset()
-        with torch.no_grad(), config.patch({"cpp.enable_loop_tail_vec": True}):
+        with config.patch({"cpp.enable_loop_tail_vec": True}):
             expected = fn(positions, cache)
             compiled_fn = torch.compile(fn, fullgraph=True)
             actual = compiled_fn(positions, cache)

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -3503,7 +3503,7 @@ class CppVecKernel(CppKernel):
         cond = f"{self._get_mask_type(var.dtype)}({cond})"
         if mask:
             if not mask.is_vec:
-                mask = f"{self._get_mask_type(var.dtype)}({mask})"
+                mask = f"{self._get_mask_type(var.dtype)}::from({mask})"
             # We need not check when the mask is False
             cond = f"({cond}) | ~({mask})"
         if self.tail_size:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #178148

Fixes: #178136, https://github.com/vllm-project/vllm/issues/37325

Signed-off-by: Fadi Arafeh <fadi.arafeh@arm.com>

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos