### PR TITLE
[TEST][CUTLASS][SM100] Accept other `stream_k` kernels for `cutlass_op_allowlist_regex` for B200

### DIFF
--- a/test/inductor/test_cutlass_backend.py
+++ b/test/inductor/test_cutlass_backend.py
@@ -1173,7 +1173,7 @@ class TestCutlassBackend(TestCase):
                 "max_autotune": True,
                 "autotune_in_subproc": False,
                 "max_autotune_gemm_backends": "CUTLASS",
-                "cutlass.cutlass_op_allowlist_regex": "128x256x64.*stream_k_warpspecialized_cooperative_epi_nosmem",
+                "cutlass.cutlass_op_allowlist_regex": "128x256x64.*stream_k",
                 "cutlass.cutlass_max_profiling_configs": 1,
             }
         ):


### PR DESCRIPTION
authored with claude code
Otherwise fails with `No choices exist for backend.`

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo