### PR TITLE
Prevent cross-stream inplace buffer reuse

### DIFF
--- a/test/inductor/test_user_streams.py
+++ b/test/inductor/test_user_streams.py
@@ -1310,9 +1310,7 @@ class TestStreamOrderingStress(InductorTestCase):
     #    Without the event.wait() the consumer would launch immediately
     #    and read stale memory because the producer chain hasn't finished.
     # ------------------------------------------------------------------
-    @unittest.skip(
-        "Pre-existing cross-stream buffer reuse bug — needs record_stream support"
-    )
+
     def test_race_producer_consumer(self):
         N = self.N
 
@@ -1373,9 +1371,7 @@ class TestStreamOrderingStress(InductorTestCase):
     # 3. Race: fan-out where the producer is slow.
     #    All three consumers depend on the producer finishing.
     # ------------------------------------------------------------------
-    @unittest.skip(
-        "Pre-existing cross-stream buffer reuse bug — needs record_stream support"
-    )
+
     def test_race_fan_out(self):
         N = self.N
 
@@ -1505,9 +1501,7 @@ class TestStreamOrderingStress(InductorTestCase):
     # ------------------------------------------------------------------
     # 6. Race: back-to-back sync, both directions carry heavy work
     # ------------------------------------------------------------------
-    @unittest.skip(
-        "Pre-existing cross-stream buffer reuse bug — needs record_stream support"
-    )
+
     def test_race_back_to_back(self):
         N = self.N
 

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -916,8 +916,32 @@ class BaseSchedulerNode:
                         for x in input_buf.users
                         if x.node.get_name() not in inconsequential_nodes
                     ]
+                    # In multi-stream graphs, don't reuse a buffer if
+                    # completed (codegen'd) users on other streams may
+                    # still be reading it on the GPU.
+                    has_cross_stream_hazard = False
+                    if self.scheduler._has_multi_stream_nodes():
+                        my_stream = self.scheduler.node_to_stream.get(self)
+                        for user in input_buf.users:
+                            unode = user.node
+                            if (
+                                isinstance(unode, BaseSchedulerNode)
+                                and unode is not self
+                                and unode.get_name() in inconsequential_nodes
+                            ):
+                                user_stream = self.scheduler.node_to_stream.get(
+                                    unode
+                                )
+                                if (
+                                    user_stream is not None
+                                    and user_stream != my_stream
+                                ):
+                                    has_cross_stream_hazard = True
+                                    break
+
                     if (
-                        len(remaining_uses) == 1
+                        not has_cross_stream_hazard
+                        and len(remaining_uses) == 1
                         and remaining_uses[0].can_inplace
                         and remaining_uses[0].node is self
                         and input_buf.node is not None


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #178254
* #178252
* #178549
* __->__ #178548
* #178547
* #178471

In multi-stream graphs, the inplace buffer optimization could reuse a
buffer whose previous users on other streams haven't finished reading
it on the GPU. This caused fan-out patterns to silently corrupt data
when a consumer stream's inplace write overlapped with another stream
still reading the same buffer.

Fix by checking for cross-stream hazards in `decide_inplace_update`:
if any completed user of the input buffer lives on a different stream,
skip the inplace optimization and allocate a fresh buffer instead.

Unskips `test_race_producer_consumer`, `test_race_fan_out`, and
`test_race_back_to_back` which now pass.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo