### PR TITLE
[inductor] Handle OpaqueObjectState in graph outputs and memory planner

### DIFF
--- a/test/test_opaque_obj_v2.py
+++ b/test/test_opaque_obj_v2.py
@@ -3740,7 +3740,6 @@ def forward(self, p_linear_weight, p_linear_bias, obj_lifted_custom_0, x):
         for code in codes:
             self.assertNotIn("pickle", code)
 
-
     def test_opaque_object_state_in_graph_output(self):
         """When compile_fx_inner receives a graph where a raw opaque reference
         type appears in the outputs (not just inputs), inductor must handle it.

--- a/test/test_opaque_obj_v2.py
+++ b/test/test_opaque_obj_v2.py
@@ -3741,6 +3741,42 @@ def forward(self, p_linear_weight, p_linear_bias, obj_lifted_custom_0, x):
             self.assertNotIn("pickle", code)
 
 
+    def test_opaque_object_state_in_graph_output(self):
+        """When compile_fx_inner receives a graph where a raw opaque reference
+        type appears in the outputs (not just inputs), inductor must handle it.
+        This happens in CooR (compile-on-one-rank) precompile: aot_autograd
+        partitions the joint graph so the forward graph saves opaque objects
+        (e.g. DeviceMesh) for the backward graph by including them in forward
+        outputs.  Inductor must:
+          1. Accept OpaqueObjectState in the output type assertion
+             (GraphLowering.output).
+          2. Handle NonTensorObj graph inputs in the memory planner
+             (get_dep_size_hint) without calling get_numel/get_dtype on them."""
+        m = OpaqueMultiplier(2.0)
+        x = torch.ones(3)
+
+        graph = torch.fx.Graph()
+        m_node = graph.placeholder("m")
+        m_node.meta["val"] = m
+        fake_mode = FakeTensorMode()
+        x_node = graph.placeholder("x")
+        x_node.meta["val"] = fake_mode.from_tensor(x)
+        out = graph.call_function(
+            torch.ops._TestOpaqueObject.mul_with_scale.default, (m_node, x_node)
+        )
+        out.meta["val"] = fake_mode.from_tensor(x)
+        # Include the opaque object in the output tuple, simulating how
+        # aot_autograd's forward graph passes saved-for-backward objects
+        # through as outputs.
+        graph.output((out, m_node))
+
+        gm = torch.fx.GraphModule({}, graph)
+        compiled = compile_fx_inner(gm, [m, x])
+        result = compiled([m, x])
+        self.assertEqual(result[0], x * 2)
+        self.assertIs(result[1], m)
+
+
 instantiate_parametrized_tests(TestOpaqueObject)
 
 

--- a/torch/_functorch/_aot_autograd/graph_compile.py
+++ b/torch/_functorch/_aot_autograd/graph_compile.py
@@ -197,8 +197,10 @@ def _hoist_opaque_ref_getattrs(
         joint_inputs[0].append(val)
 
         info: dict[str, Any] = {"type": type(real_val).__name__}
-        if hasattr(real_val, "mesh_dim_names"):
+        if hasattr(real_val, "mesh_dim_names") and real_val.mesh_dim_names is not None:
             info["mesh_dim_names"] = tuple(real_val.mesh_dim_names)
+        else:
+            info["value"] = val
         hoisted_info.append(info)
 
     for get_attr_node, obj_id, _val in hoisted_nodes:
@@ -247,18 +249,23 @@ def _wrap_hoisted_opaque_refs(
     """
     from functools import wraps
 
+    needs_mesh = any("mesh_dim_names" in info for info in info_list)
+
     @wraps(compiled_fn)
     def wrapper(args: list[Any]) -> Any:
-        parent_mesh = _find_parent_device_mesh(args)
-        if parent_mesh is None:
+        parent_mesh = _find_parent_device_mesh(args) if needs_mesh else None
+        if needs_mesh and parent_mesh is None:
             raise RuntimeError(
                 "Cannot find parent DeviceMesh in runtime args to derive "
                 "hoisted submeshes: "
                 f"{[i.get('mesh_dim_names') for i in info_list]}"
             )
         for info in info_list:
-            dim_names = tuple(info["mesh_dim_names"])
-            args.append(parent_mesh[dim_names])
+            if "mesh_dim_names" in info:
+                dim_names = tuple(info["mesh_dim_names"])
+                args.append(parent_mesh[dim_names])
+            else:
+                args.append(info["value"])
         return compiled_fn(args)
 
     wrapper._boxed_call = True  # type: ignore[attr-defined]

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -663,6 +663,12 @@ class GraphLowering(torch.fx.Interpreter):
         """
         if (dep, count_bytes) not in self.dep_size_hint_cache:
             res = 0
+            # Non-tensor graph inputs (TorchBindObject, OpaqueObjectState)
+            # have no meaningful size — skip the size computation entirely.
+            inp = self.graph_inputs.get(dep.name)
+            if isinstance(inp, ir.NonTensorObj):
+                self.dep_size_hint_cache[(dep, count_bytes)] = 0
+                return 0
             try:
                 if (
                     not dep.has_unbacked_symbols()
@@ -1563,6 +1569,7 @@ class GraphLowering(torch.fx.Interpreter):
                     TorchBindObject,
                     ir.OpaqueMultiOutput,
                     ir.OpaqueValueTypeConstant,
+                    ir.OpaqueObjectState,
                 ),
             )
             for x in result


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #178694
* __->__ #178701
* #178692
* #178691

When CooR (compile-on-one-rank) precompile compiles a model with
hoisted opaque reference types (e.g. DeviceMesh with hoist=True),
aot_autograd partitions the joint forward/backward graph such that
the opaque object appears as a forward graph output — it must be
saved for the backward graph. This triggered two failures in
inductor's GraphLowering:

1. **Output type assertion** (GraphLowering.output): The assertion
   at graph.py:1550 that validates all output types did not include
   OpaqueObjectState. When the hoisted DeviceMesh appeared in forward
   outputs (passed through to backward), the assertion failed with
   `AssertionError: [TensorBox(...), OpaqueObjectState(...)]`.
   Fix: add ir.OpaqueObjectState to the allowed output types.

2. **Memory planner crash** (get_dep_size_hint): Hoisted opaque
   objects have names like `hoisted__torchbind_obj0` which don't
   match the `primals_`/`arg` prefixes that is_nonfreeable_buffers
   checks. The memory planner then tried to compute their size via
   get_numel/get_dtype, which NonTensorObj doesn't implement.
   Fix: early-return 0 for NonTensorObj graph inputs in
   get_dep_size_hint, since non-tensor objects have no memory
   footprint to plan around.

Both issues are exercised by the new test which constructs an
inductor graph with OpaqueObjectState in both inputs and outputs,
mirroring the CooR precompile forward graph structure.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo