### PR TITLE
[functorch] Fix vmap/functionalize under inference_mode

### DIFF
--- a/aten/src/ATen/functorch/DynamicLayer.cpp
+++ b/aten/src/ATen/functorch/DynamicLayer.cpp
@@ -10,6 +10,8 @@
 
 #include <torch/library.h>
 #include <c10/core/impl/LocalDispatchKeySet.h>
+#include <c10/core/AutogradState.h>
+#include <c10/core/InferenceMode.h>
 #include <ATen/core/dispatch/Dispatcher.h>
 #include <c10/util/irange.h>
 #include <ATen/FuncTorchTLS.h>
@@ -30,7 +32,7 @@ DynamicLayer::DynamicLayer(
     std::optional<bool> prev_grad_mode,
     std::optional<bool> prev_fwd_grad_mode,
     std::optional<bool> functionalize_add_back_views,
-    std::optional<bool> prev_inference_mode)
+    bool prev_inference_mode)
 {
   if (transform_type == TransformType::Grad) {
     TORCH_INTERNAL_ASSERT(prev_grad_mode.has_value());
@@ -41,17 +43,17 @@ DynamicLayer::DynamicLayer(
   switch (transform_type) {
     case TransformType::Vmap:
       // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-      interpreter_ = Interpreter::Vmap(layerId, std::move(batchSize.value()), randomness.value());
+      interpreter_ = Interpreter::Vmap(layerId, std::move(batchSize.value()), randomness.value(), prev_inference_mode);
       break;
     case TransformType::Grad:
-      interpreter_ = Interpreter::Grad(layerId, prev_grad_mode.value(), prev_inference_mode.value_or(false));
+      interpreter_ = Interpreter::Grad(layerId, prev_grad_mode.value(), prev_inference_mode);
       break;
     case TransformType::Jvp:
-      interpreter_ = Interpreter::Jvp(layerId, prev_fwd_grad_mode.value(), prev_inference_mode.value_or(false));
+      interpreter_ = Interpreter::Jvp(layerId, prev_fwd_grad_mode.value(), prev_inference_mode);
       break;
     case TransformType::Functionalize:
       // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-      interpreter_ = Interpreter::Functionalize(layerId, functionalize_add_back_views.value());
+      interpreter_ = Interpreter::Functionalize(layerId, functionalize_add_back_views.value(), prev_inference_mode);
       break;
     default:
       TORCH_INTERNAL_ASSERT(false);
@@ -247,15 +249,25 @@ int64_t initAndPushDynamicLayer(
     std::optional<RandomnessType> randomness,
     std::optional<bool> prev_grad_mode,
     std::optional<bool> prev_fwd_grad_mode,
-    std::optional<bool> functionalize_add_back_views,
-    std::optional<bool> prev_inference_mode) {
+    std::optional<bool> functionalize_add_back_views) {
+  // When inference_mode is on, new tensors lack autograd dispatch keys
+  // (TensorImpl strips them in its constructor). Toggle the flag off so
+  // tensors created inside the transform can participate in autograd.
+  // Uses AutogradState::set_inference_mode directly — not the InferenceMode
+  // RAII guard, which would clobber grad_mode and fw_grad_mode on destruction.
+  bool prev_inference_mode = c10::InferenceMode::is_enabled();
+  if (prev_inference_mode) {
+    auto state = c10::AutogradState::get_tls_state();
+    state.set_inference_mode(false);
+    c10::AutogradState::set_tls_state(state);
+  }
+
   const auto& dynamicLayerStack = dynamicLayerStackAccessor();
   const int64_t layerId = static_cast<int64_t>(1 + dynamicLayerStack.size());
   DynamicLayer new_layer(transform_type, layerId, std::move(batch_size), randomness, prev_grad_mode, prev_fwd_grad_mode, functionalize_add_back_views, prev_inference_mode);
   // NB: this function should be called while holding the GIL to avoid races
   new_layer.interpreter().set_is_alive(true);
   pushDynamicLayer(std::move(new_layer));
-
 
   if (transform_type == TransformType::Grad) {
     TORCH_INTERNAL_ASSERT(prev_grad_mode.has_value());
@@ -271,6 +283,12 @@ DynamicLayer popDynamicLayerAndDeleteMetadata() {
 
   // NB: this function should be called while holding the GIL to avoid races
   result.interpreter().set_is_alive(false);
+  // Restore inference_mode if it was saved by initAndPushDynamicLayer.
+  if (result.interpreter().prevInferenceMode()) {
+    auto state = c10::AutogradState::get_tls_state();
+    state.set_inference_mode(true);
+    c10::AutogradState::set_tls_state(state);
+  }
   return result;
 }
 

--- a/aten/src/ATen/functorch/DynamicLayer.h
+++ b/aten/src/ATen/functorch/DynamicLayer.h
@@ -48,7 +48,7 @@ struct TORCH_API DynamicLayer {
       std::optional<bool> prev_grad_mode = std::nullopt,
       std::optional<bool> pre_fwd_grad_mode = std::nullopt,
       std::optional<bool> functionalize_add_back_views = std::nullopt,
-      std::optional<bool> prev_inference_mode = std::nullopt);
+      bool prev_inference_mode = false);
 
   TransformType key() const;
   int64_t layerId() const;
@@ -70,8 +70,7 @@ TORCH_API int64_t initAndPushDynamicLayer(
     std::optional<RandomnessType> randomness = std::nullopt,
     std::optional<bool> prev_grad_mode = std::nullopt,
     std::optional<bool> prev_fwd_grad_mode = std::nullopt,
-    std::optional<bool> functionalize_add_back_views = std::nullopt,
-    std::optional<bool> prev_inference_mode = std::nullopt);
+    std::optional<bool> functionalize_add_back_views = std::nullopt);
 TORCH_API DynamicLayer popDynamicLayerAndDeleteMetadata();
 TORCH_API std::optional<DynamicLayer> maybeCurrentDynamicLayer();
 TORCH_API const std::vector<DynamicLayer>& getDynamicLayerStack();

--- a/aten/src/ATen/functorch/Interpreter.h
+++ b/aten/src/ATen/functorch/Interpreter.h
@@ -123,8 +123,8 @@ struct VmapInterpreterMeta {
 };
 
 struct GradInterpreterMeta {
-  explicit GradInterpreterMeta(bool prevGradMode, bool prevInferenceMode = false)
-    : prevGradMode_(prevGradMode), prevInferenceMode_(prevInferenceMode) {}
+  explicit GradInterpreterMeta(bool prevGradMode)
+    : prevGradMode_(prevGradMode) {}
   GradInterpreterMeta() = default;
   GradInterpreterMeta(const GradInterpreterMeta&) = default;
   GradInterpreterMeta(GradInterpreterMeta&&) = default;
@@ -133,23 +133,20 @@ struct GradInterpreterMeta {
   ~GradInterpreterMeta() = default;
 
   bool prevGradMode_;
-  bool prevInferenceMode_;
   template <typename T>
   friend void to_json(T& json_j, const GradInterpreterMeta& json_t) {
     json_j["prevGradMode"] = json_t.prevGradMode_;
-    json_j["prevInferenceMode"] = json_t.prevInferenceMode_;
   }
 
   template <typename T>
   friend void from_json(const T& json_j, GradInterpreterMeta& json_t) {
     json_t.prevGradMode_ = json_j["prevGradMode"];
-    json_t.prevInferenceMode_ = json_j.value("prevInferenceMode", false);
   }
 };
 
 struct JvpInterpreterMeta {
-  explicit JvpInterpreterMeta(bool prevFwdGradMode, bool prevInferenceMode = false)
-    : prevFwdGradMode_(prevFwdGradMode), prevInferenceMode_(prevInferenceMode) {}
+  explicit JvpInterpreterMeta(bool prevFwdGradMode)
+    : prevFwdGradMode_(prevFwdGradMode) {}
   JvpInterpreterMeta() = default;
   JvpInterpreterMeta(const JvpInterpreterMeta&) = default;
   JvpInterpreterMeta(JvpInterpreterMeta&&) = default;
@@ -158,17 +155,14 @@ struct JvpInterpreterMeta {
   ~JvpInterpreterMeta() = default;
 
   bool prevFwdGradMode_;
-  bool prevInferenceMode_;
   template <typename T>
   friend void to_json(T& json_j, const JvpInterpreterMeta& json_t) {
     json_j["prevFwdGradMode"] = json_t.prevFwdGradMode_;
-    json_j["prevInferenceMode"] = json_t.prevInferenceMode_;
   }
 
   template <typename T>
   friend void from_json(const T& json_j, JvpInterpreterMeta& json_t) {
     json_t.prevFwdGradMode_ = json_j["prevFwdGradMode"];
-    json_t.prevInferenceMode_ = json_j.value("prevInferenceMode", false);
   }
 };
 
@@ -205,17 +199,17 @@ typedef std::variant<
 
 struct Interpreter {
   // factory functions
-  static Interpreter Vmap(int64_t level, c10::SymInt batchSize, RandomnessType randomness) {
-    return Interpreter(TransformType::Vmap, level, VmapInterpreterMeta(std::move(batchSize), randomness));
+  static Interpreter Vmap(int64_t level, c10::SymInt batchSize, RandomnessType randomness, bool prevInferenceMode = false) {
+    return Interpreter(TransformType::Vmap, level, VmapInterpreterMeta(std::move(batchSize), randomness), prevInferenceMode);
   }
   static Interpreter Grad(int64_t level, bool prevGradMode, bool prevInferenceMode = false) {
-    return Interpreter(TransformType::Grad, level, GradInterpreterMeta(prevGradMode, prevInferenceMode));
+    return Interpreter(TransformType::Grad, level, GradInterpreterMeta(prevGradMode), prevInferenceMode);
   }
   static Interpreter Jvp(int64_t level, bool prevFwdGradMode, bool prevInferenceMode = false) {
-    return Interpreter(TransformType::Jvp, level, JvpInterpreterMeta(prevFwdGradMode, prevInferenceMode));
+    return Interpreter(TransformType::Jvp, level, JvpInterpreterMeta(prevFwdGradMode), prevInferenceMode);
   }
-  static Interpreter Functionalize(int64_t level, bool functionalizeAddBackViews) {
-    return Interpreter(TransformType::Functionalize, level, FunctionalizeInterpreterMeta(functionalizeAddBackViews));
+  static Interpreter Functionalize(int64_t level, bool functionalizeAddBackViews, bool prevInferenceMode = false) {
+    return Interpreter(TransformType::Functionalize, level, FunctionalizeInterpreterMeta(functionalizeAddBackViews), prevInferenceMode);
   }
 
   // methods
@@ -251,6 +245,8 @@ struct Interpreter {
   void set_is_alive(bool alive) {
     *is_alive_ = alive;
   }
+
+  bool prevInferenceMode() const { return prevInferenceMode_; }
 
   // Please don't use this
   explicit Interpreter() = default;
@@ -325,8 +321,8 @@ struct Interpreter {
   }
 
  private:
-  explicit Interpreter(TransformType type, int64_t level, InterpreterMeta meta):
-    type_(type), level_(level), is_alive_(std::make_shared<bool>(false)), meta_(std::move(meta)) {}
+  explicit Interpreter(TransformType type, int64_t level, InterpreterMeta meta, bool prevInferenceMode = false):
+    type_(type), level_(level), is_alive_(std::make_shared<bool>(false)), meta_(std::move(meta)), prevInferenceMode_(prevInferenceMode) {}
 
   // fields
   TransformType type_{};
@@ -334,6 +330,7 @@ struct Interpreter {
   std::optional<c10::impl::LocalDispatchKeySet> savedLocalDispatchKeySet_;
   std::shared_ptr<bool> is_alive_;
   InterpreterMeta meta_;
+  bool prevInferenceMode_{};
 };
 
 // Applies the following for-loop:

--- a/test/functorch/test_eager_transforms.py
+++ b/test/functorch/test_eager_transforms.py
@@ -1249,6 +1249,181 @@ class TestGradTransform(TestCase):
             self.assertTrue(torch.is_inference_mode_enabled())
         self.assertTrue(not torch.is_inference_mode_enabled())
 
+    def test_inference_mode_vmap_restored(self, device):
+        # inference_mode flag must be saved/restored across vmap
+        self.assertTrue(not torch.is_inference_mode_enabled())
+        with torch.inference_mode():
+            self.assertTrue(torch.is_inference_mode_enabled())
+            vmap(lambda x: x**2)(torch.randn(5, 3, device=device))
+            self.assertTrue(torch.is_inference_mode_enabled())
+        self.assertTrue(not torch.is_inference_mode_enabled())
+
+    def test_inference_mode_functionalize_restored(self, device):
+        # inference_mode flag must be saved/restored across functionalize
+        self.assertTrue(not torch.is_inference_mode_enabled())
+        with torch.inference_mode():
+            self.assertTrue(torch.is_inference_mode_enabled())
+            torch.func.functionalize(lambda x: x**2)(torch.randn(3, device=device))
+            self.assertTrue(torch.is_inference_mode_enabled())
+        self.assertTrue(not torch.is_inference_mode_enabled())
+
+    def test_inference_mode_vmap_flag_disabled_inside(self, device):
+        # The inference_mode flag should be OFF inside vmap's scope,
+        # so tensors created there carry autograd dispatch keys.
+        flag_inside = []
+
+        def f(x):
+            flag_inside.append(torch.is_inference_mode_enabled())
+            return x**2
+
+        with torch.inference_mode():
+            vmap(f)(torch.randn(5, 3, device=device))
+            # Flag should be off inside vmap, on outside
+            self.assertFalse(flag_inside[0])
+            self.assertTrue(torch.is_inference_mode_enabled())
+
+    def test_inference_mode_functionalize_flag_disabled_inside(self, device):
+        # The inference_mode flag should be OFF inside functionalize's scope.
+        flag_inside = []
+
+        def f(x):
+            flag_inside.append(torch.is_inference_mode_enabled())
+            return x**2
+
+        with torch.inference_mode():
+            torch.func.functionalize(f)(torch.randn(3, device=device))
+            self.assertFalse(flag_inside[0])
+            self.assertTrue(torch.is_inference_mode_enabled())
+
+    def test_inference_mode_vmap_output_not_inference_tensor(self, device):
+        # Tensors created inside vmap under inference_mode should NOT be
+        # inference tensors. Without this, the output can't later be used
+        # with autograd (requires_grad_ raises RuntimeError).
+        x = torch.randn(3, 4, device=device)
+        with torch.inference_mode():
+            r = vmap(lambda v: v**2)(x)
+        self.assertFalse(r.is_inference())
+        # Must be usable with autograd after exiting inference_mode
+        r.requires_grad_(True)
+        r.sum().backward()
+        self.assertEqual(r.grad, torch.ones_like(r))
+
+    def test_inference_mode_functionalize_output_not_inference_tensor(self, device):
+        # Same for functionalize: output must not be an inference tensor.
+        x = torch.randn(4, device=device)
+        with torch.inference_mode():
+            r = torch.func.functionalize(lambda v: v**2)(x)
+        self.assertFalse(r.is_inference())
+        r.requires_grad_(True)
+        r.sum().backward()
+        self.assertEqual(r.grad, torch.ones_like(r))
+
+    def test_inference_mode_jvp_restored(self, device):
+        # inference_mode flag must be saved/restored across jvp
+        with torch.inference_mode():
+            self.assertTrue(torch.is_inference_mode_enabled())
+            _, y = jvp(
+                lambda x: (x**2).sum(),
+                (torch.randn(3, device=device),),
+                (torch.ones(3, device=device),),
+            )
+            self.assertTrue(torch.is_inference_mode_enabled())
+        self.assertFalse(torch.is_inference_mode_enabled())
+
+    def test_inference_mode_restored_after_exception(self, device):
+        # If a transform body raises, inference_mode must still be restored
+        # (Python context managers use try/finally to guarantee the pop).
+        def raises(x):
+            raise RuntimeError("intentional error")
+
+        with torch.inference_mode():
+            with self.assertRaisesRegex(RuntimeError, "intentional error"):
+                vmap(raises)(torch.randn(5, 3, device=device))
+            self.assertTrue(torch.is_inference_mode_enabled())
+
+        with torch.inference_mode():
+            with self.assertRaisesRegex(RuntimeError, "intentional error"):
+                torch.func.functionalize(raises)(torch.randn(3, device=device))
+            self.assertTrue(torch.is_inference_mode_enabled())
+
+        with torch.inference_mode():
+            with self.assertRaisesRegex(RuntimeError, "intentional error"):
+                grad(lambda x: raises(x))(torch.randn(3, device=device))
+            self.assertTrue(torch.is_inference_mode_enabled())
+
+        with torch.inference_mode():
+            with self.assertRaisesRegex(RuntimeError, "intentional error"):
+                jvp(
+                    raises,
+                    (torch.randn(3, device=device),),
+                    (torch.ones(3, device=device),),
+                )
+            self.assertTrue(torch.is_inference_mode_enabled())
+
+    def test_inference_mode_nested_transforms(self, device):
+        # Each transform independently saves/restores inference_mode.
+        # Verify the restore chain works when multiple layers are stacked.
+        x = torch.randn(3, 4, device=device)
+        with torch.inference_mode():
+            # vmap(grad(f)) — grad restores first, then vmap
+            def f(x):
+                return (x**2).sum()
+
+            r = vmap(grad(f))(x)
+            self.assertTrue(torch.is_inference_mode_enabled())
+        self.assertFalse(r.is_inference())
+
+        with torch.inference_mode():
+            # functionalize(vmap(f))
+            r = torch.func.functionalize(vmap(lambda v: v**2))(x)
+            self.assertTrue(torch.is_inference_mode_enabled())
+        self.assertFalse(r.is_inference())
+
+    def test_inference_mode_noop_when_disabled(self, device):
+        # When inference_mode is already off, the save/restore must not
+        # accidentally flip it on.
+        self.assertFalse(torch.is_inference_mode_enabled())
+        vmap(lambda x: x**2)(torch.randn(5, 3, device=device))
+        self.assertFalse(torch.is_inference_mode_enabled())
+
+        torch.func.functionalize(lambda x: x**2)(torch.randn(3, device=device))
+        self.assertFalse(torch.is_inference_mode_enabled())
+
+        grad(lambda x: (x**2).sum())(torch.randn(3, device=device))
+        self.assertFalse(torch.is_inference_mode_enabled())
+
+        jvp(
+            lambda x: (x**2).sum(),
+            (torch.randn(3, device=device),),
+            (torch.ones(3, device=device),),
+        )
+        self.assertFalse(torch.is_inference_mode_enabled())
+
+    def test_inference_mode_preserves_grad_mode(self, device):
+        # The fix uses AutogradState::set_inference_mode directly (not the
+        # InferenceMode RAII guard) to avoid clobbering grad_mode. Verify
+        # that grad_mode survives the transform boundary.
+        grad_mode_inside = []
+
+        def check_grad_mode(x):
+            grad_mode_inside.append(torch.is_grad_enabled())
+            return x**2
+
+        with torch.inference_mode():
+            # grad_mode is off under inference_mode by default
+            torch.set_grad_enabled(True)
+            vmap(check_grad_mode)(torch.randn(5, 3, device=device))
+            self.assertTrue(torch.is_grad_enabled())
+            torch.set_grad_enabled(False)
+
+        # Also check functionalize
+        grad_mode_inside.clear()
+        with torch.inference_mode():
+            torch.set_grad_enabled(True)
+            torch.func.functionalize(check_grad_mode)(torch.randn(3, device=device))
+            self.assertTrue(torch.is_grad_enabled())
+            torch.set_grad_enabled(False)
+
 
 @markDynamoStrictTest
 class TestAutogradFunction(TestCase):

--- a/test/functorch/test_eager_transforms.py
+++ b/test/functorch/test_eager_transforms.py
@@ -1399,6 +1399,7 @@ class TestGradTransform(TestCase):
         )
         self.assertFalse(torch.is_inference_mode_enabled())
 
+    @skipIfTorchDynamo("tests C++ TLS state preservation")
     def test_inference_mode_preserves_grad_mode(self, device):
         # The fix uses AutogradState::set_inference_mode directly (not the
         # InferenceMode RAII guard) to avoid clobbering grad_mode. Verify

--- a/torch/csrc/functorch/init.cpp
+++ b/torch/csrc/functorch/init.cpp
@@ -247,36 +247,13 @@ static RandomnessType get_randomness_enum(const std::string& randomness) {
 static int64_t _grad_increment_nesting() {
   // See NOTE [grad and vjp interaction with no_grad]
   bool prev_grad_mode = c10::GradMode::is_enabled();
-  // When inference_mode is on, new tensors lack autograd dispatch keys
-  // (TensorImpl strips them in its constructor). Toggle the flag off so
-  // tensors created inside the transform can participate in autograd.
-  // Uses AutogradState::set_inference_mode — not the InferenceMode RAII
-  // guard, which would clobber grad_mode and fw_grad_mode.
-  bool prev_inference_mode = c10::InferenceMode::is_enabled();
-  if (prev_inference_mode) {
-    auto state = c10::AutogradState::get_tls_state();
-    state.set_inference_mode(false);
-    c10::AutogradState::set_tls_state(state);
-  }
   return initAndPushDynamicLayer(
-      TransformType::Grad,
-      std::nullopt,
-      std::nullopt,
-      prev_grad_mode,
-      std::nullopt,
-      std::nullopt,
-      prev_inference_mode);
+      TransformType::Grad, std::nullopt, std::nullopt, prev_grad_mode);
 }
 
 static int64_t _grad_decrement_nesting() {
   auto layer = popDynamicLayerAndDeleteMetadata();
   TORCH_INTERNAL_ASSERT(layer.key() == TransformType::Grad);
-  auto& meta = std::get<GradInterpreterMeta>(layer.interpreter().meta());
-  if (meta.prevInferenceMode_) {
-    auto state = c10::AutogradState::get_tls_state();
-    state.set_inference_mode(true);
-    c10::AutogradState::set_tls_state(state);
-  }
   return layer.layerId();
 }
 
@@ -284,31 +261,17 @@ static int64_t _jvp_increment_nesting() {
   // See NOTE [grad and vjp interaction with no_grad]
   bool prev_fwd_grad_mode =
       c10::AutogradState::get_tls_state().get_fw_grad_mode();
-  bool prev_inference_mode = c10::InferenceMode::is_enabled();
-  if (prev_inference_mode) {
-    auto state = c10::AutogradState::get_tls_state();
-    state.set_inference_mode(false);
-    c10::AutogradState::set_tls_state(state);
-  }
   return initAndPushDynamicLayer(
       TransformType::Jvp,
       std::nullopt,
       std::nullopt,
       std::nullopt,
-      prev_fwd_grad_mode,
-      std::nullopt,
-      prev_inference_mode);
+      prev_fwd_grad_mode);
 }
 
 static int64_t _jvp_decrement_nesting() {
   auto layer = popDynamicLayerAndDeleteMetadata();
   TORCH_INTERNAL_ASSERT(layer.key() == TransformType::Jvp);
-  auto& meta = std::get<JvpInterpreterMeta>(layer.interpreter().meta());
-  if (meta.prevInferenceMode_) {
-    auto state = c10::AutogradState::get_tls_state();
-    state.set_inference_mode(true);
-    c10::AutogradState::set_tls_state(state);
-  }
   return layer.layerId();
 }
 
@@ -455,31 +418,9 @@ namespace {
 
 // Pop the DynamicLayer stack until it's at the given depth.
 // Used by Dynamo for error-recovery cleanup of the transform stack.
-//
-// NB: we peek at .back() to determine the type, then call the
-// type-specific decrement helper which does the actual pop.
-// Do NOT pop before the switch — the helpers call
-// popDynamicLayerAndDeleteMetadata() internally.
 void popDynamicLayerStackToDepth(size_t depth) {
   while (at::functorch::getDynamicLayerStack().size() > depth) {
-    const auto& top = at::functorch::getDynamicLayerStack().back();
-    switch (top.key()) {
-      case at::functorch::TransformType::Vmap:
-        _vmap_decrement_nesting();
-        break;
-      case at::functorch::TransformType::Grad:
-        _grad_decrement_nesting();
-        break;
-      case at::functorch::TransformType::Jvp:
-        _jvp_decrement_nesting();
-        break;
-      case at::functorch::TransformType::Functionalize:
-        _func_decrement_nesting();
-        break;
-      case at::functorch::TransformType::Torch:
-        popDynamicLayerAndDeleteMetadata();
-        break;
-    }
+    popDynamicLayerAndDeleteMetadata();
   }
 }
 


### PR DESCRIPTION
Fixes #177750

This PR completes the inference_mode handling for the functorch transforms begun in #177596. cc @aorenste 

Under `torch.inference_mode()`, vmap and functionalize outputs became permanently marked as inference tensors because these transforms didn't save/restore the inference_mode flag. #177596 fixed this for grad/vjp/jvp per-transform in init.cpp; this PR extends the fix to all transforms by centralizing the save/restore in `initAndPushDynamicLayer` and `popDynamicLayerAndDeleteMetadata`.

`prevInferenceMode_` moves from `GradInterpreterMeta` and `JvpInterpreterMeta` to `Interpreter` itself — it applies identically to all transform types (vmap, grad/vjp, jvp, functionalize). The four decrement functions in init.cpp become identical pop+assert, so `popDynamicLayerStackToDepth`'s type-dispatching switch is replaced with a direct loop.
