### PR TITLE
[xpu][fix] Fix DeviceOpOverrides registered incorrectly

### DIFF
--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -628,36 +628,26 @@ def register_device_op_overrides(
 
 
 def _initialize_device_op_overrides():
+    # Use a flag rather than checking device_op_overrides_dict, since external/test
+    # code may partially populate it before we are called.
     global _device_op_overrides_initialized
-
-    # Ensure one-time initialization of all device-specific overrides.
-    # This must NOT depend on the current state of `device_op_overrides_dict`,
-    # since external/test code may partially populate it and break lazy init.
     if _device_op_overrides_initialized:
         return
 
-    # Importing these modules has the side effect of registering their
-    # corresponding DeviceOpOverrides via `register_device_op_overrides`.
-    # We explicitly import all known backends here to guarantee complete
-    # and deterministic registration.
     from .cpu_device_op_overrides import CpuDeviceOpOverrides
-    from . import mps_device_op_overrides,  # noqa: F401
+    from . import mps_device_op_overrides  # noqa: F401
     from .cuda import device_op_overrides  # noqa: F401
     from .mtia import device_op_overrides as mtia_op_overrides  # noqa: F401
     from .xpu import device_op_overrides as xpu_op_overrides  # noqa: F401
-    # For backends like TPU that only need no-op overrides (Pallas handles codegen)
+    # TPU uses Pallas for codegen and only needs no-op overrides
     register_device_op_overrides("tpu", CpuDeviceOpOverrides())
 
-    # Mark initialization as complete to prevent duplicate imports and
-    # ensure consistent behavior even if this function is called multiple times.
     _device_op_overrides_initialized = True
 
 
 def get_device_op_overrides(device: str) -> DeviceOpOverrides:
     assert isinstance(device, str), type(device)
-
     _initialize_device_op_overrides()
-
     return device_op_overrides_dict[device]
 
 

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -634,11 +634,12 @@ def _initialize_device_op_overrides():
     if _device_op_overrides_initialized:
         return
 
-    from .cpu_device_op_overrides import CpuDeviceOpOverrides
     from . import mps_device_op_overrides  # noqa: F401
+    from .cpu_device_op_overrides import CpuDeviceOpOverrides
     from .cuda import device_op_overrides  # noqa: F401
     from .mtia import device_op_overrides as mtia_op_overrides  # noqa: F401
     from .xpu import device_op_overrides as xpu_op_overrides  # noqa: F401
+
     # TPU uses Pallas for codegen and only needs no-op overrides
     register_device_op_overrides("tpu", CpuDeviceOpOverrides())
 

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -371,6 +371,7 @@ class DeviceOpOverrides:
 
 
 device_op_overrides_dict: dict[str, DeviceOpOverrides] = {}
+_device_op_overrides_initialized = False
 custom_backend_passes: dict[str, CustomGraphModulePass | None] = {}
 custom_backend_codegen_configs: dict[str, ConfigModule | None] = {}
 
@@ -629,7 +630,8 @@ def register_device_op_overrides(
 def get_device_op_overrides(device: str) -> DeviceOpOverrides:
     assert isinstance(device, str), type(device)
 
-    if not device_op_overrides_dict:
+    global _device_op_overrides_initialized
+    if not _device_op_overrides_initialized:
         from . import (  # noqa: F401  # noqa: F401
             cpu_device_op_overrides,
             mps_device_op_overrides,
@@ -638,7 +640,9 @@ def get_device_op_overrides(device: str) -> DeviceOpOverrides:
         from .mtia import device_op_overrides as mtia_op_overrides  # noqa: F401
         from .xpu import device_op_overrides as xpu_op_overrides  # noqa: F401
 
-    if device not in device_op_overrides_dict:
+        _device_op_overrides_initialized = True
+
+    if device not in device_op_overrides_dict and device == "tpu":
         # For backends like TPU that only need no-op overrides (Pallas handles codegen)
         from .cpu_device_op_overrides import CpuDeviceOpOverrides
 

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -627,20 +627,36 @@ def register_device_op_overrides(
     device_op_overrides_dict[device] = device_op_overrides
 
 
+def _initialize_device_op_overrides():
+    global _device_op_overrides_initialized
+
+    # Ensure one-time initialization of all device-specific overrides.
+    # This must NOT depend on the current state of `device_op_overrides_dict`,
+    # since external/test code may partially populate it and break lazy init.
+    if _device_op_overrides_initialized:
+        return
+
+    # Importing these modules has the side effect of registering their
+    # corresponding DeviceOpOverrides via `register_device_op_overrides`.
+    # We explicitly import all known backends here to guarantee complete
+    # and deterministic registration.
+    from . import (
+        cpu_device_op_overrides,  # noqa: F401
+        mps_device_op_overrides,  # noqa: F401
+    )
+    from .cuda import device_op_overrides  # noqa: F401
+    from .mtia import device_op_overrides as mtia_op_overrides  # noqa: F401
+    from .xpu import device_op_overrides as xpu_op_overrides  # noqa: F401
+
+    # Mark initialization as complete to prevent duplicate imports and
+    # ensure consistent behavior even if this function is called multiple times.
+    _device_op_overrides_initialized = True
+
+
 def get_device_op_overrides(device: str) -> DeviceOpOverrides:
     assert isinstance(device, str), type(device)
 
-    global _device_op_overrides_initialized
-    if not _device_op_overrides_initialized:
-        from . import (  # noqa: F401  # noqa: F401
-            cpu_device_op_overrides,
-            mps_device_op_overrides,
-        )
-        from .cuda import device_op_overrides  # noqa: F401
-        from .mtia import device_op_overrides as mtia_op_overrides  # noqa: F401
-        from .xpu import device_op_overrides as xpu_op_overrides  # noqa: F401
-
-        _device_op_overrides_initialized = True
+    _initialize_device_op_overrides()
 
     if device not in device_op_overrides_dict and device == "tpu":
         # For backends like TPU that only need no-op overrides (Pallas handles codegen)

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -640,13 +640,13 @@ def _initialize_device_op_overrides():
     # corresponding DeviceOpOverrides via `register_device_op_overrides`.
     # We explicitly import all known backends here to guarantee complete
     # and deterministic registration.
-    from . import (
-        cpu_device_op_overrides,  # noqa: F401
-        mps_device_op_overrides,  # noqa: F401
-    )
+    from .cpu_device_op_overrides import CpuDeviceOpOverrides
+    from . import mps_device_op_overrides,  # noqa: F401
     from .cuda import device_op_overrides  # noqa: F401
     from .mtia import device_op_overrides as mtia_op_overrides  # noqa: F401
     from .xpu import device_op_overrides as xpu_op_overrides  # noqa: F401
+    # For backends like TPU that only need no-op overrides (Pallas handles codegen)
+    register_device_op_overrides("tpu", CpuDeviceOpOverrides())
 
     # Mark initialization as complete to prevent duplicate imports and
     # ensure consistent behavior even if this function is called multiple times.
@@ -657,12 +657,6 @@ def get_device_op_overrides(device: str) -> DeviceOpOverrides:
     assert isinstance(device, str), type(device)
 
     _initialize_device_op_overrides()
-
-    if device not in device_op_overrides_dict and device == "tpu":
-        # For backends like TPU that only need no-op overrides (Pallas handles codegen)
-        from .cpu_device_op_overrides import CpuDeviceOpOverrides
-
-        register_device_op_overrides(device, CpuDeviceOpOverrides())
 
     return device_op_overrides_dict[device]
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #178986
* __->__ #178959

# Motivation
The current initialization logic for DeviceOpOverrides relies on checking whether `device_op_overrides_dict` is empty:
```python
def get_device_op_overrides(device: str) -> DeviceOpOverrides:
    assert isinstance(device, str), type(device)

    if not device_op_overrides_dict:
        from . import (  # noqa: F401  # noqa: F401
            cpu_device_op_overrides,
            mps_device_op_overrides,
        )
        from .cuda import device_op_overrides  # noqa: F401
        from .mtia import device_op_overrides as mtia_op_overrides  # noqa: F401
        from .xpu import device_op_overrides as xpu_op_overrides  # noqa: F401

    if device not in device_op_overrides_dict:
        # For backends like TPU that only need no-op overrides (Pallas handles codegen)
        from .cpu_device_op_overrides import CpuDeviceOpOverrides

        register_device_op_overrides(device, CpuDeviceOpOverrides())

    return device_op_overrides_dict[device]
```
This approach is fragile because it assumes no overrides are registered prior to calling `get_device_op_overrides`. However, if `register_device_op_overrides` is invoked independently (e.g., in tests or other modules), the dictionary may become partially populated before full initialization occurs.

In such cases, the lazy initialization block is skipped, and some backends (e.g., XPU) never register their corresponding `DeviceOpOverrides`. As a result, the system silently falls back to `CpuDeviceOpOverrides`, leading to incorrect behavior.

This issue has already caused **multiple failures in XPU CI**, particularly in `test_gpu_cpp_wrapper.py`. For example, [PR #175385](https://github.com/pytorch/pytorch/pull/175385) unintentionally registers `CUDADeviceOpOverrides` early, making `device_op_overrides_dict` non-empty and preventing XPU overrides from being registered.

The silent fallback to CPU overrides makes these issues difficult to detect and debug.

# Solution
To make initialization robust and deterministic, introduce a dedicated flag `_device_op_overrides_initialized` to explicitly track whether all device overrides have been fully registered.

# Additional Context
fix https://github.com/pytorch/pytorch/issues/178857
fix https://github.com/pytorch/pytorch/issues/178761
fix https://github.com/pytorch/pytorch/issues/178753
fix https://github.com/pytorch/pytorch/issues/178855, etc...

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo