### PR TITLE
[pytorch] Catch-all exception suppression in pinned allocator free() (opt-in) (#178154)

### DIFF
--- a/aten/src/ATen/cuda/CachingHostAllocator.cpp
+++ b/aten/src/ATen/cuda/CachingHostAllocator.cpp
@@ -4,6 +4,7 @@
 #include <c10/core/thread_pool.h>
 #include <c10/cuda/CUDAAllocatorConfig.h>
 #include <c10/cuda/CUDAGraphsC10Utils.h>
+#include <c10/util/Gauge.h>
 
 #include <cuda_runtime_api.h>
 #include <future>
@@ -15,6 +16,25 @@ using Block = HostBlock<CUDAStream>;
 
 struct CUDACachingHostAllocatorImpl
     : public CachingHostAllocatorImpl<CUDAStream, CUDAEventPool::Event> {
+  void free(void* ctx) override {
+    using Base = CachingHostAllocatorImpl<CUDAStream, CUDAEventPool::Event>;
+    try {
+      Base::free(ctx);
+    } catch (...) {
+      if (!c10::cuda::CUDACachingAllocator::CUDAAllocatorConfig::
+              pinned_free_catch_all()) {
+        TORCH_WARN("Exception in pinned allocator free(), rethrowing");
+        throw;
+      }
+      // pinned_free_catch_all is enabled: suppress the exception to prevent
+      // it from escaping through ~StorageImpl() (implicitly noexcept), which
+      // would cause std::terminate. Allows graceful shutdown to proceed.
+      STATIC_GAUGE(pytorch.CUDACachingHostAllocator.free_fail_catch_all)
+          .record(1);
+      TORCH_WARN("Suppressed exception in pinned allocator free()");
+    }
+  }
+
  private:
   ska::flat_hash_map<void*, bool> use_host_register;
 

--- a/c10/cuda/CUDAAllocatorConfig.cpp
+++ b/c10/cuda/CUDAAllocatorConfig.cpp
@@ -109,6 +109,9 @@ void CUDAAllocatorConfig::parseArgs(const std::string& env) {
     } else if (key == "per_process_memory_fraction") {
       i = parsePerProcessMemoryFraction(tokenizer, i);
       used_native_specific_option = true;
+    } else if (key == "pinned_free_catch_all") {
+      i = parsePinnedFreeCatchAll(tokenizer, i);
+      used_native_specific_option = true;
     } else {
       const auto& keys =
           c10::CachingAllocator::AcceleratorAllocatorConfig::getKeys();
@@ -189,6 +192,14 @@ size_t CUDAAllocatorConfig::parsePinnedReserveSegmentSize(
   TORCH_CHECK_VALUE(
       val2 > 0, "Pinned reserve segment size has to be greater than 0");
   m_pinned_reserve_segment_size_mb = val2;
+  return i;
+}
+
+size_t CUDAAllocatorConfig::parsePinnedFreeCatchAll(
+    const c10::CachingAllocator::ConfigTokenizer& tokenizer,
+    size_t i) {
+  tokenizer.checkToken(++i, ":");
+  m_pinned_free_catch_all = tokenizer.toBool(++i);
   return i;
 }
 

--- a/c10/cuda/CUDAAllocatorConfig.h
+++ b/c10/cuda/CUDAAllocatorConfig.h
@@ -92,6 +92,10 @@ class C10_CUDA_API CUDAAllocatorConfig {
     return 128;
   }
 
+  static bool pinned_free_catch_all() {
+    return instance().m_pinned_free_catch_all;
+  }
+
   C10_DEPRECATED_MESSAGE(
       "c10::cuda::CUDACachingAllocator::CUDAAllocatorConfig::roundup_power2_divisions() is deprecated. Please use c10::CachingAllocator::AcceleratorAllocatorConfig::roundup_power2_divisions() instead.")
   static size_t roundup_power2_divisions(size_t size) {
@@ -157,7 +161,8 @@ class C10_CUDA_API CUDAAllocatorConfig {
         "graph_capture_record_stream_reuse",
         "pinned_reserve_segment_size_mb",
         "pinned_num_register_threads",
-        "per_process_memory_fraction"};
+        "per_process_memory_fraction",
+        "pinned_free_catch_all"};
     return keys;
   }
 
@@ -185,6 +190,9 @@ class C10_CUDA_API CUDAAllocatorConfig {
   double parsePerProcessMemoryFraction(
       const c10::CachingAllocator::ConfigTokenizer& tokenizer,
       size_t i);
+  size_t parsePinnedFreeCatchAll(
+      const c10::CachingAllocator::ConfigTokenizer& tokenizer,
+      size_t i);
 
   std::atomic<size_t> m_pinned_num_register_threads{1};
   std::atomic<size_t> m_pinned_reserve_segment_size_mb{0};
@@ -198,6 +206,7 @@ class C10_CUDA_API CUDAAllocatorConfig {
   std::atomic<bool> m_pinned_use_cuda_host_register{false};
   std::atomic<bool> m_graph_capture_record_stream_reuse{false};
   std::atomic<double> m_per_process_memory_fraction{1.0};
+  std::atomic<bool> m_pinned_free_catch_all{false};
 };
 
 // Keep this for backwards compatibility


### PR DESCRIPTION
Summary:

When a GPU sticky error (e.g. device-side assert) occurs during inference,
tensor destructors call CUDACachingHostAllocatorImpl::free(), which calls
record_stream(), which calls event->record(). In a sticky error state,
event->record() also fails with a CUDA exception. This exception propagates
through ~StorageImpl() (implicitly noexcept), causing std::terminate before
the server can perform graceful shutdown.

Add a new CUDAAllocatorConfig option:
  pinned_free_catch_all:true|false (default: false)

When enabled, CUDACachingHostAllocatorImpl overrides free() with a catch-all
handler that suppresses any exception from the free() path, allowing graceful
shutdown to proceed (error logging, Scuba upload, etc.). A TORCH_WARN is emitted
and a counter (pytorch.CUDACachingHostAllocator.free_fail_catch_all) is
incremented whenever an exception is caught, so suppressed failures are visible
on ODS.

Default is false so OSS/vllm users see no behavior change. Deployments can
enable this via PYTORCH_CUDA_ALLOC_CONF in their config.

Test Plan:
Tested on model 2133239133/snapshot 15 (GIF/VDD, 1 GPU):

WITHOUT flag (default / prod baseline):
- Sent bad_request_cco_1.recordio (triggers device-side assert) at QPS=1
- Server immediately hit:
    terminate() called, exception stack follows
    Exception type: c10::AcceleratorError
    terminate called after throwing an instance of 'c10::AcceleratorError'
      what(): CUDA error: device-side assert triggered
- Process aborted (core dumped) on first bad request

WITH flag (PYTORCH_CUDA_ALLOC_CONF=...,pinned_free_catch_all:True):
- Sent same bad request
- Server logged:
    W  Suppressed exception in pinned allocator free()    <- catch-all fired, TORCH_WARN emitted
    E  CUDA error: device-side assert triggered           <- error returned to client cleanly
    I  Logging Bad Request and associated error to scuba sigrid_predictor_bad_requests
- Server remained alive (still listening on :7449) with no std::terminate
- ODS counter pytorch.CUDACachingHostAllocator.free_fail_catch_all incremented on catch (confirmed on FB303)

Reviewed By: yangw-dev, mrajpal

Differential Revision: D97384298
