### PR TITLE
Memory stack unwinding for arm64 code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1181,6 +1181,12 @@ if(NOT MSVC)
     string(APPEND CMAKE_CXX_FLAGS_DEBUG " -fno-omit-frame-pointer -O0")
     string(APPEND CMAKE_LINKER_FLAGS_DEBUG " -fno-omit-frame-pointer -O0")
   endif()
+  # aarch64 C++ stack unwinding uses frame-pointer chain walking, so frame
+  # pointers must be present in all build types.  The cost is negligible on
+  # aarch64 (31 GPRs vs x86-64's 16, so dedicating x29 rarely spills).
+  if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
+    append_cxx_flag_if_supported("-fno-omit-frame-pointer" CMAKE_CXX_FLAGS)
+  endif()
   append_cxx_flag_if_supported("-fno-math-errno" CMAKE_CXX_FLAGS)
   append_cxx_flag_if_supported("-fno-trapping-math" CMAKE_CXX_FLAGS)
   append_cxx_flag_if_supported("-Werror=format" CMAKE_CXX_FLAGS)

--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -1929,7 +1929,9 @@ if HAS_CUDA_AND_TRITON:
             del x
             self.assertEqual(all_live_block_count(), 0)
 
-        @unittest.skipUnless(IS_X86 and IS_LINUX, "cpp contexts are linux only")
+        @unittest.skipUnless(
+            (IS_X86 or IS_ARM64) and IS_LINUX, "cpp contexts are linux x86/aarch64 only"
+        )
         @torch._inductor.config.patch("triton.cudagraph_trees_history_recording", True)
         @blas_library_context("cublas")
         def test_workspace_allocation_error(self):

--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -62,6 +62,7 @@ from torch.testing._internal.common_utils import (
     IS_JETSON,
     IS_LINUX,
     IS_WINDOWS,
+    IS_X86,
     parametrize,
     run_tests,
     serialTest,
@@ -3589,7 +3590,9 @@ aten::mm""",
                 actual_fields = sorted(event.keys())
                 self.assertEqual(expected_fields, actual_fields)
 
-    @unittest.skipIf(IS_ARM64 or not IS_LINUX, "x86 linux only cpp unwinding")
+    @unittest.skipIf(
+        not IS_LINUX or not (IS_X86 or IS_ARM64), "linux x86/aarch64 only cpp unwinding"
+    )
     def test_fuzz_symbolize(self):
         # generate some random addresses in the text section and make sure the
         # symbolizers do not throw exceptions/crash

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -63,6 +63,7 @@ from torch.testing._internal.common_utils import (
     gcIfJetson,
     get_cycles_per_ms,
     instantiate_parametrized_tests,
+    IS_ARM64,
     IS_FBCODE,
     IS_JETSON,
     IS_LINUX,
@@ -98,7 +99,7 @@ from torch.utils.viz._cycles import observe_tensor_cycles
 
 
 requiresCppContext = unittest.skipUnless(
-    IS_X86 and IS_LINUX, "cpp contexts are x86 linux only"
+    (IS_X86 or IS_ARM64) and IS_LINUX, "cpp contexts are linux x86/aarch64 only"
 )
 
 # load_tests from common_utils is used to automatically filter tests for
@@ -4270,7 +4271,9 @@ class TestCudaAllocator(TestCase):
         x = torch.rand(64, device="cuda")
         self.assertIsNone(torch.cuda.memory._allocation_traceback(x.data_ptr()))
 
-    @unittest.skipUnless(IS_X86 and IS_LINUX, "x86 linux only cpp unwinding")
+    @unittest.skipUnless(
+        (IS_X86 or IS_ARM64) and IS_LINUX, "linux x86/aarch64 only cpp unwinding"
+    )
     def test_direct_traceback(self):
         from torch._C._profiler import gather_traceback, symbolize_tracebacks  # @manual
 

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -5001,7 +5001,7 @@ print(value, end="")
             torch.empty(1024 * 1024 * 1024 * 1024, device="cuda")
 
     @unittest.skipIf(
-        not (IS_LINUX and os.uname().machine == "x86_64"), "cpp traces only on linux"
+        not ((IS_X86 or IS_ARM64) and IS_LINUX), "cpp traces are linux x86/aarch64 only"
     )
     @unittest.skipIf(
         TEST_CUDAMALLOCASYNC, "setContextRecorder not supported by CUDAMallocAsync"

--- a/torch/csrc/profiler/unwind/action.h
+++ b/torch/csrc/profiler/unwind/action.h
@@ -11,7 +11,8 @@ enum {
   A_REG_PLUS_DATA_DEREF = 0x3 // exp = *(REG[reg] + data0)
 };
 
-// register numbers in dwarf info
+// DWARF register numbers — architecture-specific
+#if defined(__x86_64__)
 enum {
   D_UNDEFINED = -1,
   D_RBP = 6,
@@ -19,6 +20,28 @@ enum {
   D_RIP = 16,
   D_REG_SIZE = 17,
 };
+static constexpr int D_FRAME_PTR = D_RBP;
+static constexpr int D_STACK_PTR = D_RSP;
+static constexpr int D_RET_ADDR = D_RIP;
+static constexpr int D_EXPECTED_RA_REG = 16;
+#elif defined(__aarch64__)
+enum {
+  D_UNDEFINED = -1,
+  D_FP = 29,
+  D_LR = 30,
+  D_SP = 31,
+  D_REG_SIZE = 32,
+};
+static constexpr int D_FRAME_PTR = D_FP;
+static constexpr int D_STACK_PTR = D_SP;
+static constexpr int D_RET_ADDR = D_LR;
+static constexpr int D_EXPECTED_RA_REG = 30;
+#else
+enum {
+  D_UNDEFINED = -1,
+  D_REG_SIZE = 1,
+};
+#endif
 
 struct Action {
   uint8_t kind = A_UNDEFINED;

--- a/torch/csrc/profiler/unwind/dwarf_enums.h
+++ b/torch/csrc/profiler/unwind/dwarf_enums.h
@@ -30,6 +30,7 @@ enum {
   DW_CFA_advance_loc1 = 0x02,
   DW_CFA_advance_loc2 = 0x03,
   DW_CFA_advance_loc4 = 0x04,
+  DW_CFA_offset_extended = 0x05,
   DW_CFA_restore_extended = 0x06,
   DW_CFA_undefined = 0x07,
   DW_CFA_register = 0x09,

--- a/torch/csrc/profiler/unwind/fde.h
+++ b/torch/csrc/profiler/unwind/fde.h
@@ -63,8 +63,10 @@ struct FDE {
     } else {
       ra_register_ = static_cast<int64_t>(LC.readULEB128());
     }
-    // we assume this in the state
-    TORCH_INTERNAL_ASSERT(ra_register_ == 16, "unexpected number of registers");
+    TORCH_INTERNAL_ASSERT(
+        ra_register_ == D_EXPECTED_RA_REG,
+        "unexpected ra register: ",
+        ra_register_);
     if (augmentation_string_ && *augmentation_string_ == 'z') {
       augmentation_length_ = static_cast<int64_t>(LC.readULEB128());
       Lexer A(LC.loc());
@@ -270,6 +272,11 @@ struct FDE {
           case DW_CFA_advance_loc4: {
             auto delta = L.read<uint32_t>();
             return advance_loc(delta);
+          }
+          case DW_CFA_offset_extended: {
+            auto reg = L.readULEB128();
+            auto off = L.readULEB128();
+            return offset(reg, off);
           }
           case DW_CFA_restore_extended: {
             auto reg = L.readULEB128();

--- a/torch/csrc/profiler/unwind/unwind.cpp
+++ b/torch/csrc/profiler/unwind/unwind.cpp
@@ -3,32 +3,32 @@
 #include <c10/util/env.h>
 #include <torch/csrc/profiler/unwind/unwind.h>
 
-#if !defined(__linux__) || !defined(__x86_64__) || !defined(__has_include) || \
-    !__has_include("ext/stdio_filebuf.h")
+#if !defined(__linux__) || !(defined(__x86_64__) || defined(__aarch64__)) || \
+    !defined(__has_include) || !__has_include("ext/stdio_filebuf.h")
 namespace torch::unwind {
 std::vector<void*> unwind() {
   TORCH_WARN_ONCE(
-      "record_context_cpp is not support on non-linux non-x86_64 platforms");
+      "record_context_cpp is not supported on this platform (requires linux x86_64 or aarch64)");
   return {};
 }
 
 std::optional<std::pair<std::string, uint64_t>> libraryFor(void* addr) {
   TORCH_WARN_ONCE(
-      "record_context_cpp is not support on non-linux non-x86_64 platforms");
+      "record_context_cpp is not supported on this platform (requires linux x86_64 or aarch64)");
   return {};
 }
 
 #ifndef FBCODE_CAFFE2
 std::vector<Frame> symbolize(const std::vector<void*>& frames, Mode mode) {
   TORCH_WARN_ONCE(
-      "record_context_cpp is not support on non-linux non-x86_64 platforms");
+      "record_context_cpp is not supported on this platform (requires linux x86_64 or aarch64)");
   return {};
 }
 #endif
 
 Stats stats() {
   TORCH_WARN_ONCE(
-      "record_context_cpp is not support on non-linux non-x86_64 platforms");
+      "record_context_cpp is not supported on this platform (requires linux x86_64 or aarch64)");
   return {};
 }
 
@@ -41,6 +41,7 @@ Stats stats() {
 #include <elf.h>
 #include <link.h>
 #include <linux/limits.h>
+#include <pthread.h>
 #include <algorithm>
 #include <climits>
 #include <vector>
@@ -53,7 +54,11 @@ Stats stats() {
 #include <torch/csrc/profiler/unwind/unwinder.h>
 #include <shared_mutex>
 
+#if defined(__aarch64__)
+extern "C" void unwind_c(std::vector<void*>* result, int64_t fp, int64_t lr);
+#else
 extern "C" void unwind_c(std::vector<void*>* result, int64_t rsp, int64_t rbp);
+#endif
 extern "C" void unwind_entry(std::vector<void*>* result);
 
 namespace torch::unwind {
@@ -98,7 +103,8 @@ struct LibraryInfo {
     void* fde_data = eh_frame_hdr_.entryForAddr(addr);
     FDE fde(fde_data, name().c_str(), load_bias());
     TableState state = fde.readUpTo(addr);
-    return Unwinder(state.cfa, state.registers[D_RIP], state.registers[D_RBP]);
+    return Unwinder(
+        state.cfa, state.registers[D_RET_ADDR], state.registers[D_FRAME_PTR]);
   }
   const std::string& name() const {
     return name_;
@@ -501,6 +507,82 @@ Stats stats() {
 
 } // namespace torch::unwind
 
+#if defined(__aarch64__)
+// aarch64 uses frame-pointer chain walking instead of DWARF unwinding.
+// Each frame has: *(FP) = caller's FP, *(FP+8) = saved LR (return address).
+// This is simpler and avoids issues with tail calls producing stale x30
+// values in DWARF-based unwinding.  GCC/Clang on aarch64 emit frame
+// pointers by default even at -O2.
+//
+// External libraries (CPython, libc, CUDA runtime) may be built without
+// frame pointers, making x29 an arbitrary callee-saved value.  We obtain
+// the current thread's stack bounds and reject any fp outside that range
+// to avoid dereferencing garbage pointers.
+//
+// No cache_mutex_ needed: frame-pointer walking reads only the stack,
+// unlike the x86 path which queries the DWARF FDE cache.
+
+static bool get_stack_bounds(uintptr_t& lo, uintptr_t& hi) {
+  pthread_attr_t attr;
+  if (pthread_getattr_np(pthread_self(), &attr) != 0) {
+    return false;
+  }
+  void* base = nullptr;
+  size_t size = 0;
+  int rc = pthread_attr_getstack(&attr, &base, &size);
+  pthread_attr_destroy(&attr);
+  if (rc != 0) {
+    return false;
+  }
+  lo = reinterpret_cast<uintptr_t>(base);
+  hi = lo + size;
+  return true;
+}
+
+extern "C" C10_USED void unwind_c(
+    std::vector<void*>* result,
+    int64_t fp,
+    int64_t lr) {
+  // NOLINTNEXTLINE(performance-no-int-to-ptr)
+  result->push_back((void*)lr);
+
+  uintptr_t stack_lo = 0, stack_hi = 0;
+  if (!get_stack_bounds(stack_lo, stack_hi)) {
+    return;
+  }
+
+  constexpr int kMaxFrames = 4096;
+  int depth = 0;
+  while (fp != 0 && (fp & 0xF) == 0 && depth++ < kMaxFrames) {
+    auto ufp = static_cast<uintptr_t>(fp);
+    if (ufp < stack_lo || ufp + 16 > stack_hi) {
+      break;
+    }
+    // NOLINTNEXTLINE(performance-no-int-to-ptr)
+    int64_t saved_lr = *(int64_t*)(fp + 8);
+    if (saved_lr == 0) {
+      break;
+    }
+    // NOLINTNEXTLINE(performance-no-int-to-ptr)
+    result->push_back((void*)saved_lr);
+    // NOLINTNEXTLINE(performance-no-int-to-ptr)
+    int64_t next_fp = *(int64_t*)fp;
+    if (next_fp <= fp) {
+      break;
+    }
+    fp = next_fp;
+  }
+}
+
+// x0 already holds the result pointer.
+// Pass FP (x29) and LR (x30), then tail-call unwind_c.
+__asm__(
+    ".global unwind_entry\n"
+    "unwind_entry:\n"
+    "mov x1, x29\n"
+    "mov x2, x30\n"
+    "b unwind_c\n");
+#else
 extern "C" C10_USED void unwind_c(
     std::vector<void*>* result,
     int64_t rsp,
@@ -508,17 +590,17 @@ extern "C" C10_USED void unwind_c(
   std::shared_lock lock(torch::unwind::cache_mutex_);
   torch::unwind::UnwindState state{};
   // NOLINTNEXTLINE(performance-no-int-to-ptr)
-  state.rip = *(int64_t*)rsp;
+  state.pc = *(int64_t*)rsp;
   // +8 because we saved rsp after the return address was already pushed
   // to the stack
-  state.rsp = rsp + 8;
-  state.rbp = rbp;
+  state.sp = rsp + 8;
+  state.fp = rbp;
   torch::unwind::unwind_cache.checkRefresh(lock);
-  while (true) { // unwind for _start sets rip as being undefined
+  while (true) {
     // NOLINTNEXTLINE(performance-no-int-to-ptr)
-    result->push_back((void*)state.rip);
+    result->push_back((void*)state.pc);
     const torch::unwind::Unwinder& uw =
-        torch::unwind::unwind_cache.unwinderFor(state.rip, lock);
+        torch::unwind::unwind_cache.unwinderFor(state.pc, lock);
     if (uw.terminator()) {
       if (uw.isUnknown()) {
         result->push_back(nullptr);
@@ -529,8 +611,7 @@ extern "C" C10_USED void unwind_c(
   }
 }
 
-// calling convention puts the first three pointer/int64_t arguments in
-// rdi rsi rdx (all caller-saved)
+// x86-64 calling convention: rdi rsi rdx (all caller-saved)
 // rdi already holds the pointer to the result vector
 // we add arguments for current rsp and rbp and then tail call
 // into unwind_c
@@ -540,5 +621,6 @@ __asm__(
     "mov %rsp, %rsi;\n"
     "mov %rbp, %rdx;\n"
     "jmp unwind_c;\n");
+#endif
 
 #endif

--- a/torch/csrc/profiler/unwind/unwind.cpp
+++ b/torch/csrc/profiler/unwind/unwind.cpp
@@ -44,6 +44,7 @@ Stats stats() {
 #include <pthread.h>
 #include <algorithm>
 #include <climits>
+#include <cstring>
 #include <vector>
 
 #include <c10/util/irange.h>
@@ -55,7 +56,10 @@ Stats stats() {
 #include <shared_mutex>
 
 #if defined(__aarch64__)
-extern "C" void unwind_c(std::vector<void*>* result, int64_t fp, int64_t lr);
+extern "C" void unwind_c(
+    std::vector<void*>* result,
+    uintptr_t fp,
+    uintptr_t lr);
 #else
 extern "C" void unwind_c(std::vector<void*>* result, int64_t rsp, int64_t rbp);
 #endif
@@ -541,8 +545,8 @@ static bool get_stack_bounds(uintptr_t& lo, uintptr_t& hi) {
 
 extern "C" C10_USED void unwind_c(
     std::vector<void*>* result,
-    int64_t fp,
-    int64_t lr) {
+    uintptr_t fp,
+    uintptr_t lr) {
   // NOLINTNEXTLINE(performance-no-int-to-ptr)
   result->push_back((void*)lr);
 
@@ -554,19 +558,19 @@ extern "C" C10_USED void unwind_c(
   constexpr int kMaxFrames = 4096;
   int depth = 0;
   while (fp != 0 && (fp & 0xF) == 0 && depth++ < kMaxFrames) {
-    auto ufp = static_cast<uintptr_t>(fp);
-    if (ufp < stack_lo || ufp + 16 > stack_hi) {
+    if (fp < stack_lo || fp + 16 > stack_hi) {
       break;
     }
-    // NOLINTNEXTLINE(performance-no-int-to-ptr)
-    int64_t saved_lr = *(int64_t*)(fp + 8);
+    uintptr_t saved_lr;
+    std::memcpy(
+        &saved_lr, reinterpret_cast<const void*>(fp + 8), sizeof(saved_lr));
     if (saved_lr == 0) {
       break;
     }
     // NOLINTNEXTLINE(performance-no-int-to-ptr)
     result->push_back((void*)saved_lr);
-    // NOLINTNEXTLINE(performance-no-int-to-ptr)
-    int64_t next_fp = *(int64_t*)fp;
+    uintptr_t next_fp;
+    std::memcpy(&next_fp, reinterpret_cast<const void*>(fp), sizeof(next_fp));
     if (next_fp <= fp) {
       break;
     }

--- a/torch/csrc/profiler/unwind/unwinder.h
+++ b/torch/csrc/profiler/unwind/unwinder.h
@@ -6,30 +6,32 @@
 
 namespace torch::unwind {
 
+// Architecture-neutral names: pc (program counter / return address),
+// fp (frame pointer: x86 RBP, aarch64 x29), sp (stack pointer).
 struct UnwindState {
-  int64_t rip, rbp, rsp;
+  int64_t pc, fp, sp;
 };
 
 struct Unwinder {
-  Unwinder(Action rsp, Action rip, Action rbp)
-      : kind_(rip.kind == A_UNDEFINED ? END : STANDARD),
-        reg_(rsp.reg),
-        off_(rsp.data),
-        rip_off_(rip.data),
-        rbp_off_(
-            rbp.kind == A_UNDEFINED ? std::numeric_limits<int64_t>::max()
-                                    : rbp.data),
-        deref_(rsp.kind == A_REG_PLUS_DATA_DEREF) {
-    check(rsp.reg == D_RSP || rsp.reg == D_RBP);
-    check(rip.kind == A_UNDEFINED || rip.kind == A_LOAD_CFA_OFFSET);
-    if (rsp.kind == A_REG_PLUS_DATA) {
-      check(rbp.kind == A_LOAD_CFA_OFFSET || rbp.kind == A_UNDEFINED);
-    } else if (rsp.kind == A_REG_PLUS_DATA_DEREF) {
-      if (rbp.kind == A_REG_PLUS_DATA_DEREF) {
-        check(rbp.reg == rsp.reg);
-        rbp_off_ -= rsp.data;
+  Unwinder(Action cfa, Action ret, Action fp)
+      : kind_(ret.kind == A_UNDEFINED ? END : STANDARD),
+        reg_(cfa.reg),
+        off_(cfa.data),
+        ret_off_(ret.data),
+        fp_off_(
+            fp.kind == A_UNDEFINED ? std::numeric_limits<int64_t>::max()
+                                   : fp.data),
+        deref_(cfa.kind == A_REG_PLUS_DATA_DEREF) {
+    check(cfa.reg == D_STACK_PTR || cfa.reg == D_FRAME_PTR);
+    check(ret.kind == A_UNDEFINED || ret.kind == A_LOAD_CFA_OFFSET);
+    if (cfa.kind == A_REG_PLUS_DATA) {
+      check(fp.kind == A_LOAD_CFA_OFFSET || fp.kind == A_UNDEFINED);
+    } else if (cfa.kind == A_REG_PLUS_DATA_DEREF) {
+      if (fp.kind == A_REG_PLUS_DATA_DEREF) {
+        check(fp.reg == cfa.reg);
+        fp_off_ -= cfa.data;
       } else {
-        check(rbp.kind == A_UNDEFINED);
+        check(fp.kind == A_UNDEFINED);
       }
     } else {
       check(false);
@@ -53,28 +55,28 @@ struct Unwinder {
   }
   UnwindState run(const UnwindState& cur) const {
     UnwindState r = cur;
-    r.rsp = (reg_ == D_RSP ? cur.rsp : cur.rbp) + off_;
-    r.rbp = rbp_off_ == std::numeric_limits<int64_t>::max()
-        ? cur.rbp
+    r.sp = (reg_ == D_STACK_PTR ? cur.sp : cur.fp) + off_;
+    r.fp = fp_off_ == std::numeric_limits<int64_t>::max()
+        ? cur.fp
         // NOLINTNEXTLINE(performance-no-int-to-ptr)
-        : *(int64_t*)(r.rsp + rbp_off_);
+        : *(int64_t*)(r.sp + fp_off_);
     if (deref_) {
       // NOLINTNEXTLINE(performance-no-int-to-ptr)
-      r.rsp = *(int64_t*)r.rsp;
+      r.sp = *(int64_t*)r.sp;
     }
     // NOLINTNEXTLINE(performance-no-int-to-ptr)
-    r.rip = *(int64_t*)(r.rsp + rip_off_);
+    r.pc = *(int64_t*)(r.sp + ret_off_);
 
     return r;
   }
 
  private:
-  Unwinder() : kind_(UNKNOWN), reg_(0), off_(0), rip_off_(0), rbp_off_(0) {}
+  Unwinder() : kind_(UNKNOWN), reg_(0), off_(0), ret_off_(0), fp_off_(0) {}
   enum Kind { STANDARD, END, UNKNOWN } kind_;
   uint32_t reg_;
   int64_t off_;
-  int64_t rip_off_;
-  int64_t rbp_off_;
+  int64_t ret_off_;
+  int64_t fp_off_;
   bool deref_{false};
 };
 

--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -993,8 +993,7 @@ def _get_debug_context_and_cb() -> Tuple[Callable[[], Any], Callable[[Checkpoint
     # checkpointing mechanism. error_cb is invoked when an error is detected
     # during unpack.
 
-    # record_context_cpp is not support on non-linux non-x86_64 platforms
-    cpp_tb = platform.machine() == 'x86_64' and platform.system() == 'Linux'
+    cpp_tb = platform.machine() in ('x86_64', 'aarch64', 'arm64') and platform.system() == 'Linux'
 
     class CaptureLogs:
         def __init__(self) -> None:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #178418

# Summary

This PR enables record_context_cpp on Linux aarch64. The main change is adding an aarch64-specific unwinding path that walks the frame-pointer chain rather than relying on the existing x86-64 DWARF-based unwinder. 

While from some googling 02 shoudl preserve frame pointers but also explicitly set it in cmake.  Also since some other frames my get inthe mix that might not have frame pointers we basically just exit in that case by bound checking the next candidate FP. 
The PR also cleans up architecture-specific unwind constants, teaches the FDE parser a few additional CFA opcodes, and broadens existing traceback tests to cover Linux aarch64.


aarch64 unwinding in this PR:

    frame_n
    +----------------------+
    | prev FP              | --------------------+
    | saved LR (ret addr)  |                     |
    +----------------------+                     v

    frame_(n-1)
    +----------------------+
    | prev FP              | --------------------+
    | saved LR (ret addr)  |                     |
    +----------------------+                     v

    frame_(n-2)
    +----------------------+
    | prev FP              | ---- candidate next FP ----+
    | saved LR (ret addr)  |                            |
    +----------------------+                            v

                                              0x7f12deadbeef
                                                    |
                                                    v
                                         +----------------------+
                                         | bogus address        |
                                         | not a real FP frame  |
                                         | not "prev FP / LR"   |
                                         | maybe junk / foreign |
                                         +----------------------+

Unwinder logic:

    current FP -> read candidate next FP
               -> check: is candidate within this thread's stack bounds?
                    yes -> keep walking
                    no  -> stop

So the walk becomes:

    frame_n -> frame_(n-1) -> frame_(n-2) -> [bogus FP] -> stop



## Testing
# AArch64 Unwind Test Results

Executed from `/home/drisspg/meta/pytorch` using the `dev` environment.

## Command

```zsh
export PATH=$HOME/.venvs/dev/bin:$PATH
tests=(
  'test/profiler/test_profiler.py::TestExperimentalUtils::test_fuzz_symbolize'
  'test/test_cuda.py::TestCudaAllocator::test_direct_traceback'
  'test/test_cuda.py::TestCudaAllocator::test_memory_snapshot_with_cpp'
  'test/test_cuda.py::TestCudaAllocator::test_cycles'
  'test/test_cuda.py::TestCudaAllocator::test_memory_plots'
  'test/test_cuda.py::TestCudaAllocator::test_memory_plots_free_stack'
  'test/test_cuda.py::TestCudaAllocator::test_memory_compile_regions'
  'test/test_cuda.py::TestCudaAllocator::test_memory_plots_history_context'
  'test/test_cuda.py::TestCudaAllocator::test_memory_plots_free_segment_stack'
  'test/test_cuda.py::TestCudaAllocator::test_memory_plots_metadata'
  'test/test_cuda.py::TestCudaAllocator::test_cpp_memory_snapshot_pickle'
  'test/inductor/test_cudagraph_trees.py::CudaGraphTreeTests::test_workspace_allocation_error'
)
overall=0
for t in "${tests[@]}"; do
  print -r -- "$t"
  ~/.venvs/dev/bin/pytest -q -rs "$t" || overall=$?
done
exit $overall
```

## Environment Notes

- `python`: `/home/drisspg/.venvs/dev/bin/python`
- `pytest`: `/home/drisspg/.venvs/dev/bin/pytest`
- `ninja`: `/home/drisspg/.venvs/dev/bin/ninja`
- `triton`: `/home/drisspg/.venvs/dev/lib/python3.13/site-packages/triton/__init__.py`
- `PATH` must include `~/.venvs/dev/bin` so subprocesses can resolve `ninja` and Triton-backed tooling correctly.

## Results

- `test/profiler/test_profiler.py::TestExperimentalUtils::test_fuzz_symbolize`: PASSED
- `test/test_cuda.py::TestCudaAllocator::test_direct_traceback`: PASSED
- `test/test_cuda.py::TestCudaAllocator::test_memory_snapshot_with_cpp`: PASSED
- `test/test_cuda.py::TestCudaAllocator::test_cycles`: PASSED
- `test/test_cuda.py::TestCudaAllocator::test_memory_plots`: PASSED
- `test/test_cuda.py::TestCudaAllocator::test_memory_plots_free_stack`: PASSED
- `test/test_cuda.py::TestCudaAllocator::test_memory_compile_regions`: PASSED
- `test/test_cuda.py::TestCudaAllocator::test_memory_plots_history_context`: PASSED
- `test/test_cuda.py::TestCudaAllocator::test_memory_plots_free_segment_stack`: PASSED
- `test/test_cuda.py::TestCudaAllocator::test_memory_plots_metadata`: PASSED
- `test/test_cuda.py::TestCudaAllocator::test_cpp_memory_snapshot_pickle`: PASSED
- `test/inductor/test_cudagraph_trees.py::CudaGraphTreeTests::test_workspace_allocation_error`: PASSED

## Summary

- Total targeted tests: 12
- Passed: 12
- Failed: 0
- Skipped: 0


Before:
<img width="1071" height="1442" alt="image" src="https://github.com/user-attachments/assets/c9da8e12-c1ec-4974-8799-5e72820d4832" />


After:
<img width="1048" height="1716" alt="image" src="https://github.com/user-attachments/assets/52668dcc-2a1b-4ace-b416-cffd5b4ee28f" />


cc @snadampal @milpuz01 @aditew01 @nikhil-arm @fadara01 @nWEIdia @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo