### PR TITLE
[bug][ROCm][inductor] accept 1D bias in addmm ATen heuristic

### DIFF
--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -2547,7 +2547,8 @@ class TestMaxAutotune(TestCase):
         """
         ROCm regression test for addmm autotune input wiring.
         A 1D bias is required for hipBLASLt bias-fused addmm kernels; expanded 2D
-        bias disables that fused path.
+        bias disables that fused path. Exercise the real bias_addmm heuristic
+        so regressions in the runtime path are caught as part of this test.
         """
         bias_input_ranks: dict[str, set[int]] = {"addmm": set(), "bias_addmm": set()}
 
@@ -2567,26 +2568,11 @@ class TestMaxAutotune(TestCase):
             mat1 = torch.randn(32, 128, device=GPU_TYPE)
             mat2 = torch.randn(128, 64, device=GPU_TYPE)
 
-            from torch._inductor.template_heuristics.aten import (
-                ATenAddMMConfigHeuristics,
+            compiled_fn = torch.compile(
+                lambda b, x, w: torch.addmm(b, x, w),
+                dynamic=False,
             )
-
-            def allow_bias_addmm_configs(self, kernel_inputs, op_name):
-                yield from ATenAddMMConfigHeuristics._get_template_configs_impl(
-                    self, kernel_inputs, op_name
-                )
-
-            # Relax bias_addmm heuristics here so this test can assert 1D vs 2D bias wiring.
-            with mock.patch(
-                "torch._inductor.template_heuristics.aten.ATenBiasAddMMConfigHeuristics._get_template_configs_impl",
-                autospec=True,
-                side_effect=allow_bias_addmm_configs,
-            ):
-                compiled_fn = torch.compile(
-                    lambda b, x, w: torch.addmm(b, x, w),
-                    dynamic=False,
-                )
-                _ = compiled_fn(bias, mat1, mat2)
+            _ = compiled_fn(bias, mat1, mat2)
 
             self.assertTrue(
                 bias_input_ranks["addmm"], "Expected ATen addmm choice to be generated"

--- a/torch/_inductor/template_heuristics/aten.py
+++ b/torch/_inductor/template_heuristics/aten.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import torch
 from typing import Any, TYPE_CHECKING
 
 from torch._inductor import config as inductor_config
@@ -86,6 +87,12 @@ class ATenBiasAddMMConfigHeuristics(
         nodes = kernel_inputs.nodes()
         # for addmm, bias is the first input
         bias = nodes[0]
-        # Conditions should be checked in tuned_addmm before adding this template
-        assert bias.get_stride()[0] == 0 and inductor_config.triton.autotune_cublasLt
+        # Conditions should be checked in tuned_addmm before adding this template.
+        #
+        # On ROCm, tuned_addmm passes the original 1D bias input so hipBLASLt
+        # fused-bias kernels can see the native bias form. In that case the bias
+        # no longer has the expanded stride-0 layout used on the non-ROCm path.
+        is_rocm_1d_bias = torch.version.hip and len(bias.get_size()) == 1
+        valid_bias_input = is_rocm_1d_bias or bias.get_stride()[0] == 0
+        assert valid_bias_input and inductor_config.triton.autotune_cublasLt
         yield from super()._get_template_configs_impl(kernel_inputs, op_name)

--- a/torch/_inductor/template_heuristics/aten.py
+++ b/torch/_inductor/template_heuristics/aten.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-import torch
 from typing import Any, TYPE_CHECKING
 
+import torch
 from torch._inductor import config as inductor_config
 
 from ..kernel.bmm import aten_baddbmm, aten_bmm, aten_bmm_dtype

--- a/torch/_inductor/template_heuristics/aten.py
+++ b/torch/_inductor/template_heuristics/aten.py
@@ -88,7 +88,6 @@ class ATenBiasAddMMConfigHeuristics(
         # for addmm, bias is the first input
         bias = nodes[0]
         # Conditions should be checked in tuned_addmm before adding this template.
-        #
         # On ROCm, tuned_addmm passes the original 1D bias input so hipBLASLt
         # fused-bias kernels can see the native bias form. In that case the bias
         # no longer has the expanded stride-0 layout used on the non-ROCm path.


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/179023

Fixes a bug that was introduced in this PR: https://github.com/pytorch/pytorch/pull/177130

Keep ROCm's original 1D bias input for ATen addmm templates while allowing the bias_addmm heuristic to accept that native bias form. Improve the original unit test.

Made-with: Cursor

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @mlazos