### PR TITLE
[xpu][fix] Fix test_flash_attention_dynamic on XPU.

### DIFF
--- a/aten/src/ATen/native/transformers/attention.cpp
+++ b/aten/src/ATen/native/transformers/attention.cpp
@@ -492,6 +492,20 @@ int64_t _fused_sdp_choice_meta(
     return choice_int;
   }
 #endif
+  bool has_xpu = query_key_set.has(c10::DispatchKey::XPU);
+  if (has_xpu) {
+    auto choice_int = _fused_sdp_choice_stub(
+        at::kXPU,
+        query_,
+        key,
+        value,
+        attn_mask_,
+        dropout_p,
+        is_causal,
+        scale,
+        enable_gqa);
+    return choice_int;
+  }
   return static_cast<int64_t>(sdp::SDPBackend::math);
 }
 namespace {

--- a/aten/src/ATen/native/transformers/xpu/sdp_utils.cpp
+++ b/aten/src/ATen/native/transformers/xpu/sdp_utils.cpp
@@ -80,9 +80,12 @@ inline bool check_flash_attention_datatype(
 inline bool check_flash_attention_head_dim_size(
     sdp_params const& params,
     bool debug) {
-  const int query_size_last = params.query.size(3);
-  const int key_size_last = params.key.size(3);
-  const int value_size_last = params.value.size(3);
+  // Use sym_size to preserve symbolic shapes during tracing.
+  // Using concrete .size() would materialize symbolic dimensions into static
+  // guards, preventing dynamic shape generalization across recompilations.
+  const auto query_size_last = params.query.sym_size(-1);
+  const auto key_size_last = params.key.sym_size(-1);
+  const auto value_size_last = params.value.sym_size(-1);
 
   const bool head_dims_equal = (query_size_last == key_size_last) &&
       (query_size_last == value_size_last);
@@ -101,7 +104,7 @@ inline bool check_flash_attention_head_dim_size(
     return false;
   }
 
-  constexpr auto max_supported_headdim = 192;
+  const auto max_supported_headdim = c10::SymInt(192);
   if (query_size_last > max_supported_headdim) {
     if (debug) {
       TORCH_WARN(

--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -1455,7 +1455,6 @@ class CudaReproTests(TestCase):
             torch._dynamo.reset()
             gc.collect()
 
-    @skipIfXpu(msg="AssertionError, torch-xpu-ops: #3007")
     @unittest.skipIf(
         not PLATFORM_SUPPORTS_FLASH_ATTENTION, "flash attention not supported"
     )
@@ -1488,12 +1487,7 @@ class CudaReproTests(TestCase):
         model = Model().to(device_type).half()
         model = torch.compile(model, backend=cnts, dynamic=True)
 
-        with torch.backends.cuda.sdp_kernel(
-            enable_flash=True,
-            enable_math=False,
-            enable_mem_efficient=False,
-            enable_cudnn=False,
-        ):
+        with sdpa_kernel(SDPBackend.FLASH_ATTENTION):
             input1 = torch.rand(5, 512, 1024, device=device_type, dtype=torch.float16)
             input2 = torch.rand(5, 513, 1024, device=device_type, dtype=torch.float16)
             input3 = torch.rand(5, 514, 1024, device=device_type, dtype=torch.float16)

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -3026,7 +3026,7 @@ def sdpa_constraint(fx_node, *args, **kwargs):
         return result
 
     def _apply_constraint_inner(idx, arg, meta_val, meta_stride_expr, stride_order):
-        if not meta_val.is_cuda:
+        if not (meta_val.is_cuda or meta_val.is_xpu):
             return ir.ExternKernel.require_stride_order(arg, stride_order)
 
         # This is the minimum alignment required by SDPA kernels for attention_bias.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #178385
* __->__ #178369

## Motivation

test_flash_attention_dynamic was failing on XPU with frame_count=3 (expected 2).
The test verifies that torch.compile with dynamic=True generates a dynamic graph
after the first recompile and reuses it for subsequent inputs with different
sequence lengths.

The root cause has three parts:

1. In `check_flash_attention_head_dim_size` (xpu/sdp_utils.cpp), `.size(3)` was
   used instead of `.sym_size(-1)`. During FakeTensor tracing, `.size()` on a
   symbolic dimension materializes it into a concrete value, adding static Eq
   guards (e.g. `Eq(s0, 512)`) that prevent dynamic shape generalization.
   CUDA already uses `sym_size(-1)` here.

2. `_fused_sdp_choice_meta` (attention.cpp) had no XPU dispatch path. During
   FakeTensor tracing, it fell through to returning SDPBackend::math instead
   of redispatching to `_fused_sdp_choice_xpu`. This meant XPU SDP constraint
   checks were never executed during tracing, unlike CUDA which has an
   explicit redispatch.

3. `sdpa_constraint` in lowering.py checked `meta_val.is_cuda` to decide
   whether to apply SDPA alignment guards. XPU tensors have `is_cuda=False`,
   so they skipped the alignment guard path entirely, resulting in no
   alignment-based recompilation guard.

## Solution

1. Change `check_flash_attention_head_dim_size` to use `sym_size(-1)` and
   `c10::SymInt` for max_supported_headdim, matching CUDA behavior.

2. Add XPU DispatchKey check in `_fused_sdp_choice_meta` to redispatch to
   `_fused_sdp_choice_xpu` via the existing stub mechanism.

3. Extend the `sdpa_constraint` guard condition to `is_cuda or is_xpu`.

4. Remove the @skipIfXpu decorator from test_flash_attention_dynamic and
   modernize the sdpa_kernel context manager usage.

## Test Plan

python test/inductor/test_cuda_repro.py CudaReproTests.test_flash_attention_dynamic

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo