### PR TITLE
[dynamo] Avoid overspecializing list append/clear mutations

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -6251,6 +6251,40 @@ not ___dict_contains('cccccccc', G['sys'].modules)""",
         res2 = opt_f2()
         self.assertTrue(same(res1, res2))
 
+    def test_list_append_does_not_recompile_on_existing_contents(self):
+        items = []
+        cnts = CompileCounter()
+
+        def fn():
+            items.append(torch.ones(8))
+
+        opt_fn = torch.compile(fn, backend=cnts, fullgraph=True)
+
+        opt_fn()
+        opt_fn()
+        opt_fn()
+
+        self.assertEqual(len(items), 3)
+        self.assertEqual(cnts.frame_count, 1)
+
+    def test_list_clear_does_not_recompile_on_existing_contents(self):
+        items = [torch.randn(8)]
+        cnts = CompileCounter()
+
+        def fn():
+            items.clear()
+
+        opt_fn = torch.compile(fn, backend=cnts, fullgraph=True)
+
+        opt_fn()
+        self.assertEqual(len(items), 0)
+
+        items.extend([torch.randn(8), torch.randn(8)])
+        opt_fn()
+
+        self.assertEqual(len(items), 0)
+        self.assertEqual(cnts.frame_count, 1)
+
     def test_inline_dict_mutation(self):
         def f1(d):
             d["c"] = d["a"] + d.pop("b")

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -6273,16 +6273,18 @@ not ___dict_contains('cccccccc', G['sys'].modules)""",
 
         def fn():
             items.clear()
+            return torch.ones(8)
 
         opt_fn = torch.compile(fn, backend=cnts, fullgraph=True)
 
-        opt_fn()
+        out1 = opt_fn()
         self.assertEqual(len(items), 0)
 
         items.extend([torch.randn(8), torch.randn(8)])
-        opt_fn()
+        out2 = opt_fn()
 
         self.assertEqual(len(items), 0)
+        self.assertTrue(same(out1, out2))
         self.assertEqual(cnts.frame_count, 1)
 
     def test_inline_dict_mutation(self):

--- a/torch/_dynamo/side_effects.py
+++ b/torch/_dynamo/side_effects.py
@@ -1024,9 +1024,9 @@ class SideEffects:
                 side_effects_log.debug(msg)
 
         def _codegen_direct_list_replay(
-            list_vt: "ListVariable", source: Source
+            list_vt: "ListVariable", source: Source | None
         ) -> bool:
-            if not list_vt.has_direct_list_replay():
+            if source is None or not list_vt.has_direct_list_replay():
                 return False
             appended_items = list_vt.direct_list_replay_appends()
 
@@ -1058,9 +1058,7 @@ class SideEffects:
             ):
                 continue
             if isinstance(var, variables.ListVariable):
-                if _codegen_direct_list_replay(
-                    var, var.source
-                ):  # type: ignore[arg-type]
+                if _codegen_direct_list_replay(var, var.source):
                     continue
                 # old[:] = new
                 cg(var, allow_cache=False)  # Don't codegen via source
@@ -1247,9 +1245,7 @@ class SideEffects:
                     var,
                     variables.UserDefinedListVariable,
                 ) and self.is_modified(var._list_vt):
-                    if not _codegen_direct_list_replay(
-                        var._list_vt, var.source
-                    ):  # type: ignore[arg-type]
+                    if not _codegen_direct_list_replay(var._list_vt, var.source):
                         # Update the list to the updated items. Be careful in
                         # calling the list methods and not the overridden methods.
                         varname_map = {}

--- a/torch/_dynamo/side_effects.py
+++ b/torch/_dynamo/side_effects.py
@@ -1035,9 +1035,7 @@ class SideEffects:
             )
             cg(source)
             cg.foreach(appended_items)
-            cg.append_output(
-                create_instruction("BUILD_LIST", arg=len(appended_items))
-            )
+            cg.append_output(create_instruction("BUILD_LIST", arg=len(appended_items)))
             cg.append_output(
                 cg.create_load_const(list_vt.direct_list_replay_should_clear())
             )

--- a/torch/_dynamo/side_effects.py
+++ b/torch/_dynamo/side_effects.py
@@ -87,6 +87,14 @@ def _manual_list_update(list_from: list[Any], list_to: list[Any]) -> None:
     list.extend(list_to, list_from)
 
 
+def _manual_list_replay(
+    list_to: list[Any], appended_items: list[Any], clear_first: bool
+) -> None:
+    if clear_first:
+        list.clear(list_to)
+    list.extend(list_to, appended_items)
+
+
 class SideEffects:
     """
     Maintain records of mutations and provide methods to apply them during code generation.
@@ -1015,6 +1023,33 @@ class SideEffects:
                 # Log individual side effects for granular debugging
                 side_effects_log.debug(msg)
 
+        def _codegen_direct_list_replay(
+            list_vt: "ListVariable", source: Source
+        ) -> bool:
+            if not list_vt.has_direct_list_replay():
+                return False
+            appended_items = list_vt.direct_list_replay_appends()
+
+            cg.add_push_null(
+                lambda: cg.load_import_from(__name__, "_manual_list_replay")
+            )
+            cg(source)
+            cg.foreach(appended_items)
+            cg.append_output(
+                create_instruction("BUILD_LIST", arg=len(appended_items))
+            )
+            cg.append_output(
+                cg.create_load_const(list_vt.direct_list_replay_should_clear())
+            )
+            suffixes.append(
+                [
+                    *create_call_function(3, False),
+                    create_instruction("POP_TOP"),
+                ]
+            )
+            _maybe_log_side_effect(list_vt)
+            return True
+
         suffixes = []
         for var in self._get_modified_vars():
             # When replay_side_effects=False, only update variables with TempLocalSource
@@ -1023,6 +1058,10 @@ class SideEffects:
             ):
                 continue
             if isinstance(var, variables.ListVariable):
+                if _codegen_direct_list_replay(
+                    var, var.source
+                ):  # type: ignore[arg-type]
+                    continue
                 # old[:] = new
                 cg(var, allow_cache=False)  # Don't codegen via source
                 cg(var.source)  # type: ignore[attr-defined]
@@ -1208,41 +1247,44 @@ class SideEffects:
                     var,
                     variables.UserDefinedListVariable,
                 ) and self.is_modified(var._list_vt):
-                    # Update the list to the updated items. Be careful in
-                    # calling the list methods and not the overridden methods.
-                    varname_map = {}
-                    for name in _manual_list_update.__code__.co_varnames:
-                        varname_map[name] = cg.tx.output.new_var()
+                    if not _codegen_direct_list_replay(
+                        var._list_vt, var.source
+                    ):  # type: ignore[arg-type]
+                        # Update the list to the updated items. Be careful in
+                        # calling the list methods and not the overridden methods.
+                        varname_map = {}
+                        for name in _manual_list_update.__code__.co_varnames:
+                            varname_map[name] = cg.tx.output.new_var()
 
-                    cg(var.source)  # type: ignore[attr-defined]
-                    cg.extend_output(
-                        [
-                            create_instruction(
-                                "STORE_FAST", argval=varname_map["list_to"]
-                            )
-                        ]
-                    )
+                        cg(var.source)  # type: ignore[attr-defined]
+                        cg.extend_output(
+                            [
+                                create_instruction(
+                                    "STORE_FAST", argval=varname_map["list_to"]
+                                )
+                            ]
+                        )
 
-                    cg(var._list_vt, allow_cache=False)  # Don't codegen via source
-                    cg.extend_output(
-                        [
-                            create_instruction(
-                                "STORE_FAST", argval=varname_map["list_from"]
-                            )
-                        ]
-                    )
+                        cg(var._list_vt, allow_cache=False)  # Don't codegen via source
+                        cg.extend_output(
+                            [
+                                create_instruction(
+                                    "STORE_FAST", argval=varname_map["list_from"]
+                                )
+                            ]
+                        )
 
-                    list_update_insts = bytecode_from_template(
-                        _manual_list_update, varname_map=varname_map
-                    )
+                        list_update_insts = bytecode_from_template(
+                            _manual_list_update, varname_map=varname_map
+                        )
 
-                    suffixes.append(
-                        [
-                            *list_update_insts,
-                            create_instruction("POP_TOP"),
-                        ]
-                    )
-                    _maybe_log_side_effect(var._list_vt)
+                        suffixes.append(
+                            [
+                                *list_update_insts,
+                                create_instruction("POP_TOP"),
+                            ]
+                        )
+                        _maybe_log_side_effect(var._list_vt)
 
                 # Applying mutations involves two steps: 1) Push all
                 # reconstructed objects onto the stack.  2) Call STORE_ATTR to

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -744,7 +744,10 @@ def generic_jump(
             # ConstDictVariable is optimized to be very lazy about insertion of
             # guards, so we have to manually insert a SEQUENCE_LENGTH guard
             # here.
-            if isinstance(value, (BaseListVariable, ConstDictVariable)) and value.source:
+            if (
+                isinstance(value, (BaseListVariable, ConstDictVariable))
+                and value.source
+            ):
                 install_guard(value.source.make_guard(GuardBuilder.SEQUENCE_LENGTH))
             if truth_fn(value.as_python_constant()):
                 if push:

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -744,7 +744,7 @@ def generic_jump(
             # ConstDictVariable is optimized to be very lazy about insertion of
             # guards, so we have to manually insert a SEQUENCE_LENGTH guard
             # here.
-            if isinstance(value, ConstDictVariable) and value.source:
+            if isinstance(value, (BaseListVariable, ConstDictVariable)) and value.source:
                 install_guard(value.source.make_guard(GuardBuilder.SEQUENCE_LENGTH))
             if truth_fn(value.as_python_constant()):
                 if push:

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -744,10 +744,9 @@ def generic_jump(
             # ConstDictVariable is optimized to be very lazy about insertion of
             # guards, so we have to manually insert a SEQUENCE_LENGTH guard
             # here.
-            if (
-                isinstance(value, (BaseListVariable, ConstDictVariable))
-                and value.source
-            ):
+            if isinstance(value, BaseListVariable):
+                value._install_list_length_guard()
+            elif isinstance(value, ConstDictVariable) and value.source:
                 install_guard(value.source.make_guard(GuardBuilder.SEQUENCE_LENGTH))
             if truth_fn(value.as_python_constant()):
                 if push:

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -1852,8 +1852,10 @@ class VariableBuilder:
             return ConstantVariable.create(value=value)
 
         # One can index a tensor with a list/tuple. Therefore, we need to
-        # have a stricter match.
-        self.install_guards(GuardBuilder.SEQUENCE_LENGTH)
+        # have a stricter match. Keep plain list length guards lazy so mutating
+        # methods like append()/clear() don't specialize on untouched contents.
+        if type(value) is not list:
+            self.install_guards(GuardBuilder.SEQUENCE_LENGTH)
 
         # Tuples are immutable objects, so we should mark its items static. This
         # avoids wrapping of tuple items as symints. This helps for nn module

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -125,6 +125,7 @@ from ..source import (
     GradSource,
     is_constant_source,
     is_from_closure_source,
+    is_from_flatten_script_object_source,
     is_from_global_source,
     is_from_nonlocal_source,
     is_from_optimizer_source,
@@ -1854,7 +1855,12 @@ class VariableBuilder:
         # One can index a tensor with a list/tuple. Therefore, we need to
         # have a stricter match. Keep plain list length guards lazy so mutating
         # methods like append()/clear() don't specialize on untouched contents.
-        if type(value) is not list:
+        # Flattened torchbind state still needs eager length guards because its
+        # size can be observed through fake-class methods outside list VT reads.
+        if type(value) is not list or (
+            self.source is not None
+            and is_from_flatten_script_object_source(self.source)
+        ):
             self.install_guards(GuardBuilder.SEQUENCE_LENGTH)
 
         # Tuples are immutable objects, so we should mark its items static. This
@@ -1954,8 +1960,12 @@ class VariableBuilder:
             # https://github.com/pytorch/pytorch/issues/153701.
             for vt in output:
                 vt.realize()
+        list_options: dict[str, Any] = {"source": self.source}
+        if type(value) is list:
+            list_options["mutation_type"] = ValueMutationExisting()
+
         # type: ignore[arg-type]
-        result = BaseListVariable.cls_for_instance(value)(output, source=self.source)
+        result = BaseListVariable.cls_for_instance(value)(output, **list_options)
         if istype(value, (list, collections.deque)):
             return self.tx.output.side_effects.track_mutable(value, result)
         return result

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -916,9 +916,9 @@ class CommonListMethodsVariable(BaseListVariable):
             tx.output.side_effects.mutation(self)
             self._disable_direct_list_replay()
             if isinstance(key, SymNodeVariable):
-                self.items[
-                    operator.index(cast(SupportsIndex, key.evaluate_expr()))
-                ] = value
+                self.items[operator.index(cast(SupportsIndex, key.evaluate_expr()))] = (
+                    value
+                )
             elif isinstance(key, SliceVariable):
                 if key.is_python_constant():
                     self.items[key.as_python_constant()] = list(value.items)  # type: ignore[attr-defined]
@@ -952,9 +952,7 @@ class CommonListMethodsVariable(BaseListVariable):
                 args[0].as_python_constant(), (int, slice)
             ):
                 if isinstance(args[0], SymNodeVariable):
-                    idx = operator.index(
-                        cast(SupportsIndex, args[0].evaluate_expr())
-                    )
+                    idx = operator.index(cast(SupportsIndex, args[0].evaluate_expr()))
                 else:
                     idx = args[0].as_python_constant()
 

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -101,6 +101,9 @@ class BaseListVariable(VariableTracker):
         if self.source and self.python_type() is list:
             install_guard(self.source.make_guard(GuardBuilder.SEQUENCE_LENGTH))
 
+    def _disable_direct_list_replay(self) -> None:
+        return
+
     def modified(
         self, items: list[VariableTracker], **kwargs: Any
     ) -> "BaseListVariable":
@@ -127,6 +130,7 @@ class BaseListVariable(VariableTracker):
     ) -> VariableTracker:
         from .tensor import SymNodeVariable
 
+        self._install_list_length_guard()
         if isinstance(arg, SymNodeVariable):
             index = arg.sym_num
         else:
@@ -151,6 +155,7 @@ class BaseListVariable(VariableTracker):
                 raise_observed_exception(IndexError, tx, args=[error_message])
 
     def unpack_var_sequence(self, tx: "InstructionTranslator") -> list[VariableTracker]:
+        self._install_list_length_guard()
         return list(self.items)
 
     def call_tree_map_branch(
@@ -166,8 +171,11 @@ class BaseListVariable(VariableTracker):
                 tx, tree_map_fn, map_fn, rest, tree_map_kwargs
             )
 
+        self._install_list_length_guard()
         other_lists: list[BaseListVariable] = []
         for candidate in rest:
+            if isinstance(candidate, BaseListVariable):
+                candidate._install_list_length_guard()
             if (
                 not isinstance(candidate, BaseListVariable)
                 or len(candidate.items) != len(self.items)
@@ -211,8 +219,11 @@ class BaseListVariable(VariableTracker):
                 tx, tree_map_fn, map_fn, rest, tree_map_kwargs, keypath
             )
 
+        self._install_list_length_guard()
         other_lists: list[BaseListVariable] = []
         for candidate in rest:
+            if isinstance(candidate, BaseListVariable):
+                candidate._install_list_length_guard()
             if (
                 not isinstance(candidate, BaseListVariable)
                 or len(candidate.items) != len(self.items)
@@ -306,6 +317,7 @@ class BaseListVariable(VariableTracker):
                     f"{len(args)} args and {len(kwargs)} kwargs",
                 )
 
+            self._install_list_length_guard()
             try:
                 # Speedup trace times for constant data structures
                 items = [item.as_python_constant() for item in self.items]
@@ -335,6 +347,7 @@ class BaseListVariable(VariableTracker):
                     "1 args and 0 kwargs",
                     f"{len(args)} args and {len(kwargs)} kwargs",
                 )
+            self._install_list_length_guard()
             return VariableTracker.build(tx, operator.countOf).call_function(
                 tx,
                 [self, args[0]],
@@ -357,10 +370,20 @@ class BaseListVariable(VariableTracker):
                 )
                 raise_observed_exception(TypeError, tx, args=[msg_vt])
 
+            other_list = args[0]
+            assert isinstance(other_list, BaseListVariable)
             if name == "__add__":
-                return type(self)(self.items + args[0].items, source=self.source)  # type: ignore[attr-defined]
+                self._install_list_length_guard()
+                other_list._install_list_length_guard()
+                return type(self)(
+                    self.items + other_list.items,
+                    source=self.source,
+                )
             else:
-                self.items += args[0].items  # type: ignore[attr-defined]
+                if self.is_mutable():
+                    tx.output.side_effects.mutation(self)
+                    self._disable_direct_list_replay()
+                self.items += other_list.items
                 return self
         elif name in ("__mul__", "__imul__"):
             if kwargs or len(args) != 1:
@@ -381,8 +404,12 @@ class BaseListVariable(VariableTracker):
             val = args[0].as_python_constant()
 
             if name == "__mul__":
+                self._install_list_length_guard()
                 return type(self)(self.items * val, source=self.source)
             else:
+                if self.is_mutable():
+                    tx.output.side_effects.mutation(self)
+                    self._disable_direct_list_replay()
                 self.items *= val
                 return self
         elif name in cmp_name_to_op_mapping:
@@ -421,6 +448,8 @@ class BaseListVariable(VariableTracker):
                     )
                     raise_observed_exception(TypeError, tx, args=[msg])
 
+            left._install_list_length_guard()
+            right._install_list_length_guard()
             return SourcelessBuilder.create(tx, polyfills.list_cmp).call_function(
                 tx,
                 [
@@ -431,7 +460,9 @@ class BaseListVariable(VariableTracker):
                 {},
             )
         elif name == "__iter__":
-            return ListIteratorVariable(self.items, mutation_type=ValueMutationNew())
+            return ListIteratorVariable(
+                self.unpack_var_sequence(tx), mutation_type=ValueMutationNew()
+            )
 
         return super().call_method(tx, name, args, kwargs)
 
@@ -757,9 +788,6 @@ class CommonListMethodsVariable(BaseListVariable):
     Implement methods common to List and other List-like things
     """
 
-    def _disable_direct_list_replay(self) -> None:
-        return
-
     def _record_direct_list_append(self, arg: VariableTracker) -> None:
         return
 
@@ -804,6 +832,8 @@ class CommonListMethodsVariable(BaseListVariable):
                 raise_observed_exception(TypeError, tx, args=[msg])
 
             (arg,) = args
+            # Intentionally preserve direct replay here: extend is equivalent to
+            # a sequence of append() calls for builtin list semantics.
             arg.force_apply_to_var_sequence(
                 tx, lambda item: self.call_method(tx, "append", [item], {})
             )
@@ -818,7 +848,7 @@ class CommonListMethodsVariable(BaseListVariable):
                 )
             idx, value = args
             if isinstance(idx, SymNodeVariable):
-                const_idx = idx.evaluate_expr()
+                const_idx = operator.index(idx.evaluate_expr())
             else:
                 const_idx = idx.as_python_constant()
             tx.output.side_effects.mutation(self)
@@ -880,8 +910,7 @@ class CommonListMethodsVariable(BaseListVariable):
             tx.output.side_effects.mutation(self)
             self._disable_direct_list_replay()
             if isinstance(key, SymNodeVariable):
-                # pyrefly: ignore[unsupported-operation]
-                self.items[key.evaluate_expr()] = value
+                self.items[operator.index(key.evaluate_expr())] = value
             elif isinstance(key, SliceVariable):
                 if key.is_python_constant():
                     self.items[key.as_python_constant()] = list(value.items)  # type: ignore[attr-defined]
@@ -915,7 +944,7 @@ class CommonListMethodsVariable(BaseListVariable):
                 args[0].as_python_constant(), (int, slice)
             ):
                 if isinstance(args[0], SymNodeVariable):
-                    idx = args[0].evaluate_expr()
+                    idx = operator.index(args[0].evaluate_expr())
                 else:
                     idx = args[0].as_python_constant()
 
@@ -1092,6 +1121,7 @@ class ListVariable(CommonListMethodsVariable):
                 super().call_method(tx, name, args, kwargs)
 
             tx.output.side_effects.mutation(self)
+            self._disable_direct_list_replay()
             if isinstance(key, SliceVariable):
                 if not value.has_force_unpack_var_sequence(tx):
                     msg = VariableTracker.build(tx, "can only assign an iterable")
@@ -1113,13 +1143,11 @@ class ListVariable(CommonListMethodsVariable):
                     )
             else:
                 if isinstance(key, SymNodeVariable):
-                    key = key.evaluate_expr()
+                    key = operator.index(key.evaluate_expr())
                 else:
                     key = key.as_python_constant()
 
                 try:
-                    # pyrefly: ignore[unsupported-operation]
-                    self._disable_direct_list_replay()
                     self.items[key] = value
                 except (IndexError, TypeError) as e:
                     raise_observed_exception(
@@ -1194,6 +1222,7 @@ class ListVariable(CommonListMethodsVariable):
             elif len(args) == 1 and args[0].has_force_unpack_var_sequence(tx):
                 (arg,) = args
                 tx.output.side_effects.mutation(self)
+                self._disable_direct_list_replay()
                 self.items[:] = arg.force_unpack_var_sequence(tx)
                 return CONSTANT_VARIABLE_NONE
 

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -34,6 +34,7 @@ from ..bytecode_transformation import (
     create_rot_n,
 )
 from ..exc import raise_observed_exception, unimplemented
+from ..guards import GuardBuilder, install_guard
 from ..source import AttrSource, NamedTupleFieldsSource
 from ..utils import (
     cmp_name_to_op_mapping,
@@ -47,7 +48,12 @@ from ..utils import (
     range_iterator,
     set_example_value,
 )
-from .base import AsPythonConstantNotImplementedError, ValueMutationNew, VariableTracker
+from .base import (
+    AsPythonConstantNotImplementedError,
+    ValueMutationExisting,
+    ValueMutationNew,
+    VariableTracker,
+)
 from .constant import CONSTANT_VARIABLE_FALSE, CONSTANT_VARIABLE_NONE, ConstantVariable
 from .functions import UserFunctionVariable
 from .iter import IteratorVariable
@@ -91,6 +97,10 @@ class BaseListVariable(VariableTracker):
     def _as_proxy(self) -> list[Any]:
         return [x.as_proxy() for x in self.items]
 
+    def _install_list_length_guard(self) -> None:
+        if self.source and self.python_type() is list:
+            install_guard(self.source.make_guard(GuardBuilder.SEQUENCE_LENGTH))
+
     def modified(
         self, items: list[VariableTracker], **kwargs: Any
     ) -> "BaseListVariable":
@@ -104,9 +114,11 @@ class BaseListVariable(VariableTracker):
         return prefix + ", ".join(i.debug_repr() for i in self.items) + suffix
 
     def as_python_constant(self) -> Any:
+        self._install_list_length_guard()
         return self.python_type()([x.as_python_constant() for x in self.items])
 
     def as_proxy(self) -> Any:
+        self._install_list_length_guard()
         assert self.python_type() is not SizeVariable
         return self.python_type()(self._as_proxy())
 
@@ -241,7 +253,10 @@ class BaseListVariable(VariableTracker):
     ) -> VariableTracker:
         from .builder import SourcelessBuilder
 
-        if name == "__getitem__":
+        if name == "__len__":
+            self._install_list_length_guard()
+            return ConstantVariable.create(len(self.items))
+        elif name == "__getitem__":
             if kwargs or len(args) != 1:
                 raise_args_mismatch(
                     tx,
@@ -742,6 +757,15 @@ class CommonListMethodsVariable(BaseListVariable):
     Implement methods common to List and other List-like things
     """
 
+    def _disable_direct_list_replay(self) -> None:
+        return
+
+    def _record_direct_list_append(self, arg: VariableTracker) -> None:
+        return
+
+    def _record_direct_list_clear(self) -> None:
+        return
+
     def call_method(
         self,
         tx: "InstructionTranslator",
@@ -761,6 +785,7 @@ class CommonListMethodsVariable(BaseListVariable):
                 )
             (arg,) = args
             tx.output.side_effects.mutation(self)
+            self._record_direct_list_append(arg)
             self.items.append(arg)
             return CONSTANT_VARIABLE_NONE
         elif name == "extend" and self.is_mutable():
@@ -797,6 +822,7 @@ class CommonListMethodsVariable(BaseListVariable):
             else:
                 const_idx = idx.as_python_constant()
             tx.output.side_effects.mutation(self)
+            self._disable_direct_list_replay()
             # type: ignore[arg-type]
             self.items.insert(const_idx, value)
             return CONSTANT_VARIABLE_NONE
@@ -819,6 +845,7 @@ class CommonListMethodsVariable(BaseListVariable):
                     msg = VariableTracker.build(tx, "pop index out of range")
                     raise_observed_exception(IndexError, tx, args=[msg])
             tx.output.side_effects.mutation(self)
+            self._disable_direct_list_replay()
             return self.items.pop(*[a.as_python_constant() for a in args])
         elif name == "clear" and self.is_mutable():
             if args or kwargs:
@@ -829,6 +856,7 @@ class CommonListMethodsVariable(BaseListVariable):
                     f"{len(args)} args and {len(kwargs)} kwargs",
                 )
             tx.output.side_effects.mutation(self)
+            self._record_direct_list_clear()
             self.items.clear()
             return CONSTANT_VARIABLE_NONE
         elif name == "__setitem__" and self.is_mutable() and args:
@@ -850,6 +878,7 @@ class CommonListMethodsVariable(BaseListVariable):
                 raise_args_mismatch(tx, name, "0 kwargs", f"{len(kwargs)} kwargs")
             value = args[1]
             tx.output.side_effects.mutation(self)
+            self._disable_direct_list_replay()
             if isinstance(key, SymNodeVariable):
                 # pyrefly: ignore[unsupported-operation]
                 self.items[key.evaluate_expr()] = value
@@ -881,6 +910,7 @@ class CommonListMethodsVariable(BaseListVariable):
                 )
 
             tx.output.side_effects.mutation(self)
+            self._disable_direct_list_replay()
             if args[0].is_python_constant() and isinstance(
                 args[0].as_python_constant(), (int, slice)
             ):
@@ -926,6 +956,7 @@ class CommonListMethodsVariable(BaseListVariable):
                 )
             self.items.reverse()
             tx.output.side_effects.mutation(self)
+            self._disable_direct_list_replay()
             return CONSTANT_VARIABLE_NONE
         elif name == "remove" and self.is_mutable():
             if kwargs or len(args) != 1:
@@ -944,8 +975,69 @@ class CommonListMethodsVariable(BaseListVariable):
 
 
 class ListVariable(CommonListMethodsVariable):
+    _nonvar_fields = {
+        *CommonListMethodsVariable._nonvar_fields,
+        "_direct_list_replay_enabled",
+        "_replay_list_cleared",
+        "_replay_list_appends",
+    }
+
+    def __init__(
+        self,
+        items: list[VariableTracker],
+        _direct_list_replay_enabled: bool = True,
+        _replay_list_cleared: bool = False,
+        _replay_list_appends: list[VariableTracker] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(items, **kwargs)
+        self._direct_list_replay_enabled = _direct_list_replay_enabled
+        self._replay_list_cleared = _replay_list_cleared
+        self._replay_list_appends = (
+            [] if _replay_list_appends is None else list(_replay_list_appends)
+        )
+        if not (
+            self.source is not None
+            and isinstance(self.mutation_type, ValueMutationExisting)
+        ):
+            self._direct_list_replay_enabled = False
+            self._replay_list_cleared = False
+            self._replay_list_appends = []
+
     def python_type(self) -> type:
         return list
+
+    def _disable_direct_list_replay(self) -> None:
+        if self.source is not None:
+            install_guard(self.source.make_guard(GuardBuilder.SEQUENCE_LENGTH))
+        self._direct_list_replay_enabled = False
+        self._replay_list_cleared = False
+        self._replay_list_appends.clear()
+
+    def _record_direct_list_append(self, arg: VariableTracker) -> None:
+        if not self._direct_list_replay_enabled:
+            return
+        if arg is self:
+            self._disable_direct_list_replay()
+            return
+        self._replay_list_appends.append(arg)
+
+    def _record_direct_list_clear(self) -> None:
+        if not self._direct_list_replay_enabled:
+            return
+        self._replay_list_cleared = True
+        self._replay_list_appends.clear()
+
+    def has_direct_list_replay(self) -> bool:
+        return self._direct_list_replay_enabled and (
+            self._replay_list_cleared or bool(self._replay_list_appends)
+        )
+
+    def direct_list_replay_should_clear(self) -> bool:
+        return self._replay_list_cleared
+
+    def direct_list_replay_appends(self) -> list[VariableTracker]:
+        return list(self._replay_list_appends)
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(length={len(self.items)})"
@@ -1027,6 +1119,7 @@ class ListVariable(CommonListMethodsVariable):
 
                 try:
                     # pyrefly: ignore[unsupported-operation]
+                    self._disable_direct_list_replay()
                     self.items[key] = value
                 except (IndexError, TypeError) as e:
                     raise_observed_exception(
@@ -1043,6 +1136,7 @@ class ListVariable(CommonListMethodsVariable):
             ).as_python_constant()
             if len(kwargs) != 0:
                 raise_args_mismatch(tx, name, "0 kwargs", f"{len(kwargs)} kwargs")
+            self._disable_direct_list_replay()
 
             if key_fn_var.is_constant_none():
                 keys = self.items.copy()

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -18,7 +18,7 @@ import collections
 import operator
 import sys
 from collections.abc import Sequence
-from typing import Any, Literal, Optional, TYPE_CHECKING
+from typing import Any, cast, Literal, Optional, SupportsIndex, TYPE_CHECKING
 
 import torch
 import torch.fx
@@ -99,7 +99,12 @@ class BaseListVariable(VariableTracker):
 
     def _install_list_length_guard(self) -> None:
         if self.source and self.python_type() is list:
-            install_guard(self.source.make_guard(GuardBuilder.SEQUENCE_LENGTH))
+            try:
+                install_guard(self.source.make_guard(GuardBuilder.SEQUENCE_LENGTH))
+            except NotImplementedError:
+                # Constant-backed lists are already immutable from Dynamo's
+                # perspective, so they do not need a runtime length guard.
+                return
 
     def _disable_direct_list_replay(self) -> None:
         return
@@ -448,6 +453,8 @@ class BaseListVariable(VariableTracker):
                     )
                     raise_observed_exception(TypeError, tx, args=[msg])
 
+            assert isinstance(left, BaseListVariable)
+            assert isinstance(right, BaseListVariable)
             left._install_list_length_guard()
             right._install_list_length_guard()
             return SourcelessBuilder.create(tx, polyfills.list_cmp).call_function(
@@ -460,9 +467,8 @@ class BaseListVariable(VariableTracker):
                 {},
             )
         elif name == "__iter__":
-            return ListIteratorVariable(
-                self.unpack_var_sequence(tx), mutation_type=ValueMutationNew()
-            )
+            self._install_list_length_guard()
+            return ListIteratorVariable(self.items, mutation_type=ValueMutationNew())
 
         return super().call_method(tx, name, args, kwargs)
 
@@ -848,7 +854,7 @@ class CommonListMethodsVariable(BaseListVariable):
                 )
             idx, value = args
             if isinstance(idx, SymNodeVariable):
-                const_idx = operator.index(idx.evaluate_expr())
+                const_idx = operator.index(cast(SupportsIndex, idx.evaluate_expr()))
             else:
                 const_idx = idx.as_python_constant()
             tx.output.side_effects.mutation(self)
@@ -910,7 +916,9 @@ class CommonListMethodsVariable(BaseListVariable):
             tx.output.side_effects.mutation(self)
             self._disable_direct_list_replay()
             if isinstance(key, SymNodeVariable):
-                self.items[operator.index(key.evaluate_expr())] = value
+                self.items[
+                    operator.index(cast(SupportsIndex, key.evaluate_expr()))
+                ] = value
             elif isinstance(key, SliceVariable):
                 if key.is_python_constant():
                     self.items[key.as_python_constant()] = list(value.items)  # type: ignore[attr-defined]
@@ -944,7 +952,9 @@ class CommonListMethodsVariable(BaseListVariable):
                 args[0].as_python_constant(), (int, slice)
             ):
                 if isinstance(args[0], SymNodeVariable):
-                    idx = operator.index(args[0].evaluate_expr())
+                    idx = operator.index(
+                        cast(SupportsIndex, args[0].evaluate_expr())
+                    )
                 else:
                     idx = args[0].as_python_constant()
 
@@ -1037,8 +1047,7 @@ class ListVariable(CommonListMethodsVariable):
         return list
 
     def _disable_direct_list_replay(self) -> None:
-        if self.source is not None:
-            install_guard(self.source.make_guard(GuardBuilder.SEQUENCE_LENGTH))
+        self._install_list_length_guard()
         self._direct_list_replay_enabled = False
         self._replay_list_cleared = False
         self._replay_list_appends.clear()
@@ -1143,7 +1152,7 @@ class ListVariable(CommonListMethodsVariable):
                     )
             else:
                 if isinstance(key, SymNodeVariable):
-                    key = operator.index(key.evaluate_expr())
+                    key = operator.index(cast(SupportsIndex, key.evaluate_expr()))
                 else:
                     key = key.as_python_constant()
 


### PR DESCRIPTION
Fix #93724

## Summary

### Root cause
Dynamo eagerly installs plain-list length guards and replays existing list mutations by reconstructing the entire list from tracked items. For `append()` and `clear()`, that pulls untouched list contents into guards and recompiles as the list grows or changes.

### Proposed fix
- Make plain list length guards lazy, materializing them only when the list itself is actually consumed.
- Replay pure `append()`/`clear()` mutations directly with builtin list helpers instead of rebuilding the old list contents.
- Fall back to the existing full-list replay path, with a length guard, for list mutations that still depend on the original structure.
- Add regression coverage for `append()` and `clear()` recompilation behavior.

### Why this is the right long term fix
It removes specialization only for side-effect-only list mutations while preserving the existing guarded behavior when Dynamo actually depends on the list structure, so it narrows guards without weakening correctness.

Drafted via Codex, published after manual review by @bobrenjc93

@diff-train-skip-merge

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo