### PR TITLE
[Inductor] Add register_lowering for aten.arange.start_step (#179028)

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -3190,6 +3190,15 @@ class CommonTemplate:
         self.common(fn, (make_arg(1, dtype=torch.float32),))
         self.common(fn, (make_arg(1, dtype=torch.int64),))
 
+    def test_arange7(self):
+        def fn(x):
+            # Test aten.arange.start_step lowering with integer dtypes
+            return x + torch.ops.aten.arange.start_step(
+                0, 10, 2, dtype=torch.int64, device=x.device
+            )
+
+        self.common(fn, (torch.zeros(5, dtype=torch.int64),), check_lowp=False)
+
     def test_linspace1(self):
         def fn(x):
             return torch.linspace(0.125, 0.875, 7, device=x.device) + x

--- a/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
@@ -131,6 +131,7 @@ test_failures = {
     "test_arange3_dynamic_shapes": TestFailure(("cpu",)),
     "test_arange4_dynamic_shapes": TestFailure(("cpu",)),
     "test_arange6_dynamic_shapes": TestFailure(("cpu",)),
+    "test_arange7_dynamic_shapes": TestFailure(("cpu",)),
     "test_clamp_type_promotion_dynamic_shapes": TestFailure(("cpu",)),
     "test_conv2d_channels_last_dynamic_shapes": TestFailure(("cpu",)),
     "test_conv3d_dynamic_shapes": TestFailure(("cpu",)),

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -3574,6 +3574,30 @@ def iota(
     )
 
 
+@register_lowering(aten.arange.start_step, type_promotion_kind=None)
+def arange_start_step(
+    start,
+    end,
+    step=1,
+    *,
+    dtype=None,
+    device=None,
+    layout=None,
+    pin_memory=None,
+    requires_grad=False,
+):
+    assert dtype is not None
+    length = ceildiv(end - start, step)
+    return iota(
+        length,
+        start=start,
+        step=step,
+        dtype=dtype,
+        device=device if device is not None else "cpu",
+        requires_grad=requires_grad,
+    )
+
+
 @register_lowering(aten.select_scatter, type_promotion_kind=None)
 def select_scatter(x, src, dim: int, index: int):
     src = to_dtype(src, x.get_dtype())


### PR DESCRIPTION
Summary:

## Summary

`aten.arange.start_step` only existed in Inductor's decomposition table (decomposed to `prims.iota`), but was NOT registered in the `lowerings` dict. This caused `KeyError` when any code tried to access `lowerings[aten.arange.start_step]`.

This fixes 176 opinfo e2e test failures for `arange` on MTIA, where `arange_int_lowering.py` (D98064707) delegates to `lowerings[aten.arange.start_step]`.

### Root Cause

D98064707 added `arange_int_lowering.py` which registers a lowering for `torch.ops.mtia.arange_int` and delegates to `lowerings[aten.arange.start_step]`. However, upstream Inductor only registers `aten.arange` in its **decomposition** table (decomposed to `prims.iota` at `lowering.py:3453`), not in the **lowerings** dict. The unit tests masked this by injecting a mock via `patch.dict(lowerings, {aten.arange.start_step: mock_arange})`.

### Fix

Add `register_lowering(aten.arange.start_step)` that delegates to the existing `prims.iota` lowering (which generates `Pointwise.create` with `ops.index_expr`). This makes the key available in the `lowerings` dict for any downstream code.

### Changed Files

- `fbcode/caffe2/torch/_inductor/lowering.py` — add `arange_start_step` lowering after `iota`
- `xplat/caffe2/torch/_inductor/lowering.py` — mirror
- `fbcode/caffe2/test/inductor/test_torchinductor.py` — add `test_arange7` for integer arange via `aten.arange.start_step`
- `xplat/caffe2/test/inductor/test_torchinductor.py` — mirror

Test Plan:
- `test_arange7` in `test_torchinductor.py` — verifies `aten.arange.start_step` with integer dtype
- Existing `test_arange3` already calls `aten.arange.start_step` directly — passes with new lowering
- MTIA `test_arange_int_lowering` unit tests — delegation to `lowerings[aten.arange.start_step]` no longer raises KeyError
- Opinfo e2e: `arange; 1; 0; int, 2` should compile successfully with auto DS

Reviewed By: blaine-rister

Differential Revision: D98755321




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo