### PR TITLE
Remove stale Python  comments

### DIFF
--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -376,8 +376,7 @@ def get_closure(fn):
 # annotations on `eg``, but starting in Python 4.0, they will represented as
 # strings and no longer present. Furthermore, since the body of `eg` does
 # not reference those names, they do not appear in the list of closed over
-# variables. In Python 2.x, type annotations are in comments, leading to a
-# similar situation where their definitions are not available. We anticipate
+# variables. We anticipate
 # that most users will not run into this issue because their modules and
 # functions will be defined at a global scope like MyGlobalClass. In cases
 # where they are not, it is possible to work around issues by declaring the

--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -1201,9 +1201,9 @@ class Tensor(torch._C.TensorBase):
         return self.shape[0]
 
     def __iter__(self):
-        # NB: we use 'imap' and not 'map' here, so that in Python 2 we get a
-        # generator and don't eagerly perform all the indexes.  This could
-        # save us work, and also helps keep trace ordering deterministic
+        # NB: we use 'imap' and not 'map' here, so that we get a generator
+        # and don't eagerly perform all the indexes.  This could save us
+        # work, and also helps keep trace ordering deterministic
         # (e.g., if you zip(*hiddens), the eager map will force all the
         # indexes of hiddens[0] before hiddens[1], while the generator
         # map will interleave them.)
@@ -1364,8 +1364,6 @@ class Tensor(torch._C.TensorBase):
         :attr:`names` to the same length as ``self.dim()`` using names from the
         corresponding indices of ``self.names``.
 
-        Python 2 does not support Ellipsis but one may use a string literal
-        instead (``'...'``).
 
         Args:
             names (iterable of str): The desired names of the output tensor. May
@@ -1408,8 +1406,6 @@ class Tensor(torch._C.TensorBase):
         that are not mentioned in :attr:`names`, in the order that they appear
         in :attr:`self`.
 
-        Python 2 does not support Ellipsis but one may use a string literal
-        instead (``'...'``).
 
         Args:
             names (iterable of str): The desired dimension ordering of the

--- a/torch/ao/quantization/observer.py
+++ b/torch/ao/quantization/observer.py
@@ -144,7 +144,7 @@ def _with_callable_args(cls_or_self, **kwargs):
     return r.with_callable_args(**kwargs)
 
 
-ABC: Any = ABCMeta("ABC", (object,), {})  # compatible with Python 2 *and* 3:
+ABC: Any = ABCMeta("ABC", (object,), {})
 
 
 class ObserverBase(ABC, nn.Module):

--- a/torch/autograd/profiler_util.py
+++ b/torch/autograd/profiler_util.py
@@ -1174,7 +1174,6 @@ def _build_table(
     if append_node_id:
         headers.append("Node ID")
 
-    # Have to use a list because nonlocal is Py3 only...
     SPACING_SIZE = 2
     row_format_lst = [""]
     header_sep_lst = [""]
@@ -1235,7 +1234,6 @@ def _build_table(
     line_length = line_length_lst[0]
     add_column = None  # type: ignore[assignment]
 
-    # Have to use a list because nonlocal is Py3 only...
     result = []
 
     def append(s):

--- a/torch/backends/cudnn/rnn.py
+++ b/torch/backends/cudnn/rnn.py
@@ -46,8 +46,6 @@ class Unserializable:
         return self.inner
 
     def __getstate__(self):
-        # Note: can't return {}, because python2 won't call __setstate__
-        # if the value evaluates to False
         return "<unserializable>"
 
     def __setstate__(self, state):

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -654,7 +654,7 @@ class DistributedDataParallel(Module, Joinable):
         If you plan on using this module with a ``nccl`` backend or a ``gloo``
         backend (that uses Infiniband), together with a DataLoader that uses
         multiple workers, please change the multiprocessing start method to
-        ``forkserver`` (Python 3 only) or ``spawn``. Unfortunately
+        ``forkserver`` or ``spawn``. Unfortunately
         Gloo (that uses Infiniband) and NCCL2 are not fork safe, and you will
         likely experience deadlocks if you don't change this setting.
 

--- a/torch/nn/utils/spectral_norm.py
+++ b/torch/nn/utils/spectral_norm.py
@@ -185,8 +185,6 @@ class SpectralNorm:
         return fn
 
 
-# This is a top level class because Py2 pickle doesn't like inner class nor an
-# instancemethod.
 class SpectralNormLoadStateDictPreHook:
     # See docstring of SpectralNorm._version on the changes to spectral_norm.
     def __init__(self, fn) -> None:
@@ -244,8 +242,6 @@ class SpectralNormLoadStateDictPreHook:
                 state_dict[weight_key + "_v"] = v
 
 
-# This is a top level class because Py2 pickle doesn't like inner class nor an
-# instancemethod.
 class SpectralNormStateDictHook:
     # See docstring of SpectralNorm._version on the changes to spectral_norm.
     def __init__(self, fn) -> None:

--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -1384,7 +1384,7 @@ def load(
             second step is a no-op if the final location is CPU. When the ``mmap`` flag is set, instead of copying the
             tensor storages from disk to CPU memory in the first step, ``f`` is mapped, which means tensor storages
             will be lazily loaded when their data is accessed.
-        pickle_load_args: (Python 3 only) optional keyword arguments passed over to
+        pickle_load_args: optional keyword arguments passed over to
             :func:`pickle_module.load` and :func:`pickle_module.Unpickler`,
             only works if :attr:`weights_only=False`, e.g., :attr:`errors=...`.
 


### PR DESCRIPTION
This PR removes stale comments mentioning Python 2 and Python 3 because it is Python 3 only.