### PR TITLE
[inductor] Add dimension-size guards to BMM template contiguity hints (#179267)

### DIFF
--- a/test/inductor/test_select_algorithm.py
+++ b/test/inductor/test_select_algorithm.py
@@ -231,6 +231,23 @@ class TestSelectAlgorithm(TestCase):
             self.assertEqual(counters["inductor"]["select_algorithm_autotune"], 1)
 
     @patches
+    def test_bmm_small_m(self):
+        # Verify BMM works when M < BLOCK_M. The triton_bmm template's
+        # tl.max_contiguous/tl.multiple_of hints must be guarded by
+        # M >= BLOCK_M to avoid out-of-bounds vectorized loads (see #179267).
+        @torch.compile
+        def foo(a, b):
+            return torch.bmm(a, b)
+
+        # M=2 is smaller than any BLOCK_M autotuning config (typically >= 16)
+        foo(
+            torch.randn(4, 2, 64, device=GPU_TYPE),
+            torch.randn(4, 64, 32, device=GPU_TYPE),
+        )
+        if not torch.version.hip:
+            self.assertEqual(counters["inductor"]["select_algorithm_autotune"], 1)
+
+    @patches
     def test_mm_not_even_k(self):
         @torch.compile
         def foo(a, b):

--- a/torch/_inductor/kernel/templates/triton_bmm.py.jinja
+++ b/torch/_inductor/kernel/templates/triton_bmm.py.jinja
@@ -28,11 +28,11 @@
 
     rm = pid_m * BLOCK_M + tl.arange(0, BLOCK_M).to(INDEX_DTYPE)
     rn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N).to(INDEX_DTYPE)
-    if (stride_am == 1 and stride_ak == M) or (stride_am == K and stride_ak == 1):
+    if ((stride_am == 1 and stride_ak == M) or (stride_am == K and stride_ak == 1)) and (M >= BLOCK_M and K > 1):
         ram = tl.max_contiguous(tl.multiple_of(rm % M, BLOCK_M), BLOCK_M)
     else:
         ram = rm % M
-    if (stride_bk == 1 and stride_bn == K) or (stride_bk == N and stride_bn == 1):
+    if ((stride_bk == 1 and stride_bn == K) or (stride_bk == N and stride_bn == 1)) and (N >= BLOCK_N and K > 1):
         rbn = tl.max_contiguous(tl.multiple_of(rn % N, BLOCK_N), BLOCK_N)
     else:
         rbn = rn % N


### PR DESCRIPTION
Summary:

The Triton BMM template applied `tl.max_contiguous`/`tl.multiple_of`
hints unconditionally based on stride patterns. When M < BLOCK_M (e.g.,
M=96 with BLOCK_M=128), this told Triton to use 128-element vectorized
loads on a 96-element dimension, causing out-of-bounds memory accesses.
On AMD MI300x (ROCm), masked loads to invalid addresses still trigger
Memory Access Faults (IMA), unlike NVIDIA which silently handles them.

This fix adds `M >= BLOCK_M and K > 1` / `N >= BLOCK_N and K > 1`
guards, matching the pattern already present in `triton_mm.py.jinja`
(added in https://github.com/pytorch/pytorch/pull/146293). Without the guard, the template falls back to
plain `rm % M` which is always safe.

This issue was exposed first in https://fb.workplace.com/groups/254777643194247/permalink/1294877242517610/

Test Plan: Added unit test, also verified model lowering can now work.

Reviewed By: desertfire

Differential Revision: D99365299


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo