### PR TITLE
[ROCm] Fix MIOpen CTC loss crash on Windows dGPU systems

### DIFF
--- a/aten/src/ATen/native/miopen/LossCTC_miopen.cpp
+++ b/aten/src/ATen/native/miopen/LossCTC_miopen.cpp
@@ -207,7 +207,16 @@ std::tuple<Tensor, Tensor> miopen_ctc_loss(
   Tensor costs = at::empty({batch_size}, log_probs->options());
   Tensor grad = at::empty_like(log_probs_t, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
 
-  // MIOpen requires labels and lengths on GPU
+#ifdef _WIN32
+  // On Windows there is no unified memory (HSA), so MIOpen cannot read
+  // GPU pointers from the host side. Pass CPU pointers for labels and
+  // lengths which MIOpen reads during workspace size calculation.
+  Tensor labels_cpu = targets_t.to(at::kInt).contiguous();
+  int* labels_ptr = labels_cpu.data_ptr<int>();
+  int* label_lengths_ptr = target_lengths.data();
+  int* input_lengths_ptr = input_lengths.data();
+#else
+  // On Linux with HSA, GPU memory is host-accessible.
   Tensor labels_gpu = targets_t.to(Device(at::kCUDA), at::kInt);
   Tensor label_lengths_gpu = at::empty(
       {static_cast<int64_t>(target_lengths.size())},
@@ -227,15 +236,20 @@ std::tuple<Tensor, Tensor> miopen_ctc_loss(
       input_lengths.size() * sizeof(int),
       hipMemcpyHostToDevice));
 
+  int* labels_ptr = labels_gpu.data_ptr<int>();
+  int* label_lengths_ptr = label_lengths_gpu.data_ptr<int>();
+  int* input_lengths_ptr = input_lengths_gpu.data_ptr<int>();
+#endif
+
   size_t workspace_size;
   (void)deterministic; // MIOpen only supports deterministic algorithm
   MIOPEN_CHECK(miopenGetCTCLossWorkspaceSize(
       handle,
       probs_desc,
       grads_desc,
-      labels_gpu.data_ptr<int>(),
-      label_lengths_gpu.data_ptr<int>(),
-      input_lengths_gpu.data_ptr<int>(),
+      labels_ptr,
+      label_lengths_ptr,
+      input_lengths_ptr,
       MIOPEN_CTC_LOSS_ALGO_DETERMINISTIC,
       ctc_desc,
       &workspace_size));
@@ -246,9 +260,9 @@ std::tuple<Tensor, Tensor> miopen_ctc_loss(
       handle,
       probs_desc,
       log_probs_t.data_ptr(),
-      labels_gpu.data_ptr<int>(),
-      label_lengths_gpu.data_ptr<int>(),
-      input_lengths_gpu.data_ptr<int>(),
+      labels_ptr,
+      label_lengths_ptr,
+      input_lengths_ptr,
       costs.data_ptr(),
       grads_desc,
       grad.data_ptr(),


### PR DESCRIPTION
<h2>Fix MIOpen CTC loss access violation on Windows discrete GPUs</h2>

<h3>Problem</h3>

<p>After the initial unit test failure on Windows for MIOpen CTC loss, a missing <code>#include</code> was added and the test was passing on APU systems. But after running CI again, the failure showed again on dGPU with a very similar stack.</p>

<p><code>test_CTCLoss_no_batch_dim</code> (and any code path hitting <code>miopen_ctc_loss</code>) crashes with a fatal access violation on Windows systems with discrete AMD GPUs:</p>

<pre><code>Windows fatal exception: access violation
Exception Code: 0xC0000005
#0 miopen::CTCLossDescriptor::GetCTCLossWorkspaceSize (MIOpen.dll+0x14fde4)
#1 miopenGetCTCLossWorkspaceSize (MIOpen.dll+0x150912)
#2 at::native::miopen_ctc_loss (torch_hip.dll)
</code></pre>

<h3>Root Cause</h3>

<p><code>miopenGetCTCLossWorkspaceSize</code> and <code>miopenCTCLoss</code> read the <code>labels</code>, <code>label_lengths</code>, and <code>input_lengths</code> arrays <strong>on the host side</strong> to plan the computation and calculate workspace requirements. The existing code copies these arrays to GPU memory and passes device pointers:</p>

<pre><code>Tensor labels_gpu = targets_t.to(Device(at::kCUDA), at::kInt);
// ... hipMemcpy to GPU ...
MIOPEN_CHECK(miopenGetCTCLossWorkspaceSize(...,
    labels_gpu.data_ptr&lt;int&gt;(),          // device pointer
    label_lengths_gpu.data_ptr&lt;int&gt;(),   // device pointer
    input_lengths_gpu.data_ptr&lt;int&gt;()    // device pointer
));
</code></pre>

<p>This works on:</p>
<ul>
<li><strong>Linux</strong> — HSA (Heterogeneous System Architecture) maps GPU allocations into the process virtual address space, making device pointers host-readable</li>
<li><strong>Windows APUs</strong> — CPU and iGPU share system RAM, so device pointers point to host-accessible memory</li>
</ul>

<p>This crashes on:</p>
<ul>
<li><strong>Windows dGPUs</strong> — GPU has dedicated VRAM across PCIe; device pointers are opaque handles that cannot be dereferenced from host code</li>
</ul>

<h3>Verification</h3>

<p>Tested on gfx1201:</p>

<table border="1" cellpadding="6" cellspacing="0">
<tr><th>Check</th><th>Result</th></tr>
<tr><td><code>hipDeviceAttributeIntegrated</code></td><td><code>0</code> (discrete GPU)</td></tr>
<tr><td><code>hipDeviceAttributeCanUseHostPointerForRegisteredMem</code></td><td><code>0</code></td></tr>
<tr><td><code>hipDeviceAttributeManagedMemory</code></td><td><code>0x7FFFFFFF</code> (unsupported)</td></tr>
<tr><td><code>hipDeviceAttributeUnifiedAddressing</code></td><td><code>0x7FFFFFFF</code> (unsupported)</td></tr>
<tr><td>Host read of <code>hipMalloc</code> pointer via <code>ctypes</code></td><td>Access violation</td></tr>
<tr><td>CTC loss with CPU pointers</td><td>Pass (forward + backward)</td></tr>
</table>

<h3>Fix</h3>

<p>Use <code>#ifdef _WIN32</code> to conditionally pass CPU pointers on Windows, while preserving the original GPU pointer path on Linux:</p>

<pre><code>#ifdef _WIN32
  Tensor labels_cpu = targets_t.to(at::kInt).contiguous();
  int* labels_ptr = labels_cpu.data_ptr&lt;int&gt;();
  int* label_lengths_ptr = target_lengths.data();
  int* input_lengths_ptr = input_lengths.data();
#else
  // Original GPU path (HSA makes these host-accessible on Linux)
  Tensor labels_gpu = targets_t.to(Device(at::kCUDA), at::kInt);
  // ... hipMemcpy ...
  int* labels_ptr = labels_gpu.data_ptr&lt;int&gt;();
  int* label_lengths_ptr = label_lengths_gpu.data_ptr&lt;int&gt;();
  int* input_lengths_ptr = input_lengths_gpu.data_ptr&lt;int&gt;();
#endif
</code></pre>

<p>Both paths feed into the same <code>labels_ptr</code> / <code>label_lengths_ptr</code> / <code>input_lengths_ptr</code> variables used by the MIOpen calls, keeping the rest of the function shared.</p>

<h3>Testing</h3>

<ul>
<li><code>test_CTCLoss_no_batch_dim</code> passes on Windows dGPU (previously crashed)</li>
<li>No change to Linux behavior (original GPU path preserved behind <code>#else</code>)</li>
<li>CPU pointers are also correct on APUs (shared memory), so this is safe for all Windows configurations</li>
</ul>

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang