### PR TITLE
Refactor addmv_out to use a temporary 2D tensor for output, preventing corruption of non-contiguous tensors and ensuring safe handling of inplace operations.

### DIFF
--- a/aten/src/ATen/native/mkldnn/xpu/Blas.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/Blas.cpp
@@ -376,18 +376,15 @@ Tensor& addmv_out(
 
   Tensor vec_v = vec.view({vec.size(0), 1});
 
-  bool is_float64 =
-      mat.scalar_type() == at::kDouble || vec.scalar_type() == at::kDouble;
+  // Use a temporary 2D tensor for addmm output to avoid resize_ of out,
+  // which corrupts non-contiguous tensors (e.g. from vmap fallback).
+  // Also clone self_v when inplace (self aliases out) to prevent oneDNN
+  // post-ops from reading overwritten data.
   bool is_inplace = self.is_same(out);
-  if (is_float64 && is_inplace) {
-    Tensor self_v_copy = self_v.clone();
-    at::native::xpu::addmm_out(self_v_copy, mat, vec_v, beta, alpha, out);
-    out.resize_({mat.size(0)});
-    return out;
-  }
-
-  at::native::xpu::addmm_out(self_v, mat, vec_v, beta, alpha, out);
-  out.resize_({mat.size(0)});
+  Tensor self_v_safe = is_inplace ? self_v.clone() : self_v;
+  Tensor result_2d = at::empty({mat.size(0), 1}, out.options());
+  at::native::xpu::addmm_out(self_v_safe, mat, vec_v, beta, alpha, result_2d);
+  out.copy_(result_2d.view({mat.size(0)}));
   return out;
 }
 


### PR DESCRIPTION
Resolves https://github.com/intel/torch-xpu-ops/issues/2669. Fix XPU `addmv_out` to handle non-contiguous and strided output tensors

## Summary
Fixes `addmv_out` in the XPU/oneDNN backend to correctly handle non-contiguous output tensors (e.g., those produced by vmap fallback paths).

## Problem
The previous implementation called `out.resize_({mat.size(0)})` after writing the 2D `addmm` result directly into `out`. This corrupts non-contiguous tensors because `resize_` can discard strides and metadata, leading to incorrect results when the output tensor has non-trivial striding (such as tensors constructed by vmap's batching fallback).

Additionally, the special-case for `float64` inplace operations was unnecessarily narrow — the same aliasing hazard (oneDNN post-ops reading overwritten data from `self` when `self` aliases `out`) applies to all dtypes.

## Fix
- Allocate a **temporary contiguous 2D tensor** (`result_2d`) as the output for `addmm_out`, instead of writing directly into `out`.
- **Copy** the result back into `out` via `out.copy_(result_2d.view(...))`, which correctly respects the output tensor's existing strides and memory layout.
- **Clone `self_v`** whenever `self` aliases `out` (inplace case), regardless of dtype, to prevent oneDNN from reading partially-overwritten input data.
- Remove the now-unnecessary `float64`-specific inplace branch.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01