### PR TITLE
make pyspy dumps nonblocking by default

### DIFF
--- a/torch/distributed/debug/_debug_handlers.py
+++ b/torch/distributed/debug/_debug_handlers.py
@@ -228,9 +228,10 @@ class PySpyHandler(DebugHandler):
         return {"pyspy_dump.html": PYSPY_DUMP_TEMPLATE}
 
     def _handle(self, req: HTTPRequestHandler) -> bytes:
-        addrs, resps = fetch_all(
-            "pyspy_dump", req.get_raw_query(), timeout=self.fetch_timeout
-        )
+        query = req.get_raw_query()
+        if "nonblocking" not in query:
+            query = f"nonblocking=1&{query}" if query else "nonblocking=1"
+        addrs, resps = fetch_all("pyspy_dump", query, timeout=self.fetch_timeout)
         return req.frontend.render_template(
             "pyspy_dump.html",
             addrs=addrs,
@@ -238,7 +239,9 @@ class PySpyHandler(DebugHandler):
         )
 
     def dump(self) -> str | None:
-        addrs, resps = fetch_all("pyspy_dump", timeout=self.fetch_timeout)
+        addrs, resps = fetch_all(
+            "pyspy_dump", "nonblocking=1", timeout=self.fetch_timeout
+        )
         parts: list[str] = []
         summary = format_fetch_summary(addrs, resps)
         if summary:


### PR DESCRIPTION

Summary:
Prevent pyspy dumps from blocking by default, since blocking behavior can cause delays during debugging. The `nonblocking=1` query parameter is now automatically injected into both HTTP handler requests and direct `dump()` calls unless explicitly overridden.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/pytorch/pytorch/pull/178312).
* #178359
* __->__ #178312