### PR TITLE
Add API to clone tensor outputs outside of CUDA graphs

### DIFF
--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -5139,6 +5139,136 @@ if HAS_CUDA_AND_TRITON:
             run(10)
             run(25)
 
+        def test_cloned_output_basic(self):
+            """Cloned outputs get fresh storage on every replay."""
+
+            def foo(args):
+                x = args[0]
+                args.clear()
+                return x * 2, x + 1
+
+            inp = torch.randn(4, device="cuda")
+            foo_cg = self.cudagraphify_impl(foo, [inp], (0,), cloned_output_idxs=(0,))
+
+            # warmup + record
+            foo_cg([inp])
+            out1_a, out1_b = foo_cg([inp])
+
+            # replay — cloned output should have different storage
+            out2_a, out2_b = foo_cg([inp])
+            self.assertNotEqual(out1_a.data_ptr(), out2_a.data_ptr())
+
+            # values should be correct
+            self.assertEqual(out2_a, inp * 2)
+            self.assertEqual(out2_b, inp + 1)
+
+        def test_cloned_output_survives_replay(self):
+            """Cloned outputs remain valid after subsequent replays."""
+
+            def foo(args):
+                x = args[0]
+                args.clear()
+                return (x * 3,)
+
+            inp = torch.randn(4, device="cuda")
+            foo_cg = self.cudagraphify_impl(foo, [inp], (0,), cloned_output_idxs=(0,))
+
+            foo_cg([inp])
+            (first,) = foo_cg([inp])
+            expected = first.clone()
+
+            # replay again — first should still hold correct data
+            foo_cg([inp])
+            self.assertEqual(first, expected)
+
+        def test_cloned_output_multiple_idxs(self):
+            """Multiple outputs can be cloned."""
+
+            def foo(args):
+                x = args[0]
+                args.clear()
+                return x + 1, x + 2, x + 3
+
+            inp = torch.randn(4, device="cuda")
+            foo_cg = self.cudagraphify_impl(foo, [inp], (0,), cloned_output_idxs=(0, 2))
+
+            foo_cg([inp])
+            a1, b1, c1 = foo_cg([inp])
+            a2, b2, c2 = foo_cg([inp])
+
+            # idxs 0 and 2 are cloned — different storage each call
+            self.assertNotEqual(a1.data_ptr(), a2.data_ptr())
+            self.assertNotEqual(c1.data_ptr(), c2.data_ptr())
+
+            self.assertEqual(a2, inp + 1)
+            self.assertEqual(b2, inp + 2)
+            self.assertEqual(c2, inp + 3)
+
+        def test_cloned_output_compile(self):
+            """End-to-end test with torch.compile."""
+            from torch._inductor import cudagraph_prims  # noqa: F401
+
+            @torch.compile(mode="reduce-overhead")
+            def foo(x):
+                y = x * 2
+                z = x + 1
+                torch.ops.aten_cudagraphs.exclude_from_cudagraphs(
+                    y, clone=True
+                )
+                return y, z
+
+            inp = torch.randn(4, device="cuda")
+            for _ in range(3):
+                foo(inp)
+
+            out1_y, _ = foo(inp)
+            out2_y, _ = foo(inp)
+
+            # cloned output should have different storage
+            self.assertNotEqual(out1_y.data_ptr(), out2_y.data_ptr())
+
+            # values correct
+            self.assertEqual(out2_y, inp * 2)
+
+            # cloned output survives further replays
+            expected_y = out1_y.clone()
+            foo(inp)
+            self.assertEqual(out1_y, expected_y)
+
+        def test_cloned_output_with_cpu_partition(self):
+            """Cloned output works when graph has CPU ops causing partitions."""
+            from torch._inductor import cudagraph_prims  # noqa: F401
+
+            def foo(x):
+                y = x * 2
+                torch.ops.aten_cudagraphs.exclude_from_cudagraphs(
+                    y, clone=True
+                )
+                cpu_val = x.sum().cpu()
+                z = x + cpu_val.to("cuda")
+                return y, z
+
+            inp = torch.randn(4, device="cuda")
+            f_compiled = torch.compile(foo, mode="reduce-overhead")
+
+            for _ in range(3):
+                f_compiled(inp)
+
+            out1_y, out1_z = f_compiled(inp)
+            out2_y, out2_z = f_compiled(inp)
+
+            # cloned output has different storage
+            self.assertNotEqual(out1_y.data_ptr(), out2_y.data_ptr())
+
+            # values correct
+            self.assertEqual(out2_y, inp * 2)
+            self.assertEqual(out2_z, inp + inp.sum())
+
+            # cloned output survives
+            expected = out1_y.clone()
+            f_compiled(inp)
+            self.assertEqual(out1_y, expected)
+
     class TestSAC(TestCase):
         def _make_observer_mode(self):
             class ObserverMode(TorchDispatchMode):
@@ -5614,6 +5744,54 @@ if HAS_CUDA_AND_TRITON:
         instantiate_device_type_tests(
             TestCudagraphIndexingOps, globals(), only_for=("cuda",)
         )
+
+
+if torch.cuda.is_available():
+
+    class TestMarkOutputsMeta(InductorTestCase):
+        """Tests for mark_outputs_meta tracing (no triton needed)."""
+
+        def test_no_annotation(self):
+            """make_fx works normally when no cudagraph annotations exist."""
+            gm = make_fx(lambda x: x * 2, tracing_mode="fake")(
+                torch.randn(4, device="cuda")
+            )
+            out = next(reversed(gm.graph.find_nodes(op="output")))
+            self.assertNotIn("cloned_idxs", out.meta)
+
+        def test_clone_annotation(self):
+            """exclude_from_cudagraphs with clone=True sets cloned_idxs."""
+            from torch._inductor import cudagraph_prims  # noqa: F401
+
+            def f(x):
+                y = x * 2
+                torch.ops.aten_cudagraphs.exclude_from_cudagraphs(
+                    y, clone=True
+                )
+                return y, x + 1
+
+            gm = make_fx(f, tracing_mode="fake")(torch.randn(4, device="cuda"))
+            out = next(reversed(gm.graph.find_nodes(op="output")))
+            self.assertEqual(out.meta["cloned_idxs"], {0})
+
+            # custom op must be erased
+            for node in gm.graph.nodes:
+                self.assertNotIn("exclude", str(node.target))
+
+        def test_single_output(self):
+            """mark_outputs_meta handles single (non-tuple) output."""
+            from torch._inductor import cudagraph_prims  # noqa: F401
+
+            def f(x):
+                y = x * 2
+                torch.ops.aten_cudagraphs.exclude_from_cudagraphs(
+                    y, clone=True
+                )
+                return y
+
+            gm = make_fx(f, tracing_mode="fake")(torch.randn(4, device="cuda"))
+            out = next(reversed(gm.graph.find_nodes(op="output")))
+            self.assertEqual(out.meta["cloned_idxs"], {0})
 
 
 if __name__ == "__main__":

--- a/torch/_functorch/_aot_autograd/graph_compile.py
+++ b/torch/_functorch/_aot_autograd/graph_compile.py
@@ -22,6 +22,7 @@ from typing import Any, TYPE_CHECKING
 
 from torch._library.fake_class_registry import FakeScriptObject
 from torch._opaque_base import OpaqueBase
+from torch.utils._ordered_set import OrderedSet
 
 
 if TYPE_CHECKING:
@@ -1190,6 +1191,58 @@ def prepare_hook_gm(
     return gm
 
 
+def propagate_output_meta_to_fw_module(
+    fx_g: torch.fx.GraphModule,
+    fw_module: torch.fx.GraphModule,
+    num_inner_fwd_outputs: int,
+):
+    """
+    Propagate cloned_idxs from joint graph to forward module.
+    Maps the indices from joint graph outputs to fw_module outputs.
+    """
+    from torch._inductor.fx_utils import get_node_storage
+
+    # Get metadata from joint graph output node
+    joint_output_node = next(reversed(fx_g.graph.find_nodes(op="output")))
+    cloned_idxs = joint_output_node.meta.get("cloned_idxs", OrderedSet())
+
+    if not cloned_idxs:
+        return  # Nothing to propagate
+
+    # Get joint graph outputs
+    joint_outs = joint_output_node.args[0]
+
+    # Build storage -> joint_idx mapping for user outputs only
+    joint_storage_to_idx = {}
+    for i in range(num_inner_fwd_outputs):
+        node = joint_outs[i]
+        if isinstance(node, torch.fx.Node):
+            storage = get_node_storage(node)
+            if storage is not None:
+                joint_storage_to_idx[storage] = i
+
+    # Get fw_module outputs
+    fw_output_node = next(reversed(fw_module.graph.find_nodes(op="output")))
+    fw_outs = fw_output_node.args[0]
+
+    # Map indices from joint graph to fw_module
+    fw_cloned_idxs: OrderedSet[int] = OrderedSet()
+
+    for fw_idx, fw_node in enumerate(fw_outs):
+        if not isinstance(fw_node, torch.fx.Node):
+            continue
+
+        fw_storage = get_node_storage(fw_node)
+        if fw_storage is None:
+            continue
+
+        joint_idx = joint_storage_to_idx.get(fw_storage)
+        if joint_idx is not None and joint_idx in cloned_idxs:
+            fw_cloned_idxs.add(fw_idx)
+
+    fw_output_node.meta["cloned_idxs"] = fw_cloned_idxs
+
+
 # Inline Autograd saved_tensors_hooks into epilogue of forward graph
 # and prologue of backward graph.
 # This changes forward graph outputs and inputs.
@@ -1788,6 +1841,8 @@ def _aot_stage2a_partition(
                 num_fwd_outputs=num_inner_fwd_outputs,
                 static_lifetime_input_indices=static_lifetime_input_indices,
             )
+            propagate_output_meta_to_fw_module(fx_g, fw_module, num_inner_fwd_outputs)
+
             rng_states = [
                 n
                 for n in fw_module.graph.find_nodes(op="placeholder")

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -1848,6 +1848,7 @@ def cudagraphify(
     constants: tuple[torch.Tensor, ...] = (),
     placeholders: Sequence[PlaceholderInfo] = (),
     mutated_input_idxs: tuple[int, ...] = (),
+    cloned_output_idxs: tuple[int, ...] = (),
 ) -> Callable[..., Any]:
     from torch._inductor.cudagraph_trees import (
         cudagraphify_impl as new_cudagraphify_impl,
@@ -1865,6 +1866,7 @@ def cudagraphify(
             placeholders=placeholders,
             mutated_input_idxs=mutated_input_idxs,
             compile_id=torch._guards.CompileContext.current_compile_id(),
+            cloned_output_idxs=cloned_output_idxs,
         )
     else:
         cudagraphify_fn = cudagraphify_impl

--- a/torch/_inductor/cudagraph_prims.py
+++ b/torch/_inductor/cudagraph_prims.py
@@ -1,0 +1,19 @@
+import torch
+
+
+@torch.library.custom_op("aten_cudagraphs::exclude_from_cudagraphs", mutates_args={})
+def exclude_from_cudagraphs(
+    inp: torch.Tensor,
+    clone: bool = False,
+) -> None:
+    return None
+
+
+def exclude_from_cudagraphs_fake(
+    inp: torch.Tensor,
+    clone: bool = False,
+) -> None:
+    return None
+
+
+exclude_from_cudagraphs.register_fake(exclude_from_cudagraphs_fake)

--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -486,6 +486,7 @@ def cudagraphify(
     placeholders: tuple[PlaceholderInfo, ...] = (),
     mutated_input_idxs: tuple[int, ...] = (),
     compile_id: CompileId | None = None,
+    cloned_output_idxs: tuple[int, ...] = (),
 ) -> tuple[ModelType, OutputType]:
     assert not (is_backward and is_inference)
     mode = (
@@ -507,6 +508,7 @@ def cudagraphify(
         placeholders,
         mutated_input_idxs,
         compile_id,
+        cloned_output_idxs,
     )
 
 
@@ -743,7 +745,10 @@ class CUDAWarmupNode:
         assert len(new_inputs) == 0
 
         # sdpa returns cpu tensors when not recording cuda graph
-        def add_ref(o: Any) -> bool:
+        def add_ref(i: int, o: Any) -> bool:
+            if i in self.wrapped_function.cloned_output_idxs:
+                return False
+
             return (
                 isinstance(o, torch.Tensor)
                 and o.is_cuda
@@ -752,15 +757,21 @@ class CUDAWarmupNode:
             )
 
         self.outputs_weakrefs.extend(
-            [map_to_ref(o) if add_ref(o) else None for o in out]
+            [map_to_ref(o) if add_ref(i, o) else None for i, o in enumerate(out)]
         )
         self.tensor_weakrefs.extend(
-            [TensorWeakRef(o) if add_ref(o) else None for o in out]
+            [TensorWeakRef(o) if add_ref(i, o) else None for i, o in enumerate(out)]
         )
 
         if config.triton.slow_path_cudagraph_asserts and not self.already_warm:
             out_refs = list(self.path_live_weakrefs())
+            for i in self.wrapped_function.cloned_output_idxs:
+                out_refs.append(StorageWeakRefWrapper(out[i]))
+
             check_memory_pool(self.device_index, self.cuda_graphs_pool, out_refs)
+
+        if idxs := self.wrapped_function.cloned_output_idxs:
+            out = tuple(o.clone() if i in idxs else o for i, o in enumerate(out))
 
         return out
 
@@ -888,6 +899,11 @@ class CUDAGraphNode:
         # A single wrapped function may be recorded multiple times if memory patterns or
         # invariants change from one execution to the next
         self.children: dict[FunctionID, list[CUDAGraphNode]] = defaultdict(list)
+
+        # user annotated cloned outputs
+        self.cloned_output_idxs: OrderedSet[int] = OrderedSet(
+            wrapped_function.cloned_output_idxs
+        )
 
         # StorageWeakRef maintains whether the Storage C++ object remains allocated,
         # not whether the corresponding memory has been deallocated. In order
@@ -1142,6 +1158,12 @@ class CUDAGraphNode:
         outputs = self.recording_outputs
         self.recording_outputs = None
         assert outputs is not None
+
+        if idxs := self.cloned_output_idxs:
+            outputs = tuple(
+                o.clone() if i in idxs else o for i, o in enumerate(outputs)
+            )
+
         return outputs
 
     def run(self, new_inputs: list[InputType]) -> OutputType:
@@ -1186,6 +1208,10 @@ class CUDAGraphNode:
 
             cached_t = self.cached_tensor_outputs[i]
             if cached_t is not None:
+                if i in self.cloned_output_idxs:
+                    outputs.append(cached_t.clone())
+                    continue
+
                 # this output represents a fresh allocated tensor.
                 # We return the same TensorImpl from run to run to avoid overhead.
                 # autograd.Function will reset the Autograd meta of output tensors
@@ -1215,6 +1241,10 @@ class CUDAGraphNode:
                 out = self._reconstruct_from_tensor_metadata(
                     metadata, cast(torch.Tensor, outputs[storage]).untyped_storage()
                 )
+
+            if i in self.cloned_output_idxs:
+                outputs.append(out.clone())
+                continue
 
             outputs.append(out)
             w = self.outputs_weakrefs[i]
@@ -1357,6 +1387,10 @@ class CUDAGraphNode:
                 self.output_storage_alias.append(UnaliasedStorage)
                 continue
 
+            if i in self.cloned_output_idxs:
+                self.output_storage_alias.append(UnaliasedStorage)
+                continue
+
             torch._check(
                 o.is_cuda or o.untyped_storage().data_ptr() == 0,
                 lambda: (
@@ -1406,8 +1440,14 @@ class CUDAGraphNode:
             )
 
         assert not self.outputs_weakrefs
-        for out, static_output_tensor in zip(outputs, self.static_output_tensors):
-            if not isinstance(out, torch.Tensor) or static_output_tensor is not None:
+        for idx, (out, static_output_tensor) in enumerate(
+            zip(outputs, self.static_output_tensors)
+        ):
+            # Skip weakref tracking for cloned outputs - we'll clone them fresh each time
+            if idx in self.cloned_output_idxs:
+                self.outputs_weakrefs.append(None)
+                self.tensor_weakrefs.append(None)
+            elif not isinstance(out, torch.Tensor) or static_output_tensor is not None:
                 self.outputs_weakrefs.append(None)
                 self.tensor_weakrefs.append(None)
             else:
@@ -1427,9 +1467,15 @@ class CUDAGraphNode:
 
         self.debug_check_invariants_after_invocation()
         if config.triton.slow_path_cudagraph_asserts:
-            check_memory_pool(
-                self.device, self.cuda_graphs_pool, list(self.path_live_weakrefs())
-            )
+            # In this memory check after initial recording, we still want to
+            # make sure that the memory pool is in a good state, which includes
+            # the tensors we will clone later. We need to manually add them now,
+            # because we do not track their liveness after running.
+            all_refs = list(self.path_live_weakrefs())
+            for idx in self.cloned_output_idxs:
+                all_refs.append(StorageWeakRefWrapper(outputs[idx]))
+
+            check_memory_pool(self.device, self.cuda_graphs_pool, all_refs)
 
     def _mark_prior_graph_output_as_aliased(self, index: PathOutputIndex) -> None:
         "Remove a graph output from the unaliased, cached tensors in an ancestor node"
@@ -1460,6 +1506,9 @@ class CUDAGraphNode:
             assert isinstance(metadata, dict)
             s = self.create_storage(metadata)
             out = self._reconstruct_from_tensor_metadata(metadata, storage=s)  # type: ignore[arg-type]
+            if i in self.cloned_output_idxs:
+                self.cached_tensor_outputs.append(out)
+                continue
 
             # XXX: let autograd know that there will be an additional reference to the tensor
             # that can be ignored when deciding whether to do gradient buffer inplacing.
@@ -2425,6 +2474,7 @@ class CUDAGraphTreeManager:
         placeholders: tuple[PlaceholderInfo, ...],
         mutated_input_idxs: tuple[int, ...],
         compile_id: CompileId | None,
+        cloned_output_idxs: tuple[int, ...],
     ) -> tuple[
         ModelType,
         OutputType,
@@ -2438,6 +2488,7 @@ class CUDAGraphTreeManager:
             tuple(t for t in constants if isinstance(t, torch.Tensor) and t.is_cuda),
             placeholders,
             mutated_input_idxs,
+            cloned_output_idxs,
         )
         self.id_to_mode[id] = mode
         self.id_to_compile_id[id] = compile_id

--- a/torch/_inductor/cudagraph_utils.py
+++ b/torch/_inductor/cudagraph_utils.py
@@ -65,6 +65,7 @@ class WrappedFunction:
     constants: tuple[torch.Tensor, ...]
     placeholders: Sequence[PlaceholderInfo]
     mutated_input_idxs: Sequence[int]
+    cloned_output_idxs: Sequence[int]
 
 
 def get_mutating_use_stack_trace_from_node(
@@ -368,6 +369,7 @@ class CudagraphMetadata:
     mutated_input_idxs: OrderedSet[int]
     stack_traces: list[str | None]
     constants: dict[str, torch.Tensor]
+    cloned_output_idxs: OrderedSet[int]
 
 
 def get_partition_cudagraph_metadata(
@@ -405,11 +407,13 @@ def get_partition_cudagraph_metadata(
         partition_placeholders.append(placeholder)
 
     partition_stack_traces = []
+    partition_cloned_idxs: OrderedSet[int] = OrderedSet()
     for i, graph_output_idx in enumerate(partition_map.output_index_mapping):
         if graph_output_idx is not None:
             partition_stack_traces.append(metadata.stack_traces[graph_output_idx])
+            if graph_output_idx in metadata.cloned_output_idxs:
+                partition_cloned_idxs.add(i)
         elif partition_map.stack_traces and i < len(partition_map.stack_traces):
-            # For partition-internal outputs, use stack traces from IR nodes
             partition_stack_traces.append(partition_map.stack_traces[i])
         else:
             partition_stack_traces.append(None)
@@ -424,6 +428,7 @@ def get_partition_cudagraph_metadata(
         partition_mutated_input_idxs,
         partition_stack_traces,
         partition_constants,
+        partition_cloned_idxs,
     )
 
 

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -414,6 +414,7 @@ class GraphLowering(torch.fx.Interpreter):
         self.graph_inputs: dict[str, TensorBox | TorchBindObject | sympy.Expr] = {}
         self.graph_inputs_original: dict[str, InputBuffer] = {}
         self.partition_maps: list[GraphPartitionMap] | None = None
+        self.cudagraph_cloned_bufs: OrderedSet[str] = OrderedSet()
         self.zero_dim_cpu_tensor_list: OrderedSet[str] = OrderedSet()
         self.device_types: OrderedSet[str] = (
             const_module.device_types if const_module else OrderedSet()
@@ -1575,6 +1576,7 @@ class GraphLowering(torch.fx.Interpreter):
             for x in result
         ), result
 
+        n_meta = V.graph.current_node.meta
         fx_node_args = V.graph.current_node.args[0]  # type: ignore[arg-type]
         if not isinstance(fx_node_args, (tuple, list)):
             # nested subgraphs can have singleton outputs
@@ -1583,7 +1585,7 @@ class GraphLowering(torch.fx.Interpreter):
         result_correct_strides = []
 
         assert len(fx_node_args) == len(result)
-        for r, fx_node in zip(result, fx_node_args):
+        for i, (r, fx_node) in enumerate(zip(result, fx_node_args)):
             if not isinstance(r, (ir.TensorBox, ir.BaseView)):
                 result_correct_strides.append(r)
             elif isinstance(r.get_output_spec(), ir.CommBufferLayout):
@@ -1604,6 +1606,8 @@ class GraphLowering(torch.fx.Interpreter):
                 result_correct_strides.append(
                     ir.try_match_insignificant_strides(r, meta_strides)
                 )
+            if i in n_meta.get("cloned_idxs", ()):
+                self.cudagraph_cloned_bufs.add(result_correct_strides[-1].get_name())
 
         self.graph_outputs = result_correct_strides
         value: ir.IRNode

--- a/torch/_inductor/output_code.py
+++ b/torch/_inductor/output_code.py
@@ -252,6 +252,7 @@ def cudagraph_post_compile(
             constants=tuple(tensor_constants.values()),
             placeholders=placeholders,
             mutated_input_idxs=tuple(compiled_graph.mutated_input_idxs),
+            cloned_output_idxs=tuple(compiled_graph.cudagraph_cloned_idxs),
         )
 
     else:
@@ -330,6 +331,7 @@ def cudagraph_partition_post_compile(
         mutated_input_idxs,
         compiled_graph.cudagraph_info.stack_traces,
         tensor_constants,
+        compiled_graph.cudagraph_cloned_idxs,
     )
 
     prepare_cudagraph_post_compile(
@@ -356,6 +358,7 @@ def cudagraph_partition_post_compile(
             constants=tuple(partition_metadata.constants.values()),
             placeholders=partition_metadata.placeholders,
             mutated_input_idxs=tuple(partition_metadata.mutated_input_idxs),
+            cloned_output_idxs=tuple(partition_metadata.cloned_output_idxs),
         )
         cudagraphify_fns.append(cudagraphify_fn)
 
@@ -520,6 +523,13 @@ class CompiledFxGraph(OutputCode):
         self.device_idxs = OrderedSet(graph.device_idxs)
         self.mutated_inputs = OrderedSet(graph.mutated_inputs)
         self.mutated_input_idxs = OrderedSet(graph.mutated_input_idxs)
+        cloned_bufs = getattr(graph, "cudagraph_cloned_bufs", OrderedSet())
+        self.cudagraph_cloned_idxs: OrderedSet[int] = OrderedSet()
+        if cloned_bufs:
+            output_names = graph.get_output_names()
+            for i, name in enumerate(output_names):
+                if name in cloned_bufs:
+                    self.cudagraph_cloned_idxs.add(i)
 
         # We store the constant attributes in the cache entry and re-attach them
         # to the module created in PyCodeCache.load_by_key_path. In the case that

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -65,9 +65,11 @@ from torch.fx.node import (
     Argument,
     Target,
 )
+from torch.fx.operator_schemas import normalize_function
 from torch.fx.passes.shape_prop import _extract_tensor_metadata
 from torch.nn import Module
 from torch.overrides import TorchFunctionMode
+from torch.utils._ordered_set import OrderedSet
 from torch.utils._python_dispatch import (
     _disable_infra_mode,
     _push_mode,
@@ -1578,6 +1580,59 @@ def _make_temp_remove_mode_context_manager(
     return context_manager_fn
 
 
+def mark_outputs_meta(graph: torch.fx.Graph):
+    op = getattr(
+        getattr(torch.ops, "aten_cudagraphs", None),
+        "exclude_from_cudagraphs",
+        None,
+    )
+    if op is None:
+        return
+
+    excluded_outputs = graph.find_nodes(
+        op="call_function",
+        target=op.default,
+    )
+    if not excluded_outputs:
+        return
+
+    from torch._inductor.fx_utils import get_node_storage
+
+    cloned_metas = OrderedSet()
+
+    for op in excluded_outputs:
+        _, new_kwargs = normalize_function(
+            op.target, args=op.args, kwargs=op.kwargs, normalize_to_only_use_kwargs=True
+        )
+        storage = get_node_storage(new_kwargs["inp"])
+        if storage is None:
+            continue
+
+        if new_kwargs["clone"]:
+            cloned_metas.add(storage)
+
+    output_nodes = graph.find_nodes(op="output")
+    torch._check(len(output_nodes) == 1)
+
+    output_args = output_nodes[0].args[0]
+    if not isinstance(output_args, (tuple, list)):
+        output_args = (output_args,)
+
+    cloned_idxs: OrderedSet[int] = OrderedSet()
+
+    for i, inp in enumerate(output_args):
+        if not isinstance(inp, torch.fx.Node):
+            continue
+        stor = get_node_storage(inp)
+        if stor in cloned_metas:
+            cloned_idxs.add(i)
+
+    output_nodes[0].meta["cloned_idxs"] = cloned_idxs
+
+    for n in excluded_outputs:
+        n.graph.erase_node(n)
+
+
 @torch._disable_dynamo
 def dispatch_trace(
     root: Module | Callable,
@@ -1615,6 +1670,7 @@ def dispatch_trace(
         # No idea, just assume it's not OK
         return True
 
+    mark_outputs_meta(graph)
     graph.eliminate_dead_code(impure_pred)
     from torch._inductor.fx_passes.dedupe_symint_uses import dedupe_symints
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #178915
* #177890

Adds `torch.ops.aten_cudagraphs.exclude_from_cudagraphs` custom op that
lets users annotate outputs that should be cloned out of the graph's
memory pool after replay. This prevents issues where graph-managed memory
gets reused across replays while user code still holds references.

The implementation threads the clone metadata through:
- proxy_tensor.py: `mark_outputs_meta` detects the custom op during
  tracing and propagates indices to the output node metadata
- graph_compile.py: `propagate_output_meta_to_fw_module` maps joint
  graph indices to forward module indices after partitioning
- graph.py / output_code.py / compile_fx.py: threads the indices
  through GraphLowering, CompiledFxGraph, and cudagraphify
- cudagraph_trees.py: CUDAGraphNode and CUDAWarmupNode clone the
  annotated outputs after replay, skipping weakref tracking for them
- cudagraph_utils.py: maps cloned indices across graph partitions

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo

Differential Revision: [D98961383](https://our.internmc.facebook.com/intern/diff/D98961383)