### PR TITLE
Check scale `numel` before dispatching MKLDNN for fp8 `scaled_mm`

### DIFF
--- a/aten/src/ATen/native/ScaledBlas.cpp
+++ b/aten/src/ATen/native/ScaledBlas.cpp
@@ -261,7 +261,7 @@ _scaled_mm_out_cpu(const Tensor& mat1, const Tensor& mat2,
           bool use_fast_accum,
           Tensor& out) {
 #if AT_MKLDNN_ENABLED() && !defined(__powerpc__)
-  if (at::globalContext().userEnabledMkldnn()) {
+  if (at::globalContext().userEnabledMkldnn() && scale_a.numel() == 1 && scale_b.numel() == 1) {
     bool mixed_dtype = mat1.scalar_type() != mat2.scalar_type();
     if ((!mixed_dtype && cpuinfo_has_x86_amx_int8()) ||
         (mixed_dtype && cpuinfo_has_x86_amx_fp16())) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #179118

As per
https://github.com/pytorch/pytorch/blob/d386e0bc6997651befa71c0143e57072ea28a446/aten/src/ATen/native/mkldnn/Linear.cpp#L516
MKLDNN scaled_mm only supports tensor-wise scaling. Rowwise tests have failed
in CI e.g. https://github.com/pytorch/pytorch/actions/runs/23883862339/job/69643425822#step:24:3402

Signed-off-by: Masaki Kozuki <mkozuki@nvidia.com>