### PR TITLE
Set gradcheck nondeterminism tolerance for index_reduce mean/prod.

### DIFF
--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -20135,6 +20135,7 @@ op_db: list[OpInfo] = [
              ),
              supports_out=True,
              sample_inputs_func=sample_inputs_index_reduce,
+             gradcheck_nondet_tol=GRADCHECK_NONDET_TOL if reduction_type in ('mean', 'prod') else 0.0,
              ) for reduction_type in ('mean', 'prod', 'amin', 'amax')),
     OpInfo('_unsafe_masked_index',
            dtypes=all_types_and_complex_and(torch.float16, torch.bfloat16, torch.bool),


### PR DESCRIPTION
Fixes: #179562

## Summary
This change updates OpInfo for `index_reduce` so gradgrad checks allow nondeterminism tolerance for the reduction variants that are not reentrant in backward.

Specifically:
- Enable `gradcheck_nondet_tol` for `index_reduce` with `reduction=mean` and `reduction=prod`
- Keep strict nondeterminism tolerance (`0.0`) for `reduction=amin` and `reduction=amax`

## Problem

The `index_reduce` operator is marked as not-deterministic by both CUDA and XPU, yet the tolerance is set to `0.0` for this operator.
CUDA: [CUDA IMPLEMENTATION FRAGMENT](https://github.com/pytorch/pytorch/blob/02521a04a312f42a178283e785d9ccdae7e31b9d/aten/src/ATen/native/cuda/Indexing.cu#L1357)
XPU: [XPU IMPLEMENTATION FRAGMENT](https://github.com/intel/torch-xpu-ops/blob/a2d516a58c64f18b76880f3a77efbc02885d65af/src/ATen/native/xpu/sycl/Indexing.cpp#L1418)

The `index_reduce` with `reduction=prod` and `reduction=mean` on XPU use atomic operations that are not associative and thus non-deterministic. So, for identical inputs, the same kernel can return slightly different results.

Currently the tolerance is set to `0.0` (default gradcheck_nondet_tol value). So even the least significant bit change can cause the assertion error.

## Reasoning

The failure is a classic gradcheck nondeterminism case: numerics are correct, but repeated backward passes are not bitwise/reentrant-identical on XPU for these reductions. The proper PyTorch testing-side remedy is to declare nondeterminism tolerance in OpInfo for exactly those variants.

Setting
```python
gradcheck_nondet_tol=GRADCHECK_NONDET_TOL
```
is a common and broadly used approach in many places of the `common_methods_invocations.py` file. 

## Risk and scope
- It only affects the gradcheck tests for `index_reduce_prod` and `index_reduce_mean`.
- OpInfo is shared across backends, so this tolerance applies globally for these two variants - as there is no simple mechanism to apply this `gradcheck_nondet_tol` only to one device type.
