### PR TITLE
[dynamo] Migrate allow_in_graph → nonstrict_trace in torch/ production code

### DIFF
--- a/torch/_dynamo/backends/debugging.py
+++ b/torch/_dynamo/backends/debugging.py
@@ -166,8 +166,7 @@ def invoke_subgraph_inner_compiler(
     from torch._higher_order_ops.invoke_subgraph import invoke_subgraph_infer
 
     @disable
-    # pyrefly: ignore [deprecated]
-    @torch._dynamo.allow_in_graph
+    @torch._dynamo.nonstrict_trace
     def invoke_subgraph_wrapper_unboxed(*operands: Any) -> Any:
         return invoke_subgraph_infer(subgraph, *operands)
 
@@ -212,7 +211,7 @@ def invoke_subgraph_inner_compiler_good(
     fx_g_is_boxed = getattr(fx_g, "_boxed_call", False)
 
     @disable
-    @torch._dynamo.allow_in_graph
+    @torch._dynamo.nonstrict_trace
     def invoke_subgraph_wrapper_unboxed(*args: Any) -> Any:
         proxy_mode = get_proxy_mode()
         if proxy_mode is not None:

--- a/torch/_dynamo/backends/debugging.py
+++ b/torch/_dynamo/backends/debugging.py
@@ -166,9 +166,10 @@ def invoke_subgraph_inner_compiler(
     from torch._higher_order_ops.invoke_subgraph import invoke_subgraph_infer
 
     @disable
-    @torch._dynamo.nonstrict_trace
     def invoke_subgraph_wrapper_unboxed(*operands: Any) -> Any:
         return invoke_subgraph_infer(subgraph, *operands)
+
+    torch._dynamo.nonstrict_trace(invoke_subgraph_wrapper_unboxed, in_place=True)
 
     # NB: The direct to unboxed path is broken, you MUST DO THIS
 
@@ -211,7 +212,6 @@ def invoke_subgraph_inner_compiler_good(
     fx_g_is_boxed = getattr(fx_g, "_boxed_call", False)
 
     @disable
-    @torch._dynamo.nonstrict_trace
     def invoke_subgraph_wrapper_unboxed(*args: Any) -> Any:
         proxy_mode = get_proxy_mode()
         if proxy_mode is not None:
@@ -223,6 +223,8 @@ def invoke_subgraph_inner_compiler_good(
                 return fx_g(list(args))
             else:
                 return fx_g(*args)
+
+    torch._dynamo.nonstrict_trace(invoke_subgraph_wrapper_unboxed, in_place=True)
 
     # Wrap to handle boxed arguments (list of args) as expected by AOTAutograd
     def invoke_subgraph_wrapper(args: list[Any]) -> Any:

--- a/torch/_dynamo/compiled_autograd.py
+++ b/torch/_dynamo/compiled_autograd.py
@@ -224,7 +224,8 @@ class OpNamespace:
         result = Op(name, fn, is_custom_function)
         if is_traceable:
             # pyrefly: ignore [deprecated]
-            setattr(self, name, torch._dynamo.nonstrict_trace(result))
+            torch._dynamo.nonstrict_trace(result, in_place=True)
+            setattr(self, name, result)
         else:
             # C++ autograd function was not marked as traceable
             # Dynamo can't dry run it at compile time, so must fallback to eager
@@ -485,7 +486,6 @@ class AutogradCompilerInstance:
                         "torch.compile does not currently support higher order gradients."
                     )
 
-        @torch._dynamo.nonstrict_trace  # type: ignore[misc]
         def call_aot_bwd_prologue(
             ctx_saved_tensors: Sequence[torch.Tensor],
             ctx_symints: Sequence[IntLikeType],
@@ -501,6 +501,8 @@ class AutogradCompilerInstance:
                 *flat_args,
             )
             return out
+
+        torch._dynamo.nonstrict_trace(call_aot_bwd_prologue, in_place=True)  # type: ignore[misc]
 
         pgrads = self.fx_tracer.create_proxy(
             kind="call_function",
@@ -626,9 +628,10 @@ class AutogradCompilerInstance:
         def proxy_subclass_constructor(
             subclass_meta: Any, is_runtime: bool, unwrapped_args: Sequence[Any]
         ) -> torch.Tensor:
-            @torch._dynamo.nonstrict_trace  # type: ignore[misc]
             def make_subclass(*unwrapped_args: Any) -> Any:
                 return subclass_meta.creation_fn(unwrapped_args, is_runtime=is_runtime)
+
+            torch._dynamo.nonstrict_trace(make_subclass, in_place=True)  # type: ignore[misc]
 
             punwrapped_args = pytree.tree_map(self.to_proxy, unwrapped_args)
 

--- a/torch/_dynamo/compiled_autograd.py
+++ b/torch/_dynamo/compiled_autograd.py
@@ -224,7 +224,7 @@ class OpNamespace:
         result = Op(name, fn, is_custom_function)
         if is_traceable:
             # pyrefly: ignore [deprecated]
-            setattr(self, name, torch._dynamo.allow_in_graph(result))
+            setattr(self, name, torch._dynamo.nonstrict_trace(result))
         else:
             # C++ autograd function was not marked as traceable
             # Dynamo can't dry run it at compile time, so must fallback to eager
@@ -485,7 +485,7 @@ class AutogradCompilerInstance:
                         "torch.compile does not currently support higher order gradients."
                     )
 
-        @torch._dynamo.allow_in_graph  # type: ignore[misc]
+        @torch._dynamo.nonstrict_trace  # type: ignore[misc]
         def call_aot_bwd_prologue(
             ctx_saved_tensors: Sequence[torch.Tensor],
             ctx_symints: Sequence[IntLikeType],
@@ -626,7 +626,7 @@ class AutogradCompilerInstance:
         def proxy_subclass_constructor(
             subclass_meta: Any, is_runtime: bool, unwrapped_args: Sequence[Any]
         ) -> torch.Tensor:
-            @torch._dynamo.allow_in_graph  # type: ignore[misc]
+            @torch._dynamo.nonstrict_trace  # type: ignore[misc]
             def make_subclass(*unwrapped_args: Any) -> Any:
                 return subclass_meta.creation_fn(unwrapped_args, is_runtime=is_runtime)
 

--- a/torch/_dynamo/decorators.py
+++ b/torch/_dynamo/decorators.py
@@ -306,11 +306,9 @@ def nonstrict_trace(
         fn_id = id(traceable_fn)
         trace_rules._disallowed_callable_ids.remove(fn_id)
         trace_rules._allowed_callable_ids.add(fn_id)
-        trace_rules._nonstrict_trace_callable_ids.add(fn_id)
 
         def deregister() -> None:
             trace_rules._allowed_callable_ids.remove(fn_id)
-            trace_rules._nonstrict_trace_callable_ids.remove(fn_id)
 
         weakref.finalize(traceable_fn, deregister)
         return traceable_fn

--- a/torch/_dynamo/decorators.py
+++ b/torch/_dynamo/decorators.py
@@ -219,7 +219,11 @@ def _check_mutually_exclusive_decorators(fn: Callable, decorator_name: str) -> N
             )
 
 
-def nonstrict_trace(traceable_fn: Callable[_P, _R]) -> Callable[_P, _R]:
+def nonstrict_trace(
+    traceable_fn: Callable[_P, _R],
+    *,
+    in_place: bool = False,
+) -> Callable[_P, _R]:
     """
     Decorator to mark a function as nonstrict-traceable for dynamo.
 
@@ -287,19 +291,39 @@ def nonstrict_trace(traceable_fn: Callable[_P, _R]) -> Callable[_P, _R]:
 
     _check_mutually_exclusive_decorators(traceable_fn, "nonstrict_trace")
 
+    if inspect.isclass(traceable_fn):
+        cls_id = id(traceable_fn)
+        trace_rules._disallowed_callable_ids.remove(cls_id)
+        trace_rules._allowed_callable_ids.add(cls_id)
+
+        def deregister() -> None:
+            trace_rules._allowed_callable_ids.remove(cls_id)
+
+        weakref.finalize(traceable_fn, deregister)
+        return traceable_fn
+
+    if in_place:
+        fn_id = id(traceable_fn)
+        trace_rules._disallowed_callable_ids.remove(fn_id)
+        trace_rules._allowed_callable_ids.add(fn_id)
+        trace_rules._nonstrict_trace_callable_ids.add(fn_id)
+
+        def deregister() -> None:
+            trace_rules._allowed_callable_ids.remove(fn_id)
+            trace_rules._nonstrict_trace_callable_ids.remove(fn_id)
+
+        weakref.finalize(traceable_fn, deregister)
+        return traceable_fn
+
     @functools.wraps(traceable_fn)
     def wrapped(*args: _P.args, **kwargs: _P.kwargs) -> _R:
         return traceable_fn(*args, **kwargs)
 
     wrapped_id = id(wrapped)
 
-    # This line allows us to reuse much of the `allow_in_graph` impl.
     trace_rules._allowed_callable_ids.add(wrapped_id)
-
-    # This line allows us to diverge the impl from `allow_in_graph`.
     trace_rules._nonstrict_trace_callable_ids.add(wrapped_id)
 
-    # Avoid id reuse which creates subtle bugs.
     def deregister() -> None:
         trace_rules._allowed_callable_ids.remove(wrapped_id)
         trace_rules._nonstrict_trace_callable_ids.remove(wrapped_id)
@@ -1402,16 +1426,16 @@ def _allow_in_graph_einops() -> None:
         # helpers. Backport the try/except TypeError fallback from einops 0.7.0+
         # so allow_in_graph works during fake tensor validation.
         _patch_einops_symint_compat(einops.einops)  # type: ignore[attr-defined]
-        allow_in_graph(einops.rearrange)
-        allow_in_graph(einops.reduce)
+        nonstrict_trace(einops.rearrange, in_place=True)
+        nonstrict_trace(einops.reduce, in_place=True)
         if hasattr(einops, "repeat"):
-            allow_in_graph(einops.repeat)  # available since einops 0.2.0
+            nonstrict_trace(einops.repeat, in_place=True)
         if hasattr(einops, "einsum"):
-            allow_in_graph(einops.einsum)  # available since einops 0.5.0
+            nonstrict_trace(einops.einsum, in_place=True)
         if hasattr(einops, "pack"):
-            allow_in_graph(einops.pack)  # available since einops 0.6.0
+            nonstrict_trace(einops.pack, in_place=True)
         if hasattr(einops, "unpack"):
-            allow_in_graph(einops.unpack)  # available since einops 0.6.0
+            nonstrict_trace(einops.unpack, in_place=True)
 
 
 # Note: this carefully avoids eagerly import einops.

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -3465,7 +3465,7 @@ def handle_traced_output(
         from .sdpa import PARAM_NAMES, SDPAParamsVariable
 
         set_example_value(proxy.node, example_value)
-        param_vars = []
+        param_vars: list[VariableTracker] = []
         for name in PARAM_NAMES:
             attr_val = getattr(example_value, name)
             attr_proxy = proxy.tracer.create_proxy(
@@ -3476,7 +3476,7 @@ def handle_traced_output(
             )
             param_vars.append(
                 wrap_fx_proxy_cls(
-                    target_cls=target_cls,
+                    target_cls=target_cls,  # pyrefly: ignore[bad-argument-type]
                     tx=tx,
                     proxy=attr_proxy,
                     example_value=attr_val,

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -3462,10 +3462,27 @@ def handle_traced_output(
         set_example_value(proxy.node, example_value)
         return ConstantVariable.create(example_value, **options)
     elif isinstance(example_value, torch.backends.cuda.SDPAParams):
-        from .sdpa import SDPAParamsVariable
+        from .sdpa import PARAM_NAMES, SDPAParamsVariable
 
         set_example_value(proxy.node, example_value)
-        return SDPAParamsVariable(proxy, **options)
+        param_vars = []
+        for name in PARAM_NAMES:
+            attr_val = getattr(example_value, name)
+            attr_proxy = proxy.tracer.create_proxy(
+                kind="call_function",
+                target=getattr,
+                args=(proxy, name),
+                kwargs={},
+            )
+            param_vars.append(
+                wrap_fx_proxy_cls(
+                    target_cls=target_cls,
+                    tx=tx,
+                    proxy=attr_proxy,
+                    example_value=attr_val,
+                )
+            )
+        return SDPAParamsVariable(proxy, param_vars=param_vars)
     elif isinstance(example_value, bool) and (
         proxy.node.target
         in [

--- a/torch/_higher_order_ops/flat_apply.py
+++ b/torch/_higher_order_ops/flat_apply.py
@@ -27,11 +27,9 @@ def register_graphable_type(typ: type) -> None:
 
 def is_graphable(val: object) -> TypeIs[torch.fx.node.BaseArgumentTypes]:
     """Definition: a graphable type is a type that is an acceptable input/output type to a FX node."""
-    return (
-        isinstance(val, (*torch.fx.node.base_types, FakeScriptObject))
-        or is_opaque_type(type(val))
-        or isinstance(val, tuple(_extra_graphable_types))
-    )
+    return isinstance(
+        val, (*torch.fx.node.base_types, FakeScriptObject, *_extra_graphable_types)
+    ) or is_opaque_type(type(val))
 
 
 def is_graphable_type(typ: type[object]) -> bool:

--- a/torch/_higher_order_ops/flat_apply.py
+++ b/torch/_higher_order_ops/flat_apply.py
@@ -17,11 +17,21 @@ _P = ParamSpec("_P")
 _Ts = TypeVarTuple("_Ts")
 
 
+_extra_graphable_types: set[type] = set()
+
+
+def register_graphable_type(typ: type) -> None:
+    """Register a type as an acceptable leaf type for flat_apply I/O."""
+    _extra_graphable_types.add(typ)
+
+
 def is_graphable(val: object) -> TypeIs[torch.fx.node.BaseArgumentTypes]:
     """Definition: a graphable type is a type that is an acceptable input/output type to a FX node."""
-    return isinstance(
-        val, (*torch.fx.node.base_types, FakeScriptObject)
-    ) or is_opaque_type(type(val))
+    return (
+        isinstance(val, (*torch.fx.node.base_types, FakeScriptObject))
+        or is_opaque_type(type(val))
+        or isinstance(val, tuple(_extra_graphable_types))
+    )
 
 
 def is_graphable_type(typ: type[object]) -> bool:
@@ -30,6 +40,7 @@ def is_graphable_type(typ: type[object]) -> bool:
         issubclass(typ, torch.fx.node.base_types)
         or is_opaque_type(typ)
         or issubclass(typ, FakeScriptObject)
+        or typ in _extra_graphable_types
     )
 
 

--- a/torch/compiler/__init__.py
+++ b/torch/compiler/__init__.py
@@ -145,7 +145,7 @@ def allow_in_graph(fn):
     """
     import torch._dynamo
 
-    return torch._dynamo.allow_in_graph(fn)
+    return torch._dynamo.nonstrict_trace(fn, in_place=True)
 
 
 def substitute_in_graph(

--- a/torch/nn/attention/bias.py
+++ b/torch/nn/attention/bias.py
@@ -24,10 +24,13 @@ from torch.nn.attention._utils import (
 __all__ = ["causal_upper_left", "causal_lower_right", "CausalVariant", "CausalBias"]
 
 
-torch._dynamo.allow_in_graph(is_flash_attention_available)
-torch._dynamo.allow_in_graph(can_use_flash_attention)
-torch._dynamo.allow_in_graph(can_use_efficient_attention)
-torch._dynamo.allow_in_graph(SDPAParams)
+torch._dynamo.nonstrict_trace(is_flash_attention_available, in_place=True)
+torch._dynamo.nonstrict_trace(can_use_flash_attention, in_place=True)
+torch._dynamo.nonstrict_trace(can_use_efficient_attention, in_place=True)
+torch._dynamo.nonstrict_trace(SDPAParams, in_place=True)
+from torch._higher_order_ops.flat_apply import register_graphable_type
+
+register_graphable_type(SDPAParams)
 
 
 class CausalVariant(IntEnum):

--- a/torch/nn/attention/bias.py
+++ b/torch/nn/attention/bias.py
@@ -28,7 +28,9 @@ torch._dynamo.nonstrict_trace(is_flash_attention_available, in_place=True)
 torch._dynamo.nonstrict_trace(can_use_flash_attention, in_place=True)
 torch._dynamo.nonstrict_trace(can_use_efficient_attention, in_place=True)
 torch._dynamo.nonstrict_trace(SDPAParams, in_place=True)
-from torch._higher_order_ops.flat_apply import register_graphable_type
+
+from torch._higher_order_ops.flat_apply import register_graphable_type  # noqa: E402
+
 
 register_graphable_type(SDPAParams)
 

--- a/torch/sparse/semi_structured.py
+++ b/torch/sparse/semi_structured.py
@@ -132,7 +132,7 @@ class SparseSemiStructuredTensor(torch.Tensor):
             cls._load_dispatch_table()
 
             # we can also register the classes with dynamo when the warning is shown.
-            torch._dynamo.allow_in_graph(cls)
+            torch._dynamo.nonstrict_trace(cls, in_place=True)
 
         if packed is not None:
             previous_tensor = packed


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #180616
* __->__ #178416
* #178340

We would like to deprecate allow_in_graph in favor of nonstrict_trace because
they have the same functionality from user's perspecitve i.e. skip dynamo tracing.
They have different unlying implmentations though, nonstrict_trace uses flat_apply HOP
instead of a simple call_function node.

This pr studied what it takes to completely replace allow_in_graph in pytorch. We find 
This migration would require three extensions to nonstrict_trace:

1. in_place kwarg: allow_in_graph registered id(fn) and returned fn
   unchanged. nonstrict_trace by default creates a wrapper. Adding
   in_place=True preserves the old in-place semantics for call sites
   that don't use the return value (einops, bias.py) or need existing
   references to remain recognized by dynamo.

2. Class support: nonstrict_trace wraps via functools.wraps, which
   breaks classes (isinstance, subclassing, attribute access).
   Classes now take the in-place path unconditionally, registering
   id(cls) in _allowed_callable_ids only (not _nonstrict_trace_callable_ids,
   since NONSTRICT_TRACE's flat_apply requires pytree-compatible I/O
   that most classes don't satisfy).

3. SDPAParams as flat_apply leaf: NONSTRICT_TRACE requires outputs to
   be "graphable" (tensors, scalars, etc). SDPAParams isn't pytree-
   registered and failed is_graphable. Rather than requiring pytree
   registration (which is side-effectful), we add register_graphable_type
   to let specific types pass through flat_apply as opaque leaves.
   Also fixed handle_traced_output's SDPAParams branch, which was
   missing the required param_vars argument.

Files changed:
- torch/_dynamo/decorators.py: nonstrict_trace gains in_place kwarg and
  class support; einops registration migrated
- torch/_dynamo/compiled_autograd.py: 3 call sites
- torch/_dynamo/backends/debugging.py: 2 call sites
- torch/compiler/__init__.py: allow_in_graph delegates to nonstrict_trace
- torch/nn/attention/bias.py: 4 call sites + register_graphable_type
- torch/sparse/semi_structured.py: 1 call site
- torch/_higher_order_ops/flat_apply.py: register_graphable_type API
- torch/_dynamo/variables/builder.py: fix handle_traced_output for SDPAParams

The change is kind of substantial with no clear benefits. Given this, should we 
reconsider deprecating allow_in_graph? Maybe we should just keep it as it is
 and creating a cleaner unfied API like https://github.com/pytorch/pytorch/pull/177180 (which directs to nonstrict_trace or leaf_functino)? @anijain2305 @zou3519 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98 @xmfan @aditvenk @Lucaskabela