### PR TITLE
[c10] Fix off-by-one issue in ApproximateClock.cpp

### DIFF
--- a/c10/util/ApproximateClock.cpp
+++ b/c10/util/ApproximateClock.cpp
@@ -50,7 +50,7 @@ std::function<time_t(approx_time_t)> ApproximateClockToUnixTimeConverter::
         static_cast<double>(delta_ns) / static_cast<double>(delta_approx);
   }
   std::sort(scale_factors.begin(), scale_factors.end());
-  long double scale_factor = scale_factors[replicates / 2 + 1];
+  long double scale_factor = scale_factors[replicates / 2];
 
   // We shift all times by `t0` for better numerics. Double precision only has
   // 16 decimal digits of accuracy, so if we blindly multiply times by
@@ -69,7 +69,7 @@ std::function<time_t(approx_time_t)> ApproximateClockToUnixTimeConverter::
         scale_factor;
     t0_correction[i] = dt - (time_t)dt_approx; // NOLINT
   }
-  t0 += t0_correction[t0_correction.size() / 2 + 1]; // NOLINT
+  t0 += t0_correction[t0_correction.size() / 2]; // NOLINT
 
   return [=](approx_time_t t_approx) {
     // See above for why this is more stable than `A * t_approx + B`.


### PR DESCRIPTION
# Problem
When replicates is odd (e.g., 1001), the correct 0‑based median index is replicates / 2 = 500. The code incorrectly added +1, using index 501 instead. This selects the element right of the true median, skewing the scale factor and t0 correction.

# Example
replicates = 1001

Wrong: scale_factors[1001/2 + 1] = scale_factors[501] (off by one)

Correct: scale_factors[1001/2] = scale_factors[500] (true median)

# Changes

Remove +1 from median index for scale_factors

Remove +1 from median index for t0_correction

# Impact
Fixes inaccurate time conversion from approximate clock to Unix time. Without this, the converter uses a biased scale factor, leading to systematic errors in all converted timestamps.

# Important
Not tested, but pretty confident that this should be correct

Contributed by Benedikt Johannes