### PR TITLE
[Inductor] Fix memory planner crash when template buffer reuse has inverted range

### DIFF
--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -892,6 +892,10 @@ class AllocateLine(MemoryPlanningLine):
     def should_reuse_buffer(self, free_line: FreeIfNotReusedLine, size: int) -> bool:
         if self.comm_buffer:
             return True
+        if free_line.scheduler_node_index >= self.scheduler_node_index:
+            # Buffer is freed at or after this allocation's scheduler node,
+            # so it may still be live — reuse is unsafe.
+            return False
         if free_line.scheduler_node_index + 1 == self.scheduler_node_index:
             return True
         overall_peak_memory = self.wrapper.estimate_peak.overall_peak_memory


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #178556
* __->__ #178578
* #178555

When allow_prologue_fusion=False on a multi-output TemplateBuffer, the
scheduler may produce a free_line with scheduler_node_index >= the
allocation's scheduler_node_index.  should_reuse_buffer() did not guard
against this, causing peak_between() to call summarize_range(start, end)
with start > end, crashing in SegmentedTree.

Add an early return False when free_line.scheduler_node_index >=
self.scheduler_node_index — the buffer may still be live so reuse is
unsafe.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo