### PR TITLE
[inductor] Enable Reduction+Pointwise fusion when reduction output has opaque consumers

### DIFF
--- a/torch/_inductor/choices.py
+++ b/torch/_inductor/choices.py
@@ -548,31 +548,48 @@ class InductorChoices:
         if shared_data_score == 0 and (
             not config.aggressive_fusion or node1.is_reduction() or node2.is_reduction()
         ):
-            if is_metric_table_enabled("fusion_failure_due_to_indexing_mismatch"):
-                common_buf_names: OrderedSet[str] = (
-                    node1.read_writes.buffer_names() & node2.read_writes.buffer_names()
-                )
-                if len(common_buf_names) > 0:
-                    get_metric_table("fusion_failure_due_to_indexing_mismatch").add_row(
-                        # pyrefly: ignore [bad-argument-type]
-                        lambda: {
-                            "pre_grad_graph_id": V.graph.graph_id,
-                            "post_grad_graph_id": V.graph.post_grad_graph_id,
-                            "node1_name": node1.get_name(),
-                            "node2_name": node2.get_name(),
-                            "node1_debug_str": write_text(node1.debug_str()),
-                            "node2_debug_str": write_text(node2.debug_str()),
-                            "common_buffer_names": list(common_buf_names),  # type: ignore[dict-item]
-                            "failure_reason": scheduler.decide_fusion_fail_reason(
-                                node1, node2, common_buf_names
-                            ),
-                        }
+            # Allow fusion when nodes have a producer-consumer relationship
+            # (one writes a buffer that the other reads), even if shared_data_score
+            # is 0. This enables fusing Reduction+Pointwise epilogues when the
+            # Reduction output feeds an opaque consumer (e.g., cutlass_scaled_mm).
+            node1_writes = {d.name for d in node1.read_writes.writes}
+            node2_reads = {d.name for d in node2.read_writes.reads}
+            node2_writes = {d.name for d in node2.read_writes.writes}
+            node1_reads = {d.name for d in node1.read_writes.reads}
+            has_producer_consumer = bool(
+                (node1_writes & node2_reads) or (node2_writes & node1_reads)
+            )
+            if not has_producer_consumer:
+                if is_metric_table_enabled("fusion_failure_due_to_indexing_mismatch"):
+                    common_buf_names: OrderedSet[str] = (
+                        node1.read_writes.buffer_names()
+                        & node2.read_writes.buffer_names()
                     )
+                    if len(common_buf_names) > 0:
+                        get_metric_table(
+                            "fusion_failure_due_to_indexing_mismatch"
+                        ).add_row(
+                            # pyrefly: ignore [bad-argument-type]
+                            lambda: {
+                                "pre_grad_graph_id": V.graph.graph_id,
+                                "post_grad_graph_id": V.graph.post_grad_graph_id,
+                                "node1_name": node1.get_name(),
+                                "node2_name": node2.get_name(),
+                                "node1_debug_str": write_text(node1.debug_str()),
+                                "node2_debug_str": write_text(node2.debug_str()),
+                                "common_buffer_names": list(common_buf_names),  # type: ignore[dict-item]
+                                "failure_reason": scheduler.decide_fusion_fail_reason(
+                                    node1, node2, common_buf_names
+                                ),
+                            }
+                        )
 
-                    WhyNoFuse(node1, node2)("no shared data due to indexing mismatch")
-                    return False
-            WhyNoFuse(node1, node2)("no shared data")
-            return False  # heuristic not needed for correctness
+                        WhyNoFuse(node1, node2)(
+                            "no shared data due to indexing mismatch"
+                        )
+                        return False
+                WhyNoFuse(node1, node2)("no shared data")
+                return False  # heuristic not needed for correctness
 
         if (
             not node1.is_foreach()

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -6089,11 +6089,43 @@ class Scheduler:
             if self.mode_requires_synchronization(write.mode):
                 return False
 
-            return (
+            if (
                 read.index == write.index
                 and len(read.size) >= len(write.size)
                 and read.size[: len(write.size)] == write.size
-            )
+            ):
+                return True
+
+            # Check for broadcast-compatible read pattern:
+            # A Pointwise reads a Reduction output using integer division
+            # (e.g., scales[d1 // 128] over [N*K] matches scales[d1] over [N]).
+            # This is safe to fuse because the Pointwise can run as an epilogue
+            # inside the Reduction's loop, using the value already in registers.
+            if len(read.size) == len(write.size) and read.size[:-1] == write.size[:-1]:
+                import sympy
+                from torch.utils._sympy.functions import FloorDiv
+
+                last_read = read.size[-1]
+                last_write = write.size[-1]
+                if (
+                    last_read != last_write
+                    and last_write != 0
+                    and sympy.sympify(last_read % last_write) == 0
+                ):
+                    K = sympy.sympify(last_read // last_write)
+                    read_vars = sorted(read.index.free_symbols, key=str)
+                    write_vars = sorted(write.index.free_symbols, key=str)
+                    if read_vars and write_vars:
+                        d_read_last = read_vars[-1]
+                        d_write_last = write_vars[-1]
+                        # The read index contains FloorDiv(d1, K).
+                        # Replace it with d_write_last and check match.
+                        floor_div_expr = FloorDiv(d_read_last, K)
+                        substituted = read.index.subs(floor_div_expr, d_write_last)
+                        if substituted == write.index:
+                            return True
+
+            return False
         elif isinstance(read, StarDep):
             read_name = self.mutation_renames.get(read.name, read.name)
             write_name = self.mutation_renames.get(write.name, write.name)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #178237

Summary:
Two fixes in the Inductor scheduler that enable fusing a Reduction with its
Pointwise epilogue when the Reduction output is also consumed by an opaque
custom op (e.g., cutlass_scaled_mm).

Inductor dashboard shows broad speed up:
<img width="814" height="395" alt="Screenshot 2026-03-27 at 9 55 48 PM" src="https://github.com/user-attachments/assets/c3c7260a-28a3-43f5-91bc-bd43aaa10ac7" />

**Problem:**
When a Reduction output (e.g., per-group FP8 quantization scales) has two
consumers — a Pointwise (FP8 cast: x / scale) and an opaque extern kernel
(cutlass_scaled_mm) — Inductor refuses to fuse the Reduction and Pointwise
into one kernel. This forces the Pointwise into a separate triton_poi kernel,
adding unnecessary kernel launch overhead.

Two independent blockers prevented fusion:

1. **choices.py `can_fuse` "no shared data" heuristic**: When `shared_data_score == 0`,
   fusion is rejected even for producer-consumer pairs. This happens because the
   fused node read/write sets do not reflect the internal producer-consumer
   relationship after the Reduction output is materialized for the opaque consumer.

2. **scheduler.py `fusable_read_and_write` index mismatch**: The Pointwise reads
   the Reduction output with integer division (broadcast pattern):
   `read.index = 56*d0 + FloorDiv(d1, 128)` over [N*K] does not match
   `write.index = 56*d0 + d1` over [N]. This is a valid broadcast read
   (each scale value is reused for 128 elements), but the existing check
   requires exact index equality.

**Fix:**

1. **choices.py**: Before rejecting for "no shared data", check if the nodes
   have a producer-consumer relationship (one writes a buffer the other reads).
   If so, allow fusion to proceed.

2. **scheduler.py**: In `fusable_read_and_write`, recognize broadcast-compatible
   read patterns where the last dimension uses FloorDiv. When the read size is
   a multiple of the write size and substituting `FloorDiv(d_read, K)` with
   `d_write` produces the write index, the read is fusable.

Test Plan:
Standalone repro test (quant + opaque consumer):
  - Before: 2 kernels (triton_per for amax+scale, triton_poi for fp8 cast)
  - After:  1 kernel (triton_per fuses amax+scale+fp8_cast as epilogue)

Full RMSNorm + FP8 quant + opaque GEMM:
  - Before: 3 kernels (triton_red variance, triton_per normalize+amax+scale, triton_poi fp8_cast)
  - After:  2 kernels (triton_red variance, triton_per normalize+amax+scale+fp8_cast)

DeepSeek-R1 671B FP8 E2E (vllm bench latency, TP=8):
  - Before fix: 88.56 ms (+4.55ms vs baseline, extra triton_poi per norm-adjacent call)
  - After fix:  85.03 ms (+1.02ms vs baseline, triton_poi eliminated)

Repro:
```python
import torch, shutil, re, io, logging

FP8 = torch.float8_e4m3fn
FP8_MAX = torch.finfo(FP8).max
HIDDEN, GROUP_SIZE = 7168, 128

@torch.library.custom_op("test::opaque_gemm", mutates_args=())
def opaque_gemm(x_q: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
    return torch.zeros(x_q.shape[0], 1024, device=x_q.device, dtype=torch.bfloat16)

@opaque_gemm.register_fake
def _(x_q, scale):
    return torch.zeros(x_q.shape[0], 1024, device=x_q.device, dtype=torch.bfloat16)

def quant_with_opaque(x):
    grouped = x.reshape(-1, HIDDEN // GROUP_SIZE, GROUP_SIZE).float()
    absmax = grouped.abs().amax(dim=-1, keepdim=True)
    scale = (absmax / FP8_MAX).clamp(min=1e-6)
    x_q = (grouped / scale).clamp(-FP8_MAX, FP8_MAX).to(FP8).reshape(x.shape)
    scale = scale.squeeze(-1)
    return torch.ops.test.opaque_gemm(x_q, scale)

x = torch.randn(8, HIDDEN, device="cuda", dtype=torch.bfloat16)
compiled = torch.compile(quant_with_opaque, fullgraph=True)
compiled(x)
# Before fix: 2 triton kernels (triton_per + triton_poi)
# After fix:  1 triton kernel (triton_per, fp8 cast fused as epilogue)
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo