### PR TITLE
[c10d] Support stacked output tensors in Gloo all_gather_into_tensor …

### DIFF
--- a/test/distributed/test_c10d_gloo.py
+++ b/test/distributed/test_c10d_gloo.py
@@ -813,6 +813,31 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
             self.assertTrue(torch.allclose(output, expect))
 
     @requires_gloo()
+    def test_allgather_into_tensor_stacked(self):
+        store = c10d.FileStore(self.file_name, self.world_size)
+        dist.init_process_group(
+            backend="gloo",
+            store=store,
+            rank=self.rank,
+            world_size=self.world_size,
+        )
+        # 1-D input with stacked (world_size, N) output
+        input_1d = torch.arange(12, dtype=torch.float32) + self.rank
+        output_1d = torch.empty(self.world_size, *input_1d.shape, dtype=input_1d.dtype)
+        dist.all_gather_into_tensor(output_1d, input_1d)
+        for i in range(self.world_size):
+            expected = torch.arange(12, dtype=torch.float32) + i
+            self.assertEqual(output_1d[i], expected)
+
+        # 2-D input with stacked (world_size, M, N) output
+        input_2d = torch.arange(12, dtype=torch.float32).reshape(3, 4) + self.rank
+        output_2d = torch.empty(self.world_size, *input_2d.shape, dtype=input_2d.dtype)
+        dist.all_gather_into_tensor(output_2d, input_2d)
+        for i in range(self.world_size):
+            expected = torch.arange(12, dtype=torch.float32).reshape(3, 4) + i
+            self.assertEqual(output_2d[i], expected)
+
+    @requires_gloo()
     def test_reduce_scatter(self):
         store = c10d.FileStore(self.file_name, self.world_size)
         dist.init_process_group(

--- a/torch/csrc/distributed/c10d/ProcessGroupGloo.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupGloo.cpp
@@ -25,6 +25,7 @@
 #include <utility>
 
 #include <ATen/ThreadLocalState.h>
+#include <ATen/TensorUtils.h>
 
 #include <c10/util/StringUtil.h>
 #include <c10/util/intrusive_ptr.h>
@@ -1560,7 +1561,36 @@ c10::intrusive_ptr<Work> ProcessGroupGloo::_allgather_base(
     at::Tensor& output_tensor,
     at::Tensor& input_tensor,
     const AllgatherOptions& opts) {
-  auto tensor_list = at::chunk(output_tensor, this->getSize(), 0);
+  auto worldSize = this->getSize();
+
+  TORCH_CHECK_VALUE(
+      input_tensor.numel() * worldSize == output_tensor.numel(),
+      "ProcessGroupGloo::_allgather_base: output tensor size must be equal "
+      "to world_size times input tensor size");
+
+  // Support both concatenation and stacking output layouts.
+  // The underlying allgather() validates that each output chunk has the same
+  // shape as the input.  A stacked output (world_size, *input.shape) needs to
+  // be viewed as the concatenated form (world_size * input.size(0), ...) so
+  // that chunking along dim 0 produces chunks matching the input shape.
+  // We verify the strides are compatible before calling view() to guarantee a
+  // zero-copy alias rather than silently writing into a temporary copy.
+  auto expected_cat_sizes = input_tensor.sizes().vec();
+  if (!expected_cat_sizes.empty()) {
+    expected_cat_sizes[0] *= worldSize;
+  }
+  auto new_strides = at::detail::computeStride(
+      output_tensor.sizes(), output_tensor.strides(), expected_cat_sizes);
+  TORCH_CHECK(
+      new_strides.has_value(),
+      "ProcessGroupGloo::_allgather_base: output tensor with shape ",
+      output_tensor.sizes(),
+      " is not viewable as ",
+      expected_cat_sizes,
+      ". Output must be contiguous in the concatenation or stacking layout.");
+  auto output_for_chunk = output_tensor.view(expected_cat_sizes);
+
+  auto tensor_list = at::chunk(output_for_chunk, worldSize, 0);
   std::vector<std::vector<at::Tensor>> outputs = {tensor_list};
   std::vector<at::Tensor> inputs = {input_tensor};
   return this->allgather(outputs, inputs, opts);


### PR DESCRIPTION
**Summary**  
Fixes #178798

`ProcessGroupGloo::_allgather_base` chunked the output tensor along dim 0 and required every chunk to match the input shape exactly. For stacked outputs `(world_size, *input.shape)` the chunks retained the leading dimension — e.g. `(1, N)` vs `(N,)` — so the downstream `allgather()` validation rejected them with `"invalid tensor size"`. NCCL never had this restriction because it only validates `numel`.

**Fix**  
View the output tensor as the concatenated form before chunking, so both `(world_size * N, ...)` and `(world_size, N, ...)` layouts are accepted. Uses `view()` (not `reshape()`) to guarantee a zero-copy alias into the caller's buffer — if the output is non-contiguous in a way that prevents a view, we raise an explicit error instead of silently writing into a temporary copy.

Also adds a `numel`-based size check consistent with NCCL's validation.

**Test**  
`test_allgather_into_tensor_stacked` — exercises both 1-D→2-D stacking and 2-D→3-D stacking with multi-rank data verification on the Gloo backend.