### PR TITLE
fixes:division by zero check for inductor

### DIFF
--- a/c10/util/generic_math.h
+++ b/c10/util/generic_math.h
@@ -80,6 +80,20 @@ inline C10_HOST_DEVICE scalar_t div_floor_integer(scalar_t a, scalar_t b) {
   return a / b;
 }
 
+template <typename scalar_t>
+inline C10_HOST_DEVICE scalar_t trunc_floor_integer(scalar_t a, scalar_t b) {
+  if (C10_UNLIKELY(b == 0)) {
+    return scalar_t(0);
+  }
+
+  if (C10_UNLIKELY(
+          std::is_signed<scalar_t>::value &&
+          a == std::numeric_limits<scalar_t>::min() && b == scalar_t(-1))) {
+    return a;
+  }
+  return a / b;
+}
+
 template <
     typename scalar_t,
     std::enable_if_t<std::is_floating_point_v<scalar_t>, int> = 0>

--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -2478,7 +2478,7 @@ class CPUReproTests(TestCase):
         x3 = torch.tensor([-32768, -32768, -32768, -32768], dtype=torch.int16)
         y3 = torch.tensor([-1, -1, -1, -1], dtype=torch.int16)
         ret = run_division(x3, y3, rounding_mode="trunc")
-        self.assertTrue(ret[0] == 0 and ret[1] == 0 and ret[2] == 0 and ret[3] == 0)
+        self.assertTrue(torch.equal(ret, x3))
 
         x4 = torch.randint(0, 10, size=(1,))
         ret = run_division(x4, 1, rounding_mode="trunc")

--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -2469,8 +2469,6 @@ class CPUReproTests(TestCase):
         y2 = torch.zeros((3,4), dtype=torch.int32)
         ret = run_division(x2, y2, rounding_mode="trunc")
         self.assertTrue(ret is None)
-        ret = run_division(x2, y2, rounding_mode="floor")
-        self.assertTrue(ret is None)
 
     def test_no_op_squeeze(self):
         @torch.compile(backend="inductor")

--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -2465,6 +2465,11 @@ class CPUReproTests(TestCase):
                 self.assertTrue(detected)
                 return None
 
+        x2 = torch.randint(0, 10, size=(1,))
+        y2 = torch.zeros((1,), dtype=torch.int32)
+        ret = run_division(x2, y2, rounding_mode="trunc")
+        self.assertTrue(ret is None)
+
         x2 = torch.randint(0, 10, size=(3, 4))
         y2 = torch.zeros((3, 4), dtype=torch.int32)
         ret = run_division(x2, y2, rounding_mode="trunc")

--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -2466,7 +2466,7 @@ class CPUReproTests(TestCase):
                 return None
 
         x2 = torch.randint(0, 10, size=(3, 4))
-        y2 = torch.tensor(0, dtype=torch.int32)
+        y2 = torch.zeros((3,4), dtype=torch.int32)
         ret = run_division(x2, y2, rounding_mode="trunc")
         self.assertTrue(ret is None)
         ret = run_division(x2, y2, rounding_mode="floor")

--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -2465,14 +2465,29 @@ class CPUReproTests(TestCase):
                 self.assertTrue(detected)
                 return None
 
-        x2 = torch.randint(0, 10, size=(1,))
-        y2 = torch.zeros((1,), dtype=torch.int32)
-        ret = run_division(x2, y2, rounding_mode="trunc")
+        x1 = torch.randint(0, 10, size=(1,))
+        y1 = torch.zeros((1,), dtype=torch.int32)
+        ret = run_division(x1, y1, rounding_mode="trunc")
         self.assertTrue(ret is None)
 
         x2 = torch.randint(0, 10, size=(3, 4))
         y2 = torch.zeros((3, 4), dtype=torch.int32)
         ret = run_division(x2, y2, rounding_mode="trunc")
+        self.assertTrue(ret is None)
+
+        x3 = torch.tensor([-32768, -32768, -32768, -32768], dtype=torch.int16)
+        y3 = torch.tensor([-1, -1, -1, -1], dtype=torch.int16)
+        ret = run_division(x3, y3, rounding_mode="trunc")
+        self.assertTrue(ret[0] == 0 and ret[1] == 0 and ret[2] == 0 and ret[3] == 0)
+
+        x4 = torch.randint(0, 10, size=(1,))
+        ret = run_division(x4, 1, rounding_mode="trunc")
+        ret = run_division(x4, 0, rounding_mode="trunc")
+        self.assertTrue(ret is None)
+
+        x5 = torch.randint(0, 10, size=(1,))
+        y5 = torch.zeros((1,), dtype=torch.int32)
+        ret = run_division(x5, y5, rounding_mode="floor")
         self.assertTrue(ret is None)
 
     def test_no_op_squeeze(self):

--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -2451,6 +2451,27 @@ class CPUReproTests(TestCase):
         p1 = torch.randn(1)
         self.common(fn, (p0, p1))
 
+    def test_division_by_zero(self):
+        @torch.compile(backend="inductor")
+        def test_division(x, y, rounding_mode=None):
+            return torch.div(x, y, rounding_mode=rounding_mode)
+
+        def run_division(x, y, rounding_mode=None):
+            try:
+                ret = test_division(x, y, rounding_mode=rounding_mode)
+                return ret
+            except Exception as e:
+                detected = "ZeroDivisionError" in str(e)
+                self.assertTrue(detected)
+                return None
+
+        x2 = torch.randint(0, 10, size=(3, 4))
+        y2 = torch.tensor(0, dtype=torch.int32)
+        ret = run_division(x2, y2, rounding_mode="trunc")
+        self.assertTrue(ret is None)
+        ret = run_division(x2, y2, rounding_mode="floor")
+        self.assertTrue(ret is None)
+
     def test_no_op_squeeze(self):
         @torch.compile(backend="inductor")
         def forward(arg0_1):

--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -2466,7 +2466,7 @@ class CPUReproTests(TestCase):
                 return None
 
         x2 = torch.randint(0, 10, size=(3, 4))
-        y2 = torch.zeros((3,4), dtype=torch.int32)
+        y2 = torch.zeros((3, 4), dtype=torch.int32)
         ret = run_division(x2, y2, rounding_mode="trunc")
         self.assertTrue(ret is None)
 

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -855,6 +855,9 @@ class CppOverrides(OpOverrides):
     @staticmethod
     def floordiv(a, b):
         # a and b are integer type
+        V.kernel.compute.writeline(
+            f'TORCH_CHECK({b} != 0, "ZeroDivisionError: integer division or modulo by zero");'
+        )
         return f"floor_divide_integral({a}, {b})"
 
     @staticmethod
@@ -871,6 +874,9 @@ class CppOverrides(OpOverrides):
     # pyrefly: ignore [bad-override]
     def truncdiv(a, b):
         # a and b are integer type
+        V.kernel.compute.writeline(
+            f'TORCH_CHECK({b} != 0, "ZeroDivisionError: integer division or modulo by zero");'
+        )
         return f"{a} / {b}"
 
     @staticmethod

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -639,6 +639,8 @@ def decltype_promoted(*args):
     else:
         return f"decltype({args[0]})"
 
+def is_nonzero_divisor(b):
+    return isinstance(b, CppCSEVariable) and 0 not in b.bounds
 
 class CppOverrides(OpOverrides):
     """Map element-wise ops to C++"""
@@ -855,7 +857,9 @@ class CppOverrides(OpOverrides):
     @staticmethod
     def floordiv(a, b):
         # a and b are integer type
-        return f"floor_divide_integral({a}, {b})"
+        if is_nonzero_divisor(b):
+            return f"c10::div_floor_integer({a}, {b})"
+        return f"floor_divide_integral({a}, {b}, &inductor_cpu_integer_div_error)"
 
     @staticmethod
     # pyrefly: ignore [bad-override]
@@ -871,7 +875,9 @@ class CppOverrides(OpOverrides):
     # pyrefly: ignore [bad-override]
     def truncdiv(a, b):
         # a and b are integer type
-        return f"trunc_divide_integral({a}, {b})"
+        if is_nonzero_divisor(b):
+            return f"c10::trunc_floor_integer({a}, {b})"
+        return f"trunc_divide_integral({a}, {b}, &inductor_cpu_integer_div_error)"
 
     @staticmethod
     # pyrefly: ignore [bad-override]
@@ -1017,7 +1023,9 @@ class CppOverrides(OpOverrides):
 
     @staticmethod
     def mod(a, b):
-        return f"mod({a}, {b})"
+        if is_nonzero_divisor(b):
+            return f"mod({a}, {b})"
+        return f"mod({a}, {b}, &inductor_cpu_integer_div_error)"
 
     @staticmethod
     def constant(val, dtype):
@@ -1545,7 +1553,7 @@ class CppVecOverrides(CppOverrides):
             _t = f"decltype({a})"
             if V.kernel._get_raw_num_vectors(b.dtype) < 1:
                 b = f"{_t}::blend<{(1 << V.kernel.tiling_factor) - 1}>({_t}(1), {b})"
-            return f"remainder_integral({a}, {b})"
+            return f"remainder_integral({a}, {b}, &inductor_cpu_integer_div_error)"
         return f"{a} - ({CppVecOverrides.floordiv(a, b)}) * {b}"
 
     @staticmethod
@@ -1687,14 +1695,14 @@ class CppVecOverrides(CppOverrides):
             # a and b are integer type
             _t = f"decltype({b})"
             b = f"{_t}::set({_t}(1), {b}, {cexpr_index(V.kernel.num_elems)})"
-            return f"floor_divide_integral({a}, {b})"
+            return f"floor_divide_integral({a}, {b}, &inductor_cpu_integer_div_error)"
 
     @staticmethod
     def truncdiv(a, b):
         # a and b are integer type
         _t = f"decltype({b})"
         b = f"{_t}::set({_t}(1), {b}, {cexpr_index(V.kernel.num_elems)})"
-        return f"trunc_divide_integral({a}, {b})"
+        return f"trunc_divide_integral({a}, {b}, &inductor_cpu_integer_div_error)"
 
     @staticmethod
     def minimum(a, b):
@@ -6115,9 +6123,6 @@ class KernelGroup:
         # 3. Function body
         with code.indent():
             code.writeline("std::atomic<int> inductor_cpu_integer_div_error{0};")
-            code.writeline(
-                "inductor_cpu_integer_div_error_flag = &inductor_cpu_integer_div_error;"
-            )
             if enable_kernel_profile:
                 graph_id = V.graph.graph_id
                 prefix = "graph_" + str(graph_id) + "_" if graph_id is not None else ""
@@ -6132,7 +6137,6 @@ class KernelGroup:
             for old, new in self.args.aliases():
                 code.writeline(f"auto {old} = {new};")
             code.splice(self.loops_code)
-            code.writeline("inductor_cpu_integer_div_error_flag = nullptr;")
             code.writeline(
                 "inductor_cpu_throw_if_integer_div_error(inductor_cpu_integer_div_error);"
             )

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -1694,7 +1694,7 @@ class CppVecOverrides(CppOverrides):
         # a and b are integer type
         _t = f"decltype({b})"
         b = f"{_t}::set({_t}(1), {b}, {cexpr_index(V.kernel.num_elems)})"
-        return f"{a} / {b}"
+        return f"trunc_divide_integral({a}, {b})"
 
     @staticmethod
     def minimum(a, b):

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -855,9 +855,6 @@ class CppOverrides(OpOverrides):
     @staticmethod
     def floordiv(a, b):
         # a and b are integer type
-        V.kernel.compute.writeline(
-            f'TORCH_CHECK({b} != 0, "ZeroDivisionError: integer division or modulo by zero");'
-        )
         return f"floor_divide_integral({a}, {b})"
 
     @staticmethod
@@ -874,10 +871,7 @@ class CppOverrides(OpOverrides):
     # pyrefly: ignore [bad-override]
     def truncdiv(a, b):
         # a and b are integer type
-        V.kernel.compute.writeline(
-            f'TORCH_CHECK({b} != 0, "ZeroDivisionError: integer division or modulo by zero");'
-        )
-        return f"{a} / {b}"
+        return f"trunc_divide_integral({a}, {b})"
 
     @staticmethod
     # pyrefly: ignore [bad-override]

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -639,8 +639,67 @@ def decltype_promoted(*args):
     else:
         return f"decltype({args[0]})"
 
-def is_nonzero_divisor(b):
-    return isinstance(b, CppCSEVariable) and 0 not in b.bounds
+
+def is_const_and_nonzero(x) -> bool:
+    """
+    Check whether `x` is provably != 0 at codegen time by tracing its source.
+
+    A value is considered a "const" (compile-time known) if:
+      - It is a Python int/float literal
+      - It is a sympy numeric expression (no free symbols)
+      - It is a CppCSEVariable whose `dependent_itervars` is empty, meaning it
+        does not depend on any loop iteration variable and is therefore a
+        compile-time constant.
+
+    For const values, we then check whether 0 falls outside the known value
+    range.  For CppCSEVariable this uses the `bounds` attribute (a
+    ValueRanges object with `.lower` and `.upper`).  If the entire range is
+    strictly positive (lower > 0) or strictly negative (upper < 0), we can
+    safely conclude x != 0.
+
+    Returns True if we can prove x != 0, False otherwise (conservative).
+    """
+    if isinstance(x, (int, float)):
+        return x != 0
+
+    if isinstance(x, sympy.Expr):
+        if x.is_number:
+            try:
+                return int(x) != 0
+            except Exception:
+                return False
+        try:
+            return V.graph.sizevars.guard_or_false(sympy.Ne(x, 0))
+        except Exception:
+            return False
+
+    if isinstance(x, OpsValue):
+        return is_const_and_nonzero(x.value)
+
+    if isinstance(x, CppCSEVariable):
+        if x.dependent_itervars:
+            return False
+
+        def _try_numeric(val):
+            if isinstance(val, (int, float)):
+                return val
+            if isinstance(val, sympy.Expr) and val.is_number:
+                try:
+                    return int(val)
+                except Exception:
+                    try:
+                        return float(val)
+                    except Exception:
+                        return None
+            return None
+
+        lo = _try_numeric(x.bounds.lower)
+        hi = _try_numeric(x.bounds.upper)
+        if lo is not None and hi is not None:
+            return lo > 0 or hi < 0
+        return False
+    return False
+
 
 class CppOverrides(OpOverrides):
     """Map element-wise ops to C++"""
@@ -857,7 +916,7 @@ class CppOverrides(OpOverrides):
     @staticmethod
     def floordiv(a, b):
         # a and b are integer type
-        if is_nonzero_divisor(b):
+        if is_const_and_nonzero(b):
             return f"c10::div_floor_integer({a}, {b})"
         return f"floor_divide_integral({a}, {b}, &inductor_cpu_integer_div_error)"
 
@@ -875,7 +934,7 @@ class CppOverrides(OpOverrides):
     # pyrefly: ignore [bad-override]
     def truncdiv(a, b):
         # a and b are integer type
-        if is_nonzero_divisor(b):
+        if is_const_and_nonzero(b):
             return f"c10::trunc_floor_integer({a}, {b})"
         return f"trunc_divide_integral({a}, {b}, &inductor_cpu_integer_div_error)"
 
@@ -1023,7 +1082,7 @@ class CppOverrides(OpOverrides):
 
     @staticmethod
     def mod(a, b):
-        if is_nonzero_divisor(b):
+        if is_const_and_nonzero(b):
             return f"mod({a}, {b})"
         return f"mod({a}, {b}, &inductor_cpu_integer_div_error)"
 

--- a/torch/_inductor/codegen/cpp_flex_attention_template.py
+++ b/torch/_inductor/codegen/cpp_flex_attention_template.py
@@ -224,7 +224,7 @@ extern "C"
 {{kernel.def_kernel(inputs=kernel_args, outputs={"output": output}, extra_sizevars=template.extra_sizevars)}}
 {
   {{ kernel.maybe_codegen_profile() }}
-
+  std::atomic<int> inductor_cpu_integer_div_error{0};
   // dtypes
   using scalar_t = {{kernel.dtype(query)}};
   constexpr bool is_reduced_type = c10::is_reduced_floating_point_v<scalar_t>;
@@ -683,6 +683,7 @@ FLEX_ATTENTION_TEMPLATE = r"""
     at::native::cpublas::brgemm_release(need_pack);
 
   });
+  inductor_cpu_throw_if_integer_div_error(inductor_cpu_integer_div_error);
 }
 """
 
@@ -1055,6 +1056,7 @@ FLEX_DECODING_TEMPLATE = r"""
     }
 
   });
+  inductor_cpu_throw_if_integer_div_error(inductor_cpu_integer_div_error);
 }
 """
 

--- a/torch/csrc/inductor/cpp_prefix.h
+++ b/torch/csrc/inductor/cpp_prefix.h
@@ -811,7 +811,8 @@ Welford<scalar_t> welford_vec_reduce_all(
 }
 #endif
 
-inline void inductor_cpu_note_integer_div_by_zero(std::atomic<int>* err = nullptr) {
+inline void inductor_cpu_note_integer_div_by_zero(
+  std::atomic<int>* err = nullptr) {
   if (err != nullptr) {
     err->store(1, std::memory_order_relaxed);
   } else {
@@ -826,7 +827,10 @@ inline void inductor_cpu_throw_if_integer_div_error(std::atomic<int>& err) {
 }
 
 template <typename T, typename U>
-inline std::common_type_t<T, U> floor_divide_integral(T a, U b, std::atomic<int>* err = nullptr) {
+inline std::common_type_t<T, U> floor_divide_integral(
+  T a,
+  U b,
+  std::atomic<int>* err = nullptr) {
   using C = std::common_type_t<T, U>;
   static_assert(
       std::is_integral_v<C>,
@@ -841,7 +845,10 @@ inline std::common_type_t<T, U> floor_divide_integral(T a, U b, std::atomic<int>
 }
 
 template <typename T, typename U>
-inline std::common_type_t<T, U> trunc_divide_integral(T a, U b, std::atomic<int>* err = nullptr) {
+inline std::common_type_t<T, U> trunc_divide_integral(
+  T a,
+  U b,
+  std::atomic<int>* err = nullptr) {
   using C = std::common_type_t<T, U>;
   static_assert(
       std::is_integral_v<C>,

--- a/torch/csrc/inductor/cpp_prefix.h
+++ b/torch/csrc/inductor/cpp_prefix.h
@@ -890,6 +890,39 @@ inline at::vec::VectorizedN<T, N> floor_divide_integral(
   }
   return out;
 }
+
+template <typename T>
+inline at::vec::Vectorized<T> trunc_divide_integral(
+    const at::vec::Vectorized<T>& a,
+    const at::vec::Vectorized<T>& b) {
+  static_assert(
+      std::is_integral_v<T>,
+      "trunc_divide_integral expects integral underlying type");
+  using Vec = at::vec::Vectorized<T>;
+  constexpr int kLen = Vec::size();
+  alignas(alignof(Vec)) T out_buf[kLen];
+  alignas(alignof(Vec)) T b_buf[kLen];
+  a.store(out_buf);
+  b.store(b_buf);
+  for (int i = 0; i < kLen; ++i) {
+    out_buf[i] = trunc_divide_integral(out_buf[i], b_buf[i]);
+  }
+  return Vec::loadu(out_buf);
+}
+
+template <typename T, int N>
+inline at::vec::VectorizedN<T, N> trunc_divide_integral(
+    const at::vec::VectorizedN<T, N>& a,
+    const at::vec::VectorizedN<T, N>& b) {
+  static_assert(
+      std::is_integral_v<T>,
+      "trunc_divide_integral expects integral underlying type");
+  at::vec::VectorizedN<T, N> out;
+  for (int i = 0; i < N; ++i) {
+    out[i] = trunc_divide_integral(a[i], b[i]);
+  }
+  return out;
+}
 #endif
 
 template <typename T, typename U>

--- a/torch/csrc/inductor/cpp_prefix.h
+++ b/torch/csrc/inductor/cpp_prefix.h
@@ -812,7 +812,7 @@ Welford<scalar_t> welford_vec_reduce_all(
 #endif
 
 inline void inductor_cpu_note_integer_div_by_zero(
-  std::atomic<int>* err = nullptr) {
+    std::atomic<int>* err = nullptr) {
   if (err != nullptr) {
     err->store(1, std::memory_order_relaxed);
   } else {
@@ -828,9 +828,9 @@ inline void inductor_cpu_throw_if_integer_div_error(std::atomic<int>& err) {
 
 template <typename T, typename U>
 inline std::common_type_t<T, U> floor_divide_integral(
-  T a,
-  U b,
-  std::atomic<int>* err = nullptr) {
+    T a,
+    U b,
+    std::atomic<int>* err = nullptr) {
   using C = std::common_type_t<T, U>;
   static_assert(
       std::is_integral_v<C>,
@@ -846,9 +846,9 @@ inline std::common_type_t<T, U> floor_divide_integral(
 
 template <typename T, typename U>
 inline std::common_type_t<T, U> trunc_divide_integral(
-  T a,
-  U b,
-  std::atomic<int>* err = nullptr) {
+    T a,
+    U b,
+    std::atomic<int>* err = nullptr) {
   using C = std::common_type_t<T, U>;
   static_assert(
       std::is_integral_v<C>,

--- a/torch/csrc/inductor/cpp_prefix.h
+++ b/torch/csrc/inductor/cpp_prefix.h
@@ -811,11 +811,9 @@ Welford<scalar_t> welford_vec_reduce_all(
 }
 #endif
 
-inline std::atomic<int>* inductor_cpu_integer_div_error_flag = nullptr;
-
-inline void inductor_cpu_note_integer_div_by_zero() {
-  if (inductor_cpu_integer_div_error_flag != nullptr) {
-    inductor_cpu_integer_div_error_flag->store(1, std::memory_order_relaxed);
+inline void inductor_cpu_note_integer_div_by_zero(std::atomic<int>* err = nullptr) {
+  if (err != nullptr) {
+    err->store(1, std::memory_order_relaxed);
   } else {
     TORCH_CHECK(false, "ZeroDivisionError");
   }
@@ -828,7 +826,7 @@ inline void inductor_cpu_throw_if_integer_div_error(std::atomic<int>& err) {
 }
 
 template <typename T, typename U>
-inline std::common_type_t<T, U> floor_divide_integral(T a, U b) {
+inline std::common_type_t<T, U> floor_divide_integral(T a, U b, std::atomic<int>* err = nullptr) {
   using C = std::common_type_t<T, U>;
   static_assert(
       std::is_integral_v<C>,
@@ -836,14 +834,14 @@ inline std::common_type_t<T, U> floor_divide_integral(T a, U b) {
   const C a_c = static_cast<C>(a);
   const C b_c = static_cast<C>(b);
   if (C10_UNLIKELY_OR_CONST(b_c == 0)) {
-    inductor_cpu_note_integer_div_by_zero();
+    inductor_cpu_note_integer_div_by_zero(err);
     return C(0);
   }
   return c10::div_floor_integer(a_c, b_c);
 }
 
 template <typename T, typename U>
-inline std::common_type_t<T, U> trunc_divide_integral(T a, U b) {
+inline std::common_type_t<T, U> trunc_divide_integral(T a, U b, std::atomic<int>* err = nullptr) {
   using C = std::common_type_t<T, U>;
   static_assert(
       std::is_integral_v<C>,
@@ -851,17 +849,18 @@ inline std::common_type_t<T, U> trunc_divide_integral(T a, U b) {
   const C a_c = static_cast<C>(a);
   const C b_c = static_cast<C>(b);
   if (C10_UNLIKELY_OR_CONST(b_c == 0)) {
-    inductor_cpu_note_integer_div_by_zero();
+    inductor_cpu_note_integer_div_by_zero(err);
     return C(0);
   }
-  return a_c / b_c;
+  return c10::trunc_floor_integer(a_c, b_c);
 }
 
 #if INDUCTOR_USE_VECTOR_TYPES()
 template <typename T>
 inline at::vec::Vectorized<T> floor_divide_integral(
     const at::vec::Vectorized<T>& a,
-    const at::vec::Vectorized<T>& b) {
+    const at::vec::Vectorized<T>& b,
+    std::atomic<int>* err = nullptr) {
   static_assert(
       std::is_integral_v<T>,
       "floor_divide_integral expects integral underlying type");
@@ -872,7 +871,7 @@ inline at::vec::Vectorized<T> floor_divide_integral(
   a.store(out_buf);
   b.store(b_buf);
   for (int i = 0; i < kLen; ++i) {
-    out_buf[i] = floor_divide_integral(out_buf[i], b_buf[i]);
+    out_buf[i] = floor_divide_integral(out_buf[i], b_buf[i], err);
   }
   return Vec::loadu(out_buf);
 }
@@ -880,13 +879,14 @@ inline at::vec::Vectorized<T> floor_divide_integral(
 template <typename T, int N>
 inline at::vec::VectorizedN<T, N> floor_divide_integral(
     const at::vec::VectorizedN<T, N>& a,
-    const at::vec::VectorizedN<T, N>& b) {
+    const at::vec::VectorizedN<T, N>& b,
+    std::atomic<int>* err = nullptr) {
   static_assert(
       std::is_integral_v<T>,
       "floor_divide_integral expects integral underlying type");
   at::vec::VectorizedN<T, N> out;
   for (int i = 0; i < N; ++i) {
-    out[i] = floor_divide_integral(a[i], b[i]);
+    out[i] = floor_divide_integral(a[i], b[i], err);
   }
   return out;
 }
@@ -894,7 +894,8 @@ inline at::vec::VectorizedN<T, N> floor_divide_integral(
 template <typename T>
 inline at::vec::Vectorized<T> trunc_divide_integral(
     const at::vec::Vectorized<T>& a,
-    const at::vec::Vectorized<T>& b) {
+    const at::vec::Vectorized<T>& b,
+    std::atomic<int>* err = nullptr) {
   static_assert(
       std::is_integral_v<T>,
       "trunc_divide_integral expects integral underlying type");
@@ -905,7 +906,7 @@ inline at::vec::Vectorized<T> trunc_divide_integral(
   a.store(out_buf);
   b.store(b_buf);
   for (int i = 0; i < kLen; ++i) {
-    out_buf[i] = trunc_divide_integral(out_buf[i], b_buf[i]);
+    out_buf[i] = trunc_divide_integral(out_buf[i], b_buf[i], err);
   }
   return Vec::loadu(out_buf);
 }
@@ -913,27 +914,28 @@ inline at::vec::Vectorized<T> trunc_divide_integral(
 template <typename T, int N>
 inline at::vec::VectorizedN<T, N> trunc_divide_integral(
     const at::vec::VectorizedN<T, N>& a,
-    const at::vec::VectorizedN<T, N>& b) {
+    const at::vec::VectorizedN<T, N>& b,
+    std::atomic<int>* err = nullptr) {
   static_assert(
       std::is_integral_v<T>,
       "trunc_divide_integral expects integral underlying type");
   at::vec::VectorizedN<T, N> out;
   for (int i = 0; i < N; ++i) {
-    out[i] = trunc_divide_integral(a[i], b[i]);
+    out[i] = trunc_divide_integral(a[i], b[i], err);
   }
   return out;
 }
 #endif
 
 template <typename T, typename U>
-inline std::common_type_t<T, U> mod(T a, U b) {
+inline std::common_type_t<T, U> mod(T a, U b, std::atomic<int>* err = nullptr) {
   using C = std::common_type_t<T, U>;
   static_assert(
       std::is_integral_v<C>,
       "inductor template mod(T a, U b) is only for integral types; use the float/double specializations "
       "for floating-point operands.");
   if (C10_UNLIKELY_OR_CONST(b == 0)) {
-    inductor_cpu_note_integer_div_by_zero();
+    inductor_cpu_note_integer_div_by_zero(err);
     return C(0);
   }
   const C a_c = static_cast<C>(a);
@@ -944,20 +946,20 @@ inline std::common_type_t<T, U> mod(T a, U b) {
   return a_c % b_c;
 }
 template <>
-inline float mod(float a, float b) {
+inline float mod(float a, float b, std::atomic<int>* err) {
   return std::fmod(a, b);
 }
 template <>
-inline double mod(double a, double b) {
+inline double mod(double a, double b, std::atomic<int>* err) {
   return std::fmod(a, b);
 }
 
 template <typename T>
-inline T remainder_integral(T a, T b) {
+inline T remainder_integral(T a, T b, std::atomic<int>* err = nullptr) {
   static_assert(
       std::is_integral_v<T>, "remainder_integral expects integral scalar T");
   if (C10_UNLIKELY_OR_CONST(b == 0)) {
-    inductor_cpu_note_integer_div_by_zero();
+    inductor_cpu_note_integer_div_by_zero(err);
     return T(0);
   }
   if (a == std::numeric_limits<T>::min() && b == T(-1)) {
@@ -974,7 +976,8 @@ inline T remainder_integral(T a, T b) {
 template <typename T>
 inline at::vec::Vectorized<T> remainder_integral(
     const at::vec::Vectorized<T>& a,
-    const at::vec::Vectorized<T>& b) {
+    const at::vec::Vectorized<T>& b,
+    std::atomic<int>* err = nullptr) {
   static_assert(
       std::is_integral_v<T>,
       "remainder_integral expects integral underlying type");
@@ -987,7 +990,7 @@ inline at::vec::Vectorized<T> remainder_integral(
   a.store(out_buf);
   b.store(b_buf);
   for (int i = 0; i < kLen; ++i) {
-    out_buf[i] = remainder_integral(out_buf[i], b_buf[i]);
+    out_buf[i] = remainder_integral(out_buf[i], b_buf[i], err);
   }
   return Vec::loadu(out_buf);
 }
@@ -995,13 +998,14 @@ inline at::vec::Vectorized<T> remainder_integral(
 template <typename T, int N>
 inline at::vec::VectorizedN<T, N> remainder_integral(
     const at::vec::VectorizedN<T, N>& a,
-    const at::vec::VectorizedN<T, N>& b) {
+    const at::vec::VectorizedN<T, N>& b,
+    std::atomic<int>* err = nullptr) {
   static_assert(
       std::is_integral_v<T>,
       "remainder_integral expects integral underlying type");
   at::vec::VectorizedN<T, N> out;
   for (int i = 0; i < N; ++i) {
-    out[i] = remainder_integral(a[i], b[i]);
+    out[i] = remainder_integral(a[i], b[i], err);
   }
   return out;
 }

--- a/torch/csrc/inductor/cpp_prefix.h
+++ b/torch/csrc/inductor/cpp_prefix.h
@@ -842,6 +842,21 @@ inline std::common_type_t<T, U> floor_divide_integral(T a, U b) {
   return c10::div_floor_integer(a_c, b_c);
 }
 
+template <typename T, typename U>
+inline std::common_type_t<T, U> trunc_divide_integral(T a, U b) {
+  using C = std::common_type_t<T, U>;
+  static_assert(
+      std::is_integral_v<C>,
+      "trunc_divide_integral expects integral scalar operands");
+  const C a_c = static_cast<C>(a);
+  const C b_c = static_cast<C>(b);
+  if (C10_UNLIKELY_OR_CONST(b_c == 0)) {
+    inductor_cpu_note_integer_div_by_zero();
+    return C(0);
+  }
+  return a_c / b_c;
+}
+
 #if INDUCTOR_USE_VECTOR_TYPES()
 template <typename T>
 inline at::vec::Vectorized<T> floor_divide_integral(


### PR DESCRIPTION
fixes: #178480
add check to division by zero for inductor.

add code checking  the divisor is zero for the function in floordiv/truncdiv/truediv in class CppOverrides


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo