### PR TITLE
Add conflict detection for overlapping backend override rules

### DIFF
--- a/test/dynamo/test_debug_utils.py
+++ b/test/dynamo/test_debug_utils.py
@@ -325,9 +325,12 @@ class TestBackendOverrideIntegration(TestCase):
         result = self._run_with_override(device, "0:aot_eager;1:inductor;3:eager")
         self.assertEqual(result, ["aot_eager", "inductor", "eager"])
 
-    def test_first_rule_wins(self, device):
-        result = self._run_with_override(device, ">=0:aot_eager;>=1:inductor")
-        self.assertEqual(result, ["aot_eager", "aot_eager", "aot_eager", "aot_eager"])
+    def test_conflicting_rules_raise(self, device):
+        with self.assertRaisesRegex(
+            torch._dynamo.exc.InternalTorchDynamoError,
+            "Conflicting backend override",
+        ):
+            self._run_with_override(device, ">=0:aot_eager;>=1:inductor")
 
     def test_complex_config(self, device):
         result = self._run_with_override(device, "0:aot_eager;>=2:inductor")

--- a/test/dynamo/test_debug_utils.py
+++ b/test/dynamo/test_debug_utils.py
@@ -468,6 +468,18 @@ class TestInductorConfigOverrideIntegration(TestCase):
         self.assertEqual(router.get_value_for_graph(1), {"b": 2, "c": 3})
         self.assertEqual(router.get_value_for_graph(2), {"c": 3})
 
+    def test_backend_router_conflict_raises(self, device):
+        from torch._dynamo.graph_id_filter import GraphBackendRouter
+
+        with self.assertRaisesRegex(ValueError, "Conflicting backend override"):
+            GraphBackendRouter("0-5:eager;3-10:inductor")
+
+    def test_backend_router_same_backend_no_conflict(self, device):
+        from torch._dynamo.graph_id_filter import GraphBackendRouter
+
+        router = GraphBackendRouter("0:eager;>=0:eager")
+        self.assertIsNotNone(router.get_value_for_graph(0))
+
     def test_get_inductor_config_override_empty(self, device):
         from torch._dynamo.graph_id_filter import (
             get_inductor_config_override_for_compile_id,

--- a/torch/_dynamo/graph_id_filter.py
+++ b/torch/_dynamo/graph_id_filter.py
@@ -185,7 +185,8 @@ class GraphBackendRouter(_GraphRouterBase[Any]):
     The router parses a configuration string with rules in the format:
         "filter1:backend1;filter2:backend2;..."
 
-    Rules are evaluated in order, and the first matching rule wins.
+    If a graph ID matches multiple rules with different backends, a ValueError
+    is raised.
 
     Examples:
         "0-5:eager;>5:inductor"     - IDs 0-5 use eager, rest use inductor
@@ -197,6 +198,7 @@ class GraphBackendRouter(_GraphRouterBase[Any]):
     """
 
     def __init__(self, config_str: str) -> None:
+        self._backend_names: dict[int, str] = {}
         super().__init__(config_str, "backend")
 
     def _parse_value_str(self, value_str: str) -> Any | None:
@@ -209,7 +211,24 @@ class GraphBackendRouter(_GraphRouterBase[Any]):
         # Register the backend so its reset() is called during torch._dynamo.reset()
         assert backend is not None, "Invalid override backend: " + value_str
         cached_backends.setdefault(id(backend), backend)
+        self._backend_names[id(backend)] = value_str
         return backend
+
+    def _match_rules(self, graph_id: int) -> Any | None:
+        """Match rules with conflict detection for overlapping filters."""
+        result = None
+        result_name = None
+        for f, backend in self._rules:
+            if graph_id in f:
+                name = self._backend_names[id(backend)]
+                if result is not None and result is not backend:
+                    raise ValueError(
+                        f"Conflicting backend override for graph {graph_id}: "
+                        f"matched both '{result_name}' and '{name}'"
+                    )
+                result = backend
+                result_name = name
+        return result
 
     def __repr__(self) -> str:
         if not self._rules:

--- a/torch/_dynamo/graph_id_filter.py
+++ b/torch/_dynamo/graph_id_filter.py
@@ -216,19 +216,15 @@ class GraphBackendRouter(_GraphRouterBase[Any]):
 
     def _match_rules(self, graph_id: int) -> Any | None:
         """Match rules with conflict detection for overlapping filters."""
-        result = None
-        result_name = None
-        for f, backend in self._rules:
-            if graph_id in f:
-                name = self._backend_names[id(backend)]
-                if result is not None and result is not backend:
-                    raise ValueError(
-                        f"Conflicting backend override for graph {graph_id}: "
-                        f"matched both '{result_name}' and '{name}'"
-                    )
-                result = backend
-                result_name = name
-        return result
+        matches = {id(backend): backend for f, backend in self._rules if graph_id in f}
+        if len(matches) > 1:
+            names = [self._backend_names[bid] for bid in matches]
+            raise ValueError(
+                f"Conflicting backend override for graph {graph_id}: matched {names}"
+            )
+        if matches:
+            return next(iter(matches.values()))
+        return None
 
     def __repr__(self) -> str:
         if not self._rules:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #178268

Previously, GraphBackendRouter silently used first-match-wins when a
graph ID matched multiple rules with different backends (e.g.,
"0-5:eager;3-10:inductor" would silently ignore inductor for graphs
3-5). This is surprising and likely a user mistake, so raise a
ValueError instead, matching GraphConfigRouter's behavior.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @mlazos