### PR TITLE
[Dynamo][CPython] Add mp_subscript_impl for unified __getitem__ dispatch

### DIFF
--- a/test/dynamo/test_getitem.py
+++ b/test/dynamo/test_getitem.py
@@ -1,0 +1,450 @@
+# Owner(s): ["module: dynamo"]
+"""Tests for mp_subscript_impl: unified __getitem__ dispatch via vt_getitem in Dynamo.
+
+Each test uses operator.getitem() to exercise the vt_getitem → mp_subscript_impl
+path (BuiltinVariable.call_getitem → vt_getitem → VT.mp_subscript_impl), which
+is distinct from the call_method("__getitem__") path.
+"""
+
+import collections
+import operator
+import types
+import unittest
+
+import torch
+import torch._dynamo.test_case
+import torch._dynamo.testing
+from torch.testing._internal.inductor_utils import HAS_CUDA_AND_TRITON, HAS_GPU
+
+
+requires_gpu_and_triton = unittest.skipUnless(
+    HAS_GPU and HAS_CUDA_AND_TRITON, "requires gpu and triton"
+)
+
+
+class GetItemTests(torch._dynamo.test_case.TestCase):
+    def _compile(self, fn, *args):
+        return torch.compile(fn, backend="eager", fullgraph=True)(*args)
+
+    # --- BaseListVariable (ListVariable) ---
+
+    def test_list_int_index(self):
+        def fn(x):
+            items = [x, x + 1, x + 2]
+            return operator.getitem(items, 1)
+
+        x = torch.randn(4)
+        self.assertEqual(fn(x), self._compile(fn, x))
+
+    def test_list_slice(self):
+        def fn(x):
+            items = [x, x + 1, x + 2]
+            return operator.getitem(items, slice(0, 2))
+
+        x = torch.randn(4)
+        ref = fn(x)
+        res = self._compile(fn, x)
+        for r, e in zip(res, ref):
+            self.assertEqual(r, e)
+
+    def test_list_negative_index(self):
+        def fn(x):
+            items = [x, x + 1, x + 2]
+            return operator.getitem(items, -1)
+
+        x = torch.randn(4)
+        self.assertEqual(fn(x), self._compile(fn, x))
+
+    def test_list_bool_index(self):
+        def fn(x):
+            items = [x, x + 1, x + 2]
+            return operator.getitem(items, True)
+
+        x = torch.randn(4)
+        self.assertEqual(fn(x), self._compile(fn, x))
+
+    def test_list_custom_index_class(self):
+        class MyIdx:
+            def __index__(self):
+                return 1
+
+        def fn(x):
+            items = [x, x + 1, x + 2]
+            idx = MyIdx()
+            return operator.getitem(items, idx)
+
+        x = torch.randn(4)
+        self.assertEqual(fn(x), self._compile(fn, x))
+
+    def test_list_invalid_index_type(self):
+        def fn(x):
+            items = [x, x + 1, x + 2]
+            return operator.getitem(items, "a")
+
+        x = torch.randn(4)
+        with self.assertRaises(torch._dynamo.exc.Unsupported):
+            self._compile(fn, x)
+
+    # --- BaseListVariable (TupleVariable) ---
+
+    def test_tuple_int_index(self):
+        def fn(x):
+            items = (x, x + 1, x + 2)
+            return operator.getitem(items, 0)
+
+        x = torch.randn(4)
+        self.assertEqual(fn(x), self._compile(fn, x))
+
+    # --- RangeVariable ---
+
+    def test_range_int_index(self):
+        def fn(x):
+            r = range(0, 10, 2)
+            return x + operator.getitem(r, 3)
+
+        x = torch.randn(4)
+        self.assertEqual(fn(x), self._compile(fn, x))
+
+    def test_range_slice(self):
+        def fn(x):
+            r = range(0, 10, 2)
+            result = operator.getitem(r, slice(1, 3))
+            return x + result[0]
+
+        x = torch.randn(4)
+        self.assertEqual(fn(x), self._compile(fn, x))
+
+    # --- SizeVariable ---
+
+    def test_size_int_index(self):
+        def fn(x):
+            s = x.size()
+            return x + operator.getitem(s, 0)
+
+        x = torch.randn(4, 8)
+        self.assertEqual(fn(x), self._compile(fn, x))
+
+    # --- ConstDictVariable ---
+
+    def test_dict_str_key(self):
+        def fn(x):
+            d = {"a": x, "b": x + 1}
+            return operator.getitem(d, "a")
+
+        x = torch.randn(4)
+        self.assertEqual(fn(x), self._compile(fn, x))
+
+    def test_dict_int_key(self):
+        def fn(x):
+            d = {0: x, 1: x + 1}
+            return operator.getitem(d, 1)
+
+        x = torch.randn(4)
+        self.assertEqual(fn(x), self._compile(fn, x))
+
+    # --- DefaultDictVariable ---
+
+    def test_defaultdict_existing_key(self):
+        def fn(x):
+            d = collections.defaultdict(lambda: x + 99)
+            d["a"] = x
+            return operator.getitem(d, "a")
+
+        x = torch.randn(4)
+        self.assertEqual(fn(x), self._compile(fn, x))
+
+    # --- TensorVariable ---
+
+    def test_tensor_int_index(self):
+        def fn(x):
+            return operator.getitem(x, 0)
+
+        x = torch.randn(4, 4)
+        self.assertEqual(fn(x), self._compile(fn, x))
+
+    def test_tensor_slice(self):
+        def fn(x):
+            return operator.getitem(x, slice(0, 2))
+
+        x = torch.randn(4, 4)
+        self.assertEqual(fn(x), self._compile(fn, x))
+
+    def test_tensor_tuple_index(self):
+        def fn(x):
+            return operator.getitem(x, (0, slice(1, 3)))
+
+        x = torch.randn(4, 4)
+        self.assertEqual(fn(x), self._compile(fn, x))
+
+    # --- NamedTupleVariable (via UserDefinedTupleVariable) ---
+
+    def test_namedtuple_int_index(self):
+        def fn(x):
+            result = torch.topk(x, 2)
+            return operator.getitem(result, 1)
+
+        x = torch.randn(10)
+        self.assertEqual(fn(x), self._compile(fn, x))
+
+    def test_namedtuple_values_index(self):
+        def fn(x):
+            result = torch.topk(x, 2)
+            return operator.getitem(result, 0)
+
+        x = torch.randn(10)
+        self.assertEqual(fn(x), self._compile(fn, x))
+
+    # --- TypingVariable ---
+
+    def test_typing_subscript(self):
+        def fn(x):
+            operator.getitem(list, int)
+            return x + 1
+
+        x = torch.randn(4)
+        self.assertEqual(fn(x), self._compile(fn, x))
+
+    # --- MappingProxyVariable ---
+
+    def test_mappingproxy_getitem(self):
+        def fn(x):
+            d = {"a": 1, "b": 2}
+            proxy = types.MappingProxyType(d)
+            return x + operator.getitem(proxy, "a")
+
+        x = torch.randn(4)
+        self.assertEqual(fn(x), self._compile(fn, x))
+
+    # --- NNModuleVariable (ModuleList) ---
+
+    def test_nn_module_list_int_index(self):
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.layers = torch.nn.ModuleList(
+                    [torch.nn.Linear(4, 4) for _ in range(3)]
+                )
+
+            def forward(self, x):
+                return operator.getitem(self.layers, 1)(x)
+
+        model = Model()
+        x = torch.randn(4)
+        compiled = torch.compile(model, backend="eager", fullgraph=True)
+        self.assertEqual(model(x), compiled(x))
+
+    # --- NNModuleVariable (ModuleDict) ---
+
+    def test_nn_module_dict_str_key(self):
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.layers = torch.nn.ModuleDict({"fc": torch.nn.Linear(4, 4)})
+
+            def forward(self, x):
+                return operator.getitem(self.layers, "fc")(x)
+
+        model = Model()
+        x = torch.randn(4)
+        compiled = torch.compile(model, backend="eager", fullgraph=True)
+        self.assertEqual(model(x), compiled(x))
+
+    # --- NNModuleVariable (Sequential) ---
+
+    def test_nn_sequential_int_index(self):
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.seq = torch.nn.Sequential(
+                    torch.nn.Linear(4, 4),
+                    torch.nn.ReLU(),
+                )
+
+            def forward(self, x):
+                return operator.getitem(self.seq, 0)(x)
+
+        model = Model()
+        x = torch.randn(4)
+        compiled = torch.compile(model, backend="eager", fullgraph=True)
+        self.assertEqual(model(x), compiled(x))
+
+    # --- UserDefinedObjectVariable ---
+
+    def test_user_defined_object_getitem(self):
+        class Container:
+            def __init__(self, items):
+                self.items = items
+
+            def __getitem__(self, key):
+                return self.items[key]
+
+        def fn(x):
+            c = Container([x, x + 1])
+            return operator.getitem(c, 0)
+
+        x = torch.randn(4)
+        self.assertEqual(fn(x), self._compile(fn, x))
+
+    def test_object_without_getitem(self):
+        class NoGetItem:
+            pass
+
+        def fn(x):
+            obj = NoGetItem()
+            return operator.getitem(obj, 0)
+
+        x = torch.randn(4)
+        with self.assertRaises(torch._dynamo.exc.Unsupported):
+            self._compile(fn, x)
+
+    # --- UserDefinedListVariable ---
+
+    def test_user_defined_list_getitem(self):
+        class MyList(list):
+            pass
+
+        def fn(x):
+            items = MyList([x, x + 1, x + 2])
+            return operator.getitem(items, 1)
+
+        x = torch.randn(4)
+        self.assertEqual(fn(x), self._compile(fn, x))
+
+    # --- UserDefinedDictVariable ---
+
+    def test_user_defined_dict_getitem(self):
+        class MyDict(dict):
+            pass
+
+        def fn(x):
+            d = MyDict(a=x, b=x + 1)
+            return operator.getitem(d, "a")
+
+        x = torch.randn(4)
+        self.assertEqual(fn(x), self._compile(fn, x))
+
+    def test_user_defined_dict_missing(self):
+        class MyDict(dict):
+            def __missing__(self, key):
+                return 42
+
+        def fn(x):
+            d = MyDict(a=1)
+            return x + operator.getitem(d, "b")
+
+        x = torch.randn(4)
+        self.assertEqual(fn(x), self._compile(fn, x))
+
+    def test_user_defined_dict_custom_missing(self):
+        class DefaultDict(dict):
+            def __missing__(self, key):
+                self[key] = len(self)
+                return self[key]
+
+        def fn(x):
+            d = DefaultDict()
+            d["a"] = 1
+            val = operator.getitem(d, "b")
+            return x + val
+
+        x = torch.randn(4)
+        self.assertEqual(fn(x), self._compile(fn, x))
+
+    def test_collections_counter_getitem(self):
+        def fn(x):
+            c = collections.Counter({"a": 1, "b": 2})
+            return x + operator.getitem(c, "a")
+
+        x = torch.randn(4)
+        self.assertEqual(fn(x), self._compile(fn, x))
+
+    # --- GetAttrVariable (__dict__ access) ---
+
+    def test_getattr_dict_getitem(self):
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = torch.nn.Linear(4, 4)
+
+            def forward(self, x):
+                layer = operator.getitem(self.__dict__["_modules"], "linear")
+                return layer(x)
+
+        model = Model()
+        x = torch.randn(4)
+        compiled = torch.compile(model, backend="eager", fullgraph=True)
+        self.assertEqual(model(x), compiled(x))
+
+    # --- TorchScriptObjectVariable ---
+
+    def test_opaque_object_getitem(self):
+        from torch._library.opaque_object import (
+            MemberType,
+            OpaqueBase,
+            register_opaque_type,
+        )
+
+        class OpaqueScaler(OpaqueBase):
+            def __init__(self, scale):
+                self.scale = scale
+
+            def apply(self, x):
+                return x * self.scale
+
+        class OpaqueContainer(OpaqueBase):
+            def __init__(self, items):
+                self.items = items
+
+            def __getitem__(self, idx):
+                return self.items[idx]
+
+        register_opaque_type(
+            OpaqueScaler,
+            typ="reference",
+            members={
+                "scale": MemberType.USE_REAL,
+                "apply": MemberType.INLINED,
+            },
+        )
+        register_opaque_type(
+            OpaqueContainer,
+            typ="reference",
+            members={
+                "items": MemberType.USE_REAL,
+                "__getitem__": MemberType.INLINED,
+            },
+        )
+
+        def fn(x, c):
+            scaler = operator.getitem(c, 0)
+            return scaler.apply(x)
+
+        x = torch.randn(4)
+        c = OpaqueContainer([OpaqueScaler(2.0), OpaqueScaler(3.0)])
+        compiled = torch.compile(fn, backend="eager", fullgraph=True)
+        self.assertEqual(fn(x, c), compiled(x, c))
+
+    # --- TritonKernelVariable ---
+
+    @requires_gpu_and_triton
+    def test_triton_kernel_getitem_grid(self):
+        from torch.testing._internal.triton_utils import add_kernel
+
+        def fn(x, y):
+            output = torch.zeros_like(x)
+            n_elements = output.numel()
+            grid = (n_elements // 256,)
+            bound = operator.getitem(add_kernel, grid)
+            bound(x, y, output, n_elements, BLOCK_SIZE=256)
+            return output
+
+        x = torch.randn(256, device="cuda")
+        y = torch.randn(256, device="cuda")
+        compiled = torch.compile(fn, backend="eager", fullgraph=True)
+        self.assertEqual(fn(x, y), compiled(x, y))
+
+
+if __name__ == "__main__":
+    from torch._dynamo.test_case import run_tests
+
+    run_tests()

--- a/torch/_dynamo/graph_break_registry.json
+++ b/torch/_dynamo/graph_break_registry.json
@@ -870,6 +870,22 @@
   "GB0070": [
     {
       "Gb_type": "Indexing list with non-scalar tensor",
+      "Context": "mp_subscript_impl {self} {key}",
+      "Explanation": "Attempted to index list-like object with tensor with > 1 element.",
+      "Hints": [
+        "Your code may result in an error when running in eager. Please double check that your code doesn't contain a similar error when actually running eager/uncompiled. You can do this by removing the `torch.compile` call, or by using `torch.compiler.set_stance(\"force_eager\")`. "
+      ]
+    },
+    {
+      "Gb_type": "Indexing list with non-scalar tensor",
+      "Context": "getitem_impl {self} {key}",
+      "Explanation": "Attempted to index list-like object with tensor with > 1 element.",
+      "Hints": [
+        "Your code may result in an error when running in eager. Please double check that your code doesn't contain a similar error when actually running eager/uncompiled. You can do this by removing the `torch.compile` call, or by using `torch.compiler.set_stance(\"force_eager\")`. "
+      ]
+    },
+    {
+      "Gb_type": "Indexing list with non-scalar tensor",
       "Context": "call_method {self} {name} {args} {kwargs}",
       "Explanation": "Attempted to index list-like object with tensor with > 1 element.",
       "Hints": [
@@ -1502,6 +1518,34 @@
       ]
     }
   ],
+  "GB1201": [
+    {
+      "Gb_type": "unsupported __getitem__",
+      "Context": "mp_subscript_impl {self} {key}",
+      "Explanation": "Dynamo does not know how to handle __getitem__ on {self}",
+      "Hints": []
+    },
+    {
+      "Gb_type": "unsupported operator.getitem",
+      "Context": "call_getitem fallback {args[0]} {args[1]}",
+      "Explanation": "Dynamo does not know how to handle operator.getitem on {args[0]}",
+      "Hints": []
+    }
+  ],
+  "GB3228": [
+    {
+      "Gb_type": "Illegal __getitem__ invocation in strict mode",
+      "Context": "mp_subscript_impl {self} {key}",
+      "Explanation": "Dynamo currently does not support __getitem__ invocation in strict mode.",
+      "Hints": []
+    },
+    {
+      "Gb_type": "Illegal __getitem__ invocation in strict mode",
+      "Context": "getitem_impl {self} {key}",
+      "Explanation": "Dynamo currently does not support __getitem__ invocation in strict mode.",
+      "Hints": []
+    }
+  ],
   "GB4695": [
     {
       "Gb_type": "torch.jit.script/freeze modules unsupported",
@@ -1866,6 +1910,18 @@
     }
   ],
   "GB0153": [
+    {
+      "Gb_type": "Unsupported key type for nn.Module.__getitem__",
+      "Context": "mp_subscript_impl: {self} {key}",
+      "Explanation": "Dynamo does not support getitem on `nn.Module` with non-constant key.",
+      "Hints": []
+    },
+    {
+      "Gb_type": "Unsupported key type for nn.Module.__getitem__",
+      "Context": "getitem_impl: {self} {key}",
+      "Explanation": "Dynamo does not support getitem on `nn.Module` with non-constant key.",
+      "Hints": []
+    },
     {
       "Gb_type": "Unsupported key type for nn.Module.__getitem__",
       "Context": "call_method: {self} {name} {args} {kwargs}",
@@ -3516,6 +3572,22 @@
   "GB0281": [
     {
       "Gb_type": "Invalid or non-const argument in nn.Module __getitem__",
+      "Context": "mp_subscript_impl: {self} {key}",
+      "Explanation": "Dynamo does not support calling method `__getitem__` of ``nn.Module`` {module} with a non-constant or non-(str, int) key.",
+      "Hints": [
+        "Use constant arguments of type str or int for __getitem__"
+      ]
+    },
+    {
+      "Gb_type": "Invalid or non-const argument in nn.Module __getitem__",
+      "Context": "getitem_impl: {self} {key}",
+      "Explanation": "Dynamo does not support calling method `__getitem__` of ``nn.Module`` {module} with a non-constant or non-(str, int) key.",
+      "Hints": [
+        "Use constant arguments of type str or int for __getitem__"
+      ]
+    },
+    {
+      "Gb_type": "Invalid or non-const argument in nn.Module __getitem__",
       "Context": "call_method: {self} {name} {args} {kwargs}",
       "Explanation": "Dynamo does not support calling method `{name}` of ``nn.Module`` {module} with a non-constant or non-(str, int) key.",
       "Hints": [
@@ -4434,6 +4506,14 @@
       "Hints": [
         "This is likely to be a Dynamo bug. Please report an issue to PyTorch."
       ]
+    }
+  ],
+  "GB7699": [
+    {
+      "Gb_type": "unsupported operator.getitem",
+      "Context": "call_getitem fallback {args[0]} {args[1]}",
+      "Explanation": "Dynamo does not know how to handle operator.getitem on {args[0]}",
+      "Hints": []
     }
   ],
   "GB0355": [

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -3867,10 +3867,27 @@ class InstructionTranslatorBase(
     BINARY_REMAINDER = stack_op(operator.mod)
     BINARY_ADD = stack_op(operator.add)
     BINARY_SUBTRACT = stack_op(operator.sub)
-    BINARY_SUBSCR = break_graph_if_unsupported(
+
+    @break_graph_if_unsupported(
         push=True,
         msg_prefix="Encountered graph break when attempting to trace BINARY_SUBSCR: a binary subscript, e.g. x[attr]",
-    )(stack_op(operator.getitem))
+    )
+    def BINARY_SUBSCR(self, inst):
+        args = self.popn(2)
+        obj, key = args[0], args[1]
+        # Fast path: dispatch directly to mp_subscript_impl when the VT
+        # overrides it, skipping the BuiltinVariable(operator.getitem)
+        # dispatch chain.
+        if type(obj).mp_subscript_impl is not VariableTracker.mp_subscript_impl:
+            from .variables.object_protocol import vt_getitem
+
+            self.push(vt_getitem(self, obj, key))  # type: ignore[arg-type]
+        else:
+            # Types without mp_subscript_impl (e.g., BuiltinVariable for type
+            # subscripts like list[int]) need the full dispatch chain, which
+            # includes the constant fold fallback.
+            self.push(BuiltinVariable(operator.getitem).call_function(self, args, {}))  # type: ignore[arg-type]
+
     BINARY_LSHIFT = stack_op(operator.lshift)
     BINARY_RSHIFT = stack_op(operator.rshift)
     BINARY_AND = stack_op(operator.and_)

--- a/torch/_dynamo/variables/base.py
+++ b/torch/_dynamo/variables/base.py
@@ -548,6 +548,19 @@ class VariableTracker(metaclass=VariableTrackerMeta):
             ],
         )
 
+    def mp_subscript_impl(
+        self,
+        tx: "InstructionTranslator",
+        key: "VariableTracker",
+    ) -> "VariableTracker":
+        # PyObject_GetItem: https://github.com/python/cpython/blob/62a6e898e01/Objects/abstract.c#L155-L206
+        unimplemented(
+            gb_type="unsupported __getitem__",
+            context=f"mp_subscript_impl {self} {key}",
+            explanation=f"Dynamo does not know how to handle __getitem__ on {self}",
+            hints=[],
+        )
+
     def call_method(
         self,
         tx: Any,
@@ -555,7 +568,19 @@ class VariableTracker(metaclass=VariableTrackerMeta):
         args: list["VariableTracker"],
         kwargs: dict[str, "VariableTracker"],
     ) -> "VariableTracker":
-        if name == "__len__" and self.has_unpack_var_sequence(tx):
+        if name == "__getitem__":
+            if type(self).mp_subscript_impl is not VariableTracker.mp_subscript_impl:
+                if len(args) == 1 and not kwargs:
+                    return self.mp_subscript_impl(tx, args[0])
+                from ..utils import raise_args_mismatch
+
+                raise_args_mismatch(
+                    tx,
+                    name,
+                    "1 args and 0 kwargs",
+                    f"{len(args)} args and {len(kwargs)} kwargs",
+                )
+        elif name == "__len__" and self.has_unpack_var_sequence(tx):
             assert not (args or kwargs)
             return variables.ConstantVariable.create(len(self.unpack_var_sequence(tx)))
         elif (

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -2194,7 +2194,25 @@ class BuiltinVariable(BaseBuiltinVariable):
         *args: VariableTracker,
         **kwargs: VariableTracker,
     ) -> VariableTracker:
-        return args[0].call_method(tx, "__getitem__", list(args[1:]), kwargs)
+        # BINARY_SUBSCR shortcircuits to vt_getitem for VTs that override
+        # mp_subscript_impl. This call_getitem path is the fallback for VTs
+        # that don't — when mp_subscript_impl raises Unsupported here, the
+        # BuiltinVariable dispatch continues to constant fold (step 5),
+        # which handles type subscripts like list[int] / dict[str, Any].
+        from .base import VariableTracker
+        from .object_protocol import vt_getitem
+
+        if type(args[0]).mp_subscript_impl is not VariableTracker.mp_subscript_impl:
+            return vt_getitem(tx, args[0], args[1])
+        # VTs without mp_subscript_impl override (e.g. BuiltinVariable for
+        # type subscripts like list[int]). Raise Unsupported so the
+        # _make_handler dispatch chain falls through to constant fold.
+        unimplemented(
+            gb_type="unsupported operator.getitem",
+            context=f"call_getitem fallback {args[0]} {args[1]}",
+            explanation=f"Dynamo does not know how to handle operator.getitem on {args[0]}",
+            hints=[],
+        )
 
     def call_isinstance(
         self,

--- a/torch/_dynamo/variables/dicts.py
+++ b/torch/_dynamo/variables/dicts.py
@@ -600,6 +600,15 @@ class ConstDictVariable(VariableTracker):
             else:
                 self.install_dict_keys_match_guard()
 
+    def mp_subscript_impl(
+        self,
+        tx: "InstructionTranslator",
+        key: VariableTracker,
+    ) -> VariableTracker:
+        # dict_subscript: https://github.com/python/cpython/blob/62a6e898e01/Objects/dictobject.c#L3673-L3706
+        # TODO: check tp_hash — raise TypeError if key is unhashable
+        return self.getitem_const_raise_exception_if_absent(tx, key)
+
     def call_method(
         self,
         tx: "InstructionTranslator",
@@ -626,11 +635,6 @@ class ConstDictVariable(VariableTracker):
             tx.output.side_effects.mutation(self)
             self.items.update(temp_dict_vt.items)  # type: ignore[attr-defined]
             return CONSTANT_VARIABLE_NONE
-        elif name == "__getitem__":
-            # Key guarding - Nothing to do. LazyVT for value will take care.
-            if len(args) != 1:
-                raise_args_mismatch(tx, name, "1 args", f"{len(args)} args")
-            return self.getitem_const_raise_exception_if_absent(tx, args[0])
         elif name == "items":
             if args or kwargs:
                 raise_args_mismatch(
@@ -1063,13 +1067,7 @@ class MappingProxyVariable(VariableTracker):
         codegen(self.dv_dict)
         codegen.extend_output(create_call_function(1, False))
 
-    def call_method(
-        self,
-        tx: "InstructionTranslator",
-        name: str,
-        args: list[VariableTracker],
-        kwargs: dict[str, VariableTracker],
-    ) -> VariableTracker:
+    def _check_mutation_guard(self, tx: "InstructionTranslator") -> None:
         if self.source and tx.output.side_effects.has_existing_dict_mutation():
             msg = (
                 "A dict has been modified while we have an existing mappingproxy object. "
@@ -1090,6 +1088,24 @@ class MappingProxyVariable(VariableTracker):
                     "Or avoid using the mapping proxy objects after modifying its underlying dictionary",
                 ],
             )
+
+    def mp_subscript_impl(
+        self,
+        tx: "InstructionTranslator",
+        key: VariableTracker,
+    ) -> VariableTracker:
+        # mappingproxy_getitem: https://github.com/python/cpython/blob/62a6e898e01/Objects/descrobject.c#L1052-L1056
+        self._check_mutation_guard(tx)
+        return self.dv_dict.mp_subscript_impl(tx, key)
+
+    def call_method(
+        self,
+        tx: "InstructionTranslator",
+        name: str,
+        args: list[VariableTracker],
+        kwargs: dict[str, VariableTracker],
+    ) -> VariableTracker:
+        self._check_mutation_guard(tx)
         return self.dv_dict.call_method(tx, name, args, kwargs)
 
     def call_obj_hasattr(
@@ -1149,6 +1165,28 @@ class DefaultDictVariable(ConstDictVariable):
             ),
         ) or (isinstance(arg, variables.ConstantVariable) and arg.value is None)
 
+    def mp_subscript_impl(
+        self,
+        tx: "InstructionTranslator",
+        key: VariableTracker,
+    ) -> VariableTracker:
+        # defaultdict inherits mp_subscript from dict (no override in
+        # _collectionsmodule.c slot table), so dict_subscript runs first.
+        # On KeyError, dict_subscript calls tp->__missing__ which resolves to
+        # defdict_missing: https://github.com/python/cpython/blob/62a6e898e01/Modules/_collectionsmodule.c#L2233-L2254
+        if key in self:
+            return self.getitem_const(tx, key)
+
+        if (
+            istype(self.default_factory, ConstantVariable)
+            and self.default_factory.value is None
+        ):
+            raise_observed_exception(KeyError, tx, args=[key])
+        else:
+            default_var = self.default_factory.call_function(tx, [], {})
+            super().call_method(tx, "__setitem__", [key, default_var], {})
+            return default_var
+
     def call_method(
         self,
         tx: "InstructionTranslator",
@@ -1156,25 +1194,7 @@ class DefaultDictVariable(ConstDictVariable):
         args: list[VariableTracker],
         kwargs: dict[str, VariableTracker],
     ) -> VariableTracker:
-        if name == "__getitem__":
-            if len(args) != 1:
-                raise_args_mismatch(tx, name, "1 args", f"{len(args)} args")
-
-            if args[0] in self:
-                return self.getitem_const(tx, args[0])
-            else:
-                if (
-                    istype(self.default_factory, ConstantVariable)
-                    and self.default_factory.value is None
-                ):
-                    raise_observed_exception(KeyError, tx, args=[args[0]])
-                else:
-                    default_var = self.default_factory.call_function(tx, [], {})
-                    super().call_method(
-                        tx, "__setitem__", [args[0], default_var], kwargs
-                    )
-                    return default_var
-        elif name == "__setattr__" and self.is_mutable:
+        if name == "__setattr__" and self.is_mutable:
             if len(args) != 2:
                 raise_args_mismatch(tx, name, "2 args", f"{len(args)} args")
             # Setting a default factory must be a callable or None type

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -3220,6 +3220,13 @@ class TritonKernelVariable(VariableTracker):
             self, args, kwargs, tx
         )
 
+    def mp_subscript_impl(
+        self,
+        tx: "InstructionTranslator",
+        key: VariableTracker,
+    ) -> VariableTracker:
+        return dynamo_triton_hopifier_singleton.call_getitem(self, [key])
+
     def call_method(
         self,
         tx: "InstructionTranslator",
@@ -3227,9 +3234,7 @@ class TritonKernelVariable(VariableTracker):
         args: list[VariableTracker],
         kwargs: dict[str, VariableTracker],
     ) -> VariableTracker:
-        if name == "__getitem__":
-            return dynamo_triton_hopifier_singleton.call_getitem(self, args)
-        elif name == "run":
+        if name == "run":
             return dynamo_triton_hopifier_singleton.call_run(self, args, kwargs, tx)  # type: ignore[return-value]
 
         # Bail out to parent's implementation

--- a/torch/_dynamo/variables/invoke_subgraph.py
+++ b/torch/_dynamo/variables/invoke_subgraph.py
@@ -670,14 +670,10 @@ def is_reusable(
             value = new_source.get_value(resolve_globals, resolve_locals, resolve_cache)
         except Exception:
             hc_log.debug(
-                "subgraph_reuse: reuse failed -- cannot resolve source\n"
-                "  guard type: %s\n"
-                "  guard source: %s\n"
-                "  guard source name: %s\n"
-                "  user stack:\n%s",
-                guard.create_fn_name(),
-                new_source,
+                "subgraph_reuse: reuse failed -- cannot resolve source '%s' "
+                "(guard type: %s, user stack:\n%s)",
                 new_source.name,
+                guard.create_fn_name(),
                 "".join(guard.user_stack.format())
                 if guard.user_stack
                 else "<no stack>",
@@ -686,18 +682,11 @@ def is_reusable(
 
         if not handler.eval_fn(value, expected):
             hc_log.debug(
-                "subgraph_reuse: reuse failed --\n"
-                "  guard type: %s\n"
-                "  guard source: %s\n"
-                "  guard source name: %s\n"
-                "  expected: %s\n"
-                "  got: %s\n"
-                "  user stack:\n%s",
-                guard.create_fn_name(),
-                new_source,
+                "subgraph_reuse: reuse failed -- guard on '%s': expected %s, got mismatch "
+                "(guard type: %s, user stack:\n%s)",
                 new_source.name,
                 expected,
-                value,
+                guard.create_fn_name(),
                 "".join(guard.user_stack.format())
                 if guard.user_stack
                 else "<no stack>",

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -262,6 +262,48 @@ class BaseListVariable(VariableTracker):
             mutation_type=ValueMutationNew(),
         )
 
+    def mp_subscript_impl(
+        self,
+        tx: "InstructionTranslator",
+        key: VariableTracker,
+    ) -> VariableTracker:
+        # list_subscript: https://github.com/python/cpython/blob/62a6e898e01/Objects/listobject.c#L3689-L3710
+        if key.is_tensor():
+            value = get_fake_value(key.as_proxy().node, tx)
+            if value.constant is not None and value.constant.numel() == 1:
+                key = VariableTracker.build(tx, value.constant.item())
+            else:
+                unimplemented(
+                    gb_type="Indexing list with non-scalar tensor",
+                    context=f"mp_subscript_impl {self} {key}",
+                    explanation=(
+                        "Attempted to index list-like object with tensor with > 1 element."
+                    ),
+                    hints=[*graph_break_hints.USER_ERROR],
+                )
+
+        # _PyIndex_Check: https://github.com/python/cpython/blob/62a6e898e01/Include/internal/pycore_abstract.h#L13-L17
+        # CPython: list_subscript checks _PyIndex_Check first, and
+        # raises its own error if the type doesn't have nb_index.
+        # Only if the type has __index__ does it call PyNumber_AsSsize_t.
+        try:
+            key_type = key.python_type()
+        except NotImplementedError:
+            key_type = None
+        if key_type not in (int, bool, slice):
+            if key_type is not None and not hasattr(key_type, "__index__"):
+                container_name = self.python_type_name()
+                raise_observed_exception(
+                    TypeError,
+                    tx,
+                    args=[
+                        f"{container_name} indices must be integers or slices, not {key.python_type_name()}"
+                    ],
+                )
+            key = key.nb_index_impl(tx)
+
+        return self.getitem_const(tx, key)
+
     def call_method(
         self,
         tx: "InstructionTranslator",
@@ -274,37 +316,6 @@ class BaseListVariable(VariableTracker):
         if name == "__len__":
             self._install_list_length_guard()
             return ConstantVariable.create(len(self.items))
-        elif name == "__getitem__":
-            if kwargs or len(args) != 1:
-                raise_args_mismatch(
-                    tx,
-                    name,
-                    "1 args and 0 kwargs",
-                    f"{len(args)} args and {len(kwargs)} kwargs",
-                )
-
-            value = args[0]
-
-            try:
-                value_type = value.python_type()
-            except NotImplementedError:
-                value_type = None
-            if value_type not in (int, bool, slice):
-                # CPython: list_subscript checks _PyIndex_Check first, and
-                # raises its own error if the type doesn't have nb_index.
-                # Only if the type has __index__ does it call PyNumber_AsSsize_t.
-                if value_type is not None and not hasattr(value_type, "__index__"):
-                    container_name = self.python_type_name()
-                    raise_observed_exception(
-                        TypeError,
-                        tx,
-                        args=[
-                            f"{container_name} indices must be integers or slices, not {value.python_type_name()}"
-                        ],
-                    )
-                value = value.nb_index_impl(tx)
-
-            return self.getitem_const(tx, value)
         elif name == "__contains__":
             if kwargs or len(args) != 1:
                 raise_args_mismatch(
@@ -702,6 +713,14 @@ class RangeVariable(BaseListVariable):
             return int(re)
         return 0
 
+    def mp_subscript_impl(
+        self,
+        tx: "InstructionTranslator",
+        key: VariableTracker,
+    ) -> VariableTracker:
+        # range_subscript: https://github.com/python/cpython/blob/62a6e898e01/Objects/rangeobject.c#L729-L748
+        return self.getitem_const(tx, key)
+
     def call_method(
         self,
         tx: "InstructionTranslator",
@@ -738,8 +757,6 @@ class RangeVariable(BaseListVariable):
                 tx,
                 args=[f"{x} is not in range"],
             )
-        elif name == "__getitem__":
-            return self.getitem_const(tx, *args)
         elif name in cmp_name_to_op_mapping:
             other = args[0]
             pt = other.python_type()
@@ -1581,6 +1598,16 @@ class SizeVariable(TupleVariable):
             result = mul.call_function(tx, [result, v], {})
         return result
 
+    def mp_subscript_impl(
+        self,
+        tx: "InstructionTranslator",
+        key: VariableTracker,
+    ) -> VariableTracker:
+        # tuple_subscript: https://github.com/python/cpython/blob/62a6e898e01/Objects/tupleobject.c#L877-L930
+        # TODO: investigate sharing BaseListVariable.mp_subscript_impl —
+        # get_item_dyn differs by handling SymNodeVariable and wrapping as SizeVariable.
+        return self.get_item_dyn(tx, key)
+
     def call_method(
         self,
         tx: "InstructionTranslator",
@@ -1588,17 +1615,7 @@ class SizeVariable(TupleVariable):
         args: list[VariableTracker],
         kwargs: dict[str, VariableTracker],
     ) -> VariableTracker:
-        if name == "__getitem__":
-            if kwargs or len(args) != 1:
-                raise_args_mismatch(
-                    tx,
-                    name,
-                    "1 args and 0 kwargs",
-                    f"{len(args)} args and {len(kwargs)} kwargs",
-                )
-            out = self.get_item_dyn(tx, args[0])
-            return out
-        elif name == "numel":
+        if name == "numel":
             if args or kwargs:
                 raise_args_mismatch(
                     tx,

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -51,6 +51,7 @@ from ..guards import GuardBuilder, install_guard
 from ..mutation_guard import unpatched_nn_module_init
 from ..source import (
     AttrSource,
+    DictGetItemSource,
     GenericAttrSource,
     GetItemSource,
     TypeMROSource,
@@ -1339,6 +1340,118 @@ class GetAttrVariable(VariableTracker):
     ) -> VariableTracker:
         return self.obj.call_method(tx, self.name, list(args), kwargs)
 
+    def _getattr_dict_lookup(
+        self,
+        tx: "InstructionTranslator",
+        key: VariableTracker,
+    ) -> "VariableTracker | None":
+        if (
+            self.name == "__dict__"
+            and key.is_python_constant()
+            and isinstance(
+                self.obj,
+                (
+                    variables.NNModuleVariable,
+                    variables.UserDefinedClassVariable,
+                ),
+            )
+        ):
+            obj = self.obj
+            k = key.as_python_constant()
+            if obj.has_key_in_generic_dict(tx, k):  # type: ignore[union-attr]
+                if tx.output.side_effects.has_pending_mutation_of_attr(obj, k):
+                    return tx.output.side_effects.load_attr(obj, k)
+
+                # For instance dicts, read directly from __dict__
+                if isinstance(obj.value.__dict__, dict):
+                    raw_value = obj.value.__dict__[k]
+                    raw_source = (
+                        DictGetItemSource(AttrSource(obj.source, "__dict__"), k)
+                        if obj.source
+                        else None
+                    )
+                    return VariableTracker.build(tx, raw_value, raw_source)
+
+                return obj.var_getattr(tx, k)
+        return None
+
+    def mp_subscript_impl(
+        self,
+        tx: "InstructionTranslator",
+        key: VariableTracker,
+    ) -> VariableTracker:
+        result = self._getattr_dict_lookup(tx, key)
+        if result is not None:
+            return result
+        return super().mp_subscript_impl(tx, key)
+
+    def call_method(
+        self,
+        tx: "InstructionTranslator",
+        name: str,
+        args: list[VariableTracker],
+        kwargs: dict[str, VariableTracker],
+    ) -> VariableTracker:
+        if (
+            name == "get"
+            and self.name == "__dict__"
+            and not kwargs
+            and args[0].is_python_constant()
+            and isinstance(
+                self.obj,
+                (
+                    variables.NNModuleVariable,
+                    variables.UserDefinedClassVariable,
+                ),
+            )
+        ):
+            result = self._getattr_dict_lookup(tx, args[0])
+            if result is not None:
+                return result
+
+            # Return the default value for get
+            if len(args) == 2:
+                return args[1]
+            else:
+                return variables.CONSTANT_VARIABLE_NONE
+
+        elif (
+            name == "__contains__"
+            and self.name == "__dict__"
+            and len(args) == 1
+            and args[0].is_python_constant()
+            and not kwargs
+            and isinstance(
+                self.obj,
+                (
+                    variables.NNModuleVariable,
+                    variables.UserDefinedClassVariable,
+                ),
+            )
+        ):
+            obj = self.obj
+            key = args[0].as_python_constant()
+            if obj.has_key_in_generic_dict(tx, key):  # type: ignore[union-attr]
+                return variables.CONSTANT_VARIABLE_TRUE
+            else:
+                return variables.CONSTANT_VARIABLE_FALSE
+
+        elif name == "__setitem__" and self.name == "__dict__" and not kwargs:
+            if isinstance(self.obj, variables.NNModuleVariable):
+                # This matches how `setattr` is handled for NNModuleVariable
+                self.obj.convert_to_unspecialized(tx)
+
+        return super().call_method(tx, name, args, kwargs)
+
+    def get_forwarded_dict(self, tx: "InstructionTranslator") -> VariableTracker:
+        assert (
+            self.name == "__dict__"
+            and isinstance(self.obj, variables.UserDefinedClassVariable)
+            and not tx.output.side_effects.has_pending_mutation(self.obj)
+        )
+        self.obj.ban_mutation = True
+        return VariableTracker.build(tx, self.obj.value.__dict__, self.source)
+
 
 class MethodWrapperVariable(VariableTracker):
     def __init__(self, method_wrapper: types.MethodWrapperType, **kwargs: Any) -> None:
@@ -1557,6 +1670,15 @@ class TypingVariable(VariableTracker):
         super().__init__(**kwargs)
         self.value = value
 
+    def mp_subscript_impl(
+        self,
+        tx: "InstructionTranslator",
+        key: VariableTracker,
+    ) -> VariableTracker:
+        # e.g., List[int] → typing.List[int]
+        new_typing = self.value[key.as_python_constant()]
+        return TypingVariable(new_typing)
+
     def call_method(
         self,
         tx: "InstructionTranslator",
@@ -1564,11 +1686,7 @@ class TypingVariable(VariableTracker):
         args: list[VariableTracker],
         kwargs: dict[str, VariableTracker],
     ) -> VariableTracker:
-        # Create a new typing variable, e.g., `List[int]`
-        if name == "__getitem__" and len(args) == 1:
-            new_typing = self.value[args[0].as_python_constant()]
-            return TypingVariable(new_typing)
-        elif name == "__eq__":
+        if name == "__eq__":
             if len(args) == 1 and not kwargs:
                 result = istype(args[0], TypingVariable) and self.value == args[0].value
                 return variables.ConstantVariable.create(result)

--- a/torch/_dynamo/variables/nn_module.py
+++ b/torch/_dynamo/variables/nn_module.py
@@ -72,7 +72,6 @@ from ..utils import (
 from .base import raise_type_error_exc, typestr, ValueMutationNew, VariableTracker
 from .functions import invoke_and_store_as_constant
 from .lazy import LazyVariableTracker
-from .lists import SliceVariable
 from .user_defined import UserDefinedObjectVariable
 
 
@@ -574,6 +573,100 @@ class NNModuleVariable(VariableTracker):
                     kwargs,
                 )
 
+    def mp_subscript_impl(
+        self,
+        tx: "InstructionTranslator",
+        key: "VariableTracker",
+    ) -> "VariableTracker":
+        from .lists import SliceVariable
+        from .tensor import SymNodeVariable
+
+        module = tx.output.get_submodule(self.module_key)
+
+        builtin_supported = (
+            torch.nn.ModuleDict.__getitem__,
+            torch.nn.ModuleList.__getitem__,
+            torch.nn.ParameterDict.__getitem__,
+            torch.nn.ParameterList.__getitem__,
+            torch.nn.Sequential.__getitem__,
+        )
+        # pyrefly: ignore[missing-attribute]
+        if type(module).__getitem__ not in builtin_supported:
+            if not (
+                key.is_python_constant()
+                and isinstance(key.as_python_constant(), (str, int))
+            ):
+                unimplemented(
+                    gb_type="Invalid or non-const argument in nn.Module __getitem__",
+                    context=f"mp_subscript_impl: {self} {key}",
+                    explanation="Dynamo does not support calling "
+                    f"method `__getitem__` of ``nn.Module`` {module} with a non-constant or non-(str, int) key.",
+                    hints=["Use constant arguments of type str or int for __getitem__"],
+                )
+            fn = module.__getitem__.__func__  # pyrefly: ignore[missing-attribute]
+
+            assert isinstance(fn, types.FunctionType)
+
+            src = AttrSource(AttrSource(self.source, "__getitem__"), "__func__")  # type: ignore[arg-type]
+            return tx.inline_user_function_return(
+                variables.UserFunctionVariable(fn, source=src),
+                [self, key],
+                {},
+            )
+
+        if isinstance(key, SliceVariable):
+            # TODO(anijain2305,export-team) - Remove this if condition when inlining of inbuilt nn modules is
+            # enabled for export.
+            if tx.output.export:
+                result = []
+                keys = list(range(len(module)))[key.as_python_constant()]  # type: ignore[arg-type]
+                for idx, submod in enumerate(module[key.as_python_constant()]):  # type: ignore[arg-type]
+                    k = keys[idx]
+                    src = NNModuleSource(GetItemSource(self.source, k))
+                    result.append(
+                        tx.output.register_attr_or_module(
+                            submod,
+                            k,
+                            source=src,
+                        )
+                    )
+
+                new_module = module[key.as_python_constant()]  # type: ignore[index]
+                new_module_variable = tx.output.register_attr_or_module(
+                    new_module,
+                    f"{self}.__getitem__(slice)",
+                    source=NNModuleSource(
+                        GetItemSource(self.source, key.as_python_constant())
+                    ),
+                )
+                return new_module_variable
+            else:
+                # slice on nn module results in a creation of new module instance, so we need to make it sourceless.
+                # Convert to unspecialized so that UnspecializedNNModule variable can take care of it.
+                self.convert_to_unspecialized(tx)
+
+        key_value = 0
+        if isinstance(key, SymNodeVariable):
+            key_value = key.evaluate_expr(tx.output)
+        elif key.is_python_constant():
+            key_value = key.as_python_constant()
+        else:
+            unimplemented(
+                gb_type="Unsupported key type for nn.Module.__getitem__",
+                context=f"mp_subscript_impl: {self} {key}",
+                explanation="Dynamo does not support getitem on "
+                "`nn.Module` with non-constant key.",
+                hints=[],
+            )
+
+        submod = module[key_value]  # type: ignore[index]
+        return tx.output.register_attr_or_module(
+            submod,
+            self.module_key,
+            key_value,
+            source=NNModuleSource(GetItemSource(self.source, key_value)),
+        )
+
     def call_method(
         self,
         tx: "InstructionTranslator",
@@ -839,104 +932,6 @@ class NNModuleVariable(VariableTracker):
         ):
             return VariableTracker.build(
                 tx, args[0].as_python_constant() in module._modules
-            )
-        elif name == "__getitem__":
-            if kwargs or len(args) != 1:
-                raise_args_mismatch(
-                    tx,
-                    name,
-                    "1 args and 0 kwargs",
-                    f"{len(args)} args and {len(kwargs)} kwargs",
-                )
-            builtin_supported = (
-                torch.nn.ModuleDict.__getitem__,
-                torch.nn.ModuleList.__getitem__,
-                torch.nn.ParameterDict.__getitem__,
-                torch.nn.ParameterList.__getitem__,
-                torch.nn.Sequential.__getitem__,
-            )
-            # pyrefly: ignore[missing-attribute]
-            if type(module).__getitem__ not in builtin_supported:
-                if not (
-                    args[0].is_python_constant()
-                    and isinstance(args[0].as_python_constant(), (str, int))
-                ):
-                    unimplemented(
-                        gb_type="Invalid or non-const argument in nn.Module __getitem__",
-                        context=f"call_method: {self} {name} {args} {kwargs}",
-                        explanation="Dynamo does not support calling "
-                        f"method `{name}` of ``nn.Module`` {module} with a non-constant or non-(str, int) key.",
-                        hints=[
-                            "Use constant arguments of type str or int for __getitem__"
-                        ],
-                    )
-                fn = getattr(module, name).__func__
-
-                assert isinstance(fn, types.FunctionType)
-
-                src = AttrSource(AttrSource(self.source, name), "__func__")  # type: ignore[arg-type]
-                return tx.inline_user_function_return(
-                    variables.UserFunctionVariable(fn, source=src),
-                    [self] + list(args),
-                    kwargs,
-                )
-
-            if isinstance(args[0], SliceVariable):
-                # TODO(anijain2305,export-team) - Remove this if condition when inlining of inbuilt nn modules is
-                # enabled for export.
-                if tx.output.export:
-                    # Build a TupleVariable of NNModules
-                    result = []
-
-                    # Turn the slice into the list of integers
-                    keys = list(range(len(module)))[args[0].as_python_constant()]  # type: ignore[arg-type]
-                    for idx, submod in enumerate(module[args[0].as_python_constant()]):  # type: ignore[arg-type]
-                        key = keys[idx]
-                        src = NNModuleSource(GetItemSource(self.source, key))
-                        result.append(
-                            tx.output.register_attr_or_module(
-                                submod,
-                                key,
-                                source=src,
-                            )
-                        )
-
-                    new_module = module[args[0].as_python_constant()]  # type: ignore[index]
-                    new_module_variable = tx.output.register_attr_or_module(
-                        new_module,
-                        f"{self}.__getitem__(slice)",
-                        source=NNModuleSource(
-                            GetItemSource(self.source, args[0].as_python_constant())
-                        ),
-                    )
-                    return new_module_variable
-                else:
-                    # slice on nn module results in a creation of new module instance, so we need to make it sourceless.
-                    # Convert to unspecialized so that UnspecializedNNModule variable can take care of it.
-                    self.convert_to_unspecialized(tx)
-
-            from .tensor import SymNodeVariable
-
-            key_value = 0
-            if isinstance(args[0], SymNodeVariable):
-                key_value = args[0].evaluate_expr(tx.output)
-            elif args[0].is_python_constant():
-                key_value = args[0].as_python_constant()
-            else:
-                unimplemented(
-                    gb_type="Unsupported key type for nn.Module.__getitem__",
-                    context=f"call_method: {self} {name} {args} {kwargs}",
-                    explanation="Dynamo does not support getitem on "
-                    "`nn.Module` with non-constant key.",
-                    hints=[],
-                )
-
-            submod = module[key_value]  # type: ignore[index]
-            return tx.output.register_attr_or_module(
-                submod,
-                self.module_key,
-                key_value,
-                source=NNModuleSource(GetItemSource(self.source, key_value)),
             )
         elif (
             name == "_get_abs_string_index"

--- a/torch/_dynamo/variables/object_protocol.py
+++ b/torch/_dynamo/variables/object_protocol.py
@@ -6,9 +6,15 @@ comparison dispatch machinery that is independent of any specific type.
 Per-type richcompare_impl hooks live in their respective VT files.
 """
 
+from typing import TYPE_CHECKING
+
 from ..utils import istype
 from .base import NO_SUCH_SUBOBJ, VariableTracker
 from .constant import CONSTANT_VARIABLE_FALSE, CONSTANT_VARIABLE_TRUE
+
+
+if TYPE_CHECKING:
+    from ..symbolic_convert import InstructionTranslator
 
 
 def vt_identity_compare(
@@ -63,3 +69,25 @@ def vt_identity_compare(
         return CONSTANT_VARIABLE_FALSE
 
     return None
+
+
+def vt_getitem(
+    tx: "InstructionTranslator",
+    obj: VariableTracker,
+    key: VariableTracker,
+) -> VariableTracker:
+    """CPython's PyObject_GetItem — dispatch to the type's mp_subscript/sq_item.
+
+    PyObject_GetItem: https://github.com/python/cpython/blob/62a6e898e01/Objects/abstract.c#L155-L206
+
+    CPython checks three branches in order:
+      1. tp_as_mapping->mp_subscript  (L161-166)
+      2. tp_as_sequence->sq_item      (L168-181) — only if key passes _PyIndex_Check
+      3. PyType_Check(o)              (L183-203) — type[int] → GenericAlias/__class_getitem__
+
+    Branch 1 is the common path (list, tuple, dict, range all have mp_subscript).
+    TODO: Branch 2 (sq_item) for C extension types that only have tp_as_sequence.
+    Branch 3 is handled by TypingVariable.mp_subscript_impl for typing module types
+    and by BuiltinVariable for builtin types like list[int].
+    """
+    return obj.mp_subscript_impl(tx, key)

--- a/torch/_dynamo/variables/script_object.py
+++ b/torch/_dynamo/variables/script_object.py
@@ -392,9 +392,16 @@ class TorchScriptObjectVariable(UserDefinedObjectVariable):
             method_name=name,
         )
 
+    def mp_subscript_impl(
+        self,
+        tx: "InstructionTranslator",
+        key: "VariableTracker",
+    ) -> "VariableTracker":
+        return self.call_method(tx, "__getitem__", [key], {})
+
     # We only support method calls on script objects. Interpreting the bytecodes
     # should go through var_getattr then call_function instead of call_method.
-    #
+
     # However, it's possible for call_method to be used directly e.g. for __setattr__.
     @_raise_hard_error_if_graph_break(
         "Dynamo cannot safely trace script object due to graph break."

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -763,6 +763,39 @@ class TensorVariable(VariableTracker):
             torch._dynamo.config._autograd_backward_strict_mode_conditional_banned_ops
         )
 
+    def mp_subscript_impl(
+        self,
+        tx: "InstructionTranslator",
+        key: VariableTracker,
+    ) -> VariableTracker:
+        from .builder import SourcelessBuilder, VariableBuilder
+        from .torch_function import can_dispatch_torch_function, dispatch_torch_function
+
+        if self.is_strict_mode(tx) and "__getitem__" in self._strict_mode_banned_ops():
+            unimplemented(
+                gb_type="Illegal __getitem__ invocation in strict mode",
+                context=f"mp_subscript_impl {self} {key}",
+                explanation="Dynamo currently does not support __getitem__ "
+                "invocation in strict mode.",
+                hints=[],
+            )
+
+        empty_kwargs: dict[str, VariableTracker] = {}
+        static_attr = all_tensor_attrs.get("__getitem__", None)
+        if static_attr is not None and can_dispatch_torch_function(
+            tx, (self, key), empty_kwargs
+        ):
+            if self.source:
+                func_var = VariableBuilder(
+                    tx,
+                    AttrSource(AttrSource(self.source, "__class__"), "__getitem__"),
+                )(static_attr)
+            else:
+                func_var = SourcelessBuilder.create(tx, torch.Tensor.__getitem__)
+            return dispatch_torch_function(tx, func_var, (self, key), empty_kwargs)
+
+        return self.method___getitem__(tx, key)
+
     def call_method(
         self,
         tx: "InstructionTranslator",

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -1368,6 +1368,19 @@ class UserDefinedObjectVariable(UserDefinedVariable):
         }
         return fns
 
+    def mp_subscript_impl(
+        self,
+        tx: "InstructionTranslator",
+        key: VariableTracker,
+    ) -> VariableTracker:
+        # PyObject_GetItem: https://github.com/python/cpython/blob/62a6e898e01/Objects/abstract.c#L155-L206
+        method = self._maybe_get_baseclass_method("__getitem__")
+        if method is not None:
+            return self.resolve_type_attr(
+                tx, "__getitem__", method, self.source
+            ).call_function(tx, [key], {})
+        return super().mp_subscript_impl(tx, key)
+
     def call_method(
         self,
         tx: "InstructionTranslator",
@@ -2815,6 +2828,27 @@ class UserDefinedDictVariable(UserDefinedObjectVariable):
             self._dict_vt = dict_vt
         self._dict_methods = dict_methods
 
+    def mp_subscript_impl(
+        self,
+        tx: "InstructionTranslator",
+        key: VariableTracker,
+    ) -> VariableTracker:
+        # dict_subscript: https://github.com/python/cpython/blob/62a6e898e01/Objects/dictobject.c#L3673-L3706
+        # On key-not-found, dict_subscript checks if the subclass defines
+        # __missing__ and calls it (this is how defaultdict / Counter work).
+        method = self._maybe_get_baseclass_method("__getitem__")
+        if method in self._dict_methods:
+            try:
+                return self._dict_vt.mp_subscript_impl(tx, key)
+            except ObservedKeyError:
+                if issubclass(
+                    self.python_type(), dict
+                ) and self._maybe_get_baseclass_method("__missing__"):
+                    return self.call_method(tx, "__missing__", [key], {})
+                else:
+                    raise
+        return super().mp_subscript_impl(tx, key)
+
     def call_method(
         self,
         tx: "InstructionTranslator",
@@ -2990,6 +3024,17 @@ class UserDefinedListVariable(UserDefinedObjectVariable):
         else:
             self._list_vt = list_vt
 
+    def mp_subscript_impl(
+        self,
+        tx: "InstructionTranslator",
+        key: VariableTracker,
+    ) -> VariableTracker:
+        assert self._list_vt is not None
+        method = self._maybe_get_baseclass_method("__getitem__")
+        if method in list_methods:
+            return self._list_vt.mp_subscript_impl(tx, key)
+        return super().mp_subscript_impl(tx, key)
+
     def call_method(
         self,
         tx: "InstructionTranslator",
@@ -3065,6 +3110,17 @@ class UserDefinedTupleVariable(UserDefinedObjectVariable):
             _, (idx, _) = type_attr.__reduce__()
             return self._tuple_vt.items[idx]  # type: ignore[union-attr]
         return super().resolve_data_descriptor(tx, name, type_attr, source)
+
+    def mp_subscript_impl(
+        self,
+        tx: "InstructionTranslator",
+        key: VariableTracker,
+    ) -> VariableTracker:
+        assert self._tuple_vt is not None
+        method = self._maybe_get_baseclass_method("__getitem__")
+        if method in tuple_methods:
+            return self._tuple_vt.mp_subscript_impl(tx, key)
+        return super().mp_subscript_impl(tx, key)
 
     def call_method(
         self,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #179067

Add `mp_subscript_impl` as a tp_slot on VariableTracker for `__getitem__`
dispatch, following the same pattern as `richcompare_impl` (#177943) and
`nb_index_impl` (#178921). This mirrors CPython's `PyObject_GetItem`
(Objects/abstract.c L155-206).

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98