### PR TITLE
[dynamo] Fix shadowed unpack_var_sequence on UDOV

### DIFF
--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -1439,16 +1439,6 @@ class UserDefinedObjectVariable(UserDefinedVariable):
             return side_effects.is_modified(self.base_vt)
         return False
 
-    def unpack_var_sequence(
-        self, tx: "InstructionTranslator"
-    ) -> list[VariableTracker]:
-        if self._solid_base is not None and self.base_vt is not None:
-            # Check that __iter__ hasn't been overridden by the subclass
-            iter_fn = inspect.getattr_static(self.value, "__iter__")
-            if iter_fn is self._solid_base.__iter__:  # type: ignore[union-attr]
-                return self.base_vt.unpack_var_sequence(tx)
-        return super().unpack_var_sequence(tx)
-
     @property
     def set_items(self) -> set[Any]:
         if self._solid_base in (set, frozenset) and self.base_vt is not None:
@@ -1809,6 +1799,12 @@ class UserDefinedObjectVariable(UserDefinedVariable):
         ) and not isinstance(self.value, threading.local)
 
     def unpack_var_sequence(self, tx: "InstructionTranslator") -> list[VariableTracker]:
+        # Delegate to base_vt if __iter__ hasn't been overridden
+        if self._solid_base is not None and self.base_vt is not None:
+            iter_fn = inspect.getattr_static(self.value, "__iter__")
+            if iter_fn is self._solid_base.__iter__:  # type: ignore[union-attr]
+                return self.base_vt.unpack_var_sequence(tx)
+
         if (
             self.source
             and self._maybe_get_baseclass_method("__iter__") is list.__iter__


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #179218
* #179210

The original UDOV had an `unpack_var_sequence` that handled sourced
list-subclass unpacking. My earlier commit added a second
`unpack_var_sequence` higher up in the class body for base_vt
delegation, but the original one at the bottom of the class shadowed it
(Python uses the last definition). Merge both into a single method.

This fixes namedtuple `_replace` which needs to unpack the namedtuple
as a map iterable — the base_vt delegation now fires correctly.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98