### PR TITLE
[torch.compile] Add torch.compiler.set_default_backend

### DIFF
--- a/docs/source/torch.compiler_api.md
+++ b/docs/source/torch.compiler_api.md
@@ -20,6 +20,8 @@ For a quick overview of `torch.compiler`, see {ref}`torch.compiler_overview`.
      assume_constant_result
      list_backends
      disable
+     set_default_backend
+     get_default_backend
      set_stance
      set_enable_guard_collectives
      cudagraph_mark_step_begin

--- a/test/dynamo/test_backends.py
+++ b/test/dynamo/test_backends.py
@@ -424,6 +424,46 @@ class TestCustomBackendAPI(torch._dynamo.test_case.TestCase):
         self.assertTrue(backend_run)
 
 
+class TestDefaultBackend(torch._dynamo.test_case.TestCase):
+    def test_set_default_backend(self):
+        self.addCleanup(torch.compiler.set_default_backend, None)
+
+        self.assertEqual(torch.compiler.get_default_backend(), "inductor")
+
+        torch.compiler.set_default_backend("eager")
+        self.assertEqual(torch.compiler.get_default_backend(), "eager")
+
+        torch.compiler.set_default_backend(None)
+        self.assertEqual(torch.compiler.get_default_backend(), "inductor")
+
+        cnt = torch._dynamo.testing.CompileCounter()
+        torch.compiler.set_default_backend(cnt)
+        self.assertIs(torch.compiler.get_default_backend(), cnt)
+
+        def f(x):
+            return torch.relu(x)
+
+        opt_f = torch.compile(f)
+        opt_f(torch.randn(3, 3))
+        self.assertEqual(cnt.frame_count, 1)
+
+    def test_set_default_backend_explicit_override(self):
+        self.addCleanup(torch.compiler.set_default_backend, None)
+
+        eager_and_record = torch._dynamo.testing.EagerAndRecordGraphs()
+        torch.compiler.set_default_backend(eager_and_record)
+
+        def f(x):
+            return torch.relu(x)
+
+        # Explicit backend= should override the default
+        cnt = torch._dynamo.testing.CompileCounter()
+        opt_f = torch.compile(f, backend=cnt)
+        opt_f(torch.randn(3, 3))
+        self.assertEqual(cnt.frame_count, 1)
+        self.assertEqual(len(eager_and_record.graphs), 0)
+
+
 devices = ["cpu", "cuda", "hpu", "xpu"]
 instantiate_device_type_tests(TestOptimizations, globals(), only_for=devices)
 

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -2602,7 +2602,7 @@ def compile(
     *,
     fullgraph: builtins.bool = False,
     dynamic: builtins.bool | None = None,
-    backend: str | _Callable = "inductor",
+    backend: str | _Callable | None = None,
     mode: str | None = None,
     options: dict[str, str | builtins.int | builtins.bool | _Callable] | None = None,
     name: str | None = None,
@@ -2722,6 +2722,11 @@ def compile(
             "torch.compile is not supported on Python < 3.13.3 built with GIL disabled. "
             "Please use Python 3.13.3+."
         )
+
+    if backend is None:
+        from torch._dynamo.backends.registry import get_default_backend
+
+        backend = get_default_backend()
 
     # Decorator mode
     if model is None:

--- a/torch/_dynamo/backends/registry.py
+++ b/torch/_dynamo/backends/registry.py
@@ -79,6 +79,7 @@ CompilerFn = Callable[[fx.GraphModule, list[torch.Tensor]], CompiledFn]
 
 _BACKENDS: dict[str, EntryPoint | None] = {}
 _COMPILER_FNS: dict[str, CompilerFn] = {}
+_default_backend: str | CompilerFn = "inductor"
 
 
 def register_backend(
@@ -204,3 +205,22 @@ def _is_registered_backend(compiler_fn: CompilerFn) -> bool:
         return compiler_fn.compiler_fn in _COMPILER_FNS.values()
 
     return False
+
+
+def set_default_backend(backend: str | CompilerFn | None) -> None:
+    """Set the default backend used by torch.compile when no backend is explicitly specified.
+
+    Pass None to reset to the default ("inductor").
+    """
+    global _default_backend
+    if backend is None:
+        _default_backend = "inductor"
+        return
+    if not isinstance(backend, str) and not callable(backend):
+        raise TypeError(f"backend must be a string or callable, got {type(backend)}")
+    _default_backend = backend
+
+
+def get_default_backend() -> str | CompilerFn:
+    """Return the current default backend for torch.compile."""
+    return _default_backend

--- a/torch/compiler/__init__.py
+++ b/torch/compiler/__init__.py
@@ -21,6 +21,8 @@ __all__ = [
     "substitute_in_graph",
     "list_backends",
     "disable",
+    "set_default_backend",
+    "get_default_backend",
     "set_stance",
     "set_enable_guard_collectives",
     "cudagraph_mark_step_begin",
@@ -256,6 +258,39 @@ def disable(fn=None, recursive=True, *, reason=None):
     import torch._dynamo
 
     return torch._dynamo.disable(fn, recursive, reason=reason)
+
+
+def set_default_backend(backend: str | Callable[..., Any] | None) -> None:
+    """Set the default backend for ``torch.compile`` when no ``backend`` argument is specified.
+
+    Passing ``None`` resets the default back to ``"inductor"``.
+
+    Args:
+        backend: A backend name (string), a callable backend, or ``None``.
+
+    Example::
+
+        >>> torch.compiler.set_default_backend("eager")
+        >>> torch.compiler.get_default_backend()
+        'eager'
+        >>> torch.compiler.set_default_backend(None)  # reset
+        >>> torch.compiler.get_default_backend()
+        'inductor'
+    """
+    from torch._dynamo.backends.registry import set_default_backend
+
+    set_default_backend(backend)
+
+
+def get_default_backend() -> str | Callable[..., Any]:
+    """Return the current default backend for ``torch.compile``.
+
+    Returns:
+        The current default backend (string or callable). Initially ``"inductor"``.
+    """
+    from torch._dynamo.backends.registry import get_default_backend
+
+    return get_default_backend()
 
 
 def set_stance(


### PR DESCRIPTION
Addresses https://github.com/pytorch/pytorch/issues/178930

Allow overriding the default torch.compile backend globally so that out-of-tree backend authors don't need to pass `backend=` at every call site. Follows the same pattern as `torch.set_default_dtype` and `torch.set_default_device`. Explicit `backend= arguments to torch.compile still take precedence.

Usage:

```python
import torch

torch.compiler.set_default_backend("my_custom_backend")
compiled_model = torch.compile(model)  # uses "my_custom_backend"

torch.compiler.set_default_backend(None)
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98 @mlazos