### PR TITLE
[pytorch] enable frame pointers in aoti_inductor wrappers.so (#179240)

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1949,6 +1949,11 @@ class aot_inductor:
     debug_compile = os.environ.get("AOT_INDUCTOR_DEBUG_COMPILE", "0") == "1"
     debug_symbols = os.environ.get("AOT_INDUCTOR_DEBUG_SYMBOLS", "0") == "1"
 
+    # Enable frame pointers for profiling tools (e.g. strobelight)
+    enable_frame_pointer = (
+        os.environ.get("AOT_INDUCTOR_ENABLE_FRAME_POINTER", "0") == "1"
+    )
+
     # Annotate generated main wrapper function, i.e. AOTInductorModel::run_impl,
     # to use which cpp compiler optimization level, default to O1
     compile_wrapper_opt_level = os.environ.get(

--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -963,6 +963,12 @@ def _get_optimization_cflags(
         cflags += debug_cflags
         ldflags += debug_ldflags
 
+    if config.aot_inductor.enable_frame_pointer:
+        if _IS_WINDOWS:
+            cflags.append("Oy-")
+        else:
+            cflags.append("fno-omit-frame-pointer")
+
     cflags += _get_ffast_math_flags()
 
     if _IS_WINDOWS:


### PR DESCRIPTION
Summary:

Add a new `config.aot_inductor.enable_frame_pointer` option that passes `-fno-omit-frame-pointer` to the C++ compiler when building AOTInductor shared libraries. This preserves frame pointers in the generated `wrappers.so`, allowing profiling tools like Strobelight to produce accurate stack traces through AOTInductor-compiled code.

Controlled via `AOT_INDUCTOR_ENABLE_FRAME_POINTER=1` env var or by setting `torch._inductor.config.aot_inductor.enable_frame_pointer = True`. Disabled by default to avoid any performance overhead when profiling is not needed.

Test Plan:
```
[nbeloborodov@devgpu031]% export AOT_INDUCTOR_DEBUG_COMPILE=0
[nbeloborodov@devgpu031]% export AOT_INDUCTOR_DEBUG_SYMBOLS=1
[nbeloborodov@devgpu031]% export AOT_INDUCTOR_ENABLE_FRAME_POINTER=1
[nbeloborodov@devgpu031]% buck2 run mode/dev-nosan fbcode//caffe2/test/inductor:provenance_tracing -- -r test_aoti_python_stack_traces
...
```
```
[nbeloborodov@devgpu031]% strobe gpuevent --duration-ms=45000 --collect-kernel-events --kernel-sample-interval=0 --attach-to-driver-api --collect-native-stacks --collect-aoti-stacks --log-address-stack --log-module-stack --log-symbolizer-stack --pids 686779
```
https://pxl.cl/9hrbW

```
[nbeloborodov@devgpu031]% export AOT_INDUCTOR_DEBUG_COMPILE=0
[nbeloborodov@devgpu031]% export AOT_INDUCTOR_DEBUG_SYMBOLS=0
[nbeloborodov@devgpu031]% export AOT_INDUCTOR_ENABLE_FRAME_POINTER=1
[nbeloborodov@devgpu031]% buck2 run mode/dev-nosan fbcode//caffe2/test/inductor:provenance_tracing -- -r test_aoti_python_stack_traces
...
```
```
[nbeloborodov@devgpu031]% strobe gpuevent --duration-ms=45000 --collect-kernel-events --kernel-sample-interval=0 --attach-to-driver-api --collect-native-stacks --collect-aoti-stacks --log-address-stack --log-module-stack --log-symbolizer-stack --pids 952384
```
https://pxl.cl/9hrhr

Reviewed By: desertfire

Differential Revision: D99431656


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo