### PR TITLE
[Bugfix] Fallback to `StringFormat` for better support, error message

### DIFF
--- a/test/dynamo/test_reorder_logs.py
+++ b/test/dynamo/test_reorder_logs.py
@@ -302,6 +302,35 @@ Unsupported Tensor.item() call with capture_scalar_outputs=False
  For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0124.html""",  # noqa: B950
         )
 
+    def test_reorder_print_data_dependent_fstring(self):
+        """Print with data-dependent bool in f-string should graph break on print,
+        but work when print is reorderable."""
+
+        def f(x, mask):
+            make_causal = bool((mask == 0).all())
+            print(f"make_causal={make_causal}")
+            return x + 1
+
+        x = torch.randn(2, 3)
+        mask = torch.zeros(2, 3)
+
+        with self.assertRaisesRegex(
+            torch._dynamo.exc.Unsupported,
+            "Dynamo does not know how to trace builtin operator `print`",
+        ):
+            torch.compile(backend="eager", fullgraph=True)(f)(x, mask)
+
+        with torch._dynamo.config.patch(
+            reorderable_logging_functions={print}, capture_scalar_outputs=True
+        ):
+            opt_f = torch.compile(backend="eager", fullgraph=True)(f)
+            with patch("sys.stdout", new_callable=io.StringIO) as mock_stdout:
+                opt_out = opt_f(x, mask)
+                printed_output = mock_stdout.getvalue().strip()
+
+        self.assertTrue(same(opt_out, x + 1))
+        self.assertEqual(printed_output, "make_causal=True")
+
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -256,6 +256,7 @@ from .misc import (
     RandomClassVariable,
     RandomVariable,
     SavedTensorBox,
+    StringFormatVariable,
     TorchVersionVariable,
     TypingVariable,
     WeakRefVariable,
@@ -4291,7 +4292,19 @@ class SourcelessBuilder:
         elif isinstance(value, re.Pattern):
             return ConstantLikeVariable(value)
         elif isinstance(value, torch._dynamo.variables.lazy.LazySymNodeFormatString):
-            return ConstantVariable.create(str(value))
+            try:
+                return ConstantVariable.create(str(value))
+            # If we cannot create due to error in str() call, we should
+            # try explicitly for string format variable
+            except (
+                torch._dynamo.exc.UserError,
+                torch.fx.experimental.symbolic_shapes.GuardOnDataDependentSymNode,
+            ):
+                return StringFormatVariable.create(
+                    value.fmt_var.as_python_constant(),
+                    [value.sym_node_var],
+                    {},
+                )
         elif isinstance(value, type(torch._higher_order_ops.flex_attention_backward)):
             return torch._dynamo.variables.higher_order_ops.FlexAttentionBackwardHighOrderVariable(
                 value


### PR DESCRIPTION
Fixes #178382

## Summary

The error message complains that there is a data dependent error; however, given the call is in a F string, we could support this with a StringFormatVariable if there is an exception in the constant string

Further, this gives a direct error message that print is not supported, suggesting reordering the logs which will make this code pass

## Testplan 

```python
python test/dynamo/test_reorder_logs.py ReorderLogsTests.test_reorder_print_data_dependent_fstring
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo