### PR TITLE
[cuBLASLt] Add option to only retrieve current cuBLAS handle without setup code

### DIFF
--- a/aten/src/ATen/cuda/CUDAContextLight.h
+++ b/aten/src/ATen/cuda/CUDAContextLight.h
@@ -85,7 +85,7 @@ TORCH_CUDA_CPP_API c10::Allocator* getCUDADeviceAllocator();
 
 /* Handles */
 TORCH_CUDA_CPP_API cusparseHandle_t getCurrentCUDASparseHandle();
-TORCH_CUDA_CPP_API cublasHandle_t getCurrentCUDABlasHandle();
+TORCH_CUDA_CPP_API cublasHandle_t getCurrentCUDABlasHandle(bool setup = true);
 TORCH_CUDA_CPP_API cublasLtHandle_t getCurrentCUDABlasLtHandle();
 
 TORCH_CUDA_CPP_API void clearCublasWorkspaces();

--- a/aten/src/ATen/cuda/CublasHandlePool.cpp
+++ b/aten/src/ATen/cuda/CublasHandlePool.cpp
@@ -310,15 +310,26 @@ void setWorkspaceForHandle(cublasHandle_t handle, c10::cuda::CUDAStream stream) 
 void* getCUDABlasLtWorkspace() {
 #ifndef USE_ROCM
   if (unified_cublas_and_lt_workspaces()) {
-    cublasHandle_t handle = at::cuda::getCurrentCUDABlasHandle();
+    cublasHandle_t handle = at::cuda::getCurrentCUDABlasHandle(/*setup=*/false);
     auto stream = c10::cuda::getCurrentCUDAStream();
     cudaStream_t _stream = stream;
     auto key = std::make_tuple(static_cast<void *>(handle), static_cast<void *>(_stream));
     auto& workspace = at::cuda::cublas_handle_stream_to_workspace();
-    std::shared_lock<std::shared_mutex> lock(workspace.mutex);
-    auto workspace_it = workspace.map.find(key);
-    TORCH_INTERNAL_ASSERT(workspace_it != workspace.map.end());
-    return workspace_it->second.mutable_get();
+    {
+      std::shared_lock<std::shared_mutex> lock(workspace.mutex);
+      auto workspace_it = workspace.map.find(key);
+      if (workspace_it != workspace.map.end()) {
+        return workspace_it->second.mutable_get();
+      }
+    }
+    // First use for this handle+stream pair — allocate and insert directly.
+    // No need to call cublasSetWorkspace; Lt passes workspace explicitly.
+    auto new_workspace = getNewWorkspace();
+    {
+      std::unique_lock<std::shared_mutex> lock(workspace.mutex);
+      auto workspace_it = workspace.map.try_emplace(key, std::move(new_workspace)).first;
+      return workspace_it->second.mutable_get();
+    }
   }
 #endif
   cublasLtHandle_t handle = getCurrentCUDABlasLtHandle();
@@ -350,7 +361,7 @@ void* getCUDABlasLtWorkspace() {
   }
 }
 
-cublasHandle_t getCurrentCUDABlasHandle() {
+cublasHandle_t getCurrentCUDABlasHandle(bool setup) {
   c10::DeviceIndex device = 0;
   AT_CUDA_CHECK(c10::cuda::GetDevice(&device));
 
@@ -358,8 +369,6 @@ cublasHandle_t getCurrentCUDABlasHandle() {
   CUcontext pctx = nullptr;
   at::globalContext().getNVRTC().cuCtxGetCurrent(&pctx);
   if (C10_UNLIKELY(!pctx)) {
-    // workaround for corner case where a primary context exists but is not
-    // the current context, seen in multithreaded use-cases
     TORCH_WARN_ONCE("Attempting to run cuBLAS, but there was no current CUDA context! Attempting to set the primary context...");
     at::globalContext().getNVRTC().cuDevicePrimaryCtxRetain(&pctx, device);
     at::globalContext().getNVRTC().cuCtxSetCurrent(pctx);
@@ -382,6 +391,11 @@ cublasHandle_t getCurrentCUDABlasHandle() {
       pool->newPoolWindow());
 
   auto handle = myPoolWindow->reserve(device);
+
+  if (!setup) {
+    return handle;
+  }
+
   auto stream = c10::cuda::getCurrentCUDAStream();
   TORCH_CUDABLAS_CHECK(cublasSetStream(handle, stream));
   // We explicitly set the cublas workspace even though CUDA 12.2+ fixed the
@@ -438,7 +452,7 @@ cublasLtHandle_t getCurrentCUDABlasLtHandle() {
   auto handle = myPoolWindow->reserve(device);
   return handle;
 #else
-  return reinterpret_cast<cublasLtHandle_t>(getCurrentCUDABlasHandle());
+  return reinterpret_cast<cublasLtHandle_t>(getCurrentCUDABlasHandle(/*setup=*/false));
 #endif
 }
 


### PR DESCRIPTION
When we are getting the current cuBLAS(Lt) handle just for the purpose of querying the handle + stream to workspace map in the Lt path we don't actually care about binding it to the handle or the associated setup of querying the stream. Skipping this seems to speed up cuBLASLt by high single digit % end-to-end for small-medium calls.

Coached claude to write this

cc @csarofeen @ptrblck @nWEIdia