### PR TITLE
[compile] Add an option to print debug information on autograd cache guard expr.

### DIFF
--- a/test/dynamo/test_aot_autograd_cache.py
+++ b/test/dynamo/test_aot_autograd_cache.py
@@ -4,6 +4,7 @@ import contextlib
 import copy
 import dataclasses
 import functools
+import json
 import multiprocessing
 import operator
 import os
@@ -2914,6 +2915,78 @@ class AOTAutogradCacheTests(InductorTestCase):
 
             self.assertEqual(counters["aot_autograd"]["autograd_cache_miss"], 1)
             self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 1)
+
+
+    @inductor_config.patch("fx_graph_cache", True)
+    @inductor_config.patch("fx_graph_remote_cache", False)
+    @functorch_config.patch({"enable_autograd_cache": True, "autograd_cache_guards_debug_info": True})
+    def test_guards_expr_debug_info_on_save(self):
+        """
+        Verify that saving a compiled graph with dynamic shapes emits
+        fx_graph_cache_guards_expr via trace_structured with symint provenance.
+        """
+        import torch._logging
+
+        def fn(x, y):
+            return x + y
+
+        a = torch.rand(5, 6)
+        b = torch.rand(5, 6)
+
+        with patch.object(torch._logging, "trace_structured") as mock_trace:
+            compiled_fn = torch.compile(fn, dynamic=True)
+            compiled_fn(a, b)
+
+        # Find the call with fx_graph_cache_guards_expr
+        guards_expr_calls = [
+            call
+            for call in mock_trace.call_args_list
+            if call[0][0] == "artifact"
+            and call[1].get("metadata_fn", dict)().get("name")
+            == "fx_graph_cache_guards_expr"
+        ]
+        self.assertGreater(len(guards_expr_calls), 0)
+        payload = json.loads(guards_expr_calls[0][1]["payload_fn"]())
+        self.assertIn("key", payload)
+        self.assertIn("guards_expr", payload)
+        self.assertIn("symint_provenance", payload)
+
+    @inductor_config.patch("fx_graph_cache", True)
+    @inductor_config.patch("fx_graph_remote_cache", False)
+    @functorch_config.patch({"autograd_cache_guards_debug_info": True})
+    def test_guards_expr_debug_info_on_guard_miss(self):
+        """
+        Verify that on guard_miss, find_guarded_entry returns the persisted
+        guards_expr_debug_info so it can flow to trace_structured logging.
+        """
+        from types import SimpleNamespace
+
+        from torch._inductor.codecache import FxGraphCache
+
+        mock_debug_info = {"t0": {"symbol": "s0", "sources": ["L['x'].size()[0]"]}}
+        candidate = SimpleNamespace(
+            guards_expr="L['t0'] > 100",
+            guards_expr_debug_info=mock_debug_info,
+        )
+
+        def mock_iterate(*args, **kwargs):
+            yield candidate, b"content", True
+
+        with patch.object(
+            FxGraphCache, "iterate_over_candidates", side_effect=mock_iterate
+        ):
+            graph, content, info = FxGraphCache.find_guarded_entry(
+                key="test_key",
+                local=True,
+                remote_cache=None,
+                evaluate_guards=lambda expr, hints: False,
+                hints=[5],
+            )
+
+        self.assertIsNone(graph)
+        self.assertEqual(info["cache_status_detailed"], "guard_miss")
+        self.assertEqual(info["cache_status_guard_expr"], "L['t0'] > 100")
+        self.assertEqual(info["cache_status_guard_expr_debug_info"], mock_debug_info)
 
 
 @functorch_config.patch({"bundled_autograd_cache": True})

--- a/torch/_functorch/_aot_autograd/aot_autograd_result.py
+++ b/torch/_functorch/_aot_autograd/aot_autograd_result.py
@@ -370,6 +370,7 @@ class GenericAOTAutogradResult(Generic[TForward, TBackward]):
     sanitized_aot_config: AOTConfig
 
     guards_expr: str | None
+    guards_expr_debug_info: dict[str, Any] | None
 
     # Used by Compiled Autograd
     serialized_bw_module: SerializedGraphModule | None

--- a/torch/_functorch/_aot_autograd/autograd_cache.py
+++ b/torch/_functorch/_aot_autograd/autograd_cache.py
@@ -1011,15 +1011,62 @@ class AOTAutogradCache(GuardedCache[GenericAOTAutogradResult[Any, Any]]):
     @classmethod
     def generate_guards_expression(
         cls: type[AOTAutogradCache], cache_info: AOTAutogradCacheInfo
-    ) -> str | None:
+    ) -> tuple[str | None, dict[str, Any] | None]:
+        """
+        Generate guards expression and debug info for cache validation.
+
+        Returns:
+            A tuple of (guards_expr, guards_expr_debug_info).
+            guards_expr: String representation of guard expression for validation.
+            guards_expr_debug_info: Dict mapping symint placeholders to their symbols and sources.
+        """
+        import torch._functorch.config as functorch_config
+
         shape_env = cls._get_shape_env()
 
         if shape_env is None:
-            return None
+            return None, None
 
         symints = cache_info.forward_symints
         guards = shape_env.get_pruned_guards(symints)
-        return shape_env.produce_guards_expression(placeholders=symints, guards=guards)
+        guards_expr = shape_env.produce_guards_expression(
+            placeholders=symints, guards=guards
+        )
+
+        guards_expr_debug_info = None
+        if functorch_config.autograd_cache_guards_debug_info:
+            import sympy
+
+            from torch._logging import trace_structured
+
+            guards_expr_debug_info = {
+                f"t{i}": {
+                    "symbol": str(s.node.expr),
+                    "sources": [
+                        src.name
+                        for src in shape_env.var_to_sources.get(s.node.expr, [])
+                    ],
+                }
+                for i, s in enumerate(symints)
+                if isinstance(s.node.expr, sympy.Symbol)
+            }
+
+            trace_structured(
+                "artifact",
+                metadata_fn=lambda: {
+                    "name": "fx_graph_cache_guards_expr",
+                    "encoding": "json",
+                },
+                payload_fn=lambda: json.dumps(
+                    {
+                        "key": cache_info.cache_key,
+                        "guards_expr": guards_expr,
+                        "symint_provenance": guards_expr_debug_info,
+                    }
+                ),
+            )
+
+        return guards_expr, guards_expr_debug_info
 
     @classmethod
     def _get_tmp_dir(cls: type[AOTAutogradCache]) -> str:
@@ -1284,6 +1331,7 @@ class AOTAutogradCache(GuardedCache[GenericAOTAutogradResult[Any, Any]]):
         backward_time_taken_ns: int,
         sanitized_aot_config: AOTConfig,
         guards_expr: str | None,
+        guards_expr_debug_info: dict[str, Any] | None,
         backward_state_indices: list[int] | None,
         num_symints_saved_for_bw: int | None,
         serialized_bw_module: SerializedGraphModule | None,
@@ -1326,6 +1374,7 @@ class AOTAutogradCache(GuardedCache[GenericAOTAutogradResult[Any, Any]]):
                 backward_time_taken_ns=backward_time_taken_ns,
                 sanitized_aot_config=sanitized_aot_config,
                 guards_expr=guards_expr,
+                guards_expr_debug_info=guards_expr_debug_info,
                 serialized_bw_module=serialized_bw_module,
             )
 
@@ -1375,5 +1424,6 @@ class AOTAutogradCache(GuardedCache[GenericAOTAutogradResult[Any, Any]]):
                 backward_time_taken_ns=backward_time_taken_ns,
                 sanitized_aot_config=sanitized_aot_config,
                 guards_expr=guards_expr,
+                guards_expr_debug_info=guards_expr_debug_info,
                 serialized_bw_module=serialized_bw_module,
             )

--- a/torch/_functorch/_aot_autograd/graph_compile.py
+++ b/torch/_functorch/_aot_autograd/graph_compile.py
@@ -508,7 +508,9 @@ def _cache_inference_info(
     entry: GenericAOTAutogradResult[Any, Any] | None = None
     if cache_info is not None and should_save_cache():
         time_taken_ns = time.time_ns() - cache_info.start_time_ns
-        guards_expr = AOTAutogradCache.generate_guards_expression(cache_info)
+        guards_expr, guards_expr_debug_info = (
+            AOTAutogradCache.generate_guards_expression(cache_info)
+        )
         entry = AOTAutogradCache.make_entry(
             compiled_fw_func=compiled_fw,  # type: ignore[arg-type]
             compiled_bw_func=None,
@@ -524,6 +526,7 @@ def _cache_inference_info(
             backward_time_taken_ns=0,
             sanitized_aot_config=sanitize_aot_config(aot_config),
             guards_expr=guards_expr,
+            guards_expr_debug_info=guards_expr_debug_info,
             backward_state_indices=None,
             num_symints_saved_for_bw=None,
             serialized_bw_module=None,
@@ -2391,7 +2394,9 @@ def _cache_autograd_info(
                 aot_forward_graph_str: str | None = fw_module_str
                 aot_backward_graph_str: str | None = bw_module_str
                 aot_joint_graph_str: str | None = joint_graph_str
-                guards_expr = AOTAutogradCache.generate_guards_expression(cache_info)
+                guards_expr, guards_expr_debug_info = (
+                    AOTAutogradCache.generate_guards_expression(cache_info)
+                )
 
                 entry = AOTAutogradCache.make_entry(
                     compiled_fw_func,  # type: ignore[arg-type]
@@ -2408,6 +2413,7 @@ def _cache_autograd_info(
                     backward_time_taken_ns,
                     sanitized_aot_config=sanitize_aot_config(aot_config),
                     guards_expr=guards_expr,
+                    guards_expr_debug_info=guards_expr_debug_info,
                     backward_state_indices=backward_state_indices,
                     num_symints_saved_for_bw=num_symints_saved_for_bw,
                     serialized_bw_module=serialize_graph_module(bw_module),

--- a/torch/_functorch/config.py
+++ b/torch/_functorch/config.py
@@ -424,6 +424,12 @@ joint_custom_pass: Callable = None  # type: ignore[assignment]
 
 force_autograd_cache = False
 
+# When enabled, generate and persist debug info (symint provenance) alongside
+# guards expressions in the autograd / FX graph caches.  This adds a small
+# amount of overhead to cache save paths but makes guard-miss diagnostics
+# available via trace_structured logging and tlparse.
+autograd_cache_guards_debug_info: bool = False
+
 # Note [Selective Decomposition]
 # This config allows selective decomposition of certain operators in the graph.
 # When True, it does NOT decompose any nodes, except those nodes that users explicitly

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -1203,6 +1203,7 @@ class GuardedCache(Generic[T]):
         Returns:
             A tuple of (graph, pickled_content) if found, or (None, None) if not found
         """
+        import torch._functorch.config as functorch_config
         graph = None
         pickled_content = None
         result_status = "full_miss"
@@ -1242,6 +1243,10 @@ class GuardedCache(Generic[T]):
         info = {"cache_status_detailed": result_status}
         if sample_guards_expr is not None:
             info["cache_status_guard_expr"] = sample_guards_expr
+            if functorch_config.autograd_cache_guards_debug_info:
+                debug_info = getattr(candidate, "guards_expr_debug_info", None)
+                if debug_info is not None:
+                    info["cache_status_guard_expr_debug_info"] = debug_info
 
         # Record hits/misses for compilation event logging. The tricky part is that a
         # remote hit would imply a local miss (if local caching is enabled).
@@ -1601,6 +1606,38 @@ class FxGraphCache(GuardedCache[CompiledFxGraph]):
             )
         except Exception:
             pass
+
+        import sympy
+
+        import torch._functorch.config as functorch_config
+
+        if functorch_config.autograd_cache_guards_debug_info:
+            guards_expr_debug_info = {
+                f"t{i}": {
+                    "symbol": str(s.node.expr),
+                    "sources": [
+                        src.name
+                        for src in shape_env.var_to_sources.get(s.node.expr, [])
+                    ],
+                }
+                for i, s in enumerate(symints)
+                if isinstance(s.node.expr, sympy.Symbol)
+            }
+            compiled_graph.guards_expr_debug_info = guards_expr_debug_info
+            trace_structured(
+                "artifact",
+                metadata_fn=lambda: {
+                    "name": "fx_graph_cache_guards_expr",
+                    "encoding": "json",
+                },
+                payload_fn=lambda: json.dumps(
+                    {
+                        "key": key,
+                        "guards_expr": compiled_graph.guards_expr,
+                        "symint_provenance": guards_expr_debug_info,
+                    }
+                ),
+            )
         disk_compiled_graph = copy(compiled_graph)
         disk_compiled_graph.prepare_for_serialization()
 

--- a/torch/_inductor/output_code.py
+++ b/torch/_inductor/output_code.py
@@ -463,6 +463,7 @@ class CompiledFxGraph(OutputCode):
     # ShapeEnv.produce_guards_expression()
     guards_expr: str | None
     extern_libs_key: str | None
+    guards_expr_debug_info: Optional[dict[str, Any]]
     inductor_provenance_mapping_str: str | None
     inductor_provenance_stack_traces_str: str | None
 
@@ -548,6 +549,7 @@ class CompiledFxGraph(OutputCode):
         self.counter_deltas = counter_deltas
         self.guards_expr = None
         self.extern_libs_key = None
+        self.guards_expr_debug_info = None
         self.cudagraph_info = None
         self.partition_maps = graph.partition_maps
         self.fx_kwargs = {}


### PR DESCRIPTION
Summary:
This diff adds an option torch._functorch.cofnig.autograd_cache_guards_debug_info which will dump extra debug information to track symint provenance in tlparse.

Previously when there's a cache miss on autograd cache, users can only see the guard string like:
```
"guards_expr": "L['t1'] == L['t0'] and 192*L['t0'] <= 2147483647 and 96*L['t0'] <= 2147483647 and 87744*((913 + L['t0']) // 914) <= 2147483647 and 105408*((548 + L['t0']) // 549) <= 2147483647 and 3 <= L['t0'] and L['t0'] <= 2147483647",
```

It's useful to find out where these symbols are generated. (e.g. https://fb.workplace.com/groups/1075192433118967/permalink/1889199188384950/)
So we want to add more debugging info to track where these symbols come from.
```
{
  "guards_expr": "L['t1'] == L['t0'] and 192*L['t0'] <= 2147483647 and 96*L['t0'] <= 2147483647 and 87744*((913 + L['t0']) // 914) <= 2147483647 and 105408*((548 + L['t0']) // 549) <= 2147483647 and 3 <= L['t0'] and L['t0'] <= 2147483647",
  "key": "abijjnk76fs5kqlrpadxo6j7lwd36kwyrstd4bmhd23burxvmw7s",
  "symint_provenance": {
    "t0": {
      "sources": [
        "L['user_event_ts']['client_signals_logging'].size()[0]"
      ],
      "symbol": "s25"
    },
    "t1": {
      "sources": [
        "L['user_event_ts']['client_signals_logging'].size()[0]"
      ],
      "symbol": "s25"
    }
  }
}
```

Test Plan: test/dynamo:test_aot_autograd_cache

Differential Revision: D94921697


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98