### PR TITLE
[JIT] Silence CPython 3.13.8 inspect.getsourcelines() bug

### DIFF
--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -1106,6 +1106,7 @@ def _overload_method(func):
         # Fixed in 3.13.9. Swallow the error on affected versions; re-raise otherwise.
         if sys.version_info[:3] == (3, 13, 8):
             import warnings
+
             warnings.warn(
                 "Skipping overload body check due to a known CPython 3.13.8 bug "
                 "(https://github.com/python/cpython/issues/139783). "

--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -1097,7 +1097,23 @@ _overloaded_method_class_fileno: dict[tuple[str, str], int] = {}
 
 
 def _overload_method(func):
-    _check_overload_body(func)
+    try:
+        _check_overload_body(func)
+    except IndentationError:
+        # CPython 3.13.8 has a bug (https://github.com/python/cpython/issues/139783)
+        # where inspect.getsourcelines() returns truncated source when a decorator
+        # is followed by a comment, causing ast.parse() to fail with IndentationError.
+        # Fixed in 3.13.9. Swallow the error on affected versions; re-raise otherwise.
+        if sys.version_info[:3] == (3, 13, 8):
+            import warnings
+            warnings.warn(
+                "Skipping overload body check due to a known CPython 3.13.8 bug "
+                "(https://github.com/python/cpython/issues/139783). "
+                "Consider upgrading to Python 3.13.9+.",
+                stacklevel=2,
+            )
+        else:
+            raise
     qual_name = _qualified_name(func)
     global _overloaded_methods
     class_name_map = _overloaded_methods.get(qual_name)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #179066

Silences spurious indent error raised due to https://github.com/python/cpython/issues/139783
The fix catches `IndentationError` in `torch._jit_internal._overload_method`, and skips the overload body checks in that case on 3.13.8

Fixes https://github.com/pytorch/pytorch/issues/178255

Co-authored-by: Claude <noreply@anthropic.com>