### PR TITLE
[SymmetricMemory] Add RECORD_PARAM_COMMS to symmetric memory CUDA ops for PG metadata in profiler traces (#178571)

### DIFF
--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.cu
@@ -1,4 +1,5 @@
 #include <torch/csrc/distributed/c10d/GroupRegistry.hpp>
+#include <torch/csrc/distributed/c10d/ParamCommsUtils.hpp>
 #include <torch/csrc/distributed/c10d/cuda/utils.hpp>
 #include <torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory-inl.cuh>
 #include <torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.hpp>
@@ -79,7 +80,8 @@ CUDAPeerAllocInfo::CUDAPeerAllocInfo(
     size_t buffer_size,
     int local_device_idx,
     int rank,
-    int world_size)
+    int world_size,
+    std::string group_name)
     : alloc_refs_(std::move(alloc_refs)),
       buffers_(std::move(buffers)),
       signal_pads_(std::move(signal_pads)),
@@ -88,7 +90,8 @@ CUDAPeerAllocInfo::CUDAPeerAllocInfo(
       buffer_size_(buffer_size),
       local_device_idx_(local_device_idx),
       rank_(rank),
-      world_size_(world_size) {
+      world_size_(world_size),
+      group_name_(std::move(group_name)) {
   const size_t arr_size = sizeof(void*) * world_size_;
   buffers_dev_ = reinterpret_cast<void**>(
       c10::cuda::CUDACachingAllocator::raw_alloc(arr_size));
@@ -210,7 +213,21 @@ static __global__ void barrier_kernel(
 
 void CUDASymmetricMemory::barrier(int channel, size_t timeout_ms) {
   check_channel(channel, world_size_);
-  c10::cuda::CUDAGuard guard(local_device_idx_);
+  auto pg = c10d::resolve_process_group(pai_->group_name_);
+  RECORD_PARAM_COMMS(
+      static_cast<int64_t>(0),
+      std::make_tuple(pg->getGroupName(), pg->getGroupDesc()),
+      rank_,
+      "symm_mem::barrier",
+      0,
+      0,
+      at::kByte,
+      std::vector<int64_t>(),
+      std::vector<int64_t>(),
+      -1,
+      -1,
+      world_size_);
+  c10::cuda::CUDAGuard device_guard(local_device_idx_);
   barrier_kernel<<<
       1,
       max(at::cuda::warp_size(), world_size_),
@@ -252,7 +269,21 @@ void CUDASymmetricMemory::put_signal(
     int channel,
     size_t timeout_ms) {
   check_channel(channel, world_size_);
-  c10::cuda::CUDAGuard guard(local_device_idx_);
+  auto pg = c10d::resolve_process_group(pai_->group_name_);
+  RECORD_PARAM_COMMS(
+      static_cast<int64_t>(0),
+      std::make_tuple(pg->getGroupName(), pg->getGroupDesc()),
+      rank_,
+      "symm_mem::put_signal",
+      0,
+      0,
+      at::kByte,
+      std::vector<int64_t>(),
+      std::vector<int64_t>(),
+      -1,
+      -1,
+      world_size_);
+  c10::cuda::CUDAGuard device_guard(local_device_idx_);
   put_signal_kernel<<<
       1,
       at::cuda::warp_size(),
@@ -300,7 +331,21 @@ void CUDASymmetricMemory::wait_signal(
     int channel,
     size_t timeout_ms) {
   check_channel(channel, world_size_);
-  c10::cuda::CUDAGuard guard(local_device_idx_);
+  auto pg = c10d::resolve_process_group(pai_->group_name_);
+  RECORD_PARAM_COMMS(
+      static_cast<int64_t>(0),
+      std::make_tuple(pg->getGroupName(), pg->getGroupDesc()),
+      rank_,
+      "symm_mem::wait_signal",
+      0,
+      0,
+      at::kByte,
+      std::vector<int64_t>(),
+      std::vector<int64_t>(),
+      -1,
+      -1,
+      world_size_);
+  c10::cuda::CUDAGuard device_guard(local_device_idx_);
   wait_signal_kernel<<<
       1,
       at::cuda::warp_size(),
@@ -785,7 +830,8 @@ c10::intrusive_ptr<CUDAPeerAllocInfo> make_peer_alloc_info(
       block->buffer_size,
       block->device_idx,
       rank,
-      world_size);
+      world_size,
+      group_name);
 
   return pai;
 }

--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.hpp
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.hpp
@@ -84,7 +84,8 @@ class CUDAPeerAllocInfo : public c10::intrusive_ptr_target {
       size_t buffer_size,
       int local_device_idx,
       int rank,
-      int world_size);
+      int world_size,
+      std::string group_name);
 
  private:
   std::vector<c10::intrusive_ptr<AllocationRef>> alloc_refs_;
@@ -98,6 +99,7 @@ class CUDAPeerAllocInfo : public c10::intrusive_ptr_target {
   int world_size_;
   void** buffers_dev_;
   void** signal_pads_dev_;
+  std::string group_name_;
 
   friend class CUDASymmetricMemory;
 };

--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryOps.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryOps.cu
@@ -17,6 +17,7 @@
 
 #include <torch/csrc/distributed/c10d/cuda/AsyncMM.cuh>
 #include <torch/csrc/distributed/c10d/GroupRegistry.hpp>
+#include <torch/csrc/distributed/c10d/ParamCommsUtils.hpp>
 #include <torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory-inl.cuh>
 #include <torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.hpp>
 
@@ -163,6 +164,20 @@ at::Tensor multimem_all_reduce_(
     const at::Tensor& input,
     std::string reduce_op,
     std::string group_name) {
+  auto pg = c10d::resolve_process_group(group_name);
+  RECORD_PARAM_COMMS(
+      static_cast<int64_t>(0),
+      std::make_tuple(pg->getGroupName(), pg->getGroupDesc()),
+      pg->getRank(),
+      "symm_mem::multimem_all_reduce",
+      input.numel(),
+      input.numel(),
+      input.scalar_type(),
+      std::vector<int64_t>(),
+      std::vector<int64_t>(),
+      -1,
+      -1,
+      pg->getSize());
   TORCH_CHECK(
       input.is_contiguous(), "multimem_all_reduce_: input must be contiguous.");
   TORCH_CHECK(
@@ -247,6 +262,20 @@ at::Tensor multimem_one_shot_reduce_out(
     int64_t root,
     std::string group_name,
     at::Tensor out) {
+  auto pg = c10d::resolve_process_group(group_name);
+  RECORD_PARAM_COMMS(
+      static_cast<int64_t>(0),
+      std::make_tuple(pg->getGroupName(), pg->getGroupDesc()),
+      pg->getRank(),
+      "symm_mem::multimem_one_shot_reduce",
+      input.numel(),
+      out.numel(),
+      input.scalar_type(),
+      std::vector<int64_t>(),
+      std::vector<int64_t>(),
+      -1,
+      -1,
+      pg->getSize());
   TORCH_CHECK(
       input.is_contiguous(),
       "multimem_one_shot_reduce: input must be contiguous.");
@@ -361,6 +390,20 @@ at::Tensor multimem_all_gather_out(
     const at::Tensor& input,
     std::string group_name,
     at::Tensor out) {
+  auto pg = c10d::resolve_process_group(group_name);
+  RECORD_PARAM_COMMS(
+      static_cast<int64_t>(0),
+      std::make_tuple(pg->getGroupName(), pg->getGroupDesc()),
+      pg->getRank(),
+      "symm_mem::multimem_all_gather",
+      input.numel(),
+      out.numel(),
+      input.scalar_type(),
+      std::vector<int64_t>(),
+      std::vector<int64_t>(),
+      -1,
+      -1,
+      pg->getSize());
   auto symm_mem = c10d::symmetric_memory::rendezvous(out, group_name);
   TORCH_CHECK(
       symm_mem != nullptr,
@@ -475,6 +518,20 @@ at::Tensor one_shot_all_reduce_out_impl(
     std::string reduce_op,
     std::string group_name,
     at::Tensor out) {
+  auto pg = c10d::resolve_process_group(group_name);
+  RECORD_PARAM_COMMS(
+      static_cast<int64_t>(0),
+      std::make_tuple(pg->getGroupName(), pg->getGroupDesc()),
+      pg->getRank(),
+      "symm_mem::one_shot_all_reduce",
+      input.numel(),
+      out.numel(),
+      input.scalar_type(),
+      std::vector<int64_t>(),
+      std::vector<int64_t>(),
+      -1,
+      -1,
+      pg->getSize());
   TORCH_CHECK(
       input.is_contiguous(), "one_shot_all_reduce: input must be contiguous.");
   TORCH_CHECK(
@@ -732,6 +789,20 @@ at::Tensor two_shot_all_reduce_impl(
     std::optional<at::Tensor> output,
     std::string reduce_op,
     std::string group_name) {
+  auto pg = c10d::resolve_process_group(group_name);
+  RECORD_PARAM_COMMS(
+      static_cast<int64_t>(0),
+      std::make_tuple(pg->getGroupName(), pg->getGroupDesc()),
+      pg->getRank(),
+      "symm_mem::two_shot_all_reduce",
+      input.numel(),
+      input.numel(),
+      input.scalar_type(),
+      std::vector<int64_t>(),
+      std::vector<int64_t>(),
+      -1,
+      -1,
+      pg->getSize());
   TORCH_CHECK(
       input.is_contiguous(), "two_shot_all_reduce: input must be contiguous.");
   TORCH_CHECK(
@@ -856,6 +927,20 @@ at::Tensor reduce_scatter_out(
     std::string group_name,
     bool split_last_dim,
     at::Tensor output) {
+  auto pg = c10d::resolve_process_group(group_name);
+  RECORD_PARAM_COMMS(
+      static_cast<int64_t>(0),
+      std::make_tuple(pg->getGroupName(), pg->getGroupDesc()),
+      pg->getRank(),
+      "symm_mem::reduce_scatter",
+      input.numel(),
+      output.numel(),
+      input.scalar_type(),
+      std::vector<int64_t>(),
+      std::vector<int64_t>(),
+      -1,
+      -1,
+      pg->getSize());
   TORCH_CHECK(
       input.is_contiguous(), "reduce_scatter: input must be contiguous.");
   TORCH_CHECK(


### PR DESCRIPTION
Summary:

Add C++ level RECORD_PARAM_COMMS annotations to all symmetric memory CUDA
operations so that process group metadata (pg_name, pg_desc) appears in
profiler traces alongside GPU kernel events.

Changes:
- Store group_name on CUDAPeerAllocInfo so barrier/put_signal/wait_signal
  can resolve the ProcessGroup for PG metadata
- Add RECORD_PARAM_COMMS to barrier(), put_signal(), wait_signal() in
  CUDASymmetricMemory.cu
- Add RECORD_PARAM_COMMS to 6 ops in CUDASymmetricMemoryOps.cu:
  multimem_all_reduce_, multimem_one_shot_reduce_out,
  multimem_all_gather_out, one_shot_all_reduce_out_impl,
  two_shot_all_reduce_impl, reduce_scatter_out
- Rename CUDAGuard guard -> device_guard to avoid naming collision with
  RECORD_FUNCTION macro internal guard variable
- Add dedicated test (test_symm_mem_pg_metadata_trace.py) verifying PG
  metadata appears directly on GPU kernel events (cat="kernel")

Test Plan:
New dedicated test file `test_symm_mem_pg_metadata_trace.py` (MultiProcessTestCase,
same pattern as `test_c10d_nccl_seq_num_trace.py`):

```
$ buck2 test fbcode//mode/dev-nosan fbcode//caffe2/test/distributed/fb:test_symm_mem_pg_metadata_trace

Tests finished: Pass 1. Fail 0.
```

`test_pg_metadata_on_kernel_events` spawns 2 processes, exercises barrier,
put_signal/wait_signal, and one_shot_all_reduce under profiler (CPU+CUDA),
exports chrome trace, and asserts PG metadata directly on GPU kernel events
(cat="kernel"):
- `Process Group Name` (non-empty)
- `Process Group Description` (non-empty)
- `Collective name` matching the op (e.g. "symm_mem::barrier")
- `Group size` >= 2

Reviewed By: ngimel

Differential Revision: D98015214


