### PR TITLE
[ROCm] Use per-stream hipblaslt handles

### DIFF
--- a/aten/src/ATen/cuda/CublasHandlePool.cpp
+++ b/aten/src/ATen/cuda/CublasHandlePool.cpp
@@ -29,6 +29,10 @@
  * For CUDA builds, getCurrentCUDABlasLtHandle will alias for getCurrentCUDABlasHandle,
  * whereas for ROCm builds, it is a distinct function.
  *
+ * Additionally, hipblaslt cannot share a single handle across multiple streams.
+ * On ROCm, getCurrentCUDABlasLtHandle returns a handle unique to each (device, stream)
+ * pair, rather than just per-device like the cublas handle pool.
+ *
  * The workspace pools are separate for ROCm. On CUDA, the env var
  * TORCH_CUBLASLT_UNIFIED_WORKSPACE can be used to opt-in to unifying the workspace pools.
  */
@@ -437,7 +441,11 @@ cublasLtHandle_t getCurrentCUDABlasLtHandle() {
   thread_local std::unique_ptr<CuBlasLtPoolType::PoolWindow> myPoolWindow(
       pool->newPoolWindow());
 
-  auto handle = myPoolWindow->reserve(device);
+  // hipblaslt cannot share a single handle across multiple streams,
+  // so reserve a handle unique to each (device, stream) pair.
+  auto stream = c10::cuda::getCurrentCUDAStream();
+  cudaStream_t _stream = stream;
+  auto handle = myPoolWindow->reserve(device, static_cast<void*>(_stream));
   return handle;
 #else
   return reinterpret_cast<cublasLtHandle_t>(getCurrentCUDABlasHandle());

--- a/aten/src/ATen/cuda/detail/DeviceThreadHandles.h
+++ b/aten/src/ATen/cuda/detail/DeviceThreadHandles.h
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#include <map>
 #include <unordered_map>
 #include <vector>
 #include <utility>
@@ -114,9 +115,45 @@ struct DeviceThreadHandlePool : public std::enable_shared_from_this<DeviceThread
         return my_handles[device];
     }
 
+#ifdef USE_ROCM
+    // hipblaslt cannot share a single handle across multiple streams, so this
+    // overload returns a handle unique to each (device, stream) pair.
+    Handle_t reserve(int device, void* stream)
+    {
+        auto key = std::make_pair(device, stream);
+        // If this thread already has a handle for this (device, stream), return it
+        if(my_stream_handles.find(key) != my_stream_handles.end())
+        return my_stream_handles[key];
+
+        // otherwise, either grab a handle from the pool if one is available,
+        // or if not, create a new one.
+        auto parent = weak_parent.lock();
+        TORCH_CHECK(parent, "Cannot create handle during program termination");
+        std::lock_guard<std::mutex> guard(parent->mutex);
+
+        if(parent->available_handles[device].size() > 0)
+        {
+        my_stream_handles[key] = parent->available_handles[device].back();
+        parent->available_handles[device].pop_back();
+        }
+        else
+        {
+        parent->created_handles[device].emplace_back(true /*create*/);
+        my_stream_handles[key] = parent->created_handles[device].back().handle;
+        }
+
+        return my_stream_handles[key];
+    }
+#endif
+
     private:
     // Stores the per-device handles currently owned by this thread
     std::unordered_map<int, Handle_t> my_handles;
+#ifdef USE_ROCM
+    // Stores per-(device, stream) handles for ROCm, where hipblaslt
+    // requires a unique handle per stream.
+    std::map<std::pair<int, void*>, Handle_t> my_stream_handles;
+#endif
 
     std::weak_ptr<DeviceThreadHandlePool> weak_parent;
 
@@ -134,6 +171,18 @@ struct DeviceThreadHandlePool : public std::enable_shared_from_this<DeviceThread
             for(auto d_h : my_handles)
                 parent->available_handles[d_h.first].push_back(d_h.second);
         }
+#ifdef USE_ROCM
+        if(!my_stream_handles.empty()) {
+            auto parent = weak_parent.lock();
+            if (!parent) {
+                return;
+            }
+
+            std::lock_guard<std::mutex> guard(parent->mutex);
+            for(auto& [key, handle] : my_stream_handles)
+                parent->available_handles[key.first].push_back(handle);
+        }
+#endif
     }
     };
 


### PR DESCRIPTION
hipblaslt cannot share a single handle across multiple streams. On ROCm, getCurrentCUDABlasLtHandle now returns a handle unique to each (device, stream) pair by using a stream-aware reserve() overload in the DeviceThreadHandlePool. All changes are guarded by #ifdef USE_ROCM so CUDA behavior is unchanged.

Assisted by Claude Opus 4.6.

cc @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang