### PR TITLE
[MPS] Add `getDeviceCapability` guard

### DIFF
--- a/aten/src/ATen/mps/MPSGuardImpl.h
+++ b/aten/src/ATen/mps/MPSGuardImpl.h
@@ -67,6 +67,22 @@ struct TORCH_API MPSGuardImpl final
     // TODO: Currently setting only device 0
   }
 
+  DeviceCapability getDeviceCapability(Device /*d*/) const override {
+    DeviceCapability cap;
+    cap.capability_data.capability_bits = (1ULL << kIndex_Byte) |
+        (1ULL << kIndex_Char) | (1ULL << kIndex_Short) | (1ULL << kIndex_Int) |
+        (1ULL << kIndex_Long) | (1ULL << kIndex_Float) |
+        (1ULL << kIndex_ComplexFloat) | (1ULL << kIndex_Bool) |
+        (1ULL << kIndex_Half) | (1ULL << kIndex_ComplexHalf) |
+        (1ULL << kIndex_UInt16) | (1ULL << kIndex_UInt32) |
+        (1ULL << kIndex_UInt64);
+    // Apple documents `MPSDataType.bFloat16` as available on macOS 14.0+.
+    if (at::detail::getMPSHooks().isOnMacOSorNewer(14, 0)) {
+      cap.capability_data.capability_bits |= (1ULL << kIndex_BFloat16);
+    }
+    return cap;
+  }
+
   Stream getStream(Device d) const override {
     return Stream(Stream::DEFAULT, Device(c10::DeviceType::MPS, 0));
   }

--- a/aten/src/ATen/mps/MPSGuardImpl.h
+++ b/aten/src/ATen/mps/MPSGuardImpl.h
@@ -69,13 +69,13 @@ struct TORCH_API MPSGuardImpl final
 
   DeviceCapability getDeviceCapability(Device /*d*/) const override {
     DeviceCapability cap;
+    // Currently the supported dtypes are align with all_mps_types()
+    // in torch/testing/_internal/common_dtype.py
+    // TODO: Need to align all_mps_types() and MPS_DTYPES in test_mps.py
     cap.capability_data.capability_bits = (1ULL << kIndex_Byte) |
-        (1ULL << kIndex_Char) | (1ULL << kIndex_Short) | (1ULL << kIndex_Int) |
-        (1ULL << kIndex_Long) | (1ULL << kIndex_Float) |
-        (1ULL << kIndex_ComplexFloat) | (1ULL << kIndex_Bool) |
-        (1ULL << kIndex_Half) | (1ULL << kIndex_ComplexHalf) |
-        (1ULL << kIndex_UInt16) | (1ULL << kIndex_UInt32) |
-        (1ULL << kIndex_UInt64);
+        (1ULL << kIndex_Char) | (1ULL << kIndex_Byte) | (1ULL << kIndex_Short) |
+        (1ULL << kIndex_Int) | (1ULL << kIndex_Long) | (1ULL << kIndex_Float) |
+        (1ULL << kIndex_Half);
     // Apple documents `MPSDataType.bFloat16` as available on macOS 14.0+.
     if (at::detail::getMPSHooks().isOnMacOSorNewer(14, 0)) {
       cap.capability_data.capability_bits |= (1ULL << kIndex_BFloat16);

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -8040,12 +8040,11 @@ class TestMPS(TestCaseMPS):
 
         # Expected dtypes for MPS testing helpers
         expected = set(all_mps_types())
-        self.assertTrue(len(supported) == len(expected))
         # Per Apple docs, bfloat16 support starts on macOS 14.0+
         if not torch.backends.mps.is_macos_or_newer(14, 0):
             expected.discard(torch.bfloat16)
 
-        self.assertTrue(all(dtype in expected for dtype in supported))
+        self.assertTrue(all(dtype in supported for dtype in expected))
 
     def test_jit_save_load(self):
         m = torch.nn.Module()

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -28,7 +28,7 @@ from torch.testing._internal.common_utils import \
      NoTest, skipIfSlowGradcheckEnv, suppress_warnings, serialTest, instantiate_parametrized_tests, xfailIf)
 from torch.testing._internal.common_mps import mps_ops_modifier, mps_ops_grad_modifier, mps_ops_error_inputs_modifier
 from torch.testing import make_tensor
-from torch.testing._internal.common_dtype import get_all_dtypes, integral_types
+from torch.testing._internal.common_dtype import get_all_dtypes, integral_types, all_mps_types
 import torch.backends.mps
 from torch.distributions import Uniform, Exponential
 from torch.utils._python_dispatch import TorchDispatchMode
@@ -8031,6 +8031,21 @@ class TestMPS(TestCaseMPS):
         torch.accelerator.synchronize()
         self.assertTrue(event.query())
         self.assertEqual(c_acc.cpu(), c)
+
+    def test_mps_device_capability(self):
+        # Query device capability via accelerator API
+        cap = torch.accelerator.get_device_capability()
+        # The API returns a dict containing a `supported_dtypes` set
+        supported = set(cap["supported_dtypes"]) if isinstance(cap, dict) else set(cap)
+
+        # Expected dtypes for MPS testing helpers
+        expected = set(all_mps_types())
+        self.assertTrue(len(supported) == len(expected))
+        # Per Apple docs, bfloat16 support starts on macOS 14.0+
+        if not torch.backends.mps.is_macos_or_newer(14, 0):
+            expected.discard(torch.bfloat16)
+
+        self.assertTrue(all(dtype in expected for dtype in supported))
 
     def test_jit_save_load(self):
         m = torch.nn.Module()


### PR DESCRIPTION
This pull request adds support for querying and testing the device capability for MPS (Apple Metal Performance Shaders) devices, focusing on supported data types. The main changes include implementing the `getDeviceCapability` method in the MPS guard, updating test imports, and introducing a new test to validate the reported device capabilities.

**Device capability support:**

* Implemented the `getDeviceCapability` method in `MPSGuardImpl` to report supported data types for MPS devices, including conditional support for `bfloat16` on macOS 14.0 and newer.

**Testing improvements:**

* Added `all_mps_types` to the imports in `test/test_mps.py` to align test expectations with supported MPS dtypes.
* Introduced `test_mps_device_capability`, a new test that verifies the MPS device capability API correctly reports all expected data types, accounting for OS version differences in `bfloat16` support.

cc @fffrog @mikaylagawarecki

Solves https://github.com/pytorch/pytorch/pull/176593#issuecomment-4118004499