### PR TITLE
[Native DSL] Post-De-registration PR nits

### DIFF
--- a/test/python_native/test_registry.py
+++ b/test/python_native/test_registry.py
@@ -149,34 +149,6 @@ class TestRegistry(TestCase):
                 result = list(self.registry._resolve_iterable(input_val))
                 self.assertEqual(result, expected)
 
-    def test_filter_functionality(self):
-        """Test _filter function with various filter criteria."""
-        # Test no filters raises error
-        with self.assertRaises(ValueError) as cm:
-            self.registry._filter("dsl", "op", "key")
-        self.assertIn("Must pass 1+ of filter_", str(cm.exception))
-
-        # Test different filter types
-        filter_test_cases = [
-            ("dsl_names", "test_dsl", "op", "key", "test_dsl", True),
-            ("dsl_names", "test_dsl", "op", "key", ["test_dsl", "other"], True),
-            ("dsl_names", "test_dsl", "op", "key", "other_dsl", False),
-            ("op_symbols", "dsl", "test_op", "key", "test_op", True),
-            ("op_symbols", "dsl", "test_op", "key", ["test_op", "other"], True),
-            ("op_symbols", "dsl", "test_op", "key", "other_op", False),
-            ("dispatch_keys", "dsl", "op", "test_key", "test_key", True),
-            ("dispatch_keys", "dsl", "op", "test_key", ["test_key", "other"], True),
-            ("dispatch_keys", "dsl", "op", "test_key", "other_key", False),
-        ]
-
-        for filter_type, dsl, op, key, filter_val, expected in filter_test_cases:
-            with self.subTest(
-                filter_type=filter_type, filter_val=filter_val, expected=expected
-            ):
-                kwargs = {f"filter_{filter_type}": filter_val}
-                result = self.registry._filter(dsl, op, key, **kwargs)
-                self.assertEqual(result, expected)
-
     def test_update_registration_maps(self):
         """Test _update_registration_maps updates all mapping dictionaries."""
         key = ("test_op", "CPU")
@@ -247,28 +219,47 @@ class TestRegistry(TestCase):
         self.assertFalse(node.unconditional_override)
         self.assertTrue(node.active)
 
-        mock_lib.impl.assert_called_with(
-            "add.Tensor", impl_fn, "CPU", with_keyset=True, allow_override=False
+        # In the lazy model, library.impl should not be called immediately
+        mock_lib.impl.assert_not_called()
+
+        # But when we trigger registration, it should be called
+        self.registry._register_overrides_from_graph(
+            "add.Tensor", "CPU", self.registry._graphs[key]
+        )
+        mock_lib.impl.assert_called_once_with(
+            "add.Tensor", impl_fn, "CPU", with_keyset=True, allow_override=True
         )
 
-        # Test 2: Unconditional override
-        mock_lib.reset_mock()
-        self.registry.register_op_override(
-            backend="test_backend2",
-            lib_symbol="aten",
-            op_symbol="mul.Tensor",
-            dispatch_key="CPU",
-            impl=impl_fn,
-            unconditional_override=True,
-        )
+        # Test 2: Test with_keyset = not unconditional_override relationship
+        for unconditional_override in [False, True]:
+            with self.subTest(unconditional_override=unconditional_override):
+                mock_lib.reset_mock()
+                op_symbol = f"test_unconditional_{unconditional_override}.Tensor"
 
-        key2 = ("mul.Tensor", "CPU")
-        node2 = self.registry._graphs[key2][0]
-        self.assertTrue(node2.unconditional_override)
+                self.registry.register_op_override(
+                    backend="test_backend2",
+                    lib_symbol="aten",
+                    op_symbol=op_symbol,
+                    dispatch_key="CPU",
+                    impl=impl_fn,
+                    unconditional_override=unconditional_override,
+                )
 
-        mock_lib.impl.assert_called_with(
-            "mul.Tensor", impl_fn, "CPU", with_keyset=False, allow_override=False
-        )
+                # In lazy model, registration should not have been called immediately
+                mock_lib.impl.assert_not_called()
+
+                # Trigger registration and verify with_keyset = not unconditional_override
+                test_key = (op_symbol, "CPU")
+                self.registry._register_overrides_from_graph(
+                    op_symbol, "CPU", self.registry._graphs[test_key]
+                )
+                mock_lib.impl.assert_called_with(
+                    op_symbol,
+                    impl_fn,
+                    "CPU",
+                    with_keyset=not unconditional_override,
+                    allow_override=True,
+                )
 
         # Test 3: Allow multiple overrides
         mock_lib.reset_mock()
@@ -281,9 +272,71 @@ class TestRegistry(TestCase):
             allow_multiple_override=True,
         )
 
+        key3 = ("div.Tensor", "CPU")
+        # In lazy model, no immediate registration
+        mock_lib.impl.assert_not_called()
+
+        # Test lazy registration for multiple overrides
+        self.registry._register_overrides_from_graph(
+            "div.Tensor", "CPU", self.registry._graphs[key3]
+        )
         mock_lib.impl.assert_called_with(
             "div.Tensor", impl_fn, "CPU", with_keyset=True, allow_override=True
         )
+
+    @patch("torch.library.Library")
+    def test_lazy_registration_model(self, mock_library_cls):
+        """Test that registration is lazy and only happens when explicitly triggered."""
+        mock_lib = MagicMock()
+        mock_library_cls.return_value = mock_lib
+
+        def impl_fn1(x):
+            return x + 1
+
+        def impl_fn2(x):
+            return x + 2
+
+        # Register multiple overrides
+        self.registry.register_op_override(
+            backend="backend1",
+            lib_symbol="aten",
+            op_symbol="lazy_test.Tensor",
+            dispatch_key="CPU",
+            impl=impl_fn1,
+        )
+
+        self.registry.register_op_override(
+            backend="backend2",
+            lib_symbol="aten",
+            op_symbol="lazy_test.Tensor",
+            dispatch_key="CUDA",
+            impl=impl_fn2,
+        )
+
+        # At this point, no lib.impl calls should have been made
+        mock_lib.impl.assert_not_called()
+
+        # But graphs should be populated
+        key1 = ("lazy_test.Tensor", "CPU")
+        key2 = ("lazy_test.Tensor", "CUDA")
+        self.assertIn(key1, self.registry._graphs)
+        self.assertIn(key2, self.registry._graphs)
+        self.assertEqual(len(self.registry._graphs[key1]), 1)
+        self.assertEqual(len(self.registry._graphs[key2]), 1)
+
+        # No libraries should be created yet
+        self.assertNotIn(key1, self.registry._libs)
+        self.assertNotIn(key2, self.registry._libs)
+
+        # Now trigger all registrations
+        self.registry._register_all_overrides()
+
+        # Now lib.impl should have been called for both registrations
+        self.assertEqual(mock_lib.impl.call_count, 2)
+
+        # And libraries should exist
+        self.assertIn(key1, self.registry._libs)
+        self.assertIn(key2, self.registry._libs)
 
     @patch("torch.library.Library")
     def testderegister_op_overrides(self, mock_library_cls):
@@ -384,6 +437,9 @@ class TestRegistry(TestCase):
             "dsl2", "aten", "add.Tensor", "CPU", impl_fn2
         )
 
+        # In the lazy model, we need to trigger actual registration to create libraries
+        self.registry._register_all_overrides()
+
         # Check both are registered
         key = ("add.Tensor", "CPU")
         self.assertEqual(len(self.registry._graphs[key]), 2)
@@ -450,6 +506,8 @@ class TestRegistry(TestCase):
         self.assertTrue(all(node.active for node in nodes))
 
         # Test 2: Remove middle override
+        # In the lazy model, we need to trigger actual registration first
+        self.registry._register_all_overrides()
         self.registry.deregister_op_overrides(disable_dsl_names="backend2")
         nodes = self.registry._graphs[key]
         backend1_node = next(n for n in nodes if n.dsl_name == "backend1")
@@ -492,6 +550,8 @@ class TestRegistry(TestCase):
             backends_all, op_symbol_all, dispatch_key, mock_library_cls
         )
 
+        # Trigger registration before deregistration
+        self.registry._register_all_overrides()
         self.registry.deregister_op_overrides(disable_dsl_names=backends_all)
         nodes_all = self.registry._graphs[key_all]
         self.assertTrue(all(not node.active for node in nodes_all))
@@ -549,6 +609,9 @@ class TestRegistry(TestCase):
             add_impl_fn2,
             allow_multiple_override=True,
         )
+
+        # In the lazy model, we need to trigger actual registration to create libraries
+        self.registry._register_all_overrides()
 
         # Remove by op_symbol should affect all backends for that op only
         self.registry.deregister_op_overrides(disable_op_symbols="mul.Tensor")
@@ -612,6 +675,9 @@ class TestRegistry(TestCase):
             allow_multiple_override=True,
         )
 
+        # In the lazy model, we need to trigger actual registration to create libraries
+        self.registry._register_all_overrides()
+
         # Remove by dispatch_key should affect all operations for CUDA only
         self.registry.deregister_op_overrides(disable_dispatch_keys="CUDA")
 
@@ -666,6 +732,9 @@ class TestRegistry(TestCase):
                         impl_fn,
                         allow_multiple_override=True,
                     )
+
+        # In the lazy model, we need to trigger actual registration to create libraries
+        self.registry._register_all_overrides()
 
         # Complex deregistration:
         # - Disable triton backend (affects all ops/dispatch_keys for triton)
@@ -732,6 +801,9 @@ class TestRegistry(TestCase):
                 impl2,
                 allow_multiple_override=True,
             )
+
+            # In the lazy model, we need to trigger actual registration to create libraries
+            self.registry._register_all_overrides()
 
             # Verify registry state
             key = (test_op, "CPU")
@@ -806,6 +878,9 @@ class TestRegistry(TestCase):
                     impl_fn,
                     allow_multiple_override=True,
                 )
+
+            # In the lazy model, we need to trigger actual registration to create libraries
+            self.registry._register_all_overrides()
 
             # Partial deregistration
             # Note: PyTorch may warn about kernel override (but only shows warning once per session)
@@ -1084,6 +1159,448 @@ class TestRegistry(TestCase):
 
         self.assertIs(filter_state_ref1, filter_state_ref2)
         self.assertIn("test_dsl", filter_state_ref2._dsl_names)
+
+    def test_reorder_graphs_basic_reordering(self):
+        """Test that user ordering function correctly reorders graphs."""
+
+        # Set up test nodes
+        def impl_fn1(x):
+            return x + 1
+
+        def impl_fn2(x):
+            return x + 2
+
+        def impl_fn3(x):
+            return x + 3
+
+        # Register multiple overrides for the same operation
+        key = ("test_reorder.Tensor", "CPU")
+        node1 = self.registry._OverrideNode(
+            "backend1", "test_reorder.Tensor", "CPU", impl_fn1
+        )
+        node2 = self.registry._OverrideNode(
+            "backend2", "test_reorder.Tensor", "CPU", impl_fn2
+        )
+        node3 = self.registry._OverrideNode(
+            "backend3", "test_reorder.Tensor", "CPU", impl_fn3
+        )
+
+        self.registry._graphs[key] = [node1, node2, node3]
+
+        # Define a reverse ordering function
+        def reverse_order(op_symbol, dispatch_key, graph):
+            return list(reversed(graph))
+
+        # Apply reordering (without reregistration)
+        self.registry.reorder_graphs_from_user_fn(reverse_order)
+
+        # Verify the graph was reordered
+        reordered_graph = self.registry._graphs[key]
+        self.assertEqual(len(reordered_graph), 3)
+        self.assertEqual(reordered_graph[0].dsl_name, "backend3")
+        self.assertEqual(reordered_graph[1].dsl_name, "backend2")
+        self.assertEqual(reordered_graph[2].dsl_name, "backend1")
+
+        # Clean up
+        self._cleanup_test_registration(key)
+
+    def test_reorder_graphs_no_reregistration_by_default(self):
+        """Test that reregister_overrides=False doesn't trigger lib.impl calls."""
+        # Set up test nodes with a mock library
+        with patch("torch.library.Library") as mock_library_cls:
+            mock_lib = MagicMock()
+            mock_library_cls.return_value = mock_lib
+
+            def impl_fn1(x):
+                return x + 1
+
+            def impl_fn2(x):
+                return x + 2
+
+            key = ("test_no_reregister.Tensor", "CPU")
+            node1 = self.registry._OverrideNode(
+                "backend1", "test_no_reregister.Tensor", "CPU", impl_fn1
+            )
+            node2 = self.registry._OverrideNode(
+                "backend2", "test_no_reregister.Tensor", "CPU", impl_fn2
+            )
+
+            # Set up initial state with existing library
+            self.registry._graphs[key] = [node1, node2]
+            self.registry._libs[key] = mock_lib
+
+            # Define ordering function that changes order
+            def reverse_order(op_symbol, dispatch_key, graph):
+                return list(reversed(graph))
+
+            # Apply reordering with default reregister_overrides=False
+            self.registry.reorder_graphs_from_user_fn(reverse_order)
+
+            # Verify no lib.impl calls were made (no re-registration)
+            mock_lib.impl.assert_not_called()
+
+            # Verify the graph was still reordered
+            reordered_graph = self.registry._graphs[key]
+            self.assertEqual(reordered_graph[0].dsl_name, "backend2")
+            self.assertEqual(reordered_graph[1].dsl_name, "backend1")
+
+            # Clean up
+            self._cleanup_test_registration(key)
+
+    @patch("torch.library.Library")
+    def test_reorder_graphs_with_reregistration(self, mock_library_cls):
+        """Test that reregister_overrides=True triggers re-registration for changed graphs."""
+        mock_old_lib = MagicMock()
+        mock_new_lib = MagicMock()
+        mock_library_cls.return_value = mock_new_lib
+
+        def impl_fn1(x):
+            return x + 1
+
+        def impl_fn2(x):
+            return x + 2
+
+        key = ("test_reregister.Tensor", "CPU")
+        node1 = self.registry._OverrideNode(
+            "backend1", "test_reregister.Tensor", "CPU", impl_fn1
+        )
+        node2 = self.registry._OverrideNode(
+            "backend2", "test_reregister.Tensor", "CPU", impl_fn2
+        )
+
+        # Set up initial state with existing library
+        self.registry._graphs[key] = [node1, node2]
+        self.registry._libs[key] = mock_old_lib
+
+        # Define ordering function that changes order
+        def reverse_order(op_symbol, dispatch_key, graph):
+            return list(reversed(graph))
+
+        # Apply reordering with reregister_overrides=True
+        self.registry.reorder_graphs_from_user_fn(
+            reverse_order, reregister_overrides=True
+        )
+
+        # Verify the old library was removed
+        self.assertNotEqual(self.registry._libs[key], mock_old_lib)
+        self.assertEqual(self.registry._libs[key], mock_new_lib)
+
+        # Verify re-registration occurred in new order
+        self.assertEqual(mock_new_lib.impl.call_count, 2)
+        # First call should be for backend2 (now first), second for backend1 (now second)
+        calls = mock_new_lib.impl.call_args_list
+        self.assertEqual(calls[0][0][1], impl_fn2)  # backend2's function
+        self.assertEqual(calls[1][0][1], impl_fn1)  # backend1's function
+
+        # Verify the graph was reordered
+        reordered_graph = self.registry._graphs[key]
+        self.assertEqual(reordered_graph[0].dsl_name, "backend2")
+        self.assertEqual(reordered_graph[1].dsl_name, "backend1")
+
+        # Clean up
+        self._cleanup_test_registration(key)
+
+    @patch("torch.library.Library")
+    def test_reorder_graphs_unchanged_graphs_no_reregistration(self, mock_library_cls):
+        """Test that unchanged graphs don't trigger unnecessary re-registration."""
+        mock_lib = MagicMock()
+        mock_library_cls.return_value = mock_lib
+
+        def impl_fn1(x):
+            return x + 1
+
+        def impl_fn2(x):
+            return x + 2
+
+        key = ("test_unchanged.Tensor", "CPU")
+        node1 = self.registry._OverrideNode(
+            "backend1", "test_unchanged.Tensor", "CPU", impl_fn1
+        )
+        node2 = self.registry._OverrideNode(
+            "backend2", "test_unchanged.Tensor", "CPU", impl_fn2
+        )
+
+        # Set up initial state
+        original_graph = [node1, node2]
+        self.registry._graphs[key] = original_graph
+        self.registry._libs[key] = mock_lib
+
+        # Define ordering function that doesn't change order
+        def no_change_order(op_symbol, dispatch_key, graph):
+            return graph  # Return same order
+
+        # Apply reordering with reregister_overrides=True
+        self.registry.reorder_graphs_from_user_fn(
+            no_change_order, reregister_overrides=True
+        )
+
+        # Verify the library wasn't replaced (no re-registration needed)
+        self.assertEqual(self.registry._libs[key], mock_lib)
+
+        # Verify no lib.impl calls were made
+        mock_lib.impl.assert_not_called()
+
+        # Clean up
+        self._cleanup_test_registration(key)
+
+    def test_reorder_graphs_by_dsl_name_alphabetical(self):
+        """Test ordering overrides by DSL name instead of registration order."""
+
+        # Set up test nodes with DSL names NOT in alphabetical order
+        def impl_fn_zebra(x):
+            return x + 100
+
+        def impl_fn_alpha(x):
+            return x + 200
+
+        def impl_fn_charlie(x):
+            return x + 300
+
+        key = ("test_alphabetical.Tensor", "CPU")
+        # Register in non-alphabetical order: zebra -> alpha -> charlie
+        node_zebra = self.registry._OverrideNode(
+            "zebra_backend", "test_alphabetical.Tensor", "CPU", impl_fn_zebra
+        )
+        node_alpha = self.registry._OverrideNode(
+            "alpha_backend", "test_alphabetical.Tensor", "CPU", impl_fn_alpha
+        )
+        node_charlie = self.registry._OverrideNode(
+            "charlie_backend", "test_alphabetical.Tensor", "CPU", impl_fn_charlie
+        )
+
+        self.registry._graphs[key] = [node_zebra, node_alpha, node_charlie]
+
+        # Define alphabetical ordering function by DSL name
+        def alphabetical_by_dsl(op_symbol, dispatch_key, graph):
+            return sorted(graph, key=lambda node: node.dsl_name)
+
+        # Apply alphabetical reordering
+        self.registry.reorder_graphs_from_user_fn(alphabetical_by_dsl)
+
+        # Verify the graph was reordered alphabetically
+        reordered_graph = self.registry._graphs[key]
+        self.assertEqual(len(reordered_graph), 3)
+        self.assertEqual(reordered_graph[0].dsl_name, "alpha_backend")
+        self.assertEqual(reordered_graph[1].dsl_name, "charlie_backend")
+        self.assertEqual(reordered_graph[2].dsl_name, "zebra_backend")
+
+        # Clean up
+        self._cleanup_test_registration(key)
+
+    @patch("torch.library.Library")
+    def test_reorder_graphs_by_dsl_name_with_reregistration(self, mock_library_cls):
+        """Test that alphabetical reordering with reregistration preserves the new order."""
+        mock_lib = MagicMock()
+        mock_library_cls.return_value = mock_lib
+
+        def impl_fn_zebra(x):
+            return x + 100
+
+        def impl_fn_alpha(x):
+            return x + 200
+
+        key = ("test_alpha_reregister.Tensor", "CPU")
+        # Register in reverse alphabetical order
+        node_zebra = self.registry._OverrideNode(
+            "zebra_backend", "test_alpha_reregister.Tensor", "CPU", impl_fn_zebra
+        )
+        node_alpha = self.registry._OverrideNode(
+            "alpha_backend", "test_alpha_reregister.Tensor", "CPU", impl_fn_alpha
+        )
+
+        self.registry._graphs[key] = [node_zebra, node_alpha]
+        self.registry._libs[key] = MagicMock()  # Existing library to be replaced
+
+        # Define alphabetical ordering function
+        def alphabetical_by_dsl(op_symbol, dispatch_key, graph):
+            return sorted(graph, key=lambda node: node.dsl_name)
+
+        # Apply reordering with reregistration
+        self.registry.reorder_graphs_from_user_fn(
+            alphabetical_by_dsl, reregister_overrides=True
+        )
+
+        # Verify re-registration occurred in alphabetical order
+        self.assertEqual(mock_lib.impl.call_count, 2)
+        calls = mock_lib.impl.call_args_list
+        # First call should be for alpha_backend (alphabetically first)
+        self.assertEqual(calls[0][0][1], impl_fn_alpha)
+        # Second call should be for zebra_backend (alphabetically second)
+        self.assertEqual(calls[1][0][1], impl_fn_zebra)
+
+        # Verify graph order is preserved
+        reordered_graph = self.registry._graphs[key]
+        self.assertEqual(reordered_graph[0].dsl_name, "alpha_backend")
+        self.assertEqual(reordered_graph[1].dsl_name, "zebra_backend")
+
+        # Clean up
+        self._cleanup_test_registration(key)
+
+    def test_reorder_graphs_selective_disabling_by_empty_list(self):
+        """Test selective disabling of op_symbol overrides by returning [] as the transformed graph."""
+
+        # Set up test nodes for multiple operations
+        def impl_fn_keep(x):
+            return x + 100
+
+        def impl_fn_disable1(x):
+            return x + 200
+
+        def impl_fn_disable2(x):
+            return x + 300
+
+        key_keep = ("keep_operation.Tensor", "CPU")
+        key_disable = ("disable_operation.Tensor", "CPU")
+
+        # Register overrides for operations we want to keep and disable
+        node_keep = self.registry._OverrideNode(
+            "test_backend", "keep_operation.Tensor", "CPU", impl_fn_keep
+        )
+        node_disable1 = self.registry._OverrideNode(
+            "backend1", "disable_operation.Tensor", "CPU", impl_fn_disable1
+        )
+        node_disable2 = self.registry._OverrideNode(
+            "backend2", "disable_operation.Tensor", "CPU", impl_fn_disable2
+        )
+
+        self.registry._graphs[key_keep] = [node_keep]
+        self.registry._graphs[key_disable] = [node_disable1, node_disable2]
+
+        # Define selective disabling function - return [] for "disable_operation"
+        def selective_disable(op_symbol, dispatch_key, graph):
+            if op_symbol == "disable_operation.Tensor":
+                return []  # Disable this operation entirely
+            return graph  # Keep other operations as-is
+
+        # Apply selective disabling
+        self.registry.reorder_graphs_from_user_fn(selective_disable)
+
+        # Verify the disable operation has empty graph
+        disabled_graph = self.registry._graphs[key_disable]
+        self.assertEqual(len(disabled_graph), 0)
+        self.assertEqual(disabled_graph, [])
+
+        # Verify the keep operation is unchanged
+        kept_graph = self.registry._graphs[key_keep]
+        self.assertEqual(len(kept_graph), 1)
+        self.assertEqual(kept_graph[0].dsl_name, "test_backend")
+
+        # Clean up
+        self._cleanup_test_registration(key_keep)
+        self._cleanup_test_registration(key_disable)
+
+    @patch("torch.library.Library")
+    def test_reorder_graphs_selective_disabling_with_reregistration(
+        self, mock_library_cls
+    ):
+        """Test that selective disabling with reregistration handles empty graphs correctly."""
+        mock_lib_disable = MagicMock()
+        mock_library_cls.return_value = mock_lib_disable
+
+        def impl_fn_keep(x):
+            return x + 100
+
+        def impl_fn_disable(x):
+            return x + 200
+
+        key_keep = ("keep_reregister.Tensor", "CPU")
+        key_disable = ("disable_reregister.Tensor", "CPU")
+
+        # Set up initial state with existing libraries
+        node_keep = self.registry._OverrideNode(
+            "test_backend", "keep_reregister.Tensor", "CPU", impl_fn_keep
+        )
+        node_disable = self.registry._OverrideNode(
+            "test_backend", "disable_reregister.Tensor", "CPU", impl_fn_disable
+        )
+
+        self.registry._graphs[key_keep] = [node_keep]
+        self.registry._graphs[key_disable] = [node_disable]
+        self.registry._libs[key_keep] = MagicMock()
+        self.registry._libs[key_disable] = MagicMock()
+
+        # Define selective disabling function
+        def selective_disable(op_symbol, dispatch_key, graph):
+            if op_symbol == "disable_reregister.Tensor":
+                return []  # Disable this operation (graph changes)
+            return graph  # Keep others unchanged (no graph change)
+
+        # Apply selective disabling with reregistration
+        self.registry.reorder_graphs_from_user_fn(
+            selective_disable, reregister_overrides=True
+        )
+
+        # Verify the disabled operation: library should be completely removed (no library for empty graphs)
+        self.assertNotIn(
+            key_disable, self.registry._libs
+        )  # No library should exist for disabled operations
+        mock_lib_disable.impl.assert_not_called()  # And no implementations registered
+
+        # Verify the kept operation: since graph didn't change, library wasn't replaced
+        # The original mock library should still be there (not the new mock)
+        self.assertIn(key_keep, self.registry._libs)
+        self.assertNotEqual(
+            self.registry._libs[key_keep], mock_lib_disable
+        )  # Should be the original library
+
+        # Verify graph states
+        self.assertEqual(len(self.registry._graphs[key_disable]), 0)  # Empty (disabled)
+        self.assertEqual(len(self.registry._graphs[key_keep]), 1)  # Unchanged (kept)
+
+        # Clean up
+        self._cleanup_test_registration(key_keep)
+        self._cleanup_test_registration(key_disable)
+
+    def test_reorder_graphs_priority_based_ordering(self):
+        """Test priority-based ordering where certain DSLs have higher priority."""
+
+        # Set up test nodes with mixed priority backends
+        def impl_fn_triton(x):
+            return x + 100
+
+        def impl_fn_cutedsl(x):
+            return x + 200
+
+        def impl_fn_fallback(x):
+            return x + 300
+
+        key = ("test_priority.Tensor", "CPU")
+        # Register in random order
+        node_fallback = self.registry._OverrideNode(
+            "fallback_backend", "test_priority.Tensor", "CPU", impl_fn_fallback
+        )
+        node_triton = self.registry._OverrideNode(
+            "triton", "test_priority.Tensor", "CPU", impl_fn_triton
+        )
+        node_cutedsl = self.registry._OverrideNode(
+            "cutedsl", "test_priority.Tensor", "CPU", impl_fn_cutedsl
+        )
+
+        self.registry._graphs[key] = [node_fallback, node_triton, node_cutedsl]
+
+        # Define priority ordering: triton > cutedsl > others (alphabetical)
+        def priority_order(op_symbol, dispatch_key, graph):
+            priority_map = {"triton": 0, "cutedsl": 1}
+
+            def get_priority(node):
+                return (priority_map.get(node.dsl_name, 999), node.dsl_name)
+
+            return sorted(graph, key=get_priority)
+
+        # Apply priority-based reordering
+        self.registry.reorder_graphs_from_user_fn(priority_order)
+
+        # Verify the graph was reordered by priority
+        reordered_graph = self.registry._graphs[key]
+        self.assertEqual(len(reordered_graph), 3)
+        self.assertEqual(reordered_graph[0].dsl_name, "triton")  # Highest priority
+        self.assertEqual(reordered_graph[1].dsl_name, "cutedsl")  # Second priority
+        self.assertEqual(
+            reordered_graph[2].dsl_name, "fallback_backend"
+        )  # Lowest priority (fallback)
+
+        # Clean up
+        self._cleanup_test_registration(key)
 
     def _cleanup_test_registration(self, key):
         """Helper method to clean up test registrations."""

--- a/torch/_native/README.md
+++ b/torch/_native/README.md
@@ -180,3 +180,55 @@ Register a given implementation to a library - `lib_symbol = "aten"` for most ca
 `deregister_op_overrides() -> None` : De-register all operators that are currently registered by this DSL. Note that `torch._native.registry` has a `deregister_op_overrides` method to enable this in a centralized fashion.
 
 An example of an implementation of this spec can be found in [cutedsl_utils.py](cutedsl_utils.py), but please talk to us if you're planning on adding a new DSL.
+
+## Registration Orders and You
+
+Currently the registration order (both in general and per-op) is set by the order of imports in `torch/_native/ops/__init__.py`, noting that registration acts as a stack, in that **the last registered override for an op is the first that will be called**. If you wish to exercise control of the override ordering, please utilize one of the methods below.
+
+### User-Ordering Functions
+
+We allow for user-defined ordering functions of the form:
+
+```
+from torch._native.registry import _OverrideNode
+
+def ordering_fn(
+    op_symbol: str,
+    dispatch_key: str,
+    graph: list[_OverrideNode],
+) -> list[_OverrideNode]
+```
+
+In other words, a function that takes some context and a graph describing the override order, and returning a modified graph.
+
+This can used by either setting the environment variable `TORCH_PYTHON_NATIVE_USER_GRAPH_ORDER_FN` to an importable python function with the above signature, or by adding the following to your top-level script, post `import torch`:
+
+```
+torch._native.reorder_graphs_from_user_function(
+    my_ordering_fn,
+    reregister_overrides=True,
+)
+```
+
+Both methods are equivalent in functionality, but the environment-variable version is a little more efficient in that torch doesn't have to register **all** ops, before disabling/re-registering again based on the user-passed function.
+
+**NOTE**: The passed ordering function can be destructive in nature - one can disable an op completely by returning `[]` for a given graph, indicating that no overrides exist / are allowed. **There is currently no supported way to retrieve the original graphs - they are considered gone for the lifetime of the process**.
+
+An example user-ordering function is demonstrated below:
+
+```
+def example_ordering_fn(op_symbol, dispatch_key, nodes):
+    out_nodes = []
+
+    # disable overrides for these symbols completely
+    if op_symbol in ["_scaled_mm_v2", "add"]:
+         return []
+
+    # Only keep triton overrides otherwise
+    for node in nodes:
+        if node.dsl_name != 'triton':
+            continue
+        out_nodes.append(node)
+
+    return out_nodes
+```

--- a/torch/_native/__init__.py
+++ b/torch/_native/__init__.py
@@ -1,2 +1,41 @@
+import os
+from functools import cache
+from typing import cast
+
 # This handles collecting registration of all native ops
-from . import ops
+from . import ops, registry
+
+
+@cache
+def get_user_ordering_fn() -> registry.UserOrderingFn | None:
+    env_var = os.getenv("TORCH_PYTHON_NATIVE_USER_GRAPH_ORDER_FN")
+
+    if not env_var:
+        return None
+
+    try:
+        import importlib
+
+        module_name, fn_name = env_var.split(".", 1)
+
+        module = importlib.import_module(module_name)
+        fn = getattr(module, fn_name)
+
+        if not callable(fn):
+            raise TypeError(f"{env_var} does not describe a callable function")
+
+        # Cast needed: getattr returns object, but we've verified fn is callable with correct signature
+        return cast(registry.UserOrderingFn, fn)
+    except Exception as e:
+        raise ValueError(
+            f"Could not resolve {env_var} into an importable & callable function"
+        ) from e
+
+
+user_order_fn = get_user_ordering_fn()
+if user_order_fn:
+    registry.reorder_graphs_from_user_fn(user_order_fn)
+
+
+# Actually perform all registrations
+registry._register_all_overrides()

--- a/torch/_native/registry.py
+++ b/torch/_native/registry.py
@@ -31,6 +31,9 @@ class _OverrideNode:
     active: bool = True
 
 
+UserOrderingFn = Callable[[str, str, list[_OverrideNode]], list[_OverrideNode]]
+
+
 @dataclass
 class _FilterState:
     _dsl_names: set[str] = field(default_factory=set)
@@ -166,6 +169,19 @@ def _get_or_create_library(op_symbol: str, dispatch_key: str) -> torch.library.L
     return _libs[key]
 
 
+def _register_node_impl(
+    lib: torch.library.Library, node: _OverrideNode, dispatch_key: str
+) -> None:
+    """Helper function to register a single node implementation with proper parameters."""
+    lib.impl(
+        node.op_symbol,
+        node.override_fn,
+        dispatch_key,
+        with_keyset=not node.unconditional_override,
+        allow_override=True,
+    )
+
+
 def _resolve_iterable(iterable: str | Iterable[str] | None) -> Iterable[str]:
     if iterable is None:
         return []
@@ -174,37 +190,6 @@ def _resolve_iterable(iterable: str | Iterable[str] | None) -> Iterable[str]:
         return (iterable,)
 
     return iterable
-
-
-def _filter(
-    dsl_name: str,
-    op_symbol: str,
-    dispatch_key: str,
-    filter_dsl_names: str | Iterable[str] | None = None,
-    filter_op_symbols: str | Iterable[str] | None = None,
-    filter_dispatch_keys: str | Iterable[str] | None = None,
-) -> bool:
-    if (
-        (not filter_dsl_names)
-        and (not filter_op_symbols)
-        and (not filter_dispatch_keys)
-    ):
-        raise ValueError("Must pass 1+ of filter_{dsl_names,op_symbols,dispatch_keys}")
-
-    _filter_dsl_names = _resolve_iterable(filter_dsl_names)
-    _filter_op_symbols = _resolve_iterable(filter_op_symbols)
-    _filter_dispatch_keys = _resolve_iterable(filter_dispatch_keys)
-
-    if dsl_name in _filter_dsl_names:
-        return True
-
-    if op_symbol in _filter_op_symbols:
-        return True
-
-    if dispatch_key in _filter_dispatch_keys:
-        return True
-
-    return False
 
 
 def reenable_op_overrides(
@@ -240,24 +225,9 @@ def reenable_op_overrides(
 
     for key in key_set:
         op_symbol, dispatch_key = key
-
-        # get the appropriate graph
-        lib = _get_or_create_library(*key)
-
-        # Re-register
-        for node in _graphs[key]:
-            node_enabled = _filter_state.check_enabled(node)
-            if node_enabled:
-                lib.impl(
-                    op_symbol,
-                    node.override_fn,
-                    dispatch_key,
-                    with_keyset=not node.unconditional_override,
-                    allow_override=True,
-                )
-                node.active = True
-            else:
-                node.active = False
+        _register_overrides_from_graph(
+            op_symbol, dispatch_key, _graphs[key], filter_state=_filter_state
+        )
 
 
 def deregister_op_overrides(
@@ -292,25 +262,16 @@ def deregister_op_overrides(
 
     for key in key_set:
         op_symbol, dispatch_key = key
-        # Remove the old graph
-        del _libs[key]
-        # create a new graph
-        lib = _get_or_create_library(*key)
+        # Remove the old library if it exists (lazy registration may not have created it yet)
+        if key in _libs:
+            del _libs[key]
 
-        # Re-register
-        for node in _graphs[key]:
-            node_enabled = _filter_state.check_enabled(node)
-            if node_enabled:
-                lib.impl(
-                    op_symbol,
-                    node.override_fn,
-                    dispatch_key,
-                    with_keyset=not node.unconditional_override,
-                    allow_override=True,
-                )
-                node.active = True
-            else:
-                node.active = False
+        _register_overrides_from_graph(
+            op_symbol,
+            dispatch_key,
+            _graphs[key],
+            filter_state=_filter_state,
+        )
 
 
 def _update_registration_maps(
@@ -353,7 +314,10 @@ def register_op_override(
     Register a passed override function to the dispatcher, based on the
     passed lib and op symbols, and the dispatch key.
 
-    lib_symbol: str - library you're overriding symbols in (generally "aten")
+    Actually a just graph-building op, will perform the real registration
+    in a later step (still user-invisible).
+
+    lib_symbol: str - library yourve overriding symbols in (generally "aten")
     op_symbol: str - name of the op you're overriding
     dispatch_key: str - dispatch key to override
     impl: Fn - implementation for the override
@@ -361,8 +325,10 @@ def register_op_override(
     unconditional_override: bool - Impl doesn't have a fallback, and doesn't require
                                    torch.DispatchKeySet as the first argument.
     """
+    if lib_symbol != "aten":
+        raise ValueError(f'Unsupported lib_symbol (must be "aten", got: "{lib_symbol}"')
+
     key = (op_symbol, dispatch_key)
-    lib = _get_or_create_library(*key)
 
     global _graphs
     op_graph = _graphs.get(key, [])
@@ -380,10 +346,74 @@ def register_op_override(
     # Build additional maps helpful for de-registration
     _update_registration_maps(backend, op_symbol, dispatch_key, key=key)
 
-    lib.impl(
-        op_symbol,
-        impl,
-        dispatch_key,
-        with_keyset=(not unconditional_override),
-        allow_override=allow_multiple_override,
-    )
+
+def _register_overrides_from_graph(
+    op_symbol: str,
+    dispatch_key: str,
+    graph: list[_OverrideNode],
+    *,
+    filter_state: _FilterState | None = None,
+) -> None:
+    """
+    Register all overrides in a single graph
+    """
+    key = (op_symbol, dispatch_key)
+    lib = _get_or_create_library(*key)
+
+    for node in graph:
+        enable = True
+        if filter_state:
+            enable = filter_state.check_enabled(node)
+
+        if enable:
+            _register_node_impl(lib, node, dispatch_key)
+            node.active = True
+        else:
+            node.active = False
+
+
+def _register_all_overrides() -> None:
+    """
+    Perform all registration calls from previously-built
+    override graphs
+    """
+    for key, graph in _graphs.items():
+        op_symbol, dispatch_key = key
+
+        _register_overrides_from_graph(
+            op_symbol,
+            dispatch_key,
+            graph,
+        )
+
+
+def reorder_graphs_from_user_fn(
+    fn: UserOrderingFn,
+    *,
+    reregister_overrides: bool = False,
+) -> None:
+    global _graphs
+    global _libs
+
+    for (op_symbol, dispatch_key), graph in _graphs.items():
+        # Update the ordering of each graph
+        _graphs[(op_symbol, dispatch_key)] = fn(op_symbol, dispatch_key, graph)
+
+        # if we don't need to register things, don't.
+        if not reregister_overrides:
+            continue
+
+        # If a graph has been modified
+        if graph != _graphs[(op_symbol, dispatch_key)]:
+            # if a lib already exists
+            if (op_symbol, dispatch_key) in _libs:
+                del _libs[(op_symbol, dispatch_key)]
+
+            # Only create a library if the new graph has nodes
+            # Empty graphs (disabled operations) shouldn't get libraries
+            if _graphs[(op_symbol, dispatch_key)]:
+                _register_overrides_from_graph(
+                    op_symbol,
+                    dispatch_key,
+                    _graphs[(op_symbol, dispatch_key)],
+                )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #176284
* #176283
* #176892
* #178518
* #178381
* __->__ #178635

Status:

Follow up nit-fixes from #177550

Test Plan:

```
pytest -sv test/python_native
```

Signed-off-by: Simon Layton <simonlayton@meta.com>