### PR TITLE
Fix downstream consumers for CK f1746955 upgrade

### DIFF
--- a/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_fwd_ck.hip
+++ b/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_fwd_ck.hip
@@ -112,6 +112,8 @@ fmha_fwd_args get_ck_fmha_fwd_args(bool has_lse,
                          nullptr, // seqlen_k_ptr
                          nullptr, // cu_seqlen_q_ptr
                          nullptr, // cu_seqlen_k_ptr
+                         nullptr, // block_scale_seqstart_q_ptr
+                         nullptr, // block_scale_seqstart_k_ptr
                          nullptr, // sink_ptr
                          seqlen_q,
                          seqlen_k,
@@ -136,6 +138,9 @@ fmha_fwd_args get_ck_fmha_fwd_args(bool has_lse,
                          nhead_stride_randval,
                          nhead_stride_lse,
                          nhead_stride_o,
+                         0,                                 // nhead_stride_q_descale
+                         0,                                 // nhead_stride_k_descale
+                         0,                                 // nhead_stride_v_descale
                          batch_stride_q,
                          batch_stride_k,
                          batch_stride_v,
@@ -143,6 +148,9 @@ fmha_fwd_args get_ck_fmha_fwd_args(bool has_lse,
                          batch_stride_randval,
                          batch_stride_lse,
                          batch_stride_o,
+                         0,                                 // batch_stride_q_descale
+                         0,                                 // batch_stride_k_descale
+                         0,                                 // batch_stride_v_descale
                          mask.left,
                          mask.right,
                          0,                                 // sink_size
@@ -150,7 +158,9 @@ fmha_fwd_args get_ck_fmha_fwd_args(bool has_lse,
                          -1,                                // min_seqlen_q
                          p_dropout,
                          has_dropout_randval,
-                         drop_seed_offset};
+                         std::pair<const void*, const void*>{drop_seed_offset.first, drop_seed_offset.second},
+                         0,                                 // block_scale_size_q
+                         0};                                // block_scale_size_kv
 }
 
 std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor>

--- a/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_varlen_fwd_ck.hip
+++ b/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_varlen_fwd_ck.hip
@@ -113,6 +113,8 @@ fmha_fwd_args get_ck_fmha_varlen_fwd_args(bool has_lse,
                          nullptr, // seqlen_k_ptr
                          nullptr, // cu_seqlen_q_ptr
                          nullptr, // cu_seqlen_k_ptr
+                         nullptr, // block_scale_seqstart_q_ptr
+                         nullptr, // block_scale_seqstart_k_ptr
                          nullptr, // sink_ptr
                          total_q,
                          total_k,
@@ -137,6 +139,9 @@ fmha_fwd_args get_ck_fmha_varlen_fwd_args(bool has_lse,
                          nhead_stride_randval,
                          nhead_stride_lse,
                          nhead_stride_o,
+                         0, // nhead_stride_q_descale
+                         0, // nhead_stride_k_descale
+                         0, // nhead_stride_v_descale
                          batch_stride_q,
                          batch_stride_k,
                          batch_stride_v,
@@ -144,14 +149,19 @@ fmha_fwd_args get_ck_fmha_varlen_fwd_args(bool has_lse,
                          batch_stride_randval,
                          batch_stride_lse,
                          batch_stride_o,
+                         0, // batch_stride_q_descale
+                         0, // batch_stride_k_descale
+                         0, // batch_stride_v_descale
                          mask.left,
                          mask.right,
                          0,             // sink_size
                          static_cast<ck_tile::index_t>(mask.type),
-                         -1,                                // min_seqlen_q
+                         -1,            // min_seqlen_q
                          p_dropout,
                          has_dropout_randval,
-                         drop_seed_offset};
+                         std::pair<const void*, const void*>{drop_seed_offset.first, drop_seed_offset.second},
+                         0,             // block_scale_size_q
+                         0};            // block_scale_size_kv
 }
 
 std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor>


### PR DESCRIPTION
Summary:
- Update fmha_fwd_args aggregate initialization in mha_fwd_ck.hip and
  mha_varlen_fwd_ck.hip for new struct fields (block_scale pointers,
  descale strides, block_scale sizes) and drop_seed_offset type change
  to std::variant
- Remove deleted test targets (test_software_exp2, test_xcd_scheduling,
  test_l2_swizzle, test_fmha_fa4_rescale) and deleted
  example/91_tile_program/fmha references from BUCK
- Add num_groups_to_merge field to CKGroupedConvFwdOp Python dataclass
  to match new template parameter
- Add missing libfb/py:parutil dependency for ck4inductor

Differential Revision: D98344491


