### PR TITLE
[Windows][ROCm] Fix missing native header includes causing DLL export…

### DIFF
--- a/aten/src/ATen/native/cuda/Blas.cpp
+++ b/aten/src/ATen/native/cuda/Blas.cpp
@@ -34,6 +34,7 @@
 #else
 #include <ATen/ops/_addmm_activation_native.h>
 #include <ATen/ops/_efficientzerotensor.h>
+#include <ATen/ops/_int_mm_native.h>
 #include <ATen/ops/_scaled_mm_native.h>
 #include <ATen/ops/_unsafe_view_native.h>
 #include <ATen/ops/abs.h>

--- a/aten/src/ATen/native/cuda/GroupedBlas.cpp
+++ b/aten/src/ATen/native/cuda/GroupedBlas.cpp
@@ -37,6 +37,7 @@
 #else
 #include <ATen/ops/_addmm_activation_native.h>
 #include <ATen/ops/_efficientzerotensor.h>
+#include <ATen/ops/_grouped_mm_native.h>
 #include <ATen/ops/_scaled_mm_native.h>
 #include <ATen/ops/_unsafe_view_native.h>
 #include <ATen/ops/abs.h>

--- a/aten/src/ATen/native/cuda/ScaledBlas.cpp
+++ b/aten/src/ATen/native/cuda/ScaledBlas.cpp
@@ -35,6 +35,7 @@
 #include <ATen/ops/_addmm_activation_native.h>
 #include <ATen/ops/_efficientzerotensor.h>
 #include <ATen/ops/_scaled_mm_native.h>
+#include <ATen/ops/_scaled_mm_v2_native.h>
 #include <ATen/ops/_unsafe_view_native.h>
 #include <ATen/ops/abs.h>
 #include <ATen/ops/addmm_native.h>


### PR DESCRIPTION
Three operations — `torch._int_mm`,` torch._grouped_mm`, and `torch._scaled_mm_v2` — crash immediately on Windows ROCm builds with an access violation.
The problem comes down to how Windows DLLs handle function visibility. Windows requires functions to be explicitly marked for export. In PyTorch, this happens through a somewhat indirect mechanism: when a source file includes a function's _native.h header, the compiler sees the TORCH_API declaration, recognizes it's defining that function locally, and automatically exports it.

Three source files were missing their corresponding headers:
- Blas.cpp was missing _int_mm_native.h
- GroupedBlas.cpp was missing _grouped_mm_native.h
- ScaledBlas.cpp was missing _scaled_mm_v2_native.h

Without these includes, the functions were compiled as internal symbols and never exported. Meanwhile, the auto-generated dispatch code tried to call them through import thunks that couldn't resolve — resulting in a jump to address zero and an immediate crash.

Fixes:
- https://github.com/ROCm/TheRock/issues/4086
- https://github.com/ROCm/rocm-libraries/issues/5205
- https://github.com/ROCm/TheRock/issues/4079

The fix was tested on all reproduction examples mentioned in the issues above, and all of them are passing now.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang