### PR TITLE
[Build] Stop building even more of NativeRT in OSS

### DIFF
--- a/build_variables.bzl
+++ b/build_variables.bzl
@@ -691,7 +691,7 @@ libtorch_lite_cmake_sources = sorted(
     torch_mobile_core,
 )
 
-libtorch_cmake_sources = libtorch_core_sources + libtorch_core_jit_sources + libtorch_nativert_sources
+libtorch_cmake_sources = libtorch_core_sources + libtorch_core_jit_sources
 
 libtorch_extra_sources = libtorch_core_jit_sources + [
     "torch/csrc/autograd/TraceTypeManual.cpp",

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -556,13 +556,6 @@ if(USE_CUDA OR USE_ROCM)
   append_filelist("libtorch_cuda_core_sources" Caffe2_GPU_HIP_JIT_FUSERS_SRCS)
 endif()
 
-# NativeRT is disabled
-# if(USE_CUDA)
-#   append_filelist("libtorch_nativert_cuda_sources" Caffe2_GPU_SRCS)
-# endif()
-# if(USE_ROCM)
-#   append_filelist("libtorch_nativert_cuda_sources" Caffe2_HIP_SRCS)
-# endif()
 
 if(USE_CUDA)
   list(APPEND Caffe2_GPU_CU_SRCS ${Caffe2_GPU_HIP_JIT_FUSERS_SRCS})
@@ -1369,8 +1362,6 @@ if(BUILD_TEST)
   else()
     add_subdirectory(${TORCH_ROOT}/test/cpp/jit ${CMAKE_BINARY_DIR}/test_jit)
     add_subdirectory(${TORCH_ROOT}/test/cpp/lazy ${CMAKE_BINARY_DIR}/test_lazy)
-    # NativeRT is disabled
-    # add_subdirectory(${TORCH_ROOT}/test/cpp/nativert ${CMAKE_BINARY_DIR}/test_nativert)
     add_subdirectory(${TORCH_ROOT}/test/cpp/profiler ${CMAKE_BINARY_DIR}/test_profiler)
     add_subdirectory(${TORCH_ROOT}/test/inductor ${CMAKE_BINARY_DIR}/test_inductor)
     add_subdirectory(${TORCH_ROOT}/test/cpp/aoti_abi_check ${CMAKE_BINARY_DIR}/test_aoti_abi_check)

--- a/torch/nativert/python/Bindings.cpp
+++ b/torch/nativert/python/Bindings.cpp
@@ -3,6 +3,7 @@
 #include <torch/csrc/jit/python/pybind_utils.h>
 #include <torch/csrc/utils/pybind.h>
 
+#ifdef FBCODE_CAFFE2
 #include <torch/nativert/ModelRunner.h>
 
 namespace py = pybind11;
@@ -81,3 +82,13 @@ void initModelRunnerPybind(py::module& m) {
 }
 
 } // namespace torch::nativert
+
+#else // !FBCODE_CAFFE2
+
+namespace py = pybind11;
+
+namespace torch::nativert {
+void initModelRunnerPybind(py::module& m) {}
+} // namespace torch::nativert
+
+#endif // FBCODE_CAFFE2

--- a/torch/nativert/python/Bindings.cpp
+++ b/torch/nativert/python/Bindings.cpp
@@ -88,7 +88,16 @@ void initModelRunnerPybind(py::module& m) {
 namespace py = pybind11;
 
 namespace torch::nativert {
-void initModelRunnerPybind(py::module& m) {}
+
+class StubModelRunner {};
+
+// PyModelRunner is referenced from
+// https://github.com/pytorch/benchmark/blob/b8d35ba51a3149b7212888b4010ddee97f19947f/userbenchmark/dynamo/dynamobench/common.py#L45
+void initModelRunnerPybind(py::module& m) {
+  py::class_<StubModelRunner, std::shared_ptr<StubModelRunner>>(
+      m, "PyModelRunner");
+}
+
 } // namespace torch::nativert
 
 #endif // FBCODE_CAFFE2


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #178479
* __->__ #178475

Testing + Accelerator parts were disabled in https://github.com/pytorch/pytorch/pull/164463

This takes it one step further, but keeps Bazel/BUCK builds functional