### PR TITLE
[Inductor][Pallas] Support handling 0-D tensors

### DIFF
--- a/test/inductor/test_pallas.py
+++ b/test/inductor/test_pallas.py
@@ -660,7 +660,6 @@ class PallasTestsMixin:
         x = torch.randn(1, 1, 16, device=self.DEVICE).expand(4, 8, 16)
         self.assertEqual(compiled(x, x), x + x)
 
-    @skip_if_tpu
     def test_stride_multiple_inputs(self):
         """Test multiple strided inputs and broadcasting."""
         compiled = self._compile(lambda a, b, c: a * b + c)
@@ -685,6 +684,48 @@ class PallasTestsMixin:
         s = torch.tensor(2.0, device=self.DEVICE)  # scalar
         compiled_bcast = self._compile(lambda x, y, s: x + y * s)
         self.assertEqual(compiled_bcast(x, y, s), x + y * s)
+
+    def test_scalar_tensor_ops(self):
+        """Test scalar-tensor operations."""
+
+        def test_scalar_add_tensor(s, t):
+            return s + t
+
+        def test_tensor_add_scalar(t, s):
+            return t + s
+
+        def test_scalar_mul_tensor(s, t):
+            return s * t
+
+        def test_tensor_mul_scalar(t, s):
+            return t * s
+
+        shapes = [(16,), (8, 8), (4, 4, 4)]
+
+        for shape in shapes:
+            for fn in [
+                test_scalar_add_tensor,
+                test_tensor_add_scalar,
+                test_scalar_mul_tensor,
+                test_tensor_mul_scalar,
+            ]:
+                with self.subTest(op=fn.__name__, shape=shape):
+                    compiled = self._compile(fn)
+
+                    # Create 0-D scalar tensor
+                    scalar = torch.tensor(2.5, dtype=torch.float32, device=self.DEVICE)
+                    tensor = torch.randn(shape, dtype=torch.float32, device=self.DEVICE)
+
+                    if "scalar" in fn.__name__.split("_")[0]:
+                        result = compiled(scalar, tensor)
+                        expected = fn(scalar, tensor)
+                    else:
+                        result = compiled(tensor, scalar)
+                        expected = fn(tensor, scalar)
+
+                    self.assertEqual(result, expected)
+                    self.assertEqual(result.shape, shape)
+                    self.assertEqual(result.dtype, torch.float32)
 
     def test_non_power_of_2_sizes(self):
         """Test that non-power-of-2 tensor sizes work correctly.

--- a/test/inductor/test_pallas.py
+++ b/test/inductor/test_pallas.py
@@ -685,6 +685,37 @@ class PallasTestsMixin:
         compiled_bcast = self._compile(lambda x, y, s: x + y * s)
         self.assertEqual(compiled_bcast(x, y, s), x + y * s)
 
+    def test_scalar_scalar_ops(self):
+        """Test scalar-scalar operations."""
+
+        def test_add(a, b):
+            return a + b
+
+        def test_mul(a, b):
+            return a * b
+
+        def test_sub(a, b):
+            return a - b
+
+        def test_div(a, b):
+            return a / b
+
+        for fn in [test_add, test_mul, test_sub, test_div]:
+            with self.subTest(op=fn.__name__):
+                compiled = self._compile(fn)
+
+                # Test with 0-D tensors (scalars)
+                a = torch.tensor(3.5, dtype=torch.float32, device=self.DEVICE)
+                b = torch.tensor(2.0, dtype=torch.float32, device=self.DEVICE)
+
+                result = compiled(a, b)
+                expected = fn(a, b)
+                self.assertEqual(result, expected)
+
+                # Ensure result is also scalar
+                self.assertEqual(result.dim(), 0)
+                self.assertEqual(result.dtype, torch.float32)
+
     def test_scalar_tensor_ops(self):
         """Test scalar-tensor operations."""
 

--- a/test/inductor/test_pallas.py
+++ b/test/inductor/test_pallas.py
@@ -685,6 +685,7 @@ class PallasTestsMixin:
         compiled_bcast = self._compile(lambda x, y, s: x + y * s)
         self.assertEqual(compiled_bcast(x, y, s), x + y * s)
 
+    @skip_if_cuda
     def test_scalar_scalar_ops(self):
         """Test scalar-scalar operations."""
 

--- a/torch/_inductor/codegen/pallas.py
+++ b/torch/_inductor/codegen/pallas.py
@@ -3562,15 +3562,14 @@ class PallasKernel(SIMDKernel):
                         if cshape is not None:
                             code.writeline(f"{param} = {param}.reshape({cshape})")
 
-                    code.writeline("indexer = lambda n: lambda i: [jnp.int32(i)] * n")
                     code.writeline("out_specs_pallas = tuple(")
-                    code.writeline("    pl.BlockSpec(shape, indexer(len(shape)))")
+                    code.writeline("    pallas_make_block_spec_non_tiled(shape)")
                     code.writeline(
                         "    for shape, dtype in zip(_pallas_out_shapes, out_dtypes)"
                     )
                     code.writeline(")")
                     code.writeline("in_specs_pallas = tuple(")
-                    code.writeline("    pl.BlockSpec(i.shape, indexer(len(i.shape)))")
+                    code.writeline("    pallas_make_block_spec_non_tiled(i.shape)")
                     code.writeline(
                         "    for i in [" + ", ".join(ctx.kernel_input_params) + "]"
                     )
@@ -3659,7 +3658,9 @@ from torch.utils._ordered_set import OrderedSet
 from torch._inductor.runtime.runtime_utils import (
     pallas_compute_tiling, pallas_make_block_spec, pallas_permute,
     pallas_gpu_align_output_specs, pallas_gpu_pad_inputs,
-    pallas_gpu_unpad_results, pallas_ensure_nonzero_rank,
+    pallas_gpu_unpad_results,
+    pallas_ensure_nonzero_rank,
+    pallas_make_block_spec_non_tiled,
     torch_dtype_to_jax_runtime,
 )
 """

--- a/torch/_inductor/codegen/pallas.py
+++ b/torch/_inductor/codegen/pallas.py
@@ -3659,7 +3659,7 @@ from torch.utils._ordered_set import OrderedSet
 from torch._inductor.runtime.runtime_utils import (
     pallas_compute_tiling, pallas_make_block_spec, pallas_permute,
     pallas_gpu_align_output_specs, pallas_gpu_pad_inputs,
-    pallas_gpu_unpad_results,
+    pallas_gpu_unpad_results, pallas_ensure_nonzero_rank,
     torch_dtype_to_jax_runtime,
 )
 """
@@ -4156,7 +4156,10 @@ from torch._inductor.runtime.runtime_utils import (
         )
         code.writeline(")(")
         if ctx.kernel_input_params:
-            code.writeline(f"    {', '.join(ctx.kernel_input_params)},")
+            kernel_input_params_nonzero_rank = [
+                f"pallas_ensure_nonzero_rank({p})" for p in ctx.kernel_input_params
+            ]
+            code.writeline(f"    {', '.join(kernel_input_params_nonzero_rank)},")
         code.writeline(")")
         # Reshape results back to original shapes (restores 0-d from promoted (1,))
         code.writeline("if isinstance(_result, tuple):")

--- a/torch/_inductor/runtime/runtime_utils.py
+++ b/torch/_inductor/runtime/runtime_utils.py
@@ -790,5 +790,17 @@ def _make_index_map(
 
 def pallas_ensure_nonzero_rank(x: torch.Tensor) -> torch.Tensor:
     if len(x.shape) == 0:
-        return x.reshape([1])
+        return x.reshape((1,))
     return x
+
+
+def pallas_make_block_spec_non_tiled(shape: tuple[int, ...]) -> "pl.BlockSpec":
+    from jax.experimental import (  # pyrefly: ignore [import-error, missing-import]
+        pallas as pl,
+    )
+    import jax.numpy as jnp  # pyrefly: ignore [import-error, missing-import]
+    nonzero_rank_shape = shape if len(shape) > 0 else (1,)
+    return pl.BlockSpec(
+        nonzero_rank_shape,
+        lambda i: [jnp.int32(i)] * len(nonzero_rank_shape),
+    )

--- a/torch/_inductor/runtime/runtime_utils.py
+++ b/torch/_inductor/runtime/runtime_utils.py
@@ -697,7 +697,7 @@ def pallas_make_block_spec(
 
     if buf_nd == 0:
         # Scalar — untouched regardless of grid shape.
-        return pl.BlockSpec((), _make_index_map([], buf_nd, n_grid))
+        return pl.BlockSpec((1,), _make_index_map([], 1, n_grid))
 
     bs = list(buf_shape)
     tiled_pairs: list[tuple[int, int]] = []
@@ -786,3 +786,9 @@ def _make_index_map(
         )
 
     return index_map
+
+
+def pallas_ensure_nonzero_rank(x: Any) -> Any:
+    if len(x.shape) == 0:
+        return x.reshape([1])
+    return x

--- a/torch/_inductor/runtime/runtime_utils.py
+++ b/torch/_inductor/runtime/runtime_utils.py
@@ -788,7 +788,7 @@ def _make_index_map(
     return index_map
 
 
-def pallas_ensure_nonzero_rank(x: Any) -> Any:
+def pallas_ensure_nonzero_rank(x: torch.Tensor) -> torch.Tensor:
     if len(x.shape) == 0:
         return x.reshape([1])
     return x

--- a/torch/_inductor/runtime/runtime_utils.py
+++ b/torch/_inductor/runtime/runtime_utils.py
@@ -794,11 +794,12 @@ def pallas_ensure_nonzero_rank(x: torch.Tensor) -> torch.Tensor:
     return x
 
 
-def pallas_make_block_spec_non_tiled(shape: tuple[int, ...]) -> "pl.BlockSpec":
+def pallas_make_block_spec_non_tiled(shape: tuple[int, ...]) -> Any:
+    import jax.numpy as jnp  # pyrefly: ignore [import-error, missing-import]
     from jax.experimental import (  # pyrefly: ignore [import-error, missing-import]
         pallas as pl,
     )
-    import jax.numpy as jnp  # pyrefly: ignore [import-error, missing-import]
+
     nonzero_rank_shape = shape if len(shape) > 0 else (1,)
     return pl.BlockSpec(
         nonzero_rank_shape,


### PR DESCRIPTION

Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #178193


From pallas doc:

> Not all block shapes are supported. On TPU, only blocks with rank at least 1
are supported. Furthermore, the last two dimensions of your block shape must be divisible by 8 and 128 respectively, or be equal to the respective dimensions of the overall array.

This PR makes it so that 0-D tensors are treated as tensors with shape `[1]`.  This fixes the  `test_stride_multiple_inputs` test, for which this PR removed the `@skip_if_tpu` tag. This PR also added a new test for testing scalar-tensor ops.

scalar-scalar ops are still not yet working, because we take a slightly different path (the non-tiled path) in the codegen. Will fix in future PRs.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo