### PR TITLE
Make dist.record_comm dynamo traceable

### DIFF
--- a/test/distributed/test_dynamo_distributed.py
+++ b/test/distributed/test_dynamo_distributed.py
@@ -638,6 +638,101 @@ class TestFakeDistributedSingleProc(torch._dynamo.test_case.TestCase):
             "DDPOptimizer should activate for compiled regions inside nested DDP",
         )
 
+    @torch._dynamo.config.patch(capture_record_comm=True)
+    def test_record_comm_capture(self):
+        backend = torch._dynamo.testing.EagerAndRecordGraphs()
+
+        @torch.compile(backend=backend, fullgraph=True)
+        def fn(x):
+            with dist.record_comm("my_collective"):
+                y = x + 1
+            return y
+
+        result = fn(torch.randn(4))
+        self.assertEqual(result.shape, (4,))
+
+        graph = backend.graphs[0]
+        graph_code = graph.print_readable(False)
+        self.assertIn("_record_comm_enter", graph_code)
+        self.assertIn("_record_comm_exit", graph_code)
+
+    @torch._dynamo.config.patch(capture_record_comm=True)
+    def test_record_comm_nested_capture(self):
+        backend = torch._dynamo.testing.EagerAndRecordGraphs()
+
+        @torch.compile(backend=backend, fullgraph=True)
+        def fn(x):
+            with dist.record_comm("outer"):
+                x = x + 1
+                with dist.record_comm("inner"):
+                    x = x * 2
+            return x
+
+        result = fn(torch.ones(4))
+        self.assertEqual(result, torch.ones(4) * 4)
+
+        graph = backend.graphs[0]
+        nodes = [n for n in graph.graph.nodes if n.op == "call_function"]
+        record_nodes = [
+            n
+            for n in nodes
+            if hasattr(n.target, "__name__") and "record_comm" in n.target.__name__
+        ]
+        self.assertEqual(len(record_nodes), 4)
+        self.assertEqual(record_nodes[0].args, ("outer",))
+        self.assertEqual(record_nodes[1].args, ("inner",))
+        self.assertEqual(record_nodes[2].target.__name__, "_record_comm_exit")
+        self.assertEqual(record_nodes[3].target.__name__, "_record_comm_exit")
+
+        # Inner exit should reference inner enter's handle
+        self.assertIs(record_nodes[2].args[0], record_nodes[1])
+        # Outer exit should reference outer enter's handle
+        self.assertIs(record_nodes[3].args[0], record_nodes[0])
+
+    def test_record_comm_no_capture(self):
+        backend = torch._dynamo.testing.EagerAndRecordGraphs()
+
+        @torch.compile(backend=backend, fullgraph=True)
+        def fn(x):
+            with dist.record_comm("my_collective"):
+                y = x + 1
+            return y
+
+        result = fn(torch.randn(4))
+        self.assertEqual(result.shape, (4,))
+
+        graph = backend.graphs[0]
+        graph_code = graph.print_readable(False)
+        self.assertNotIn("_record_comm_enter", graph_code)
+        self.assertNotIn("_record_comm_exit", graph_code)
+
+    @torch._dynamo.config.patch(capture_record_comm=True)
+    def test_record_comm_survives_aot_autograd(self):
+        """Verify record_comm ops survive through AOTAutograd (not just Dynamo)."""
+        aot_graphs = []
+
+        def capture_fw(gm, example_inputs):
+            aot_graphs.append(gm)
+            return gm
+
+        from torch._dynamo.backends.common import aot_autograd
+
+        @torch.compile(backend=aot_autograd(fw_compiler=capture_fw), fullgraph=True)
+        def fn(x):
+            with dist.record_comm("aot_test"):
+                y = x + 1
+            return y
+
+        fn(torch.randn(4))
+        self.assertEqual(len(aot_graphs), 1)
+
+        node_names = [
+            n.target.__name__
+            for n in aot_graphs[0].graph.nodes
+            if n.op == "call_function" and hasattr(n.target, "__name__")
+        ]
+        self.assertIn("with_effects", node_names)
+
 
 # These tests aren't really distributed, but need multiple GPUs to run
 class TestMultiGPU(torch._inductor.test_case.TestCase):
@@ -2516,6 +2611,39 @@ class TestSingleProc(DynamoDistributedSingleProcTestCase):
         compiled_fn = torch.compile(fn, backend="aot_eager", fullgraph=True)
         actual = compiled_fn(x, w)
         self.assertEqual(actual, expected)
+
+    @torch._dynamo.config.patch(capture_record_comm=True)
+    def test_record_comm_with_all_reduce(self):
+        backend = torch._dynamo.testing.EagerAndRecordGraphs()
+
+        def fn(x):
+            with dist.record_comm("test::all_reduce"):
+                dist.all_reduce(x, async_op=False)
+            return x
+
+        x = torch.ones(4, 4, device=self.device)
+        compiled_fn = torch.compile(fn, backend=backend, fullgraph=True)
+        result = compiled_fn(x)
+        self.assertEqual(result, torch.ones(4, 4, device=self.device))
+        self.assertEqual(torch._C._distributed_c10d._get_comm_profiling_name(), "")
+
+        graph = backend.graphs[0]
+        call_nodes = [
+            (n.target.__name__ if hasattr(n.target, "__name__") else str(n.target))
+            for n in graph.graph.nodes
+            if n.op == "call_function"
+        ]
+        enter_idx = next(
+            i for i, name in enumerate(call_nodes) if "record_comm_enter" in name
+        )
+        reduce_idx = next(
+            i for i, name in enumerate(call_nodes) if "all_reduce" in name
+        )
+        exit_idx = next(
+            i for i, name in enumerate(call_nodes) if "record_comm_exit" in name
+        )
+        self.assertLess(enter_idx, reduce_idx)
+        self.assertLess(reduce_idx, exit_idx)
 
     def test_compiled_all_gather_into_tensor_returns_none(self):
         def fn(output, input, w):

--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -680,6 +680,12 @@ capture_func_transforms = True
 # are treated as nullcontext.
 capture_profiler_record_function: bool = False
 
+# Enable capturing dist.record_comm into the FX graph.
+# When True, _record_comm_enter/_exit ops are emitted to the graph and
+# preserved through compilation. When False, record_comm is treated as
+# nullcontext.
+capture_record_comm: bool = False
+
 # If to log Dynamo compilation metrics into log files (for OSS) and Scuba tables (for fbcode).
 log_compilation_metrics = True
 

--- a/torch/_dynamo/variables/ctx_manager.py
+++ b/torch/_dynamo/variables/ctx_manager.py
@@ -1173,6 +1173,74 @@ class ProfilerRecordFunctionContextVariable(ContextWrappingVariable):
             super().reconstruct_type(codegen)
 
 
+class RecordCommVariable(ContextWrappingVariable):
+    """
+    Emits _c10d_functional._record_comm_enter/_exit ops into the FX graph so
+    the comm profiling name survives compilation. Behaves like nullcontext when
+    config.capture_record_comm is False.
+    """
+
+    @staticmethod
+    def create(
+        record_args: Sequence[VariableTracker],
+        record_kwargs: dict[str, VariableTracker],
+        **kwargs: Any,
+    ) -> "RecordCommVariable":
+        target_values = None
+        if config.capture_record_comm:
+            name = (
+                record_args[0].as_python_constant()
+                if record_args
+                else record_kwargs["name"].as_python_constant()
+            )
+            target_values = [name]
+        else:
+            warning_once(log, "dist.record_comm will be ignored")
+        return RecordCommVariable(
+            target_values=target_values, initial_values=None, **kwargs
+        )
+
+    def enter(self, tx: "InstructionTranslator") -> VariableTracker:
+        if config.capture_record_comm:
+            (name,) = self.target_values
+            self.proxy = tx.output.create_node(
+                "call_function",
+                torch.ops._c10d_functional._record_comm_enter,
+                (name,),
+                {},
+            )
+        return self
+
+    def exit(
+        self, tx: "InstructionTranslator", *args: VariableTracker
+    ) -> VariableTracker:
+        if config.capture_record_comm:
+            tx.output.create_node(
+                "call_function",
+                torch.ops._c10d_functional._record_comm_exit,
+                (self.proxy,),
+                {},
+            )
+        return variables.CONSTANT_VARIABLE_NONE
+
+    def module_name(self) -> str:
+        return "torch.distributed" if config.capture_record_comm else "contextlib"
+
+    def fn_name(self) -> str:
+        return "record_comm" if config.capture_record_comm else "nullcontext"
+
+    def reconstruct_type(self, codegen: "PyCodegen") -> None:
+        if config.capture_record_comm:
+            unimplemented(
+                gb_type="record_comm escaped from compiled region",
+                context=str(self),
+                explanation="Dynamo doesn't support graph break inside record_comm region.",
+                hints=[*graph_break_hints.SUPPORTABLE],
+            )
+        else:
+            super().reconstruct_type(codegen)
+
+
 class PreserveVersionContextVariable(ContextWrappingVariable):
     """
     Wraps torch.autograd._unsafe_preserve_version_counter

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -87,6 +87,7 @@ from .ctx_manager import (
     AutocastModeVariable,
     ProfilerContextVariable,
     ProfilerRecordFunctionContextVariable,
+    RecordCommVariable,
     TorchFunctionDisableVariable,
 )
 from .distributed import DistributedVariable
@@ -156,6 +157,8 @@ supported_ctx_manager_classes = dict.fromkeys(
         torch.nn.attention.sdpa_kernel.__wrapped__,  # type: ignore[attr-defined]
     ]
 )
+if torch.distributed.is_available():
+    supported_ctx_manager_classes[torch.distributed.distributed_c10d.record_comm] = None
 
 
 REWRITE_OPS_TO_TENSOR_SIZE_METHOD = dict.fromkeys(
@@ -575,6 +578,11 @@ class TorchCtxManagerClassVariable(BaseTorchVariable):
         ):
             warning_once(log, "Profiler function %s will be ignored", self.value)
             return ProfilerContextVariable()
+        elif (
+            torch.distributed.is_available()
+            and self.value is torch.distributed.distributed_c10d.record_comm
+        ):
+            return RecordCommVariable.create(record_args=args, record_kwargs=kwargs)
         elif (
             self.value is torch._C.DisableTorchFunctionSubclass
             or self.value is torch._C.DisableTorchFunction

--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -1578,6 +1578,90 @@ torch.fx.node.has_side_effect(torch.ops._c10d_functional.batch_p2p_ops.default) 
 torch.fx.node.has_side_effect(torch.ops._c10d_functional.batch_p2p_ops)  # type: ignore[has-type]
 
 
+from torch._library.opaque_object import get_opaque_type_name, register_opaque_type
+
+# Opaque handle for record_comm ops.  Wraps the previous profiling name so
+# it can flow through the FX graph as a reference-typed opaque object,
+# surviving AOTAutograd/make_fx tracing. Reference type is needed
+# because the handle's prev_name depends on runtime state (the profiling
+# name active when _record_comm_enter is called), so it cannot be baked
+# as a compile-time constant.
+from torch._opaque_base import OpaqueBase
+
+
+class RecordCommHandle(OpaqueBase):
+    def __init__(self, prev_name: str = "") -> None:
+        self.prev_name = prev_name
+
+
+register_opaque_type(RecordCommHandle, typ="reference")
+
+_record_comm_lib = torch.library.Library("_c10d_functional", "FRAGMENT")
+_record_comm_handle_type = get_opaque_type_name(RecordCommHandle)
+
+_record_comm_lib.define(
+    f"_record_comm_enter(str name) -> {_record_comm_handle_type}",
+    tags=[torch.Tag.pt2_compliant_tag],
+)
+_record_comm_lib.define(
+    f"_record_comm_exit({_record_comm_handle_type} handle) -> ()",
+    tags=[torch.Tag.pt2_compliant_tag],
+)
+
+
+def _record_comm_enter_impl(name: str) -> RecordCommHandle:
+    from torch.distributed.distributed_c10d import _record_comm_enter
+
+    prev = _record_comm_enter(name)
+    return RecordCommHandle(prev)
+
+
+def _record_comm_exit_impl(handle: RecordCommHandle) -> None:
+    from torch.distributed.distributed_c10d import _record_comm_exit
+
+    _record_comm_exit(handle.prev_name)
+
+
+lib_impl.impl(
+    "_record_comm_enter", _record_comm_enter_impl, "CompositeExplicitAutograd"
+)
+lib_impl.impl("_record_comm_exit", _record_comm_exit_impl, "CompositeExplicitAutograd")
+
+
+@torch.library.register_fake("_c10d_functional::_record_comm_enter")
+def _record_comm_enter_fake(name: str) -> RecordCommHandle:
+    return RecordCommHandle("")
+
+
+@torch.library.register_fake("_c10d_functional::_record_comm_exit")
+def _record_comm_exit_fake(handle: RecordCommHandle) -> None:
+    pass
+
+
+torch.fx.node.has_side_effect(  # type: ignore[has-type]
+    torch.ops._c10d_functional._record_comm_enter
+)
+torch.fx.node.has_side_effect(  # type: ignore[has-type]
+    torch.ops._c10d_functional._record_comm_exit
+)
+
+# Register as effectful so that AOTAutograd threads effect tokens through
+# these ops, preventing them from being DCE'd during functionalization.
+# The opaque handle provides the data dependency between enter/exit, but
+# without effect tokens the nodes can still be removed because they have
+# no tensor outputs connected to the graph output.
+from torch._higher_order_ops.effects import _register_effectful_op
+from torch._library.effects import EffectType
+
+
+_register_effectful_op(
+    torch.ops._c10d_functional._record_comm_enter.default, EffectType.ORDERED
+)
+_register_effectful_op(
+    torch.ops._c10d_functional._record_comm_exit.default, EffectType.ORDERED
+)
+
+
 # Register legacy ops for backward compatibility
 # TODO(yifu): remove these in functional collective beta release
 legacy_lib = torch.library.Library("c10d_functional", "DEF")

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -6584,6 +6584,16 @@ def _update_process_group_global_state(
         _world.pg_to_tag[pg] = pg_tag
 
 
+def _record_comm_enter(name: str) -> str:
+    prev = torch._C._distributed_c10d._get_comm_profiling_name()
+    torch._C._distributed_c10d._set_comm_profiling_name(name)
+    return prev
+
+
+def _record_comm_exit(prev_name: str) -> None:
+    torch._C._distributed_c10d._set_comm_profiling_name(prev_name)
+
+
 @contextlib.contextmanager
 def record_comm(name: str):
     """Context manager to set a custom profiling name for communication collectives.
@@ -6601,9 +6611,8 @@ def record_comm(name: str):
         >>> with dist.record_comm("FSDP::all_gather (layer1)"):
         ...     dist.all_gather_into_tensor(output, input, group=pg)
     """
-    prev = torch._C._distributed_c10d._get_comm_profiling_name()
-    torch._C._distributed_c10d._set_comm_profiling_name(name)
+    prev = _record_comm_enter(name)
     try:
         yield
     finally:
-        torch._C._distributed_c10d._set_comm_profiling_name(prev)
+        _record_comm_exit(prev)


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/178820

Insert nodes in the graph for record comm enter/exit. Use opaque type to ensure names survive AOTAutograd. Add unit tests and validated using profiler trace that comm name survives in the compiled region

<img width="1273" height="355" alt="Screenshot 2026-04-01 at 4 49 37 PM" src="https://github.com/user-attachments/assets/03c0c988-a801-462d-9127-23b241c8c719" />

<!-- ps-id: 883de669-6e75-4458-bc9c-4c8b0707a1ba -->

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98