### PR TITLE
[CI] Make Chocolatey cmake install non-fatal in Windows build

### DIFF
--- a/.ci/pytorch/win-test-helpers/build_pytorch.bat
+++ b/.ci/pytorch/win-test-helpers/build_pytorch.bat
@@ -37,11 +37,11 @@ call %INSTALLER_DIR%\activate_miniconda3.bat
 if errorlevel 1 goto fail
 if not errorlevel 0 goto fail
 
-:: Update CMake
-:: TODO: Investigate why this helps MKL detection, even when CMake from choco is not used
+:: Update CMake via Chocolatey to add it to System PATH for MKL detection.
+:: Non-fatal: cmake is also installed via pip, so Chocolatey CDN outages
+:: should not break the build (see https://github.com/meta-pytorch/pytorch-gha-infra/issues/1044).
 call choco upgrade -y cmake --no-progress --installargs 'ADD_CMAKE_TO_PATH=System' --apply-install-arguments-to-dependencies --version=3.27.9
-if errorlevel 1 goto fail
-if not errorlevel 0 goto fail
+if errorlevel 1 echo WARNING: Chocolatey cmake install failed, continuing with pip-installed cmake
 
 :: TODO: Move to .ci/docker/requirements-ci.txt
 call pip install mkl==2024.2.0 mkl-static==2024.2.0 mkl-include==2024.2.0


### PR DESCRIPTION
## Summary

- Make the Chocolatey cmake install step in `build_pytorch.bat` non-fatal so that Chocolatey CDN outages don't break Windows trunk builds
- cmake is already installed via pip (`requirements-ci.txt`), so the Chocolatey install is only needed to add cmake to the System PATH for MKL detection

Fixes https://github.com/meta-pytorch/pytorch-gha-infra/issues/1044

## Context

On 2026-03-31, `community.chocolatey.org` returned HTTP 499 errors, causing **every** Windows trunk build to fail at the `choco upgrade cmake` step. The builds themselves were fine — cmake was already available via pip — but the `if errorlevel 1 goto fail` made the Chocolatey failure fatal.

## Test plan

- [x] Verified the existing `handle.exe` steps in `setup-win` and `teardown-win` already have `continue-on-error: true`
- [x] Confirmed cmake 3.31.6 is installed via pip before this step runs
- [ ] Windows CI signal from this PR