### PR TITLE
[dynamo] Preserve MHA fastpath layout while tracing

### DIFF
--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -5950,6 +5950,34 @@ def forward(self, s77 : torch.SymInt, s27 : torch.SymInt, L_x_ : torch.Tensor):
             self.assertEqual(len(compile_nodes), 0)
             self.assertEqual(len(export_nodes), 0)
 
+    def test_multiheadattention_tracing_slowpath_matches_fastpath_layout(self):
+        class MHAWithView(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.hidden_dim = 64
+                self.attention = nn.MultiheadAttention(
+                    self.hidden_dim, 8, batch_first=True
+                )
+
+            def forward(self, x):
+                attn_output, _ = self.attention(x, x, x)
+                return attn_output.view(-1, self.hidden_dim)
+
+        with torch.no_grad():
+            model = MHAWithView().eval()
+            x = torch.randn(4, 32, model.hidden_dim)
+            eager = model(x)
+
+            backend = EagerAndRecordGraphs()
+            compiled_model = torch.compile(model, backend=backend, fullgraph=True)
+            compiled = compiled_model(x)
+
+            compile_nodes = backend.graphs[0].graph.find_nodes(
+                op="call_function", target=torch._native_multi_head_attention
+            )
+            self.assertEqual(compiled, eager)
+            self.assertEqual(len(compile_nodes), 0)
+
     def test_negative_floor_div_solve(self):
         class CompiledClass(nn.Module):
             def __init__(self) -> None:

--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -1394,6 +1394,7 @@ class MultiheadAttention(Module):
         elif torch.is_autocast_enabled():
             why_not_fast_path = "autocast is enabled"
 
+        fast_path_blocked_by_tracing = False
         if not why_not_fast_path:
             tensor_args = (
                 query,
@@ -1408,8 +1409,6 @@ class MultiheadAttention(Module):
             # generator expressions.
             if torch.overrides.has_torch_function(tensor_args):
                 why_not_fast_path = "some Tensor argument has_torch_function"
-            elif _is_make_fx_tracing():
-                why_not_fast_path = "we are running make_fx tracing"
             elif not all(_check_arg_device(x) for x in tensor_args):
                 why_not_fast_path = (
                     "some Tensor argument's device is neither one of "
@@ -1422,6 +1421,9 @@ class MultiheadAttention(Module):
                     "grad is enabled and at least one of query or the "
                     "input/output projection weights or biases requires_grad"
                 )
+            elif _is_make_fx_tracing():
+                why_not_fast_path = "we are running make_fx tracing"
+                fast_path_blocked_by_tracing = True
             if not why_not_fast_path:
                 merged_mask, mask_type = self.merge_masks(
                     attn_mask, key_padding_mask, query
@@ -1511,7 +1513,11 @@ class MultiheadAttention(Module):
                 is_causal=is_causal,
             )
         if self.batch_first and is_batched:
-            return attn_output.transpose(1, 0), attn_output_weights
+            attn_output = attn_output.transpose(1, 0)
+            if fast_path_blocked_by_tracing:
+                # Keep the traced slowpath layout aligned with eager fastpath.
+                attn_output = attn_output.contiguous()
+            return attn_output, attn_output_weights
         else:
             return attn_output, attn_output_weights
 


### PR DESCRIPTION
Fix #178039

## Summary
1) What is the root cause problem
`nn.MultiheadAttention` disables `_native_multi_head_attention` while Dynamo/proxy-tensor tracing is active, so compile falls back to the transpose-based Python path even when eager would use the native fastpath. That slowpath returns a non-contiguous batch-first attention output, which makes a downstream `view()` fail during FakeTensor tracing on otherwise valid eager models.

2) What is the proposed fix
Keep tracing on the slowpath, but when tracing is the only reason the native fastpath was skipped, make the final batch-first attention output contiguous before returning it. This preserves the eager fastpath layout without reintroducing `_native_multi_head_attention` into traced graphs. The PR also adds a Dynamo regression test covering a compiled batch-first self-attention module followed by `view()`.

3) Why the proposed fix is the right long term fix
This fixes the correctness gap at the layout boundary that users observe today while preserving the existing export/compile decision to avoid `_native_multi_head_attention` in traced graphs. It keeps the change narrowly scoped to the tracing-only divergence instead of broadening eager behavior or reintroducing an op that export still cannot decompose.

Drafted via Codex, published after manual review by @bobrenjc93

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98