### PR TITLE
Auto-detach returned tensors with consumed grad_fns instead of graph breaking

### DIFF
--- a/test/dynamo/test_fwd_loss_bwd.py
+++ b/test/dynamo/test_fwd_loss_bwd.py
@@ -587,26 +587,6 @@ class GraphModule(torch.nn.Module):
         self.assertIsNone(y_compiled.grad_fn)
         self.assertFalse(y_compiled.requires_grad)
 
-    def test_autograd_grad_leaked_tensor_names_in_error(self):
-        """Test that returned tensors with consumed grad_fns are auto-detached."""
-        torch._dynamo.reset()
-
-        def fn(x):
-            a = x * 2
-            b = x * 3
-            z = (a + b).sum()
-            torch.autograd.grad(z, x)
-            # Both a and b have consumed grad_fns
-            return a, b
-
-        compiled_fn = torch.compile(fn, fullgraph=True, backend="aot_eager")
-
-        x = torch.randn(4, requires_grad=True)
-        a, b = compiled_fn(x)
-        # Both should be auto-detached
-        self.assertIsNone(a.grad_fn)
-        self.assertIsNone(b.grad_fn)
-
     @skipIfCrossRef
     def test_autograd_grad_external_grad_fn_detached(self):
         torch._dynamo.reset()

--- a/test/dynamo/test_fwd_loss_bwd.py
+++ b/test/dynamo/test_fwd_loss_bwd.py
@@ -530,43 +530,34 @@ class GraphModule(torch.nn.Module):
             loss_eager.backward()
 
         torch._dynamo.reset()
-        # With fullgraph=True, we get an Unsupported error at compile time
+        # With fullgraph=True, the consumed grad_fn tensor is auto-detached
         step_compiled_fullgraph = torch.compile(
             step, fullgraph=True, backend="aot_eager"
         )
 
-        with self.assertRaisesRegex(
-            torch._dynamo.exc.Unsupported,
-            re.escape(
-                """\
-autograd.grad consumed returned tensor's grad_fn
-  Explanation: torch.autograd.grad() consumes grad_fns that are needed by tensors returned from this compiled function. This would cause 'backward through graph a second time' errors.
-  Hint: If you don't need to backward through the returned tensor, call .detach() before returning: `return loss.detach()`
-  Hint: If you need to backward through the returned tensor, use retain_graph=True in autograd.grad()."""  # noqa: B950
-            ),
-        ):
-            step_compiled_fullgraph(torch.nn.Linear(4, 4), torch.randn(2, 4))
+        loss_fullgraph, grad_sum_fullgraph = step_compiled_fullgraph(
+            torch.nn.Linear(4, 4), torch.randn(2, 4)
+        )
+        # loss should be auto-detached (no grad_fn)
+        self.assertIsNone(loss_fullgraph.grad_fn)
 
         torch._dynamo.reset()
 
-        # With fullgraph=False, code before and after autograd.grad is compiled,
-        # but autograd.grad itself runs in eager.
+        # With fullgraph=False, auto-detach also applies — everything
+        # compiles in a single frame.
         cnt = torch._dynamo.testing.CompileCounter()
         step_compiled_graph_break = torch.compile(step, fullgraph=False, backend=cnt)
 
         loss_compiled, grad_sum_compiled = step_compiled_graph_break(
             torch.nn.Linear(4, 4), torch.randn(2, 4)
         )
-        self.assertEqual(cnt.frame_count, 2)
+        self.assertEqual(cnt.frame_count, 1)
 
-        # The returned loss still has the eager behavior issue
-        with self.assertRaisesRegex(
-            RuntimeError,
-            "Trying to backward through the graph a second time",
-        ):
-            loss_compiled.backward()
+        # The returned loss is auto-detached, so backward is not possible
+        self.assertIsNone(loss_compiled.grad_fn)
 
     def test_autograd_grad_consumed_intermediate_tensor(self):
+        """Test that returned tensors with consumed grad_fns are auto-detached."""
         torch._dynamo.reset()
 
         def fn(x):
@@ -577,7 +568,7 @@ autograd.grad consumed returned tensor's grad_fn
             )  # consumes AddBackward and MulBackward
             return y, grad  # y's grad_fn was consumed!
 
-        # Verify eager fails
+        # Verify eager fails if you try to backward through y
         x_eager = torch.randn(4, requires_grad=True)
         y_eager, grad_eager = fn(x_eager)
         with self.assertRaisesRegex(
@@ -586,23 +577,35 @@ autograd.grad consumed returned tensor's grad_fn
         ):
             y_eager.sum().backward()
 
-        # Compiled should detect this and raise Unsupported
+        # Compiled should auto-detach y since its grad_fn was consumed
         torch._dynamo.reset()
         compiled_fn = torch.compile(fn, fullgraph=True, backend="aot_eager")
 
-        msg = textwrap.dedent(
-            """\
-autograd.grad consumed returned tensor's grad_fn
-  Explanation: torch.autograd.grad() consumes grad_fns that are needed by tensors returned from this compiled function. This would cause 'backward through graph a second time' errors.
-  Hint: If you don't need to backward through the returned tensor, call .detach() before returning: `return loss.detach()`
-  Hint: If you need to backward through the returned tensor, use retain_graph=True in autograd.grad()."""  # noqa: B950
-        )
+        x_compiled = torch.randn(4, requires_grad=True)
+        y_compiled, grad_compiled = compiled_fn(x_compiled)
+        # y should be auto-detached (no grad_fn)
+        self.assertIsNone(y_compiled.grad_fn)
+        self.assertFalse(y_compiled.requires_grad)
 
-        with self.assertRaisesRegex(
-            torch._dynamo.exc.Unsupported,
-            re.escape(msg) + r"[\s\S]*",
-        ):
-            compiled_fn(torch.randn(4, requires_grad=True))
+    def test_autograd_grad_leaked_tensor_names_in_error(self):
+        """Test that returned tensors with consumed grad_fns are auto-detached."""
+        torch._dynamo.reset()
+
+        def fn(x):
+            a = x * 2
+            b = x * 3
+            z = (a + b).sum()
+            torch.autograd.grad(z, x)
+            # Both a and b have consumed grad_fns
+            return a, b
+
+        compiled_fn = torch.compile(fn, fullgraph=True, backend="aot_eager")
+
+        x = torch.randn(4, requires_grad=True)
+        a, b = compiled_fn(x)
+        # Both should be auto-detached
+        self.assertIsNone(a.grad_fn)
+        self.assertIsNone(b.grad_fn)
 
     @skipIfCrossRef
     def test_autograd_grad_external_grad_fn_detached(self):

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -2463,7 +2463,9 @@ class OutputGraph(OutputGraphCommon):
                 # The grad_fn was already consumed by backward/autograd.grad
                 # within this graph. Auto-detach instead of graph breaking since
                 # the tensor can't be backward'd again anyway.
-                rv[i] = var.call_method(tx, "detach", [], {})
+                rv[i] = var.call_method(
+                    tx, "detach", [], {}
+                )  # pyrefly: ignore[bad-argument-type]
 
     def _check_requires_grad_intermediate_outputs(
         self, rv: list["VariableTracker"], tx: "InstructionTranslatorBase"

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -2434,8 +2434,9 @@ class OutputGraph(OutputGraphCommon):
     ) -> None:
         """
         Validate that if torch.autograd.grad is used in the graph and outputs
-        require grad, we trigger AutogradGradRestartAnalysis only if the output is connected
-        to the autograd.grad computation.
+        require grad, auto-detach the output if the grad_fn was already consumed
+        by backward/autograd.grad within the same graph. This is safe because
+        the grad_fn is already consumed and can't be backward'd again.
 
         rv here refers to list of variables that are being returned from dynamo graph.
 
@@ -2446,7 +2447,7 @@ class OutputGraph(OutputGraphCommon):
 
         from .variables.tensor import TensorVariable
 
-        for var in rv:
+        for i, var in enumerate(rv):
             if not isinstance(var, TensorVariable) or not var.requires_grad:
                 continue
 
@@ -2459,11 +2460,10 @@ class OutputGraph(OutputGraphCommon):
             # if any node was consumed by autograd.grad
             reachable_grad_fns = collect_reachable_grad_fns([(fake_tensor, None)])
             if reachable_grad_fns & self.autograd_grad_consumed_grad_fns:
-                # Set the flag to graph break at autograd.grad on retry
-                tx.speculation_log.graph_break_on_autograd_grad = True
-                raise exc.AutogradGradRestartAnalysis(
-                    restart_reason="autograd.grad consumed grad_fns of returned tensors"
-                )
+                # The grad_fn was already consumed by backward/autograd.grad
+                # within this graph. Auto-detach instead of graph breaking since
+                # the tensor can't be backward'd again anyway.
+                rv[i] = var.call_method(tx, "detach", [], {})
 
     def _check_requires_grad_intermediate_outputs(
         self, rv: list["VariableTracker"], tx: "InstructionTranslatorBase"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #178807

When backward/autograd.grad consumes a tensor's grad_fn within the
compiled graph, auto-detach it on return instead of raising
AutogradGradRestartAnalysis. This avoids unnecessary graph breaks
and removes the need for manual .detach() calls.

Signed-off-by: Animesh Jain <anijain@umich.edu>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo