### PR TITLE
[ROCM][CI] Add build_env check for rocm

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -17,7 +17,8 @@ source "$(dirname "${BASH_SOURCE[0]}")/common-build.sh"
 # Only change workspace permissions if passwordless sudo is available
 # (e.g. ROCm and s390x CI jobs lack it, and changing permissions
 # can leave the workspace in a bad state for cancelled jobs)
-if sudo -n true 2>/dev/null && [[ -d /var/lib/jenkins/workspace ]]; then
+# passwordless sudo is available but this change leaves rocm runners in a bad state. Exception for rocm.
+if [[ "$BUILD_ENVIRONMENT" != *rocm* ]] && sudo -n true 2>/dev/null && [[ -d /var/lib/jenkins/workspace ]]; then
   # Workaround for dind-rootless userid mapping (https://github.com/pytorch/ci-infra/issues/96)
   WORKSPACE_ORIGINAL_OWNER_ID=$(stat -c '%u' "/var/lib/jenkins/workspace")
   cleanup_workspace() {


### PR DESCRIPTION
https://github.com/pytorch/pytorch/commit/1c6eb4d746e8eb769f60fc9071ffa1ad6cccb7db
This commit appears to be causing failures with persistent runners. The `_work` files end up in a state where they can't be deleted, which causes the following jobs to fail like the following one:
https://github.com/pytorch/pytorch/actions/runs/23372593644/job/68000498120


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang