### PR TITLE
[ONNX] Fix torchvision roi_align export with dynamo

### DIFF
--- a/test/onnx/exporter/test_small_models_e2e.py
+++ b/test/onnx/exporter/test_small_models_e2e.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import importlib
 import logging
 
 import onnx_ir as ir
@@ -967,6 +968,53 @@ class DynamoExporterNewOpsetsTest(common_utils.TestCase, _WithExport):
 
         # Verify the output is correct
         onnx_testing.assert_onnx_program(onnx_program, args=(x, y))
+
+
+@common_utils.instantiate_parametrized_tests
+class TorchVisionExporterTest(common_utils.TestCase, _WithExport):
+    @pytest.mark.skipif(
+        importlib.util.find_spec("torchvision") is None,
+        reason="torchvision is required",
+    )
+    def test_roi_align(self):
+        import torchvision  # noqa: F401
+
+        class RoiAlignModel(torch.nn.Module):
+            def forward(self, input, rois):
+                return torchvision.ops.roi_align(
+                    input, rois, output_size=(7, 7), spatial_scale=1.0
+                )
+
+        input = torch.randn(1, 1, 10, 10)
+        rois = torch.tensor([[0.0, 0.0, 0.0, 9.0, 9.0]])
+
+        onnx_program = self.export(RoiAlignModel(), (input, rois))
+        onnx_testing.assert_onnx_program(onnx_program)
+
+    @pytest.mark.skipif(
+        importlib.util.find_spec("torchvision") is None,
+        reason="torchvision is required",
+    )
+    def test_roi_align_aligned(self):
+        import torchvision  # noqa: F401
+
+        class RoiAlignAlignedModel(torch.nn.Module):
+            def forward(self, input, rois):
+                return torchvision.ops.roi_align(
+                    input,
+                    rois,
+                    output_size=(7, 7),
+                    spatial_scale=0.25,
+                    aligned=True,
+                )
+
+        input = torch.randn(2, 3, 16, 16)
+        rois = torch.tensor(
+            [[0.0, 1.0, 1.0, 5.0, 5.0], [1.0, 2.0, 2.0, 6.0, 6.0]]
+        )
+
+        onnx_program = self.export(RoiAlignAlignedModel(), (input, rois))
+        onnx_testing.assert_onnx_program(onnx_program)
 
 
 if __name__ == "__main__":

--- a/torch/onnx/_internal/exporter/_torchlib/ops/__init__.py
+++ b/torch/onnx/_internal/exporter/_torchlib/ops/__init__.py
@@ -1,6 +1,13 @@
 from __future__ import annotations
 
 
-__all__ = ["core", "hop", "nn", "symbolic", "symops"]
+__all__ = ["core", "hop", "nn", "symbolic", "symops", "vision"]
 
-from torch.onnx._internal.exporter._torchlib.ops import core, hop, nn, symbolic, symops
+from torch.onnx._internal.exporter._torchlib.ops import (
+    core,
+    hop,
+    nn,
+    symbolic,
+    symops,
+    vision,
+)

--- a/torch/onnx/_internal/exporter/_torchlib/ops/vision.py
+++ b/torch/onnx/_internal/exporter/_torchlib/ops/vision.py
@@ -1,0 +1,65 @@
+"""ONNX implementations for torchvision operators."""
+
+# mypy: disable-error-code="misc,arg-type,type-arg,valid-type,assignment,return-value,type-var,operator,no-untyped-def,index"
+# pyrefly: ignore-errors
+# ruff: noqa: TC001,TC002
+
+from __future__ import annotations
+
+import importlib
+
+from onnxscript.onnx_opset import opset18 as op  # type: ignore[attr-defined]
+
+import torch
+from torch.onnx._internal.exporter._torchlib._tensor_typing import TReal
+from torch.onnx._internal.exporter._torchlib._torchlib_registry import onnx_impl
+
+
+# Only register the torchvision op if torchvision is installed, since
+# torch.ops.torchvision is not available otherwise.
+if importlib.util.find_spec("torchvision") is not None:
+    import torchvision  # noqa: F401  # Loads the torchvision custom ops
+
+    @onnx_impl(torch.ops.torchvision.roi_align.default, trace_only=True)
+    def torchvision_roi_align(
+        input: TReal,
+        rois: TReal,
+        spatial_scale: float,
+        output_height: int,
+        output_width: int,
+        sampling_ratio: int,
+        aligned: bool,
+    ) -> TReal:
+        """roi_align(Tensor input, Tensor rois, float spatial_scale, SymInt pooled_height, SymInt pooled_width, int sampling_ratio, bool aligned) -> Tensor
+
+        Torchvision passes rois as [num_rois, 5] where column 0 is the batch
+        index, but ONNX RoiAlign expects rois as [num_rois, 4] with a separate
+        batch_indices tensor.
+        """
+        # Split the 5-column rois tensor into batch_indices (col 0) and
+        # roi coordinates (cols 1-4)
+        batch_indices = op.Cast(
+            op.Squeeze(op.Slice(rois, [0], [1], [1]), axes=[1]),
+            to=7,  # INT64
+        )
+        roi_coords = op.Slice(rois, [1], [5], [1])
+
+        # Negative sampling_ratio in torchvision means adaptive (let the op
+        # decide). ONNX represents this as 0.
+        if sampling_ratio < 0:
+            sampling_ratio = 0
+
+        coordinate_transformation_mode = (
+            "half_pixel" if aligned else "output_half_pixel"
+        )
+
+        return op.RoiAlign(
+            input,
+            roi_coords,
+            batch_indices,
+            coordinate_transformation_mode=coordinate_transformation_mode,
+            output_height=output_height,
+            output_width=output_width,
+            sampling_ratio=sampling_ratio,
+            spatial_scale=spatial_scale,
+        )


### PR DESCRIPTION
## Summary

- Add a `torchlib` implementation for `torchvision::roi_align` that matches the exact C++ op schema (7 positional arguments), fixing the `TypeError` that occurs during dynamo-based ONNX export.
- Correctly split the torchvision 5-column rois format into ONNX's separate `batch_indices` tensor and 4-column roi coordinates.
- Map torchvision's `aligned` flag to the appropriate ONNX `coordinate_transformation_mode` and normalize negative `sampling_ratio` to 0.

## Motivation

Exporting models using `torchvision.ops.roi_align` via `torch.onnx.export(..., dynamo=True)` fails with:

```
TypeError: torchvision_roi_align() takes from 3 to 6 positional arguments but 7 were given
```

The torchvision C++ op dispatches 7 individual positional arguments (`input, rois, spatial_scale, pooled_height, pooled_width, sampling_ratio, aligned`), but the existing onnxscript conversion function expects a bundled `output_size: Sequence[int]` parameter instead of separate height/width values.

Fixes #175732

## Changes

- **`torch/onnx/_internal/exporter/_torchlib/ops/vision.py`** (new): Registers `torchvision_roi_align` via `@onnx_impl` with `trace_only=True`, matching the C++ schema. Handles rois splitting, batch index extraction (cast to INT64), coordinate transformation mode mapping, and sampling ratio normalization. Guarded behind `importlib.util.find_spec("torchvision")` so it's safe when torchvision is absent.
- **`torch/onnx/_internal/exporter/_torchlib/ops/__init__.py`**: Import the new `vision` module so it gets registered at torchlib load time.
- **`test/onnx/exporter/test_small_models_e2e.py`**: Two end-to-end tests (`test_roi_align`, `test_roi_align_aligned`) covering both `aligned=False` and `aligned=True`, with numerical validation via `assert_onnx_program`.

## Test Plan

- [ ] `python -m pytest test/onnx/exporter/test_small_models_e2e.py::TorchVisionExporterTest -v`
- [ ] Verify `test_roi_align` passes (default `aligned=False`, `spatial_scale=1.0`)
- [ ] Verify `test_roi_align_aligned` passes (`aligned=True`, `spatial_scale=0.25`, multi-batch)
- [ ] Existing ONNX exporter tests remain green

cc @justinchuby @titaiwangms