### PR TITLE
[Dynamo][cache]Add isolated cache setup

### DIFF
--- a/test/dynamo/test_recompile_ux.py
+++ b/test/dynamo/test_recompile_ux.py
@@ -321,268 +321,44 @@ class RecompileUxTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(res, inp + 3)
 
 
-class RegionRecompileLimitTests(torch._dynamo.test_case.TestCase):
+class IsolatedCacheTests(torch._dynamo.test_case.TestCase):
+    """Tests for isolated_cache=True on torch.compile(). Each compile region
+    gets its own isolated cache via C++ region_id filtering."""
+
     @staticmethod
     def _num_cache_entries(code):
         return len(torch._dynamo.eval_frame._debug_get_cache_entry_list(code))
 
-    def test_region_recompile_limit_basic(self):
-        cnt = torch._dynamo.testing.CompileCounter()
-
-        def f(x, y):
-            return x + y
-
-        opt_f = torch.compile(f, backend=cnt, region_recompile_limit=2)
-
-        opt_f(torch.randn(3), torch.randn(3))
-        self.assertEqual(self._num_cache_entries(f), 1)
-
-        opt_f(torch.randn(3, dtype=torch.float64), torch.randn(3, dtype=torch.float64))
-        self.assertEqual(self._num_cache_entries(f), 2)
-
-        # Third dtype should NOT trigger recompilation (region_recompile_limit=2 reached)
-        opt_f(torch.randn(3, dtype=torch.float16), torch.randn(3, dtype=torch.float16))
-        self.assertEqual(self._num_cache_entries(f), 2)
-
-    def test_region_recompile_limit_independent_per_function(self):
-        cnt_f = torch._dynamo.testing.CompileCounter()
-        cnt_g = torch._dynamo.testing.CompileCounter()
-
-        def f(x):
-            return x + 1
-
-        def g(x):
-            return x * 2
-
-        opt_f = torch.compile(f, backend=cnt_f, region_recompile_limit=1)
-        opt_g = torch.compile(g, backend=cnt_g, region_recompile_limit=3)
-
-        opt_f(torch.randn(3))
-        self.assertEqual(self._num_cache_entries(f), 1)
-
-        # f should stop recompiling after 1
-        opt_f(torch.randn(3, dtype=torch.float64))
-        self.assertEqual(self._num_cache_entries(f), 1)
-
-        # g should allow up to 3
-        opt_g(torch.randn(3))
-        opt_g(torch.randn(3, dtype=torch.float64))
-        opt_g(torch.randn(3, dtype=torch.float16))
-        self.assertEqual(self._num_cache_entries(g), 3)
-
-        # g should stop at 3
-        opt_g(torch.randn(3, dtype=torch.bfloat16))
-        self.assertEqual(self._num_cache_entries(g), 3)
-
-    def test_region_recompile_limit_none_uses_global(self):
-        cnt = torch._dynamo.testing.CompileCounter()
-
-        def f(x, y):
-            return x + y
-
-        opt_f = torch.compile(f, backend=cnt)
-
-        # Without region_recompile_limit, should use global recompile_limit (default 8)
-        for i in range(10):
-            dtype = [
-                torch.float32,
-                torch.float64,
-                torch.float16,
-                torch.bfloat16,
-                torch.int32,
-                torch.int64,
-                torch.int16,
-                torch.int8,
-                torch.uint8,
-                torch.complex64,
-            ][i]
-            opt_f(torch.ones(3, dtype=dtype), torch.ones(3, dtype=dtype))
-
-        self.assertEqual(
-            self._num_cache_entries(f), torch._dynamo.config.recompile_limit
-        )
-
-    def test_region_recompile_limit_multi_function(self):
-        cnt = torch._dynamo.testing.CompileCounter()
-
-        def helper(x):
-            return x.sin()
-
-        def f(x):
-            y = helper(x)
-            return y.cos()
-
-        opt_f = torch.compile(f, backend=cnt, region_recompile_limit=2)
-
-        opt_f(torch.randn(3))
-        self.assertEqual(self._num_cache_entries(f), 1)
-
-        opt_f(torch.randn(3, dtype=torch.float64))
-        self.assertEqual(self._num_cache_entries(f), 2)
-
-        # Third dtype hits the limit for the whole region
-        opt_f(torch.randn(3, dtype=torch.float16))
-        self.assertEqual(self._num_cache_entries(f), 2)
-
-    def test_region_recompile_limit_same_function_different_regions(self):
+    def test_isolated_cache_same_function_different_regions(self):
+        """Two torch.compile() calls on the same function with isolated_cache
+        get fully independent caches."""
         cnt1 = torch._dynamo.testing.CompileCounter()
         cnt2 = torch._dynamo.testing.CompileCounter()
 
         def f(x, y):
             return x + y
 
-        opt_f = torch.compile(f, backend=cnt1, region_recompile_limit=2)
-        opt_g = torch.compile(f, backend=cnt2, region_recompile_limit=1)
+        opt_f = torch.compile(f, backend=cnt1, isolated_cache=True)
+        opt_g = torch.compile(f, backend=cnt2, isolated_cache=True)
 
-        # opt_f: first compilation
         opt_f(torch.randn(3), torch.randn(3))
         self.assertEqual(cnt1.frame_count, 1)
 
-        # opt_f: second compilation (different dtype)
         opt_f(
             torch.randn(3, dtype=torch.float64),
             torch.randn(3, dtype=torch.float64),
         )
         self.assertEqual(cnt1.frame_count, 2)
 
-        # opt_g: should still be able to compile once despite f already having
-        # 2 cache entries from opt_f, because opt_g is a separate region
+        # opt_g can compile despite f.__code__ having 2 entries from opt_f
         opt_g(torch.randn(3, dtype=torch.float16), torch.randn(3, dtype=torch.float16))
         self.assertEqual(cnt2.frame_count, 1)
 
-        # opt_g: second call with new dtype should NOT compile (limit=1 reached)
-        opt_g(
-            torch.randn(3, dtype=torch.bfloat16),
-            torch.randn(3, dtype=torch.bfloat16),
-        )
-        self.assertEqual(cnt2.frame_count, 1)
-
-        # opt_f: third dtype should NOT compile (limit=2 reached for opt_f)
-        opt_f(
-            torch.randn(3, dtype=torch.float16),
-            torch.randn(3, dtype=torch.float16),
-        )
-        self.assertEqual(cnt1.frame_count, 2)
-
-    def test_region_recompile_limit_graph_break(self):
-        cnt = torch._dynamo.testing.CompileCounter()
-
-        def f(x):
-            a = x.sin()
-            # graph break
-            print("graph break")
-            b = a.cos()
-            return b
-
-        opt_f = torch.compile(f, backend=cnt, region_recompile_limit=2)
-
-        # First dtype: compiles two subgraphs (before and after graph break)
-        opt_f(torch.randn(3))
-        self.assertEqual(self._num_cache_entries(f), 1)
-        self.assertEqual(cnt.frame_count, 2)
-
-        # Second dtype: f recompiles (f=2, max=2 hits limit),
-        # resume function can't recompile because max already at limit
-        opt_f(torch.randn(3, dtype=torch.float64))
-        self.assertEqual(self._num_cache_entries(f), 2)
-        frame_count_after_2 = cnt.frame_count
-
-        # Third dtype: both subgraphs should hit the limit
-        opt_f(torch.randn(3, dtype=torch.float16))
-        self.assertEqual(self._num_cache_entries(f), 2)
-        self.assertEqual(cnt.frame_count, frame_count_after_2)
-
-        # Verify no code object exceeds the limit
-        all_entries = torch._dynamo.eval_frame._debug_get_all_cache_entry_lists(f)
-        for code, entries in all_entries.items():
-            self.assertLessEqual(
-                len(entries),
-                2,
-                f"{code.co_name} has {len(entries)} entries, exceeds limit of 2",
-            )
-
-    @torch._dynamo.config.patch(automatic_dynamic_shapes=True)
-    def test_region_recompile_limit_graph_break_automatic_dynamic(self):
-        cnt = torch._dynamo.testing.CompileCounter()
-
-        def f(x):
-            a = x.sin()
-            print("graph break")
-            b = a.cos()
-            return b
-
-        opt_f = torch.compile(f, backend=cnt, region_recompile_limit=2)
-
-        # Call 1: compiles both subgraphs (static shapes)
-        opt_f(torch.randn(4, 8))
-        self.assertEqual(self._num_cache_entries(f), 1)
-        frame_count_after_1 = cnt.frame_count
-
-        # Call 2: dim0 changes -> both f and resume function recompile
-        # with automatic dynamic (dim0 becomes dynamic)
-        opt_f(torch.randn(5, 8))
-        self.assertEqual(self._num_cache_entries(f), 2)
-        frame_count_after_2 = cnt.frame_count
-        self.assertGreater(frame_count_after_2, frame_count_after_1)
-
-        # Call 3: dim1 changes -> region_recompile_limit=2 reached,
-        # neither f nor resume function should recompile
-        opt_f(torch.randn(5, 9))
-        self.assertEqual(cnt.frame_count, frame_count_after_2)
-
-        # Verify ALL code objects (f + resume functions) respect the limit
-        all_entries = torch._dynamo.eval_frame._debug_get_all_cache_entry_lists(f)
-        for code, entries in all_entries.items():
-            self.assertLessEqual(
-                len(entries),
-                2,
-                f"{code.co_name} has {len(entries)} entries, exceeds limit of 2",
-            )
-
-    @torch._dynamo.config.patch(recompile_limit=1)
-    def test_region_recompile_limit_overrides_global(self):
-        """region_recompile_limit overrides config.recompile_limit. Multiple
-        torch.compile() calls on the same function can each compile
-        independently even when the shared code object's total entries
-        exceed config.recompile_limit. This is the factory pattern fix."""
-        cnt1 = torch._dynamo.testing.CompileCounter()
-        cnt2 = torch._dynamo.testing.CompileCounter()
-
-        def f(x):
-            return x.sin()
-
-        opt_f = torch.compile(f, backend=cnt1, region_recompile_limit=2)
-        opt_g = torch.compile(f, backend=cnt2, region_recompile_limit=2)
-
-        # opt_f compiles twice (under region limit of 2, over global limit of 1)
-        opt_f(torch.randn(3))
-        opt_f(torch.randn(3, dtype=torch.float64))
-        self.assertEqual(cnt1.frame_count, 2)
-
-        # opt_g can still compile despite f.__code__ having 2+ entries
-        # (global recompile_limit=1 would block this without the override)
-        opt_g(torch.randn(4))
-        self.assertEqual(cnt2.frame_count, 1)
-
-        # opt_f hits its own region limit
-        opt_f(torch.randn(3, dtype=torch.float16))
-        self.assertEqual(cnt1.frame_count, 2)
-
-        # opt_g can compile once more (under its region limit of 2)
-        opt_g(torch.randn(4, dtype=torch.float64))
-        self.assertEqual(cnt2.frame_count, 2)
-
-        # opt_g hits its own region limit
-        opt_g(torch.randn(4, dtype=torch.float16))
-        self.assertEqual(cnt2.frame_count, 2)
-
     @torch._dynamo.config.patch(recompile_limit=1, fail_on_recompile_limit_hit=True)
-    def test_region_recompile_limit_factory_pattern(self):
-        """Reproduces the factory pattern from the workplace post: a cached
-        factory creates torch.compile wrappers around the same inner function.
-        Without region_recompile_limit, the third factory instance hits the
-        global recompile_limit. With region_recompile_limit, each instance
-        gets its own budget."""
+    def test_isolated_cache_factory_pattern(self):
+        """Factory creates multiple torch.compile wrappers around the same
+        inner function. Each gets its own isolated cache, so the global
+        recompile_limit doesn't block them."""
         from functools import cache
 
         def core(x):
@@ -590,92 +366,98 @@ class RegionRecompileLimitTests(torch._dynamo.test_case.TestCase):
 
         @cache
         def factory(key):
-            @torch.compile(
-                fullgraph=True,
-                dynamic=False,
-                region_recompile_limit=1,
-            )
+            @torch.compile(fullgraph=True, dynamic=False, isolated_cache=True)
             def frontend(x, n):
                 return core(x) + n
 
             return frontend
 
-        # Each factory instance can compile once with its own budget,
-        # even though global recompile_limit=1 and fail_on_recompile_limit_hit=True
         factory("foo")(torch.ones(3), 3)
         factory("bar")(torch.ones(4), 3)
         factory("baz")(torch.ones(5), 3)
 
-    @torch._dynamo.config.patch(accumulated_recompile_limit=3)
-    def test_region_recompile_limit_accumulated_still_applies(self):
-        """accumulated_recompile_limit still applies as a hard safety cap
-        even when region_recompile_limit is set."""
+    def test_isolated_cache_static_and_dynamic(self):
+        """Two compile regions on the same function: one static, one dynamic.
+        Their cache entries don't interfere."""
+        cnt_static = torch._dynamo.testing.CompileCounter()
+        cnt_dynamic = torch._dynamo.testing.CompileCounter()
+
+        def magic(x, y):
+            return x.sum() - y.sum()
+
+        magic_static = torch.compile(
+            magic, backend=cnt_static, dynamic=False, isolated_cache=True
+        )
+        magic_dynamic = torch.compile(
+            magic, backend=cnt_dynamic, dynamic=True, isolated_cache=True
+        )
+
+        magic_static(torch.randn(128, 32), torch.randn(128, 32))
+        self.assertEqual(cnt_static.frame_count, 1)
+
+        magic_dynamic(torch.randn(64, 16), torch.randn(64, 16))
+        self.assertEqual(cnt_dynamic.frame_count, 1)
+
+        # Static: same shape -> cache hit
+        magic_static(torch.randn(128, 32), torch.randn(128, 32))
+        self.assertEqual(cnt_static.frame_count, 1)
+
+        # Dynamic: different shape -> cache hit (dynamic graph)
+        magic_dynamic(torch.randn(32, 8), torch.randn(32, 8))
+        self.assertEqual(cnt_dynamic.frame_count, 1)
+
+    @torch._dynamo.config.patch(recompile_limit=1)
+    def test_isolated_cache_fullgraph_raises(self):
+        """With fullgraph=True, hitting the recompile limit raises
+        FailOnRecompileLimitHit."""
         cnt = torch._dynamo.testing.CompileCounter()
 
         def f(x):
             return x.sin()
 
-        # region limit is high, but accumulated limit is low
-        opt_f = torch.compile(f, backend=cnt, region_recompile_limit=10)
+        opt_f = torch.compile(f, backend=cnt, fullgraph=True, isolated_cache=True)
 
         opt_f(torch.randn(3))
-        opt_f(torch.randn(3, dtype=torch.float64))
-        opt_f(torch.randn(3, dtype=torch.float16))
-        # accumulated_recompile_limit=3 should cap here
-        opt_f(torch.randn(3, dtype=torch.bfloat16))
-        self.assertLessEqual(cnt.frame_count, 3)
+        self.assertEqual(cnt.frame_count, 1)
 
-    def test_region_recompile_limit_resume_exceeds_max_budget(self):
-        """Resume function recompiles independently via global changes.
-        With region_recompile_limit=3, f compiles once but the resume function
-        recompiles up to 3 times. Once any code object in the region hits the
-        limit, all code objects in the region stop compiling."""
-        cnt = torch._dynamo.testing.CompileCounter()
+        with self.assertRaisesRegex(
+            FailOnRecompileLimitHit,
+            "reached with fullgraph=True",
+        ):
+            opt_f(torch.randn(3, dtype=torch.float64))
 
-        mode = {"value": "a"}
+    def test_isolated_cache_two_models_independent(self):
+        """Two compile regions wrapping the same model. Recompilations in
+        one region don't affect the other."""
+        cnt1 = torch._dynamo.testing.CompileCounter()
+        cnt2 = torch._dynamo.testing.CompileCounter()
 
-        def f(x):
-            a = x.sin()
-            print("graph break")
-            if mode["value"] == "a":
-                return a.cos()
-            elif mode["value"] == "b":
-                return a.tan()
-            elif mode["value"] == "c":
-                return a.exp()
-            else:
-                return a + 1
+        def helper(x):
+            return x.sin()
 
-        opt_f = torch.compile(f, backend=cnt, region_recompile_limit=3)
+        def model(x):
+            return helper(x).cos()
 
-        # Call 1: f compiles, resume compiles. max=1
-        opt_f(torch.randn(4, 8))
-        frame_count_after_1 = cnt.frame_count
+        opt_a = torch.compile(model, backend=cnt1, isolated_cache=True)
+        opt_b = torch.compile(model, backend=cnt2, isolated_cache=True)
 
-        # Call 2: mode changes, f cache hit, resume recompiles. max=2
-        mode["value"] = "b"
-        opt_f(torch.randn(4, 8))
-        frame_count_after_2 = cnt.frame_count
-        self.assertGreater(frame_count_after_2, frame_count_after_1)
+        opt_a(torch.randn(3))
+        frame_count_a = cnt1.frame_count
 
-        # Call 3: mode changes, f cache hit, resume recompiles. max=3
-        mode["value"] = "c"
-        opt_f(torch.randn(4, 8))
-        frame_count_after_3 = cnt.frame_count
-        self.assertGreater(frame_count_after_3, frame_count_after_2)
+        opt_b(torch.randn(4))
+        frame_count_b = cnt2.frame_count
 
-        # Call 4: mode changes again. max=3, 3 >= 3 -> stop.
-        # Resume function should NOT recompile.
-        mode["value"] = "d"
-        opt_f(torch.randn(4, 8))
-        self.assertEqual(cnt.frame_count, frame_count_after_3)
+        # Region A recompiles, doesn't affect region B
+        opt_a(torch.randn(3, dtype=torch.float64))
+        self.assertGreater(cnt1.frame_count, frame_count_a)
+
+        opt_b(torch.randn(4))
+        self.assertEqual(cnt2.frame_count, frame_count_b)
 
     @torch._dynamo.config.patch(recompile_limit=3, accumulated_recompile_limit=64)
-    def test_global_recompile_limit_resume_exceeds(self):
-        """With global recompile_limit=3, the resume function recompiles
-        independently via global changes while f gets cache hits. The global
-        limit is per-code-object, so the resume function can reach 3 entries
-        even though f only has 1. This test documents the current behavior."""
+    def test_global_recompile_limit_resume_function(self):
+        """Documents existing behavior: global recompile_limit is per-code-object.
+        Resume functions independently accumulate entries."""
         cnt = torch._dynamo.testing.CompileCounter()
 
         mode = {"value": "a"}
@@ -694,120 +476,133 @@ class RegionRecompileLimitTests(torch._dynamo.test_case.TestCase):
 
         opt_f = torch.compile(f, backend=cnt)
 
-        # Call 1: f compiles, resume compiles
         opt_f(torch.randn(4, 8))
         frame_count_after_1 = cnt.frame_count
 
-        # Call 2: mode changes, f cache hit, resume recompiles
         mode["value"] = "b"
         opt_f(torch.randn(4, 8))
-        frame_count_after_2 = cnt.frame_count
-        self.assertGreater(frame_count_after_2, frame_count_after_1)
+        self.assertGreater(cnt.frame_count, frame_count_after_1)
 
-        # Call 3: mode changes, f cache hit, resume recompiles
         mode["value"] = "c"
         opt_f(torch.randn(4, 8))
         frame_count_after_3 = cnt.frame_count
-        self.assertGreater(frame_count_after_3, frame_count_after_2)
 
-        # Call 4: mode changes. Global limit is per-code-object, so resume
-        # has 3 entries and should stop. But f only has 1, so if the limit
-        # were checked across all code objects, this would have stopped earlier.
+        # Resume hits limit=3, stops
         mode["value"] = "d"
         opt_f(torch.randn(4, 8))
-
-        # With per-code-object global limit: resume hits limit=3, stops.
-        # This PASSES because the resume function individually reaches the limit.
         self.assertEqual(cnt.frame_count, frame_count_after_3)
 
-    def test_region_recompile_limit_resume_function_independent(self):
-        """Resume function recompiles independently when a global used only
-        after the graph break changes, while the main function gets cache hits."""
-        cnt = torch._dynamo.testing.CompileCounter()
-
-        mode = {"value": "a"}
+    def test_isolated_cache_mark_dynamic_vs_static(self):
+        """Two regions on the same function: one with mark_static, one with
+        mark_dynamic. Their guards don't interfere."""
+        cnt_static = torch._dynamo.testing.CompileCounter()
+        cnt_dynamic = torch._dynamo.testing.CompileCounter()
 
         def f(x):
-            a = x.sin()
-            print("graph break")
-            if mode["value"] == "a":
-                return a.cos()
-            else:
-                return a.tan()
+            return x.sin()
 
-        opt_f = torch.compile(f, backend=cnt, region_recompile_limit=2)
+        opt_static = torch.compile(f, backend=cnt_static, isolated_cache=True)
+        opt_dynamic = torch.compile(f, backend=cnt_dynamic, isolated_cache=True)
 
-        # Call 1: compiles f + resume function
-        opt_f(torch.randn(4, 8))
-        f_entries_after_1 = self._num_cache_entries(f)
-        frame_count_after_1 = cnt.frame_count
+        # Static region: mark dim0 as static
+        x_static = torch.randn(4, 8)
+        torch._dynamo.mark_static(x_static, 0)
+        opt_static(x_static)
+        self.assertEqual(cnt_static.frame_count, 1)
 
-        # Call 2: change mode -> f cache hit, resume function recompiles
-        mode["value"] = "b"
-        opt_f(torch.randn(4, 8))
-        frame_count_after_2 = cnt.frame_count
-        # f should NOT have recompiled
-        self.assertEqual(self._num_cache_entries(f), f_entries_after_1)
-        # but resume function should have recompiled
-        self.assertGreater(frame_count_after_2, frame_count_after_1)
+        # Dynamic region: mark dim0 as dynamic
+        x_dynamic = torch.randn(4, 8)
+        torch._dynamo.mark_dynamic(x_dynamic, 0)
+        opt_dynamic(x_dynamic)
+        self.assertEqual(cnt_dynamic.frame_count, 1)
 
-        # Call 3: change mode again -> resume function should NOT recompile
-        # (region_recompile_limit=2 reached for the resume function)
-        mode["value"] = "c"
-        opt_f(torch.randn(4, 8))
-        self.assertEqual(cnt.frame_count, frame_count_after_2)
+        # Static region: same shape -> cache hit
+        x_static2 = torch.randn(4, 8)
+        torch._dynamo.mark_static(x_static2, 0)
+        opt_static(x_static2)
+        self.assertEqual(cnt_static.frame_count, 1)
 
-        # Verify via _debug_get_all_cache_entry_lists
-        all_entries = torch._dynamo.eval_frame._debug_get_all_cache_entry_lists(f)
-        for code, entries in all_entries.items():
-            self.assertLessEqual(
-                len(entries),
-                2,
-                f"{code.co_name} has {len(entries)} entries, exceeds limit of 2",
-            )
+        # Dynamic region: different shape -> cache hit (dynamic graph)
+        x_dynamic2 = torch.randn(7, 8)
+        opt_dynamic(x_dynamic2)
+        self.assertEqual(cnt_dynamic.frame_count, 1)
 
-    def test_region_recompile_limit_graph_break_asymmetric(self):
-        cnt = torch._dynamo.testing.CompileCounter()
+        # Static region: different shape -> recompile (static guard fails)
+        x_static3 = torch.randn(7, 8)
+        torch._dynamo.mark_static(x_static3, 0)
+        opt_static(x_static3)
+        self.assertEqual(cnt_static.frame_count, 2)
 
-        results = []
+    @torch._dynamo.config.patch(automatic_dynamic_shapes=True)
+    def test_isolated_cache_auto_dynamic_shared_pgo(self):
+        """With isolated_cache, PGO (frame_state) is shared. Region B
+        benefits from region A's shape observations — goes directly to
+        dynamic compilation instead of starting static."""
+        cnt_a = torch._dynamo.testing.CompileCounter()
+        cnt_b = torch._dynamo.testing.CompileCounter()
 
-        def f(x, y):
-            a = x.sin()
-            results.append(a)
-            # graph break
-            print("graph break")
-            # Second subgraph only depends on y, not a or x
-            b = y.cos()
-            return b
+        def f(x):
+            return x.sin()
 
-        opt_f = torch.compile(f, backend=cnt, region_recompile_limit=4)
+        opt_a = torch.compile(f, backend=cnt_a, isolated_cache=True)
+        opt_b = torch.compile(f, backend=cnt_b, isolated_cache=True)
 
-        # Call 1: x=(4,8), y=(4,8) -> compiles both subgraphs
-        opt_f(torch.randn(4, 8), torch.randn(4, 8))
-        self.assertEqual(self._num_cache_entries(f), 1)
-        self.assertEqual(cnt.frame_count, 2)
+        # Region A: two calls with different shapes -> PGO marks dim0 dynamic
+        opt_a(torch.randn(3, 4))
+        opt_a(torch.randn(5, 4))
+        self.assertEqual(cnt_a.frame_count, 2)
 
-        # Call 2: x=(7,8), y=(4,8) -> subgraph1 recompiles (x shape changed),
-        # subgraph2 cache hit (y unchanged, a not used after break)
-        opt_f(torch.randn(7, 8), torch.randn(4, 8))
-        self.assertEqual(self._num_cache_entries(f), 2)
-        self.assertEqual(cnt.frame_count, 3)
+        # Region B: first call. PGO already knows dim0 is dynamic (shared).
+        # Should compile once with dynamic dim0.
+        opt_b(torch.randn(7, 4))
+        self.assertEqual(cnt_b.frame_count, 1)
 
-        # Call 3: x=(5,8), y=(4,8) -> subgraph1 recompiles again, subgraph2 still hit
-        opt_f(torch.randn(5, 8), torch.randn(4, 8))
-        self.assertEqual(self._num_cache_entries(f), 3)
-        self.assertEqual(cnt.frame_count, 4)
+        # Region B: different dim0 -> cache hit (dynamic graph)
+        opt_b(torch.randn(9, 4))
+        self.assertEqual(cnt_b.frame_count, 1)
 
-        # f has 3 cache entries, resume function should have only 1
-        all_entries = torch._dynamo.eval_frame._debug_get_all_cache_entry_lists(f)
-        counts = {c.co_name: len(entries) for c, entries in all_entries.items()}
-        self.assertEqual(counts["f"], 3)
-        resume_counts = {
-            k: v for k, v in counts.items() if k.startswith("torch_dynamo_resume")
-        }
-        self.assertTrue(len(resume_counts) > 0, f"No resume functions found: {counts}")
-        for name, count in resume_counts.items():
-            self.assertEqual(count, 1, f"{name} has {count} entries, expected 1")
+    def test_isolated_cache_explicit_dispatch_static_vs_dynamic(self):
+        """With isolated_cache, users can explicitly dispatch to static or
+        dynamic compiled regions without relying on automatic dynamic
+        transitions or exclusion guards. Each region has its own compilation
+        strategy set once at compile time."""
+        cnt_static = torch._dynamo.testing.CompileCounter()
+        cnt_dynamic = torch._dynamo.testing.CompileCounter()
+
+        def magic(x, y):
+            return x.sum() - y.sum()
+
+        # Set strategy once at compile time — no per-call mark_dynamic needed
+        magic_static = torch.compile(
+            magic, backend=cnt_static, dynamic=False, isolated_cache=True
+        )
+        magic_dynamic = torch.compile(
+            magic, backend=cnt_dynamic, dynamic=True, isolated_cache=True
+        )
+
+        # Static region: always uses fixed shapes, no recompilation
+        static_shape = (128, 32)
+        magic_static(torch.randn(*static_shape), torch.randn(*static_shape))
+        magic_static(torch.randn(*static_shape), torch.randn(*static_shape))
+        self.assertEqual(cnt_static.frame_count, 1)
+
+        # Dynamic region: varying shapes, single dynamic graph handles all
+        magic_dynamic(torch.randn(64, 16), torch.randn(64, 16))
+        magic_dynamic(torch.randn(32, 8), torch.randn(32, 8))
+        magic_dynamic(torch.randn(128, 64), torch.randn(128, 64))
+        self.assertEqual(cnt_dynamic.frame_count, 1)
+
+        # Static region still works — not polluted by dynamic region
+        magic_static(torch.randn(*static_shape), torch.randn(*static_shape))
+        self.assertEqual(cnt_static.frame_count, 1)
+
+        # Static region with DIFFERENT shape -> recompiles (static = specialized)
+        magic_static(torch.randn(64, 16), torch.randn(64, 16))
+        self.assertEqual(cnt_static.frame_count, 2)
+
+        # Dynamic region still serves any shape without recompilation
+        magic_dynamic(torch.randn(256, 128), torch.randn(256, 128))
+        self.assertEqual(cnt_dynamic.frame_count, 1)
 
 
 if __name__ == "__main__":

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -2593,7 +2593,7 @@ def compile(
     mode: str | None = None,
     options: dict[str, str | builtins.int | builtins.bool | _Callable] | None = None,
     disable: builtins.bool = False,
-    region_recompile_limit: builtins.int | None = None,
+    isolated_cache: builtins.bool = False,
 ) -> (
     _Callable[[_Callable[_InputT, _RetT]], _Callable[_InputT, _RetT]]
     | _Callable[_InputT, _RetT]
@@ -2684,17 +2684,23 @@ def compile(
 
         - For inductor you can see the full list of configs that it supports by calling `torch._inductor.list_options()`
        disable (bool): Turn torch.compile() into a no-op for testing
-       region_recompile_limit (int or None): Maximum number of recompilations
-        for this specific compiled region. When the limit is reached, further
-        recompilations are suppressed and the function falls back to eager.
-        If None (default), the global ``torch._dynamo.config.recompile_limit``
-        is used instead.
+       isolated_cache (bool): If True, this compiled region gets its own
+        isolated cache. Cache entries from this region are invisible to other
+        regions, even if they compile the same function. Useful for the factory
+        pattern (multiple torch.compile wrappers around the same function) and
+        for using the same function with different compile configurations
+        (e.g., static vs dynamic shapes).
 
     Example::
 
         @torch.compile(options={"triton.cudagraphs": True}, fullgraph=True)
         def foo(x):
             return torch.sin(x) + torch.cos(x)
+
+
+        # Isolate cache for static and dynamic versions of the same function
+        magic_static = torch.compile(magic, dynamic=False, isolated_cache=True)
+        magic_dynamic = torch.compile(magic, dynamic=True, isolated_cache=True)
 
     """
     import sysconfig
@@ -2726,7 +2732,7 @@ def compile(
                 mode=mode,
                 options=options,
                 disable=disable,
-                region_recompile_limit=region_recompile_limit,
+                isolated_cache=isolated_cache,
             )
 
         return fn
@@ -2783,7 +2789,7 @@ def compile(
         dynamic=dynamic,
         disable=disable,
         guard_filter_fn=guard_filter_fn,
-        region_recompile_limit=region_recompile_limit,
+        isolated_cache=isolated_cache,
     )(model)  # type: ignore[return-value]
 
 

--- a/torch/_dynamo/cache_size.py
+++ b/torch/_dynamo/cache_size.py
@@ -85,32 +85,12 @@ class CacheSizeRelevantForFrame:
     # Number of CacheEntry objects having same ID_MATCH'd objects as given frame.
     num_cache_entries_with_same_id_matched_objs: int = 0
 
-    # Per-region recompile limit set via torch.compile(region_recompile_limit=N).
-    # None means use global config limits only.
-    #
-    # Unlike the global config.recompile_limit (which checks each code object
-    # independently), region_recompile_limit uses max semantics across all code
-    # objects in the region: once ANY code object (the original function or any
-    # of its resume functions from graph breaks) reaches N compilations, ALL
-    # compilation in the region stops. This prevents the total compilations
-    # from growing unboundedly when resume functions recompile independently.
-    #
-    # Each torch.compile() call gets its own independent budget tracked via
-    # ConvertFrameAssert._region_compilation_counts, so two torch.compile()
-    # calls on the same function don't interfere with each other's limits.
-    region_recompile_limit: int | None = None
+    # Whether this compile region has isolated cache (via region_id)
+    isolated_cache: bool = False
 
-    # The max number of compilations across all code objects in this compile
-    # region. Set by ConvertFrameAssert from max(_region_compilation_counts).
-    # This is the value checked against region_recompile_limit.
+    # Max compilations across all code objects in this region.
+    # Used for the per-region limit check when isolated_cache=True.
     region_num_compilations: int = 0
-
-    @property
-    def exceeds_region_recompile_limit(self) -> bool:
-        return (
-            self.region_recompile_limit is not None
-            and self.region_num_compilations >= self.region_recompile_limit
-        )
 
     def will_compilation_exceed(self, limit: int) -> bool:
         # Checks if a compilation will exceed the given limit (that's why >=).

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -587,7 +587,7 @@ class ConvertFrameAssert:
         export: bool = False,
         export_constraints: Any | None = None,
         package: CompilePackage | None = None,
-        region_recompile_limit: int | None = None,
+        isolated_cache: bool = False,
     ) -> None:
         # assert export_constraints is None
         reset_graph_break_dup_checker()
@@ -596,9 +596,9 @@ class ConvertFrameAssert:
         self._export = export
         self._export_constraints = export_constraints
         self._package = package
-        self._region_recompile_limit = region_recompile_limit
+        self._isolated_cache = isolated_cache
         self._region_compilation_counts: dict[CodeType, int] = {}
-        if region_recompile_limit is not None:
+        if isolated_cache:
             global _next_region_id
             self._region_id = _next_region_id
             _next_region_id += 1
@@ -613,7 +613,7 @@ class ConvertFrameAssert:
             self._one_graph,
             self._export,
             self._export_constraints,
-            region_recompile_limit=self._region_recompile_limit,
+            isolated_cache=self._isolated_cache,
         )
 
     def __call__(
@@ -629,7 +629,7 @@ class ConvertFrameAssert:
         code = frame.f_code
 
         cache_size = compute_cache_size(frame, cache_entry)
-        cache_size.region_recompile_limit = self._region_recompile_limit
+        cache_size.isolated_cache = self._isolated_cache
         cache_size.region_num_compilations = max(
             self._region_compilation_counts.values(), default=0
         )
@@ -781,7 +781,7 @@ def convert_frame_assert(
     export: bool = False,
     export_constraints: Any | None = None,
     package: CompilePackage | None = None,
-    region_recompile_limit: int | None = None,
+    isolated_cache: bool = False,
 ) -> ConvertFrameAssert:
     """Fully convert a frame into an FX graph, raising an exception if we fail."""
     return ConvertFrameAssert(
@@ -790,7 +790,7 @@ def convert_frame_assert(
         export,
         export_constraints,
         package,
-        region_recompile_limit,
+        isolated_cache,
     )
 
 
@@ -1807,13 +1807,14 @@ def _compile(
             }
             metrics_context.set("recompile_user_contexts", user_contexts_msg)
 
-        if cache_size.exceeds_region_recompile_limit:
-            exceeded, limit_type = True, "region_recompile_limit"
-        elif cache_size.region_recompile_limit is not None:
-            # region_recompile_limit overrides config.recompile_limit, but
-            # accumulated_recompile_limit still applies as a hard safety cap.
+        if cache_size.isolated_cache:
+            # With isolated_cache, use per-region compilation count instead
+            # of global num_cache_entries. The C++ region_id isolates cache
+            # lookup; this isolates the limit check.
             if cache_size.will_compilation_exceed_accumulated_limit():
                 exceeded, limit_type = True, "accumulated_recompile_limit"
+            elif cache_size.region_num_compilations >= config.recompile_limit:
+                exceeded, limit_type = True, "recompile_limit"
             else:
                 exceeded, limit_type = False, ""
         else:
@@ -1823,14 +1824,9 @@ def _compile(
             def format_func_info(code: CodeType) -> str:
                 return f"'{code.co_name}' ({code.co_filename}:{code.co_firstlineno})"
 
-            if limit_type == "region_recompile_limit":
-                limit_value = cache_size.region_recompile_limit
-                limit_source = f"torch.compile(region_recompile_limit={limit_value})"
-                num_recompiles = cache_size.region_num_compilations
-            else:
-                limit_value = getattr(config, limit_type)
-                limit_source = f"config.{limit_type}"
-                num_recompiles = cache_size.num_cache_entries
+            limit_value = getattr(config, limit_type)
+            limit_source = f"config.{limit_type}"
+            num_recompiles = cache_size.num_cache_entries
 
             # NS: Don't add period at the end of string, as it'll be added to URL
             # rendering it incorrect
@@ -1873,7 +1869,7 @@ def _compile(
                     ) from e
                 elif one_graph:
                     raise FailOnRecompileLimitHit(
-                        "Hard failure due to fullgraph=True"
+                        f"{limit_type} reached with fullgraph=True"
                     ) from e
                 else:
                     # Set frame execution strategy to RUN_ONLY for this recompile limit case
@@ -2119,24 +2115,24 @@ class ConvertFrame:
         compiler_fn: CompilerFn,
         hooks: Hooks,
         package: CompilePackage | None = None,
-        region_recompile_limit: int | None = None,
+        isolated_cache: bool = False,
     ) -> None:
         self._torchdynamo_orig_backend = compiler_fn
         self._inner_convert = convert_frame_assert(
             compiler_fn,
             one_graph=False,
             package=package,
-            region_recompile_limit=region_recompile_limit,
+            isolated_cache=isolated_cache,
         )
         self._hooks = hooks
-        self._region_recompile_limit = region_recompile_limit
+        self._isolated_cache = isolated_cache
 
     @property
     def _clone_with_backend(self) -> Callable[[WrapBackendDebug], ConvertFrame]:
         return lambda backend: convert_frame(
             backend,
             self._hooks,
-            region_recompile_limit=self._region_recompile_limit,
+            isolated_cache=self._isolated_cache,
         )
 
     def __call__(
@@ -2255,9 +2251,9 @@ class ConvertFrame:
                 return ConvertFrameReturn(
                     frame_exec_strategy=e.frame_exec_strategy,
                     # Don't apply strategy to the code object when
-                    # region_recompile_limit is set — other regions sharing
+                    # isolated_cache is set — other regions sharing
                     # this code object should still be able to compile.
-                    apply_to_code=self._region_recompile_limit is None,
+                    apply_to_code=not self._isolated_cache,
                 )
 
         return ConvertFrameReturn()
@@ -2267,14 +2263,14 @@ def convert_frame(
     compiler_fn: CompilerFn,
     hooks: Hooks,
     package: CompilePackage | None = None,
-    region_recompile_limit: int | None = None,
+    isolated_cache: bool = False,
 ) -> ConvertFrame:
     """Try to convert a frame into an FX graph, if error leave frame unmodified"""
     return ConvertFrame(
         compiler_fn,
         hooks,
         package=package,
-        region_recompile_limit=region_recompile_limit,
+        isolated_cache=isolated_cache,
     )
 
 

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -763,7 +763,7 @@ class _TorchDynamoContext:
         compiler_config: Any | None = None,
         package: CompilePackage | None = None,
         hooks: Hooks | None = None,
-        region_recompile_limit: int | None = None,
+        isolated_cache: bool = False,
     ) -> None:
         super().__init__()
         assert callable(callback) or callback is False or callback is None
@@ -780,7 +780,7 @@ class _TorchDynamoContext:
         self.enter_exit_hooks = []
         self._package = package
         self._hooks = hooks
-        self._region_recompile_limit = region_recompile_limit
+        self._isolated_cache = isolated_cache
         patch_fn()
 
         # Save the backends so that we can reset them during torch._dynamo.reset
@@ -1158,7 +1158,7 @@ class OptimizeContext(_TorchDynamoContext):
         rebuild_ctx: Callable[[], OptimizeContext | _NullDecorator] | None = None,
         package: CompilePackage | None = None,
         hooks: Hooks | None = None,
-        region_recompile_limit: int | None = None,
+        isolated_cache: bool = False,
     ) -> None:
         def on_enter() -> None:
             install_generation_tagging_init()
@@ -1176,7 +1176,7 @@ class OptimizeContext(_TorchDynamoContext):
             compiler_config=compiler_config,
             package=package,
             hooks=hooks,
-            region_recompile_limit=region_recompile_limit,
+            isolated_cache=isolated_cache,
         )
 
         if config.compiled_autograd:
@@ -1328,7 +1328,7 @@ def _optimize_catch_errors(
     compiler_config: Any | None = None,
     rebuild_ctx: Callable[[], OptimizeContext | _NullDecorator] | None = None,
     package: CompilePackage | None = None,
-    region_recompile_limit: int | None = None,
+    isolated_cache: bool = False,
 ) -> OptimizeContext:
     return OptimizeContext(
         convert_frame.catch_errors_wrapper(compile_fn, hooks),
@@ -1342,7 +1342,7 @@ def _optimize_catch_errors(
         rebuild_ctx=rebuild_ctx,
         package=package,
         hooks=hooks,
-        region_recompile_limit=region_recompile_limit,
+        isolated_cache=isolated_cache,
     )
 
 
@@ -1528,7 +1528,7 @@ def _optimize(
     disable: bool = False,
     dynamic: bool | None = None,
     package: CompilePackage | None = None,
-    region_recompile_limit: int | None = None,
+    isolated_cache: bool = False,
 ) -> OptimizeContext | _NullDecorator:
     """
     The main entrypoint of TorchDynamo.  Do graph capture and call
@@ -1587,7 +1587,7 @@ def _optimize(
             hooks=hooks,
             rebuild_ctx=rebuild_ctx,
             package=package,
-            region_recompile_limit=region_recompile_limit,
+            isolated_cache=isolated_cache,
         )
 
     backend = get_compiler_fn(backend)
@@ -1611,7 +1611,7 @@ def _optimize(
             backend,
             hooks,
             package=package,
-            region_recompile_limit=region_recompile_limit,
+            isolated_cache=isolated_cache,
         ),
         hooks,
         backend_ctx_ctor,
@@ -1626,7 +1626,7 @@ def _optimize(
         ),
         rebuild_ctx=rebuild_ctx,
         package=package,
-        region_recompile_limit=region_recompile_limit,
+        isolated_cache=isolated_cache,
     )
 
 
@@ -2465,7 +2465,7 @@ def _optimize_assert(
     export_constraints: Any | None = None,
     dynamic: bool | None = None,
     package: CompilePackage | None = None,
-    region_recompile_limit: int | None = None,
+    isolated_cache: bool = False,
 ) -> OptimizeContext:
     """
     Guarantees single-graph capture.
@@ -2496,7 +2496,7 @@ def _optimize_assert(
             export=export,
             export_constraints=export_constraints,
             package=package,
-            region_recompile_limit=region_recompile_limit,
+            isolated_cache=isolated_cache,
         ),
         hooks,
         backend_ctx_ctor,
@@ -2505,7 +2505,7 @@ def _optimize_assert(
         dynamic=dynamic,
         rebuild_ctx=rebuild_ctx,
         package=package,
-        region_recompile_limit=region_recompile_limit,
+        isolated_cache=isolated_cache,
     )
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #178307
* #177895
* #177894
* #177399
* #177355


## Summary

Cache entries in Dynamo are stored per code object. When multiple `torch.compile()` calls
target the same function, their cache entries are interleaved on the same linked list. This
causes cross-region interference: one region's compilations affect another region's cache
lookup, recompile limit checks, and `FrameExecStrategy`.

`torch.compile(f, isolated_cache=True)` gives each compile region its own isolated cache:

1. **C++ `region_id`** — each `CacheEntry` is tagged with a region_id. `lookup()` filters
   entries by region_id, so each region only sees its own entries.
2. **Python `_region_compilation_counts`** — tracks per-region, per-code-object compilation
   counts. Uses `max` across all code objects in the region (including resume functions from
   graph breaks) so that once any code object hits the limit, all compilation in the region
   stops.
3. **Global limit override** — with `isolated_cache=True`, `config.recompile_limit` is
   checked against per-region counts (not the shared code object total).
   `accumulated_recompile_limit` still applies as a hard safety cap.
4. **`FrameExecStrategy` isolation** — `apply_to_code=False` when `isolated_cache=True`,
   so one region hitting its limit doesn't set `RUN_ONLY` on the code object for other
   regions.

Regions without `isolated_cache` (region_id = -1) use the shared cache as before.

## Use cases

### Factory pattern
Multiple `torch.compile()` wrappers around the same inner function:
```python
@cache
def factory(key):
    @torch.compile(fullgraph=True, isolated_cache=True)
    def frontend(x, n):
        return core(x) + n
    return frontend

factory("foo")(torch.ones(3), 3)  # compiles
factory("bar")(torch.ones(4), 3)  # compiles (separate region)
factory("baz")(torch.ones(5), 3)  # compiles (separate region)
```

### Static vs dynamic on same function
```python
magic_static = torch.compile(magic, dynamic=False, isolated_cache=True)
magic_dynamic = torch.compile(magic, dynamic=True, isolated_cache=True)
# Each has its own cache — static entries don't interfere with dynamic entries
```

### Shared PGO
With `isolated_cache`, PGO (`frame_state`) is still shared across regions on the same
code object. Region B benefits from region A's shape observations — faster convergence
to dynamic shapes without redundant compilations.

## Changes

**C++:**
- `cache_entry.h/cpp`: `region_id` field on `CacheEntry`, `get_region_id()` helper
- `extra_state.h/cpp`: `lookup()` filters by `region_id`
- `eval_frame_cpp.cpp`: Extracts `region_id` from callback and passes to `lookup()`
- `init.cpp`: Exposes `region_id` via pybind

**Python:**
- `torch/__init__.py`: `isolated_cache: bool = False` kwarg on `torch.compile()`
- `torch/_dynamo/eval_frame.py`: Threads `isolated_cache` through `_optimize` / `optimize_assert`
- `torch/_dynamo/convert_frame.py`: `_isolated_cache`, `_region_id`, `_region_compilation_counts`
  on `ConvertFrameAssert`. Global limit override and `apply_to_code` fix in error handler.
- `torch/_dynamo/cache_size.py`: `isolated_cache` and `region_num_compilations` fields
- `torch/_dynamo/types.py`: `region_id` on `GuardedCode`
- `torch/_dynamo/resume_execution.py`: `get_all_resume_code_objects` helper


## Test Plan

- `test_isolated_cache_same_function_different_regions` — two regions on same function, independent caches
- `test_isolated_cache_factory_pattern` — factory pattern with `fail_on_recompile_limit_hit=True`
- `test_isolated_cache_static_and_dynamic` — static vs dynamic on same function
- `test_isolated_cache_fullgraph_raises` — fullgraph contract honored
- `test_isolated_cache_two_models_independent` — two model compiles don't interfere
- `test_isolated_cache_mark_dynamic_vs_static` — mark_static and mark_dynamic coexist
- `test_isolated_cache_auto_dynamic_shared_pgo` — PGO sharing across isolated regions
- `test_isolated_cache_explicit_dispatch_static_vs_dynamic` — explicit dispatch without exclusion guards
- `test_global_recompile_limit_resume_function` — documents existing per-code-object behavior



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo