### PR TITLE
[c10d] Remove static from barrier tensor variable

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroup.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroup.hpp
@@ -793,7 +793,7 @@ class TORCH_API ProcessGroup : public torch::CustomClassHolder {
 
   virtual c10::intrusive_ptr<Work> barrier(
       const BarrierOptions& opts = BarrierOptions()) {
-    static at::Tensor tensor;
+    at::Tensor tensor;
     // TODO: if nccl was specified then use it
     auto device = opts.device;
     if (device.has_value()) {


### PR DESCRIPTION
The `static at::Tensor tensor` in `ProcessGroup::barrier()` is a data race when multiple threads call barrier concurrently: the tensor is reassigned on every call, so concurrent calls race on the shared variable. The `static` also doesn't serve any useful purpose since a new tensor is allocated via `at::empty()` on every call anyway.

Authored with Claude.