### PR TITLE
[Inductor] Register lowering for prims.scalar_tensor (#179017)

### DIFF
--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -3679,7 +3679,7 @@ def _unwrap(x):
     return x
 
 
-@register_lowering([torch.tensor, aten.scalar_tensor])
+@register_lowering([torch.tensor, aten.scalar_tensor, prims.scalar_tensor])
 def tensor(data, *, dtype=None, device=None, layout=None, pin_memory=False):
     assert_nyi(layout in (None, torch.strided), f"layout={layout}")
     assert_nyi(not pin_memory, "pin_memory")


### PR DESCRIPTION
Summary:

Fix `prims.scalar_tensor` handling in two places:

1. **Inductor lowering** (`lowering.py`): Add `prims.scalar_tensor` to the existing `register_lowering` for `torch.tensor` and `aten.scalar_tensor`. The existing lowering handles scalar values correctly — just expanding the registration list.

2. **FBA pipeline** (`fba_inductor.py`): Add `_replace_scalar_tensor_with_cast` to `_dynamic_shape_preprocessing`. With auto dynamic shapes, `_refs` decompositions (e.g. `xlogy`) trace `prims.scalar_tensor(scalar_val)` during Dynamo. Dynamo lifts the scalar to a 0-dim tensor placeholder, but the graph still has `prims.scalar_tensor(placeholder)` which fails during functionalization: `prims::scalar_tensor() Expected 'number' but found 'FunctionalTensor'`. Since the placeholder is already a 0-dim tensor, we replace with `aten._to_copy` for dtype casting.

This fixes ~200 xlogy failures and benefits any op that decomposes through `_refs` using `prims.scalar_tensor` (e.g. `xlog1py`).

**Changed files**:
- `torch/_inductor/lowering.py` — add `prims.scalar_tensor` to lowering registration (mirrored to xplat)
- `glow/fb/fx/fba/fba_inductor.py` — replace `prims.scalar_tensor(placeholder)` with dtype cast in `_dynamic_shape_preprocessing`

Test Plan:
Local opinfo e2e test with OPINFO_AUTO_DS=1:
- 5/5 xlogy tests pass (tensor-tensor, tensor-scalar, scalar-tensor variants)
- Before fix: scalar variants failed with "prims::scalar_tensor() Expected 'number' but found 'FunctionalTensor'"
- Existing parametrized test_special_op covers xlogy tensor-tensor variant in OSS tests

Reviewed By: aneeshgupta42

Differential Revision: D98758672




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo