### PR TITLE
Pass tensor data pointer to dlDeviceToTorchDevice from maybeCopyTensor in DLConvertor.cpp

### DIFF
--- a/aten/src/ATen/DLConvertor.cpp
+++ b/aten/src/ATen/DLConvertor.cpp
@@ -536,7 +536,8 @@ Tensor maybeCopyTensor(
   if (optional_dl_device.has_value()) {
     auto device = at::dlDeviceToTorchDevice(
         optional_dl_device->device_type,
-        static_cast<c10::DeviceIndex>(optional_dl_device->device_id));
+        static_cast<c10::DeviceIndex>(optional_dl_device->device_id),
+        data.data_ptr());
 
     if (device != data.device()) {
       TORCH_CHECK_VALUE(

--- a/test/test_dlpack.py
+++ b/test/test_dlpack.py
@@ -554,7 +554,6 @@ class TestTorchDlPack(TestCase):
 
     @skipMeta
     @onlyOn(["xpu", "cuda"])
-    @skipXPUIf(True, "https://github.com/intel/torch-xpu-ops/issues/3077")
     def test_no_copy(self, device):
         # No copy, since tensor lives in the same device.
         self._test_from_dlpack(device)

--- a/test/test_xpu.py
+++ b/test/test_xpu.py
@@ -1738,6 +1738,22 @@ if __name__ == "__main__":
         restored_handle = module.get_xpu_work_stream(tensor, api_capsule)
         self.assertEqual(default_handle, restored_handle)
 
+    @parametrize("copy", [None, True, False])
+    def test_dlpack_conversion_with_device(self, copy):
+        if self.expandable_segments:
+            self.skipTest("Skipping DLPack test for expandable segments allocator.")
+        x = make_tensor((5,), dtype=torch.float32, device="xpu")
+
+        # Same-device exercises maybeCopyTensor's dlDeviceToTorchDevice path which requires
+        # the data pointer for XPU.
+        z = torch.from_dlpack(x, device=x.device, copy=copy)
+        self.assertEqual(z, x)
+        self.assertEqual(z.device, x.device)
+        if copy:
+            self.assertNotEqual(z.data_ptr(), x.data_ptr())
+        else:
+            self.assertEqual(z.data_ptr(), x.data_ptr())
+
     def test_storage_pin_memory(self):
         t = torch.empty(10, pin_memory=True)
         self.assertTrue(t.is_pinned())

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -789,7 +789,9 @@ struct TorchDLPackExchangeAPI : public DLPackExchangeAPI {
               .dtype(at::toScalarType(prototype->dtype))
               .device(at::dlDeviceToTorchDevice(
                   prototype->device.device_type,
-                  static_cast<c10::DeviceIndex>(prototype->device.device_id)));
+                  static_cast<c10::DeviceIndex>(prototype->device.device_id),
+                  prototype->data));
+
       at::Tensor tensor = at::empty(shape, options);
       *out = at::toDLPackVersioned(tensor);
       return 0;


### PR DESCRIPTION
Previously this optional data pointer was not passed to dlDeviceToTorchDevice, which is not supported on XPU. Now that is being passed along, the device can be correctly determined.

Fixes https://github.com/intel/torch-xpu-ops/issues/3077