### PR TITLE
Fix 5x RAM regression in DataLoader on AArch64 by           disabling mimalloc arena retention    

### DIFF
--- a/c10/core/impl/alloc_cpu.cpp
+++ b/c10/core/impl/alloc_cpu.cpp
@@ -11,6 +11,13 @@
 
 #ifdef USE_MIMALLOC
 #include <mimalloc.h>
+
+namespace {
+const bool mimalloc_defaults_set = [] {
+  mi_option_set_default(mi_option_purge_delay, 0);
+  return true;
+}();
+} // namespace
 #endif
 
 #ifdef __linux__


### PR DESCRIPTION
Resolve #178726. From PyTorch 2.9 to 2.10, #164741 replaced glibc with mimalloc to increase memory allocation speed on AArch64. However, mimalloc retains freed memory in its arena for 10ms for caching purposes. As reported in #178726, this increases RAM usage by 5x and causes performance regressions. 

Since DataLoader reads data sequentially, there is no benefit to arena caching, and setting mi_option_purge_delay to 0 resolves the issue by returning memory to the OS immediately. 

Uses the official mimalloc API (mi_option_set_default) at third_party/mimalloc/include/mimalloc.h:432.  


cc @ptrblck @msaroufim @eqy @jerryzh168 @tinglvv @nWEIdia @snadampal @milpuz01 @aditew01 @nikhil-arm @fadara01 @murste01 @malfet @alceballosa 