### PR TITLE
[inductor][auto_chunker] Add annotation-driven auto-chunking via auto…

### DIFF
--- a/test/inductor/test_auto_chunker.py
+++ b/test/inductor/test_auto_chunker.py
@@ -2,9 +2,11 @@
 import os
 
 import torch
+import torch.fx.traceback as fx_traceback
 from torch import nn
 from torch._dynamo.utils import same
 from torch._inductor import config, metrics
+from torch._inductor.auto_chunk import auto_chunk
 from torch._inductor.test_case import TestCase
 from torch.testing._internal.common_device_type import largeTensorTest
 from torch.testing._internal.common_utils import (
@@ -371,6 +373,158 @@ class AutoChunkerTest(TestCase):
         w.grad = None
         opt_f = torch.compile(f)
         actual = (opt_f(x, w, targets), x.grad, w.grad)
+
+        self.assertTrue(same(expect, actual, tol=1e-3))
+        self.assertEqual(metrics.num_auto_chunking, 1)
+
+    @config.patch("auto_chunker.num_chunk", 2)
+    def test_annotated_linear_with_bias(self):
+        """Annotation works with nn.Linear (decomposes to addmm with bias)."""
+        M, K, N = 32, 4, 32
+        linear = nn.Linear(K, N, device=GPU_TYPE)
+
+        def f(x):
+            with auto_chunk():
+                out = linear(x)
+            out = out.softmax(dim=-1)
+            loss = out.sum()
+            loss.backward()
+            return loss
+
+        x = torch.randn(M, K, device=GPU_TYPE, requires_grad=True)
+        expect = (f(x), x.grad, linear.weight.grad, linear.bias.grad)
+        x.grad = None
+        linear.weight.grad = None
+        linear.bias.grad = None
+        opt_f = torch.compile(f)
+        actual = (opt_f(x), x.grad, linear.weight.grad, linear.bias.grad)
+
+        self.assertTrue(same(expect, actual, tol=1e-3))
+        self.assertEqual(metrics.num_auto_chunking, 1)
+
+    @config.patch("auto_chunker.num_chunk", 2)
+    def test_annotated_matmul_softmax(self):
+        """Annotation-driven chunking works even with small tensors that
+        would not trigger heuristic detection."""
+        M, K, N = 32, 4, 32
+        x = torch.randn(M, K, device=GPU_TYPE, requires_grad=True)
+        w = torch.randn(K, N, device=GPU_TYPE, requires_grad=True)
+
+        def f(x, w):
+            with auto_chunk():
+                out = (x * 2) @ w
+            out = out.softmax(dim=-1)
+            loss = out.sum()
+            loss.backward()
+            return loss
+
+        expect = (f(x, w), x.grad, w.grad)
+        x.grad = None
+        w.grad = None
+        opt_f = torch.compile(f)
+        actual = (opt_f(x, w), x.grad, w.grad)
+
+        self.assertTrue(same(expect, actual, tol=1e-3))
+        self.assertEqual(metrics.num_auto_chunking, 1)
+
+    @config.patch("auto_chunker.num_chunk", 2)
+    def test_annotated_manual_cross_entropy(self):
+        """Annotation-driven chunking with the manual cross entropy pattern."""
+        M, K, N = 32, 4, 32
+        x = torch.randn(M, K, device=GPU_TYPE, requires_grad=True)
+        w = torch.randn(K, N, device=GPU_TYPE, requires_grad=True)
+        targets = torch.randint(0, N, (M,), device=GPU_TYPE)
+
+        def f(x, w, targets):
+            with auto_chunk():
+                logits = (x * 2) @ w
+            max_logits = logits.amax(dim=-1)
+            shifted = logits - max_logits.unsqueeze(-1)
+            exp_shifted = shifted.exp()
+            sum_exp = exp_shifted.sum(dim=-1)
+            log_probs = shifted - sum_exp.log().unsqueeze(-1)
+            target_log_probs = log_probs.gather(1, targets.unsqueeze(1))
+            loss = -target_log_probs.squeeze(1).sum() / M
+            loss.backward()
+            return loss
+
+        expect = (f(x, w, targets), x.grad, w.grad)
+        x.grad = None
+        w.grad = None
+        opt_f = torch.compile(f)
+        actual = (opt_f(x, w, targets), x.grad, w.grad)
+
+        self.assertTrue(same(expect, actual, tol=1e-3))
+        self.assertEqual(metrics.num_auto_chunking, 1)
+
+    @config.patch("auto_chunker.num_chunk", 2)
+    def test_annotated_with_fx_traceback(self):
+        """Using fx_traceback.annotate directly also works."""
+        M, K, N = 32, 4, 32
+        x = torch.randn(M, K, device=GPU_TYPE, requires_grad=True)
+        w = torch.randn(K, N, device=GPU_TYPE, requires_grad=True)
+
+        def f(x, w):
+            with fx_traceback.annotate({"auto_chunk": True}):
+                out = (x * 2) @ w
+            out = out.softmax(dim=-1)
+            loss = out.sum()
+            loss.backward()
+            return loss
+
+        expect = (f(x, w), x.grad, w.grad)
+        x.grad = None
+        w.grad = None
+        opt_f = torch.compile(f)
+        actual = (opt_f(x, w), x.grad, w.grad)
+
+        self.assertTrue(same(expect, actual, tol=1e-3))
+        self.assertEqual(metrics.num_auto_chunking, 1)
+
+    @config.patch("auto_chunker.num_chunk", 2)
+    def test_annotated_on_invalid_op(self):
+        """Annotating non-amplifier ops raises a clear error."""
+        M, K, N = 32, 4, 32
+        x = torch.randn(M, K, device=GPU_TYPE, requires_grad=True)
+        w = torch.randn(K, N, device=GPU_TYPE, requires_grad=True)
+
+        def f(x, w):
+            out = (x * 2) @ w
+            with auto_chunk():
+                out = out.softmax(dim=-1)
+            loss = out.sum()
+            loss.backward()
+            return loss
+
+        _ = f(x.clone().requires_grad_(True), w.clone().requires_grad_(True))
+        x.grad = None
+        w.grad = None
+        opt_f = torch.compile(f)
+        # Should still compile (CantChunk is caught), but no chunking happens
+        opt_f(x, w)
+        self.assertEqual(metrics.num_auto_chunking, 0)
+
+    @config.patch("auto_chunker.enable", False)
+    @config.patch("auto_chunker.num_chunk", 2)
+    def test_annotated_without_config_enable(self):
+        """Annotation alone enables auto-chunking without config.auto_chunker.enable."""
+        M, K, N = 32, 4, 32
+        x = torch.randn(M, K, device=GPU_TYPE, requires_grad=True)
+        w = torch.randn(K, N, device=GPU_TYPE, requires_grad=True)
+
+        def f(x, w):
+            with auto_chunk():
+                out = (x * 2) @ w
+            out = out.softmax(dim=-1)
+            loss = out.sum()
+            loss.backward()
+            return loss
+
+        expect = (f(x, w), x.grad, w.grad)
+        x.grad = None
+        w.grad = None
+        opt_f = torch.compile(f)
+        actual = (opt_f(x, w), x.grad, w.grad)
 
         self.assertTrue(same(expect, actual, tol=1e-3))
         self.assertEqual(metrics.num_auto_chunking, 1)

--- a/torch/_dynamo/trace_rules.py
+++ b/torch/_dynamo/trace_rules.py
@@ -3445,6 +3445,7 @@ MOD_INLINELIST = [
     "torch._functorch.functional_call",
     "torch._functorch.pyfunctorch",
     "torch._functorch.vmap",
+    "torch._inductor.auto_chunk",
     "torch._inductor.test_operators",
     "torch._library.autograd",
     "torch._library.custom_ops",

--- a/torch/_dynamo/variables/ctx_manager.py
+++ b/torch/_dynamo/variables/ctx_manager.py
@@ -1439,6 +1439,11 @@ class FxTracebackAnnotateVariable(ContextWrappingVariable):
         stack.enter_context(torch.fx.traceback.annotate(self.target_values))
         stack.enter_context(torch.fx.traceback.preserve_node_meta())
         self.set_cleanup_hook(tx, lambda: stack.close())
+
+        # Enable auto-chunker pass when auto_chunk annotation is present
+        if self.target_values.get("auto_chunk"):
+            torch._inductor.config.auto_chunker.enable = True
+
         return variables.CONSTANT_VARIABLE_NONE
 
     def module_name(self) -> str:

--- a/torch/_inductor/auto_chunk.py
+++ b/torch/_inductor/auto_chunk.py
@@ -1,0 +1,22 @@
+from contextlib import contextmanager
+
+import torch.fx.traceback as fx_traceback
+
+
+@contextmanager
+def auto_chunk():
+    """Mark operations for deterministic auto-chunking.
+
+    Operations traced within this context will be annotated so that the
+    auto-chunker can identify them as chunking amplifier nodes without
+    relying on output/input size ratio heuristics. Using this context
+    manager automatically enables the auto-chunker pass.
+
+    Example::
+
+        with torch._inductor.auto_chunk.auto_chunk():
+            logits = self.linear(x)
+        loss = F.cross_entropy(logits, y)
+    """
+    with fx_traceback.annotate({"auto_chunk": True}):
+        yield

--- a/torch/_inductor/fx_passes/auto_chunker/core.py
+++ b/torch/_inductor/fx_passes/auto_chunker/core.py
@@ -119,20 +119,33 @@ def find_amplifier_node(graph: Graph) -> Node | None:
     Find the 'amplifier' node which is a node that generates large
     output with small/medium input.
 
-    If there are multiple amplifier nodes, return the one with the largest
-    amplification ratio.
+    If a node is explicitly annotated with auto_chunk (via
+    torch.fx.traceback.annotate), it is returned immediately and bypasses
+    size/ratio thresholds. Otherwise falls back to heuristic detection.
+
+    Raises CantChunk if auto_chunk annotations exist but none are on
+    eligible amplifier ops (mm/addmm).
     """
+    from .common import CantChunk
 
     amplifier_nodes_ratio = []
+    annotated_ineligible_nodes: list[Node] = []
 
     for node in graph.nodes:
         if use_tangent(node):
             # enter backward part of the graph
             break
 
-        # Only trigger chunking for a small set of nodes like matmul for now
+        is_annotated = bool(node.meta.get("custom", {}).get("auto_chunk"))
+
         if node.op != "call_function" or node.target not in eligible_amplifier_node:
+            if is_annotated:
+                annotated_ineligible_nodes.append(node)
             continue
+
+        # Annotated nodes bypass size/ratio thresholds
+        if is_annotated:
+            return node
 
         input_size = compute_tensor_size(node.args, node.kwargs)
         output_size = compute_tensor_size(node)
@@ -146,6 +159,15 @@ def find_amplifier_node(graph: Graph) -> Node | None:
             and ratio > config.auto_chunker.amplify_ratio_threshold
         ):
             amplifier_nodes_ratio.append((node, ratio))
+
+    if annotated_ineligible_nodes:
+        nodes_str = ", ".join(str(n.format_node()) for n in annotated_ineligible_nodes)
+        raise CantChunk(
+            f"auto_chunk() annotation found but no eligible amplifier op "
+            f"(mm/addmm) was annotated. The following annotated nodes are "
+            f"not eligible: {nodes_str}. Wrap the context manager around a "
+            f"matmul or linear operation."
+        )
 
     amplifier_nodes_ratio = sorted(
         amplifier_nodes_ratio, key=lambda x: x[1], reverse=True


### PR DESCRIPTION
…_chunk() context manager

Add a deterministic UX for enabling auto-chunking on specific ops, instead of relying solely on the amplifier ratio heuristic. Users can now wrap operations with `auto_chunk()` to explicitly mark them for chunking, bypassing size/ratio thresholds.

The context manager automatically enables the auto-chunker pass (no need to separately set config.auto_chunker.enable). If the annotation is placed on ineligible ops (not mm/addmm), a clear error message is raised listing the offending nodes.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98 @Lucaskabela