### PR TITLE
[Inductor] Add _debug_assert_fused option to foreach_map

### DIFF
--- a/test/inductor/test_foreach.py
+++ b/test/inductor/test_foreach.py
@@ -276,6 +276,51 @@ class ForeachTests(TestCase):
     def test_foreach_cpp_wrapper_cuda(self):
         self._test_single_list(op=torch._foreach_add)
 
+    @requires_gpu
+    def test_foreach_map_debug_assert_fused_happy_basic(self):
+        def fn(xs):
+            return torch._higher_order_ops.foreach_map(
+                torch.add, xs, 1.0, _debug_assert_fused=True
+            )
+
+        xs = [
+            torch.rand(10, 10, device=GPU_TYPE),
+            torch.rand(10, 10, device=GPU_TYPE),
+        ]
+
+        self.check_model_gpu(fn, (xs,))
+
+    @requires_gpu
+    def test_foreach_map_debug_assert_fused_raises(self):
+        def body(x):
+            return torch.mm(x, x)
+
+        def fn(xs):
+            return torch._higher_order_ops.foreach_map(
+                body, xs, _debug_assert_fused=True
+            )
+
+        xs = [torch.rand(10, 10, device=GPU_TYPE)]
+
+        with self.assertRaisesRegex(Exception, "_debug_assert_fused"):
+            self.check_model_gpu(fn, (xs,))
+
+    @requires_gpu
+    def test_foreach_map_debug_assert_fused_disabled(self):
+        def body(x):
+            return torch.mm(x, x)
+
+        def fn(xs):
+            return torch._higher_order_ops.foreach_map(body, xs)
+
+        xs = [torch.randn(10, 10, device=GPU_TYPE)]
+
+        with self.assertRaisesRegex(
+            Exception,
+            "Buffers cannot be created while lowering a pointwise subgraph",
+        ):
+            self.check_model_gpu(fn, (xs,))
+
     # called in test_gpu_cpp_wrapper.py
     test_foreach_cpp_wrapper_xpu = test_foreach_cpp_wrapper_cuda
 

--- a/torch/_higher_order_ops/foreach_map.py
+++ b/torch/_higher_order_ops/foreach_map.py
@@ -18,7 +18,14 @@ class ForeachMap(BaseHOP):
 _foreach_map = ForeachMap()
 
 
-def foreach_map(op: Callable, *operands: Any, **kwargs: dict[str, Any]):
+def foreach_map(
+    op: Callable,
+    *operands: Any,
+    _debug_assert_fused: bool = False,
+    **kwargs: dict[str, Any],
+):
     from torch._dynamo.polyfills import foreach_map_fn
 
-    return _foreach_map(foreach_map_fn, op, *operands, **kwargs)
+    return _foreach_map(
+        foreach_map_fn, op, *operands, _debug_assert_fused=_debug_assert_fused, **kwargs
+    )

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -1015,6 +1015,25 @@ def _float8_e8m0fnu_to_dtype(x: TensorBox, dtype: torch.dtype) -> TensorBox:
     return make_pointwise(_to_float, override_return_dtype=dtype)(x_u8)
 
 
+def _unwrap_tensorbox_to_irnode(x):
+    if isinstance(x, TensorBox):
+        x = x.data
+    if isinstance(x, ir.BaseView):
+        x = x.unwrap_view()
+    if isinstance(x, ir.StorageBox):
+        x = x.data
+    return x
+
+
+def _is_single_realized_tensor_output(x):
+    node = _unwrap_tensorbox_to_irnode(x)
+    return (
+        isinstance(node, ir.IRNode)
+        and node.has_tensor_output()
+        and ir.IRNode.is_realized_node(node)
+    )
+
+
 @register_lowering(torch._higher_order_ops._foreach_map, type_promotion_kind=None)
 def _foreach_map(subgraph, *args, **kwargs):
     """
@@ -1026,14 +1045,25 @@ def _foreach_map(subgraph, *args, **kwargs):
     The graph outputs represent the vertically fused sequence of ops, and then register_operation_list
     below registers the buffers as horizontally fuseable in the scheduler.
     """
-    from .subgraph_lowering import PointwiseSubgraphLowering
+    from .subgraph_lowering import PointwiseSubgraphLowering, SubgraphLoweringException
+
+    debug_assert_fused = kwargs.pop("_debug_assert_fused", False)
+    assert not kwargs, (
+        f"unexpected kwargs to foreach_map lowering: {list(kwargs.keys())}"
+    )
 
     inputs = args
-
     gm = subgraph.graph_module
-    pw_subgraph = PointwiseSubgraphLowering(gm, root_graph_lowering=V.graph)
-    with V.set_graph_handler(pw_subgraph):  # type: ignore[arg-type]
-        pw_subgraph.run(*inputs)
+    try:
+        pw_subgraph = PointwiseSubgraphLowering(gm, root_graph_lowering=V.graph)
+        with V.set_graph_handler(pw_subgraph):  # type: ignore[arg-type]
+            pw_subgraph.run(*inputs)
+    except SubgraphLoweringException as e:
+        if debug_assert_fused:
+            raise RuntimeError(
+                f"Failed to lower foreach_map with _debug_assert_fused=True: {e}"
+            ) from e
+        raise
 
     sub_outputs = pw_subgraph.graph_outputs
     # group outputs by device and register as foreach
@@ -1043,6 +1073,18 @@ def _foreach_map(subgraph, *args, **kwargs):
 
     outputs = [None] * len(sub_outputs)
     for (device, use_foreach), group in groups.items():
+        if debug_assert_fused:
+            if not use_foreach:
+                raise RuntimeError(
+                    f"foreach_map _debug_assert_fused=True failed: "
+                    f"outputs on device {device} are not eligible for foreach fusion "
+                    f"because use_foreach=False"
+                )
+            if not V.graph.has_feature(device, BackendFeature.FOREACH):
+                raise RuntimeError(
+                    f"foreach_map _debug_assert_fused=True failed: "
+                    f"device {device} does not support foreach"
+                )
         operation_list: list[str] = []
         for (
             output_ind,
@@ -1052,6 +1094,11 @@ def _foreach_map(subgraph, *args, **kwargs):
 
             if V.graph.has_feature(device, BackendFeature.FOREACH) and use_foreach:
                 output.realize()
+                if debug_assert_fused and not _is_single_realized_tensor_output(output):
+                    raise RuntimeError(
+                        f"foreach_map _debug_assert_fused=True failed: "
+                        f"output {output_ind} did not realize to a single tensor IR node"
+                    )
                 operation_list.append(output.get_operation_name())
 
         if operation_list:


### PR DESCRIPTION
## Summary

Fixes #158970.
Part of #158968.

Add an `_debug_assert_fused` option to `torch._higher_order_ops.foreach_map`.

When `_debug_assert_fused=True`, `foreach_map` now errors in lowering if the
subgraph cannot remain on the foreach fused path.

When `_debug_assert_fused=False`, behavior is unchanged.

This change also adds tests for:
- a basic happy path
- the `_debug_assert_fused=True` failure path
- preserving the default behavior when `_debug_assert_fused` is not enabled

## Reviewer notes

This PR is intended to be a narrow implementation of #158970.

Things to check:
- Is `_debug_assert_fused` the right internal/debug-only API name?
- Is the behavior unchanged when `_debug_assert_fused=False`?
- Are the failure conditions in lowering the right places to assert that foreach_map stayed on the fused path?
- Are the tests sufficient, or should I add a case matching the previous unlanded PR more closely?

## Test Plan

```bash
python -m pytest test/inductor/test_foreach.py -k "_debug_assert_fused or input_mutation" -v
python -m pytest test/inductor/test_foreach.py -k foreach_map -v

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo