### PR TITLE
[Inductor][NVGEMM] Wrap GroupedGemmArguments in try/except

### DIFF
--- a/torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm.py
+++ b/torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm.py
@@ -371,13 +371,17 @@ def _add_nv_gemm_choices_impl(
     if variant == GemmVariant.GROUPED_GEMM:
         a_tensor, b_tensor, offs_tensor = dummy_tensors
         assert b_tensor is not None
-        args = cutlass_api.arguments.GroupedGemmArguments(
-            a_tensor,
-            b_tensor,
-            out_tensor,
-            accumulator_type=accumulator_type,
-            offsets=offs_tensor,
-        )
+        try:
+            args = cutlass_api.arguments.GroupedGemmArguments(
+                a_tensor,
+                b_tensor,
+                out_tensor,
+                accumulator_type=accumulator_type,
+                offsets=offs_tensor,
+            )
+        except Exception:
+            log.debug("GroupedGemmArguments creation failed", exc_info=True)
+            return
     elif variant == GemmVariant.SCALED_GEMM:
         from cutlass_api.arguments import ScaledTensor
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #179049
* __->__ #179014
* #179013
* #176859
* #176847
* #176845
* #176549
* #176548
* #176547
* #176546
* #176545
* #176544
* #176543

GroupedGemmArguments construction can fail with edge-case tensor
shapes during kernel enumeration. Catch the exception and skip
NVGEMM for that op rather than crashing compilation.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo