### PR TITLE
Fix Dynamo locals resume liveness after graph breaks

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -13314,6 +13314,30 @@ fn
 
         self.assertEqual(torch.compile(fn, backend="eager")().shape, (3, 5))
 
+    def test_locals_after_graph_break_preserves_live_locals(self):
+        cnts = CompileCounterWithBackend("eager")
+        counters.clear()
+
+        def fn(x):
+            if x.dim() > 2:
+                batch_size, seq_len, hidden_dim = x.shape
+                x = x.view(-1, hidden_dim)
+
+            x = x.sin()
+
+            if "batch_size" in locals() and "seq_len" in locals():
+                x = x.view(batch_size, seq_len, -1)
+
+            return x
+
+        x = torch.randn(2, 3, 4)
+        ref = fn(x)
+        res = torch.compile(fn, backend=cnts, fullgraph=False)(x)
+
+        self.assertTrue(same(ref, res))
+        self.assertEqual(res.shape, ref.shape)
+        self.assertEqual(len(counters["graph_break"]), 1)
+
     def test_raises_importerror1(self):
         @torch.compile(backend="eager")
         def fn(x):

--- a/torch/_dynamo/bytecode_analysis.py
+++ b/torch/_dynamo/bytecode_analysis.py
@@ -202,10 +202,7 @@ def inst_reads_all_locals(instructions: list["Instruction"], inst_idx: int) -> b
     if prev_idx < 0:
         return False
 
-    if (
-        instructions[prev_idx].opname == "PRECALL"
-        and instructions[prev_idx].arg == 0
-    ):
+    if instructions[prev_idx].opname == "PRECALL" and instructions[prev_idx].arg == 0:
         prev_idx -= 1
 
     return prev_idx >= 0 and _is_locals_builtin_load(instructions, prev_idx)

--- a/torch/_dynamo/bytecode_analysis.py
+++ b/torch/_dynamo/bytecode_analysis.py
@@ -169,29 +169,52 @@ def livevars_analysis(
     may = ReadsWrites(set(), set(), set())
     implicit_locals = set() if implicit_locals is None else implicit_locals
 
-    def reads_all_locals(inst_idx: int) -> bool:
+    def is_locals_builtin(inst_idx: int) -> bool:
         inst = instructions[inst_idx]
-        if inst.opname not in ("LOAD_GLOBAL", "LOAD_NAME") or inst.argval not in (
+        return inst.opname in ("LOAD_GLOBAL", "LOAD_NAME") and inst.argval in (
             "locals",
             "vars",
-        ):
+        )
+
+    def reads_all_locals(inst_idx: int) -> bool:
+        inst = instructions[inst_idx]
+        if is_locals_builtin(inst_idx):
+            if inst_idx + 1 >= len(instructions):
+                return False
+
+            next_inst = instructions[inst_idx + 1]
+            if next_inst.opname in ("CALL", "CALL_FUNCTION"):
+                return next_inst.arg == 0
+
+            if next_inst.opname == "PRECALL" and next_inst.arg == 0:
+                return (
+                    inst_idx + 2 < len(instructions)
+                    and instructions[inst_idx + 2].opname == "CALL"
+                    and instructions[inst_idx + 2].arg == 0
+                )
+
             return False
 
-        if inst_idx + 1 >= len(instructions):
-            return False
-
-        next_inst = instructions[inst_idx + 1]
-        if next_inst.opname in ("CALL", "CALL_FUNCTION"):
-            return next_inst.arg == 0
-
-        if next_inst.opname == "PRECALL" and next_inst.arg == 0:
+        if inst.opname == "PRECALL" and inst.arg == 0:
             return (
-                inst_idx + 2 < len(instructions)
-                and instructions[inst_idx + 2].opname == "CALL"
-                and instructions[inst_idx + 2].arg == 0
+                inst_idx + 1 < len(instructions)
+                and instructions[inst_idx + 1].opname == "CALL"
+                and instructions[inst_idx + 1].arg == 0
+                and inst_idx > 0
+                and is_locals_builtin(inst_idx - 1)
             )
 
-        return False
+        if inst.opname not in ("CALL", "CALL_FUNCTION") or inst.arg != 0:
+            return False
+
+        prev_idx = inst_idx - 1
+        if prev_idx < 0:
+            return False
+
+        if instructions[prev_idx].opname == "PRECALL" and instructions[prev_idx].arg == 0:
+            prev_idx -= 1
+
+        return prev_idx >= 0 and is_locals_builtin(prev_idx)
 
     def walk(state: ReadsWrites, start: int) -> None:
         if start in state.visited:

--- a/torch/_dynamo/bytecode_analysis.py
+++ b/torch/_dynamo/bytecode_analysis.py
@@ -160,11 +160,38 @@ class ReadsWrites:
 
 
 def livevars_analysis(
-    instructions: list["Instruction"], instruction: "Instruction"
+    instructions: list["Instruction"],
+    instruction: "Instruction",
+    implicit_locals: set[Any] | None = None,
 ) -> set[Any]:
     indexof = get_indexof(instructions)
     must = ReadsWrites(set(), set(), set())
     may = ReadsWrites(set(), set(), set())
+    implicit_locals = set() if implicit_locals is None else implicit_locals
+
+    def reads_all_locals(inst_idx: int) -> bool:
+        inst = instructions[inst_idx]
+        if inst.opname not in ("LOAD_GLOBAL", "LOAD_NAME") or inst.argval not in (
+            "locals",
+            "vars",
+        ):
+            return False
+
+        if inst_idx + 1 >= len(instructions):
+            return False
+
+        next_inst = instructions[inst_idx + 1]
+        if next_inst.opname in ("CALL", "CALL_FUNCTION"):
+            return next_inst.arg == 0
+
+        if next_inst.opname == "PRECALL" and next_inst.arg == 0:
+            return (
+                inst_idx + 2 < len(instructions)
+                and instructions[inst_idx + 2].opname == "CALL"
+                and instructions[inst_idx + 2].arg == 0
+            )
+
+        return False
 
     def walk(state: ReadsWrites, start: int) -> None:
         if start in state.visited:
@@ -173,6 +200,9 @@ def livevars_analysis(
 
         for i in range(start, len(instructions)):
             inst = instructions[i]
+            if implicit_locals and reads_all_locals(i):
+                # locals()/vars() with no args can observe every currently live local.
+                state.reads.update(implicit_locals - must.writes)
             if inst.opcode in HASLOCAL or inst.opcode in HASFREE:
                 if "LOAD" in inst.opname or "DELETE" in inst.opname:
                     if inst.argval not in must.writes:

--- a/torch/_dynamo/bytecode_analysis.py
+++ b/torch/_dynamo/bytecode_analysis.py
@@ -159,6 +159,58 @@ class ReadsWrites:
     visited: set[Any]
 
 
+def _is_locals_builtin_load(instructions: list["Instruction"], inst_idx: int) -> bool:
+    inst = instructions[inst_idx]
+    return inst.opname in ("LOAD_GLOBAL", "LOAD_NAME") and inst.argval in (
+        "locals",
+        "vars",
+    )
+
+
+def inst_reads_all_locals(instructions: list["Instruction"], inst_idx: int) -> bool:
+    inst = instructions[inst_idx]
+    if _is_locals_builtin_load(instructions, inst_idx):
+        if inst_idx + 1 >= len(instructions):
+            return False
+
+        next_inst = instructions[inst_idx + 1]
+        if next_inst.opname in ("CALL", "CALL_FUNCTION"):
+            return next_inst.arg == 0
+
+        if next_inst.opname == "PRECALL" and next_inst.arg == 0:
+            return (
+                inst_idx + 2 < len(instructions)
+                and instructions[inst_idx + 2].opname == "CALL"
+                and instructions[inst_idx + 2].arg == 0
+            )
+
+        return False
+
+    if inst.opname == "PRECALL" and inst.arg == 0:
+        return (
+            inst_idx + 1 < len(instructions)
+            and instructions[inst_idx + 1].opname == "CALL"
+            and instructions[inst_idx + 1].arg == 0
+            and inst_idx > 0
+            and _is_locals_builtin_load(instructions, inst_idx - 1)
+        )
+
+    if inst.opname not in ("CALL", "CALL_FUNCTION") or inst.arg != 0:
+        return False
+
+    prev_idx = inst_idx - 1
+    if prev_idx < 0:
+        return False
+
+    if (
+        instructions[prev_idx].opname == "PRECALL"
+        and instructions[prev_idx].arg == 0
+    ):
+        prev_idx -= 1
+
+    return prev_idx >= 0 and _is_locals_builtin_load(instructions, prev_idx)
+
+
 def livevars_analysis(
     instructions: list["Instruction"],
     instruction: "Instruction",
@@ -169,53 +221,6 @@ def livevars_analysis(
     may = ReadsWrites(set(), set(), set())
     implicit_locals = set() if implicit_locals is None else implicit_locals
 
-    def is_locals_builtin(inst_idx: int) -> bool:
-        inst = instructions[inst_idx]
-        return inst.opname in ("LOAD_GLOBAL", "LOAD_NAME") and inst.argval in (
-            "locals",
-            "vars",
-        )
-
-    def reads_all_locals(inst_idx: int) -> bool:
-        inst = instructions[inst_idx]
-        if is_locals_builtin(inst_idx):
-            if inst_idx + 1 >= len(instructions):
-                return False
-
-            next_inst = instructions[inst_idx + 1]
-            if next_inst.opname in ("CALL", "CALL_FUNCTION"):
-                return next_inst.arg == 0
-
-            if next_inst.opname == "PRECALL" and next_inst.arg == 0:
-                return (
-                    inst_idx + 2 < len(instructions)
-                    and instructions[inst_idx + 2].opname == "CALL"
-                    and instructions[inst_idx + 2].arg == 0
-                )
-
-            return False
-
-        if inst.opname == "PRECALL" and inst.arg == 0:
-            return (
-                inst_idx + 1 < len(instructions)
-                and instructions[inst_idx + 1].opname == "CALL"
-                and instructions[inst_idx + 1].arg == 0
-                and inst_idx > 0
-                and is_locals_builtin(inst_idx - 1)
-            )
-
-        if inst.opname not in ("CALL", "CALL_FUNCTION") or inst.arg != 0:
-            return False
-
-        prev_idx = inst_idx - 1
-        if prev_idx < 0:
-            return False
-
-        if instructions[prev_idx].opname == "PRECALL" and instructions[prev_idx].arg == 0:
-            prev_idx -= 1
-
-        return prev_idx >= 0 and is_locals_builtin(prev_idx)
-
     def walk(state: ReadsWrites, start: int) -> None:
         if start in state.visited:
             return
@@ -223,7 +228,7 @@ def livevars_analysis(
 
         for i in range(start, len(instructions)):
             inst = instructions[i]
-            if implicit_locals and reads_all_locals(i):
+            if implicit_locals and inst_reads_all_locals(instructions, i):
                 # locals()/vars() with no args can observe every currently live local.
                 state.reads.update(implicit_locals - must.writes)
             if inst.opcode in HASLOCAL or inst.opcode in HASFREE:

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -1245,7 +1245,11 @@ class InstructionTranslatorBase(
             if k in self.cell_and_freevars()
         }
         # Only keep the locals that must remain on the stack.
-        reads = livevars_analysis(self.instructions, self.current_instruction)
+        reads = livevars_analysis(
+            self.instructions,
+            self.current_instruction,
+            set(self.symbolic_locals),
+        )
         self.symbolic_locals = {
             k: v for k, v in self.symbolic_locals.items() if k in reads
         }
@@ -2964,7 +2968,11 @@ class InstructionTranslatorBase(
         # There should not be any pruning in the other frames since
         # the current instruction there should be a CALL.
         if is_leaf:
-            reads = livevars_analysis(self.instructions, resume_inst)
+            reads = livevars_analysis(
+                self.instructions,
+                resume_inst,
+                set(self.symbolic_locals),
+            )
             all_argnames = tuple(
                 k
                 for k in self.symbolic_locals

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -67,6 +67,7 @@ from . import (
 )
 from .bytecode_analysis import (
     get_indexof,
+    inst_reads_all_locals,
     JUMP_OPNAMES,
     livevars_analysis,
     propagate_line_nums,
@@ -980,6 +981,36 @@ def break_graph_if_unsupported(
             _reconstruct_block_stack(self, cg, cleanup)
             self.output.add_output_instructions(cg.get_instructions())
             del cg
+
+            current_frame_meta = all_stack_locals_metadata[0]
+            if current_frame_meta.locals_names and inst_reads_all_locals(
+                self.instructions, get_indexof(self.instructions)[inst]
+            ):
+                # locals()/vars() inspects the active frame before the resume
+                # function reloads fast locals, so materialize the current
+                # frame's live locals before we execute the unsupported call.
+                current_num_stack = len(self.stack) - len(
+                    current_frame_meta.stack_null_idxes
+                )
+                cg = PyCodegen(self.output.root_tx)
+                self.output.add_output_instructions(
+                    [
+                        *create_copy(current_num_stack + 1),
+                        cg.create_load_const(0),
+                        cg.create_binary_subscr(),
+                    ]
+                )
+                for local, idx in current_frame_meta.locals_names.items():
+                    self.output.add_output_instructions(
+                        [
+                            create_dup_top(),
+                            cg.create_load_const(idx),
+                            cg.create_binary_subscr(),
+                            cg.create_store(local),
+                        ]
+                    )
+                self.output.add_output_instructions([create_instruction("POP_TOP")])
+                del cg
 
             if sys.version_info >= (3, 11) and inst.opname == "CALL":
                 kw_names = (


### PR DESCRIPTION
Fix #178041

## Summary
This fixes a Dynamo silent correctness issue when `locals()` (or `vars()` with no arguments) appears after a graph break in a partially compiled function.

1. Root cause problem
Dynamo's resume-path liveness analysis only treated explicit `LOAD_FAST`/`LOAD_DEREF` reads as live. When a later `locals()` check implicitly read the current frame locals, values like `batch_size` and `seq_len` were pruned as dead locals during graph-break resume reconstruction, so post-break control flow could observe the wrong local state.

2. Proposed fix
Teach `livevars_analysis()` to treat zero-argument `locals()` and `vars()` calls as implicit reads of the currently live locals, and thread the current symbolic locals through the two resume-time liveness checks that decide which locals to preserve.

3. Why this is the right long term fix
The bug is in Dynamo's bytecode-level liveness model, not in any individual backend. Fixing the liveness accounting at the graph-break boundary preserves Python semantics for all backends that rely on the same resume path, and the added regression test locks in the expected reshape behavior for this class of partial-graph programs.

## Testing
- Added a Dynamo regression test covering a post-graph-break `locals()` reshape path.
- Sanity-checked the edited Python files with `python3 -m py_compile`.

Drafted via Codex, published after manual review by @bobrenjc93

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98