### PR TITLE
SetVariable to inherit directly from VT.

### DIFF
--- a/torch/_dynamo/CLAUDE.md
+++ b/torch/_dynamo/CLAUDE.md
@@ -47,7 +47,7 @@ Key fields: `source` (where the value came from, for guards) and
 
 Key subclass families in `variables/`: `TensorVariable` / `SymNodeVariable`
 (tensor.py), `ConstantVariable` (constant.py), `ListVariable` /
-`TupleVariable` (lists.py), `ConstDictVariable` / `SetVariable` (dicts.py),
+`TupleVariable` (lists.py), `ConstDictVariable` (dicts.py), `SetVariable` (sets.py),
 `UserFunctionVariable` (functions.py), `BuiltinVariable` (builtin.py),
 `NNModuleVariable` (nn_module.py), `UserDefinedObjectVariable`
 (user_defined.py), `TorchHigherOrderOperatorVariable` (higher_order_ops.py),

--- a/torch/_dynamo/graph_break_registry.json
+++ b/torch/_dynamo/graph_break_registry.json
@@ -4392,6 +4392,14 @@
     {
       "Gb_type": "strict_mode: improper args",
       "Context": "args: {args}, kwargs: {kwargs}",
+      "Explanation": "strict_mode higher order op expects flat inputs (list/tuple/dict/set)",
+      "Hints": [
+        "Your code may result in an error when running in eager. Please double check that your code doesn't contain a similar error when actually running eager/uncompiled. You can do this by removing the `torch.compile` call, or by using `torch.compiler.set_stance(\"force_eager\")`. "
+      ]
+    },
+    {
+      "Gb_type": "strict_mode: improper args",
+      "Context": "args: {args}, kwargs: {kwargs}",
       "Explanation": "strict_mode higher order op expects flat inputs (list/tuple/dict)",
       "Hints": [
         "Your code may result in an error when running in eager. Please double check that your code doesn't contain a similar error when actually running eager/uncompiled. You can do this by removing the `torch.compile` call, or by using `torch.compiler.set_stance(\"force_eager\")`. "

--- a/torch/_dynamo/side_effects.py
+++ b/torch/_dynamo/side_effects.py
@@ -741,11 +741,7 @@ class SideEffects:
             var.mutation_type.is_modified = True
         if var.source is not None:
             self.mutated_sources.add(var.source)
-        if (
-            var.source
-            and isinstance(var, variables.ConstDictVariable)
-            and not isinstance(var, variables.SetVariable)
-        ):
+        if var.source and isinstance(var, variables.ConstDictVariable):
             self._has_existing_dict_mutation = True
 
     def has_existing_dict_mutation(self) -> bool:
@@ -1095,7 +1091,7 @@ class SideEffects:
                 )
                 _maybe_log_side_effect(var)
 
-            elif isinstance(var, variables.ConstDictVariable):
+            elif isinstance(var, (variables.ConstDictVariable, variables.SetVariable)):
                 # Reconstruct works as follow:
                 # (1) Skip codegen if there are no new items
                 # (2) codegen(...) each pair of key/value

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -151,7 +151,7 @@ from .variables.ctx_manager import (
     WithEnterFunctionVariable,
     WithExitFunctionVariable,
 )
-from .variables.dicts import ConstDictVariable, SetVariable
+from .variables.dicts import ConstDictVariable
 from .variables.functions import (
     BaseUserFunctionVariable,
     LocalGeneratorFunctionVariable,
@@ -181,6 +181,7 @@ from .variables.misc import (
     UnknownVariable,
 )
 from .variables.nn_module import NNModuleVariable, UnspecializedNNModuleVariable
+from .variables.sets import SetVariable
 from .variables.streams import SymbolicStreamState
 from .variables.tensor import supported_comparison_ops, SymNodeVariable, TensorVariable
 from .variables.torch_function import (

--- a/torch/_dynamo/variables/__init__.py
+++ b/torch/_dynamo/variables/__init__.py
@@ -57,14 +57,9 @@ from .dicts import (
     ConstDictVariable,
     DefaultDictVariable,
     DictItemsVariable,
-    DictKeySetVariable,
     DunderDictVariable,
-    FrozensetVariable,
     MappingProxyVariable,
     NNModuleHooksDictVariable,
-    OrderedSetClassVariable,
-    OrderedSetVariable,
-    SetVariable,
 )
 from .distributed import BackwardHookVariable, DistributedVariable
 from .functions import (
@@ -149,6 +144,13 @@ from .nn_module import (
 )
 from .optimizer import OptimizerVariable
 from .sdpa import SDPAParamsVariable
+from .sets import (
+    DictKeySetVariable,
+    FrozensetVariable,
+    OrderedSetClassVariable,
+    OrderedSetVariable,
+    SetVariable,
+)
 from .streams import (
     CudaStreamVariable,
     EventVariable,

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -198,11 +198,7 @@ from .ctx_manager import (
 from .dicts import (
     ConstDictVariable,
     DefaultDictVariable,
-    DictKeySetVariable,
-    FrozensetVariable,
     MappingProxyVariable,
-    OrderedSetClassVariable,
-    OrderedSetVariable,
     SetVariable,
 )
 from .distributed import WorldMetaClassVariable
@@ -269,6 +265,12 @@ from .nn_module import (
 from .optimizer import OptimizerVariable
 from .script_object import OpaqueObjectClassVariable, TorchScriptObjectVariable
 from .sdpa import SDPAParamsVariable
+from .sets import (
+    DictKeySetVariable,
+    FrozensetVariable,
+    OrderedSetClassVariable,
+    OrderedSetVariable,
+)
 from .streams import EventVariable, StreamContextVariable, StreamVariable
 from .tensor import (
     NumpyNdarrayVariable,
@@ -855,7 +857,7 @@ class VariableBuilder:
                 self.tx.output.guard_on_key_order.add(self.source)
 
             # We need all the keys to be hashable. We do this within the
-            # _HashableTracker class in dicts.py
+            # HashableTracker class in sets.py
             def build_key_value(
                 i: Any, k: Any, v: Any
             ) -> tuple[VariableTracker, VariableTracker]:
@@ -1661,7 +1663,7 @@ class VariableBuilder:
             self.tx.output.guard_on_key_order.add(self.source)
 
             # We need all the keys to be hashable. We do this within the
-            # _HashableTracker class in dicts.py
+            # HashableTracker class in sets.py
             def build_key_value(
                 i: Any, k: Any, v: Any
             ) -> tuple[VariableTracker, VariableTracker]:

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -857,7 +857,7 @@ class VariableBuilder:
                 self.tx.output.guard_on_key_order.add(self.source)
 
             # We need all the keys to be hashable. We do this within the
-            # HashableTracker class in sets.py
+            # HashableTracker class in hashable.py
             def build_key_value(
                 i: Any, k: Any, v: Any
             ) -> tuple[VariableTracker, VariableTracker]:
@@ -1663,7 +1663,7 @@ class VariableBuilder:
             self.tx.output.guard_on_key_order.add(self.source)
 
             # We need all the keys to be hashable. We do this within the
-            # HashableTracker class in sets.py
+            # HashableTracker class in hashable.py
             def build_key_value(
                 i: Any, k: Any, v: Any
             ) -> tuple[VariableTracker, VariableTracker]:

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -101,6 +101,7 @@ from .dicts import (
     DictKeysVariable,
     DictViewVariable,
 )
+from .hashable import is_hashable
 from .lists import (
     BaseListVariable,
     ListIteratorVariable,
@@ -111,7 +112,6 @@ from .lists import (
     TupleVariable,
 )
 from .misc import NullVariable
-from .hashable import is_hashable
 from .sets import FrozensetVariable, OrderedSetClassVariable, SetVariable
 from .tensor import (
     FakeItemVariable,

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -111,7 +111,8 @@ from .lists import (
     TupleVariable,
 )
 from .misc import NullVariable
-from .sets import FrozensetVariable, is_hashable, OrderedSetClassVariable, SetVariable
+from .hashable import is_hashable
+from .sets import FrozensetVariable, OrderedSetClassVariable, SetVariable
 from .tensor import (
     FakeItemVariable,
     supported_comparison_ops,

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -100,10 +100,6 @@ from .dicts import (
     DictItemsVariable,
     DictKeysVariable,
     DictViewVariable,
-    FrozensetVariable,
-    is_hashable,
-    OrderedSetClassVariable,
-    SetVariable,
 )
 from .lists import (
     BaseListVariable,
@@ -115,6 +111,7 @@ from .lists import (
     TupleVariable,
 )
 from .misc import NullVariable
+from .sets import FrozensetVariable, is_hashable, OrderedSetClassVariable, SetVariable
 from .tensor import (
     FakeItemVariable,
     supported_comparison_ops,
@@ -1651,7 +1648,7 @@ class BuiltinVariable(BaseBuiltinVariable):
             # - https://github.com/python/cpython/blob/3.12/Objects/floatobject.c#L878-L882
             assert istype(arg.sym_num, (torch.SymInt, torch.SymFloat))
             return SymNodeVariable.create(tx, arg.as_proxy() != 0)
-        if isinstance(arg, ConstDictVariable):
+        if isinstance(arg, (ConstDictVariable, SetVariable)):
             return ConstantVariable.build(tx, bool(arg.items))
         if isinstance(arg, variables.UserDefinedObjectVariable):
             # for user-defined objects, first try __bool__ if defined, else
@@ -2021,10 +2018,13 @@ class BuiltinVariable(BaseBuiltinVariable):
                         obj.source.make_guard(GuardBuilder.TUPLE_ITERATOR_LEN)
                     )
                 else:
-                    if (
-                        getattr(obj, "source", False)
-                        and isinstance(obj, ConstDictVariable)
-                        and not istype(obj, (SetVariable, FrozensetVariable))
+                    if getattr(obj, "source", False) and isinstance(
+                        obj,
+                        (
+                            ConstDictVariable,
+                            variables.OrderedSetVariable,
+                            variables.DictKeySetVariable,
+                        ),
                     ):
                         tx.output.guard_on_key_order.add(obj.source)
 
@@ -3205,7 +3205,7 @@ class BuiltinVariable(BaseBuiltinVariable):
         # Unwrap the underlying ConstDictVariable
         if isinstance(a, DictViewVariable):
             a = a.dv_dict
-        if isinstance(a, (ListVariable, ConstDictVariable)):
+        if isinstance(a, (ListVariable, ConstDictVariable, SetVariable)):
             return VariableTracker.build(tx, len(a.items) == 0)
         if isinstance(a, UserDefinedObjectVariable):
             bool_result = self.call_bool(tx, a)

--- a/torch/_dynamo/variables/dicts.py
+++ b/torch/_dynamo/variables/dicts.py
@@ -6,27 +6,23 @@ This module implements variable tracking for different types of dictionary-like 
 - Ordered dictionaries (collections.OrderedDict)
 - Default dictionaries (collections.defaultdict)
 - Dictionary views (keys and values)
-- Sets and frozensets (implemented internally using dictionaries)
 
 These classes are responsible for tracking dictionary operations during graph compilation,
 maintaining proper guards for dictionary mutations and key existence checks. They handle
 dictionary creation, modification, key/value access, and view operations while ensuring
 correct behavior in the compiled code through appropriate guard installation.
 
-The implementation uses a special _HashableTracker wrapper to handle dictionary keys
-while preserving proper aliasing semantics. Sets are implemented as dictionaries with
-None values for efficiency and code reuse.
+The implementation uses a special HashableTracker wrapper (from sets.py) to handle
+dictionary keys while preserving proper aliasing semantics. Set-related classes live
+in sets.py.
 """
 
 import collections
 import functools
-import operator
 import types
-from collections.abc import Callable, Iterable, Iterator, Sequence
-from typing import Any, Literal, Optional, TYPE_CHECKING, Union
+from collections.abc import Callable, Iterator, Sequence
+from typing import Any, Literal, TYPE_CHECKING, Union
 
-import torch
-from torch.utils._ordered_set import OrderedSet
 from torch.utils._pytree import MappingKey
 
 from .. import graph_break_hints, polyfills, variables
@@ -51,7 +47,6 @@ from ..utils import (
     dict_values,
     istype,
     raise_args_mismatch,
-    specialize_symnode,
 )
 from .base import (
     AttributeMutationExisting,
@@ -66,12 +61,12 @@ from .constant import (
     CONSTANT_VARIABLE_TRUE,
     ConstantVariable,
 )
+from .sets import HashableTracker, is_hashable, raise_unhashable, SetVariable
 
 
 if TYPE_CHECKING:
     from torch._dynamo.codegen import PyCodegen
     from torch._dynamo.symbolic_convert import InstructionTranslator
-    from torch._dynamo.variables.builtin import BuiltinVariable
 
     from .functions import UserFunctionVariable
 
@@ -79,41 +74,6 @@ if TYPE_CHECKING:
 # [Adding a new supported class within the keys of ConstDictVariable]
 # - Implement is_python_hashable() method in the VariableTracker subclass
 # - Implement get_python_hash() and is_python_equal() methods for hashable types
-
-
-def raise_unhashable(
-    arg: VariableTracker, tx: Optional["InstructionTranslator"] = None
-) -> None:
-    if tx is None:
-        from torch._dynamo.symbolic_convert import InstructionTranslator
-
-        tx = InstructionTranslator.current_tx()
-    try:
-        arg_type = arg.python_type()
-    except Exception:
-        arg_type = type(arg)
-
-    raise_observed_exception(
-        TypeError,
-        tx,
-        args=[
-            f"unhashable type: {arg_type!r} and variable tracker = {type(arg.realize())}",
-        ],
-    )
-
-
-def is_hashable(x: VariableTracker) -> bool:
-    # NB - performing isinstance check on a LazVT realizes the VT, accidentally
-    # inserting the guard. To avoid this, lazyVT `is_hashable` methods looks at
-    # the underlying value without realizing the VT. Consider updating the
-    # lazyVT `is_hashable` method if you see unnecessary guarding for a key VT.
-    if (
-        isinstance(x, variables.LazyVariableTracker)
-        and not x.is_realized()
-        and x.is_hashable()
-    ):
-        return True
-    return x.is_python_hashable()
 
 
 class ConstDictVariable(VariableTracker):
@@ -127,114 +87,6 @@ class ConstDictVariable(VariableTracker):
         "user_cls",
         *VariableTracker._nonvar_fields,
     }
-
-    class _HashableTracker:
-        """
-        Auxiliary opaque internal class that wraps a VariableTracker and makes it hashable
-        This should not be seen or touched by anything outside of ConstDictVariable and its children
-        Note that it's also fine to put VTs into dictionaries and sets, but doing so does not take into account aliasing
-        """
-
-        _MISSING = object()
-
-        def __init__(self, vt: VariableTracker) -> None:
-            # We specialize SymNodes
-            vt = specialize_symnode(vt)
-
-            # If Dynamo does not know the hashability of the vt, it will raise unsupported here
-            if not is_hashable(vt):
-                raise_unhashable(vt)
-            self.vt = vt
-
-        @classmethod
-        def _maybe_constant_torch_size(cls, vt: VariableTracker) -> object:
-            from .lists import SizeVariable
-            from .tensor import TensorVariable
-
-            if (
-                isinstance(vt, variables.LazyVariableTracker)
-                and not vt.is_realized()
-                and isinstance(vt.original_value(), torch.Size)
-            ):
-                return vt.original_value()
-
-            if not isinstance(vt, SizeVariable):
-                return cls._MISSING
-
-            items = []
-            for item in vt.items:
-                if item.is_python_constant():
-                    items.append(item.as_python_constant())
-                    continue
-
-                if isinstance(item, TensorVariable):
-                    proxy = getattr(item, "proxy", None)
-                    node = getattr(proxy, "node", None)
-                    meta = getattr(node, "meta", None) if node is not None else None
-                    example_value = (
-                        meta.get("example_value") if isinstance(meta, dict) else None
-                    )
-                    constant = getattr(example_value, "constant", None)
-
-                    if isinstance(constant, torch.Tensor) and constant.numel() == 1:
-                        items.append(constant.item())
-                        continue
-
-                return cls._MISSING
-
-            return torch.Size(items)
-
-        def __hash__(self) -> int:
-            """
-            Computes the hash value for the wrapped VariableTracker.
-
-            For unrealized LazyVariableTrackers, uses the hash of the original value
-            to avoid realizing the tracker and inserting unnecessary guards.
-            For all other cases, delegates to the VariableTracker's get_python_hash method.
-
-            Returns:
-                The hash value of the underlying variable tracker
-            """
-            if (
-                isinstance(self.vt, variables.LazyVariableTracker)
-                and not self.vt.is_realized()
-                and self.vt.is_hashable()
-            ):
-                return hash(self.vt.original_value())
-
-            maybe_constant = self._maybe_constant_torch_size(self.vt)
-            if maybe_constant is not self._MISSING:
-                return hash(maybe_constant)
-
-            return self.vt.get_python_hash()
-
-        def __eq__(self, other: object) -> bool:
-            """
-            Checks equality between two _HashableTracker instances.
-
-            Delegates to the VariableTracker's is_python_equal method to compare
-            the underlying variable trackers for Python-level equality.
-
-            Args:
-                other: Another _HashableTracker instance to compare with
-
-            Returns:
-                True if the underlying variable trackers are Python-equal, False otherwise
-            """
-            if not isinstance(other, ConstDictVariable._HashableTracker):
-                return False
-            if self.vt is other.vt:
-                return True
-
-            self_constant = self._maybe_constant_torch_size(self.vt)
-            other_constant = self._maybe_constant_torch_size(other.vt)
-            if (
-                self_constant is not self._MISSING
-                and other_constant is not self._MISSING
-            ):
-                return self_constant == other_constant
-
-            return self.vt.is_python_equal(other.vt)
 
     def __init__(
         self,
@@ -251,7 +103,7 @@ class ConstDictVariable(VariableTracker):
 
         super().__init__(**kwargs)
 
-        Hashable = ConstDictVariable._HashableTracker
+        Hashable = HashableTracker
 
         # Keys will just be HashableTrackers when cloning, in any other case they'll be VariableTrackers
         assert all(
@@ -261,8 +113,8 @@ class ConstDictVariable(VariableTracker):
         )
 
         def make_hashable(
-            key: Union[VariableTracker, "ConstDictVariable._HashableTracker"],
-        ) -> "ConstDictVariable._HashableTracker":
+            key: Union[VariableTracker, "HashableTracker"],
+        ) -> "HashableTracker":
             return key if isinstance(key, Hashable) else Hashable(key)
 
         dict_cls = self._get_dict_cls_from_user_cls(user_cls)
@@ -320,7 +172,7 @@ class ConstDictVariable(VariableTracker):
 
     def __contains__(self, vt: VariableTracker) -> bool:
         assert isinstance(vt, VariableTracker)
-        Hashable = ConstDictVariable._HashableTracker
+        Hashable = HashableTracker
         if not is_hashable(vt):
             return False
         key = Hashable(vt)
@@ -513,7 +365,7 @@ class ConstDictVariable(VariableTracker):
     def getitem_const_raise_exception_if_absent(
         self, tx: "InstructionTranslator", arg: VariableTracker
     ) -> VariableTracker:
-        key = ConstDictVariable._HashableTracker(arg)
+        key = HashableTracker(arg)
         if key not in self.items:
             try:
                 error_message = (
@@ -528,7 +380,7 @@ class ConstDictVariable(VariableTracker):
     def getitem_const(
         self, tx: "InstructionTranslator", arg: VariableTracker
     ) -> VariableTracker:
-        key = ConstDictVariable._HashableTracker(arg)
+        key = HashableTracker(arg)
         if key not in self.items:
             msg = f"Dictionary key {arg.value} not found during tracing"  # type: ignore[attr-defined]
             unimplemented(
@@ -543,7 +395,7 @@ class ConstDictVariable(VariableTracker):
         return self.items[key]
 
     def maybe_getitem_const(self, arg: VariableTracker) -> VariableTracker | None:
-        key = ConstDictVariable._HashableTracker(arg)
+        key = HashableTracker(arg)
         if key not in self.items:
             return None
         return self.items[key]
@@ -551,7 +403,7 @@ class ConstDictVariable(VariableTracker):
     def realize_key_vt(self, arg: VariableTracker) -> None:
         # Realize the LazyVT on a particular index
         assert arg in self
-        key = ConstDictVariable._HashableTracker(arg)
+        key = HashableTracker(arg)
         index = tuple(self.items.keys()).index(key)
         original_key_vt = tuple(self.original_items.keys())[index]
         if isinstance(original_key_vt, variables.LazyVariableTracker):
@@ -620,7 +472,7 @@ class ConstDictVariable(VariableTracker):
         from . import DictBuiltinVariable
         from .builder import SourcelessBuilder
 
-        Hashable = ConstDictVariable._HashableTracker
+        Hashable = HashableTracker
 
         if name == "__init__":
             temp_dict_vt = DictBuiltinVariable.call_custom_dict(
@@ -1245,623 +1097,6 @@ class DefaultDictVariable(ConstDictVariable):
         )
 
 
-# TODO: Implementing this via inheritance rather than composition is a
-# footgun, because self method calls in dict will route back to the set
-# implementation, which is almost assuredly wrong
-class SetVariable(ConstDictVariable):
-    """We model a sets as dictionary with None values"""
-
-    # PySet_Type: https://github.com/python/cpython/blob/v3.13.0/Objects/setobject.c#L2436
-    _cpython_type = set
-
-    CONTAINS_GUARD = GuardBuilder.SET_CONTAINS
-    NOT_CONTAINS_GUARD = GuardBuilder.SET_NOT_CONTAINS
-
-    def __init__(
-        self,
-        items: Iterable[VariableTracker],
-        **kwargs: Any,
-    ) -> None:
-        # Items can be either VariableTrackers or _HashableTrackers (from set ops).
-        # For VariableTrackers, realize them to ensure aliasing guards are installed
-        # when the same object appears multiple times.
-        realized_items = []
-        for item in items:
-            if isinstance(item, ConstDictVariable._HashableTracker):
-                # Already a _HashableTracker from a set operation
-                realized_items.append(item)
-            else:
-                # VariableTracker - realize to install guards
-                # pyrefly: ignore [bad-argument-type]
-                realized_items.append(item.realize())
-        items = dict.fromkeys(realized_items, SetVariable._default_value())
-        super().__init__(items, **kwargs)
-
-    def debug_repr(self) -> str:
-        if not self.items:
-            return "set()"
-        else:
-            items: list[str] = []
-            for v in self.items:
-                vt = v.vt if isinstance(v, ConstDictVariable._HashableTracker) else v
-                val_str = repr(vt.value) if hasattr(vt, "value") else vt.debug_repr()
-                items.append(val_str)
-            return "{" + ",".join(items) + "}"
-
-    @property
-    def set_items(self) -> set["ConstDictVariable._HashableTracker"]:
-        return set(self.items.keys())
-
-    @staticmethod
-    def _default_value() -> VariableTracker:
-        # Variable to fill in he keys of the dictionary
-        return CONSTANT_VARIABLE_NONE
-
-    def as_proxy(self) -> Any:
-        return {k.vt.as_proxy() for k in self.set_items}
-
-    def python_type(self) -> type:
-        return set
-
-    def as_python_constant(self) -> Any:
-        return {k.vt.as_python_constant() for k in self.set_items}
-
-    def reconstruct(self, codegen: "PyCodegen") -> None:
-        codegen.foreach([x.vt for x in self.set_items])
-        codegen.append_output(create_instruction("BUILD_SET", arg=len(self.set_items)))
-
-    def _fast_set_method(
-        self,
-        tx: "InstructionTranslator",
-        fn: Any,
-        args: list[VariableTracker],
-        kwargs: dict[str, VariableTracker],
-    ) -> VariableTracker:
-        try:
-            res = fn(
-                *[x.as_python_constant() for x in [self, *args]],
-                **{k: v.as_python_constant() for k, v in kwargs.items()},
-            )
-        except Exception as exc:
-            raise_observed_exception(type(exc), tx, args=list(exc.args))
-        return VariableTracker.build(tx, res)
-
-    def call_method(
-        self,
-        tx: "InstructionTranslator",
-        name: str,
-        args: list[VariableTracker],
-        kwargs: dict[str, VariableTracker],
-    ) -> VariableTracker:
-        # We forward the calls to the dictionary model
-        from ..utils import check_constant_args
-        from .builder import SourcelessBuilder
-
-        if (
-            name
-            in (
-                "isdisjoint",
-                "union",
-                "intersection",
-                "difference",
-                "symmetric_difference",
-            )
-            and check_constant_args(args, kwargs)
-            and self.python_type() is set
-        ):
-            py_type = self.python_type()
-            return self._fast_set_method(tx, getattr(py_type, name), args, kwargs)
-
-        if name == "__init__":
-            temp_set_vt = SourcelessBuilder.create(tx, set).call_set(
-                tx, *args, **kwargs
-            )
-            tx.output.side_effects.mutation(self)
-            self.items.clear()
-            self.items.update(temp_set_vt.items)  # type: ignore[attr-defined]
-            return CONSTANT_VARIABLE_NONE
-        elif name == "add":
-            if kwargs or len(args) != 1:
-                raise_args_mismatch(
-                    tx,
-                    name,
-                    "1 args and 0 kwargs",
-                    f"{len(args)} args and {len(kwargs)} kwargs",
-                )
-            name = "__setitem__"
-            args = [args[0], SetVariable._default_value()]
-        elif name == "pop":
-            if kwargs or args:
-                raise_args_mismatch(
-                    tx,
-                    name,
-                    "0 args and 0 kwargs",
-                    f"{len(args)} args and {len(kwargs)} kwargs",
-                )
-            # Choose an item at random and pop it via the Dict.pop method
-            try:
-                result: VariableTracker = self.set_items.pop().vt  # type: ignore[assignment]
-            except KeyError as e:
-                raise_observed_exception(KeyError, tx, args=list(e.args))
-            super().call_method(tx, name, [result], kwargs)
-            return result
-        elif name == "isdisjoint":
-            if kwargs or len(args) != 1:
-                raise_args_mismatch(
-                    tx,
-                    name,
-                    "1 args and 0 kwargs",
-                    f"{len(args)} args and {len(kwargs)} kwargs",
-                )
-            return SourcelessBuilder.create(tx, polyfills.set_isdisjoint).call_function(
-                tx, [self, args[0]], {}
-            )
-        elif name == "intersection":
-            if kwargs:
-                raise_args_mismatch(tx, name, "0 kwargs", f"{len(kwargs)} kwargs")
-            return SourcelessBuilder.create(
-                tx, polyfills.set_intersection
-            ).call_function(
-                tx,
-                [self, *args],
-                {"cls": self.python_type_var()},
-            )
-        elif name == "intersection_update":
-            if kwargs:
-                raise_args_mismatch(tx, name, "0 kwargs", f"{len(kwargs)} kwargs")
-            return SourcelessBuilder.create(
-                tx, polyfills.set_intersection_update
-            ).call_function(tx, [self, *args], {})
-        elif name == "union":
-            if kwargs:
-                raise_args_mismatch(tx, name, "0 kwargs", f"{len(kwargs)} kwargs")
-            return SourcelessBuilder.create(tx, polyfills.set_union).call_function(
-                tx,
-                [self, *args],
-                {"cls": self.python_type_var()},
-            )
-        elif name == "difference":
-            if kwargs:
-                raise_args_mismatch(
-                    tx, name, f"Expect: 0 kwargs, Actual: {len(kwargs)} kwargs"
-                )
-            return SourcelessBuilder.create(tx, polyfills.set_difference).call_function(
-                tx,
-                [self, *args],
-                {"cls": self.python_type_var()},
-            )
-        elif name == "difference_update":
-            if kwargs:
-                raise_args_mismatch(tx, name, "0 kwargs", f"{len(kwargs)} kwargs")
-            return SourcelessBuilder.create(
-                tx, polyfills.set_difference_update
-            ).call_function(tx, [self, *args], {})
-        elif name == "symmetric_difference":
-            if kwargs or len(args) != 1:
-                raise_args_mismatch(
-                    tx,
-                    name,
-                    "1 args and 0 kwargs",
-                    f"{len(args)} args and {len(kwargs)} kwargs",
-                )
-            return SourcelessBuilder.create(
-                tx, polyfills.set_symmetric_difference
-            ).call_function(
-                tx,
-                [self, *args],
-                {"cls": self.python_type_var()},
-            )
-        elif name == "symmetric_difference_update":
-            if kwargs or len(args) != 1:
-                raise_args_mismatch(
-                    tx,
-                    name,
-                    "1 args and 0 kwargs",
-                    f"{len(args)} args and {len(kwargs)} kwargs",
-                )
-            return SourcelessBuilder.create(
-                tx, polyfills.set_symmetric_difference_update
-            ).call_function(tx, [self, *args], {})
-        elif name == "update" and self.is_mutable():
-            if kwargs:
-                raise_args_mismatch(tx, name, "0 kwargs", f"{len(kwargs)} kwargs")
-            return SourcelessBuilder.create(tx, polyfills.set_update).call_function(
-                tx, [self, *args], {}
-            )
-        elif name == "remove":
-            if kwargs or len(args) != 1:
-                raise_args_mismatch(
-                    tx,
-                    name,
-                    "1 args and 0 kwargs",
-                    f"{len(args)} args and {len(kwargs)} kwargs",
-                )
-            if args[0] not in self:
-                raise_observed_exception(KeyError, tx, args=args)
-            return super().call_method(tx, "pop", args, kwargs)
-        elif name == "discard":
-            if kwargs or len(args) != 1:
-                raise_args_mismatch(
-                    tx,
-                    name,
-                    "1 args and 0 kwargs",
-                    f"{len(args)} args and {len(kwargs)} kwargs",
-                )
-            if args[0] in self:
-                return super().call_method(tx, "pop", args, kwargs)
-            else:
-                return CONSTANT_VARIABLE_NONE
-        elif name in ("issubset", "issuperset"):
-            if len(args) != 1:
-                raise_args_mismatch(tx, name, "1 args", f"{len(args)} args")
-
-            op = {
-                "issubset": operator.le,
-                "issuperset": operator.ge,
-            }
-            other = args[0].realize()
-            if not istype(other, SetVariable):
-                other = SourcelessBuilder.create(tx, set).call_function(tx, [other], {})
-            return SourcelessBuilder.create(tx, op.get(name)).call_function(
-                tx, [self, other], {}
-            )
-        elif name in ("__and__", "__or__", "__xor__", "__sub__"):
-            m = {
-                "__and__": "intersection",
-                "__or__": "union",
-                "__xor__": "symmetric_difference",
-                "__sub__": "difference",
-            }.get(name)
-            if not isinstance(
-                args[0],
-                (
-                    SetVariable,
-                    variables.UserDefinedSetVariable,
-                    DictItemsVariable,
-                    DictKeysVariable,
-                ),
-            ):
-                raise_observed_exception(
-                    TypeError,
-                    tx,
-                    args=[
-                        f"unsupported operand type(s) for {name}: '{self.python_type_name()}' and '{args[0].python_type_name()}'"
-                    ],
-                )
-            assert m is not None
-            return self.call_method(tx, m, args, kwargs)
-        elif name in ("__rand__", "__ror__", "__rxor__", "__rsub__"):
-            m = {
-                "__rand__": "__and__",
-                "__ror__": "__or__",
-                "__rxor__": "__xor__",
-                "__rsub__": "__sub__",
-            }.get(name)
-            if not isinstance(
-                args[0],
-                (
-                    SetVariable,
-                    variables.UserDefinedSetVariable,
-                    DictItemsVariable,
-                    DictKeysVariable,
-                ),
-            ):
-                raise_observed_exception(
-                    TypeError,
-                    tx,
-                    args=[
-                        f"unsupported operand type(s) for {name}: '{args[0].python_type_name()}' and '{self.python_type_name()}'"
-                    ],
-                )
-            assert m is not None
-            return args[0].call_method(tx, m, [self], kwargs)
-        elif name in ("__iand__", "__ior__", "__ixor__", "__isub__"):
-            if not isinstance(
-                args[0],
-                (
-                    SetVariable,
-                    variables.UserDefinedSetVariable,
-                    DictItemsVariable,
-                    DictKeysVariable,
-                ),
-            ):
-                raise_observed_exception(
-                    TypeError,
-                    tx,
-                    args=[
-                        f"unsupported operand type(s) for {name}: '{self.python_type_name()}' and '{args[0].python_type_name()}'"
-                    ],
-                )
-            m = {
-                "__iand__": "intersection_update",
-                "__ior__": "update",
-                "__ixor__": "symmetric_difference_update",
-                "__isub__": "difference_update",
-            }.get(name)
-            assert m is not None
-            self.call_method(tx, m, args, kwargs)
-            return self
-        elif name == "__eq__":
-            if not isinstance(
-                args[0],
-                (
-                    SetVariable,
-                    variables.UserDefinedSetVariable,
-                    DictItemsVariable,
-                    DictKeysVariable,
-                ),
-            ):
-                return CONSTANT_VARIABLE_FALSE
-            r = self.call_method(tx, "symmetric_difference", args, kwargs)
-            return VariableTracker.build(tx, len(r.set_items) == 0)  # type: ignore[attr-defined]
-        elif name in cmp_name_to_op_mapping:
-            if not isinstance(
-                args[0],
-                (
-                    SetVariable,
-                    variables.UserDefinedSetVariable,
-                    DictItemsVariable,
-                    DictKeysVariable,
-                ),
-            ):
-                return VariableTracker.build(tx, NotImplemented)
-            return VariableTracker.build(
-                tx,
-                cmp_name_to_op_mapping[name](self.set_items, args[0].set_items),  # type: ignore[attr-defined]
-            )
-        return super().call_method(tx, name, args, kwargs)
-
-    def python_type_var(self) -> "BuiltinVariable":
-        return variables.BuiltinVariable(set)
-
-    def getitem_const(
-        self, tx: "InstructionTranslator", arg: VariableTracker
-    ) -> VariableTracker:
-        raise RuntimeError("Illegal to getitem on a set")
-
-    def install_dict_keys_match_guard(self) -> None:
-        # Already EQUALS_MATCH guarded
-        pass
-
-    def sq_length(self, tx: "InstructionTranslator") -> VariableTracker:
-        return VariableTracker.build(tx, len(self.set_items))
-
-
-class OrderedSetClassVariable(VariableTracker):
-    def __init__(self, **kwargs: Any) -> None:
-        super().__init__(**kwargs)
-
-    def as_python_constant(self) -> type[OrderedSet[Any]]:
-        return OrderedSet
-
-    def var_getattr(self, tx: "InstructionTranslator", name: str) -> VariableTracker:
-        if name == "__new__":
-            from .misc import GetAttrVariable
-
-            if self.source:
-                attr_source = AttrSource(self.source, name)
-            else:
-                attr_source = None
-            return GetAttrVariable(self, name, source=attr_source)
-        else:
-            return super().var_getattr(tx, name)
-
-    def call_method(
-        self,
-        tx: "InstructionTranslator",
-        name: str,
-        args: list[VariableTracker],
-        kwargs: dict[str, VariableTracker],
-    ) -> VariableTracker:
-        from .builtin import set_methods
-
-        if name == "__new__":
-            if len(args) != 2 or kwargs:
-                raise_args_mismatch(
-                    tx,
-                    name,
-                    "OrderedSet.__new__ only accepts one arg"
-                    f"{len(args)} args and {len(kwargs)} kwargs",
-                )
-
-            return variables.OrderedSetVariable([], mutation_type=ValueMutationNew())
-
-        resolved_fn = getattr(set, name)
-        if resolved_fn in set_methods and isinstance(args[0], variables.SetVariable):
-            return args[0].call_method(tx, name, args[1:], kwargs)
-
-        return super().call_method(tx, name, args, kwargs)
-
-    def call_function(
-        self,
-        tx: "InstructionTranslator",
-        args: Sequence[VariableTracker],
-        kwargs: dict[str, VariableTracker],
-    ) -> "OrderedSetVariable":
-        if len(args) > 1 or kwargs:
-            raise_args_mismatch(
-                tx,
-                "OrderedSet",
-                "OrderedSet only accepts one arg"
-                f"{len(args)} args and {len(kwargs)} kwargs",
-            )
-
-        if len(args) == 0:
-            # pyrefly: ignore [implicit-any]
-            items = []
-        else:
-            items = args[0].force_unpack_var_sequence(tx)
-        return variables.OrderedSetVariable(items, mutation_type=ValueMutationNew())
-
-
-class OrderedSetVariable(SetVariable):
-    def debug_repr(self) -> str:
-        if not self.items:
-            return "OrderedSet([])"
-        else:
-            items: list[str] = []
-            for k, v in self.items:
-                key_str = (
-                    repr(k.vt.value) if hasattr(k.vt, "value") else k.vt.debug_repr()
-                )
-                items.append(key_str)
-            return "OrderedSet([" + ",".join(items) + "])"
-
-    def as_python_constant(self) -> OrderedSet[Any]:
-        return OrderedSet([k.vt.as_python_constant() for k in self.set_items])
-
-    def python_type(self) -> type[OrderedSet[Any]]:
-        return OrderedSet
-
-    # pyrefly: ignore[bad-override]
-    def python_type_var(self) -> OrderedSetClassVariable:
-        return OrderedSetClassVariable()
-
-    def reconstruct(self, codegen: "PyCodegen") -> None:
-        codegen.add_push_null(
-            lambda: codegen.load_import_from("torch.utils._ordered_set", "OrderedSet")
-        )
-        codegen.foreach([x.vt for x in self.set_items])
-        codegen.append_output(create_instruction("BUILD_LIST", arg=len(self.set_items)))
-        codegen.extend_output(create_call_function(1, False))
-
-
-class FrozensetVariable(SetVariable):
-    # PyFrozenSet_Type: https://github.com/python/cpython/blob/v3.13.0/Objects/setobject.c#L2526
-    _cpython_type = frozenset
-
-    def debug_repr(self) -> str:
-        if not self.items:
-            return "frozenset()"
-        else:
-            items: list[str] = []
-            for k in self.items:
-                key_str = (
-                    repr(k.vt.value) if hasattr(k.vt, "value") else k.vt.debug_repr()
-                )
-                items.append(key_str)
-            return "{" + ",".join(items) + "}"
-
-    @property
-    def set_items(self) -> set["ConstDictVariable._HashableTracker"]:
-        return self.items.keys()
-
-    def python_type(self) -> type:
-        return frozenset
-
-    def python_type_var(self) -> "BuiltinVariable":
-        return variables.BuiltinVariable(frozenset)
-
-    def as_python_constant(self) -> Any:
-        return frozenset({k.vt.as_python_constant() for k in self.set_items})
-
-    def reconstruct(self, codegen: "PyCodegen") -> None:
-        codegen.add_push_null(
-            lambda: codegen.extend_output(
-                [
-                    codegen.create_load_global("frozenset"),
-                ]
-            )
-        )
-        codegen.foreach([x.vt for x in self.set_items])
-        codegen.extend_output(
-            [
-                create_instruction("BUILD_LIST", arg=len(self.set_items)),
-                *create_call_function(1, False),
-            ]
-        )
-
-    def call_method(
-        self,
-        tx: "InstructionTranslator",
-        name: str,
-        args: list[VariableTracker],
-        kwargs: dict[str, VariableTracker],
-    ) -> VariableTracker:
-        if name in ["add", "pop", "update", "remove", "discard", "clear"]:
-            raise RuntimeError(f"Illegal call_method {name} on a frozenset")
-        elif name == "__init__":
-            # frozenset is immutable. Calling __init__ again shouldn't have any effect
-            # In[1]: s = frozenset([1, 2])
-            #
-            # In[2]: s.__init__([3, 4])
-            #
-            # In[3]: s
-            # frozenset({1, 2})
-            return CONSTANT_VARIABLE_NONE
-        elif name in (
-            "copy",
-            "difference",
-            "intersection",
-            "symmetric_difference",
-        ):
-            r = super().call_method(tx, name, args, kwargs)
-            return FrozensetVariable(r.items)  # type: ignore[attr-defined]
-        return super().call_method(tx, name, args, kwargs)
-
-    def is_python_hashable(self) -> Literal[True]:
-        """
-        Frozensets are immutable and hashable in Python.
-        """
-        return True
-
-    def get_python_hash(self) -> int:
-        return hash(self.as_python_constant())
-
-    def is_python_equal(self, other: object) -> bool:
-        return (
-            isinstance(other, VariableTracker)
-            and self.as_python_constant() == other.as_python_constant()
-        )
-
-
-class DictKeySetVariable(SetVariable):
-    def debug_repr(self) -> str:
-        if not self.items:
-            return "dict_keys([])"
-        else:
-            items: list[str] = []
-            for k in self.items:
-                key_str = (
-                    repr(k.vt.value) if hasattr(k.vt, "value") else k.vt.debug_repr()
-                )
-                items.append(key_str)
-            return "dict_keys([" + ",".join(items) + "])"
-
-    def install_dict_keys_match_guard(self) -> None:
-        # Already EQUALS_MATCH guarded
-        pass
-
-    def install_dict_contains_guard(
-        self, tx: "InstructionTranslator", args: list[VariableTracker]
-    ) -> None:
-        # Already EQUALS_MATCH guarded
-        pass
-
-    @property
-    def set_items(self) -> Any:
-        return self.items
-
-    def python_type(self) -> type:
-        return dict_keys
-
-    def as_python_constant(self) -> Any:
-        return dict.fromkeys(
-            {k.vt.as_python_constant() for k in self.set_items}, None
-        ).keys()
-
-    def call_method(
-        self,
-        tx: "InstructionTranslator",
-        name: str,
-        args: list[VariableTracker],
-        kwargs: dict[str, VariableTracker],
-    ) -> VariableTracker:
-        if name in ["add", "pop", "update", "remove", "discard", "clear"]:
-            raise RuntimeError(f"Illegal call_method {name} on a dict_keys")
-        return super().call_method(tx, name, args, kwargs)
-
-
 class DictViewVariable(VariableTracker):
     """
     Models _PyDictViewObject
@@ -2030,9 +1265,9 @@ class DictItemsVariable(DictViewVariable):
     kv = "items"
 
     @property
-    def set_items(self) -> set["ConstDictVariable._HashableTracker"]:
+    def set_items(self) -> set["HashableTracker"]:
         return {
-            ConstDictVariable._HashableTracker(variables.TupleVariable([k.vt, v]))
+            HashableTracker(variables.TupleVariable([k.vt, v]))
             for k, v in self.view_items
         }
 
@@ -2129,7 +1364,7 @@ class DictItemsVariable(DictViewVariable):
         return False
 
 
-kV = ConstDictVariable._HashableTracker | str
+kV = HashableTracker | str
 
 
 class SideEffectsProxyDict(collections.abc.MutableMapping[kV, VariableTracker]):
@@ -2186,7 +1421,7 @@ class SideEffectsProxyDict(collections.abc.MutableMapping[kV, VariableTracker]):
         self.item_dict = self.get_value___dict__(tx, item)
 
     def _maybe_unwrap_key(self, key: kV) -> str:
-        Hasher = ConstDictVariable._HashableTracker
+        Hasher = HashableTracker
         return key.vt.as_python_constant() if istype(key, Hasher) else key
 
     def side_effects_table(self) -> dict[str, VariableTracker]:
@@ -2199,7 +1434,7 @@ class SideEffectsProxyDict(collections.abc.MutableMapping[kV, VariableTracker]):
         return self.item_dict[name]
 
     def __setitem__(self, key: kV, value: VariableTracker) -> None:
-        # Find a way to not hash the key using _HashableTracker
+        # Find a way to not hash the key using HashableTracker
         name = self._maybe_unwrap_key(key)
         assert istype(name, str)
         self.side_effects.store_attr(self.item, name, value)
@@ -2221,8 +1456,8 @@ class SideEffectsProxyDict(collections.abc.MutableMapping[kV, VariableTracker]):
     def __len__(self) -> int:
         return sum(1 for _ in self)
 
-    def __iter__(self) -> Iterator[ConstDictVariable._HashableTracker]:
-        Hasher = ConstDictVariable._HashableTracker
+    def __iter__(self) -> Iterator[HashableTracker]:
+        Hasher = HashableTracker
         d = self.side_effects_table()
         for k, v in d.items():
             if isinstance(v, variables.DeletedVariable):

--- a/torch/_dynamo/variables/dicts.py
+++ b/torch/_dynamo/variables/dicts.py
@@ -12,7 +12,7 @@ maintaining proper guards for dictionary mutations and key existence checks. The
 dictionary creation, modification, key/value access, and view operations while ensuring
 correct behavior in the compiled code through appropriate guard installation.
 
-The implementation uses a special HashableTracker wrapper (from sets.py) to handle
+The implementation uses a special HashableTracker wrapper to handle
 dictionary keys while preserving proper aliasing semantics. Set-related classes live
 in sets.py.
 """
@@ -61,7 +61,8 @@ from .constant import (
     CONSTANT_VARIABLE_TRUE,
     ConstantVariable,
 )
-from .sets import HashableTracker, is_hashable, raise_unhashable, SetVariable
+from .hashable import HashableTracker, is_hashable, raise_unhashable
+from .sets import SetVariable
 
 
 if TYPE_CHECKING:

--- a/torch/_dynamo/variables/hashable.py
+++ b/torch/_dynamo/variables/hashable.py
@@ -1,0 +1,161 @@
+"""
+Hashability utilities for PyTorch Dynamo variable tracking.
+
+This module provides the HashableTracker wrapper class and associated utilities
+for making VariableTracker instances usable as dictionary keys and set elements
+during symbolic execution. Used by both ConstDictVariable and SetVariable.
+"""
+
+from typing import Optional, TYPE_CHECKING
+
+import torch
+
+from .. import variables
+from ..exc import raise_observed_exception
+from ..utils import specialize_symnode
+from .base import VariableTracker
+
+
+if TYPE_CHECKING:
+    from torch._dynamo.symbolic_convert import InstructionTranslator
+
+
+def raise_unhashable(
+    arg: VariableTracker, tx: Optional["InstructionTranslator"] = None
+) -> None:
+    if tx is None:
+        from torch._dynamo.symbolic_convert import InstructionTranslator
+
+        tx = InstructionTranslator.current_tx()
+    try:
+        arg_type = arg.python_type()
+    except Exception:
+        arg_type = type(arg)
+
+    raise_observed_exception(
+        TypeError,
+        tx,
+        args=[
+            f"unhashable type: {arg_type!r} and variable tracker = {type(arg.realize())}",
+        ],
+    )
+
+
+def is_hashable(x: VariableTracker) -> bool:
+    # NB - performing isinstance check on a LazVT realizes the VT, accidentally
+    # inserting the guard. To avoid this, lazyVT `is_hashable` methods looks at
+    # the underlying value without realizing the VT. Consider updating the
+    # lazyVT `is_hashable` method if you see unnecessary guarding for a key VT.
+    if (
+        isinstance(x, variables.LazyVariableTracker)
+        and not x.is_realized()
+        and x.is_hashable()
+    ):
+        return True
+    return x.is_python_hashable()
+
+
+class HashableTracker:
+    """
+    Class that wraps a VariableTracker and makes it hashable.
+    Note that it's fine to put VTs into dictionaries and sets, but doing so
+    does not take into account aliasing.
+    """
+
+    _MISSING = object()
+
+    def __init__(self, vt: VariableTracker) -> None:
+        # We specialize SymNodes
+        vt = specialize_symnode(vt)
+
+        # If Dynamo does not know the hashability of the vt, it will raise unsupported here
+        if not is_hashable(vt):
+            raise_unhashable(vt)
+        self.vt = vt
+
+    @classmethod
+    def _maybe_constant_torch_size(cls, vt: VariableTracker) -> object:
+        from .lists import SizeVariable
+        from .tensor import TensorVariable
+
+        if (
+            isinstance(vt, variables.LazyVariableTracker)
+            and not vt.is_realized()
+            and isinstance(vt.original_value(), torch.Size)
+        ):
+            return vt.original_value()
+
+        if not isinstance(vt, SizeVariable):
+            return cls._MISSING
+
+        items = []
+        for item in vt.items:
+            if item.is_python_constant():
+                items.append(item.as_python_constant())
+                continue
+
+            if isinstance(item, TensorVariable):
+                proxy = getattr(item, "proxy", None)
+                node = getattr(proxy, "node", None)
+                meta = getattr(node, "meta", None) if node is not None else None
+                example_value = (
+                    meta.get("example_value") if isinstance(meta, dict) else None
+                )
+                constant = getattr(example_value, "constant", None)
+
+                if isinstance(constant, torch.Tensor) and constant.numel() == 1:
+                    items.append(constant.item())
+                    continue
+
+            return cls._MISSING
+
+        return torch.Size(items)
+
+    def __hash__(self) -> int:
+        """
+        Computes the hash value for the wrapped VariableTracker.
+
+        For unrealized LazyVariableTrackers, uses the hash of the original value
+        to avoid realizing the tracker and inserting unnecessary guards.
+        For all other cases, delegates to the VariableTracker's get_python_hash method.
+
+        Returns:
+            The hash value of the underlying variable tracker
+        """
+        if (
+            isinstance(self.vt, variables.LazyVariableTracker)
+            and not self.vt.is_realized()
+            and self.vt.is_hashable()
+        ):
+            return hash(self.vt.original_value())
+
+        maybe_constant = self._maybe_constant_torch_size(self.vt)
+        if maybe_constant is not self._MISSING:
+            return hash(maybe_constant)
+
+        return self.vt.get_python_hash()
+
+    def __eq__(self, other: object) -> bool:
+        """
+        Checks equality between two HashableTracker instances.
+
+        Delegates to the VariableTracker's is_python_equal method to compare
+        the underlying variable trackers for Python-level equality.
+
+        Args:
+            other: Another HashableTracker instance to compare with
+
+        Returns:
+            True if the underlying variable trackers are Python-equal, False otherwise
+        """
+        if not isinstance(other, HashableTracker):
+            return False
+        if self.vt is other.vt:
+            return True
+
+        self_constant = self._maybe_constant_torch_size(self.vt)
+        other_constant = self._maybe_constant_torch_size(other.vt)
+        if self_constant is not self._MISSING and other_constant is not self._MISSING:
+            return self_constant == other_constant
+
+        return self.vt.is_python_equal(other.vt)

--- a/torch/_dynamo/variables/hashable.py
+++ b/torch/_dynamo/variables/hashable.py
@@ -6,7 +6,7 @@ for making VariableTracker instances usable as dictionary keys and set elements
 during symbolic execution. Used by both ConstDictVariable and SetVariable.
 """
 
-from typing import Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 import torch
 
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 
 
 def raise_unhashable(
-    arg: VariableTracker, tx: Optional["InstructionTranslator"] = None
+    arg: VariableTracker, tx: "InstructionTranslator | None" = None
 ) -> None:
     if tx is None:
         from torch._dynamo.symbolic_convert import InstructionTranslator

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -64,6 +64,7 @@ from .base import VariableTracker
 from .dicts import ConstDictVariable
 from .lazy import LazyVariableTracker
 from .lists import ListVariable, TupleVariable
+from .sets import SetVariable
 
 
 if TYPE_CHECKING:
@@ -233,6 +234,9 @@ def find_mismatched_vars(
     elif isinstance(var, ConstDictVariable):
         for value in var.items.values():
             mismatched_vars.update(find_mismatched_vars(value, types, allow_none))
+    elif isinstance(var, SetVariable):
+        for key in var.items:
+            mismatched_vars.update(find_mismatched_vars(key.vt, types, allow_none))
     else:
         if not isinstance(var, types) and not (allow_none and var.is_constant_none()):
             mismatched_vars.add(var)
@@ -3757,11 +3761,13 @@ class StrictModeHigherOrderVariable(TorchHigherOrderOperatorVariable):
         unpacked_sequence = args[1].unpack_var_sequence(tx)
         # TODO (tmanlaibaatar) support pytree here
         for arg in unpacked_sequence:
-            if isinstance(arg, (ListVariable, TupleVariable, ConstDictVariable)):
+            if isinstance(
+                arg, (ListVariable, TupleVariable, ConstDictVariable, SetVariable)
+            ):
                 unimplemented(
                     gb_type="strict_mode: improper args",
                     context=f"args: {args}, kwargs: {kwargs}",
-                    explanation="strict_mode higher order op expects flat inputs (list/tuple/dict)",
+                    explanation="strict_mode higher order op expects flat inputs (list/tuple/dict/set)",
                     hints=[
                         *graph_break_hints.USER_ERROR,
                     ],

--- a/torch/_dynamo/variables/object_protocol.py
+++ b/torch/_dynamo/variables/object_protocol.py
@@ -52,8 +52,9 @@ def vt_identity_compare(
     # Mutable containers created during tracing: VT identity = Python identity.
     from .dicts import ConstDictVariable
     from .lists import ListVariable
+    from .sets import SetVariable
 
-    if isinstance(left, (ConstDictVariable, ListVariable)):
+    if isinstance(left, (ConstDictVariable, ListVariable, SetVariable)):
         return CONSTANT_VARIABLE_FALSE
 
     # Different Python types can never be the same object.

--- a/torch/_dynamo/variables/optimizer.py
+++ b/torch/_dynamo/variables/optimizer.py
@@ -46,6 +46,7 @@ from .constant import CONSTANT_VARIABLE_TRUE, ConstantVariable
 from .dicts import ConstDictVariable
 from .lists import ListVariable
 from .misc import GetAttrVariable
+from .sets import HashableTracker
 from .user_defined import UserDefinedObjectVariable
 
 
@@ -207,9 +208,7 @@ class OptimizerVariable(UserDefinedObjectVariable):
             VariableTracker.build(tx, self.value.param_groups, source)
         )
         for param_group_vt in param_groups_vt.items:
-            key = ConstDictVariable._HashableTracker(
-                ConstantVariable.create("capturable")
-            )
+            key = HashableTracker(ConstantVariable.create("capturable"))
             param_group_vt.items[key] = CONSTANT_VARIABLE_TRUE
 
     def get_python_args(

--- a/torch/_dynamo/variables/optimizer.py
+++ b/torch/_dynamo/variables/optimizer.py
@@ -44,9 +44,9 @@ from ..utils import GLOBAL_KEY_PREFIX
 from .base import VariableTracker
 from .constant import CONSTANT_VARIABLE_TRUE, ConstantVariable
 from .dicts import ConstDictVariable
+from .hashable import HashableTracker
 from .lists import ListVariable
 from .misc import GetAttrVariable
-from .hashable import HashableTracker
 from .user_defined import UserDefinedObjectVariable
 
 

--- a/torch/_dynamo/variables/optimizer.py
+++ b/torch/_dynamo/variables/optimizer.py
@@ -46,7 +46,7 @@ from .constant import CONSTANT_VARIABLE_TRUE, ConstantVariable
 from .dicts import ConstDictVariable
 from .lists import ListVariable
 from .misc import GetAttrVariable
-from .sets import HashableTracker
+from .hashable import HashableTracker
 from .user_defined import UserDefinedObjectVariable
 
 

--- a/torch/_dynamo/variables/sets.py
+++ b/torch/_dynamo/variables/sets.py
@@ -20,7 +20,6 @@ import operator
 from collections.abc import Iterable, Sequence
 from typing import Any, Literal, TYPE_CHECKING
 
-import torch
 from torch.utils._ordered_set import OrderedSet
 
 from .. import polyfills, variables
@@ -28,11 +27,7 @@ from ..bytecode_transformation import create_call_function, create_instruction
 from ..exc import raise_observed_exception
 from ..guards import GuardBuilder, install_guard
 from ..source import AttrSource, is_constant_source, is_from_local_source
-from ..utils import (
-    cmp_name_to_op_mapping,
-    istype,
-    raise_args_mismatch,
-)
+from ..utils import cmp_name_to_op_mapping, istype, raise_args_mismatch
 from .base import ValueMutationNew, VariableTracker
 from .constant import CONSTANT_VARIABLE_FALSE, CONSTANT_VARIABLE_NONE, ConstantVariable
 from .hashable import HashableTracker, is_hashable, raise_unhashable
@@ -42,9 +37,6 @@ if TYPE_CHECKING:
     from torch._dynamo.codegen import PyCodegen
     from torch._dynamo.symbolic_convert import InstructionTranslator
     from torch._dynamo.variables.builtin import BuiltinVariable
-
-
-
 
 
 # [Adding a new supported class within the keys of SetVariable]

--- a/torch/_dynamo/variables/sets.py
+++ b/torch/_dynamo/variables/sets.py
@@ -18,7 +18,7 @@ dictionaries with None values.
 import functools
 import operator
 from collections.abc import Iterable, Sequence
-from typing import Any, Literal, Optional, TYPE_CHECKING
+from typing import Any, Literal, TYPE_CHECKING
 
 import torch
 from torch.utils._ordered_set import OrderedSet
@@ -32,10 +32,10 @@ from ..utils import (
     cmp_name_to_op_mapping,
     istype,
     raise_args_mismatch,
-    specialize_symnode,
 )
 from .base import ValueMutationNew, VariableTracker
 from .constant import CONSTANT_VARIABLE_FALSE, CONSTANT_VARIABLE_NONE, ConstantVariable
+from .hashable import HashableTracker, is_hashable, raise_unhashable
 
 
 if TYPE_CHECKING:
@@ -44,144 +44,7 @@ if TYPE_CHECKING:
     from torch._dynamo.variables.builtin import BuiltinVariable
 
 
-def raise_unhashable(
-    arg: VariableTracker, tx: Optional["InstructionTranslator"] = None
-) -> None:
-    if tx is None:
-        from torch._dynamo.symbolic_convert import InstructionTranslator
 
-        tx = InstructionTranslator.current_tx()
-    try:
-        arg_type = arg.python_type()
-    except Exception:
-        arg_type = type(arg)
-
-    raise_observed_exception(
-        TypeError,
-        tx,
-        args=[
-            f"unhashable type: {arg_type!r} and variable tracker = {type(arg.realize())}",
-        ],
-    )
-
-
-def is_hashable(x: VariableTracker) -> bool:
-    # NB - performing isinstance check on a LazVT realizes the VT, accidentally
-    # inserting the guard. To avoid this, lazyVT `is_hashable` methods looks at
-    # the underlying value without realizing the VT. Consider updating the
-    # lazyVT `is_hashable` method if you see unnecessary guarding for a key VT.
-    if (
-        isinstance(x, variables.LazyVariableTracker)
-        and not x.is_realized()
-        and x.is_hashable()
-    ):
-        return True
-    return x.is_python_hashable()
-
-
-class HashableTracker:
-    """
-    Class that wraps a VariableTracker and makes it hashable.
-    Note that it's fine to put VTs into dictionaries and sets, but doing so does not take into account aliasing.
-    """
-
-    _MISSING = object()
-
-    def __init__(self, vt: VariableTracker) -> None:
-        # We specialize SymNodes
-        vt = specialize_symnode(vt)
-
-        # If Dynamo does not know the hashability of the vt, it will raise unsupported here
-        if not is_hashable(vt):
-            raise_unhashable(vt)
-        self.vt = vt
-
-    @classmethod
-    def _maybe_constant_torch_size(cls, vt: VariableTracker) -> object:
-        from .lists import SizeVariable
-        from .tensor import TensorVariable
-
-        if (
-            isinstance(vt, variables.LazyVariableTracker)
-            and not vt.is_realized()
-            and isinstance(vt.original_value(), torch.Size)
-        ):
-            return vt.original_value()
-
-        if not isinstance(vt, SizeVariable):
-            return cls._MISSING
-
-        items = []
-        for item in vt.items:
-            if item.is_python_constant():
-                items.append(item.as_python_constant())
-                continue
-
-            if isinstance(item, TensorVariable):
-                proxy = getattr(item, "proxy", None)
-                node = getattr(proxy, "node", None)
-                meta = getattr(node, "meta", None) if node is not None else None
-                example_value = (
-                    meta.get("example_value") if isinstance(meta, dict) else None
-                )
-                constant = getattr(example_value, "constant", None)
-
-                if isinstance(constant, torch.Tensor) and constant.numel() == 1:
-                    items.append(constant.item())
-                    continue
-
-            return cls._MISSING
-
-        return torch.Size(items)
-
-    def __hash__(self) -> int:
-        """
-        Computes the hash value for the wrapped VariableTracker.
-
-        For unrealized LazyVariableTrackers, uses the hash of the original value
-        to avoid realizing the tracker and inserting unnecessary guards.
-        For all other cases, delegates to the VariableTracker's get_python_hash method.
-
-        Returns:
-            The hash value of the underlying variable tracker
-        """
-        if (
-            isinstance(self.vt, variables.LazyVariableTracker)
-            and not self.vt.is_realized()
-            and self.vt.is_hashable()
-        ):
-            return hash(self.vt.original_value())
-
-        maybe_constant = self._maybe_constant_torch_size(self.vt)
-        if maybe_constant is not self._MISSING:
-            return hash(maybe_constant)
-
-        return self.vt.get_python_hash()
-
-    def __eq__(self, other: object) -> bool:
-        """
-        Checks equality between two HashableTracker instances.
-
-        Delegates to the VariableTracker's is_python_equal method to compare
-        the underlying variable trackers for Python-level equality.
-
-        Args:
-            other: Another HashableTracker instance to compare with
-
-        Returns:
-            True if the underlying variable trackers are Python-equal, False otherwise
-        """
-        if not isinstance(other, HashableTracker):
-            return False
-        if self.vt is other.vt:
-            return True
-
-        self_constant = self._maybe_constant_torch_size(self.vt)
-        other_constant = self._maybe_constant_torch_size(other.vt)
-        if self_constant is not self._MISSING and other_constant is not self._MISSING:
-            return self_constant == other_constant
-
-        return self.vt.is_python_equal(other.vt)
 
 
 # [Adding a new supported class within the keys of SetVariable]

--- a/torch/_dynamo/variables/sets.py
+++ b/torch/_dynamo/variables/sets.py
@@ -1,0 +1,951 @@
+"""
+Set-related variable tracking classes for PyTorch Dynamo.
+
+This module implements variable tracking for different types of set-like objects:
+- Regular Python sets (set)
+- Frozen sets (frozenset)
+- Ordered sets (torch.utils._ordered_set.OrderedSet)
+- Dictionary key sets (dict_keys views used as sets)
+
+These classes are responsible for tracking set operations during graph compilation,
+maintaining proper guards for set mutations and element existence checks.
+
+The implementation uses a special HashableTracker wrapper to handle set elements
+while preserving proper aliasing semantics. Sets are modeled internally as
+dictionaries with None values.
+"""
+
+import functools
+import operator
+from collections.abc import Iterable, Sequence
+from typing import Any, Literal, Optional, TYPE_CHECKING
+
+import torch
+from torch.utils._ordered_set import OrderedSet
+
+from .. import polyfills, variables
+from ..bytecode_transformation import create_call_function, create_instruction
+from ..exc import raise_observed_exception
+from ..guards import GuardBuilder, install_guard
+from ..source import AttrSource, is_constant_source, is_from_local_source
+from ..utils import (
+    cmp_name_to_op_mapping,
+    istype,
+    raise_args_mismatch,
+    specialize_symnode,
+)
+from .base import ValueMutationNew, VariableTracker
+from .constant import CONSTANT_VARIABLE_FALSE, CONSTANT_VARIABLE_NONE, ConstantVariable
+
+
+if TYPE_CHECKING:
+    from torch._dynamo.codegen import PyCodegen
+    from torch._dynamo.symbolic_convert import InstructionTranslator
+    from torch._dynamo.variables.builtin import BuiltinVariable
+
+
+def raise_unhashable(
+    arg: VariableTracker, tx: Optional["InstructionTranslator"] = None
+) -> None:
+    if tx is None:
+        from torch._dynamo.symbolic_convert import InstructionTranslator
+
+        tx = InstructionTranslator.current_tx()
+    try:
+        arg_type = arg.python_type()
+    except Exception:
+        arg_type = type(arg)
+
+    raise_observed_exception(
+        TypeError,
+        tx,
+        args=[
+            f"unhashable type: {arg_type!r} and variable tracker = {type(arg.realize())}",
+        ],
+    )
+
+
+def is_hashable(x: VariableTracker) -> bool:
+    # NB - performing isinstance check on a LazVT realizes the VT, accidentally
+    # inserting the guard. To avoid this, lazyVT `is_hashable` methods looks at
+    # the underlying value without realizing the VT. Consider updating the
+    # lazyVT `is_hashable` method if you see unnecessary guarding for a key VT.
+    if (
+        isinstance(x, variables.LazyVariableTracker)
+        and not x.is_realized()
+        and x.is_hashable()
+    ):
+        return True
+    return x.is_python_hashable()
+
+
+class HashableTracker:
+    """
+    Class that wraps a VariableTracker and makes it hashable.
+    Note that it's fine to put VTs into dictionaries and sets, but doing so does not take into account aliasing.
+    """
+
+    _MISSING = object()
+
+    def __init__(self, vt: VariableTracker) -> None:
+        # We specialize SymNodes
+        vt = specialize_symnode(vt)
+
+        # If Dynamo does not know the hashability of the vt, it will raise unsupported here
+        if not is_hashable(vt):
+            raise_unhashable(vt)
+        self.vt = vt
+
+    @classmethod
+    def _maybe_constant_torch_size(cls, vt: VariableTracker) -> object:
+        from .lists import SizeVariable
+        from .tensor import TensorVariable
+
+        if (
+            isinstance(vt, variables.LazyVariableTracker)
+            and not vt.is_realized()
+            and isinstance(vt.original_value(), torch.Size)
+        ):
+            return vt.original_value()
+
+        if not isinstance(vt, SizeVariable):
+            return cls._MISSING
+
+        items = []
+        for item in vt.items:
+            if item.is_python_constant():
+                items.append(item.as_python_constant())
+                continue
+
+            if isinstance(item, TensorVariable):
+                proxy = getattr(item, "proxy", None)
+                node = getattr(proxy, "node", None)
+                meta = getattr(node, "meta", None) if node is not None else None
+                example_value = (
+                    meta.get("example_value") if isinstance(meta, dict) else None
+                )
+                constant = getattr(example_value, "constant", None)
+
+                if isinstance(constant, torch.Tensor) and constant.numel() == 1:
+                    items.append(constant.item())
+                    continue
+
+            return cls._MISSING
+
+        return torch.Size(items)
+
+    def __hash__(self) -> int:
+        """
+        Computes the hash value for the wrapped VariableTracker.
+
+        For unrealized LazyVariableTrackers, uses the hash of the original value
+        to avoid realizing the tracker and inserting unnecessary guards.
+        For all other cases, delegates to the VariableTracker's get_python_hash method.
+
+        Returns:
+            The hash value of the underlying variable tracker
+        """
+        if (
+            isinstance(self.vt, variables.LazyVariableTracker)
+            and not self.vt.is_realized()
+            and self.vt.is_hashable()
+        ):
+            return hash(self.vt.original_value())
+
+        maybe_constant = self._maybe_constant_torch_size(self.vt)
+        if maybe_constant is not self._MISSING:
+            return hash(maybe_constant)
+
+        return self.vt.get_python_hash()
+
+    def __eq__(self, other: object) -> bool:
+        """
+        Checks equality between two HashableTracker instances.
+
+        Delegates to the VariableTracker's is_python_equal method to compare
+        the underlying variable trackers for Python-level equality.
+
+        Args:
+            other: Another HashableTracker instance to compare with
+
+        Returns:
+            True if the underlying variable trackers are Python-equal, False otherwise
+        """
+        if not isinstance(other, HashableTracker):
+            return False
+        if self.vt is other.vt:
+            return True
+
+        self_constant = self._maybe_constant_torch_size(self.vt)
+        other_constant = self._maybe_constant_torch_size(other.vt)
+        if self_constant is not self._MISSING and other_constant is not self._MISSING:
+            return self_constant == other_constant
+
+        return self.vt.is_python_equal(other.vt)
+
+
+# [Adding a new supported class within the keys of SetVariable]
+# see steps outlined for ConstDictVariable
+
+
+class SetVariable(VariableTracker):
+    """Represents a Python set during symbolic execution."""
+
+    # PySet_Type: https://github.com/python/cpython/blob/v3.13.0/Objects/setobject.c#L2436
+    _cpython_type = set
+
+    CONTAINS_GUARD = GuardBuilder.SET_CONTAINS
+    NOT_CONTAINS_GUARD = GuardBuilder.SET_NOT_CONTAINS
+
+    def __init__(
+        self,
+        items: Iterable[VariableTracker | HashableTracker],
+        **kwargs: Any,
+    ) -> None:
+        # .clone() passes these arguments in kwargs but they're recreated below
+        if "original_items" in kwargs:
+            kwargs.pop("original_items")
+        if "should_reconstruct_all" in kwargs:
+            kwargs.pop("should_reconstruct_all")
+
+        super().__init__(**kwargs)
+
+        # Items can be either VariableTrackers or HashableTrackers (from set ops).
+        # For VariableTrackers, realize them to ensure aliasing guards are installed
+        # when the same object appears multiple times.
+        hashable_items = []
+        for item in items:
+            if isinstance(item, HashableTracker):
+                # Already a HashableTracker from a set operation
+                hashable_items.append(item)
+            else:
+                # VariableTracker - realize to install guards, then wrap
+                # pyrefly: ignore [bad-argument-type]
+                hashable_items.append(HashableTracker(item.realize()))
+        self.items = dict.fromkeys(hashable_items, SetVariable._default_value())
+        self.should_reconstruct_all = (
+            not is_from_local_source(self.source) if self.source else True
+        )
+        self.original_items = dict.fromkeys(
+            hashable_items, SetVariable._default_value()
+        )
+
+    def debug_repr(self) -> str:
+        if not self.items:
+            return "set()"
+        else:
+            items: list[str] = []
+            for v in self.items:
+                vt = v.vt if isinstance(v, HashableTracker) else v
+                val_str = repr(vt.value) if hasattr(vt, "value") else vt.debug_repr()
+                items.append(val_str)
+            return "{" + ",".join(items) + "}"
+
+    @property
+    def set_items(self) -> set["HashableTracker"]:
+        return set(self.items.keys())
+
+    @staticmethod
+    def _default_value() -> VariableTracker:
+        # Variable to fill in the keys of the dictionary
+        return CONSTANT_VARIABLE_NONE
+
+    def as_proxy(self) -> Any:
+        return {k.vt.as_proxy() for k in self.set_items}
+
+    def python_type(self) -> type:
+        return set
+
+    def as_python_constant(self) -> Any:
+        return {k.vt.as_python_constant() for k in self.set_items}
+
+    def reconstruct(self, codegen: "PyCodegen") -> None:
+        codegen.foreach([x.vt for x in self.set_items])
+        codegen.append_output(create_instruction("BUILD_SET", arg=len(self.set_items)))
+
+    def __contains__(self, vt: VariableTracker) -> bool:
+        assert isinstance(vt, VariableTracker)
+        if not is_hashable(vt):
+            return False
+        key = HashableTracker(vt)
+        return key in self.items and not isinstance(
+            self.items[key], variables.DeletedVariable
+        )
+
+    def len(self) -> int:
+        return sum(
+            not isinstance(x, variables.DeletedVariable) for x in self.items.values()
+        )
+
+    def has_new_items(self) -> bool:
+        return self.should_reconstruct_all or any(
+            self.is_new_item(self.original_items.get(key.vt), value)
+            for key, value in self.items.items()
+        )
+
+    def is_new_item(
+        self, value: VariableTracker | None, other: VariableTracker
+    ) -> bool:
+        if value and value.is_realized() and other.is_realized():
+            return id(value.realize()) != id(other.realize())
+        return id(value) != id(other)
+
+    def unpack_var_sequence(self, tx: "InstructionTranslator") -> list[VariableTracker]:
+        return [x.vt for x in self.items]
+
+    def clone(self, **kwargs: Any) -> VariableTracker:
+        return super().clone(**kwargs)
+
+    def is_python_hashable(self) -> bool:
+        return False
+
+    def var_getattr(self, tx: "InstructionTranslator", name: str):
+        if name == "__class__":
+            return VariableTracker.build(tx, self.python_type())
+        return super().var_getattr(tx, name)
+
+    def call_obj_hasattr(
+        self, tx: "InstructionTranslator", name: str
+    ) -> ConstantVariable:
+        return VariableTracker.build(tx, hasattr(set, name))
+
+    def install_dict_keys_match_guard(self) -> None:
+        # Already EQUALS_MATCH guarded
+        pass
+
+    def install_dict_contains_guard(
+        self, tx: "InstructionTranslator", args: list[VariableTracker]
+    ) -> None:
+        if not self.source:
+            return
+
+        if tx.output.side_effects.is_modified(self):
+            return
+
+        contains = args[0] in self
+        if args[0].source is None and args[0].is_python_constant():
+            guard_fn = (
+                type(self).CONTAINS_GUARD if contains else type(self).NOT_CONTAINS_GUARD
+            )
+            install_guard(
+                self.make_guard(
+                    functools.partial(
+                        guard_fn,
+                        key=args[0].as_python_constant(),
+                    )
+                )
+            )
+        elif args[0].source:
+            if not contains:
+                self.install_dict_keys_match_guard()
+
+    def _fast_set_method(
+        self,
+        tx: "InstructionTranslator",
+        fn: Any,
+        args: list[VariableTracker],
+        kwargs: dict[str, VariableTracker],
+    ) -> VariableTracker:
+        try:
+            res = fn(
+                *[x.as_python_constant() for x in [self, *args]],
+                **{k: v.as_python_constant() for k, v in kwargs.items()},
+            )
+        except Exception as exc:
+            raise_observed_exception(type(exc), tx, args=list(exc.args))
+        return VariableTracker.build(tx, res)
+
+    def call_method(
+        self,
+        tx: "InstructionTranslator",
+        name: str,
+        args: list[VariableTracker],
+        kwargs: dict[str, VariableTracker],
+    ) -> VariableTracker:
+        from ..utils import check_constant_args
+        from .builder import SourcelessBuilder
+
+        if (
+            name
+            in (
+                "isdisjoint",
+                "union",
+                "intersection",
+                "difference",
+                "symmetric_difference",
+            )
+            and check_constant_args(args, kwargs)
+            and self.python_type() is set
+        ):
+            py_type = self.python_type()
+            return self._fast_set_method(tx, getattr(py_type, name), args, kwargs)
+
+        # Lazy imports to avoid circular dependencies
+        from .dicts import DictItemsVariable, DictKeysVariable
+
+        if name == "__init__":
+            temp_set_vt = SourcelessBuilder.create(tx, set).call_set(
+                tx, *args, **kwargs
+            )
+            tx.output.side_effects.mutation(self)
+            self.items.clear()
+            self.items.update(temp_set_vt.items)  # type: ignore[attr-defined]
+            return CONSTANT_VARIABLE_NONE
+        elif name == "add":
+            if kwargs or len(args) != 1:
+                raise_args_mismatch(
+                    tx,
+                    name,
+                    "1 args and 0 kwargs",
+                    f"{len(args)} args and {len(kwargs)} kwargs",
+                )
+            # Convert add to __setitem__ with None value
+            if not is_hashable(args[0]):
+                raise_unhashable(args[0], tx)
+            tx.output.side_effects.mutation(self)
+            self.items[HashableTracker(args[0])] = SetVariable._default_value()
+            return CONSTANT_VARIABLE_NONE
+        elif name == "pop":
+            if kwargs or args:
+                raise_args_mismatch(
+                    tx,
+                    name,
+                    "0 args and 0 kwargs",
+                    f"{len(args)} args and {len(kwargs)} kwargs",
+                )
+            # Choose an item at random and pop it
+            try:
+                result: VariableTracker = self.set_items.pop().vt  # type: ignore[assignment]
+            except KeyError as e:
+                raise_observed_exception(KeyError, tx, args=list(e.args))
+            self.should_reconstruct_all = True
+            tx.output.side_effects.mutation(self)
+            self.items.pop(HashableTracker(result))
+            return result
+        elif name == "isdisjoint":
+            if kwargs or len(args) != 1:
+                raise_args_mismatch(
+                    tx,
+                    name,
+                    "1 args and 0 kwargs",
+                    f"{len(args)} args and {len(kwargs)} kwargs",
+                )
+            return SourcelessBuilder.create(tx, polyfills.set_isdisjoint).call_function(
+                tx, [self, args[0]], {}
+            )
+        elif name == "intersection":
+            if kwargs:
+                raise_args_mismatch(tx, name, "0 kwargs", f"{len(kwargs)} kwargs")
+            return SourcelessBuilder.create(
+                tx, polyfills.set_intersection
+            ).call_function(
+                tx,
+                [self, *args],
+                {"cls": self.python_type_var()},
+            )
+        elif name == "intersection_update":
+            if kwargs:
+                raise_args_mismatch(tx, name, "0 kwargs", f"{len(kwargs)} kwargs")
+            return SourcelessBuilder.create(
+                tx, polyfills.set_intersection_update
+            ).call_function(tx, [self, *args], {})
+        elif name == "union":
+            if kwargs:
+                raise_args_mismatch(tx, name, "0 kwargs", f"{len(kwargs)} kwargs")
+            return SourcelessBuilder.create(tx, polyfills.set_union).call_function(
+                tx,
+                [self, *args],
+                {"cls": self.python_type_var()},
+            )
+        elif name == "difference":
+            if kwargs:
+                raise_args_mismatch(
+                    tx, name, f"Expect: 0 kwargs, Actual: {len(kwargs)} kwargs"
+                )
+            return SourcelessBuilder.create(tx, polyfills.set_difference).call_function(
+                tx,
+                [self, *args],
+                {"cls": self.python_type_var()},
+            )
+        elif name == "difference_update":
+            if kwargs:
+                raise_args_mismatch(tx, name, "0 kwargs", f"{len(kwargs)} kwargs")
+            return SourcelessBuilder.create(
+                tx, polyfills.set_difference_update
+            ).call_function(tx, [self, *args], {})
+        elif name == "symmetric_difference":
+            if kwargs or len(args) != 1:
+                raise_args_mismatch(
+                    tx,
+                    name,
+                    "1 args and 0 kwargs",
+                    f"{len(args)} args and {len(kwargs)} kwargs",
+                )
+            return SourcelessBuilder.create(
+                tx, polyfills.set_symmetric_difference
+            ).call_function(
+                tx,
+                [self, *args],
+                {"cls": self.python_type_var()},
+            )
+        elif name == "symmetric_difference_update":
+            if kwargs or len(args) != 1:
+                raise_args_mismatch(
+                    tx,
+                    name,
+                    "1 args and 0 kwargs",
+                    f"{len(args)} args and {len(kwargs)} kwargs",
+                )
+            return SourcelessBuilder.create(
+                tx, polyfills.set_symmetric_difference_update
+            ).call_function(tx, [self, *args], {})
+        elif name == "update" and self.is_mutable():
+            if kwargs:
+                raise_args_mismatch(tx, name, "0 kwargs", f"{len(kwargs)} kwargs")
+            return SourcelessBuilder.create(tx, polyfills.set_update).call_function(
+                tx, [self, *args], {}
+            )
+        elif name == "remove":
+            if kwargs or len(args) != 1:
+                raise_args_mismatch(
+                    tx,
+                    name,
+                    "1 args and 0 kwargs",
+                    f"{len(args)} args and {len(kwargs)} kwargs",
+                )
+            if args[0] not in self:
+                raise_observed_exception(KeyError, tx, args=args)
+            self.should_reconstruct_all = True
+            tx.output.side_effects.mutation(self)
+            self.items.pop(HashableTracker(args[0]))
+            return CONSTANT_VARIABLE_NONE
+        elif name == "discard":
+            if kwargs or len(args) != 1:
+                raise_args_mismatch(
+                    tx,
+                    name,
+                    "1 args and 0 kwargs",
+                    f"{len(args)} args and {len(kwargs)} kwargs",
+                )
+            if args[0] in self:
+                self.should_reconstruct_all = True
+                tx.output.side_effects.mutation(self)
+                self.items.pop(HashableTracker(args[0]))
+            return CONSTANT_VARIABLE_NONE
+        elif name in ("issubset", "issuperset"):
+            if len(args) != 1:
+                raise_args_mismatch(tx, name, "1 args", f"{len(args)} args")
+
+            op = {
+                "issubset": operator.le,
+                "issuperset": operator.ge,
+            }
+            other = args[0].realize()
+            if not istype(other, SetVariable):
+                other = SourcelessBuilder.create(tx, set).call_function(tx, [other], {})
+            return SourcelessBuilder.create(tx, op.get(name)).call_function(
+                tx, [self, other], {}
+            )
+        elif name in ("__and__", "__or__", "__xor__", "__sub__"):
+            m = {
+                "__and__": "intersection",
+                "__or__": "union",
+                "__xor__": "symmetric_difference",
+                "__sub__": "difference",
+            }.get(name)
+            if not isinstance(
+                args[0],
+                (
+                    SetVariable,
+                    variables.UserDefinedSetVariable,
+                    DictItemsVariable,
+                    DictKeysVariable,
+                ),
+            ):
+                raise_observed_exception(
+                    TypeError,
+                    tx,
+                    args=[
+                        f"unsupported operand type(s) for {name}: '{self.python_type_name()}' and '{args[0].python_type_name()}'"
+                    ],
+                )
+            assert m is not None
+            return self.call_method(tx, m, args, kwargs)
+        elif name in ("__rand__", "__ror__", "__rxor__", "__rsub__"):
+            m = {
+                "__rand__": "__and__",
+                "__ror__": "__or__",
+                "__rxor__": "__xor__",
+                "__rsub__": "__sub__",
+            }.get(name)
+            if not isinstance(
+                args[0],
+                (
+                    SetVariable,
+                    variables.UserDefinedSetVariable,
+                    DictItemsVariable,
+                    DictKeysVariable,
+                ),
+            ):
+                raise_observed_exception(
+                    TypeError,
+                    tx,
+                    args=[
+                        f"unsupported operand type(s) for {name}: '{args[0].python_type_name()}' and '{self.python_type_name()}'"
+                    ],
+                )
+            assert m is not None
+            return args[0].call_method(tx, m, [self], kwargs)
+        elif name in ("__iand__", "__ior__", "__ixor__", "__isub__"):
+            if not isinstance(
+                args[0],
+                (
+                    SetVariable,
+                    variables.UserDefinedSetVariable,
+                    DictItemsVariable,
+                    DictKeysVariable,
+                ),
+            ):
+                raise_observed_exception(
+                    TypeError,
+                    tx,
+                    args=[
+                        f"unsupported operand type(s) for {name}: '{self.python_type_name()}' and '{args[0].python_type_name()}'"
+                    ],
+                )
+            m = {
+                "__iand__": "intersection_update",
+                "__ior__": "update",
+                "__ixor__": "symmetric_difference_update",
+                "__isub__": "difference_update",
+            }.get(name)
+            assert m is not None
+            self.call_method(tx, m, args, kwargs)
+            return self
+        elif name == "__eq__":
+            if not isinstance(
+                args[0],
+                (
+                    SetVariable,
+                    variables.UserDefinedSetVariable,
+                    DictItemsVariable,
+                    DictKeysVariable,
+                ),
+            ):
+                return CONSTANT_VARIABLE_FALSE
+            r = self.call_method(tx, "symmetric_difference", args, kwargs)
+            return VariableTracker.build(tx, len(r.set_items) == 0)  # type: ignore[attr-defined]
+        elif name == "__ne__":
+            eq_result = self.call_method(tx, "__eq__", args, kwargs)
+            return VariableTracker.build(tx, not eq_result.value)  # type: ignore[attr-defined]
+        elif name in cmp_name_to_op_mapping:
+            if not isinstance(
+                args[0],
+                (
+                    SetVariable,
+                    variables.UserDefinedSetVariable,
+                    DictItemsVariable,
+                    DictKeysVariable,
+                ),
+            ):
+                return VariableTracker.build(tx, NotImplemented)
+            return VariableTracker.build(
+                tx,
+                cmp_name_to_op_mapping[name](self.set_items, args[0].set_items),  # type: ignore[attr-defined]
+            )
+        elif name == "__contains__":
+            if not len(args):
+                raise_args_mismatch(
+                    tx,
+                    name,
+                    "more than 1 args and 0 kwargs",
+                    f"{len(args)} args and {len(kwargs)} kwargs",
+                )
+            if not (args and is_hashable(args[0])):
+                raise_unhashable(args[0], tx)
+            self.install_dict_contains_guard(tx, args)
+            contains = args[0] in self
+            return VariableTracker.build(tx, contains)
+        elif name == "__len__":
+            if args or kwargs:
+                raise_args_mismatch(
+                    tx,
+                    name,
+                    "0 args and 0 kwargs",
+                    f"{len(args)} args and {len(kwargs)} kwargs",
+                )
+            return VariableTracker.build(tx, len(self.items))
+        elif name == "copy":
+            if args or kwargs:
+                raise_args_mismatch(
+                    tx,
+                    name,
+                    "0 args and 0 kwargs",
+                    f"{len(args)} args and {len(kwargs)} kwargs",
+                )
+            return self.clone(
+                items=self.items.copy(), mutation_type=ValueMutationNew(), source=None
+            )
+        elif name == "clear":
+            if args or kwargs:
+                raise_args_mismatch(
+                    tx,
+                    name,
+                    "0 args and 0 kwargs",
+                    f"{len(args)} args and {len(kwargs)} kwargs",
+                )
+            self.should_reconstruct_all = True
+            tx.output.side_effects.mutation(self)
+            self.items.clear()
+            return CONSTANT_VARIABLE_NONE
+        elif name == "__iter__":
+            from .lists import ListIteratorVariable
+
+            if self.source and not is_constant_source(self.source):
+                tx.output.guard_on_key_order.add(self.source)
+            return ListIteratorVariable(
+                self.unpack_var_sequence(tx), mutation_type=ValueMutationNew()
+            )
+        return super().call_method(tx, name, args, kwargs)
+
+    def python_type_var(self) -> "BuiltinVariable":
+        return variables.BuiltinVariable(set)
+
+    def getitem_const(
+        self, tx: "InstructionTranslator", arg: VariableTracker
+    ) -> VariableTracker:
+        raise RuntimeError("Illegal to getitem on a set")
+    
+    def sq_length(self, tx: "InstructionTranslator") -> VariableTracker:
+        return VariableTracker.build(tx, len(self.set_items))
+
+
+class OrderedSetClassVariable(VariableTracker):
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+
+    def as_python_constant(self) -> type[OrderedSet[Any]]:
+        return OrderedSet
+
+    def var_getattr(self, tx: "InstructionTranslator", name: str) -> VariableTracker:
+        if name == "__new__":
+            from .misc import GetAttrVariable
+
+            if self.source:
+                attr_source = AttrSource(self.source, name)
+            else:
+                attr_source = None
+            return GetAttrVariable(self, name, source=attr_source)
+        else:
+            return super().var_getattr(tx, name)
+
+    def call_method(
+        self,
+        tx: "InstructionTranslator",
+        name: str,
+        args: list[VariableTracker],
+        kwargs: dict[str, VariableTracker],
+    ) -> VariableTracker:
+        from .builtin import set_methods
+
+        if name == "__new__":
+            if len(args) != 2 or kwargs:
+                raise_args_mismatch(
+                    tx,
+                    name,
+                    "OrderedSet.__new__ only accepts one arg"
+                    f"{len(args)} args and {len(kwargs)} kwargs",
+                )
+
+            return variables.OrderedSetVariable([], mutation_type=ValueMutationNew())
+
+        resolved_fn = getattr(set, name)
+        if resolved_fn in set_methods and isinstance(args[0], variables.SetVariable):
+            return args[0].call_method(tx, name, args[1:], kwargs)
+
+        return super().call_method(tx, name, args, kwargs)
+
+    def call_function(
+        self,
+        tx: "InstructionTranslator",
+        args: Sequence[VariableTracker],
+        kwargs: dict[str, VariableTracker],
+    ) -> "OrderedSetVariable":
+        if len(args) > 1 or kwargs:
+            raise_args_mismatch(
+                tx,
+                "OrderedSet",
+                "OrderedSet only accepts one arg"
+                f"{len(args)} args and {len(kwargs)} kwargs",
+            )
+
+        if len(args) == 0:
+            # pyrefly: ignore [implicit-any]
+            items = []
+        else:
+            items = args[0].force_unpack_var_sequence(tx)
+        return variables.OrderedSetVariable(items, mutation_type=ValueMutationNew())
+
+
+class OrderedSetVariable(SetVariable):
+    def debug_repr(self) -> str:
+        if not self.items:
+            return "OrderedSet([])"
+        else:
+            items: list[str] = []
+            for k in self.items:
+                key_str = (
+                    repr(k.vt.value) if hasattr(k.vt, "value") else k.vt.debug_repr()
+                )
+                items.append(key_str)
+            return "OrderedSet([" + ",".join(items) + "])"
+
+    def as_python_constant(self) -> OrderedSet[Any]:
+        return OrderedSet([k.vt.as_python_constant() for k in self.set_items])
+
+    def python_type(self) -> type[OrderedSet[Any]]:
+        return OrderedSet
+
+    # pyrefly: ignore[bad-override]
+    def python_type_var(self) -> OrderedSetClassVariable:
+        return OrderedSetClassVariable()
+
+    def reconstruct(self, codegen: "PyCodegen") -> None:
+        codegen.add_push_null(
+            lambda: codegen.load_import_from("torch.utils._ordered_set", "OrderedSet")
+        )
+        codegen.foreach([x.vt for x in self.set_items])
+        codegen.append_output(create_instruction("BUILD_LIST", arg=len(self.set_items)))
+        codegen.extend_output(create_call_function(1, False))
+
+
+class FrozensetVariable(SetVariable):
+    # PyFrozenSet_Type: https://github.com/python/cpython/blob/v3.13.0/Objects/setobject.c#L2526
+    _cpython_type = frozenset
+
+    def debug_repr(self) -> str:
+        if not self.items:
+            return "frozenset()"
+        else:
+            items: list[str] = []
+            for k in self.items:
+                key_str = (
+                    repr(k.vt.value) if hasattr(k.vt, "value") else k.vt.debug_repr()
+                )
+                items.append(key_str)
+            return "{" + ",".join(items) + "}"
+
+    @property
+    def set_items(self) -> set["HashableTracker"]:
+        return set(self.items.keys())
+
+    def python_type(self) -> type:
+        return frozenset
+
+    def python_type_var(self) -> "BuiltinVariable":
+        return variables.BuiltinVariable(frozenset)
+
+    def as_python_constant(self) -> Any:
+        return frozenset({k.vt.as_python_constant() for k in self.set_items})
+
+    def reconstruct(self, codegen: "PyCodegen") -> None:
+        codegen.add_push_null(
+            lambda: codegen.extend_output(
+                [
+                    codegen.create_load_global("frozenset"),
+                ]
+            )
+        )
+        codegen.foreach([x.vt for x in self.set_items])
+        codegen.extend_output(
+            [
+                create_instruction("BUILD_LIST", arg=len(self.set_items)),
+                *create_call_function(1, False),
+            ]
+        )
+
+    def call_method(
+        self,
+        tx: "InstructionTranslator",
+        name: str,
+        args: list[VariableTracker],
+        kwargs: dict[str, VariableTracker],
+    ) -> VariableTracker:
+        if name in ["add", "pop", "update", "remove", "discard", "clear"]:
+            raise RuntimeError(f"Illegal call_method {name} on a frozenset")
+        elif name == "__init__":
+            # frozenset is immutable. Calling __init__ again shouldn't have any effect
+            return CONSTANT_VARIABLE_NONE
+        elif name in (
+            "copy",
+            "difference",
+            "intersection",
+            "symmetric_difference",
+        ):
+            r = super().call_method(tx, name, args, kwargs)
+            return FrozensetVariable(r.items)  # type: ignore[attr-defined]
+        return super().call_method(tx, name, args, kwargs)
+
+    def is_python_hashable(self) -> Literal[True]:
+        """
+        Frozensets are immutable and hashable in Python.
+        """
+        return True
+
+    def get_python_hash(self) -> int:
+        return hash(self.as_python_constant())
+
+    def is_python_equal(self, other: object) -> bool:
+        return (
+            isinstance(other, VariableTracker)
+            and self.as_python_constant() == other.as_python_constant()
+        )
+
+
+class DictKeySetVariable(SetVariable):
+    def debug_repr(self) -> str:
+        if not self.items:
+            return "dict_keys([])"
+        else:
+            items: list[str] = []
+            for k in self.items:
+                key_str = (
+                    repr(k.vt.value) if hasattr(k.vt, "value") else k.vt.debug_repr()
+                )
+                items.append(key_str)
+            return "dict_keys([" + ",".join(items) + "])"
+
+    def install_dict_keys_match_guard(self) -> None:
+        # Already EQUALS_MATCH guarded
+        pass
+
+    def install_dict_contains_guard(
+        self, tx: "InstructionTranslator", args: list[VariableTracker]
+    ) -> None:
+        # Already EQUALS_MATCH guarded
+        pass
+
+    @property
+    def set_items(self) -> Any:
+        return self.items
+
+    def python_type(self) -> type:
+        from ..utils import dict_keys
+
+        return dict_keys
+
+    def as_python_constant(self) -> Any:
+        return dict.fromkeys(
+            {k.vt.as_python_constant() for k in self.set_items}, None
+        ).keys()
+
+    def call_method(
+        self,
+        tx: "InstructionTranslator",
+        name: str,
+        args: list[VariableTracker],
+        kwargs: dict[str, VariableTracker],
+    ) -> VariableTracker:
+        if name in ["add", "pop", "update", "remove", "discard", "clear"]:
+            raise RuntimeError(f"Illegal call_method {name} on a dict_keys")
+        return super().call_method(tx, name, args, kwargs)

--- a/torch/_dynamo/variables/sets.py
+++ b/torch/_dynamo/variables/sets.py
@@ -309,11 +309,7 @@ class SetVariable(VariableTracker):
     ) -> ConstantVariable:
         return VariableTracker.build(tx, hasattr(set, name))
 
-    def install_dict_keys_match_guard(self) -> None:
-        # Already EQUALS_MATCH guarded
-        pass
-
-    def install_dict_contains_guard(
+    def install_set_contains_guard(
         self, tx: "InstructionTranslator", args: list[VariableTracker]
     ) -> None:
         if not self.source:
@@ -335,9 +331,6 @@ class SetVariable(VariableTracker):
                     )
                 )
             )
-        elif args[0].source:
-            if not contains:
-                self.install_dict_keys_match_guard()
 
     def _fast_set_method(
         self,
@@ -663,7 +656,7 @@ class SetVariable(VariableTracker):
                 )
             if not (args and is_hashable(args[0])):
                 raise_unhashable(args[0], tx)
-            self.install_dict_contains_guard(tx, args)
+            self.install_set_contains_guard(tx, args)
             contains = args[0] in self
             return VariableTracker.build(tx, contains)
         elif name == "__len__":
@@ -915,11 +908,7 @@ class DictKeySetVariable(SetVariable):
                 items.append(key_str)
             return "dict_keys([" + ",".join(items) + "])"
 
-    def install_dict_keys_match_guard(self) -> None:
-        # Already EQUALS_MATCH guarded
-        pass
-
-    def install_dict_contains_guard(
+    def install_set_contains_guard(
         self, tx: "InstructionTranslator", args: list[VariableTracker]
     ) -> None:
         # Already EQUALS_MATCH guarded

--- a/torch/_dynamo/variables/sets.py
+++ b/torch/_dynamo/variables/sets.py
@@ -563,7 +563,7 @@ class SetVariable(VariableTracker):
         self, tx: "InstructionTranslator", arg: VariableTracker
     ) -> VariableTracker:
         raise RuntimeError("Illegal to getitem on a set")
-    
+
     def sq_length(self, tx: "InstructionTranslator") -> VariableTracker:
         return VariableTracker.build(tx, len(self.set_items))
 

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -95,7 +95,8 @@ from ..utils import (
     unpatched_nn_module_getattr,
 )
 from .base import MutationType, NO_SUCH_SUBOBJ, ValueMutationNew, VariableTracker
-from .dicts import ConstDictVariable, DefaultDictVariable, SetVariable
+from .dicts import ConstDictVariable, DefaultDictVariable
+from .sets import SetVariable
 
 
 try:

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -96,6 +96,7 @@ from ..utils import (
 )
 from .base import MutationType, NO_SUCH_SUBOBJ, ValueMutationNew, VariableTracker
 from .dicts import ConstDictVariable, DefaultDictVariable
+from .hashable import HashableTracker
 from .sets import SetVariable
 
 
@@ -2968,7 +2969,7 @@ class UserDefinedSetVariable(UserDefinedObjectVariable):
         return self._base_vt.set_items  # pyrefly: ignore[missing-attribute]
 
     @property
-    def items(self) -> list[VariableTracker]:
+    def items(self) -> dict[HashableTracker, VariableTracker]:
         assert self._base_vt is not None
         return self._base_vt.items  # pyrefly: ignore[missing-attribute]
 


### PR DESCRIPTION
### Summary
Refactors `SetVariable` to inherit directly from `VariableTracker` instead of `ConstDictVariable`, fully decoupling set tracking from dict tracking in Dynamo.

### Motivation
Cpython handles dict and set quite differently now, so to more closely follow the cpython paradigm and support transitioning to tp_slot support it was important to decouple the previous inheritence scheme. The inheritance was a known footgun due to incorrect fallback routing possibility from set operations sharing names with dict operations.

### Changes

- `sets.py` (new standalone module): `SetVariable` and all subclasses (`OrderedSetVariable`, `FrozensetVariable`, `DictKeySetVariable`, `OrderedSetClassVariable`) now live in a self-contained module with proper imports. `HashableTracker`, `is_hashable`, and `raise_unhashable` also moved here from `dicts.py` since they're part of the shared hashability protocol.
- `SetVariable` is now independent of `ConstDictVariable`: All functionality that `SetVariable` previously inherited — `__contains__, len, clone, unpack_var_sequence, has_new_items, is_new_item, is_python_hashable, var_getattr, call_obj_hasattr, install_dict_contains_guard`  is ported directly onto `SetVariable`. 
  - All call_method cases that previously fell through to `ConstDictVariable` (`__contains__, __len__, __iter__, __ne__, copy, clear, add, pop, remove, discard`) are now handled by `SetVariable`. Dict-only methods are correctly omitted.
- `isinstance` checks updated across 8 files: Each `isinstance(x, ConstDictVariable)` check was individually assessed — some were simplified (removing now-unnecessary `not isinstance(x, SetVariable)` exclusions in `side_effects.py` and `builtin.py`), some had `SetVariable` added to maintain equivalent behavior (side_effects.py codegen, builtin.py bool/not, higher_order_ops.py, object_protocol.py), and dict-only checks were left unchanged.
- `dicts.py` cleaned up: Set-related classes, `is_hashable`, and `raise_unhashable` removed (now imported from sets.py). Docstring updated. Import chain is strictly one-directional: dicts.py → sets.py.

`SetVariable` still handles its contents as a dict with `None` keys. This was a decision to limit the scope of code changes where possible, but should maintain all functionality.

### Testing
The existing dynamo and cpython test coverage of the SetVariable class and Subclasses to support the correctness of the changes.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98