### PR TITLE
[FSDP] enable async H2D prefetching for world_size=1

### DIFF
--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
@@ -205,6 +205,7 @@ class FSDPParamGroup:
         # Optional custom factor for the gradient reduction op (e.g. to divide
         # by a factor other than the world size)
         self.gradient_divide_factor: float | None = None
+        self.reduce_scatter_unused_params: bool = False
         # Whether reduce-scatter and all-reduce should be issued using only
         # summations, potentially with separate pre-/post-scaling.
         self.force_sum_reduction_for_comms: bool = False
@@ -355,17 +356,41 @@ class FSDPParamGroup:
         else:
             world_size = 1
         if world_size == 1:
-            # can't skip due to early return in wait_for_unshard if
-            # no self._all_gather_result
+            copy_in_stream, _ = self.comm_ctx.get_all_gather_streams(
+                async_op, self._training_state
+            )
+            param_all_gather_input_dtypes: list[list[torch.dtype]] = []
+            param_all_gather_input_numels: list[list[int]] = []
+            with record_function(self._with_fqn("FSDP::all_gather")):
+                with self.device_handle.stream(copy_in_stream):
+                    for fsdp_param in self.fsdp_params:
+                        all_gather_inputs = fsdp_param.all_gather_inputs
+                        all_gather_input = all_gather_inputs[0]
+                        param_all_gather_input_dtypes.append(
+                            [inp.dtype for inp in all_gather_inputs]
+                        )
+                        param_all_gather_input_numels.append(
+                            [inp.numel() for inp in all_gather_inputs]
+                        )
+                        fsdp_param.init_all_gather_outputs(
+                            [all_gather_input.numel()],
+                            [all_gather_input.dtype],
+                            world_size,
+                            self.device,
+                            force_recreate=False,
+                        )
+                        tensor = fsdp_param.all_gather_outputs[0]
+                        alloc_storage(tensor)
+                        with torch.autograd._unsafe_preserve_version_counter(tensor):
+                            tensor.copy_(all_gather_input, non_blocking=True)
             self._all_gather_result = AllGatherResult(
                 all_gather_output=self._all_gather_output,
-                all_gather_event=self.device_handle.Event().record(),
+                all_gather_event=copy_in_stream.record_event(),
                 all_gather_work=None,
-                param_all_gather_input_dtypes=[],
-                param_all_gather_input_numels=[],
+                param_all_gather_input_dtypes=param_all_gather_input_dtypes,
+                param_all_gather_input_numels=param_all_gather_input_numels,
                 all_gather_input_split_sizes=[],
             )
-
             return
 
         with record_function(self._with_fqn("FSDP::all_gather")):
@@ -399,30 +424,11 @@ class FSDPParamGroup:
         else:
             world_size = 1
         if world_size == 1:
-            # directly initialize unsharded parameters from sharded parameters
-
-            for fsdp_param in self.fsdp_params:
-                # Use all_gather_inputs which already handles conversion to param_dtype
-                # This is consistent with the world_size > 1 path
-                all_gather_input = fsdp_param.all_gather_inputs[0]
-
-                # Make sure the all_gather_outputs has proper storage size before using it
-                # First ensure we have at least one tensor in all_gather_outputs
-                fsdp_param.init_all_gather_outputs(
-                    [all_gather_input.numel()],
-                    [all_gather_input.dtype],
-                    world_size,
-                    self.device,
-                    force_recreate=False,
+            # H2D was issued on copy_in_stream in unshard(); wait for it here
+            if self._all_gather_result.all_gather_event is not None:
+                self.device_handle.current_stream().wait_event(
+                    self._all_gather_result.all_gather_event
                 )
-
-                tensor = fsdp_param.all_gather_outputs[0]
-                alloc_storage(tensor)
-
-                # find alternative way to check if tensor.is_inference
-                with torch.autograd._unsafe_preserve_version_counter(tensor):
-                    tensor.copy_(all_gather_input)
-
         else:
             with record_function(self._with_fqn("FSDP::all_gather_copy_out")):
                 foreach_all_gather_copy_out(
@@ -438,11 +444,7 @@ class FSDPParamGroup:
         all_gather_copy_out_event = self.device_handle.Event()
         all_gather_copy_out_event.record()
 
-        if (
-            not async_op
-            and self._training_state == TrainingState.FORWARD
-            and world_size > 1
-        ):
+        if not async_op and self._training_state == TrainingState.FORWARD:
             # Defer free to allow for overlap of this copy-out with next
             # all-gather collective
             self.comm_ctx.all_gather_state = AllGatherState(
@@ -533,6 +535,7 @@ class FSDPParamGroup:
             # access the unsharded parameters when their data is present
             fsdp_params_with_grad: list[FSDPParam] = []
             unsharded_grads: list[torch.Tensor] = []
+
             for fsdp_param in self.fsdp_params:
                 if not hasattr(fsdp_param, "_unsharded_param"):
                     continue
@@ -546,6 +549,12 @@ class FSDPParamGroup:
                     fsdp_params_with_grad.append(fsdp_param)
                     unsharded_grads.append(fsdp_param.unsharded_grad_data)
                     fsdp_param.unsharded_param.grad = None
+                elif self.reduce_scatter_unused_params:
+                    fsdp_params_with_grad.append(fsdp_param)
+                    grad_dtype = self._reduce_dtype or fsdp_param.unsharded_param.dtype
+                    unsharded_grads.append(
+                        torch.zeros_like(fsdp_param.unsharded_param, dtype=grad_dtype)
+                    )
             if self.reshard_after_backward:
                 self.reshard()
         # Wait on prior module's RS states (assumes backward fires groups

--- a/torch/distributed/fsdp/_fully_shard/_fully_shard.py
+++ b/torch/distributed/fsdp/_fully_shard/_fully_shard.py
@@ -625,6 +625,26 @@ class FSDPModule:
         for fsdp_param_group in state._fsdp_param_groups:
             fsdp_param_group.force_sum_reduction_for_comms = enable
 
+    def set_reduce_scatter_unused_params(
+        self, reduce_scatter_unused_params: bool, *, recurse: bool = True
+    ) -> None:
+        """
+        Sets whether to include zero gradients for parameters that did not
+        receive a gradient in backward. This is needed when different ranks
+        use different parameters due to conditional control flow (e.g.
+        mixture of experts), causing mismatched reduce-scatter collectives.
+        Analogous to DDP's ``find_unused_parameters``.
+        """
+        self_module = cast(nn.Module, self)
+        modules = list(self_module.modules()) if recurse else [self_module]
+        for module in modules:
+            if isinstance(module, FSDPModule):
+                state = module._get_fsdp_state()
+                for fsdp_param_group in state._fsdp_param_groups:
+                    fsdp_param_group.reduce_scatter_unused_params = (
+                        reduce_scatter_unused_params
+                    )
+
     def set_unshard_in_backward(self, unshard_in_backward: bool) -> None:
         """
         Sets whether the FSDP module's parameters need to be unsharded in


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #178861
* #178730
* #178785
* #178735

For world_size=1 with CPU offload, FSDP's set_modules_to_forward_prefetch()
was a no-op because unshard() created a dummy AllGatherResult and
wait_for_unshard() did the H2D copy synchronously on the default stream.

Move the H2D copy into unshard() on copy_in_stream so it can overlap with
the previous module's compute. wait_for_unshard() now just waits on the
recorded event. Also remove the world_size>1 guard on the deferred-free
path so the pipelined prefetch pattern works for world_size=1.

Also add set_reduce_scatter_unused_params() for conditional parameter usage
across ranks (e.g. mixture models), analogous to DDP's find_unused_parameters.

Fixes https://github.com/pytorch/torchtitan/issues/2749

Authored with Claude.