### PR TITLE
[MPS] Add device guard for MPS dispatch key (#142048)

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1824,6 +1824,7 @@
 # We need this to be able to properly copy from a CPU to an XLA tensor with different sizes.
 # See https://github.com/pytorch/xla/issues/2881
 - func: _copy_from_and_resize(Tensor self, Tensor dst) -> Tensor
+  device_check: NoCheck
   dispatch:
     MPS: _copy_from_and_resize_mps
   autogen: _copy_from_and_resize.out

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -13010,6 +13010,15 @@ class TestConsistency(TestCaseMPS):
             # Broadcast
             self.assertEqual(op(x, y[0]), op(x.to("mps"), y.to("mps")[0]).cpu())
 
+    # Regression test for https://github.com/pytorch/pytorch/issues/142048
+    def test_solve_triangular_device_mismatch(self):
+        A = torch.randn(3, 3, device="mps")
+        B = torch.eye(3, device="cpu")
+        with self.assertRaisesRegex(RuntimeError, "same device"):
+            torch.linalg.solve_triangular(A, B, upper=True)
+        with self.assertRaisesRegex(RuntimeError, "same device"):
+            torch.linalg.solve_triangular(B, A.cpu(), upper=True, out=torch.empty(0, device="mps"))
+
 
 class TestErrorInputs(TestCase):
     _ignore_not_implemented_error = True

--- a/torchgen/gen.py
+++ b/torchgen/gen.py
@@ -62,6 +62,7 @@ from torchgen.model import (
     is_generic_dispatch_key,
     is_ufunc_dispatch_key,
     is_xpu_dispatch_key,
+    is_mps_dispatch_key,
     Location,
     NativeFunction,
     NativeFunctionsGroup,
@@ -213,7 +214,7 @@ def parse_native_yaml_struct(
             use_out_as_primary=True,
             external=False,
             # Only cuda-like devices in tree require device guards
-            device_guard=is_cuda_dispatch_key(k) or is_xpu_dispatch_key(k),
+            device_guard=is_cuda_dispatch_key(k) or is_xpu_dispatch_key(k) or is_mps_dispatch_key(k),
             index=v,
         )
     return ParsedYaml(rs, indices)

--- a/torchgen/model.py
+++ b/torchgen/model.py
@@ -362,6 +362,17 @@ def is_xpu_dispatch_key(dk: DispatchKey) -> bool:
         DispatchKey.AutogradXPU,
     }
 
+# MPS specific dispatcy keys
+def is_mps_dispatch_key(dk: DispatchKey) -> bool:
+    return dk in {
+        DispatchKey.MPS,
+        DispatchKey.QuantizedMPS,
+        DispatchKey.SparseMPS,
+        DispatchKey.SparseCsrMPS,
+        DispatchKey.NestedTensorMPS,
+        DispatchKey.AutogradMPS,
+    }
+
 
 # Structured kernel generation is only supported for certain key types;
 # otherwise use old-style


### PR DESCRIPTION
Fixes #142048

Calling `torch.linalg.solve_triangular` with tensors on different devices (MPS vs CPU) causes a segfault instead of a RuntimeError. This is because the MPS backend's codegen wrappers don't emit device checks, unlike CUDA and XPU.

This adds `is_mps_dispatch_key()` to `torchgen/model.py` and includes MPS in the `device_guard` flag in `torchgen/gen.py`, so all generated MPS dispatch wrappers now validate that tensors are on the same device before calling into the kernel.

Includes a regression test in `test/test_mps.py`.

Authored with Claude.