### PR TITLE
TORCH_CHECK guards in quantized_group_norm_impl for weight or bias

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qnormalization.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qnormalization.cpp
@@ -80,6 +80,20 @@ static Tensor quantized_group_norm_impl(
 
   const int64_t batches = input_shape[0];
   const int64_t num_channels = input_shape[1];
+
+  if (weight.defined()) {
+    TORCH_CHECK(
+        weight.numel() == num_channels,
+        "quantized::group_norm: Expected weight to have ",
+        num_channels, " elements, but got ", weight.numel());
+  }
+  if (bias.defined()) {
+    TORCH_CHECK(
+        bias.numel() == num_channels,
+        "quantized::group_norm: Expected bias to have ",
+        num_channels, " elements, but got ", bias.numel());
+  }
+
   const int64_t elements_per_batch =
       c10::multiply_integers(input_shape.cbegin() + 1, input_shape.cend());
 

--- a/test/quantization/core/test_quantized_op.py
+++ b/test/quantization/core/test_quantized_op.py
@@ -2624,6 +2624,31 @@ class TestQuantizedOps(TestCase):
                 self.assertTrue(pct_diff_off_by_one < 0.01)
 
     @skipIfNoFBGEMM
+    def test_group_norm_wrong_bias_size(self):
+        # Regression test: bias with wrong size should raise a user-friendly error
+        # rather than an internal assert failure.
+        num_groups = 2
+        num_channels = 6
+        weight = torch.ones(num_channels)
+        bias_wrong = torch.ones(1)  # should be num_channels
+        X = torch.randn(2, num_channels, 4, 4)
+        qX = torch.quantize_per_tensor(X, scale=1.0, zero_point=0, dtype=torch.qint8)
+        with self.assertRaisesRegex(RuntimeError, "quantized::group_norm: Expected bias to have 6 elements"):
+            torch.ops.quantized.group_norm(qX, num_groups, weight, bias_wrong, 1e-5, 1.0, 0)
+
+    @skipIfNoFBGEMM
+    def test_group_norm_wrong_weight_size(self):
+        # Regression test: weight with wrong size should raise a user-friendly error.
+        num_groups = 2
+        num_channels = 6
+        weight_wrong = torch.ones(1)  # should be num_channels
+        bias = torch.ones(num_channels)
+        X = torch.randn(2, num_channels, 4, 4)
+        qX = torch.quantize_per_tensor(X, scale=1.0, zero_point=0, dtype=torch.qint8)
+        with self.assertRaisesRegex(RuntimeError, "quantized::group_norm: Expected weight to have 6 elements"):
+            torch.ops.quantized.group_norm(qX, num_groups, weight_wrong, bias, 1e-5, 1.0, 0)
+
+    @skipIfNoFBGEMM
     def test_instance_norm(self):
         max_sides = (4, 5)
         shape_list = ([2, 2, 2, 2], [8, 8, 8, 8], [11, 11, 11, 11])


### PR DESCRIPTION
user  encountered bug in PyTorch when using the API torch.ao.nn.quantized.GroupNorm. The crash is triggered by an internal C++ assertion failure when the bias parameter (referred to internally as beta) is initialized with a size that does not match the num_channels dimension. 

Fixed at cpp level such that both python and cpp is taken care.
Not adding in python wrapper.

Fixes [177825](https://github.com/pytorch/pytorch/issues/177825)

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01