### PR TITLE
[BE] Fix compilation warning in Indexing.metal

### DIFF
--- a/aten/src/ATen/native/mps/kernels/Indexing.metal
+++ b/aten/src/ATen/native/mps/kernels/Indexing.metal
@@ -760,14 +760,6 @@ INSTANTIATE_INDEX_FILL(uchar);
 INSTANTIATE_INDEX_FILL(float2);
 INSTANTIATE_INDEX_FILL(half2);
 
-[[host_name("index_fill_set_mask")]]
-kernel void index_fill_set_mask(
-    device bool*,
-    constant long*,
-    constant long&,
-    constant long&,
-    uint);
-
 #define INSTANTIATE_INDEX_FILL_FROM_MASK(T)                  \
   template [[host_name("index_fill_dense_from_mask_" #T)]]   \
   kernel void index_fill_dense_from_mask<T>(                 \


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #178484
* __->__ #178507

I.e. if kernel is not a template, no need to create a prototype with
specifically issigned name.
Fixes
```
/Users/malfet/git/pytorch/pytorch/aten/src/ATen/native/mps/kernels/Indexing.metal:763:3: warning: attribute declaration must precede definition [-Wignored-attributes]
[[host_name("index_fill_set_mask")]]
  ^
/Users/malfet/git/pytorch/pytorch/aten/src/ATen/native/mps/kernels/Indexing.metal:598:13: note: previous definition is here
kernel void index_fill_set_mask(
            ^
1 warning generated.
```