### PR TITLE
[PT2][export] Fix unflatten KeyError for @N-suffixed module FQNs (#179278)

### DIFF
--- a/test/export/test_unflatten.py
+++ b/test/export/test_unflatten.py
@@ -178,6 +178,48 @@ class TestUnflatten(TestCase):
             id(getattr(unflattened_module.sub_net, "2")),
         )
 
+    def test_unflatten_shared_submodule_reorder(self):
+        """Test that _reorder_submodules handles @N-suffixed FQNs correctly.
+
+        When modules are shared (aliased), PyTorch assigns @N suffixes to
+        duplicate entries in _modules. The fqn_order dict (built from
+        fqn_list) filters out @N entries, so _reorder_submodules must fall
+        back to the base FQN for ordering.
+        """
+
+        class Block(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.linear = torch.nn.Linear(10, 10)
+
+            def forward(self, x):
+                return self.linear(x)
+
+        class Model(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                shared_block = Block()
+                self.blocks = torch.nn.Sequential(
+                    shared_block,
+                    torch.nn.ReLU(),
+                    shared_block,
+                    torch.nn.ReLU(),
+                )
+
+            def forward(self, x):
+                return self.blocks(x)
+
+        eager_module = Model()
+        inps = (torch.rand(2, 10),)
+        export_module = export(eager_module, inps, {}, strict=True)
+        unflattened_module = unflatten(export_module)
+        self.compare_outputs(eager_module, unflattened_module, inps)
+        # Verify shared identity is preserved
+        self.assertEqual(
+            id(getattr(unflattened_module.blocks, "0")),
+            id(getattr(unflattened_module.blocks, "2")),
+        )
+
     def test_assert_tensor_metadata_stack(self):
         class N(torch.nn.Module):
             def __init__(self):

--- a/torch/export/unflatten.py
+++ b/torch/export/unflatten.py
@@ -1650,7 +1650,10 @@ def _reorder_submodules(
         fqn = prefix + name
         _reorder_submodules(child, fqn_order, prefix=fqn.split("@")[0] + ".")
         delattr(parent, name)
-        children.append((fqn_order[fqn], name, child))
+        base_fqn = fqn.split("@")[0]
+        children.append(
+            (fqn_order.get(fqn, fqn_order.get(base_fqn, len(fqn_order))), name, child)
+        )
     children.sort(key=operator.itemgetter(0))
     for _, name, child in children:
         parent.register_module(name, child)


### PR DESCRIPTION
Summary:

During `torch.export.unflatten`, `_reorder_submodules` fails with a `KeyError`
when module FQNs contain `N` suffixes. PyTorch uses `N` suffixes for duplicate
(shared/aliased) submodules — e.g., when the same `LayerNorm` or `Block` module
appears multiple times in a `Sequential`.

The `fqn_order` dict is built from a filtered `fqn_list` that excludes all `N`
entries (line 576: `fqn_list = [fqn for fqn in fqn_list if "@" not in fqn]`).
However, `_reorder_submodules` iterates `parent._modules.items()` which includes
`N`-suffixed keys. When it looks up `fqn_order[fqn]` for an `N` FQN, it raises
`KeyError`.

**Fix**: Use `fqn_order.get(fqn, fqn_order.get(base_fqn, len(fqn_order)))` where
`base_fqn = fqn.split("@")[0]`. This falls back to the base FQN for ordering,
which is correct since `N` modules are duplicates that should sort the same as
their base.

Authored with Claude.

Test Plan:
- Added `test_unflatten_shared_submodule_reorder` unit test that creates a model
  with shared `Block` modules in a `Sequential`, exports, unflattens, and verifies
  correct output and shared identity preservation.
- All 30 existing `TestUnflatten` tests pass: https://www.internalfb.com/intern/testinfra/testrun/20266198334622134

Differential Revision: D99393147


