### PR TITLE
inductor: link c10 on Windows cpp wrapper builds

### DIFF
--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -1219,6 +1219,8 @@ def _get_torch_related_args(
         libraries_dirs = [TORCH_LIB_PATH]
         if sys.platform != "darwin" and not config.is_fbcode():
             libraries.extend(["torch", "torch_cpu"])
+            if _IS_WINDOWS:
+                libraries.append("c10")
             if not aot_mode:
                 libraries.append("torch_python")
     else:


### PR DESCRIPTION
## Summary
Fix a Windows link failure in Inductor C++ wrapper compilation by adding c10 to the libtorch link libraries.

## Problem
With TORCHINDUCTOR_CPP_WRAPPER=1, a targeted inductor repro test failed on Windows during JIT C++ extension linking with:
- LNK2019 unresolved external symbol c10::detail::torchInternalAssertFail
- LNK1120 unresolved externals

## Root Cause
The Windows link list in torch._inductor.cpp_builder included torch and torch_cpu (and torch_python in non-AOT mode), but did not include c10, which owns the unresolved symbol.

## Why Linux Does Not Hit This
Linux typically resolves this through shared-object and transitive symbol resolution paths when linking/loading libtorch and related shared libraries.
Windows link.exe is stricter for import-library resolution and generally requires the direct provider library to be present on the link line, so missing c10.lib leads to LNK2019.

## Fix
When link_libtorch is enabled on Windows, append c10 to the libraries list in torch/_inductor/cpp_builder.py.

## Validation
After reinstalling PyTorch from this change, the failing repro passed:
- python -m pytest -v test/inductor/test_cpu_repro.py -k test_aten_normal_dtype
- Result: 1 passed

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo