### PR TITLE
XPU: align _int_mm dtype error messages with CUDA

### DIFF
--- a/aten/src/ATen/native/mkldnn/xpu/Blas.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/Blas.cpp
@@ -513,13 +513,17 @@ Tensor& _int_mm_out_xpu(
       mat2.size(0));
 
   TORCH_CHECK(
-      self.dtype() == at::kChar,
-      "Expected self dtype to be of type int8 but got ",
-      self.dtype());
+      self.scalar_type() == at::kChar,
+      "expected scalar type ",
+      at::kChar,
+      " but found ",
+      self.scalar_type());
   TORCH_CHECK(
-      mat2.dtype() == at::kChar,
-      "Expected mat2 dtype to be of type int8 but got ",
-      mat2.dtype());
+      mat2.scalar_type() == at::kChar,
+      "expected scalar type ",
+      at::kChar,
+      " but found ",
+      mat2.scalar_type());
   TORCH_CHECK(
       result.dtype() == at::kInt,
       "Expected result dtype to be of type kInt but got ",


### PR DESCRIPTION
Change the error messages for self/mat2 dtype checks in _int_mm_out_xpu to match CUDA's format. CUDA raises 'expected scalar type Char but found Float' while XPU was raising 'Expected self/mat2 dtype to be of type int8 but got ...'. This aligns the XPU error messages with CUDA for consistency.

Fixes: https://github.com/intel/torch-xpu-ops/issues/2530

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01