### PR TITLE
Fix division-by-zero in lr_scheduler parameter validation (#177833)

### DIFF
--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -352,7 +352,7 @@ class TestLRScheduler(TestCase):
 
     @parametrize("step_size", [0, -1])
     def test_step_lr_step_size_non_positive(self, step_size):
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError, "step_size must be a positive integer"):
             StepLR(self.opt, step_size=step_size)
 
     def test_get_last_lr_step_lr(self):
@@ -542,7 +542,7 @@ class TestLRScheduler(TestCase):
 
     @parametrize("T_max", [0, -1])
     def test_cos_anneal_lr_T_max_non_positive(self, T_max):
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError, "T_max must be a positive integer"):
             CosineAnnealingLR(self.opt, T_max=T_max)
 
     def test_closed_form_step_lr(self):
@@ -1719,7 +1719,9 @@ class TestLRScheduler(TestCase):
     def test_cycle_lr_step_size_up_non_positive(self, step_size_up):
         base_lr = 1
         max_lr = 5
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(
+            ValueError, "step_size_up must be a positive integer"
+        ):
             CyclicLR(
                 self.opt, base_lr=base_lr, max_lr=max_lr, step_size_up=step_size_up
             )
@@ -1864,13 +1866,17 @@ class TestLRScheduler(TestCase):
 
     @parametrize("div_factor", [0, -1])
     def test_onecycle_lr_div_factor_non_positive(self, div_factor):
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError, "div_factor must be a positive float"):
             OneCycleLR(self.opt, max_lr=1e-3, total_steps=10, div_factor=div_factor)
 
     @parametrize("final_div_factor", [0, -1])
     def test_onecycle_lr_final_div_factor_non_positive(self, final_div_factor):
-        with self.assertRaises(ValueError):
-            OneCycleLR(self.opt, max_lr=1e-3, total_steps=10, final_div_factor=final_div_factor)
+        with self.assertRaisesRegex(
+            ValueError, "final_div_factor must be a positive float"
+        ):
+            OneCycleLR(
+                self.opt, max_lr=1e-3, total_steps=10, final_div_factor=final_div_factor
+            )
 
     def test_cycle_lr_with_adam(self):
         old_opt = self.opt

--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -350,6 +350,11 @@ class TestLRScheduler(TestCase):
         scheduler = StepLR(self.opt, gamma=0.1, step_size=3)
         self._test(scheduler, targets, epochs)
 
+    @parametrize("step_size", [0, -1])
+    def test_step_lr_step_size_non_positive(self, step_size):
+        with self.assertRaises(ValueError):
+            StepLR(self.opt, step_size=step_size)
+
     def test_get_last_lr_step_lr(self):
         from torch.nn import Parameter
 
@@ -445,6 +450,11 @@ class TestLRScheduler(TestCase):
         scheduler = ConstantLR(self.opt, factor=1.0 / 2, total_iters=5)
         self._test(scheduler, targets, epochs)
 
+    @parametrize("factor", [0, -1])
+    def test_constantlr_factor_non_positive(self, factor):
+        with self.assertRaises(ValueError):
+            ConstantLR(self.opt, factor=factor)
+
     def test_linearlr(self):
         # lr = 0.025     if epoch == 0
         # lr = 0.03125   if epoch == 1
@@ -529,6 +539,11 @@ class TestLRScheduler(TestCase):
         targets = [single_targets, [x * epochs for x in single_targets]]
         scheduler = CosineAnnealingLR(self.opt, T_max=epochs, eta_min=eta_min)
         self._test(scheduler, targets, epochs)
+
+    @parametrize("T_max", [0, -1])
+    def test_cos_anneal_lr_T_max_non_positive(self, T_max):
+        with self.assertRaises(ValueError):
+            CosineAnnealingLR(self.opt, T_max=T_max)
 
     def test_closed_form_step_lr(self):
         scheduler = StepLR(self.opt, gamma=0.1, step_size=3)
@@ -1700,6 +1715,15 @@ class TestLRScheduler(TestCase):
         self.assertIs(scheduler._scale_fn_custom, scale_fn)
         self.assertIs(restored_scheduler._scale_fn_custom, scale_fn)
 
+    @parametrize("step_size_up", [0, -1])
+    def test_cycle_lr_step_size_up_non_positive(self, step_size_up):
+        base_lr = 1
+        max_lr = 5
+        with self.assertRaises(ValueError):
+            CyclicLR(
+                self.opt, base_lr=base_lr, max_lr=max_lr, step_size_up=step_size_up
+            )
+
     def test_onecycle_lr_invalid_anneal_strategy(self):
         with self.assertRaises(ValueError):
             scheduler = OneCycleLR(
@@ -1837,6 +1861,16 @@ class TestLRScheduler(TestCase):
         lr_targets = [lr_target, lr_target]
         momentum_targets = [momentum_target, momentum_target]
         self._test_cycle_lr(scheduler, lr_targets, momentum_targets, 10)
+
+    @parametrize("div_factor", [0, -1])
+    def test_onecycle_lr_div_factor_non_positive(self, div_factor):
+        with self.assertRaises(ValueError):
+            OneCycleLR(self.opt, max_lr=1e-3, total_steps=10, div_factor=div_factor)
+
+    @parametrize("final_div_factor", [0, -1])
+    def test_onecycle_lr_final_div_factor_non_positive(self, final_div_factor):
+        with self.assertRaises(ValueError):
+            OneCycleLR(self.opt, max_lr=1e-3, total_steps=10, final_div_factor=final_div_factor)
 
     def test_cycle_lr_with_adam(self):
         old_opt = self.opt

--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -1717,14 +1717,17 @@ class TestLRScheduler(TestCase):
 
     @parametrize("step_size_up", [0, -1])
     def test_cycle_lr_step_size_up_non_positive(self, step_size_up):
-        base_lr = 1
-        max_lr = 5
         with self.assertRaisesRegex(
             ValueError, "step_size_up must be a positive integer"
         ):
-            CyclicLR(
-                self.opt, base_lr=base_lr, max_lr=max_lr, step_size_up=step_size_up
-            )
+            CyclicLR(self.opt, base_lr=1, max_lr=5, step_size_up=step_size_up)
+
+    @parametrize("step_size_down", [0, -1])
+    def test_cycle_lr_step_size_down_non_positive(self, step_size_down):
+        with self.assertRaisesRegex(
+            ValueError, "step_size_down must be a positive integer"
+        ):
+            CyclicLR(self.opt, base_lr=1, max_lr=5, step_size_down=step_size_down)
 
     def test_onecycle_lr_invalid_anneal_strategy(self):
         with self.assertRaises(ValueError):

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -1916,10 +1916,15 @@ class CyclicLR(LRScheduler):
             )
         # pyrefly: ignore [bad-assignment]
         step_size_up = float(step_size_up)
-        step_size_down = (
+        if step_size_down is not None:
+            if step_size_down <= 0:
+                raise ValueError(
+                    f"step_size_down must be a positive integer, but got {step_size_down}"
+                )
             # pyrefly: ignore [bad-assignment]
-            float(step_size_down) if step_size_down is not None else step_size_up
-        )
+            step_size_down = float(step_size_down)
+        else:
+            step_size_down = step_size_up
         # pyrefly: ignore [unsupported-operation]
         self.total_size = step_size_up + step_size_down
         self.step_ratio = step_size_up / self.total_size

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -625,6 +625,8 @@ class StepLR(LRScheduler):
         gamma: float = 0.1,
         last_epoch: int = -1,
     ) -> None:  # noqa: D107
+        if step_size <= 0:
+            raise ValueError(f"Expected positive integer, but got {step_size}")
         self.step_size = step_size
         self.gamma = gamma
         super().__init__(optimizer, last_epoch)
@@ -810,7 +812,7 @@ class ConstantLR(LRScheduler):
         total_iters: int = 5,
         last_epoch: int = -1,
     ) -> None:  # noqa: D107
-        if factor > 1.0 or factor < 0:
+        if factor > 1.0 or factor <= 0:
             raise ValueError(
                 "Constant multiplicative factor expected to be between 0 and 1."
             )
@@ -1391,6 +1393,8 @@ class CosineAnnealingLR(LRScheduler):
         eta_min: float = 0.0,
         last_epoch: int = -1,
     ) -> None:  # noqa: D107
+        if T_max <= 0:
+            raise ValueError(f"Expected positive integer, but got {T_max}")
         self.T_max = T_max
         self.eta_min = eta_min
         super().__init__(optimizer, last_epoch)
@@ -1904,6 +1908,8 @@ class CyclicLR(LRScheduler):
 
         self.max_lrs = _format_param("max_lr", optimizer, max_lr)
 
+        if step_size_up <= 0:
+            raise ValueError(f"Expected positive integer, but got {step_size_up}")
         # pyrefly: ignore [bad-assignment]
         step_size_up = float(step_size_up)
         step_size_down = (
@@ -2399,6 +2405,12 @@ class OneCycleLR(LRScheduler):
         if not isinstance(optimizer, Optimizer):
             raise TypeError(f"{type(optimizer).__name__} is not an Optimizer")
         self.optimizer = optimizer
+
+        # Validate div_factor
+        if div_factor <= 0:
+            raise ValueError(f"Expected positive float, but got {div_factor}")
+        if final_div_factor <= 0:
+            raise ValueError(f"Expected positive float, but got {final_div_factor}")
 
         # Validate total_steps
         if total_steps is not None:

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -626,7 +626,9 @@ class StepLR(LRScheduler):
         last_epoch: int = -1,
     ) -> None:  # noqa: D107
         if step_size <= 0:
-            raise ValueError(f"Expected positive integer, but got {step_size}")
+            raise ValueError(
+                f"step_size must be a positive integer, but got {step_size}"
+            )
         self.step_size = step_size
         self.gamma = gamma
         super().__init__(optimizer, last_epoch)
@@ -1394,7 +1396,7 @@ class CosineAnnealingLR(LRScheduler):
         last_epoch: int = -1,
     ) -> None:  # noqa: D107
         if T_max <= 0:
-            raise ValueError(f"Expected positive integer, but got {T_max}")
+            raise ValueError(f"T_max must be a positive integer, but got {T_max}")
         self.T_max = T_max
         self.eta_min = eta_min
         super().__init__(optimizer, last_epoch)
@@ -1909,7 +1911,9 @@ class CyclicLR(LRScheduler):
         self.max_lrs = _format_param("max_lr", optimizer, max_lr)
 
         if step_size_up <= 0:
-            raise ValueError(f"Expected positive integer, but got {step_size_up}")
+            raise ValueError(
+                f"step_size_up must be a positive integer, but got {step_size_up}"
+            )
         # pyrefly: ignore [bad-assignment]
         step_size_up = float(step_size_up)
         step_size_down = (
@@ -2408,9 +2412,13 @@ class OneCycleLR(LRScheduler):
 
         # Validate div_factor
         if div_factor <= 0:
-            raise ValueError(f"Expected positive float, but got {div_factor}")
+            raise ValueError(
+                f"div_factor must be a positive float, but got {div_factor}"
+            )
         if final_div_factor <= 0:
-            raise ValueError(f"Expected positive float, but got {final_div_factor}")
+            raise ValueError(
+                f"final_div_factor must be a positive float, but got {final_div_factor}"
+            )
 
         # Validate total_steps
         if total_steps is not None:


### PR DESCRIPTION
**Summary**
Several `lr_scheduler` classes silently accept zero values for parameters, then raise a `ZeroDivisionError` at runtime. This PR adds validation so users get a clear error message:

- **StepLR**: reject `step_size == 0`
- **CosineAnnealingLR**: reject `T_max == 0`
- **CyclicLR**: reject `step_size_up == 0`
- **ConstantLR**: tighten existing `factor` validation from `< 0` to `<= 0`, since `factor=0` also causes division by zero in `get_lr()`

**Known issues not addressed**
- The learning rate itself can still go negative, which doesn't produce meaningful behavior. Restricting this can be done as a follow-up.
- Two additional `ZeroDivisionError` cases identified which are only happening in the deprecated use case: In `LinearLR` and in `PolynomialLR`: `total_iters=0` causes `ZeroDivisionError` when using the closed form `.step(epoch=..)`

**Test plan**
- Added `test_step_lr_step_size_zero`, `test_constantlr_factor_zero`, `test_cos_anneal_lr_T_max_zero`, and `test_cycle_lr_step_size_up_zero` to verify each scheduler raises `ValueError` on zero input
- Existing `lr_scheduler` tests pass: test/optim/test_lrscheduler.py

Addresses:
#177833 and #174025 