### PR TITLE
[lumen] Register lint test plan CLI entry point with noclang plan

### DIFF
--- a/.ci/lumen_cli/cli/lib/pytorch/lint_test/__init__.py
+++ b/.ci/lumen_cli/cli/lib/pytorch/lint_test/__init__.py
@@ -1,0 +1,3 @@
+from cli.lib.pytorch.lint_test.lint_plans import LINT_PLANS
+
+__all__ = ["LINT_PLANS"]

--- a/.ci/lumen_cli/cli/lib/pytorch/lint_test/lint_plans.py
+++ b/.ci/lumen_cli/cli/lib/pytorch/lint_test/lint_plans.py
@@ -1,0 +1,72 @@
+"""
+Lint test plans — declarative lint job definitions.
+
+Usage:
+    lumen test lint --group-id lintrunner_noclang
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class TestStep:
+    test_id: str
+    commands: list[str]
+    env_vars: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class LintTestPlan:
+    group_id: str
+    title: str
+    image: str
+    steps: list[TestStep] = field(default_factory=list)
+    env_vars: dict[str, str] = field(default_factory=dict)
+    setup_commands: list[str] = field(default_factory=list)
+    inputs: dict[str, str] = field(default_factory=dict)
+
+    def resolve_env_vars(self, overrides: dict[str, str] | None = None) -> dict[str, str]:
+        """Resolve env_vars by substituting {input_name} placeholders.
+
+        Special handling: if an input value is "*", the placeholder
+        {input_name} is replaced with "--all-files" (matching the
+        CHANGED_FILES convention in lint-osdc.yml).
+        """
+        values = {**self.inputs, **(overrides or {})}
+        resolved = {}
+        for k, v in values.items():
+            if v == "*":
+                resolved[k] = "--all-files"
+            else:
+                resolved[k] = v
+        return {k: v.format(**resolved) for k, v in self.env_vars.items()}
+
+
+# Common setup shared by all _lint.yml based jobs
+_LINT_SETUP = [
+    "python -m pip install -r .ci/docker/requirements-ci.txt",
+    "dnf install -y doxygen graphviz nodejs npm",
+    "npm install -g markdown-toc",
+    "lintrunner init",
+]
+
+LINT_PLANS: dict[str, LintTestPlan] = {
+    "lintrunner_noclang": LintTestPlan(
+        group_id="lintrunner_noclang",
+        title="Lintrunner (no clang)",
+        image="ghcr.io/pytorch/test-infra:cpu-x86_64-67eb930",
+        setup_commands=_LINT_SETUP,
+        inputs={"changed_files": "*"},
+        env_vars={
+            "ADDITIONAL_LINTRUNNER_ARGS": "--skip CLANGTIDY,CLANGTIDY_EXECUTORCH_COMPATIBILITY,CLANGFORMAT,PYREFLY {changed_files}",
+        },
+        steps=[
+            TestStep(
+                test_id="noclang",
+                commands=["bash .github/scripts/lintrunner.sh"],
+            ),
+        ],
+    ),
+}

--- a/.ci/lumen_cli/cli/lib/pytorch/runner.py
+++ b/.ci/lumen_cli/cli/lib/pytorch/runner.py
@@ -1,0 +1,62 @@
+"""
+Lint test runner.
+
+Usage:
+    lumen test lint --group-id lintrunner_noclang
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from cli.lib.common.cli_helper import BaseRunner
+from cli.lib.pytorch.lint_test.lint_plans import LINT_PLANS, LintTestPlan
+
+
+logger = logging.getLogger(__name__)
+
+
+def generate_script(plan: LintTestPlan, input_overrides: dict[str, str] | None = None) -> str:
+    """Generate a self-contained bash script from a lint test plan."""
+    parts = ["#!/bin/bash", "set -euo pipefail", ""]
+
+    # env vars (resolved with inputs)
+    env_vars = plan.resolve_env_vars(input_overrides)
+    for k, v in env_vars.items():
+        parts.append(f'export {k}="{v}"')
+    for step in plan.steps:
+        for k, v in step.env_vars.items():
+            parts.append(f'export {k}="{v}"')
+    if env_vars or any(s.env_vars for s in plan.steps):
+        parts.append("")
+
+    # setup
+    if plan.setup_commands:
+        parts.append("# === setup ===")
+        parts.extend(plan.setup_commands)
+        parts.append("")
+
+    # steps
+    for step in plan.steps:
+        parts.append(f"# === {step.test_id} ===")
+        parts.extend(step.commands)
+        parts.append("")
+
+    return "\n".join(parts)
+
+
+class PytorchTestRunner(BaseRunner):
+    def __init__(self, args: Any) -> None:
+        self.group_id: str = args.group_id
+        raw_inputs = getattr(args, "input", []) or []
+        self.input_overrides = dict(i.split("=", 1) for i in raw_inputs)
+
+    def run(self) -> None:
+        if self.group_id not in LINT_PLANS:
+            raise RuntimeError(
+                f"group '{self.group_id}' not found. "
+                f"Available: {sorted(LINT_PLANS)}"
+            )
+        plan = LINT_PLANS[self.group_id]
+        print(generate_script(plan, self.input_overrides))

--- a/.ci/lumen_cli/cli/test_cli/register_test.py
+++ b/.ci/lumen_cli/cli/test_cli/register_test.py
@@ -6,6 +6,8 @@ import logging
 from cli.lib.common.cli_helper import register_targets, RichHelp, TargetSpec
 from cli.lib.core.torchtitan.torchtitan_test import TorchtitanTestRunner
 from cli.lib.core.vllm.vllm_test import VllmTestRunner
+from cli.lib.pytorch.lint_test.lint_plans import LINT_PLANS
+from cli.lib.pytorch.runner import PytorchTestRunner
 
 
 logger = logging.getLogger(__name__)
@@ -66,3 +68,29 @@ def register_test_commands(subparsers: argparse._SubParsersAction) -> None:
         formatter_class=RichHelp,
     )
     register_targets(external_parser, _TARGETS, common_args=common_args)
+    _register_pytorch_commands(build_subparsers)
+
+
+def _register_pytorch_commands(subparsers: argparse._SubParsersAction) -> None:
+    available = "\n".join(
+        f"  {gid:30} {plan.title}" for gid, plan in LINT_PLANS.items()
+    )
+    parser = subparsers.add_parser(
+        "lint",
+        help="Run lint test plans",
+        description="Run Pytroch test.\n\nAvailable group IDs:\n" + available,
+        formatter_class=RichHelp,
+    )
+    parser.add_argument(
+        "--group-id",
+        required=True,
+        help="lint plan to run, e.g. 'lintrunner_noclang'",
+    )
+    parser.add_argument(
+        "--input",
+        metavar="KEY=VALUE",
+        action="append",
+        default=[],
+        help="override plan inputs, e.g. --input changed_files='src/foo.py src/bar.py'",
+    )
+    parser.set_defaults(func=lambda args: PytorchTestRunner(args).run())

--- a/.ci/lumen_cli/pyproject.toml
+++ b/.ci/lumen_cli/pyproject.toml
@@ -1,13 +1,22 @@
+[build-system]
+requires = ["setuptools>=64"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "lumen-ci"
 version = "0.1.0"
+requires-python = ">=3.10"
 dependencies = [
     "pyyaml==6.0.2",
     "GitPython==3.1.45",
     "docker==7.1.0",
     "pytest==7.3.2",
-    "uv==0.9.6"
+    "uv>=0.9.6",
+    "jinja2>=3.1",
 ]
+
+[project.scripts]
+lumen = "cli.run:main"
 
 [tool.setuptools]
 packages = ["cli"]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* (to be filled)

Add the declarative lint test plan framework:
- LintTestPlan/TestStep dataclasses for defining lint jobs
- `lumen test lint --group-id noclang` prints the generated bash script
- Only noclang plan for now; more plans to follow

Authored with Claude.