### PR TITLE
Filter out torch_version artifact in structured trace tests (#178238)

### DIFF
--- a/test/dynamo/test_structured_trace.py
+++ b/test/dynamo/test_structured_trace.py
@@ -78,6 +78,10 @@ class StructuredTraceTestingFilter(logging.Filter):
     def filter(self, record):
         if "str" in record.metadata:
             return False
+        # torch_version is emitted by LazyTraceHandler only in fbcode;
+        # filter it out so expected output is consistent across environments.
+        if torch._environment.is_fbcode() and record.metadata.get("artifact", {}).get("name") == "torch_version":
+            return False
         if self.match_name is not None:
             if "artifact" in record.metadata:
                 if self.match_name != record.metadata["artifact"]["name"]:


### PR DESCRIPTION
Summary:

The `torch_version` artifact is emitted by `LazyTraceHandler` only in fbcode
(the handler disables itself in OSS). Filter it out in
`StructuredTraceTestingFilter` so the expected test output is consistent
across fbcode and OSS.

Test Plan:
```
buck test fbcode//mode/opt fbcode//caffe2/test/dynamo:test_dynamo -- --exact 'fbcode//caffe2/test/dynamo:test_dynamo - test_structured_trace.py::StructuredTraceTest::test_dump_file' --run-disabled
```
Passes.

Reviewed By: IvanKobzarev

Differential Revision: D97883971


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98