### PR TITLE
[dont review][dynamo] Unify UserDefined{Dict,Set,List,Tuple}Variable into UDOV via base_vt

### DIFF
--- a/test/dynamo/test_comptime.py
+++ b/test/dynamo/test_comptime.py
@@ -63,7 +63,7 @@ FakeTensor(..., size=(s77,))
 {'foo': FakeTensor(..., size=(s77,))}
 range(1, 3)
 Employee(name='foo', id=2)
-UserDefinedListVariable(mylist)
+UserDefinedObjectVariable(mylist)
 set()
 {'a','b'}
 s77""",

--- a/test/dynamo/test_user_defined_object.py
+++ b/test/dynamo/test_user_defined_object.py
@@ -691,5 +691,80 @@ class TestUserDefinedClassDict(TestCase):
         self.assertEqual(cnt.frame_count, 2)
 
 
+class TestStrSubclass(TestCase):
+    def test_str_subclass_basic(self):
+        class MyStr(str):
+            pass
+
+        @torch.compile(backend="eager", fullgraph=True)
+        def fn(x):
+            s = MyStr("hello")
+            return x + len(s)
+
+        self.assertEqual(fn(torch.tensor(1.0)), torch.tensor(6.0))
+
+    def test_str_subclass_method_delegation(self):
+        class MyStr(str):
+            pass
+
+        @torch.compile(backend="eager", fullgraph=True)
+        def fn(x):
+            s = MyStr("hello")
+            return x + len(s.upper())
+
+        self.assertEqual(fn(torch.tensor(1.0)), torch.tensor(6.0))
+
+    def test_str_subclass_custom_method(self):
+        class MyStr(str):
+            def shout(self):
+                return self.upper() + "!"
+
+        @torch.compile(backend="eager", fullgraph=True)
+        def fn(x):
+            s = MyStr("hello")
+            return x + len(s.shout())
+
+        # "HELLO!" = 6 chars
+        self.assertEqual(fn(torch.tensor(1.0)), torch.tensor(7.0))
+
+    def test_str_subclass_as_input(self):
+        class MyStr(str):
+            pass
+
+        @torch.compile(backend="eager", fullgraph=True)
+        def fn(x, s):
+            return x + len(s)
+
+        s = MyStr("world")
+        self.assertEqual(fn(torch.tensor(1.0), s), torch.tensor(6.0))
+
+    def test_str_subclass_multi_level_inheritance(self):
+        class MyStr(str):
+            pass
+
+        class MyStr2(MyStr):
+            pass
+
+        @torch.compile(backend="eager", fullgraph=True)
+        def fn(x):
+            s = MyStr2("test")
+            return x + len(s)
+
+        self.assertEqual(fn(torch.tensor(1.0)), torch.tensor(5.0))
+
+    def test_str_subclass_as_dict_key(self):
+        class MyStr(str):
+            pass
+
+        @torch.compile(backend="eager", fullgraph=True)
+        def fn(x):
+            s1 = MyStr("key")
+            d = {s1: 42}
+            s2 = MyStr("key")
+            return x + d[s2]
+
+        self.assertEqual(fn(torch.tensor(1.0)), torch.tensor(43.0))
+
+
 if __name__ == "__main__":
     run_tests()

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -173,7 +173,8 @@ from .variables.tensor import (
     UnspecializedPythonVariable,
 )
 from .variables.torch_function import TensorWithTFOverrideVariable
-from .variables.user_defined import UserDefinedDictVariable
+from .variables.dicts import ConstDictVariable
+from .variables.user_defined import UserDefinedObjectVariable
 
 
 if TYPE_CHECKING:
@@ -2184,10 +2185,12 @@ class OutputGraph(OutputGraphCommon):
                     if isinstance(
                         mut_type, (AttributeMutationExisting, ValueMutationExisting)
                     ):
-                        if isinstance(var, UserDefinedDictVariable) and isinstance(
-                            var.value, _ExportModuleSpecTrackerDict
+                        if (
+                            isinstance(var, UserDefinedObjectVariable)
+                            and isinstance(var.base_vt, ConstDictVariable)
+                            and isinstance(var.value, _ExportModuleSpecTrackerDict)
                         ):
-                            for k, v in var.items.items():
+                            for k, v in var.base_vt.items.items():
                                 # pyrefly: ignore [implicit-any]
                                 specs = {}
                                 # pyrefly: ignore[missing-attribute]
@@ -2203,7 +2206,8 @@ class OutputGraph(OutputGraphCommon):
                         # export uses tracepoint pass to dump submodule inp/out spec
                         # into global state, so we filter it here
                         if not (
-                            isinstance(var, UserDefinedDictVariable)
+                            isinstance(var, UserDefinedObjectVariable)
+                            and isinstance(var.base_vt, ConstDictVariable)
                             and isinstance(var.value, _ExportModuleSpecTrackerDict)
                         ):
                             potential_side_effects.append(var)

--- a/torch/_dynamo/side_effects.py
+++ b/torch/_dynamo/side_effects.py
@@ -525,14 +525,8 @@ class SideEffects:
             variable_cls = GenericContextWrappingVariable
         elif issubclass(user_cls, torch.nn.Module):
             variable_cls = variables.UnspecializedNNModuleVariable
-        elif issubclass(user_cls, (dict, collections.OrderedDict)):
-            variable_cls = variables.UserDefinedDictVariable
-        elif issubclass(user_cls, (set, frozenset)):
-            variable_cls = variables.UserDefinedSetVariable
-        elif issubclass(user_cls, tuple):
-            variable_cls = variables.UserDefinedTupleVariable
-        elif issubclass(user_cls, list):
-            variable_cls = variables.UserDefinedListVariable
+        elif self._find_solid_base(user_cls) is not None:
+            variable_cls = variables.UserDefinedObjectVariable
         elif issubclass(user_cls, MutableMapping):
             variable_cls = variables.MutableMappingVariable
         elif is_frozen_dataclass(user_cls):
@@ -577,6 +571,63 @@ class SideEffects:
             obj = base_cls.__new__(user_cls)
         return obj
 
+    @staticmethod
+    def _find_solid_base(user_cls: type) -> type | None:
+        """Walk __base__ (tp_base) to find the builtin type that provides data layout.
+
+        Like CPython's solid_base(), walks the single-inheritance chain until
+        finding a builtin type with its own C data layout (dict, list, set, etc.).
+        Returns None if the solid base is object (no special data layout).
+        """
+        # Known builtin types that have their own data layout (tp_basicsize
+        # differs from object). Add new entries here to support more types.
+        _SOLID_BASES: set[type] = {dict, collections.OrderedDict, set, frozenset, list, tuple, str}
+        base = user_cls
+        while base is not object:
+            if base in _SOLID_BASES:
+                return base
+            base = base.__base__  # type: ignore[assignment]
+        return None
+
+    @staticmethod
+    def _make_sourceless_base_vt(
+        user_cls: type,
+        obj: object,
+        init_args: list[VariableTracker],
+    ) -> VariableTracker | None:
+        """Create a sourceless base_vt for a given solid base type."""
+        from .variables.dicts import ConstDictVariable
+        from .variables.lists import ListVariable, TupleVariable
+
+        solid_base = SideEffects._find_solid_base(user_cls)
+        if solid_base is None:
+            return None
+        if solid_base in (dict, collections.OrderedDict):
+            return ConstDictVariable({}, type(obj), mutation_type=ValueMutationNew())
+        if solid_base is set:
+            return variables.SetVariable(set(), mutation_type=ValueMutationNew())
+        if solid_base is frozenset:
+            # frozenset sourceless case uses SourcelessBuilder at init time
+            return None
+        if solid_base is list:
+            return ListVariable([], mutation_type=ValueMutationNew())
+        if solid_base is tuple:
+            if init_args:
+                from torch._dynamo.symbolic_convert import InstructionTranslator
+
+                tx = InstructionTranslator.current_tx()
+                elems = init_args[0].force_unpack_var_sequence(tx)
+                return TupleVariable(elems, mutation_type=ValueMutationNew())
+            return TupleVariable([], mutation_type=ValueMutationNew())
+        if solid_base is str:
+            # str is immutable — value is set at __new__ time via init_args
+            from .variables.constant import ConstantVariable
+
+            if init_args and init_args[0].is_python_constant():
+                return ConstantVariable.create(str(init_args[0].as_python_constant()))
+            return ConstantVariable.create("")
+        return None
+
     def track_new_user_defined_object(
         self,
         base_cls_vt: VariableTracker,
@@ -596,12 +647,21 @@ class SideEffects:
         variable_cls = self.get_variable_cls(user_cls)
         obj = self.get_example_value(base_cls_vt, cls_vt, init_args)
 
+        # Walk __base__ (CPython's tp_base) to find the "solid base" — the
+        # first builtin type with its own data layout. Create a base_vt to
+        # track that type's data.
+        base_vt = self._make_sourceless_base_vt(user_cls, obj, init_args)
+        base_vt_kwargs: dict[str, Any] = {}
+        if base_vt is not None:
+            base_vt_kwargs["base_vt"] = base_vt
+
         variable = variable_cls(
             obj,
             cls_source=cls_vt.source,
             base_cls_vt=base_cls_vt,
             init_args=init_args,
             mutation_type=AttributeMutationNew(cls_source),
+            **base_vt_kwargs,
         )
         self.id_to_variable[id(obj)] = variable
         self.keepalive.append(obj)
@@ -1186,10 +1246,11 @@ class SideEffects:
                     # These frozen attribute initializations are handled in codegen_save_tempvars
                     # and don't need to be reset in the suffix.
                     continue
-                elif isinstance(
-                    var,
-                    variables.UserDefinedDictVariable,
-                ) and self.is_modified(var._dict_vt):
+                elif (
+                    isinstance(var, variables.UserDefinedObjectVariable)
+                    and isinstance(var.base_vt, variables.ConstDictVariable)
+                    and self.is_modified(var.base_vt)
+                ):
                     # Do dict related update manually here. The store_attr
                     # mutations will be applied later.
                     varname_map = {}
@@ -1221,7 +1282,7 @@ class SideEffects:
                         ]
                     )
 
-                    cg(var._dict_vt, allow_cache=False)  # Don't codegen via source
+                    cg(var.base_vt, allow_cache=False)  # Don't codegen via source
                     cg.extend_output(
                         [
                             create_instruction(
@@ -1240,12 +1301,13 @@ class SideEffects:
                             create_instruction("POP_TOP"),
                         ]
                     )
-                    _maybe_log_side_effect(var._dict_vt)
-                elif isinstance(
-                    var,
-                    variables.UserDefinedListVariable,
-                ) and self.is_modified(var._list_vt):
-                    if not _codegen_direct_list_replay(var._list_vt, var.source):
+                    _maybe_log_side_effect(var.base_vt)
+                elif (
+                    isinstance(var, variables.UserDefinedObjectVariable)
+                    and isinstance(var.base_vt, variables.ListVariable)
+                    and self.is_modified(var.base_vt)
+                ):
+                    if not _codegen_direct_list_replay(var.base_vt, var.source):
                         # Update the list to the updated items. Be careful in
                         # calling the list methods and not the overridden methods.
                         varname_map = {}
@@ -1261,7 +1323,7 @@ class SideEffects:
                             ]
                         )
 
-                        cg(var._list_vt, allow_cache=False)  # Don't codegen via source
+                        cg(var.base_vt, allow_cache=False)  # Don't codegen via source
                         cg.extend_output(
                             [
                                 create_instruction(
@@ -1280,7 +1342,7 @@ class SideEffects:
                                 create_instruction("POP_TOP"),
                             ]
                         )
-                        _maybe_log_side_effect(var._list_vt)
+                        _maybe_log_side_effect(var.base_vt)
 
                 # Applying mutations involves two steps: 1) Push all
                 # reconstructed objects onto the stack.  2) Call STORE_ATTR to

--- a/torch/_dynamo/variables/__init__.py
+++ b/torch/_dynamo/variables/__init__.py
@@ -173,13 +173,9 @@ from .user_defined import (
     MutableMappingVariable,
     RemovableHandleVariable,
     UserDefinedClassVariable,
-    UserDefinedDictVariable,
     UserDefinedExceptionClassVariable,
     UserDefinedExceptionObjectVariable,
-    UserDefinedListVariable,
     UserDefinedObjectVariable,
-    UserDefinedSetVariable,
-    UserDefinedTupleVariable,
     UserDefinedVariable,
 )
 
@@ -255,7 +251,6 @@ __all__ = [
     "UnspecializedPythonVariable",
     "UntypedStorageVariable",
     "UserDefinedClassVariable",
-    "UserDefinedTupleVariable",
     "UserDefinedObjectVariable",
     "UserFunctionVariable",
     "UserMethodVariable",

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -299,13 +299,9 @@ from .user_defined import (
     MutableMappingVariable,
     SourcelessGraphModuleVariable,
     UserDefinedClassVariable,
-    UserDefinedDictVariable,
     UserDefinedEnumClassVariable,
     UserDefinedExceptionClassVariable,
-    UserDefinedListVariable,
     UserDefinedObjectVariable,
-    UserDefinedSetVariable,
-    UserDefinedTupleVariable,
 )
 
 
@@ -1659,7 +1655,7 @@ class VariableBuilder:
             isinstance(value, (dict, collections.OrderedDict))
             and type(value).__new__ is dict.__new__
         ):
-            # Construct a dict_vt that will reside inside the UserDefinedDictVariable
+            # Construct a dict_vt that will reside inside UserDefinedObjectVariable as base_vt
             self.install_guards(GuardBuilder.TYPE_MATCH)
             self.install_guards(GuardBuilder.SEQUENCE_LENGTH)
 
@@ -1703,7 +1699,7 @@ class VariableBuilder:
             # bytecode simple
             dict_vt.should_reconstruct_all = True
 
-            result = UserDefinedDictVariable(value, dict_vt=dict_vt, source=self.source)
+            result = UserDefinedObjectVariable(value, base_vt=dict_vt, source=self.source)
             return self.tx.output.side_effects.track_object_existing(value, result)
         elif isinstance(value, tuple):
             self.install_guards(GuardBuilder.TYPE_MATCH)
@@ -1724,8 +1720,8 @@ class VariableBuilder:
                 source=self.source,
                 mutation_type=ValueMutationExisting(),
             )
-            result = UserDefinedTupleVariable(
-                value, tuple_vt=tuple_vt, source=self.source
+            result = UserDefinedObjectVariable(
+                value, base_vt=tuple_vt, source=self.source
             )
             return self.tx.output.side_effects.track_object_existing(value, result)
         elif isinstance(value, list):
@@ -1746,7 +1742,7 @@ class VariableBuilder:
                 source=self.source,
                 mutation_type=ValueMutationExisting(),
             )
-            result = UserDefinedListVariable(value, list_vt=list_vt, source=self.source)
+            result = UserDefinedObjectVariable(value, base_vt=list_vt, source=self.source)
             return self.tx.output.side_effects.track_object_existing(value, result)
         elif isinstance(value, (set, frozenset)):
             self.install_guards(GuardBuilder.TYPE_MATCH)
@@ -1769,7 +1765,14 @@ class VariableBuilder:
             set_vt = set_vt_cls(
                 output, source=self.source, mutation_type=ValueMutationExisting()
             )
-            result = UserDefinedSetVariable(value, set_vt=set_vt, source=self.source)
+            result = UserDefinedObjectVariable(value, base_vt=set_vt, source=self.source)
+            return self.tx.output.side_effects.track_object_existing(value, result)
+        elif isinstance(value, str):
+            self.install_guards(GuardBuilder.EQUALS_MATCH)
+            str_vt = ConstantVariable.create(
+                str(value), source=self.source
+            )
+            result = UserDefinedObjectVariable(value, base_vt=str_vt, source=self.source)
             return self.tx.output.side_effects.track_object_existing(value, result)
         elif issubclass(type(value), MutableMapping):
             self.install_guards(GuardBuilder.TYPE_MATCH)

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -124,7 +124,6 @@ from .tensor import (
 )
 from .user_defined import (
     MutableMappingVariable,
-    UserDefinedDictVariable,
     UserDefinedObjectVariable,
     UserDefinedVariable,
 )
@@ -1516,6 +1515,26 @@ class BuiltinVariable(BaseBuiltinVariable):
                     args[1:],
                 )
 
+            if self.fn is set:
+                set_vt = variables.SetVariable(set(), mutation_type=ValueMutationNew())
+                if len(args) == 1 and isinstance(args[0], BuiltinVariable) and args[0].fn is set:
+                    return set_vt
+                if len(args) >= 1:
+                    return tx.output.side_effects.track_new_user_defined_object(
+                        self,
+                        args[0],
+                        args[1:],
+                    )
+
+            if self.fn is str and len(args) >= 1:
+                if len(args) == 1 and isinstance(args[0], BuiltinVariable) and args[0].fn is str:
+                    return ConstantVariable.create("")
+                return tx.output.side_effects.track_new_user_defined_object(
+                    self,
+                    args[0],
+                    args[1:],
+                )
+
         if name in _BUILTIN_CONSTANT_FOLDABLE_METHODS.get(self.fn, ()):
             if all(a.is_python_constant() for a in args) and all(
                 v.is_python_constant() for v in kwargs.values()
@@ -1541,8 +1560,11 @@ class BuiltinVariable(BaseBuiltinVariable):
         if self.fn is set:
             resolved_fn = getattr(self.fn, name)
             if resolved_fn in set_methods:
-                if isinstance(args[0], variables.UserDefinedSetVariable):
-                    return args[0]._set_vt.call_method(tx, name, args[1:], kwargs)
+                if (
+                    isinstance(args[0], variables.UserDefinedObjectVariable)
+                    and isinstance(args[0].base_vt, variables.SetVariable)
+                ):
+                    return args[0].base_vt.call_method(tx, name, args[1:], kwargs)
                 elif isinstance(args[0], variables.SetVariable):
                     return args[0].call_method(tx, name, args[1:], kwargs)
 
@@ -3100,8 +3122,10 @@ class BuiltinVariable(BaseBuiltinVariable):
                 *_SET_LIKE_OP_SUPPORT,
                 ConstDictVariable,
                 MutableMappingVariable,
-                UserDefinedDictVariable,
             ),
+        ) or (
+            isinstance(a, UserDefinedObjectVariable)
+            and isinstance(a.base_vt, ConstDictVariable)
         ):
             # TODO(guilhermeleobas): forward the call to b.__ror__(a) if
             # a.__ror__(b) returns NotImplemented
@@ -3223,8 +3247,11 @@ class DictBuiltinVariable(BaseBuiltinVariable):
 
         resolved_fn = getattr(dict, name, None)
         if resolved_fn is not None and resolved_fn in dict_methods:
-            if isinstance(args[0], variables.UserDefinedDictVariable):
-                return args[0]._dict_vt.call_method(tx, name, args[1:], kwargs)
+            if (
+                isinstance(args[0], variables.UserDefinedObjectVariable)
+                and isinstance(args[0].base_vt, ConstDictVariable)
+            ):
+                return args[0].base_vt.call_method(tx, name, args[1:], kwargs)
             elif isinstance(args[0], ConstDictVariable):
                 return args[0].call_method(tx, name, args[1:], kwargs)
 

--- a/torch/_dynamo/variables/dicts.py
+++ b/torch/_dynamo/variables/dicts.py
@@ -915,9 +915,6 @@ class ConstDictVariable(VariableTracker):
             # Let's not forward the call to __ror__ yet because __ror__ can be
             # implemented in C (i.e. OrderedDict subclass) which Dynamo cannot
             # trace
-            # if istype(other, variables.UserDefinedDictVariable):
-            #     if other.call_obj_hasattr(tx, "__ror__").value:
-            #         return other.call_method(tx, "__ror__", [self], kwargs)
 
             # The three dict types Dynamo can handle are dict, OrderedDict and
             # defaultdict.
@@ -927,10 +924,20 @@ class ConstDictVariable(VariableTracker):
                 other,
                 (
                     ConstDictVariable,
-                    variables.UserDefinedDictVariable,
                     variables.DefaultDictVariable,
                 ),
+            ) or (
+                isinstance(other, variables.UserDefinedObjectVariable)
+                and isinstance(other.base_vt, ConstDictVariable)
             ):
+                # Unwrap UDOV with dict base_vt for the or operation
+                other_dict = (
+                    other.base_vt
+                    if isinstance(other, variables.UserDefinedObjectVariable)
+                    and isinstance(other.base_vt, ConstDictVariable)
+                    else other
+                )
+
                 # Always return the specialized dictionary, and in the case
                 # both are specialized, take the first to be the type of the
                 # new dictionary
@@ -938,9 +945,9 @@ class ConstDictVariable(VariableTracker):
                     user_cls = self.user_cls
                     to_cpy = self
                 else:
-                    assert isinstance(other, ConstDictVariable)
-                    user_cls = other.user_cls
-                    to_cpy = other
+                    assert isinstance(other_dict, ConstDictVariable)
+                    user_cls = other_dict.user_cls
+                    to_cpy = other_dict
 
                 to_cpy.install_dict_keys_match_guard()
                 new_dict_vt = to_cpy.clone(
@@ -952,8 +959,8 @@ class ConstDictVariable(VariableTracker):
 
                 # NB - Guard on all the keys of the other dict to ensure
                 # correctness.
-                args[0].install_dict_keys_match_guard()  # type: ignore[attr-defined]
-                new_dict_vt.items.update(args[0].items)  # type: ignore[attr-defined]
+                other_dict.install_dict_keys_match_guard()
+                new_dict_vt.items.update(other_dict.items)
                 return new_dict_vt
             else:
                 raise_observed_exception(
@@ -1235,6 +1242,16 @@ class DefaultDictVariable(ConstDictVariable):
 
 
 # TODO: Implementing this via inheritance rather than composition is a
+def _is_set_like(var: VariableTracker) -> bool:
+    """Check if var is a set-like variable (SetVariable, DictItems/Keys, or UDOV wrapping a set)."""
+    if isinstance(var, (SetVariable, FrozensetVariable, DictItemsVariable, DictKeysVariable)):
+        return True
+    return (
+        isinstance(var, variables.UserDefinedObjectVariable)
+        and isinstance(var.base_vt, (SetVariable, FrozensetVariable))
+    )
+
+
 # footgun, because self method calls in dict will route back to the set
 # implementation, which is almost assuredly wrong
 class SetVariable(ConstDictVariable):
@@ -1498,15 +1515,7 @@ class SetVariable(ConstDictVariable):
                 "__xor__": "symmetric_difference",
                 "__sub__": "difference",
             }.get(name)
-            if not isinstance(
-                args[0],
-                (
-                    SetVariable,
-                    variables.UserDefinedSetVariable,
-                    DictItemsVariable,
-                    DictKeysVariable,
-                ),
-            ):
+            if not _is_set_like(args[0]):
                 raise_observed_exception(
                     TypeError,
                     tx,
@@ -1523,15 +1532,7 @@ class SetVariable(ConstDictVariable):
                 "__rxor__": "__xor__",
                 "__rsub__": "__sub__",
             }.get(name)
-            if not isinstance(
-                args[0],
-                (
-                    SetVariable,
-                    variables.UserDefinedSetVariable,
-                    DictItemsVariable,
-                    DictKeysVariable,
-                ),
-            ):
+            if not _is_set_like(args[0]):
                 raise_observed_exception(
                     TypeError,
                     tx,
@@ -1542,15 +1543,7 @@ class SetVariable(ConstDictVariable):
             assert m is not None
             return args[0].call_method(tx, m, [self], kwargs)
         elif name in ("__iand__", "__ior__", "__ixor__", "__isub__"):
-            if not isinstance(
-                args[0],
-                (
-                    SetVariable,
-                    variables.UserDefinedSetVariable,
-                    DictItemsVariable,
-                    DictKeysVariable,
-                ),
-            ):
+            if not _is_set_like(args[0]):
                 raise_observed_exception(
                     TypeError,
                     tx,
@@ -1568,28 +1561,12 @@ class SetVariable(ConstDictVariable):
             self.call_method(tx, m, args, kwargs)
             return self
         elif name == "__eq__":
-            if not isinstance(
-                args[0],
-                (
-                    SetVariable,
-                    variables.UserDefinedSetVariable,
-                    DictItemsVariable,
-                    DictKeysVariable,
-                ),
-            ):
+            if not _is_set_like(args[0]):
                 return CONSTANT_VARIABLE_FALSE
             r = self.call_method(tx, "symmetric_difference", args, kwargs)
             return VariableTracker.build(tx, len(r.set_items) == 0)  # type: ignore[attr-defined]
         elif name in cmp_name_to_op_mapping:
-            if not isinstance(
-                args[0],
-                (
-                    SetVariable,
-                    variables.UserDefinedSetVariable,
-                    DictItemsVariable,
-                    DictKeysVariable,
-                ),
-            ):
+            if not _is_set_like(args[0]):
                 return VariableTracker.build(tx, NotImplemented)
             return VariableTracker.build(
                 tx,
@@ -1956,15 +1933,7 @@ class DictKeysVariable(DictViewVariable):
             r = m(args[0].set_items)  # type: ignore[attr-defined]
             return SetVariable(r)
         elif name in cmp_name_to_op_mapping:
-            if not isinstance(
-                args[0],
-                (
-                    SetVariable,
-                    variables.UserDefinedSetVariable,
-                    DictItemsVariable,
-                    DictKeysVariable,
-                ),
-            ):
+            if not _is_set_like(args[0]):
                 return VariableTracker.build(tx, NotImplemented)
             return VariableTracker.build(
                 tx,
@@ -2044,7 +2013,6 @@ class DictItemsVariable(DictViewVariable):
                 args[0],
                 (
                     SetVariable,
-                    variables.UserDefinedSetVariable,
                     DictItemsVariable,
                     DictKeysVariable,
                 ),
@@ -2075,15 +2043,7 @@ class DictItemsVariable(DictViewVariable):
             ret_val = fn_hdl(args[0].set_items)  # type: ignore[attr-defined]
             return SetVariable(ret_val)
         elif name in cmp_name_to_op_mapping:
-            if not isinstance(
-                args[0],
-                (
-                    SetVariable,
-                    variables.UserDefinedSetVariable,
-                    DictItemsVariable,
-                    DictKeysVariable,
-                ),
-            ):
+            if not _is_set_like(args[0]):
                 return VariableTracker.build(tx, NotImplemented)
             return VariableTracker.build(
                 tx,

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -57,7 +57,7 @@ from .base import (
 from .constant import CONSTANT_VARIABLE_FALSE, CONSTANT_VARIABLE_NONE, ConstantVariable
 from .functions import UserFunctionVariable
 from .iter import IteratorVariable
-from .user_defined import UserDefinedTupleVariable
+from .user_defined import UserDefinedObjectVariable
 
 
 if TYPE_CHECKING:
@@ -1644,11 +1644,11 @@ class SizeVariable(TupleVariable):
         return VariableTracker.build(tx, hasattr(torch.Size, name))
 
 
-class NamedTupleVariable(UserDefinedTupleVariable):
+class NamedTupleVariable(UserDefinedObjectVariable):
     _nonvar_fields = {
         "tuple_cls",
         "dynamic_attributes",
-        *UserDefinedTupleVariable._nonvar_fields,
+        *UserDefinedObjectVariable._nonvar_fields,
     }
 
     def __init__(
@@ -1675,7 +1675,7 @@ class NamedTupleVariable(UserDefinedTupleVariable):
 
         super().__init__(
             value=dummy_value,
-            tuple_vt=tuple_vt,
+            base_vt=tuple_vt,
             init_args=items,
             **kwargs,
         )
@@ -1686,7 +1686,7 @@ class NamedTupleVariable(UserDefinedTupleVariable):
 
     @property
     def items(self) -> list[VariableTracker]:
-        return self._tuple_vt.items
+        return self.base_vt.items
 
     def is_namedtuple(self) -> bool:
         return isinstance(getattr(self.tuple_cls, "_fields", None), tuple) and callable(
@@ -1723,8 +1723,8 @@ class NamedTupleVariable(UserDefinedTupleVariable):
 
     def as_proxy(self) -> Any:
         if self.is_structseq():
-            return self.python_type()([x.as_proxy() for x in self._tuple_vt.items])
-        return self.python_type()(*[x.as_proxy() for x in self._tuple_vt.items])
+            return self.python_type()([x.as_proxy() for x in self.base_vt.items])
+        return self.python_type()(*[x.as_proxy() for x in self.base_vt.items])
 
     def call_tree_map(
         self,
@@ -1880,10 +1880,10 @@ class NamedTupleVariable(UserDefinedTupleVariable):
                 codegen.create_load_const_unchecked(create_fn)
             )
         )
-        codegen.foreach(self._tuple_vt.items)
+        codegen.foreach(self.base_vt.items)
         codegen.extend_output(
             [
-                create_build_tuple(len(self._tuple_vt.items)),
+                create_build_tuple(len(self.base_vt.items)),
             ]
             + create_call_function(1, False)
         )
@@ -1913,7 +1913,7 @@ class NamedTupleVariable(UserDefinedTupleVariable):
         kwargs: dict[str, VariableTracker],
     ) -> VariableTracker:
         if self._is_method_overridden(name):
-            # Fall back to UserDefinedTupleVariable
+            # Fall back to UserDefinedObjectVariable
             return super().call_method(tx, name, args, kwargs)
         elif name == "__setattr__":
             if kwargs or len(args) != 2:
@@ -1956,7 +1956,7 @@ class NamedTupleVariable(UserDefinedTupleVariable):
         fields = self.fields()
         if name in fields:
             field_index = fields.index(name)
-            return self._tuple_vt.items[field_index]
+            return self.base_vt.items[field_index]
 
         return super().var_getattr(tx, name)
 

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -341,25 +341,12 @@ class SuperVariable(VariableTracker):
             )
             return variables.CONSTANT_VARIABLE_NONE
         elif (
-            isinstance(self.objvar, variables.UserDefinedDictVariable)
-            and inner_fn in self.objvar._dict_methods
+            isinstance(self.objvar, variables.UserDefinedObjectVariable)
+            and self.objvar.base_vt is not None
+            and self.objvar._base_methods is not None
+            and inner_fn in self.objvar._base_methods
         ):
-            return self.objvar._dict_vt.call_method(tx, name, args, kwargs)
-        elif (
-            isinstance(self.objvar, variables.UserDefinedSetVariable)
-            and inner_fn in self.objvar._set_methods
-        ):
-            return self.objvar._set_vt.call_method(tx, name, args, kwargs)
-        elif (
-            isinstance(self.objvar, variables.UserDefinedTupleVariable)
-            and inner_fn in tuple_methods
-        ):
-            return self.objvar._tuple_vt.call_method(tx, name, args, kwargs)
-        elif (
-            isinstance(self.objvar, variables.UserDefinedListVariable)
-            and inner_fn in list_methods
-        ):
-            return self.objvar._list_vt.call_method(tx, name, args, kwargs)
+            return self.objvar.base_vt.call_method(tx, name, args, kwargs)
         elif inner_fn is object.__getattribute__:
             # object.__getattribute__ has no side-effects. We can directly call
             # __getattribute__ to access the attribute.

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -7,9 +7,6 @@ The key classes are:
 - UserDefinedObjectVariable: Fallback class for instance objects, with support for method calls,
   attribute access, and other Python object behaviors.
 - Specialized subclasses for common patterns:
-  - UserDefinedDictVariable: For dict subclasses
-  - UserDefinedSetVariable: For set subclasses
-  - UserDefinedTupleVariable: For tuple subclasses
   - UserDefinedExceptionObjectVariable: For exception subclasses
   - FrozenDataClassVariable: Special handling of frozen dataclasses
   - MutableMappingVariable: For collections.abc.MutableMapping subclasses
@@ -284,6 +281,7 @@ class UserDefinedClassVariable(UserDefinedVariable):
             frozenset.__new__,
             tuple.__new__,
             list.__new__,
+            str.__new__,
         }
         return c_new_fns.union(exceptions)
 
@@ -1342,6 +1340,8 @@ class UserDefinedObjectVariable(UserDefinedVariable):
     _nonvar_fields = {
         "value",
         "value_type",
+        "_solid_base",
+        "_base_methods",
         *UserDefinedVariable._nonvar_fields,
     }
 
@@ -1353,6 +1353,7 @@ class UserDefinedObjectVariable(UserDefinedVariable):
         cls_source: TypeSource | None = None,
         base_cls_vt: VariableTracker | None = None,
         init_args: Sequence[VariableTracker] | None = None,
+        base_vt: "VariableTracker | None" = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -1370,6 +1371,29 @@ class UserDefinedObjectVariable(UserDefinedVariable):
         #   obj = base_cls.__new__(user_cls, *args)
         self.base_cls_vt = base_cls_vt
         self.init_args = init_args
+
+        # Analogous to CPython's tp_base / solid_base: holds the VT for the
+        # builtin base type's data (e.g. ConstDictVariable for dict subclasses).
+        # Methods inherited from the builtin base are delegated to this VT.
+        self.base_vt = base_vt
+
+        # The solid base type (e.g. dict, list, set) whose methods are
+        # delegated to base_vt. Computed by walking __base__ like CPython's
+        # solid_base(). None if the solid base is object.
+        from ..side_effects import SideEffects
+
+        self._solid_base = SideEffects._find_solid_base(self.value_type)
+        if self._solid_base is None:
+            self._base_methods: set[object] | None = None
+        elif self._solid_base in (dict, collections.OrderedDict):
+            # dict includes OrderedDict methods for compatibility
+            self._base_methods = dict_methods
+        else:
+            self._base_methods = {
+                method
+                for method in self._solid_base.__dict__.values()
+                if callable(method)
+            }
 
         # This records the attributes that were modified via instance
         # `__dict__` directly, rather than the normal setattr path.
@@ -1411,7 +1435,53 @@ class UserDefinedObjectVariable(UserDefinedVariable):
         return self.dict_vt
 
     def is_underlying_vt_modified(self, side_effects: "SideEffects") -> bool:
+        if self.base_vt is not None:
+            return side_effects.is_modified(self.base_vt)
         return False
+
+    def unpack_var_sequence(
+        self, tx: "InstructionTranslator"
+    ) -> list[VariableTracker]:
+        if self._solid_base is not None and self.base_vt is not None:
+            # Check that __iter__ hasn't been overridden by the subclass
+            iter_fn = inspect.getattr_static(self.value, "__iter__")
+            if iter_fn is self._solid_base.__iter__:  # type: ignore[union-attr]
+                return self.base_vt.unpack_var_sequence(tx)
+        return super().unpack_var_sequence(tx)
+
+    @property
+    def set_items(self) -> set[Any]:
+        if self._solid_base in (set, frozenset) and self.base_vt is not None:
+            return self.base_vt.set_items
+        raise AttributeError("set_items")
+
+    def install_dict_keys_match_guard(self) -> None:
+        if self._solid_base is not None and self.base_vt is not None:
+            return self.base_vt.install_dict_keys_match_guard()
+        raise NotImplementedError
+
+    def install_dict_contains_guard(
+        self, tx: "InstructionTranslator", args: list[VariableTracker]
+    ) -> None:
+        if self._solid_base is not None and self.base_vt is not None:
+            return self.base_vt.install_dict_contains_guard(tx, args)
+        raise NotImplementedError
+
+    def is_python_hashable(self) -> bool:
+        if self._solid_base is not None and self.base_vt is not None:
+            raise_on_overridden_hash(self.value, self)
+            # If the solid base defines __hash__ as None (e.g. dict, list, set),
+            # the type is unhashable. Otherwise delegate to base_vt.
+            if self._solid_base.__hash__ is None:
+                return False
+            return self.base_vt.is_python_hashable()
+        return super().is_python_hashable()
+
+    def get_python_hash(self) -> int:
+        if self._solid_base is not None and self.base_vt is not None:
+            return self.base_vt.get_python_hash()
+        return super().get_python_hash()
+
 
     def python_type(self) -> type:
         return self.value_type  # type: ignore[return-value]
@@ -1420,6 +1490,9 @@ class UserDefinedObjectVariable(UserDefinedVariable):
         return self.value
 
     def as_python_constant(self) -> object:
+        if self._solid_base in (set, frozenset) and self.base_vt is not None:
+            return self.base_vt.as_python_constant()
+
         if self.is_pytree_constant_class and self.source:
             # NOTE pytree constants created in the torch.compile region will
             # NOT be guarded (even though they have a source set)
@@ -1530,6 +1603,29 @@ class UserDefinedObjectVariable(UserDefinedVariable):
         from . import CONSTANT_VARIABLE_NONE, UserMethodVariable
 
         method = self._maybe_get_baseclass_method(name)
+
+        # Delegate to base_vt for methods inherited from the builtin base type
+        if self.base_vt is not None and method is not None:
+            # Tuple __eq__/__ne__ use is_python_equal for constant folding
+            if self._solid_base is tuple and name in ("__eq__", "__ne__"):
+                if len(args) != 1 or kwargs:
+                    raise ValueError("Improper arguments for method.")
+                eq = self.is_python_equal(args[0])
+                return VariableTracker.build(tx, eq if name == "__eq__" else not eq)
+
+            base_methods = self._base_methods
+            if base_methods is not None and method in base_methods:
+                try:
+                    return self.base_vt.call_method(tx, name, args, kwargs)
+                except ObservedKeyError:
+                    if (
+                        name == "__getitem__"
+                        and issubclass(self.python_type(), dict)
+                        and self._maybe_get_baseclass_method("__missing__")
+                    ):
+                        return self.call_method(tx, "__missing__", args, kwargs)
+                    raise
+
         if method is not None:
             if method is object.__init__:
                 return CONSTANT_VARIABLE_NONE
@@ -2173,6 +2269,13 @@ class UserDefinedObjectVariable(UserDefinedVariable):
         source: Source | None,
     ) -> VariableTracker:
         """Handle data descriptors found on the type MRO (property, _tuplegetter, etc.)."""
+        # namedtuple fields are _tuplegetter descriptors implemented in C.
+        # Emulate _tuplegetter.__get__ by indexing into the tracked tuple items.
+        if isinstance(type_attr, _collections._tuplegetter):
+            if self._solid_base is tuple and self.base_vt is not None:
+                _, (idx, _) = type_attr.__reduce__()
+                return self.base_vt.items[idx]
+
         if isinstance(type_attr, property) and not self._is_c_defined_property(
             type_attr
         ):
@@ -2367,6 +2470,15 @@ class UserDefinedObjectVariable(UserDefinedVariable):
         return hash(self.value)
 
     def is_python_equal(self, other: object) -> bool:
+        if self._solid_base is not None and self.base_vt is not None:
+            other_vt = (
+                other.base_vt
+                if isinstance(other, UserDefinedObjectVariable)
+                and other._solid_base == self._solid_base
+                else other
+            )
+            return self.base_vt.is_python_equal(other_vt)
+
         # id check
         if not isinstance(other, UserDefinedVariable):
             return False
@@ -2937,325 +3049,6 @@ class RemovableHandleVariable(VariableTracker):
 
     def python_type(self) -> type[object]:
         return RemovableHandleClass
-
-
-class UserDefinedDictVariable(UserDefinedObjectVariable):
-    """
-    Represents user defined objects that are subclasses of dict/OrderedDict.
-
-    Internally, it uses a ConstDictVariable to represent the dict part of the
-    variable tracker. For everything else, it falls back to
-    UserDefinedObjectVariable.
-    """
-
-    def __init__(
-        self,
-        value: object,
-        dict_vt: ConstDictVariable | None = None,
-        **kwargs: Any,
-    ) -> None:
-        super().__init__(value, **kwargs)
-        if dict_vt is None:
-            assert self.source is None, (
-                "dict_vt must be constructed by builder.py when source is present"
-            )
-            self._dict_vt = ConstDictVariable(
-                {}, type(value), mutation_type=ValueMutationNew()
-            )
-        else:
-            self._dict_vt = dict_vt
-        self._dict_methods = dict_methods
-
-    def call_method(
-        self,
-        tx: "InstructionTranslator",
-        name: str,
-        args: list[VariableTracker],
-        kwargs: dict[str, VariableTracker],
-    ) -> VariableTracker:
-        method = self._maybe_get_baseclass_method(name)
-        if method in self._dict_methods:
-            # Dict subclasses can override __missing__ to provide fallback
-            # behavior instead of raising a KeyError. This is used, for example,
-            # by collections.Counter.
-            try:
-                return self._dict_vt.call_method(tx, name, args, kwargs)
-            except ObservedKeyError:
-                if (
-                    name == "__getitem__"
-                    and issubclass(self.python_type(), dict)
-                    and self._maybe_get_baseclass_method("__missing__")
-                ):
-                    return self.call_method(tx, "__missing__", args, kwargs)
-                else:
-                    raise
-        return super().call_method(tx, name, args, kwargs)
-
-    def unpack_var_sequence(self, tx: "InstructionTranslator") -> list[VariableTracker]:
-        if type(self.value).__iter__ in (  # type: ignore[attr-defined]
-            dict.__iter__,
-            collections.OrderedDict.__iter__,
-        ):
-            return self._dict_vt.unpack_var_sequence(tx)
-        raise NotImplementedError
-
-    def is_underlying_vt_modified(self, side_effects: "SideEffects") -> bool:
-        return side_effects.is_modified(self._dict_vt)
-
-    @property
-    def user_cls(self) -> type[object]:
-        return self._dict_vt.user_cls
-
-    @property
-    def items(self) -> dict[VariableTracker, VariableTracker]:
-        return self._dict_vt.items
-
-    def install_dict_keys_match_guard(self) -> None:
-        return self._dict_vt.install_dict_keys_match_guard()
-
-    def install_dict_contains_guard(
-        self, tx: "InstructionTranslator", args: list[VariableTracker]
-    ) -> None:
-        return self._dict_vt.install_dict_contains_guard(tx, args)
-
-    def is_python_hashable(self) -> Literal[False]:
-        raise_on_overridden_hash(self.value, self)
-        return False
-
-
-class UserDefinedSetVariable(UserDefinedObjectVariable):
-    """
-    Represents user defined objects that are subclasses of set.
-
-    Internally, it uses a SetVariable to represent the set part of the
-    variable tracker. For everything else, it falls back to
-    UserDefinedObjectVariable.
-    """
-
-    def __init__(
-        self, value: object, set_vt: SetVariable | None = None, **kwargs: Any
-    ) -> None:
-        from .builder import SourcelessBuilder
-
-        tx = kwargs.pop("tx", None)
-        super().__init__(value, **kwargs)
-
-        python_type = set if isinstance(value, set) else frozenset
-        self._set_methods = set_methods if python_type is set else frozenset_methods
-
-        if set_vt is None:
-            assert self.source is None, (
-                "set_vt must be constructed by builder.py when source is present"
-            )
-            if python_type is set:
-                # set is initialized later
-                self._set_vt = variables.SetVariable(
-                    set(),
-                    mutation_type=ValueMutationNew(),
-                )
-            else:
-                init_args = kwargs.get("init_args", {})
-                if tx is None:
-                    tx = torch._dynamo.symbolic_convert.InstructionTranslator.current_tx()
-                self._set_vt = SourcelessBuilder.create(tx, python_type).call_function(  # type: ignore[assignment]
-                    tx, init_args, {}
-                )
-        else:
-            self._set_vt = set_vt
-
-    def call_method(
-        self,
-        tx: "InstructionTranslator",
-        name: str,
-        args: list[VariableTracker],
-        kwargs: dict[str, VariableTracker],
-    ) -> VariableTracker:
-        method = self._maybe_get_baseclass_method(name)
-        if method in self._set_methods:
-            return self._set_vt.call_method(tx, name, args, kwargs)
-        return super().call_method(tx, name, args, kwargs)
-
-    def as_python_constant(self) -> object:
-        return self._set_vt.as_python_constant()
-
-    def unpack_var_sequence(self, tx: "InstructionTranslator") -> list[VariableTracker]:
-        if inspect.getattr_static(self.value, "__iter__") in (
-            set.__iter__,
-            frozenset.__iter__,
-        ):
-            return self._set_vt.unpack_var_sequence(tx)
-        raise NotImplementedError
-
-    @property
-    def set_items(self) -> set[Any]:
-        return self._set_vt.set_items
-
-    @property
-    def items(self) -> list[VariableTracker]:
-        return self._set_vt.items
-
-    def is_underlying_vt_modified(self, side_effects: "SideEffects") -> bool:
-        return side_effects.is_modified(self._set_vt)
-
-    def install_dict_keys_match_guard(self) -> None:
-        return self._set_vt.install_dict_keys_match_guard()
-
-    def install_dict_contains_guard(
-        self, tx: "InstructionTranslator", args: list[VariableTracker]
-    ) -> None:
-        return self._set_vt.install_dict_contains_guard(tx, args)
-
-    def is_python_hashable(self) -> bool:
-        raise_on_overridden_hash(self.value, self)
-        return self._set_vt.is_python_hashable()
-
-    def get_python_hash(self) -> int:
-        return self._set_vt.get_python_hash()
-
-    def is_python_equal(self, other: object) -> bool:
-        return isinstance(
-            other, UserDefinedSetVariable
-        ) and self._set_vt.is_python_equal(other._set_vt)
-
-
-class UserDefinedListVariable(UserDefinedObjectVariable):
-    """
-    Represents user defined objects that are subclasses of lists.
-
-    Internally, it uses a ListVariable to represent the list part of the
-    variable tracker. For everything else, it falls back to
-    UserDefinedObjectVariable.
-    """
-
-    def __init__(
-        self, value: object, list_vt: Union["ListVariable", None] = None, **kwargs: Any
-    ) -> None:
-        from .lists import ListVariable
-
-        super().__init__(value, **kwargs)
-        if list_vt is None:
-            assert self.source is None, (
-                "list_vt must be constructed by builder.py when source is present"
-            )
-            self._list_vt = ListVariable([], mutation_type=ValueMutationNew())
-        else:
-            self._list_vt = list_vt
-
-    def call_method(
-        self,
-        tx: "InstructionTranslator",
-        name: str,
-        args: list[VariableTracker],
-        kwargs: dict[str, VariableTracker],
-    ) -> VariableTracker:
-        assert self._list_vt is not None
-        method = self._maybe_get_baseclass_method(name)
-        if method in list_methods:
-            return self._list_vt.call_method(tx, name, args, kwargs)
-        return super().call_method(tx, name, args, kwargs)
-
-    def unpack_var_sequence(self, tx: "InstructionTranslator") -> list[VariableTracker]:
-        assert self._list_vt is not None
-        if type(self.value).__iter__ is list.__iter__:  # type: ignore[attr-defined]
-            return self._list_vt.unpack_var_sequence(tx)
-        raise NotImplementedError
-
-    def is_underlying_vt_modified(self, side_effects: "SideEffects") -> bool:
-        return side_effects.is_modified(self._list_vt)
-
-    def is_python_hashable(self) -> Literal[False]:
-        raise_on_overridden_hash(self.value, self)
-        return False
-
-
-class UserDefinedTupleVariable(UserDefinedObjectVariable):
-    """
-    Represents user defined objects that are subclasses of tuple.
-
-    Internally, it uses a TupleVariable to represent the tuple part of the
-    variable tracker. For everything else, it falls back to
-    UserDefinedObjectVariable.
-    """
-
-    _nonvar_fields = UserDefinedObjectVariable._nonvar_fields
-
-    def __init__(self, value, tuple_vt=None, init_args=None, **kwargs):  # type: ignore[all]
-        from .lists import TupleVariable
-
-        tx = kwargs.pop("tx", None)
-        super().__init__(value, init_args=init_args, **kwargs)
-        if tuple_vt is None:
-            assert self.source is None, (
-                "tuple_vt must be constructed by builder.py when source is present"
-            )
-            assert init_args, "init_args must be provided when tuple_vt is None"
-            # Emulate `tuple.__new__`
-            # https://github.com/python/cpython/blob/3.11/Objects/tupleobject.c#L697-L710
-            #
-            # TODO this duplicates the logic in `BuiltinVariable(tuple)`
-            if tx is None:
-                from torch._dynamo.symbolic_convert import InstructionTranslator
-
-                tx = InstructionTranslator.current_tx()
-            elems = init_args[0].force_unpack_var_sequence(tx)
-            self._tuple_vt = TupleVariable(elems, mutation_type=ValueMutationNew())
-        else:
-            self._tuple_vt = tuple_vt
-
-    def resolve_data_descriptor(
-        self,
-        tx: "InstructionTranslator",
-        name: str,
-        type_attr: object,
-        source: Source | None,
-    ) -> VariableTracker:
-        if isinstance(type_attr, _collections._tuplegetter):
-            # namedtuple fields are _tuplegetter descriptors implemented in C.
-            # We emulate _tuplegetter.__get__ by indexing into the tracked
-            # tuple items, because self.value may not hold actual runtime values.
-            _, (idx, _) = type_attr.__reduce__()
-            return self._tuple_vt.items[idx]  # type: ignore[union-attr]
-        return super().resolve_data_descriptor(tx, name, type_attr, source)
-
-    def call_method(
-        self,
-        tx: "InstructionTranslator",
-        name: str,
-        args: list[VariableTracker],
-        kwargs: dict[str, VariableTracker],
-    ) -> VariableTracker:
-        assert self._tuple_vt is not None
-        if name == "__eq__":
-            if len(args) != 1 or kwargs:
-                raise ValueError("Improper arguments for method.")
-            return VariableTracker.build(tx, self.is_python_equal(args[0]))
-        elif name == "__ne__":
-            if len(args) != 1 or kwargs:
-                raise ValueError("Improper arguments for method.")
-            return VariableTracker.build(tx, not self.is_python_equal(args[0]))
-        method = self._maybe_get_baseclass_method(name)
-        if method in tuple_methods:
-            return self._tuple_vt.call_method(tx, name, args, kwargs)
-        return super().call_method(tx, name, args, kwargs)
-
-    def unpack_var_sequence(self, tx: "InstructionTranslator") -> list[VariableTracker]:
-        assert self._tuple_vt is not None
-        if type(self.value).__iter__ is tuple.__iter__:  # type: ignore[attr-defined]
-            return self._tuple_vt.unpack_var_sequence(tx)
-        raise NotImplementedError
-
-    def is_python_hashable(self) -> bool:
-        raise_on_overridden_hash(self.value, self)
-        return self._tuple_vt.is_python_hashable()
-
-    def get_python_hash(self) -> int:
-        return self._tuple_vt.get_python_hash()
-
-    def is_python_equal(self, other: object) -> bool:
-        other = (
-            other._tuple_vt if isinstance(other, UserDefinedTupleVariable) else other
-        )
-        return self._tuple_vt.is_python_equal(other)
 
 
 class MutableMappingVariable(UserDefinedObjectVariable):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #179218
* __->__ #179210

Inspired by CPython's tp_base / solid_base mechanism, this adds a
`base_vt` field to UserDefinedObjectVariable that holds the VT for the
builtin base type's data (e.g. ConstDictVariable for dict subclasses,
SetVariable for set subclasses, etc.). Methods inherited from the
builtin base are delegated to this VT.

The solid base type is found by walking `__base__` (tp_base), mirroring
CPython's solid_base(). The base method set is computed from the solid
base's `__dict__`, so adding support for new builtin types requires
minimal code — demonstrated by adding str subclass support (6 tests).

This deletes UserDefinedDictVariable, UserDefinedSetVariable,
UserDefinedListVariable, and UserDefinedTupleVariable. NamedTupleVariable
now inherits directly from UserDefinedObjectVariable.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98