### PR TITLE
[Test] Make test_unused_stream accelerator-agnostic in test_guard_serialization.py

### DIFF
--- a/test/dynamo/test_guard_serialization.py
+++ b/test/dynamo/test_guard_serialization.py
@@ -1675,18 +1675,18 @@ class TestGuardSerialization(TestGuardSerializationBase):
         self._test_check_fn(ref, loaded, {"inputs": Inputs(x, weakref.ref(x))}, True)
 
     def test_unused_stream(self):
-        if not torch.cuda.is_available():
-            self.skipTest("CUDA is not available")
+        if not torch.accelerator.is_available():
+            self.skipTest("Accelerator is not available")
 
         def foo(inputs):
             return inputs.x + 1
 
         x = torch.randn(3, 2)
         ref, loaded = self._test_serialization(
-            "TENSOR_MATCH", foo, Inputs(x, torch.cuda.Stream())
+            "TENSOR_MATCH", foo, Inputs(x, torch.Stream())
         )
         self._test_check_fn(
-            ref, loaded, {"inputs": Inputs(x, torch.cuda.Stream())}, True
+            ref, loaded, {"inputs": Inputs(x, torch.Stream())}, True
         )
 
     def test_unused_process_group(self):

--- a/test/dynamo/test_guard_serialization.py
+++ b/test/dynamo/test_guard_serialization.py
@@ -1685,9 +1685,7 @@ class TestGuardSerialization(TestGuardSerializationBase):
         ref, loaded = self._test_serialization(
             "TENSOR_MATCH", foo, Inputs(x, torch.Stream())
         )
-        self._test_check_fn(
-            ref, loaded, {"inputs": Inputs(x, torch.Stream())}, True
-        )
+        self._test_check_fn(ref, loaded, {"inputs": Inputs(x, torch.Stream())}, True)
 
     def test_unused_process_group(self):
         import torch.distributed as dist


### PR DESCRIPTION
 Replaced CUDA-hardcoded APIs with accelerator-generic equivalents to enable testing on PrivateUse1 devices (Intel XPU, Habana HPU, MPS, and other custom accelerators).

  Changes:
  - Replace torch.cuda.is_available() with torch.accelerator.is_available()
  - Replace torch.cuda.Stream() with torch.Stream() for device-agnostic stream creation
  - Update skip message to be accelerator-generic

 
 Test Plan:
1. Verified test passes with `TEST_CONFIG=cpu`: OK (0.133s)
2. Verified test passes with `TEST_CONFIG=cuda`: OK (0.133s)



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98 @mruberry @mikaylagawarecki @mansiag05 