### PR TITLE
Add record_stream to control_deps wrapping

### DIFF
--- a/test/dynamo/test_streams.py
+++ b/test/dynamo/test_streams.py
@@ -2032,6 +2032,64 @@ class <lambda>(torch.nn.Module):
         self.assertEqual(eager_result, compiled_result)
 
 
+    @requires_cuda
+    def test_control_deps_wrapping_record_stream(self) -> None:
+        """Test wrapping record_stream with control_deps.
+
+        record_stream takes (tensor, stream_index), so its tensor arg must
+        flow through the control_deps subgraph as a placeholder.
+        """
+
+        def fn(x) -> torch.Tensor:
+            s = torch.Stream(device="cuda")
+            y = x + 1
+            y.record_stream(s)
+            return y
+
+        inp = (torch.ones(2, 2, device="cuda"),)
+        (
+            _,
+            _,
+            fw_graphs,
+            _,
+        ) = extract_graph(fn, *inp)
+
+        gm = fw_graphs[0]
+        graph = gm.graph
+
+        import operator
+
+        from torch._functorch._aot_autograd.streams import (
+            wrap_all_sync_nodes_with_control_deps,
+        )
+        from torch._inductor.fx_passes.control_dependencies import control_deps
+
+        wrap_all_sync_nodes_with_control_deps(gm)
+
+        control_deps_nodes = list(
+            graph.find_nodes(op="call_function", target=control_deps)
+        )
+        self.assertEqual(len(control_deps_nodes), 1)
+
+        ctrl_node = control_deps_nodes[0]
+        # The tensor arg (add node) should be passed as an arg to control_deps
+        # after additional_deps and subgraph: (deps, subgraph, *node_args, *pass_through)
+        # args[0] = additional_deps tuple, args[1] = subgraph, args[2:] = node_args + pass_through
+        self.assertGreaterEqual(len(ctrl_node.args), 3)
+        # The tensor arg should be an fx.Node (the add result)
+        tensor_arg = ctrl_node.args[2]
+        self.assertIsInstance(tensor_arg, torch.fx.Node)
+
+        # Verify getitem nodes thread the dependency through
+        getitem_nodes = [
+            n
+            for n in graph.nodes
+            if n.op == "call_function"
+            and n.target == operator.getitem
+            and n.args[0] is ctrl_node
+        ]
+        self.assertGreaterEqual(len(getitem_nodes), 1)
+
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests
 

--- a/torch/_functorch/_aot_autograd/streams.py
+++ b/torch/_functorch/_aot_autograd/streams.py
@@ -29,6 +29,7 @@ _SYNC_OPS = (
     torch.ops.streams.record_event.default,
     torch.ops.streams.wait_event.default,
     torch.ops.streams.synchronize_event.default,
+    torch.ops.streams.record_stream.default,
 )
 
 
@@ -375,6 +376,7 @@ def _wrap_sync_node(
     """
     from torch._inductor.fx_passes.control_dependencies import (
         _create_subgraph_for_node,
+        _extract_unique_nodes,
         control_deps,
         get_subgraph_name,
     )
@@ -395,8 +397,11 @@ def _wrap_sync_node(
     subgraph_attr_name = get_subgraph_name(gm, sync_node.name)
     setattr(gm, subgraph_attr_name, subgraph_module)
 
+    # Extract the sync node's own Node args (e.g., the tensor arg for record_stream).
+    # For event-based ops (record_event/wait_event) this is empty since all args are ints.
+    node_args, _, _ = _extract_unique_nodes(sync_node.args, sync_node.kwargs)
+
     # Create control_deps call
-    # Note: sync nodes (record_event/wait_event) only take int args, no Node args.
     with graph.inserting_before(sync_node):
         get_subgraph = graph.get_attr(subgraph_attr_name)
         control_deps_node = graph.call_function(
@@ -404,6 +409,7 @@ def _wrap_sync_node(
             args=(
                 tuple(deps_before_sync),  # additional_deps (all deps for ordering)
                 get_subgraph,  # subgraph
+                *node_args,  # sync node's own Node args (if any)
                 *deps_with_uses_after_sync,  # only pass through deps that are used
             ),
             kwargs={},
@@ -479,7 +485,14 @@ def wrap_all_sync_nodes_with_control_deps(gm: torch.fx.GraphModule) -> None:
 
         if node.op == "call_function":
             if node.target in _SYNC_OPS:
-                event_index: int = node.args[0]  # type: ignore[assignment]
+                is_record_stream = (
+                    node.target is torch.ops.streams.record_stream.default
+                )
+
+                # record_stream takes (tensor, stream_index) — no event_index.
+                # Event-based ops take (event_index, stream_index).
+                if not is_record_stream:
+                    event_index: int = node.args[0]  # type: ignore[assignment]
 
                 # synchronize_event blocks the CPU thread, so it acts
                 # as a barrier across all streams. Collect deps from every
@@ -496,6 +509,12 @@ def wrap_all_sync_nodes_with_control_deps(gm: torch.fx.GraphModule) -> None:
                         deps_before_sync = [*placeholders, *all_stream_deps]
                     else:
                         deps_before_sync = all_stream_deps
+                elif is_record_stream:
+                    # record_stream(tensor, stream_index): deps come from the
+                    # tensor's producing stream (where the tensor lives), not
+                    # the target stream_index.
+                    sync_stream = get_stream(node.args[0])  # type: ignore[arg-type]
+                    deps_before_sync = list(stream_to_nodes.get(sync_stream, ()))
                 else:
                     sync_stream = node.args[1]  # type: ignore[assignment]
                     deps_before_sync = list(stream_to_nodes.get(sync_stream, ()))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #178254
* __->__ #178253
* #178252

Add `torch.ops.streams.record_stream.default` to `_SYNC_OPS` so it gets
wrapped in the `control_deps` HOP for proper ordering in the inductor
scheduler.

Unlike event-based sync ops (record_event, wait_event, synchronize_event)
which take `(event_index: int, stream_index: int)`, record_stream takes
`(tensor: Node, stream_index: int)`. This requires three adaptations:

- Guard `event_index` extraction in `wrap_all_sync_nodes_with_control_deps`
  since record_stream's first arg is a tensor Node, not an event index.
- Use the tensor's producing stream for dependency collection rather than
  `args[1]` (the target stream index).
- Extract the sync node's own Node args via `_extract_unique_nodes` and
  pass them through the `control_deps` call so the subgraph placeholder
  for the tensor arg gets matched.

Authored with Claude.

Pull-Request: https://github.com/pytorch/pytorch/pull/XXXXX

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo