### PR TITLE
Add differentiable decomposition for max_pool2d/3d_with_indices

### DIFF
--- a/test/expect/HasDecompTest.test_aten_core_operators.expect
+++ b/test/expect/HasDecompTest.test_aten_core_operators.expect
@@ -351,8 +351,12 @@ aten::lt.Tensor
 aten::lt.Tensor_out
 aten::lt_.Scalar
 aten::lt_.Tensor
+aten::max_pool2d_with_indices
+aten::max_pool2d_with_indices.out
 aten::max_pool2d_with_indices_backward
 aten::max_pool2d_with_indices_backward.grad_input
+aten::max_pool3d_with_indices
+aten::max_pool3d_with_indices.out
 aten::maximum
 aten::maximum.out
 aten::mean

--- a/test/expect/HasDecompTest.test_has_decomposition.expect
+++ b/test/expect/HasDecompTest.test_has_decomposition.expect
@@ -963,10 +963,6 @@ aten::max.dim_max
 aten::max.unary_out
 aten::max_pool2d_backward
 aten::max_pool2d_backward.out
-aten::max_pool2d_with_indices
-aten::max_pool2d_with_indices.out
-aten::max_pool3d_with_indices
-aten::max_pool3d_with_indices.out
 aten::max_pool3d_with_indices_backward
 aten::max_pool3d_with_indices_backward.grad_input
 aten::median

--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -5192,6 +5192,7 @@ class TestFunctionalTracing(JitTestCase):
         "max_pool1d": PROXY_ITERABLE,
         "max_pool2d": PROXY_ITERABLE,
         "max_pool3d": PROXY_ITERABLE,
+        "max_pool3d_with_indices": CONTROL_FLOW,
         "lp_pool2d": PROXY_ITERATED,
         "lp_pool3d": PROXY_ITERATED,
         "max_unpool1d": PROXY_ITERATED,

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1485,6 +1485,31 @@ class TestTorchDeviceType(TestCase):
             False)
 
     @skipIfTorchInductor("aot-autograd issue")
+    def test_deterministic_max_pool3d(self, device):
+        test_cases = [
+            # size, kernel_size, stride, padding, dilation, ceil_mode
+            [(2, 3, 8, 8, 8), 3, 1, 1, 1, False],
+            [(2, 3, 8, 8, 8), 3, 2, 1, 1, False],
+            [(2, 3, 8, 8, 8), 2, 2, 0, 1, False],
+            [(2, 3, 8, 8, 8), 3, 2, 1, 1, True],
+            [(3, 8, 8, 8), 3, 1, 1, 1, False],  # unbatched
+        ]
+
+        for size, ks, st, pa, di, cm in test_cases:
+            input = torch.randn(*size, device=device, requires_grad=True)
+            grad = None
+            with DeterministicGuard(True):
+                for _ in range(5):
+                    res, _ = torch.nn.functional.max_pool3d(
+                        input, ks, st, pa, di, cm, return_indices=True)
+                    res.backward(torch.ones_like(res))
+                    if grad is None:
+                        grad = input.grad
+                    else:
+                        self.assertEqual(grad, input.grad, atol=0, rtol=0)
+                    input.grad = None
+
+    @skipIfTorchInductor("aot-autograd issue")
     def test_deterministic_replication_pad2d(self, device):
         test_cases = [
             # size, padding

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -1430,6 +1430,7 @@ def use_deterministic_algorithms(
         * :func:`torch.Tensor.index_copy` when called on a CPU or CUDA tensor
         * :func:`torch.Tensor.scatter` when `src` type is Tensor and called on CUDA tensor
         * :func:`torch.Tensor.scatter_reduce` when ``reduce='sum'`` or ``reduce='mean'`` and called on CUDA tensor
+        * :class:`torch.nn.MaxPool3d` when attempting to differentiate a CUDA tensor
 
     The following normally-nondeterministic operations will throw a
     :class:`RuntimeError` when ``mode=True``:
@@ -1437,7 +1438,6 @@ def use_deterministic_algorithms(
         * :class:`torch.nn.AvgPool3d` when attempting to differentiate a CUDA tensor
         * :class:`torch.nn.AdaptiveAvgPool2d` when attempting to differentiate a CUDA tensor
         * :class:`torch.nn.AdaptiveAvgPool3d` when attempting to differentiate a CUDA tensor
-        * :class:`torch.nn.MaxPool3d` when attempting to differentiate a CUDA tensor
         * :class:`torch.nn.AdaptiveMaxPool2d` when attempting to differentiate a CUDA tensor
         * :class:`torch.nn.FractionalMaxPool2d` when attempting to differentiate a CUDA tensor
         * :class:`torch.nn.FractionalMaxPool3d` when attempting to differentiate a CUDA tensor

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -2760,6 +2760,170 @@ def adaptive_avg_pool2d(input: Tensor, output_size: tuple[int, int]):
     return ret / (length_h * length_w)
 
 
+def _max_pool_nd_with_indices(
+    self: Tensor,
+    kernel_size: list[int],
+    stride: list[int],
+    padding: list[int],
+    dilation: list[int],
+    ceil_mode: bool,
+    n_dim: int,
+) -> tuple[Tensor, Tensor]:
+    def _expand(val: list[int] | int, default: list[int] | None = None) -> list[int]:
+        if not isinstance(val, (list, tuple)):
+            return [val] * n_dim
+        if not val:
+            torch._check(default is not None, lambda: "default must be provided")
+            return default  # type: ignore[return-value]
+        return val * n_dim if len(val) == 1 else list(val)
+
+    ks = _expand(kernel_size)
+    st = _expand(stride, default=ks)
+    pa = _expand(padding)
+    di = _expand(dilation)
+
+    torch._check(
+        self.ndim in (n_dim + 1, n_dim + 2),
+        lambda: f"Expected {n_dim + 1}D or {n_dim + 2}D input, got {self.ndim}D",
+    )
+
+    is_batched = self.ndim == n_dim + 2
+    if not is_batched:
+        self = self.unsqueeze(0)
+
+    input_sizes = list(self.shape[-n_dim:])
+    device = self.device
+
+    output_sizes = [
+        torch._meta_registrations.pooling_output_shape(
+            input_sizes[d], ks[d], pa[d], st[d], di[d], ceil_mode
+        )
+        for d in range(n_dim)
+    ]
+
+    # Pad with -inf so out-of-bounds positions never win the max. For integer
+    # types, iinfo.min is a valid data value, so padding with it causes ties
+    # in argmax that produce wrong indices. Promote to a wider type so the
+    # sentinel is strictly below any representable value in the original dtype.
+    dtype = self.dtype
+    promoted = False
+    if dtype is torch.bool:
+        fill_value = 0.0
+    elif dtype.is_floating_point:
+        fill_value = float("-inf")
+    else:
+        info = torch.iinfo(dtype)
+        if info.bits < 32:
+            self = self.to(torch.int32)
+        elif info.bits < 64:
+            self = self.to(torch.int64)
+        fill_value = float(info.min - 1) if info.bits < 64 else float(info.min)
+        promoted = True
+
+    # Compute asymmetric padding: left = pa[d], right may be larger for ceil_mode
+    pad_args: list[int] = []
+    for d in reversed(range(n_dim)):  # F.pad takes last dim first
+        left = pa[d]
+        needed = (output_sizes[d] - 1) * st[d] + (ks[d] - 1) * di[d] + 1
+        right = max(0, needed - (input_sizes[d] + 2 * pa[d])) + pa[d]
+        pad_args.extend([left, right])
+    x = F.pad(self, pad_args, value=fill_value)
+
+    # Build index tensor per spatial dim:
+    #   idx[out_pos, ker_pos] = out_pos * stride + ker_pos * dilation
+    # Reshape each for broadcasting into the Cartesian product of all dims
+    idx_tensors = []
+    for d in range(n_dim):
+        idx = (
+            torch.arange(output_sizes[d], device=device, dtype=torch.int64).unsqueeze(1)
+            * st[d]
+            + torch.arange(ks[d], device=device, dtype=torch.int64).unsqueeze(0) * di[d]
+        )
+        shape = [1] * (2 * n_dim)
+        shape[2 * d] = output_sizes[d]
+        shape[2 * d + 1] = ks[d]
+        idx_tensors.append(idx.reshape(shape))
+
+    # Advanced indexing gathers all pooling windows at once via broadcasting.
+    # Result: (N, C, out_0, k_0, out_1, k_1, ..., out_{n-1}, k_{n-1})
+    windows = x[(Ellipsis, *idx_tensors)]
+
+    # Permute to (N, C, out_0, ..., out_{n-1}, k_0, ..., k_{n-1})
+    n_batch = 2
+    perm = list(range(n_batch))
+    perm += [n_batch + 2 * d for d in range(n_dim)]
+    perm += [n_batch + 2 * d + 1 for d in range(n_dim)]
+    windows = windows.permute(perm)
+
+    # Flatten kernel dims and take the max
+    out_shape = list(windows.shape[: n_batch + n_dim])
+    windows = windows.reshape(*out_shape, -1)
+    values, local_argmax = windows.max(dim=-1)
+
+    # Convert local_argmax in [0, prod(ks)) to per-dim kernel offsets
+    kernel_pos = []
+    remaining = local_argmax
+    for d in range(n_dim):
+        divisor = 1
+        for dd in range(d + 1, n_dim):
+            divisor *= ks[dd]
+        kernel_pos.append(remaining // divisor)
+        remaining = remaining % divisor
+
+    # Compute flat index into the original (unpadded) input spatial volume
+    orig_coords = []
+    for d in range(n_dim):
+        shape = [1] * (n_batch + n_dim)
+        shape[n_batch + d] = output_sizes[d]
+        out_pos = torch.arange(
+            output_sizes[d], device=device, dtype=torch.int64
+        ).reshape(shape)
+        orig_coords.append(out_pos * st[d] + kernel_pos[d] * di[d] - pa[d])
+
+    flat_indices = orig_coords[0]
+    for d in range(1, n_dim):
+        flat_indices = flat_indices * input_sizes[d] + orig_coords[d]
+
+    if promoted:
+        values = values.to(dtype)
+
+    if not is_batched:
+        values = values.squeeze(0)
+        flat_indices = flat_indices.squeeze(0)
+
+    return values, flat_indices
+
+
+@register_decomposition(aten.max_pool2d_with_indices)
+@out_wrapper("out", "indices")
+def max_pool2d_with_indices(
+    self: Tensor,
+    kernel_size: list[int],
+    stride: list[int] = [],  # noqa: B006
+    padding: list[int] = [0],  # noqa: B006
+    dilation: list[int] = [1],  # noqa: B006
+    ceil_mode: bool = False,
+) -> tuple[Tensor, Tensor]:
+    return _max_pool_nd_with_indices(
+        self, kernel_size, stride, padding, dilation, ceil_mode, n_dim=2
+    )
+
+
+@register_decomposition(aten.max_pool3d_with_indices)
+@out_wrapper("out", "indices")
+def max_pool3d_with_indices(
+    self: Tensor,
+    kernel_size: list[int],
+    stride: list[int] = [],  # noqa: B006
+    padding: list[int] = [0],  # noqa: B006
+    dilation: list[int] = [1],  # noqa: B006
+    ceil_mode: bool = False,
+) -> tuple[Tensor, Tensor]:
+    return _max_pool_nd_with_indices(
+        self, kernel_size, stride, padding, dilation, ceil_mode, n_dim=3
+    )
+
+
 def _max_unpoolnd(
     self: TensorLike, indices: TensorLike, output_size: list[int], dim: int
 ):

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -893,6 +893,13 @@ def max_pool3d_with_indices(
         )
     if stride is None:
         stride = torch.jit.annotate(list[int], [])
+    if not torch.jit.is_scripting():
+        if input.is_cuda and torch.are_deterministic_algorithms_enabled():
+            return importlib.import_module(
+                "torch._decomp.decompositions"
+            ).max_pool3d_with_indices(
+                input, kernel_size, stride, padding, dilation, ceil_mode
+            )
     return torch._C._nn.max_pool3d_with_indices(
         input, kernel_size, stride, padding, dilation, ceil_mode
     )


### PR DESCRIPTION
## Summary

Add a pure-tensor-op forward decomposition for `max_pool2d_with_indices` and `max_pool3d_with_indices` so that autograd computes the backward deterministically, no `atomicAdd` needed.

This picks up the approach from #175411 by @WizardsForgeGames, fixing the lint failures that were blocking it (PYREFLY errors from tuple defaults on `list[int]` parameters).

A generic `_max_pool_nd_with_indices` helper handles both 2D and 3D pooling by:
1. Padding the input with `-inf` so out-of-bounds positions never win the max
2. Building index tensors per spatial dimension for stride/dilation offsets
3. Using advanced indexing to gather all pooling windows via broadcasting
4. Taking the max over flattened kernel dimensions
5. Converting the local argmax back to flat indices into the original input

Inductor is unaffected as it has its own optimized max_pool decompositions that take priority. These global decompositions live outside `core_aten_decompositions()`, so they're only used by non-inductor backends and `torch.export`.

## Changes vs #175411
- Default params use `list[int] = []` / `[0]` / `[1]` with `# noqa: B006` instead of tuples, fixes PYREFLY lint
- Rebased on current main

## Testing
Verified on NVIDIA RTX 5080 (SM 12.0), PyTorch 2.11.0+cu128:
- Forward correctness: exact match (values and indices) against native impl across 11 configs (2D/3D, asymmetric kernels, dilation, ceil_mode, unbatched)
- Backward determinism: passes with `torch.use_deterministic_algorithms(True)` on CUDA
- Gradient consistency: identical across 5 runs
- Lint: clean (`lintrunner` passes)

Fixes #85425

cc @mruberry @kurtamohler @jansel @mikaylagawarecki
