### PR TITLE
[Bugfix] Make checkpoint pack_hook opaque when submodules use nn.Module.compile()

### DIFF
--- a/test/dynamo/test_activation_checkpointing.py
+++ b/test/dynamo/test_activation_checkpointing.py
@@ -2473,6 +2473,58 @@ def forward(self, arg0_1):
     return (detach_3,)""",
         )
 
+    @torch._dynamo.config.patch(skip_fwd_side_effects_in_bwd_under_checkpoint=True)
+    def test_attr_compile_submodules_in_checkpoint_wrapper(self):
+        """Compiling submodules inside a checkpointed block should not hit the
+        recompile limit due to WeakKeyDictionary guards in the pack_hook."""
+        from torch.utils.checkpoint import checkpoint
+
+        class Block(nn.Module):
+            def __init__(self, dim):
+                super().__init__()
+                self.norm1 = nn.RMSNorm(dim)
+                self.linear1 = nn.Linear(dim, dim, bias=False)
+                self.norm2 = nn.RMSNorm(dim)
+                self.linear2 = nn.Linear(dim, dim, bias=False)
+                self.norm3 = nn.RMSNorm(dim)
+                self.linear3 = nn.Linear(dim, dim, bias=False)
+
+            def forward(self, x):
+                x = x + self.linear1(self.norm1(x))
+                x = x + self.linear2(self.norm2(x))
+                x = x + self.linear3(self.norm3(x))
+                return x
+
+        class CheckpointedBlock(nn.Module):
+            def __init__(self, block):
+                super().__init__()
+                self.block = block
+
+            def forward(self, x):
+                return checkpoint(self.block, x, use_reentrant=False)
+
+        dim = 32
+        block = Block(dim)
+
+        x_ref = torch.randn(4, dim, requires_grad=True)
+        ref = block(x_ref)
+        ref.sum().backward()
+
+        block_cp = Block(dim)
+        block_cp.load_state_dict(block.state_dict())
+        wrapped = CheckpointedBlock(block_cp)
+
+        for _, submod in wrapped.block.named_children():
+            submod.compile(backend="aot_eager", fullgraph=True)
+
+        with torch._dynamo.config.patch(recompile_limit=2):
+            x_test = x_ref.detach().clone().requires_grad_(True)
+            result = wrapped(x_test)
+            result.sum().backward()
+
+        self.assertEqual(ref, result)
+        self.assertEqual(x_ref.grad, x_test.grad)
+
 
 devices = ["cuda", "hpu"]
 instantiate_device_type_tests(

--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -1069,6 +1069,10 @@ class _StopRecomputationError(Exception):
 
 class _recomputation_hook(torch.autograd.graph.saved_tensors_hooks):
     def __init__(self, target_frame_ref: ReferenceType, gid: GraphExecGroup | int) -> None:
+        # Dynamo guards on WeakKeyDictionary internals are unstable here
+        # (dict length/keys change every call), causing recompilation storms.
+        # with `.compile()` so we disable
+        @torch._dynamo.disable
         def pack_hook(x):
             x = x.detach() if x.requires_grad else x
             target_frame = target_frame_ref()


### PR DESCRIPTION
## Summary

### **Root Cause**

The pack_hook mutates a WeakKeyDictionary (target_frame.recomputed[gid]) whose internal state changes on every tensor save. Dynamo placed guards on dict length and key identity, which are inherently unstable and caused recompilation until the cache limit was hit, raising FailOnRecompileLimitHit with fullgraph=True

### **Fix**
We fix by making this particular function opaque to dynamo with `@torch._dynamo.disable` - further, the hook is called by the C++ autograd engine (via saved_tensors_hooks), so disabling dynamo for this frame doesn't affect the compiled submodule's graph


### Additional Context

We discovered this when migrating torchtitan to use `module.compile` as opposed to `torch.compile` for fixed FQN and behavior on rl experiment 

See https://github.com/pytorch/torchtitan/pull/2688 for more details


### Test

```bash
python -m pytest test/dynamo/test_activation_checkpointing.py -x -v
  -k "test_attr_compile_submodules_in_checkpoint_wrapper"
```


Authored with Claude 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo