### PR TITLE
Nit fix: Align state_step tensor max to param tensor max

### DIFF
--- a/aten/src/ATen/native/cuda/MultiTensorApply.cuh
+++ b/aten/src/ATen/native/cuda/MultiTensorApply.cuh
@@ -4,7 +4,6 @@
 #include <c10/cuda/CUDAGuard.h>
 #include <ATen/native/cuda/Loops.cuh>
 #include <ATen/native/cuda/MemoryAccess.cuh>
-#include <cstdint>
 #include <vector>
 
 namespace at::native {

--- a/aten/src/ATen/native/cuda/MultiTensorApply.cuh
+++ b/aten/src/ATen/native/cuda/MultiTensorApply.cuh
@@ -4,6 +4,7 @@
 #include <c10/cuda/CUDAGuard.h>
 #include <ATen/native/cuda/Loops.cuh>
 #include <ATen/native/cuda/MemoryAccess.cuh>
+#include <cstdint>
 #include <vector>
 
 namespace at::native {
@@ -85,11 +86,14 @@ struct TensorListScalarListMetadata<c10::complex<double>, 2> {
 // NOTE(crcrpar): This is a conservative resolution to handle `state_steps`
 // whose each element is `at::Tensor` of 1 element representing the number of
 // `step`s called so far.
+// We're aware this struct overflows the kernel arg limit at n=1 (4244 bytes),
+// but our current fused optimizers only instantiate at n>=4 so it's not a
+// concern (yet).
 template <int n>
 struct FusedOptimizerTensorListMetadata {
   const void* addresses[n][depth_to_max_tensors[n - 1]];
   int64_t numel_for_tensor[depth_to_max_tensors[n - 1]];
-  const void* state_steps_addresses[depth_to_max_tensors_scalarlist[n - 1]];
+  const void* state_steps_addresses[depth_to_max_tensors[n - 1]];
   unsigned char block_to_tensor[depth_to_max_blocks[n - 1]];
   int block_to_chunk[depth_to_max_blocks[n - 1]];
   int start_tensor_this_launch;


### PR DESCRIPTION
It doesn't make sense for the length of tensors be diff from the length of the state_steps in this struct. This hasn't mattered because we only instantiate the struct with 4 and 5 in which both depth_to_max_tensors_scalarlist and depth_to_max_tensors have the same values.

Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #178913

