### PR TITLE
[CUDA] [PERFORMANCE] Improve performance for `RowwiseScaledMM.cu` by avoiding redundant IO/compute via indicating that `ElementC` type is void

### DIFF
--- a/aten/src/ATen/native/cuda/RowwiseScaledMM.cu
+++ b/aten/src/ATen/native/cuda/RowwiseScaledMM.cu
@@ -198,7 +198,7 @@ void f8f8bf16_rowwise_impl(
           cutlass::epilogue::collective::EpilogueTileAuto,
           DtypeAccum,
           DtypeEpilogue,
-          DtypeOutput,
+          void, // Indicate there is no beta scaling to save register
           LayoutOutput,
           AlignmentOutput,
           DtypeOutput,
@@ -255,7 +255,7 @@ void f8f8bf16_rowwise_impl(
                            : nullptr},
          {{reinterpret_cast<DtypeScale*>(w_scale.data_ptr())},
           {{reinterpret_cast<DtypeScale*>(x_scale.data_ptr())}}}}},
-       reinterpret_cast<DtypeOutput*>(out.data_ptr()),
+       nullptr,
        stride_output,
        reinterpret_cast<DtypeOutput*>(out.data_ptr()),
        stride_output}};
@@ -390,7 +390,7 @@ void f8f8bf16_rowwise_impl_sm100_sm120(
       TileShape, ClusterShape,
       cutlass::epilogue::collective::EpilogueTileAuto,
       DtypeAccum, DtypeEpilogue,
-      DtypeOutput, LayoutOutput, AlignmentOutput,
+      void, LayoutOutput, AlignmentOutput,
       DtypeOutput, LayoutOutput, AlignmentOutput,
       EpilogueScheduleType,
       EpilogueEVT>::CollectiveOp;
@@ -448,7 +448,7 @@ void f8f8bf16_rowwise_impl_sm100_sm120(
                            : nullptr},
          {{reinterpret_cast<DtypeScale*>(w_scale.data_ptr())},
           {{reinterpret_cast<DtypeScale*>(x_scale.data_ptr())}}}}},
-       reinterpret_cast<DtypeOutput*>(out.data_ptr()),
+       nullptr,
        stride_output,
        reinterpret_cast<DtypeOutput*>(out.data_ptr()),
        stride_output}};


### PR DESCRIPTION
This pull request is a follow-up for #178325 and features #170802 by @malfet (credits to you for the nice improvement 👍) and (probably (I could not test it because I don't have a cuda device, but it's basically the same like in #170802, so I'm pretty sure that this also brings some profits to performance (and also I'm pretty sure from looking at the code))) speeds up `RowwiseScaledGroupMM.cu` by (probably) around 5% (see #170802 (1237 to 1313 TFlops for `GroupMM.cu` and `RowwiseScaledMM.cu` should in my opinion (but please correct me if I'm mistaken) be around this in some range)).

The changed parts (before the change to `GroupMM.cu` which `RowwiseScaledMM.cu` was missing) are quite similar for both scripts (except for some differences (**attention**, in this case we got other differences to `GroupMM.cu` than we got in the other PR #178325 to `ScaledGroupMM.cu`, but I think that these are irrelevant for the change (IMO) (like e.g. in `GroupMM.cu` and in `ScaledGroupMM.cu` we got `DtypeAccum `two times before `DtypeOutput`, but this should in my opinion only be a name thing (but there may be any other relevant differences as well which I maybe didn't see (or maybe this is not only a name thing and I made a mistake here, so please correct me if I'm mistaken (and another **important** things is that in `RowwiseScaledMM.cu` I found those parts to change two times (and also **important** there are several different differences as well which I didn't mention explicitly, so please have a look at the code because it would be way to long to describe all, but I think that this is probably correct nevertheless) (the two changes two times, so four times) and in `GroupMM.cu` and in `ScaledGroupMM.cu` I found each two changes only one time each (so in total four changes for both `GroupMM.cu` and in `ScaledGroupMM.cu`, but also four in only `RowwiseScaledMM.cu` which is quite different))))), but please correct me if I'm mistaken)), but I'm still pretty confident that this should behave the same and be correct, so the change should be fine in my opinion (while I couldn't test it because I don't have a cuda device)).

Contributed by **Benedikt Johannes**

cc @jerryzh168