### PR TITLE
[lumen] Add CommitResolver for PR detection and safety checks

### DIFF
--- a/.ci/lumen_cli/cli/lib/pytorch/git_utils.py
+++ b/.ci/lumen_cli/cli/lib/pytorch/git_utils.py
@@ -1,0 +1,110 @@
+"""Git and PR utilities for remote execution."""
+
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+
+logger = logging.getLogger(__name__)
+
+
+class CommitResolver:
+    """Resolve commit SHA and repo URL for RE submission.
+
+    Safety checks: blocks if workdir is dirty or local HEAD
+    doesn't match remote PR HEAD.
+    """
+
+    def __init__(self, repo: str) -> None:
+        self.repo = repo
+
+    def resolve(self, pr: int | None = None, commit: str | None = None) -> dict:
+        """Return {"sha": ..., "repo": ...} for RE submission."""
+        if commit:
+            return {"sha": commit, "repo": self.repo}
+
+        self.check_clean_workdir()
+
+        if pr is None:
+            pr = self.detect_pr()
+            logger.info("Auto-detected PR #%d from current branch", pr)
+
+        info = self.pr_info(pr)
+        local_sha = self.local_head()
+        if local_sha != info["sha"]:
+            raise RuntimeError(
+                f"Local HEAD ({local_sha[:12]}) does not match "
+                f"PR #{pr} HEAD ({info['sha'][:12]}). "
+                "Push your changes before running RE."
+            )
+
+        logger.info("PR #%d -> %s (%s)", pr, info["sha"][:12], info["repo"])
+        return {"sha": info["sha"], "repo": info["repo"]}
+
+    def pr_info(self, pr: int) -> dict:
+        """Get commit SHA and repo URL from a PR number."""
+        out = subprocess.run(
+            [
+                "gh", "pr", "view", str(pr),
+                "--repo", self.repo.replace("https://github.com/", "").replace(".git", ""),
+                "--json", "headRefOid,headRefName,headRepository,headRepositoryOwner",
+            ],
+            capture_output=True, text=True, check=True,
+        )
+        data = json.loads(out.stdout)
+        owner = data["headRepositoryOwner"]["login"]
+        repo_name = data["headRepository"]["name"]
+        return {
+            "sha": data["headRefOid"],
+            "branch": data["headRefName"],
+            "repo": f"https://github.com/{owner}/{repo_name}.git",
+        }
+
+    def detect_pr(self) -> int:
+        """Detect PR number from the current branch."""
+        branch = subprocess.run(
+            ["git", "branch", "--show-current"],
+            capture_output=True, text=True, check=True,
+        ).stdout.strip()
+        out = subprocess.run(
+            [
+                "gh", "pr", "list",
+                "--repo", self.repo.replace("https://github.com/", "").replace(".git", ""),
+                "--head", branch,
+                "--json", "number",
+            ],
+            capture_output=True, text=True,
+        )
+        if out.returncode != 0:
+            raise RuntimeError(
+                "No PR found for current branch. "
+                "Push your branch and open a PR first, or pass --pr explicitly."
+            )
+        prs = json.loads(out.stdout)
+        if not prs:
+            raise RuntimeError(
+                f"No open PR found for branch '{branch}'. "
+                "Push your branch and open a PR first, or pass --pr explicitly."
+            )
+        return prs[0]["number"]
+
+    def local_head(self) -> str:
+        """Get local HEAD commit SHA."""
+        out = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            capture_output=True, text=True, check=True,
+        )
+        return out.stdout.strip()
+
+    def check_clean_workdir(self) -> None:
+        """Ensure no uncommitted changes exist."""
+        out = subprocess.run(
+            ["git", "status", "--porcelain"],
+            capture_output=True, text=True, check=True,
+        )
+        if out.stdout.strip():
+            raise RuntimeError(
+                "You have uncommitted local changes. "
+                "Commit or stash them before running RE."
+            )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #178643
* __->__ #178640
* #178633
* #178627
* #178626

Add git_utils.py with CommitResolver class that auto-detect remote PR info
from current branch, 

block reuser to execute re when they don't have clean remote pr. Mainly for demo, in the future, we should support patch local changes.

Add git_utils.py with CommitResolver class that auto-detect remote PR info
from current branch,  

verifies clean workdir and local HEAD matches remote PR HEAD. Takes repo URL as input so it's reusable across
different repositories.

