### PR TITLE
Align slow-path MHA batch_first layout

### DIFF
--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -403,6 +403,31 @@ class TestTransformers(NNTestCase):
         finally:
             torch.backends.mha.set_fastpath_enabled(previous_fastpath)
 
+    def test_multiheadattention_batch_first_slowpath_output_is_contiguous(self, device):
+        previous_fastpath = torch.backends.mha.get_fastpath_enabled()
+        try:
+            torch.backends.mha.set_fastpath_enabled(False)
+            batch_size = 4
+            seq_len = 32
+            embed_dim = 256
+            num_heads = 8
+
+            mha = nn.MultiheadAttention(
+                embed_dim, num_heads, batch_first=True, device=device
+            ).eval()
+            x = torch.randn(batch_size, seq_len, embed_dim, device=device)
+
+            with torch.no_grad():
+                attn_output, _ = mha(x, x, x, need_weights=False)
+
+            self.assertTrue(attn_output.is_contiguous())
+            self.assertEqual(
+                attn_output.view(batch_size * seq_len, embed_dim).shape,
+                (batch_size * seq_len, embed_dim),
+            )
+        finally:
+            torch.backends.mha.set_fastpath_enabled(previous_fastpath)
+
     @parametrize("nhead", [1, 4, 8])
     def test_transformerencoderlayer_src_mask(self, device, nhead):
         batch_size = 2

--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -1511,7 +1511,7 @@ class MultiheadAttention(Module):
                 is_causal=is_causal,
             )
         if self.batch_first and is_batched:
-            return attn_output.transpose(1, 0), attn_output_weights
+            return attn_output.transpose(1, 0).contiguous(), attn_output_weights
         else:
             return attn_output, attn_output_weights
 


### PR DESCRIPTION
Fix #178039

## Summary
1. Root cause problem
   The slow `nn.MultiheadAttention(batch_first=True)` path returns `attn_output.transpose(1, 0)` directly, which is a non-contiguous view. Eager runs that hit `_native_multi_head_attention` return a contiguous batch-first tensor instead, so `torch.compile` can observe a different layout than eager and reject downstream `.view()` calls.

2. Proposed fix
   Return a contiguous tensor from the slow `batch_first` path by materializing the transposed output before returning it, and add a regression test that disables the MHA fast path and verifies the returned tensor is contiguous and supports `.view()`.

3. Why the proposed fix is the right long term fix
   This aligns the observable output layout of the slow and fast `batch_first` paths, which removes layout-dependent behavior differences between eager and compiled execution while preserving the existing tensor values and API shape contract.

Drafted via Codex, published after manual review by @bobrenjc93