### PR TITLE
[Inductor][NVGEMM] Fix FP4 autotuning tensor creation

### DIFF
--- a/torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm.py
+++ b/torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm.py
@@ -115,6 +115,10 @@ class NVUniversalGemmBenchmarkRequest(GPUDeviceBenchmarkMixin, BenchmarkRequest)
         """Create a function to run the NVIDIA Universal GEMM kernel."""
         import cutlass_api
 
+        from torch._inductor.utils import _ensure_fp4_dtype_registered
+
+        _ensure_fp4_dtype_registered()
+
         args = self._create_gemm_arguments(cutlass_api, input_tensors, out)
 
         if self._compiled_artifact is None:
@@ -284,7 +288,9 @@ class NVUniversalGemmCaller(ChoiceCaller):
         }
 
 
-def _create_dummy_tensor_from_layout(layout: Layout) -> torch.Tensor | None:
+def _create_dummy_tensor_from_layout(
+    layout: Layout, dtype_override: torch.dtype | None = None
+) -> torch.Tensor | None:
     """
     Create a FakeTensor from a Layout for kernel filtering.
 
@@ -293,7 +299,10 @@ def _create_dummy_tensor_from_layout(layout: Layout) -> torch.Tensor | None:
     metadata for its supports() checks.
     """
     try:
-        return layout.get_example()
+        result = layout.get_example()
+        if dtype_override is not None and result.dtype != dtype_override:
+            result = result.view(dtype_override)
+        return result
     except Exception:
         return None
 
@@ -339,13 +348,19 @@ def _add_nv_gemm_choices_impl(
     """
     import cutlass_api
 
+    from torch._inductor.utils import _ensure_fp4_dtype_registered
+
+    _ensure_fp4_dtype_registered()
+
     from torch._inductor.codegen.nv_universal_gemm.kernel_cache import (
         get_compatible_kernels,
     )
 
-    # Create dummy tensors for cutlass_api's supports() checks
+    # Create dummy tensors for cutlass_api's supports() checks.
+    # Pass node dtype to handle FP4 ReinterpretView (uint8 storage viewed as float4_e2m1fn_x2).
     dummy_tensors = [
-        _create_dummy_tensor_from_layout(node.get_layout()) for node in input_nodes
+        _create_dummy_tensor_from_layout(node.get_layout(), dtype_override=node.get_dtype())
+        for node in input_nodes
     ]
     out_tensor = _create_dummy_tensor_from_layout(layout)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #179169
* #179168
* __->__ #179175
* #176859
* #176847
* #176845
* #176549
* #176548
* #176547
* #176546
* #176545
* #176544
* #176543

FP4 tensors in Inductor IR use uint8 storage with a ReinterpretView
to float4_e2m1fn_x2. When creating dummy tensors for cutlass_api's
supports() checks, the layout produces uint8 tensors, which don't
match any FP4 kernel signatures.

Fix by passing dtype_override to view the dummy tensor as the
node's logical dtype (float4_e2m1fn_x2), and register the FP4
dtype before kernel enumeration.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo