### PR TITLE
[auto functionalize][partitioner] Support auto_functionalized_v2 in can_fuse_into_auto_functionalized

### DIFF
--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -2063,23 +2063,29 @@ def solve_min_cut(
         log.info("Ops banned from re-materialization: %s", ops_ignored)
 
     def can_fuse_into_auto_functionalized(a: fx.Node, b: fx.Node) -> bool:
-        if b.target != torch.ops.higher_order.auto_functionalized:
-            return False
-        mutable_op = b.args[0]
-        (
-            mutable_arg_names,
-            _,
-        ) = torch._higher_order_ops.auto_functionalize.get_mutable_args(
-            # pyrefly: ignore[bad-argument-type]
-            mutable_op
-        )
-        for name in mutable_arg_names:  # pyrefly: ignore [not-iterable]
-            arg = b.kwargs[name]
-            if a is arg:
-                return True
-            if isinstance(arg, list):
-                if a in arg:
+        if b.target == torch.ops.higher_order.auto_functionalized:
+            mutable_op = b.args[0]
+            (
+                mutable_arg_names,
+                _,
+            ) = torch._higher_order_ops.auto_functionalize.get_mutable_args(
+                # pyrefly: ignore[bad-argument-type]
+                mutable_op
+            )
+            for name in mutable_arg_names:  # pyrefly: ignore [not-iterable]
+                arg = b.kwargs[name]
+                if a is arg:
                     return True
+                if isinstance(arg, list):
+                    if a in arg:
+                        return True
+            return False
+        elif b.target == torch.ops.higher_order.auto_functionalized_v2:
+            all_bases = b.kwargs.get("_all_bases", [])
+            for base in all_bases:
+                if a is base:
+                    return True
+            return False
         return False
 
     def can_fuse_into_triton_kernel_wrapper_functional(a: fx.Node, b: fx.Node) -> bool:


### PR DESCRIPTION
## Summary

The partitioner function `can_fuse_into_auto_functionalized` only checked for `auto_functionalized` (v1) but not `auto_functionalized_v2`. When `ones_like` is used in a model and the in-place operation is captured as `auto_functionalized_v2`, the partitioner fails to recognize that `aten.full` (from `ones_like` decomposition) can be fused, causing it to be saved in the forward graph instead of being recomputed in the backward graph.

## Root Cause

In the AOT Autograd graph construction:
1. `ones_like` decomposes into `aten.full`
2. The subsequent in-place op (`sin_`) is captured as `auto_functionalized_v2` (a Higher-Order Op)
3. The partitioner algorithm iterates nodes to determine recomputability and calls `is_materialized_backwards(node)`
4. It checks `is_fusible(full, auto_functionalized_v2_user)` which calls `can_fuse_into_auto_functionalized`
5. Since `can_fuse_into_auto_functionalized` only checked for v1, `can_fuse_into_auto_functionalized(a, b)` returns **False**
6. Since fusible is False, `is_materialized_backwards` returns True, forcing `aten.full` to be saved in the forward graph

## Fix

Add an `elif` branch to handle `auto_functionalized_v2` by checking if the node is in the `_all_bases` kwarg:

```python
elif b.target == torch.ops.higher_order.auto_functionalized_v2:
    all_bases = b.kwargs.get("_all_bases", [])
    for base in all_bases:
        if a is base:
            return True
    return False
```

Fixes #170160