### PR TITLE
[DTensor] Fix CuTe view propagation edge cases for production readiness

### DIFF
--- a/torch/distributed/tensor/_ops/CUTE_VIEW_PROPAGATION.md
+++ b/torch/distributed/tensor/_ops/CUTE_VIEW_PROPAGATION.md
@@ -1,0 +1,104 @@
+# CuTe Layout Composition for DTensor View Ops
+
+## Overview
+
+`_cute_view_propagation.py` replaces Phase 2 (`rewrite_output_placements`) of
+`_ViewShardingPropagator` with CuTe layout composition. Where Phase 2 threads
+mutable state (`local_tensor_shapes`, `strided_shard_claimed_dims`) sequentially
+across mesh dims, CuTe encodes cross-dim dependencies in the layout's stride
+structure and computes output placements in one pass via view composition.
+
+The module is gated behind `USE_CUTE_VIEW_PROPAGATION=1` (env var, off by
+default). When enabled, `propagate_shape_and_sharding` tries CuTe first and
+falls back to Phase 2 for unsupported cases.
+
+## Data model
+
+A `DistLayout` wraps a CuTe `Layout` with metadata tracking which sub-modes
+correspond to mesh dimensions (GPU modes):
+
+```
+DistLayout
+├── layout: Layout       # Hierarchical CuTe layout over all tensor dims
+├── num_dims: int         # Tensor dimensionality
+└── gpu_modes: [GpuMode]  # Which sub-modes are mesh-dim partitions
+        ├── mesh_dim: int
+        └── flat_index: int  # Position in flattened sub-mode list
+```
+
+Each tensor dimension's mode decomposes into sub-modes. A `Shard(d)` on mesh
+dim `i` with mesh size `M` makes dim `d`'s mode `(S/M, M)` with the `M`
+sub-mode marked as GPU. A `_StridedShard(d, sf)` produces `(lpg, M, sf)` where
+`lpg = S/(sf*M)`.
+
+## Pipeline
+
+```
+from_placements ──► compose_view ──► to_placements
+   (input DTensor      (apply DimMap      (convert back
+    placements to       rule: Split,       to Shard /
+    DistLayout)         Flatten, etc.)     _StridedShard /
+                                           Replicate)
+```
+
+**`from_placements`**: Builds a `DistLayout` by decomposing each sharded dim
+into sub-modes. Processes placements left-to-right (matching DTensor semantics).
+When multiple mesh dims shard the same tensor dim, `_add_shard_to_dim` /
+`_add_strided_shard_to_dim` insert additional GPU sub-modes into the existing
+decomposition.
+
+**`compose_view`**: Walks the DimMap rule tree. For each output dim, collects
+the sub-modes that fall within its stride range from the input layout. GPU
+sub-modes are carried through, so the output layout inherits the right mesh-dim
+assignments.
+
+**`to_placements`**: For each mesh dim, finds its GPU sub-mode in the output
+layout. If it's the outermost sub-mode in its dim → `Shard`; if inner →
+`_StridedShard` (with `split_factor` derived from the product of outer
+sub-mode shapes); if absent → `Replicate`.
+
+## Fallback conditions
+
+CuTe returns `None` (falling back to Phase 2) when:
+
+| Condition | Reason |
+|---|---|
+| Any shape element is `SymInt` | CuTe uses plain arithmetic |
+| Uneven sharding in flatten range with later mesh dim | Local shapes vary across ranks, breaking stride uniformity |
+| `_StridedShard` `group_size % M != 0` | Layout requires non-integer sub-mode division |
+| Split factor exceeds outer sub-mode shape | Strides from different mesh dims are incompatible |
+| GPU mode in Split piece with mismatched product | Sharding doesn't align with unflatten boundaries |
+
+All fallbacks are via `_UnsupportedCase` caught in `cute_rewrite_output_placements`.
+
+## Split sub-mode division
+
+When unflatten splits a dim into pieces, each piece occupies a stride range.
+A local sub-mode may straddle a piece boundary — e.g., `(24, stride=1)` when
+the piece boundary is at stride 12. The Split handler pre-divides straddling
+non-GPU sub-modes:
+
+```
+(24, stride=1) with piece_stride=12
+→ inner: (12, stride=1)   # below boundary
+  outer: (2, stride=12)   # at boundary
+```
+
+GPU sub-modes that straddle a boundary indicate incompatible sharding and
+trigger `_UnsupportedCase`.
+
+## Scalar tensors
+
+0-d tensors (scalars) produce empty mode lists. Both `from_placements` and
+`compose_view` handle this by returning `Layout(1, 0)` — a trivial layout with
+no GPU modes, correctly yielding all-Replicate output.
+
+## Testing
+
+```bash
+# With CuTe enabled (exercises CuTe + fallback for all view ops)
+USE_CUTE_VIEW_PROPAGATION=1 python -m pytest test/distributed/tensor/test_view_ops.py -v
+
+# Without CuTe (baseline, should be identical)
+python -m pytest test/distributed/tensor/test_view_ops.py -v
+```

--- a/torch/distributed/tensor/_ops/_cute_view_propagation.py
+++ b/torch/distributed/tensor/_ops/_cute_view_propagation.py
@@ -226,10 +226,16 @@ def _add_strided_shard_to_dim(
     if outer_idx == -1:
         raise _UnsupportedCase("no local sub-mode for multi-mesh _StridedShard")
     outer_shape = shapes[outer_idx]
+    if sf > outer_shape or outer_shape % sf != 0:
+        raise _UnsupportedCase(
+            f"sf={sf} doesn't divide outer sub-mode shape {outer_shape}"
+        )
     group_size = outer_shape // sf
+    if group_size % M != 0:
+        raise _UnsupportedCase(
+            f"local {outer_shape}: group_size {group_size} not divisible by M={M}"
+        )
     lpg = group_size // M
-    if lpg == 0:
-        raise _UnsupportedCase(f"local {outer_shape} not divisible by sf*M={sf * M}")
     if lpg == 1:
         # (M, sf) replaces the outer sub-mode
         shapes[outer_idx] = M
@@ -300,11 +306,11 @@ def from_placements(
                     p.split_factor,
                 )
                 group_size = S // sf
-                lpg = group_size // M
-                if lpg == 0:
+                if group_size % M != 0:
                     raise _UnsupportedCase(
-                        f"dim {dim} size {S} not divisible by sf*M={sf * M}"
+                        f"dim {dim}: group_size {group_size} not divisible by M={M}"
                     )
+                lpg = group_size // M
                 if lpg == 1:
                     dim_modes[dim] = (
                         [M, sf],
@@ -339,7 +345,11 @@ def from_placements(
             modes.append(Layout(shape[d], bstrides[d]))
             flat_idx += 1
 
-    L = make_layout(*modes)
+    if modes:
+        L = make_layout(*modes)
+    else:
+        # Scalar (0-d) tensor
+        L = Layout(1, 0)
     return DistLayout(layout=L, num_dims=len(shape), gpu_modes=gpu_modes)
 
 
@@ -369,7 +379,11 @@ def compose_view(dist: DistLayout, rule: DimMap) -> DistLayout:
 
         flat_idx_out += len(out_shapes)
 
-    out_layout = make_layout(*output_modes)
+    if output_modes:
+        out_layout = make_layout(*output_modes)
+    else:
+        # Scalar output (e.g. squeeze of a 1-element tensor)
+        out_layout = Layout(1, 0)
     return DistLayout(layout=out_layout, num_dims=len(rule), gpu_modes=gpu_modes_out)
 
 
@@ -417,15 +431,45 @@ def _collect_submodes(
         piece_size = cmd.group_shape[cmd.split_id]
         piece_end_stride = piece_stride * piece_size
 
+        # Divide sub-modes that straddle the piece boundary before filtering.
+        # A sub-mode (s, st) with st < piece_stride but s * st > piece_stride
+        # spans across multiple Split pieces and must be split into an inner
+        # part (stays at lower strides) and an outer part (at piece_stride).
+        divided_shapes: list[int] = []
+        divided_strides: list[int] = []
+        divided_gpu: list[tuple[int, int]] = []
+        for i, (s, st) in enumerate(zip(inner_shapes, inner_strides)):
+            is_gpu = any(orig == i for _, orig in inner_gpu)
+            if st < piece_stride and s * st > piece_stride and not is_gpu:
+                divisor = piece_stride // st
+                if divisor > 0 and st * divisor == piece_stride and s % divisor == 0:
+                    # Inner part: (divisor, st) — below piece_stride
+                    divided_shapes.append(divisor)
+                    divided_strides.append(st)
+                    # Outer part: (s // divisor, piece_stride) — at piece_stride
+                    divided_shapes.append(s // divisor)
+                    divided_strides.append(piece_stride)
+                else:
+                    divided_shapes.append(s)
+                    divided_strides.append(st)
+            else:
+                gpu_sub_idx = len(divided_shapes)
+                divided_shapes.append(s)
+                divided_strides.append(st)
+                if is_gpu:
+                    for mesh_dim, orig in inner_gpu:
+                        if orig == i:
+                            divided_gpu.append((mesh_dim, gpu_sub_idx))
+
         out_shapes: list[int] = []
         out_strides: list[int] = []
         out_gpu: list[tuple[int, int]] = []
         sub_idx_out = 0
-        for i, (s, st) in enumerate(zip(inner_shapes, inner_strides)):
+        for i, (s, st) in enumerate(zip(divided_shapes, divided_strides)):
             if piece_stride <= st < piece_end_stride:
                 out_shapes.append(s)
                 out_strides.append(st)
-                for mesh_dim, orig_sub_idx in inner_gpu:
+                for mesh_dim, orig_sub_idx in divided_gpu:
                     if orig_sub_idx == i:
                         out_gpu.append((mesh_dim, sub_idx_out))
                 sub_idx_out += 1
@@ -434,12 +478,19 @@ def _collect_submodes(
             out_shapes = [piece_size]
             out_strides = [piece_stride]
         elif math.prod(out_shapes) != piece_size:
+            if out_gpu:
+                # A GPU mode falls inside this piece's stride range but the
+                # decomposition doesn't match the piece size — the sharding is
+                # incompatible with this Split and can't be represented.
+                raise _UnsupportedCase(
+                    f"GPU mode in piece but prod {math.prod(out_shapes)} != "
+                    f"piece_size {piece_size}"
+                )
             # Sub-modes straddle the split boundary — the input sharding is
             # incompatible with this view.  Drop GPU modes so this mesh dim
             # becomes Replicate in the output.
             out_shapes = [piece_size]
             out_strides = [piece_stride]
-            out_gpu = []
         return out_shapes, out_strides, out_gpu
 
     elif isinstance(cmd, Singleton):
@@ -544,6 +595,34 @@ def cute_rewrite_output_placements(
     for s in global_input_shape:
         if not isinstance(s, int):
             return None
+
+    # Reject uneven sharding on non-last flatten dims.
+    # Uneven sharding makes local shapes vary across ranks, breaking the
+    # uniform-stride assumption that _StridedShard relies on.
+    flatten_ranges: list[tuple[int, int]] = []
+    for cmd in rule:
+        if isinstance(cmd, Flatten):
+            dims = [d.input_dim for d in cmd.input_dims if isinstance(d, InputDim)]
+            if len(dims) >= 2:
+                flatten_ranges.append((min(dims), max(dims) + 1))
+    for start, end in flatten_ranges:
+        local_shapes = list(global_input_shape)
+        for mesh_dim, p in enumerate(input_tgt_placements):
+            if not isinstance(p, (Shard, _StridedShard)):
+                continue
+            if not (start <= p.dim < end):
+                continue
+            if local_shapes[p.dim] % mesh_sizes[mesh_dim] != 0:
+                # Check if a later mesh dim also shards within this range
+                has_later = any(
+                    isinstance(q, (Shard, _StridedShard))
+                    and start <= q.dim < end
+                    and q.dim >= p.dim
+                    for q in input_tgt_placements[mesh_dim + 1 :]
+                )
+                if has_later:
+                    return None
+            local_shapes[p.dim] //= mesh_sizes[mesh_dim]
 
     try:
         dist = from_placements(global_input_shape, input_tgt_placements, mesh_sizes)

--- a/torch/distributed/tensor/_ops/_view_ops.py
+++ b/torch/distributed/tensor/_ops/_view_ops.py
@@ -1,6 +1,7 @@
 # mypy: allow-untyped-defs
 # Copyright (c) Meta Platforms, Inc. and affiliates
 import math
+import os
 from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass
 from typing import cast, NamedTuple
@@ -42,8 +43,10 @@ Shape = tuple[int, ...]
 
 # When True, propagate_shape_and_sharding uses CuTe layout composition for
 # Phase 2 (output placement rewriting).  Falls back to the existing sequential
-# algorithm for unsupported cases (multi-mesh-same-dim, symbolic shapes).
-_USE_CUTE_VIEW_PROPAGATION = False
+# algorithm for unsupported cases (symbolic shapes).
+_USE_CUTE_VIEW_PROPAGATION = os.environ.get(
+    "USE_CUTE_VIEW_PROPAGATION", "0"
+) == "1"
 
 
 class ClaimedDim(NamedTuple):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #178504
* #178454
* #176151
* #166483

Make the CuTe layout composition path handle edge cases discovered
by running the full test_view_ops.py suite:

- Read the CuTe flag from env var USE_CUTE_VIEW_PROPAGATION so it
  propagates to MultiProcContinuousTest child processes.
- Fall back to Phase 2 for uneven sharding within flatten ranges where
  local shapes vary across ranks (breaking _StridedShard assumptions).
- Fix Split sub-mode division when a local sub-mode straddles a
  Split piece boundary.
- Validate _StridedShard group_size divisibility before constructing
  layouts (group_size % M != 0, sf > outer sub-mode shape).
- Raise _UnsupportedCase when a GPU mode falls within a Split piece's
  stride range but the decomposition doesn't match the piece size.
- Handle 0-d (scalar) tensors in from_placements and compose_view.

Authored with Claude.

