### PR TITLE
[Bugfix] Add output_padding and bias validation for convolution meta path

### DIFF
--- a/test/nn/test_convolution.py
+++ b/test/nn/test_convolution.py
@@ -337,6 +337,119 @@ class TestConvolutionNN(NNTestCase):
                 output_mask,
             )
 
+    def test_conv_transpose_meta_invalid_output_padding(self):
+        # conv_transpose1d: output_padding not smaller than stride or dilation
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "output padding must be smaller than either stride or dilation",
+        ):
+            F.conv_transpose1d(
+                torch.randn(20, 16, 50, device="meta"),
+                torch.randn(16, 33, 5, device="meta"),
+                stride=2,
+                padding=0,
+                output_padding=2,
+                groups=2,
+                dilation=1,
+            )
+
+        # conv_transpose2d: output_padding not smaller than stride or dilation
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "output padding must be smaller than either stride or dilation",
+        ):
+            F.conv_transpose2d(
+                torch.randn(1, 4, 5, 5, device="meta"),
+                torch.randn(4, 8, 3, 3, device="meta"),
+                stride=2,
+                padding=(1, 0),
+                output_padding=2,
+                groups=1,
+                dilation=2,
+            )
+
+        # conv_transpose3d: output_padding not smaller than stride or dilation
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "output padding must be smaller than either stride or dilation",
+        ):
+            F.conv_transpose3d(
+                torch.randn(2, 4, 5, 5, 5, device="meta"),
+                torch.randn(4, 8, 3, 3, 3, device="meta"),
+                stride=2,
+                padding=1,
+                output_padding=2,
+                dilation=1,
+            )
+
+        # valid output_padding should succeed
+        result = F.conv_transpose1d(
+            torch.randn(20, 16, 50, device="meta"),
+            torch.randn(16, 33, 5, device="meta"),
+            stride=2,
+            padding=0,
+            output_padding=1,
+            groups=2,
+            dilation=1,
+        )
+        self.assertEqual(result.shape, torch.Size([20, 66, 104]))
+
+    def test_conv_meta_invalid_bias(self):
+        # conv_transpose3d: bias size doesn't match weight.shape[1] * groups
+        with self.assertRaisesRegex(
+            RuntimeError,
+            r"expected bias to be 1-dimensional with 66 elements",
+        ):
+            F.conv_transpose3d(
+                torch.randn(20, 16, 50, 10, 20, device="meta"),
+                torch.randn(16, 33, 3, 3, 3, device="meta"),
+                bias=torch.randn(33, device="meta"),
+                stride=1,
+                padding=1,
+                output_padding=0,
+                groups=2,
+                dilation=1,
+            )
+
+        # conv_transpose1d: bias size doesn't match weight.shape[1] * groups
+        with self.assertRaisesRegex(
+            RuntimeError,
+            r"expected bias to be 1-dimensional with 66 elements",
+        ):
+            F.conv_transpose1d(
+                torch.randn(20, 16, 50, device="meta"),
+                torch.randn(16, 33, 5, device="meta"),
+                bias=torch.randn(33, device="meta"),
+                stride=1,
+                padding=0,
+                output_padding=0,
+                groups=2,
+            )
+
+        # non-transposed conv: bias size doesn't match weight.shape[0]
+        with self.assertRaisesRegex(
+            RuntimeError,
+            r"expected bias to be 1-dimensional with 4 elements",
+        ):
+            F.conv2d(
+                torch.randn(1, 3, 8, 8, device="meta"),
+                torch.randn(4, 3, 3, 3, device="meta"),
+                bias=torch.randn(3, device="meta"),
+            )
+
+        # valid bias should succeed
+        result = F.conv_transpose3d(
+            torch.randn(20, 16, 50, 10, 20, device="meta"),
+            torch.randn(16, 33, 3, 3, 3, device="meta"),
+            bias=torch.randn(66, device="meta"),
+            stride=1,
+            padding=1,
+            output_padding=0,
+            groups=2,
+            dilation=1,
+        )
+        self.assertEqual(result.shape, torch.Size([20, 66, 50, 10, 20]))
+
     def test_conv3d_overflow_values(self):
         input = torch.full(
             (

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -2497,6 +2497,20 @@ def calc_conv_nd_return_shape(
         else:
             output_padding_list = output_padding
 
+        for i in range(len(output_padding_list)):
+            torch._check(
+                # pyrefly: ignore [bad-index, index-error]
+                output_padding_list[i] < stride[i]
+                # pyrefly: ignore [bad-index, index-error]
+                or output_padding_list[i] < dilation[i],
+                lambda i=i: (
+                    "output padding must be smaller than either stride or dilation, "
+                    f"but got output_padding[{i}]={output_padding_list[i]}, "
+                    # pyrefly: ignore [bad-index, index-error]
+                    f"stride[{i}]={stride[i]}, dilation[{i}]={dilation[i]}"
+                ),
+            )
+
     for i in range(len(dims)):
         # If output_padding is present, we are dealing with a transposed convolution
         if output_padding_list:
@@ -2610,6 +2624,24 @@ def meta_conv(
         groups,
         output_padding if is_transposed else None,
     )
+
+    if bias is not None:
+        if is_transposed:
+            expected_bias_size = weight.shape[1] * groups
+            torch._check(
+                bias.ndim == 1 and bias.shape[0] == expected_bias_size,
+                lambda: f"Given transposed={is_transposed}, weight of size {list(weight.shape)}, "
+                f"expected bias to be 1-dimensional with {expected_bias_size} elements, "
+                f"but got bias of size {list(bias.shape)} instead",
+            )
+        else:
+            expected_bias_size = weight.shape[0]
+            torch._check(
+                bias.ndim == 1 and bias.shape[0] == expected_bias_size,
+                lambda: f"Given weight of size {list(weight.shape)}, "
+                f"expected bias to be 1-dimensional with {expected_bias_size} elements, "
+                f"but got bias of size {list(bias.shape)} instead",
+            )
 
     from torch.fx.experimental.symbolic_shapes import guard_or_false
 


### PR DESCRIPTION
## Issue

Fixes #178125, #178127, #178128

## Summary

The meta device path for convolution (`calc_conv_nd_return_shape` and `meta_conv` in `_meta_registrations.py`) was missing two classes of validation checks that exist in the C++ backend (`Convolution.cpp`, `NaiveConvolutionTranspose{2d,3d}.cpp`):

1. **output_padding validation** — `output_padding[i]` must be smaller than either `stride[i]` or `dilation[i]`. Without this, `conv_transpose{1,2,3}d` on meta tensors silently accepted invalid `output_padding` values and returned incorrect shapes.

2. **bias shape validation** — `bias` must be 1-dimensional with the correct number of elements (`weight.shape[1] * groups` for transposed, `weight.shape[0]` for non-transposed). Without this, `conv_transpose3d` and `conv2d` on meta tensors accepted mismatched bias shapes without error.

## Changes

- `torch/_meta_registrations.py` (+32 lines):
  - Added `output_padding` vs `stride`/`dilation` check in `calc_conv_nd_return_shape`
  - Added `bias` shape check in `meta_conv`
- `test/nn/test_convolution.py` (+113 lines):
  - `test_conv_transpose_meta_invalid_output_padding`: tests invalid output_padding for conv_transpose{1,2,3}d on meta + valid case
  - `test_conv_meta_invalid_bias`: tests invalid bias for conv_transpose{3,1}d and conv2d on meta + valid case

## Checklist

- [x] Added tests
- [x] Matches C++ backend validation logic
- [x] No BC-breaking changes (only adds missing error checks for invalid inputs)

## End-to-end run logs

Test script exercises all 3 bug repros plus valid cases, comparing meta device behavior against CPU (ground truth).

<details>
<summary>BEFORE (unpatched — bugs present)</summary>

```
PyTorch version: 2.12.0a0+git18464b7

======================================================================
Test: #178125 conv_transpose1d: output_padding=2, stride=2, dilation=1 on META
======================================================================
  Result shape: torch.Size([20, 66, 105])
  Status: NO ERROR (returned successfully)

======================================================================
Test: #178125 conv_transpose1d: output_padding=2, stride=2, dilation=1 on CPU
======================================================================
  RuntimeError: output padding must be smaller than either stride or dilation, but got output_padding_height: 0 output_padding_width: 2 stride_height: 1 stride_width: 2 dilation_height: 1 dilation_width: 1
  Status: ERROR RAISED

======================================================================
Test: #178127 conv_transpose2d: output_padding=2, stride=2, dilation=2 on META
======================================================================
  Result shape: torch.Size([1, 8, 13, 15])
  Status: NO ERROR (returned successfully)

======================================================================
Test: #178127 conv_transpose2d: output_padding=2, stride=2, dilation=2 on CPU
======================================================================
  RuntimeError: output padding must be smaller than either stride or dilation, but got output_padding_height: 2 output_padding_width: 2 stride_height: 2 stride_width: 2 dilation_height: 2 dilation_width: 2
  Status: ERROR RAISED

======================================================================
Test: #178128 conv_transpose3d: bias=33 but expected=66 (groups=2) on META
======================================================================
  Result shape: torch.Size([20, 66, 50, 10, 20])
  Status: NO ERROR (returned successfully)

======================================================================
Test: #178128 conv_transpose3d: bias=33 but expected=66 (groups=2) on CPU
======================================================================
  RuntimeError: Given transposed=1, weight of size [16, 33, 3, 3, 3], expected bias to be 1-dimensional with 66 elements, but got bias of size [33] instead
  Status: ERROR RAISED

======================================================================
Test: conv2d: bias=3 but expected=4 on META
======================================================================
  Result shape: torch.Size([1, 4, 6, 6])
  Status: NO ERROR (returned successfully)

======================================================================
Test: conv2d: bias=3 but expected=4 on CPU
======================================================================
  RuntimeError: Given weight of size [4, 3, 3, 3], expected bias to be 1-dimensional with 4 elements, but got bias of size [3] instead
  Status: ERROR RAISED

======================================================================
Test: VALID: conv_transpose1d output_padding=1 < stride=2 on META
======================================================================
  Result shape: torch.Size([20, 66, 104])
  Status: NO ERROR (returned successfully)

======================================================================
Test: VALID: conv_transpose3d correct bias=66 on META
======================================================================
  Result shape: torch.Size([20, 66, 50, 10, 20])
  Status: NO ERROR (returned successfully)

======================================================================
All tests completed.
======================================================================
```

**Key issues in BEFORE:**
- **#178125:** `conv_transpose1d` with `output_padding=2, stride=2, dilation=1` silently returns shape `[20, 66, 105]` on meta instead of raising an error (CPU correctly raises RuntimeError)
- **#178127:** `conv_transpose2d` with `output_padding=2, stride=2, dilation=2` silently returns shape `[1, 8, 13, 15]` on meta instead of raising an error (CPU correctly raises RuntimeError)
- **#178128:** `conv_transpose3d` with `bias=33` (expected `66` for `groups=2`) silently returns shape `[20, 66, 50, 10, 20]` on meta instead of raising an error (CPU correctly raises RuntimeError)
- `conv2d` with `bias=3` (expected `4`) also silently succeeds on meta
</details>

<details>
<summary>AFTER (patched — bugs fixed)</summary>

```
PyTorch version: 2.12.0a0+git18464b7

======================================================================
Test: #178125 conv_transpose1d: output_padding=2, stride=2, dilation=1 on META
======================================================================
  RuntimeError: output padding must be smaller than either stride or dilation, but got output_padding[0]=2, stride[0]=2, dilation[0]=1
  Status: ERROR RAISED

======================================================================
Test: #178125 conv_transpose1d: output_padding=2, stride=2, dilation=1 on CPU
======================================================================
  RuntimeError: output padding must be smaller than either stride or dilation, but got output_padding_height: 0 output_padding_width: 2 stride_height: 1 stride_width: 2 dilation_height: 1 dilation_width: 1
  Status: ERROR RAISED

======================================================================
Test: #178127 conv_transpose2d: output_padding=2, stride=2, dilation=2 on META
======================================================================
  RuntimeError: output padding must be smaller than either stride or dilation, but got output_padding[0]=2, stride[0]=2, dilation[0]=2
  Status: ERROR RAISED

======================================================================
Test: #178127 conv_transpose2d: output_padding=2, stride=2, dilation=2 on CPU
======================================================================
  RuntimeError: output padding must be smaller than either stride or dilation, but got output_padding_height: 2 output_padding_width: 2 stride_height: 2 stride_width: 2 dilation_height: 2 dilation_width: 2
  Status: ERROR RAISED

======================================================================
Test: #178128 conv_transpose3d: bias=33 but expected=66 (groups=2) on META
======================================================================
  RuntimeError: Given transposed=True, weight of size [16, 33, 3, 3, 3], expected bias to be 1-dimensional with 66 elements, but got bias of size [33] instead
  Status: ERROR RAISED

======================================================================
Test: #178128 conv_transpose3d: bias=33 but expected=66 (groups=2) on CPU
======================================================================
  RuntimeError: Given transposed=1, weight of size [16, 33, 3, 3, 3], expected bias to be 1-dimensional with 66 elements, but got bias of size [33] instead
  Status: ERROR RAISED

======================================================================
Test: conv2d: bias=3 but expected=4 on META
======================================================================
  RuntimeError: Given weight of size [4, 3, 3, 3], expected bias to be 1-dimensional with 4 elements, but got bias of size [3] instead
  Status: ERROR RAISED

======================================================================
Test: conv2d: bias=3 but expected=4 on CPU
======================================================================
  RuntimeError: Given weight of size [4, 3, 3, 3], expected bias to be 1-dimensional with 4 elements, but got bias of size [3] instead
  Status: ERROR RAISED

======================================================================
Test: VALID: conv_transpose1d output_padding=1 < stride=2 on META
======================================================================
  Result shape: torch.Size([20, 66, 104])
  Status: NO ERROR (returned successfully)

======================================================================
Test: VALID: conv_transpose3d correct bias=66 on META
======================================================================
  Result shape: torch.Size([20, 66, 50, 10, 20])
  Status: NO ERROR (returned successfully)

======================================================================
All tests completed.
======================================================================
```

**All issues fixed in AFTER:**
- **#178125:** Now correctly raises `"output padding must be smaller than either stride or dilation"` — matches CPU behavior
- **#178127:** Now correctly raises `"output padding must be smaller than either stride or dilation"` — matches CPU behavior
- **#178128:** Now correctly raises `"expected bias to be 1-dimensional with 66 elements"` — matches CPU behavior
- `conv2d` now correctly raises `"expected bias to be 1-dimensional with 4 elements"` — matches CPU behavior
- Valid cases continue to work correctly (no regression)
</details>

<details>
<summary>pytest results (2 new tests)</summary>

```
test/nn/test_convolution.py::TestConvolutionNN::test_conv_meta_invalid_bias PASSED
test/nn/test_convolution.py::TestConvolutionNN::test_conv_transpose_meta_invalid_output_padding PASSED
2 passed, 1179 deselected in 0.62s
```
</details>

Authored with the assistance of Claude (AI).