### PR TITLE
[Accelerator] Document `get_device_capability` and clarify what supported dtypes mean

### DIFF
--- a/docs/source/accelerator.md
+++ b/docs/source/accelerator.md
@@ -20,6 +20,7 @@
     set_device_idx
     current_device_index
     current_device_idx
+    get_device_capability
     set_stream
     current_stream
     synchronize

--- a/torch/accelerator/__init__.py
+++ b/torch/accelerator/__init__.py
@@ -169,7 +169,10 @@ def get_device_capability(device: _device_t = None, /) -> dict[str, Any]:
 
     Returns:
         dict[str, Any]: A dictionary containing device capability information. The dictionary includes:
-            - ``supported_dtypes`` (set(torch.dtype)): Set of PyTorch data types supported by the device
+            - ``supported_dtypes`` (set(torch.dtype)): Set of PyTorch data types for which
+              tensors can be allocated on the accelerator and type conversion across
+              supported dtypes are supported. Any operator support outside of that
+              is not guaranteed
 
     Examples:
         >>> # xdoctest: +SKIP("requires cuda")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #178180
* #178423
* __->__ #178397

Add `get_device_capability` to the accelerator.md autosummary listing and clarify the `supported_dtypes` docstring to explain that it covers tensor allocation and type conversion, with no guarantees for other
operators support.

Co-authored-by: Claude <noreply@anthropic.com>