### PR TITLE
Dynamo/fix ignore logging functions

### DIFF
--- a/test/dynamo/test_utils.py
+++ b/test/dynamo/test_utils.py
@@ -1,7 +1,7 @@
 # Owner(s): ["module: dynamo"]
 import dataclasses
-import os
 import json
+import os
 import pprint
 import sys
 from unittest import mock

--- a/test/dynamo/test_utils.py
+++ b/test/dynamo/test_utils.py
@@ -1,6 +1,7 @@
 # Owner(s): ["module: dynamo"]
 import dataclasses
 import os
+import json
 import pprint
 import sys
 from unittest import mock
@@ -296,6 +297,14 @@ class TestUtils(TestCase):
             ReinplaceCounters._values,
             "Should not use enum value (integer) in key, should use trigger.name instead",
         )
+
+    def test_get_dynamo_config_for_logging_ignores_logging_functions(self):
+        with dynamo_config.patch(ignore_logging_functions={print}):
+            result = utils._get_dynamo_config_for_logging()
+            parsed = json.loads(result)
+
+        self.assertIsInstance(parsed, dict)
+        self.assertNotIn("ignore_logging_functions", parsed)
 
 
 class TestModel(torch.nn.Module):

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -1740,6 +1740,7 @@ def _get_dynamo_config_for_logging() -> str | None:
             "_autograd_backward_strict_mode_banned_ops",
             "reorderable_logging_functions",
             "ignore_logger_methods",
+            "ignore_logging_functions",
             "traceable_tensor_subclasses",
             "nontraceable_tensor_subclasses",
             "_custom_ops_profile",


### PR DESCRIPTION
## PR Summary

Fixes #178455  ignore_logger_methods was renamed to ignore_logging_functions in torch 2.11 but wasn't added to blocklist in _get_dynamo_config_for_logging()


## Repro
```
  import torch                                                                                                                                                                               
  import torch._dynamo.config                                                                                                                                                                
  import torch._dynamo.utils                                                                                                                                                                 
                                                                                                                                                                                           
  torch._dynamo.config.ignore_logging_functions.add(print)                                                                                                                                   
  torch._dynamo.utils._get_dynamo_config_for_logging()   
```
## Changes

* Include `ignore_logging_functions` from `_get_dynamo_config_for_logging()` (consistent with existing `ignore_logger_methods`)
* Add a regression test to ensure no crash when logging config includes builtin functions
* 

Added a test that:

* Inserts `print` into `ignore_logging_functions`
* Verifies `_get_dynamo_config_for_logging()` returns valid JSON without errors

related issue: #178455



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo