### PR TITLE
[BE] Move some common CI steps to setup-linux

### DIFF
--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -19,10 +19,58 @@ inputs:
     description: CUDA version to activate (e.g. "13.0"). Empty string keeps the default.
     required: false
     default: ''
+  submodules:
+    description: Submodule checkout mode passed to checkout-pytorch (default "recursive", use "false" for test jobs).
+    required: false
+    default: 'recursive'
+  github-token:
+    description: GITHUB_TOKEN, needed to retrieve the workflow job id.
+    required: false
+    default: ''
+
+outputs:
+  branch:
+    description: Parsed branch name from GITHUB_REF
+    value: ${{ steps.parse-ref.outputs.branch }}
+  tag:
+    description: Parsed tag name from GITHUB_REF (if applicable)
+    value: ${{ steps.parse-ref.outputs.tag }}
+  job-id:
+    description: The workflow job id
+    value: ${{ steps.get-job-id.outputs.job-id }}
+  job-name:
+    description: The workflow job name
+    value: ${{ steps.get-job-id.outputs.job-name }}
 
 runs:
   using: composite
   steps:
+    # ── Common steps (shared) ────────────────────────────────────────
+    - name: Fix Git ownership
+      if: ${{ inputs.use-arc == 'true' }}
+      shell: bash
+      run: |
+        git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+    - name: Checkout PyTorch
+      uses: pytorch/pytorch/.github/actions/checkout-pytorch@main
+      with:
+        no-sudo: true
+        checkout-mode: treeless
+        submodules: ${{ inputs.submodules }}
+
+    - name: Parse ref
+      id: parse-ref
+      shell: bash
+      run: python3 .github/scripts/parse_ref.py
+
+    - name: Get workflow job id
+      id: get-job-id
+      if: ${{ always() && inputs.github-token != '' }}
+      uses: pytorch/pytorch/.github/actions/get-workflow-job-id@main
+      with:
+        github-token: ${{ inputs.github-token }}
+
     # ── EC2-only steps ──────────────────────────────────────────────────
     - name: Display EC2 information
       if: ${{ inputs.use-arc != 'true' }}

--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -46,7 +46,7 @@ runs:
   using: composite
   steps:
     # ── Common steps (shared) ────────────────────────────────────────
-    - name: Fix Git ownership
+    - name: Ack Git cache ownership
       if: ${{ inputs.use-arc == 'true' }}
       shell: bash
       run: |

--- a/.github/workflows/llm_td_retrieval.yml
+++ b/.github/workflows/llm_td_retrieval.yml
@@ -26,15 +26,8 @@ jobs:
     continue-on-error: true
     needs: get-label-type
     steps:
-      - name: Clone PyTorch
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          repository: pytorch/pytorch
-          fetch-depth: 0
-          path: pytorch
-
       - name: Setup Linux
-        uses: ./pytorch/.github/actions/setup-linux
+        uses: pytorch/pytorch/.github/actions/setup-linux@main
 
       - name: Clone CodeLlama
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
Move the following steps, which are duplicated across most Linux CI workflows, into the `setup-linux` composite action:

* **Fix Git ownership** – `git config --global --add safe.directory` (ARC runners only)
* **Checkout PyTorch** – `checkout-pytorch` with treeless mode and configurable submodule checkout
* **Parse ref** – `parse_ref.py` (outputs `branch` and `tag`)
* **Get workflow job id** – `get-workflow-job-id` (outputs `job-id` and `job-name`)

New inputs: `submodules` (default `recursive`) and `github-token`.
New outputs: `branch`, `tag`, `job-id`, `job-name`.

After this, we have:

```
┌──────────────────────────┬─────────────┬──────────────────┬────────────┬─────────────────┐
│          Action          │ build (EC2) │ build-osdc (ARC) │ test (EC2) │ test-osdc (ARC) │
├──────────────────────────┼─────────────┼──────────────────┼────────────┼─────────────────┤
│ setup-linux              │      ✓      │        ✓         │     ✓      │        ✓        │
├──────────────────────────┼─────────────┼──────────────────┼────────────┼─────────────────┤
│ filter-test-configs      │      ✓      │        ✓         │     ✓      │        ✓        │
├──────────────────────────┼─────────────┼──────────────────┼────────────┼─────────────────┤
│ reuse-old-whl            │      ✓      │        ✓         │            │                 │
├──────────────────────────┼─────────────┼──────────────────┼────────────┼─────────────────┤
│ upload-sccache-stats     │      ✓      │        ✓         │            │                 │
├──────────────────────────┼─────────────┼──────────────────┼────────────┼─────────────────┤
│ upload-utilization-stats │      ✓      │                  │     ✓      │                 │
├──────────────────────────┼─────────────┼──────────────────┼────────────┼─────────────────┤
│ ecr-login                │      ✓      │                  │     ✓      │                 │
├──────────────────────────┼─────────────┼──────────────────┼────────────┼─────────────────┤
│ build-external-packages  │      ✓      │        ✓         │            │                 │
├──────────────────────────┼─────────────┼──────────────────┼────────────┼─────────────────┤
│ download-build-artifacts │             │                  │     ✓      │        ✓        │
├──────────────────────────┼─────────────┼──────────────────┼────────────┼─────────────────┤
│ download-td-artifacts    │             │                  │     ✓      │        ✓        │
├──────────────────────────┼─────────────┼──────────────────┼────────────┼─────────────────┤
│ pytest-cache-upload      │             │                  │     ✓      │        ✓        │
├──────────────────────────┼─────────────┼──────────────────┼────────────┼─────────────────┤
│ upload-test-artifacts    │             │                  │     ✓      │        ✓        │
├──────────────────────────┼─────────────┼──────────────────┼────────────┼─────────────────┤
│ check-tpu                │             │                  │     ✓      │                 │
└──────────────────────────┴─────────────┴──────────────────┴────────────┴─────────────────┘

```