### PR TITLE
[Inductor] Fix Define unbacked slice size symbol when bounds become provable after tracing

### DIFF
--- a/test/inductor/test_unbacked_symints.py
+++ b/test/inductor/test_unbacked_symints.py
@@ -826,37 +826,33 @@ class TestUnbackedSymints(InductorTestCase):
         torch.testing.assert_close(actual, expected)
 
     @skipGPUIf(not HAS_GPU, "requires gpu and triton")
-    @dynamo_config.patch({"capture_dynamic_output_shape_ops": True})
-    def test_slice_on_unbacked_plus_constant(self, device):
-        """
-        Test slicing on a tensor whose size is (unbacked + constant).
+    @dynamo_config.patch({"capture_scalar_outputs": True})
+    def test_slice_unbacked_bindings_with_later_constraint(self, device):
+        # Regression test for https://github.com/pytorch/pytorch/issues/166460
+        # When slicing with an unbacked symint end index (e.g. x[:total] where
+        # total = sum of data-dependent values), dynamo may allocate a fresh
+        # unbacked symbol for the output size because it can't prove bounds at
+        # trace time. Later operations (e.g. new_zeros with padding) may
+        # establish constraints that make the bounds provable at inductor time.
+        # Inductor must still define the unbacked symbol even when taking the
+        # efficient SliceView path.
+        def fn(x, sizes):
+            sizes_list = sizes.tolist()
+            total = sum(sizes_list)
+            num_padding = x.shape[0] - total
+            sliced = x[:total]
+            splits = torch.split(sliced, sizes_list, dim=0)
+            out = torch.cat([s * 2 for s in splits], dim=0)
+            out = torch.vstack((out, out.new_zeros((num_padding, out.shape[-1]))))
+            return out
 
-        When we have:
-        - repeat_interleave creates unbacked symbol u0
-        - cat creates size u0 + 1
-        - slice [1:] produces size u0 (existing symbol, not fresh)
+        example_inputs = (
+            torch.randn(64, 16, device=device, dtype=torch.bfloat16),
+            torch.tensor([8, 8], device=device, dtype=torch.int64),
+        )
 
-        The lowering should handle this case where the output uses an existing
-        unbacked symbol rather than creating a new one.
-        """
-
-        def fn(x: torch.Tensor, repeats: list[int]):
-            repeats_t = torch.tensor(repeats, device=x.device, dtype=torch.long)
-
-            # repeat_interleave with tensor repeats -> unbacked size u0
-            vals = torch.repeat_interleave(x, repeats_t)
-
-            # cat with fixed-size tensor -> size becomes u0 + 1
-            vals = torch.cat([torch.zeros(1, device=x.device, dtype=x.dtype), vals])
-
-            # slice on u0 + 1 sized tensor -> should produce size u0
-            return vals[1:]
-
-        x = torch.tensor([10, 20, 30], device=device, dtype=torch.int32)
-        repeats = [2, 3, 1]
-
-        actual = torch.compile(fn, fullgraph=True)(x, repeats)
-        expected = fn(x, repeats)
+        actual = torch.compile(fn, fullgraph=True)(*example_inputs)
+        expected = fn(*example_inputs)
         torch.testing.assert_close(actual, expected)
 
 

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -1458,6 +1458,32 @@ def slice_(x, dim=0, start=0, end=sys.maxsize, step=1, clamp=True):
             ambiguous_slice = False
 
     if not ambiguous_slice:
+        # Even though the bounds are resolvable now, the FX node may have
+        # allocated unbacked symbols for the slice output size because dynamo
+        # couldn't prove the bounds at trace time (constraints may have been
+        # learned after tracing the slice). We still need to define those
+        # symbols so the assertion new_unbacked_defs >= renamed_unbacked_bindings
+        # passes. Register a DynamicSliceSize operation to define the size symbol.
+        # Note: storage_offset bindings should not appear here because
+        # a resolved start_index means the offset is computable directly
+        # (base_offset + start * stride), so dynamo wouldn't allocate an
+        # unbacked symbol for it.
+        node_unbacked_bindings = resolve_unbacked_bindings(
+            V.graph.sizevars.shape_env,
+            V.graph.current_node.meta.get("unbacked_bindings", {}),
+        )
+        if node_unbacked_bindings:
+            for sym, keypath in node_unbacked_bindings.items():
+                if keypath == (CallMethodKey("size"), pytree.SequenceKey(dim)):
+                    b_size = ir.DynamicSliceSize(sym, start, end, step, size)
+                    b_size.name = V.graph.register_buffer(b_size)
+                    V.graph.register_operation(b_size)
+                elif keypath == (CallMethodKey("storage_offset"),):
+                    raise AssertionError(
+                        "Unexpected storage_offset unbacked binding when both "
+                        "start and end indices are resolved"
+                    )
+
         return TensorBox(
             ir.SliceView.create(x.data, dim, start, end, step, clamp=clamp)
         )  # go to SliceView/ReinterpretView

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -1468,9 +1468,15 @@ def slice_(x, dim=0, start=0, end=sys.maxsize, step=1, clamp=True):
         # a resolved start_index means the offset is computable directly
         # (base_offset + start * stride), so dynamo wouldn't allocate an
         # unbacked symbol for it.
+        # Note: current_node may be None when slice_ is called from template
+        # rendering (e.g. cpp_template_kernel.slice_nd) rather than FX graph
+        # lowering, so we handle that.
+        current_node = V.graph.current_node
         node_unbacked_bindings = resolve_unbacked_bindings(
             V.graph.sizevars.shape_env,
-            V.graph.current_node.meta.get("unbacked_bindings", {}),
+            current_node.meta.get("unbacked_bindings", {})
+            if current_node is not None
+            else {},
         )
         if node_unbacked_bindings:
             for sym, keypath in node_unbacked_bindings.items():
@@ -1479,6 +1485,9 @@ def slice_(x, dim=0, start=0, end=sys.maxsize, step=1, clamp=True):
                     b_size.name = V.graph.register_buffer(b_size)
                     V.graph.register_operation(b_size)
                 elif keypath == (CallMethodKey("storage_offset"),):
+                    # Not handled yet — would require materializing the
+                    # tensor layout. Unlikely to be hit because a resolved
+                    # start_index means the offset is computable directly.
                     raise AssertionError(
                         "Unexpected storage_offset unbacked binding when both "
                         "start and end indices are resolved"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #178897

Fixes https://github.com/pytorch/pytorch/issues/166460

When compiling a function that slices with a data-dependent index (e.g. x[:total] where total comes from tensor.tolist()), inductor can fail with:

AssertionError: failed OrderedSet([]) >= OrderedSet([u2]) (inductor >= fx)

Root cause: A timing mismatch between dynamo tracing and inductor lowering. At trace time, dynamo's _compute_slice_index cannot prove the slice bounds (e.g. total >= 0 and total <= size) because the constraints haven't been established yet — they are added by later operations like torch.split (which asserts sizes >= 0) and new_zeros (which requires padding >= 0). So dynamo allocates a fresh unbacked symbol u2 for the slice output size.

By the time inductor lowers the same slice node, all constraints from the full graph are available. Inductor's compute_slice_index can now prove both bounds, so it takes the efficient SliceView path — which doesn't define u2. The assertion new_unbacked_defs >= renamed_unbacked_bindings then fails.

Fix: In the slice_ lowering, when compute_slice_index resolves both bounds but the FX node has unbacked_bindings, register a DynamicSliceSize operation to define the unbacked size symbol before returning the SliceView. This way the symbol is properly defined for the scheduler and runtime asserts, while still using the efficient view path.




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo