### PR TITLE
[12/12] Enforce C++20 minimum in header guards (#178150)

### DIFF
--- a/aten/src/ATen/ATen.h
+++ b/aten/src/ATen/ATen.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#if !defined(_MSC_VER) && __cplusplus < 201703L
-#error C++17 or later compatible compiler is required to use ATen.
+#if !defined(_MSC_VER) && __cplusplus < 202002L
+#error C++20 or later compatible compiler is required to use ATen.
 #endif
 
 #include <ATen/Context.h>

--- a/torch/csrc/api/include/torch/all.h
+++ b/torch/csrc/api/include/torch/all.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#if !defined(_MSC_VER) && __cplusplus < 201703L
-#error C++17 or later compatible compiler is required to use PyTorch.
+#if !defined(_MSC_VER) && __cplusplus < 202002L
+#error C++20 or later compatible compiler is required to use PyTorch.
 #endif
 
 #include <torch/autograd.h>


### PR DESCRIPTION
Summary:

Raise the compile-time enforcement from C++17 to C++20 in the
header guards of c10/util/C++17.h, ATen/ATen.h, and torch/all.h.
This is the enforcement gate — all consumers must already be
building with -std=c++20 before this lands.

#buildmore

Test Plan: Sandcastle

Reviewed By: huydhn


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo