### PR TITLE
[CUDA] Fix wrong non-atomic handling in `AdaptiveMaxPooling2d.cu`

### DIFF
--- a/aten/src/ATen/native/cuda/AdaptiveMaxPooling2d.cu
+++ b/aten/src/ATen/native/cuda/AdaptiveMaxPooling2d.cu
@@ -393,7 +393,7 @@ TORCH_IMPL_FUNC(adaptive_max_pool2d_backward_out_cuda)
             C10_CUDA_KERNEL_LAUNCH_CHECK();
           } else {
             // run updateGradInput kernel
-            atomicadaptivemaxgradinput<<<
+            adaptivemaxgradinput<<<
                 blocks,
                 threads,
                 0,


### PR DESCRIPTION
This was clearly an issue, we check whether atomic is true or false and in both cases we used atomic

Contribued by Benedikt Johannes