### PR TITLE
Fix meta conv shape checks for invalid groups vs out_channels

### DIFF
--- a/test/test_meta.py
+++ b/test/test_meta.py
@@ -1829,6 +1829,28 @@ class TestMeta(TestCase):
         elif cpu_err is not None and meta_err is None:
             raise RuntimeError("cpu failed, but meta didn't.") from cpu_err
 
+    def test_functional_conv_meta_errors_invalid_groups_weight_shape(self):
+        groups = 6
+        in_channel = 12
+        out_channel = 3
+        # test 1d
+        input_tensor = torch.randn(2, in_channel, 15, device="meta")
+        weight_tensor = torch.randn(out_channel, in_channel // groups, 3, device="meta")
+        with self.assertRaisesRegex(RuntimeError, "Invalid channel dimensions"):
+            torch.nn.functional.conv1d(input_tensor, weight_tensor, groups=6)
+
+        # test 2d
+        input_tensor = torch.randn(2, in_channel, 15, 15, device="meta")
+        weight_tensor = torch.randn(out_channel, in_channel // groups, 3, 3, device="meta")
+        with self.assertRaisesRegex(RuntimeError, "Invalid channel dimensions"):
+            torch.nn.functional.conv2d(input_tensor, weight_tensor, groups=6)
+
+        # test 3d
+        input_tensor = torch.randn(2, in_channel, 15, 15, 15, device="meta")
+        weight_tensor = torch.randn(out_channel, in_channel // groups, 3, 3, 3, device="meta")
+        with self.assertRaisesRegex(RuntimeError, "Invalid channel dimensions"):
+            torch.nn.functional.conv3d(input_tensor, weight_tensor, groups=6)
+
     def test_nonzero(self):
         t = torch.randn(2, 3, 4, device='meta')
         with exp_config.patch(meta_nonzero_assume_all_nonzero=True):

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -2464,7 +2464,8 @@ def calc_conv_nd_return_shape(
     else:
         out_channels = weight.shape[0]
         torch._check(
-            weight.shape[1] * groups == input_tensor.shape[1],
+            weight.shape[1] * groups == input_tensor.shape[1]
+            and out_channels % groups == 0,
             lambda: "Invalid channel dimensions",
         )
 

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -2465,6 +2465,7 @@ def calc_conv_nd_return_shape(
         out_channels = weight.shape[0]
         torch._check(
             weight.shape[1] * groups == input_tensor.shape[1]
+            and out_channels >= groups
             and out_channels % groups == 0,
             lambda: "Invalid channel dimensions",
         )

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -86,8 +86,8 @@ Args:
           may be needed internally. Lowering performance.
     dilation: the spacing between kernel elements. Can be a single number or
       a one-element tuple `(dW,)`. Default: 1
-    groups: split input into groups, :math:`\text{in\_channels}` should be divisible by
-      the number of groups. Default: 1
+    groups: split input into groups, both :math:`\text{in\_channels}` and :math:`\text{out\_channels}`
+      should be divisible by the number of groups. Default: 1
 
 Examples::
 
@@ -187,8 +187,8 @@ Args:
 
     dilation: the spacing between kernel elements. Can be a single number or
       a tuple `(dT, dH, dW)`. Default: 1
-    groups: split input into groups, :math:`\text{in\_channels}` should be divisible by
-      the number of groups. Default: 1
+    groups: split input into groups, both :math:`\text{in\_channels}` and :math:`\text{out\_channels}`
+      should be divisible by the number of groups. Default: 1
 
 Examples::
 


### PR DESCRIPTION
Grouped convolution requires both input and output channel counts to be compatible with groups. This change tightens the meta implementation so invalid combinations fail with the same "Invalid channel dimensions" error as on real devices, updates the conv1d / conv3d docs to state that both in_channels and out_channels must be divisible by groups, and adds regression tests on the meta device for conv1d, conv2d, and conv3d.

Fixes #177237