### PR TITLE
fix issue#176211: Add out-of-bounds handling

### DIFF
--- a/test/dynamo/test_guard_with_list_tensors.py
+++ b/test/dynamo/test_guard_with_list_tensors.py
@@ -1,0 +1,26 @@
+import torch
+import torch._dynamo
+import torch._dynamo.test_case
+from torch._C._dynamo import guards
+
+# logging.basicConfig(level=logging.DEBUG,
+#                     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+
+@torch.compile
+def fn(a, b, data):
+    x = a + b
+    if data is not None:
+        x = x + data[0] + data[1]
+    return x
+
+class TestGuardWithListofTensors(torch._dynamo.test_case.TestCase):
+    def test_tensor_duplicated_outbound(self):
+        t1, t2 = torch.randn(4), torch.randn(4)
+        fn(t1, t2, [torch.randn(4), torch.randn(4)])
+        t = torch.randn(4)
+        fn(t, t, None)
+
+if __name__ == "__main__":
+    from torch._dynamo.test_case import run_tests
+
+    run_tests()

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -4865,17 +4865,26 @@ def recompilation_reason_for_no_tensor_aliasing_guard(
     assert guard_manager.global_scope is not None
     global_scope = dict(guard_manager.global_scope)
     ids_to_source = collections.defaultdict(list)
+    outbound_tensors = []
     for tensor_source in guard_manager.no_tensor_aliasing_sources:
         global_scope["__compile_source__"] = tensor_source
-        tensor_id = id(eval(tensor_source, global_scope, scope))
+        try:
+            tensor = eval(tensor_source, global_scope, scope)
+        except:
+            outbound_tensors.append(tensor_source)
+        tensor_id = id(tensor)
         ids_to_source[tensor_id].append(tensor_source)
 
     duplicate_tensors = [
         f"{ids_to_source[key]}" for key in ids_to_source if len(ids_to_source[key]) > 1
     ]
 
-    reason = ", ".join(duplicate_tensors)
-    return [f"Duplicate tensors found: {reason}"]
+    duplicate_reason = ", ".join(duplicate_tensors)
+    reason = [f"Duplicate tensors found: {duplicate_reason}"]
+    if len(outbound_tensors) > 0:
+        outbound_reason = ",".join(outbound_tensors)
+        reason.append(f"Outbound tensors found: {outbound_reason}")
+    return reason
 
 
 def strip_local_scope(s: str) -> str:

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -4866,22 +4866,25 @@ def recompilation_reason_for_no_tensor_aliasing_guard(
     global_scope = dict(guard_manager.global_scope)
     ids_to_source = collections.defaultdict(list)
     outbound_tensors = []
+
     for tensor_source in guard_manager.no_tensor_aliasing_sources:
         global_scope["__compile_source__"] = tensor_source
         try:
             tensor = eval(tensor_source, global_scope, scope)
-        except:
+            tensor_id = id(tensor)
+            ids_to_source[tensor_id].append(tensor_source)
+        except Exception:
             outbound_tensors.append(tensor_source)
-        tensor_id = id(tensor)
-        ids_to_source[tensor_id].append(tensor_source)
 
     duplicate_tensors = [
         f"{ids_to_source[key]}" for key in ids_to_source if len(ids_to_source[key]) > 1
     ]
 
-    duplicate_reason = ", ".join(duplicate_tensors)
-    reason = [f"Duplicate tensors found: {duplicate_reason}"]
-    if len(outbound_tensors) > 0:
+    reason = []
+    if duplicate_tensors:
+        duplicate_reason = ", ".join(duplicate_tensors)
+        reason.append(f"Duplicate tensors found: {duplicate_reason}")
+    if outbound_tensors:
         outbound_reason = ",".join(outbound_tensors)
         reason.append(f"Outbound tensors found: {outbound_reason}")
     return reason


### PR DESCRIPTION
fix https://github.com/pytorch/pytorch/issues/176211
Add handling for out-of-bounds values ​​to `recompilation_reason_for_no_tensor_aliasing_guard` to prevent errors when retrieving the id of tensor_source.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98