### PR TITLE
Delay common_utils import to pytest_sessionstart to prevent faulthandler race condition

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -21,13 +21,21 @@ from _pytest.terminal import _get_raw_skip_reason
 from pytest_shard_custom import pytest_addoptions as shard_addoptions, PytestShardPlugin
 
 
-try:
-    from torch.testing._internal.common_utils import parse_cmd_line_args
-except ImportError:
-    # Temporary workaround needed until parse_cmd_line_args makes it into a nightlye because
-    # main / PR's tests are sometimes run against the previous day's nightly which won't
-    # have this function.
-    def parse_cmd_line_args():
+def _call_parse_cmd_line_args():
+    # Called from pytest_sessionstart rather than pytest_configure to avoid
+    # importing common_utils too early. common_utils triggers GPU runtime
+    # initialization as an import side effect (for example via
+    # device-availability queries), which may install signal handlers
+    # (e.g., custom runtimes, profilers, or simulators relying on SIGSEGV
+    # for managed memory page faults). conftest's pytest_configure runs
+    # before built-in plugins, so importing there would race with pytest's
+    # faulthandler plugin — faulthandler.enable() would overwrite the
+    # runtime's handlers.
+    try:
+        from torch.testing._internal.common_utils import parse_cmd_line_args
+
+        parse_cmd_line_args()
+    except ImportError:
         pass
 
 
@@ -92,8 +100,11 @@ def pytest_addoption(parser: Parser) -> None:
     shard_addoptions(parser)
 
 
+def pytest_sessionstart(session):
+    _call_parse_cmd_line_args()
+
+
 def pytest_configure(config: Config) -> None:
-    parse_cmd_line_args()
     xmlpath = config.option.xmlpath_reruns
     # Prevent opening xmllog on worker nodes (xdist).
     if xmlpath and not hasattr(config, "workerinput"):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -31,12 +31,9 @@ def _call_parse_cmd_line_args():
     # before built-in plugins, so importing there would race with pytest's
     # faulthandler plugin — faulthandler.enable() would overwrite the
     # runtime's handlers.
-    try:
-        from torch.testing._internal.common_utils import parse_cmd_line_args
+    from torch.testing._internal.common_utils import parse_cmd_line_args
 
-        parse_cmd_line_args()
-    except ImportError:
-        pass
+    parse_cmd_line_args()
 
 
 if TYPE_CHECKING:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -31,7 +31,12 @@ def _call_parse_cmd_line_args():
     # before built-in plugins, so importing there would race with pytest's
     # faulthandler plugin — faulthandler.enable() would overwrite the
     # runtime's handlers.
-    from torch.testing._internal.common_utils import parse_cmd_line_args
+    try:
+        from torch.testing._internal.common_utils import parse_cmd_line_args
+    except ImportError:
+        # torch may not be importable in lint-only CI environments where
+        # PyTorch hasn't been built (torch.version is a generated module).
+        return
 
     parse_cmd_line_args()
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -35,7 +35,7 @@ def _call_parse_cmd_line_args():
         from torch.testing._internal.common_utils import parse_cmd_line_args
     except ImportError:
         # torch may not be importable in lint-only CI environments where
-        # PyTorch hasn't been built (torch.version is a generated module).
+        # PyTorch hasn't been built.
         return
 
     parse_cmd_line_args()


### PR DESCRIPTION
**The Problem**
Currently, test/conftest.py imports torch.testing._internal.common_utils inside the pytest_configure hook. This import has the side effect of triggering device initialization (via module-level checks like torch.xpu.is_available()).

During this device initialization, custom runtimes, GPU simulators, or profiling tools may install their own signal handlers (e.g., hooking SIGSEGV to handle user-space managed memory page faults).

Because a local conftest.py's pytest_configure hook executes before the pytest_configure hooks of built-in plugins, this early import creates a race condition with pytest's faulthandler plugin. The device runtime installs its signal handlers, and then faulthandler.enable() runs and silently overwrites them. This results in crashes for environments that rely on these handlers for memory management or profiling.

**The Solution**
This PR moves the invocation of parse_cmd_line_args (and its accompanying lazy import of common_utils) from pytest_configure to pytest_sessionstart.

By the time pytest_sessionstart is fired, all pytest plugins (including faulthandler) have been fully configured and initialized. This ensures faulthandler sets up its signal handlers first, allowing any subsequent device initialization to properly chain or override the handlers as intended.

Because the globals set by parse_cmd_line_args are only consumed during actual test execution, deferring this setup to pytest_sessionstart is safe and does not affect test behavior.