### PR TITLE
Fix CWE-78 OS command injection in release_notes scripts

### DIFF
--- a/scripts/release_notes/categorize.py
+++ b/scripts/release_notes/categorize.py
@@ -1,5 +1,5 @@
 import argparse
-import os
+import subprocess
 import textwrap
 from pathlib import Path
 
@@ -128,7 +128,7 @@ class Categorizer:
         if "module: deprecation" in features.labels:
             breaking_alarm += "\n!!!!!! DEPRECATION !!!!!!"
 
-        os.system("clear")
+        subprocess.run(["clear"], check=False)
         view = textwrap.dedent(
             f"""\
 [{i}/{total}]

--- a/scripts/release_notes/commitlist.py
+++ b/scripts/release_notes/commitlist.py
@@ -375,13 +375,13 @@ class CommitList:
 
     @staticmethod
     def get_commits_between(base_version, new_version):
-        cmd = f"git merge-base {base_version} {new_version}"
+        cmd = ["git", "merge-base", base_version, new_version]
         rc, merge_base, _ = run(cmd)
         assert rc == 0
 
         # Returns a list of something like
         # b33e38ec47 Allow a higher-precision step type for Vec256::arange (#34555)
-        cmd = f"git log --reverse --oneline {merge_base}..{new_version}"
+        cmd = ["git", "log", "--reverse", "--oneline", f"{merge_base}..{new_version}"]
         rc, commits, _ = run(cmd)
         assert rc == 0
 

--- a/scripts/release_notes/common.py
+++ b/scripts/release_notes/common.py
@@ -144,9 +144,7 @@ def features_to_dict(features):
 
 def run(command):
     """Returns (return-code, stdout, stderr)"""
-    p = subprocess.Popen(
-        command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True
-    )
+    p = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     output, err = p.communicate()
     rc = p.returncode
     enc = locale.getpreferredencoding()
@@ -156,19 +154,19 @@ def run(command):
 
 
 def commit_body(commit_hash):
-    cmd = f"git log -n 1 --pretty=format:%b {commit_hash}"
+    cmd = ["git", "log", "-n", "1", "--pretty=format:%b", commit_hash]
     ret, out, err = run(cmd)
     return out if ret == 0 else None
 
 
 def commit_title(commit_hash):
-    cmd = f"git log -n 1 --pretty=format:%s {commit_hash}"
+    cmd = ["git", "log", "-n", "1", "--pretty=format:%s", commit_hash]
     ret, out, err = run(cmd)
     return out if ret == 0 else None
 
 
 def commit_files_changed(commit_hash):
-    cmd = f"git diff-tree --no-commit-id --name-only -r {commit_hash}"
+    cmd = ["git", "diff-tree", "--no-commit-id", "--name-only", "-r", commit_hash]
     ret, out, err = run(cmd)
     return out.split("\n") if ret == 0 else None
 

--- a/scripts/release_notes/parse_cherry_picks.py
+++ b/scripts/release_notes/parse_cherry_picks.py
@@ -25,13 +25,56 @@ from pathlib import Path
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 logger = logging.getLogger(__name__)
 
+# --- Input validation helpers (CWE-78 hardening) ---
+# These ensure that externally-sourced values (from GitHub comments, user-provided
+# URLs, etc.) conform to strict expected formats before being interpolated into
+# subprocess arguments.  While subprocess list-mode avoids shell interpretation,
+# defence-in-depth protects against argument-injection and future refactors.
+
+_REPO_RE = re.compile(r"^[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+$")
+_PR_NUMBER_RE = re.compile(r"^\d+$")
+_ISSUE_NUMBER_RE = re.compile(r"^\d+$")
+_COMMIT_SHA_RE = re.compile(r"^[0-9a-f]{4,40}$")
+
+
+def _validate_repo(repo: str) -> str:
+    """Validate that *repo* looks like 'owner/name' with safe characters."""
+    if not _REPO_RE.fullmatch(repo):
+        raise ValueError(
+            f"Invalid repository identifier (expected 'owner/repo'): {repo!r}"
+        )
+    return repo
+
+
+def _validate_pr_number(pr_number: str) -> str:
+    """Validate that *pr_number* is a purely numeric string."""
+    if not _PR_NUMBER_RE.fullmatch(pr_number):
+        raise ValueError(f"Invalid PR number (expected digits only): {pr_number!r}")
+    return pr_number
+
+
+def _validate_issue_number(issue_number: str) -> str:
+    """Validate that *issue_number* is a purely numeric string."""
+    if not _ISSUE_NUMBER_RE.fullmatch(issue_number):
+        raise ValueError(
+            f"Invalid issue number (expected digits only): {issue_number!r}"
+        )
+    return issue_number
+
+
+def _validate_commit_sha(sha: str) -> str:
+    """Validate that *sha* is a hex string between 4 and 40 characters."""
+    if not _COMMIT_SHA_RE.fullmatch(sha):
+        raise ValueError(f"Invalid commit SHA (expected 4-40 hex chars): {sha!r}")
+    return sha
+
 
 def parse_issue_url(url: str) -> tuple[str, str]:
     """Extract owner/repo and issue number from a GitHub issue URL."""
     m = re.match(r"https://github\.com/([^/]+/[^/]+)/issues/(\d+)", url)  # @lint-ignore
     if not m:
         raise ValueError(f"Invalid GitHub issue URL: {url}")
-    return m.group(1), m.group(2)
+    return _validate_repo(m.group(1)), _validate_issue_number(m.group(2))
 
 
 def gh_api(endpoint: str) -> list | dict:
@@ -77,6 +120,8 @@ def gh_api(endpoint: str) -> list | dict:
 
 def fetch_comments(repo: str, issue_number: str) -> list[dict]:
     """Fetch all comments from a GitHub issue."""
+    _validate_repo(repo)
+    _validate_issue_number(issue_number)
     endpoint = f"repos/{repo}/issues/{issue_number}/comments?per_page=100"
     comments = gh_api(endpoint)
     logger.info(f"Fetched {len(comments)} comments from {repo}#{issue_number}")
@@ -85,6 +130,8 @@ def fetch_comments(repo: str, issue_number: str) -> list[dict]:
 
 def fetch_pr_title(repo: str, pr_number: str) -> str:
     """Fetch the title of a PR."""
+    _validate_repo(repo)
+    _validate_pr_number(pr_number)
     try:
         result = subprocess.run(
             ["gh", "api", f"repos/{repo}/pulls/{pr_number}", "--jq", ".title"],
@@ -108,6 +155,8 @@ def fetch_landed_commit(repo: str, pr_number: str) -> str:
     1. Issue events API: look for the 'closed' event with a commit_id
     2. Commit search API: search for commits containing '(#NNNNN)' in message
     """
+    _validate_repo(repo)
+    _validate_pr_number(pr_number)
     # Strategy 1: Issue events API
     try:
         result = subprocess.run(
@@ -251,7 +300,18 @@ def main():
             pr_number = pr_info["pr_number"]
             raw_commit = pr_info["raw_commit"]
             pr_title = ""
-            commit_sha = raw_commit  # Use raw commit if provided
+            commit_sha = ""
+
+            # Validate externally-sourced values before use (CWE-78 hardening)
+            if raw_commit:
+                try:
+                    commit_sha = _validate_commit_sha(raw_commit)
+                except ValueError:
+                    logger.warning(
+                        f"Skipping invalid commit SHA in comment {comment_id}: "
+                        f"{raw_commit!r}"
+                    )
+                    continue
 
             if pr_number:
                 logger.info(f"Fetching info for PR #{pr_number}...")


### PR DESCRIPTION
## Summary

Eliminates [CWE-78 (OS Command Injection)](https://cwe.mitre.org/data/definitions/78.html) vulnerabilities in `scripts/release_notes/`.

## Changes

**common.py** — Removed `shell=True` from `run()`; converted `commit_body()`, `commit_title()`, `commit_files_changed()` to list-form args.

**commitlist.py** — Converted `get_commits_between()` f-string commands to list-form args (required after `run()` change).

**categorize.py** — Replaced `os.system("clear")` with `subprocess.run(["clear"])`.

**parse_cherry_picks.py** — Added input validators (`_validate_repo`, `_validate_pr_number`, `_validate_issue_number`, `_validate_commit_sha`) that reject shell metacharacters. Applied defence-in-depth at both entry points and each `fetch_*` function.

## Why

`run()` used `shell=True` with f-string interpolated values (commit hashes, version tags). Any value containing `;`, `|`, `$()`, or backticks would be interpreted by the shell. `parse_cherry_picks.py` passes data extracted from GitHub comments into subprocess calls — an untrusted input source.

## Testing

- All `subprocess` calls now use list-form (verified via AST inspection).
- No `shell=True` remains in any modified file.
- Syntax validated on all 4 files.
- All documented workflows (`--create_new`, `--update_to`, `--rerun_with_new_filters`, `categorize.py`, `classifier.py`) route through the same fixed code paths with no behavioral change.