### PR TITLE
[mergebot] Add explicit error when ghstack revert finds no revertable PRs

### DIFF
--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -2174,6 +2174,13 @@ def try_revert(
                 f"Failed to fetch dependent PRs: {str(e)}, fall over to single revert"
             )
 
+    if not shas_and_prs:
+        raise RuntimeError(
+            f"No revertable PRs found in ghstack for #{pr.pr_num}. "
+            f"This typically means the PR is still open (not merged) or "
+            f"its GitHub state is inconsistent. Only closed/merged PRs can be reverted."
+        )
+
     do_revert_prs(
         repo,
         pr,


### PR DESCRIPTION
## Summary
- Fixes a crash in the revert workflow where `do_revert_prs` hits `IndexError: list index out of range` on `shas_and_prs[0]` when the list is empty
- `get_ghstack_dependent_prs` returns an empty list when the ghstack PR's GitHub state is inconsistent (merged but still showing as open), because it filters out non-closed PRs with `only_closed=True`
- Adds an explicit check with a clear error message before calling `do_revert_prs`, so users see `"No revertable PRs found in ghstack for #NNNNN"` instead of a raw `IndexError`

Observed in https://github.com/pytorch/pytorch/pull/178725 — the revert failed twice with `list index out of range`.

## Test plan
- Verified the fix is on the correct code path by tracing the traceback from [the failed job](https://github.com/pytorch/pytorch/actions/runs/23763315286/job/69236298067)

Authored with Claude.