### PR TITLE
Implement igamma/igammac backward w.r.t. first argument

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -454,3 +454,37 @@ and reference the following license:
     LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE
     OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
     PERFORMANCE OF THIS SOFTWARE.
+
+=======================================================================
+Stan's 3-Clause BSD License
+=======================================================================
+
+Code derived from implementations in Stan should mention its derivation
+and reference the following license:
+
+    Copyright (c) 2011-2020, Stan Developers and their Assignees
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+        - Redistributions of source code must retain the above copyright notice,
+        this list of conditions and the following disclaimer.
+        - Redistributions in binary form must reproduce the above copyright
+        notice, this list of conditions and the following disclaimer in the
+        documentation and/or other materials provided with the distribution.
+        - Neither the name of the copyright holder nor the names of its
+        contributors may be used to endorse or promote products derived from
+        this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.

--- a/aten/src/ATen/core/NamedRegistrations.cpp
+++ b/aten/src/ATen/core/NamedRegistrations.cpp
@@ -220,6 +220,10 @@ TORCH_LIBRARY_IMPL(aten, Named, m) {
   m.impl("igammac", CppFunction::makeFallthrough());
   m.impl("igammac.out", CppFunction::makeFallthrough());
   m.impl("igammac_", CppFunction::makeFallthrough());
+  m.impl("igamma_self_backward", CppFunction::makeFallthrough());
+  m.impl("igamma_self_backward.out", CppFunction::makeFallthrough());
+  m.impl("igammac_self_backward", CppFunction::makeFallthrough());
+  m.impl("igammac_self_backward.out", CppFunction::makeFallthrough());
   m.impl("imag", CppFunction::makeFallthrough());
   m.impl("index_fill.Dimname_Scalar", CppFunction::makeFallthrough());
   m.impl("index_fill.Dimname_Tensor", CppFunction::makeFallthrough());

--- a/aten/src/ATen/functorch/BatchRulesBinaryOps.cpp
+++ b/aten/src/ATen/functorch/BatchRulesBinaryOps.cpp
@@ -442,6 +442,8 @@ TORCH_LIBRARY_IMPL(aten, FuncTorchBatched, m) {
   BINARY_POINTWISE(gcd);
   BINARY_POINTWISE(igamma);
   BINARY_POINTWISE(igammac);
+  BINARY_POINTWISE(igamma_self_backward);
+  BINARY_POINTWISE(igammac_self_backward);
   BINARY_POINTWISE2(ldexp, Tensor);
   BINARY_POINTWISE(logaddexp);
   BINARY_POINTWISE(logaddexp2);

--- a/aten/src/ATen/native/BinaryOps.cpp
+++ b/aten/src/ATen/native/BinaryOps.cpp
@@ -63,6 +63,8 @@
 #include <ATen/ops/igamma_native.h>
 #include <ATen/ops/igammac.h>
 #include <ATen/ops/igammac_native.h>
+#include <ATen/ops/igamma_self_backward_native.h>
+#include <ATen/ops/igammac_self_backward_native.h>
 #include <ATen/ops/lcm_native.h>
 #include <ATen/ops/ldexp.h>
 #include <ATen/ops/ldexp_native.h>
@@ -328,6 +330,8 @@ CREATE_BINARY_META_FUNC(lcm)
 CREATE_BINARY_META_FUNC(hypot)
 CREATE_BINARY_META_FUNC(igamma)
 CREATE_BINARY_META_FUNC(igammac)
+CREATE_BINARY_META_FUNC(igamma_self_backward)
+CREATE_BINARY_META_FUNC(igammac_self_backward)
 CREATE_BINARY_META_FUNC(nextafter)
 
 TORCH_META_FUNC(maximum) (const Tensor& self, const Tensor& other) {
@@ -429,6 +433,8 @@ DEFINE_DISPATCH(shifted_chebyshev_polynomial_t_stub);
 DEFINE_DISPATCH(shifted_chebyshev_polynomial_u_stub);
 DEFINE_DISPATCH(shifted_chebyshev_polynomial_v_stub);
 DEFINE_DISPATCH(shifted_chebyshev_polynomial_w_stub);
+DEFINE_DISPATCH(igamma_self_backward_stub);
+DEFINE_DISPATCH(igammac_self_backward_stub);
 DEFINE_DISPATCH(ldexp_stub);
 
 TORCH_IMPL_FUNC(sub_out) (
@@ -548,6 +554,8 @@ CREATE_BINARY_TORCH_IMPL_FUNC(lcm_out, lcm_stub)
 CREATE_BINARY_TORCH_IMPL_FUNC(hypot_out, hypot_stub)
 CREATE_BINARY_TORCH_IMPL_FUNC(igamma_out, igamma_stub)
 CREATE_BINARY_TORCH_IMPL_FUNC(igammac_out, igammac_stub)
+CREATE_BINARY_TORCH_IMPL_FUNC(igamma_self_backward_out, igamma_self_backward_stub)
+CREATE_BINARY_TORCH_IMPL_FUNC(igammac_self_backward_out, igammac_self_backward_stub)
 CREATE_BINARY_TORCH_IMPL_FUNC(nextafter_out, nextafter_stub)
 CREATE_BINARY_TORCH_IMPL_FUNC(remainder_out, remainder_stub)
 CREATE_BINARY_TORCH_IMPL_FUNC(xlogy_out, xlogy_stub)

--- a/aten/src/ATen/native/BinaryOps.h
+++ b/aten/src/ATen/native/BinaryOps.h
@@ -117,6 +117,8 @@ DECLARE_DISPATCH(structured_binary_fn, shifted_chebyshev_polynomial_t_stub)
 DECLARE_DISPATCH(structured_binary_fn, shifted_chebyshev_polynomial_u_stub)
 DECLARE_DISPATCH(structured_binary_fn, shifted_chebyshev_polynomial_v_stub)
 DECLARE_DISPATCH(structured_binary_fn, shifted_chebyshev_polynomial_w_stub)
+DECLARE_DISPATCH(structured_binary_fn, igamma_self_backward_stub)
+DECLARE_DISPATCH(structured_binary_fn, igammac_self_backward_stub)
 DECLARE_DISPATCH(ldexp_fn, ldexp_stub)
 
 } // namespace at::native

--- a/aten/src/ATen/native/Math.h
+++ b/aten/src/ATen/native/Math.h
@@ -2,6 +2,7 @@
 
 #include <ATen/AccumulateType.h>
 #include <ATen/NumericUtils.h>
+#include <ATen/OpMathType.h>
 #include <ATen/jiterator_macros.h>
 #include <c10/macros/Macros.h>
 #include <c10/util/BFloat16.h>
@@ -372,7 +373,7 @@ inline float trigamma(float x) __ubsan_ignore_float_divide_by_zero__ {
  * This function is derived from the implementation of the digamma function in the Cephes Math Library.
  * See note [3-Clause BSD License for the Cephes Math Library].
  */
-inline double calc_digamma(double x) {
+inline C10_HOST_DEVICE double calc_digamma(double x) {
   // [C++ Standard Reference: Gamma Function] https://en.cppreference.com/w/cpp/numeric/math/tgamma
   static double PSI_10 = 2.25175258906672110764;
   if (x == 0) {
@@ -430,7 +431,7 @@ inline double calc_digamma(double x) {
  * This function is derived from the implementation of the digamma function in the Cephes Math Library.
  * See note [3-Clause BSD License for the Cephes Math Library].
  */
-inline float calc_digamma(float x) {
+inline C10_HOST_DEVICE float calc_digamma(float x) {
   // See [C++ Standard Reference: Gamma Function]
   static float PSI_10 = 2.25175258906672110764f;
   if (x == 0) {
@@ -1228,6 +1229,205 @@ template <>
     c10::Half a,
     c10::Half x) {
   return calc_igammac<float>(float(a), float(x));
+}
+
+// Backward pass for igamma/igammac w.r.t. first argument (a).
+// Derived from Stan math library's grad_reg_inc_gamma.
+// See note [Stan's 3-Clause BSD License] in NOTICE.
+
+template <typename opmath_t>
+static C10_HOST_DEVICE opmath_t
+_igammac_grada_helper_asymptotic_series(opmath_t a, opmath_t x) {
+  // Compute igammac gradient from [dlmf] 8.11.2
+  const int NTERMS = 9;
+  constexpr opmath_t ONE = opmath_t(1.0);
+  opmath_t sum = opmath_t(0.0);
+  opmath_t uk = opmath_t(1.0);
+  opmath_t du = opmath_t(1.0);
+  opmath_t uterm = opmath_t(a);
+  opmath_t logx = std::log(x);
+  int k;
+
+  for (k = 1; k <= NTERMS; ++k) {
+    uterm -= ONE;
+    if (k > 1) {
+      du = uk + du * uterm;
+    }
+    uk *= uterm;
+    sum += du / std::pow(x, static_cast<opmath_t>(k));
+  }
+  return (
+    calc_igammac(a, x) * (logx - calc_digamma(a)) +
+      sum * std::exp((a - ONE) * logx - x - std::lgamma(a))
+  );
+}
+
+template <typename opmath_t>
+static C10_HOST_DEVICE opmath_t
+_igammac_grada_helper_series(opmath_t a, opmath_t x) {
+  // Compute igammac gradient from [dlmf] 8.7.3
+  const int MAXITER = 2000;
+  const opmath_t MACHEP = std::is_same<opmath_t, double>::value ?
+    opmath_t(1.11022302462515654042E-16) : opmath_t(5.9604644775390625E-8);
+  constexpr opmath_t ONE = opmath_t(1.0);
+  constexpr opmath_t TWO = opmath_t(2.0);
+  opmath_t sum = opmath_t(0.0);
+  opmath_t subterm = opmath_t(0.0);
+  opmath_t a_plus_k = a;
+  opmath_t logx = std::log(x);
+  opmath_t term;
+  int k;
+
+  for (k = 0; k <= MAXITER; ++k) {
+    term = std::exp(subterm - TWO * std::log(a_plus_k));
+    sum += ((k % 2) ? -ONE : +ONE) * term;
+    if (std::fabs(term) <= MACHEP) {
+      break;
+    }
+    a_plus_k += ONE;
+    subterm += logx - std::log1p(k);
+  }
+  return (
+    (ONE - calc_igammac(a, x)) * (calc_digamma(a) - logx) +
+      sum * std::exp(a * logx - std::lgamma(a))
+  );
+}
+
+template <typename opmath_t>
+static C10_HOST_DEVICE opmath_t
+_igamma_grada_helper_series(opmath_t a, opmath_t x) {
+  // Compute igamma gradient from [gautschi] 5.4
+  const int MAXITER = 2000;
+  const opmath_t MACHEP = std::is_same<opmath_t, double>::value ?
+    opmath_t(1.11022302462515654042E-16) : opmath_t(5.9604644775390625E-8);
+  constexpr opmath_t ONE = opmath_t(1.0);
+  opmath_t suma = opmath_t(0.0);
+  opmath_t sumb = opmath_t(0.0);
+  opmath_t terma = opmath_t(1.0);
+  opmath_t termb = opmath_t(1.0);
+  opmath_t a_plus_k = a;
+  opmath_t logx = std::log(x);
+  opmath_t coef = calc_digamma(a + ONE);
+  opmath_t expo = a * logx - std::lgamma(a + ONE);
+  int k;
+
+  for (k = 0; k <= MAXITER; ++k) {
+    if (std::fabs(terma) > MACHEP) {
+      terma = std::exp(expo);
+      suma += terma;
+    }
+    if (std::fabs(termb) > MACHEP) {
+      termb = coef * std::exp(expo);
+      sumb += termb;
+    }
+    if ((std::fabs(terma) <= MACHEP) && (std::fabs(termb) <= MACHEP)) {
+      break;
+    }
+    expo += logx - std::log1p(a_plus_k);
+    a_plus_k += ONE;
+    coef += ONE / a_plus_k;
+  }
+  return std::exp(-x) * (logx * suma - sumb);
+}
+
+template <typename scalar_t>
+C10_HOST_DEVICE at::opmath_type<scalar_t>
+calc_igammac_grada(scalar_t a_, scalar_t x_) {
+  using opmath_t = at::opmath_type<scalar_t>;
+  opmath_t a = static_cast<opmath_t>(a_);
+  opmath_t x = static_cast<opmath_t>(x_);
+  constexpr opmath_t ZERO = opmath_t(0.0);
+  constexpr opmath_t LARGE = opmath_t(8.0);
+
+  if (std::isnan(a) || std::isnan(x)) {
+    return std::numeric_limits<opmath_t>::quiet_NaN();
+  }
+  else if ((a <= ZERO) || (x < ZERO)) {
+    return std::numeric_limits<opmath_t>::quiet_NaN();
+  }
+  else if (std::isinf(x)) {
+    return std::numeric_limits<opmath_t>::quiet_NaN();
+  }
+  else if (std::isinf(a)) {
+    return ZERO;
+  }
+  else if (x == ZERO) {
+    return ZERO;
+  }
+
+  if ((x >= LARGE) && (x >= a)) {
+    return _igammac_grada_helper_asymptotic_series(a, x);
+  }
+  return _igammac_grada_helper_series(a, x);
+}
+
+template <typename scalar_t>
+C10_HOST_DEVICE at::opmath_type<scalar_t>
+calc_igamma_grada(scalar_t a_, scalar_t x_) {
+  using opmath_t = at::opmath_type<scalar_t>;
+  opmath_t a = static_cast<opmath_t>(a_);
+  opmath_t x = static_cast<opmath_t>(x_);
+  constexpr opmath_t ZERO = opmath_t(0.0);
+  constexpr opmath_t SMALLA1 = opmath_t(0.8);
+  constexpr opmath_t LARGEX1 = opmath_t(15.0);
+  constexpr opmath_t SMALLA2 = opmath_t(12.0);
+  constexpr opmath_t LARGEX2 = opmath_t(30.0);
+  opmath_t REGION = std::sqrt(-x * x + 60.0 * x - 756.0);
+
+  if (std::isnan(a) || std::isnan(x)) {
+    return std::numeric_limits<opmath_t>::quiet_NaN();
+  }
+  else if ((a <= ZERO) || (x < ZERO)) {
+    return std::numeric_limits<opmath_t>::quiet_NaN();
+  }
+  else if (std::isinf(x)) {
+    return std::numeric_limits<opmath_t>::quiet_NaN();
+  }
+  else if (std::isinf(a)) {
+    return ZERO;
+  }
+  else if (x == ZERO) {
+    return ZERO;
+  }
+
+  if ((x > LARGEX1) && (a < SMALLA1)) {
+    return -calc_igammac_grada(a_, x_);
+  }
+  else if ((x > LARGEX2) && (a < SMALLA2)) {
+    return -calc_igammac_grada(a_, x_);
+  }
+  else if (a < REGION) {
+    return -calc_igammac_grada(a_, x_);
+  }
+  return _igamma_grada_helper_series(a, x);
+}
+
+template <>
+[[maybe_unused]] inline c10::BFloat16 calc_igamma_grada<c10::BFloat16>(
+    c10::BFloat16 a,
+    c10::BFloat16 x) {
+  return calc_igamma_grada<float>(float(a), float(x));
+}
+
+template <>
+[[maybe_unused]] inline c10::Half calc_igamma_grada<c10::Half>(
+    c10::Half a,
+    c10::Half x) {
+  return calc_igamma_grada<float>(float(a), float(x));
+}
+
+template <>
+[[maybe_unused]] inline c10::BFloat16 calc_igammac_grada<c10::BFloat16>(
+    c10::BFloat16 a,
+    c10::BFloat16 x) {
+  return calc_igammac_grada<float>(float(a), float(x));
+}
+
+template <>
+[[maybe_unused]] inline c10::Half calc_igammac_grada<c10::Half>(
+    c10::Half a,
+    c10::Half x) {
+  return calc_igammac_grada<float>(float(a), float(x));
 }
 
 inline c10::BFloat16 calc_erfinv(c10::BFloat16 a) { return calc_erfinv(float(a)); }

--- a/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
@@ -1242,6 +1242,28 @@ void igammac_kernel(TensorIteratorBase& iter) {
       });
 }
 
+void igamma_self_backward_kernel(TensorIteratorBase& iter) {
+  AT_DISPATCH_FLOATING_TYPES_AND2(
+      kHalf, kBFloat16, iter.dtype(), "igamma_self_backward_cpu", [&]() {
+        cpu_kernel(
+            iter,
+            [=](scalar_t a, scalar_t b) -> scalar_t {
+              return calc_igamma_grada(a, b);
+            });
+      });
+}
+
+void igammac_self_backward_kernel(TensorIteratorBase& iter) {
+  AT_DISPATCH_FLOATING_TYPES_AND2(
+      kHalf, kBFloat16, iter.dtype(), "igammac_self_backward_cpu", [&]() {
+        cpu_kernel(
+            iter,
+            [=](scalar_t a, scalar_t b) -> scalar_t {
+              return calc_igammac_grada(a, b);
+            });
+      });
+}
+
 void nextafter_kernel(TensorIteratorBase& iter) {
   if (at::isReducedFloatingType(iter.common_dtype())) {
     AT_DISPATCH_REDUCED_FLOATING_TYPES(iter.dtype(), "nextafter_cpu", [&]() {
@@ -1512,5 +1534,7 @@ ALSO_REGISTER_AVX512_DISPATCH(logaddexp2_stub, &logaddexp2_kernel)
 ALSO_REGISTER_AVX512_DISPATCH(hypot_stub, &hypot_kernel)
 ALSO_REGISTER_AVX512_DISPATCH(igamma_stub, &igamma_kernel)
 ALSO_REGISTER_AVX512_DISPATCH(igammac_stub, &igammac_kernel)
+ALSO_REGISTER_AVX512_DISPATCH(igamma_self_backward_stub, &igamma_self_backward_kernel)
+ALSO_REGISTER_AVX512_DISPATCH(igammac_self_backward_stub, &igammac_self_backward_kernel)
 
 } // namespace at::native

--- a/aten/src/ATen/native/cuda/IGammaBackwardKernel.cu
+++ b/aten/src/ATen/native/cuda/IGammaBackwardKernel.cu
@@ -1,0 +1,30 @@
+#define TORCH_ASSERT_NO_OPERATORS
+#include <ATen/Dispatch.h>
+#include <ATen/native/DispatchStub.h>
+#include <ATen/native/cuda/Loops.cuh>
+#include <ATen/native/Math.h>
+#include <ATen/native/TensorIterator.h>
+#include <ATen/native/BinaryOps.h>
+
+namespace at::native {
+
+void igamma_self_backward_kernel_cuda(TensorIteratorBase& iter) {
+  AT_DISPATCH_FLOATING_TYPES(iter.common_dtype(), "igamma_self_backward_cuda", [&]() {
+    gpu_kernel(iter, []GPU_LAMBDA(scalar_t a, scalar_t x) -> scalar_t {
+      return calc_igamma_grada(a, x);
+    });
+  });
+}
+
+void igammac_self_backward_kernel_cuda(TensorIteratorBase& iter) {
+  AT_DISPATCH_FLOATING_TYPES(iter.common_dtype(), "igammac_self_backward_cuda", [&]() {
+    gpu_kernel(iter, []GPU_LAMBDA(scalar_t a, scalar_t x) -> scalar_t {
+      return calc_igammac_grada(a, x);
+    });
+  });
+}
+
+REGISTER_DISPATCH(igamma_self_backward_stub, &igamma_self_backward_kernel_cuda)
+REGISTER_DISPATCH(igammac_self_backward_stub, &igammac_self_backward_kernel_cuda)
+
+} // namespace at::native

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -10171,6 +10171,30 @@
   variants: method
   tags: pointwise
 
+- func: igamma_self_backward.out(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
+  structured: True
+  structured_inherits: TensorIteratorBase
+  dispatch:
+    CPU, CUDA: igamma_self_backward_out
+  tags: pointwise
+
+- func: igamma_self_backward(Tensor self, Tensor other) -> Tensor
+  structured_delegate: igamma_self_backward.out
+  variants: function
+  tags: pointwise
+
+- func: igammac_self_backward.out(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
+  structured: True
+  structured_inherits: TensorIteratorBase
+  dispatch:
+    CPU, CUDA: igammac_self_backward_out
+  tags: pointwise
+
+- func: igammac_self_backward(Tensor self, Tensor other) -> Tensor
+  structured_delegate: igammac_self_backward.out
+  variants: function
+  tags: pointwise
+
 - func: nextafter.out(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
   structured: True
   structured_inherits: TensorIteratorBase

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -824,11 +824,11 @@
   result: auto_element_wise
 
 - name: igamma(Tensor self, Tensor other) -> Tensor
-  self: 'not_implemented("igamma: input")'
+  self: grad * at::igamma_self_backward(self, other)
   other: grad * exp((self - 1) * log(other) - other - lgamma(self))
 
 - name: igammac(Tensor self, Tensor other) -> Tensor
-  self: 'not_implemented("igammac: input")'
+  self: grad * at::igammac_self_backward(self, other)
   other: -grad * exp((self - 1) * log(other) - other - lgamma(self))
 
 - name: index.Tensor(Tensor self, Tensor?[] indices) -> Tensor

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -17823,9 +17823,11 @@ op_db: list[OpInfo] = [
                     dtypes=floating_types_and(torch.bfloat16, torch.float16),
                     aliases=('torch.special.gammainc',),
                     dtypesIfCUDA=floating_types(),
-                    # TODO: FIXME
                     supports_rhs_python_scalar=False,
-                    supports_autograd=False,
+                    supports_autograd=True,
+                    supports_gradgrad=False,
+                    supports_forward_ad=False,
+                    supports_fwgrad_bwgrad=False,
                     skips=(
                         # FIXME: incorrectly tries to pass a rhs scalar
                         DecorateInfo(unittest.expectedFailure, 'TestJit',
@@ -17864,7 +17866,10 @@ op_db: list[OpInfo] = [
                     dtypes=floating_types_and(torch.bfloat16, torch.float16),
                     aliases=('torch.special.gammaincc',),
                     dtypesIfCUDA=floating_types(),
-                    supports_autograd=False,
+                    supports_autograd=True,
+                    supports_gradgrad=False,
+                    supports_forward_ad=False,
+                    supports_fwgrad_bwgrad=False,
                     supports_rhs_python_scalar=False,
                     skips=(
                         # FIXME: incorrectly tries to pass a rhs scalar


### PR DESCRIPTION
## Summary

Implements the gradient of `torch.special.gammainc` / `torch.special.gammaincc` (igamma/igammac) with respect to the first argument `a` (shape parameter). Previously calling `.backward()` on these functions raised `not_implemented("igamma: input")`.

- Uses two computation regimes based on Stan math library: asymptotic expansion (DLMF 8.11.2) when `z >= 8 && z >= a`, series expansion (DLMF 8.7.3 / Gautschi 5.4) otherwise
- Registers `igamma_self_backward` and `igammac_self_backward` as structured binary ops with CPU + CUDA dispatch
- Enables differentiable CDFs for Gamma/Poisson distributions (survival analysis, temporal point processes)

Based on the work by @drewfustin in #130782, rebased onto current main.

Fixes #80025

## Files changed (11)

**Core math** (`aten/src/ATen/native/Math.h`): `calc_igamma_grada`, `calc_igammac_grada` and helpers. Also adds `C10_HOST_DEVICE` to `calc_digamma` for CUDA compatibility.

**Op registration**: `native_functions.yaml`, `BinaryOps.cpp/h`, `NamedRegistrations.cpp`, `BatchRulesBinaryOps.cpp`

**Kernels**: `cpu/BinaryOpsKernel.cpp` (CPU), `cuda/IGammaBackwardKernel.cu` (CUDA, new file)

**Autograd**: `derivatives.yaml` - replaces `not_implemented` with `at::igamma_self_backward`

**Tests**: `common_methods_invocations.py` - enables `supports_autograd=True`, sets `supports_gradgrad=False`

**License**: `NOTICE` - Stan BSD 3-Clause attribution

## Test plan

- [ ] CI passes (codegen, CPU tests, CUDA tests)
- [ ] `pytest test/test_ops.py -vk igamma` -- OpInfo gradient tests
- [ ] `pytest test/functorch/test_ops.py -vk igamma` -- functorch tests
- [ ] Smoke test:
  \`\`\`python
  import torch
  a = torch.tensor(2.0, requires_grad=True)
  x = torch.tensor(0.5)
  r = torch.special.gammainc(a, x)
  r.backward()
  print(a.grad)  # should print a finite gradient
  \`\`\`

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01 @lezcano @peterbell10