### PR TITLE
[xpu][fix] Fix nn.Embedding module failures on XPU

### DIFF
--- a/torch/testing/_internal/common_modules.py
+++ b/torch/testing/_internal/common_modules.py
@@ -2894,7 +2894,7 @@ def module_error_inputs_torch_nn_Embedding(module_info, device, dtype, requires_
     # Out of range indices: index exceeds num_embeddings
     # Only test on CPU - CUDA triggers kernel assertion instead of Python exception
     device_str = str(device)
-    if 'cuda' not in device_str and 'mps' not in device_str:
+    if 'cuda' not in device_str and 'mps' not in device_str and 'xpu' not in device_str:
         samples.append(
             ErrorModuleInput(
                 ModuleInput(

--- a/torch/testing/_internal/common_modules.py
+++ b/torch/testing/_internal/common_modules.py
@@ -2893,8 +2893,7 @@ def module_error_inputs_torch_nn_Embedding(module_info, device, dtype, requires_
 
     # Out of range indices: index exceeds num_embeddings
     # Only test on CPU - CUDA triggers kernel assertion instead of Python exception
-    device_str = str(device)
-    if 'cuda' not in device_str and 'mps' not in device_str and 'xpu' not in device_str:
+    if torch.device(device).type == 'cpu':
         samples.append(
             ErrorModuleInput(
                 ModuleInput(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #178987

# Motivation
https://github.com/pytorch/pytorch/pull/174180 introduces `nn.Embedding` module, which causes CI failures on XPU.

# Additional Context
fix https://github.com/pytorch/pytorch/issues/178854
fix https://github.com/pytorch/pytorch/issues/178762