### PR TITLE
Add GitHub Action for checking out upstream PyTorch PRs

### DIFF
--- a/.github/actions/checkout-upstream-pr/action.yml
+++ b/.github/actions/checkout-upstream-pr/action.yml
@@ -1,0 +1,51 @@
+name: "Checkout PyTorch PR"
+description: >
+  Checks out the upstream PyTorch PR commit into the downstream workspace based on the `repository_dispatch` client_payload fields. 
+  This action encapsulates all git logic so downstream repos do not need to parse the payload or run git commands themselves.
+
+inputs:
+  path:
+    description: Checkout path relative to $GITHUB_WORKSPACE
+    required: false
+    default: "pytorch"
+  token:
+    description: GitHub token for auth (prevents rate limits)
+    required: false
+    default: ${{ github.token }}
+
+runs:
+  using: composite
+  steps:
+    - name: Fetch and Checkout Upstream
+      shell: bash
+      env:
+        UPSTREAM_REPO: ${{ github.event.client_payload.upstream_repo }}
+        HEAD_SHA: ${{ github.event.client_payload.head_sha }}
+        CHECKOUT_PATH: ${{ github.workspace }}/${{ inputs.path }}
+        GH_TOKEN: ${{ inputs.token }}
+      run: |
+        set -euo pipefail
+
+        echo "::group::Fetching ${UPSTREAM_REPO}@${HEAD_SHA}"
+
+        echo "Clean & Prepare ${CHECKOUT_PATH}"
+        rm -rf "${CHECKOUT_PATH}"
+        mkdir -p "${CHECKOUT_PATH}"
+        pushd "${CHECKOUT_PATH}"
+
+        echo "Init repo ${UPSTREAM_REPO}"
+        git init -q
+        git remote add origin "https://x-access-token:${GH_TOKEN}@github.com/${UPSTREAM_REPO}.git"
+
+        echo "Fetching commit ${HEAD_SHA}..."
+        git fetch --depth=1 origin "${HEAD_SHA}"
+        git checkout -q FETCH_HEAD
+
+        echo "Initializing submodules..."
+        git submodule sync --recursive
+        git submodule update --init --recursive --jobs 8
+
+        popd
+
+        echo "Successfully checked out to $(git rev-parse HEAD)"
+        echo "::endgroup::"


### PR DESCRIPTION

### Summary
This pull request introduces a new GitHub Action, `Checkout PyTorch PR`, which streamlines the process of checking out a specific commit from an upstream PyTorch pull request into a downstream workspace. 

This encapsulates all necessary git operations, making it easier for downstream repositories to integrate upstream changes without handling git commands or parsing payloads themselves.

**New GitHub Action for Upstream PR Checkout:**

* Added `.github/actions/checkout-upstream-pr/action.yml` defining a composite action that:
  - Accepts `path` and `token` as inputs for customization.
  - Fetches and checks out a specific commit from an upstream repository using values from the `repository_dispatch` event payload.
  - Initializes the repository and submodules in the specified workspace path.
  - Encapsulates all git logic, reducing complexity for downstream repositories.

### Context
This PR is a part of contribution to the feature: Cross-Repo-CI-Relay
- RFC: https://github.com/pytorch/rfcs/pull/90
- L1 implementation: https://github.com/pytorch/test-infra/pull/7847

### TODO
- Another GitHub action for reporting result back to the relay server (at L2 stage)

cc @fffrog @can-gaa-hou @ZainRizvi 