### PR TITLE
[Triton][Inductor] Enable out_dtype support for Triton BMM template (#178287)

### DIFF
--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -1987,20 +1987,32 @@ class TestMaxAutotune(TestCase):
 
         a = torch.randn(2, 3, 4, device=GPU_TYPE, dtype=torch.float16)
         b = torch.randn(2, 4, 5, device=GPU_TYPE, dtype=torch.float16)
+        expected = torch.bmm(a.float(), b.float())
+        with config.patch(
+            max_autotune=False,
+            max_autotune_gemm_backends="ATEN",
+        ):
+            compiled_f = torch.compile(f)
+            out, code = run_and_get_code(compiled_f, a, b)
+            FileCheck().check("extern_kernels.bmm_dtype").run(code[0])
+            self.assertEqual(out, expected, atol=1e-3, rtol=1e-3)
+
+    @unittest.skipIf(config.cpp_wrapper, "out_dtype override not supported for AOTI")
+    def test_triton_bmm_out_dtype(self):
+        def f(a, b, out_dtype=torch.float32):
+            return torch.bmm(a, b, out_dtype=out_dtype)
+
+        a = torch.randn(2, 3, 4, device=GPU_TYPE, dtype=torch.float16)
+        b = torch.randn(2, 4, 5, device=GPU_TYPE, dtype=torch.float16)
+        expected = torch.bmm(a.float(), b.float())
         with config.patch(
             max_autotune=True,
             max_autotune_gemm_backends="TRITON",
         ):
             compiled_f = torch.compile(f)
-            with self.assertRaisesRegex(
-                torch._inductor.exc.InductorError,
-                r"LoweringException: NoValidChoicesError: No choices to select",
-            ):
-                out, code = run_and_get_code(compiled_f, a, b)
-
-        compiled_f = torch.compile(f)
-        out, code = run_and_get_code(compiled_f, a, b)
-        FileCheck().check("extern_kernels.bmm_dtype").run(code[0])
+            out, code = run_and_get_code(compiled_f, a, b, out_dtype=torch.float32)
+            FileCheck().check("triton_tem_fused_bmm").run(code[0])
+            self.assertEqual(out, expected, atol=1e-3, rtol=1e-3)
 
     def test_triton_template_generated_code_cache_key(self):
         generate_and_load_args = len(

--- a/torch/_inductor/kernel/bmm.py
+++ b/torch/_inductor/kernel/bmm.py
@@ -179,11 +179,13 @@ def tuned_bmm(mat1, mat2, out_dtype=None, *, layout=None):
         templates_to_use.append(aten_handler)
         kwarg_overrides[aten_handler.uid] = aten_extra_kwargs
 
-    if use_triton_template(layout, check_max_autotune=False) and (
-        out_dtype is None or out_dtype == mat1.get_dtype()
-    ):
-        # TODO: add out_dtype support for Triton Template
+    if use_triton_template(layout, check_max_autotune=False):
         templates_to_use.append(bmm_template)
+        # when out_dtype not specified, default to the input dtype
+        triton_out_dtype = out_dtype or mat1.get_dtype()
+        kwarg_overrides[bmm_template.uid] = {
+            "OUT_DTYPE": f"tl.{triton_out_dtype}".replace("torch.", ""),
+        }
 
     # Single unified call for all templates
     choices.extend(
@@ -275,15 +277,25 @@ def tuned_baddbmm(inp, mat1, mat2, *, alpha=1, beta=1, layout=None):
 
     # Collect all templates for unified call
     templates_to_use: list[ExternKernelChoice | KernelTemplate] = []
+    kwarg_overrides = {}
+
     if use_aten_gemm_kernels():
         templates_to_use.append(aten_baddbmm)
 
     if use_triton_template(layout, check_max_autotune=False):
         templates_to_use.append(bmm_template)
+        kwarg_overrides[bmm_template.uid] = {
+            "OUT_DTYPE": f"tl.{mat1.get_dtype()}".replace("torch.", ""),
+        }
 
     # Single unified call for all templates
     choices.extend(
-        V.choices.get_template_configs(kernel_inputs, templates_to_use, name)
+        V.choices.get_template_configs(
+            kernel_inputs,
+            templates_to_use,
+            name,
+            kwarg_overrides=kwarg_overrides,
+        )
     )
 
     node, _ = autotune_select_algorithm(name, choices, kernel_inputs.nodes(), layout)

--- a/torch/_inductor/kernel/templates/triton_bmm.py.jinja
+++ b/torch/_inductor/kernel/templates/triton_bmm.py.jinja
@@ -62,5 +62,8 @@
     idx_n = rn[None, :]
     mask = (idx_m < M) & (idx_n < N)
 
+    # cast accumulator to output dtype
+    acc = acc.to({{OUT_DTYPE}})
+
     # inductor generates a suffix
     {{store_output(("idx_q", "idx_m", "idx_n"), "acc", "mask", val_shape=("BLOCK_M", "BLOCK_N"))}}


### PR DESCRIPTION
Summary:

Enable out_dtype for Triton bmm templates

Test Plan:
TORCHINDUCTOR_FORCE_DISABLE_CACHES=1 buck2 run fbcode//mode/opt-amd-gpu                                             
fbcode//caffe2/test/inductor:max_autotune_amd -- -r test_triton_bmm_out_dtype

Reviewed By: PaulZhang12

Differential Revision: D97946266




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos