### PR TITLE
[torchelastic] Keep health check alive during exit barrier

### DIFF
--- a/test/distributed/elastic/agent/server/test/api_test.py
+++ b/test/distributed/elastic/agent/server/test/api_test.py
@@ -485,6 +485,47 @@ class SimpleElasticAgentTest(unittest.TestCase):
         record_events_mock.assert_called_once()
         shutdown_mock.assert_called_once()
 
+    def test_exit_barrier_sets_and_clears_flag(self):
+        """Verify _in_exit_barrier is set before barrier and cleared after."""
+        spec = self._get_worker_spec(max_restarts=0)
+        agent = TestAgent(spec)
+        agent._worker_group.state = WorkerState.SUCCEEDED
+        agent._worker_group.group_world_size = 1
+        agent._store = MagicMock()
+
+        flag_during_barrier = []
+
+        def mock_barrier(**kwargs):
+            flag_during_barrier.append(agent._in_exit_barrier)
+
+        with patch(
+            "torch.distributed.elastic.utils.store.barrier",
+            side_effect=mock_barrier,
+        ):
+            agent._exit_barrier()
+
+        # Flag was True during barrier call
+        self.assertTrue(flag_during_barrier[0])
+        # Flag is False after barrier completes
+        self.assertFalse(agent._in_exit_barrier)
+
+    def test_exit_barrier_clears_flag_on_timeout(self):
+        """Verify _in_exit_barrier is cleared even if barrier times out."""
+        spec = self._get_worker_spec(max_restarts=0)
+        agent = TestAgent(spec)
+        agent._worker_group.state = WorkerState.SUCCEEDED
+        agent._worker_group.group_world_size = 1
+        agent._store = MagicMock()
+
+        with patch(
+            "torch.distributed.elastic.utils.store.barrier",
+            side_effect=Exception("wait timeout"),
+        ):
+            agent._exit_barrier()
+
+        # Flag must be cleared even on timeout
+        self.assertFalse(agent._in_exit_barrier)
+
     @patch("torch.distributed.elastic.agent.server.api.put_metric")
     def test_record_metrics_success_no_retries(self, put_metric_mock):
         spec = self._get_worker_spec(max_restarts=1)

--- a/test/distributed/elastic/agent/server/test/local_elastic_agent_test.py
+++ b/test/distributed/elastic/agent/server/test/local_elastic_agent_test.py
@@ -1533,6 +1533,96 @@ class LocalElasticAgentTest(unittest.TestCase):
         self.assertEqual(alive_time, expected_time)
         mock_watchdog.get_last_progress_time.assert_called_once()
 
+    def test_get_alive_time_during_exit_barrier(self):
+        """When _in_exit_barrier is True, _get_alive_time returns current time
+        even if the watchdog exists (since watchdog progress time is stale)."""
+        node_conf = Conf(entrypoint=_happy_function, local_world_size=1)
+
+        rdzv_handler = Mock()
+        rdzv_handler.get_backend.return_value = "c10d"
+        spec = WorkerSpec(
+            role=node_conf.role,
+            local_world_size=node_conf.local_world_size,
+            entrypoint=node_conf.entrypoint,
+            args=node_conf.args,
+            rdzv_handler=rdzv_handler,
+            max_restarts=0,
+            monitor_interval=0.01,
+        )
+        agent = self.get_agent(spec, node_config=node_conf)
+
+        # Set up a mock watchdog with a stale time
+        mock_watchdog = Mock()
+        mock_watchdog.get_last_progress_time.return_value = 1000  # very old
+        agent._worker_watchdog = mock_watchdog
+
+        # Without exit barrier flag, should return watchdog time
+        agent._in_exit_barrier = False
+        self.assertEqual(agent._get_alive_time(), 1000)
+
+        # With exit barrier flag, should return current time (not stale watchdog time)
+        agent._in_exit_barrier = True
+        alive_time = agent._get_alive_time()
+        now = int(time.time())
+        self.assertAlmostEqual(alive_time, now, delta=2)
+
+    def test_healthcheck_reports_healthy_during_exit_barrier(self):
+        """Verify health check callback returns current time during exit barrier,
+        preventing TW from killing the task while agents coordinate shutdown."""
+        node_conf = Conf(entrypoint=_happy_function, local_world_size=1)
+
+        rdzv_handler = Mock()
+        rdzv_handler.get_backend.return_value = "c10d"
+        spec = WorkerSpec(
+            role=node_conf.role,
+            local_world_size=node_conf.local_world_size,
+            entrypoint=node_conf.entrypoint,
+            args=node_conf.args,
+            rdzv_handler=rdzv_handler,
+            max_restarts=0,
+            monitor_interval=0.01,
+        )
+        agent = self.get_agent(spec, node_config=node_conf)
+
+        # Simulate post-training state: watchdog exists but progress time is stale
+        mock_watchdog = Mock()
+        stale_time = int(time.time()) - 600  # 10 minutes ago
+        mock_watchdog.get_last_progress_time.return_value = stale_time
+        agent._worker_watchdog = mock_watchdog
+
+        # Before exit barrier: alive_time is stale (would fail TW health check)
+        alive_time = agent._get_alive_time()
+        self.assertEqual(alive_time, stale_time)
+
+        # During exit barrier: alive_time is current (TW health check passes)
+        agent._in_exit_barrier = True
+        alive_time = agent._get_alive_time()
+        now = int(time.time())
+        self.assertAlmostEqual(alive_time, now, delta=2)
+
+        # After exit barrier: back to watchdog time
+        agent._in_exit_barrier = False
+        alive_time = agent._get_alive_time()
+        self.assertEqual(alive_time, stale_time)
+
+    def test_in_exit_barrier_initialized_false(self):
+        """Verify _in_exit_barrier is False on agent construction."""
+        node_conf = Conf(entrypoint=_happy_function, local_world_size=1)
+
+        rdzv_handler = Mock()
+        rdzv_handler.get_backend.return_value = "c10d"
+        spec = WorkerSpec(
+            role=node_conf.role,
+            local_world_size=node_conf.local_world_size,
+            entrypoint=node_conf.entrypoint,
+            args=node_conf.args,
+            rdzv_handler=rdzv_handler,
+            max_restarts=0,
+            monitor_interval=0.01,
+        )
+        agent = self.get_agent(spec, node_config=node_conf)
+        self.assertFalse(agent._in_exit_barrier)
+
     def test_setup_healthcheck_idempotent(self):
         """Test _setup_healthcheck is idempotent and does not recreate server when JK is enabled."""
         node_conf = Conf(entrypoint=_happy_function, local_world_size=1)

--- a/torch/distributed/elastic/agent/server/api.py
+++ b/torch/distributed/elastic/agent/server/api.py
@@ -471,6 +471,7 @@ class SimpleElasticAgent(ElasticAgent):
         self._exit_barrier_timeout = exit_barrier_timeout
         self._shutdown_timeout = shutdown_timeout
         self._total_execution_time = 0
+        self._in_exit_barrier: bool = False
 
     def get_worker_group(self, role: str = DEFAULT_ROLE) -> WorkerGroup:
         return self._worker_group
@@ -998,6 +999,7 @@ class SimpleElasticAgent(ElasticAgent):
             self._exit_barrier_timeout,
         )
         start = time.time()
+        self._in_exit_barrier = True
         try:
             store_util.barrier(
                 store=self._store,
@@ -1017,3 +1019,5 @@ class SimpleElasticAgent(ElasticAgent):
                 "Error waiting on exit barrier. Elapsed: %s seconds",
                 time.time() - start,
             )
+        finally:
+            self._in_exit_barrier = False

--- a/torch/distributed/elastic/agent/server/local_elastic_agent.py
+++ b/torch/distributed/elastic/agent/server/local_elastic_agent.py
@@ -217,7 +217,13 @@ class LocalElasticAgent(SimpleElasticAgent):
         Once workers are running and the watchdog is active, we delegate
         to the watchdog's ``get_last_progress_time`` for real liveness
         tracking.
+
+        During the exit barrier wait, workers have finished and the watchdog
+        progress time is stale. We return the current time to prevent TW
+        from killing the task while agents coordinate shutdown.
         """
+        if self._in_exit_barrier:
+            return int(time.time())
         if self._worker_watchdog is not None:
             return self._worker_watchdog.get_last_progress_time()
         return int(time.time())


### PR DESCRIPTION
Summary:
After workers finish, the TorchElastic exit barrier waits up to 300s for
all agents to coordinate shutdown via TCPStore. During this wait, the
watchdog progress time is stale, causing the thrift health check to
report ServiceHealth::ERROR after ~60s. TW then kills the task, which
drops its TCPStore connection and cascades failures to other agents.

Fix: Add an `_in_exit_barrier` flag to SimpleElasticAgent. When the exit
barrier starts, set this flag so `_get_alive_time()` returns the current
time instead of the stale watchdog time. This keeps the health check
returning OK while agents coordinate. The flag is cleared in a `finally`
block when the barrier completes or times out.

Test Plan:
Buck test results:
- `buck test fbcode//caffe2/test/distributed/elastic/agent/server/test:api_test
  -- test_exit_barrier_sets_and_clears_flag
     test_exit_barrier_clears_flag_on_timeout
     test_invoke_run
     test_agent_process_signal_exception` → 4/4 PASS
- `local_agent_test` tests could not run in sandcastle due to missing
  etcd binary (pre-existing environment limitation)

Differential Revision: D97813988


