### PR TITLE
[leaf_function] Name _LeafCallable opaque objects after wrapped function

### DIFF
--- a/test/functorch/test_leaf_function.py
+++ b/test/functorch/test_leaf_function.py
@@ -62,10 +62,10 @@ class TestLeafFunctionMakeFx(TestCase):
             """\
 class f(torch.nn.Module):
     def forward(self, x_1: "f32[3, 3]", y_1: "f32[3, 3]"):
-        _opaque_obj0 = self._opaque_obj0
-        _opaque_obj1 = self._opaque_obj1
+        _leaf_fn_my_fn0 = self._leaf_fn_my_fn0
+        _leaf_fn_my_fn1 = self._leaf_fn_my_fn1
         _tree_spec_constant0 = self._tree_spec_constant0
-        invoke_leaf_function = torch.ops.higher_order.invoke_leaf_function(_opaque_obj0, _opaque_obj1, _tree_spec_constant0, '', x_1, y_1, requires_grad_indices = '');  _opaque_obj0 = _opaque_obj1 = _tree_spec_constant0 = x_1 = y_1 = None
+        invoke_leaf_function = torch.ops.higher_order.invoke_leaf_function(_leaf_fn_my_fn0, _leaf_fn_my_fn1, _tree_spec_constant0, '', x_1, y_1, requires_grad_indices = '');  _leaf_fn_my_fn0 = _leaf_fn_my_fn1 = _tree_spec_constant0 = x_1 = y_1 = None
         getitem: "f32[3, 3]" = invoke_leaf_function[0];  invoke_leaf_function = None
         return (getitem,)
 """,  # noqa: B950
@@ -98,10 +98,10 @@ class f(torch.nn.Module):
             """\
 class f(torch.nn.Module):
     def forward(self, x_1: "f32[3, 3]"):
-        _opaque_obj0 = self._opaque_obj0
-        _opaque_obj1 = self._opaque_obj1
+        _leaf_fn_scaled_fn0 = self._leaf_fn_scaled_fn0
+        _leaf_fn_scaled_fn1 = self._leaf_fn_scaled_fn1
         _tree_spec_constant0 = self._tree_spec_constant0
-        invoke_leaf_function = torch.ops.higher_order.invoke_leaf_function(_opaque_obj0, _opaque_obj1, _tree_spec_constant0, '', x_1, requires_grad_indices = '');  _opaque_obj0 = _opaque_obj1 = _tree_spec_constant0 = x_1 = None
+        invoke_leaf_function = torch.ops.higher_order.invoke_leaf_function(_leaf_fn_scaled_fn0, _leaf_fn_scaled_fn1, _tree_spec_constant0, '', x_1, requires_grad_indices = '');  _leaf_fn_scaled_fn0 = _leaf_fn_scaled_fn1 = _tree_spec_constant0 = x_1 = None
         getitem: "f32[3, 3]" = invoke_leaf_function[0];  invoke_leaf_function = None
         return (getitem,)
 """,  # noqa: B950
@@ -158,10 +158,10 @@ class f(torch.nn.Module):
             """\
 class f(torch.nn.Module):
     def forward(self, x_1: "f32[3, 3]", y_1: "f32[3, 3]"):
-        _opaque_obj0 = self._opaque_obj0
-        _opaque_obj1 = self._opaque_obj1
+        _leaf_fn_pytree_fn0 = self._leaf_fn_pytree_fn0
+        _leaf_fn_pytree_fn1 = self._leaf_fn_pytree_fn1
         _tree_spec_constant0 = self._tree_spec_constant0
-        invoke_leaf_function = torch.ops.higher_order.invoke_leaf_function(_opaque_obj0, _opaque_obj1, _tree_spec_constant0, '', x_1, y_1, requires_grad_indices = '');  _opaque_obj0 = _opaque_obj1 = _tree_spec_constant0 = x_1 = y_1 = None
+        invoke_leaf_function = torch.ops.higher_order.invoke_leaf_function(_leaf_fn_pytree_fn0, _leaf_fn_pytree_fn1, _tree_spec_constant0, '', x_1, y_1, requires_grad_indices = '');  _leaf_fn_pytree_fn0 = _leaf_fn_pytree_fn1 = _tree_spec_constant0 = x_1 = y_1 = None
         getitem: "f32[3, 3]" = invoke_leaf_function[0];  invoke_leaf_function = None
         return (getitem,)
 """,  # noqa: B950
@@ -307,18 +307,18 @@ class f(torch.nn.Module):
             """\
 class f(torch.nn.Module):
     def forward(self, x_1: "f32[3, 3]", y_1: "f32[3, 3]"):
-        _opaque_obj0 = self._opaque_obj0
-        _opaque_obj1 = self._opaque_obj1
+        _leaf_fn_my_fn0 = self._leaf_fn_my_fn0
+        _leaf_fn_my_fn1 = self._leaf_fn_my_fn1
         _tree_spec_constant0 = self._tree_spec_constant0
-        invoke_leaf_function = torch.ops.higher_order.invoke_leaf_function(_opaque_obj0, _opaque_obj1, _tree_spec_constant0, '', x_1, y_1, requires_grad_indices = '0,1');  _opaque_obj0 = _opaque_obj1 = _tree_spec_constant0 = x_1 = y_1 = None
+        invoke_leaf_function = torch.ops.higher_order.invoke_leaf_function(_leaf_fn_my_fn0, _leaf_fn_my_fn1, _tree_spec_constant0, '', x_1, y_1, requires_grad_indices = '0,1');  _leaf_fn_my_fn0 = _leaf_fn_my_fn1 = _tree_spec_constant0 = x_1 = y_1 = None
         getitem: "f32[3, 3]" = invoke_leaf_function[0];  invoke_leaf_function = None
         sum_1: "f32[]" = torch.ops.aten.sum.default(getitem);  getitem = None
         ones_like: "f32[]" = torch.ops.aten.ones_like.default(sum_1, pin_memory = False, memory_format = torch.preserve_format);  sum_1 = None
         expand: "f32[3, 3]" = torch.ops.aten.expand.default(ones_like, [3, 3]);  ones_like = None
-        _opaque_obj2 = self._opaque_obj2
-        _opaque_obj3 = self._opaque_obj3
+        _leaf_fn_my_fn_backward0 = self._leaf_fn_my_fn_backward0
+        _leaf_fn_my_fn_backward1 = self._leaf_fn_my_fn_backward1
         _tree_spec_constant1 = self._tree_spec_constant1
-        invoke_leaf_function_1 = torch.ops.higher_order.invoke_leaf_function(_opaque_obj2, _opaque_obj3, _tree_spec_constant1, '', expand, requires_grad_indices = '');  _opaque_obj2 = _opaque_obj3 = _tree_spec_constant1 = expand = None
+        invoke_leaf_function_1 = torch.ops.higher_order.invoke_leaf_function(_leaf_fn_my_fn_backward0, _leaf_fn_my_fn_backward1, _tree_spec_constant1, '', expand, requires_grad_indices = '');  _leaf_fn_my_fn_backward0 = _leaf_fn_my_fn_backward1 = _tree_spec_constant1 = expand = None
         getitem_1: "f32[3, 3]" = invoke_leaf_function_1[0]
         getitem_2: "f32[3, 3]" = invoke_leaf_function_1[1];  invoke_leaf_function_1 = None
         return (getitem_1, getitem_2)
@@ -354,18 +354,18 @@ class f(torch.nn.Module):
             """\
 class f(torch.nn.Module):
     def forward(self, x_1: "f32[3, 3]", y_1: "f32[3, 3]"):
-        _opaque_obj0 = self._opaque_obj0
-        _opaque_obj1 = self._opaque_obj1
+        _leaf_fn_my_fn0 = self._leaf_fn_my_fn0
+        _leaf_fn_my_fn1 = self._leaf_fn_my_fn1
         _tree_spec_constant0 = self._tree_spec_constant0
-        invoke_leaf_function = torch.ops.higher_order.invoke_leaf_function(_opaque_obj0, _opaque_obj1, _tree_spec_constant0, '', x_1, y_1, requires_grad_indices = '0');  _opaque_obj0 = _opaque_obj1 = _tree_spec_constant0 = x_1 = y_1 = None
+        invoke_leaf_function = torch.ops.higher_order.invoke_leaf_function(_leaf_fn_my_fn0, _leaf_fn_my_fn1, _tree_spec_constant0, '', x_1, y_1, requires_grad_indices = '0');  _leaf_fn_my_fn0 = _leaf_fn_my_fn1 = _tree_spec_constant0 = x_1 = y_1 = None
         getitem: "f32[3, 3]" = invoke_leaf_function[0];  invoke_leaf_function = None
         sum_1: "f32[]" = torch.ops.aten.sum.default(getitem);  getitem = None
         ones_like: "f32[]" = torch.ops.aten.ones_like.default(sum_1, pin_memory = False, memory_format = torch.preserve_format);  sum_1 = None
         expand: "f32[3, 3]" = torch.ops.aten.expand.default(ones_like, [3, 3]);  ones_like = None
-        _opaque_obj2 = self._opaque_obj2
-        _opaque_obj3 = self._opaque_obj3
+        _leaf_fn_my_fn_backward0 = self._leaf_fn_my_fn_backward0
+        _leaf_fn_my_fn_backward1 = self._leaf_fn_my_fn_backward1
         _tree_spec_constant1 = self._tree_spec_constant1
-        invoke_leaf_function_1 = torch.ops.higher_order.invoke_leaf_function(_opaque_obj2, _opaque_obj3, _tree_spec_constant1, '', expand, requires_grad_indices = '');  _opaque_obj2 = _opaque_obj3 = _tree_spec_constant1 = expand = None
+        invoke_leaf_function_1 = torch.ops.higher_order.invoke_leaf_function(_leaf_fn_my_fn_backward0, _leaf_fn_my_fn_backward1, _tree_spec_constant1, '', expand, requires_grad_indices = '');  _leaf_fn_my_fn_backward0 = _leaf_fn_my_fn_backward1 = _tree_spec_constant1 = expand = None
         getitem_1: "f32[3, 3]" = invoke_leaf_function_1[0]
         getitem_2: "f32[3, 3]" = invoke_leaf_function_1[1];  invoke_leaf_function_1 = getitem_2 = None
         return getitem_1
@@ -421,10 +421,10 @@ class TestLeafFunctionAotFunction(TestCase):
             """\
 class GraphModule(torch.nn.Module):
     def forward(self, primals_1: "f32[0]", primals_2: "f32[3, 3]", primals_3: "f32[3, 3]"):
-        _opaque_obj0 = self._opaque_obj0
-        _opaque_obj1 = self._opaque_obj1
+        _leaf_fn_my_fn0 = self._leaf_fn_my_fn0
+        _leaf_fn_my_fn1 = self._leaf_fn_my_fn1
         _tree_spec_constant0 = self._tree_spec_constant0
-        with_effects = torch.ops.higher_order.with_effects(primals_1, torch.ops.higher_order.invoke_leaf_function, _opaque_obj0, _opaque_obj1, _tree_spec_constant0, '', primals_2, primals_3, requires_grad_indices = '0,1');  primals_1 = _opaque_obj0 = _opaque_obj1 = _tree_spec_constant0 = primals_2 = primals_3 = None
+        with_effects = torch.ops.higher_order.with_effects(primals_1, torch.ops.higher_order.invoke_leaf_function, _leaf_fn_my_fn0, _leaf_fn_my_fn1, _tree_spec_constant0, '', primals_2, primals_3, requires_grad_indices = '0,1');  primals_1 = _leaf_fn_my_fn0 = _leaf_fn_my_fn1 = _tree_spec_constant0 = primals_2 = primals_3 = None
 
         getitem: "f32[0]" = with_effects[0]
         getitem_1: "f32[3, 3]" = with_effects[1];  with_effects = None
@@ -436,10 +436,10 @@ class GraphModule(torch.nn.Module):
             """\
 class GraphModule(torch.nn.Module):
     def forward(self, tangents_1: "f32[3, 3]", tangents_token: "f32[0]"):
-        _opaque_obj2 = self._opaque_obj2
-        _opaque_obj3 = self._opaque_obj3
+        _leaf_fn_my_fn_backward0 = self._leaf_fn_my_fn_backward0
+        _leaf_fn_my_fn_backward1 = self._leaf_fn_my_fn_backward1
         _tree_spec_constant1 = self._tree_spec_constant1
-        with_effects_1 = torch.ops.higher_order.with_effects(tangents_token, torch.ops.higher_order.invoke_leaf_function, _opaque_obj2, _opaque_obj3, _tree_spec_constant1, '', tangents_1, requires_grad_indices = '');  tangents_token = _opaque_obj2 = _opaque_obj3 = _tree_spec_constant1 = tangents_1 = None
+        with_effects_1 = torch.ops.higher_order.with_effects(tangents_token, torch.ops.higher_order.invoke_leaf_function, _leaf_fn_my_fn_backward0, _leaf_fn_my_fn_backward1, _tree_spec_constant1, '', tangents_1, requires_grad_indices = '');  tangents_token = _leaf_fn_my_fn_backward0 = _leaf_fn_my_fn_backward1 = _tree_spec_constant1 = tangents_1 = None
         getitem_2: "f32[0]" = with_effects_1[0]
         getitem_3: "f32[3, 3]" = with_effects_1[1]
         getitem_4: "f32[3, 3]" = with_effects_1[2];  with_effects_1 = None
@@ -803,10 +803,10 @@ class outer(torch.nn.Module):
 
     class repeated_subgraph0(torch.nn.Module):
         def forward(self, arg0_1, arg1_1: "f32[3, 3]", arg2_1: "f32[3, 3]"):
-            _opaque_obj0 = self._opaque_obj0
-            _opaque_obj1 = self._opaque_obj1
+            _leaf_fn_my_leaf0 = self._leaf_fn_my_leaf0
+            _leaf_fn_my_leaf1 = self._leaf_fn_my_leaf1
             _tree_spec_constant0 = self._tree_spec_constant0
-            with_effects = torch.ops.higher_order.with_effects(None, torch.ops.higher_order.invoke_leaf_function, _opaque_obj0, _opaque_obj1, _tree_spec_constant0, '', arg1_1, arg2_1, requires_grad_indices = '');  _opaque_obj0 = _opaque_obj1 = _tree_spec_constant0 = arg1_1 = arg2_1 = None
+            with_effects = torch.ops.higher_order.with_effects(None, torch.ops.higher_order.invoke_leaf_function, _leaf_fn_my_leaf0, _leaf_fn_my_leaf1, _tree_spec_constant0, '', arg1_1, arg2_1, requires_grad_indices = '');  _leaf_fn_my_leaf0 = _leaf_fn_my_leaf1 = _tree_spec_constant0 = arg1_1 = arg2_1 = None
             getitem: "f32[0]" = with_effects[0]
             getitem_1: "f32[3, 3]" = with_effects[1];  with_effects = None
             return (getitem, getitem_1)
@@ -853,10 +853,10 @@ class outer(torch.nn.Module):
         repeated_subgraph0 = self.repeated_subgraph0
         invoke_subgraph = torch.ops.higher_order.invoke_subgraph(repeated_subgraph0, 'invoke_subgraph_0', x_1);  repeated_subgraph0 = x_1 = None
         getitem: "f32[3, 3]" = invoke_subgraph[0];  invoke_subgraph = None
-        _opaque_obj0 = self._opaque_obj0
-        _opaque_obj1 = self._opaque_obj1
+        _leaf_fn_my_leaf0 = self._leaf_fn_my_leaf0
+        _leaf_fn_my_leaf1 = self._leaf_fn_my_leaf1
         _tree_spec_constant0 = self._tree_spec_constant0
-        invoke_leaf_function = torch.ops.higher_order.invoke_leaf_function(_opaque_obj0, _opaque_obj1, _tree_spec_constant0, '', getitem, requires_grad_indices = '');  _opaque_obj0 = _opaque_obj1 = _tree_spec_constant0 = getitem = None
+        invoke_leaf_function = torch.ops.higher_order.invoke_leaf_function(_leaf_fn_my_leaf0, _leaf_fn_my_leaf1, _tree_spec_constant0, '', getitem, requires_grad_indices = '');  _leaf_fn_my_leaf0 = _leaf_fn_my_leaf1 = _tree_spec_constant0 = getitem = None
         getitem_1: "f32[3, 3]" = invoke_leaf_function[0];  invoke_leaf_function = None
         return (getitem_1,)
 
@@ -907,19 +907,19 @@ class outer(torch.nn.Module):
         invoke_subgraph = torch.ops.higher_order.invoke_subgraph(repeated_subgraph0, 'invoke_subgraph_0', None, x_1);  repeated_subgraph0 = x_1 = None
         getitem: "f32[0]" = invoke_subgraph[0];  getitem = None
         getitem_1: "f32[3, 3]" = invoke_subgraph[1];  invoke_subgraph = None
-        _opaque_obj0 = self._opaque_obj0
-        _opaque_obj1 = self._opaque_obj1
+        _leaf_fn_my_leaf0 = self._leaf_fn_my_leaf0
+        _leaf_fn_my_leaf1 = self._leaf_fn_my_leaf1
         _tree_spec_constant0 = self._tree_spec_constant0
-        invoke_leaf_function = torch.ops.higher_order.invoke_leaf_function(_opaque_obj0, _opaque_obj1, _tree_spec_constant0, '', getitem_1, requires_grad_indices = '');  _opaque_obj0 = _opaque_obj1 = _tree_spec_constant0 = getitem_1 = None
+        invoke_leaf_function = torch.ops.higher_order.invoke_leaf_function(_leaf_fn_my_leaf0, _leaf_fn_my_leaf1, _tree_spec_constant0, '', getitem_1, requires_grad_indices = '');  _leaf_fn_my_leaf0 = _leaf_fn_my_leaf1 = _tree_spec_constant0 = getitem_1 = None
         getitem_2: "f32[3, 3]" = invoke_leaf_function[0];  invoke_leaf_function = None
         return (getitem_2,)
 
     class repeated_subgraph0(torch.nn.Module):
         def forward(self, arg0_1, arg1_1: "f32[3, 3]"):
-            _opaque_obj0 = self._opaque_obj0
-            _opaque_obj1 = self._opaque_obj1
+            _leaf_fn_my_leaf0 = self._leaf_fn_my_leaf0
+            _leaf_fn_my_leaf1 = self._leaf_fn_my_leaf1
             _tree_spec_constant0 = self._tree_spec_constant0
-            with_effects = torch.ops.higher_order.with_effects(None, torch.ops.higher_order.invoke_leaf_function, _opaque_obj0, _opaque_obj1, _tree_spec_constant0, '', arg1_1, requires_grad_indices = '');  _opaque_obj0 = _opaque_obj1 = _tree_spec_constant0 = arg1_1 = None
+            with_effects = torch.ops.higher_order.with_effects(None, torch.ops.higher_order.invoke_leaf_function, _leaf_fn_my_leaf0, _leaf_fn_my_leaf1, _tree_spec_constant0, '', arg1_1, requires_grad_indices = '');  _leaf_fn_my_leaf0 = _leaf_fn_my_leaf1 = _tree_spec_constant0 = arg1_1 = None
             getitem: "f32[0]" = with_effects[0]
             getitem_1: "f32[3, 3]" = with_effects[1];  with_effects = None
             return (getitem, getitem_1)
@@ -1094,10 +1094,11 @@ class GraphModule(torch.nn.Module):
             """\
 class GraphModule(torch.nn.Module):
     def forward(self, primals_1: "f32[0]", primals_2: "f32[3, 3]", primals_3: "f32[3, 3]", primals_4: "f32[3]"):
-        _opaque_obj0 = self._opaque_obj0
-        _opaque_obj1 = self._opaque_obj1
+        _leaf_fn_non_tracable_forward0 = self._leaf_fn_non_tracable_forward0
+        _leaf_fn_non_tracable_forward1 = self._leaf_fn_non_tracable_forward1
+
         _tree_spec_constant0 = self._tree_spec_constant0
-        with_effects = torch.ops.higher_order.with_effects(primals_1, torch.ops.higher_order.invoke_leaf_function, _opaque_obj0, _opaque_obj1, _tree_spec_constant0, '', 0, primals_3, primals_4, primals_2, requires_grad_indices = '1,2,3');  primals_1 = _opaque_obj0 = _opaque_obj1 = _tree_spec_constant0 = primals_3 = primals_4 = primals_2 = None
+        with_effects = torch.ops.higher_order.with_effects(primals_1, torch.ops.higher_order.invoke_leaf_function, _leaf_fn_non_tracable_forward0, _leaf_fn_non_tracable_forward1, _tree_spec_constant0, '', 0, primals_3, primals_4, primals_2, requires_grad_indices = '1,2,3');  primals_1 = _leaf_fn_non_tracable_forward0 = _leaf_fn_non_tracable_forward1 = _tree_spec_constant0 = primals_3 = primals_4 = primals_2 = None
 
         getitem: "f32[0]" = with_effects[0]
         getitem_1: "f32[3, 3]" = with_effects[1];  with_effects = None
@@ -1109,10 +1110,11 @@ class GraphModule(torch.nn.Module):
             """\
 class GraphModule(torch.nn.Module):
     def forward(self, tangents_1: "f32[3, 3]", tangents_token: "f32[0]"):
-        _opaque_obj2 = self._opaque_obj2
-        _opaque_obj3 = self._opaque_obj3
+        _leaf_fn_non_tracable_forward_backward0 = self._leaf_fn_non_tracable_forward_backward0
+        _leaf_fn_non_tracable_forward_backward1 = self._leaf_fn_non_tracable_forward_backward1
+
         _tree_spec_constant1 = self._tree_spec_constant1
-        with_effects_1 = torch.ops.higher_order.with_effects(tangents_token, torch.ops.higher_order.invoke_leaf_function, _opaque_obj2, _opaque_obj3, _tree_spec_constant1, '', tangents_1, requires_grad_indices = '');  tangents_token = _opaque_obj2 = _opaque_obj3 = _tree_spec_constant1 = tangents_1 = None
+        with_effects_1 = torch.ops.higher_order.with_effects(tangents_token, torch.ops.higher_order.invoke_leaf_function, _leaf_fn_non_tracable_forward_backward0, _leaf_fn_non_tracable_forward_backward1, _tree_spec_constant1, '', tangents_1, requires_grad_indices = '');  tangents_token = _leaf_fn_non_tracable_forward_backward0 = _leaf_fn_non_tracable_forward_backward1 = _tree_spec_constant1 = tangents_1 = None
         getitem_2: "f32[0]" = with_effects_1[0]
         getitem_4: "f32[3, 3]" = with_effects_1[2]
         getitem_5: "f32[3]" = with_effects_1[3]
@@ -1339,10 +1341,11 @@ class GraphModule(torch.nn.Module):
             """\
 class GraphModule(torch.nn.Module):
     def forward(self, primals_1: "f32[0]", primals_2: "f32[3, 3]", primals_3: "f32[3]", primals_4: "f32[3, 3]", primals_5: "f32[3]"):
-        _opaque_obj0 = self._opaque_obj0
-        _opaque_obj1 = self._opaque_obj1
+        _leaf_fn_closure_forward0 = self._leaf_fn_closure_forward0
+        _leaf_fn_closure_forward1 = self._leaf_fn_closure_forward1
+
         _tree_spec_constant0 = self._tree_spec_constant0
-        with_effects = torch.ops.higher_order.with_effects(primals_1, torch.ops.higher_order.invoke_leaf_function, _opaque_obj0, _opaque_obj1, _tree_spec_constant0, '', 0, primals_3, primals_4, primals_5, primals_2, requires_grad_indices = '1,2,3,4');  primals_1 = _opaque_obj0 = _opaque_obj1 = _tree_spec_constant0 = primals_3 = primals_4 = primals_5 = primals_2 = None
+        with_effects = torch.ops.higher_order.with_effects(primals_1, torch.ops.higher_order.invoke_leaf_function, _leaf_fn_closure_forward0, _leaf_fn_closure_forward1, _tree_spec_constant0, '', 0, primals_3, primals_4, primals_5, primals_2, requires_grad_indices = '1,2,3,4');  primals_1 = _leaf_fn_closure_forward0 = _leaf_fn_closure_forward1 = _tree_spec_constant0 = primals_3 = primals_4 = primals_5 = primals_2 = None
 
         getitem: "f32[0]" = with_effects[0]
         getitem_1: "f32[3, 3]" = with_effects[1];  with_effects = None
@@ -1354,10 +1357,11 @@ class GraphModule(torch.nn.Module):
             """\
 class GraphModule(torch.nn.Module):
     def forward(self, tangents_1: "f32[3, 3]", tangents_token: "f32[0]"):
-        _opaque_obj2 = self._opaque_obj2
-        _opaque_obj3 = self._opaque_obj3
+        _leaf_fn_closure_forward_backward0 = self._leaf_fn_closure_forward_backward0
+        _leaf_fn_closure_forward_backward1 = self._leaf_fn_closure_forward_backward1
+
         _tree_spec_constant1 = self._tree_spec_constant1
-        with_effects_1 = torch.ops.higher_order.with_effects(tangents_token, torch.ops.higher_order.invoke_leaf_function, _opaque_obj2, _opaque_obj3, _tree_spec_constant1, '', tangents_1, requires_grad_indices = '');  tangents_token = _opaque_obj2 = _opaque_obj3 = _tree_spec_constant1 = tangents_1 = None
+        with_effects_1 = torch.ops.higher_order.with_effects(tangents_token, torch.ops.higher_order.invoke_leaf_function, _leaf_fn_closure_forward_backward0, _leaf_fn_closure_forward_backward1, _tree_spec_constant1, '', tangents_1, requires_grad_indices = '');  tangents_token = _leaf_fn_closure_forward_backward0 = _leaf_fn_closure_forward_backward1 = _tree_spec_constant1 = tangents_1 = None
         getitem_2: "f32[0]" = with_effects_1[0]
         getitem_4: "f32[3]" = with_effects_1[2]
         getitem_5: "f32[3, 3]" = with_effects_1[3]
@@ -1468,10 +1472,10 @@ class GraphModule(torch.nn.Module):
             """\
 class GraphModule(torch.nn.Module):
     def forward(self, primals_1: "f32[0]", primals_2: "f32[3, 3]", primals_3: "f32[3, 3]", primals_4: "f32[3]", primals_5: "f32[3, 3]", primals_6: "f32[3]"):
-        _opaque_obj0 = self._opaque_obj0
-        _opaque_obj1 = self._opaque_obj1
+        _leaf_fn_outer_leaf_forward0 = self._leaf_fn_outer_leaf_forward0
+        _leaf_fn_outer_leaf_forward1 = self._leaf_fn_outer_leaf_forward1
         _tree_spec_constant0 = self._tree_spec_constant0
-        with_effects = torch.ops.higher_order.with_effects(primals_1, torch.ops.higher_order.invoke_leaf_function, _opaque_obj0, _opaque_obj1, _tree_spec_constant0, '', 0, primals_3, primals_4, primals_5, primals_6, primals_2, requires_grad_indices = '1,2,3,4,5');  primals_1 = _opaque_obj0 = _opaque_obj1 = _tree_spec_constant0 = primals_3 = primals_4 = primals_5 = primals_6 = primals_2 = None
+        with_effects = torch.ops.higher_order.with_effects(primals_1, torch.ops.higher_order.invoke_leaf_function, _leaf_fn_outer_leaf_forward0, _leaf_fn_outer_leaf_forward1, _tree_spec_constant0, '', 0, primals_3, primals_4, primals_5, primals_6, primals_2, requires_grad_indices = '1,2,3,4,5');  primals_1 = _leaf_fn_outer_leaf_forward0 = _leaf_fn_outer_leaf_forward1 = _tree_spec_constant0 = primals_3 = primals_4 = primals_5 = primals_6 = primals_2 = None
 
         getitem: "f32[0]" = with_effects[0]
         getitem_1: "f32[3, 3]" = with_effects[1];  with_effects = None
@@ -1483,10 +1487,10 @@ class GraphModule(torch.nn.Module):
             """\
 class GraphModule(torch.nn.Module):
     def forward(self, tangents_1: "f32[3, 3]", tangents_token: "f32[0]"):
-        _opaque_obj2 = self._opaque_obj2
-        _opaque_obj3 = self._opaque_obj3
+        _leaf_fn_outer_leaf_forward_backward0 = self._leaf_fn_outer_leaf_forward_backward0
+        _leaf_fn_outer_leaf_forward_backward1 = self._leaf_fn_outer_leaf_forward_backward1
         _tree_spec_constant1 = self._tree_spec_constant1
-        with_effects_1 = torch.ops.higher_order.with_effects(tangents_token, torch.ops.higher_order.invoke_leaf_function, _opaque_obj2, _opaque_obj3, _tree_spec_constant1, '', tangents_1, requires_grad_indices = '');  tangents_token = _opaque_obj2 = _opaque_obj3 = _tree_spec_constant1 = tangents_1 = None
+        with_effects_1 = torch.ops.higher_order.with_effects(tangents_token, torch.ops.higher_order.invoke_leaf_function, _leaf_fn_outer_leaf_forward_backward0, _leaf_fn_outer_leaf_forward_backward1, _tree_spec_constant1, '', tangents_1, requires_grad_indices = '');  tangents_token = _leaf_fn_outer_leaf_forward_backward0 = _leaf_fn_outer_leaf_forward_backward1 = _tree_spec_constant1 = tangents_1 = None
         getitem_2: "f32[0]" = with_effects_1[0]
         getitem_4: "f32[3, 3]" = with_effects_1[2]
         getitem_5: "f32[3]" = with_effects_1[3]
@@ -2193,10 +2197,10 @@ class GraphModule(torch.nn.Module):
             """\
 class GraphModule(torch.nn.Module):
     def forward(self, primals_1: "f32[0]", primals_2: "f32[3, 3]", primals_3: "f32[3, 3]", primals_4: "f32[3]"):
-        _opaque_obj0 = self._opaque_obj0
-        _opaque_obj1 = self._opaque_obj1
+        _leaf_fn_fn_no_return0 = self._leaf_fn_fn_no_return0
+        _leaf_fn_fn_no_return1 = self._leaf_fn_fn_no_return1
         _tree_spec_constant0 = self._tree_spec_constant0
-        with_effects = torch.ops.higher_order.with_effects(primals_1, torch.ops.higher_order.invoke_leaf_function, _opaque_obj0, _opaque_obj1, _tree_spec_constant0, '', primals_2, requires_grad_indices = '0');  primals_1 = _opaque_obj0 = _opaque_obj1 = _tree_spec_constant0 = None
+        with_effects = torch.ops.higher_order.with_effects(primals_1, torch.ops.higher_order.invoke_leaf_function, _leaf_fn_fn_no_return0, _leaf_fn_fn_no_return1, _tree_spec_constant0, '', primals_2, requires_grad_indices = '0');  primals_1 = _leaf_fn_fn_no_return0 = _leaf_fn_fn_no_return1 = _tree_spec_constant0 = None
 
         getitem: "f32[0]" = with_effects[0];  with_effects = None
 

--- a/torch/_dynamo/decorators.py
+++ b/torch/_dynamo/decorators.py
@@ -359,8 +359,15 @@ def _invoke_leaf_function_python(
         real_impl, fake_impl, captured_out_spec
     )
 
-    real_fn_callable = _LeafCallable(wrapped_real)
-    fake_fn_callable = _LeafCallable(wrapped_fake)
+    from torch._higher_order_ops.invoke_leaf_function import _get_source_location
+
+    source_location = _get_source_location(real_impl)
+    real_fn_callable = _LeafCallable(
+        wrapped_real, name=real_impl.__name__, source_location=source_location
+    )
+    fake_fn_callable = _LeafCallable(
+        wrapped_fake, name=real_impl.__name__, source_location=source_location
+    )
 
     mutated_flat_indices = ""
     if mutates_args:

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -3558,8 +3558,8 @@ def emit_noargs_leaf_function_to_graph(
         real_impl, fake_impl, captured_out_spec
     )
 
-    real_callable = _LeafCallable(wrapped_real)
-    fake_callable = _LeafCallable(wrapped_fake)
+    real_callable = _LeafCallable(wrapped_real, name=name)
+    fake_callable = _LeafCallable(wrapped_fake, name=name)
     input_spec = pytree.tree_flatten(((), {}))[1]
 
     def make_proxy(attr_name: str, val: Any) -> Any:

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -2692,7 +2692,7 @@ For now, dynamo will explicitly graph break when it encounters user code with th
                 fake_tensor_tls.allow_non_fake_inputs_override = old_val
             return res
 
-        f_callable = _LeafCallable(patched_fn)
+        f_callable = _LeafCallable(patched_fn, name=fn.__name__)
 
         f_callable_proxy = tx.output.register_static_attr_and_return_proxy(
             f"{fn.__name__}_callable", f_callable
@@ -2902,8 +2902,19 @@ For now, dynamo will explicitly graph break when it encounters user code with th
             real_impl, fake_impl, captured_out_spec
         )
 
-        real_impl_callable = _LeafCallable(wrapped_real_impl)
-        fake_impl_callable = _LeafCallable(wrapped_fake_impl)
+        from torch._higher_order_ops.invoke_leaf_function import _get_source_location
+
+        source_location = _get_source_location(real_impl)
+        real_impl_callable = _LeafCallable(
+            wrapped_real_impl,
+            name=real_impl.__name__,
+            source_location=source_location,
+        )
+        fake_impl_callable = _LeafCallable(
+            wrapped_fake_impl,
+            name=real_impl.__name__,
+            source_location=source_location,
+        )
 
         def make_callable_proxy(name: str, spec: Any) -> Any:
             proxy = tx.output.register_static_attr_and_return_proxy(name, spec)

--- a/torch/_higher_order_ops/invoke_leaf_function.py
+++ b/torch/_higher_order_ops/invoke_leaf_function.py
@@ -1,5 +1,6 @@
 import contextlib
 import functools
+import inspect
 from collections.abc import Callable, Generator, Sequence
 from dataclasses import dataclass
 from typing import Any, NamedTuple
@@ -49,14 +50,25 @@ def reset_makefx_module_storage() -> None:
 
 
 class _LeafCallable(OpaqueBase):
-    def __init__(self, fn: Callable) -> None:
+    def __init__(self, fn: Callable, name: str = "", source_location: str = "") -> None:
         self._fn = fn
+        self._name = name
+        self._source_location = source_location
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
         return self._fn(*args, **kwargs)
 
 
 register_opaque_type(_LeafCallable, typ="reference")
+
+
+def _get_source_location(fn: Callable) -> str:
+    try:
+        file = inspect.getfile(fn)
+        _, line = inspect.getsourcelines(fn)
+        return f"{file}:{line}"
+    except (TypeError, OSError):
+        return ""
 
 
 def set_leaf_function_module_retriever(retriever: Callable[[int], Any]) -> None:
@@ -719,7 +731,11 @@ class InvokeLeafFunctionAutogradOp(torch.autograd.Function):
                     result.append(None)
             return tuple(result)
 
-        new_real_fn_callable = _LeafCallable(real_forward)
+        name = getattr(real_fn_callable, "_name", "")
+        source_location = getattr(real_fn_callable, "_source_location", "")
+        new_real_fn_callable = _LeafCallable(
+            real_forward, name=name, source_location=source_location
+        )
 
         with torch._C._AutoDispatchBelowAutograd():
             fw_outputs = invoke_leaf_function(
@@ -733,14 +749,22 @@ class InvokeLeafFunctionAutogradOp(torch.autograd.Function):
 
         ctx.real_backward = real_backward
         ctx.fake_backward = fake_backward
+        ctx._leaf_name = name
+        ctx._leaf_source_location = source_location
 
         return fw_outputs
 
     @staticmethod
     # pyrefly: ignore [bad-override]
     def backward(ctx, *grads):
-        real_bw_callable = _LeafCallable(ctx.real_backward)
-        fake_bw_callable = _LeafCallable(ctx.fake_backward)
+        bw_name = f"{ctx._leaf_name}_backward" if ctx._leaf_name else ""
+        source_location = ctx._leaf_source_location
+        real_bw_callable = _LeafCallable(
+            ctx.real_backward, name=bw_name, source_location=source_location
+        )
+        fake_bw_callable = _LeafCallable(
+            ctx.fake_backward, name=bw_name, source_location=source_location
+        )
         _, bw_input_spec = pytree.tree_flatten((grads, {}))
         fw_grads = invoke_leaf_function(
             real_bw_callable, fake_bw_callable, bw_input_spec, "", *grads

--- a/torch/fx/_symbolic_trace.py
+++ b/torch/fx/_symbolic_trace.py
@@ -425,6 +425,8 @@ class Tracer(TracerBase):
         if isinstance(a, _constant_attribute_types) or (
             is_opaque_reference_type(type(a))
         ):
+            from torch._higher_order_ops.invoke_leaf_function import _LeafCallable
+
             qualname: str | None = self.tensor_attrs.get(a)
 
             # Tensor was not found in the Module hierarchy, stow it away in a
@@ -437,7 +439,10 @@ class Tracer(TracerBase):
                 elif isinstance(a, pytree.TreeSpec):
                     base_name = "_tree_spec_constant"
                 elif is_opaque_type(type(a)):
-                    base_name = "_opaque_obj"
+                    if isinstance(a, _LeafCallable) and a._name:
+                        base_name = f"_leaf_fn_{a._name}"
+                    else:
+                        base_name = "_opaque_obj"
                 else:
                     raise RuntimeError(
                         f"cannot create constant arg for {a} of type {type(a)}."
@@ -450,7 +455,10 @@ class Tracer(TracerBase):
                 self.tensor_attrs[a] = qualname
                 setattr(self.root, qualname, a)
 
-            return self.create_node("get_attr", qualname, (), {})
+            node = self.create_node("get_attr", qualname, (), {})
+            if isinstance(a, _LeafCallable) and a._source_location:
+                node.meta["stack_trace"] = a._source_location
+            return node
 
         if type(a) in _proxyable_classes:
             # This is an instance of a proxyable class for which we did not


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #178444
* #178422

When users inspect FX graphs containing invoke_leaf_function, the wrapped
function previously appeared as generic _opaque_obj0, _opaque_obj1 with no
indication of which Python function they represent. Now they show as
_leaf_fn_<name> (e.g. _leaf_fn_my_fn0) and backward callables as
_leaf_fn_<name>_backward0.

Also captures source location (file:line) on _LeafCallable and propagates
it to the get_attr node's stack_trace metadata for print_readable().

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98 @Lucaskabela