### PR TITLE
Fix xplat build: use PyObjectType::get() directly

### DIFF
--- a/torch/csrc/jit/frontend/schema_type_parser.cpp
+++ b/torch/csrc/jit/frontend/schema_type_parser.cpp
@@ -108,7 +108,9 @@ TypePtr SchemaTypeParser::parseBaseType() {
       {"Any", c10::TypeFactory::get<c10::AnyType>()},
       {"AnyClassType", c10::TypeFactory::get<c10::AnyClassType>()},
       {"AnyEnumType", c10::TypeFactory::get<c10::AnyEnumType>()},
-      {"PyObject", c10::TypeFactory::get<c10::PyObjectType>()},
+      // PyObjectType::get() used directly because PyObjectType is excluded
+      // from FORALL_DYNAMIC_TYPES (not supported on xplat/mobile)
+      {"PyObject", c10::PyObjectType::get()},
   };
   auto tok = L.cur();
   if (!L.nextIf(TK_NONE) && !L.nextIf(TK_NONE_TYPE)) {


### PR DESCRIPTION
Summary:
Forward-fix for D98670756 ([coor] Add _dtensor::mesh_get_process_group custom op).

The original diff added `{"PyObject", c10::TypeFactory::get<c10::PyObjectType>()}` to the
schema type parser's type map. On xplat builds, `TypeFactory` resolves to `DynamicTypeFactory`,
which calls `DynamicTypeTrait<T>::getBaseType()`. But `PyObjectType` is intentionally excluded
from `FORALL_DYNAMIC_TYPES` in `dynamic_type.h` (it's a Python concept, meaningless for
mobile/edge runtimes), so this causes 100 xplat build failures.

Fix: Use `c10::PyObjectType::get()` directly, which bypasses the DynamicTypeFactory path.
This is consistent with how the rest of the codebase handles PyObjectType (e.g., the
`isRegisteredOpaqueType` check in the same file uses `c10::PyObjectType::get()`).

Test Plan: xplat CI should now pass — the only failures on D98670756 were this build error.

Reviewed By: aorenste

Differential Revision: D98689012


