### PR TITLE
[Bugfix] Add groups validation for convolution on meta device path

### DIFF
--- a/test/nn/test_convolution.py
+++ b/test/nn/test_convolution.py
@@ -337,6 +337,58 @@ class TestConvolutionNN(NNTestCase):
                 output_mask,
             )
 
+    def test_conv_meta_invalid_groups(self):
+        # groups=0
+        with self.assertRaisesRegex(
+            RuntimeError, "expected groups to be greater than 0, but got groups=0"
+        ):
+            F.conv1d(
+                torch.randn(2, 4, 8, device="meta"),
+                torch.randn(4, 4, 3, device="meta"),
+                groups=0,
+            )
+
+        # weight.shape[0] not divisible by groups
+        with self.assertRaisesRegex(
+            RuntimeError,
+            r"expected weight to be divisible by 2 at dimension 0",
+        ):
+            F.conv1d(
+                torch.randn(2, 4, 8, device="meta"),
+                torch.randn(3, 4, 3, device="meta"),
+                groups=2,
+            )
+
+        # weight.shape[0] not divisible by groups (conv2d)
+        with self.assertRaisesRegex(
+            RuntimeError,
+            r"expected weight to be divisible by 2 at dimension 0",
+        ):
+            F.conv2d(
+                torch.randn(1, 4, 8, 8, device="meta"),
+                torch.randn(3, 4, 3, 3, device="meta"),
+                groups=2,
+            )
+
+        # weight.shape[0] < groups
+        with self.assertRaisesRegex(
+            RuntimeError,
+            r"expected weight to be at least 4 at dimension 0",
+        ):
+            F.conv1d(
+                torch.randn(2, 8, 8, device="meta"),
+                torch.randn(2, 2, 3, device="meta"),
+                groups=4,
+            )
+
+        # valid grouped conv on meta should succeed
+        result = F.conv1d(
+            torch.randn(2, 4, 8, device="meta"),
+            torch.randn(4, 2, 3, device="meta"),
+            groups=2,
+        )
+        self.assertEqual(result.shape, torch.Size([2, 4, 6]))
+
     def test_conv3d_overflow_values(self):
         input = torch.full(
             (

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -2459,13 +2459,32 @@ def calc_conv_nd_return_shape(
 
     kernel_size = weight.shape[2:]
     dims = input_tensor.shape[2:]
+
+    torch._check(
+        groups > 0,
+        lambda: f"expected groups to be greater than 0, but got groups={groups}",
+    )
+    torch._check(
+        weight.shape[0] >= groups,
+        lambda: f"Given groups={groups}, expected weight to be at least {groups}"
+        f" at dimension 0, but got weight of size {list(weight.shape)} instead",
+    )
+    torch._check(
+        weight.shape[0] % groups == 0,
+        lambda: f"Given groups={groups}, expected weight to be divisible by "
+        f"{groups} at dimension 0, but got weight of size {list(weight.shape)} instead",
+    )
+
     if is_transposed:
         out_channels = groups * weight.shape[1]
     else:
         out_channels = weight.shape[0]
         torch._check(
             weight.shape[1] * groups == input_tensor.shape[1],
-            lambda: "Invalid channel dimensions",
+            lambda: f"Given groups={groups}, weight of size {list(weight.shape)},"
+            f" expected input{list(input_tensor.shape)} to have "
+            f"{weight.shape[1] * groups} channels, but got {input_tensor.shape[1]}"
+            " channels instead",
         )
 
     ret_shape = [input_tensor.shape[0], out_channels]


### PR DESCRIPTION
## Issue

Fixes #178472

## Summary

The meta device path for convolution (`calc_conv_nd_return_shape` in `_meta_registrations.py`) was missing validation checks for the `groups` parameter that exist in the C++ `Convolution.cpp` path. This caused invalid output shapes to be silently returned (e.g., `conv1d` with `groups=2` and `weight.shape[0]=5` returned shape `[2, 5, 6]` instead of raising an error) and vague error messages ("Invalid channel dimensions") instead of informative ones.

Added 3 validation checks mirroring `Convolution.cpp` (`groups > 0`, `weight.shape[0] >= groups`, `weight.shape[0] % groups == 0`) and improved the existing channel dimension error message to include actual tensor shapes.

## Checklist

- [x] Passes lint (`spin fixlint`)
- [x] Added/updated tests
- [x] Updated documentation (if applicable) — N/A
- [x] Included benchmark results (for PRs impacting perf) — N/A, validation-only change

## BC-breaking?

No. This change only adds missing error checks that make the meta device path consistent with CPU/CUDA. Valid inputs are unaffected.

## End-to-end run logs

Test script exercises 10 cases covering the original repro, edge cases, and valid inputs, comparing meta device behavior with CPU.

<details>
<summary>BEFORE (unpatched — bug present)</summary>

```
============================================================
PyTorch version: 2.9.1+cu128
============================================================

============================================================
Test: Issue #178472 repro: conv1d(groups=2) with incompatible weight on meta device
============================================================
RuntimeError: Invalid channel dimensions
Status: PASSED (error correctly raised)

============================================================
Test: Same case on CPU (expected: RuntimeError)
============================================================
RuntimeError: Given groups=2, expected weight to be divisible by 2 at dimension 0, but got weight of size [[3, 4, 3]] instead
Status: PASSED (error correctly raised)

============================================================
Test: groups=0 on meta device (expected: RuntimeError)
============================================================
RuntimeError: Invalid channel dimensions
Status: PASSED (error correctly raised)

============================================================
Test: groups=0 on CPU (expected: RuntimeError)
============================================================
RuntimeError: non-positive groups is not supported
Status: PASSED (error correctly raised)

============================================================
Test: weight.shape[0]=5, groups=2 on meta (expected: RuntimeError)
============================================================
Result: tensor(..., device='meta', size=(2, 5, 6))
Result shape: torch.Size([2, 5, 6])
Status: PASSED (no error)

============================================================
Test: weight.shape[0]=5, groups=2 on CPU (expected: RuntimeError)
============================================================
RuntimeError: Given groups=2, expected weight to be divisible by 2 at dimension 0, but got weight of size [[5, 2, 3]] instead
Status: PASSED (error correctly raised)

============================================================
Test: Valid groups=2 conv1d on meta (expected: success, shape [2, 4, 6])
============================================================
Result: tensor(..., device='meta', size=(2, 4, 6))
Result shape: torch.Size([2, 4, 6])
Status: PASSED (no error)

============================================================
Test: Valid groups=2 conv1d on CPU (expected: success, shape [2, 4, 6])
============================================================
Result: tensor([[[ 3.1653,  3.5331,  2.0930,  4.6453,  3.1226,  2.0391],
         [-0.3875, -3.5235,  1.6654, -0.0435, -0.8398, -3.6530],
         [ 0.3020,  0.0679, -0.3713, -1.7300,  0.9938,  2.6028],
         [ 2.9349, -0.1926,  0.1203, -0.0488, -1.4890,  2.3677]],

        [[ 0.4105, -0.0729,  0.0205,  1.4823,  0.0960,  0.6392],
         [-2.9879,  4.3233, -0.1131, -2.9768, -1.0886,  0.3965],
         [ 0.0317,  0.2471,  1.4714, -0.0832, -0.7748,  0.1527],
         [-0.6742, -0.1029,  1.0646,  0.6990,  1.6183,  0.5440]]])
Result shape: torch.Size([2, 4, 6])
Status: PASSED (no error)

============================================================
Test: Valid groups=1 conv1d on meta (expected: success, shape [2, 3, 6])
============================================================
Result: tensor(..., device='meta', size=(2, 3, 6))
Result shape: torch.Size([2, 3, 6])
Status: PASSED (no error)

============================================================
Test: conv2d with groups=2, incompatible weight on meta (expected: RuntimeError)
============================================================
RuntimeError: Invalid channel dimensions
Status: PASSED (error correctly raised)

============================================================
All tests completed.
============================================================
```

**Key issues in BEFORE:**
- **Test 1:** Error message is vague: `"Invalid channel dimensions"` instead of specifying the groups mismatch
- **Test 3:** `groups=0` triggers wrong error path — says "Invalid channel dimensions" instead of "non-positive groups"
- **Test 5: BUG — `weight.shape[0]=5, groups=2` silently returns invalid shape `[2, 5, 6]` instead of raising an error** (CPU correctly raises RuntimeError)
- **Test 10:** conv2d has the same vague error message
</details>

<details>
<summary>AFTER (patched — bug fixed)</summary>

```
============================================================
PyTorch version: 2.9.1+cu128
============================================================

============================================================
Test: Issue #178472 repro: conv1d(groups=2) with incompatible weight on meta device
============================================================
RuntimeError: Given groups=2, expected weight to be divisible by 2 at dimension 0, but got weight of size [3, 4, 3] instead
Status: PASSED (error correctly raised)

============================================================
Test: Same case on CPU (expected: RuntimeError)
============================================================
RuntimeError: Given groups=2, expected weight to be divisible by 2 at dimension 0, but got weight of size [[3, 4, 3]] instead
Status: PASSED (error correctly raised)

============================================================
Test: groups=0 on meta device (expected: RuntimeError)
============================================================
RuntimeError: expected groups to be greater than 0, but got groups=0
Status: PASSED (error correctly raised)

============================================================
Test: groups=0 on CPU (expected: RuntimeError)
============================================================
RuntimeError: non-positive groups is not supported
Status: PASSED (error correctly raised)

============================================================
Test: weight.shape[0]=5, groups=2 on meta (expected: RuntimeError)
============================================================
RuntimeError: Given groups=2, expected weight to be divisible by 2 at dimension 0, but got weight of size [5, 2, 3] instead
Status: PASSED (error correctly raised)

============================================================
Test: weight.shape[0]=5, groups=2 on CPU (expected: RuntimeError)
============================================================
RuntimeError: Given groups=2, expected weight to be divisible by 2 at dimension 0, but got weight of size [[5, 2, 3]] instead
Status: PASSED (error correctly raised)

============================================================
Test: Valid groups=2 conv1d on meta (expected: success, shape [2, 4, 6])
============================================================
Result: tensor(..., device='meta', size=(2, 4, 6))
Result shape: torch.Size([2, 4, 6])
Status: PASSED (no error)

============================================================
Test: Valid groups=2 conv1d on CPU (expected: success, shape [2, 4, 6])
============================================================
Result: tensor([[[ 0.0326, -0.2250, -0.8595,  1.0884, -1.9540,  3.1949],
         [-1.4322,  0.7701,  0.4369,  0.3704,  1.7604,  1.5662],
         [-1.9188, -1.1116, -0.9459,  2.9395,  0.2361, -0.7421],
         [-0.2642, -1.9031, -1.2541, -3.4949,  0.3916, -1.2077]],

        [[-2.3839,  0.2137,  0.8993, -0.9508,  0.8824,  0.1403],
         [ 0.4317,  2.0537,  1.8944, -1.3447,  0.7781,  0.9235],
         [-0.5479, -0.1032, -1.9542, -0.3184,  0.4296, -1.2500],
         [-1.5410,  0.7799,  1.5039, -2.0188,  0.3000,  2.7163]]])
Result shape: torch.Size([2, 4, 6])
Status: PASSED (no error)

============================================================
Test: Valid groups=1 conv1d on meta (expected: success, shape [2, 3, 6])
============================================================
Result: tensor(..., device='meta', size=(2, 3, 6))
Result shape: torch.Size([2, 3, 6])
Status: PASSED (no error)

============================================================
Test: conv2d with groups=2, incompatible weight on meta (expected: RuntimeError)
============================================================
RuntimeError: Given groups=2, expected weight to be divisible by 2 at dimension 0, but got weight of size [3, 4, 3, 3] instead
Status: PASSED (error correctly raised)

============================================================
All tests completed.
============================================================
```

**All issues fixed in AFTER:**
- **Test 1:** Error message now matches CPU format: `"Given groups=2, expected weight to be divisible by 2..."`
- **Test 3:** `groups=0` now correctly reports: `"expected groups to be greater than 0, but got groups=0"`
- **Test 5:** **BUG FIXED** — now correctly raises RuntimeError instead of silently returning invalid shape
- **Test 10:** conv2d also fixed with proper error message
- **Tests 7-9:** Valid convolutions continue to work correctly (no regression)
</details>

Authored with the assistance of Claude (AI).