### PR TITLE
BFloat16 NaN values have a same representation across different  HIP platforms.

### DIFF
--- a/torch/headeronly/util/BFloat16.h
+++ b/torch/headeronly/util/BFloat16.h
@@ -124,9 +124,11 @@ C10_CLANG_DIAGNOSTIC_IGNORE("-Wimplicit-int-float-conversion")
 /// Constructors
 inline C10_HOST_DEVICE BFloat16::BFloat16(float value)
     :
-#if defined(__CUDACC__) &&                                                   \
-    (!defined(USE_ROCM) && defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800 || \
-     defined(USE_ROCM) && (TORCH_HIP_VERSION >= 702))
+#if defined(__HIPCC__) && defined(USE_ROCM) && (TORCH_HIP_VERSION >= 702)
+      // Ensure NAN have same canonical form as in RNE path
+      x(value != value ? UINT16_C(0x7FC0) : __bfloat16_as_ushort(__float2bfloat16(value)))
+#elif defined(__CUDACC__) &&                                                 \
+    !defined(USE_ROCM) && defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800
       x(__bfloat16_as_ushort(__float2bfloat16(value)))
 #elif defined(__SYCL_DEVICE_ONLY__) && \
     defined(SYCL_EXT_ONEAPI_BFLOAT16_MATH_FUNCTIONS)

--- a/torch/headeronly/util/BFloat16.h
+++ b/torch/headeronly/util/BFloat16.h
@@ -126,9 +126,10 @@ inline C10_HOST_DEVICE BFloat16::BFloat16(float value)
     :
 #if defined(__HIPCC__) && defined(USE_ROCM) && (TORCH_HIP_VERSION >= 702)
       // Ensure NAN have same canonical form as in RNE path
-      x(value != value ? UINT16_C(0x7FC0) : __bfloat16_as_ushort(__float2bfloat16(value)))
-#elif defined(__CUDACC__) &&                                                 \
-    !defined(USE_ROCM) && defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800
+      x(value != value ? UINT16_C(0x7FC0)
+                       : __bfloat16_as_ushort(__float2bfloat16(value)))
+#elif defined(__CUDACC__) && !defined(USE_ROCM) && defined(__CUDA_ARCH__) && \
+    __CUDA_ARCH__ >= 800
       x(__bfloat16_as_ushort(__float2bfloat16(value)))
 #elif defined(__SYCL_DEVICE_ONLY__) && \
     defined(SYCL_EXT_ONEAPI_BFLOAT16_MATH_FUNCTIONS)


### PR DESCRIPTION
Recent chages in https://github.com/pytorch/pytorch/pull/178814 make use of hardware conversion:

HIP hardware implementation bitwise corresponds to Pytorch round_to_nearest_even function. Numerous random numbers returned same bitwise result. Only NaN numbers are not guaranteed to be returned in canonical form, rather 2 NaN bits are set.
 
```
Device: AMD Radeon Graphics
Comparing c10::detail::round_to_nearest_even vs __bfloat16_as_ushort(__float2bfloat16) on GPU
TORCH_HIP_VERSION=702  (BFloat16(float) uses intrinsic when >= 702)
mode=grid  n=100000

  [       416]  f32=0x7FD8C09A  rne=0x7FC0  hip=0x7FD8  isnan=1
  [       460]  f32=0x7FF51DC5  rne=0x7FC0  hip=0x7FF5  isnan=1
  [       536]  f32=0x7FBE4F1B  rne=0x7FC0  hip=0x7FFE  isnan=1
  [      1092]  f32=0xFFA5EEAD  rne=0x7FC0  hip=0xFFE5  isnan=1
  [      3964]  f32=0x7FF96024  rne=0x7FC0  hip=0x7FF9  isnan=1
  [      4376]  f32=0xFFC5102C  rne=0x7FC0  hip=0xFFC5  isnan=1
  [      5076]  f32=0xFFD7A3C0  rne=0x7FC0  hip=0xFFD7  isnan=1
  [      5852]  f32=0xFFF5BC71  rne=0x7FC0  hip=0xFFF5  isnan=1
Results:
  mismatches: 105 / 100000  (0.105%)
  of those, f != f (NaN input): 105
Host check (first min(n,100000) elements): BFloat16(f).x vs __float2bfloat16 mismatch: 0``
```
After this change, performance does not degrade, rather is even better:

```
Device: AMD Radeon Graphics
c10::BFloat16 on ROCm: + and * use float promotion (see BFloat16.h).
Grid: 4096 x 256 = 1048576 threads, repeat = 80000

Kernel                            time          Gop/s
------------------------------------------------------------
__hip_bfloat16 __hadd           10.110 ms      8297.68 Gop/s
__hip_bfloat16 __hmul           10.091 ms      8313.14 Gop/s
c10::BFloat16 operator+          9.601 ms      8737.12 Gop/s
c10::BFloat16 operator*          9.991 ms      8395.80 Gop/s
------------------------------------------------------------
Each line counts one scalar add or mul in the loop body.
```