### PR TITLE
Fix SYMPY_INTERP calling convention for IsNonOverlappingAndDenseIndicator

### DIFF
--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -37,6 +37,7 @@ from torch.fx.experimental.symbolic_shapes import (
     StatelessSymbolicContext,
     statically_known_false,
     statically_known_true,
+    SYMPY_INTERP,
 )
 from torch.testing._internal.common_dtype import all_types_and
 from torch.testing._internal.common_utils import (
@@ -917,6 +918,46 @@ def forward(self, x_1):
                 )
             )
         )
+
+    def test_sympy_interp_is_non_overlapping_and_dense_flat_args(self):
+        # SYMPY_INTERP is used as the eval() namespace for guard code strings.
+        # Guard code prints IsNonOverlappingAndDenseIndicator(s0, s1, ..., st0, st1, ...)
+        # with flat args, so the SYMPY_INTERP function must accept flat args.
+        interp_fn = SYMPY_INTERP["IsNonOverlappingAndDenseIndicator"]
+
+        # 1D contiguous: sizes=(5,), strides=(1,)
+        self.assertEqual(interp_fn(5, 1), 1)
+        # 1D non-contiguous: sizes=(5,), strides=(2,)
+        self.assertEqual(interp_fn(5, 2), 0)
+        # 1D single element: sizes=(1,), strides=(42,)
+        self.assertEqual(interp_fn(1, 42), 1)
+
+        # 2D contiguous: sizes=(3, 4), strides=(4, 1)
+        self.assertEqual(interp_fn(3, 4, 4, 1), 1)
+        # 2D non-contiguous: sizes=(3, 4), strides=(5, 1) -- gap in memory
+        self.assertEqual(interp_fn(3, 4, 5, 1), 0)
+        # 2D transposed but still dense: sizes=(4, 3), strides=(1, 4)
+        self.assertEqual(interp_fn(4, 3, 1, 4), 1)
+
+        # 4D contiguous (the exact scenario from the MAST job failure):
+        # sizes=(2, 3, 4, 5), strides=(60, 20, 5, 1)
+        self.assertEqual(interp_fn(2, 3, 4, 5, 60, 20, 5, 1), 1)
+        # 4D non-contiguous:
+        self.assertEqual(interp_fn(2, 3, 4, 5, 100, 20, 5, 1), 0)
+
+    def test_sympy_interp_guard_eval_simulation(self):
+        # Simulate the actual guard eval() path: guard code strings use
+        # IsNonOverlappingAndDenseIndicator as a function name, and SYMPY_INTERP
+        # provides the binding in the eval namespace.
+        guard_code = "IsNonOverlappingAndDenseIndicator(2, 3, 4, 5, 60, 20, 5, 1) == 1"
+        result = eval(guard_code, SYMPY_INTERP)  # noqa: P204
+        self.assertTrue(result)
+
+        guard_code_false = (
+            "IsNonOverlappingAndDenseIndicator(2, 3, 4, 5, 100, 20, 5, 1) == 1"
+        )
+        result_false = eval(guard_code_false, SYMPY_INTERP)  # noqa: P204
+        self.assertFalse(result_false)
 
     def test_prims_is_non_overlapping_and_dense_or_false(self):
         shape_env = ShapeEnv()

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -2664,8 +2664,16 @@ def cast_symbool_to_symint_guardless(
     )
 
 
+def _eval_is_non_overlapping_and_dense_flat(*args: int) -> int:
+    # Guard code strings print IsNonOverlappingAndDenseIndicator with flat args
+    # (s0, s1, ..., stride0, stride1, ...) but eval_is_non_overlapping_and_dense
+    # expects two sequences (sizes, strides). This wrapper bridges the gap.
+    dim = len(args) // 2
+    return eval_is_non_overlapping_and_dense(list(args[:dim]), list(args[dim:]))
+
+
 SYMPY_INTERP = {
-    "IsNonOverlappingAndDenseIndicator": eval_is_non_overlapping_and_dense,
+    "IsNonOverlappingAndDenseIndicator": _eval_is_non_overlapping_and_dense_flat,
     "cast_symbool_to_symint_guardless": cast_symbool_to_symint_guardless,
     "math": math,
     "torch": torch,


### PR DESCRIPTION
Summary:
Fix a guard evaluation crash where `eval_is_non_overlapping_and_dense()` is called with flat positional arguments instead of two sequences.

The `SYMPY_INTERP` dict maps `"IsNonOverlappingAndDenseIndicator"` to a Python function used in `eval()` of guard code strings. The guard printer emits `IsNonOverlappingAndDenseIndicator(s0, s1, s2, s3, st0, st1, st2, st3)` with flat args (sizes followed by strides), but `eval_is_non_overlapping_and_dense(sizes, strides)` expects two sequence arguments. This causes:

```
AssertionError: Guard check failed: eval_is_non_overlapping_and_dense() takes 2 positional arguments but 8 were given
```

The fix adds a wrapper `_eval_is_non_overlapping_and_dense_flat(*args)` that splits the flat args into sizes and strides before delegating, matching the calling convention that `IsNonOverlappingAndDenseIndicator.eval()` already uses in `functions.py`.

This bug is latent — it only triggers when an `IsNonOverlappingAndDenseIndicator` expression survives unsimplified into a guard code string (i.e., when some tensor dimensions are symbolic at tracing time but concrete at guard evaluation time).


```
● Here's the full call chain:

  1. produce_guards_verbose()  (symbolic_shapes.py:5616)
     └─ ShapeGuardPythonPrinter.doprint(guard_expr)
        └─ No _print_IsNonOverlappingAndDenseIndicator method exists
           └─ sympy default StrPrinter._print_Function emits:
              "IsNonOverlappingAndDenseIndicator(L['x'].size()[0], ..., L['x'].stride()[3])"

  2. SHAPE_ENV_GUARD (guards.py:3260)
     └─ add_python_lambda_leaf_guard_to_root(
          code_parts=["IsNonOverlappingAndDenseIndicator(...) == 1"],
          closure_vars={**SYMPY_INTERP, ...}   # line 3264
        )

  3. add_python_lambda_leaf_guard_to_root (guards.py:1928)
     └─ build_guard_function(code_parts, closure_var_names)  # wraps in a function
     └─ exec(pycode, globals, out)                           # line 1945
     └─ guard_fn = out["___make_guard_fn"](*closure_vars.values())  # line 1946
        # Now IsNonOverlappingAndDenseIndicator is bound to eval_is_non_overlapping_and_dense

Line 3264: closure_vars={**SYMPY_INTERP, **_get_closure_vars()}

  So closure_vars is a dict like:        
  {"IsNonOverlappingAndDenseIndicator": eval_is_non_overlapping_and_dense, "math": math, ...}
                                                                            
  Line 1940: make_guard_fn_args = ", ".join(closure_vars.keys())
                                                                                                                                                 
  This produces a string: "IsNonOverlappingAndDenseIndicator, cast_symbool_to_symint_guardless, math, torch, ..."
                                                                                                                                                 
  Line 1941: build_guard_function(code_parts, make_guard_fn_args) generates Python code like:
  def ___make_guard_fn(IsNonOverlappingAndDenseIndicator, cast_symbool_to_symint_guardless, math, torch, ...):
      def guard_fn(L):                                                                                                                           
          return IsNonOverlappingAndDenseIndicator(L['x'].size()[0], ...) == 1
      return guard_fn                                                                                                                            
                                                                                         
  Line 1946: guard_fn = out["___make_guard_fn"](*closure_vars.values())                                                                          
                                                                                                                                                 
  This calls ___make_guard_fn with the dict values as positional args. The first value is eval_is_non_overlapping_and_dense, which gets bound to 
  the parameter named IsNonOverlappingAndDenseIndicator.                                                                                         
                                                                                                                                                 
  So the dict key becomes the parameter name (matching what the printer emits), and the dict value becomes the actual function that gets called. 
  That's how the name IsNonOverlappingAndDenseIndicator in the guard code string resolves to whatever Python object is stored as the value in    
  SYMPY_INTERP.               

  4. Guard evaluation (at cache-lookup time, or validation in CheckFunctionManager.__init__)
     └─ guard_fn(L)
     └─ eval: "IsNonOverlappingAndDenseIndicator(L['x'].size()[0], L['x'].size()[1],
                L['x'].size()[2], L['x'].size()[3], L['x'].stride()[0], L['x'].stride()[1],
                L['x'].stride()[2], L['x'].stride()[3]) == 1"
     └─ This calls: eval_is_non_overlapping_and_dense(4, 128, 256, 512, 131072, 1024, 4, 1)
                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                                                       8 individual int args, but function expects 2 sequences
     └─ TypeError: takes 2 positional arguments but 8 were given

```

Test Plan:
```
buck test fbcode//caffe2/test:dynamic_shapes -- -r test_sympy_interp_is_non_overlapping_
```

Reviewed By: williamwen42

Differential Revision: D99129807


