### PR TITLE
OSS changes needed to use horizontal fusion for custom backend

### DIFF
--- a/torch/_inductor/codegen/triton_combo_kernel.py
+++ b/torch/_inductor/codegen/triton_combo_kernel.py
@@ -762,7 +762,7 @@ class ComboKernel(Kernel):
             "combo_grid_meta": self.combo_grid_meta(size_hints_list),
             "kernel_name": str(Placeholder.DESCRIPTIVE_NAME),
             "mutated_arg_names": mutated_args,
-            **self.triton_kernel_cls.inductor_meta_common(),
+            **selected_kernel.inductor_meta_common(),
         }
         if max_persistent_rblock > 0:
             inductor_meta["max_persistent_rblock"] = max_persistent_rblock

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -2619,8 +2619,11 @@ class ForeachKernelSchedulerNode(FusedSchedulerNode):
             )
             for node in nodes:
                 device = node.get_device()
-                if device and (device.type == "mps" or device.type == "cpu"):
-                    continue
+                # MTIA could lower with fake tensors on cpu, but the kernel is executed on device.
+                # Give it a chance to use combo kernel.
+                if not torch.mtia.is_available():
+                    if device and (device.type == "mps" or device.type == "cpu"):
+                        continue
 
                 # exclude nodes that read from FusedMixOrderReductions output buffers'
                 if node.used_buffer_names() & excluded_buffer_names:


### PR DESCRIPTION
Summary:
two OSS changes:
- Today horizontal fusion decision aka. combo kernel logic today rejects the kernels if device == cpu. However, MTIA lowers subgraphs with fake tensors on cpu where the kernel will eventually run on device. So should also check mtia.is_available() for the combo kernel logic.
- update `triton_combo_kernels.py` to call `selected_kernel.inductor_meta_common()` instead of `self.triton_kernel_cls.inductor_meta_common()` because MTIA's out-of-tree customizes inductor_meta_common() into a instance method.

Test Plan: build.

Differential Revision: D98163217




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos