### PR TITLE
[xpu] Add deterministic matmul test to test_gemm.py

### DIFF
--- a/test/xpu/test_gemm.py
+++ b/test/xpu/test_gemm.py
@@ -872,9 +872,10 @@ class TestBasicGEMM(TestCase):
         self.assertEqual(c, cpu_result)
 
     @parametrize("shape", [513, 767])
-    def test_matmul_deterministic_mode(self, device, shape):
+    @dtypes(torch.bfloat16, torch.half, torch.float, torch.double)
+    def test_matmul_deterministic_mode(self, device, shape, dtype):
         with DeterministicGuard(True):
-            inp = torch.randn(shape, shape, device=device, dtype=torch.float32)
+            inp = torch.randn(shape, shape, device=device, dtype=dtype)
             first = torch.matmul(inp, inp)
             for _ in range(10):
                 self.assertEqual(first, torch.matmul(inp, inp), atol=0.0, rtol=0.0)

--- a/test/xpu/test_gemm.py
+++ b/test/xpu/test_gemm.py
@@ -26,6 +26,7 @@ from torch.testing._internal.common_quantization import (
     _dynamically_quantize_per_channel,
 )
 from torch.testing._internal.common_utils import (
+    DeterministicGuard,
     iter_indices,
     parametrize,
     run_tests,
@@ -869,6 +870,14 @@ class TestBasicGEMM(TestCase):
         cpu_result = torch.matmul(a.cpu().float(), b.cpu().float()).half()
         torch.matmul(a, b, out=c)
         self.assertEqual(c, cpu_result)
+
+    @parametrize("shape", [513, 767])
+    def test_matmul_deterministic_mode(self, device, shape):
+        with DeterministicGuard(True):
+            inp = torch.randn(shape, shape, device=device, dtype=torch.float32)
+            first = torch.matmul(inp, inp)
+            for _ in range(10):
+                self.assertEqual(first, torch.matmul(inp, inp), atol=0.0, rtol=0.0)
 
     @dtypes(
         torch.int16,


### PR DESCRIPTION
## Summary

Adds `test_matmul_deterministic_mode` to `test/xpu/test_gemm.py` to verify that
`torch.matmul` produces bit-identical results across repeated calls when deterministic
algorithms are enabled via `torch.use_deterministic_algorithms(True)`.

## Motivation

XPU implementation allows using deterministic mode for matmul, so we should test if it produce correct results.

The two shapes (`513` and `767`) are chosen to cover non-power-of-two sizes that
commonly expose non-determinism in GPU tiling strategies.

This PR is a follow up task after conversation in https://github.com/intel/torch-xpu-ops/pull/3201

## Changes

### `test/xpu/test_gemm.py`

- Added `DeterministicGuard` to the `torch.testing._internal.common_utils` import block.
- Added `test_matmul_deterministic_mode` to `TestBasicGEMM`.
