### PR TITLE
[Inductor] Add xmask unswitch for dynamic pointwise kernels

### DIFF
--- a/test/inductor/test_codegen_triton.py
+++ b/test/inductor/test_codegen_triton.py
@@ -514,6 +514,114 @@ class TestCodegenTriton(InductorTestCase):
         self.assertNotIn("tt.pointer_range", code_str)
 
 
+class TestXmaskUnswitch(InductorTestCase):
+    """Test the xmask_unswitch codegen optimization.
+
+    The unswitched pattern is only generated for dynamic shapes where xnumel
+    is symbolic. For static shapes, Triton already specializes on the
+    actual value via divisibility hints.
+    """
+
+    @unittest.skipUnless(HAS_GPU_AND_TRITON, "requires GPU and Triton")
+    def test_dynamic_shape_generates_unswitch(self):
+        """Dynamic (symbolic) xnumel should emit unswitched pattern."""
+
+        def fn(x):
+            return x * 3.0 + 1.0
+
+        x = torch.randn(4097, device=GPU_TYPE, dtype=torch.float16)
+        with inductor_config.patch({"triton.xmask_unswitch": True}):
+            result, code = run_and_get_code(torch.compile(fn, dynamic=True), x)
+        code_str = "\n".join(code)
+        self.assertIn("xoffset + XBLOCK <= xnumel", code_str)
+        self.assertIn("xmask = tl.full", code_str)
+        self.assertIn(", xmask)", code_str)
+        # Should have one full/tail branch around the generated body.
+        self.assertEqual(
+            code_str.count("xoffset + XBLOCK <= xnumel"),
+            1,
+            "should have one full/tail branch around the generated body",
+        )
+        torch.testing.assert_close(result, fn(x), atol=1e-3, rtol=1e-3)
+
+    @unittest.skipUnless(HAS_GPU_AND_TRITON, "requires GPU and Triton")
+    def test_store_only_generates_unswitch(self):
+        """xmask-only stores should be enough to emit unswitch."""
+
+        def fn(x):
+            return torch.full_like(x, 1.0)
+
+        x = torch.randn(4097, device=GPU_TYPE, dtype=torch.float16)
+        with inductor_config.patch({"triton.xmask_unswitch": True}):
+            result, code = run_and_get_code(torch.compile(fn, dynamic=True), x)
+        code_str = "\n".join(code)
+        self.assertIn("xoffset + XBLOCK <= xnumel", code_str)
+        self.assertIn("xmask = tl.full", code_str)
+        self.assertNotIn("tl.load(", code_str)
+        torch.testing.assert_close(result, fn(x), atol=1e-3, rtol=1e-3)
+
+    @unittest.skipUnless(HAS_GPU_AND_TRITON, "requires GPU and Triton")
+    def test_static_shape_no_unswitch(self):
+        """Static shapes should NOT emit unswitch — Triton specializes
+        on the actual value via divisibility hints."""
+
+        def fn(x):
+            return x * 3.0 + 1.0
+
+        x = torch.randn(1000, device=GPU_TYPE, dtype=torch.float16)
+        with inductor_config.patch({"triton.xmask_unswitch": True}):
+            _, code = run_and_get_code(torch.compile(fn), x)
+        code_str = "\n".join(code)
+        self.assertNotIn("xoffset + XBLOCK <= xnumel", code_str)
+        self.assertNotIn("xmask = tl.full", code_str)
+
+    @unittest.skipUnless(HAS_GPU_AND_TRITON, "requires GPU and Triton")
+    def test_2d_transpose_no_unswitch(self):
+        """2D tiled kernels (e.g. transpose) should NOT emit unswitch
+        because both x and y masks are dynamic."""
+
+        def fn(a, b):
+            return a + b.T
+
+        a = torch.randn(33, 17, device=GPU_TYPE, dtype=torch.float16)
+        b = torch.randn(17, 33, device=GPU_TYPE, dtype=torch.float16)
+        with inductor_config.patch({"triton.xmask_unswitch": True}):
+            _, code = run_and_get_code(torch.compile(fn, dynamic=True), a, b)
+        code_str = "\n".join(code)
+        self.assertNotIn("xoffset + XBLOCK <= xnumel", code_str)
+        self.assertNotIn("xmask = tl.full", code_str)
+
+    @unittest.skipUnless(HAS_GPU_AND_TRITON, "requires GPU and Triton")
+    def test_combo_kernel_unswitch(self):
+        """Combo kernel fusing two independent pointwise ops should emit
+        both the pid dispatch (combo) and the unswitch pattern in each
+        sub-kernel under dynamic shapes."""
+
+        def fn(x1, x2):
+            return x1 * x1, x2 + 1.0
+
+        x1 = torch.randn(4097, device=GPU_TYPE, dtype=torch.float16)
+        x2 = torch.randn(4097, device=GPU_TYPE, dtype=torch.float16)
+        with inductor_config.patch(
+            {
+                "combo_kernels": True,
+                "benchmark_combo_kernel": False,
+                "triton.xmask_unswitch": True,
+            }
+        ):
+            result, code = run_and_get_code(torch.compile(fn, dynamic=True), x1, x2)
+        code_str = "\n".join(code)
+        # Should be a combo kernel with pid-based dispatch
+        self.assertIn("pid = tl.program_id(0)", code_str)
+        self.assertIn("num_xblocks_0", code_str)
+        # Should contain unswitch pattern inside the combo sub-kernels
+        self.assertIn("xoffset + XBLOCK <= xnumel_0", code_str)
+        self.assertIn("xmask = tl.full", code_str)
+        result_ref = fn(x1, x2)
+        torch.testing.assert_close(result[0], result_ref[0], atol=1e-3, rtol=1e-3)
+        torch.testing.assert_close(result[1], result_ref[1], atol=1e-3, rtol=1e-3)
+
+
 if __name__ == "__main__":
     from torch._inductor.test_case import run_tests
 

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -3128,6 +3128,18 @@ class TMACompatibilityChecker:
         return self.force
 
 
+def _may_use_xmask_unswitch(kernel: TritonKernel) -> bool:
+    """Whether xmask unswitch optimization may apply.
+
+    Config flag must be enabled and x-dimension numel must be dynamic.
+    Per-op eligibility (xmask is sole mask) is checked at load/store sites.
+    """
+    if not config.triton.xmask_unswitch:
+        return False
+    xtree = kernel.range_trees[0]
+    return not isinstance(xtree.numel, (sympy.Integer, int))
+
+
 class TritonKernel(SIMDKernel[TritonCSEVariable]):
     """A class to represent a triton kernel and helpers to generate
     triton kernel programmatically
@@ -3168,6 +3180,8 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         self.post_loop_store: IndentedBuffer = IndentedBuffer()
         self.outside_loop_vars = OrderedSet[Any]()
         self.min_elem_per_thread = min_elem_per_thread
+        # True after load()/store() observes an xmask-only memory op.
+        self._use_xmask_unswitch = False
         self.block_ptr_id = itertools.count()
         self.block_ptr_to_buffer = dict[str, str]()
         self.helper_functions = HelperFunctions()
@@ -3201,6 +3215,11 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
 
     def triton_tensor_ndim(self) -> int:
         return sum(int(tree.tensor_dim is not None) for tree in self.range_trees)
+
+    def _is_xmask_unswitchable_indexing(self, indexing: IndexingOptions) -> bool:
+        return _may_use_xmask_unswitch(self) and indexing.mask_vars == OrderedSet(
+            ["xmask"]
+        )
 
     def indexing_size_str(self, i: int) -> str:
         sizes = ["None"] * self.triton_tensor_ndim()
@@ -4337,6 +4356,9 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 shape = ()
             else:
                 line = f"tl.load({var} + ({indexing.index_str}), {indexing.mask_str}{ep}{other}{cachemod})"
+                # Mark this kernel for xmask unswitch optimization.
+                if self._is_xmask_unswitchable_indexing(indexing):
+                    self._use_xmask_unswitch = True
 
                 # The block shape of tl.load depends on the indexing expression.
                 # Inferring shape solely from the mask may miss cases where the mask is constant.
@@ -4477,6 +4499,9 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                     value_shape = ", ".join(map(str, value.shape))
                     indexing_str += f".broadcast_to({value_shape})"
             line = f"tl.store({var} + ({indexing_str}), {value}, {indexing.mask_str})"
+            # Mark this kernel for xmask unswitch optimization.
+            if self._is_xmask_unswitchable_indexing(indexing):
+                self._use_xmask_unswitch = True
         elif mode == "atomic_add":
             self.atomic_add_found = True
             indexing_str = indexing.index_str
@@ -6057,10 +6082,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 self.cse.invalidate(self.outside_loop_vars)
                 tree.cache_clear()
         else:
-            self.body.splice(self.indexing_code)
-            self.body.splice(self.loads)
-            self.body.splice(self.compute)
-            self.body.splice(self.stores)
+            self._codegen_body()
         self.body.splice(self.post_loop_combine)
         if self.cooperative_reduction and (
             self.post_loop_combine or self.post_loop_store
@@ -7008,6 +7030,34 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         if xtree.prefix != "x":
             raise AssertionError(f"expected xtree prefix 'x', got {xtree.prefix!r}")
         return self._has_constant_mask(xtree)
+
+    def _codegen_body(self) -> None:
+        """Splice indexing/loads/compute/stores into self.body."""
+
+        def splice_ld_compute_st() -> None:
+            self.body.splice(self.loads)
+            self.body.splice(self.compute)
+            self.body.splice(self.stores)
+
+        if self._use_xmask_unswitch:
+            xtree = self.range_trees[0]
+            if xtree.prefix != "x":
+                raise AssertionError(f"expected xtree prefix 'x', got {xtree.prefix!r}")
+
+            block_var = f"{xtree.prefix.upper()}BLOCK"
+            predicate = f"{xtree.prefix}offset + {block_var} <= {xtree.prefix}numel"
+
+            self.body.splice(self.indexing_code)
+            self.body.writeline(f"if {predicate}:")
+            with self.body.indent():
+                self.body.writeline(self.create_constant_mask(xtree))
+                splice_ld_compute_st()
+            self.body.writeline("else:")
+            with self.body.indent():
+                splice_ld_compute_st()
+        else:
+            self.body.splice(self.indexing_code)
+            splice_ld_compute_st()
 
     def filter_masks(self, mask_vars: OrderedSet[str]) -> None:
         for tree in self.range_trees:

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -3136,8 +3136,22 @@ def _may_use_xmask_unswitch(kernel: TritonKernel) -> bool:
     """
     if not config.triton.xmask_unswitch:
         return False
-    xtree = kernel.range_trees[0]
+    device = V.graph.current_device
+    if device is None or not utils.is_gpu(device.type):
+        return False
+    xtree = _get_xmask_unswitch_tree(kernel)
+    if xtree is None:
+        return False
     return not isinstance(xtree.numel, (sympy.Integer, int))
+
+
+def _get_xmask_unswitch_tree(kernel: TritonKernel) -> IterationRangesRoot | None:
+    # 2D pointwise tiling can order range_trees as y, x, so find x by prefix
+    # instead of assuming a fixed position.
+    for tree in kernel.range_trees:
+        if tree.prefix == "x":
+            return tree
+    return None
 
 
 class TritonKernel(SIMDKernel[TritonCSEVariable]):
@@ -3205,6 +3219,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             self.init_cooperative_reduction()
 
         self.codegen_range_tree()
+        self._may_use_xmask_unswitch = _may_use_xmask_unswitch(self)
 
         if self.cooperative_reduction:
             self.init_cooperative_reduction_mask()
@@ -3217,7 +3232,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         return sum(int(tree.tensor_dim is not None) for tree in self.range_trees)
 
     def _is_xmask_unswitchable_indexing(self, indexing: IndexingOptions) -> bool:
-        return _may_use_xmask_unswitch(self) and indexing.mask_vars == OrderedSet(
+        return self._may_use_xmask_unswitch and indexing.mask_vars == OrderedSet(
             ["xmask"]
         )
 
@@ -7040,9 +7055,9 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             self.body.splice(self.stores)
 
         if self._use_xmask_unswitch:
-            xtree = self.range_trees[0]
-            if xtree.prefix != "x":
-                raise AssertionError(f"expected xtree prefix 'x', got {xtree.prefix!r}")
+            xtree = _get_xmask_unswitch_tree(self)
+            if xtree is None:
+                raise AssertionError("expected an xmask unswitch range tree")
 
             block_var = f"{xtree.prefix.upper()}BLOCK"
             predicate = f"{xtree.prefix}offset + {block_var} <= {xtree.prefix}numel"

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -2041,6 +2041,11 @@ class triton:
         os.environ.get("TORCHINDUCTOR_EMIT_POINTER_RANGE_32", "1") == "1"
     )
 
+    # Enable xmask unswitch optimization for dynamic pointwise Triton kernels.
+    # Kernels with xmask-only loads/stores emit a full-block branch that sets
+    # xmask to True and a tail branch that uses the normal mask.
+    xmask_unswitch: bool = os.environ.get("TORCHINDUCTOR_XMASK_UNSWITCH", "1") == "1"
+
     # Minimum R0_BLOCK to be used for a TritonSplitScanKernel
     # NOTE: This also indirectly controls the size of workspace buffer required
     min_split_scan_rblock = 256


### PR DESCRIPTION
## Summary

This adds an xmask unswitch optimization for dynamic pointwise Triton kernels.
When `xnumel` is symbolic, generated kernels normally keep `xmask` on every
load/store, even for full blocks. That prevents Triton from seeing the common
full-block path as unmasked and can block better vectorization.

With `config.triton.xmask_unswitch` enabled, kernels that have xmask-only
loads or stores now emit:

1. a full-block branch where `xmask` is replaced with a constant `True` mask
2. a tail branch that keeps the normal dynamic `xmask`

The optimization is controlled by:

```python
torch._inductor.config.triton.xmask_unswitch
```

and by the environment variable:

```bash
TORCHINDUCTOR_XMASK_UNSWITCH
```

## How It Works

`TritonKernel` first checks whether xmask unswitch may apply:

- the config flag must be enabled
- the x dimension must be dynamic

During load/store codegen, the kernel records that xmask unswitch should be
used only when the memory op is guarded solely by `xmask`.

Then `_codegen_body()` emits the usual indexing code followed by either:

- the original body for kernels without xmask-only memory ops
- an `if xoffset + XBLOCK <= xnumel` full/tail split for eligible kernels

The full-block branch reuses the existing generated load/store body, but first
sets `xmask` to a constant true mask. This avoids string-rewriting individual
load/store lines and keeps the codegen path close to the normal Triton body
emission.

## Generated Triton Code

For a simple dynamic pointwise kernel:

```python
def fn(x):
    return x * 3.0 + 1.0
```

the generated Triton code contains a full-block branch that replaces `xmask`
with a constant true mask, and a tail branch that keeps the normal dynamic
mask:

```python
@triton.jit
def triton_poi_fused_add_mul_0(
    in_ptr0, out_ptr0, xnumel, XBLOCK: tl.constexpr
):
    xoffset = tl.program_id(0) * XBLOCK
    xindex = xoffset + tl.arange(0, XBLOCK)[:]
    xmask = xindex < xnumel
    x0 = xindex
    if xoffset + XBLOCK <= xnumel:
        xmask = tl.full([XBLOCK], True, tl.int1)[:]
        tmp0 = tl.load(in_ptr0 + (x0), xmask).to(tl.float32)
        tmp1 = tl.full([1], 3.0, tl.float32)
        tmp2 = tmp0 * tmp1
        tmp3 = tl.full([1], 1.0, tl.float32)
        tmp4 = tmp2 + tmp3
        tl.store(out_ptr0 + (x0), tmp4, xmask)
    else:
        tmp0 = tl.load(in_ptr0 + (x0), xmask).to(tl.float32)
        tmp1 = tl.full([1], 3.0, tl.float32)
        tmp2 = tmp0 * tmp1
        tmp3 = tl.full([1], 1.0, tl.float32)
        tmp4 = tmp2 + tmp3
        tl.store(out_ptr0 + (x0), tmp4, xmask)
```

## Tests

Added coverage for:

- dynamic pointwise kernels emitting the xmask split
- store-only kernels still triggering the split
- static shapes not emitting the split
- 2D kernels with both x/y masks not emitting the split
- combo kernels emitting the split inside each sub-kernel

Local validation:

```bash
lintrunner torch/_inductor/codegen/triton.py test/inductor/test_codegen_triton.py torch/_inductor/config.py
python test/inductor/test_codegen_triton.py TestXmaskUnswitch
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo