### PR TITLE
[dynamo] Fix FakeScriptObject leaking into TYPE_MATCH guards

### DIFF
--- a/test/dynamo/test_guard_manager.py
+++ b/test/dynamo/test_guard_manager.py
@@ -10,6 +10,7 @@ import torch._dynamo.test_case
 from torch._C._dynamo import guards
 from torch._dynamo.convert_frame import GlobalStateGuard
 from torch._dynamo.eval_frame import _debug_get_cache_entry_list
+from torch._library.fake_class_registry import FakeScriptObject
 from torch.testing._internal.common_utils import set_default_dtype
 
 
@@ -199,6 +200,34 @@ user_stack=None)
         self.assertFalse(guard({}))
         self.assertFalse(guard(5))
         self.assertFalse(guard("foo"))
+
+    def test_fake_script_object_match_guard(self):
+        class Real:
+            pass
+
+        class Other:
+            pass
+
+        root = RootGuardManager()
+        real = Real()
+        fake = FakeScriptObject(object(), "Real", real)
+        guard = guards.FAKE_SCRIPT_OBJECT_MATCH(
+            root,
+            FakeScriptObject,
+            id_type(real),
+            ["type match through FakeScriptObject"],
+            None,
+        )
+
+        # Passes for the FakeScriptObject at compile time and the real
+        # underlying object at runtime.
+        self.assertTrue(guard(fake))
+        self.assertTrue(guard(real))
+        # Different real type wrapped in FakeScriptObject should fail.
+        self.assertFalse(guard(FakeScriptObject(object(), "Other", Other())))
+        # Different raw type should fail.
+        self.assertFalse(guard(Other()))
+        self.assertFalse(guard(5))
 
     def test_id_guard(self):
         root = RootGuardManager()

--- a/test/dynamo/test_guard_manager.py
+++ b/test/dynamo/test_guard_manager.py
@@ -201,7 +201,7 @@ user_stack=None)
         self.assertFalse(guard(5))
         self.assertFalse(guard("foo"))
 
-    def test_fake_script_object_match_guard(self):
+    def test_fake_script_type_match_guard(self):
         class Real:
             pass
 
@@ -211,7 +211,7 @@ user_stack=None)
         root = RootGuardManager()
         real = Real()
         fake = FakeScriptObject(object(), "Real", real)
-        guard = guards.FAKE_SCRIPT_OBJECT_MATCH(
+        guard = guards.FAKE_SCRIPT_TYPE_MATCH(
             root,
             FakeScriptObject,
             id_type(real),

--- a/torch/_C/_dynamo/guards.pyi
+++ b/torch/_C/_dynamo/guards.pyi
@@ -333,7 +333,7 @@ class GuardManager:
         verbose_code_parts: list[str],
         user_stack: traceback.StackSummary | None,
     ) -> None: ...
-    def add_fake_script_object_guard(
+    def add_fake_script_type_match_guard(
         self,
         fake_script_object_type: type,
         type_id: int,

--- a/torch/_C/_dynamo/guards.pyi
+++ b/torch/_C/_dynamo/guards.pyi
@@ -333,6 +333,13 @@ class GuardManager:
         verbose_code_parts: list[str],
         user_stack: traceback.StackSummary | None,
     ) -> None: ...
+    def add_fake_script_object_guard(
+        self,
+        fake_script_object_type: type,
+        type_id: int,
+        verbose_code_parts: list[str],
+        user_stack: traceback.StackSummary | None,
+    ) -> None: ...
     def add_dict_version_guard(
         self,
         value: Any,

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -100,6 +100,7 @@ from torch._guards import (
     StorageOverlap,
 )
 from torch._inductor.utils import IndentedBuffer
+from torch._library.fake_class_registry import FakeScriptObject
 from torch._library.opaque_object import get_opaque_obj_info, is_opaque_value_type
 from torch._logging import structured
 from torch._utils_internal import justknobs_check
@@ -2128,64 +2129,38 @@ class GuardBuilder(GuardBuilderBase):
         value = self.get(guard)
         if isinstance(value, torch._subclasses.FakeTensor) and value.pytype:
             t = value.pytype
+        elif isinstance(value, FakeScriptObject):
+            # During compile-time tracing, opaque objects like DeviceMesh are
+            # wrapped in FakeScriptObject. Guard against the real underlying
+            # type so the guard passes at runtime when the real object shows up.
+            t = type(value.real_obj)
         else:
-            from torch._library.fake_class_registry import FakeScriptObject
-
-            if isinstance(value, FakeScriptObject):
-                # During compile-time tracing, opaque objects like DeviceMesh
-                # are wrapped in FakeScriptObject. Guard against the real
-                # underlying type so the guard passes at runtime.
-                t = type(value.real_obj)
-            else:
-                t = type(value)
+            t = type(value)
 
         if t.__qualname__ != t.__name__:
             # Type match guards must be local scope, this is
             # raised in self.serialize_guards
             guard._unserializable = True
 
-        from torch._library.fake_class_registry import FakeScriptObject
+        obj_id = self.id_ref(t, f"type({guard.name})")
+        type_repr = repr(t)
+        code = f"___check_type_id({self.arg_ref(guard)}, {obj_id}), type={type_repr}"
+        self._set_guard_export_info(guard, [code])
 
+        verbose_code_parts = get_verbose_code_parts(
+            code, guard, recompile_hint=f"type {t.__qualname__}"
+        )
         if isinstance(value, FakeScriptObject):
-            # Use a lambda guard that unwraps FakeScriptObject before checking
-            # type, so the guard passes both at compile time (FakeScriptObject)
-            # and at runtime (real object).
-            expected_type = t
-
-            def _check_type_through_fake(val, expected=expected_type):
-                from torch._library.fake_class_registry import FakeScriptObject
-
-                if isinstance(val, FakeScriptObject):
-                    return type(val.real_obj) is expected
-                return type(val) is expected
-
-            obj_id = self.id_ref(t, f"type({guard.name})")
-            type_repr = repr(t)
-            code = (
-                f"___check_type_id({self.arg_ref(guard)}, {obj_id}), type={type_repr}"
-            )
-            self._set_guard_export_info(guard, [code])
-
-            self.get_guard_manager(guard).add_lambda_guard(
-                _check_type_through_fake,
-                get_verbose_code_parts(
-                    code, guard, recompile_hint=f"type {t.__qualname__}"
-                ),
+            self.get_guard_manager(guard).add_fake_script_object_guard(
+                FakeScriptObject,
+                obj_id,
+                verbose_code_parts,
                 guard.user_stack,
             )
         else:
-            obj_id = self.id_ref(t, f"type({guard.name})")
-            type_repr = repr(t)
-            code = (
-                f"___check_type_id({self.arg_ref(guard)}, {obj_id}), type={type_repr}"
-            )
-            self._set_guard_export_info(guard, [code])
-
             self.get_guard_manager(guard).add_type_match_guard(
                 obj_id,
-                get_verbose_code_parts(
-                    code, guard, recompile_hint=f"type {t.__qualname__}"
-                ),
+                verbose_code_parts,
                 guard.user_stack,
             )
 

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -2129,25 +2129,65 @@ class GuardBuilder(GuardBuilderBase):
         if isinstance(value, torch._subclasses.FakeTensor) and value.pytype:
             t = value.pytype
         else:
-            t = type(value)
+            from torch._library.fake_class_registry import FakeScriptObject
+
+            if isinstance(value, FakeScriptObject):
+                # During compile-time tracing, opaque objects like DeviceMesh
+                # are wrapped in FakeScriptObject. Guard against the real
+                # underlying type so the guard passes at runtime.
+                t = type(value.real_obj)
+            else:
+                t = type(value)
 
         if t.__qualname__ != t.__name__:
             # Type match guards must be local scope, this is
             # raised in self.serialize_guards
             guard._unserializable = True
 
-        obj_id = self.id_ref(t, f"type({guard.name})")
-        type_repr = repr(t)
-        code = f"___check_type_id({self.arg_ref(guard)}, {obj_id}), type={type_repr}"
-        self._set_guard_export_info(guard, [code])
+        from torch._library.fake_class_registry import FakeScriptObject
 
-        self.get_guard_manager(guard).add_type_match_guard(
-            obj_id,
-            get_verbose_code_parts(
-                code, guard, recompile_hint=f"type {t.__qualname__}"
-            ),
-            guard.user_stack,
-        )
+        if isinstance(value, FakeScriptObject):
+            # Use a lambda guard that unwraps FakeScriptObject before checking
+            # type, so the guard passes both at compile time (FakeScriptObject)
+            # and at runtime (real object).
+            expected_type = t
+
+            def _check_type_through_fake(val, expected=expected_type):
+                from torch._library.fake_class_registry import FakeScriptObject
+
+                if isinstance(val, FakeScriptObject):
+                    return type(val.real_obj) is expected
+                return type(val) is expected
+
+            obj_id = self.id_ref(t, f"type({guard.name})")
+            type_repr = repr(t)
+            code = (
+                f"___check_type_id({self.arg_ref(guard)}, {obj_id}), type={type_repr}"
+            )
+            self._set_guard_export_info(guard, [code])
+
+            self.get_guard_manager(guard).add_lambda_guard(
+                _check_type_through_fake,
+                get_verbose_code_parts(
+                    code, guard, recompile_hint=f"type {t.__qualname__}"
+                ),
+                guard.user_stack,
+            )
+        else:
+            obj_id = self.id_ref(t, f"type({guard.name})")
+            type_repr = repr(t)
+            code = (
+                f"___check_type_id({self.arg_ref(guard)}, {obj_id}), type={type_repr}"
+            )
+            self._set_guard_export_info(guard, [code])
+
+            self.get_guard_manager(guard).add_type_match_guard(
+                obj_id,
+                get_verbose_code_parts(
+                    code, guard, recompile_hint=f"type {t.__qualname__}"
+                ),
+                guard.user_stack,
+            )
 
     # Dict versions change on any mutation, so a version captured during one
     # trace is meaningless for a later subgraph reuse check.

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -2129,11 +2129,6 @@ class GuardBuilder(GuardBuilderBase):
         value = self.get(guard)
         if isinstance(value, torch._subclasses.FakeTensor) and value.pytype:
             t = value.pytype
-        elif isinstance(value, FakeScriptObject):
-            # During compile-time tracing, opaque objects like DeviceMesh are
-            # wrapped in FakeScriptObject. Guard against the real underlying
-            # type so the guard passes at runtime when the real object shows up.
-            t = type(value.real_obj)
         else:
             t = type(value)
 
@@ -2147,22 +2142,50 @@ class GuardBuilder(GuardBuilderBase):
         code = f"___check_type_id({self.arg_ref(guard)}, {obj_id}), type={type_repr}"
         self._set_guard_export_info(guard, [code])
 
-        verbose_code_parts = get_verbose_code_parts(
-            code, guard, recompile_hint=f"type {t.__qualname__}"
+        self.get_guard_manager(guard).add_type_match_guard(
+            obj_id,
+            get_verbose_code_parts(
+                code, guard, recompile_hint=f"type {t.__qualname__}"
+            ),
+            guard.user_stack,
         )
+
+    @register_guard_check_spec(
+        get_metadata_fn=lambda guard, value: type(
+            value.real_obj if isinstance(value, FakeScriptObject) else value
+        ),
+        eval_fn=lambda value, metadata: type(
+            value.real_obj if isinstance(value, FakeScriptObject) else value
+        )
+        is metadata,
+    )
+    def FAKE_SCRIPT_TYPE_MATCH(self, guard: Guard) -> None:
+        # Like TYPE_MATCH, but for sources that may resolve to either a
+        # FakeScriptObject (during outer AOTAutograd tracing) or the
+        # underlying real opaque object (at runtime). The C++ leaf guard
+        # unwraps FakeScriptObject before comparing types.
+        value = self.get(guard)
         if isinstance(value, FakeScriptObject):
-            self.get_guard_manager(guard).add_fake_script_object_guard(
-                FakeScriptObject,
-                obj_id,
-                verbose_code_parts,
-                guard.user_stack,
-            )
+            t = type(value.real_obj)
         else:
-            self.get_guard_manager(guard).add_type_match_guard(
-                obj_id,
-                verbose_code_parts,
-                guard.user_stack,
-            )
+            t = type(value)
+
+        if t.__qualname__ != t.__name__:
+            guard._unserializable = True
+
+        obj_id = self.id_ref(t, f"type({guard.name})")
+        type_repr = repr(t)
+        code = f"___check_fake_script_type({self.arg_ref(guard)}, {obj_id}), type={type_repr}"
+        self._set_guard_export_info(guard, [code])
+
+        self.get_guard_manager(guard).add_fake_script_type_match_guard(
+            FakeScriptObject,
+            obj_id,
+            get_verbose_code_parts(
+                code, guard, recompile_hint=f"type {t.__qualname__}"
+            ),
+            guard.user_stack,
+        )
 
     # Dict versions change on any mutation, so a version captured during one
     # trace is meaningless for a later subgraph reuse check.

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -1618,8 +1618,11 @@ class VariableBuilder:
                 # Value-type: guard on equality (will use __eq__)
                 self.install_guards(GuardBuilder.CONSTANT_MATCH)
             elif is_opaque_reference_type(type(value)):
-                # Reference-type: guard only on type, and registered guard_fn
-                self.install_guards(GuardBuilder.TYPE_MATCH)
+                # Reference-type: guard only on type, and registered guard_fn.
+                # Use FAKE_SCRIPT_TYPE_MATCH because at runtime the source may
+                # resolve to either a FakeScriptObject (during outer
+                # AOTAutograd tracing) or the underlying real opaque object.
+                self.install_guards(GuardBuilder.FAKE_SCRIPT_TYPE_MATCH)
                 self.install_guards(GuardBuilder.OPAQUE_OBJ_GUARD_FN_MATCH)
             elif not hasattr(value, "__obj_flatten__"):
                 # This exists to allow a smoother transition.

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -1840,6 +1840,53 @@ class TYPE_MATCH : public LeafGuard {
   intptr_t _expected;
 };
 
+// Type match that unwraps FakeScriptObject before checking. During outer
+// AOTAutograd tracing, opaque objects (e.g. DeviceMesh) are wrapped in a
+// FakeScriptObject for FX tracing; at runtime Dynamo sees the real object.
+// The guard must pass in both cases.
+class FAKE_SCRIPT_OBJECT_MATCH : public LeafGuard {
+ public:
+  FAKE_SCRIPT_OBJECT_MATCH(
+      RootGuardManager* root_guard_manager,
+      py::object fake_script_object_type,
+      py::object type_id,
+      py::object verbose_code_parts,
+      py::object user_stack)
+      : LeafGuard(
+            root_guard_manager,
+            std::move(verbose_code_parts),
+            std::move(user_stack)),
+        _fake_script_object_type(std::move(fake_script_object_type)),
+        _expected(py::cast<intptr_t>(std::move(type_id))) {}
+
+  bool check_nopybind(PyObject* value) override { // borrowed ref
+    int is_fake = PyObject_IsInstance(value, _fake_script_object_type.ptr());
+    if (is_fake == -1) {
+      PyErr_Clear();
+      return false;
+    }
+    if (is_fake == 1) {
+      PyObject* real_obj = PyObject_GetAttrString(value, "real_obj");
+      if (real_obj == nullptr) {
+        PyErr_Clear();
+        return false;
+      }
+      // NOLINTNEXTLINE(performance-no-int-to-ptr)
+      bool result = Py_TYPE(real_obj) == (void*)_expected;
+      Py_DECREF(real_obj);
+      return result;
+    }
+    // NOLINTNEXTLINE(performance-no-int-to-ptr)
+    return Py_TYPE(value) == (void*)_expected;
+  }
+
+ private:
+  // The FakeScriptObject Python class, used for the isinstance check.
+  py::object _fake_script_object_type;
+  // id of the expected (unwrapped) type.
+  intptr_t _expected;
+};
+
 class ID_MATCH : public LeafGuard {
  public:
   // obj_id = id(obj)
@@ -7093,6 +7140,18 @@ PyObject* torch_c_dynamo_guards_init() {
       py_m, "TYPE_MATCH")
       .def(py::init<RootGuardManager*, py::object, py::list, py::object>())
       .def("__call__", &TYPE_MATCH::check);
+  py::class_<
+      FAKE_SCRIPT_OBJECT_MATCH,
+      LeafGuard,
+      std::shared_ptr<FAKE_SCRIPT_OBJECT_MATCH>>(
+      py_m, "FAKE_SCRIPT_OBJECT_MATCH")
+      .def(py::init<
+           RootGuardManager*,
+           py::object,
+           py::object,
+           py::list,
+           py::object>())
+      .def("__call__", &FAKE_SCRIPT_OBJECT_MATCH::check);
   py::class_<ID_MATCH, LeafGuard, std::shared_ptr<ID_MATCH>>(py_m, "ID_MATCH")
       .def(py::init<RootGuardManager*, py::object, py::list, py::object>())
       .def("__call__", &ID_MATCH::check);
@@ -7424,6 +7483,21 @@ PyObject* torch_c_dynamo_guards_init() {
             self.add_leaf_guard(std::make_shared<TYPE_MATCH>(
                 self.get_root(),
                 std::move(value),
+                std::move(verbose_code_parts),
+                std::move(user_stack)));
+          })
+      .def(
+          "add_fake_script_object_guard",
+          [](GuardManager& self,
+             py::object fake_script_object_type,
+             py::object type_id,
+             py::object verbose_code_parts,
+             py::object user_stack) -> void {
+            SKIP_IF_GUARD_ALREADY_PRESENT("FAKE_SCRIPT_OBJECT_MATCH");
+            self.add_leaf_guard(std::make_shared<FAKE_SCRIPT_OBJECT_MATCH>(
+                self.get_root(),
+                std::move(fake_script_object_type),
+                std::move(type_id),
                 std::move(verbose_code_parts),
                 std::move(user_stack)));
           })

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -1844,9 +1844,9 @@ class TYPE_MATCH : public LeafGuard {
 // AOTAutograd tracing, opaque objects (e.g. DeviceMesh) are wrapped in a
 // FakeScriptObject for FX tracing; at runtime Dynamo sees the real object.
 // The guard must pass in both cases.
-class FAKE_SCRIPT_OBJECT_MATCH : public LeafGuard {
+class FAKE_SCRIPT_TYPE_MATCH : public LeafGuard {
  public:
-  FAKE_SCRIPT_OBJECT_MATCH(
+  FAKE_SCRIPT_TYPE_MATCH(
       RootGuardManager* root_guard_manager,
       py::object fake_script_object_type,
       py::object type_id,
@@ -7141,17 +7141,16 @@ PyObject* torch_c_dynamo_guards_init() {
       .def(py::init<RootGuardManager*, py::object, py::list, py::object>())
       .def("__call__", &TYPE_MATCH::check);
   py::class_<
-      FAKE_SCRIPT_OBJECT_MATCH,
+      FAKE_SCRIPT_TYPE_MATCH,
       LeafGuard,
-      std::shared_ptr<FAKE_SCRIPT_OBJECT_MATCH>>(
-      py_m, "FAKE_SCRIPT_OBJECT_MATCH")
+      std::shared_ptr<FAKE_SCRIPT_TYPE_MATCH>>(py_m, "FAKE_SCRIPT_TYPE_MATCH")
       .def(py::init<
            RootGuardManager*,
            py::object,
            py::object,
            py::list,
            py::object>())
-      .def("__call__", &FAKE_SCRIPT_OBJECT_MATCH::check);
+      .def("__call__", &FAKE_SCRIPT_TYPE_MATCH::check);
   py::class_<ID_MATCH, LeafGuard, std::shared_ptr<ID_MATCH>>(py_m, "ID_MATCH")
       .def(py::init<RootGuardManager*, py::object, py::list, py::object>())
       .def("__call__", &ID_MATCH::check);
@@ -7487,14 +7486,14 @@ PyObject* torch_c_dynamo_guards_init() {
                 std::move(user_stack)));
           })
       .def(
-          "add_fake_script_object_guard",
+          "add_fake_script_type_match_guard",
           [](GuardManager& self,
              py::object fake_script_object_type,
              py::object type_id,
              py::object verbose_code_parts,
              py::object user_stack) -> void {
-            SKIP_IF_GUARD_ALREADY_PRESENT("FAKE_SCRIPT_OBJECT_MATCH");
-            self.add_leaf_guard(std::make_shared<FAKE_SCRIPT_OBJECT_MATCH>(
+            SKIP_IF_GUARD_ALREADY_PRESENT("FAKE_SCRIPT_TYPE_MATCH");
+            self.add_leaf_guard(std::make_shared<FAKE_SCRIPT_TYPE_MATCH>(
                 self.get_root(),
                 std::move(fake_script_object_type),
                 std::move(type_id),


### PR DESCRIPTION
Possible fix with https://github.com/pytorch/torchtitan/issues/2771

During the outer AOTAutograd trace, DTensor inputs are flattened via `unwrap_tensor_subclasses`, which wraps opaque components like DeviceMesh in FakeScriptObject for FX tracing. When inner torch.compile frames (e.g. an attention module) are compiled during this outer trace, Dynamo sees x.device_mesh as a FakeScriptObject and installs TYPE_MATCH guards against it. At runtime, x.device_mesh is a real DeviceMesh, so all compile-time guards fail, causing unnecessary recompilations that produce different saved activations and trigger the CheckpointError.

So the fix in this PR is that in GuardBuilder.TYPE_MATCH (guards.py), when the guarded value is a FakeScriptObject, guard against type(value.real_obj) instead of type(value), and use a lambda guard that unwraps FakeScriptObject before checking type. This way the guard passes both at compile time (FakeScriptObject wrapping DeviceMesh) and at runtime (real DeviceMesh).

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98