### PR TITLE
Error on torch.utils.checkpoint under non-strict tracing

### DIFF
--- a/test/dynamo/test_activation_checkpointing.py
+++ b/test/dynamo/test_activation_checkpointing.py
@@ -2637,6 +2637,37 @@ instantiate_device_type_tests(
     ActivationCheckpointingViaTagsTests, globals(), only_for=devices
 )
 
+
+class ActivationCheckpointingNonStrictTracerTests(torch._dynamo.test_case.TestCase):
+    """Tests for non-strict tracing flag interaction with checkpoint."""
+
+    def test_checkpoint_errors_under_non_strict_tracing(self):
+        from torch.fx.experimental.proxy_tensor import make_fx
+
+        def fn(x):
+            return checkpoint(torch.sin, x, use_reentrant=False)
+
+        with torch.compiler._non_strict_tracing_context():
+            with self.assertRaisesRegex(
+                RuntimeError, "torch.utils.checkpoint is not supported"
+            ):
+                make_fx(fn)(torch.randn(4, requires_grad=True))
+
+    def test_checkpoint_errors_under_non_strict_tracing_preserve_rng_false(self):
+        from torch.fx.experimental.proxy_tensor import make_fx
+
+        def fn(x):
+            return checkpoint(
+                torch.sin, x, use_reentrant=False, preserve_rng_state=False
+            )
+
+        with torch.compiler._non_strict_tracing_context():
+            with self.assertRaisesRegex(
+                RuntimeError, "torch.utils.checkpoint is not supported"
+            ):
+                make_fx(fn)(torch.randn(4, requires_grad=True))
+
+
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests
 

--- a/torch/compiler/__init__.py
+++ b/torch/compiler/__init__.py
@@ -1,4 +1,5 @@
 # mypy: allow-untyped-defs
+import contextlib
 import io
 from collections.abc import Callable
 from typing import Any, TypeVar
@@ -433,6 +434,7 @@ def wrap_numpy(fn):
 
 _is_compiling_flag: bool = False
 _is_exporting_flag: bool = False
+_is_non_strict_tracing_flag: bool = False
 
 
 def is_compiling() -> bool:
@@ -455,6 +457,25 @@ def is_compiling() -> bool:
         return False
     else:
         return _is_compiling_flag
+
+
+def _is_non_strict_tracing() -> bool:
+    """
+    Indicates whether we are inside a non-strict make_fx-based tracing session.
+    """
+    return _is_non_strict_tracing_flag
+
+
+@contextlib.contextmanager
+def _non_strict_tracing_context():
+    """Context manager that sets the non-strict tracing flag."""
+    global _is_non_strict_tracing_flag
+    old = _is_non_strict_tracing_flag
+    try:
+        _is_non_strict_tracing_flag = True
+        yield
+    finally:
+        _is_non_strict_tracing_flag = old
 
 
 def is_dynamo_compiling() -> bool:

--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -1539,6 +1539,15 @@ def _checkpoint_without_reentrant_generator(
             f"but got {determinism_check}"
         )
 
+    if torch.compiler._is_non_strict_tracing():
+        # TODO: update this error message once we have a proper pipeline in torchtitan
+        raise RuntimeError(
+            "torch.utils.checkpoint is not supported under non-strict tracing "
+            "because the checkpoint machinery (RNG state stashing, saved tensor hooks) "
+            "is not traceable. Please use torch.compile or use graph-based Activation "
+            "Checkpointing instead. Reach out to the PT2 team for help migrating."
+        )
+
     device_type = _infer_device_type(*args)
     device_module = _get_device_module(device_type)
     forward_context, recompute_context = context_fn()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #179021

The eager checkpoint machinery (RNG state stashing via get/set_rng_state,
saved tensor hooks) is not traceable through make_fx — the ops are
silently dropped from the graph. Add an unconditional error when
checkpoint is called under the non-strict tracing flag, directing users
to torch.compile or graph-based AC/SAC instead.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98