### PR TITLE
[XPU] Add Uint16/Uint32/Uint64/fp8 support to device capability

### DIFF
--- a/c10/xpu/impl/XPUGuardImpl.h
+++ b/c10/xpu/impl/XPUGuardImpl.h
@@ -53,7 +53,7 @@ struct XPUGuardImpl final : public c10::impl::DeviceGuardImplInterface {
         (1ULL << kIndex_ComplexFloat) | (1ULL << kIndex_Bool) |
         (1ULL << kIndex_Float8_e5m2) | (1ULL << kIndex_Float8_e4m3fn) |
         (1ULL << kIndex_Float8_e5m2fnuz) | (1ULL << kIndex_Float8_e4m3fnuz) |
-        (1ULL << kIndex_Float8_e8m0fnu)(1ULL << kIndex_UInt16) |
+        (1ULL << kIndex_Float8_e8m0fnu) | (1ULL << kIndex_UInt16) |
         (1ULL << kIndex_UInt32) | (1ULL << kIndex_UInt64);
     // BFloat16 may be emulated. We always assume BFloat16 is available;
     // users can call is_bf16_supported() to check for native hardware support.

--- a/c10/xpu/impl/XPUGuardImpl.h
+++ b/c10/xpu/impl/XPUGuardImpl.h
@@ -50,7 +50,9 @@ struct XPUGuardImpl final : public c10::impl::DeviceGuardImplInterface {
     cap.capability_data.capability_bits = (1ULL << kIndex_Byte) |
         (1ULL << kIndex_Char) | (1ULL << kIndex_Short) | (1ULL << kIndex_Int) |
         (1ULL << kIndex_Long) | (1ULL << kIndex_Float) |
-        (1ULL << kIndex_ComplexFloat) | (1ULL << kIndex_Bool);
+        (1ULL << kIndex_ComplexFloat) | (1ULL << kIndex_Bool) |
+        (1ULL << kIndex_UInt16) | (1ULL << kIndex_UInt32) |
+        (1ULL << kIndex_UInt64);
     // BFloat16 may be emulated. We always assume BFloat16 is available;
     // users can call is_bf16_supported() to check for native hardware support.
     cap.capability_data.capability_bits |= (1ULL << kIndex_BFloat16);

--- a/c10/xpu/impl/XPUGuardImpl.h
+++ b/c10/xpu/impl/XPUGuardImpl.h
@@ -51,8 +51,10 @@ struct XPUGuardImpl final : public c10::impl::DeviceGuardImplInterface {
         (1ULL << kIndex_Char) | (1ULL << kIndex_Short) | (1ULL << kIndex_Int) |
         (1ULL << kIndex_Long) | (1ULL << kIndex_Float) |
         (1ULL << kIndex_ComplexFloat) | (1ULL << kIndex_Bool) |
-        (1ULL << kIndex_UInt16) | (1ULL << kIndex_UInt32) |
-        (1ULL << kIndex_UInt64);
+        (1ULL << kIndex_Float8_e5m2) | (1ULL << kIndex_Float8_e4m3fn) |
+        (1ULL << kIndex_Float8_e5m2fnuz) | (1ULL << kIndex_Float8_e4m3fnuz) |
+        (1ULL << kIndex_Float8_e8m0fnu)(1ULL << kIndex_UInt16) |
+        (1ULL << kIndex_UInt32) | (1ULL << kIndex_UInt64);
     // BFloat16 may be emulated. We always assume BFloat16 is available;
     // users can call is_bf16_supported() to check for native hardware support.
     cap.capability_data.capability_bits |= (1ULL << kIndex_BFloat16);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #178467

# Motivation
https://github.com/pytorch/pytorch/pull/178397 documents `torch.accelerator.get_device_capability` and clarifies what `supported_dtypes` means. Now we need to add all torch.dtype that we need to support to `get_device_capability`

# Additional Context
Pass the test introduced in https://github.com/pytorch/pytorch/pull/178423
Without this PR, test failure:
<img width="1702" height="593" alt="image" src="https://github.com/user-attachments/assets/b9489025-b820-4659-a49d-b64d045e00ca" />

