### PR TITLE
[ROCm][UT][NAVI] Restore gfx1100 Inductor blocklist in run_test

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -201,10 +201,12 @@ ROCM_BLOCKLIST = [
 
 # Add architecture-specific blocklist entries
 if TEST_WITH_ROCM and isRocmArchAnyOf(("gfx1100",)):
-    # Skip all inductor tests on Navi arch
-    ROCM_BLOCKLIST.extend(
-        test for test in TESTS if test.startswith(INDUCTOR_TEST_PREFIX)
-    )
+    # Some autotune tests on gfx1100 are hanging, disable for now
+    ROCM_BLOCKLIST.append("inductor/test_max_autotune")
+    # ROCm 7.2 gfx1100 started timing out due to these
+    ROCM_BLOCKLIST.append("inductor/test_torchinductor_dynamic_shapes")
+    ROCM_BLOCKLIST.append("inductor/test_torchinductor_opinfo")
+    ROCM_BLOCKLIST.append("inductor/test_ck_backend")
 
 S390X_BLOCKLIST = [
     # these tests fail due to various reasons


### PR DESCRIPTION
PR https://github.com/pytorch/pytorch/pull/174896 is now in upstream main, so the temporary ROCm skip decorators added for Triton 3.7 are no longer needed for these tests. This is the NAVI specific version of this PR: https://github.com/pytorch/pytorch/pull/178450

Made with [Cursor](https://cursor.com)

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @pragupta @jerrymannil @xinyazhang