### PR TITLE
[c10d] [PERFORMANCE] Improve performance for `AsyncMM.cu` by avoiding redundant IO/compute via indicating that `ElementC` type is void

### DIFF
--- a/torch/csrc/distributed/c10d/cuda/AsyncMM.cu
+++ b/torch/csrc/distributed/c10d/cuda/AsyncMM.cu
@@ -79,7 +79,7 @@ at::Tensor async_input_mm_impl(
           cutlass::epilogue::collective::EpilogueTileAuto,
           ElementAccumulator,
           ElementAccumulator,
-          ElementC,
+          void, // Indicate there is no beta scaling to save register
           LayoutC,
           AlignmentC,
           ElementC,
@@ -151,7 +151,7 @@ at::Tensor async_input_mm_impl(
           stride_B,
       },
       {{},
-       reinterpret_cast<ElementC*>(out.data_ptr<at::BFloat16>()),
+       nullptr,
        stride_C,
        reinterpret_cast<ElementC*>(out.data_ptr<at::BFloat16>()),
        stride_C},


### PR DESCRIPTION
This pull request is a follow-up for #178325 and #178644 and features #170802 by @malfet (credits to you for the nice improvement 👍) and (probably (I could not test it because I don't have a cuda device, but it's basically the same like in #170802, so I'm pretty sure that this also brings some profits to performance (and also I'm pretty sure from looking at the code))) speeds up `AsyncMM.cu` in `c10d` by (probably) around 5% (see #170802 (1237 to 1313 TFlops for `GroupMM.cu` and `RowwiseScaledGroupMM.cu` should in my opinion (but please correct me if I'm mistaken) be around this in some range)).

The changed parts (before the change to `GroupMM.cu` which `AsyncMM.cu` was missing) are quite similar for both scripts (except for some differences (**attention**, in this case we got other differences to `GroupMM.cu` than we got in the other PR #178325 to `ScaledGroupMM.cu`, but I think that these are irrelevant for the change (IMO), but please correct me if I'm mistaken), but I'm still pretty confident that this should behave the same and be correct, so the change should be fine in my opinion (while I couldn't test it because I don't have a cuda device)).

Contributed by **Benedikt Johannes**

cc @jerryzh168