### PR TITLE
[dynamo] Make GuardManager destructor safe during interpreter finalization 

### DIFF
--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -7,6 +7,7 @@
 #include <ATen/EmptyTensor.h>
 #include <ATen/SparseCsrTensorUtils.h>
 #include <c10/util/Synchronized.h>
+#include <c10/util/CallOnce.h>
 #include <c10/util/flat_hash_map.h>
 #include <fmt/format.h>
 #include <torch/csrc/autograd/grad_mode.h>
@@ -1662,10 +1663,10 @@ class RootGuardManager;
 class DictGuardManager;
 
 void cleanup_live_guard_managers_at_exit();
-void register_guard_manager_for_atexit(GuardManager* guard_manager);
+bool register_guard_manager_for_atexit(GuardManager* guard_manager);
 void unregister_guard_manager_for_atexit(GuardManager* guard_manager);
 
-static std::once_flag guard_manager_atexit_once;
+static c10::once_flag guard_manager_atexit_once;
 static std::mutex live_guard_managers_mutex;
 static std::unordered_set<GuardManager*> live_guard_managers;
 
@@ -3671,7 +3672,9 @@ class GuardManager {
 #if IS_PYTHON_3_12_PLUS
         // Ideally we don't need to even register a weakref callback for value.
         // But it does not hurt to be more cautious
-        _dict_callback_installed = watch_dict_pointers(value);
+        if (!_disable_dict_tag_matching) {
+          _dict_callback_installed = watch_dict_pointers(value);
+        }
 #endif
       }
     }
@@ -3737,7 +3740,13 @@ class GuardManager {
       PyErr_Clear();
       return false;
     }
-    register_guard_manager_for_atexit(this);
+
+    if (!register_guard_manager_for_atexit(this)) {
+      Py_DECREF(wr);
+      disable_recursive_dict_tag_optimization();
+      return true;
+    }
+
     // These will be decrefed in destructor
     Py_INCREF(capsule);
     _tag_safe_entries.push_back({wr, capsule});
@@ -3781,26 +3790,36 @@ class GuardManager {
   // Caller must hold dict_to_guard_managers lock.
   void unwatch_all_saved_dict_pointers(DictToGuardManagersMap& map) {
 #if IS_PYTHON_3_12_PLUS
-    if (!_disable_dict_tag_matching) {
-      for (auto& value_stashed_pointers : _dict_pointers) {
-        auto stashed_pointers = value_stashed_pointers.second;
+    if (!_dict_callback_installed) {
+      return;
+    }
 
-        for (auto& stashed_pointer : stashed_pointers) {
-          PyObject* dict_pointer = stashed_pointer.first;
+    for (auto& value_stashed_pointers : _dict_pointers) {
+      auto stashed_pointers = value_stashed_pointers.second;
 
-          auto it = std::find(
-              map[dict_pointer].begin(), map[dict_pointer].end(), this);
-          if (it != map[dict_pointer].end()) {
-            map[dict_pointer].erase(it);
-          }
+      for (auto& stashed_pointer : stashed_pointers) {
+        PyObject* dict_pointer = stashed_pointer.first;
+        auto dict_it = map.find(dict_pointer);
+        if (dict_it == map.end()) {
+          continue;
+        }
 
-          if (map[dict_pointer].empty()) {
-            PyDict_Unwatch(dict_recursive_tag_watcher_id, dict_pointer);
-            map.erase(dict_pointer);
-          }
+        // Delete the guard manager from the dict_to_guard_managers.
+        auto& guard_managers = dict_it->second;
+        auto it = std::find(guard_managers.begin(), guard_managers.end(), this);
+        if (it != guard_managers.end()) {
+          guard_managers.erase(it);
+        }
+
+        // Unwatch the dict pointer if this was the last guard manager
+        // watching it.
+        if (guard_managers.empty()) {
+          PyDict_Unwatch(dict_recursive_tag_watcher_id, dict_pointer);
+          map.erase(dict_it);
         }
       }
     }
+    _dict_callback_installed = false;
 #endif
   }
 
@@ -4065,34 +4084,27 @@ void cleanup_live_guard_managers_at_exit() {
   // Python-level atexit runs while the interpreter is still alive, so it is
   // the last safe point to release the extra capsule refs we hold for the
   // weakref callback path.
-  std::vector<GuardManager*> guard_managers;
-  {
-    std::lock_guard<std::mutex> lock(live_guard_managers_mutex);
-    guard_managers.reserve(live_guard_managers.size());
-    guard_managers.insert(
-        guard_managers.end(),
-        live_guard_managers.begin(),
-        live_guard_managers.end());
-  }
-  for (GuardManager* guard_manager : guard_managers) {
+  std::lock_guard<std::mutex> lock(live_guard_managers_mutex);
+  for (GuardManager* guard_manager : live_guard_managers) {
     guard_manager->cleanup_python_state();
   }
 }
 
-void register_guard_manager_for_atexit(GuardManager* guard_manager) {
+bool register_guard_manager_for_atexit(GuardManager* guard_manager) {
   try {
-    std::call_once(guard_manager_atexit_once, []() {
+    c10::call_once(guard_manager_atexit_once, []() {
       py::module_::import("atexit").attr("register")(
           py::cpp_function([]() { cleanup_live_guard_managers_at_exit(); }));
     });
-  } catch (const py::error_already_set& e) {
+  } catch (py::error_already_set& e) {
     e.restore();
     PyErr_Clear();
-    return;
+    return false;
   }
 
   std::lock_guard<std::mutex> lock(live_guard_managers_mutex);
   live_guard_managers.insert(guard_manager);
+  return true;
 }
 
 void unregister_guard_manager_for_atexit(GuardManager* guard_manager) {

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -3236,7 +3236,7 @@ class GuardManager {
     // During interpreter shutdown, weakrefs/callbacks/capsules may already
     // have been torn down before the C++ GuardManager destructor runs. In
     // that state we must not call Python C API from destructor cleanup.
-    if (!Py_IsInitialized() || _Py_IsFinalizing()) {
+    if (!Py_IsInitialized() || Py_IsFinalizing()) {
       _tag_safe_entries.clear();
       _dict_pointers.clear();
       _disable_dict_tag_matching = true;

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -40,8 +40,10 @@
 #endif
 
 #include <chrono>
+#include <mutex>
 #include <sstream>
 #include <tuple>
+#include <unordered_set>
 #include <utility>
 
 // Uncomment next line to count instructions for guard eval.
@@ -1659,6 +1661,14 @@ class GuardManager;
 class RootGuardManager;
 class DictGuardManager;
 
+void cleanup_live_guard_managers_at_exit();
+void register_guard_manager_for_atexit(GuardManager* guard_manager);
+void unregister_guard_manager_for_atexit(GuardManager* guard_manager);
+
+static std::once_flag guard_manager_atexit_once;
+static std::mutex live_guard_managers_mutex;
+static std::unordered_set<GuardManager*> live_guard_managers;
+
 // Global registry used by the *recursive-dict-tag* optimisation.
 //
 // Key   : `PyObject*` pointing to a watched `dict`
@@ -3233,6 +3243,8 @@ class GuardManager {
   GuardManager& operator=(const GuardManager&) = delete;
 
   virtual ~GuardManager() {
+    unregister_guard_manager_for_atexit(this);
+
     // During interpreter shutdown, weakrefs/callbacks/capsules may already
     // have been torn down before the C++ GuardManager destructor runs. In
     // that state we must not call Python C API from destructor cleanup.
@@ -3248,12 +3260,19 @@ class GuardManager {
     // destruction happens on a thread that does not currently hold it.
     if (!PyGILState_Check()) {
       py::gil_scoped_acquire gil;
-      cleanup_tag_safe_entries();
-      disable_recursive_dict_tag_optimization();
+      cleanup_python_state();
+      return;
+    }
+    cleanup_python_state();
+  }
+
+  void cleanup_python_state() {
+    if (_python_cleanup_done) {
       return;
     }
     cleanup_tag_safe_entries();
     disable_recursive_dict_tag_optimization();
+    _python_cleanup_done = true;
   }
 
   void cleanup_tag_safe_entries() {
@@ -3718,6 +3737,7 @@ class GuardManager {
       PyErr_Clear();
       return false;
     }
+    register_guard_manager_for_atexit(this);
     // These will be decrefed in destructor
     Py_INCREF(capsule);
     _tag_safe_entries.push_back({wr, capsule});
@@ -4033,12 +4053,52 @@ class GuardManager {
 
   // 3.12+ related helper
   bool _dict_callback_installed = false;
+  bool _python_cleanup_done = false;
 
  protected:
   // weakref to the type of guarded value
   // protected because it is used for cloning by DictGuardManager
   py::object _weak_type;
 };
+
+void cleanup_live_guard_managers_at_exit() {
+  // Python-level atexit runs while the interpreter is still alive, so it is
+  // the last safe point to release the extra capsule refs we hold for the
+  // weakref callback path.
+  std::vector<GuardManager*> guard_managers;
+  {
+    std::lock_guard<std::mutex> lock(live_guard_managers_mutex);
+    guard_managers.reserve(live_guard_managers.size());
+    guard_managers.insert(
+        guard_managers.end(),
+        live_guard_managers.begin(),
+        live_guard_managers.end());
+  }
+  for (GuardManager* guard_manager : guard_managers) {
+    guard_manager->cleanup_python_state();
+  }
+}
+
+void register_guard_manager_for_atexit(GuardManager* guard_manager) {
+  try {
+    std::call_once(guard_manager_atexit_once, []() {
+      py::module_::import("atexit").attr("register")(
+          py::cpp_function([]() { cleanup_live_guard_managers_at_exit(); }));
+    });
+  } catch (const py::error_already_set& e) {
+    e.restore();
+    PyErr_Clear();
+    return;
+  }
+
+  std::lock_guard<std::mutex> lock(live_guard_managers_mutex);
+  live_guard_managers.insert(guard_manager);
+}
+
+void unregister_guard_manager_for_atexit(GuardManager* guard_manager) {
+  std::lock_guard<std::mutex> lock(live_guard_managers_mutex);
+  live_guard_managers.erase(guard_manager);
+}
 
 GuardAccessor::GuardAccessor(
     RootGuardManager* root,

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -3233,6 +3233,25 @@ class GuardManager {
   GuardManager& operator=(const GuardManager&) = delete;
 
   virtual ~GuardManager() {
+    // During interpreter shutdown, weakrefs/callbacks/capsules may already
+    // have been torn down before the C++ GuardManager destructor runs. In
+    // that state we must not call Python C API from destructor cleanup.
+    if (!Py_IsInitialized() || _Py_IsFinalizing()) {
+      _tag_safe_entries.clear();
+      _dict_pointers.clear();
+      _disable_dict_tag_matching = true;
+      return;
+    }
+
+    // Outside of interpreter finalization we still need full cleanup, notably
+    // removing dict watcher registrations on Python 3.12+. Acquire the GIL if
+    // destruction happens on a thread that does not currently hold it.
+    if (!PyGILState_Check()) {
+      py::gil_scoped_acquire gil;
+      cleanup_tag_safe_entries();
+      disable_recursive_dict_tag_optimization();
+      return;
+    }
     cleanup_tag_safe_entries();
     disable_recursive_dict_tag_optimization();
   }
@@ -3246,6 +3265,7 @@ class GuardManager {
       }
       Py_DECREF(e.cap);
       Py_CLEAR(e.wr); // kills weakref (may remove callback)
+      Py_DECREF(e.cap);
     }
     _tag_safe_entries.clear();
   }


### PR DESCRIPTION
#178224 
Summary

This PR fixes a shutdown-time crash in Dynamo guard cleanup when GuardManager destruction happens after Python has already started interpreter finalization.

Root cause

GuardManager stores weakref/capsule pairs for recursive dict-tag optimization and cleans them up in the destructor.

During normal runtime, destructor cleanup assumes the associated Python objects are still valid:

the weakref callback still owns a live capsule
destructor-time cleanup can safely call Python C API
dict watcher registrations can still be removed normally
That assumption does not always hold during interpreter shutdown.

During Py_Finalize / Py_FinalizeEx, CPython may clear weakrefs and tear down the callback/capsule chain before the corresponding C++ GuardManager is destroyed. If the destructor later calls Python C API on those objects, it can observe freed Python objects and crash.

What this PR changes

Hold an explicit strong reference to the callback capsule while it is stored in _tag_safe_entries
register_weakref_callback now Py_INCREFs the capsule before storing it
cleanup_tag_safe_entries releases that reference with Py_DECREF
Make GuardManager destructor shutdown-safe
if Python is no longer initialized or is already finalizing, destructor cleanup skips Python C API entirely
in that case we only clear local C++ containers and mark dict-tag matching as disabled
Preserve full runtime cleanup behavior
outside interpreter finalization, destructor still performs normal cleanup
if destruction happens on a thread without the GIL, it acquires the GIL first
this keeps the existing cleanup semantics, including dict watcher unregistration on Python 3.12+
Why this shape

The important distinction is between:

interpreter finalization, where Python-side objects may already be torn down and Python C API is no longer safe in destructor cleanup
normal runtime destruction without the GIL, where we still want full cleanup rather than silently skipping it
Without that distinction, skipping cleanup whenever the current thread lacks the GIL can leave watcher bookkeeping behind during normal execution.

Behavioral impact

normal runtime behavior is preserved
shutdown-time cleanup becomes defensive and avoids touching Python objects after finalization has started
this prevents crashes caused by destructor-time access to stale weakref/capsule state
Files changed

torch/csrc/dynamo/guards.cpp
Testing

This change was validated against the reported shutdown crash scenario and by checking that the edited file has no new static errors.

I have not added a dedicated regression test in this PR yet because the failure is shutdown-order dependent and can be difficult to minimize into a deterministic standalone reproducer.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98