### PR TITLE
[MPS] Implement `torch.distributions.Gamma` (fwd + bwd)

### DIFF
--- a/aten/src/ATen/native/mps/kernels/Distributions.metal
+++ b/aten/src/ATen/native/mps/kernels/Distributions.metal
@@ -1,4 +1,5 @@
 #include <c10/metal/random.h>
+#include <c10/metal/special_math.h>
 #include <metal_stdlib>
 
 using namespace metal;
@@ -69,3 +70,181 @@ REGISTER_OP(geometric, long);
 REGISTER_OP(geometric, short);
 REGISTER_OP(geometric, char);
 REGISTER_OP(geometric, uchar);
+
+// Marsaglia & Tsang (2000) acceptance-rejection method for Gamma distribution.
+// Adapted from aten/src/ATen/native/Distributions.h sample_gamma(),
+// which originates from NumPy's random module (Copyright 2005 Robert Kern).
+// Each thread uses a per-thread RNG offset stride to allow variable-length
+// rejection loops without colliding with other threads' random streams.
+constant constexpr int GAMMA_RANDOMS_STRIDE = 32;
+
+template <typename T>
+kernel void standard_gamma(
+    device T* output [[buffer(0)]],
+    device const T* alpha_in [[buffer(1)]],
+    constant long2& seed_base_offset [[buffer(2)]],
+    uint tid [[thread_position_in_grid]]) {
+  float alpha = static_cast<float>(alpha_in[tid]);
+  float scale = 1.0f;
+  long base =
+      seed_base_offset.y + static_cast<long>(tid) * GAMMA_RANDOMS_STRIDE;
+  long seed = seed_base_offset.x;
+  int rng_idx = 0;
+
+  // Boost alpha < 1 for higher acceptance probability
+  if (alpha < 1.0f) {
+    if (alpha == 0.0f) {
+      output[tid] = static_cast<T>(0.0f);
+      return;
+    }
+    float u = c10::metal::rand(seed, base + rng_idx++);
+    scale = ::metal::precise::pow(1.0f - u, 1.0f / alpha);
+    alpha += 1.0f;
+  }
+
+  // Marsaglia & Tsang acceptance-rejection
+  float d = alpha - 1.0f / 3.0f;
+  float c = 1.0f / ::metal::precise::sqrt(9.0f * d);
+  for (;;) {
+    float x, y;
+    do {
+      x = c10::metal::randn(seed, base + rng_idx++);
+      y = 1.0f + c * x;
+    } while (y <= 0.0f);
+    float v = y * y * y;
+    float u = 1.0f - c10::metal::rand(seed, base + rng_idx++);
+    float xx = x * x;
+    if (u < 1.0f - 0.0331f * xx * xx) {
+      float result = scale * d * v;
+      output[tid] = static_cast<T>(max(result, FLT_MIN));
+      return;
+    }
+    if (::metal::precise::log(u) <
+        0.5f * xx + d * (1.0f - v + ::metal::precise::log(v))) {
+      float result = scale * d * v;
+      output[tid] = static_cast<T>(max(result, FLT_MIN));
+      return;
+    }
+  }
+}
+
+#define REGISTER_GAMMA(DTYPE)                      \
+  template [[host_name("standard_gamma_" #DTYPE)]] \
+  kernel void standard_gamma<DTYPE>(               \
+      device DTYPE*, device const DTYPE*, constant long2&, uint)
+
+REGISTER_GAMMA(float);
+REGISTER_GAMMA(half);
+REGISTER_GAMMA(bfloat);
+
+// Reparameterized gradient for Gamma distribution.
+// Computes -(d/dalpha cdf(x;alpha)) / pdf(x;alpha).
+// Adapted from aten/src/ATen/native/Distributions.h standard_gamma_grad_one().
+
+constant const float GAMMA_GRAD_COEF_UV[3][8] = {
+    {0.16009398f,
+     -0.094634809f,
+     0.025146376f,
+     -0.0030648343f,
+     1.0f,
+     0.32668115f,
+     0.10406089f,
+     0.0014179084f},
+    {0.53487893f,
+     0.1298071f,
+     0.065735949f,
+     -0.0015649758f,
+     0.16639465f,
+     0.020070113f,
+     -0.0035938915f,
+     -0.00058392623f},
+    {0.040121004f,
+     -0.0065914022f,
+     -0.0026286047f,
+     -0.0013441777f,
+     0.017050642f,
+     -0.0021309326f,
+     0.00085092367f,
+     -1.5247877e-07f},
+};
+
+template <typename T>
+kernel void standard_gamma_grad(
+    device T* output [[buffer(0)]],
+    device const T* self_data [[buffer(1)]],
+    device const T* output_data [[buffer(2)]],
+    uint tid [[thread_position_in_grid]]) {
+  float alpha = static_cast<float>(self_data[tid]);
+  float x = static_cast<float>(output_data[tid]);
+
+  // Region 1: Small x - Taylor series expansion
+  if (x < 0.8f) {
+    float numer = 1.0f;
+    float denom = alpha;
+    float series1 = numer / denom;
+    float series2 = numer / (denom * denom);
+    for (int i = 1; i <= 5; ++i) {
+      numer *= -x / static_cast<float>(i);
+      denom += 1.0f;
+      series1 += numer / denom;
+      series2 += numer / (denom * denom);
+    }
+    float pow_x_alpha = ::metal::precise::pow(x, alpha);
+    float gamma_pdf =
+        ::metal::precise::pow(x, alpha - 1.0f) * ::metal::precise::exp(-x);
+    float gamma_cdf = pow_x_alpha * series1;
+    float gamma_cdf_alpha =
+        (::metal::precise::log(x) - c10::metal::digamma(alpha)) * gamma_cdf -
+        pow_x_alpha * series2;
+    float result = -gamma_cdf_alpha / gamma_pdf;
+    output[tid] = static_cast<T>(isnan(result) ? 0.0f : result);
+    return;
+  }
+
+  // Region 2: Large alpha - Rice saddle point expansion
+  if (alpha > 8.0f) {
+    if (0.9f * alpha <= x && x <= 1.1f * alpha) {
+      float numer_1 = 1.0f + 24.0f * alpha * (1.0f + 12.0f * alpha);
+      float numer_2 = 1440.0f * (alpha * alpha) +
+          6.0f * x * (53.0f - 120.0f * x) - 65.0f * x * x / alpha +
+          alpha * (107.0f + 3600.0f * x);
+      float denom = 1244160.0f * (alpha * alpha) * (alpha * alpha);
+      output[tid] = static_cast<T>(numer_1 * numer_2 / denom);
+      return;
+    }
+    float denom = ::metal::precise::sqrt(8.0f * alpha);
+    float term2 = denom / (alpha - x);
+    float term3 = ::metal::precise::pow(
+        x - alpha - alpha * ::metal::precise::log(x / alpha), -1.5f);
+    float term23 = (x < alpha) ? term2 - term3 : term2 + term3;
+    float term1 = ::metal::precise::log(x / alpha) * term23 -
+        ::metal::precise::sqrt(2.0f / alpha) * (alpha + x) /
+            ((alpha - x) * (alpha - x));
+    float stirling =
+        1.0f + 1.0f / (12.0f * alpha) * (1.0f + 1.0f / (24.0f * alpha));
+    float numer = x * term1;
+    output[tid] = static_cast<T>(-stirling * numer / denom);
+    return;
+  }
+
+  // Region 3: Moderate alpha - bivariate rational approximation
+  float u = ::metal::precise::log(x / alpha);
+  float v = ::metal::precise::log(alpha);
+  float coef_v[8];
+  for (int i = 0; i < 8; ++i) {
+    coef_v[i] = GAMMA_GRAD_COEF_UV[0][i] +
+        u * (GAMMA_GRAD_COEF_UV[1][i] + u * GAMMA_GRAD_COEF_UV[2][i]);
+  }
+  float p = coef_v[0] + v * (coef_v[1] + v * (coef_v[2] + v * coef_v[3]));
+  float q = coef_v[4] + v * (coef_v[5] + v * (coef_v[6] + v * coef_v[7]));
+  output[tid] = static_cast<T>(::metal::precise::exp(p / q));
+}
+
+#define REGISTER_GAMMA_GRAD(DTYPE)                      \
+  template [[host_name("standard_gamma_grad_" #DTYPE)]] \
+  kernel void standard_gamma_grad<DTYPE>(               \
+      device DTYPE*, device const DTYPE*, device const DTYPE*, uint)
+
+REGISTER_GAMMA_GRAD(float);
+REGISTER_GAMMA_GRAD(half);
+REGISTER_GAMMA_GRAD(bfloat);

--- a/aten/src/ATen/native/mps/kernels/Distributions.metal
+++ b/aten/src/ATen/native/mps/kernels/Distributions.metal
@@ -141,7 +141,7 @@ REGISTER_GAMMA(bfloat);
 // Computes -(d/dalpha cdf(x;alpha)) / pdf(x;alpha).
 // Adapted from aten/src/ATen/native/Distributions.h standard_gamma_grad_one().
 
-constant const float GAMMA_GRAD_COEF_UV[3][8] = {
+constant constexpr float GAMMA_GRAD_COEF_UV[3][8] = {
     {0.16009398f,
      -0.094634809f,
      0.025146376f,

--- a/aten/src/ATen/native/mps/operations/Distributions.mm
+++ b/aten/src/ATen/native/mps/operations/Distributions.mm
@@ -11,6 +11,8 @@
 #include <ATen/Functions.h>
 #include <ATen/NativeFunctions.h>
 #else
+#include <ATen/ops/_standard_gamma_grad_native.h>
+#include <ATen/ops/_standard_gamma_native.h>
 #include <ATen/ops/argmax.h>
 #include <ATen/ops/bernoulli_native.h>
 #include <ATen/ops/cauchy_native.h>
@@ -509,6 +511,75 @@ Tensor& geometric_mps_(Tensor& self, double p, std::optional<Generator> gen) {
   TORCH_CHECK(p > 0.0 && p < 1.0, "geometric_ expects p to be in (0, 1), but got p=", p);
   double log_one_minus_p = std::log1p(-p);
   return distribution_kernel_mps_impl(self, log_one_minus_p, 0.0, "geometric", 1, gen);
+}
+
+Tensor _s_gamma_mps(const Tensor& alpha, std::optional<Generator> gen) {
+  if (alpha.numel() == 0) {
+    return at::empty_like(alpha);
+  }
+
+  using namespace mps;
+
+  auto mps_gen = get_generator_or_default<MPSGeneratorImpl>(gen, at::mps::detail::getDefaultMPSGenerator());
+  auto stream = getCurrentMPSStream();
+  Tensor ret = at::empty_like(alpha);
+  const auto needs_copy = !alpha.is_contiguous();
+  auto alpha_contig = needs_copy ? alpha.contiguous() : alpha;
+
+  @autoreleasepool {
+    auto pso = lib.getPipelineStateForFunc("standard_gamma_" + scalarToMetalTypeString(ret));
+
+    int64_t seed;
+    int64_t base_offset;
+    // Each thread may consume up to GAMMA_RANDOMS_STRIDE random numbers
+    constexpr int64_t GAMMA_RANDOMS_STRIDE = 32;
+    {
+      // See Note [Acquire lock when using random generators]
+      std::lock_guard<std::mutex> lock(mps_gen->mutex_);
+      seed = static_cast<int64_t>(mps_gen->current_seed());
+      base_offset = static_cast<int64_t>(mps_gen->get_offset());
+      mps_gen->set_offset(base_offset + GAMMA_RANDOMS_STRIDE * ret.numel());
+    }
+
+    dispatch_sync_with_rethrow(stream->queue(), ^() {
+      @autoreleasepool {
+        auto computeEncoder = stream->commandEncoder();
+        [computeEncoder setComputePipelineState:pso];
+        mtl_setArgs(computeEncoder, ret, alpha_contig, std::array<long, 2>{seed, base_offset});
+        mtl_dispatch1DJob(computeEncoder, pso, ret.numel());
+      }
+    });
+  }
+
+  return ret;
+}
+
+Tensor _standard_gamma_grad_mps(const Tensor& self, const Tensor& output) {
+  if (self.numel() == 0) {
+    return at::empty_like(self);
+  }
+
+  using namespace mps;
+
+  auto stream = getCurrentMPSStream();
+  Tensor ret = at::empty_like(self);
+  const auto self_contig = self.is_contiguous() ? self : self.contiguous();
+  const auto output_contig = output.is_contiguous() ? output : output.contiguous();
+
+  @autoreleasepool {
+    auto pso = lib.getPipelineStateForFunc("standard_gamma_grad_" + scalarToMetalTypeString(ret));
+
+    dispatch_sync_with_rethrow(stream->queue(), ^() {
+      @autoreleasepool {
+        auto computeEncoder = stream->commandEncoder();
+        [computeEncoder setComputePipelineState:pso];
+        mtl_setArgs(computeEncoder, ret, self_contig, output_contig);
+        mtl_dispatch1DJob(computeEncoder, pso, ret.numel());
+      }
+    });
+  }
+
+  return ret;
 }
 
 Tensor& randperm_out_mps(int64_t n, std::optional<Generator> generator, Tensor& result) {

--- a/aten/src/ATen/native/mps/operations/Distributions.mm
+++ b/aten/src/ATen/native/mps/operations/Distributions.mm
@@ -522,9 +522,8 @@ Tensor _s_gamma_mps(const Tensor& alpha, std::optional<Generator> gen) {
 
   auto mps_gen = get_generator_or_default<MPSGeneratorImpl>(gen, at::mps::detail::getDefaultMPSGenerator());
   auto stream = getCurrentMPSStream();
-  Tensor ret = at::empty_like(alpha);
-  const auto needs_copy = !alpha.is_contiguous();
-  auto alpha_contig = needs_copy ? alpha.contiguous() : alpha;
+  Tensor ret = at::empty_like(alpha, alpha.options(), at::MemoryFormat::Contiguous);
+  auto alpha_contig = alpha.contiguous();
 
   @autoreleasepool {
     auto pso = lib.getPipelineStateForFunc("standard_gamma_" + scalarToMetalTypeString(ret));
@@ -562,9 +561,9 @@ Tensor _standard_gamma_grad_mps(const Tensor& self, const Tensor& output) {
   using namespace mps;
 
   auto stream = getCurrentMPSStream();
-  Tensor ret = at::empty_like(self);
-  const auto self_contig = self.is_contiguous() ? self : self.contiguous();
-  const auto output_contig = output.is_contiguous() ? output : output.contiguous();
+  Tensor ret = at::empty_like(self, self.options(), at::MemoryFormat::Contiguous);
+  const auto self_contig = self.contiguous();
+  const auto output_contig = output.contiguous();
 
   @autoreleasepool {
     auto pso = lib.getPipelineStateForFunc("standard_gamma_grad_" + scalarToMetalTypeString(ret));

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -6822,6 +6822,7 @@
   dispatch:
     CPU: _standard_gamma_grad_cpu
     CUDA: _standard_gamma_grad_cuda
+    MPS: _standard_gamma_grad_mps
   autogen: _standard_gamma_grad.out
 
 - func: _standard_gamma(Tensor self, Generator? generator=None) -> Tensor
@@ -6829,6 +6830,7 @@
   dispatch:
     CPU: _s_gamma_cpu
     CUDA: _s_gamma_cuda
+    MPS: _s_gamma_mps
   tags: nondeterministic_seeded
   autogen: _standard_gamma.out
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #179228

Implement `_standard_gamma` and `_standard_gamma_grad` for MPS

`_standard_gamma` uses the Marsaglia & Tsang (2000) acceptance-rejection method, ported from aten/src/ATen/native/Distributions.h which originates from NumPy's random module (Copyright 2005 Robert Kern). 
`_standard_gamma_grad` ports the three-region reparameterized gradient approximation (Taylor series, Rice saddle point, bivariate rational) from standard_gamma_grad_one in Distributions.h, reusing the existing c10::metal::digamma from special_math.h.

It was requested 10+ times on https://github.com/pytorch/pytorch/issues/141287

Implementation quality was validated using this script:

```python
"""Visual + statistical test for _standard_gamma on MPS vs CPU."""
import os
import torch
import numpy as np
from scipy import stats
import matplotlib.pyplot as plt

alphas = [0.1, 0.5, 1.0, 2.0, 5.0, 10.0, 50.0]
N = 100_000

fig, axes = plt.subplots(2, 4, figsize=(18, 8))
axes = axes.flatten()

print(f"{'alpha':>6} | {'CPU mean':>9} | {'MPS mean':>9} | {'CPU var':>9} | {'MPS var':>9} | {'KS p-val':>8}")
print("-" * 65)

for i, a in enumerate(alphas):
    alpha = torch.full((N,), a)
    torch.manual_seed(42)
    cpu = torch._standard_gamma(alpha).numpy()
    torch.manual_seed(42)
    mps = torch._standard_gamma(alpha.to("mps")).cpu().numpy()

    _, p = stats.ks_2samp(cpu, mps)
    print(f"{a:6.1f} | {cpu.mean():9.4f} | {mps.mean():9.4f} | {cpu.var():9.4f} | {mps.var():9.4f} | {p:8.5f}")

    ax = axes[i]
    clip = np.percentile(np.concatenate([cpu, mps]), 99)
    bins = np.linspace(0, clip, 60)
    ax.hist(cpu, bins=bins, alpha=0.5, density=True, label="CPU", color="steelblue")
    ax.hist(mps, bins=bins, alpha=0.5, density=True, label="MPS", color="coral")
    x = np.linspace(1e-6, clip, 200)
    ax.plot(x, stats.gamma.pdf(x, a), "k--", lw=1.5, label="Theory")
    ax.set_title(f"α = {a}")
    ax.legend(fontsize=8)

axes[-1].axis("off")

# Gradient test
print(f"\n{'alpha':>6} | {'max |diff|':>12} | {'mean |diff|':>12}")
print("-" * 40)
for a in [0.1, 0.5, 1.0, 5.0, 50.0]:
    alpha = torch.full((10_000,), a)
    torch.manual_seed(0)
    x = torch._standard_gamma(alpha)
    d = (torch._standard_gamma_grad(alpha, x) - torch._standard_gamma_grad(alpha.to("mps"), x.to("mps")).cpu()).abs()
    print(f"{a:6.1f} | {d.max().item():12.6e} | {d.mean().item():12.6e}")

plt.suptitle("Gamma Distribution: MPS vs CPU vs Theory", fontsize=14)
plt.tight_layout()
plt.savefig("gamma_mps_vs_cpu.png", dpi=150)
```

That yields following
<img width="2700" height="1200" alt="gamma_mps_vs_cpu" src="https://github.com/user-attachments/assets/19f9e83c-fb85-48b1-9bdf-2190f7694d72" />


Co-authored-by: Claude <noreply@anthropic.com>