### PR TITLE
[DTensor] Remove artificial +1.0 shard→shard penalty in cost model

### DIFF
--- a/test/distributed/tensor/debug/test_comm_mode.py
+++ b/test/distributed/tensor/debug/test_comm_mode.py
@@ -110,9 +110,10 @@ class TestCommMode(TestCase):
             f(x_dtensor, y_dtensor)
 
         comm_counts = comm_mode.get_comm_counts()
+        # S(0)->S(1) alltoall via _dtensor::shard_dim_alltoall
         self.assertEqual(comm_mode.get_total_counts(), 1)
         self.assertEqual(comm_counts[c10d_functional.all_reduce], 0)
-        self.assertEqual(comm_counts[c10d_functional.all_gather_into_tensor], 1)
+        self.assertEqual(comm_counts[c10d_functional.all_gather_into_tensor], 0)
         self.assertEqual(comm_counts[c10d_functional.reduce_scatter_tensor], 0)
 
     @requires_accelerator_dist_backend(["nccl", "xccl"])

--- a/test/distributed/tensor/debug/test_debug_mode.py
+++ b/test/distributed/tensor/debug/test_debug_mode.py
@@ -50,6 +50,10 @@ class TestDTensorDebugMode(TestCase):
     def tearDown(self):
         super().tearDown()
         dist.destroy_process_group()
+        import gc
+
+        gc.collect()
+        torch.cuda.empty_cache()
 
     def setUp(self):
         super().setUp()
@@ -74,18 +78,16 @@ class TestDTensorDebugMode(TestCase):
         self.assertExpectedInline(
             debug_mode.debug_string(),
             """\
-  torch.mm(dt$0: f32[8, 8]| S(0), dt$1: f32[8, 32]| S(0))  ->  dt$7: f32[8, 32]| S(0)
+  torch.mm(dt$0: f32[8, 8]| S(0), dt$1: f32[8, 32]| S(0))  ->  dt$6: f32[8, 32]| P(sum)
     aten::mm(dt$0: f32[8, 8]| S(0), dt$1: f32[8, 32]| S(0))
-      -> output: S(0)
-      redistribute_input [implicit] (1, S(0) -> R)
-        redistribute_input(t$2: f32[1, 32], trace: S(0)->R)
-          _c10d_functional::all_gather_into_tensor(t$2: f32[1, 32], 8, 0)  ->  t$3: f32[8, 32]
-          _c10d_functional::_wrap_tensor_autograd(t$3: f32[8, 32])  ->  t$4: f32[8, 32]
-          _c10d_functional::wait_tensor(t$3: f32[8, 32])  ->  t$3: f32[8, 32]
-      aten::mm(t$5: f32[1, 8], t$3: f32[8, 32])  ->  t$6: f32[1, 32]
-  <method 'sum' of 'torch._C.TensorBase' objects>(dt$7: f32[8, 32]| S(0))  ->  dt$9: f32[]| P(sum)
-    aten::sum(dt$7: f32[8, 32]| S(0))
-      aten::sum(t$6: f32[1, 32])  ->  t$8: f32[]""",
+      -> output: P(sum)
+      redistribute_input [implicit] (0, S(0) -> S(1))
+        redistribute_input(t$2: f32[1, 8], trace: S(0)->S(1))
+          _dtensor::shard_dim_alltoall(t$2: f32[1, 8], 0, 1, 0)  ->  t$3: f32[8, 1]
+      aten::mm(t$3: f32[8, 1], t$4: f32[1, 32])  ->  t$5: f32[8, 32]
+  <method 'sum' of 'torch._C.TensorBase' objects>(dt$6: f32[8, 32]| P(sum))  ->  dt$8: f32[]| P(sum)
+    aten::sum(dt$6: f32[8, 32]| P(sum))
+      aten::sum(t$5: f32[8, 32])  ->  t$7: f32[]""",
         )
 
         self.assertTrue(isinstance(debug_mode.operators[0], _OpCall))
@@ -111,7 +113,7 @@ class TestDTensorDebugMode(TestCase):
             compiled_out = torch.compile(mm, backend="aot_eager")(x_dtensor, y_dtensor)
 
         # check numerical equivalence
-        self.assertTrue(torch.equal(eager_out, compiled_out))
+        self.assertEqual(eager_out, compiled_out)
         sum_op = next(
             iter(
                 op
@@ -121,7 +123,7 @@ class TestDTensorDebugMode(TestCase):
         )
         self.assertTrue(torch.equal(sum_op.record["output"], eager_out.to_local()))
         self.assertTrue(
-            "aten::sum(t: f32[1, 32])  ->  t: f32[]  # {'hash': "
+            "aten::sum(t: f32[8, 32])  ->  t: f32[]  # {'hash': "
             in debug_mode.debug_string()
         )
 
@@ -366,15 +368,11 @@ class TestDTensorDebugMode(TestCase):
             debug_mode.debug_string(),
             """\
   aten::topk(dt: f32[8, 16]| S(1), 4, 1)
-    -> output: ('R', 'R')
-    redistribute_input [implicit] (0, S(1) -> R)
-      redistribute_input(t: f32[8, 2], trace: S(1)->R)
-        _c10d_functional::all_gather_into_tensor(t: f32[8, 2], 8, 0)  ->  t: f32[64, 2]
-        _c10d_functional::_wrap_tensor_autograd(t: f32[64, 2])  ->  t: f32[64, 2]
-        _c10d_functional::wait_tensor(t: f32[64, 2])  ->  t: f32[64, 2]
-        aten::chunk(t: f32[64, 2], 8)  ->  ['t: f32[8, 2]', 't: f32[8, 2]', 't: f32[8, 2]', 't: f32[8, 2]', 't: f32[8, 2]', 't: f32[8, 2]', 't: f32[8, 2]', 't: f32[8, 2]']
-        aten::cat(['t: f32[8, 2]', 't: f32[8, 2]', 't: f32[8, 2]', 't: f32[8, 2]', 't: f32[8, 2]', 't: f32[8, 2]', 't: f32[8, 2]', 't: f32[8, 2]'], 1)  ->  t: f32[8, 16]
-    aten::topk(t: f32[8, 16], 4, 1)  ->  ('t: f32[8, 4]', 't: i64[8, 4]')""",  # noqa: B950
+    -> output: ('S(0)', 'S(0)')
+    redistribute_input [implicit] (0, S(1) -> S(0))
+      redistribute_input(t: f32[8, 2], trace: S(1)->S(0))
+        _dtensor::shard_dim_alltoall(t: f32[8, 2], 1, 0, 0)  ->  t: f32[1, 16]
+    aten::topk(t: f32[1, 16], 4, 1)  ->  ('t: f32[1, 4]', 't: i64[1, 4]')""",  # noqa: B950
         )
 
     def test_debug_mode_einsum(self):
@@ -525,7 +523,8 @@ class TestDTensorDebugMode(TestCase):
                     torch.mm(x_dtensor, y_dtensor)
 
         self.assertTrue(
-            "redistribute_input [implicit] (1, S(0) -> R)" in debug_mode.debug_string()
+            "redistribute_input [implicit] (0, S(0) -> S(1))"
+            in debug_mode.debug_string()
         )
 
     def test_debug_mode_higher_order_cond(self):

--- a/test/distributed/tensor/test_math_ops.py
+++ b/test/distributed/tensor/test_math_ops.py
@@ -1084,7 +1084,9 @@ class DistMathOpsTest(DTensorTestBase):
                 with comm_mode:
                     dt_values, dt_indices = op(input_dtensor, dim=dim)
                 if dim == shard_dim:
-                    self.assertTrue(dt_values.placements[0].is_replicate())
+                    # alltoall reshards to S(1) before scanning along dim 0;
+                    # scan preserves shape so output stays S(1)
+                    self.assertTrue(dt_values.placements[0].is_shard(1))
                 else:
                     self.assertTrue(dt_values.placements[0].is_shard(shard_dim))
                 self.assertEqual(dt_values.full_tensor(), values)
@@ -1116,10 +1118,10 @@ class DistMathOpsTest(DTensorTestBase):
             dt_vals, dt_idxs = torch.nanmedian(dtensor, dim=dim)
             self.assertEqual(dt_vals.full_tensor(), vals)
             self.assertEqual(dt_idxs.full_tensor(), idxs)
-            if dim == shard_dim:
-                self.assertTrue(dt_vals.placements[0].is_replicate())
-            else:
-                self.assertTrue(dt_vals.placements[0].is_shard(shard_dim))
+            # When reducing along the shard dim, alltoall reshards to S(1)
+            # first; the reduction removes that dim so output is S(0).
+            # When reducing along other dims, shard is preserved as S(0).
+            self.assertTrue(dt_vals.placements[0].is_shard(0))
 
         # kthvalue: reduce along each dim
         for dim in range(tensor.ndim):
@@ -1127,10 +1129,7 @@ class DistMathOpsTest(DTensorTestBase):
             dt_vals, dt_idxs = torch.kthvalue(dtensor, 3, dim=dim)
             self.assertEqual(dt_vals.full_tensor(), vals)
             self.assertEqual(dt_idxs.full_tensor(), idxs)
-            if dim == shard_dim:
-                self.assertTrue(dt_vals.placements[0].is_replicate())
-            else:
-                self.assertTrue(dt_vals.placements[0].is_shard(shard_dim))
+            self.assertTrue(dt_vals.placements[0].is_shard(0))
 
         # mode: reduce along each dim
         for dim in range(tensor.ndim):
@@ -1138,10 +1137,7 @@ class DistMathOpsTest(DTensorTestBase):
             dt_vals, dt_idxs = torch.mode(dtensor, dim=dim)
             self.assertEqual(dt_vals.full_tensor(), vals)
             self.assertEqual(dt_idxs.full_tensor(), idxs)
-            if dim == shard_dim:
-                self.assertTrue(dt_vals.placements[0].is_replicate())
-            else:
-                self.assertTrue(dt_vals.placements[0].is_shard(shard_dim))
+            self.assertTrue(dt_vals.placements[0].is_shard(0))
 
     @with_comms
     def test_conj_complex_dtensor(self):

--- a/test/distributed/tensor/test_matrix_ops.py
+++ b/test/distributed/tensor/test_matrix_ops.py
@@ -449,7 +449,9 @@ class DistMatrixOpsTest(DTensorTestBase):
         )
         weight = distribute_tensor(global_weight, device_mesh, (Replicate(),))
         out = torch.mm(inps_viewed, weight)
-        expected_placements = (Replicate(),)
+        # S(0) output is unshardable (dim 0 size < world_size), so the planner
+        # chooses S(1),S(0)->P(sum) via alltoall (cheaper than allgather to R).
+        expected_placements = (Partial(),)
         self.assertEqual(out.placements, expected_placements)
 
     @with_comms

--- a/test/distributed/tensor/test_redistribute.py
+++ b/test/distributed/tensor/test_redistribute.py
@@ -1173,7 +1173,7 @@ class DistributeWithDeviceOrderTest(DTensorContinuousTestBase):
             elif idx == 3:
                 self.assertExpectedInline(
                     trace_str,
-                    """S(0)[0]S(0)[1]R->S(0)RR->S(0)S(1)R->RS(1)R->RS(1)S(0)""",
+                    """S(0)[0]S(0)[1]R->S(0)S(1)R->RS(1)R->RS(1)S(0)""",
                 )
             expected_dt = _distribute_tensor(
                 input_data.clone(), mesh, dst_placement, shard_order=dst_order
@@ -1221,17 +1221,15 @@ class DistributeWithDeviceOrderTest(DTensorContinuousTestBase):
 
             # Validate graph-based algorithm trace (idx=0, disable_graph=False)
             # Graph-based uses optimal path search (Dijkstra's algorithm)
-            # Expected path has 6 transformations with strategic intermediate states
-            # Path: S(0)[0,1,2] → S(0)[0,1]S(2) → S(0)S(2)[1,0] →
-            #       S(1)S(2)[1,0] → S(1)[0,1]S(2) → S(1)[0,1,2]
+            # Path: S(0)[0,1,2] → S(0)[0,1]R → S(0)RR →
+            #       S(1)RR → S(1)[0,1]R → S(1)[0,1,2]
             if idx == 0:
                 self.assertExpectedInline(
                     trace_str,
-                    """S(0)[0]S(0)[1]S(0)[2]->S(0)[0]S(0)[1]R->S(0)RR->RRR->S(1)RR->S(1)[0]S(1)[1]R->S(1)[0]S(1)[1]S(1)[2]""",
+                    """S(0)[0]S(0)[1]S(0)[2]->S(0)[0]S(0)[1]R->S(0)RR->S(1)RR->S(1)[0]S(1)[1]R->S(1)[0]S(1)[1]S(1)[2]""",
                 )
             # Validate greedy algorithm trace (idx=1, disable_graph=True)
             # Greedy uses simple heuristic approach (processes mesh dims sequentially)
-            # Expected path has 6 transformations but with different intermediate states
             # Path: S(0)[0,1,2] → S(0)[0,1]R → S(0)RR →
             #       S(1)RR → S(1)[0,1]R → S(1)[0,1,2]
             elif idx == 1:

--- a/torch/distributed/tensor/_collective_utils.py
+++ b/torch/distributed/tensor/_collective_utils.py
@@ -322,6 +322,18 @@ def reduce_scatter_cost(
     return latency + bw * 1e6
 
 
+def alltoall_cost(bytes_gb: float, mesh_topo: MeshTopoInfo, mesh_dim: int) -> float:
+    # TODO: alltoall may be cheaper than allgather on NVSwitch hardware (direct
+    # exchange vs ring), but we use the same formula as a safe upper bound since
+    # the existing model is already approximate (hardcoded BW, ring assumption).
+    num_devices_on_mesh_dim = mesh_topo.mesh_dim_devices[mesh_dim]
+    mesh_dim_bandwidth = mesh_topo.mesh_dim_bandwidth[mesh_dim]
+    num_hops = num_devices_on_mesh_dim - 1
+    latency = 6.6 + num_hops * mesh_topo.mesh_dim_latency[mesh_dim]
+    bw = (bytes_gb * num_hops / num_devices_on_mesh_dim) / mesh_dim_bandwidth
+    return latency + bw * 1e6
+
+
 def _compute_placement_transition_cost(
     current_placement: "dtensor_spec.Placement",
     target_placement: "dtensor_spec.Placement",
@@ -354,10 +366,7 @@ def _compute_placement_transition_cost(
         comm_bytes_gb *= num_devices_on_mesh_dim
         return allgather_cost(comm_bytes_gb, mesh_topo, mesh_dim), comm_bytes_gb
     elif current_placement.is_shard() and target_placement.is_shard():
-        # should be alltoall comm, since we haven't implement it yet, add 1.0 as penalty
-        # to favor allgather instead
-        # TODO: add alltoall_cost
-        return allgather_cost(comm_bytes_gb, mesh_topo, mesh_dim) + 1.0, comm_bytes_gb
+        return alltoall_cost(comm_bytes_gb, mesh_topo, mesh_dim), comm_bytes_gb
     elif current_placement.is_partial() and target_placement.is_replicate():
         return allreduce_cost(comm_bytes_gb, mesh_topo, mesh_dim), comm_bytes_gb
     elif current_placement.is_partial() and target_placement.is_shard():


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #178175
* #177798

The cost model in `_compute_placement_transition_cost` added a +1.0
penalty on top of the allgather cost for shard→shard transitions
(e.g., S(0)→S(1)), with a comment saying "since we haven't implement
it yet". However, alltoall IS implemented via `shard_dim_alltoall`
(C++ in Functional.cpp, calls ncclAllToAll). This artificial penalty
caused the cost model to overestimate shard→shard transitions, creating
inconsistencies between the full-expansion strategy search and the
Dijkstra search (which could find multi-hop paths that bypass the
penalty).

This change adds a proper `alltoall_cost` function and uses it for
shard→shard transitions. The formula matches `allgather_cost` as a safe
upper bound — alltoall is likely cheaper on NVSwitch hardware (direct
exchange vs ring), but we use the same formula since the existing model
is already approximate (hardcoded BW, ring assumption).

With the accurate cost, the planner now correctly prefers alltoall over
allgather when alltoall moves less data (alltoall doesn't inflate comm
bytes like allgather does). This affects strategy selection for several
ops (mm, reductions, scans) and produces shorter redistribution paths.

Fixes #177663

Authored with Claude.