### PR TITLE
[regional_inductor] Add partition merging for regions connected by data dependencies

### DIFF
--- a/test/dynamo/test_regional_inductor.py
+++ b/test/dynamo/test_regional_inductor.py
@@ -1605,6 +1605,60 @@ class RegionalInductorPartitionTests(torch._inductor.test_case.TestCase):
         gm = torch.fx.GraphModule(torch.nn.Module(), g)
         self.assertEqual(self._scoop_and_count(gm), 2)
 
+    def test_dependent_partitions_merged_across_gap(self):
+        """Two tagged runs separated by an untagged node but connected by a
+        data dependency should be merged into 1 partition.
+
+        tagged(x) -> untagged -> tagged(tagged_result) => 1 partition
+        """
+        g = torch.fx.Graph()
+        x = g.placeholder("x")
+        mul_a = self._make_tag_node(g, x, 2.0, tagged=True)
+        sin = g.call_function(torch.ops.aten.sin.default, (x,))
+        sin.meta["val"] = torch.empty(10)
+        # mul_b consumes mul_a, creating a data dependency across the gap
+        mul_b = self._make_tag_node(g, mul_a, 3.0, tagged=True)
+        g.output(mul_b)
+        gm = torch.fx.GraphModule(torch.nn.Module(), g)
+        self.assertEqual(self._scoop_and_count(gm), 1)
+
+    def test_different_annotations_not_merged(self):
+        """Two tagged runs with different annotations should NOT be merged,
+        even if connected by a data dependency.
+        """
+        g = torch.fx.Graph()
+        x = g.placeholder("x")
+        mul_a = self._make_tag_node(g, x, 2.0, tagged=True)
+        # Override annotation to use a different ID
+        mul_a.meta["custom"] = {"compile_with_inductor": 0}
+        sin = g.call_function(torch.ops.aten.sin.default, (x,))
+        sin.meta["val"] = torch.empty(10)
+        mul_b = self._make_tag_node(g, mul_a, 3.0, tagged=True)
+        mul_b.meta["custom"] = {"compile_with_inductor": 1}
+        g.output(mul_b)
+        gm = torch.fx.GraphModule(torch.nn.Module(), g)
+        self.assertEqual(self._scoop_and_count(gm), 2)
+
+    def test_chained_merges_across_multiple_gaps(self):
+        """Multiple tagged runs with the same annotation and chained data
+        dependencies should all merge into 1 partition.
+
+        tagged_a(x) -> untagged(x) -> tagged_b(tagged_a) -> untagged(x) -> tagged_c(tagged_b) => 1
+        """
+        g = torch.fx.Graph()
+        x = g.placeholder("x")
+        tagged_a = self._make_tag_node(g, x, 2.0, tagged=True)
+        # Untagged node consuming x (not tagged_a), just occupying a slot
+        filler_1 = g.call_function(torch.ops.aten.sin.default, (x,))
+        filler_1.meta["val"] = torch.empty(10)
+        tagged_b = self._make_tag_node(g, tagged_a, 3.0, tagged=True)
+        filler_2 = g.call_function(torch.ops.aten.sin.default, (x,))
+        filler_2.meta["val"] = torch.empty(10)
+        tagged_c = self._make_tag_node(g, tagged_b, 4.0, tagged=True)
+        g.output(tagged_c)
+        gm = torch.fx.GraphModule(torch.nn.Module(), g)
+        self.assertEqual(self._scoop_and_count(gm), 1)
+
 
 if __name__ == "__main__":
     run_tests()

--- a/torch/fx/passes/regional_inductor.py
+++ b/torch/fx/passes/regional_inductor.py
@@ -23,6 +23,36 @@ def _dummy_wrapper(fn):
     return inner
 
 
+def _merge_connected_partitions(
+    partitions: list[dict[torch.fx.Node, int | None]],
+) -> list[dict[torch.fx.Node, int | None]]:
+    """Merge adjacent partitions with the same annotation connected by data dependencies."""
+    if len(partitions) <= 1:
+        return partitions
+
+    def _depends_on(part, prev_nodes):
+        for node in part:
+            for inp in node.all_input_nodes:
+                if inp in prev_nodes:
+                    return True
+        return False
+
+    def _get_partition_annotation(part):
+        node = next(iter(part))
+        return node.meta["custom"]["compile_with_inductor"]
+
+    merged = [partitions[0]]
+    for part in partitions[1:]:
+        current_annotation = _get_partition_annotation(part)
+        prev_annotation = _get_partition_annotation(merged[-1])
+        prev_nodes = set(merged[-1].keys())
+        if current_annotation == prev_annotation and _depends_on(part, prev_nodes):
+            merged[-1].update(part)
+        else:
+            merged.append(part)
+    return merged
+
+
 def _compile_submod(gm, prefix):
     from torch._inductor.standalone_compile import AOTCompiledArtifact
 
@@ -134,6 +164,8 @@ class _RegionScooper:
         if not partitions:
             logger.info("No inductor marked nodes found")
             return gm
+
+        partitions = _merge_connected_partitions(partitions)
 
         return fuse_by_partitions(
             gm,


### PR DESCRIPTION
Summary: https://github.com/pytorch/pytorch/pull/178421 changed the scooper to contiguous-run partitioning. However, in torchtitan graph_trainer's captured graph, each transformer block with flex attention has the following structure:
```
  [MARKED]     detach nodes + get_attr nodes (fw_graph0, joint_graph0, mask_graph0)
  [UNMARKED]   ~50 recompute nodes (rms_norm, FSDP all-gather, wq/wk/wv matmuls, RoPE, transposes)
  [MARKED]     flex_attention_backward(... fw_graph0, joint_graph0, mask_graph0 ...)
```
The`get_attr` nodes reference GraphModule objects (subgraph functions for flex_attention_backward such as score_mod, joint_score_mod, and mask_mod). The unmarked nodes are inserted between the two marked region because of SAC.

With contiguous-run partitioning, scoop_regions creates two separate partitions:

- Partition 0: detach nodes + get_attr nodes (fw_graph0, joint_graph0, mask_graph0). The get_attr
nodes are inside this partition, so lift_subgraph_as_module copies the GraphModule attributes into the scooped submodule. This partition compiles fine.
- Partition 1: flex_attention_backward. This op uses fw_graph0, joint_graph0, mask_graph0, but those get_attr nodes are in Partition 0, not here. So fuse_as_graphmodule treats them as external inputs and creates placeholder nodes for them. The GraphModule values become regular function arguments. When Partition 1 is being compiled, it cannot handle GraphModule input argument during tracing.

This PR fixes the issue by merging adjacent regional inductor partitions that have the same annotation and are connected by data dependencies.

Test Plan: Added unittests

Also fixed torchtitan CI failure
```
MODULE=graph_trainer.llama3 CONFIG=graph_trainer_llama3_debugmodel_flex_attn ./run_train.sh --parallelism.data_parallel_shard_degree 4 --parallelism.tensor_parallel_degree 2 --compile.passes regional_inductor    
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98