### PR TITLE
[inductor] Make lazy compile kernel state per-module instead of global

### DIFF
--- a/test/inductor/test_gpu_cpp_wrapper.py
+++ b/test/inductor/test_gpu_cpp_wrapper.py
@@ -1,6 +1,9 @@
 # Owner(s): ["module: inductor"]
 import itertools
+import os
+import subprocess
 import sys
+import tempfile
 import unittest
 from typing import NamedTuple
 
@@ -76,6 +79,80 @@ class TestGpuWrapper(InductorTestCase):
         with torch.utils._device.DeviceContext(self.device):
             _, code = test_torchinductor.run_and_get_cpp_code(compiled, x, 3)
         self.assertIn("torch.tensor(arg, device='cpu')", code)
+
+
+# Helper script for test_lazy_compile_kernel_name_collision_across_modules.
+# Run as a subprocess so dlopen truly re-runs .so static initializers.
+_LAZY_COMPILE_COLLISION_SCRIPT = """\
+import torch
+from torch._inductor import config
+
+config.cpp_wrapper = True
+config.triton.autotune_at_compile_time = False
+
+def fn(x, y, z, w):
+    a = x.sin()
+    torch._dynamo.graph_break()
+    b = (a * y).cos()
+    torch._dynamo.graph_break()
+    c = (b * z).sin()
+    torch._dynamo.graph_break()
+    d = (c * w).cos()
+    return d.sum()
+
+args = [torch.randn(32, device="cuda", requires_grad=True) for _ in range(4)]
+ref_args = [a.detach().clone().requires_grad_(True) for a in args]
+ref = fn(*ref_args)
+ref.backward()
+
+compiled_fn = torch.compile(fn)
+res = compiled_fn(*args)
+res.backward()
+
+assert torch.allclose(res.detach(), ref.detach()), f"Forward mismatch: {res} vs {ref}"
+for i, (a, r) in enumerate(zip(args, ref_args)):
+    assert torch.allclose(a.grad, r.grad), f"Grad mismatch for arg {i}"
+"""
+
+
+class TestLazyCompileKernelCollision(InductorTestCase):
+    device = GPU_TYPE
+
+    def test_lazy_compile_kernel_name_collision_across_modules(self):
+        """The collision manifests when a fresh process loads .so modules from
+        warm on-disk caches: AOTAutograd cache hits cause both forward and
+        backward .so to be loaded (static initializers register kernels in
+        _pending_kernels) before either executes.  If two modules share a
+        kernel name, the global dict collision corrupts the mapping.
+
+        This requires two process invocations because dlopen within a single
+        process reuses loaded libraries without re-running static initializers.
+        """
+        if not RUN_GPU:
+            self.skipTest("GPU not available")
+
+        with tempfile.TemporaryDirectory() as cache_dir:
+            env = {
+                **os.environ,
+                "TORCHINDUCTOR_CACHE_DIR": cache_dir,
+                "INDUCTOR_TEST_DISABLE_FRESH_CACHE": "1",
+            }
+            # First run: cold compile, populates on-disk caches.
+            r1 = subprocess.run(
+                [sys.executable, "-c", _LAZY_COMPILE_COLLISION_SCRIPT],
+                capture_output=True,
+                text=True,
+                env=env,
+            )
+            self.assertEqual(r1.returncode, 0, f"Cold run failed:\n{r1.stderr[-2000:]}")
+            # Second run: warm caches trigger the collision without the fix.
+            r2 = subprocess.run(
+                [sys.executable, "-c", _LAZY_COMPILE_COLLISION_SCRIPT],
+                capture_output=True,
+                text=True,
+                env=env,
+            )
+            self.assertEqual(r2.returncode, 0, f"Warm run failed:\n{r2.stderr[-2000:]}")
 
 
 class DynamicShapesGpuWrapperGpuTests(InductorTestCase):

--- a/torch/_inductor/codegen/cpp_wrapper_gpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_gpu.py
@@ -105,6 +105,10 @@ static PyObject* triton_lazy_compile_module = nullptr;
 static PyObject* start_kernel_compile = nullptr;
 static PyObject* run_triton_kernel_with_autotune = nullptr;
 
+// Per-module dict for pending kernel compile results (avoids global state
+// collisions when multiple compiled modules produce kernels with the same name).
+static PyObject* _module_pending_kernels = nullptr;
+
 static inline void loadLazyCompileFuncs() {
     if (triton_lazy_compile_module == nullptr) {
         triton_lazy_compile_module = PyImport_ImportModule("torch._inductor.runtime.triton_lazy_compile");
@@ -191,6 +195,7 @@ static inline PyObject* convertArgToPython(const T& arg) {
 
 template<typename... Args>
 static inline LazyKernelCompileResult runTritonKernelWithAutotune(
+        PyObject* pending_kernels,
         const std::string& kernel_name,
         cudaStream_t stream,
         const Args&... kernel_args) {
@@ -207,7 +212,8 @@ static inline LazyKernelCompileResult runTritonKernelWithAutotune(
     };
     (add_arg(convertArgToPython(kernel_args)), ...);
 
-    RAIIPyObject call_args = PyTuple_Pack(3,
+    RAIIPyObject call_args = PyTuple_Pack(4,
+        pending_kernels,
         PyUnicode_FromString(kernel_name.c_str()),
         PyLong_FromVoidPtr(stream),
         py_args_list.get()
@@ -220,14 +226,18 @@ static inline LazyKernelCompileResult runTritonKernelWithAutotune(
     return extractCompileResult(result);
 }
 
-static inline void startKernelCompile(const std::string& kernel_name, const std::string& kernel_source) {
+static inline void startKernelCompile(
+    PyObject* pending_kernels,
+    const std::string& kernel_name,
+    const std::string& kernel_source)
+{
     py::gil_scoped_acquire_simple acquire;
 
     RAIIPyObject py_name = PyUnicode_FromString(kernel_name.c_str());
     RAIIPyObject py_source = PyUnicode_FromString(kernel_source.c_str());
-    AOTI_TORCH_CHECK(py_name && py_source, "Failed to create Python strings");
+    AOTI_TORCH_CHECK(py_name && py_source, "Failed to create Python args");
 
-    RAIIPyObject call_args = PyTuple_Pack(2, py_name.get(), py_source.get());
+    RAIIPyObject call_args = PyTuple_Pack(3, pending_kernels, py_name.get(), py_source.get());
     AOTI_TORCH_CHECK(call_args, "Failed to create call args");
 
     RAIIPyObject result = PyObject_CallObject(start_kernel_compile, call_args);
@@ -652,9 +662,8 @@ class DeferredTritonCallWrapper:
         )
         prefix.writeline(kernel_var_decl)
         # Use delimited raw string to handle )" in kernel source
-        kernel_body = (
-            f'R"TRITON(\n{self.kernel_name_to_body.get(kernel_name, "")}\n)TRITON"'
-        )
+        kernel_source_str = self.kernel_name_to_body.get(kernel_name, "")
+        kernel_body = f'R"TRITON(\n{kernel_source_str}\n)TRITON"'
         prefix.writeline(f"static const char* {kernel_name}_source = {kernel_body};")
         prefix.writeline(f"static LazyKernelCompileResult {kernel_name}_result;")
 
@@ -682,7 +691,7 @@ class DeferredTritonCallWrapper:
                 f"""\
                 if ({kernel_name} == nullptr) {{
                     {kernel_name}_result = runTritonKernelWithAutotune(
-                        "{kernel_name}", stream_, {autotune_args});
+                        _module_pending_kernels, "{kernel_name}", stream_, {autotune_args});
 
                     {kernel_name} = loadKernel(
                         {kernel_name}_result.cubin_path,
@@ -1076,7 +1085,7 @@ class CppWrapperGpu(CppWrapperCpu):
         # Generate parallel kernel compilation initialization function
         if self._lazy_kernel_names:
             start_compile_calls = "\n    ".join(
-                f'startKernelCompile("{name}", {name}_source);'
+                f'startKernelCompile(_module_pending_kernels, "{name}", {name}_source);'
                 for name in self._lazy_kernel_names
             )
             self.prefix.splice(
@@ -1084,6 +1093,8 @@ class CppWrapperGpu(CppWrapperCpu):
 // Start parallel compilation of all Triton kernels
 static inline void start_all_triton_kernel_compiles() {{
     loadLazyCompileFuncs();
+    _module_pending_kernels = PyDict_New();
+    AOTI_TORCH_CHECK(_module_pending_kernels, "Failed to create pending kernels dict");
     {start_compile_calls}
 }}
 

--- a/torch/_inductor/runtime/triton_lazy_compile.py
+++ b/torch/_inductor/runtime/triton_lazy_compile.py
@@ -41,8 +41,6 @@ class TritonKernelCompileResult:
     profile_scratch: int | None
 
 
-_pending_kernels: dict[str, Any] = {}
-
 _async_compile: Any = None
 
 
@@ -98,13 +96,18 @@ def _wrap_tma_args(args: list[Any], kernel_fn: CachingAutotuner) -> list[Any]:
     return wrapped
 
 
-def start_kernel_compile(kernel_name: str, kernel_source: str) -> None:
+def start_kernel_compile(
+    pending_kernels: dict[str, Any], kernel_name: str, kernel_source: str
+) -> None:
     """
     This function is called from C++ at model initialization time for each kernel.
     It starts the compilation in a background process but does NOT wait for it.
     The actual kernel execution happens later in run_triton_kernel_with_autotune().
+
+    The pending_kernels dict is per-module, created in C++ and passed through
+    to avoid global state collisions across compiled modules.
     """
-    if kernel_name in _pending_kernels:
+    if kernel_name in pending_kernels:
         return
 
     async_compile = _get_async_compile()  # noqa: F841 (used by eval below)
@@ -113,10 +116,11 @@ def start_kernel_compile(kernel_name: str, kernel_source: str) -> None:
     # The kernel_source is like: async_compile.triton('name', '''...''', ...)
     kernel_obj = eval(kernel_source.strip())  # noqa: S307
 
-    _pending_kernels[kernel_name] = kernel_obj
+    pending_kernels[kernel_name] = kernel_obj
 
 
 def run_triton_kernel_with_autotune(
+    pending_kernels: dict[str, Any],
     kernel_name: str,
     stream: Any,
     args: list[Any],
@@ -127,9 +131,9 @@ def run_triton_kernel_with_autotune(
     from torch._inductor.codecache import CodeCacheFuture, CudaKernelParamCache
     from torch._inductor.runtime.triton_heuristics import config_to_dict
 
-    if kernel_name not in _pending_kernels:
-        raise RuntimeError(f"Kernel {kernel_name} not found in pending kernels. ")
-    kernel_obj = _pending_kernels.pop(kernel_name)
+    if kernel_name not in pending_kernels:
+        raise RuntimeError(f"Kernel {kernel_name} not found in pending kernels.")
+    kernel_obj = pending_kernels[kernel_name]
 
     if isinstance(kernel_obj, CodeCacheFuture):
         kernel_fn = kernel_obj.result()
@@ -160,9 +164,11 @@ def run_triton_kernel_with_autotune(
     from torch._inductor.codecache import get_cpp_wrapper_cubin_path_name
 
     cubin_path_name = get_cpp_wrapper_cubin_path_name()
-    for key in (cubin_path_name, "mangled_name", "num_warps", "shared_mem"):
-        if key not in cached_params:
-            raise RuntimeError(f"{key} not found in cached params for {kernel_name}")
+    for key_name in (cubin_path_name, "mangled_name", "num_warps", "shared_mem"):
+        if key_name not in cached_params:
+            raise RuntimeError(
+                f"{key_name} not found in cached params for {kernel_name}"
+            )
     cubin_path = cached_params[cubin_path_name]
     mangled_name = cached_params["mangled_name"]
     num_warps = cached_params["num_warps"]
@@ -210,7 +216,7 @@ def run_triton_kernel_with_autotune(
         profile_scratch,
     )
 
-    return TritonKernelCompileResult(
+    result = TritonKernelCompileResult(
         cubin_path=cubin_path,
         mangled_name=mangled_name,
         num_warps=num_warps,
@@ -225,3 +231,4 @@ def run_triton_kernel_with_autotune(
         global_scratch=global_scratch,
         profile_scratch=profile_scratch,
     )
+    return result


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #177732
* #178166
* #178165
* #178164
* __->__ #178163
* #178162

The _pending_kernels global dict caused two classes of bugs:
1. Name collision: different modules produce kernels with the same name but
   different source; one overwrites the other in the global dict.
2. Shared kernel consumption: identical kernels across modules; the first
   lookup removes the entry so the second module fails.

Both stem from global state shared across compiled modules. Fix by replacing
the global dict with a per-module dict created in C++ (PyDict_New) and passed
to the Python functions as a parameter. Each compiled .so gets its own dict,
so kernel names are naturally scoped and can't collide across modules.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos