### PR TITLE
[CUDA] Fix wrong LayoutB in fpA_intB_gemm.h

### DIFF
--- a/aten/src/ATen/native/cuda/cutlass_extensions/gemm/kernel/fpA_intB_gemm.h
+++ b/aten/src/ATen/native/cuda/cutlass_extensions/gemm/kernel/fpA_intB_gemm.h
@@ -68,7 +68,7 @@ struct GemmFpAIntB {
     using ElementA     = typename Mma::IteratorA::Element;
     using LayoutA      = typename Mma::IteratorA::Layout;
     using ElementB     = typename Mma::IteratorB::Element;
-    using LayoutB      = typename Mma::IteratorB::Element;
+    using LayoutB      = typename Mma::IteratorB::Layout;
     using ElementC     = typename Epilogue::OutputTileIterator::Element;
     using LayoutC      = typename Mma::LayoutC;
     using ElementScale = ElementC;


### PR DESCRIPTION
    using ElementB     = typename Mma::IteratorB::Element;
    using LayoutB      = typename Mma::IteratorB::Element;

is clearly a typo and has to be

    using ElementB     = typename Mma::IteratorB::Element;
    using LayoutB      = typename Mma::IteratorB::Layout;

Contributed by Benedikt Johannes