### PR TITLE
[inductor] Handle non-tensor graph inputs in GraphLowering

### DIFF
--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -1009,7 +1009,12 @@ class GraphLowering(torch.fx.Interpreter):
         if buffer_name in self.name_to_buffer:
             return self.name_to_buffer[buffer_name].get_dtype()
         if buffer_name in self.graph_inputs:
-            return self.graph_inputs[buffer_name].get_dtype()
+            inp = self.graph_inputs[buffer_name]
+            if isinstance(inp, ir.NonTensorObj):
+                raise TypeError(
+                    f"get_dtype called on non-tensor graph input {buffer_name!r}"
+                )
+            return inp.get_dtype()
         m = re.match(r"(as_strided|reinterpret_tensor)\(([a-zA-Z0-9_]+),", buffer_name)
         if m:
             return self.get_dtype(m.group(1))
@@ -1024,7 +1029,12 @@ class GraphLowering(torch.fx.Interpreter):
                 return 1
             return buf.get_numel()
         if buffer_name in self.graph_inputs:
-            return self.graph_inputs[buffer_name].get_numel()
+            inp = self.graph_inputs[buffer_name]
+            if isinstance(inp, ir.NonTensorObj):
+                raise TypeError(
+                    f"get_numel called on non-tensor graph input {buffer_name!r}"
+                )
+            return inp.get_numel()
         raise KeyError(f"could not find {buffer_name}")
 
     def run(self, *args: Any) -> Any:  # type: ignore[override]
@@ -1540,6 +1550,7 @@ class GraphLowering(torch.fx.Interpreter):
                     ir.EffectfulKernel,
                     ir.ShapeAsConstantBuffer,
                     TorchBindObject,
+                    ir.OpaqueObjectState,
                     ir.OpaqueMultiOutput,
                     ir.OpaqueValueTypeConstant,
                 ),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #178695
* #178694
* #178693
* #178692
* #178691

With opaque reference hoisting, DeviceMesh flows through Inductor as a
graph input (NonTensorObj). GraphLowering.get_dtype() and get_numel()
assumed all graph_inputs support these methods, causing AttributeError
for non-tensor inputs.

Raise TypeError for get_dtype/get_numel when the input is a
NonTensorObj — these should never be called on non-tensor inputs, and
an explicit error is better than returning a fake value. Also add
OpaqueObjectState to the set of non-tensor IR types that bypass
tensor-specific processing in the run method.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo