### PR TITLE
fix(inductor): remove fp8 special handling in signature_of

### DIFF
--- a/torch/_inductor/codegen/triton_utils.py
+++ b/torch/_inductor/codegen/triton_utils.py
@@ -34,18 +34,7 @@ def should_unwrap_unspec_arg(name: str):
 
 def signature_of(arg: KernelArgType, *, size_dtype: str | None) -> str:
     if isinstance(arg, TensorArg):
-        # TODO: Remove fp8 special handling when Triton supports PyTorch fp8 dtypes.
-        # Related PR: https://github.com/triton-lang/triton/pull/2279/
-        if arg.dtype == torch.float8_e4m3fn:
-            typ = "*fp8e4nv"
-        elif arg.dtype == torch.float8_e5m2:
-            typ = "*fp8e5"
-        elif arg.dtype == torch.float8_e4m3fnuz:
-            typ = "*fp8e4b8"
-        elif arg.dtype == torch.float8_e5m2fnuz:
-            typ = "*fp8e5b16"
-        else:
-            typ = _type_of(arg.dtype)
+        typ = _type_of(arg.dtype)
         if should_unwrap_unspec_arg(arg.buffer):
             # had unwrapped 0d tensor as scalar
             new_typ = typ.lstrip("*")

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -487,6 +487,8 @@ def _type_of(key: torch.dtype | None) -> str:
         "float8e4b15x4": "fp8e4b15x4",
         "float8_e4m3fn": "fp8e4nv",
         "float8_e5m2": "fp8e5",
+        "float8_e4m3fnuz": "fp8e4b8",
+        "float8_e5m2fnuz": "fp8e5b16",
         # TODO: remove when support is added in triton
         # https://github.com/triton-lang/triton/issues/6054
         "float8_e8m0fnu": "u8",


### PR DESCRIPTION
## Problem

`torch/_inductor/codegen/triton_utils.py` contains manual fp8 dtype-to-Triton-type mapping in `signature_of` behind a TODO comment referencing [triton-lang/triton#2279](https://github.com/triton-lang/triton/pull/2279/). That PR was merged in September 2023, making the special-case branches redundant.

## Solution

- **Remove** the four `if/elif` branches for fp8 dtypes in `signature_of`, letting all tensor args fall through to `_type_of(arg.dtype)`
- **Add** the two missing fnuz variants to the `_type_of` mapping in `utils.py`:
  - `float8_e4m3fnuz` → `fp8e4b8`
  - `float8_e5m2fnuz` → `fp8e5b16`

## Files Changed

- `torch/_inductor/codegen/triton_utils.py` — removed 12 lines of special handling
- `torch/_inductor/utils.py` — added 2 missing dtype mappings

## Verification

The `_type_of` function already correctly mapped `float8_e4m3fn` → `fp8e4nv` and `float8_e5m2` → `fp8e5`. The two fnuz variants were the only ones missing. After this change, all four fp8 dtypes use the same canonical path as every other dtype.

Closes #178938

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo