### PR TITLE
[CUDA][FP8][CPU][TEST] Properly saturate E4M3 on finite-overflow on CPU/C++ conversion code

### DIFF
--- a/aten/src/ATen/cpu/vec/vec512/vec512_float8.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_float8.h
@@ -125,10 +125,15 @@ static inline __m128i cvtfp32_fp8e4m3(const __m512& src) {
   __m512i result = _mm512_setzero_si512();
 
   // Step 1: Handle case of overflow
-  // (f_bits >= fp8_max): set result = 0x7f
+  // NaN (f_bits > fp32_inf): set result = 0x7f
+  // Finite overflow or inf (fp8_max <= f_bits <= fp32_inf): saturate to 0x7e
+  const __m512i fp32_inf = _mm512_set1_epi32(UINT32_C(0x7F800000));
   __mmask16 overflow_mask = _mm512_cmpge_epu32_mask(f_bits, fp8_max);
   if (overflow_mask) {
-    result = _mm512_mask_set1_epi32(result, overflow_mask, 0x7f);
+    __mmask16 nan_mask = _mm512_cmpgt_epu32_mask(f_bits, fp32_inf);
+    __mmask16 sat_mask = overflow_mask & ~nan_mask;
+    result = _mm512_mask_set1_epi32(result, nan_mask, 0x7f);
+    result = _mm512_mask_set1_epi32(result, sat_mask, 0x7e);
   }
 
   // Step 2: Handle small numbers (denormals)
@@ -158,6 +163,11 @@ static inline __m128i cvtfp32_fp8e4m3(const __m512& src) {
     rounded = _mm512_add_epi32(rounded, mant_odd);
     // Shift right by 20 bits
     __m512i normal_result = _mm512_srli_epi32(rounded, 20);
+    // Rounding may carry into the NaN bit pattern (0x7f); saturate to max
+    __mmask16 round_overflow =
+        _mm512_cmpeq_epi32_mask(normal_result, _mm512_set1_epi32(0x7f));
+    normal_result =
+        _mm512_mask_set1_epi32(normal_result, round_overflow, 0x7e);
     result = _mm512_mask_mov_epi32(result, normal_mask, normal_result);
   }
 

--- a/aten/src/ATen/cpu/vec/vec512/vec512_float8.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_float8.h
@@ -166,8 +166,7 @@ static inline __m128i cvtfp32_fp8e4m3(const __m512& src) {
     // Rounding may carry into the NaN bit pattern (0x7f); saturate to max
     __mmask16 round_overflow =
         _mm512_cmpeq_epi32_mask(normal_result, _mm512_set1_epi32(0x7f));
-    normal_result =
-        _mm512_mask_set1_epi32(normal_result, round_overflow, 0x7e);
+    normal_result = _mm512_mask_set1_epi32(normal_result, round_overflow, 0x7e);
     result = _mm512_mask_mov_epi32(result, normal_mask, normal_result);
   }
 

--- a/test/quantization/core/experimental/test_floatx.py
+++ b/test/quantization/core/experimental/test_floatx.py
@@ -274,7 +274,11 @@ class TestFloat8Dtype(TestCase):
         x = torch.cat((x, -x))
         x8 = x.to(dtype)
         # CUDA uses __NV_SATFINITE intrinsics which clamp overflow to max
-        saturate = x.is_cuda and torch.version.cuda >= "13.2" and torch.cuda.get_device_capability() >= (8, 9)
+        saturate = (
+            x.is_cuda
+            and torch.version.cuda >= "13.2"
+            and torch.cuda.get_device_capability() >= (8, 9)
+        )
         x8_simulated = simulate_fp8_precision(x, dtype, saturate=saturate)
         self.assertEqual(x8_simulated, x8.float())
 

--- a/test/quantization/core/experimental/test_floatx.py
+++ b/test/quantization/core/experimental/test_floatx.py
@@ -127,18 +127,16 @@ SPECIAL_NUMBERS = {
 
 FLOAT8_DTYPES_WITH_INF = [torch.float8_e5m2]
 
+FLOAT8_DTYPES_SATURATE_ON_OVERFLOW = [torch.float8_e4m3fn]
+
 
 def _int_bits_to_float(x):
     y = struct.unpack("!f", struct.pack("!I", x))[0]
     return y
 
 
-def simulate_fp8_precision(input, variant, saturate=False):
-    """Round input (as float32) to the given float8 datatype variant.
-
-    When saturate is True, overflows for types without inf clamp to max (matching
-    CUDA __NV_SATFINITE behavior). When False, they become NaN.
-    """
+def simulate_fp8_precision(input, variant):
+    """Round input (as float32) to the given float8 datatype variant."""
 
     # Constants
     dtype = torch.float32
@@ -182,12 +180,12 @@ def simulate_fp8_precision(input, variant, saturate=False):
     # Re-compose mantissa and exponent
     vals = (mantissa_val_rounded * 2.0 ** (-23 + exponent)).to(dtype)
 
-    # Replace overflows with inf/NaN/max as appropriate
-    have_inf = variant in FLOAT8_DTYPES_WITH_INF
+    # Replace overflows: inf for types that have it, saturate to max for types
+    # that use satfinite semantics, NaN otherwise
     overflow = vals > torch.finfo(variant).max
-    if have_inf:
+    if variant in FLOAT8_DTYPES_WITH_INF:
         vals[overflow] = torch.inf
-    elif saturate:
+    elif variant in FLOAT8_DTYPES_SATURATE_ON_OVERFLOW:
         vals[overflow] = torch.finfo(variant).max
     else:
         vals[overflow] = torch.nan
@@ -273,13 +271,7 @@ class TestFloat8Dtype(TestCase):
         x = get_input(dtype, device)
         x = torch.cat((x, -x))
         x8 = x.to(dtype)
-        # CUDA uses __NV_SATFINITE intrinsics which clamp overflow to max
-        saturate = (
-            x.is_cuda
-            and torch.version.cuda >= "13.2"
-            and torch.cuda.get_device_capability() >= (8, 9)
-        )
-        x8_simulated = simulate_fp8_precision(x, dtype, saturate=saturate)
+        x8_simulated = simulate_fp8_precision(x, dtype)
         self.assertEqual(x8_simulated, x8.float())
 
     def test_float8_e8m0fnu_rne_rounding(self, device):

--- a/test/quantization/core/experimental/test_floatx.py
+++ b/test/quantization/core/experimental/test_floatx.py
@@ -133,8 +133,12 @@ def _int_bits_to_float(x):
     return y
 
 
-def simulate_fp8_precision(input, variant):
-    """Round input (as float32) to the given float8 datatype variant."""
+def simulate_fp8_precision(input, variant, saturate=False):
+    """Round input (as float32) to the given float8 datatype variant.
+
+    When saturate is True, overflows for types without inf clamp to max (matching
+    CUDA __NV_SATFINITE behavior). When False, they become NaN.
+    """
 
     # Constants
     dtype = torch.float32
@@ -178,9 +182,15 @@ def simulate_fp8_precision(input, variant):
     # Re-compose mantissa and exponent
     vals = (mantissa_val_rounded * 2.0 ** (-23 + exponent)).to(dtype)
 
-    # Replace overflows with inf/NaN as appropriate (no saturation)
+    # Replace overflows with inf/NaN/max as appropriate
     have_inf = variant in FLOAT8_DTYPES_WITH_INF
-    vals[vals > torch.finfo(variant).max] = torch.inf if have_inf else torch.nan
+    overflow = vals > torch.finfo(variant).max
+    if have_inf:
+        vals[overflow] = torch.inf
+    elif saturate:
+        vals[overflow] = torch.finfo(variant).max
+    else:
+        vals[overflow] = torch.nan
 
     return vals * signs
 
@@ -263,7 +273,9 @@ class TestFloat8Dtype(TestCase):
         x = get_input(dtype, device)
         x = torch.cat((x, -x))
         x8 = x.to(dtype)
-        x8_simulated = simulate_fp8_precision(x, dtype)
+        # CUDA uses __NV_SATFINITE intrinsics which clamp overflow to max
+        saturate = x.is_cuda and torch.version.cuda >= "13.2" and torch.cuda.get_device_capability() >= (8, 9)
+        x8_simulated = simulate_fp8_precision(x, dtype, saturate=saturate)
         self.assertEqual(x8_simulated, x8.float())
 
     def test_float8_e8m0fnu_rne_rounding(self, device):

--- a/torch/headeronly/util/Float8_e4m3fn.h
+++ b/torch/headeronly/util/Float8_e4m3fn.h
@@ -204,8 +204,13 @@ inline C10_HOST_DEVICE uint8_t fp8e4m3fn_from_fp32_value(float f) {
   f_bits ^= sign;
 
   if (f_bits >= fp8_max) {
-    // NaN - all exponent and mantissa bits set to 1
-    result = 0x7f;
+    if (f_bits > UINT32_C(0x7F800000)) {
+      // NaN input → NaN output
+      result = 0x7f;
+    } else {
+      // Finite overflow or inf → saturate to max finite value
+      result = 0x7e;
+    }
   } else {
     if (f_bits < (UINT32_C(121) << 23)) {
       // Input number is smaller than 2^(-6), which is the smallest
@@ -225,6 +230,11 @@ inline C10_HOST_DEVICE uint8_t fp8e4m3fn_from_fp32_value(float f) {
 
       // take the bits!
       result = static_cast<uint8_t>(f_bits >> 20);
+
+      // Rounding may carry into the NaN bit pattern (0x7f); saturate to max
+      if (result == 0x7f) {
+        result = 0x7e;
+      }
     }
   }
 


### PR DESCRIPTION
~~Following #177870 the expected behavior of extreme values changes~~
#177870 revealed that the reference computation/CPU casting behavior wasn't actually saturating E4M3 casts as expected

authored with claude

cc @ptrblck @msaroufim @jerryzh168 @tinglvv @nWEIdia @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01