### PR TITLE
Fix maximum/minimum CUDA type promotion with out= argument

### DIFF
--- a/aten/src/ATen/native/cuda/MaxMinElementwiseKernel.cu
+++ b/aten/src/ATen/native/cuda/MaxMinElementwiseKernel.cu
@@ -12,20 +12,20 @@
 namespace at::native {
 
 void maximum_kernel_cuda(TensorIteratorBase& iter) {
-  if (iter.dtype() == ScalarType::Bool) {
+  if (iter.common_dtype() == ScalarType::Bool) {
     opmath_symmetric_gpu_kernel_with_scalars<bool>(
         iter, []GPU_LAMBDA(bool a, bool b) -> bool {
       return a || b;
     });
-  } else if (isIntegralType(iter.dtype(), /*includeBool=*/ false)) {
-    AT_DISPATCH_INTEGRAL_TYPES(iter.dtype(), "max_elementwise_cuda", [&]() {
+  } else if (isIntegralType(iter.common_dtype(), /*includeBool=*/ false)) {
+    AT_DISPATCH_INTEGRAL_TYPES(iter.common_dtype(), "max_elementwise_cuda", [&]() {
       opmath_symmetric_gpu_kernel_with_scalars<scalar_t>(
           iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
         return ::max(a, b);
       });
     });
   } else {
-    AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, iter.dtype(), "max_elementwise_cuda", [&]() {
+    AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, iter.common_dtype(), "max_elementwise_cuda", [&]() {
       opmath_symmetric_gpu_kernel_with_scalars<scalar_t>(
           iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
         if (a != a) {
@@ -41,18 +41,18 @@ void maximum_kernel_cuda(TensorIteratorBase& iter) {
 }
 
 void minimum_kernel_cuda(TensorIteratorBase& iter) {
-  if (iter.dtype() == ScalarType::Bool) {
+  if (iter.common_dtype() == ScalarType::Bool) {
     opmath_symmetric_gpu_kernel_with_scalars<bool>(iter, []GPU_LAMBDA(bool a, bool b) -> bool {
       return a && b;
     });
-  } else if (isIntegralType(iter.dtype(), /*includeBool=*/ false)) {
-    AT_DISPATCH_INTEGRAL_TYPES(iter.dtype(), "minimum_cuda", [&]() {
+  } else if (isIntegralType(iter.common_dtype(), /*includeBool=*/ false)) {
+    AT_DISPATCH_INTEGRAL_TYPES(iter.common_dtype(), "minimum_cuda", [&]() {
       opmath_symmetric_gpu_kernel_with_scalars<scalar_t>(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
         return ::min(a, b);
       });
     });
   } else {
-    AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, iter.dtype(), "min_elementwise_cuda", [&]() {
+    AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, iter.common_dtype(), "min_elementwise_cuda", [&]() {
       opmath_symmetric_gpu_kernel_with_scalars<scalar_t>(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
         if (a != a) {
           return a;

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -2155,6 +2155,27 @@ class TestBinaryUfuncs(TestCase):
             result = op(a, b)
             self.assertEqual(result.dtype, torch.result_type(a, b))
 
+    def test_maximum_minimum_out_type_promotion(self, device):
+        # Regression test for https://github.com/pytorch/pytorch/issues/173110
+        # maximum/minimum with out= should promote inputs to common dtype
+        # before comparison, then cast the result to the output dtype.
+        b0 = torch.tensor([1], dtype=torch.uint8, device=device)
+        l0 = torch.tensor([-9], dtype=torch.int64, device=device)
+
+        for op in (torch.maximum, torch.minimum):
+            # Out-of-place result (always correct)
+            expected_full = op(b0, l0)
+
+            # Out= with output dtype matching common dtype
+            out_common = torch.empty(1, dtype=torch.int64, device=device)
+            op(b0, l0, out=out_common)
+            self.assertEqual(out_common, expected_full)
+
+            # Out= with output dtype different from common dtype
+            out_narrow = torch.empty(1, dtype=torch.uint8, device=device)
+            op(b0, l0, out=out_narrow)
+            self.assertEqual(out_narrow, expected_full.to(torch.uint8))
+
     @dtypes(*integral_types_and(torch.bool))
     def test_maximum_minimum_int_and_bool(self, device, dtype):
         ops = (


### PR DESCRIPTION
Fixes #173110

## Summary

The CUDA `maximum` and `minimum` kernels dispatched on `iter.dtype()` (the output tensor's dtype) rather than `iter.common_dtype()` (the promoted dtype of the inputs). When using `out=` with a narrower output dtype (e.g., `uint8`) and inputs of mixed types (e.g., `uint8` + `int64`), the kernel would:

1. Dispatch as `uint8` instead of `int64`
2. Cast inputs to `uint8` *before* the comparison (`-9` becomes `247`)
3. Compute `max(1, 247) = 247` instead of the correct `max(1, -9) = 1`

The fix changes `iter.dtype()` to `iter.common_dtype()` in both `maximum_kernel_cuda` and `minimum_kernel_cuda`. This matches the existing pattern used by `fmax_kernel_cuda` and `fmin_kernel_cuda`, and allows the GPU dynamic casting in `gpu_kernel_impl` to handle load/store conversions correctly.

### Reproducer
```python
import torch

b0 = torch.tensor([1], dtype=torch.uint8, device="cuda")
b1 = torch.zeros(1, dtype=torch.uint8, device="cuda")
l0 = torch.tensor([-9], dtype=torch.int64, device="cuda")

# Before fix: tensor([247]) -- wrong
# After fix:  tensor([1])   -- correct
torch.maximum(b0, l0, out=b1)
```

## Test plan
- Added `test_maximum_minimum_out_type_promotion` to `test_binary_ufuncs.py`
- Tests both `torch.maximum` and `torch.minimum` with `out=` across dtype boundaries
- Verifies both `out=common_dtype` and `out=narrow_dtype` cases

cc @ezyang @ptrblck @eqy