### PR TITLE
[SDPA] Fix device mismatch in scaled_dot_product_attention docstring example

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -5996,7 +5996,7 @@ scaled_dot_product_attention = _add_docstr(
             attn_bias = torch.zeros(L, S, dtype=query.dtype, device=query.device)
             if is_causal:
                 assert attn_mask is None
-                temp_mask = torch.ones(L, S, dtype=torch.bool).tril(diagonal=0)
+                temp_mask = torch.ones(L, S, dtype=torch.bool, device=query.device).tril(diagonal=0)
                 attn_bias.masked_fill_(temp_mask.logical_not(), float("-inf"))
 
             if attn_mask is not None:


### PR DESCRIPTION
The example code in the `scaled_dot_product_attention` docstring creates
`attn_bias` on `query.device` but creates `temp_mask` on CPU (no device
specified). This causes a device mismatch error when running the example
with CUDA tensors, since `masked_fill_` requires both tensors on the same
device.

Add `device=query.device` to the `torch.ones()` call, matching the
`torch.zeros()` call two lines above.

Fixes https://github.com/pytorch/pytorch/issues/166117

cc @jbschlosser