### PR TITLE
[inductor][autotuning] add generic post-init hooks to CachingAutotuner (#178424)

### DIFF
--- a/test/inductor/test_triton_heuristics.py
+++ b/test/inductor/test_triton_heuristics.py
@@ -303,6 +303,21 @@ class TestTritonHeuristics(TestCase):
             )
             self.assertEqual(len(configs), expected_count)
 
+    @skipUnless(HAS_GPU_AND_TRITON, "requires gpu and triton")
+    def test_post_init_hook_fires_on_init(self):
+        saved_hooks = CachingAutotuner._post_init_hooks[:]
+        CachingAutotuner._post_init_hooks.clear()
+        try:
+            hook = MagicMock()
+            CachingAutotuner.register_post_init_hook(hook)
+
+            args = self._get_cos_kernel_caching_autotuner_args()
+            autotuner = CachingAutotuner(**args)
+
+            hook.assert_called_once_with(autotuner)
+        finally:
+            CachingAutotuner._post_init_hooks[:] = saved_hooks
+
 
 class TestArgumentCloneAndRestore(TestCase):
     # Our tensor is large enough. If a unexpected copy happens, the

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -19,7 +19,7 @@ import sys
 import threading
 import time
 from collections import namedtuple
-from typing import Any, Generic, Literal, TYPE_CHECKING, TypeVar
+from typing import Any, ClassVar, Generic, Literal, TYPE_CHECKING, TypeVar
 
 import torch
 from torch._dynamo.utils import counters, set_feature_use
@@ -327,6 +327,17 @@ class CachingAutotuner(KernelInterface):
     configs, and does not rely on the Triton JIT.
     """
 
+    _post_init_hooks: ClassVar[list[Callable[[CachingAutotuner], None]]] = []
+
+    @classmethod
+    def register_post_init_hook(cls, hook: Callable[[CachingAutotuner], None]) -> None:
+        """Register a hook called on every new CachingAutotuner instance.
+
+        Hooks fire at the end of __init__ (including subclasses that call
+        super().__init__). They receive the fully-initialized instance.
+        """
+        cls._post_init_hooks.append(hook)
+
     def __init__(
         self,
         fn,
@@ -440,6 +451,9 @@ class CachingAutotuner(KernelInterface):
 
         # Mode for launch grid calculation
         self.grid_mode: Literal["python", "cpp"] = "python"
+
+        for hook in self._post_init_hooks:
+            hook(self)
 
     def is_statically_launchable(self):
         """


### PR DESCRIPTION
Summary:

Adds a new extension point to CachingAutotuner:

Class-level post-init hooks: `register_post_init_hook(hook)` —
registers a callable that fires at the end of every
CachingAutotuner.__init__. Hooks receive
the fully-initialized instance. Good for registering callbacks.

This is a generic extension point — any consumer can register hooks. A follow-up diff uses this to plug in FB-internal autotuning telemetry.

Authored with Claude.

Test Plan: ```buck test fbcode//mode/opt caffe2/test/inductor:triton_heuristics -- TestTritonHeuristics.test_post_init_hook_fires_on_init```

Reviewed By: PaulZhang12

Differential Revision: D97986727




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo