### PR TITLE
Make aten::add.Scalar use a structured out path

### DIFF
--- a/aten/src/ATen/native/BinaryOps.cpp
+++ b/aten/src/ATen/native/BinaryOps.cpp
@@ -438,6 +438,13 @@ TORCH_IMPL_FUNC(sub_out) (
   TORCH_INTERNAL_ASSERT(result.scalar_type() == output().dtype());
 }
 
+TORCH_IMPL_FUNC(add_Scalar_out) (
+  const Tensor& self, const Scalar& other, const Scalar& alpha, const Tensor& result
+) {
+  add_stub(device_type(), *this, alpha);
+  TORCH_INTERNAL_ASSERT(result.scalar_type() == output().dtype());
+}
+
 TORCH_IMPL_FUNC(mul_out) (
   const Tensor& self, const Tensor& other, const Tensor& result
 ) {
@@ -1168,17 +1175,6 @@ Tensor& subtract_(Tensor& self, const Scalar& other, const Scalar& alpha) {
 
 Tensor rsub(const Tensor& self, const Tensor& other, const Scalar& alpha) {
   return at::sub(other, self, alpha); // redispatch!
-}
-
-// TODO: Make this structured to undo the perf regression from native:: removal
-// in call here
-
-Tensor add(const Tensor& self, const Scalar& other, const Scalar& alpha) {
-  return at::add(self, wrapped_scalar_tensor(other), alpha);
-}
-
-Tensor& add_(Tensor& self, const Scalar& other, const Scalar& alpha) {
-  return self.add_(wrapped_scalar_tensor(other), alpha);
 }
 
 Tensor remainder(const Tensor& self, const Scalar& other) {

--- a/aten/src/ATen/native/mps/operations/BinaryOps.mm
+++ b/aten/src/ATen/native/mps/operations/BinaryOps.mm
@@ -249,6 +249,10 @@ TORCH_IMPL_FUNC(add_out_mps)(const Tensor& self, const Tensor& other, const Scal
   mps::add_sub_lerp_template(self, other, alpha, output, "add");
 }
 
+TORCH_IMPL_FUNC(add_Scalar_out_mps)(const Tensor& self, const Scalar& other, const Scalar& alpha, const Tensor& output) {
+  mps::add_sub_lerp_template(self, wrapped_scalar_tensor(other), alpha, output, "add");
+}
+
 TORCH_IMPL_FUNC(sub_out_mps)(const Tensor& self, const Tensor& other, const Scalar& alpha, const Tensor& output) {
   mps::add_sub_lerp_template(self, other, alpha, output, "sub");
 }

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -620,19 +620,29 @@
   autogen: _add_relu.Scalar_out
 
 # For C++ only, until we have conversion from C++ numbers to Tensor
+- func: add.Scalar_out(Tensor self, Scalar other, Scalar alpha=1, *, Tensor(a!) out) -> Tensor(a!)
+  device_check: NoCheck   # TensorIterator
+  structured: True
+  structured_inherits: TensorIteratorBase
+  dispatch:
+    CPU, CUDA, MTIA: add_Scalar_out
+    MPS: add_Scalar_out_mps
+  tags: pointwise
+
 - func: add.Scalar(Tensor self, Scalar other, Scalar alpha=1) -> Tensor
   device_check: NoCheck   # TensorIterator
   variants: function, method
+  structured_delegate: add.Scalar_out
   dispatch:
-    CompositeExplicitAutograd: add
+    NestedTensorCPU, NestedTensorHPU, NestedTensorCUDA: NestedTensor_add_Scalar
   tags: [core, pointwise]
 
 - func: add_.Scalar(Tensor(a!) self, Scalar other, Scalar alpha=1) -> Tensor(a!)
   device_check: NoCheck   # TensorIterator
   variants: method
+  structured_delegate: add.Scalar_out
   dispatch:
-    CompositeExplicitAutograd: add_
-  autogen: add.Scalar_out
+    NestedTensorCPU, NestedTensorHPU, NestedTensorCUDA: NestedTensor_add__Scalar
   tags: pointwise
 
 - func: addmv(Tensor self, Tensor mat, Tensor vec, *, Scalar beta=1, Scalar alpha=1) -> Tensor

--- a/aten/src/ATen/native/nested/NestedTensorBinaryOps.cpp
+++ b/aten/src/ATen/native/nested/NestedTensorBinaryOps.cpp
@@ -189,6 +189,14 @@ Tensor NestedTensor_add_Tensor(
       });
 }
 
+// Only usable on the C++ side; scalars are converted to tensors coming from Python.
+Tensor NestedTensor_add_Scalar(
+    const Tensor& self,
+    const Scalar& other,
+    const Scalar& alpha) {
+  return NestedTensor_add_Tensor(self, wrapped_scalar_tensor(other), alpha);
+}
+
 Tensor NestedTensor_sub_Tensor(
     const Tensor& self,
     const Tensor& other,
@@ -269,6 +277,11 @@ Tensor& NestedTensor_add__Tensor(
       self, other, "add_", [alpha](const Tensor& b1, const Tensor& b2) {
         return b1.add_(b2, alpha);
       });
+}
+
+// Only usable on the C++ side; scalars are converted to tensors coming from Python.
+Tensor& NestedTensor_add__Scalar(Tensor& self, const Scalar& other, const Scalar& alpha) {
+  return NestedTensor_add__Tensor(self, wrapped_scalar_tensor(other), alpha);
 }
 
 Tensor& NestedTensor_mul__Tensor(Tensor& self, const Tensor& other) {

--- a/benchmarks/operator_benchmark/pt/add_scalar_test.py
+++ b/benchmarks/operator_benchmark/pt/add_scalar_test.py
@@ -1,0 +1,46 @@
+import operator_benchmark as op_bench
+
+import torch
+
+
+"""Microbenchmarks for torch.add with a scalar rhs."""
+
+
+add_scalar_configs = op_bench.config_list(
+    attr_names=["N", "alpha"],
+    attrs=[
+        [1, 1],
+        [1, 3],
+        [16, 1],
+        [16, 3],
+        [256, 1],
+        [256, 3],
+        [4096, 1],
+        [4096, 3],
+    ],
+    cross_product_configs={
+        "device": ["cpu", "cuda"],
+        "dtype": [torch.float],
+    },
+    tags=["short"],
+)
+
+
+class AddScalarBenchmark(op_bench.TorchBenchmarkBase):
+    def init(self, N, alpha, device, dtype):
+        self.inputs = {
+            "input": torch.rand(N, device=device, dtype=dtype),
+            "other": 1.0,
+            "alpha": alpha,
+        }
+        self.set_module_name("add_scalar")
+
+    def forward(self, input, other, alpha):
+        return torch.add(input, other, alpha=alpha)
+
+
+op_bench.generate_pt_test(add_scalar_configs, AddScalarBenchmark)
+
+
+if __name__ == "__main__":
+    op_bench.benchmark_runner.main()

--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -1792,6 +1792,10 @@ class TestNestedTensorDeviceType(NestedTensorTestCase):
         out = nt1 + nt2
         self.assertEqual(ref, out)
 
+        ref_scalar = torch.nested.nested_tensor([t + 2 for t in nt1.unbind()])
+        out_scalar = torch.ops.aten.add.Scalar(nt1, 2)
+        self.assertEqual(ref_scalar, out_scalar)
+
     @dtypes(torch.float, torch.float16)
     @skipMeta
     @torch.inference_mode()
@@ -1930,6 +1934,11 @@ class TestNestedTensorDeviceType(NestedTensorTestCase):
         )
         nt1 += nt2
         self.assertEqual(ref, nt1)
+
+        ref_scalar = torch.nested.nested_tensor([t + 2 for t in nt1.unbind()])
+        nt1_scalar = nt1.clone()
+        torch.ops.aten.add_.Scalar(nt1_scalar, 2)
+        self.assertEqual(ref_scalar, nt1_scalar)
 
     @dtypes(torch.float, torch.float16)
     @skipMeta

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -9017,6 +9017,15 @@ tensor([[[1.+1.j, 1.+1.j, 1.+1.j,  ..., 1.+1.j, 1.+1.j, 1.+1.j],
         y = x + 2
         self.assertEqual(y.size(), x.size())
 
+        x = torch.empty(4, 3, 8, 8, device='meta', memory_format=torch.channels_last)
+        out = torch.empty(0, device='meta')
+        torch.add(x, 2, out=out)
+        self.assertEqual(out.size(), x.size())
+        self.assertTrue(out.is_contiguous(memory_format=torch.channels_last))
+
+        x.add_(2)
+        self.assertTrue(x.is_contiguous(memory_format=torch.channels_last))
+
     def test_normal_shape(self):
         for device in get_all_device_types():
             tensor1 = torch.rand(1, device=device)


### PR DESCRIPTION
## Summary
- add an explicit structured `add.Scalar_out` so dense scalar add no longer wraps the scalar in a temporary 0-d tensor and redispatches through `add.Tensor`
- route `add.Scalar` and `add_.Scalar` through the new structured out path, while keeping `NestedTensor` scalar add/add_ behavior wired up and adding an MPS scalar-out entry point
- add a focused operator benchmark for scalar rhs `torch.add`, plus targeted meta and nested regression tests

## Testing
- `PYTHONPATH=. python3 -m torchgen.gen --dry-run --mps --mtia`
- `python3 -m py_compile benchmarks/operator_benchmark/pt/add_scalar_test.py test/test_torch.py test/test_nestedtensor.py`
- `git diff --check`

## Notes
- I could not run targeted runtime tests in this checkout because the available Python environment does not have an importable `torch` build.