### PR TITLE
[c10d][NCCL] avoid reusing scalable init store keys across communicat…

### DIFF
--- a/test/cpp/c10d/ProcessGroupNCCLTest.cpp
+++ b/test/cpp/c10d/ProcessGroupNCCLTest.cpp
@@ -1,5 +1,6 @@
 #include <chrono>
 #include <iostream>
+#include <unordered_set>
 
 #include <torch/csrc/distributed/c10d/FileStore.hpp>
 #include <torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp>
@@ -17,6 +18,11 @@
 using namespace c10d::test;
 
 using at::cuda::CUDAStream;
+
+class ProcessGroupNCCLTestAccessor : public c10d::ProcessGroupNCCL {
+ public:
+  using ProcessGroupNCCL::buildScalableInitStoreKeys;
+};
 
 class NCCLTestBase {
  public:
@@ -859,6 +865,23 @@ TEST_F(ProcessGroupNCCLTest, testBackendName) {
   EXPECT_EQ(
       test.getProcessGroup()->getBackendName(),
       std::string(c10d::NCCL_BACKEND_NAME));
+}
+
+TEST_F(ProcessGroupNCCLTest, testScalableInitStoreKeysAreNamespacedPerRound) {
+  auto round1Keys =
+      ProcessGroupNCCLTestAccessor::buildScalableInitStoreKeys(/*numRoots=*/24, 1);
+  auto round12Keys =
+      ProcessGroupNCCLTestAccessor::buildScalableInitStoreKeys(/*numRoots=*/4, 12);
+
+  EXPECT_EQ(round1Keys.size(), 24);
+  EXPECT_EQ(round12Keys.size(), 4);
+  EXPECT_EQ(round1Keys[0], "UniqueNCCLID:1:0");
+  EXPECT_EQ(round12Keys[3], "UniqueNCCLID:12:3");
+  EXPECT_NE(round1Keys[23], round12Keys[3]);
+
+  std::unordered_set<std::string> uniqueKeys(
+      round1Keys.begin(), round1Keys.end());
+  EXPECT_EQ(uniqueKeys.size(), round1Keys.size());
 }
 
 TEST_F(ProcessGroupNCCLTest, testSplittingCommunicator) {

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -2976,9 +2976,10 @@ void ProcessGroupNCCL::allgatherUniqueNCCLIDs(
       globalRankStart_, // globalRankStart_
       globalRankStride_, // globalRankStride_
       size_); // worldSize
-
+  std::string commCounterStr = std::to_string(ncclCommCounter_++);
   for (size_t r = 0; r < ncclIDs.size(); r++) {
-    storeKeys.emplace_back("UniqueNCCLID:" + std::to_string(r));
+    storeKeys.emplace_back(
+        "UniqueNCCLID:" + commCounterStr + std::to_string(r));
   }
   // For non-root rank, rootIdx is set to -1.
   if (rootIdx >= 0) {

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -2954,6 +2954,17 @@ void ProcessGroupNCCL::broadcastUniqueNCCLID(
   }
 }
 
+std::vector<std::string> ProcessGroupNCCL::buildScalableInitStoreKeys(
+    size_t numRoots,
+    uint64_t commCounter) {
+  std::vector<std::string> storeKeys;
+  storeKeys.reserve(numRoots);
+  for (size_t r = 0; r < numRoots; r++) {
+    storeKeys.emplace_back(c10::str("UniqueNCCLID:", commCounter, ":", r));
+  }
+  return storeKeys;
+}
+
 // We want to all-gather unique NCCL IDs from all roots using TCPStore.
 // This is first done by setting the ID by each root and then `multiGet` by all
 // ranks.
@@ -2976,11 +2987,7 @@ void ProcessGroupNCCL::allgatherUniqueNCCLIDs(
       globalRankStart_, // globalRankStart_
       globalRankStride_, // globalRankStride_
       size_); // worldSize
-  std::string commCounterStr = std::to_string(ncclCommCounter_++);
-  for (size_t r = 0; r < ncclIDs.size(); r++) {
-    storeKeys.emplace_back(
-        "UniqueNCCLID:" + commCounterStr + std::to_string(r));
-  }
+  storeKeys = buildScalableInitStoreKeys(ncclIDs.size(), ncclCommCounter_++);
   // For non-root rank, rootIdx is set to -1.
   if (rootIdx >= 0) {
     auto vec = std::vector<uint8_t>(

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -1049,6 +1049,12 @@ class TORCH_API ProcessGroupNCCL : public Backend {
       const c10::intrusive_ptr<Work>& work,
       const std::chrono::milliseconds& timeout);
 
+  // Helper to namespace scalable-init store keys across communicator
+  // initialization rounds.
+  static std::vector<std::string> buildScalableInitStoreKeys(
+      size_t numRoots,
+      uint64_t commCounter);
+
   void setEnableNanCheck(bool enableNanCheck);
 
   // APIs related to memory offload (require NCCL 2.29.7+ at runtime)


### PR DESCRIPTION
## Summary

Fix a scalable NCCL initialization bug where `allgatherUniqueNCCLIDs()` reused the same store key namespace across different communicator initialization rounds.

Under scalable init, later communicator-init rounds may observe stale `ncclUniqueId` values left behind by earlier rounds, which can lead to mismatched communicator IDs across ranks and eventual bootstrap failures.

This change factors scalable-init store key construction into a helper and namespaces the keys with both a per-communicator counter and an explicit delimiter, so different initialization rounds no longer share or collide on the same key namespace.

Fixes #178473

## External Repro

I reproduced this on a 4xH800 setup using a small external repro that:
- enables scalable init with `TORCH_NCCL_RANKS_PER_ROOT=1`
- creates multiple communicator-init rounds within the same process group
- introduces rank skew between rounds

In the failing run:
- round 0 completed successfully on all ranks
- round 1 triggered another scalable communicator initialization
- different ranks entered `ncclCommInitRankScalable` with different `commId` values
- the run then failed during NCCL bootstrap with repeated `socketPollConnect: connect returned Connection refused`

## Test Plan

- ran the external repro on a 4xH800 worker
- observed round-0 success and round-1 communicator ID divergence before the fix
- added an in-tree C++ regression test in `test/cpp/c10d/ProcessGroupNCCLTest.cpp`
- the regression test verifies scalable-init store keys are namespaced per communicator round and do not collide across rounds

## Notes

The in-tree regression test is implemented as a deterministic white-box test for scalable-init store key generation, instead of a timing-sensitive multi-GPU race test.