### PR TITLE
Fix unbounded DTensor sharding propagation cache growth

### DIFF
--- a/test/distributed/tensor/test_optimizers.py
+++ b/test/distributed/tensor/test_optimizers.py
@@ -717,6 +717,56 @@ class TestDTensorOptimizer(DTensorTestBase):
             inp = torch.ones(8, 10, device=self.device_type)
             self._assert_optimizer(None, mod, opt, mod_copy, dist_opt, inp)
 
+    @with_comms
+    def test_adamw_sharding_cache_no_leak(self):
+        """Foreach optimizer ops with step-varying ScalarList args (like
+        AdamW's bias corrections) must not cause unbounded growth of the
+        DTensor sharding propagation cache."""
+        mesh = init_device_mesh(self.device_type, (self.world_size,))
+        model = MLPModule(self.device_type)
+        for name, param in model.named_parameters():
+            dist_param = nn.Parameter(distribute_tensor(param, mesh, [Shard(0)]))
+            dist_param.register_hook(
+                lambda grad: grad.redistribute(placements=[Shard(0)])
+            )
+            # set the parameter on the parent module
+            parts = name.split(".")
+            mod = model
+            for part in parts[:-1]:
+                mod = getattr(mod, part)
+            mod.register_parameter(parts[-1], dist_param)
+
+        optimizer = torch.optim.AdamW(model.parameters(), lr=1e-4)
+
+        def run_step():
+            inp = distribute_tensor(
+                torch.randn(8, 10, device=self.device_type), mesh, [Shard(0)]
+            )
+            out = model(inp)
+            out.sum().backward()
+            optimizer.step()
+            optimizer.zero_grad()
+
+        # Warmup to populate caches
+        for _ in range(3):
+            run_step()
+
+        _, misses_after_warmup = torch._C._get_DTensor_sharding_propagator_cache_stats()
+
+        for _ in range(10):
+            run_step()
+
+        # After warmup, the cache should be fully populated: no new
+        # misses across subsequent training steps.
+        _, misses_after_steps = torch._C._get_DTensor_sharding_propagator_cache_stats()
+        self.assertEqual(
+            misses_after_warmup,
+            misses_after_steps,
+            f"Cache misses increased from {misses_after_warmup} to "
+            f"{misses_after_steps} over 10 steps (expected 0 new misses "
+            "after warmup)",
+        )
+
 
 TestDTensorOptimizerWithLocalTensor = create_local_tensor_test_class(
     TestDTensorOptimizer,

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -2420,7 +2420,13 @@ create_native_op_schema(
                 item_flavor == TensorFlavor::NON_DTENSOR_TENSOR_SUBCLASS) {
               handle_exactly_tensor(item_py_tensor);
             } else { // non-tensor
-              handle_non_tensor_or_undefined(item);
+              // Use handle_non_dtensor_arg to respect static_argnum.
+              // Non-tensor items in lists (e.g., ScalarList args to
+              // foreach ops) should only be included in the cache key
+              // if the list's argument index is >= static_argnum.
+              // Otherwise, step-varying scalars (like AdamW bias
+              // corrections) cause unbounded cache growth.
+              handle_non_dtensor_arg(idx, item);
             }
           }
         } else {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #178335

The C++ DTensor dispatch fast path (NativeShardingPropagatorCache)
hashes non-tensor items inside list arguments unconditionally into the
cache key. For foreach optimizer ops like `_foreach_div_.ScalarList` and
`_foreach_addcdiv_.ScalarList`, the ScalarList contains step-varying
values (AdamW bias corrections change every training step). This causes
a new cache entry on every step, leaking OpStrategy, OpSpec, and
OutputSharding objects indefinitely.

The fix: apply the same `static_argnum` filtering to non-tensor items
inside lists as is already applied to top-level non-tensor arguments.
Since foreach ops register with `static_argnum=100` (default), their
scalar list values are excluded from the cache key, and the cache
stabilizes after warmup.

Authored with Claude.