### PR TITLE
Add detectron2_maskrcnn_r_50_c4 model to detectron2_models

### DIFF
--- a/benchmarks/dynamo/torchbench.yaml
+++ b/benchmarks/dynamo/torchbench.yaml
@@ -148,6 +148,7 @@ detectron2_models: &DETECTRON2_MODELS
   - detectron2_maskrcnn_r_101_c4
   - detectron2_maskrcnn_r_101_fpn
   - detectron2_maskrcnn_r_50_fpn
+  - detectron2_maskrcnn_r_50_c4
 
 
 # These models support only train mode. So accuracy checking can't be done in


### PR DESCRIPTION
Self explanatory. 

Caught this while trying to benchmark models on different devices.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98 @Lucaskabela