### PR TITLE
[Inductor] Fix sym_sum lowering to accept varargs

### DIFF
--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -7701,7 +7701,11 @@ for method, func in magic_methods.items():
 
 
 @register_lowering(torch.sym_sum)
-def sym_sum(args):
+def sym_sum(*args):
+    # sym_sum can be called as sym_sum([a, b]) or sym_sum(a, b).
+    # Normalize to a flat list before summing.
+    if len(args) == 1 and isinstance(args[0], (list, tuple)):
+        args = args[0]
     return sympy.Add(*args)
 
 


### PR DESCRIPTION
Summary:
## Summary

The Inductor lowering for `torch.sym_sum` was registered as `def sym_sum(args)` expecting a single iterable argument. However, `_build_proxy_for_sym_expr` in `proxy_tensor.py` (line 622) calls `torch.sym_sum(*args)` with unpacked positional args when decomposing `sympy.Add` expressions. This causes a `TypeError` when `sym_sum` receives more than one argument.

Example: for `flip` with dynamic shapes, Inductor generates `sym_sum(-1, s33)` during shape computation — two separate positional args — but the lowering only accepts one.

### Root Cause

`_build_proxy_for_sym_expr` decomposes `sympy.Add(-1, s33)` by:
1. Getting `expr.args = (-1, s33)`
2. Looking up `handlers[sympy.Add] = torch.sym_sum`
3. Calling `func(*args)` → `torch.sym_sum(-1, s33)` — unpacked

The Python-level `torch.sym_sum` handles both conventions (line 966 of `__init__.py`), but the Inductor lowering did not.

### Fix

Changed the lowering signature from `def sym_sum(args)` to `def sym_sum(*args)` with normalization to handle both `sym_sum([a, b])` and `sym_sum(a, b)` calling conventions, matching the contract of `torch.sym_sum`.

### Changed Files
- `fbcode/caffe2/torch/_inductor/lowering.py` — fix sym_sum lowering signature
- `xplat/caffe2/torch/_inductor/lowering.py` — mirror

Test Plan:
Local repro with flip op + auto dynamic shapes:
```
OPINFO_TESTS_FILE=/tmp/test_flip.txt OPINFO_LOWERING_MODE=AFG_INDUCTOR_COMPILE OPINFO_AUTO_DS=1 TORCHDYNAMO_VERBOSE=1 buck2 run fbcode//mtia/compiler/graph_compiler/test_library/afg_opinfo_e2e_tests/chronos_job:compile_afg_opinfo -- /tmp/output
```

Note: flip test currently blocked by a separate `aten.arange.start_step` missing lowering issue, so the sym_sum fix could not be independently verified end-to-end via flip. The fix is a straightforward signature change matching the documented `torch.sym_sum` contract.

Existing Inductor tests should continue to pass since the normalization handles both calling conventions.

Reviewed By: cgufb

Differential Revision: D98539830




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo