### PR TITLE
[ROCm][Inductor] Don't apply pointer_range_32 to user-defined Triton kernels

### DIFF
--- a/test/inductor/test_codegen_triton.py
+++ b/test/inductor/test_codegen_triton.py
@@ -396,6 +396,38 @@ class TestCodegenTriton(InductorTestCase):
             "Expected at least one generated Triton kernel body to match",
         )
 
+    @unittest.skipUnless(torch.version.hip is not None, "pointer_range_32 is HIP-only")
+    @unittest.skipUnless(HAS_GPU_AND_TRITON, "requires GPU and Triton")
+    def test_pointer_range_not_in_user_defined_triton_kernel(self):
+        """User-defined Triton kernels should not get pointer_range_32."""
+        import triton
+        import triton.language as tl
+
+        @triton.jit
+        def add_kernel(in_ptr0, in_ptr1, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+            pid = tl.program_id(axis=0)
+            offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+            mask = offsets < n_elements
+            x = tl.load(in_ptr0 + offsets, mask=mask)
+            y = tl.load(in_ptr1 + offsets, mask=mask)
+            tl.store(out_ptr + offsets, x + y, mask=mask)
+
+        def fn(x, y):
+            out = torch.empty_like(x)
+            n = x.numel()
+
+            def grid(meta):
+                return (triton.cdiv(n, meta["BLOCK_SIZE"]),)
+
+            add_kernel[grid](x, y, out, n, BLOCK_SIZE=128)
+            return out
+
+        x = torch.randn(64, 64, device=GPU_TYPE, dtype=torch.bfloat16)
+        y = torch.randn(64, 64, device=GPU_TYPE, dtype=torch.bfloat16)
+        _, code = run_and_get_code(torch.compile(fn), x, y)
+        code_str = " ".join(code)
+        self.assertNotIn("tt.pointer_range", code_str)
+
 
 if __name__ == "__main__":
     from torch._inductor.test_case import run_tests

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -2943,6 +2943,7 @@ class PythonWrapperCodegen(CodeGen):
                 config_of(
                     signature,
                     indices=arg_indices,
+                    pointer_range_override=(),
                 )
             ],
         }


### PR DESCRIPTION
User-defined Triton kernels (written with @triton.jit and called inside torch.compile) may contain pointer patterns that CanonicalizePointers cannot decompose (flagged by https://github.com/pytorch/pytorch/pull/178300), causing compilation crashes. Since we cannot guarantee compatibility, disable pointer_range_32 for user kernels by passing pointer_range_override=() in define_user_defined_triton_kernel.

Inductor-generated kernels are unaffected as they continue to get pointer_range_32 through the TritonKernel.codegen_kernel() path.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben