### PR TITLE
[ROCm][UT] Remove ROCm skips after upstream Triton 3.7 pin update

### DIFF
--- a/test/distributed/tensor/test_attention.py
+++ b/test/distributed/tensor/test_attention.py
@@ -688,7 +688,6 @@ class CPFlexAttentionTest(DTensorTestBase):
     @unittest.skipIf(
         not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Does not support flash attention"
     )
-    @skipIfRocm(msg="Fails with Triton 3.7")
     def test_cp_flex_attention_document_mask(self) -> None:
         random.seed(10)
 

--- a/test/dynamo/test_structured_trace.py
+++ b/test/dynamo/test_structured_trace.py
@@ -21,7 +21,7 @@ import torch.fx as fx
 from torch._inductor.test_case import TestCase
 from torch._logging._internal import TorchLogsFormatter
 from torch.nn.parallel import DistributedDataParallel as DDP
-from torch.testing._internal.common_utils import find_free_port, skipIfRocm
+from torch.testing._internal.common_utils import find_free_port
 from torch.testing._internal.triton_utils import requires_cuda_and_triton
 
 

--- a/test/dynamo/test_structured_trace.py
+++ b/test/dynamo/test_structured_trace.py
@@ -744,7 +744,6 @@ class StructuredTraceTest(TestCase):
 
         self.assertParses()
 
-    @skipIfRocm(msg="Fails with Triton 3.7")
     @requires_tlparse
     @unittest.skip("https://github.com/pytorch/pytorch/issues/176188")
     def test_graph_breaks(self):

--- a/test/functorch/test_vmap.py
+++ b/test/functorch/test_vmap.py
@@ -70,7 +70,6 @@ from torch.testing._internal.common_utils import (
     markDynamoStrictTest,
     parametrize,
     run_tests,
-    skipIfRocm,
     skipIfTorchDynamo,
     subtest,
     TEST_WITH_ROCM,

--- a/test/functorch/test_vmap.py
+++ b/test/functorch/test_vmap.py
@@ -4439,7 +4439,6 @@ class TestVmapOperatorsOpInfo(TestCase):
             }
         ),
     )
-    @skipIfRocm(msg="Fails with Triton 3.7 on MI200")
     def test_vmap_exhaustive(self, device, dtype, op):
         # needs to be fixed
         inplace_failure_list = ()

--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -3563,7 +3563,6 @@ class AOTInductorTestsTemplate:
         example_inputs = (torch.randn(3, 10, device=self.device),)
         self.check_model(Model(), example_inputs)
 
-    @skipIfRocm(msg="Fails with Triton 3.7")
     @skipIfRocmArch(NAVI_ARCH)  # regression on ROCm 7.2
     def test_repeated_calling(self):
         if self.device != "cuda":

--- a/test/inductor/test_aot_inductor_package.py
+++ b/test/inductor/test_aot_inductor_package.py
@@ -322,7 +322,6 @@ class TestAOTInductorPackage(TestCase):
                 self.assertTrue(torch.allclose(actual, expected))
 
     @requires_triton_ptxas_compat
-    @skipIfRocm(msg="Fails with Triton 3.7")
     @unittest.skipIf(IS_FBCODE, "cmake won't work in fbcode")
     def test_compile_after_package_multi_arch(self):
         if self.device != GPU_TYPE:

--- a/test/inductor/test_aot_inductor_package.py
+++ b/test/inductor/test_aot_inductor_package.py
@@ -32,7 +32,7 @@ from torch.testing._internal.common_cuda import (
     requires_triton_ptxas_compat,
     TRITON_PTXAS_VERSION,
 )
-from torch.testing._internal.common_utils import IS_FBCODE, skipIfRocm, TEST_CUDA
+from torch.testing._internal.common_utils import IS_FBCODE, TEST_CUDA
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
 
 

--- a/test/inductor/test_combo_kernels.py
+++ b/test/inductor/test_combo_kernels.py
@@ -415,7 +415,6 @@ class ComboKernelTests(TestCase):
         self.assertEqual(torch._inductor.metrics.generated_kernel_count, 2)
 
     @skipIfXpu(msg="Profiler JSON traceEvents is not supported on XPU")
-    @skipIfRocm(msg="Fails with Triton 3.7")
     @requires_gpu_and_triton
     def test_combo_kernel_per_config_subkernel_block_size(self):
         from torch.profiler import ProfilerActivity
@@ -495,7 +494,6 @@ class ComboKernelTests(TestCase):
             FileCheck().check("pid_offset = pid").run(code[0])
 
     @skipIfXpu(msg="Profiler JSON traceEvents is not supported on XPU")
-    @skipIfRocm(msg="Fails with Triton 3.7")
     @requires_gpu_and_triton
     @torch._dynamo.config.patch("assume_static_by_default", False)
     def test_combo_kernel_dynamic_shapes_grid_changes(self):
@@ -576,7 +574,6 @@ class ComboKernelTests(TestCase):
             )
 
     @skipIfXpu(msg="Profiler JSON traceEvents is not supported on XPU")
-    @skipIfRocm(msg="Fails with Triton 3.7")
     @requires_gpu_and_triton
     @unittest.skipIf(not SM90OrLater, "Avoid oom on CI")
     def test_combo_kernel_yz_overflow(self):

--- a/test/inductor/test_compiled_autograd.py
+++ b/test/inductor/test_compiled_autograd.py
@@ -46,7 +46,6 @@ from torch.testing._internal.common_utils import (
     scoped_load_inline,
     skipIfWindows,
     skipIfXpu,
-    TEST_WITH_ROCM,
 )
 from torch.testing._internal.hop_db import hop_db
 from torch.testing._internal.inductor_utils import (
@@ -5416,10 +5415,6 @@ skipped_tests.add("test_checkpoint_error_suggests_mark_dynamic")
 skipped_tests.add("test_checkpoint_automatic_dynamic_graph_shadowing")
 skipped_tests.add("test_checkpoint_automatic_dynamic_mark_dynamic_workaround")
 skipped_tests.add("test_checkpoint_automatic_dynamic_lru_disabled_workaround")
-
-# Fails with triton 3.7
-if TEST_WITH_ROCM:
-    skipped_tests.add("test_concat_unbacked_shape_tensor")
 
 test_autograd = load_test_module("test_autograd")
 test_custom_ops = load_test_module("test_custom_ops")

--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -5245,7 +5245,6 @@ class CPUReproTests(TestCase):
         get_gcc_major_version() == 13,
         "Fails under GCC 13 due to vector codegen (passes with GCC 11)",
     )
-    @skipIfRocm(msg="Fails with Triton 3.7")
     def test_convert_fp32_to_double_vec(self):
         def fn(x):
             return x.to(torch.double)

--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -40,7 +40,6 @@ from torch.testing._internal.common_utils import (
     IS_MACOS,
     MI200_ARCH,
     parametrize,
-    skipIfRocm,
     skipIfRocmArch,
     slowTest,
     TEST_MKL,

--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -2117,7 +2117,6 @@ class CudaReproTests(TestCase):
         self.assertEqual(graph.device_types, {device_type})
         self.assertEqual(compiled_fn(*inp), fn(*inp))
 
-    @skipIfRocm(msg="Fails with Triton 3.7")
     def test_epilogue_fusion_with_view(self):
         class ToyModel(torch.nn.Module):
             def __init__(self) -> None:

--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -8162,8 +8162,6 @@ class TestLearnableBiases(InductorTestCase):
         )
 
     @skip_on_cpu
-    # Fails with triton 3.7
-    @skip_on_rocm
     def test_flex_attention_with_dynamic_max_autotune(self, device):
         self._test_flex_attention_with_dynamic_max_autotune(device)
 

--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -8173,7 +8173,6 @@ class TestLearnableBiases(InductorTestCase):
         self._test_flex_attention_with_dynamic_max_autotune(device)
 
     @skip_on_cpu
-    @skipIfRocm(msg="Fails with Triton 3.7")
     def test_flex_attention_logging(self, device):
         with tempfile.TemporaryDirectory() as tmpdir:
             log_file = os.path.join(tmpdir, "flex_attention_configs")

--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -1153,7 +1153,6 @@ class TestMaxAutotune(TestCase):
         f_c = torch.compile(mode="max-autotune-no-cudagraphs")(f)
         self.assertEqual(f_c(*inps), f(*inps), atol=0.03, rtol=0.25)
 
-    @skipIfRocm(msg="Fails with Triton 3.7")
     @config.patch("trace.enabled", True)
     @config.patch({"test_configs.force_extern_kernel_in_multi_template": True})
     @config.patch("triton.native_matmul", False)
@@ -1207,7 +1206,6 @@ class TestMaxAutotune(TestCase):
 
         torch._logging.set_logs()
 
-    @skipIfRocm(msg="Fails with Triton 3.7")
     @config.patch({"test_configs.force_extern_kernel_in_multi_template": True})
     def test_cat_max_autotune_extern(self):
         self._test_cat_max_autotune_impl(using_triton_mm=False)
@@ -1795,7 +1793,6 @@ class TestMaxAutotune(TestCase):
             # Check that contiguous transform was used
             FileCheck().check("contiguous_addmm").run(code[0])
 
-    @skipIfRocm(msg="Fails with Triton 3.7")
     @unittest.skipIf(not torch.version.hip, "ROCM only")
     @parametrize("dynamic", (False, True))
     def test_max_autotune_contiguous_transform_non_contiguous_second_matrix(
@@ -4976,7 +4973,6 @@ class TestMaxAutotuneAsyncPipelined(TestMaxAutotune, TestEpilogueFusionStaticAna
         cache_entries_after_second = len(AsyncAutotuner.choice_hash_to_future)
         self.assertEqual(cache_entries_after_second, 0)
 
-    @skipIfRocm(msg="Fails with Triton 3.7")
     @config.patch(max_autotune_gemm=True)
     def test_triton_error_precompilation_and_autotuning(self):
         """

--- a/test/inductor/test_memory.py
+++ b/test/inductor/test_memory.py
@@ -240,7 +240,6 @@ class TestOperatorReorderForPeakMemory(TestCase):
             outp = compiled_model(self.inputs)
             self.assertTrue(same(outp, outp_corr))
 
-    @skipIfRocm(msg="Fails with Triton 3.7")
     @skipIfXpu(msg="Blocked by https://github.com/pytorch/pytorch/issues/170049")
     @mock.patch.object(config, "allow_buffer_reuse", False)
     @unittest.skipUnless(TRITON_AVAILABLE, "Triton is not available")

--- a/test/inductor/test_memory.py
+++ b/test/inductor/test_memory.py
@@ -8,7 +8,7 @@ from torch._dynamo.utils import same
 from torch._inductor import config, memory
 from torch._inductor.test_case import TestCase
 from torch._inductor.utils import run_and_get_triton_code
-from torch.testing._internal.common_utils import serialTest, skipIfRocm, skipIfXpu
+from torch.testing._internal.common_utils import serialTest, skipIfXpu
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
 
 

--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -31,7 +31,6 @@ from torch.testing import FileCheck
 from torch.testing._internal import common_utils
 from torch.testing._internal.common_utils import (
     parametrize,
-    skipIfRocm,
     skipIfWindows,
     skipIfXpu,
 )

--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -3588,7 +3588,6 @@ class MutationTests(torch._inductor.test_case.TestCase):
         )
 
     @skipIfXpu(msg="Blocked by https://github.com/pytorch/pytorch/issues/170049")
-    @skipIfRocm(msg="Fails with Triton 3.7")
     @make_mutation_test
     def test_for_loop_arg_2():
         @triton.jit
@@ -3650,7 +3649,6 @@ class MutationTests(torch._inductor.test_case.TestCase):
         )
 
     @skipIfXpu(msg="Blocked by https://github.com/pytorch/pytorch/issues/170049")
-    @skipIfRocm(msg="Fails with Triton 3.7")
     @make_mutation_test
     def test_while_loop():
         @triton.jit

--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -29,11 +29,7 @@ from torch._inductor.utils import run_and_get_code, triton_version_uses_attrs_di
 from torch._library import capture_triton
 from torch.testing import FileCheck
 from torch.testing._internal import common_utils
-from torch.testing._internal.common_utils import (
-    parametrize,
-    skipIfWindows,
-    skipIfXpu,
-)
+from torch.testing._internal.common_utils import parametrize, skipIfWindows, skipIfXpu
 from torch.testing._internal.inductor_utils import (
     get_func_call,
     GPU_TYPE,

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -4404,7 +4404,6 @@ class TestCudaAllocator(TestCase):
         TEST_CUDAMALLOCASYNC, "setContextRecorder not supported by CUDAMallocAsync"
     )
     @requiresCppContext
-    @skipIfRocm(msg="Fails with Triton 3.7")
     def test_memory_plots(self):
         for context, stacks in (
             ("all", "all" if IS_LINUX else "python"),
@@ -4568,7 +4567,6 @@ class TestCudaAllocator(TestCase):
     @unittest.skipIf(
         TEST_CUDAMALLOCASYNC, "setContextRecorder not supported by CUDAMallocAsync"
     )
-    @skipIfRocm(msg="Fails with Triton 3.7")
     @requiresCppContext
     def test_memory_plots_free_segment_stack(self):
         for context in ["alloc", "all", "state"]:

--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -4429,7 +4429,6 @@ def forward(self, args_list: List[torch.Tensor]){maybe_return_annotation}:
         torch.fx.proxy.TracerBase.check_mutable_operations = orig_tracer_mutable_flag
 
     # This only fails on navi31
-    @skipIfRocm(msg="Fails with Triton 3.7")
     @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
     @torch.fx.experimental._config.patch("enrich_profiler_metadata", True)
     @blas_library_context("cublaslt")

--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -74,7 +74,6 @@ from torch.testing._internal.common_utils import (
     IS_WINDOWS,
     run_tests,
     skipIfTorchDynamo,
-    skipIfRocm,
 )
 from torch.testing._internal.jit_utils import JitTestCase
 

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -6131,7 +6131,6 @@ class TestLinalg(TestCase):
     @onlyCUDA
     @skipCUDAIfNotRocm
     # Fails with triton 3.7
-    @skipIfRocmArch(NAVI_ARCH)
     @dtypes(torch.float)
     def test_mm_submatrix_offline_tunableop(self, device, dtype):
         import os

--- a/test/test_matmul_cuda.py
+++ b/test/test_matmul_cuda.py
@@ -713,7 +713,6 @@ class TestMatmulCuda(InductorTestCase):
 
     @skipCUDAIfNotRocm
     # Fails with triton 3.7
-    @skipIfRocmArch(NAVI_ARCH)
     def test_grouped_gemm_rocm_ck_flag(self):
         CK_EQUAL_K_HINT = "kernel_grouped_gemm_xdl_splitk"
         CK_UNEQUAL_K_HINT = "kernel_grouped_gemm_xdl_splitk"

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -67,7 +67,6 @@ from torch.testing._internal.common_utils import (
     parametrize,
     run_tests,
     set_default_dtype,
-    skipIfRocm,
     skipIfTorchDynamo,
     skipIfTorchInductor,
     suppress_warnings,

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -496,7 +496,6 @@ class TestCommon(TestCase):
     @onlyOn(["cuda", "xpu"])
     @suppress_warnings
     @skipCUDAIfNotRocm
-    @skipIfRocm(msg="Fails with Triton 3.7")
     @ops(_ops_and_refs_with_no_numpy_ref, dtypes=OpDTypes.any_common_cpu_cuda_one)
     def test_compare_cpu(self, device, dtype, op):
         def to_cpu(arg):
@@ -841,7 +840,6 @@ class TestCommon(TestCase):
     # Tests that the function produces the same result when called with
     #   noncontiguous tensors.
     @skipXPU
-    @skipIfRocm(msg="Fails with Triton 3.7")
     @with_tf32_off
     @onlyNativeDeviceTypesAnd(["hpu"])
     @suppress_warnings
@@ -1611,7 +1609,6 @@ class TestCommon(TestCase):
     #   correctly for CPU and CUDA devices
     @skipXPU
     @skipMeta
-    @skipIfRocm(msg="Fails with Triton 3.7")
     @onlyNativeDeviceTypesAnd(["hpu"])
     @ops(ops_and_refs, dtypes=OpDTypes.none)
     def test_dtypes(self, device, op):

--- a/test/test_ops_gradients.py
+++ b/test/test_ops_gradients.py
@@ -11,7 +11,6 @@ from torch.testing._internal.common_device_type import (
 from torch.testing._internal.common_methods_invocations import op_db
 from torch.testing._internal.common_utils import (
     run_tests,
-    skipIfRocm,
     TestCase,
     TestGradients,
     unMarkDynamoStrictTest,
@@ -64,7 +63,6 @@ class TestBwdGradients(TestGradients):
                 device, dtype, op, self._get_safe_inplace(op.get_inplace())
             )
 
-    @skipIfRocm(msg="Fails with Triton 3.7")
     # Test that gradients of gradients are computed correctly
     @_gradcheck_ops(op_db + hop_db + custom_op_db)
     def test_fn_gradgrad(self, device, dtype, op):

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -22,7 +22,6 @@ from torch.testing._internal.common_utils import (
     TestCase, run_tests, skipIfNoSciPy, slowTest, torch_to_numpy_dtype_dict,
     parametrize,
     skipIfTorchDynamo,
-    skipIfRocm,
     IS_WINDOWS)
 from torch.testing._internal.common_device_type import (
     OpDTypes, expectedFailureMeta, instantiate_device_type_tests, onlyCPU, dtypes, dtypesIfCUDA, dtypesIfCPU,

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -2525,7 +2525,6 @@ class TestReductions(TestCase):
     @dtypes(torch.int, torch.long, torch.float, torch.double)
     @dtypesIfCUDA(torch.int, torch.long, torch.half, torch.float, torch.double)
     @dtypesIfXPU(torch.int, torch.long, torch.half, torch.float, torch.double)
-    @skipIfRocm(msg="Fails with Triton 3.7 on MI200")
     def test_median_real_values(self, device, dtype):
         # Generate random 0-3D sizes
         sizes = [random.sample(range(1, 32), i) for i in range(4) for _ in range(2)]
@@ -2556,7 +2555,6 @@ class TestReductions(TestCase):
     @dtypes(torch.float, torch.double)
     @dtypesIfCUDA(torch.half, torch.float, torch.double)
     @dtypesIfXPU(torch.half, torch.float, torch.double)
-    @skipIfRocm(msg="Fails with Triton 3.7 on MI200")
     def test_median_nan_values(self, device, dtype):
         # Generate random 0-3D sizes
         sizes = [random.sample(range(1, 32), i) for i in range(4) for _ in range(2)]
@@ -2595,7 +2593,6 @@ class TestReductions(TestCase):
                     ref = numpy_op(t_numpy, dim, keepdims=True)[mask.cpu().numpy()]
                     self.assertEqual(res, torch.from_numpy(ref))
 
-    @skipIfRocm(msg="Fails with Triton 3.7 on MI200")
     def test_median_corner_cases(self, device):
         def check(op, a, args, key):
             t = torch.tensor(a, device=device)

--- a/test/test_sort_and_select.py
+++ b/test/test_sort_and_select.py
@@ -1075,7 +1075,6 @@ class TestSortAndSelect(TestCase):
             )
             self._test_unique_scalar_empty(dtype, device, f)
 
-    @skipIfRocm(msg="Fails with Triton 3.7 on MI200")
     @dtypes(torch.double)
     def test_kthvalue(self, device, dtype):
         SIZE = 50

--- a/test/test_sort_and_select.py
+++ b/test/test_sort_and_select.py
@@ -27,7 +27,6 @@ from torch.testing._internal.common_dtype import (
 from torch.testing._internal.common_utils import (
     parametrize,
     run_tests,
-    skipIfRocm,
     skipIfTorchDynamo,
     slowTest,
     TestCase,

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -2399,7 +2399,6 @@ class TestImports(TestCase):
     @skipIfXpu(msg="The test is flaky on XPU, see https://github.com/pytorch/pytorch/issues/110040")
     # The test is flaky on ROCm/XPU and has been open and close multiple times
     # https://github.com/pytorch/pytorch/issues/110040
-    @skipIfRocm(msg="Fails with Triton 3.7")
     def test_circular_dependencies(self) -> None:
         """ Checks that all modules inside torch can be imported
         Prevents regression reported in https://github.com/pytorch/pytorch/issues/77441 """

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -22,7 +22,7 @@ from torch.testing import make_tensor
 from torch.testing._internal.common_utils import (
     IS_FBCODE, IS_JETSON, IS_MACOS, IS_SANDCASTLE, IS_WINDOWS, TestCase, run_tests, slowTest,
     parametrize, reparametrize, subtest, instantiate_parametrized_tests, dtype_name,
-    TEST_WITH_ROCM, decorateIf, skipIfXpu, skipIfRocm
+    TEST_WITH_ROCM, decorateIf, skipIfXpu
 )
 from torch.testing._internal.common_device_type import \
     (PYTORCH_TESTING_DEVICE_EXCEPT_FOR_KEY, PYTORCH_TESTING_DEVICE_ONLY_FOR_KEY, dtypes,


### PR DESCRIPTION
PR #174896 is now in upstream main, so the temporary ROCm skip decorators added for Triton 3.7 are no longer needed for these tests.

## Retained skip
- `test/inductor/test_torchinductor_opinfo.py::TestInductorOpInfo.test_comprehensive` remains skipped with `@skipIfRocm(msg="Fails with Triton 3.7 on MI200")`.
- Reason: Tested locally on MI300 system and took a long time to complete. Assumed it was hanging.

Made-with: Cursor

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @Lucaskabela
