### PR TITLE
Use `device` in `test_pooling_large`

### DIFF
--- a/test/nn/test_pooling.py
+++ b/test/nn/test_pooling.py
@@ -2061,11 +2061,11 @@ torch.cuda.synchronize()
     def test_pooling_large(self, device):
         def helper(pool):
             inp = torch.randn(
-                2**7 + 10, 2**8, 2**8, 2**8, dtype=torch.half, device="cuda"
+                2**7 + 10, 2**8, 2**8, 2**8, dtype=torch.half, device=device
             )
             self.assertTrue(inp.numel() > 2**31 - 1)
             pool(inp)
-            torch.cuda.synchronize()  # asserts test finishes normally without raising errors
+            torch.accelerator.synchronize(device)  # asserts test finishes normally without raising errors
 
         helper(nn.MaxPool2d(4, 4))
         helper(nn.AvgPool2d(4, 4))


### PR DESCRIPTION
Instead of hardcoding `cuda` in the `test_pooling_large` test case, use the provided `device` arguments. This enables the test also on other platforms such as XPU.

Fixes https://github.com/intel/torch-xpu-ops/issues/2132
