### PR TITLE
[mergebot] Allow facebook-github-tools bot to issue reverts

### DIFF
--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -2034,9 +2034,13 @@ def validate_revert(
     # For some reason, one can not be a member of private repo, only CONTRIBUTOR
     if pr.is_base_repo_private():
         allowed_reverters.append("CONTRIBUTOR")
-    # Special case the pytorch-auto-revert app, whose does not have association
-    # But should be able to issue revert command
-    if comment.author_url == "https://github.com/apps/pytorch-auto-revert":
+    # Special case GitHub Apps that don't have a repo association
+    # but should be able to issue revert commands
+    allowed_apps = {
+        "https://github.com/apps/pytorch-auto-revert",
+        "https://github.com/apps/facebook-github-tools",
+    }
+    if comment.author_url in allowed_apps:
         allowed_reverters.append("NONE")
 
     if author_association not in allowed_reverters:


### PR DESCRIPTION
## Summary
- The `facebook-github-tools` GitHub App issues `@pytorchbot revert` commands for internal reverts (e.g., #178808), but its `author_association` is `NONE` since it's not a repo collaborator
- `validate_revert()` in `trymerge.py` was only allowing `NONE` association for the `pytorch-auto-revert` app
- Add `facebook-github-tools` to the allowed apps set so it can issue reverts

Fixes: https://github.com/pytorch/pytorch/pull/178808#issuecomment-4174307909

## Test plan
- Existing `test_app_can_revert` validates the allowlist pattern works correctly
- The change follows the exact same mechanism as the existing `pytorch-auto-revert` exception: checking `comment.author_url` against known GitHub App URLs

Contributed with Claude.