### PR TITLE
docs(nn): clarify return type for MaxPool1d/2d/3d when return_indices=True

### DIFF
--- a/torch/nn/modules/pooling.py
+++ b/torch/nn/modules/pooling.py
@@ -123,6 +123,12 @@ class MaxPool1d(_MaxPoolNd):
         - Ensure that the last pooling starts inside the image, make :math:`L_{out} = L_{out} - 1`
           when :math:`(L_{out} - 1) * \text{stride} >= L_{in} + \text{padding}`.
 
+    .. note::
+        When :attr:`return_indices` is ``True``, the return value is a tuple
+        ``(output, indices)`` where ``indices`` has the same shape as ``output``
+        and contains the index of the maximum value in each pooling window.
+        These indices can be passed to :class:`~torch.nn.MaxUnpool1d`.
+
     Examples::
 
         >>> # pool of size=3, stride=2
@@ -200,6 +206,12 @@ class MaxPool2d(_MaxPoolNd):
           .. math::
               W_{out} = \left\lfloor\frac{W_{in} + 2 * \text{padding[1]} - \text{dilation[1]}
                     \times (\text{kernel\_size[1]} - 1) - 1}{\text{stride[1]}} + 1\right\rfloor
+
+    .. note::
+        When :attr:`return_indices` is ``True``, the return value is a tuple
+        ``(output, indices)`` where ``indices`` has the same shape as ``output``
+        and contains the index of the maximum value in each pooling window.
+        These indices can be passed to :class:`~torch.nn.MaxUnpool2d`.
 
     Examples::
 
@@ -284,6 +296,12 @@ class MaxPool3d(_MaxPoolNd):
           .. math::
               W_{out} = \left\lfloor\frac{W_{in} + 2 \times \text{padding}[2] - \text{dilation}[2] \times
                 (\text{kernel\_size}[2] - 1) - 1}{\text{stride}[2]} + 1\right\rfloor
+
+    .. note::
+        When :attr:`return_indices` is ``True``, the return value is a tuple
+        ``(output, indices)`` where ``indices`` has the same shape as ``output``
+        and contains the index of the maximum value in each pooling window.
+        These indices can be passed to :class:`~torch.nn.MaxUnpool3d`.
 
     Examples::
 


### PR DESCRIPTION
## Summary

`MaxPool1d`, `MaxPool2d`, and `MaxPool3d` all support a `return_indices` parameter, but the documentation only mentions it briefly in the Args section. Users who aren't already familiar with the behavior may not realize:

- The return type changes from a `Tensor` to a **tuple `(output, indices)`**
- `indices` has the **same shape** as `output`
- These indices are designed to be passed to the corresponding `MaxUnpool` module

This PR adds an explicit `.. note::` to each of the three classes making this clear and linking to the relevant `MaxUnpool` class.

## Changes

- `torch/nn/modules/pooling.py`: added `.. note::` blocks to `MaxPool1d`, `MaxPool2d`, and `MaxPool3d` docstrings

## Testing

Documentation-only change, no functional code modified. Verified the documented behavior at runtime:

```python
>>> out = nn.MaxPool2d(2, return_indices=True)(torch.randn(1,1,4,4))
>>> type(out), out[0].shape == out[1].shape
(<class 'tuple'>, True)
```