### PR TITLE
[ROCm][CI][TunableOp] Make TunableOp submatrix count backend-aware

### DIFF
--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -6260,8 +6260,12 @@ class TestLinalg(TestCase):
             # This stores total number of cumulative results
             total_num_results = new_results - ref_results
 
-            # There must be a new tuning results
-            self.assertEqual(total_num_results, 10)
+            preferred_blas = str(torch.backends.cuda.preferred_blas_library())
+            # With hipBLASLt preferred, the two linear/addmm+bias calls are
+            # tracked as GemmAndBias tunables (+2). With rocBLAS preferred,
+            # they fall back to regular GEMM signatures and don't add entries.
+            expected_num_results = 10 if preferred_blas == "_BlasBackend.Cublaslt" else 8
+            self.assertEqual(total_num_results, expected_num_results)
 
             results_filename = torch.cuda.tunable.get_filename()
             self.assertTrue(os.path.exists(results_filename))


### PR DESCRIPTION
Fixes: https://github.com/pytorch/pytorch/issues/177402

Adjust the offline TunableOp submatrix test to expect different result counts based on the preferred BLAS backend, since linear/addmm+bias contributes extra GemmAndBias entries only on the hipBLASLt path.

Made-with: Cursor

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @pragupta @jerrymannil @xinyazhang