### PR TITLE
inductor: fix C++ compile error when indexing transposed tensor with indirect index

### DIFF
--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -6327,6 +6327,19 @@ class CPUReproTests(TestCase):
 
         self.assertTrue(torch.allclose(out1, out2, equal_nan=True))
 
+    def test_indirect_index_transposed_tensor(self):
+        # https://github.com/pytorch/pytorch/issues/178521
+        # transpose_mxn was referencing a tmp variable defined inside the inner
+        # loop when the index used indirect (SymT.TMP) indexing.
+        def f(buf, idx):
+            return buf[torch.arange(buf.shape[0]), idx, :]
+
+        buf = torch.randn(16, 2, 16).permute(2, 1, 0)
+        idx = torch.randint(0, 2, (16,))
+        expected = f(buf, idx)
+        actual = torch.compile(f, backend="inductor")(buf, idx)
+        self.assertEqual(actual, expected)
+
 
 if __name__ == "__main__":
     from torch._inductor.test_case import run_tests

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -3676,6 +3676,10 @@ class CppTile2DKernel(CppVecKernel):
     def need_vec_transpose(self, index):
         outer_var = self.itervars[self.outer_idx]
         inner_var = self.itervars[self.tiling_idx]
+        # Indirect indexing (SymT.TMP) variables are declared inside the inner
+        # loop, but transpose_mxn is emitted into preloads (before the loop).
+        if free_symbol_is_type(index, SymT.TMP):
+            return False
         outer_stride = stride_at_vec_range(index, outer_var, self.tiling_factor)
         inner_stride = stride_at_vec_range(index, inner_var, self.tiling_factor)
         return (


### PR DESCRIPTION
When you index a permuted tensor like `buf[arange(n), idx, :]` where `idx` is a tensor, the inductor CPU vectorized path can end up generating invalid C++. The `transpose_mxn` call gets emitted as a preload before the inner loop, but the index expression contains `tmpN` variables that are only declared inside that loop, so the compiler rightfully complains.

The fix is a one-liner in `need_vec_transpose`: bail out early if the index has any indirect (`SymT.TMP`) symbols, since we can't safely hoist the transpose before the loop in that case. Added a regression test that directly reproduces the shape/permute/indirect-index pattern from the bug report.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo