### PR TITLE
[DeviceMesh] Reconstruct closure-captured submesh from tracked ancestor in make_fx

### DIFF
--- a/test/distributed/tensor/test_dtensor_compile.py
+++ b/test/distributed/tensor/test_dtensor_compile.py
@@ -1989,6 +1989,98 @@ class outer_fn(torch.nn.Module):
                 "fake", store=FakeStore(), rank=0, world_size=self.world_size
             )
 
+    def test_sibling_submesh_reconstruct_from_ancestor(self):
+        """When a closure captures an FSDP submesh while a sibling mesh (the
+        concatenated fsdp+tp mesh) is a graph input, the closure-captured mesh
+        must be reconstructed via _get_submesh — not baked as a get_attr
+        constant that breaks serialization.
+
+        This reproduces the SimpleFSDP + TP pattern: ReplicateComputation
+        captures the FSDP submesh as self.device_mesh, while parameters are
+        DTensors on DeviceMesh._concatenate([fsdp_mesh, tp_mesh]). With a
+        1D world mesh unflattened into (fsdp, tp), the root mesh has dim
+        name 'world' — so the reconstruct_fn must find the concatenated
+        ancestor (which contains 'fsdp') rather than looking only at root.
+        """
+        from torch._library.fake_class_registry import FakeScriptObject
+
+        dist.destroy_process_group()
+        dist.init_process_group("fake", store=FakeStore(), rank=0, world_size=8)
+
+        try:
+            # Build 1D world mesh → unflatten → (fsdp=4, tp=2)
+            world_mesh = init_device_mesh(
+                self.device_type, (8,), mesh_dim_names=("world",)
+            )
+            dense_mesh = world_mesh._unflatten(0, (4, 2), ("fsdp", "tp"))
+            fsdp_mesh = dense_mesh["fsdp"]
+            tp_mesh = dense_mesh["tp"]
+
+            # Concatenate like SimpleFSDP's _distribute_dtensor does
+            concat_mesh = DeviceMesh._concatenate([fsdp_mesh, tp_mesh])
+
+            with dist.config.patch(compile_on_one_rank=True):
+
+                def fn(local_tensor, concat_mesh_input):
+                    # concat_mesh_input is a graph input (placeholder).
+                    # Simulate SimpleFSDP: create DTensor on concat mesh,
+                    # extract local, re-wrap on the closure-captured
+                    # fsdp_mesh, then all-gather.
+                    dt = DTensor.from_local(
+                        local_tensor,
+                        concat_mesh_input,
+                        [Shard(0), Shard(1)],
+                        run_check=False,
+                    )
+                    local = dt.to_local()
+                    fsdp_dt = DTensor.from_local(
+                        local, fsdp_mesh, [Shard(0)], run_check=False
+                    )
+                    return (
+                        fsdp_dt.redistribute(fsdp_mesh, [Replicate()])
+                        .to_local()
+                        .sum()
+                    )
+
+                local_t = torch.randn(4, 4)
+                gm = make_fx(fn, tracing_mode="fake")(local_t, concat_mesh)
+
+            device_mesh_getattr_count = 0
+            for node in gm.graph.nodes:
+                if node.op != "get_attr":
+                    continue
+                val = getattr(gm, node.target, None)
+                if isinstance(val, FakeScriptObject):
+                    val = getattr(val, "real_obj", val)
+                if isinstance(val, DeviceMesh):
+                    device_mesh_getattr_count += 1
+
+            self.assertEqual(
+                device_mesh_getattr_count,
+                0,
+                "DeviceMesh get_attr nodes found; the closure-captured FSDP "
+                "submesh should be reconstructed from the tracked concatenated "
+                "ancestor via _get_submesh, not baked as a constant",
+            )
+
+            submesh_ops = [
+                node
+                for node in gm.graph.nodes
+                if node.op == "call_function"
+                and "get_submesh" in str(node.target)
+            ]
+            self.assertGreater(
+                len(submesh_ops),
+                0,
+                "Expected _get_submesh call to derive the FSDP submesh from "
+                "the tracked concatenated ancestor mesh",
+            )
+        finally:
+            dist.destroy_process_group()
+            dist.init_process_group(
+                "fake", store=FakeStore(), rank=0, world_size=self.world_size
+            )
+
     def test_to_local_symbolic_sizes_non_sharded_dims(self):
         # Checks that symbolic sizes are not polluted by the sharding
         # in to_local - for instance we could incorrectly have (16 * (s27//2))

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -1604,40 +1604,75 @@ def _device_mesh_reconstruct_fn(
     get_tracked_proxy: Callable[["OpaqueBase"], "torch.fx.Proxy | None"],
     tracer: Any,
 ) -> "torch.fx.Proxy | None":
-    """Reconstruct a DeviceMesh submesh from its root mesh.
+    """Reconstruct a DeviceMesh submesh from a tracked ancestor mesh.
 
     Called by PythonKeyTracer when make_fx encounters a DeviceMesh that isn't
-    tracked (e.g. a submesh captured by a backward closure). If the root mesh
-    is already a graph input, emits a call_function node that derives the
-    submesh via the _get_submesh custom op.
+    tracked (e.g. a submesh captured by a backward closure). Looks for any
+    tracked mesh that shares the same root and contains the target dim names,
+    then emits a call_function node that derives the submesh via _get_submesh.
     """
     if not isinstance(mesh, DeviceMesh):
         raise AssertionError("DeviceMesh expected")
+
+    # The mesh itself may already be tracked as a graph input (e.g. Dynamo
+    # hoisted the fsdp/tp submesh, and backward captured the same logical
+    # mesh as a different Python object). Check equality match first.
+    mesh_proxy = get_tracked_proxy(mesh)
+    if mesh_proxy is not None:
+        return mesh_proxy
+
     root_mesh = mesh._get_root_mesh()
 
     # Only submeshes can be reconstructed; root meshes must already be tracked.
     if mesh is root_mesh:
         return None
 
-    # The root mesh must already be a graph input for us to derive from it.
-    root_proxy = get_tracked_proxy(root_mesh)
-    if root_proxy is None:
-        return None
-
     dim_names = mesh._mesh_dim_names
-    root_dim_names = root_mesh._mesh_dim_names
-    if dim_names is None or root_dim_names is None:
+    if dim_names is None:
         return None
 
-    # Convert dim names to indices into the root mesh's dim names
-    mesh_dims = [root_dim_names.index(n) for n in dim_names]
-
-    # Ensure the custom op is registered
+    # Ensure the custom ops are registered
     from torch.distributed._ops import device_mesh as _dm_ops  # noqa: F401
+
+    # Try the root mesh first (original path).
+    ancestor_proxy = get_tracked_proxy(root_mesh)
+    ancestor_dim_names = root_mesh._mesh_dim_names
+
+    # If root isn't tracked, search for any tracked DeviceMesh that shares
+    # the same root AND contains all our dim names. This handles the case
+    # where e.g. a concatenated (fsdp, tp) mesh is a graph input (from
+    # DTensor.__tensor_flatten__) but neither root nor the individual
+    # submeshes are tracked directly.
+    if ancestor_proxy is None:
+        from torch._library.fake_class_registry import FakeScriptObject
+
+        for tracked_obj, proxy in tracer.opaque_tracker.items():
+            real_obj = (
+                tracked_obj.real_obj
+                if isinstance(tracked_obj, FakeScriptObject)
+                else tracked_obj
+            )
+            if not isinstance(real_obj, DeviceMesh) or real_obj is mesh:
+                continue
+            if real_obj._get_root_mesh() is not root_mesh:
+                continue
+            tracked_dim_names = real_obj._mesh_dim_names
+            if tracked_dim_names is None:
+                continue
+            if all(n in tracked_dim_names for n in dim_names):
+                ancestor_proxy = proxy
+                ancestor_dim_names = tracked_dim_names
+                break
+
+    if ancestor_proxy is None or ancestor_dim_names is None:
+        return None
+
+    # Convert our dim names to indices into the ancestor mesh's dim names
+    mesh_dims = [ancestor_dim_names.index(n) for n in dim_names]
 
     # Dispatch through the custom op with proxy mode active so that
     # meta["val"] is set and the result is tracked in opaque_tracker.
-    return torch.ops.device_mesh._get_submesh(root_proxy, mesh_dims)
+    return torch.ops.device_mesh._get_submesh(ancestor_proxy, mesh_dims)
 
 
 def _register_distributed_opaque_types():


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #179080
* #179079

When FSDP + TP are used with a 1D world mesh unflattened into (fsdp, tp),
the FSDP submesh captured as a closure in ReplicateComputation.forward()
was being baked into the FX graph as a get_attr constant. This breaks
serialization in CooR (compile-on-one-rank) precompilation because the
constant holds a ProcessGroup that can't survive pickling.

The existing _device_mesh_reconstruct_fn only looked at the root mesh
(world_mesh with dim "world") to derive submeshes. But when submeshes are
created via _unflatten, their dim names ("fsdp", "tp") don't appear in
the root's dim names ("world"), so _get_submesh fails.

The fix searches all tracked DeviceMesh objects in the tracer's
opaque_tracker for an ancestor that shares the same root AND contains
the target dim names. In the FSDP+TP case, the concatenated (fsdp, tp)
mesh (which enters the graph via DTensor.__tensor_flatten__) is such an
ancestor, and the FSDP submesh is derived from it via _get_submesh.