### PR TITLE
fix distributed elastic and launcher tests

### DIFF
--- a/test/distributed/elastic/rendezvous/c10d_rendezvous_backend_test.py
+++ b/test/distributed/elastic/rendezvous/c10d_rendezvous_backend_test.py
@@ -168,7 +168,9 @@ class CreateBackendTest(TestCase):
     def test_create_backend_returns_backend_if_is_host_is_not_specified_and_store_already_exists(
         self,
     ) -> None:
-        TCPStore(  # type: ignore[call-arg]
+        # Need unused variable assignment below to keep the store alive for the
+        # duration of the test or GC is removing it
+        _store = TCPStore(  # type: ignore[call-arg] # noqa: F841
             self._expected_endpoint_host, self._expected_endpoint_port, is_master=True
         )
 

--- a/test/distributed/elastic/rendezvous/dynamic_rendezvous_test.py
+++ b/test/distributed/elastic/rendezvous/dynamic_rendezvous_test.py
@@ -1761,7 +1761,7 @@ class IntegrationTest(TestCase):
         handler2 = self._create_handler(
             min_nodes=1,
             max_nodes=2,
-            keep_alive_interval=timedelta(seconds=1),
+            keep_alive_interval=1,
         )
         handler3 = self._create_handler(
             min_nodes=1,

--- a/test/distributed/launcher/test_run.py
+++ b/test/distributed/launcher/test_run.py
@@ -253,7 +253,7 @@ class ElasticLaunchTest(TestCase):
     @skip_but_pass_in_sandcastle_if(
         TEST_WITH_DEV_DBG_ASAN, "test incompatible with dev/dbg asan"
     )
-    @patch("torch.cuda.is_available", return_value=False)
+    @patch("torch.accelerator.is_available", return_value=False)
     def test_nproc_launch_auto_configurations(self, _mock1):
         expected = torch._utils.cpu_count()
         self._test_nproc_launch_configuration("auto", expected)


### PR DESCRIPTION
## Motivation
To fix failing distributed elastic tests
## Changes
1) test/distributed/elastic/rendezvous/c10d_rendezvous_backend_test.py - Assign the TCPStore instance to _store to keep a reference alive and add a note for future maintainers.
2) test/distributed/elastic/rendezvous/dynamic_rendezvous_test.py -  test_redundancy_transition_to_wait_list_then_join_rendezvous, use keep_alive_interval = 1 instead of timedelta
3) test/distributed/launcher/test_run.py - nproc_type="auto" determines world size using torch.accelerator.is_available(), so test patch changed from cuda availability to accelerator available