### PR TITLE
[inductor] Fix CPP wrapper lazy compile for scalar tensor args

### DIFF
--- a/torch/_inductor/codegen/cpp_wrapper_gpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_gpu.py
@@ -679,17 +679,30 @@ class DeferredTritonCallWrapper:
         tma_tensor_args = self.tma_tensor_args
         num_autotune_args = len(wrapper_arg_names) - len(tma_tensor_args)
         autotune_arg_list = []
-        for name in wrapper_arg_names[:num_autotune_args]:
+        # Track which args need scalar extraction for the autotune call.
+        # UnwrapUnspecArg args are 0-dim tensors in C++ that Triton expects
+        # as Python scalars; we use codegen_tensor_item to extract them.
+        scalar_extractions: list[tuple[str, str, torch_dtype]] = []
+        for idx, name in enumerate(wrapper_arg_names[:num_autotune_args]):
             if name in tma_signature_types:
                 autotune_arg_list.append(f"_tma_tensor_{name}")
+            elif isinstance(self.arg_types[idx], UnwrapUnspecArg):
+                scalar_var = f"_autotune_scalar_{name}"
+                scalar_extractions.append((name, scalar_var, self.arg_types[idx].dtype))
+                autotune_arg_list.append(scalar_var)
             else:
                 autotune_arg_list.append(name)
         autotune_args = ", ".join(autotune_arg_list)
         # Lazy compile with autotuning on first invocation
         with prefix.indent():
-            prefix.splice(
-                f"""\
-                if ({kernel_name} == nullptr) {{
+            prefix.writeline(f"if ({kernel_name} == nullptr) {{")
+            with prefix.indent():
+                for tensor_name, scalar_var, dtype in scalar_extractions:
+                    wrapper.codegen_tensor_item(
+                        dtype, tensor_name, scalar_var, indented_buffer=prefix
+                    )
+                prefix.splice(
+                    f"""\
                     {kernel_name}_result = runTritonKernelWithAutotune(
                         _module_pending_kernels, "{kernel_name}", stream_, {autotune_args});
 
@@ -700,9 +713,9 @@ class DeferredTritonCallWrapper:
 
                     // First invocation already ran the kernel, so return early
                     return;
-                }}
-                """
-            )
+                    """
+                )
+            prefix.writeline("}")
 
             self._generate_lazy_grid(prefix)
             self._generate_lazy_launch(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #178478

In the lazy compile path, `runTritonKernelWithAutotune` passes all
args to the Python `run_triton_kernel_with_autotune` which calls
`kernel_fn.run()`. The C++ `convertArgToPython` converts
`AtenTensorHandle` to Python tensors, but for UnwrapUnspecArg (0-dim
scalar tensors like uint8/bfloat16), Triton's launcher now expects
Python scalars, not tensors.

Extract the scalar value via `codegen_tensor_item` before the
autotune call, matching the direct kernel launch path which already
does this.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo