### PR TITLE
Make python_registrations_ and leaked_python_filenames_ thread-safe

### DIFF
--- a/torch/csrc/utils/python_dispatch.cpp
+++ b/torch/csrc/utils/python_dispatch.cpp
@@ -18,6 +18,7 @@
 #include <torch/csrc/jit/python/pybind_utils.h>
 #include <torch/csrc/utils/tensor_new.h>
 
+#include <c10/util/Synchronized.h>
 #include <c10/util/flat_hash_map.h>
 #include <torch/csrc/inductor/aoti_eager/kernel_holder.h>
 #include <torch/csrc/utils/python_raii.h>
@@ -30,15 +31,18 @@ namespace py = pybind11;
 namespace torch::impl::dispatch {
 
 // Global storage for leaked Python filenames to ensure they remain valid
-// for the lifetime of Library objects
-static std::vector<std::string> leaked_python_filenames_;
+// for the lifetime of Library objects. We use unique_ptr<string> rather than
+// plain string so that c_str() pointers handed to Library objects remain valid
+// when the vector reallocates.
+static c10::Synchronized<std::vector<std::unique_ptr<std::string>>>
+    leaked_python_filenames_;
 
 // NB: I'd like to index this on OperatorHandle, but I can't, as I can't
 // guarantee that the main interpreter has finish doing all registrations before
 // the other interpreters start banging on it
-static ska::flat_hash_map<
+static c10::Synchronized<ska::flat_hash_map<
     c10::OperatorName,
-    ska::flat_hash_map<c10::DispatchKey, std::shared_ptr<c10::SafePyObject>>>
+    ska::flat_hash_map<c10::DispatchKey, std::shared_ptr<c10::SafePyObject>>>>
     python_registrations_;
 
 static torch::Library::Kind parseKind(const std::string& k) {
@@ -424,10 +428,12 @@ void initDispatchBindings(PyObject* module) {
                           std::make_unique<PythonKernelHolder>(
                               func, dispatch, with_keyset))),
                   register_or_verify());
-              python_registrations_[lib._resolve(name)].insert_or_assign(
-                  dispatch,
-                  std::make_shared<c10::SafePyObject>(
-                      func.release().ptr(), getPyInterpreter()));
+              python_registrations_.withLock([&](auto& regs) {
+                regs[lib._resolve(name)].insert_or_assign(
+                    dispatch,
+                    std::make_shared<c10::SafePyObject>(
+                        func.release().ptr(), getPyInterpreter()));
+              });
             }
             END_HANDLE_TH_ERRORS_PYBIND
           },
@@ -512,8 +518,11 @@ void initDispatchBindings(PyObject* module) {
         HANDLE_TH_ERRORS
         // Store the file string in global storage to ensure it remains valid
         // for the lifetime of the Library object
-        leaked_python_filenames_.emplace_back(file);
-        const char* leaked_file = leaked_python_filenames_.back().c_str();
+        const char* leaked_file =
+            leaked_python_filenames_.withLock([&](auto& filenames) {
+              filenames.push_back(std::make_unique<std::string>(file));
+              return filenames.back()->c_str();
+            });
 
         return std::make_unique<torch::Library>(
             parseKind(kind),
@@ -534,7 +543,7 @@ void initDispatchBindings(PyObject* module) {
 
   m.def(
       "_dispatch_clear_leaked_python_filenames",
-      []() { leaked_python_filenames_.clear(); },
+      []() { leaked_python_filenames_.withLock([](auto& f) { f.clear(); }); },
       "Clear the global storage of leaked Python filenames. "
       "WARNING: Only call this if you're sure no Library objects are still using the filenames.");
 
@@ -1077,7 +1086,8 @@ void python_op_registration_trampoline_impl(
   auto arguments = torch::jit::pop(*stack, op.schema().arguments().size());
   py::gil_scoped_acquire g;
   auto args_kwargs = parseIValuesToPyArgsKwargs(op, arguments);
-  const auto& func = python_registrations_[op.operator_name()][key];
+  auto func = python_registrations_.withLock(
+      [&](auto& regs) { return regs[op.operator_name()][key]; });
   TORCH_INTERNAL_ASSERT(func != nullptr);
   auto* pyobj = func->ptr(getPyInterpreter());
   TORCH_INTERNAL_ASSERT(pyobj != nullptr);


### PR DESCRIPTION
Wrap both globals in c10::Synchronized so that concurrent access from multiple threads is safe. Also switch leaked_python_filenames_ from `vector<string>` to `vector<unique_ptr<string>>` so that c_str() pointers handed to Library objects survive vector reallocation.

Authored with Claude.