### PR TITLE
Add CUDA-aware detection for Cray MPICH

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupMPI.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupMPI.cpp
@@ -67,7 +67,15 @@ bool cudaAwareMpiCheck() {
   } else {
     return false;
   }
-#else // !defined(MPIX_CUDA_AWARE_SUPPORT)
+// Recognize that Cray MPICH is CUDA-aware (used on Cray/HPE supercomputers)
+#elif defined(MPIX_GPU_SUPPORT_CUDA)
+  const char* cray_gpu_support = std::getenv("MPICH_GPU_SUPPORT_ENABLED");
+  if (cray_gpu_support != nullptr && std::string(cray_gpu_support) == "1") {
+    return true;
+  } else {
+    return false;
+  }
+#else // !defined(MPIX_CUDA_AWARE_SUPPORT) && !defined(MPIX_GPU_SUPPORT_CUDA)
   return false;
 #endif // MPIX_CUDA_AWARE_SUPPORT
 }


### PR DESCRIPTION
Fixes #178191 

**Summary:**
Currently, cudaAwareMpiCheck() only detects CUDA-aware MPI through Open MPI's MPIX_CUDA_AWARE_SUPPORT. This means Cray MPICH environments (common on HPE/Cray supercomputers like ALCF's Polaris) are not recognized as CUDA-aware, causing PyTorch to fall back to CPU transfers for MPI operations even when GPU-direct support is available.
This PR adds a #elif branch that checks for MPIX_GPU_SUPPORT_CUDA (a Cray MPICH compile-time define) and the MPICH_GPU_SUPPORT_ENABLED environment variable at runtime, matching the existing pattern used for Open MPI detection.

**Testing:**
Built and tested on ALCF Polaris (Cray MPICH, NVIDIA A100s). Before this fix, cudaAwareMpiCheck() returned false; after, it correctly returns true and GPU-direct MPI operations work as expected.
The new code is in a #elif preprocessor branch, it only compiles when MPIX_GPU_SUPPORT_CUDA is defined and MPIX_CUDA_AWARE_SUPPORT is not. Existing Open MPI behavior is completely unchanged.