### PR TITLE
Fix: Repsect include_last_offset in cuda EmbeddingBag

### DIFF
--- a/aten/src/ATen/native/cuda/EmbeddingBag.cu
+++ b/aten/src/ATen/native/cuda/EmbeddingBag.cu
@@ -58,7 +58,7 @@ __global__ void EmbeddingBag_updateOutputKernel_max(
     index_t *offset2bag, int64_t numIndices, int64_t numBags,
     int64_t featureSize, int64_t weight_stride0, int64_t weight_stride1,
     index_t *bag_size, index_t *max_indices,
-    index_t padding_idx, int64_t numRows) {
+    index_t padding_idx, int64_t numRows, bool include_last_offset) {
 
   // the strategy here is that each bag x feature is handled by a single thread
 
@@ -73,7 +73,7 @@ __global__ void EmbeddingBag_updateOutputKernel_max(
       int64_t bag = chunk / chunksPerBag;
       const scalar_t *weightFeat = weight + featureDim * weight_stride1;
       int64_t begin = bag == 0 ? 0 : offsets[bag]; // forces first offset to be 0 instead of asserting on it
-      int64_t end = (bag < numBags - 1) ? (offsets[bag + 1]) : numIndices;
+      int64_t end = (bag < numBags - 1) ? (offsets[bag + 1]) : (include_last_offset ? (offsets[bag + 1]) :  numIndices);
       CUDA_KERNEL_ASSERT(end >= begin);
       scalar_t weightFeatMax = 0;
       int64_t bag_size_ = 0;
@@ -118,7 +118,7 @@ __global__ void EmbeddingBag_updateOutputKernel_sum_mean(
     int64_t featureSize, int64_t weight_stride0, int64_t weight_stride1,
     int mode, index_t *bag_size,
     const scalar_t* per_sample_weights, int64_t per_sample_weights_stride,
-    index_t padding_idx, int64_t numRows) {
+    index_t padding_idx, int64_t numRows, bool include_last_offset) {
 
   // the strategy here is that each bag x feature is handled by a single thread
 
@@ -134,7 +134,7 @@ __global__ void EmbeddingBag_updateOutputKernel_sum_mean(
       int64_t bag = chunk / chunksPerBag;
       const scalar_t *weightFeat = weight + featureDim * weight_stride1;
       int64_t begin = bag == 0 ? 0 : offsets[bag]; // forces first offset to be 0 instead of asserting on it
-      int64_t end = (bag < numBags - 1) ? (offsets[bag + 1]) : numIndices;
+      int64_t end = (bag < numBags - 1) ? (offsets[bag + 1]) : (include_last_offset ? (offsets[bag + 1]) :  numIndices);
       CUDA_KERNEL_ASSERT(end >= begin);
       accscalar_t weightFeatSum = 0;
       int64_t bag_size_ = 0;
@@ -412,7 +412,7 @@ _embedding_bag_cuda(const Tensor &weight, const Tensor &indices_,
             offset2bag.mutable_data_ptr<index_t>(), numIndices, numBags, featureSize,
             weight.stride(0), weight.stride(1), bag_size.mutable_data_ptr<index_t>(),
             max_indices.mutable_data_ptr<index_t>(),
-            padding_idx, weight.size(0));
+            padding_idx, weight.size(0), include_last_offset);
         C10_CUDA_KERNEL_LAUNCH_CHECK();
       } else {
         EmbeddingBag_updateOutputKernel_sum_mean<scalar_t, index_t><<<grid, block, 0, stream>>>(
@@ -422,7 +422,7 @@ _embedding_bag_cuda(const Tensor &weight, const Tensor &indices_,
             weight.stride(0), weight.stride(1), mode, bag_size.mutable_data_ptr<index_t>(),
             per_sample_weights.defined() ? per_sample_weights.const_data_ptr<scalar_t>() : NULL,
             per_sample_weights.defined() ? per_sample_weights.stride(0) : 0,
-            padding_idx, weight.size(0));
+            padding_idx, weight.size(0), include_last_offset);
         C10_CUDA_KERNEL_LAUNCH_CHECK();
       }
     });

--- a/test/nn/test_embedding.py
+++ b/test/nn/test_embedding.py
@@ -1939,6 +1939,26 @@ class TestEmbeddingNNDeviceType(NNTestCase):
         w = torch.rand(3, 4, device=device, requires_grad=per_sample_weights_use_grad)
         bag(x, per_sample_weights=F.softmax(w, dim=-1))
 
+    @onlyOn(["cuda", "xpu"])
+    @dtypes(torch.float, torch.double)
+    def test_embedding_bag_include_last_offset_device(self, device, dtype):
+        # Regression test: CUDA/XPU kernels must respect include_last_offset
+        # when offsets[-1] < len(input) (trailing indices must not leak into the last bag)
+        torch.manual_seed(0)
+        weight = torch.randn(10, 4, dtype=dtype, device=device)
+        indices = torch.tensor([0, 1, 2, 3, 4, 5], device=device, dtype=torch.long)
+        # offsets[-1]=5, len(indices)=6: index 5 must be excluded from all bags
+        offsets = torch.tensor([0, 2, 5], device=device, dtype=torch.long)
+        for mode in ("sum", "mean", "max"):
+            result = F.embedding_bag(
+                indices, weight, offsets, mode=mode, include_last_offset=True
+            )
+            expected = self._embedding_bag_reference_impl(
+                indices.cpu(), weight.cpu(), offsets.cpu(),
+                mode=mode, include_last_offset=True,
+            )
+            self.assertEqual(result.cpu(), expected)
+
 
 instantiate_device_type_tests(TestEmbeddingNNDeviceType, globals(), allow_xpu=True)
 instantiate_parametrized_tests(TestEmbeddingNN)


### PR DESCRIPTION
Both EmbeddingBag_updateOutputKernel_max and EmbeddingBag_updateOutputKernel_sum_mean were computing the end index for the last bag by unconditionally using numIndices. When include_last_offset=true the offsets tensor has an extra sentinel element (equal to numIndices), so the kernels should read offsets[bag+1] for the last bag just as they do for all others.

Add include_last_offset as a parameter to both kernels and update the end-index computation accordingly, passing the flag through from _embedding_bag_cuda at the call sites.

fix: https://github.com/pytorch/pytorch/issues/178614
