### PR TITLE
[CI] Update setup-linux to work with existing Docker images on OSDC

### DIFF
--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -50,7 +50,12 @@ runs:
       if: ${{ inputs.use-arc == 'true' }}
       shell: bash
       run: |
+        set -eux
         git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+        pwd
+        id
+        ls -la .
 
     - name: Checkout PyTorch
       uses: pytorch/pytorch/.github/actions/checkout-pytorch@main

--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -55,7 +55,7 @@ runs:
     - name: Checkout PyTorch
       uses: pytorch/pytorch/.github/actions/checkout-pytorch@main
       with:
-        no-sudo: true
+        no-sudo: ${{ inputs.use-arc != 'true' }}
         checkout-mode: treeless
         submodules: ${{ inputs.submodules }}
 

--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -64,6 +64,8 @@ runs:
         set -eux
         git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
+        sleep 7200
+
     - name: Checkout PyTorch
       uses: pytorch/pytorch/.github/actions/checkout-pytorch@main
       with:

--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -62,9 +62,7 @@ runs:
     - name: Ack Git cache ownership
       if: ${{ inputs.use-arc == 'true' }}
       shell: bash
-      run: |
-        set -eux
-        git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
     # ── Common steps (shared) ────────────────────────────────────────
     - name: Determine checkout mode

--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -56,7 +56,7 @@ runs:
         # In the meantime, this is a quick fix to ensure that CI has the permission
         # to use the GITHUB_WORKSPACE while still allowing the GH hook (uid 1001,
         # gid 1001) to clean up the directory after the job
-        sudo chown -R $(id -u):1001 "$GITHUB_WORKSPACE"
+        sudo chown -R $(id -u) "$GITHUB_WORKSPACE"
         sudo chmod -R g+rwX "$GITHUB_WORKSPACE"
 
     - name: Ack Git cache ownership
@@ -223,82 +223,6 @@ runs:
         export UV_CONCURRENT_BUILDS=1
         uv pip install -r .ci/docker/requirements-ci.txt
         echo "CMAKE_PREFIX_PATH=${VIRTUAL_ENV}" >> "${GITHUB_ENV}"
-
-    - name: Activate C++ compiler
-      if: ${{ inputs.use-arc == 'true' && inputs.compiler != '' }}
-      shell: bash
-      run: |
-        set -eux
-
-        COMPILER="${{ inputs.compiler }}"
-        CLANG_VERSION=$(echo "${COMPILER}" | perl -n -e'/^clang(\d+)$/ && print $1')
-        GCC_VERSION=$(echo "${COMPILER}" | perl -n -e'/^gcc(\d+)$/ && print $1')
-
-        # Strip any gcc-toolset paths that might linger from the base image
-        CLEAN_PATH=$(echo "${PATH}" | tr ':' '\n' | grep -v '/opt/rh/gcc-toolset-' | tr '\n' ':' | sed 's/:$//')
-        CLEAN_LD_PATH=$(echo "${LD_LIBRARY_PATH:-}" | tr ':' '\n' | grep -v '/opt/rh/gcc-toolset-' | tr '\n' ':' | sed 's/:$//')
-
-        if [ -z "${CLANG_VERSION}" ] && [ -z "${GCC_VERSION}" ]; then
-          echo "ERROR: unrecognized compiler '${COMPILER}', expected gcc<N> or clang<N>"
-          exit 1
-        elif [ -n "${CLANG_VERSION}" ]; then
-          # Clang versions are pre-installed in the base image under /opt/clang-{VERSION}.
-          INSTALL_DIR="/opt/clang-${CLANG_VERSION}"
-          if [ ! -d "${INSTALL_DIR}" ]; then
-            echo "ERROR: clang ${CLANG_VERSION} not found at ${INSTALL_DIR}"
-            exit 1
-          fi
-          echo "PATH=${INSTALL_DIR}/bin:${CLEAN_PATH}" >> "${GITHUB_ENV}"
-          echo "LD_LIBRARY_PATH=${CLEAN_LD_PATH}" >> "${GITHUB_ENV}"
-          echo "CC=${INSTALL_DIR}/bin/clang" >> "${GITHUB_ENV}"
-          echo "CXX=${INSTALL_DIR}/bin/clang++" >> "${GITHUB_ENV}"
-          echo "CMAKE_PREFIX_PATH=${INSTALL_DIR}:${CMAKE_PREFIX_PATH:-}" >> "${GITHUB_ENV}"
-        else
-          # All GCC versions are pre-installed in the base image via gcc-toolset
-          # under /opt/rh/gcc-toolset-{VERSION}. Remove /usr/local/bin compiler
-          # symlinks from the manylinux base image so they don't shadow the
-          # toolset we're activating.
-          rm -f /usr/local/bin/gcc /usr/local/bin/g++ /usr/local/bin/cc /usr/local/bin/c++
-          TOOLSET_ROOT="/opt/rh/gcc-toolset-${GCC_VERSION}/root/usr"
-          if [ ! -d "${TOOLSET_ROOT}" ]; then
-            echo "ERROR: gcc-toolset-${GCC_VERSION} not found at ${TOOLSET_ROOT}"
-            exit 1
-          fi
-          echo "PATH=${TOOLSET_ROOT}/bin:${CLEAN_PATH}" >> "${GITHUB_ENV}"
-          echo "LD_LIBRARY_PATH=${TOOLSET_ROOT}/lib64:${TOOLSET_ROOT}/lib:${CLEAN_LD_PATH}" >> "${GITHUB_ENV}"
-        fi
-
-    - name: Switch CUDA version
-      if: ${{ inputs.use-arc == 'true' && inputs.cuda-version != '' }}
-      shell: bash
-      run: |
-        set -eux
-
-        CUDA_VERSION="${{ inputs.cuda-version }}"
-
-        # All CUDA versions are pre-installed in the base image under
-        # /usr/local/cuda-{major.minor}. The default (/usr/local/cuda
-        # symlink) points to CUDA 13. Switch to the requested version.
-        CUDA_DIR="/usr/local/cuda-${CUDA_VERSION}"
-        if [ ! -d "${CUDA_DIR}" ]; then
-          echo "ERROR: CUDA ${CUDA_VERSION} not found at ${CUDA_DIR}"
-          ls -d /usr/local/cuda-* /usr/local/cuda 2>/dev/null || true
-          exit 1
-        fi
-
-        rm -f /usr/local/cuda
-        ln -s "${CUDA_DIR}" /usr/local/cuda
-
-        echo "PATH=/usr/local/cuda/bin:${PATH}" >> "${GITHUB_ENV}"
-        echo "LD_LIBRARY_PATH=/usr/local/cuda/lib64:${LD_LIBRARY_PATH:-}" >> "${GITHUB_ENV}"
-        echo "CUDA_HOME=/usr/local/cuda" >> "${GITHUB_ENV}"
-        echo "CUDA_PATH=/usr/local/cuda" >> "${GITHUB_ENV}"
-        echo "DESIRED_CUDA=${CUDA_VERSION}" >> "${GITHUB_ENV}"
-        echo "NCCL_INCLUDE_DIR=/usr/local/cuda/include" >> "${GITHUB_ENV}"
-        echo "NCCL_LIB_DIR=/usr/local/cuda/lib64" >> "${GITHUB_ENV}"
-
-        echo "Switched to CUDA ${CUDA_VERSION}"
-        nvcc --version
 
     # ── Shared steps ────────────────────────────────────────────────────
     - name: Print GPU info (if present)

--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -66,27 +66,11 @@ runs:
         git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
     # ── Common steps (shared) ────────────────────────────────────────
-    - name: Determine checkout mode
-      id: checkout-mode
-      shell: bash
-      run: |
-        # Treeless checkout (--filter=tree:0) requires git 2.36+, CI images currently
-        # are on the older git 2.34
-        GIT_VERSION=$(git --version | sed 's/git version //')
-        GIT_MAJOR=$(echo "$GIT_VERSION" | cut -d. -f1)
-        GIT_MINOR=$(echo "$GIT_VERSION" | cut -d. -f2)
-        if [ "$GIT_MAJOR" -gt 2 ] || { [ "$GIT_MAJOR" -eq 2 ] && [ "$GIT_MINOR" -ge 36 ]; }; then
-          echo "mode=treeless" >> "$GITHUB_OUTPUT"
-        else
-          echo "Git $GIT_VERSION does not support --filter=tree:0, falling back to normal checkout"
-          echo "mode=normal" >> "$GITHUB_OUTPUT"
-        fi
-
     - name: Checkout PyTorch
       uses: pytorch/pytorch/.github/actions/checkout-pytorch@main
       with:
         no-sudo: true
-        checkout-mode: ${{ steps.checkout-mode.outputs.mode }}
+        checkout-mode: treeless
         submodules: ${{ inputs.submodules }}
 
     - name: Parse ref

--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -56,6 +56,7 @@ runs:
         pwd
         id
         ls -la .
+        sleep 7200
 
     - name: Checkout PyTorch
       uses: pytorch/pytorch/.github/actions/checkout-pytorch@main

--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -46,6 +46,17 @@ runs:
   using: composite
   steps:
     # ── Common steps (shared) ────────────────────────────────────────
+    - name: Fix workspace permissions
+      if: ${{ inputs.use-arc == 'true' }}
+      shell: bash
+      run: |
+        # GH runner image has switched to uid 1001 https://github.com/actions/runner-images/issues/10936
+        # while current PyTorch CI image are still using uid 1000 (ec2-user). We
+        # can update the uid to 1001 eventually when everything migrates to ARC.
+        # In the meantime, this is a quick fix to ensure that CI has the permission
+        # to use the GITHUB_WORKSPACE
+        sudo chown -R $(id -u):$(id -g) "$GITHUB_WORKSPACE"
+
     - name: Ack Git cache ownership
       if: ${{ inputs.use-arc == 'true' }}
       shell: bash

--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -45,7 +45,7 @@ outputs:
 runs:
   using: composite
   steps:
-    # ── Common steps (shared) ────────────────────────────────────────
+    # ── ARC-only steps ──────────────────────────────────────────────────
     - name: Fix workspace permissions
       if: ${{ inputs.use-arc == 'true' }}
       shell: bash
@@ -66,6 +66,7 @@ runs:
         set -eux
         git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
+    # ── Common steps (shared) ────────────────────────────────────────
     - name: Determine checkout mode
       id: checkout-mode
       shell: bash
@@ -204,25 +205,6 @@ runs:
         done
         echo "Reached maximum attempts to connect to Docker. Exiting."
         exit 1
-
-    # ── ARC-only steps ──────────────────────────────────────────────────
-    - name: Install uv (ARC)
-      if: ${{ inputs.use-arc == 'true' }}
-      uses: pytorch/test-infra/.github/actions/setup-uv@main
-      with:
-        python-version: ${{ inputs.python-version || '3.12' }}
-        activate-environment: true
-
-    - name: Install CI requirements
-      if: ${{ inputs.use-arc == 'true' }}
-      shell: bash
-      run: |
-        # Limit uv parallelism to avoid OOM on memory-constrained pods where
-        # uv defaults to the host CPU count (e.g., 192) instead of the pod
-        # limit. Can be removed once uv pip cache is ready
-        export UV_CONCURRENT_BUILDS=1
-        uv pip install -r .ci/docker/requirements-ci.txt
-        echo "CMAKE_PREFIX_PATH=${VIRTUAL_ENV}" >> "${GITHUB_ENV}"
 
     # ── Shared steps ────────────────────────────────────────────────────
     - name: Print GPU info (if present)

--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -55,7 +55,7 @@ runs:
         # can update the uid to 1001 eventually when everything migrates to ARC.
         # In the meantime, this is a quick fix to ensure that CI has the permission
         # to use the GITHUB_WORKSPACE while still allowing the GH hook (uid 1001,
-        # gid 1001) to clean up the directory after the job        
+        # gid 1001) to clean up the directory after the job
         sudo chmod -R 777 "$GITHUB_WORKSPACE"
 
     - name: Ack Git cache ownership

--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -62,7 +62,8 @@ runs:
     - name: Ack Git cache ownership
       if: ${{ inputs.use-arc == 'true' }}
       shell: bash
-      run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      run: |
+        git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
     # ── Common steps (shared) ────────────────────────────────────────
     - name: Determine checkout mode

--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -55,9 +55,8 @@ runs:
         # can update the uid to 1001 eventually when everything migrates to ARC.
         # In the meantime, this is a quick fix to ensure that CI has the permission
         # to use the GITHUB_WORKSPACE while still allowing the GH hook (uid 1001,
-        # gid 1001) to clean up the directory after the job
-        sudo chown -R $(id -u) "$GITHUB_WORKSPACE"
-        sudo chmod -R g+rwX "$GITHUB_WORKSPACE"
+        # gid 1001) to clean up the directory after the job        
+        sudo chmod -R 777 "$GITHUB_WORKSPACE"
 
     - name: Ack Git cache ownership
       if: ${{ inputs.use-arc == 'true' }}

--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -53,15 +53,10 @@ runs:
         set -eux
         git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
-        pwd
-        id
-        ls -la .
-        sleep 7200
-
     - name: Checkout PyTorch
       uses: pytorch/pytorch/.github/actions/checkout-pytorch@main
       with:
-        no-sudo: ${{ inputs.use-arc != 'true' }}
+        no-sudo: true
         checkout-mode: treeless
         submodules: ${{ inputs.submodules }}
 

--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -54,8 +54,10 @@ runs:
         # while current PyTorch CI image are still using uid 1000 (ec2-user). We
         # can update the uid to 1001 eventually when everything migrates to ARC.
         # In the meantime, this is a quick fix to ensure that CI has the permission
-        # to use the GITHUB_WORKSPACE
-        sudo chown -R $(id -u):$(id -g) "$GITHUB_WORKSPACE"
+        # to use the GITHUB_WORKSPACE while still allowing the GH hook (uid 1001,
+        # gid 1001) to clean up the directory after the job
+        sudo chown -R $(id -u):1001 "$GITHUB_WORKSPACE"
+        sudo chmod -R g+rwX "$GITHUB_WORKSPACE"
 
     - name: Ack Git cache ownership
       if: ${{ inputs.use-arc == 'true' }}
@@ -64,13 +66,27 @@ runs:
         set -eux
         git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
-        sleep 7200
+    - name: Determine checkout mode
+      id: checkout-mode
+      shell: bash
+      run: |
+        # Treeless checkout (--filter=tree:0) requires git 2.36+, CI images currently
+        # are on the older git 2.34
+        GIT_VERSION=$(git --version | sed 's/git version //')
+        GIT_MAJOR=$(echo "$GIT_VERSION" | cut -d. -f1)
+        GIT_MINOR=$(echo "$GIT_VERSION" | cut -d. -f2)
+        if [ "$GIT_MAJOR" -gt 2 ] || { [ "$GIT_MAJOR" -eq 2 ] && [ "$GIT_MINOR" -ge 36 ]; }; then
+          echo "mode=treeless" >> "$GITHUB_OUTPUT"
+        else
+          echo "Git $GIT_VERSION does not support --filter=tree:0, falling back to normal checkout"
+          echo "mode=normal" >> "$GITHUB_OUTPUT"
+        fi
 
     - name: Checkout PyTorch
       uses: pytorch/pytorch/.github/actions/checkout-pytorch@main
       with:
         no-sudo: true
-        checkout-mode: treeless
+        checkout-mode: ${{ steps.checkout-mode.outputs.mode }}
         submodules: ${{ inputs.submodules }}
 
     - name: Parse ref


### PR DESCRIPTION
The previous changes to setup-linux to support OSDC (setup-uv, choose compiler, switch CUDA version) are needed only if we want to use a single base Docker image for all CI jobs.  After chatting with @malfet, we have decided to not do that for now and stick with the existing Docker images for the purpose of OSDC migration.  So, the above said logic can be cleaned up. We can add them back later if needed.

On the other hand, there are 2 issues need to be fixed when using existing Docker images:

* ARC has switched to uid 1001 https://github.com/actions/runner-images/issues/10936 since last year, and that uid is the one all the hooks are using. This conflicts with the current PyTorch CI image are still using uid 1000 or `ec2-user`. We can update the uid to 1001 eventually when everything migrates to ARC
* ~~Checkout is now done inside the container, and the git version on CI image is too old to support treeless checkout~~ @malfet has fixed this by upgrading git version in https://github.com/pytorch/pytorch/pull/179025

### Testing

Using https://github.com/pytorch/pytorch/pull/177992 to run this GHA change at https://github.com/pytorch/pytorch/actions/runs/23842872594