### PR TITLE
Add autograd_cache_key to compile_fx with tests

### DIFF
--- a/test/dynamo/test_aot_autograd_cache.py
+++ b/test/dynamo/test_aot_autograd_cache.py
@@ -15,6 +15,7 @@ import torch._dynamo.test_case
 import torch._functorch._aot_autograd
 import torch._functorch._aot_autograd.autograd_cache as autograd_cache
 import torch._functorch.aot_autograd as aot_autograd
+import torch._inductor.compile_fx as compile_fx
 from torch._dynamo import config as dynamo_config
 from torch._dynamo.utils import counters
 from torch._functorch import config as functorch_config
@@ -3193,6 +3194,12 @@ class CacheKeyAPITests(torch._dynamo.test_case.TestCase):
         self.assertIsNotNone(captured_key)
         return captured_key, captured_gm, captured_example_inputs
 
+    def _tracing_context(self):
+        """Create a TracingContext with a ShapeEnv, as required by
+        _check_can_cache inside the cache key computation."""
+        fake_mode = FakeTensorMode(shape_env=ShapeEnv())
+        return torch._guards.tracing(TracingContext(fake_mode))
+
     def _aot_autograd_cache_key(self, fx_graph, example_inputs):
         """Call aot_autograd.autograd_cache_key with the same config and
         tracing context that compile_fx would use."""
@@ -3202,14 +3209,10 @@ class CacheKeyAPITests(torch._dynamo.test_case.TestCase):
         compiler_config_extra = create_compiler_config_extra(fx_graph)
         decompositions = select_decomp_table()
 
-        # _check_can_cache requires a TracingContext with a ShapeEnv.
-        fake_mode = FakeTensorMode(shape_env=ShapeEnv())
-        ctx = TracingContext(fake_mode)
-
         # Match the config patches that compile_fx applies during compilation
         # so that the autograd_config snapshot is identical.
         with (
-            torch._guards.tracing(ctx),
+            self._tracing_context(),
             functorch_config.patch(
                 unlift_effect_tokens=True,
                 selective_decompose=inductor_config.selective_decompose,
@@ -3222,6 +3225,16 @@ class CacheKeyAPITests(torch._dynamo.test_case.TestCase):
                 decompositions=decompositions,
                 compiler_config_extra=compiler_config_extra,
                 keep_inference_input_mutations=True,
+            )
+
+    def _compile_fx_cache_key(self, fx_graph, example_inputs):
+        """Call compile_fx.autograd_cache_key, the higher-level API that
+        handles decompositions and config patching internally."""
+        with self._tracing_context():
+            return compile_fx.autograd_cache_key(
+                fx_graph,
+                example_inputs,
+                ignore_shape_env=True,
             )
 
     @requires_triton()
@@ -3239,7 +3252,9 @@ class CacheKeyAPITests(torch._dynamo.test_case.TestCase):
         x = torch.randn(4, 4)
         gt_key, fx_graph, example_inputs = self._compile_and_capture(fn, x)
         api_key, _ = self._aot_autograd_cache_key(fx_graph, example_inputs)
+        cfx_key, _ = self._compile_fx_cache_key(fx_graph, example_inputs)
         self.assertEqual(gt_key, api_key)
+        self.assertEqual(gt_key, cfx_key)
 
     @requires_triton()
     @inductor_config.patch("fx_graph_remote_cache", False)
@@ -3257,8 +3272,12 @@ class CacheKeyAPITests(torch._dynamo.test_case.TestCase):
         gt_key, fx_graph, example_inputs = self._compile_and_capture(fn, x)
         key1, _ = self._aot_autograd_cache_key(fx_graph, example_inputs)
         key2, _ = self._aot_autograd_cache_key(fx_graph, example_inputs)
+        cfx_key1, _ = self._compile_fx_cache_key(fx_graph, example_inputs)
+        cfx_key2, _ = self._compile_fx_cache_key(fx_graph, example_inputs)
         self.assertEqual(gt_key, key1)
         self.assertEqual(key1, key2)
+        self.assertEqual(gt_key, cfx_key1)
+        self.assertEqual(cfx_key1, cfx_key2)
 
     @requires_triton()
     @inductor_config.patch("fx_graph_remote_cache", False)
@@ -3279,8 +3298,12 @@ class CacheKeyAPITests(torch._dynamo.test_case.TestCase):
         gt_key2, graph2, inputs2 = self._compile_and_capture(fn, x_double)
         api_key1, _ = self._aot_autograd_cache_key(graph1, inputs1)
         api_key2, _ = self._aot_autograd_cache_key(graph2, inputs2)
+        cfx_key1, _ = self._compile_fx_cache_key(graph1, inputs1)
+        cfx_key2, _ = self._compile_fx_cache_key(graph2, inputs2)
         self.assertEqual(gt_key1, api_key1)
         self.assertEqual(gt_key2, api_key2)
+        self.assertEqual(gt_key1, cfx_key1)
+        self.assertEqual(gt_key2, cfx_key2)
         self.assertNotEqual(gt_key1, gt_key2)
 
     @requires_triton()
@@ -3304,8 +3327,12 @@ class CacheKeyAPITests(torch._dynamo.test_case.TestCase):
         gt_key2, graph2, inputs2 = self._compile_and_capture(fn2, x)
         api_key1, _ = self._aot_autograd_cache_key(graph1, inputs1)
         api_key2, _ = self._aot_autograd_cache_key(graph2, inputs2)
+        cfx_key1, _ = self._compile_fx_cache_key(graph1, inputs1)
+        cfx_key2, _ = self._compile_fx_cache_key(graph2, inputs2)
         self.assertEqual(gt_key1, api_key1)
         self.assertEqual(gt_key2, api_key2)
+        self.assertEqual(gt_key1, cfx_key1)
+        self.assertEqual(gt_key2, cfx_key2)
         self.assertNotEqual(gt_key1, gt_key2)
 
     @requires_triton()
@@ -3329,7 +3356,9 @@ class CacheKeyAPITests(torch._dynamo.test_case.TestCase):
         x = torch.randn(4, 4)
         gt_key, fx_graph, example_inputs = self._compile_and_capture(mod, x)
         api_key, _ = self._aot_autograd_cache_key(fx_graph, example_inputs)
+        cfx_key, _ = self._compile_fx_cache_key(fx_graph, example_inputs)
         self.assertEqual(gt_key, api_key)
+        self.assertEqual(gt_key, cfx_key)
 
 
 if __name__ == "__main__":

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -35,6 +35,7 @@ from torch._dynamo import (
     logging as dynamo_logging,
     utils as dynamo_utils,
 )
+from torch._dynamo.backends import common as dynamo_common
 from torch._dynamo.device_interface import get_interface_for_device
 from torch._dynamo.repro.after_aot import wrap_compiler_debug
 from torch._dynamo.utils import (
@@ -49,7 +50,7 @@ from torch._dynamo.utils import (
     lazy_format_graph_code,
     set_feature_use,
 )
-from torch._functorch import config as functorch_config
+from torch._functorch import aot_autograd, config as functorch_config
 from torch._functorch._aot_autograd.subclass_parametrization import (
     unwrap_tensor_subclass_parameters,
 )
@@ -102,7 +103,6 @@ from torch.fx.passes.fake_tensor_prop import FakeTensorProp
 from torch.monitor import _WaitCounter
 from torch.utils._ordered_set import OrderedSet
 
-from .._dynamo.backends.common import aot_autograd
 from .._dynamo.exc import ShortenTraceback, SkipFrame
 from ..fx._lazy_graph_module import _use_lazy_graph_module
 from ..fx.graph import _PyTreeCodeGen
@@ -2898,7 +2898,7 @@ def _compile_fx_main(
             ),
         ):
             try:
-                return aot_autograd(
+                return dynamo_common.aot_autograd(
                     fw_compiler=fw_compiler,
                     bw_compiler=bw_compiler,
                     inference_compiler=inference_compiler,
@@ -3095,3 +3095,30 @@ def _aoti_flatten_inputs(
         }
     )
     return flat_example_inputs, options
+
+
+def autograd_cache_key(
+    graph,
+    example_inputs,
+    ignore_shape_env: bool,
+    decompositions=None,
+):
+    decompositions = (
+        decompositions if decompositions is not None else select_decomp_table()
+    )
+    compiler_config_extra = create_compiler_config_extra(graph)
+
+    # Match the config patches that compile_fx applies during compilation
+    # so that the autograd_config snapshot is identical.
+    with functorch_config.patch(
+        unlift_effect_tokens=True,
+        selective_decompose=config.selective_decompose,
+    ):
+        return aot_autograd.autograd_cache_key(
+            graph,
+            example_inputs,
+            ignore_shape_env=ignore_shape_env,
+            decompositions=decompositions,
+            compiler_config_extra=compiler_config_extra,
+            keep_inference_input_mutations=True,
+        )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

Add compile_fx.autograd_cache_key that wraps
aot_autograd.autograd_cache_key with the inductor-specific config
patches and decompositions. This gives callers a single entry point to
compute the cache key for a dynamo graph without having to replicate
the compile_fx config setup.

To resolve the naming conflict between the aot_autograd module and the
aot_autograd function from dynamo.backends.common, import the latter
via its module (dynamo_common.aot_autograd).

Tests verify that both API layers produce the same key as the real
compilation pipeline.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Lucaskabela