### PR TITLE
Let FlexBackward be standalone invoakable

### DIFF
--- a/test/dynamo/test_higher_order_ops.py
+++ b/test/dynamo/test_higher_order_ops.py
@@ -7289,7 +7289,6 @@ xfail_hops_compile = {
     # inductor
     "while_loop",  # LoweringException: AssertionError
     "flex_attention",  # LoweringException: AssertionError
-    "flex_attention_backward",  # AssertionError: Input shapes should have M >= 16, N >= 16 and K >= 16
 }
 
 

--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -4900,6 +4900,305 @@ class GraphModule(torch.nn.Module):
         )
 
     @supported_platform
+    @skip_on_cpu
+    def test_direct_backward_preserves_explicit_buffers(self, device):
+        mask_buffer = torch.full((), 128, device=device, dtype=torch.int32)
+
+        def score_mod(score, b, h, m, n):
+            return score
+
+        def mask_mod(b, h, m, n):
+            return m + mask_buffer >= n
+
+        block_mask = create_block_mask(
+            mask_mod,
+            B=2,
+            H=2,
+            Q_LEN=128,
+            KV_LEN=128,
+            device=device,
+        )
+        scale = 1.0 / 16**0.5
+
+        dtype = torch.float32
+        q = torch.randn(
+            (2, 2, 128, 16),
+            dtype=dtype,
+            device=device,
+            requires_grad=True,
+        )
+        k = torch.randn(
+            (2, 2, 128, 16),
+            dtype=dtype,
+            device=device,
+            requires_grad=True,
+        )
+        v = torch.randn(
+            (2, 2, 128, 16),
+            dtype=dtype,
+            device=device,
+            requires_grad=True,
+        )
+        q_ref, k_ref, v_ref = query_key_value_clones(q, k, v)
+        q_gold, k_gold, v_gold = query_key_value_clones(q, k, v, torch.float64)
+
+        sdpa_partial = create_attention(score_mod, block_mask)
+        golden_out = sdpa_partial(q_gold, k_gold, v_gold)
+        ref_out = sdpa_partial(q_ref, k_ref, v_ref)
+
+        backward_grad = torch.randn((2, 2, 128, 16), dtype=dtype, device=device)
+        golden_out.backward(backward_grad.to(torch.float64))
+        ref_out.backward(backward_grad)
+
+        out, logsumexp, _ = flex_attention_hop(
+            q,
+            k,
+            v,
+            score_mod,
+            block_mask.as_tuple(),
+            scale,
+            {},
+        )
+
+        @torch.compile(fullgraph=True)
+        def compiled_bw(query, key, value, fwd_out, lse, grad_out):
+            return torch.ops.higher_order.flex_attention_backward(
+                query,
+                key,
+                value,
+                fwd_out,
+                lse,
+                grad_out,
+                None,
+                score_mod,
+                None,
+                block_mask.as_tuple(),
+                scale,
+                {},
+                (),
+                (),
+            )
+
+        with torch.no_grad():
+            dq, dk, dv, _ = compiled_bw(
+                q,
+                k,
+                v,
+                out.detach(),
+                logsumexp.detach(),
+                backward_grad,
+            )
+
+        fudge_factor = 10.0
+        self._check_equal(q_gold.grad, q_ref.grad, dq, fudge_factor, "Grad_Query")
+        self._check_equal(k_gold.grad, k_ref.grad, dk, fudge_factor, "Grad_Key")
+        self._check_equal(v_gold.grad, v_ref.grad, dv, fudge_factor, "Grad_Value")
+
+    @supported_platform
+    @skip_on_cpu
+    def test_direct_backward_supports_symint_score_mod_buffers(self, device):
+        def score_mod(score, b, h, m, n, head_dim):
+            return score
+
+        def mask_mod(b, h, m, n):
+            return m >= n
+
+        block_mask = create_block_mask(
+            mask_mod,
+            B=2,
+            H=2,
+            Q_LEN=128,
+            KV_LEN=128,
+            device=device,
+        )
+        scale = 1.0 / 16**0.5
+        dtype = torch.float32
+        q = torch.randn((2, 2, 128, 16), dtype=dtype, device=device)
+        k = torch.randn((2, 2, 128, 16), dtype=dtype, device=device)
+        v = torch.randn((2, 2, 128, 16), dtype=dtype, device=device)
+        backward_grad = torch.randn((2, 2, 128, 16), dtype=dtype, device=device)
+
+        out, logsumexp, _ = flex_attention_hop(
+            q,
+            k,
+            v,
+            score_mod,
+            block_mask.as_tuple(),
+            scale,
+            {},
+            (q.shape[-1],),
+        )
+        static_head_dim = q.shape[-1]
+
+        @torch.compile(backend="aot_eager", fullgraph=True)
+        def compiled_literal_bw(query, key, value, fwd_out, lse, grad_out):
+            return torch.ops.higher_order.flex_attention_backward(
+                query,
+                key,
+                value,
+                fwd_out,
+                lse,
+                grad_out,
+                None,
+                score_mod,
+                None,
+                block_mask.as_tuple(),
+                scale,
+                {},
+                (static_head_dim,),
+                (),
+            )
+
+        @torch.compile(backend="aot_eager", fullgraph=True, dynamic=True)
+        def compiled_bw(query, key, value, fwd_out, lse, grad_out):
+            return torch.ops.higher_order.flex_attention_backward(
+                query,
+                key,
+                value,
+                fwd_out,
+                lse,
+                grad_out,
+                None,
+                score_mod,
+                None,
+                block_mask.as_tuple(),
+                scale,
+                {},
+                (query.shape[-1],),
+                (),
+            )
+
+        with torch.no_grad():
+            ref_dq, ref_dk, ref_dv, ref_buffer_grads = compiled_literal_bw(
+                q,
+                k,
+                v,
+                out.detach(),
+                logsumexp.detach(),
+                backward_grad,
+            )
+            compiled_dq, compiled_dk, compiled_dv, compiled_buffer_grads = compiled_bw(
+                q,
+                k,
+                v,
+                out.detach(),
+                logsumexp.detach(),
+                backward_grad,
+            )
+
+        torch.testing.assert_close(compiled_dq, ref_dq)
+        torch.testing.assert_close(compiled_dk, ref_dk)
+        torch.testing.assert_close(compiled_dv, ref_dv)
+        self.assertEqual(compiled_buffer_grads, ref_buffer_grads)
+
+    @supported_platform
+    @skip_on_cpu
+    def test_direct_backward_supports_graphmodule_fw_graph(self, device):
+        from torch.fx.experimental.proxy_tensor import make_fx
+
+        def score_mod(score, b, h, m, n):
+            return score
+
+        def mask_mod(b, h, m, n):
+            return m >= n
+
+        block_mask = create_block_mask(
+            mask_mod,
+            B=2,
+            H=2,
+            Q_LEN=128,
+            KV_LEN=128,
+            device=device,
+        )
+        scale = 1.0 / 16**0.5
+        dtype = torch.float32
+        q = torch.randn((2, 2, 128, 16), dtype=dtype, device=device)
+        k = torch.randn((2, 2, 128, 16), dtype=dtype, device=device)
+        v = torch.randn((2, 2, 128, 16), dtype=dtype, device=device)
+        backward_grad = torch.randn((2, 2, 128, 16), dtype=dtype, device=device)
+        index_values = (
+            q.new_zeros((), requires_grad=True),
+            q.new_zeros((), dtype=torch.int),
+            q.new_zeros((), dtype=torch.int),
+            q.new_zeros((), dtype=torch.int),
+            q.new_zeros((), dtype=torch.int),
+        )
+        fw_graph = make_fx(score_mod)(*index_values)
+
+        out, logsumexp, _ = flex_attention_hop(
+            q,
+            k,
+            v,
+            score_mod,
+            block_mask.as_tuple(),
+            scale,
+            {},
+        )
+
+        @torch.compile(fullgraph=True)
+        def compiled_callable_bw(query, key, value, fwd_out, lse, grad_out):
+            return torch.ops.higher_order.flex_attention_backward(
+                query,
+                key,
+                value,
+                fwd_out,
+                lse,
+                grad_out,
+                None,
+                score_mod,
+                None,
+                block_mask.as_tuple(),
+                scale,
+                {},
+                (),
+                (),
+            )
+
+        @torch.compile(fullgraph=True)
+        def compiled_graph_bw(query, key, value, fwd_out, lse, grad_out):
+            return torch.ops.higher_order.flex_attention_backward(
+                query,
+                key,
+                value,
+                fwd_out,
+                lse,
+                grad_out,
+                None,
+                fw_graph,
+                None,
+                block_mask.as_tuple(),
+                scale,
+                {},
+                (),
+                (),
+            )
+
+        with torch.no_grad():
+            ref_dq, ref_dk, ref_dv, ref_buffer_grads = compiled_callable_bw(
+                q,
+                k,
+                v,
+                out.detach(),
+                logsumexp.detach(),
+                backward_grad,
+            )
+            compiled_dq, compiled_dk, compiled_dv, compiled_buffer_grads = (
+                compiled_graph_bw(
+                    q,
+                    k,
+                    v,
+                    out.detach(),
+                    logsumexp.detach(),
+                    backward_grad,
+                )
+            )
+
+        torch.testing.assert_close(compiled_dq, ref_dq)
+        torch.testing.assert_close(compiled_dk, ref_dk)
+        torch.testing.assert_close(compiled_dv, ref_dv)
+        self.assertEqual(compiled_buffer_grads, ref_buffer_grads)
+
+    @supported_platform
     def test_tensor_subclass_dispatch_order(self, device):
         """Test that tensor subclasses get proper dispatch priority over modes.
 

--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -178,6 +178,21 @@ def create_attention(score_mod, block_mask, enable_gqa=False, kernel_options=Non
     )
 
 
+def flex_attention_fwd(q, k, v, score_mod, block_mask, scale):
+    # Uses the HOP directly because flex_attention_backward expects lse in log2
+    # scale, but the public flex_attention API converts lse to natural log.
+    out, lse, _ = flex_attention_hop(
+        q,
+        k,
+        v,
+        score_mod,
+        block_mask.as_tuple(),
+        scale,
+        {},
+    )
+    return out, lse
+
+
 def create_block_mask_test(score_mod, query, key):
     block_mask = create_block_mask(
         score_mod,
@@ -4950,14 +4965,13 @@ class GraphModule(torch.nn.Module):
         golden_out.backward(backward_grad.to(torch.float64))
         ref_out.backward(backward_grad)
 
-        out, logsumexp, _ = flex_attention_hop(
+        out, logsumexp = flex_attention_fwd(
             q,
             k,
             v,
             score_mod,
-            block_mask.as_tuple(),
+            block_mask,
             scale,
-            {},
         )
 
         @torch.compile(fullgraph=True)
@@ -5018,15 +5032,13 @@ class GraphModule(torch.nn.Module):
         v = torch.randn((2, 2, 128, 16), dtype=dtype, device=device)
         backward_grad = torch.randn((2, 2, 128, 16), dtype=dtype, device=device)
 
-        out, logsumexp, _ = flex_attention_hop(
+        out, logsumexp = flex_attention_fwd(
             q,
             k,
             v,
-            score_mod,
-            block_mask.as_tuple(),
+            _identity,
+            block_mask,
             scale,
-            {},
-            (q.shape[-1],),
         )
         static_head_dim = q.shape[-1]
 
@@ -5084,113 +5096,6 @@ class GraphModule(torch.nn.Module):
                 out.detach(),
                 logsumexp.detach(),
                 backward_grad,
-            )
-
-        torch.testing.assert_close(compiled_dq, ref_dq)
-        torch.testing.assert_close(compiled_dk, ref_dk)
-        torch.testing.assert_close(compiled_dv, ref_dv)
-        self.assertEqual(compiled_buffer_grads, ref_buffer_grads)
-
-    @supported_platform
-    @skip_on_cpu
-    def test_direct_backward_supports_graphmodule_fw_graph(self, device):
-        from torch.fx.experimental.proxy_tensor import make_fx
-
-        def score_mod(score, b, h, m, n):
-            return score
-
-        def mask_mod(b, h, m, n):
-            return m >= n
-
-        block_mask = create_block_mask(
-            mask_mod,
-            B=2,
-            H=2,
-            Q_LEN=128,
-            KV_LEN=128,
-            device=device,
-        )
-        scale = 1.0 / 16**0.5
-        dtype = torch.float32
-        q = torch.randn((2, 2, 128, 16), dtype=dtype, device=device)
-        k = torch.randn((2, 2, 128, 16), dtype=dtype, device=device)
-        v = torch.randn((2, 2, 128, 16), dtype=dtype, device=device)
-        backward_grad = torch.randn((2, 2, 128, 16), dtype=dtype, device=device)
-        index_values = (
-            q.new_zeros((), requires_grad=True),
-            q.new_zeros((), dtype=torch.int),
-            q.new_zeros((), dtype=torch.int),
-            q.new_zeros((), dtype=torch.int),
-            q.new_zeros((), dtype=torch.int),
-        )
-        fw_graph = make_fx(score_mod)(*index_values)
-
-        out, logsumexp, _ = flex_attention_hop(
-            q,
-            k,
-            v,
-            score_mod,
-            block_mask.as_tuple(),
-            scale,
-            {},
-        )
-
-        @torch.compile(fullgraph=True)
-        def compiled_callable_bw(query, key, value, fwd_out, lse, grad_out):
-            return torch.ops.higher_order.flex_attention_backward(
-                query,
-                key,
-                value,
-                fwd_out,
-                lse,
-                grad_out,
-                None,
-                score_mod,
-                None,
-                block_mask.as_tuple(),
-                scale,
-                {},
-                (),
-                (),
-            )
-
-        @torch.compile(fullgraph=True)
-        def compiled_graph_bw(query, key, value, fwd_out, lse, grad_out):
-            return torch.ops.higher_order.flex_attention_backward(
-                query,
-                key,
-                value,
-                fwd_out,
-                lse,
-                grad_out,
-                None,
-                fw_graph,
-                None,
-                block_mask.as_tuple(),
-                scale,
-                {},
-                (),
-                (),
-            )
-
-        with torch.no_grad():
-            ref_dq, ref_dk, ref_dv, ref_buffer_grads = compiled_callable_bw(
-                q,
-                k,
-                v,
-                out.detach(),
-                logsumexp.detach(),
-                backward_grad,
-            )
-            compiled_dq, compiled_dk, compiled_dv, compiled_buffer_grads = (
-                compiled_graph_bw(
-                    q,
-                    k,
-                    v,
-                    out.detach(),
-                    logsumexp.detach(),
-                    backward_grad,
-                )
             )
 
         torch.testing.assert_close(compiled_dq, ref_dq)

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -4164,20 +4164,6 @@ class FlexAttentionBackwardHighOrderVariable(TorchHigherOrderOperatorVariable):
         set_example_value(p_submod.node, joint_gm)
         return p_submod
 
-    @staticmethod
-    def _is_graphmodule_variable(var: VariableTracker) -> bool:
-        """Distinguish pre-built GraphModules from raw callables.
-
-        Raw callables (UserFunctionVariable etc.) come from direct user calls
-        and need tracing via speculate_subgraph. GraphModules come from either
-        compiled autograd (UnspecializedNNModuleVariable with DictGetItemSource).
-        """
-        from .user_defined import SourcelessGraphModuleVariable
-
-        return isinstance(
-            var, (UnspecializedNNModuleVariable, SourcelessGraphModuleVariable)
-        )
-
     def _call_function(
         self,
         tx: "InstructionTranslator",
@@ -4214,10 +4200,7 @@ class FlexAttentionBackwardHighOrderVariable(TorchHigherOrderOperatorVariable):
         ):
             return self._call_function_fallback(tx, args, kwargs)
 
-        # Compiled autograd: fw_graph arrives as a pre-built GraphModule from
-        # the autograd context, not as a raw callable. Route to the fallback
-        # which installs it via proxy_submod using its DictGetItemSource.
-        if self._is_graphmodule_variable(fw_graph):
+        if torch._dynamo.compiled_autograd.in_compiled_autograd_region:
             return self._call_function_fallback(tx, args, kwargs)
 
         fw_graph_node, fw_graph_lifted_args, fw_graph_gm = self.create_wrapped_node(

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -4200,7 +4200,7 @@ class FlexAttentionBackwardHighOrderVariable(TorchHigherOrderOperatorVariable):
         ):
             return self._call_function_fallback(tx, args, kwargs)
 
-        if torch._dynamo.compiled_autograd.in_compiled_autograd_region:
+        if isinstance(fw_graph, UnspecializedNNModuleVariable):
             return self._call_function_fallback(tx, args, kwargs)
 
         fw_graph_node, fw_graph_lifted_args, fw_graph_gm = self.create_wrapped_node(

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -4127,30 +4127,6 @@ class FlexAttentionBackwardHighOrderVariable(TorchHigherOrderOperatorVariable):
         body_name = tx.output.install_subgraph(fn_name, gm)
         return make_attr(tx, body_name), tuple(body_lifted_freevars), gm
 
-    def install_graph_module(
-        self,
-        tx: "InstructionTranslator",
-        graph_var: VariableTracker,
-        name: str,
-    ) -> Proxy:
-        gm = self._graph_module_value(graph_var)
-
-        submod_name = tx.output.install_subgraph(name, gm)
-        p_submod = make_attr(tx, submod_name)
-        set_example_value(p_submod.node, gm)
-        return p_submod
-
-    @staticmethod
-    def _graph_module_value(graph_var: VariableTracker) -> GraphModule:
-        from .user_defined import SourcelessGraphModuleVariable
-
-        if isinstance(
-            graph_var,
-            (UnspecializedNNModuleVariable, SourcelessGraphModuleVariable),
-        ):
-            return cast(GraphModule, graph_var.value)
-        return cast(GraphModule, graph_var.as_python_constant())
-
     @staticmethod
     def _buffer_example_value(buffer: VariableTracker) -> Any:
         proxy = buffer.as_proxy()
@@ -4190,6 +4166,12 @@ class FlexAttentionBackwardHighOrderVariable(TorchHigherOrderOperatorVariable):
 
     @staticmethod
     def _is_graphmodule_variable(var: VariableTracker) -> bool:
+        """Distinguish pre-built GraphModules from raw callables.
+
+        Raw callables (UserFunctionVariable etc.) come from direct user calls
+        and need tracing via speculate_subgraph. GraphModules come from either
+        compiled autograd (UnspecializedNNModuleVariable with DictGetItemSource).
+        """
         from .user_defined import SourcelessGraphModuleVariable
 
         return isinstance(
@@ -4232,6 +4214,9 @@ class FlexAttentionBackwardHighOrderVariable(TorchHigherOrderOperatorVariable):
         ):
             return self._call_function_fallback(tx, args, kwargs)
 
+        # Compiled autograd: fw_graph arrives as a pre-built GraphModule from
+        # the autograd context, not as a raw callable. Route to the fallback
+        # which installs it via proxy_submod using its DictGetItemSource.
         if self._is_graphmodule_variable(fw_graph):
             return self._call_function_fallback(tx, args, kwargs)
 
@@ -4239,25 +4224,13 @@ class FlexAttentionBackwardHighOrderVariable(TorchHigherOrderOperatorVariable):
             tx, query, fw_graph, "score_mod", score_mod_other_buffers.items
         )
 
-        joint_graph_is_none = (
-            joint_graph.is_python_constant()
-            and joint_graph.as_python_constant() is None
+        joint_graph_node = self._derive_joint_graph(
+            tx,
+            query,
+            fw_graph_gm,
+            score_mod_other_buffers,
+            fw_graph_lifted_args,
         )
-        if joint_graph_is_none:
-            joint_graph_node = self._derive_joint_graph(
-                tx,
-                query,
-                fw_graph_gm,
-                score_mod_other_buffers,
-                fw_graph_lifted_args,
-            )
-        elif self._is_graphmodule_variable(joint_graph):
-            joint_graph_node = self.install_graph_module(tx, joint_graph, "joint_graph")
-        else:
-            raise ValueError(
-                "Passing a pre-traced joint_graph to flex_attention_backward is not supported. "
-                "Pass joint_graph=None to have it derived automatically from fw_graph."
-            )
 
         mask_fn = block_mask.items[-1]
         if mask_fn.is_python_constant() and mask_fn.as_python_constant() is None:

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -4233,13 +4233,11 @@ class FlexAttentionBackwardHighOrderVariable(TorchHigherOrderOperatorVariable):
             return self._call_function_fallback(tx, args, kwargs)
 
         if self._is_graphmodule_variable(fw_graph):
-            fw_graph_node = self.install_graph_module(tx, fw_graph, "fw_graph")
-            fw_graph_lifted_args = ()
-            fw_graph_gm = self._graph_module_value(fw_graph)
-        else:
-            fw_graph_node, fw_graph_lifted_args, fw_graph_gm = self.create_wrapped_node(
-                tx, query, fw_graph, "score_mod", score_mod_other_buffers.items
-            )
+            return self._call_function_fallback(tx, args, kwargs)
+
+        fw_graph_node, fw_graph_lifted_args, fw_graph_gm = self.create_wrapped_node(
+            tx, query, fw_graph, "score_mod", score_mod_other_buffers.items
+        )
 
         joint_graph_is_none = (
             joint_graph.is_python_constant()

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -28,7 +28,7 @@ import types
 import warnings
 from collections.abc import Sequence
 from dataclasses import dataclass, field
-from typing import Any, Literal, Optional, TYPE_CHECKING, Union
+from typing import Any, cast, Literal, Optional, TYPE_CHECKING, Union
 
 import torch._C
 import torch.fx
@@ -4075,7 +4075,266 @@ class FlexAttentionBackwardHighOrderVariable(TorchHigherOrderOperatorVariable):
         else:
             return arg.as_proxy()
 
+    def create_wrapped_node(
+        self,
+        tx: "InstructionTranslator",
+        query: VariableTracker,
+        fn: VariableTracker,
+        fn_name: str,
+        other_buffers: Sequence[VariableTracker],
+    ) -> tuple[Proxy, tuple[Proxy, ...], torch.fx.GraphModule]:
+        from .._trace_wrapped_higher_order_op import TransformGetItemToIndex
+
+        def create_scalar() -> VariableTracker:
+            return query.call_method(
+                tx,
+                "new_empty",
+                [VariableTracker.build(tx, [])],
+                {"dtype": VariableTracker.build(tx, torch.int32)},
+            )
+
+        with discard_graph_changes(tx):
+            bhmn = [create_scalar() for _ in range(4)]
+            if fn_name == "score_mod":
+                scores_require_grad: bool = query.requires_grad  # type: ignore[attr-defined]
+                score = query.call_method(
+                    tx,
+                    "new_empty",
+                    [VariableTracker.build(tx, [])],
+                    {"requires_grad": VariableTracker.build(tx, scores_require_grad)},
+                )
+                new_args = [score, *bhmn, *other_buffers]
+            else:
+                assert fn_name == "mask_fn", "Illegal function name: " + fn_name
+                new_args = [*bhmn, *other_buffers]
+
+        with TransformGetItemToIndex():
+            (
+                (_body_output, _body_spec),
+                body_graph,
+                body_lifted_freevars,
+            ) = speculate_subgraph(
+                tx,
+                fn,
+                new_args,
+                {},
+                description=f"{self._HOP_NAME}: {fn_name}",
+                source_target=self.value,
+                set_subgraph_inputs="flatten_manual",
+            )
+
+        gm = torch.fx.GraphModule(tx.output.nn_modules, body_graph)
+        body_name = tx.output.install_subgraph(fn_name, gm)
+        return make_attr(tx, body_name), tuple(body_lifted_freevars), gm
+
+    def install_graph_module(
+        self,
+        tx: "InstructionTranslator",
+        graph_var: VariableTracker,
+        name: str,
+    ) -> Proxy:
+        gm = self._graph_module_value(graph_var)
+
+        submod_name = tx.output.install_subgraph(name, gm)
+        p_submod = make_attr(tx, submod_name)
+        set_example_value(p_submod.node, gm)
+        return p_submod
+
+    @staticmethod
+    def _graph_module_value(graph_var: VariableTracker) -> GraphModule:
+        from .user_defined import SourcelessGraphModuleVariable
+
+        if isinstance(
+            graph_var,
+            (UnspecializedNNModuleVariable, SourcelessGraphModuleVariable),
+        ):
+            return cast(GraphModule, graph_var.value)
+        return cast(GraphModule, graph_var.as_python_constant())
+
+    @staticmethod
+    def _buffer_example_value(buffer: VariableTracker) -> Any:
+        proxy = buffer.as_proxy()
+        if isinstance(proxy, Proxy):
+            return proxy.node.meta["example_value"]
+        return proxy
+
+    def _derive_joint_graph(
+        self,
+        tx: "InstructionTranslator",
+        query: VariableTracker,
+        fw_graph_gm: torch.fx.GraphModule,
+        score_mod_other_buffers: TupleVariable,
+        fw_graph_lifted_args: tuple[Proxy, ...],
+    ) -> Proxy:
+        from torch._higher_order_ops.flex_attention import create_fw_bw_graph
+
+        query_example = query.as_proxy().node.meta["example_value"]
+        example_vals = (
+            query_example.new_zeros((), requires_grad=True),
+            query_example.new_zeros((), dtype=torch.int),
+            query_example.new_zeros((), dtype=torch.int),
+            query_example.new_zeros((), dtype=torch.int),
+            query_example.new_zeros((), dtype=torch.int),
+        )
+        all_buffer_examples = tuple(
+            self._buffer_example_value(buf) for buf in score_mod_other_buffers.items
+        ) + tuple(buf.node.meta["example_value"] for buf in fw_graph_lifted_args)
+
+        _, joint_gm = create_fw_bw_graph(fw_graph_gm, example_vals, all_buffer_examples)
+        joint_gm = cast(GraphModule, joint_gm)
+
+        submod_name = tx.output.install_subgraph("joint_graph", joint_gm)
+        p_submod = make_attr(tx, submod_name)
+        set_example_value(p_submod.node, joint_gm)
+        return p_submod
+
+    @staticmethod
+    def _is_graphmodule_variable(var: VariableTracker) -> bool:
+        from .user_defined import SourcelessGraphModuleVariable
+
+        return isinstance(
+            var, (UnspecializedNNModuleVariable, SourcelessGraphModuleVariable)
+        )
+
     def _call_function(
+        self,
+        tx: "InstructionTranslator",
+        args: Sequence[VariableTracker],
+        kwargs: dict[str, VariableTracker],
+    ) -> VariableTracker:
+        from .builder import wrap_fx_proxy
+
+        if len(args) != 14:
+            return self._call_function_fallback(tx, args, kwargs)
+
+        (
+            query,
+            key,
+            value,
+            out,
+            logsumexp,
+            grad_out,
+            grad_logsumexp,
+            fw_graph,
+            joint_graph,
+            block_mask,
+            scale,
+            kernel_options,
+            score_mod_other_buffers,
+            mask_mod_other_buffers,
+        ) = args
+
+        if (
+            not isinstance(block_mask, TupleVariable)
+            or not isinstance(score_mod_other_buffers, TupleVariable)
+            or not isinstance(mask_mod_other_buffers, TupleVariable)
+            or len(block_mask.items) < 1
+        ):
+            return self._call_function_fallback(tx, args, kwargs)
+
+        if self._is_graphmodule_variable(fw_graph):
+            fw_graph_node = self.install_graph_module(tx, fw_graph, "fw_graph")
+            fw_graph_lifted_args = ()
+            fw_graph_gm = self._graph_module_value(fw_graph)
+        else:
+            fw_graph_node, fw_graph_lifted_args, fw_graph_gm = self.create_wrapped_node(
+                tx, query, fw_graph, "score_mod", score_mod_other_buffers.items
+            )
+
+        joint_graph_is_none = (
+            joint_graph.is_python_constant()
+            and joint_graph.as_python_constant() is None
+        )
+        if joint_graph_is_none:
+            joint_graph_node = self._derive_joint_graph(
+                tx,
+                query,
+                fw_graph_gm,
+                score_mod_other_buffers,
+                fw_graph_lifted_args,
+            )
+        elif self._is_graphmodule_variable(joint_graph):
+            joint_graph_node = self.install_graph_module(tx, joint_graph, "joint_graph")
+        else:
+            raise ValueError(
+                "Passing a pre-traced joint_graph to flex_attention_backward is not supported. "
+                "Pass joint_graph=None to have it derived automatically from fw_graph."
+            )
+
+        mask_fn = block_mask.items[-1]
+        if mask_fn.is_python_constant() and mask_fn.as_python_constant() is None:
+            mask_fn = VariableTracker.build(
+                tx,
+                torch.nn.attention.flex_attention.noop_mask,
+                source=mask_fn.source,
+            )
+        mask_fn_node, mask_fn_lifted_args, _ = self.create_wrapped_node(
+            tx, query, mask_fn, "mask_fn", mask_mod_other_buffers.items
+        )
+
+        proxied_args = [
+            query,
+            key,
+            value,
+            out,
+            logsumexp,
+            grad_out,
+            grad_logsumexp,
+            TupleVariable(block_mask.items[:-1], source=block_mask.source),
+            scale,
+            kernel_options,
+        ]
+        inp_args, _ = proxy_args_kwargs(proxied_args, {})
+        proxied_score_mod_other_buffers = tuple(
+            self.to_proxy(tx, arg) for arg in score_mod_other_buffers.items
+        )
+        proxied_mask_mod_other_buffers = tuple(
+            self.to_proxy(tx, arg) for arg in mask_mod_other_buffers.items
+        )
+
+        (
+            inp_q,
+            inp_k,
+            inp_v,
+            inp_out,
+            inp_lse,
+            inp_grad_out,
+            inp_grad_lse,
+            inp_block_mask,
+            inp_scale,
+            inp_kernel_options,
+        ) = inp_args
+
+        block_mask_proxy = tuple(inp_block_mask + (mask_fn_node,))
+
+        with torch.fx.experimental.proxy_tensor.set_original_aten_op(self.value):
+            return wrap_fx_proxy(
+                tx=tx,
+                proxy=tx.output.create_proxy(
+                    "call_function",
+                    self.value,
+                    args=(
+                        inp_q,
+                        inp_k,
+                        inp_v,
+                        inp_out,
+                        inp_lse,
+                        inp_grad_out,
+                        inp_grad_lse,
+                        fw_graph_node,
+                        joint_graph_node,
+                        block_mask_proxy,
+                        inp_scale,
+                        inp_kernel_options,
+                        proxied_score_mod_other_buffers + fw_graph_lifted_args,
+                        proxied_mask_mod_other_buffers + mask_fn_lifted_args,
+                    ),
+                    kwargs={},
+                ),
+                example_value=None,
+            )
+
+    def _call_function_fallback(
         self,
         tx: "InstructionTranslator",
         args: Sequence[VariableTracker],

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -4056,6 +4056,14 @@ class AutoFunctionalizeHigherOrderVariable(TorchHigherOrderOperatorVariable):
 class FlexAttentionBackwardHighOrderVariable(TorchHigherOrderOperatorVariable):
     _HOP_NAME = "torch.ops.higher_order.flex_attention_backward"
 
+    @staticmethod
+    def _uses_pretraced_graphs(
+        fw_graph: VariableTracker, joint_graph: VariableTracker
+    ) -> bool:
+        return not joint_graph.is_constant_none() or isinstance(
+            fw_graph, UnspecializedNNModuleVariable
+        )
+
     def proxy_submod(
         self, tx: "InstructionTranslator", arg: UnspecializedNNModuleVariable
     ) -> Proxy:
@@ -4200,7 +4208,7 @@ class FlexAttentionBackwardHighOrderVariable(TorchHigherOrderOperatorVariable):
         ):
             return self._call_function_fallback(tx, args, kwargs)
 
-        if isinstance(fw_graph, UnspecializedNNModuleVariable):
+        if self._uses_pretraced_graphs(fw_graph, joint_graph):
             return self._call_function_fallback(tx, args, kwargs)
 
         fw_graph_node, fw_graph_lifted_args, fw_graph_gm = self.create_wrapped_node(

--- a/torch/_higher_order_ops/flex_attention.py
+++ b/torch/_higher_order_ops/flex_attention.py
@@ -1023,7 +1023,9 @@ def sdpa_dense_backward(
     if grad_logsumexp is None:
         grad_logsumexp = torch.zeros_like(logsumexp)
 
-    # We're undoing the log -> log2 change of base in the forwards
+    # logsumexp is expected in log2 scale (as returned by the forward HOP).
+    # The public flex_attention API converts lse to natural log before returning,
+    # so callers using the public API must not pass that value here directly.
     logsumexp = logsumexp * math.log(2)
     # The backwards formula for the log -> log2 change of base in the forwards
     grad_logsumexp = grad_logsumexp / math.log(2)

--- a/torch/_higher_order_ops/flex_attention.py
+++ b/torch/_higher_order_ops/flex_attention.py
@@ -966,6 +966,17 @@ def sdpa_dense_backward(
             f"got query.dtype={query.dtype}, key.dtype={key.dtype}, "
             f"and value.dtype={value.dtype}"
         )
+    if joint_graph is None:
+        example_vals = (
+            query.new_zeros((), requires_grad=True),
+            query.new_zeros((), dtype=torch.int),
+            query.new_zeros((), dtype=torch.int),
+            query.new_zeros((), dtype=torch.int),
+            query.new_zeros((), dtype=torch.int),
+        )
+        _, joint_graph = create_fw_bw_graph(
+            fw_graph, example_vals, score_mod_other_buffers
+        )
     from torch._dynamo._trace_wrapped_higher_order_op import TransformGetItemToIndex
 
     Bq, Hq, seq_len_q, qk_head_dim = query.shape

--- a/torch/_inductor/kernel/flex/flex_attention.py
+++ b/torch/_inductor/kernel/flex/flex_attention.py
@@ -711,6 +711,10 @@ def flex_attention_backward(*args, **kwargs):
         for k, v in kernel_options.items()
     }
     kernel_options.setdefault("FLOAT32_PRECISION", get_float32_precision())
+    kernel_options.setdefault("PRESCALE_QK", False)
+    kernel_options.setdefault("ROWS_GUARANTEED_SAFE", False)
+    kernel_options.setdefault("BLOCKS_ARE_CONTIGUOUS", False)
+    kernel_options.setdefault("WRITE_DQ", True)
     seq_q_divisible = V.graph.sizevars.statically_known_true(
         sympy.Eq(Mod(seq_len_q, 128), 0)
     )

--- a/torch/testing/_internal/hop_db.py
+++ b/torch/testing/_internal/hop_db.py
@@ -5,7 +5,14 @@ import unittest
 
 import torch
 from functorch.experimental.control_flow import map
-from torch.nn.attention.flex_attention import _create_empty_block_mask, flex_attention
+from torch._higher_order_ops.flex_attention import (
+    flex_attention as flex_attention_hop,
+)
+from torch.nn.attention.flex_attention import (
+    _create_empty_block_mask,
+    create_block_mask,
+    flex_attention,
+)
 from torch.testing import make_tensor
 from torch._higher_order_ops.inline_asm_elementwise import inline_asm_elementwise
 from torch.testing._internal.common_device_type import onlyCUDA
@@ -194,6 +201,99 @@ def sample_inputs_flex_attention(opinfo, device, dtype, requires_grad, **kwargs)
     q, k, v = (make_arg(2, 2, 128, 8, low=0.1, high=2) for _ in range(3))
     block_mask = _create_empty_block_mask(q, k)
     yield SampleInput(q, k, v, score_mod, block_mask)
+
+
+def sample_inputs_flex_attention_backward(
+    opinfo, device, dtype, requires_grad, **kwargs
+):
+    make_arg = functools.partial(
+        make_tensor, device=device, dtype=dtype, requires_grad=False
+    )
+
+    def score_mod(score, b, h, m, n):
+        return score
+
+    def mask_mod(b, h, m, n):
+        return m >= n
+
+    q, k, v = (make_arg(2, 2, 128, 16, low=0.1, high=2) for _ in range(3))
+    block_mask = create_block_mask(mask_mod, B=2, H=2, Q_LEN=128, KV_LEN=128, device=device)
+    scale = 1.0 / q.size(-1) ** 0.5
+    out, logsumexp, _ = flex_attention_hop(
+        q, k, v, score_mod, block_mask.as_tuple(), scale, {},
+    )
+    yield SampleInput(
+        q,
+        args=(
+            k, v, out.detach(), logsumexp.detach(), torch.rand_like(out), None,
+            score_mod, None, block_mask.as_tuple(),
+            scale, {}, (), (),
+        ),
+    )
+
+
+def sample_inputs_flex_attention_backward_explicit_buffers(
+    opinfo, device, dtype, requires_grad, **kwargs
+):
+    make_arg = functools.partial(
+        make_tensor, device=device, dtype=dtype, requires_grad=False
+    )
+    mask_offset = torch.full((), 128, device=device, dtype=torch.int32)
+
+    def score_mod(score, b, h, m, n):
+        return score
+
+    def mask_mod(b, h, m, n):
+        return m + mask_offset >= n
+
+    q, k, v = (make_arg(2, 2, 128, 16, low=0.1, high=2) for _ in range(3))
+    block_mask = create_block_mask(mask_mod, B=2, H=2, Q_LEN=128, KV_LEN=128, device=device)
+    scale = 1.0 / q.size(-1) ** 0.5
+    out, logsumexp, _ = flex_attention_hop(
+        q, k, v, score_mod, block_mask.as_tuple(), scale, {},
+    )
+    yield SampleInput(
+        q,
+        args=(
+            k, v, out.detach(), logsumexp.detach(), torch.rand_like(out), None,
+            score_mod, None, block_mask.as_tuple(),
+            scale, {}, (), (),
+        ),
+    )
+
+
+def simple_flex_attention_backward(
+    query,
+    key,
+    value,
+    out,
+    logsumexp,
+    grad_out,
+    grad_logsumexp,
+    fw_graph,
+    joint_graph,
+    block_mask,
+    scale,
+    kernel_options,
+    score_mod_other_buffers,
+    mask_mod_other_buffers,
+):
+    return torch.ops.higher_order.flex_attention_backward(
+        query,
+        key,
+        value,
+        out,
+        logsumexp,
+        grad_out,
+        grad_logsumexp,
+        fw_graph,
+        joint_graph,
+        block_mask,
+        scale,
+        kernel_options,
+        score_mod_other_buffers,
+        mask_mod_other_buffers,
+    )
 
 
 def sample_inputs_while_loop(opinfo, device, dtype, requires_grad, **kwargs):
@@ -490,14 +590,39 @@ hop_db = [
     OpInfo(
         name="flex_attention_backward",
         variant_test_name="simple",
-        op=flex_attention,
-        sample_inputs_func=sample_inputs_flex_attention,
+        op=simple_flex_attention_backward,
+        sample_inputs_func=sample_inputs_flex_attention_backward,
         dtypes=custom_types(torch.float16, torch.float32),
         supports_out=False,
         check_batched_grad=False,
         check_batched_gradgrad=False,
         check_batched_forward_grad=False,
         check_inplace_batched_forward_grad=False,
+        supports_autograd=False,
+        supports_gradgrad=False,
+        skips=(
+            DecorateInfo(unittest.expectedFailure, "TestHOP", "test_aot_export"),
+            DecorateInfo(
+                unittest.expectedFailure, "TestHOP", "test_pre_dispatch_export"
+            ),
+            DecorateInfo(unittest.expectedFailure, "TestHOP", "test_serialize_export"),
+            DecorateInfo(unittest.expectedFailure, "TestHOP", "test_retrace_export"),
+        ),
+        decorators=[onlyCUDA],
+    ),
+    OpInfo(
+        name="flex_attention_backward",
+        variant_test_name="explicit_buffers",
+        op=simple_flex_attention_backward,
+        sample_inputs_func=sample_inputs_flex_attention_backward_explicit_buffers,
+        dtypes=custom_types(torch.float16, torch.float32),
+        supports_out=False,
+        check_batched_grad=False,
+        check_batched_gradgrad=False,
+        check_batched_forward_grad=False,
+        check_inplace_batched_forward_grad=False,
+        supports_autograd=False,
+        supports_gradgrad=False,
         skips=(
             DecorateInfo(unittest.expectedFailure, "TestHOP", "test_aot_export"),
             DecorateInfo(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #178357

### Sumary
This is a kind of a big PR so hopefully ill make it easier to review

TDLR: This lets users invoke flex-backward individually without needing to go through forward.
Issue: https://github.com/pytorch/pytorch/issues/177869
Usage:


```Py
	
        def score_mod(score, b, h, m, n):
            return score

        def mask_mod(b, h, m, n):
            return m + mask_buffer >= n

        block_mask = create_block_mask(
            mask_mod,
            B=2,
            H=2,
            Q_LEN=128,
            KV_LEN=128,
            device=device,
        )
		 out, logsumexp, _ = flex_attention_hop(
	            q,
	            k,
	            v,
	            score_mod,
	            block_mask.as_tuple(),
	            scale,
	            {},
	        )

        @torch.compile(fullgraph=True)
        def compiled_bw(query, key, value, fwd_out, lse, grad_out):
            return torch.ops.higher_order.flex_attention_backward(
                query,
                key,
                value,
                fwd_out,
                lse,
                grad_out,
                None,
                score_mod,
                None,
                block_mask.as_tuple(),
                scale,
                {},
                (),
                (),
            )

```

### How does it work


### Existing

Unless we are funning compiled backward we never actually hit the VT for the backward impl. What happens is that we speculate the fwd then manually invoke aot autograd machinery to create the joint and setup our autograd not. AotAutograd proper then kicks in and we compile the backward hop avoiding dynamo.

If we are doing compiled backward we do in fact run this VT but its minimal and mostly setup in either fwd hop VT / autograd node.

### New

We now will recreate the joint_graph in the VT for flex-backward, here: https://github.com/pytorch/pytorch/pull/178357/changes#diff-d6c3a57794a9a8a79eacedc57d68ff631fe80776f8701398eb3ef349973b033bR4161 which is basically exact copy of what we do in the hop autograd func. 

Claude decided to add some more error checking and im cool with it. The main new logic is from figuring out which path we are in the, the aotautgrad path or the user direct call path; 

The default path will never see this; 

The default compiled backward  path will use the traced score_mod from dynamo and produce be an fx.GM the new user flow will be a non traced python func.  That is what we use to determine if we should create joint graph / do all the proxing. 


### One big gotcha

This is is fundamentally a very pro user API and im hesitant to make it too nice, since I really want users to know what they're doing. For instance, the output of flex attention (the blessed op) is in regular ln space, but the output from the hop is in log2 space, and the expected lse of flex attention  backward is also in log2 space. 



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Lucaskabela @Chillee @yanboliang @BoyuanFeng @liangel-02 @howardzhang-cv