### PR TITLE
[Inductor] `max_autotune` benchmark runs under CUDA Graph

### DIFF
--- a/test/inductor/test_benchmarking.py
+++ b/test/inductor/test_benchmarking.py
@@ -456,10 +456,22 @@ class TestBenchmarker(TestCase):
             finally:
                 calls.append("exit")
 
+        class FakeStream:
+            def wait_stream(self, stream):
+                pass
+
+            def synchronize(self):
+                pass
+
+        current_stream = FakeStream()
+
         previous = _bench.set_gpu_benchmark_lock_context(custom_context)
         try:
             with (
                 patch("torch.cuda.synchronize"),
+                patch("torch.cuda.Stream", FakeStream),
+                patch("torch.cuda.current_stream", return_value=current_stream),
+                patch("torch.cuda.stream", return_value=contextlib.nullcontext()),
                 patch("torch.cuda.CUDAGraph", FakeCUDAGraph),
                 patch("torch.cuda.graph", return_value=contextlib.nullcontext()),
             ):
@@ -474,6 +486,7 @@ class TestBenchmarker(TestCase):
             calls,
             [
                 "enter",
+                "call",
                 "call",
                 "call",
                 "enter",

--- a/test/inductor/test_benchmarking.py
+++ b/test/inductor/test_benchmarking.py
@@ -12,6 +12,7 @@ from torch._inductor.config import (
 )
 from torch._inductor.runtime.benchmarking import (
     Benchmarker,
+    InductorBenchmarker,
     TorchProfilerBenchmarker,
     TritonBenchmarker,
 )
@@ -496,6 +497,74 @@ class TestBenchmarker(TestCase):
                 "exit",
             ],
         )
+
+    def test_autotune_cudagraph_benchmarking_requires_max_autotune(self):
+        from torch._inductor.runtime import benchmarking as _bench
+
+        class FakeBuffer:
+            def zero_(self):
+                pass
+
+        class FakeDeviceInterface:
+            def synchronize(self):
+                pass
+
+        class FakeEvent:
+            def record(self):
+                pass
+
+            def elapsed_time(self, other):
+                return 1.0
+
+        class FakeInductorBenchmarker(InductorBenchmarker):
+            def __init__(self):
+                super().__init__()
+                self.cuda_graph_benchmark_calls = 0
+
+            def benchmark_gpu_with_cuda_graph(self, _callable, **kwargs):
+                self.cuda_graph_benchmark_calls += 1
+                return 7.0
+
+            def get_device_cache_size(self, device_type=None):
+                return 4
+
+            def get_event_pairs(self, iters, device_type=None):
+                return [(FakeEvent(), FakeEvent()) for _ in range(iters)]
+
+        def run_benchmark(max_autotune):
+            benchmarker = FakeInductorBenchmarker()
+            callable_calls = []
+            with (
+                patch.object(
+                    _bench,
+                    "get_interface_for_device",
+                    return_value=FakeDeviceInterface(),
+                ),
+                patch.object(_bench.torch, "empty", return_value=FakeBuffer()),
+                patch.object(
+                    _bench.inductor_config, "autotune_cudagraph_benchmarking", True
+                ),
+                patch.object(_bench.inductor_config, "max_autotune", max_autotune),
+            ):
+                result = benchmarker.benchmark_gpu(
+                    lambda: callable_calls.append("call"),
+                    estimation_iters=1,
+                    memory_warmup_iters=1,
+                    benchmark_iters=1,
+                    is_vetted_benchmarking=True,
+                    device_type="cuda",
+                )
+            return result, benchmarker.cuda_graph_benchmark_calls, callable_calls
+
+        result, cuda_graph_calls, callable_calls = run_benchmark(max_autotune=False)
+        self.assertEqual(result, 1.0)
+        self.assertEqual(cuda_graph_calls, 0)
+        self.assertEqual(callable_calls, ["call", "call", "call"])
+
+        result, cuda_graph_calls, callable_calls = run_benchmark(max_autotune=True)
+        self.assertEqual(result, 7.0)
+        self.assertEqual(cuda_graph_calls, 1)
+        self.assertEqual(callable_calls, [])
 
     @unittest.skipIf(not HAS_GPU, "requires GPU")
     @parametrize(

--- a/test/inductor/test_custom_op_autotune.py
+++ b/test/inductor/test_custom_op_autotune.py
@@ -629,10 +629,10 @@ class TestCustomOpAutoTune(TestCase):
         cuda_graph_benchmark_called = False
         original_benchmark_gpu_with_cuda_graph = torch._inductor.runtime.benchmarking.Benchmarker.benchmark_gpu_with_cuda_graph
 
-        def patched_benchmark_gpu_with_cuda_graph(self, fn):
+        def patched_benchmark_gpu_with_cuda_graph(self, fn, *args, **kwargs):
             nonlocal cuda_graph_benchmark_called
             cuda_graph_benchmark_called = True
-            return original_benchmark_gpu_with_cuda_graph(self, fn)
+            return original_benchmark_gpu_with_cuda_graph(self, fn, *args, **kwargs)
 
         torch._dynamo.reset()
         with config.patch(max_autotune=True, fx_graph_cache=False):

--- a/torch/_inductor/autotune_process.py
+++ b/torch/_inductor/autotune_process.py
@@ -22,6 +22,8 @@ from concurrent.futures import Future, ProcessPoolExecutor, ThreadPoolExecutor
 from ctypes import byref, c_size_t, c_void_p, CDLL
 from typing import Any, IO, TYPE_CHECKING
 
+from typing_extensions import override
+
 import torch
 import torch._inductor.async_compile
 from torch._dynamo.device_interface import get_interface_for_device
@@ -701,6 +703,7 @@ class TritonBenchmarkRequest(BenchmarkRequest):
         self.workspace_zero_fill = workspace_zero_fill
         self._benchmark_module: Any | None = None
 
+    @override
     def make_run_fn(
         self, *input_tensors: torch.Tensor, out: torch.Tensor
     ) -> Callable[[], None]:

--- a/torch/_inductor/autotune_process.py
+++ b/torch/_inductor/autotune_process.py
@@ -746,36 +746,45 @@ class TritonBenchmarkRequest(BenchmarkRequest):
             warmup_arg["warmup"] = False
 
         if out.device.type == "cpu":
-            stream = 0
+            device_interface = None
+            device_index = 0
         else:
             device_type = out.device.type
             device_interface = get_interface_for_device(device_type)
-            stream = device_interface.get_raw_stream(
-                self.output_tensor_meta.device.index
-            )
+            device_index = self.output_tensor_meta.device.index
 
-        if isinstance(
+        is_debug_autotuner = isinstance(
             getattr(mod, self.kernel_name),
             torch._inductor.runtime.triton_heuristics.DebugAutotuner,
-        ):
-            return functools.partial(
-                run_method,
-                *input_tensors,
-                out,
-                *extra_args,
-                **warmup_arg,
-                stream=stream,
+        )
+
+        # Resolve the stream at call time (not at closure-creation time) so that
+        # CUDA graph capture on a different stream works correctly.
+        def run_fn() -> None:
+            stream = (
+                0
+                if device_interface is None
+                else device_interface.get_raw_stream(device_index)
             )
-        else:
-            return functools.partial(
-                run_method,
-                *input_tensors,
-                out,
-                *extra_args,
-                **warmup_arg,
-                stream=stream,
-                benchmark_run=True,
-            )
+            if is_debug_autotuner:
+                run_method(
+                    *input_tensors,
+                    out,
+                    *extra_args,
+                    **warmup_arg,
+                    stream=stream,
+                )
+            else:
+                run_method(
+                    *input_tensors,
+                    out,
+                    *extra_args,
+                    **warmup_arg,
+                    stream=stream,
+                    benchmark_run=True,
+                )
+
+        return run_fn
 
     def cleanup_run_fn(self) -> None:
         # Authoritative cleanup for one benchmark module load. Higher-level

--- a/torch/_inductor/autotune_process.py
+++ b/torch/_inductor/autotune_process.py
@@ -21,7 +21,6 @@ from collections.abc import Callable, Iterable, Sequence
 from concurrent.futures import Future, ProcessPoolExecutor, ThreadPoolExecutor
 from ctypes import byref, c_size_t, c_void_p, CDLL
 from typing import Any, IO, TYPE_CHECKING
-
 from typing_extensions import override
 
 import torch

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -551,7 +551,7 @@ inductor_default_autotune_rep = int(
 # and benchmarks graph replay instead of eager kernel launches. This eliminates
 # host-side dispatch overhead from timing measurements, giving results that are
 # representative of CUDA graph replay execution. Useful when the compiled output
-# will run under external CUDA graph capture.
+# will run under external CUDA graph capture. Only applies with max_autotune.
 autotune_cudagraph_benchmarking: bool = (
     os.environ.get("TORCHINDUCTOR_AUTOTUNE_CUDAGRAPH_BENCHMARKING") == "1"
 )

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -547,6 +547,15 @@ inductor_default_autotune_rep = int(
     os.getenv("TORCHINDUCTOR_DEFAULT_AUTOTUNE_REP", 100)
 )
 
+# When enabled, the autotuner captures each candidate kernel in a CUDA graph
+# and benchmarks graph replay instead of eager kernel launches. This eliminates
+# host-side dispatch overhead from timing measurements, giving results that are
+# representative of CUDA graph replay execution. Useful when the compiled output
+# will run under external CUDA graph capture.
+autotune_cudagraph_benchmarking: bool = (
+    os.environ.get("TORCHINDUCTOR_AUTOTUNE_CUDAGRAPH_BENCHMARKING") == "1"
+)
+
 
 # Modifies the number of autotuning choices displayed, set to None for all
 def _autotune_num_choices_displayed_default() -> int | None:

--- a/torch/_inductor/runtime/benchmarking.py
+++ b/torch/_inductor/runtime/benchmarking.py
@@ -684,6 +684,7 @@ class InductorBenchmarker(TritonBenchmarker):  # noqa: docstring_linter
         if (
             device_type == "cuda"
             and inductor_config.autotune_cudagraph_benchmarking
+            and inductor_config.max_autotune
             and not self._in_cudagraph_benchmark
         ):
             try:

--- a/torch/_inductor/runtime/benchmarking.py
+++ b/torch/_inductor/runtime/benchmarking.py
@@ -680,6 +680,7 @@ class InductorBenchmarker(TritonBenchmarker):  # noqa: docstring_linter
 
         device_type = _normalize_gpu_device_type(device_type)
         device_interface = get_interface_for_device(device_type)
+
         if (
             device_type == "cuda"
             and inductor_config.autotune_cudagraph_benchmarking

--- a/torch/_inductor/runtime/benchmarking.py
+++ b/torch/_inductor/runtime/benchmarking.py
@@ -202,7 +202,7 @@ class Benchmarker:
     """
 
     def __init__(self: Self) -> None:
-        pass
+        self._in_cudagraph_benchmark = False
 
     def infer_device(self, *fn_args: Any, **fn_kwargs: Any) -> torch.device:
         inferred_device: torch.device | None = None
@@ -361,6 +361,7 @@ class Benchmarker:
     def benchmark_gpu_with_cuda_graph(
         self: Self,
         _callable: Callable[[], Any],
+        grad_to_none: list[torch.Tensor] | None = None,
         **kwargs: Any,
     ) -> float:
         """Benchmark a GPU callable using CUDA graph capture and replay.
@@ -369,17 +370,42 @@ class Benchmarker:
         which eliminates kernel launch overhead for fair comparison between different
         implementations.
         """
-        # Warmup
+        # Warmup: triggers cuBLAS/cuDNN/Triton lazy init
+        torch.cuda.synchronize()
         _callable()
         torch.cuda.synchronize()
 
-        # Capture into CUDA graph
-        cuda_graph = torch.cuda.CUDAGraph()
-        with torch.cuda.graph(cuda_graph, capture_error_mode="thread_local"):
+        # Side-stream warmup then capture
+        stream = torch.cuda.Stream()
+        stream.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(stream):
+            if grad_to_none is not None:
+                for x in grad_to_none:
+                    x.grad = None
             _callable()
+        stream.synchronize()
+
+        cuda_graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(
+            cuda_graph, stream=stream, capture_error_mode="thread_local"
+        ):
+            if grad_to_none is not None:
+                for x in grad_to_none:
+                    x.grad = None
+            _callable()
+
+        torch.cuda.current_stream().wait_stream(stream)
         torch.cuda.synchronize()
 
-        return self.benchmark_gpu(cuda_graph.replay, **kwargs)
+        try:
+            # grad clearing is captured in the graph, don't pass it through.
+            # Set flag to prevent benchmark_gpu from re-entering this method
+            # when autotune_cudagraph_benchmarking is enabled.
+            self._in_cudagraph_benchmark = True
+            return self.benchmark_gpu(cuda_graph.replay, **kwargs)
+        finally:
+            self._in_cudagraph_benchmark = False
+            del cuda_graph
 
 
 # Make built-in defaults explicit via the registry
@@ -642,6 +668,28 @@ class InductorBenchmarker(TritonBenchmarker):  # noqa: docstring_linter
 
         device_type = _normalize_gpu_device_type(device_type)
         device_interface = get_interface_for_device(device_type)
+        if (
+            device_type == "cuda"
+            and inductor_config.autotune_cudagraph_benchmarking
+            and not self._in_cudagraph_benchmark
+        ):
+            try:
+                return self.benchmark_gpu_with_cuda_graph(
+                    _callable,
+                    estimation_iters=estimation_iters,
+                    memory_warmup_iters=memory_warmup_iters,
+                    benchmark_iters=benchmark_iters,
+                    max_benchmark_duration=max_benchmark_duration,
+                    return_mode=return_mode,
+                    grad_to_none=grad_to_none,
+                    device_type=device_type,
+                )
+            except RuntimeError:
+                logger.debug(
+                    "CUDA graph capture failed during benchmarking, "
+                    "falling back to eager benchmarking",
+                    exc_info=True,
+                )
 
         # we don't want any outside errors propagating into benchmarking
         device_interface.synchronize()

--- a/torch/_inductor/runtime/benchmarking.py
+++ b/torch/_inductor/runtime/benchmarking.py
@@ -621,10 +621,12 @@ class InductorBenchmarker(TritonBenchmarker):  # noqa: docstring_linter
         # Prevent benchmark_gpu from re-entering this method
         # when autotune_cudagraph_benchmarking is enabled.
         self._in_cudagraph_benchmark = True
-        result = super().benchmark_gpu_with_cuda_graph(
-            _callable, grad_to_none=grad_to_none, **kwargs
-        )
-        self._in_cudagraph_benchmark = False
+        try:
+            result = super().benchmark_gpu_with_cuda_graph(
+                _callable, grad_to_none=grad_to_none, **kwargs
+            )
+        finally:
+            self._in_cudagraph_benchmark = False
         return result
 
     @may_distort_benchmarking_result
@@ -695,7 +697,7 @@ class InductorBenchmarker(TritonBenchmarker):  # noqa: docstring_linter
                     device_type=device_type,
                 )
             except RuntimeError:
-                logger.debug(
+                logger.warning(
                     "CUDA graph capture failed during benchmarking, "
                     "falling back to eager benchmarking",
                     exc_info=True,

--- a/torch/_inductor/runtime/benchmarking.py
+++ b/torch/_inductor/runtime/benchmarking.py
@@ -394,11 +394,8 @@ class Benchmarker:
         torch.cuda.current_stream().wait_stream(stream)
         torch.cuda.synchronize()
 
-        try:
-            # grad clearing is captured in the graph, don't pass it through.
-            return self.benchmark_gpu(cuda_graph.replay, **kwargs)
-        finally:
-            del cuda_graph
+        # grad clearing is captured in the graph, don't pass it through.
+        return self.benchmark_gpu(cuda_graph.replay, **kwargs)
 
 
 # Make built-in defaults explicit via the registry

--- a/torch/_inductor/runtime/benchmarking.py
+++ b/torch/_inductor/runtime/benchmarking.py
@@ -370,7 +370,7 @@ class Benchmarker:
         which eliminates kernel launch overhead for fair comparison between different
         implementations.
         """
-        # Warmup: triggers cuBLAS/cuDNN/Triton lazy init
+        # Warmup
         torch.cuda.synchronize()
         _callable()
         torch.cuda.synchronize()

--- a/torch/_inductor/runtime/benchmarking.py
+++ b/torch/_inductor/runtime/benchmarking.py
@@ -201,9 +201,6 @@ class Benchmarker:
     inductor generated callables.
     """
 
-    def __init__(self: Self) -> None:
-        self._in_cudagraph_benchmark = False
-
     def infer_device(self, *fn_args: Any, **fn_kwargs: Any) -> torch.device:
         inferred_device: torch.device | None = None
         for arg_or_kwarg in chain(fn_args, fn_kwargs.values()):
@@ -399,12 +396,8 @@ class Benchmarker:
 
         try:
             # grad clearing is captured in the graph, don't pass it through.
-            # Set flag to prevent benchmark_gpu from re-entering this method
-            # when autotune_cudagraph_benchmarking is enabled.
-            self._in_cudagraph_benchmark = True
             return self.benchmark_gpu(cuda_graph.replay, **kwargs)
         finally:
-            self._in_cudagraph_benchmark = False
             del cuda_graph
 
 
@@ -569,6 +562,10 @@ class TritonBenchmarker(Benchmarker):
 
 
 class InductorBenchmarker(TritonBenchmarker):  # noqa: docstring_linter
+    def __init__(self: Self) -> None:
+        super().__init__()
+        self._in_cudagraph_benchmark = False
+
     @cached_property
     def L2_cache_size(self: Self) -> int:
         """Get the L2 cache size, in bytes, of the current device."""
@@ -616,6 +613,22 @@ class InductorBenchmarker(TritonBenchmarker):  # noqa: docstring_linter
                 for start_event, end_event in event_pairs
             ]
         )
+
+    @time_and_count
+    def benchmark_gpu_with_cuda_graph(
+        self: Self,
+        _callable: Callable[[], Any],
+        grad_to_none: list[torch.Tensor] | None = None,
+        **kwargs: Any,
+    ) -> float:
+        # Prevent benchmark_gpu from re-entering this method
+        # when autotune_cudagraph_benchmarking is enabled.
+        self._in_cudagraph_benchmark = True
+        result = super().benchmark_gpu_with_cuda_graph(
+            _callable, grad_to_none=grad_to_none, **kwargs
+        )
+        self._in_cudagraph_benchmark = False
+        return result
 
     @may_distort_benchmarking_result
     @time_and_count

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -1353,9 +1353,7 @@ class CachingAutotuner(KernelInterface):
         def kernel_call():
             # Resolve the raw stream at call time rather than at closure-creation
             # time so that CUDA graph capture on a different stream works correctly.
-            stream = device_interface.get_raw_stream(
-                device_interface.current_device()
-            )
+            stream = device_interface.get_raw_stream(device_interface.current_device())
             cloned_args, cloned_kwargs = self.maybe_clone_args(
                 cpu_copies, *args, **kwargs
             )

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -1347,11 +1347,15 @@ class CachingAutotuner(KernelInterface):
             return float("inf")
 
         device_interface = self.get_device_interface()
-        stream = device_interface.get_raw_stream(device_interface.current_device())
 
         cpu_copies = self.copy_args_to_cpu_if_needed(*args, **kwargs)
 
         def kernel_call():
+            # Resolve the raw stream at call time rather than at closure-creation
+            # time so that CUDA graph capture on a different stream works correctly.
+            stream = device_interface.get_raw_stream(
+                device_interface.current_device()
+            )
             cloned_args, cloned_kwargs = self.maybe_clone_args(
                 cpu_copies, *args, **kwargs
             )


### PR DESCRIPTION
Closes #179236.

For memory-bound kernels like RMSNorm, `max_autotune` selects worse configs than `default` mode when the workload runs under an externally captured CUDA graph. This happens because the autotuner's eager benchmarking includes host-side kernel launch overhead in its measurements, which distorts the ranking of configs that differ primarily in GPU-side execution time.

This PR adds `autotune_cudagraph_benchmarking` — when enabled, the Triton config autotuner captures each candidate kernel in a CUDA graph and benchmarks graph replay instead of eager launches. This eliminates launch overhead from measurements, giving timings representative of CUDA graph replay execution.

Enable via config or environment variable:
```python
torch._inductor.config.autotune_cudagraph_benchmarking = True
# or
TORCHINDUCTOR_AUTOTUNE_CUDAGRAPH_BENCHMARKING=1
```

On GB200 with the RMSNorm repro from the issue:
| Config | Time |
|---|---|
| max_autotune (eager bench) | 6.19 us |
| max_autotune (cudagraph bench) | **4.14 us** |
| default compile | 4.13 us |

The implementation reuses the existing `benchmark_gpu_with_cuda_graph` path (used by custom op autotuning) — `InductorBenchmarker.benchmark_gpu` delegates to it when the config flag is on, with fallback to eager benchmarking if CUDA graph capture fails.



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo