### PR TITLE
Update pthreadpool submodule to google/pthreadpool

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,7 +25,7 @@
 [submodule "third_party/NNPACK_deps/pthreadpool"]
     ignore = dirty
     path = third_party/pthreadpool
-    url = https://github.com/Maratyszcza/pthreadpool.git
+    url = https://github.com/google/pthreadpool.git
 [submodule "third_party/NNPACK_deps/FXdiv"]
     ignore = dirty
     path = third_party/FXdiv


### PR DESCRIPTION
Update pthreadpool dependency to point to google/pthreadpool. The original is no longer actively maintained and google has taken up ongoing development.

Google's fork is a continuation of the original and should be drop-in compatible (no core API changes). It adds new APIs that XNNPACK needs. This is done in preparation for updating the XNNPACK version.