### PR TITLE
[lumen] Add RE script modules and LumenScriptBuilder

### DIFF
--- a/.ci/lumen_cli/cli/lib/pytorch/re_runner.py
+++ b/.ci/lumen_cli/cli/lib/pytorch/re_runner.py
@@ -1,0 +1,56 @@
+"""Remote execution support — submit commands to run on RE infrastructure."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from re_cli.core.script_builder import RunnerScriptBuilder
+
+
+logger = logging.getLogger(__name__)
+
+SCRIPT_MODULES_DIR = Path(__file__).resolve().parent / "script_modules"
+
+DEFAULT_IMAGE = "ghcr.io/pytorch/test-infra:cpu-x86_64-67eb930"
+DEFAULT_BOOTSTRAP = ["git_clone", "setup_uv", "check_python", "install_lumen"]
+
+
+def _load_script_module(name: str) -> str:
+    """Load a bash script from script_modules/ by name (without .sh)."""
+    path = SCRIPT_MODULES_DIR / f"{name}.sh"
+    if not path.exists():
+        raise RuntimeError(f"script module '{name}' not found at {path}")
+    template = path.read_text()
+    return "\n".join(
+        line
+        for line in template.splitlines()
+        if not line.startswith("#") and not line.startswith("set -")
+    ).strip()
+
+
+class LumenScriptBuilder(RunnerScriptBuilder):
+    """RE script builder for lumen."""
+
+    def _add_script(self, module_name: str, script_name: str) -> LumenScriptBuilder:
+        body = _load_script_module(script_name)
+        self._modules.append(
+            f"\n# {'=' * 44}\n# MODULE: {module_name}\n# {'=' * 44}\n" + body
+        )
+        return self
+
+    def add_git_clone(self) -> LumenScriptBuilder:
+        return self._add_script("git_clone", "git_clone")
+
+    def add_setup_uv(self) -> LumenScriptBuilder:
+        return self._add_script("setup_uv", "setup_uv")
+
+    def add_check_python(self) -> LumenScriptBuilder:
+        return self._add_script("check_python", "check_python")
+
+    def add_install_lumen(self) -> LumenScriptBuilder:
+        self._modules.append(
+            f"\n# {'=' * 44}\n# MODULE: install_lumen\n# {'=' * 44}\n"
+            "uv pip install -e .ci/lumen_cli"
+        )
+        return self

--- a/.ci/lumen_cli/cli/lib/pytorch/script_modules/check_python.sh
+++ b/.ci/lumen_cli/cli/lib/pytorch/script_modules/check_python.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -eu
+: "${PYTHON_VERSION:=3.12}"
+
+ACTUAL=$(python3 --version 2>&1 | grep -oP '\d+\.\d+')
+if [ "$ACTUAL" != "$PYTHON_VERSION" ]; then
+    echo "ERROR: expected Python $PYTHON_VERSION but got $ACTUAL"
+    exit 1
+fi
+echo "Python version OK: $ACTUAL"

--- a/.ci/lumen_cli/cli/lib/pytorch/script_modules/git_clone.sh
+++ b/.ci/lumen_cli/cli/lib/pytorch/script_modules/git_clone.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -eu
+: "${REPO_URL:?REPO_URL must be set}"
+: "${COMMIT_SHA:?COMMIT_SHA must be set}"
+
+git clone --depth=1 "$REPO_URL" pytorch
+cd pytorch
+git fetch --depth=1 origin "$COMMIT_SHA"
+git checkout "$COMMIT_SHA"

--- a/.ci/lumen_cli/cli/lib/pytorch/script_modules/setup_uv.sh
+++ b/.ci/lumen_cli/cli/lib/pytorch/script_modules/setup_uv.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# RE equivalent of pytorch/test-infra/.github/actions/setup-uv
+set -eu
+: "${PYTHON_VERSION:=3.12}"
+: "${UV_VERSION:=0.9.21}"
+
+if ! command -v uv &>/dev/null; then
+    curl -LsSf "https://astral.sh/uv/${UV_VERSION}/install.sh" | sh
+    export PATH="$HOME/.local/bin:$PATH"
+fi
+
+uv python install "$PYTHON_VERSION"
+uv venv --seed --python "$PYTHON_VERSION"
+source .venv/bin/activate


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #178643
* #178640
* __->__ #178633
* #178627
* #178626

Add bash script modules (setup_uv, git_clone, check_python) and
LumenScriptBuilder that assembles them into RE runner scripts.

the scriptbuilder is used to generate the runner script to setup env in re，the core lib in test-infra has the basic
one, this is extended version for pytorch specific needs


Authored with Claude.