### PR TITLE
[windows_ci] Adjust Windows test blocklist for SM89 and SM120

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1832,6 +1832,8 @@ def get_selected_tests(options) -> list[str]:
                     # Output mismatch errors and long running tests
                     "test_linalg",
                     "test_matmul_cuda",
+                    "functorch/test_ops",
+                    "test_scaled_matmul_cuda",
                 ]
             )
 
@@ -1840,11 +1842,6 @@ def get_selected_tests(options) -> list[str]:
         if SM120OrLater:
             WINDOWS_BLOCKLIST.extend(
                 [
-                    # Windows fatal exception / access violation
-                    "test_fake_tensor",
-                    "test_cpp_extensions_jit",
-                    # TDR, BSOD observed
-                    "functorch/test_ops",
                     # test_api fails on Windows SM120+. Triage pending.
                     "cpp/test_api",
                 ]


### PR DESCRIPTION
- **SM89+**: add `functorch/test_ops` and `test_scaled_matmul_cuda` to the blocklist - failing on windows
- **SM120+**: Remove `test_fake_tensor`, `test_cpp_extensions_jit`. These tests are now fixed on windows.
