### PR TITLE
Remove unused expected failure decorator from FakeTensorOperatorInvariants test and clean up condition in Module class

### DIFF
--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -3194,7 +3194,6 @@ class FakeTensorOperatorInvariants(TestCase):
         IS_LINUX or TEST_WITH_ROCM or TEST_WITH_SLOW,
         "https://github.com/pytorch/pytorch/issues/165387",
     )
-    @expectedFailurePropagateRealTensors
     @unittest.skipIf(not RUN_CUDA, "requires cuda")
     def test_module_to(self):
         def _check_device(sd, device_type):

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -3319,7 +3319,6 @@ class FakeTensorOperatorInvariants(TestCase):
         IS_LINUX or TEST_WITH_ROCM or TEST_WITH_SLOW,
         "https://github.com/pytorch/pytorch/issues/165387",
     )
-    @expectedFailurePropagateRealTensors
     @unittest.skipIf(not RUN_CUDA, "requires cuda")
     def test_module_to(self):
         def _check_device(sd, device_type):

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -478,6 +478,12 @@ class FakeTensorConverter:
         tid = self.meta_converter.describer.get_tensor_id(t)
         self.meta_converter.tensor_memo[tid] = v
 
+    def remove_from_tensor_memo(self, fake_tensor: Tensor) -> None:
+        """Remove a FakeTensor from tensor_memo, clearing its weakref."""
+        keys = [k for k, v in list(self.tensor_memo.items()) if v is fake_tensor]
+        for k in keys:
+            del self.tensor_memo[k]
+
     # You can have a real tensor that you need to convert into a fake tensor.
     # If you have a meta tensor already, call from_meta_and_device.
     #

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -985,6 +985,13 @@ class Module:
                         param_applied,
                         requires_grad=param.requires_grad,
                     )
+                    # FakeTensors may be stored in the converter's tensor_memo
+                    # (WeakValueDictionary), which installs weakrefs that
+                    # swap_tensors does not allow.  Remove them before swapping.
+                    if isinstance(param, FakeTensor):  # noqa: ISINSTANCE_FAKE_TENSOR
+                        converter = param.fake_mode.fake_tensor_converter
+                        converter.remove_from_tensor_memo(param)
+                        converter.remove_from_tensor_memo(param_applied)
                     torch.utils.swap_tensors(param, param_applied)
                 except Exception as e:
                     if param_grad is not None:
@@ -1014,6 +1021,10 @@ class Module:
                 if p_should_use_swap_tensors:
                     grad_applied.requires_grad_(param_grad.requires_grad)
                     try:
+                        if isinstance(param_grad, FakeTensor):  # noqa: ISINSTANCE_FAKE_TENSOR
+                            converter = param_grad.fake_mode.fake_tensor_converter
+                            converter.remove_from_tensor_memo(param_grad)
+                            converter.remove_from_tensor_memo(grad_applied)
                         torch.utils.swap_tensors(param_grad, grad_applied)
                     except Exception as e:
                         raise RuntimeError(


### PR DESCRIPTION
Resolves https://github.com/intel/torch-xpu-ops/issues/2712

### Root cause
`FakeTensorConverter.from_meta_and_device()` stores FakeTensors in `tensor_memo` (a `WeakValueDictionary`), which creates `KeyedRef` weakrefs on them. When `nn.Module._apply()` calls `swap_tensors()` on FakeTensor parameters, `swap_tensors` rejects tensors that have weakrefs.

The weakrefs are created because `Parameter.__new__` calls `data.detach()` on FakeTensors, which dispatches through `FakeTensorMode` → `from_meta_and_device()` → `tensor_memo[key] = fake_tensor`.

### Changes made (3 files)

1. fake_tensor.py — Added `remove_from_tensor_memo()` method to `FakeTensorConverter` that removes a FakeTensor from the tensor memo by value, clearing its weakref.
2. module.py — In `_apply()`, before calling `swap_tensors`, remove both the old param and new param_applied from the converter's `tensor_memo` to clear their weakrefs. Applied to both the parameter swap and the gradient swap paths.
3. test_fake_tensor_xpu.py and test_fake_tensor.py — Removed `@expectedFailurePropagateRealTensors` from `test_module_to` since the fix resolves the issue for both normal and PropagateRealTensors modes.