### PR TITLE
[DTensor] Add InputDim.__eq__ type guard to prevent int comparison bugs

### DIFF
--- a/test/distributed/tensor/test_view_ops.py
+++ b/test/distributed/tensor/test_view_ops.py
@@ -2134,6 +2134,27 @@ class TestViewOps(DTensorContinuousTestBase):
         )
         self.assertEqual(out_plc, [Replicate(), Replicate()])
 
+    def test_input_dim_rejects_int_comparison(self):
+        """InputDim.__eq__ should raise TypeError when compared with int.
+
+        Regression guard: shard.dim == in_dim (int == InputDim) silently
+        returned False for over 3 years, making downstream validation dead code.
+        """
+        dim = InputDim(0)
+        # InputDim == InputDim is fine
+        self.assertEqual(dim, InputDim(0))
+        self.assertNotEqual(dim, InputDim(1))
+        # hash contract: equal InputDims must have equal hashes
+        self.assertEqual(hash(dim), hash(InputDim(0)))
+        # hash is salted so it won't collide with raw int in dicts/sets
+        self.assertNotEqual(hash(dim), hash(0))
+        # InputDim == int raises (catches `dim == some_int`)
+        with self.assertRaisesRegex(TypeError, "Did you mean to use .input_dim"):
+            _ = dim == 0
+        # int == InputDim also raises (catches the original bug: `shard.dim == in_dim`)
+        with self.assertRaisesRegex(TypeError, "Did you mean to use .input_dim"):
+            _ = 0 == dim
+
 
 TestViewOpsWithLocalTensor = create_local_tensor_test_class(
     TestViewOps,

--- a/torch/distributed/tensor/_ops/_view_ops.py
+++ b/torch/distributed/tensor/_ops/_view_ops.py
@@ -65,11 +65,26 @@ class Singleton(DimSpec):
     """Output dimension is a singleton."""
 
 
-@dataclass
+@dataclass(eq=False)
 class InputDim(DimSpec):
     """Output dimension maps directly to an input dimension."""
 
     input_dim: int
+
+    def __eq__(self, other: object) -> bool:
+        """Raises TypeError for non-DimSpec comparisons to catch accidental
+        ``shard.dim == input_dim`` bugs where ``.input_dim`` was intended."""
+        if isinstance(other, InputDim):
+            return self.input_dim == other.input_dim
+        if not isinstance(other, DimSpec):
+            raise TypeError(
+                f"Cannot compare InputDim with {type(other).__name__}. "
+                f"Did you mean to use .input_dim?"
+            )
+        return NotImplemented
+
+    def __hash__(self) -> int:
+        return hash((InputDim, self.input_dim))
 
 
 @dataclass


### PR DESCRIPTION
Follow on for https://github.com/pytorch/pytorch/issues/177972 . 

InputDim is a dataclass wrapping an int (input_dim), which makes it easy to accidentally compare shard.dim (an int) with an InputDim instance instead of InputDim.input_dim. This comparison always
 returns False, making downstream logic dead code.

The original instance of this bug (shard.dim == in_dim) in propagate_shape_and_sharding was fixed in #177973. This change adds a structural guard: InputDim.__eq__ raises TypeError when compared with non-DimSpec types (like int), directing the developer to use .input_dim instead. A matching __hash__ preserves the hash contract. This prevents the bug class from recurring. @wconstab 