### PR TITLE
Fix addr/addmv backward for mixed complex/real inputs

### DIFF
--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -1008,19 +1008,6 @@ class TestLinalg(TestCase):
         self.assertEqual(vec1.grad.dtype, torch.float64)
         self.assertEqual(vec2.grad.dtype, torch.complex128)
 
-    def test_addmv_backward_mixed_complex_real(self, device):
-        # Regression test for https://github.com/pytorch/pytorch/issues/95434
-        self_ = torch.rand([3], dtype=torch.float64, device=device, requires_grad=True)
-        mat = torch.rand([3, 2], dtype=torch.complex128, device=device, requires_grad=True)
-        vec = torch.rand([2], dtype=torch.complex128, device=device, requires_grad=True)
-
-        res = torch.addmv(self_, mat, vec)
-        res.backward(torch.ones_like(res))
-
-        self.assertEqual(self_.grad.dtype, torch.float64)
-        self.assertEqual(mat.grad.dtype, torch.complex128)
-        self.assertEqual(vec.grad.dtype, torch.complex128)
-
     # Tests migrated from test_torch.py
     # 1) test the shape of the result tensor when there is empty input tensor
     # 2) test the Runtime Exception when there is scalar input tensor

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -994,6 +994,33 @@ class TestLinalg(TestCase):
                 result = op(m, a, b)
                 self.assertEqual(result.dtype, desired_dtype)
 
+    def test_addr_backward_mixed_complex_real(self, device):
+        # Regression test for https://github.com/pytorch/pytorch/issues/95434
+        # addr backward should handle mixed complex/real inputs via type promotion
+        self_ = torch.rand([3, 2], dtype=torch.complex128, device=device, requires_grad=True)
+        vec1 = torch.rand([3], dtype=torch.float64, device=device, requires_grad=True)
+        vec2 = torch.rand([2], dtype=torch.complex128, device=device, requires_grad=True)
+
+        res = torch.addr(self_, vec1, vec2)
+        res.backward(torch.ones_like(res))
+
+        self.assertEqual(self_.grad.dtype, torch.complex128)
+        self.assertEqual(vec1.grad.dtype, torch.float64)
+        self.assertEqual(vec2.grad.dtype, torch.complex128)
+
+    def test_addmv_backward_mixed_complex_real(self, device):
+        # Regression test for https://github.com/pytorch/pytorch/issues/95434
+        self_ = torch.rand([3], dtype=torch.float64, device=device, requires_grad=True)
+        mat = torch.rand([3, 2], dtype=torch.complex128, device=device, requires_grad=True)
+        vec = torch.rand([2], dtype=torch.complex128, device=device, requires_grad=True)
+
+        res = torch.addmv(self_, mat, vec)
+        res.backward(torch.ones_like(res))
+
+        self.assertEqual(self_.grad.dtype, torch.float64)
+        self.assertEqual(mat.grad.dtype, torch.complex128)
+        self.assertEqual(vec.grad.dtype, torch.complex128)
+
     # Tests migrated from test_torch.py
     # 1) test the shape of the result tensor when there is empty input tensor
     # 2) test the Runtime Exception when there is scalar input tensor

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -265,15 +265,15 @@
   mat2: mm_mat2_backward(grad, mat1, mat2.sym_sizes(), mat2.sym_strides(), mat2.layout(), alpha)
 
 - name: addmv(Tensor self, Tensor mat, Tensor vec, *, Scalar beta=1, Scalar alpha=1) -> Tensor
-  self: maybe_multiply(grad, beta.conj())
-  mat: maybe_multiply(grad.ger(vec.conj()), alpha.conj())
-  vec: maybe_multiply(mat.t().conj().mv(grad), alpha.conj())
+  self: handle_r_to_c(self.scalar_type(), maybe_multiply(grad, beta.conj()))
+  mat: handle_r_to_c(mat.scalar_type(), maybe_multiply(grad.ger(vec.conj()), alpha.conj()))
+  vec: handle_r_to_c(vec.scalar_type(), maybe_multiply(mat.t().conj().mv(grad), alpha.conj()))
   result: maybe_multiply(self_t, beta) + maybe_multiply(mat_t.mv(vec_p), alpha) + maybe_multiply(mat_p.mv(vec_t), alpha)
 
 - name: addr(Tensor self, Tensor vec1, Tensor vec2, *, Scalar beta=1, Scalar alpha=1) -> Tensor
-  self: maybe_multiply(grad, beta.conj())
-  vec1: maybe_multiply(grad.mv(vec2.conj()), alpha.conj())
-  vec2: maybe_multiply(grad.t().mv(vec1.conj()), alpha.conj())
+  self: handle_r_to_c(self.scalar_type(), maybe_multiply(grad, beta.conj()))
+  vec1: handle_r_to_c(vec1.scalar_type(), maybe_multiply(grad.mv(vec2.conj()), alpha.conj()))
+  vec2: handle_r_to_c(vec2.scalar_type(), maybe_multiply(grad.t().mv(vec1.conj()), alpha.conj()))
   result: maybe_multiply(self_t, beta) + maybe_multiply(vec1_t.outer(vec2_p), alpha) + maybe_multiply(vec1_p.outer(vec2_t), alpha)
 
 - name: affine_grid_generator(Tensor theta, SymInt[] size, bool align_corners) -> Tensor


### PR DESCRIPTION
Fixes #95434

## Summary

`torch.addr` and `torch.addmv` crash during backward when inputs have mixed complex/real dtypes. For example, `addr(complex128_mat, float64_vec, complex128_vec)` produces a complex128 result, but backward fails because the gradient for the `float64` input is complex.

The fix wraps each backward gradient formula with `handle_r_to_c()`, which extracts the real part of a complex gradient when the corresponding input is real. This follows the same pattern already used by `add`, `sub`, `addcmul`, `addcdiv`, and other ops in `derivatives.yaml`.

### Reproducer
```python
import torch

self_ = torch.rand([3, 2], dtype=torch.complex128, requires_grad=True)
vec1 = torch.rand([3], dtype=torch.float64, requires_grad=True)
vec2 = torch.rand([2], dtype=torch.complex128, requires_grad=True)

res = torch.addr(self_, vec1, vec2)
# Before fix: RuntimeError: expected scalar type ComplexDouble but found Double
# After fix: succeeds, vec1.grad has dtype float64
res.backward(torch.ones_like(res))
```

## Test plan
- Added `test_addr_backward_mixed_complex_real` and `test_addmv_backward_mixed_complex_real` in `test_linalg.py`
- Both tests verify that backward succeeds and gradients have correct dtypes

cc @albanD @soulitzer