### PR TITLE
[Docs] Check __all__ exports in coverage to catch decorated callables

### DIFF
--- a/.claude/skills/pr-review/review-checklist.md
+++ b/.claude/skills/pr-review/review-checklist.md
@@ -26,6 +26,11 @@ When a PR introduces new API patterns, carefully evaluate the broader implicatio
 - [ ] **Testing implications** - Does this pattern require awkward test patterns? Internal-only flags often lead to tests that use "forbidden" parameters
 - [ ] **UX implications** - Is this pattern discoverable and understandable to users? Will it appear in autocomplete, type hints, or docs in confusing ways?
 
+### Public API Documentation
+
+- [ ] **`__all__` requires docs** - Any callable added to a module's `__all__` must have a corresponding entry in the module's `.rst`/`.md` doc file (typically in an `autosummary` block). CI enforces this via `docs/source/conf.py`'s `coverage_post_process`
+- [ ] **Never add to coverage ignore lists** - `coverage_ignore_functions` and `coverage_ignore_classes` in `docs/source/conf.py` are legacy allowlists. Never add new entries. Instead, either properly document the API or remove it from `__all__`
+
 ### Code Clarity
 
 - [ ] **Self-explanatory code** - Variable and function names convey intent; minimal comments needed

--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -93,6 +93,7 @@ jobs:
             timeout-minutes: 360
           - docs_type: python
             runner: ${{ inputs.runner_prefix }}linux.c7i.2xlarge
+            # It takes less than 30m to finish python docs unless there are issues
             timeout-minutes: 45
     # Set a fixed name for this job instead of using the current matrix-generated name, i.e. build-docs (cpp, linux.12xlarge, 180)
     # The current name requires updating the database last docs push query from test-infra every time the matrix is updated

--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -94,7 +94,7 @@ jobs:
           - docs_type: python
             runner: ${{ inputs.runner_prefix }}linux.c7i.2xlarge
             # It takes less than 30m to finish python docs unless there are issues
-            timeout-minutes: 45
+            timeout-minutes: 30
     # Set a fixed name for this job instead of using the current matrix-generated name, i.e. build-docs (cpp, linux.12xlarge, 180)
     # The current name requires updating the database last docs push query from test-infra every time the matrix is updated
     name: build-docs-${{ matrix.docs_type }}-${{ inputs.push }}

--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -94,7 +94,7 @@ jobs:
           - docs_type: python
             runner: ${{ inputs.runner_prefix }}linux.c7i.2xlarge
             # It takes less than 30m to finish python docs unless there are issues
-            timeout-minutes: 30
+            timeout-minutes: 45
     # Set a fixed name for this job instead of using the current matrix-generated name, i.e. build-docs (cpp, linux.12xlarge, 180)
     # The current name requires updating the database last docs push query from test-infra every time the matrix is updated
     name: build-docs-${{ matrix.docs_type }}-${{ inputs.push }}

--- a/docs/source/autograd.md
+++ b/docs/source/autograd.md
@@ -483,8 +483,6 @@ Also see {ref}`saved-tensors-hooks-doc`.
 ```
 
 ```{eval-rst}
-.. automodule:: torch.autograd.variable
-
 .. currentmodule:: torch.autograd.variable
 
 .. autosummary::

--- a/docs/source/autograd.md
+++ b/docs/source/autograd.md
@@ -220,6 +220,12 @@ like the following:
 When creating a new {class}`Function`, the following methods are available to `ctx`.
 
 ```{eval-rst}
+.. autoclass:: torch.autograd.function.FunctionCtx
+    :no-members:
+
+.. autoclass:: torch.autograd.function.FunctionMeta
+    :no-members:
+
 .. autosummary::
     :toctree: generated
     :nosignatures:

--- a/docs/source/autograd.md
+++ b/docs/source/autograd.md
@@ -249,8 +249,6 @@ Base custom {class}`Function` used to build PyTorch utilities
     :toctree: generated
     :nosignatures:
 
-    function.FunctionCtx
-    function.FunctionMeta
     function.BackwardCFunction
     function.InplaceFunction
     function.NestedIOFunction

--- a/docs/source/autograd.md
+++ b/docs/source/autograd.md
@@ -249,6 +249,8 @@ Base custom {class}`Function` used to build PyTorch utilities
     :toctree: generated
     :nosignatures:
 
+    function.FunctionCtx
+    function.FunctionMeta
     function.BackwardCFunction
     function.InplaceFunction
     function.NestedIOFunction
@@ -275,6 +277,9 @@ Base custom {class}`Function` used to build PyTorch utilities
     gradcheck
     gradgradcheck
     GradcheckError
+    get_analytical_jacobian
+    get_numerical_jacobian
+    get_numerical_jacobian_wrt_specific_input
 ```
 
 % Just to reset the base path for the rest of this file
@@ -310,6 +315,10 @@ and vtune profiler based using
     profiler.EnforceUnique
     profiler.KinetoStepTracker
     profiler.record_function
+    profiler_util.EventList
+    profiler_util.FormattedTimesMixin
+    profiler_util.FunctionEvent
+    profiler_util.FunctionEventAvg
     profiler_util.Interval
     profiler_util.Kernel
     profiler_util.MemRecordsAcc
@@ -470,5 +479,19 @@ Also see {ref}`saved-tensors-hooks-doc`.
 ```
 
 ```{eval-rst}
+.. automodule:: torch.autograd.variable
+
+.. currentmodule:: torch.autograd.variable
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    Variable
+    VariableMeta
+```
+
+```{eval-rst}
 .. py:module:: torch.autograd.variable
+   :noindex:
 ```

--- a/docs/source/autograd.md
+++ b/docs/source/autograd.md
@@ -483,6 +483,8 @@ Also see {ref}`saved-tensors-hooks-doc`.
 ```
 
 ```{eval-rst}
+.. automodule:: torch.autograd.variable
+
 .. currentmodule:: torch.autograd.variable
 
 .. autosummary::

--- a/docs/source/autograd.md
+++ b/docs/source/autograd.md
@@ -362,6 +362,7 @@ and vtune profiler based using
     :nosignatures:
 
     grad_mode.set_multithreading_enabled
+    grad_mode.enforce_grad_layout_policy
 
 
 ```

--- a/docs/source/backends.md
+++ b/docs/source/backends.md
@@ -259,6 +259,10 @@ These backends include:
 .. autofunction:: torch.backends.cusparselt.is_available
 ```
 
+```{eval-rst}
+.. autofunction:: torch.backends.cusparselt.get_max_alg_id
+```
+
 ## torch.backends.mha
 
 ```{eval-rst}
@@ -300,6 +304,22 @@ These backends include:
 ```{eval-rst}
 .. autofunction::  torch.backends.mps.is_built
 
+```
+
+```{eval-rst}
+.. autofunction::  torch.backends.mps.get_core_count
+```
+
+```{eval-rst}
+.. autofunction::  torch.backends.mps.get_name
+```
+
+```{eval-rst}
+.. autofunction::  torch.backends.mps.is_macos13_or_newer
+```
+
+```{eval-rst}
+.. autofunction::  torch.backends.mps.is_macos_or_newer
 ```
 
 ## torch.backends.mkl

--- a/docs/source/checkpoint.md
+++ b/docs/source/checkpoint.md
@@ -39,4 +39,5 @@ output compared to non-checkpointed passes is never guaranteed.
 .. autoclass:: CheckpointPolicy
 .. autoclass:: SelectiveCheckpointContext
 .. autofunction:: create_selective_checkpoint_contexts
+.. autoclass:: GraphExecGroup
 ```

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -2367,10 +2367,11 @@ def coverage_post_process(app, exception):
     ignore_names = set(app.config.coverage_ignore_functions) | set(
         app.config.coverage_ignore_classes
     )
-    # TorchScript-only pybind11 types that are in __all__ (via dir(torch._C))
-    # but intentionally not documented: their .str member creates ambiguous
-    # cross-references with Python's builtin str across all docstrings.
-    ignore_names |= {"ErrorReport", "FutureType", "StreamObjType"}
+    # pybind11 objects from torch._C that are in __all__ but cannot be
+    # documented via autosummary: the first three have .str members that
+    # create ambiguous cross-references with Python's builtin str;
+    # unify_type_list has a C++ arglist Sphinx cannot parse.
+    ignore_names |= {"ErrorReport", "FutureType", "StreamObjType", "unify_type_list"}
     undocumented = []
     for mod_name in modules:
         if not is_not_internal(mod_name):

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -2238,15 +2238,6 @@ language = "en"
 # This patterns also effect to html_static_path and html_extra_path
 exclude_patterns = []
 
-if not torch.distributed.is_available():
-    exclude_patterns += [
-        "distributed*.md",
-        "distributed*.rst",
-        "elastic/*",
-        "rpc.md",
-        "rpc/*",
-    ]
-
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = "sphinx"
 
@@ -2342,11 +2333,11 @@ def coverage_post_process(app, exception):
         return
 
     if not torch.distributed.is_available():
-        print(
-            "Skipping coverage check: torch.distributed is not available "
-            "(built with USE_DISTRIBUTED=0)."
+        raise RuntimeError(
+            "The coverage tool cannot run with a version "
+            "of PyTorch that was built with USE_DISTRIBUTED=0 "
+            "as this module's API changes."
         )
-        return
 
     # These are all the modules that have "automodule" in an rst file
     # These modules are the ones for which coverage is checked

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -2380,12 +2380,12 @@ def coverage_post_process(app, exception):
 
     if undocumented:
         items = "\n".join(f"  - {u}" for u in sorted(undocumented))
-        raise RuntimeError(
-            f"The following public APIs are in __all__ but not documented:\n{items}\n"
-            "Add them to the appropriate .rst/.md doc file, add to "
-            "coverage_ignore_functions/coverage_ignore_classes, or "
+        print(
+            f"\nThe following public APIs are in __all__ but not documented:\n{items}\n"
+            "Either add them to the appropriate .rst/.md doc file or "
             "remove from __all__."
         )
+        sys.exit(1)
 
     # We go through all the torch submodules and make sure they are
     # properly documented

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -260,6 +260,10 @@ autosummary_filename_map = {
 coverage_ignore_functions = [
     "main",  # utility script
     "run",  # utility script
+    # TorchVitals (C++ bindings still in torch._C, Python wrappers removed)
+    "read_vitals",
+    "set_vital",
+    "vitals_enabled",
     # torch.hub
     "import_module",
     # torch.jit.unsupported_tensor_ops

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -2367,6 +2367,10 @@ def coverage_post_process(app, exception):
     ignore_names = set(app.config.coverage_ignore_functions) | set(
         app.config.coverage_ignore_classes
     )
+    # TorchScript-only pybind11 types that are in __all__ (via dir(torch._C))
+    # but intentionally not documented: their .str member creates ambiguous
+    # cross-references with Python's builtin str across all docstrings.
+    ignore_names |= {"ErrorReport", "FutureType", "StreamObjType"}
     undocumented = []
     for mod_name in modules:
         if not is_not_internal(mod_name):

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -2341,12 +2341,7 @@ def coverage_post_process(app, exception):
 
     # These are all the modules that have "automodule" in an rst file
     # These modules are the ones for which coverage is checked
-    # Here, we make sure that no module is missing from that list
     modules = app.env.domaindata["py"]["modules"]
-
-    # We go through all the torch submodules and make sure they are
-    # properly tested
-    missing = set()
 
     def is_not_internal(modname):
         split_name = modname.split(".")
@@ -2354,6 +2349,47 @@ def coverage_post_process(app, exception):
             if name[0] == "_":
                 return False
         return True
+
+    # Sphinx's built-in coverage only catches items that pass
+    # inspect.isfunction() or inspect.isclass(), missing decorated/wrapped
+    # callables (e.g. @cache, @lru_cache, @deprecated). Cross-reference
+    # __all__ exports directly against the documented objects dict.
+    objects = app.env.domaindata["py"]["objects"]
+    ignore_names = set(app.config.coverage_ignore_functions) | set(
+        app.config.coverage_ignore_classes
+    )
+    undocumented = []
+    for mod_name in modules:
+        if not is_not_internal(mod_name):
+            continue
+        try:
+            mod = __import__(mod_name, fromlist=["__all__"])
+        except ImportError:
+            continue
+        for name in getattr(mod, "__all__", []):
+            if name.startswith("_") or name in ignore_names:
+                continue
+            full_name = f"{mod_name}.{name}"
+            obj = getattr(mod, name, None)
+            if obj is None or not callable(obj):
+                continue
+            if getattr(obj, "__module__", mod_name) != mod_name:
+                continue
+            if full_name not in objects:
+                undocumented.append(full_name)
+
+    if undocumented:
+        items = "\n".join(f"  - {u}" for u in sorted(undocumented))
+        raise RuntimeError(
+            f"The following public APIs are in __all__ but not documented:\n{items}\n"
+            "Add them to the appropriate .rst/.md doc file, add to "
+            "coverage_ignore_functions/coverage_ignore_classes, or "
+            "remove from __all__."
+        )
+
+    # We go through all the torch submodules and make sure they are
+    # properly documented
+    missing = set()
 
     # The walk function does not return the top module
     if "torch" not in modules:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -2389,8 +2389,17 @@ def coverage_post_process(app, exception):
                 continue
             if getattr(obj, "__module__", mod_name) != mod_name:
                 continue
-            if full_name not in objects:
-                undocumented.append(full_name)
+            if full_name in objects:
+                continue
+            # Check if documented under a parent module (e.g.
+            # torch.distributed.distributed_c10d.get_rank is documented
+            # as torch.distributed.get_rank via currentmodule).
+            parts = mod_name.split(".")
+            if any(
+                f"{'.'.join(parts[:i])}.{name}" in objects for i in range(1, len(parts))
+            ):
+                continue
+            undocumented.append(full_name)
 
     if undocumented:
         items = "\n".join(f"  - {u}" for u in sorted(undocumented))

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -2238,6 +2238,15 @@ language = "en"
 # This patterns also effect to html_static_path and html_extra_path
 exclude_patterns = []
 
+if not torch.distributed.is_available():
+    exclude_patterns += [
+        "distributed*.md",
+        "distributed*.rst",
+        "elastic/*",
+        "rpc.md",
+        "rpc/*",
+    ]
+
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = "sphinx"
 
@@ -2333,11 +2342,11 @@ def coverage_post_process(app, exception):
         return
 
     if not torch.distributed.is_available():
-        raise RuntimeError(
-            "The coverage tool cannot run with a version "
-            "of PyTorch that was built with USE_DISTRIBUTED=0 "
-            "as this module's API changes."
+        print(
+            "Skipping coverage check: torch.distributed is not available "
+            "(built with USE_DISTRIBUTED=0)."
         )
+        return
 
     # These are all the modules that have "automodule" in an rst file
     # These modules are the ones for which coverage is checked

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1924,6 +1924,8 @@ coverage_ignore_classes = [
     "PackagingErrorReason",
     # torch.package.package_importer
     "PackageImporter",
+    # torch.autograd.profiler_util
+    "EventMetadata",
     # torch.profiler.profiler
     "ExecutionTraceObserver",
     "profile",

--- a/docs/source/cpu.rst
+++ b/docs/source/cpu.rst
@@ -9,6 +9,7 @@ torch.cpu
 
     current_device
     current_stream
+    get_capabilities
     is_available
     is_initialized
     synchronize

--- a/docs/source/cuda.md
+++ b/docs/source/cuda.md
@@ -188,6 +188,8 @@
     nvtx.range_push
     nvtx.range_pop
     nvtx.range
+    nvtx.range_end
+    nvtx.range_start
 ```
 
 ## Jiterator (beta)

--- a/docs/source/cuda.md
+++ b/docs/source/cuda.md
@@ -318,14 +318,6 @@ See the docs for {class}`~torch.cuda.green_contexts.GreenContext` for an example
 ```
 
 ```{eval-rst}
-.. autofunction:: range_start
-```
-
-```{eval-rst}
-.. autofunction:: range_end
-```
-
-```{eval-rst}
 .. py:module:: torch.cuda.profiler
 ```
 

--- a/docs/source/data.md
+++ b/docs/source/data.md
@@ -533,5 +533,29 @@ for batch_ndx, sample in enumerate(loader):
 ```
 
 ```{eval-rst}
+.. automodule:: torch.utils.data.datapipes.iter.streamreader
+
+.. currentmodule:: torch.utils.data.datapipes.iter.streamreader
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    StreamReaderIterDataPipe
+```
+
+```{eval-rst}
+.. automodule:: torch.utils.data.datapipes.utils.common
+
+.. currentmodule:: torch.utils.data.datapipes.utils.common
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    StreamWrapper
+```
+
+```{eval-rst}
 .. py:module:: torch.utils.data.datapipes.utils
 ```

--- a/docs/source/data.md
+++ b/docs/source/data.md
@@ -533,8 +533,6 @@ for batch_ndx, sample in enumerate(loader):
 ```
 
 ```{eval-rst}
-.. automodule:: torch.utils.data.datapipes.iter.streamreader
-
 .. currentmodule:: torch.utils.data.datapipes.iter.streamreader
 
 .. autosummary::
@@ -545,8 +543,6 @@ for batch_ndx, sample in enumerate(loader):
 ```
 
 ```{eval-rst}
-.. automodule:: torch.utils.data.datapipes.utils.common
-
 .. currentmodule:: torch.utils.data.datapipes.utils.common
 
 .. autosummary::

--- a/docs/source/data.md
+++ b/docs/source/data.md
@@ -533,6 +533,8 @@ for batch_ndx, sample in enumerate(loader):
 ```
 
 ```{eval-rst}
+.. automodule:: torch.utils.data.datapipes.iter.streamreader
+
 .. currentmodule:: torch.utils.data.datapipes.iter.streamreader
 
 .. autosummary::
@@ -543,6 +545,8 @@ for batch_ndx, sample in enumerate(loader):
 ```
 
 ```{eval-rst}
+.. automodule:: torch.utils.data.datapipes.utils.common
+
 .. currentmodule:: torch.utils.data.datapipes.utils.common
 
 .. autosummary::

--- a/docs/source/distributed.checkpoint.md
+++ b/docs/source/distributed.checkpoint.md
@@ -116,6 +116,23 @@ The following types define the IO interface used during checkpoint:
   :members:
 ```
 
+The following types define the metadata used during checkpoint:
+
+```{eval-rst}
+.. autoclass:: torch.distributed.checkpoint.metadata.StorageMeta
+  :members:
+```
+
+```{eval-rst}
+.. autoclass:: torch.distributed.checkpoint.metadata.TensorProperties
+  :members:
+```
+
+```{eval-rst}
+.. autoclass:: torch.distributed.checkpoint.metadata.TensorStorageMetadata
+  :members:
+```
+
 The following types define the planner interface used during checkpoint:
 
 ```{eval-rst}
@@ -153,7 +170,27 @@ The following types define the planner interface used during checkpoint:
   :members:
 ```
 
+```{eval-rst}
+.. autoclass:: torch.distributed.checkpoint.planner.TensorWriteData
+  :members:
+```
+
 We provide a filesystem based storage layer:
+
+```{eval-rst}
+.. autoclass:: torch.distributed.checkpoint.filesystem.FileSystemBase
+  :members:
+```
+
+```{eval-rst}
+.. autoclass:: torch.distributed.checkpoint.filesystem.FileSystem
+  :members:
+```
+
+```{eval-rst}
+.. autoclass:: torch.distributed.checkpoint.filesystem.SerializationFormat
+  :members:
+```
 
 ```{eval-rst}
 .. autoclass:: torch.distributed.checkpoint.FileSystemReader

--- a/docs/source/distributed.fsdp.fully_shard.md
+++ b/docs/source/distributed.fsdp.fully_shard.md
@@ -204,3 +204,8 @@ The frontend API is `fully_shard` that can be called on a `module`:
 ```{eval-rst}
 .. autofunction:: share_comm_ctx
 ```
+
+```{eval-rst}
+.. autoclass:: DataParallelMeshDims
+    :members:
+```

--- a/docs/source/distributed.md
+++ b/docs/source/distributed.md
@@ -343,11 +343,27 @@ check whether the process group has already been initialized use {func}`torch.di
 ```
 
 ```{eval-rst}
+.. autofunction:: get_backend_config
+```
+
+```{eval-rst}
 .. autofunction:: get_rank
 ```
 
 ```{eval-rst}
 .. autofunction:: get_world_size
+```
+
+```{eval-rst}
+.. autofunction:: get_debug_level
+```
+
+```{eval-rst}
+.. autofunction:: get_node_local_rank
+```
+
+```{eval-rst}
+.. autofunction:: get_pg_count
 ```
 
 ## Shutdown
@@ -409,6 +425,14 @@ an opaque group handle that can be given as a `group` argument to all collective
 ```{eval-rst}
 .. autofunction:: get_process_group_ranks
 
+```
+
+```{eval-rst}
+.. autofunction:: split_group
+```
+
+```{eval-rst}
+.. autodata:: torch.distributed.distributed_c10d.GroupName
 ```
 
 ## DeviceMesh
@@ -533,6 +557,10 @@ if rank == 0:
 ```
 
 ```{eval-rst}
+.. autofunction:: all_reduce_coalesced
+```
+
+```{eval-rst}
 .. autofunction:: reduce
 ```
 
@@ -546,6 +574,10 @@ if rank == 0:
 
 ```{eval-rst}
 .. autofunction:: all_gather_object
+```
+
+```{eval-rst}
+.. autofunction:: all_gather_coalesced
 ```
 
 ```{eval-rst}
@@ -1259,6 +1291,8 @@ If you are running single node training, it may be convenient to interactively b
 
 ```{eval-rst}
 .. py:module:: torch.distributed.collective_utils
+
+.. autofunction:: torch.distributed.collective_utils.all_gather_object_enforce_type
 ```
 
 ```{eval-rst}

--- a/docs/source/distributed.pipelining.md
+++ b/docs/source/distributed.pipelining.md
@@ -517,3 +517,7 @@ The following set of APIs transform your model into a pipeline representation.
 .. autoclass:: PipelineScheduleMulti
   :members:
 ```
+
+```{eval-rst}
+.. autofunction:: get_schedule_class
+```

--- a/docs/source/distributed.tensor.md
+++ b/docs/source/distributed.tensor.md
@@ -270,6 +270,10 @@ these features.
 .. autofunction:: implicit_replication
 ```
 
+```{eval-rst}
+.. autofunction:: implicit_replication
+```
+
 % modules that are missing docs, add the doc later when necessary
 
 ```{eval-rst}

--- a/docs/source/distributed.tensor.md
+++ b/docs/source/distributed.tensor.md
@@ -270,10 +270,6 @@ these features.
 .. autofunction:: implicit_replication
 ```
 
-```{eval-rst}
-.. autofunction:: implicit_replication
-```
-
 % modules that are missing docs, add the doc later when necessary
 
 ```{eval-rst}

--- a/docs/source/distributions.md
+++ b/docs/source/distributions.md
@@ -581,6 +581,14 @@
 .. automodule:: torch.distributions.transforms
     :members:
     :member-order: bysource
+
+.. currentmodule:: torch.distributions.transforms
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    identity_transform
 ```
 
 ## `Constraints`
@@ -589,6 +597,14 @@
 .. automodule:: torch.distributions.constraints
     :members:
     :member-order: bysource
+
+.. currentmodule:: torch.distributions.constraints
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    dependent
 ```
 
 ## `Constraint Registry`
@@ -597,6 +613,15 @@
 .. automodule:: torch.distributions.constraint_registry
     :members:
     :member-order: bysource
+
+.. currentmodule:: torch.distributions.constraint_registry
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    biject_to
+    transform_to
 ```
 
 % This module needs to be documented. Adding here in the meantime
@@ -690,8 +715,11 @@
     :toctree: generated
     :nosignatures:
 
+    broadcast_all
+    clamp_probs
     logits_to_probs
     probs_to_logits
+    tril_matrix_to_vec
     vec_to_tril_matrix
 
 .. py:module:: torch.distributions.von_mises

--- a/docs/source/elastic/events.rst
+++ b/docs/source/elastic/events.rst
@@ -26,3 +26,5 @@ Event Objects
 .. autoclass:: torch.distributed.elastic.events.api.EventSource
 
 .. autoclass:: torch.distributed.elastic.events.api.EventMetadataValue
+
+.. autoclass:: torch.distributed.elastic.events.api.NodeState

--- a/docs/source/elastic/rendezvous.rst
+++ b/docs/source/elastic/rendezvous.rst
@@ -19,6 +19,8 @@ Registry
 
 .. automodule:: torch.distributed.elastic.rendezvous.registry
 
+.. autofunction:: torch.distributed.elastic.rendezvous.registry.get_rendezvous_handler
+
 Handler
 -------
 

--- a/docs/source/fx.experimental.md
+++ b/docs/source/fx.experimental.md
@@ -68,6 +68,10 @@ These APIs are experimental and subject to change without notice.
     StatelessSymbolicContext
     StatefulSymbolicContext
     SubclassSymbolicContext
+    SymIntEqByExpr
+    SymIntSymbolicContext
+    TrackedFake
+    ValueRangesSLoc
     DimConstraints
     ShapeEnvSettings
     ConvertIntKey
@@ -142,9 +146,11 @@ These APIs are experimental and subject to change without notice.
 
     make_fx
     handle_sym_dispatch
+    get_innermost_proxy_mode
     get_proxy_mode
     maybe_enable_thunkify
     maybe_disable_thunkify
+    selective_decompose
     thunkify
     track_tensor
     track_tensor_tree
@@ -182,6 +188,7 @@ These APIs are experimental and subject to change without notice.
     :nosignatures:
 
     extract_subgraph
+    gen_mkl_autotuner
     matches_module_pattern
     modules_to_mkldnn
     optimize_for_inference
@@ -270,6 +277,7 @@ These APIs are experimental and subject to change without notice.
     assoc_in
     dissoc
     first
+    get_in
     groupby
     keyfilter
     keymap
@@ -342,22 +350,47 @@ These APIs are experimental and subject to change without notice.
     :nosignatures:
 
     adaptive_inference_rule
+    add_layer_norm_constraints
+    add_linear_constraints
+    arange_inference_rule
     assert_inference_rule
     batchnorm_inference_rule
     bmm_inference_rule
+    broadcasting_inference_rule
+    conv2d_inference_rule
+    cumsum_inference_rule
     embedding_inference_rule
     embedding_inference_rule_functional
     eq_inference_rule
     equality_inference_rule
     expand_inference_rule
+    flatten_inference_rule
     full_inference_rule
+    gen_broadcasting_constraints
+    gen_embedding_rules
+    gen_layer_norm_constraints
+    generate_flatten_constraints
+    get_attr_inference_rule
+    getitem_inference_rule
     gt_inference_rule
+    index_select_inference_rule
+    layer_norm_functional
+    layer_norm_inference_rule
+    linear_constraints
+    linear_inference_rule
     lt_inference_rule
     masked_fill_inference_rule
+    maxpool_inference_rule
     neq_inference_rule
+    range_check
+    register_inference_rule
+    relu_inference_rule
+    reshape_inference_rule
+    size_inference_rule
     tensor_inference_rule
     torch_dim_inference_rule
     torch_linear_inference_rule
+    transpose_inference_rule
     type_inference_rule
     view_inference_rule
     register_inference_rule
@@ -413,17 +446,34 @@ These APIs are experimental and subject to change without notice.
 
     adaptiveavgpool2d_check
     adaptiveavgpool2d_inference_rule
+    add_inference_rule
     all_eq
     bn2d_inference_rule
+    broadcast_types
     calculate_out_dimension
+    conv2d_inference_rule
     conv_refinement_rule
     conv_rule
     element_wise_eq
     expand_to_tensor_dim
     first_two_eq
+    flatten_check
+    flatten_inference_rule
+    flatten_refinement_rule
+    get_attr_inference_rule
+    get_greatest_upper_bound
+    get_parameter
+    GraphTypeChecker
+    linear_check
+    linear_inference_rule
+    linear_refinement_rule
+    maxpool2d_check
+    maxpool2d_inference_rule
     register_algebraic_expressions_inference_rule
     register_inference_rule
     register_refinement_rule
+    relu_inference_rule
+    reshape_inference_rule
     transpose_inference_rule
 ```
 
@@ -722,6 +772,7 @@ These APIs are experimental and subject to change without notice.
     :nosignatures:
 
     bisect
+    TranslationValidator
     translation_validation_enabled
     translation_validation_timeout
     z3op

--- a/docs/source/fx.experimental.md
+++ b/docs/source/fx.experimental.md
@@ -428,6 +428,7 @@ These APIs are experimental and subject to change without notice.
     generate_binconstraint_d
     generate_binconstraint_t
     generate_broadcasting
+    generate_calc_conv
     generate_calc_maxpool
     generate_calc_product
     generate_conj
@@ -513,6 +514,7 @@ These APIs are experimental and subject to change without notice.
 
     embedding_override
     functional_relu_override
+    gen_constructor_wrapper
     nn_layernorm_override
     proxys_to_metas
     symbolic_trace

--- a/docs/source/fx.experimental.md
+++ b/docs/source/fx.experimental.md
@@ -312,6 +312,7 @@ These APIs are experimental and subject to change without notice.
     transform_to_z3
     transform_var
     evaluate_conditional_with_constraints
+    iterate_till_fixed_point
 ```
 
 ## torch.fx.experimental.migrate_gradual_types.constraint
@@ -414,8 +415,26 @@ These APIs are experimental and subject to change without notice.
     :nosignatures:
 
     apply_padding
+    broadcast_dim
     calc_last_two_dims
     create_equality_constraints_for_broadcasting
+    gen_all_reshape_possibilities
+    gen_broadcasting_constraints
+    gen_consistency_constraints
+    gen_greatest_upper_bound
+    gen_lists_of_dims
+    generate_all_broadcasting_possibilities_no_padding
+    generate_all_int_dyn_dim_possibilities
+    generate_binconstraint_d
+    generate_binconstraint_t
+    generate_broadcasting
+    generate_calc_maxpool
+    generate_calc_product
+    generate_conj
+    generate_d_gub
+    generate_disj
+    generate_gub
+    generate_reshape
     is_target_div_by_dim
     no_broadcast_dim_with_index
     register_transformation_rule
@@ -749,6 +768,7 @@ These APIs are experimental and subject to change without notice.
     :nosignatures:
 
     check_for_type_equality
+    convert_eq
     infer_symbolic_types
     infer_symbolic_types_single_pass
     substitute_all_types

--- a/docs/source/fx.md
+++ b/docs/source/fx.md
@@ -1156,6 +1156,9 @@ The set of leaf modules can be customized by overriding
 
     check_for_mutable_operation
     create_type_hint
+    get_signature_for_torch_op
+    normalize_function
+    normalize_module
     type_matches
 ```
 
@@ -1175,6 +1178,9 @@ The set of leaf modules can be customized by overriding
     :nosignatures:
 
     annotate_fn
+    get_graph_provenance_json
+    NodeSource
+    NodeSourceAction
 ```
 
 ## torch.fx.subgraph_rewriter
@@ -1424,6 +1430,15 @@ The set of leaf modules can be customized by overriding
 .. py:module:: torch.fx.passes.dialect.common
 .. py:module:: torch.fx.config
 .. py:module:: torch.fx.experimental.const_fold
+
+.. currentmodule:: torch.fx.experimental.const_fold
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    get_unique_attr_name_in_module
+    split_const_subgraphs
 .. py:module:: torch.fx.experimental.migrate_gradual_types.operation
 .. py:module:: torch.fx.experimental.migrate_gradual_types.util
 .. py:module:: torch.fx.experimental.migrate_gradual_types.z3_types
@@ -1434,7 +1449,25 @@ The set of leaf modules can be customized by overriding
 .. py:module:: torch.fx.experimental.schema_type_annotation
 .. py:module:: torch.fx.experimental.unification.dispatch
 .. py:module:: torch.fx.graph
+
+.. currentmodule:: torch.fx.graph
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    CodeGen
+
 .. py:module:: torch.fx.graph_module
+
+.. currentmodule:: torch.fx.graph_module
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    reduce_graph_module
+    reduce_package_graph_module
 .. py:module:: torch.fx.immutable_collections
 .. py:module:: torch.fx.interpreter
 .. py:module:: torch.fx.passes.annotate_getitem_nodes
@@ -1444,6 +1477,14 @@ The set of leaf modules can be customized by overriding
 .. py:module:: torch.fx.passes.graph_drawer
 .. py:module:: torch.fx.passes.graph_manipulation
 .. py:module:: torch.fx.passes.graph_transform_observer
+
+.. currentmodule:: torch.fx.passes.graph_transform_observer
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    GraphTransformObserver
 .. py:module:: torch.fx.passes.infra.partitioner
 .. py:module:: torch.fx.passes.infra.pass_base
 .. py:module:: torch.fx.passes.infra.pass_manager
@@ -1454,19 +1495,60 @@ The set of leaf modules can be customized by overriding
 .. py:module:: torch.fx.passes.regional_inductor
 .. py:module:: torch.fx.passes.reinplace
 .. py:module:: torch.fx.passes.runtime_assert
+
+.. currentmodule:: torch.fx.passes.runtime_assert
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    insert_deferred_runtime_asserts
 .. py:module:: torch.fx.passes.shape_prop
+
+.. currentmodule:: torch.fx.passes.shape_prop
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    TensorMetadata
 .. py:module:: torch.fx.passes.split_module
 .. py:module:: torch.fx.passes.split_utils
 .. autofunction:: torch.fx.passes.split_utils.move_non_tensor_nodes_on_boundary
 .. py:module:: torch.fx.passes.splitter_base
+
+.. currentmodule:: torch.fx.passes.splitter_base
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    NodeEvent
+    NodeEventTracker
 .. py:module:: torch.fx.passes.tests.test_pass_manager
 .. py:module:: torch.fx.passes.tools_common
 .. py:module:: torch.fx.passes.utils.common
 .. py:module:: torch.fx.passes.utils.fuser_utils
 .. py:module:: torch.fx.passes.utils.matcher_utils
 .. py:module:: torch.fx.passes.utils.matcher_with_name_node_map_utils
+
+.. currentmodule:: torch.fx.passes.utils.matcher_with_name_node_map_utils
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    SubgraphMatcherWithNameNodeMap
 .. py:module:: torch.fx.passes.utils.source_matcher_utils
 .. py:module:: torch.fx.proxy
+
+.. currentmodule:: torch.fx.proxy
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    GraphAppendingTracer
 .. py:module:: torch.fx.subgraph_rewriter
 .. py:module:: torch.fx.tensor_type
 ```

--- a/docs/source/mps.md
+++ b/docs/source/mps.md
@@ -26,6 +26,7 @@
     driver_allocated_memory
     recommended_max_memory
     compile_shader
+    load_metallib
 ```
 
 ## MPS Profiler

--- a/docs/source/mtia.md
+++ b/docs/source/mtia.md
@@ -27,6 +27,7 @@ here.
     is_initialized
     memory_stats
     get_device_capability
+    get_device_properties
     empty_cache
     record_memory_history
     snapshot

--- a/docs/source/mtia.memory.md
+++ b/docs/source/mtia.memory.md
@@ -15,6 +15,7 @@ The MTIA backend is implemented out of the tree, only interfaces are defined her
     :toctree: generated
     :nosignatures:
 
+    max_memory_allocated
     memory_stats
     memory_allocated
 ```

--- a/docs/source/optim.md
+++ b/docs/source/optim.md
@@ -697,6 +697,9 @@ We train the model for a total of 300 epochs and start to collect EMA averages i
 
     swa_utils.AveragedModel
     swa_utils.SWALR
+    swa_utils.get_ema_avg_fn
+    swa_utils.get_swa_avg_fn
+    swa_utils.get_swa_multi_avg_fn
 
 
 .. autofunction:: torch.optim.swa_utils.get_ema_multi_avg_fn

--- a/docs/source/quantization-support.md
+++ b/docs/source/quantization-support.md
@@ -47,6 +47,7 @@ This module contains Eager mode quantization APIs.
     :nosignatures:
     :template: classtemplate.rst
 
+    ObserverOrFakeQuantize
     swap_module
     propagate_qconfig_
     default_eval_fn
@@ -66,9 +67,18 @@ This module contains Eager mode quantization APIs.
     activation_is_int8_quantized
     activation_is_statically_quantized
 
-    determine_qparams
-    check_min_max_valid
     calculate_qmin_qmax
+    check_min_max_valid
+    determine_qparams
+    get_combined_dict
+    get_fqn_to_example_inputs
+    get_qconfig_dtypes
+    get_qparam_dict
+    get_quant_type
+    get_swapped_custom_module_class
+    getattr_from_fqn
+    NodePattern
+    Pattern
     validate_qmin_qmax
 ```
 
@@ -146,6 +156,15 @@ Quantization to work with this as well.
     :template: classtemplate.rst
 
     entry_to_pretty_str
+    get_fused_module_classes
+    get_fuser_method_mapping
+    get_fusion_pattern_to_extra_inputs_getter
+    get_fusion_pattern_to_root_node_getter
+    get_module_to_qat_module
+    get_pattern_to_dtype_configs
+    get_pattern_to_input_type_to_index
+    get_qat_module_classes
+    get_root_module_to_quantized_reference_module
     pattern_to_human_readable
     remove_boolean_dispatch_from_name
 
@@ -171,6 +190,21 @@ This module contains a few CustomConfig classes that's used in both eager mode a
     StandaloneModuleConfigEntry
 ```
 
+## torch.ao.quantization.fx.graph_module
+
+```{eval-rst}
+.. currentmodule:: torch.ao.quantization.fx.graph_module
+```
+
+```{eval-rst}
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+    :template: classtemplate.rst
+
+    QuantizedGraphModule
+```
+
 ## torch.ao.quantization.fx.utils
 
 ```{eval-rst}
@@ -185,13 +219,21 @@ This module contains a few CustomConfig classes that's used in both eager mode a
 
     all_node_args_except_first
     all_node_args_have_no_tensors
+    assert_and_get_unique_device
     collect_producer_nodes
     create_getattr_from_value
     create_node_from_old_node_preserve_meta
+    get_custom_module_class_keys
+    get_linear_prepack_op_for_dtype
+    get_new_attr_name_with_prefix
+    get_non_observable_arg_indexes_and_types
+    get_qconv_prepack_op
+    get_skipped_module_name_and_classes
     graph_module_from_producer_nodes
     maybe_get_next_module
     node_arg_is_bias
     node_arg_is_weight
+    NodeInfo
     return_arg_list
 ```
 
@@ -283,6 +325,7 @@ the values observed during calibration (PTQ) or training (QAT).
     NoopObserver
     get_observer_state_dict
     load_observer_state_dict
+    default_affine_fixed_qparams_observer
     default_observer
     default_placeholder_observer
     default_debug_observer
@@ -290,7 +333,13 @@ the values observed during calibration (PTQ) or training (QAT).
     default_histogram_observer
     default_per_channel_weight_observer
     default_dynamic_quant_observer
+    default_fixed_qparams_range_0to1_observer
+    default_fixed_qparams_range_neg1to1_observer
     default_float_qparams_observer
+    default_float_qparams_observer_4bit
+    default_symmetric_fixed_qparams_observer
+    per_channel_weight_observer_range_neg_127_to_127
+    weight_observer_range_neg_127_to_127
     AffineQuantizedObserverBase
     Granularity
     MappingType
@@ -324,17 +373,26 @@ during QAT.
     FakeQuantize
     FixedQParamsFakeQuantize
     FusedMovingAvgObsFakeQuantize
+    default_affine_fixed_qparams_fake_quant
+    default_dynamic_fake_quant
+    default_embedding_fake_quant
+    default_embedding_fake_quant_4bit
     default_fake_quant
-    default_weight_fake_quant
-    default_per_channel_weight_fake_quant
-    default_histogram_fake_quant
+    default_fixed_qparams_range_0to1_fake_quant
+    default_fixed_qparams_range_neg1to1_fake_quant
     default_fused_act_fake_quant
-    default_fused_wt_fake_quant
     default_fused_per_channel_wt_fake_quant
+    default_fused_wt_fake_quant
+    default_histogram_fake_quant
+    default_per_channel_weight_fake_quant
+    default_symmetric_fixed_qparams_fake_quant
+    default_weight_fake_quant
     disable_fake_quant
-    enable_fake_quant
     disable_observer
+    enable_fake_quant
     enable_observer
+    fused_per_channel_wt_fake_quant_range_neg_127_to_127
+    fused_wt_fake_quant_range_neg_127_to_127
 ```
 
 ## torch.ao.quantization.qconfig
@@ -353,6 +411,7 @@ to configure quantization settings for individual ops.
     :template: classtemplate.rst
 
     QConfig
+    QConfigAny
     default_qconfig
     default_debug_qconfig
     default_per_channel_qconfig
@@ -383,6 +442,20 @@ to configure quantization settings for individual ops.
     :nosignatures:
     :template: classtemplate.rst
 
+    get_default_compare_output_module_list
+    get_default_dynamic_quant_module_mappings
+    get_default_dynamic_sparse_quant_module_mappings
+    get_default_float_to_quantized_operator_mappings
+    get_default_qat_module_mappings
+    get_default_qconfig_propagation_list
+    get_default_static_quant_module_mappings
+    get_default_static_quant_reference_module_mappings
+    get_default_static_sparse_quant_module_mappings
+    get_dynamic_quant_module_class
+    get_embedding_qat_module_mappings
+    get_embedding_static_quant_module_mappings
+    get_quantized_operator
+    get_static_quant_module_class
     no_observer_set
 ```
 

--- a/docs/source/sparse.rst
+++ b/docs/source/sparse.rst
@@ -311,6 +311,16 @@ You can accelerate the linear layers in your model if the weights are already se
 
 .. autofunction:: torch.sparse.semi_structured.to_sparse_semi_structured
 
+.. currentmodule:: torch.sparse.semi_structured
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    SparseSemiStructuredTensorCUSPARSELT
+    SparseSemiStructuredTensorCUTLASS
+
+.. currentmodule:: torch
 
 .. _sparse-coo-docs:
 

--- a/docs/source/torch.compiler_api.md
+++ b/docs/source/torch.compiler_api.md
@@ -35,4 +35,8 @@ For a quick overview of `torch.compiler`, see {ref}`torch.compiler_overview`.
      skip_guard_on_globals_unsafe
      skip_all_guards_unsafe
      nested_compile_region
+     load_cache_artifacts
+     load_compiled_function
+     save_cache_artifacts
+     wrap_numpy
 ```

--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -982,7 +982,6 @@ Utilities
     result_type
     can_cast
     promote_types
-    read_vitals
     set_anomaly_enabled
     set_autocast_cache_enabled
     set_autocast_cpu_dtype
@@ -994,7 +993,6 @@ Utilities
     set_autocast_ipu_enabled
     set_autocast_xla_dtype
     set_autocast_xla_enabled
-    set_vital
     use_deterministic_algorithms
     are_deterministic_algorithms_enabled
     is_deterministic_algorithms_warn_only_enabled
@@ -1004,7 +1002,6 @@ Utilities
     get_float32_matmul_precision
     set_warn_always
     is_warn_always_enabled
-    vitals_enabled
     vmap
     _assert
     typename

--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -995,7 +995,6 @@ Utilities
     set_autocast_xla_dtype
     set_autocast_xla_enabled
     set_vital
-    unify_type_list
     use_deterministic_algorithms
     are_deterministic_algorithms_enabled
     is_deterministic_algorithms_warn_only_enabled

--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -957,8 +957,6 @@ Utilities
     autocast_increment_nesting
     clear_autocast_cache
     compiled_with_cxx11_abi
-    ErrorReport
-    FutureType
     get_autocast_cpu_dtype
     get_autocast_dtype
     get_autocast_gpu_dtype
@@ -997,8 +995,6 @@ Utilities
     set_autocast_xla_dtype
     set_autocast_xla_enabled
     set_vital
-    StreamObjType
-    TensorType
     unify_type_list
     use_deterministic_algorithms
     are_deterministic_algorithms_enabled
@@ -1013,6 +1009,11 @@ Utilities
     vmap
     _assert
     typename
+
+Type Information
+----------------
+.. autoclass:: TensorType
+    :no-members:
 
 Symbolic Numbers
 ----------------

--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -14,7 +14,11 @@ Tensors
     is_complex
     is_conj
     is_floating_point
+    is_inference
+    is_neg
     is_nonzero
+    is_same_size
+    is_signed
     set_default_dtype
     get_default_dtype
     set_default_device
@@ -71,14 +75,18 @@ Creation Ops
     eye
     empty
     empty_like
+    empty_permuted
+    empty_quantized
     empty_strided
     full
     full_like
     quantize_per_tensor
+    quantize_per_tensor_dynamic
     quantize_per_channel
     dequantize
     complex
     polar
+    scalar_tensor
     heaviside
 
 .. _indexing-slicing-joining:
@@ -90,53 +98,86 @@ Indexing, Slicing, Joining, Mutating Ops
     :nosignatures:
 
     adjoint
+    alias_copy
     argwhere
+    as_strided_copy
+    as_strided_scatter
     cat
+    ccol_indices_copy
+    col_indices_copy
     concat
     concatenate
     conj
     chunk
+    crow_indices_copy
+    detach
+    detach_copy
+    diagonal_copy
     dsplit
     column_stack
     dstack
+    expand_copy
+    fill
     gather
     hsplit
     hstack
     index_add
     index_copy
+    index_put_
     index_reduce
     index_select
+    indices_copy
+    masked_fill
     masked_select
     movedim
     moveaxis
     narrow
     narrow_copy
     nonzero
+    nonzero_static
     permute
+    permute_copy
+    put
     reshape
+    row_indices_copy
     row_stack
     select
+    select_copy
     scatter
     diagonal_scatter
     select_scatter
+    slice_copy
+    slice_inverse
     slice_scatter
     scatter_add
     scatter_reduce
     segment_reduce
     split
+    split_copy
+    split_with_sizes_copy
     squeeze
+    squeeze_copy
     stack
     swapaxes
     swapdims
     t
+    t_copy
     take
     take_along_dim
     tensor_split
     tile
     transpose
+    transpose_copy
     unbind
+    unbind_copy
+    unfold_copy
     unravel_index
     unsqueeze
+    unsqueeze_copy
+    values_copy
+    view_as_complex_copy
+    view_as_real_copy
+    view_copy
     vsplit
     vstack
     where
@@ -271,10 +312,13 @@ Parallelism
     :toctree: generated
     :nosignatures:
 
+    fork
     get_num_threads
+    init_num_threads
     set_num_threads
     get_num_interop_threads
     set_num_interop_threads
+    wait
 
 .. _torch-rst-local-disable-grad:
 
@@ -342,23 +386,36 @@ Pointwise Ops
     :nosignatures:
 
     abs
+    abs_
     absolute
     acos
+    acos_
     arccos
+    arccos_
     acosh
+    acosh_
     arccosh
+    arccosh_
     add
     addcdiv
     addcmul
     angle
     asin
+    asin_
     arcsin
+    arcsin_
     asinh
+    asinh_
     arcsinh
+    arcsinh_
     atan
+    atan_
     arctan
+    arctan_
     atanh
+    atanh_
     arctanh
+    arctanh_
     atan2
     arctan2
     bitwise_not
@@ -368,40 +425,63 @@ Pointwise Ops
     bitwise_left_shift
     bitwise_right_shift
     ceil
+    ceil_
     clamp
+    clamp_
+    clamp_max_
+    clamp_min_
     clip
+    clip_
     conj_physical
+    conj_physical_
     copysign
     cos
+    cos_
     cosh
+    cosh_
     deg2rad
+    deg2rad_
     div
     divide
     digamma
     erf
+    erf_
     erfc
+    erfc_
     erfinv
     exp
+    exp_
     exp2
+    exp2_
     expm1
+    expm1_
     fake_quantize_per_channel_affine
     fake_quantize_per_tensor_affine
+    fill_
     fix
+    fix_
     float_power
     floor
+    floor_
     floor_divide
     fmod
     frac
+    frac_
     frexp
     gradient
     imag
     ldexp
+    ldexp_
     lerp
     lgamma
     log
+    log_
     log10
+    log10_
     log1p
+    log1p_
     log2
+    log2_
     logaddexp
     logaddexp2
     logical_and
@@ -409,16 +489,21 @@ Pointwise Ops
     logical_or
     logical_xor
     logit
+    logit_
     hypot
     i0
+    i0_
     igamma
     igammac
     mul
     multiply
     mvlgamma
     nan_to_num
+    nan_to_num_
     neg
+    neg_
     negative
+    negative_
     nextafter
     polygamma
     positive
@@ -427,28 +512,43 @@ Pointwise Ops
     quantized_max_pool1d
     quantized_max_pool2d
     rad2deg
+    rad2deg_
     real
     reciprocal
+    reciprocal_
     remainder
     round
+    round_
     rsqrt
+    rsqrt_
     sigmoid
+    sigmoid_
     sign
     sgn
     signbit
     sin
+    sin_
     sinc
+    sinc_
     sinh
+    sinh_
     softmax
     sqrt
+    sqrt_
     square
+    square_
     sub
     subtract
     tan
+    tan_
     tanh
+    tanh_
     true_divide
     trunc
+    trunc_
     xlogy
+    xlogy_
+    zero_
 
 Reduction Ops
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -473,6 +573,8 @@ Reduction Ops
     nanmedian
     mode
     norm
+    norm_except_dim
+    nuclear_norm
     nansum
     prod
     quantile
@@ -547,10 +649,26 @@ Other Operations
     :toctree: generated
     :nosignatures:
 
+    adaptive_avg_pool1d
+    adaptive_max_pool1d
+    affine_grid_generator
+    alpha_dropout
+    alpha_dropout_
+    as_strided_
     atleast_1d
     atleast_2d
     atleast_3d
+    avg_pool1d
+    batch_norm_backward_elemt
+    batch_norm_backward_reduce
+    batch_norm_elemt
+    batch_norm_gather_stats
+    batch_norm_gather_stats_with_counts
+    batch_norm_stats
+    batch_norm_update_stats
+    bilinear
     bincount
+    binomial
     block_diag
     broadcast_tensors
     broadcast_to
@@ -558,45 +676,149 @@ Other Operations
     bucketize
     cartesian_prod
     cdist
+    celu_
+    channel_shuffle
+    choose_qparams_optimized
     clone
     combinations
+    conv1d
+    conv3d
+    conv_tbc
+    conv_transpose1d
+    conv_transpose2d
+    conv_transpose3d
+    convolution
     corrcoef
+    cosine_embedding_loss
+    cosine_similarity
     cov
     cross
+    ctc_loss
+    cudnn_affine_grid_generator
+    cudnn_batch_norm
+    cudnn_convolution
+    cudnn_convolution_add_relu
+    cudnn_convolution_relu
+    cudnn_convolution_transpose
+    cudnn_grid_sampler
+    cudnn_is_acceptable
     cummax
     cummin
     cumprod
     cumsum
+    detach_
     diag
     diag_embed
     diagflat
     diagonal
     diff
+    dropout_
     einsum
+    embedding
+    embedding_renorm_
+    fbgemm_linear_fp16_weight
+    fbgemm_linear_fp16_weight_fp32_activation
+    fbgemm_linear_int8_weight
+    fbgemm_linear_int8_weight_fp32_activation
+    fbgemm_linear_quantize_weight
+    fbgemm_pack_gemm_matrix_fp16
+    fbgemm_pack_quantized_matrix
+    feature_alpha_dropout
+    feature_alpha_dropout_
+    feature_dropout
+    feature_dropout_
     flatten
     flip
     fliplr
     flipud
-    kron
-    rot90
+    fused_moving_avg_obs_fake_quant
     gcd
+    gcd_
+    grid_sampler_2d
+    grid_sampler_3d
+    group_norm
+    gru
+    gru_cell
+    hardshrink
+    hinge_embedding_loss
     histc
     histogram
     histogramdd
-    meshgrid
+    instance_norm
+    int_repr
+    kl_div
+    kron
     lcm
+    lcm_
     logcumsumexp
+    lstm
+    lstm_cell
+    margin_ranking_loss
+    max_pool1d
+    max_pool3d
+    meshgrid
+    miopen_batch_norm
+    miopen_convolution
+    miopen_convolution_add_relu
+    miopen_convolution_relu
+    miopen_convolution_transpose
+    miopen_ctc_loss
+    miopen_depthwise_convolution
+    miopen_rnn
+    mkldnn_adaptive_avg_pool2d
+    mkldnn_convolution
+    mkldnn_linear_backward_weights
+    mkldnn_max_pool2d
+    mkldnn_max_pool3d
+    mkldnn_rnn_layer
+    native_batch_norm
+    native_channel_shuffle
+    native_group_norm
+    native_layer_norm
+    native_norm
+    pairwise_distance
+    pdist
+    pixel_unshuffle
+    poisson_nll_loss
+    prelu
+    q_per_channel_axis
+    q_per_channel_scales
+    q_per_channel_zero_points
+    q_scale
+    q_zero_point
+    quantized_gru_cell
+    quantized_lstm_cell
+    quantized_max_pool3d
+    quantized_rnn_relu_cell
+    quantized_rnn_tanh_cell
     ravel
+    relu_
     renorm
     repeat_interleave
+    resize_as_
+    resize_as_sparse_
+    rms_norm
+    rnn_relu
+    rnn_relu_cell
+    rnn_tanh
+    rnn_tanh_cell
     roll
+    rot90
+    rrelu
+    rrelu_
+    rsub
     searchsorted
+    selu
+    selu_
     tensordot
+    threshold
+    threshold_
     trace
     tril
     tril_indices
     triu
     triu_indices
+    triplet_margin_loss
     unflatten
     vander
     view_as_real
@@ -614,6 +836,7 @@ BLAS and LAPACK Operations
     addbmm
     addmm
     addmv
+    addmv_
     addr
     baddbmm
     bmm
@@ -622,8 +845,10 @@ BLAS and LAPACK Operations
     cholesky_inverse
     cholesky_solve
     dot
+    dsmm
     geqrf
     ger
+    hsmm
     inner
     inverse
     det
@@ -641,6 +866,8 @@ BLAS and LAPACK Operations
     ormqr
     outer
     pinverse
+    saddmm
+    spmm
     qr
     svd
     svd_lowrank
@@ -726,10 +953,53 @@ Utilities
     :toctree: generated
     :nosignatures:
 
+    autocast_decrement_nesting
+    autocast_increment_nesting
+    clear_autocast_cache
     compiled_with_cxx11_abi
+    ErrorReport
+    FutureType
+    get_autocast_cpu_dtype
+    get_autocast_dtype
+    get_autocast_gpu_dtype
+    get_autocast_ipu_dtype
+    get_autocast_xla_dtype
+    get_device
+    get_device_module
+    import_ir_module
+    import_ir_module_from_buffer
+    is_anomaly_check_nan_enabled
+    is_anomaly_enabled
+    is_autocast_cache_enabled
+    is_autocast_cpu_enabled
+    is_autocast_enabled
+    is_autocast_ipu_enabled
+    is_autocast_xla_enabled
+    is_distributed
+    is_vulkan_available
+    merge_type_from_type_comment
+    parse_ir
+    parse_schema
+    parse_type_comment
     result_type
     can_cast
     promote_types
+    read_vitals
+    set_anomaly_enabled
+    set_autocast_cache_enabled
+    set_autocast_cpu_dtype
+    set_autocast_cpu_enabled
+    set_autocast_dtype
+    set_autocast_enabled
+    set_autocast_gpu_dtype
+    set_autocast_ipu_dtype
+    set_autocast_ipu_enabled
+    set_autocast_xla_dtype
+    set_autocast_xla_enabled
+    set_vital
+    StreamObjType
+    TensorType
+    unify_type_list
     use_deterministic_algorithms
     are_deterministic_algorithms_enabled
     is_deterministic_algorithms_warn_only_enabled
@@ -738,8 +1008,8 @@ Utilities
     set_float32_matmul_precision
     get_float32_matmul_precision
     set_warn_always
-    get_device_module
     is_warn_always_enabled
+    vitals_enabled
     vmap
     _assert
     typename
@@ -759,6 +1029,8 @@ Symbolic Numbers
     :toctree: generated
     :nosignatures:
 
+    sym_constrain_range
+    sym_constrain_range_for_size
     sym_float
     sym_fresh_size
     sym_int
@@ -824,7 +1096,18 @@ Operator Tags
 .. py:module:: torch.utils.viz
 .. py:module:: torch.quasirandom
 .. py:module:: torch.return_types
+.. automodule:: torch.serialization
+
+.. currentmodule:: torch.serialization
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    StorageType
+
 .. py:module:: torch.serialization
+   :noindex:
 .. py:module:: torch.signal.windows.windows
 .. py:module:: torch.sparse.semi_structured
 .. py:module:: torch.storage

--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -1084,11 +1084,16 @@ Operator Tags
 .. This module is only used internally for ROCm builds.
 .. py:module:: torch.utils.hipify
 
-.. This module needs to be documented. Adding here in the meantime
-.. for tracking purposes
 .. py:module:: torch.utils.model_dump
 
 .. currentmodule:: torch.utils.model_dump
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    get_inline_skeleton
+    get_model_info
 
 .. py:module:: torch.utils.viz
 .. py:module:: torch.quasirandom

--- a/docs/source/user_guide/torch_compiler/export/api_reference.md
+++ b/docs/source/user_guide/torch_compiler/export/api_reference.md
@@ -12,7 +12,7 @@
    :exclude-members: __init__
 
 .. automodule:: torch.export.dynamic_shapes
-   :members: Dim, ShapesCollection, AdditionalInputs, refine_dynamic_shapes_from_suggested_fixes
+   :members: Dim, ShapesCollection, AdditionalInputs, dims, refine_dynamic_shapes_from_suggested_fixes
 
 .. autofunction:: torch.export.save
 

--- a/docs/source/utils.md
+++ b/docs/source/utils.md
@@ -84,6 +84,7 @@
     :toctree: generated
     :nosignatures:
 
+    add_dim3
     compute_stats
     extract_arguments
     file_add_header
@@ -92,6 +93,7 @@
     find_closure_group
     find_parentheses_group
     fix_static_global_kernels
+    get_hip_file_path
     hip_header_magic
     hipify
     is_caffe2_gpu_file
@@ -180,5 +182,16 @@ for tracking purposes -->
 .. py:module:: torch.utils.tensorboard.summary
 .. py:module:: torch.utils.tensorboard.writer
 .. py:module:: torch.utils.throughput_benchmark
+.. automodule:: torch.utils.weak
+
+.. currentmodule:: torch.utils.weak
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    TensorWeakRef
+
 .. py:module:: torch.utils.weak
+   :noindex:
 ```

--- a/docs/source/utils.md
+++ b/docs/source/utils.md
@@ -155,14 +155,12 @@ for tracking purposes -->
 .. py:module:: torch.utils.data.datapipes.iter.routeddecoder
 .. py:module:: torch.utils.data.datapipes.iter.selecting
 .. py:module:: torch.utils.data.datapipes.iter.sharding
-.. py:module:: torch.utils.data.datapipes.iter.streamreader
 .. py:module:: torch.utils.data.datapipes.iter.utils
 .. py:module:: torch.utils.data.datapipes.map.callable
 .. py:module:: torch.utils.data.datapipes.map.combinatorics
 .. py:module:: torch.utils.data.datapipes.map.combining
 .. py:module:: torch.utils.data.datapipes.map.grouping
 .. py:module:: torch.utils.data.datapipes.map.utils
-.. py:module:: torch.utils.data.datapipes.utils.common
 .. py:module:: torch.utils.data.datapipes.utils.decoder
 .. py:module:: torch.utils.data.datapipes.utils.snapshot
 .. py:module:: torch.utils.data.dataset

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -3669,7 +3669,7 @@ Keyword args:
         than the total number of non-zero elements. Default is `-1` to represent
         invalid index.
 
-Example:
+Example::
 
     # Example 1: Padding
     >>> input_tensor = torch.tensor([[1, 0], [3, 2]])

--- a/torch/ao/quantization/backend_config/utils.py
+++ b/torch/ao/quantization/backend_config/utils.py
@@ -104,13 +104,15 @@ def get_fusion_pattern_to_root_node_getter(
     backend_config: BackendConfig,
 ) -> dict[Pattern, Callable]:
     """Get a map from fusion pattern to a function that returns the root node
-    from the fusion pattern, e.g. the most common one is:
-    def get_root_node(node_pattern):
-        while not isinstance(node_pattern[-1], Node):
-            node_pattern = node_pattern[-1]
-        return node_pattern[-1]
+    from the fusion pattern, e.g. the most common one is::
+
+        def get_root_node(node_pattern):
+            while not isinstance(node_pattern[-1], Node):
+                node_pattern = node_pattern[-1]
+            return node_pattern[-1]
+
     This can work for all patterns whose root node is the "last node" in the pattern,
-    e.g. (torch.add, MatchAllNode, (torch.ReLU, torch.Conv2d))
+    e.g. ``(torch.add, MatchAllNode, (torch.ReLU, torch.Conv2d))``.
     """
     root_node_getter_mapping: dict[Pattern, Callable] = {}
     for pattern, config in backend_config._pattern_complex_format_to_config.items():
@@ -125,15 +127,17 @@ def get_fusion_pattern_to_extra_inputs_getter(
     """Get a map from fusion pattern to a function that returns extra input nodes
     from the fusion pattern, in the order required by the root node. This is optional,
     if not specified, we will not copy over any extra inputs for the root node.
-    Example:
-    # Let's say we have the pattern (torch.add, MatchAllNode, (torch.nn.BatchNorm2d, torch.nn.Conv2d))
-    # and root node is torch.nn.Conv2d, and the node in MatchAllNode would be an extra
-    # argument to the fused module, we can unpack the pattern and return the node at
-    # MatchAllNode here
-    # we can implement extra_inputs_getter as follows:
-    def extra_inputs_getter(pattern) -> List[Any]:
-        add, extra_input, conv_pattern = pattern
-        return [extra_input]
+
+    Example::
+
+        # Let's say we have the pattern (torch.add, MatchAllNode, (torch.nn.BatchNorm2d, torch.nn.Conv2d))
+        # and root node is torch.nn.Conv2d, and the node in MatchAllNode would be an extra
+        # argument to the fused module, we can unpack the pattern and return the node at
+        # MatchAllNode here
+        # we can implement extra_inputs_getter as follows:
+        def extra_inputs_getter(pattern) -> List[Any]:
+            add, extra_input, conv_pattern = pattern
+            return [extra_input]
     """
     extra_inputs_getter_mapping: dict[Pattern, Callable] = {}
     for pattern, config in backend_config._pattern_complex_format_to_config.items():

--- a/torch/ao/quantization/fx/utils.py
+++ b/torch/ao/quantization/fx/utils.py
@@ -118,24 +118,26 @@ def node_arg_is_bias(node: Node, arg: Any) -> bool:
 def get_custom_module_class_keys(
     custom_module_mapping: dict[QuantType, dict[type, type]],
 ) -> list[Any]:
-    r"""Get all the unique custom module keys in the custom config dict
-    e.g.
-    Input:
-    {
-        QuantType.STATIC: {
-            CustomModule1: ObservedCustomModule
-        },
-        QuantType.DYNAMIC: {
-            CustomModule2: DynamicObservedCustomModule
-        },
-        QuantType.WEIGHT_ONLY: {
-            CustomModule3: WeightOnlyObservedCustomModule
-        },
-    }
+    r"""Get all the unique custom module keys in the custom config dict.
 
-    Output:
-    # extract the keys across all inner STATIC, DYNAMIC, and WEIGHT_ONLY dicts
-    [CustomModule1, CustomModule2, CustomModule3]
+    Example input::
+
+        {
+            QuantType.STATIC: {
+                CustomModule1: ObservedCustomModule
+            },
+            QuantType.DYNAMIC: {
+                CustomModule2: DynamicObservedCustomModule
+            },
+            QuantType.WEIGHT_ONLY: {
+                CustomModule3: WeightOnlyObservedCustomModule
+            },
+        }
+
+    Example output::
+
+        # extract the keys across all inner STATIC, DYNAMIC, and WEIGHT_ONLY dicts
+        [CustomModule1, CustomModule2, CustomModule3]
     """
     # using set to dedup
     float_custom_module_classes: set[Any] = set()

--- a/torch/ao/quantization/fx/utils.py
+++ b/torch/ao/quantization/fx/utils.py
@@ -123,15 +123,9 @@ def get_custom_module_class_keys(
     Example input::
 
         {
-            QuantType.STATIC: {
-                CustomModule1: ObservedCustomModule
-            },
-            QuantType.DYNAMIC: {
-                CustomModule2: DynamicObservedCustomModule
-            },
-            QuantType.WEIGHT_ONLY: {
-                CustomModule3: WeightOnlyObservedCustomModule
-            },
+            QuantType.STATIC: {CustomModule1: ObservedCustomModule},
+            QuantType.DYNAMIC: {CustomModule2: DynamicObservedCustomModule},
+            QuantType.WEIGHT_ONLY: {CustomModule3: WeightOnlyObservedCustomModule},
         }
 
     Example output::

--- a/torch/ao/quantization/utils.py
+++ b/torch/ao/quantization/utils.py
@@ -746,8 +746,7 @@ def get_fqn_to_example_inputs(
     arguments as positional arguments and fill in the missing keyword args with default
     values, e.g. if we have a forward function::
 
-        def forward(self, x, key1=3, key2=3):
-            ...
+        def forward(self, x, key1=3, key2=3): ...
 
     and we call it with ``self.submodule(x, key2=6)``
     we'll get ``example_inputs: (x, 3, 6)``

--- a/torch/ao/quantization/utils.py
+++ b/torch/ao/quantization/utils.py
@@ -241,14 +241,17 @@ def get_swapped_custom_module_class(
     custom_module, custom_module_class_mapping, qconfig
 ):
     """Get the observed/quantized custom module class that we need
-    to swap `custom_module` to
+    to swap ``custom_module`` to.
+
     Input:
-        custom_module: input, can be an instance of either a float or observed custom module
-        custom_module_class_mapping: the float to observed or observed to quantized custom module class mapping
-        qconfig: qconfig configured for the custom module
+
+    - custom_module: input, can be an instance of either a float or observed custom module
+    - custom_module_class_mapping: the float to observed or observed to quantized custom module class mapping
+    - qconfig: qconfig configured for the custom module
 
     Output:
-        corresponding observed/quantized custom module class for input custom module instance
+
+    Corresponding observed/quantized custom module class for input custom module instance.
     """
     quant_type = get_quant_type(qconfig)
     class_mapping = custom_module_class_mapping.get(quant_type, {})
@@ -733,24 +736,25 @@ def get_fqn_to_example_inputs(
 ) -> dict[str, tuple[Any, ...]]:
     """Given a model and its example inputs, return a dictionary from
     fully qualified name of submodules to example_inputs for that submodule,
-    e.g. {"linear1": (tensor1,), "linear2": (tensor2,), "sub": (tensor3,),
-          "sub.linear1": (tensor4,), ...}
+    e.g. ``{"linear1": (tensor1,), "linear2": (tensor2,), "sub": (tensor3,),
+    "sub.linear1": (tensor4,), ...}``
 
     Used to make quantizing submodules easier now that FX Graph Mode Quantization requires
     example inputs.
 
     Also works for keyword arguments with default values, we would flatten keyword
     arguments as positional arguments and fill in the missing keyword args with default
-    values, e.g. if we have a forward function:
-    def forward(self, x, key1=3, key2=3):
-        ...
+    values, e.g. if we have a forward function::
 
-    and we call it with self.submodule(x, key2=6)
-    we'll get example_inputs: (x, 3, 6)
+        def forward(self, x, key1=3, key2=3):
+            ...
 
-    user can also override `key1` with positional arguments as well:
-    for self.submodule(x, 5, key2=6)
-    we'll get: (x, 5, 6)
+    and we call it with ``self.submodule(x, key2=6)``
+    we'll get ``example_inputs: (x, 3, 6)``
+
+    user can also override ``key1`` with positional arguments as well:
+    for ``self.submodule(x, 5, key2=6)``
+    we'll get: ``(x, 5, 6)``
 
     variable positional arguments and variable positional keyword arguments in forward
     function are not supported currently, so please make sure no submodules is using

--- a/torch/compiler/__init__.py
+++ b/torch/compiler/__init__.py
@@ -436,8 +436,8 @@ def cudagraph_mark_step_begin():
 
 
 def wrap_numpy(fn):
-    r"""Decorator that turns a function from ``np.ndarray``s to ``np.ndarray``s into a function
-    from ``torch.Tensor``s to ``torch.Tensor``s.
+    r"""Decorator that turns a function from ``np.ndarray``\ s to ``np.ndarray``\ s into a function
+    from ``torch.Tensor``\ s to ``torch.Tensor``\ s.
 
     It is designed to be used with :func:`torch.compile` with ``fullgraph=True``. It allows to
     compile a NumPy function as if it were a PyTorch function. This allows you to run NumPy code

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -4382,22 +4382,26 @@ def all_gather_coalesced(
         Async work handle, if async_op is set to True.
         None, if not async_op or if not part of the group
 
-    Example:
-        we have 2 process groups, 2 ranks.
-        rank 0 passes:
-            input_tensor_list = [[[1, 1], [1, 1]], [2], [3, 3]]
-            output_tensor_lists =
-               [[[[-1, -1], [-1, -1]], [-1], [-1, -1]],
-                [[[-1, -1], [-1, -1]], [-1], [-1, -1]]]
-        rank 1 passes:
-            input_tensor_list = [[[3, 3], [3, 3]], [5], [1, 1]]
-            output_tensor_lists =
-               [[[[-1, -1], [-1, -1]], [-1], [-1, -1]],
-                [[[-1, -1], [-1, -1]], [-1], [-1, -1]]]
-        both rank 0 and 1 get:
-            output_tensor_lists =
-               [[[1, 1], [1, 1]], [2], [3, 3]],
-                [[3, 3], [3, 3]], [5], [1, 1]]].
+    Example::
+
+        # we have 2 process groups, 2 ranks.
+        # rank 0 passes:
+        input_tensor_list = [[[1, 1], [1, 1]], [2], [3, 3]]
+        output_tensor_lists = [
+            [[[-1, -1], [-1, -1]], [-1], [-1, -1]],
+            [[[-1, -1], [-1, -1]], [-1], [-1, -1]],
+        ]
+        # rank 1 passes:
+        input_tensor_list = [[[3, 3], [3, 3]], [5], [1, 1]]
+        output_tensor_lists = [
+            [[[-1, -1], [-1, -1]], [-1], [-1, -1]],
+            [[[-1, -1], [-1, -1]], [-1], [-1, -1]],
+        ]
+        # both rank 0 and 1 get:
+        output_tensor_lists = [
+            [[[1, 1], [1, 1]], [2], [3, 3]],
+            [[[3, 3], [3, 3]], [5], [1, 1]],
+        ]
 
     WARNING: at this time individual shape checking is not implemented across nodes.
     For example, if the rank 0 node passes [torch.rand(4), torch.rand(2)] and the

--- a/torch/distributions/utils.py
+++ b/torch/distributions/utils.py
@@ -29,7 +29,7 @@ def broadcast_all(*values: Tensor | Number) -> tuple[Tensor, ...]:
     Given a list of values (possibly containing numbers), returns a list where each
     value is broadcasted based on the following rules:
 
-    - `torch.*Tensor` instances are broadcasted as per :ref:`_broadcasting-semantics`.
+    - `torch.*Tensor` instances are broadcasted as per :ref:`broadcasting-semantics`.
     - Number instances (scalars) are upcast to tensors having
       the same size and type as the first tensor passed to `values`.  If all the
       values are scalars, then they are upcasted to scalar Tensors.

--- a/torch/distributions/utils.py
+++ b/torch/distributions/utils.py
@@ -28,10 +28,11 @@ def broadcast_all(*values: Tensor | Number) -> tuple[Tensor, ...]:
     r"""
     Given a list of values (possibly containing numbers), returns a list where each
     value is broadcasted based on the following rules:
-      - `torch.*Tensor` instances are broadcasted as per :ref:`_broadcasting-semantics`.
-      - Number instances (scalars) are upcast to tensors having
-        the same size and type as the first tensor passed to `values`.  If all the
-        values are scalars, then they are upcasted to scalar Tensors.
+
+    - `torch.*Tensor` instances are broadcasted as per :ref:`_broadcasting-semantics`.
+    - Number instances (scalars) are upcast to tensors having
+      the same size and type as the first tensor passed to `values`.  If all the
+      values are scalars, then they are upcasted to scalar Tensors.
 
     Args:
         values (list of `Number`, `torch.*Tensor` or objects implementing __torch_function__)

--- a/torch/fx/experimental/graph_gradual_typechecker.py
+++ b/torch/fx/experimental/graph_gradual_typechecker.py
@@ -498,6 +498,7 @@ def maxpool2d_check(typ: Any, module_instance: Any) -> TensorType:
 def maxpool2d_inference_rule(n: Node, module_instance: Any) -> Any:
     """
     Given a MaxPool2D instance and a node check the following conditions:
+
     - Input size matches size 3 or 4
     - Current node type is consistent with the output type we will calculate
     - Input size matches output size and the last two dimensions of the output

--- a/torch/fx/experimental/migrate_gradual_types/constraint_generator.py
+++ b/torch/fx/experimental/migrate_gradual_types/constraint_generator.py
@@ -1505,12 +1505,12 @@ def add_layer_norm_constraints(
     input_dim: list[DVar], normalized_dim: list[int]
 ) -> list[Constraint]:
     """
-    The constraints say that the type has te form: [*, 1024, 1024]
-     while the normalized_dim have the form [1024, 1024]
+    The constraints say that the type has the form: ``[*, 1024, 1024]``
+    while the normalized_dim have the form ``[1024, 1024]``.
+
     Args:
         input_dim: Input shape of layer norm
         normalized_dim: normalized_dim parameter of the module instance
-
     """
 
     # in this case we return false since there's a pattern mismatch

--- a/torch/fx/operator_schemas.py
+++ b/torch/fx/operator_schemas.py
@@ -399,7 +399,7 @@ def normalize_function(
     signature and return exclusively kwargs in positional order if
     `normalize_to_only_use_kwargs` is True.
     Also populates default values. Does not support positional-only
-    parameters or varargs parameters (*args, **kwargs). Does not support modules.
+    parameters or varargs parameters (``*args``, ``**kwargs``). Does not support modules.
 
     May require `arg_types` and `kwarg_types` in order to disambiguate overloads.
 
@@ -538,7 +538,7 @@ def normalize_module(
     signature and return exclusively kwargs in positional order if
     `normalize_to_only_use_kwargs` is True.
     Also populates default values. Does not support positional-only
-    parameters or varargs parameters (*args, **kwargs).
+    parameters or varargs parameters (``*args``, ``**kwargs``).
 
     Args:
         root (nn.Module): root module upon which we query modules

--- a/torch/fx/passes/shape_prop.py
+++ b/torch/fx/passes/shape_prop.py
@@ -16,8 +16,7 @@ __all__ = ["TensorMetadata", "ShapeProp"]
 
 @compatibility(is_backward_compatible=True)
 class TensorMetadata(NamedTuple):
-    # TensorMetadata is a structure containing pertinent information
-    # about a tensor within a PyTorch program.
+    """A structure containing pertinent information about a tensor within a PyTorch program."""
 
     # General Tensor metadata
     shape: torch.Size

--- a/torch/fx/passes/utils/matcher_with_name_node_map_utils.py
+++ b/torch/fx/passes/utils/matcher_with_name_node_map_utils.py
@@ -50,18 +50,17 @@ class SubgraphMatcherWithNameNodeMap(SubgraphMatcher):
     initialization since we need to modify the graph (which requires `recompile` the GraphModule)
 
     Example::
+
         def pattern(x, weight):
             conv = F.conv2d(x, weight)
             relu = F.relu(conv)
             return relu, {"conv": conv, "relu": relu}
-
 
         def target_graph(x, weight):
             conv = F.conv2d(x, weight)
             relu = F.relu(conv)
             relu *= 2
             return relu
-
 
         pattern_gm = export(pattern, example_inputs).module()
         target_gm = export(target_graph, example_inputs).module()
@@ -93,21 +92,20 @@ class SubgraphMatcherWithNameNodeMap(SubgraphMatcher):
     def match(self, graph: Graph, node_name_match: str = "") -> list[InternalMatch]:
         """The returned InternalMatch will have name_node_map populated with a map
         from node name (str) to the target node, e.g.
-        {"conv": target_conv_ndoe, "relu": target_relu_node}
+        ``{"conv": target_conv_ndoe, "relu": target_relu_node}``
 
-        this requires the pattern graph returns an additional
-        output of node name to node, e.g. instead of:
-        ```
-        def pattern(...):
-            ...
-            return relu
-        ```
-        we should do:
-        ```
-        def pattern(...):
-            ...
-            return relu, {"conv": conv, "relu": relu}
-        ``` instead
+        This requires the pattern graph returns an additional
+        output of node name to node, e.g. instead of::
+
+            def pattern(...):
+                ...
+                return relu
+
+        we should do::
+
+            def pattern(...):
+                ...
+                return relu, {"conv": conv, "relu": relu}
         """
         internal_matches = super().match(graph, node_name_match)
         for internal_match in internal_matches:

--- a/torch/fx/passes/utils/matcher_with_name_node_map_utils.py
+++ b/torch/fx/passes/utils/matcher_with_name_node_map_utils.py
@@ -56,11 +56,13 @@ class SubgraphMatcherWithNameNodeMap(SubgraphMatcher):
             relu = F.relu(conv)
             return relu, {"conv": conv, "relu": relu}
 
+
         def target_graph(x, weight):
             conv = F.conv2d(x, weight)
             relu = F.relu(conv)
             relu *= 2
             return relu
+
 
         pattern_gm = export(pattern, example_inputs).module()
         target_gm = export(target_graph, example_inputs).module()

--- a/torch/fx/traceback.py
+++ b/torch/fx/traceback.py
@@ -73,6 +73,8 @@ def _register_fx_metadata(module_name: str, metadata: dict[str, Any]) -> None:
 
 @compatibility(is_backward_compatible=False)
 class NodeSourceAction(Enum):
+    """Enum representing the action taken to produce a node in provenance tracking."""
+
     CREATE = "create"
     REPLACE = "replace"
 

--- a/torch/sparse/semi_structured.py
+++ b/torch/sparse/semi_structured.py
@@ -470,9 +470,11 @@ class SparseSemiStructuredTensorCUTLASS(SparseSemiStructuredTensor):
             )
 
             pruned = _sparse_semi_structured_tile(dense)
-            packed_cutlass, meta_cutlass = sparse_semi_structured_from_dense_cutlass(pruned)
-            packed_t_cutlass, meta_t_cutlass = sparse_semi_structured_from_dense_cutlass(
-                pruned.t().contiguous()
+            packed_cutlass, meta_cutlass = sparse_semi_structured_from_dense_cutlass(
+                pruned
+            )
+            packed_t_cutlass, meta_t_cutlass = (
+                sparse_semi_structured_from_dense_cutlass(pruned.t().contiguous())
             )
             bitmask = _compute_compressed_swizzled_bitmask(pruned)
 

--- a/torch/sparse/semi_structured.py
+++ b/torch/sparse/semi_structured.py
@@ -446,44 +446,44 @@ class SparseSemiStructuredTensorCUTLASS(SparseSemiStructuredTensor):
         pruned dense tensor.
         Since we cannot transpose the compressed representations, we store both for the fw/bw pass respectively.
 
-        Finally, this function also computes a compressed swizzled bitmask that encodes the sparsity pattern
+        Finally, this function also computes a compressed swizzled bitmask that encodes the sparsity pattern.
         This can be used in the backward pass to mask the gradients.
 
-        [9 1 7 4]                       [9 0 7 0]
-        [1 2 3 0]                       [0 2 0 0]
-        [8 3 5 4] -> prune 4x4 tile  -> [8 0 0 4] -> pack to CUTLASS semi-structured -> packed
-        [1 2 6 2]                       [0 0 6 2]                                    -> metadata
+        ::
 
-                                                  -> pack to transposed CUTLASS      -> packed_t
-                                                     semi-structured representation  -> metadata_t
+            [9 1 7 4]                       [9 0 7 0]
+            [1 2 3 0]                       [0 2 0 0]
+            [8 3 5 4] -> prune 4x4 tile  -> [8 0 0 4] -> pack to CUTLASS semi-structured -> packed
+            [1 2 6 2]                       [0 0 6 2]                                    -> metadata
 
-                                                  -> compute swizzled bitmask        -> compressed_swizzled_bitmask
+                                                      -> pack to transposed CUTLASS      -> packed_t
+                                                         semi-structured representation  -> metadata_t
 
+                                                      -> compute swizzled bitmask        -> compressed_swizzled_bitmask
 
-        The equivalent PyTorch code to create the same five outputs from the dense tensor can be found below:
-        ```
-        from torch.sparse import SparseSemiStructuredTensorCUTLASS
-        from torch.sparse._semi_structured_conversions import (
-            _sparse_semi_structured_tile,
-            _compute_compressed_swizzled_bitmask,
-        )
+        The equivalent PyTorch code to create the same five outputs from the dense tensor can be found below::
 
-        pruned = _sparse_semi_structured_tile(dense)
-        packed_cutlass, meta_cutlass = sparse_semi_structured_from_dense_cutlass(pruned)
-        packed_t_cutlass, meta_t_cutlass = sparse_semi_structured_from_dense_cutlass(
-            pruned.t().contiguous()
-        )
-        bitmask = _compute_compressed_swizzled_bitmask(pruned)
+            from torch.sparse import SparseSemiStructuredTensorCUTLASS
+            from torch.sparse._semi_structured_conversions import (
+                _sparse_semi_structured_tile,
+                _compute_compressed_swizzled_bitmask,
+            )
 
-        SparseSemiStructuredTensorCUTLASS(
-            dense.shape,
-            packed_cutlass,
-            meta_cutlass,
-            packed_t_cutlass,
-            meta_t_cutlass,
-            bitmask,
-        )
-        ```
+            pruned = _sparse_semi_structured_tile(dense)
+            packed_cutlass, meta_cutlass = sparse_semi_structured_from_dense_cutlass(pruned)
+            packed_t_cutlass, meta_t_cutlass = sparse_semi_structured_from_dense_cutlass(
+                pruned.t().contiguous()
+            )
+            bitmask = _compute_compressed_swizzled_bitmask(pruned)
+
+            SparseSemiStructuredTensorCUTLASS(
+                dense.shape,
+                packed_cutlass,
+                meta_cutlass,
+                packed_t_cutlass,
+                meta_t_cutlass,
+                bitmask,
+            )
         """
         # We can either pack to the CUTLASS or cuSPARSELt representation, depending on the use_cutlass flag.
         (
@@ -593,34 +593,34 @@ class SparseSemiStructuredTensorCUSPARSELT(SparseSemiStructuredTensor):
 
         The only functional difference is that cuSPARSELt stores `metadata` and `packed` together into a single tensor.
 
-        [9 1 7 4]                       [9 0 7 0]
-        [1 2 3 0]                       [0 2 0 0]
-        [8 3 5 4] -> prune 4x4 tile  -> [8 0 0 4] -> pack to cuSPARSELT semi-structured -> packed
-        [1 2 6 2]                       [0 0 6 2]
+        ::
 
-                                                  -> pack to transposed cuSPARSELt      -> packed_t
-                                                     semi-structured representation
+            [9 1 7 4]                       [9 0 7 0]
+            [1 2 3 0]                       [0 2 0 0]
+            [8 3 5 4] -> prune 4x4 tile  -> [8 0 0 4] -> pack to cuSPARSELT semi-structured -> packed
+            [1 2 6 2]                       [0 0 6 2]
 
-                                                  -> compute swizzled bitmask           -> compressed_swizzled_bitmask
+                                                      -> pack to transposed cuSPARSELt      -> packed_t
+                                                         semi-structured representation
 
+                                                      -> compute swizzled bitmask           -> compressed_swizzled_bitmask
 
-        The equivalent PyTorch code to create the same three outputs from the dense tensor can be found below:
-        ```
-        from torch.sparse import SparseSemiStructuredTensorCUSPARSELT
-        from torch.sparse._semi_structured_conversions import (
-            _sparse_semi_structured_tile,
-            _compute_compressed_swizzled_bitmask,
-        )
+        The equivalent PyTorch code to create the same three outputs from the dense tensor can be found below::
 
-        pruned = _sparse_semi_structured_tile(dense)
-        packed_cusparselt = torch._cslt_compress(pruned)
-        packed_t_cusparselt = torch._cslt_compress(pruned.t().contiguous())
-        bitmask = _compute_compressed_swizzled_bitmask(pruned)
+            from torch.sparse import SparseSemiStructuredTensorCUSPARSELT
+            from torch.sparse._semi_structured_conversions import (
+                _sparse_semi_structured_tile,
+                _compute_compressed_swizzled_bitmask,
+            )
 
-        SparseSemiStructuredTensorCUSPARSELT(
-            dense.shape, packed_cutlass, None, packed_t_cutlass, None, bitmask
-        )
-        ```
+            pruned = _sparse_semi_structured_tile(dense)
+            packed_cusparselt = torch._cslt_compress(pruned)
+            packed_t_cusparselt = torch._cslt_compress(pruned.t().contiguous())
+            bitmask = _compute_compressed_swizzled_bitmask(pruned)
+
+            SparseSemiStructuredTensorCUSPARSELT(
+                dense.shape, packed_cutlass, None, packed_t_cutlass, None, bitmask
+            )
         """
         (
             packed,


### PR DESCRIPTION
## Author Notes
_Testing CI — do not review yet._

## Agent Notes
Sphinx's built-in coverage extension uses `inspect.isfunction()` and `inspect.isclass()` to discover which public APIs need documentation. Decorated functions (e.g. `@cache`, `@lru_cache`, `@deprecated`) return wrapper objects that fail these checks, silently bypassing coverage.

This adds a cross-check in `coverage_post_process` that iterates each documented module's `__all__` and verifies every callable entry appears in Sphinx's documented objects dict. If any are missing, the build fails with a clear error listing the undocumented APIs.