### PR TITLE
 [inductor] Bundle only winning autotuning configs in TritonBundler                                                                                                                                                                                         

### DIFF
--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -1468,7 +1468,6 @@ class CachingAutotuner(KernelInterface):
             )
 
         if best_config not in config2launcher:
-
             # On a Coordesc cache hit, we might not have loaded the launcher
             # This can happen because PyCodeCache saves CachingAutotuners in memory,
             # even for separate compile IDs (which can have different inputs without changing output code)
@@ -1558,6 +1557,11 @@ class CachingAutotuner(KernelInterface):
             ]
 
         (launcher,) = self.launchers
+        # Ensure the final launcher is marked as a winner for bundle filtering.
+        # For multi-config autotuning and coordesc, put_winner was already called
+        # (this is an idempotent set-add). For single-config kernels that skip
+        # autotuning entirely, this is the only call site that records the winner.
+        TritonBundler.put_winner(launcher.cache_hash)
         if launcher.store_cubin and (not benchmark_run or not self.cuda_kernel_saved):
             self.save_gpu_kernel(stream, launcher)
 

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -1286,6 +1286,8 @@ class CachingAutotuner(KernelInterface):
             launcher.shared,
         )
 
+        TritonBundler.put_winner(launcher.cache_hash)
+
         if self.save_cache_hook:
             self.save_cache_hook(
                 launcher.config,
@@ -1466,6 +1468,7 @@ class CachingAutotuner(KernelInterface):
             )
 
         if best_config not in config2launcher:
+
             # On a Coordesc cache hit, we might not have loaded the launcher
             # This can happen because PyCodeCache saves CachingAutotuners in memory,
             # even for separate compile IDs (which can have different inputs without changing output code)
@@ -1473,11 +1476,14 @@ class CachingAutotuner(KernelInterface):
                 best_config
             ).make_launcher()
 
+        winner = config2launcher[best_config]
+        TritonBundler.put_winner(winner.cache_hash)
+
         fn_hash = generate_lookup_hash_from_source_code(
             str(self.size_hints), self.fn.src
         )
         log.debug("Function hash %s has best config %s", fn_hash, best_config)
-        return config2launcher[best_config]
+        return winner
 
     def get_profiler_kwargs(self, stream, launcher):
         kernel_kwargs_str = ",".join(

--- a/torch/_inductor/triton_bundler.py
+++ b/torch/_inductor/triton_bundler.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from torch._dynamo.utils import counters, dynamo_timed, set_feature_use
 from torch._utils_internal import justknobs_check
 from torch.utils._filelock import FileLock
+from torch.utils._ordered_set import OrderedSet
 
 from .runtime.runtime_utils import triton_cache_dir
 from .utils import _IS_WINDOWS, GPU_KERNEL_BIN_EXTS
@@ -106,7 +107,7 @@ class TritonBundler:
 
     _entries: list[TritonBundleEntry] | None = None
     _static_autotuners: list[StaticallyLaunchedAutotuner] | None = None
-    _winners: set[str] | None = None
+    _winners: OrderedSet[str] | None = None
 
     # __grp__kernel_name.json contains metadata with source code paths
     # we use this as sentinel value for search and replace
@@ -141,7 +142,7 @@ class TritonBundler:
         assert cls._entries is None
         cls._entries = []
         cls._static_autotuners = []
-        cls._winners = set()
+        cls._winners = OrderedSet()
 
     @classmethod
     def end_compile(cls) -> None:
@@ -285,9 +286,7 @@ class TritonBundler:
                 kernel_names: list[str] = []
                 for entry in entries:
                     if winners and entry.kernel_hash not in winners:
-                        log.debug(
-                            "Skipping non-winning kernel %s", entry.kernel_hash
-                        )
+                        log.debug("Skipping non-winning kernel %s", entry.kernel_hash)
                         continue
                     artifacts: list[TritonKernelArtifact] = []
                     path = os.path.join(entry.directory, entry.kernel_hash)

--- a/torch/_inductor/triton_bundler.py
+++ b/torch/_inductor/triton_bundler.py
@@ -106,6 +106,7 @@ class TritonBundler:
 
     _entries: list[TritonBundleEntry] | None = None
     _static_autotuners: list[StaticallyLaunchedAutotuner] | None = None
+    _winners: set[str] | None = None
 
     # __grp__kernel_name.json contains metadata with source code paths
     # we use this as sentinel value for search and replace
@@ -140,6 +141,7 @@ class TritonBundler:
         assert cls._entries is None
         cls._entries = []
         cls._static_autotuners = []
+        cls._winners = set()
 
     @classmethod
     def end_compile(cls) -> None:
@@ -150,6 +152,7 @@ class TritonBundler:
         log.debug("TritonBundler.end_compile is called")
         cls._entries = None
         cls._static_autotuners = None
+        cls._winners = None
 
     @classmethod
     def put(cls, kernel_hash: str, device: int) -> None:
@@ -161,6 +164,17 @@ class TritonBundler:
             entries.append(
                 TritonBundleEntry(kernel_hash, device, triton_cache_dir(device))
             )
+
+    @classmethod
+    def put_winner(cls, kernel_hash: str) -> None:
+        """
+        Marks a kernel hash as a winning autotuning config. Only winning
+        kernels are included in the bundle by collect(). If no winners are
+        recorded (e.g. single-config kernels that skip autotuning), all
+        entries are bundled.
+        """
+        if cls._winners is not None:
+            cls._winners.add(kernel_hash)
 
     @classmethod
     def put_static_autotuner(cls, key: str, kernel: "CachingAutotuner") -> None:  # type: ignore[name-defined] # noqa: F821
@@ -262,9 +276,19 @@ class TritonBundler:
         with dynamo_timed(key="TritonBundler.collect", log_pt2_compile_event=True):
             entries = cls._entries
             if entries is not None:
+                # Only bundle winning autotuning configs. If _winners is
+                # non-empty, skip entries whose kernel_hash is not a winner.
+                # When _winners is empty (single-config kernels, or no
+                # autotuning ran), bundle everything.
+                winners = cls._winners
                 result: list[TritonKernelArtifacts] = []
                 kernel_names: list[str] = []
                 for entry in entries:
+                    if winners and entry.kernel_hash not in winners:
+                        log.debug(
+                            "Skipping non-winning kernel %s", entry.kernel_hash
+                        )
+                        continue
                     artifacts: list[TritonKernelArtifact] = []
                     path = os.path.join(entry.directory, entry.kernel_hash)
                     if not os.path.exists(path):


### PR DESCRIPTION
When max_autotune is enabled, TritonBundler bundles the compiled artifacts for every autotuning candidate into the FX graph cache including configs that lost the benchmark. Only the winning config is used at runtime and the rest are dead weight in the cache entry.

This change tracks which kernel hashes correspond to autotuning winners and filters out the losers in collect(). 

The mechanism: TritonBundler._winners accumulates hashes via put_winner(), called from autotune_to_one_config, coordinate_descent_tuning, and CachingAutotuner.run (the last one covers single-config kernels that skip autotuning entirely). collect() skips entries whose hash is not in _winners.
When _winners is empty (bundling disabled, or no autotuning ran), all entries are bundled as before.

The put_winner call in run() is the key correctness detail: without it, single-config kernels would be silently dropped from the bundle whenever multi-config kernels are also present (since _winners would be non-empty but missing the single-config hashes).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo