### PR TITLE
[Native DSLs] Post De-Registration Nits

### DIFF
--- a/test/python_native/test_registry.py
+++ b/test/python_native/test_registry.py
@@ -149,34 +149,6 @@ class TestRegistry(TestCase):
                 result = list(self.registry._resolve_iterable(input_val))
                 self.assertEqual(result, expected)
 
-    def test_filter_functionality(self):
-        """Test _filter function with various filter criteria."""
-        # Test no filters raises error
-        with self.assertRaises(ValueError) as cm:
-            self.registry._filter("dsl", "op", "key")
-        self.assertIn("Must pass 1+ of filter_", str(cm.exception))
-
-        # Test different filter types
-        filter_test_cases = [
-            ("dsl_names", "test_dsl", "op", "key", "test_dsl", True),
-            ("dsl_names", "test_dsl", "op", "key", ["test_dsl", "other"], True),
-            ("dsl_names", "test_dsl", "op", "key", "other_dsl", False),
-            ("op_symbols", "dsl", "test_op", "key", "test_op", True),
-            ("op_symbols", "dsl", "test_op", "key", ["test_op", "other"], True),
-            ("op_symbols", "dsl", "test_op", "key", "other_op", False),
-            ("dispatch_keys", "dsl", "op", "test_key", "test_key", True),
-            ("dispatch_keys", "dsl", "op", "test_key", ["test_key", "other"], True),
-            ("dispatch_keys", "dsl", "op", "test_key", "other_key", False),
-        ]
-
-        for filter_type, dsl, op, key, filter_val, expected in filter_test_cases:
-            with self.subTest(
-                filter_type=filter_type, filter_val=filter_val, expected=expected
-            ):
-                kwargs = {f"filter_{filter_type}": filter_val}
-                result = self.registry._filter(dsl, op, key, **kwargs)
-                self.assertEqual(result, expected)
-
     def test_update_registration_maps(self):
         """Test _update_registration_maps updates all mapping dictionaries."""
         key = ("test_op", "CPU")

--- a/torch/_native/registry.py
+++ b/torch/_native/registry.py
@@ -176,37 +176,6 @@ def _resolve_iterable(iterable: str | Iterable[str] | None) -> Iterable[str]:
     return iterable
 
 
-def _filter(
-    dsl_name: str,
-    op_symbol: str,
-    dispatch_key: str,
-    filter_dsl_names: str | Iterable[str] | None = None,
-    filter_op_symbols: str | Iterable[str] | None = None,
-    filter_dispatch_keys: str | Iterable[str] | None = None,
-) -> bool:
-    if (
-        (not filter_dsl_names)
-        and (not filter_op_symbols)
-        and (not filter_dispatch_keys)
-    ):
-        raise ValueError("Must pass 1+ of filter_{dsl_names,op_symbols,dispatch_keys}")
-
-    _filter_dsl_names = _resolve_iterable(filter_dsl_names)
-    _filter_op_symbols = _resolve_iterable(filter_op_symbols)
-    _filter_dispatch_keys = _resolve_iterable(filter_dispatch_keys)
-
-    if dsl_name in _filter_dsl_names:
-        return True
-
-    if op_symbol in _filter_op_symbols:
-        return True
-
-    if dispatch_key in _filter_dispatch_keys:
-        return True
-
-    return False
-
-
 def reenable_op_overrides(
     *,
     enable_dsl_names: str | list[str] | None = None,
@@ -361,6 +330,9 @@ def register_op_override(
     unconditional_override: bool - Impl doesn't have a fallback, and doesn't require
                                    torch.DispatchKeySet as the first argument.
     """
+    if lib_symbol != "aten":
+        raise ValueError(f'Unsupported lib_symbol (must be "aten", got: "{lib_symbol}"')
+
     key = (op_symbol, dispatch_key)
     lib = _get_or_create_library(*key)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #176284
* #176283
* #176892
* #178518
* #178381
* #178637
* __->__ #178636

Summary:

Fix follow-up nits from #177550

Test Plan:

```
pytest -sv test/python_native
```

Signed-off-by: Simon Layton <simonlayton@meta.com>