### PR TITLE
Rework XPU addmv_out to correctly preserve strides for non-contiguous output.

### DIFF
--- a/aten/src/ATen/native/mkldnn/xpu/Blas.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/Blas.cpp
@@ -381,16 +381,24 @@ Tensor& addmv_out(
 
   bool is_float64 =
       mat.scalar_type() == at::kDouble || vec.scalar_type() == at::kDouble;
-  bool is_inplace = self.is_same(out);
-  if (is_float64 && is_inplace) {
-    Tensor self_v_copy = self_v.clone();
-    at::native::xpu::addmm_out(self_v_copy, mat, vec_v, beta, alpha, out);
-    out.resize_({mat.size(0)});
-    return out;
+  bool need_preserve_strides =
+      out.dim() == 1 && out.stride(0) != 1 && out.numel() > 0;
+
+  if (is_float64 && self.is_same(out) && !need_preserve_strides) {
+    self_v = self_v.clone();
   }
 
-  at::native::xpu::addmm_out(self_v, mat, vec_v, beta, alpha, out);
-  out.resize_({mat.size(0)});
+  // addmm_out resizes its output to 2D, destroying stride information.
+  // When out has noncontiguous strides, compute into a temporary and copy back.
+  if (need_preserve_strides) {
+    Tensor tmp = at::empty({mat.size(0)}, out.options());
+    at::native::xpu::addmm_out(self_v, mat, vec_v, beta, alpha, tmp);
+    tmp.resize_({mat.size(0)});
+    out.copy_(tmp);
+  } else {
+    at::native::xpu::addmm_out(self_v, mat, vec_v, beta, alpha, out);
+    out.resize_({mat.size(0)});
+  }
   return out;
 }
 

--- a/test/xpu/test_gemm.py
+++ b/test/xpu/test_gemm.py
@@ -1019,6 +1019,33 @@ class TestBasicGEMM(TestCase):
         ):
             _test(row_major, incx, incy, lda_tail)
 
+    @dtypes(torch.double, torch.float32, torch.bfloat16, torch.half)
+    @tf32_on_and_off()
+    def test_addmv_out_noncontiguous_preserves_strides(self, device, dtype):
+        M, K = 5, 3
+        mat = torch.randn(M, K, device=device, dtype=dtype)
+        vec = torch.randn(K, device=device, dtype=dtype)
+        bias = torch.randn(M, device=device, dtype=dtype)
+
+        expected = torch.addmv(bias, mat, vec)
+
+        # Create a noncontiguous output tensor (stride != 1)
+        out = make_tensor((M,), device=device, dtype=dtype, noncontiguous=True)
+        original_stride = out.stride()
+        original_ptr = out.data_ptr()
+
+        torch.addmv(bias, mat, vec, out=out)
+
+        self.assertEqual(out, expected)
+        self.assertEqual(
+            out.stride(),
+            original_stride,
+            "addmv out= must preserve noncontiguous strides",
+        )
+        self.assertEqual(
+            out.data_ptr(), original_ptr, "addmv out= must not reallocate storage"
+        )
+
     @precisionOverride(
         {
             torch.float: 1e-4,


### PR DESCRIPTION
When running addmv_out with non-contiguous output tensor, stride information was lost, due to reshaping the 1D vector to 2D, causing incorrect output strides.
This PR changes the behaviour to compute into a temporary tensor and then copy with correct strides to the output.

Fixes: https://github.com/intel/torch-xpu-ops/issues/3194

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01