### PR TITLE
docs: fix out_dtype signatures for bmm, mm, addmm, baddbmm

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -547,7 +547,7 @@ Example::
 add_docstr(
     torch.addmm,
     r"""
-addmm(input, mat1, mat2, out_dtype=None, *, beta=1, alpha=1, out=None) -> Tensor
+addmm(input, mat1, mat2, *, beta=1, alpha=1, out=None) -> Tensor
 
 Performs a matrix multiplication of the matrices :attr:`mat1` and :attr:`mat2`.
 The matrix :attr:`input` is added to the final result.
@@ -584,9 +584,6 @@ Args:
     input (Tensor): matrix to be added
     mat1 (Tensor): the first matrix to be matrix multiplied
     mat2 (Tensor): the second matrix to be matrix multiplied
-    out_dtype (dtype, optional): the dtype of the output tensor,
-        Supported only on CUDA and for torch.float32 given
-        torch.float16/torch.bfloat16 input dtypes
 
 Keyword args:
     beta (Number, optional): multiplier for :attr:`input` (:math:`\beta`)
@@ -601,6 +598,22 @@ Example::
     >>> torch.addmm(M, mat1, mat2)
     tensor([[-4.8716,  1.4671, -1.3746],
             [ 0.7573, -3.9555, -2.8681]])
+
+.. function:: addmm(input, mat1, mat2, out_dtype, *, beta=1, alpha=1, out=None) -> Tensor
+   :noindex:
+
+Args:
+    input (Tensor): matrix to be added
+    mat1 (Tensor): the first matrix to be matrix multiplied
+    mat2 (Tensor): the second matrix to be matrix multiplied
+    out_dtype (dtype): the dtype of the output tensor.
+        Supported only on CUDA and for torch.float32 given
+        torch.float16/torch.bfloat16 input dtypes.
+
+Keyword args:
+    beta (Number, optional): multiplier for :attr:`input` (:math:`\beta`)
+    alpha (Number, optional): multiplier for :math:`mat1 @ mat2` (:math:`\alpha`)
+    {out}
 """.format(**common_args, **tf32_notes, **rocm_fp16_notes, **sparse_support_notes),
 )
 
@@ -1353,7 +1366,7 @@ Example::
 add_docstr(
     torch.baddbmm,
     r"""
-baddbmm(input, batch1, batch2, out_dtype=None, *, beta=1, alpha=1, out=None) -> Tensor
+baddbmm(input, batch1, batch2, *, beta=1, alpha=1, out=None) -> Tensor
 
 Performs a batch matrix-matrix product of matrices in :attr:`batch1`
 and :attr:`batch2`.
@@ -1387,9 +1400,6 @@ Args:
     input (Tensor): the tensor to be added
     batch1 (Tensor): the first batch of matrices to be multiplied
     batch2 (Tensor): the second batch of matrices to be multiplied
-    out_dtype (dtype, optional): the dtype of the output tensor,
-        Supported only on CUDA and for torch.float32 given
-        torch.float16/torch.bfloat16 input dtypes
 
 Keyword args:
     beta (Number, optional): multiplier for :attr:`input` (:math:`\beta`)
@@ -1403,6 +1413,22 @@ Example::
     >>> batch2 = torch.randn(10, 4, 5)
     >>> torch.baddbmm(M, batch1, batch2).size()
     torch.Size([10, 3, 5])
+
+.. function:: baddbmm(input, batch1, batch2, out_dtype, *, beta=1, alpha=1, out=None) -> Tensor
+   :noindex:
+
+Args:
+    input (Tensor): the tensor to be added
+    batch1 (Tensor): the first batch of matrices to be multiplied
+    batch2 (Tensor): the second batch of matrices to be multiplied
+    out_dtype (dtype): the dtype of the output tensor.
+        Supported only on CUDA and for torch.float32 given
+        torch.float16/torch.bfloat16 input dtypes.
+
+Keyword args:
+    beta (Number, optional): multiplier for :attr:`input` (:math:`\beta`)
+    alpha (Number, optional): multiplier for :math:`\text{{batch1}} \mathbin{{@}} \text{{batch2}}` (:math:`\alpha`)
+    {out}
 """.format(**common_args, **tf32_notes, **rocm_fp16_notes),
 )
 
@@ -1532,7 +1558,7 @@ Example::
 add_docstr(
     torch.bmm,
     r"""
-bmm(input, mat2, out_dtype=None, *, out=None) -> Tensor
+bmm(input, mat2, *, out=None) -> Tensor
 
 Performs a batch matrix-matrix product of matrices stored in :attr:`input`
 and :attr:`mat2`.
@@ -1558,9 +1584,6 @@ If :attr:`input` is a :math:`(b \times n \times m)` tensor, :attr:`mat2` is a
 Args:
     input (Tensor): the first batch of matrices to be multiplied
     mat2 (Tensor): the second batch of matrices to be multiplied
-    out_dtype (dtype, optional): the dtype of the output tensor,
-        Supported only on CUDA and for torch.float32 given
-        torch.float16/torch.bfloat16 input dtypes
 
 Keyword Args:
     {out}
@@ -1572,6 +1595,19 @@ Example::
     >>> res = torch.bmm(input, mat2)
     >>> res.size()
     torch.Size([10, 3, 5])
+
+.. function:: bmm(input, mat2, out_dtype, *, out=None) -> Tensor
+   :noindex:
+
+Args:
+    input (Tensor): the first batch of matrices to be multiplied
+    mat2 (Tensor): the second batch of matrices to be multiplied
+    out_dtype (dtype): the dtype of the output tensor.
+        Supported only on CUDA and for torch.float32 given
+        torch.float16/torch.bfloat16 input dtypes.
+
+Keyword Args:
+    {out}
 """.format(**common_args, **tf32_notes, **rocm_fp16_notes),
 )
 
@@ -7517,7 +7553,7 @@ Example::
 add_docstr(
     torch.mm,
     r"""
-mm(input, mat2, out_dtype=None, *, out=None) -> Tensor
+mm(input, mat2, *, out=None) -> Tensor
 
 Performs a matrix multiplication of the matrices :attr:`input` and :attr:`mat2`.
 
@@ -7543,9 +7579,6 @@ layout will be deduced from that of :attr:`input`.
 Args:
     input (Tensor): the first matrix to be matrix multiplied
     mat2 (Tensor): the second matrix to be matrix multiplied
-    out_dtype (dtype, optional): the dtype of the output tensor,
-        Supported only on CUDA and for torch.float32 given
-        torch.float16/torch.bfloat16 input dtypes
 
 Keyword args:
     {out}
@@ -7557,6 +7590,19 @@ Example::
     >>> torch.mm(mat1, mat2)
     tensor([[ 0.4851,  0.5037, -0.3633],
             [-0.0760, -3.6705,  2.4784]])
+
+.. function:: mm(input, mat2, out_dtype, *, out=None) -> Tensor
+   :noindex:
+
+Args:
+    input (Tensor): the first matrix to be matrix multiplied
+    mat2 (Tensor): the second matrix to be matrix multiplied
+    out_dtype (dtype): the dtype of the output tensor.
+        Supported only on CUDA and for torch.float32 given
+        torch.float16/torch.bfloat16 input dtypes.
+
+Keyword args:
+    {out}
 """.format(**common_args, **tf32_notes, **rocm_fp16_notes, **sparse_support_notes),
 )
 


### PR DESCRIPTION
Fixes #172751

## Summary

`torch.bmm`, `torch.mm`, `torch.addmm`, and `torch.baddbmm` document `out_dtype=None` as the default value for that parameter. However, passing `out_dtype=None` explicitly raises a `TypeError` at runtime because the C++ dispatcher resolves overloads structurally and does not accept `None` for a dtype argument.

As suggested by @albanD, this PR updates the docstrings to show two explicit signatures for each function:
- One without `out_dtype` (the common case)
- One with `out_dtype` as a required positional argument (when dtype casting is needed)

This follows the existing pattern used for `torch.max`, `torch.min`, and other functions with multiple overloads.

## Changes

- `torch/_torch_docs.py`: updated `addmm`, `baddbmm`, `bmm`, and `mm` docstrings

## Test plan

- [ ] Verify rendered docs show two overload signatures per function
- [ ] Confirm no other references to `out_dtype=None` remain in affected docstrings