### PR TITLE
[Test] Refactor test_debug_utils.py to be device agnostic

### DIFF
--- a/test/dynamo/test_debug_utils.py
+++ b/test/dynamo/test_debug_utils.py
@@ -211,8 +211,7 @@ class TestDebugUtilsDevice(TestCase):
 
 instantiate_device_type_tests(TestDebugUtils, globals())
 
-devices = ["cuda", "hpu"]
-instantiate_device_type_tests(TestDebugUtilsDevice, globals(), only_for=devices)
+instantiate_device_type_tests(TestDebugUtilsDevice, globals(), except_for="mps")
 
 
 class TestBackendOverrideIntegration(TestCase):
@@ -376,7 +375,7 @@ class TestBackendOverrideIntegration(TestCase):
 
 
 instantiate_device_type_tests(
-    TestBackendOverrideIntegration, globals(), only_for=["cpu", "cuda"]
+    TestBackendOverrideIntegration, globals(), except_for="mps"
 )
 
 


### PR DESCRIPTION
Refactor test/dynamo/test_debug_utils.py to be device-generic by replacing only_for restrictions with except_for to enable tests to run on all accelerators including out-of-tree devices via PrivateUse1.

  Changes in test/dynamo/test_debug_utils.py:

  - TestDebugUtilsDevice: Change only_for=("cuda", "hpu") to except_for="mps" to enable tests on all accelerators
  - TestBackendOverrideIntegration: Change only_for=("cpu", "cuda") to except_for="mps" to enable tests on all accelerators
  - Remove unused devices variable

  Test Plan:

1.   Verified all tests pass with TEST_CONFIG=cpu: 67 tests OK (20.447s)
2.   Verified all tests pass with TEST_CONFIG=sgpu: 67 tests OK (15.492s)


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98 @fffrog @albanD 