### PR TITLE
Improve Conv2d docs: clarify math variable to parameter mapping and fix cross-correlation link

### DIFF
--- a/torch/nn/modules/conv.py
+++ b/torch/nn/modules/conv.py
@@ -502,7 +502,7 @@ class Conv2d(_ConvNd):
         >>> output = m(input)
 
     .. _cross-correlation:
-        https://en.wikipedia.org/wiki/Cross-correlation#Discrete_functions
+        https://en.wikipedia.org/wiki/Cross-correlation
 
     .. _link:
         https://github.com/vdumoulin/conv_arithmetic/blob/master/README.md

--- a/torch/nn/modules/conv.py
+++ b/torch/nn/modules/conv.py
@@ -400,9 +400,11 @@ class Conv2d(_ConvNd):
 
 
     where :math:`\star` is the valid 2D `cross-correlation`_ operator,
-    :math:`N` is a batch size, :math:`C` denotes a number of channels,
-    :math:`H` is a height of input planes in pixels, and :math:`W` is
-    width in pixels.
+    :math:`N` is a batch size, :math:`C_{\text{in}}` and :math:`C_{\text{out}}` correspond to
+    :attr:`in_channels` and :attr:`out_channels` respectively,
+    :math:`H` and :math:`W` are the input height and width in pixels.
+    See the Shape section below for how :math:`H_{\text{out}}` and :math:`W_{\text{out}}`
+    are derived from :attr:`kernel_size`, :attr:`stride`, :attr:`padding`, and :attr:`dilation`.
     """
         + r"""
 
@@ -500,7 +502,7 @@ class Conv2d(_ConvNd):
         >>> output = m(input)
 
     .. _cross-correlation:
-        https://en.wikipedia.org/wiki/Cross-correlation
+        https://en.wikipedia.org/wiki/Cross-correlation#Discrete_functions
 
     .. _link:
         https://github.com/vdumoulin/conv_arithmetic/blob/master/README.md


### PR DESCRIPTION
Addresses #178399

- Extended the variable description after the Conv2d formula to explicitly
  map math symbols to parameters (C_in → in_channels, C_out → out_channels, etc.)
- Updated cross-correlation link to point to the discrete functions section
  of the Wikipedia article, which is more relevant to PyTorch's use case