### PR TITLE
[profiler] Make ValueCache per-thread for free-threaded Python safety

### DIFF
--- a/test/profiler/test_python_tracer.py
+++ b/test/profiler/test_python_tracer.py
@@ -3,8 +3,10 @@
 import json
 import subprocess
 import sys
+import threading
 import time
 
+import torch
 from torch.profiler import profile, ProfilerActivity
 from torch.testing._internal.common_utils import (
     run_tests,
@@ -103,6 +105,36 @@ with torch.profiler.profile(activities=[torch.profiler.ProfilerActivity.CPU], wi
         self.assertFalse(
             "Python replay stack is empty during pop operation" in result.stderr
         )
+
+    def test_concurrent_profiling(self):
+        """Repeatedly start/stop profiling while background threads are active.
+
+        On free-threaded Python (3.14t+), this exercises concurrent access to
+        the profiler's per-thread state without GIL protection. Without the
+        thread-safety fixes (setprofileAllThreads, per-thread ValueCache,
+        StopTheWorldGuard), this crashes from heap corruption due to data
+        races on the shared hash maps.
+        """
+        stop = threading.Event()
+
+        def work():
+            while not stop.is_set():
+                d = {str(i): list(range(i % 10)) for i in range(20)}
+                _ = sorted(d.items(), key=lambda x: len(x[1]))
+                torch.ones(10) + torch.zeros(10)
+
+        threads = [threading.Thread(target=work) for _ in range(8)]
+        for t in threads:
+            t.start()
+
+        try:
+            for _ in range(30):
+                with torch.profiler.profile(with_stack=True, with_modules=True):
+                    torch.ones(10)
+        finally:
+            stop.set()
+            for t in threads:
+                t.join(timeout=5)
 
 
 if __name__ == "__main__":

--- a/torch/csrc/autograd/profiler_python.cpp
+++ b/torch/csrc/autograd/profiler_python.cpp
@@ -641,11 +641,8 @@ class StopTheWorldGuard {
 // == Thread local cache ======================================================
 // ============================================================================
 struct ThreadLocalResults {
-  ThreadLocalResults(
-      PyThreadState* thread_state,
-      PythonTracer* active_tracer)
-      : thread_state_{thread_state},
-        active_tracer_{active_tracer} {}
+  ThreadLocalResults(PyThreadState* thread_state, PythonTracer* active_tracer)
+      : thread_state_{thread_state}, active_tracer_{active_tracer} {}
 
   ThreadLocalResults() = delete;
   ThreadLocalResults(const ThreadLocalResults&) = delete;
@@ -1296,7 +1293,10 @@ class PostProcess {
       : end_time_{end_time_ns}, time_converter_{std::move(time_converter)} {
     for (size_t python_tid : c10::irange(tls.size())) {
       CallTypeHelper<TraceKeyCacheState>::map(
-          tls[python_tid].trace_keys_, *this, tls[python_tid].value_cache_, python_tid);
+          tls[python_tid].trace_keys_,
+          *this,
+          tls[python_tid].value_cache_,
+          python_tid);
 
       addExits<EventType::PyCall>(tls[python_tid].exit_times_, python_tid);
       addExits<EventType::PyCCall>(tls[python_tid].c_exit_times_, python_tid);
@@ -1461,9 +1461,7 @@ std::vector<std::shared_ptr<Result>> PythonTracer::getEvents(
     tls.value_cache_.trimPrefixes();
   }
   PostProcess post_process(
-      std::move(time_converter),
-      thread_local_results_,
-      end_time_ns);
+      std::move(time_converter), thread_local_results_, end_time_ns);
   post_process.set_start_frames(start_frames_, enters);
   auto out = post_process.run(enters);
 

--- a/torch/csrc/autograd/profiler_python.cpp
+++ b/torch/csrc/autograd/profiler_python.cpp
@@ -641,10 +641,8 @@ class StopTheWorldGuard {
 struct ThreadLocalResults {
   ThreadLocalResults(
       PyThreadState* thread_state,
-      ValueCache* value_cache,
       PythonTracer* active_tracer)
       : thread_state_{thread_state},
-        value_cache_{value_cache},
         active_tracer_{active_tracer} {}
 
   ThreadLocalResults() = delete;
@@ -659,13 +657,13 @@ struct ThreadLocalResults {
         Config<C>::event_type == E,
         "ThreadLocalResults.intern called from the wrong typed context.");
     auto callsite = Callsite<C>(std::forward<Args>(args)...);
-    return std::get<C>(trace_keys_).intern(callsite, ephemeral, *value_cache_);
+    return std::get<C>(trace_keys_).intern(callsite, ephemeral, value_cache_);
   }
 
   static constexpr size_t BLOCK_SIZE = 1024;
 
   PyThreadState* thread_state_;
-  ValueCache* value_cache_;
+  ValueCache value_cache_;
   PythonTracer* active_tracer_;
   CallTypeHelper<TraceKeyCacheState>::tuple_type trace_keys_;
   AppendOnlyList<c10::approx_time_t, BLOCK_SIZE> exit_times_;
@@ -744,7 +742,6 @@ class PythonTracer final : public python_tracer::PythonTracerBase {
 
   std::vector<StartFrame> start_frames_;
   std::deque<ThreadLocalResults> thread_local_results_;
-  ValueCache value_cache_;
 
 #if IS_PYTHON_3_12
   friend PyObject* c_call_callback(
@@ -1060,7 +1057,7 @@ PythonTracer::PythonTracer(torch::profiler::impl::RecordQueue* queue)
   {
     StopTheWorldGuard stw(interpreter_);
     for (const auto thread_state : interpreterThreads()) {
-      thread_local_results_.emplace_back(thread_state, &value_cache_, this);
+      thread_local_results_.emplace_back(thread_state, this);
       auto& tls = thread_local_results_.back();
 
       // When we begin profiling there are already frames on the Python
@@ -1296,12 +1293,11 @@ class PostProcess {
   PostProcess(
       std::function<c10::time_t(c10::approx_time_t)> time_converter,
       std::deque<ThreadLocalResults>& tls,
-      const ValueCache& value_cache,
       c10::time_t end_time_ns)
       : end_time_{end_time_ns}, time_converter_{std::move(time_converter)} {
     for (size_t python_tid : c10::irange(tls.size())) {
       CallTypeHelper<TraceKeyCacheState>::map(
-          tls[python_tid].trace_keys_, *this, value_cache, python_tid);
+          tls[python_tid].trace_keys_, *this, tls[python_tid].value_cache_, python_tid);
 
       addExits<EventType::PyCall>(tls[python_tid].exit_times_, python_tid);
       addExits<EventType::PyCCall>(tls[python_tid].c_exit_times_, python_tid);
@@ -1462,11 +1458,12 @@ std::vector<std::shared_ptr<Result>> PythonTracer::getEvents(
     std::function<c10::time_t(c10::approx_time_t)> time_converter,
     std::vector<python_tracer::CompressedEvent>& enters,
     c10::time_t end_time_ns) {
-  value_cache_.trimPrefixes();
+  for (auto& tls : thread_local_results_) {
+    tls.value_cache_.trimPrefixes();
+  }
   PostProcess post_process(
       std::move(time_converter),
       thread_local_results_,
-      value_cache_,
       end_time_ns);
   post_process.set_start_frames(start_frames_, enters);
   auto out = post_process.run(enters);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #178552
* #178551

ValueCache stores expanded metadata (filenames, class names, parameters)
for profiled callsites. It was previously shared across all threads with
no synchronization — safe under the GIL but a data race on free-threaded
3.14t where multiple profile callbacks can fire concurrently.

Move ValueCache from a single instance on PythonTracer to per-thread
ownership in ThreadLocalResults. Each thread's cache miss writes to its
own ValueCache with no contention. Post-processing reads each thread's
cache independently, producing identical results.

Authored with Claude.