### PR TITLE
api to dump fr tracer to file

### DIFF
--- a/torch/distributed/debug/__init__.py
+++ b/torch/distributed/debug/__init__.py
@@ -102,6 +102,7 @@ def start_debug_server(
             enabled_dumps = {
                 "stacks",
                 "fr_trace",
+                "torchcomms_health_check",
             }
 
         main_kwargs = {

--- a/torch/distributed/debug/_debug_handlers.py
+++ b/torch/distributed/debug/_debug_handlers.py
@@ -575,6 +575,118 @@ class TorchCommsFlightRecorderHandler(DebugHandler):
         return "torchcomms_fr_trace"
 
 
+HEALTH_CHECK_TEMPLATE = """
+{% extends "base.html" %}
+{% block header %}
+    <h1>{% block title %}TorchComms Health Check{% endblock %}</h1>
+{% endblock %}
+{% block content %}
+    <h2>Health Status</h2>
+    {% if fetch_summary %}<pre>{{ fetch_summary }}</pre>{% endif %}
+    {% for i, (addr, resp) in enumerate(zip(addrs, resps)) %}
+        <h3>Rank {{ i }}: {{ addr }}</h3>
+        {% if resp.status_code != 200 %}
+            <p>Failed to fetch: status={{ resp.status_code }}</p>
+            <pre>{{ resp.text }}</pre>
+        {% else %}
+            <pre>{{ resp.text }}</pre>
+        {% endif %}
+    {% endfor %}
+    {% if dump_triggered %}
+        <h2>Flight Recorder Dump (triggered by unhealthy rank)</h2>
+        {% for i, (addr, resp) in enumerate(zip(dump_addrs, dump_resps)) %}
+            <h3>Rank {{ i }}: {{ addr }}</h3>
+            {% if resp.status_code != 200 %}
+                <p>Failed to dump: status={{ resp.status_code }}</p>
+                <pre>{{ resp.text }}</pre>
+            {% else %}
+                <pre>{{ resp.text }}</pre>
+            {% endif %}
+        {% endfor %}
+    {% endif %}
+{% endblock %}
+    """
+
+
+class TorchCommsHealthCheckHandler(DebugHandler):
+    """Health check that detects watchdog timeouts and triggers FR dumps."""
+
+    def routes(self) -> list[Route]:
+        return [Route("/torchcomms_health_check", self._handle)]
+
+    def nav_links(self) -> list[NavLink]:
+        return [NavLink("/torchcomms_health_check", "TorchComms Health")]
+
+    def templates(self) -> dict[str, str]:
+        return {"torchcomms_health_check.html": HEALTH_CHECK_TEMPLATE}
+
+    @staticmethod
+    def _any_unhealthy(resps: list[Response]) -> bool:
+        for resp in resps:
+            if resp.status_code == 200:
+                try:
+                    data = resp.json()
+                    if not data.get("healthy", True):
+                        return True
+                except Exception:
+                    pass
+        return False
+
+    def _handle(self, req: HTTPRequestHandler) -> bytes:
+        addrs, resps = fetch_all(
+            "torchcomms_health_check", timeout=self.fetch_timeout
+        )
+        dump_triggered = False
+        dump_addrs: list[str] = []
+        dump_resps: list[Response] = []
+        if self._any_unhealthy(resps):
+            dump_addrs, dump_resps = fetch_all(
+                "torchcomms_fr_dump_file", timeout=self.fetch_timeout
+            )
+            dump_triggered = True
+        return req.frontend.render_template(
+            "torchcomms_health_check.html",
+            fetch_summary=format_fetch_summary(addrs, resps),
+            addrs=addrs,
+            resps=resps,
+            dump_triggered=dump_triggered,
+            dump_addrs=dump_addrs,
+            dump_resps=dump_resps,
+        )
+
+    def dump(self) -> str | None:
+        addrs, resps = fetch_all(
+            "torchcomms_health_check", timeout=self.fetch_timeout
+        )
+        parts: list[str] = []
+        summary = format_fetch_summary(addrs, resps)
+        if summary:
+            parts.append(summary)
+            parts.append("")
+        for i, (addr, resp) in enumerate(zip(addrs, resps)):
+            parts.append(f"=== Rank {i}: {addr} ===")
+            parts.append(
+                resp.text if resp.status_code == 200 else f"Error: {resp.status_code}"
+            )
+        if self._any_unhealthy(resps):
+            parts.append("")
+            parts.append("=== Unhealthy rank detected, triggering FR dump ===")
+            dump_addrs, dump_resps = fetch_all(
+                "torchcomms_fr_dump_file", timeout=self.fetch_timeout
+            )
+            for i, (addr, resp) in enumerate(zip(dump_addrs, dump_resps)):
+                parts.append(f"--- Rank {i}: {addr} ---")
+                parts.append(
+                    resp.text
+                    if resp.status_code == 200
+                    else f"Error: {resp.status_code}"
+                )
+        return "\n".join(parts)
+
+    def dump_filename(self) -> str:
+        return "torchcomms_health_check"
+
+
 def default_handlers() -> list[DebugHandler]:
     return [
         IndexHandler(),
@@ -582,6 +694,7 @@ def default_handlers() -> list[DebugHandler]:
         PySpyHandler(),
         FlightRecorderHandler(),
         TorchCommsFlightRecorderHandler(),
+        TorchCommsHealthCheckHandler(),
         ProfilerHandler(),
         WaitCountersHandler(),
         TCPStoreHandler(),

--- a/torch/distributed/debug/_debug_handlers.py
+++ b/torch/distributed/debug/_debug_handlers.py
@@ -569,6 +569,16 @@ class TorchCommsFlightRecorderHandler(DebugHandler):
                 tabulate(db.ncclcalls, headers=NCCLCall._fields, tablefmt="plain"),
             ]
         )
+
+        parts.append("")
+        parts.append("=== TorchComms FR Dump File ===")
+        dump_addrs, dump_resps = fetch_all(
+            "torchcomms_fr_dump_file", timeout=self.fetch_timeout
+        )
+        for i, (_, resp) in enumerate(zip(dump_addrs, dump_resps)):
+            status = "OK" if resp.status_code == 200 else "FAILED"
+            parts.append(f"Rank {i}: {status} - {resp.text}")
+
         return "\n".join(parts)
 
     def dump_filename(self) -> str:


### PR DESCRIPTION

Summary:
Add support for dumping TorchComms FR tracer output to file by fetching the dump file status from all ranks and including the results in the debug handler report.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/pytorch/pytorch/pull/179046).
* __->__ #179046
* #179326