### PR TITLE
Fix batch_isend_irecv to support ProcessGroup subclasses

### DIFF
--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -2975,7 +2975,10 @@ def batch_isend_irecv(p2p_op_list: list[P2POp]) -> list[Work]:
         key = "group_dst" if op.op is isend else "group_src"
         return {key: op.group_peer}
 
-    if type(group) is ProcessGroup and group._get_backend(device).supports_coalescing:
+    if (
+        isinstance(group, ProcessGroup)
+        and group._get_backend(device).supports_coalescing
+    ):
         # NCCL style coalescing
         with _coalescing_manager(group, device, async_ops=True) as cm:
             for p2p_op in p2p_op_list:


### PR DESCRIPTION
Change `type(group) is ProcessGroup` to `isinstance(group, ProcessGroup)` in `batch_isend_irecv`. The exact type check prevents Python-subclass backends from entering the coalescing path, falling through to individual send/recv calls.

The rest of distributed_c10d.py already uses `isinstance` consistently for ProcessGroup checks. This aligns the last remaining `type() is` check with that pattern.

There's no lightweight way to add a unit test that meaningfully validates it, but rather any existing batch_isend_irecv tests cover the functionality and this is a mechanical fix consistent with the rest of the file.