### PR TITLE
Metal backend alias for MPS

### DIFF
--- a/c10/core/Device.cpp
+++ b/c10/core/Device.cpp
@@ -31,6 +31,7 @@ DeviceType parse_type(const std::string& device_string) {
           {"lazy", DeviceType::Lazy},
           {"vulkan", DeviceType::Vulkan},
           {"mps", DeviceType::MPS},
+          {"metal", DeviceType::MPS},
           {"meta", DeviceType::Meta},
           {"hpu", DeviceType::HPU},
           {"mtia", DeviceType::MTIA},

--- a/c10/core/DeviceType.cpp
+++ b/c10/core/DeviceType.cpp
@@ -37,7 +37,7 @@ std::string DeviceTypeName(DeviceType d, bool lower_case) {
     case DeviceType::Lazy:
       return lower_case ? "lazy" : "LAZY";
     case DeviceType::MPS:
-      return lower_case ? "mps" : "MPS";
+      return lower_case ? "metal" : "METAL";
     case DeviceType::Vulkan:
       return lower_case ? "vulkan" : "VULKAN";
     case DeviceType::Metal:
@@ -148,8 +148,8 @@ void register_privateuse1_backend(const std::string& backend_name) {
       "torch.register_privateuse1_backend() has already been set! Current backend: ",
       privateuse1_backend_name);
 
-  static const std::array<std::string, 6> types = {
-      "cpu", "cuda", "hip", "mps", "xpu", "mtia"};
+  static const std::array<std::string, 7> types = {
+      "cpu", "cuda", "hip", "mps", "xpu", "mtia", "metal"};
   TORCH_CHECK(
       std::find(types.begin(), types.end(), backend_name) == types.end(),
       "Cannot register privateuse1 backend with in-tree device name: ",


### PR DESCRIPTION
Minimal PR for adding "metal" as alias for the "mps" device. First step for #173225.