### PR TITLE
[inductor] Respect TORCHINDUCTOR_CACHE_DIR in fresh_cache

### DIFF
--- a/test/inductor/test_caching.py
+++ b/test/inductor/test_caching.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import tempfile
 from concurrent.futures import Future, ThreadPoolExecutor, TimeoutError, wait
 from contextlib import contextmanager
 from functools import wraps
@@ -2100,6 +2101,39 @@ class FreshCacheIntegrationTest(TestMixin, TestCase):
             self.assertFalse(disk_cache_dir.exists())
             # And memory cache was cleared (via the underlying Memoizer)
             self.assertEqual(len(persistent._memoizer._cache._memory), 0)
+
+    def test_fresh_cache_respects_user_cache_dir(self) -> None:
+        from torch._inductor.cpp_builder import normalize_path_separator
+        from torch._inductor.utils import fresh_cache
+
+        with tempfile.TemporaryDirectory() as custom_dir, patch.dict(
+            os.environ,
+            {"TORCHINDUCTOR_CACHE_DIR": custom_dir},
+            clear=False,
+        ):
+            original_triton_cache_dir = os.environ.pop("TRITON_CACHE_DIR", None)
+            try:
+                expected_inductor_cache_dir = normalize_path_separator(custom_dir)
+                expected_triton_cache_dir = normalize_path_separator(
+                    os.path.join(custom_dir, "triton")
+                )
+
+                with fresh_cache():
+                    self.assertEqual(
+                        os.environ["TORCHINDUCTOR_CACHE_DIR"],
+                        expected_inductor_cache_dir,
+                    )
+                    self.assertEqual(
+                        os.environ["TRITON_CACHE_DIR"],
+                        expected_triton_cache_dir,
+                    )
+
+                self.assertTrue(os.path.isdir(custom_dir))
+            finally:
+                if original_triton_cache_dir is None:
+                    os.environ.pop("TRITON_CACHE_DIR", None)
+                else:
+                    os.environ["TRITON_CACHE_DIR"] = original_triton_cache_dir
 
     @patch_on_disk_cache_base_dir
     @set_caching_module_enabled(True)

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -1333,6 +1333,9 @@ def fresh_cache(
     """
     Contextmanager that provides a clean tmp cachedir for pt2 caches.
 
+    If TORCHINDUCTOR_CACHE_DIR is already set and dir is not provided, reuse the
+    existing cache directory instead of creating a new temporary one.
+
     Optionally, pass a dict as 'cache_entries' to get a list of filenames and sizes
     generated with this cache instance.
     """
@@ -1340,13 +1343,21 @@ def fresh_cache(
 
     from torch._inductor.cpp_builder import normalize_path_separator
 
-    inductor_cache_dir = normalize_path_separator(tempfile.mkdtemp(dir=dir))
+    inductor_cache_dir = os.environ.get("TORCHINDUCTOR_CACHE_DIR")
+    owns_inductor_cache_dir = dir is not None or inductor_cache_dir is None
+    if owns_inductor_cache_dir:
+        inductor_cache_dir = tempfile.mkdtemp(dir=dir)
+    else:
+        os.makedirs(inductor_cache_dir, exist_ok=True)
+
+    inductor_cache_dir = normalize_path_separator(inductor_cache_dir)
     try:
         with _set_env("TORCHINDUCTOR_CACHE_DIR", inductor_cache_dir):
             log.debug("Using inductor cache dir %s", inductor_cache_dir)
-            triton_cache_dir = normalize_path_separator(
-                os.path.join(inductor_cache_dir, "triton")
-            )
+            triton_cache_dir = os.environ.get("TRITON_CACHE_DIR")
+            if owns_inductor_cache_dir or triton_cache_dir is None:
+                triton_cache_dir = os.path.join(inductor_cache_dir, "triton")
+            triton_cache_dir = normalize_path_separator(triton_cache_dir)
             with _set_env("TRITON_CACHE_DIR", triton_cache_dir):
                 yield
                 if isinstance(cache_entries, dict):
@@ -1360,7 +1371,7 @@ def fresh_cache(
                                 if ".lock" not in f
                             }
                         )
-        if delete:
+        if delete and owns_inductor_cache_dir:
             if is_windows() and torch.xpu.is_available():
                 unload_xpu_triton_pyds()
 


### PR DESCRIPTION
## Summary
Fixes `fresh_cache()` so it reuses an explicitly configured `TORCHINDUCTOR_CACHE_DIR` when `dir` is not passed, instead of always replacing it with a new temp directory.

This keeps user-selected cache roots stable while preserving the existing fresh-temp behavior for callers that do not pin a cache directory.

Fixes #178858

## Test Plan
- Temporary standalone reproducer for `#178858` failed before the patch and passed after it
- Added regression coverage in `test/inductor/test_caching.py`
- `python -m py_compile torch/_inductor/utils.py test/inductor/test_caching.py`


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo