### PR TITLE
Fix issue in AMD persistent_mm_template selection

### DIFF
--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -1950,12 +1950,16 @@ def can_use_tma(
 def use_triton_tma_template(
     *matrices: IRNode, output_layout: Layout, add_guards: bool = False
 ) -> bool:
+    if not config.triton.enable_persistent_tma_matmul:
+        return False
+    if not all(len(m.get_size()) == 2 for m in matrices):
+        return False
+    # On AMD (HIP), TMA is not available but we still use non-TMA persistent
+    # kernels, so skip the TMA compatibility checks.
+    if torch.version.hip is not None:
+        return True
     layout = output_layout if config.triton.enable_template_tma_store else None
-    return (
-        all(len(m.get_size()) == 2 for m in matrices)
-        and can_use_tma(*matrices, output_layout=layout, add_guards=add_guards)
-        and config.triton.enable_persistent_tma_matmul
-    )
+    return can_use_tma(*matrices, output_layout=layout, add_guards=add_guards)
 
 
 def use_triton_blackwell_tma_template(


### PR DESCRIPTION
Summary:
Refactor `use_triton_tma_template` to use early-return style instead of a single compound boolean expression. This adds explicit handling for AMD

Key changes:
- Return `False` early if `config.triton.enable_persistent_tma_matmul` is disabled.
- Return `False` early if any matrix is not 2D.
- Return `True` early on AMD HIP, since TMA is not available but persistent non-TMA kernels are still used, so TMA compatibility checks should be skipped.
- The remaining path calls `can_use_tma` for the final TMA compatibility check.

Test Plan: TORCHINDUCTOR_FORCE_DISABLE_CACHES=1 buck2 run fbcodemode/opt-amd-gpu fbcodecaffe2/test/inductor:max_autotune_amd -- -r test_max_autotune_regular_mm_persistent

Differential Revision: D97791690




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos