### PR TITLE
dist/c10d: Add TorchComms backend c10d tests and fix gather on non-dst ranks

### DIFF
--- a/test/distributed/test_c10d_torchcomms.py
+++ b/test/distributed/test_c10d_torchcomms.py
@@ -1,0 +1,156 @@
+# Owner(s): ["oncall: distributed"]
+
+import unittest
+
+import torch
+import torch.distributed as dist
+from torch.distributed.distributed_c10d import _TORCHCOMM_AVAILABLE
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_distributed import C10dTorchCommsTestBase
+from torch.testing._internal.common_utils import parametrize, run_tests, subtest
+
+
+@unittest.skipIf(not _TORCHCOMM_AVAILABLE, "TorchComms is not installed")
+class TestC10dTorchCommsBasic(C10dTorchCommsTestBase):
+    REDUCE_OPS = [
+        subtest(dist.ReduceOp.SUM, name="SUM"),
+        subtest(dist.ReduceOp.AVG, name="AVG"),
+        subtest(dist.ReduceOp.MIN, name="MIN"),
+        subtest(dist.ReduceOp.MAX, name="MAX"),
+    ]
+
+    def _expected_reduce_result(self, op):
+        """Return the expected scalar result for a rank+1 input reduced across all ranks."""
+        total = sum(range(1, self.world_size + 1))
+        if op == dist.ReduceOp.SUM:
+            return total
+        elif op == dist.ReduceOp.AVG:
+            return total / self.world_size
+        elif op == dist.ReduceOp.MIN:
+            return 1
+        elif op == dist.ReduceOp.MAX:
+            return self.world_size
+        raise ValueError(f"Unsupported op: {op}")
+
+    @parametrize("op", REDUCE_OPS)
+    def test_allreduce(self, op):
+        tensor = torch.tensor([self.rank + 1], dtype=torch.float32)
+        dist.all_reduce(tensor, op=op, group=self.pg)
+        self.assertEqual(tensor.item(), self._expected_reduce_result(op))
+
+    def test_all_gather(self):
+        input_tensor = torch.tensor([self.rank], dtype=torch.float32)
+        gather_list = [torch.empty_like(input_tensor) for _ in range(self.world_size)]
+        dist.all_gather(gather_list, input_tensor, group=self.pg)
+        expected = list(range(self.world_size))
+        self.assertEqual([t.item() for t in gather_list], expected)
+
+    def test_all_gather_into_tensor(self):
+        input_tensor = torch.tensor([self.rank], dtype=torch.float32)
+        output_tensor = torch.empty(self.world_size, dtype=torch.float32)
+        dist.all_gather_into_tensor(output_tensor, input_tensor, group=self.pg)
+        expected = list(range(self.world_size))
+        self.assertEqual([t.item() for t in output_tensor], expected)
+
+    def test_broadcast(self):
+        tensor = torch.tensor([self.rank + 1], dtype=torch.float32)
+        dist.broadcast(tensor, src=0, group=self.pg)
+        self.assertEqual(tensor.item(), 1)
+
+    def test_gather(self):
+        tensor = torch.tensor([self.rank], dtype=torch.float32)
+        gather_list = None
+        if self.rank == 0:
+            gather_list = [torch.empty_like(tensor) for _ in range(self.world_size)]
+        dist.gather(tensor, gather_list=gather_list, dst=0, group=self.pg)
+        if self.rank == 0:
+            expected = list(range(self.world_size))
+            self.assertEqual([t.item() for t in gather_list], expected)
+
+    def test_scatter(self):
+        if self.rank == 0:
+            scatter_list = [
+                torch.tensor([i], dtype=torch.float32) for i in range(self.world_size)
+            ]
+        else:
+            scatter_list = None
+        tensor = torch.empty(1, dtype=torch.float32)
+        dist.scatter(tensor, scatter_list=scatter_list, src=0, group=self.pg)
+        self.assertEqual(tensor.item(), self.rank)
+
+    @parametrize("op", REDUCE_OPS)
+    def test_reduce(self, op):
+        input_tensor = torch.tensor([self.rank + 1], dtype=torch.float32)
+        dist.reduce(input_tensor, dst=0, op=op, group=self.pg)
+        if self.rank == 0:
+            self.assertEqual(input_tensor.item(), self._expected_reduce_result(op))
+
+    @parametrize("op", REDUCE_OPS)
+    def test_reduce_scatter(self, op):
+        input_tensor = [
+            torch.tensor([self.rank + 1], dtype=torch.float32)
+            for _ in range(self.world_size)
+        ]
+        output_tensor = torch.empty(1, dtype=torch.float32)
+        dist.reduce_scatter(output_tensor, input_tensor, op=op, group=self.pg)
+        self.assertEqual(output_tensor.item(), self._expected_reduce_result(op))
+
+    @parametrize("op", REDUCE_OPS)
+    def test_reduce_scatter_tensor(self, op):
+        input_tensor = torch.full(
+            (self.world_size,), self.rank + 1, dtype=torch.float32
+        )
+        output_tensor = torch.empty(1, dtype=torch.float32)
+        dist.reduce_scatter_tensor(output_tensor, input_tensor, op=op, group=self.pg)
+        self.assertEqual(output_tensor.item(), self._expected_reduce_result(op))
+
+    def test_all_to_all(self):
+        input_tensor = [
+            torch.tensor([self.rank + 1], dtype=torch.float32)
+            for _ in range(self.world_size)
+        ]
+        output_tensor = [
+            torch.empty(1, dtype=torch.float32) for _ in range(self.world_size)
+        ]
+        dist.all_to_all(output_tensor, input_tensor, group=self.pg)
+        expected = list(range(1, self.world_size + 1))
+        self.assertEqual([t.item() for t in output_tensor], expected)
+
+    def test_all_to_all_single(self):
+        input_tensor = torch.full(
+            (self.world_size,), self.rank + 1, dtype=torch.float32
+        )
+        output_tensor = torch.empty([self.world_size], dtype=torch.float32)
+        dist.all_to_all_single(output_tensor, input_tensor, group=self.pg)
+        expected = list(range(1, self.world_size + 1))
+        self.assertEqual([t.item() for t in output_tensor], expected)
+
+    def test_send_recv(self):
+        send_rank = (self.rank + 1) % self.world_size
+        recv_rank = (self.rank + self.world_size - 1) % self.world_size
+        send_tensor = torch.tensor([self.rank], dtype=torch.float32)
+        recv_tensor = torch.empty(1, dtype=torch.float32)
+        if self.rank % 2 == 0:
+            # Even ranks: send first, then receive
+            dist.send(send_tensor, dst=send_rank, group=self.pg)
+            dist.recv(recv_tensor, src=recv_rank, group=self.pg)
+        else:
+            # Odd ranks: receive first, then send
+            dist.recv(recv_tensor, src=recv_rank, group=self.pg)
+            dist.send(send_tensor, dst=send_rank, group=self.pg)
+        # Each rank receives the rank number of the sender
+        self.assertEqual(recv_tensor.item(), recv_rank)
+
+    def test_barrier(self):
+        dist.barrier(group=self.pg)
+        # If we reach this point, the barrier succeeded without deadlock
+        self.assertTrue(True)
+
+
+devices = ["cpu", "cuda", "xpu"]
+instantiate_device_type_tests(
+    TestC10dTorchCommsBasic, globals(), only_for=devices, allow_xpu=True
+)
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/distributed/test_c10d_torchcomms.py
+++ b/test/distributed/test_c10d_torchcomms.py
@@ -167,6 +167,7 @@ class TestC10dTorchCommsBasic(C10dTorchCommsTestBase):
             input_tensor,
             output_split_sizes=output_split_sizes,
             input_split_sizes=input_split_sizes,
+            group=self.pg,
         )
 
         # Verify: section from sender i should contain value (i + rank)

--- a/test/distributed/test_c10d_torchcomms.py
+++ b/test/distributed/test_c10d_torchcomms.py
@@ -17,7 +17,18 @@ class TestC10dTorchCommsBasic(C10dTorchCommsTestBase):
         subtest(dist.ReduceOp.AVG, name="AVG"),
         subtest(dist.ReduceOp.MIN, name="MIN"),
         subtest(dist.ReduceOp.MAX, name="MAX"),
+        subtest(dist.ReduceOp.PRODUCT, name="PRODUCT"),
     ]
+
+    @property
+    def _rank_value(self):
+        return self.rank + 1
+
+    def _skip_if_product_overflows(self, op):
+        if op == dist.ReduceOp.PRODUCT and self.world_size > 34:
+            self.skipTest(
+                f"world_size={self.world_size} causes float32 overflow for PRODUCT"
+            )
 
     def _expected_reduce_result(self, op):
         """Return the expected scalar result for a rank+1 input reduced across all ranks."""
@@ -30,41 +41,47 @@ class TestC10dTorchCommsBasic(C10dTorchCommsTestBase):
             return 1
         elif op == dist.ReduceOp.MAX:
             return self.world_size
+        elif op == dist.ReduceOp.PRODUCT:
+            result = 1
+            for i in range(1, self.world_size + 1):
+                result *= i
+            return result
         raise ValueError(f"Unsupported op: {op}")
 
     @parametrize("op", REDUCE_OPS)
     def test_allreduce(self, op):
-        tensor = torch.tensor([self.rank + 1], dtype=torch.float32)
+        self._skip_if_product_overflows(op)
+        tensor = torch.tensor([self._rank_value], dtype=torch.float32)
         dist.all_reduce(tensor, op=op, group=self.pg)
         self.assertEqual(tensor.item(), self._expected_reduce_result(op))
 
     def test_all_gather(self):
-        input_tensor = torch.tensor([self.rank], dtype=torch.float32)
+        input_tensor = torch.tensor([self._rank_value], dtype=torch.float32)
         gather_list = [torch.empty_like(input_tensor) for _ in range(self.world_size)]
         dist.all_gather(gather_list, input_tensor, group=self.pg)
-        expected = list(range(self.world_size))
+        expected = list(range(1, self.world_size + 1))
         self.assertEqual([t.item() for t in gather_list], expected)
 
     def test_all_gather_into_tensor(self):
-        input_tensor = torch.tensor([self.rank], dtype=torch.float32)
+        input_tensor = torch.tensor([self._rank_value], dtype=torch.float32)
         output_tensor = torch.empty(self.world_size, dtype=torch.float32)
         dist.all_gather_into_tensor(output_tensor, input_tensor, group=self.pg)
-        expected = list(range(self.world_size))
+        expected = list(range(1, self.world_size + 1))
         self.assertEqual([t.item() for t in output_tensor], expected)
 
     def test_broadcast(self):
-        tensor = torch.tensor([self.rank + 1], dtype=torch.float32)
+        tensor = torch.tensor([self._rank_value], dtype=torch.float32)
         dist.broadcast(tensor, src=0, group=self.pg)
         self.assertEqual(tensor.item(), 1)
 
     def test_gather(self):
-        tensor = torch.tensor([self.rank], dtype=torch.float32)
+        tensor = torch.tensor([self._rank_value], dtype=torch.float32)
         gather_list = None
         if self.rank == 0:
             gather_list = [torch.empty_like(tensor) for _ in range(self.world_size)]
         dist.gather(tensor, gather_list=gather_list, dst=0, group=self.pg)
         if self.rank == 0:
-            expected = list(range(self.world_size))
+            expected = list(range(1, self.world_size + 1))
             self.assertEqual([t.item() for t in gather_list], expected)
 
     def test_scatter(self):
@@ -80,15 +97,17 @@ class TestC10dTorchCommsBasic(C10dTorchCommsTestBase):
 
     @parametrize("op", REDUCE_OPS)
     def test_reduce(self, op):
-        input_tensor = torch.tensor([self.rank + 1], dtype=torch.float32)
+        self._skip_if_product_overflows(op)
+        input_tensor = torch.tensor([self._rank_value], dtype=torch.float32)
         dist.reduce(input_tensor, dst=0, op=op, group=self.pg)
         if self.rank == 0:
             self.assertEqual(input_tensor.item(), self._expected_reduce_result(op))
 
     @parametrize("op", REDUCE_OPS)
     def test_reduce_scatter(self, op):
+        self._skip_if_product_overflows(op)
         input_tensor = [
-            torch.tensor([self.rank + 1], dtype=torch.float32)
+            torch.tensor([self._rank_value], dtype=torch.float32)
             for _ in range(self.world_size)
         ]
         output_tensor = torch.empty(1, dtype=torch.float32)
@@ -97,8 +116,9 @@ class TestC10dTorchCommsBasic(C10dTorchCommsTestBase):
 
     @parametrize("op", REDUCE_OPS)
     def test_reduce_scatter_tensor(self, op):
+        self._skip_if_product_overflows(op)
         input_tensor = torch.full(
-            (self.world_size,), self.rank + 1, dtype=torch.float32
+            (self.world_size,), self._rank_value, dtype=torch.float32
         )
         output_tensor = torch.empty(1, dtype=torch.float32)
         dist.reduce_scatter_tensor(output_tensor, input_tensor, op=op, group=self.pg)
@@ -106,7 +126,7 @@ class TestC10dTorchCommsBasic(C10dTorchCommsTestBase):
 
     def test_all_to_all(self):
         input_tensor = [
-            torch.tensor([self.rank + 1], dtype=torch.float32)
+            torch.tensor([self._rank_value], dtype=torch.float32)
             for _ in range(self.world_size)
         ]
         output_tensor = [
@@ -118,12 +138,47 @@ class TestC10dTorchCommsBasic(C10dTorchCommsTestBase):
 
     def test_all_to_all_single(self):
         input_tensor = torch.full(
-            (self.world_size,), self.rank + 1, dtype=torch.float32
+            (self.world_size,), self._rank_value, dtype=torch.float32
         )
         output_tensor = torch.empty([self.world_size], dtype=torch.float32)
         dist.all_to_all_single(output_tensor, input_tensor, group=self.pg)
         expected = list(range(1, self.world_size + 1))
         self.assertEqual([t.item() for t in output_tensor], expected)
+
+    def test_all_to_all_single_with_split_sizes(self):
+        # Each rank sends (rank + 1) elements to every other rank,
+        # so rank r's input_split_sizes are all (rank + 1).
+        input_split_sizes = [self._rank_value] * self.world_size
+        # Rank r receives (sender_rank + 1) elements from each sender,
+        # so output_split_sizes[i] = i + 1.
+        output_split_sizes = [i + 1 for i in range(self.world_size)]
+
+        input_tensor = torch.empty(sum(input_split_sizes), dtype=torch.float32)
+        offset = 0
+        for dst in range(self.world_size):
+            input_tensor[offset : offset + input_split_sizes[dst]].fill_(
+                self.rank + dst
+            )
+            offset += input_split_sizes[dst]
+
+        output_tensor = torch.empty(sum(output_split_sizes), dtype=torch.float32)
+        dist.all_to_all_single(
+            output_tensor,
+            input_tensor,
+            output_split_sizes=output_split_sizes,
+            input_split_sizes=input_split_sizes,
+        )
+
+        # Verify: section from sender i should contain value (i + rank)
+        offset = 0
+        for src in range(self.world_size):
+            section = output_tensor[offset : offset + output_split_sizes[src]]
+            expected = torch.full_like(section, src + self.rank)
+            self.assertTrue(
+                torch.equal(section, expected),
+                f"Mismatch in section from rank {src}: got {section}, expected {expected}",
+            )
+            offset += output_split_sizes[src]
 
     def test_send_recv(self):
         send_rank = (self.rank + 1) % self.world_size

--- a/test/distributed/test_c10d_torchcomms.py
+++ b/test/distributed/test_c10d_torchcomms.py
@@ -25,9 +25,10 @@ class TestC10dTorchCommsBasic(C10dTorchCommsTestBase):
         return self.rank + 1
 
     def _skip_if_product_overflows(self, op):
-        if op == dist.ReduceOp.PRODUCT and self.world_size > 34:
+        if op == dist.ReduceOp.PRODUCT and self.world_size > 12:
             self.skipTest(
-                f"world_size={self.world_size} causes float32 overflow for PRODUCT"
+                f"world_size={self.world_size} > 12: PRODUCT is world_size! "
+                "and only up to 12! is exactly representable in float32"
             )
 
     def _expected_reduce_result(self, op):

--- a/test/distributed/test_device_mesh.py
+++ b/test/distributed/test_device_mesh.py
@@ -185,13 +185,6 @@ class DeviceMeshTest(DTensorTestBase):
         self.assertTrue(is_initialized())
         self.destroy_pg(self.rank)
 
-    @with_comms
-    @skip_if_lt_x_gpu(4)
-    def test_assert_invalid_mesh_tensor(self):
-        mesh = torch.arange(self.world_size).to(self.rank)
-        with self.assertRaises(ValueError):
-            DeviceMesh(self.device_type, mesh)
-
     @with_comms()
     def test_2d_mesh_non_eager_init_subgroup(self):
         mesh_shape = (2, self.world_size // 2)

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -232,7 +232,7 @@ else:
                         "Cannot provide _layout and/or _rank_map if passing explicit mesh"
                     )
                 if isinstance(mesh, torch.Tensor) and mesh.device.type != "cpu":
-                    raise ValueError(f"`mesh` must be a CPU tensor, got {mesh}")
+                    mesh = mesh.to("cpu")
                 mesh_tensor = (
                     mesh.detach().to(dtype=torch.int).contiguous()
                     if isinstance(mesh, torch.Tensor)

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -4612,7 +4612,15 @@ def gather(
     group_dst = _canonicalize_group_rank(group, dst, group_dst, return_global=False)
     my_group_rank = group.rank()
     _validate_output_list_for_rank(my_group_rank, group_dst, gather_list)
-    output_tensors = [gather_list] if group_dst == my_group_rank else []
+    if group_dst == my_group_rank:
+        output_tensors = [gather_list]
+    elif _use_torchcomms_enabled():
+        # TorchComms BackendWrapper::gather requires exactly one entry in
+        # outputTensors on all ranks (including non-dst), so we pass [[]] instead
+        # of [] to satisfy the TORCH_CHECK(outputTensors.size() == 1) guard.
+        output_tensors = [[]]
+    else:
+        output_tensors = []
     input_tensors = [tensor]
 
     opts = GatherOptions()

--- a/torch/optim/adam.py
+++ b/torch/optim/adam.py
@@ -172,7 +172,7 @@ class Adam(Optimizer):
                             device=p.device,
                         )
                         if group["capturable"] or group["fused"]
-                        else torch.tensor(0.0, dtype=_get_scalar_dtype())
+                        else torch.tensor(0.0, dtype=_get_scalar_dtype(), device="cpu")
                     )
                     # Exponential moving average of gradient values
                     state["exp_avg"] = torch.zeros_like(

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -35,6 +35,7 @@ import torch.nn as nn
 from torch._C._autograd import DeviceType
 from torch._C._distributed_c10d import _SymmetricMemory
 from torch._logging._internal import trace_log
+from torch.distributed.distributed_c10d import _TORCHCOMM_AVAILABLE
 from torch.testing._internal import common_utils
 from torch.testing._internal.common_utils import (
     FILE_SCHEMA,
@@ -57,6 +58,28 @@ from torch.testing._internal.distributed.multi_threaded_pg import (
     ProcessLocalGroup,
 )
 
+
+TORCHCOMM_HAS_GLOO = False
+TORCHCOMM_HAS_XCCL = False
+TORCHCOMM_HAS_NCCL = False
+TORCHCOMM_HAS_RCCL = False
+TORCHCOMM_HAS_NCCLX = False
+TORCHCOMM_HAS_RCCLX = False
+if _TORCHCOMM_AVAILABLE:
+    import torchcomms
+
+    for _backend, _flag in [
+        ("gloo", "TORCHCOMM_HAS_GLOO"),
+        ("xccl", "TORCHCOMM_HAS_XCCL"),
+        ("nccl", "TORCHCOMM_HAS_NCCL"),
+        ("rcclx", "TORCHCOMM_HAS_RCCLX"),
+        ("ncclx", "TORCHCOMM_HAS_NCCLX"),
+    ]:
+        try:
+            torchcomms._load_backend(_backend)
+            globals()[_flag] = True
+        except ImportError:
+            pass
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -1213,12 +1236,56 @@ class DistributedTestBase(MultiProcessTestCase):
             store=store,
         )
         if "nccl" in self.backend(device) or "xccl" in self.backend(device):
-            torch.accelerator.set_device_index(self.rank)
+            accelerator = torch.accelerator.current_accelerator()
+            if accelerator:
+                device_type = accelerator.type
+                device = torch.device(f"{device_type}:{self.rank}")
+                torch.set_default_device(device)
+                torch.accelerator.set_device_index(device)
+            else:
+                raise RuntimeError(
+                    f"Expected to find an accelerator when initializing process group"
+                    f" with {self.backend(device)} backend, but got None"
+                )
         return torch.distributed.distributed_c10d._get_default_group()
 
     def rank_to_device(self, device):
         num_visible_devices = torch.get_device_module(device).device_count()
         return {i: [i % num_visible_devices] for i in range(self.world_size)}
+
+
+class C10dTorchCommsTestBase(DistributedTestBase):
+    def _skip_if_backend_unavailable(self, test_name: str, device: str) -> None:
+        backend_flags = {
+            "gloo": TORCHCOMM_HAS_GLOO,
+            "xccl": TORCHCOMM_HAS_XCCL,
+            "nccl": TORCHCOMM_HAS_NCCL,
+            "rccl": TORCHCOMM_HAS_RCCL,
+            "ncclx": TORCHCOMM_HAS_NCCLX,
+            "rcclx": TORCHCOMM_HAS_RCCLX,
+        }
+        backend = self.backend(device)
+        if backend in backend_flags and not backend_flags[backend]:
+            self.skipTest(
+                f"Skipping {test_name} since torchcomms does not have {backend} support"
+            )
+
+    def setUp(self) -> None:
+        super().setUp()
+        device = getattr(self, "device_type", getattr(self, "device", "cpu"))
+        self._skip_if_backend_unavailable(self._current_test_name(), device)
+
+    @retry_on_connect_failures
+    def run_test(self, test_name: str, parent_pipe) -> None:
+        torch.distributed.config.use_torchcomms = True
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = str(find_free_port())
+        os.environ["TORCHCOMM_RANK"] = str(self.rank)
+        os.environ["TORCHCOMM_SIZE"] = str(self.world_size)
+        os.environ["TORCHCOMM_STORE_PATH"] = self.file_name
+        device = getattr(self, "device_type", getattr(self, "device", "cpu"))
+        self.pg = self.create_pg(device)
+        super().run_test(test_name, parent_pipe)
 
 
 def run_subtests(

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -1254,40 +1254,6 @@ class DistributedTestBase(MultiProcessTestCase):
         return {i: [i % num_visible_devices] for i in range(self.world_size)}
 
 
-class C10dTorchCommsTestBase(DistributedTestBase):
-    def _skip_if_backend_unavailable(self, test_name: str, device: str) -> None:
-        backend_flags = {
-            "gloo": TORCHCOMM_HAS_GLOO,
-            "xccl": TORCHCOMM_HAS_XCCL,
-            "nccl": TORCHCOMM_HAS_NCCL,
-            "rccl": TORCHCOMM_HAS_RCCL,
-            "ncclx": TORCHCOMM_HAS_NCCLX,
-            "rcclx": TORCHCOMM_HAS_RCCLX,
-        }
-        backend = self.backend(device)
-        if backend in backend_flags and not backend_flags[backend]:
-            self.skipTest(
-                f"Skipping {test_name} since torchcomms does not have {backend} support"
-            )
-
-    def setUp(self) -> None:
-        super().setUp()
-        device = getattr(self, "device_type", getattr(self, "device", "cpu"))
-        self._skip_if_backend_unavailable(self._current_test_name(), device)
-
-    @retry_on_connect_failures
-    def run_test(self, test_name: str, parent_pipe) -> None:
-        torch.distributed.config.use_torchcomms = True
-        os.environ["MASTER_ADDR"] = "localhost"
-        os.environ["MASTER_PORT"] = str(find_free_port())
-        os.environ["TORCHCOMM_RANK"] = str(self.rank)
-        os.environ["TORCHCOMM_SIZE"] = str(self.world_size)
-        os.environ["TORCHCOMM_STORE_PATH"] = self.file_name
-        device = getattr(self, "device_type", getattr(self, "device", "cpu"))
-        self.pg = self.create_pg(device)
-        super().run_test(test_name, parent_pipe)
-
-
 def run_subtests(
     cls_inst,
     subtest_config: dict[str, list[Any]],
@@ -2175,3 +2141,72 @@ class MultiProcContinuousTest(TestCase):
                 raise ValueError(
                     f"no such test method in {self.__class__}: {methodName}"
                 ) from e
+
+
+class C10dTorchCommsTestBase(MultiProcContinuousTest):
+    world_size: int = DEFAULT_WORLD_SIZE
+
+    @staticmethod
+    def backend(device) -> str:
+        if "cuda" in device:
+            return "nccl"
+        elif "hpu" in device:
+            return "hccl"
+        elif "xpu" in device:
+            return "xccl"
+        else:
+            return "gloo"
+
+    @classmethod
+    def backend_str(cls) -> str:
+        device_type = cls.device_type
+        if callable(device_type):
+            device_type = device_type()
+        return cls.backend(device_type)
+
+    def _skip_if_backend_unavailable(self, device: str) -> None:
+        backend_flags = {
+            "gloo": TORCHCOMM_HAS_GLOO,
+            "xccl": TORCHCOMM_HAS_XCCL,
+            "nccl": TORCHCOMM_HAS_NCCL,
+            "rccl": TORCHCOMM_HAS_RCCL,
+            "ncclx": TORCHCOMM_HAS_NCCLX,
+            "rcclx": TORCHCOMM_HAS_RCCLX,
+        }
+        backend_name = self.backend(device)
+        if backend_name in backend_flags and not backend_flags[backend_name]:
+            self.skipTest(f"torchcomms {backend_name} backend is not available")
+
+    @classmethod
+    def _init_pg(cls, rank, world_size, rdvz_file):
+        torch.distributed.config.use_torchcomms = True
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = str(find_free_port())
+        os.environ["TORCHCOMM_RANK"] = str(rank)
+        os.environ["TORCHCOMM_SIZE"] = str(world_size)
+        os.environ["TORCHCOMM_STORE_PATH"] = rdvz_file
+        super()._init_pg(rank, world_size, rdvz_file)
+        # Set up accelerator device if using nccl/xccl backend
+        backend = cls.backend_str()
+        if "nccl" in backend or "xccl" in backend:
+            accelerator = torch.accelerator.current_accelerator()
+            if accelerator:
+                device = torch.device(f"{accelerator.type}:{rank}")
+                torch.set_default_device(device)
+                torch.accelerator.set_device_index(device)
+            else:
+                raise RuntimeError(
+                    f"Expected to find an accelerator when initializing process group with {backend} backend, but got None"
+                )
+
+    def setUp(self) -> None:
+        device_type = self.__class__.device_type
+        logger.debug("Setting up test: %s on device type: %s", self.id(), device_type)
+        if callable(device_type):
+            device_type = device_type()
+        self._skip_if_backend_unavailable(str(device_type))
+        super().setUp()
+
+    def rank_to_device(self, device):
+        num_visible_devices = torch.get_device_module(device).device_count()
+        return {i: [i % num_visible_devices] for i in range(self.world_size)}

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -75,11 +75,8 @@ if _TORCHCOMM_AVAILABLE:
         ("rcclx", "TORCHCOMM_HAS_RCCLX"),
         ("ncclx", "TORCHCOMM_HAS_NCCLX"),
     ]:
-        try:
-            torchcomms._load_backend(_backend)
+        if torchcomms.is_backend_built(_backend):
             globals()[_flag] = True
-        except ImportError:
-            pass
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)


### PR DESCRIPTION
Add `test/distributed/test_c10d_torchcomms.py` with collective tests (`allreduce`, `all_gather`, `broadcast`, `gather`, `scatter`, `reduce`, `reduce_scatter`, `all_to_all`, `send`, `recv` and `barrier`) for `cpu`/`cuda`/`xpu`.

Add `C10dTorchCommsTestBase` in `common_distributed.py` with per-backend availability checks and TorchComms env/pg setup via `run_test()`

Fix  `gather()` in `distributed_c10d.py` to pass `[[]]` instead of `[]` on non-dst ranks when TorchComms is enabled, satisfying its `outputTensors.size() == 1` guard

Update DistributedTestBase to use `torch.accelerator.current_accelerator()` for device initialization with `nccl`/`xccl` backends

cc @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci @aditvenk @xmfan