### PR TITLE
Allow torch.testing.assert_close to accept tensor-like and scalar inputs

### DIFF
--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -967,6 +967,7 @@ class TestAssertClose(TestCase):
 
         with self.assertRaisesRegex(RuntimeError, "unexpected exception"):
             torch.testing.assert_close(actual, expected)
+
     def test_tensor_to_int_scalar(self):
         actual = torch.ones(())
         expected = 1

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -967,8 +967,50 @@ class TestAssertClose(TestCase):
 
         with self.assertRaisesRegex(RuntimeError, "unexpected exception"):
             torch.testing.assert_close(actual, expected)
+    def test_tensor_to_int_scalar(self):
+        actual = torch.ones(())
+        expected = 1
+        torch.testing.assert_close(actual, expected)
 
+    def test_tensor_to_float_scalar(self):
+        actual = torch.ones((), dtype=torch.float32)
+        expected = 1.0
+        torch.testing.assert_close(actual, expected)
 
+    def test_tensor_to_complex_scalar(self):
+        actual = torch.ones((), dtype=torch.complex64)
+        expected = 1 + 0j
+        torch.testing.assert_close(actual, expected)
+
+    def test_tensor_to_list(self):
+        actual = torch.arange(3)
+        expected = [0, 1, 2]
+        torch.testing.assert_close(actual, expected)
+
+    def test_tensor_to_tuple(self):
+        actual = torch.arange(3)
+        expected = (0, 1, 2)
+        torch.testing.assert_close(actual, expected)
+
+    def test_int_scalar_to_tensor(self):
+        actual = 1
+        expected = torch.ones(())
+        torch.testing.assert_close(actual, expected)
+
+    def test_list_to_tensor(self):
+        actual = [0, 1, 2]
+        expected = torch.arange(3)
+        torch.testing.assert_close(actual, expected)
+
+    def test_tensor_to_int_in_sequence(self):
+        actual = (torch.ones(()),)
+        expected = (1,)
+        torch.testing.assert_close(actual, expected)
+
+    def test_tensor_to_int_in_mapping(self):
+        actual = {"x": torch.ones(())}
+        expected = {"x": 1}
+        torch.testing.assert_close(actual, expected)
 
 
 class TestAssertCloseMultiDevice(TestCase):

--- a/torch/testing/_comparison.py
+++ b/torch/testing/_comparison.py
@@ -728,13 +728,20 @@ class TensorLikePair(Pair):
     def _process_inputs(
         self, actual: Any, expected: Any, *, id: tuple[Any, ...], allow_subclasses: bool
     ) -> tuple[torch.Tensor, torch.Tensor]:
+        is_python_scalar = isinstance(actual, (int, float, complex)) or isinstance(
+            expected, (int, float, complex)
+        )
         directly_related = isinstance(actual, type(expected)) or isinstance(
             expected, type(actual)
-        )
+        ) or is_python_scalar
         if not directly_related:
             self._inputs_not_supported()
 
-        if not allow_subclasses and type(actual) is not type(expected):
+        if (
+            not allow_subclasses
+            and type(actual) is not type(expected)
+            and not is_python_scalar
+        ):
             self._inputs_not_supported()
 
         actual, expected = (self._to_tensor(input) for input in (actual, expected))

--- a/torch/testing/_comparison.py
+++ b/torch/testing/_comparison.py
@@ -711,6 +711,9 @@ class TensorLikePair(Pair):
         check_stride: bool = False,
         **other_parameters: Any,
     ):
+        self._has_python_scalar = isinstance(actual, (int, float, complex)) or isinstance(
+            expected, (int, float, complex)
+        )
         actual, expected = self._process_inputs(
             actual, expected, id=id, allow_subclasses=allow_subclasses
         )
@@ -836,7 +839,7 @@ class TensorLikePair(Pair):
         if self.check_device and actual.device != expected.device:
             raise_mismatch_error("device", actual.device, expected.device)
 
-        if self.check_dtype and actual.dtype != expected.dtype:
+        if self.check_dtype and actual.dtype != expected.dtype and not self._has_python_scalar:
             raise_mismatch_error("dtype", actual.dtype, expected.dtype)
 
     def _equalize_attributes(


### PR DESCRIPTION
Allow TensorLikePair to compare Python scalars (int, float, complex) with tensors, as documented. This aligns the implementation with the docstring which states that assert_close accepts 'any tensor-or-scalar-likes' and that 'Python scalars are an exception to the type relation requirement'.

Fixes #161863

Tests added for:
- Tensor vs scalar comparisons (int, float, complex)
- Tensor vs list/tuple comparisons
- Reverse order comparisons (scalar vs tensor, list vs tensor)
- Scalar-tensor comparisons in containers (sequences and mappings)