### PR TITLE
[Pooling] Validate non-positive inferred output dimensions in MaxUnpool

### DIFF
--- a/aten/src/ATen/native/MaxUnpooling.cpp
+++ b/aten/src/ATen/native/MaxUnpooling.cpp
@@ -46,6 +46,11 @@ Tensor& max_unpooling2d_forward_out_cpu(
   auto oheight = output_size[0];
   auto owidth = output_size[1];
 
+  TORCH_CHECK(
+      oheight > 0 && owidth > 0,
+      "max_unpooling2d(): Expected positive output_size, but got output_size=(",
+      oheight, ", ", owidth, ").");
+
   auto memory_format = self_.suggest_memory_format();
   auto self = self_.contiguous(memory_format);
   auto indices = indices_.contiguous(memory_format);
@@ -119,6 +124,11 @@ static void max_unpooling3d_shape_check(
   int64_t oT = output_size[0];
   int64_t oH = output_size[1];
   int64_t oW = output_size[2];
+
+  TORCH_CHECK(
+      oT > 0 && oH > 0 && oW > 0,
+      "max_unpooling3d(): Expected positive output_size, but got output_size=(",
+      oT, ", ", oH, ", ", oW, ").");
 
   int dimw = 3;
   int dimh = 2;

--- a/aten/src/ATen/native/cuda/MaxUnpooling.cu
+++ b/aten/src/ATen/native/cuda/MaxUnpooling.cu
@@ -150,6 +150,11 @@ Tensor& max_unpooling2d_forward_out_cuda(const Tensor& self_,
   auto oheight = output_size[0];
   auto owidth = output_size[1];
 
+  TORCH_CHECK(
+      oheight > 0 && owidth > 0,
+      "max_unpooling2d(): Expected positive output_size, but got output_size=(",
+      oheight, ", ", owidth, ").");
+
   int64_t dimw = 2;
   int64_t dimh = 1;
   int64_t numBatch = 1;
@@ -251,6 +256,11 @@ static void max_unpooling3d_shape_check(
   int64_t oT = output_size[0];
   int64_t oH = output_size[1];
   int64_t oW = output_size[2];
+
+  TORCH_CHECK(
+      oT > 0 && oH > 0 && oW > 0,
+      "max_unpooling3d(): Expected positive output_size, but got output_size=(",
+      oT, ", ", oH, ", ", oW, ").");
 
   int dimw = 3;
   int dimh = 2;

--- a/test/nn/test_pooling.py
+++ b/test/nn/test_pooling.py
@@ -478,6 +478,34 @@ class TestPoolingNN(NNTestCase):
             )
             gradcheck(F.max_unpool3d, (output, indices, 2), check_forward_ad=True)
 
+    def test_max_unpool_negative_output_size(self):
+        # https://github.com/pytorch/pytorch/issues/178483
+        # When padding is large relative to input/stride, the inferred
+        # output dimensions can be negative. Verify we raise a clear error.
+
+        # MaxUnpool2d: kernel_size=[1,1], stride=5, padding=[3,4]
+        # dim H = (2-1)*5+1-6=0, dim W = (2-1)*5+1-8=-2
+        x = torch.randn(1, 1, 2, 2)
+        idx = torch.zeros(1, 1, 2, 2, dtype=torch.long)
+        with self.assertRaisesRegex(ValueError, "non-positive"):
+            F.max_unpool2d(x, idx, [1, 1], stride=5, padding=[3, 4])
+        with self.assertRaisesRegex(ValueError, "non-positive"):
+            nn.MaxUnpool2d([1, 1], stride=5, padding=[3, 4])(x, idx)
+
+        # MaxUnpool1d: kernel_size=1, stride=5, padding=4
+        # dim = (2-1)*5+1-8=-2
+        x1d = torch.randn(1, 1, 2)
+        idx1d = torch.zeros(1, 1, 2, dtype=torch.long)
+        with self.assertRaisesRegex(ValueError, "non-positive"):
+            F.max_unpool1d(x1d, idx1d, 1, stride=5, padding=4)
+
+        # MaxUnpool3d: kernel_size=1, stride=5, padding=4
+        # each dim = (2-1)*5+1-8=-2
+        x3d = torch.randn(1, 1, 2, 2, 2)
+        idx3d = torch.zeros(1, 1, 2, 2, 2, dtype=torch.long)
+        with self.assertRaisesRegex(ValueError, "non-positive"):
+            F.max_unpool3d(x3d, idx3d, 1, stride=5, padding=4)
+
     def test_max_unpool3d_input_check(self):
         x = torch.ones(1, 3, 1, 1, 1)
         with self.assertRaises(RuntimeError):

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -2815,6 +2815,15 @@ def max_unpool2d(
             ),
         )
 
+    for i in range(len(output_size)):
+        torch._check(
+            output_size[i] > 0,
+            lambda: (
+                f"max_unpooling2d(): Expected positive output_size, but got "
+                f"output_size[{i}] = {output_size[i]}."
+            ),
+        )
+
     return _max_unpoolnd(self, indices, output_size, 2)
 
 
@@ -2871,6 +2880,15 @@ def max_unpool3d(
         stride[0] > 0 and stride[1] > 0 and stride[2] > 0,
         lambda: f"strides should be greater than zero, but got stride: {stride}",
     )
+
+    for i in range(len(output_size)):
+        torch._check(
+            output_size[i] > 0,
+            lambda: (
+                f"max_unpooling3d(): Expected positive output_size, but got "
+                f"output_size[{i}] = {output_size[i]}."
+            ),
+        )
 
     return _max_unpoolnd(input, indices, output_size, 3)
 

--- a/torch/csrc/api/include/torch/nn/functional/pooling.h
+++ b/torch/csrc/api/include/torch/nn/functional/pooling.h
@@ -639,6 +639,23 @@ inline std::vector<int64_t> _unpool_output_size(
             stride[d] +
         kernel_size[d] - 2 * padding[d]);
   }
+  for (const auto d : c10::irange(kernel_size.size())) {
+    TORCH_CHECK(
+        default_size[d] > 0,
+        "max_unpooling: inferred output size for dimension ",
+        d,
+        " is ",
+        default_size[d],
+        ", which is non-positive. The combination of input size ",
+        input_size[input_size.size() - kernel_size.size() + d],
+        ", kernel_size ",
+        kernel_size[d],
+        ", stride ",
+        stride[d],
+        ", and padding ",
+        padding[d],
+        " leads to invalid output dimensions.");
+  }
   if (!output_size) {
     return default_size;
   } else {

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -951,6 +951,15 @@ def _unpool_output_size(
             + kernel_size[d]
             - 2 * padding[d]
         )
+    for d in range(len(kernel_size)):
+        if default_size[d] <= 0:
+            raise ValueError(
+                f"max_unpooling: inferred output size for dimension {d} is "
+                f"{default_size[d]}, which is non-positive. The combination of "
+                f"input size {input_size[-len(kernel_size) + d]}, kernel_size "
+                f"{kernel_size[d]}, stride {stride[d]}, and padding "
+                f"{padding[d]} leads to invalid output dimensions."
+            )
     if output_size is None:
         ret = default_size
     else:


### PR DESCRIPTION
## Issue

Fixes #178483

## Summary

`MaxUnpool1d/2d/3d` silently produce tensors with negative or zero output dimensions when `padding` is large relative to `input_size`/`stride`/`kernel_size`. In eager mode this yields an invalid tensor shape (e.g. `torch.Size([1, 1, 0, -2])`); under `torch.compile` it triggers an unclear `RuntimeError`.

Added validation in `_unpool_output_size()` (Python and C++ frontend) to raise a clear `ValueError` when the inferred output size is non-positive. Also added defense-in-depth checks in the decomposition layer and ATen C++/CUDA implementations.

## Checklist

- [ ] Passes lint (`spin fixlint`)
- [x] Added/updated tests
- [ ] Updated documentation (if applicable)
- [ ] Included benchmark results (for PRs impacting perf)

## BC-breaking?

No. This only adds validation that rejects previously undefined behavior (negative output dimensions). Any code that was producing valid results before will continue to work unchanged.

## Test plan

- [x] New test `test_max_unpool_negative_output_size` covers MaxUnpool1d, MaxUnpool2d, MaxUnpool3d and functional API
- [x] All existing `test_max_unpool*` tests pass

<details>
<summary>Before (bug — no validation)</summary>

```
$ python agent_space/repro_178483.py

W0327 15:45:39.146000 63006 /ssd1/jianglidang/workspace/pytorch/torch/utils/flop_counter.py:29] triton not found; flop counting will not work for triton kernels
=== MaxUnpool2d: negative output size repro ===
Eager: got shape torch.Size([1, 1, 0, -2]) (BUG: should have raised error)

=== MaxUnpool2d: torch.compile path ===
Compiled: TorchRuntimeError: RuntimeError when making fake tensor call
  Explanation: Dynamo failed to run FX node with fake tensors: call_function <function max_unpool2d at 0x7efbc54eeca0>(*(FakeTensor(..., size=(1, 1, 2, 2)), FakeTensor(..., size=(1, 1, 2, 2), dtype=torch.int64), (1, 1), (5, 5), (3, 4), None), **{}): got RuntimeError('Trying to create tensor with negative dimension -2: [1, 1, 0, -2]')
  Hint: Your code may result in an error when running in eager. Please double check that your code doesn't contain a similar error when actually running eager/uncompiled. You can do this by removing the `torch.compile` call, or by using `torch.compiler.set_stance("force_eager")`. 

  Developer debug context: 

 For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb4315.html

from user code:
   File "/ssd1/jianglidang/workspace/pytorch/agent_space/repro_178483.py", line 23, in torch_dynamo_resume_in_call_func_at_23
    return torch.nn.MaxUnpool2d(kernel_size, stride, padding)(x, idx)
  File "/ssd1/jianglidang/workspace/pytorch/torch/nn/modules/pooling.py", line 498, in forward
    return F.max_unpool2d(

Set TORCHDYNAMO_VERBOSE=1 for the internal stack trace (please do this especially if you're reporting a bug to PyTorch). For even more developer context, set TORCH_LOGS="+dynamo"


=== MaxUnpool1d: negative output size ===
Eager: RuntimeError: numel: integer multiplication overflow

=== MaxUnpool3d: negative output size ===
Eager: RuntimeError: numel: integer multiplication overflow
```

</details>

<details>
<summary>After (fix — clear ValueError)</summary>

```
$ python agent_space/repro_178483.py

W0327 15:49:03.669000 84960 /ssd1/jianglidang/workspace/pytorch/torch/utils/flop_counter.py:29] triton not found; flop counting will not work for triton kernels
=== MaxUnpool2d: negative output size repro ===
Eager: ValueError raised (FIXED): max_unpooling: inferred output size for dimension 0 is 0, which is non-positive. The combination of input size 2, kernel_size 1, stride 5, and padding 3 leads to invalid output dimensions.

=== MaxUnpool2d: torch.compile path ===
Compiled: TorchRuntimeError: RuntimeError when making fake tensor call
  Explanation: Dynamo failed to run FX node with fake tensors: call_function <function max_unpool2d at 0x7ff24e60afc0>(*(FakeTensor(..., size=(1, 1, 2, 2)), FakeTensor(..., size=(1, 1, 2, 2), dtype=torch.int64), (1, 1), (5, 5), (3, 4), None), **{}): got ValueError('max_unpooling: inferred output size for dimension 0 is 0, which is non-positive. The combination of input size 2, kernel_size 1, stride 5, and padding 3 leads to invalid output dimensions.')
  Hint: Your code may result in an error when running in eager. Please double check that your code doesn't contain a similar error when actually running eager/uncompiled. You can do this by removing the `torch.compile` call, or by using `torch.compiler.set_stance("force_eager")`. 

  Developer debug context: 

 For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb4315.html

from user code:
   File "/ssd1/jianglidang/workspace/pytorch/agent_space/repro_178483.py", line 23, in torch_dynamo_resume_in_call_func_at_23
    return torch.nn.MaxUnpool2d(kernel_size, stride, padding)(x, idx)
  File "/ssd1/jianglidang/workspace/pytorch/torch/nn/modules/pooling.py", line 498, in forward
    return F.max_unpool2d(

Set TORCHDYNAMO_VERBOSE=1 for the internal stack trace (please do this especially if you're reporting a bug to PyTorch). For even more developer context, set TORCH_LOGS="+dynamo"


=== MaxUnpool1d: negative output size ===
Eager: ValueError raised (FIXED): max_unpooling: inferred output size for dimension 0 is -2, which is non-positive. The combination of input size 2, kernel_size 1, stride 5, and padding 4 leads to invalid output dimensions.

=== MaxUnpool3d: negative output size ===
Eager: ValueError raised (FIXED): max_unpooling: inferred output size for dimension 0 is -2, which is non-positive. The combination of input size 2, kernel_size 1, stride 5, and padding 4 leads to invalid output dimensions.
```

</details>

<details>
<summary>Test results</summary>

```
$ python -m pytest test/nn/test_pooling.py -xvs -k "test_max_unpool_negative_output_size or test_max_unpool3d_input_check or test_max_unpool "

test/nn/test_pooling.py::TestPoolingNN::test_max_unpool PASSED [0.3437s]
test/nn/test_pooling.py::TestPoolingNN::test_max_unpool2d_nhwc_cpu PASSED [0.0033s]
test/nn/test_pooling.py::TestPoolingNN::test_max_unpool3d_input_check PASSED [0.0015s]
test/nn/test_pooling.py::TestPoolingNN::test_max_unpool_negative_output_size PASSED [0.0011s]

====================== 4 passed, 239 deselected in 0.84s =======================
```

</details>

Authored with Claude.