### PR TITLE
Fix libtorch_memory_profiler build: replace dynamic_cast with virtual dispatch (#179116)

### DIFF
--- a/torch/csrc/autograd/anomaly_mode.cpp
+++ b/torch/csrc/autograd/anomaly_mode.cpp
@@ -74,4 +74,8 @@ void AnomalyMetadata::assign_parent(const std::shared_ptr<Node>& parent_node) {
   parent_ = parent_node;
 }
 
+std::vector<std::string> AnomalyMetadata::get_forward_traceback() {
+  return {};
+}
+
 } // namespace torch::autograd

--- a/torch/csrc/autograd/anomaly_mode.h
+++ b/torch/csrc/autograd/anomaly_mode.h
@@ -3,6 +3,7 @@
 #include <torch/csrc/Export.h>
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace torch::autograd {
 
@@ -62,6 +63,7 @@ struct TORCH_API AnomalyMetadata {
   virtual void store_stack();
   virtual void print_stack(const std::string& current_node_name);
   virtual void assign_parent(const std::shared_ptr<Node>& parent_node);
+  virtual std::vector<std::string> get_forward_traceback();
 
  private:
   std::string traceback_;

--- a/torch/csrc/autograd/python_anomaly_mode.cpp
+++ b/torch/csrc/autograd/python_anomaly_mode.cpp
@@ -92,6 +92,54 @@ void PyAnomalyMetadata::assign_parent(
   }
 }
 
+std::vector<std::string> PyAnomalyMetadata::get_forward_traceback() {
+  std::vector<std::string> result;
+  pybind11::gil_scoped_acquire gil;
+
+  // Save/restore exception state to avoid interfering with pending exceptions.
+  // This runs from a CUDA allocator callback where a Python exception may
+  // already be pending.
+  PyObject* exc_type = nullptr;
+  PyObject* exc_value = nullptr;
+  PyObject* exc_tb = nullptr;
+  PyErr_Fetch(&exc_type, &exc_value, &exc_tb);
+
+  PyObject* d = dict();
+  if (!d || !PyDict_Check(d)) {
+    PyErr_Restore(exc_type, exc_value, exc_tb);
+    return result;
+  }
+
+  PyObject* traceback = nullptr;
+  if (PyDict_GetItemStringRef(d, ANOMALY_TRACE_KEY, &traceback) < 0) {
+    PyErr_Clear();
+    PyErr_Restore(exc_type, exc_value, exc_tb);
+    return result;
+  }
+
+  if (!traceback || !PyList_Check(traceback)) {
+    Py_XDECREF(traceback);
+    PyErr_Restore(exc_type, exc_value, exc_tb);
+    return result;
+  }
+
+  Py_ssize_t size = PyList_Size(traceback);
+  result.reserve(size);
+  for (Py_ssize_t i = 0; i < size; ++i) {
+    PyObject* item = PyList_GetItem(traceback, i);
+    if (item && PyUnicode_Check(item)) {
+      const char* str = PyUnicode_AsUTF8(item);
+      if (str != nullptr) {
+        result.emplace_back(str);
+      }
+    }
+  }
+
+  Py_DECREF(traceback);
+  PyErr_Restore(exc_type, exc_value, exc_tb);
+  return result;
+}
+
 void _print_stack(
     PyObject* stack,
     const std::string& current_node_name,

--- a/torch/csrc/autograd/python_anomaly_mode.h
+++ b/torch/csrc/autograd/python_anomaly_mode.h
@@ -27,6 +27,7 @@ struct PyAnomalyMetadata : public AnomalyMetadata {
   void store_stack() override;
   void print_stack(const std::string& current_node_name) override;
   void assign_parent(const std::shared_ptr<Node>& parent_node) override;
+  std::vector<std::string> get_forward_traceback() override;
 
   PyObject* dict() {
     return dict_;

--- a/torch/csrc/profiler/python/combined_traceback.cpp
+++ b/torch/csrc/profiler/python/combined_traceback.cpp
@@ -1,5 +1,4 @@
 #include <torch/csrc/autograd/function.h>
-#include <torch/csrc/autograd/python_anomaly_mode.h>
 #include <torch/csrc/profiler/python/combined_traceback.h>
 #include <torch/csrc/python_headers.h>
 #include <torch/csrc/utils/pybind.h>
@@ -128,87 +127,16 @@ struct PythonTraceback : public CapturedTraceback::Python {
     }
   }
 
-  // Extract forward traceback from the current autograd node's anomaly
-  // metadata. Returns a vector of strings representing the forward stack trace,
-  // or empty if not available.
   std::vector<std::string> gatherForwardTraceback() override {
-    std::vector<std::string> result;
-
-    // Get the currently executing backward node
     auto node = torch::autograd::get_current_node();
     if (!node) {
-      return result;
+      return {};
     }
-
-    // Get metadata from the node.
-    // Note: metadata() may create new metadata if it doesn't exist, but we need
-    // to check the dict for ANOMALY_TRACE_KEY anyway to know if forward tracing
-    // was actually enabled during forward pass.
-    auto* base_metadata = node->metadata();
-    if (!base_metadata) {
-      return result;
-    }
-
-    // Check if the metadata is a Python anomaly metadata (which contains the
-    // dict)
-    auto* metadata =
-        dynamic_cast<torch::autograd::PyAnomalyMetadata*>(base_metadata);
+    auto* metadata = node->metadata();
     if (!metadata) {
-      return result;
+      return {};
     }
-
-    // Get the traceback from the metadata dict.
-    // This runs from a CUDA allocator callback, so a Python exception may
-    // already be pending (e.g. the forward function just raised). The compat
-    // shim for PyDict_GetItemRef on Python < 3.13 uses PyErr_Occurred() to
-    // distinguish "not found" from "error", so a stale pending exception would
-    // be misread as a lookup failure and then cleared, destroying the real
-    // exception. Save/restore the exception state to avoid that.
-    py::gil_scoped_acquire gil;
-
-    PyObject* exc_type = nullptr;
-    PyObject* exc_value = nullptr;
-    PyObject* exc_tb = nullptr;
-    PyErr_Fetch(&exc_type, &exc_value, &exc_tb);
-
-    PyObject* dict = metadata->dict();
-    if (!dict || !PyDict_Check(dict)) {
-      PyErr_Restore(exc_type, exc_value, exc_tb);
-      return result;
-    }
-
-    PyObject* traceback = nullptr;
-    if (PyDict_GetItemStringRef(
-            dict,
-            torch::autograd::PyAnomalyMetadata::ANOMALY_TRACE_KEY,
-            &traceback) < 0) {
-      PyErr_Clear();
-      PyErr_Restore(exc_type, exc_value, exc_tb);
-      return result;
-    }
-
-    if (!traceback || !PyList_Check(traceback)) {
-      Py_XDECREF(traceback);
-      PyErr_Restore(exc_type, exc_value, exc_tb);
-      return result;
-    }
-
-    // Convert Python list of strings to vector of strings
-    Py_ssize_t size = PyList_Size(traceback);
-    result.reserve(size);
-    for (Py_ssize_t i = 0; i < size; ++i) {
-      PyObject* item = PyList_GetItem(traceback, i); // borrowed reference
-      if (item && PyUnicode_Check(item)) {
-        const char* str = PyUnicode_AsUTF8(item);
-        if (str) {
-          result.emplace_back(str);
-        }
-      }
-    }
-
-    Py_DECREF(traceback);
-    PyErr_Restore(exc_type, exc_value, exc_tb);
-    return result;
+    return metadata->get_forward_traceback();
   }
 };
 


### PR DESCRIPTION
Summary:

The `libtorch_memory_profiler` target fails to link with `undefined symbol: typeinfo for torch::autograd::PyAnomalyMetadata`. This was caused by `combined_traceback.cpp` using `dynamic_cast<PyAnomalyMetadata*>` which requires RTTI typeinfo from `python_anomaly_mode.cpp` — a file not linked into this target.

Fix by adding a virtual `get_forward_traceback()` method to the `AnomalyMetadata` base class (which IS in `libtorch`), with `PyAnomalyMetadata` overriding it. This uses virtual dispatch instead of `dynamic_cast`, eliminating the RTTI dependency and decoupling `combined_traceback.cpp` from the Python binding layer.

Test Plan:
- `buck build --flagfile fbcode//mode/dev-nosan fbcode//caffe2:libtorch_memory_profiler` — previously failed, now succeeds
- `buck build --flagfile fbcode//mode/dev-nosan fbcode//caffe2:libtorch` — still builds successfully
- CI

Differential Revision: D99137494


