### PR TITLE
Remove dead avg_pool3d backward shape-check variables in CUDA

### DIFF
--- a/aten/src/ATen/native/cuda/AveragePool3d.cu
+++ b/aten/src/ATen/native/cuda/AveragePool3d.cu
@@ -500,11 +500,6 @@ TORCH_IMPL_FUNC(avg_pool3d_backward_out_cuda) (
   const int64_t oheight = gradOutput.size(-2);
   const int64_t owidth = gradOutput.size(-1);
 
-  /* XXX shape check behavior from TH */
-  const int64_t otime_for_shape_check = pooling_output_shape<int64_t>(itime, kT, padT, dT, 1, ceil_mode);
-  const int64_t oheight_for_shape_check = pooling_output_shape<int64_t>(iheight, kH, padH, dH, 1, ceil_mode);
-  const int64_t owidth_for_chape_check = pooling_output_shape<int64_t>(iwidth, kW, padW, dW, 1, ceil_mode);
-
   const bool kernelsOverlap = (dT < kT) || (dH < kH) || (dW < kW);
 
   Tensor work_grad_input = gradInput;


### PR DESCRIPTION
## Summary
This removes dead shape-check variables from the CUDA `avg_pool3d_backward` path in `AveragePool3d.cu`.

The code was computing:
- `otime_for_shape_check`
- `oheight_for_shape_check`
- `owidth_for_chape_check`

but none of them were used. The last one also had a typo in its name. Since the variables are dead, this change removes the block instead of renaming it.

A focused regression test is added to ensure these stale variables do not reappear in the CUDA source.

Fixes #178719

## Test Plan
- `python -m unittest tools.test.test_avg_pool3d_source_consistency.TestAvgPool3dSourceConsistency.test_cuda_backward_has_no_dead_shape_check_variables`
