### PR TITLE
[Oncall][vllm] Fix output node filtering in check_input_alias_and_mutation_return_outputs causing MTIA perf regression (#178969)

### DIFF
--- a/torch/_higher_order_ops/utils.py
+++ b/torch/_higher_order_ops/utils.py
@@ -1030,8 +1030,11 @@ def check_input_alias_and_mutation_return_outputs(
     def _get_example_value(n):
         if not isinstance(n, torch.fx.Node):
             return n
-        else:
-            return n.meta["val"] if "val" in n.meta else n.meta["example_value"]
+        if "val" in n.meta:
+            return n.meta["val"]
+        if "example_value" in n.meta:
+            return n.meta["example_value"]
+        return None
 
     fake_args = [
         _get_example_value(n)
@@ -1041,7 +1044,6 @@ def check_input_alias_and_mutation_return_outputs(
     outputs = [
         _get_example_value(n)
         for n in pytree.tree_flatten(gm.graph.find_nodes(op="output")[0].args[0])[0]
-        if not isinstance(n, torch.fx.Node) or "val" in n.meta
     ]
 
     # We need to analyze the original fake_args to detect


### PR DESCRIPTION
Summary:

D98182506 added a filter `if not isinstance(n, torch.fx.Node) or "val" in n.meta`
to the outputs list in `check_input_alias_and_mutation_return_outputs()`. This
filter excludes FX nodes without "val" in their meta, which changes the output
count returned by the function.

The fix modifies `_get_example_value()` to return None for nodes without "val"
or "example_value" in meta, instead of filtering them out entirely. This
preserves the output list length (keeping aliasing analysis correct) while
avoiding the KeyError that the filter was designed to prevent.

Reviewed By: aorenste

Differential Revision: D99029865
