### PR TITLE
[invoke_subgraph] Fix get_output_metadata requires_grad bug

### DIFF
--- a/test/test_proxy_tensor.py
+++ b/test/test_proxy_tensor.py
@@ -999,6 +999,26 @@ def _trace(f, *args):
     inps = [torch.randn(arg) for arg in args]
     return make_fx(f, tracing_mode="symbolic")(*inps)
 
+class TestGetOutputMetadata(TestCase):
+    def test_get_output_metadata_float_not_no_grad(self):
+        # Verify that get_output_metadata does not mark float tensor outputs
+        # as no-grad. meta["val"] is populated via detach() which strips
+        # requires_grad, so we must not rely on it.
+        from torch._higher_order_ops.invoke_subgraph import get_output_metadata
+
+        def f(x):
+            return x * 2.0, x.to(torch.int64)
+
+        x = torch.randn(4, requires_grad=True)
+        gm = make_fx(f, tracing_mode="fake")(x)
+
+        metadata = get_output_metadata(gm, x)
+        # Only the int output (index 1) should be marked as no-grad;
+        # the float output (index 0) must not be, even though meta["val"]
+        # has requires_grad=False due to detach().
+        self.assertEqual(metadata.indexes_with_no_grad, {1})
+
+
 # TODO: Need to test the guards themselves specifically as well
 class TestSymbolicTracing(TestCase):
     def _test_dynamic(self, fn, trace_inputs, test_inputs, assert_eq=True):

--- a/torch/_higher_order_ops/invoke_subgraph.py
+++ b/torch/_higher_order_ops/invoke_subgraph.py
@@ -469,8 +469,16 @@ def get_output_metadata(subgraph, *operands):
             output_metadata.indexes_with_symint.add(idx)
             output_metadata.indexes_with_no_grad.add(idx)
         elif isinstance(val, torch.Tensor):
-            # Check if tensor requires grad from metadata
-            if hasattr(val, "requires_grad") and not val.requires_grad:
+            if val.dtype.is_floating_point or val.is_complex():
+                # Can't trust requires_grad from meta["val"] since snapshot_fake
+                # uses detach() which strips it. Fall back to execution to get
+                # the accurate requires_grad for differentiable dtypes.
+                return _get_output_metadata_by_execution(subgraph, *operands)
+            else:
+                if val.requires_grad:
+                    raise AssertionError(
+                        f"Non-floating point, non-complex tensor has requires_grad=True: {val.dtype}"
+                    )
                 output_metadata.indexes_with_no_grad.add(idx)
         else:
             # Non-tensor, non-symint (shouldn't happen but be safe)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #178528

`meta["val"]` is always populated via `snapshot_fake → detach()`, which
strips `requires_grad`. This caused `get_output_metadata` to incorrectly
mark all float outputs as no-grad (0 tangents in backward) when taking
the static metadata path (e.g. in `reenter_make_fx`).

For float/complex tensor outputs, fall back to
`_get_output_metadata_by_execution` which checks `requires_grad` on the
actual executed output.

Authored with Claude.