### PR TITLE
[ROCm] Fix wrong ROCM code execution in in `ScaledBlas.cpp` at `check_swizzle_lengths()`

### DIFF
--- a/aten/src/ATen/native/cuda/ScaledBlas.cpp
+++ b/aten/src/ATen/native/cuda/ScaledBlas.cpp
@@ -1228,7 +1228,7 @@ _scaled_nvfp4_nvfp4(
 void check_swizzle_lengths(ScaledGemmImplementation impl,
                            std::vector<SwizzleType>& swizzle_a,
                            std::vector<SwizzleType>& swizzle_b) {
-#ifdef ROCM
+#ifdef USE_ROCM
   // ROCM doesn't swizzle their formats - we don't care what's passed.
   return;
 #else


### PR DESCRIPTION
This fixes #178687

In line 1231 we got

```cpp
#ifdef ROCM
  // ROCM doesn't swizzle their formats - we don't care what's passed.
  return;
#else
  // Store implementations that care about swizzling, and how many swizzle arguments
  // they have to have
  // NOTE(slayton): auto here is unable to deduce the correct type..
  std::array<std::tuple<ScaledGemmImplementation, unsigned int>, 4> swizzled_impl = {{
    // {implementation, # required arguments}
    {ScaledGemmImplementation::MXFP8_MXFP8, 1},
    {ScaledGemmImplementation::NVFP4_NVFP4, 2},
    {ScaledGemmImplementation::NVFP4_NVFP4_SINGLE_SCALE, 1},
    {ScaledGemmImplementation::MXFP4_MXFP4, 1}
  }};
```

while `#ifdef ROCM` is not defined, so `// ROCM doesn't swizzle their formats - we don't care what's passed.
  return;` will never be executed, instead the other part is executed always which causes overhead, so the part should  be changed to

```cpp
#ifdef USE_ROCM
  // ROCM doesn't swizzle their formats - we don't care what's passed.
  return;
#else
  // Store implementations that care about swizzling, and how many swizzle arguments
  // they have to have
  // NOTE(slayton): auto here is unable to deduce the correct type..
  std::array<std::tuple<ScaledGemmImplementation, unsigned int>, 4> swizzled_impl = {{
    // {implementation, # required arguments}
    {ScaledGemmImplementation::MXFP8_MXFP8, 1},
    {ScaledGemmImplementation::NVFP4_NVFP4, 2},
    {ScaledGemmImplementation::NVFP4_NVFP4_SINGLE_SCALE, 1},
    {ScaledGemmImplementation::MXFP4_MXFP4, 1}
  }};
```

Contributed by Benedikt Johannes

cc @jerryzh168 @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang