### PR TITLE
[AMD] Use optimized tiled kernel for LayerNorm gamma beta backward

### DIFF
--- a/aten/src/ATen/native/cuda/layer_norm_kernel.cu
+++ b/aten/src/ATen/native/cuda/layer_norm_kernel.cu
@@ -955,7 +955,11 @@ void LaunchGammaBetaBackwardCUDAKernel(
     Tensor* dgamma,
     Tensor* dbeta,
     cudaStream_t cuda_stream) {
+#ifdef USE_ROCM
+  constexpr int block_dim_x = 64;
+#else
   constexpr int block_dim_x = 32;
+#endif
   const int sm_count = at::cuda::getCurrentDeviceProperties()->multiProcessorCount;
   if (M > 64 * 1024 && N / block_dim_x < sm_count / 2) {
     // We have a situation where M >> N and N is small.
@@ -1010,7 +1014,13 @@ void LaunchGammaBetaBackwardCUDAKernel(
     } else if (M < 256) {
       ConfigureAndLaunchGammaBetaBackwardKernel<T, T_ACC, block_dim_x, 16, 128, rms_norm>(dY_data, X_data, mean_data, rstd_data, M, N, dgamma, dbeta, cuda_stream);
     } else {
+#ifdef USE_ROCM
+      // Cap block_dim_y at 16 to keep total threads (64*16=1024) within GPU limits.
+      // rows_per_thread_y = 256/16 = 16, still within warp size constraint.
+      ConfigureAndLaunchGammaBetaBackwardKernel<T, T_ACC, block_dim_x, 16, 256, rms_norm>(dY_data, X_data, mean_data, rstd_data, M, N, dgamma, dbeta, cuda_stream);
+#else
       ConfigureAndLaunchGammaBetaBackwardKernel<T, T_ACC, block_dim_x, 32, 256, rms_norm>(dY_data, X_data, mean_data, rstd_data, M, N, dgamma, dbeta, cuda_stream);
+#endif
     }
   }
 }
@@ -1617,40 +1627,12 @@ void LayerNormBackwardKernelImplInternal(
               dbeta_data);
       C10_CUDA_KERNEL_LAUNCH_CHECK();
     } else {
-      // For small batch size, do colwise reduce directly.
-      const int part_size = warp_size;
-      const dim3 threads2(warp_size, 4, 1);
-      const dim3 blocks2((N + threads2.x - 1) / threads2.x, part_size, 1);
-      const int nshared2_a = 2 * sizeof(T_ACC) * threads2.y * threads2.y * (threads2.x + 1);
-      const int nshared2_b = threads2.x * threads2.y * sizeof(T_ACC);
-      const int nshared2 = nshared2_a > nshared2_b ? nshared2_a : nshared2_b;
-
-      const auto part_grad_dtype = at::toAccumulateType(X.scalar_type(), true);
-      Tensor part_grad_gamma = at::empty({part_size,N}, gamma.options().dtype(part_grad_dtype));
-      Tensor part_grad_beta = at::native::empty_like(part_grad_gamma);
-
-      cuComputePartGradGammaBeta<T, T_ACC, rms_norm><<<blocks2, threads2, nshared2, cuda_stream>>>(
-                      dY_data,
-                      X_data,
-                      M,N,
-                      mean_data,
-                      rstd_data,
-                      part_grad_gamma.template data_ptr<T_ACC>(),
-                      part_grad_beta.template data_ptr<T_ACC>());
-      C10_CUDA_KERNEL_LAUNCH_CHECK();
-
-      const dim3 threads3(warp_size, 8, 1); // Optimization for ROCm
-      const dim3 blocks3((N + threads3.x - 1) / threads3.x, 1, 1);
-      const int nshared3 = threads3.x * threads3.y * sizeof(T_ACC);
-
-      cuComputeGradGammaBeta<T, T_ACC, rms_norm><<<blocks3, threads3, nshared3, cuda_stream>>>(
-                      part_grad_gamma.template data_ptr<T_ACC>(),
-                      part_grad_beta.template data_ptr<T_ACC>(),
-                      part_size,
-                      M,N,
-                      dgamma_data,
-                      dbeta_data);
-      C10_CUDA_KERNEL_LAUNCH_CHECK();
+      // Use the optimized tiled kernel adapted for wavefront-64.
+      // This replaces the legacy two-pass cuComputePartGradGammaBeta +
+      // cuComputeGradGammaBeta approach with a single-pass tiled reduction
+      // that has coalesced memory access and adaptive tile sizing.
+      LaunchGammaBetaBackwardCUDAKernel<T, T_ACC, rms_norm>(
+        dY_data, X_data, mean_data, rstd_data, M, N, dgamma, dbeta, cuda_stream);
     }
 #else
     LaunchGammaBetaBackwardCUDAKernel<T, T_ACC, rms_norm>(


### PR DESCRIPTION
Summary: Adopt the GammaBetaBackwardCUDAKernelTemplate tiled kernel introduced in D72575858 for ROCm, replacing the legacy two-pass cuComputePartGradGammaBeta and cuComputeGradGammaBeta approach. This brings AMD towards Nvidia parity.

Test Plan:
Results:
- Local Benchmark:
  - Higher performance across 39 shapes: 1.02x speedup on mi350 (1 pass vs 2 pass implementation)
  - Higher numerical accuracy on mi350 vs h100
    - Avg rel error vs CPU fp32 (mi350): dgamma=3.040359e-06  dbeta=1.750184e-06
     - Avg rel error vs CPU fp32 (h100): dgamma=3.506308e-06  dbeta=1.792510e-06
- E2E Test
  - 1.02x speedup in qps
    - baseline: 765k
    - with diff: 782k


```
Benchmarks:
buck2 run //scripts/echen40/amd/benchmark/layer_norm:layer_norm_backward_benchmark -- \
    --correctness --label h100
HIP_VISIBLE_DEVICES=2 buck2 run @//mode/opt-amd-gpu -m rocm70 -m ovr_config//triton:beta -m rccl_dev -m fbcode//triton/cc:force_noop -c fbcode.split-dwarf=True \
    //scripts/echen40/amd/benchmark/layer_norm:layer_norm_backward_benchmark -- \
    --correctness --label mi350 --compare h100
HIP_VISIBLE_DEVICES=2 buck2 run @//mode/opt-amd-gpu -m rocm70 -m ovr_config//triton:beta -m rccl_dev -m fbcode//triton/cc:force_noop -c fbcode.split-dwarf=True  \
    //scripts/echen40/amd/benchmark/layer_norm:layer_norm_backward_benchmark -- \
    --performance --label mi350x_2pass
HIP_VISIBLE_DEVICES=2 buck2 run @//mode/opt-amd-gpu -m rocm70 -m ovr_config//triton:beta -m rccl_dev -m fbcode//triton/cc:force_noop -c fbcode.split-dwarf=True \
    //scripts/echen40/amd/benchmark/layer_norm:layer_norm_backward_benchmark -- \
    --performance --label mi350x_1pass --compare mi350x_2pass
```

E2E tests:
Baseline: 765k qps
https://www.internalfb.com/mlhub/pipelines/runs/mast/aps-cmf_amd_echen40_20260320_131047-d9f3209936?job_attempt=0&version=0&tab=tb_legacy
With diff: 782k qps
https://www.internalfb.com/mlhub/pipelines/runs/mast/aps-cmf_amd_echen40_20260320_141250-d9120ce4bb?job_attempt=1&version=0&tab=tb_legacy

Reviewed By: jhadidjojo

Differential Revision: D98176771


