### PR TITLE
Add isinf() to Float8_e4m3fnuz to fix nan_asserts crash with fp8 inputs

### DIFF
--- a/torch/headeronly/util/Float8_e4m3fnuz.h
+++ b/torch/headeronly/util/Float8_e4m3fnuz.h
@@ -52,6 +52,7 @@ struct alignas(1) Float8_e4m3fnuz {
   inline C10_HOST_DEVICE Float8_e4m3fnuz(float value);
   inline C10_HOST_DEVICE operator float() const;
   inline C10_HOST_DEVICE bool isnan() const;
+  inline C10_HOST_DEVICE bool isinf() const;
 };
 
 inline std::ostream& operator<<(
@@ -158,6 +159,11 @@ inline C10_HOST_DEVICE Float8_e4m3fnuz::operator float() const {
 
 inline C10_HOST_DEVICE bool Float8_e4m3fnuz::isnan() const {
   return x == 0b10000000;
+}
+
+inline C10_HOST_DEVICE bool Float8_e4m3fnuz::isinf() const {
+  // Note: fp8e4m3fnuz does not have infinity, so this always returns false.
+  return false;
 }
 
 /// Arithmetic


### PR DESCRIPTION
Follow up to #160641 that did not also add isinf() to fnuz, only fn.

Additionally fixes #149002, had it been reported on the fnuz type.

Fixes a RuntimeError when `torch._inductor.config.nan_asserts = True` is used with `Float8_e4m3fn` inputs in compiled models.

Adds `Float8_e4m3fnuz::isinf()` returning false unconditionally. This is correct by the format specification: the "FNUZ" in `e4m3fnuz` stands for Finite (no inf), NaN, Unsigned NaN, and (unsigned) Zero.