### PR TITLE
[BE][JIT] Replace LOG(FATAL) with TORCH_INTERNAL_ASSERT

### DIFF
--- a/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
@@ -37,7 +37,7 @@ static inline ExprPtr newBinaryOpOfType(
     case IRNodeType::kRshift:
       return alloc<Rshift>(lhs, rhs);
     default:
-      LOG(FATAL) << "unsupported expr_type: " << static_cast<int>(expr_type);
+      TORCH_INTERNAL_ASSERT(false, "unsupported expr_type: ", static_cast<int>(expr_type));
       return nullptr;
   }
 }

--- a/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
@@ -37,7 +37,8 @@ static inline ExprPtr newBinaryOpOfType(
     case IRNodeType::kRshift:
       return alloc<Rshift>(lhs, rhs);
     default:
-      TORCH_INTERNAL_ASSERT(false, "unsupported expr_type: ", static_cast<int>(expr_type));
+      TORCH_INTERNAL_ASSERT(
+          false, "unsupported expr_type: ", static_cast<int>(expr_type));
       return nullptr;
   }
 }


### PR DESCRIPTION
We should never use `FATAL` (which kills the program), but rather throw an exception

cc @EikanWang @jgong5