### PR TITLE
[CI] Add script to map EC2 runner labels to ARC equivalents

### DIFF
--- a/.github/scripts/map_ec2_to_arc.py
+++ b/.github/scripts/map_ec2_to_arc.py
@@ -61,10 +61,14 @@ def main() -> None:
     mapping = load_mapping(arc_yaml)
 
     matrix = yaml.safe_load(args.matrix)
+    if not matrix:
+        set_output("test-matrix", args.matrix)
+        return
+
     entries = matrix.get("include", [])
     if not entries:
-        print("error: matrix has no 'include' entries", file=sys.stderr)
-        sys.exit(1)
+        set_output("test-matrix", json.dumps(matrix))
+        return
 
     for entry in entries:
         if "runner" not in entry:

--- a/.github/scripts/map_ec2_to_arc.py
+++ b/.github/scripts/map_ec2_to_arc.py
@@ -12,6 +12,7 @@ Usage:
 
 import argparse
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -46,6 +47,14 @@ def load_mapping(arc_yaml: Path) -> dict[str, str]:
     return data["runner_mapping"]
 
 
+def set_output(name: str, val: str) -> None:
+    print(f"Setting {name}={val}")
+    github_output = os.getenv("GITHUB_OUTPUT")
+    if github_output:
+        with open(github_output, "a") as f:
+            print(f"{name}={val}", file=f)
+
+
 def main() -> None:
     args = parse_args()
     arc_yaml = Path(__file__).resolve().parent.parent / "arc.yaml"
@@ -66,7 +75,7 @@ def main() -> None:
             sys.exit(1)
         entry["runner"] = args.prefix + mapping[clean]
 
-    print(json.dumps(matrix))
+    set_output("test-matrix", json.dumps(matrix))
 
 
 if __name__ == "__main__":

--- a/.github/scripts/map_ec2_to_arc.py
+++ b/.github/scripts/map_ec2_to_arc.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Map EC2 runner labels to ARC equivalents using .github/arc.yaml.
+
+Takes a GitHub Actions test matrix, replaces each runner with its ARC
+equivalent, and prints the updated matrix as JSON.
+
+Usage:
+    python map_ec2_to_arc.py --prefix mt- '{ include: [
+      { config: "default", shard: 1, num_shards: 5, runner: "mt-linux.4xlarge" },
+    ]}'
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import yaml
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Map EC2 runner labels to ARC runner labels in a test matrix"
+    )
+    parser.add_argument(
+        "matrix",
+        help="GitHub Actions test matrix string to transform",
+    )
+    parser.add_argument(
+        "--prefix",
+        default="",
+        help="Runner prefix to strip from labels (e.g. 'mt-')",
+    )
+    return parser.parse_args()
+
+
+def strip_prefix(label: str, prefix: str) -> str:
+    if prefix and label.startswith(prefix):
+        return label[len(prefix) :]
+    return label
+
+
+def load_mapping(arc_yaml: Path) -> dict[str, str]:
+    with open(arc_yaml) as f:
+        data = yaml.safe_load(f)
+    return data["runner_mapping"]
+
+
+def main() -> None:
+    args = parse_args()
+    arc_yaml = Path(__file__).resolve().parent.parent / "arc.yaml"
+    mapping = load_mapping(arc_yaml)
+
+    matrix = yaml.safe_load(args.matrix)
+    entries = matrix.get("include", [])
+    if not entries:
+        print("error: matrix has no 'include' entries", file=sys.stderr)
+        sys.exit(1)
+
+    for entry in entries:
+        if "runner" not in entry:
+            continue
+        clean = strip_prefix(entry["runner"].strip(), args.prefix)
+        if clean not in mapping:
+            print(f"error: no ARC runner found for '{clean}'", file=sys.stderr)
+            sys.exit(1)
+        entry["runner"] = args.prefix + mapping[clean]
+
+    print(json.dumps(matrix))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/test_map_ec2_to_arc.py
+++ b/.github/scripts/test_map_ec2_to_arc.py
@@ -117,11 +117,17 @@ def test_preserves_non_runner_fields():
     check(entry["runner"] == "l-x86iavx512-2-4")
 
 
-def test_empty_include_fails():
+def test_empty_include_passes_through():
     matrix = """{ include: [] }"""
     result = run(matrix)
-    check(result.returncode == 1)
-    check("no 'include' entries" in result.stderr)
+    check(result.returncode == 0, result.stderr)
+    output = parse_output(result.stdout)
+    check(output == {"include": []}, f"expected empty include, got {output}")
+
+
+def test_empty_string_passes_through():
+    result = run("")
+    check(result.returncode == 0, result.stderr)
 
 
 def test_mixed_runners():
@@ -157,7 +163,9 @@ def test_github_output_file():
         check(result.returncode == 0, result.stderr)
 
         contents = Path(tmp_path).read_text()
-        check(contents.startswith("test-matrix="), f"unexpected file contents: {contents}")
+        check(
+            contents.startswith("test-matrix="), f"unexpected file contents: {contents}"
+        )
         written = json.loads(contents[len("test-matrix=") :].strip())
         check(written["include"][0]["runner"] == "l-x86iavx512-8-64")
     finally:

--- a/.github/scripts/test_map_ec2_to_arc.py
+++ b/.github/scripts/test_map_ec2_to_arc.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parent / "map_ec2_to_arc.py"
+
+
+def run(matrix: str, prefix: str = "") -> subprocess.CompletedProcess:
+    cmd = [sys.executable, str(SCRIPT)]
+    if prefix:
+        cmd += ["--prefix", prefix]
+    cmd.append(matrix)
+    return subprocess.run(cmd, capture_output=True, text=True)
+
+
+def check(condition: bool, msg: str = "") -> None:
+    if not condition:
+        raise AssertionError(msg)
+
+
+def test_basic_matrix():
+    matrix = """{ include: [
+      { config: "default", shard: 1, num_shards: 1, runner: "linux.4xlarge" },
+      { config: "openreg", shard: 1, num_shards: 1, runner: "linux.2xlarge" },
+    ]}"""
+    result = run(matrix)
+    check(result.returncode == 0, result.stderr)
+    output = json.loads(result.stdout)
+    runners = [e["runner"] for e in output["include"]]
+    check(runners == ["l-x86iavx512-16-128", "l-x86iavx512-8-64"])
+
+
+def test_matrix_with_prefix():
+    matrix = """{ include: [
+      { config: "default", shard: 1, num_shards: 7, runner: "mt-linux.4xlarge" },
+      { config: "default", shard: 2, num_shards: 7, runner: "mt-linux.4xlarge" },
+      { config: "openreg", shard: 1, num_shards: 1, runner: "mt-linux.2xlarge" },
+    ]}"""
+    result = run(matrix, prefix="mt-")
+    check(result.returncode == 0, result.stderr)
+    output = json.loads(result.stdout)
+    runners = [e["runner"] for e in output["include"]]
+    check(
+        runners
+        == [
+            "mt-l-x86iavx512-16-128",
+            "mt-l-x86iavx512-16-128",
+            "mt-l-x86iavx512-8-64",
+        ]
+    )
+
+
+def test_matrix_without_prefix_when_none_present():
+    matrix = """{ include: [
+      { config: "default", shard: 1, num_shards: 1, runner: "linux.g5.4xlarge.nvidia.gpu" },
+    ]}"""
+    result = run(matrix)
+    check(result.returncode == 0, result.stderr)
+    output = json.loads(result.stdout)
+    check(output["include"][0]["runner"] == "l-x86aavx2-29-113-a10g")
+
+
+def test_unknown_runner_fails():
+    matrix = """{ include: [
+      { config: "default", shard: 1, num_shards: 1, runner: "bogus.runner" },
+    ]}"""
+    result = run(matrix)
+    check(result.returncode == 1)
+    check("no ARC runner found for 'bogus.runner'" in result.stderr)
+
+
+def test_prefix_not_present_on_runner():
+    """When --prefix is given but a runner doesn't have it, the raw label is used."""
+    matrix = """{ include: [
+      { config: "default", shard: 1, num_shards: 1, runner: "linux.4xlarge" },
+    ]}"""
+    result = run(matrix, prefix="mt-")
+    check(result.returncode == 0, result.stderr)
+    output = json.loads(result.stdout)
+    check(output["include"][0]["runner"] == "mt-l-x86iavx512-16-128")
+
+
+def test_preserves_non_runner_fields():
+    matrix = """{ include: [
+      { config: "default", shard: 3, num_shards: 7, runner: "linux.large" },
+    ]}"""
+    result = run(matrix)
+    check(result.returncode == 0, result.stderr)
+    entry = json.loads(result.stdout)["include"][0]
+    check(entry["config"] == "default")
+    check(entry["shard"] == 3)
+    check(entry["num_shards"] == 7)
+    check(entry["runner"] == "l-x86iavx512-2-4")
+
+
+def test_empty_include_fails():
+    matrix = """{ include: [] }"""
+    result = run(matrix)
+    check(result.returncode == 1)
+    check("no 'include' entries" in result.stderr)
+
+
+def test_mixed_runners():
+    matrix = """{ include: [
+      { config: "default", shard: 1, num_shards: 1, runner: "linux.4xlarge" },
+      { config: "gpu", shard: 1, num_shards: 1, runner: "linux.g5.4xlarge.nvidia.gpu" },
+      { config: "arm", shard: 1, num_shards: 1, runner: "linux.arm64.2xlarge" },
+    ]}"""
+    result = run(matrix)
+    check(result.returncode == 0, result.stderr)
+    output = json.loads(result.stdout)
+    runners = [e["runner"] for e in output["include"]]
+    check(
+        runners
+        == [
+            "l-x86iavx512-16-128",
+            "l-x86aavx2-29-113-a10g",
+            "l-arm64g2-6-32",
+        ]
+    )
+
+
+if __name__ == "__main__":
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  PASS  {t.__name__}")
+        except AssertionError as e:
+            print(f"  FAIL  {t.__name__}: {e}")
+            failed += 1
+    if failed:
+        print(f"\n{failed}/{len(tests)} tests failed")
+        sys.exit(1)
+    print(f"\nAll {len(tests)} tests passed")

--- a/.github/scripts/test_map_ec2_to_arc.py
+++ b/.github/scripts/test_map_ec2_to_arc.py
@@ -1,20 +1,40 @@
 #!/usr/bin/env python3
 
 import json
+import os
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 
 SCRIPT = Path(__file__).resolve().parent / "map_ec2_to_arc.py"
 
 
-def run(matrix: str, prefix: str = "") -> subprocess.CompletedProcess:
+def run(
+    matrix: str, prefix: str = "", github_output: str | None = None
+) -> subprocess.CompletedProcess:
     cmd = [sys.executable, str(SCRIPT)]
     if prefix:
         cmd += ["--prefix", prefix]
     cmd.append(matrix)
-    return subprocess.run(cmd, capture_output=True, text=True)
+
+    env = os.environ.copy()
+    if github_output is not None:
+        env["GITHUB_OUTPUT"] = github_output
+    else:
+        env.pop("GITHUB_OUTPUT", None)
+
+    return subprocess.run(cmd, capture_output=True, text=True, env=env)
+
+
+def parse_output(stdout: str) -> dict:
+    """Extract the JSON matrix from the 'Setting test-matrix=...' line."""
+    prefix = "Setting test-matrix="
+    for line in stdout.splitlines():
+        if line.startswith(prefix):
+            return json.loads(line[len(prefix) :])
+    raise ValueError(f"no test-matrix output found in: {stdout}")
 
 
 def check(condition: bool, msg: str = "") -> None:
@@ -29,7 +49,7 @@ def test_basic_matrix():
     ]}"""
     result = run(matrix)
     check(result.returncode == 0, result.stderr)
-    output = json.loads(result.stdout)
+    output = parse_output(result.stdout)
     runners = [e["runner"] for e in output["include"]]
     check(runners == ["l-x86iavx512-16-128", "l-x86iavx512-8-64"])
 
@@ -42,7 +62,7 @@ def test_matrix_with_prefix():
     ]}"""
     result = run(matrix, prefix="mt-")
     check(result.returncode == 0, result.stderr)
-    output = json.loads(result.stdout)
+    output = parse_output(result.stdout)
     runners = [e["runner"] for e in output["include"]]
     check(
         runners
@@ -60,7 +80,7 @@ def test_matrix_without_prefix_when_none_present():
     ]}"""
     result = run(matrix)
     check(result.returncode == 0, result.stderr)
-    output = json.loads(result.stdout)
+    output = parse_output(result.stdout)
     check(output["include"][0]["runner"] == "l-x86aavx2-29-113-a10g")
 
 
@@ -80,7 +100,7 @@ def test_prefix_not_present_on_runner():
     ]}"""
     result = run(matrix, prefix="mt-")
     check(result.returncode == 0, result.stderr)
-    output = json.loads(result.stdout)
+    output = parse_output(result.stdout)
     check(output["include"][0]["runner"] == "mt-l-x86iavx512-16-128")
 
 
@@ -90,7 +110,7 @@ def test_preserves_non_runner_fields():
     ]}"""
     result = run(matrix)
     check(result.returncode == 0, result.stderr)
-    entry = json.loads(result.stdout)["include"][0]
+    entry = parse_output(result.stdout)["include"][0]
     check(entry["config"] == "default")
     check(entry["shard"] == 3)
     check(entry["num_shards"] == 7)
@@ -112,7 +132,7 @@ def test_mixed_runners():
     ]}"""
     result = run(matrix)
     check(result.returncode == 0, result.stderr)
-    output = json.loads(result.stdout)
+    output = parse_output(result.stdout)
     runners = [e["runner"] for e in output["include"]]
     check(
         runners
@@ -122,6 +142,26 @@ def test_mixed_runners():
             "l-arm64g2-6-32",
         ]
     )
+
+
+def test_github_output_file():
+    """When GITHUB_OUTPUT is set, the script writes test-matrix to that file."""
+    matrix = """{ include: [
+      { config: "default", shard: 1, num_shards: 1, runner: "linux.2xlarge" },
+    ]}"""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+        tmp_path = f.name
+
+    try:
+        result = run(matrix, github_output=tmp_path)
+        check(result.returncode == 0, result.stderr)
+
+        contents = Path(tmp_path).read_text()
+        check(contents.startswith("test-matrix="), f"unexpected file contents: {contents}")
+        written = json.loads(contents[len("test-matrix=") :].strip())
+        check(written["include"][0]["runner"] == "l-x86iavx512-8-64")
+    finally:
+        os.unlink(tmp_path)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/_linux-build.yml
+++ b/.github/workflows/_linux-build.yml
@@ -477,7 +477,7 @@ jobs:
     timeout-minutes: 480
     outputs:
       docker-image: ${{ inputs.docker-image-name }}
-      test-matrix: ${{ steps.filter.outputs.test-matrix }}
+      test-matrix: ${{ steps.map-runners.outputs.test-matrix }}
       build-environment: ${{ inputs.build-environment }}
     steps:
       - name: Setup Linux
@@ -510,6 +510,15 @@ jobs:
           test-matrix: ${{ inputs.test-matrix }}
           selected-test-configs: ${{ inputs.selected-test-configs }}
           job-name: ${{ steps.setup-linux.outputs.job-name }}
+
+      - name: Map EC2 runners to ARC runners
+        id: map-runners
+        env:
+          FILTERED_TEST_MATRIX: ${{ steps.filter.outputs.test-matrix }}
+          RUNNER_PREFIX: ${{ inputs.runner_prefix }}
+        shell: bash
+        run: |
+          python3 .github/scripts/map_ec2_to_arc.py --prefix "${RUNNER_PREFIX}" "${FILTERED_TEST_MATRIX}"
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7


### PR DESCRIPTION
Reads .github/arc.yaml and transforms a GitHub Actions test matrix, replacing EC2 runner labels with their ARC counterparts while preserving the runner prefix.

Inputs:
* Runner label prefix, i.e. `mt-`
* Test matrix configs, i.e. 
```
{ include: [
      { config: "default", shard: 1, num_shards: 1, runner: "linux.4xlarge" },
      { config: "openreg", shard: 1, num_shards: 1, runner: "linux.2xlarge" },
]}
```

Return the new test matrix with the corresponding ARC runner labels:
```
{ include: [
      { config: "default", shard: 1, num_shards: 1, runner: "mt-l-x86iavx512-16-128" },
      { config: "openreg", shard: 1, num_shards: 1, runner: "mt-l-x86iavx512-16-128" },
]}
```

### Testing

```
python .github/scripts/test_map_ec2_to_arc.py
```