### PR TITLE
[inductor] Fix scalar-broadcast scatter zero-mask analysis

### DIFF
--- a/test/inductor/test_scatter_optimization.py
+++ b/test/inductor/test_scatter_optimization.py
@@ -143,6 +143,27 @@ class TestScatterOpt(TestCase):
         )
         self.assertGreaterEqual(metrics.num_bytes_accessed, expected_num_bytes)
 
+    def test_scatter_reduce_scalar_broadcast_non_power_of_2(self):
+        def f(x, bias, idx):
+            src = x + bias
+            out = torch.zeros(1, 1, device=x.device, dtype=x.dtype)
+            return out.scatter_reduce(
+                0,
+                idx.unsqueeze(-1).expand_as(src),
+                src,
+                "sum",
+                include_self=True,
+            )
+
+        n = 33
+        x = torch.randn(n, 1, device=GPU_TYPE)
+        bias = torch.tensor([0.020368], device=GPU_TYPE)
+        idx = torch.zeros(n, dtype=torch.long, device=GPU_TYPE)
+
+        expected = f(x, bias, idx)
+        actual = torch.compile(f, fullgraph=True, dynamic=False)(x, bias, idx)
+        self.assertTrue(same(expected, actual, tol=1e-5), f"{expected=}\n{actual=}\n")
+
         # the second kernel and third kernel are both mutation kernel. So we
         # overestimated the memory accessed
         # Update the test once the overestimiation is fixed.

--- a/torch/_inductor/analyze_preserves_zero_mask.py
+++ b/torch/_inductor/analyze_preserves_zero_mask.py
@@ -33,8 +33,16 @@ class PreservesZeros(SymPyOps, DefaultHandler):
         self.dtype_prop = DtypePropagationOpsHandler()
 
     def load(self, name: str, index: sympy.Expr) -> TypedExpr:
-        # In prologue fusion, all loads get broadcasted
         dtype = self.dtype_prop.load(name, index)
+        buf = V.graph.try_get_buffer(name)
+        if (
+            buf is not None
+            and hasattr(buf, "get_numel")
+            and V.graph.sizevars.statically_known_equals(buf.get_numel(), 1)
+        ):
+            return TypedExpr(construct_symbol(next(self.count), dtype), dtype)
+
+        # In prologue fusion, masked tensor loads get broadcasted.
         return TypedExpr(
             sympy.Float(0) if dtype.is_floating_point else sympy.Integer(0), dtype
         )


### PR DESCRIPTION
## Summary
Fixes a silent correctness issue in the zero-mask analysis used for prologue fusion around scatter-reduce kernels.

`PreservesZeros.load()` was assuming that all prologue loads behave like masked tensor loads and therefore produce `0` for out-of-bounds lanes. That is not true for scalar / numel-1 broadcast inputs such as the fused `bias` in the issue reproducer.

When that scalar load was treated as zero-preserving, Inductor could incorrectly conclude that the fused prologue preserved masked-out values, which in turn could drop the effective mask on the scatter atomic-add path for non-power-of-2 launch shapes.

This change makes the analysis conservative for known `numel == 1` loads by treating them as unknown values instead of masked zeros.

Fixes #178871

## Test Plan
- Standalone reproducer for the zero-mask analysis failed before the patch and passed after it
- Added regression coverage in `test/inductor/test_scatter_optimization.py`
- `python -m py_compile torch/_inductor/analyze_preserves_zero_mask.py test/inductor/test_scatter_optimization.py`


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo