### PR TITLE
[ROCm] Skip linalg UT's when MAGMA is not available with ROCM

### DIFF
--- a/test/functorch/test_vmap.py
+++ b/test/functorch/test_vmap.py
@@ -59,7 +59,6 @@ from torch.testing._internal.common_device_type import (
     onlyCUDA,
     OpDTypes,
     ops,
-    skipCUDAIf,
     tol,
     toleranceOverride,
 )
@@ -5092,10 +5091,6 @@ class TestVmapOperatorsOpInfo(TestCase):
 
         test(self, op, tuple(inputs), in_dims=tuple(in_dims))
 
-    @skipCUDAIf(
-        TEST_WITH_ROCM and not torch.cuda.has_magma,
-        "ROCm hipsolver backend does not currently support eig",
-    )
     def test_torch_return_types_returns(self, device):
         t = torch.randn(3, 2, 2, device=device)
         self.assertTrue(
@@ -5109,9 +5104,12 @@ class TestVmapOperatorsOpInfo(TestCase):
                 vmap(torch.topk, (0, None, None))(t, 1, 0), torch.return_types.topk
             )
         )
-        self.assertTrue(
-            isinstance(vmap(torch.linalg.eig, (0))(t), torch.return_types.linalg_eig)
-        )
+        if not (TEST_WITH_ROCM and not torch.cuda.has_magma):
+            self.assertTrue(
+                isinstance(
+                    vmap(torch.linalg.eig, (0))(t), torch.return_types.linalg_eig
+                )
+            )
 
     def test_namedtuple_returns(self, device):
         Point = namedtuple("Point", ["x", "y"])

--- a/test/inductor/test_compile_subprocess.py
+++ b/test/inductor/test_compile_subprocess.py
@@ -76,6 +76,11 @@ test_failures = {
     "test_weight_norm_conv2d": TestFailure(("cpu", "cuda"), is_skip=True),
 }
 
+if TEST_WITH_ROCM and not torch.cuda.has_magma:
+    test_failures["test_linalg_eig_stride_consistency"] = TestFailure(
+        ("cuda",), is_skip=True
+    )
+
 
 class TestSubprocess(TestCase):
     def setUp(self):

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -6445,7 +6445,7 @@ class CommonTemplate:
             reference_in_float=False,
         )
 
-    @skipCUDAIf(
+    @unittest.skipIf(
         TEST_WITH_ROCM and not torch.cuda.has_magma,
         "ROCm hipsolver backend does not currently support eig",
     )


### PR DESCRIPTION
Skipping MAGMA related UT's failing in https://github.com/pytorch/pytorch/pull/176306. These tests should be skipped when ROCm is available but MAGMA is not.
tested in https://github.com/pytorch/pytorch/pull/176306

Snippet here from XMLs
```
<testcase classname="GPUTests" name="test_linalg_eig_stride_consistency_cuda" time="0.000" file="inductor/test_torchinductor.py">
  <skipped type="pytest.skip" message="ROCm hipsolver backend does not currently support eig">
    /var/lib/jenkins/pytorch/test/inductor/test_torchinductor.py:6421: ROCm hipsolver backend does not currently support eig
  </skipped>
</testcase>
<testcase classname="GPUTests" name="test_linalg_eig_stride_consistency_cuda" time="0.000" file="inductor/test_compile_subprocess.py">
  <skipped type="pytest.skip" message="Skipped!">
    /var/lib/jenkins/pytorch/test/inductor/test_torchinductor.py:6421: Skipped!
  </skipped>
</testcase>
<testcase classname="DynamicShapesGPUTests" name="test_linalg_eig_stride_consistency_dynamic_shapes_cuda" time="0.000" file="inductor/test_torchinductor_dynamic_shapes.py">
  <skipped type="pytest.skip" message="ROCm hipsolver backend does not currently support eig">
    /var/lib/jenkins/pytorch/test/inductor/test_torchinductor.py:6421: ROCm hipsolver backend does not currently support eig
  </skipped>
</testcase>

```

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben