### PR TITLE
[BE] Cleanup rust installation after sccache build

### DIFF
--- a/.ci/docker/common/install_cache.sh
+++ b/.ci/docker/common/install_cache.sh
@@ -18,7 +18,8 @@ install_ubuntu() {
   cp target/release/sccache-dist /opt/cache/bin
   echo "Cleaning up"
   cd ..
-  rm -rf sccache .cargo
+  rm -rf sccache
+  rustup self uninstall -y
   apt-get remove -y pkg-config libssl-dev
   apt-get autoclean && apt-get clean
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #178790
* __->__ #178789

This slashes install_cache layer size from 1.6Gb to just 250Mb for the binaries