### PR TITLE
Update third-party/rocm_composable_kernel to f1746955

### DIFF
--- a/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_fwd_ck.hip
+++ b/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_fwd_ck.hip
@@ -112,6 +112,8 @@ fmha_fwd_args get_ck_fmha_fwd_args(bool has_lse,
                          nullptr, // seqlen_k_ptr
                          nullptr, // cu_seqlen_q_ptr
                          nullptr, // cu_seqlen_k_ptr
+                         nullptr, // block_scale_seqstart_q_ptr
+                         nullptr, // block_scale_seqstart_k_ptr
                          nullptr, // sink_ptr
                          seqlen_q,
                          seqlen_k,
@@ -136,6 +138,9 @@ fmha_fwd_args get_ck_fmha_fwd_args(bool has_lse,
                          nhead_stride_randval,
                          nhead_stride_lse,
                          nhead_stride_o,
+                         0,                                 // nhead_stride_q_descale
+                         0,                                 // nhead_stride_k_descale
+                         0,                                 // nhead_stride_v_descale
                          batch_stride_q,
                          batch_stride_k,
                          batch_stride_v,
@@ -143,6 +148,9 @@ fmha_fwd_args get_ck_fmha_fwd_args(bool has_lse,
                          batch_stride_randval,
                          batch_stride_lse,
                          batch_stride_o,
+                         0,                                 // batch_stride_q_descale
+                         0,                                 // batch_stride_k_descale
+                         0,                                 // batch_stride_v_descale
                          mask.left,
                          mask.right,
                          0,                                 // sink_size
@@ -150,7 +158,13 @@ fmha_fwd_args get_ck_fmha_fwd_args(bool has_lse,
                          -1,                                // min_seqlen_q
                          p_dropout,
                          has_dropout_randval,
-                         drop_seed_offset};
+                         std::pair<const void*, const void*>{drop_seed_offset.first, drop_seed_offset.second},
+                         nullptr,                           // block_mask_ptr
+                         0,                                 // stride_block_mask
+                         0,                                 // nhead_stride_block_mask
+                         0,                                 // batch_stride_block_mask
+                         0,                                 // block_scale_size_q
+                         0};                                // block_scale_size_kv
 }
 
 std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor>

--- a/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_varlen_fwd_ck.hip
+++ b/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_varlen_fwd_ck.hip
@@ -113,6 +113,8 @@ fmha_fwd_args get_ck_fmha_varlen_fwd_args(bool has_lse,
                          nullptr, // seqlen_k_ptr
                          nullptr, // cu_seqlen_q_ptr
                          nullptr, // cu_seqlen_k_ptr
+                         nullptr, // block_scale_seqstart_q_ptr
+                         nullptr, // block_scale_seqstart_k_ptr
                          nullptr, // sink_ptr
                          total_q,
                          total_k,
@@ -137,6 +139,9 @@ fmha_fwd_args get_ck_fmha_varlen_fwd_args(bool has_lse,
                          nhead_stride_randval,
                          nhead_stride_lse,
                          nhead_stride_o,
+                         0, // nhead_stride_q_descale
+                         0, // nhead_stride_k_descale
+                         0, // nhead_stride_v_descale
                          batch_stride_q,
                          batch_stride_k,
                          batch_stride_v,
@@ -144,14 +149,23 @@ fmha_fwd_args get_ck_fmha_varlen_fwd_args(bool has_lse,
                          batch_stride_randval,
                          batch_stride_lse,
                          batch_stride_o,
+                         0, // batch_stride_q_descale
+                         0, // batch_stride_k_descale
+                         0, // batch_stride_v_descale
                          mask.left,
                          mask.right,
                          0,             // sink_size
                          static_cast<ck_tile::index_t>(mask.type),
-                         -1,                                // min_seqlen_q
+                         -1,            // min_seqlen_q
                          p_dropout,
                          has_dropout_randval,
-                         drop_seed_offset};
+                         std::pair<const void*, const void*>{drop_seed_offset.first, drop_seed_offset.second},
+                         nullptr,       // block_mask_ptr
+                         0,             // stride_block_mask
+                         0,             // nhead_stride_block_mask
+                         0,             // batch_stride_block_mask
+                         0,             // block_scale_size_q
+                         0};            // block_scale_size_kv
 }
 
 std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor>


### PR DESCRIPTION
Summary: Bumps internal CK to this commit `f1746955` to unblock https://github.com/pytorch/pytorch/pull/178539. This diff is just mgt import, downstream CI fixes are D98344491 kept separately for easier review, but will be squashed for landing.

Test Plan: mgt upgrade --src-type git https://github.com/ROCm/composable_kernel --git-commit f1746955fdaf80a3414de814bf32437686dac347 --name rocm_composable_kernel  --use-unversioned-structure --skip-patches

Reviewed By: wychi

Differential Revision: D98343335


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang