### PR TITLE
[mkldnn] Ensure tensors start at the beginning of their storage in convolution functions

### DIFF
--- a/aten/src/ATen/native/mkldnn/xpu/Conv.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/Conv.cpp
@@ -21,6 +21,21 @@ using namespace at::native::onednn;
 namespace at::native::xpu {
 namespace impl {
 
+// Returns a tensor that always satisfies oneDNN layout requirements:
+// it is contiguous in the given memory format and has zero storage offset.
+// If the input already satisfies these conditions, it is returned as-is;
+// otherwise, a cloned copy with the required properties is created.
+static Tensor prepare_onednn_tensor(
+    const Tensor& tensor,
+    at::MemoryFormat mfmt) {
+  if (tensor.is_contiguous(mfmt) && tensor.storage_offset() == 0) {
+    return tensor;
+  }
+  // Clone produces a fresh, contiguous tensor with storage_offset() == 0
+  // in the requested memory format, avoiding an extra intermediate copy.
+  return tensor.clone(mfmt);
+}
+
 struct ConvParams {
   std::vector<int64_t> stride;
   std::vector<int64_t> padding;
@@ -380,13 +395,14 @@ Tensor _convolution_out(
     params.groups = groups_;
   }
 
-  // ensure the input/weight/bias/output are congituous in desired format
   at::MemoryFormat mfmt = is_channels_last_suggested
       ? get_cl_tag_by_ndim(input.ndimension())
       : at::MemoryFormat::Contiguous;
-  auto bias = bias_r.defined() ? bias_r.contiguous() : bias_r;
-  input = input.contiguous(mfmt);
-  weight = weight.contiguous(mfmt);
+  input = prepare_onednn_tensor(input, mfmt);
+  weight = prepare_onednn_tensor(weight, mfmt);
+  auto bias = bias_r.defined()
+      ? prepare_onednn_tensor(bias_r, at::MemoryFormat::Contiguous)
+      : bias_r;
   check_shape_forward(input, weight, bias, params, true);
 
   Tensor output;
@@ -587,13 +603,12 @@ std::tuple<Tensor, Tensor, Tensor> convolution_backward_overrideable(
     groups_ = groups;
   }
 
-  // ensure the tensors are contiguous
   auto mfmt = is_channels_last_suggested
       ? get_cl_tag_by_ndim(input_.ndimension())
       : at::MemoryFormat::Contiguous;
-  grad_output_ = grad_output_.contiguous(mfmt);
-  weight_ = weight_.contiguous(mfmt);
-  input_ = input_.contiguous(mfmt);
+  grad_output_ = prepare_onednn_tensor(grad_output_, mfmt);
+  weight_ = prepare_onednn_tensor(weight_, mfmt);
+  input_ = prepare_onednn_tensor(input_, mfmt);
 
   auto opt = grad_output_.options();
   Tensor grad_input;

--- a/test/xpu/test_conv.py
+++ b/test/xpu/test_conv.py
@@ -1369,6 +1369,52 @@ class TestConvolutionNNDeviceType(NNTestCase):
             self.assertTrue(torch.backends.mkldnn.allow_tf32)
 
 
+    @onlyXPU
+    @dtypes(torch.float)
+    def test_conv_nonzero_storage_offset(self, device, dtype):
+        # Tensors created via slicing have non-zero storage_offset, which
+        # oneDNN does not support. Verify that convolution still produces
+        # correct results for input, weight, and bias with non-zero offsets.
+        conv = nn.Conv2d(3, 8, kernel_size=3, padding=1, dtype=dtype).to(device)
+
+        # Create tensors with non-zero storage_offset via slicing
+        input_base = torch.randn(2, 3, 8, 8, dtype=dtype, device=device)
+        input_sliced = input_base[1:]  # storage_offset != 0
+        input_sliced.requires_grad_(True)
+        self.assertNotEqual(input_sliced.storage_offset(), 0)
+
+        bias_base = torch.randn(16, dtype=dtype, device=device)
+        bias_sliced = bias_base[8:]  # storage_offset != 0
+        self.assertNotEqual(bias_sliced.storage_offset(), 0)
+        conv.bias = nn.Parameter(bias_sliced)
+
+        weight_base = torch.randn(16, 3, 3, 3, dtype=dtype, device=device)
+        weight_sliced = weight_base[8:]  # storage_offset != 0
+        self.assertNotEqual(weight_sliced.storage_offset(), 0)
+        conv.weight = nn.Parameter(weight_sliced)
+
+        # Reference: use contiguous copies with zero storage_offset
+        conv_ref = nn.Conv2d(3, 8, kernel_size=3, padding=1, dtype=dtype).to(device)
+        conv_ref.weight = nn.Parameter(weight_sliced.clone())
+        conv_ref.bias = nn.Parameter(bias_sliced.clone())
+        input_ref = input_sliced.clone().detach().requires_grad_(True)
+
+        out = conv(input_sliced)
+        out_ref = conv_ref(input_ref)
+        self.assertEqual(out, out_ref)
+
+        # Also verify backward pass, with grad_output having non-zero storage_offset
+        grad_output_base = torch.randn(out.size(0) + 1, *out.shape[1:], dtype=dtype, device=device)
+        grad_sliced = grad_output_base[1:]  # storage_offset != 0, same shape as out
+        self.assertNotEqual(grad_sliced.storage_offset(), 0)
+
+        out.backward(grad_sliced)
+        out_ref.backward(grad_sliced.clone())
+        self.assertEqual(input_sliced.grad, input_ref.grad)
+        self.assertEqual(conv.weight.grad, conv_ref.weight.grad)
+        self.assertEqual(conv.bias.grad, conv_ref.bias.grad)
+
+
 instantiate_device_type_tests(
     TestConvolutionNNDeviceType, globals(), only_for="xpu", allow_xpu=True
 )


### PR DESCRIPTION
Resolves https://github.com/intel/torch-xpu-ops/issues/2670

### Root cause
The oneDNN backend on XPU requires input tensors to start at the beginning of their storage (storage_offset == 0). When vmap's batching rule reshapes tensors by merging/splitting dimensions, the resulting views can have non-zero storage offsets. Calling `.contiguous()` preserves these offsets since the tensor is already contiguous in terms of strides. oneDNN then reads from the wrong memory location.

### Fix
Conv.cpp: After making tensors contiguous, clone any tensor with a non-zero `storage_offset()` in both `_convolution_out` (forward) and `convolution_backward_overrideable` (backward). This ensures all tensors passed to oneDNN start at the base of their allocated memory.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01