### PR TITLE
[DTensor] Fix None IValue == DTensorSpec, cache key collision, and move op_strategy_context

### DIFF
--- a/test/distributed/tensor/test_op_strategy.py
+++ b/test/distributed/tensor/test_op_strategy.py
@@ -2,7 +2,6 @@
 
 import itertools
 import random
-from contextlib import contextmanager
 from itertools import chain
 from unittest.mock import patch
 
@@ -31,16 +30,14 @@ from torch.distributed.tensor._ops._einsum_strategy import (
     EinsumDims,
     gen_einsum_strategies,
 )
-from torch.distributed.tensor._ops.utils import (
-    register_op_strategy,
-    replicate_op_strategy,
-)
-from torch.distributed.tensor.debug import _clear_sharding_prop_cache, CommDebugMode
+from torch.distributed.tensor._ops.utils import replicate_op_strategy
+from torch.distributed.tensor.debug import CommDebugMode
 from torch.testing._internal.common_utils import run_tests, TestCase
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     create_local_tensor_test_class,
     DTensorOpTestBase,
     DTensorTestBase,
+    op_strategy_context,
     with_comms,
 )
 from torch.testing._internal.distributed.fake_pg import FakeStore
@@ -491,45 +488,6 @@ def _fw_tuple(x, y, z):
 torch.library.register_autograd(
     "mylib::numpy_tuple_sin", tuple_backward, setup_context=setup_tuple_context
 )
-
-
-@contextmanager
-def op_strategy_context(op_overload, strategy_func, schema_info=None):
-    """
-    Context manager for setting and clearing op strategies.
-    Args:
-        op_overload: The operator overload to set or clear the strategy for.
-        strategy_func: The strategy function to set for the operator overload.
-        schema_info: Optional schema information for the operator overload.
-    Yields:
-        None
-    """
-    propagator = DTensor._op_dispatcher.sharding_propagator
-    _origin_op_strategy_funcs = None
-    _origin_op_strategy_schema = None
-    try:
-        # register the op strategy
-        if op_overload in propagator.op_strategy_funcs:
-            _origin_op_strategy_funcs = propagator.op_strategy_funcs[op_overload]
-            del propagator.op_strategy_funcs[op_overload]
-        if op_overload in propagator.op_to_schema_info:
-            _origin_op_strategy_schema = propagator.op_to_schema_info[op_overload]
-            del propagator.op_to_schema_info[op_overload]
-        register_op_strategy(op_overload, schema_info=schema_info)(strategy_func)
-        yield
-    finally:
-        # clear this op strategy cache
-        if _origin_op_strategy_funcs is None:
-            if op_overload in propagator.op_strategy_funcs:
-                del propagator.op_strategy_funcs[op_overload]
-        else:
-            propagator.op_strategy_funcs[op_overload] = _origin_op_strategy_funcs
-        if _origin_op_strategy_schema is None:
-            if op_overload in propagator.op_to_schema_info:
-                del propagator.op_to_schema_info[op_overload]
-        else:
-            propagator.op_to_schema_info[op_overload] = _origin_op_strategy_schema
-        _clear_sharding_prop_cache()
 
 
 def detect_exists_identical_opspec(*args, op, mesh, strategy_function) -> bool:

--- a/test/distributed/tensor/test_tensor_ops.py
+++ b/test/distributed/tensor/test_tensor_ops.py
@@ -32,6 +32,7 @@ from torch.testing._internal.distributed._tensor.common_dtensor import (
     DTensorTestBase,
     LocalDTensorContinuousTestBase,
     LocalDTensorTestBase,
+    op_strategy_context,
     with_comms,
 )
 
@@ -1297,6 +1298,18 @@ DistTensorOpsTestWithLocalTensor = create_local_tensor_test_class(
 )
 
 
+@torch.library.custom_op("testlib::optional_clamp_op", mutates_args=())
+def optional_clamp_op(
+    x: torch.Tensor, lo: torch.Tensor | None, hi: torch.Tensor | None
+) -> torch.Tensor:
+    return torch.clamp(x, lo, hi)
+
+
+@optional_clamp_op.register_fake
+def _optional_clamp_op_fake(x, lo, hi):
+    return torch.empty_like(x)
+
+
 @torch.library.custom_op("testlib::modified_cat_op", mutates_args=())
 def modified_cat_op(a: list[torch.Tensor], b: list[torch.Tensor]) -> torch.Tensor:
     return torch.cat(a, dim=0)
@@ -1372,8 +1385,6 @@ class DistTensorCppPyTree(DTensorContinuousTestBase):
             self.assertEqual(hits, 1)
 
     def test_two_list_op_cache_collision(self):
-        from test_op_strategy import op_strategy_context
-
         from torch.distributed.tensor._op_schema import RuntimeSchemaInfo
         from torch.distributed.tensor._ops.utils import replicate_op_strategy
         from torch.distributed.tensor.debug import (
@@ -1399,6 +1410,63 @@ class DistTensorCppPyTree(DTensorContinuousTestBase):
             self.assertEqual(hits, 0)
             self.assertEqual(misses, 2)
             self.assertEqual(result.shape, torch.Size([8, 8]))
+
+    def test_optional_tensor_cache_key(self):
+        """Cache must distinguish op(t1, None, t2) from op(t1, t2, None).
+
+        Uses a custom op with high static_argnum so that None args for
+        optional Tensor? parameters would be dropped from the cache key
+        without the is_none_or_undefined fix in handle_non_dtensor_arg.
+        With same-spec DTensors the collision is deterministic.
+        """
+        from torch.distributed.tensor._op_schema import RuntimeSchemaInfo
+        from torch.distributed.tensor._ops.utils import replicate_op_strategy
+        from torch.distributed.tensor.debug import (
+            _clear_fast_path_sharding_prop_cache,
+            _get_fast_path_sharding_prop_cache_stats,
+        )
+
+        mesh = self.build_device_mesh()
+        op = torch.ops.testlib.optional_clamp_op
+
+        with op_strategy_context(
+            op.default,
+            replicate_op_strategy,
+            schema_info=RuntimeSchemaInfo(static_argnum=3),
+        ):
+            _clear_fast_path_sharding_prop_cache()
+            a = distribute_tensor(torch.randn(4, 8), mesh, [Shard(0)])
+
+            op(a, a, None)  # miss 1: key should include None at position 2
+            op(a, None, a)  # miss 2: key should include None at position 1
+
+            hits, misses = _get_fast_path_sharding_prop_cache_stats()
+            self.assertEqual(hits, 0)
+            self.assertEqual(misses, 2)
+
+    def test_optional_tensor_cache_key_python_slow_path(self):
+        """Same as above but exercises the Python slow path via OpSchema directly.
+
+        DTensor_OpSchema_recompute_comparison_key_impl must include None
+        args for optional Tensor? parameters in the comparison key.
+        """
+        from torch.distributed.tensor._dtensor_spec import DTensorSpec
+        from torch.distributed.tensor._op_schema import OpSchema, RuntimeSchemaInfo
+
+        mesh = self.build_device_mesh()
+        spec = DTensorSpec(mesh, (Shard(0),))
+        op = torch.ops.testlib.optional_clamp_op.default
+
+        schema1 = OpSchema(op, (spec, None, spec), {})
+        schema1.schema_info = RuntimeSchemaInfo(static_argnum=3)
+        schema1._recompute_comparison_key()
+
+        schema2 = OpSchema(op, (spec, spec, None), {})
+        schema2.schema_info = RuntimeSchemaInfo(static_argnum=3)
+        schema2._recompute_comparison_key()
+
+        self.assertNotEqual(hash(schema1), hash(schema2))
+        self.assertNotEqual(schema1, schema2)
 
 
 class TestNewEmptyStridedUneven(DTensorTestBase):

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -1087,9 +1087,10 @@ struct IValueOrDTensorSpec {
   py::object dtensor_spec;
 
   bool operator==(const IValueOrDTensorSpec& rhs) const {
-    return dtensor_spec
-        ? (rhs.dtensor_spec && dtensor_spec.equal(rhs.dtensor_spec))
-        : (iv == rhs.iv);
+    if (dtensor_spec) {
+      return rhs.dtensor_spec && dtensor_spec.equal(rhs.dtensor_spec);
+    }
+    return !rhs.dtensor_spec && iv == rhs.iv;
   }
 };
 
@@ -1162,18 +1163,6 @@ class NativeOpSchema {
   // have no guarantees about its lifetime. This class is cheap anyway.
   c10::OperatorHandle op_;
   std::size_t hash_;
-  // Subtle point: consider clamp.Tensor(Tensor self, Tensor?
-  // min=None, Tensor? max=None). The invocations clamp(t1, None, t2)
-  // and clamp(t1, t2, None) have the same comparison key (t1, t2)
-  // because we drop non-static non-tensor args from comparison. The
-  // only way we happen to be able to tell them apart is that we omit
-  // trailing defaulted arguments from the args tuple passed to
-  // __torch_dispatch__ (and hence to DTensor dispatch as well), so
-  // they have different args_schema_len_.
-  //
-  // I am preserving this existing behavior, but I suspect we should
-  // make an algorithm change to be less brittle, such as including
-  // None defaults for Tensor arguments in the comparison.
   std::size_t args_schema_len_;
   // There is no particular justification for the choice of 8
   // here. Feel free to change it.
@@ -1842,7 +1831,7 @@ static bool DTensor_OpSchema_recompute_comparison_key_impl(
   size_t idx = 0;
   for (const auto& e : args_schema) {
     if (idx >= native_info.static_argnum ||
-        arg_type_tensor_or_tensor_list_like(e)) {
+        arg_type_tensor_or_tensor_list_like(e) || e.is_none()) {
       if (PyList_Check(e.ptr())) {
         args_to_hash.push_back(
             py::reinterpret_steal<py::object>(PyList_AsTuple(e.ptr())));
@@ -2304,7 +2293,9 @@ create_native_op_schema(
   const auto handle_non_dtensor_arg =
       [&comparison_key, &comparison_key_hash, &native_info](
           size_t idx, c10::IValue arg) {
-        if (idx >= native_info.static_argnum) {
+        bool is_none_or_undefined =
+            arg.isNone() || (arg.isTensor() && !arg.toTensor().defined());
+        if (idx >= native_info.static_argnum || is_none_or_undefined) {
           if (arg.isList()) {
             const auto& list = arg.toList();
             if (list.empty()) {

--- a/torch/testing/_internal/distributed/_tensor/common_dtensor.py
+++ b/torch/testing/_internal/distributed/_tensor/common_dtensor.py
@@ -1465,3 +1465,45 @@ def validate_sharding_rule_sample(
         ):
             return False
     return True
+
+
+@contextlib.contextmanager
+def op_strategy_context(op_overload, strategy_func, schema_info=None):
+    """
+    Context manager for setting and clearing op strategies.
+    Args:
+        op_overload: The operator overload to set or clear the strategy for.
+        strategy_func: The strategy function to set for the operator overload.
+        schema_info: Optional schema information for the operator overload.
+    Yields:
+        None
+    """
+    from torch.distributed.tensor._ops.utils import register_op_strategy
+    from torch.distributed.tensor.debug import _clear_sharding_prop_cache
+
+    propagator = DTensor._op_dispatcher.sharding_propagator
+    _origin_op_strategy_funcs = None
+    _origin_op_strategy_schema = None
+    try:
+        # register the op strategy
+        if op_overload in propagator.op_strategy_funcs:
+            _origin_op_strategy_funcs = propagator.op_strategy_funcs[op_overload]
+            del propagator.op_strategy_funcs[op_overload]
+        if op_overload in propagator.op_to_schema_info:
+            _origin_op_strategy_schema = propagator.op_to_schema_info[op_overload]
+            del propagator.op_to_schema_info[op_overload]
+        register_op_strategy(op_overload, schema_info=schema_info)(strategy_func)
+        yield
+    finally:
+        # clear this op strategy cache
+        if _origin_op_strategy_funcs is None:
+            if op_overload in propagator.op_strategy_funcs:
+                del propagator.op_strategy_funcs[op_overload]
+        else:
+            propagator.op_strategy_funcs[op_overload] = _origin_op_strategy_funcs
+        if _origin_op_strategy_schema is None:
+            if op_overload in propagator.op_to_schema_info:
+                del propagator.op_to_schema_info[op_overload]
+        else:
+            propagator.op_to_schema_info[op_overload] = _origin_op_strategy_schema
+        _clear_sharding_prop_cache()


### PR DESCRIPTION
## Summary

Squashed version of the ghstack PRs #178348 and #178349 into a single non-ghstack PR.

Two bugs in NativeShardingPropagatorCache:

1. `IValueOrDTensorSpec::operator==` returned true when comparing a None IValue against a DTensorSpec, because both have default `iv=None`. On hash bucket collisions this caused false-positive equality, leading to wrong OutputSharding results. Fixed by checking `!rhs.dtensor_spec` before comparing iv fields.

2. `handle_non_dtensor_arg` dropped None/undefined tensor args from the cache key when `idx < static_argnum`. For ops with optional `Tensor?` parameters at those positions, this made `op(t1, t2, None)` and `op(t1, None, t2)` produce identical keys. Fixed by always including None/undefined args regardless of `static_argnum`.

Also moves `op_strategy_context` from `test_op_strategy.py` to the shared `common_dtensor.py` testing utilities module, reducing code duplication and fixing the import error.

Resolves https://github.com/pytorch/pytorch/issues/176974

Authored with Claude.

## Test plan
- Existing DTensor tests pass with the bug fixes and moved utility
- `test_dtensor_op_db_clamp_cpu_float32` no longer flaky (root cause was bug 1)