### PR TITLE
[CUDA] Fix typo: owidth_for_chape_check -> owidth_for_shape_check in AveragePool3d.cu

### DIFF
--- a/aten/src/ATen/native/cuda/AveragePool3d.cu
+++ b/aten/src/ATen/native/cuda/AveragePool3d.cu
@@ -503,7 +503,7 @@ TORCH_IMPL_FUNC(avg_pool3d_backward_out_cuda) (
   /* XXX shape check behavior from TH */
   const int64_t otime_for_shape_check = pooling_output_shape<int64_t>(itime, kT, padT, dT, 1, ceil_mode);
   const int64_t oheight_for_shape_check = pooling_output_shape<int64_t>(iheight, kH, padH, dH, 1, ceil_mode);
-  const int64_t owidth_for_chape_check = pooling_output_shape<int64_t>(iwidth, kW, padW, dW, 1, ceil_mode);
+  const int64_t owidth_for_shape_check = pooling_output_shape<int64_t>(iwidth, kW, padW, dW, 1, ceil_mode);
 
   const bool kernelsOverlap = (dT < kT) || (dH < kH) || (dW < kW);
 


### PR DESCRIPTION
Fixes #178719

Corrects a typo in AveragePool3d.cu where `owidth_for_chape_check` 
was misspelled. Should be `owidth_for_shape_check`.