### PR TITLE
[PyTorch][OSS][AOTAutograd] Allow None values in saved tensors for vc_check split (#178204)

### DIFF
--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -651,6 +651,60 @@ class TestAOTAutograd(AOTTestCase):
 
         self.verify_aot_autograd(F(), inp)
 
+    def test_none_in_saved_activations(self):
+        # Regression test: when a compiled forward function returns None for
+        # certain saved activations (e.g., optional parameters that are None
+        # emitted via inductor's NoneAsConstantBuffer), the assertion and detach
+        # logic in CompiledFunction.forward() must handle None correctly.
+        # Previously, isinstance(x, torch.Tensor) rejected None, and
+        # x._is_view() crashed on None.
+
+        # Simulate saved activations containing None (as produced by inductor)
+        view_tensor = torch.randn(4, 4).view(2, 8)
+        non_view_tensor = torch.randn(3, 3)
+        saved = [non_view_tensor, None, view_tensor]
+
+        # Test the OLD expression (pre-fix) — this would reject None
+        self.assertFalse(
+            all(isinstance(x, torch.Tensor) for x in saved),
+            "Old assertion rejects None — this is the bug",
+        )
+
+        # Test the OLD detach expression — this crashes on None
+        with self.assertRaises(
+            AttributeError, msg="'NoneType' has no attribute '_is_view'"
+        ):
+            _ = [x.detach() if x._is_view() else x for x in saved]
+
+        # Test the NEW expression (post-fix) — accepts None
+        self.assertTrue(all(isinstance(x, torch.Tensor) or x is None for x in saved))
+
+        # Test the NEW detach expression (post-fix) — handles None
+        result = [
+            (x.detach() if x._is_view() else x) if x is not None else None
+            for x in saved
+        ]
+        self.assertIs(result[0], non_view_tensor)  # non-view passes through
+        self.assertIsNone(result[1])  # None passes through
+        self.assertFalse(result[2]._is_view())  # view gets detached
+
+        # Verify save_for_backward accepts None (PyTorch documents this)
+        class TestFn(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, x):
+                ctx.save_for_backward(x, None, x)
+                return x.clone()
+
+            @staticmethod
+            def backward(ctx, grad):
+                a, b, c = ctx.saved_tensors
+                if b is not None:
+                    raise RuntimeError("Expected saved tensor b to be None")
+                return grad
+
+        x = torch.randn(2, requires_grad=True)
+        TestFn.apply(x).sum().backward()
+
     def test_embedding_bag_view_dynamic(self):
         # Backwards pass tries to wrap a sparse tensor in a FunctionalTensorWrapper;
         # test that this works even though the sparse tensor has no storage.

--- a/torch/_functorch/_aot_autograd/runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/runtime_wrappers.py
@@ -2627,28 +2627,47 @@ Your tensor subclass must implement __coerce_same_metadata_as_tangent__."""
                     CompiledFunction.metadata.tensors_saved_for_backwards_no_vc_check_slice
                 ]
                 if not all(
-                    isinstance(x, torch.Tensor) for x in tensors_saved_with_vc_check
+                    isinstance(x, torch.Tensor) or x is None
+                    for x in tensors_saved_with_vc_check
                 ):
+                    _vc_slice = CompiledFunction.metadata.tensors_saved_for_backwards_with_vc_check_slice
+                    non_tensor_idxs = [
+                        (i, type(x).__name__)
+                        for i, x in enumerate(tensors_saved_with_vc_check)
+                        if not isinstance(x, torch.Tensor) and x is not None
+                    ]
                     raise AssertionError(
-                        f"expected all tensors_saved_with_vc_check to be Tensors, "
-                        f"got types: {[type(x) for x in tensors_saved_with_vc_check]}"
+                        f"expected all tensors_saved_with_vc_check to be Tensors or None, "
+                        f"but found non-tensors at indices {non_tensor_idxs} "
+                        f"(slice={_vc_slice}, fw_outs_len={len(fw_outs)}, "
+                        f"num_forward={CompiledFunction.metadata.num_forward})"
                     )
                 if not all(
-                    isinstance(x, torch.Tensor) for x in tensors_saved_no_vc_check
+                    isinstance(x, torch.Tensor) or x is None
+                    for x in tensors_saved_no_vc_check
                 ):
+                    _no_vc_slice = CompiledFunction.metadata.tensors_saved_for_backwards_no_vc_check_slice
+                    non_tensor_idxs = [
+                        (i, type(x).__name__)
+                        for i, x in enumerate(tensors_saved_no_vc_check)
+                        if not isinstance(x, torch.Tensor) and x is not None
+                    ]
                     raise AssertionError(
-                        f"expected all tensors_saved_no_vc_check to be Tensors, "
-                        f"got types: {[type(x) for x in tensors_saved_no_vc_check]}"
+                        f"expected all tensors_saved_no_vc_check to be Tensors or None, "
+                        f"but found non-tensors at indices {non_tensor_idxs} "
+                        f"(slice={_no_vc_slice}, fw_outs_len={len(fw_outs)}, "
+                        f"num_forward={CompiledFunction.metadata.num_forward})"
                     )
 
                 # See Note [Detaching saved tensors in AOTAutograd]
                 num_vc_check = len(tensors_saved_with_vc_check)
                 tensors_to_save = [
-                    x.detach() if x._is_view() else x
+                    (x.detach() if x._is_view() else x) if x is not None else None
                     for x in tensors_saved_with_vc_check
                 ]
                 tensors_no_vc = [
-                    x.detach() if x._is_view() else x for x in tensors_saved_no_vc_check
+                    (x.detach() if x._is_view() else x) if x is not None else None
+                    for x in tensors_saved_no_vc_check
                 ]
 
                 # dynamic_saved_tensors_idxs has indices relative to all saved tensors
@@ -2658,11 +2677,16 @@ Your tensor subclass must implement __coerce_same_metadata_as_tangent__."""
                     dims,
                 ) in CompiledFunction.metadata.dynamic_saved_tensors_idxs.items():
                     if idx < num_vc_check:
-                        maybe_mark_dynamic_helper(tensors_to_save[idx], dims)
+                        if tensors_to_save[idx] is not None:
+                            # pyrefly: ignore[bad-argument-type]
+                            maybe_mark_dynamic_helper(tensors_to_save[idx], dims)
                     else:
-                        maybe_mark_dynamic_helper(
-                            tensors_no_vc[idx - num_vc_check], dims
-                        )
+                        if tensors_no_vc[idx - num_vc_check] is not None:
+                            maybe_mark_dynamic_helper(
+                                # pyrefly: ignore[bad-argument-type]
+                                tensors_no_vc[idx - num_vc_check],
+                                dims,
+                            )
 
                 # Only save tensors that need VC checks via save_for_backward
                 ctx.save_for_backward(*tensors_to_save)


### PR DESCRIPTION
Summary:

When a compiled forward function (e.g., via inductor) returns None for
certain saved activations — such as optional parameters like bias=None
— the AOT autograd runtime previously crashed with:

  AssertionError: expected all tensors_saved_with_vc_check to be Tensors

This happened because the assertion in CompiledFunction.forward() used
`isinstance(x, torch.Tensor)` which rejects None. Additionally, the
subsequent detach logic `x._is_view()` would crash on None with an
AttributeError.

None values in saved activations are legitimate: they represent optional
parameters that don't exist in the model. PyTorch's save_for_backward()
natively supports None arguments (preserving them positionally in
ctx.saved_tensors), so the backward pass receives None at the correct
positions as expected by the compiled backward function.

Changes:
- Updated the type assertions for both vc_check and no_vc_check saved
  tensors to accept None alongside torch.Tensor
- Added None guards in the detach logic so .detach() and ._is_view()
  are only called on actual tensors
- Added None guards in the dynamic saved tensor marking logic
- Improved assertion error messages to include slice boundaries and
  only report truly unexpected types (not None)

Test Plan:
Added `test_none_in_saved_activations` in test_aotdispatch.py that
verifies:

1. The OLD assertion rejects None (proving the bug existed):
```
self.assertFalse(
    all(isinstance(x, torch.Tensor) for x in saved),
    "Old assertion rejects None — this is the bug"
)
```

2. The OLD detach expression crashes on None:
```
with self.assertRaises(AttributeError):
    _ = [x.detach() if x._is_view() else x for x in saved]
```

3. The NEW assertion accepts None:
```
self.assertTrue(
    all(isinstance(x, torch.Tensor) or x is None for x in saved)
)
```

4. The NEW detach expression handles None correctly:
```
result = [
    (x.detach() if x._is_view() else x) if x is not None else None
    for x in saved
]
self.assertIsNone(result[1])  # None passes through
```

5. save_for_backward accepts None and preserves it in ctx.saved_tensors:
```
ctx.save_for_backward(x, None, x)
# In backward:
a, b, c = ctx.saved_tensors
assert b is None
```

Test results:
```
$ buck2 test fbcode//caffe2/test/functorch:test_aotdispatch -- test_none_in_saved_activations
Tests finished: Pass 4. Fail 0.
```

Differential Revision: D97394028




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98