### PR TITLE
[ROCm] Fix flash attention backward meta stride mismatch

### DIFF
--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -8024,7 +8024,7 @@ class ReproTestsDevice(torch._dynamo.test_case.TestCase):
 
     @skipIfHpu
     @unittest.skipIf(
-        TEST_WITH_ROCM or not PLATFORM_SUPPORTS_FLASH_ATTENTION,
+        not PLATFORM_SUPPORTS_FLASH_ATTENTION,
         "flash attention not supported",
     )
     def test_flash_attn_backward_mixed_strides(self, device):

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -6050,7 +6050,8 @@ def meta__scaled_dot_product_flash_backward(
 ):
     grad_q = torch.empty_like(query)
     grad_k = torch.empty_like(key)
-    grad_v = torch.empty_like(value)
+    # eager returns contiguous grad_v, empty_like would keep transposed strides.
+    grad_v = torch.empty_like(value, memory_format=torch.contiguous_format)
     return grad_q, grad_k, grad_v
 
 


### PR DESCRIPTION
Fixes #168540
Fixes #168541

#### Summary
UT - `test_flash_attn_backward_mixed_strides `
Fixes flash-attention backward meta stride handling for grad_v, and corrects the skip condition on the mixed-strides repro test.
- meta used empty_like(value), so grad_v inherited transposed strides when value was non-contiguous. The real backward returns a contiguous grad_v, so meta didn’t match eager (shape checks passed, stride checks failed).

#### Fix
- Allocate grad_v with `memory_format=torch.contiguous_format` in meta__scaled_dot_product_flash_backward.

#### Testing
Test is now passing on MI300.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela