### PR TITLE
[fix] put strided shard in safe globals

### DIFF
--- a/torch/distributed/tensor/__init__.py
+++ b/torch/distributed/tensor/__init__.py
@@ -19,6 +19,7 @@ from torch.distributed.tensor.placement_types import (
     Placement,
     Replicate,
     Shard,
+    _StridedShard
 )
 from torch.optim.optimizer import (
     _foreach_supported_types as _optim_foreach_supported_types,
@@ -63,6 +64,7 @@ torch.serialization.add_safe_globals(
         Partial,
         Replicate,
         Shard,
+        _StridedShard,
     ]
 )
 

--- a/torch/distributed/tensor/__init__.py
+++ b/torch/distributed/tensor/__init__.py
@@ -15,11 +15,11 @@ from torch.distributed.tensor._api import (
     zeros,
 )
 from torch.distributed.tensor.placement_types import (
+    _StridedShard,
     Partial,
     Placement,
     Replicate,
     Shard,
-    _StridedShard
 )
 from torch.optim.optimizer import (
     _foreach_supported_types as _optim_foreach_supported_types,


### PR DESCRIPTION
The `_StridedShard` placement is missing from the safe globals, leading to `torch.load` with `weights_only=True` to error.

Test script
```
import tempfile

import torch
import torch.distributed as dist
from torch.distributed.tensor import DTensor, DeviceMesh, Shard
from torch.distributed.tensor.placement_types import _StridedShard

def main():
    dist.init_process_group(backend="nccl")
    rank = dist.get_rank()
    torch.cuda.set_device(rank)

    mesh = DeviceMesh("cuda", list(range(dist.get_world_size())))
    tensor = torch.randn(8, 16, device=f"cuda:{rank}")

    for name, placements in [
        ("Shard", [Shard(0)]),
        ("_StridedShard", [_StridedShard(0, split_factor=2)]),
    ]:
        dt = DTensor.from_local(tensor.clone(), mesh, placements)
        path = f"{tempfile.mkdtemp()}/dt_{rank}.pt"
        torch.save({"tensor": dt}, path)
        dist.barrier()

        loaded = torch.load(path, weights_only=True)
        if rank == 0:
            print(f"{name}: OK — loaded type={type(loaded['tensor']).__name__}")

        dist.barrier()

    dist.destroy_process_group()


if __name__ == "__main__":
    main()
```

With fix
```
❯ torchrun --nproc-per-node 2 test_dtensor_strided_shard.py 
W0327 01:28:45.000000 2665898 torch/distributed/run.py:852] 
W0327 01:28:45.000000 2665898 torch/distributed/run.py:852] *****************************************
W0327 01:28:45.000000 2665898 torch/distributed/run.py:852] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
W0327 01:28:45.000000 2665898 torch/distributed/run.py:852] *****************************************
/scratch/prime-rl/.venv/lib/python3.12/site-packages/torch/distributed/c10d_logger.py:83: UserWarning: barrier(): using the device under current context. You can specify `device_id` in `init_process_group` to mute this warning.
  return func(*args, **kwargs)
[rank0]:[W327 01:28:50.700923841 ProcessGroupNCCL.cpp:5138] Guessing device ID based on global rank. This can cause a hang if rank to GPU mapping is heterogeneous. You can specify device_id in init_process_group()
NCCL version 2.27.5+cuda12.9
Shard: OK — loaded type=DTensor
_StridedShard: OK — loaded type=DTensor
```

Without fix
```
❯ torchrun --nproc-per-node 2 test_dtensor_strided_shard.py 
W0327 01:28:02.236000 2665545 torch/distributed/run.py:852] 
W0327 01:28:02.236000 2665545 torch/distributed/run.py:852] *****************************************
W0327 01:28:02.236000 2665545 torch/distributed/run.py:852] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
W0327 01:28:02.236000 2665545 torch/distributed/run.py:852] *****************************************
/scratch/prime-rl/.venv/lib/python3.12/site-packages/torch/distributed/c10d_logger.py:83: UserWarning: barrier(): using the device under current context. You can specify `device_id` in `init_process_group` to mute this warning.
  return func(*args, **kwargs)
[rank0]:[W327 01:28:07.956620417 ProcessGroupNCCL.cpp:5138] Guessing device ID based on global rank. This can cause a hang if rank to GPU mapping is heterogeneous. You can specify device_id in init_process_group()
NCCL version 2.27.5+cuda12.9
Shard: OK — loaded type=DTensor
[rank0]: Traceback (most recent call last):
[rank0]:   File "/scratch/prime-rl/test_dtensor_strided_shard.py", line 44, in <module>
[rank0]:     main()
[rank0]:   File "/scratch/prime-rl/test_dtensor_strided_shard.py", line 34, in main
[rank0]:     loaded = torch.load(path, weights_only=True)
[rank0]:              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/scratch/prime-rl/.venv/lib/python3.12/site-packages/torch/serialization.py", line 1548, in load
[rank0]:     raise pickle.UnpicklingError(_get_wo_message(str(e))) from None
[rank0]: _pickle.UnpicklingError: Weights only load failed. This file can still be loaded, to do so you have two options, do those steps only if you trust the source of the checkpoint. 
[rank0]:        (1) In PyTorch 2.6, we changed the default value of the `weights_only` argument in `torch.load` from `False` to `True`. Re-running `torch.load` with `weights_only` set to `False` will likely succeed, but it can result in arbitrary code execution. Do it only if you got the file from a trusted source.
[rank0]:        (2) Alternatively, to load with `weights_only=True` please check the recommended steps in the following error message.
[rank0]:        WeightsUnpickler error: Unsupported global: GLOBAL torch.distributed.tensor.placement_types._StridedShard was not an allowed global by default. Please use `torch.serialization.add_safe_globals([torch.distributed.tensor.placement_types._StridedShard])` or the `torch.serialization.safe_globals([torch.distributed.tensor.placement_types._StridedShard])` context manager to allowlist this global if you trust this class/function.

[rank0]: Check the documentation of torch.load to learn more about types accepted by default with weights_only https://pytorch.org/docs/stable/generated/torch.load.html.
[rank1]: Traceback (most recent call last):
[rank1]:   File "/scratch/prime-rl/test_dtensor_strided_shard.py", line 44, in <module>
[rank1]:     main()
[rank1]:   File "/scratch/prime-rl/test_dtensor_strided_shard.py", line 34, in main
[rank1]:     loaded = torch.load(path, weights_only=True)
[rank1]:              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank1]:   File "/scratch/prime-rl/.venv/lib/python3.12/site-packages/torch/serialization.py", line 1548, in load
[rank1]:     raise pickle.UnpicklingError(_get_wo_message(str(e))) from None
[rank1]: _pickle.UnpicklingError: Weights only load failed. This file can still be loaded, to do so you have two options, do those steps only if you trust the source of the checkpoint. 
[rank1]:        (1) In PyTorch 2.6, we changed the default value of the `weights_only` argument in `torch.load` from `False` to `True`. Re-running `torch.load` with `weights_only` set to `False` will likely succeed, but it can result in arbitrary code execution. Do it only if you got the file from a trusted source.
[rank1]:        (2) Alternatively, to load with `weights_only=True` please check the recommended steps in the following error message.
[rank1]:        WeightsUnpickler error: Unsupported global: GLOBAL torch.distributed.tensor.placement_types._StridedShard was not an allowed global by default. Please use `torch.serialization.add_safe_globals([torch.distributed.tensor.placement_types._StridedShard])` or the `torch.serialization.safe_globals([torch.distributed.tensor.placement_types._StridedShard])` context manager to allowlist this global if you trust this class/function.

[rank1]: Check the documentation of torch.load to learn more about types accepted by default with weights_only https://pytorch.org/docs/stable/generated/torch.load.html.
[rank0]:[W327 01:28:09.144848006 ProcessGroupNCCL.cpp:1553] Warning: WARNING: destroy_process_group() was not called before program exit, which can leak resources. For more info, please see https://pytorch.org/docs/stable/distributed.html#shutdown (function operator())
W0327 01:28:09.694000 2665545 torch/distributed/elastic/multiprocessing/api.py:1010] Sending process 2665670 closing signal SIGTERM
E0327 01:28:09.909000 2665545 torch/distributed/elastic/multiprocessing/api.py:984] failed (exitcode: 1) local_rank: 0 (pid: 2665669) of binary: /scratch/prime-rl/.venv/bin/python
Traceback (most recent call last):
  File "/scratch/prime-rl/.venv/bin/torchrun", line 10, in <module>
    sys.exit(main())
             ^^^^^^
  File "/scratch/prime-rl/.venv/lib/python3.12/site-packages/torch/distributed/elastic/multiprocessing/errors/__init__.py", line 362, in wrapper
    return f(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^
  File "/scratch/prime-rl/.venv/lib/python3.12/site-packages/torch/distributed/run.py", line 991, in main
    run(args)
  File "/scratch/prime-rl/.venv/lib/python3.12/site-packages/torch/distributed/run.py", line 982, in run
    elastic_launch(
  File "/scratch/prime-rl/.venv/lib/python3.12/site-packages/torch/distributed/launcher/api.py", line 170, in __call__
    return launch_agent(self._config, self._entrypoint, list(args))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/scratch/prime-rl/.venv/lib/python3.12/site-packages/torch/distributed/launcher/api.py", line 317, in launch_agent
    raise ChildFailedError(
torch.distributed.elastic.multiprocessing.errors.ChildFailedError: 
============================================================
test_dtensor_strided_shard.py FAILED
------------------------------------------------------------
Failures:
[1]:
  time      : 2026-03-27_01:28:09
  host      : ltc-idc3-hgx8-h200-63
  rank      : 1 (local_rank: 1)
  exitcode  : 1 (pid: 2665670)
  error_file: <N/A>
  traceback : To enable traceback see: https://pytorch.org/docs/stable/elastic/errors.html
------------------------------------------------------------
Root Cause (first observed failure):
[0]:
  time      : 2026-03-27_01:28:09
  host      : ltc-idc3-hgx8-h200-63
  rank      : 0 (local_rank: 0)
  exitcode  : 1 (pid: 2665669)
  error_file: <N/A>
  traceback : To enable traceback see: https://pytorch.org/docs/stable/elastic/errors.html
============================================================
```