### PR TITLE
[ROCm][CI] adjust paths for rocm-nightly Docker image

### DIFF
--- a/.ci/docker/common/install_rocm.sh
+++ b/.ci/docker/common/install_rocm.sh
@@ -29,11 +29,11 @@ install_ubuntu() {
     # When ROCM_VERSION=nightly, install ROCm from TheRock nightly tarballs
     # Mirrors: https://github.com/ROCm/TheRock/blob/main/dockerfiles/install_rocm_tarball.sh
     if [[ "${ROCM_VERSION}" == "nightly" ]]; then
-      # rocm_smi cmake config uses pkg_check_modules(REQUIRED libdrm);
-      # the tarball bundles libdrm under rocm_sysdeps but its .pc file
-      # may not be on the default pkg-config search path, so install the
-      # system package to satisfy the check at cmake configure time.
-      apt-get install -y --no-install-recommends libdrm-dev pkg-config
+      # TheRock tarball consumers need system -dev packages whose .pc files
+      # are not on the default pkg-config search path:
+      #   libdrm  - rocm_smi cmake config (pkg_check_modules)
+      #   liblzma - aotriton cmake config  (pkg_search_module)
+      apt-get install -y --no-install-recommends libdrm-dev liblzma-dev pkg-config
 
       if [[ -d /opt/rocm ]]; then
         rm -rf /opt/rocm

--- a/.ci/docker/common/install_rocm.sh
+++ b/.ci/docker/common/install_rocm.sh
@@ -29,6 +29,12 @@ install_ubuntu() {
     # When ROCM_VERSION=nightly, install ROCm from TheRock nightly tarballs
     # Mirrors: https://github.com/ROCm/TheRock/blob/main/dockerfiles/install_rocm_tarball.sh
     if [[ "${ROCM_VERSION}" == "nightly" ]]; then
+      # rocm_smi cmake config uses pkg_check_modules(REQUIRED libdrm);
+      # the tarball bundles libdrm under rocm_sysdeps but its .pc file
+      # may not be on the default pkg-config search path, so install the
+      # system package to satisfy the check at cmake configure time.
+      apt-get install -y --no-install-recommends libdrm-dev pkg-config
+
       if [[ -d /opt/rocm ]]; then
         rm -rf /opt/rocm
       fi

--- a/.ci/docker/common/install_rocm.sh
+++ b/.ci/docker/common/install_rocm.sh
@@ -29,11 +29,8 @@ install_ubuntu() {
     # When ROCM_VERSION=nightly, install ROCm from TheRock nightly tarballs
     # Mirrors: https://github.com/ROCm/TheRock/blob/main/dockerfiles/install_rocm_tarball.sh
     if [[ "${ROCM_VERSION}" == "nightly" ]]; then
-      # TheRock tarball consumers need system -dev packages whose .pc files
-      # are not on the default pkg-config search path:
-      #   libdrm  - rocm_smi cmake config (pkg_check_modules)
-      #   liblzma - aotriton cmake config  (pkg_search_module)
-      apt-get install -y --no-install-recommends libdrm-dev liblzma-dev pkg-config
+      # aotriton cmake config uses pkg_search_module(liblzma)
+      apt-get install -y --no-install-recommends liblzma-dev pkg-config
 
       if [[ -d /opt/rocm ]]; then
         rm -rf /opt/rocm
@@ -139,6 +136,8 @@ export C_INCLUDE_PATH=/opt/rocm/lib/rocm_sysdeps/include:\${C_INCLUDE_PATH:-}
 # Device library path
 export HIP_DEVICE_LIB_PATH=/opt/rocm/amdgcn/bitcode
 export MAGMA_HOME=/opt/rocm/magma
+# Tarball bundles libdrm; expose its .pc files so cmake pkg_check_modules finds them
+export PKG_CONFIG_PATH=/opt/rocm/lib/rocm_sysdeps/lib/pkgconfig:\${PKG_CONFIG_PATH:-}
 # Disable MSLK for theRock nightly (not yet supported)
 export USE_MSLK=0
 ROCM_ENV

--- a/.ci/docker/common/install_rocm.sh
+++ b/.ci/docker/common/install_rocm.sh
@@ -29,8 +29,7 @@ install_ubuntu() {
     # When ROCM_VERSION=nightly, install ROCm from TheRock nightly tarballs
     # Mirrors: https://github.com/ROCm/TheRock/blob/main/dockerfiles/install_rocm_tarball.sh
     if [[ "${ROCM_VERSION}" == "nightly" ]]; then
-      # aotriton cmake config uses pkg_search_module(liblzma)
-      apt-get install -y --no-install-recommends liblzma-dev pkg-config
+      apt-get install -y --no-install-recommends pkg-config
 
       if [[ -d /opt/rocm ]]; then
         rm -rf /opt/rocm
@@ -136,8 +135,11 @@ export C_INCLUDE_PATH=/opt/rocm/lib/rocm_sysdeps/include:\${C_INCLUDE_PATH:-}
 # Device library path
 export HIP_DEVICE_LIB_PATH=/opt/rocm/amdgcn/bitcode
 export MAGMA_HOME=/opt/rocm/magma
-# Tarball bundles libdrm; expose its .pc files so cmake pkg_check_modules finds them
-export PKG_CONFIG_PATH=/opt/rocm/lib/rocm_sysdeps/lib/pkgconfig:\${PKG_CONFIG_PATH:-}
+# Tarball bundles sysdeps (libdrm, liblzma, etc.); expose their libs and .pc files
+if [ -d /opt/rocm/lib/rocm_sysdeps/lib ]; then
+  export LD_LIBRARY_PATH=/opt/rocm/lib/rocm_sysdeps/lib:\${LD_LIBRARY_PATH}
+  export PKG_CONFIG_PATH=/opt/rocm/lib/rocm_sysdeps/lib/pkgconfig:\${PKG_CONFIG_PATH:-}
+fi
 # Disable MSLK for theRock nightly (not yet supported)
 export USE_MSLK=0
 ROCM_ENV


### PR DESCRIPTION
TheRock nightly tarballs now require libdrm to be discoverable via pkg-config at cmake configure time, due to ROCm/rocm-systems@63f78a98d7c2 which added find_dependency(PkgConfig) and pkg_check_modules(REQUIRED libdrm) to rocm_smi-config.cmake.in (fixing ROCm/TheRock#3702). This was not caught until the Apr 1 scheduled run (https://github.com/pytorch/pytorch/actions/runs/23826393469) because prior runs used a cached Docker image that predated the change.

The build failed with two errors:

1. CMake configure could not find libdrm or liblzma via pkg-config:
```
CMake Error at FindPkgConfig.cmake:645: The following required packages were not found: - libdrm
CMake Error at FindPkgConfig.cmake:938: None of the required 'liblzma' found
```

2. The linker could not find the bundled rocm_sysdeps libraries needed by aotriton:
```
/usr/bin/ld: warning: librocm_sysdeps_liblzma.so.5, needed by libaotriton_v2.so, not found
undefined reference to `lzma_stream_decoder@AMDROCM_SYSDEPS_1.0'
```

The TheRock tarball bundles these dependencies under lib/rocm_sysdeps/ with their own .pc files and shared libraries. This PR adds rocm_sysdeps/lib to LD_LIBRARY_PATH and its pkgconfig directory to PKG_CONFIG_PATH in rocm_env.sh so both cmake and the linker discover them without requiring system -dev packages.
build and tests pass successfully: https://hud.pytorch.org/pr/179009
<img width="475" height="288" alt="{A430D67B-D525-48FA-9B09-3B5C36E96FCA}" src="https://github.com/user-attachments/assets/64cb3c9b-c05a-4f27-ba3b-490a6f3867eb" />

The test failure was seen also on main: `FAILED [0.5276s] inductor/test_torchinductor_opinfo_properties.py::TestOpInfoPropertiesCUDA::test_binary_ufunc_numerical_fmod_backend_inductor_default_cuda_bfloat16 - AssertionError: XPASS: fmod/inductor_default/torch.bfloat16 - remove from binary_numerical xfails` https://github.com/pytorch/pytorch/actions/runs/23928615757/job/69793171359

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang