### PR TITLE
Fix test_binary_redirect_and_tee: add log_line_prefix to assertions

### DIFF
--- a/test/distributed/elastic/multiprocessing/api_test.py
+++ b/test/distributed/elastic/multiprocessing/api_test.py
@@ -740,9 +740,9 @@ if not (TEST_WITH_DEV_DBG_ASAN or IS_WINDOWS or IS_MACOS):
             result = pc.wait()
 
             self.assertFalse(result.is_failed())
-            self.assert_in_file(["hello stdout from 0"], pc.stdouts[0])
-            self.assert_in_file(["hello stderr from 0"], pc.stderrs[0])
-            self.assert_in_file(["world stderr from 1"], pc.stderrs[1])
+            self.assert_in_file(["[rank0]:hello stdout from 0"], pc.stdouts[0])
+            self.assert_in_file(["[rank0]:hello stderr from 0"], pc.stderrs[0])
+            self.assert_in_file(["[rank1]:world stderr from 1"], pc.stderrs[1])
             self.assertFalse(pc.stdouts[1])
             for tail_log in pc._tail_logs:
                 self.assertTrue(tail_log.stopped())
@@ -842,9 +842,9 @@ if not (TEST_WITH_DEV_DBG_ASAN or IS_WINDOWS or IS_MACOS or IS_CI):
                     result = pc.wait()
 
                     self.assertFalse(result.is_failed())
-                    self.assert_in_file(["hello stdout from 0"], pc.stdouts[0])
-                    self.assert_in_file(["hello stderr from 0"], pc.stderrs[0])
-                    self.assert_in_file(["world stderr from 1"], pc.stderrs[1])
+                    self.assert_in_file(["[rank0]:hello stdout from 0"], pc.stdouts[0])
+                    self.assert_in_file(["[rank0]:hello stderr from 0"], pc.stderrs[0])
+                    self.assert_in_file(["[rank1]:world stderr from 1"], pc.stderrs[1])
                     self.assertFalse(pc.stdouts[1])
                     for tail_log in pc._tail_logs:
                         self.assertTrue(tail_log.stopped())


### PR DESCRIPTION
  Fix flaky test by correcting assertions in `test_binary_redirect_and_tee`
  for both `StartProcessesListAsBinaryTest` and `StartProcessesNotCIAsBinaryTest`.

  The tests pass `log_line_prefixes={0: "[rank0]:", 1: "[rank1]:"}` to
  `start_processes`, which prepends each log line with the rank prefix.
  The assertions were checking for bare strings (e.g. `"hello stdout from 0"`)
  instead of the prefixed form (e.g. `"[rank0]:hello stdout from 0"`), so
  they would never match actual file contents.

  The fix updates all three assertions in each affected test to include the
  correct prefix, consistent with how `test_binary_duplicate_log_filters`
  already handles this correctly.

  Fixes #163230