### PR TITLE
[Profiler] Fix profile_memory not working with profile_all_threads

### DIFF
--- a/c10/core/Allocator.cpp
+++ b/c10/core/Allocator.cpp
@@ -57,9 +57,18 @@ at::Allocator* GetAllocator(const at::DeviceType& t) {
   return alloc;
 }
 
-bool memoryProfilingEnabled() {
+static MemoryReportingInfoBase* getMemoryReporter() {
   auto* reporter_ptr = static_cast<MemoryReportingInfoBase*>(
+      GlobalDebugInfo::get(DebugInfoKind::PROFILER_STATE));
+  if (reporter_ptr) {
+    return reporter_ptr;
+  }
+  return static_cast<MemoryReportingInfoBase*>(
       ThreadLocalDebugInfo::get(DebugInfoKind::PROFILER_STATE));
+}
+
+bool memoryProfilingEnabled() {
+  auto* reporter_ptr = getMemoryReporter();
   return reporter_ptr && reporter_ptr->memoryProfilingEnabled();
 }
 
@@ -69,8 +78,7 @@ void reportMemoryUsageToProfiler(
     size_t total_allocated,
     size_t total_reserved,
     Device device) {
-  auto* reporter_ptr = static_cast<MemoryReportingInfoBase*>(
-      ThreadLocalDebugInfo::get(DebugInfoKind::PROFILER_STATE));
+  auto* reporter_ptr = getMemoryReporter();
   if (reporter_ptr) {
     reporter_ptr->reportMemoryUsage(
         ptr, alloc_size, total_allocated, total_reserved, device);
@@ -82,8 +90,7 @@ void reportOutOfMemoryToProfiler(
     size_t total_allocated,
     size_t total_reserved,
     Device device) {
-  auto* reporter_ptr = static_cast<MemoryReportingInfoBase*>(
-      ThreadLocalDebugInfo::get(DebugInfoKind::PROFILER_STATE));
+  auto* reporter_ptr = getMemoryReporter();
   if (reporter_ptr) {
     reporter_ptr->reportOutOfMemory(
         alloc_size, total_allocated, total_reserved, device);

--- a/c10/util/ThreadLocalDebugInfo.cpp
+++ b/c10/util/ThreadLocalDebugInfo.cpp
@@ -2,6 +2,7 @@
 #include <c10/util/ThreadLocal.h>
 #include <c10/util/ThreadLocalDebugInfo.h>
 
+#include <array>
 #include <utility>
 
 namespace c10 {
@@ -90,6 +91,28 @@ DebugInfoGuard::DebugInfoGuard(std::shared_ptr<ThreadLocalDebugInfo> info) {
   prev_info_ = std::move(debug_info);
   debug_info = std::move(info);
   active_ = true;
+}
+
+static std::array<
+    std::shared_ptr<DebugInfoBase>,
+    static_cast<size_t>(DebugInfoKind::NUM_DEBUG_INFO_KINDS)>
+    global_debug_info_;
+
+/* static */
+DebugInfoBase* GlobalDebugInfo::get(DebugInfoKind kind) {
+  return global_debug_info_[static_cast<size_t>(kind)].get();
+}
+
+/* static */
+void GlobalDebugInfo::set(
+    DebugInfoKind kind,
+    std::shared_ptr<DebugInfoBase> info) {
+  global_debug_info_[static_cast<size_t>(kind)] = std::move(info);
+}
+
+/* static */
+std::shared_ptr<DebugInfoBase> GlobalDebugInfo::pop(DebugInfoKind kind) {
+  return std::move(global_debug_info_[static_cast<size_t>(kind)]);
 }
 
 } // namespace c10

--- a/c10/util/ThreadLocalDebugInfo.h
+++ b/c10/util/ThreadLocalDebugInfo.h
@@ -16,6 +16,8 @@ enum class C10_API_ENUM DebugInfoKind : uint8_t {
 
   TEST_INFO, // used only in tests
   TEST_INFO_2, // used only in tests
+
+  NUM_DEBUG_INFO_KINDS, // must be last
 };
 
 class C10_API DebugInfoBase {
@@ -80,6 +82,16 @@ class C10_API DebugInfoGuard {
  private:
   bool active_ = false;
   std::shared_ptr<ThreadLocalDebugInfo> prev_info_ = nullptr;
+};
+
+// Global (process-wide) debug information, keyed by DebugInfoKind.
+// Complements ThreadLocalDebugInfo for cases where state needs to be
+// visible across all threads (e.g. profile_all_threads).
+class C10_API GlobalDebugInfo {
+ public:
+  static DebugInfoBase* get(DebugInfoKind kind);
+  static void set(DebugInfoKind kind, std::shared_ptr<DebugInfoBase> info);
+  static std::shared_ptr<DebugInfoBase> pop(DebugInfoKind kind);
 };
 
 } // namespace c10

--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -2661,6 +2661,47 @@ if KinetoStepTracker.current_step() != initial_step + 2 * niters:
 
     @skipIfTorchDynamo("profiler gets ignored if dynamo activated")
     @unittest.skipIf(not kineto_available(), "Kineto is required")
+    def test_profile_memory_with_profile_all_threads(self):
+        def worker_fn():
+            a = torch.randn(1024, 1024)
+            del a
+
+        def run(profile_all_threads):
+            t = threading.Thread(target=worker_fn, args=())
+
+            experimental_config = torch._C._profiler._ExperimentalConfig(
+                profile_all_threads=profile_all_threads
+            )
+            with torch.profiler.profile(
+                profile_memory=True,
+                experimental_config=experimental_config,
+            ) as p:
+                t.start()
+                a = torch.randn(1024, 1024)
+                del a
+                t.join()
+
+            with TemporaryFileName(mode="w+") as fname:
+                p.export_chrome_trace(fname)
+                with open(fname) as f:
+                    trace = json.load(f)
+
+            events = trace["traceEvents"]
+            mem_events = [e for e in events if e.get("name") == "[memory]"]
+            tids = {e["tid"] for e in mem_events}
+            return mem_events, tids
+
+        mem_all, tids_all = run(profile_all_threads=True)
+        mem_local, tids_local = run(profile_all_threads=False)
+
+        self.assertEqual(len(mem_all), 4)
+        self.assertEqual(len(tids_all), 2)
+
+        self.assertEqual(len(mem_local), 2)
+        self.assertEqual(len(tids_local), 1)
+
+    @skipIfTorchDynamo("profiler gets ignored if dynamo activated")
+    @unittest.skipIf(not kineto_available(), "Kineto is required")
     def test_python_gc_event(self):
         activities = [ProfilerActivity.CPU]
 

--- a/torch/csrc/profiler/orchestration/observer.cpp
+++ b/torch/csrc/profiler/orchestration/observer.cpp
@@ -1,12 +1,11 @@
 #include <torch/csrc/profiler/orchestration/observer.h>
 
+#include <c10/util/ThreadLocalDebugInfo.h>
 #include <torch/csrc/profiler/util.h>
 
 #include <utility>
 
 namespace torch::profiler::impl {
-
-using GlobalManager = GlobalStateManager<ProfilerStateBase>;
 
 // ----------------------------------------------------------------------------
 // -- Profiler Config ---------------------------------------------------------
@@ -125,7 +124,8 @@ ProfilerStateBase::~ProfilerStateBase() {
 
 /*static*/ ProfilerStateBase* ProfilerStateBase::get(bool global) {
   auto* out = global
-      ? GlobalManager::get()
+      ? static_cast<ProfilerStateBase*>(
+            c10::GlobalDebugInfo::get(c10::DebugInfoKind::PROFILER_STATE))
       : static_cast<ProfilerStateBase*>(
             c10::ThreadLocalDebugInfo::get(c10::DebugInfoKind::PROFILER_STATE));
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
@@ -137,7 +137,8 @@ ProfilerStateBase::~ProfilerStateBase() {
     std::shared_ptr<ProfilerStateBase>&& state) {
   TORCH_INTERNAL_ASSERT(state != nullptr);
   if (state->config().pushGlobalCallbacks()) {
-    GlobalManager::push(std::move(state));
+    c10::GlobalDebugInfo::set(
+        c10::DebugInfoKind::PROFILER_STATE, std::move(state));
   } else {
     c10::ThreadLocalDebugInfo::_push(c10::DebugInfoKind::PROFILER_STATE, state);
   }
@@ -158,7 +159,10 @@ std::shared_ptr<ProfilerStateBase> popTLS() {
 
 /*static*/ std::shared_ptr<ProfilerStateBase> ProfilerStateBase::pop(
     bool global) {
-  auto out = global ? GlobalManager::pop() : popTLS();
+  auto out = global
+      ? std::static_pointer_cast<ProfilerStateBase>(
+            c10::GlobalDebugInfo::pop(c10::DebugInfoKind::PROFILER_STATE))
+      : popTLS();
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(!out || out->config().global() == global);
   return out;
 }


### PR DESCRIPTION
Fix #166121 

### Summary

Fix `profile_memory=True` having no effect when
`profile_all_threads=True`. Both features are useful in our use case
and should work together.

### Root cause

`profile_all_threads=True` stores profiler state in a global manager at
the `torch/csrc` layer, but the memory allocator in `c10` only checks
`ThreadLocalDebugInfo`. Since `c10` cannot access `torch/csrc`, memory
events are silently dropped.

### Fix

Add `GlobalDebugInfo` to `c10/util/ThreadLocalDebugInfo` as a
process-wide counterpart to `ThreadLocalDebugInfo`. The allocator now
checks `GlobalDebugInfo` first, then falls back to thread-local state.
`ProfilerStateBase` in `observer.cpp` is updated to use
`GlobalDebugInfo` for global profiler state, making it visible to `c10`.