### PR TITLE
Support resize_ with address hint

### DIFF
--- a/aten/src/ATen/native/cuda/Resize.cpp
+++ b/aten/src/ATen/native/cuda/Resize.cpp
@@ -15,29 +15,18 @@
 
 namespace at::native {
 
-void resize_bytes_cuda(StorageImpl* storage, size_t size_bytes) {
+void resize_bytes_cuda(StorageImpl* storage, size_t size_bytes, void* hint) {
   TORCH_CHECK(storage->resizable(), "Trying to resize storage that is not resizable");
 
   c10::Device device = storage->device();
 
   if (size_bytes == 0) {
-    void* old_ptr = storage->data_ptr().get();
-    size_t old_size = storage->nbytes();
     storage->set_data_ptr_noswap(at::DataPtr(nullptr, device));
     storage->set_nbytes(0);
-    if (old_ptr) {
-      storage->set_preferred_data_ptr(old_ptr, old_size);
-    }
     return;
   }
 
   c10::cuda::CUDAGuard guard(device.index());
-
-  void* hint = nullptr;
-  if (storage->preferred_data_ptr_size() == size_bytes) {
-    hint = storage->preferred_data_ptr();
-  }
-  storage->clear_preferred_data_ptr();
 
   at::DataPtr data = hint
       ? c10::cuda::CUDACachingAllocator::allocateWithHint(size_bytes, hint)

--- a/aten/src/ATen/native/cuda/Resize.cpp
+++ b/aten/src/ATen/native/cuda/Resize.cpp
@@ -4,6 +4,7 @@
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/cuda/PeerToPeerAccess.h>
 #include <ATen/native/ResizeCommon.h>
+#include <c10/cuda/CUDACachingAllocator.h>
 #include <c10/cuda/CUDAGuard.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
@@ -42,6 +43,38 @@ void resize_bytes_cuda(StorageImpl* storage, size_t size_bytes) {
   }
 
   // Destructively overwrite data_ptr
+  storage->set_data_ptr_noswap(std::move(data));
+  storage->set_nbytes(size_bytes);
+}
+
+void resize_bytes_cuda_with_addr(
+    StorageImpl* storage,
+    size_t size_bytes,
+    void* addr) {
+  if (size_bytes == 0) {
+    resize_bytes_cuda(storage, 0);
+    return;
+  }
+
+  TORCH_CHECK(storage->resizable(), "Trying to resize storage that is not resizable");
+  auto allocator = storage->allocator();
+  TORCH_CHECK(allocator != nullptr, "Trying to resize storage without an allocator");
+  TORCH_CHECK(
+      storage->nbytes() == 0,
+      "_resize_with_addr_ only supports resizing a zero-sized CUDA storage to a non-zero size, but got current size ",
+      storage->nbytes(),
+      " bytes");
+  TORCH_CHECK(
+      addr != nullptr,
+      "_resize_with_addr_ expects a non-null addr when size is non-zero");
+  TORCH_CHECK(
+      allocator == c10::cuda::CUDACachingAllocator::get(),
+      "_resize_with_addr_ only supports storages allocated by the current CUDA caching allocator");
+
+  c10::Device device = storage->device();
+  c10::cuda::CUDAGuard guard(device.index());
+  at::DataPtr data =
+      c10::cuda::CUDACachingAllocator::allocateWithAddress(size_bytes, addr);
   storage->set_data_ptr_noswap(std::move(data));
   storage->set_nbytes(size_bytes);
 }

--- a/aten/src/ATen/native/cuda/Resize.cpp
+++ b/aten/src/ATen/native/cuda/Resize.cpp
@@ -4,7 +4,6 @@
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/cuda/PeerToPeerAccess.h>
 #include <ATen/native/ResizeCommon.h>
-#include <c10/cuda/CUDACachingAllocator.h>
 #include <c10/cuda/CUDAGuard.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
@@ -15,8 +14,12 @@
 
 namespace at::native {
 
-void resize_bytes_cuda(StorageImpl* storage, size_t size_bytes, void* hint) {
-  TORCH_CHECK(storage->resizable(), "Trying to resize storage that is not resizable");
+void resize_bytes_cuda(StorageImpl* storage, size_t size_bytes) {
+  TORCH_CHECK(
+      storage->resizable(), "Trying to resize storage that is not resizable");
+  auto allocator = storage->allocator();
+  TORCH_CHECK(
+      allocator != nullptr, "Trying to resize storage without an allocator");
 
   c10::Device device = storage->device();
 
@@ -28,9 +31,7 @@ void resize_bytes_cuda(StorageImpl* storage, size_t size_bytes, void* hint) {
 
   c10::cuda::CUDAGuard guard(device.index());
 
-  at::DataPtr data = hint
-      ? c10::cuda::CUDACachingAllocator::allocateWithHint(size_bytes, hint)
-      : c10::cuda::CUDACachingAllocator::get()->allocate(size_bytes);
+  at::DataPtr data = allocator->allocate(size_bytes);
 
   if (storage->data_ptr()) {
     at::globalContext().lazyInitDevice(c10::DeviceType::CUDA);
@@ -44,6 +45,7 @@ void resize_bytes_cuda(StorageImpl* storage, size_t size_bytes, void* hint) {
             c10::cuda::getCurrentCUDAStream()));
   }
 
+  // Destructively overwrite data_ptr
   storage->set_data_ptr_noswap(std::move(data));
   storage->set_nbytes(size_bytes);
 }

--- a/aten/src/ATen/native/cuda/Resize.cpp
+++ b/aten/src/ATen/native/cuda/Resize.cpp
@@ -15,11 +15,9 @@
 namespace at::native {
 
 void resize_bytes_cuda(StorageImpl* storage, size_t size_bytes) {
-  TORCH_CHECK(
-      storage->resizable(), "Trying to resize storage that is not resizable");
+  TORCH_CHECK(storage->resizable(), "Trying to resize storage that is not resizable");
   auto allocator = storage->allocator();
-  TORCH_CHECK(
-      allocator != nullptr, "Trying to resize storage without an allocator");
+  TORCH_CHECK(allocator != nullptr, "Trying to resize storage without an allocator");
 
   c10::Device device = storage->device();
 
@@ -30,9 +28,7 @@ void resize_bytes_cuda(StorageImpl* storage, size_t size_bytes) {
   }
 
   c10::cuda::CUDAGuard guard(device.index());
-
   at::DataPtr data = allocator->allocate(size_bytes);
-
   if (storage->data_ptr()) {
     at::globalContext().lazyInitDevice(c10::DeviceType::CUDA);
 

--- a/aten/src/ATen/native/cuda/Resize.h
+++ b/aten/src/ATen/native/cuda/Resize.h
@@ -7,7 +7,7 @@
 
 namespace at::native {
 
-TORCH_CUDA_CPP_API void resize_bytes_cuda(StorageImpl* storage, size_t size_bytes);
+TORCH_CUDA_CPP_API void resize_bytes_cuda(StorageImpl* storage, size_t size_bytes, void* hint = nullptr);
 
 static inline void maybe_resize_storage_cuda(TensorImpl* self, size_t new_size_bytes) {
   // It does not make sense to try to resize a storage

--- a/aten/src/ATen/native/cuda/Resize.h
+++ b/aten/src/ATen/native/cuda/Resize.h
@@ -8,6 +8,10 @@
 namespace at::native {
 
 TORCH_CUDA_CPP_API void resize_bytes_cuda(StorageImpl* storage, size_t size_bytes);
+TORCH_CUDA_CPP_API void resize_bytes_cuda_with_addr(
+    StorageImpl* storage,
+    size_t size_bytes,
+    void* addr);
 
 static inline void maybe_resize_storage_cuda(TensorImpl* self, size_t new_size_bytes) {
   // It does not make sense to try to resize a storage

--- a/aten/src/ATen/native/cuda/Resize.h
+++ b/aten/src/ATen/native/cuda/Resize.h
@@ -7,7 +7,7 @@
 
 namespace at::native {
 
-TORCH_CUDA_CPP_API void resize_bytes_cuda(StorageImpl* storage, size_t size_bytes, void* hint = nullptr);
+TORCH_CUDA_CPP_API void resize_bytes_cuda(StorageImpl* storage, size_t size_bytes);
 
 static inline void maybe_resize_storage_cuda(TensorImpl* self, size_t new_size_bytes) {
   // It does not make sense to try to resize a storage

--- a/c10/core/StorageImpl.h
+++ b/c10/core/StorageImpl.h
@@ -255,6 +255,21 @@ struct C10_API StorageImpl : public c10::intrusive_ptr_target {
     resizable_ = resizable;
   }
 
+  void* preferred_data_ptr() const {
+    return preferred_data_ptr_;
+  }
+  size_t preferred_data_ptr_size() const {
+    return preferred_data_ptr_size_;
+  }
+  void set_preferred_data_ptr(void* ptr, size_t size) {
+    preferred_data_ptr_ = ptr;
+    preferred_data_ptr_size_ = size;
+  }
+  void clear_preferred_data_ptr() {
+    preferred_data_ptr_ = nullptr;
+    preferred_data_ptr_size_ = 0;
+  }
+
   /**
    * Can only be called when use_count is 1
    */
@@ -395,6 +410,8 @@ struct C10_API StorageImpl : public c10::intrusive_ptr_target {
   // Pluggable materialization hook. See MaterializeFn in StorageMaterializer.h.
   MaterializeFn materialize_fn_ = nullptr;
   Allocator* allocator_;
+  void* preferred_data_ptr_ = nullptr;
+  size_t preferred_data_ptr_size_ = 0;
   impl::PyObjectSlot pyobj_slot_;
   std::unique_ptr<StorageExtraMeta> extra_meta_ = nullptr;
 };

--- a/c10/core/StorageImpl.h
+++ b/c10/core/StorageImpl.h
@@ -255,21 +255,6 @@ struct C10_API StorageImpl : public c10::intrusive_ptr_target {
     resizable_ = resizable;
   }
 
-  void* preferred_data_ptr() const {
-    return preferred_data_ptr_;
-  }
-  size_t preferred_data_ptr_size() const {
-    return preferred_data_ptr_size_;
-  }
-  void set_preferred_data_ptr(void* ptr, size_t size) {
-    preferred_data_ptr_ = ptr;
-    preferred_data_ptr_size_ = size;
-  }
-  void clear_preferred_data_ptr() {
-    preferred_data_ptr_ = nullptr;
-    preferred_data_ptr_size_ = 0;
-  }
-
   /**
    * Can only be called when use_count is 1
    */
@@ -410,8 +395,6 @@ struct C10_API StorageImpl : public c10::intrusive_ptr_target {
   // Pluggable materialization hook. See MaterializeFn in StorageMaterializer.h.
   MaterializeFn materialize_fn_ = nullptr;
   Allocator* allocator_;
-  void* preferred_data_ptr_ = nullptr;
-  size_t preferred_data_ptr_size_ = 0;
   impl::PyObjectSlot pyobj_slot_;
   std::unique_ptr<StorageExtraMeta> extra_meta_ = nullptr;
 };

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -1966,6 +1966,10 @@ class DeviceCachingAllocator {
     prepare_for_malloc(context, stream);
 
     const size_t size = round_size(orig_size);
+
+    // The same block pool is used for both prefix block and requested block.
+    // Prefix block may have a significantly larger size than requested block
+    // when multiple small blocks coalesced into a large prefix block.
     auto& pool = get_pool(size, stream);
     Block* containing_block =
         get_free_block_containing_address(pool, size, stream, addr);
@@ -1981,6 +1985,19 @@ class DeviceCachingAllocator {
     const auto block_begin = reinterpret_cast<uintptr_t>(containing_block->ptr);
     const auto requested_addr = reinterpret_cast<uintptr_t>(addr);
     const size_t prefix_size = requested_addr - block_begin;
+
+    // mallocWithAddress may allocates both prefix block and requested block,
+    // and free prefix block later. This adds a fake malloc/free pair for prefix
+    // block. A metadata is added for better memory visualization.
+    const auto original_user_metadata = getUserMetadata();
+    const auto malloc_with_address_metadata = original_user_metadata.empty()
+        ? std::string("mallocWithAddress")
+        : original_user_metadata + "\nmallocWithAddress";
+    setUserMetadata(malloc_with_address_metadata);
+    auto restore_user_metadata =
+        c10::make_scope_exit([this, original_user_metadata]() {
+          setUserMetadata(original_user_metadata);
+        });
 
     Block* prefix_block = nullptr;
     Block* requested_source = containing_block;

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -171,24 +171,30 @@ static bool BlockComparatorSizeCounterAddress(const Block* a, const Block* b);
 static bool BlockComparatorAddress(const Block* a, const Block* b);
 
 struct BlockPool {
+  using BlockSet = std::set<Block*, Comparison>;
+  using iterator = BlockSet::iterator;
+
   BlockPool(bool small, PrivatePool* private_pool = nullptr)
       : blocks(BlockComparatorSizeCounterAddress),
+        blocks_by_addr(BlockComparatorAddress),
         unmapped(BlockComparatorAddress),
         is_small(small),
         owner_PrivatePool(private_pool) {}
 
-  // Do not insert a Block to blocks directly; use insert_into_blocks(),
-  // instead.
-  std::set<Block*, Comparison> blocks;
-  std::set<Block*, Comparison> unmapped;
+  // Do not insert a Block into blocks or blocks_by_addr directly; use
+  // insert_into_blocks() instead.
+  BlockSet blocks;
+  BlockSet blocks_by_addr;
+  BlockSet unmapped;
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
   const bool is_small;
   PrivatePool* owner_PrivatePool;
   int64_t get_free_blocks_call_count{0};
 
-  // Add a Block into blocks set with updating gc counter.
-  std::pair<std::set<Block*, Comparison>::iterator, bool> insert_into_blocks(
-      Block* block);
+  // Add a Block into the cached free block indices with updating gc counter.
+  std::pair<iterator, bool> insert_into_blocks(Block* block);
+  void erase_from_blocks(Block* block);
+  void erase_from_blocks(iterator it);
 
   MempoolId_t owner_MempoolId() const;
 };
@@ -265,10 +271,26 @@ struct Block {
   }
 };
 
-std::pair<std::set<Block*, Comparison>::iterator, bool> BlockPool::
-    insert_into_blocks(Block* block) {
+std::pair<BlockPool::iterator, bool> BlockPool::insert_into_blocks(
+    Block* block) {
   block->gc_count_base = get_free_blocks_call_count;
-  return blocks.insert(block);
+  auto inserted = blocks.insert(block);
+  auto inserted_by_addr = blocks_by_addr.insert(block);
+  TORCH_INTERNAL_ASSERT(inserted.second == inserted_by_addr.second);
+  return inserted;
+}
+
+void BlockPool::erase_from_blocks(Block* block) {
+  auto erased = blocks.erase(block);
+  auto erased_by_addr = blocks_by_addr.erase(block);
+  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(erased == erased_by_addr);
+}
+
+void BlockPool::erase_from_blocks(iterator it) {
+  Block* block = *it;
+  blocks.erase(it);
+  auto erased_by_addr = blocks_by_addr.erase(block);
+  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(erased_by_addr == 1);
 }
 
 struct SegmentRange {
@@ -1648,7 +1670,7 @@ class DeviceCachingAllocator {
   // All public methods (except the above) acquire the allocator mutex.
   // Thus, do not call a public method from another public method.
 
-  Block* malloc(size_t orig_size, cudaStream_t stream, void* hint = nullptr) {
+  Block* malloc(size_t orig_size, cudaStream_t stream) {
     // done outside the lock because we don't know what locks the recorder needs
     // to have...
     auto context = maybeGatherContext(RecordContext::STATE);
@@ -1694,9 +1716,9 @@ class DeviceCachingAllocator {
     params.stat_types = get_stat_types_for_pool(pool);
 
     // First, try to get a block from the existing pool.
-    bool block_found = (hint && get_free_block_by_hint(hint, params))
+    bool block_found =
         // Search pool
-        || get_free_block(params)
+        get_free_block(params)
         // Trigger callbacks and retry search
         || (trigger_free_memory_callbacks(params) && get_free_block(params));
 
@@ -1905,6 +1927,46 @@ class DeviceCachingAllocator {
         params.block, params.size(), params.is_expandable_segments_active);
     return alloc_found_block(
         params, orig_size, std::move(context), split_remainder);
+  }
+
+  Block* mallocWithAddress(size_t orig_size, cudaStream_t stream, void* addr) {
+    auto context = maybeGatherContext(RecordContext::STATE);
+    auto free_context = maybeGatherContext(RecordContext::ALL);
+
+    std::unique_lock<std::recursive_mutex> lock(mutex);
+
+    if (C10_LIKELY(captures_underway.empty())) {
+      process_events(context);
+    } else if (CUDAAllocatorConfig::graph_capture_record_stream_reuse()) {
+      free_safe_blocks_in_capture(context, stream);
+    }
+
+    size_t size = round_size(orig_size);
+    auto& pool = get_pool(size, stream);
+    const size_t alloc_size = get_allocation_size(size);
+    bool active_user_pool =
+        pool.owner_PrivatePool && pool.owner_PrivatePool->allocator();
+    bool is_expandable_segments_active =
+        CUDAAllocatorConfig::expandable_segments() && !active_user_pool;
+    AllocParams params(
+        device_id,
+        size,
+        stream,
+        &pool,
+        alloc_size,
+        is_expandable_segments_active);
+    params.stat_types = get_stat_types_for_pool(pool);
+
+    Block* block = alloc_block_at_address(
+        addr, params, orig_size, context, free_context);
+    TORCH_CHECK(
+        block != nullptr,
+        "Could not allocate CUDA storage at exact address ",
+        addr,
+        " with size ",
+        orig_size,
+        " bytes");
+    return block;
   }
 
   bool try_mempool_fallback(
@@ -2268,15 +2330,11 @@ class DeviceCachingAllocator {
     }
   }
 
-  void free(Block* block) {
-    std::shared_ptr<GatheredContext> context =
-        maybeGatherContext(RecordContext::ALL);
-    std::lock_guard<std::recursive_mutex> lock(mutex);
-
+  void free_allocated_block(
+      Block* block,
+      const std::shared_ptr<GatheredContext>& context) {
     block->allocated = false;
 
-    // following logic might modifying underlying Block, causing the size
-    // changed. We store ahead for reporting
     auto orig_block_ptr = block->ptr;
     auto orig_block_size = block->size;
 
@@ -2300,10 +2358,26 @@ class DeviceCachingAllocator {
         block->pool->owner_MempoolId(),
         context ? context : block->context_when_allocated);
 
-    if (block->size >= AcceleratorAllocatorConfig::max_split_size())
+    if (block->size >= AcceleratorAllocatorConfig::max_split_size()) {
       stats.oversize_allocations.decrease(1);
+    }
 
-    // If the block has been used on more than one stream, handle accordingly.
+    TORCH_INTERNAL_ASSERT(block->stream_uses.empty());
+    free_block(block, context);
+
+    c10::reportMemoryUsageToProfiler(
+        orig_block_ptr,
+        -static_cast<int64_t>(orig_block_size),
+        stats.allocated_bytes[static_cast<size_t>(StatType::AGGREGATE)].current,
+        stats.reserved_bytes[static_cast<size_t>(StatType::AGGREGATE)].current,
+        c10::Device(c10::DeviceType::CUDA, block->device));
+  }
+
+  void free(Block* block) {
+    std::shared_ptr<GatheredContext> context =
+        maybeGatherContext(RecordContext::ALL);
+    std::lock_guard<std::recursive_mutex> lock(mutex);
+
     if (!block->stream_uses.empty()) {
       if (C10_UNLIKELY(is_capture_context())) {
         if (CUDAAllocatorConfig::graph_capture_record_stream_reuse()) {
@@ -2321,16 +2395,18 @@ class DeviceCachingAllocator {
         // If not in a capture, insert events for the block.
         insert_events(block);
       }
-    } else {
-      free_block(block, context);
-    }
 
-    c10::reportMemoryUsageToProfiler(
-        orig_block_ptr,
-        -static_cast<int64_t>(orig_block_size),
-        stats.allocated_bytes[static_cast<size_t>(StatType::AGGREGATE)].current,
-        stats.reserved_bytes[static_cast<size_t>(StatType::AGGREGATE)].current,
-        c10::Device(c10::DeviceType::CUDA, block->device));
+      c10::reportMemoryUsageToProfiler(
+          orig_block_ptr,
+          -static_cast<int64_t>(orig_block_size),
+          stats.allocated_bytes[static_cast<size_t>(StatType::AGGREGATE)]
+              .current,
+          stats.reserved_bytes[static_cast<size_t>(StatType::AGGREGATE)]
+              .current,
+          c10::Device(c10::DeviceType::CUDA, block->device));
+    } else {
+      free_allocated_block(block, context);
+    }
   }
 
   void* getBaseAllocation(Block* block, size_t* outSize) {
@@ -2625,7 +2701,7 @@ class DeviceCachingAllocator {
           &pool,
           block_state.size,
           curr_block->expandable_segment_ != nullptr);
-      pool.blocks.erase(curr_block);
+      pool.erase_from_blocks(curr_block);
       params.block = curr_block;
       params.stat_types = get_stat_types_for_pool(pool);
 
@@ -3352,7 +3428,7 @@ class DeviceCachingAllocator {
       }
       candidate = new_candidate;
     }
-    pool->blocks.erase(candidate);
+    pool->erase_from_blocks(candidate);
     return candidate;
   }
 
@@ -3461,7 +3537,8 @@ class DeviceCachingAllocator {
     dst->size += subsumed_size;
     // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
     auto erased =
-        src->mapped ? pool.blocks.erase(src) : pool.unmapped.erase(src);
+        src->mapped ? (pool.erase_from_blocks(src), size_t{1})
+                    : pool.unmapped.erase(src);
     TORCH_INTERNAL_ASSERT_DEBUG_ONLY(erased == 1);
     delete src;
 
@@ -3618,55 +3695,69 @@ class DeviceCachingAllocator {
          p.size() + AcceleratorAllocatorConfig::max_non_split_rounding_size()))
       return false;
     p.block = *it;
-    pool.blocks.erase(it);
+    pool.erase_from_blocks(it);
     return true;
   }
 
-  bool get_free_block_by_hint(void* hint, AllocParams& params) {
-    // Get a free block starting at hint address. If hint is at the middle of a
-    // block, split the block at hint and return the second part.
+  Block* alloc_block_at_address(
+      void* addr,
+      const AllocParams& params,
+      size_t orig_size,
+      const std::shared_ptr<GatheredContext>& context,
+      const std::shared_ptr<GatheredContext>& free_context) {
     BlockPool& pool = *params.pool;
     Block search_key(params.device(), params.stream(), 0);
-    auto it = pool.blocks.lower_bound(&search_key);
-    for (; it != pool.blocks.end() && (*it)->stream == params.stream(); ++it) {
-      Block* block = *it;
-      char* block_start = static_cast<char*>(block->ptr);
-      char* hint_ptr = static_cast<char*>(hint);
-      if (hint_ptr < block_start ||
-          hint_ptr + params.size() > block_start + block->size) {
-        continue;
-      }
-      size_t prefix_size = hint_ptr - block_start;
-      if (prefix_size > 0 &&
-          !should_split(
-              block,
-              block->size - prefix_size,
-              params.is_expandable_segments_active)) {
-        continue;
-      }
-      pool.blocks.erase(it);
-      if (prefix_size > 0) {
-        Block* prefix = new Block(
-            params.device(),
-            params.stream(),
-            prefix_size,
-            block->pool,
-            block->ptr);
-        prefix->expandable_segment_ = block->expandable_segment_;
-        prefix->prev = block->prev;
-        if (prefix->prev) {
-          prefix->prev->next = prefix;
-        }
-        prefix->next = block;
-        block->prev = prefix;
-        block->ptr = hint_ptr;
-        block->size -= prefix_size;
-        pool.insert_into_blocks(prefix);
-      }
-      params.block = block;
-      return true;
+    search_key.ptr = addr;
+    auto it = pool.blocks_by_addr.upper_bound(&search_key);
+    if (it == pool.blocks_by_addr.begin()) {
+      return nullptr;
     }
-    return false;
+    --it;
+
+    Block* block = *it;
+    auto requested_addr = reinterpret_cast<uintptr_t>(addr);
+    auto block_start = reinterpret_cast<uintptr_t>(block->ptr);
+    if (block->stream != params.stream() || requested_addr < block_start) {
+      return nullptr;
+    }
+
+    size_t prefix_size = requested_addr - block_start;
+    if (prefix_size > block->size ||
+        params.size() > block->size - prefix_size) {
+      return nullptr;
+    }
+
+    pool.erase_from_blocks(block);
+
+    if (prefix_size == 0) {
+      AllocParams target_params = params;
+      target_params.block = block;
+      return alloc_found_block(
+          target_params, orig_size, context, block->size > params.size());
+    }
+
+    AllocParams prefix_params(
+        params.device(),
+        prefix_size,
+        params.stream(),
+        &pool,
+        prefix_size,
+        params.is_expandable_segments_active);
+    prefix_params.block = block;
+    prefix_params.stat_types = params.stat_types;
+
+    Block* prefix = alloc_found_block(
+        prefix_params, prefix_size, context, block->size > prefix_size);
+    Block* target = prefix->next;
+    TORCH_INTERNAL_ASSERT(target != nullptr);
+    TORCH_INTERNAL_ASSERT(target->ptr == addr);
+
+    AllocParams target_params = params;
+    target_params.block = target;
+    Block* allocated = alloc_found_block(
+        target_params, orig_size, context, target->size > params.size());
+    free_allocated_block(prefix, free_context ? free_context : context);
+    return allocated;
   }
 
   bool trigger_free_memory_callbacks(AllocParams& p) {
@@ -4068,7 +4159,7 @@ class DeviceCachingAllocator {
 
     if (block->size >= AcceleratorAllocatorConfig::max_split_size())
       stats.oversize_segments.decrease(1);
-    pool->blocks.erase(block);
+    pool->erase_from_blocks(block);
     delete block;
   }
 
@@ -4080,7 +4171,7 @@ class DeviceCachingAllocator {
     if (unmapped.size == 0) {
       return;
     }
-    block->pool->blocks.erase(block);
+    block->pool->erase_from_blocks(block);
 
     ptrdiff_t before_size = unmapped.ptr - static_cast<char*>(block->ptr);
     if (before_size > 0) {
@@ -4525,18 +4616,19 @@ class NativeCachingAllocator : public CUDAAllocator {
     }
   }
 
-  void mallocWithHint(
+  void mallocWithAddress(
       void** devPtr,
       c10::DeviceIndex device,
       size_t size,
       cudaStream_t stream,
-      void* hint) {
+      void* addr) {
     TORCH_INTERNAL_ASSERT(
         0 <= device && static_cast<size_t>(device) < device_allocator.size(),
         "Allocator not initialized for device ",
         device,
         ": did you call init?");
-    Block* block = device_allocator[device]->malloc(size, stream, hint);
+    Block* block = device_allocator[device]->mallocWithAddress(
+        size, stream, addr);
     add_allocated_block(block);
     *devPtr = block->ptr;
     const c10::impl::PyInterpreter* interp = c10::impl::GPUTrace::get_trace();
@@ -4876,7 +4968,7 @@ class NativeCachingAllocator : public CUDAAllocator {
 
     return {devPtr, devPtr, deleteFunc, Device(DeviceType::CUDA, device)};
   }
-  DataPtr allocateWithHint(size_t size, void* hint) override {
+  DataPtr allocateWithAddress(size_t size, void* addr) {
     constexpr size_t one_exa_bytes = 1152921504606846976ULL;
     TORCH_CHECK_WITH(
         OutOfMemoryError,
@@ -4888,11 +4980,11 @@ class NativeCachingAllocator : public CUDAAllocator {
     void (*deleteFunc)(void*) = &local_raw_delete;
     CUDAStream stream = cuda::getCurrentCUDAStream(device);
 
-    if (forceUncachedAllocator() || !isEnabled()) {
-      return allocate(size);
-    }
+    TORCH_CHECK(
+        !forceUncachedAllocator() && isEnabled(),
+        "Exact-address allocation requires the native CUDA caching allocator");
     if (size != 0) {
-      this->mallocWithHint(&devPtr, device, size, stream, hint);
+      this->mallocWithAddress(&devPtr, device, size, stream, addr);
     }
 
     if (size && TORCH_SDT_IS_ENABLED(malloc)) {
@@ -5286,5 +5378,13 @@ struct BackendStaticInitializer {
 
 std::atomic<CUDAAllocator*> allocator;
 static BackendStaticInitializer backend_static_initializer;
+
+DataPtr allocateWithAddress(size_t size, void* addr) {
+  auto* current = get();
+  TORCH_CHECK(
+      current == &Native::allocator,
+      "Exact-address allocation requires the native CUDA caching allocator");
+  return Native::allocator.allocateWithAddress(size, addr);
+}
 } // namespace cuda::CUDACachingAllocator
 } // namespace c10

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -1648,7 +1648,10 @@ class DeviceCachingAllocator {
   // All public methods (except the above) acquire the allocator mutex.
   // Thus, do not call a public method from another public method.
 
-  Block* malloc(size_t orig_size, cudaStream_t stream) {
+  Block* malloc(
+      size_t orig_size,
+      cudaStream_t stream,
+      void* hint = nullptr) {
     // done outside the lock because we don't know what locks the recorder needs
     // to have...
     auto context = maybeGatherContext(RecordContext::STATE);
@@ -1694,9 +1697,9 @@ class DeviceCachingAllocator {
     params.stat_types = get_stat_types_for_pool(pool);
 
     // First, try to get a block from the existing pool.
-    bool block_found =
+    bool block_found = (hint && get_free_block_by_hint(hint, params))
         // Search pool
-        get_free_block(params)
+        || get_free_block(params)
         // Trigger callbacks and retry search
         || (trigger_free_memory_callbacks(params) && get_free_block(params));
 
@@ -3622,6 +3625,20 @@ class DeviceCachingAllocator {
     return true;
   }
 
+  bool get_free_block_by_hint(void* hint, AllocParams& params) {
+    BlockPool& pool = *params.pool;
+    Block search_key(params.device(), params.stream(), 0);
+    auto it = pool.blocks.lower_bound(&search_key);
+    for (; it != pool.blocks.end() && (*it)->stream == params.stream(); ++it) {
+      if ((*it)->ptr == hint && (*it)->size >= params.size()) {
+        params.block = *it;
+        pool.blocks.erase(it);
+        return true;
+      }
+    }
+    return false;
+  }
+
   bool trigger_free_memory_callbacks(AllocParams& p) {
     bool freed_memory = false;
     for (const auto& name : FreeCudaMemoryCallbacksRegistry()->Keys()) {
@@ -4478,6 +4495,27 @@ class NativeCachingAllocator : public CUDAAllocator {
     }
   }
 
+  void mallocWithHint(
+      void** devPtr,
+      c10::DeviceIndex device,
+      size_t size,
+      cudaStream_t stream,
+      void* hint) {
+    TORCH_INTERNAL_ASSERT(
+        0 <= device && static_cast<size_t>(device) < device_allocator.size(),
+        "Allocator not initialized for device ",
+        device,
+        ": did you call init?");
+    Block* block = device_allocator[device]->malloc(size, stream, hint);
+    add_allocated_block(block);
+    *devPtr = block->ptr;
+    const c10::impl::PyInterpreter* interp = c10::impl::GPUTrace::get_trace();
+    if (C10_UNLIKELY(interp)) {
+      (*interp)->trace_gpu_memory_allocation(
+          c10::kCUDA, reinterpret_cast<uintptr_t>(*devPtr));
+    }
+  }
+
   void free(void* ptr) {
     if (!ptr) {
       return;
@@ -4800,6 +4838,31 @@ class NativeCachingAllocator : public CUDAAllocator {
       if (size != 0) {
         this->malloc(&devPtr, device, size, stream);
       }
+    }
+
+    if (size && TORCH_SDT_IS_ENABLED(malloc)) {
+      TORCH_SDT_WITH_SEMAPHORE(malloc, devPtr, device, size, stream.id());
+    }
+
+    return {devPtr, devPtr, deleteFunc, Device(DeviceType::CUDA, device)};
+  }
+  DataPtr allocateWithHint(size_t size, void* hint) override {
+    constexpr size_t one_exa_bytes = 1152921504606846976ULL;
+    TORCH_CHECK_WITH(
+        OutOfMemoryError,
+        size < one_exa_bytes,
+        "CUDA out of memory. Tried to allocate more than 1EB memory.");
+    c10::DeviceIndex device = 0;
+    C10_CUDA_CHECK(c10::cuda::GetDevice(&device));
+    void* devPtr = nullptr;
+    void (*deleteFunc)(void*) = &local_raw_delete;
+    CUDAStream stream = cuda::getCurrentCUDAStream(device);
+
+    if (forceUncachedAllocator() || !isEnabled()) {
+      return allocate(size);
+    }
+    if (size != 0) {
+      this->mallocWithHint(&devPtr, device, size, stream, hint);
     }
 
     if (size && TORCH_SDT_IS_ENABLED(malloc)) {

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -1744,7 +1744,7 @@ class DeviceCachingAllocator {
         is_expandable_segments_active);
     params.stat_types = get_stat_types_for_pool(pool);
 
-    // try to get a block from the existing pool.
+    // First, try to get a block from the existing pool.
     bool block_found =
         // Search pool
         get_free_block(params)
@@ -2001,7 +2001,6 @@ class DeviceCachingAllocator {
           context,
           true /* always split for prefix */);
       requested_source = prefix_block->next;
-      TORCH_INTERNAL_ASSERT(requested_source != nullptr);
     }
 
     pool.erase_from_blocks(requested_source);

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -1686,6 +1686,7 @@ class DeviceCachingAllocator {
     if ((offset > block->size) || (size > block->size - offset)) {
       return nullptr;
     }
+    pool.erase_from_blocks(block);
     return block;
   }
 
@@ -2018,16 +2019,17 @@ class DeviceCachingAllocator {
           is_expandable_segments_active);
       prefix_params.stat_types = stat_types;
       prefix_params.block = containing_block;
-      pool.erase_from_blocks(containing_block);
       prefix_block = alloc_found_block(
           prefix_params,
           prefix_size,
           context,
           true /* always split for prefix */);
       requested_source = prefix_block->next;
+      // alloc_found_block re-inserts the split remainder into the pool. We have
+      // to manually erase the requested_source.
+      pool.erase_from_blocks(requested_source);
     }
 
-    pool.erase_from_blocks(requested_source);
     AllocParams requested_params(
         device_id,
         size,

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -1648,10 +1648,7 @@ class DeviceCachingAllocator {
   // All public methods (except the above) acquire the allocator mutex.
   // Thus, do not call a public method from another public method.
 
-  Block* malloc(
-      size_t orig_size,
-      cudaStream_t stream,
-      void* hint = nullptr) {
+  Block* malloc(size_t orig_size, cudaStream_t stream, void* hint = nullptr) {
     // done outside the lock because we don't know what locks the recorder needs
     // to have...
     auto context = maybeGatherContext(RecordContext::STATE);
@@ -3626,15 +3623,48 @@ class DeviceCachingAllocator {
   }
 
   bool get_free_block_by_hint(void* hint, AllocParams& params) {
+    // Get a free block starting at hint address. If hint is at the middle of a block,
+    // split the block at hint and return the second part.
     BlockPool& pool = *params.pool;
     Block search_key(params.device(), params.stream(), 0);
     auto it = pool.blocks.lower_bound(&search_key);
     for (; it != pool.blocks.end() && (*it)->stream == params.stream(); ++it) {
-      if ((*it)->ptr == hint && (*it)->size >= params.size()) {
-        params.block = *it;
-        pool.blocks.erase(it);
-        return true;
+      Block* block = *it;
+      char* block_start = static_cast<char*>(block->ptr);
+      char* hint_ptr = static_cast<char*>(hint);
+      if (hint_ptr < block_start ||
+          hint_ptr + params.size() > block_start + block->size) {
+        continue;
       }
+      size_t prefix_size = hint_ptr - block_start;
+      if (prefix_size > 0 &&
+          !should_split(
+              block,
+              block->size - prefix_size,
+              params.is_expandable_segments_active)) {
+        continue;
+      }
+      pool.blocks.erase(it);
+      if (prefix_size > 0) {
+        Block* prefix = new Block(
+            params.device(),
+            params.stream(),
+            prefix_size,
+            block->pool,
+            block->ptr);
+        prefix->expandable_segment_ = block->expandable_segment_;
+        prefix->prev = block->prev;
+        if (prefix->prev) {
+          prefix->prev->next = prefix;
+        }
+        prefix->next = block;
+        block->prev = prefix;
+        block->ptr = hint_ptr;
+        block->size -= prefix_size;
+        pool.insert_into_blocks(prefix);
+      }
+      params.block = block;
+      return true;
     }
     return false;
   }

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -1976,10 +1976,23 @@ class DeviceCachingAllocator {
   Block* mallocWithAddress(size_t orig_size, cudaStream_t stream, void* addr) {
     auto context = maybeGatherContext(RecordContext::STATE);
     std::unique_lock<std::recursive_mutex> lock(mutex);
-    if (C10_LIKELY(captures_underway.empty())) {
+    if (C10_LIKELY(num_active_captures_ == 0)) {
+      // Processes end-of-life events for outstanding allocations used on
+      // multiple streams (checks if their GPU-side uses are complete and
+      // recycles their memory if so)
+      //
+      // Q. Why skip process_events if a capture might be underway?
+      // A. process_events involves cudaEventQueries, illegal during CUDA graph
+      //    capture.
+      //    Dumb simple solution: defer reclaiming these allocations until after
+      //    capture. Cross-stream memory use is uncommon, so the deferral's
+      //    effect on memory use during capture should be small.
       process_events(context);
-    } else if (CUDAAllocatorConfig::graph_capture_record_stream_reuse()) {
-      free_safe_blocks_in_capture(context, stream);
+    } else {
+      if (CUDAAllocatorConfig::graph_capture_record_stream_reuse()) {
+        // We check if there is some block that is safe to reuse on this stream
+        free_safe_blocks_in_capture(context, stream);
+      }
     }
 
     const size_t size = round_size(orig_size);

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -1658,23 +1658,6 @@ class DeviceCachingAllocator {
     return context_recorder_.load()();
   }
 
-  Block* get_free_block_by_exact_address(
-      BlockPool& pool,
-      size_t size,
-      cudaStream_t stream,
-      void* addr) {
-    Block search_key(device_id, stream, 0);
-    search_key.ptr = addr;
-    auto it = pool.blocks_by_addr.lower_bound(&search_key);
-    if (it != pool.blocks_by_addr.end() && (*it)->stream == stream &&
-        (*it)->ptr == addr && (*it)->size >= size) {
-      Block* block = *it;
-      pool.erase_from_blocks(block);
-      return block;
-    }
-    return nullptr;
-  }
-
   Block* get_free_block_containing_address(
       BlockPool& pool,
       size_t size,
@@ -1693,23 +1676,22 @@ class DeviceCachingAllocator {
     }
     Block* block = *it;
     const auto block_begin = reinterpret_cast<uintptr_t>(block->ptr);
-    const auto block_end = block_begin + block->size;
-    if (block_begin <= requested_addr && requested_addr + size <= block_end) {
-      return block;
+    // check block_begin <= requested_addr < requested_addr + size <=
+    // block_begin + block->size
+    if (requested_addr < block_begin) {
+      return nullptr;
     }
-    return nullptr;
+    // use offset to avoid overflow or underflow
+    const auto offset = requested_addr - block_begin;
+    if ((offset > block->size) || (size > block->size - offset)) {
+      return nullptr;
+    }
+    return block;
   }
 
-  // All public methods (except the above) acquire the allocator mutex.
-  // Thus, do not call a public method from another public method.
-
-  Block* malloc(size_t orig_size, cudaStream_t stream, void* addr = nullptr) {
-    // done outside the lock because we don't know what locks the recorder needs
-    // to have...
-    auto context = maybeGatherContext(RecordContext::STATE);
-
-    std::unique_lock<std::recursive_mutex> lock(mutex);
-
+  void prepare_for_malloc(
+      const std::shared_ptr<GatheredContext>& context,
+      cudaStream_t stream) {
     if (C10_LIKELY(!is_capture_context())) {
       // Processes end-of-life events for outstanding allocations used on
       // multiple streams (checks if their GPU-side uses are complete and
@@ -1731,6 +1713,20 @@ class DeviceCachingAllocator {
         free_safe_blocks_in_capture(context, stream);
       }
     }
+  }
+
+  // All public methods (except the above) acquire the allocator mutex.
+  // Thus, do not call a public method from another public method.
+
+  Block* malloc(size_t orig_size, cudaStream_t stream) {
+    // done outside the lock because we don't know what locks the recorder needs
+    // to have...
+    auto context = maybeGatherContext(RecordContext::STATE);
+
+    std::unique_lock<std::recursive_mutex> lock(mutex);
+
+    prepare_for_malloc(context, stream);
+
     size_t size = round_size(orig_size);
     auto& pool = get_pool(size, stream);
     const size_t alloc_size = get_allocation_size(size);
@@ -1748,23 +1744,12 @@ class DeviceCachingAllocator {
         is_expandable_segments_active);
     params.stat_types = get_stat_types_for_pool(pool);
 
-    // First, try to get a block from the existing pool.
-    bool block_found = false;
-    if (addr != nullptr) {
-      // Exact-address mode must either reuse this address or fail. Do not
-      // silently fall back to a different cached block.
-      params.block = get_free_block_by_exact_address(pool, size, stream, addr);
-      if (!params.block) {
-        return nullptr;
-      }
-      block_found = true;
-    } else {
-      block_found =
-          // Search pool
-          get_free_block(params)
-          // Trigger callbacks and retry search
-          || (trigger_free_memory_callbacks(params) && get_free_block(params));
-    }
+    // try to get a block from the existing pool.
+    bool block_found =
+        // Search pool
+        get_free_block(params)
+        // Trigger callbacks and retry search
+        || (trigger_free_memory_callbacks(params) && get_free_block(params));
 
     // Can't reuse an existing block; try to get a new one.
     if (!block_found) {
@@ -1974,26 +1959,11 @@ class DeviceCachingAllocator {
   }
 
   Block* mallocWithAddress(size_t orig_size, cudaStream_t stream, void* addr) {
+    // done outside the lock because we don't know what locks the recorder needs
+    // to have.
     auto context = maybeGatherContext(RecordContext::STATE);
     std::unique_lock<std::recursive_mutex> lock(mutex);
-    if (C10_LIKELY(num_active_captures_ == 0)) {
-      // Processes end-of-life events for outstanding allocations used on
-      // multiple streams (checks if their GPU-side uses are complete and
-      // recycles their memory if so)
-      //
-      // Q. Why skip process_events if a capture might be underway?
-      // A. process_events involves cudaEventQueries, illegal during CUDA graph
-      //    capture.
-      //    Dumb simple solution: defer reclaiming these allocations until after
-      //    capture. Cross-stream memory use is uncommon, so the deferral's
-      //    effect on memory use during capture should be small.
-      process_events(context);
-    } else {
-      if (CUDAAllocatorConfig::graph_capture_record_stream_reuse()) {
-        // We check if there is some block that is safe to reuse on this stream
-        free_safe_blocks_in_capture(context, stream);
-      }
-    }
+    prepare_for_malloc(context, stream);
 
     const size_t size = round_size(orig_size);
     auto& pool = get_pool(size, stream);
@@ -2003,30 +1973,54 @@ class DeviceCachingAllocator {
       return nullptr;
     }
 
+    const bool active_user_pool =
+        pool.owner_PrivatePool && pool.owner_PrivatePool->allocator();
+    const bool is_expandable_segments_active =
+        CUDAAllocatorConfig::expandable_segments() && !active_user_pool;
+    const auto stat_types = get_stat_types_for_pool(pool);
     const auto block_begin = reinterpret_cast<uintptr_t>(containing_block->ptr);
     const auto requested_addr = reinterpret_cast<uintptr_t>(addr);
     const size_t prefix_size = requested_addr - block_begin;
 
     Block* prefix_block = nullptr;
+    Block* requested_source = containing_block;
     if (prefix_size > 0) {
-      prefix_block = malloc(prefix_size, stream, containing_block->ptr);
-      if (!prefix_block) {
-        return nullptr;
-      }
+      AllocParams prefix_params(
+          device_id,
+          prefix_size,
+          stream,
+          &pool,
+          get_allocation_size(prefix_size),
+          is_expandable_segments_active);
+      prefix_params.stat_types = stat_types;
+      prefix_params.block = containing_block;
+      pool.erase_from_blocks(containing_block);
+      prefix_block = alloc_found_block(
+          prefix_params,
+          prefix_size,
+          context,
+          true /* always split for prefix */);
+      requested_source = prefix_block->next;
+      TORCH_INTERNAL_ASSERT(requested_source != nullptr);
     }
 
-    Block* requested_block = malloc(orig_size, stream, addr);
-    if (!requested_block) {
-      if (prefix_block) {
-        free(prefix_block);
-      }
-      return nullptr;
-    }
-
+    pool.erase_from_blocks(requested_source);
+    AllocParams requested_params(
+        device_id,
+        size,
+        stream,
+        &pool,
+        get_allocation_size(size),
+        is_expandable_segments_active);
+    requested_params.stat_types = stat_types;
+    requested_params.block = requested_source;
+    bool split_remainder =
+        should_split(requested_source, size, is_expandable_segments_active);
+    Block* requested_block = alloc_found_block(
+        requested_params, orig_size, std::move(context), split_remainder);
     if (prefix_block) {
-      free(prefix_block);
+      free_locked(prefix_block, nullptr);
     }
-    TORCH_INTERNAL_ASSERT(requested_block->ptr == addr);
     return requested_block;
   }
 
@@ -2391,11 +2385,7 @@ class DeviceCachingAllocator {
     }
   }
 
-  void free(Block* block) {
-    std::shared_ptr<GatheredContext> context =
-        maybeGatherContext(RecordContext::ALL);
-    std::lock_guard<std::recursive_mutex> lock(mutex);
-
+  void free_locked(Block* block, std::shared_ptr<GatheredContext> context) {
     block->allocated = false;
 
     // following logic might modifying underlying Block, causing the size
@@ -2454,6 +2444,13 @@ class DeviceCachingAllocator {
         stats.allocated_bytes[static_cast<size_t>(StatType::AGGREGATE)].current,
         stats.reserved_bytes[static_cast<size_t>(StatType::AGGREGATE)].current,
         c10::Device(c10::DeviceType::CUDA, block->device));
+  }
+
+  void free(Block* block) {
+    std::shared_ptr<GatheredContext> context =
+        maybeGatherContext(RecordContext::ALL);
+    std::lock_guard<std::recursive_mutex> lock(mutex);
+    free_locked(block, std::move(context));
   }
 
   void* getBaseAllocation(Block* block, size_t* outSize) {
@@ -4615,7 +4612,7 @@ class NativeCachingAllocator : public CUDAAllocator {
     Block* block =
         device_allocator[device]->mallocWithAddress(size, stream, addr);
     TORCH_CHECK(
-        block != nullptr && block->ptr == addr,
+        block != nullptr,
         "Could not allocate CUDA storage at exact address ",
         addr);
     add_allocated_block(block);

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -1959,6 +1959,14 @@ class DeviceCachingAllocator {
   }
 
   Block* mallocWithAddress(size_t orig_size, cudaStream_t stream, void* addr) {
+    const auto requested_addr = reinterpret_cast<uintptr_t>(addr);
+    TORCH_CHECK(
+        requested_addr % kMinBlockSize == 0,
+        "mallocWithAddress: addr must be aligned to kMinBlockSize (",
+        kMinBlockSize,
+        " bytes), got ",
+        addr);
+
     // done outside the lock because we don't know what locks the recorder needs
     // to have.
     auto context = maybeGatherContext(RecordContext::STATE);
@@ -1983,7 +1991,6 @@ class DeviceCachingAllocator {
         CUDAAllocatorConfig::expandable_segments() && !active_user_pool;
     const auto stat_types = get_stat_types_for_pool(pool);
     const auto block_begin = reinterpret_cast<uintptr_t>(containing_block->ptr);
-    const auto requested_addr = reinterpret_cast<uintptr_t>(addr);
     const size_t prefix_size = requested_addr - block_begin;
 
     // mallocWithAddress may allocate both prefix block and requested block,

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -1738,6 +1738,8 @@ class DeviceCachingAllocator {
     // First, try to get a block from the existing pool.
     bool block_found = false;
     if (addr != nullptr) {
+      // Exact-address mode must either reuse this address or fail. Do not
+      // silently fall back to a different cached block.
       params.block = get_free_block_by_exact_address(pool, size, stream, addr);
       if (!params.block) {
         return nullptr;
@@ -4933,7 +4935,7 @@ class NativeCachingAllocator : public CUDAAllocator {
     return {devPtr, devPtr, deleteFunc, Device(DeviceType::CUDA, device)};
   }
 
-  DataPtr allocateWithAddress(size_t size, void* addr) {
+  DataPtr allocateWithAddress(size_t size, void* addr) override {
     c10::DeviceIndex device = 0;
     C10_CUDA_CHECK(c10::cuda::GetDevice(&device));
     TORCH_CHECK(
@@ -5268,13 +5270,6 @@ namespace CudaMallocAsync {
 CUDAAllocator* allocator();
 
 } // namespace CudaMallocAsync
-
-DataPtr allocateWithAddress(size_t size, void* addr) {
-  TORCH_CHECK(
-      get() == &Native::allocator,
-      "Exact-address allocation is only supported by the native CUDA caching allocator");
-  return Native::allocator.allocateWithAddress(size, addr);
-}
 
 struct BackendStaticInitializer {
   // Parses the environment configuration for CUDA/ROCm allocator backend at

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -1986,7 +1986,7 @@ class DeviceCachingAllocator {
     const auto requested_addr = reinterpret_cast<uintptr_t>(addr);
     const size_t prefix_size = requested_addr - block_begin;
 
-    // mallocWithAddress may allocates both prefix block and requested block,
+    // mallocWithAddress may allocate both prefix block and requested block,
     // and free prefix block later. This adds a fake malloc/free pair for prefix
     // block. A metadata is added for better memory visualization.
     const auto original_user_metadata = getUserMetadata();

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -171,9 +171,6 @@ static bool BlockComparatorSizeCounterAddress(const Block* a, const Block* b);
 static bool BlockComparatorAddress(const Block* a, const Block* b);
 
 struct BlockPool {
-  using BlockSet = std::set<Block*, Comparison>;
-  using iterator = BlockSet::iterator;
-
   BlockPool(bool small, PrivatePool* private_pool = nullptr)
       : blocks(BlockComparatorSizeCounterAddress),
         blocks_by_addr(BlockComparatorAddress),
@@ -181,20 +178,19 @@ struct BlockPool {
         is_small(small),
         owner_PrivatePool(private_pool) {}
 
-  // Do not insert a Block into blocks or blocks_by_addr directly; use
-  // insert_into_blocks() instead.
-  BlockSet blocks;
-  BlockSet blocks_by_addr;
-  BlockSet unmapped;
+  // Do not insert a Block to blocks directly; use insert_into_blocks(),
+  // instead.
+  std::set<Block*, Comparison> blocks;
+  std::set<Block*, Comparison> blocks_by_addr;
+  std::set<Block*, Comparison> unmapped;
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
   const bool is_small;
   PrivatePool* owner_PrivatePool;
   int64_t get_free_blocks_call_count{0};
 
-  // Add a Block into the cached free block indices with updating gc counter.
-  std::pair<iterator, bool> insert_into_blocks(Block* block);
-  void erase_from_blocks(Block* block);
-  void erase_from_blocks(iterator it);
+  // Add a Block into blocks set with updating gc counter.
+  std::pair<std::set<Block*, Comparison>::iterator, bool> insert_into_blocks(
+      Block* block);
 
   MempoolId_t owner_MempoolId() const;
 };
@@ -271,26 +267,10 @@ struct Block {
   }
 };
 
-std::pair<BlockPool::iterator, bool> BlockPool::insert_into_blocks(
-    Block* block) {
+std::pair<std::set<Block*, Comparison>::iterator, bool> BlockPool::
+    insert_into_blocks(Block* block) {
   block->gc_count_base = get_free_blocks_call_count;
-  auto inserted = blocks.insert(block);
-  auto inserted_by_addr = blocks_by_addr.insert(block);
-  TORCH_INTERNAL_ASSERT(inserted.second == inserted_by_addr.second);
-  return inserted;
-}
-
-void BlockPool::erase_from_blocks(Block* block) {
-  auto erased = blocks.erase(block);
-  auto erased_by_addr = blocks_by_addr.erase(block);
-  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(erased == erased_by_addr);
-}
-
-void BlockPool::erase_from_blocks(iterator it) {
-  Block* block = *it;
-  blocks.erase(it);
-  auto erased_by_addr = blocks_by_addr.erase(block);
-  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(erased_by_addr == 1);
+  return blocks.insert(block);
 }
 
 struct SegmentRange {
@@ -1667,10 +1647,50 @@ class DeviceCachingAllocator {
     return context_recorder_.load()();
   }
 
+  Block* get_free_block_by_exact_address(
+      BlockPool& pool,
+      size_t size,
+      cudaStream_t stream,
+      void* addr) {
+    Block search_key(device_id, stream, 0);
+    auto it = pool.blocks.lower_bound(&search_key);
+    for (; it != pool.blocks.end() && (*it)->stream == stream; ++it) {
+      if ((*it)->ptr == addr && (*it)->size >= size) {
+        Block* block = *it;
+        pool.blocks.erase(it);
+        return block;
+      }
+    }
+    return nullptr;
+  }
+
+  Block* get_free_block_containing_address(
+      BlockPool& pool,
+      size_t size,
+      cudaStream_t stream,
+      void* addr) {
+    const auto requested_addr = reinterpret_cast<uintptr_t>(addr);
+    Block search_key(device_id, stream, 0);
+    auto it = pool.blocks.lower_bound(&search_key);
+    for (; it != pool.blocks.end() && (*it)->stream == stream; ++it) {
+      Block* block = *it;
+      const auto block_begin = reinterpret_cast<uintptr_t>(block->ptr);
+      const auto block_end = block_begin + block->size;
+      if (block_begin <= requested_addr &&
+          requested_addr + size <= block_end) {
+        return block;
+      }
+    }
+    return nullptr;
+  }
+
   // All public methods (except the above) acquire the allocator mutex.
   // Thus, do not call a public method from another public method.
 
-  Block* malloc(size_t orig_size, cudaStream_t stream) {
+  Block* malloc(
+      size_t orig_size,
+      cudaStream_t stream,
+      void* addr = nullptr) {
     // done outside the lock because we don't know what locks the recorder needs
     // to have...
     auto context = maybeGatherContext(RecordContext::STATE);
@@ -1716,11 +1736,20 @@ class DeviceCachingAllocator {
     params.stat_types = get_stat_types_for_pool(pool);
 
     // First, try to get a block from the existing pool.
-    bool block_found =
-        // Search pool
-        get_free_block(params)
-        // Trigger callbacks and retry search
-        || (trigger_free_memory_callbacks(params) && get_free_block(params));
+    bool block_found = false;
+    if (addr != nullptr) {
+      params.block = get_free_block_by_exact_address(pool, size, stream, addr);
+      if (!params.block) {
+        return nullptr;
+      }
+      block_found = true;
+    } else {
+      block_found =
+          // Search pool
+          get_free_block(params)
+          // Trigger callbacks and retry search
+          || (trigger_free_memory_callbacks(params) && get_free_block(params));
+    }
 
     // Can't reuse an existing block; try to get a new one.
     if (!block_found) {
@@ -1929,44 +1958,51 @@ class DeviceCachingAllocator {
         params, orig_size, std::move(context), split_remainder);
   }
 
-  Block* mallocWithAddress(size_t orig_size, cudaStream_t stream, void* addr) {
+  Block* mallocWithAddress(
+      size_t orig_size,
+      cudaStream_t stream,
+      void* addr) {
     auto context = maybeGatherContext(RecordContext::STATE);
-    auto free_context = maybeGatherContext(RecordContext::ALL);
-
     std::unique_lock<std::recursive_mutex> lock(mutex);
-
     if (C10_LIKELY(captures_underway.empty())) {
       process_events(context);
     } else if (CUDAAllocatorConfig::graph_capture_record_stream_reuse()) {
       free_safe_blocks_in_capture(context, stream);
     }
 
-    size_t size = round_size(orig_size);
+    const size_t size = round_size(orig_size);
     auto& pool = get_pool(size, stream);
-    const size_t alloc_size = get_allocation_size(size);
-    bool active_user_pool =
-        pool.owner_PrivatePool && pool.owner_PrivatePool->allocator();
-    bool is_expandable_segments_active =
-        CUDAAllocatorConfig::expandable_segments() && !active_user_pool;
-    AllocParams params(
-        device_id,
-        size,
-        stream,
-        &pool,
-        alloc_size,
-        is_expandable_segments_active);
-    params.stat_types = get_stat_types_for_pool(pool);
+    Block* containing_block =
+        get_free_block_containing_address(pool, size, stream, addr);
+    if (!containing_block) {
+      return nullptr;
+    }
 
-    Block* block = alloc_block_at_address(
-        addr, params, orig_size, context, free_context);
-    TORCH_CHECK(
-        block != nullptr,
-        "Could not allocate CUDA storage at exact address ",
-        addr,
-        " with size ",
-        orig_size,
-        " bytes");
-    return block;
+    const auto block_begin = reinterpret_cast<uintptr_t>(containing_block->ptr);
+    const auto requested_addr = reinterpret_cast<uintptr_t>(addr);
+    const size_t prefix_size = requested_addr - block_begin;
+
+    Block* prefix_block = nullptr;
+    if (prefix_size > 0) {
+      prefix_block = malloc(prefix_size, stream, containing_block->ptr);
+      if (!prefix_block) {
+        return nullptr;
+      }
+    }
+
+    Block* requested_block = malloc(orig_size, stream, addr);
+    if (!requested_block) {
+      if (prefix_block) {
+        free(prefix_block);
+      }
+      return nullptr;
+    }
+
+    if (prefix_block) {
+      free(prefix_block);
+    }
+    TORCH_INTERNAL_ASSERT(requested_block->ptr == addr);
+    return requested_block;
   }
 
   bool try_mempool_fallback(
@@ -2330,11 +2366,15 @@ class DeviceCachingAllocator {
     }
   }
 
-  void free_allocated_block(
-      Block* block,
-      const std::shared_ptr<GatheredContext>& context) {
+  void free(Block* block) {
+    std::shared_ptr<GatheredContext> context =
+        maybeGatherContext(RecordContext::ALL);
+    std::lock_guard<std::recursive_mutex> lock(mutex);
+
     block->allocated = false;
 
+    // following logic might modifying underlying Block, causing the size
+    // changed. We store ahead for reporting
     auto orig_block_ptr = block->ptr;
     auto orig_block_size = block->size;
 
@@ -2358,26 +2398,10 @@ class DeviceCachingAllocator {
         block->pool->owner_MempoolId(),
         context ? context : block->context_when_allocated);
 
-    if (block->size >= AcceleratorAllocatorConfig::max_split_size()) {
+    if (block->size >= AcceleratorAllocatorConfig::max_split_size())
       stats.oversize_allocations.decrease(1);
-    }
 
-    TORCH_INTERNAL_ASSERT(block->stream_uses.empty());
-    free_block(block, context);
-
-    c10::reportMemoryUsageToProfiler(
-        orig_block_ptr,
-        -static_cast<int64_t>(orig_block_size),
-        stats.allocated_bytes[static_cast<size_t>(StatType::AGGREGATE)].current,
-        stats.reserved_bytes[static_cast<size_t>(StatType::AGGREGATE)].current,
-        c10::Device(c10::DeviceType::CUDA, block->device));
-  }
-
-  void free(Block* block) {
-    std::shared_ptr<GatheredContext> context =
-        maybeGatherContext(RecordContext::ALL);
-    std::lock_guard<std::recursive_mutex> lock(mutex);
-
+    // If the block has been used on more than one stream, handle accordingly.
     if (!block->stream_uses.empty()) {
       if (C10_UNLIKELY(is_capture_context())) {
         if (CUDAAllocatorConfig::graph_capture_record_stream_reuse()) {
@@ -2395,18 +2419,16 @@ class DeviceCachingAllocator {
         // If not in a capture, insert events for the block.
         insert_events(block);
       }
-
-      c10::reportMemoryUsageToProfiler(
-          orig_block_ptr,
-          -static_cast<int64_t>(orig_block_size),
-          stats.allocated_bytes[static_cast<size_t>(StatType::AGGREGATE)]
-              .current,
-          stats.reserved_bytes[static_cast<size_t>(StatType::AGGREGATE)]
-              .current,
-          c10::Device(c10::DeviceType::CUDA, block->device));
     } else {
-      free_allocated_block(block, context);
+      free_block(block, context);
     }
+
+    c10::reportMemoryUsageToProfiler(
+        orig_block_ptr,
+        -static_cast<int64_t>(orig_block_size),
+        stats.allocated_bytes[static_cast<size_t>(StatType::AGGREGATE)].current,
+        stats.reserved_bytes[static_cast<size_t>(StatType::AGGREGATE)].current,
+        c10::Device(c10::DeviceType::CUDA, block->device));
   }
 
   void* getBaseAllocation(Block* block, size_t* outSize) {
@@ -2701,7 +2723,7 @@ class DeviceCachingAllocator {
           &pool,
           block_state.size,
           curr_block->expandable_segment_ != nullptr);
-      pool.erase_from_blocks(curr_block);
+      pool.blocks.erase(curr_block);
       params.block = curr_block;
       params.stat_types = get_stat_types_for_pool(pool);
 
@@ -3428,7 +3450,7 @@ class DeviceCachingAllocator {
       }
       candidate = new_candidate;
     }
-    pool->erase_from_blocks(candidate);
+    pool->blocks.erase(candidate);
     return candidate;
   }
 
@@ -3537,8 +3559,7 @@ class DeviceCachingAllocator {
     dst->size += subsumed_size;
     // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
     auto erased =
-        src->mapped ? (pool.erase_from_blocks(src), size_t{1})
-                    : pool.unmapped.erase(src);
+        src->mapped ? pool.blocks.erase(src) : pool.unmapped.erase(src);
     TORCH_INTERNAL_ASSERT_DEBUG_ONLY(erased == 1);
     delete src;
 
@@ -3695,69 +3716,8 @@ class DeviceCachingAllocator {
          p.size() + AcceleratorAllocatorConfig::max_non_split_rounding_size()))
       return false;
     p.block = *it;
-    pool.erase_from_blocks(it);
+    pool.blocks.erase(it);
     return true;
-  }
-
-  Block* alloc_block_at_address(
-      void* addr,
-      const AllocParams& params,
-      size_t orig_size,
-      const std::shared_ptr<GatheredContext>& context,
-      const std::shared_ptr<GatheredContext>& free_context) {
-    BlockPool& pool = *params.pool;
-    Block search_key(params.device(), params.stream(), 0);
-    search_key.ptr = addr;
-    auto it = pool.blocks_by_addr.upper_bound(&search_key);
-    if (it == pool.blocks_by_addr.begin()) {
-      return nullptr;
-    }
-    --it;
-
-    Block* block = *it;
-    auto requested_addr = reinterpret_cast<uintptr_t>(addr);
-    auto block_start = reinterpret_cast<uintptr_t>(block->ptr);
-    if (block->stream != params.stream() || requested_addr < block_start) {
-      return nullptr;
-    }
-
-    size_t prefix_size = requested_addr - block_start;
-    if (prefix_size > block->size ||
-        params.size() > block->size - prefix_size) {
-      return nullptr;
-    }
-
-    pool.erase_from_blocks(block);
-
-    if (prefix_size == 0) {
-      AllocParams target_params = params;
-      target_params.block = block;
-      return alloc_found_block(
-          target_params, orig_size, context, block->size > params.size());
-    }
-
-    AllocParams prefix_params(
-        params.device(),
-        prefix_size,
-        params.stream(),
-        &pool,
-        prefix_size,
-        params.is_expandable_segments_active);
-    prefix_params.block = block;
-    prefix_params.stat_types = params.stat_types;
-
-    Block* prefix = alloc_found_block(
-        prefix_params, prefix_size, context, block->size > prefix_size);
-    Block* target = prefix->next;
-    TORCH_INTERNAL_ASSERT(target != nullptr);
-    TORCH_INTERNAL_ASSERT(target->ptr == addr);
-
-    AllocParams target_params = params;
-    target_params.block = target;
-    Block* allocated = alloc_found_block(
-        target_params, orig_size, context, target->size > params.size());
-    free_allocated_block(prefix, free_context ? free_context : context);
-    return allocated;
   }
 
   bool trigger_free_memory_callbacks(AllocParams& p) {
@@ -4159,7 +4119,7 @@ class DeviceCachingAllocator {
 
     if (block->size >= AcceleratorAllocatorConfig::max_split_size())
       stats.oversize_segments.decrease(1);
-    pool->erase_from_blocks(block);
+    pool->blocks.erase(block);
     delete block;
   }
 
@@ -4171,7 +4131,7 @@ class DeviceCachingAllocator {
     if (unmapped.size == 0) {
       return;
     }
-    block->pool->erase_from_blocks(block);
+    block->pool->blocks.erase(block);
 
     ptrdiff_t before_size = unmapped.ptr - static_cast<char*>(block->ptr);
     if (before_size > 0) {
@@ -4627,8 +4587,12 @@ class NativeCachingAllocator : public CUDAAllocator {
         "Allocator not initialized for device ",
         device,
         ": did you call init?");
-    Block* block = device_allocator[device]->mallocWithAddress(
-        size, stream, addr);
+    Block* block =
+        device_allocator[device]->mallocWithAddress(size, stream, addr);
+    TORCH_CHECK(
+        block != nullptr && block->ptr == addr,
+        "Could not allocate CUDA storage at exact address ",
+        addr);
     add_allocated_block(block);
     *devPtr = block->ptr;
     const c10::impl::PyInterpreter* interp = c10::impl::GPUTrace::get_trace();
@@ -4968,31 +4932,25 @@ class NativeCachingAllocator : public CUDAAllocator {
 
     return {devPtr, devPtr, deleteFunc, Device(DeviceType::CUDA, device)};
   }
+
   DataPtr allocateWithAddress(size_t size, void* addr) {
-    constexpr size_t one_exa_bytes = 1152921504606846976ULL;
-    TORCH_CHECK_WITH(
-        OutOfMemoryError,
-        size < one_exa_bytes,
-        "CUDA out of memory. Tried to allocate more than 1EB memory.");
     c10::DeviceIndex device = 0;
     C10_CUDA_CHECK(c10::cuda::GetDevice(&device));
-    void* devPtr = nullptr;
-    void (*deleteFunc)(void*) = &local_raw_delete;
-    CUDAStream stream = cuda::getCurrentCUDAStream(device);
-
     TORCH_CHECK(
         !forceUncachedAllocator() && isEnabled(),
-        "Exact-address allocation requires the native CUDA caching allocator");
+        "Exact-address allocation is only supported by the native CUDA caching allocator");
+    void* devPtr = nullptr;
+    CUDAStream stream = cuda::getCurrentCUDAStream(device);
     if (size != 0) {
-      this->mallocWithAddress(&devPtr, device, size, stream, addr);
+      mallocWithAddress(&devPtr, device, size, stream, addr);
     }
-
     if (size && TORCH_SDT_IS_ENABLED(malloc)) {
       TORCH_SDT_WITH_SEMAPHORE(malloc, devPtr, device, size, stream.id());
     }
-
-    return {devPtr, devPtr, deleteFunc, Device(DeviceType::CUDA, device)};
+    return {
+        devPtr, devPtr, &local_raw_delete, Device(DeviceType::CUDA, device)};
   }
+
   DeleterFnPtr raw_deleter() const override {
     if (forceUncachedAllocator() || !isEnabled()) {
       return &uncached_delete;
@@ -5311,6 +5269,13 @@ CUDAAllocator* allocator();
 
 } // namespace CudaMallocAsync
 
+DataPtr allocateWithAddress(size_t size, void* addr) {
+  TORCH_CHECK(
+      get() == &Native::allocator,
+      "Exact-address allocation is only supported by the native CUDA caching allocator");
+  return Native::allocator.allocateWithAddress(size, addr);
+}
+
 struct BackendStaticInitializer {
   // Parses the environment configuration for CUDA/ROCm allocator backend at
   // load time. This duplicates some logic from CUDAAllocatorConfig to ensure
@@ -5378,13 +5343,5 @@ struct BackendStaticInitializer {
 
 std::atomic<CUDAAllocator*> allocator;
 static BackendStaticInitializer backend_static_initializer;
-
-DataPtr allocateWithAddress(size_t size, void* addr) {
-  auto* current = get();
-  TORCH_CHECK(
-      current == &Native::allocator,
-      "Exact-address allocation requires the native CUDA caching allocator");
-  return Native::allocator.allocateWithAddress(size, addr);
-}
 } // namespace cuda::CUDACachingAllocator
 } // namespace c10

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -3623,8 +3623,8 @@ class DeviceCachingAllocator {
   }
 
   bool get_free_block_by_hint(void* hint, AllocParams& params) {
-    // Get a free block starting at hint address. If hint is at the middle of a block,
-    // split the block at hint and return the second part.
+    // Get a free block starting at hint address. If hint is at the middle of a
+    // block, split the block at hint and return the second part.
     BlockPool& pool = *params.pool;
     Block search_key(params.device(), params.stream(), 0);
     auto it = pool.blocks.lower_bound(&search_key);

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -178,8 +178,8 @@ struct BlockPool {
         is_small(small),
         owner_PrivatePool(private_pool) {}
 
-  // Do not insert a Block to blocks directly; use insert_into_blocks(),
-  // instead.
+  // Do not insert or erase a Block from blocks/blocks_by_addr directly; use
+  // insert_into_blocks()/erase_from_blocks() instead.
   std::set<Block*, Comparison> blocks;
   std::set<Block*, Comparison> blocks_by_addr;
   std::set<Block*, Comparison> unmapped;
@@ -191,6 +191,7 @@ struct BlockPool {
   // Add a Block into blocks set with updating gc counter.
   std::pair<std::set<Block*, Comparison>::iterator, bool> insert_into_blocks(
       Block* block);
+  size_t erase_from_blocks(Block* block);
 
   MempoolId_t owner_MempoolId() const;
 };
@@ -270,7 +271,17 @@ struct Block {
 std::pair<std::set<Block*, Comparison>::iterator, bool> BlockPool::
     insert_into_blocks(Block* block) {
   block->gc_count_base = get_free_blocks_call_count;
-  return blocks.insert(block);
+  auto inserted = blocks.insert(block);
+  auto inserted_by_addr = blocks_by_addr.insert(block);
+  TORCH_INTERNAL_ASSERT(inserted.second == inserted_by_addr.second);
+  return inserted;
+}
+
+size_t BlockPool::erase_from_blocks(Block* block) {
+  auto erased = blocks.erase(block);
+  auto erased_by_addr = blocks_by_addr.erase(block);
+  TORCH_INTERNAL_ASSERT(erased == erased_by_addr);
+  return erased;
 }
 
 struct SegmentRange {
@@ -1653,13 +1664,13 @@ class DeviceCachingAllocator {
       cudaStream_t stream,
       void* addr) {
     Block search_key(device_id, stream, 0);
-    auto it = pool.blocks.lower_bound(&search_key);
-    for (; it != pool.blocks.end() && (*it)->stream == stream; ++it) {
-      if ((*it)->ptr == addr && (*it)->size >= size) {
-        Block* block = *it;
-        pool.blocks.erase(it);
-        return block;
-      }
+    search_key.ptr = addr;
+    auto it = pool.blocks_by_addr.lower_bound(&search_key);
+    if (it != pool.blocks_by_addr.end() && (*it)->stream == stream &&
+        (*it)->ptr == addr && (*it)->size >= size) {
+      Block* block = *it;
+      pool.erase_from_blocks(block);
+      return block;
     }
     return nullptr;
   }
@@ -1671,15 +1682,20 @@ class DeviceCachingAllocator {
       void* addr) {
     const auto requested_addr = reinterpret_cast<uintptr_t>(addr);
     Block search_key(device_id, stream, 0);
-    auto it = pool.blocks.lower_bound(&search_key);
-    for (; it != pool.blocks.end() && (*it)->stream == stream; ++it) {
-      Block* block = *it;
-      const auto block_begin = reinterpret_cast<uintptr_t>(block->ptr);
-      const auto block_end = block_begin + block->size;
-      if (block_begin <= requested_addr &&
-          requested_addr + size <= block_end) {
-        return block;
-      }
+    search_key.ptr = addr;
+    auto it = pool.blocks_by_addr.upper_bound(&search_key);
+    if (it == pool.blocks_by_addr.begin()) {
+      return nullptr;
+    }
+    --it;
+    if ((*it)->stream != stream) {
+      return nullptr;
+    }
+    Block* block = *it;
+    const auto block_begin = reinterpret_cast<uintptr_t>(block->ptr);
+    const auto block_end = block_begin + block->size;
+    if (block_begin <= requested_addr && requested_addr + size <= block_end) {
+      return block;
     }
     return nullptr;
   }
@@ -1687,10 +1703,7 @@ class DeviceCachingAllocator {
   // All public methods (except the above) acquire the allocator mutex.
   // Thus, do not call a public method from another public method.
 
-  Block* malloc(
-      size_t orig_size,
-      cudaStream_t stream,
-      void* addr = nullptr) {
+  Block* malloc(size_t orig_size, cudaStream_t stream, void* addr = nullptr) {
     // done outside the lock because we don't know what locks the recorder needs
     // to have...
     auto context = maybeGatherContext(RecordContext::STATE);
@@ -1960,10 +1973,7 @@ class DeviceCachingAllocator {
         params, orig_size, std::move(context), split_remainder);
   }
 
-  Block* mallocWithAddress(
-      size_t orig_size,
-      cudaStream_t stream,
-      void* addr) {
+  Block* mallocWithAddress(size_t orig_size, cudaStream_t stream, void* addr) {
     auto context = maybeGatherContext(RecordContext::STATE);
     std::unique_lock<std::recursive_mutex> lock(mutex);
     if (C10_LIKELY(captures_underway.empty())) {
@@ -2725,7 +2735,7 @@ class DeviceCachingAllocator {
           &pool,
           block_state.size,
           curr_block->expandable_segment_ != nullptr);
-      pool.blocks.erase(curr_block);
+      pool.erase_from_blocks(curr_block);
       params.block = curr_block;
       params.stat_types = get_stat_types_for_pool(pool);
 
@@ -3452,7 +3462,7 @@ class DeviceCachingAllocator {
       }
       candidate = new_candidate;
     }
-    pool->blocks.erase(candidate);
+    pool->erase_from_blocks(candidate);
     return candidate;
   }
 
@@ -3561,7 +3571,7 @@ class DeviceCachingAllocator {
     dst->size += subsumed_size;
     // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
     auto erased =
-        src->mapped ? pool.blocks.erase(src) : pool.unmapped.erase(src);
+        src->mapped ? pool.erase_from_blocks(src) : pool.unmapped.erase(src);
     TORCH_INTERNAL_ASSERT_DEBUG_ONLY(erased == 1);
     delete src;
 
@@ -3718,7 +3728,7 @@ class DeviceCachingAllocator {
          p.size() + AcceleratorAllocatorConfig::max_non_split_rounding_size()))
       return false;
     p.block = *it;
-    pool.blocks.erase(it);
+    pool.erase_from_blocks(p.block);
     return true;
   }
 
@@ -4121,7 +4131,7 @@ class DeviceCachingAllocator {
 
     if (block->size >= AcceleratorAllocatorConfig::max_split_size())
       stats.oversize_segments.decrease(1);
-    pool->blocks.erase(block);
+    pool->erase_from_blocks(block);
     delete block;
   }
 
@@ -4133,7 +4143,7 @@ class DeviceCachingAllocator {
     if (unmapped.size == 0) {
       return;
     }
-    block->pool->blocks.erase(block);
+    block->pool->erase_from_blocks(block);
 
     ptrdiff_t before_size = unmapped.ptr - static_cast<char*>(block->ptr);
     if (before_size > 0) {

--- a/c10/cuda/CUDACachingAllocator.h
+++ b/c10/cuda/CUDACachingAllocator.h
@@ -277,10 +277,6 @@ class CUDAAllocator : public DeviceAllocator {
       c10::DeviceIndex device,
       std::shared_ptr<AllocatorState> pps) = 0;
   virtual std::string name() = 0;
-  virtual DataPtr allocateWithHint(size_t size, void* hint) {
-    // Default: ignore hint, fall back to normal allocation
-    return allocate(size);
-  }
   std::pair<size_t, size_t> getMemoryInfo(c10::DeviceIndex device) override {
     c10::DeviceGuard device_guard({at::kCUDA, device});
     size_t free = 0;
@@ -498,9 +494,7 @@ inline std::string name() {
   return get()->name();
 }
 
-inline DataPtr allocateWithHint(size_t size, void* hint) {
-  return get()->allocateWithHint(size, hint);
-}
+C10_CUDA_API DataPtr allocateWithAddress(size_t size, void* addr);
 
 inline cudaError_t memcpyAsync(
     void* dst,

--- a/c10/cuda/CUDACachingAllocator.h
+++ b/c10/cuda/CUDACachingAllocator.h
@@ -276,6 +276,13 @@ class CUDAAllocator : public DeviceAllocator {
   virtual CheckpointDelta setCheckpointPoolState(
       c10::DeviceIndex device,
       std::shared_ptr<AllocatorState> pps) = 0;
+  virtual DataPtr allocateWithAddress(size_t size, void* addr) {
+    TORCH_CHECK(
+        false,
+        name(),
+        " does not yet support allocateWithAddress. "
+        "If you need it, please file an issue describing your use case.");
+  }
   virtual std::string name() = 0;
   std::pair<size_t, size_t> getMemoryInfo(c10::DeviceIndex device) override {
     c10::DeviceGuard device_guard({at::kCUDA, device});
@@ -380,6 +387,10 @@ inline CheckpointDelta setCheckpointPoolState(
     c10::DeviceIndex device,
     std::shared_ptr<AllocatorState> pps) {
   return get()->setCheckpointPoolState(device, std::move(pps));
+}
+
+inline DataPtr allocateWithAddress(size_t size, void* addr) {
+  return get()->allocateWithAddress(size, addr);
 }
 
 // CUDAGraph interactions
@@ -493,8 +504,6 @@ inline ShareableHandle shareIpcHandle(void* ptr) {
 inline std::string name() {
   return get()->name();
 }
-
-C10_CUDA_API DataPtr allocateWithAddress(size_t size, void* addr);
 
 inline cudaError_t memcpyAsync(
     void* dst,

--- a/c10/cuda/CUDACachingAllocator.h
+++ b/c10/cuda/CUDACachingAllocator.h
@@ -277,6 +277,10 @@ class CUDAAllocator : public DeviceAllocator {
       c10::DeviceIndex device,
       std::shared_ptr<AllocatorState> pps) = 0;
   virtual std::string name() = 0;
+  virtual DataPtr allocateWithHint(size_t size, void* hint) {
+    // Default: ignore hint, fall back to normal allocation
+    return allocate(size);
+  }
   std::pair<size_t, size_t> getMemoryInfo(c10::DeviceIndex device) override {
     c10::DeviceGuard device_guard({at::kCUDA, device});
     size_t free = 0;
@@ -492,6 +496,10 @@ inline ShareableHandle shareIpcHandle(void* ptr) {
 
 inline std::string name() {
   return get()->name();
+}
+
+inline DataPtr allocateWithHint(size_t size, void* hint) {
+  return get()->allocateWithHint(size, hint);
 }
 
 inline cudaError_t memcpyAsync(

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -4802,6 +4802,7 @@ class TestResizeStorageHint(TestCase):
         TEST_CUDAMALLOCASYNC,
         "CUDAMallocAsync does not use the caching allocator hint path",
     )
+    @unittest.skipIf(not TEST_CUDA, "CUDA not available, skipping tests")
     def test_resize_split_block(self):
         pool = torch.cuda.MemPool()
 
@@ -4833,6 +4834,7 @@ class TestResizeStorageHint(TestCase):
         TEST_CUDAMALLOCASYNC,
         "CUDAMallocAsync does not use the caching allocator hint path",
     )
+    @unittest.skipIf(not TEST_CUDA, "CUDA not available, skipping tests")
     @skipIfRocm(msg="expandable_segments mode is not supported on ROCm")
     def test_resize_storage_hint_expandable_segments_with_split_block(self):
         torch.cuda.empty_cache()

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -4718,153 +4718,188 @@ print(ret)
         self.assertEqual(r, "1.0")
 
 
-class TestResizeStorageHint(TestCase):
+class TestResizeStorageWithAddr(TestCase):
     _do_cuda_memory_leak_check = True
     _do_cuda_non_default_stream = True
 
+    def _find_pool_block(self, pool, addr):
+        for segment in pool.snapshot(include_traces=False):
+            for idx, block in enumerate(segment["blocks"]):
+                if block["address"] == addr:
+                    return segment["blocks"], idx
+        self.fail(f"Could not find block at address {addr}")
+
     @unittest.skipIf(
         TEST_CUDAMALLOCASYNC,
-        "CUDAMallocAsync does not use the caching allocator hint path",
+        "CUDAMallocAsync does not support exact-address allocation",
     )
-    def test_resize_storage_hint_basic(self):
-        t = torch.randn(1024, device="cuda")
+    def test_resize_storage_with_addr_exact_allocation(self):
+        pool = torch.cuda.MemPool()
+        with torch.cuda.use_mem_pool(pool):
+            t = torch.empty(4096, dtype=torch.uint8, device="cuda")
+
+        original_ptr = t.untyped_storage().data_ptr()
+        original_size = t.untyped_storage().nbytes()
+        t.untyped_storage().resize_(0)
+
+        with torch.cuda.use_mem_pool(pool):
+            t.untyped_storage()._resize_with_addr_(original_size, original_ptr)
+            other = torch.empty(4096, dtype=torch.uint8, device="cuda")
+
+        self.assertEqual(t.untyped_storage().nbytes(), original_size)
+        self.assertEqual(t.untyped_storage().data_ptr(), original_ptr)
+        self.assertNotEqual(other.untyped_storage().data_ptr(), original_ptr)
+
+    @unittest.skipIf(
+        TEST_CUDAMALLOCASYNC,
+        "CUDAMallocAsync does not support exact-address allocation",
+    )
+    def test_resize_storage_with_addr_occupied_address_errors(self):
+        pool = torch.cuda.MemPool()
+        with torch.cuda.use_mem_pool(pool):
+            occupied = torch.empty(4096, dtype=torch.uint8, device="cuda")
+            t = torch.empty(2048, dtype=torch.uint8, device="cuda")
+
+        occupied_ptr = occupied.untyped_storage().data_ptr()
+        occupied_size = occupied.untyped_storage().nbytes()
+        t.untyped_storage().resize_(0)
+
+        with self.assertRaisesRegex(RuntimeError, "exact address"):
+            with torch.cuda.use_mem_pool(pool):
+                t.untyped_storage()._resize_with_addr_(occupied_size, occupied_ptr)
+
+    @unittest.skipIf(
+        TEST_CUDAMALLOCASYNC,
+        "CUDAMallocAsync does not support exact-address allocation",
+    )
+    def test_resize_storage_with_addr_middle_of_block(self):
+        pool = torch.cuda.MemPool()
+        with torch.cuda.use_mem_pool(pool):
+            prefix = torch.empty(4096, dtype=torch.uint8, device="cuda")
+            t = torch.empty(4096, dtype=torch.uint8, device="cuda")
+            suffix = torch.empty(4096, dtype=torch.uint8, device="cuda")
+
+        original_ptr = t.untyped_storage().data_ptr()
+        original_size = t.untyped_storage().nbytes()
+        prefix.untyped_storage().resize_(0)
+        t.untyped_storage().resize_(0)
+        suffix.untyped_storage().resize_(0)
+
+        with torch.cuda.use_mem_pool(pool):
+            t.untyped_storage()._resize_with_addr_(original_size, original_ptr)
+
+        blocks, idx = self._find_pool_block(pool, original_ptr)
+        self.assertGreater(idx, 0)
+        self.assertLess(idx + 1, len(blocks))
+        self.assertEqual(blocks[idx]["state"], "active_allocated")
+        self.assertEqual(blocks[idx - 1]["state"], "inactive")
+        self.assertEqual(
+            blocks[idx - 1]["address"] + blocks[idx - 1]["size"],
+            original_ptr,
+        )
+        self.assertEqual(blocks[idx + 1]["state"], "inactive")
+        self.assertEqual(
+            blocks[idx]["address"] + blocks[idx]["size"],
+            blocks[idx + 1]["address"],
+        )
+
+    def test_resize_storage_with_addr_does_not_change_resize(self):
+        storage = torch.empty(1).untyped_storage()
+        with self.assertRaises(TypeError):
+            storage.resize_(storage.nbytes(), 0)
+
+    @unittest.skipIf(
+        TEST_CUDAMALLOCASYNC,
+        "CUDAMallocAsync does not support exact-address allocation",
+    )
+    def test_resize_storage_with_addr_out_of_pool_errors(self):
+        pool = torch.cuda.MemPool()
+        with torch.cuda.use_mem_pool(pool):
+            t = torch.empty(4096, dtype=torch.uint8, device="cuda")
+
+        original_ptr = t.untyped_storage().data_ptr()
+        original_size = t.untyped_storage().nbytes()
+        t.untyped_storage().resize_(0)
+
+        with self.assertRaisesRegex(RuntimeError, "exact address"):
+            with torch.cuda.use_mem_pool(pool):
+                t.untyped_storage()._resize_with_addr_(original_size, original_ptr - 1)
+
+    @unittest.skipIf(
+        TEST_CUDAMALLOCASYNC,
+        "CUDAMallocAsync does not support exact-address allocation",
+    )
+    def test_resize_storage_with_addr_recovers_viewed_slices(self):
+        pool = torch.cuda.MemPool()
+        with torch.cuda.use_mem_pool(pool):
+            base = torch.empty(4096, dtype=torch.uint8, device="cuda")
+            view1 = base[512:1024]
+            view2 = base[1024:1536]
+
+        storage = base.untyped_storage()
+        original_ptr = storage.data_ptr()
+        original_size = storage.nbytes()
+        storage.resize_(0)
+
+        self.assertEqual(base.untyped_storage().nbytes(), 0)
+        self.assertEqual(view1.untyped_storage().nbytes(), 0)
+        self.assertEqual(view2.untyped_storage().nbytes(), 0)
+
+        with torch.cuda.use_mem_pool(pool):
+            storage._resize_with_addr_(original_size, original_ptr)
+
+        self.assertEqual(base.untyped_storage().data_ptr(), original_ptr)
+        self.assertEqual(view1.untyped_storage().data_ptr(), original_ptr)
+        self.assertEqual(view2.untyped_storage().data_ptr(), original_ptr)
+        self.assertEqual(base.untyped_storage().nbytes(), original_size)
+        self.assertEqual(view1.untyped_storage().nbytes(), original_size)
+        self.assertEqual(view2.untyped_storage().nbytes(), original_size)
+
+    def test_resize_storage_with_addr_requires_zero_sized_source(self):
+        pool = torch.cuda.MemPool()
+        with torch.cuda.use_mem_pool(pool):
+            t = torch.empty(4096, dtype=torch.uint8, device="cuda")
+
         original_ptr = t.untyped_storage().data_ptr()
         original_size = t.untyped_storage().nbytes()
 
-        t.untyped_storage().resize_(0)
+        with self.assertRaisesRegex(RuntimeError, "zero-sized CUDA storage"):
+            with torch.cuda.use_mem_pool(pool):
+                t.untyped_storage()._resize_with_addr_(original_size, original_ptr)
+
+    def test_resize_storage_with_addr_zero_ignores_addr(self):
+        t = torch.empty(4096, dtype=torch.uint8, device="cuda")
+        t.untyped_storage()._resize_with_addr_(0, 1)
         self.assertEqual(t.untyped_storage().nbytes(), 0)
 
-        t.untyped_storage().resize_(original_size, original_ptr)
-        self.assertEqual(t.untyped_storage().data_ptr(), original_ptr)
-
     @unittest.skipIf(
         TEST_CUDAMALLOCASYNC,
-        "CUDAMallocAsync does not use the caching allocator hint path",
-    )
-    def test_resize_storage_hint_consumed(self):
-        t = torch.randn(1024, device="cuda")
-        original_ptr = t.untyped_storage().data_ptr()
-        original_size = t.untyped_storage().nbytes()
-
-        t.untyped_storage().resize_(0)
-
-        # Allocate another tensor that may consume the freed block
-        blocker = torch.randn(1024, device="cuda")
-
-        t.untyped_storage().resize_(original_size, original_ptr)
-        # The hint may or may not succeed depending on whether blocker
-        # consumed the exact block -- either way, no crash.
-        self.assertEqual(t.untyped_storage().nbytes(), original_size)
-        del blocker
-
-    @unittest.skipIf(
-        TEST_CUDAMALLOCASYNC,
-        "CUDAMallocAsync does not use the caching allocator hint path",
-    )
-    def test_resize_storage_hint_no_hint(self):
-        t = torch.randn(1024, device="cuda")
-        original_size = t.untyped_storage().nbytes()
-
-        t.untyped_storage().resize_(0)
-
-        # Resize without hint -- should work like normal allocation
-        new_size = original_size * 2
-        t.untyped_storage().resize_(new_size)
-        self.assertEqual(t.untyped_storage().nbytes(), new_size)
-
-    @unittest.skipIf(
-        TEST_CUDAMALLOCASYNC,
-        "CUDAMallocAsync does not use the caching allocator hint path",
+        "CUDAMallocAsync does not support exact-address allocation",
     )
     @skipIfRocm(msg="expandable_segments mode is not supported on ROCm")
-    def test_resize_storage_hint_expandable_segments(self):
-        torch.cuda.empty_cache()
-        torch.cuda.memory._set_allocator_settings("expandable_segments:True")
-        try:
-            t = torch.randn(1024, device="cuda")
-            original_ptr = t.untyped_storage().data_ptr()
-            original_size = t.untyped_storage().nbytes()
-
-            t.untyped_storage().resize_(0)
-            self.assertEqual(t.untyped_storage().nbytes(), 0)
-
-            t.untyped_storage().resize_(original_size, original_ptr)
-            # With expandable segments the hint is best-effort; the block
-            # may have been merged or unmapped.  Just verify no crash and
-            # correct size.
-            self.assertEqual(t.untyped_storage().nbytes(), original_size)
-        finally:
-            del t
-            torch.cuda.empty_cache()
-            torch.cuda.memory._set_allocator_settings("")
-
-    @unittest.skipIf(
-        TEST_CUDAMALLOCASYNC,
-        "CUDAMallocAsync does not use the caching allocator hint path",
-    )
-    @unittest.skipIf(not TEST_CUDA, "CUDA not available, skipping tests")
-    def test_resize_split_block(self):
-        pool = torch.cuda.MemPool()
-
-        # Allocate two tensors in private pool and t is the second tensor
-        with torch.cuda.use_mem_pool(pool):
-            blocker = torch.randn(1024, device="cuda")
-            t = torch.randn(1024, device="cuda")
-
-        original_ptr = t.untyped_storage().data_ptr()
-        original_size = t.untyped_storage().nbytes()
-
-        # delete blocker and t such that the two blocks have been merged
-        # in CUDACachingAllocator.
-        t.untyped_storage().resize_(0)
-        blocker.untyped_storage().resize_(0)
-
-        # Reallocate t at the original ptr in mempool.
-        with torch.cuda.use_mem_pool(pool):
-            t.untyped_storage().resize_(original_size, original_ptr)
-
-        self.assertEqual(t.untyped_storage().nbytes(), original_size)
-        self.assertEqual(t.untyped_storage().data_ptr(), original_ptr)
-
-        del blocker
-        del t
-        del pool
-
-    @unittest.skipIf(
-        TEST_CUDAMALLOCASYNC,
-        "CUDAMallocAsync does not use the caching allocator hint path",
-    )
-    @unittest.skipIf(not TEST_CUDA, "CUDA not available, skipping tests")
-    @skipIfRocm(msg="expandable_segments mode is not supported on ROCm")
-    def test_resize_storage_hint_expandable_segments_with_split_block(self):
+    @serialTest()
+    def test_resize_storage_with_addr_expandable_segments_middle_of_block(self):
         torch.cuda.empty_cache()
         torch.cuda.memory._set_allocator_settings("expandable_segments:True")
         try:
             pool = torch.cuda.MemPool()
-
-            # Allocate two tensors in private pool and t is the second tensor
+            torch.cuda.empty_cache()
             with torch.cuda.use_mem_pool(pool):
-                blocker = torch.randn(1024, device="cuda")
-                t = torch.randn(1024, device="cuda")
+                prefix = torch.empty(4096, dtype=torch.uint8, device="cuda")
+                t = torch.empty(4096, dtype=torch.uint8, device="cuda")
+                suffix = torch.empty(4096, dtype=torch.uint8, device="cuda")
 
             original_ptr = t.untyped_storage().data_ptr()
             original_size = t.untyped_storage().nbytes()
-
-            # delete blocker and t such that the two blocks have been merged
-            # in CUDACachingAllocator.
+            prefix.untyped_storage().resize_(0)
             t.untyped_storage().resize_(0)
-            blocker.untyped_storage().resize_(0)
+            suffix.untyped_storage().resize_(0)
 
-            # Reallocate t at the original ptr in mempool.
             with torch.cuda.use_mem_pool(pool):
-                t.untyped_storage().resize_(original_size, original_ptr)
+                t.untyped_storage()._resize_with_addr_(original_size, original_ptr)
 
-            self.assertEqual(t.untyped_storage().nbytes(), original_size)
             self.assertEqual(t.untyped_storage().data_ptr(), original_ptr)
         finally:
-            del blocker
-            del t
-            del pool
             torch.cuda.empty_cache()
             torch.cuda.memory._set_allocator_settings("")
 

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -4718,6 +4718,11 @@ print(ret)
         self.assertEqual(r, "1.0")
 
 
+@unittest.skipIf(not TEST_CUDA, "CUDA not available, skipping tests")
+@unittest.skipIf(
+    TEST_WITH_ROCM and EXPANDABLE_SEGMENTS,
+    "expandable_segments mode is not supported on ROCm",
+)
 class TestResizeStorageWithAddr(TestCase):
     _do_cuda_memory_leak_check = True
     _do_cuda_non_default_stream = True
@@ -4736,15 +4741,17 @@ class TestResizeStorageWithAddr(TestCase):
     def test_resize_storage_with_addr_exact_allocation(self):
         pool = torch.cuda.MemPool()
         with torch.cuda.use_mem_pool(pool):
+            other = torch.empty(294, dtype=torch.uint8, device="cuda")
             t = torch.empty(4096, dtype=torch.uint8, device="cuda")
 
         original_ptr = t.untyped_storage().data_ptr()
         original_size = t.untyped_storage().nbytes()
         t.untyped_storage().resize_(0)
+        other.untyped_storage().resize_(0)
 
         with torch.cuda.use_mem_pool(pool):
             t.untyped_storage()._resize_with_addr_(original_size, original_ptr)
-            other = torch.empty(4096, dtype=torch.uint8, device="cuda")
+            other = torch.empty(294, dtype=torch.uint8, device="cuda")
 
         self.assertEqual(t.untyped_storage().nbytes(), original_size)
         self.assertEqual(t.untyped_storage().data_ptr(), original_ptr)
@@ -4775,9 +4782,9 @@ class TestResizeStorageWithAddr(TestCase):
     def test_resize_storage_with_addr_middle_of_block(self):
         pool = torch.cuda.MemPool()
         with torch.cuda.use_mem_pool(pool):
-            prefix = torch.empty(4096, dtype=torch.uint8, device="cuda")
-            t = torch.empty(4096, dtype=torch.uint8, device="cuda")
-            suffix = torch.empty(4096, dtype=torch.uint8, device="cuda")
+            prefix = torch.empty(3729, dtype=torch.uint8, device="cuda")
+            t = torch.empty(4017, dtype=torch.uint8, device="cuda")
+            suffix = torch.empty(2738, dtype=torch.uint8, device="cuda")
 
         original_ptr = t.untyped_storage().data_ptr()
         original_size = t.untyped_storage().nbytes()
@@ -4802,11 +4809,6 @@ class TestResizeStorageWithAddr(TestCase):
             blocks[idx]["address"] + blocks[idx]["size"],
             blocks[idx + 1]["address"],
         )
-
-    def test_resize_storage_with_addr_does_not_change_resize(self):
-        storage = torch.empty(1).untyped_storage()
-        with self.assertRaises(TypeError):
-            storage.resize_(storage.nbytes(), 0)
 
     @unittest.skipIf(
         TEST_CUDAMALLOCASYNC,
@@ -4867,42 +4869,10 @@ class TestResizeStorageWithAddr(TestCase):
             with torch.cuda.use_mem_pool(pool):
                 t.untyped_storage()._resize_with_addr_(original_size, original_ptr)
 
-    def test_resize_storage_with_addr_zero_ignores_addr(self):
+    def test_resize_storage_with_size_zero_ignores_addr(self):
         t = torch.empty(4096, dtype=torch.uint8, device="cuda")
         t.untyped_storage()._resize_with_addr_(0, 1)
         self.assertEqual(t.untyped_storage().nbytes(), 0)
-
-    @unittest.skipIf(
-        TEST_CUDAMALLOCASYNC,
-        "CUDAMallocAsync does not support exact-address allocation",
-    )
-    @skipIfRocm(msg="expandable_segments mode is not supported on ROCm")
-    @serialTest()
-    def test_resize_storage_with_addr_expandable_segments_middle_of_block(self):
-        torch.cuda.empty_cache()
-        torch.cuda.memory._set_allocator_settings("expandable_segments:True")
-        try:
-            pool = torch.cuda.MemPool()
-            torch.cuda.empty_cache()
-            with torch.cuda.use_mem_pool(pool):
-                prefix = torch.empty(4096, dtype=torch.uint8, device="cuda")
-                t = torch.empty(4096, dtype=torch.uint8, device="cuda")
-                suffix = torch.empty(4096, dtype=torch.uint8, device="cuda")
-
-            original_ptr = t.untyped_storage().data_ptr()
-            original_size = t.untyped_storage().nbytes()
-            prefix.untyped_storage().resize_(0)
-            t.untyped_storage().resize_(0)
-            suffix.untyped_storage().resize_(0)
-
-            with torch.cuda.use_mem_pool(pool):
-                t.untyped_storage()._resize_with_addr_(original_size, original_ptr)
-
-            self.assertEqual(t.untyped_storage().data_ptr(), original_ptr)
-        finally:
-            torch.cuda.empty_cache()
-            torch.cuda.memory._set_allocator_settings("")
-
 
 @unittest.skipIf(not TEST_CUDA, "CUDA not available, skipping tests")
 @torch.testing._internal.common_utils.markDynamoStrictTest

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -4887,7 +4887,7 @@ class TestResizeStorageWithAddr(TestCase):
     )
     def test_resize_storage_with_size_zero_ignores_addr(self):
         t = torch.empty(4096, dtype=torch.uint8, device="cuda")
-        t.untyped_storage()._resize_with_addr_(0, 1)
+        t.untyped_storage()._resize_with_addr_(0, 0)
         self.assertEqual(t.untyped_storage().nbytes(), 0)
 
     @unittest.skipIf(

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -4734,7 +4734,7 @@ class TestResizeStorageHint(TestCase):
         t.untyped_storage().resize_(0)
         self.assertEqual(t.untyped_storage().nbytes(), 0)
 
-        t.untyped_storage().resize_(original_size)
+        t.untyped_storage().resize_(original_size, original_ptr)
         self.assertEqual(t.untyped_storage().data_ptr(), original_ptr)
 
     @unittest.skipIf(
@@ -4751,7 +4751,7 @@ class TestResizeStorageHint(TestCase):
         # Allocate another tensor that may consume the freed block
         blocker = torch.randn(1024, device="cuda")
 
-        t.untyped_storage().resize_(original_size)
+        t.untyped_storage().resize_(original_size, original_ptr)
         # The hint may or may not succeed depending on whether blocker
         # consumed the exact block -- either way, no crash.
         self.assertEqual(t.untyped_storage().nbytes(), original_size)
@@ -4761,14 +4761,13 @@ class TestResizeStorageHint(TestCase):
         TEST_CUDAMALLOCASYNC,
         "CUDAMallocAsync does not use the caching allocator hint path",
     )
-    def test_resize_storage_hint_different_size(self):
+    def test_resize_storage_hint_no_hint(self):
         t = torch.randn(1024, device="cuda")
-        original_ptr = t.untyped_storage().data_ptr()
         original_size = t.untyped_storage().nbytes()
 
         t.untyped_storage().resize_(0)
 
-        # Resize to a different size -- hint should be discarded
+        # Resize without hint -- should work like normal allocation
         new_size = original_size * 2
         t.untyped_storage().resize_(new_size)
         self.assertEqual(t.untyped_storage().nbytes(), new_size)
@@ -4779,14 +4778,14 @@ class TestResizeStorageHint(TestCase):
     )
     def test_resize_storage_hint_inductor_path(self):
         t = torch.randn(1024, device="cuda")
-        original_ptr = t.untyped_storage().data_ptr()
         original_size = t.untyped_storage().nbytes()
 
         torch.ops.inductor.resize_storage_bytes_(t, 0)
         self.assertEqual(t.untyped_storage().nbytes(), 0)
 
         torch.ops.inductor.resize_storage_bytes_(t, original_size)
-        self.assertEqual(t.untyped_storage().data_ptr(), original_ptr)
+        self.assertEqual(t.untyped_storage().nbytes(), original_size)
+        # TODO: Decide if we want to support inductor case.
 
     @unittest.skipIf(
         TEST_CUDAMALLOCASYNC,
@@ -4804,7 +4803,7 @@ class TestResizeStorageHint(TestCase):
             t.untyped_storage().resize_(0)
             self.assertEqual(t.untyped_storage().nbytes(), 0)
 
-            t.untyped_storage().resize_(original_size)
+            t.untyped_storage().resize_(original_size, original_ptr)
             # With expandable segments the hint is best-effort; the block
             # may have been merged or unmapped.  Just verify no crash and
             # correct size.
@@ -4813,6 +4812,37 @@ class TestResizeStorageHint(TestCase):
             del t
             torch.cuda.empty_cache()
             torch.cuda.memory._set_allocator_settings("")
+
+    @unittest.skipIf(
+        TEST_CUDAMALLOCASYNC,
+        "CUDAMallocAsync does not use the caching allocator hint path",
+    )
+    def test_resize_split_block(self):
+        pool = torch.cuda.MemPool()
+
+        # Allocate two tensors in private pool and t is the second tensor
+        with torch.cuda.use_mem_pool(pool):
+            blocker = torch.randn(1024, device="cuda")
+            t = torch.randn(1024, device="cuda")
+
+        original_ptr = t.untyped_storage().data_ptr()
+        original_size = t.untyped_storage().nbytes()
+
+        # delete blocker and t such that the two blocks have been merged
+        # in CUDACachingAllocator.
+        t.untyped_storage().resize_(0)
+        blocker.untyped_storage().resize_(0)
+
+        # Reallocate t at the original ptr in mempool.
+        with torch.cuda.use_mem_pool(pool):
+            t.untyped_storage().resize_(original_size, original_ptr)
+
+        self.assertEqual(t.untyped_storage().nbytes(), original_size)
+        self.assertEqual(t.untyped_storage().data_ptr(), original_ptr)
+
+        del blocker
+        del t
+        del pool
 
 
 @unittest.skipIf(not TEST_CUDA, "CUDA not available, skipping tests")

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -4749,6 +4749,8 @@ class TestResizeStorageWithAddr(TestCase):
         t.untyped_storage().resize_(0)
         other.untyped_storage().resize_(0)
 
+        # `resize_(0)` does not record mempool information. We still need `use_mem_pool`
+        # when resizing it back.
         with torch.cuda.use_mem_pool(pool):
             t.untyped_storage()._resize_with_addr_(original_size, original_ptr)
             other = torch.empty(294, dtype=torch.uint8, device="cuda")
@@ -4794,7 +4796,12 @@ class TestResizeStorageWithAddr(TestCase):
 
         with torch.cuda.use_mem_pool(pool):
             t.untyped_storage()._resize_with_addr_(original_size, original_ptr)
+            self.assertEqual(t.untyped_storage().data_ptr(), original_ptr)
 
+        # when `original_ptr` is in the middle of an empty block, `_resize_with_addr_`
+        # should still allocate a tensor with exactly `original_size` at `original_ptr`.
+        # It should also keep prefix and suffix blocks inactive. These assertions
+        # check that the block state matches expectations.
         blocks, idx = self._find_pool_block(pool, original_ptr)
         self.assertGreater(idx, 0)
         self.assertLess(idx + 1, len(blocks))
@@ -4850,6 +4857,8 @@ class TestResizeStorageWithAddr(TestCase):
         with torch.cuda.use_mem_pool(pool):
             storage._resize_with_addr_(original_size, original_ptr)
 
+        # This test mimics a state offloading pattern where we offload a large
+        # tensor and keep many small tensors as slices of the large tensor.
         self.assertEqual(base.untyped_storage().data_ptr(), original_ptr)
         self.assertEqual(view1.untyped_storage().data_ptr(), original_ptr)
         self.assertEqual(view2.untyped_storage().data_ptr(), original_ptr)
@@ -4857,6 +4866,10 @@ class TestResizeStorageWithAddr(TestCase):
         self.assertEqual(view1.untyped_storage().nbytes(), original_size)
         self.assertEqual(view2.untyped_storage().nbytes(), original_size)
 
+    @unittest.skipIf(
+        TEST_CUDAMALLOCASYNC,
+        "CUDAMallocAsync does not support exact-address allocation",
+    )
     def test_resize_storage_with_addr_requires_zero_sized_source(self):
         pool = torch.cuda.MemPool()
         with torch.cuda.use_mem_pool(pool):
@@ -4869,6 +4882,10 @@ class TestResizeStorageWithAddr(TestCase):
             with torch.cuda.use_mem_pool(pool):
                 t.untyped_storage()._resize_with_addr_(original_size, original_ptr)
 
+    @unittest.skipIf(
+        TEST_CUDAMALLOCASYNC,
+        "CUDAMallocAsync does not support exact-address allocation",
+    )
     def test_resize_storage_with_size_zero_ignores_addr(self):
         t = torch.empty(4096, dtype=torch.uint8, device="cuda")
         t.untyped_storage()._resize_with_addr_(0, 1)

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -4776,21 +4776,6 @@ class TestResizeStorageHint(TestCase):
         TEST_CUDAMALLOCASYNC,
         "CUDAMallocAsync does not use the caching allocator hint path",
     )
-    def test_resize_storage_hint_inductor_path(self):
-        t = torch.randn(1024, device="cuda")
-        original_size = t.untyped_storage().nbytes()
-
-        torch.ops.inductor.resize_storage_bytes_(t, 0)
-        self.assertEqual(t.untyped_storage().nbytes(), 0)
-
-        torch.ops.inductor.resize_storage_bytes_(t, original_size)
-        self.assertEqual(t.untyped_storage().nbytes(), original_size)
-        # TODO: Decide if we want to support inductor case.
-
-    @unittest.skipIf(
-        TEST_CUDAMALLOCASYNC,
-        "CUDAMallocAsync does not use the caching allocator hint path",
-    )
     @skipIfRocm(msg="expandable_segments mode is not supported on ROCm")
     def test_resize_storage_hint_expandable_segments(self):
         torch.cuda.empty_cache()

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -4821,18 +4821,17 @@ class TestResizeStorageWithAddr(TestCase):
         TEST_CUDAMALLOCASYNC,
         "CUDAMallocAsync does not support exact-address allocation",
     )
-    def test_resize_storage_with_addr_out_of_pool_errors(self):
+    def test_resize_storage_with_addr_misaligned_address_errors(self):
         pool = torch.cuda.MemPool()
         with torch.cuda.use_mem_pool(pool):
             t = torch.empty(4096, dtype=torch.uint8, device="cuda")
 
         original_ptr = t.untyped_storage().data_ptr()
-        original_size = t.untyped_storage().nbytes()
         t.untyped_storage().resize_(0)
 
-        with self.assertRaisesRegex(RuntimeError, "exact address"):
+        with self.assertRaisesRegex(RuntimeError, "aligned to kMinBlockSize"):
             with torch.cuda.use_mem_pool(pool):
-                t.untyped_storage()._resize_with_addr_(original_size, original_ptr - 1)
+                t.untyped_storage()._resize_with_addr_(2048, original_ptr + 1)
 
     @unittest.skipIf(
         TEST_CUDAMALLOCASYNC,

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -4874,6 +4874,7 @@ class TestResizeStorageWithAddr(TestCase):
         t.untyped_storage()._resize_with_addr_(0, 1)
         self.assertEqual(t.untyped_storage().nbytes(), 0)
 
+
 @unittest.skipIf(not TEST_CUDA, "CUDA not available, skipping tests")
 @torch.testing._internal.common_utils.markDynamoStrictTest
 class TestCudaAllocator(TestCase):

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -4844,6 +4844,43 @@ class TestResizeStorageHint(TestCase):
         del t
         del pool
 
+    @unittest.skipIf(
+        TEST_CUDAMALLOCASYNC,
+        "CUDAMallocAsync does not use the caching allocator hint path",
+    )
+    @skipIfRocm(msg="expandable_segments mode is not supported on ROCm")
+    def test_resize_storage_hint_expandable_segments_with_split_block(self):
+        torch.cuda.empty_cache()
+        torch.cuda.memory._set_allocator_settings("expandable_segments:True")
+        try:
+            pool = torch.cuda.MemPool()
+
+            # Allocate two tensors in private pool and t is the second tensor
+            with torch.cuda.use_mem_pool(pool):
+                blocker = torch.randn(1024, device="cuda")
+                t = torch.randn(1024, device="cuda")
+
+            original_ptr = t.untyped_storage().data_ptr()
+            original_size = t.untyped_storage().nbytes()
+
+            # delete blocker and t such that the two blocks have been merged
+            # in CUDACachingAllocator.
+            t.untyped_storage().resize_(0)
+            blocker.untyped_storage().resize_(0)
+
+            # Reallocate t at the original ptr in mempool.
+            with torch.cuda.use_mem_pool(pool):
+                t.untyped_storage().resize_(original_size, original_ptr)
+
+            self.assertEqual(t.untyped_storage().nbytes(), original_size)
+            self.assertEqual(t.untyped_storage().data_ptr(), original_ptr)
+        finally:
+            del blocker
+            del t
+            del pool
+            torch.cuda.empty_cache()
+            torch.cuda.memory._set_allocator_settings("")
+
 
 @unittest.skipIf(not TEST_CUDA, "CUDA not available, skipping tests")
 @torch.testing._internal.common_utils.markDynamoStrictTest

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -4718,6 +4718,103 @@ print(ret)
         self.assertEqual(r, "1.0")
 
 
+class TestResizeStorageHint(TestCase):
+    _do_cuda_memory_leak_check = True
+    _do_cuda_non_default_stream = True
+
+    @unittest.skipIf(
+        TEST_CUDAMALLOCASYNC,
+        "CUDAMallocAsync does not use the caching allocator hint path",
+    )
+    def test_resize_storage_hint_basic(self):
+        t = torch.randn(1024, device="cuda")
+        original_ptr = t.untyped_storage().data_ptr()
+        original_size = t.untyped_storage().nbytes()
+
+        t.untyped_storage().resize_(0)
+        self.assertEqual(t.untyped_storage().nbytes(), 0)
+
+        t.untyped_storage().resize_(original_size)
+        self.assertEqual(t.untyped_storage().data_ptr(), original_ptr)
+
+    @unittest.skipIf(
+        TEST_CUDAMALLOCASYNC,
+        "CUDAMallocAsync does not use the caching allocator hint path",
+    )
+    def test_resize_storage_hint_consumed(self):
+        t = torch.randn(1024, device="cuda")
+        original_ptr = t.untyped_storage().data_ptr()
+        original_size = t.untyped_storage().nbytes()
+
+        t.untyped_storage().resize_(0)
+
+        # Allocate another tensor that may consume the freed block
+        blocker = torch.randn(1024, device="cuda")
+
+        t.untyped_storage().resize_(original_size)
+        # The hint may or may not succeed depending on whether blocker
+        # consumed the exact block -- either way, no crash.
+        self.assertEqual(t.untyped_storage().nbytes(), original_size)
+        del blocker
+
+    @unittest.skipIf(
+        TEST_CUDAMALLOCASYNC,
+        "CUDAMallocAsync does not use the caching allocator hint path",
+    )
+    def test_resize_storage_hint_different_size(self):
+        t = torch.randn(1024, device="cuda")
+        original_ptr = t.untyped_storage().data_ptr()
+        original_size = t.untyped_storage().nbytes()
+
+        t.untyped_storage().resize_(0)
+
+        # Resize to a different size -- hint should be discarded
+        new_size = original_size * 2
+        t.untyped_storage().resize_(new_size)
+        self.assertEqual(t.untyped_storage().nbytes(), new_size)
+
+    @unittest.skipIf(
+        TEST_CUDAMALLOCASYNC,
+        "CUDAMallocAsync does not use the caching allocator hint path",
+    )
+    def test_resize_storage_hint_inductor_path(self):
+        t = torch.randn(1024, device="cuda")
+        original_ptr = t.untyped_storage().data_ptr()
+        original_size = t.untyped_storage().nbytes()
+
+        torch.ops.inductor.resize_storage_bytes_(t, 0)
+        self.assertEqual(t.untyped_storage().nbytes(), 0)
+
+        torch.ops.inductor.resize_storage_bytes_(t, original_size)
+        self.assertEqual(t.untyped_storage().data_ptr(), original_ptr)
+
+    @unittest.skipIf(
+        TEST_CUDAMALLOCASYNC,
+        "CUDAMallocAsync does not use the caching allocator hint path",
+    )
+    @skipIfRocm(msg="expandable_segments mode is not supported on ROCm")
+    def test_resize_storage_hint_expandable_segments(self):
+        torch.cuda.empty_cache()
+        torch.cuda.memory._set_allocator_settings("expandable_segments:True")
+        try:
+            t = torch.randn(1024, device="cuda")
+            original_ptr = t.untyped_storage().data_ptr()
+            original_size = t.untyped_storage().nbytes()
+
+            t.untyped_storage().resize_(0)
+            self.assertEqual(t.untyped_storage().nbytes(), 0)
+
+            t.untyped_storage().resize_(original_size)
+            # With expandable segments the hint is best-effort; the block
+            # may have been merged or unmapped.  Just verify no crash and
+            # correct size.
+            self.assertEqual(t.untyped_storage().nbytes(), original_size)
+        finally:
+            del t
+            torch.cuda.empty_cache()
+            torch.cuda.memory._set_allocator_settings("")
+
+
 @unittest.skipIf(not TEST_CUDA, "CUDA not available, skipping tests")
 @torch.testing._internal.common_utils.markDynamoStrictTest
 class TestCudaAllocator(TestCase):

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -4891,6 +4891,85 @@ class TestResizeStorageWithAddr(TestCase):
         t.untyped_storage()._resize_with_addr_(0, 1)
         self.assertEqual(t.untyped_storage().nbytes(), 0)
 
+    @unittest.skipIf(
+        TEST_CUDAMALLOCASYNC,
+        "CUDAMallocAsync does not support exact-address allocation",
+    )
+    def test_resize_storage_with_multiple_blocks_in_the_middle(self):
+        # Test allocating multiple target tensors in the middle of an empty memory segment
+        pool = torch.cuda.MemPool()
+
+        targets = []
+        dummys = []
+        with torch.cuda.use_mem_pool(pool):
+            for _ in range(10):
+                dummy = torch.empty(3729, dtype=torch.uint8, device="cuda")
+                target = torch.empty(4017, dtype=torch.uint8, device="cuda")
+                targets.append(target)
+                dummys.append(dummy)
+
+        original_ptrs = [t.untyped_storage().data_ptr() for t in targets]
+        original_sizes = [t.untyped_storage().nbytes() for t in targets]
+
+        for t, d in zip(targets, dummys):
+            t.untyped_storage().resize_(0)
+            d.untyped_storage().resize_(0)
+
+        with torch.cuda.use_mem_pool(pool):
+            for i in range(10):
+                ptr = original_ptrs[i]
+                size = original_sizes[i]
+                targets[i].untyped_storage()._resize_with_addr_(size, ptr)
+
+        for i in range(10):
+            ptr = original_ptrs[i]
+            size = original_sizes[i]
+            t = targets[i]
+            self.assertEqual(t.untyped_storage().data_ptr(), ptr)
+            self.assertEqual(t.untyped_storage().nbytes(), size)
+
+    @unittest.skipIf(
+        TEST_CUDAMALLOCASYNC,
+        "CUDAMallocAsync does not support exact-address allocation",
+    )
+    def test_resize_storage_with_coalesced_small_prefixes(self):
+        # Suppose we have allocated many small prefix tensors and a target tensor, where
+        # all tensors falls into the small block pool. When resize the target tensor later,
+        # we allocate 1 large prefix tensors for all small prefix tensors, then allocate
+        # the target tensor, and finally free the large prefix tensor. This large prefix
+        # tensor should come from the small block pool, even if its size is beyond the threshold.
+        pool = torch.cuda.MemPool()
+        with torch.cuda.use_mem_pool(pool):
+            small_prefixes = []
+            for _ in range(800):
+                prefix = torch.empty(3729, dtype=torch.uint8, device="cuda")
+                small_prefixes.append(prefix)
+            t1 = torch.empty(4017, dtype=torch.uint8, device="cuda")
+            mid = torch.empty(2738, dtype=torch.uint8, device="cuda")
+            t2 = torch.empty(3897, dtype=torch.uint8, device="cuda")
+            suffix = torch.empty(9124, dtype=torch.uint8, device="cuda")
+
+        original_ptr1 = t1.untyped_storage().data_ptr()
+        original_size1 = t1.untyped_storage().nbytes()
+        original_ptr2 = t2.untyped_storage().data_ptr()
+        original_size2 = t2.untyped_storage().nbytes()
+
+        for prefix in small_prefixes:
+            prefix.untyped_storage().resize_(0)
+        mid.untyped_storage().resize_(0)
+        suffix.untyped_storage().resize_(0)
+        t1.untyped_storage().resize_(0)
+        t2.untyped_storage().resize_(0)
+
+        with torch.cuda.use_mem_pool(pool):
+            t1.untyped_storage()._resize_with_addr_(original_size1, original_ptr1)
+            t2.untyped_storage()._resize_with_addr_(original_size2, original_ptr2)
+
+        self.assertEqual(t1.untyped_storage().data_ptr(), original_ptr1)
+        self.assertEqual(t1.untyped_storage().nbytes(), original_size1)
+        self.assertEqual(t2.untyped_storage().data_ptr(), original_ptr2)
+        self.assertEqual(t2.untyped_storage().nbytes(), original_size2)
+
 
 @unittest.skipIf(not TEST_CUDA, "CUDA not available, skipping tests")
 @torch.testing._internal.common_utils.markDynamoStrictTest

--- a/test/test_cuda_expandable_segments.py
+++ b/test/test_cuda_expandable_segments.py
@@ -23,6 +23,7 @@ from test_cuda import (  # noqa: F401
     TestCuda,
     TestCudaAllocator,
     TestMemPool,
+    TestResizeStorageWithAddr,
 )
 
 import torch

--- a/torch/csrc/StorageMethods.cpp
+++ b/torch/csrc/StorageMethods.cpp
@@ -29,8 +29,7 @@
 
 #ifdef USE_CUDA
 #include <ATen/native/cuda/Resize.h>
-#include <c10/cuda/CUDACachingAllocator.h>
-#include <c10/cuda/CUDAGuard.h>
+#include <cuda_runtime.h>
 #endif
 
 #include <ATen/detail/PrivateUse1HooksInterface.h>
@@ -40,47 +39,6 @@
 #define LSEEK _lseeki64
 #else
 #define LSEEK lseek
-#endif
-
-#ifdef USE_CUDA
-namespace {
-
-void resize_storage_cuda_with_addr(
-    const at::Storage& storage,
-    size_t size_bytes,
-    void* addr) {
-  if (size_bytes == 0) {
-    at::native::resize_bytes_cuda(storage.unsafeGetStorageImpl(), 0);
-    return;
-  }
-
-  auto* storage_impl = storage.unsafeGetStorageImpl();
-  TORCH_CHECK(
-      storage_impl->resizable(),
-      "Trying to resize storage that is not resizable");
-  auto allocator = storage_impl->allocator();
-  TORCH_CHECK(
-      allocator != nullptr, "Trying to resize storage without an allocator");
-  TORCH_CHECK(
-      storage.nbytes() == 0,
-      "_resize_with_addr_ only supports resizing a zero-sized CUDA storage to a non-zero size, but got current size ",
-      storage.nbytes(),
-      " bytes");
-  TORCH_CHECK(
-      addr != nullptr,
-      "_resize_with_addr_ expects a non-null addr when size is non-zero");
-  TORCH_CHECK(
-      allocator == c10::cuda::CUDACachingAllocator::get(),
-      "_resize_with_addr_ only supports storages allocated by the current CUDA caching allocator");
-
-  c10::cuda::CUDAGuard guard(storage.device().index());
-  auto data = c10::cuda::CUDACachingAllocator::allocateWithAddress(
-      size_bytes, addr);
-  storage_impl->set_data_ptr_noswap(std::move(data));
-  storage_impl->set_nbytes(size_bytes);
-}
-
-} // namespace
 #endif
 
 static PyObject* THPStorage_nbytes(PyObject* self, PyObject* noargs) {
@@ -247,7 +205,8 @@ static PyObject* THPStorage_resize_with_addr_(PyObject* self, PyObject* args) {
         size_bytes_i,
         ") cannot be represented as a size_t");
     const auto size_bytes = static_cast<size_t>(size_bytes_i);
-    resize_storage_cuda_with_addr(storage, size_bytes, addr);
+    at::native::resize_bytes_cuda_with_addr(
+        storage.unsafeGetStorageImpl(), size_bytes, addr);
 #else
     TORCH_CHECK(false, "built without USE_CUDA");
 #endif

--- a/torch/csrc/StorageMethods.cpp
+++ b/torch/csrc/StorageMethods.cpp
@@ -128,7 +128,7 @@ static PyObject* THPStorage_new(PyObject* self, PyObject* noargs) {
   END_HANDLE_TH_ERRORS
 }
 
-static PyObject* THPStorage_resize_(PyObject* self, PyObject* number_arg) {
+static PyObject* THPStorage_resize_(PyObject* self, PyObject* args) {
   HANDLE_TH_ERRORS
   THPStorage_assertNotNull(self);
   const auto& storage = THPStorage_Unpack(self);
@@ -138,12 +138,28 @@ static PyObject* THPStorage_resize_(PyObject* self, PyObject* number_arg) {
       storage.sym_nbytes() != 0;
   TORCH_CHECK(
       !invalid, "Attempted to call resize_() on an invalid python storage.")
+  Py_ssize_t nargs = PyTuple_GET_SIZE(args);
+  TORCH_CHECK(
+      nargs >= 1 && nargs <= 2,
+      "resize_ expects 1 or 2 arguments, got ",
+      nargs);
+  PyObject* number_arg = PyTuple_GET_ITEM(args, 0);
   TORCH_CHECK(
       THPUtils_checkLong(number_arg),
       "resize_ expects an int, "
       "but got ",
       THPUtils_typename(number_arg));
   int64_t newsize = THPUtils_unpackLong(number_arg);
+  void* hint = nullptr;
+  if (nargs == 2) {
+    PyObject* hint_arg = PyTuple_GET_ITEM(args, 1);
+    TORCH_CHECK(
+        THPUtils_checkLong(hint_arg),
+        "resize_ hint_addr expects an int, "
+        "but got ",
+        THPUtils_typename(hint_arg));
+    hint = reinterpret_cast<void*>(THPUtils_unpackLong(hint_arg));
+  }
   c10::DeviceType device_type = storage.device_type();
   if (device_type == at::kCUDA) {
 #ifdef USE_CUDA
@@ -154,7 +170,8 @@ static PyObject* THPStorage_resize_(PyObject* self, PyObject* number_arg) {
         size_bytes_i,
         ") cannot be represented as a size_t");
     const auto size_bytes = static_cast<size_t>(size_bytes_i);
-    at::native::resize_bytes_cuda(storage.unsafeGetStorageImpl(), size_bytes);
+    at::native::resize_bytes_cuda(
+        storage.unsafeGetStorageImpl(), size_bytes, hint);
 #else
     TORCH_CHECK(false, "built without USE_CUDA");
 #endif
@@ -637,7 +654,7 @@ static PyMethodDef THPStorage_methods[] = {
     {"element_size", THPStorage_elementSize, METH_NOARGS, nullptr},
     {"fill_", THPStorage_fill_, METH_O, nullptr},
     {"new", THPStorage_new, METH_NOARGS, nullptr},
-    {"resize_", THPStorage_resize_, METH_O, nullptr},
+    {"resize_", THPStorage_resize_, METH_VARARGS, nullptr},
     {"nbytes", THPStorage_nbytes, METH_NOARGS, nullptr},
     {"data_ptr", THPStorage_dataPtr, METH_NOARGS, nullptr},
     {"resizable", THPStorage_resizable, METH_NOARGS, nullptr},

--- a/torch/csrc/StorageMethods.cpp
+++ b/torch/csrc/StorageMethods.cpp
@@ -185,10 +185,10 @@ static PyObject* THPStorage_resize_with_addr_(PyObject* self, PyObject* args) {
       "_resize_with_addr_ expects an int size, "
       "but got ",
       THPUtils_typename(number_arg));
-  int64_t newsize = THPUtils_unpackLong(number_arg);
   c10::DeviceType device_type = storage.device_type();
   if (device_type == at::kCUDA) {
 #ifdef USE_CUDA
+    int64_t newsize = THPUtils_unpackLong(number_arg);
     PyObject* addr_arg = PyTuple_GET_ITEM(args, 1);
     TORCH_CHECK(
         THPUtils_checkLong(addr_arg),

--- a/torch/csrc/StorageMethods.cpp
+++ b/torch/csrc/StorageMethods.cpp
@@ -150,19 +150,19 @@ static PyObject* THPStorage_resize_(PyObject* self, PyObject* args) {
       "but got ",
       THPUtils_typename(number_arg));
   int64_t newsize = THPUtils_unpackLong(number_arg);
-  void* hint = nullptr;
-  if (nargs == 2) {
-    PyObject* hint_arg = PyTuple_GET_ITEM(args, 1);
-    TORCH_CHECK(
-        THPUtils_checkLong(hint_arg),
-        "resize_ hint_addr expects an int, "
-        "but got ",
-        THPUtils_typename(hint_arg));
-    hint = reinterpret_cast<void*>(THPUtils_unpackLong(hint_arg));
-  }
   c10::DeviceType device_type = storage.device_type();
   if (device_type == at::kCUDA) {
 #ifdef USE_CUDA
+    void* hint = nullptr;
+    if (nargs == 2) {
+      PyObject* hint_arg = PyTuple_GET_ITEM(args, 1);
+      TORCH_CHECK(
+          THPUtils_checkLong(hint_arg),
+          "resize_ hint_addr expects an int, "
+          "but got ",
+          THPUtils_typename(hint_arg));
+      hint = reinterpret_cast<void*>(THPUtils_unpackLong(hint_arg));
+    }
     ptrdiff_t size_bytes_i = newsize;
     TORCH_CHECK(
         !c10::overflows<size_t>(size_bytes_i),

--- a/torch/csrc/StorageMethods.cpp
+++ b/torch/csrc/StorageMethods.cpp
@@ -29,7 +29,8 @@
 
 #ifdef USE_CUDA
 #include <ATen/native/cuda/Resize.h>
-#include <cuda_runtime.h>
+#include <c10/cuda/CUDACachingAllocator.h>
+#include <c10/cuda/CUDAGuard.h>
 #endif
 
 #include <ATen/detail/PrivateUse1HooksInterface.h>
@@ -39,6 +40,47 @@
 #define LSEEK _lseeki64
 #else
 #define LSEEK lseek
+#endif
+
+#ifdef USE_CUDA
+namespace {
+
+void resize_storage_cuda_with_addr(
+    const at::Storage& storage,
+    size_t size_bytes,
+    void* addr) {
+  if (size_bytes == 0) {
+    at::native::resize_bytes_cuda(storage.unsafeGetStorageImpl(), 0);
+    return;
+  }
+
+  auto* storage_impl = storage.unsafeGetStorageImpl();
+  TORCH_CHECK(
+      storage_impl->resizable(),
+      "Trying to resize storage that is not resizable");
+  auto allocator = storage_impl->allocator();
+  TORCH_CHECK(
+      allocator != nullptr, "Trying to resize storage without an allocator");
+  TORCH_CHECK(
+      storage.nbytes() == 0,
+      "_resize_with_addr_ only supports resizing a zero-sized CUDA storage to a non-zero size, but got current size ",
+      storage.nbytes(),
+      " bytes");
+  TORCH_CHECK(
+      addr != nullptr,
+      "_resize_with_addr_ expects a non-null addr when size is non-zero");
+  TORCH_CHECK(
+      allocator == c10::cuda::CUDACachingAllocator::get(),
+      "_resize_with_addr_ only supports storages allocated by the current CUDA caching allocator");
+
+  c10::cuda::CUDAGuard guard(storage.device().index());
+  auto data = c10::cuda::CUDACachingAllocator::allocateWithAddress(
+      size_bytes, addr);
+  storage_impl->set_data_ptr_noswap(std::move(data));
+  storage_impl->set_nbytes(size_bytes);
+}
+
+} // namespace
 #endif
 
 static PyObject* THPStorage_nbytes(PyObject* self, PyObject* noargs) {
@@ -128,7 +170,7 @@ static PyObject* THPStorage_new(PyObject* self, PyObject* noargs) {
   END_HANDLE_TH_ERRORS
 }
 
-static PyObject* THPStorage_resize_(PyObject* self, PyObject* args) {
+static PyObject* THPStorage_resize_(PyObject* self, PyObject* number_arg) {
   HANDLE_TH_ERRORS
   THPStorage_assertNotNull(self);
   const auto& storage = THPStorage_Unpack(self);
@@ -138,12 +180,6 @@ static PyObject* THPStorage_resize_(PyObject* self, PyObject* args) {
       storage.sym_nbytes() != 0;
   TORCH_CHECK(
       !invalid, "Attempted to call resize_() on an invalid python storage.")
-  Py_ssize_t nargs = PyTuple_GET_SIZE(args);
-  TORCH_CHECK(
-      nargs >= 1 && nargs <= 2,
-      "resize_ expects 1 or 2 arguments, got ",
-      nargs);
-  PyObject* number_arg = PyTuple_GET_ITEM(args, 0);
   TORCH_CHECK(
       THPUtils_checkLong(number_arg),
       "resize_ expects an int, "
@@ -153,16 +189,6 @@ static PyObject* THPStorage_resize_(PyObject* self, PyObject* args) {
   c10::DeviceType device_type = storage.device_type();
   if (device_type == at::kCUDA) {
 #ifdef USE_CUDA
-    void* hint = nullptr;
-    if (nargs == 2) {
-      PyObject* hint_arg = PyTuple_GET_ITEM(args, 1);
-      TORCH_CHECK(
-          THPUtils_checkLong(hint_arg),
-          "resize_ hint_addr expects an int, "
-          "but got ",
-          THPUtils_typename(hint_arg));
-      hint = reinterpret_cast<void*>(THPUtils_unpackLong(hint_arg));
-    }
     ptrdiff_t size_bytes_i = newsize;
     TORCH_CHECK(
         !c10::overflows<size_t>(size_bytes_i),
@@ -170,8 +196,7 @@ static PyObject* THPStorage_resize_(PyObject* self, PyObject* args) {
         size_bytes_i,
         ") cannot be represented as a size_t");
     const auto size_bytes = static_cast<size_t>(size_bytes_i);
-    at::native::resize_bytes_cuda(
-        storage.unsafeGetStorageImpl(), size_bytes, hint);
+    at::native::resize_bytes_cuda(storage.unsafeGetStorageImpl(), size_bytes);
 #else
     TORCH_CHECK(false, "built without USE_CUDA");
 #endif
@@ -179,6 +204,61 @@ static PyObject* THPStorage_resize_(PyObject* self, PyObject* args) {
     at::native::resize_bytes_nocuda(storage, newsize);
   }
   return Py_NewRef(self);
+  END_HANDLE_TH_ERRORS
+}
+
+static PyObject* THPStorage_resize_with_addr_(PyObject* self, PyObject* args) {
+  HANDLE_TH_ERRORS
+  THPStorage_assertNotNull(self);
+  const auto& storage = THPStorage_Unpack(self);
+  // See Note [Invalid Python Storages]
+  auto invalid = storage.data() == nullptr &&
+      storage.device_type() != c10::DeviceType::Meta &&
+      storage.sym_nbytes() != 0;
+  TORCH_CHECK(
+      !invalid,
+      "Attempted to call _resize_with_addr_() on an invalid python storage.")
+  Py_ssize_t nargs = PyTuple_GET_SIZE(args);
+  TORCH_CHECK(
+      nargs == 2,
+      "_resize_with_addr_ expects 2 arguments, got ",
+      nargs);
+  PyObject* number_arg = PyTuple_GET_ITEM(args, 0);
+  TORCH_CHECK(
+      THPUtils_checkLong(number_arg),
+      "_resize_with_addr_ expects an int size, "
+      "but got ",
+      THPUtils_typename(number_arg));
+  int64_t newsize = THPUtils_unpackLong(number_arg);
+  c10::DeviceType device_type = storage.device_type();
+  if (device_type == at::kCUDA) {
+#ifdef USE_CUDA
+    PyObject* addr_arg = PyTuple_GET_ITEM(args, 1);
+    TORCH_CHECK(
+        THPUtils_checkLong(addr_arg),
+        "_resize_with_addr_ expects an int addr, "
+        "but got ",
+        THPUtils_typename(addr_arg));
+    void* addr = reinterpret_cast<void*>(THPUtils_unpackLong(addr_arg));
+    ptrdiff_t size_bytes_i = newsize;
+    TORCH_CHECK(
+        !c10::overflows<size_t>(size_bytes_i),
+        "Requested storage size (",
+        size_bytes_i,
+        ") cannot be represented as a size_t");
+    const auto size_bytes = static_cast<size_t>(size_bytes_i);
+    resize_storage_cuda_with_addr(storage, size_bytes, addr);
+#else
+    TORCH_CHECK(false, "built without USE_CUDA");
+#endif
+  } else {
+    TORCH_CHECK(
+        false,
+        "_resize_with_addr_ is only supported on CUDA storage, got ",
+        storage.device_type());
+  }
+  Py_INCREF(self);
+  return self;
   END_HANDLE_TH_ERRORS
 }
 
@@ -654,7 +734,8 @@ static PyMethodDef THPStorage_methods[] = {
     {"element_size", THPStorage_elementSize, METH_NOARGS, nullptr},
     {"fill_", THPStorage_fill_, METH_O, nullptr},
     {"new", THPStorage_new, METH_NOARGS, nullptr},
-    {"resize_", THPStorage_resize_, METH_VARARGS, nullptr},
+    {"resize_", THPStorage_resize_, METH_O, nullptr},
+    {"_resize_with_addr_", THPStorage_resize_with_addr_, METH_VARARGS, nullptr},
     {"nbytes", THPStorage_nbytes, METH_NOARGS, nullptr},
     {"data_ptr", THPStorage_dataPtr, METH_NOARGS, nullptr},
     {"resizable", THPStorage_resizable, METH_NOARGS, nullptr},

--- a/torch/csrc/StorageMethods.cpp
+++ b/torch/csrc/StorageMethods.cpp
@@ -178,9 +178,7 @@ static PyObject* THPStorage_resize_with_addr_(PyObject* self, PyObject* args) {
       "Attempted to call _resize_with_addr_() on an invalid python storage.")
   Py_ssize_t nargs = PyTuple_GET_SIZE(args);
   TORCH_CHECK(
-      nargs == 2,
-      "_resize_with_addr_ expects 2 arguments, got ",
-      nargs);
+      nargs == 2, "_resize_with_addr_ expects 2 arguments, got ", nargs);
   PyObject* number_arg = PyTuple_GET_ITEM(args, 0);
   TORCH_CHECK(
       THPUtils_checkLong(number_arg),

--- a/torch/csrc/StorageMethods.cpp
+++ b/torch/csrc/StorageMethods.cpp
@@ -195,7 +195,10 @@ static PyObject* THPStorage_resize_with_addr_(PyObject* self, PyObject* args) {
         "_resize_with_addr_ expects an int addr, "
         "but got ",
         THPUtils_typename(addr_arg));
-    void* addr = reinterpret_cast<void*>(THPUtils_unpackLong(addr_arg));
+    void* addr = PyLong_AsVoidPtr(addr_arg);
+    if (addr == nullptr && PyErr_Occurred()) {
+      throw python_error();
+    }
     ptrdiff_t size_bytes_i = newsize;
     TORCH_CHECK(
         !c10::overflows<size_t>(size_bytes_i),


### PR DESCRIPTION
This PR adds a new API to allocate untyped storage at a user-specified address and size, assuming that the memory is mapped but inactive:

```python
x.untyped_storage()._resize_with_addr_(size, ptr)
```

## Use Cases
CUDAGraph requires static addresses. A naive approach is to always keep the static input tensors alive. However, this leads to extra memory consumption. Another approach is to record address/size and reconstruct as a view (e.g., `torch._C._construct_storage_from_data_pointer`). However, CUDACachingAllocator knows nothing about this view and may reuse the memory for other tensors, leading to data corruption. Instead, `_resize_with_addr_` allows CUDACachingAllocator to reconstruct the tensor at user specified address and size.

Example: Optimizer cudagraph requires grads at static address. But we don't want to always keep grads alive due to memory budget. When backward is also cudagraph'ed, we can reconstruct the grad at the same address with `_resize_with_addr_`.

## Properties

- For BC reasons, add a new `_resize_with_addr_` instead of modifying existing `resize_`.
- Returns the block with user-specified `ptr`, or error.
- Support address in the middle of an empty block: When CG replays, the mempool may have a single inactive block, while we want to allocate a block in the middle of the mempool. `mallocWithAddress` will 1) `malloc` a `prefix` block with `(empty_block_start_addr, prefix_size)`, 2) `malloc` a user-specified `block` with `(ptr, size)`, 3) free the `prefix` block, and 4) return the `block`.
- Binary search to find the block: It's too slow to iterate through all empty blocks to find the one with the right address. This pr added `blocks_by_addr` sorted by (stream, address) and use binary search to find the right block.


Ideas borrowed largely from #175516.
