### PR TITLE
[BE][Win] Don't use `small` as argument name

### DIFF
--- a/c10/cuda/CUDACachingAllocator.h
+++ b/c10/cuda/CUDACachingAllocator.h
@@ -101,8 +101,8 @@ struct ShareableHandle {
 };
 
 struct StreamSegmentSize {
-  StreamSegmentSize(cudaStream_t s, bool sm, size_t sz)
-      : stream(s), is_small_pool(sm), total_size(sz) {}
+  StreamSegmentSize(cudaStream_t s, bool small_, size_t sz)
+      : stream(s), is_small_pool(small_), total_size(sz) {}
   cudaStream_t stream;
   bool is_small_pool;
   size_t total_size;

--- a/c10/cuda/CUDACachingAllocator.h
+++ b/c10/cuda/CUDACachingAllocator.h
@@ -101,8 +101,8 @@ struct ShareableHandle {
 };
 
 struct StreamSegmentSize {
-  StreamSegmentSize(cudaStream_t s, bool small, size_t sz)
-      : stream(s), is_small_pool(small), total_size(sz) {}
+  StreamSegmentSize(cudaStream_t s, bool sm, size_t sz)
+      : stream(s), is_small_pool(sm), total_size(sz) {}
   cudaStream_t stream;
   bool is_small_pool;
   size_t total_size;


### PR DESCRIPTION
Otherwise, if one include <windows.h> without defining `WIN32_LEAN_AND_MEAN` you still get headers compatible with COM/Win16, and one of them is a glorious `#define small char`, which will render above code syntactically incorrect and any inclusions of the header will fail with `invalid combination of type specifiers` as show in https://github.com/pytorch/pytorch/issues/179005
```
D:\Program Files\Nvidia\CUDA_Toolkit_13.2\bin\nvcc -MD -MF C:\B\vision\build\temp.win-amd64-cpython-314\Release\B\vision\torchvision\csrc\ops\cuda\roi_pool_kernel.obj.d -std=c++20 -Xcompiler /MD -Xcompiler /wd4819 -Xcompiler /wd4251 -Xcompiler /wd4244 -Xcompiler /wd4267 -Xcompiler /wd4275 -Xcompiler /wd4018 -Xcompiler /wd4190 -Xcompiler /wd4624 -Xcompiler /wd4067 -Xcompiler /wd4068 -Xcompiler /EHsc --use-local-env -Xcudafe --diag_suppress=base_class_has_different_dll_interface -Xcudafe --diag_suppress=field_without_dll_interface -Xcudafe --diag_suppress=dll_interface_conflict_none_assumed -Xcudafe --diag_suppress=dll_interface_conflict_dllexport_assumed -DWITH_CUDA -Dtorchvision_EXPORTS -IC:\B\vision\torchvision\csrc -IF:\Python314\install\Lib\site-packages\torch\include -IF:\Python314\install\Lib\site-packages\torch\include\torch\csrc\api\include "-ID:\Program Files\Nvidia\CUDA_Toolkit_13.2\include" "-ID:\Program Files\Nvidia\CuDNN\include" -IF:\Python314\install\include -IF:\Python314\install\Include "-ID:\Program Files\Nvidia\CUDA_Toolkit_13.2\extras\CUPTI\include" "-ID:\Program Files\Nvidia\CUDA_Toolkit_13.2\include\CL" "-ID:\Program Files\Nvidia\CUDA_Toolkit_13.2\src" "-ID:\Program Files\Nvidia\cuDNN\include\13.1" "-ID:\Program Files\Nvidia\cuDSS\include" "-ID:\Program Files\Nvidia\cuSPARSELt\include" "-IC:\Program Files\NVIDIA Corporation\Nsight Compute 2025.4.0\host\target-windows-x64\nvtx\include\nvtx3" "-IC:\Program Files\NVIDIA Corporation\Nsight Compute 2025.4.0\host\target-windows-x64\nvtx\include\nvtx3\nvtxDetail" "-IC:\Program Files\NVIDIA Corporation\Nsight Systems 2025.5.2\target-windows-x64\nvtx\include\nvtx3" "-IC:\Program Files\NVIDIA Corporation\Nsight Systems 2025.5.2\target-windows-x64\nvtx\include\nvtx3\nvtxDetail" "-IC:\Program Files\NVIDIA cuTENSOR\v2.4\include" "-IC:\Program Files\NVIDIA cuTENSOR\v2.4\include\cutensor" -IF:\Python314\install\include -IF:\Python314\install\include\cpython -IF:\Python314\install\include\internal -IF:\Python314\install\include\internal\mimalloc -IF:\Python314\install\include\internal\mimalloc\mimalloc "-ID:\Program Files\Microsoft Visual Studio\18\Insiders\VC\Tools\MSVC\14.50.35717\include" "-ID:\Program Files\Microsoft Visual Studio\18\Insiders\VC\Tools\MSVC\14.50.35717\ATLMFC\include" "-ID:\Program Files\Microsoft Visual Studio\18\Insiders\VC\Auxiliary\VS\include" "-IC:\Program Files (x86)\Windows Kits\10\include\10.0.26100.0\ucrt" "-IC:\Program Files (x86)\Windows Kits\10\\include\10.0.26100.0\\um" "-IC:\Program Files (x86)\Windows Kits\10\\include\10.0.26100.0\\shared" "-IC:\Program Files (x86)\Windows Kits\10\\include\10.0.26100.0\\winrt" "-IC:\Program Files (x86)\Windows Kits\10\\include\10.0.26100.0\\cppwinrt" "-IC:\Program Files (x86)\Windows Kits\NETFXSDK\4.8\include\um" -c C:\B\vision\torchvision\csrc\ops\cuda\roi_pool_kernel.cu -o C:\B\vision\build\temp.win-amd64-cpython-314\Release\B\vision\torchvision\csrc\ops\cuda\roi_pool_kernel.obj -D__CUDA_NO_HALF_OPERATORS__ -D__CUDA_NO_HALF_CONVERSIONS__ -D__CUDA_NO_BFLOAT16_CONVERSIONS__ -D__CUDA_NO_HALF2_OPERATORS__ --expt-relaxed-constexpr -DTORCH_API_INCLUDE_EXTENSION_H -DTORCH_EXTENSION_NAME=_C -gencode=arch=compute_120,code=compute_120 -gencode=arch=compute_120,code=sm_120
F:/Python314/install/Lib/site-packages/torch/include\c10/cuda/CUDACachingAllocator.h(105): error: invalid combination of type specifiers
    StreamSegmentSize(cudaStream_t s, bool char , size_t sz)
```

I hope fixes https://github.com/pytorch/pytorch/issues/173112