### PR TITLE
Use fn.__code__ instead of id(fn) for nested_compile_region reuse cache

### DIFF
--- a/test/higher_order_ops/test_invoke_subgraph.py
+++ b/test/higher_order_ops/test_invoke_subgraph.py
@@ -3755,6 +3755,158 @@ class GraphModule(torch.nn.Module):
         # mod1.c=5 and mod2.c=10 differ → two separate traces
         self.assertEqual(count(), 2)
 
+    def test_subgraph_reuse_monkeypatch_forward(self):
+        """Monkeypatching forward with nested_compile_region should reuse cache.
+
+        When a user wraps a module's forward with nested_compile_region via
+        monkeypatching, each module instance gets a distinct bound method and
+        thus a distinct function object passed to nested_compile_region. The
+        cache key should be based on fn.__code__ rather than id(fn) so that
+        reuse still works across instances whose forward shares the same code.
+        """
+
+        class Mod(torch.nn.Module):
+            def __init__(self, c):
+                super().__init__()
+                self.c = c
+
+            def forward(self, x):
+                return x * self.c
+
+        def apply_nested_compile_region(mod):
+            # Grab the unbound function and create a fresh copy so that each
+            # module instance gets a function with a *different* id() but the
+            # *same* __code__ object, mimicking a monkeypatch/code-gen scenario.
+            import types
+
+            orig = type(mod).forward
+            fresh_fn = types.FunctionType(
+                orig.__code__,
+                orig.__globals__,
+                orig.__name__,
+                orig.__defaults__,
+                orig.__closure__,
+            )
+            mod.forward = nested_compile_region(fresh_fn).__get__(mod, type(mod))
+            return mod
+
+        mod1 = apply_nested_compile_region(Mod(5))
+        mod2 = apply_nested_compile_region(Mod(5))
+
+        # The inner functions passed to invoke_subgraph_placeholder are
+        # different objects but share the same __code__.
+        fn1 = mod1.forward.__func__.__marked_compile_region_fn__
+        fn2 = mod2.forward.__func__.__marked_compile_region_fn__
+        self.assertIsNot(fn1, fn2)
+        self.assertIs(fn1.__code__, fn2.__code__)
+
+        def fn(x):
+            return mod1(x) + mod2(x)
+
+        x = torch.randn(8)
+        ref = fn(x)
+
+        with self._count_speculate_calls() as count:
+            res = torch.compile(fn, backend="aot_eager", fullgraph=True)(x)
+
+        self.assertEqual(ref, res)
+        # Both modules have the same code and same c=5, so the second call
+        # should reuse the first trace despite having different function ids.
+        self.assertEqual(count(), 1)
+
+    def test_subgraph_reuse_module_apply(self):
+        """Using module.apply to wrap transformer layers with nested_compile_region."""
+
+        class Layer(torch.nn.Module):
+            def __init__(self, c):
+                super().__init__()
+                self.c = c
+
+            def forward(self, x):
+                return x * self.c
+
+        model = torch.nn.Sequential(Layer(5), Layer(5), Layer(5))
+        ref_model = torch.nn.Sequential(Layer(5), Layer(5), Layer(5))
+
+        def wrap_layer(mod):
+            if isinstance(mod, Layer):
+                fwd = type(mod).forward
+                if not hasattr(fwd, "__marked_compile_region_fn__"):
+                    type(mod).forward = nested_compile_region(fwd)
+
+        model.apply(wrap_layer)
+
+        x = torch.randn(8)
+        ref = ref_model(x)
+
+        with self._count_speculate_calls() as count:
+            res = torch.compile(model, backend="aot_eager", fullgraph=True)(x)
+
+        self.assertEqual(ref, res)
+        # All three layers share the same class and c=5, only one trace needed.
+        self.assertEqual(count(), 1)
+
+    def test_subgraph_reuse_class_level_wrap(self):
+        """Wrapping cls.forward with nested_compile_region for named_modules pattern."""
+
+        class Layer(torch.nn.Module):
+            def __init__(self, c):
+                super().__init__()
+                self.c = c
+
+            def forward(self, x):
+                return x * self.c
+
+        # Wrap at the class level — the pattern a user would use after
+        # iterating named_modules to wrap all layers of a given type.
+        Layer.forward = nested_compile_region(Layer.forward)
+
+        mod1 = Layer(5)
+        mod2 = Layer(5)
+
+        def fn(x):
+            return mod1(x) + mod2(x)
+
+        x = torch.randn(8)
+        ref = fn(x)
+
+        with self._count_speculate_calls() as count:
+            res = torch.compile(fn, backend="aot_eager", fullgraph=True)(x)
+
+        self.assertEqual(ref, res)
+        self.assertEqual(count(), 1)
+
+    def test_subgraph_reuse_module_instance_as_callable(self):
+        """Passing nn.Module instances directly to nested_compile_region."""
+
+        class Layer(torch.nn.Module):
+            def __init__(self, c):
+                super().__init__()
+                self.c = c
+
+            def forward(self, x):
+                return x * self.c
+
+        mod1 = Layer(5)
+        mod2 = Layer(5)
+
+        wrapped1 = nested_compile_region(mod1)
+        wrapped2 = nested_compile_region(mod2)
+
+        def fn(x):
+            return wrapped1(x) + wrapped2(x)
+
+        x = torch.randn(8)
+        ref = fn(x)
+
+        with self._count_speculate_calls() as count:
+            res = torch.compile(fn, backend="aot_eager", fullgraph=True)(x)
+
+        self.assertEqual(ref, res)
+        # Both modules have the same forward code and same c=5, so the
+        # second call should reuse the first trace.
+        self.assertEqual(count(), 1)
+
 
 @skipIfTorchDynamo("Not a torch._dynamo test")
 @parameterized_class(

--- a/torch/_dynamo/variables/invoke_subgraph.py
+++ b/torch/_dynamo/variables/invoke_subgraph.py
@@ -329,7 +329,7 @@ LiftedArgOrigin = (
 )
 
 
-def get_fn_id(fn_var: Any) -> types.CodeType | None:
+def get_fn_code(fn_var: Any) -> types.CodeType | None:
     if isinstance(fn_var, UserFunctionVariable):
         return fn_var.get_function().__code__
     elif isinstance(fn_var, UnspecializedNNModuleVariable):
@@ -720,8 +720,8 @@ def has_reuse_entries(
     )
     if not isinstance(invoke_subgraph_cache, InvokeSubgraphCache):
         return False
-    fn_id = get_fn_id(fn_var)
-    return fn_id is not None and fn_id in invoke_subgraph_cache.subgraph_reuse_cache
+    fn_code = get_fn_code(fn_var)
+    return fn_code is not None and fn_code in invoke_subgraph_cache.subgraph_reuse_cache
 
 
 def find_reuse_match(
@@ -736,8 +736,8 @@ def find_reuse_match(
     )
     if not isinstance(invoke_subgraph_cache, InvokeSubgraphCache):
         return None
-    fn_id = get_fn_id(fn_var)
-    if fn_id is None:
+    fn_code = get_fn_code(fn_var)
+    if fn_code is None:
         return None
 
     # this evaluator function is called one by one for all the invoke subgraph
@@ -748,7 +748,7 @@ def find_reuse_match(
     ) -> bool:
         return is_reusable(tx, cond, fingerprint, entry)
 
-    return invoke_subgraph_cache.find_reuse_entry(fn_id, evaluator)
+    return invoke_subgraph_cache.find_reuse_entry(fn_code, evaluator)
 
 
 def save_reuse_entry(
@@ -779,8 +779,8 @@ def save_reuse_entry(
     if not isinstance(invoke_subgraph_cache, InvokeSubgraphCache):
         return
 
-    fn_id = get_fn_id(fn_var)
-    if fn_id is None:
+    fn_code = get_fn_code(fn_var)
+    if fn_code is None:
         return
 
     subgraph_input_mapping = build_subgraph_input_mapping(
@@ -825,7 +825,7 @@ def save_reuse_entry(
         arg_sources=fingerprint.arg_sources,
         num_user_outputs=num_user_outputs,
     )
-    invoke_subgraph_cache.add_reuse_entry(fn_id, condition, entry, max_reuse_entries)
+    invoke_subgraph_cache.add_reuse_entry(fn_code, condition, entry, max_reuse_entries)
 
 
 def stamp_out_subgraph(
@@ -1052,17 +1052,17 @@ class InvokeSubgraphHigherOrderVariable(WrapHigherOrderVariable):
         )
 
         if isinstance(fn_vt, UserFunctionVariable):
-            fn_id = fn_vt.get_function().__code__
+            fn_code = fn_vt.get_function().__code__
             fn_name = fn_vt.get_function().__name__
         else:
             assert isinstance(fn_vt, UnspecializedNNModuleVariable)
-            fn_id = fn_vt.value.forward.__func__.__code__  # type: ignore[attr-defined]
+            fn_code = fn_vt.value.forward.__func__.__code__  # type: ignore[attr-defined]
             fn_name = fn_vt.value.forward.__name__  # type: ignore[attr-defined]
         # pyrefly: ignore [implicit-any]
         previously_installed_submodules = []
         if invoke_subgraph_cache:
             previously_installed_submodules = (
-                invoke_subgraph_cache.get_dynamo_installed_submodules(fn_id)
+                invoke_subgraph_cache.get_dynamo_installed_submodules(fn_code)
             )
             current_mod = body_gmod
             # NB - reverse is more likely to cause a hit sooner because first
@@ -1091,7 +1091,7 @@ class InvokeSubgraphHigherOrderVariable(WrapHigherOrderVariable):
             len(previously_installed_submodules) + 1,
         )
         if invoke_subgraph_cache:
-            invoke_subgraph_cache.add_dynamo_installed_submodule(fn_id, body_name)
+            invoke_subgraph_cache.add_dynamo_installed_submodule(fn_code, body_name)
 
         return body_name
 
@@ -1129,7 +1129,7 @@ class InvokeSubgraphHigherOrderVariable(WrapHigherOrderVariable):
         # and enable if request arises.
         reuse = not tx.output.export
 
-        # Reuse lookup: check fn_id first (cheap) to avoid the
+        # Reuse lookup: check fn_code first (cheap) to avoid the
         # expensive pytree flatten in build_input_fingerprint on the
         # first call when there's nothing in the cache yet.
         if reuse and has_reuse_entries(tx, fn_var):

--- a/torch/_dynamo/variables/invoke_subgraph.py
+++ b/torch/_dynamo/variables/invoke_subgraph.py
@@ -7,6 +7,7 @@ higher-order operator.
 import enum
 import logging
 import traceback
+import types
 from dataclasses import dataclass
 from typing import Any, cast, NamedTuple, TYPE_CHECKING
 
@@ -328,11 +329,11 @@ LiftedArgOrigin = (
 )
 
 
-def get_fn_id(fn_var: Any) -> int | None:
+def get_fn_id(fn_var: Any) -> types.CodeType | None:
     if isinstance(fn_var, UserFunctionVariable):
-        return id(fn_var.get_function())
+        return fn_var.get_function().__code__
     elif isinstance(fn_var, UnspecializedNNModuleVariable):
-        return id(fn_var.value.forward.__func__)  # pyrefly: ignore[missing-attribute]
+        return fn_var.value.forward.__func__.__code__  # pyrefly: ignore[missing-attribute]
     return None
 
 
@@ -1051,11 +1052,11 @@ class InvokeSubgraphHigherOrderVariable(WrapHigherOrderVariable):
         )
 
         if isinstance(fn_vt, UserFunctionVariable):
-            fn_id = id(fn_vt.get_function())
+            fn_id = fn_vt.get_function().__code__
             fn_name = fn_vt.get_function().__name__
         else:
             assert isinstance(fn_vt, UnspecializedNNModuleVariable)
-            fn_id = id(fn_vt.value.forward.__func__)  # type: ignore[attr-defined]
+            fn_id = fn_vt.value.forward.__func__.__code__  # type: ignore[attr-defined]
             fn_name = fn_vt.value.forward.__name__  # type: ignore[attr-defined]
         # pyrefly: ignore [implicit-any]
         previously_installed_submodules = []

--- a/torch/_dynamo/variables/invoke_subgraph.py
+++ b/torch/_dynamo/variables/invoke_subgraph.py
@@ -333,7 +333,9 @@ def get_fn_code(fn_var: Any) -> types.CodeType | None:
     if isinstance(fn_var, UserFunctionVariable):
         return fn_var.get_function().__code__
     elif isinstance(fn_var, UnspecializedNNModuleVariable):
-        return fn_var.value.forward.__func__.__code__  # pyrefly: ignore[missing-attribute]
+        return (
+            fn_var.value.forward.__func__.__code__  # pyrefly: ignore[missing-attribute]
+        )
     return None
 
 

--- a/torch/_guards.py
+++ b/torch/_guards.py
@@ -831,9 +831,7 @@ class InvokeSubgraphCache(HopSubgraphCache):
     def __init__(self) -> None:
         self.autograd_cache: dict[str, Callable] = {}
         self.proxy_dispatch_cache: dict[str, Callable] = {}
-        self.dynamo_installed_submodules: dict[CodeType, list[str]] = defaultdict(
-            list
-        )
+        self.dynamo_installed_submodules: dict[CodeType, list[str]] = defaultdict(list)
         self.lazy_bwd_cache: dict[
             str, dict[tuple[object], tuple[torch.fx.GraphModule, int]]
         ] = defaultdict(dict)

--- a/torch/_guards.py
+++ b/torch/_guards.py
@@ -8,7 +8,6 @@ import logging
 import re
 import threading
 import traceback
-import types
 import unittest.mock
 import weakref
 from abc import abstractmethod
@@ -742,10 +741,12 @@ class GuardsContext(Checkpointable[GuardsCheckpointState]):
 
 class HopSubgraphCache:
     @abstractmethod
-    def add_dynamo_installed_submodule(self, fn_id: types.CodeType, identifier: str) -> None: ...
+    def add_dynamo_installed_submodule(
+        self, fn_code: CodeType, identifier: str
+    ) -> None: ...
 
     @abstractmethod
-    def get_dynamo_installed_submodules(self, fn_id: types.CodeType) -> list[str]: ...
+    def get_dynamo_installed_submodules(self, fn_code: CodeType) -> list[str]: ...
 
     @abstractmethod
     def add_autograd_key_entry(self, identifier: str, key: Callable) -> None: ...
@@ -830,7 +831,9 @@ class InvokeSubgraphCache(HopSubgraphCache):
     def __init__(self) -> None:
         self.autograd_cache: dict[str, Callable] = {}
         self.proxy_dispatch_cache: dict[str, Callable] = {}
-        self.dynamo_installed_submodules: dict[types.CodeType, list[str]] = defaultdict(list)
+        self.dynamo_installed_submodules: dict[CodeType, list[str]] = defaultdict(
+            list
+        )
         self.lazy_bwd_cache: dict[
             str, dict[tuple[object], tuple[torch.fx.GraphModule, int]]
         ] = defaultdict(dict)
@@ -840,14 +843,17 @@ class InvokeSubgraphCache(HopSubgraphCache):
         # fn.__code__ → list of (condition, cache_entry) pairs. Walked linearly
         # on lookup; first matching condition wins.
         self.subgraph_reuse_cache: dict[
-            types.CodeType, list[tuple[InvokeSubgraphReuseCondition, InvokeSubgraphReuseEntry]]
+            CodeType,
+            list[tuple[InvokeSubgraphReuseCondition, InvokeSubgraphReuseEntry]],
         ] = defaultdict(list)
 
-    def add_dynamo_installed_submodule(self, fn_id: types.CodeType, identifier: str) -> None:
-        self.dynamo_installed_submodules[fn_id].append(identifier)
+    def add_dynamo_installed_submodule(
+        self, fn_code: CodeType, identifier: str
+    ) -> None:
+        self.dynamo_installed_submodules[fn_code].append(identifier)
 
-    def get_dynamo_installed_submodules(self, fn_id: types.CodeType) -> list[str]:
-        return self.dynamo_installed_submodules.get(fn_id, [])
+    def get_dynamo_installed_submodules(self, fn_code: CodeType) -> list[str]:
+        return self.dynamo_installed_submodules.get(fn_code, [])
 
     def add_autograd_key_entry(self, identifier: str, key: Callable) -> None:
         self.autograd_cache[identifier] = key
@@ -898,16 +904,16 @@ class InvokeSubgraphCache(HopSubgraphCache):
 
     def add_reuse_entry(
         self,
-        fn_id: types.CodeType,
+        fn_code: CodeType,
         condition: InvokeSubgraphReuseCondition,
         entry: InvokeSubgraphReuseEntry,
         max_reuse_entries: int = 8,
     ) -> None:
-        entries = self.subgraph_reuse_cache[fn_id]
+        entries = self.subgraph_reuse_cache[fn_code]
         if len(entries) >= max_reuse_entries:
             raise RuntimeError(
                 f"invoke_subgraph: exceeded maximum reuse entries "
-                f"({max_reuse_entries}) for function id {fn_id}. "
+                f"({max_reuse_entries}) for function code {fn_code}. "
                 f"This most likely means a guard keeps failing on every "
                 f"invocation, preventing subgraph reuse. "
                 f"Set TORCH_LOGS='+hierarchical_compile' to identify which "
@@ -919,12 +925,12 @@ class InvokeSubgraphCache(HopSubgraphCache):
 
     def find_reuse_entry(
         self,
-        fn_id: types.CodeType,
+        fn_code: CodeType,
         evaluator: Callable[
             [InvokeSubgraphReuseCondition, InvokeSubgraphReuseEntry], bool
         ],
     ) -> InvokeSubgraphReuseEntry | None:
-        entries = self.subgraph_reuse_cache.get(fn_id, [])
+        entries = self.subgraph_reuse_cache.get(fn_code, [])
         for i, (condition, entry) in enumerate(entries):
             if evaluator(condition, entry):
                 # MRU: move the hit entry to the front for faster future lookups

--- a/torch/_guards.py
+++ b/torch/_guards.py
@@ -8,6 +8,7 @@ import logging
 import re
 import threading
 import traceback
+import types
 import unittest.mock
 import weakref
 from abc import abstractmethod
@@ -741,10 +742,10 @@ class GuardsContext(Checkpointable[GuardsCheckpointState]):
 
 class HopSubgraphCache:
     @abstractmethod
-    def add_dynamo_installed_submodule(self, fn_id: int, identifier: str) -> None: ...
+    def add_dynamo_installed_submodule(self, fn_id: types.CodeType, identifier: str) -> None: ...
 
     @abstractmethod
-    def get_dynamo_installed_submodules(self, fn_id: int) -> list[str]: ...
+    def get_dynamo_installed_submodules(self, fn_id: types.CodeType) -> list[str]: ...
 
     @abstractmethod
     def add_autograd_key_entry(self, identifier: str, key: Callable) -> None: ...
@@ -829,23 +830,23 @@ class InvokeSubgraphCache(HopSubgraphCache):
     def __init__(self) -> None:
         self.autograd_cache: dict[str, Callable] = {}
         self.proxy_dispatch_cache: dict[str, Callable] = {}
-        self.dynamo_installed_submodules: dict[int, list[str]] = defaultdict(list)
+        self.dynamo_installed_submodules: dict[types.CodeType, list[str]] = defaultdict(list)
         self.lazy_bwd_cache: dict[
             str, dict[tuple[object], tuple[torch.fx.GraphModule, int]]
         ] = defaultdict(dict)
         self.effects_cache: dict[
             str, set
         ] = {}  # Maps identifier -> set of effect types
-        # fn_id → list of (condition, cache_entry) pairs. Walked linearly
+        # fn.__code__ → list of (condition, cache_entry) pairs. Walked linearly
         # on lookup; first matching condition wins.
         self.subgraph_reuse_cache: dict[
-            int, list[tuple[InvokeSubgraphReuseCondition, InvokeSubgraphReuseEntry]]
+            types.CodeType, list[tuple[InvokeSubgraphReuseCondition, InvokeSubgraphReuseEntry]]
         ] = defaultdict(list)
 
-    def add_dynamo_installed_submodule(self, fn_id: int, identifier: str) -> None:
+    def add_dynamo_installed_submodule(self, fn_id: types.CodeType, identifier: str) -> None:
         self.dynamo_installed_submodules[fn_id].append(identifier)
 
-    def get_dynamo_installed_submodules(self, fn_id: int) -> list[str]:
+    def get_dynamo_installed_submodules(self, fn_id: types.CodeType) -> list[str]:
         return self.dynamo_installed_submodules.get(fn_id, [])
 
     def add_autograd_key_entry(self, identifier: str, key: Callable) -> None:
@@ -897,7 +898,7 @@ class InvokeSubgraphCache(HopSubgraphCache):
 
     def add_reuse_entry(
         self,
-        fn_id: int,
+        fn_id: types.CodeType,
         condition: InvokeSubgraphReuseCondition,
         entry: InvokeSubgraphReuseEntry,
         max_reuse_entries: int = 8,
@@ -918,7 +919,7 @@ class InvokeSubgraphCache(HopSubgraphCache):
 
     def find_reuse_entry(
         self,
-        fn_id: int,
+        fn_id: types.CodeType,
         evaluator: Callable[
             [InvokeSubgraphReuseCondition, InvokeSubgraphReuseEntry], bool
         ],


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #179148

This allows cache reuse when the same function code is wrapped multiple
times (e.g. monkeypatching forward with nested_compile_region), since
each wrap creates a new function object with a different id() but the
same __code__.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98