### PR TITLE
Fix attn_mask shape documentation in scaled_dot_product_attention

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -6078,7 +6078,7 @@ scaled_dot_product_attention = _add_docstr(
         key (Tensor): Key tensor; shape :math:`(N, ..., H, S, E)`.
         value (Tensor): Value tensor; shape :math:`(N, ..., H, S, Ev)`.
         attn_mask (optional Tensor): Attention mask; shape must be broadcastable to the shape of attention weights,
-            which is :math:`(N,..., L, S)`. Two types of masks are supported.
+            which is :math:`(N, ..., Hq, L, S)`. Two types of masks are supported.
             A boolean mask where a value of True indicates that the element *should* take part in attention.
             A float mask of the same type as query, key, value that is added to the attention score.
         dropout_p (float): Dropout probability; if greater than 0.0, dropout is applied


### PR DESCRIPTION
## Problem

The `torch.nn.functional.scaled_dot_product_attention` documentation incorrectly states that `attn_mask` must be broadcastable to shape `(N, ..., L, S)`. The head dimension `Hq` is missing from the documented shape.

## Solution

Updated the documentation to correctly specify the `attn_mask` shape as `(N, ..., Hq, L, S)`, matching the actual behavior when using GQA (Grouped Query Attention).

## Validation

```python
# Documentation now matches code behavior
mask = torch.ones(N, Hq, L, S, dtype=torch.bool)  # ✅ Correct shape
F.scaled_dot_product_attention(q, k, v, attn_mask=mask, enable_gqa=True)
```

Fixes #177482