### PR TITLE
Add _dump_snapshot_sqlite() for efficient memory snapshot querying

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -8744,7 +8744,7 @@ class TestFXMemoryProfiler(TestCase):
             self.assertIn("fx_original_trace", frame)
 
             self.assertIn(frame["fx_node_name"], ["addmm", "relu", "addmm_1"])
-            fx_node_name: Literal['addmm', 'addmm_1', 'relu'] = frame["fx_node_name"]
+            fx_node_name = frame["fx_node_name"]
             if fx_node_name == "addmm":
                 self.assertIn("d = self.net1(x)", frame["fx_original_trace"])
             elif fx_node_name == "addmm_1":

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -4239,6 +4239,140 @@ class TestCudaAllocator(TestCase):
         finally:
             torch.cuda.memory._record_memory_history(None)
 
+    @contextlib.contextmanager
+    def _snapshot_sqlite_context(self, history_mode="all"):
+        """Helper context manager for _dump_snapshot_sqlite tests."""
+        import sqlite3
+
+        try:
+            torch.cuda.memory.empty_cache()
+            torch.cuda.memory._record_memory_history(history_mode, stacks="python")
+
+            with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+                db_path = f.name
+
+            def dump_and_connect(augment_with_fx_traces=False):
+                torch.cuda.memory._dump_snapshot_sqlite(
+                    db_path, augment_with_fx_traces=augment_with_fx_traces
+                )
+                return sqlite3.connect(db_path)
+
+            yield db_path, dump_and_connect
+        finally:
+            torch.cuda.memory._record_memory_history(None)
+            if os.path.exists(db_path):
+                os.remove(db_path)
+
+    @unittest.skipIf(
+        TEST_CUDAMALLOCASYNC, "setContextRecorder not supported by CUDAMallocAsync"
+    )
+    def test_dump_snapshot_sqlite(self):
+        """Test that _dump_snapshot_sqlite creates a valid SQLite database."""
+        with self._snapshot_sqlite_context("state") as (db_path, dump_and_connect):
+            x = torch.rand(311, 411, device="cuda")
+            y = torch.rand(128, device="cuda")
+
+            conn = dump_and_connect()
+            cursor = conn.cursor()
+
+            # Verify data exists in all 3 tables
+            for table in ["device_traces", "blocks", "segments"]:
+                cursor.execute(f"SELECT COUNT(*) FROM {table}")
+                self.assertGreater(cursor.fetchone()[0], 0)
+
+            conn.close()
+            del x, y
+
+    @unittest.skipIf(
+        TEST_CUDAMALLOCASYNC, "setContextRecorder not supported by CUDAMallocAsync"
+    )
+    def test_dump_snapshot_sqlite_trace_block_correlation(self):
+        """Test that device_traces.addr can be JOINed with blocks.addr."""
+        with self._snapshot_sqlite_context() as (db_path, dump_and_connect):
+            x = torch.rand(311, 411, device="cuda")
+            x_addr = x.untyped_storage().data_ptr()
+
+            conn = dump_and_connect()
+            cursor = conn.cursor()
+
+            # Find the allocation trace for our tensor
+            cursor.execute(
+                "SELECT id, size FROM device_traces WHERE action = 'alloc' AND addr = ?",
+                (x_addr,),
+            )
+            trace_row = cursor.fetchone()
+            self.assertIsNotNone(trace_row, "Should find alloc trace for tensor")
+            trace_id, trace_size = trace_row
+            self.assertEqual(trace_size, 311 * 411 * 4)  # 311*411 floats * 4 bytes
+
+            # Execute join by finding corresponding block
+            cursor.execute(
+                """SELECT b.addr, b.state FROM blocks b
+                   JOIN device_traces t ON t.addr = b.addr
+                   WHERE t.id = ?""",
+                (trace_id,),
+            )
+            block_row = cursor.fetchone()
+            self.assertIsNotNone(block_row, "Should find block via JOIN")
+            self.assertEqual(block_row[0], x_addr)
+            self.assertEqual(block_row[1], "active_allocated")
+
+            conn.close()
+            del x
+
+    @unittest.skipIf(
+        TEST_CUDAMALLOCASYNC, "setContextRecorder not supported by CUDAMallocAsync"
+    )
+    @torch.fx.experimental._config.patch("enrich_profiler_metadata", True)
+    def test_dump_snapshot_sqlite_augment_with_fx_traces(self):
+        """Test that augment_with_fx_traces captures FX debug info with torch.compile."""
+
+        class SimpleModule(torch.nn.Module):
+            def __init__(self, device):
+                super().__init__()
+                self.linear = torch.nn.Linear(10, 10, device=device)
+                self.relu = torch.nn.ReLU()
+
+            def forward(self, x):
+                a = self.linear(x)
+                b = self.relu(a)
+                return b
+
+        with self._snapshot_sqlite_context() as (db_path, dump_and_connect):
+            device = "cuda"
+            mod = SimpleModule(device)
+            compiled = torch.compile(mod, backend="aot_eager", fullgraph=True)
+            _ = compiled(torch.randn(10, 10, device=device))
+
+            conn = dump_and_connect(augment_with_fx_traces=True)
+            cursor = conn.cursor()
+
+            # Verify tables exist and have data
+            for table in ["device_traces", "blocks", "segments"]:
+                cursor.execute(f"SELECT COUNT(*) FROM {table}")
+                self.assertGreater(cursor.fetchone()[0], 0)
+
+            # Collect all frames and check for FX debug fields
+            cursor.execute("SELECT frames FROM device_traces WHERE action = 'alloc'")
+            fx_frames_found = []
+            for row in cursor.fetchall():
+                frames = json.loads(row[0])
+                for frame in frames:
+                    if "fx_node_op" in frame or "fx_node_name" in frame:
+                        fx_frames_found.append(frame)
+
+            # Should have FX-augmented frames from torch.compile
+            self.assertGreater(len(fx_frames_found), 0)
+
+            # Verify FX fields are present in augmented frames
+            for frame in fx_frames_found:
+                self.assertIn("fx_node_op", frame)
+                self.assertIn("fx_node_name", frame)
+                self.assertIn("fx_node_target", frame)
+                self.assertIn("fx_original_trace", frame)
+
+            conn.close()
+
     @unittest.skipIf(
         TEST_CUDAMALLOCASYNC, "setContextRecorder not supported by CUDAMallocAsync"
     )
@@ -8610,7 +8744,7 @@ class TestFXMemoryProfiler(TestCase):
             self.assertIn("fx_original_trace", frame)
 
             self.assertIn(frame["fx_node_name"], ["addmm", "relu", "addmm_1"])
-            fx_node_name = frame["fx_node_name"]
+            fx_node_name: Literal['addmm', 'addmm_1', 'relu'] = frame["fx_node_name"]
             if fx_node_name == "addmm":
                 self.assertIn("d = self.net1(x)", frame["fx_original_trace"])
             elif fx_node_name == "addmm_1":

--- a/torch/cuda/memory.py
+++ b/torch/cuda/memory.py
@@ -1128,6 +1128,131 @@ def _dump_snapshot(filename="dump_snapshot.pickle", augment_with_fx_traces=False
         pickle.dump(s, f)
 
 
+def _dump_snapshot_sqlite(filename="dump_snapshot.db", augment_with_fx_traces=False):
+    """
+    Save a CUDA memory snapshot to a SQLite database file.
+
+    This format allows efficient querying of plot data (timestamps, sizes, actions)
+    without loading the entire snapshot into memory. Stack traces are stored as JSON
+    and can be loaded on demand. The schema is 1:1 with the pickle format.
+
+    The database contains the following tables:
+        - device_traces: Allocation events with plot data (time_us, size, action, addr)
+          and frames as JSON array.
+        - blocks: Current memory block state with frames as JSON array.
+        - segments: Memory segments stored as JSON blobs
+
+    Example queries:
+        -- Get plot data (no frame parsing needed)
+        SELECT time_us, size, action FROM device_traces WHERE action = 'alloc';
+
+        -- Correlate trace to block
+        SELECT b.* FROM blocks b
+        JOIN device_traces t ON t.addr = b.addr
+        WHERE t.id = ?;
+
+        -- Load stack trace for a specific allocation
+        SELECT frames FROM device_traces WHERE id = ?;
+
+    Args:
+        filename (str, optional): Name of the database file. Defaults to "dump_snapshot.db".
+        augment_with_fx_traces (bool, optional): If True, augment frames with FX debug
+            information that maps generated FX code back to original model source.
+            Defaults to False.
+    """
+    import json
+    import os
+    import sqlite3
+
+    s = _snapshot(augment_with_fx_traces=augment_with_fx_traces)
+
+    if os.path.exists(filename):
+        os.remove(filename)
+
+    conn = sqlite3.connect(filename)
+    cursor = conn.cursor()
+
+    cursor.executescript("""
+        CREATE TABLE device_traces (
+            id INTEGER PRIMARY KEY,
+            time_us INTEGER,
+            size INTEGER,
+            action TEXT,
+            addr INTEGER,
+            frames TEXT
+        );
+
+        CREATE TABLE blocks (
+            id INTEGER PRIMARY KEY,
+            segment_id INTEGER,
+            addr INTEGER,
+            size INTEGER,
+            requested_size INTEGER,
+            state TEXT,
+            frames TEXT
+        );
+
+        CREATE TABLE segments (
+            segment_id INTEGER PRIMARY KEY,
+            data TEXT
+        );
+
+        CREATE INDEX idx_traces_time ON device_traces(time_us);
+        CREATE INDEX idx_traces_action ON device_traces(action);
+        CREATE INDEX idx_traces_addr ON device_traces(addr);
+        CREATE INDEX idx_blocks_addr ON blocks(addr);
+    """)
+
+    # Insert device traces (frames used in "Allocator State History" tab)
+    trace_id = 0
+    for traces in s.get("device_traces", []):
+        for trace in traces:
+            cursor.execute(
+                "INSERT INTO device_traces (id, time_us, size, action, addr, frames) VALUES (?, ?, ?, ?, ?, ?)",
+                (
+                    trace_id,
+                    trace.get("time_us", 0),
+                    trace.get("size", 0),
+                    trace.get("action", ""),
+                    trace.get("addr", 0),
+                    json.dumps(trace.get("frames", [])),
+                ),
+            )
+            trace_id += 1
+
+    # Insert segments and blocks (frames used in "Active Memory Timeline" tab)
+    block_id = 0
+    for seg_idx, segment in enumerate(s.get("segments", [])):
+        # Store segment as JSON (without blocks, they go in separate table)
+        segment_data = dict(segment)
+        segment_data.pop("blocks", None)
+
+        cursor.execute(
+            "INSERT INTO segments (segment_id, data) VALUES (?, ?)",
+            (seg_idx, json.dumps(segment_data)),
+        )
+
+        # Insert blocks for addr-based correlation with traces
+        for block in segment.get("blocks", []):
+            cursor.execute(
+                """INSERT INTO blocks (id, segment_id, addr, size, requested_size, state, frames)
+                   VALUES (?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    block_id,
+                    seg_idx,
+                    block.get("address", 0),
+                    block.get("size", 0),
+                    block.get("requested_size", 0),
+                    block.get("state", ""),
+                    json.dumps(block.get("frames", [])),
+                ),
+            )
+            block_id += 1
+
+    conn.commit()
+    conn.close()
+
+
 def _set_memory_metadata(metadata: str):
     """
     Set custom metadata that will be attached to all subsequent CUDA memory allocations.


### PR DESCRIPTION
### Summary
Adds torch.cuda.memory._dump_snapshot_sqlite() function that saves CUDA memory snapshots to SQLite format, enabling efficient querying of plot data without loading entire snapshots into memory.

### Motivation
The existing _dump_snapshot() saves to pickle format, which requires loading the entire file to access any data. For large snapshots (can be GBs for long-running workflows), this makes rendering buggy on browser based visualization tools. See https://github.com/pytorch/pytorch/issues/176288

### Design
We want to create minimal tables (with minimal columns) to ensure broad coverage and speed. Here, we create 3 tables:
* `device_traces`: Allocation history events
* `blocks`: Current memory block state
* `segments`: cudaMalloc'd regions

`segment_id` joins `blocks` and `segments`. `addr` joins `device_traces` and `blocks`.

```
# Record and dump
torch.cuda.memory._record_memory_history("all")
# ... run workload ...
torch.cuda.memory._dump_snapshot_sqlite("snapshot.db")

# Query plot data efficiently (no frame parsing)
cursor.execute("SELECT time_us, size, action FROM device_traces WHERE action = 'alloc'")

# Load stack trace only when needed
cursor.execute("SELECT frames FROM device_traces WHERE id = ?", (trace_id,))

# Correlate trace to current block
cursor.execute("""
    SELECT b.state, b.size FROM blocks b
    JOIN device_traces t ON t.addr = b.addr
    WHERE t.id = ?
""", (trace_id,))
```

