### PR TITLE
Make inductor_choices_class participate in cache key via uuid()

### DIFF
--- a/test/inductor/test_cache.py
+++ b/test/inductor/test_cache.py
@@ -833,14 +833,16 @@ class ConfigSerializationTest(TestCase):
 
     def test_callable_config_not_json_serializable_2(self):
         # save_config_portable calls the factory and then .uuid(),
-        # producing a JSON-serializable string (qualname).
+        # producing a JSON-serializable value for the cache key.
         from torch._inductor.choices import InductorChoices
 
         class ChoicesA(InductorChoices):
-            pass
+            def uuid(self):
+                return "choices_a"
 
         class ChoicesB(InductorChoices):
-            pass
+            def uuid(self):
+                return "choices_b"
 
         # None is trivially JSON-serializable
         with inductor_config.patch(inductor_choices_class=None):
@@ -855,7 +857,7 @@ class ConfigSerializationTest(TestCase):
             portable = inductor_config.save_config_portable(
                 ignore_private_configs=False
             )
-            self.assertIn("ChoicesA", portable["inductor_choices_class"])
+            self.assertEqual(portable["inductor_choices_class"], "choices_a")
             json_a = json.dumps(portable)
 
         # Factory returning ChoicesB → different uuid string
@@ -863,7 +865,7 @@ class ConfigSerializationTest(TestCase):
             portable = inductor_config.save_config_portable(
                 ignore_private_configs=False
             )
-            self.assertIn("ChoicesB", portable["inductor_choices_class"])
+            self.assertEqual(portable["inductor_choices_class"], "choices_b")
             json_b = json.dumps(portable)
 
         self.assertNotEqual(json_a, json_b)

--- a/test/inductor/test_cache.py
+++ b/test/inductor/test_cache.py
@@ -832,8 +832,8 @@ class ConfigSerializationTest(TestCase):
                 json.dumps(portable)
 
     def test_callable_config_not_json_serializable_2(self):
-        # InductorChoices metaclass provides __str__ returning qualname,
-        # making subclasses JSON-serializable via default=str.
+        # save_config_portable calls the factory and hashes the result
+        # via InductorChoices.__hash__, producing a JSON-serializable int.
         from torch._inductor.choices import InductorChoices
 
         class ChoicesA(InductorChoices):
@@ -850,21 +850,21 @@ class ConfigSerializationTest(TestCase):
             self.assertIsNone(portable["inductor_choices_class"])
             json.dumps(portable)
 
-        # Derived class is serializable via default=str
+        # Factory returning ChoicesA → hash int
         with inductor_config.patch(inductor_choices_class=ChoicesA):
             portable = inductor_config.save_config_portable(
                 ignore_private_configs=False
             )
-            json_a = json.dumps(portable, default=str)
-            self.assertIn("ChoicesA", json_a)
+            self.assertIsInstance(portable["inductor_choices_class"], int)
+            json_a = json.dumps(portable)
 
-        # Different derived class produces different JSON
+        # Factory returning ChoicesB → different hash int
         with inductor_config.patch(inductor_choices_class=ChoicesB):
             portable = inductor_config.save_config_portable(
                 ignore_private_configs=False
             )
-            json_b = json.dumps(portable, default=str)
-            self.assertIn("ChoicesB", json_b)
+            self.assertIsInstance(portable["inductor_choices_class"], int)
+            json_b = json.dumps(portable)
 
         self.assertNotEqual(json_a, json_b)
 

--- a/test/inductor/test_cache.py
+++ b/test/inductor/test_cache.py
@@ -873,23 +873,11 @@ class ConfigSerializationTest(TestCase):
     def test_callable_config_without_uuid(self):
         from torch._inductor.choices import InductorChoices
 
-        # A subclass without uuid() warns and is excluded from the config hash.
+        # A subclass without uuid() raises RuntimeError.
         class PlainChoices(InductorChoices):
             pass
 
         with inductor_config.patch(inductor_choices_class=PlainChoices):
-            with self.assertWarnsRegex(UserWarning, "does not implement uuid"):
-                portable = inductor_config.save_config_portable(
-                    ignore_private_configs=False
-                )
-            self.assertNotIn("inductor_choices_class", portable)
-            json.dumps(portable)
-
-        # With strict mode, missing uuid() raises.
-        with inductor_config.patch(
-            inductor_choices_class=PlainChoices,
-            strict_cache_config_hashing=True,
-        ):
             with self.assertRaises(RuntimeError):
                 inductor_config.save_config_portable(ignore_private_configs=False)
 

--- a/test/inductor/test_cache.py
+++ b/test/inductor/test_cache.py
@@ -832,8 +832,8 @@ class ConfigSerializationTest(TestCase):
                 json.dumps(portable)
 
     def test_callable_config_not_json_serializable_2(self):
-        # save_config_portable calls the factory and hashes the result
-        # via InductorChoices.__hash__, producing a JSON-serializable int.
+        # save_config_portable calls the factory and then .uuid(),
+        # producing a JSON-serializable string (qualname).
         from torch._inductor.choices import InductorChoices
 
         class ChoicesA(InductorChoices):
@@ -850,20 +850,20 @@ class ConfigSerializationTest(TestCase):
             self.assertIsNone(portable["inductor_choices_class"])
             json.dumps(portable)
 
-        # Factory returning ChoicesA → hash int
+        # Factory returning ChoicesA → uuid string
         with inductor_config.patch(inductor_choices_class=ChoicesA):
             portable = inductor_config.save_config_portable(
                 ignore_private_configs=False
             )
-            self.assertIsInstance(portable["inductor_choices_class"], int)
+            self.assertIn("ChoicesA", portable["inductor_choices_class"])
             json_a = json.dumps(portable)
 
-        # Factory returning ChoicesB → different hash int
+        # Factory returning ChoicesB → different uuid string
         with inductor_config.patch(inductor_choices_class=ChoicesB):
             portable = inductor_config.save_config_portable(
                 ignore_private_configs=False
             )
-            self.assertIsInstance(portable["inductor_choices_class"], int)
+            self.assertIn("ChoicesB", portable["inductor_choices_class"])
             json_b = json.dumps(portable)
 
         self.assertNotEqual(json_a, json_b)

--- a/test/inductor/test_cache.py
+++ b/test/inductor/test_cache.py
@@ -844,12 +844,12 @@ class ConfigSerializationTest(TestCase):
             def uuid(self):
                 return "choices_b"
 
-        # None default is excluded from the config hash entirely.
+        # None default stays as None in the config hash.
         with inductor_config.patch(inductor_choices_class=None):
             portable = inductor_config.save_config_portable(
                 ignore_private_configs=False
             )
-            self.assertNotIn("inductor_choices_class", portable)
+            self.assertIsNone(portable["inductor_choices_class"])
             json.dumps(portable)
 
         # Factory returning ChoicesA → uuid string

--- a/test/inductor/test_cache.py
+++ b/test/inductor/test_cache.py
@@ -1,6 +1,7 @@
 # Owner(s): ["module: inductor"]
 from __future__ import annotations
 
+import json
 import pickle
 from concurrent.futures import ThreadPoolExecutor
 from inspect import isclass
@@ -12,6 +13,7 @@ from typing import Any, TYPE_CHECKING
 from typing_extensions import Self
 from unittest.mock import patch
 
+import torch._inductor.config as inductor_config
 from torch._inductor import cache as icache
 from torch._inductor.test_case import run_tests, TestCase
 from torch.testing._internal.common_utils import (
@@ -813,6 +815,21 @@ class OtherTest(TestMixin, TestCase):
         self.assertIsNone(cache.get(key))
         self.assertTrue(cache.insert(key, value))
         self.assertEqual(cache.get(key), value)
+
+
+class ConfigSerializationTest(TestCase):
+    def test_callable_config_not_json_serializable(self):
+        # Repro: setting callable configs to a non-None value
+        # save_config_portable() return a dict that is not JSON-serializable.
+        with inductor_config.patch(
+            bucket_all_gathers_fx_bucket_size_determinator=lambda: None
+        ):
+            portable = inductor_config.save_config_portable(
+                ignore_private_configs=False
+            )
+            self.assertIn("bucket_all_gathers_fx_bucket_size_determinator", portable)
+            with self.assertRaises(TypeError, msg="not JSON serializable"):
+                json.dumps(portable)
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_cache.py
+++ b/test/inductor/test_cache.py
@@ -818,7 +818,7 @@ class OtherTest(TestMixin, TestCase):
 
 
 class ConfigSerializationTest(TestCase):
-    def test_callable_config_not_json_serializable(self):
+    def test_callable_config_not_json_serializable_1(self):
         # Repro: setting callable configs to a non-None value
         # save_config_portable() return a dict that is not JSON-serializable.
         with inductor_config.patch(
@@ -830,6 +830,43 @@ class ConfigSerializationTest(TestCase):
             self.assertIn("bucket_all_gathers_fx_bucket_size_determinator", portable)
             with self.assertRaises(TypeError, msg="not JSON serializable"):
                 json.dumps(portable)
+
+    def test_callable_config_not_json_serializable_2(self):
+        # InductorChoices metaclass provides __str__ returning qualname,
+        # making subclasses JSON-serializable via default=str.
+        from torch._inductor.choices import InductorChoices
+
+        class ChoicesA(InductorChoices):
+            pass
+
+        class ChoicesB(InductorChoices):
+            pass
+
+        # None is trivially JSON-serializable
+        with inductor_config.patch(inductor_choices_class=None):
+            portable = inductor_config.save_config_portable(
+                ignore_private_configs=False
+            )
+            self.assertIsNone(portable["inductor_choices_class"])
+            json.dumps(portable)
+
+        # Derived class is serializable via default=str
+        with inductor_config.patch(inductor_choices_class=ChoicesA):
+            portable = inductor_config.save_config_portable(
+                ignore_private_configs=False
+            )
+            json_a = json.dumps(portable, default=str)
+            self.assertIn("ChoicesA", json_a)
+
+        # Different derived class produces different JSON
+        with inductor_config.patch(inductor_choices_class=ChoicesB):
+            portable = inductor_config.save_config_portable(
+                ignore_private_configs=False
+            )
+            json_b = json.dumps(portable, default=str)
+            self.assertIn("ChoicesB", json_b)
+
+        self.assertNotEqual(json_a, json_b)
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_cache.py
+++ b/test/inductor/test_cache.py
@@ -834,23 +834,22 @@ class ConfigSerializationTest(TestCase):
     def test_callable_config_not_json_serializable_2(self):
         # save_config_portable calls the factory and then .uuid(),
         # producing a JSON-serializable value for the cache key.
-        from torch._inductor.cache import CacheAware
         from torch._inductor.choices import InductorChoices
 
-        class ChoicesA(InductorChoices, CacheAware):
+        class ChoicesA(InductorChoices):
             def uuid(self):
                 return "choices_a"
 
-        class ChoicesB(InductorChoices, CacheAware):
+        class ChoicesB(InductorChoices):
             def uuid(self):
                 return "choices_b"
 
-        # None is trivially JSON-serializable
+        # None default is excluded from the config hash entirely.
         with inductor_config.patch(inductor_choices_class=None):
             portable = inductor_config.save_config_portable(
                 ignore_private_configs=False
             )
-            self.assertIsNone(portable["inductor_choices_class"])
+            self.assertNotIn("inductor_choices_class", portable)
             json.dumps(portable)
 
         # Factory returning ChoicesA → uuid string
@@ -871,27 +870,27 @@ class ConfigSerializationTest(TestCase):
 
         self.assertNotEqual(json_a, json_b)
 
-    def test_callable_config_without_cache_aware(self):
-        from torch._inductor.cache import CacheAware
+    def test_callable_config_without_uuid(self):
         from torch._inductor.choices import InductorChoices
 
-        # A subclass without CacheAware is excluded from the cache key.
+        # A subclass without uuid() warns and is excluded from the config hash.
         class PlainChoices(InductorChoices):
             pass
 
         with inductor_config.patch(inductor_choices_class=PlainChoices):
-            portable = inductor_config.save_config_portable(
-                ignore_private_configs=False
-            )
-            self.assertIsNone(portable["inductor_choices_class"])
+            with self.assertWarnsRegex(UserWarning, "does not implement uuid"):
+                portable = inductor_config.save_config_portable(
+                    ignore_private_configs=False
+                )
+            self.assertNotIn("inductor_choices_class", portable)
             json.dumps(portable)
 
-        # A subclass with CacheAware but no uuid() raises.
-        class BadChoices(InductorChoices, CacheAware):
-            pass
-
-        with inductor_config.patch(inductor_choices_class=BadChoices):
-            with self.assertRaises(NotImplementedError):
+        # With strict mode, missing uuid() raises.
+        with inductor_config.patch(
+            inductor_choices_class=PlainChoices,
+            strict_cache_config_hashing=True,
+        ):
+            with self.assertRaises(RuntimeError):
                 inductor_config.save_config_portable(ignore_private_configs=False)
 
 

--- a/test/inductor/test_cache.py
+++ b/test/inductor/test_cache.py
@@ -834,13 +834,14 @@ class ConfigSerializationTest(TestCase):
     def test_callable_config_not_json_serializable_2(self):
         # save_config_portable calls the factory and then .uuid(),
         # producing a JSON-serializable value for the cache key.
+        from torch._inductor.cache import CacheAware
         from torch._inductor.choices import InductorChoices
 
-        class ChoicesA(InductorChoices):
+        class ChoicesA(InductorChoices, CacheAware):
             def uuid(self):
                 return "choices_a"
 
-        class ChoicesB(InductorChoices):
+        class ChoicesB(InductorChoices, CacheAware):
             def uuid(self):
                 return "choices_b"
 
@@ -869,6 +870,29 @@ class ConfigSerializationTest(TestCase):
             json_b = json.dumps(portable)
 
         self.assertNotEqual(json_a, json_b)
+
+    def test_callable_config_without_cache_aware(self):
+        from torch._inductor.cache import CacheAware
+        from torch._inductor.choices import InductorChoices
+
+        # A subclass without CacheAware is excluded from the cache key.
+        class PlainChoices(InductorChoices):
+            pass
+
+        with inductor_config.patch(inductor_choices_class=PlainChoices):
+            portable = inductor_config.save_config_portable(
+                ignore_private_configs=False
+            )
+            self.assertIsNone(portable["inductor_choices_class"])
+            json.dumps(portable)
+
+        # A subclass with CacheAware but no uuid() raises.
+        class BadChoices(InductorChoices, CacheAware):
+            pass
+
+        with inductor_config.patch(inductor_choices_class=BadChoices):
+            with self.assertRaises(NotImplementedError):
+                inductor_config.save_config_portable(ignore_private_configs=False)
 
 
 if __name__ == "__main__":

--- a/torch/_inductor/cache.py
+++ b/torch/_inductor/cache.py
@@ -27,14 +27,14 @@ Key = TypeVar("Key", str, int, tuple[Any, ...])
 Value = TypeVar("Value", str, int, tuple[Any, ...], bytes, dict[Any, Any], list[Any])
 
 
-class CacheAware(ABC):
+class CacheAware:
     """Base class for objects that participate in cache key computation.
-    Subclasses must return a JSON/pickle-serializable ID from uuid()."""
+    Subclasses must override uuid() to return a JSON/pickle-serializable ID."""
 
-    @abstractmethod
     def uuid(self) -> Any | None:
         """Return an ID uniquely identifying this configuration.
         Return None to skip caching."""
+        raise NotImplementedError("Subclasses must implement uuid()")
 
 
 class CacheError(ValueError):

--- a/torch/_inductor/cache.py
+++ b/torch/_inductor/cache.py
@@ -27,16 +27,6 @@ Key = TypeVar("Key", str, int, tuple[Any, ...])
 Value = TypeVar("Value", str, int, tuple[Any, ...], bytes, dict[Any, Any], list[Any])
 
 
-class CacheAware:
-    """Base class for objects that participate in cache key computation.
-    Subclasses must override uuid() to return a JSON/pickle-serializable ID."""
-
-    def uuid(self) -> Any | None:
-        """Return an ID uniquely identifying this configuration.
-        Return None to skip caching."""
-        raise NotImplementedError("Subclasses must implement uuid()")
-
-
 class CacheError(ValueError):
     """
     Exception raised for errors encountered during cache operations.

--- a/torch/_inductor/cache.py
+++ b/torch/_inductor/cache.py
@@ -27,6 +27,16 @@ Key = TypeVar("Key", str, int, tuple[Any, ...])
 Value = TypeVar("Value", str, int, tuple[Any, ...], bytes, dict[Any, Any], list[Any])
 
 
+class CacheAware(ABC):
+    """Base class for objects that participate in cache key computation.
+    Subclasses must return a JSON/pickle-serializable ID from uuid()."""
+
+    @abstractmethod
+    def uuid(self) -> Any | None:
+        """Return an ID uniquely identifying this configuration.
+        Return None to skip caching."""
+
+
 class CacheError(ValueError):
     """
     Exception raised for errors encountered during cache operations.

--- a/torch/_inductor/choices.py
+++ b/torch/_inductor/choices.py
@@ -93,7 +93,12 @@ class FusionScore:
         )
 
 
-class InductorChoices:
+class _InductorChoicesMeta(type):
+    def __str__(cls) -> str:
+        return f"{cls.__module__}.{cls.__qualname__}"
+
+
+class InductorChoices(metaclass=_InductorChoicesMeta):
     """
     This class contains a collection of default heuristics that effect performance of our generated
     code.  We try to not put correctness requirements in this file.

--- a/torch/_inductor/choices.py
+++ b/torch/_inductor/choices.py
@@ -12,7 +12,6 @@ from torch._inductor.scheduler import MixOrderReduction
 from torch.utils._sympy.value_ranges import bound_sympy
 
 from . import config
-from .cache import CacheAware
 from .codecache import write_text
 from .kernel_inputs import KernelInputs  # noqa: TC001
 from .kernel_template_choice import make_ktc_generator
@@ -94,7 +93,7 @@ class FusionScore:
         )
 
 
-class InductorChoices(CacheAware):
+class InductorChoices:
     """
     This class contains a collection of default heuristics that effect performance of our generated
     code.  We try to not put correctness requirements in this file.
@@ -106,8 +105,8 @@ class InductorChoices(CacheAware):
 
             torch._inductor.virtualized.V.set_choices_handler(MyHeuristics())
 
-    Subclasses that are used with inductor_choices_class must override uuid()
-    to return a unique, JSON-serializable identifier for cache key computation.
+    Subclasses that want to participate in cache key computation should also
+    inherit from CacheAware and implement uuid().
     """
 
     def get_config_heuristics(

--- a/torch/_inductor/choices.py
+++ b/torch/_inductor/choices.py
@@ -12,6 +12,7 @@ from torch._inductor.scheduler import MixOrderReduction
 from torch.utils._sympy.value_ranges import bound_sympy
 
 from . import config
+from .cache import CacheAware
 from .codecache import write_text
 from .kernel_inputs import KernelInputs  # noqa: TC001
 from .kernel_template_choice import make_ktc_generator
@@ -93,7 +94,7 @@ class FusionScore:
         )
 
 
-class InductorChoices:
+class InductorChoices(CacheAware):
     """
     This class contains a collection of default heuristics that effect performance of our generated
     code.  We try to not put correctness requirements in this file.
@@ -106,8 +107,8 @@ class InductorChoices:
             torch._inductor.virtualized.V.set_choices_handler(MyHeuristics())
     """
 
-    def __hash__(self) -> int:
-        return hash(type(self).__qualname__)
+    def uuid(self) -> str:
+        return type(self).__qualname__
 
     def get_config_heuristics(
         self, device_type: str | None = "cuda"

--- a/torch/_inductor/choices.py
+++ b/torch/_inductor/choices.py
@@ -105,10 +105,10 @@ class InductorChoices(CacheAware):
                 ...
 
             torch._inductor.virtualized.V.set_choices_handler(MyHeuristics())
-    """
 
-    def uuid(self) -> str:
-        return type(self).__qualname__
+    Subclasses that are used with inductor_choices_class must override uuid()
+    to return a unique, JSON-serializable identifier for cache key computation.
+    """
 
     def get_config_heuristics(
         self, device_type: str | None = "cuda"

--- a/torch/_inductor/choices.py
+++ b/torch/_inductor/choices.py
@@ -95,7 +95,7 @@ class FusionScore:
 
 class InductorChoices:
     """
-    This class contains a collection of default heuristics that effect performance of our generated
+    This class contains a collection of default heuristics that affect performance of our generated
     code.  We try to not put correctness requirements in this file.
 
     You can override the choices made here by doing:
@@ -105,8 +105,8 @@ class InductorChoices:
 
             torch._inductor.virtualized.V.set_choices_handler(MyHeuristics())
 
-    Subclasses that want to participate in cache key computation should also
-    inherit from CacheAware and implement uuid().
+    Subclasses that want to participate in cache key computation should
+    implement uuid().
     """
 
     def get_config_heuristics(

--- a/torch/_inductor/choices.py
+++ b/torch/_inductor/choices.py
@@ -105,8 +105,8 @@ class InductorChoices:
 
             torch._inductor.virtualized.V.set_choices_handler(MyHeuristics())
 
-    Subclasses that want to participate in cache key computation should
-    implement uuid().
+    Subclasses used with inductor_choices_class must implement uuid() for
+    cache key computation.
     """
 
     def get_config_heuristics(

--- a/torch/_inductor/choices.py
+++ b/torch/_inductor/choices.py
@@ -93,12 +93,7 @@ class FusionScore:
         )
 
 
-class _InductorChoicesMeta(type):
-    def __str__(cls) -> str:
-        return f"{cls.__module__}.{cls.__qualname__}"
-
-
-class InductorChoices(metaclass=_InductorChoicesMeta):
+class InductorChoices:
     """
     This class contains a collection of default heuristics that effect performance of our generated
     code.  We try to not put correctness requirements in this file.
@@ -110,6 +105,9 @@ class InductorChoices(metaclass=_InductorChoicesMeta):
 
             torch._inductor.virtualized.V.set_choices_handler(MyHeuristics())
     """
+
+    def __hash__(self) -> int:
+        return hash(type(self).__qualname__)
 
     def get_config_heuristics(
         self, device_type: str | None = "cuda"

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -2488,6 +2488,8 @@ _cache_config_ignore_prefix: list[str] = [
     "pre_grad_custom_pass",
     "_fuse_ddp_communication_passes",
     "_pre_fusion_custom_pass",
+    # callable hook, not a serializable config value
+    "inductor_choices_class",
     # tests assume that changes here don't invalidate cache
     "always_complex_memory_overlap_TESTING_ONLY",
     # timing affects cache structure, not cache content

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -814,8 +814,18 @@ assume_unaligned_fallback_output = (
     os.environ.get("TORCHINDUCTOR_ASSUME_UNALIGNED_FALLBACK_OUTPUT") == "1"
 )
 
-# Custom InductorChoices subclass to use
-inductor_choices_class: type["InductorChoices"] | None = None
+# Factory callable that returns a custom InductorChoices instance.
+# A callable (rather than a class) is used to defer imports and avoid circular
+# dependencies between config and the choices module. Example:
+#
+#     def _custom_choices_factory():
+#         from my_package.choices import MyInductorChoices
+#         return MyInductorChoices()
+#
+#     config.inductor_choices_class = _custom_choices_factory
+#
+# The returned instance must define __hash__ for cache key serialization.
+inductor_choices_class: Callable[[], "InductorChoices"] | None = None
 
 # fuse even in cases without common reads
 aggressive_fusion = False
@@ -2497,6 +2507,12 @@ _cache_config_ignore_prefix: list[str] = [
     "fx_graph_remote_cache",
     "autotune_local_cache",
     "autotune_remote_cache",
+]
+
+# Config keys whose values are callable factories. save_config_portable
+# will call them and hash the result instead of serializing the callable.
+_cache_config_factory_keys: list[str] = [
+    "inductor_choices_class",
 ]
 
 # External callable for matmul tuning candidates

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -814,8 +814,8 @@ assume_unaligned_fallback_output = (
     os.environ.get("TORCHINDUCTOR_ASSUME_UNALIGNED_FALLBACK_OUTPUT") == "1"
 )
 
-# Custom InductorChoices callable to use (can be a class or functools.partial with kwargs)
-inductor_choices_class: Callable[[], "InductorChoices"] | None = None
+# Custom InductorChoices subclass to use
+inductor_choices_class: type["InductorChoices"] | None = None
 
 # fuse even in cases without common reads
 aggressive_fusion = False
@@ -2488,8 +2488,6 @@ _cache_config_ignore_prefix: list[str] = [
     "pre_grad_custom_pass",
     "_fuse_ddp_communication_passes",
     "_pre_fusion_custom_pass",
-    # callable hook, not a serializable config value
-    # "inductor_choices_class",
     # tests assume that changes here don't invalidate cache
     "always_complex_memory_overlap_TESTING_ONLY",
     # timing affects cache structure, not cache content

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -824,9 +824,14 @@ assume_unaligned_fallback_output = (
 #
 #     config.inductor_choices_class = _custom_choices_factory
 #
-# The returned instance must inherit from CacheAware and implement uuid()
-# for cache key serialization. See torch/_inductor/cache.py.
+# The returned instance should implement uuid() for cache key serialization.
 inductor_choices_class: Callable[[], "InductorChoices"] | None = None
+
+# When True, raise an error if inductor_choices_class (or any factory config)
+# does not implement uuid(). This prevents silent incorrect cache hits.
+strict_cache_config_hashing: bool = (
+    os.environ.get("TORCHINDUCTOR_STRICT_CACHE_CONFIG_HASHING", "0") == "1"
+)
 
 # fuse even in cases without common reads
 aggressive_fusion = False
@@ -2510,8 +2515,8 @@ _cache_config_ignore_prefix: list[str] = [
     "autotune_remote_cache",
 ]
 
-# Config keys whose values are callable factories returning CacheAware instances.
-# save_config_portable will call the factory and use .uuid() for serialization.
+# Config keys whose values are callable factories. save_config_portable will
+# instantiate the factory and use .uuid() for serialization if available.
 _cache_config_factory_keys: list[str] = [
     "inductor_choices_class",
 ]

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -824,14 +824,8 @@ assume_unaligned_fallback_output = (
 #
 #     config.inductor_choices_class = _custom_choices_factory
 #
-# The returned instance should implement uuid() for cache key serialization.
+# The returned instance must implement uuid() for cache key serialization.
 inductor_choices_class: Callable[[], "InductorChoices"] | None = None
-
-# When True, raise an error if inductor_choices_class (or any factory config)
-# does not implement uuid(). This prevents silent incorrect cache hits.
-strict_cache_config_hashing: bool = (
-    os.environ.get("TORCHINDUCTOR_STRICT_CACHE_CONFIG_HASHING", "0") == "1"
-)
 
 # fuse even in cases without common reads
 aggressive_fusion = False
@@ -2516,7 +2510,7 @@ _cache_config_ignore_prefix: list[str] = [
 ]
 
 # Config keys whose values are callable factories. save_config_portable will
-# instantiate the factory and use .uuid() for serialization if available.
+# instantiate the factory and use .uuid() for serialization.
 _cache_config_factory_keys: list[str] = [
     "inductor_choices_class",
 ]

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -2489,7 +2489,7 @@ _cache_config_ignore_prefix: list[str] = [
     "_fuse_ddp_communication_passes",
     "_pre_fusion_custom_pass",
     # callable hook, not a serializable config value
-    "inductor_choices_class",
+    # "inductor_choices_class",
     # tests assume that changes here don't invalidate cache
     "always_complex_memory_overlap_TESTING_ONLY",
     # timing affects cache structure, not cache content

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -824,7 +824,8 @@ assume_unaligned_fallback_output = (
 #
 #     config.inductor_choices_class = _custom_choices_factory
 #
-# The returned instance must define __hash__ for cache key serialization.
+# The returned instance must inherit from CacheAware and implement uuid()
+# for cache key serialization. See torch/_inductor/cache.py.
 inductor_choices_class: Callable[[], "InductorChoices"] | None = None
 
 # fuse even in cases without common reads
@@ -2509,8 +2510,8 @@ _cache_config_ignore_prefix: list[str] = [
     "autotune_remote_cache",
 ]
 
-# Config keys whose values are callable factories. save_config_portable
-# will call them and hash the result instead of serializing the callable.
+# Config keys whose values are callable factories returning CacheAware instances.
+# save_config_portable will call the factory and use .uuid() for serialization.
 _cache_config_factory_keys: list[str] = [
     "inductor_choices_class",
 ]

--- a/torch/utils/_config_module.py
+++ b/torch/utils/_config_module.py
@@ -566,15 +566,17 @@ class ConfigModule(ModuleType):
             prefixes.append("_")
         prefixes.extend(getattr(self, "_cache_config_ignore_prefix", []))
         config = self._get_dict(ignored_prefixes=prefixes)
-        for key in getattr(self, "_cache_config_factory_keys", []):
-            if key in config and config[key] is not None:
-                from torch._inductor.cache import CacheAware
+        factory_keys = getattr(self, "_cache_config_factory_keys", [])
+        if any(key in config and config[key] is not None for key in factory_keys):
+            from torch._inductor.cache import CacheAware
 
-                instance = config[key]()
-                if isinstance(instance, CacheAware):
-                    config[key] = instance.uuid()
-                else:
-                    config[key] = None
+            for key in factory_keys:
+                if key in config and config[key] is not None:
+                    instance = config[key]()
+                    if isinstance(instance, CacheAware):
+                        config[key] = instance.uuid()
+                    else:
+                        config[key] = None
         return config
 
     def codegen_config(self) -> str:

--- a/torch/utils/_config_module.py
+++ b/torch/utils/_config_module.py
@@ -568,7 +568,13 @@ class ConfigModule(ModuleType):
         config = self._get_dict(ignored_prefixes=prefixes)
         for key in getattr(self, "_cache_config_factory_keys", []):
             if key in config and config[key] is not None:
-                config[key] = config[key]().uuid()
+                from torch._inductor.cache import CacheAware
+
+                instance = config[key]()
+                if isinstance(instance, CacheAware):
+                    config[key] = instance.uuid()
+                else:
+                    config[key] = None
         return config
 
     def codegen_config(self) -> str:

--- a/torch/utils/_config_module.py
+++ b/torch/utils/_config_module.py
@@ -573,22 +573,12 @@ class ConfigModule(ModuleType):
                 instance = config[key]()
                 if hasattr(instance, "uuid"):
                     config[key] = instance.uuid()
-                elif getattr(self, "strict_cache_config_hashing", False):
+                else:
                     raise RuntimeError(
                         f"Config '{key}' is set to {config[key]} which does not "
                         f"implement uuid(). Implement uuid() for cache key "
-                        f"participation, or set strict_cache_config_hashing=False."
+                        f"participation."
                     )
-                else:
-                    import warnings
-
-                    warnings.warn(
-                        f"Config '{key}' is set to {config[key]} which does not "
-                        f"implement uuid(). It will be ignored in cache key "
-                        f"computation, which may lead to incorrect cache hits.",
-                        stacklevel=2,
-                    )
-                    del config[key]
         return config
 
     def codegen_config(self) -> str:

--- a/torch/utils/_config_module.py
+++ b/torch/utils/_config_module.py
@@ -568,7 +568,7 @@ class ConfigModule(ModuleType):
         config = self._get_dict(ignored_prefixes=prefixes)
         for key in getattr(self, "_cache_config_factory_keys", []):
             if key in config and config[key] is not None:
-                config[key] = hash(config[key]())
+                config[key] = config[key]().uuid()
         return config
 
     def codegen_config(self) -> str:

--- a/torch/utils/_config_module.py
+++ b/torch/utils/_config_module.py
@@ -567,9 +567,7 @@ class ConfigModule(ModuleType):
         prefixes.extend(getattr(self, "_cache_config_ignore_prefix", []))
         config = self._get_dict(ignored_prefixes=prefixes)
         for key in getattr(self, "_cache_config_factory_keys", []):
-            if key in config and config[key] is None:
-                del config[key]
-            elif key in config:
+            if key in config and config[key] is not None:
                 instance = config[key]()
                 if hasattr(instance, "uuid"):
                     config[key] = instance.uuid()

--- a/torch/utils/_config_module.py
+++ b/torch/utils/_config_module.py
@@ -566,17 +566,29 @@ class ConfigModule(ModuleType):
             prefixes.append("_")
         prefixes.extend(getattr(self, "_cache_config_ignore_prefix", []))
         config = self._get_dict(ignored_prefixes=prefixes)
-        factory_keys = getattr(self, "_cache_config_factory_keys", [])
-        if any(key in config and config[key] is not None for key in factory_keys):
-            from torch._inductor.cache import CacheAware
+        for key in getattr(self, "_cache_config_factory_keys", []):
+            if key in config and config[key] is None:
+                del config[key]
+            elif key in config:
+                instance = config[key]()
+                if hasattr(instance, "uuid"):
+                    config[key] = instance.uuid()
+                elif getattr(self, "strict_cache_config_hashing", False):
+                    raise RuntimeError(
+                        f"Config '{key}' is set to {config[key]} which does not "
+                        f"implement uuid(). Implement uuid() for cache key "
+                        f"participation, or set strict_cache_config_hashing=False."
+                    )
+                else:
+                    import warnings
 
-            for key in factory_keys:
-                if key in config and config[key] is not None:
-                    instance = config[key]()
-                    if isinstance(instance, CacheAware):
-                        config[key] = instance.uuid()
-                    else:
-                        config[key] = None
+                    warnings.warn(
+                        f"Config '{key}' is set to {config[key]} which does not "
+                        f"implement uuid(). It will be ignored in cache key "
+                        f"computation, which may lead to incorrect cache hits.",
+                        stacklevel=2,
+                    )
+                    del config[key]
         return config
 
     def codegen_config(self) -> str:

--- a/torch/utils/_config_module.py
+++ b/torch/utils/_config_module.py
@@ -565,7 +565,11 @@ class ConfigModule(ModuleType):
         if ignore_private_configs:
             prefixes.append("_")
         prefixes.extend(getattr(self, "_cache_config_ignore_prefix", []))
-        return self._get_dict(ignored_prefixes=prefixes)
+        config = self._get_dict(ignored_prefixes=prefixes)
+        for key in getattr(self, "_cache_config_factory_keys", []):
+            if key in config and config[key] is not None:
+                config[key] = hash(config[key]())
+        return config
 
     def codegen_config(self) -> str:
         """Convert config to Python statements that replicate current config.


### PR DESCRIPTION
  Summary

  Factory configs like inductor_choices_class are callable hooks that were previously excluded from cache key computation, risking incorrect cache hits when different choice implementations produce identical keys.
  
  This PR adds a _cache_config_factory_keys mechanism in save_config_portable() that instantiates factory configs and calls .uuid() for cache key serialization when available. When inductor_choices_class is the default
   None, it is excluded from the hash entirely. Subclasses without uuid() emit a warning and are also excluded.

  A new strict_cache_config_hashing config (TORCHINDUCTOR_STRICT_CACHE_CONFIG_HASHING=1) is added for downstream users who want to error when a factory config doesn't implement uuid(). A follow-up PR will enable this
  for the internal use case.

  Test plan

  - python test/inductor/test_cache.py -k test_callable_config_not_json_serializable
  - _1: verifies that raw callable configs still fail JSON serialization
  - _2: verifies that inductor_choices_class with different InductorChoices subclasses produces distinct, JSON-serializable cache keys

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo