### PR TITLE
[CI] Reduce distributed test timeouts: add 4th shard + mark slow tests

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -86,9 +86,10 @@ jobs:
           { config: "backwards_compat", shard: 1, num_shards: 1, runner: "${{ needs.get-label-type.outputs.label-type }}linux.c7i.2xlarge" },
           # Use m7i instead of m7a to match the existing (Intel Xeon) numerics. DTensor crossref tests like linalg.multi_dot have tight
           # float32 tolerances sensitive to different FMA/reduction order across CPU vendors.
-          { config: "distributed", shard: 1, num_shards: 3, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge.amx" },
-          { config: "distributed", shard: 2, num_shards: 3, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge.amx" },
-          { config: "distributed", shard: 3, num_shards: 3, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge.amx" },
+          { config: "distributed", shard: 1, num_shards: 4, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge.amx" },
+          { config: "distributed", shard: 2, num_shards: 4, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge.amx" },
+          { config: "distributed", shard: 3, num_shards: 4, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge.amx" },
+          { config: "distributed", shard: 4, num_shards: 4, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge.amx" },
           { config: "numpy_2_x", shard: 1, num_shards: 1, runner: "${{ needs.get-label-type.outputs.label-type }}linux.c7i.2xlarge" },
           { config: "libtorch_agnostic_targetting", shard: 1, num_shards: 1, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge" },
           { config: "openreg", shard: 1, num_shards: 1, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge" },

--- a/test/distributed/tensor/test_dtensor_ops.py
+++ b/test/distributed/tensor/test_dtensor_ops.py
@@ -26,7 +26,12 @@ from torch.testing._internal.common_device_type import (
 )
 from torch.testing._internal.common_methods_invocations import DecorateInfo, op_db
 from torch.testing._internal.common_ops_unbacked import ops_dde_xfail, ops_unbacked_skip
-from torch.testing._internal.common_utils import run_tests, suppress_warnings, TestCase
+from torch.testing._internal.common_utils import (
+    run_tests,
+    slowTest,
+    suppress_warnings,
+    TestCase,
+)
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     DTensorConverter,
     DTensorOpTestBase,
@@ -1023,6 +1028,7 @@ class TestSingleDimStrategies(DTensorOpTestBase):
 
         self.skipTest(f"Op {torch_op} failed to extract aten op")
 
+    @slowTest
     @suppress_warnings
     @ops(op_db, allowed_dtypes=(torch.float,))
     @skipOps(


### PR DESCRIPTION
## Summary

The distributed test config in the pull workflow has been intermittently timing out at the 210-minute limit. Analysis of recent CI data (last 14 days) shows:

- **P90 shard duration**: ~163 min (max: ~222 min, exceeding the 210-min timeout)
- **Primary culprits**: `test_dtensor_ops` sub-shards (34-66 min each due to individual `test_single_dim_strategy_*` tests hitting the 30-min per-test timeout), `test_pointwise_ops` (up to 90 min), `test_distributed_spawn` (~21 min per sub-shard)

This PR makes two changes:

1. **Increase distributed shards from 3 → 4** in `pull.yml`. This brings the expected P90 from ~163 min to ~122 min, with ~42% headroom matching the default config's safety margin. Cost: +1 `linux.2xlarge.amx` runner per commit.

2. **Mark `test_single_dim_strategy` as `@slowTest`**. These parametrized tests iterate over the full `op_db` with `world_size=2` on CPU-only runners. Individual variants like `test_single_dim_strategy_ceil_cpu_float32` and `test_single_dim_strategy_round_cpu_float32` regularly hit the 30-min per-test timeout, consuming 100+ min of shard budget for tests that individually provide limited signal in the pull workflow. They will still run in slow test CI.

## Verification

CI results on this PR confirm the improvement:

| Shard | Duration | Status |
|-------|----------|--------|
| distributed 1/4 | 56m 0s | pass |
| distributed 2/4 | 54m 32s | pass |
| distributed 3/4 | 38m 36s | pass |
| distributed 4/4 | 1h 12m 22s | pass |

**Max shard duration dropped from ~222 min (timeout) to 72 min, with 66% headroom to the 210-min limit.**

| Metric | Before (3 shards) | After (4 shards) |
|--------|-------------------|-------------------|
| P90 duration | ~163 min | ~54 min (this run) |
| Max duration | ~222 min (timeout) | 72 min |
| Headroom at max | **-6% (exceeded)** | **66%** |
| Timeouts | Intermittent | None |

cc @pytorch/pytorch-dev-infra

## Test plan

- [x] Verify the new 4th distributed shard runs correctly in CI
- [x] Verify `test_single_dim_strategy_*` tests are skipped in normal CI runs (without `PYTORCH_TEST_WITH_SLOW`)
- [ ] Monitor distributed shard durations over the next few days for timeout reduction