### PR TITLE
[xpu][fix] Fix meta kernel for _scaled_dot_product_fused_attention_overrideable to preserve query layout

### DIFF
--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -6014,7 +6014,10 @@ def meta__scaled_dot_product_fused_attention_overrideable(
     # Preserve input dimensionality for the output shape
     out_shape = list(query.shape)
     out_shape[-1] = D_V
-    res = torch.empty(out_shape, dtype=query.dtype, device=query.device)
+    if device_hint(query) == "xpu":
+        res = alloc_with_matching_layout(query, tuple(out_shape))
+    else:
+        res = torch.empty(out_shape, dtype=query.dtype, device=query.device)
 
     logsum_exp = torch.empty(
         (B, H_Q, S_Q),

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -6014,10 +6014,7 @@ def meta__scaled_dot_product_fused_attention_overrideable(
     # Preserve input dimensionality for the output shape
     out_shape = list(query.shape)
     out_shape[-1] = D_V
-    if device_hint(query) == "xpu":
-        res = alloc_with_matching_layout(query, tuple(out_shape))
-    else:
-        res = torch.empty(out_shape, dtype=query.dtype, device=query.device)
+    res = alloc_with_matching_layout(query, tuple(out_shape))
 
     logsum_exp = torch.empty(
         (B, H_Q, S_Q),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #178986
* #178959

# Motivation
The XPU kernel `_scaled_dot_product_fused_attention_overrideable` allocates
its output using `alloc_with_matching_layout`, which assigns the output the same
stride ordering as the query tensor. When `query` is non-contiguous (e.g., after
`permute(0, 2, 1, 3)` in SDPA fusion patterns), this produces a non-contiguous
output with strides matching the permuted layout.

This PR https://github.com/pytorch/pytorch/pull/178494 changes the behavior. The meta kernel allocates outputs using `torch.empty`, which always returns a contiguous tensor with default strides. This mismatch can cause Inductor to raise an `AssertionError` during stride validation at runtime on XPU CI.

# Additional Context
fix https://github.com/pytorch/pytorch/issues/178984
fix https://github.com/pytorch/pytorch/issues/178974