### PR TITLE
[inductor][caching] Fix JSON serialization of callable config values in isolation key

### DIFF
--- a/torch/_inductor/runtime/caching/context.py
+++ b/torch/_inductor/runtime/caching/context.py
@@ -305,6 +305,17 @@ def _isolation_key(ischema: IsolationSchema = _DEFAULT_ISOLATION_SCHEMA) -> str:
         A 32-character hexadecimal string that uniquely identifies
         the context specified by the isolation schema.
     """
+    def _json_default(obj: object) -> str:
+        if callable(obj):
+            if hasattr(obj, "__module__") and hasattr(obj, "__qualname__"):
+                return f"{obj.__module__}.{obj.__qualname__}"
+            return repr(obj)
+        raise TypeError(
+            f"Object of type {type(obj).__name__} is not JSON serializable"
+        )
+
     return sha256(
-        json.dumps(_isolation_context(ischema), sort_keys=True).encode()
+        json.dumps(
+            _isolation_context(ischema), sort_keys=True, default=_json_default
+        ).encode()
     ).hexdigest()[:32]


### PR DESCRIPTION
Summary:
`_isolation_key()` calls `json.dumps()` on the dict returned by `config.save_config_portable()`, which can contain `Callable` config values (e.g. `inductor_choices_class`, `bucket_all_gathers_fx_bucket_size_determinator`). This fails with `TypeError: Object of type function is not JSON serializable`.

Fix by adding a custom `default` handler to `json.dumps()` that converts callables to their stable qualified name (`module.qualname`), keeping the key both serializable and deterministic.

Test Plan:
```
buck test fbcode//mode/opt fbcode//caffe2/test/inductor:caching -- --exact 'fbcode//caffe2/test/inductor:caching - test_isolation_key_is_repeatable (caffe2.test.inductor.test_caching.ContextTest)' --run-disabled
```
Passes. Full suite also passes (211 pass, 0 fail).

Differential Revision: D97885048




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo