### PR TITLE
Tag vanilla AC regions with ac_graph_id during make_fx tracing

### DIFF
--- a/test/dynamo/test_activation_checkpointing.py
+++ b/test/dynamo/test_activation_checkpointing.py
@@ -2690,7 +2690,7 @@ class ActivationCheckpointingMakeFxTests(torch._dynamo.test_case.TestCase):
                 self.assertEqual(node.meta.get("recompute"), CheckpointPolicy.MUST_SAVE)
 
     def test_interleaved_sac_and_vanilla_ac_ids(self):
-        """Interleaving SAC and vanilla AC regions produces monotonically increasing ac_graph_ids for SAC."""
+        """Interleaving SAC and vanilla AC regions produces monotonically increasing ac_graph_ids."""
 
         def policy_fn(ctx, func, *args, **kwargs):
             if func == torch.ops.aten.addmm.default:
@@ -2730,9 +2730,10 @@ class ActivationCheckpointingMakeFxTests(torch._dynamo.test_case.TestCase):
             if ac_id is not None and (not ids_in_order or ids_in_order[-1] != ac_id):
                 ids_in_order.append(ac_id)
 
-        # 2 SAC regions, each with a distinct id, monotonically increasing.
-        self.assertEqual(len(ids_in_order), 2)
-        self.assertLess(ids_in_order[0], ids_in_order[1])
+        # All 4 regions (SAC, vanilla, SAC, vanilla) get distinct, monotonically increasing ids.
+        self.assertEqual(len(ids_in_order), 4)
+        for i in range(len(ids_in_order) - 1):
+            self.assertLess(ids_in_order[i], ids_in_order[i + 1])
 
     def test_cleanup_recompute_tags_saves_boundary_tensors(self):
         """cleanup_recompute_tags overrides boundary nodes to MUST_SAVE."""

--- a/torch/_higher_order_ops/wrap.py
+++ b/torch/_higher_order_ops/wrap.py
@@ -21,7 +21,7 @@ from torch.fx import GraphModule
 from torch.fx.experimental.proxy_tensor import ProxyTorchDispatchMode, track_tensor_tree
 from torch.types import _dtype
 from torch.utils._debug_mode import DebugMode
-from torch.utils.checkpoint import _CachedTorchDispatchMode, _CachingTorchDispatchMode
+from torch.utils.checkpoint import _always_prefer_recompute, _CachedTorchDispatchMode, _CachingTorchDispatchMode
 
 
 _P = ParamSpec("_P")
@@ -434,10 +434,8 @@ class TagActivationCheckpoint(HigherOrderOperator):
 tag_activation_checkpoint = TagActivationCheckpoint()
 
 
-def _always_prefer_recompute(ctx, op, *args, **kwargs):
-    from torch.utils.checkpoint import CheckpointPolicy
 
-    return CheckpointPolicy.PREFER_RECOMPUTE
+
 
 
 def tag_activation_checkpoint_impl(gmod, *args, **kwargs):

--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -1314,6 +1314,23 @@ SAC_IGNORED_OPS = {
 _ac_graph_id_counter = itertools.count(1)
 
 
+def _always_prefer_recompute(ctx, op, *args, **kwargs):
+    return CheckpointPolicy.PREFER_RECOMPUTE
+
+
+@contextlib.contextmanager
+def _vanilla_ac_tag_context():
+    """Stamp ac_graph_id and PREFER_RECOMPUTE on fx_traceback metadata for
+    vanilla AC regions during tracing."""
+    fx_traceback.current_meta["ac_graph_id"] = next(_ac_graph_id_counter)
+    fx_traceback.current_meta["recompute"] = CheckpointPolicy.PREFER_RECOMPUTE
+    try:
+        yield
+    finally:
+        fx_traceback.current_meta.pop("ac_graph_id", None)
+        fx_traceback.current_meta.pop("recompute", None)
+
+
 class _CachingTorchDispatchMode(TorchDispatchMode):
     @classmethod
     def ignore_compile_internals(cls):
@@ -1542,7 +1559,13 @@ def _checkpoint_without_reentrant_generator(
     device_type = _infer_device_type(*args)
     device_module = _get_device_module(device_type)
     forward_context, recompute_context = context_fn()
-    if _is_compiling(fn, args, kwargs) and context_fn is not noop_context_fn:
+    if _is_compiling(fn, args, kwargs) and context_fn is noop_context_fn:
+        # Vanilla AC under tracing: stamp ac_graph_id and recompute policy
+        # on fx_traceback metadata so cleanup_recompute_tags can detect
+        # cross-region boundaries.  We use a lightweight context manager
+        # instead of the full SAC machinery.
+        forward_context = _vanilla_ac_tag_context()
+    elif _is_compiling(fn, args, kwargs) and context_fn is not noop_context_fn:
         if (
             not isinstance(forward_context, TorchDispatchMode)
             or not isinstance(recompute_context, TorchDispatchMode)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #178313
* #178294

Under make_fx tracing, vanilla AC regions (no context_fn) were invisible
to cleanup_recompute_tags because they had no ac_graph_id or recompute
metadata. This meant SAC↔vanilla boundaries wouldn't get MUST_SAVE,
breaking mixed-region graphs.

Add _vanilla_ac_tag_context, a lightweight context manager that stamps
ac_graph_id and PREFER_RECOMPUTE on fx_traceback.current_meta for the
duration of the forward. Move _always_prefer_recompute to checkpoint.py
and share the _ac_graph_id_counter between the HOP path (wrap.py) and
the make_fx path so region ids never collide.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98 @Lucaskabela