### PR TITLE
[dynamo] Reject nn.Parameter as torch.full fill_value to match eager

### DIFF
--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -5863,6 +5863,25 @@ class DefaultsTests(torch._dynamo.test_case.TestCaseWithNestedGraphBreaks):
         self.assertEqual(result_a, torch.full((2,), 3.14, dtype=torch.float32))
         self.assertEqual(result_b, torch.full((2,), 2.71, dtype=torch.float32))
 
+    def test_full_nn_parameter_fill_value_raises_error(self):
+        def f(fill_value):
+            return torch.full(
+                (4, 2),
+                fill_value=fill_value,
+                dtype=torch.float32,
+                device=device_type,
+            )
+
+        fill_value = torch.nn.Parameter(torch.tensor(1.0))
+
+        with self.assertRaises(TypeError):
+            f(fill_value)
+
+        torch._dynamo.reset()
+        compiled_f = torch.compile(f, fullgraph=True)
+        with self.assertRaises(Unsupported):
+            compiled_f(fill_value)
+
 
 instantiate_parametrized_tests(FunctionTests)
 instantiate_parametrized_tests(DefaultsTests)

--- a/torch/_dynamo/polyfills/tensor.py
+++ b/torch/_dynamo/polyfills/tensor.py
@@ -1,8 +1,14 @@
-from typing import Any
+from __future__ import annotations
+
+from typing import Any, cast, TYPE_CHECKING
 
 import torch
 
 from ..decorators import substitute_in_graph
+
+
+if TYPE_CHECKING:
+    from torch.distributed.tensor import DTensor
 
 
 @substitute_in_graph(  # type: ignore[arg-type]
@@ -33,6 +39,45 @@ def make_subclass(
         # 2. the C impls match at this point -- both `THPVariable_make_subclass` and
         #    `THPVariable_as_subclass` calls `THPVariable_NewWithVar`.
         return data.as_subclass(cls)
+
+
+def dtensor_full_via_local_full(
+    fill_value: DTensor, size: Any, **kwargs: Any
+) -> DTensor:
+    """torch.full for replicated DTensor fill_value via local full + DTensor.from_local."""
+    import torch.distributed.tensor as dt
+
+    names = kwargs.pop("names", None)
+    if names is not None:
+        raise RuntimeError(
+            "torch.full(..., names=...) with DTensor fill_value "
+            "is not supported under torch.compile."
+        )
+    dtype = kwargs.pop("dtype", None)
+    layout = kwargs.pop("layout", torch.strided)
+    requires_grad = kwargs.pop("requires_grad", False)
+    kwargs.pop("device", None)
+    kwargs.pop("pin_memory", None)
+    if kwargs:
+        raise RuntimeError(
+            "torch.full with DTensor fill_value: unsupported keyword arguments "
+            f"{sorted(kwargs)!r}"
+        )
+
+    local = torch.full(
+        cast(Any, size),
+        cast(Any, fill_value.to_local()),
+        dtype=dtype,
+        layout=layout,
+        device=fill_value.device,
+        requires_grad=requires_grad,
+    )
+    return dt.DTensor.from_local(
+        local,
+        device_mesh=fill_value.device_mesh,
+        placements=list(fill_value.placements),
+        run_check=False,
+    )
 
 
 __all__ = [

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -1222,6 +1222,12 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
             **kwargs: VariableTracker,
         ) -> VariableTracker | None:
             if fill_value.is_tensor():
+                if fill_value.python_type() is torch.nn.Parameter:
+                    raise_type_error_exc(
+                        tx,
+                        "torch.full(): fill_value must be a Python number, not torch.nn.Parameter. "
+                        "Use a scalar such as fill_value=param.item().",
+                    )
                 # Decompose: create empty tensor and fill it
                 # This avoids the scalar extraction at compile time
                 empty_result = TorchInGraphFunctionVariable(torch.empty).call_function(

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -1228,6 +1228,16 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
                         "torch.full(): fill_value must be a Python number, not torch.nn.Parameter. "
                         "Use a scalar such as fill_value=param.item().",
                     )
+                if torch.distributed.is_available() and (
+                    fill_value.python_type() is torch.distributed.tensor.DTensor
+                ):
+                    from ..polyfills.tensor import dtensor_full_via_local_full
+
+                    return tx.inline_user_function_return(
+                        VariableTracker.build(tx, dtensor_full_via_local_full),
+                        [fill_value, size],
+                        kwargs,
+                    )
                 # Decompose: create empty tensor and fill it
                 # This avoids the scalar extraction at compile time
                 empty_result = TorchInGraphFunctionVariable(torch.empty).call_function(


### PR DESCRIPTION
This PR fixes a correctness gap where torch.compile accepted nn.Parameter as fill_value to torch.full() by routing through Dynamo’s empty + fill_ decomposition, while eager correctly rejects that argument (Scalar-only). The handle_full path now detects nn.Parameter and raises a TypeError consistent with the intended API.

fixes #178046.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98 @Lucaskabela @mlazos