### PR TITLE
torchcomms: use either import path for _BackendWrapper

### DIFF
--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -143,11 +143,15 @@ _UCC_AVAILABLE = True
 _XCCL_AVAILABLE = True
 
 try:
-    # pyrefly: ignore [missing-import]
-    from torchcomms._backend_wrapper import _BackendWrapper
+    try:
+        # pyrefly: ignore [missing-import]
+        from torchcomms._comms import _BackendWrapper
+    except ImportError:
+        # pyrefly: ignore [missing-import]
+        from torchcomms._backend_wrapper import _BackendWrapper
 
     # pyrefly: ignore [missing-import]
-    from torchcomms._comms import new_comm
+    from torchcomms import new_comm
 
     # pyrefly: ignore [missing-import]
     from torchcomms.hooks import FlightRecorderHook


### PR DESCRIPTION
Supports both options as added in https://github.com/pytorch/pytorch/pull/177157/changes

We reverted the change as PyTorch 2.11 is using the old import path. See https://github.com/meta-pytorch/torchcomms/commit/b2efd638bee818e9b5bc06cc088de7fd19ee7a4e

Test plan:

CI + lint

local build

```
TORCH_DISTRIBUTED_USE_TORCHCOMMS=1 torchrun --no-python -- python -c "import torch.distributed as dist; dist.init_process_group('gloo'); dist.destroy_process_group()"
```