### PR TITLE
[profiler] Fix thread-safety of PyEval_SetProfile for free-threaded Python

### DIFF
--- a/torch/csrc/autograd/profiler_python.cpp
+++ b/torch/csrc/autograd/profiler_python.cpp
@@ -608,9 +608,7 @@ static PyTypeObject TraceContextType = {
 #if IS_PYTHON_3_14_PLUS
 extern "C" void _PyEval_StopTheWorld(PyInterpreterState*);
 extern "C" void _PyEval_StartTheWorld(PyInterpreterState*);
-#endif
 
-#if IS_PYTHON_3_14_PLUS
 class StopTheWorldGuard {
  public:
   explicit StopTheWorldGuard(PyInterpreterState* interp) : interp_(interp) {

--- a/torch/csrc/autograd/profiler_python.cpp
+++ b/torch/csrc/autograd/profiler_python.cpp
@@ -604,10 +604,6 @@ static PyTypeObject TraceContextType = {
     nullptr /* tp_free */
 };
 
-#if IS_PYTHON_3_13_PLUS
-extern "C" int _PyEval_SetProfile(PyThreadState*, Py_tracefunc, PyObject*);
-#endif
-
 #if IS_PYTHON_3_14_PLUS
 extern "C" void _PyEval_StopTheWorld(PyInterpreterState*);
 extern "C" void _PyEval_StartTheWorld(PyInterpreterState*);

--- a/torch/csrc/autograd/profiler_python.cpp
+++ b/torch/csrc/autograd/profiler_python.cpp
@@ -604,7 +604,6 @@ static PyTypeObject TraceContextType = {
     nullptr /* tp_free */
 };
 
-
 #if IS_PYTHON_3_13_PLUS
 extern "C" int _PyEval_SetProfile(PyThreadState*, Py_tracefunc, PyObject*);
 #endif
@@ -614,26 +613,29 @@ extern "C" void _PyEval_StopTheWorld(PyInterpreterState*);
 extern "C" void _PyEval_StartTheWorld(PyInterpreterState*);
 #endif
 
+#if IS_PYTHON_3_14_PLUS
 class StopTheWorldGuard {
  public:
   explicit StopTheWorldGuard(PyInterpreterState* interp) : interp_(interp) {
-#if IS_PYTHON_3_14_PLUS
     _PyEval_StopTheWorld(interp_);
-#endif
   }
-
   ~StopTheWorldGuard() {
-#if IS_PYTHON_3_14_PLUS
     _PyEval_StartTheWorld(interp_);
-#endif
   }
-
   StopTheWorldGuard(const StopTheWorldGuard&) = delete;
   StopTheWorldGuard& operator=(const StopTheWorldGuard&) = delete;
 
  private:
   PyInterpreterState* interp_;
 };
+#else
+class StopTheWorldGuard {
+ public:
+  explicit StopTheWorldGuard(PyInterpreterState*) {}
+  StopTheWorldGuard(const StopTheWorldGuard&) = delete;
+  StopTheWorldGuard& operator=(const StopTheWorldGuard&) = delete;
+};
+#endif
 
 // ============================================================================
 // == Thread local cache ======================================================
@@ -836,8 +838,7 @@ static PyObject* c_call_callback(
       auto* local_results = tracer->findThreadLocalResults(tstate);
       if (local_results) {
         Py_INCREF(frame);
-        local_results->active_tracer_->recordCCall(
-            *local_results, frame, func);
+        local_results->active_tracer_->recordCCall(*local_results, frame, func);
         Py_DECREF(frame);
       }
     }
@@ -989,9 +990,8 @@ const std::vector<PyThreadState*> PythonTracer::interpreterThreads() const {
   return out;
 }
 
-void PythonTracer::setprofileAllThreads(
-    Py_tracefunc func,
-    PyObject* arg) const {
+void PythonTracer::setprofileAllThreads(Py_tracefunc func, PyObject* arg)
+    const {
 #if IS_PYTHON_3_13_PLUS
   PyEval_SetProfileAllThreads(func, arg);
 #else
@@ -1044,8 +1044,7 @@ PythonTracer::PythonTracer(torch::profiler::impl::RecordQueue* queue)
   interpreter_ = PyInterpreterState_Get();
 
   // Shared context passed as the profile arg to all threads.
-  shared_ctx_ =
-      (TraceContext*)TraceContextType.tp_alloc(&TraceContextType, 0);
+  shared_ctx_ = (TraceContext*)TraceContextType.tp_alloc(&TraceContextType, 0);
   shared_ctx_->tracer_ = this;
 
   // Enable profiling on all threads. setprofileAllThreads handles its own
@@ -1568,13 +1567,11 @@ int PythonTracer::pyProfileFn(
   }
   switch (what) {
     case PyTrace_CALL:
-      local_results->active_tracer_->recordPyCall(
-          *local_results, frame, false);
+      local_results->active_tracer_->recordPyCall(*local_results, frame, false);
       break;
 
     case PyTrace_C_CALL:
-      local_results->active_tracer_->recordCCall(
-          *local_results, frame, arg);
+      local_results->active_tracer_->recordCCall(*local_results, frame, arg);
       break;
 
     case PyTrace_RETURN:
@@ -1582,8 +1579,7 @@ int PythonTracer::pyProfileFn(
       local_results->active_frames_--;
       if (local_results->active_frames_ <
           local_results->remaining_start_frames_) {
-        local_results->remaining_start_frames_ =
-            local_results->active_frames_;
+        local_results->remaining_start_frames_ = local_results->active_frames_;
       }
       break;
 

--- a/torch/csrc/autograd/profiler_python.cpp
+++ b/torch/csrc/autograd/profiler_python.cpp
@@ -7,6 +7,7 @@
 #include <memory>
 #include <queue>
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -725,7 +726,7 @@ class PythonTracer final : public python_tracer::PythonTracerBase {
       PyObject* arg,
       bool start_frame = false);
 
-  ThreadLocalResults* findThreadLocalResults(PyThreadState* tstate);
+  ThreadLocalResults* findThreadLocalResults(PyThreadState* tstate) const;
 
   const std::vector<PyThreadState*> interpreterThreads() const;
   void setprofileAllThreads(Py_tracefunc func, PyObject* arg) const;
@@ -742,6 +743,8 @@ class PythonTracer final : public python_tracer::PythonTracerBase {
 
   std::vector<StartFrame> start_frames_;
   std::deque<ThreadLocalResults> thread_local_results_;
+  std::unordered_map<PyThreadState*, ThreadLocalResults*>
+      thread_local_results_map_;
   ValueCache value_cache_;
 
 #if IS_PYTHON_3_12
@@ -964,13 +967,9 @@ static void unregisterMonitoringCallback() {
 #endif
 
 ThreadLocalResults* PythonTracer::findThreadLocalResults(
-    PyThreadState* tstate) {
-  for (auto& tls : thread_local_results_) {
-    if (tls.thread_state_ == tstate) {
-      return &tls;
-    }
-  }
-  return nullptr;
+    PyThreadState* tstate) const {
+  auto it = thread_local_results_map_.find(tstate);
+  return it != thread_local_results_map_.end() ? it->second : nullptr;
 }
 
 const std::vector<PyThreadState*> PythonTracer::interpreterThreads() const {
@@ -1057,6 +1056,7 @@ PythonTracer::PythonTracer(torch::profiler::impl::RecordQueue* queue)
     for (const auto thread_state : interpreterThreads()) {
       thread_local_results_.emplace_back(thread_state, &value_cache_, this);
       auto& tls = thread_local_results_.back();
+      thread_local_results_map_[thread_state] = &tls;
 
       // When we begin profiling there are already frames on the Python
       // interpreter stack. To ensure a complete trace, we must push calls

--- a/torch/csrc/autograd/profiler_python.cpp
+++ b/torch/csrc/autograd/profiler_python.cpp
@@ -1033,6 +1033,12 @@ PythonTracer::PythonTracer(torch::profiler::impl::RecordQueue* queue)
     return;
   }
 
+#if defined(Py_GIL_DISABLED) && !defined(IS_PYTHON_3_14_PLUS)
+  TORCH_WARN(
+      "The PyTorch profiler is not thread-safe on Python 3.13t. "
+      "Please use Python 3.14t or later.");
+#endif
+
   pybind11::gil_scoped_acquire gil;
   interpreter_ = PyInterpreterState_Get();
 

--- a/torch/csrc/autograd/profiler_python.cpp
+++ b/torch/csrc/autograd/profiler_python.cpp
@@ -551,13 +551,13 @@ struct TraceKeyCacheState {
 // ============================================================================
 // == Core CPython data types =================================================
 // ============================================================================
-// PyObject that allows different threads to record events without colliding.
-// It is passed as the second argument when enabling tracing via
-// `PyEval_SetProfile`.
-struct ThreadLocalResults;
+// PyObject passed as the second argument when enabling tracing via
+// `PyEval_SetProfile`. A single shared instance is used for all threads;
+// the callback resolves per-thread state via PyThreadState_Get().
+class PythonTracer;
 struct TraceContext {
   PyObject_HEAD
-  ThreadLocalResults* thread_local_results_;
+  PythonTracer* tracer_;
 };
 
 // CPython boilerplate to define `TraceContext` as a proper python object.
@@ -604,59 +604,54 @@ static PyTypeObject TraceContextType = {
     nullptr /* tp_free */
 };
 
-class gil_and_restore_thread {
+
+#if IS_PYTHON_3_13_PLUS
+extern "C" int _PyEval_SetProfile(PyThreadState*, Py_tracefunc, PyObject*);
+#endif
+
+#if IS_PYTHON_3_14_PLUS
+extern "C" void _PyEval_StopTheWorld(PyInterpreterState*);
+extern "C" void _PyEval_StartTheWorld(PyInterpreterState*);
+#endif
+
+class StopTheWorldGuard {
  public:
-  gil_and_restore_thread() : initial_thread_state_{PyThreadState_Get()} {}
-  ~gil_and_restore_thread() {
-    PyThreadState_Swap(initial_thread_state_);
-
-    // `gil_scoped_acquire` is a bit fragile in on-demand mode:
-    // https://github.com/pytorch/pytorch/pull/91684#issuecomment-1413154458
-    if (!Py_IsInitialized()) {
-      gil_.disarm();
-    }
+  explicit StopTheWorldGuard(PyInterpreterState* interp) : interp_(interp) {
+#if IS_PYTHON_3_14_PLUS
+    _PyEval_StopTheWorld(interp_);
+#endif
   }
 
-  PyThreadState* initial_thread_state() const {
-    return initial_thread_state_;
+  ~StopTheWorldGuard() {
+#if IS_PYTHON_3_14_PLUS
+    _PyEval_StartTheWorld(interp_);
+#endif
   }
+
+  StopTheWorldGuard(const StopTheWorldGuard&) = delete;
+  StopTheWorldGuard& operator=(const StopTheWorldGuard&) = delete;
 
  private:
-  pybind11::gil_scoped_acquire gil_;
-  PyThreadState* initial_thread_state_;
+  PyInterpreterState* interp_;
 };
 
 // ============================================================================
 // == Thread local cache ======================================================
 // ============================================================================
-class PythonTracer;
 struct ThreadLocalResults {
   ThreadLocalResults(
       PyThreadState* thread_state,
       ValueCache* value_cache,
       PythonTracer* active_tracer)
       : thread_state_{thread_state},
-        ctx_{(TraceContext*)TraceContextType.tp_alloc(&TraceContextType, 0)},
         value_cache_{value_cache},
-        active_tracer_{active_tracer} {
-    ctx_->thread_local_results_ = this;
-  }
+        active_tracer_{active_tracer} {}
 
   ThreadLocalResults() = delete;
   ThreadLocalResults(const ThreadLocalResults&) = delete;
   ThreadLocalResults(ThreadLocalResults&&) = delete;
   ThreadLocalResults& operator=(const ThreadLocalResults&) = delete;
   ThreadLocalResults& operator=(const ThreadLocalResults&&) = delete;
-
-  ~ThreadLocalResults() {
-    // Currently, there is a bug in Profiler when using Python 3.12 that causes
-    // a segfault when decrementing the refcount of a TraceContext during
-    // on-demand. We are purposefully allowing for a small leak in this
-    // situation to avoid the segfault. This should be fixed in the future.
-#if PY_MAJOR_VERSION < 3 || (PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION < 12)
-    Py_DECREF((PyObject*)ctx_);
-#endif
-  }
 
   template <CallType C, EventType E, typename Ephemeral, typename... Args>
   TraceKey intern(Ephemeral ephemeral, Args... args) {
@@ -670,7 +665,6 @@ struct ThreadLocalResults {
   static constexpr size_t BLOCK_SIZE = 1024;
 
   PyThreadState* thread_state_;
-  TraceContext* ctx_;
   ValueCache* value_cache_;
   PythonTracer* active_tracer_;
   CallTypeHelper<TraceKeyCacheState>::tuple_type trace_keys_;
@@ -733,7 +727,10 @@ class PythonTracer final : public python_tracer::PythonTracerBase {
       PyObject* arg,
       bool start_frame = false);
 
+  ThreadLocalResults* findThreadLocalResults(PyThreadState* tstate);
+
   const std::vector<PyThreadState*> interpreterThreads() const;
+  void setprofileAllThreads(Py_tracefunc func, PyObject* arg) const;
 
   std::atomic<bool> active_lock_{false};
   bool active_{false};
@@ -743,6 +740,7 @@ class PythonTracer final : public python_tracer::PythonTracerBase {
   PyInterpreterState* interpreter_{nullptr};
   PyCodeObject* module_call_code_;
   PyCodeObject* optimizer_hook_;
+  TraceContext* shared_ctx_{nullptr};
 
   std::vector<StartFrame> start_frames_;
   std::deque<ThreadLocalResults> thread_local_results_;
@@ -833,12 +831,15 @@ static PyObject* c_call_callback(
             PyExc_SystemError, "Missing frame when calling profile function.");
         return NULL;
       }
-      Py_INCREF(frame);
-      auto& local_results =
-          *reinterpret_cast<TraceContext*>(tstate->c_profileobj)
-               ->thread_local_results_;
-      local_results.active_tracer_->recordCCall(local_results, frame, func);
-      Py_DECREF(frame);
+      auto* tracer =
+          reinterpret_cast<TraceContext*>(tstate->c_profileobj)->tracer_;
+      auto* local_results = tracer->findThreadLocalResults(tstate);
+      if (local_results) {
+        Py_INCREF(frame);
+        local_results->active_tracer_->recordCCall(
+            *local_results, frame, func);
+        Py_DECREF(frame);
+      }
     }
   }
   Py_RETURN_NONE;
@@ -965,6 +966,16 @@ static void unregisterMonitoringCallback() {
 }
 #endif
 
+ThreadLocalResults* PythonTracer::findThreadLocalResults(
+    PyThreadState* tstate) {
+  for (auto& tls : thread_local_results_) {
+    if (tls.thread_state_ == tstate) {
+      return &tls;
+    }
+  }
+  return nullptr;
+}
+
 const std::vector<PyThreadState*> PythonTracer::interpreterThreads() const {
   pybind11::gil_scoped_acquire gil;
   std::vector<PyThreadState*> out;
@@ -976,6 +987,20 @@ const std::vector<PyThreadState*> PythonTracer::interpreterThreads() const {
     }
   }
   return out;
+}
+
+void PythonTracer::setprofileAllThreads(
+    Py_tracefunc func,
+    PyObject* arg) const {
+#if IS_PYTHON_3_13_PLUS
+  PyEval_SetProfileAllThreads(func, arg);
+#else
+  for (const auto thread_state : interpreterThreads()) {
+    if (_PyEval_SetProfile(thread_state, func, arg) < 0) {
+      PyErr_WriteUnraisable(nullptr);
+    }
+  }
+#endif
 }
 
 // we are only registering on main thread while holding GIL so this should be
@@ -1015,56 +1040,59 @@ PythonTracer::PythonTracer(torch::profiler::impl::RecordQueue* queue)
     return;
   }
 
-  gil_and_restore_thread gil;
+  pybind11::gil_scoped_acquire gil;
   interpreter_ = PyInterpreterState_Get();
 
-  if (!gil.initial_thread_state()) {
-    TORCH_WARN("PyThreadState_Get returned NULL");
-    return;
-  }
+  // Shared context passed as the profile arg to all threads.
+  shared_ctx_ =
+      (TraceContext*)TraceContextType.tp_alloc(&TraceContextType, 0);
+  shared_ctx_->tracer_ = this;
 
-  // Register the tracer in each thread.
-  for (const auto thread_state : interpreterThreads()) {
-    PyThreadState_Swap(thread_state);
+  // Enable profiling on all threads. setprofileAllThreads handles its own
+  // synchronization (stop-the-world on free-threaded builds). The callback
+  // returns early because findThreadLocalResults returns nullptr for threads
+  // we haven't set up yet.
+  // Note: This profile will not compose with other CPython profilers, and
+  // cannot be round tripped via `sys.settrace(sys.gettrace())`
+  setprofileAllThreads(PythonTracer::pyProfileFn, (PyObject*)shared_ctx_);
 
-    thread_local_results_.emplace_back(thread_state, &value_cache_, this);
-    auto& tls = thread_local_results_.back();
-    auto* ctx = tls.ctx_;
+  // Capture existing frames on each thread's stack.
+  {
+    StopTheWorldGuard stw(interpreter_);
+    for (const auto thread_state : interpreterThreads()) {
+      thread_local_results_.emplace_back(thread_state, &value_cache_, this);
+      auto& tls = thread_local_results_.back();
 
-    // When we begin profiling there are already frames on the Python
-    // interpreter stack. To ensure a complete trace, we must push calls
-    // to all the prior frames onto our event stack. (We stop at depth=128)
+      // When we begin profiling there are already frames on the Python
+      // interpreter stack. To ensure a complete trace, we must push calls
+      // to all the prior frames onto our event stack. (We stop at depth=128)
 
-    std::vector<THPFrameObjectPtr> current_stack;
-    auto frame = PyEval_GetFrame();
-    Py_XINCREF(frame);
+      // NB: `PyThreadState_GetFrame` returns a strong reference.
+      std::vector<THPFrameObjectPtr> current_stack;
+      auto frame = PyThreadState_GetFrame(thread_state);
 
-    size_t depth = 0; // Make sure we can't infinite loop.
-    while (frame != nullptr) {
-      current_stack.emplace_back(frame);
-      if (++depth == 128) {
-        break;
+      size_t depth = 0; // Make sure we can't infinite loop.
+      while (frame != nullptr) {
+        current_stack.emplace_back(frame);
+        if (++depth == 128) {
+          break;
+        }
+
+        // NB: `PyFrame_GetBack` returns a strong reference.
+        frame = PyFrame_GetBack(frame);
       }
 
-      // NB: `PyFrame_GetBack` returns a strong reference.
-      frame = PyFrame_GetBack(frame);
+      for (auto it = current_stack.rbegin(); it != current_stack.rend(); it++) {
+        recordPyCall(tls, it->get(), true);
+        auto frame_refcount = Py_REFCNT(it->get());
+
+        // We hold one reference in `current_stack`, and the interpreter holds
+        // another.
+        TORCH_INTERNAL_ASSERT(frame_refcount >= 2, frame_refcount);
+      }
+
+      tls.remaining_start_frames_ = tls.active_frames_;
     }
-
-    for (auto it = current_stack.rbegin(); it != current_stack.rend(); it++) {
-      recordPyCall(tls, it->get(), true);
-      auto frame_refcount = Py_REFCNT(it->get());
-
-      // We hold one reference in `current_stack`, and the interpreter holds
-      // another.
-      TORCH_INTERNAL_ASSERT(frame_refcount >= 2, frame_refcount);
-    }
-
-    tls.remaining_start_frames_ = tls.active_frames_;
-
-    // Note:
-    //   This profile will not compose with other CPython profilers, and
-    //   cannot be round tripped via `sys.settrace(sys.gettrace())`
-    PyEval_SetProfile(PythonTracer::pyProfileFn, (PyObject*)ctx);
   }
 #if IS_PYTHON_3_12
   registerMonitoringCallback();
@@ -1134,18 +1162,13 @@ void PythonTracer::register_gc_callback() {
 }
 
 void PythonTracer::stop() {
-  gil_and_restore_thread gil;
+  pybind11::gil_scoped_acquire gil;
   if (gc_callback_registered_) {
     unregister_gc_callback();
     gc_callback_registered_ = false;
   }
   if (active_) {
-    for (const auto thread_state : interpreterThreads()) {
-      if (thread_state->c_profilefunc == &PythonTracer::pyProfileFn) {
-        PyThreadState_Swap(thread_state);
-        PyEval_SetProfile(nullptr, nullptr);
-      }
-    }
+    setprofileAllThreads(nullptr, nullptr);
 
 #if IS_PYTHON_3_12
     unregisterMonitoringCallback();
@@ -1158,7 +1181,7 @@ void PythonTracer::stop() {
 }
 
 void PythonTracer::restart() {
-  gil_and_restore_thread gil;
+  pybind11::gil_scoped_acquire gil;
   active_ = active_lock_.compare_exchange_strong(active_, true);
   if (!active_) {
     TORCH_WARN(
@@ -1166,14 +1189,7 @@ void PythonTracer::restart() {
         "Refusing to register profile functions.");
     return;
   }
-  int cur_thread = 0;
-  for (const auto thread_state : interpreterThreads()) {
-    if (thread_state->c_profilefunc == nullptr) {
-      auto* ctx = thread_local_results_[cur_thread].ctx_;
-      PyThreadState_Swap(thread_state);
-      PyEval_SetProfile(PythonTracer::pyProfileFn, (PyObject*)ctx);
-    }
-  }
+  setprofileAllThreads(PythonTracer::pyProfileFn, (PyObject*)shared_ctx_);
 #if IS_PYTHON_3_12
   registerMonitoringCallback();
 #endif
@@ -1185,6 +1201,7 @@ PythonTracer::~PythonTracer() {
     TORCH_WARN("`PythonTracer::stop()` was not called.");
     stop();
   }
+  Py_XDECREF((PyObject*)shared_ctx_);
 }
 
 void PythonTracer::recordPyCall(
@@ -1544,32 +1561,38 @@ int PythonTracer::pyProfileFn(
     PyFrameObject* frame,
     int what,
     PyObject* arg) {
-  auto& local_results =
-      *reinterpret_cast<TraceContext*>(obj)->thread_local_results_;
+  auto* tracer = reinterpret_cast<TraceContext*>(obj)->tracer_;
+  auto* local_results = tracer->findThreadLocalResults(PyThreadState_Get());
+  if (C10_UNLIKELY(!local_results)) {
+    return 0;
+  }
   switch (what) {
     case PyTrace_CALL:
-      local_results.active_tracer_->recordPyCall(local_results, frame, false);
+      local_results->active_tracer_->recordPyCall(
+          *local_results, frame, false);
       break;
 
     case PyTrace_C_CALL:
-      local_results.active_tracer_->recordCCall(local_results, frame, arg);
+      local_results->active_tracer_->recordCCall(
+          *local_results, frame, arg);
       break;
 
     case PyTrace_RETURN:
-      local_results.exit_times_.emplace_back(c10::getApproximateTime());
-      local_results.active_frames_--;
-      if (local_results.active_frames_ <
-          local_results.remaining_start_frames_) {
-        local_results.remaining_start_frames_ = local_results.active_frames_;
+      local_results->exit_times_.emplace_back(c10::getApproximateTime());
+      local_results->active_frames_--;
+      if (local_results->active_frames_ <
+          local_results->remaining_start_frames_) {
+        local_results->remaining_start_frames_ =
+            local_results->active_frames_;
       }
       break;
 
     case PyTrace_C_EXCEPTION:
     case PyTrace_C_RETURN:
-      if (local_results.active_frames_ >
-          local_results.remaining_start_frames_) {
-        local_results.c_exit_times_.emplace_back(c10::getApproximateTime());
-        local_results.active_frames_--;
+      if (local_results->active_frames_ >
+          local_results->remaining_start_frames_) {
+        local_results->c_exit_times_.emplace_back(c10::getApproximateTime());
+        local_results->active_frames_--;
       }
       break;
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #178552
* __->__ #178551

On free-threaded Python 3.14t, the GIL no longer serializes access to
interpreter thread state. The profiler's previous approach of iterating
threads with PyThreadState_Swap + PyEval_SetProfile was unsafe.

This adds setprofileAllThreads which uses PyEval_SetProfileAllThreads
on 3.13+ (handles its own stop-the-world synchronization) and falls
back to _PyEval_SetProfile per-thread on older Python. A
StopTheWorldGuard RAII wrapper is added for the frame capture phase
that still needs to iterate threads directly.

For context, this is essentially the same strategy used by memray: first
enable the profiler on all threads, then capture stacks.

Authored with Claude.