### PR TITLE
test_cutlass_backend: fix fp8 fast-accum handling on sm100+

### DIFF
--- a/test/inductor/test_cutlass_backend.py
+++ b/test/inductor/test_cutlass_backend.py
@@ -46,6 +46,7 @@ from torch.testing._internal.common_cuda import (
     PLATFORM_SUPPORTS_FP8,
     SM80OrLater,
     SM90OrLater,
+    SM100OrLater,
 )
 from torch.testing._internal.common_utils import (
     IN_RE_WORKER,
@@ -1424,7 +1425,12 @@ class TestCutlassBackend(TestCase):
                                         f"Expected op_conf_name to be str, got {type(op_conf_name)}"
                                     )
                                 if use_fast_accum:
-                                    if "fastaccum" not in op_conf_name:
+                                    if SM100OrLater:
+                                        if "fastaccum" in op_conf_name:
+                                            raise AssertionError(
+                                                "Blackwell CUTLASS kernels should not use Hopper-only fastaccum naming"
+                                            )
+                                    elif "fastaccum" not in op_conf_name:
                                         raise AssertionError(
                                             "Only fastaccum Kernels should have been allowed"
                                         )

--- a/test/inductor/test_cutlass_backend.py
+++ b/test/inductor/test_cutlass_backend.py
@@ -44,9 +44,9 @@ from torch.sparse import SparseSemiStructuredTensor, to_sparse_semi_structured
 from torch.testing import FileCheck
 from torch.testing._internal.common_cuda import (
     PLATFORM_SUPPORTS_FP8,
+    SM100OrLater,
     SM80OrLater,
     SM90OrLater,
-    SM100OrLater,
 )
 from torch.testing._internal.common_utils import (
     IN_RE_WORKER,

--- a/torch/_inductor/codegen/cutlass/gemm_template.py
+++ b/torch/_inductor/codegen/cutlass/gemm_template.py
@@ -962,9 +962,14 @@ class CUTLASSGemmTemplate(CUTLASSTemplate, ABC):
         op.element_epilogue = op.accumulator_type()
 
         if self.use_fast_accum is not None:
-            is_op_fast_accum = "fastaccum" in op.configuration_name()
-            if self.use_fast_accum ^ is_op_fast_accum:
-                return None
+            # Hopper encodes FP8 fast-accum support in the CUTLASS op name.
+            # Blackwell kernels do not expose a distinct fast-accum variant, so
+            # treating the flag as a hard name filter would drop every valid op.
+            cuda_arch = cutlass_utils.get_cuda_arch()
+            if cuda_arch is None or int(cuda_arch) < 100:
+                is_op_fast_accum = "fastaccum" in op.configuration_name()
+                if self.use_fast_accum ^ is_op_fast_accum:
+                    return None
 
         # Set bias layout and alignment.
         status = self._set_bias_layout_and_alignment(op)

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -2022,9 +2022,22 @@ def compile_fx_aot(
             "into a pt2, please call `torch._inductor.aoti_compile_and_package`."
         )
     else:
+        with config.patch(config_patches):
+            effective_inductor_config = config.save_config_portable(
+                ignore_private_configs=False
+            )
         config_patches = {
             **config_patches,
-            "aot_inductor.output_path": code_hash(model_.code),
+            "aot_inductor.output_path": code_hash(
+                json.dumps(
+                    {
+                        "model_code": model_.code,
+                        "inductor_config": effective_inductor_config,
+                    },
+                    sort_keys=True,
+                    default=repr,
+                )
+            ),
         }
 
     from .utils import maybe_aoti_standalone_config


### PR DESCRIPTION
Fix two issues exposed by test_cutlass_backend FP8 rowwise scaled_mm coverage on Blackwell-class GPUs.

1. stop treating `use_fast_accum=True` as a hard "fastaccum" configuration-name filter for CUTLASS GEMM choices on SM100+. That naming convention is Hopper-specific, and keeping the name filter on Blackwell incorrectly removes every valid CUTLASS choice for rowwise FP8 scaled_mm.
2. make the default AOTI output path hash depend on the effective portable Inductor config in addition to `model_.code`. Without that, AOTI package generation can reuse a stale artifact built under a different `config.patch(...)` state, which is what caused the remaining `use_aoti=True` multiple-linear failure in test_cutlass_backend.

Plus, update the test_cutlass_backend fast-accum expectation so SM100+ no longer assumes Hopper-style "fastaccum" naming in CUTLASS op configuration names.

This commit was developed with GPT-5.4.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos