### PR TITLE
[profiler] Acquire GIL in PythonTracer destructor before Py_XDECREF

### DIFF
--- a/torch/csrc/autograd/profiler_python.cpp
+++ b/torch/csrc/autograd/profiler_python.cpp
@@ -1194,7 +1194,10 @@ PythonTracer::~PythonTracer() {
     TORCH_WARN("`PythonTracer::stop()` was not called.");
     stop();
   }
-  Py_XDECREF((PyObject*)shared_ctx_);
+  if (Py_IsInitialized() && !Py_IsFinalizing()) {
+    pybind11::gil_scoped_acquire gil;
+    Py_XDECREF((PyObject*)shared_ctx_);
+  }
 }
 
 void PythonTracer::recordPyCall(


### PR DESCRIPTION
On-demand profiling via LibKinetoClient::stop() calls disableProfiler() from a C++ thread without the GIL. This flows through finalizeTrace() → getRecords() → python_tracer_.reset(), destroying PythonTracer on a thread that never held the GIL. The Py_XDECREF(shared_ctx_) then crashes in _PyObject_Free because pymalloc is not thread-safe.

Acquire the GIL before decrementing, and skip the decref entirely if the interpreter is shutting down.

Authored with Claude.