### PR TITLE
Add more vllm tests (compile/, quantization/test_torchao, standalone_tests)

### DIFF
--- a/.ci/lumen_cli/cli/lib/core/vllm/vllm_test_library.yaml
+++ b/.ci/lumen_cli/cli/lib/core/vllm/vllm_test_library.yaml
@@ -54,15 +54,6 @@ vllm_lora_tp_test_distributed:
     - HF_DATASETS_OFFLINE=0 TRANSFORMERS_OFFLINE=0 pytest -v -s -x lora/test_llama_tp.py -k test_tp2_serialize_and_deserialize_lora
     - pytest -v -s -x lora/test_llm_with_multi_loras.py
 
-vllm_distributed_test_28_failure_test:
-  title: Distributed Tests (2 GPUs) pytorch 2.8 release failure
-  id: vllm_distributed_test_28_failure_test
-  env_vars:
-    VLLM_WORKER_MULTIPROC_METHOD: spawn
-  num_gpus: 4
-  steps:
-    - pytest -v -s compile/correctness_e2e/test_sequence_parallel.py
-
 vllm_lora_28_failure_test:
   title: LoRA pytorch 2.8 failure test
   id: vllm_lora_28_failure_test
@@ -91,18 +82,36 @@ vllm_multi_model_test_28_failure_test:
     - HF_DATASETS_OFFLINE=0 TRANSFORMERS_OFFLINE=0 pytest -v -s models/multimodal/generation/test_voxtral.py
     - pytest -v -s models/multimodal/pooling
 
-vllm_pytorch_compilation_unit_tests:
-  title: PyTorch Compilation Unit Tests
-  id: vllm_pytorch_compilation_unit_tests
+vllm_compile_test:
+  title: Compile Tests
+  id: vllm_compile_test
   steps:
-    - pytest -v -s compile/passes/test_pass_manager.py
-    - pytest -v -s compile/passes/test_fusion.py
-    - pytest -v -s compile/passes/test_fusion_attn.py
-    - pytest -v -s compile/passes/test_silu_mul_quant_fusion.py
-    - pytest -v -s compile/passes/distributed/test_sequence_parallelism.py
-    - pytest -v -s compile/passes/distributed/test_async_tp.py
-    - pytest -v -s compile/passes/distributed/test_fusion_all_reduce.py
-    - pytest -v -s compile/test_decorator.py
+    - pytest -v -s compile/ --ignore compile/correctness_e2e --ignore compile/fusions_e2e --ignore compile/passes/distributed
+
+vllm_compile_distributed_test:
+  title: Compile Distributed Tests
+  id: vllm_compile_distributed_test
+  env_vars:
+    VLLM_WORKER_MULTIPROC_METHOD: spawn
+    VLLM_TEST_CLEAN_GPU_MEMORY: "1"
+  num_gpus: 4
+  steps:
+    - pytest -v -s compile/correctness_e2e/test_sequence_parallel.py
+    - pytest -v -s compile/correctness_e2e/test_async_tp.py
+    - pytest -v -s compile/passes/distributed
+    - pytest -v -s compile/fusions_e2e
+
+vllm_standalone_test:
+  title: Standalone Tests
+  id: vllm_standalone_test
+  steps:
+    - python standalone_tests/lazy_imports.py
+
+vllm_quantization_torchao_test:
+  title: Quantization TorchAO Test
+  id: vllm_quantization_torchao_test
+  steps:
+    - VLLM_TEST_FORCE_LOAD_FORMAT=auto pytest -v -s quantization/test_torchao.py
 
 vllm_language_model_test_extended_generation_28_failure_test:
   title: Language Models Test (Extended Generation) 2.8 release failure
@@ -112,15 +121,6 @@ vllm_language_model_test_extended_generation_28_failure_test:
     - git+https://github.com/Dao-AILab/causal-conv1d@v1.6.0
   steps:
     - pytest -v -s models/language/generation/test_mistral.py
-
-vllm_distributed_test_2_gpu_28_failure_test:
-  title: Distributed Tests (2 GPUs) pytorch 2.8 release failure
-  id: vllm_distributed_test_2_gpu_28_failure_test
-  env_vars:
-    VLLM_WORKER_MULTIPROC_METHOD: spawn
-  num_gpus: 4
-  steps:
-    - pytest -v -s compile/correctness_e2e/test_sequence_parallel.py
 
 vllm_lora_test:
   title: LoRA Test %N

--- a/.github/workflows/vllm.yml
+++ b/.github/workflows/vllm.yml
@@ -26,7 +26,7 @@ jobs:
     with:
       # When building vLLM, uv doesn't like that we rename wheel without changing the wheel metadata
       allow-reuse-old-whl: false
-      build-additional-packages: "vision audio"
+      build-additional-packages: "vision audio torchao"
       build-external-packages: "vllm"
       build-environment: linux-jammy-cuda13.0-py3.12-gcc11
       docker-image-name: ci-image:pytorch-linux-jammy-cuda13.0-cudnn9-py3.12-gcc11-vllm
@@ -39,18 +39,19 @@ jobs:
           { config: "vllm_entrypoints_test", shard: 1, num_shards: 1,runner: "linux.g6.4xlarge.experimental.nvidia.gpu" },
           { config: "vllm_regression_test", shard: 1, num_shards: 1, runner: "linux.g6.4xlarge.experimental.nvidia.gpu" },
           { config: "vllm_multi_model_processor_test", shard: 1, num_shards: 1, runner: "linux.g6.4xlarge.experimental.nvidia.gpu" },
-          { config: "vllm_pytorch_compilation_unit_tests", shard: 1, num_shards: 1, runner: "linux.g6.4xlarge.experimental.nvidia.gpu" },
-          { config: "vllm_pytorch_compilation_unit_tests", shard: 1, num_shards: 1, runner: "linux.dgx.b200" },
+          { config: "vllm_compile_test", shard: 1, num_shards: 1, runner: "linux.g6.4xlarge.experimental.nvidia.gpu" },
+          { config: "vllm_compile_distributed_test", shard: 1, num_shards: 1, runner: "linux.dgx.b200.8" },
+          { config: "vllm_compile_distributed_test", shard: 1, num_shards: 1, runner: "linux.aws.h100.4" },
+          { config: "vllm_standalone_test", shard: 1, num_shards: 1, runner: "linux.g6.4xlarge.experimental.nvidia.gpu" },
+          { config: "vllm_quantization_torchao_test", shard: 1, num_shards: 1, runner: "linux.g6.4xlarge.experimental.nvidia.gpu" },
           { config: "vllm_lora_28_failure_test", shard: 1, num_shards: 1, runner: "linux.g6.4xlarge.experimental.nvidia.gpu" },
           { config: "vllm_multi_model_test_28_failure_test", shard: 1, num_shards: 1, runner: "linux.g6.4xlarge.experimental.nvidia.gpu"},
           { config: "vllm_language_model_test_extended_generation_28_failure_test", shard: 1, num_shards: 1, runner: "linux.g6.4xlarge.experimental.nvidia.gpu"},
-          { config: "vllm_distributed_test_2_gpu_28_failure_test", shard: 1, num_shards: 1, runner: "linux.g6.4xlarge.experimental.nvidia.gpu" },
           { config: "vllm_lora_test", shard: 0, num_shards: 4, runner: "linux.g6.4xlarge.experimental.nvidia.gpu" },
           { config: "vllm_lora_test", shard: 1, num_shards: 4, runner: "linux.g6.4xlarge.experimental.nvidia.gpu" },
           { config: "vllm_lora_test", shard: 2, num_shards: 4,  runner: "linux.g6.4xlarge.experimental.nvidia.gpu" },
           { config: "vllm_lora_test", shard: 3, num_shards: 4,  runner: "linux.g6.4xlarge.experimental.nvidia.gpu" },
           { config: "vllm_lora_tp_test_distributed", shard: 1, num_shards: 1, runner: "linux.g6.12xlarge.nvidia.gpu"},
-          { config: "vllm_distributed_test_28_failure_test", shard: 1, num_shards: 1, runner: "linux.g6.12xlarge.nvidia.gpu"}
         ]}
     secrets: inherit
 


### PR DESCRIPTION
As a retro to the PyTorch 2.11 release, this PR expands the vllm x pytorch nightly test job to cover more of vllm's test suite.

New test plans added:
- `vllm_compile_test`: all single-GPU compile tests (L4)
- `vllm_compile_distributed_test`: multi-GPU compile tests including correctness_e2e, passes/distributed, and fusions_e2e (B200 + H100)
- `vllm_standalone_test`: lazy_imports.py to catch eager import regressions like #176581
- `vllm_quantization_torchao_test`: quantization/test_torchao.py, using pinned torchao built from source

Removed test plans that are now subsumed:
- `vllm_pytorch_compilation_unit_tests` (replaced by the broader vllm_compile_test + vllm_compile_distributed_test)
- `vllm_distributed_test_28_failure_test` and `vllm_distributed_test_2_gpu_28_failure_test` (both only ran compile/correctness_e2e/test_sequence_parallel.py, now covered by vllm_compile_distributed_test)

Hardware comparison with vllm's buildkite CI (compile.yaml):

| vllm test area                  | vllm CI hardware     | our CI hardware       |
|---------------------------------|----------------------|-----------------------|
| compile top-level tests         | default (L4)       | L4                    |
| correctness_e2e/seq_parallel    | default + H100       | B200 + H100           |
| correctness_e2e/async_tp        | H100 + B200          | B200 + H100           |
| passes/distributed              | H100                 | B200 + H100           |
| fusions_e2e                     | H100 + B200          | B200 + H100           |

Also adds `torchao` to `build-additional-packages` so it is built from the pinned commit in `.github/ci_commit_pins/torchao.txt`, matching the pattern used by inductor workflows.

Authored with Claude.