### PR TITLE
[wip] Add isolated parameter to torch.compile for independent Dynamo caches

### DIFF
--- a/test/dynamo/test_clone_compile.py
+++ b/test/dynamo/test_clone_compile.py
@@ -1,0 +1,54 @@
+# Owner(s): ["module: dynamo"]
+
+import torch
+import torch._dynamo
+import torch._dynamo.testing
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+class TestCloneCompile(TestCase):
+    def test_clone_no_cache_collision(self):
+        """g1 exceeds recompile limit, g2 should not be affected."""
+        recompile_limit = 2
+
+        def fn(x):
+            return x + 1
+
+        cnt1 = torch._dynamo.testing.CompileCounter()
+        cnt2 = torch._dynamo.testing.CompileCounter()
+
+        g1 = torch.compile(
+            fn,
+            backend=cnt1,
+            dynamic=False,
+            isolated=True,
+            recompile_limit=recompile_limit,
+        )
+        g2 = torch.compile(
+            fn,
+            backend=cnt2,
+            dynamic=True,
+            isolated=True,
+            recompile_limit=recompile_limit,
+        )
+
+        # Exhaust g1's recompile limit by passing different shapes.
+        # With dynamic=False, each new shape triggers a recompile until the
+        # limit is hit, after which Dynamo falls back to eager.
+        for i in range(1, recompile_limit + 2):
+            g1(torch.randn(i))
+        self.assertEqual(cnt1.frame_count, recompile_limit)
+
+        # g2 should compile fine — its cache is independent of g1's.
+        # With dynamic=True, it compiles a dynamic kernel that handles
+        # varying shapes without recompilation.
+        g2(torch.randn(10))
+        self.assertEqual(cnt2.frame_count, 1)
+
+        g2(torch.randn(20))
+        g2(torch.randn(30))
+        self.assertEqual(cnt2.frame_count, 1)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -2568,6 +2568,7 @@ def compile(
     mode: str | None = None,
     options: dict[str, str | builtins.int | builtins.bool | _Callable] | None = None,
     disable: builtins.bool = False,
+    isolated: builtins.bool = False,
 ) -> _Callable[_InputT, _RetT]: ...
 
 
@@ -2581,6 +2582,7 @@ def compile(
     mode: str | None = None,
     options: dict[str, str | builtins.int | builtins.bool | _Callable] | None = None,
     disable: builtins.bool = False,
+    isolated: builtins.bool = False,
 ) -> _Callable[[_Callable[_InputT, _RetT]], _Callable[_InputT, _RetT]]: ...
 
 
@@ -2594,6 +2596,7 @@ def compile(
     options: dict[str, str | builtins.int | builtins.bool | _Callable] | None = None,
     disable: builtins.bool = False,
     recompile_limit: builtins.int | None = None,
+    isolated: builtins.bool = False,
 ) -> (
     _Callable[[_Callable[_InputT, _RetT]], _Callable[_InputT, _RetT]]
     | _Callable[_InputT, _RetT]
@@ -2721,6 +2724,7 @@ def compile(
                 mode=mode,
                 options=options,
                 disable=disable,
+                isolated=isolated,
             )
 
         return fn
@@ -2778,6 +2782,7 @@ def compile(
         disable=disable,
         guard_filter_fn=guard_filter_fn,
         recompile_limit=recompile_limit,
+        isolated=isolated,
     )(model)  # type: ignore[return-value]
 
 

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -612,6 +612,31 @@ def always_false() -> bool:
     return False
 
 
+def _clone_function(fn: Any) -> Any:
+    """Clone a function by creating a new code object so it gets its own Dynamo cache.
+
+    Dynamo caches compiled code on fn.__code__ via _PyCode_SetExtra. When
+    multiple torch.compile calls target the same function, they share a cache
+    and can thrash each other. Cloning creates a new code object (via
+    code.replace()) so each compiled version gets an independent cache.
+    """
+    if hasattr(fn, "__code__"):
+        cloned = types.FunctionType(
+            fn.__code__.replace(),
+            fn.__globals__,
+            fn.__name__,
+            fn.__defaults__,
+            fn.__closure__,
+        )
+        cloned.__kwdefaults__ = fn.__kwdefaults__
+        cloned.__dict__.update(fn.__dict__)
+        return cloned
+    if isinstance(fn, torch.nn.Module) and hasattr(fn.forward, "__code__"):
+        fn.forward = _clone_function(fn.forward.__func__).__get__(fn, type(fn))
+        return fn
+    return fn
+
+
 def innermost_fn(fn: Callable[..., Any]) -> Callable[..., Any]:
     """
     In case of nesting of _TorchDynamoContext calls, find the innermost
@@ -745,6 +770,7 @@ class _TorchDynamoContext:
         compiler_config: Any | None = None,
         package: CompilePackage | None = None,
         hooks: Hooks | None = None,
+        isolated: bool = False,
     ) -> None:
         super().__init__()
         assert callable(callback) or callback is False or callback is None
@@ -761,6 +787,7 @@ class _TorchDynamoContext:
         self.enter_exit_hooks = []
         self._package = package
         self._hooks = hooks
+        self._isolated = isolated
         patch_fn()
 
         # Save the backends so that we can reset them during torch._dynamo.reset
@@ -847,6 +874,9 @@ class _TorchDynamoContext:
                         )
 
         fn = innermost_fn(fn)
+
+        if self._isolated:
+            fn = _clone_function(fn)
 
         def aot_compile(example_inputs: tuple[tuple[Any, ...], dict[str, Any]]) -> Any:
             from torch._dynamo.aot_compile import aot_compile_fullgraph
@@ -1144,6 +1174,7 @@ class OptimizeContext(_TorchDynamoContext):
         rebuild_ctx: Callable[[], OptimizeContext | _NullDecorator] | None = None,
         package: CompilePackage | None = None,
         hooks: Hooks | None = None,
+        isolated: bool = False,
     ) -> None:
         def on_enter() -> None:
             install_generation_tagging_init()
@@ -1161,6 +1192,7 @@ class OptimizeContext(_TorchDynamoContext):
             compiler_config=compiler_config,
             package=package,
             hooks=hooks,
+            isolated=isolated,
         )
 
         if config.compiled_autograd:
@@ -1312,6 +1344,7 @@ def _optimize_catch_errors(
     compiler_config: Any | None = None,
     rebuild_ctx: Callable[[], OptimizeContext | _NullDecorator] | None = None,
     package: CompilePackage | None = None,
+    isolated: bool = False,
 ) -> OptimizeContext:
     return OptimizeContext(
         convert_frame.catch_errors_wrapper(compile_fn, hooks),
@@ -1325,6 +1358,7 @@ def _optimize_catch_errors(
         rebuild_ctx=rebuild_ctx,
         package=package,
         hooks=hooks,
+        isolated=isolated,
     )
 
 
@@ -1511,6 +1545,7 @@ def _optimize(
     dynamic: bool | None = None,
     package: CompilePackage | None = None,
     recompile_limit: int | None = None,
+    isolated: bool = False,
 ) -> OptimizeContext | _NullDecorator:
     """
     The main entrypoint of TorchDynamo.  Do graph capture and call
@@ -1570,6 +1605,7 @@ def _optimize(
             rebuild_ctx=rebuild_ctx,
             package=package,
             recompile_limit=recompile_limit,
+            isolated=isolated,
         )
 
     backend = get_compiler_fn(backend)
@@ -1608,6 +1644,7 @@ def _optimize(
         ),
         rebuild_ctx=rebuild_ctx,
         package=package,
+        isolated=isolated,
     )
 
 
@@ -2447,6 +2484,7 @@ def _optimize_assert(
     dynamic: bool | None = None,
     package: CompilePackage | None = None,
     recompile_limit: int | None = None,
+    isolated: bool = False,
 ) -> OptimizeContext:
     """
     Guarantees single-graph capture.
@@ -2486,6 +2524,7 @@ def _optimize_assert(
         dynamic=dynamic,
         rebuild_ctx=rebuild_ctx,
         package=package,
+        isolated=isolated,
     )
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #178347

When multiple torch.compile calls target the same function, they share
a Dynamo cache on `fn.__code__` which can cause cache thrashing and shared
recompile limit exhaustion. The new isolated=True parameter creates a
fresh code object (via code.replace()) for each compiled version, giving
each its own independent ExtraState with separate cache entries,
recompile limits, and frame_state.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo