### PR TITLE
[Inductor] Prefer smaller R0_BLOCK for Blackwell (#178512)

### DIFF
--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -3228,6 +3228,10 @@ def _reduction_configs(
     loads_and_red = inductor_meta.get("num_load", 0) + inductor_meta.get(
         "num_reduction", 0
     )
+
+    device_major = triton_meta["device"].major
+    # Prefer smaller MAX_R0_BLOCK for Blackwell
+    MAX_R0_BLOCK = 1024 if device_major is not None and device_major >= 10 else 2048
     if size_hints["x"] >= 1024 and loads_and_red >= 10:
         # A heuristics to reduce R0_BLOCK if a kernel potentially need many registers.
         # Consider load and reduction since load need move data into registers and


### PR DESCRIPTION
Summary: Pull Request resolved: https://github.com/pytorch/pytorch/pull/178512

When revisiting Quack fwd rmsnorm benchmarking, B200 seems to generally prefer a smaller max RBLOCK, leading to quite significant speedups. Generally we have seen this pattern where B200 is better on less num_warps. Results:
```
  rnumel = 2048 (significant improvement expected)                                                                                                                             
  ┌────────┬───────────────┬──────────────┬─────────┐                                                                                                                          
  │   M    │ BEFORE (gbps) │ AFTER (gbps) │ Speedup │                                                                                                                          
  ├────────┼───────────────┼──────────────┼─────────┤                                                                                                                          
  │ 1024   │ 1025.00       │ 1025.00      │ 1.00x   │                                                                                                                          
  ├────────┼───────────────┼──────────────┼─────────┤                                                                                                                          
  │ 2048   │ 1639.20       │ 2049.00      │ 1.25x   │                                                                                                                          
  ├────────┼───────────────┼──────────────┼─────────┤                                                                                                                          
  │ 4096   │ 2731.33       │ 2731.33      │ 1.00x   │                                                                                                                          
  ├────────┼───────────────┼──────────────┼─────────┤                                                                                                                          
  │ 8192   │ 3277.20       │ 3641.33      │ 1.11x   │                                                                                                                          
  ├────────┼───────────────┼──────────────┼─────────┤                                                                                                                          
  │ 16384  │ 3761.94       │ 4681.43      │ 1.24x   │                                                                                                                          
  ├────────┼───────────────┼──────────────┼─────────┤                                                                                                                          
  │ 32768  │ 4092.13       │ 5044.42      │ 1.23x   │                                                                                                                          
  ├────────┼───────────────┼──────────────┼─────────┤                                                                                                                          
  │ 65536  │ 4196.47       │ 5242.96      │ 1.25x   │                                                                                                                          
  ├────────┼───────────────┼──────────────┼─────────┤                                                                                                                          
  │ 131072 │ 4245.82       │ 5213.59      │ 1.23x   │                                                                                                                          
  └────────┴───────────────┴──────────────┴─────────┘                                                                                                                          
  rnumel = 4096 (significant improvement expected)                                                                                                                             
  ┌────────┬───────────────┬──────────────┬─────────┐                                                                                                                          
  │   M    │ BEFORE (gbps) │ AFTER (gbps) │ Speedup │                                                                                                                          
  ├────────┼───────────────┼──────────────┼─────────┤                                                                                                                          
  │ 1024   │ 1640.00       │ 2058.04      │ 1.26x   │                                                                                                                          
  ├────────┼───────────────┼──────────────┼─────────┤                                                                                                                          
  │ 2048   │ 2724.90       │ 2732.00      │ 1.00x   │                                                                                                                          
  ├────────┼───────────────┼──────────────┼─────────┤                                                                                                                          
  │ 4096   │ 2979.64       │ 3641.78      │ 1.22x   │                                                                                                                          
  ├────────┼───────────────┼──────────────┼─────────┤                                                                                                                          
  │ 8192   │ 3742.03       │ 4681.71      │ 1.25x   │                                                                                                                          
  ├────────┼───────────────┼──────────────┼─────────┤                                                                                                                          
  │ 16384  │ 4171.62       │ 5360.46      │ 1.28x   │                                                                                                                          
  ├────────┼───────────────┼──────────────┼─────────┤                                                                                                                          
  │ 32768  │ 4333.09       │ 5751.71      │ 1.33x   │                                                                                                                          
  ├────────┼───────────────┼──────────────┼─────────┤                                                                                                                          
  │ 65536  │ 4387.41       │ 5730.99      │ 1.31x   │                                                                                                                          
  ├────────┼───────────────┼──────────────┼─────────┤                                                                                                                          
  │ 131072 │ 4396.29       │ 5654.65      │ 1.29x   │                                                                                                                          
  └────────┴───────────────┴──────────────┴─────────┘                                                                                                                          
  Summary                                                                                                                                                                      
  ┌─────────┬────────────┬───────────┬─────────────┐                                                                                                                           
  │ rnumel  │ Avg BEFORE │ Avg AFTER │ Avg Speedup │                                                                                                                           
  ├─────────┼────────────┼───────────┼─────────────┤                                                                                                                           
  │ 1024    │ 3358.28    │ 3346.60   │ 1.00x       │                                                                                                                           
  ├─────────┼────────────┼───────────┼─────────────┤                                                                                                                           
  │ 2048    │ 3121.14    │ 3703.63   │ 1.19x       │                                                                                                                           
  ├─────────┼────────────┼───────────┼─────────────┤                                                                                                                           
  │ 4096    │ 3296.87    │ 4451.67   │ 1.35x       │                                                                                                                           
  ├─────────┼────────────┼───────────┼─────────────┤                                                                                                                           
  │ Overall │ 3342.10    │ 3833.84   │ 1.15x       │                                                                                                                           
  └─────────┴────────────┴───────────┴─────────────┘
```

```
  ┌─────────────────┬───────────────┬──────────────┬─────────┐                                                                                                                 
  │      Shape      │ BEFORE (2048) │ AFTER (1024) │ Speedup │                                                                                                                 
  ├─────────────────┼───────────────┼──────────────┼─────────┤                                                                                                                 
  │ (32768, 256)    │ 2730.75       │ 2730.75      │ 1.00x   │                                                                                                                 
  ├─────────────────┼───────────────┼──────────────┼─────────┤                                                                                                                 
  │ (32768, 512)    │ 4096.13       │ 4096.13      │ 1.00x   │                                                                                                                 
  ├─────────────────┼───────────────┼──────────────┼─────────┤                                                                                                                 
  │ (32768, 1024)   │ 5041.38       │ 5041.38      │ 1.00x   │                                                                                                                 
  ├─────────────────┼───────────────┼──────────────┼─────────┤                                                                                                                 
  │ (32768, 2048)   │ 4096.13       │ 5059.63      │ +24%    │                                                                                                                 
  ├─────────────────┼───────────────┼──────────────┼─────────┤                                                                                                                 
  │ (32768, 4096)   │ 4369.20       │ 5759.60      │ +32%    │                                                                                                                 
  ├─────────────────┼───────────────┼──────────────┼─────────┤                                                                                                                 
  │ (32768, 8192)   │ 5576.78       │ 6059.13      │ +9%     │                                                                                                                 
  ├─────────────────┼───────────────┼──────────────┼─────────┤                                                                                                                 
  │ (32768, 16384)  │ 5743.34       │ 5652.40      │ -2%     │                                                                                                                 
  ├─────────────────┼───────────────┼──────────────┼─────────┤                                                                                                                 
  │ (32768, 32768)  │ 4917.27       │ 4894.68      │ 0%      │                                                                                                                 
  ├─────────────────┼───────────────┼──────────────┼─────────┤                                                                                                                 
  │ (32768, 65536)  │ 3979.48       │ 3748.32      │ -6%     │                                                                                                                 
  ├─────────────────┼───────────────┼──────────────┼─────────┤                                                                                                                 
  │ (16384, 131072) │ 3738.73       │ 3669.73      │ -2%     │                                                                                                                 
  ├─────────────────┼───────────────┼──────────────┼─────────┤                                                                                                                 
  │ (8192, 262144)  │ 3644.60       │ 3654.02      │ 0%      │                                                                                                                 
  ├─────────────────┼───────────────┼──────────────┼─────────┤                                                                                                                 
  │ Average         │ 4357.62       │ 4578.71      │ +5%     │                                                                                                                 
  └─────────────────┴───────────────┴──────────────┴─────────┘ 
```

Differential Revision: D98309852




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo