### PR TITLE
[inductor] Preserve select bounds checks in split-cat pass

### DIFF
--- a/test/inductor/test_split_cat_fx_passes.py
+++ b/test/inductor/test_split_cat_fx_passes.py
@@ -1533,6 +1533,43 @@ class TestSplitCatFxPasses(TestCase):
             )
             counters.clear()
 
+    @torch._inductor.config.patch(
+        pre_grad_fusion_options={
+            "normalization_aten_pass": {},
+            "select_cat_aten_pass": {},
+            "unbind_stack_aten_pass": {},
+        },
+        post_grad_fusion_options={},
+    )
+    def test_unbind_stack_aten_preserves_select_bounds_checks(self):
+        def fn(x):
+            slice0 = torch.select(x, dim=1, index=0)
+            slice1 = torch.select(x, dim=1, index=1)
+            slice2 = torch.select(x, dim=1, index=2)
+            return torch.cat(
+                [
+                    torch.unsqueeze(slice0, dim=1),
+                    torch.unsqueeze(slice1, dim=1),
+                    torch.unsqueeze(slice2, dim=1),
+                ],
+                dim=1,
+            )
+
+        x = torch.randn(4, 1, 10, 16)
+
+        self.assertRaisesRegex(
+            IndexError,
+            r"select\(\): index 1 out of range",
+            lambda: fn(x),
+        )
+        self.assertRaisesRegex(
+            IndexError,
+            r"select\(\): index 1 out of range",
+            lambda: torch.compile(fn)(x),
+        )
+        self.assertEqual(counters["inductor"]["unbind_stack_aten_pass"], 0)
+        counters.clear()
+
     def test_numpy_compat_normalization(self):
         def fn(x, y):
             a = torch.stack([x, y], axis=1)

--- a/torch/_inductor/fx_passes/split_cat.py
+++ b/torch/_inductor/fx_passes/split_cat.py
@@ -2034,6 +2034,11 @@ def merge_unbind_stack_aten(match: Match, *args, **kwargs):
         [get_arg_value(select_node, 2, "index") for select_node in select_nodes]
     ):
         return
+    if (
+        "val" not in parent_of_select_node.meta
+        or len(select_nodes) != parent_of_select_node.meta["val"].shape[cat_dim]
+    ):
+        return
     # check the users of parent of select node only from unsqueeze nodes that go to the cat node
     # we simply check the number of users of the parent of select node
     if len(parent_of_select_node.users.keys()) != len(node.args[0]):  # type: ignore[arg-type]


### PR DESCRIPTION
Fixes #178881


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo