### PR TITLE
[AOTI][XPU] Support lazy Triton kernel compilation for cpp-wrapper on XPU

### DIFF
--- a/torch/_inductor/codegen/cpp_wrapper_gpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_gpu.py
@@ -463,7 +463,12 @@ class DeferredTritonCallWrapper:
         )
         call_args_str = self._generate_lazy_scratch(prefix, wrapper, call_args_str)
 
-        launch_args = f"{kernel_name}, grid_0, grid_1, grid_2, {kernel_name}_result.num_warps, {kernel_name}_result.shared_mem, kernel_args_, stream_"
+        launch_args = (
+            f"{kernel_name}, grid_0, grid_1, grid_2,"
+            f" {kernel_name}_result.num_warps,"
+            f" {kernel_name}_result.shared_mem,"
+            f" kernel_args_, stream_"
+        )
 
         prefix.splice(
             f"""\

--- a/torch/_inductor/codegen/cpp_wrapper_gpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_gpu.py
@@ -394,12 +394,13 @@ class DeferredTritonCallWrapper:
         device_type, _ = wrapper.codegen_device(torch.device(get_gpu_type())).split(
             ", "
         )
+        device_ptr_type = wrapper.device_codegen.cpp_device_ptr()
         for scratch_name in ("global_scratch", "profile_scratch"):
             size_expr = f"{kernel_name}_result.{scratch_name}"
             var = f"{scratch_name}_ptr"
             prefix.splice(
                 f"""\
-                CUdeviceptr {var} = 0;
+                {device_ptr_type} {var} = 0;
                 RAIIAtenTensorHandle {var}_tensor;
                 if ({size_expr} > 0) {{
                     int64_t {var}_size[] = {{{size_expr}}};
@@ -409,7 +410,7 @@ class DeferredTritonCallWrapper:
                         1, {var}_size, {var}_stride, {dtype_str},
                         {device_type}, device_idx_, &{var}_handle));
                     {var}_tensor = RAIIAtenTensorHandle({var}_handle);
-                    {var} = reinterpret_cast<CUdeviceptr>({var}_tensor.data_ptr());
+                    {var} = reinterpret_cast<{device_ptr_type}>({var}_tensor.data_ptr());
                 }}
             """
             )
@@ -462,11 +463,12 @@ class DeferredTritonCallWrapper:
         )
         call_args_str = self._generate_lazy_scratch(prefix, wrapper, call_args_str)
 
+        launch_args = f"{kernel_name}, grid_0, grid_1, grid_2, {kernel_name}_result.num_warps, {kernel_name}_result.shared_mem, kernel_args_, stream_"
+
         prefix.splice(
             f"""\
             void* kernel_args_[] = {{{call_args_str}}};
-            launchKernel({kernel_name}, grid_0, grid_1, grid_2,
-                {kernel_name}_result.num_warps, {kernel_name}_result.shared_mem, kernel_args_, stream_);
+            launchKernel({launch_args});
             """
         )
 
@@ -655,8 +657,6 @@ class DeferredTritonCallWrapper:
             "kernel_args_",
             "stream_",
         ]
-        if wrapper.device == "xpu":
-            launch_kernel_args.append(str(params["threads_per_warp"]))
 
         enable_kernel_profile = config.cpp.enable_kernel_profile and sys.platform in [
             "linux",

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -1327,14 +1327,6 @@ class CachingAutotuner(KernelInterface):
             "global_scratch": launcher.global_scratch,
             "profile_scratch": launcher.profile_scratch,
         }
-        if self.device_props.type == "xpu":
-            # On the XPU backend, threads_per_warp is not always 32.
-            # For Intel GEMM Triton kernels, it can be 16.
-            # This information must be preserved so that the Cpp wrapper
-            # can launch the kernel with the correct configuration.
-            params["threads_per_warp"] = getattr(
-                launcher.bin.metadata, "threads_per_warp", 32
-            )
 
         from torch._inductor import config
         from torch._inductor.codecache import CudaKernelParamCache

--- a/torch/csrc/inductor/aoti_runtime/sycl_runtime_wrappers.h
+++ b/torch/csrc/inductor/aoti_runtime/sycl_runtime_wrappers.h
@@ -134,8 +134,13 @@ static std::unique_ptr<sycl::kernel> _createKernel(
     uint32_t numWarps,
     uint32_t sharedMemory,
     void** params,
-    sycl::queue* queuePtr,
-    uint32_t threadsPerWarp) {
+    sycl::queue* queuePtr) {
+  uint32_t threadsPerWarp = kernelPtr->get_info<
+      sycl::info::kernel_device_specific::compile_sub_group_size>(
+      queuePtr->get_device());
+  if (threadsPerWarp == 0) {
+    threadsPerWarp = 32; // default to 32 if not set
+  }
   std::string kernelName =
       kernelPtr->get_info<sycl::info::kernel::function_name>();
   uint32_t numParams = kernelPtr->get_info<sycl::info::kernel::num_args>();

--- a/torch/csrc/inductor/cpp_wrapper/lazy_triton_compile.h
+++ b/torch/csrc/inductor/cpp_wrapper/lazy_triton_compile.h
@@ -4,7 +4,11 @@
 
 #include <torch/csrc/inductor/aoti_torch/utils.h>
 #include <torch/csrc/inductor/cpp_wrapper/common.h>
+#if defined(USE_XPU)
+#include <torch/csrc/inductor/cpp_wrapper/device_internal/xpu.h>
+#else
 #include <torch/csrc/inductor/cpp_wrapper/device_internal/cuda.h>
+#endif
 
 struct LazyKernelCompileResult {
   std::string cubin_path;
@@ -144,7 +148,7 @@ template <typename... Args>
 static inline LazyKernelCompileResult runTritonKernelWithAutotune(
     PyObject* pending_kernels,
     const std::string& kernel_name,
-    cudaStream_t stream,
+    void* stream,
     const Args&... kernel_args) {
   py::gil_scoped_acquire_simple acquire;
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #179239

The lazy Triton kernel compilation feature (#175416) introduced
CUDA-specific assumptions that broke XPU cpp-wrapper codegen.

Fix the XPU incompatibilities:
- lazy_triton_compile.h: conditional include for XPU vs CUDA device
  headers; change runTritonKernelWithAutotune stream param from
  cudaStream_t to void* (both pointer types convert implicitly)
- cpp_wrapper_gpu.py: use device-appropriate pointer type for scratch
  allocations instead of hardcoded CUdeviceptr
- sycl_runtime_wrappers.h: query threads_per_warp from the kernel
  object via compile_sub_group_size instead of requiring it as an
  external parameter.
- Remove threads_per_warp plumbing from triton_heuristics.py and
  cpp_wrapper_gpu.py codegen since it is no longer needed

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo