### PR TITLE
[MHA Backward] Disable ASM v3 backward for head dim > 192 to fall back to CK tile (#178946)

### DIFF
--- a/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_bwd_ck.hip
+++ b/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_bwd_ck.hip
@@ -127,7 +127,7 @@ aiter::mha_bwd_args get_ck_fmha_bwd_args(const mask_info &mask,
     return aiter::mha_bwd_args{
         // aiter args
         static_cast<int>(mask.type),
-        true,   // use_asm_v3
+        hdim <= 192,   // use_asm_v3: ASM v3 only supports head dim <= 192
         true,   // v3_atomic_fp32
         1,      // v3_bf16_cvt
         false,  // v3_api_check


### PR DESCRIPTION
Summary:

Training jobs with head dimensions greater than 192 crash with assert(false) in the auto-generated mha_bwd.hip codegen, since the ASM v3 backward kernels only support head dims up to 192. Instead of modifying the codegen output, this sets use_asm_v3 = false on the caller side when hdim > 192, so mha_bwd skips the ASM v3 path and falls back to the CK tile-based fmha_bwd.

Test Plan:
Failed Job: https://www.internalfb.com/mlhub/pipelines/runs/mast/aps-him_echen40_mi350_20260326-19a329b3b0
Running Job: https://www.internalfb.com/mlhub/pipelines/runs/mast/aps-him_echen40_mi350_20260331-cab82272f4

Reviewed By: haoyuz, yinbinm

Differential Revision: D98824096
