### PR TITLE
[c10d] Register atexit handler to destroy process groups before inter…

### DIFF
--- a/test/distributed/test_c10d_gloo.py
+++ b/test/distributed/test_c10d_gloo.py
@@ -3516,6 +3516,41 @@ class LargeCommTest(test_c10d_common.AbstractLargeCommTest, MultiProcessTestCase
         self._test_new_group_ordered(backend="gloo")
 
 
+class GlooAtexitTest(TestCase):
+    """Test that the atexit handler destroys process groups cleanly."""
+
+    @requires_gloo()
+    def test_exit_without_destroy_pg(self):
+        # Verify that a process using gloo exits cleanly even without an
+        # explicit destroy_process_group() call.  Before the atexit handler was
+        # added, Gloo worker threads could try to acquire the GIL during
+        # interpreter finalization, causing SIGABRT.
+        script = """\
+import os, tempfile, torch, torch.distributed as dist
+f = tempfile.NamedTemporaryFile(delete=False)
+store = dist.FileStore(f.name, 1)
+dist.init_process_group(backend="gloo", store=store, rank=0, world_size=1)
+t = torch.ones(4)
+dist.all_reduce(t)
+os.unlink(f.name)
+# Exit without calling destroy_process_group()
+"""
+        import signal
+        import subprocess
+
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            timeout=60,
+            capture_output=True,
+        )
+        self.assertNotEqual(
+            result.returncode,
+            -signal.SIGABRT,
+            f"Process died with SIGABRT:\n{result.stderr.decode(errors='replace')}",
+        )
+        self.assertEqual(result.returncode, 0, result.stderr.decode(errors="replace"))
+
+
 if __name__ == "__main__":
     if torch.cuda._initialized:
         raise AssertionError(

--- a/torch/csrc/distributed/c10d/ProcessGroupGloo.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupGloo.cpp
@@ -664,7 +664,15 @@ ProcessGroupGloo::ProcessGroupGloo(
 }
 
 ProcessGroupGloo::~ProcessGroupGloo() {
+  shutdown();
+}
+
+void ProcessGroupGloo::shutdown() {
   std::unique_lock<std::mutex> lock(workMutex_);
+  if (stop_) {
+    // Already shut down.
+    return;
+  }
   workConsumeCV_.wait(lock, [&] { return workQueue_.empty(); });
 
   // Queue is empty, signal stop

--- a/torch/csrc/distributed/c10d/ProcessGroupGloo.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupGloo.hpp
@@ -300,6 +300,8 @@ class TORCH_API ProcessGroupGloo : public Backend {
 
   ~ProcessGroupGloo() override;
 
+  void shutdown() override;
+
   c10::intrusive_ptr<Options> getOptions() {
     return options_;
   }

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -1,6 +1,7 @@
 # mypy: allow-untyped-defs
 """Distributed Collective Communication (c10d)."""
 
+import atexit
 import collections.abc
 import contextlib
 import copy
@@ -1912,6 +1913,26 @@ def init_process_group(
             # Use store based barrier here since barrier() used a bunch of
             # default devices and messes up NCCL internal state.
             _store_based_barrier(rank, store, group_name, world_size, timeout)
+
+    # Ensure Gloo process groups are shut down before the Python interpreter
+    # starts finalizing. Without this, Gloo's C++ worker threads may try to
+    # acquire the GIL to decref tensors after the interpreter is torn down,
+    # causing SIGABRT. We only target Gloo here because calling shutdown() on
+    # other backends (e.g. NCCL) during atexit could hang if peers are gone.
+    atexit.register(_shutdown_gloo_backends)
+
+
+def _shutdown_gloo_backends():
+    if not is_gloo_available():
+        return
+    for pg in list(_world.pg_map.keys()):
+        for device_type in pg._device_types:
+            try:
+                backend = pg._get_backend(device_type)
+            except RuntimeError:
+                continue
+            if isinstance(backend, ProcessGroupGloo):
+                backend.shutdown()
 
 
 def _get_split_source(pg: ProcessGroup):


### PR DESCRIPTION
…preter finalization

When a process exits without calling destroy_process_group(), Gloo's C++ worker threads may still hold AsyncWork objects containing tensors with Python references. During interpreter finalization, destroying these tensors triggers a GIL acquire that crashes with SIGABRT because the interpreter is being torn down.

Register an atexit handler in init_process_group() that calls destroy_process_group() while the interpreter is still fully alive. If the user already called it explicitly, the handler is a no-op.

Authored in collaboration with Claude.

Fixes https://github.com/pytorch/pytorch/pull/179291