### PR TITLE
Prevent cross-stream memory planning buffer reuse

### DIFF
--- a/test/inductor/test_user_streams.py
+++ b/test/inductor/test_user_streams.py
@@ -1167,7 +1167,7 @@ with torch.cuda._DeviceGuard(0):
         torch.ops.streams.record_event.default(4, 1)
     with torch.cuda.stream(stream3):
         torch.ops.streams.wait_event.default(4, 2)
-        buf6 = buf0; del buf0
+        buf6 = empty_strided_cuda((32, 32), (32, 1), torch.float32)
         extern_kernels.mm(buf3, arg3_1, out=buf6)
     return (buf6, )""",
         )
@@ -1264,9 +1264,9 @@ with torch.cuda._DeviceGuard(0):
     with torch.cuda.stream(default_stream):
         torch.ops.streams.wait_event.default(2, 4)
         torch.ops.streams.wait_event.default(3, 4)
-        buf6 = buf0; del buf0
+        buf6 = empty_strided_cuda((32, 32), (32, 1), torch.float32)
         stream0 = get_raw_stream(0)
-        triton_kernel.run(buf6, buf2, 1024, stream=stream0)
+        triton_kernel.run(buf0, buf2, buf6, 1024, stream=stream0)
     return (buf6, )""",  # noqa: B950
         )
 
@@ -1421,7 +1421,6 @@ class TestStreamOrderingStress(InductorTestCase):
     # 4. Race: diamond pattern with heavy work on both branches.
     #    The join must wait for both branches.
     # ------------------------------------------------------------------
-    @unittest.skip("requires cross-stream buffer reuse fix")
     def test_race_diamond(self):
         N = self.N
 

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -920,6 +920,23 @@ class AllocateLine(MemoryPlanningLine):
         key = buffer_reuse_key(self.node)
         if config.allow_buffer_reuse and key in state:
             free_line = state.pop(key)
+            # In multi-stream graphs, only reuse buffers from the same stream
+            # to avoid races where a stream is still reading a buffer whose
+            # memory slot gets reused by a different stream.
+            if V.graph.scheduler._has_multi_stream_nodes():
+                alloc_stream = V.graph.scheduler.buff_to_stream.get(
+                    self.node.get_name()
+                )
+                free_stream = V.graph.scheduler.buff_to_stream.get(
+                    free_line.node.get_name()
+                )
+                if (
+                    alloc_stream is not None
+                    and free_stream is not None
+                    and alloc_stream != free_stream
+                ):
+                    state.push(key, free_line)
+                    return self
             size = V.graph.sizevars.optimization_hint(
                 V.graph.get_allocation_storage_size(self.node), fallback=0
             ) * get_dtype_size(self.node.get_dtype())


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #178254
* #178252
* __->__ #178549
* #178548
* #178547
* #178471

The memory planner's `AllocateLine.plan()` could reuse a freed buffer's
memory slot for a new allocation on a different stream. This caused
diamond-pattern workloads to corrupt data when one stream's write
aliased memory still being read by another stream.

Fix by checking stream affinity when popping from the reuse pool: if the
freed buffer and the new allocation belong to different streams, push it
back and allocate fresh memory instead.

Unskips `test_race_diamond` which now passes. All stress tests pass
with 0 skips.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo