### PR TITLE
Guard on function.__defaults__ in CLOSURE_MATCH

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -1144,6 +1144,26 @@ graph():
 
         self.assertEqual(cnt.frame_count, 2)
 
+    def test_function_defaults_guarded(self):
+        cnt = CompileCounter()
+
+        @torch.compile(backend=cnt)
+        def fn(x, val):
+            return x + val
+
+        x = torch.randn(8)
+        results = []
+        for i in range(3):
+            def inner(y, default_val=i):
+                return y + default_val
+
+            results.append(fn(x, inner))
+
+        for i, r in enumerate(results):
+            self.assertEqual(r, x + i)
+
+        self.assertEqual(cnt.frame_count, 3)
+
     def test_generate_trivial_abstract_impl(self):
         with torch.library._scoped_library("mylib", "FRAGMENT") as lib:
             torch.library.define(

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -2698,7 +2698,7 @@ class GuardBuilder(GuardBuilderBase):
         eval_fn=check_closure,
     )
     def CLOSURE_MATCH(self, guard: Guard) -> None:
-        """matches a closure by __code__ id."""
+        """matches a closure by __code__ id and __defaults__ identity."""
         # don't support this in serialization because it uses unsupported FUNCTION_MATCH
         val = self.get(guard)
         # Strictly only want user-defined functions
@@ -2706,6 +2706,11 @@ class GuardBuilder(GuardBuilderBase):
             # No explicit HASATTR guard needed for __code__ — the getattr
             # accessor installed by CONSTANT_MATCH implicitly guards hasattr.
             self._guard_on_attribute(guard, "__code__", GuardBuilder.CONSTANT_MATCH)  # type: ignore[arg-type]
+            # Guard on __defaults__ identity to ensure recompilation when default
+            # args change (e.g., when a function is defined in a loop with different
+            # default values, each iteration creates a new __defaults__ tuple).
+            if hasattr(val, "__defaults__") and val.__defaults__ is not None:
+                self._guard_on_attribute(guard, "__defaults__", GuardBuilder.ID_MATCH)  # type: ignore[arg-type]
         else:
             self.FUNCTION_MATCH(guard)
 


### PR DESCRIPTION
## Summary

Fixes #178365 - Dynamo does not guard on function.__defaults__, causing silent correctness bugs with flex_attention.

When a function is defined in a loop with different default argument values, each iteration creates a new function with the same __code__ but different __defaults__. Previously, CLOSURE_MATCH only guarded on __code__ identity, so Dynamo would reuse the first cached graph with stale constants from the first call's defaults baked in.

## Fix

Added an ID_MATCH guard on __defaults__ in CLOSURE_MATCH to ensure recompilation when default args change.

## Test

Added test `test_function_defaults_guarded` that verifies recompilation when functions with different defaults are passed.

Authored with Claude

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo