### PR TITLE
[fake tensor] Use torch.accelerator.is_available() in avoid_device_init

### DIFF
--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -1428,15 +1428,7 @@ class FakeTensorMode(TorchDispatchMode):
     #   (see NOTE: [torch.tensor, lift_fresh, and device movement])
     @property
     def avoid_device_init(self) -> bool:
-        if torch.xpu._is_compiled():
-            if torch.cuda._is_compiled():
-                raise AssertionError("Cannot have both xpu and cuda compiled")
-            return not torch.xpu.is_available()
-
-        return not (
-            torch.cuda.is_available()
-            or (hasattr(torch, "hpu") and torch.hpu.is_available())
-        )
+        return not torch.accelerator.is_available()
 
     @property
     def stack(self) -> str:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #178671

FakeTensorMode.avoid_device_init had a hardcoded chain of backend
checks (CUDA, XPU, HPU) that was missing PrivateUse1. This meant that
on systems with only a PrivateUse1 accelerator, tensor
constants created under fake tracing were unnecessarily forced through
CPU with a to_copy to device, instead of being created on-device
directly.

Replace the ad-hoc checks with torch.accelerator.is_available(), which
already handles CUDA, XPU, HPU, MTIA, and PrivateUse1 through the
unified accelerator API (at::getAccelerator in C++). This also
future-proofs the function against new accelerator backends.

cc @zou3519 @australopitek @guangyey @eellison

Authored with Claude.