### PR TITLE
Fix use after free in ensureCUDADeviceGuardSet

### DIFF
--- a/c10/core/impl/DeviceGuardImplInterface.cpp
+++ b/c10/core/impl/DeviceGuardImplInterface.cpp
@@ -21,11 +21,6 @@ DeviceGuardImplRegistrar::DeviceGuardImplRegistrar(
   registerDeviceGuard(type, impl);
 }
 
-namespace {
-thread_local std::unique_ptr<DeviceGuardImplInterface> tls_fake_device_guard =
-    nullptr;
-} // namespace
-
 void ensureCUDADeviceGuardSet() {
   constexpr auto cuda_idx = static_cast<std::size_t>(DeviceType::CUDA);
 
@@ -38,8 +33,8 @@ void ensureCUDADeviceGuardSet() {
     // In following cases, we override CUDA guard interface with a no-op
     // device guard. When p->deviceCount() == 0, cuda build is enabled, but no
     // cuda devices available.
-    tls_fake_device_guard = std::make_unique<FakeGuardImpl<DeviceType::CUDA>>();
-    device_guard_impl_registry[cuda_idx].store(tls_fake_device_guard.get());
+    static FakeGuardImpl<DeviceType::CUDA> fake_cuda_guard;
+    device_guard_impl_registry[cuda_idx].store(&fake_cuda_guard);
   }
 }
 

--- a/c10/test/core/DeviceGuard_test.cpp
+++ b/c10/test/core/DeviceGuard_test.cpp
@@ -1,7 +1,11 @@
 #include <gtest/gtest.h>
 
 #include <c10/core/DeviceGuard.h>
+#include <c10/core/impl/DeviceGuardImplInterface.h>
 #include <c10/core/impl/FakeGuardImpl.h>
+
+#include <thread>
+#include <vector>
 
 using namespace c10;
 using namespace c10::impl;
@@ -38,4 +42,76 @@ TEST(OptionalDeviceGuard, ResetDeviceDifferentDeviceType) {
   ASSERT_EQ(FakeGuardImpl<DeviceType::HIP>::getDeviceIndex(), 2);
   ASSERT_EQ(g.current_device(), Device(DeviceType::HIP, 2));
   ASSERT_EQ(g.original_device(), Device(DeviceType::HIP, 0));
+}
+
+// -- ensureCUDADeviceGuardSet -------------------------------------------
+
+// Regression test: ensureCUDADeviceGuardSet() used to store a thread-local
+// FakeGuardImpl* in the global device_guard_impl_registry.  When the owning
+// thread exited its TLS was freed, leaving a dangling pointer that the next
+// thread to call deviceCount() would dereference (segfault).
+//
+// The fix is a function-local static, which has program lifetime.  We verify
+// that the pointer in the registry is still valid (and returns the expected
+// deviceCount) after the threads that triggered guard installation have exited.
+TEST(EnsureCUDADeviceGuard, NoUseAfterFreeWhenThreadsExit) {
+  // Simulate "CUDA compiled, no devices visible": a guard that is non-null but
+  // returns deviceCount() == 0, which is the condition that triggers fake guard
+  // installation in ensureCUDADeviceGuardSet().
+  struct ZeroDeviceGuardImpl final : public DeviceGuardImplInterface {
+    DeviceType type() const override {
+      return DeviceType::CUDA;
+    }
+    Device exchangeDevice(Device d) const override {
+      return d;
+    }
+    Device getDevice() const override {
+      return Device(DeviceType::CUDA, 0);
+    }
+    void setDevice(Device) const override {}
+    void uncheckedSetDevice(Device) const noexcept override {}
+    Stream getStream(Device d) const noexcept override {
+      return Stream(Stream::UNSAFE, d, 0);
+    }
+    Stream exchangeStream(Stream s) const noexcept override {
+      return s;
+    }
+    DeviceIndex deviceCount() const noexcept override {
+      return 0;
+    }
+    void record(void**, const Stream&, const DeviceIndex, const EventFlag)
+        const override {}
+    void block(void*, const Stream&) const override {}
+    bool queryEvent(void*) const override {
+      return true;
+    }
+    void destroyEvent(void*, const DeviceIndex) const noexcept override {}
+  };
+
+  constexpr auto cuda_idx = static_cast<size_t>(DeviceType::CUDA);
+  const auto* saved = device_guard_impl_registry[cuda_idx].load();
+
+  static ZeroDeviceGuardImpl zero_impl;
+  device_guard_impl_registry[cuda_idx].store(&zero_impl);
+
+  // Phase 1: threads call ensureCUDADeviceGuardSet(), detect deviceCount()==0,
+  // and install a FakeGuardImpl in the global registry.
+  {
+    std::vector<std::thread> threads;
+    for (int i = 0; i < 4; i++) {
+      threads.emplace_back(ensureCUDADeviceGuardSet);
+    }
+    for (auto& t : threads) {
+      t.join();
+    }
+  }
+  // The threads' TLS is now destroyed.  With the old code the registry now
+  // holds a dangling pointer; with the fix it holds &fake_cuda_guard (static).
+
+  // Phase 2: the pointer must still be valid and return the expected count.
+  const auto* p = device_guard_impl_registry[cuda_idx].load();
+  ASSERT_NE(p, nullptr);
+  ASSERT_EQ(p->deviceCount(), kFakeGuardImplMaxDevices);
+
+  device_guard_impl_registry[cuda_idx].store(saved);
 }

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -10,6 +10,8 @@ import inspect
 import io
 import itertools
 import pickle
+import subprocess
+import sys
 import unittest
 import weakref
 from unittest.mock import patch
@@ -1257,6 +1259,57 @@ class FakeTensorTest(TestCase):
         self.assertEqual(out[0].dtype, eye.dtype)
         self.assertEqual(out[1].dtype, eye.dtype)
         self.assertEqual(out[2].dtype, eye.dtype)
+
+    @unittest.skipIf(not torch.cuda._is_compiled(), "requires CUDA-compiled PyTorch")
+    def test_fake_device_guard_no_use_after_free(self):
+        # Regression test: when CUDA is compiled but no devices are visible,
+        # FakeTensorMode installs a FakeGuardImpl into the global
+        # device_guard_impl_registry.  The impl must outlive all threads that
+        # use it; previously it was stored as a thread-local unique_ptr, so
+        # the pointer became dangling after the thread exited, causing a
+        # segfault when a later thread called deviceCount() on it.
+        #
+        # CUDA_VISIBLE_DEVICES must be set before torch is imported, so we
+        # run the repro in a subprocess.
+
+        script = """\
+import os
+os.environ["CUDA_VISIBLE_DEVICES"] = ""
+import threading
+import torch
+
+def f(x):
+    return x * x
+
+def run_compile():
+    g = torch.compile(f, backend="eager")
+    for i in range(10):
+        g(torch.randn(i))
+
+threads = [threading.Thread(target=run_compile) for _ in range(2)]
+for t in threads:
+    t.start()
+for t in threads:
+    t.join()
+
+torch._dynamo.reset()
+
+threads = [threading.Thread(target=run_compile) for _ in range(2)]
+for t in threads:
+    t.start()
+for t in threads:
+    t.join()
+"""
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            timeout=60,
+        )
+        self.assertEqual(
+            result.returncode,
+            0,
+            msg=f"subprocess failed:\n{result.stderr.decode()}",
+        )
 
 
 instantiate_parametrized_tests(FakeTensorTest)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #173568
* __->__ #178950

This was triggered by an internal test failure on https://github.com/pytorch/pytorch/pull/173568 (thanks to @williamwen42
for help debugging).  See https://gist.github.com/williamwen42/a31bee4f3175c0f540d4170c2dd7ceae for more context/detail

Authored with Claude.

Differential Revision: [D99142314](https://our.internmc.facebook.com/intern/diff/D99142314)