### PR TITLE
[lumen] Add local execution for lint test plans

### DIFF
--- a/.ci/lumen_cli/cli/lib/pytorch/runner.py
+++ b/.ci/lumen_cli/cli/lib/pytorch/runner.py
@@ -1,19 +1,81 @@
 """
-Lint test runner.
+Lint test runner — local execution or remote execution via RE.
 
-Usage:
+Local:
     lumen test lint --group-id lintrunner_noclang
 """
 
 from __future__ import annotations
 
 import logging
+import os
+import subprocess
 from typing import Any
 
-from cli.lib.pytorch.lint_test.lint_plans import LINT_PLANS
+from cli.lib.pytorch.lint_test.lint_plans import LINT_PLANS, LintTestPlan
 
 
 logger = logging.getLogger(__name__)
+
+
+def generate_script(plan: LintTestPlan, input_overrides: dict[str, str] | None = None) -> str:
+    """Generate a self-contained bash script from a lint test plan."""
+    parts = ["#!/bin/bash", "set -euo pipefail", ""]
+
+    # env vars (resolved with inputs)
+    env_vars = plan.resolve_env_vars(input_overrides)
+    for k, v in env_vars.items():
+        parts.append(f'export {k}="{v}"')
+    for step in plan.steps:
+        for k, v in step.env_vars.items():
+            parts.append(f'export {k}="{v}"')
+    if env_vars or any(s.env_vars for s in plan.steps):
+        parts.append("")
+
+    # setup
+    if plan.setup_commands:
+        parts.append("# === setup ===")
+        parts.extend(plan.setup_commands)
+        parts.append("")
+
+    # steps
+    for step in plan.steps:
+        parts.append(f"# === {step.test_id} ===")
+        parts.extend(step.commands)
+        parts.append("")
+
+    return "\n".join(parts)
+
+
+def run_plan(group_id: str, plan: LintTestPlan, input_overrides: dict[str, str] | None = None) -> None:
+    """Run a lint test plan locally."""
+    logger.info("[%s] %s", group_id, plan.title)
+
+    env_backup = {}
+    resolved = plan.resolve_env_vars(input_overrides)
+    for k, v in resolved.items():
+        env_backup[k] = os.environ.get(k)
+        os.environ[k] = v
+
+    try:
+        for cmd in plan.setup_commands:
+            logger.info("[%s] setup: %s", group_id, cmd)
+            subprocess.check_call(cmd, shell=True)
+
+        for step in plan.steps:
+            for k, v in step.env_vars.items():
+                env_backup.setdefault(k, os.environ.get(k))
+                os.environ[k] = v
+            for cmd in step.commands:
+                logger.info("[%s/%s] %s", group_id, step.test_id, cmd)
+                subprocess.check_call(cmd, shell=True)
+            logger.info("[%s/%s] passed", group_id, step.test_id)
+    finally:
+        for k, orig in env_backup.items():
+            if orig is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = orig
 
 
 class PytorchTestRunner:
@@ -29,4 +91,4 @@ class PytorchTestRunner:
                 f"Available: {sorted(LINT_PLANS)}"
             )
         plan = LINT_PLANS[self.group_id]
-        logger.info("Plan: %s", plan)
+        run_plan(self.group_id, plan, self.input_overrides)

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -67,6 +67,12 @@ jobs:
           set -eux
           lintrunner init
 
+      - name: Install lumen CLI
+        shell: bash
+        run: |
+          set -eux
+          uv pip install -e .ci/lumen_cli
+
       - name: Run linter
         shell: bash
         env:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -98,7 +98,6 @@ jobs:
       runner: mt-l-x86iamx-8-16
       docker-image: ghcr.io/pytorch/test-infra:cpu-x86_64-810d48d
       script: |
-        uv pip install -e .ci/lumen_cli
         CHANGED_FILES="${{ needs.get-changed-files.outputs.changed-files }}"
         if [ "$CHANGED_FILES" = '*' ]; then
           lumen test lint --group-id lintrunner_noclang


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #178643
* #178640
* #178633
* __->__ #178627
* #178626

Add run_plan() that executes setup_commands and test steps locally
via subprocess. `lumen test lint --group-id noclang` now runs the
lint plan instead of just logging it.

Authored with Claude.