### PR TITLE
[TPU] [Pallas] Fix pallas codegen to use [...] for scalar and size-1 buffer accesses

### DIFF
--- a/test/inductor/pallas_expected_failures/CpuTests.test_slice_scatter_reinplace_cpu
+++ b/test/inductor/pallas_expected_failures/CpuTests.test_slice_scatter_reinplace_cpu
@@ -1,5 +1,0 @@
-ERROR
-  File "<string>", line 7, in __init__
-  File "/home/oulgen/py312/lib/python3.12/site-packages/jax/_src/state/indexing.py", line 176, in __post_init__
-    raise ValueError(f"Out of bound slice: start={value}, dim={s}.")
-ValueError: Out of bound slice: start=56, dim=56.

--- a/torch/_inductor/codegen/pallas.py
+++ b/torch/_inductor/codegen/pallas.py
@@ -2110,8 +2110,13 @@ class PallasKernel(SIMDKernel):
 
         buf_size = buf_obj.get_size()
 
-        # 0-dimensional (scalar) buffer - use [...] to access it
         if len(buf_size) == 0:
+            return _BufferIndexing(
+                index_str="...", needs_flatten=indexing.needs_flatten
+            )
+        
+        # if buffer size is 1, and index is an integer, use "..."
+        if len(buf_size) == 1 and not self._has_iteration_vars(index):
             return _BufferIndexing(
                 index_str="...", needs_flatten=indexing.needs_flatten
             )
@@ -3133,6 +3138,9 @@ class PallasKernel(SIMDKernel):
                 else:
                     # Get base index expression
                     indexing = self._get_index_expr(index)
+
+                    # Adjust index for buffer shape (scalar, multi-dim, etc.)
+                    indexing = self._adjust_index_for_buffer_shape(name, index, indexing)
 
                     # Check for im2col-like patterns
                     indexing = self._check_im2col_pattern(index, indexing)

--- a/torch/_inductor/codegen/pallas.py
+++ b/torch/_inductor/codegen/pallas.py
@@ -2116,7 +2116,7 @@ class PallasKernel(SIMDKernel):
             )
         
         # if buffer size is 1, and index is an integer, use "..."
-        if len(buf_size) == 1 and not self._has_iteration_vars(index):
+        if len(buf_size) == 1 and buf_size[0] == 1 and not self._has_iteration_vars(index):
             return _BufferIndexing(
                 index_str="...", needs_flatten=indexing.needs_flatten
             )

--- a/torch/_inductor/codegen/pallas.py
+++ b/torch/_inductor/codegen/pallas.py
@@ -2745,7 +2745,7 @@ class PallasKernel(SIMDKernel):
             # Block variable indexing (e.g., im2col) - use flattened scatter
             scatter_op = "add" if mode == "atomic_add" else "set"
             return [
-                f"{out}[...] = {out}[...].flatten().at[({indexing.index_str}).flatten()].{scatter_op}("
+                f"{out}[...] = {out}[...].flatten().at[jnp.asarray({indexing.index_str}).flatten()].{scatter_op}("
                 f"jnp.asarray({value}).flatten()).reshape({out}.shape)"
             ]
 
@@ -2769,8 +2769,8 @@ class PallasKernel(SIMDKernel):
                 self.outputs_need_read.add(out)
                 alias_param = f"{out}_alias"
                 lines.append(
-                    f"{out}[...] = {alias_param}[...].flatten().at[({indexing.index_str}).flatten()].{scatter_op}("
-                    f"{value_expr}.flatten()).reshape({out}.shape)"
+                    f"{out}[...] = {alias_param}[...].flatten().at[jnp.asarray({indexing.index_str}).flatten()].{scatter_op}("
+                    f"jnp.asarray({value_expr}).flatten()).reshape({out}.shape)"
                 )
             else:
                 lines.append(f"{out}[{indexing.index_str}] = {value_expr}")

--- a/torch/_inductor/codegen/pallas.py
+++ b/torch/_inductor/codegen/pallas.py
@@ -2114,9 +2114,13 @@ class PallasKernel(SIMDKernel):
             return _BufferIndexing(
                 index_str="...", needs_flatten=indexing.needs_flatten
             )
-        
+
         # if buffer size is 1, and index is an integer, use "..."
-        if len(buf_size) == 1 and buf_size[0] == 1 and not self._has_iteration_vars(index):
+        if (
+            len(buf_size) == 1
+            and buf_size[0] == 1
+            and not self._has_iteration_vars(index)
+        ):
             return _BufferIndexing(
                 index_str="...", needs_flatten=indexing.needs_flatten
             )
@@ -3140,7 +3144,9 @@ class PallasKernel(SIMDKernel):
                     indexing = self._get_index_expr(index)
 
                     # Adjust index for buffer shape (scalar, multi-dim, etc.)
-                    indexing = self._adjust_index_for_buffer_shape(name, index, indexing)
+                    indexing = self._adjust_index_for_buffer_shape(
+                        name, index, indexing
+                    )
 
                     # Check for im2col-like patterns
                     indexing = self._check_im2col_pattern(index, indexing)


### PR DESCRIPTION
This is the last inductor backend test taht's intentionally skipper per Meta.

Root cause: scalars need to be in SMEM not VMEM.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos