### PR TITLE
[MPS] Migrate RELU to metal

### DIFF
--- a/aten/src/ATen/native/mps/MetalShaderLibrary.h
+++ b/aten/src/ATen/native/mps/MetalShaderLibrary.h
@@ -141,7 +141,8 @@ class MetalShaderLibrary {
       TensorIteratorBase& iter,
       const std::string& name,
       const std::optional<c10::Scalar> alpha = std::nullopt,
-      const std::optional<c10::ScalarType> scalar_arg_type = std::nullopt);
+      const std::optional<c10::ScalarType> scalar_arg_type = std::nullopt,
+      bool supports_vec4 = false);
   void exec_binary_kernel(
       TensorIteratorBase& iter,
       const std::string& name,

--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -976,11 +976,12 @@ class BundledShaderLibary : public MetalShaderLibrary {
 void MetalShaderLibrary::exec_unary_kernel(TensorIteratorBase& iter,
                                            const std::string& name,
                                            std::optional<c10::Scalar> alpha,
-                                           std::optional<c10::ScalarType> scalar_arg_type) {
+                                           std::optional<c10::ScalarType> scalar_arg_type,
+                                           bool supports_vec4) {
   // Decompose 64-bit tensor into 32-bit ones
   if (!iter.can_use_32bit_indexing()) {
     for (auto&& sub_iter : iter.with_32bit_indexing()) {
-      exec_unary_kernel(sub_iter, name, alpha, scalar_arg_type);
+      exec_unary_kernel(sub_iter, name, alpha, scalar_arg_type, supports_vec4);
     }
     return;
   }
@@ -992,10 +993,12 @@ void MetalShaderLibrary::exec_unary_kernel(TensorIteratorBase& iter,
     return;
   }
   using namespace mps;
+  bool use_vec4 = supports_vec4 && iter.is_contiguous() && !alpha.has_value()
+      && at::isFloatingType(iter.common_dtype());
   const auto alpha_type = scalar_arg_type.has_value() ? scalar_arg_type.value() : iter.common_dtype();
   auto kernel_name = fmt::format("{}_{}_{}_{}{}",
                                  name,
-                                 iter.is_contiguous() ? "dense" : "strided",
+                                 use_vec4 ? "dense_vec4" : (iter.is_contiguous() ? "dense" : "strided"),
                                  scalarToMetalTypeString(outputTensor),
                                  scalarToMetalTypeString(inputTensor),
                                  alpha.has_value() ? fmt::format("_{}", scalarToMetalTypeString(alpha_type)) : "");
@@ -1010,17 +1013,22 @@ void MetalShaderLibrary::exec_unary_kernel(TensorIteratorBase& iter,
 
       [computeEncoder setComputePipelineState:cplState];
       bind_iter_tensors(computeEncoder, iter);
-      if (!iter.is_contiguous()) {
-        mtl_setArgs<2>(computeEncoder,
-                       outputTensor.sizes(),
-                       inputTensor.strides(),
-                       outputTensor.strides(),
-                       inputTensor.ndimension());
+      if (use_vec4) {
+        mtl_setBytes(computeEncoder, length, 2);
+        mtl_dispatch1DJob(computeEncoder, cplState, (length + 3) / 4);
+      } else {
+        if (!iter.is_contiguous()) {
+          mtl_setArgs<2>(computeEncoder,
+                         outputTensor.sizes(),
+                         inputTensor.strides(),
+                         outputTensor.strides(),
+                         inputTensor.ndimension());
+        }
+        if (alpha) {
+          mtl_setBytes(computeEncoder, getMPSScalar(*alpha, alpha_type), iter.is_contiguous() ? 2 : 6);
+        }
+        mtl_dispatch1DJob(computeEncoder, cplState, length);
       }
-      if (alpha) {
-        mtl_setBytes(computeEncoder, getMPSScalar(*alpha, alpha_type), iter.is_contiguous() ? 2 : 6);
-      }
-      mtl_dispatch1DJob(computeEncoder, cplState, length);
 
       getMPSProfiler().endProfileKernel(cplState);
     });

--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -993,8 +993,8 @@ void MetalShaderLibrary::exec_unary_kernel(TensorIteratorBase& iter,
     return;
   }
   using namespace mps;
-  bool use_vec4 = supports_vec4 && iter.is_contiguous() && !alpha.has_value()
-      && at::isFloatingType(iter.common_dtype());
+  bool use_vec4 =
+      supports_vec4 && iter.is_contiguous() && !alpha.has_value() && at::isFloatingType(iter.common_dtype());
   const auto alpha_type = scalar_arg_type.has_value() ? scalar_arg_type.value() : iter.common_dtype();
   auto kernel_name = fmt::format("{}_{}_{}_{}{}",
                                  name,

--- a/aten/src/ATen/native/mps/kernels/ActivationKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/ActivationKernel.metal
@@ -44,6 +44,51 @@ REGISTER_BINARY_ALPHA_OP(shrink_backward, float, float, float);
 REGISTER_BINARY_ALPHA_OP(shrink_backward, half, half, half);
 REGISTER_BINARY_ALPHA_OP(shrink_backward, bfloat, bfloat, bfloat);
 
+struct relu_functor {
+  template <typename T>
+  inline T operator()(const T x) {
+    return x > T(0) ? x : T(0);
+  }
+};
+
+REGISTER_UNARY_OP(relu, float, float);
+REGISTER_UNARY_OP(relu, half, half);
+REGISTER_UNARY_OP(relu, bfloat, bfloat);
+
+template <typename T>
+kernel void relu_vec4(
+    device T* output [[buffer(0)]],
+    constant T* input [[buffer(1)]],
+    constant uint& numel [[buffer(2)]],
+    uint index [[thread_position_in_grid]]) {
+  uint base = index * 4;
+  if (base + 4 <= numel) {
+    vec<T, 4> val = *(constant vec<T, 4>*)(input + base);
+    T zero = T(0);
+    *(device vec<T, 4>*)(output + base) = {
+        val.x > zero ? val.x : zero,
+        val.y > zero ? val.y : zero,
+        val.z > zero ? val.z : zero,
+        val.w > zero ? val.w : zero};
+  } else {
+    for (uint i = base; i < numel; i++) {
+      T x = input[i];
+      output[i] = x > T(0) ? x : T(0);
+    }
+  }
+}
+
+#define REGISTER_RELU_VEC4(DTYPE)                                           \
+  template [[host_name("relu_vec4_" #DTYPE)]] kernel void relu_vec4<DTYPE>( \
+      device DTYPE * output [[buffer(0)]],                                  \
+      constant DTYPE * input [[buffer(1)]],                                 \
+      constant uint & numel [[buffer(2)]],                                  \
+      uint index [[thread_position_in_grid]]);
+
+REGISTER_RELU_VEC4(float);
+REGISTER_RELU_VEC4(half);
+REGISTER_RELU_VEC4(bfloat);
+
 struct hardsigmoid_functor {
   template <typename T>
   inline T operator()(const T x) {

--- a/aten/src/ATen/native/mps/kernels/ActivationKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/ActivationKernel.metal
@@ -61,39 +61,9 @@ REGISTER_UNARY_OP(relu, char, char);
 REGISTER_UNARY_OP(relu, uchar, uchar);
 REGISTER_UNARY_OP(relu, bool, bool);
 
-template <typename T>
-kernel void relu_vec4(
-    device T* output [[buffer(0)]],
-    constant T* input [[buffer(1)]],
-    constant uint& numel [[buffer(2)]],
-    uint index [[thread_position_in_grid]]) {
-  uint base = index * 4;
-  if (base + 4 <= numel) {
-    vec<T, 4> val = *(constant vec<T, 4>*)(input + base);
-    constexpr T zero = T(0);
-    *(device vec<T, 4>*)(output + base) = {
-        val.x > zero ? val.x : zero,
-        val.y > zero ? val.y : zero,
-        val.z > zero ? val.z : zero,
-        val.w > zero ? val.w : zero};
-  } else {
-    for (uint i = base; i < numel; i++) {
-      T x = input[i];
-      output[i] = x > T(0) ? x : T(0);
-    }
-  }
-}
-
-#define REGISTER_RELU_VEC4(DTYPE)                                           \
-  template [[host_name("relu_vec4_" #DTYPE)]] kernel void relu_vec4<DTYPE>( \
-      device DTYPE * output [[buffer(0)]],                                  \
-      constant DTYPE * input [[buffer(1)]],                                 \
-      constant uint & numel [[buffer(2)]],                                  \
-      uint index [[thread_position_in_grid]]);
-
-REGISTER_RELU_VEC4(float);
-REGISTER_RELU_VEC4(half);
-REGISTER_RELU_VEC4(bfloat);
+REGISTER_UNARY_VEC4_OP(relu, float, float);
+REGISTER_UNARY_VEC4_OP(relu, half, half);
+REGISTER_UNARY_VEC4_OP(relu, bfloat, bfloat);
 
 struct hardsigmoid_functor {
   template <typename T>

--- a/aten/src/ATen/native/mps/kernels/ActivationKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/ActivationKernel.metal
@@ -70,7 +70,7 @@ kernel void relu_vec4(
   uint base = index * 4;
   if (base + 4 <= numel) {
     vec<T, 4> val = *(constant vec<T, 4>*)(input + base);
-    T zero = T(0);
+    constexpr T zero = T(0);
     *(device vec<T, 4>*)(output + base) = {
         val.x > zero ? val.x : zero,
         val.y > zero ? val.y : zero,

--- a/aten/src/ATen/native/mps/kernels/ActivationKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/ActivationKernel.metal
@@ -59,6 +59,7 @@ REGISTER_UNARY_OP(relu, int, int);
 REGISTER_UNARY_OP(relu, short, short);
 REGISTER_UNARY_OP(relu, char, char);
 REGISTER_UNARY_OP(relu, uchar, uchar);
+REGISTER_UNARY_OP(relu, bool, bool);
 
 template <typename T>
 kernel void relu_vec4(

--- a/aten/src/ATen/native/mps/kernels/ActivationKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/ActivationKernel.metal
@@ -54,6 +54,11 @@ struct relu_functor {
 REGISTER_UNARY_OP(relu, float, float);
 REGISTER_UNARY_OP(relu, half, half);
 REGISTER_UNARY_OP(relu, bfloat, bfloat);
+REGISTER_UNARY_OP(relu, long, long);
+REGISTER_UNARY_OP(relu, int, int);
+REGISTER_UNARY_OP(relu, short, short);
+REGISTER_UNARY_OP(relu, char, char);
+REGISTER_UNARY_OP(relu, uchar, uchar);
 
 template <typename T>
 kernel void relu_vec4(

--- a/aten/src/ATen/native/mps/operations/Activation.mm
+++ b/aten/src/ATen/native/mps/operations/Activation.mm
@@ -1,5 +1,7 @@
 //  Copyright © 2022 Apple Inc.
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
+#include <ATen/TensorIterator.h>
+#include <ATen/mps/MPSProfiler.h>
 #include <ATen/native/Activation.h>
 #include <ATen/native/mps/OperationUtils.h>
 
@@ -35,84 +37,53 @@ using namespace at::mps;
 
 namespace at::native {
 
+#ifndef PYTORCH_JIT_COMPILE_SHADERS
+static auto& lib = mps::MetalShaderLibrary::getBundledLibrary();
+#else
+#include <ATen/native/mps/ActivationKernel_metallib.h>
+#endif
+
+static void relu_mps_contiguous(const Tensor& output, const Tensor& input) {
+  auto key = "relu_vec4_" + mps::scalarToMetalTypeString(input);
+  auto pso = lib.getPipelineStateForFunc(key);
+  auto mpsStream = getCurrentMPSStream();
+  auto numel = static_cast<uint32_t>(input.numel());
+
+  dispatch_sync(mpsStream->queue(), ^() {
+    @autoreleasepool {
+      auto computeEncoder = mpsStream->commandEncoder();
+      [computeEncoder setComputePipelineState:pso];
+      mps::mtl_setBuffer(computeEncoder, output, 0);
+      mps::mtl_setBuffer(computeEncoder, input, 1);
+      [computeEncoder setBytes:&numel length:sizeof(numel) atIndex:2];
+      mps::mtl_dispatch1DJob(computeEncoder, pso, (numel + 3) / 4);
+    }
+  });
+}
+
 Tensor relu_mps(const Tensor& self) {
-  using namespace mps;
-  using CachedGraph = MPSUnaryCachedGraph;
-
-  bool executeGatherOp =
-      !(self.is_contiguous(MemoryFormat::Contiguous) || self.is_contiguous(MemoryFormat::ChannelsLast) ||
-        self.is_contiguous(MemoryFormat::ChannelsLast3d));
-  Tensor output = at::empty_like(self, executeGatherOp ? MemoryFormat::Contiguous : MemoryFormat::Preserve);
-
-  if (output.numel() == 0) {
+  auto output = at::empty_like(self);
+  if (output.numel() == 0)
+    return output;
+  if (self.is_non_overlapping_and_dense()) {
+    relu_mps_contiguous(output, self);
     return output;
   }
-
-  MPSStream* stream = getCurrentMPSStream();
-  @autoreleasepool {
-    std::string key = "relu" + getTensorsStringKey({self});
-    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
-      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
-      // passing selector of reLUWithTensor on the mpsGraph object
-      MPSGraphTensor* outputTensor = [mpsGraph reLUWithTensor:inputTensor name:nil];
-
-      newCachedGraph->inputTensor_ = inputTensor;
-      newCachedGraph->outputTensor_ = outputTensor;
-    });
-
-    Placeholder selfPlaceholder = Placeholder(cachedGraph->inputTensor_, self, nil, executeGatherOp);
-    Placeholder outputPlaceholder = Placeholder(cachedGraph->outputTensor_, output, nil, false);
-
-    // Create dictionary of inputs and outputs
-    auto feeds = dictionaryFromPlaceholders(selfPlaceholder);
-    runMPSGraph(stream, cachedGraph->graph(), feeds, outputPlaceholder);
-  }
-
+  auto iter = at::TensorIteratorConfig().add_output(output).add_input(self).build();
+  lib.exec_unary_kernel(iter, "relu");
   return output;
 }
 
 Tensor& relu_mps_(Tensor& self) {
-  using namespace mps;
-  using CachedGraph = MPSUnaryCachedGraph;
-
-  if (self.numel() == 0) {
+  if (self.numel() == 0)
+    return self;
+  if (self.is_non_overlapping_and_dense()) {
+    relu_mps_contiguous(self, self);
     return self;
   }
-  // Inplace relu
-  Tensor& output = self;
-  bool executeGatherOp =
-      !(self.is_contiguous(MemoryFormat::Contiguous) || self.is_contiguous(MemoryFormat::ChannelsLast) ||
-        self.is_contiguous(MemoryFormat::ChannelsLast3d));
-  Tensor out;
-  if (executeGatherOp) {
-    out = at::empty_like(self, MemoryFormat::Contiguous);
-  }
-
-  MPSStream* stream = getCurrentMPSStream();
-
-  @autoreleasepool {
-    std::string key = "relu_" + getTensorsStringKey({self});
-    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
-      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
-      // passing selector of reLUWithTensor on the mpsGraph object
-      MPSGraphTensor* outputTensor = [mpsGraph reLUWithTensor:inputTensor name:nil];
-
-      newCachedGraph->inputTensor_ = inputTensor;
-      newCachedGraph->outputTensor_ = outputTensor;
-    });
-
-    Placeholder selfPlaceholder = Placeholder(cachedGraph->inputTensor_, self, nil, executeGatherOp);
-    Placeholder outputPlaceholder = Placeholder(cachedGraph->outputTensor_, executeGatherOp ? out : output, nil, false);
-
-    // Create dictionary of inputs and outputs
-    auto feeds = dictionaryFromPlaceholders(selfPlaceholder);
-    runMPSGraph(stream, cachedGraph->graph(), feeds, outputPlaceholder);
-    if (executeGatherOp) {
-      output.copy_(out);
-    }
-  }
-
-  return output;
+  auto iter = at::TensorIteratorConfig().add_output(self).add_input(self).set_check_mem_overlap(false).build();
+  lib.exec_unary_kernel(iter, "relu");
+  return self;
 }
 
 TORCH_IMPL_FUNC(log_softmax_mps_out)

--- a/aten/src/ATen/native/mps/operations/Activation.mm
+++ b/aten/src/ATen/native/mps/operations/Activation.mm
@@ -1,7 +1,5 @@
 //  Copyright © 2022 Apple Inc.
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
-#include <ATen/TensorIterator.h>
-#include <ATen/mps/MPSProfiler.h>
 #include <ATen/native/Activation.h>
 #include <ATen/native/mps/OperationUtils.h>
 
@@ -36,55 +34,6 @@
 using namespace at::mps;
 
 namespace at::native {
-
-#ifndef PYTORCH_JIT_COMPILE_SHADERS
-static auto& lib = mps::MetalShaderLibrary::getBundledLibrary();
-#else
-#include <ATen/native/mps/ActivationKernel_metallib.h>
-#endif
-
-static void relu_mps_contiguous(const Tensor& output, const Tensor& input) {
-  auto key = "relu_vec4_" + mps::scalarToMetalTypeString(input);
-  auto pso = lib.getPipelineStateForFunc(key);
-  auto mpsStream = getCurrentMPSStream();
-  auto numel = static_cast<uint32_t>(input.numel());
-
-  dispatch_sync(mpsStream->queue(), ^() {
-    @autoreleasepool {
-      auto computeEncoder = mpsStream->commandEncoder();
-      [computeEncoder setComputePipelineState:pso];
-      mps::mtl_setBuffer(computeEncoder, output, 0);
-      mps::mtl_setBuffer(computeEncoder, input, 1);
-      [computeEncoder setBytes:&numel length:sizeof(numel) atIndex:2];
-      mps::mtl_dispatch1DJob(computeEncoder, pso, (numel + 3) / 4);
-    }
-  });
-}
-
-Tensor relu_mps(const Tensor& self) {
-  auto output = at::empty_like(self);
-  if (output.numel() == 0)
-    return output;
-  if (self.is_non_overlapping_and_dense()) {
-    relu_mps_contiguous(output, self);
-    return output;
-  }
-  auto iter = at::TensorIteratorConfig().add_output(output).add_input(self).build();
-  lib.exec_unary_kernel(iter, "relu");
-  return output;
-}
-
-Tensor& relu_mps_(Tensor& self) {
-  if (self.numel() == 0)
-    return self;
-  if (self.is_non_overlapping_and_dense()) {
-    relu_mps_contiguous(self, self);
-    return self;
-  }
-  auto iter = at::TensorIteratorConfig().add_output(self).add_input(self).set_check_mem_overlap(false).build();
-  lib.exec_unary_kernel(iter, "relu");
-  return self;
-}
 
 TORCH_IMPL_FUNC(log_softmax_mps_out)
 (const Tensor& self, const int64_t dim, const bool half_to_float, const Tensor& out) {

--- a/aten/src/ATen/native/mps/operations/ActivationKernel.mm
+++ b/aten/src/ATen/native/mps/operations/ActivationKernel.mm
@@ -22,7 +22,7 @@ static auto& lib = mps::MetalShaderLibrary::getBundledLibrary();
 #endif
 
 static void relu_mps_contiguous(const Tensor& output, const Tensor& input) {
-  auto key = "relu_vec4_" + mps::scalarToMetalTypeString(input);
+  auto key = fmt::format("relu_vec4_{}", mps::scalarToMetalTypeString(input));
   auto pso = lib.getPipelineStateForFunc(key);
   auto mpsStream = at::mps::getCurrentMPSStream();
   auto numel = static_cast<uint32_t>(input.numel());

--- a/aten/src/ATen/native/mps/operations/ActivationKernel.mm
+++ b/aten/src/ATen/native/mps/operations/ActivationKernel.mm
@@ -39,11 +39,17 @@ static void relu_mps_contiguous(const Tensor& output, const Tensor& input) {
   });
 }
 
+static bool relu_use_vec4(const Tensor& t) {
+  return at::isFloatingType(t.scalar_type()) && t.is_non_overlapping_and_dense();
+}
+
 Tensor relu_mps(const Tensor& self) {
+  TORCH_CHECK(!self.is_complex(), "relu is not supported for complex types");
+  TORCH_CHECK(self.scalar_type() != kBool, "relu is not supported for bool");
   auto output = at::empty_like(self);
   if (output.numel() == 0)
     return output;
-  if (self.is_non_overlapping_and_dense()) {
+  if (relu_use_vec4(self)) {
     relu_mps_contiguous(output, self);
     return output;
   }
@@ -53,9 +59,11 @@ Tensor relu_mps(const Tensor& self) {
 }
 
 Tensor& relu_mps_(Tensor& self) {
+  TORCH_CHECK(!self.is_complex(), "relu is not supported for complex types");
+  TORCH_CHECK(self.scalar_type() != kBool, "relu is not supported for bool");
   if (self.numel() == 0)
     return self;
-  if (self.is_non_overlapping_and_dense()) {
+  if (relu_use_vec4(self)) {
     relu_mps_contiguous(self, self);
     return self;
   }

--- a/aten/src/ATen/native/mps/operations/ActivationKernel.mm
+++ b/aten/src/ATen/native/mps/operations/ActivationKernel.mm
@@ -45,7 +45,6 @@ static bool relu_use_vec4(const Tensor& t) {
 
 Tensor relu_mps(const Tensor& self) {
   TORCH_CHECK(!self.is_complex(), "relu is not supported for complex types");
-  TORCH_CHECK(self.scalar_type() != kBool, "relu is not supported for bool");
   auto output = at::empty_like(self);
   if (output.numel() == 0)
     return output;
@@ -60,7 +59,6 @@ Tensor relu_mps(const Tensor& self) {
 
 Tensor& relu_mps_(Tensor& self) {
   TORCH_CHECK(!self.is_complex(), "relu is not supported for complex types");
-  TORCH_CHECK(self.scalar_type() != kBool, "relu is not supported for bool");
   if (self.numel() == 0)
     return self;
   if (relu_use_vec4(self)) {

--- a/aten/src/ATen/native/mps/operations/ActivationKernel.mm
+++ b/aten/src/ATen/native/mps/operations/ActivationKernel.mm
@@ -4,6 +4,12 @@
 #include <ATen/mps/MPSProfiler.h>
 #include <ATen/native/Activation.h>
 #include <ATen/native/mps/OperationUtils.h>
+
+#ifndef AT_PER_OPERATOR_HEADERS
+#include <ATen/NativeFunctions.h>
+#else
+#include <ATen/ops/relu_native.h>
+#endif
 #include <ATen/native/mps/kernels/Activation.h>
 #include <fmt/format.h>
 
@@ -14,6 +20,49 @@ static auto& lib = mps::MetalShaderLibrary::getBundledLibrary();
 #else
 #include <ATen/native/mps/ActivationKernel_metallib.h>
 #endif
+
+static void relu_mps_contiguous(const Tensor& output, const Tensor& input) {
+  auto key = "relu_vec4_" + mps::scalarToMetalTypeString(input);
+  auto pso = lib.getPipelineStateForFunc(key);
+  auto mpsStream = at::mps::getCurrentMPSStream();
+  auto numel = static_cast<uint32_t>(input.numel());
+
+  dispatch_sync(mpsStream->queue(), ^() {
+    @autoreleasepool {
+      auto computeEncoder = mpsStream->commandEncoder();
+      [computeEncoder setComputePipelineState:pso];
+      mps::mtl_setBuffer(computeEncoder, output, 0);
+      mps::mtl_setBuffer(computeEncoder, input, 1);
+      [computeEncoder setBytes:&numel length:sizeof(numel) atIndex:2];
+      mps::mtl_dispatch1DJob(computeEncoder, pso, (numel + 3) / 4);
+    }
+  });
+}
+
+Tensor relu_mps(const Tensor& self) {
+  auto output = at::empty_like(self);
+  if (output.numel() == 0)
+    return output;
+  if (self.is_non_overlapping_and_dense()) {
+    relu_mps_contiguous(output, self);
+    return output;
+  }
+  auto iter = at::TensorIteratorConfig().add_output(output).add_input(self).build();
+  lib.exec_unary_kernel(iter, "relu");
+  return output;
+}
+
+Tensor& relu_mps_(Tensor& self) {
+  if (self.numel() == 0)
+    return self;
+  if (self.is_non_overlapping_and_dense()) {
+    relu_mps_contiguous(self, self);
+    return self;
+  }
+  auto iter = at::TensorIteratorConfig().add_output(self).add_input(self).set_check_mem_overlap(false).build();
+  lib.exec_unary_kernel(iter, "relu");
+  return self;
+}
 
 static void hardshrink_kernel(TensorIteratorBase& iter, const Scalar& lambda = 0.5) {
   lib.exec_unary_kernel(iter, "hardshrink", lambda);

--- a/aten/src/ATen/native/mps/operations/ActivationKernel.mm
+++ b/aten/src/ATen/native/mps/operations/ActivationKernel.mm
@@ -21,39 +21,13 @@ static auto& lib = mps::MetalShaderLibrary::getBundledLibrary();
 #include <ATen/native/mps/ActivationKernel_metallib.h>
 #endif
 
-static void relu_mps_contiguous(const Tensor& output, const Tensor& input) {
-  auto key = fmt::format("relu_vec4_{}", mps::scalarToMetalTypeString(input));
-  auto pso = lib.getPipelineStateForFunc(key);
-  auto mpsStream = at::mps::getCurrentMPSStream();
-  auto numel = static_cast<uint32_t>(input.numel());
-
-  dispatch_sync(mpsStream->queue(), ^() {
-    @autoreleasepool {
-      auto computeEncoder = mpsStream->commandEncoder();
-      [computeEncoder setComputePipelineState:pso];
-      mps::mtl_setBuffer(computeEncoder, output, 0);
-      mps::mtl_setBuffer(computeEncoder, input, 1);
-      [computeEncoder setBytes:&numel length:sizeof(numel) atIndex:2];
-      mps::mtl_dispatch1DJob(computeEncoder, pso, (numel + 3) / 4);
-    }
-  });
-}
-
-static bool relu_use_vec4(const Tensor& t) {
-  return at::isFloatingType(t.scalar_type()) && t.is_non_overlapping_and_dense();
-}
-
 Tensor relu_mps(const Tensor& self) {
   TORCH_CHECK(!self.is_complex(), "relu is not supported for complex types");
   auto output = at::empty_like(self);
   if (output.numel() == 0)
     return output;
-  if (relu_use_vec4(self)) {
-    relu_mps_contiguous(output, self);
-    return output;
-  }
   auto iter = at::TensorIteratorConfig().add_output(output).add_input(self).build();
-  lib.exec_unary_kernel(iter, "relu");
+  lib.exec_unary_kernel(iter, "relu", /*alpha=*/std::nullopt, /*scalar_arg_type=*/std::nullopt, /*supports_vec4=*/true);
   return output;
 }
 
@@ -61,12 +35,8 @@ Tensor& relu_mps_(Tensor& self) {
   TORCH_CHECK(!self.is_complex(), "relu is not supported for complex types");
   if (self.numel() == 0)
     return self;
-  if (relu_use_vec4(self)) {
-    relu_mps_contiguous(self, self);
-    return self;
-  }
   auto iter = at::TensorIteratorConfig().add_output(self).add_input(self).set_check_mem_overlap(false).build();
-  lib.exec_unary_kernel(iter, "relu");
+  lib.exec_unary_kernel(iter, "relu", /*alpha=*/std::nullopt, /*scalar_arg_type=*/std::nullopt, /*supports_vec4=*/true);
   return self;
 }
 

--- a/c10/metal/indexing.h
+++ b/c10/metal/indexing.h
@@ -54,6 +54,26 @@ kernel void unary_dense(
 }
 
 template <typename T, typename F>
+kernel void unary_dense_vec4(
+    device result_of<F, T>* output [[buffer(0)]],
+    constant T* input [[buffer(1)]],
+    constant uint& numel [[buffer(2)]],
+    uint index [[thread_position_in_grid]]) {
+  F f;
+  uint base = index * 4;
+  if (base + 4 <= numel) {
+    using ::metal::vec;
+    vec<T, 4> val = *(constant vec<T, 4>*)(input + base);
+    *(device vec<result_of<F, T>, 4>*)(output + base) = {
+      f(val.x), f(val.y), f(val.z), f(val.w)
+    };
+  } else {
+    for (uint i = base; i < numel; i++)
+      output[i] = f(input[i]);
+  }
+}
+
+template <typename T, typename F>
 kernel void unary_strided(
     device result_of<F, T>* output [[buffer(0)]],
     constant T* input [[buffer(1)]],
@@ -88,6 +108,18 @@ kernel void unary_strided(
           constant long* input_strides,                                        \
           constant long* output_strides,                                       \
           constant uint& ndim,                                                 \
+          uint index)
+
+#define REGISTER_UNARY_VEC4_OP(NAME, DTYPE0, DTYPE1)                           \
+  static_assert(                                                               \
+      ::metal::                                                                \
+          is_same_v<DTYPE1, ::c10::metal::result_of<NAME##_functor, DTYPE0>>,  \
+      "Output dtype mismatch for unary op " #NAME " and input " #DTYPE0);      \
+  template [[host_name(#NAME "_dense_vec4_" #DTYPE1 "_" #DTYPE0)]]             \
+      kernel void ::c10::metal::unary_dense_vec4<DTYPE0, NAME##_functor>(      \
+          device ::c10::metal::result_of<NAME##_functor, DTYPE0> * output,     \
+          constant DTYPE0 * input,                                             \
+          constant uint & numel,                                               \
           uint index)
 
 #define DEFINE_UNARY_FLOATING_FUNCTOR(NAME)                                     \

--- a/c10/metal/indexing.h
+++ b/c10/metal/indexing.h
@@ -65,8 +65,7 @@ kernel void unary_dense_vec4(
     using ::metal::vec;
     vec<T, 4> val = *(constant vec<T, 4>*)(input + base);
     *(device vec<result_of<F, T>, 4>*)(output + base) = {
-      f(val.x), f(val.y), f(val.z), f(val.w)
-    };
+        f(val.x), f(val.y), f(val.z), f(val.w)};
   } else {
     for (uint i = base; i < numel; i++)
       output[i] = f(input[i]);
@@ -110,17 +109,17 @@ kernel void unary_strided(
           constant uint& ndim,                                                 \
           uint index)
 
-#define REGISTER_UNARY_VEC4_OP(NAME, DTYPE0, DTYPE1)                           \
-  static_assert(                                                               \
-      ::metal::                                                                \
-          is_same_v<DTYPE1, ::c10::metal::result_of<NAME##_functor, DTYPE0>>,  \
-      "Output dtype mismatch for unary op " #NAME " and input " #DTYPE0);      \
-  template [[host_name(#NAME "_dense_vec4_" #DTYPE1 "_" #DTYPE0)]]             \
-      kernel void ::c10::metal::unary_dense_vec4<DTYPE0, NAME##_functor>(      \
-          device ::c10::metal::result_of<NAME##_functor, DTYPE0> * output,     \
-          constant DTYPE0 * input,                                             \
-          constant uint & numel,                                               \
-          uint index)
+#define REGISTER_UNARY_VEC4_OP(NAME, DTYPE0, DTYPE1)                          \
+  static_assert(                                                              \
+      ::metal::                                                               \
+          is_same_v<DTYPE1, ::c10::metal::result_of<NAME##_functor, DTYPE0>>, \
+      "Output dtype mismatch for unary op " #NAME " and input " #DTYPE0);     \
+  template [[host_name(#NAME "_dense_vec4_" #DTYPE1 "_" #DTYPE0)]]            \
+  kernel void ::c10::metal::unary_dense_vec4<DTYPE0, NAME##_functor>(         \
+      device ::c10::metal::result_of<NAME##_functor, DTYPE0> * output,        \
+      constant DTYPE0 * input,                                                \
+      constant uint & numel,                                                  \
+      uint index)
 
 #define DEFINE_UNARY_FLOATING_FUNCTOR(NAME)                                     \
   struct NAME##_functor {                                                       \


### PR DESCRIPTION
Migrate RELU to metal 
<img width="3283" height="2258" alt="relu_bench_relu_" src="https://github.com/user-attachments/assets/4d068c9d-7a12-46a5-a408-89f62a0d6f56" />
<img width="3283" height="2258" alt="relu_bench_relu" src="https://github.com/user-attachments/assets/ee23412e-25b8-4a59-8988-cdd2d900e8f6" />

benchmark script:
```
import csv
import sys
import time

import torch


def benchmark_fn(fn, warmup=50, repeats=1000):
    for _ in range(warmup):
        fn()
    torch.mps.synchronize()

    start = time.perf_counter()
    for _ in range(repeats):
        fn()
    torch.mps.synchronize()
    return (time.perf_counter() - start) / repeats * 1e6


def main():
    if len(sys.argv) != 2:
        print(f"Usage: python {sys.argv[0]} <output.csv>")
        sys.exit(1)

    output_file = sys.argv[1]
    device = "mps"

    shapes = [
        (64,),
        (256,),
        (1024,),
        (4096,),
        (65536,),
        (1 << 20,),
        (128, 128),
        (256, 256),
        (512, 512),
        (1024, 1024),
        (4096, 4096),
        (8, 3, 224, 224),
        (32, 3, 224, 224),
        (16, 64, 56, 56),
    ]

    dtypes = [torch.float32, torch.float16, torch.bfloat16]

    results = []

    for shape in shapes:
        for dtype in dtypes:
            # contiguous
            x = torch.randn(shape, device=device, dtype=dtype)
            t = benchmark_fn(lambda x=x: torch.relu(x))
            numel = x.numel()
            results.append({
                "shape": str(shape), "dtype": str(dtype), "layout": "contiguous",
                "numel": numel, "variant": "relu", "time_us": round(t, 2),
            })
            print(f"  relu  {str(shape):>25s}  {str(dtype):>15s}  contiguous   {t:8.2f} us")

            # contiguous inplace
            x = torch.randn(shape, device=device, dtype=dtype)
            t = benchmark_fn(lambda x=x: x.relu_())
            results.append({
                "shape": str(shape), "dtype": str(dtype), "layout": "contiguous",
                "numel": numel, "variant": "relu_", "time_us": round(t, 2),
            })
            print(f"  relu_ {str(shape):>25s}  {str(dtype):>15s}  contiguous   {t:8.2f} us")

            # transposed (non-contiguous)
            if len(shape) >= 2:
                x = torch.randn(shape, device=device, dtype=dtype).transpose(-1, -2).contiguous().transpose(-1, -2)
                t = benchmark_fn(lambda x=x: torch.relu(x))
                results.append({
                    "shape": str(shape), "dtype": str(dtype), "layout": "transposed",
                    "numel": numel, "variant": "relu", "time_us": round(t, 2),
                })
                print(f"  relu  {str(shape):>25s}  {str(dtype):>15s}  transposed   {t:8.2f} us")

                # inplace transposed
                x = torch.randn(shape, device=device, dtype=dtype).transpose(-1, -2).contiguous().transpose(-1, -2)
                t = benchmark_fn(lambda x=x: x.relu_())
                results.append({
                    "shape": str(shape), "dtype": str(dtype), "layout": "transposed",
                    "numel": numel, "variant": "relu_", "time_us": round(t, 2),
                })
                print(f"  relu_ {str(shape):>25s}  {str(dtype):>15s}  transposed   {t:8.2f} us")

            # channels_last (4D only)
            if len(shape) == 4:
                x = torch.randn(shape, device=device, dtype=dtype).to(memory_format=torch.channels_last)
                t = benchmark_fn(lambda x=x: torch.relu(x))
                results.append({
                    "shape": str(shape), "dtype": str(dtype), "layout": "channels_last",
                    "numel": numel, "variant": "relu", "time_us": round(t, 2),
                })
                print(f"  relu  {str(shape):>25s}  {str(dtype):>15s}  channels_last {t:8.2f} us")

                x = torch.randn(shape, device=device, dtype=dtype).to(memory_format=torch.channels_last)
                t = benchmark_fn(lambda x=x: x.relu_())
                results.append({
                    "shape": str(shape), "dtype": str(dtype), "layout": "channels_last",
                    "numel": numel, "variant": "relu_", "time_us": round(t, 2),
                })
                print(f"  relu_ {str(shape):>25s}  {str(dtype):>15s}  channels_last {t:8.2f} us")

    with open(output_file, "w", newline="") as f:
        writer = csv.DictWriter(
            f, fieldnames=["shape", "dtype", "layout", "numel", "variant", "time_us"]
        )
        writer.writeheader()
        writer.writerows(results)

    print(f"\nResults saved to {output_file}")


if __name__ == "__main__":
    main()

```


## Reason for vec4 kernels
Vec4 kernels are needed for certain cases. i.e. see performance comparison on various numel and different dtypes below, comparing vec4 to generic(i.e. one thread per element approach)

<img width="1784" height="1775" alt="image" src="https://github.com/user-attachments/assets/3eead0d6-02e7-4f5c-bc4c-982668e631f4" />
