### PR TITLE
[MPS] Replace MPSGraph nonzero with native Metal prefix-sum + scatter

### DIFF
--- a/aten/src/ATen/native/mps/kernels/Indexing.metal
+++ b/aten/src/ATen/native/mps/kernels/Indexing.metal
@@ -795,10 +795,10 @@ INSTANTIATE_INDEX_FILL_FROM_MASK(half2)
 // Nonzero kernel implementation using prefix-sum + scatter approach.
 //
 // Phase 1 (count_nonzero_prefix_sum): Each threadgroup processes a chunk of the
-// flattened input. Within each threadgroup we compute an exclusive prefix sum of
-// the nonzero flags. The total count for each threadgroup is written to a small
-// auxiliary buffer (block_sums). The prefix sum values are written to a temporary
-// buffer (prefix) so phase 2 can look up output positions.
+// flattened input. Within each threadgroup we compute an exclusive prefix sum
+// of the nonzero flags. The total count for each threadgroup is written to a
+// small auxiliary buffer (block_sums). The prefix sum values are written to a
+// temporary buffer (prefix) so phase 2 can look up output positions.
 //
 // Between phases the host reads back the block_sums, computes a CPU-side prefix
 // sum to get per-block offsets, and allocates the output tensor.
@@ -819,7 +819,6 @@ kernel void count_nonzero_prefix_sum(
     uint tgid [[threadgroup_position_in_grid]],
     uint simd_lane_id [[thread_index_in_simdgroup]],
     uint simd_group_id [[simdgroup_index_in_threadgroup]]) {
-
   uint num_simds = (tgsize + simdgroup_size - 1) / simdgroup_size;
 
   int flag = 0;
@@ -853,9 +852,11 @@ kernel void count_nonzero_prefix_sum(
   // First simd group computes exclusive prefix sum of simd group totals
   threadgroup int simdgroup_offsets[32];
   if (simd_group_id == 0) {
-    int sg_val = (simd_lane_id < num_simds) ? simdgroup_totals[simd_lane_id] : 0;
+    int sg_val =
+        (simd_lane_id < num_simds) ? simdgroup_totals[simd_lane_id] : 0;
     for (uint offset = 1; offset < simdgroup_size; offset <<= 1) {
-      int other = simd_shuffle_and_fill_up(sg_val, 0, static_cast<ushort>(offset));
+      int other =
+          simd_shuffle_and_fill_up(sg_val, 0, static_cast<ushort>(offset));
       sg_val += other;
     }
     int exclusive = simd_shuffle_and_fill_up(sg_val, 0, static_cast<ushort>(1));
@@ -870,7 +871,70 @@ kernel void count_nonzero_prefix_sum(
   }
 
   if (lid == tgsize - 1) {
-    block_sums[tgid] = simdgroup_offsets[num_simds - 1] + simdgroup_totals[num_simds - 1];
+    block_sums[tgid] =
+        simdgroup_offsets[num_simds - 1] + simdgroup_totals[num_simds - 1];
+  }
+}
+
+// Phase 1.5: exclusive prefix sum of block_sums → block_offsets, and write
+// total nonzero count to a 1-element buffer.  Runs in a single threadgroup
+// (num_blocks <= 32*32 = 1024 for numel < INT_MAX with TG_SIZE = 256).
+kernel void prefix_sum_blocks(
+    const device int* block_sums [[buffer(0)]],
+    device int* block_offsets [[buffer(1)]],
+    device int* total_nonzero [[buffer(2)]],
+    constant uint& num_blocks [[buffer(3)]],
+    uint lid [[thread_position_in_threadgroup]],
+    uint tgsize [[threads_per_threadgroup]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simd_group_id [[simdgroup_index_in_threadgroup]]) {
+  uint num_simds = (tgsize + simdgroup_size - 1) / simdgroup_size;
+
+  int val_in = (lid < num_blocks) ? block_sums[lid] : 0;
+
+  // Inclusive SIMD scan
+  int val = val_in;
+  for (uint offset = 1; offset < simdgroup_size; offset <<= 1) {
+    int other = simd_shuffle_and_fill_up(val, 0, static_cast<ushort>(offset));
+    val += other;
+  }
+
+  threadgroup int simdgroup_totals[32];
+  bool is_last_lane_in_simd;
+  if (simd_group_id < num_simds - 1) {
+    is_last_lane_in_simd = (simd_lane_id == simdgroup_size - 1);
+  } else {
+    uint lanes_in_last = tgsize - simd_group_id * simdgroup_size;
+    is_last_lane_in_simd = (simd_lane_id == lanes_in_last - 1);
+  }
+  if (is_last_lane_in_simd) {
+    simdgroup_totals[simd_group_id] = val;
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  threadgroup int simdgroup_offsets[32];
+  if (simd_group_id == 0) {
+    int sg_val =
+        (simd_lane_id < num_simds) ? simdgroup_totals[simd_lane_id] : 0;
+    for (uint offset = 1; offset < simdgroup_size; offset <<= 1) {
+      int other =
+          simd_shuffle_and_fill_up(sg_val, 0, static_cast<ushort>(offset));
+      sg_val += other;
+    }
+    int exclusive = simd_shuffle_and_fill_up(sg_val, 0, static_cast<ushort>(1));
+    simdgroup_offsets[simd_lane_id] = exclusive;
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  int exclusive_val = val - val_in + simdgroup_offsets[simd_group_id];
+
+  if (lid < num_blocks) {
+    block_offsets[lid] = exclusive_val;
+  }
+
+  if (lid == tgsize - 1) {
+    *total_nonzero =
+        simdgroup_offsets[num_simds - 1] + simdgroup_totals[num_simds - 1];
   }
 }
 
@@ -887,44 +951,46 @@ kernel void scatter_nonzero_indices(
     constant int* block_offsets [[buffer(6)]],
     uint tid [[thread_position_in_grid]],
     uint tgid [[threadgroup_position_in_grid]]) {
-
-  if (tid >= numel) return;
-  if (input[tid] == T(0)) return;
+  if (tid >= numel)
+    return;
+  if (input[tid] == T(0))
+    return;
 
   int pos = block_offsets[tgid] + prefix[tid];
 
   uint flat = tid;
   for (int d = ndim - 1; d >= 0; d--) {
     int64_t dim_size = sizes[d];
-    output[pos * ndim + d] = static_cast<int64_t>(flat % static_cast<uint>(dim_size));
+    output[pos * ndim + d] =
+        static_cast<int64_t>(flat % static_cast<uint>(dim_size));
     flat /= static_cast<uint>(dim_size);
   }
 }
 
-#define REGISTER_NONZERO_KERNELS(DTYPE)                                            \
-  template [[host_name("count_nonzero_prefix_sum_" #DTYPE)]] [[kernel]] void       \
-  count_nonzero_prefix_sum<DTYPE>(                                                 \
-      const device DTYPE* input [[buffer(0)]],                                     \
-      device int* prefix [[buffer(1)]],                                            \
-      device int* block_sums [[buffer(2)]],                                        \
-      constant uint& numel [[buffer(3)]],                                          \
-      uint tid [[thread_position_in_grid]],                                        \
-      uint lid [[thread_position_in_threadgroup]],                                 \
-      uint tgsize [[threads_per_threadgroup]],                                     \
-      uint tgid [[threadgroup_position_in_grid]],                                  \
-      uint simd_lane_id [[thread_index_in_simdgroup]],                             \
-      uint simd_group_id [[simdgroup_index_in_threadgroup]]);                      \
-                                                                                   \
-  template [[host_name("scatter_nonzero_indices_" #DTYPE)]] [[kernel]] void        \
-  scatter_nonzero_indices<DTYPE>(                                                  \
-      const device DTYPE* input [[buffer(0)]],                                     \
-      const device int* prefix [[buffer(1)]],                                      \
-      device int64_t* output [[buffer(2)]],                                        \
-      constant uint& numel [[buffer(3)]],                                          \
-      constant int& ndim [[buffer(4)]],                                            \
-      constant int64_t* sizes [[buffer(5)]],                                       \
-      constant int* block_offsets [[buffer(6)]],                                   \
-      uint tid [[thread_position_in_grid]],                                        \
+#define REGISTER_NONZERO_KERNELS(DTYPE)                                      \
+  template [[host_name("count_nonzero_prefix_sum_" #DTYPE)]] [[kernel]] void \
+  count_nonzero_prefix_sum<DTYPE>(                                           \
+      const device DTYPE* input [[buffer(0)]],                               \
+      device int* prefix [[buffer(1)]],                                      \
+      device int* block_sums [[buffer(2)]],                                  \
+      constant uint& numel [[buffer(3)]],                                    \
+      uint tid [[thread_position_in_grid]],                                  \
+      uint lid [[thread_position_in_threadgroup]],                           \
+      uint tgsize [[threads_per_threadgroup]],                               \
+      uint tgid [[threadgroup_position_in_grid]],                            \
+      uint simd_lane_id [[thread_index_in_simdgroup]],                       \
+      uint simd_group_id [[simdgroup_index_in_threadgroup]]);                \
+                                                                             \
+  template [[host_name("scatter_nonzero_indices_" #DTYPE)]] [[kernel]] void  \
+  scatter_nonzero_indices<DTYPE>(                                            \
+      const device DTYPE* input [[buffer(0)]],                               \
+      const device int* prefix [[buffer(1)]],                                \
+      device int64_t* output [[buffer(2)]],                                  \
+      constant uint& numel [[buffer(3)]],                                    \
+      constant int& ndim [[buffer(4)]],                                      \
+      constant int64_t* sizes [[buffer(5)]],                                 \
+      constant int* block_offsets [[buffer(6)]],                             \
+      uint tid [[thread_position_in_grid]],                                  \
       uint tgid [[threadgroup_position_in_grid]])
 
 REGISTER_NONZERO_KERNELS(float);

--- a/aten/src/ATen/native/mps/kernels/Indexing.metal
+++ b/aten/src/ATen/native/mps/kernels/Indexing.metal
@@ -794,25 +794,34 @@ INSTANTIATE_INDEX_FILL_FROM_MASK(half2)
 
 // Nonzero kernel implementation using prefix-sum + scatter approach.
 //
-// Phase 1 (count_nonzero_prefix_sum): Each threadgroup processes a chunk of the
-// flattened input. Within each threadgroup we compute an exclusive prefix sum
-// of the nonzero flags. The total count for each threadgroup is written to a
-// small auxiliary buffer (block_sums). The prefix sum values are written to a
-// temporary buffer (prefix) so phase 2 can look up output positions.
+// Step 1 (count_nonzero_prefix_sum): Each threadgroup computes an exclusive
+// prefix sum of the nonzero flags over its chunk. Per-threadgroup totals are
+// written to block_sums.
 //
-// Between phases the host reads back the block_sums, computes a CPU-side prefix
-// sum to get per-block offsets, and allocates the output tensor.
+// Step 2 (prefix_sum_blocks): A single threadgroup computes the exclusive
+// prefix sum of block_sums → block_offsets and writes the total nonzero count
+// to a 1-element buffer. The host reads back only that single int, then
+// allocates the output tensor.
 //
-// Phase 2 (scatter_nonzero_indices): Each thread with a nonzero element writes
+// Step 3 (scatter_nonzero_indices): Each thread with a nonzero element writes
 // its multi-dimensional indices into the output at the position determined by
-// block_offset + prefix[flat_idx].
+// block_offsets[tgid] + prefix[tid].
+
+template <typename T, enable_if_t<!is_complex_v<T>, bool> = true>
+inline bool is_nonzero(T val) {
+  return val != T(0);
+}
+
+template <typename T, enable_if_t<is_complex_v<T>, bool> = true>
+inline bool is_nonzero(T val) {
+  return val.x != 0 || val.y != 0;
+}
 
 template <typename T>
 kernel void count_nonzero_prefix_sum(
     const device T* input [[buffer(0)]],
     device int* prefix [[buffer(1)]],
     device int* block_sums [[buffer(2)]],
-    constant uint& numel [[buffer(3)]],
     uint tid [[thread_position_in_grid]],
     uint lid [[thread_position_in_threadgroup]],
     uint tgsize [[threads_per_threadgroup]],
@@ -821,10 +830,7 @@ kernel void count_nonzero_prefix_sum(
     uint simd_group_id [[simdgroup_index_in_threadgroup]]) {
   uint num_simds = (tgsize + simdgroup_size - 1) / simdgroup_size;
 
-  int flag = 0;
-  if (tid < numel) {
-    flag = (input[tid] != T(0)) ? 1 : 0;
-  }
+  int flag = is_nonzero(input[tid]) ? 1 : 0;
 
   // Inclusive prefix sum within SIMD group using shuffle
   int val = flag;
@@ -866,9 +872,7 @@ kernel void count_nonzero_prefix_sum(
 
   int exclusive_val = val - flag + simdgroup_offsets[simd_group_id];
 
-  if (tid < numel) {
-    prefix[tid] = exclusive_val;
-  }
+  prefix[tid] = exclusive_val;
 
   if (lid == tgsize - 1) {
     block_sums[tgid] =
@@ -876,7 +880,7 @@ kernel void count_nonzero_prefix_sum(
   }
 }
 
-// Phase 1.5: exclusive prefix sum of block_sums → block_offsets, and write
+// Step 2: exclusive prefix sum of block_sums → block_offsets, and write
 // total nonzero count to a 1-element buffer.  Runs in a single threadgroup
 // (num_blocks <= 32*32 = 1024 for numel < INT_MAX with TG_SIZE = 256).
 kernel void prefix_sum_blocks(
@@ -945,15 +949,12 @@ kernel void scatter_nonzero_indices(
     const device T* input [[buffer(0)]],
     const device int* prefix [[buffer(1)]],
     device int64_t* output [[buffer(2)]],
-    constant uint& numel [[buffer(3)]],
-    constant int& ndim [[buffer(4)]],
-    constant int64_t* sizes [[buffer(5)]],
-    constant int* block_offsets [[buffer(6)]],
+    constant int& ndim [[buffer(3)]],
+    constant int64_t* sizes [[buffer(4)]],
+    constant int* block_offsets [[buffer(5)]],
     uint tid [[thread_position_in_grid]],
     uint tgid [[threadgroup_position_in_grid]]) {
-  if (tid >= numel)
-    return;
-  if (input[tid] == T(0))
+  if (!is_nonzero(input[tid]))
     return;
 
   int pos = block_offsets[tgid] + prefix[tid];
@@ -973,7 +974,6 @@ kernel void scatter_nonzero_indices(
       const device DTYPE* input [[buffer(0)]],                               \
       device int* prefix [[buffer(1)]],                                      \
       device int* block_sums [[buffer(2)]],                                  \
-      constant uint& numel [[buffer(3)]],                                    \
       uint tid [[thread_position_in_grid]],                                  \
       uint lid [[thread_position_in_threadgroup]],                           \
       uint tgsize [[threads_per_threadgroup]],                               \
@@ -986,10 +986,9 @@ kernel void scatter_nonzero_indices(
       const device DTYPE* input [[buffer(0)]],                               \
       const device int* prefix [[buffer(1)]],                                \
       device int64_t* output [[buffer(2)]],                                  \
-      constant uint& numel [[buffer(3)]],                                    \
-      constant int& ndim [[buffer(4)]],                                      \
-      constant int64_t* sizes [[buffer(5)]],                                 \
-      constant int* block_offsets [[buffer(6)]],                             \
+      constant int& ndim [[buffer(3)]],                                      \
+      constant int64_t* sizes [[buffer(4)]],                                 \
+      constant int* block_offsets [[buffer(5)]],                             \
       uint tid [[thread_position_in_grid]],                                  \
       uint tgid [[threadgroup_position_in_grid]])
 
@@ -1002,3 +1001,5 @@ REGISTER_NONZERO_KERNELS(short);
 REGISTER_NONZERO_KERNELS(char);
 REGISTER_NONZERO_KERNELS(uchar);
 REGISTER_NONZERO_KERNELS(bool);
+REGISTER_NONZERO_KERNELS(float2);
+REGISTER_NONZERO_KERNELS(half2);

--- a/aten/src/ATen/native/mps/kernels/Indexing.metal
+++ b/aten/src/ATen/native/mps/kernels/Indexing.metal
@@ -818,6 +818,7 @@ inline bool is_nonzero(T val) {
 }
 
 template <typename T>
+[[max_total_threads_per_threadgroup(1024)]]
 kernel void count_nonzero_prefix_sum(
     const device T* input [[buffer(0)]],
     device int* prefix [[buffer(1)]],
@@ -881,8 +882,10 @@ kernel void count_nonzero_prefix_sum(
 }
 
 // Step 2: exclusive prefix sum of block_sums → block_offsets, and write
-// total nonzero count to a 1-element buffer.  Runs in a single threadgroup
-// (num_blocks <= 32*32 = 1024 for numel < INT_MAX with TG_SIZE = 256).
+// total nonzero count to a 1-element buffer.  Runs in a single threadgroup.
+// Each thread handles ceil(num_blocks / tgsize) consecutive blocks via a
+// serial loop, then the per-thread totals are scanned in parallel.
+[[max_total_threads_per_threadgroup(1024)]]
 kernel void prefix_sum_blocks(
     const device int* block_sums [[buffer(0)]],
     device int* block_offsets [[buffer(1)]],
@@ -894,10 +897,19 @@ kernel void prefix_sum_blocks(
     uint simd_group_id [[simdgroup_index_in_threadgroup]]) {
   uint num_simds = (tgsize + simdgroup_size - 1) / simdgroup_size;
 
-  int val_in = (lid < num_blocks) ? block_sums[lid] : 0;
+  // Each thread handles a contiguous chunk of blocks
+  uint chunk_size = (num_blocks + tgsize - 1) / tgsize;
+  uint start = lid * chunk_size;
+  uint end = min(start + chunk_size, num_blocks);
 
-  // Inclusive SIMD scan
-  int val = val_in;
+  // Serial sum over this thread's chunk
+  int chunk_total = 0;
+  for (uint i = start; i < end; i++) {
+    chunk_total += block_sums[i];
+  }
+
+  // Parallel inclusive prefix sum of chunk_totals across threads
+  int val = chunk_total;
   for (uint offset = 1; offset < simdgroup_size; offset <<= 1) {
     int other = simd_shuffle_and_fill_up(val, 0, static_cast<ushort>(offset));
     val += other;
@@ -930,10 +942,15 @@ kernel void prefix_sum_blocks(
   }
   threadgroup_barrier(mem_flags::mem_threadgroup);
 
-  int exclusive_val = val - val_in + simdgroup_offsets[simd_group_id];
+  // This thread's exclusive offset = inclusive_scan - chunk_total +
+  // simdgroup_offset
+  int thread_offset = val - chunk_total + simdgroup_offsets[simd_group_id];
 
-  if (lid < num_blocks) {
-    block_offsets[lid] = exclusive_val;
+  // Write block_offsets for this thread's chunk using a serial exclusive scan
+  int running = thread_offset;
+  for (uint i = start; i < end; i++) {
+    block_offsets[i] = running;
+    running += block_sums[i];
   }
 
   if (lid == tgsize - 1) {
@@ -945,6 +962,7 @@ kernel void prefix_sum_blocks(
 // Scatter the multi-dimensional indices of nonzero elements.
 // Output layout: out[position * ndim + d] = index along dimension d.
 template <typename T>
+[[max_total_threads_per_threadgroup(1024)]]
 kernel void scatter_nonzero_indices(
     const device T* input [[buffer(0)]],
     const device int* prefix [[buffer(1)]],

--- a/aten/src/ATen/native/mps/kernels/Indexing.metal
+++ b/aten/src/ATen/native/mps/kernels/Indexing.metal
@@ -799,3 +799,148 @@ INSTANTIATE_INDEX_FILL_FROM_MASK(uchar)
 INSTANTIATE_INDEX_FILL_FROM_MASK(bool)
 INSTANTIATE_INDEX_FILL_FROM_MASK(float2)
 INSTANTIATE_INDEX_FILL_FROM_MASK(half2)
+
+// Nonzero kernel implementation using prefix-sum + scatter approach.
+//
+// Phase 1 (count_nonzero_prefix_sum): Each threadgroup processes a chunk of the
+// flattened input. Within each threadgroup we compute an exclusive prefix sum of
+// the nonzero flags. The total count for each threadgroup is written to a small
+// auxiliary buffer (block_sums). The prefix sum values are written to a temporary
+// buffer (prefix) so phase 2 can look up output positions.
+//
+// Between phases the host reads back the block_sums, computes a CPU-side prefix
+// sum to get per-block offsets, and allocates the output tensor.
+//
+// Phase 2 (scatter_nonzero_indices): Each thread with a nonzero element writes
+// its multi-dimensional indices into the output at the position determined by
+// block_offset + prefix[flat_idx].
+
+template <typename T>
+kernel void count_nonzero_prefix_sum(
+    const device T* input [[buffer(0)]],
+    device int* prefix [[buffer(1)]],
+    device int* block_sums [[buffer(2)]],
+    constant uint& numel [[buffer(3)]],
+    uint tid [[thread_position_in_grid]],
+    uint lid [[thread_position_in_threadgroup]],
+    uint tgsize [[threads_per_threadgroup]],
+    uint tgid [[threadgroup_position_in_grid]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simd_group_id [[simdgroup_index_in_threadgroup]]) {
+
+  uint num_simds = (tgsize + simdgroup_size - 1) / simdgroup_size;
+
+  int flag = 0;
+  if (tid < numel) {
+    flag = (input[tid] != T(0)) ? 1 : 0;
+  }
+
+  // Inclusive prefix sum within SIMD group using shuffle
+  int val = flag;
+  for (uint offset = 1; offset < simdgroup_size; offset <<= 1) {
+    int other = simd_shuffle_and_fill_up(val, 0, static_cast<ushort>(offset));
+    val += other;
+  }
+
+  // The last lane in each simd group writes its total.
+  // For full groups this is lane 31; for the last (partial) group we compute
+  // which lane is actually last.
+  threadgroup int simdgroup_totals[32];
+  bool is_last_lane_in_simd;
+  if (simd_group_id < num_simds - 1) {
+    is_last_lane_in_simd = (simd_lane_id == simdgroup_size - 1);
+  } else {
+    uint lanes_in_last = tgsize - simd_group_id * simdgroup_size;
+    is_last_lane_in_simd = (simd_lane_id == lanes_in_last - 1);
+  }
+  if (is_last_lane_in_simd) {
+    simdgroup_totals[simd_group_id] = val;
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  // First simd group computes exclusive prefix sum of simd group totals
+  threadgroup int simdgroup_offsets[32];
+  if (simd_group_id == 0) {
+    int sg_val = (simd_lane_id < num_simds) ? simdgroup_totals[simd_lane_id] : 0;
+    for (uint offset = 1; offset < simdgroup_size; offset <<= 1) {
+      int other = simd_shuffle_and_fill_up(sg_val, 0, static_cast<ushort>(offset));
+      sg_val += other;
+    }
+    int exclusive = simd_shuffle_and_fill_up(sg_val, 0, static_cast<ushort>(1));
+    simdgroup_offsets[simd_lane_id] = exclusive;
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  int exclusive_val = val - flag + simdgroup_offsets[simd_group_id];
+
+  if (tid < numel) {
+    prefix[tid] = exclusive_val;
+  }
+
+  if (lid == tgsize - 1) {
+    block_sums[tgid] = simdgroup_offsets[num_simds - 1] + simdgroup_totals[num_simds - 1];
+  }
+}
+
+// Scatter the multi-dimensional indices of nonzero elements.
+// Output layout: out[position * ndim + d] = index along dimension d.
+template <typename T>
+kernel void scatter_nonzero_indices(
+    const device T* input [[buffer(0)]],
+    const device int* prefix [[buffer(1)]],
+    device int64_t* output [[buffer(2)]],
+    constant uint& numel [[buffer(3)]],
+    constant int& ndim [[buffer(4)]],
+    constant int64_t* sizes [[buffer(5)]],
+    constant int* block_offsets [[buffer(6)]],
+    uint tid [[thread_position_in_grid]],
+    uint tgid [[threadgroup_position_in_grid]]) {
+
+  if (tid >= numel) return;
+  if (input[tid] == T(0)) return;
+
+  int pos = block_offsets[tgid] + prefix[tid];
+
+  uint flat = tid;
+  for (int d = ndim - 1; d >= 0; d--) {
+    int64_t dim_size = sizes[d];
+    output[pos * ndim + d] = static_cast<int64_t>(flat % static_cast<uint>(dim_size));
+    flat /= static_cast<uint>(dim_size);
+  }
+}
+
+#define REGISTER_NONZERO_KERNELS(DTYPE)                                            \
+  template [[host_name("count_nonzero_prefix_sum_" #DTYPE)]] [[kernel]] void       \
+  count_nonzero_prefix_sum<DTYPE>(                                                 \
+      const device DTYPE* input [[buffer(0)]],                                     \
+      device int* prefix [[buffer(1)]],                                            \
+      device int* block_sums [[buffer(2)]],                                        \
+      constant uint& numel [[buffer(3)]],                                          \
+      uint tid [[thread_position_in_grid]],                                        \
+      uint lid [[thread_position_in_threadgroup]],                                 \
+      uint tgsize [[threads_per_threadgroup]],                                     \
+      uint tgid [[threadgroup_position_in_grid]],                                  \
+      uint simd_lane_id [[thread_index_in_simdgroup]],                             \
+      uint simd_group_id [[simdgroup_index_in_threadgroup]]);                      \
+                                                                                   \
+  template [[host_name("scatter_nonzero_indices_" #DTYPE)]] [[kernel]] void        \
+  scatter_nonzero_indices<DTYPE>(                                                  \
+      const device DTYPE* input [[buffer(0)]],                                     \
+      const device int* prefix [[buffer(1)]],                                      \
+      device int64_t* output [[buffer(2)]],                                        \
+      constant uint& numel [[buffer(3)]],                                          \
+      constant int& ndim [[buffer(4)]],                                            \
+      constant int64_t* sizes [[buffer(5)]],                                       \
+      constant int* block_offsets [[buffer(6)]],                                   \
+      uint tid [[thread_position_in_grid]],                                        \
+      uint tgid [[threadgroup_position_in_grid]])
+
+REGISTER_NONZERO_KERNELS(float);
+REGISTER_NONZERO_KERNELS(half);
+REGISTER_NONZERO_KERNELS(bfloat);
+REGISTER_NONZERO_KERNELS(long);
+REGISTER_NONZERO_KERNELS(int);
+REGISTER_NONZERO_KERNELS(short);
+REGISTER_NONZERO_KERNELS(char);
+REGISTER_NONZERO_KERNELS(uchar);
+REGISTER_NONZERO_KERNELS(bool);

--- a/aten/src/ATen/native/mps/operations/Indexing.mm
+++ b/aten/src/ATen/native/mps/operations/Indexing.mm
@@ -45,7 +45,6 @@
 #include <ATen/ops/view_as_real.h>
 #endif
 
-
 namespace at::native {
 namespace mps {
 
@@ -336,14 +335,16 @@ Tensor& nonzero_out_mps(const Tensor& self, Tensor& out_) {
   constexpr uint32_t threads_per_group = 256;
   uint32_t num_blocks = (numel + threads_per_group - 1) / threads_per_group;
 
-  // Allocate temporary buffers for prefix sums and block totals
+  // Allocate temporary buffers for prefix sums, block totals, and block offsets
   Tensor prefix_buf = at::empty({static_cast<int64_t>(numel)}, input.options().dtype(kInt));
   Tensor block_sums_buf = at::empty({static_cast<int64_t>(num_blocks)}, input.options().dtype(kInt));
+  Tensor block_offsets_buf = at::empty({static_cast<int64_t>(num_blocks)}, input.options().dtype(kInt));
+  Tensor total_nonzero_buf = at::empty({1}, input.options().dtype(kInt));
 
   MPSStream* stream = getCurrentMPSStream();
+  const auto type_str = scalarToMetalTypeString(input);
 
   // Phase 1: prefix sum + block totals
-  const auto type_str = scalarToMetalTypeString(input);
   dispatch_sync_with_rethrow(stream->queue(), ^() {
     @autoreleasepool {
       id<MTLComputeCommandEncoder> computeEncoder = stream->commandEncoder();
@@ -354,23 +355,23 @@ Tensor& nonzero_out_mps(const Tensor& self, Tensor& out_) {
       mtl_setArgs(computeEncoder, input, prefix_buf, block_sums_buf, numel);
       [computeEncoder dispatchThreads:MTLSizeMake(numel, 1, 1)
                 threadsPerThreadgroup:MTLSizeMake(threads_per_group, 1, 1)];
+
+      // Phase 1.5: GPU prefix sum of block_sums → block_offsets + total
+      id<MTLComputePipelineState> pso_blocks = lib.getPipelineStateForFunc("prefix_sum_blocks");
+      [computeEncoder setComputePipelineState:pso_blocks];
+      mtl_setArgs(computeEncoder, block_sums_buf, block_offsets_buf, total_nonzero_buf, num_blocks);
+      uint32_t tg_size_blocks = std::min(1024u, ((num_blocks + 31) / 32) * 32);
+      [computeEncoder dispatchThreads:MTLSizeMake(tg_size_blocks, 1, 1)
+                threadsPerThreadgroup:MTLSizeMake(tg_size_blocks, 1, 1)];
     }
   });
 
-  // Sync to read back block sums
+  // Sync to read back just the total count (1 int instead of all block_sums)
   dispatch_sync_with_rethrow(stream->queue(), ^() {
     stream->synchronize(SyncType::COMMIT_AND_WAIT);
   });
 
-  // Compute block offsets on CPU (exclusive prefix sum of block totals)
-  Tensor block_sums_cpu = block_sums_buf.to(kCPU);
-  auto* bs_ptr = block_sums_cpu.data_ptr<int>();
-  std::vector<int> block_offsets(num_blocks);
-  int64_t total_nonzero = 0;
-  for (uint32_t i = 0; i < num_blocks; i++) {
-    block_offsets[i] = static_cast<int>(total_nonzero);
-    total_nonzero += bs_ptr[i];
-  }
+  int64_t total_nonzero = total_nonzero_buf.item<int>();
 
   at::native::resize_output(out_, {total_nonzero, nDim});
   if (total_nonzero == 0 || out_.numel() == 0) {
@@ -380,18 +381,13 @@ Tensor& nonzero_out_mps(const Tensor& self, Tensor& out_) {
   bool contiguous_output = out_.is_contiguous();
   Tensor out = contiguous_output ? out_ : at::empty_like(out_, MemoryFormat::Contiguous);
 
-  // Upload block offsets and sizes to GPU
-  Tensor block_offsets_buf = at::empty({static_cast<int64_t>(num_blocks)}, input.options().dtype(kInt));
-  block_offsets_buf.copy_(
-      at::from_blob(block_offsets.data(), {static_cast<int64_t>(num_blocks)}, at::kInt));
-
   std::vector<int64_t> sizes_vec(input.sizes().begin(), input.sizes().end());
   Tensor sizes_buf = at::empty({nDim}, input.options().dtype(kLong));
   sizes_buf.copy_(at::from_blob(sizes_vec.data(), {nDim}, at::kLong));
 
   int ndim_int = static_cast<int>(nDim);
 
-  // Phase 2: scatter indices
+  // Phase 2: scatter indices (block_offsets already on GPU)
   dispatch_sync_with_rethrow(stream->queue(), ^() {
     @autoreleasepool {
       id<MTLComputeCommandEncoder> computeEncoder = stream->commandEncoder();

--- a/aten/src/ATen/native/mps/operations/Indexing.mm
+++ b/aten/src/ATen/native/mps/operations/Indexing.mm
@@ -377,7 +377,7 @@ Tensor& nonzero_out_mps(const Tensor& self, Tensor& out_) {
     return out_;
   }
 
-  bool contiguous_output = !needsGather(out_);
+  bool contiguous_output = out_.is_contiguous();
   Tensor out = contiguous_output ? out_ : at::empty_like(out_, MemoryFormat::Contiguous);
 
   // Upload block offsets and sizes to GPU

--- a/aten/src/ATen/native/mps/operations/Indexing.mm
+++ b/aten/src/ATen/native/mps/operations/Indexing.mm
@@ -29,7 +29,6 @@
 #include <ATen/native/IndexKernel.h>
 #include <ATen/ops/embedding_dense_backward_native.h>
 #include <ATen/ops/flip_native.h>
-#include <ATen/ops/from_blob.h>
 #include <ATen/ops/index.h>
 #include <ATen/ops/index_add_native.h>
 #include <ATen/ops/index_copy_native.h>
@@ -313,7 +312,6 @@ Tensor& nonzero_out_mps(const Tensor& self, Tensor& out_) {
               out_.device(),
               " and self on ",
               self.device());
-  TORCH_CHECK(self.dim() <= 16, "nonzero is not supported for tensor with more than 16 dimensions");
   TORCH_CHECK(out_.is_mps());
 
   Tensor input = self.contiguous();
@@ -370,9 +368,9 @@ Tensor& nonzero_out_mps(const Tensor& self, Tensor& out_) {
   // Step 3: scatter indices (block_offsets already on GPU)
   dispatch_sync_with_rethrow(stream->queue(), ^() {
     @autoreleasepool {
-      id<MTLComputeCommandEncoder> computeEncoder = stream->commandEncoder();
+      auto computeEncoder = stream->commandEncoder();
       auto kernel_name = fmt::format("scatter_nonzero_indices_{}", type_str);
-      id<MTLComputePipelineState> pso = lib.getPipelineStateForFunc(kernel_name);
+      auto pso = lib.getPipelineStateForFunc(kernel_name);
 
       [computeEncoder setComputePipelineState:pso];
       mtl_setArgs(computeEncoder, input, prefix_buf, out, ndim_int, input.sizes(), block_offsets_buf);

--- a/aten/src/ATen/native/mps/operations/Indexing.mm
+++ b/aten/src/ATen/native/mps/operations/Indexing.mm
@@ -289,25 +289,12 @@ TORCH_IMPL_FUNC(index_copy_out_mps)(const Tensor& self,
   });
 }
 
-static Tensor nonzero_fallback(const Tensor& self) {
-  return at::nonzero(self.to("cpu")).to("mps");
-}
-
 // Metal kernel-based nonzero using prefix-sum + scatter.
-// Phase 1: Compute per-element exclusive prefix sum of nonzero flags and
-//          per-threadgroup totals.
-// Host:    Read back block totals, compute block offsets, allocate output.
-// Phase 2: Scatter multi-dimensional indices into the output.
+// Step 1: Per-element exclusive prefix sum of nonzero flags + block totals.
+// Step 2: GPU prefix sum of block totals → block offsets + total count.
+// Host:   Read back 1 int (total count), allocate output.
+// Step 3: Scatter multi-dimensional indices into the output.
 Tensor& nonzero_out_mps(const Tensor& self, Tensor& out_) {
-  if (self.is_complex()) {
-    TORCH_WARN_ONCE("MPS: nonzero op is not supported for complex datatypes. ",
-                    "Falling back on CPU. This may have performance implications.");
-    Tensor out_fallback = nonzero_fallback(self);
-    at::native::resize_output(out_, out_fallback.sizes());
-    out_.copy_(out_fallback);
-    return out_;
-  }
-
   int64_t nDim = self.dim();
   if (self.numel() == 0) {
     at::native::resize_output(out_, {0, nDim});
@@ -330,34 +317,36 @@ Tensor& nonzero_out_mps(const Tensor& self, Tensor& out_) {
   TORCH_CHECK(out_.is_mps());
 
   Tensor input = self.contiguous();
-  uint32_t numel = static_cast<uint32_t>(input.numel());
+  const auto numel = static_cast<uint32_t>(input.numel());
 
   constexpr uint32_t threads_per_group = 256;
   uint32_t num_blocks = (numel + threads_per_group - 1) / threads_per_group;
 
-  // Allocate temporary buffers for prefix sums, block totals, and block offsets
-  Tensor prefix_buf = at::empty({static_cast<int64_t>(numel)}, input.options().dtype(kInt));
-  Tensor block_sums_buf = at::empty({static_cast<int64_t>(num_blocks)}, input.options().dtype(kInt));
-  Tensor block_offsets_buf = at::empty({static_cast<int64_t>(num_blocks)}, input.options().dtype(kInt));
-  Tensor total_nonzero_buf = at::empty({1}, input.options().dtype(kInt));
+  // Single allocation for all temporary int32 buffers:
+  // [prefix (numel) | block_sums (num_blocks) | block_offsets (num_blocks) | total (1)]
+  const auto tmp = at::empty({input.numel() + 2 * num_blocks + 1}, input.options().dtype(kInt));
+  Tensor prefix_buf = tmp.slice(0, 0, numel);
+  Tensor block_sums_buf = tmp.slice(0, numel, numel + num_blocks);
+  Tensor block_offsets_buf = tmp.slice(0, numel + num_blocks, numel + 2 * num_blocks);
+  Tensor total_nonzero_buf = tmp.slice(0, numel + 2 * num_blocks, numel + 2 * num_blocks + 1);
 
   MPSStream* stream = getCurrentMPSStream();
   const auto type_str = scalarToMetalTypeString(input);
 
-  // Phase 1: prefix sum + block totals
+  // Step 1: prefix sum + block totals
   dispatch_sync_with_rethrow(stream->queue(), ^() {
     @autoreleasepool {
-      id<MTLComputeCommandEncoder> computeEncoder = stream->commandEncoder();
+      auto computeEncoder = stream->commandEncoder();
       auto kernel_name = fmt::format("count_nonzero_prefix_sum_{}", type_str);
-      id<MTLComputePipelineState> pso = lib.getPipelineStateForFunc(kernel_name);
+      auto pso = lib.getPipelineStateForFunc(kernel_name);
 
       [computeEncoder setComputePipelineState:pso];
-      mtl_setArgs(computeEncoder, input, prefix_buf, block_sums_buf, numel);
+      mtl_setArgs(computeEncoder, input, prefix_buf, block_sums_buf);
       [computeEncoder dispatchThreads:MTLSizeMake(numel, 1, 1)
                 threadsPerThreadgroup:MTLSizeMake(threads_per_group, 1, 1)];
 
-      // Phase 1.5: GPU prefix sum of block_sums → block_offsets + total
-      id<MTLComputePipelineState> pso_blocks = lib.getPipelineStateForFunc("prefix_sum_blocks");
+      // Step 2: GPU prefix sum of block_sums → block_offsets + total
+      auto pso_blocks = lib.getPipelineStateForFunc("prefix_sum_blocks");
       [computeEncoder setComputePipelineState:pso_blocks];
       mtl_setArgs(computeEncoder, block_sums_buf, block_offsets_buf, total_nonzero_buf, num_blocks);
       uint32_t tg_size_blocks = std::min(1024u, ((num_blocks + 31) / 32) * 32);
@@ -366,28 +355,19 @@ Tensor& nonzero_out_mps(const Tensor& self, Tensor& out_) {
     }
   });
 
-  // Sync to read back just the total count (1 int instead of all block_sums)
-  dispatch_sync_with_rethrow(stream->queue(), ^() {
-    stream->synchronize(SyncType::COMMIT_AND_WAIT);
-  });
-
-  int64_t total_nonzero = total_nonzero_buf.item<int>();
+  const int64_t total_nonzero = total_nonzero_buf.item<int>();
 
   at::native::resize_output(out_, {total_nonzero, nDim});
-  if (total_nonzero == 0 || out_.numel() == 0) {
+  if (out_.numel() == 0) {
     return out_;
   }
 
   bool contiguous_output = out_.is_contiguous();
   Tensor out = contiguous_output ? out_ : at::empty_like(out_, MemoryFormat::Contiguous);
 
-  std::vector<int64_t> sizes_vec(input.sizes().begin(), input.sizes().end());
-  Tensor sizes_buf = at::empty({nDim}, input.options().dtype(kLong));
-  sizes_buf.copy_(at::from_blob(sizes_vec.data(), {nDim}, at::kLong));
-
   int ndim_int = static_cast<int>(nDim);
 
-  // Phase 2: scatter indices (block_offsets already on GPU)
+  // Step 3: scatter indices (block_offsets already on GPU)
   dispatch_sync_with_rethrow(stream->queue(), ^() {
     @autoreleasepool {
       id<MTLComputeCommandEncoder> computeEncoder = stream->commandEncoder();
@@ -395,7 +375,7 @@ Tensor& nonzero_out_mps(const Tensor& self, Tensor& out_) {
       id<MTLComputePipelineState> pso = lib.getPipelineStateForFunc(kernel_name);
 
       [computeEncoder setComputePipelineState:pso];
-      mtl_setArgs(computeEncoder, input, prefix_buf, out, numel, ndim_int, sizes_buf, block_offsets_buf);
+      mtl_setArgs(computeEncoder, input, prefix_buf, out, ndim_int, input.sizes(), block_offsets_buf);
       [computeEncoder dispatchThreads:MTLSizeMake(numel, 1, 1)
                 threadsPerThreadgroup:MTLSizeMake(threads_per_group, 1, 1)];
     }
@@ -409,12 +389,6 @@ Tensor& nonzero_out_mps(const Tensor& self, Tensor& out_) {
 }
 
 Tensor nonzero_mps(const Tensor& self) {
-  if (self.is_complex()) {
-    TORCH_WARN_ONCE("MPS: nonzero op is not supported for complex datatypes ",
-                    "Falling back on CPU. This may have performance implications.");
-    return nonzero_fallback(self);
-  }
-
   Tensor out = at::empty({0}, self.options().dtype(kLong));
   return nonzero_out_mps(self, out);
 }

--- a/aten/src/ATen/native/mps/operations/Indexing.mm
+++ b/aten/src/ATen/native/mps/operations/Indexing.mm
@@ -27,10 +27,9 @@
 #include <ATen/NativeFunctions.h>
 #else
 #include <ATen/native/IndexKernel.h>
-#include <ATen/ops/count_nonzero.h>
-#include <ATen/ops/count_nonzero_native.h>
 #include <ATen/ops/embedding_dense_backward_native.h>
 #include <ATen/ops/flip_native.h>
+#include <ATen/ops/from_blob.h>
 #include <ATen/ops/index.h>
 #include <ATen/ops/index_add_native.h>
 #include <ATen/ops/index_copy_native.h>
@@ -46,7 +45,6 @@
 #include <ATen/ops/view_as_real.h>
 #endif
 
-constexpr auto nonZeroMaxSize = 1UL << 24;
 
 namespace at::native {
 namespace mps {
@@ -296,52 +294,11 @@ static Tensor nonzero_fallback(const Tensor& self) {
   return at::nonzero(self.to("cpu")).to("mps");
 }
 
-static Tensor& nonzero_out_native_mps(const Tensor& self, Tensor& out_) {
-  using namespace mps;
-
-  int64_t nDim = self.dim();
-  MPSStream* stream = getCurrentMPSStream();
-  using CachedGraph = MPSUnaryCachedGraph;
-
-  dispatch_sync_with_rethrow(stream->queue(), ^() {
-    stream->synchronize(SyncType::COMMIT_AND_WAIT);
-  });
-  int64_t total_nonzero = at::count_nonzero(self).item<int64_t>();
-  at::native::resize_output(out_, {total_nonzero, nDim});
-  if (out_.numel() == 0) {
-    return out_;
-  }
-
-  bool contiguous_output = !needsGather(out_);
-  Tensor out = out_;
-  if (!contiguous_output) {
-    out = at::empty_like(out_, MemoryFormat::Contiguous);
-  }
-
-  @autoreleasepool {
-    std::string key = "nonzero_out_native_mps" + getTensorsStringKey(self);
-    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
-      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
-
-      MPSGraphTensor* outputTensor = [mpsGraph nonZeroIndicesOfTensor:inputTensor name:nil];
-
-      newCachedGraph->inputTensor_ = inputTensor;
-      newCachedGraph->outputTensor_ = outputTensor;
-    });
-
-    Placeholder selfPlaceholder = Placeholder(cachedGraph->inputTensor_, self);
-    Placeholder outputPlaceholder = Placeholder(cachedGraph->outputTensor_, out);
-    auto feeds = dictionaryFromPlaceholders(selfPlaceholder);
-    runMPSGraph(stream, cachedGraph->graph(), feeds, outputPlaceholder);
-  }
-
-  if (!contiguous_output) {
-    out_.copy_(out);
-  }
-
-  return out_;
-}
-
+// Metal kernel-based nonzero using prefix-sum + scatter.
+// Phase 1: Compute per-element exclusive prefix sum of nonzero flags and
+//          per-threadgroup totals.
+// Host:    Read back block totals, compute block offsets, allocate output.
+// Phase 2: Scatter multi-dimensional indices into the output.
 Tensor& nonzero_out_mps(const Tensor& self, Tensor& out_) {
   if (self.is_complex()) {
     TORCH_WARN_ONCE("MPS: nonzero op is not supported for complex datatypes. ",
@@ -359,11 +316,10 @@ Tensor& nonzero_out_mps(const Tensor& self, Tensor& out_) {
   }
 
   using namespace mps;
-  const uint32_t maxDimensions = 16;
 
   TORCH_CHECK(self.numel() < std::numeric_limits<int>::max(),
-              "nonzero is not supported for tensors with more than INT_MAX elements, \
-  See https://github.com/pytorch/pytorch/issues/51871");
+              "nonzero is not supported for tensors with more than INT_MAX elements, "
+              "See https://github.com/pytorch/pytorch/issues/51871");
   TORCH_CHECK(
       out_.dtype() == at::kLong, "Expected object of scalar type ", at::kLong, " as out, but got ", out_.dtype());
   TORCH_CHECK(self.device() == out_.device(),
@@ -371,54 +327,83 @@ Tensor& nonzero_out_mps(const Tensor& self, Tensor& out_) {
               out_.device(),
               " and self on ",
               self.device());
-  TORCH_CHECK(self.dim() <= maxDimensions, "nonzero is not supported for tensor with more than ", 16, " dimensions");
+  TORCH_CHECK(self.dim() <= 16, "nonzero is not supported for tensor with more than 16 dimensions");
   TORCH_CHECK(out_.is_mps());
 
-  if (!is_macos_13_or_newer(MacOSVersion::MACOS_VER_15_0_PLUS) &&
-      (self.numel() >= nonZeroMaxSize || self.is_complex())) {
-    TORCH_WARN_ONCE("MPS: nonzero op is not natively supported for the provided input on MacOS14",
-                    "Falling back on CPU. This may have performance implications.",
-                    "See github.com/pytorch/pytorch/issues/122916 for further info");
-    Tensor out_fallback = nonzero_fallback(self);
-    at::native::resize_output(out_, out_fallback.sizes());
-    out_.copy_(out_fallback);
-    return out_;
-  }
+  Tensor input = self.contiguous();
+  uint32_t numel = static_cast<uint32_t>(input.numel());
+
+  constexpr uint32_t threads_per_group = 256;
+  uint32_t num_blocks = (numel + threads_per_group - 1) / threads_per_group;
+
+  // Allocate temporary buffers for prefix sums and block totals
+  Tensor prefix_buf = at::empty({static_cast<int64_t>(numel)}, input.options().dtype(kInt));
+  Tensor block_sums_buf = at::empty({static_cast<int64_t>(num_blocks)}, input.options().dtype(kInt));
 
   MPSStream* stream = getCurrentMPSStream();
-  using CachedGraph = MPSUnaryCachedGraph;
 
+  // Phase 1: prefix sum + block totals
+  const auto type_str = scalarToMetalTypeString(input);
+  dispatch_sync_with_rethrow(stream->queue(), ^() {
+    @autoreleasepool {
+      id<MTLComputeCommandEncoder> computeEncoder = stream->commandEncoder();
+      auto kernel_name = fmt::format("count_nonzero_prefix_sum_{}", type_str);
+      id<MTLComputePipelineState> pso = lib.getPipelineStateForFunc(kernel_name);
+
+      [computeEncoder setComputePipelineState:pso];
+      mtl_setArgs(computeEncoder, input, prefix_buf, block_sums_buf, numel);
+      [computeEncoder dispatchThreads:MTLSizeMake(numel, 1, 1)
+                threadsPerThreadgroup:MTLSizeMake(threads_per_group, 1, 1)];
+    }
+  });
+
+  // Sync to read back block sums
   dispatch_sync_with_rethrow(stream->queue(), ^() {
     stream->synchronize(SyncType::COMMIT_AND_WAIT);
   });
-  int64_t total_nonzero = at::count_nonzero(self).item<int64_t>();
+
+  // Compute block offsets on CPU (exclusive prefix sum of block totals)
+  Tensor block_sums_cpu = block_sums_buf.to(kCPU);
+  auto* bs_ptr = block_sums_cpu.data_ptr<int>();
+  std::vector<int> block_offsets(num_blocks);
+  int64_t total_nonzero = 0;
+  for (uint32_t i = 0; i < num_blocks; i++) {
+    block_offsets[i] = static_cast<int>(total_nonzero);
+    total_nonzero += bs_ptr[i];
+  }
+
   at::native::resize_output(out_, {total_nonzero, nDim});
-  if (out_.numel() == 0) {
+  if (total_nonzero == 0 || out_.numel() == 0) {
     return out_;
   }
 
   bool contiguous_output = !needsGather(out_);
-  Tensor out = out_;
-  if (!contiguous_output) {
-    out = at::empty_like(out_, MemoryFormat::Contiguous);
-  }
+  Tensor out = contiguous_output ? out_ : at::empty_like(out_, MemoryFormat::Contiguous);
 
-  @autoreleasepool {
-    std::string key = "nonzero_out_native_mps" + getTensorsStringKey(self);
-    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
-      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
+  // Upload block offsets and sizes to GPU
+  Tensor block_offsets_buf = at::empty({static_cast<int64_t>(num_blocks)}, input.options().dtype(kInt));
+  block_offsets_buf.copy_(
+      at::from_blob(block_offsets.data(), {static_cast<int64_t>(num_blocks)}, at::kInt));
 
-      MPSGraphTensor* outputTensor = [mpsGraph nonZeroIndicesOfTensor:inputTensor name:nil];
+  std::vector<int64_t> sizes_vec(input.sizes().begin(), input.sizes().end());
+  Tensor sizes_buf = at::empty({nDim}, input.options().dtype(kLong));
+  sizes_buf.copy_(at::from_blob(sizes_vec.data(), {nDim}, at::kLong));
 
-      newCachedGraph->inputTensor_ = inputTensor;
-      newCachedGraph->outputTensor_ = outputTensor;
-    });
+  int ndim_int = static_cast<int>(nDim);
 
-    Placeholder selfPlaceholder = Placeholder(cachedGraph->inputTensor_, self);
-    Placeholder outputPlaceholder = Placeholder(cachedGraph->outputTensor_, out);
-    auto feeds = dictionaryFromPlaceholders(selfPlaceholder);
-    runMPSGraph(stream, cachedGraph->graph(), feeds, outputPlaceholder);
-  }
+  // Phase 2: scatter indices
+  dispatch_sync_with_rethrow(stream->queue(), ^() {
+    @autoreleasepool {
+      id<MTLComputeCommandEncoder> computeEncoder = stream->commandEncoder();
+      auto kernel_name = fmt::format("scatter_nonzero_indices_{}", type_str);
+      id<MTLComputePipelineState> pso = lib.getPipelineStateForFunc(kernel_name);
+
+      [computeEncoder setComputePipelineState:pso];
+      mtl_setArgs(computeEncoder, input, prefix_buf, out, numel, ndim_int, sizes_buf, block_offsets_buf);
+      [computeEncoder dispatchThreads:MTLSizeMake(numel, 1, 1)
+                threadsPerThreadgroup:MTLSizeMake(threads_per_group, 1, 1)];
+    }
+  });
 
   if (!contiguous_output) {
     out_.copy_(out);

--- a/aten/src/ATen/native/mps/operations/Indexing.mm
+++ b/aten/src/ATen/native/mps/operations/Indexing.mm
@@ -291,7 +291,7 @@ TORCH_IMPL_FUNC(index_copy_out_mps)(const Tensor& self,
 // Metal kernel-based nonzero using prefix-sum + scatter.
 // Step 1: Per-element exclusive prefix sum of nonzero flags + block totals.
 // Step 2: GPU prefix sum of block totals → block offsets + total count.
-// Host:   Read back 1 int (total count), allocate output.
+// Host:   Read back total count, allocate output.
 // Step 3: Scatter multi-dimensional indices into the output.
 Tensor& nonzero_out_mps(const Tensor& self, Tensor& out_) {
   int64_t nDim = self.dim();
@@ -305,8 +305,7 @@ Tensor& nonzero_out_mps(const Tensor& self, Tensor& out_) {
   TORCH_CHECK(self.numel() < std::numeric_limits<int>::max(),
               "nonzero is not supported for tensors with more than INT_MAX elements, "
               "See https://github.com/pytorch/pytorch/issues/51871");
-  TORCH_CHECK(
-      out_.dtype() == at::kLong, "Expected object of scalar type ", at::kLong, " as out, but got ", out_.dtype());
+  TORCH_CHECK(out_.dtype() == at::kLong, "Expected output type to be Long, but got ", out_.dtype());
   TORCH_CHECK(self.device() == out_.device(),
               "expected self and out to be on the same device, but got out on ",
               out_.device(),
@@ -316,36 +315,38 @@ Tensor& nonzero_out_mps(const Tensor& self, Tensor& out_) {
 
   Tensor input = self.contiguous();
   const auto numel = static_cast<uint32_t>(input.numel());
+  const auto type_str = scalarToMetalTypeString(input);
+  MPSStream* stream = getCurrentMPSStream();
 
-  constexpr uint32_t threads_per_group = 256;
+  // All three kernels declare [[max_total_threads_per_threadgroup(1024)]]
+  // so mtl_dispatch1DJob picks the same threadgroup size for steps 1 and 3,
+  // ensuring tgid in scatter matches block_offsets from the prefix sum.
+  auto pso_step1 = lib.getPipelineStateForFunc(fmt::format("count_nonzero_prefix_sum_{}", type_str));
+  auto pso_step2 = lib.getPipelineStateForFunc("prefix_sum_blocks");
+  auto pso_step3 = lib.getPipelineStateForFunc(fmt::format("scatter_nonzero_indices_{}", type_str));
+  TORCH_INTERNAL_ASSERT([pso_step1 maxTotalThreadsPerThreadgroup] == [pso_step3 maxTotalThreadsPerThreadgroup],
+                        "nonzero: step 1 and step 3 threadgroup sizes must match");
+
+  uint32_t threads_per_group = static_cast<uint32_t>([pso_step1 maxTotalThreadsPerThreadgroup]);
   uint32_t num_blocks = (numel + threads_per_group - 1) / threads_per_group;
 
-  // Single allocation for all temporary int32 buffers:
-  // [prefix (numel) | block_sums (num_blocks) | block_offsets (num_blocks) | total (1)]
-  const auto tmp = at::empty({input.numel() + 2 * num_blocks + 1}, input.options().dtype(kInt));
+  // Single allocation: [prefix | block_sums | block_offsets | total]
+  auto tmp = at::empty({input.numel() + 2 * num_blocks + 1}, input.options().dtype(kInt));
   Tensor prefix_buf = tmp.slice(0, 0, numel);
   Tensor block_sums_buf = tmp.slice(0, numel, numel + num_blocks);
   Tensor block_offsets_buf = tmp.slice(0, numel + num_blocks, numel + 2 * num_blocks);
   Tensor total_nonzero_buf = tmp.slice(0, numel + 2 * num_blocks, numel + 2 * num_blocks + 1);
 
-  MPSStream* stream = getCurrentMPSStream();
-  const auto type_str = scalarToMetalTypeString(input);
-
-  // Step 1: prefix sum + block totals
+  // Steps 1+2: compute prefix sums and block offsets entirely on GPU
   dispatch_sync_with_rethrow(stream->queue(), ^() {
     @autoreleasepool {
       auto computeEncoder = stream->commandEncoder();
-      auto kernel_name = fmt::format("count_nonzero_prefix_sum_{}", type_str);
-      auto pso = lib.getPipelineStateForFunc(kernel_name);
 
-      [computeEncoder setComputePipelineState:pso];
+      [computeEncoder setComputePipelineState:pso_step1];
       mtl_setArgs(computeEncoder, input, prefix_buf, block_sums_buf);
-      [computeEncoder dispatchThreads:MTLSizeMake(numel, 1, 1)
-                threadsPerThreadgroup:MTLSizeMake(threads_per_group, 1, 1)];
+      mtl_dispatch1DJob(computeEncoder, pso_step1, numel);
 
-      // Step 2: GPU prefix sum of block_sums → block_offsets + total
-      auto pso_blocks = lib.getPipelineStateForFunc("prefix_sum_blocks");
-      [computeEncoder setComputePipelineState:pso_blocks];
+      [computeEncoder setComputePipelineState:pso_step2];
       mtl_setArgs(computeEncoder, block_sums_buf, block_offsets_buf, total_nonzero_buf, num_blocks);
       uint32_t tg_size_blocks = std::min(1024u, ((num_blocks + 31) / 32) * 32);
       [computeEncoder dispatchThreads:MTLSizeMake(tg_size_blocks, 1, 1)
@@ -369,13 +370,9 @@ Tensor& nonzero_out_mps(const Tensor& self, Tensor& out_) {
   dispatch_sync_with_rethrow(stream->queue(), ^() {
     @autoreleasepool {
       auto computeEncoder = stream->commandEncoder();
-      auto kernel_name = fmt::format("scatter_nonzero_indices_{}", type_str);
-      auto pso = lib.getPipelineStateForFunc(kernel_name);
-
-      [computeEncoder setComputePipelineState:pso];
+      [computeEncoder setComputePipelineState:pso_step3];
       mtl_setArgs(computeEncoder, input, prefix_buf, out, ndim_int, input.sizes(), block_offsets_buf);
-      [computeEncoder dispatchThreads:MTLSizeMake(numel, 1, 1)
-                threadsPerThreadgroup:MTLSizeMake(threads_per_group, 1, 1)];
+      mtl_dispatch1DJob(computeEncoder, pso_step3, numel);
     }
   });
 

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -11721,6 +11721,18 @@ class TestAdvancedIndexing(TestCaseMPS):
         self.assertEqual(dst1, dst4, atol=0, rtol=0)
         self.assertEqual(strides, dst4.stride())
 
+    def test_nonzero_large(self):
+        # Regression test: with 2M elements and threadgroup size 1024, the
+        # prefix_sum_blocks kernel must handle ~1954 blocks via its
+        # multi-element-per-thread loop (each thread processes
+        # ceil(num_blocks/tg_size) blocks). This verifies correctness when
+        # the block count exceeds a single threadgroup.
+        x = torch.rand(2_000_000, device="mps")
+        x[x > 0.5] = 0
+        result = torch.nonzero(x)
+        expected = torch.nonzero(x.cpu())
+        self.assertEqual(result.cpu(), expected)
+
     def test_nonzero_non_diff(self):
         device = "mps"
         x = torch.randn(10, requires_grad=True, device=device)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #178484

Idea borrowed from both CUDA implementation:
- `count_nonzero_prefix_sum`: each threadgroup computes a SIMD-shuffle-based exclusive prefix sum of nonzero flags over the flattened input. Per-threadgroup totals are written to a small auxiliary buffer. The host reads these back, computes block offsets via a CPU-side prefix sum, and allocates the output tensor.

- Unlike CUDA replace the CPU-side blocks prefix sum with  `prefix_sum_blocks` kernel  that computes block offsets on-device and writes the total nonzero count

- Copy total non-zero count back to CPU, and resize output buffer

- `scatter_nonzero_indices`: each thread with a nonzero element uses its prefix-sum value plus its block offset to write the multi-dimensional indices directly into the output.

This eliminates the prior approach that called `at::count_nonzero` (a full MPSGraph reduction) followed by `nonZeroIndicesOfTensor` (another MPSGraph pass), replacing two graph compilations and two full data passes with a single counting pass and a lightweight scatter.

Removes fallback-to-CPU path for 2^24+ elements as well as complex numbers that were workarounds for MPSGraph limitations.

Per benchmark script below, above yields about 3x perf gain over existing MPSGraph implementation. 
See some examples collected on M5 Pro

| Size | Sparsity | Before (us) | After (us) | Speedup |
|------|----------|-------------|------------|---------|
| 10K  | 0.5      | 506         | 163        | 3.1x    |
| 100K | 0.5      | 515         | 165        | 3.1x    |
| 1M   | 0.2      | 612         | 208        | 2.9x    |
| 1M   | 0.8      | 738         | 216        | 3.4x    |
| (100,100)  | 0.5      | 519         | 165        | 3.1x    |
| (1000,100) | 0.5      | 529         | 171        | 3.1x    |




<details>

<summary>Benchmark script</summary>

```python
import torch
import torch.utils.benchmark as benchmark
import itertools

sizes = [
    (10_000,),
    (100_000,),
    (1_000_000,),
]

sizes_2d = [
    (100, 100),
    (1000, 100),
]

sparsities = [0.2, 0.6, 0.8]

dtypes = [torch.float]


def make_input(size, sparsity, dtype, device, transposed=False):
    if dtype == torch.bool:
        x = torch.rand(size, device=device) < sparsity
    else:
        x = torch.randn(size, device=device, dtype=dtype)
        zero_mask = torch.rand(size, device=device) >= sparsity
        x[zero_mask] = 0
    if transposed and x.dim() >= 2:
        x = x.t()
    return x


def bench(x, label):
    t = benchmark.Timer(
        stmt="torch.nonzero(x)",
        globals={"torch": torch, "x": x},
        num_threads=torch.get_num_threads(),
    )
    for _ in range(2):
        result = t.timeit(1000)
    return result.median


def run_benchmark(device):
    print(f"{'layout':>12} {'dtype':>12} {'size':>20} {'sparsity':>8} {'median':>12}")
    print("-" * 70)

    # 1D contiguous
    for dtype, size, sparsity in itertools.product(dtypes, sizes, sparsities):
        x = make_input(size, sparsity, dtype, device)
        m = bench(x, "1d")
        size_str = str(size).replace(" ", "")
        print(f"{'contiguous':>12} {str(dtype):>12} {size_str:>20} {sparsity:>8.2f} {m:>12.3e}")

    print()

    # 2D contiguous vs transposed
    for dtype, size, sparsity in itertools.product(dtypes, sizes_2d, sparsities):
        x_c = make_input(size, sparsity, dtype, device, transposed=False)
        x_t = make_input(size, sparsity, dtype, device, transposed=True)
        m_c = bench(x_c, "contig")
        m_t = bench(x_t, "transposed")
        size_str = str(size).replace(" ", "")
        print(f"{'contiguous':>12} {str(dtype):>12} {size_str:>20} {sparsity:>8.2f} {m_c:>12.3e}")
        print(f"{'transposed':>12} {str(dtype):>12} {size_str:>20} {sparsity:>8.2f} {m_t:>12.3e}")


run_benchmark("mps")
```
</details>

Fixes https://github.com/pytorch/pytorch/issues/178079

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>