### PR TITLE
[Kineto] Fix null deref crash in disableProfiler() during preemption (#178288)

### DIFF
--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -876,10 +876,16 @@ std::unique_ptr<ProfilerResult> disableProfiler() {
   profiler_state_info_ptr = nullptr;
 
   auto state_ptr = ProfilerStateBase::pop();
+  if (!state_ptr) {
+    LOG(WARNING)
+        << "disableProfiler called but no active profiling session found. "
+        << "This can happen if profiling was cancelled during warmup.";
+    return std::make_unique<ProfilerResult>();
+  }
   const auto& config = state_ptr->config();
   TORCH_CHECK(
-      state_ptr && isValidDisableState(config.state),
-      "Can't disable Kineto profiler when it's not running");
+      isValidDisableState(config.state),
+      "Can't disable Kineto profiler: config is not in a valid disable state");
 
   state_ptr->removeCallback();
 


### PR DESCRIPTION
Summary:
MAST training jobs crash with "Can't disable Kineto profiler when it's not running" during preemption when the profiler is active. The crash occurs in `disableProfiler()` because `ProfilerStateBase::pop()` can return null (when a concurrent thread already popped the state), but the code dereferences `state_ptr` to access `config()` before checking for null.

This fix adds a null check on `state_ptr` immediately after `pop()`. If null, it logs a warning and returns an empty `ProfilerResult` instead of crashing. The `TORCH_CHECK` is also simplified to remove the now-redundant `state_ptr &&` check.

More details - https://docs.google.com/document/d/1pnoKPGYijOQ_C_dtmT2QS--KmXuu08cAAXT9u3KwYco/edit?usp=sharing


Test Plan: CI

Reviewed By: ryanzhang22, yangw-dev

Differential Revision: D97822176

Pulled By: RohanVardhan
