### PR TITLE
[logging] Use default=repr for trace logger JSON serialization

### DIFF
--- a/torch/_logging/_internal.py
+++ b/torch/_logging/_internal.py
@@ -1024,11 +1024,7 @@ class TorchLogsFormatter(logging.Formatter):
         if self._is_trace:
             if s != "":
                 raise AssertionError(f"expected empty string for trace, got {s!r}")
-            try:
-                r = f"{prefix} {json.dumps(record.metadata)}"
-            except TypeError:
-                log.warning("failing metadata: %r", record.metadata)
-                raise
+            r = f"{prefix} {json.dumps(record.metadata, default=repr)}"
             if record.payload is not None:
                 r += "".join(f"\n\t{l}" for l in record.payload.split("\n"))
             return r


### PR DESCRIPTION
Replace try/except around json.dumps with default=repr so opaque objects in metadata are serialized instead of raising TypeError.

Authored with Claude.