### PR TITLE
[ROCm] Update BFloat16.h to support ROCm with HIPCC using __hip_bf16 as helper.

### DIFF
--- a/torch/headeronly/util/BFloat16.h
+++ b/torch/headeronly/util/BFloat16.h
@@ -127,7 +127,7 @@ C10_CLANG_DIAGNOSTIC_IGNORE("-Wimplicit-int-float-conversion")
 inline C10_HOST_DEVICE BFloat16::BFloat16(float value)
     :
 #if defined(__CUDACC__) && !defined(USE_ROCM) && defined(__CUDA_ARCH__) && \
-    __CUDA_ARCH__ >= 800 || \
+        __CUDA_ARCH__ >= 800 ||                                            \
     defined(__HIPCC__) && defined(USE_ROCM) && (TORCH_HIP_VERSION >= 702)
       x(__bfloat16_as_ushort(__float2bfloat16(value)))
 #elif defined(__SYCL_DEVICE_ONLY__) && \

--- a/torch/headeronly/util/BFloat16.h
+++ b/torch/headeronly/util/BFloat16.h
@@ -124,7 +124,7 @@ C10_CLANG_DIAGNOSTIC_IGNORE("-Wimplicit-int-float-conversion")
 /// Constructors
 inline C10_HOST_DEVICE BFloat16::BFloat16(float value)
     :
-#if defined(__CUDACC__) &&                                                   \    
+#if defined(__CUDACC__) &&                                                   \
     (!defined(USE_ROCM) && defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800 || \
      defined(USE_ROCM) && (TORCH_HIP_VERSION >= 702))
       x(__bfloat16_as_ushort(__float2bfloat16(value)))

--- a/torch/headeronly/util/BFloat16.h
+++ b/torch/headeronly/util/BFloat16.h
@@ -13,7 +13,7 @@
 #include <ostream>
 
 #if defined(__CUDACC__) && !defined(USE_ROCM) || \
-    defined(__HIPCC__) && defined(USE_ROCM)
+    defined(__HIPCC__) && defined(USE_ROCM) && (TORCH_HIP_VERSION >= 702)
 #include <cuda_bf16.h>
 #endif
 
@@ -48,7 +48,7 @@ struct alignas(2) BFloat16 {
   inline C10_HOST_DEVICE operator float() const;
 
 #if defined(__CUDACC__) && !defined(USE_ROCM) || \
-    defined(__HIPCC__) && defined(USE_ROCM)
+    defined(__HIPCC__) && defined(USE_ROCM) && (TORCH_HIP_VERSION >= 702)
   inline C10_HOST_DEVICE BFloat16(const __nv_bfloat16& value);
   explicit inline C10_HOST_DEVICE operator __nv_bfloat16() const;
 #endif
@@ -128,7 +128,7 @@ inline C10_HOST_DEVICE BFloat16::BFloat16(float value)
     :
 #if defined(__CUDACC__) && !defined(USE_ROCM) && defined(__CUDA_ARCH__) && \
     __CUDA_ARCH__ >= 800 || \
-    defined(__HIPCC__) && defined(USE_ROCM)
+    defined(__HIPCC__) && defined(USE_ROCM) && (TORCH_HIP_VERSION >= 702)
       x(__bfloat16_as_ushort(__float2bfloat16(value)))
 #elif defined(__SYCL_DEVICE_ONLY__) && \
     defined(SYCL_EXT_ONEAPI_BFLOAT16_MATH_FUNCTIONS)
@@ -143,7 +143,7 @@ inline C10_HOST_DEVICE BFloat16::BFloat16(float value)
 /// Implicit conversions
 inline C10_HOST_DEVICE BFloat16::operator float() const {
 #if defined(__CUDACC__) && !defined(USE_ROCM) || \
-    defined(__HIPCC__) && defined(USE_ROCM)
+    defined(__HIPCC__) && defined(USE_ROCM) && (TORCH_HIP_VERSION >= 702)
   return __bfloat162float(*reinterpret_cast<const __nv_bfloat16*>(&x));
 #elif defined(__SYCL_DEVICE_ONLY__) && \
     defined(SYCL_EXT_ONEAPI_BFLOAT16_MATH_FUNCTIONS)
@@ -154,7 +154,7 @@ inline C10_HOST_DEVICE BFloat16::operator float() const {
 }
 
 #if defined(__CUDACC__) && !defined(USE_ROCM) || \
-    defined(__HIPCC__) && defined(USE_ROCM)
+    defined(__HIPCC__) && defined(USE_ROCM) && (TORCH_HIP_VERSION >= 702)
 inline C10_HOST_DEVICE BFloat16::BFloat16(const __nv_bfloat16& value) {
   x = *reinterpret_cast<const unsigned short*>(&value);
 }

--- a/torch/headeronly/util/BFloat16.h
+++ b/torch/headeronly/util/BFloat16.h
@@ -12,7 +12,8 @@
 #include <iosfwd>
 #include <ostream>
 
-#if defined(__CUDACC__) && !defined(USE_ROCM)
+#if defined(__CUDACC__) && !defined(USE_ROCM) || \
+    defined(__HIPCC__) && defined(USE_ROCM)
 #include <cuda_bf16.h>
 #endif
 
@@ -46,7 +47,8 @@ struct alignas(2) BFloat16 {
   /* implicit */ inline C10_HOST_DEVICE BFloat16(float value);
   inline C10_HOST_DEVICE operator float() const;
 
-#if defined(__CUDACC__) && !defined(USE_ROCM)
+#if defined(__CUDACC__) && !defined(USE_ROCM) || \
+    defined(__HIPCC__) && defined(USE_ROCM)
   inline C10_HOST_DEVICE BFloat16(const __nv_bfloat16& value);
   explicit inline C10_HOST_DEVICE operator __nv_bfloat16() const;
 #endif
@@ -125,7 +127,8 @@ C10_CLANG_DIAGNOSTIC_IGNORE("-Wimplicit-int-float-conversion")
 inline C10_HOST_DEVICE BFloat16::BFloat16(float value)
     :
 #if defined(__CUDACC__) && !defined(USE_ROCM) && defined(__CUDA_ARCH__) && \
-    __CUDA_ARCH__ >= 800
+    __CUDA_ARCH__ >= 800 || \
+    defined(__HIPCC__) && defined(USE_ROCM)
       x(__bfloat16_as_ushort(__float2bfloat16(value)))
 #elif defined(__SYCL_DEVICE_ONLY__) && \
     defined(SYCL_EXT_ONEAPI_BFLOAT16_MATH_FUNCTIONS)
@@ -139,7 +142,8 @@ inline C10_HOST_DEVICE BFloat16::BFloat16(float value)
 
 /// Implicit conversions
 inline C10_HOST_DEVICE BFloat16::operator float() const {
-#if defined(__CUDACC__) && !defined(USE_ROCM)
+#if defined(__CUDACC__) && !defined(USE_ROCM) || \
+    defined(__HIPCC__) && defined(USE_ROCM)
   return __bfloat162float(*reinterpret_cast<const __nv_bfloat16*>(&x));
 #elif defined(__SYCL_DEVICE_ONLY__) && \
     defined(SYCL_EXT_ONEAPI_BFLOAT16_MATH_FUNCTIONS)
@@ -149,7 +153,8 @@ inline C10_HOST_DEVICE BFloat16::operator float() const {
 #endif
 }
 
-#if defined(__CUDACC__) && !defined(USE_ROCM)
+#if defined(__CUDACC__) && !defined(USE_ROCM) || \
+    defined(__HIPCC__) && defined(USE_ROCM)
 inline C10_HOST_DEVICE BFloat16::BFloat16(const __nv_bfloat16& value) {
   x = *reinterpret_cast<const unsigned short*>(&value);
 }

--- a/torch/headeronly/util/BFloat16.h
+++ b/torch/headeronly/util/BFloat16.h
@@ -124,7 +124,7 @@ C10_CLANG_DIAGNOSTIC_IGNORE("-Wimplicit-int-float-conversion")
 /// Constructors
 inline C10_HOST_DEVICE BFloat16::BFloat16(float value)
     :
-#if defined(__CUDACC__) &&                                           \
+#if defined(__CUDACC__) &&                                                   \    
     (!defined(USE_ROCM) && defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800 || \
      defined(USE_ROCM) && (TORCH_HIP_VERSION >= 702))
       x(__bfloat16_as_ushort(__float2bfloat16(value)))

--- a/torch/headeronly/util/BFloat16.h
+++ b/torch/headeronly/util/BFloat16.h
@@ -12,8 +12,7 @@
 #include <iosfwd>
 #include <ostream>
 
-#if defined(__CUDACC__) && !defined(USE_ROCM) || \
-    defined(__HIPCC__) && defined(USE_ROCM) && (TORCH_HIP_VERSION >= 702)
+#if defined(__CUDACC__) && (!defined(USE_ROCM) || (TORCH_HIP_VERSION >= 702))
 #include <cuda_bf16.h>
 #endif
 
@@ -47,8 +46,7 @@ struct alignas(2) BFloat16 {
   /* implicit */ inline C10_HOST_DEVICE BFloat16(float value);
   inline C10_HOST_DEVICE operator float() const;
 
-#if defined(__CUDACC__) && !defined(USE_ROCM) || \
-    defined(__HIPCC__) && defined(USE_ROCM) && (TORCH_HIP_VERSION >= 702)
+#if defined(__CUDACC__) && (!defined(USE_ROCM) || (TORCH_HIP_VERSION >= 702))
   inline C10_HOST_DEVICE BFloat16(const __nv_bfloat16& value);
   explicit inline C10_HOST_DEVICE operator __nv_bfloat16() const;
 #endif
@@ -126,9 +124,9 @@ C10_CLANG_DIAGNOSTIC_IGNORE("-Wimplicit-int-float-conversion")
 /// Constructors
 inline C10_HOST_DEVICE BFloat16::BFloat16(float value)
     :
-#if defined(__CUDACC__) && !defined(USE_ROCM) && defined(__CUDA_ARCH__) && \
-        __CUDA_ARCH__ >= 800 ||                                            \
-    defined(__HIPCC__) && defined(USE_ROCM) && (TORCH_HIP_VERSION >= 702)
+#if defined(__CUDACC__) &&                                           \
+    (!defined(USE_ROCM) && defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800 || \
+     defined(USE_ROCM) && (TORCH_HIP_VERSION >= 702))
       x(__bfloat16_as_ushort(__float2bfloat16(value)))
 #elif defined(__SYCL_DEVICE_ONLY__) && \
     defined(SYCL_EXT_ONEAPI_BFLOAT16_MATH_FUNCTIONS)
@@ -142,8 +140,7 @@ inline C10_HOST_DEVICE BFloat16::BFloat16(float value)
 
 /// Implicit conversions
 inline C10_HOST_DEVICE BFloat16::operator float() const {
-#if defined(__CUDACC__) && !defined(USE_ROCM) || \
-    defined(__HIPCC__) && defined(USE_ROCM) && (TORCH_HIP_VERSION >= 702)
+#if defined(__CUDACC__) && (!defined(USE_ROCM) || (TORCH_HIP_VERSION >= 702))
   return __bfloat162float(*reinterpret_cast<const __nv_bfloat16*>(&x));
 #elif defined(__SYCL_DEVICE_ONLY__) && \
     defined(SYCL_EXT_ONEAPI_BFLOAT16_MATH_FUNCTIONS)
@@ -153,8 +150,7 @@ inline C10_HOST_DEVICE BFloat16::operator float() const {
 #endif
 }
 
-#if defined(__CUDACC__) && !defined(USE_ROCM) || \
-    defined(__HIPCC__) && defined(USE_ROCM) && (TORCH_HIP_VERSION >= 702)
+#if defined(__CUDACC__) && (!defined(USE_ROCM) || (TORCH_HIP_VERSION >= 702))
 inline C10_HOST_DEVICE BFloat16::BFloat16(const __nv_bfloat16& value) {
   x = *reinterpret_cast<const unsigned short*>(&value);
 }


### PR DESCRIPTION
Refactor the BFloat16 implementation to efficiently leverage the native HIP float‑conversion capabilities. Instead of performing software‑based conversions to 32‑bit float and back for all operations,update the HIP environment to use the native __bf16 type, which provides hardware‑accelerated conversion for both floating‑point and integer types. 

Example:
The current implementation sums two 16‑bit floating‑point values by converting them to 32‑bit floats in software, performing the addition in 32‑bit precision, and then converting the result back to 16‑bit. This introduces extra operations and register memory overhead of 2x32‑bit for converted values (plus another extra space for conversion function variables: float, int and pointer ~ 4x32-bit).

The proposed implementation performs conversion using hardware utilizing __hip_bfloat16 class functionality. 

Development notes:
1. Usage of __bf16 type is based of its usage in __hip_bfloat16 class from amd_hip_bf16.h included in hip/hip_bf16.h.
2.  BFloat16.h will be  hipified during build: __CUDACC__ -> __HIPCC__, __nv_bfloat16 -> __hip_bfloat16, cuda_bf16.h -> hip/hip_bf16.h. It makes harder to review code as some code changes still rely on hipification, some code changes overrule it.  

Performance Justification:

Quick check using HIP program test shows performance of c10::BFloat16  vs __hip_bfloat16 about 20% improvement potential. on kernel level:
```
Device: AMD Radeon Graphics (MI350)
c10::BFloat16 on ROCm: + and * use float promotion (see BFloat16.h).
Grid: 4096 x 256 = 1048576 threads, repeat = 80000

Kernel                            time          Gop/s
------------------------------------------------------------
__hip_bfloat16 __hadd           10.076 ms      8325.12 Gop/s
__hip_bfloat16 __hmul           10.099 ms      8306.73 Gop/s
c10::BFloat16 operator+         12.163 ms      6896.67 Gop/s
c10::BFloat16 operator*         12.035 ms      6970.00 Gop/s
------------------------------------------------------------
Each line counts one scalar add or mul in the loop body.
c10 path does extra bf16<->f32 work each iteration.

```
After current changes:

```
Grid: 4096 x 256 = 1048576 threads, repeat = 80000

Kernel                            time          Gop/s
------------------------------------------------------------
__hip_bfloat16 __hadd           10.057 ms      8340.75 Gop/s
__hip_bfloat16 __hmul           10.037 ms      8357.48 Gop/s
c10::BFloat16 operator+         10.064 ms      8335.59 Gop/s
c10::BFloat16 operator*         10.046 ms      8350.42 Gop/s
------------------------------------------------------------
Each line counts one scalar add or mul in the loop body.

```

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang