### PR TITLE
[inductor] add option to autotune at fusion time for mm

### DIFF
--- a/test/inductor/test_benchmark_fusion.py
+++ b/test/inductor/test_benchmark_fusion.py
@@ -346,7 +346,7 @@ if HAS_GPU_AND_TRITON:
             torch._dynamo.reset()
 
         @fresh_cache()
-        @config.patch(autotune_gemm_at_fusion_time=True)
+        @config.patch(autotune_at_fusion_time=True)
         def test_autotune_fused_epilogue(self):
             from unittest.mock import patch as mock_patch
 

--- a/test/inductor/test_benchmark_fusion.py
+++ b/test/inductor/test_benchmark_fusion.py
@@ -345,6 +345,32 @@ if HAS_GPU_AND_TRITON:
 
             torch._dynamo.reset()
 
+        @fresh_cache()
+        @config.patch(autotune_gemm_at_fusion_time=True)
+        def test_autotune_fused_epilogue(self):
+            from unittest.mock import patch as mock_patch
+
+            def foo(m, inp):
+                return torch.nn.functional.relu(m(inp))
+
+            m = torch.nn.Linear(256, 256, bias=True).half().to(GPU_TYPE)
+            inp = torch.rand([256, 256]).half().to(GPU_TYPE)
+
+            foo_c = torch.compile(mode="max-autotune-no-cudagraphs")(foo)
+            with (
+                torch.no_grad(),
+                mock_patch.object(
+                    Scheduler,
+                    "_autotune_fused_epilogue",
+                    wraps=Scheduler._autotune_fused_epilogue,
+                ) as mock_autotune,
+            ):
+                expected = foo(m, inp)
+                actual = foo_c(m, inp)
+
+            mock_autotune.assert_called()
+            self.assertEqual(expected, actual, atol=1e-4, rtol=1.1)
+
 
 if HAS_CPU and not torch.backends.mps.is_available():
 

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -513,8 +513,11 @@ max_autotune_pointwise = os.environ.get("TORCHINDUCTOR_MAX_AUTOTUNE_POINTWISE") 
 max_autotune_gemm = os.environ.get("TORCHINDUCTOR_MAX_AUTOTUNE_GEMM") == "1"
 
 # Autotune gemm configs at fusion time, skipping unfused autotuning
-autotune_gemm_at_fusion_time = (
-    os.environ.get("TORCHINDUCTOR_AUTOTUNE_GEMM_AT_FUSION_TIME") == "1"
+autotune_at_fusion_time = os.environ.get("TORCHINDUCTOR_AUTOTUNE_AT_FUSION_TIME") == "1"
+
+# Also benchmark the winning fused config unfused to verify fusion is beneficial
+autotune_at_fusion_time_compare_unfused = (
+    os.environ.get("TORCHINDUCTOR_AUTOTUNE_AT_FUSION_TIME_COMPARE_UNFUSED") == "1"
 )
 
 

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -512,6 +512,12 @@ max_autotune_pointwise = os.environ.get("TORCHINDUCTOR_MAX_AUTOTUNE_POINTWISE") 
 # enable slow autotuning passes to select gemm algorithms
 max_autotune_gemm = os.environ.get("TORCHINDUCTOR_MAX_AUTOTUNE_GEMM") == "1"
 
+# Autotune gemm configs at fusion time, skipping unfused autotuning
+autotune_gemm_at_fusion_time = (
+    os.environ.get("TORCHINDUCTOR_AUTOTUNE_GEMM_AT_FUSION_TIME") == "1"
+)
+
+
 inductor_default_autotune_warmup = int(
     os.getenv("TORCHINDUCTOR_DEFAULT_AUTOTUNE_WARMUP", 25)
 )

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -4265,9 +4265,18 @@ class Scheduler:
                 epilogue_fusion=True,
             )
 
-            log_fusion(min_ms_fused, extern_time, ms2)
+            baseline_time = extern_time
+            if (
+                config.autotune_at_fusion_time_compare_unfused
+                and ms_fused_choice is not None
+            ):
+                assert hasattr(ms_fused_choice, "bmreq")
+                unfused_triton_time = ms_fused_choice.bmreq.benchmark()
+                baseline_time = min(extern_time, unfused_triton_time)
 
-            if min_ms_fused < (extern_time + ms2) and ms_fused_choice is not None:
+            log_fusion(min_ms_fused, baseline_time, ms2)
+
+            if min_ms_fused < (baseline_time + ms2) and ms_fused_choice is not None:
                 # pyrefly: ignore [missing-attribute]
                 multi_node.finalize_as_triton_caller(ms_fused_choice)
                 multi_node._choice_timings[None] = new_timings
@@ -4555,7 +4564,7 @@ class Scheduler:
             if self._has_layout_conflict_for_template(multi_node):
                 return FusionResult.fuse(False)
 
-            if config.autotune_gemm_at_fusion_time and epilogue_fusion:
+            if config.autotune_at_fusion_time and epilogue_fusion:
                 return self._autotune_fused_epilogue(
                     multi_node,
                     node_list_fused,

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -4165,6 +4165,119 @@ class Scheduler:
         with dynamo_timed("benchmark_codegened_module"):
             return backend.benchmark_codegened_module(module)
 
+    def _benchmark_fused_choices(
+        self,
+        multi_node: ir.MultiTemplateBuffer,
+        future_choices: list[tuple[Any, LambdaFuture | None, ModuleType]],
+        device: torch.device,
+        epilogue_fusion: bool,
+    ) -> tuple[float, TritonTemplateCallerBase | None, dict[Any, float]]:
+        """
+        Benchmark compiled fused kernels and return (best_time, best_choice, timings).
+
+        Waits for each compilation future, then benchmarks the fused module
+        with the corresponding Triton caller swapped in.
+        """
+        min_ms_fused = float("inf")
+        ms_fused_choice: TritonTemplateCallerBase | None = None
+        new_timings: dict[Any, float] = {}
+        for choice, future, mod_fused in future_choices:
+            try:
+                if future is not None:
+                    future.result()
+            except Exception as e:
+                if fusion_log.isEnabledFor(logging.DEBUG):
+                    fusion_log.debug(  # noqa: G200
+                        "Exception in compiling %s: %s",
+                        "prologue" if not epilogue_fusion else "epilogue",
+                        str(e),
+                    )
+                continue
+            with multi_node.swap_as_triton_caller(choice):
+                ms_fused, path = self.benchmark_codegened_module(
+                    mod_fused,
+                    # pyrefly: ignore [bad-argument-type]
+                    device,
+                )
+                new_timings[choice] = ms_fused
+                if ms_fused < min_ms_fused:
+                    min_ms_fused = ms_fused
+                    ms_fused_choice = choice
+        return min_ms_fused, ms_fused_choice, new_timings
+
+    def _autotune_fused_epilogue(
+        self,
+        multi_node: ir.MultiTemplateBuffer,
+        node_list_fused: Sequence[BaseSchedulerNode],
+        node_list_2: Sequence[BaseSchedulerNode],
+        device: torch.device,
+        log_fusion: Callable[[float, float, float], None],
+    ) -> FusionResult:
+        """
+        Autotune all Triton configs at fusion time: benchmark each
+        config fused with the epilogue, comparing against extern baseline.
+        """
+        from torch._inductor.codegen.simd import CantSplit
+
+        # Benchmark extern callers (cuBLAS) directly via bmreq,
+        # bypassing the autotuning pipeline.
+        extern_time = float("inf")
+        for choice in multi_node.choices:
+            if not isinstance(choice, TritonTemplateCallerBase):
+                # pyrefly: ignore [missing-attribute]
+                assert choice.bmreq is not None
+                # pyrefly: ignore [missing-attribute]
+                timing = choice.bmreq.benchmark()
+                extern_time = min(extern_time, timing)
+
+        if extern_time == float("inf"):
+            fusion_log.debug("No extern callers found, skipping fusion-time autotuning")
+            return FusionResult.fuse(False)
+
+        ms2, _ = self.benchmark_fused_nodes(node_list_2)
+
+        # Compile all Triton choices with fusion
+        future_choices: list[tuple[Any, LambdaFuture | None, ModuleType]] = []
+        for choice in multi_node.choices:
+            if not isinstance(choice, TritonTemplateCallerBase):
+                continue
+            with multi_node.swap_as_triton_caller(choice):
+                try:
+                    future_choices.append(
+                        (
+                            choice,
+                            *self.compile_kernel(node_list_fused),
+                        )
+                    )
+                except CantSplit:
+                    continue
+
+        if not future_choices:
+            return FusionResult.fuse(False)
+
+        def benchmark_fused_autotune() -> bool:
+            assert isinstance(multi_node, ir.MultiTemplateBuffer)
+            min_ms_fused, ms_fused_choice, new_timings = self._benchmark_fused_choices(
+                multi_node,
+                future_choices,
+                # pyrefly: ignore [bad-argument-type]
+                device,
+                epilogue_fusion=True,
+            )
+
+            log_fusion(min_ms_fused, extern_time, ms2)
+
+            if min_ms_fused < (extern_time + ms2) and ms_fused_choice is not None:
+                # pyrefly: ignore [missing-attribute]
+                multi_node.finalize_as_triton_caller(ms_fused_choice)
+                multi_node._choice_timings[None] = new_timings
+                return True
+            return False
+
+        return FusionResult.from_callable(
+            benchmark_fused_autotune, future_choices[0][1]
+        )
+
     def _has_layout_conflict_for_template(
         self, multi_node: ir.MultiTemplateBuffer
     ) -> bool:
@@ -4442,6 +4555,15 @@ class Scheduler:
             if self._has_layout_conflict_for_template(multi_node):
                 return FusionResult.fuse(False)
 
+            if config.autotune_gemm_at_fusion_time and epilogue_fusion:
+                return self._autotune_fused_epilogue(
+                    multi_node,
+                    node_list_fused,
+                    node_list_2,
+                    device,
+                    log_fusion,
+                )
+
             hint_override_best_fusion_choice: dict[
                 int | None, TritonTemplateCallerBase
             ] = {}
@@ -4463,29 +4585,11 @@ class Scheduler:
                             )
                         )
 
-                min_ms_fused = float("inf")
-                ms_fused_choice: TritonTemplateCallerBase | None = None
-                new_timings = {}
-                for choice, future, mod_fused in future_choices:
-                    try:
-                        if future is not None:
-                            future.result()
-                    except Exception as e:
-                        if fusion_log.isEnabledFor(logging.DEBUG):
-                            fusion_log.debug(
-                                "Exception in compiling %s: %s",
-                                "prologue" if not epilogue_fusion else "epilogue",
-                                e,
-                            )
-                        continue
-                    with multi_node.swap_as_triton_caller(choice):
-                        ms_fused, path = self.benchmark_codegened_module(
-                            mod_fused, device
-                        )
-                        new_timings[choice] = ms_fused
-                        if ms_fused < min_ms_fused:
-                            min_ms_fused = ms_fused
-                            ms_fused_choice = choice
+                min_ms_fused, ms_fused_choice, new_timings = (
+                    self._benchmark_fused_choices(
+                        multi_node, future_choices, device, epilogue_fusion
+                    )
+                )
                 multi_node._choice_timings[hint_override] = new_timings
                 assert isinstance(ms_fused_choice, TritonTemplateCallerBase)
                 hint_override_best_fusion_choice[hint_override] = ms_fused_choice


### PR DESCRIPTION
For epilogue fusion with max-autotuning enabled, we first autotune gemms at lowering time to get an initial selection of configs before benchmarking them with fused epilogue. Because we autotune prior to fusion benchmarking, we potentially miss out on configs that are optimal for fusion. 

In this PR, we add an option to move autotuning from lowering to fusion time.

In this implementation, we skip compilation and benchmarking of unfused triton configs in favor of benchmarking all possible fused triton configs. In case where fused configs are slower than Aten, we all back to benchmarking unfused configs. 

This has an advantage over maxing out max_epilogue_benchmarked_choices since we save on autotuning time in cases where fused configs are faster than Aten.

We ran tests on a simple mat mul + relu script and saw compile time improvements over maxing out max_epilogue_benchmarked_choices

<img width="1031" height="601" alt="image" src="https://github.com/user-attachments/assets/0bb96081-8326-43d4-beb7-a93b5e7f4529" />

We also ran benchmarks on OSS HuggingFace suite and saw speedup for some models vs default max-autotune and vs max-autotune + increasing max_epilogue_benchmarked_choices. In these benchmarks, we saw roughly similar compilation time between our new path and prod path. Results are shown below 

<img width="679" height="1105" alt="image" src="https://github.com/user-attachments/assets/b9b6ed0a-17b4-4947-ae5b-94d99b8d6579" />
<img width="640" height="1056" alt="image" src="https://github.com/user-attachments/assets/f84819ae-2a3e-4a08-91d0-d8eb66f22688" />
<img width="487" height="1036" alt="image" src="https://github.com/user-attachments/assets/54616ea9-f9ca-40b6-b852-532cf5c33dfd" />

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @PaulZhang12 