### PR TITLE
[CPU] Add blendv to Vectorizedf8 for bool-to-float8 conversion

### DIFF
--- a/aten/src/ATen/cpu/vec/vec512/vec512_float8.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_float8.h
@@ -377,6 +377,15 @@ class Vectorizedf8 {
     }
   }
 
+  static Vectorized<T> blendv(
+      const Vectorized<T>& a,
+      const Vectorized<T>& b,
+      const Vectorized<T>& mask) {
+    auto msb_one = _mm512_set1_epi8(0xFF);
+    auto mask_ = _mm512_cmp_epu8_mask((__m512i)mask, msb_one, _MM_CMPINT_EQ);
+    return _mm512_mask_blend_epi8(mask_, (__m512i)a, (__m512i)b);
+  }
+
   Vectorized<T> abs() const {
     return _mm512_andnot_si512(_mm512_set1_epi8(0x80), values);
   }

--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -5992,6 +5992,31 @@ class CPUReproTests(TestCase):
             "Expected convert<at::Float8_e4m3fn,1,float,2> in generated code for func1",
         )
 
+    @requires_vectorization
+    def test_bool_to_float8_e4m3fn(self):
+        """
+        Test that bool to float8_e4m3fn cast succeeds.
+        Issue: https://github.com/pytorch/pytorch/issues/178095
+        """
+
+        def fn(x):
+            return x.to(dtype=torch.float8_e4m3fn)
+
+        x = torch.ones(64, dtype=torch.bool)
+        self.common(fn, (x,))
+
+    @requires_vectorization
+    def test_bool_to_float8_e5m2(self):
+        """
+        Test that bool to float8_e5m2 cast succeeds.
+        """
+
+        def fn(x):
+            return x.to(dtype=torch.float8_e5m2)
+
+        x = torch.ones(64, dtype=torch.bool)
+        self.common(fn, (x,))
+
     @config.patch("cpp.simdlen", 256)
     @requires_vectorization
     def test_avx2_bool_constant_pad_nd(self):


### PR DESCRIPTION
Reopen of https://github.com/pytorch/pytorch/pull/178221 since I don't know how to merge that PR created by copilot.
Fixes #178095
**Summary**
The Vectorizedf8 base class (used by Vectorized<Float8_e4m3fn> and Vectorized<Float8_e5m2>) was missing a blendv static method. This caused a C++ compilation failure when Inductor's VecMaskTo::apply tried to use blendv during bool-to-float8 dtype conversion. 
Fix adds blendv to Vectorizedf8 with the same byte-level semantics as the existing uint8_t/int8_t blendv implementations in vec512_int.h.

**Test plan**
Adds regression tests for both float8_e4m3fn and float8_e5m2 in test_cpu_repro.py.

Assisted by Copilot/Claude


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo