### PR TITLE
[BE] enable docs test for ~50 public APIs (lots of fx) using Claude SKILL

### DIFF
--- a/.claude/skills/document-public-apis/SKILL.md
+++ b/.claude/skills/document-public-apis/SKILL.md
@@ -7,7 +7,9 @@ description: Document undocumented public APIs in PyTorch by removing functions 
 
 This skill documents undocumented public APIs in PyTorch by removing entries from the coverage ignore lists in `docs/source/conf.py` and adding Sphinx autodoc directives (e.g., `autosummary`, `currentmodule`, `autoclass`, `automodule`) to the corresponding `.md` or `.rst` doc source files in `docs/source/`.
 
-**"Documenting" means adding autodoc directives to doc source files — NEVER modifying Python source code.** Do not add or edit docstrings in `.py` files. Do not read or inspect Python source files. Sphinx will pull whatever docstring exists (or render an empty entry if none exists). Your only job is to add the correct directive to the correct doc file.
+**"Documenting" means adding autodoc directives to doc source files — NEVER modifying Python source code.** Do not add or edit docstrings in `.py` files. Your only job is to add the correct directive to the correct doc file.
+
+**IMPORTANT: Before adding any function to the sphinx doctree, verify it has a real docstring.** Use a quick Python check (e.g., `python -c "from torch.module import func; print(bool(func.__doc__))"`) to confirm the function has actual documentation content — not just an empty docstring or a bare `.. warning:: This API is experimental` stub. Functions without meaningful docstrings should be left in the `coverage_ignore_functions`/`coverage_ignore_classes` lists. Adding undocumented functions to the doctree creates empty or near-empty pages that degrade documentation quality.
 
 ## Overview
 
@@ -71,9 +73,24 @@ Work through the lists top-to-bottom. Choose enough groups to make meaningful pr
 
 If a module group has a **mix** of regular entries and entries with inline comments, still process the group — but only comment out the regular entries. Leave entries with inline comments untouched in the ignore list.
 
+### Step 1b: Verify functions have actual docstrings
+
+For each function selected in Step 1, check that it has a meaningful docstring by running:
+
+```bash
+python -c "from torch.module.path import func_name; doc = func_name.__doc__; print('HAS DOC' if doc and len(doc.strip()) > 80 else 'NO DOC'); print(repr(doc[:120]) if doc else 'None')"
+```
+
+A function has a **meaningful docstring** if it has real descriptive content — not just:
+- `None` or empty string
+- Only a `.. warning:: This API is experimental` stub with no description
+- Only a one-line auto-generated signature
+
+**Functions without meaningful docstrings must stay in the ignore list.** Remove them from your batch. If an entire module group has no functions with docstrings, skip the whole group.
+
 ### Step 2: Present the batch to the user
 
-**Before making any edits**, present the selected module groups and their functions to the user. Show them organized by module:
+**Before making any edits**, present the selected module groups and their functions to the user. Indicate which functions passed the docstring check and which were excluded. Show them organized by module:
 
 ```
 Module: torch.ao.quantization.fx.convert
@@ -315,8 +332,8 @@ Also delete any module label comments that no longer have active entries beneath
 
 ## Important notes
 
-- **Follow the steps exactly as written.** Do not add extra investigation steps like importing Python modules to check docstrings, inspecting source code to verify function signatures, or running any commands not specified in the instructions. The `make coverage` step is the only verification needed — let it tell you what's wrong.
-- **Never modify Python source files (`.py`).** This skill only edits `docs/source/conf.py` and doc source files (`.md`/`.rst`) in `docs/source/`. Do not add or edit docstrings, do not read Python source to check function signatures, do not inspect implementations.
+- **Follow the steps exactly as written.** The `make coverage` step is the primary verification for correct Sphinx directives, and Step 1b's docstring check ensures you only document functions that have real content.
+- **Never modify Python source files (`.py`).** This skill only edits `docs/source/conf.py` and doc source files (`.md`/`.rst`) in `docs/source/`. Do not add or edit docstrings. The only reason to inspect Python modules is in Step 1b to check whether a docstring exists — never to modify source code.
 - Entries are commented out in Step 3, verified in Step 6, and cleaned up in Step 8 after verification passes. Never delete uncommented entries directly.
 - **Read inline comments** on entries before deciding to document them. Entries marked `# deprecated`, `# documented as ...`, `# looks unintentionally public`, or `# legacy helper` should stay in the ignore list.
 - The `coverage_ignore_functions` list uses bare function names (not fully qualified), so the same name can appear multiple times for different modules. Use the module label comment above each entry to identify which module it belongs to. Be careful during Step 8 cleanup to only delete the correct commented-out lines — commented-out string entries have **quotes** (`# "func_name",`), module label comments do not.

--- a/docs/source/accelerator.md
+++ b/docs/source/accelerator.md
@@ -2,6 +2,7 @@
 
 ```{eval-rst}
 .. automodule:: torch.accelerator
+   :no-members:
 ```
 
 ```{eval-rst}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -253,31 +253,18 @@ autosummary_filename_map = {
 coverage_ignore_functions = [
     "main",  # utility script
     "run",  # utility script
-    # torch.distributions.constraints
-    "is_dependent",
     # torch.hub
     "import_module",
-    # torch.jit
-    "export_opnames",
     # torch.jit.unsupported_tensor_ops
     "execWrapper",
-    # torch.onnx
-    "unregister_custom_op_symbolic",
-    # torch.ao.quantization
-    "default_eval_fn",
     # torch.backends
     "disable_global_flags",
     "flags_frozen",
-    # torch.distributed.algorithms.ddp_comm_hooks
-    "register_ddp_comm_hook",
     # torch.nn.parallel
     "DistributedDataParallelCPU",
     # torch.utils
-    "set_module",
     "burn_in_info",
     "get_info_and_burn_skeleton",
-    "get_inline_skeleton",
-    "get_model_info",
     "get_storage_info",
     "hierarchical_pickle",
     # torch.amp.autocast_mode
@@ -612,70 +599,33 @@ coverage_ignore_functions = [
     "make_sharded_output_tensor",
     # torch.fx.passes.annotate_getitem_nodes
     "annotate_getitem_nodes",
-    # torch.fx.passes.backends.cudagraphs
-    "partition_cudagraphs",
     # torch.fx.passes.dialect.common.cse_pass
     "get_CSE_banned_ops",
     # torch.fx.passes.graph_manipulation
     "get_size_of_all_nodes",
     "get_size_of_node",
     "get_tensor_meta",
-    "replace_target_nodes_with",
-    # torch.fx.passes.infra.pass_manager
-    "pass_result_wrapper",
-    "this_before_that_pass_constraint",
-    # torch.fx.passes.operator_support
-    "any_chain",
-    "chain",
-    "create_op_support",
-    # torch.fx.passes.param_fetch
-    "default_matching",
-    "extract_attrs_for_lowering",
-    "lift_lowering_attrs_to_nodes",
-    # torch.fx.passes.pass_manager
-    "inplace_wrapper",
-    "log_hook",
-    "loop_pass",
-    "these_before_those_pass_constraint",
-    "this_before_that_pass_constraint",
-    # torch.fx.passes.regional_inductor
-    "regional_inductor",
-    # torch.fx.passes.reinplace
-    "reinplace",
     # torch.fx.passes.split_module
     "split_module",
     # torch.fx.passes.split_utils
     "getattr_recursive",
-    "setattr_recursive",
     "split_by_tags",
     # torch.fx.passes.splitter_base
     "generate_inputs_for_submodules",
     # torch.fx.passes.tools_common
     "get_acc_ops_name",
     "get_node_target",
-    "is_node_output_tensor",
     "legalize_graph",
     # torch.fx.passes.utils.common
-    "compare_graphs",
     "lift_subgraph_as_module",
     # torch.fx.passes.utils.fuser_utils
-    "erase_nodes",
     "fuse_as_graphmodule",
     "fuse_by_partitions",
     "insert_subgm",
-    "topo_sort",
-    "validate_partition",
     # torch.fx.passes.utils.source_matcher_utils
-    "check_subgraphs_connected",
     "get_source_partitions",
     # torch.fx.proxy
     "assert_fn",
-    # torch.fx.subgraph_rewriter
-    "replace_pattern",
-    "replace_pattern_with_filters",
-    # torch.fx.tensor_type
-    "is_consistent",
-    "is_more_precise",
     # torch.fx.traceback
     "format_stack",
     "get_current_meta",
@@ -683,9 +633,9 @@ coverage_ignore_functions = [
     "preserve_node_meta",
     "reset_grad_fn_seq_nr",
     "set_current_meta",
+    "set_current_replay_node",
     "set_grad_fn_seq_nr",
     "set_stack_trace",
-    "set_current_replay_node",
     "get_current_replay_node",
     # torch.jit.annotations
     "ann_to_type",
@@ -726,13 +676,6 @@ coverage_ignore_functions = [
     "quantize_linear_modules",
     "quantize_rnn_cell_modules",
     "quantize_rnn_modules",
-    # torch.library
-    "define",
-    "get_ctx",
-    "impl",
-    "impl_abstract",
-    # torch.masked.maskedtensor.core
-    "is_masked_tensor",
     # torch.masked.maskedtensor.creation
     "as_masked_tensor",
     "masked_tensor",
@@ -1018,19 +961,8 @@ coverage_ignore_functions = [
     "check_export_model_diff",
     "verify",
     "verify_aten_graph",
-    # torch.optim.optimizer
-    "register_optimizer_step_post_hook",
-    "register_optimizer_step_pre_hook",
     # torch.overrides
     "enable_reentrant_dispatch",
-    # torch.package.analyze.find_first_use_of_broken_modules
-    "find_first_use_of_broken_modules",
-    # torch.package.analyze.is_from_package
-    "is_from_package",
-    # torch.package.analyze.trace_dependencies
-    "trace_dependencies",
-    # torch.profiler.itt
-    "range",
     # torch.profiler.profiler
     "schedule",
     "supported_activities",
@@ -1038,8 +970,6 @@ coverage_ignore_functions = [
     # torch.return_types
     "pytree_register_structseq",
     # torch.serialization
-    "check_module_version_greater_or_equal",
-    "default_restore_location",
     "load",
     "location_tag",
     "mkdtemp",
@@ -1060,8 +990,6 @@ coverage_ignore_functions = [
     "hann",
     "kaiser",
     "nuttall",
-    # torch.sparse.semi_structured
-    "to_sparse_semi_structured",
     # torch.utils.backend_registration
     "generate_methods_for_privateuse1_backend",
     "rename_privateuse1_backend",

--- a/docs/source/cuda.md
+++ b/docs/source/cuda.md
@@ -308,7 +308,19 @@ See the docs for {class}`~torch.cuda.green_contexts.GreenContext` for an example
 ```
 
 ```{eval-rst}
-.. py:module:: torch.cuda.nvtx
+.. automodule:: torch.cuda.nvtx
+```
+
+```{eval-rst}
+.. currentmodule:: torch.cuda.nvtx
+```
+
+```{eval-rst}
+.. autofunction:: range_start
+```
+
+```{eval-rst}
+.. autofunction:: range_end
 ```
 
 ```{eval-rst}

--- a/docs/source/ddp_comm_hooks.md
+++ b/docs/source/ddp_comm_hooks.md
@@ -33,6 +33,13 @@ Particularly, {class}`torch.distributed.GradBucket` represents a bucket of gradi
 .. autofunction:: torch.distributed.GradBucket.parameters
 ```
 
+## Register Communication Hook
+
+```{eval-rst}
+.. currentmodule:: torch.distributed.algorithms.ddp_comm_hooks
+.. autofunction:: register_ddp_comm_hook
+```
+
 ## Default Communication Hooks
 
 Default communication hooks are simple **stateless** hooks, so the input state

--- a/docs/source/distributed.tensor.md
+++ b/docs/source/distributed.tensor.md
@@ -264,7 +264,10 @@ these features.
 
 ```{eval-rst}
 .. autofunction:: register_sharding
+```
 
+```{eval-rst}
+.. autofunction:: implicit_replication
 ```
 
 % modules that are missing docs, add the doc later when necessary

--- a/docs/source/fx.experimental.md
+++ b/docs/source/fx.experimental.md
@@ -362,6 +362,7 @@ These APIs are experimental and subject to change without notice.
     view_inference_rule
     register_inference_rule
     transpose_inference_rule
+    range_check
 ```
 
 ## torch.fx.experimental.migrate_gradual_types.constraint_transformation

--- a/docs/source/fx.md
+++ b/docs/source/fx.md
@@ -8,6 +8,7 @@
 ## Overview
 ```{eval-rst}
 .. automodule:: torch.fx
+   :no-members:
 ```
 
 
@@ -1176,6 +1177,236 @@ The set of leaf modules can be customized by overriding
     annotate_fn
 ```
 
+## torch.fx.subgraph_rewriter
+
+```{eval-rst}
+.. currentmodule:: torch.fx.subgraph_rewriter
+```
+
+```{eval-rst}
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    replace_pattern
+    replace_pattern_with_filters
+```
+
+## torch.fx.tensor_type
+
+```{eval-rst}
+.. currentmodule:: torch.fx.tensor_type
+```
+
+```{eval-rst}
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    is_consistent
+    is_more_precise
+```
+
+## torch.fx.passes.backends.cudagraphs
+
+```{eval-rst}
+.. currentmodule:: torch.fx.passes.backends.cudagraphs
+```
+
+```{eval-rst}
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    partition_cudagraphs
+```
+
+## torch.fx.passes.graph_manipulation
+
+```{eval-rst}
+.. currentmodule:: torch.fx.passes.graph_manipulation
+```
+
+```{eval-rst}
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    replace_target_nodes_with
+```
+
+## torch.fx.passes.infra.pass_manager
+
+```{eval-rst}
+.. currentmodule:: torch.fx.passes.infra.pass_manager
+```
+
+```{eval-rst}
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    pass_result_wrapper
+    this_before_that_pass_constraint
+```
+
+## torch.fx.passes.operator_support
+
+```{eval-rst}
+.. currentmodule:: torch.fx.passes.operator_support
+```
+
+```{eval-rst}
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    any_chain
+    chain
+    create_op_support
+```
+
+## torch.fx.passes.param_fetch
+
+```{eval-rst}
+.. automodule:: torch.fx.passes.param_fetch
+   :no-members:
+```
+
+```{eval-rst}
+.. currentmodule:: torch.fx.passes.param_fetch
+```
+
+```{eval-rst}
+.. autofunction:: default_matching
+```
+
+```{eval-rst}
+.. autofunction:: extract_attrs_for_lowering
+```
+
+```{eval-rst}
+.. autofunction:: lift_lowering_attrs_to_nodes
+```
+
+## torch.fx.passes.pass_manager
+
+```{eval-rst}
+.. currentmodule:: torch.fx.passes.pass_manager
+```
+
+```{eval-rst}
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    inplace_wrapper
+    log_hook
+    loop_pass
+    these_before_those_pass_constraint
+    this_before_that_pass_constraint
+```
+
+## torch.fx.passes.regional_inductor
+
+```{eval-rst}
+.. currentmodule:: torch.fx.passes.regional_inductor
+```
+
+```{eval-rst}
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    regional_inductor
+```
+
+## torch.fx.passes.reinplace
+
+```{eval-rst}
+.. currentmodule:: torch.fx.passes.reinplace
+```
+
+```{eval-rst}
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    reinplace
+```
+
+## torch.fx.passes.split_utils
+
+```{eval-rst}
+.. currentmodule:: torch.fx.passes.split_utils
+```
+
+```{eval-rst}
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    setattr_recursive
+```
+
+## torch.fx.passes.tools_common
+
+```{eval-rst}
+.. currentmodule:: torch.fx.passes.tools_common
+```
+
+```{eval-rst}
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    is_node_output_tensor
+```
+
+## torch.fx.passes.utils.common
+
+```{eval-rst}
+.. currentmodule:: torch.fx.passes.utils.common
+```
+
+```{eval-rst}
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    compare_graphs
+```
+
+## torch.fx.passes.utils.fuser_utils
+
+```{eval-rst}
+.. currentmodule:: torch.fx.passes.utils.fuser_utils
+```
+
+```{eval-rst}
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    erase_nodes
+    topo_sort
+    validate_partition
+```
+
+## torch.fx.passes.utils.source_matcher_utils
+
+```{eval-rst}
+.. currentmodule:: torch.fx.passes.utils.source_matcher_utils
+```
+
+```{eval-rst}
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    check_subgraphs_connected
+```
+
 <!-- The experimental and passes submodules are missing docs. -->
 <!-- Adding it here for coverage but this doesn't add anything to the -->
 <!-- rendered doc. -->
@@ -1218,7 +1449,7 @@ The set of leaf modules can be customized by overriding
 .. py:module:: torch.fx.passes.infra.pass_manager
 .. py:module:: torch.fx.passes.net_min_base
 .. py:module:: torch.fx.passes.operator_support
-.. py:module:: torch.fx.passes.param_fetch
+
 .. py:module:: torch.fx.passes.pass_manager
 .. py:module:: torch.fx.passes.regional_inductor
 .. py:module:: torch.fx.passes.reinplace

--- a/docs/source/masked.md
+++ b/docs/source/masked.md
@@ -304,6 +304,20 @@ The following ops are currently supported:
     Tensor.view
 ```
 
+## torch.masked.maskedtensor.core
+
+```{eval-rst}
+.. currentmodule:: torch.masked.maskedtensor.core
+```
+
+```{eval-rst}
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    is_masked_tensor
+```
+
 ```{eval-rst}
 .. This module needs to be documented. Adding here in the meantime
 .. for tracking purposes

--- a/docs/source/multiprocessing.md
+++ b/docs/source/multiprocessing.md
@@ -206,6 +206,12 @@ terminate processes upon detecting an error in one of them.
 
 % for tracking purposes
 
+## torch.multiprocessing.pool
+
+```{eval-rst}
+.. currentmodule:: torch.multiprocessing.pool
+```
+
 ```{eval-rst}
 .. py:module:: torch.multiprocessing.pool
 ```

--- a/docs/source/optim.md
+++ b/docs/source/optim.md
@@ -149,6 +149,18 @@ for input, target in dataset:
     Optimizer.zero_grad
 ```
 
+## Module-level hooks
+
+```{eval-rst}
+.. currentmodule:: torch.optim.optimizer
+
+.. autofunction:: register_optimizer_step_post_hook
+
+.. autofunction:: register_optimizer_step_pre_hook
+
+.. currentmodule:: torch.optim
+```
+
 ## Algorithms
 
 ```{eval-rst}

--- a/docs/source/package.md
+++ b/docs/source/package.md
@@ -726,12 +726,23 @@ statements more clearly show whether they are referring to packaged code or not.
   :members:
 ```
 
-<!-- This module needs to be documented. Adding here in the meantime
-for tracking purposes -->
+## Analysis Utilities
 ```{eval-rst}
 .. py:module:: torch.package.analyze.find_first_use_of_broken_modules
 .. py:module:: torch.package.analyze.is_from_package
 .. py:module:: torch.package.analyze.trace_dependencies
+
+.. currentmodule:: torch.package.analyze.find_first_use_of_broken_modules
+
+.. autofunction:: find_first_use_of_broken_modules
+
+.. currentmodule:: torch.package.analyze.is_from_package
+
+.. autofunction:: is_from_package
+
+.. currentmodule:: torch.package.analyze.trace_dependencies
+
+.. autofunction:: trace_dependencies
 .. py:module:: torch.package.file_structure_representation
 .. py:module:: torch.package.find_file_dependencies
 .. py:module:: torch.package.glob_group

--- a/docs/source/profiler.md
+++ b/docs/source/profiler.md
@@ -26,6 +26,8 @@
 .. autofunction:: torch.profiler.schedule
 
 .. autofunction:: torch.profiler.tensorboard_trace_handler
+
+.. autofunction:: torch.profiler.supported_activities
 ```
 
 ## Intel Instrumentation and Tracing Technology APIs
@@ -38,6 +40,8 @@
 .. autofunction:: torch.profiler.itt.range_push
 
 .. autofunction:: torch.profiler.itt.range_pop
+
+.. autofunction:: torch.profiler.itt.range
 ```
 
 <!-- This module needs to be documented. Adding here in the meantime

--- a/docs/source/quantization-support.md
+++ b/docs/source/quantization-support.md
@@ -793,6 +793,10 @@ the `custom operator mechanism <https://pytorch.org/tutorials/advanced/torch_scr
 .. automodule:: torch.nn.intrinsic.quantized.dynamic.modules
 .. automodule:: torch.nn.quantized.dynamic.modules
 .. automodule:: torch.quantization
+
+.. currentmodule:: torch.quantization
+.. autofunction:: default_eval_fn
+
 .. automodule:: torch.nn.intrinsic.modules
 ```
 

--- a/docs/source/sparse.rst
+++ b/docs/source/sparse.rst
@@ -309,6 +309,8 @@ You can accelerate the linear layers in your model if the weights are already se
     >>> linear = nn.Linear(64, 64).half().cuda()
     >>> linear.weight = nn.Parameter(to_sparse_semi_structured(linear.weight.masked_fill(~mask, 0)))
 
+.. autofunction:: torch.sparse.semi_structured.to_sparse_semi_structured
+
 
 .. _sparse-coo-docs:
 

--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -257,6 +257,14 @@ Serialization
     save
     load
 
+.. currentmodule:: torch.serialization
+
+.. autofunction:: check_module_version_greater_or_equal
+
+.. autofunction:: default_restore_location
+
+.. currentmodule:: torch
+
 Parallelism
 ----------------------------------
 .. autosummary::
@@ -810,6 +818,9 @@ Operator Tags
 .. This module needs to be documented. Adding here in the meantime
 .. for tracking purposes
 .. py:module:: torch.utils.model_dump
+
+.. currentmodule:: torch.utils.model_dump
+
 .. py:module:: torch.utils.viz
 .. py:module:: torch.quasirandom
 .. py:module:: torch.return_types

--- a/torch/fx/_compatibility.py
+++ b/torch/fx/_compatibility.py
@@ -16,6 +16,7 @@ def compatibility(is_backward_compatible: bool) -> Callable[[_T], _T]:
         def mark_back_compat(fn: _T) -> _T:
             docstring = textwrap.dedent(getattr(fn, "__doc__", None) or "")
             docstring += """
+
 .. note::
     Backwards-compatibility for this API is guaranteed.
 """
@@ -30,6 +31,7 @@ def compatibility(is_backward_compatible: bool) -> Callable[[_T], _T]:
         def mark_not_back_compat(fn: _T) -> _T:
             docstring = textwrap.dedent(getattr(fn, "__doc__", None) or "")
             docstring += """
+
 .. warning::
     This API is experimental and is *NOT* backward-compatible.
 """

--- a/torch/fx/passes/graph_manipulation.py
+++ b/torch/fx/passes/graph_manipulation.py
@@ -26,8 +26,10 @@ def replace_target_nodes_with(
     new_op: str,
     new_target: Target,
 ):
-    """Modifies all nodes in fx_module.graph.nodes which match the specified op code and target,
-    and updates them to match the new op code and target"""
+    """
+    Modifies all nodes in fx_module.graph.nodes which match the specified op code
+    and target, and updates them to match the new op code and target.
+    """
     new_graph = Graph()
     val_map: dict[Node, Node] = {}
     for node in fx_module.graph.nodes:

--- a/torch/fx/passes/infra/pass_manager.py
+++ b/torch/fx/passes/infra/pass_manager.py
@@ -124,22 +124,21 @@ def _topological_sort_passes(
 @compatibility(is_backward_compatible=False)
 def this_before_that_pass_constraint(this: Callable, that: Callable) -> Callable:
     """
-    Defines a partial order ('depends on' function) where `this` must occur
-    before `that`.
+    Defines a partial order ('depends on' function) where ``this`` must occur
+    before ``that``.
 
-    For example, the following pass list and constraint list would be invalid.
-    ```
-    passes = [pass_b, pass_a]
+    For example, the following pass list and constraint list would be invalid::
 
-    constraints = [this_before_that_pass_constraint(pass_a, pass_b)]
-    ```
+        passes = [pass_b, pass_a]
+
+        constraints = [this_before_that_pass_constraint(pass_a, pass_b)]
 
     Args:
         this (Callable): pass which should occur first
         that (Callable): pass which should occur later
 
     Returns:
-        depends_on (Callable[[Object, Object], bool]
+        depends_on (Callable[[Object, Object], bool])
     """
 
     def depends_on(a: Callable, b: Callable):

--- a/torch/fx/passes/pass_manager.py
+++ b/torch/fx/passes/pass_manager.py
@@ -43,22 +43,21 @@ def log_hook(fn: Callable, level=logging.INFO) -> Callable:
     """
     Logs callable output.
 
-    This is useful for logging output of passes. Note inplace_wrapper replaces
+    This is useful for logging output of passes. Note ``inplace_wrapper`` replaces
     the pass output with the modified object. If we want to log the original
-    output, apply this wrapper before inplace_wrapper.
+    output, apply this wrapper before ``inplace_wrapper``.
+
+    Example::
+
+        def my_pass(d: Dict) -> bool:
+            changed = False
+            if "foo" in d:
+                d["foo"] = "bar"
+                changed = True
+            return changed
 
 
-    ```
-    def my_pass(d: Dict) -> bool:
-        changed = False
-        if "foo" in d:
-            d["foo"] = "bar"
-            changed = True
-        return changed
-
-
-    pm = PassManager(passes=[inplace_wrapper(log_hook(my_pass))])
-    ```
+        pm = PassManager(passes=[inplace_wrapper(log_hook(my_pass))])
 
     Args:
         fn (Callable[Type1, Type2])
@@ -147,25 +146,24 @@ def this_before_that_pass_constraint(this: Callable, that: Callable):
 
 def these_before_those_pass_constraint(these: Callable, those: Callable):
     """
-    Defines a partial order ('depends on' function) where `these` must occur
-    before `those`. Where the inputs are 'unwrapped' before comparison.
+    Defines a partial order ('depends on' function) where ``these`` must occur
+    before ``those``. Where the inputs are 'unwrapped' before comparison.
 
-    For example, the following pass list and constraint list would be invalid.
-    ```
-    passes = [
-        loop_pass(pass_b, 3),
-        loop_pass(pass_a, 5),
-    ]
+    For example, the following pass list and constraint list would be invalid::
 
-    constraints = [these_before_those_pass_constraint(pass_a, pass_b)]
-    ```
+        passes = [
+            loop_pass(pass_b, 3),
+            loop_pass(pass_a, 5),
+        ]
+
+        constraints = [these_before_those_pass_constraint(pass_a, pass_b)]
 
     Args:
         these (Callable): pass which should occur first
         those (Callable): pass which should occur later
 
     Returns:
-        depends_on (Callable[[Object, Object], bool]
+        depends_on (Callable[[Object, Object], bool])
     """
 
     def depends_on(a: Callable, b: Callable):

--- a/torch/fx/passes/regional_inductor.py
+++ b/torch/fx/passes/regional_inductor.py
@@ -244,15 +244,19 @@ def regional_inductor(gm, *example_args):
     """
     Scoops out inductor marked regions and compiles them with inductor.
 
-    Inductor options should be provided via the annotation API:
-    with fx_traceback.annotate({
-        "compile_with_inductor": {
-            "inductor_configs": {
-                "max_autotune": True,
-                "triton.cudagraphs": False
+    Inductor options should be provided via the annotation API::
+
+        with fx_traceback.annotate(
+            {
+                "compile_with_inductor": {
+                    "inductor_configs": {
+                        "max_autotune": True,
+                        "triton.cudagraphs": False,
+                    }
+                }
             }
-        }
-    }):
+        ):
+            ...
     """
 
     # fuser utils create new nodes using create_proxy which retains the seq_nr

--- a/torch/fx/passes/reinplace.py
+++ b/torch/fx/passes/reinplace.py
@@ -309,104 +309,108 @@ def _get_view_inverse_node_usages(
 
 @compatibility(is_backward_compatible=True)
 def reinplace(gm, *sample_args):
-    """
+    r"""
     Given an fx.GraphModule, modifies it to perform "reinplacing",
     mutating the nodes of the graph.
-    We look for out-of-place op call sites like `b = a.add(...)`,
-    and convert them to be inplace (`b = a.add_(...)`),
+    We look for out-of-place op call sites like ``b = a.add(...)``,
+    and convert them to be inplace (``b = a.add_(...)``),
     as long as the input to the current operator ("a") isn't reused
     anywhere later in the graph.
 
     This pass currently expects to operate on a **functional, ATen** graph.
-    This can be obtained by running `make_fx(functionalize(f))`.
+    This can be obtained by running ``make_fx(functionalize(f))``.
 
     Sample inputs are needed to determine aliasing relationships of the inputs.
-    In general, we can't reinplace node `b = a.add(...)` if "a" aliases any of the
+    In general, we can't reinplace node ``b = a.add(...)`` if "a" aliases any of the
     inputs to the program.
 
-    Given a node "b = foo(a, args...) the algorithm for re-inplacing is as follows:
+    Given a node ``b = foo(a, args...)`` the algorithm for re-inplacing is as follows:
 
-    (1) Perform some initial checks on the metadata of "a" and "args..."
-        that can disqualify them from being reinplaced.
+    **(1)** Perform some initial checks on the metadata of "a" and "args..."
+    that can disqualify them from being reinplaced.
 
-      (1a) Check that the self argument we're attempting to reinplace
-           has acceptable dtype/size metadata to reinplace with.
+    - **(1a)** Check that the self argument we're attempting to reinplace
+      has acceptable dtype/size metadata to reinplace with.
 
-           For example, if we have:
-             a = torch.ones(1)
-             b = torch.ones(10)
-             out = torch.add(a, b)
-           We can't turn that into
-             a.add_(b)
-           Because that would require resizing "a".
+      For example, if we have::
 
-           Similarly, we can't convert torch.ge(a, b) into a.ge_(b),
-           because that would require changing a's dtype (from e.g. float32 to bool).
-           Note that in this specific example, we could technically do better..
+        a = torch.ones(1)
+        b = torch.ones(10)
+        out = torch.add(a, b)
 
-           If we see the pattern:
-             a_1 = a.ge(b)
-             a_2 = aten._to_copy(a_1, a.dtype)
-           Then we this should be valid to completely re-inplace
-           (this is exactly what functionalization will emit when it sees a.ge_(b)).
+      We can't turn that into ``a.add_(b)`` because that would require resizing "a".
 
-           This optimization is only really important for user programs
-           that directly use inplace comparison ops though.
+      Similarly, we can't convert ``torch.ge(a, b)`` into ``a.ge_(b)``,
+      because that would require changing a's dtype (from e.g. float32 to bool).
+      Note that in this specific example, we could technically do better..
 
-           We also cannot re-inplace on tensors that have overlapping memory,
-           e.g. torch.ones(1).expand(4, 4).add_(1)
+      If we see the pattern::
 
-      (1b) Check if "a" is an alias of any of the program inputs.
+        a_1 = a.ge(b)
+        a_2 = aten._to_copy(a_1, a.dtype)
 
-          If it is, skip and move to the next node.
-          Inplace'ing an op that would cause it to mutate a program is not sound,
-          because that would be a side effect visible to the user.
+      Then this should be valid to completely re-inplace
+      (this is exactly what functionalization will emit when it sees ``a.ge_(b)``).
 
-          NOTE: there's a future optimization that we should make:
-          if "a" is a (alias of a)  program input, but later in the program
-          there is a node that looks like "a.copy_(...)",
-          Then re-inplacing is ok to do - we are temporarily reusing a's buffer,
-          which will later be overwritten by the copy_() call.
+      This optimization is only really important for user programs
+      that directly use inplace comparison ops though.
 
-          This will be an important optimization to have for programs that mutate
-          their inputs. It currently isn't implemented though.
+      We also cannot re-inplace on tensors that have overlapping memory,
+      e.g. ``torch.ones(1).expand(4, 4).add_(1)``.
 
-      (1c) Check if "a" and "args..." alias
+    - **(1b)** Check if "a" is an alias of any of the program inputs.
 
-          For example, re-inplacing to create code like the below
-          isn't guaranteed to be sound:
+      If it is, skip and move to the next node.
+      Inplace'ing an op that would cause it to mutate a program is not sound,
+      because that would be a side effect visible to the user.
 
-            aten.mul_(a, a)
+      NOTE: there's a future optimization that we should make:
+      if "a" is a (alias of a)  program input, but later in the program
+      there is a node that looks like ``a.copy_(...)``,
+      then re-inplacing is ok to do - we are temporarily reusing a's buffer,
+      which will later be overwritten by the ``copy_()`` call.
 
-    (2) Check that "a" and all of its outstanding aliases are not used anywhere
-        later in the graph. If this is the case, then it's safe to re-inplace
-        to "b = foo_(a)".
+      This will be an important optimization to have for programs that mutate
+      their inputs. It currently isn't implemented though.
 
-        There are a few caveats to this, explained in more detail below:
-        (a) If "a" is used later as an argument to a view op, that is okay.
-            It's only a problem if "a" (or that view) is later passed
-            into a normal operator, or if it is returned as the program output.
-        (b) If "a" is a repeat argument in `foo()`, then don't reinplace.
-            Most ATen kernels don't make any guarantees that this is sound,
-            e.g. if you do aten.mul_(a, a).
-            So we'll just ban re-inplacing in this case.
-            It's only a problem if "a" (or that view) is later passed
-        (c) If "a" is used as an input into a view "inverse" / "scatter"
-            operator, it is potentially fine to re-inplace
-            (and remove that scatter operator from the graph).
-            See below for a more detailed example.
+    - **(1c)** Check if "a" and "args..." alias.
 
-        NOTE: there is an optimization in this step that is crucial
-        to fully recovering performance from functionalization.
+      For example, re-inplacing to create code like the below
+      isn't guaranteed to be sound::
 
-        Given this program:
+        aten.mul_(a, a)
+
+    **(2)** Check that "a" and all of its outstanding aliases are not used anywhere
+    later in the graph. If this is the case, then it's safe to re-inplace
+    to ``b = foo_(a)``.
+
+    There are a few caveats to this, explained in more detail below:
+
+    - (a) If "a" is used later as an argument to a view op, that is okay.
+      It's only a problem if "a" (or that view) is later passed
+      into a normal operator, or if it is returned as the program output.
+    - (b) If "a" is a repeat argument in ``foo()``, then don't reinplace.
+      Most ATen kernels don't make any guarantees that this is sound,
+      e.g. if you do ``aten.mul_(a, a)``.
+      So we'll just ban re-inplacing in this case.
+    - (c) If "a" is used as an input into a view "inverse" / "scatter"
+      operator, it is potentially fine to re-inplace
+      (and remove that scatter operator from the graph).
+      See below for a more detailed example.
+
+    NOTE: there is an optimization in this step that is crucial
+    to fully recovering performance from functionalization.
+
+    Given this program::
+
         def f(x):
             a = torch.ops.aten.add(x, x)
             b = torch.ops.aten.diagonal(a)
             torch.ops.aten.fill_(b, 0)
             return d
 
-        Functionalization will emit the following:
+    Functionalization will emit the following::
+
         def f(x):
             a = torch.ops.aten.add(x, x)
             b = torch.ops.aten.diagonal(a, 0, 1)
@@ -414,99 +418,115 @@ def reinplace(gm, *sample_args):
             a_updated = torch.ops.aten.diagonal_scatter(a, b_updated, 0, 1)
             return a_updated
 
-        Ordinarily, we would not be able to reinplace the fill,
-        because "b" aliases with "a" which is used by the diagonal_scatter call.
+    Ordinarily, we would not be able to reinplace the fill,
+    because "b" aliases with "a" which is used by the diagonal_scatter call.
 
-        "re-inplacing" is on the hook for figuring out that it is ok to
-        completely, the expensive diagonal_scatter call, if we re-inplace the add().
+    "re-inplacing" is on the hook for figuring out that it is ok to
+    completely remove the expensive diagonal_scatter call, if we re-inplace
+    the add().
 
-        So, for every `alias in alias_set(a)`, instead of checking
-        that "alias" is not used anywhere later in the graph,
-        we check that
-            EITHER:
-          (a) alias is not used anywhere later in the graph
-            OR:
-          (b) alias is used exactly once later on in the graph,
-              in the following op:
+    So, for every ``alias in alias_set(a)``, instead of checking
+    that "alias" is not used anywhere later in the graph,
+    we check that EITHER:
 
-                out = foo_scatter(alias, x, args...)
+    - (a) alias is not used anywhere later in the graph, OR
+    - (b) alias is used exactly once later on in the graph,
+      in the following op::
 
-              where the following must hold:
-                (i) "foo_scatter" is the "inverse" operator for foo.
-                    This only applies to "foo" ops that are view operators,
-                    which view into a subset of the original tensor's memory.
-                    In practice, there are ~4 operators where this applies:
-                      diagonal -> diagonal_scatter
-                      slice -> slice_scatter
-                      select -> select_scatter
-                      as_strided -> as_strided_scatter
-                (ii) "args..." are the same between the foo() and foo_scatter() calls.
+        out = foo_scatter(alias, x, args...)
 
-    (3) Perform the actual re-inplacing on foo!
+      where the following must hold:
 
-      (3b) is the common case, but special care is needed for {view}_scatter (3a)
+      - (i) ``foo_scatter`` is the "inverse" operator for foo.
+        This only applies to "foo" ops that are view operators,
+        which view into a subset of the original tensor's memory.
+        In practice, there are ~4 operators where this applies::
 
-      (3a) {view}_scatter ops.
+          diagonal -> diagonal_scatter
+          slice -> slice_scatter
+          select -> select_scatter
+          as_strided -> as_strided_scatter
 
-        Consider this program:
-          a = torch.zeros(2, 2)
-          b = torch.ones(2)
-          a[0] = b
+      - (ii) "args..." are the same between the ``foo()`` and
+        ``foo_scatter()`` calls.
 
-        Post functionalization, that will look like:
-          a = torch.zeros(2)
-          b = torch.ones(1)
-          a_updated = torch.select_scatter(a, b, 0, 0)
+    **(3)** Perform the actual re-inplacing on foo!
 
-        In this case though, there is no "functional" op to re-inplace!
-        Instead, we'd like to directly remove toe select_scatter call.
-        We already know from (3) that this is valid,
-        because "a" has no later usages in the graph.
+    (3b) is the common case, but special care is needed for
+    ``{view}_scatter`` (3a).
 
-        We perform the re-inplacing on the {view}_scatter op like so
-        Before:
-          a_updated = torch.select_scatter(a, b, args...)
-        After:
-          a_slice = a.select(a, args...)
-          a_slice.copy_(b)
+    - **(3a)** ``{view}_scatter`` ops.
 
-      (3b) Otherwise, replace the functional op with its inplace variant.
-        Before:
-          b = foo(a, args...)
-        After:
-          a.foo_(args...)
+      Consider this program::
 
-    (4) Finally, after converting either:
-          Before:
-            b = foo(a)
-          After:
-            foo_(a)
-        or
-          Before:
-            b = {slice}_scatter(a, mutated_slice, args...)
-          After:
-            slice = {slice}(a, args...)
-            slice.copy_(mutated_slice)
+        a = torch.zeros(2, 2)
+        b = torch.ones(2)
+        a[0] = b
 
-        We now need to find all later nodes that use "b" as an argument
-        and update them to take in "a" instead.
+      Post functionalization, that will look like::
 
-        Note that for the majority of inplace ops, this isn't actually necessary
-        (because most inplace ops return "self" as their output).
-        This isn't generally true for all mutable ops though, which is why
-        we need to actually replace all of the arguments.
+        a = torch.zeros(2)
+        b = torch.ones(1)
+        a_updated = torch.select_scatter(a, b, 0, 0)
 
-        We also need to update our metadata of Dict[StorageWeakRef, Set[Node]],
-        That maps a given tensor storage to the set of all nodes that take in that storage
-        as an input.
-        Specifically, re-inplacing `b = foo(a)` causes "a" and "b"'s sets to get fused
-        together.
+      In this case though, there is no "functional" op to re-inplace!
+      Instead, we'd like to directly remove the select_scatter call.
+      We already know from (3) that this is valid,
+      because "a" has no later usages in the graph.
 
-    (5) Any "view_inverse/scatter" nodes that were identified as "it's ok to ignore them"
-        during step (3) get manually deleted from the graph.
-        Their outputs are no longer used, so technically standard DCE would be able
-        to do this, but we can no longer run FX's DCE pass now that we have mutable
-        ops in the graph.
+      We perform the re-inplacing on the ``{view}_scatter`` op like so.
+
+      Before::
+
+        a_updated = torch.select_scatter(a, b, args...)
+
+      After::
+
+        a_slice = a.select(a, args...)
+        a_slice.copy_(b)
+
+    - **(3b)** Otherwise, replace the functional op with its inplace variant.
+
+      Before::
+
+        b = foo(a, args...)
+
+      After::
+
+        a.foo_(args...)
+
+    **(4)** Finally, after converting either::
+
+        # Before:                              # After:
+        b = foo(a)                             foo_(a)
+
+    or::
+
+        # Before:
+        b = {slice}_scatter(a, mutated_slice, args...)
+        # After:
+        slice = {slice}(a, args...)
+        slice.copy_(mutated_slice)
+
+    We now need to find all later nodes that use "b" as an argument
+    and update them to take in "a" instead.
+
+    Note that for the majority of inplace ops, this isn't actually necessary
+    (because most inplace ops return "self" as their output).
+    This isn't generally true for all mutable ops though, which is why
+    we need to actually replace all of the arguments.
+
+    We also need to update our metadata of ``Dict[StorageWeakRef, Set[Node]]``,
+    that maps a given tensor storage to the set of all nodes that take in that
+    storage as an input.
+    Specifically, re-inplacing ``b = foo(a)`` causes "a" and "b"'s sets to get
+    fused together.
+
+    **(5)** Any ``view_inverse/scatter`` nodes that were identified as
+    "it's ok to ignore them" during step (3) get manually deleted from the graph.
+    Their outputs are no longer used, so technically standard DCE would be able
+    to do this, but we can no longer run FX's DCE pass now that we have mutable
+    ops in the graph.
     """
     _FunctionalizationMetadataProp(gm).propagate(*sample_args)
 


### PR DESCRIPTION
removing undocumented functions (FX, packaging, jit) from conf.py coverage_ignore_functions and coverage_ignore_classes. added public APIs to sphinx documentation list and then ran `make coverage` to test and verified that documentation coverage is 100%. 

also checked w/ some screenshots of docs preview 

<img width="1064" height="494" alt="Screenshot 2026-04-05 at 6 57 51 PM" src="https://github.com/user-attachments/assets/3d021a4f-8e7a-403e-a631-83d2a0276d70" />

<img width="644" height="583" alt="Screenshot 2026-04-09 at 11 19 46 AM" src="https://github.com/user-attachments/assets/6fb29f64-645a-4a7a-b9a0-af5e92e9ed84" />

<img width="644" height="315" alt="Screenshot 2026-04-09 at 11 20 19 AM" src="https://github.com/user-attachments/assets/19a5b73e-ebd4-4d2b-8d4e-84473c200c59" />

<img width="661" height="540" alt="Screenshot 2026-04-09 at 11 20 50 AM" src="https://github.com/user-attachments/assets/add6a3ec-ec73-4624-871b-964ca6fe3bbd" />

