### PR TITLE
[MPS] Fix hi/lo swap typo in Metal Philox RNG single_round

### DIFF
--- a/c10/metal/random.h
+++ b/c10/metal/random.h
@@ -33,7 +33,7 @@ uint4 single_round(uint4 ctr, uint2 key) {
   constexpr uint kPhiloxSB = 0xCD9E8D57;
   auto rc0 = mulhilo(kPhiloxSA, ctr.x);
   auto rc1 = mulhilo(kPhiloxSB, ctr.z);
-  return uint4(rc1.y ^ ctr.y ^ key.x, rc1.x, rc0.y ^ ctr.w ^ key.y, rc0.x);
+  return uint4(rc1.x ^ ctr.y ^ key.x, rc1.y, rc0.x ^ ctr.w ^ key.y, rc0.y);
 }
 
 uint4 multiple_rounds(uint4 ctr, uint2 key, uint rounds) {

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -13375,6 +13375,21 @@ class TestMetalLibrary(TestCaseMPS):
         self.assertRaises(ValueError, lambda: lib.full(mps_tensor, threads=(3, max_thread_group_size),
                                                        group_size=(3, max_thread_group_size)))
 
+    def test_metal_randn(self):
+        lib = torch.mps.compile_shader("""
+            #include <c10/metal/random.h>
+            kernel void randn(device float* out, constant long2& seed_offset,
+                              uint idx [[thread_position_in_grid]]) {
+              out[idx] = c10::metal::randn(seed_offset.x, seed_offset.y + idx);
+            }
+        """)
+        N = 100_000
+        out = torch.empty(N, device="mps")
+        seed_offset = torch.tensor([42, 0], dtype=torch.long, device="mps")
+        lib.randn(out, seed_offset)
+        self.assertEqual(out.mean(), torch.tensor(0.0, device="mps"), atol=0.01, rtol=0)
+        self.assertEqual(out.std(), torch.tensor(1.0, device="mps"), atol=0.02, rtol=0)
+
     def test_metal_include(self):
         # Checks that includes embedding works
         lib = torch.mps.compile_shader("#include <c10/metal/special_math.h>")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #179230
* #179228
* __->__ #179227

`mulhilo` returns `(hi, lo)` as `(.x, .y)`, but `single_round` was using `.y` (lo) in the XOR position and `.x` (hi) as the passthrough — the reverse of the standard Philox Feistel structure.
This caused `c10::metal::randn` to produce biased normal samples (mean ≈ -0.076 instead of 0.0).

Add test for `c10::metal::randn` in TestMetalLibrary that for a given seed computed mean and std and make sure it falls within certain tolerance levels.

CUDA implementation of the same algorithm for referenc https://github.com/pytorch/pytorch/blob/7231118db31/aten/src/ATen/core/PhiloxRNGEngine.h#L202-L213

Found with help of Claude while debugging bias in `torch.distributions.Gamma` implementaiton