### PR TITLE
Fix uint32 overflow in CUDA scan _with_indices kernels

### DIFF
--- a/aten/src/ATen/native/cuda/ScanUtils.cuh
+++ b/aten/src/ATen/native/cuda/ScanUtils.cuh
@@ -400,7 +400,7 @@ __global__ void tensor_kernel_scan_innermost_dim(
   T* sbuf2 = reinterpret_cast<T*>(sbuf);
   const uint32_t num_threads_x = 1 << log_num_threads_x;
   T* row_buf = reinterpret_cast<T*>(sbuf2 + num_threads_x * 2 * threadIdx.y);
-  if (num_rows * (size_t) row_size <= UINT_MAX) {
+  if (std::in_range<uint32_t>(num_rows * (size_t) row_size)) {
       tensor_kernel_scan_innermost_dim_impl<T, uint32_t>(
           row_buf, tgt_, src_, num_rows, row_size, log_num_threads_x, init, binary_op);
   } else {

--- a/aten/src/ATen/native/cuda/ScanUtils.cuh
+++ b/aten/src/ATen/native/cuda/ScanUtils.cuh
@@ -7,6 +7,7 @@
 #include <c10/util/Load.h>
 #include <limits>
 #include <cmath>
+#include <utility>
 
 namespace at::native {
 
@@ -208,7 +209,7 @@ __host__ void scan_outer_dim_with_indices(
   dim3 threads(std::min(512, int(num_irows)));
   int64_t maxGridDim = at::cuda::getCurrentDeviceProperties()->maxGridSize[1];
   dim3 grid(std::min(maxGridDim, num_orows), std::min(maxGridDim, ceil_div(num_irows, int64_t{threads.x})));
-  if (static_cast<size_t>(num_irows) * num_orows * row_size <= UINT_MAX) {
+  if (std::in_range<uint32_t>(static_cast<size_t>(num_irows) * num_orows * row_size)) {
     tensor_kernel_scan_outer_dim_with_indices<scalar_t, uint32_t><<<grid, threads, 0, at::cuda::getCurrentCUDAStream()>>>(
       self.const_data_ptr<scalar_t>(), values.mutable_data_ptr<scalar_t>(), indices.mutable_data_ptr<int64_t>(),
       num_orows, num_irows, row_size, init, binary_op);
@@ -242,7 +243,7 @@ __host__ void scan_innermost_dim_with_indices(
   check_fits_in_unsigned(row_size, "row_size");
 
   const uint32_t mem_size = 2 * num_threads * (sizeof(scalar_t) + sizeof(int64_t));
-  if (num_rows * static_cast<size_t>(row_size) <= UINT_MAX) {
+  if (std::in_range<uint32_t>(num_rows * static_cast<size_t>(row_size))) {
     tensor_kernel_scan_innermost_dim_with_indices<scalar_t, uint32_t><<<grid, threads, mem_size,
                                                               at::cuda::getCurrentCUDAStream()>>>(
       self.const_data_ptr<scalar_t>(), values.mutable_data_ptr<scalar_t>(), indices.mutable_data_ptr<int64_t>(),
@@ -428,7 +429,7 @@ __host__ void scan_outer_dim(const TensorBase& self, const TensorBase& result,
   check_fits_in_unsigned(num_irows, "num_irows");
   check_fits_in_unsigned(num_orows, "num_orows");
   check_fits_in_unsigned(row_size, "row_size");
-  if (static_cast<size_t>(num_irows) * num_orows * row_size <= UINT_MAX) {
+  if (std::in_range<uint32_t>(static_cast<size_t>(num_irows) * num_orows * row_size)) {
   tensor_kernel_scan_outer_dim<scalar_t, uint32_t><<<grid, threads, 0, at::cuda::getCurrentCUDAStream()>>>(
     result.mutable_data_ptr<scalar_t>(), self.const_data_ptr<scalar_t>(),
     num_orows, num_irows, row_size, init, binary_op);

--- a/aten/src/ATen/native/cuda/ScanUtils.cuh
+++ b/aten/src/ATen/native/cuda/ScanUtils.cuh
@@ -56,23 +56,24 @@ __device__ void binary_op_update(const scalar_t lhs, scalar_t& rhs, const idx_t 
  * Each thread block processes one or more sets of contiguous rows (processing multiple rows
  * per thread block is quicker than processing a single row, especially for short rows).
  */
-template<typename scalar_t, class BinaryFunction>
-__global__ void tensor_kernel_scan_innermost_dim_with_indices(const scalar_t *self_, scalar_t *values_, int64_t *indices_,
-                                                int num_rows, int row_size,
-                                                const uint32_t num_threads, const uint32_t log_num_threads_x,
-                                                scalar_t init, BinaryFunction binary_op) {
+template<typename scalar_t, typename index_t, class BinaryFunction>
+__global__ void tensor_kernel_scan_innermost_dim_with_indices(
+    const scalar_t *self_, scalar_t *values_, int64_t *indices_,
+    const uint32_t num_rows, const uint32_t row_size,
+    const uint32_t num_threads, const uint32_t log_num_threads_x,
+    scalar_t init, BinaryFunction binary_op) {
   // dynamic memory allocation for vbuf and ibuf
   alignas(sizeof(double)) extern __shared__ char buf[];
   scalar_t* vbuf = reinterpret_cast<scalar_t*>(buf); // the size is num_threads * 2
   int64_t* ibuf = reinterpret_cast<int64_t*>(vbuf + num_threads * 2);
-  const uint32_t num_threads_x = 1 << log_num_threads_x;
+  const index_t num_threads_x = 1 << log_num_threads_x;
   scalar_t* row_buf = vbuf + 2 * num_threads_x * threadIdx.y;
   int64_t* row_idx_buf = ibuf + 2 * num_threads_x * threadIdx.y;
 
-  for (int block_row = blockIdx.x * blockDim.y;
+  for (index_t block_row = blockIdx.x * static_cast<index_t>(blockDim.y);
        block_row < num_rows;
-       block_row += blockDim.y * gridDim.x) {
-    int row = block_row + threadIdx.y;
+       block_row += static_cast<index_t>(blockDim.y) * gridDim.x) {
+    index_t row = block_row + threadIdx.y;
     const scalar_t *row_self = self_ + row * row_size;
     scalar_t *row_values = values_ + row * row_size;
     int64_t *row_indices = indices_ + row * row_size;
@@ -81,10 +82,10 @@ __global__ void tensor_kernel_scan_innermost_dim_with_indices(const scalar_t *se
     const bool row_exists = row < num_rows;
     // Perform scan on one block at a time, keeping track of the total value of
     // all blocks processed so far.
-    for (int block_col = 0; block_col < row_size; block_col += 2 * num_threads_x) {
+    for (index_t block_col = 0; block_col < row_size; block_col += 2 * num_threads_x) {
       // Load data into shared memory (two values per thread).
-      int col1 = block_col + threadIdx.x;
-      int col2 = block_col + num_threads_x + threadIdx.x;
+      index_t col1 = block_col + threadIdx.x;
+      index_t col2 = block_col + num_threads_x + threadIdx.x;
       if (row_exists) {
         if (col1 < row_size) {
           row_buf[threadIdx.x] = c10::load(&row_self[col1]);
@@ -150,14 +151,15 @@ __global__ void tensor_kernel_scan_innermost_dim_with_indices(const scalar_t *se
  * outer dimensions, which contains several "inner rows").
  * Each thread processes a single inner row at a time.
  */
-template<typename scalar_t, class BinaryFunction>
+template<typename scalar_t, typename index_t, class BinaryFunction>
 __global__ void tensor_kernel_scan_outer_dim_with_indices(const scalar_t *self_, scalar_t *values_, int64_t *indices_,
                   const uint32_t num_orows, const uint32_t num_irows, const uint32_t row_size, scalar_t init, BinaryFunction binary_op) {
   for (uint32_t orow = blockIdx.x; orow < num_orows; orow += gridDim.x) {
     for (uint32_t irow = blockIdx.y * blockDim.x + threadIdx.x; irow < num_irows; irow += gridDim.y * blockDim.x) {
-      const scalar_t *self = self_ + orow * row_size * num_irows + irow;
-      scalar_t *values = values_ + orow * row_size * num_irows + irow;
-      int64_t *indices = indices_ + orow * row_size * num_irows + irow;
+      const index_t offset = static_cast<index_t>(orow) * row_size * num_irows + irow;
+      const scalar_t *self = self_ + offset;
+      scalar_t *values = values_ + offset;
+      int64_t *indices = indices_ + offset;
       scalar_t out = init;
       int64_t out_idx = 0;
 
@@ -206,9 +208,15 @@ __host__ void scan_outer_dim_with_indices(
   dim3 threads(std::min(512, int(num_irows)));
   int64_t maxGridDim = at::cuda::getCurrentDeviceProperties()->maxGridSize[1];
   dim3 grid(std::min(maxGridDim, num_orows), std::min(maxGridDim, ceil_div(num_irows, int64_t{threads.x})));
-  tensor_kernel_scan_outer_dim_with_indices<scalar_t><<<grid, threads, 0, at::cuda::getCurrentCUDAStream()>>>(
-    self.const_data_ptr<scalar_t>(), values.mutable_data_ptr<scalar_t>(), indices.mutable_data_ptr<int64_t>(),
-    num_orows, num_irows, row_size, init, binary_op);
+  if (static_cast<size_t>(num_irows) * num_orows * row_size <= UINT_MAX) {
+    tensor_kernel_scan_outer_dim_with_indices<scalar_t, uint32_t><<<grid, threads, 0, at::cuda::getCurrentCUDAStream()>>>(
+      self.const_data_ptr<scalar_t>(), values.mutable_data_ptr<scalar_t>(), indices.mutable_data_ptr<int64_t>(),
+      num_orows, num_irows, row_size, init, binary_op);
+  } else {
+    tensor_kernel_scan_outer_dim_with_indices<scalar_t, size_t><<<grid, threads, 0, at::cuda::getCurrentCUDAStream()>>>(
+      self.const_data_ptr<scalar_t>(), values.mutable_data_ptr<scalar_t>(), indices.mutable_data_ptr<int64_t>(),
+      num_orows, num_irows, row_size, init, binary_op);
+  }
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 }
 
@@ -216,10 +224,10 @@ template <typename scalar_t, class BinaryFunction>
 __host__ void scan_innermost_dim_with_indices(
     const TensorBase& self, const TensorBase& values, const TensorBase& indices,
     scalar_t init, BinaryFunction binary_op) {
-  int ndim = self.dim();
+  int64_t ndim = self.dim();
   // Treat all outer dimensions as a single dimension.
-  int row_size = self.size(ndim - 1);
-  int num_rows = self.numel() / row_size;
+  int64_t row_size = self.size(ndim - 1);
+  int64_t num_rows = self.numel() / row_size;
 
   // assuming max_num_threads per block is 512
   const uint32_t num_threads = 512;
@@ -227,13 +235,24 @@ __host__ void scan_innermost_dim_with_indices(
   const uint32_t num_threads_x = (1 << log_num_threads_x);
   const uint32_t num_threads_y = num_threads / num_threads_x;
   dim3 threads(num_threads_x, num_threads_y);
-  dim3 grid(std::min(at::cuda::getCurrentDeviceProperties()->maxGridSize[0], ceil_div(num_rows, int(threads.y))));
+  int64_t maxGridDim = at::cuda::getCurrentDeviceProperties()->maxGridSize[0];
+  dim3 grid(std::min(maxGridDim, ceil_div(num_rows, int64_t{threads.y})));
+
+  check_fits_in_unsigned(num_rows, "Number of rows (self.numel()/self.size(self.dim()-1))");
+  check_fits_in_unsigned(row_size, "row_size");
 
   const uint32_t mem_size = 2 * num_threads * (sizeof(scalar_t) + sizeof(int64_t));
-  tensor_kernel_scan_innermost_dim_with_indices<scalar_t><<<grid, threads, mem_size,
+  if (num_rows * static_cast<size_t>(row_size) <= UINT_MAX) {
+    tensor_kernel_scan_innermost_dim_with_indices<scalar_t, uint32_t><<<grid, threads, mem_size,
+                                                              at::cuda::getCurrentCUDAStream()>>>(
+      self.const_data_ptr<scalar_t>(), values.mutable_data_ptr<scalar_t>(), indices.mutable_data_ptr<int64_t>(),
+      num_rows, row_size, num_threads, log_num_threads_x, init, binary_op);
+  } else {
+    tensor_kernel_scan_innermost_dim_with_indices<scalar_t, size_t><<<grid, threads, mem_size,
                                                             at::cuda::getCurrentCUDAStream()>>>(
-    self.const_data_ptr<scalar_t>(), values.mutable_data_ptr<scalar_t>(), indices.mutable_data_ptr<int64_t>(),
-    num_rows, row_size, num_threads, log_num_threads_x, init, binary_op);
+      self.const_data_ptr<scalar_t>(), values.mutable_data_ptr<scalar_t>(), indices.mutable_data_ptr<int64_t>(),
+      num_rows, row_size, num_threads, log_num_threads_x, init, binary_op);
+  }
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 }
 

--- a/aten/src/ATen/native/cuda/ScanUtils.cuh
+++ b/aten/src/ATen/native/cuda/ScanUtils.cuh
@@ -253,7 +253,7 @@ __host__ void scan_innermost_dim_with_indices(
 
   // assuming max_num_threads per block is 512
   const uint32_t num_threads = 512;
-  const uint32_t log_num_threads_x = get_log_num_threads_x_inner_scan<int64_t>(num_rows, row_size);
+  const uint32_t log_num_threads_x = get_log_num_threads_x_inner_scan<uint64_t>(num_rows, row_size);
   const uint32_t num_threads_x = (1 << log_num_threads_x);
   const uint32_t num_threads_y = num_threads / num_threads_x;
   dim3 threads(num_threads_x, num_threads_y);

--- a/aten/src/ATen/native/cuda/ScanUtils.cuh
+++ b/aten/src/ATen/native/cuda/ScanUtils.cuh
@@ -67,26 +67,27 @@ __global__ void tensor_kernel_scan_innermost_dim_with_indices(
   alignas(sizeof(double)) extern __shared__ char buf[];
   scalar_t* vbuf = reinterpret_cast<scalar_t*>(buf); // the size is num_threads * 2
   int64_t* ibuf = reinterpret_cast<int64_t*>(vbuf + num_threads * 2);
-  const index_t num_threads_x = 1 << log_num_threads_x;
+  const uint32_t num_threads_x = 1 << log_num_threads_x;
   scalar_t* row_buf = vbuf + 2 * num_threads_x * threadIdx.y;
   int64_t* row_idx_buf = ibuf + 2 * num_threads_x * threadIdx.y;
 
+  const size_t row_stride = static_cast<size_t>(blockDim.y) * gridDim.x;
   for (index_t block_row = blockIdx.x * static_cast<index_t>(blockDim.y);
-       block_row < num_rows;
-       block_row += static_cast<index_t>(blockDim.y) * gridDim.x) {
-    index_t row = block_row + threadIdx.y;
-    const scalar_t *row_self = self_ + row * row_size;
-    scalar_t *row_values = values_ + row * row_size;
-    int64_t *row_indices = indices_ + row * row_size;
+       block_row < num_rows;) {
+    const index_t row = block_row + threadIdx.y;
+    const bool row_exists = row < num_rows;
+    const index_t row_offset = row_exists ? row * row_size : 0;
+    const scalar_t *row_self = self_ + row_offset;
+    scalar_t *row_values = values_ + row_offset;
+    int64_t *row_indices = indices_ + row_offset;
     scalar_t block_total = init;
     int64_t block_idx_final = 0;
-    const bool row_exists = row < num_rows;
     // Perform scan on one block at a time, keeping track of the total value of
     // all blocks processed so far.
-    for (index_t block_col = 0; block_col < row_size; block_col += 2 * num_threads_x) {
+    for (uint32_t block_col = 0; block_col < row_size;) {
       // Load data into shared memory (two values per thread).
-      index_t col1 = block_col + threadIdx.x;
-      index_t col2 = block_col + num_threads_x + threadIdx.x;
+      uint32_t col1 = block_col + threadIdx.x;
+      uint32_t col2 = block_col + num_threads_x + threadIdx.x;
       if (row_exists) {
         if (col1 < row_size) {
           row_buf[threadIdx.x] = c10::load(&row_self[col1]);
@@ -137,7 +138,15 @@ __global__ void tensor_kernel_scan_innermost_dim_with_indices(
       block_total = row_buf[2 * num_threads_x - 1];
       block_idx_final = row_idx_buf[2 * num_threads_x - 1];
       __syncthreads();
+      if (row_size - block_col <= 2 * num_threads_x) {
+        break;
+      }
+      block_col += 2 * num_threads_x;
     }
+    if (num_rows - block_row <= row_stride) {
+      break;
+    }
+    block_row += static_cast<index_t>(row_stride);
   }
 }
 
@@ -155,8 +164,10 @@ __global__ void tensor_kernel_scan_innermost_dim_with_indices(
 template<typename scalar_t, typename index_t, class BinaryFunction>
 __global__ void tensor_kernel_scan_outer_dim_with_indices(const scalar_t *self_, scalar_t *values_, int64_t *indices_,
                   const uint32_t num_orows, const uint32_t num_irows, const uint32_t row_size, scalar_t init, BinaryFunction binary_op) {
-  for (uint32_t orow = blockIdx.x; orow < num_orows; orow += gridDim.x) {
-    for (uint32_t irow = blockIdx.y * blockDim.x + threadIdx.x; irow < num_irows; irow += gridDim.y * blockDim.x) {
+  const size_t orow_stride = gridDim.x;
+  const size_t irow_stride = static_cast<size_t>(gridDim.y) * blockDim.x;
+  for (uint32_t orow = blockIdx.x; orow < num_orows;) {
+    for (uint32_t irow = blockIdx.y * blockDim.x + threadIdx.x; irow < num_irows;) {
       const index_t offset = static_cast<index_t>(orow) * row_size * num_irows + irow;
       const scalar_t *self = self_ + offset;
       scalar_t *values = values_ + offset;
@@ -176,7 +187,15 @@ __global__ void tensor_kernel_scan_outer_dim_with_indices(const scalar_t *self_,
         values += num_irows;
         indices += num_irows;
       }
+      if (num_irows - irow <= irow_stride) {
+        break;
+      }
+      irow += static_cast<uint32_t>(irow_stride);
     }
+    if (num_orows - orow <= orow_stride) {
+      break;
+    }
+    orow += static_cast<uint32_t>(orow_stride);
   }
 }
 
@@ -205,8 +224,7 @@ __host__ void scan_outer_dim_with_indices(
   check_fits_in_unsigned(num_orows, "num_orows");
   check_fits_in_unsigned(row_size, "row_size");
 
-
-  dim3 threads(std::min(512, int(num_irows)));
+  dim3 threads(std::min<int64_t>(512, num_irows));
   int64_t maxGridDim = at::cuda::getCurrentDeviceProperties()->maxGridSize[1];
   dim3 grid(std::min(maxGridDim, num_orows), std::min(maxGridDim, ceil_div(num_irows, int64_t{threads.x})));
   if (std::in_range<uint32_t>(static_cast<size_t>(num_irows) * num_orows * row_size)) {
@@ -230,17 +248,17 @@ __host__ void scan_innermost_dim_with_indices(
   int64_t row_size = self.size(ndim - 1);
   int64_t num_rows = self.numel() / row_size;
 
+  check_fits_in_unsigned(num_rows, "Number of rows (self.numel()/self.size(self.dim()-1))");
+  check_fits_in_unsigned(row_size, "row_size");
+
   // assuming max_num_threads per block is 512
   const uint32_t num_threads = 512;
-  const uint32_t log_num_threads_x = get_log_num_threads_x_inner_scan<uint32_t>(num_rows, row_size);
+  const uint32_t log_num_threads_x = get_log_num_threads_x_inner_scan<int64_t>(num_rows, row_size);
   const uint32_t num_threads_x = (1 << log_num_threads_x);
   const uint32_t num_threads_y = num_threads / num_threads_x;
   dim3 threads(num_threads_x, num_threads_y);
   int64_t maxGridDim = at::cuda::getCurrentDeviceProperties()->maxGridSize[0];
   dim3 grid(std::min(maxGridDim, ceil_div(num_rows, int64_t{threads.y})));
-
-  check_fits_in_unsigned(num_rows, "Number of rows (self.numel()/self.size(self.dim()-1))");
-  check_fits_in_unsigned(row_size, "row_size");
 
   const uint32_t mem_size = 2 * num_threads * (sizeof(scalar_t) + sizeof(int64_t));
   if (std::in_range<uint32_t>(num_rows * static_cast<size_t>(row_size))) {
@@ -400,7 +418,7 @@ __global__ void tensor_kernel_scan_innermost_dim(
   T* sbuf2 = reinterpret_cast<T*>(sbuf);
   const uint32_t num_threads_x = 1 << log_num_threads_x;
   T* row_buf = reinterpret_cast<T*>(sbuf2 + num_threads_x * 2 * threadIdx.y);
-  if (std::in_range<uint32_t>(num_rows * (size_t) row_size)) {
+  if (num_rows * (size_t) row_size <= UINT_MAX) {
       tensor_kernel_scan_innermost_dim_impl<T, uint32_t>(
           row_buf, tgt_, src_, num_rows, row_size, log_num_threads_x, init, binary_op);
   } else {

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1799,42 +1799,60 @@ class TestTorchDeviceType(TestCase):
 
     @onlyCUDA
     @largeTensorTest('48GB')
-    def test_cummax_cummin_outer_dim_64bit_indexing(self, device):
+    @parametrize(
+        "shape",
+        [
+            (262145, 1, 16384),
+            (2**32 - 1, 1, 1),
+            (2, 1, 2**31 + 1),
+            (1, 1, 2**32 - 1),
+        ],
+    )
+    def test_cummax_cummin_outer_dim_64bit_indexing(self, device, shape):
         # https://github.com/pytorch/pytorch/issues/167086
         # scan_outer_dim_with_indices had uint32 overflow when
         # num_orows * row_size * num_irows > UINT_MAX.
         # Use int8 to keep memory within 48GB (input + vals + int64 indices).
-        # 262144 * 16384 = 2^32 = UINT_MAX + 1.
-        x = torch.zeros(262144, 1, 16384, dtype=torch.int8, device=device)
-        # Allocate+free a non-zero tensor so the caching allocator's freed
-        # block contains non-zero values.  If the scan kernel has an OOB
-        # read due to index overflow, stale values will appear in the output.
-        tmp = torch.ones_like(x)
-        del tmp
-        vals, indices = torch.cummax(x, dim=1)
+        # These shapes cover wide offsets, UINT_MAX orows and irows, and irows
+        # above INT_MAX in the host launch configuration.
+        x = torch.zeros(shape, dtype=torch.int8, device=device)
+        vals = torch.ones_like(x)
+        indices = torch.full_like(x, -1, dtype=torch.int64)
+        torch.cummax(x, dim=1, out=(vals, indices))
         self.assertEqual(vals.max().item(), 0)
+        self.assertEqual(indices.min().item(), 0)
         self.assertEqual(indices.max().item(), 0)
-        del vals, indices
-        vals, indices = torch.cummin(x, dim=1)
-        self.assertEqual(vals.min().item(), 0)
+        vals.fill_(1)
+        indices.fill_(-1)
+        torch.cummin(x, dim=1, out=(vals, indices))
+        self.assertEqual(vals.max().item(), 0)
+        self.assertEqual(indices.min().item(), 0)
         self.assertEqual(indices.max().item(), 0)
 
     @onlyCUDA
     @largeTensorTest('48GB')
-    def test_cummax_cummin_inner_dim_64bit_indexing(self, device):
+    @parametrize(
+        "num_rows,row_size",
+        [(262144, 16384), (2**31 + 1, 2), (2**32 - 1, 1), (1, 2**32 - 1)],
+    )
+    def test_cummax_cummin_inner_dim_64bit_indexing(self, device, num_rows, row_size):
         # Exercises the innermost-dim _with_indices path when
         # num_rows * row_size > UINT_MAX (scan along the last dimension).
-        # 262144 * 16384 = 2^32 = UINT_MAX + 1.
-        x = torch.zeros(262144, 16384, dtype=torch.int8, device=device)
-        tmp = torch.ones_like(x)
-        del tmp
-        vals, indices = torch.cummax(x, dim=-1)
+        # The latter cases cover more than INT_MAX rows and the exact UINT_MAX
+        # row and column grid-stride boundaries.
+        x = torch.zeros(num_rows, row_size, dtype=torch.int8, device=device)
+        vals = torch.ones_like(x)
+        indices = torch.full_like(x, -1, dtype=torch.int64)
+        torch.cummax(x, dim=-1, out=(vals, indices))
         self.assertEqual(vals.max().item(), 0)
-        self.assertEqual(indices.max().item(), 0)
-        del vals, indices
-        vals, indices = torch.cummin(x, dim=-1)
-        self.assertEqual(vals.min().item(), 0)
-        self.assertEqual(indices.max().item(), 0)
+        self.assertEqual(indices[:, -1].min().item(), row_size - 1)
+        self.assertEqual(indices[:, -1].max().item(), row_size - 1)
+        vals.fill_(1)
+        indices.fill_(-1)
+        torch.cummin(x, dim=-1, out=(vals, indices))
+        self.assertEqual(vals.max().item(), 0)
+        self.assertEqual(indices[:, -1].min().item(), row_size - 1)
+        self.assertEqual(indices[:, -1].max().item(), row_size - 1)
 
     @expectedFailureMeta  # expected a non-determinitic error, but it was not raised
     @onlyNativeDeviceTypes

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1803,6 +1803,7 @@ class TestTorchDeviceType(TestCase):
         "shape",
         [
             (262145, 1, 16384),
+            (131073, 2, 16384),
             (2**32 - 1, 1, 1),
             (2, 1, 2**31 + 1),
             (1, 1, 2**32 - 1),
@@ -1813,21 +1814,23 @@ class TestTorchDeviceType(TestCase):
         # scan_outer_dim_with_indices had uint32 overflow when
         # num_orows * row_size * num_irows > UINT_MAX.
         # Use int8 to keep memory within 48GB (input + vals + int64 indices).
-        # These shapes cover wide offsets, UINT_MAX orows and irows, and irows
-        # above INT_MAX in the host launch configuration.
+        # Shapes above UINT_MAX elements exercise wide offsets. Shapes at
+        # UINT_MAX exercise the uint32 kernel's row and column boundaries.
+        # The cases also cover nontrivial row sizes and irows above INT_MAX.
         x = torch.zeros(shape, dtype=torch.int8, device=device)
         vals = torch.ones_like(x)
         indices = torch.full_like(x, -1, dtype=torch.int64)
+        expected_indices = torch.arange(shape[1], device=device)
         torch.cummax(x, dim=1, out=(vals, indices))
         self.assertEqual(vals.max().item(), 0)
-        self.assertEqual(indices.min().item(), 0)
-        self.assertEqual(indices.max().item(), 0)
+        self.assertEqual(indices.amin(dim=(0, 2)), expected_indices)
+        self.assertEqual(indices.amax(dim=(0, 2)), expected_indices)
         vals.fill_(1)
         indices.fill_(-1)
         torch.cummin(x, dim=1, out=(vals, indices))
         self.assertEqual(vals.max().item(), 0)
-        self.assertEqual(indices.min().item(), 0)
-        self.assertEqual(indices.max().item(), 0)
+        self.assertEqual(indices.amin(dim=(0, 2)), expected_indices)
+        self.assertEqual(indices.amax(dim=(0, 2)), expected_indices)
 
     @onlyCUDA
     @largeTensorTest('48GB')
@@ -1838,19 +1841,22 @@ class TestTorchDeviceType(TestCase):
     def test_cummax_cummin_inner_dim_64bit_indexing(self, device, num_rows, row_size):
         # Exercises the innermost-dim _with_indices path when
         # num_rows * row_size > UINT_MAX (scan along the last dimension).
-        # The latter cases cover more than INT_MAX rows and the exact UINT_MAX
-        # row and column grid-stride boundaries.
+        # Shapes above UINT_MAX elements exercise wide offsets. Shapes at
+        # UINT_MAX exercise the uint32 kernel's row and column boundaries.
+        # The cases also cover more than INT_MAX rows.
         x = torch.zeros(num_rows, row_size, dtype=torch.int8, device=device)
         vals = torch.ones_like(x)
         indices = torch.full_like(x, -1, dtype=torch.int64)
         torch.cummax(x, dim=-1, out=(vals, indices))
         self.assertEqual(vals.max().item(), 0)
+        self.assertEqual(indices.min().item(), 0)
         self.assertEqual(indices[:, -1].min().item(), row_size - 1)
         self.assertEqual(indices[:, -1].max().item(), row_size - 1)
         vals.fill_(1)
         indices.fill_(-1)
         torch.cummin(x, dim=-1, out=(vals, indices))
         self.assertEqual(vals.max().item(), 0)
+        self.assertEqual(indices.min().item(), 0)
         self.assertEqual(indices[:, -1].min().item(), row_size - 1)
         self.assertEqual(indices[:, -1].max().item(), row_size - 1)
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1797,6 +1797,28 @@ class TestTorchDeviceType(TestCase):
         cumsum = torch.cumsum(x, dim=1)
         self.assertEqual(cumsum.max().item(), 0., atol=0., rtol=0.)
 
+    @onlyCUDA
+    @largeTensorTest('48GB')
+    def test_cummax_cummin_outer_dim_64bit_indexing(self, device):
+        # https://github.com/pytorch/pytorch/issues/167086
+        # scan_outer_dim_with_indices had uint32 overflow when
+        # num_orows * row_size * num_irows > UINT_MAX.
+        # Use int8 to keep memory within 48GB (input + vals + int64 indices).
+        # 262144 * 16384 = 2^32 = UINT_MAX + 1.
+        x = torch.zeros(262144, 1, 16384, dtype=torch.int8, device=device)
+        # Allocate+free a non-zero tensor so the caching allocator's freed
+        # block contains non-zero values.  If the scan kernel has an OOB
+        # read due to index overflow, stale values will appear in the output.
+        tmp = torch.ones_like(x)
+        del tmp
+        vals, indices = torch.cummax(x, dim=1)
+        self.assertEqual(vals.max().item(), 0)
+        self.assertEqual(indices.max().item(), 0)
+        del vals, indices
+        vals, indices = torch.cummin(x, dim=1)
+        self.assertEqual(vals.min().item(), 0)
+        self.assertEqual(indices.max().item(), 0)
+
     @expectedFailureMeta  # expected a non-determinitic error, but it was not raised
     @onlyNativeDeviceTypes
     def test_nondeterministic_alert_put(self, device):

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1819,6 +1819,23 @@ class TestTorchDeviceType(TestCase):
         self.assertEqual(vals.min().item(), 0)
         self.assertEqual(indices.max().item(), 0)
 
+    @onlyCUDA
+    @largeTensorTest('48GB')
+    def test_cummax_cummin_inner_dim_64bit_indexing(self, device):
+        # Exercises the innermost-dim _with_indices path when
+        # num_rows * row_size > UINT_MAX (scan along the last dimension).
+        # 262144 * 16384 = 2^32 = UINT_MAX + 1.
+        x = torch.zeros(262144, 16384, dtype=torch.int8, device=device)
+        tmp = torch.ones_like(x)
+        del tmp
+        vals, indices = torch.cummax(x, dim=-1)
+        self.assertEqual(vals.max().item(), 0)
+        self.assertEqual(indices.max().item(), 0)
+        del vals, indices
+        vals, indices = torch.cummin(x, dim=-1)
+        self.assertEqual(vals.min().item(), 0)
+        self.assertEqual(indices.max().item(), 0)
+
     @expectedFailureMeta  # expected a non-determinitic error, but it was not raised
     @onlyNativeDeviceTypes
     def test_nondeterministic_alert_put(self, device):


### PR DESCRIPTION
Fixes #167086

#167326 added 64-bit index support to `scan_outer_dim` (cumsum/cumprod). This PR does the same for the `_with_indices` variants (cummax/cummin), which still overflow when `num_orows * row_size * num_irows > UINT_MAX`.

Both kernels (`tensor_kernel_scan_outer_dim_with_indices`, `tensor_kernel_scan_innermost_dim_with_indices`) now take an `index_t` template parameter for pointer offset arithmetic. The host functions (`scan_outer_dim_with_indices`, `scan_innermost_dim_with_indices`) check the total element count and dispatch `uint32_t` or `size_t`, matching #167326's pattern. `scan_innermost_dim_with_indices` also widens its `int` locals to `int64_t` and adds `check_fits_in_unsigned` bounds checks that were missing.

## Test plan
`test_cummax_cummin_outer_dim_64bit_indexing` (48GB, CUDA-only): allocates 2^32 int8 elements and verifies `cummax`/`cummin` produce correct results on the outer-dim scan path.