### PR TITLE
[leaf_func]Add print multi tensors example with multi_grad_hook

### DIFF
--- a/test/functorch/test_leaf_function.py
+++ b/test/functorch/test_leaf_function.py
@@ -2764,6 +2764,31 @@ class TestLeafFunctionRegisterHook(TestCase):
         out.sum().backward()
         self.assertEqual(hook_count[0], 1)
 
+    def test_register_multi_grad_hook_alias(self):
+        """register_multi_grad_hook is an alias for register_hook."""
+        hook_calls = []
+
+        @leaf_function
+        def my_fn(x, y):
+            return (x * 2 + y * 3,)
+
+        @my_fn.register_fake
+        def my_fn_fake(x, y):
+            return (torch.empty_like(x),)
+
+        @my_fn.register_multi_grad_hook
+        def my_fn_hook(x_grad, y_grad):
+            hook_calls.append((x_grad.clone(), y_grad.clone()))
+
+        x = torch.randn(3, requires_grad=True)
+        y = torch.randn(3, requires_grad=True)
+        out = my_fn(x, y)[0]
+        out.sum().backward()
+
+        self.assertEqual(len(hook_calls), 1)
+        self.assertEqual(hook_calls[0][0], torch.full((3,), 2.0))
+        self.assertEqual(hook_calls[0][1], torch.full((3,), 3.0))
+
 
 if __name__ == "__main__":
     run_tests()

--- a/torch/_dynamo/decorators.py
+++ b/torch/_dynamo/decorators.py
@@ -514,15 +514,15 @@ def leaf_function(
         To validate that your fake implementation matches the real function's outputs, set
         ``torch._dynamo.config.leaf_function_validate_outputs = True``.
 
-        **register_hook (optional)**:
-        You can register a backward hook via ``@fn.register_hook`` to run code when
-        gradients have been computed for all requires_grad tensor inputs during backward.
-        The hook fires exactly once per backward pass. The hook function has the same
-        signature as the leaf function; each requires_grad tensor argument receives the
-        corresponding gradient instead of the original tensor. Non-tensor arguments and
-        tensors without requires_grad are passed through unchanged. The hook must return
-        ``None``. The hook is called as a leaf function itself, so it is also opaque to
-        the compiler.
+        **register_hook / register_multi_grad_hook (optional)**:
+        You can register a backward hook via ``@fn.register_hook`` (or equivalently
+        ``@fn.register_multi_grad_hook``) to run code when gradients have been computed
+        for all requires_grad tensor inputs during backward. The hook fires exactly once
+        per backward pass. The hook function has the same signature as the leaf function;
+        each requires_grad tensor argument receives the corresponding gradient instead
+        of the original tensor. Non-tensor arguments and tensors without requires_grad
+        are passed through unchanged. The hook must return ``None``. The hook is called
+        as a leaf function itself, so it is also opaque to the compiler.
 
         Example::
 
@@ -781,6 +781,7 @@ def leaf_function(
         return inner
 
     inner.register_hook = register_hook_setter  # type: ignore[attr-defined]
+    inner.register_multi_grad_hook = register_hook_setter  # type: ignore[attr-defined]
 
     return inner
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #178890
* #175453

## Summary

Adds ``register_multi_grad_hook`` as an alternative to ``register_hook`` on ``@leaf_function``. The name better communicates the semantics: the hook fires exactly once when all requires_grad tensor inputs have their gradients  computed, matching the convention of  ``torch.autograd.graph.register_multi_grad_hook``.

 ## Test plan

  - Added ``test_register_multi_grad_hook_alias`` that uses ``@fn.register_multi_grad_hook`` with multiple tensor inputs and verifies it fires once with correct distinct gradients
  - All existing ``register_hook`` tests continue to pass


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo