### PR TITLE
Fix efficient zero tensor handling in torch.compile

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -16482,15 +16482,6 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
                 check_lowp=False,
             )
 
-    def test_efficientzerotensor_lowering(self):
-        def fn(x):
-            z = torch.ops.aten._efficientzerotensor(
-                x.shape, dtype=x.dtype, device=x.device
-            )
-            return x + z
-
-        self.common(fn, (torch.randn(8, 8, device=self.device),))
-
     def test_jvp_compile_backward(self):
         def jvp_fn(f, x):
             return torch.func.jvp(f, (x.clone(),), (torch.ones_like(x),))[1]

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -16482,6 +16482,49 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
                 check_lowp=False,
             )
 
+    def test_efficientzerotensor_lowering(self):
+        def fn(x):
+            z = torch.ops.aten._efficientzerotensor(
+                x.shape, dtype=x.dtype, device=x.device
+            )
+            return x + z
+
+        self.common(fn, (torch.randn(8, 8, device=self.device),))
+
+    def test_jvp_compile_backward(self):
+        def jvp_fn(f, x):
+            return torch.func.jvp(f, (x.clone(),), (torch.ones_like(x),))[1]
+
+        def compute(f, x):
+            first, rest = x[..., :1], x[..., 1:]
+            return jvp_fn(lambda X: f(torch.cat([X, rest])), first)
+
+        in_features = 4
+        net = torch.nn.Sequential(
+            torch.nn.Linear(in_features, 32),
+            torch.nn.Linear(32, 32),
+            torch.nn.Linear(32, 8),
+        ).to(self.device)
+
+        x = torch.rand((in_features,), device=self.device)
+
+        eager_out = compute(net, x).sum()
+        eager_out.backward()
+        eager_grads = [p.grad.clone() for p in net.parameters() if p.grad is not None]
+        net.zero_grad()
+
+        compiled = torch.compile(compute)
+        compiled_out = compiled(net, x).sum()
+        compiled_out.backward()
+        compiled_grads = [
+            p.grad.clone() for p in net.parameters() if p.grad is not None
+        ]
+
+        self.assertEqual(eager_out, compiled_out)
+        self.assertEqual(len(eager_grads), len(compiled_grads))
+        for eg, cg in zip(eager_grads, compiled_grads):
+            self.assertEqual(eg, cg)
+
     # end of class CommonTemplate - add new tests here
 
 

--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -59,6 +59,10 @@ importlib.import_module("filelock")
 
 # xfail by default, set is_skip=True to skip
 test_failures = {
+    # torch.func.jvp with nn.Module doesn't retrace with symbolic sizes
+    "test_jvp_compile_backward_dynamic_shapes": TestFailure(
+        ("cpu", "cuda", "xpu"), is_skip=True
+    ),
     "test_kwargs_dynamic_shapes": TestFailure(("cpu",)),
     # PDL tests are CUDA SM90+ only, skip on CPU
     "test_pdl_mutation_dynamic_shapes": TestFailure(("cpu",), is_skip=True),

--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -61,7 +61,7 @@ importlib.import_module("filelock")
 test_failures = {
     # torch.func.jvp with nn.Module doesn't retrace with symbolic sizes
     "test_jvp_compile_backward_dynamic_shapes": TestFailure(
-        ("cpu", "cuda", "xpu"), is_skip=True
+        ("cpu", "cuda", "xpu", "mps"), is_skip=True
     ),
     "test_kwargs_dynamic_shapes": TestFailure(("cpu",)),
     # PDL tests are CUDA SM90+ only, skip on CPU

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -4139,7 +4139,6 @@ def full(size, fill_value, **kwargs):
 
 @register_lowering(aten._efficientzerotensor)
 def _efficientzerotensor(size, **kwargs):
-    kwargs.setdefault("dtype", torch.get_default_dtype())
     return tensor_constructor(0)(size, **kwargs)
 
 

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -3499,8 +3499,6 @@ make_fallback(aten.masked_scatter_backward)
 make_fallback(aten.view_as_complex, require_contiguous)
 make_fallback(aten.angle)  # needs complex
 
-# Needs efficentzerotensor
-make_fallback(aten._efficientzerotensor)
 
 # Needs Sparse
 make_fallback(aten._sparse_coo_tensor_with_dims_and_tensors)
@@ -4137,6 +4135,12 @@ def copy_strided(x, stride):
 def full(size, fill_value, **kwargs):
     assert kwargs.get("dtype") is not None, "dtype should be handled by decomposition"
     return tensor_constructor(fill_value)(size, **kwargs)
+
+
+@register_lowering(aten._efficientzerotensor)
+def _efficientzerotensor(size, **kwargs):
+    kwargs.setdefault("dtype", torch.get_default_dtype())
+    return tensor_constructor(0)(size, **kwargs)
 
 
 @register_lowering(aten.gather, type_promotion_kind=None)


### PR DESCRIPTION
Fixes #177261 

In eager mode, efficient zero tensor helps eliminate allocating storage for a zeros tensor if any consumer op doesn't need to read/write to the zeros tensor to compute the result. This is done via a torch dispatch key. `torch.compile` doesn't go through the same code path when tracing autograd graphs triggering IMA if an op tries to read/write to the storage of an efficient zero tensor (which is NULL). Fix the bug by creating a real storage at runtime whenever an efficient zeros tensor is present in the FX graph.

AI help used: Claude Code 4.6

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo