### PR TITLE
[user-streams][inductor] Add fallback lowering for synchronize_device

### DIFF
--- a/test/dynamo/test_streams.py
+++ b/test/dynamo/test_streams.py
@@ -2083,6 +2083,35 @@ class <lambda>(torch.nn.Module):
         ]
         self.assertEqual(len(sync_nodes), 1)
 
+    @requires_cuda
+    def test_device_synchronize_inductor_lowering(self):
+        def f(x):
+            y = x + 1
+            torch.cuda.synchronize()
+            return y + 1
+
+        f_compiled = torch.compile(f, fullgraph=True)
+        x = torch.randn(10, device="cuda")
+        eager_result = f(x)
+        compiled_result = f_compiled(x)
+        self.assertEqual(eager_result, compiled_result)
+
+    @requires_cuda
+    def test_control_deps_wrapping_synchronize_device(self):
+        def f(x):
+            s = torch.cuda.Stream()
+            with torch.cuda.stream(s):
+                y = x + 1
+            torch.cuda.synchronize()
+            return y + 2
+
+        backend = torch._dynamo.testing.EagerAndRecordGraphs()
+        f_compiled = torch.compile(f, backend=backend)
+        x = torch.randn(10, device="cuda")
+        eager_result = f(x)
+        compiled_result = f_compiled(x)
+        self.assertEqual(eager_result, compiled_result)
+
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -2594,6 +2594,7 @@ make_fallback(aten.randint)
 make_fallback(torch.ops.streams.record_event.default)
 make_fallback(torch.ops.streams.wait_event.default)
 make_fallback(torch.ops.streams.synchronize_event.default)
+make_fallback(torch.ops.streams.synchronize_device.default)
 
 
 @register_lowering(aten.rand)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #178219
* #178218
* #178217

Register make_fallback for synchronize_device so it works with the
inductor backend. Also adds tests for inductor lowering and control_deps
barrier semantics with multi-stream code.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Lucaskabela