### PR TITLE
[cuBLASLt] Make cuBLASLt workspace size env var static

### DIFF
--- a/aten/src/ATen/cuda/CublasHandlePool.cpp
+++ b/aten/src/ATen/cuda/CublasHandlePool.cpp
@@ -251,10 +251,10 @@ size_t parseCUDABlasLtWorkspaceSize() {
 }
 
 size_t getCUDABlasLtWorkspaceSize() {
-  size_t pool_size = parseCUDABlasLtWorkspaceSize();
+  static size_t pool_size = parseCUDABlasLtWorkspaceSize();
 #ifndef USE_ROCM
   if (unified_cublas_and_lt_workspaces()) {
-    auto cublasWorkspaceSize = parseChosenWorkspaceSize();
+    static size_t cublasWorkspaceSize = parseChosenWorkspaceSize();
     if (cublasWorkspaceSize < pool_size) {
       TORCH_WARN_ONCE("Requested unified CUBLASLT workspace size of ", pool_size,
                       " bytes exceeds CUBLAS workspace size of ", cublasWorkspaceSize,


### PR DESCRIPTION
saves ~500ns which is ~5% of E2E time for up to 1024x1024 matmuls on H100                                                                                                                                                                                                                                                                                                                                                                                        and using the workspace size env var dynamically isn't a good idea anyway especially for thread-safety reasons

Once https://github.com/pytorch/pytorch/pull/177912/changes is merged we can do the same for cuBLAS workspaces and update tests that use the env var as a hack

benchmarking investigation done with claude

cc @csarofeen @ptrblck @nWEIdia