### PR TITLE
[CUDA] [PERFORMANCE] Improve performance for `ScaledGroupMM.cu` by avoiding redundant IO/compute via indicating that `ElementC` type is void

### DIFF
--- a/aten/src/ATen/native/cuda/ScaledGroupMM.cu
+++ b/aten/src/ATen/native/cuda/ScaledGroupMM.cu
@@ -192,7 +192,7 @@ void f8f8bf16_grouped_gemm_impl_sm90(
           cutlass::epilogue::collective::EpilogueTileAuto,
           DtypeAccum,
           DtypeAccum,
-          DtypeOutput,
+          void, // Indicate there is no beta scaling to save register
           LayoutOutput*,
           AlignmentOutput,
           DtypeOutput,
@@ -390,7 +390,7 @@ void f8f8bf16_grouped_gemm_impl_sm90(
        (const DtypeB**)inputB_ptrs,
        stride_B},
       {{{{inputB_scale_ptrs}, {{inputA_scale_ptrs}, {}, {}}, {}}, {}},
-       (const DtypeOutput**)output_ptrs,
+       nullptr,
        stride_output,
        output_ptrs,
        stride_output}};


### PR DESCRIPTION
This pull request features #170802 by @malfet (credits to you for the nice improvement 👍) and (probably (I could not test it because I don't have a cuda device, but it's basically the same like in #170802, so I'm pretty sure that this also brings some profits to performance (and also I'm pretty sure from looking at the code))) speeds up `ScaledGroupMM.cu` by (probably) around 5% (see #170802 (1237 to 1313 TFlops for `GroupMM.cu` and `ScaledGroupMM.cu` should in my opinion (but please correct me if I'm mistaken) be around this in some range)).

The changed parts (before the change to `GroupMM.cu` which `ScaledGroupMM.cu` was missing) are nearly the same (except for some differences, e.g. `{{{{inputB_scale_ptrs}, {{inputA_scale_ptrs}, {}, {}}, {}}, {}},`) for both scripts, so I'm pretty confident that this should behave the same and be correct, so the change should be fine in my opinion (while I couldn't test it because I don't have a cuda device)).

Contributed by Benedikt Johannes

cc @jerryzh168