### PR TITLE
Add missing #include <shared_mutex> to CublasHandlePool.cpp

### DIFF
--- a/aten/src/ATen/cuda/CublasHandlePool.cpp
+++ b/aten/src/ATen/cuda/CublasHandlePool.cpp
@@ -7,6 +7,7 @@
 #include <map>
 #include <memory>
 #include <regex>
+#include <shared_mutex>
 #include <string>
 #include <tuple>
 


### PR DESCRIPTION
CublasHandlePool.cpp uses std::shared_mutex but does not directly include <shared_mutex>, causing the ROCm Windows build to fail.