### PR TITLE
Skip fake autocast tests for `linalg.pinv` and `pinverse` on XPU

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -2768,6 +2768,7 @@ fake_autocast_device_skips = defaultdict(dict)
 # TODO: investigate/fix
 fake_autocast_device_skips["cpu"] = {"linalg.pinv"}
 fake_autocast_device_skips["cuda"] = {"linalg.pinv", "pinverse"}
+fake_autocast_device_skips["xpu"] = {"linalg.pinv", "pinverse"}
 
 
 dynamic_output_op_tests = (

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -2779,6 +2779,7 @@ fake_autocast_device_skips = defaultdict(dict)
 # TODO: investigate/fix
 fake_autocast_device_skips["cpu"] = {"linalg.pinv"}
 fake_autocast_device_skips["cuda"] = {"linalg.pinv", "pinverse"}
+fake_autocast_device_skips["xpu"] = {"linalg.pinv", "pinverse"}
 
 
 dynamic_output_op_tests = (


### PR DESCRIPTION
Add `fake_autocast_device_skips` entry for XPU, aligned with the existing CUDA and CPU behavior. FakeTensor cannot correctly model autocast dtype promotion through `at::matmul` (called internally by `linalg_pinv` and `pinverse`), producing float32 output while real autocast produces float16.

CUDA already skips these tests (added in [1]). The same root cause applies to XPU since it shares the same autocast operation lists and default dtype.

[1] https://github.com/pytorch/pytorch/pull/114531