### PR TITLE
Optimize the performance by reducing the cpu overhead (#179193)

### DIFF
--- a/torch/sparse/semi_structured.py
+++ b/torch/sparse/semi_structured.py
@@ -728,23 +728,28 @@ def _ensure_cutlass_mm_registered():
         out_features: int,
         min_rows: int,
         min_cols: int,
-        transpose_dense: bool,
+        should_transpose_dense: bool,
     ) -> torch.Tensor:
         m, n = dense.shape
         to_pad_m = (-m) % min_rows
         to_pad_n = (-n) % min_cols
-        dense_padded = torch.nn.functional.pad(dense, (0, to_pad_n, 0, to_pad_m))
-        mm_input = dense_padded.t() if transpose_dense else dense_padded
+        need_pad = to_pad_m != 0 or to_pad_n != 0
+        dense_padded = dense
+        if need_pad:
+            dense_padded = torch.nn.functional.pad(dense, (0, to_pad_n, 0, to_pad_m))
+        mm_input = dense_padded.t() if should_transpose_dense else dense_padded
         if bias is None:
             res = torch._sparse_semi_structured_mm(packed, meta, mm_input)
         else:
             res = torch._sparse_semi_structured_addmm(bias, packed, meta, mm_input)
-        out_cols = m if transpose_dense else n
-        return (
-            res[:out_features]
-            .narrow(1, 0, out_cols)
-            .clone(memory_format=torch.contiguous_format)
-        )
+        if need_pad:
+            out_cols = m if should_transpose_dense else n
+            return (
+                res[:out_features]
+                .narrow(1, 0, out_cols)
+                .clone(memory_format=torch.contiguous_format)
+            )
+        return res.contiguous()
 
     @cutlass_mm.register_fake
     def _cutlass_mm_fake(
@@ -793,7 +798,10 @@ def _ensure_cusparselt_mm_registered():
         m, n = dense.shape
         to_pad_m = (-m) % min_rows
         to_pad_n = (-n) % min_cols
-        dense_padded = torch.nn.functional.pad(dense, (0, to_pad_n, 0, to_pad_m))
+        need_pad = to_pad_m != 0 or to_pad_n != 0
+        dense_padded = dense
+        if need_pad:
+            dense_padded = torch.nn.functional.pad(dense, (0, to_pad_n, 0, to_pad_m))
         mm_input = dense_padded.t() if should_transpose_dense else dense_padded
         res = torch._cslt_sparse_mm(
             packed,
@@ -804,8 +812,12 @@ def _ensure_cusparselt_mm_registered():
         )
         if fuse_transpose:
             res = res.t()
-        out_cols = m if should_transpose_dense else n
-        return res.narrow(1, 0, out_cols).clone(memory_format=torch.contiguous_format)
+        if need_pad:
+            out_cols = m if should_transpose_dense else n
+            return res.narrow(1, 0, out_cols).clone(
+                memory_format=torch.contiguous_format
+            )
+        return res.contiguous()
 
     @cusparselt_mm.register_fake
     def _cusparselt_mm_fake(


### PR DESCRIPTION
Summary:

The padding logic is required for input before sending them to cuSPARSElt, as the cuSPARSElt requires input dim % 8 == 0 for fp16. 

**Context**
We previously implemented the logic in a way trying out best to avoid if-else branch on SymInt so Dynamo wouldn't do algebra on SymInt and generate unnecessary guards. As a solution, we hide the input preparation steps from tracing by wrapping it into a custom-op as a single node in graph.

However we noticed there are some CPU side overhead from the padding step as we need to handle post-padding properly. We also noticed that padding may not always happen -- acctually it will not happen for most inputs. We should avoid the post-padding steps for these inputs that padding is not needed as much as possible, so we return to the early version to introduce a if-else (as we have custom-op we don't need to worry about if-else on SymInt again).

**Benchmark**
Benchmark script used: D98221760 - benchmark_cutlass_vs_cusparselt_fp8.py
SS-cSPLT-16-def: semi_structure_cuSPARSElt-fp16-default (no alg_id search)
SS-cSPLT-16-tun: semi_structure_cuSPARSElt-fp16-tuned with alg_id search

Performance gain
shapes tested:
<img width="177" height="767" alt="Screenshot 2026-04-02 at 3 28 15 PM" src="https://github.com/user-attachments/assets/e69a430f-3dc2-4bed-ba64-505dc346d79d" />
Before change:
<img width="258" height="762" alt="Screenshot 2026-04-02 at 3 22 54 PM" src="https://github.com/user-attachments/assets/407203e2-f082-45c8-9cb4-d2ae31a727aa" />
After change:
<img width="261" height="759" alt="Screenshot 2026-04-02 at 3 22 59 PM" src="https://github.com/user-attachments/assets/a06717ef-1e90-42c7-8aaa-34f129208697" />


Test Plan: OSS CI

Differential Revision: D98394896


