### PR TITLE
[GraphPickler] Handle weakref objects during graph serialization (#178190)

### DIFF
--- a/test/fx/test_graph_pickler.py
+++ b/test/fx/test_graph_pickler.py
@@ -924,6 +924,177 @@ class TestIgnoreRawNode(TestCase):
         self.assertIsNone(call_node.meta.get("raw_ref"))
 
 
+class _WeakrefTarget:
+    """A simple picklable class that supports weak references, for use in tests.
+
+    Plain dicts do not support weak references in Python, so tests must use
+    instances of a regular class instead.
+    """
+
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
+@unittest.skipUnless(HAS_DILL, "dill not available")
+class TestWeakrefPickle(TestCase):
+    """Tests that weakref objects are properly serialized and reconstructed."""
+
+    def setUp(self):
+        super().setUp()
+        import weakref
+
+        from torch._subclasses.fake_tensor import FakeTensorMode
+        from torch.fx._graph_pickler import GraphPickler, Options
+        from torch.fx.experimental.symbolic_shapes import ShapeEnv
+
+        self.weakref = weakref
+        self.GraphPickler = GraphPickler
+        self.Options = Options
+        self.fake_mode = FakeTensorMode(shape_env=ShapeEnv())
+
+    def _make_graph_with_weakref_in_meta(self, ref_obj):
+        """Return a graph module with a weakref stored in node metadata."""
+
+        class M(torch.nn.Module):
+            def forward(self, x):
+                return x + 1
+
+        gm = torch.fx.symbolic_trace(M())
+        call_node = next((n for n in gm.graph.nodes if n.op == "call_function"), None)
+        self.assertIsNotNone(call_node)
+        call_node.meta["weak_ref"] = ref_obj
+        return gm
+
+    def test_alive_weakref_in_meta_is_reconstructed(self):
+        """An alive weakref.ref in node metadata should be reconstructed as a weakref."""
+        target = _WeakrefTarget(key="value")
+        weak = self.weakref.ref(target)
+        gm = self._make_graph_with_weakref_in_meta(weak)
+        # Also store a strong ref so the referent survives after unpickling
+        call_node = next((n for n in gm.graph.nodes if n.op == "call_function"), None)
+        call_node.meta["strong_ref"] = target
+
+        options = self.Options(node_metadata_key_filter=None)
+        data = self.GraphPickler.dumps(gm, options)
+        restored = self.GraphPickler.loads(data, self.fake_mode)
+
+        self.assertIsInstance(restored, torch.fx.GraphModule)
+        call_node = next(
+            (n for n in restored.graph.nodes if n.op == "call_function"), None
+        )
+        self.assertIsNotNone(call_node)
+        restored_ref = call_node.meta.get("weak_ref")
+        self.assertIsInstance(restored_ref, self.weakref.ref)
+        self.assertEqual(restored_ref().key, "value")
+
+    def test_dead_weakref_in_meta_unpickles_as_callable_none(self):
+        """A dead weakref should unpickle as a callable that returns None."""
+        target = _WeakrefTarget()
+        weak = self.weakref.ref(target)
+        gm = self._make_graph_with_weakref_in_meta(weak)
+        # Kill the referent so the weakref is dead at pickle time
+        del target
+
+        options = self.Options(node_metadata_key_filter=None)
+        data = self.GraphPickler.dumps(gm, options)
+        restored = self.GraphPickler.loads(data, self.fake_mode)
+
+        self.assertIsInstance(restored, torch.fx.GraphModule)
+        call_node = next(
+            (n for n in restored.graph.nodes if n.op == "call_function"), None
+        )
+        self.assertIsNotNone(call_node)
+        restored_ref = call_node.meta.get("weak_ref")
+        # Should be callable and return None, like a dead weakref
+        self.assertIsNotNone(restored_ref)
+        self.assertIsNone(restored_ref())
+
+    def test_keyed_ref_in_meta_is_reconstructed(self):
+        """A weakref.KeyedRef (from WeakValueDictionary) should be reconstructed."""
+        wvd = self.weakref.WeakValueDictionary()
+        target = _WeakrefTarget(val=42)
+        wvd["k"] = target
+        keyed_ref = wvd.data["k"]
+        self.assertIsInstance(keyed_ref, self.weakref.KeyedRef)
+
+        gm = self._make_graph_with_weakref_in_meta(keyed_ref)
+        # Also store a strong ref so the referent survives after unpickling
+        call_node = next((n for n in gm.graph.nodes if n.op == "call_function"), None)
+        call_node.meta["strong_ref"] = target
+
+        options = self.Options(node_metadata_key_filter=None)
+        data = self.GraphPickler.dumps(gm, options)
+        restored = self.GraphPickler.loads(data, self.fake_mode)
+
+        self.assertIsInstance(restored, torch.fx.GraphModule)
+        call_node = next(
+            (n for n in restored.graph.nodes if n.op == "call_function"), None
+        )
+        self.assertIsNotNone(call_node)
+        restored_ref = call_node.meta.get("weak_ref")
+        self.assertIsInstance(restored_ref, self.weakref.ref)
+        self.assertEqual(restored_ref().val, 42)
+
+    def test_weakref_in_module_dict_is_reconstructed(self):
+        """A weakref stored in the graph module's __dict__ should be reconstructed."""
+
+        class M(torch.nn.Module):
+            def forward(self, x):
+                return x + 1
+
+        gm = torch.fx.symbolic_trace(M())
+        target = _WeakrefTarget(key="value")
+        gm._weak_cache = self.weakref.ref(target)
+        # Also store a strong ref so the referent survives after unpickling
+        gm._strong_cache = target
+
+        options = self.Options(node_metadata_key_filter=None)
+        data = self.GraphPickler.dumps(gm, options)
+        restored = self.GraphPickler.loads(data, self.fake_mode)
+
+        self.assertIsInstance(restored, torch.fx.GraphModule)
+        restored_ref = restored._weak_cache
+        self.assertIsInstance(restored_ref, self.weakref.ref)
+        self.assertEqual(restored_ref().key, "value")
+
+    def test_weakref_and_strong_ref_share_same_object(self):
+        """When a weakref and a strong ref point to the same object, pickle's
+        memo should deduplicate them so they share identity after unpickling.
+        This also covers the case where the weakref is the first reference
+        pickle encounters — the memo must still work correctly."""
+
+        class M(torch.nn.Module):
+            def forward(self, x):
+                return x + 1
+
+        gm = torch.fx.symbolic_trace(M())
+        target = _WeakrefTarget(key="value")
+        weak = self.weakref.ref(target)
+
+        call_node = next((n for n in gm.graph.nodes if n.op == "call_function"), None)
+        self.assertIsNotNone(call_node)
+        # Put weakref first so it's the first reference pickle encounters
+        call_node.meta["weak_ref"] = weak
+        call_node.meta["strong_ref"] = target
+
+        options = self.Options(node_metadata_key_filter=None)
+        data = self.GraphPickler.dumps(gm, options)
+        restored = self.GraphPickler.loads(data, self.fake_mode)
+
+        self.assertIsInstance(restored, torch.fx.GraphModule)
+        restored_node = next(
+            (n for n in restored.graph.nodes if n.op == "call_function"), None
+        )
+        self.assertIsNotNone(restored_node)
+
+        restored_weak = restored_node.meta["weak_ref"]
+        restored_strong = restored_node.meta["strong_ref"]
+
+        self.assertIsInstance(restored_weak, self.weakref.ref)
+        # The weakref's referent and the strong ref should be the same object
+        self.assertIs(restored_weak(), restored_strong)
+
+
 if __name__ == "__main__":
     from torch.testing._internal.common_utils import run_tests
 

--- a/torch/fx/_graph_pickler.py
+++ b/torch/fx/_graph_pickler.py
@@ -4,6 +4,7 @@ import importlib
 import io
 import itertools
 import pickle
+import weakref
 from abc import abstractmethod
 from collections.abc import Callable
 from typing import Any, NewType, TypeVar
@@ -71,6 +72,14 @@ class Options:
 
 def _unpickle_as_none() -> None:
     return None
+
+
+def _unpickle_as_weakref(referent: object) -> weakref.ref:
+    return weakref.ref(referent)
+
+
+def _unpickle_as_dead_weakref() -> Callable[[], None]:
+    return lambda: None
 
 
 @contextlib.contextmanager
@@ -147,6 +156,15 @@ class GraphPickler(pickle.Pickler):
             return _SymNodePickleData.reduce_helper(self, obj)
         elif isinstance(obj, torch._guards.TracingContext):
             return _TracingContextPickleData.reduce_helper(self, obj)
+        elif isinstance(obj, weakref.ref):
+            # Serialize weakrefs properly: if the referent is alive,
+            # serialize it and reconstruct the weakref on unpickle.
+            # If the referent is dead, unpickle as a dead-weakref-like callable.
+            referent = obj()
+            if referent is not None:
+                return (_unpickle_as_weakref, (referent,))
+            else:
+                return (_unpickle_as_dead_weakref, ())
         else:
             # We should never get a raw Node!
             if isinstance(obj, torch.fx.Node):


### PR DESCRIPTION
Summary:

GraphPickler's `reducer_override` does not handle `weakref.ref` types
(including `KeyedRef` from `WeakValueDictionary`), causing
`TypeError: cannot pickle 'KeyedRef' object` when serializing graph
modules that contain weak references in their state.

This adds a handler that properly serializes weakrefs: alive weakrefs have their referent serialized and the weakref is reconstructed on unpickle via `_unpickle_as_weakref`. Dead weakrefs are replaced with a callable that returns None via `_unpickle_as_dead_weakref`, preserving the dead-weakref calling convention.

Test Plan:
- Added _WeakrefTarget helper class and TestWeakrefPickle test class in test_graph_pickler.py with 5 cases:
    - test_alive_weakref_in_meta_is_reconstructed: alive weakref.ref in node metadata is reconstructed
    - test_dead_weakref_in_meta_unpickles_as_callable_none: dead weakref unpickles as a callable returning None
    - test_keyed_ref_in_meta_is_reconstructed: weakref.KeyedRef from WeakValueDictionary is reconstructed
    - test_weakref_in_module_dict_is_reconstructed: weakref in module __dict__ is reconstructed
    - test_weakref_and_strong_ref_share_same_object: weakref and strong ref share identity after unpickling
  - All 5 tests pass locally via fbcode//caffe2:ifbpy

Differential Revision: D97505196




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo