### PR TITLE
Improve attn_mask handling of multi_head_attention_forward

### DIFF
--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -1437,9 +1437,18 @@ class TestTransformers(NNTestCase):
 
         attn_out, _ = mha(t_qvk, t_qvk, t_qvk, attn_mask=mask, is_causal=True)
 
-        # Can't give only is_causal
+        # is_causal=True without attn_mask is allowed when there's no
+        # key_padding_mask and need_weights=False.
+        attn_out_no_mask, _ = mha(
+            t_qvk, t_qvk, t_qvk, is_causal=True, need_weights=False
+        )
+
+        # Still need attn_mask when key_padding_mask is provided.
+        # t_qvk is (S, L, E) with batch_first=False, so MHA reads it as
+        # (seq=S, batch=L, embed=E); key_padding_mask must be (batch, src_seq).
+        kpm = torch.zeros(L, S, device=device, dtype=torch.bool)
         with self.assertRaises(RuntimeError):
-            mha(t_qvk, t_qvk, t_qvk, is_causal=True)
+            mha(t_qvk, t_qvk, t_qvk, key_padding_mask=kpm, is_causal=True)
 
         # # Passing a causal mask sets is_causal to 1
         causal_mask = torch.triu(

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -6486,12 +6486,15 @@ def multi_head_attention_forward(
             leads to a significant performance degradation.*
         attn_mask: 2D or 3D mask that prevents attention to certain positions. A 2D mask will be broadcasted for all
             the batches while a 3D mask allows to specify a different mask for the entries of each batch.
-        is_causal: If specified, applies a causal mask as attention mask, and ignores
-            attn_mask for computing scaled dot product attention.
+        is_causal: If specified, applies a causal mask as attention mask.
             Default: ``False``.
+            When ``key_padding_mask`` is not provided and ``need_weights``
+            is ``False``, ``attn_mask`` is optional and causal masking will
+            be applied natively. If ``attn_mask`` is provided in this case,
+            it will be ignored with a warning.
             .. warning::
-                is_causal is provides a hint that the attn_mask is the
-                causal mask.Providing incorrect hints can result in
+                ``is_causal`` provides a hint that ``attn_mask`` is the
+                causal mask. Providing incorrect hints can result in
                 incorrect execution, including forward and backward
                 compatibility.
         use_separate_proj_weight: the function accept the proj. weights for query, key,
@@ -6605,18 +6608,21 @@ def multi_head_attention_forward(
         target_type=query.dtype,
     )
 
-    if is_causal and attn_mask is None:
-        raise RuntimeError(
-            "Need attn_mask if specifying the is_causal hint. "
-            "You may use the Transformer module method "
-            "`generate_square_subsequent_mask` to create this mask."
-        )
-
     if is_causal and key_padding_mask is None and not need_weights:
-        # when we have a kpm or need weights, we need attn_mask
-        # Otherwise, we use the is_causal hint go as is_causal
-        # indicator to SDPA.
+        # Use the is_causal hint directly for SDPA; no explicit mask needed.
+        if attn_mask is not None:
+            warnings.warn(
+                "is_causal=True with an explicit attn_mask: the mask will be "
+                "ignored. Pass attn_mask=None to silence this warning.",
+                stacklevel=2,
+            )
         attn_mask = None
+    elif is_causal and attn_mask is None:
+        raise RuntimeError(
+            "Need attn_mask if specifying the is_causal hint with "
+            "key_padding_mask or need_weights. Use "
+            "nn.Transformer.generate_square_subsequent_mask to create this mask."
+        )
     else:
         attn_mask = _canonical_mask(
             mask=attn_mask,
@@ -6628,9 +6634,8 @@ def multi_head_attention_forward(
         )
 
         if key_padding_mask is not None:
-            # We have the attn_mask, and use that to merge kpm into it.
-            # Turn off use of is_causal hint, as the merged mask is no
-            # longer causal.
+            # Merge kpm into attn_mask. Turn off is_causal hint, as
+            # the merged mask is no longer causal.
             is_causal = False
 
     if embed_dim != embed_dim_to_check:


### PR DESCRIPTION

  Summary

  Previously, passing is_causal=True without an attn_mask always raised, even in the case where the mask isn't actually needed. This relaxes that: when
  key_padding_mask is None and need_weights=False, attn_mask is now optional and the is_causal hint is passed straight to SDPA for native causal masking.

  Behavior in detail:
  - is_causal=True, no key_padding_mask, need_weights=False → attn_mask optional; causal masking applied natively. If an attn_mask is also passed, it is ignored with 
  a warning (previously ignored silently).
  - is_causal=True with a key_padding_mask or need_weights=True but no attn_mask → still raises RuntimeError, since an explicit mask is required to merge/return
  weights.
  
  Also tidies the is_causal docstring (typos, formatting) to match the new behavior.

  Backward compatible: need_weights defaults to True, so mha(q, k, v, is_causal=True) still raises as before.

cc @albanD @mruberry @jbschlosser @walterddr @mikaylagawarecki