### PR TITLE
[CI] Migrate facebook-github-bot to facebook-github-tools

### DIFF
--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -665,7 +665,7 @@ def can_skip_internal_checks(pr: GitHubPR, comment_id: int | None = None) -> boo
     comment = pr.get_comment_by_id(comment_id)
     if comment.editor_login is not None:
         return False
-    return comment.author_login == "facebook-github-bot"
+    return comment.author_login == "facebook-github-tools[bot]"
 
 
 def _revlist_to_prs(

--- a/tools/stats/upload_external_contrib_stats.py
+++ b/tools/stats/upload_external_contrib_stats.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 
 FILTER_OUT_USERS = {
     "pytorchmergebot",
-    "facebook-github-bot",
+    "facebook-github-tools[bot]",
     "pytorch-bot[bot]",
     "pytorchbot",
     "pytorchupdatebot",


### PR DESCRIPTION
Update bot identity references following the migration from facebook-github-bot to facebook-github-tools.

Authored with Claude.