### PR TITLE
[symm_mem] Improve error message on symmetric memory handle exchange

### DIFF
--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -5,6 +5,7 @@
 #include <c10/cuda/CUDAException.h>
 #include <c10/cuda/CUDAFunctions.h>
 #include <c10/cuda/CUDAGuard.h>
+#include <c10/cuda/PeerToPeerAccess.h>
 #include <c10/util/Gauge.h>
 #include <c10/util/Logging.h>
 #include <c10/util/ScopeExit.h>
@@ -685,11 +686,15 @@ struct ExpandableSegment {
         C10_CUDA_CHECK(hipMemImportFromShareableHandle(
             &handle, myfd_handle, hipMemHandleTypePosixFileDescriptor));
 #else
-        C10_CUDA_DRIVER_CHECK(DriverAPI::get()->cuMemImportFromShareableHandle_(
-            &handle,
-            // NOLINTNEXTLINE(performance-no-int-to-ptr)
-            (void*)(uintptr_t)myfd,
-            CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR));
+        C10_CUDA_DRIVER_CHECK_MSG(
+            DriverAPI::get()->cuMemImportFromShareableHandle_(
+                &handle,
+                // NOLINTNEXTLINE(performance-no-int-to-ptr)
+                (void*)(uintptr_t)myfd,
+                CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR),
+            " fabric_info: {",
+            get_nvml_fabric_info(device),
+            "}");
 #endif
         LOG(INFO) << "use posix fd to import expandable segments.";
         close(static_cast<int>(myfd));
@@ -708,11 +713,15 @@ struct ExpandableSegment {
         buf.read(
             reinterpret_cast<char*>(&fabric_handle), sizeof(CUmemFabricHandle));
         CUmemGenericAllocationHandle handle = 0;
-        C10_CUDA_DRIVER_CHECK(DriverAPI::get()->cuMemImportFromShareableHandle_(
-            &handle,
-            // NOLINTNEXTLINE(performance-no-int-to-ptr)
-            (void*)&fabric_handle,
-            CU_MEM_HANDLE_TYPE_FABRIC));
+        C10_CUDA_DRIVER_CHECK_MSG(
+            DriverAPI::get()->cuMemImportFromShareableHandle_(
+                &handle,
+                // NOLINTNEXTLINE(performance-no-int-to-ptr)
+                (void*)&fabric_handle,
+                CU_MEM_HANDLE_TYPE_FABRIC),
+            " fabric_info: {",
+            get_nvml_fabric_info(device),
+            "}");
         LOG(INFO) << "use fabric handle to import expandable segments.";
         segment->handles_.emplace_back(Handle{handle, std::nullopt});
       }

--- a/c10/cuda/PeerToPeerAccess.cpp
+++ b/c10/cuda/PeerToPeerAccess.cpp
@@ -10,12 +10,15 @@
 #include <c10/util/Logging.h>
 #include <c10/util/irange.h>
 
+#include <iomanip>
+#include <sstream>
 #include <vector>
 
 namespace c10::cuda {
 
 static std::vector<int8_t> p2pAccessEnabled_;
 static std::vector<int8_t> fabricAccessEnabled_;
+static std::vector<int> fabricCliqueId_;
 static int64_t num_devices_ = -1;
 
 namespace detail {
@@ -35,6 +38,8 @@ void init_p2p_access_cache(int64_t num_devices) {
   }
   fabricAccessEnabled_.clear();
   fabricAccessEnabled_.resize(num_devices, -1);
+  fabricCliqueId_.clear();
+  fabricCliqueId_.resize(num_devices, kCliqueIdNotQueried);
 }
 
 } // namespace detail
@@ -180,6 +185,7 @@ bool get_fabric_access(c10::DeviceIndex dev) {
     fabricInfo.version = nvmlGpuFabricInfo_v2;
     if (DriverAPI::get()->nvmlDeviceGetGpuFabricInfoV_ == nullptr) {
       cache = 0;
+      fabricCliqueId_[dev] = kCliqueIdUnsupported;
       return false;
     }
     TORCH_CHECK(
@@ -188,18 +194,103 @@ bool get_fabric_access(c10::DeviceIndex dev) {
             nvml_device, &fabricInfo));
     auto state = fabricInfo.state != NVML_GPU_FABRIC_STATE_NOT_SUPPORTED;
     if (state) {
+      fabricCliqueId_[dev] = static_cast<int>(fabricInfo.cliqueId);
       // now perform the full cycle of allocating - exporting - importing memory
       state = isFabricSupported();
+    } else {
+      fabricCliqueId_[dev] = kCliqueIdUnsupported;
     }
     cache = state ? 1 : 0;
     return cache;
   } else {
     cache = 0;
+    fabricCliqueId_[dev] = kCliqueIdUnsupported;
     return false;
   }
 #else
   (void)dev; // Suppress unused parameter warning
   return false;
+#endif
+}
+
+int get_fabric_clique_id(c10::DeviceIndex dev) {
+#if !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 12040 && \
+    defined(PYTORCH_C10_DRIVER_API_SUPPORTED)
+  // Ensure cache is populated via get_fabric_access (which does the NVML query
+  // and stashes clique_id as a side effect).
+  get_fabric_access(dev);
+  return fabricCliqueId_[dev];
+#else
+  (void)dev;
+  return kCliqueIdUnsupported;
+#endif
+}
+
+std::string get_nvml_fabric_info([[maybe_unused]] c10::DeviceIndex dev) {
+#if !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 12040 && \
+    defined(PYTORCH_C10_DRIVER_API_SUPPORTED)
+  if (DriverAPI::get()->nvmlDeviceGetGpuFabricInfoV_ == nullptr) {
+    return "fabric info unsupported (nvmlDeviceGetGpuFabricInfoV not available)";
+  }
+
+  auto nvml_device = get_nvml_device(dev);
+  if (nvml_device == nullptr) {
+    return "fabric info unknown (failed to get NVML device handle)";
+  }
+
+  nvmlGpuFabricInfoV_t info{};
+#ifdef nvmlGpuFabricInfo_v3
+  bool has_health_summary = false;
+  info.version = nvmlGpuFabricInfo_v3;
+  if (DriverAPI::get()->nvmlDeviceGetGpuFabricInfoV_(nvml_device, &info) ==
+      NVML_SUCCESS) {
+    has_health_summary = true;
+  } else
+#endif
+  {
+    info = {};
+    info.version = nvmlGpuFabricInfo_v2;
+    if (DriverAPI::get()->nvmlDeviceGetGpuFabricInfoV_(nvml_device, &info) !=
+        NVML_SUCCESS) {
+      return "fabric info unknown (nvmlDeviceGetGpuFabricInfoV failed)";
+    }
+  }
+
+  char uuid_hex[33];
+  for (int i = 0; i < 16; ++i) {
+    snprintf(uuid_hex + i * 2, 3, "%02x", info.clusterUuid[i]);
+  }
+
+  const char* state_str = "unknown";
+  switch (info.state) {
+    case NVML_GPU_FABRIC_STATE_NOT_SUPPORTED:
+      state_str = "not_supported";
+      break;
+    case NVML_GPU_FABRIC_STATE_NOT_STARTED:
+      state_str = "not_started";
+      break;
+    case NVML_GPU_FABRIC_STATE_IN_PROGRESS:
+      state_str = "in_progress";
+      break;
+    case NVML_GPU_FABRIC_STATE_COMPLETED:
+      state_str = "completed";
+      break;
+  }
+
+  std::ostringstream oss;
+  oss << "clique_id=" << info.cliqueId << ", cluster_uuid=" << uuid_hex
+      << ", state=" << state_str << ", status=" << info.status
+      << ", health_mask=0x" << std::hex << std::setfill('0') << std::setw(8)
+      << info.healthMask;
+#ifdef nvmlGpuFabricInfo_v3
+  if (has_health_summary) {
+    oss << ", health_summary=" << std::dec
+        << static_cast<int>(info.healthSummary);
+  }
+#endif
+  return oss.str();
+#else
+  return "fabric info unsupported (requires CUDA >= 12.4)";
 #endif
 }
 

--- a/c10/cuda/PeerToPeerAccess.h
+++ b/c10/cuda/PeerToPeerAccess.h
@@ -5,6 +5,7 @@
 #include <c10/macros/Macros.h>
 
 #include <cstdint>
+#include <string>
 
 namespace c10::cuda {
 
@@ -31,5 +32,18 @@ C10_CUDA_API bool get_p2p_access(
 /// @param device The device index to check.
 /// @return true if fabric access is available, false otherwise.
 C10_CUDA_API bool get_fabric_access(c10::DeviceIndex device);
+
+constexpr int kCliqueIdNotQueried = -2;
+constexpr int kCliqueIdUnsupported = -1;
+
+/// Query the NVLink fabric clique ID for a device.
+/// Returns the clique ID (>= 0) if fabric is supported, or kCliqueIdUnsupported
+/// if unsupported.
+C10_CUDA_API int get_fabric_clique_id(c10::DeviceIndex device);
+
+/// Returns a formatted string with NVML fabric info (clique_id, cluster_uuid,
+/// state, status, health_mask) for the given device. Intended for error
+/// diagnostics — only call on failure paths.
+C10_CUDA_API std::string get_nvml_fabric_info(c10::DeviceIndex device);
 
 } // namespace c10::cuda

--- a/c10/cuda/driver_api.h
+++ b/c10/cuda/driver_api.h
@@ -20,6 +20,23 @@
     }                                                                      \
   } while (0)
 
+// clang-format off
+#define C10_CUDA_DRIVER_CHECK_MSG(EXPR, ...)                                \
+  do {                                                                      \
+    CUresult __err = EXPR;                                                  \
+    if (__err != CUDA_SUCCESS) {                                            \
+      const char* err_str;                                                  \
+      CUresult get_error_str_err [[maybe_unused]] =                         \
+          c10::cuda::DriverAPI::get()->cuGetErrorString_(__err, &err_str);  \
+      if (get_error_str_err != CUDA_SUCCESS) {                              \
+        TORCH_CHECK(false, "CUDA driver error: unknown error", __VA_ARGS__);\
+      } else {                                                              \
+        TORCH_CHECK(false, "CUDA driver error: ", err_str, __VA_ARGS__);   \
+      }                                                                     \
+    }                                                                       \
+  } while (0)
+// clang-format on
+
 #define C10_CUDA_DRIVER_CHECK_GOTO(EXPR, NEXT)                             \
   do {                                                                     \
     CUresult __err = EXPR;                                                 \

--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.cu
@@ -10,6 +10,7 @@
 #include <ATen/cuda/PeerToPeerAccess.h>
 #include <c10/cuda/CUDACachingAllocator.h>
 #include <c10/cuda/CUDAGuard.h>
+#include <c10/util/env.h>
 #include <c10/util/error.h>
 
 #include <sys/socket.h>
@@ -498,8 +499,24 @@ struct RendezvousRequest {
   size_t buffer_size;
   size_t signal_pad_offset;
   bool has_multicast_support;
+  int clique_id;
   char hostname[HOST_NAME_MAX + 1];
 };
+
+static std::string import_err_msg(
+    int rank,
+    int peer,
+    const std::vector<RendezvousRequest>& reqs) {
+  std::ostringstream oss;
+  oss << ". Rank " << rank << " (host: " << reqs[rank].hostname
+      << ", device: " << reqs[rank].device_idx << ", fabric_info: {"
+      << at::cuda::get_nvml_fabric_info(reqs[rank].device_idx)
+      << "}) failed to import memory from rank " << peer
+      << " (host: " << reqs[peer].hostname
+      << ", device: " << reqs[peer].device_idx << ", NCCL_MNNVL_CLIQUE_ID: "
+      << c10::utils::get_env("NCCL_MNNVL_CLIQUE_ID").value_or("unset") << ").";
+  return oss.str();
+}
 
 void validate_rendezvous_requests(
     const std::vector<RendezvousRequest>& reqs,
@@ -511,7 +528,8 @@ void validate_rendezvous_requests(
   // Use (hostname, device_idx) pair to uniquely identify each allocation.
   std::set<std::pair<std::string, int>> device_host_pairs;
   for (auto req : reqs) {
-    device_host_pairs.insert(std::make_pair(std::string(req.hostname), req.device_idx));
+    device_host_pairs.insert(
+        std::make_pair(std::string(req.hostname), req.device_idx));
   }
   if (!allow_overlapping_devices() &&
       device_host_pairs.size() < (size_t)world_size) {
@@ -526,6 +544,35 @@ void validate_rendezvous_requests(
     TORCH_CHECK(reqs[r].block_size == reqs[0].block_size);
     TORCH_CHECK(reqs[r].buffer_size == reqs[0].buffer_size);
     TORCH_CHECK(reqs[r].signal_pad_offset == reqs[0].signal_pad_offset);
+  }
+}
+
+// All ranks must be in the same NVLink domain (same clique_id). Detect
+// mismatches early before the import fails with an opaque CUDA error.
+static void validate_nvlink_fabric_support(
+    const std::vector<RendezvousRequest>& reqs,
+    int world_size) {
+  std::unordered_set<int> clique_ids;
+  for (const auto& req : reqs) {
+    if (req.clique_id >= 0) {
+      clique_ids.insert(req.clique_id);
+    }
+  }
+  if (clique_ids.size() > 1) {
+    std::ostringstream oss;
+    oss << "CUDASymmetricMemory::rendezvous: "
+        << "ranks have mismatched NVLink clique_ids. "
+        << "All ranks using fabric handles must be in the same NVLink domain. "
+        << "Per-rank info: ";
+    for (int r = 0; r < world_size; ++r) {
+      if (r > 0) {
+        oss << ", ";
+      }
+      oss << "rank " << r << " (host: " << reqs[r].hostname
+          << ", device: " << reqs[r].device_idx
+          << ", clique_id: " << reqs[r].clique_id << ")";
+    }
+    TORCH_CHECK(false, oss.str());
   }
 }
 
@@ -723,11 +770,13 @@ c10::intrusive_ptr<CUDAPeerAllocInfo> make_peer_alloc_info(
       .block_size = block->block_size,
       .buffer_size = block->buffer_size,
       .signal_pad_offset = block->signal_pad_offset,
-      .has_multicast_support = device_has_multicast_support(block->device_idx)};
+      .has_multicast_support = device_has_multicast_support(block->device_idx),
+      .clique_id = at::cuda::get_fabric_clique_id(block->device_idx)};
 
   // Populate hostname field for host identification
   gethostname(local_req.hostname, sizeof(local_req.hostname));
   auto reqs = storeExchange.all_gather(store, rank, world_size, local_req);
+  validate_nvlink_fabric_support(reqs, world_size);
   validate_rendezvous_requests(reqs, world_size);
 
   std::vector<int> pids(world_size);
@@ -760,15 +809,19 @@ c10::intrusive_ptr<CUDAPeerAllocInfo> make_peer_alloc_info(
     // note how in one case it's directly imported_handles[r] and in another
     // &(imported_handles[r]) so can't do with just type definitions
     if constexpr (!use_fabric_handle) {
-      C10_CUDA_DRIVER_CHECK(driver_api->cuMemImportFromShareableHandle_(
-          &handles[r],
-          (void*)(uintptr_t)imported_handles[r],
-          CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR));
+      C10_CUDA_DRIVER_CHECK_MSG(
+          driver_api->cuMemImportFromShareableHandle_(
+              &handles[r],
+              (void*)(uintptr_t)imported_handles[r],
+              CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR),
+          import_err_msg(rank, r, reqs));
     } else {
-      C10_CUDA_DRIVER_CHECK(driver_api->cuMemImportFromShareableHandle_(
-          &handles[r],
-          (void*)&(imported_handles[r]),
-          CU_MEM_HANDLE_TYPE_FABRIC));
+      C10_CUDA_DRIVER_CHECK_MSG(
+          driver_api->cuMemImportFromShareableHandle_(
+              &handles[r],
+              (void*)&(imported_handles[r]),
+              CU_MEM_HANDLE_TYPE_FABRIC),
+          import_err_msg(rank, r, reqs));
     }
 #elif defined(USE_ROCM)
     C10_CUDA_CHECK(hipMemImportFromShareableHandle(


### PR DESCRIPTION
## Summary

When symmetric memory ranks span different NVLink domains, `cuMemImportFromShareableHandle` fails with an opaque "CUDA driver error: invalid resource handle" that provides no additional context about the ranks.

This PR improves error diagnostics:

1. **Better error messages on import failure**: When `cuMemImportFromShareableHandle` fails, the error now includes rank, hostname, device index, NVML fabric info (clique_id, cluster_uuid, state, status, health_mask), and the `NCCL_MNNVL_CLIQUE_ID` env var value. This applies to both `CUDASymmetricMemory` and `CUDACachingAllocator`.
2. **Early clique_id validation**: Before attempting handle exchange, each rank now queries its NVML fabric clique_id via `get_fabric_clique_id()` and includes it in the `RendezvousRequest`. After the store all_gather, `validate_nvlink_fabric_support()` checks that all ranks share the same clique_id. If they don't, it fails immediately with a clear per-rank breakdown instead of proceeding to an opaque CUDA error.
3. Added `C10_CUDA_DRIVER_CHECK_MSG` to allow passing useful info as an error message

## Test plan

Tested locally on 8xH100:

- Added `_test_set_clique_id_override(clique_id, use_fabric)` / `_test_clear_clique_id_override()` to override the clique_id in `RendezvousRequest` before all_gather
- Exposed these via pybind as `_SymmetricMemory._test_set_clique_id_override` / `_test_clear_clique_id_override`
- 8-rank test where rank 1 overrides its clique_id to mismatched id, all ranks call rendezvous normally, and the test asserts the error contains "mismatched NVLink clique_ids" with per-rank details

### Example error messages

**Early clique_id mismatch (before handle exchange)**:
```
CUDASymmetricMemory::rendezvous: ranks have mismatched NVLink clique_ids. All ranks must be in the same NVLink domain. Per-rank info: rank 0 (host: hostA, device: 0, clique_id: 0), rank 1 (host: hostB, device: 1, clique_id: 9999), ...
```

**Import failure (if clique_ids match but import still fails)**:
```
CUDA driver error: invalid resource handle. Rank 0 (host: hostA, device: 0, fabric_info: {clique_id=0, cluster_uuid=abcdef..., state=completed, status=0, health_mask=0x00000000}) failed to import memory from rank 1 (host: hostB, device: 1, NCCL_MNNVL_CLIQUE_ID: unset).
```