### PR TITLE
[CI] Purge pip cache after uninstalling nightly torch in ONNX setup

### DIFF
--- a/.ci/docker/common/install_onnx.sh
+++ b/.ci/docker/common/install_onnx.sh
@@ -30,4 +30,5 @@ conda_run python "${IMPORT_SCRIPT_FILENAME}"
 
 # Cleaning up
 conda_run pip uninstall -y torch
+conda_run pip cache purge
 rm "${IMPORT_SCRIPT_FILENAME}" || true


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #179027
* #179025

The install_onnx.sh script installs a nightly torch wheel to cache a
transformers model, then uninstalls it. The wheel remains in pip's
cache, bloating the Docker image. Purge the cache after uninstall.

Co-authored-by: Claude <noreply@anthropic.com>