### PR TITLE
[CI] Bump MACOSX_DEPLOYMENT_TARGET to 14.0

### DIFF
--- a/.ci/pytorch/macos-build.sh
+++ b/.ci/pytorch/macos-build.sh
@@ -48,7 +48,7 @@ if [[ ${BUILD_ENVIRONMENT} == *"distributed"* ]]; then
 else
   # Explicitly set USE_DISTRIBUTED=0 to align with the default build config on mac. This also serves as the sole CI config that tests
   # that building with USE_DISTRIBUTED=0 works at all. See https://github.com/pytorch/pytorch/issues/86448
-  USE_DISTRIBUTED=0 USE_OPENMP=1 MACOSX_DEPLOYMENT_TARGET=11.0 WERROR=1 BUILD_TEST=OFF USE_PYTORCH_METAL=1 python -m build --wheel --no-isolation -C--build-option=--plat-name=macosx_11_0_arm64
+  USE_DISTRIBUTED=0 USE_OPENMP=1 WERROR=1 BUILD_TEST=OFF USE_PYTORCH_METAL=1 python -m build --wheel --no-isolation
 fi
 if which sccache > /dev/null; then
   print_sccache_stats

--- a/.ci/pytorch/macos-common.sh
+++ b/.ci/pytorch/macos-common.sh
@@ -9,6 +9,6 @@ sysctl -a | grep machdep.cpu
 
 # These are required for both the build job and the test job.
 # In the latter to test cpp extensions.
-export MACOSX_DEPLOYMENT_TARGET=11.1
+export MACOSX_DEPLOYMENT_TARGET=14.0
 export CXX=clang++
 export CC=clang

--- a/.ci/pytorch/smoke_test/check_wheel_tags.py
+++ b/.ci/pytorch/smoke_test/check_wheel_tags.py
@@ -181,8 +181,14 @@ def _check_dylibs_minos(dylibs: list, expected_minos: str, source: str) -> None:
                         break
                 break
 
-        if minos and minos != expected_minos:
-            mismatches.append(f"{dylib.name}: minos={minos}, expected={expected_minos}")
+        # A dylib with a lower minos than the wheel tag is safe (forward compatible).
+        # Only flag dylibs that require a *higher* macOS than the wheel claims to support.
+        if minos and tuple(int(x) for x in minos.split(".")) > tuple(
+            int(x) for x in expected_minos.split(".")
+        ):
+            mismatches.append(
+                f"{dylib.name}: minos={minos}, expected<={expected_minos}"
+            )
 
     if mismatches:
         raise RuntimeError(

--- a/.ci/wheel/build_wheel.sh
+++ b/.ci/wheel/build_wheel.sh
@@ -97,7 +97,7 @@ fi
 whl_tmp_dir="${MAC_PACKAGE_WORK_DIR}/dist"
 mkdir -p "$whl_tmp_dir"
 
-mac_version='macosx-11.0-arm64'
+mac_version='macosx-14.0-arm64'
 libtorch_arch='arm64'
 
 # Create a consistent wheel package name to rename the wheel to
@@ -125,7 +125,7 @@ popd
 
 export TH_BINARY_BUILD=1
 export INSTALL_TEST=0 # dont install test binaries into site-packages
-export MACOSX_DEPLOYMENT_TARGET=11.0
+export MACOSX_DEPLOYMENT_TARGET=14.0
 
 EXTRA_CONDA_INSTALL_FLAGS=""
 CONDA_ENV_CREATE_FLAGS=""
@@ -179,6 +179,7 @@ retry pip install "${PINNED_PACKAGES[@]}" -r "${pytorch_rootdir}/requirements.tx
 if [[ -d "/opt/llvm-openmp" ]]; then
   export OMP_PREFIX=/opt/llvm-openmp
 else
+  echo "libomp not found, installing via brew"
   retry brew install libomp
 fi
 


### PR DESCRIPTION
## Summary
https://github.com/pytorch/pytorch/issues/177303

- Update `MACOSX_DEPLOYMENT_TARGET` from 11.0/11.1 to 14.0 across all macOS CI build scripts
- Update wheel platform name from `macosx_11_0_arm64` to `macosx_14_0_arm64`
- Companion PR in test-infra: https://github.com/pytorch/test-infra/pull/7916

## Files changed
- `.ci/pytorch/macos-common.sh` — 11.1 → 14.0
- `.ci/pytorch/macos-build.sh` — 11.0 → 14.0, plat-name updated
- `.ci/wheel/build_wheel.sh` — mac_version and MACOSX_DEPLOYMENT_TARGET updated
