### PR TITLE
[Easy] Log when expandable segments is enabled in CUDAAllocatorConfig

### DIFF
--- a/c10/cuda/CUDAAllocatorConfig.h
+++ b/c10/cuda/CUDAAllocatorConfig.h
@@ -40,6 +40,9 @@ class C10_CUDA_API CUDAAllocatorConfig {
     }
     return false;
 #else
+    if (enabled) {
+      TORCH_WARN_ONCE("expandable_segments is enabled");
+    }
     return enabled;
 #endif
   }


### PR DESCRIPTION
Summary:
Adds a TORCH_WARN_ONCE log message when expandable_segments() returns true
on supported platforms, making it easier to verify the feature is active.

Differential Revision: D97975647


