### PR TITLE
[MPS] Fix nested ops.masked variable name collisions in Metal codegen

### DIFF
--- a/test/inductor/test_mps_basic.py
+++ b/test/inductor/test_mps_basic.py
@@ -207,6 +207,44 @@ class MPSBasicTests(TestCase):
 
         self.common(fn, (q, k, v), atol=1e-4, rtol=1e-4, check_lowp=False)
 
+    def test_nested_masked_cat(self):
+        # Regression test for YOLOv3 compilation failure on MPS.
+        # See https://github.com/pytorch/pytorch/actions/runs/23477894502
+        # YOLOv3 detection heads do view/permute/clone, then in-place slice
+        # assignment (sigmoid+grid, exp*anchor, sigmoid) followed by cat across
+        # scales. The slice_scatter decomposition fused with cat produces nested
+        # ops.masked calls in Metal codegen. Without depth-aware variable
+        # prefixes, inner scoped variables shadow outer ones, causing:
+        #   "variable 'tmp_scoped_1' declared with deduced type 'auto'
+        #    cannot appear in its own initializer"
+        na, no = 3, 5
+
+        def head(p, grid, anchor_wh):
+            bs, _, ny, nx = p.shape
+            p = p.view(bs, na, no, ny, nx).permute(0, 1, 3, 4, 2).contiguous()
+            io = p.clone()
+            io[..., :2] = torch.sigmoid(io[..., :2]) + grid
+            io[..., 2:4] = torch.exp(io[..., 2:4]) * anchor_wh
+            torch.sigmoid_(io[..., 4:])
+            return io.view(bs, -1, no)
+
+        def fn(p1, p2, grid1, grid2, anchor_wh1, anchor_wh2):
+            return torch.cat(
+                [head(p1, grid1, anchor_wh1), head(p2, grid2, anchor_wh2)], dim=1
+            )
+
+        self.common(
+            fn,
+            (
+                torch.randn(1, na * no, 4, 4, device="mps"),
+                torch.randn(1, na * no, 8, 8, device="mps"),
+                torch.randn(1, 1, 4, 4, 2, device="mps"),
+                torch.randn(1, 1, 8, 8, 2, device="mps"),
+                torch.randn(1, na, 1, 1, 2, device="mps"),
+                torch.randn(1, na, 1, 1, 2, device="mps"),
+            ),
+        )
+
 
 class MPSBasicTestsAOTI(TestCase):
     def check_model(self, m, inp, dynamic_shapes=None):

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -224,12 +224,17 @@ class MetalOverrides(OpOverrides):
 
         other_str = value_to_metal(other)
         scoped_body = IndentedBuffer()
+        # Use a unique prefix per nesting level to avoid variable name collisions
+        # when masked() calls are nested (body() itself contains another masked()).
+        outer_prefix = V.kernel.cse.name_prefix
+        depth = outer_prefix.count("_scoped") + 1 if outer_prefix.startswith("tmp_scoped") else 1
+        scope_prefix = "tmp" + "_scoped" * depth + "_"
         with V.kernel.swap_buffers(scoped_body), scoped_body.indent():
             # Reset the scoped variable counter so that each invocation of the same body
             # generates identical variable names. Without this reset, repeated calls to
             # body() would keep incrementing the counter, resulting in different cache key.
             V.kernel.cse.iter_buffer_ids = itertools.count()
-            V.kernel.cse.name_prefix = "tmp_scoped_"
+            V.kernel.cse.name_prefix = scope_prefix
             rc = body()
 
         # Compute cache key manually as variable name is needed to actually generate the code

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -224,17 +224,13 @@ class MetalOverrides(OpOverrides):
 
         other_str = value_to_metal(other)
         scoped_body = IndentedBuffer()
-        # Use a unique prefix per nesting level to avoid variable name collisions
-        # when masked() calls are nested (body() itself contains another masked()).
-        outer_prefix = V.kernel.cse.name_prefix
-        depth = outer_prefix.count("_scoped") + 1 if outer_prefix.startswith("tmp_scoped") else 1
-        scope_prefix = "tmp" + "_scoped" * depth + "_"
         with V.kernel.swap_buffers(scoped_body), scoped_body.indent():
             # Reset the scoped variable counter so that each invocation of the same body
             # generates identical variable names. Without this reset, repeated calls to
             # body() would keep incrementing the counter, resulting in different cache key.
             V.kernel.cse.iter_buffer_ids = itertools.count()
-            V.kernel.cse.name_prefix = scope_prefix
+            # Append "_scoped" to the current prefix so each nesting level gets unique vars
+            V.kernel.cse.name_prefix += "_scoped"
             rc = body()
 
         # Compute cache key manually as variable name is needed to actually generate the code


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #178304

MetalOverrides.masked() always used "tmp_scoped_" as the variable prefix,
so when masked() calls were nested (e.g. from cat-of-slice_scatter fusion
in YOLOv3 detection heads), inner scoped variables shadowed outer ones,
causing Metal compilation failure: "variable 'tmp_scoped_1' declared with
deduced type 'auto' cannot appear in its own initializer".

Use depth-aware prefixes (tmp_scoped_, tmp_scoped_scoped_, etc.) so each
nesting level gets unique variable names.

This is a regression introduced by https://github.com/pytorch/pytorch/pull/170134

Co-authored-by: Claude <noreply@anthropic.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo