### PR TITLE
Add append_system_prompt to Claude Code workflow for PR reviews

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -17,3 +17,6 @@ jobs:
     secrets: inherit
     with:
       additional_claude_args: '--allowedTools Skill'
+      append_system_prompt: |
+        When asked to review a PR, always use the /pr-review skill first.
+        It contains PyTorch-specific review guidelines, output format, and critical checks.


### PR DESCRIPTION
## Author Notes

Tested in ciforge in https://github.com/pytorch/ciforge/pull/228 and requires https://github.com/pytorch/test-infra/pull/7925 . It should ensure our pr-review skill is used.

## Agent Notes

Use the new `append_system_prompt` input from pytorch/test-infra#7925 to inject a system-level instruction ensuring the `/pr-review` skill is always invoked when the CI bot is asked to review a PR. This reinforces the existing CLAUDE.md guidance at the system prompt level.

Authored with Claude.