### PR TITLE
[inductor] Mark lazy compile wrapper functions as noniline

### DIFF
--- a/torch/_inductor/codegen/cpp_wrapper_gpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_gpu.py
@@ -189,7 +189,7 @@ class DeferredTritonCallWrapper:
         )
 
         # Write function signature
-        prefix.writeline(f"static inline void {self.wrapper_name}(")
+        prefix.writeline(f"static __attribute__((noinline)) void {self.wrapper_name}(")
         with prefix.indent():
             for i, param in enumerate(param_lines):
                 comma = "," if i < len(param_lines) - 1 else ""


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #177732
* #178166
* __->__ #178165
* #178164
* #178163
* #178162

Local experiment shows this can reduce vision_maskrcnn training run's
compilation_latency from 187s to 178s.

Authored with: Claude

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos