### PR TITLE
[Inductor] Fix Grid2DWithYZOverflow division by zero when ynumel=0

### DIFF
--- a/test/inductor/test_unbacked_symints.py
+++ b/test/inductor/test_unbacked_symints.py
@@ -855,6 +855,27 @@ class TestUnbackedSymints(InductorTestCase):
         expected = fn(*example_inputs)
         torch.testing.assert_close(actual, expected)
 
+    @skipGPUIf(not HAS_GPU, "requires gpu and triton")
+    @dynamo_config.patch({"capture_scalar_outputs": True})
+    def test_grid2d_yz_overflow_zero_ynumel(self, device):
+        # Grid2DWithYZOverflow used to divide by zero when ynumel=0.
+        # repeat_interleave with all-zero counts produces an empty tensor
+        # whose size is an unbacked symint. A 2D pointwise kernel then gets
+        # ynumel=0, causing ceildiv(0, 0) in the grid computation.
+        def fn(x, counts):
+            idx = torch.arange(counts.shape[0], device=x.device).repeat_interleave(
+                counts
+            )
+            gathered = x[idx]
+            return gathered + 1
+
+        x = torch.randn(8, 64, device=device)
+        counts = torch.zeros(8, dtype=torch.long, device=device)
+
+        expected = fn(x, counts)
+        actual = torch.compile(fn, fullgraph=True)(x, counts)
+        torch.testing.assert_close(actual, expected)
+
 
 instantiate_device_type_tests(TestUnbackedSymints, globals(), allow_xpu=True)
 

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -4338,7 +4338,8 @@ class Grid2DWithYZOverflow(GridExpr):
                     "y_grid_raw_", self.ceildiv("ynumel", meta.get("YBLOCK"))
                 ),
                 self.assign_tmp(
-                    "y_grid_div_", self.ceildiv("y_grid_raw_", get_max_y_grid())
+                    "y_grid_div_",
+                    f"max(1, {self.ceildiv('y_grid_raw_', get_max_y_grid())})",
                 ),
             ]
         )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #179222

When a Triton kernel has `ynumel=0` (e.g. an EP rank receives zero tokens
  in MoE expert dispatch), the grid computation produces:
  - `y_grid_raw_ = ceildiv(0, YBLOCK) = 0`
  - `y_grid_div_ = ceildiv(0, max_y_grid) = 0`
  - `y_grid = ceildiv(0, 0)` → **ZeroDivisionError**

  Fix by wrapping `y_grid_div_` with `max(1, ...)` so it is always at least 1.
  When `ynumel=0`, this gives `y_grid = ceildiv(0, 1) = 0` and `z_grid = 1`,
  which correctly launches zero work.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo