### PR TITLE
Fix GroupNorm backward correctness bug on AMD wavefront-64

### DIFF
--- a/aten/src/ATen/native/cuda/group_norm_kernel.cu
+++ b/aten/src/ATen/native/cuda/group_norm_kernel.cu
@@ -26,6 +26,19 @@ namespace {
 constexpr int kCUDANumThreads = 256;
 constexpr int kReduceTileSize = 32;
 
+// Reduce across exactly 32 lanes (offsets 16, 8, 4, 2, 1).
+// On NVIDIA (warp=32) this is identical to WarpReduceSum.
+// On AMD (wavefront=64) this avoids summing across two tile columns
+// when the block is (32, 16) and consecutive y-rows share a wavefront.
+template <typename T>
+__inline__ __device__ T ReduceSum32(T val) {
+#pragma unroll
+  for (int offset = 16; offset > 0; offset >>= 1) {
+    val += WARP_SHFL_DOWN(val, offset);
+  }
+  return val;
+}
+
 template <typename T>
 __global__ void RowwiseMomentsCUDAKernel(
     int64_t N,
@@ -238,8 +251,11 @@ __global__ void GammaBeta1dBackwardCUDAKernel2(
   // Do warp reduce for the 1st 16 cols in the tile.
   T_ACC sum1 = g_shared[threadIdx.x][threadIdx.y];
   T_ACC sum2 = b_shared[threadIdx.x][threadIdx.y];
-  sum1 = cuda_utils::WarpReduceSum<T_ACC>(sum1);
-  sum2 = cuda_utils::WarpReduceSum<T_ACC>(sum2);
+  // Use ReduceSum32 (not WarpReduceSum) to reduce exactly 32 lanes.
+  // On AMD wavefront-64, WarpReduceSum would incorrectly sum across two
+  // tile columns since consecutive y-rows share a wavefront.
+  sum1 = ReduceSum32<T_ACC>(sum1);
+  sum2 = ReduceSum32<T_ACC>(sum2);
   if (threadIdx.x == 0) {
     const int64_t c = blockIdx.x * blockDim.x + threadIdx.y;
     if (c < C) {
@@ -255,8 +271,8 @@ __global__ void GammaBeta1dBackwardCUDAKernel2(
   // Do warp reduce for the 2nd 16 cols in the tile.
   sum1 = g_shared[threadIdx.x][threadIdx.y + blockDim.y];
   sum2 = b_shared[threadIdx.x][threadIdx.y + blockDim.y];
-  sum1 = cuda_utils::WarpReduceSum<T_ACC>(sum1);
-  sum2 = cuda_utils::WarpReduceSum<T_ACC>(sum2);
+  sum1 = ReduceSum32<T_ACC>(sum1);
+  sum2 = ReduceSum32<T_ACC>(sum2);
   if (threadIdx.x == 0) {
     const int64_t c = blockIdx.x * blockDim.x + threadIdx.y + blockDim.y;
     if (c < C) {
@@ -440,10 +456,11 @@ __global__ void GammaBetaBackwardCUDAKernel2(
   __syncthreads();
 
   // Do warp reduce for the 1st 16 cols in the tile.
+  // Use ReduceSum32 for correctness on AMD wavefront-64 (see above).
   T_ACC sum1 = g_shared[threadIdx.x][threadIdx.y];
   T_ACC sum2 = b_shared[threadIdx.x][threadIdx.y];
-  sum1 = cuda_utils::WarpReduceSum<T_ACC>(sum1);
-  sum2 = cuda_utils::WarpReduceSum<T_ACC>(sum2);
+  sum1 = ReduceSum32<T_ACC>(sum1);
+  sum2 = ReduceSum32<T_ACC>(sum2);
   if (threadIdx.x == 0) {
     const int64_t c = blockIdx.x * blockDim.x + threadIdx.y;
     if (c < C) {
@@ -459,8 +476,8 @@ __global__ void GammaBetaBackwardCUDAKernel2(
   // Do warp reduce for the 2nd 16 cols in the tile.
   sum1 = g_shared[threadIdx.x][threadIdx.y + blockDim.y];
   sum2 = b_shared[threadIdx.x][threadIdx.y + blockDim.y];
-  sum1 = cuda_utils::WarpReduceSum<T_ACC>(sum1);
-  sum2 = cuda_utils::WarpReduceSum<T_ACC>(sum2);
+  sum1 = ReduceSum32<T_ACC>(sum1);
+  sum2 = ReduceSum32<T_ACC>(sum2);
   if (threadIdx.x == 0) {
     const int64_t c = blockIdx.x * blockDim.x + threadIdx.y + blockDim.y;
     if (c < C) {

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -9418,6 +9418,44 @@ class TestNNDeviceType(NNTestCase):
             Y_cpu = group_norm(X.cpu())
             self.assertEqual(Y_cpu, Y, rtol=0, atol=1e-5)
 
+    @onlyCUDA
+    @dtypes(torch.float32, torch.bfloat16)
+    def test_GroupNorm_backward_large_batch(self, device, dtype):
+        # Test GroupNorm backward with N > 128, which triggers
+        # GammaBetaBackwardCUDAKernel2. This kernel uses a (32, 16) block
+        # with WarpReduceSum after a shared memory transpose. On AMD
+        # wavefront-64, WarpReduceSum incorrectly summed across two tile
+        # columns, producing wrong dgamma/dbeta.
+        rtol = 1e-2 if dtype == torch.bfloat16 else 1e-3
+        atol = 1e-2 if dtype == torch.bfloat16 else 1e-3
+        for N in [129, 256, 512]:
+            for C, G in [(32, 4), (64, 8), (128, 32)]:
+                x = torch.randn(N, C, 16, device=device, dtype=dtype, requires_grad=True)
+                gamma = torch.randn(C, device=device, dtype=dtype, requires_grad=True)
+                beta = torch.randn(C, device=device, dtype=dtype, requires_grad=True)
+
+                y = F.group_norm(x, G, gamma, beta)
+                grad = torch.randn_like(y)
+                y.backward(grad)
+                dgamma_gpu = gamma.grad.clone()
+                dbeta_gpu = beta.grad.clone()
+
+                # CPU reference in float32
+                x_cpu = x.detach().float().cpu().requires_grad_(True)
+                gamma_cpu = gamma.detach().float().cpu().requires_grad_(True)
+                beta_cpu = beta.detach().float().cpu().requires_grad_(True)
+                y_cpu = F.group_norm(x_cpu, G, gamma_cpu, beta_cpu)
+                y_cpu.backward(grad.float().cpu())
+
+                self.assertEqual(
+                    dgamma_gpu.float().cpu(), gamma_cpu.grad, atol=atol, rtol=rtol,
+                    msg=f"dgamma mismatch: N={N} C={C} G={G} dtype={dtype}",
+                )
+                self.assertEqual(
+                    dbeta_gpu.float().cpu(), beta_cpu.grad, atol=atol, rtol=rtol,
+                    msg=f"dbeta mismatch: N={N} C={C} G={G} dtype={dtype}",
+                )
+
     @expectedFailureMPS  # Double is not supported on MPS
     @onlyNativeDeviceTypes
     @dtypes(torch.float64, torch.complex128)


### PR DESCRIPTION
Summary:
**Correctness fix for AMD GPUs with wavefront-64 (MI300X, MI250X, etc.)**

The `GammaBeta1dBackwardCUDAKernel2` and `GammaBetaBackwardCUDAKernel2` kernels (triggered when batch size N > 128) use a `(32, 16)` block with a 32x32 shared memory tile. After transposing data through shared memory, `WarpReduceSum` is called to reduce each tile column. On NVIDIA (warp=32), threads with the same `threadIdx.y` form a single warp, so the reduction correctly sums one column.

On AMD (wavefront=64), threads `(x=0-31, y=0)` and `(x=0-31, y=1)` share a single wavefront. After the transpose, `WarpReduceSum` sums across all 64 lanes — combining two tile columns instead of one. This produces **incorrect** `dgamma` and `dbeta` gradients.

**Fix:** Replace `WarpReduceSum` with `ReduceSum32`, a helper that reduces exactly 32 lanes (shuffle offsets 16, 8, 4, 2, 1). On NVIDIA (warp=32), this is identical to `WarpReduceSum`. On AMD (wavefront=64), each half-wavefront independently reduces its own tile column.

**No impact on NVIDIA** — `ReduceSum32` with offsets 16→1 is the same as `WarpReduceSum` when `C10_WARP_SIZE=32`.

Test Plan:
**Correctness fix** — baseline produced wrong results on AMD wavefront-64 GPUs (MI300X).

This diff adds `test_GroupNorm_backward_large_batch` to `caffe2/test/test_nn.py`, which tests GroupNorm backward with batch sizes N ∈ {129, 256, 512} (triggering the Kernel2 path where N > 128). The test compares CUDA dgamma/dbeta gradients against a CPU reference and verifies they match within tolerance.

Without this fix, the test fails on AMD GPUs because `WarpReduceSum` reduces across 64 lanes (full wavefront) instead of the intended 32-lane tile width, causing cross-column contamination in the shared memory transpose.

The fix introduces a `ReduceSum32` helper that always reduces across exactly 32 lanes regardless of hardware warp/wavefront size, matching the (32, blockDim.y) tile layout. On NVIDIA (warp=32), `ReduceSum32` is equivalent to `WarpReduceSum`, so behavior is unchanged.

**Tests:**
- New test: `test_GroupNorm_backward_large_batch` in `caffe2/test/test_nn.py` — tests N ∈ {129, 256, 512}, C ∈ {32, 64, 128}, G ∈ {4, 8, 32} for float32 and bfloat16. Compares GPU backward gradients against CPU reference.
- Run: `buck test caffe2/test:test_nn -- -r test_GroupNorm_backward_large_batch`
- Existing GroupNorm tests in `test_nn.py` continue to pass.

Differential Revision: D98531674


