### PR TITLE
spaceship operator for comparisons in Dict.h

### DIFF
--- a/aten/src/ATen/core/Dict.h
+++ b/aten/src/ATen/core/Dict.h
@@ -156,24 +156,8 @@ private:
     return lhs.get_iterator_() == rhs.get_iterator_();
   }
 
-  friend bool operator!=(const DictIterator& lhs, const DictIterator& rhs) {
-    return lhs.get_iterator_() != rhs.get_iterator_();
-  }
-
-  friend bool operator<(const DictIterator& lhs, const DictIterator& rhs) {
-    return lhs.get_iterator_() < rhs.get_iterator_();
-  }
-
-  friend bool operator<=(const DictIterator& lhs, const DictIterator& rhs) {
-    return lhs.get_iterator_() <= rhs.get_iterator_();
-  }
-
-  friend bool operator>(const DictIterator& lhs, const DictIterator& rhs) {
-    return lhs.get_iterator_() > rhs.get_iterator_();
-  }
-
-  friend bool operator>=(const DictIterator& lhs, const DictIterator& rhs) {
-    return lhs.get_iterator_() >= rhs.get_iterator_();
+  friend auto operator<=>(const DictIterator& lhs, const DictIterator& rhs) {
+    return lhs.get_iterator_() <=> rhs.get_iterator_();
   }
 
   DictEntryRef<Key, Value, Iterator> entryRef_;

--- a/aten/src/ATen/core/List.h
+++ b/aten/src/ATen/core/List.h
@@ -188,24 +188,8 @@ private:
     return lhs.iterator_ == rhs.iterator_;
   }
 
-  friend bool operator!=(const ListIterator& lhs, const ListIterator& rhs) {
-    return !(lhs == rhs);
-  }
-
-  friend bool operator<(const ListIterator& lhs, const ListIterator& rhs) {
-    return lhs.iterator_ < rhs.iterator_;
-  }
-
-  friend bool operator<=(const ListIterator& lhs, const ListIterator& rhs) {
-    return lhs.iterator_ <= rhs.iterator_;
-  }
-
-  friend bool operator>(const ListIterator& lhs, const ListIterator& rhs) {
-    return lhs.iterator_ > rhs.iterator_;
-  }
-
-  friend bool operator>=(const ListIterator& lhs, const ListIterator& rhs) {
-    return lhs.iterator_ >= rhs.iterator_;
+  friend auto operator<=>(const ListIterator& lhs, const ListIterator& rhs) {
+    return lhs.iterator_ <=> rhs.iterator_;
   }
 
   friend class ListIterator<T, typename c10::detail::ListImpl::list_type::iterator>;

--- a/aten/src/ATen/core/List.h
+++ b/aten/src/ATen/core/List.h
@@ -188,8 +188,24 @@ private:
     return lhs.iterator_ == rhs.iterator_;
   }
 
-  friend auto operator<=>(const ListIterator& lhs, const ListIterator& rhs) {
-    return lhs.iterator_ <=> rhs.iterator_;
+  friend bool operator!=(const ListIterator& lhs, const ListIterator& rhs) {
+    return !(lhs == rhs);
+  }
+
+  friend bool operator<(const ListIterator& lhs, const ListIterator& rhs) {
+    return lhs.iterator_ < rhs.iterator_;
+  }
+
+  friend bool operator<=(const ListIterator& lhs, const ListIterator& rhs) {
+    return lhs.iterator_ <= rhs.iterator_;
+  }
+
+  friend bool operator>(const ListIterator& lhs, const ListIterator& rhs) {
+    return lhs.iterator_ > rhs.iterator_;
+  }
+
+  friend bool operator>=(const ListIterator& lhs, const ListIterator& rhs) {
+    return lhs.iterator_ >= rhs.iterator_;
   }
 
   friend class ListIterator<T, typename c10::detail::ListImpl::list_type::iterator>;


### PR DESCRIPTION
We have C++20 in PyTorch now #176662
Spaceship/Three-way comparison operator automatically generates <, <=, >, >=
`operator==` automatically generates `operator!=`
This reduces a little bit of code.