### PR TITLE
[xpu][fix]Output tensor stride preservation in `addmv`

### DIFF
--- a/aten/src/ATen/native/mkldnn/xpu/Blas.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/Blas.cpp
@@ -379,15 +379,17 @@ Tensor& addmv_out(
   bool is_float64 =
       mat.scalar_type() == at::kDouble || vec.scalar_type() == at::kDouble;
   bool is_inplace = self.is_same(out);
+  // Compute into a temporary tensor to avoid modifying out's existing strides.
+  // Passing `out` directly to addmm_out would cause it to be resized from 1D
+  // (N,) to 2D (N,1) and back, which resets strides to contiguous (1,).
+  Tensor tmp = at::empty({mat.size(0), 1}, out.options());
   if (is_float64 && is_inplace) {
     Tensor self_v_copy = self_v.clone();
-    at::native::xpu::addmm_out(self_v_copy, mat, vec_v, beta, alpha, out);
-    out.resize_({mat.size(0)});
-    return out;
+    at::native::xpu::addmm_out(self_v_copy, mat, vec_v, beta, alpha, tmp);
+  } else {
+    at::native::xpu::addmm_out(self_v, mat, vec_v, beta, alpha, tmp);
   }
-
-  at::native::xpu::addmm_out(self_v, mat, vec_v, beta, alpha, out);
-  out.resize_({mat.size(0)});
+  out.copy_(tmp.view({mat.size(0)}));
   return out;
 }
 


### PR DESCRIPTION
Fix https://github.com/intel/torch-xpu-ops/issues/1893
This pull request improves the handling of output tensor strides in the `addmv_out` function to prevent unintentional stride changes when performing matrix-vector operations. Instead of writing directly to the output tensor, the computation is first performed in a temporary tensor, and the result is then copied back to the output tensor, preserving its original strides.

**Bug fix: Output tensor stride preservation**
* Modified `addmv_out` in `Blas.cpp` to compute results in a temporary tensor, avoiding stride resets that occur when resizing the output tensor from 1D to 2D and back. The result is then copied back to the output tensor to maintain its existing strides.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01 @gujinghui @EikanWang @fengyuan14 @guangyey