### PR TITLE
[Native ops] Add Version 4.4.2 to allowed cutedsl versions

### DIFF
--- a/torch/_native/cutedsl_utils.py
+++ b/torch/_native/cutedsl_utils.py
@@ -24,6 +24,7 @@ _CUTEDSL_REQUIRED_VERSIONS: set[Version] = {
     # Current version - Note Version.from_part(release=(4.4.1)) is better
     #                   but > v26 of packaging.
     Version(f"{4}.{4}.{1}"),
+    Version(f"{4}.{4}.{2}"),
 }
 
 


### PR DESCRIPTION
Note: quack-kernels is currently on this version, which is needed for pr #178326

cc @slayton58