### PR TITLE
[Inductor][Triton] Add non-TMA persistent addmm Triton template (#179095)

### DIFF
--- a/test/inductor/test_lookup_table.py
+++ b/test/inductor/test_lookup_table.py
@@ -986,13 +986,19 @@ class TestLookupTableE2E(BaseE2ELookupTableTest):
             partial(verify_choice_names, pattern="bias_addmm", expected_count=1)
         )
 
-        # Run with original unexpanded bias
+        # Run with expanded bias (stride[0] == 0) so the inductor sees
+        # bias_addmm-eligible inputs and the lookup key matches.
+        # Limit backends to ATEN so only the lookup table entry is selected.
         with inductor_config.patch(
-            {"max_autotune_gemm": True, "triton.autotune_cublasLt": True}
+            {
+                "max_autotune_gemm": True,
+                "triton.autotune_cublasLt": True,
+                "max_autotune_gemm_backends": "ATEN",
+            }
         ):
             model = UnifiedModel("addmm")
             compiled_model = torch.compile(model.to(self.device), mode="max-autotune")
-            compiled_model(bias_unexpanded, tensors[1], tensors[2])
+            compiled_model(expanded_bias, tensors[1], tensors[2])
 
     @unittest.skipIf(not has_triton_tma_device(), "Need TMA support")
     @fresh_cache()

--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -416,6 +416,59 @@ class TestMaxAutotune(TestCase):
 
         torch.testing.assert_close(c_actual, c_expected, atol=1e-2, rtol=1e-2)
 
+    @unittest.skipIf(not torch.version.hip, "ROCM only")
+    @parametrize("a_transposed", (False, True))
+    @parametrize("b_transposed", (False, True))
+    @parametrize("dynamic", (False, True))
+    def test_max_autotune_regular_addmm_persistent(
+        self,
+        a_transposed: bool,
+        b_transposed: bool,
+        dynamic: bool,
+    ):
+        def addmm(x, a, b):
+            x = x.repeat(8)
+            a = a.repeat(8, 8)
+            b = b.repeat(8, 8)
+
+            if a_transposed:
+                a = a.T
+            if b_transposed:
+                b = b.T
+
+            return torch.addmm(x, a, b)
+
+        M, N, K = 21, 31, 11
+        a = (
+            torch.randn(*((K, M) if a_transposed else (M, K)))
+            .to(torch.float16)
+            .to(GPU_TYPE)
+        )
+        b = (
+            torch.randn(*((N, K) if b_transposed else (K, N)))
+            .to(torch.float16)
+            .to(GPU_TYPE)
+        )
+        x = torch.randn(N).to(torch.float16).to(GPU_TYPE)
+
+        with config.patch(
+            {
+                "max_autotune": True,
+                "triton.enable_persistent_tma_matmul": "1",
+                "triton.native_matmul": False,
+                "test_configs.autotune_choice_name_regex": "mm_persistent",
+            }
+        ):
+            c_actual, code = run_and_get_code(
+                torch.compile(addmm, dynamic=dynamic), x, a, b
+            )
+            c_expected = addmm(x, a, b)
+
+        # Verify that we are using the non-TMA persistent implementation
+        FileCheck().check("triton_tem_fused_addmm").check("NUM_SMS").run(code[0])
+
+        torch.testing.assert_close(c_actual, c_expected, atol=1e-2, rtol=1e-2)
+
     @unittest.skipIf(
         not has_triton_tma_device(), "Need device-side TMA support in Triton"
     )

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -694,7 +694,10 @@ def tuned_addmm(inp, mat1, mat2, *, alpha=1, beta=1, layout=None):
         ):
             templates_to_use.append(blackwell_ws_persistent_device_tma_mm_template)
         elif use_triton_tma_template(mat1, mat2, output_layout=layout, add_guards=True):
-            templates_to_use.append(persistent_tma_mm_template)
+            if torch.version.hip is None:
+                templates_to_use.append(persistent_tma_mm_template)
+            else:
+                templates_to_use.append(persistent_mm_template)
 
         templates_to_use.append(addmm_contiguous_subgraph_template)
 

--- a/torch/_inductor/template_heuristics/triton.py
+++ b/torch/_inductor/template_heuristics/triton.py
@@ -2845,6 +2845,18 @@ class ROCmAddMMTemplateConfigHeuristic(AddMMConfigMixin, ROCmMMTemplateConfigHeu
     """Addmm specific mixin for ROCm"""
 
 
+@register_template_heuristic(
+    persistent_mm_template.uid,
+    "cuda",
+    register=torch.version.hip is not None,
+    op_name="addmm",
+)
+class ROCmAddMMPersistentTemplateConfigHeuristic(
+    AddMMConfigMixin, PersistentMMTemplateConfigHeuristic
+):
+    """Addmm specific mixin for persistent MM on ROCm"""
+
+
 # TODO(coconutruben): deprecate once autoheuristic is deprecated
 @register_template_heuristic("mm-ah", "cuda", register=torch.version.hip is not None)
 class ROCmMMAHTemplateConfigHeuristic(MMTemplateConfigMixin, ROCmConfigHeuristic):


### PR DESCRIPTION
Summary:

Add non-TMA persistent matmul template support for addmm on AMD GPUs

D96971956 added a non-TMA persistent MM template (persistent_mm_template) as a fallback for AMD GPUs that lack TMA support, but only wired it up for torch.mm. The torch.addmm code path was left unconditionally using persistent_tma_mm_template, which doesn't work on AMD.

This applies the same torch.version.hip check to the addmm path in mm.py and adds a corresponding test_max_autotune_regular_addmm_persistent test, mirroring the existing mm test. Changes applied to both fbcode/ and xplat/ mirrors.

Test Plan: TORCHINDUCTOR_FORCE_DISABLE_CACHES=1 buck2 run fbcode//mode/opt-amd-gpu fbcode//scripts/robeck/inductor:test_max_autotune_amd -- -r test_max_autotune_regular_addmm_persistent

Differential Revision: D99194762




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos