### PR TITLE
[Docs] Fix attn_mask shape in scaled_dot_product_attention docstring

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -6078,7 +6078,7 @@ scaled_dot_product_attention = _add_docstr(
         key (Tensor): Key tensor; shape :math:`(N, ..., H, S, E)`.
         value (Tensor): Value tensor; shape :math:`(N, ..., H, S, Ev)`.
         attn_mask (optional Tensor): Attention mask; shape must be broadcastable to the shape of attention weights,
-            which is :math:`(N,..., L, S)`. Two types of masks are supported.
+            which is :math:`(N,..., Hq, L, S)`. Two types of masks are supported.
             A boolean mask where a value of True indicates that the element *should* take part in attention.
             A float mask of the same type as query, key, value that is added to the attention score.
         dropout_p (float): Dropout probability; if greater than 0.0, dropout is applied


### PR DESCRIPTION
## Summary
- Fix incorrect `attn_mask` shape documentation in `torch.nn.functional.scaled_dot_product_attention`

## Motivation
The docstring for `scaled_dot_product_attention` documents the `attn_mask` shape as broadcastable to `(N, ..., L, S)`, but the actual attention weight tensor has shape `(N, ..., Hq, L, S)` — the query head dimension `Hq` is missing. This causes confusion when using `attn_mask` with GQA (`enable_gqa=True`), where `Hq != H`, since a mask of shape `(N, L, S)` fails at runtime while `(N, Hq, L, S)` works correctly.

Fixes #177482

## Changes
- Updated the `attn_mask` parameter docstring in `torch/nn/functional.py` to use the correct shape `:math:\`(N,..., Hq, L, S)\`` instead of `:math:\`(N,..., L, S)\``

## Test Plan
- Documentation-only change; no functional behavior is modified
- Verified shape is consistent with `query` shape `(N, ..., Hq, L, E)` and return shape `(N, ..., Hq, L, Ev)` already documented in the same docstring
- Verified against the reproduction in the issue: `attn_mask` of shape `(N, Hq, L, S)` works while `(N, L, S)` raises a RuntimeError

cc @drisspg @josh-gleason