### PR TITLE
[MPS] Fix linear backward crash with channels_last grad

### DIFF
--- a/aten/src/ATen/native/mps/operations/Linear.mm
+++ b/aten/src/ATen/native/mps/operations/Linear.mm
@@ -206,8 +206,7 @@ static Tensor _mps_linear_backward_input(IntArrayRef input_size, const Tensor& g
     MPSGraphTensor* outputTensor_ = nil;
   };
 
-  Tensor output = at::empty(
-      input_size, grad_output.scalar_type(), std::nullopt, kMPS, std::nullopt, grad_output.suggest_memory_format());
+  Tensor output = at::empty(input_size, grad_output.options());
   TORCH_CHECK(output.is_mps());
   if (grad_output.numel() == 0) {
     return output;
@@ -275,18 +274,8 @@ static std::tuple<Tensor, Tensor> _mps_linear_backward_weights(const Tensor& gra
   TORCH_CHECK(grad_output_reshaped.is_mps());
   TORCH_CHECK(input_reshaped.is_mps());
 
-  Tensor output = at::empty({grad_output_reshaped.size(1), input_reshaped.size(1)},
-                            grad_output.scalar_type(),
-                            std::nullopt,
-                            kMPS,
-                            std::nullopt,
-                            grad_output.suggest_memory_format());
-  Tensor bias = at::empty({grad_output_reshaped.size(1)},
-                          grad_output.scalar_type(),
-                          std::nullopt,
-                          kMPS,
-                          std::nullopt,
-                          grad_output.suggest_memory_format());
+  Tensor output = at::empty({grad_output_reshaped.size(1), input_reshaped.size(1)}, grad_output.options());
+  Tensor bias = at::empty({grad_output_reshaped.size(1)}, grad_output.options());
   TORCH_CHECK(output.is_mps());
   TORCH_CHECK(bias.is_mps());
 

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1395,6 +1395,19 @@ class TestMPS(TestCaseMPS):
         result_contig = torch.nn.functional.linear(input_s, weight_contiguous_equiv)
         self.assertEqual(result_contig, result_sliced)
 
+    def test_linear_backward_channels_last_grad(self):
+        # Regression test for https://github.com/pytorch/pytorch/issues/178222
+        # Linear backward crashed when grad_output had channels_last strides,
+        # because suggest_memory_format() returned ChannelsLast which was then
+        # applied to 2D weight grad and 1D bias grad tensors (requires rank 4).
+        x = torch.randn(2, 8, 3, 4, device='mps', requires_grad=True)
+        proj = torch.nn.Linear(4, 4, device='mps')
+        y = proj(x)
+        z = y.permute(0, 2, 3, 1).contiguous()
+        target = torch.randn_like(z)
+        loss = (z - target).pow(2).sum()
+        loss.backward()
+
     def _linear_helper(self, in_features, out_features, shape, bias=True, backward_pass=False):
         cpu_linear = torch.nn.Linear(in_features=in_features, out_features=out_features, device="cpu", bias=bias)
         mps_linear = torch.nn.Linear(in_features=in_features, out_features=out_features, device="mps", bias=bias)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #178278

`mps_linear_backward` passed `grad_output.suggest_memory_format()` to `at::empty()` when allocating the weight and bias gradient tensors. When `grad_output` happened to have NHWC-like strides (e.g. from a permute
chain), `suggest_memory_format()` returned `ChannelsLast`, which requires rank 4 — but the weight gradient is 2D and the bias gradient is 1D, triggering "required rank 4 tensor to use channels_last format". This logic existed there since the inception of MPS backend in https://github.com/pytorch/pytorch/77343 


Replace verbose `at::empty(size, scalar_type, nullopt, kMPS, nullopt,
suggest_memory_format())` with more compact `at::empty(size, grad_output.options())`


Fixes https://github.com/pytorch/pytorch/issues/178222