### PR TITLE
[BE] Update `skipIfNNModuleInlined` condition to True

### DIFF
--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -2064,7 +2064,7 @@ torch_to_numpy_dtype_dict.update({
 
 def skipIfNNModuleInlined(
     msg="test doesn't currently work with nn module inlining",
-    condition=torch._dynamo.config.inline_inbuilt_nn_modules,
+    condition=True,
 ):
     def decorator(fn):
         if not isinstance(fn, type):


### PR DESCRIPTION
From `torch._dynamo.config.inline_inbuilt_nn_module` to squash annoying warning
```
/Users/malfet/git/pytorch/pytorch/torch/testing/_internal/common_utils.py:2006: FutureWarning: torch._dynamo.config.inline_inbuilt_nn_modules is deprecated and does not do anything, inline_inbuilt_nn_modules is always True. It will be removed in a future version of PyTorch.
  condition=torch._dynamo.config.inline_inbuilt_nn_modules,
```