### PR TITLE
[MPS] Fix BatchNorm with mixed input/weight dtypes (#178770)

### DIFF
--- a/aten/src/ATen/native/mps/operations/Normalization.mm
+++ b/aten/src/ATen/native/mps/operations/Normalization.mm
@@ -229,9 +229,10 @@ std::tuple<Tensor&, Tensor&, Tensor&> batch_norm_mps_out(const Tensor& self,
           MPSGraphTensor* besselConstantTensor = [mpsGraph constantWithScalar:(double)besselCorrectionTerm
                                                                         shape:@[ @1 ]
                                                                      dataType:running_mean_dtype];
-          MPSGraphTensor* unbiasedVarianceTensor = [mpsGraph multiplicationWithPrimaryTensor:castMPSTensor(mpsGraph, batchVarianceTensor, running_mean_dtype)
-                                                                             secondaryTensor:besselConstantTensor
-                                                                                        name:nil];
+          MPSGraphTensor* unbiasedVarianceTensor =
+              [mpsGraph multiplicationWithPrimaryTensor:castMPSTensor(mpsGraph, batchVarianceTensor, running_mean_dtype)
+                                        secondaryTensor:besselConstantTensor
+                                                   name:nil];
           MPSGraphTensor* momentumTensor = [mpsGraph constantWithScalar:(double)momentum
                                                                   shape:@[ @1 ]
                                                                dataType:running_mean_dtype];
@@ -239,9 +240,10 @@ std::tuple<Tensor&, Tensor&, Tensor&> batch_norm_mps_out(const Tensor& self,
                                                                     shape:@[ @1 ]
                                                                  dataType:running_mean_dtype];
           // Compute updated running mean
-          MPSGraphTensor* scaledBatchMean = [mpsGraph multiplicationWithPrimaryTensor:castMPSTensor(mpsGraph, batchMeanTensor, running_mean_dtype)
-                                                                      secondaryTensor:momentumTensor
-                                                                                 name:nil];
+          MPSGraphTensor* scaledBatchMean =
+              [mpsGraph multiplicationWithPrimaryTensor:castMPSTensor(mpsGraph, batchMeanTensor, running_mean_dtype)
+                                        secondaryTensor:momentumTensor
+                                                   name:nil];
           MPSGraphTensor* scaledRunningMean = [mpsGraph multiplicationWithPrimaryTensor:runningMeanTensor
                                                                         secondaryTensor:oneMinusMomentum
                                                                                    name:nil];

--- a/aten/src/ATen/native/mps/operations/Normalization.mm
+++ b/aten/src/ATen/native/mps/operations/Normalization.mm
@@ -221,23 +221,25 @@ std::tuple<Tensor&, Tensor&, Tensor&> batch_norm_mps_out(const Tensor& self,
         MPSGraphTensor* batchVarianceTensor = [mpsGraph varianceOfTensor:inputTensor axes:axes name:nil];
         varTensor = batchVarianceTensor;
         if (has_running_mean) {
+          // Running stats may have a different dtype (e.g. float32 with float16 input)
+          auto running_mean_dtype = getMPSDataType(running_mean_opt.value());
           // TODO: This is not the formula used in PyTorch, is this OK? Seems more robust
           // float besselCorrectionTerm = float(N) / std::max(N - 1.0f, 1.0f);
           float besselCorrectionTerm = float(N) / float(N - 1.0f);
           MPSGraphTensor* besselConstantTensor = [mpsGraph constantWithScalar:(double)besselCorrectionTerm
                                                                         shape:@[ @1 ]
-                                                                     dataType:input_mps_dtype];
-          MPSGraphTensor* unbiasedVarianceTensor = [mpsGraph multiplicationWithPrimaryTensor:batchVarianceTensor
+                                                                     dataType:running_mean_dtype];
+          MPSGraphTensor* unbiasedVarianceTensor = [mpsGraph multiplicationWithPrimaryTensor:castMPSTensor(mpsGraph, batchVarianceTensor, running_mean_dtype)
                                                                              secondaryTensor:besselConstantTensor
                                                                                         name:nil];
           MPSGraphTensor* momentumTensor = [mpsGraph constantWithScalar:(double)momentum
                                                                   shape:@[ @1 ]
-                                                               dataType:input_mps_dtype];
+                                                               dataType:running_mean_dtype];
           MPSGraphTensor* oneMinusMomentum = [mpsGraph constantWithScalar:(double)(1.0 - momentum)
                                                                     shape:@[ @1 ]
-                                                                 dataType:input_mps_dtype];
+                                                                 dataType:running_mean_dtype];
           // Compute updated running mean
-          MPSGraphTensor* scaledBatchMean = [mpsGraph multiplicationWithPrimaryTensor:batchMeanTensor
+          MPSGraphTensor* scaledBatchMean = [mpsGraph multiplicationWithPrimaryTensor:castMPSTensor(mpsGraph, batchMeanTensor, running_mean_dtype)
                                                                       secondaryTensor:momentumTensor
                                                                                  name:nil];
           MPSGraphTensor* scaledRunningMean = [mpsGraph multiplicationWithPrimaryTensor:runningMeanTensor
@@ -278,12 +280,16 @@ std::tuple<Tensor&, Tensor&, Tensor&> batch_norm_mps_out(const Tensor& self,
         varTensor = saveVarTensor;
       }
 
+      // Cast weight and bias to input dtype if needed (mixed-precision support)
+      MPSGraphTensor* gammaTensor = has_weight ? castMPSTensor(mpsGraph, weightTensor, input_mps_dtype) : nil;
+      MPSGraphTensor* betaTensor = has_bias ? castMPSTensor(mpsGraph, biasTensor, input_mps_dtype) : nil;
+
       // Compute output of batch norm
       MPSGraphTensor* outputTensor = [mpsGraph normalizationWithTensor:inputTensor
                                                             meanTensor:saveMeanTensor
                                                         varianceTensor:varTensor
-                                                           gammaTensor:weightTensor
-                                                            betaTensor:biasTensor
+                                                           gammaTensor:gammaTensor
+                                                            betaTensor:betaTensor
                                                                epsilon:(float)epsilon
                                                                   name:nil];
 
@@ -610,7 +616,9 @@ std::tuple<Tensor, Tensor, Tensor> batch_norm_backward_mps(const Tensor& grad_ou
 
     NSString* ns_shape_key = [[input_shape valueForKey:@"description"] componentsJoinedByString:@","];
 
-    std::string key = fmt::format("batch_norm_backward_mps:{}:{}:{}:{}:{}:{}:{}:{}",
+    auto input_mps_dtype = getMPSDataType(input);
+    auto weight_mps_dtype = has_weight ? getMPSDataType(weight_opt.value()) : input_mps_dtype;
+    std::string key = fmt::format("batch_norm_backward_mps:{}:{}:{}:{}:{}:{}:{}:{}:{}",
                                   get_mem_string(memory_format),
                                   epsilon,
                                   train,
@@ -618,8 +626,8 @@ std::tuple<Tensor, Tensor, Tensor> batch_norm_backward_mps(const Tensor& grad_ou
                                   has_weight,
                                   [ns_shape_key UTF8String],
                                   c10::Join(",", grad_input_mask),
-                                  getMPSTypeString(input));
-    auto input_mps_dtype = getMPSDataType(input);
+                                  getMPSTypeString(input),
+                                  has_weight ? getMPSTypeString(weight_opt.value()) : "none");
     auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
       // NCHW - Channels dim is 1
       int channelsDim = 1;
@@ -628,8 +636,11 @@ std::tuple<Tensor, Tensor, Tensor> batch_norm_backward_mps(const Tensor& grad_ou
       // Shape is the ORIGINAL NCHW shape
       auto gradOutputTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(grad_out), input_shape_readonly);
       MPSGraphTensor* weightTensor = nil;
-      if (has_weight)
-        weightTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(weight_opt.value()), new_mean_shape);
+      MPSGraphTensor* weightTensorCasted = nil;
+      if (has_weight) {
+        weightTensor = mpsGraphRankedPlaceHolder(mpsGraph, weight_mps_dtype, new_mean_shape);
+        weightTensorCasted = castMPSTensor(mpsGraph, weightTensor, input_mps_dtype);
+      }
       MPSGraphTensor* runningMeanTensor = nil;
       MPSGraphTensor* runningVarTensor = nil;
       if (has_running_mean) {
@@ -698,7 +709,7 @@ std::tuple<Tensor, Tensor, Tensor> batch_norm_backward_mps(const Tensor& grad_ou
                                                                          sourceTensor:inputTensor
                                                                            meanTensor:saveMeanTensor
                                                                        varianceTensor:revertSaveVarTensor
-                                                                          gammaTensor:weightTensor
+                                                                          gammaTensor:weightTensorCasted
                                                                   gammaGradientTensor:gradWeightTensor
                                                                    betaGradientTensor:gradBiasTensor
                                                                         reductionAxes:axes
@@ -766,7 +777,7 @@ std::tuple<Tensor, Tensor, Tensor> batch_norm_backward_mps(const Tensor& grad_ou
           gradInputTensor = [mpsGraph multiplicationWithPrimaryTensor:unitTensor secondaryTensor:rsqrtTensor name:nil];
           if (has_weight)
             gradInputTensor = [mpsGraph multiplicationWithPrimaryTensor:gradInputTensor
-                                                        secondaryTensor:weightTensor
+                                                        secondaryTensor:weightTensorCasted
                                                                    name:nil];
           gradInputTensor = [mpsGraph multiplicationWithPrimaryTensor:gradInputTensor
                                                       secondaryTensor:gradOutputTensor
@@ -778,11 +789,13 @@ std::tuple<Tensor, Tensor, Tensor> batch_norm_backward_mps(const Tensor& grad_ou
         gradWeightTensor = [mpsGraph reshapeTensor:gradWeightTensor
                                          withShape:@[ input_shape_readonly[channelsDim] ]
                                               name:nil];
+        gradWeightTensor = castMPSTensor(mpsGraph, gradWeightTensor, weight_mps_dtype);
       }
       if (grad_input_mask[2]) {
         gradBiasTensor = [mpsGraph reshapeTensor:gradBiasTensor
                                        withShape:@[ input_shape_readonly[channelsDim] ]
                                             name:nil];
+        gradBiasTensor = castMPSTensor(mpsGraph, gradBiasTensor, weight_mps_dtype);
       }
 
       MPSGraphTensor* gradInputTensorFinal = nil;

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -2016,6 +2016,19 @@ class TestMPS(TestCaseMPS):
         self.assertEqual(bn_cpu.weight.grad, bn_mps.weight.grad, atol=1e-5, rtol=1e-5)
         self.assertEqual(bn_cpu.bias.grad, bn_mps.bias.grad, atol=1e-5, rtol=1e-5)
 
+    def test_batch_norm_mixed_dtype(self):
+        # Regression test for https://github.com/pytorch/pytorch/issues/178770
+        # BatchNorm with float32 weights and float16 input should work
+        x = torch.rand(2, 32, 15, 15, device="mps", dtype=torch.float16, requires_grad=True)
+        model = nn.BatchNorm2d(32, device="mps", dtype=torch.float32).train()
+        y_mps = model(x)
+        # Compare against CPU using a copy of the model
+        import copy
+        y_cpu = copy.deepcopy(model).cpu()(x.detach().cpu())
+        self.assertEqual(y_cpu, y_mps.cpu(), atol=1e-3, rtol=1e-3)
+        y_mps.sum().backward()
+        self.assertIsNotNone(x.grad)
+
     def test_layer_norm_backward(self):
         inputs = torch.rand(4, 4, device="mps", requires_grad=True)
         x = torch.nn.LayerNorm(4).to("mps")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #178781
* __->__ #178775

MPSGraph's normalization ops require all tensors to have matching data types. 
When input is float16 and weights are float32 (common in mixed-precision training), the operation would crash.
Cast weight, bias, and running stats to the appropriate dtype using `castMPSTensor` before passing to MPSGraph normalization ops, and cast gradients back to weight dtype in the backward pass.

TODO: Remove new test as it's already covered by `test_instancenorm_mixed_dtype_backward` in `test_nn.py`

Fixes https://github.com/pytorch/pytorch/issues/178770

Co-authored-by: Claude <noreply@anthropic.com>