### PR TITLE
[CI] Add --include-inductor-graph-partition to vllm benchmarking

### DIFF
--- a/.github/workflows/_vllm-benchmark.yml
+++ b/.github/workflows/_vllm-benchmark.yml
@@ -190,6 +190,7 @@ jobs:
             --models "${MODELS}" \
             --device "${DEVICE_NAME}" \
             --include-eager-mode \
+            --include-inductor-graph-partition \
             --compilation-config "${COMPILATION_CONFIG}"
           popd
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #178272

https://github.com/pytorch/pytorch-integration-testing/pull/166
added a new benchmarking config generation to vllm. Enable it
on PyTorch vLLM data collection pipeline.