### PR TITLE
[inductor] Handle overlapping bases in scatter decomposition

### DIFF
--- a/test/inductor/test_inplacing_pass.py
+++ b/test/inductor/test_inplacing_pass.py
@@ -441,6 +441,46 @@ class TestReinplacingPassCorrectness(InductorTestCase):
         result = torch.compile(fn, fullgraph=True, backend="inductor")(x)
         self.assertEqual(result, expected)
 
+    def test_generalized_scatter_overlapping_base(self):
+        from torch._inductor.fx_passes.reinplace import (
+            _decompose_scatter_mutating,
+            _generalized_scatter,
+            ViewOp,
+        )
+        from torch._inductor.virtualized import V
+        from torch._subclasses.fake_tensor import FakeTensorMode
+
+        fake_mode = FakeTensorMode()
+        graph = torch.fx.Graph()
+
+        with fake_mode:
+            base = torch.ones(1).expand(2, 2)
+            src = torch.arange(2.0)
+            expected = torch.diagonal_scatter(base, src)
+
+        self.assertEqual(torch._debug_has_internal_overlap(base), 1)
+
+        inp = graph.placeholder("inp")
+        inp.meta["val"] = base
+        src_node = graph.placeholder("src")
+        src_node.meta["val"] = src
+        scatter = graph.call_function(
+            _generalized_scatter,
+            args=(inp, src_node, [ViewOp(aten.diagonal.default, (), {})]),
+        )
+        scatter.meta["val"] = expected
+
+        with V.set_fake_mode(fake_mode):
+            _decompose_scatter_mutating(graph, scatter)
+
+        clone_nodes = list(
+            graph.find_nodes(op="call_function", target=aten.clone.default)
+        )
+        self.assertEqual(len(clone_nodes), 1)
+        self.assertEqual(
+            clone_nodes[0].kwargs["memory_format"], torch.contiguous_format
+        )
+
     @parametrize(
         "factory_op",
         [

--- a/torch/_inductor/fx_passes/reinplace.py
+++ b/torch/_inductor/fx_passes/reinplace.py
@@ -141,6 +141,20 @@ def _decompose_scatter_functional_helper(
     )
 
 
+def _clone_scatter_input(
+    graph: torch.fx.Graph, inp: torch.fx.Node
+) -> torch.fx.Node:
+    if torch._debug_has_internal_overlap(inp.meta["val"]) == 1:
+        # Match clone_preserve_strides(), which materializes overlapping inputs.
+        return graph_call_function(
+            graph,
+            aten.clone.default,
+            inp,
+            memory_format=torch.contiguous_format,
+        )
+    return graph_call_function(graph, aten.clone, inp)
+
+
 def _decompose_scatter_functional(
     graph: torch.fx.Graph, node: torch.fx.Node
 ) -> torch.fx.Node:
@@ -178,7 +192,7 @@ def _decompose_scatter_mutating(
     assert not node.kwargs
 
     if node.target is _generalized_scatter:
-        inp = graph_call_function(graph, aten.clone, inp)
+        inp = _clone_scatter_input(graph, inp)
 
     tmp = inp
     for view in view_ops:  # type: ignore[union-attr]

--- a/torch/_inductor/fx_passes/reinplace.py
+++ b/torch/_inductor/fx_passes/reinplace.py
@@ -141,9 +141,7 @@ def _decompose_scatter_functional_helper(
     )
 
 
-def _clone_scatter_input(
-    graph: torch.fx.Graph, inp: torch.fx.Node
-) -> torch.fx.Node:
+def _clone_scatter_input(graph: torch.fx.Graph, inp: torch.fx.Node) -> torch.fx.Node:
     if torch._debug_has_internal_overlap(inp.meta["val"]) == 1:
         # Match clone_preserve_strides(), which materializes overlapping inputs.
         return graph_call_function(
@@ -192,6 +190,7 @@ def _decompose_scatter_mutating(
     assert not node.kwargs
 
     if node.target is _generalized_scatter:
+        assert isinstance(inp, torch.fx.Node)
         inp = _clone_scatter_input(graph, inp)
 
     tmp = inp


### PR DESCRIPTION
Fix #178995

## Summary
- Root cause: `_decompose_scatter_mutating` cloned scatter bases with `aten.clone`, which preserves internally overlapping layouts from inputs like `expand()`. When the pass then replays a view such as `diagonal` and runs `copy_` for fake-tensor metadata, the write targets aliased storage and raises `RuntimeError: more than one element of the written-to tensor refers to a single memory location`.
- Proposed fix: make the mutating scatter decomposition match `clone_preserve_strides()` by materializing the clone with `memory_format=torch.contiguous_format` when the scatter base has internal overlap.
- Why this is the right long term fix: it aligns the reinplace decomposition with the native scatter operators' existing overlap handling instead of introducing a diagonal-specific special case, so all generalized scatter decompositions follow the same semantics for overlapping bases.

## Testing
- Added a focused reinplace regression test that constructs an overlapping expanded base and verifies the decomposition emits a contiguous clone before the mutating view copy.

Drafted via Codex, published after manual review by @bobrenjc93

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo