### PR TITLE
profiler: fix USE_KINETO=OFF build failure (unconditional ActivityType.h include)

### DIFF
--- a/torch/csrc/autograd/init.cpp
+++ b/torch/csrc/autograd/init.cpp
@@ -309,12 +309,7 @@ PyObject* THPAutograd_initExtension(PyObject* _unused, PyObject* unused) {
       .def("privateuse1_elapsed_us", &KinetoEvent::privateuse1ElapsedUs)
       .def(
           "is_user_annotation",
-          [](const KinetoEvent& e) {
-            return e.activityType() ==
-                (uint8_t)libkineto::ActivityType::USER_ANNOTATION ||
-                e.activityType() ==
-                (uint8_t)libkineto::ActivityType::GPU_USER_ANNOTATION;
-          })
+          [](const KinetoEvent& e) { return e.isUserAnnotation(); })
       .def(
           "is_python_function",
           [](const KinetoEvent& e) { return e.isPythonFunction(); })

--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -1243,27 +1243,33 @@ int64_t KinetoEvent::externalId() const {
     return static_cast<int64_t>(linked);
   }
 
+#if defined(USE_KINETO) && \
+    (!defined(LIBKINETO_NOCUPTI) || !defined(LIBKINETO_NOROCTRACER))
   // Orphaned GPU activities (no linked CPU op) in these types should not get
   // an External id, to avoid incorrect cross-linking in trace viewers.
+  // These GPU-specific ActivityType values are only present when kineto is
+  // built with GPU backend support (CUPTI or ROCtracer). CPU-only kineto
+  // builds (e.g. system packages without GPU support) omit them.
   auto type = static_cast<libkineto::ActivityType>(activityType());
-  if (type != libkineto::ActivityType::GPU_MEMCPY &&
-      type != libkineto::ActivityType::GPU_MEMSET &&
-      type != libkineto::ActivityType::CONCURRENT_KERNEL &&
-      type != libkineto::ActivityType::CUDA_RUNTIME &&
-      type != libkineto::ActivityType::CUDA_DRIVER &&
-      type != libkineto::ActivityType::PRIVATEUSE1_RUNTIME &&
-      type != libkineto::ActivityType::PRIVATEUSE1_DRIVER) {
-    return static_cast<int64_t>(result_->visit(c10::overloaded(
-        [](const ExtraFields<EventType::TorchOp>& e) -> uint64_t {
-          return e.correlation_id_;
-        },
-        [](const ExtraFields<EventType::Kineto>& e) -> uint64_t {
-          return e.correlation_id_;
-        },
-        [](const auto&) -> uint64_t { return 0; })));
+  if (type == libkineto::ActivityType::GPU_MEMCPY ||
+      type == libkineto::ActivityType::GPU_MEMSET ||
+      type == libkineto::ActivityType::CONCURRENT_KERNEL ||
+      type == libkineto::ActivityType::CUDA_RUNTIME ||
+      type == libkineto::ActivityType::CUDA_DRIVER ||
+      type == libkineto::ActivityType::PRIVATEUSE1_RUNTIME ||
+      type == libkineto::ActivityType::PRIVATEUSE1_DRIVER) {
+    return 0;
   }
+#endif
 
-  return 0;
+  return static_cast<int64_t>(result_->visit(c10::overloaded(
+      [](const ExtraFields<EventType::TorchOp>& e) -> uint64_t {
+        return e.correlation_id_;
+      },
+      [](const ExtraFields<EventType::Kineto>& e) -> uint64_t {
+        return e.correlation_id_;
+      },
+      [](const auto&) -> uint64_t { return 0; })));
 }
 
 #define FORWARD_FROM_RESULT(method_name, result_expr)                        \

--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -1199,6 +1199,13 @@ int64_t KinetoEvent::privateuse1ElapsedUs() const {
       &privateuse1_event_start, &privateuse1_event_end);
 }
 
+bool KinetoEvent::isUserAnnotation() const {
+  constexpr uint8_t kUserAnnotation = 1;
+  constexpr uint8_t kGpuUserAnnotation = 2;
+  const auto type = activityType();
+  return type == kUserAnnotation || type == kGpuUserAnnotation;
+}
+
 void KinetoEvent::getPerfEventCounters(std::vector<uint64_t>& in) const {
   return result_->visit(c10::overloaded(
       [&in](const ExtraFields<EventType::TorchOp>& e) -> void {

--- a/torch/csrc/autograd/profiler_kineto.h
+++ b/torch/csrc/autograd/profiler_kineto.h
@@ -71,6 +71,7 @@ struct TORCH_API KinetoEvent {
   bool isPythonFunction() const;
   int64_t cudaElapsedUs() const;
   int64_t privateuse1ElapsedUs() const;
+  bool isUserAnnotation() const;
   void getPerfEventCounters(torch::profiler::perf_counters_t& /*in*/) const;
   extra_meta_t extraMeta() const;
   std::string metadataJson() const;

--- a/torch/csrc/profiler/collection.cpp
+++ b/torch/csrc/profiler/collection.cpp
@@ -571,11 +571,13 @@ std::string toString(const ExtraFields<EventType::PyCall>& e) {
       e.callsite_.funcname_.str());
 }
 
+#ifdef USE_KINETO
 auto scopeToType(at::RecordScope scope) {
   return scope == at::RecordScope::USER_SCOPE
       ? libkineto::ActivityType::USER_ANNOTATION
       : libkineto::ActivityType::CPU_OP;
 }
+#endif
 
 int64_t torchOpEndNS(
     const ExtraFields<EventType::TorchOp>& e,
@@ -624,6 +626,7 @@ std::string Result::overload_name() const {
       [](const auto& e) -> std::string { return ""; }));
 }
 
+#ifdef USE_KINETO
 libkineto::ActivityType Result::kinetoType() const {
   return visit(c10::overloaded(
       ATTRIBUTE(TorchOp, scopeToType(e.scope_)),
@@ -636,6 +639,11 @@ libkineto::ActivityType Result::kinetoType() const {
       ATTRIBUTE(PythonGC, libkineto::ActivityType::PYTHON_FUNCTION),
       ATTRIBUTE(Kineto, e.activity_type_)));
 }
+#else
+libkineto::ActivityType Result::kinetoType() const {
+  return libkineto::ActivityType::NONE;
+}
+#endif
 
 uint64_t Result::correlationID() const {
   return visit(c10::overloaded(

--- a/torch/csrc/profiler/kineto_shim.cpp
+++ b/torch/csrc/profiler/kineto_shim.cpp
@@ -138,6 +138,7 @@ TraceWrapper::TraceWrapper(const int64_t start_time, const std::string& name)
 }
 #endif // USE_KINETO
 
+#ifdef USE_KINETO
 activity_t* TraceWrapper::addCPUActivity(
     const std::string& name,
     const libkineto::ActivityType type,
@@ -145,7 +146,6 @@ activity_t* TraceWrapper::addCPUActivity(
     const uint64_t correlation_id,
     const int64_t start_time,
     const int64_t end_time) {
-#ifdef USE_KINETO
   TORCH_CHECK((bool)(*this), "Cannot add event to non-existent trace.");
   cpu_trace_->emplace_activity(cpu_trace_->span, type, name);
   auto& act = libkineto::CpuTraceBuffer::toRef(cpu_trace_->activities.back());
@@ -157,10 +157,18 @@ activity_t* TraceWrapper::addCPUActivity(
     act.endTime = end_time;
   }
   return cpu_trace_->activities.back().get();
-#else
-  return nullptr;
-#endif // USE_KINETO
 }
+#else
+activity_t* TraceWrapper::addCPUActivity(
+    const std::string& name,
+    const libkineto::ActivityType type,
+    const DeviceAndResource device_and_resource,
+    const uint64_t correlation_id,
+    const int64_t start_time,
+    const int64_t end_time) {
+  return nullptr;
+}
+#endif // USE_KINETO
 
 void TraceWrapper::transferCpuTrace(int64_t end_time) {
 #ifdef USE_KINETO
@@ -473,6 +481,7 @@ void logInvariantViolation(
 
 namespace autograd::profiler {
 c10::DeviceType deviceTypeFromActivity(libkineto::ActivityType activity_type) {
+#ifdef USE_KINETO
   // PrivateUse1 kineto backend reuse some ActivityTypes,
   // If PrivateUse1 backend is enabled, this should return
   // c10::DeviceType::PrivateUse1.
@@ -524,6 +533,9 @@ c10::DeviceType deviceTypeFromActivity(libkineto::ActivityType activity_type) {
       return c10::DeviceType::CPU;
     }
   }
+#else
+  return c10::DeviceType::CPU;
+#endif // USE_KINETO
 }
 
 void addMetadataJson(const std::string& key, const std::string& value) {

--- a/torch/csrc/profiler/kineto_shim.h
+++ b/torch/csrc/profiler/kineto_shim.h
@@ -15,9 +15,16 @@
 #ifdef USE_KINETO
 #include <ActivityType.h>
 #else
-// Minimal stub so non-Kineto builds can compile types that hold ActivityType.
 namespace libkineto {
-enum class ActivityType : uint8_t { NONE = 0 };
+enum class ActivityType : uint8_t {
+  CPU_OP = 0,
+  USER_ANNOTATION,
+  GPU_USER_ANNOTATION,
+  NONE = CPU_OP,
+};
+inline const char* toString(ActivityType) {
+  return "CPU_OP";
+}
 } // namespace libkineto
 #endif
 

--- a/torch/csrc/profiler/kineto_shim.h
+++ b/torch/csrc/profiler/kineto_shim.h
@@ -12,7 +12,14 @@
 #undef USE_KINETO
 #endif
 
+#ifdef USE_KINETO
 #include <ActivityType.h>
+#else
+// Minimal stub so non-Kineto builds can compile types that hold ActivityType.
+namespace libkineto {
+enum class ActivityType : uint8_t { NONE = 0 };
+} // namespace libkineto
+#endif
 
 #include <torch/csrc/Export.h>
 #include <torch/csrc/profiler/api.h>


### PR DESCRIPTION
When building with `USE_KINETO=OFF`, `kineto_shim.h` was unconditionally including `<ActivityType.h>`, a Kineto-only header, causing a fatal compile error on systems where Kineto is not installed (e.g. Gentoo with system libraries instead of bundled third-party). The fix wraps the include in `#ifdef USE_KINETO` and provides a minimal stub enum so the data structures and function signatures referencing `libkineto::ActivityType` still compile without Kineto. Function bodies in `kineto_shim.cpp` and `collection.cpp` that reference specific enum values (`CPU_OP`, `PYTHON_FUNCTION`, etc.) are similarly guarded with safe no-op fallbacks in the `#else` paths.