### PR TITLE
[Inductor] Fix nan_asserts for FP8 dtypes

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -17748,6 +17748,16 @@ if RUN_GPU:
             ):
                 torch.compile(f)(x)
 
+        @config.patch("nan_asserts", True)
+        def test_nan_checker_fp8(self):
+            def f(x):
+                return x.half() + 1
+
+            x = torch.randn(10, device=GPU_TYPE).to(torch.float8_e4m3fn)
+            ref = f(x)
+            actual = torch.compile(f)(x)
+            self.assertEqual(ref, actual)
+
 
 if RUN_CPU:
 

--- a/torch/_inductor/codegen/multi_kernel.py
+++ b/torch/_inductor/codegen/multi_kernel.py
@@ -257,9 +257,12 @@ class MultiKernel:
                     continue
                 seen.add(arg)
                 if isinstance(precompile_arg, TensorArg):
-                    line = f"assert not {arg}.isnan().any().item()"
+                    # FP8 dtypes don't support isnan/isinf, upcast to float first
+                    dtype = precompile_arg.dtype
+                    cast = ".float()" if dtype.is_floating_point and dtype.itemsize == 1 else ""
+                    line = f"assert not {arg}{cast}.isnan().any().item()"
                     wrapper.writeline(line)
-                    line = f"assert not {arg}.isinf().any().item()"
+                    line = f"assert not {arg}{cast}.isinf().any().item()"
                     wrapper.writeline(line)
 
     @property

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -5972,9 +5972,12 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                         f'AOTI_TORCH_ERROR_CODE_CHECK(aoti_torch_check_inf_and_nan("{arg}", {arg}));'
                     )
                 else:
-                    line = f"assert not {arg}.isnan().any().item()"
+                    # FP8 dtypes don't support isnan/isinf, upcast to float first
+                    dtype = arg_signature.dtype
+                    cast = ".float()" if dtype.is_floating_point and dtype.itemsize == 1 else ""
+                    line = f"assert not {arg}{cast}.isnan().any().item()"
                     wrapper.writeline(line)
-                    line = f"assert not {arg}.isinf().any().item()"
+                    line = f"assert not {arg}{cast}.isinf().any().item()"
                     wrapper.writeline(line)
 
     def create_cse_var(self, *args, **kwargs) -> TritonCSEVariable:

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -1562,9 +1562,12 @@ class PythonWrapperCodegen(CodeGen):
             if isinstance(buf, (sympy.Expr, ir.TorchBindObject)):
                 continue
 
-            line = f"assert not {name}.isnan().any().item()"
+            # FP8 dtypes don't support isnan/isinf, upcast to float first
+            dtype = buf.get_dtype()
+            cast = ".float()" if dtype.is_floating_point and dtype.itemsize == 1 else ""
+            line = f"assert not {name}{cast}.isnan().any().item()"
             self.prefix.writeline(line)
-            line = f"assert not {name}.isinf().any().item()"
+            line = f"assert not {name}{cast}.isinf().any().item()"
             self.prefix.writeline(line)
 
     def write_async_compile_wait(self) -> None:
@@ -1766,8 +1769,12 @@ class PythonWrapperCodegen(CodeGen):
                 self.wrapper_call.do_indent()
                 self.wrapper_call.writeline("if isinstance(var, torch.Tensor):")
                 self.wrapper_call.do_indent()
-                self.wrapper_call.writeline("assert not var.isnan().any().item()")
-                self.wrapper_call.writeline("assert not var.isinf().any().item()")
+                # FP8 dtypes don't support isnan/isinf, upcast to float first
+                self.wrapper_call.writeline(
+                    "_check = var.float() if var.dtype.is_floating_point and var.element_size() == 1 else var"
+                )
+                self.wrapper_call.writeline("assert not _check.isnan().any().item()")
+                self.wrapper_call.writeline("assert not _check.isinf().any().item()")
                 self.wrapper_call.do_unindent(2)
 
             self.wrapper_call.writeline("return (" + ", ".join(output_refs) + ", )")


### PR DESCRIPTION
## Summary
- Fix `nan_asserts` config option crashing with `RuntimeError: "isinf" not implemented for 'Float8_e4m3fn'` when FP8 tensors are used
- Upcast FP8 tensors to float32 before isnan/isinf checks in all four codegen paths

## Motivation
Fixes #149002

When `torch._inductor.config.nan_asserts = True`, the inductor generates `isnan()` / `isinf()` assertions on graph inputs, outputs, and kernel arguments. FP8 dtypes (`float8_e4m3fn`, `float8_e5m2`, etc.) don't implement these operations, so the generated code crashes at runtime.

As suggested in the issue, the fix upcasts FP8 tensors to float32 before checking. FP8 types are identified at codegen time by `dtype.is_floating_point and dtype.itemsize == 1` (all FP8 types are 1-byte floating point). For the output-checking path where dtype is not available at codegen time, a runtime check using `element_size() == 1` is used instead.

## Changes
- **`torch/_inductor/codegen/wrapper.py`**: Fix `codegen_input_nan_asserts` (graph inputs) and `generate_return` (graph outputs)
- **`torch/_inductor/codegen/triton.py`**: Fix `codegen_nan_check` (Triton kernel arguments)
- **`torch/_inductor/codegen/multi_kernel.py`**: Fix `codegen_nan_check` (multi-kernel arguments)
- **`test/inductor/test_torchinductor.py`**: Add `test_nan_checker_fp8` test

## Test Plan
- Added `NanCheckerTest.test_nan_checker_fp8` which runs the exact repro from the issue (FP8 input → half conversion → addition) with `nan_asserts=True`
- Existing `test_nan_checker_pass` and `test_nan_checker_fail` tests continue to verify non-FP8 behavior

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos @henrylhtsang @eellison