### PR TITLE
[Inductor][NVGEMM] Add supplement heuristic configs behind flag

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -599,6 +599,14 @@ def _nvgemm_max_profiling_configs_default() -> int | None:
 
 nvgemm_max_profiling_configs: int | None = _nvgemm_max_profiling_configs_default()
 
+# When enabled, adds supplement kernel configs that nvMatmulHeuristics
+# doesn't explore (certain tile/cluster combos that empirically beat
+# cuBLAS on decode shapes). These are added on top of the heuristic
+# picks, increasing the total number of configs benchmarked.
+nvgemm_supplement_configs: bool = (
+    os.environ.get("TORCHINDUCTOR_NVGEMM_SUPPLEMENT_CONFIGS", "0") == "1"
+)
+
 
 # As above, specify candidate backends for conv autotune.
 # NB: in some cases for 1x1 convs we emit as matmul,

--- a/torch/_inductor/template_heuristics/nv_universal_gemm.py
+++ b/torch/_inductor/template_heuristics/nv_universal_gemm.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import torch
+from torch._inductor import config
 from torch._inductor.utils import ensure_nvmatmul_heuristics_available
 from torch._logging import getArtifactLogger
 from torch.utils._ordered_set import OrderedSet
@@ -172,6 +173,33 @@ class NVUniversalGemmHeuristics(GemmMaxAutotuneTemplateConfigHeuristics):
         matched.sort(key=lambda x: x[1])
         selected = matched[:count]
         result = [k for k, _ in selected]
+
+        # Supplement with configs the heuristics model doesn't explore.
+        # nvMatmulHeuristics omits large cluster_n (8,16), tile64x32,
+        # and tile256x* that empirically beat cuBLAS on B200 bf16.
+        if config.nvgemm_supplement_configs:
+            _SUPPLEMENT_CONFIGS: set[ConfigKey] = {
+                (64, 128, 1, 1), (64, 128, 1, 2), (64, 128, 1, 4),
+                (64, 128, 1, 8), (64, 128, 1, 16),
+                (64, 256, 1, 8), (64, 256, 1, 16),
+                (64, 32, 1, 2), (64, 32, 1, 4),
+                (128, 64, 1, 1),
+                (128, 128, 1, 8), (128, 128, 1, 16),
+                (128, 128, 2, 2), (128, 128, 2, 4), (128, 128, 2, 8),
+                (128, 256, 1, 4), (128, 256, 1, 8), (128, 256, 1, 16),
+                (128, 256, 2, 1), (128, 256, 2, 8),
+                (256, 256, 2, 1), (256, 256, 2, 4),
+                (256, 256, 4, 2), (256, 256, 4, 4),
+                (256, 256, 8, 1), (256, 256, 8, 2),
+                (256, 128, 2, 1), (256, 128, 2, 2),
+            }
+            selected_keys = {
+                _make_config_key_from_kernel_design(k.metadata.design)
+                for k in result
+            }
+            for key, key_kernels in config_to_kernels.items():
+                if key not in selected_keys and key in _SUPPLEMENT_CONFIGS:
+                    result.append(key_kernels[0])
 
         log.debug(
             "Heuristic filtered to %d kernels from %d total", len(result), len(kernels)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #179049
* #179014
* #179013
* #176859
* #176847
* #176845
* #176549
* #176548
* #176547
* #176546
* #176545
* #176544
* #176543

Add 28 kernel configs that nvMatmulHeuristics doesn't explore but
empirically beat cuBLAS on B200 bf16 decode shapes (found via
exhaustive search on Llama-70B and Qwen3-32B).

Gated behind TORCHINDUCTOR_NVGEMM_SUPPLEMENT_CONFIGS=1 (default off).
When enabled, supplements are added on top of the heuristic picks.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo