### PR TITLE
Enable FA4 on Hopper in `test_varlen_attention`

### DIFF
--- a/test/test_varlen_attention.py
+++ b/test/test_varlen_attention.py
@@ -16,6 +16,7 @@ from torch.testing._internal.common_cuda import (
     PLATFORM_SUPPORTS_FLASH_ATTENTION,
     SM100OrLater,
     SM120OrLater,
+    SM90OrLater,
 )
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_nn import NNTestCase
@@ -56,6 +57,13 @@ def use_fa4():
 
 def _use_backend(backend):
     return {"fa2": nullcontext, "fa3": use_fa3, "fa4": use_fa4}[backend]()
+
+
+def _varlen_backends(*, include_fa4_paged_kv: bool) -> list[str]:
+    fa4_supported = (
+        SM100OrLater if include_fa4_paged_kv else SM90OrLater
+    ) and not SM120OrLater
+    return ["fa2"] + (["fa3"] if IS_SM90 else []) + (["fa4"] if fa4_supported else [])
 
 
 VarlenShape = namedtuple(
@@ -243,9 +251,7 @@ class TestVarlenAttention(NNTestCase):
     @parametrize("dtype", [torch.bfloat16, torch.float16])
     @parametrize(
         "backend",
-        ["fa2"]
-        + (["fa3"] if IS_SM90 else [])
-        + (["fa4"] if SM100OrLater and not SM120OrLater else []),
+        _varlen_backends(include_fa4_paged_kv=False),
     )
     def test_basic_functionality(self, device, dtype, backend):
         torch.manual_seed(42)
@@ -472,9 +478,7 @@ class TestVarlenAttention(NNTestCase):
     )
     @parametrize(
         "backend",
-        ["fa2"]
-        + (["fa3"] if IS_SM90 else [])
-        + (["fa4"] if SM100OrLater and not SM120OrLater else []),
+        _varlen_backends(include_fa4_paged_kv=False),
     )
     def test_varlen_vs_sdpa(self, device, dtype, scale, window_size, backend):
         torch.manual_seed(42)
@@ -754,12 +758,7 @@ class TestVarlenAttention(NNTestCase):
             [127, 63, 33, 17],
         ],
     )
-    @parametrize(
-        "backend",
-        ["fa2"]
-        + (["fa3"] if IS_SM90 else [])
-        + (["fa4"] if SM100OrLater and not SM120OrLater else []),
-    )
+    @parametrize("backend", _varlen_backends(include_fa4_paged_kv=False))
     def test_seqused_k_kv_cache(self, device, dtype, actual_kv_lens, backend):
         torch.manual_seed(42)
 
@@ -879,9 +878,7 @@ class TestVarlenAttention(NNTestCase):
     )
     @parametrize(
         "backend",
-        ["fa2"]
-        + (["fa3"] if IS_SM90 else [])
-        + (["fa4"] if SM100OrLater and not SM120OrLater else []),
+        _varlen_backends(include_fa4_paged_kv=True),
     )
     def test_block_table_kv_cache(
         self, device, dtype, page_size, compile, actual_kv_lens, backend


### PR DESCRIPTION
Since FA4 supports SM 9.0 
https://github.com/pytorch/pytorch/blob/e41371ce3a045f4306e0816921d38060e666b697/torch/nn/attention/_fa4.py#L110-L111 but there's one exception: https://github.com/pytorch/pytorch/blob/35f93d15cd44ddd175b54fb577c7eb33d6d947aa/torch/nn/attention/_fa4.py#L139-L140