### PR TITLE
Fix DTensor backward for value-selecting reductions (topk, sort, min,…

### DIFF
--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -2351,10 +2351,14 @@ bool cpu_equal(const Tensor& self, const Tensor& other) {
 Tensor value_selecting_reduction_backward_symint(const Tensor& grad, int64_t dim, const Tensor& indices, c10::SymIntArrayRef sizes, bool keepdim) {
   auto inplace_scatter_if_not_tensor_subclass =
       [&](const Tensor& grad_out, const Tensor& indices_) {
-        auto grad_in = at::zeros_symint(sizes, grad_out.options());
         if (areAnyTensorSubclassLike({grad, indices})) {
+          // Use new_zeros_symint so that tensor subclasses (e.g. DTensor)
+          // can intercept the zeros creation through dispatch, ensuring
+          // the result has matching subclass type for subsequent scatter.
+          auto grad_in = grad_out.new_zeros_symint(sizes);
           return grad_in.scatter(dim, indices_, grad_out);
         }
+        auto grad_in = at::zeros_symint(sizes, grad_out.options());
         return grad_in.scatter_(dim, indices_, grad_out);
       };
 

--- a/test/distributed/tensor/test_math_ops.py
+++ b/test/distributed/tensor/test_math_ops.py
@@ -688,9 +688,34 @@ class DistMathOpsTest(DTensorTestBase):
             out_full_values = out_dt.values.full_tensor()
             self.assertEqual(global_topk.values, out_full_values)
 
-            # TODO: support backward scatter
-            # global_topk.values.sum().backward()
-            # out_full_values.sum().backward()
+    @with_comms
+    def test_topk_backward(self):
+        device_mesh = self.build_device_mesh()
+        # Test backward for topk with various shard_dim / topk_dim combinations.
+        # The fix in value_selecting_reduction_backward ensures that the zeros
+        # tensor created during backward is properly dispatched through DTensor
+        # (using new_zeros instead of at::zeros).
+        topk_dims = [0, 1, -1]
+        shard_dims = [0, 1, 2]
+        for topk_dim, shard_dim in itertools.product(topk_dims, shard_dims):
+            # Use DTensor.from_local to create a sharded DTensor that exercises
+            # the backward path through DTensor dispatch (as opposed to
+            # distribute_tensor which may create a different autograd graph).
+            local_x = torch.randn(
+                12, 8, 8, device=self.device_type, requires_grad=True
+            )
+            dist_x = DTensor.from_local(local_x, device_mesh, [Shard(shard_dim)])
+            dist_x.retain_grad()
+
+            dist_topk = dist_x.topk(3, dim=topk_dim)
+            dist_loss = dist_topk.values.sum()
+            dist_loss.backward()
+
+            # Verify gradient exists and has the right placement
+            self.assertIsNotNone(
+                dist_x.grad,
+                msg=f"topk_dim={topk_dim}, shard_dim={shard_dim}",
+            )
 
     @with_comms
     def test_shard0_svd(self):

--- a/test/distributed/tensor/test_math_ops.py
+++ b/test/distributed/tensor/test_math_ops.py
@@ -698,24 +698,31 @@ class DistMathOpsTest(DTensorTestBase):
         topk_dims = [0, 1, -1]
         shard_dims = [0, 1, 2]
         for topk_dim, shard_dim in itertools.product(topk_dims, shard_dims):
-            # Use DTensor.from_local to create a sharded DTensor that exercises
-            # the backward path through DTensor dispatch (as opposed to
-            # distribute_tensor which may create a different autograd graph).
-            local_x = torch.randn(
-                12, 8, 8, device=self.device_type, requires_grad=True
+            # Reference: plain (non-distributed) backward
+            x = torch.randn(12, 8, 8, device=self.device_type, requires_grad=True)
+            ref_topk = x.topk(3, dim=topk_dim)
+            ref_topk.values.sum().backward()
+
+            # Distributed backward
+            dist_x = distribute_tensor(
+                x.detach().clone().requires_grad_(True),
+                device_mesh,
+                [Shard(shard_dim)],
             )
-            dist_x = DTensor.from_local(local_x, device_mesh, [Shard(shard_dim)])
-            dist_x.retain_grad()
-
             dist_topk = dist_x.topk(3, dim=topk_dim)
-            dist_loss = dist_topk.values.sum()
-            dist_loss.backward()
+            dist_topk.values.sum().backward()
 
-            # Verify gradient exists and has the right placement
+            # Verify gradient exists, has the right placement, and matches
             self.assertIsNotNone(
                 dist_x.grad,
                 msg=f"topk_dim={topk_dim}, shard_dim={shard_dim}",
             )
+            self.assertEqual(
+                dist_x.grad.full_tensor(),
+                x.grad,
+                msg=f"topk_dim={topk_dim}, shard_dim={shard_dim}",
+            )
+            x.grad.zero_()
 
     @with_comms
     def test_shard0_svd(self):


### PR DESCRIPTION
… max)

`value_selecting_reduction_backward` creates a zeros tensor via `at::zeros_symint(sizes, grad_out.options())` which bypasses tensor subclass dispatch since `options()` only carries dtype/device. When `grad_out` is a DTensor, the resulting plain zeros tensor is passed to `scatter` alongside DTensor arguments, causing a mixed-type error.

Fix: use `grad_out.new_zeros_symint(sizes)` in the tensor subclass path so that subclasses (DTensor, FakeTensor, etc.) can intercept the creation through dispatch and produce a properly-typed result.

Authored with Claude