### PR TITLE
Add version counter check for gradient tensors in the autograd engine

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -7184,6 +7184,36 @@ Done""",
         xz.add_(1)
         self.assertTrue(x._version == xz._version)
 
+    def test_gradient_version_check_no_false_positive(self):
+        # Verify that the gradient version check in the engine does not produce
+        # false positives for various graph topologies.
+
+        # Simple chain: a -> b -> c
+        a = torch.randn(3, requires_grad=True)
+        b = a * 2
+        c = b.sum()
+        c.backward()
+
+        # Fan-in: a used by both b and c, gradients accumulate at a
+        a = torch.randn(3, requires_grad=True)
+        b = a * 2
+        c = a * 3
+        (b + c).sum().backward()
+
+        # Hooks that return new tensors (not in-place)
+        a = torch.randn(3, requires_grad=True)
+        b = a * 2
+        b.register_hook(lambda grad: grad * 0.5)
+        c = b.sum()
+        c.backward()
+
+        # Multiple backward with retain_graph
+        a = torch.randn(3, requires_grad=True)
+        b = (a * 2).sum()
+        b.backward(retain_graph=True)
+        b.backward(retain_graph=True)
+        b.backward()
+
     def test_set_data_tensorimpl_type(self):
         # Dense tensor has impl of type `TensorImpl`, while sparse tensor has impl
         # of type `SparseTensorImpl`.

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -1088,6 +1088,8 @@ void Engine::evaluate_function(
     }
   }
 
+  inputs.check_versions(*func);
+
   // If exec_info_ is not empty, we have to instrument the execution
   auto& exec_info_ = graph_task->exec_info_;
   if (!exec_info_.empty()) {
@@ -1204,6 +1206,7 @@ void Engine::evaluate_function(
           next.function.get());
 
       if (is_ready) {
+
         auto queue = ready_queue(cpu_ready_queue, next.function->device());
         queue->push(
             NodeTask(graph_task, next.function, std::move(input_buffer)));
@@ -1223,6 +1226,7 @@ void Engine::evaluate_function(
           opt_next_stream,
           next.function.get());
       if (is_ready) {
+
         auto queue = ready_queue(cpu_ready_queue, next.function->device());
         queue->push(
             NodeTask(graph_task, next.function, std::move(input_buffer)));
@@ -1427,6 +1431,7 @@ c10::intrusive_ptr<at::ivalue::Future> Engine::execute_with_graph_task(
 
     // Now that all the non-thread safe fields of the graph_task have been
     // populated, we can enqueue it.
+
     queue->push(
         NodeTask(graph_task, std::move(graph_root), std::move(input_buffer)));
 
@@ -1447,6 +1452,7 @@ c10::intrusive_ptr<at::ivalue::Future> Engine::execute_with_graph_task(
 
     // Now that all the non-thread safe fields of the graph_task have been
     // populated, we can enqueue it.
+
     queue->push(
         NodeTask(graph_task, std::move(graph_root), std::move(input_buffer)));
 

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -1206,7 +1206,6 @@ void Engine::evaluate_function(
           next.function.get());
 
       if (is_ready) {
-
         auto queue = ready_queue(cpu_ready_queue, next.function->device());
         queue->push(
             NodeTask(graph_task, next.function, std::move(input_buffer)));
@@ -1226,7 +1225,6 @@ void Engine::evaluate_function(
           opt_next_stream,
           next.function.get());
       if (is_ready) {
-
         auto queue = ready_queue(cpu_ready_queue, next.function->device());
         queue->push(
             NodeTask(graph_task, next.function, std::move(input_buffer)));
@@ -1431,7 +1429,6 @@ c10::intrusive_ptr<at::ivalue::Future> Engine::execute_with_graph_task(
 
     // Now that all the non-thread safe fields of the graph_task have been
     // populated, we can enqueue it.
-
     queue->push(
         NodeTask(graph_task, std::move(graph_root), std::move(input_buffer)));
 
@@ -1452,7 +1449,6 @@ c10::intrusive_ptr<at::ivalue::Future> Engine::execute_with_graph_task(
 
     // Now that all the non-thread safe fields of the graph_task have been
     // populated, we can enqueue it.
-
     queue->push(
         NodeTask(graph_task, std::move(graph_root), std::move(input_buffer)));
 

--- a/torch/csrc/autograd/input_buffer.cpp
+++ b/torch/csrc/autograd/input_buffer.cpp
@@ -77,6 +77,14 @@ void record_stream_any_impl(Variable& var, const c10::Stream& stream) {
   }
 }
 
+bool has_version(const Variable& v) {
+  return v.defined() && v.unsafeGetTensorImpl()->version_counter().enabled();
+}
+
+uint32_t get_version(const Variable& v) {
+  return v.unsafeGetTensorImpl()->version_counter().current_version();
+}
+
 bool can_accumulate_inplace(const Variable& v) {
   return (
       // `v` is a "vanilla" Tensor
@@ -210,9 +218,11 @@ void InputBuffer::add(
     if (!buffer[pos].defined()) {
       buffer[pos] = std::move(var);
     } else {
+      check_version_at(pos, fn);
       c10::OptionalDeviceGuard device_guard{device};
       accumulate(buffer, pos, std::move(var));
     }
+    save_version_at(pos);
     return;
   }
   // Handle the case where var is on an accelerator but producer node has no
@@ -273,6 +283,7 @@ void InputBuffer::add(
     }
     // 2)
     buffer[pos] = std::move(var);
+    save_version_at(pos);
     // 3)
     auto& opt_accum_stream = opt_accum_streams[pos];
     TORCH_INTERNAL_ASSERT(opt_accum_stream.has_value());
@@ -305,8 +316,10 @@ void InputBuffer::add(
       record_stream_any_impl(buffer[pos], *accum_stream);
     }
     // 2)
+    check_version_at(pos, fn);
     c10::OptionalStreamGuard stream_guard{accum_stream};
     accumulate(buffer, pos, std::move(var));
+    save_version_at(pos);
     // 3)
     if (*opt_consumer_stream != *accum_stream) {
       // Only the consumer stream needs to wait for this event
@@ -321,6 +334,59 @@ void InputBuffer::add(
 auto InputBuffer::variables(InputBuffer&& g) -> std::vector<Variable> {
   std::vector<Variable> result = std::move(g.buffer);
   return result;
+}
+
+void InputBuffer::save_version_at(size_t pos) {
+  if (has_version(buffer[pos])) {
+    saved_versions_[pos] = get_version(buffer[pos]);
+  }
+}
+
+void InputBuffer::check_version_at(size_t pos, const Node* fn) {
+  if (!has_version(buffer[pos])) {
+    return;
+  }
+  auto current = get_version(buffer[pos]);
+  TORCH_CHECK(
+      current == saved_versions_[pos],
+      "gradient input ",
+      pos,
+      " of ",
+      fn->name(),
+      " was modified in-place after the gradient was produced by the "
+      "autograd engine. This is not allowed because it can lead to "
+      "incorrect gradient computation. (expected version ",
+      saved_versions_[pos],
+      " but found version ",
+      current,
+      ")");
+}
+
+void InputBuffer::check_versions(const Node& consumer) const {
+  if (saved_versions_.empty()) {
+    return;
+  }
+  for (const auto i : c10::irange(buffer.size())) {
+    if (!buffer[i].defined() ||
+        !buffer[i].unsafeGetTensorImpl()->version_counter().enabled()) {
+      continue;
+    }
+    auto current_version =
+        buffer[i].unsafeGetTensorImpl()->version_counter().current_version();
+    TORCH_CHECK(
+        current_version == saved_versions_[i],
+        "gradient input ",
+        i,
+        " of ",
+        consumer.name(),
+        " was modified in-place after the gradient was produced by the "
+        "autograd engine. This is not allowed because it can lead to "
+        "incorrect gradient computation. (expected version ",
+        saved_versions_[i],
+        " but found version ",
+        current_version,
+        ")");
+  }
 }
 
 } // namespace torch::autograd

--- a/torch/csrc/autograd/input_buffer.h
+++ b/torch/csrc/autograd/input_buffer.h
@@ -19,7 +19,8 @@ struct InputBuffer {
       : buffer(size),
         opt_accum_streams(size),
         ready_events(size),
-        ready_streams(size) {}
+        ready_streams(size),
+        saved_versions_(size) {}
   InputBuffer(const InputBuffer& other) = delete;
   InputBuffer(InputBuffer&& other) = default;
   explicit InputBuffer(variable_list&& inputs) : buffer(std::move(inputs)) {}
@@ -42,6 +43,17 @@ struct InputBuffer {
   // Returns the inputs as a list of variables. Destroys given InputBuffer.
   static std::vector<Variable> variables(InputBuffer&& g);
 
+  // Check that version counters haven't changed since the gradients were
+  // placed in the buffer. Errors if a gradient was modified in-place
+  // between production and consumption.
+  void check_versions(const Node& consumer) const;
+
+ private:
+  void save_version_at(size_t pos);
+  void check_version_at(size_t pos, const Node* fn);
+
+ public:
+
   std::vector<Variable> buffer;
   // The stream used for accumulation when a variable is used multiple times.
   std::vector<std::optional<c10::Stream>> opt_accum_streams;
@@ -51,6 +63,10 @@ struct InputBuffer {
   // The streams corresponding to the events above. This is only used to
   // check if more synchronization is needed or not.
   std::vector<std::optional<c10::Stream>> ready_streams;
+  // Version counters recorded when gradients are placed in the buffer (via
+  // add()) and updated after accumulation. Used to detect in-place
+  // modification of gradients between production and consumption.
+  std::vector<uint32_t> saved_versions_;
 };
 
 } // namespace torch::autograd


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #178315
* #175338
* #176447
* #176455
* #175348
* #176931
* #177396
* #174327

The engine now records the version counter of each gradient tensor when
it is placed into an InputBuffer (via add()), checks it before
accumulation, and verifies it again when the next node consumes the
buffer. This detects in-place modifications to gradients between
production and consumption, which would silently produce incorrect
results.

Authored with Claude.