### PR TITLE
Generalize CurrentWorkStream to get correct out_stream on XPU.

### DIFF
--- a/test/test_xpu.py
+++ b/test/test_xpu.py
@@ -1476,6 +1476,125 @@ if __name__ == "__main__":
             self.assertTrue(z.is_xpu)
             self.assertEqual(z.cpu(), cpu)
 
+    def test_dlpack_exchange_api_current_work_stream_xpu(self):
+        """Test DLPack Exchange API current_work_stream returns non-null for XPU."""
+        from torch.utils import cpp_extension
+
+        self.assertTrue(hasattr(torch.Tensor, "__dlpack_c_exchange_api__"))
+        api_capsule = torch.Tensor.__dlpack_c_exchange_api__
+
+        tensor = torch.randn(8, device="xpu")
+
+        source = """
+        #include <torch/extension.h>
+        #include <ATen/dlpack.h>
+        #include <pybind11/pybind11.h>
+
+        namespace py = pybind11;
+
+        void test_xpu_current_work_stream(at::Tensor tensor, py::object api_obj) {
+            PyObject* api_capsule = api_obj.ptr();
+            TORCH_CHECK(PyCapsule_IsValid(api_capsule, "dlpack_exchange_api"),
+                        "Invalid DLPack exchange API capsule");
+            const DLPackExchangeAPI* api =
+                static_cast<const DLPackExchangeAPI*>(
+                    PyCapsule_GetPointer(api_capsule, "dlpack_exchange_api"));
+            TORCH_CHECK(api != nullptr, "API pointer is NULL");
+            TORCH_CHECK(api->current_work_stream != nullptr,
+                        "current_work_stream function pointer is NULL");
+
+            // Get the DL device info from the tensor
+            DLTensor dltensor;
+            {
+                std::unique_ptr<PyObject, decltype(&Py_DecRef)> py_obj(
+                    THPVariable_Wrap(tensor), &Py_DecRef);
+                int result = api->dltensor_from_py_object_no_sync(py_obj.get(), &dltensor);
+                TORCH_CHECK(result == 0, "dltensor_from_py_object_no_sync failed");
+            }
+
+            // Verify device type is kDLOneAPI (14)
+            TORCH_CHECK(dltensor.device.device_type == kDLOneAPI,
+                        "Expected kDLOneAPI (14), got ", dltensor.device.device_type);
+
+            // Test current_work_stream returns success and non-null stream
+            void* stream_out = nullptr;
+            int result = api->current_work_stream(
+                dltensor.device.device_type, dltensor.device.device_id, &stream_out);
+            TORCH_CHECK(result == 0,
+                        "current_work_stream failed with code ", result);
+            TORCH_CHECK(stream_out != nullptr,
+                        "current_work_stream returned NULL for XPU device - "
+                        "expected a valid stream handle");
+        }
+        """
+
+        module = cpp_extension.load_inline(
+            name="test_xpu_current_work_stream",
+            cpp_sources=[source],
+            functions=["test_xpu_current_work_stream"],
+            verbose=False,
+        )
+        module.test_xpu_current_work_stream(tensor, api_capsule)
+
+    def test_dlpack_exchange_api_stream_changes_with_xpu_stream(self):
+        """Test that current_work_stream reflects XPU stream context changes."""
+        from torch.utils import cpp_extension
+
+        api_capsule = torch.Tensor.__dlpack_c_exchange_api__
+        tensor = torch.randn(4, device="xpu")
+
+        source = """
+        #include <torch/extension.h>
+        #include <ATen/dlpack.h>
+        #include <pybind11/pybind11.h>
+
+        namespace py = pybind11;
+
+        uintptr_t get_xpu_work_stream(at::Tensor tensor, py::object api_obj) {
+            PyObject* api_capsule = api_obj.ptr();
+            const DLPackExchangeAPI* api =
+                static_cast<const DLPackExchangeAPI*>(
+                    PyCapsule_GetPointer(api_capsule, "dlpack_exchange_api"));
+            TORCH_CHECK(api != nullptr);
+
+            DLTensor dltensor;
+            {
+                std::unique_ptr<PyObject, decltype(&Py_DecRef)> py_obj(
+                    THPVariable_Wrap(tensor), &Py_DecRef);
+                int result = api->dltensor_from_py_object_no_sync(py_obj.get(), &dltensor);
+                TORCH_CHECK(result == 0);
+            }
+
+            void* stream_out = nullptr;
+            int result = api->current_work_stream(
+                dltensor.device.device_type, dltensor.device.device_id, &stream_out);
+            TORCH_CHECK(result == 0, "current_work_stream failed");
+            TORCH_CHECK(stream_out != nullptr, "stream is NULL");
+            return reinterpret_cast<uintptr_t>(stream_out);
+        }
+        """
+
+        module = cpp_extension.load_inline(
+            name="test_xpu_stream_changes",
+            cpp_sources=[source],
+            functions=["get_xpu_work_stream"],
+            verbose=False,
+        )
+
+        # Get stream handle on default stream
+        default_handle = module.get_xpu_work_stream(tensor, api_capsule)
+        self.assertNotEqual(default_handle, 0)
+
+        # Create a new stream and switch to it
+        new_stream = torch.xpu.Stream()
+        with torch.xpu.stream(new_stream):
+            new_handle = module.get_xpu_work_stream(tensor, api_capsule)
+            self.assertNotEqual(new_handle, default_handle)
+
+        # After exiting context, should be back on default stream
+        restored_handle = module.get_xpu_work_stream(tensor, api_capsule)
+        self.assertEqual(default_handle, restored_handle)
+
     def test_graph_is_current_stream_capturing(self):
         self.assertFalse(torch.xpu.is_current_stream_capturing())
         s = torch.xpu.Stream()

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -788,7 +788,6 @@ struct TorchDLPackExchangeAPI : public DLPackExchangeAPI {
         *out_stream = nullptr;
         return 0;
       }
-      *out_stream = nullptr;
       if (at::torchDeviceToDLDevice(*acc_type).device_type == device_type) {
         *out_stream =
             at::accelerator::getCurrentStream(device_id).native_handle();

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -783,9 +783,9 @@ struct TorchDLPackExchangeAPI : public DLPackExchangeAPI {
       int32_t device_id,
       void** out_stream) {
     try {
+      *out_stream = nullptr;
       const auto acc_type = at::accelerator::getAccelerator(false);
       if (!acc_type) {
-        *out_stream = nullptr;
         return 0;
       }
       if (at::torchDeviceToDLDevice(*acc_type).device_type == device_type) {

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -128,7 +128,6 @@
 
 #ifdef USE_XPU
 #include <ATen/native/transformers/xpu/sdp_utils.h>
-#include <c10/xpu/XPUStream.h>
 #ifndef _WIN32
 #include <torch/csrc/inductor/static_launcher/xpu.h>
 #endif
@@ -784,18 +783,13 @@ struct TorchDLPackExchangeAPI : public DLPackExchangeAPI {
       int32_t device_id,
       void** out_stream) {
     try {
-#ifdef USE_CUDA
-      if (device_type == kDLCUDA || device_type == kDLROCM) {
-        *out_stream = at::cuda::getCurrentCUDAStream(device_id).stream();
-        return 0;
-      }
+#if defined(USE_CUDA) || defined(USE_XPU)
+    if (at::accelerator::getAccelerator() && (device_type == kDLCUDA || device_type == kDLROCM || device_type == kDLOneAPI)) {
+      *out_stream = at::accelerator::getCurrentStream(device_id).native_handle();
+      return 0;
+    }
 #endif
-#ifdef USE_XPU
-      if (device_type == kDLOneAPI) {
-        *out_stream = &c10::xpu::getCurrentXPUStream(device_id).queue();
-        return 0;
-      }
-#endif
+
       // For CPU and other devices, return NULL (no stream concept)
       *out_stream = nullptr;
       return 0;

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -783,15 +783,16 @@ struct TorchDLPackExchangeAPI : public DLPackExchangeAPI {
       int32_t device_id,
       void** out_stream) {
     try {
-#if defined(USE_CUDA) || defined(USE_XPU)
-    if (at::accelerator::getAccelerator() && (device_type == kDLCUDA || device_type == kDLROCM || device_type == kDLOneAPI)) {
-      *out_stream = at::accelerator::getCurrentStream(device_id).native_handle();
-      return 0;
-    }
-#endif
-
-      // For CPU and other devices, return NULL (no stream concept)
+      const auto acc_type = at::accelerator::getAccelerator(false);
+      if (!acc_type) {
+        *out_stream = nullptr;
+        return 0;
+      }
       *out_stream = nullptr;
+      if (at::torchDeviceToDLDevice(*acc_type).device_type == device_type) {
+        *out_stream =
+            at::accelerator::getCurrentStream(device_id).native_handle();
+      }
       return 0;
     } catch (const std::exception& e) {
       PyErr_SetString(PyExc_RuntimeError, e.what());

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -128,6 +128,7 @@
 
 #ifdef USE_XPU
 #include <ATen/native/transformers/xpu/sdp_utils.h>
+#include <c10/xpu/XPUStream.h>
 #ifndef _WIN32
 #include <torch/csrc/inductor/static_launcher/xpu.h>
 #endif
@@ -777,7 +778,7 @@ struct TorchDLPackExchangeAPI : public DLPackExchangeAPI {
     }
   }
 
-  // Get current CUDA/ROCm work stream
+  // Get current CUDA/ROCm or XPU work stream
   static int CurrentWorkStream(
       DLDeviceType device_type,
       int32_t device_id,
@@ -786,6 +787,12 @@ struct TorchDLPackExchangeAPI : public DLPackExchangeAPI {
 #ifdef USE_CUDA
       if (device_type == kDLCUDA || device_type == kDLROCM) {
         *out_stream = at::cuda::getCurrentCUDAStream(device_id).stream();
+        return 0;
+      }
+#endif
+#ifdef USE_XPU
+      if (device_type == kDLOneAPI) {
+        *out_stream = &c10::xpu::getCurrentXPUStream(device_id).queue();
         return 0;
       }
 #endif


### PR DESCRIPTION
Previously only CUDA path was supported correctly, and XPU fell on the same path as CPU, which is incorrect in this context.

This PR introduces XPU-specific path for this.

Fixes: https://github.com/intel/torch-xpu-ops/issues/3074