### PR TITLE
[lumen] Add submit_command and lumen re CLI

### DIFF
--- a/.ci/lumen_cli/cli/lib/pytorch/re_runner.py
+++ b/.ci/lumen_cli/cli/lib/pytorch/re_runner.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
+from re_cli.core.core_types import StepConfig
+from re_cli.core.job_runner import JobRunner
+from re_cli.core.k8s_client import K8sClient, K8sConfig
 from re_cli.core.script_builder import RunnerScriptBuilder
+
+from cli.lib.pytorch.git_utils import CommitResolver
 
 
 logger = logging.getLogger(__name__)
@@ -54,3 +59,94 @@ class LumenScriptBuilder(RunnerScriptBuilder):
             "uv pip install -e .ci/lumen_cli"
         )
         return self
+
+
+REPO = "https://github.com/pytorch/pytorch.git"
+
+
+def submit_command(
+    command: str,
+    name: str = "re-run",
+    pr: int | None = None,
+    commit: str | None = None,
+    dry_run: bool = False,
+    no_follow: bool = False,
+    image: str = DEFAULT_IMAGE,
+    bootstrap: list[str] | None = None,
+) -> None:
+    """Submit a command to Remote Execution."""
+    if bootstrap is None:
+        bootstrap = list(DEFAULT_BOOTSTRAP)
+
+    modules_list = (
+        ["header", "find_script", "git_clone", "git_checkout"]
+        + bootstrap
+        + ["run_script", "upload_outputs"]
+    )
+    seen: set[str] = set()
+    modules = [m for m in modules_list if not (m in seen or seen.add(m))]
+
+    step = StepConfig(
+        name=name,
+        command=command,
+        task_type="cpu-large",
+        image=image,
+        runner_modules=modules,
+        env_vars={},
+    )
+
+    resolver = CommitResolver(REPO)
+    resolved = resolver.resolve(pr, commit)
+
+    client = K8sClient(K8sConfig(namespace="remote-execution-system", timeout=60))
+    runner = JobRunner(
+        client=client,
+        name=name,
+        step_configs=[step],
+        script_builder_class=LumenScriptBuilder,
+    )
+    runner.run(
+        commit=resolved["sha"],
+        repo=resolved["repo"],
+        follow=not no_follow,
+        dry_run=dry_run,
+    )
+    if runner.run_id:
+        print(f"\nRun ID: {runner.run_id}")
+        print(f"Stream:  blast stream {runner.run_id}")
+
+
+# ---------------------------------------------------------------------------
+# CLI registration
+# ---------------------------------------------------------------------------
+
+
+def _run_re(args) -> None:
+    submit_command(
+        command=args.command,
+        pr=getattr(args, "pr", None),
+        commit=getattr(args, "commit", None),
+        dry_run=getattr(args, "dry_run", False),
+        no_follow=getattr(args, "no_follow", False),
+    )
+
+
+def register_re_commands(subparsers) -> None:
+    """Register `lumen re` subcommand."""
+    import argparse
+
+    parser = subparsers.add_parser(
+        "re",
+        help="Submit a command to Remote Execution",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--command",
+        required=True,
+        help="command to run remotely, e.g. 'echo hello'",
+    )
+    parser.add_argument("--pr", type=int, help="PR number (auto-detected if omitted)")
+    parser.add_argument("--commit", help="commit SHA (skips PR detection)")
+    parser.add_argument("--dry-run", action="store_true", default=False)
+    parser.add_argument("--no-follow", action="store_true", default=False)
+    parser.set_defaults(func=_run_re)

--- a/.ci/lumen_cli/cli/run.py
+++ b/.ci/lumen_cli/cli/run.py
@@ -5,6 +5,7 @@ import logging
 
 from cli.build_cli.register_build import register_build_commands
 from cli.lib.common.logger import setup_logging
+from cli.lib.pytorch.re_runner import register_re_commands
 from cli.test_cli.register_test import register_test_commands
 
 
@@ -22,6 +23,7 @@ def main():
     # registers second-level subcommands
     register_build_commands(subparsers)
     register_test_commands(subparsers)
+    register_re_commands(subparsers)
 
     # parse args after all options are registered
     args = parser.parse_args()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #178643
* #178640
* #178633
* #178627
* #178626

Add `submit_command()` which wires together `CommitResolver`, `LumenScriptBuilder`,
and `JobRunner` to submit arbitrary commands to Remote Execution infrastructure.

Register `lumen re --command "echo hello"` CLI entry point with `--pr`, `--commit`,
`--dry-run`, and `--no-follow` options.

Authored with Claude.