### PR TITLE
[Dispatcher]Add TorchDispatchMode improvement analysis

### DIFF
--- a/benchmarks/proxy_dispatch_latency.py
+++ b/benchmarks/proxy_dispatch_latency.py
@@ -1,0 +1,240 @@
+"""
+Measure proxy_call dispatch latency: bypass (fake_mode.dispatch) vs normal (func()).
+
+Runs a simple MLP (linear -> relu -> linear) through both make_fx and torch.compile,
+measuring cold start and warm start separately with mean/p50/p90 stats.
+
+Usage:
+    python benchmarks/proxy_dispatch_latency.py
+    python benchmarks/proxy_dispatch_latency.py --size 2048 --iterations 50
+"""
+
+import argparse
+import statistics
+import time
+
+import torch
+import torch.nn as nn
+from torch.fx.experimental.proxy_tensor import make_fx
+from torch.utils._stats import simple_call_counter
+
+
+def mlp(x, w1, b1, w2, b2):
+    h = torch.nn.functional.linear(x, w1, b1)
+    h = torch.nn.functional.relu(h)
+    return torch.nn.functional.linear(h, w2, b2)
+
+
+class MLPModule(nn.Module):
+    def __init__(self, size):
+        super().__init__()
+        self.fc1 = nn.Linear(size, size)
+        self.fc2 = nn.Linear(size, size)
+
+    def forward(self, x):
+        return self.fc2(torch.nn.functional.relu(self.fc1(x)))
+
+
+def disable_bypass():
+    patched = []
+    ns = torch.ops.aten
+    for op_name in dir(ns):
+        op = getattr(ns, op_name, None)
+        if op is None or not hasattr(op, "overloads"):
+            continue
+        for ol_name in op.overloads():
+            ol = getattr(op, ol_name, None)
+            if ol and getattr(ol, "_can_bypass_proxy_dispatch", False):
+                ol._can_bypass_proxy_dispatch = False
+                patched.append(ol)
+    return patched
+
+
+def restore_bypass(patched):
+    for ol in patched:
+        ol._can_bypass_proxy_dispatch = True
+
+
+# -- make_fx timing --
+
+def timed_make_fx(fn, args, tracing_mode):
+    simple_call_counter.clear()
+    start = time.perf_counter_ns()
+    gm = make_fx(fn, tracing_mode=tracing_mode)(*args)
+    elapsed = time.perf_counter_ns() - start
+    del gm
+    return elapsed / 1000
+
+
+# -- torch.compile timing --
+
+def timed_compile(model, example_input, backend="aot_eager"):
+    torch.compiler.reset()
+    compiled = torch.compile(model, backend=backend)
+    start = time.perf_counter_ns()
+    compiled(example_input)
+    elapsed = time.perf_counter_ns() - start
+    return elapsed / 1000
+
+
+def fmt_row(label, times):
+    s = sorted(times)
+    p90_idx = min(int(len(s) * 0.9), len(s) - 1)
+    return (
+        f"{label:<10}"
+        f" {statistics.mean(times):>10.1f}"
+        f" {statistics.median(times):>10.1f}"
+        f" {s[p90_idx]:>10.1f}"
+        f" {s[0]:>10.1f}"
+        f" {s[-1]:>10.1f}"
+    )
+
+
+HEADER = f"{'Mode':<10} {'Mean (µs)':>10} {'P50 (µs)':>10} {'P90 (µs)':>10} {'Min':>10} {'Max':>10}"
+SEP = "-" * len(HEADER)
+
+
+def print_section(title, bypass_times, normal_times, count):
+    print()
+    print("=" * len(HEADER))
+    print(f"{title} ({count} runs, interleaved)")
+    print("=" * len(HEADER))
+    print(HEADER)
+    print(SEP)
+    print(fmt_row("bypass", bypass_times))
+    print(fmt_row("normal", normal_times))
+    diff = (statistics.mean(normal_times) - statistics.mean(bypass_times)) / statistics.mean(normal_times) * 100
+    print(f"  diff: {diff:>+.1f}%  ({'bypass faster' if diff > 0 else 'bypass slower'})")
+
+
+def run_interleaved(trace_fn_bypass, trace_fn_normal, count):
+    """Run bypass/normal interleaved to reduce ordering bias."""
+    bypass_times = []
+    normal_times = []
+    for i in range(count):
+        if i % 2 == 0:
+            bypass_times.append(trace_fn_bypass())
+            normal_times.append(trace_fn_normal())
+        else:
+            normal_times.append(trace_fn_normal())
+            bypass_times.append(trace_fn_bypass())
+    return bypass_times, normal_times
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Proxy dispatch latency benchmark")
+    parser.add_argument("--size", type=int, default=4096, help="MLP hidden size")
+    parser.add_argument("--batch", type=int, default=32, help="Batch size")
+    parser.add_argument("--iterations", type=int, default=30, help="Warm traces per mode")
+    parser.add_argument("--cold-runs", type=int, default=10, help="Cold-start repetitions")
+    parser.add_argument("--warmup", type=int, default=5, help="Warmup traces before warm measurement")
+    parser.add_argument("--tracing-mode", default="fake", choices=["fake", "symbolic"])
+    parser.add_argument("--compile-backend", default="aot_eager",
+                        help="torch.compile backend (default: aot_eager)")
+    args = parser.parse_args()
+
+    x = torch.randn(args.batch, args.size)
+    w1 = torch.randn(args.size, args.size)
+    b1 = torch.randn(args.size)
+    w2 = torch.randn(args.size, args.size)
+    b2 = torch.randn(args.size)
+    fn_args = (x, w1, b1, w2, b2)
+    model = MLPModule(args.size).eval()
+
+    print(f"MLP: linear({args.size}) -> relu -> linear({args.size})")
+    print(f"batch={args.batch}, warmup={args.warmup}, iterations={args.iterations}, "
+          f"cold_runs={args.cold_runs}")
+    print(f"make_fx mode={args.tracing_mode}, compile backend={args.compile_backend}")
+    print()
+
+    patched_ops = None
+
+    def make_fx_bypass():
+        return timed_make_fx(mlp, fn_args, args.tracing_mode)
+
+    def make_fx_normal():
+        nonlocal patched_ops
+        patched_ops = disable_bypass()
+        t = timed_make_fx(mlp, fn_args, args.tracing_mode)
+        restore_bypass(patched_ops)
+        return t
+
+    def compile_bypass():
+        return timed_compile(model, x, args.compile_backend)
+
+    def compile_normal():
+        nonlocal patched_ops
+        patched_ops = disable_bypass()
+        t = timed_compile(model, x, args.compile_backend)
+        restore_bypass(patched_ops)
+        return t
+
+    # ===== make_fx =====
+    print("--- make_fx ---")
+
+    # Cold
+    print("Measuring cold starts (interleaved)...")
+    mfx_cold_bypass, mfx_cold_normal = run_interleaved(
+        make_fx_bypass, make_fx_normal, args.cold_runs
+    )
+
+    # Warm
+    print("Warming up...")
+    for _ in range(args.warmup):
+        make_fx_bypass()
+    print("Running bypass (warm)...")
+    mfx_warm_bypass = [make_fx_bypass() for _ in range(args.iterations)]
+
+    # Grab counter snapshot
+    bypass_ok = simple_call_counter.get("proxy_call.bypass_succeeded", 0)
+    bypass_fail = simple_call_counter.get("proxy_call.bypass_failed", 0)
+    normal_stat = simple_call_counter.get("proxy_call.normal_dispatch", 0)
+
+    print("Warming up...")
+    for _ in range(args.warmup):
+        make_fx_normal()
+    print("Running normal (warm)...")
+    mfx_warm_normal = [make_fx_normal() for _ in range(args.iterations)]
+
+    print_section("make_fx Cold Start", mfx_cold_bypass, mfx_cold_normal, args.cold_runs)
+    print_section("make_fx Warm Start", mfx_warm_bypass, mfx_warm_normal, args.iterations)
+
+    # ===== torch.compile =====
+    print()
+    print("--- torch.compile ---")
+
+    # Cold
+    print("Measuring cold starts (interleaved)...")
+    tc_cold_bypass, tc_cold_normal = run_interleaved(
+        compile_bypass, compile_normal, args.cold_runs
+    )
+
+    # Warm
+    print("Warming up...")
+    for _ in range(args.warmup):
+        compile_bypass()
+    print("Running bypass (warm)...")
+    tc_warm_bypass = [compile_bypass() for _ in range(args.iterations)]
+
+    print("Warming up...")
+    for _ in range(args.warmup):
+        compile_normal()
+    print("Running normal (warm)...")
+    tc_warm_normal = [compile_normal() for _ in range(args.iterations)]
+
+    print_section(f"torch.compile ({args.compile_backend}) Cold Start",
+                  tc_cold_bypass, tc_cold_normal, args.cold_runs)
+    print_section(f"torch.compile ({args.compile_backend}) Warm Start",
+                  tc_warm_bypass, tc_warm_normal, args.iterations)
+
+    # Bypass rate
+    total_ops = bypass_ok + bypass_fail + normal_stat
+    if total_ops > 0:
+        print()
+        print(f"Bypass rate (make_fx last trace): {bypass_ok}/{total_ops} ops "
+              f"({bypass_ok / total_ops * 100:.0f}%)")
+        print(f"  succeeded={bypass_ok}, failed={bypass_fail}, normal={normal_stat}")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/test_static_dispatch.py
+++ b/test/test_static_dispatch.py
@@ -1,0 +1,269 @@
+# Owner(s): ["module: dispatch"]
+
+"""
+Tests for static dispatch POC for TorchDispatchMode.
+
+This module tests the static dispatch infrastructure that eliminates TLS
+stack lookups for infra modes by statically chaining them in known order.
+"""
+
+import time
+import torch
+import torch.nn.functional as F
+from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.fx.experimental.proxy_tensor import make_fx
+
+
+class TestStaticDispatch(TestCase):
+    """Tests for static dispatch functionality."""
+
+    def test_static_dispatch_basic(self):
+        """Basic test that static dispatch works."""
+        def model(x):
+            return x.sin() + x.cos()
+
+        x = torch.randn(4, 4)
+
+        # Static dispatch
+        gm = make_fx(model, static_dispatch=True)(x)
+
+        # Verify graph executes correctly
+        out_expected = model(x)
+        out_actual = gm(x)
+        self.assertEqual(out_expected, out_actual)
+
+    def test_static_dispatch_graph_equivalence(self):
+        """Verify static and dynamic dispatch produce identical graphs."""
+        def model(x, y):
+            z = x @ y
+            return F.gelu(z) + z.sin()
+
+        x = torch.randn(32, 32)
+        y = torch.randn(32, 32)
+
+        # Dynamic dispatch (current behavior)
+        gm_dynamic = make_fx(model)(x, y)
+
+        # Static dispatch (new behavior)
+        gm_static = make_fx(model, static_dispatch=True)(x, y)
+
+        # Verify graphs are functionally equivalent
+        out_dynamic = gm_dynamic(x, y)
+        out_static = gm_static(x, y)
+        self.assertEqual(out_dynamic, out_static)
+
+        # Verify graph structure is similar (may differ slightly in structure)
+        # Just check that both have valid graphs
+        self.assertGreater(len(list(gm_dynamic.graph.nodes)), 0)
+        self.assertGreater(len(list(gm_static.graph.nodes)), 0)
+
+    def test_static_dispatch_with_decomposition(self):
+        """Test static dispatch with decomposition table."""
+        def my_gelu_decomp(x):
+            return x * 0.5 * (1 + torch.tanh(
+                0.7978845608028654 * (x + 0.044715 * x.pow(3))
+            ))
+
+        decomp_table = {torch.ops.aten.gelu.default: my_gelu_decomp}
+
+        def model(x):
+            return F.gelu(x)
+
+        x = torch.randn(8, 8)
+
+        # With decomposition and static dispatch
+        gm = make_fx(
+            model,
+            decomposition_table=decomp_table,
+            static_dispatch=True
+        )(x)
+
+        # Verify output is correct
+        out_expected = model(x)
+        out_actual = gm(x)
+        # Note: decomposed output may differ slightly due to implementation
+        self.assertTrue(gm is not None)
+        self.assertGreater(len(list(gm.graph.nodes)), 0)
+
+    def test_static_dispatch_symbolic_tracing(self):
+        """Test static dispatch with symbolic tracing mode."""
+        def model(x):
+            return x.sin() * x.cos()
+
+        x = torch.randn(4, 4)
+
+        # Static dispatch with symbolic tracing
+        gm = make_fx(model, tracing_mode="symbolic", static_dispatch=True)(x)
+
+        # Verify graph executes correctly
+        out_expected = model(x)
+        out_actual = gm(x)
+        self.assertEqual(out_expected, out_actual)
+
+    def test_static_dispatch_fake_tracing(self):
+        """Test static dispatch with fake tensor mode."""
+        def model(x):
+            return x.relu() + 1
+
+        x = torch.randn(4, 4)
+
+        # Static dispatch with fake tracing
+        gm = make_fx(model, tracing_mode="fake", static_dispatch=True)(x)
+
+        # Verify graph executes correctly
+        out_expected = model(x)
+        out_actual = gm(x)
+        self.assertEqual(out_expected, out_actual)
+
+    def test_user_mode_with_static_infra(self):
+        """Verify user modes work correctly with static infra dispatch."""
+        from torch.utils._python_dispatch import TorchDispatchMode
+
+        call_count = [0]
+
+        class CountingMode(TorchDispatchMode):
+            def __torch_dispatch__(self, func, types, args=(), kwargs=None):
+                call_count[0] += 1
+                return func(*args, **(kwargs or {}))
+
+        def model(x):
+            return x.sin() + x.cos()
+
+        x = torch.randn(4, 4)
+
+        with CountingMode():
+            gm = make_fx(model, static_dispatch=True)(x)
+
+        # Verify user mode was called
+        self.assertGreater(call_count[0], 0)
+
+        # Verify graph is correct
+        out_expected = model(x)
+        out_actual = gm(x)
+        self.assertEqual(out_expected, out_actual)
+
+
+class TestStaticDispatchPerformance(TestCase):
+    """Performance benchmarks for static dispatch."""
+
+    def _benchmark_make_fx(self, model, x, static_dispatch, num_warmup=3, num_runs=20):
+        """Benchmark make_fx with given settings."""
+        # Cold start: first call
+        cold_start = time.perf_counter()
+        _ = make_fx(model, static_dispatch=static_dispatch)(x)
+        cold_time = time.perf_counter() - cold_start
+
+        # Warm up
+        for _ in range(num_warmup):
+            _ = make_fx(model, static_dispatch=static_dispatch)(x)
+
+        # Warm start: averaged over multiple runs
+        warm_start = time.perf_counter()
+        for _ in range(num_runs):
+            _ = make_fx(model, static_dispatch=static_dispatch)(x)
+        warm_time = (time.perf_counter() - warm_start) / num_runs
+
+        return cold_time, warm_time
+
+    def test_performance_cold_start(self):
+        """Measure cold start performance."""
+        def model(x):
+            y = x @ x.T
+            y = F.gelu(y)
+            y = y.sin() + y.cos()
+            return F.softmax(y, dim=-1)
+
+        x = torch.randn(64, 64)
+
+        cold_dynamic, _ = self._benchmark_make_fx(model, x, static_dispatch=False, num_runs=1)
+        cold_static, _ = self._benchmark_make_fx(model, x, static_dispatch=True, num_runs=1)
+
+        print(f"\nCold Start Performance:")
+        print(f"  Dynamic dispatch: {cold_dynamic * 1000:.2f}ms")
+        print(f"  Static dispatch:  {cold_static * 1000:.2f}ms")
+        if cold_static > 0:
+            print(f"  Speedup: {cold_dynamic / cold_static:.2f}x")
+
+    def test_performance_warm_start(self):
+        """Measure warm start performance."""
+        def model(x):
+            y = x @ x.T
+            y = F.gelu(y)
+            y = y.sin() + y.cos()
+            return F.softmax(y, dim=-1)
+
+        x = torch.randn(64, 64)
+
+        _, warm_dynamic = self._benchmark_make_fx(model, x, static_dispatch=False)
+        _, warm_static = self._benchmark_make_fx(model, x, static_dispatch=True)
+
+        print(f"\nWarm Start Performance (avg of 20 runs):")
+        print(f"  Dynamic dispatch: {warm_dynamic * 1000:.2f}ms")
+        print(f"  Static dispatch:  {warm_static * 1000:.2f}ms")
+        if warm_static > 0:
+            print(f"  Speedup: {warm_dynamic / warm_static:.2f}x")
+
+    def test_performance_varying_model_sizes(self):
+        """Benchmark across different model complexities."""
+        results = []
+
+        for num_ops in [5, 10, 25, 50]:
+            def make_model(n):
+                def model(x):
+                    for _ in range(n):
+                        x = x.sin()
+                    return x
+                return model
+
+            model = make_model(num_ops)
+            x = torch.randn(32, 32)
+
+            _, warm_dynamic = self._benchmark_make_fx(model, x, static_dispatch=False, num_runs=10)
+            _, warm_static = self._benchmark_make_fx(model, x, static_dispatch=True, num_runs=10)
+
+            speedup = warm_dynamic / warm_static if warm_static > 0 else 0
+            results.append((num_ops, warm_dynamic, warm_static, speedup))
+
+        print(f"\nPerformance by Model Complexity:")
+        print(f"{'Ops':<6} {'Dynamic (ms)':<14} {'Static (ms)':<14} {'Speedup':<8}")
+        print("-" * 44)
+        for num_ops, dyn, stat, speedup in results:
+            print(f"{num_ops:<6} {dyn*1000:<14.2f} {stat*1000:<14.2f} {speedup:<8.2f}x")
+
+
+class TestTorchCompileIntegration(TestCase):
+    """Tests for torch.compile integration with static dispatch."""
+
+    def test_torch_compile_basic(self):
+        """Basic test that torch.compile works (baseline)."""
+        def model(x):
+            return x.sin() + x.cos()
+
+        x = torch.randn(4, 4)
+
+        # Compile the model
+        compiled = torch.compile(model, backend="eager")
+
+        # Verify it works
+        out_expected = model(x)
+        out_actual = compiled(x)
+        self.assertEqual(out_expected, out_actual)
+
+    def test_torch_compile_with_decomposition(self):
+        """Test torch.compile with decomposition."""
+        def model(x):
+            return F.gelu(x) + x.sin()
+
+        x = torch.randn(4, 4)
+
+        # Compile with eager backend
+        compiled = torch.compile(model, backend="eager")
+
+        # Verify it works
+        out_expected = model(x)
+        out_actual = compiled(x)
+        self.assertEqual(out_expected, out_actual)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/_ops.py
+++ b/torch/_ops.py
@@ -817,8 +817,12 @@ class OpOverload(OperatorBase, Generic[_P, _T]):
         self._overloadname = (
             "default" if schema.overload_name == "" else schema.overload_name
         )
-        if tags:
-            self._nondeterministic_seeded = torch.Tag.nondeterministic_seeded in tags
+        self._nondeterministic_seeded = (
+            bool(tags) and torch.Tag.nondeterministic_seeded in tags
+        )
+        self._data_dependent_output = (
+            bool(tags) and torch.Tag.data_dependent_output in tags
+        )
         self._name = self._schema.name
         if schema.overload_name:
             self._name += "." + schema.overload_name
@@ -843,6 +847,12 @@ class OpOverload(OperatorBase, Generic[_P, _T]):
                 # aliased inputs as NOT a view
                 is_write = a.alias_info.is_write or is_write
         self.is_view = is_write is not None and not is_write
+        self._has_multiple_returns = len(schema.returns) > 1
+        # Static bypass eligibility for proxy_call fast path.
+        # Only dynamic arg-level checks (sym scalars, symbolic sizes) remain per-call.
+        self._can_bypass_proxy_dispatch = (
+            not self._has_multiple_returns and not self._data_dependent_output
+        )
 
     @cached_property
     def _namespace(self) -> str:

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -75,7 +75,7 @@ from torch.utils._python_dispatch import (
     autograd_would_have_decomposed,
     TorchDispatchMode,
 )
-from torch.utils._stats import count
+from torch.utils._stats import count, simple_call_counter
 from torch.utils._thunk import Thunk
 from torch.utils.weak import _WeakHashRef, WeakIdKeyDictionary, WeakTensorKeyDictionary
 
@@ -1052,20 +1052,30 @@ def _maybe_record_pointwise_barrier(
 
 def _fetch_proxies_and_all_constant_flag(
     flat_args_kwargs: list[object] | tuple[object, ...], tracer: _ProxyTracer
-) -> tuple[list[object], tuple[object, ...], bool]:
+) -> tuple[list[object], tuple[object, ...], bool, bool, bool]:
     """
     Given flat arguments, fetch the proxies and whether they are all constants.
     This is later used in proxy_call or when someone is trying to stitch together
     graph node in tf or td modes.
+
+    Returns (f_flat_args_kwargs, proxy_flat_args_kwargs, all_constant,
+    has_sym_scalars, has_symbolic_sizes).
+    All three flags are computed in a single pass to avoid redundant iteration.
     """
-    f_flat_args_kwargs = [
-        (
-            fetch_object_proxy(tracer, x)
-            if isinstance(x, (Tensor, _AnyScriptObject)) or is_opaque_value(x)
-            else x
-        )
-        for x in flat_args_kwargs
-    ]
+    f_flat_args_kwargs: list[object] = []
+    has_sym_scalars = False
+    has_symbolic_sizes = False
+
+    for x in flat_args_kwargs:
+        if isinstance(x, py_sym_types):
+            has_sym_scalars = True
+            f_flat_args_kwargs.append(x)
+        elif isinstance(x, (Tensor, _AnyScriptObject)) or is_opaque_value(x):
+            if isinstance(x, Tensor) and x._has_symbolic_sizes_strides:
+                has_symbolic_sizes = True
+            f_flat_args_kwargs.append(fetch_object_proxy(tracer, x))
+        else:
+            f_flat_args_kwargs.append(x)
 
     # If there are SymInts, we also should not consider this constant.
     # However, fake tensor handling of SymInts is sufficiently broken that
@@ -1078,7 +1088,7 @@ def _fetch_proxies_and_all_constant_flag(
         )
         # TODO: maybe constant SymInts should also be allowed?  Not sure if
         # this can happen
-        and not any(isinstance(x, py_sym_types) for x in flat_args_kwargs)
+        and not has_sym_scalars
     )
 
     proxy_flat_args_kwargs = [
@@ -1090,7 +1100,13 @@ def _fetch_proxies_and_all_constant_flag(
         for e in proxy_flat_args_kwargs
     ]
 
-    return f_flat_args_kwargs, tuple(proxy_flat_args_kwargs), all_constant
+    return (
+        f_flat_args_kwargs,
+        tuple(proxy_flat_args_kwargs),
+        all_constant,
+        has_sym_scalars,
+        has_symbolic_sizes,
+    )
 
 
 def proxy_call(
@@ -1099,6 +1115,7 @@ def proxy_call(
     pre_dispatch: bool,
     args: tuple[object, ...],
     kwargs: dict[str, object],
+    types: tuple[type, ...] | None = None,
 ) -> object:
     unrecognized_types: list[type] = []
     flat_args_kwargs, spec = pytree.tree_flatten((args, kwargs))
@@ -1150,9 +1167,13 @@ def proxy_call(
             return (args[0] != 0).item()  # type: ignore[attr-defined]
 
     tracer = proxy_mode.tracer
-    f_flat_args_kwargs, proxy_flat_args_kwargs, all_constant = (
-        _fetch_proxies_and_all_constant_flag(flat_args_kwargs, tracer)
-    )
+    (
+        f_flat_args_kwargs,
+        proxy_flat_args_kwargs,
+        all_constant,
+        has_sym_scalars,
+        has_symbolic_sizes,
+    ) = _fetch_proxies_and_all_constant_flag(flat_args_kwargs, tracer)
 
     if torch.Tag.data_dependent_output in func.tags:
         # Check if all of the Tensor inputs are constants
@@ -1225,8 +1246,27 @@ def proxy_call(
         name=proxy_mode.tracer.graph._target_to_str(func.overloadpacket.__name__),
     )
 
-    with _enable_thunkify(proxy_mode.tracer):
-        out = func(*args, **kwargs)
+    # Bypass proxy mode and call fake tensor dispatch directly for eligible ops.
+    # Static eligibility is cached on OpOverload; dynamic checks are from the
+    # single-pass in _fetch_proxies_and_all_constant_flag.
+    if (
+        func._can_bypass_proxy_dispatch
+        and not has_sym_scalars
+        and not has_symbolic_sizes
+    ):
+        fake_mode = torch._C._get_dispatch_mode(torch._C._TorchDispatchModeKey.FAKE)
+        if fake_mode is not None:
+            with unset_fake_temporarily():
+                with _enable_thunkify(proxy_mode.tracer):
+                    out = fake_mode.dispatch(
+                        func, types or (), args, kwargs or {}
+                    )
+        else:
+            with _enable_thunkify(proxy_mode.tracer):
+                out = func(*args, **kwargs)
+    else:
+        with _enable_thunkify(proxy_mode.tracer):
+            out = func(*args, **kwargs)
 
     # In some circumstances, we will be tracing in a situation where a tensor
     # is *statically* known to be a constant (currently, this only happens if
@@ -1736,7 +1776,9 @@ class PreDispatchTorchFunctionMode(TorchFunctionMode):
             torch._functorch.predispatch._vmap_decrement_nesting,
             torch._functorch.vmap.lazy_load_decompositions,
         ]:
-            _, proxies, _ = _fetch_proxies_and_all_constant_flag(args, self.tracer)
+            _, proxies, _, _, _ = _fetch_proxies_and_all_constant_flag(
+                args, self.tracer
+            )
             out_proxy = self.tracer.create_proxy(
                 "call_function",
                 func,
@@ -1806,7 +1848,7 @@ class ProxyTorchDispatchMode(TorchDispatchMode):
             if func == prim.device.default:
                 return func(*args, **kwargs)
 
-            return proxy_call(self, func, self.pre_dispatch, args, kwargs)
+            return proxy_call(self, func, self.pre_dispatch, args, kwargs, types)
 
     def __enter__(self) -> Self:
         # Stash and store the previous proxy mode (there may or may not be one)
@@ -2735,6 +2777,26 @@ class _MakefxTracer:
                     ).src,
                 )
                 raise
+
+            # Emit bypass dispatch stats for tlparse visibility
+            bypass_ok = simple_call_counter.get("proxy_call.bypass_succeeded", 0)
+            bypass_fail = simple_call_counter.get("proxy_call.bypass_failed", 0)
+            normal = simple_call_counter.get("proxy_call.normal_dispatch", 0)
+            if bypass_ok + bypass_fail + normal > 0:
+                trace_structured(
+                    "artifact",
+                    metadata_fn=lambda: {
+                        "name": "proxy_dispatch_bypass_stats",
+                        "encoding": "string",
+                    },
+                    payload_fn=lambda: (
+                        f"bypass_succeeded={bypass_ok}, "
+                        f"bypass_failed={bypass_fail}, "
+                        f"normal_dispatch={normal}, "
+                        f"bypass_rate="
+                        f"{bypass_ok / (bypass_ok + bypass_fail + normal) * 100:.1f}%"
+                    ),
+                )
 
         if (
             self.is_hop_subgraph_tracer()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #178415

ProxyTorchDispatchMode has a worse performance with cold start on selected model. 

```
--- make_fx ---
Measuring cold starts (interleaved)...
Warming up...
Running bypass (warm)...
Warming up...
Running normal (warm)...

=================================================================
make_fx Cold Start (10 runs, interleaved)
=================================================================
Mode        Mean (µs)   P50 (µs)   P90 (µs)        Min        Max
-----------------------------------------------------------------
bypass       102289.3     3497.6   991333.4     3408.5   991333.4
normal         3711.7     3634.1     4095.0     3396.8     4095.0
  diff: -2655.8%  (bypass slower)

=================================================================
make_fx Warm Start (50 runs, interleaved)
=================================================================
Mode        Mean (µs)   P50 (µs)   P90 (µs)        Min        Max
-----------------------------------------------------------------
bypass         3503.1     3472.4     3566.8     3313.6     4165.8
normal         3604.8     3556.1     3869.6     3386.9     4483.2
  diff: +2.8%  (bypass faster)

--- torch.compile ---
Measuring cold starts (interleaved)...
W0325 14:15:13.300000 3036649 /home/xiaofu/dev_torch/pytorch/torch/utils/flop_counter.py:29] triton not found; flop counting will not work for triton kernels
Warming up...
Running bypass (warm)...
Warming up...
Running normal (warm)...

=================================================================
torch.compile (aot_eager) Cold Start (10 runs, interleaved)
=================================================================
Mode        Mean (µs)   P50 (µs)   P90 (µs)        Min        Max
-----------------------------------------------------------------
bypass       250080.2   201133.4   576012.9   194887.3   576012.9
normal       200527.4   199708.6   211428.1   197157.3   211428.1
  diff: -24.7%  (bypass slower)

=================================================================
torch.compile (aot_eager) Warm Start (50 runs, interleaved)
=================================================================
Mode        Mean (µs)   P50 (µs)   P90 (µs)        Min        Max
-----------------------------------------------------------------
bypass       204421.1   200345.3   206945.3   197770.4   347827.7
normal       210206.1   204461.4   207372.3   199828.2   489691.5
  diff: +2.8%  (bypass faster)
```
