### PR TITLE
[Test] Refactor GuardManagerTests to be device-generic

### DIFF
--- a/test/dynamo/test_guard_manager.py
+++ b/test/dynamo/test_guard_manager.py
@@ -2,7 +2,6 @@
 import abc
 import functools
 import inspect
-import unittest
 import weakref
 
 import torch
@@ -254,8 +253,12 @@ user_stack=None)
         guard = guards.DEFAULT_DEVICE(root, ["cpu device"], None)
         self.assertTrue(guard(foo))
 
+        if not torch.accelerator.is_available():
+            self.skipTest("Accelerator is not available")
+
         try:
-            torch.set_default_device("cuda")
+            device = torch.accelerator.current_accelerator()
+            torch.set_default_device(device)
             self.assertFalse(guard(foo))
         finally:
             torch.set_default_device(None)
@@ -445,10 +448,14 @@ user_stack=None)
         del x
         self.assertFalse(guard(weakref_x()))
 
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
     def test_call_function_no_args_guard(self):
+        if not torch.accelerator.is_available():
+            self.skipTest("Accelerator is not available")
+
         root = RootGuardManager()
-        x = torch.cuda.current_device()
+        device = torch.accelerator.current_accelerator()
+        # Use device.index which is device-agnostic (works on all accelerators)
+        x = device.index if device.index is not None else 0
         guard = guards.EQUALS_MATCH(root, x, [0], None)
         self.assertTrue(guard(0))
         self.assertFalse(guard(1))


### PR DESCRIPTION
Refactor test/dynamo/test_guard_manager.py to be device-generic by replacing hardcoded CUDA references with torch.accelerator API to enable tests to run on all accelerators including out of tree devices via PrivateUse1.                                              
                                                                                                                                                                                                                    
  Changes in test/dynamo/test_guard_manager.py:             
  - test_default_device_guard: Use torch.accelerator.current_accelerator() and torch.set_default_device(device)
  - test_call_function_no_args_guard: Use device.index for device-agnostic integer value
  - Remove @unittest.skipIf decorators in favor of runtime skipTest checks
  
Test Plan:

1. Verified test passes with TEST_CONFIG=cpu: OK (0.133s)
2. Verified test passes with TEST_CONFIG=cuda: OK (0.133s)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98 @mansiag05 @mikaylagawarecki @williamwen42 @mlazos 