### PR TITLE
[regional_inductor] Revert to CapabilityBasedPartitioner with per-region partitioning

### DIFF
--- a/test/dynamo/test_regional_inductor.py
+++ b/test/dynamo/test_regional_inductor.py
@@ -1528,8 +1528,9 @@ class TestRegionalOutputCode(torch._inductor.test_case.TestCase):
 class RegionalInductorPartitionTests(torch._inductor.test_case.TestCase):
     """Tests for _RegionScooper partitioning behavior.
 
-    Ensures that non-contiguous annotated regions are NOT horizontally fused
-    into a single compiled partition.
+    Uses CapabilityBasedPartitioner per region ID. Nodes with the same region ID
+    are merged as aggressively as possible (only cycles prevent merging). Nodes
+    with different region IDs are never merged.
     """
 
     def _make_tag_node(self, g, inp, scalar, tagged):
@@ -1587,11 +1588,9 @@ class RegionalInductorPartitionTests(torch._inductor.test_case.TestCase):
         gm = torch.fx.GraphModule(torch.nn.Module(), g)
         self.assertEqual(self._scoop_and_count(gm), 1)
 
-    def test_parallel_branches_with_gap_not_fused(self):
-        """Two independent tagged nodes separated by an untagged node in
-        topological order must produce 2 partitions, not be horizontally fused.
-
-        The old CapabilityBasedPartitioner would fuse these into 1 partition.
+    def test_parallel_branches_with_gap_same_region(self):
+        """Two independent tagged nodes separated by an untagged node but
+        sharing the same region ID are fused into 1 partition (no cycle).
         """
         g = torch.fx.Graph()
         x = g.placeholder("x")
@@ -1603,13 +1602,29 @@ class RegionalInductorPartitionTests(torch._inductor.test_case.TestCase):
         out.meta["val"] = torch.empty(10)
         g.output(out)
         gm = torch.fx.GraphModule(torch.nn.Module(), g)
+        self.assertEqual(self._scoop_and_count(gm), 1)
+
+    def test_parallel_branches_with_gap_different_regions(self):
+        """Two independent tagged nodes with different region IDs produce
+        2 separate partitions regardless of graph topology.
+        """
+        g = torch.fx.Graph()
+        x = g.placeholder("x")
+        mul_a = self._make_tag_node(g, x, 2.0, tagged=True)
+        mul_a.meta["custom"] = {"compile_with_inductor": {"inductor_region": 0}}
+        sin = g.call_function(torch.ops.aten.sin.default, (x,))
+        sin.meta["val"] = torch.empty(10)
+        mul_b = self._make_tag_node(g, x, 3.0, tagged=True)
+        mul_b.meta["custom"] = {"compile_with_inductor": {"inductor_region": 1}}
+        out = g.call_function(torch.ops.aten.add.Tensor, (mul_a, mul_b))
+        out.meta["val"] = torch.empty(10)
+        g.output(out)
+        gm = torch.fx.GraphModule(torch.nn.Module(), g)
         self.assertEqual(self._scoop_and_count(gm), 2)
 
     def test_dependent_partitions_merged_across_gap(self):
-        """Two tagged runs separated by an untagged node but connected by a
-        data dependency should be merged into 1 partition.
-
-        tagged(x) -> untagged -> tagged(tagged_result) => 1 partition
+        """Two tagged nodes (same region) separated by an untagged node and
+        connected by a data dependency are merged into 1 partition.
         """
         g = torch.fx.Graph()
         x = g.placeholder("x")
@@ -1623,27 +1638,24 @@ class RegionalInductorPartitionTests(torch._inductor.test_case.TestCase):
         self.assertEqual(self._scoop_and_count(gm), 1)
 
     def test_different_annotations_not_merged(self):
-        """Two tagged runs with different annotations should NOT be merged,
+        """Two tagged nodes with different region IDs are NOT merged,
         even if connected by a data dependency.
         """
         g = torch.fx.Graph()
         x = g.placeholder("x")
         mul_a = self._make_tag_node(g, x, 2.0, tagged=True)
-        # Override annotation to use a different ID
-        mul_a.meta["custom"] = {"compile_with_inductor": 0}
+        mul_a.meta["custom"] = {"compile_with_inductor": {"inductor_region": 0}}
         sin = g.call_function(torch.ops.aten.sin.default, (x,))
         sin.meta["val"] = torch.empty(10)
         mul_b = self._make_tag_node(g, mul_a, 3.0, tagged=True)
-        mul_b.meta["custom"] = {"compile_with_inductor": 1}
+        mul_b.meta["custom"] = {"compile_with_inductor": {"inductor_region": 1}}
         g.output(mul_b)
         gm = torch.fx.GraphModule(torch.nn.Module(), g)
         self.assertEqual(self._scoop_and_count(gm), 2)
 
     def test_chained_merges_across_multiple_gaps(self):
-        """Multiple tagged runs with the same annotation and chained data
-        dependencies should all merge into 1 partition.
-
-        tagged_a(x) -> untagged(x) -> tagged_b(tagged_a) -> untagged(x) -> tagged_c(tagged_b) => 1
+        """Multiple tagged nodes (same region) with chained data dependencies
+        across untagged gaps are all merged into 1 partition.
         """
         g = torch.fx.Graph()
         x = g.placeholder("x")

--- a/torch/fx/passes/regional_inductor.py
+++ b/torch/fx/passes/regional_inductor.py
@@ -23,36 +23,6 @@ def _dummy_wrapper(fn):
     return inner
 
 
-def _merge_connected_partitions(
-    partitions: list[dict[torch.fx.Node, int | None]],
-) -> list[dict[torch.fx.Node, int | None]]:
-    """Merge adjacent partitions with the same annotation connected by data dependencies."""
-    if len(partitions) <= 1:
-        return partitions
-
-    def _depends_on(part, prev_nodes):
-        for node in part:
-            for inp in node.all_input_nodes:
-                if inp in prev_nodes:
-                    return True
-        return False
-
-    def _get_partition_annotation(part):
-        node = next(iter(part))
-        return node.meta["custom"]["compile_with_inductor"]
-
-    merged = [partitions[0]]
-    for part in partitions[1:]:
-        current_annotation = _get_partition_annotation(part)
-        prev_annotation = _get_partition_annotation(merged[-1])
-        prev_nodes = set(merged[-1].keys())
-        if current_annotation == prev_annotation and _depends_on(part, prev_nodes):
-            merged[-1].update(part)
-        else:
-            merged.append(part)
-    return merged
-
-
 def _compile_submod(gm, prefix):
     from torch._inductor.standalone_compile import AOTCompiledArtifact
 
@@ -145,31 +115,51 @@ class _RegionScooper:
 
     @staticmethod
     def scoop_regions(gm):
+        from torch.fx.passes.infra.partitioner import CapabilityBasedPartitioner
+        from torch.fx.passes.operator_support import create_op_support
         from torch.fx.passes.utils.fuser_utils import fuse_by_partitions
 
-        # Collect contiguous runs of marked nodes (no horizontal fusion).
-        # Each partition maps nodes to None (no partition-id needed).
-        partitions: list[dict[torch.fx.Node, int | None]] = []
-        current_run: dict[torch.fx.Node, int | None] = {}
+        # Group tagged nodes by region ID.  The region ID comes from the
+        # optional "inductor_region" key inside the compile_with_inductor
+        # annotation. When absent, all tagged nodes share a single default region
+        _DEFAULT_REGION = object()
+        regions: dict[object, set[torch.fx.Node]] = {}
         for node in gm.graph.nodes:
             if _needs_inductor_compile(node):
-                current_run[node] = None
-            else:
-                if current_run:
-                    partitions.append(current_run)
-                    current_run = {}
-        if current_run:
-            partitions.append(current_run)
+                compile_value = node.meta["custom"]["compile_with_inductor"]
+                if (
+                    isinstance(compile_value, dict)
+                    and "inductor_region" in compile_value
+                ):
+                    rid = compile_value["inductor_region"]
+                else:
+                    rid = _DEFAULT_REGION
+                regions.setdefault(rid, set()).add(node)
 
-        if not partitions:
+        if not regions:
             logger.info("No inductor marked nodes found")
             return gm
 
-        partitions = _merge_connected_partitions(partitions)
+        # Run CapabilityBasedPartitioner per region to get cycle-safe partitions
+        # without merging across region boundaries.
+        def _is_in_region(region_nodes):
+            def is_node_supported(_submodules, node):
+                return node in region_nodes
+
+            return is_node_supported
+
+        all_partitions: list[dict[torch.fx.Node, int | None]] = []
+        for region_nodes in regions.values():
+            support = create_op_support(_is_in_region(region_nodes))
+            partitioner = CapabilityBasedPartitioner(
+                gm, support, allows_single_node_partition=True
+            )
+            for partition in partitioner.propose_partitions():
+                all_partitions.append(partition.nodes)
 
         return fuse_by_partitions(
             gm,
-            partitions,
+            all_partitions,
             prefix="__marked_inductor_submod",
             always_return_tuple=True,
         )


### PR DESCRIPTION
This PR reverts the regional inductor partitioner back to using `CapabilityBasedPartitioner` and introduces an explicit `"inductor_region"` field for controlling partition boundaries.

PR #178421 replaced `CapabilityBasedPartitioner` with contiguous-run partitioning to prevent incorrect horizontal fusion of non-contiguous annotated regions. PR #178690 then added `_merge_connected_partitions` to re-merge partitions connected by data dependencies, since contiguous-run splitting broke flex attention's get_attr + backward pattern in torchtitan. 

The contiguous-run approach was fragile, as it relied on iterating graph nodes to collect contiguous runs. However, nodes in annotated regions could be moved and inserted with new nodes when SAC or bucketing/reordering are applied.

In this PR, we go back to using `CapabilityBasedPartitioner` directly but scope it per region ID. A new optional `"inductor_region"` key in the `compile_with_inductor` annotation lets users explicitly mark nodes that should not be fused together. Within a single region, `CapabilityBasedPartitioner` merges as aggressively as possible (only cycles prevent merging). Across different region IDs, partitions are never merged.


Test Plan:

pytorch unittest: `RegionalInductorPartitionTests`

torchtitan CI:
```
NGPU=8 MODULE=graph_trainer.llama3 CONFIG=graph_trainer_llama3_debugmodel_flex_attn ./run_train.sh --parallelism.data_parallel_shard_degree=4 --parallelism.tensor_parallel_degree=2 --compile.passes auto_bucketing,regional_inductor
```
cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98