### PR TITLE
[pyrefly] Fix missing-attribute false positive in `torch/accelerator/memory.py`

### DIFF
--- a/torch/accelerator/memory.py
+++ b/torch/accelerator/memory.py
@@ -39,6 +39,7 @@ def empty_host_cache() -> None:
     .. note:: This function is a no-op if the memory allocator for the current
         :ref:`accelerator <accelerators>` has not been initialized.
     """
+    # pyrefly: ignore[missing-attribute]
     torch._C._accelerator_emptyHostCache()
 
 


### PR DESCRIPTION
`_accelerator_emptyHostCache` is defined in C++ and not visible to Pyrefly's type checker, causing a false `missing-attribute` lint error.

**Before**
```
>>> Lint for torch/accelerator/memory.py:

  Error (PYREFLY) missing-attribute
    No attribute `_accelerator_emptyHostCache` in module `torch._C`

    >>>  42  |    torch._C._accelerator_emptyHostCache()
```

cc #163283 #169633 

cc @albanD @guangyey @EikanWang