### PR TITLE
Fix FA3 test which currently fails and times out

### DIFF
--- a/.github/workflows/_linux-test-stable-fa3.yml
+++ b/.github/workflows/_linux-test-stable-fa3.yml
@@ -54,24 +54,19 @@ jobs:
     # Don't run on forked repos
     if: github.repository_owner == 'pytorch'
     runs-on: linux.aws.h100
-    timeout-minutes: ${{ inputs.timeout-minutes || 30 }}
+    timeout-minutes: ${{ inputs.timeout-minutes || 60 }}
     permissions:
       id-token: write
       contents: read
     steps:
-      - name: Checkout PyTorch
-        uses: pytorch/pytorch/.github/actions/checkout-pytorch@main
-        with:
-          no-sudo: true
+      - name: Setup Linux
+        uses: ./.github/actions/setup-linux
 
       - name: Checkout flash-attention as a secondary repository
         uses: actions/checkout@v4
         with:
           repository: Dao-AILab/flash-attention
           path: flash-attention
-
-      - name: Setup Linux
-        uses: ./.github/actions/setup-linux
 
       - name: Login to ECR
         uses: ./.github/actions/ecr-login


### PR DESCRIPTION
https://github.com/pytorch/pytorch/commit/c62f72647d6f1bf86025b5e6dbdbd40e6721daf3 broke FA3 tests because the new checkout pytorch wiped the workspace so flash attention wasn't installed anymore.

This fixes that and increases the timeout because checking everything out takes longer than I thought.

Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #179183

