### PR TITLE
Deduplicate and trim pr-review skill

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -5,7 +5,7 @@ description: Review PyTorch pull requests for code quality, test coverage, secur
 
 # PyTorch PR Review Skill
 
-Review PyTorch pull requests focusing on what CI cannot check: code quality, test coverage adequacy, security vulnerabilities, and backward compatibility. Linting, formatting, type checking, and import ordering are handled by CI.
+Review PyTorch pull requests focusing on what CI cannot check: code quality, test coverage adequacy, security vulnerabilities, and backward compatibility.
 
 ## Usage Modes
 
@@ -115,90 +115,40 @@ only the diff and commit log need to be fetched via git.
 
 A single line of code can have deep cross-cutting implications: a missing device guard causes silent data corruption on multi-GPU, a missing `Composite` dispatch key breaks every out-of-tree backend, a manual dtype check instead of `TensorIterator` silently skips type promotion. **Treat every line as potentially load-bearing.**
 
-Do not skim. Do not summarize the diff and move on. Read every changed line and ask: *does this interact with existing PyTorch infrastructure that the author may not know about?* When uncertain, **investigate** — spawn a sub-agent to read the surrounding code, the infrastructure the PR should be using, or the tests that should exist. The cost of a false negative (missing a real issue) is much higher than the cost of investigation.
+1. **Investigate, don't guess** — When uncertain whether a checklist item applies, spawn a sub-agent to read the relevant code. A reviewer who guesses wrong provides negative value.
+2. **Review the design, not just the implementation** — A PR can have perfectly correct implementation of a bad design. Question side-channel communication, on/off private flags, and demand concrete interface documentation for new contracts between components.
+3. **Focus on what CI cannot check** — Don't comment on formatting, linting, type errors, or CI failures. Focus on design quality, interface correctness, thread safety, BC implications, test adequacy, and pattern adherence.
+4. **Everything is a must-fix** — There are no "nits." If it's worth mentioning, it's worth fixing. Every inconsistency degrades the codebase over time.
+5. **Be specific and actionable** — Reference file paths and line numbers. Name the function/class/file the author should use.
+6. **Match the immediate context** — Read how similar features are already implemented in the same file. Pattern mismatches within a file are always wrong.
+7. **Assume competence** — The author knows PyTorch; explain only non-obvious context.
+8. **No repetition** — Each observation appears in exactly one section of the review output.
+
+### Using sub-agents
+
+The review checklist is large. You cannot hold the full context of every infrastructure system in your head. **Spawn sub-agents** to investigate whether checklist items apply: read surrounding code, infrastructure the PR should be using, or tests that should exist. Spawn them in parallel for independent areas. A typical medium PR should spawn 3-8 sub-agents.
 
 ## Review Workflow
 
-### Step 1: Fetch PR Information
-
-**Local CLI mode**: Use `gh` commands to get PR metadata, changed files, full diff,
-existing comments/reviews, and associated issue information.
-
-**Local Branch mode**: Use `git diff` and `git log` against `main` as shown in the
-Local Branch Mode section above.
-
-**GitHub Actions mode**: PR metadata, comments, and reviews are already in the prompt.
-Use `git diff origin/<baseBranch>...HEAD` for the full diff and
-`git log origin/<baseBranch>..HEAD --oneline` for the commit log.
-
-### Step 2: Understand Context
+### Step 1: Understand Context
 
 Before reviewing, build understanding of what the PR touches and why:
 1. Identify the purpose of the change from title/description/issue
 2. Group changes by type (new code, tests, config, docs)
 3. Note the scope of changes (files affected, lines changed)
-4. **Spawn sub-agents to read the unchanged code surrounding each changed file.** The diff alone is not enough — you need to understand the existing patterns, base classes, and infrastructure in the files being modified. For each significantly changed file, a sub-agent should read the full file (or the relevant class/function) and report back: what patterns does this file follow? What infrastructure does it use? What invariants does it maintain?
+4. Spawn sub-agents to read the unchanged code surrounding each significantly changed file to understand existing patterns and infrastructure
 
-### Step 3: Deep Review — Line-by-Line with Investigation
+### Step 2: Deep Review
 
-This is the core of the review. Go through **every changed line** in the diff and evaluate it against the review checklist in [review-checklist.md](review-checklist.md).
+Go through **every changed line** in the diff and evaluate it against the review checklist in [review-checklist.md](review-checklist.md).
 
-**How to use sub-agents during review:**
+### Step 3: Check Backward Compatibility
 
-The checklist is large. You cannot hold the full context of every infrastructure system in your head. Instead, when you encounter a changed line that touches a checklist area, **spawn a sub-agent** to investigate whether the checklist item applies. For example:
+Evaluate BC implications per [bc-guidelines.md](bc-guidelines.md). For non-trivial BC questions, spawn a sub-agent to search for existing callers of the modified API.
 
-- A PR adds a new C++ kernel → spawn a sub-agent to check: Does it use TensorIterator? DispatchStub? Structured kernels? AT_DISPATCH? Does it have a meta implementation? A Composite fallback?
-- A PR adds a new test → spawn a sub-agent to check: Does an OpInfo exist for this op? Is the test device-generic? Does it use make_tensor, @dtypes, TestCase?
-- A PR modifies autograd code → spawn a sub-agent to check: Is derivatives.yaml the right place? Does it use setup_context? Does it have gradcheck tests?
-- A PR adds a new operator → spawn a sub-agent to check: Is it in native_functions.yaml? Does it have proper tags? A Composite dispatch? Meta/fake impls? Schema annotations?
+### Step 4: Formulate Review
 
-**Spawn sub-agents in parallel** for independent investigation areas. A typical review of a medium PR should spawn 3-8 sub-agents. Large PRs touching multiple subsystems may need more.
-
-**Checklist areas** (see [review-checklist.md](review-checklist.md) for full details):
-- Code quality and design
-- PyTorch infrastructure — C++ kernels (TensorIterator, DispatchStub, AT_DISPATCH, device guards), CUDA/device management, operator registration and codegen (native_functions.yaml, Composite dispatch, meta/fake implementations), autograd (derivatives.yaml, autograd.Function, gradcheck), Python utilities (pytree, __torch_function__, logging), nn module patterns, Dynamo/Inductor/compile, FX/export, type promotion, serialization, distributed, tensor subclasses
-- Testing adequacy (OpInfo, ModuleInfo, device-generic tests, @dtypes, @parametrize, make_tensor)
-- Security considerations
-- Thread safety and concurrency (Python, C++, CPython C API, NoGIL)
-- Performance implications
-- Any behavior change not expected by author
-
-### Step 4: Check Backward Compatibility
-
-Evaluate BC implications. See [bc-guidelines.md](bc-guidelines.md) for:
-- What constitutes a BC-breaking change
-- Required deprecation patterns
-- Common BC pitfalls
-
-For non-trivial BC questions (e.g., "does changing this default break downstream users?"), spawn a sub-agent to search for existing callers of the modified API.
-
-### Step 5: Formulate Review
-
-Structure your review with actionable feedback organized by category. Every finding should be traceable to a specific line in the diff and a specific checklist item.
-
-## Review Areas
-
-| Area | Focus | Reference |
-|------|-------|-----------|
-| Code Quality | Abstractions, patterns, complexity | [review-checklist.md](review-checklist.md) |
-| API Design | New patterns, flag-based access, broader implications | [review-checklist.md](review-checklist.md) |
-| C++ Kernels | TensorIterator, DispatchStub, AT_DISPATCH, structured kernels, device guards, memory format | [review-checklist.md](review-checklist.md) |
-| CUDA/Device | C10_CUDA_CHECK, stream/event guards, recordStream, CUDA graphs, AcceleratorHooks | [review-checklist.md](review-checklist.md) |
-| Op Registration | native_functions.yaml, Composite fallback, meta/fake impls, tags, schema annotations | [review-checklist.md](review-checklist.md) |
-| Autograd | derivatives.yaml, autograd.Function patterns, gradcheck, forward-mode AD, vmap | [review-checklist.md](review-checklist.md) |
-| Python Utils | __torch_function__, pytree, logging, deprecation, backends context | [review-checklist.md](review-checklist.md) |
-| nn Modules | ModuleList/Dict, nn.init, parametrize, state_dict versioning, LazyModule | [review-checklist.md](review-checklist.md) |
-| Dynamo/Inductor | @register_lowering, decompositions, CustomGraphPass, config.patch, graph breaks | [review-checklist.md](review-checklist.md) |
-| FX/Export | PassBase, PassManager, Interpreter, subgraph rewriter, ShapeProp, make_fx | [review-checklist.md](review-checklist.md) |
-| Type Promotion | elementwise_dtypes, TensorIterator dtype handling, result_type, promoteTypes | [review-checklist.md](review-checklist.md) |
-| Serialization | weights_only, safe_globals, skip_data | [review-checklist.md](review-checklist.md) |
-| Distributed | DeviceMesh, distributed testing with MultiThreadedPG | [review-checklist.md](review-checklist.md) |
-| Tensor Subclasses | _make_wrapper_subclass, __tensor_flatten__/__unflatten__ | [review-checklist.md](review-checklist.md) |
-| Testing | OpInfo, ModuleInfo, device-generic, @dtypes, @parametrize, make_tensor | [review-checklist.md](review-checklist.md) |
-| Security | Injection, credentials, input handling | [review-checklist.md](review-checklist.md) |
-| Performance | Regressions, device handling, memory, profiling, benchmarking | [review-checklist.md](review-checklist.md) |
-| Thread Safety | Data races, GIL assumptions, NoGIL, CPython C API | [review-checklist.md](review-checklist.md) |
-| BC | Breaking changes, deprecation | [bc-guidelines.md](bc-guidelines.md) |
+Structure your review with actionable feedback organized by category. Every finding should be traceable to a specific line in the diff.
 
 ## Output Format
 
@@ -258,20 +208,9 @@ When requested, add file-specific feedback with line references:
 - `torch/nn/modules/linear.py:78` - This allocation could be moved outside the loop
 ```
 
-## Key Principles
-
-1. **Investigate, don't guess** - When uncertain whether a checklist item applies, spawn a sub-agent to read the relevant infrastructure code. A reviewer who guesses wrong provides negative value. A reviewer who investigates and reports findings provides immense value.
-2. **Every line matters** - A single missing `C10_CUDA_KERNEL_LAUNCH_CHECK()`, a single `weights_only=False`, a single missing Composite dispatch key — each of these is a real bug that affects real users. Do not skip lines.
-3. **No repetition** - Each observation appears in exactly one section. Never repeat the same issue, concern, or suggestion across multiple sections. If an issue spans categories (e.g., a security issue that also affects performance), place it in the most relevant section only.
-4. **Focus on what CI cannot check** - Don't comment on formatting, linting, or type errors
-5. **Be specific** - Reference file paths and line numbers. Every finding should point to a concrete line in the diff.
-6. **Be actionable** - Provide concrete suggestions with the right infrastructure to use, not vague concerns. If flagging a missing pattern, name the function/class/file the author should use.
-7. **Be proportionate** - Minor issues shouldn't block, but note them
-8. **Assume competence** - The author knows PyTorch; explain only non-obvious context. The value of this review is in catching infrastructure patterns the author may not know about, not in explaining basic programming.
-
 ## Files to Reference
 
-When reviewing, consult these project files for context. **Spawn sub-agents to read these** rather than relying on memory — the files change frequently:
+When reviewing, consult these project files for context — read them rather than relying on memory, as they change frequently:
 - `CLAUDE.md` - Coding style philosophy and testing patterns
 - `CONTRIBUTING.md` - PR requirements and review process
 - `torch/testing/_internal/common_utils.py` - Test patterns and utilities

--- a/.claude/skills/pr-review/review-checklist.md
+++ b/.claude/skills/pr-review/review-checklist.md
@@ -7,7 +7,10 @@ This checklist covers areas that CI cannot check. Skip items related to linting,
 ### Abstractions and Design
 
 - [ ] **Clear abstractions** - State management is explicit; no dynamic attribute setting/getting
-- [ ] **Match existing patterns** - Code follows architectural patterns already in the codebase
+- [ ] **No side-channel communication** - If behavior changes based on a hidden flag or dynamically-set attribute, the interface itself should change instead (different function signature, different class, different code path). Side-channel patterns (set a private flag in one place, check it in another via `getattr`) create undocumented behavioral modes
+- [ ] **Proper interface, not on/off flags** - A private boolean that switches between two fundamentally different behaviors should be two separate code paths or a proper interface change, not a flag
+- [ ] **Interface documentation** - New internal calling conventions, protocols, or contracts between components must have concrete documentation: what the caller provides, what the callee receives, what invariants hold, and cleanup responsibilities. Motivational comments ("this allows X") are not interface documentation
+- [ ] **Match existing patterns in the same file** - Before accepting new code in a file, read how similar features are already implemented in that same file. If the file uses class attributes for boolean flags, new boolean flags must use class attributes. If the file uses a specific setter pattern, new setters must use the same pattern
 - [ ] **No over-engineering** - Only requested changes are made; no speculative features
 - [ ] **No premature abstraction** - Helpers and utilities are only created when reused; three similar lines is better than a one-use helper
 - [ ] **No trivial helpers** - Avoid 1-2 LOC helper functions used only once (unless significantly improves readability)
@@ -36,17 +39,9 @@ When a PR introduces new API patterns, carefully evaluate the broader implicatio
 - [ ] **No fragile init ordering** - If multiple imports/calls must happen in a specific undocumented order, flag the design. Dependencies should be explicit or combined into a single entry point
 - [ ] **Idempotent global state** - Registries and global lists that accumulate entries must handle multiple calls safely (no duplicate registration, clear cleanup story)
 
-### Common Issues to Flag
-
-- Dynamic `setattr`/`getattr` for state management (prefer explicit class members)
-- Unused imports, variables, or dead code paths
-- Copy-pasted code that could be a shared helper
-- Magic numbers without explanation
-- Overly defensive error handling for impossible cases
-
 ## PyTorch Infrastructure
 
-When a PR touches code in the scope of any item below, **stop and investigate** whether the established infrastructure should be used. Spawn a sub-agent to read the relevant infrastructure code and determine if the PR should be using it instead of rolling its own solution.
+When a PR touches code in the scope of any item below, **stop and investigate** whether the established infrastructure should be used.
 
 ### C++ Kernel Infrastructure
 
@@ -190,31 +185,8 @@ When a PR touches code in the scope of any item below, **stop and investigate** 
 
 - [ ] **Edge cases covered** - Tests include boundary conditions, empty inputs, error cases
 - [ ] **Error conditions tested** - Expected exceptions are tested with `assertRaises` or `assertRaisesRegex`
-- [ ] **No duplicated test logic** - Similar tests share a private helper method (e.g., `_test_foo(config)`) called from individual tests with different configs
-
-**Example of good test structure:**
-```python
-def _test_feature_with_config(self, flag, expected_shape):
-    """Shared test logic called by device-specific tests."""
-    x = torch.randn(10)
-    result = my_feature(x, flag)
-    self.assertEqual(result.shape, expected_shape)
-
-def test_feature_enabled(self):
-    self._test_feature_with_config(True, (10, 10))
-
-def test_feature_disabled(self):
-    self._test_feature_with_config(False, (10, 5))
-```
-
-### Common Testing Issues
-
-- Tests that only check the happy path without error cases
-- Duplicated test code that should be a parameterized helper
-- Manual operator tests that duplicate existing OpInfo coverage — the fix should update the OpInfo's dtype list instead
-- Tests that don't clean up resources (files, CUDA memory)
-- Flaky tests (timing-dependent, order-dependent, golden value)
-- Tests that skip without clear justification
+- [ ] **No duplicated test logic** - Similar tests share a private helper method called from individual tests with different configs
+- [ ] **Use weakref for lifetime testing** - PR uses `sys.getrefcount()` to test whether objects are kept alive. Use `weakref.ref()` instead — create a weak reference, delete the strong references, then check if the weakref is dead (`wr() is None`). `sys.getrefcount` is a CPython implementation detail that varies across versions and is fragile
 
 ## Security
 
@@ -258,7 +230,7 @@ This is particularly important for PyTorch's autograd, which has multi-threaded 
 
 - [ ] **GIL held for Python object access** - Any code that touches `PyObject*` (incref, decref, attribute access, container mutation) must hold the GIL. When releasing the GIL for long-running C++ work (`Py_BEGIN_ALLOW_THREADS`), verify no Python objects are accessed in that region
 - [ ] **Borrowed references across GIL release** - Borrowed references (`PyTuple_GET_ITEM`, `PyList_GET_ITEM`) become unsafe if the GIL is released and reacquired, since another thread may have mutated the container
-- [ ] **Decref-before-update hazard** - When replacing an item in a container (tuple, list, dict), update the container slot first, then `Py_DECREF` the old value. Decref can trigger `__del__` finalizers that re-enter and observe the container in an inconsistent state. Without the GIL (free-threaded builds), this is also a data race.
+- [ ] **Decref-before-update hazard** - When replacing an item in a container (tuple, list, dict), update the container slot first, then `Py_DECREF` the old value. Decref can trigger `__del__` finalizers that re-enter and observe the container in an inconsistent state. Without the GIL (free-threaded builds), this is also a data race. This is **always** a must-fix — even if "safe in practice" because of refcount guarantees, the pattern is wrong and breaks under NoGIL. The correct pattern costs nothing extra
 
 ### Free-Threaded Python (NoGIL, PEP 703)
 
@@ -298,10 +270,3 @@ CPython 3.13t+ can run without the GIL. Code that was previously safe under the 
 
 - [ ] **Use torch.profiler** - PR adds manual `time.time()` instrumentation instead of using `torch.profiler.profile()` context manager with `schedule()` and `tensorboard_trace_handler()`
 - [ ] **Use torch.utils.benchmark.Timer** - PR benchmarks with `time.time()` loops instead of `torch.utils.benchmark.Timer` which handles warmup, statistics, and proper CUDA synchronization
-
-### Common Performance Issues
-
-- Creating new tensors inside training loops instead of pre-allocating
-- Synchronous CUDA operations where async would work
-- Keeping computation graph alive longer than needed
-- Redundant clones or copies


### PR DESCRIPTION
## Author Notes

Small manually checked updates following running some review.

## Agent Notes

The SKILL.md and review-checklist.md files had significant duplication. This consolidates all of it, reducing SKILL.md by ~37% and review-checklist.md by ~14% with no information loss.

Changes in SKILL.md:
- Removed the 22-line Review Areas table (every row just said "see checklist")
- Removed the "Checklist areas" bullet summary from Step 3
- Merged Step 1 (Fetch PR Information) into Usage Modes
- Consolidated sub-agent guidance into one paragraph instead of 7+ scattered mentions
- Merged Key Principles into Review Philosophy, deduplicating "no nits", "every line matters", "CI can't check", and "investigate don't guess"

Changes in review-checklist.md:
- Removed "Common Issues to Flag" section (duplicated Abstractions/Design checklist items)
- Removed "Common Testing Issues" section (duplicated Test Patterns/Quality checklist items)
- Removed "Common Performance Issues" section (duplicated Performance checklist items)
- Removed example code block (audience "assumes competence")