### PR TITLE
Fix CUDA batch_norm eval returning populated save_mean/save_invstd

### DIFF
--- a/aten/src/ATen/native/cuda/Normalization.cu
+++ b/aten/src/ATen/native/cuda/Normalization.cu
@@ -450,9 +450,15 @@ std::tuple<Tensor&, Tensor&, Tensor&> batch_norm_cuda_out(const Tensor& self, co
     }
   } else {
     TORCH_CHECK(has_running_mean);
-    at::native::resize_output(save_mean, running_mean_opt->sizes());
-    save_mean.copy_(*running_mean_opt, /*non_blocking=*/true);
-    batch_norm_calc_invstd(save_invstd, running_var_opt.value(), epsilon);
+    // In eval mode, compute the forward pass using running stats directly,
+    // then return empty save_mean/save_invstd to match CPU behavior (they
+    // are not needed for the backward pass in eval mode).
+    auto invstd = at::empty_like(running_var_opt.value());
+    batch_norm_calc_invstd(invstd, running_var_opt.value(), epsilon);
+    batch_norm_elementwise(output, self, weight_opt, bias_opt, *running_mean_opt, invstd);
+    at::native::resize_output(save_mean, {0});
+    at::native::resize_output(save_invstd, {0});
+    return std::tuple<Tensor&, Tensor&, Tensor&>(output, save_mean, save_invstd);
   }
 
   batch_norm_elementwise(output, self, weight_opt, bias_opt, save_mean, save_invstd);
@@ -464,8 +470,10 @@ std::tuple<Tensor, Tensor, Tensor> batch_norm_cuda(const Tensor& self, const std
   int64_t n_input = self.size(1);
   auto options = self.options().dtype(
       at::toAccumulateType(self.scalar_type(), /*is_cuda=*/true));
-  auto save_mean = at::empty({n_input}, options);
-  auto save_invstd = at::empty({n_input}, options);
+  // In eval mode, save_mean/save_invstd will be resized to {0} by
+  // batch_norm_cuda_out, so avoid unnecessary allocation.
+  auto save_mean = train ? at::empty({n_input}, options) : at::empty({0}, options);
+  auto save_invstd = train ? at::empty({n_input}, options) : at::empty({0}, options);
 
   at::native::batch_norm_cuda_out(
       self,


### PR DESCRIPTION
Fixes #85960

## Summary

In eval mode, the CUDA `native_batch_norm` kernel was copying `running_mean` into `save_mean` and computing `save_invstd` from `running_var`, returning populated tensors of shape `[num_features]`. The CPU kernel returns empty (size-0) tensors for both, since they are not needed for the backward pass in eval mode.

```python
import torch
bn = torch.nn.BatchNorm2d(3).eval()
x = torch.randn(2, 3, 4, 4)

# CPU - correct
_, save_mean_cpu, save_invstd_cpu = torch.native_batch_norm(
    x, bn.weight, bn.bias, bn.running_mean, bn.running_var, False, 0.1, 1e-5)
print(save_mean_cpu.shape)    # torch.Size([0])
print(save_invstd_cpu.shape)  # torch.Size([0])

# CUDA - before this fix
_, save_mean_cuda, save_invstd_cuda = torch.native_batch_norm(
    x.cuda(), bn.weight.cuda(), bn.bias.cuda(), bn.running_mean.cuda(),
    bn.running_var.cuda(), False, 0.1, 1e-5)
print(save_mean_cuda.shape)    # torch.Size([3])  <-- should be [0]
print(save_invstd_cuda.shape)  # torch.Size([3])  <-- should be [0]
```

The fix computes the forward pass using `running_mean` and a locally computed `invstd` from `running_var`, then returns empty `save_mean`/`save_invstd` tensors to match CPU behavior.

## Test plan

- Existing `test_compare_cpu_nn_functional_batch_norm` opinfo test should now pass for the eval case (previously CUDA returned different-shaped auxiliary outputs)
- Manual verification: `torch.native_batch_norm(..., training=False)` on CUDA returns size-0 `save_mean`/`save_invstd`

cc @ngimel @albanD @jjsjann123