### PR TITLE
[BE] Clean conda cache before publishing image

### DIFF
--- a/.ci/docker/common/install_conda.sh
+++ b/.ci/docker/common/install_conda.sh
@@ -96,5 +96,8 @@ if [ -n "$ANACONDA_PYTHON_VERSION" ]; then
     pip_install -r /opt/conda/requirements-docs.txt
   fi
 
+  # Clean conda package cache
+  as_jenkins conda clean -ya
+
   popd
 fi


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #178790
* #178789

`/opt/conda/pkgs/` is about 1.4Gb of dead weight