### PR TITLE
inductor: fix cpp_wrapper backward failing with CudaKernelParamCache assertion

### DIFF
--- a/test/inductor/test_gpu_cpp_wrapper.py
+++ b/test/inductor/test_gpu_cpp_wrapper.py
@@ -249,6 +249,29 @@ class TestGpuWrapper(InductorTestCase):
             self.assertEqual(p, e)
 
 
+    def test_cpp_wrapper_backward_lazy_compile(self):
+        """Test that options={"cpp_wrapper": True} works with backward pass.
+
+        Backward graphs may be compiled lazily (after compile_fx returns).
+        The cpp_wrapper triton config (store_cubin, autotune_at_compile_time)
+        must still be applied. See https://github.com/pytorch/pytorch/issues/178845
+        """
+        if not RUN_GPU:
+            self.skipTest("GPU not available")
+
+        def fn(x, output_grad):
+            layer_norm = torch.nn.LayerNorm(normalized_shape=4).to(self.device)
+            output = layer_norm(x)
+            output.backward(output_grad)
+            return output
+
+        x = torch.randn(2, 3, 4, device=self.device)
+        output_grad = torch.randn(2, 3, 4, device=self.device)
+
+        opt_fn = torch.compile(options={"cpp_wrapper": True})(fn)
+        result = opt_fn(x, output_grad)
+        self.assertEqual(result.shape, x.shape)
+
 instantiate_parametrized_tests(TestGpuWrapper)
 
 # Helper script for test_lazy_compile_kernel_name_collision_across_modules.

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -806,6 +806,12 @@ def compile_fx_inner(
     # compile_fx return and we may want to use the _LazyGraphModule for compiling
     # the backward graph as well.
     with contextlib.ExitStack() as stack:
+        # When cpp_wrapper is enabled, ensure the required triton config
+        # (store_cubin, autotune_at_compile_time, etc.) is applied. This is
+        # needed because lazy backward compilation may run after the
+        # config.patch context from compile_fx has already exited.
+        if kwargs["cpp_wrapper"]:
+            stack.enter_context(config.patch(get_cpp_wrapper_config()))
         stack.enter_context(torch.utils._python_dispatch._disable_current_modes())
         stack.enter_context(_use_lazy_graph_module(dynamo_config.use_lazy_graph_module))
         stack.enter_context(

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -810,8 +810,11 @@ def compile_fx_inner(
         # (store_cubin, autotune_at_compile_time, etc.) is applied. This is
         # needed because lazy backward compilation may run after the
         # config.patch context from compile_fx has already exited.
+        # Suppress cudagraph skip logging here; compile_fx already logged it.
         if kwargs["cpp_wrapper"]:
-            stack.enter_context(config.patch(get_cpp_wrapper_config()))
+            stack.enter_context(
+                config.patch(get_cpp_wrapper_config(log_cudagraph_skip=False))
+            )
         stack.enter_context(torch.utils._python_dispatch._disable_current_modes())
         stack.enter_context(_use_lazy_graph_module(dynamo_config.use_lazy_graph_module))
         stack.enter_context(
@@ -2214,8 +2217,8 @@ def fw_compiler_freezing(
     return wrapper
 
 
-def get_cpp_wrapper_config() -> dict[str, object]:
-    if config.triton.cudagraphs and config.graph_partition:
+def get_cpp_wrapper_config(log_cudagraph_skip: bool = True) -> dict[str, object]:
+    if log_cudagraph_skip and config.triton.cudagraphs and config.graph_partition:
         log_cudagraph_skip_and_bump_counter(
             format_default_skip_message(
                 "cpp-wrapper does not support graph partition yet"


### PR DESCRIPTION
## Summary

Fixes #178845

`torch.compile(options={"cpp_wrapper": True})` fails with an assertion error when compiling a backward graph:

```
AssertionError: CudaKernelParamCache not populated for
triton_poi_fused_native_layer_norm_native_layer_norm_backward_1
```

## Root Cause

Backward graphs are compiled **lazily** — the first call to `.backward()` triggers compilation, which happens after `compile_fx()` has returned and its `config.patch({"cpp_wrapper": True})` context has exited.

At that point, `compile_fx_backward` checks `config.cpp_wrapper` (which is now `False`) and skips calling `get_cpp_wrapper_config()`. This leaves `triton.store_cubin = False`, so cubins are never saved to `CudaKernelParamCache`. When `DeferredTritonCallWrapper.generate()` later tries to retrieve the kernel params, the cache is empty and the assertion fires.

The reason `torch._inductor.config.cpp_wrapper = True` works is that setting the flag globally means it persists through lazy backward compilation.

## Fix

Apply `get_cpp_wrapper_config()` inside `compile_fx_inner` whenever `kwargs["cpp_wrapper"]` is `True`. This guarantees `store_cubin=True` and `autotune_at_compile_time` are set for every cpp_wrapper compile, regardless of whether it runs eagerly (inside `compile_fx`'s context) or lazily (after it exits). The patch is idempotent in the eager path since:

- In the eager path the outer `config.patch` already sets the same values, so the inner one is a no-op.
- In the lazy path there is no outer patch, so the inner one does the necessary setup.

## Test

Added `test_cpp_wrapper_backward_lazy_compile` to `TestGpuWrapper` in `test/inductor/test_gpu_cpp_wrapper.py`. It exercises `options={"cpp_wrapper": True}` with a backward pass through LayerNorm, directly reproducing the failure mode.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo