### PR TITLE
[Inductor][Reinplace] Make auto fucntionalize info message more readable

### DIFF
--- a/torch/_inductor/fx_passes/reinplace.py
+++ b/torch/_inductor/fx_passes/reinplace.py
@@ -596,7 +596,11 @@ def reinplace_inplaceable_ops_core(graph: torch.fx.Graph) -> None:
             old_node_name,
             node_name,
             old_tensors_to_clone,
-            [tensor_idx for tensor_idx in old_tensors_to_clone if tensor_idx not in tensors_to_clone],
+            [
+                tensor_idx
+                for tensor_idx in old_tensors_to_clone
+                if tensor_idx not in tensors_to_clone
+            ],
             tensors_to_clone,
             missed_args,
             missed_bytes,

--- a/torch/_inductor/fx_passes/reinplace.py
+++ b/torch/_inductor/fx_passes/reinplace.py
@@ -896,6 +896,7 @@ def reinplace_inplaceable_ops_core(graph: torch.fx.Graph) -> None:
             tensors_to_clone = reinplace_and_refine_tensors_to_clone(
                 node.kwargs["tensors_to_clone"],
                 node.kwargs["kwargs"],
+                node.name,
                 kernel_name,
                 ReInplaceTrigger.TRITON_OPS,
             )

--- a/torch/_inductor/fx_passes/reinplace.py
+++ b/torch/_inductor/fx_passes/reinplace.py
@@ -561,6 +561,7 @@ def reinplace_inplaceable_ops_core(graph: torch.fx.Graph) -> None:
         return all(can_inplace(node, arg) for arg in mutated_args)
 
     def log_inplace_results(
+        old_node_name,
         node_name,
         old_tensors_to_clone,
         tensors_to_clone,
@@ -590,12 +591,12 @@ def reinplace_inplaceable_ops_core(graph: torch.fx.Graph) -> None:
                 missed_bytes += bytes(node)
 
         log.info(
-            "For node %s, attempted to reinplace %s. We were unable to reinplace %s; "
-            "%s (if non-empty) are possible missed reinplacing opportunities that may be bad for "
-            "memory usage and performance. Total size of missed opportunities with static shapes is"
-            " : %s bytes.",
+            "Reinplace for %s (wrapped by %s): candidates=%s, successfully reinplaced=%s, "
+            "remain clones=%s, missed opportunities=%s, missed static bytes=%s.",
+            old_node_name,
             node_name,
             old_tensors_to_clone,
+            [tensor_idx for tensor_idx in old_tensors_to_clone if tensor_idx not in tensors_to_clone],
             tensors_to_clone,
             missed_args,
             missed_bytes,
@@ -607,7 +608,7 @@ def reinplace_inplaceable_ops_core(graph: torch.fx.Graph) -> None:
     replace_dict: dict[torch.fx.Node, torch.fx.Node] = {}
 
     def reinplace_and_refine_tensors_to_clone(
-        old_tensors_to_clone, kwargs, node_name, trigger
+        old_tensors_to_clone, kwargs, node_name, old_node_name, trigger
     ):
         tensors_to_clone: list[str] = []
         storage_of_reinplaced_args = OrderedSet[int | None]()
@@ -669,6 +670,7 @@ def reinplace_inplaceable_ops_core(graph: torch.fx.Graph) -> None:
                 tensors_to_clone.append(arg)
 
         log_inplace_results(
+            old_node_name,
             node_name,
             old_tensors_to_clone,
             tensors_to_clone,
@@ -705,7 +707,8 @@ def reinplace_inplaceable_ops_core(graph: torch.fx.Graph) -> None:
                 new_bases_to_clone: list[int] = reinplace_and_refine_tensors_to_clone(
                     bases_to_clone,
                     base_tensors_dct,
-                    node.target,
+                    node.name,
+                    _mutable_op._name,
                     ReInplaceTrigger.AUTO_FUNC_V2,
                 )
                 # Stash the metadata. There is a pass later on where we decompose
@@ -724,6 +727,7 @@ def reinplace_inplaceable_ops_core(graph: torch.fx.Graph) -> None:
             tensors_to_clone = reinplace_and_refine_tensors_to_clone(
                 tensors_to_clone,
                 node.kwargs,
+                node.name,
                 _mutable_op._name,
                 ReInplaceTrigger.AUTO_FUNC_V1,
             )


### PR DESCRIPTION
This PR is going to fix #135032, make auto functionalize info message more readable.

**Before:**
For node **auto_functionalized_v2,** attempted to reinplace **range(0, 2)**. We were unable to reinplace **[]**; **[]** (if non-empty) are possible missed reinplacing opportunities that may be bad for memory usage and performance. Total size of missed opportunities with static shapes is : **0** bytes.

For node **add_kernel_autotuned**, attempted to reinplace **['out_ptr']**. We were unable to reinplace **[]**; **[]** (if non-empty) are possible missed reinplacing opportunities that may be bad for memory usage and performance. Total size of missed opportunities with static shapes is : **0** bytes.

**After:**
Reinplace for **mylib::foo** (wrapped by **auto_functionalized_v2**): candidates=**range(0, 2)**, successfully reinplaced=**[0, 1]**, remain clones=**[]**, missed opportunities=**[]**, missed static bytes=**0**.

Reinplace for **add_kernel_autotuned**(wrapped by **triton_kernel_wrapper_functional_proxy**): candidates=**['out_ptr']**, successfully reinplaced=**['out_ptr']**, remain clones=**[]**, missed opportunities=**[]**, missed static bytes=**0**.

cc @tugsbayasgalan @zou3519 @ydwu4 @Chillee @kshitij12345 @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @eellison @cyyever

