### PR TITLE
[accelerator] Expose Event in the accelerator namespace

### DIFF
--- a/test/test_accelerator.py
+++ b/test/test_accelerator.py
@@ -178,6 +178,19 @@ class TestAccelerator(TestCase):
         ):
             event1.elapsed_time(event2)
 
+    def test_event_namespace(self):
+        self.assertEqual(torch.accelerator.Event.__module__, "torch.accelerator")
+
+        event1 = torch.accelerator.Event(enable_timing=True)
+        event2 = torch.accelerator.Event(enable_timing=True)
+        self.assertIsInstance(event1, torch.Event)
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "Both events must be recorded before calculating elapsed time",
+        ):
+            event1.elapsed_time(event2)
+
     @unittest.skipIf(TEST_MPS, "MPS doesn't support torch.accelerator memory API!")
     def test_memory_stats(self):
         # Ensure that device allocator is initialized

--- a/torch/accelerator/__init__.py
+++ b/torch/accelerator/__init__.py
@@ -24,7 +24,34 @@ from .memory import (
 )
 
 
+class Event:
+    r"""Accelerator-aware event factory.
+
+    This is the accelerator namespace entry point for the generic :class:`torch.Event`
+    API. Constructing it returns a :class:`torch.Event`.
+    """
+
+    def __new__(
+        cls,
+        device: torch.device | None = None,
+        *,
+        enable_timing: bool = False,
+        blocking: bool = False,
+        interprocess: bool = False,
+    ) -> torch.Event:
+        return torch.Event(
+            device=device,
+            enable_timing=enable_timing,
+            blocking=blocking,
+            interprocess=interprocess,
+        )
+
+    @classmethod
+    def from_ipc_handle(cls, device: torch.device, handle: str) -> torch.Event:
+        return torch.Event.from_ipc_handle(device, handle)
+
 __all__ = [
+    "Event",
     "Graph",
     "current_accelerator",
     "current_device_idx",  # deprecated
@@ -257,8 +284,8 @@ def synchronize(device: _device_t = None, /) -> None:
 
         >>> # xdoctest: +REQUIRES(env:TORCH_DOCTEST_CUDA)
         >>> assert torch.accelerator.is_available() "No available accelerators detected."
-        >>> start_event = torch.Event(enable_timing=True)
-        >>> end_event = torch.Event(enable_timing=True)
+        >>> start_event = torch.accelerator.Event(enable_timing=True)
+        >>> end_event = torch.accelerator.Event(enable_timing=True)
         >>> start_event.record()
         >>> tensor = torch.randn(100, device=torch.accelerator.current_accelerator())
         >>> sum = torch.sum(tensor)


### PR DESCRIPTION
To be consistent with `torch.cuda.Event()`

There are other inconsistencies like current_stream, set_stream and synchronize

This is obviously a nit so feel free to close, just threw me off at first

Had to do some shenanigans to support it being a public class

cc @albanD @guangyey @EikanWang