### PR TITLE
[XPU] Fix autocast dtype validation to match CUDA behavior

### DIFF
--- a/test/dynamo/test_ctx_manager.py
+++ b/test/dynamo/test_ctx_manager.py
@@ -658,14 +658,14 @@ class CtxManagerTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(exported.device.index, 0)
         self.assertEqual(exported.dtype, torch.bfloat16)
 
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
+    @unittest.skipIf(device_type not in ("cuda", "xpu"), "requires cuda or xpu")
     def test_cuda_amp_autocast(self):
         class MyModule(torch.nn.Module):
             def forward(self, x):
-                a_float32 = torch.rand((8, 8), device="cuda")
-                b_float32 = torch.rand((8, 8), device="cuda")
+                a_float32 = torch.rand((8, 8), device=device_type)
+                b_float32 = torch.rand((8, 8), device=device_type)
 
-                with torch.autocast(device_type="cuda", dtype=torch.float64):
+                with torch.autocast(device_type=device_type, dtype=torch.float64):
                     c_float64 = torch.mm(a_float32, b_float32)
                 return c_float64
 
@@ -679,7 +679,7 @@ class CtxManagerTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(exported.device, real_device)
         self.assertEqual(exported.dtype, real_dtype)
 
-        self.assertEqual(exported.device.type, "cuda")
+        self.assertEqual(exported.device.type, device_type)
         self.assertEqual(exported.device.index, 0)
         self.assertEqual(exported.dtype, torch.float64)
 
@@ -932,15 +932,15 @@ class CtxManagerTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(out_32.device.type, "cpu")
         self.assertEqual(out_32.dtype, torch.float32)
 
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
+    @unittest.skipIf(device_type not in ("cuda", "xpu"), "requires cuda or xpu")
     def test_autocast_float64(self):
         class MyModule(torch.nn.Module):
             def forward(self, x):
-                a_float32 = torch.rand((8, 8), device="cuda")
-                b_float32 = torch.rand((8, 8), device="cuda")
-                d_float32 = torch.rand((8, 8), device="cuda")
+                a_float32 = torch.rand((8, 8), device=device_type)
+                b_float32 = torch.rand((8, 8), device=device_type)
+                d_float32 = torch.rand((8, 8), device=device_type)
 
-                with torch.autocast(device_type="cuda", dtype=torch.float64):
+                with torch.autocast(device_type=device_type, dtype=torch.float64):
                     e_float64 = torch.mm(a_float32, b_float32)
                     f_float64 = torch.mm(d_float32, e_float64)
                 return f_float64

--- a/torch/amp/autocast_mode.py
+++ b/torch/amp/autocast_mode.py
@@ -294,6 +294,8 @@ class autocast:
                     raise RuntimeError(
                         "Current CUDA Device does not support bfloat16. Please switch dtype to float16."
                     )
+            elif self.device == "xpu":
+                pass  # XPU supports bfloat16 without any special checks
             elif self.fast_dtype not in device_supported_dtypes:
                 error_message = (
                     f"In {device_name} autocast, but the target dtype is not supported. Disabling autocast.\n"


### PR DESCRIPTION
Fixes https://github.com/intel/torch-xpu-ops/issues/2714

Currently XPU in amp hits generic dtype allowlist that only permits `torch.float16` and `torch.bfloat16`. On the other hand CUDA only checks if given GPU architecture support `torch.bfloat16`, allowing other dtypes. Since all XPUs support `torch.bfloat16` we can add dedicated branch for XPU-flow to pass without extra validation. 

This patch fills the gap that was observed for tests using autocast to `torch.float64`, like:
```Python
import torch

a = torch.rand(3, 3, device="xpu")
b = torch.rand(3, 3, device="xpu")
with torch.autocast(device_type="xpu", dtype=torch.float64):
    ab = torch.mm(a, b)

assert ab.dtype == torch.float64
```
that without this patch would raise
```
UserWarning: In XPU autocast, but the target dtype is not supported. Disabling autocast.
XPU Autocast only supports dtypes of torch.bfloat16, torch.float16 currently.
```


Existing CUDA tests were extended to run also for XPU.

cc @mcarilli @ptrblck @leslie-fang-intel @jgong5 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98