### PR TITLE
Fix arange half-precision scalar/vectorized inconsistency

### DIFF
--- a/aten/src/ATen/native/cpu/RangeFactoriesKernel.cpp
+++ b/aten/src/ATen/native/cpu/RangeFactoriesKernel.cpp
@@ -27,17 +27,25 @@ void arange_kernel(TensorIterator& iter, const Scalar& scalar_start, const Scala
     at::parallel_for(0, steps, internal::GRAIN_SIZE, [&](int64_t p_begin, int64_t p_end) {
       int64_t idx(p_begin);
       TensorIterator it(iter);
-      cpu_serial_kernel_vec(
-          it,
-          [start, step, &idx]() -> scalar_t {
-            return start + step * (idx++);
-          },
-          [start, step, &idx]() -> Vectorized<scalar_t> {
-            Vectorized<scalar_t> res;
-            res = Vectorized<scalar_t>::arange(start + step * idx, step);
-            idx += Vectorized<scalar_t>::size();
-            return res;
-          }, {p_begin, p_end});
+      if constexpr (std::is_same_v<scalar_t, at::Half> || std::is_same_v<scalar_t, at::BFloat16>) {
+        cpu_serial_kernel(
+            it,
+            [start, step, &idx]() -> scalar_t {
+              return start + step * (idx++);
+            }, {p_begin, p_end});
+      } else {
+        cpu_serial_kernel_vec(
+            it,
+            [start, step, &idx]() -> scalar_t {
+              return start + step * (idx++);
+            },
+            [start, step, &idx]() -> Vectorized<scalar_t> {
+              Vectorized<scalar_t> res;
+              res = Vectorized<scalar_t>::arange(start + step * idx, step);
+              idx += Vectorized<scalar_t>::size();
+              return res;
+            }, {p_begin, p_end});
+      }
     });
   });
 }

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -3013,6 +3013,24 @@ class TestTensorCreation(TestCase):
         f16_tensor = torch.arange(0, 6, step=2, dtype=dtype, device=device)
         self.assertEqual(ref_tensor, f16_tensor)
 
+    @dtypes(torch.bfloat16, torch.float16)
+    @onlyCPU
+    def test_arange_lowp_precision(self, device, dtype):
+        start = -912.2
+        step = 4.64
+        n = 50
+        end = start + step * n
+
+        result = torch.arange(start, end, step, dtype=dtype, device=device)
+
+        expected = torch.tensor(
+            [start + step * i for i in range(len(result))],
+            dtype=torch.float32,
+            device=device,
+        ).to(dtype)
+
+        self.assertEqual(result, expected, atol=0, rtol=0)
+
     @dtypes(*all_types_and_complex_and(torch.bfloat16))
     @dtypesIfCUDA(*all_types_and_complex_and(torch.bfloat16))
     def test_linspace(self, device, dtype):


### PR DESCRIPTION
Fixes #177599 

**Problem:**

The CPU ```arange``` kernel uses two code paths; a scalar lambda and a vectorized lambda. For ```Half``` and ```BFloat16``` types, the vectorized path passes a float32 base value into ```Vectorized<T>::arange(T base, ...)```, which implicitly truncates it to fp16/bf16 before per-element arithmetic. This causes ~30% of elements to produce different values compared to the scalar path, depending on tensor size and chunk alignment


**Solution:** 

Remove the vectorized path for ```Half``` and ```BFloat16``` using ```if constexpr```, keeping it for other types where ```accscalar_t == scalar_t``` and no truncation occurs. This is similar to the approach in ```linspace_kernel``` in the same file, and benchmarks show it also improves fp16/bf16 performance since the vectorized path was slower due to conversion overhead. Added ```test_arange_lowp_precision``` regression test with exact equality checks.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01