### PR TITLE
[dynamo] Fix invoke_subgraph reuse breaking autograd graph under trace_autograd_ops

### DIFF
--- a/torch/_dynamo/variables/invoke_subgraph.py
+++ b/torch/_dynamo/variables/invoke_subgraph.py
@@ -889,19 +889,45 @@ def stamp_out_subgraph(
             vt = VariableBuilder(tx, new_source)(value)
             new_lifted_args.append(vt.as_proxy())
 
-    # Generate fake tensor outputs
+    # Generate fake tensor outputs.
     assert tx.fake_mode is not None
+    # When trace_autograd_ops is enabled, output FakeTensors must have grad_fn
+    # connected to the inputs so that torch.autograd.grad can trace through the
+    # full autograd graph. We establish this link via a trivial zero-valued
+    # addition that creates the grad_fn chain without affecting tensor values.
+    grad_inputs = []
+    if torch._dynamo.config.trace_autograd_ops and torch.is_grad_enabled():
+        grad_inputs = [
+            p.node.meta["example_value"]
+            for p in new_lifted_args
+            if isinstance(p.node.meta.get("example_value"), torch.Tensor)
+            and p.node.meta["example_value"].requires_grad
+        ]
     with tx.fake_mode:
-        example_value = tuple(
-            torch.empty_strided(
-                shape,
-                stride,
-                dtype=dtype,
-                device=device,
-                requires_grad=req_grad,
+        if grad_inputs:
+            zero = sum(inp.reshape(-1)[0] * 0 for inp in grad_inputs)
+            example_value = tuple(
+                (
+                    torch.empty_strided(shape, stride, dtype=dtype, device=device)
+                    + zero
+                ).as_strided(shape, stride)
+                if req_grad
+                else torch.empty_strided(
+                    shape, stride, dtype=dtype, device=device
+                )
+                for shape, stride, dtype, device, req_grad in cached.output_metadata
             )
-            for shape, stride, dtype, device, req_grad in cached.output_metadata
-        )
+        else:
+            example_value = tuple(
+                torch.empty_strided(
+                    shape,
+                    stride,
+                    dtype=dtype,
+                    device=device,
+                    requires_grad=req_grad,
+                )
+                for shape, stride, dtype, device, req_grad in cached.output_metadata
+            )
 
     # Install the invoke_subgraph call
     body_node = make_attr(tx, cached.body_name)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #178777

When `trace_autograd_ops=True`, Dynamo traces `torch.autograd.grad` into
the graph and relies on FakeTensor autograd reachability to determine which
gradients are None. `stamp_out_subgraph` (the invoke_subgraph cache-hit
path) created output FakeTensors via `torch.empty_strided(...,
requires_grad=True)` — leaf tensors with no `grad_fn`. This severed the
autograd graph: with 2+ invoke_subgraph calls of the same subgraph,
`autograd.grad` couldn't trace from the loss back to the original input,
returned `(None,)`, and the compiled function produced no output.

Fix: when `trace_autograd_ops` is active, establish a trivial autograd
connection between the stamped-out outputs and the requires-grad inputs
via a zero-valued addition, preserving the grad_fn chain needed for
reachability analysis.

Co-authored-by: Claude <noreply@anthropic.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98 @Lucaskabela