### PR TITLE
Change mutable symm_mem ops to return void instead of aliased tensors

### DIFF
--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -1257,10 +1257,10 @@ This class does not support ``__members__`` property.)");
           "memset32",
           [](at::Tensor& input, int64_t offset, int64_t val, int64_t count) {
             // The range of `val` is checked inside the op
-            auto op = c10::Dispatcher::singleton()
-                          .findSchemaOrThrow("symm_mem::memset32_", "")
-                          .typed<void(
-                              at::Tensor&, int64_t, int64_t, int64_t)>();
+            auto op =
+                c10::Dispatcher::singleton()
+                    .findSchemaOrThrow("symm_mem::memset32_", "")
+                    .typed<void(at::Tensor&, int64_t, int64_t, int64_t)>();
             op.call(input, offset, val, count);
           },
           py::arg("input"),

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -1247,8 +1247,8 @@ This class does not support ``__members__`` property.)");
             auto op =
                 c10::Dispatcher::singleton()
                     .findSchemaOrThrow("symm_mem::stream_write_value32_", "")
-                    .typed<at::Tensor(at::Tensor&, int64_t, int64_t)>();
-            return op.call(input, offset, val);
+                    .typed<void(at::Tensor&, int64_t, int64_t)>();
+            op.call(input, offset, val);
           },
           py::arg("input"),
           py::arg("offset"),
@@ -1259,9 +1259,9 @@ This class does not support ``__members__`` property.)");
             // The range of `val` is checked inside the op
             auto op = c10::Dispatcher::singleton()
                           .findSchemaOrThrow("symm_mem::memset32_", "")
-                          .typed<at::Tensor(
+                          .typed<void(
                               at::Tensor&, int64_t, int64_t, int64_t)>();
-            return op.call(input, offset, val, count);
+            op.call(input, offset, val, count);
           },
           py::arg("input"),
           py::arg("offset"),

--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryOps.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryOps.cu
@@ -160,7 +160,7 @@ static __global__ void multimem_all_reduce_kernel(
   sync_remote_blocks<true, true>(signal_pads, rank, world_size);
 }
 
-at::Tensor multimem_all_reduce_(
+void multimem_all_reduce_(
     const at::Tensor& input,
     std::string reduce_op,
     std::string group_name) {
@@ -225,7 +225,7 @@ at::Tensor multimem_all_reduce_(
           C10_CUDA_KERNEL_LAUNCH_CHECK();
         });
       });
-  return input;
+  return;
 }
 
 template <typename T, int alignment>
@@ -256,7 +256,7 @@ static __global__ void multimem_one_shot_reduce_kernel(
   sync_remote_blocks<true, false>(signal_pads, rank, world_size);
 }
 
-at::Tensor multimem_one_shot_reduce_out(
+void multimem_one_shot_reduce_out(
     const at::Tensor& input,
     std::string reduce_op,
     int64_t root,
@@ -341,17 +341,17 @@ at::Tensor multimem_one_shot_reduce_out(
           C10_CUDA_KERNEL_LAUNCH_CHECK();
         });
       });
-  return out;
+  return;
 }
 
-at::Tensor multimem_one_shot_all_reduce_out(
+void multimem_one_shot_all_reduce_out(
     const at::Tensor& input,
     std::string reduce_op,
     std::string group_name,
     at::Tensor out) {
   auto group = c10d::resolve_process_group(group_name);
   int root = group->getRank();  // each rank reduces to itself
-  return multimem_one_shot_reduce_out(input, reduce_op, root, group_name, out);
+  multimem_one_shot_reduce_out(input, reduce_op, root, group_name, out);
 }
 
 at::Tensor multimem_one_shot_all_reduce(
@@ -359,7 +359,8 @@ at::Tensor multimem_one_shot_all_reduce(
     std::string reduce_op,
     std::string group_name) {
   auto out = at::empty_like(input);
-  return multimem_one_shot_all_reduce_out(input, reduce_op, group_name, out);
+  multimem_one_shot_all_reduce_out(input, reduce_op, group_name, out);
+  return out;
 }
 
 template <int alignment>
@@ -386,7 +387,7 @@ static __global__ void multimem_all_gather_kernel(
   sync_remote_blocks<true, true>(signal_pads, rank, world_size);
 }
 
-at::Tensor multimem_all_gather_out(
+void multimem_all_gather_out(
     const at::Tensor& input,
     std::string group_name,
     at::Tensor out) {
@@ -466,7 +467,7 @@ at::Tensor multimem_all_gather_out(
             symm_mem->get_world_size());
     C10_CUDA_KERNEL_LAUNCH_CHECK();
   });
-  return out;
+  return;
 }
 
 #endif //no multi-cast support on ROCm
@@ -512,7 +513,7 @@ static __launch_bounds__(one_shot_all_reduce_max_num_threads) __global__
   sync_remote_blocks<true, false>(signal_pads, rank, world_size);
 }
 
-at::Tensor one_shot_all_reduce_out_impl(
+void one_shot_all_reduce_out_impl(
     const at::Tensor& input,
     const std::optional<at::Tensor>& local_input,
     std::string reduce_op,
@@ -555,7 +556,7 @@ at::Tensor one_shot_all_reduce_out_impl(
   }
   if (input.numel() == 0) {
     TORCH_CHECK(input.scalar_type() == out.scalar_type());
-    return out;
+    return;
   }
   auto symm_mem = c10d::symmetric_memory::rendezvous(input, group_name);
   TORCH_CHECK(
@@ -608,25 +609,25 @@ at::Tensor one_shot_all_reduce_out_impl(
           });
         });
       });
-  return out;
+  return;
 }
 
-at::Tensor one_shot_all_reduce_out(
+void one_shot_all_reduce_out(
     const at::Tensor& input,
     std::string reduce_op,
     std::string group_name,
     at::Tensor out) {
-  return one_shot_all_reduce_out_impl(
+  one_shot_all_reduce_out_impl(
       input, std::nullopt, reduce_op, group_name, out);
 }
 
-at::Tensor one_shot_all_reduce_copy_out(
+void one_shot_all_reduce_copy_out(
     const at::Tensor& input,
     const at::Tensor& local_input,
     std::string reduce_op,
     std::string group_name,
     at::Tensor out) {
-  return one_shot_all_reduce_out_impl(
+  one_shot_all_reduce_out_impl(
       input, local_input, reduce_op, group_name, out);
 }
 
@@ -635,8 +636,9 @@ at::Tensor one_shot_all_reduce(
     std::string reduce_op,
     std::string group_name) {
   auto out = at::empty_like(input);
-  return one_shot_all_reduce_out_impl(
+  one_shot_all_reduce_out_impl(
       input, std::nullopt, reduce_op, group_name, out);
+  return out;
 }
 
 at::Tensor one_shot_all_reduce_copy(
@@ -645,8 +647,9 @@ at::Tensor one_shot_all_reduce_copy(
     std::string reduce_op,
     std::string group_name) {
   auto out = at::empty_like(local_input);
-  return one_shot_all_reduce_out_impl(
+  one_shot_all_reduce_out_impl(
       input, local_input, reduce_op, group_name, out);
+  return out;
 }
 
 #if defined(USE_ROCM)
@@ -784,7 +787,7 @@ static __launch_bounds__(two_shot_all_reduce_max_num_threads) __global__
   sync_remote_blocks<true, true>(signal_pads, rank, world_size);
 }
 
-at::Tensor two_shot_all_reduce_impl(
+void two_shot_all_reduce_impl(
     at::Tensor input,
     std::optional<at::Tensor> output,
     std::string reduce_op,
@@ -834,11 +837,11 @@ at::Tensor two_shot_all_reduce_impl(
         output->sizes());
     if (input.numel() == 0) {
       TORCH_CHECK(output->scalar_type() == input.scalar_type());
-      return *output;
+      return;
     }
   } else {
     if (input.numel() == 0) {
-      return input;
+      return;
     }
   }
 
@@ -879,7 +882,7 @@ at::Tensor two_shot_all_reduce_impl(
             });
           });
         });
-    return input;
+    return;
   } else {
     AT_DISPATCH_FLOAT_AND_BFLOAT16(
         input.scalar_type(), "two_shot_all_reduce", [&]() {
@@ -903,26 +906,26 @@ at::Tensor two_shot_all_reduce_impl(
             });
           });
         });
-    return *output;
+    return;
   }
 }
 
-at::Tensor two_shot_all_reduce_(
+void two_shot_all_reduce_(
     at::Tensor input,
     std::string reduce_op,
     std::string group_name) {
-  return two_shot_all_reduce_impl(input, std::nullopt, reduce_op, group_name);
+  two_shot_all_reduce_impl(input, std::nullopt, reduce_op, group_name);
 }
 
-at::Tensor two_shot_all_reduce_out(
+void two_shot_all_reduce_out(
     at::Tensor input,
     std::string reduce_op,
     std::string group_name,
     at::Tensor output) {
-  return two_shot_all_reduce_impl(input, output, reduce_op, group_name);
+  two_shot_all_reduce_impl(input, output, reduce_op, group_name);
 }
 
-at::Tensor reduce_scatter_out(
+void reduce_scatter_out(
     at::Tensor input,
     std::string group_name,
     bool split_last_dim,
@@ -997,7 +1000,7 @@ at::Tensor reduce_scatter_out(
   }
   if (input.numel() == 0) {
     TORCH_CHECK(input.scalar_type() == output.scalar_type());
-    return output;
+    return;
   }
 
   TORCH_CHECK(
@@ -1074,26 +1077,26 @@ at::Tensor reduce_scatter_out(
           });
         });
   }
-  return output;
+  return;
 }
 } // namespace
 #elif defined(CUDART_VERSION) && CUDART_VERSION < 12030
 namespace {
-at::Tensor multimem_all_reduce_(
+void multimem_all_reduce_(
     const at::Tensor& input,
     std::string reduce_op,
     std::string group_name) {
   TORCH_CHECK(false, "multimem_all_reduce_: requires CUDA 12.3+.");
-  return input;
+  return;
 }
 
-at::Tensor multimem_one_shot_all_reduce_out(
+void multimem_one_shot_all_reduce_out(
     const at::Tensor& input,
     std::string reduce_op,
     std::string group_name,
     at::Tensor out) {
   TORCH_CHECK(false, "multimem_one_shot_all_reduce_out: requires CUDA 12.3+.");
-  return out;
+  return;
 }
 
 at::Tensor multimem_one_shot_all_reduce(
@@ -1104,31 +1107,31 @@ at::Tensor multimem_one_shot_all_reduce(
   return input;
 }
 
-at::Tensor multimem_all_gather_out(
+void multimem_all_gather_out(
     const at::Tensor& input,
     std::string group_name,
     at::Tensor out) {
   TORCH_CHECK(false, "multimem_all_gather_out: requires CUDA 12.3+.");
-  return out;
+  return;
 }
 
-at::Tensor one_shot_all_reduce_out(
+void one_shot_all_reduce_out(
     const at::Tensor& input,
     std::string reduce_op,
     std::string group_name,
     at::Tensor out) {
   TORCH_CHECK(false, "one_shot_all_reduce_out: requires CUDA 12.3+.");
-  return out;
+  return;
 }
 
-at::Tensor one_shot_all_reduce_copy_out(
+void one_shot_all_reduce_copy_out(
     const at::Tensor& input,
     const at::Tensor& local_input,
     std::string reduce_op,
     std::string group_name,
     at::Tensor out) {
   TORCH_CHECK(false, "one_shot_all_reduce_copy_out: requires CUDA 12.3+.");
-  return out;
+  return;
 }
 
 at::Tensor one_shot_all_reduce(
@@ -1148,40 +1151,40 @@ at::Tensor one_shot_all_reduce_copy(
   return input;
 }
 
-at::Tensor two_shot_all_reduce_(
+void two_shot_all_reduce_(
     at::Tensor input,
     std::string reduce_op,
     std::string group_name) {
   TORCH_CHECK(false, "two_shot_all_reduce_: requires CUDA 12.3+.");
-  return input;
+  return;
 }
 
-at::Tensor two_shot_all_reduce_out(
+void two_shot_all_reduce_out(
     at::Tensor input,
     std::string reduce_op,
     std::string group_name,
     at::Tensor output) {
   TORCH_CHECK(false, "two_shot_all_reduce_out: requires CUDA 12.3+.");
-  return output;
+  return;
 }
 
-at::Tensor reduce_scatter_out(
+void reduce_scatter_out(
     at::Tensor input,
     std::string group_name,
     bool split_last_dim,
     at::Tensor output) {
   TORCH_CHECK(false, "reduce_scatter_out: requires CUDA 12.3+.");
-  return output;
+  return;
 }
 
-at::Tensor multimem_one_shot_reduce_out(
+void multimem_one_shot_reduce_out(
     const at::Tensor& input,
     std::string reduce_op,
     int64_t root,
     std::string group_name,
     at::Tensor out) {
   TORCH_CHECK(false, "multimem_one_shot_reduce_out: requires CUDA 12.3+.");
-  return out;
+  return;
 }
 
 } // namespace
@@ -1189,7 +1192,7 @@ at::Tensor multimem_one_shot_reduce_out(
 
 namespace {
 
-at::Tensor memset32_(
+void memset32_(
     at::Tensor& input,
     int64_t offset,
     int64_t val,
@@ -1244,10 +1247,10 @@ at::Tensor memset32_(
   TORCH_CHECK(
       false, "CUDASymmetricMemory requires PYTORCH_C10_DRIVER_API_SUPPORTED");
 #endif
-  return input;
+  return;
 }
 
-at::Tensor stream_write_value32_(
+void stream_write_value32_(
     at::Tensor& input,
     int64_t offset,
     int64_t val) {
@@ -1302,7 +1305,7 @@ at::Tensor stream_write_value32_(
   TORCH_CHECK(
       false, "CUDASymmetricMemory requires PYTORCH_C10_DRIVER_API_SUPPORTED");
 #endif
-  return input;
+  return;
 }
 
 } // namespace

--- a/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.cpp
+++ b/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.cpp
@@ -495,34 +495,34 @@ at::Tensor one_shot_all_reduce_copy_meta(
 
 TORCH_LIBRARY_FRAGMENT(symm_mem, m) {
   m.def(
-      "multimem_all_reduce_(Tensor(a!) input, str reduce_op, str group_name) -> Tensor(a!)");
+      "multimem_all_reduce_(Tensor(a!) input, str reduce_op, str group_name) -> ()");
   m.def(
       "multimem_one_shot_all_reduce(Tensor input, str reduce_op, str group_name) -> Tensor");
   m.def(
-      "multimem_one_shot_all_reduce_out(Tensor input, str reduce_op, str group_name, Tensor(a!) out) -> Tensor(a!)");
+      "multimem_one_shot_all_reduce_out(Tensor input, str reduce_op, str group_name, Tensor(a!) out) -> ()");
   m.def(
-      "multimem_one_shot_reduce_out(Tensor input, str reduce_op, int root, str group_name, Tensor(a!) out) -> Tensor(a!)");
+      "multimem_one_shot_reduce_out(Tensor input, str reduce_op, int root, str group_name, Tensor(a!) out) -> ()");
   m.def(
-      "multimem_all_gather_out(Tensor input, str group_name, Tensor(a!) out) -> Tensor(a!)");
+      "multimem_all_gather_out(Tensor input, str group_name, Tensor(a!) out) -> ()");
   m.def(
       "one_shot_all_reduce(Tensor input, str reduce_op, str group_name) -> Tensor");
   m.def(
-      "one_shot_all_reduce_out(Tensor input, str reduce_op, str group_name, Tensor(a!) out) -> Tensor(a!)");
+      "one_shot_all_reduce_out(Tensor input, str reduce_op, str group_name, Tensor(a!) out) -> ()");
   m.def(
       "one_shot_all_reduce_copy(Tensor symm_buffer, Tensor local_input, str reduce_op, str group_name) -> Tensor");
   m.def(
-      "one_shot_all_reduce_copy_out(Tensor symm_buffer, Tensor local_input, str reduce_op, str group_name, Tensor(a!) out) -> Tensor(a!)");
+      "one_shot_all_reduce_copy_out(Tensor symm_buffer, Tensor local_input, str reduce_op, str group_name, Tensor(a!) out) -> ()");
 
   m.def(
-      "two_shot_all_reduce_(Tensor(a!) input, str reduce_op, str group_name) -> Tensor(a!)");
-
-  // note this implementation also modified the input tensor
-  m.def(
-      "two_shot_all_reduce_out(Tensor(a!) input, str reduce_op, str group_name, Tensor(b!) output) -> Tensor(b!)");
+      "two_shot_all_reduce_(Tensor(a!) input, str reduce_op, str group_name) -> ()");
 
   // note this implementation also modified the input tensor
   m.def(
-      "reduce_scatter_out(Tensor(a!) input, str group_name, bool split_last_dim, Tensor(b!) output) -> Tensor(b!)");
+      "two_shot_all_reduce_out(Tensor(a!) input, str reduce_op, str group_name, Tensor(b!) output) -> ()");
+
+  // note this implementation also modified the input tensor
+  m.def(
+      "reduce_scatter_out(Tensor(a!) input, str group_name, bool split_last_dim, Tensor(b!) output) -> ()");
 
   // An mm that supports consuming asynchronous input. It guarantees the
   // following rasterization order, and that the corresponding signal arrives
@@ -535,15 +535,12 @@ TORCH_LIBRARY_FRAGMENT(symm_mem, m) {
   //     # Compute output tiles that consumes the input chunk
   m.def(
       "_async_input_mm(Tensor a, Tensor b, Tensor a_chunk_signals, int a_chunk_pivot) -> Tensor");
-  m.def(
-      "stream_write_value32_(Tensor(a!) input, int offset, int val) -> Tensor(a!)");
-  m.def(
-      "memset32_(Tensor(a!) input, int offset, int val, int count) -> Tensor(a!)");
+  m.def("stream_write_value32_(Tensor(a!) input, int offset, int val) -> ()");
+  m.def("memset32_(Tensor(a!) input, int offset, int val, int count) -> ()");
 
   m.def("nvshmem_put(Tensor(a!) tensor, int peer) -> ()");
   m.def("nvshmem_get(Tensor(a!) tensor, int peer) -> ()");
-  m.def(
-      "nvshmem_broadcast(Tensor(a!) input, int root, str group_name) -> Tensor(a!)");
+  m.def("nvshmem_broadcast(Tensor(a!) input, int root, str group_name) -> ()");
   m.def("nvshmem_wait_for_signal(Tensor sigpad, int signal, int peer) -> ()");
   m.def(
       "nvshmem_put_with_signal(Tensor(a) tensor, Tensor(a) sigpad, int signal, int peer) -> ()");
@@ -554,7 +551,7 @@ TORCH_LIBRARY_FRAGMENT(symm_mem, m) {
   m.def(
       "nccl_reduce_scatter_offset(Tensor input, Tensor(a!)[] out, str group_name, int dim, int[]? offsets=None, int[]? dst_ranks=None, str red_op='sum') -> ()");
   m.def(
-      "nvshmem_all_to_all(Tensor input, Tensor(a!) out, str group_name) -> Tensor(a!)");
+      "nvshmem_all_to_all(Tensor input, Tensor(a!) out, str group_name) -> ()");
   m.def(
       "all_to_all_vdev(Tensor input, Tensor(a!) out, Tensor in_splits, Tensor(a!) out_splits_offsets, str group_name) -> ()");
   m.def(

--- a/torch/csrc/distributed/c10d/symm_mem/nvshmem_extension.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/nvshmem_extension.cu
@@ -78,7 +78,7 @@ void nvshmemx_cumodule_init(uintptr_t module) {
     "nvshmemx_cumodule_init failed");
 }
 
-at::Tensor nvshmem_broadcast(at::Tensor& input, const int64_t root, const std::string& group_name) {
+void nvshmem_broadcast(at::Tensor& input, const int64_t root, const std::string& group_name) {
   auto input_hdl = c10d::symmetric_memory::rendezvous(input, group_name);
   int rank = input_hdl->get_rank();
   void* buffer_ptr = input.mutable_data_ptr();
@@ -90,7 +90,6 @@ at::Tensor nvshmem_broadcast(at::Tensor& input, const int64_t root, const std::s
 
   auto stream = at::cuda::getCurrentCUDAStream();
   nvshmemx_broadcastmem_on_stream(team, buffer_ptr, buffer_ptr, buffer_size, root, stream);
-  return input;
 }
 
 void nvshmem_put(at::Tensor& tensor, const int64_t peer) {
@@ -147,7 +146,7 @@ void nvshmem_get(at::Tensor& tensor, const int64_t peer) {
   nvshmemx_getmem_on_stream(tensor.mutable_data_ptr(), buffer_ptr, buffer_size, peer, stream);
 }
 
-at::Tensor nvshmem_all_to_all(
+void nvshmem_all_to_all(
     at::Tensor& input,
     at::Tensor& out,
     std::string group_name) {
@@ -169,7 +168,6 @@ at::Tensor nvshmem_all_to_all(
 
   auto stream = at::cuda::getCurrentCUDAStream(input.device().index());
   nvshmemx_alltoallmem_on_stream(team, output_ptr, input_ptr, bytes_per_rank, stream);
-  return out;
 }
 
 // This is an exclusive prefix sum function that calculates read (or write) offsets for each peer.

--- a/torch/csrc/distributed/c10d/symm_mem/nvshmem_extension.hpp
+++ b/torch/csrc/distributed/c10d/symm_mem/nvshmem_extension.hpp
@@ -25,7 +25,7 @@ TORCH_API void nvshmem_put(at::Tensor& tensor, const int64_t peer);
 
 TORCH_API void nvshmem_get(at::Tensor& tensor, const int64_t peer);
 
-at::Tensor nvshmem_broadcast(
+void nvshmem_broadcast(
     at::Tensor& input,
     const int64_t root,
     const std::string& group_name);
@@ -41,7 +41,7 @@ TORCH_API void nvshmem_put_with_signal(
     int64_t signal,
     int64_t peer);
 
-at::Tensor nvshmem_all_to_all(
+void nvshmem_all_to_all(
     at::Tensor& input,
     at::Tensor& out,
     std::string group_name);


### PR DESCRIPTION
Custom operators are not allowed to return an alias of a mutated input (e.g. `Tensor(a!) -> Tensor(a!)`), as this pattern is incompatible with torch.compile's functionalization. Change all mutable symm_mem ops to return void (`-> ()`) instead. No callers in the codebase rely on the return values — all use these ops for their in-place side effects.

Discussed with @zou3519 and @kwen2501 on #173513.