### PR TITLE
[inductor] fold half addmm+relu into _addmm_activation

### DIFF
--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -1279,6 +1279,34 @@ class TestPatternMatcher(TestCase):
     @inductor_config.patch(
         {
             "fx_graph_remote_cache": False,
+            "keep_addmm_fused_for_half_dtypes": True,
+        }
+    )
+    def test_addmm_relu_half_dtypes_use_addmm_activation(self, dtype):
+        args = [
+            torch.randn(20, device=GPU_TYPE, dtype=dtype),
+            torch.randn(10, 15, device=GPU_TYPE, dtype=dtype),
+            torch.randn(15, 20, device=GPU_TYPE, dtype=dtype),
+        ]
+
+        def eager_fn(inp, a, b):
+            return torch.nn.functional.relu(torch.ops.aten.addmm(inp, a, b))
+
+        @torch.compile()
+        def fn(inp, a, b):
+            return torch.nn.functional.relu(torch.ops.aten.addmm(inp, a, b))
+
+        expected = eager_fn(*args)
+        actual, (code) = run_and_get_code(fn, *args)
+        torch.testing.assert_close(actual, expected)
+        FileCheck().check("torch.ops.aten._addmm_activation.default").check_not(
+            "extern_kernels.addmm("
+        ).run(code[0])
+
+    @parametrize("dtype", [torch.bfloat16, torch.float16])
+    @inductor_config.patch(
+        {
+            "fx_graph_remote_cache": False,
             "keep_addmm_fused_for_half_dtypes": False,
         }
     )
@@ -1295,6 +1323,31 @@ class TestPatternMatcher(TestCase):
 
         _, (code) = run_and_get_code(fn, args[0], args[1], args[2])
         FileCheck().check_not("extern_kernels.addmm(").run(code[0])
+
+    @parametrize("dtype", [torch.bfloat16, torch.float16])
+    @inductor_config.patch(
+        {
+            "fx_graph_remote_cache": False,
+            "keep_addmm_fused_for_half_dtypes": False,
+        }
+    )
+    def test_addmm_relu_half_dtypes_without_keep_fused_does_not_use_addmm_activation(
+        self, dtype
+    ):
+        args = [
+            torch.randn(20, device=GPU_TYPE, dtype=dtype),
+            torch.randn(10, 15, device=GPU_TYPE, dtype=dtype),
+            torch.randn(15, 20, device=GPU_TYPE, dtype=dtype),
+        ]
+
+        @torch.compile()
+        def fn(inp, a, b):
+            return torch.nn.functional.relu(torch.ops.aten.addmm(inp, a, b))
+
+        _, (code) = run_and_get_code(fn, args[0], args[1], args[2])
+        FileCheck().check_not("torch.ops.aten._addmm_activation.default").check_not(
+            "extern_kernels.addmm("
+        ).run(code[0])
 
     def test_addmm_alpha_beta_with_pointwise(self):
         # Test that addmm with alpha/beta != 1 is unfused correctly with pointwise ops

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -1580,6 +1580,48 @@ def view_to_reshape(gm):
     _recursive_view_to_reshape(gm.graph)
 
 
+def should_fold_addmm_relu_to_activation(match):
+    inp = match.kwargs["inp"]
+    if not (
+        config.keep_addmm_fused_for_half_dtypes
+        and isinstance(inp, torch.fx.Node)
+        and isinstance(inp.meta["val"], torch.Tensor)
+    ):
+        return False
+
+    val = inp.meta["val"]
+    return is_gpu(val.device.type) and val.dtype in (torch.bfloat16, torch.float16)
+
+
+@register_graph_pattern(
+    CallFunction(
+        aten.relu.default,
+        CallFunction(
+            aten.addmm,
+            KeywordArg("inp"),
+            Arg(),
+            Arg(),
+            beta=KeywordArg("beta"),
+            alpha=KeywordArg("alpha"),
+            _users=1,
+        ),
+    ),
+    # pyrefly: ignore [bad-argument-type]
+    pass_dict=pass_patterns[2],
+    extra_check=should_fold_addmm_relu_to_activation,
+)
+def fold_addmm_relu(match: Match, mat1, mat2, *, inp, alpha, beta):
+    # We intentionally keep half/bfloat16 addmm fused, so fold a trailing relu
+    # into the native fused op instead of paying for a separate pointwise kernel.
+    def repl(inp, x1, x2, alpha, beta):
+        return aten._addmm_activation.default(
+            inp, x1, x2, beta=beta, alpha=alpha, use_gelu=False
+        )
+
+    # pyrefly: ignore [bad-argument-type]
+    match.replace_by_example(repl, [inp, mat1, mat2, alpha, beta])
+
+
 def should_prefer_unfused_addmm(match):
     inp = match.kwargs["inp"]
     if not is_gpu(inp.meta["val"].device.type):


### PR DESCRIPTION
## Summary
- fold GPU `relu(addmm(...))` on `torch.float16`/`torch.bfloat16` into `aten._addmm_activation` in the post-grad pattern matcher
- keep the change narrowly gated on `keep_addmm_fused_for_half_dtypes`, GPU tensor metadata, and single-use `addmm` outputs
- add pattern-matcher coverage for the enabled and disabled cases

## Validation
- `./.venv/bin/python test/inductor/test_pattern_matcher.py TestPatternMatcher.test_addmm_relu_half_dtypes_use_addmm_activation TestPatternMatcher.test_addmm_relu_half_dtypes_without_keep_fused_does_not_use_addmm_activation`
- source build: `./.venv/bin/python -m pip install -e . -v --no-build-isolation`

## Benchmark
GPU: NVIDIA GeForce RTX 5070, CUDA 13.2, Triton 3.6.0

With `keep_addmm_fused_for_half_dtypes=True`, the parent commit emits `extern_kernels.addmm(` while this branch emits `torch.ops.aten._addmm_activation.default`.

- `float16`, shape `(4096, 4096, 256)`: `0.2391 ms -> 0.2228 ms` (`+6.8%`)
- `float16`, shape `(2048, 4096, 256)`: `0.1256 ms -> 0.1183 ms` (`+5.8%`)
- `bfloat16`, shape `(2048, 4096, 256)`: `0.1229 ms -> 0.1202 ms` (`+2.2%`)
- `bfloat16`, shape `(4096, 4096, 256)`: `0.2254 ms -> 0.2256 ms` (within noise on this machine)


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos