### PR TITLE
[CI] Use newer cmake version since 3.18.4 is not available anymore

### DIFF
--- a/.ci/docker/almalinux/Dockerfile
+++ b/.ci/docker/almalinux/Dockerfile
@@ -18,9 +18,9 @@ RUN yum install -y sudo wget curl perl util-linux xz bzip2 git patch which perl 
 RUN git config --global --add safe.directory '*'
 ENV PATH=/opt/rh/gcc-toolset-${DEVTOOLSET_VERSION}/root/usr/bin:$PATH
 
-# cmake-3.18.4 from pip
+# cmake-3.28.4 from pip
 RUN yum install -y python3-pip && \
-    python3 -mpip install cmake==3.18.4 && \
+    python3 -mpip install cmake==3.28.4 && \
     ln -s /usr/local/bin/cmake /usr/bin/cmake3
 RUN rm -rf /usr/local/cuda-*
 

--- a/.ci/docker/manywheel/Dockerfile_2_28
+++ b/.ci/docker/manywheel/Dockerfile_2_28
@@ -12,9 +12,9 @@ RUN yum install -y sudo wget curl perl util-linux xz bzip2 git patch which perl 
 ENV PATH=/opt/rh/gcc-toolset-${DEVTOOLSET_VERSION}/root/usr/bin:$PATH
 ENV LD_LIBRARY_PATH=/opt/rh/gcc-toolset-${DEVTOOLSET_VERSION}/root/usr/lib64:/opt/rh/gcc-toolset-${DEVTOOLSET_VERSION}/root/usr/lib:$LD_LIBRARY_PATH
 
-# cmake-3.18.4 from pip
+# cmake-3.28.4 from pip
 RUN yum install -y python3-pip && \
-    python3 -mpip install cmake==3.18.4 && \
+    python3 -mpip install cmake==3.28.4 && \
     ln -s /usr/local/bin/cmake /usr/bin/cmake3
 
 FROM base as openssl
@@ -127,9 +127,9 @@ RUN for cpython_version in "cp312-cp312" "cp313-cp313" "cp313-cp313t"; do \
 ADD ./common/patch_libstdc.sh patch_libstdc.sh
 RUN bash ./patch_libstdc.sh && rm patch_libstdc.sh
 
-# cmake-3.18.4 from pip; force in case cmake3 already exists
+# cmake-3.28.4 from pip; force in case cmake3 already exists
 RUN yum install -y python3-pip && \
-    python3 -mpip install cmake==3.18.4 && \
+    python3 -mpip install cmake==3.28.4 && \
     ln -sf /usr/local/bin/cmake /usr/bin/cmake3
 
 FROM cpu_final as cuda_final


### PR DESCRIPTION
Fixes errors such as https://github.com/pytorch/pytorch/actions/runs/23843825447/job/69506026235:
```
[2026-04-01T08:26:57.217Z] 2.366 Collecting cmake==3.18.4

[2026-04-01T08:26:57.217Z] 2.768   Could not find a version that satisfies the requirement cmake==3.18.4 (from versions: 0.1.0, 0.2.0, 0.4.0, 0.5.0, 0.6.0, 0.7.0, 0.7.1, 0.8.0, 0.9.0, 3.6.3.post1, 3.7.2, 3.8.2, 3.9.6, 3.10.3, 3.11.0, 3.11.4, 3.11.4.post1, 3.12.0, 3.13.0, 3.13.1, 3.13.2.post1, 3.13.3, 3.14.3.post1, 3.14.4.post1, 3.15.3.post1, 3.16.3.post1, 3.16.5, 3.16.6, 3.16.7, 3.16.8, 3.17.0, 3.17.1, 3.17.2, 3.17.3, 3.18.0, 3.18.2.post1, 3.18.4.post1, 3.20.2, 3.20.3, 3.20.4, 3.20.5, 3.21.0, 3.21.1.post1, 3.21.2, 3.21.3, 3.21.4, 3.22.0, 3.22.1, 3.22.2, 3.22.3, 3.22.4, 3.22.5, 3.22.6, 3.23.3, 3.24.0, 3.24.1, 3.24.1.1, 3.24.2, 3.24.3, 3.25.0, 3.25.2, 3.26.0, 3.26.1, 3.26.3, 3.26.4, 3.27.0, 3.27.1, 3.27.2, 3.27.4.1, 3.27.5, 3.27.6, 3.27.7, 3.27.9, 3.28.1, 3.28.3, 3.28.4)

[2026-04-01T08:26:57.217Z] 2.769 No matching distribution found for cmake==3.18.4
```