### PR TITLE
[fix] Fix that fresh_cache() ignores TORCHINDUCTOR_CACHE_DIR global setting

### DIFF
--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -3444,6 +3444,27 @@ class TestUtils(TestCase):
         self.assertEqual(res1, res2)
         self.assertNotEqual(cache_dir1, cache_dir2)
 
+    @config.patch({"fx_graph_remote_cache": False})
+    def test_fresh_cache_respects_env_var(self):
+        """Test that fresh_cache uses TORCHINDUCTOR_CACHE_DIR when set."""
+        with tempfile.TemporaryDirectory() as user_cache_dir:
+            with mock.patch.dict(
+                os.environ, {"TORCHINDUCTOR_CACHE_DIR": user_cache_dir}
+            ):
+                with fresh_cache(delete=False):
+                    # When TORCHINDUCTOR_CACHE_DIR is pre-set, fresh_cache should
+                    # honor it instead of creating a new temp directory.
+                    actual = normalize_path_separator(
+                        os.environ["TORCHINDUCTOR_CACHE_DIR"]
+                    )
+                    expected = normalize_path_separator(user_cache_dir)
+                    self.assertEqual(
+                        actual,
+                        expected,
+                        f"fresh_cache ignored TORCHINDUCTOR_CACHE_DIR: "
+                        f"expected {expected}, got {actual}",
+                    )
+
     # This combination of settings exposed a bug where we cleared the
     # PyCodeCache disk artifacts while they were still needed:
     @requires_gpu_and_triton

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -1340,7 +1340,9 @@ def fresh_cache(
 
     from torch._inductor.cpp_builder import normalize_path_separator
 
-    inductor_cache_dir = normalize_path_separator(tempfile.mkdtemp(dir=dir))
+    inductor_cache_dir = normalize_path_separator(
+        os.getenv("TORCHINDUCTOR_CACHE_DIR") or tempfile.mkdtemp(dir=dir)
+    )
     try:
         with _set_env("TORCHINDUCTOR_CACHE_DIR", inductor_cache_dir):
             log.debug("Using inductor cache dir %s", inductor_cache_dir)


### PR DESCRIPTION
Fixes #178858

The `fresh_cache()` call ignores the `TORCHINDUCTOR_CACHE_DIR`, so during the tests in helion, we witnessed that even if the `TORCHINDUCTOR_CACHE_DIR` is set to custom folder, we still find that the `/tmp/tmp_xxx` is created, so we got cache miss like the following:

```
test 1:
/tmp/tmpu055r7oy/triton/4SQ645TW7ISAHZEXTEURYAESZMDMDC4BKNH3CAV7DKEGHU6GXLPQ  key: 4SQ645TW...
test 2: (suppose to hit cache, but the cache missed, because tmp folder not the same)
/tmp/tmpoygmne2a/triton/4SQ645TW7ISAHZEXTEURYAESZMDMDC4BKNH3CAV7DKEGHU6GXLPQ  key: 4SQ645TW...
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo