### PR TITLE
Relax concat-linear fusion to support GQA QKV

### DIFF
--- a/test/inductor/test_inductor_freezing.py
+++ b/test/inductor/test_inductor_freezing.py
@@ -345,14 +345,12 @@ class OptimizeForInferenceTemplate(TestCase):
                 mod2.b1 = torch.nn.Parameter(torch.rand([15], device=self.device))
                 mod2.b2 = torch.nn.Parameter(torch.rand([20], device=self.device))
 
-            # not fused
-            count = 3 if hasattr(mod2, "t3") else 2
-
+            # fused: weights share same dim 0 (in_features), different dim 1 is OK
             with torch.no_grad():
                 out_eager = mod2(inp)
                 out, code = run_and_get_code(foo, mod2, inp)
                 FileCheck().check_not(kernel_invoke).check_count(
-                    mm_invoke, count=count, exactly=True
+                    mm_invoke, count=1, exactly=True
                 ).run(code[0])
                 self.assertEqual(out_eager, out)
 

--- a/torch/_inductor/fx_passes/freezing_patterns.py
+++ b/torch/_inductor/fx_passes/freezing_patterns.py
@@ -187,7 +187,7 @@ def addmm_patterns_init():
 
             if not all(
                 inp.op == "get_attr"
-                and inp.meta["val"].shape == inps[0].meta["val"].shape
+                and inp.meta["val"].shape[:-1] == inps[0].meta["val"].shape[:-1]
                 for inp in inps
             ):
                 return False
@@ -221,9 +221,10 @@ def addmm_patterns_init():
         return (inp @ w1, inp @ w2, inp @ w3)
 
     def matmul_replacement(inp, w1, w2, w3):
-        cat_t = torch.cat((w1, w2, w3), dim=1)
+        weights = (w1, w2, w3)
+        cat_t = torch.cat(weights, dim=1)
         mm = inp @ cat_t
-        return mm.chunk(3, dim=1)
+        return mm.split([w.size(1) for w in weights], dim=1)
 
     register_replacement(
         # pyrefly: ignore [bad-argument-type]
@@ -243,9 +244,10 @@ def addmm_patterns_init():
         return (inp @ w1, inp @ w2)
 
     def matmul_replacement_two(inp, w1, w2):
-        cat_t = torch.cat((w1, w2), dim=1)
+        weights = (w1, w2)
+        cat_t = torch.cat(weights, dim=1)
         mm = inp @ cat_t
-        return mm.chunk(2, dim=1)
+        return mm.split([w.size(1) for w in weights], dim=1)
 
     register_replacement(
         # pyrefly: ignore [bad-argument-type]
@@ -269,9 +271,10 @@ def addmm_patterns_init():
         )
 
     def addmm_fuse_replacement_second(inp, w1, w2, w3, b1, b2, b3):
-        cat_w = torch.cat((w1, w2, w3), dim=1)
+        weights = (w1, w2, w3)
+        cat_w = torch.cat(weights, dim=1)
         cat_b = torch.cat((b1, b2, b3))
-        return aten.addmm(cat_b, inp, cat_w).chunk(3, dim=1)
+        return aten.addmm(cat_b, inp, cat_w).split([w.size(1) for w in weights], dim=1)
 
     register_replacement(
         # pyrefly: ignore [bad-argument-type]


### PR DESCRIPTION
The freezing concat-linear optimization fuses independent matmuls that share the same input (e.g., QKV projections) into a single GEMM.  It previously required all weights to have identical shapes, preventing fusion of GQA-style attention where Q has a larger output dimension than K/V (e.g., Q=960, K=V=320).

Relax the shape check to require only that non-concatenated dimensions match (shape[:-1]), allowing weights and biases to differ in the last dimension.  Use split (which supports unequal sizes) instead of chunk (which requires equal sizes) to split the fused result.

Fixes #178387, "Fusable GQA-style QKV matmuls are overlooked."

Using the reproducer script from the ticket with commit c0c089817e69e999ee07b5efa0396c1cc5b9c655,

```
$ LD_LIBRARY_PATH="$(rocm-sdk path --root)/lib:${LD_LIBRARY_PATH}" python ./repro_concat_linear.py
PASS: 1 matmul(s) in generated code
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo