### PR TITLE
[DTensor] Support sharding propagation with meta device mesh

### DIFF
--- a/test/distributed/test_device_mesh.py
+++ b/test/distributed/test_device_mesh.py
@@ -1704,6 +1704,21 @@ class LogicalMeshTest(TestCase):
         with self.assertRaisesRegex(RuntimeError, "logical mesh"):
             a + b
 
+    def test_explicit_redistribute_on_logical_mesh(self):
+        mesh = DeviceMesh.from_logical((4,), mesh_dim_names=("tp",))
+        x = DTensor.from_local(torch.randn(2, 16, device="meta"), mesh, [Shard(0)])
+        # Shard(0) -> Replicate (simulated allgather)
+        y = x.redistribute(mesh, [torch.distributed.tensor.Replicate()])
+        self.assertEqual(y.placements, (torch.distributed.tensor.Replicate(),))
+        self.assertEqual(y.shape, torch.Size([8, 16]))
+        self.assertEqual(y._local_tensor.shape, torch.Size([8, 16]))
+
+        # Replicate -> Shard(1) (simulated local slice)
+        z = y.redistribute(mesh, [Shard(1)])
+        self.assertEqual(z.placements, (Shard(1),))
+        self.assertEqual(z.shape, torch.Size([8, 16]))
+        self.assertEqual(z._local_tensor.shape, torch.Size([8, 4]))
+
 
 class CuTeLayoutTest(TestCase):
     def test_coalesce(self):

--- a/test/distributed/test_device_mesh.py
+++ b/test/distributed/test_device_mesh.py
@@ -1625,6 +1625,11 @@ class DeviceMeshCollectiveTest(DTensorTestBase):
 class LogicalMeshTest(TestCase):
     """Tests for DeviceMesh.from_logical() — no distributed init required."""
 
+    def tearDown(self):
+        super().tearDown()
+        if is_initialized():
+            dist.destroy_process_group()
+
     def test_from_logical_1d(self):
         mesh = DeviceMesh.from_logical((4,), mesh_dim_names=("tp",))
         self.assertEqual(mesh.size(0), 4)
@@ -1642,10 +1647,11 @@ class LogicalMeshTest(TestCase):
         self.assertEqual(mesh.shape, (2, 4))
         self.assertEqual(mesh.get_coordinate(), (0, 0))
 
-    def test_from_logical_no_process_groups(self):
+    def test_from_logical_has_fake_process_groups(self):
         mesh = DeviceMesh.from_logical((4,))
-        with self.assertRaises(RuntimeError):
-            mesh.get_group()
+        # Fake PG provides process groups for redistribute support
+        pg = mesh.get_group()
+        self.assertIsNotNone(pg)
 
     def test_propagation_elementwise(self):
         mesh = DeviceMesh.from_logical((4,), mesh_dim_names=("tp",))

--- a/test/distributed/test_device_mesh.py
+++ b/test/distributed/test_device_mesh.py
@@ -30,6 +30,7 @@ from torch.distributed.tensor._collective_utils import (
     mesh_scatter,
     unpad_tensor,
 )
+from torch.distributed.tensor._utils import ExplicitRedistributionContext
 from torch.distributed.tensor.placement_types import _Partial, Shard
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_utils import run_tests, TEST_HPU, TEST_XPU, TestCase
@@ -1619,6 +1620,89 @@ class DeviceMeshCollectiveTest(DTensorTestBase):
         dist.all_reduce(tensor, group=flatten_pg)
         expected_tensor = torch.ones(3, 3) * 28
         self.assertEqual(tensor, expected_tensor)
+
+
+class LogicalMeshTest(TestCase):
+    """Tests for DeviceMesh.from_logical() — no distributed init required."""
+
+    def test_from_logical_1d(self):
+        mesh = DeviceMesh.from_logical((4,), mesh_dim_names=("tp",))
+        self.assertEqual(mesh.size(0), 4)
+        self.assertEqual(mesh.ndim, 1)
+        self.assertEqual(mesh.shape, (4,))
+        self.assertEqual(mesh.device_type, "meta")
+        self.assertEqual(mesh.get_coordinate(), (0,))
+        self.assertTrue(mesh._is_current_rank_part_of_mesh())
+
+    def test_from_logical_2d(self):
+        mesh = DeviceMesh.from_logical((2, 4), mesh_dim_names=("dp", "tp"))
+        self.assertEqual(mesh.size(0), 2)
+        self.assertEqual(mesh.size(1), 4)
+        self.assertEqual(mesh.ndim, 2)
+        self.assertEqual(mesh.shape, (2, 4))
+        self.assertEqual(mesh.get_coordinate(), (0, 0))
+
+    def test_from_logical_no_process_groups(self):
+        mesh = DeviceMesh.from_logical((4,))
+        with self.assertRaises(RuntimeError):
+            mesh.get_group()
+
+    def test_propagation_elementwise(self):
+        mesh = DeviceMesh.from_logical((4,), mesh_dim_names=("tp",))
+        with ExplicitRedistributionContext(strict=True):
+            x = DTensor.from_local(torch.randn(2, 16, device="meta"), mesh, [Shard(0)])
+            y = x + x
+        self.assertEqual(y.placements, (Shard(0),))
+        self.assertEqual(y.shape, torch.Size([8, 16]))
+
+    def test_propagation_mm(self):
+        mesh = DeviceMesh.from_logical((4,), mesh_dim_names=("tp",))
+        with ExplicitRedistributionContext(strict=True):
+            a = DTensor.from_local(torch.randn(2, 16, device="meta"), mesh, [Shard(0)])
+            b = DTensor.from_local(
+                torch.randn(16, 8, device="meta"),
+                mesh,
+                [torch.distributed.tensor.Replicate()],
+            )
+            c = torch.mm(a, b)
+        self.assertEqual(c.placements, (Shard(0),))
+        self.assertEqual(c.shape, torch.Size([8, 8]))
+
+    def test_propagation_mm_partial(self):
+        mesh = DeviceMesh.from_logical((4,), mesh_dim_names=("tp",))
+        with ExplicitRedistributionContext(strict=True):
+            a = DTensor.from_local(torch.randn(8, 4, device="meta"), mesh, [Shard(1)])
+            b = DTensor.from_local(torch.randn(4, 8, device="meta"), mesh, [Shard(0)])
+            c = torch.mm(a, b)
+        self.assertEqual(c.placements[0].is_partial(), True)
+        self.assertEqual(c.shape, torch.Size([8, 8]))
+
+    def test_propagation_transpose(self):
+        mesh = DeviceMesh.from_logical((4,), mesh_dim_names=("tp",))
+        with ExplicitRedistributionContext(strict=True):
+            x = DTensor.from_local(torch.randn(2, 16, device="meta"), mesh, [Shard(0)])
+            y = x.t()
+        self.assertEqual(y.placements, (Shard(1),))
+        self.assertEqual(y.shape, torch.Size([16, 8]))
+
+    def test_propagation_2d_mesh(self):
+        mesh = DeviceMesh.from_logical((2, 4), mesh_dim_names=("dp", "tp"))
+        with ExplicitRedistributionContext(strict=True):
+            x = DTensor.from_local(
+                torch.randn(4, 4, device="meta"), mesh, [Shard(0), Shard(1)]
+            )
+            y = x + x
+        self.assertEqual(y.placements, (Shard(0), Shard(1)))
+        self.assertEqual(y.shape, torch.Size([8, 16]))
+
+    def test_implicit_redistribution_raises_on_logical_mesh(self):
+        mesh = DeviceMesh.from_logical((4,), mesh_dim_names=("tp",))
+        # Adding Shard(0) + Shard(1) requires redistributing one input,
+        # which is impossible on a logical mesh.
+        a = DTensor.from_local(torch.randn(2, 16, device="meta"), mesh, [Shard(0)])
+        b = DTensor.from_local(torch.randn(8, 4, device="meta"), mesh, [Shard(1)])
+        with self.assertRaisesRegex(RuntimeError, "logical mesh"):
+            a + b
 
 
 class CuTeLayoutTest(TestCase):

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -42,11 +42,16 @@ if not is_available():
 
 
 else:
-    from torch._C._distributed_c10d import Backend as C10dBackend
+    from torch._C._distributed_c10d import (
+        Backend as C10dBackend,
+        FakeProcessGroup,
+        HashStore,
+    )
     from torch.distributed import config as dist_config
     from torch.distributed.distributed_c10d import (
         _get_default_group,
         _resolve_process_group,
+        destroy_process_group,
         get_backend,
         get_process_group_ranks,
         get_rank,
@@ -72,6 +77,26 @@ else:
 
     BackendConfig = tuple[str | None, C10dBackend.Options | None]
     torch.serialization.add_safe_globals([_MeshLayout])
+
+    def _create_fake_pg(common_opts, backend_opts):
+        return FakeProcessGroup._create_internal(
+            common_opts.group_rank, common_opts.group_size, backend_opts
+        )
+
+    def _init_logical_mesh_pg(world_size: int) -> None:
+        """Initialize a fake distributed backend for logical meshes."""
+        from torch.distributed.distributed_c10d import Backend
+
+        # Avoid redundant re-registration (register_backend is idempotent
+        # for the name, but re-runs the device mapping loop each time).
+        if "FAKE" not in Backend._plugins:
+            Backend.register_backend(
+                "fake",
+                _create_fake_pg,
+                extended_api=True,
+                devices=["cpu", "cuda", "hpu", "xpu"],
+            )
+        init_process_group("fake", store=HashStore(), rank=0, world_size=world_size)
 
     def _get_pg_from_name(mesh: "DeviceMesh", name: str) -> ProcessGroup:
         """
@@ -1165,8 +1190,9 @@ else:
 
             The returned mesh carries enough metadata (shape, rank coordinates) for
             DTensor sharding propagation to determine output placements given input
-            placements. It has no process groups and cannot be used for actual
-            collective communication.
+            placements. It uses fake process groups so that explicit
+            ``redistribute()`` calls work (producing correctly-shaped meta
+            tensors), but no real collective communication is performed.
 
             Args:
                 mesh_shape: The shape of the mesh as a tuple of ints (e.g. ``(4,)``
@@ -1191,13 +1217,27 @@ else:
                 ).reshape(mesh_shape)
             else:
                 mesh_tensor = torch.tensor(mesh_shape, device="cpu", dtype=torch.int)
+                numel = mesh_tensor.numel()
+
+            # Initialize a fake distributed backend for redistribute() support.
+            # If already initialized with a smaller world, re-init with the
+            # larger size so that bigger meshes can be created.
+            if not is_initialized():
+                _init_logical_mesh_pg(numel)
+            elif get_backend() != "fake":
+                raise RuntimeError(
+                    "Cannot create a logical mesh: a non-fake process group "
+                    "is already active. Destroy it first with "
+                    "destroy_process_group()."
+                )
+            elif get_world_size() < numel:
+                destroy_process_group()
+                _init_logical_mesh_pg(numel)
 
             device_mesh = DeviceMesh(
                 "meta",
                 mesh_tensor,
                 mesh_dim_names=mesh_dim_names,
-                _init_backend=False,
-                _rank=0,
             )
             return device_mesh
 

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -119,6 +119,12 @@ else:
 
         @staticmethod
         def num_devices_per_host(device_type: str) -> int:
+            if device_type == "meta":
+                # Logical meshes (from_logical) use "meta" device type and
+                # have no real devices. The exact value doesn't affect output
+                # sharding correctness — it only influences cost estimation
+                # for strategy selection, which is irrelevant in explicit mode.
+                return 1
             return _get_device_handle(device_type).device_count()
 
         @staticmethod
@@ -1145,6 +1151,54 @@ else:
             device_mesh._dim_group_names = [group.group_name for group in groups]
             for group in groups:
                 device_mesh._pg_registry[group.group_name] = group
+            return device_mesh
+
+        @staticmethod
+        def from_logical(
+            mesh_shape: "tuple[int, ...] | ArrayLike",
+            *,
+            mesh_dim_names: tuple[str, ...] | None = None,
+        ) -> "DeviceMesh":
+            """
+            Create a logical :class:`DeviceMesh` for sharding propagation without
+            requiring distributed initialization or real devices.
+
+            The returned mesh carries enough metadata (shape, rank coordinates) for
+            DTensor sharding propagation to determine output placements given input
+            placements. It has no process groups and cannot be used for actual
+            collective communication.
+
+            Args:
+                mesh_shape: The shape of the mesh as a tuple of ints (e.g. ``(4,)``
+                    for a 1-D mesh of size 4, or ``(2, 4)`` for a 2-D mesh).
+                mesh_dim_names: Optional tuple of mesh dimension names.
+
+            Returns:
+                A :class:`DeviceMesh` suitable for propagation-only use.
+
+            Example::
+
+                >>> mesh = DeviceMesh.from_logical((4,), mesh_dim_names=("tp",))
+                >>> mesh.size(0)
+                4
+            """
+            if isinstance(mesh_shape, tuple):
+                numel = 1
+                for s in mesh_shape:
+                    numel *= s
+                mesh_tensor = torch.arange(
+                    numel, device="cpu", dtype=torch.int
+                ).reshape(mesh_shape)
+            else:
+                mesh_tensor = torch.tensor(mesh_shape, device="cpu", dtype=torch.int)
+
+            device_mesh = DeviceMesh(
+                "meta",
+                mesh_tensor,
+                mesh_dim_names=mesh_dim_names,
+                _init_backend=False,
+                _rank=0,
+            )
             return device_mesh
 
         def size(self, mesh_dim: int | None = None) -> int:

--- a/torch/distributed/tensor/_redistribute.py
+++ b/torch/distributed/tensor/_redistribute.py
@@ -22,7 +22,10 @@ from torch.distributed.tensor._dtensor_spec import (
     ShardOrderEntry,
     TensorMeta,
 )
-from torch.distributed.tensor._utils import assert_no_mixed_partial_types
+from torch.distributed.tensor._utils import (
+    assert_no_mixed_partial_types,
+    compute_local_shape_and_global_offset,
+)
 from torch.distributed.tensor.device_mesh import DeviceMesh
 from torch.distributed.tensor.placement_types import (
     _StridedShard,
@@ -1490,6 +1493,19 @@ def redistribute_local_tensor(
 
     new_local_tensor = local_tensor
     device_mesh = current_spec.mesh
+
+    if device_mesh.device_type == "meta":
+        # Logical mesh: no real collectives, just compute the target local
+        # shape and return a meta tensor with the correct shape.
+        if target_spec.tensor_meta is None:
+            raise AssertionError("target spec should have tensor meta defined!")
+        local_shape, _ = compute_local_shape_and_global_offset(
+            target_spec.tensor_meta.shape,
+            device_mesh,
+            target_spec.placements,
+            skip_offset=True,
+        )
+        return local_tensor.new_empty(local_shape, device="meta")
 
     if not device_mesh._is_current_rank_part_of_mesh():
         # if rank is not part of mesh, we skip redistribute and simply return local_tensor,

--- a/torch/distributed/tensor/_redistribute.py
+++ b/torch/distributed/tensor/_redistribute.py
@@ -22,10 +22,7 @@ from torch.distributed.tensor._dtensor_spec import (
     ShardOrderEntry,
     TensorMeta,
 )
-from torch.distributed.tensor._utils import (
-    assert_no_mixed_partial_types,
-    compute_local_shape_and_global_offset,
-)
+from torch.distributed.tensor._utils import assert_no_mixed_partial_types
 from torch.distributed.tensor.device_mesh import DeviceMesh
 from torch.distributed.tensor.placement_types import (
     _StridedShard,
@@ -1493,19 +1490,6 @@ def redistribute_local_tensor(
 
     new_local_tensor = local_tensor
     device_mesh = current_spec.mesh
-
-    if device_mesh.device_type == "meta":
-        # Logical mesh: no real collectives, just compute the target local
-        # shape and return a meta tensor with the correct shape.
-        if target_spec.tensor_meta is None:
-            raise AssertionError("target spec should have tensor meta defined!")
-        local_shape, _ = compute_local_shape_and_global_offset(
-            target_spec.tensor_meta.shape,
-            device_mesh,
-            target_spec.placements,
-            skip_offset=True,
-        )
-        return local_tensor.new_empty(local_shape, device="meta")
 
     if not device_mesh._is_current_rank_part_of_mesh():
         # if rank is not part of mesh, we skip redistribute and simply return local_tensor,

--- a/torch/distributed/tensor/_utils.py
+++ b/torch/distributed/tensor/_utils.py
@@ -66,12 +66,13 @@ class ExplicitRedistributionContext:
         dst_spec: DTensorSpec,
         redistribution_msg: LazyString,
     ):
-        # Logical meshes (device_type="meta") cannot perform redistribution
-        # since they have no process groups. Always raise.
+        # Logical meshes (device_type="meta") have no process groups, so
+        # implicit redistribution should always be flagged.
         if src_spec.mesh.device_type == "meta":
             raise RuntimeError(
                 f"Implicit redistribution is not supported on a logical mesh "
-                f"(DeviceMesh.from_logical). {redistribution_msg}"
+                f"(DeviceMesh.from_logical). Use explicit redistribute() instead. "
+                f"{redistribution_msg}"
             )
 
         if instance := getattr(cls._local, "_active", None):

--- a/torch/distributed/tensor/_utils.py
+++ b/torch/distributed/tensor/_utils.py
@@ -66,6 +66,14 @@ class ExplicitRedistributionContext:
         dst_spec: DTensorSpec,
         redistribution_msg: LazyString,
     ):
+        # Logical meshes (device_type="meta") cannot perform redistribution
+        # since they have no process groups. Always raise.
+        if src_spec.mesh.device_type == "meta":
+            raise RuntimeError(
+                f"Implicit redistribution is not supported on a logical mesh "
+                f"(DeviceMesh.from_logical). {redistribution_msg}"
+            )
+
         if instance := getattr(cls._local, "_active", None):
             allowed = True
             if instance._enable:


### PR DESCRIPTION
Add a way to run DTensor sharding propagation (determining output placements given input placements) without requiring distributed initialization or real devices.

Previously this was impossible because `DeviceMesh.__init__` always calls `get_rank()` even with `_init_backend=False`, and `MeshTopoInfo.build_from_mesh` calls `num_devices_per_host()` which has no handler for non-physical devices.

Changes:
- `DeviceMesh.from_logical(mesh_shape, mesh_dim_names)`: creates a logical mesh with device_type="meta", _rank=0, no process groups
- `num_devices_per_host`: handle "meta" device type
- `ExplicitRedistributionContext.observe_redistribution`: always raise on logical meshes since 1) they cannot perform collective communication 2) the redistribute cost will be a garbage value on meta device mesh;

Authored with Claude.