### PR TITLE
[Accelerator] Add test for get_device_capability supported_dtypes

### DIFF
--- a/test/test_accelerator.py
+++ b/test/test_accelerator.py
@@ -3,6 +3,7 @@
 import gc
 import sys
 import unittest
+from contextlib import nullcontext
 
 import torch
 from torch.testing._internal.common_utils import (
@@ -13,7 +14,6 @@ from torch.testing._internal.common_utils import (
     TEST_MULTIACCELERATOR,
     TestCase,
 )
-from contextlib import nullcontext
 
 
 if not TEST_ACCELERATOR:
@@ -281,7 +281,11 @@ class TestAccelerator(TestCase):
         ]
         for dtype in all_dtypes:
             with self.subTest(dtype=dtype):
-                ctx = nullcontext() if dtype in supported_dtypes else self.assertRaises((RuntimeError, TypeError))
+                ctx = (
+                    nullcontext()
+                    if dtype in supported_dtypes
+                    else self.assertRaises((RuntimeError, TypeError))
+                )
                 with ctx:
                     t = torch.empty(16, dtype=dtype, device=acc)
                     t = t.to(reference_dtype)

--- a/test/test_accelerator.py
+++ b/test/test_accelerator.py
@@ -13,6 +13,7 @@ from torch.testing._internal.common_utils import (
     TEST_MULTIACCELERATOR,
     TestCase,
 )
+from contextlib import nullcontext
 
 
 if not TEST_ACCELERATOR:
@@ -259,6 +260,32 @@ class TestAccelerator(TestCase):
         free_bytes, total_bytes = torch.accelerator.get_memory_info()
         self.assertGreaterEqual(free_bytes, 0)
         self.assertGreaterEqual(total_bytes, 0)
+
+    def test_device_capability_supported_dtypes(self):
+        try:
+            caps = torch.accelerator.get_device_capability()
+        except RuntimeError:
+            self.skipTest("Backend doesn't support get_device_capability")
+
+        supported_dtypes = caps["supported_dtypes"]
+        self.assertIsInstance(supported_dtypes, set)
+        self.assertGreater(len(supported_dtypes), 0)
+
+        acc = torch.accelerator.current_accelerator()
+        reference_dtype = next(iter(supported_dtypes))
+
+        all_dtypes = [
+            getattr(torch, name)
+            for name in dir(torch)
+            if isinstance(getattr(torch, name), torch.dtype)
+        ]
+        for dtype in all_dtypes:
+            with self.subTest(dtype=dtype):
+                ctx = nullcontext() if dtype in supported_dtypes else self.assertRaises((RuntimeError, TypeError))
+                with ctx:
+                    t = torch.empty(16, dtype=dtype, device=acc)
+                    t = t.to(reference_dtype)
+                    t = t.to(dtype)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #178423
* #178180

Test is skipped if accelerator does not support `get_device_capability`

Verify that tensor allocation and conversion succeeds for all dtypes reported as
supported and fails for the rest, which are constructed dynamically from all `torch.type` subclasses from `torch.` package

Co-authored-by: Claude <noreply@anthropic.com>

cc @albanD @guangyey @EikanWang