### PR TITLE
Fix parse_ref.py path in setup-linux action to use github.action_path

### DIFF
--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -62,7 +62,7 @@ runs:
     - name: Parse ref
       id: parse-ref
       shell: bash
-      run: python3 .github/scripts/parse_ref.py
+      run: python3 "${{ github.action_path }}/../../scripts/parse_ref.py"
 
     - name: Get workflow job id
       id: get-job-id

--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -62,7 +62,15 @@ runs:
     - name: Parse ref
       id: parse-ref
       shell: bash
-      run: python3 "${{ github.action_path }}/../../scripts/parse_ref.py"
+      run: |
+        if [ -f "${{ github.action_path }}/../../scripts/parse_ref.py" ]; then
+          python3 "${{ github.action_path }}/../../scripts/parse_ref.py"
+        elif [ -f .github/scripts/parse_ref.py ]; then
+          python3 .github/scripts/parse_ref.py
+        else
+          echo "ERROR: parse_ref.py not found" >&2
+          exit 1
+        fi
 
     - name: Get workflow job id
       id: get-job-id


### PR DESCRIPTION
Update the action to use the relative directory for the parse_ref script. 

#177950 added the parse ref step which pulls the script relative to the workspace.  This is probably what is causing build failuers in Tutorials repo : https://github.com/pytorch/tutorials/issues/3808 

This change resolves the script path relative to the action's own directory using github.action_path

cc: @svekars @huydhn 