### PR TITLE
[dynamo] Implement tp_as_number->nb_or slot

### DIFF
--- a/torch/_dynamo/variables/base.py
+++ b/torch/_dynamo/variables/base.py
@@ -569,6 +569,10 @@ class VariableTracker(metaclass=VariableTrackerMeta):
             return self.nb_index_impl(tx)
         elif name == "__int__" and not args and not kwargs:
             return self.nb_int_impl(tx)
+        elif name == "__or__" and len(args) == 1 and not kwargs:
+            return self.nb_or_impl(tx, args[0])
+        elif name == "__ior__" and len(args) == 1 and not kwargs:
+            return self.nb_ior_impl(tx, args[0])
         elif name in cmp_name_to_op_mapping and len(args) == 1 and not kwargs:
             other = args[0]
             if not isinstance(self, type(other)) and not (
@@ -959,6 +963,22 @@ class VariableTracker(metaclass=VariableTrackerMeta):
                 f"int() argument must be a string, a bytes-like object or a real number, not '{self.python_type_name()}'"
             ],
         )
+
+    def nb_or_impl(
+        self,
+        tx: Any,
+        other: "VariableTracker",
+    ) -> "VariableTracker":
+        """tp_as_number->nb_or slot. Default: returns NotImplemented."""
+        return variables.ConstantVariable.create(NotImplemented)
+
+    def nb_ior_impl(
+        self,
+        tx: Any,
+        other: "VariableTracker",
+    ) -> "VariableTracker":
+        """tp_as_number->nb_inplace_or slot. Default: returns NotImplemented."""
+        return variables.ConstantVariable.create(NotImplemented)
 
     def __init__(
         self,

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -3215,80 +3215,18 @@ class BuiltinVariable(VariableTracker):
     def call_or_(
         self, tx: "InstructionTranslator", a: VariableTracker, b: VariableTracker
     ) -> VariableTracker | None:
-        # Rely on constant_handler
-        if isinstance(a, ConstantVariable) and isinstance(b, ConstantVariable):
-            return None
+        # TensorVariable | is handled by the can_insert_in_graph fast path
+        # in _make_handler before we get here.
+        from .object_protocol import binary_op
 
-        # Constant fold or_ for class/type variables (e.g. Shard | _StridedShard
-        # producing a types.UnionType for isinstance checks). This handles cases
-        # like OpaqueObjectClassVariable where is_python_constant() returns False
-        # but as_python_constant() works.
-        try:
-            a_const = a.as_python_constant()
-            b_const = b.as_python_constant()
-            if isinstance(a_const, type) and isinstance(b_const, type):
-                return VariableTracker.build(tx, a_const | b_const)
-        except NotImplementedError:
-            pass
-
-        if a.is_symnode_like() and b.is_symnode_like():
-            return SymNodeVariable.create(
-                tx,
-                tx.output.create_proxy(
-                    "call_function", operator.or_, *proxy_args_kwargs([a, b], {})
-                ),
-                sym_num=None,
-            )
-
-        # This call looks like `{"one": torch.ones(1)} | {"two": torch.ones(2)}`.
-        if isinstance(
-            a,
-            (
-                ConstDictVariable,
-                DictKeysVariable,
-                MutableMappingVariable,
-                SetVariable,
-                UserDefinedDictVariable,
-                UserDefinedObjectVariable,
-            ),
-        ):
-            # TODO(guilhermeleobas): forward the call to b.__ror__(a) if
-            # a.__ror__(b) returns NotImplemented
-            return a.call_method(tx, "__or__", [b], {})
-
-        # None no-ops this handler and lets the driving function proceed
-        return None
+        return binary_op(tx, a, b, "nb_or", "|")
 
     def call_ior(
         self, tx: "InstructionTranslator", a: VariableTracker, b: VariableTracker
     ) -> VariableTracker | None:
-        # Rely on constant_handler
-        if isinstance(a, ConstantVariable) and isinstance(b, ConstantVariable):
-            return None
-        if a.is_symnode_like() and b.is_symnode_like():
-            return SymNodeVariable.create(
-                tx,
-                tx.output.create_proxy(
-                    "call_function", operator.ior, *proxy_args_kwargs([a, b], {})
-                ),
-                sym_num=None,
-            )
+        from .object_protocol import binary_iop
 
-        # This call looks like `{"one": torch.ones(1)} |= {"two": torch.ones(2)}`.
-        if isinstance(
-            a,
-            (
-                ConstDictVariable,
-                DictKeysVariable,
-                MutableMappingVariable,
-                SetVariable,
-                UserDefinedObjectVariable,
-            ),
-        ):
-            return a.call_method(tx, "__ior__", [b], {})
-
-        # None no-ops this handler and lets the driving function proceed
-        return None
+        return binary_iop(tx, a, b, "nb_ior", "nb_or", "|=")
 
     def call_not_(
         self, tx: "InstructionTranslator", a: VariableTracker

--- a/torch/_dynamo/variables/constant.py
+++ b/torch/_dynamo/variables/constant.py
@@ -405,6 +405,23 @@ its type to `common_constant_types`.
             return ConstantVariable.create(int(self.value))
         return super().nb_int_impl(tx)
 
+    def nb_or_impl(
+        self,
+        tx: Any,
+        other: "VariableTracker",
+    ) -> "VariableTracker":
+        # CPython: int, bool, frozenset, and type all define nb_or.
+        # For type objects, nb_or implements _Py_union_type_or (type unions).
+        if not isinstance(self.value, (int, bool, frozenset, type)):
+            return ConstantVariable.create(NotImplemented)
+        if not other.is_python_constant():
+            return ConstantVariable.create(NotImplemented)
+        other_val = other.as_python_constant()
+        result = type(self.value).__or__(self.value, other_val)
+        if result is NotImplemented:
+            return ConstantVariable.create(NotImplemented)
+        return VariableTracker.build(tx, result)
+
 
 CONSTANT_VARIABLE_NONE = ConstantVariable(None)
 CONSTANT_VARIABLE_TRUE = ConstantVariable(True)

--- a/torch/_dynamo/variables/dicts.py
+++ b/torch/_dynamo/variables/dicts.py
@@ -600,6 +600,54 @@ class ConstDictVariable(VariableTracker):
             else:
                 self.install_dict_keys_match_guard()
 
+    def nb_or_impl(
+        self,
+        tx: "InstructionTranslator",
+        other: VariableTracker,
+    ) -> VariableTracker:
+        if not istype(
+            other,
+            (
+                ConstDictVariable,
+                variables.UserDefinedDictVariable,
+                variables.DefaultDictVariable,
+            ),
+        ):
+            return VariableTracker.build(tx, NotImplemented)
+
+        # Always return the specialized dictionary, and in the case
+        # both are specialized, take the first to be the type of the
+        # new dictionary
+        if self.user_cls is not dict:
+            user_cls = self.user_cls
+            to_cpy = self
+        else:
+            assert isinstance(other, ConstDictVariable)
+            user_cls = other.user_cls
+            to_cpy = other
+
+        to_cpy.install_dict_keys_match_guard()
+        new_dict_vt = to_cpy.clone(
+            items=self.items.copy(),
+            mutation_type=ValueMutationNew(),
+            source=None,
+            user_cls=user_cls,
+        )
+
+        other.install_dict_keys_match_guard()  # type: ignore[attr-defined]
+        new_dict_vt.items.update(other.items)  # type: ignore[attr-defined]
+        return new_dict_vt
+
+    def nb_ior_impl(
+        self,
+        tx: "InstructionTranslator",
+        other: VariableTracker,
+    ) -> VariableTracker:
+        # CPython's dict.__ior__ delegates to dict.update, which accepts
+        # dicts, iterables of key-value pairs, etc.
+        self.call_method(tx, "update", [other], {})
+        return self
+
     def call_method(
         self,
         tx: "InstructionTranslator",
@@ -898,72 +946,6 @@ class ConstDictVariable(VariableTracker):
                 tx,
                 not self.call_method(tx, "__eq__", args, kwargs).value,  # type: ignore[attr-defined]
             )
-        elif name == "__or__":
-            if len(args) != 1:
-                raise_args_mismatch(tx, name, "1 args", f"{len(args)} args")
-            other = args[0]
-
-            # Method resolution for binops works as follow (using __or__ as example):
-            # (1) dict.__or__(dict) => dict
-            # (2) dict.__or__(subclass): return NotImplemented
-            # (3) Check if subclass implements __ror__ => forward the call
-            # to subclass.__ror__(dict)
-
-            # Let's not forward the call to __ror__ yet because __ror__ can be
-            # implemented in C (i.e. OrderedDict subclass) which Dynamo cannot
-            # trace
-            # if istype(other, variables.UserDefinedDictVariable):
-            #     if other.call_obj_hasattr(tx, "__ror__").value:
-            #         return other.call_method(tx, "__ror__", [self], kwargs)
-
-            # The three dict types Dynamo can handle are dict, OrderedDict and
-            # defaultdict.
-
-            # TODO(guilhermeleobas): this check should be on builtin.py::call_or_
-            if istype(
-                other,
-                (
-                    ConstDictVariable,
-                    variables.UserDefinedDictVariable,
-                    variables.DefaultDictVariable,
-                ),
-            ):
-                # Always return the specialized dictionary, and in the case
-                # both are specialized, take the first to be the type of the
-                # new dictionary
-                if self.user_cls is not dict:
-                    user_cls = self.user_cls
-                    to_cpy = self
-                else:
-                    assert isinstance(other, ConstDictVariable)
-                    user_cls = other.user_cls
-                    to_cpy = other
-
-                to_cpy.install_dict_keys_match_guard()
-                new_dict_vt = to_cpy.clone(
-                    items=self.items.copy(),
-                    mutation_type=ValueMutationNew(),
-                    source=None,
-                    user_cls=user_cls,
-                )
-
-                # NB - Guard on all the keys of the other dict to ensure
-                # correctness.
-                args[0].install_dict_keys_match_guard()  # type: ignore[attr-defined]
-                new_dict_vt.items.update(args[0].items)  # type: ignore[attr-defined]
-                return new_dict_vt
-            else:
-                raise_observed_exception(
-                    TypeError,
-                    tx,
-                    args=[
-                        f"unsupported operand type(s) for |: '{self.python_type().__name__}'"
-                        f"and '{other.python_type().__name__}'"
-                    ],
-                )
-        elif name == "__ior__":
-            self.call_method(tx, "update", args, kwargs)
-            return self
         elif name == "__iter__":
             from .lists import ListIteratorVariable
 
@@ -1309,6 +1291,25 @@ class SetVariable(ConstDictVariable):
             raise_observed_exception(type(exc), tx, args=list(exc.args))
         return VariableTracker.build(tx, res)
 
+    def nb_or_impl(
+        self,
+        tx: "InstructionTranslator",
+        other: VariableTracker,
+    ) -> VariableTracker:
+        if not isinstance(other, (SetVariable, variables.UserDefinedSetVariable)):
+            return VariableTracker.build(tx, NotImplemented)
+        return self.call_method(tx, "union", [other], {})
+
+    def nb_ior_impl(
+        self,
+        tx: "InstructionTranslator",
+        other: VariableTracker,
+    ) -> VariableTracker:
+        if not isinstance(other, (SetVariable, variables.UserDefinedSetVariable)):
+            return VariableTracker.build(tx, NotImplemented)
+        self.call_method(tx, "update", [other], {})
+        return self
+
     def call_method(
         self,
         tx: "InstructionTranslator",
@@ -1488,10 +1489,9 @@ class SetVariable(ConstDictVariable):
             return SourcelessBuilder.create(tx, op.get(name)).call_function(
                 tx, [self, other], {}
             )
-        elif name in ("__and__", "__or__", "__xor__", "__sub__"):
+        elif name in ("__and__", "__xor__", "__sub__"):
             m = {
                 "__and__": "intersection",
-                "__or__": "union",
                 "__xor__": "symmetric_difference",
                 "__sub__": "difference",
             }.get(name)
@@ -1505,7 +1505,7 @@ class SetVariable(ConstDictVariable):
                 )
             assert m is not None
             return self.call_method(tx, m, args, kwargs)
-        elif name in ("__iand__", "__ior__", "__ixor__", "__isub__"):
+        elif name in ("__iand__", "__ixor__", "__isub__"):
             if not isinstance(args[0], (SetVariable, variables.UserDefinedSetVariable)):
                 raise_observed_exception(
                     TypeError,
@@ -1516,7 +1516,6 @@ class SetVariable(ConstDictVariable):
                 )
             m = {
                 "__iand__": "intersection_update",
-                "__ior__": "update",
                 "__ixor__": "symmetric_difference_update",
                 "__isub__": "difference_update",
             }.get(name)
@@ -1872,6 +1871,16 @@ class DictKeysVariable(DictViewVariable):
                 items.append(key_str)
             return "dict_keys([" + ",".join(items) + "])"
 
+    def nb_or_impl(
+        self,
+        tx: "InstructionTranslator",
+        other: VariableTracker,
+    ) -> VariableTracker:
+        if not hasattr(other, "set_items"):
+            return VariableTracker.build(tx, NotImplemented)
+        r = self.set_items | other.set_items
+        return SetVariable(r)
+
     def call_method(
         self,
         tx: "InstructionTranslator",
@@ -1884,8 +1893,6 @@ class DictKeysVariable(DictViewVariable):
         elif name in (
             "__and__",
             "__iand__",
-            "__or__",
-            "__ior__",
             "__sub__",
             "__isub__",
             "__xor__",

--- a/torch/_dynamo/variables/object_protocol.py
+++ b/torch/_dynamo/variables/object_protocol.py
@@ -1,11 +1,12 @@
 """
 Dynamo implementations of CPython's PyObject_* default slot algorithms.
 
-Analogous to CPython's Objects/object.c, this module holds the general
-comparison dispatch machinery that is independent of any specific type.
-Per-type richcompare_impl hooks live in their respective VT files.
+Analogous to CPython's Objects/object.c and abstract.c, this module holds
+the general comparison and binary-op dispatch machinery that is independent
+of any specific type. Per-type slot hooks live in their respective VT files.
 """
 
+from ..exc import raise_observed_exception
 from ..utils import istype
 from .base import NO_SUCH_SUBOBJ, VariableTracker
 from .constant import CONSTANT_VARIABLE_FALSE, CONSTANT_VARIABLE_TRUE
@@ -63,3 +64,100 @@ def vt_identity_compare(
         return CONSTANT_VARIABLE_FALSE
 
     return None
+
+
+# ---------------------------------------------------------------------------
+# Binary-op dispatch (CPython's abstract.c: binary_op1 / binary_op)
+# ---------------------------------------------------------------------------
+
+
+def is_nb_not_implemented(result: VariableTracker) -> bool:
+    return result.is_constant_match(NotImplemented)
+
+
+def binary_op1(
+    tx: "InstructionTranslator",  # noqa: F821
+    v: VariableTracker,
+    w: VariableTracker,
+    slot_name: str,
+) -> VariableTracker:
+    """CPython's binary_op1: try v's slot, then w's slot (with subclass priority).
+
+    Each VT that participates provides a ``<slot_name>_impl(self, tx, other)``
+    method where *self* is the slot owner and *other* is the second operand.
+    The generic algorithm calls ``v.<slot>_impl(tx, w)`` for the left slot
+    and ``w.<slot>_impl(tx, v)`` for the right slot (reversed args, matching
+    CPython's ``slotw(v, w)`` / ``slotv(v, w)`` pattern — for the types we
+    support the slots check both operands symmetrically so the result is the
+    same).
+    """
+    impl_attr = f"{slot_name}_impl"
+    v_slot = getattr(type(v), impl_attr, None)
+    w_slot = getattr(type(w), impl_attr, None)
+
+    # Same class → only call once (CPython: slotw = NULL if same type)
+    if type(v) is type(w):
+        w_slot = None
+    # Same implementation (inherited) → skip w
+    elif v_slot is w_slot:
+        w_slot = None
+
+    if v_slot is not None:
+        result = v_slot(v, tx, w)
+        if not is_nb_not_implemented(result):
+            return result
+    if w_slot is not None:
+        result = w_slot(w, tx, v)
+        if not is_nb_not_implemented(result):
+            return result
+    from .constant import ConstantVariable
+
+    return ConstantVariable.create(NotImplemented)
+
+
+def binary_op(
+    tx: "InstructionTranslator",  # noqa: F821
+    v: VariableTracker,
+    w: VariableTracker,
+    slot_name: str,
+    op_symbol: str,
+) -> VariableTracker:
+    """CPython's binary_op: binary_op1 + TypeError fallback."""
+    result = binary_op1(tx, v, w, slot_name)
+    if is_nb_not_implemented(result):
+        raise_observed_exception(
+            TypeError,
+            tx,
+            args=[
+                f"unsupported operand type(s) for {op_symbol}: "
+                f"'{v.python_type_name()}' and '{w.python_type_name()}'"
+            ],
+        )
+    return result
+
+
+def binary_iop(
+    tx: "InstructionTranslator",  # noqa: F821
+    v: VariableTracker,
+    w: VariableTracker,
+    islot_name: str,
+    slot_name: str,
+    op_symbol: str,
+) -> VariableTracker:
+    """CPython's binary_iop: try inplace slot, fallback to binary_op1."""
+    islot_impl = getattr(type(v), f"{islot_name}_impl", None)
+    if islot_impl is not None:
+        result = islot_impl(v, tx, w)
+        if not is_nb_not_implemented(result):
+            return result
+    result = binary_op1(tx, v, w, slot_name)
+    if is_nb_not_implemented(result):
+        raise_observed_exception(
+            TypeError,
+            tx,
+            args=[
+                f"unsupported operand type(s) for {op_symbol}: "
+                f"'{v.python_type_name()}' and '{w.python_type_name()}'"
+            ],
+        )
+    return result

--- a/torch/_dynamo/variables/script_object.py
+++ b/torch/_dynamo/variables/script_object.py
@@ -107,6 +107,20 @@ class OpaqueObjectClassVariable(UserDefinedVariable):
     def get_python_hash(self) -> int:
         return hash(self.value)
 
+    def nb_or_impl(
+        self,
+        tx: "InstructionTranslator",
+        other: "VariableTracker",
+    ) -> "VariableTracker":
+        try:
+            other_val = other.as_python_constant()
+        except NotImplementedError:
+            return VariableTracker.build(tx, NotImplemented)
+        result = type(self.value).__or__(self.value, other_val)
+        if result is NotImplemented:
+            return VariableTracker.build(tx, NotImplemented)
+        return VariableTracker.build(tx, result)
+
     def as_proxy(self) -> Any:
         return self.value
 

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -2203,6 +2203,21 @@ class SymNodeVariable(VariableTracker):
     ) -> VariableTracker:
         return self.nb_int_impl(tx)
 
+    def nb_or_impl(
+        self,
+        tx: "InstructionTranslator",
+        other: VariableTracker,
+    ) -> VariableTracker:
+        if not other.is_symnode_like():
+            return VariableTracker.build(tx, NotImplemented)
+        return SymNodeVariable.create(
+            tx,
+            tx.output.create_proxy(
+                "call_function", operator.or_, *proxy_args_kwargs([self, other], {})
+            ),
+            sym_num=None,
+        )
+
     def is_python_hashable(self) -> bool:
         return True
 

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -296,6 +296,21 @@ class UserDefinedClassVariable(UserDefinedVariable):
     def can_constant_fold_through(self) -> bool:
         return self.value in self._constant_fold_classes()
 
+    def nb_or_impl(
+        self,
+        tx: "InstructionTranslator",
+        other: VariableTracker,
+    ) -> VariableTracker:
+        # CPython's type.__or__ implements _Py_union_type_or (type unions).
+        try:
+            other_val = other.as_python_constant()
+        except NotImplementedError:
+            return VariableTracker.build(tx, NotImplemented)
+        result = type(self.value).__or__(self.value, other_val)
+        if result is NotImplemented:
+            return VariableTracker.build(tx, NotImplemented)
+        return VariableTracker.build(tx, result)
+
     def var_getattr(self, tx: "InstructionTranslator", name: str) -> VariableTracker:
         from . import ConstantVariable
 
@@ -1390,6 +1405,24 @@ class UserDefinedObjectVariable(UserDefinedVariable):
             random.uniform,
         }
         return fns
+
+    def nb_or_impl(
+        self,
+        tx: "InstructionTranslator",
+        other: VariableTracker,
+    ) -> VariableTracker:
+        method = self._maybe_get_baseclass_method("__or__")
+        if method is not None and isinstance(method, types.FunctionType):
+            from . import UserMethodVariable
+
+            source = self.source
+            source_fn = None
+            if source:
+                source_fn = self.get_source_by_walking_mro(tx, "__or__")
+            return UserMethodVariable(
+                method, self, source_fn=source_fn, source=source
+            ).call_function(tx, [other], {})
+        return VariableTracker.build(tx, NotImplemented)
 
     def call_method(
         self,
@@ -2838,6 +2871,20 @@ class UserDefinedDictVariable(UserDefinedObjectVariable):
             self._dict_vt = dict_vt
         self._dict_methods = dict_methods
 
+    def nb_or_impl(
+        self,
+        tx: "InstructionTranslator",
+        other: VariableTracker,
+    ) -> VariableTracker:
+        return self._dict_vt.nb_or_impl(tx, other)
+
+    def nb_ior_impl(
+        self,
+        tx: "InstructionTranslator",
+        other: VariableTracker,
+    ) -> VariableTracker:
+        return self._dict_vt.nb_ior_impl(tx, other)
+
     def call_method(
         self,
         tx: "InstructionTranslator",
@@ -2934,6 +2981,20 @@ class UserDefinedSetVariable(UserDefinedObjectVariable):
                 )
         else:
             self._set_vt = set_vt
+
+    def nb_or_impl(
+        self,
+        tx: "InstructionTranslator",
+        other: VariableTracker,
+    ) -> VariableTracker:
+        return self._set_vt.nb_or_impl(tx, other)
+
+    def nb_ior_impl(
+        self,
+        tx: "InstructionTranslator",
+        other: VariableTracker,
+    ) -> VariableTracker:
+        return self._set_vt.nb_ior_impl(tx, other)
 
     def call_method(
         self,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #178948
* #178942
* #178931
* #178921

Replace the ad-hoc isinstance cascades in call_or_/call_ior with a generic
binary-op dispatch that mirrors CPython's binary_op1 algorithm. Each VT
subclass that supports | now provides an nb_or_impl (and nb_ior_impl for |=)
slot method, following the pattern established by nb_index_impl and nb_int_impl.

The generic infrastructure in object_protocol.py (binary_op1, binary_op,
binary_iop) handles forward/reverse dispatch and NotImplemented propagation.
Per-type slots are implemented on ConstantVariable (int/bool/frozenset/type),
SetVariable, ConstDictVariable, DictKeysVariable, SymNodeVariable,
UserDefinedClassVariable, UserDefinedObjectVariable, UserDefinedDictVariable,
UserDefinedSetVariable, and OpaqueObjectClassVariable.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98