### PR TITLE
[Inductor] Remove fp8 special handling in triton_utils.py (#178938)

### DIFF
--- a/test/inductor/test_triton_fp8_types.py
+++ b/test/inductor/test_triton_fp8_types.py
@@ -1,0 +1,47 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates
+# Owner(s): ["oncall: pt2"]
+
+import torch
+from torch._inductor.utils import _type_of
+
+
+class TestTritonFp8Types:
+    """Test that fp8 dtypes are correctly mapped to Triton types."""
+
+    def test_float8_e4m3fn_mapping(self):
+        """Test float8_e4m3fn maps to fp8e4nv."""
+        result = _type_of(torch.float8_e4m3fn)
+        assert result == "fp8e4nv", f"Expected fp8e4nv, got {result}"
+
+    def test_float8_e5m2_mapping(self):
+        """Test float8_e5m2 maps to fp8e5."""
+        result = _type_of(torch.float8_e5m2)
+        assert result == "fp8e5", f"Expected fp8e5, got {result}"
+
+    def test_float8_e4m3fnuz_mapping(self):
+        """Test float8_e4m3fnuz maps to fp8e4b8."""
+        result = _type_of(torch.float8_e4m3fnuz)
+        assert result == "fp8e4b8", f"Expected fp8e4b8, got {result}"
+
+    def test_float8_e5m2fnuz_mapping(self):
+        """Test float8_e5m2fnuz maps to fp8e5b16."""
+        result = _type_of(torch.float8_e5m2fnuz)
+        assert result == "fp8e5b16", f"Expected fp8e5b16, got {result}"
+
+    def test_all_fp8_types(self):
+        """Test all fp8 dtype variants map correctly."""
+        fp8_types = {
+            torch.float8_e4m3fn: "fp8e4nv",
+            torch.float8_e5m2: "fp8e5",
+            torch.float8_e4m3fnuz: "fp8e4b8",
+            torch.float8_e5m2fnuz: "fp8e5b16",
+        }
+        for dtype, expected in fp8_types.items():
+            result = _type_of(dtype)
+            assert result == expected, f"dtype {dtype} expected {expected}, got {result}"
+
+
+if __name__ == "__main__":
+    from torch._inductor.test_case import run_tests
+
+    run_tests("test_triton_fp8_types")

--- a/torch/_inductor/codegen/triton_utils.py
+++ b/torch/_inductor/codegen/triton_utils.py
@@ -34,18 +34,7 @@ def should_unwrap_unspec_arg(name: str):
 
 def signature_of(arg: KernelArgType, *, size_dtype: str | None) -> str:
     if isinstance(arg, TensorArg):
-        # TODO: Remove fp8 special handling when Triton supports PyTorch fp8 dtypes.
-        # Related PR: https://github.com/triton-lang/triton/pull/2279/
-        if arg.dtype == torch.float8_e4m3fn:
-            typ = "*fp8e4nv"
-        elif arg.dtype == torch.float8_e5m2:
-            typ = "*fp8e5"
-        elif arg.dtype == torch.float8_e4m3fnuz:
-            typ = "*fp8e4b8"
-        elif arg.dtype == torch.float8_e5m2fnuz:
-            typ = "*fp8e5b16"
-        else:
-            typ = _type_of(arg.dtype)
+        typ = _type_of(arg.dtype)
         if should_unwrap_unspec_arg(arg.buffer):
             # had unwrapped 0d tensor as scalar
             new_typ = typ.lstrip("*")

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -487,6 +487,8 @@ def _type_of(key: torch.dtype | None) -> str:
         "float8e4b15x4": "fp8e4b15x4",
         "float8_e4m3fn": "fp8e4nv",
         "float8_e5m2": "fp8e5",
+        "float8_e4m3fnuz": "fp8e4b8",
+        "float8_e5m2fnuz": "fp8e5b16",
         # TODO: remove when support is added in triton
         # https://github.com/triton-lang/triton/issues/6054
         "float8_e8m0fnu": "u8",


### PR DESCRIPTION
Fixes #178938

Triton now natively supports PyTorch fp8 dtypes (triton-lang/triton#2279), so the manual dtype-to-Triton-type mapping in `signature_of()` is redundant with `_type_of()` in `utils.py`.

## Changes
- Remove the fp8 special-case branches in `signature_of()` and delegate all dtype-to-signature mapping to `_type_of()`
- Add missing `float8_e4m3fnuz` and `float8_e5m2fnuz` entries to the `_type_of()` mapping table (these were previously only handled by the now-removed special case)

## Details
The TODO comment referenced triton-lang/triton#2279 which has been merged. `_type_of()` already handles `float8_e4m3fn` → `fp8e4nv` and `float8_e5m2` → `fp8e5` correctly, but was missing the `fnuz` variants. This PR adds those mappings and removes the redundant special case, making the code DRY.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @eqy

@pytorchbot label "topic: not user facing"