### PR TITLE
[Inductor] Fix data dependent dynamic shape for repeat_interleave codegen

### DIFF
--- a/test/dynamo/test_fx_graph_runnable.py
+++ b/test/dynamo/test_fx_graph_runnable.py
@@ -6,10 +6,12 @@ import subprocess
 import sys
 import unittest
 from unittest import mock
+from unittest.mock import MagicMock
 
 import torch
 import torch._logging.structured
 import torch.distributed as dist
+from torch._dynamo.repro.after_aot import repro_common
 from torch._inductor.codecache import WritableTempFile
 from torch._inductor.test_case import TestCase
 from torch.testing._internal.common_utils import IS_FBCODE, IS_SANDCASTLE
@@ -586,6 +588,59 @@ class FxGraphRunnableTest(TestCase):
         self._exec_and_verify_payload()
         payload = self.buffer.getvalue().strip()
         self.assertNotIn("# Fixup: ensure sum(repeats) == output_size", payload)
+
+    def test_repro_common_converts_symints(self):
+        """Test that repro_common converts plain int symint args to SymInt objects."""
+
+        class MinimalRepeatInterleaveRepro(torch.nn.Module):
+            def forward(
+                self, repeats: torch.Tensor, data: torch.Tensor, output_size: int
+            ):
+                indices = torch.ops.aten.repeat_interleave.Tensor(
+                    repeats, output_size=output_size
+                )
+                result = torch.ops.aten.index.Tensor(data, [indices])
+                return (result,)
+
+        def load_args(reader):
+            buf0 = reader.storage(
+                None, 80, device=torch.device("cpu"), dtype_hint=torch.int64
+            )
+            reader.tensor(buf0, (10,), dtype=torch.int64, is_leaf=True)
+
+            buf1 = reader.storage(
+                None, 400, device=torch.device("cpu"), dtype_hint=torch.float32
+            )
+            reader.tensor(buf1, (100, 1), is_leaf=True)
+
+            reader.symint(50)
+
+            # Fixup for repeat_interleave
+            if hasattr(reader, "args"):
+                _repeats = reader.args[0]
+                _output_size = reader.args[2]
+                if isinstance(_repeats, torch.Tensor) and _repeats.dtype == torch.int64:
+                    _n = _repeats.numel()
+                    _repeats.fill_(_output_size // _n)
+                    _repeats[: _output_size % _n] += 1
+
+        load_args._version = 0
+
+        mod = MinimalRepeatInterleaveRepro()
+        options = MagicMock()
+        options.save_dir = None
+        options.tracing_mode = "symbolic"
+
+        _, args = repro_common(options, mod, load_args)
+
+        # Verify symint arg was converted to SymInt
+        output_size_arg = args[2]
+        self.assertIsInstance(
+            output_size_arg,
+            torch.SymInt,
+            f"Expected SymInt, got {type(output_size_arg)}",
+        )
+        self.assertEqual(output_size_arg.node.hint, 50)
 
 
 @unittest.skipIf(IS_FBCODE or IS_SANDCASTLE, "Skip in fbcode/sandcastle")

--- a/torch/_dynamo/debug_utils.py
+++ b/torch/_dynamo/debug_utils.py
@@ -607,6 +607,8 @@ class InputReader:
         self.store = ContentStoreReader(save_dir) if save_dir is not None else None
         self.args: list[Any] = []
         self.pbar = pbar
+        # Track indices of symint arguments for proper SymInt conversion later
+        self.symint_indices: list[int] = []
 
     def storage(
         self,
@@ -671,6 +673,7 @@ class InputReader:
         return t  # for BC
 
     def symint(self, val: Any) -> Any:
+        self.symint_indices.append(len(self.args))
         self.args.append(val)
         return val  # for BC
 

--- a/torch/_dynamo/repro/after_aot.py
+++ b/torch/_dynamo/repro/after_aot.py
@@ -1056,12 +1056,37 @@ def repro_common(
         load_args(input_reader)
         args = input_reader.args
 
+    # Track symint indices before make_fx modifies anything
+    symint_indices = getattr(input_reader, "symint_indices", [])
+
     # Turn mod into a GraphModule the slow way
     # TODO: speed this up
     mod = make_fx(mod, tracing_mode=options.tracing_mode)(*args)
 
     # pyrefly: ignore [bad-assignment]
     torch._inductor.config.generate_intermediate_hooks = True
+
+    # Convert plain int symint args to proper SymInt objects using the GraphModule's
+    # shape_env. This ensures compile_fx_inner can properly track unbacked symbols
+    # from operations like repeat_interleave. Without this, shape_env_from_inputs()
+    # returns None and unbacked symbols are never defined in the generated code.
+    # Only convert args at indices that were loaded via reader.symint().
+    if symint_indices and mod.shape_env:
+        shape_env = mod.shape_env
+        from torch._dynamo.source import SyntheticLocalSource
+        from torch.fx.experimental.symbolic_shapes import DimDynamic
+
+        for i, idx in enumerate(symint_indices):
+            val = args[idx]
+            if isinstance(val, int) and not isinstance(val, bool):
+                source = SyntheticLocalSource(f"repro_symint_{i}")
+                sym = shape_env.create_symbol(
+                    val,
+                    source=source,
+                    dynamic_dim=DimDynamic.DYNAMIC,
+                    constraint_dim=None,
+                )
+                args[idx] = shape_env.create_symintnode(sym, hint=val)
 
     return mod, args
 


### PR DESCRIPTION
Differential Revision: D97972598

Previously, https://github.com/pytorch/pytorch/pull/177909/ fixes the `repeat_interleave` constraints requirements on the tensor values. However, the `output_size` int passed in is marked as static, which creates issues as an unbacked symint is emitted from `repeat_interleave`. Here, we actually mark all the symints in the reader as actual symints




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo