### PR TITLE
[CK-Tile][FMHA] FP8 per-block scaling: codegen, runner infrastructure, and pipeline overload (#178232)

### DIFF
--- a/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_fwd_ck.hip
+++ b/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_fwd_ck.hip
@@ -103,6 +103,12 @@ fmha_fwd_args get_ck_fmha_fwd_args(bool has_lse,
                          nullptr, // q_descale_ptr
                          nullptr, // k_descale_ptr
                          nullptr, // v_descale_ptr
+                         0, // q_descale_stride_b
+                         0, // q_descale_stride_h
+                         0, // k_descale_stride_b
+                         0, // k_descale_stride_h
+                         0, // v_descale_stride_b
+                         0, // v_descale_stride_h
                          has_dropout_randval ? dropout_randval.data_ptr() : nullptr,
                          has_lse ? softmax_lse.data_ptr() : nullptr,
                          out.data_ptr(),

--- a/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_varlen_fwd_ck.hip
+++ b/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_varlen_fwd_ck.hip
@@ -104,6 +104,12 @@ fmha_fwd_args get_ck_fmha_varlen_fwd_args(bool has_lse,
                          nullptr, // q_descale_ptr
                          nullptr, // k_descale_ptr
                          nullptr, // v_descale_ptr
+                         0, // q_descale_stride_b
+                         0, // q_descale_stride_h
+                         0, // k_descale_stride_b
+                         0, // k_descale_stride_h
+                         0, // v_descale_stride_b
+                         0, // v_descale_stride_h
                          has_dropout_randval ? dropout_randval.data_ptr() : nullptr,
                          has_lse ? softmax_lse.data_ptr() : nullptr,
                          out.data_ptr(),


### PR DESCRIPTION
Summary:

Add codegen, example runner, and pipeline infrastructure for FP8 per-block
(PERBLOCK) descaling support in CK-Tile FMHA forward.

- Codegen: Add "perblock" to QSCALE_MAP/QSCALE_CHECK_MAP in cpp_symbol_map.py,
  and to FP8 codegen factories in fmha_fwd.py (GFX9: qr pipeline only for
  perblock since qr_async doesn't support it; GFX12: added to product)
- quant.hpp: Add perblock=2 enum value with "pb" serialization and decode
- Runner (fmha_fwd_runner.hpp): Proper-shaped descale tensor allocation
  [batch, nhead, num_tiles], random initialization, stride setup, per-element
  Q*K descale in reference S computation, per-N-tile V descale in reference
  P*V computation
- fmha_fwd.hpp: Add 6 descale stride fields to fmha_fwd_args, forwarded
  to MakeKargsImpl in both batch and group mode
- example_fmha_fwd.cpp: Add descale_block_q/kv CLI args
- Pipeline simplified overload: Forward k/v_descale_base and perblock_scale_p
  params to full overload

Stacked on D96877795 (FP8 per-block scaling core: enum, kargs, kernel operator,
pipeline descaling).

Test Plan:
buck2 test mode/opt-amd-gpu -c fbcode.enable_gpu_sections=true -c fbcode.rocm_arch=mi300 \
  //third-party/rocm_composable_kernel/test/ck_tile:fmha_fwd_fp8bf16

Differential Revision: D97786884
