### PR TITLE
Move SAC ac_graph_id tagging from HOP to _CachingTorchDispatchMode

### DIFF
--- a/test/dynamo/test_activation_checkpointing.py
+++ b/test/dynamo/test_activation_checkpointing.py
@@ -5,13 +5,16 @@ import contextlib
 import copy
 import functools
 import math
+import operator
 import re
 import unittest  # noqa: F811
+from collections import defaultdict
 from importlib import import_module
 
 import torch
 import torch._dynamo.config
 import torch._dynamo.test_case
+import torch.utils._pytree as pytree
 import torch._functorch.config
 import torch.distributed as dist
 import torch.nn as nn
@@ -2481,6 +2484,108 @@ devices = ["cuda", "hpu"]
 instantiate_device_type_tests(
     ActivationCheckpointingViaTagsTests, globals(), only_for=devices
 )
+
+
+class ActivationCheckpointingMakeFxTests(torch._dynamo.test_case.TestCase):
+    """Tests that SAC metadata is correctly stamped when tracing with make_fx."""
+
+    def _trace_with_make_fx(self, mod, args):
+        from torch._subclasses import FakeTensorMode
+        from torch.fx.experimental.proxy_tensor import make_fx
+        from torch.fx.experimental.symbolic_shapes import ShapeEnv
+        from torch.fx.traceback import preserve_node_meta
+        from torch.nn.utils import stateless
+
+        named_params = dict(mod.named_parameters(remove_duplicate=False))
+        named_bufs = dict(mod.named_buffers(remove_duplicate=False))
+        params_and_bufs = {**named_params, **named_bufs}
+        flat_params, params_spec = pytree.tree_flatten(params_and_bufs)
+        params_len = len(flat_params)
+
+        def functional_call(*all_args):
+            p = all_args[:params_len]
+            u = all_args[params_len:]
+            params = pytree.tree_unflatten(list(p), params_spec)
+            with stateless._reparametrize_module(mod, params):
+                return mod.forward(*u)
+
+        flat_user, user_spec = pytree.tree_flatten(args)
+        full_args = tuple(flat_params) + tuple(flat_user)
+
+        fake_mode = FakeTensorMode(
+            allow_non_fake_inputs=True,
+            shape_env=ShapeEnv(),
+        )
+        fake_args = tuple(
+            fake_mode.from_tensor(a, static_shapes=True) if isinstance(a, torch.Tensor) else a
+            for a in full_args
+        )
+
+        def fn(*plain_args):
+            p = list(plain_args[:params_len])
+            u = pytree.tree_unflatten(list(plain_args[params_len:]), user_spec)
+            out = functional_call(*p, *u)
+            flat, _ = pytree.tree_flatten(out)
+            return flat
+
+        prev = torch._dynamo.config.error_on_nested_fx_trace
+        torch._dynamo.config.error_on_nested_fx_trace = False
+        try:
+            with fake_mode, preserve_node_meta():
+                return make_fx(fn, record_stack_traces=True)(*fake_args)
+        finally:
+            torch._dynamo.config.error_on_nested_fx_trace = prev
+
+    def test_sac_region_ids(self):
+        """ac_graph_id is unique per checkpoint region and recompute tags are correct."""
+
+        def policy_fn(ctx, func, *args, **kwargs):
+            if func == torch.ops.aten.addmm.default:
+                return CheckpointPolicy.MUST_SAVE
+            return CheckpointPolicy.PREFER_RECOMPUTE
+
+        def context_fn():
+            return create_selective_checkpoint_contexts(policy_fn)
+
+        class Block(nn.Module):
+            def __init__(self, dim):
+                super().__init__()
+                self.linear = nn.Linear(dim, dim)
+
+            def forward(self, x):
+                return self.linear(x)
+
+        class Model(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.layers = nn.ModuleList([Block(8) for _ in range(3)])
+
+            def forward(self, x):
+                for layer in self.layers:
+                    x = checkpoint(
+                        layer, x, use_reentrant=False, context_fn=context_fn,
+                    )
+                return x
+
+        gm = self._trace_with_make_fx(Model(), (torch.randn(2, 8),))
+
+        # Collect ac_graph_ids for call_function nodes that have them.
+        ids_seen = set()
+        id_to_nodes = defaultdict(list)
+        for node in gm.graph.nodes:
+            ac_id = node.meta.get("ac_graph_id")
+            if ac_id is not None:
+                ids_seen.add(ac_id)
+                id_to_nodes[ac_id].append(node)
+
+        # 3 checkpoint regions -> 3 distinct ac_graph_ids
+        self.assertEqual(len(ids_seen), 3)
+
+        # addmm nodes should be MUST_SAVE
+        for node in gm.graph.nodes:
+            if node.target == torch.ops.aten.addmm.default:
+                self.assertEqual(node.meta.get("recompute"), CheckpointPolicy.MUST_SAVE)
+
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/torch/_higher_order_ops/wrap.py
+++ b/torch/_higher_order_ops/wrap.py
@@ -426,12 +426,12 @@ class TagActivationCheckpoint(HigherOrderOperator):
         unique_graph_id = next(uid)
         for node in gmod.graph.nodes:
             if node.op in ("call_function", "call_method", "call_module"):
-                node.meta["ac_graph_id"] = unique_graph_id
                 if is_sac:
-                    # For selective checkpointing, we will populate this tag later in _CachingTorchDispatchMode.
-                    node.meta["recompute"] = None
+                    # ac_graph_id and recompute are populated by _CachingTorchDispatchMode.
+                    pass
                 else:
                     # Under vanilla activation checkpointing, all nodes should be recomputed.
+                    node.meta["ac_graph_id"] = unique_graph_id
                     node.meta["recompute"] = CheckpointPolicy.PREFER_RECOMPUTE
         return gmod
 

--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import contextlib
+import itertools
 import platform
 import uuid
 import warnings
@@ -1310,6 +1311,9 @@ SAC_IGNORED_OPS = {
 } | set(torch._subclasses.functional_tensor.FunctionalTensor.metadata_fns)  # type: ignore[has-type]
 
 
+_sac_id_counter = itertools.count(1)
+
+
 class _CachingTorchDispatchMode(TorchDispatchMode):
     @classmethod
     def ignore_compile_internals(cls):
@@ -1319,6 +1323,7 @@ class _CachingTorchDispatchMode(TorchDispatchMode):
     def __init__(self, policy_fn, storage) -> None:
         self.policy_fn = policy_fn
         self.storage = storage
+        self.ac_graph_id = next(_sac_id_counter)
 
     def __torch_dispatch__(self, func, types, args=(), kwargs=None):
         if func in SAC_IGNORED_OPS:
@@ -1333,8 +1338,8 @@ class _CachingTorchDispatchMode(TorchDispatchMode):
         is_compiling = _is_compiling(func, args, kwargs)
 
         if is_compiling:
-            # Overwrite each node's "recompute" tag to add in the user annotation.
             fx_traceback.current_meta["recompute"] = policy
+            fx_traceback.current_meta["ac_graph_id"] = self.ac_graph_id
 
         out = func(*args, **kwargs)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #178292

For selective activation checkpointing (SAC), ac_graph_id and recompute
tags were previously stamped in two places: tag_nodes in the HOP set
ac_graph_id on body subgraph nodes, then _CachingTorchDispatchMode
overwrote the recompute tag during tracing. This moves ac_graph_id
stamping into _CachingTorchDispatchMode so both the HOP path
(torch.compile) and non-HOP path (make_fx / non-strict tracer) get
ac_graph_id through the same code path.

Vanilla (non-selective) AC is unchanged -- it doesn't use
_CachingTorchDispatchMode, so tag_nodes still handles it.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98 @Lucaskabela