### PR TITLE
[leaf_function] Fill None gradients with zeros in backward

### DIFF
--- a/test/functorch/test_leaf_function.py
+++ b/test/functorch/test_leaf_function.py
@@ -285,6 +285,99 @@ class f(torch.nn.Module):
         self.assertEqual(gm_out, eager_out)
         self.assertEqual(buf_gm, buf_eager)
 
+    def test_make_fx_unused_input_backward(self):
+        @leaf_function
+        def my_fn(x, y):
+            return (x * 2,)
+
+        @my_fn.register_fake
+        def my_fn_fake(x, y):
+            return (x * 2,)
+
+        def f(x, y):
+            out = my_fn(x, y)[0].sum()
+            return torch.autograd.grad(out, (x, y), allow_unused=True)
+
+        x = torch.randn(3, 3, requires_grad=True)
+        y = torch.randn(3, 3, requires_grad=True)
+
+        gm = make_fx(f, tracing_mode="fake")(x, y)
+        self.assertExpectedInline(
+            normalize_gm(gm.print_readable(print_output=False)),
+            """\
+class f(torch.nn.Module):
+    def forward(self, x_1: "f32[3, 3]", y_1: "f32[3, 3]"):
+        _opaque_obj0 = self._opaque_obj0
+        _opaque_obj1 = self._opaque_obj1
+        _tree_spec_constant0 = self._tree_spec_constant0
+        invoke_leaf_function = torch.ops.higher_order.invoke_leaf_function(_opaque_obj0, _opaque_obj1, _tree_spec_constant0, '', x_1, y_1, requires_grad_indices = '0,1');  _opaque_obj0 = _opaque_obj1 = _tree_spec_constant0 = x_1 = y_1 = None
+        getitem: "f32[3, 3]" = invoke_leaf_function[0];  invoke_leaf_function = None
+        sum_1: "f32[]" = torch.ops.aten.sum.default(getitem);  getitem = None
+        ones_like: "f32[]" = torch.ops.aten.ones_like.default(sum_1, pin_memory = False, memory_format = torch.preserve_format);  sum_1 = None
+        expand: "f32[3, 3]" = torch.ops.aten.expand.default(ones_like, [3, 3]);  ones_like = None
+        _opaque_obj2 = self._opaque_obj2
+        _opaque_obj3 = self._opaque_obj3
+        _tree_spec_constant1 = self._tree_spec_constant1
+        invoke_leaf_function_1 = torch.ops.higher_order.invoke_leaf_function(_opaque_obj2, _opaque_obj3, _tree_spec_constant1, '', expand, requires_grad_indices = '');  _opaque_obj2 = _opaque_obj3 = _tree_spec_constant1 = expand = None
+        getitem_1: "f32[3, 3]" = invoke_leaf_function_1[0]
+        getitem_2: "f32[3, 3]" = invoke_leaf_function_1[1];  invoke_leaf_function_1 = None
+        return (getitem_1, getitem_2)
+""",  # noqa: B950
+        )
+
+        x2 = torch.randn(3, 3, requires_grad=True)
+        y2 = torch.randn(3, 3, requires_grad=True)
+        dx, dy = gm(x2, y2)
+        self.assertEqual(dx, torch.ones(3, 3) * 2)
+        self.assertEqual(dy, torch.zeros(3, 3))
+
+    def test_make_fx_mixed_requires_grad_backward(self):
+        @leaf_function
+        def my_fn(x, y):
+            return (x + y,)
+
+        @my_fn.register_fake
+        def my_fn_fake(x, y):
+            return (x + y,)
+
+        def f(x, y):
+            out = my_fn(x, y)[0].sum()
+            (dx,) = torch.autograd.grad(out, x)
+            return dx
+
+        x = torch.randn(3, 3, requires_grad=True)
+        y = torch.randn(3, 3, requires_grad=False)
+
+        gm = make_fx(f, tracing_mode="fake")(x, y)
+        self.assertExpectedInline(
+            normalize_gm(gm.print_readable(print_output=False)),
+            """\
+class f(torch.nn.Module):
+    def forward(self, x_1: "f32[3, 3]", y_1: "f32[3, 3]"):
+        _opaque_obj0 = self._opaque_obj0
+        _opaque_obj1 = self._opaque_obj1
+        _tree_spec_constant0 = self._tree_spec_constant0
+        invoke_leaf_function = torch.ops.higher_order.invoke_leaf_function(_opaque_obj0, _opaque_obj1, _tree_spec_constant0, '', x_1, y_1, requires_grad_indices = '0');  _opaque_obj0 = _opaque_obj1 = _tree_spec_constant0 = x_1 = y_1 = None
+        getitem: "f32[3, 3]" = invoke_leaf_function[0];  invoke_leaf_function = None
+        sum_1: "f32[]" = torch.ops.aten.sum.default(getitem);  getitem = None
+        ones_like: "f32[]" = torch.ops.aten.ones_like.default(sum_1, pin_memory = False, memory_format = torch.preserve_format);  sum_1 = None
+        expand: "f32[3, 3]" = torch.ops.aten.expand.default(ones_like, [3, 3]);  ones_like = None
+        _opaque_obj2 = self._opaque_obj2
+        _opaque_obj3 = self._opaque_obj3
+        _tree_spec_constant1 = self._tree_spec_constant1
+        invoke_leaf_function_1 = torch.ops.higher_order.invoke_leaf_function(_opaque_obj2, _opaque_obj3, _tree_spec_constant1, '', expand, requires_grad_indices = '');  _opaque_obj2 = _opaque_obj3 = _tree_spec_constant1 = expand = None
+        getitem_1: "f32[3, 3]" = invoke_leaf_function_1[0]
+        getitem_2: "f32[3, 3]" = invoke_leaf_function_1[1];  invoke_leaf_function_1 = getitem_2 = None
+        return getitem_1
+""",  # noqa: B950
+        )
+
+        x2 = torch.randn(3, 3, requires_grad=True)
+        y2 = torch.randn(3, 3, requires_grad=False)
+        dx = gm(x2, y2)
+        self.assertIsNotNone(dx)
+        self.assertEqual(dx, torch.ones(3, 3))
+
 
 @skipIfTorchDynamo("leaf_function tests manage their own compilation")
 class TestLeafFunctionAotFunction(TestCase):

--- a/torch/_higher_order_ops/invoke_leaf_function.py
+++ b/torch/_higher_order_ops/invoke_leaf_function.py
@@ -663,12 +663,23 @@ class InvokeLeafFunctionAutogradOp(torch.autograd.Function):
                 raise RuntimeError(
                     "invoke_leaf_function backward expects inputs/outputs to be set in forward."
                 )
-            return autograd_grad_with_gradient_info(
+            result = autograd_grad_with_gradient_info(
                 output_infos=real_state["outputs"],
                 input_infos=real_state["inputs"],
                 grad_outputs=grads,
                 allow_unused=True,
             )
+            result = tuple(
+                g
+                if g is not None
+                else (
+                    torch.zeros(arg.size(), dtype=arg.dtype, device=arg.device)
+                    if isinstance(arg, torch.Tensor)
+                    else None
+                )
+                for g, arg in zip(result, flat_args)
+            )
+            return result
 
         input_infos_for_fake = tuple(
             GradientInfo(
@@ -683,15 +694,30 @@ class InvokeLeafFunctionAutogradOp(torch.autograd.Function):
             for arg in flat_args
         )
 
+        # input_infos_for_fake is None for tensor inputs without requires_grad.
+        # We still need to return zero tensors (not None) for these inputs in
+        # fake_backward, so we capture their metadata separately.
+        input_tensor_meta_for_fake = tuple(
+            (arg.size(), arg.dtype, arg.device)
+            if isinstance(arg, torch.Tensor)
+            else None
+            for arg in flat_args
+        )
+
         def fake_backward(*grads):
-            return tuple(
-                torch.empty_strided(
-                    info.size, info.stride, dtype=info.dtype, device=info.device
-                )
-                if info is not None
-                else None
-                for info in input_infos_for_fake
-            )
+            result: list[torch.Tensor | None] = []
+            for info, meta in zip(input_infos_for_fake, input_tensor_meta_for_fake):
+                if info is not None:
+                    result.append(
+                        torch.empty_strided(
+                            info.size, info.stride, dtype=info.dtype, device=info.device
+                        )
+                    )
+                elif meta is not None:
+                    result.append(torch.zeros(meta[0], dtype=meta[1], device=meta[2]))
+                else:
+                    result.append(None)
+            return tuple(result)
 
         new_real_fn_callable = _LeafCallable(real_forward)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #178444
* __->__ #178422

In invoke_leaf_function's backward, autograd_grad_with_gradient_info can
return None for non-requires_grad tensor inputs. Replace None grads with
torch.zeros(...) to prevent crashes in downstream autograd when these
None values flow into ops that expect tensors.

Also fix fake_backward to produce zero gradients for tensor inputs
without requires_grad, which previously returned None.
