### PR TITLE
Fix interpolate nearest mode with non-integer scale_factor

### DIFF
--- a/test/test_decomp.py
+++ b/test/test_decomp.py
@@ -1135,6 +1135,38 @@ class DecompOneOffTests(TestCase):
         res = torch._decomp.decompositions._log_softmax(x, -1, False)
         self.assertEqual(ref.stride(), res.stride())
 
+    @onlyNativeDeviceTypes
+    @skipIfCrossRef
+    def test_upsample_nearest_noninteger_scale_factor(self, device):
+        # Regression for https://github.com/pytorch/pytorch/issues/175154
+        from torch._decomp.decompositions import _upsample_nearest, upsample_compute_output_size
+
+        in_t = torch.arange(20, dtype=torch.float32, device=device).view(1, 1, 20)
+        scale = 1.3
+
+        ref = torch.nn.functional.interpolate(
+            in_t, scale_factor=scale, mode="nearest"
+        )
+        osize = upsample_compute_output_size(in_t.shape, None, [scale])
+        decomp_out = _upsample_nearest(in_t, osize, [scale], exact=False)
+        self.assertEqual(decomp_out, ref)
+
+        ref_recompute = torch.nn.functional.interpolate(
+            in_t, scale_factor=scale, mode="nearest", recompute_scale_factor=True
+        )
+        osize_r = upsample_compute_output_size(in_t.shape, None, [scale])
+        decomp_recompute = _upsample_nearest(
+            in_t, osize_r, [None], exact=False
+        )
+        self.assertEqual(decomp_recompute, ref_recompute)
+
+        compiled = torch.compile(
+            lambda x: torch.nn.functional.interpolate(
+                x, scale_factor=scale, mode="nearest"
+            )
+        )
+        self.assertEqual(compiled(in_t), ref)
+
     @onlyCUDA
     def test_exponential_non_inf(self, device):
         inp = torch.empty((4, 400, 256), device=device)

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -3456,7 +3456,8 @@ def _compute_upsample_nearest_indices(input, output_size, scales, exact=False):
         )
 
         output_indices = torch.arange(osize, dtype=torch.float32, device=input.device)
-        input_indices = ((output_indices + offset) * scale).to(torch.int64)
+        input_indices = torch.floor((output_indices + offset) * scale).to(torch.int64)
+        input_indices = torch.min(input_indices, isize - 1)
         for _ in range(num_spatial_dims - 1 - d):
             input_indices = input_indices.unsqueeze(-1)
         indices.append(input_indices)


### PR DESCRIPTION
When using `torch.nn.functional.interpolate` with `mode='nearest'` and a non-integer `scale_factor` (e.g., 1.3), the decomposition was producing incorrect results. The issue was that the code was using truncation (`.to(torch.int64)`) instead of `floor()` to compute the input indices.

This fix:
1. Uses `torch.floor()` to properly compute `floor(output_index * scale)` as intended and matches the C++ implementation (OpenCV INTER_NEAREST)
2. Adds `torch.min(input_indices, isize - 1)` to clamp indices to valid range, matching the C++ implementation

Adds a regression test in `test/test_decomp.py` covering direct `_upsample_nearest` decomposition (both scale paths) and `torch.compile`.

Fixes #175154

## Test plan
- [ ] `python test/test_decomp.py -k test_upsample_nearest_noninteger_scale_factor`