### PR TITLE
[BE][Skills][Triager}] Update to label helion, don't leave unlabeled PT2 issues

### DIFF
--- a/.claude/skills/triaging-issues/SKILL.md
+++ b/.claude/skills/triaging-issues/SKILL.md
@@ -156,7 +156,7 @@ If the issue belongs in another repo (vision/text/audio/RL/ExecuTorch/etc.), tra
 
 **PT2 is NOT a redirect.** `oncall: pt2` is not like the other oncall labels in Step 3. PT2 issues continue through Steps 4–7 for full triage — add `oncall: pt2`, then proceed to label with `module:` labels, mark `triaged`, etc.
 
-See [pt2-triage-rubric.md](pt2-triage-rubric.md) for detailed labeling decisions on which `module:` labels to apply.
+**Every `oncall: pt2` issue MUST have at least one `module:` label.** The PT2 oncall queue is too broad without a module label — the team needs to know which component is affected (e.g., `module: dynamo`, `module: inductor`, `module: helion`, `module: dynamic shapes`). If you cannot determine the specific module, use `module: compile ux` as a fallback, but always try to be specific first. See [pt2-triage-rubric.md](pt2-triage-rubric.md) for detailed guidance.
 
 ### 3) Redirect to Secondary Oncall
 

--- a/.claude/skills/triaging-issues/labels.json
+++ b/.claude/skills/triaging-issues/labels.json
@@ -437,7 +437,7 @@
     },
     {
       "name": "module: helion",
-      "description": ""
+      "description": "Helion (pytorch/helion) is a high-level Python DSL for writing GPU kernels that compiles to Triton. Users write kernels with @helion.kernel decorator and helion.language (hl.tile(), etc.) using familiar PyTorch operations. Helion kernels integrate with torch.compile/inductor via template fusion hooks. Apply when the issue involves helion kernel authoring, helion compilation, helion-to-Triton codegen, or helion+inductor template fusion. Do NOT apply for plain Triton kernel issues (use module: inductor) or general torch.compile issues unless helion is specifically involved."
     },
     {
       "name": "module: higher order operators",

--- a/.claude/skills/triaging-issues/pt2-triage-rubric.md
+++ b/.claude/skills/triaging-issues/pt2-triage-rubric.md
@@ -2,6 +2,8 @@
 
 This rubric guides labeling decisions for PT2 oncall triage.
 
+**Every `oncall: pt2` issue MUST have at least one `module:` label.** The PT2 queue is too broad without one — the team needs to know which component is affected. Use the sections below to determine the right module label(s).
+
 ## 1. Component Isolation - Be Precise, Don't Over-Tag
 
 ### Dynamo vs Dynamic Shapes
@@ -135,7 +137,34 @@ Check for existing labels before inventing categories:
 
 ---
 
-## 7. functorch + compile
+## 7. Helion Kernel Issues
+
+[Helion](https://github.com/pytorch/helion) is a high-level Python DSL for writing GPU kernels. Users write kernels with `@helion.kernel` and `helion.language` (`hl.tile()`, etc.) using standard PyTorch ops, and Helion compiles them to Triton. Helion kernels can also be fused into `torch.compile` graphs via inductor's template fusion hooks.
+
+### Identifying Helion Issues
+
+| Signal | Label |
+|--------|-------|
+| Issue mentions `helion`, `@helion.kernel`, `helion.language`, `hl.tile` | `module: helion` |
+| Error traceback includes `helion/` or `helion.` frames | `module: helion` |
+| Helion kernel produces wrong results (standalone, no torch.compile) | `module: helion` only |
+| Helion kernel fails or miscompiles under `torch.compile` | `module: helion` + `module: inductor` |
+| Inductor template fusion bug triggered by a Helion template | `module: helion` + `module: inductor` |
+
+### Routing
+
+- Helion issues get `oncall: pt2` — Helion is a PT2 component.
+- If the bug is purely in Helion's own compilation (standalone kernel, not under torch.compile), apply `module: helion` without `module: inductor`.
+- If the bug is in how inductor fuses or emits Helion templates, apply both `module: helion` and `module: inductor`.
+
+### Common Mistakes
+
+- **Don't confuse Helion with raw Triton**: If the user is writing Triton kernels directly (using `@triton.jit`, `tl.load`, etc.) without Helion, that's `module: inductor`, not `module: helion`.
+- **Don't apply `module: helion` for general inductor codegen bugs**: Just because inductor generates Triton code doesn't make it a Helion issue. Helion is a specific DSL — look for explicit `helion` imports or mentions.
+
+---
+
+## 8. Functorch + Compile
 
 | Situation | Labels |
 |-----------|--------|
@@ -144,7 +173,7 @@ Check for existing labels before inventing categories:
 
 ---
 
-## 8. High Priority Criteria
+## 9. High Priority Criteria
 
 **This is critical** You should not explicitly add `high priority` - add `triage review` instead
 so that it is reviewed at the next triage meeting by the oncall.
@@ -162,7 +191,7 @@ Mark `triage review` if ANY of these apply:
 
 ---
 
-## 9. Fuzzer Issues
+## 10. Fuzzer Issues
 
 For `topic: fuzzer` issues:
 
@@ -174,7 +203,7 @@ For `topic: fuzzer` issues:
 
 ---
 
-## 10. Quick Label Reference
+## 11. Quick Label Reference
 
 ### Core Components
 - `module: dynamo` - Tracing, bytecode, graph breaks
@@ -183,6 +212,7 @@ For `topic: fuzzer` issues:
 - `module: pt2-dispatcher` - AOT autograd, functionalization, FakeTensor
 - `module: cuda graphs` - CUDA graph capture/replay
 - `module: flex attention` - Flex attention API
+- `module: helion` - Helion DSL kernel authoring, compilation, and inductor fusion
 
 ### Holistic Areas
 - `module: compile ux` - Error messages, APIs, programming model

--- a/.claude/skills/triaging-issues/scripts/validate_labels.py
+++ b/.claude/skills/triaging-issues/scripts/validate_labels.py
@@ -208,12 +208,18 @@ def main():
     except json.JSONDecodeError as e:
         debug_log(f"JSON decode error: {e}")
         print(f"Hook error: Invalid JSON input: {e}", file=sys.stderr)
-        print("Hook was unable to validate labels; stopping triage.", file=sys.stderr)
+        print(
+            "Hook was unable to validate labels; stopping triage.",
+            file=sys.stderr,
+        )
         sys.exit(2)
     except Exception as e:
         debug_log(f"Unexpected error: {type(e).__name__}: {e}")
         print(f"Hook error: {e}", file=sys.stderr)
-        print("Hook was unable to validate labels; stopping triage.", file=sys.stderr)
+        print(
+            "Hook was unable to validate labels; stopping triage.",
+            file=sys.stderr,
+        )
         sys.exit(2)
 
 


### PR DESCRIPTION
See title - minor edit to better label helion issues and avoid unlabeled oncall: pt2 without submodule

## Test 

See https://github.com/pytorch/ciforge/issues/223 and https://github.com/pytorch/ciforge/issues/224