### PR TITLE
Wire OcclTransport into ProcessGroupOCCL and implement send/recv

### DIFF
--- a/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/distributed/c10d/ProcessGroupOCCL.cpp
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/distributed/c10d/ProcessGroupOCCL.cpp
@@ -1,5 +1,4 @@
 #if USE_DISTRIBUTED
-#include <cstring>
 #include <stdexcept>
 
 #include <ATen/core/Tensor.h>
@@ -205,10 +204,10 @@ std::vector<uint8_t> ProcessGroupOCCL::tensorToHost(const at::Tensor& tensor) {
       "tensorToHost requires a contiguous tensor, got non-contiguous");
   const auto nbytes = tensor.nbytes();
   std::vector<uint8_t> buf(nbytes);
-  {
-    at::native::openreg::MemoryGuard guard(tensor);
-    std::memcpy(buf.data(), tensor.data_ptr(), nbytes);
-  }
+  TORCH_CHECK(
+      orMemcpy(buf.data(), tensor.data_ptr(), nbytes, orMemcpyDeviceToHost) ==
+          orSuccess,
+      "tensorToHost: orMemcpy(DeviceToHost) failed");
   return buf;
 }
 
@@ -225,10 +224,10 @@ void ProcessGroupOCCL::hostToTensor(
       ") does not match tensor size (",
       tensor.nbytes(),
       ")");
-  {
-    at::native::openreg::MemoryGuard guard(tensor);
-    std::memcpy(tensor.data_ptr(), buf.data(), buf.size());
-  }
+  TORCH_CHECK(
+      orMemcpy(tensor.data_ptr(), buf.data(), buf.size(), orMemcpyHostToDevice) ==
+          orSuccess,
+      "hostToTensor: orMemcpy(HostToDevice) failed");
 }
 
 // ProcessGroupOCCL ---------------------------------------------------------
@@ -372,17 +371,44 @@ c10::intrusive_ptr<Work> ProcessGroupOCCL::alltoall_base(
 
 c10::intrusive_ptr<Work> ProcessGroupOCCL::send(
     std::vector<at::Tensor>& tensors,
-    int /* dstRank */,
-    int /* tag */) {
+    int dstRank,
+    int tag) {
   CHECK_TENSOR_LIST(tensors);
+  TORCH_CHECK(tensors.size() == 1, "OCCL send expects exactly one tensor");
+  auto& tensor = tensors[0];
+  TORCH_CHECK(tensor.is_contiguous(), "OCCL send requires a contiguous tensor");
+
+  auto buf = tensorToHost(tensor);
+  transport_->send(
+      buf.data(),
+      buf.size(),
+      dstRank,
+      static_cast<uint8_t>(tensor.scalar_type()),
+      static_cast<uint64_t>(tensor.numel()),
+      static_cast<uint32_t>(tag));
+
   return c10::make_intrusive<ProcessGroupOCCL::DummyWork>();
 }
 
 c10::intrusive_ptr<Work> ProcessGroupOCCL::recv(
     std::vector<at::Tensor>& tensors,
-    int /* srcRank */,
-    int /* tag */) {
+    int srcRank,
+    int tag) {
   CHECK_TENSOR_LIST(tensors);
+  TORCH_CHECK(tensors.size() == 1, "OCCL recv expects exactly one tensor");
+  auto& tensor = tensors[0];
+  TORCH_CHECK(tensor.is_contiguous(), "OCCL recv requires a contiguous tensor");
+
+  std::vector<uint8_t> buf(tensor.nbytes());
+  transport_->recv(
+      buf.data(),
+      buf.size(),
+      srcRank,
+      static_cast<uint8_t>(tensor.scalar_type()),
+      static_cast<uint64_t>(tensor.numel()),
+      static_cast<uint32_t>(tag));
+  hostToTensor(buf, tensor);
+
   return c10::make_intrusive<ProcessGroupOCCL::DummyWork>();
 }
 

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/distributed/c10d/ProcessGroupOCCL.cpp
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/distributed/c10d/ProcessGroupOCCL.cpp
@@ -1,10 +1,13 @@
 #if USE_DISTRIBUTED
+#include <cstring>
 #include <stdexcept>
 
 #include <ATen/core/Tensor.h>
 #include <c10/util/Exception.h>
 #include <c10/util/string_view.h>
 #include <torch/headeronly/core/DeviceType.h>
+
+#include <aten/native/Common.h>
 
 #include "ProcessGroupOCCL.hpp"
 namespace {
@@ -193,6 +196,40 @@ c10::intrusive_ptr<c10::ivalue::Future> ProcessGroupOCCL::DummyWork::
 
 ProcessGroupOCCL::Options::Options(std::chrono::milliseconds timeout)
     : Backend::Options(OCCL_BACKEND_NAME, timeout) {}
+
+// Memory helpers -----------------------------------------------------------
+
+std::vector<uint8_t> ProcessGroupOCCL::tensorToHost(const at::Tensor& tensor) {
+  TORCH_CHECK(
+      tensor.is_contiguous(),
+      "tensorToHost requires a contiguous tensor, got non-contiguous");
+  const auto nbytes = tensor.nbytes();
+  std::vector<uint8_t> buf(nbytes);
+  {
+    at::native::openreg::MemoryGuard guard(tensor);
+    std::memcpy(buf.data(), tensor.data_ptr(), nbytes);
+  }
+  return buf;
+}
+
+void ProcessGroupOCCL::hostToTensor(
+    const std::vector<uint8_t>& buf,
+    at::Tensor& tensor) {
+  TORCH_CHECK(
+      tensor.is_contiguous(),
+      "hostToTensor requires a contiguous tensor, got non-contiguous");
+  TORCH_CHECK(
+      buf.size() == tensor.nbytes(),
+      "hostToTensor buffer size (",
+      buf.size(),
+      ") does not match tensor size (",
+      tensor.nbytes(),
+      ")");
+  {
+    at::native::openreg::MemoryGuard guard(tensor);
+    std::memcpy(tensor.data_ptr(), buf.data(), buf.size());
+  }
+}
 
 // ProcessGroupOCCL ---------------------------------------------------------
 

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/distributed/c10d/ProcessGroupOCCL.cpp
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/distributed/c10d/ProcessGroupOCCL.cpp
@@ -133,7 +133,7 @@ namespace {
    rank, int size, const std::chrono::duration<float>& timeout) Constructs a
    ProcessGroupOCCL using the given rank and size. The store and timeout are
    accepted for API parity but are not used to affect behavior.
-            - @param store: Process group store (ignored).
+            - @param store: Process group store (used for OcclTransport address exchange).
             - @param rank: This process rank.
             - @param size: World size.
             - @param timeout: Operation timeout hint (ignored).
@@ -196,8 +196,13 @@ ProcessGroupOCCL::Options::Options(std::chrono::milliseconds timeout)
 
 // ProcessGroupOCCL ---------------------------------------------------------
 
-ProcessGroupOCCL::ProcessGroupOCCL(int rank, int size)
-    : Backend(rank, size), options_(Options::create()) {}
+ProcessGroupOCCL::ProcessGroupOCCL(
+    const c10::intrusive_ptr<c10d::Store>& store,
+    int rank,
+    int size)
+    : Backend(rank, size),
+      transport_(std::make_unique<c10d::openreg::OcclTransport>(rank, size, store)),
+      options_(Options::create()) {}
 
 ProcessGroupOCCL::~ProcessGroupOCCL() = default;
 
@@ -361,7 +366,7 @@ c10::intrusive_ptr<ProcessGroupOCCL> createProcessGroupOCCL(
     int rank,
     int size,
     const std::chrono::duration<float>& timeout) {
-  return c10::make_intrusive<ProcessGroupOCCL>(rank, size);
+  return c10::make_intrusive<ProcessGroupOCCL>(store, rank, size);
 }
 
 } // namespace c10d

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/distributed/c10d/ProcessGroupOCCL.hpp
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/distributed/c10d/ProcessGroupOCCL.hpp
@@ -160,6 +160,14 @@ class OPENREG_EXPORT ProcessGroupOCCL : public Backend {
   c10::intrusive_ptr<Work> barrier(
     const BarrierOptions& opts = BarrierOptions()) override;
 
+  // Copy contiguous tensor data from device memory to a host buffer.
+  // Handles mprotect unprotect/reprotect via MemoryGuard.
+  static std::vector<uint8_t> tensorToHost(const at::Tensor& tensor);
+
+  // Copy data from a host buffer into a contiguous device tensor.
+  // Handles mprotect unprotect/reprotect via MemoryGuard.
+  static void hostToTensor(const std::vector<uint8_t>& buf, at::Tensor& tensor);
+
  protected:
   std::unique_ptr<c10d::openreg::OcclTransport> transport_;
   const c10::intrusive_ptr<Options> options_;

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/distributed/c10d/ProcessGroupOCCL.hpp
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/distributed/c10d/ProcessGroupOCCL.hpp
@@ -160,12 +160,10 @@ class OPENREG_EXPORT ProcessGroupOCCL : public Backend {
   c10::intrusive_ptr<Work> barrier(
     const BarrierOptions& opts = BarrierOptions()) override;
 
-  // Copy contiguous tensor data from device memory to a host buffer.
-  // Handles mprotect unprotect/reprotect via MemoryGuard.
+  // Copy contiguous tensor data from device memory to a host buffer via orMemcpy.
   static std::vector<uint8_t> tensorToHost(const at::Tensor& tensor);
 
-  // Copy data from a host buffer into a contiguous device tensor.
-  // Handles mprotect unprotect/reprotect via MemoryGuard.
+  // Copy data from a host buffer into a contiguous device tensor via orMemcpy.
   static void hostToTensor(const std::vector<uint8_t>& buf, at::Tensor& tensor);
 
  protected:

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/distributed/c10d/ProcessGroupOCCL.hpp
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/distributed/c10d/ProcessGroupOCCL.hpp
@@ -11,6 +11,8 @@
 
 #include <include/Macros.h>
 
+#include <distributed/OcclTransport.h>
+
 namespace c10d {
 
 //
@@ -51,7 +53,10 @@ class OPENREG_EXPORT ProcessGroupOCCL : public Backend {
     }
   };
 
-  explicit ProcessGroupOCCL(int rank = -1, int size = -1);
+  explicit ProcessGroupOCCL(
+      const c10::intrusive_ptr<c10d::Store>& store,
+      int rank,
+      int size);
   virtual ~ProcessGroupOCCL();
   const std::string getBackendName() const override {
     return std::string(OCCL_BACKEND_NAME);
@@ -156,6 +161,7 @@ class OPENREG_EXPORT ProcessGroupOCCL : public Backend {
     const BarrierOptions& opts = BarrierOptions()) override;
 
  protected:
+  std::unique_ptr<c10d::openreg::OcclTransport> transport_;
   const c10::intrusive_ptr<Options> options_;
 };
 OPENREG_EXPORT c10::intrusive_ptr<ProcessGroupOCCL> createProcessGroupOCCL(

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_distributed.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_distributed.py
@@ -86,11 +86,25 @@ class TestProcessGroupOCCL(TestDistBackend, DistributedTest._DistTestBase):
         res = fut.value()
         self.assertEqual(res, None)
 
+    def test_occl_send_recv(self) -> None:
+        pg = _get_default_group()
+        device = torch.device("openreg")
+
+        if self.rank == 0:
+            tensor = torch.tensor([1.0, 2.0, 3.0, 4.0], device=device)
+            pg.send([tensor], 1, 0).wait()
+        else:
+            tensor = torch.zeros(4, device=device)
+            pg.recv([tensor], 0, 0).wait()
+            expected = torch.tensor([1.0, 2.0, 3.0, 4.0], device=device)
+            self.assertEqual(tensor, expected)
+
 
 # Drop inherited torch distributed backend tests; we only need the OCCL smoke test.
 _allowed_tests = {
     "test_occl_backend_registration_and_default_group",
     "test_occl_allreduce",
+    "test_occl_send_recv",
 }
 for _name in dir(TestProcessGroupOCCL):
     if _name.startswith("test_") and _name not in _allowed_tests:


### PR DESCRIPTION
Evolve the ProcessGroupOCCL stub into a backend that performs data exchange by wiring in OcclTransport and implementing point-to-point send/recv.

- ProcessGroupOCCL constructor now accepts a c10d::Store and creates an OcclTransport instance for inter-rank communication
- tensorToHost/hostToTensor helpers copy data between OpenReg device memory and host buffers via orMemcpy
- send/recv serialize tensor data to a host buffer, transmit over TCP with a wire header (dtype, numel, tag), and deserialize on the receiving side.

Depends on: PR #177512 (OcclTransport)

Added test for verifying the correctness for send_recv collective.