### PR TITLE
[CUDACachingAllocator] Add flag indicating RingBuffer Overflow

### DIFF
--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -1218,6 +1218,7 @@ class RingBuffer {
     if (alloc_trace->size() < alloc_trace_max_entries_) {
       alloc_trace->emplace_back(entry);
     } else {
+      alloc_trace_overflowed_ = true;
       (*alloc_trace)[alloc_trace_next++] = entry;
       if (alloc_trace_next == alloc_trace_max_entries_) {
         alloc_trace_next = 0;
@@ -1238,8 +1239,19 @@ class RingBuffer {
   void clear() {
     std::lock_guard<std::mutex> lk(alloc_trace_lock);
     alloc_trace_next = 0;
+    alloc_trace_overflowed_ = false;
     alloc_trace->clear();
     alloc_trace->shrink_to_fit();
+  }
+
+  bool hasOverflowed() const {
+    std::lock_guard<std::mutex> lk(alloc_trace_lock);
+    return alloc_trace_overflowed_;
+  }
+
+  size_t maxEntries() const {
+    std::lock_guard<std::mutex> lk(alloc_trace_lock);
+    return alloc_trace_max_entries_;
   }
 
  private:
@@ -1249,6 +1261,7 @@ class RingBuffer {
   // under alloc_trace_lock.
   mutable std::mutex alloc_trace_lock;
   size_t alloc_trace_next = 0;
+  bool alloc_trace_overflowed_ = false;
   std::vector<T>*
       alloc_trace; // pointer because we need to intentionally leak this on
                    // deallocation it can hold references to Python state which
@@ -1419,6 +1432,14 @@ class DeviceCachingAllocator {
   static thread_local std::string user_metadata;
 
  public:
+  bool traceBufferOverflowed() const {
+    return alloc_buffer.hasOverflowed();
+  }
+
+  size_t traceBufferMaxEntries() const {
+    return alloc_buffer.maxEntries();
+  }
+
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   explicit DeviceCachingAllocator(c10::DeviceIndex id)
       : device_id(id),
@@ -4369,6 +4390,10 @@ class NativeCachingAllocator : public CUDAAllocator {
       // Get the device_traces' TraceEntry lists.
       for (auto& da : device_allocator) {
         result.device_traces.emplace_back(da->trace(tsc_to_us));
+        result.trace_alloc_max_entries.push_back(
+            da->traceBufferMaxEntries());
+        result.trace_alloc_overflowed.push_back(
+            da->traceBufferOverflowed());
         auto snap = da->snapshot(mempool_id);
         result.segments.insert(result.segments.end(), snap.begin(), snap.end());
       }

--- a/c10/cuda/CUDACachingAllocator.h
+++ b/c10/cuda/CUDACachingAllocator.h
@@ -79,6 +79,9 @@ struct SnapshotInfo {
   std::vector<std::vector<CachingDeviceAllocator::TraceEntry>> device_traces;
   std::vector<CachingDeviceAllocator::AnnotationEntry> external_annotations;
   AllocatorConfigInfo config_metadata;
+  // Per-device ring buffer status, indexed same as device_traces.
+  std::vector<size_t> trace_alloc_max_entries;
+  std::vector<bool> trace_alloc_overflowed;
 };
 
 // returns the pointers freed in the pool

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -5225,6 +5225,56 @@ print(f"{torch.cuda.device_count()}")
             )
             self.assertEqual("1", r)
 
+    def test_ring_buffer_overflow_per_device(self):
+        torch.cuda.memory.empty_cache()
+        torch.cuda.memory._record_memory_history(
+            max_entries=10, clear_history=True
+        )
+        for _ in range(20):
+            t = torch.randn(1024, device="cuda")
+            del t
+        snapshot = torch.cuda.memory._snapshot()
+        torch.cuda.memory._record_memory_history(enabled=None)
+
+        self.assertIn("trace_alloc_overflowed", snapshot)
+        self.assertIn("trace_alloc_max_entries", snapshot)
+        self.assertIsInstance(snapshot["trace_alloc_overflowed"], list)
+        self.assertIsInstance(snapshot["trace_alloc_max_entries"], list)
+        # Per-device lists should match device_traces length
+        self.assertEqual(
+            len(snapshot["trace_alloc_overflowed"]),
+            len(snapshot["device_traces"]),
+        )
+        self.assertEqual(
+            len(snapshot["trace_alloc_max_entries"]),
+            len(snapshot["device_traces"]),
+        )
+        # The active device should have max_entries=10
+        device_idx = torch.cuda.current_device()
+        self.assertEqual(snapshot["trace_alloc_max_entries"][device_idx], 10)
+        # With 20 alloc+free cycles on a 10-entry buffer, it must overflow
+        self.assertTrue(snapshot["trace_alloc_overflowed"][device_idx])
+        # Inactive devices should not overflow
+        for i, overflowed in enumerate(snapshot["trace_alloc_overflowed"]):
+            if i != device_idx:
+                self.assertFalse(overflowed)
+
+    def test_ring_buffer_no_overflow(self):
+        torch.cuda.memory.empty_cache()
+        torch.cuda.memory._record_memory_history(
+            max_entries=1_000_000, clear_history=True
+        )
+        t = torch.randn(1024, device="cuda")
+        del t
+        snapshot = torch.cuda.memory._snapshot()
+        torch.cuda.memory._record_memory_history(enabled=None)
+
+        device_idx = torch.cuda.current_device()
+        self.assertFalse(snapshot["trace_alloc_overflowed"][device_idx])
+        self.assertEqual(
+            snapshot["trace_alloc_max_entries"][device_idx], 1_000_000
+        )
+
 
 MIN_BLOCK_SIZE = 512
 SMALL_SIZE = 1048576

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -967,10 +967,26 @@ PyObject* THCPModule_memorySnapshot(PyObject* _unused, PyObject* arg) {
   }
   allocator_settings[roundup_power2_divisions_s] = roundup_settings;
 
+  // Per-device ring buffer overflow status, indexed same as device_traces.
+  // trace_alloc_max_entries[i]: configured max_entries for device i's ring buffer.
+  // trace_alloc_overflowed[i]: true if device i's ring buffer wrapped around,
+  //   meaning some trace events were overwritten and "alloc not recorded" blocks
+  //   may appear in the visualization.
+  py::list trace_max_entries_list;
+  for (auto v : snapshot.trace_alloc_max_entries) {
+    trace_max_entries_list.append(int64_t(v));
+  }
+  py::list trace_overflowed_list;
+  for (auto v : snapshot.trace_alloc_overflowed) {
+    trace_overflowed_list.append(bool(v));
+  }
+
   py::dict result;
   result["segments"] = segments;
   result["device_traces"] = traces;
   result["allocator_settings"] = allocator_settings;
+  result["trace_alloc_max_entries"] = trace_max_entries_list;
+  result["trace_alloc_overflowed"] = trace_overflowed_list;
   result["external_annotations"] = external_annotations;
 
   auto frames = py_symbolize(to_gather_frames);

--- a/torch/csrc/cuda/memory_snapshot.cpp
+++ b/torch/csrc/cuda/memory_snapshot.cpp
@@ -500,9 +500,20 @@ std::string _memory_snapshot_pickled() {
   }
   allocator_settings.insert(roundup_power2_divisions_s, roundup_settings);
 
+  auto trace_max_entries_list = new_list();
+  for (auto v : snapshot.trace_alloc_max_entries) {
+    trace_max_entries_list.push_back(int64_t(v));
+  }
+  auto trace_overflowed_list = new_list();
+  for (auto v : snapshot.trace_alloc_overflowed) {
+    trace_overflowed_list.push_back(bool(v));
+  }
+
   auto result = new_dict();
   result.insert("segments", segments);
   result.insert("device_traces", traces);
+  result.insert("trace_alloc_max_entries", trace_max_entries_list);
+  result.insert("trace_alloc_overflowed", trace_overflowed_list);
   result.insert("allocator_settings", allocator_settings);
   result.insert("external_annotations", external_annotations);
 


### PR DESCRIPTION
## Motivation

When analyzing a memory snapshot, there's currently no way to tell whether trace
events are missing because the ring buffer overflowed (events were silently
overwritten) or because recording simply hadn't started yet. This makes it hard
to diagnose "alloc not recorded" blocks in the memory visualizer — the user
can't tell if they need to increase `max_entries` or if the allocations genuinely
happened before recording began.

This PR adds per-device `trace_alloc_max_entries` and `trace_alloc_overflowed`
fields to the snapshot, so tools and users can definitively determine whether
events were lost to ring buffer wrap-around.

# [CUDACachingAllocator] Add per-device ring buffer overflow flag to memory snapshots

## Summary

Adds per-device `trace_alloc_overflowed` and `trace_alloc_max_entries` fields to
the memory snapshot dict returned by `torch.cuda.memory._snapshot()`. These let
users and visualization tools (MemoryViz) know when trace events have been lost
due to the ring buffer wrapping around.

Previously there was no way to tell if a snapshot's trace was complete or if
some events were silently dropped. This caused confusing "alloc not recorded"
blocks in the memory visualizer with no explanation.

## Changes

- **`RingBuffer` (CUDACachingAllocator.cpp)**: Track overflow with a
  `alloc_trace_overflowed_` bool, set when the buffer wraps. Add
  `hasOverflowed()` and `maxEntries()` query methods. Reset on `clear()`.
- **`DeviceCachingAllocator`**: Expose `traceBufferOverflowed()` and
  `traceBufferMaxEntries()` public accessors.
- **`SnapshotInfo` (CUDACachingAllocator.h)**: Add per-device vectors
  `trace_alloc_max_entries` and `trace_alloc_overflowed`, indexed same as
  `device_traces`.
- **`NativeCachingAllocator::snapshot()`**: Collect overflow info in the same
  loop that builds `device_traces`.
- **Module.cpp / memory_snapshot.cpp**: Serialize as top-level per-device lists
  in both the Python dict and pickle paths.
- **test/test_cuda.py**: Two tests in `TestCudaAllocator`:
  - `test_ring_buffer_overflow_per_device`: overflow with small buffer, verify
    per-device flags
  - `test_ring_buffer_no_overflow`: large buffer, verify no overflow

## Snapshot format

```python
snapshot = torch.cuda.memory._snapshot()
# Per-device lists, indexed same as snapshot["device_traces"]
snapshot["trace_alloc_max_entries"]  # [100000, 100000, ...]
snapshot["trace_alloc_overflowed"]   # [False, False, True, ...]
```

## Test plan

```
conda run -n pytorch-3.12 --no-capture-output python test/test_cuda.py \
  TestCudaAllocator.test_ring_buffer_overflow_per_device \
  TestCudaAllocator.test_ring_buffer_no_overflow -v
```

Authored with Claude.


