### PR TITLE
[inductor] makes cuda 13.0 cross compliation works (#179229)

### DIFF
--- a/.ci/docker/build.sh
+++ b/.ci/docker/build.sh
@@ -112,6 +112,7 @@ case "$tag" in
     GCC_VERSION=11
     KATEX=yes
     TRITON=yes
+    INSTALL_MINGW=yes
     ;;
   pytorch-linux-jammy-cuda13.0-cudnn9-py3-gcc11-inductor-benchmarks)
     CUDA_VERSION=13.0.2

--- a/.ci/docker/common/install_mingw.sh
+++ b/.ci/docker/common/install_mingw.sh
@@ -4,7 +4,7 @@ set -ex
 
 # Install MinGW-w64 for Windows cross-compilation
 apt-get update
-apt-get install -y g++-mingw-w64-x86-64-posix
+apt-get install -y g++-mingw-w64-x86-64-posix mingw-w64-tools
 
 echo "MinGW-w64 installed successfully"
 x86_64-w64-mingw32-g++ --version

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -279,9 +279,20 @@ jobs:
             echo "Moved cudart.lib to win-torch-wheel-extracted/lib/x64/"
           fi
 
-          # Verify CUDA libraries are present
+          # Setup CUDA runtime DLL (needed for MinGW import lib generation on CUDA 13.0+)
+          mkdir -p win-torch-wheel-extracted/bin/x64
+          for dll in win-torch-wheel/cudart64_*.dll; do
+            if [ -f "$dll" ]; then
+              mv "$dll" win-torch-wheel-extracted/bin/x64/
+              echo "Moved $(basename $dll) to win-torch-wheel-extracted/bin/x64/"
+            fi
+          done
+
+          # Verify CUDA libraries and DLLs are present
           echo "CUDA libraries:"
           ls -la win-torch-wheel-extracted/lib/x64/ || echo "No CUDA libraries found"
+          echo "CUDA DLLs:"
+          ls -la win-torch-wheel-extracted/bin/x64/ || echo "No CUDA DLLs found"
 
       - name: Check for keep-going label and re-enabled test issues
         # This uses the filter-test-configs action because it conveniently
@@ -682,9 +693,20 @@ jobs:
             echo "Moved cudart.lib to win-torch-wheel-extracted/lib/x64/"
           fi
 
-          # Verify CUDA libraries are present
+          # Setup CUDA runtime DLL (needed for MinGW import lib generation on CUDA 13.0+)
+          mkdir -p win-torch-wheel-extracted/bin/x64
+          for dll in win-torch-wheel/cudart64_*.dll; do
+            if [ -f "$dll" ]; then
+              mv "$dll" win-torch-wheel-extracted/bin/x64/
+              echo "Moved $(basename $dll) to win-torch-wheel-extracted/bin/x64/"
+            fi
+          done
+
+          # Verify CUDA libraries and DLLs are present
           echo "CUDA libraries:"
           ls -la win-torch-wheel-extracted/lib/x64/ || echo "No CUDA libraries found"
+          echo "CUDA DLLs:"
+          ls -la win-torch-wheel-extracted/bin/x64/ || echo "No CUDA DLLs found"
 
       - name: Check for keep-going label and re-enabled test issues
         # This uses the filter-test-configs action because it conveniently

--- a/.github/workflows/_win-build.yml
+++ b/.github/workflows/_win-build.yml
@@ -193,9 +193,19 @@ jobs:
             cp "${CUDA_PATH}/lib/x64/cudart.lib" /c/${{ github.run_id }}/build-results/
           fi
 
+          # Copy CUDA runtime DLL (needed for MinGW import lib generation on CUDA 13.0+)
+          echo "Searching for CUDA runtime DLLs in ${CUDA_PATH}/bin/:"
+          ls -la "${CUDA_PATH}"/bin/cudart*.dll 2>/dev/null || echo "No cudart*.dll found in ${CUDA_PATH}/bin/"
+          for dll in "${CUDA_PATH}"/bin/cudart64_*.dll "${CUDA_PATH}"/bin/cudart.dll; do
+            if [ -f "$dll" ]; then
+              cp "$dll" /c/${{ github.run_id }}/build-results/
+              echo "Copied $(basename $dll)"
+            fi
+          done
+
           # List collected files
-          echo "Collected CUDA libs:"
-          ls -lah /c/${{ github.run_id }}/build-results/*.lib
+          echo "Collected CUDA libs and DLLs:"
+          ls -lah /c/${{ github.run_id }}/build-results/*.lib /c/${{ github.run_id }}/build-results/*.dll 2>/dev/null || true
 
       # Upload to github so that people can click and download artifacts
       - name: Upload artifacts to s3

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -81,7 +81,7 @@ jobs:
     secrets: inherit
 
   linux-jammy-cuda12_8-py3_10-gcc11-build:
-    if: ${{ needs.job-filter.outputs.jobs == '' || contains(needs.job-filter.outputs.jobs, ' linux-jammy-cuda12.8-py3.10-gcc11 ') || contains(needs.job-filter.outputs.jobs, ' cross-compile-linux-test ') }}
+    if: ${{ needs.job-filter.outputs.jobs == '' || contains(needs.job-filter.outputs.jobs, ' linux-jammy-cuda12.8-py3.10-gcc11 ') }}
     name: linux-jammy-cuda12.8-py3.10-gcc11
     uses: ./.github/workflows/_linux-build.yml
     needs:
@@ -112,7 +112,7 @@ jobs:
   # See P2188981399 for the full CI workflow analysis.
 
   linux-jammy-cuda13_0-py3_10-gcc11-build:
-    if: ${{ needs.job-filter.outputs.jobs == '' || contains(needs.job-filter.outputs.jobs, ' linux-jammy-cuda13.0-py3.10-gcc11 ') }}
+    if: ${{ needs.job-filter.outputs.jobs == '' || contains(needs.job-filter.outputs.jobs, ' linux-jammy-cuda13.0-py3.10-gcc11 ') || contains(needs.job-filter.outputs.jobs, ' cross-compile-linux-test-cuda13 ') }}
     name: linux-jammy-cuda13.0-py3.10-gcc11
     uses: ./.github/workflows/_linux-build.yml
     needs:
@@ -248,16 +248,17 @@ jobs:
       disable-monitor: false
     secrets: inherit
 
-  win-vs2022-cuda12_8-py3-build:
-    if: ${{ needs.job-filter.outputs.jobs == '' || contains(needs.job-filter.outputs.jobs, ' win-vs2022-cuda12.8-py3 ') || contains(needs.job-filter.outputs.jobs, ' cross-compile-linux-test ') }}
-    name: win-vs2022-cuda12.8-py3
+
+  win-vs2022-cuda13_0-py3-build:
+    if: ${{ needs.job-filter.outputs.jobs == '' || contains(needs.job-filter.outputs.jobs, ' win-vs2022-cuda13.0-py3 ') || contains(needs.job-filter.outputs.jobs, ' cross-compile-linux-test-cuda13 ') }}
+    name: win-vs2022-cuda13.0-py3
     uses: ./.github/workflows/_win-build.yml
     needs:
       - get-label-type
       - job-filter
     with:
-      build-environment: win-vs2022-cuda12.8-py3
-      cuda-version: "12.8"
+      build-environment: win-vs2022-cuda13.0-py3
+      cuda-version: "13.0"
       runner: "${{ needs.get-label-type.outputs.label-type }}windows.4xlarge.nonephemeral"
     secrets: inherit
 
@@ -313,22 +314,23 @@ jobs:
       cuda-arch-list: '8.0'
     secrets: inherit
 
-  # Test cross-compiled models with Windows libs extracted from wheel
-  cross-compile-linux-test:
-    if: ${{ needs.job-filter.outputs.jobs == '' || contains(needs.job-filter.outputs.jobs, ' cross-compile-linux-test ') }}
-    name: cross-compile-linux-test
+
+  # Test cross-compiled models with Windows libs extracted from wheel (CUDA 13.0)
+  cross-compile-linux-test-cuda13:
+    if: ${{ needs.job-filter.outputs.jobs == '' || contains(needs.job-filter.outputs.jobs, ' cross-compile-linux-test-cuda13 ') }}
+    name: cross-compile-linux-test-cuda13
     uses: ./.github/workflows/_linux-test.yml
     needs:
-      - linux-jammy-cuda12_8-py3_10-gcc11-build
+      - linux-jammy-cuda13_0-py3_10-gcc11-build
       - get-label-type
-      - win-vs2022-cuda12_8-py3-build
+      - win-vs2022-cuda13_0-py3-build
       - job-filter
     with:
-      build-environment: ${{ needs.linux-jammy-cuda12_8-py3_10-gcc11-build.outputs.build-environment }}
-      docker-image: ${{ needs.linux-jammy-cuda12_8-py3_10-gcc11-build.outputs.docker-image }}
+      build-environment: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-build.outputs.build-environment }}
+      docker-image: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-build.outputs.docker-image }}
       test-matrix: |
         { include: [
-          { config: "aoti_cross_compile_for_windows", shard: 1, num_shards: 1, runner: "${{ needs.get-label-type.outputs.label-type }}linux.g6.4xlarge.experimental.nvidia.gpu", win_torch_wheel_artifact: "win-vs2022-cuda12.8-py3" },
+          { config: "aoti_cross_compile_for_windows", shard: 1, num_shards: 1, runner: "${{ needs.get-label-type.outputs.label-type }}linux.g6.4xlarge.experimental.nvidia.gpu", win_torch_wheel_artifact: "win-vs2022-cuda13.0-py3" },
         ]}
       tests-to-include: ${{ github.event.inputs.tests-to-include || '' }}
     secrets: inherit

--- a/test/inductor/test_aoti_cross_compile_windows.py
+++ b/test/inductor/test_aoti_cross_compile_windows.py
@@ -1,15 +1,18 @@
 # Owner(s): ["module: inductor"]
 import os
 import platform
+import shutil
 import tempfile
 import unittest
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+from unittest.mock import MagicMock, patch
 
 import torch
 import torch._inductor.config
 from torch._environment import is_fbcode
+from torch._inductor.cpp_builder import _ensure_mingw_cudart_import_lib
 from torch._inductor.test_case import TestCase
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU, requires_gpu
 
@@ -316,6 +319,137 @@ class TestAOTInductorWindowsCrossCompilation(TestCase):
             rtol=1e-3,
             atol=1e-3,
         )
+
+
+class TestEnsureMingwCudartImportLib(TestCase):
+    """Unit tests for _ensure_mingw_cudart_import_lib."""
+
+    def setUp(self):
+        super().setUp()
+        self.tmp_dir = tempfile.mkdtemp(prefix="test_mingw_cudart_")
+        self.cuda_home = os.path.join(self.tmp_dir, "cuda")
+        self.lib_dir = os.path.join(self.tmp_dir, "lib")
+        os.makedirs(os.path.join(self.cuda_home, "bin", "x64"), exist_ok=True)
+        os.makedirs(self.lib_dir, exist_ok=True)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp_dir, ignore_errors=True)
+        super().tearDown()
+
+    def _create_fake_dll(self, version: str = "130") -> str:
+        dll_path = os.path.join(self.cuda_home, "bin", "x64", f"cudart64_{version}.dll")
+        Path(dll_path).touch()
+        return dll_path
+
+    def _create_fake_cudart_lib(self) -> str:
+        lib_path = os.path.join(self.lib_dir, "cudart.lib")
+        Path(lib_path).touch()
+        return lib_path
+
+    def test_noop_when_no_windows_cuda_home(self):
+        """Should skip gracefully when WINDOWS_CUDA_HOME is not set."""
+        env = os.environ.copy()
+        env.pop("WINDOWS_CUDA_HOME", None)
+        with patch.dict(os.environ, env, clear=True):
+            result = _ensure_mingw_cudart_import_lib([self.lib_dir])
+        self.assertEqual(result, [])
+        self.assertFalse(os.path.exists(os.path.join(self.lib_dir, "libcudart.a")))
+
+    def test_noop_when_libcudart_a_already_exists(self):
+        """Should skip generation if libcudart.a already exists."""
+        existing = os.path.join(self.lib_dir, "libcudart.a")
+        Path(existing).touch()
+        with patch.dict(os.environ, {"WINDOWS_CUDA_HOME": self.cuda_home}):
+            result = _ensure_mingw_cudart_import_lib([self.lib_dir])
+        self.assertEqual(result, [])
+        self.assertTrue(os.path.exists(existing))
+
+    @patch("torch._inductor.cpp_builder._create_msvc_gs_stubs_lib", return_value=None)
+    def test_gs_stubs_fallback_when_no_dll_found(self, mock_stubs):
+        """Should attempt GS stubs fallback when no cudart64_*.dll is found."""
+        self._create_fake_cudart_lib()
+        with patch.dict(os.environ, {"WINDOWS_CUDA_HOME": self.cuda_home}):
+            _ensure_mingw_cudart_import_lib([self.lib_dir])
+        mock_stubs.assert_called_once_with(self.lib_dir)
+
+    @patch(
+        "torch._inductor.cpp_builder._create_msvc_gs_stubs_lib",
+        return_value="msvc_gs_stubs",
+    )
+    def test_gs_stubs_returned_when_no_dll(self, mock_stubs):
+        """Should return the stubs library name when DLL is unavailable."""
+        self._create_fake_cudart_lib()
+        with patch.dict(os.environ, {"WINDOWS_CUDA_HOME": self.cuda_home}):
+            result = _ensure_mingw_cudart_import_lib([self.lib_dir])
+        self.assertEqual(result, ["msvc_gs_stubs"])
+
+    def test_noop_when_no_writable_dir_with_cudart_lib(self):
+        """Should skip gracefully when no writable directory contains cudart.lib."""
+        self._create_fake_dll()
+        with patch.dict(os.environ, {"WINDOWS_CUDA_HOME": self.cuda_home}):
+            result = _ensure_mingw_cudart_import_lib([self.lib_dir])
+        self.assertEqual(result, [])
+        self.assertFalse(os.path.exists(os.path.join(self.lib_dir, "libcudart.a")))
+
+    @patch("subprocess.run")
+    def test_successful_generation(self, mock_run: MagicMock):
+        """Should call gendef and dlltool when all conditions are met."""
+        dll_path = self._create_fake_dll()
+        self._create_fake_cudart_lib()
+
+        with patch.dict(os.environ, {"WINDOWS_CUDA_HOME": self.cuda_home}):
+            result = _ensure_mingw_cudart_import_lib([self.lib_dir])
+
+        self.assertEqual(result, [])
+        self.assertEqual(mock_run.call_count, 2)
+
+        # Verify gendef call
+        gendef_call = mock_run.call_args_list[0]
+        gendef_cmd = gendef_call[0][0]
+        self.assertEqual(gendef_cmd[0], "gendef")
+        self.assertEqual(gendef_cmd[1], "-")
+        self.assertEqual(gendef_cmd[2], dll_path)
+
+        # Verify dlltool call
+        dlltool_call = mock_run.call_args_list[1]
+        dlltool_cmd = dlltool_call[0][0]
+        self.assertEqual(dlltool_cmd[0], "x86_64-w64-mingw32-dlltool")
+        self.assertIn("-d", dlltool_cmd)
+        self.assertIn("-l", dlltool_cmd)
+        self.assertIn("-D", dlltool_cmd)
+        self.assertIn("cudart64_130.dll", dlltool_cmd)
+
+    @patch(
+        "torch._inductor.cpp_builder._create_msvc_gs_stubs_lib",
+        return_value="msvc_gs_stubs",
+    )
+    @patch("subprocess.run", side_effect=FileNotFoundError("gendef not found"))
+    def test_gs_stubs_fallback_on_gendef_not_found(self, mock_run, mock_stubs):
+        """Should fall back to GS stubs when gendef is not installed."""
+        self._create_fake_dll()
+        self._create_fake_cudart_lib()
+
+        with patch.dict(os.environ, {"WINDOWS_CUDA_HOME": self.cuda_home}):
+            result = _ensure_mingw_cudart_import_lib([self.lib_dir])
+
+        self.assertEqual(result, ["msvc_gs_stubs"])
+        mock_stubs.assert_called_once()
+
+    @patch("subprocess.run")
+    def test_bin_x64_fallback_to_bin(self, mock_run: MagicMock):
+        """Should fall back to bin/ when bin/x64/ does not exist."""
+        shutil.rmtree(os.path.join(self.cuda_home, "bin", "x64"))
+        bin_dir = os.path.join(self.cuda_home, "bin")
+        dll_path = os.path.join(bin_dir, "cudart64_130.dll")
+        Path(dll_path).touch()
+        self._create_fake_cudart_lib()
+
+        with patch.dict(os.environ, {"WINDOWS_CUDA_HOME": self.cuda_home}):
+            _ensure_mingw_cudart_import_lib([self.lib_dir])
+
+        self.assertEqual(mock_run.call_count, 2)
+        gendef_cmd = mock_run.call_args_list[0][0][0]
+        self.assertIn(dll_path, gendef_cmd)
 
 
 if __name__ == "__main__":

--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -1700,6 +1700,183 @@ def _find_libcudart_static(path: str) -> Path | None:
     return None
 
 
+def _gen_mingw_import_lib(dll_path: str, def_path: str, import_lib_path: str) -> None:
+    """Generate a MinGW import library (.a) from a DLL using gendef and dlltool."""
+    dll_name = os.path.basename(dll_path)
+    with open(def_path, "w") as def_file:
+        subprocess.run(
+            ["gendef", "-", dll_path],
+            stdout=def_file,
+            stderr=subprocess.PIPE,
+            check=True,
+        )
+
+    subprocess.run(
+        [
+            "x86_64-w64-mingw32-dlltool",
+            "-d",
+            def_path,
+            "-l",
+            import_lib_path,
+            "-D",
+            dll_name,
+        ],
+        stderr=subprocess.PIPE,
+        check=True,
+    )
+    log.info("Generated MinGW import library %s from %s", import_lib_path, dll_name)
+
+
+# MSVC /GS buffer security check stubs for MinGW cross-compilation.
+# CUDA 13.0+ cudart.lib contains MSVC-compiled static objects that reference
+# these symbols (__security_cookie, __security_check_cookie, __GSHandlerCheck).
+# When cross-compiling with MinGW, we provide no-op stubs so the linker can
+# resolve them. At runtime on Windows, the CUDA runtime DLL handles its own
+# security checks internally; the static loader code that references these
+# symbols is a thin shim whose /GS instrumentation is safe to stub out.
+_MSVC_GS_STUBS_SOURCE = """\
+#include <stdint.h>
+uint64_t __security_cookie = 0x00002B992DDFA232ULL;
+void __security_check_cookie(uint64_t cookie) { (void)cookie; }
+void __GSHandlerCheck(void) {}
+"""
+
+
+def _create_msvc_gs_stubs_lib(output_dir: str) -> str | None:
+    """
+    Create a static library with MSVC GS security symbol stubs for MinGW.
+
+    Returns the library name (without lib prefix / .a suffix) if successful,
+    or None on failure.
+    """
+    stubs_lib = os.path.join(output_dir, "libmsvc_gs_stubs.a")
+    if os.path.exists(stubs_lib):
+        return "msvc_gs_stubs"
+
+    src_path = ""
+    obj_path = ""
+    try:
+        src_path = os.path.join(output_dir, "_msvc_gs_stubs.c")
+        obj_path = os.path.join(output_dir, "_msvc_gs_stubs.o")
+        with open(src_path, "w") as f:
+            f.write(_MSVC_GS_STUBS_SOURCE)
+
+        mingw_gcc = MINGW_GXX.replace("g++", "gcc")
+        subprocess.run(
+            [mingw_gcc, "-c", src_path, "-o", obj_path],
+            stderr=subprocess.PIPE,
+            check=True,
+        )
+        mingw_ar = MINGW_GXX.replace("g++", "ar")
+        subprocess.run(
+            [mingw_ar, "rcs", stubs_lib, obj_path],
+            stderr=subprocess.PIPE,
+            check=True,
+        )
+        log.info("Created MSVC GS stubs library: %s", stubs_lib)
+        return "msvc_gs_stubs"
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        log.warning(
+            "Failed to create MSVC GS stubs library.",
+            exc_info=True,
+        )
+        if os.path.exists(stubs_lib):
+            os.remove(stubs_lib)
+        return None
+    finally:
+        for f in [src_path, obj_path]:
+            if f and os.path.exists(f):
+                os.remove(f)
+
+
+def _ensure_mingw_cudart_import_lib(libraries_dirs: list[str]) -> list[str]:
+    """
+    Auto-generate a MinGW-compatible import library (libcudart.a)
+    from the CUDA runtime DLL. This avoids linking against the hybrid cudart.lib
+    which contains MSVC-compiled static objects with /GS security symbols that
+    MinGW cannot resolve.
+
+    Falls back to creating MSVC GS security stubs if the DLL is unavailable,
+    and falls back gracefully to the original cudart.lib if that also fails.
+
+    Returns a list of extra library names to link (e.g. ["msvc_gs_stubs"]).
+    """
+    import glob
+
+    windows_cuda_home = os.environ.get("WINDOWS_CUDA_HOME")
+    if not windows_cuda_home:
+        log.debug(
+            "WINDOWS_CUDA_HOME not set, skipping MinGW cudart import lib generation"
+        )
+        return []
+
+    for lib_dir in libraries_dirs:
+        if os.path.exists(os.path.join(lib_dir, "libcudart.a")):
+            log.debug("libcudart.a already exists in %s, skipping generation", lib_dir)
+            return []
+
+    # Find the CUDA runtime DLL for import lib generation
+    bin_dir = os.path.join(windows_cuda_home, "bin", "x64")
+    if not os.path.isdir(bin_dir):
+        bin_dir = os.path.join(windows_cuda_home, "bin")
+    dll_candidates = glob.glob(os.path.join(bin_dir, "cudart64_*.dll"))
+
+    # Find a writable directory containing cudart.lib for output
+    output_dir = None
+    for lib_dir in libraries_dirs:
+        if os.path.isdir(lib_dir) and os.access(lib_dir, os.W_OK):
+            if os.path.exists(os.path.join(lib_dir, "cudart.lib")):
+                output_dir = lib_dir
+                break
+
+    if not dll_candidates:
+        log.warning(
+            "No cudart64_*.dll found in %s. Cannot generate MinGW import library. "
+            "Will create MSVC GS security stubs as fallback.",
+            bin_dir,
+        )
+        # Fallback: create GS stubs so the hybrid cudart.lib can link
+        if output_dir is not None:
+            stub_lib = _create_msvc_gs_stubs_lib(output_dir)
+            if stub_lib:
+                return [stub_lib]
+        return []
+
+    if output_dir is None:
+        log.warning(
+            "No writable directory containing cudart.lib found. "
+            "Cannot generate MinGW import library. "
+            "If linking fails with undefined references to __security_cookie, "
+            "ensure cudart.lib is present in one of: %s",
+            libraries_dirs,
+        )
+        return []
+
+    dll_path = dll_candidates[0]
+    dll_name = os.path.basename(dll_path)
+
+    def_path = os.path.join(output_dir, dll_name.replace(".dll", ".def"))
+    import_lib_path = os.path.join(output_dir, "libcudart.a")
+
+    try:
+        _gen_mingw_import_lib(dll_path, def_path, import_lib_path)
+        return []
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        log.warning(
+            "Failed to generate MinGW cudart import library. "
+            "Falling back to MSVC GS stubs.",
+            exc_info=True,
+        )
+        for f in [def_path, import_lib_path]:
+            if os.path.exists(f):
+                os.remove(f)
+        # Fallback: create GS stubs
+        stub_lib = _create_msvc_gs_stubs_lib(output_dir)
+        if stub_lib:
+            return [stub_lib]
+        return []
+
+
 def _transform_cuda_paths(lpaths: list[str]) -> None:
     # This handles two cases:
     # 1. Cases where libs are in (e.g.) lib/cuda-12 and lib/cuda-12/stubs
@@ -1768,7 +1945,8 @@ def get_cpp_torch_device_options(
             else:
                 libraries += ["cuda", "torch_cuda"]
             if config.aot_inductor.cross_target_platform == "windows":
-                libraries += ["cudart"]
+                extra_libs = _ensure_mingw_cudart_import_lib(libraries_dirs)
+                libraries += ["cudart"] + extra_libs
             _transform_cuda_paths(libraries_dirs)
 
     if device_type == "xpu":


### PR DESCRIPTION
Summary:

CUDA 13.0+ ships a hybrid cudart.lib that contains MSVC-compiled static objects referencing
GS security symbols (__security_cookie, __security_check_cookie, etc.) which MinGW cannot resolve, causing undefined reference errors during Windows cross-compilation.

This diff adds a _ensure_mingw_cudart_import_lib() function to cpp_builder.py that automatically generates a pure MinGW-compatible import library (libcudart.a) from the CUDA runtime DLL using gendef + x86_64-w64-mingw32-dlltool.

If WINDOWS_CUDA_HOME is not set or libcudart.a already exists, no action is taken.
Locates cudart64_*.dll in the CUDA bin directory, generates a .def file via gendef, and creates libcudart.a via dlltool.
Falls back gracefully to the original cudart.lib if gendef/dlltool are unavailable or fail to support lower version like 12.6.

Test Plan: ci

Differential Revision: D99398736




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo