### PR TITLE
Remove unused mkl dynamic library package from CI requirements

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -75,7 +75,8 @@ librosa==0.10.2 ; python_version == "3.12" and platform_machine != "s390x"
 #test that import: test_spectral_ops.py
 #librosa depends on numba; disable it for s390x while numba is disabled too
 
-mkl==2024.2.0 ; platform_machine != "aarch64" and sys_platform != "darwin"
+# Only mkl-static and mkl-include are needed; the mkl package contains
+# dynamic libraries that are not discoverable by our build scripts.
 mkl-static==2024.2.0 ; platform_machine != "aarch64" and sys_platform != "darwin"
 mkl-include==2024.2.0 ; platform_machine != "aarch64" and sys_platform != "darwin"
 #Description: Intel oneAPI Math Kernel Library


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #179321
* #179320
* #179314
* __->__ #179186

The mkl pip package contains dynamic libraries that are not discoverable by existing build scripts.
Save some space, by installing only packages that are needed and used (i.e. mkl-static and mkl-include), as `mkl` ships exactly the same set of libraries, as `mkl-static`