### PR TITLE
Codegen backward epilogue subclass wrapping

### DIFF
--- a/test/functorch/test_codegen_backward_epilogue.py
+++ b/test/functorch/test_codegen_backward_epilogue.py
@@ -1,0 +1,206 @@
+# Owner(s): ["module: functorch"]
+
+"""
+Tests for codegen'ing _backward_epilogue_functional subclass wrapping.
+
+Currently, _backward_epilogue_functional uses wrap_tensor_subclasses() at
+runtime to wrap backward outputs (grad inputs) back into tensor subclasses.
+This is structurally identical to the forward output wrapping that was
+codegen'd in codegen_subclass_wrapper(). These tests define the expected
+behavior of a codegen'd backward epilogue.
+
+The key failing assertion is that a "backward_subclass_wrapper" artifact
+should be emitted via trace_structured, analogous to the "subclass_wrapper"
+artifact emitted by the forward path.
+"""
+
+import importlib.util
+import logging
+from contextlib import contextmanager
+
+import torch
+import torch._functorch.config
+
+
+_orig_find_spec = importlib.util.find_spec
+
+
+def _no_numba_find_spec(name, *a, **kw):  # type: ignore[no-untyped-def]
+    if name == "numba":
+        return None
+    return _orig_find_spec(name, *a, **kw)
+
+
+importlib.util.find_spec = _no_numba_find_spec  # type: ignore[assignment]
+from torch.testing._internal.common_utils import run_tests, TestCase  # noqa: E402
+from torch.testing._internal.two_tensor import TwoTensor  # noqa: E402
+
+
+importlib.util.find_spec = _orig_find_spec  # type: ignore[assignment]
+
+
+trace_log = logging.getLogger("torch.__trace")
+
+
+class TestCodegenBackwardEpilogue(TestCase):
+    @contextmanager
+    def _capture_codegen_source(self, artifact_name):
+        """Capture codegen artifacts from the structured trace log."""
+        captured: list[str] = []
+
+        class _ArtifactHandler(logging.Handler):
+            def emit(self, record):
+                metadata = getattr(record, "metadata", {})
+                if (
+                    "artifact" in metadata
+                    and metadata["artifact"].get("name") == artifact_name
+                ):
+                    payload = getattr(record, "payload", None)
+                    if payload is not None:
+                        captured.append(payload)
+
+        handler = _ArtifactHandler()
+        handler.setLevel(logging.DEBUG)
+        old_level = trace_log.level
+        trace_log.setLevel(logging.DEBUG)
+        trace_log.addHandler(handler)
+        try:
+            yield captured
+        finally:
+            trace_log.removeHandler(handler)
+            trace_log.setLevel(old_level)
+
+    def test_simple_backward_wraps_grad_inputs(self):
+        """
+        f(TwoTensor) -> TwoTensor, backward should wrap grad inputs back
+        into TwoTensor via codegen'd epilogue.
+        """
+        with self._capture_codegen_source("backward_subclass_wrapper") as captured:
+
+            @torch.compile(backend="aot_eager")
+            def f(x):
+                return x * 2
+
+            a = torch.randn(4, requires_grad=True)
+            b = torch.randn(4, requires_grad=True)
+            tt = TwoTensor(a, b)
+
+            # Run ref (eager) and test (compiled) to compare gradients
+            tt_ref = TwoTensor(
+                a.clone().detach().requires_grad_(True),
+                b.clone().detach().requires_grad_(True),
+            )
+            out_ref = tt_ref * 2
+            out_ref.sum().backward()
+
+            out = f(tt)
+            out.sum().backward()
+
+        self.assertIsInstance(out, TwoTensor)
+        self.assertIsInstance(tt.grad, TwoTensor)
+        self.assertEqual(tt.grad.a, tt_ref.grad.a)
+        self.assertEqual(tt.grad.b, tt_ref.grad.b)
+
+        self.assertGreaterEqual(
+            len(captured),
+            1,
+            "Expected backward_subclass_wrapper codegen artifact to be emitted",
+        )
+
+    def test_multi_input_backward_wraps_grad_inputs(self):
+        """
+        f(TwoTensor, TwoTensor) -> TwoTensor, backward should wrap grad
+        inputs for each subclass input.
+        """
+        with self._capture_codegen_source("backward_subclass_wrapper") as captured:
+
+            @torch.compile(backend="aot_eager")
+            def f(x, y):
+                return x * y
+
+            a = torch.randn(4, requires_grad=True)
+            b = torch.randn(4, requires_grad=True)
+            c = torch.randn(4, requires_grad=True)
+            d = torch.randn(4, requires_grad=True)
+
+            tt1_ref = TwoTensor(
+                a.clone().detach().requires_grad_(True),
+                b.clone().detach().requires_grad_(True),
+            )
+            tt2_ref = TwoTensor(
+                c.clone().detach().requires_grad_(True),
+                d.clone().detach().requires_grad_(True),
+            )
+            out_ref = tt1_ref * tt2_ref
+            out_ref.sum().backward()
+
+            tt1 = TwoTensor(a, b)
+            tt2 = TwoTensor(c, d)
+            out = f(tt1, tt2)
+            out.sum().backward()
+
+        self.assertIsInstance(out, TwoTensor)
+        self.assertIsInstance(tt1.grad, TwoTensor)
+        self.assertIsInstance(tt2.grad, TwoTensor)
+        self.assertEqual(tt1.grad.a, tt1_ref.grad.a)
+        self.assertEqual(tt1.grad.b, tt1_ref.grad.b)
+        self.assertEqual(tt2.grad.a, tt2_ref.grad.a)
+        self.assertEqual(tt2.grad.b, tt2_ref.grad.b)
+
+        self.assertGreaterEqual(
+            len(captured),
+            1,
+            "Expected backward_subclass_wrapper codegen artifact to be emitted",
+        )
+
+    def test_nested_subclass_backward_wraps_grad_inputs(self):
+        """
+        Nested TwoTensor backward should recursively wrap grad inputs.
+        """
+        with self._capture_codegen_source("backward_subclass_wrapper") as captured:
+
+            @torch.compile(backend="aot_eager")
+            def f(x):
+                return x.sin()
+
+            a1 = torch.randn(4, requires_grad=True)
+            a2 = torch.randn(4, requires_grad=True)
+            a3 = torch.randn(4, requires_grad=True)
+            a4 = torch.randn(4, requires_grad=True)
+
+            inner_a_ref = TwoTensor(
+                a1.clone().detach().requires_grad_(True),
+                a2.clone().detach().requires_grad_(True),
+            )
+            inner_b_ref = TwoTensor(
+                a3.clone().detach().requires_grad_(True),
+                a4.clone().detach().requires_grad_(True),
+            )
+            tt_ref = TwoTensor(inner_a_ref, inner_b_ref)
+            out_ref = tt_ref.sin()
+            out_ref.sum().backward()
+
+            inner_a = TwoTensor(a1, a2)
+            inner_b = TwoTensor(a3, a4)
+            tt = TwoTensor(inner_a, inner_b)
+            out = f(tt)
+            out.sum().backward()
+
+        self.assertIsInstance(out, TwoTensor)
+        self.assertIsInstance(out.a, TwoTensor)
+        self.assertIsInstance(out.b, TwoTensor)
+        self.assertIsInstance(tt.grad, TwoTensor)
+        self.assertEqual(tt.grad.a.a, tt_ref.grad.a.a)
+        self.assertEqual(tt.grad.a.b, tt_ref.grad.a.b)
+        self.assertEqual(tt.grad.b.a, tt_ref.grad.b.a)
+        self.assertEqual(tt.grad.b.b, tt_ref.grad.b.b)
+
+        self.assertGreaterEqual(
+            len(captured),
+            1,
+            "Expected backward_subclass_wrapper codegen artifact to be emitted",
+        )
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/_functorch/_aot_autograd/runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/runtime_wrappers.py
@@ -2172,6 +2172,7 @@ def _backward_epilogue_functional(
     *,
     ctx_opaque_objects: Sequence[Any] = (),
     make_subclass_override: Callable[..., Any] | None = None,
+    codegen_wrap_fn: Callable[..., Any] | None = None,
 ) -> tuple[Any, ...]:
     # Toss out the backward output tokens
     num_bw_tokens = metadata.num_backward_tokens
@@ -2201,10 +2202,11 @@ def _backward_epilogue_functional(
                 "(expected all to be consumed by FakeScriptObject slots in backward output)"
             )
 
-    # TODO: figure out how to refactor the backward properly so I can use aot_dispatch_subclass_wrapper() here.
     if maybe_subclass_metadata is not None:
         if maybe_subclass_metadata.grad_input_metas is None:
             raise AssertionError("grad_input_metas must not be None")
+        if codegen_wrap_fn is not None and make_subclass_override is None:
+            return codegen_wrap_fn(out)
         outs_wrapped = wrap_tensor_subclasses(
             out,
             subclass_metas=maybe_subclass_metadata.grad_input_metas,
@@ -2546,6 +2548,17 @@ Your tensor subclass must implement __coerce_same_metadata_as_tangent__."""
         # store on metadata so it's accessible during backward error handling
         fw_metadata.compile_id_str = _compile_id_str
 
+        _codegen_bw_wrap_fn = None
+        if (
+            maybe_subclass_meta is not None
+            and maybe_subclass_meta.grad_input_metas is not None
+        ):
+            from .subclass_codegen import codegen_backward_subclass_wrap
+
+            _codegen_bw_wrap_fn = codegen_backward_subclass_wrap(
+                maybe_subclass_meta.grad_input_metas,
+            )
+
         class CompiledFunction(torch.autograd.Function):
             compiled_fw = compiled_fw_func
             compiled_bw = compiled_bw_func
@@ -2554,6 +2567,7 @@ Your tensor subclass must implement __coerce_same_metadata_as_tangent__."""
             num_symints_saved_for_bw = num_symints_saved_for_bw_
             _aot_id = aot_config.aot_id
             _lazy_backward_info = lazy_backward_info
+            _bw_epilogue_wrap_fn = _codegen_bw_wrap_fn
 
             @staticmethod
             def _compiled_autograd_key(ctx: Any) -> tuple[Any, ...]:
@@ -2840,6 +2854,7 @@ Your tensor subclass must implement __coerce_same_metadata_as_tangent__."""
                         CompiledFunction.metadata,
                         CompiledFunction.maybe_subclass_metadata,
                         out,
+                        codegen_wrap_fn=CompiledFunction._bw_epilogue_wrap_fn,
                     )
 
                 if (

--- a/torch/_functorch/_aot_autograd/subclass_codegen.py
+++ b/torch/_functorch/_aot_autograd/subclass_codegen.py
@@ -250,6 +250,59 @@ def _codegen_subclass_wrapper_source(
     return source, state.globals
 
 
+def _codegen_subclass_wrap_source(
+    out_metas: list[PlainTensorMeta | SubclassCreationMeta],
+) -> tuple[str, dict[str, object]]:
+    """Generate source for wrapping flat outputs into subclasses.
+
+    This is a subset of _codegen_subclass_wrapper_source that only
+    generates the output wrapping part, used for the backward epilogue.
+    Returns (source, globals_dict).
+    """
+    state = _CodegenState()
+
+    state.emit("def wrap_fn(unwrapped_outs):", indent=0)
+    out_idx_ref = [0]
+    result_exprs: list[str] = []
+
+    for meta in out_metas:
+        if isinstance(meta, PlainTensorMeta):
+            result_exprs.append(f"unwrapped_outs[{meta.unwrapped_idx}]")
+            out_idx_ref[0] = max(out_idx_ref[0], meta.unwrapped_idx + 1)
+        else:
+            result_var = _codegen_wrap_subclass(state, meta, out_idx_ref)
+            result_exprs.append(result_var)
+
+    state.emit(f"return ({', '.join(result_exprs)},)")
+
+    source = "\n".join(state.lines)
+    return source, state.globals
+
+
+def codegen_backward_subclass_wrap(
+    out_metas: list[PlainTensorMeta | SubclassCreationMeta],
+) -> Callable[..., object]:
+    """Generate a specialized function for wrapping backward outputs into subclasses."""
+    source, globals_dict = _codegen_subclass_wrap_source(out_metas)
+
+    if log.isEnabledFor(logging.DEBUG):
+        log.debug("Generated backward subclass wrapper:\n%s", source)
+
+    torch._logging.trace_structured(
+        "artifact",
+        metadata_fn=lambda: {
+            "name": "backward_subclass_wrapper",
+            "encoding": "string",
+        },
+        payload_fn=lambda: source,
+    )
+
+    code = compile(source, "<backward_subclass_wrapper>", "exec")
+    local_dict: dict[str, object] = {}
+    exec(code, globals_dict, local_dict)  # noqa: S102
+    return local_dict["wrap_fn"]  # type: ignore[return-value]
+
+
 def codegen_subclass_wrapper(
     compiled_fn: Callable[..., object],
     inp_metas: list[PlainTensorMeta | SubclassCreationMeta],


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #178674

Replace the closure-based wrap_tensor_subclasses() call in
_backward_epilogue_functional with a codegen'd wrap_fn. At compile
time, codegen_backward_subclass_wrap() generates straight-line Python
source using the existing _codegen_wrap_subclass helper, with all
subclass types, attr names, and symint positions baked in as literals.

The codegen'd path is used for the eager backward; the compiled
autograd path (which passes make_subclass_override) falls back to
the existing wrap_tensor_subclasses.