### PR TITLE
[Distributed] Make Ckpt Tests Backend Agnostic

### DIFF
--- a/test/distributed/algorithms/ddp_comm_hooks/test_ddp_hooks.py
+++ b/test/distributed/algorithms/ddp_comm_hooks/test_ddp_hooks.py
@@ -36,15 +36,15 @@ device_type = (
 )
 
 
-def gpus_for_rank(world_size):
+def devices_for_rank(world_size):
     visible_devices = list(range(torch.accelerator.device_count()))
-    gpus_per_process = torch.accelerator.device_count() // world_size
-    gpus_for_rank = []
+    devices_per_process = torch.accelerator.device_count() // world_size
+    devices = []
     for rank in range(world_size):
-        gpus_for_rank.append(
-            visible_devices[rank * gpus_per_process : (rank + 1) * gpus_per_process]
+        devices.append(
+            visible_devices[rank * devices_per_process : (rank + 1) * devices_per_process]
         )
-    return gpus_for_rank
+    return devices
 
 
 class Task(nn.Module):
@@ -77,7 +77,7 @@ class DistributedDataParallelCommHookTest(DistributedTestBase):
         return local_model
 
     def _get_grads(self, process_group, hook_type=None):
-        device_id = gpus_for_rank(self.world_size)[self.rank][0]
+        device_id = devices_for_rank(self.world_size)[self.rank][0]
         gpu_model = DistributedDataParallel(
             TestDdpCommHook().to(device_id),
             device_ids=[device_id],
@@ -202,7 +202,7 @@ class DistributedDataParallelCommHookTest(DistributedTestBase):
             return fut
 
         flags = []
-        device_id = gpus_for_rank(self.world_size)[self.rank][0]
+        device_id = devices_for_rank(self.world_size)[self.rank][0]
         model = nn.Sequential(
             nn.Linear(2, 4000, bias=False),
             *[nn.Linear(4000, 4000, bias=False) for _ in range(10)],
@@ -217,7 +217,6 @@ class DistributedDataParallelCommHookTest(DistributedTestBase):
         gpu_model(input).sum().backward()
         self.assertTrue(flags[-1])
         self.assertFalse(any(flags[:-1]))
-
 
 if __name__ == "__main__":
     if torch.cuda._initialized:

--- a/test/distributed/checkpoint/_experimental/test_checkpoint_reader.py
+++ b/test/distributed/checkpoint/_experimental/test_checkpoint_reader.py
@@ -112,7 +112,7 @@ class TestCheckpointReader(TestCase):
     def test_read_with_map_location(self):
         """Test that read correctly uses the map_location parameter."""
         # Call read with map_location='cpu'
-        map_location = "cuda" if torch.cuda.is_available() else "cpu"
+        map_location = torch.accelerator.current_accelerator().type if torch.accelerator.is_available() else "cpu"
         read_state_dict, _ = self.reader.read(
             self.checkpoint_path, map_location=map_location
         )

--- a/test/distributed/checkpoint/_experimental/test_staging.py
+++ b/test/distributed/checkpoint/_experimental/test_staging.py
@@ -7,7 +7,7 @@ from torch.distributed.checkpoint._experimental.staging import (
     CheckpointStagerConfig,
     DefaultStager,
 )
-from torch.testing._internal.common_utils import requires_cuda, run_tests, TestCase
+from torch.testing._internal.common_utils import run_tests, TestCase, requires_accelerator
 
 
 class TestDefaultStager(TestCase):
@@ -23,7 +23,7 @@ class TestDefaultStager(TestCase):
             "nested": {"inner_tensor": torch.ones(2, 2), "inner_value": 42},
         }
 
-    @requires_cuda
+    @requires_accelerator
     def test_sync_staging(self) -> None:
         """Test synchronous staging."""
         options = CheckpointStagerConfig(use_async_staging=False)
@@ -46,7 +46,7 @@ class TestDefaultStager(TestCase):
         # Clean up
         stager.close()
 
-    @requires_cuda
+    @requires_accelerator
     def test_async_staging(self) -> None:
         """Test asynchronous staging."""
         options = CheckpointStagerConfig(use_async_staging=True)
@@ -70,10 +70,12 @@ class TestDefaultStager(TestCase):
         # Clean up
         stager.close()
 
-    def test_cuda_non_blocking_without_cuda(self) -> None:
-        """Test that non-blocking copy fails when CUDA is not available."""
-        if torch.cuda.is_available():
-            self.skipTest("CUDA is available, cannot test CUDA unavailable scenario")
+    def test_non_blocking_without_accelerator(self) -> None:
+        """Test that non-blocking copy fails when no accelerator is available."""
+        if torch.accelerator.is_available():
+            self.skipTest(
+                "Accelerator is available, cannot test unavailable scenario"
+            )
 
         options = CheckpointStagerConfig(use_non_blocking_copy=True)
         with self.assertRaises(AssertionError):
@@ -81,6 +83,8 @@ class TestDefaultStager(TestCase):
 
     def test_different_option_combinations(self) -> None:
         """Test various combinations of staging options."""
+        has_accelerator = torch.accelerator.is_available()
+
         test_cases = [
             # All disabled
             CheckpointStagerConfig(
@@ -105,23 +109,23 @@ class TestDefaultStager(TestCase):
             ),
         ]
 
-        if torch.cuda.is_available():
+        if has_accelerator:
             # Only async staging
             test_cases.append(
                 CheckpointStagerConfig(
-                    use_pinned_memory=torch.accelerator.is_available(),
+                    use_pinned_memory=True,
                     use_shared_memory=False,
                     use_async_staging=True,
                     use_non_blocking_copy=False,
                 )
             )
-            # Only CUDA non-blocking copy
+            # Only non-blocking copy
             test_cases.append(
                 CheckpointStagerConfig(
-                    use_pinned_memory=torch.accelerator.is_available(),
+                    use_pinned_memory=True,
                     use_shared_memory=False,
                     use_async_staging=False,
-                    use_non_blocking_copy=torch.accelerator.is_available(),
+                    use_non_blocking_copy=True,
                 )
             )
 
@@ -130,7 +134,7 @@ class TestDefaultStager(TestCase):
                 stager = DefaultStager(options)
 
                 # Test staging works with these options
-                if options.use_async_staging and torch.accelerator.is_available():
+                if options.use_async_staging and has_accelerator:
                     result = stager.stage(self.state_dict)
                     self.assertIsInstance(result, Future)
                     staged_dict = result.result()
@@ -142,34 +146,37 @@ class TestDefaultStager(TestCase):
 
                 stager.close()
 
-    @requires_cuda
-    def test_cuda_tensors_staging(self) -> None:
-        """Test staging with CUDA tensors."""
-        # Create state dict with CUDA tensors
-        cuda_state_dict = {
-            "cuda_tensor": torch.randn(3, 4).cuda(),
+    @requires_accelerator
+    def test_accelerator_tensors_staging(self) -> None:
+        """Test staging with accelerator tensors."""
+        device = torch.accelerator.current_accelerator()
+
+        # Create state dict with accelerator tensors
+        device_state_dict = {
+            "device_tensor": torch.randn(3, 4).to(device),
             "cpu_tensor": torch.randn(2, 3),
             "mixed_model": {
-                "weight": torch.randn(5, 5).cuda(),
-                "bias": torch.randn(5).cuda(),
+                "weight": torch.randn(5, 5).to(device),
+                "bias": torch.randn(5).to(device),
             },
         }
 
         options = CheckpointStagerConfig(use_async_staging=False)
         stager = DefaultStager(options)
 
-        staged_dict = stager.stage(cuda_state_dict)
+        # Stage the state dict
+        staged_dict = stager.stage(device_state_dict)
         if not isinstance(staged_dict, dict):
             raise AssertionError(f"Expected dict, got {type(staged_dict)}")
 
         # Verify tensors are staged (should be moved to CPU)
-        self.assertIn("cuda_tensor", staged_dict)
+        self.assertIn("device_tensor", staged_dict)
         self.assertIn("cpu_tensor", staged_dict)
         self.assertIn("mixed_model", staged_dict)
 
         stager.close()
 
-    @requires_cuda
+    @requires_accelerator
     def test_resource_cleanup(self) -> None:
         """Test that resources are properly cleaned up."""
         options = CheckpointStagerConfig(use_async_staging=False)
@@ -183,11 +190,12 @@ class TestDefaultStager(TestCase):
 
     def test_multiple_staging_operations(self) -> None:
         """Test multiple staging operations with the same stager."""
+        has_accelerator = torch.accelerator.is_available()
         options = CheckpointStagerConfig(
             use_async_staging=False,
-            use_pinned_memory=torch.accelerator.is_available(),
+            use_pinned_memory=has_accelerator,
             use_shared_memory=False,
-            use_non_blocking_copy=torch.accelerator.is_available(),
+            use_non_blocking_copy=has_accelerator,
         )
         stager = DefaultStager(options)
 

--- a/test/distributed/checkpoint/e2e/test_e2e_save_and_load.py
+++ b/test/distributed/checkpoint/e2e/test_e2e_save_and_load.py
@@ -512,7 +512,7 @@ class TestE2ESaveAndLoad(DTensorTestBase, VerifyStateDictMixin):
 class TestNoCPU(DTensorTestBase):
     @property
     def backend(self):
-        return "nccl"
+        return dist.get_default_backend_for_device(device_type)
 
     @with_comms
     def test_no_cpu(self):

--- a/test/distributed/checkpoint/test_file_system_checkpoint_cpu.py
+++ b/test/distributed/checkpoint/test_file_system_checkpoint_cpu.py
@@ -428,14 +428,18 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
             ],
         )
 
-        model_to_save = MyShardedModel3(src_spec).cuda(dist.get_rank())
+        device = torch.device(
+            f"{torch.accelerator.current_accelerator()}:{dist.get_rank()}"
+        )
+
+        model_to_save = MyShardedModel3(src_spec).to(device)
         model_to_save._register_state_dict_hook(state_dict_hook)
         state_dict_to_save = model_to_save.state_dict()
 
         fs_writer = FileSystemWriter(path=path, thread_count=thread_count)
         save_state_dict(state_dict=state_dict_to_save, storage_writer=fs_writer)
 
-        model_to_load = MyShardedModel3(dst_spec).cuda(dist.get_rank())
+        model_to_load = MyShardedModel3(dst_spec).to(device)
         model_to_load._register_state_dict_hook(state_dict_hook)
         state_dict_to_load_to = model_to_load.state_dict()
 

--- a/test/distributed/checkpoint/test_state_dict.py
+++ b/test/distributed/checkpoint/test_state_dict.py
@@ -1098,7 +1098,7 @@ class TestNoComm(MultiProcessTestCase):
             model, options=StateDictOptions(full_state_dict=True, cpu_offload=True)
         )
         for v in msd.values():
-            self.assertFalse(v.is_cuda)
+            self.assertEqual(v.device, torch.device("cpu"))
         self.assertEqual(model.state_dict(), msd)
         set_model_state_dict(model, model.state_dict())
         osd = get_optimizer_state_dict(

--- a/test/distributed/checkpoint/test_state_dict_stager.py
+++ b/test/distributed/checkpoint/test_state_dict_stager.py
@@ -923,7 +923,10 @@ class TestReplicationStager(DTensorTestBase):
 
     @property
     def backend(self) -> str:
-        return "cpu:gloo,cuda:nccl"
+        if device_type == "cpu":
+            return "cpu:gloo"
+        acc_backend = dist.get_default_backend_for_device(device_type)
+        return f"cpu:gloo,{device_type}:{acc_backend}"
 
     def _create_simple_state_dict(self, rank: int) -> dict:
         """

--- a/test/distributed/test_c10d_common.py
+++ b/test/distributed/test_c10d_common.py
@@ -66,21 +66,21 @@ torch.backends.cuda.matmul.allow_tf32 = False
 device_type = acc.type if (acc := torch.accelerator.current_accelerator()) else "cpu"
 
 
-def gpus_for_rank(world_size):
-    """Multigpu tests are designed to simulate the multi nodes with multi
-    GPUs on each node. Nccl backend requires equal #GPUs in each process.
-    On a single node, all visible GPUs are evenly
+def devices_for_rank(world_size):
+    """Tests are designed to simulate multi nodes with multi
+    devices on each node. The backend requires equal #devices in each process.
+    On a single node, all visible devices are evenly
     divided to subsets, each process only uses a subset.
     """
     device_count = torch.accelerator.device_count()
     visible_devices = list(range(device_count))
-    gpus_per_process = device_count // world_size
-    gpus_for_rank = []
+    devices_per_process = device_count // world_size
+    devices = []
     for rank in range(world_size):
-        gpus_for_rank.append(
-            visible_devices[rank * gpus_per_process : (rank + 1) * gpus_per_process]
+        devices.append(
+            visible_devices[rank * devices_per_process : (rank + 1) * devices_per_process]
         )
-    return gpus_for_rank
+    return devices
 
 
 class AbstractTimeoutTest:
@@ -363,7 +363,7 @@ class CommonDistributedDataParallelTest:
         gradient_as_bucket_view=False,
     ):
         model = Net()
-        device = devices[0] if devices else torch.device(f"cuda:{self.rank:d}")
+        device = devices[0] if devices else torch.device(f"{device_type}:{self.rank:d}")
         ddp_model = DistributedDataParallel(
             copy.deepcopy(model).to(device),
             device_ids=device_ids,
@@ -852,7 +852,7 @@ class CommonDistributedDataParallelTest:
     def _gpu_model_with_ddp_comm_hook(
         self, process_group, hook=None, gradient_as_bucket_view=False, state=None
     ):
-        device_id = gpus_for_rank(self.world_size)[self.rank][0]
+        device_id = devices_for_rank(self.world_size)[self.rank][0]
         gpu_model = DistributedDataParallel(
             ModuleForDdpCommHook().to(device_id),
             device_ids=[device_id],
@@ -869,7 +869,7 @@ class CommonDistributedDataParallelTest:
     def _gpu_model_with_builtin_ddp_comm_hook(
         self, process_group, hook=None, gradient_as_bucket_view=False
     ):
-        device_id = gpus_for_rank(self.world_size)[self.rank][0]
+        device_id = devices_for_rank(self.world_size)[self.rank][0]
         gpu_model = DistributedDataParallel(
             ModuleForDdpCommHook().to(device_id),
             device_ids=[device_id],

--- a/test/distributed/test_c10d_gloo.py
+++ b/test/distributed/test_c10d_gloo.py
@@ -26,7 +26,7 @@ if not c10d.is_available() or not c10d.is_gloo_available():
 import test_c10d_common
 from test_c10d_common import (
     FFTModel,
-    gpus_for_rank,
+    devices_for_rank,
     LOOPBACK,
     ModuleForDdpCommHook,
     SparseGradientModule,
@@ -1834,28 +1834,28 @@ class DistributedDataParallelTest(
     @requires_gloo()
     @skip_if_lt_x_gpu(2)
     def test_gloo_backend_1gpu_module_device_ids_integer_list(self):
-        int_devices = gpus_for_rank(self.world_size)[self.rank][:1]
+        int_devices = devices_for_rank(self.world_size)[self.rank][:1]
         devices = [torch.device("cuda:" + str(i)) for i in int_devices]
         self._test_gloo_backend(devices, int_devices)
 
     @requires_gloo()
     @skip_if_lt_x_gpu(2)
     def test_gloo_backend_1gpu_module_device_ids_torch_device_list(self):
-        int_devices = gpus_for_rank(self.world_size)[self.rank][:1]
+        int_devices = devices_for_rank(self.world_size)[self.rank][:1]
         devices = [torch.device("cuda:" + str(i)) for i in int_devices]
         self._test_gloo_backend(devices, devices)
 
     @requires_gloo()
     @skip_if_lt_x_gpu(4)
     def test_gloo_backend_2gpu_module(self):
-        int_devices = gpus_for_rank(self.world_size)[self.rank][:2]
+        int_devices = devices_for_rank(self.world_size)[self.rank][:2]
         devices = [torch.device("cuda:" + str(i)) for i in int_devices]
         self._test_gloo_backend(devices, None, multi_device=True)
 
     @requires_gloo()
     @skip_if_lt_x_gpu(8)
     def test_gloo_backend_4gpu_module(self):
-        int_devices = gpus_for_rank(self.world_size)[self.rank][:4]
+        int_devices = devices_for_rank(self.world_size)[self.rank][:4]
         devices = [torch.device("cuda:" + str(i)) for i in int_devices]
         self._test_gloo_backend(devices, None, multi_device=True)
 
@@ -1913,7 +1913,7 @@ class DistributedDataParallelTest(
         run_and_verify_grad(cpu_model)
 
         # Test on GPU
-        device_id = gpus_for_rank(self.world_size)[self.rank][0]
+        device_id = devices_for_rank(self.world_size)[self.rank][0]
         gpu_model = DistributedDataParallel(
             GlobalLocalUnusedParamModule().to(device_id),
             device_ids=[device_id],
@@ -1986,7 +1986,7 @@ class DistributedDataParallelTest(
         run_and_verify_grad(cpu_model)
 
         # Test on GPU
-        device_id = gpus_for_rank(self.world_size)[self.rank][0]
+        device_id = devices_for_rank(self.world_size)[self.rank][0]
         gpu_model = DistributedDataParallel(
             FindUnusedParamModule().to(device_id),
             device_ids=[device_id],
@@ -2174,7 +2174,7 @@ class DistributedDataParallelTest(
                 loss.backward()
                 optimizer.step()
 
-        device_id = gpus_for_rank(self.world_size)[self.rank][0]
+        device_id = devices_for_rank(self.world_size)[self.rank][0]
 
         model_withload = TestModel().float().to(device_id)
         model_withoutload = TestModel().float().to(device_id)
@@ -2356,7 +2356,7 @@ class DistributedDataParallelTest(
     def _gpu_model_with_ddp_comm_hook(
         self, process_group, hook=None, gradient_as_bucket_view=False, state=None
     ):
-        device_id = gpus_for_rank(self.world_size)[self.rank][0]
+        device_id = devices_for_rank(self.world_size)[self.rank][0]
         gpu_model = DistributedDataParallel(
             ModuleForDdpCommHook().to(device_id),
             device_ids=[device_id],

--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -24,18 +24,23 @@ import torch.distributed as c10d
 import torch.distributed._functional_collectives as _functional_collectives
 from torch.distributed.distributed_c10d import SHRINK_ABORT as NCCL_SHRINK_ABORT
 
-
-if not c10d.is_available() or not c10d.is_nccl_available():
-    print("c10d NCCL not available, skipping tests", file=sys.stderr)
+if not c10d.is_available():
+    print("c10d not available, skipping tests", file=sys.stderr)
     sys.exit(0)
 
+if torch.accelerator.current_accelerator() is None:
+    print("No accelerator available, skipping tests", file=sys.stderr)
+    sys.exit(0)
+
+DEVICE_TYPE = torch.accelerator.current_accelerator().type
+BACKEND = c10d.get_default_backend_for_device(DEVICE_TYPE)
 
 import test_c10d_common
 from test_c10d_common import (
     ConvNet,
     DoubleGpuNet,
     FFTModel,
-    gpus_for_rank,
+    devices_for_rank,
     ModuleForDdpCommHook,
 )
 
@@ -53,6 +58,7 @@ from torch.testing._internal.common_distributed import (
     get_timeout,
     init_multigpu_helper,
     MultiProcessTestCase,
+    requires_accelerator_dist_backend,
     requires_multicast_support,
     requires_nccl,
     requires_nccl_shrink,
@@ -87,9 +93,11 @@ if TEST_WITH_DEV_DBG_ASAN:
     )
     sys.exit(0)
 
-BFLOAT16_AVAILABLE = torch.cuda.is_available() and (
-    torch.version.cuda is not None or torch.version.hip is not None
-)
+BFLOAT16_AVAILABLE = False
+if (acc := torch.accelerator.current_accelerator()):
+    device_module = getattr(torch, acc.type, None)
+    if device_module and hasattr(device_module, 'is_bf16_supported'):
+        BFLOAT16_AVAILABLE = device_module.is_bf16_supported()
 
 CUDA_12_AND_ABOVE = torch.cuda.is_available() and (
     torch.version.cuda is not None and int(torch.version.cuda.split(".")[0]) >= 12
@@ -1059,7 +1067,7 @@ class ProcessGroupNCCLGroupTest(MultiProcessTestCase):
     @requires_nccl_version((2, 18), "Need NCCL 2.18+ for ncclCommSplit")
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
     @skip_but_pass_in_sandcastle_if(
-        torch.cuda.nccl.version()[-1] == "x", "NCCL test not for NCCLX"
+        DEVICE_TYPE == "cuda" and torch.cuda.nccl.version()[-1] == "x", "NCCL test not for NCCLX"
     )
     def test_comm_split_subgroup(self):
         # Test `ncclCommSplit` for smaller subgroups of the world when
@@ -2046,17 +2054,18 @@ class DistributedDataParallelTest(
         super().setUp()
         # TORCH_NCCL_BLOCKING_WAIT overrides TORCH_NCCL_ASYNC_ERROR_HANDLING hence tests
         # that use TORCH_NCCL_BLOCKING_WAIT will test it as expected.
-        os.environ["TORCH_NCCL_ASYNC_ERROR_HANDLING"] = "1"
+        if DEVICE_TYPE == "cuda" and c10d.is_nccl_available():
+            os.environ["TORCH_NCCL_ASYNC_ERROR_HANDLING"] = "1"
         self._spawn_processes()
 
     def _get_process_group(self):
         store = self._get_store()
         c10d.init_process_group(
-            "nccl", store=store, rank=self.rank, world_size=self.world_size
+            BACKEND, store=store, rank=self.rank, world_size=self.world_size
         )
         return c10d.distributed_c10d._get_default_group()
 
-    def _test_nccl_backend(
+    def _test_backend(
         self, devices, device_ids, multi_device=False, gradient_as_bucket_view=False
     ):
         process_group = self._get_process_group()
@@ -2064,13 +2073,13 @@ class DistributedDataParallelTest(
             process_group, devices, device_ids, multi_device, gradient_as_bucket_view
         )
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
     def test_ddp_complex_params_and_grads(self):
         # test ddp with complex parameters and gradients
         process_group = self._get_process_group()
-        device_id = gpus_for_rank(self.world_size)[self.rank][0]
-        device = torch.device(f"cuda:{device_id}")
+        device_id = devices_for_rank(self.world_size)[self.rank][0]
+        device = torch.device(f"{DEVICE_TYPE}:{device_id}")
 
         torch.manual_seed(42 + self.rank)
         model = nn.Sequential(
@@ -2181,13 +2190,13 @@ class DistributedDataParallelTest(
                 "Final model parameters don't match after training",
             )
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
     def test_ddp_mixed_real_and_complex_params(self):
         # test ddp with mixed real and complex parameters and gradients
         process_group = self._get_process_group()
-        device_id = gpus_for_rank(self.world_size)[self.rank][0]
-        device = torch.device(f"cuda:{device_id}")
+        device_id = devices_for_rank(self.world_size)[self.rank][0]
+        device = torch.device(f"{DEVICE_TYPE}:{device_id}")
 
         class MixedModule(nn.Module):
             def __init__(self):
@@ -2314,7 +2323,7 @@ class DistributedDataParallelTest(
 
             # Now when nonzero rank attempts to use communicator, original failure reason should be logged.
             try:
-                pg.allreduce([torch.ones(2).cuda(self.rank)]).wait()
+                pg.allreduce([torch.ones(2).to(f"{DEVICE_TYPE}:{self.rank}")]).wait()
             except dist.DistBackendError as e:
                 self.assertTrue("aborted" in str(e))
             else:
@@ -2329,75 +2338,75 @@ class DistributedDataParallelTest(
         # the watchdog has run on the rank, and there is no reliable way
         # to confirm it has run.
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
-    def test_nccl_backend_multi_device_ids_not_allowed(self):
-        int_devices = list(range(torch.cuda.device_count()))
-        devices = [torch.device("cuda:" + str(i)) for i in int_devices]
+    def test_backend_multi_device_ids_not_allowed(self):
+        int_devices = list(range(torch.accelerator.device_count()))
+        devices = [torch.device(f"{DEVICE_TYPE}:" + str(i)) for i in int_devices]
         with self.assertRaisesRegex(
             ValueError, "device_ids can only be None or contain a single element."
         ):
-            self._test_nccl_backend(devices, int_devices)
+            self._test_backend(devices, int_devices)
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
-    def test_nccl_backend_single_device_module_device_ids_None(self):
-        self._test_nccl_backend(None, None)
+    def test_backend_single_device_module_device_ids_None(self):
+        self._test_backend(None, None)
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
-    def test_nccl_backend_single_device_module_empty_device_ids(self):
+    def test_backend_single_device_module_empty_device_ids(self):
         # This tests the backward compatibility of accepting an empty list as `device_ids`,
         # although we no longer document this in favor of the default value of `None`,
         # which is consistent with multi-device modules and CPU modules.
-        self._test_nccl_backend(None, [])
+        self._test_backend(None, [])
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(4)
-    def test_nccl_backend_multi_device_module_device_ids_None(self):
-        int_devices = gpus_for_rank(self.world_size)[self.rank][:2]
-        devices = [torch.device("cuda:" + str(i)) for i in int_devices]
-        self._test_nccl_backend(devices, None, multi_device=True)
+    def test_backend_multi_device_module_device_ids_None(self):
+        int_devices = devices_for_rank(self.world_size)[self.rank][:2]
+        devices = [torch.device(f"{DEVICE_TYPE}:" + str(i)) for i in int_devices]
+        self._test_backend(devices, None, multi_device=True)
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
-    def test_nccl_backend_1gpu_module_device_ids_integer_list(self):
-        int_devices = gpus_for_rank(self.world_size)[self.rank][:1]
-        devices = [torch.device("cuda:" + str(i)) for i in int_devices]
-        self._test_nccl_backend(devices, int_devices)
+    def test_backend_1gpu_module_device_ids_integer_list(self):
+        int_devices = devices_for_rank(self.world_size)[self.rank][:1]
+        devices = [torch.device(f"{DEVICE_TYPE}:" + str(i)) for i in int_devices]
+        self._test_backend(devices, int_devices)
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
-    def test_nccl_backend_1gpu_module_device_ids_torch_device_list(self):
-        int_devices = gpus_for_rank(self.world_size)[self.rank][:1]
-        devices = [torch.device("cuda:" + str(i)) for i in int_devices]
-        self._test_nccl_backend(devices, devices)
+    def test_backend_1gpu_module_device_ids_torch_device_list(self):
+        int_devices = devices_for_rank(self.world_size)[self.rank][:1]
+        devices = [torch.device(f"{DEVICE_TYPE}:" + str(i)) for i in int_devices]
+        self._test_backend(devices, devices)
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(4)
-    def test_nccl_backend_2gpu_module(self):
-        int_devices = gpus_for_rank(self.world_size)[self.rank][:2]
-        devices = [torch.device("cuda:" + str(i)) for i in int_devices]
-        self._test_nccl_backend(devices, None, multi_device=True)
+    def test_backend_2gpu_module(self):
+        int_devices = devices_for_rank(self.world_size)[self.rank][:2]
+        devices = [torch.device(f"{DEVICE_TYPE}:" + str(i)) for i in int_devices]
+        self._test_backend(devices, None, multi_device=True)
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(8)
-    def test_nccl_backend_4gpu_module(self):
-        int_devices = gpus_for_rank(self.world_size)[self.rank][:4]
-        devices = [torch.device("cuda:" + str(i)) for i in int_devices]
-        self._test_nccl_backend(devices, None, multi_device=True)
+    def test_backend_4gpu_module(self):
+        int_devices = devices_for_rank(self.world_size)[self.rank][:4]
+        devices = [torch.device(f"{DEVICE_TYPE}:" + str(i)) for i in int_devices]
+        self._test_backend(devices, None, multi_device=True)
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(4)
     def test_ddp_multi_device_module_config(self):
-        gpus = gpus_for_rank(self.world_size)[self.rank]
+        device_ids = devices_for_rank(self.world_size)[self.rank]
 
-        self.assertTrue(len(gpus) >= 2, "expecting at least 2 gpus per process")
+        self.assertTrue(len(device_ids) >= 2, "expecting at least 2 devices per process")
 
         process_group = self._get_process_group()
 
-        gpus = gpus[:2]
-        model = DoubleGpuNet(gpus)
+        device_ids = device_ids[:2]
+        model = DoubleGpuNet(device_ids)
 
         with self.assertRaisesRegex(
             ValueError,
@@ -2405,7 +2414,7 @@ class DistributedDataParallelTest(
             "single-device/multiple-device GPU modules or CPU modules",
         ):
             DistributedDataParallel(
-                model, output_device=gpus[1], process_group=process_group
+                model, output_device=device_ids[1], process_group=process_group
             )
 
         with self.assertRaisesRegex(
@@ -2428,12 +2437,13 @@ class DistributedDataParallelTest(
     def _test_fp16(self, gradient_as_bucket_view=False):
         process_group = self._get_process_group()
 
-        gpus = gpus_for_rank(self.world_size)[self.rank]
-        model = nn.Linear(1, 1, bias=False).cuda(gpus[0]).half()
+        dev_ids = devices_for_rank(self.world_size)[self.rank]
+        device = torch.device(DEVICE_TYPE, dev_ids[0])
+        model = nn.Linear(1, 1, bias=False).to(device).half()
         nn.init.constant_(model.weight, 1)
         ddp_model = DistributedDataParallel(
             model,
-            device_ids=[gpus[0]],
+            device_ids=[dev_ids[0]],
             process_group=process_group,
             bucket_cap_mb=0.001,
             gradient_as_bucket_view=gradient_as_bucket_view,
@@ -2442,7 +2452,7 @@ class DistributedDataParallelTest(
         # Input 2**15, so that the gradients will overflow with a
         # world_size of 2, unless we normalize the gradient by the
         # world_size before the reduction
-        input = torch.tensor([[2**15]]).cuda(gpus[0]).half()
+        input = torch.tensor([[2**15]]).to(device).half()
 
         # Step model
         ddp_model.train()
@@ -2452,12 +2462,12 @@ class DistributedDataParallelTest(
 
         self.assertFalse(any(torch.isinf(p.grad).any() for p in ddp_model.parameters()))
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
     def test_fp16(self):
         self._test_fp16()
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
     def test_fp16_grad_is_view(self):
         self._test_fp16(gradient_as_bucket_view=True)
@@ -2492,7 +2502,7 @@ class DistributedDataParallelTest(
                     F.softmax(self.fc3(x), dim=1),
                 )
 
-        device_id = gpus_for_rank(self.world_size)[self.rank][0]
+        device_id = devices_for_rank(self.world_size)[self.rank][0]
         model = DistributedDataParallel(
             ForwardReturnValueModule().float().to(device_id),
             device_ids=[device_id],
@@ -2552,17 +2562,17 @@ class DistributedDataParallelTest(
             unbox=lambda obj: obj["list"][3],
         )
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
     def test_arbitrary_forward_return_value(self):
         self._test_arbitrary_forward_return_value()
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
     def test_arbitrary_forward_return_value_grad_is_view(self):
         self._test_arbitrary_forward_return_value(gradient_as_bucket_view=True)
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
     def test_ddp_with_lazy_parameters(self):
         process_group = self._get_process_group()
@@ -2578,9 +2588,9 @@ class DistributedDataParallelTest(
         Note: this test can be sped up by only running it on a CPU module
         once DistributedDataParallel supports them.
         """
-        torch.cuda.set_device(self.rank)
+        torch.accelerator.set_device_index(self.rank)
         dist.init_process_group(
-            backend="nccl",
+            backend=BACKEND,
             world_size=self.world_size,
             rank=self.rank,
             init_method=f"file://{self.file_name}",
@@ -2603,7 +2613,7 @@ class DistributedDataParallelTest(
                 # we can use it to trigger a reducer error.
                 return (F.softmax(x, dim=1), self.fc3)
 
-        device_id = gpus_for_rank(self.world_size)[self.rank][0]
+        device_id = devices_for_rank(self.world_size)[self.rank][0]
         batch_size = 4
         criterion = nn.CrossEntropyLoss()
         input = torch.rand([batch_size, 2], dtype=torch.float)
@@ -2690,37 +2700,37 @@ class DistributedDataParallelTest(
 
     # TODO: Combine the following tests once https://github.com/pytorch/pytorch/issues/55967
     # is resolved.
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
     @with_dist_debug_levels(levels=["DETAIL"])
     def test_find_unused_parameters_kwarg_debug_detail(self):
         self._test_find_unused_parameters_kwarg()
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
     @with_dist_debug_levels(levels=["INFO"])
     def test_find_unused_parameters_kwarg_debug_info(self):
         self._test_find_unused_parameters_kwarg()
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
     @with_dist_debug_levels(levels=["OFF"])
     def test_find_unused_parameters_kwarg_debug_off(self):
         self._test_find_unused_parameters_kwarg()
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
     @with_dist_debug_levels(levels=["DETAIL"])
     def test_find_unused_parameters_kwarg_grad_is_view_debug_detail(self):
         self._test_find_unused_parameters_kwarg(gradient_as_bucket_view=True)
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
     @with_dist_debug_levels(levels=["INFO"])
     def test_find_unused_parameters_kwarg_grad_is_view_debug_info(self):
         self._test_find_unused_parameters_kwarg(gradient_as_bucket_view=True)
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
     @with_dist_debug_levels(levels=["OFF"])
     def test_find_unused_parameters_kwarg_grad_is_view_debug_off(self):
@@ -2754,7 +2764,7 @@ class DistributedDataParallelTest(
                     F.softmax(self.module1(x), dim=1),
                 )
 
-        device_id = gpus_for_rank(self.world_size)[self.rank][0]
+        device_id = devices_for_rank(self.world_size)[self.rank][0]
         model = DistributedDataParallel(
             MultipleOutputModule().float().to(device_id),
             device_ids=[device_id],
@@ -2776,17 +2786,17 @@ class DistributedDataParallelTest(
         loss2 = criterion(output2, target)
         loss2.backward()
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
     def test_multiple_outputs_multiple_backward(self):
         self._test_multiple_outputs_multiple_backward()
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
     def test_multiple_outputs_multiple_backward_grad_is_view(self):
         self._test_multiple_outputs_multiple_backward(gradient_as_bucket_view=True)
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
     def test_no_grad(self):
         """
@@ -2807,7 +2817,7 @@ class DistributedDataParallelTest(
                 x = self.relu(self.fc2(x))
                 return F.softmax(x, dim=1)
 
-        device_id = gpus_for_rank(self.world_size)[self.rank][0]
+        device_id = devices_for_rank(self.world_size)[self.rank][0]
         model = DistributedDataParallel(
             NoGradModule().float().to(device_id),
             device_ids=[device_id],
@@ -2837,8 +2847,8 @@ class DistributedDataParallelTest(
         # This is NOT the recommended way to implement accumulating grads, but
         # we would like to make sure DDP does not mess up with the underlying
         # module.
-        int_devices = gpus_for_rank(self.world_size)[self.rank][:1]
-        devices = [torch.device("cuda:" + str(i)) for i in int_devices]
+        int_devices = devices_for_rank(self.world_size)[self.rank][:1]
+        devices = [torch.device(f"{DEVICE_TYPE}:" + str(i)) for i in int_devices]
         process_group = self._get_process_group()
         global_batch_size = self.world_size
 
@@ -2885,17 +2895,17 @@ class DistributedDataParallelTest(
             torch.manual_seed(1337 + iteration)
             input = input[torch.randperm(global_batch_size)]
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
     def test_accumulate_gradients_module(self):
         self._test_accumulate_gradients_module()
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
     def test_accumulate_gradients_module_with_grad_is_view(self):
         self._test_accumulate_gradients_module(gradient_as_bucket_view=True)
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
     def test_failure_recovery(self):
         process_group = self._get_process_group()
@@ -2922,7 +2932,7 @@ class DistributedDataParallelTest(
                 x = self.relu(self.fc2(x))
                 return F.softmax(x, dim=1)
 
-        device_id = gpus_for_rank(self.world_size)[self.rank][0]
+        device_id = devices_for_rank(self.world_size)[self.rank][0]
         model = TestModel().float().to(device_id)
         ddp = DistributedDataParallel(
             model,
@@ -2947,7 +2957,7 @@ class DistributedDataParallelTest(
 
         store = c10d.FileStore(recovery_filename, self.world_size)
         c10d.init_process_group(
-            "nccl", store=store, rank=self.rank, world_size=self.world_size
+            BACKEND, store=store, rank=self.rank, world_size=self.world_size
         )
         process_group = c10d.distributed_c10d._get_default_group()
         ddp = DistributedDataParallel(
@@ -2965,11 +2975,11 @@ class DistributedDataParallelTest(
             loss = criterion(output, target)
             loss.backward()
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
     def test_pass_default_pg(self):
         dist.init_process_group(
-            "nccl",
+            BACKEND,
             init_method=f"file://{self.file_name}",
             world_size=self.world_size,
             rank=self.rank,
@@ -3101,10 +3111,10 @@ class DistributedDataParallelTest(
                             )
                             raise
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
     def test_grad_layout_1devicemodule_1replicaperprocess(self):
-        dev0 = torch.device("cuda:" + str(gpus_for_rank(self.world_size)[self.rank][0]))
+        dev0 = torch.device(f"{DEVICE_TYPE}:" + str(devices_for_rank(self.world_size)[self.rank][0]))
         # Tells DDP to use just one device.
         replica_devices = [dev0]
         # Tells _test_grad_layout to construct ConvNet with all layers on this process's first assigned device.
@@ -3112,12 +3122,12 @@ class DistributedDataParallelTest(
         local_batch_size = 16
         self._test_grad_layout(replica_devices, layer_devs, local_batch_size)
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(4)
     def test_grad_layout_2devicemodule(self):
-        int_devices = gpus_for_rank(self.world_size)[self.rank][:2]
-        dev0 = torch.device("cuda:" + str(int_devices[0]))
-        dev1 = torch.device("cuda:" + str(int_devices[1]))
+        int_devices = devices_for_rank(self.world_size)[self.rank][:2]
+        dev0 = torch.device(f"{DEVICE_TYPE}:" + str(int_devices[0]))
+        dev1 = torch.device(f"{DEVICE_TYPE}:" + str(int_devices[1]))
         # DDP's default behavior for a multi-device module is "don't replicate."
         replica_devices = None
         # Tells _test_grad_layout to constructs this process's ConvNet on 2 devices, with 2 layers on each device.
@@ -3125,12 +3135,12 @@ class DistributedDataParallelTest(
         local_batch_size = 16
         self._test_grad_layout(replica_devices, layer_devs, local_batch_size)
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
     def test_param_layout_mismatch_error(self):
         process_group = self._get_process_group()
 
-        dev0 = torch.device("cuda:" + str(gpus_for_rank(self.world_size)[self.rank][0]))
+        dev0 = torch.device(f"{DEVICE_TYPE}:" + str(devices_for_rank(self.world_size)[self.rank][0]))
         layer_devs = dev0
         layer_formats = (
             [torch.contiguous_format] * 4
@@ -3159,7 +3169,7 @@ class DistributedDataParallelTest(
         state=None,
         static_graph=False,
     ):
-        device_id = gpus_for_rank(self.world_size)[self.rank][0]
+        device_id = devices_for_rank(self.world_size)[self.rank][0]
         gpu_model = DistributedDataParallel(
             ModuleForDdpCommHook().to(device_id),
             device_ids=[device_id],
@@ -3174,11 +3184,11 @@ class DistributedDataParallelTest(
 
         return gpu_model
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
-    def test_ddp_comm_hook_future_passing_gpu_nccl(self):
+    def test_ddp_comm_hook_future_passing(self):
         """
-        This unit test verifies whether the Future object is passed properly using nccl backend.
+        This unit test verifies whether the Future object is passed properly using accelerator backend.
         The hook callback function creates a Future object and sets a value to it.
         """
         process_group = self._get_process_group()
@@ -3190,7 +3200,7 @@ class DistributedDataParallelTest(
         # without the comm_hook, result would be 0.25 * torch.ones(2, 2).
         self._run_and_verify_hook(gpu_model, 8, 2 * torch.ones(2, 2))
 
-    def _test_ddp_comm_hook_allreduce_hook_nccl(
+    def _test_ddp_comm_hook_allreduce_hook(
         self, gradient_as_bucket_view=False, static_graph=False
     ):
         """
@@ -3219,7 +3229,7 @@ class DistributedDataParallelTest(
         # check whether the grads are equal to what DDP without hook would return.
         self._run_and_verify_hook(gpu_model, 8, 0.25 * torch.ones(2, 2))
 
-    def _test_default_ddp_comm_hooks_nccl(self, gradient_as_bucket_view=False):
+    def _test_default_ddp_comm_hooks(self, gradient_as_bucket_view=False):
         """
         This unit test verifies whether default Python DDP communication hooks ALLREDUCE, FP16_COMPRESS
         and BF16_COMPRESS, can give the same result with the case of no hook registered.
@@ -3233,6 +3243,7 @@ class DistributedDataParallelTest(
             not TEST_WITH_ROCM
             and BFLOAT16_AVAILABLE
             and c10d.is_nccl_available()
+            and DEVICE_TYPE == "cuda"
             and torch.cuda.nccl.version() >= (2, 10)
         ):
             hook_options.append(default.bf16_compress_hook)
@@ -3295,7 +3306,7 @@ class DistributedDataParallelTest(
             # check whether the grads are equal to what DDP without hook would return.
             self._run_and_verify_hook(gpu_model, 8, 0.25 * torch.ones(2, 2))
 
-    def _test_powerSGD_ddp_comm_hook_nccl(self, gradient_as_bucket_view=False):
+    def _test_powerSGD_ddp_comm_hook(self, gradient_as_bucket_view=False):
         """
         This unit test verifies whether Python DDP communication hook POWER_SGD
         can give the same result with the case of no hook registered.
@@ -3324,7 +3335,7 @@ class DistributedDataParallelTest(
                 # check whether the grads are equal to what DDP without hook would return.
                 self._run_and_verify_hook(gpu_model, 8, 0.25 * torch.ones(2, 2))
 
-    def _test_builtin_ddp_comm_hooks_nccl(self, gradient_as_bucket_view=False):
+    def _test_builtin_ddp_comm_hooks(self, gradient_as_bucket_view=False):
         """
         This unit test verifies whether built-in C++ DDP communication hooks ALLREDUCE and FP16_COMPRESS
         can give the same result with the case of no hook registered.
@@ -3343,62 +3354,62 @@ class DistributedDataParallelTest(
             # check whether the grads are equal to what DDP without hook would return.
             self._run_and_verify_hook(gpu_model, 8, 0.25 * torch.ones(2, 2))
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
-    def test_ddp_comm_hook_allreduce_hook_nccl(self):
-        self._test_ddp_comm_hook_allreduce_hook_nccl()
+    def test_ddp_comm_hook_allreduce_with_future(self):
+        self._test_ddp_comm_hook_allreduce_hook()
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
-    def test_default_ddp_comm_hooks_nccl(self):
-        self._test_default_ddp_comm_hooks_nccl()
+    def test_default_ddp_comm_hooks(self):
+        self._test_default_ddp_comm_hooks()
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
-    def test_fp16_compress_wrapper_nccl(self):
+    def test_fp16_compress_hook_wrapper(self):
         self._test_fp16_compress_wrapper()
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @requires_nccl_version((2, 10), "Need NCCL 2.10+ for BF16_COMPRESS")
     @skip_but_pass_in_sandcastle_if(
         not BFLOAT16_AVAILABLE,
         "BFloat16 is only supported by CUDA 11+",
     )
     @skip_if_lt_x_gpu(2)
-    def test_bf16_compress_wrapper_nccl(self):
+    def test_bf16_compress_hook_wrapper(self):
         self._test_bf16_compress_wrapper()
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
-    def test_builtin_ddp_comm_hooks_nccl(self):
-        self._test_builtin_ddp_comm_hooks_nccl()
+    def test_builtin_ddp_comm_hooks(self):
+        self._test_builtin_ddp_comm_hooks()
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
-    def test_powerSGD_ddp_comm_hook_nccl(self):
-        self._test_powerSGD_ddp_comm_hook_nccl()
+    def test_powerSGD_ddp_comm_hook(self):
+        self._test_powerSGD_ddp_comm_hook()
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
-    def test_ddp_comm_hook_allreduce_hook_nccl_grad_is_view(self):
-        self._test_ddp_comm_hook_allreduce_hook_nccl(gradient_as_bucket_view=True)
+    def test_ddp_comm_hook_allreduce_with_future_grad_is_view(self):
+        self._test_ddp_comm_hook_allreduce_hook(gradient_as_bucket_view=True)
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
-    def test_ddp_comm_hook_allreduce_hook_nccl_static_graph(self):
-        self._test_ddp_comm_hook_allreduce_hook_nccl(static_graph=True)
+    def test_ddp_comm_hook_allreduce_with_future_static_graph(self):
+        self._test_ddp_comm_hook_allreduce_hook(static_graph=True)
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
-    def test_default_ddp_comm_hooks_nccl_is_view(self):
-        self._test_default_ddp_comm_hooks_nccl(gradient_as_bucket_view=True)
+    def test_default_ddp_comm_hooks_is_view(self):
+        self._test_default_ddp_comm_hooks(gradient_as_bucket_view=True)
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
     def test_fp16_compress_wrapper_is_view(self):
         self._test_fp16_compress_wrapper(gradient_as_bucket_view=True)
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @requires_nccl_version((2, 10), "Need NCCL 2.10+ for BF16_COMPRESS")
     @skip_but_pass_in_sandcastle_if(
         not BFLOAT16_AVAILABLE,
@@ -3408,19 +3419,19 @@ class DistributedDataParallelTest(
     def test_bf16_compress_wrapper_is_view(self):
         self._test_bf16_compress_wrapper(gradient_as_bucket_view=True)
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
-    def test_builtin_ddp_comm_hooks_nccl_grad_is_view(self):
-        self._test_builtin_ddp_comm_hooks_nccl(gradient_as_bucket_view=True)
+    def test_builtin_ddp_comm_hooks_grad_is_view(self):
+        self._test_builtin_ddp_comm_hooks(gradient_as_bucket_view=True)
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
-    def test_powerSGD_ddp_comm_hook_nccl_grad_is_view(self):
-        self._test_powerSGD_ddp_comm_hook_nccl(gradient_as_bucket_view=True)
+    def test_powerSGD_ddp_comm_hook_grad_is_view(self):
+        self._test_powerSGD_ddp_comm_hook(gradient_as_bucket_view=True)
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
-    def test_ddp_comm_hook_allreduce_with_then_hook_nccl(self):
+    def test_comm_hook_allreduce_with_then(self):
         """
         This unit test verifies whether a DDP communication hook that calls allreduce and then
         multiplies the result by ten and divides by two gives the expected result.
@@ -3461,7 +3472,7 @@ class DistributedDataParallelTest(
         def forward(self, input):
             return input + self.a * self.f
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
     def test_ddp_weight_sharing(self):
         process_group = self._get_process_group()
@@ -3475,7 +3486,7 @@ class DistributedDataParallelTest(
         for try_set_to_none, use_bucket_view in product((False, True), (False, True)):
             m = torch.nn.Sequential(
                 self.AcceptsParam(p, dev + 1), self.AcceptsParam(p, dev + 1)
-            ).cuda(dev)
+            ).to(torch.device(DEVICE_TYPE, dev))
 
             m = torch.nn.parallel.DistributedDataParallel(
                 m,
@@ -3505,7 +3516,7 @@ class DistributedDataParallelTest(
                         + f"set_to_none = {try_set_to_none}, use_bucket_view = {use_bucket_view}",
                     )
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
     def test_ddp_packed_sequence(self):
         """
@@ -3515,7 +3526,7 @@ class DistributedDataParallelTest(
         """
         store = c10d.FileStore(self.file_name, self.world_size)
         process_group = dist.init_process_group(
-            "nccl",
+            BACKEND,
             world_size=self.world_size,
             rank=self.rank,
             store=store,
@@ -3566,21 +3577,21 @@ class DistributedDataParallelTest(
         for p1, p2 in zip(lstm.parameters(), lstm_ddp.parameters()):
             self.assertEqual(p1.grad, p2.grad)
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
     def test_channels_last_contig(self):
         process_group = self._get_process_group()
-        device = torch.device(f"cuda:{self.rank}")
+        device = torch.device(f"{DEVICE_TYPE}:{self.rank}")
         tensor = torch.ones((2, 16, 768, 1152), dtype=torch.float32, device=device).to(
             memory_format=torch.channels_last
         )
         process_group.broadcast([tensor]).wait()
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
     def test_ddp_complex_params(self):
         process_group = self._get_process_group()
-        device_id = gpus_for_rank(self.world_size)[self.rank][0]
+        device_id = devices_for_rank(self.world_size)[self.rank][0]
         N, C, H, W = 1, 16, 64, 64
         ddp_model = DistributedDataParallel(
             FFTModel(hin=H, win=W, n_features=C).to(device_id),
@@ -3597,14 +3608,14 @@ class DistributedDataParallelTest(
         loss.backward()
         optimizer.step()
 
-        torch.cuda.synchronize(device=device_id)
+        torch.accelerator.synchronize(device_id)
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
     def test_bucket_cap_mb_list_initialization(self):
         """Test that bucket_cap_mb_list is properly converted to bucket_bytes_cap_list"""
         process_group = self._get_process_group()
-        device_id = gpus_for_rank(self.world_size)[self.rank][0]
+        device_id = devices_for_rank(self.world_size)[self.rank][0]
 
         # Create a simple model for testing
         model = nn.Sequential(
@@ -3640,12 +3651,12 @@ class DistributedDataParallelTest(
             f"bucket_bytes_cap should be {expected_bucket_bytes_cap}",
         )
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
     def test_bucket_cap_mb_list_default_behavior(self):
         """Test that default bucket_cap_mb is used when neither parameter is provided"""
         process_group = self._get_process_group()
-        device_id = gpus_for_rank(self.world_size)[self.rank][0]
+        device_id = devices_for_rank(self.world_size)[self.rank][0]
 
         model = nn.Sequential(
             nn.Linear(10, 20),
@@ -3675,12 +3686,12 @@ class DistributedDataParallelTest(
             "bucket_bytes_cap_list should be empty when not provided",
         )
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
     def test_bucket_cap_mb_alone(self):
         """Test that bucket_cap_mb works correctly when provided alone"""
         process_group = self._get_process_group()
-        device_id = gpus_for_rank(self.world_size)[self.rank][0]
+        device_id = devices_for_rank(self.world_size)[self.rank][0]
 
         model = nn.Sequential(
             nn.Linear(10, 20),
@@ -3711,7 +3722,6 @@ class DistributedDataParallelTest(
             [],
             "bucket_bytes_cap_list should be empty when bucket_cap_mb_list not provided",
         )
-
 
 class WorkHookTest(MultiProcessTestCase):
     @property

--- a/test/distributed/test_c10d_ucc.py
+++ b/test/distributed/test_c10d_ucc.py
@@ -20,7 +20,7 @@ if not c10d.is_available() or not c10d.is_ucc_available():
 
 import test_c10d_common
 from test_c10d_common import (
-    gpus_for_rank,
+    devices_for_rank,
     ModuleForDdpCommHook,
     SparseGradientModule,
     Task,
@@ -389,14 +389,14 @@ class DistributedDataParallelTest(
     @requires_ucc()
     @skip_if_lt_x_gpu(2)
     def test_ucc_backend_1gpu_module_device_ids_integer_list(self):
-        int_devices = gpus_for_rank(self.world_size)[self.rank][:1]
+        int_devices = devices_for_rank(self.world_size)[self.rank][:1]
         devices = [torch.device("cuda:" + str(i)) for i in int_devices]
         self._test_ucc_backend(devices, int_devices)
 
     @requires_ucc()
     @skip_if_lt_x_gpu(2)
     def test_ucc_backend_1gpu_module_device_ids_torch_device_list(self):
-        int_devices = gpus_for_rank(self.world_size)[self.rank][:1]
+        int_devices = devices_for_rank(self.world_size)[self.rank][:1]
         devices = [torch.device("cuda:" + str(i)) for i in int_devices]
         self._test_ucc_backend(devices, devices)
 
@@ -408,7 +408,7 @@ class DistributedDataParallelTest(
     @requires_ucc()
     @skip_if_lt_x_gpu(4)
     def test_ucc_backend_2gpu_module(self):
-        int_devices = gpus_for_rank(self.world_size)[self.rank][:2]
+        int_devices = devices_for_rank(self.world_size)[self.rank][:2]
         devices = [torch.device("cuda:" + str(i)) for i in int_devices]
         self._test_ucc_backend(devices, None, multi_device=True)
 
@@ -418,7 +418,7 @@ class DistributedDataParallelTest(
     @requires_ucc()
     @skip_if_lt_x_gpu(8)
     def test_ucc_backend_4gpu_module(self):
-        int_devices = gpus_for_rank(self.world_size)[self.rank][:4]
+        int_devices = devices_for_rank(self.world_size)[self.rank][:4]
         devices = [torch.device("cuda:" + str(i)) for i in int_devices]
         self._test_ucc_backend(devices, None, multi_device=True)
 
@@ -476,7 +476,7 @@ class DistributedDataParallelTest(
         run_and_verify_grad(cpu_model)
 
         # Test on GPU
-        device_id = gpus_for_rank(self.world_size)[self.rank][0]
+        device_id = devices_for_rank(self.world_size)[self.rank][0]
         gpu_model = DistributedDataParallel(
             GlobalLocalUnusedParamModule().to(device_id),
             device_ids=[device_id],
@@ -557,7 +557,7 @@ class DistributedDataParallelTest(
         run_and_verify_grad(cpu_model)
 
         # Test on GPU
-        device_id = gpus_for_rank(self.world_size)[self.rank][0]
+        device_id = devices_for_rank(self.world_size)[self.rank][0]
         gpu_model = DistributedDataParallel(
             FindUnusedParamModule().to(device_id),
             device_ids=[device_id],
@@ -703,7 +703,7 @@ class DistributedDataParallelTest(
                 loss.backward()
                 optimizer.step()
 
-        device_id = gpus_for_rank(self.world_size)[self.rank][0]
+        device_id = devices_for_rank(self.world_size)[self.rank][0]
 
         model_withload = TestModel().float().to(device_id)
         model_withoutload = TestModel().float().to(device_id)
@@ -829,7 +829,7 @@ class DistributedDataParallelTest(
     def _gpu_model_with_ddp_comm_hook(
         self, process_group, hook=None, gradient_as_bucket_view=False, state=None
     ):
-        device_id = gpus_for_rank(self.world_size)[self.rank][0]
+        device_id = devices_for_rank(self.world_size)[self.rank][0]
         gpu_model = DistributedDataParallel(
             ModuleForDdpCommHook().to(device_id),
             device_ids=[device_id],

--- a/torch/distributed/_local_tensor/__init__.py
+++ b/torch/distributed/_local_tensor/__init__.py
@@ -686,7 +686,7 @@ class _LocalOffsetBasedRNGTracker:
 
     @property
     def _device(self):
-        return torch.device(self._device_type, torch.cuda.current_device())
+        return torch.device(self._device_type, torch.accelerator.current_device_index())
 
     def _set_pre_op_offset(self, state, spec) -> None:
         """Compute and set per-rank offsets before the random operation."""

--- a/torch/distributed/_shard/sharded_tensor/_ops/binary_cmp.py
+++ b/torch/distributed/_shard/sharded_tensor/_ops/binary_cmp.py
@@ -7,15 +7,21 @@ from torch.distributed._shard.sharded_tensor import _sharded_op_impl, ShardedTen
 
 def _communicate_result(result, pg):
     # Gather results from all ranks.
+    device = None
+    if torch.accelerator.is_available():
+        device = torch.device(
+            torch.accelerator.current_accelerator().type,
+            torch.accelerator.current_device_index()
+        )
     if result:
-        result_tensor = torch.ones(1, device=torch.device(torch.cuda.current_device()))
+        result_tensor = torch.ones(1, device=device)
     else:
-        result_tensor = torch.zeros(1, device=torch.device(torch.cuda.current_device()))
+        result_tensor = torch.zeros(1, device=device)
 
     dist.all_reduce(result_tensor, group=pg)
 
     expected_result = torch.ones(
-        1, device=torch.device(torch.cuda.current_device())
+        1, device=device
     ) * dist.get_world_size(pg)
 
     return torch.equal(result_tensor, expected_result)

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -2419,6 +2419,11 @@ class DistributedDataParallel(Module, Joinable):
             )
 
         if hook.__name__ in ["bf16_compress_hook", "bf16_compress_wrapper_hook"]:
+            bf16_supported = False
+            if torch.accelerator.is_available():
+                device_module = torch.get_device_module(torch.accelerator.current_accelerator())
+                bf16_supported = getattr(device_module, 'is_bf16_supported', lambda: False)()
+
             cuda_supported = (
                 torch.version.cuda is not None
             ) or torch.version.hip is not None
@@ -2433,7 +2438,7 @@ class DistributedDataParallel(Module, Joinable):
                 and torch.xpu.is_available()
             )
 
-            if not ((cuda_supported and nccl_supported) or xpu_xccl_supported):
+            if not (bf16_supported or (cuda_supported and nccl_supported) or xpu_xccl_supported):
                 self._log_and_throw(
                     TypeError,
                     "BF16 all reduce communication hook required CUDA 11+ and NCCL 2.10+ or XPU and XCCL",

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -46,6 +46,7 @@ from torch.testing._internal.common_utils import (
     skip_but_pass_in_sandcastle_if,
     TEST_CUDA,
     TEST_HPU,
+    TEST_PRIVATEUSE1,
     TEST_WITH_ROCM,
     TEST_WITH_TSAN,
     TEST_XPU,
@@ -209,7 +210,7 @@ def at_least_x_gpu(x):
         return True
     if TEST_XPU and torch.xpu.device_count() >= x:
         return True
-    return False
+    return torch.accelerator.is_available() and torch.accelerator.device_count() >= x
 
 
 def _maybe_handle_skip_if_lt_x_gpu(args, msg) -> bool:

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -237,7 +237,9 @@ def skip_if_lt_x_gpu(x, *, allow_cpu=False):
                 return func(*args, **kwargs)
             if TEST_XPU and torch.xpu.device_count() >= x:
                 return func(*args, **kwargs)
-            if allow_cpu and not (torch.cuda.is_available() or TEST_HPU or TEST_XPU):
+            if TEST_PRIVATEUSE1 and torch.accelerator.device_count() >= x:
+                return func(*args, **kwargs)
+            if allow_cpu and not (torch.cuda.is_available() or TEST_HPU or TEST_XPU or TEST_PRIVATEUSE1):
                 return func(*args, **kwargs)
             test_skip = TEST_SKIPS[f"multi-gpu-{x}"]
             if not _maybe_handle_skip_if_lt_x_gpu(args, test_skip.message):
@@ -455,23 +457,33 @@ def requires_accelerator_dist_backend(backends=None):
     Decorator to skip tests if no accelerator communication backend (NCCL, XCCL, HCCL) is available.
 
     Args:
-        backends (Optional[List[str]]): Specific accelerator backends to check (e.g., ["nccl", "xccl", "hccl"]).
-                                       If None, checks all supported accelerator backends (NCCL, XCCL, HCCL).
+        backends (Optional[List[str]]): Specific accelerator backends to check
+            (e.g., ["nccl", "xccl", "hccl"]). Any registered PrivateUse1 backend
+            is always checked in addition to the listed backends.
+            If None, checks all known accelerator backends (NCCL, XCCL, HCCL)
+            plus any registered PrivateUse1 backend.
 
     Returns:
         callable: A decorator that skips the test if no specified accelerator backend is available.
     """
     if backends is None:
         backends = ACCELERATOR_DIST_BACKENDS
+    
+    _backend_availability_checks = {
+        "nccl": c10d.is_nccl_available,
+        "xccl": c10d.is_xccl_available,
+        "hccl": lambda: TEST_HPU,
+    }
+
+    def _is_privateuse1_backend_available() -> bool:
+        """Check if a PrivateUse1 backend is registered."""
+        pu1_device = torch._C._get_privateuse1_backend_name()
+        return c10d.Backend.default_device_backend_map.get(pu1_device) is not None
 
     backend_available = any(
-        {
-            "nccl": c10d.is_nccl_available,
-            "xccl": c10d.is_xccl_available,
-            "hccl": lambda: TEST_HPU,
-        }.get(backend, lambda: False)()
+        _backend_availability_checks.get(backend, lambda: False)()
         for backend in backends
-    )
+    ) or _is_privateuse1_backend_available()
 
     return skip_but_pass_in_sandcastle_if(
         not backend_available,
@@ -1163,14 +1175,8 @@ class DistributedTestBase(MultiProcessTestCase):
             pass
 
     def backend(self, device) -> str:
-        if "cuda" in device:
-            return "nccl"
-        elif "hpu" in device:  # intel gaudi
-            return "hccl"
-        elif "xpu" in device:
-            return "xccl"
-        else:
-            return "gloo"
+        device_type = torch.device(device).type if isinstance(device, str) else device.type
+        return c10d.Backend.default_device_backend_map.get(device_type, "gloo")
 
     def create_pg(self, device, world_size=None):
         if world_size is None:

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1648,6 +1648,10 @@ if TEST_CUDA and 'NUM_PARALLEL_PROCS' in os.environ:
     torch.cuda.set_per_process_memory_fraction(round((gb_available - num_procs * .85) / gb_available / num_procs, 2))
 
 requires_cuda = unittest.skipUnless(torch.cuda.is_available(), "Requires CUDA")
+requires_accelerator = unittest.skipUnless(
+    torch.accelerator.is_available(),
+    "No accelerator available",
+)
 
 def skipIfCrossRef(fn):
     @wraps(fn)

--- a/torch/testing/_internal/distributed/_shard/sharded_tensor/__init__.py
+++ b/torch/testing/_internal/distributed/_shard/sharded_tensor/__init__.py
@@ -23,7 +23,11 @@ class ShardedTensorTestBase(MultiProcessTestCase):
 
     def init_pg(self, backend="nccl"):
         if backend not in ["nccl", "gloo", "mpi", "hccl"]:
-            raise RuntimeError(f"Backend {backend} not supported!")
+            if torch.accelerator.is_available():
+                device_type = torch.accelerator.current_accelerator().type
+                backend = dist.Backend.default_device_backend_map[device_type]
+            else:
+                raise RuntimeError(f"Backend {backend} not supported!")
 
         dist.init_process_group(
             backend=backend,

--- a/torch/testing/_internal/distributed/_tensor/common_dtensor.py
+++ b/torch/testing/_internal/distributed/_tensor/common_dtensor.py
@@ -73,6 +73,8 @@ from torch.utils._pytree import tree_flatten, tree_unflatten, TreeSpec
 
 DEVICE_COUNT: int
 
+ENABLE_FOR_PRIVATEUSE1: bool = True
+
 if TEST_CUDA or TEST_XPU or TEST_HPU or TEST_PRIVATEUSE1:
     DEVICE_TYPE = torch.accelerator.current_accelerator().type
     DEVICE_COUNT = torch.accelerator.device_count()
@@ -806,7 +808,7 @@ class DTensorTestBase(DTensorTestMixin, MultiProcessTestCase):
 
         curr_backend = dist.get_default_backend_for_device(self.device_type)
 
-        if backend not in [
+        _known = [
             "nccl",
             "gloo",
             "mpi",
@@ -817,7 +819,13 @@ class DTensorTestBase(DTensorTestMixin, MultiProcessTestCase):
             "xccl",
             "fake",
             "cpu:gloo,xpu:xccl",
-        ]:
+        ]
+        # Dynamically accept the current device's registered backend,
+        # but only if the plugin hasn't opted out.
+        if curr_backend and ENABLE_FOR_PRIVATEUSE1:
+            _known.append(curr_backend)
+        
+        if backend not in _known:
             raise RuntimeError(f"Backend {backend} not supported!")
 
         device_id = None


### PR DESCRIPTION
This PR is part of a series to refactor distributed tests to be completely device-agnostic.

### Changes

**Source:**
- `torch/distributed/_shard/sharded_tensor/_ops/binary_cmp.py` — `_communicate_result`: Replace `torch.cuda.current_device()` with `torch.accelerator.current_accelerator()` + `torch.accelerator.current_device_index()` for device placement of result tensors, falling back to `None` (CPU) when no accelerator is available

**Test infrastructure (`torch/testing/_internal/`):**
- `common_utils.py`:
  - Add `requires_accelerator` skip decorator using `torch.accelerator.is_available()` as a device-agnostic alternative to `requires_cuda`
- `distributed/_shard/sharded_tensor/__init__.py`:
  - `ShardedTensorTestBase.init_pg()`: When an unrecognized backend is passed, dynamically resolve the correct backend via `dist.Backend.default_device_backend_map` if an accelerator is available, instead of immediately raising `RuntimeError`

**Tests:**
- `test_checkpoint_reader.py`:
  - Replace `"cuda" if torch.cuda.is_available()` with `torch.accelerator.current_accelerator().type if torch.accelerator.is_available()` for `map_location`
- `test_staging.py`:
  - Replace `@requires_cuda` with `@requires_accelerator` on all GPU-dependent tests
  - Rename `test_cuda_non_blocking_without_cuda` → `test_non_blocking_without_accelerator`; replace `torch.cuda.is_available()` guard with `torch.accelerator.is_available()`
  - Rename `test_cuda_tensors_staging` → `test_accelerator_tensors_staging`; replace `.cuda()` with `.to(device)` using `torch.accelerator.current_accelerator()`
  - Replace inline `torch.accelerator.is_available()` calls in `CheckpointStagerConfig` with a cached `has_accelerator` local variable
- `test_e2e_save_and_load.py`:
  - `TestNoCPU.backend`: Replace hardcoded `"nccl"` with `dist.get_default_backend_for_device(device_type)`
- `test_file_system_checkpoint_cpu.py`:
  - Replace `.cuda(dist.get_rank())` with `.to(device)` using `torch.accelerator.current_accelerator()` for model placement
- `test_state_dict.py`:
  - Replace `self.assertFalse(v.is_cuda)` with `self.assertEqual(v.device, torch.device("cpu"))` for device-agnostic CPU offload verification
- `test_state_dict_stager.py`:
  - `TestReplicationStager.backend`: Replace hardcoded `"cpu:gloo,cuda:nccl"` with dynamic backend resolution via `dist.get_default_backend_for_device(device_type)`

Depends on #PR178336

cc @NmomoN @mengpenghui @fwenguang @cdzhan @1274085042 @PHLens @albanD