### PR TITLE
[WIP] faketensor cpp: proxy_tensor integration

### DIFF
--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -2958,6 +2958,9 @@ Call this whenever a new thread is created in order to propagate values from
   py_module.def("_exit_fake_tensor_mode", []() {
     c10::impl::FakeTensorModeTLS::reset_state();
   });
+  py_module.def("_is_cpp_fake_tensor_mode_active", []() -> bool {
+    return c10::impl::FakeTensorModeTLS::get_state() != nullptr;
+  });
 
   py_module.def("_set_meta_in_tls_dispatch_include", [](bool meta_in_tls) {
     auto local_keyset = c10::impl::tls_local_dispatch_key_set();

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -64,6 +64,8 @@ def is_fake(x: object) -> bool:
     if isinstance(x, Tensor) and torch._C._is_fake_tensor(x):
         return True
     return False
+
+
 from torch._subclasses.functional_tensor import FunctionalTensor
 from torch._subclasses.meta_utils import is_sparse_any
 from torch.fx import GraphModule, Proxy, Tracer
@@ -680,9 +682,6 @@ def extract_val(val: _ExtractValType, include_real: bool = False) -> _ExtractVal
     elif isinstance(val, Tensor):
         if not val.is_sparse:
             if torch._C._is_cpp_fake_tensor_mode_active():
-                # C++ fake mode is active — create metadata via C++ path.
-                # Cannot create a Python FakeTensorMode here as it conflicts
-                # with the C++ Fake dispatch key in TLS.
                 return torch.empty_strided(
                     val.shape, val.stride(), device=val.device, dtype=val.dtype
                 )

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -682,9 +682,10 @@ def extract_val(val: _ExtractValType, include_real: bool = False) -> _ExtractVal
     elif isinstance(val, Tensor):
         if not val.is_sparse:
             if torch._C._is_cpp_fake_tensor_mode_active():
-                return torch.empty_strided(
+                return torch.empty_strided(  # revist
                     val.shape, val.stride(), device=val.device, dtype=val.dtype
                 )
+
             # NB: Kinda hacky, but we should try to get val as the metadata
             # everywhere
             # TODO: This doesn't properly track storages.  A more robust

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -53,9 +53,17 @@ from torch._subclasses.fake_tensor import (
     FakeTensor,
     FakeTensorMode,
     get_plain_tensors,
-    is_fake,
+    is_fake as _is_fake_python,
     unset_fake_temporarily,
 )
+
+
+def is_fake(x: object) -> bool:
+    if _is_fake_python(x):
+        return True
+    if isinstance(x, Tensor) and torch._C._is_fake_tensor(x):
+        return True
+    return False
 from torch._subclasses.functional_tensor import FunctionalTensor
 from torch._subclasses.meta_utils import is_sparse_any
 from torch.fx import GraphModule, Proxy, Tracer
@@ -632,6 +640,7 @@ def snapshot_fake(val: Tensor, include_real: bool = False) -> Tensor | None:
     if isinstance(val, FakeTensor):
         return fast_detach(val.fake_mode, val, include_real)
     else:
+        # C++ fake tensors are plain Tensors — detach is sufficient
         return val.detach()
 
 
@@ -653,6 +662,8 @@ _ExtractValType: TypeAlias = (
 
 def extract_val(val: _ExtractValType, include_real: bool = False) -> _ExtractValType:
     if is_fake(val):
+        # Handles both Python FakeTensors and C++ fake tensors.
+        # Python FakeTensors use fast_detach; C++ fake tensors use detach.
         return snapshot_fake(val, include_real=include_real)
     elif isinstance(val, py_sym_types):
         return val
@@ -668,6 +679,13 @@ def extract_val(val: _ExtractValType, include_real: bool = False) -> _ExtractVal
         return {k: extract_val(v) for k, v in val.items()}
     elif isinstance(val, Tensor):
         if not val.is_sparse:
+            if torch._C._is_cpp_fake_tensor_mode_active():
+                # C++ fake mode is active — create metadata via C++ path.
+                # Cannot create a Python FakeTensorMode here as it conflicts
+                # with the C++ Fake dispatch key in TLS.
+                return torch.empty_strided(
+                    val.shape, val.stride(), device=val.device, dtype=val.dtype
+                )
             # NB: Kinda hacky, but we should try to get val as the metadata
             # everywhere
             # TODO: This doesn't properly track storages.  A more robust
@@ -1443,7 +1461,7 @@ class PythonKeyTracer(Tracer):
             val = v.meta["val"]
             # other subclasses like FunctionalTensor error on `extract_val`
             # "Attempting to use FunctionalTensor on its own." just store FakeTensors for now
-            if isinstance(val, torch.Tensor) and not isinstance(val, FakeTensor):
+            if isinstance(val, torch.Tensor) and not is_fake(val):
                 return None
             return extract_val(v.meta["val"])
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #178537
* #178432
* #178030
* #178431
* #178430
* #178429
* #178428
* #178536

Teach proxy_tensor's is_fake() to recognize C++ fake tensors and
handle them in extract_val/snapshot_fake.