### PR TITLE
[user-streams][functorch] Handle synchronize_device in control_deps

### DIFF
--- a/torch/_functorch/_aot_autograd/streams.py
+++ b/torch/_functorch/_aot_autograd/streams.py
@@ -29,6 +29,7 @@ _SYNC_OPS = (
     torch.ops.streams.record_event.default,
     torch.ops.streams.wait_event.default,
     torch.ops.streams.synchronize_event.default,
+    torch.ops.streams.synchronize_device.default,
 )
 
 
@@ -479,6 +480,19 @@ def wrap_all_sync_nodes_with_control_deps(gm: torch.fx.GraphModule) -> None:
 
         if node.op == "call_function":
             if node.target in _SYNC_OPS:
+                # synchronize_device has no event — it acts as a full
+                # barrier across all streams, same as synchronize_event.
+                if node.target is torch.ops.streams.synchronize_device.default:
+                    all_stream_deps: list[Node] = [
+                        n for nodes in stream_to_nodes.values() for n in nodes
+                    ]
+                    if all_stream_deps:
+                        found_sync = True
+                        _wrap_sync_node(gm, node, all_stream_deps, visited)
+                    stream_to_nodes.clear()
+                    node = next_node
+                    continue
+
                 event_index: int = node.args[0]  # type: ignore[assignment]
 
                 # synchronize_event blocks the CPU thread, so it acts


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #178219
* __->__ #178218
* #178217

Add synchronize_device to _SYNC_OPS and handle it in
wrap_all_sync_nodes_with_control_deps. Unlike synchronize_event, this op
has no event argument — it acts as a full barrier across all streams,
collecting deps from every stream and clearing stream_to_nodes afterward.

Authored with Claude.