### PR TITLE
[pipelining] Guard PipelineScheduleMulti against non-adjacent communication

### DIFF
--- a/test/distributed/pipelining/test_schedule.py
+++ b/test/distributed/pipelining/test_schedule.py
@@ -35,6 +35,7 @@ from torch.distributed.pipelining.schedules import (
     B,
     F,
     get_schedule_class,
+    PipelineScheduleMulti,
     I,
     PipelineScheduleSingle,
     RECV_F,
@@ -116,6 +117,93 @@ class ScheduleTest(TestCase):
             # Test that the original name is included in the error message
             with self.assertRaisesRegex(ValueError, f"{name}"):
                 get_schedule_class(name)
+
+    def test_pipeline_schedule_multi_rejects_skip_connection_topology(self):
+        class _PeerOnlyOp:
+            def __init__(self, peer: int):
+                self.peer = peer
+
+        class _SkipConnectionStage(MockPipelineStage):
+            def __init__(self):
+                super().__init__(num_stages=3, group_size=3, group_rank=0)
+                self.stage_index = 0
+
+            def _get_init_p2p_neighbors_ops(self):
+                return []
+
+            def _prepare_forward_infra(self, *args, **kwargs):
+                self.args_recv_info = {0: tuple()}
+                self.act_send_info = {0: [2]}
+                return tuple()
+
+            def _prepare_backward_infra(self, *args, **kwargs):
+                return None
+
+            def clear_runtime_states(self):
+                return None
+
+            def get_fwd_recv_ops(self, mb_index):
+                return []
+
+            def get_fwd_send_ops(self, mb_index):
+                # Stage 0 should only send to stage 1 (rank 1), but this
+                # intentionally models a skip connection to stage 2 (rank 2).
+                return [_PeerOnlyOp(peer=2)]
+
+            def get_bwd_recv_ops(self, mb_index):
+                return []
+
+            def get_bwd_send_ops(self, mb_index):
+                return []
+
+        schedule = PipelineScheduleMulti([_SkipConnectionStage()], n_microbatches=1)
+        schedule.pipeline_order = {0: [None], 1: [None], 2: [None]}
+
+        with self.assertRaisesRegex(RuntimeError, "adjacent-stage communication"):
+            schedule.step()
+
+    def test_pipeline_schedule_multi_allows_adjacent_topology(self):
+        class _PeerOnlyOp:
+            def __init__(self, peer: int):
+                self.peer = peer
+
+        class _AdjacentStage(MockPipelineStage):
+            def __init__(self):
+                super().__init__(num_stages=3, group_size=3, group_rank=0)
+                self.stage_index = 0
+
+            def _get_init_p2p_neighbors_ops(self):
+                return []
+
+            def _prepare_forward_infra(self, *args, **kwargs):
+                self.args_recv_info = {0: tuple()}
+                self.act_send_info = {0: [1]}
+                return tuple()
+
+            def _prepare_backward_infra(self, *args, **kwargs):
+                return None
+
+            def clear_runtime_states(self):
+                return None
+
+            def get_fwd_recv_ops(self, mb_index):
+                return []
+
+            def get_fwd_send_ops(self, mb_index):
+                # Stage 0 -> stage 1 (adjacent) is valid.
+                return [_PeerOnlyOp(peer=1)]
+
+            def get_bwd_recv_ops(self, mb_index):
+                return []
+
+            def get_bwd_send_ops(self, mb_index):
+                return []
+
+        schedule = PipelineScheduleMulti([_AdjacentStage()], n_microbatches=1)
+        schedule.pipeline_order = {0: [None], 1: [None], 2: [None]}
+
+        # Should run without topology validation errors.
+        schedule.step()
 
     @parametrize(
         "ScheduleClass",

--- a/torch/distributed/pipelining/schedules.py
+++ b/torch/distributed/pipelining/schedules.py
@@ -23,7 +23,7 @@ from torch.profiler import record_function
 
 from ._utils import generate_rank_to_stage_mapping, generate_stage_to_rank_mapping
 from .microbatch import merge_chunks, split_args_kwargs_into_chunks, TensorChunkSpec
-from .stage import _PipelineStageBase
+from .stage import _PipelineStageBase, _RecvInfo
 
 
 __all__ = [
@@ -1554,12 +1554,66 @@ class PipelineScheduleMulti(_PipelineSchedule):
                     next_stage_args = stage._prepare_forward_infra(
                         self._n_microbatches, next_stage_args, kwargs
                     )
+
+            # PipelineScheduleMulti's runtime communication logic assumes only
+            # adjacent stage communication (stage i <-> i +/- 1). Validate
+            # this explicitly to avoid silent incorrectness for unsupported
+            # skip-connection topologies.
+            self._validate_adjacent_stage_communication()
             self._stages_forward_initialized = True
 
         if self._has_backward and not self._stages_backward_initialized:
             for stage in self._stages:
                 stage._prepare_backward_infra(self._n_microbatches)
             self._stages_backward_initialized = True
+
+    def _validate_adjacent_stage_communication(self) -> None:
+        """Validate that stage communication follows adjacent-stage topology only."""
+
+        def _check_stage_indices(
+            stage_idx: int,
+            direction: str,
+            actual_stage_indices: set[int],
+            expected_stage_indices: set[int],
+        ) -> None:
+            if actual_stage_indices != expected_stage_indices:
+                raise RuntimeError(
+                    "PipelineScheduleMulti only supports adjacent-stage "
+                    f"communication, but stage {stage_idx} has {direction} "
+                    f"stages {sorted(actual_stage_indices)} (expected "
+                    f"{sorted(expected_stage_indices)}). This commonly "
+                    "indicates skip connections, which are unsupported in "
+                    "this schedule runtime."
+                )
+
+        for stage in self._stages:
+            stage_idx = stage.stage_index
+            actual_fwd_recv_sources = {
+                info.source
+                for info in stage.args_recv_info[0]
+                if isinstance(info, _RecvInfo)
+            }
+            expected_fwd_recv_sources = set() if stage.is_first else {stage_idx - 1}
+            _check_stage_indices(
+                stage_idx,
+                "forward recv",
+                actual_fwd_recv_sources,
+                expected_fwd_recv_sources,
+            )
+
+            actual_fwd_send_dests = {
+                dst
+                for dsts in stage.act_send_info.values()
+                for dst in dsts
+                if dst is not None
+            }
+            expected_fwd_send_dests = set() if stage.is_last else {stage_idx + 1}
+            _check_stage_indices(
+                stage_idx,
+                "forward send",
+                actual_fwd_send_dests,
+                expected_fwd_send_dests,
+            )
 
     def _validate_and_set_stage_mapping(
         self, actions: dict[int, list[_Action | None]]


### PR DESCRIPTION
PipelineScheduleMulti currently assumes communication only happens between adjacent stages, but that was never validated explicitly. With non-adjacent stage communication (for example skip-connection topologies), it could proceed under unsupported assumptions.

This adds an initialization-time check based on `args_recv_info` and `act_send_info`, and raises a clear `RuntimeError` when non-adjacent communication is detected. Adjacent topologies continue to work as before.

Added focused tests for both rejecting non-adjacent topologies and allowing adjacent ones.

Local validation:

```bash
PYTHONPATH=test/distributed/pipelining /Users/haxx_sh/Desktop/PyTorchOpenSource/venv/bin/python -m pytest test/distributed/pipelining/test_schedule.py -k "pipeline_schedule_multi_rejects_skip_connection_topology or pipeline_schedule_multi_allows_adjacent_topology or schedule_with_single_stage or schedule_eval_then_train or test_send_recv" -q