### PR TITLE
[EZ] [BE] Match xpu build job name to container it actually uses

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -445,9 +445,9 @@ jobs:
       tests-to-include: ${{ github.event.inputs.tests-to-include || '' }}
     secrets: inherit
 
-  linux-jammy-xpu-n-py3_10-build:
+  linux-noble-xpu-n-py3_10-build:
     if: ${{ needs.job-filter.outputs.jobs == '' || contains(needs.job-filter.outputs.jobs, ' linux-jammy-xpu-n-py3.10 ') }}
-    name: linux-jammy-xpu-n-py3.10
+    name: linux-noble-xpu-n-py3.10
     uses: ./.github/workflows/_linux-build.yml
     needs:
       - get-label-type


### PR DESCRIPTION
https://github.com/pytorch/pytorch/pull/162475 update XPU build jobs base OS to noble, and properly renamed job names, but  https://github.com/pytorch/pytorch/pull/165029 for some reason renamed it back to `jammy`