### PR TITLE
[submodule] Upgrade to protobuf v33.6

### DIFF
--- a/c10/util/Logging.cpp
+++ b/c10/util/Logging.cpp
@@ -327,28 +327,26 @@ C10_DEFINE_int(
     google::GLOG_WARNING,
     "The minimum log level that caffe2 will output.");
 
-// Google glog's api does not have an external function that allows one to check
-// if glog is initialized or not. It does have an internal function - so we are
-// declaring it here. This is a hack but has been used by a bunch of others too
-// (e.g. Torch).
-namespace google {
-namespace glog_internal_namespace_ {
+// glog >= 0.6.0 exposes IsGoogleLoggingInitialized() as a public API.
+// Older versions only have it in an internal namespace, unexported on Windows.
+#if !__has_include(<glog/platform.h>)
+namespace google::glog_internal_namespace_ {
 bool IsGoogleLoggingInitialized();
-} // namespace glog_internal_namespace_
-} // namespace google
+} // namespace google::glog_internal_namespace_
+#endif
 
 namespace c10 {
 namespace {
 
 void initGoogleLogging(char const* name) {
-#if !defined(_MSC_VER)
-  // This trick can only be used on UNIX platforms
+#if __has_include(<glog/platform.h>)
+  if (!::google::IsGoogleLoggingInitialized())
+#elif !defined(_MSC_VER)
   if (!::google::glog_internal_namespace_::IsGoogleLoggingInitialized())
 #endif
   {
     ::google::InitGoogleLogging(name);
 #if !defined(_MSC_VER)
-    // This is never defined on Windows
     ::google::InstallFailureSignalHandler();
 #endif
   }

--- a/caffe2/utils/proto_wrap.cc
+++ b/caffe2/utils/proto_wrap.cc
@@ -1,35 +1,8 @@
 #include "caffe2/utils/proto_wrap.h"
 
-C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Winconsistent-missing-override")
-C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Winconsistent-missing-destructor-override")
-C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wsuggest-override")
-C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wdeprecated-dynamic-exception-spec")
 #include <google/protobuf/stubs/common.h>
-#include <google/protobuf/generated_message_util.h>
-C10_DIAGNOSTIC_POP()
-C10_DIAGNOSTIC_POP()
-C10_DIAGNOSTIC_POP()
-C10_DIAGNOSTIC_POP()
-
-namespace ONNX_NAMESPACE {
-
-// ONNX wrapper functions for protobuf's GetEmptyStringAlreadyInited() function
-// used to avoid duplicated global variable in the case when protobuf
-// is built with hidden visibility.
-TORCH_API const ::std::string& GetEmptyStringAlreadyInited() {
-  return ::google::protobuf::internal::GetEmptyStringAlreadyInited();
-}
-
-}  // namespace ONNX_NAMESPACE
 
 namespace caffe2 {
-
-// Caffe2 wrapper functions for protobuf's GetEmptyStringAlreadyInited() function
-// used to avoid duplicated global variable in the case when protobuf
-// is built with hidden visibility.
-TORCH_API const ::std::string& GetEmptyStringAlreadyInited() {
-  return ::google::protobuf::internal::GetEmptyStringAlreadyInited();
-}
 
 void ShutdownProtobufLibrary() {
   ::google::protobuf::ShutdownProtobufLibrary();
@@ -38,13 +11,6 @@ void ShutdownProtobufLibrary() {
 }  // namespace caffe2
 
 namespace torch {
-
-// Caffe2 wrapper functions for protobuf's GetEmptyStringAlreadyInited() function
-// used to avoid duplicated global variable in the case when protobuf
-// is built with hidden visibility.
-TORCH_API const ::std::string& GetEmptyStringAlreadyInited() {
-  return ::google::protobuf::internal::GetEmptyStringAlreadyInited();
-}
 
 void ShutdownProtobufLibrary() {
   ::google::protobuf::ShutdownProtobufLibrary();

--- a/caffe2/utils/proto_wrap.h
+++ b/caffe2/utils/proto_wrap.h
@@ -9,27 +9,9 @@ namespace caffe2 {
 // testing and valgrind cases to avoid protobuf appearing to "leak" memory).
 TORCH_API void ShutdownProtobufLibrary();
 
-// Caffe2 wrapper functions for protobuf's GetEmptyStringAlreadyInited()
-// function used to avoid duplicated global variable in the case when protobuf
-// is built with hidden visibility.
-TORCH_API const ::std::string& GetEmptyStringAlreadyInited();
 } // namespace caffe2
 
-namespace ONNX_NAMESPACE {
-
-// ONNX wrapper functions for protobuf's GetEmptyStringAlreadyInited() function
-// used to avoid duplicated global variable in the case when protobuf
-// is built with hidden visibility.
-TORCH_API const ::std::string& GetEmptyStringAlreadyInited();
-
-} // namespace ONNX_NAMESPACE
-
 namespace torch {
-
-// Caffe2 wrapper functions for protobuf's GetEmptyStringAlreadyInited()
-// function used to avoid duplicated global variable in the case when protobuf
-// is built with hidden visibility.
-TORCH_API const ::std::string& GetEmptyStringAlreadyInited();
 
 void ShutdownProtobufLibrary();
 

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1356,6 +1356,9 @@ if(CAFFE2_CMAKE_BUILDING_WITH_MAIN_REPO AND NOT INTERN_DISABLE_ONNX)
   endif()
   add_definitions(-DONNXIFI_ENABLE_EXT=1)
   set(Python3_EXECUTABLE "${Python_EXECUTABLE}")
+  # Tell ONNX that protobuf was built locally so it skips export() calls
+  # that fail when libprotobuf is in a different export set.
+  set(Build_Protobuf ON)
   if(NOT USE_SYSTEM_ONNX)
     add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/../third_party/onnx EXCLUDE_FROM_ALL)
   endif()

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -583,6 +583,17 @@ if(USE_XNNPACK AND NOT USE_SYSTEM_XNNPACK)
       set(XNNPACK_BUILD_WITH_LIBM OFF CACHE BOOL "")
     endif()
 
+    # Rename XNNPACK's "memory" OBJECT target to "xnnpack-memory" to avoid
+    # collision with abseil-cpp's "memory" INTERFACE target.
+    file(READ "${XNNPACK_SOURCE_DIR}/CMakeLists.txt" _xnnpack_cmake)
+    string(REPLACE "ADD_LIBRARY(memory OBJECT" "ADD_LIBRARY(xnnpack-memory OBJECT" _xnnpack_cmake "${_xnnpack_cmake}")
+    string(REPLACE "SET_TARGET_PROPERTIES(memory " "SET_TARGET_PROPERTIES(xnnpack-memory " _xnnpack_cmake "${_xnnpack_cmake}")
+    string(REPLACE "TARGET_LINK_LIBRARIES(memory " "TARGET_LINK_LIBRARIES(xnnpack-memory " _xnnpack_cmake "${_xnnpack_cmake}")
+    string(REPLACE "TARGET_INCLUDE_DIRECTORIES(memory " "TARGET_INCLUDE_DIRECTORIES(xnnpack-memory " _xnnpack_cmake "${_xnnpack_cmake}")
+    string(REPLACE " memory " " xnnpack-memory " _xnnpack_cmake "${_xnnpack_cmake}")
+    string(REPLACE " memory)" " xnnpack-memory)" _xnnpack_cmake "${_xnnpack_cmake}")
+    file(WRITE "${XNNPACK_SOURCE_DIR}/CMakeLists.txt" "${_xnnpack_cmake}")
+
     add_subdirectory(
       "${XNNPACK_SOURCE_DIR}"
       "${CONFU_DEPENDENCIES_BINARY_DIR}/XNNPACK")

--- a/cmake/ProtoBuf.cmake
+++ b/cmake/ProtoBuf.cmake
@@ -22,7 +22,16 @@ macro(custom_protobuf_find)
   # We will make sure that protobuf and caffe2 uses the same msvc runtime.
   option(protobuf_MSVC_STATIC_RUNTIME "" ${CAFFE2_USE_MSVC_STATIC_RUNTIME})
 
-  if(${CAFFE2_LINK_LOCAL_PROTOBUF})
+  # On aarch64, protobuf+abseil static libs linked into libtorch_cpu.so can
+  # exceed the ±128MB branch range (R_AARCH64_CALL26 relocation overflow),
+  # especially with the prioritized text linker script that reorders sections.
+  # Build protobuf as shared on aarch64 so inter-library calls use PLT/GOT.
+  set(__caffe2_protobuf_shared OFF)
+  if(${CAFFE2_LINK_LOCAL_PROTOBUF} AND CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64")
+    set(__caffe2_protobuf_shared ON)
+  endif()
+
+  if(${CAFFE2_LINK_LOCAL_PROTOBUF} AND NOT __caffe2_protobuf_shared)
     set(__caffe2_CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ${CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS})
     set(__caffe2_CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
     set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS OFF)
@@ -38,11 +47,15 @@ macro(custom_protobuf_find)
   set(__caffe2_CMAKE_POSITION_INDEPENDENT_CODE ${CMAKE_POSITION_INDEPENDENT_CODE})
   set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
+  if(__caffe2_protobuf_shared)
+    set(protobuf_BUILD_SHARED_LIBS ON CACHE BOOL "" FORCE)
+  endif()
+
   add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/../third_party/protobuf)
 
   set(CMAKE_POSITION_INDEPENDENT_CODE ${__caffe2_CMAKE_POSITION_INDEPENDENT_CODE})
 
-  if(${CAFFE2_LINK_LOCAL_PROTOBUF})
+  if(${CAFFE2_LINK_LOCAL_PROTOBUF} AND NOT __caffe2_protobuf_shared)
     set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ${__caffe2_CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS})
     set(BUILD_SHARED_LIBS ON)
     set(CMAKE_CXX_FLAGS ${__caffe2_CMAKE_CXX_FLAGS})

--- a/cmake/ProtoBuf.cmake
+++ b/cmake/ProtoBuf.cmake
@@ -4,7 +4,12 @@ macro(custom_protobuf_find)
   message(STATUS "Use custom protobuf build.")
   option(protobuf_BUILD_TESTS "" OFF)
   option(protobuf_BUILD_EXAMPLES "" OFF)
+  option(protobuf_BUILD_CONFORMANCE "" OFF)
   option(protobuf_WITH_ZLIB "" OFF)
+  set(protobuf_INSTALL ON CACHE BOOL "" FORCE)
+  set(ABSL_ENABLE_INSTALL ON CACHE BOOL "" FORCE)
+  set(ABSL_BUILD_TESTING OFF CACHE BOOL "" FORCE)
+  set(ABSL_PROPAGATE_CXX_STD ON)
   if(${CAFFE2_LINK_LOCAL_PROTOBUF})
     # If we are going to link protobuf locally, we will need to turn off
     # shared libs build for protobuf.
@@ -33,14 +38,7 @@ macro(custom_protobuf_find)
   set(__caffe2_CMAKE_POSITION_INDEPENDENT_CODE ${CMAKE_POSITION_INDEPENDENT_CODE})
   set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-  if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.0.0")
-    message(WARNING "Ancient protobuf forces CMake compatibility")
-    set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
-    add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/../third_party/protobuf/cmake)
-    unset(CMAKE_POLICY_VERSION_MINIMUM)
-  else()
-    add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/../third_party/protobuf/cmake)
-  endif()
+  add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/../third_party/protobuf)
 
   set(CMAKE_POSITION_INDEPENDENT_CODE ${__caffe2_CMAKE_POSITION_INDEPENDENT_CODE})
 
@@ -96,13 +94,6 @@ if((NOT TARGET protobuf::libprotobuf) AND (NOT TARGET protobuf::libprotobuf-lite
       "the future, and you will need to specify -DBUILD_CUSTOM_PROTOBUF=ON "
       "explicitly.")
   custom_protobuf_find()
-
-  # TODO(jiayq): enable this in the future, when Jenkins Mac support is
-  # properly set up with protobuf installs.
-
-  # message(FATAL_ERROR
-  #     "Protobuf cannot be found. Caffe2 will have to build with libprotobuf. "
-  #     "Please set the proper paths so that I can find protobuf correctly.")
 endif()
 
 get_target_property(__tmp protobuf::libprotobuf INTERFACE_INCLUDE_DIRECTORIES)
@@ -165,9 +156,6 @@ function(caffe2_protobuf_generate_cpp_py srcs_var hdrs_var python_var)
     # points to an existing path, it is a no-op.
 
     if(${CAFFE2_LINK_LOCAL_PROTOBUF})
-      # We need to rewrite the pb.h files to route GetEmptyStringAlreadyInited
-      # through our wrapper in proto_utils so the memory location test
-      # is correct.
       add_custom_command(
         OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${fil_we}.pb.cc"
                "${CMAKE_CURRENT_BINARY_DIR}/${fil_we}.pb.h"
@@ -176,11 +164,7 @@ function(caffe2_protobuf_generate_cpp_py srcs_var hdrs_var python_var)
         COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_CURRENT_BINARY_DIR}"
         COMMAND ${CAFFE2_PROTOC_EXECUTABLE} -I${PROJECT_SOURCE_DIR} --cpp_out=${DLLEXPORT_STR}${PROJECT_BINARY_DIR} ${abs_fil}
         COMMAND ${CAFFE2_PROTOC_EXECUTABLE} -I${PROJECT_SOURCE_DIR} --python_out "${PROJECT_BINARY_DIR}" ${abs_fil}
-
-        # If we remove all reference to these pb.h files from external
-        # libraries and binaries this rewrite can be removed.
         COMMAND ${CMAKE_COMMAND} -DFILENAME=${CMAKE_CURRENT_BINARY_DIR}/${fil_we}.pb.h -DNAMESPACES=caffe\;caffe2\;onnx\;torch -P ${PROJECT_SOURCE_DIR}/cmake/ProtoBufPatch.cmake
-
         DEPENDS ${CAFFE2_PROTOC_EXECUTABLE} ${abs_fil}
         COMMENT "Running C++/Python protocol buffer compiler on ${fil}" VERBATIM )
     else()

--- a/cmake/ProtoBuf.cmake
+++ b/cmake/ProtoBuf.cmake
@@ -48,18 +48,6 @@ macro(custom_protobuf_find)
     set(CMAKE_CXX_FLAGS ${__caffe2_CMAKE_CXX_FLAGS})
   endif()
 
-  # Protobuf "namespaced" target is only added post protobuf 3.5.1. As a
-  # result, for older versions, we will manually add alias.
-  if(NOT TARGET protobuf::libprotobuf)
-    add_library(protobuf::libprotobuf ALIAS libprotobuf)
-    add_library(protobuf::libprotobuf-lite ALIAS libprotobuf-lite)
-    # There is link error when cross compiling protoc on mobile:
-    # https://github.com/protocolbuffers/protobuf/issues/2719
-    # And protoc is very unlikely needed for mobile builds.
-    if(NOT (ANDROID OR IOS))
-      add_executable(protobuf::protoc ALIAS protoc)
-    endif()
-  endif()
 endmacro()
 
 # Main entry for protobuf. If we are building on Android, iOS or we have hard
@@ -100,15 +88,7 @@ get_target_property(__tmp protobuf::libprotobuf INTERFACE_INCLUDE_DIRECTORIES)
 message(STATUS "Caffe2 protobuf include directory: " ${__tmp})
 include_directories(BEFORE SYSTEM ${__tmp})
 
-# If Protobuf_VERSION is known (true in most cases, false if we are building
-# local protobuf), then we will add a protobuf version check in
-# Caffe2Config.cmake.in.
-if(DEFINED ${Protobuf_VERSION})
-  set(CAFFE2_KNOWN_PROTOBUF_VERSION TRUE)
-else()
-  set(CAFFE2_KNOWN_PROTOBUF_VERSION FALSE)
-  set(Protobuf_VERSION "Protobuf_VERSION_NOTFOUND")
-endif()
+set(CAFFE2_KNOWN_PROTOBUF_VERSION TRUE)
 
 
 # Figure out which protoc to use.
@@ -149,37 +129,17 @@ function(caffe2_protobuf_generate_cpp_py srcs_var hdrs_var python_var)
     # Add TORCH_API prefix to protobuf classes and methods in all cases
     set(DLLEXPORT_STR "dllexport_decl=TORCH_API:")
 
-    # Note: the following depends on PROTOBUF_PROTOC_EXECUTABLE. This
-    # is done to make sure protoc is built before attempting to
-    # generate sources if we're using protoc from the third_party
-    # directory and are building it as part of the Caffe2 build. If
-    # points to an existing path, it is a no-op.
-
-    if(${CAFFE2_LINK_LOCAL_PROTOBUF})
-      add_custom_command(
-        OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${fil_we}.pb.cc"
-               "${CMAKE_CURRENT_BINARY_DIR}/${fil_we}.pb.h"
-               "${CMAKE_CURRENT_BINARY_DIR}/${fil_we}_pb2.py"
-        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-        COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_CURRENT_BINARY_DIR}"
-        COMMAND ${CAFFE2_PROTOC_EXECUTABLE} -I${PROJECT_SOURCE_DIR} --cpp_out=${DLLEXPORT_STR}${PROJECT_BINARY_DIR} ${abs_fil}
-        COMMAND ${CAFFE2_PROTOC_EXECUTABLE} -I${PROJECT_SOURCE_DIR} --python_out "${PROJECT_BINARY_DIR}" ${abs_fil}
-        COMMAND ${CMAKE_COMMAND} -DFILENAME=${CMAKE_CURRENT_BINARY_DIR}/${fil_we}.pb.h -DNAMESPACES=caffe\;caffe2\;onnx\;torch -P ${PROJECT_SOURCE_DIR}/cmake/ProtoBufPatch.cmake
-        DEPENDS ${CAFFE2_PROTOC_EXECUTABLE} ${abs_fil}
-        COMMENT "Running C++/Python protocol buffer compiler on ${fil}" VERBATIM )
-    else()
-      add_custom_command(
-        OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${fil_we}.pb.cc"
-               "${CMAKE_CURRENT_BINARY_DIR}/${fil_we}.pb.h"
-               "${CMAKE_CURRENT_BINARY_DIR}/${fil_we}_pb2.py"
-        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-        COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_CURRENT_BINARY_DIR}"
-        COMMAND ${CAFFE2_PROTOC_EXECUTABLE} -I${PROJECT_SOURCE_DIR} --cpp_out=${DLLEXPORT_STR}${PROJECT_BINARY_DIR} ${abs_fil}
-        COMMAND ${CAFFE2_PROTOC_EXECUTABLE} -I${PROJECT_SOURCE_DIR} --python_out "${PROJECT_BINARY_DIR}" ${abs_fil}
-        COMMAND ${CMAKE_COMMAND} -DFILENAME=${CMAKE_CURRENT_BINARY_DIR}/${fil_we}.pb.h -DNAMESPACES=caffe\;caffe2\;onnx\;torch -DSYSTEM_PROTOBUF=YES -P ${PROJECT_SOURCE_DIR}/cmake/ProtoBufPatch.cmake
-        DEPENDS ${CAFFE2_PROTOC_EXECUTABLE} ${abs_fil}
-        COMMENT "Running C++/Python protocol buffer compiler on ${fil}" VERBATIM )
-    endif()
+    add_custom_command(
+      OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${fil_we}.pb.cc"
+             "${CMAKE_CURRENT_BINARY_DIR}/${fil_we}.pb.h"
+             "${CMAKE_CURRENT_BINARY_DIR}/${fil_we}_pb2.py"
+      WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+      COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_CURRENT_BINARY_DIR}"
+      COMMAND ${CAFFE2_PROTOC_EXECUTABLE} -I${PROJECT_SOURCE_DIR} --cpp_out=${DLLEXPORT_STR}${PROJECT_BINARY_DIR} ${abs_fil}
+      COMMAND ${CAFFE2_PROTOC_EXECUTABLE} -I${PROJECT_SOURCE_DIR} --python_out "${PROJECT_BINARY_DIR}" ${abs_fil}
+      COMMAND ${CMAKE_COMMAND} -DFILENAME=${CMAKE_CURRENT_BINARY_DIR}/${fil_we}.pb.h -P ${PROJECT_SOURCE_DIR}/cmake/ProtoBufPatch.cmake
+      DEPENDS ${CAFFE2_PROTOC_EXECUTABLE} ${abs_fil}
+      COMMENT "Running C++/Python protocol buffer compiler on ${fil}" VERBATIM )
   endforeach()
 
   set_source_files_properties(${${srcs_var}} ${${hdrs_var}} ${${python_var}} PROPERTIES GENERATED TRUE)

--- a/cmake/ProtoBufPatch.cmake
+++ b/cmake/ProtoBufPatch.cmake
@@ -1,85 +1,8 @@
-# CMake file to replace the string contents in ONNX, Caffe, and Caffe2 proto.
+# CMake file to patch generated .pb.h files for PyTorch compatibility.
 # Usage example:
-#   cmake -DFILENAME=caffe2.pb.h -DLOCAL_PROTOBUF=ON -P ProtoBufPatch.cmake
+#   cmake -DFILENAME=caffe2.pb.h -P ProtoBufPatch.cmake
 
 file(READ ${FILENAME} content)
-
-if(NOT SYSTEM_PROTOBUF)
-  # protobuf-3.6.0 pattern
-  string(
-    REPLACE
-    "::google::protobuf::internal::GetEmptyStringAlreadyInited"
-    "GetEmptyStringAlreadyInited"
-    content
-    "${content}")
-
-  # protobuf-3.8.0+ pattern
-  string(
-    REPLACE
-    "::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited"
-    "GetEmptyStringAlreadyInited"
-    content
-    "${content}")
-
-  string(
-    REPLACE
-    "PROTOBUF_CONSTEXPR"
-    ""
-    content
-    "${content}")
-
-  # https://github.com/protocolbuffers/protobuf/commit/0400cca3236de1ca303af38bf81eab332d042b7c
-  # changes PROTOBUF_CONSTEXPR to constexpr, which breaks windows
-  # build.
-  if(MSVC)
-    string(
-      REGEX REPLACE
-      "static constexpr ([^ ]+) ([^ ]+) ="
-      "static \\1 const \\2 ="
-      content
-      "${content}")
-  endif()
-
-  foreach(ns ${NAMESPACES})
-    # Insert "const ::std::string& GetEmptyStringAlreadyInited();" within
-    # the namespace and make sure we only do it once in the file. Unfortunately
-    # using string(REPLACE ...) doesn't work because it will replace at all
-    # locations and there might be multiple declarations of the namespace
-    # depending on how the proto is structured.
-    set(search "namespace ${ns} {")
-    string(LENGTH "${search}" search_len)
-    string(FIND "${content}" "${search}" pos)
-    if(${pos} GREATER -1)
-      math(EXPR pos "${pos}+${search_len}")
-      string(SUBSTRING "${content}" 0 ${pos} content_pre)
-      string(SUBSTRING "${content}" ${pos} -1 content_post)
-      string(
-        CONCAT
-        content
-        "${content_pre}"
-        " const ::std::string& GetEmptyStringAlreadyInited(); "
-        "${content_post}")
-    endif()
-  endforeach()
-
-  # The moving constructor is defined in the header file, which will cause
-  # a link error that claims that the vftable is not found. Luckily, we
-  # could move the definition into the source file to solve the problem.
-  list(LENGTH NAMESPACES ns_count)
-  if("${FILENAME}" MATCHES ".pb.h" AND ns_count EQUAL 1)
-    string(REPLACE ".pb.h" ".pb.cc" SOURCE_FILENAME ${FILENAME})
-    file(READ ${SOURCE_FILENAME} content_cc_origin)
-
-    string(REGEX MATCHALL "([a-zA-Z_]+)\\([a-zA-Z_]+&& from\\) noexcept[^}]*}" content_cc "${content}")
-    string(REGEX REPLACE "};" "}\n" content_cc "${content_cc}")
-    string(REGEX REPLACE "([a-zA-Z_]+)\\([a-zA-Z_]+&& from\\) noexcept" "  \\1::\\1(\\1&& from) noexcept" content_cc "${content_cc}")
-    set(content_cc "${content_cc_origin}\nnamespace ${NAMESPACES} {\n#if LANG_CXX11\n${content_cc}\n#endif\n}")
-
-    string(REGEX REPLACE "([a-zA-Z_]+)\\([a-zA-Z_]+&& from\\) noexcept([^}]*)}" "\\1(\\1&& from) noexcept;" content "${content}")
-
-    file(WRITE ${SOURCE_FILENAME} "${content_cc}")
-  endif()
-endif(NOT SYSTEM_PROTOBUF)
 
 # constexpr int TensorBoundShape_DimType_DimType_ARRAYSIZE = TensorBoundShape_DimType_DimType_MAX + 1;
 # throws


### PR DESCRIPTION
This PR upgrade Protobuf to v33.6 with the help of Claude Code. It also contains the following changes:
  - Protobuf v3.13 → v33.5 for CMake builds
  - Remove ~150 lines of legacy protobuf patching (GetEmptyStringAlreadyInited, move-constructor rewriting)
  - Fix aarch64 builds by building protobuf as shared to avoid relocation overflow
  - update c10/util/Logging.cpp to use the public IsGoogleLoggingInitialized() API added in glog 0.6.0, with fallback for older versions
  



cc @gujinghui @PenghuiCheng @XiaobingSuper @jianyuh @jgong5 @mingfeima @sanchitintel @ashokei @jingxu10 @min-jean-cho @yanbing-j @Guobing-Chen @Xia-Weiwen @snadampal @EikanWang