### PR TITLE
Use TypeAliasType for type aliases and @exposed_in for function re-exports

### DIFF
--- a/torch/distributed/tensor/experimental/__init__.py
+++ b/torch/distributed/tensor/experimental/__init__.py
@@ -25,10 +25,3 @@ def implicit_replication() -> Iterator[None]:
         yield
     finally:
         DTensor._op_dispatcher._allow_implicit_replication = False
-
-
-# Set namespace for exposed private names
-context_parallel.__module__ = "torch.distributed.tensor.experimental"
-implicit_replication.__module__ = "torch.distributed.tensor.experimental"
-local_map.__module__ = "torch.distributed.tensor.experimental"
-register_sharding.__module__ = "torch.distributed.tensor.experimental"

--- a/torch/distributed/tensor/experimental/_context_parallel/_attention.py
+++ b/torch/distributed/tensor/experimental/_context_parallel/_attention.py
@@ -23,6 +23,7 @@ from torch.nn.attention.flex_attention import (
     BlockMask,
     create_block_mask,
 )
+from torch.utils._exposed_in import exposed_in
 from torch.utils._pytree import tree_flatten, tree_unflatten
 
 from ._cp_custom_ops import flex_cp_allgather
@@ -1510,6 +1511,7 @@ def _disable_context_parallel_dispatcher() -> None:
 #####################################################
 # Current public APIs, but are also subject to change
 #####################################################
+@exposed_in("torch.distributed.tensor.experimental")
 @contextlib.contextmanager
 @torch.no_grad()
 def context_parallel(

--- a/torch/distributed/tensor/experimental/_func_map.py
+++ b/torch/distributed/tensor/experimental/_func_map.py
@@ -4,9 +4,12 @@ import functools
 from collections.abc import Callable, Sequence
 
 import torch
+from typing_extensions import TypeAliasType
+
 from torch.distributed._functional_collectives import AsyncCollectiveTensor
 from torch.distributed.tensor import DeviceMesh, DTensor
 from torch.distributed.tensor.placement_types import Placement
+from torch.utils._exposed_in import exposed_in
 
 
 try:
@@ -17,11 +20,14 @@ except ImportError:
 
 __all__ = ["local_map"]
 
-PlacementType = Sequence[Placement] | None
-InputPlacements = tuple[PlacementType, ...] | None
-OutputPlacements = PlacementType | tuple[PlacementType, ...]
+PlacementType = TypeAliasType("PlacementType", Sequence[Placement] | None)
+InputPlacements = TypeAliasType("InputPlacements", tuple[PlacementType, ...] | None)
+OutputPlacements = TypeAliasType(
+    "OutputPlacements", PlacementType | tuple[PlacementType, ...]
+)
 
 
+@exposed_in("torch.distributed.tensor.experimental")
 def local_map(
     func: Callable | None = None,
     out_placements: OutputPlacements = None,

--- a/torch/distributed/tensor/experimental/_register_sharding.py
+++ b/torch/distributed/tensor/experimental/_register_sharding.py
@@ -15,11 +15,13 @@ from torch.distributed.tensor._op_schema import (
     TupleStrategy,
 )
 from torch.distributed.tensor._ops.utils import expand_to_full_mesh_op_strategy
+from torch.utils._exposed_in import exposed_in
 
 
 __all__ = ["register_sharding"]
 
 
+@exposed_in("torch.distributed.tensor.experimental")
 def register_sharding(op: OpOverload | list[OpOverload]):
     """
     :meth:`register_sharding` is an experimental API that allows users to register sharding

--- a/torch/types.py
+++ b/torch/types.py
@@ -12,8 +12,8 @@ from builtins import (  # noqa: F401
     str as _str,
 )
 from collections.abc import Sequence
-from typing import Any, IO, TYPE_CHECKING, TypeAlias, Union
-from typing_extensions import Self
+from typing import Any, IO, TYPE_CHECKING, Union
+from typing_extensions import Self, TypeAliasType
 
 # `as` imports have better static analysis support than assignment `ExposedType: TypeAlias = HiddenType`
 from torch import (  # noqa: F401
@@ -38,41 +38,41 @@ __all__ = ["Number", "Device", "FileLike", "Storage"]
 
 # Convenience aliases for common composite types that we need
 # to talk about in PyTorch
-_TensorOrTensors: TypeAlias = Tensor | Sequence[Tensor]  # noqa: PYI047
-_TensorOrOptionalTensors: TypeAlias = Tensor | Sequence[Tensor | None]  # noqa: PYI047
-_TensorOrTensorsOrGradEdge: TypeAlias = Union[  # noqa: PYI047
-    Tensor,
-    Sequence[Tensor],
-    "GradientEdge",
-    Sequence["GradientEdge"],
-]
+_TensorOrTensors = TypeAliasType("_TensorOrTensors", Tensor | Sequence[Tensor])
+_TensorOrOptionalTensors = TypeAliasType(
+    "_TensorOrOptionalTensors", Tensor | Sequence[Tensor | None]
+)
+_TensorOrTensorsOrGradEdge = TypeAliasType(
+    "_TensorOrTensorsOrGradEdge",
+    Union[Tensor, Sequence[Tensor], "GradientEdge", Sequence["GradientEdge"]],
+)
 
-_size: TypeAlias = Size | list[int] | tuple[int, ...]  # noqa: PYI042,PYI047
-_symsize: TypeAlias = Size | Sequence[int | SymInt]  # noqa: PYI042,PYI047
-_dispatchkey: TypeAlias = str | DispatchKey  # noqa: PYI042,PYI047
+_size = TypeAliasType("_size", Size | list[int] | tuple[int, ...])
+_symsize = TypeAliasType("_symsize", Size | Sequence[int | SymInt])
+_dispatchkey = TypeAliasType("_dispatchkey", str | DispatchKey)
 
 # int or SymInt
-IntLikeType: TypeAlias = int | SymInt
+IntLikeType = TypeAliasType("IntLikeType", int | SymInt)
 # float or SymFloat
-FloatLikeType: TypeAlias = float | SymFloat
+FloatLikeType = TypeAliasType("FloatLikeType", float | SymFloat)
 # bool or SymBool
-BoolLikeType: TypeAlias = bool | SymBool
+BoolLikeType = TypeAliasType("BoolLikeType", bool | SymBool)
 
 py_sym_types = (SymInt, SymFloat, SymBool)  # left un-annotated intentionally
-PySymType: TypeAlias = SymInt | SymFloat | SymBool
+PySymType = TypeAliasType("PySymType", SymInt | SymFloat | SymBool)
 
 # Meta-type for "numeric" things; matches our docs
-Number: TypeAlias = int | float | bool
+Number = TypeAliasType("Number", int | float | bool)
 # tuple for isinstance(x, Number) checks.
 # FIXME: refactor once python 3.9 support is dropped.
 _Number = (int, float, bool)
 
-FileLike: TypeAlias = str | os.PathLike[str] | IO[bytes]
+FileLike = TypeAliasType("FileLike", str | os.PathLike[str] | IO[bytes])
 
 # Meta-type for "device-like" things.  Not to be confused with 'device' (a
 # literal device object).  This nomenclature is consistent with PythonArgParser.
 # None means use the default device (typically CPU)
-Device: TypeAlias = _device | str | int | None
+Device = TypeAliasType("Device", _device | str | int | None)
 
 
 # Storage protocol implemented by ${Type}StorageBase classes


### PR DESCRIPTION
## Summary
- Convert all `TypeAlias` annotations in `torch/types.py` to `TypeAliasType` instances from `typing_extensions`, resolving PYI042/PYI047 lint suppressions
- Convert bare type alias assignments in `torch/distributed/tensor/experimental/_func_map.py` to `TypeAliasType`
- Replace `__module__` assignment hacks in `torch.distributed.tensor.experimental.__init__` with `@exposed_in()` decorators at the function definition sites

## Motivation
Fixes #171905

The codebase uses `__module__` attribute reassignment to make imported symbols appear in their public module. For type aliases, `TypeAliasType` from `typing_extensions` (available since 4.10, already a PyTorch dependency) provides a cleaner mechanism: it automatically sets `__module__` and is understood by type checkers/linters without the workaround.

For function re-exports, `@exposed_in()` (from `torch.utils._exposed_in`) is the established pattern already used in `torch.func`, `torch.library`, and `torch._higher_order_ops`. Migrating the `torch.distributed.tensor.experimental` functions to this pattern replaces the ad-hoc `__module__` hacks.

## Changes

**`torch/types.py`** — Converts 13 type aliases from `Name: TypeAlias = <type>` to `Name = TypeAliasType("Name", <type>)`. This eliminates all `# noqa: PYI042,PYI047` suppressions.

**`torch/distributed/tensor/experimental/_func_map.py`** — Converts `PlacementType`, `InputPlacements`, `OutputPlacements` to `TypeAliasType`. Adds `@exposed_in` to `local_map`.

**`torch/distributed/tensor/experimental/_register_sharding.py`** — Adds `@exposed_in` to `register_sharding`.

**`torch/distributed/tensor/experimental/_context_parallel/_attention.py`** — Adds `@exposed_in` to `context_parallel`.

**`torch/distributed/tensor/experimental/__init__.py`** — Removes the four `__module__` reassignment lines (now handled at definition sites via `@exposed_in`, or redundant for `implicit_replication` which is already defined in `__init__.py`).

## Test Plan
- `ruff check` and `ruff format --check` pass on all modified files
- Runtime safety: `Number`, `Device`, `FileLike` are only used as type annotations (never in `isinstance` — `_Number` tuple exists for that). `TypeAliasType` instances work correctly as dict keys in `torch/_library/infer_schema.py` (same singleton object identity).
- CI should validate: `test_public_bindings`, `test_custom_ops`, `test_infer_schema_annotation`

This PR was authored with the help of Claude.

cc @Skylion007