### PR TITLE
[CP] Improve head tail load balancer indices creation performance

### DIFF
--- a/torch/distributed/tensor/experimental/_context_parallel/_load_balancer.py
+++ b/torch/distributed/tensor/experimental/_context_parallel/_load_balancer.py
@@ -148,27 +148,18 @@ class _HeadTailLoadBalancer(_LoadBalancer):
         if seq_length % (world_size * 2) != 0:
             raise AssertionError
         chunk_size = seq_length // (world_size * 2)
-        all_indices = []
 
-        for rank in range(world_size):
-            # Generate indices for first chunk of the cp rank
-            first_chunk_start = rank * chunk_size
-            first_chunk_indices = list(
-                range(first_chunk_start, first_chunk_start + chunk_size)
-            )
+        # Build indices using torch ops instead of Python lists.
+        # Split sequence into 2*world_size chunks, then pair chunk r
+        # with chunk (2*world_size - 1 - r) for each rank.
+        arange = torch.arange(seq_length, dtype=torch.int, device=self.device)
+        chunks = arange.view(world_size * 2, chunk_size)
+        head_idx = torch.arange(world_size, device=self.device)
+        tail_idx = 2 * world_size - 1 - head_idx
+        # Stack head and tail chunks for each rank: (world_size, 2, chunk_size)
+        paired = torch.stack([chunks[head_idx], chunks[tail_idx]], dim=1)
+        all_indices_tensor = paired.reshape(-1)
 
-            # Second chunk: positions from the complementary chunk
-            second_chunk_idx = world_size * 2 - rank - 1
-            second_chunk_start = second_chunk_idx * chunk_size
-            second_chunk_indices = list(
-                range(second_chunk_start, second_chunk_start + chunk_size)
-            )
-            # combine the indices for this rank
-            all_indices.extend(first_chunk_indices + second_chunk_indices)
-
-        all_indices_tensor = torch.tensor(
-            all_indices, dtype=torch.int, device=self.device
-        )
         if restore:
             all_indices_tensor = torch.argsort(all_indices_tensor)
 

--- a/torch/distributed/tensor/experimental/_context_parallel/_load_balancer.py
+++ b/torch/distributed/tensor/experimental/_context_parallel/_load_balancer.py
@@ -149,11 +149,10 @@ class _HeadTailLoadBalancer(_LoadBalancer):
             raise AssertionError
         chunk_size = seq_length // (world_size * 2)
 
-        # Build indices using torch ops instead of Python lists.
-        # Split sequence into 2*world_size chunks, then pair chunk r
-        # with chunk (2*world_size - 1 - r) for each rank.
-        arange = torch.arange(seq_length, dtype=torch.int, device=self.device)
-        chunks = arange.view(world_size * 2, chunk_size)
+        # Split sequence into 2*world_size chunks, then pair chunk r with
+        # chunk (2*world_size - 1 - r) for each rank.
+        indices = torch.arange(seq_length, dtype=torch.int, device=self.device)
+        chunks = indices.view(world_size * 2, chunk_size)
         head_idx = torch.arange(world_size, device=self.device)
         tail_idx = 2 * world_size - 1 - head_idx
         paired = torch.stack([chunks[head_idx], chunks[tail_idx]], dim=1)

--- a/torch/distributed/tensor/experimental/_context_parallel/_load_balancer.py
+++ b/torch/distributed/tensor/experimental/_context_parallel/_load_balancer.py
@@ -156,7 +156,6 @@ class _HeadTailLoadBalancer(_LoadBalancer):
         chunks = arange.view(world_size * 2, chunk_size)
         head_idx = torch.arange(world_size, device=self.device)
         tail_idx = 2 * world_size - 1 - head_idx
-        # Stack head and tail chunks for each rank: (world_size, 2, chunk_size)
         paired = torch.stack([chunks[head_idx], chunks[tail_idx]], dim=1)
         all_indices_tensor = paired.reshape(-1)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #178199

The list(range(...)) is too slow. Change it to use vectorized approach:


    seqlen    world_size    old (ms)    new (ms)    speedup
    64K       4             4.36        0.05        83x
    128K      4             8.54        0.05        164x
    256K      4             18.06       0.05        348x
    512K      4             37.56       0.05        716x
    1M        4             79.77       0.05        1555x
    64K       8             4.26        0.05        83x
    128K      8             8.46        0.05        166x
    256K      8             17.78       0.05        345x
    512K      8             37.90       0.05        737x
    1M        8             78.43       0.05        1543x
