### PR TITLE
Fix WorkspaceArg autotuning allocation: count => bytes

### DIFF
--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -328,25 +328,74 @@ class TestMaxAutotune(TestCase):
             mm_tma_heuristic.mm_configs = original_tma_configs
             mm_heuristic.mm_configs = original_mm_configs
 
+    @unittest.skipIf(
+        not has_triton_tma_device(), "Need device-side TMA support in Triton"
+    )
     def test_workspace_size_bytes_accounts_for_dtype(self):
-        """Workspace size for autotuning must be in bytes, not element count."""
+        """workspace_size passed to benchmark request must be in bytes, not elements."""
         import sympy
 
         from torch._inductor.codegen.common import WorkspaceZeroMode
         from torch._inductor.utils import get_dtype_size
 
         count = 1024
-        for dtype in [torch.uint8, torch.float16, torch.float32, torch.float64]:
-            ws = WorkspaceArg(
-                count=sympy.Integer(count),
-                zero_mode=WorkspaceZeroMode.UNINITIALIZED,
-                device=torch.device("cpu"),
-                outer_name="test_ws",
-                dtype=dtype,
-            )
-            expected_bytes = count * get_dtype_size(dtype)
-            actual_bytes = int(ws.count) * get_dtype_size(ws.dtype)
-            self.assertEqual(actual_bytes, expected_bytes)
+        dtype = torch.float32
+        expected_bytes = count * get_dtype_size(dtype)
+
+        fake_ws = WorkspaceArg(
+            count=sympy.Integer(count),
+            zero_mode=WorkspaceZeroMode.UNINITIALIZED,
+            device=torch.device(GPU_TYPE),
+            outer_name="test_ws",
+            dtype=dtype,
+        )
+
+        captured_sizes = []
+        orig_init = TritonBenchmarkRequest.__init__
+
+        def spy_init(self, *args, **kwargs):
+            captured_sizes.append(kwargs.get("workspace_size"))
+            orig_init(self, *args, **kwargs)
+
+        M, K, N = 64, 64, 64
+        a = torch.randn(M, K, device=GPU_TYPE, dtype=torch.bfloat16)
+        b = torch.randn(K, N, device=GPU_TYPE, dtype=torch.bfloat16)
+
+        mm_tma_heuristic = CUDAPersistentTMATemplateConfigHeuristic()
+        mm_heuristic = CUDAMMTemplateConfigHeuristic()
+        original_tma_configs = mm_tma_heuristic.mm_configs
+        original_mm_configs = mm_heuristic.mm_configs
+
+        try:
+            mm_heuristic.mm_configs = []
+            mm_tma_heuristic.mm_configs = [GemmConfig(128, 128, 64, 4, 8, group_m=8)]
+
+            with (
+                config.patch(
+                    {
+                        "max_autotune_gemm": True,
+                        "max_autotune_gemm_backends": "TRITON",
+                        "triton.enable_persistent_tma_matmul": True,
+                    }
+                ),
+                fresh_cache(),
+                patch(
+                    "torch._inductor.template_heuristics.triton.get_tma_workspace_arg",
+                    return_value=fake_ws,
+                ),
+                patch.object(TritonBenchmarkRequest, "__init__", spy_init),
+            ):
+                torch._dynamo.reset()
+                torch.compile(torch.mm, mode="max-autotune-no-cudagraphs")(a, b)
+
+        finally:
+            mm_tma_heuristic.mm_configs = original_tma_configs
+            mm_heuristic.mm_configs = original_mm_configs
+
+        ws_sizes = [s for s in captured_sizes if s is not None]
+        self.assertTrue(len(ws_sizes) > 0, "No workspace benchmark requests created")
+        for size in ws_sizes:
+            self.assertEqual(size, expected_bytes)
 
     @unittest.skipIf(
         not has_triton_tma_device(), "Need device-side TMA support in Triton"

--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -328,6 +328,26 @@ class TestMaxAutotune(TestCase):
             mm_tma_heuristic.mm_configs = original_tma_configs
             mm_heuristic.mm_configs = original_mm_configs
 
+    def test_workspace_size_bytes_accounts_for_dtype(self):
+        """Workspace size for autotuning must be in bytes, not element count."""
+        import sympy
+
+        from torch._inductor.codegen.common import WorkspaceZeroMode
+        from torch._inductor.utils import get_dtype_size
+
+        count = 1024
+        for dtype in [torch.uint8, torch.float16, torch.float32, torch.float64]:
+            ws = WorkspaceArg(
+                count=sympy.Integer(count),
+                zero_mode=WorkspaceZeroMode.UNINITIALIZED,
+                device=torch.device("cpu"),
+                outer_name="test_ws",
+                dtype=dtype,
+            )
+            expected_bytes = count * get_dtype_size(dtype)
+            actual_bytes = int(ws.count) * get_dtype_size(ws.dtype)
+            self.assertEqual(actual_bytes, expected_bytes)
+
     @unittest.skipIf(
         not has_triton_tma_device(), "Need device-side TMA support in Triton"
     )

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -2784,7 +2784,8 @@ class TritonTemplate(KernelTemplate):
         workspace_zero_fill = False
         workspace_args = []
         if workspace_arg is not None:
-            workspace_size_bytes = workspace_arg.count
+            ws_count = V.graph.sizevars.optimization_hint(workspace_arg.count)
+            workspace_size_bytes = ws_count * get_dtype_size(workspace_arg.dtype)
             workspace_zero_fill = (
                 workspace_arg.zero_mode != WorkspaceZeroMode.UNINITIALIZED
             )


### PR DESCRIPTION
`workspace_size_bytes` was set to `workspace_arg.count`, which is an element count, not a byte count. The default `dtype=torch.uint8` (1 byte/element) masked the bug, but any workspace with a larger dtype (e.g. torch.float32) would get a too-small allocation, causing silent corruption during autotuning benchmarks. Also uses `optimization_hint` to resolve the symbolic count to a concrete int for the autotuning subprocess.

I hit this error when a downstream project creates a WorkspaceArg with dtype=torch.float32 for the split-K workspace.

Test plan:
`pytest test/inductor/test_max_autotune.py -xvs -k test_workspace_size_bytes_accounts_for_dtype`

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo