### PR TITLE
[Inductor] Remove fp8 special handling in triton_utils.py

### DIFF
--- a/test/inductor/test_codegen_triton.py
+++ b/test/inductor/test_codegen_triton.py
@@ -15,7 +15,7 @@ from torch._inductor.codegen.triton import (
 from torch._inductor.dtype_propagation import DtypePropagationOpsHandler, promote_types
 from torch._inductor.graph import GraphLowering
 from torch._inductor.test_case import TestCase as InductorTestCase
-from torch._inductor.utils import run_and_get_code
+from torch._inductor.utils import _type_of, run_and_get_code
 from torch._inductor.virtualized import V
 from torch.testing._internal.inductor_utils import (
     GPU_TYPE,
@@ -243,6 +243,14 @@ class TestCodegenTriton(InductorTestCase):
         self.assertFalse(sv.statically_known_multiple_of(s4, 8))
         shape_env.axioms[sympy.Eq(Mod(s4, 8), 0)] = sympy.true
         self.assertTrue(sv.statically_known_multiple_of(s4, 8))
+
+
+class TestTypeOf(InductorTestCase):
+    def test_fp8_dtypes(self):
+        self.assertEqual(_type_of(torch.float8_e4m3fn), "*fp8e4nv")
+        self.assertEqual(_type_of(torch.float8_e5m2), "*fp8e5")
+        self.assertEqual(_type_of(torch.float8_e4m3fnuz), "*fp8e4b8")
+        self.assertEqual(_type_of(torch.float8_e5m2fnuz), "*fp8e5b16")
 
 
 if __name__ == "__main__":

--- a/torch/_inductor/codegen/triton_utils.py
+++ b/torch/_inductor/codegen/triton_utils.py
@@ -34,18 +34,7 @@ def should_unwrap_unspec_arg(name: str):
 
 def signature_of(arg: KernelArgType, *, size_dtype: str | None) -> str:
     if isinstance(arg, TensorArg):
-        # TODO: Remove fp8 special handling when Triton supports PyTorch fp8 dtypes.
-        # Related PR: https://github.com/triton-lang/triton/pull/2279/
-        if arg.dtype == torch.float8_e4m3fn:
-            typ = "*fp8e4nv"
-        elif arg.dtype == torch.float8_e5m2:
-            typ = "*fp8e5"
-        elif arg.dtype == torch.float8_e4m3fnuz:
-            typ = "*fp8e4b8"
-        elif arg.dtype == torch.float8_e5m2fnuz:
-            typ = "*fp8e5b16"
-        else:
-            typ = _type_of(arg.dtype)
+        typ = _type_of(arg.dtype)
         if should_unwrap_unspec_arg(arg.buffer):
             # had unwrapped 0d tensor as scalar
             new_typ = typ.lstrip("*")

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -487,6 +487,8 @@ def _type_of(key: torch.dtype | None) -> str:
         "float8e4b15x4": "fp8e4b15x4",
         "float8_e4m3fn": "fp8e4nv",
         "float8_e5m2": "fp8e5",
+        "float8_e4m3fnuz": "fp8e4b8",
+        "float8_e5m2fnuz": "fp8e5b16",
         # TODO: remove when support is added in triton
         # https://github.com/triton-lang/triton/issues/6054
         "float8_e8m0fnu": "u8",


### PR DESCRIPTION
## Summary
- Remove the redundant fp8 special-case branches in `signature_of()` and let all dtypes (including fp8) fall through to the existing `_type_of()` path
- Add two missing fnuz variant mappings to `_type_of()` so the unified code path produces identical Triton type strings
- Add unit test verifying all four fp8 dtype mappings

## Motivation
The `TODO` comment in `signature_of()` was added over two years ago before Triton supported PyTorch fp8 dtypes. Triton PR [triton-lang/triton#2279](https://github.com/triton-lang/triton/pull/2279) (merged Sep 2023) added native support, making the manual if/elif mapping redundant.

`_type_of()` already handled `float8_e4m3fn` and `float8_e5m2` but was missing entries for the `fnuz` variants (`float8_e4m3fnuz` → `fp8e4b8`, `float8_e5m2fnuz` → `fp8e5b16`). Adding those two entries makes the unified path produce identical results to the old special-case branches.

This also fixes a latent bug: the `WorkspaceArg` path in `signature_of()` already routed through `_type_of()` unconditionally, so any workspace tensor with an fnuz dtype would have raised a `KeyError` prior to this change.

Fixes #178938

## Changes
- **`torch/_inductor/codegen/triton_utils.py`**: Removed the four fp8 `if/elif` branches and the stale `TODO` comment in `signature_of()`
- **`torch/_inductor/utils.py`**: Added `float8_e4m3fnuz` and `float8_e5m2fnuz` entries to the `_type_of()` mapping dict
- **`test/inductor/test_codegen_triton.py`**: Added `TestTypeOf.test_fp8_dtypes` verifying all four fp8 dtype → Triton type string mappings

## Test Plan
- New unit test `TestTypeOf.test_fp8_dtypes` asserts the correct Triton type strings for all four fp8 dtypes
- Existing `test/inductor/test_fp8.py` suite exercises end-to-end fp8 Inductor codegen and should pass unchanged

cc @chauhang @penguinwu @voznesenskym @muchulee8 @amjames @aakhundov