### PR TITLE
Skip partial reuse for overlapping reduction families

### DIFF
--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -566,6 +566,23 @@ class TestPatternMatcher(TestCase):
         self.assertEqual(compiled_fn(x), test_fn(x))
         self.assertEqual(counters["inductor"]["partial_reduction_reuse"], 1)
 
+    def test_unsuccessful_partial_reuse_with_multiple_reduction_families(self):
+        def test_fn(x):
+            dim_amax = torch.amax(x, [2, 3], True)
+            global_amax = torch.amax(x)
+            dim_amin = torch.amin(x, [1], True)
+            global_amin = torch.min(x)
+            return x / (dim_amax + 1e-8) * global_amax + (
+                x - dim_amin
+            ) / (torch.abs(global_amin) + 1e-8)
+
+        x = torch.randn(2, 64, 32, 32, device=GPU_TYPE)
+
+        compiled_fn = torch.compile(test_fn)
+
+        self.assertEqual(compiled_fn(x), test_fn(x))
+        self.assertEqual(counters["inductor"]["partial_reduction_reuse"], 0)
+
     def test_addmm(self):
         def fn(a, b, c):
             return torch.add(a, torch.mm(b, c)), torch.mm(b, c) + a

--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -572,9 +572,9 @@ class TestPatternMatcher(TestCase):
             global_amax = torch.amax(x)
             dim_amin = torch.amin(x, [1], True)
             global_amin = torch.min(x)
-            return x / (dim_amax + 1e-8) * global_amax + (
-                x - dim_amin
-            ) / (torch.abs(global_amin) + 1e-8)
+            return x / (dim_amax + 1e-8) * global_amax + (x - dim_amin) / (
+                torch.abs(global_amin) + 1e-8
+            )
 
         x = torch.randn(2, 64, 32, 32, device=GPU_TYPE)
 

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -1644,6 +1644,9 @@ def register_partial_reduction_pattern():
         aten.amax.default: aten.max.default,
         aten.amin.default: aten.min.default,
     }
+    supported_reduction_ops = OrderedSet(
+        [aten.amax.default, aten.max.default, aten.amin.default, aten.min.default]
+    )
 
     # TODO: to support other reductions like sum, would need to skip
     # lower precision reductions since partial output would need to be kept at fp32.
@@ -1664,6 +1667,20 @@ def register_partial_reduction_pattern():
 
             # if they're small, reuse not worth it
             if not statically_known_true(input.meta["val"].numel() >= 4096):
+                return True
+            # Only rewrite isolated partial/full pairs. Overlapping supported
+            # max/min reductions on the same source can produce incorrect reuse.
+            if (
+                len(
+                    OrderedSet(
+                        user
+                        for user in input.users
+                        if user.op == "call_function"
+                        and user.target in supported_reduction_ops
+                    )
+                )
+                > 2
+            ):
                 return True
 
             def replacement(inp: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:


### PR DESCRIPTION
Fix #178883

## Root cause
`reuse_partial` assumes a source tensor only participates in one supported partial/full max/min reuse pair. When the same tensor also feeds other supported max/min reductions, the pass can rewrite overlapping reduction families and produce incorrect results.

## Proposed fix
Skip partial reduction reuse when the source tensor has more than two supported max/min reduction users, and add a regression test that mirrors the reported mixed `amax`/`amin` pattern.

## Why this is the right long term fix
This keeps the optimization for isolated, already-covered cases while making the pass conservative around overlapping reduction families until Inductor can reason about those rewrites safely.

Drafted via Codex, published after manual review by @bobrenjc93

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo