### PR TITLE
[Inductor] Add runtime assertion support to FX wrapper backend (#179142)

### DIFF
--- a/test/inductor/test_fxir_backend.py
+++ b/test/inductor/test_fxir_backend.py
@@ -42,6 +42,9 @@ from torch.testing._internal.inductor_utils import (
 from torch.utils._sympy.functions import FloorDiv
 
 
+aten = torch.ops.aten
+
+
 try:
     from .test_control_flow import CondModels
 except ImportError:
@@ -57,10 +60,10 @@ if HAS_GPU:
 
 test_config = {
     "compile_threads": 1,
-    "alignment_asserts": False,
-    "size_asserts": False,
-    "scalar_asserts": False,
-    "nan_asserts": False,
+    "alignment_asserts": True,
+    "size_asserts": True,
+    "scalar_asserts": True,
+    "nan_asserts": True,
 }
 
 
@@ -72,6 +75,28 @@ class FxirTestCase(InductorTestCase):
 
     def _count_ops(self, gm: torch.fx.GraphModule, target: Callable) -> int:
         return len(gm.graph.find_nodes(op="call_function", target=target))
+
+    @staticmethod
+    def _get_assert_nodes(gm: torch.fx.GraphModule) -> set[torch.fx.Node]:
+        """Collect torch._check nodes and all their transitive input dependencies
+        that are used exclusively by assertion subgraphs."""
+        assert_nodes: set[torch.fx.Node] = set(
+            gm.graph.find_nodes(op="call_function", target=torch._check)
+        )
+        changed = True
+        while changed:
+            changed = False
+            for node in list(assert_nodes):
+                for arg in node.args:
+                    if (
+                        hasattr(arg, "op")
+                        and arg.op == "call_function"
+                        and arg not in assert_nodes
+                        and all(u in assert_nodes for u in arg.users)
+                    ):
+                        assert_nodes.add(arg)
+                        changed = True
+        return assert_nodes
 
     def _run_and_capture_graphs(self, opt, args) -> torch.fx.GraphModule:
         gms = []
@@ -124,6 +149,17 @@ class FxirTestCase(InductorTestCase):
 
         self.assertTrue(same(ref, result))
 
+        # Verify all non-assertion, non-triton call_function nodes have metadata.
+        for gm in gms:
+            assert_nodes = self._get_assert_nodes(gm)
+            for node in gm.graph.nodes:
+                if (
+                    node.op == "call_function"
+                    and node.target != triton_kernel_wrapper_mutation
+                    and node not in assert_nodes
+                ):
+                    self.assertTrue(node.meta.get("val", None) is not None)
+
         return gms
 
     @classmethod
@@ -147,6 +183,101 @@ class FxirTestCase(InductorTestCase):
     def test_basic(self):
         args = [torch.randn(8, device=self.device) for _ in range(2)]
         self._compile_and_check(torch.add, args)
+
+    def test_size_assert_check_nodes(self):
+        """
+        Test that size_asserts generates torch._check nodes in the FX graph
+        for validating input tensor sizes and strides.
+        """
+        args = [torch.randn(4, 8, device=self.device) for _ in range(2)]
+        (gm,) = self._compile_and_check(torch.add, args)
+
+        check_nodes = gm.graph.find_nodes(op="call_function", target=torch._check)
+        # Each 2D input gets 2 size checks + 2 stride checks = 4 per input.
+        # Two inputs → at least 8 torch._check nodes.
+        self.assertGreaterEqual(len(check_nodes), 8)
+
+        # Verify sym_size and sym_stride nodes are also present.
+        sym_size_nodes = gm.graph.find_nodes(
+            op="call_function", target=torch.ops.aten.sym_size.int
+        )
+        sym_stride_nodes = gm.graph.find_nodes(
+            op="call_function", target=torch.ops.aten.sym_stride.int
+        )
+        self.assertGreaterEqual(len(sym_size_nodes), 4)
+        self.assertGreaterEqual(len(sym_stride_nodes), 4)
+
+    def test_nan_assert_check_nodes(self):
+        """
+        Test that nan_asserts generates isnan/isinf → torch._check nodes
+        in the FX graph for runtime NaN/Inf validation.  The nan_asserts
+        config flag checks for both NaN and Inf, matching the existing
+        PythonWrapperCodegen.codegen_input_nan_asserts() behavior.
+        """
+        args = [torch.randn(4, 8, device=self.device) for _ in range(2)]
+        (gm,) = self._compile_and_check(torch.add, args)
+
+        # Each input gets isnan + isinf checks → 2 isnan + 2 isinf nodes.
+        isnan_nodes = gm.graph.find_nodes(
+            op="call_function", target=torch.ops.aten.isnan.default
+        )
+        isinf_nodes = gm.graph.find_nodes(
+            op="call_function", target=torch.ops.aten.isinf.default
+        )
+        self.assertGreaterEqual(len(isnan_nodes), 2)
+        self.assertGreaterEqual(len(isinf_nodes), 2)
+
+        # Each isnan/isinf feeds into any → item → not_ → torch._check.
+        any_nodes = gm.graph.find_nodes(op="call_function", target=aten.any.default)
+        self.assertGreaterEqual(len(any_nodes), 4)  # 2 isnan + 2 isinf
+
+    def test_alignment_assert_check_nodes(self):
+        """
+        Test that alignment_asserts generates data_ptr() % align == 0 →
+        torch._check nodes in the FX graph for runtime alignment validation.
+
+        Uses torch.mm because alignment asserts are emitted by ExternKernel.codegen(),
+        which runs for extern ops like mm but not for Triton-compiled elementwise ops.
+        """
+        args = [torch.randn(8, 8, device=self.device) for _ in range(2)]
+        (gm,) = self._compile_and_check(torch.mm, args, expected_num_triton_kernels=0)
+
+        # Alignment checks use call_method("data_ptr") on output buffers.
+        data_ptr_nodes = [
+            n
+            for n in gm.graph.nodes
+            if n.op == "call_method" and n.target == "data_ptr"
+        ]
+        # The output buffer of torch.mm gets an alignment check.
+        self.assertGreaterEqual(len(data_ptr_nodes), 1)
+
+    def test_size_assert_fails_on_wrong_shape(self):
+        """Compile with one shape, run with a different shape → assertion fires."""
+        args = [torch.randn(4, 8, device=self.device) for _ in range(2)]
+        (gm,) = self._compile_and_check(torch.add, args)
+
+        # Run with wrong shape — torch._check should raise
+        wrong_args = [torch.randn(4, 16, device=self.device) for _ in range(2)]
+        with self.assertRaises(RuntimeError):
+            gm(*wrong_args)
+
+    def test_nan_assert_fails_on_nan(self):
+        """NaN input triggers the nan_assert check."""
+        args = [torch.randn(8, device=self.device) for _ in range(2)]
+        (gm,) = self._compile_and_check(torch.add, args)
+
+        nan_input = torch.full((8,), float("nan"), device=self.device)
+        with self.assertRaises(RuntimeError):
+            gm(nan_input, args[1])
+
+    def test_nan_assert_fails_on_inf(self):
+        """Inf input triggers the nan_assert check (checks both NaN and Inf)."""
+        args = [torch.randn(8, device=self.device) for _ in range(2)]
+        (gm,) = self._compile_and_check(torch.add, args)
+
+        inf_input = torch.full((8,), float("inf"), device=self.device)
+        with self.assertRaises(RuntimeError):
+            gm(inf_input, args[1])
 
     def test_device_type(self):
         """
@@ -857,10 +988,13 @@ class AOTFxirTestCase(InductorTestCase):
             flat_args, _ = pytree.tree_flatten(inp)
             self.assertTrue(same(model(*inp), gm(*flat_args)))
 
+            # Verify all non-assertion call_function nodes have metadata.
+            assert_nodes = FxirTestCase._get_assert_nodes(gm)
             for node in gm.graph.nodes:
                 if (
                     node.op == "call_function"
                     and node.target != triton_kernel_wrapper_mutation
+                    and node not in assert_nodes
                 ):
                     self.assertTrue(node.meta.get("val", None) is not None)
 
@@ -1003,8 +1137,8 @@ class AOTFxirTestCase(InductorTestCase):
         inp = (torch.randn((5, 4), device=self.device),)
         gm = self.check(M().to(self.device), inp, dynamic_shapes=dynamic_shapes)
 
-        # Check for dynamic size ops.
-        self.assertEqual(
+        # Check for dynamic size ops (size_asserts may add extra sym_size nodes).
+        self.assertGreaterEqual(
             len(
                 gm.graph.find_nodes(
                     op="call_function", target=torch.ops.aten.sym_size.int
@@ -1033,18 +1167,20 @@ class AOTFxirTestCase(InductorTestCase):
         (x, y) = [torch.randn(8, device=self.device) for _ in range(2)]
         gm = self.check(M(), (pred, x, y))
 
-        # Check the graph.
-        self.assertExpectedInline(
-            gm.code.strip(),
-            """\
-def forward(self, arg0_1, arg1_1, arg2_1):
-    true_graph_0 = self.true_graph_0
-    false_graph_0 = self.false_graph_0
-    cond = torch.ops.higher_order.cond(arg0_1, true_graph_0, false_graph_0, (arg1_1, arg2_1));  arg0_1 = true_graph_0 = false_graph_0 = arg1_1 = arg2_1 = None
-    buf1 = cond[0]
-    buf2 = cond[1];  cond = None
-    return [buf1, buf2]""",
+        # Check the graph has the expected cond structure.
+        cond_nodes = gm.graph.find_nodes(
+            op="call_function", target=torch.ops.higher_order.cond
         )
+        self.assertEqual(len(cond_nodes), 1)
+
+        # Verify cond result unpacking.
+        cond_node = cond_nodes[0]
+        getitem_users = [u for u in cond_node.users if u.target == operator.getitem]
+        self.assertEqual(len(getitem_users), 2)
+
+        # Verify subgraphs are passed correctly.
+        self.assertEqual(cond_node.args[1], gm.true_graph_0)
+        self.assertEqual(cond_node.args[2], gm.false_graph_0)
 
     def test_dims_dynamic_outer_static_padded_inner(self):
         """

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -757,9 +757,10 @@ def check_shape(
 def check_nan(buffer: IndentedBuffer, var: CSEVariableType) -> None:
     backend = get_current_backend()
     if backend == "triton":
+        assert_fn = V.kernel.assert_function
         msg = "NaN or Inf found"
         buffer.writeline(
-            f"tl.device_assert(({var} == {var}) & ({var} != float('inf')) & ({var} != float('-inf')), '{msg}')"
+            f"{assert_fn}(({var} == {var}) & ({var} != float('inf')) & ({var} != float('-inf')), '{msg}')"
         )
 
 

--- a/torch/_inductor/codegen/multi_kernel.py
+++ b/torch/_inductor/codegen/multi_kernel.py
@@ -248,6 +248,8 @@ class MultiKernel:
             V.graph.wrapper_code.generate_workspace_deallocation(ws)
 
     def codegen_nan_check(self):
+        from .wrapper import NanAssertLine
+
         wrapper = V.graph.wrapper_code
         seen: OrderedSet[str] = OrderedSet()
         for k in self.kernels:
@@ -257,10 +259,7 @@ class MultiKernel:
                     continue
                 seen.add(arg)
                 if isinstance(precompile_arg, TensorArg):
-                    line = f"assert not {arg}.isnan().any().item()"
-                    wrapper.writeline(line)
-                    line = f"assert not {arg}.isinf().any().item()"
-                    wrapper.writeline(line)
+                    wrapper.writeline(NanAssertLine(wrapper=wrapper, name=arg))
 
     @property
     def removed_buffers(self):

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -6061,6 +6061,8 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             self.deallocate_workspaces()
 
     def codegen_nan_check(self) -> None:
+        from .wrapper import NanAssertLine
+
         wrapper = V.graph.wrapper_code
         _, call_args, arg_signatures, _ = self.args.python_argdefs()
         for arg, arg_signature in zip(call_args, arg_signatures):
@@ -6070,10 +6072,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                         f'AOTI_TORCH_ERROR_CODE_CHECK(aoti_torch_check_inf_and_nan("{arg}", {arg}));'
                     )
                 else:
-                    line = f"assert not {arg}.isnan().any().item()"
-                    wrapper.writeline(line)
-                    line = f"assert not {arg}.isinf().any().item()"
-                    wrapper.writeline(line)
+                    wrapper.writeline(NanAssertLine(wrapper=wrapper, name=arg))
 
     def create_cse_var(self, *args, **kwargs) -> TritonCSEVariable:
         return TritonCSEVariable(*args, **kwargs)

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -524,6 +524,84 @@ class CommentLine(WrapperLine):
 
 
 @dataclasses.dataclass
+class SizeAssertLine(WrapperLine):
+    wrapper: PythonWrapperCodegen
+    name: str
+    size: list[sympy.Expr]
+    stride: list[sympy.Expr]
+    op_name: str | None = None
+
+    def codegen(self, code: IndentedBuffer) -> None:
+        size_str = self.wrapper.codegen_python_shape_tuple(self.size)
+        stride_str = self.wrapper.codegen_python_shape_tuple(self.stride)
+        if self.op_name is not None:
+            code.writeline(
+                f"assert_size_stride({self.name}, {size_str}, {stride_str}, {self.op_name!r})"
+            )
+        else:
+            code.writeline(f"assert_size_stride({self.name}, {size_str}, {stride_str})")
+
+    @staticmethod
+    def codegen_fx(converter: FxConverter) -> FxConversionFunc:
+        return converter._generate_size_assert
+
+
+@dataclasses.dataclass
+class AlignmentAssertLine(WrapperLine):
+    wrapper: PythonWrapperCodegen
+    name: str
+    align_bytes: int
+    op_name: str | None = None
+
+    def codegen(self, code: IndentedBuffer) -> None:
+        code.writeline(
+            f"assert_alignment({self.name}, {self.align_bytes}, {self.op_name!r})"
+        )
+
+    @staticmethod
+    def codegen_fx(converter: FxConverter) -> FxConversionFunc:
+        return converter._generate_alignment_assert
+
+
+@dataclasses.dataclass
+class NanAssertLine(WrapperLine):
+    """
+    Checks for both NaN and Inf values.  This matches the existing behavior of
+    PythonWrapperCodegen.codegen_input_nan_asserts() which checks both despite
+    the config flag being named ``nan_asserts``.
+    """
+
+    wrapper: PythonWrapperCodegen
+    name: str
+
+    def codegen(self, code: IndentedBuffer) -> None:
+        code.writeline(f"assert not {self.name}.isnan().any().item()")
+        code.writeline(f"assert not {self.name}.isinf().any().item()")
+
+    @staticmethod
+    def codegen_fx(converter: FxConverter) -> FxConversionFunc:
+        return converter._generate_nan_assert
+
+
+@dataclasses.dataclass
+class ScalarAssertLine(WrapperLine):
+    wrapper: PythonWrapperCodegen
+    scalar: sympy.Basic
+    msg: str
+    output_name: str
+
+    def codegen(self, code: IndentedBuffer) -> None:
+        sizevar = self.wrapper.codegen_python_sizevar(self.scalar, simplify=False)
+        code.writeline(f"if not ({sizevar}):")
+        code.writeline(f"    raise RuntimeError({repr(self.msg)})")
+        code.writeline(f"{self.output_name} = None")
+
+    @staticmethod
+    def codegen_fx(converter: FxConverter) -> FxConversionFunc:
+        return converter._generate_scalar_assert
+
+
+@dataclasses.dataclass
 class DynamicScalarLine(WrapperLine):
     wrapper: PythonWrapperCodegen
     node: ir.DynamicScalar
@@ -1229,7 +1307,9 @@ class PythonWrapperCodegen(CodeGen):
 
     def __init__(self):
         super().__init__()
-        self._pending_input_asserts: dict[str, tuple[str, str]] = {}
+        self._pending_input_asserts: dict[
+            str, tuple[list[sympy.Expr], list[sympy.Expr]]
+        ] = {}
         self._pending_alignment_copies: OrderedSet[str] = OrderedSet()
         self._names_iter: Iterator[int] = count()
         self.args_to_buffers: dict[
@@ -1577,9 +1657,11 @@ class PythonWrapperCodegen(CodeGen):
             # comparing strides for 0 size tensor is tricky. Ignore them for now.
             if sympy_product(buf.get_size()) == 0:
                 continue
-            size = self.codegen_python_shape_tuple(buf.get_size())
-            stride = self.codegen_python_shape_tuple(buf.get_stride())
-            self._pending_input_asserts[name] = (size, stride)
+
+            self._pending_input_asserts[name] = (
+                list(buf.get_size()),
+                list(buf.get_stride()),
+            )
 
     def codegen_input_nan_asserts(self) -> None:
         self.prefix.writeline("# make sure graph inputs are not nan/inf")
@@ -1679,7 +1761,14 @@ class PythonWrapperCodegen(CodeGen):
         for name in input_names:
             if name in self._pending_input_asserts:
                 size, stride = self._pending_input_asserts.pop(name)
-                self.writeline(AssertSizeStrideLine(name, size, stride))
+                self.writeline(
+                    SizeAssertLine(
+                        wrapper=self,
+                        name=name,
+                        size=size,
+                        stride=stride,
+                    )
+                )
 
     def register_alignment_check_inputs(self) -> None:
         """Populate pending alignment copies for non-mutated inputs.
@@ -2083,7 +2172,17 @@ class PythonWrapperCodegen(CodeGen):
 
             # At this point, we shouldn't generate any new memory planning lines.
             # Override writeline to point at the wrapper call, in case it gets called.
-            with self.set_writeline(self.wrapper_call.writeline):
+            # Use a wrapper that handles WrapperLine objects emitted during codegen
+            # (e.g., SizeAssertLine from codegen_size_asserts called via
+            # ExternKernelMultiOutLine) by calling their codegen method directly.
+            def _writeline_for_codegen(line):  # type: ignore[no-untyped-def]
+                if isinstance(line, WrapperLine):
+                    # pyrefly: ignore [missing-attribute]
+                    line.codegen(self.wrapper_call)
+                else:
+                    self.wrapper_call.writeline(line)
+
+            with self.set_writeline(_writeline_for_codegen):
                 for line in self.lines:
                     if isinstance(line, WrapperLine):
                         # pyrefly: ignore [missing-attribute]

--- a/torch/_inductor/codegen/wrapper_fxir.py
+++ b/torch/_inductor/codegen/wrapper_fxir.py
@@ -40,7 +40,7 @@ from torch.utils._sympy.solve import try_solve
 
 from .. import config, ir
 from ..runtime.triton_compat import Config
-from ..utils import cache_property_on_self, LineContext, ValueWithLineMap
+from ..utils import cache_property_on_self, LineContext, sympy_product, ValueWithLineMap
 from .common import (
     CodegenSymbol,
     FileBackedGraphModule,
@@ -48,6 +48,7 @@ from .common import (
     WorkspaceZeroMode,
 )
 from .wrapper import (
+    AlignmentAssertLine,
     AllocateLine,
     BufferLike,
     CommentLine,
@@ -66,11 +67,14 @@ from .wrapper import (
     KernelDefinitionLine,
     Line,
     MultiOutputLine,
+    NanAssertLine,
     NullLine,
     PythonWrapperCodegen,
     ReinterpretLine,
     ReuseLine,
+    ScalarAssertLine,
     ScatterFallbackLine,
+    SizeAssertLine,
     SubgraphPythonWrapperCodegen,
     SymbolicCallArg,
     SymbolicCallArgLine,
@@ -231,6 +235,41 @@ class WrapperFxCodegen(PythonWrapperCodegen):
         Override this behavior to generate prologues for FX subgraphs.
         """
         PythonWrapperCodegen.write_header(self)
+
+    def codegen_input_size_asserts(self) -> None:
+        """FXIR emits size asserts as WrapperLine objects immediately.
+
+        The base class defers input size asserts via _pending_input_asserts to
+        avoid blocking GPU kernel launches. FXIR builds a graph, so deferral is
+        unnecessary — emit SizeAssertLine objects directly."""
+        for name, buf in self.get_graph_inputs().items():
+            if isinstance(buf, (sympy.Expr, ir.TorchBindObject)):
+                continue
+            if sympy_product(buf.get_size()) == 0:
+                continue
+            self.writeline(
+                SizeAssertLine(
+                    wrapper=self,
+                    name=name,
+                    size=list(buf.get_size()),
+                    stride=list(buf.get_stride()),
+                )
+            )
+
+    def codegen_input_nan_asserts(self) -> None:
+        """FXIR emits nan/inf asserts as WrapperLine objects.
+
+        The base class writes text to self.prefix, which is ignored by the FX
+        converter. Override to emit NanAssertLine objects into self.lines."""
+        for name, buf in self.get_graph_inputs().items():
+            if isinstance(buf, (sympy.Expr, ir.TorchBindObject)):
+                continue
+            self.writeline(
+                NanAssertLine(
+                    wrapper=self,
+                    name=name,
+                )
+            )
 
     def register_alignment_check_inputs(self) -> None:
         """FXIR does not emit deferred alignment copies.
@@ -586,6 +625,14 @@ class FxConverter:
         assert graph is not None
         return self.subgm_getattrs[graph.name]
 
+    # Assertion line types that involve data-dependent operations (e.g.,
+    # data_ptr(), item()) which are incompatible with the fake-tensor
+    # metadata hook.  These are processed outside the hook context.
+    _DEFERRED_ASSERT_LINE_TYPES: tuple[type[WrapperLine], ...] = (
+        AlignmentAssertLine,
+        NanAssertLine,
+    )
+
     def generate(self) -> torch.fx.GraphModule:
         """
         Main entrypoint for FX codegen.
@@ -593,6 +640,8 @@ class FxConverter:
         self._generate_graph_inputs()
         self._generate_graph_constants()
         self._generate_subgm_getattrs()
+
+        deferred_lines: list[tuple[WrapperLine, torch.fx.Node | None]] = []
 
         with _set_node_metadata_hook(
             self.gm,
@@ -602,7 +651,13 @@ class FxConverter:
 
             # Generate FX IR from Wrapper IR lines.
             for line in self.lines:
-                if isinstance(line, WrapperLine):
+                if isinstance(line, self._DEFERRED_ASSERT_LINE_TYPES):
+                    # Snapshot the buffer node now — it may be freed
+                    # (removed from buffer_to_node) before deferred
+                    # processing runs.
+                    buffer_node = self.buffer_to_node.get(line.name)
+                    deferred_lines.append((line, buffer_node))
+                elif isinstance(line, WrapperLine):
                     line.codegen_fx(self)(line)
                 elif isinstance(line, LineContext):
                     # Ignore line context in FX IR.
@@ -620,6 +675,14 @@ class FxConverter:
                     )
 
             output = self._generate_outputs()
+
+        # Process assertion lines that use data-dependent operations outside
+        # the metadata hook, since fake tensors cannot evaluate data_ptr()
+        # or item().
+        for line, buffer_node in deferred_lines:
+            if buffer_node is not None:
+                self.buffer_to_node[line.name] = buffer_node
+            line.codegen_fx(self)(line)
 
         self.gm.graph.output(output)
         self.gm.recompile()
@@ -727,6 +790,65 @@ class FxConverter:
     def _generate_comment(self, line: WrapperLine) -> None:
         assert isinstance(line, CommentLine)
         # We ignore comments in FX IR.
+
+    def _generate_size_assert(self, line: WrapperLine) -> None:
+        assert isinstance(line, SizeAssertLine)
+        buffer_node = self.buffer_to_node.get(line.name)
+        if buffer_node is None:
+            return
+
+        graph = self.gm.graph
+        for dim, expected_size in enumerate(line.size):
+            actual = graph.call_function(aten.sym_size.int, (buffer_node, dim))
+            expected = self._generate_sym_node(expected_size)
+            eq = graph.call_function(operator.eq, (actual, expected))
+            graph.call_function(torch._check, (eq,))
+
+        for dim, expected_stride in enumerate(line.stride):
+            actual = graph.call_function(aten.sym_stride.int, (buffer_node, dim))
+            expected = self._generate_sym_node(expected_stride)
+            eq = graph.call_function(operator.eq, (actual, expected))
+            graph.call_function(torch._check, (eq,))
+
+    def _generate_alignment_assert(self, line: WrapperLine) -> None:
+        assert isinstance(line, AlignmentAssertLine)
+        buffer_node = self.buffer_to_node.get(line.name)
+        if buffer_node is None:
+            return
+
+        graph = self.gm.graph
+        # data_ptr() is a Tensor method (not an ATen op) but works as
+        # an FX call_method node for eager interpretation.
+        data_ptr = graph.call_method("data_ptr", (buffer_node,))
+        mod = graph.call_function(operator.mod, (data_ptr, line.align_bytes))
+        eq = graph.call_function(operator.eq, (mod, 0))
+        graph.call_function(torch._check, (eq,))
+
+    def _generate_nan_assert(self, line: WrapperLine) -> None:
+        assert isinstance(line, NanAssertLine)
+        buffer_node = self.buffer_to_node.get(line.name)
+        if buffer_node is None:
+            return
+
+        graph = self.gm.graph
+        # assert not tensor.isnan().any().item()
+        has_nan = graph.call_function(aten.isnan.default, (buffer_node,))
+        any_nan = graph.call_function(aten.any.default, (has_nan,))
+        any_nan_scalar = graph.call_function(aten.item.default, (any_nan,))
+        no_nan = graph.call_function(operator.not_, (any_nan_scalar,))
+        graph.call_function(torch._check, (no_nan,))
+
+        # assert not tensor.isinf().any().item()
+        has_inf = graph.call_function(aten.isinf.default, (buffer_node,))
+        any_inf = graph.call_function(aten.any.default, (has_inf,))
+        any_inf_scalar = graph.call_function(aten.item.default, (any_inf,))
+        no_inf = graph.call_function(operator.not_, (any_inf_scalar,))
+        graph.call_function(torch._check, (no_inf,))
+
+    def _generate_scalar_assert(self, line: WrapperLine) -> None:
+        assert isinstance(line, ScalarAssertLine)
+        condition_node = self._generate_sym_node(line.scalar)
+        self.gm.graph.call_function(torch._check, (condition_node,))
 
     def _generate_dynamic_scalar(self, line: WrapperLine) -> None:
         assert isinstance(line, DynamicScalarLine)

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -7067,21 +7067,35 @@ class ExternKernel(InputsKernel):
             # comparing strides for 0 size tensor is tricky. Ignore them for now.
             if sympy_product(self.get_size()) == 0:
                 return
-            size = V.graph.wrapper_code.codegen_shape_tuple(self.get_size())
-            stride = V.graph.wrapper_code.codegen_shape_tuple(self.get_stride())
-            op_name = self.get_op_name()
+            # Local import: wrapper.py imports ir.py, so module-level would be circular.
+            from .codegen.wrapper import SizeAssertLine
+
             wrapper.writeline(
-                f"assert_size_stride({self.get_name()}, {size}, {stride}, {op_name!r})"
+                SizeAssertLine(
+                    wrapper=wrapper,
+                    name=self.get_name(),
+                    size=list(self.get_size()),
+                    stride=list(self.get_stride()),
+                    op_name=self.get_op_name(),
+                )
             )
 
     def codegen_alignment_asserts(self, wrapper: PythonWrapperCodegen) -> None:
         if config.alignment_asserts and not V.graph.cpp_wrapper:
+            # Local import: wrapper.py imports ir.py, so module-level would be circular.
+            from .codegen.wrapper import AlignmentAssertLine
+
             name = self.get_name()
             aligned = name not in V.graph.unaligned_buffers
             op_name = self.get_op_name()
             if aligned:
                 wrapper.writeline(
-                    f"assert_alignment({name}, {GPU_ALIGN_BYTES}, {op_name!r})"
+                    AlignmentAssertLine(
+                        wrapper=wrapper,
+                        name=name,
+                        align_bytes=GPU_ALIGN_BYTES,
+                        op_name=op_name,
+                    )
                 )
             else:
                 wrapper.writeline(
@@ -8333,8 +8347,17 @@ class AssertScalar(ExternKernel):
         # that it's true).  But we're code generating the actual runtime assert here!!
         symbol = next(iter(self.get_free_symbol_uses(unbacked_only=False)))
         if V.graph.fx_wrapper:
-            # TODO fix
-            pass
+            # Local import: wrapper.py imports ir.py, so module-level would be circular.
+            from .codegen.wrapper import ScalarAssertLine
+
+            wrapper.writeline(
+                ScalarAssertLine(
+                    wrapper=wrapper,
+                    scalar=self.scalar,
+                    msg=self.msg,
+                    output_name=self.get_name(),
+                )
+            )
         elif V.graph.cpp_wrapper:
             symbol_str = f"std::to_string({symbol})"
             sizevar = V.graph.wrapper_code.codegen_cpp_sizevar(


### PR DESCRIPTION
Summary:

Add WrapperLine subclasses and FX converter methods so that backends using
FX IR (like MTIA) get the same runtime assertion support as the Python and
C++ wrapper backends.

New WrapperLine types and their FX IR generation:
- `SizeAssertLine`: size/stride validation via `sym_size`/`sym_stride` → `eq` → `torch._check`
- `AlignmentAssertLine`: alignment validation via `call_method("data_ptr")` → `mod` → `eq` → `torch._check`
- `NanAssertLine`: NaN/Inf validation via `isnan`/`isinf` → `any` → `item` → `not_` → `torch._check`.
  Checks both NaN and Inf, matching existing `codegen_input_nan_asserts()` behavior.
- `ScalarAssertLine`: unbacked symbol assertion via sympy condition → `torch._check`.
  Replaces the `# TODO fix` pass in `AssertScalar.codegen()` for FX wrapper.

Base class consolidation: `codegen_input_size_asserts()` and `codegen_input_nan_asserts()`
in `PythonWrapperCodegen` now emit `WrapperLine` objects via `self.writeline()`,
shared by all backends (Python text, FX IR). No overrides needed in `WrapperFxCodegen`.

`ir.py`: `codegen_size_asserts()`, `codegen_alignment_asserts()`, and
`AssertScalar.codegen()` emit WrapperLine objects for FX compatibility.
Local imports used to avoid circular imports (wrapper.py imports ir.py).

Test Plan:
- All non-GPU tests pass in buck2 (GPU tests skip on ASAN build)
- `test_size_assert_check_nodes`: verifies sym_size/sym_stride/torch._check nodes
- `test_nan_assert_check_nodes`: verifies isnan/isinf/any/torch._check nodes
- `test_alignment_assert_check_nodes`: verifies data_ptr call_method nodes
- `test_size_assert_fails_on_wrong_shape`: wrong shape → RuntimeError
- `test_nan_assert_fails_on_nan`: NaN input → RuntimeError
- `test_nan_assert_fails_on_inf`: Inf input → RuntimeError
- All 4 assert types enabled in test config
- Assert nodes extracted to `_get_assert_nodes()` helper using `find_nodes` for O(1) initial collection

Reviewed By: blaine-rister

Differential Revision: D98959391


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo