### PR TITLE
[ROCm] Move rocblas.h include out of anonymous namespace

### DIFF
--- a/aten/src/ATen/cuda/CublasHandlePool.cpp
+++ b/aten/src/ATen/cuda/CublasHandlePool.cpp
@@ -11,6 +11,10 @@
 #include <string>
 #include <tuple>
 
+#if defined(USE_ROCM)
+#include <rocblas/rocblas.h>
+#endif
+
 /**
  * Note [hipblaslt handles]
  * ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -54,8 +58,6 @@ void destroyCublasLtHandle(cublasLtHandle_t handle) {
 using CuBlasLtPoolType = DeviceThreadHandlePool<cublasLtHandle_t, createCublasLtHandle, destroyCublasLtHandle>;
 
 // ugly hack until hipblasSetWorkspace exists
-#include <rocblas/rocblas.h>
-
 static hipblasStatus_t rocBLASStatusToHIPStatus(rocblas_status error) {
     switch(error) {
     case rocblas_status_size_unchanged:


### PR DESCRIPTION
Fix for build failure caused by including `rocblas/rocblas.h` inside an anonymous namespace.

Fixes following build errors:
```
error: no template named 'unique_lock' in namespace 'at::cuda::(anonymous namespace)::std'
error: no template named 'shared_mutex' in namespace 'at::cuda::(anonymous namespace)::std'
error: no template named 'get' in namespace 'at::cuda::(anonymous namespace)::std'
error: no type named 'string' in namespace 'at::cuda::(anonymous namespace)::std'
```

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang