### PR TITLE
Use modernized cuda iterators with CCCL 3.4

### DIFF
--- a/aten/src/ATen/cuda/cub.cuh
+++ b/aten/src/ATen/cuda/cub.cuh
@@ -71,25 +71,30 @@ using cccl_discard_iterator  = ::cuda::discard_iterator;
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/constant_iterator.h>
+#include <thrust/iterator/discard_iterator.h>
 #define ATEN_CUB_TRANSFORM_ITERATOR(ValueType, ...) ::thrust::transform_iterator<__VA_ARGS__>
 #define ATEN_CUB_COUNTING_ITERATOR(...) ::thrust::counting_iterator<__VA_ARGS__>
 #define ATEN_CUB_CONSTANT_ITERATOR(...) ::thrust::constant_iterator<__VA_ARGS__>
 #define ATEN_CUB_MAXIMUM() ::cuda::maximum<>()
 template<class T>
-using cccl_constant_iterator = thrust::constant_iterator<T>;
+using cccl_constant_iterator = ::thrust::constant_iterator<T>;
 template<class T>
-using cccl_counting_iterator = thrust::counting_iterator<T>;
-using cccl_discard_iterator  = thrust::discard_iterator<>;
+using cccl_counting_iterator = ::thrust::counting_iterator<T>;
+using cccl_discard_iterator  = ::thrust::discard_iterator<>;
 #else
+#include <thrust/iterator/transform_iterator.h>
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/iterator/constant_iterator.h>
+#include <thrust/iterator/discard_iterator.h>
 #define ATEN_CUB_TRANSFORM_ITERATOR(...) NO_ROCM(at_cuda_detail)ROCM_HIPCUB(::cub)::TransformInputIterator<__VA_ARGS__>
 #define ATEN_CUB_COUNTING_ITERATOR(...) NO_ROCM(at_cuda_detail)ROCM_HIPCUB(::cub)::CountingInputIterator<__VA_ARGS__>
 #define ATEN_CUB_CONSTANT_ITERATOR(...) NO_ROCM(at_cuda_detail)ROCM_HIPCUB(::cub)::ConstantInputIterator<__VA_ARGS__>
 #define ATEN_CUB_MAXIMUM() NO_ROCM(at_cuda_detail)ROCM_HIPCUB(::cub)::Max()
 template<class T>
-using cccl_constant_iterator = thrust::constant_iterator<T>;
+using cccl_constant_iterator = ::thrust::constant_iterator<T>;
 template<class T>
-using cccl_counting_iterator = thrust::counting_iterator<T>;
-using cccl_discard_iterator  = thrust::discard_iterator<>;
+using cccl_counting_iterator = ::thrust::counting_iterator<T>;
+using cccl_discard_iterator  = ::thrust::discard_iterator<>;
 #endif
 
 #if defined(USE_ROCM)

--- a/aten/src/ATen/cuda/cub.cuh
+++ b/aten/src/ATen/cuda/cub.cuh
@@ -55,7 +55,19 @@
 #define ROCM_HIPCUB(x) x
 #endif
 
-#if CUB_V3_PLUS()
+#if CUB_V3_4_PLUS()
+#include <cuda/iterator>
+#include <cuda/functional>
+#define ATEN_CUB_TRANSFORM_ITERATOR(ValueType, ...) ::cuda::transform_iterator<__VA_ARGS__>
+#define ATEN_CUB_COUNTING_ITERATOR(...) ::cuda::counting_iterator<__VA_ARGS__>
+#define ATEN_CUB_CONSTANT_ITERATOR(...) ::cuda::constant_iterator<__VA_ARGS__>
+#define ATEN_CUB_MAXIMUM() ::cuda::maximum<>()
+template<class T>
+using cccl_constant_iterator = ::cuda::constant_iterator<T>;
+template<class T>
+using cccl_counting_iterator = ::cuda::counting_iterator<T>;
+using cccl_discard_iterator  = ::cuda::discard_iterator;
+#elif CUB_V3_PLUS()
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/constant_iterator.h>
@@ -63,6 +75,11 @@
 #define ATEN_CUB_COUNTING_ITERATOR(...) ::thrust::counting_iterator<__VA_ARGS__>
 #define ATEN_CUB_CONSTANT_ITERATOR(...) ::thrust::constant_iterator<__VA_ARGS__>
 #define ATEN_CUB_MAXIMUM() ::cuda::maximum<>()
+template<class T>
+using cccl_constant_iterator = thrust::constant_iterator<T>;
+template<class T>
+using cccl_counting_iterator = thrust::counting_iterator<T>;
+using cccl_discard_iterator  = thrust::discard_iterator<>;
 #else
 #define ATEN_CUB_TRANSFORM_ITERATOR(...) NO_ROCM(at_cuda_detail)ROCM_HIPCUB(::cub)::TransformInputIterator<__VA_ARGS__>
 #define ATEN_CUB_COUNTING_ITERATOR(...) NO_ROCM(at_cuda_detail)ROCM_HIPCUB(::cub)::CountingInputIterator<__VA_ARGS__>

--- a/aten/src/ATen/cuda/cub.cuh
+++ b/aten/src/ATen/cuda/cub.cuh
@@ -85,6 +85,11 @@ using cccl_discard_iterator  = thrust::discard_iterator<>;
 #define ATEN_CUB_COUNTING_ITERATOR(...) NO_ROCM(at_cuda_detail)ROCM_HIPCUB(::cub)::CountingInputIterator<__VA_ARGS__>
 #define ATEN_CUB_CONSTANT_ITERATOR(...) NO_ROCM(at_cuda_detail)ROCM_HIPCUB(::cub)::ConstantInputIterator<__VA_ARGS__>
 #define ATEN_CUB_MAXIMUM() NO_ROCM(at_cuda_detail)ROCM_HIPCUB(::cub)::Max()
+template<class T>
+using cccl_constant_iterator = thrust::constant_iterator<T>;
+template<class T>
+using cccl_counting_iterator = thrust::counting_iterator<T>;
+using cccl_discard_iterator  = thrust::discard_iterator<>;
 #endif
 
 #if defined(USE_ROCM)

--- a/aten/src/ATen/cuda/cub.cuh
+++ b/aten/src/ATen/cuda/cub.cuh
@@ -68,7 +68,8 @@ using cccl_constant_iterator = ::cuda::constant_iterator<T>;
 template<class T>
 using cccl_counting_iterator = ::cuda::counting_iterator<T>;
 using cccl_discard_iterator  = ::cuda::discard_iterator;
-using cccl_make_reverse_iterator = ::cuda::std::make_reverse_iterator;
+template<class Iter>
+auto cccl_make_reverse_iterator(Iter it) { return ::cuda::std::make_reverse_iterator(it); }
 #elif CUB_V3_PLUS()
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/iterator/counting_iterator.h>
@@ -84,7 +85,8 @@ using cccl_constant_iterator = ::thrust::constant_iterator<T>;
 template<class T>
 using cccl_counting_iterator = ::thrust::counting_iterator<T>;
 using cccl_discard_iterator  = ::thrust::discard_iterator<>;
-using cccl_make_reverse_iterator = ::thrust::make_reverse_iterator;
+template<class Iter>
+auto cccl_make_reverse_iterator(Iter it) { return ::thrust::make_reverse_iterator(it); }
 #else
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/iterator/counting_iterator.h>
@@ -100,7 +102,8 @@ using cccl_constant_iterator = ::thrust::constant_iterator<T>;
 template<class T>
 using cccl_counting_iterator = ::thrust::counting_iterator<T>;
 using cccl_discard_iterator  = ::thrust::discard_iterator<>;
-using cccl_make_reverse_iterator = ::thrust::make_reverse_iterator;
+template<class Iter>
+auto cccl_make_reverse_iterator(Iter it) { return ::thrust::make_reverse_iterator(it); }
 #endif
 
 #if defined(USE_ROCM)

--- a/aten/src/ATen/cuda/cub.cuh
+++ b/aten/src/ATen/cuda/cub.cuh
@@ -68,7 +68,7 @@ using cccl_constant_iterator = ::cuda::constant_iterator<T>;
 template<class T>
 using cccl_counting_iterator = ::cuda::counting_iterator<T>;
 using cccl_discard_iterator  = ::cuda::discard_iterator;
-using cccl_make_reverse_iterator ::cuda::std::make_reverse_iterator;
+using cccl_make_reverse_iterator = ::cuda::std::make_reverse_iterator;
 #elif CUB_V3_PLUS()
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/iterator/counting_iterator.h>

--- a/aten/src/ATen/cuda/cub.cuh
+++ b/aten/src/ATen/cuda/cub.cuh
@@ -58,6 +58,7 @@
 #if CUB_V3_4_PLUS()
 #include <cuda/iterator>
 #include <cuda/functional>
+#include <cuda/std/iterator>
 #define ATEN_CUB_TRANSFORM_ITERATOR(ValueType, ...) ::cuda::transform_iterator<__VA_ARGS__>
 #define ATEN_CUB_COUNTING_ITERATOR(...) ::cuda::counting_iterator<__VA_ARGS__>
 #define ATEN_CUB_CONSTANT_ITERATOR(...) ::cuda::constant_iterator<__VA_ARGS__>
@@ -67,11 +68,13 @@ using cccl_constant_iterator = ::cuda::constant_iterator<T>;
 template<class T>
 using cccl_counting_iterator = ::cuda::counting_iterator<T>;
 using cccl_discard_iterator  = ::cuda::discard_iterator;
+using cccl_make_reverse_iterator ::cuda::std::make_reverse_iterator;
 #elif CUB_V3_PLUS()
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/constant_iterator.h>
 #include <thrust/iterator/discard_iterator.h>
+#include <thrust/iterator/reverse_iterator.h>
 #define ATEN_CUB_TRANSFORM_ITERATOR(ValueType, ...) ::thrust::transform_iterator<__VA_ARGS__>
 #define ATEN_CUB_COUNTING_ITERATOR(...) ::thrust::counting_iterator<__VA_ARGS__>
 #define ATEN_CUB_CONSTANT_ITERATOR(...) ::thrust::constant_iterator<__VA_ARGS__>
@@ -81,11 +84,13 @@ using cccl_constant_iterator = ::thrust::constant_iterator<T>;
 template<class T>
 using cccl_counting_iterator = ::thrust::counting_iterator<T>;
 using cccl_discard_iterator  = ::thrust::discard_iterator<>;
+using cccl_make_reverse_iterator = ::thrust::make_reverse_iterator;
 #else
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/constant_iterator.h>
 #include <thrust/iterator/discard_iterator.h>
+#include <thrust/iterator/reverse_iterator.h>
 #define ATEN_CUB_TRANSFORM_ITERATOR(...) NO_ROCM(at_cuda_detail)ROCM_HIPCUB(::cub)::TransformInputIterator<__VA_ARGS__>
 #define ATEN_CUB_COUNTING_ITERATOR(...) NO_ROCM(at_cuda_detail)ROCM_HIPCUB(::cub)::CountingInputIterator<__VA_ARGS__>
 #define ATEN_CUB_CONSTANT_ITERATOR(...) NO_ROCM(at_cuda_detail)ROCM_HIPCUB(::cub)::ConstantInputIterator<__VA_ARGS__>
@@ -95,6 +100,7 @@ using cccl_constant_iterator = ::thrust::constant_iterator<T>;
 template<class T>
 using cccl_counting_iterator = ::thrust::counting_iterator<T>;
 using cccl_discard_iterator  = ::thrust::discard_iterator<>;
+using cccl_make_reverse_iterator = ::thrust::make_reverse_iterator;
 #endif
 
 #if defined(USE_ROCM)

--- a/aten/src/ATen/cuda/cub_definitions.cuh
+++ b/aten/src/ATen/cuda/cub_definitions.cuh
@@ -25,7 +25,7 @@
 #if CUB_VERSION >= 300400
 #define CUB_V3_4_PLUS() true
 #define CUB_V3_PLUS() false
-#if CUB_VERSION >= 200800
+#elif CUB_VERSION >= 200800
 #define CUB_V3_4_PLUS() false
 #define CUB_V3_PLUS() true
 #else

--- a/aten/src/ATen/cuda/cub_definitions.cuh
+++ b/aten/src/ATen/cuda/cub_definitions.cuh
@@ -22,8 +22,13 @@
 
 // There were many bc-breaking changes in major version release of CCCL v3.0.0
 // Please see https://nvidia.github.io/cccl/cccl/3.0_migration_guide.html
+#if CUB_VERSION >= 300400
+#define CUB_V3_4_PLUS() true
+#define CUB_V3_PLUS() false
 #if CUB_VERSION >= 200800
+#define CUB_V3_4_PLUS() false
 #define CUB_V3_PLUS() true
 #else
+#define CUB_V3_4_PLUS() false
 #define CUB_V3_PLUS() false
 #endif

--- a/aten/src/ATen/native/cuda/Embedding.cu
+++ b/aten/src/ATen/native/cuda/Embedding.cu
@@ -15,8 +15,6 @@
 #include <ATen/native/cuda/block_reduce.cuh>
 #include <ATen/native/cuda/thread_constants.h>
 
-#include <cuda/std/iterator>
-
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
 #include <ATen/NativeFunctions.h>
@@ -319,9 +317,9 @@ Tensor embedding_dense_backward_cuda(const Tensor & grad_, const Tensor & indice
       // sorted: 2 5 5 5 7 7 8 9 9
       //  count: 1 3 3 3 2 2 1 2 2
       cuda::cub::inclusive_scan_by_key(
-        ::cuda::std::make_reverse_iterator(sorted_data + num_indices),
-        ::cuda::std::make_reverse_iterator(static_cast<const index_t*>(count_data) + num_indices),
-        ::cuda::std::make_reverse_iterator(count_data + num_indices),
+        cccl_make_reverse_iterator(sorted_data + num_indices),
+        cccl_make_reverse_iterator(static_cast<const index_t*>(count_data) + num_indices),
+        cccl_make_reverse_iterator(count_data + num_indices),
         ATEN_CUB_MAXIMUM(),
         num_indices
       );

--- a/aten/src/ATen/native/cuda/Embedding.cu
+++ b/aten/src/ATen/native/cuda/Embedding.cu
@@ -15,7 +15,7 @@
 #include <ATen/native/cuda/block_reduce.cuh>
 #include <ATen/native/cuda/thread_constants.h>
 
-#include <thrust/iterator/reverse_iterator.h>
+#include <cuda/std/iterator>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
@@ -319,9 +319,9 @@ Tensor embedding_dense_backward_cuda(const Tensor & grad_, const Tensor & indice
       // sorted: 2 5 5 5 7 7 8 9 9
       //  count: 1 3 3 3 2 2 1 2 2
       cuda::cub::inclusive_scan_by_key(
-        thrust::make_reverse_iterator(sorted_data + num_indices),
-        thrust::make_reverse_iterator(static_cast<const index_t*>(count_data) + num_indices),
-        thrust::make_reverse_iterator(count_data + num_indices),
+        cuda::std::make_reverse_iterator(sorted_data + num_indices),
+        cuda::std::make_reverse_iterator(static_cast<const index_t*>(count_data) + num_indices),
+        cuda::std::make_reverse_iterator(count_data + num_indices),
         ATEN_CUB_MAXIMUM(),
         num_indices
       );

--- a/aten/src/ATen/native/cuda/Embedding.cu
+++ b/aten/src/ATen/native/cuda/Embedding.cu
@@ -319,9 +319,9 @@ Tensor embedding_dense_backward_cuda(const Tensor & grad_, const Tensor & indice
       // sorted: 2 5 5 5 7 7 8 9 9
       //  count: 1 3 3 3 2 2 1 2 2
       cuda::cub::inclusive_scan_by_key(
-        cuda::std::make_reverse_iterator(sorted_data + num_indices),
-        cuda::std::make_reverse_iterator(static_cast<const index_t*>(count_data) + num_indices),
-        cuda::std::make_reverse_iterator(count_data + num_indices),
+        ::cuda::std::make_reverse_iterator(sorted_data + num_indices),
+        ::cuda::std::make_reverse_iterator(static_cast<const index_t*>(count_data) + num_indices),
+        ::cuda::std::make_reverse_iterator(count_data + num_indices),
         ATEN_CUB_MAXIMUM(),
         num_indices
       );

--- a/aten/src/ATen/native/cuda/EmbeddingBackwardKernel.cu
+++ b/aten/src/ATen/native/cuda/EmbeddingBackwardKernel.cu
@@ -11,8 +11,6 @@
 
 #include <c10/macros/Macros.h>
 
-#include <thrust/iterator/counting_iterator.h>
-
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
 #else
@@ -306,7 +304,7 @@ Tensor embedding_backward_cuda_kernel(
   int64_t *num_of_segments_ptr = num_of_segments_tensor.mutable_data_ptr<int64_t>();
   AT_DISPATCH_INDEX_TYPES(orig_indices.scalar_type(), "embedding_backward_cuda_kernel", [&] () {
     cuda::cub::unique_by_key(
-      sorted_indices.const_data_ptr<index_t>(), thrust::make_counting_iterator(0),
+      sorted_indices.const_data_ptr<index_t>(), cccl_counting_iterator{0},
       segment_offsets.mutable_data_ptr<index_t>(),
       num_of_segments_ptr, sorted_indices.numel());
   });

--- a/aten/src/ATen/native/cuda/EmbeddingBackwardKernel.cu
+++ b/aten/src/ATen/native/cuda/EmbeddingBackwardKernel.cu
@@ -304,7 +304,7 @@ Tensor embedding_backward_cuda_kernel(
   int64_t *num_of_segments_ptr = num_of_segments_tensor.mutable_data_ptr<int64_t>();
   AT_DISPATCH_INDEX_TYPES(orig_indices.scalar_type(), "embedding_backward_cuda_kernel", [&] () {
     cuda::cub::unique_by_key(
-      sorted_indices.const_data_ptr<index_t>(), cccl_counting_iterator{0},
+      sorted_indices.const_data_ptr<index_t>(), cccl_counting_iterator<index_t>{0},
       segment_offsets.mutable_data_ptr<index_t>(),
       num_of_segments_ptr, sorted_indices.numel());
   });

--- a/aten/src/ATen/native/cuda/EmbeddingBag.cu
+++ b/aten/src/ATen/native/cuda/EmbeddingBag.cu
@@ -230,9 +230,9 @@ Tensor embedding_bag_backward_cuda_sum_avg(
       // sorted: 2 5 5 5 7 7 8 9 9
       //  count: 1 3 3 3 2 2 1 2 2
       cuda::cub::inclusive_scan_by_key(
-        cuda::std::make_reverse_iterator(sorted_data + num_indices),
-        cuda::std::make_reverse_iterator(count_data + num_indices),
-        cuda::std::make_reverse_iterator(count_data + num_indices),
+        ::cuda::std::make_reverse_iterator(sorted_data + num_indices),
+        ::cuda::std::make_reverse_iterator(count_data + num_indices),
+        ::cuda::std::make_reverse_iterator(count_data + num_indices),
         ATEN_CUB_MAXIMUM(),
         num_indices
       );

--- a/aten/src/ATen/native/cuda/EmbeddingBag.cu
+++ b/aten/src/ATen/native/cuda/EmbeddingBag.cu
@@ -31,7 +31,7 @@
 
 #include <c10/macros/Macros.h>
 
-#include <thrust/iterator/reverse_iterator.h>
+#include <cuda/std/iterator>
 
 namespace at::native {
 
@@ -230,9 +230,9 @@ Tensor embedding_bag_backward_cuda_sum_avg(
       // sorted: 2 5 5 5 7 7 8 9 9
       //  count: 1 3 3 3 2 2 1 2 2
       cuda::cub::inclusive_scan_by_key(
-        thrust::make_reverse_iterator(sorted_data + num_indices),
-        thrust::make_reverse_iterator(count_data + num_indices),
-        thrust::make_reverse_iterator(count_data + num_indices),
+        cuda::std::make_reverse_iterator(sorted_data + num_indices),
+        cuda::std::make_reverse_iterator(count_data + num_indices),
+        cuda::std::make_reverse_iterator(count_data + num_indices),
         ATEN_CUB_MAXIMUM(),
         num_indices
       );

--- a/aten/src/ATen/native/cuda/EmbeddingBag.cu
+++ b/aten/src/ATen/native/cuda/EmbeddingBag.cu
@@ -31,8 +31,6 @@
 
 #include <c10/macros/Macros.h>
 
-#include <cuda/std/iterator>
-
 namespace at::native {
 
 
@@ -230,9 +228,9 @@ Tensor embedding_bag_backward_cuda_sum_avg(
       // sorted: 2 5 5 5 7 7 8 9 9
       //  count: 1 3 3 3 2 2 1 2 2
       cuda::cub::inclusive_scan_by_key(
-        ::cuda::std::make_reverse_iterator(sorted_data + num_indices),
-        ::cuda::std::make_reverse_iterator(count_data + num_indices),
-        ::cuda::std::make_reverse_iterator(count_data + num_indices),
+        cccl_make_reverse_iterator(sorted_data + num_indices),
+        cccl_make_reverse_iterator(count_data + num_indices),
+        cccl_make_reverse_iterator(count_data + num_indices),
         ATEN_CUB_MAXIMUM(),
         num_indices
       );

--- a/aten/src/ATen/native/cuda/TensorModeKernel.cu
+++ b/aten/src/ATen/native/cuda/TensorModeKernel.cu
@@ -5,6 +5,7 @@
 #include <ATen/native/NonEmptyUtils.h>
 #include <ATen/cuda/detail/IndexUtils.cuh>
 #include <ATen/cuda/ThrustAllocator.h>
+#include <ATen/cuda/cub.cuh>
 #include <c10/core/DeviceArray.h>
 
 #include <thrust/count.h>
@@ -14,7 +15,6 @@
 #include <thrust/extrema.h>
 #include <thrust/find.h>
 #include <thrust/inner_product.h>
-#include <thrust/iterator/constant_iterator.h>
 #include <thrust/sequence.h>
 #include <thrust/sort.h>
 
@@ -33,7 +33,7 @@ struct ModeImpl {
     auto cuda_allocator = at::cuda::getCUDADeviceAllocator();
     auto sort_buffer = c10::DeviceArray<int64_t>(*cuda_allocator, n_element);
     auto sort_buffer_ptr = thrust::device_pointer_cast(sort_buffer.get());
-    auto count_from_zero_iter = thrust::make_counting_iterator(int64_t{0});
+    auto count_from_zero_iter = cccl_counting_iterator<int64_t>{0ll};
     thrust::copy_n(policy, count_from_zero_iter, n_element, sort_buffer_ptr);
 
 
@@ -64,7 +64,7 @@ struct ModeImpl {
         policy,
         iter_begin,
         iter_end,
-        thrust::constant_iterator<int>(1),
+        cccl_constant_iterator<int>{1},
         keys_ptr,
         counts_ptr);
 

--- a/aten/src/ATen/native/cuda/TensorTopK.cu
+++ b/aten/src/ATen/native/cuda/TensorTopK.cu
@@ -1438,7 +1438,7 @@ void launch(
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 
   // CUDA path: Do a prefix scan of withinKCounts and kthCounts using slice_idx as keys to get the starting index of each block
-  using counting_iter_t = ATEN_CUB_COUNTING_ITERATOR(uint32_t, uint32_t);
+  using counting_iter_t = ATEN_CUB_COUNTING_ITERATOR(uint32_t);
   using slice_idx_iter_t = ATEN_CUB_TRANSFORM_ITERATOR(uint32_t, BlockIdxToKey, counting_iter_t);
   slice_idx_iter_t slice_idx_iter(counting_iter_t(0), BlockIdxToKey(blocks_per_slice));
   at::cuda::cub::inclusive_sum_by_key(slice_idx_iter, withinKCounts, withinKCounts, num_blocks);

--- a/aten/src/ATen/native/cuda/UniqueCub.cu
+++ b/aten/src/ATen/native/cuda/UniqueCub.cu
@@ -46,7 +46,7 @@ const scalar_t * wrap_input_iterator(const scalar_t *data) {
 }
 
 struct LoadBoolOp {
-  __device__ bool operator()(uint8_t x) const {
+  __device__ int operator()(uint8_t x) const {
     return static_cast<bool>(x);
   }
 };
@@ -54,7 +54,7 @@ struct LoadBoolOp {
 auto wrap_input_iterator(const bool *data) {
   // See NOTE [Loading boolean values]
   LoadBoolOp op;
-  return ATEN_CUB_TRANSFORM_ITERATOR(bool, LoadBoolOp, const uint8_t*, int)(
+  return ATEN_CUB_TRANSFORM_ITERATOR(bool, LoadBoolOp, const uint8_t*)(
       reinterpret_cast<const uint8_t*>(data), op);
 }
 
@@ -259,7 +259,7 @@ struct UniqueCub<bool> {
 
     const bool* self_data = self.const_data_ptr<bool>();
     MapNumberOfTrueValues op;
-    ATEN_CUB_TRANSFORM_ITERATOR(int, MapNumberOfTrueValues, const uint8_t*, int)
+    ATEN_CUB_TRANSFORM_ITERATOR(int, MapNumberOfTrueValues, const uint8_t*)
         data_iter(reinterpret_cast<const uint8_t*>(self_data), op);
     at::cuda::cub::reduce(data_iter, tmp_num_true.get(), num_inp,
                           NO_ROCM(::cuda)::std::plus<>{}, 0);

--- a/aten/src/ATen/native/sparse/cuda/SoftMax.cu
+++ b/aten/src/ATen/native/sparse/cuda/SoftMax.cu
@@ -3,6 +3,7 @@
 #include <ATen/Dispatch.h>
 #include <ATen/ExpandUtils.h>
 #include <ATen/WrapDimUtilsMulti.h>
+#include <ATen/cuda/cub.cuh>
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/cuda/CUDAUtils.h>
 #include <ATen/cuda/ThrustAllocator.h>
@@ -32,8 +33,6 @@
 #include <thrust/device_ptr.h>
 #include <thrust/distance.h>
 #include <thrust/for_each.h>
-#include <thrust/iterator/constant_iterator.h>
-#include <thrust/iterator/discard_iterator.h>
 #include <thrust/scan.h>
 #include <thrust/sequence.h>
 #include <thrust/sort.h>
@@ -252,8 +251,8 @@ Tensor get_offsets(
 
   thrust::transform(
       policy,
-      thrust::make_counting_iterator(int64_t(0)),
-      thrust::make_counting_iterator(int64_t(nnz)),
+      cccl_counting_iterator<int64_t>{0ll},
+      cccl_counting_iterator<int64_t>{nnz},
       thrust::device_ptr<int64_t>(offsets.data_ptr<int64_t>()),
       [indices_accessor, strides_ptr, dim, ndim] __device__(int64_t x) {
         int64_t pool_index = 0;
@@ -310,8 +309,8 @@ std::tuple<Tensor, Tensor, Tensor, Tensor> compute_pool_max(
       policy,
       sorted_indices_thrust_ptr,
       sorted_indices_thrust_ptr + nnz,
-      thrust::make_constant_iterator(int64_t(1)),
-      thrust::make_discard_iterator(),
+      cccl_constant_iterator<int64_t>{1ll},
+      cccl_discard_iterator(),
       thrust_ptr(pool_sizes.template data_ptr<int64_t>()),
       [offsets_ptr] __device__(int64_t x, int64_t y) {
         return offsets_ptr[x] == offsets_ptr[y];
@@ -350,8 +349,8 @@ std::tuple<Tensor, Tensor, Tensor, Tensor> compute_pool_max(
 
     thrust::for_each(
         policy,
-        thrust::make_counting_iterator(int64_t(0)),
-        thrust::make_counting_iterator(int64_t(new_sz)),
+        cccl_counting_iterator<int64_t>{0ll},
+        cccl_counting_iterator<int64_t>{new_sz},
         [values_accessor,
          sorted_indices_ptr,
          pool_sizes_ptr,

--- a/aten/src/ATen/native/sparse/cuda/SparseCUDATensor.cu
+++ b/aten/src/ATen/native/sparse/cuda/SparseCUDATensor.cu
@@ -3,6 +3,7 @@
 #include <ATen/core/Tensor.h>
 #include <ATen/ceil_div.h>
 #include <ATen/Dispatch.h>
+#include <ATen/cuda/cub.cuh>
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/cuda/ThrustAllocator.h>
 #include <ATen/native/sparse/cuda/SparseCUDAApplyUtils.cuh>
@@ -76,8 +77,8 @@ SparseTensor _coalesce_sparse_cuda(const SparseTensor& self) {
 
 
   // Fill sortedOrigIndices with sequential indices
-  thrust::counting_iterator<int64_t> countIterI(0);
-  thrust::counting_iterator<int64_t> countIterO(0);
+  cccl_counting_iterator<int64_t> countIterI(0ll);
+  cccl_counting_iterator<int64_t> countIterO(0ll);
 
   thrust::copy(policy, countIterI, countIterI + nnz, origIndicesIter);
   thrust::copy(policy, countIterO, countIterO + nnz, uniqueOffsetsIter);

--- a/aten/src/ATen/native/sparse/cuda/SparseCsrTensorMath.cu
+++ b/aten/src/ATen/native/sparse/cuda/SparseCsrTensorMath.cu
@@ -29,6 +29,7 @@
 #include <type_traits>
 
 
+#include <ATen/cuda/cub.cuh>
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/cuda/CUDAUtils.h>
 #include <ATen/cuda/ThrustAllocator.h>
@@ -266,9 +267,8 @@ Tensor& add_out_dense_sparse_compressed_cuda(
               // dimension.
               thrust::for_each(
                   policy,
-                  thrust::make_counting_iterator(int64_t(0)),
-                  thrust::make_counting_iterator(
-                      int64_t(src_compressed_indices.size(-1) - 1)),
+                  cccl_counting_iterator<int64_t>{0ll},
+                  cccl_counting_iterator<int64_t>{src_compressed_indices.size(-1) - 1},
                   [values_accessor,
                    compressed_indices_accessor,
                    plain_indices_accessor,

--- a/aten/src/ATen/native/sparse/cuda/SparseMatMul.cu
+++ b/aten/src/ATen/native/sparse/cuda/SparseMatMul.cu
@@ -476,7 +476,7 @@ void sparse_sparse_matmul_cuda_kernel(
   // Filling the COO column indices
   thrust::for_each(
     policy,
-    cccl_counting_iterator<int64_t>{0ll}),
+    cccl_counting_iterator<int64_t>{0ll},
     cccl_counting_iterator<int64_t>{csr_output.nnz_},
     [output_indices_accessor,
       csr_output_pointers_accessor,

--- a/aten/src/ATen/native/sparse/cuda/SparseMatMul.cu
+++ b/aten/src/ATen/native/sparse/cuda/SparseMatMul.cu
@@ -23,6 +23,7 @@
 #include <thrust/for_each.h>
 #include <thrust/sequence.h>
 
+#include <ATen/cuda/cub.cuh>
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/cuda/CUDADataType.h>
 #include <ATen/cuda/CUDAUtils.h>
@@ -33,11 +34,8 @@
 
 #include <thrust/device_vector.h>
 #include <thrust/host_vector.h>
-#include <thrust/iterator/counting_iterator.h>
 #include <thrust/functional.h>
 #include <thrust/execution_policy.h>
-#include <thrust/iterator/discard_iterator.h>
-
 
 #include <library_types.h>
 
@@ -461,8 +459,8 @@ void sparse_sparse_matmul_cuda_kernel(
   // Filling the COO row indices
   thrust::for_each(
       policy,
-      thrust::make_counting_iterator(int64_t(0)),
-      thrust::make_counting_iterator(int64_t(major_dim)),
+      cccl_counting_iterator<int64_t>{0ll},
+      cccl_counting_iterator<int64_t>{major_dim},
       [output_indices_accessor,
        csr_output_pointers_accessor,
        major_dim,
@@ -478,8 +476,8 @@ void sparse_sparse_matmul_cuda_kernel(
   // Filling the COO column indices
   thrust::for_each(
     policy,
-    thrust::make_counting_iterator(int64_t(0)),
-    thrust::make_counting_iterator(int64_t(csr_output.nnz_)),
+    cccl_counting_iterator<int64_t>{0ll}),
+    cccl_counting_iterator<int64_t>{csr_output.nnz_},
     [output_indices_accessor,
       csr_output_pointers_accessor,
       csr_output_ind_accessor,


### PR DESCRIPTION
CCCL is deprecating the old thrust iterators in favor of more standard aligned iterators.
