### PR TITLE
Fix folded constant offset indexing in AOTI constant buffer updateFix folded constant offset indexing in AOTI constant buffer update

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -532,6 +532,94 @@ class AOTInductorTestsTemplate:
         new_output = runner_call(test_inputs)
         self.assertEqual(expected, new_output)
 
+    def test_update_inactive_constant_buffer_with_interleaved_folded_constants(self):
+        if self.device == "mps":
+            raise unittest.SkipTest("MPS baseline mismatch")
+
+        class Model(torch.nn.Module):
+            def __init__(self, device):
+                super().__init__()
+                self.fc1 = nn.Linear(2, 2, bias=True, device=device)
+                self.post = nn.Linear(2, 2, bias=False, device=device)
+                self.register_buffer(
+                    "uie_user_memory_network",
+                    torch.randn(2, 2, device=device),
+                    persistent=True,
+                )
+                self.register_buffer(
+                    "uie_item_memory_network",
+                    torch.randn(2, 2, device=device),
+                    persistent=True,
+                )
+                self.register_buffer(
+                    "late_bias",
+                    torch.randn(2, device=device),
+                    persistent=True,
+                )
+
+            def forward(self, x):
+                x = self.fc1(x)
+                direct_user = torch.matmul(x, self.uie_user_memory_network)
+                direct_item = torch.matmul(x, self.uie_item_memory_network)
+                folded_user = torch.relu(self.uie_user_memory_network.permute(1, 0))
+                folded_item = torch.relu(self.uie_item_memory_network.permute(1, 0))
+                out = direct_user + direct_item
+                out = out + torch.matmul(x, folded_user) + torch.matmul(x, folded_item)
+                return self.post(out + self.late_bias)
+
+        example_inputs = (torch.randn(2, 2, device=self.device),)
+        with (
+            torch.no_grad(),
+            config.patch(
+                {
+                    "always_keep_tensor_constants": True,
+                    "aot_inductor.use_runtime_constant_folding": True,
+                }
+            ),
+        ):
+            model = Model(self.device)
+            so_path, _ = run_and_get_cpp_code(
+                AOTIRunnerUtil.legacy_compile, model, example_inputs
+            )
+
+        runner = AOTIRunnerUtil.legacy_load_runner(self.device, so_path)
+        name_to_fqn = runner.get_constant_names_to_original_fqns()
+        self.assertTrue(
+            [name for name in name_to_fqn if name.startswith("_FOLDED_CONST_")],
+            msg="Expected runtime-folded constants in generated model",
+        )
+
+        def runner_call(x):
+            return runner.run([x])[0]
+
+        test_inputs = torch.tensor([[1.0, -2.0], [3.0, -4.0]], device=self.device)
+        atol = 1e-3
+        rtol = 1e-3
+        expected = model(test_inputs)
+        self.assertEqual(expected, runner_call(test_inputs), atol=atol, rtol=rtol)
+
+        with torch.no_grad():
+            for p in model.parameters():
+                p.add_(1.0)
+            for b in model.buffers():
+                b.add_(2.0)
+
+        state = {**dict(model.named_parameters()), **dict(model.named_buffers())}
+        new_weights = {
+            const_name: state[fqn].detach().clone()
+            for const_name, fqn in name_to_fqn.items()
+            if fqn in state
+        }
+        self.assertTrue(new_weights, msg="Expected non-empty constant update map")
+
+        new_expected = model(test_inputs)
+
+        runner.update_constant_buffer(new_weights, True, True)
+        self.assertEqual(expected, runner_call(test_inputs), atol=atol, rtol=rtol)
+
+        runner.swap_constant_buffer()
+        self.assertEqual(new_expected, runner_call(test_inputs), atol=atol, rtol=rtol)
+
     @requires_gpu
     def test_duplicate_constant_folding(self):
         class Model(torch.nn.Module):

--- a/torch/csrc/inductor/aoti_runtime/model_container.h
+++ b/torch/csrc/inductor/aoti_runtime/model_container.h
@@ -481,13 +481,19 @@ class AOTInductorModelContainer {
     auto constants_map_to_update = get_constants_map(use_inactive);
 
     auto num_constants = models_[0]->num_constants();
+    size_t non_folded_idx = 0;
     for (size_t idx = 0; idx < num_constants; idx++) {
+      bool from_folded = models_[0]->constant_from_folded(idx);
+      if (from_folded) {
+        continue;
+      }
       auto constant_name =
           std::string(models_[0]->constant_name(static_cast<int64_t>(idx)));
       auto it = constants_map.find(constant_name);
       if (it == constants_map.end() &&
           !(use_inactive &&
             _is_tensor_constant_or_buffer_type_or_empty_parameter(idx))) {
+        non_folded_idx++;
         continue;
       }
 
@@ -504,6 +510,7 @@ class AOTInductorModelContainer {
         constants_map_to_update->insert_or_assign(
             constant_name,
             MaybeOwningAtenTensorHandle(tensor, /* user_managed = */ true));
+        non_folded_idx++;
         continue;
       }
 
@@ -512,7 +519,7 @@ class AOTInductorModelContainer {
 
       // Move the data to container handled blob.
       uint8_t* internal_constants_ptr =
-          constants_blob_ptr + constants_internal_offset_[idx];
+          constants_blob_ptr + constants_internal_offset_[non_folded_idx];
       void* user_constant_ptr;
       int64_t constant_size;
       int64_t* stride;
@@ -537,11 +544,12 @@ class AOTInductorModelContainer {
           constants_blob_ptr,
           constant_size,
           offset,
-          constants_internal_offset_[idx]);
+          constants_internal_offset_[non_folded_idx]);
       // For mps tensors, all constants are stored in one buffer, with the
       // offset being where the constant starts. So we want to change the
-      // constant tensor's offset to point to constants_internal_offset_[idx]
-      offset = constants_internal_offset_[idx] /
+      // constant tensor's offset to point to
+      // constants_internal_offset_[non_folded_idx]
+      offset = constants_internal_offset_[non_folded_idx] /
           aoti_torch_dtype_element_size(dtype);
 #elif USE_CUDA
       AOTI_RUNTIME_CUDA_CHECK(cudaMemcpy(
@@ -573,6 +581,7 @@ class AOTInductorModelContainer {
       // ownership of the tensor_handle will be taken over.
       constants_map_to_update->insert_or_assign(
           constant_name, RAIIAtenTensorHandle(tensor_handle));
+      non_folded_idx++;
     }
     // Update the inactive constant array.
     update_array_from_map(


### PR DESCRIPTION
## Summary

This PR fixes an indexing issue in `AOTInductorModelContainer::update_constant_buffer`.

`constants_internal_offset_` stores offsets only for non-folded constants, but
the current implementation indexes it using the full constant index (`idx`).
When folded and non-folded constants are mixed, this can lead to incorrect
offset lookup and wrong constant buffer updates.

## Root cause

`constants_internal_offset_` is aligned with the sequence of non-folded constants,
not the full `num_constants()` index space.

However, `update_constant_buffer(...)` currently uses the full constant index
to access `constants_internal_offset_`.

## Fix

Introduce a separate `non_folded_idx` for indexing
`constants_internal_offset_`, and skip folded constants while keeping the
non-folded index aligned.

## Notes

This issue can be triggered when folded and non-folded constants are mixed in
the constant list and `update_constant_buffer(...)` is called.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo