### PR TITLE
[CI] Add git-core PPA to Docker base image for newer git

### DIFF
--- a/.ci/docker/common/install_base.sh
+++ b/.ci/docker/common/install_base.sh
@@ -22,8 +22,8 @@ install_ubuntu() {
 
   # Install common dependencies
   apt-get update
-  # Install software-properties-common first so add-apt-repository is available
-  apt-get install -y --no-install-recommends software-properties-common
+  # Install prerequisites for add-apt-repository (needs gpg-agent for PPA key import)
+  apt-get install -y --no-install-recommends software-properties-common gpg-agent
   # Add git-core PPA for a newer version of git
   add-apt-repository ppa:git-core/ppa -y
   apt-get update

--- a/.ci/docker/common/install_base.sh
+++ b/.ci/docker/common/install_base.sh
@@ -22,6 +22,11 @@ install_ubuntu() {
 
   # Install common dependencies
   apt-get update
+  # Install software-properties-common first so add-apt-repository is available
+  apt-get install -y --no-install-recommends software-properties-common
+  # Add git-core PPA for a newer version of git
+  add-apt-repository ppa:git-core/ppa -y
+  apt-get update
   # TODO: Some of these may not be necessary
   ccache_deps="asciidoc docbook-xml docbook-xsl xsltproc"
   deploy_deps="libffi-dev libbz2-dev libreadline-dev libncurses5-dev libncursesw5-dev libgdbm-dev libsqlite3-dev uuid-dev tk-dev"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #179027
* __->__ #179025

Add the ppa:git-core/ppa repository to install_base.sh so CI Docker
images get a newer version of git instead of the default Ubuntu
package.

Co-authored-by: Claude <noreply@anthropic.com>