### PR TITLE
Guard pipeline schedule adjacency

### DIFF
--- a/test/distributed/pipelining/test_schedule.py
+++ b/test/distributed/pipelining/test_schedule.py
@@ -37,6 +37,7 @@ from torch.distributed.pipelining.schedules import (
     F,
     get_schedule_class,
     I,
+    PipelineScheduleMulti,
     PipelineScheduleSingle,
     RECV_B,
     RECV_F,
@@ -45,7 +46,11 @@ from torch.distributed.pipelining.schedules import (
     UNSHARD,
     W,
 )
-from torch.distributed.pipelining.stage import _PipelineStageBase, PipelineStage
+from torch.distributed.pipelining.stage import (
+    _PipelineStageBase,
+    _RecvInfo,
+    PipelineStage,
+)
 from torch.testing._internal.common_distributed import requires_accelerator_dist_backend
 from torch.testing._internal.common_utils import (
     check_leaked_tensors,
@@ -87,6 +92,57 @@ class MockPipelineStage(_PipelineStageBase):
         pass
 
 
+def _make_adjacency_stage(
+    stage_index, num_stages, group_rank, args_recv_info, act_send_info
+):
+    """Factory for a minimal mock stage used by adjacency-guard tests."""
+
+    class _AdjacencyTestStage(MockPipelineStage):
+        def __init__(self):
+            super().__init__(
+                num_stages=num_stages,
+                group_size=num_stages,
+                group_rank=group_rank,
+            )
+            self.stage_index = stage_index
+            self.device = "cpu"
+
+        def _get_init_p2p_neighbors_ops(self):
+            return []
+
+        def _prepare_forward_infra(self, *args, **kwargs):
+            self.args_recv_info = args_recv_info
+            self.act_send_info = act_send_info
+            return tuple()
+
+        def _prepare_backward_infra(self, *args, **kwargs):
+            return None
+
+        def clear_runtime_states(self):
+            return None
+
+        def get_fwd_recv_ops(self, mb_index):
+            return []
+
+        def get_fwd_send_ops(self, mb_index):
+            return []
+
+        def get_bwd_recv_ops(self, mb_index):
+            return []
+
+        def get_bwd_send_ops(self, mb_index):
+            return []
+
+    return _AdjacencyTestStage()
+
+
+def _run_adjacency_validation(stage, num_stages):
+    """Run one step of PipelineScheduleMulti to trigger adjacency validation."""
+    schedule = PipelineScheduleMulti([stage], n_microbatches=1)
+    schedule.pipeline_order = {i: [None] for i in range(num_stages)}
+    schedule.step()
+
+
 class ScheduleTest(TestCase):
     def test_get_schedule_class(self):
         # List of all expected schedule names
@@ -118,6 +174,34 @@ class ScheduleTest(TestCase):
             # Test that the original name is included in the error message
             with self.assertRaisesRegex(ValueError, f"{name}"):
                 get_schedule_class(name)
+
+    def test_adjacency_guard_rejects_nonadjacent_send(self):
+        # Stage 0 sending to stage 2 (skip connection)
+        stage = _make_adjacency_stage(0, 3, 0, {0: tuple()}, {0: [2]})
+        with self.assertRaisesRegex(RuntimeError, "adjacent-stage communication"):
+            _run_adjacency_validation(stage, 3)
+
+    def test_adjacency_guard_rejects_nonadjacent_recv(self):
+        # Stage 3 receiving from stage 0 (non-adjacent)
+        stage = _make_adjacency_stage(
+            3,
+            4,
+            3,
+            {0: (_RecvInfo("x", source=0, buffer=None, tensor_meta=None),)},
+            {},
+        )
+        with self.assertRaisesRegex(RuntimeError, "adjacent-stage communication"):
+            _run_adjacency_validation(stage, 4)
+
+    def test_adjacency_guard_allows_adjacent_send(self):
+        # Stage 0 -> stage 1 is valid
+        stage = _make_adjacency_stage(0, 3, 0, {0: tuple()}, {0: [1]})
+        _run_adjacency_validation(stage, 3)
+
+    def test_adjacency_guard_allows_empty_recv_middle_stage(self):
+        # Middle stage with no recv is fine (no non-adjacent peers)
+        stage = _make_adjacency_stage(1, 3, 1, {0: tuple()}, {0: [2]})
+        _run_adjacency_validation(stage, 3)
 
     @parametrize(
         "ScheduleClass",

--- a/torch/distributed/pipelining/schedules.py
+++ b/torch/distributed/pipelining/schedules.py
@@ -32,7 +32,7 @@ from .microbatch import (
     split_args_kwargs_into_chunks,
     TensorChunkSpec,
 )
-from .stage import _PipelineStageBase, PipelineStage
+from .stage import _PipelineStageBase, _RecvInfo, PipelineStage
 
 
 __all__ = [
@@ -1803,6 +1803,10 @@ class PipelineScheduleMulti(_PipelineSchedule):
     def _initialize_stages(
         self, args: tuple[Any, ...], kwargs, target=None, loss_kwargs=None
     ):
+        reinit_for_mode_switch = self._stages_forward_initialized and (
+            self._has_backward != self._stages_backward_initialized
+        )
+        forward_initialized_before = self._stages_forward_initialized
         (
             self._stages_forward_initialized,
             self._stages_backward_initialized,
@@ -1815,6 +1819,64 @@ class PipelineScheduleMulti(_PipelineSchedule):
             self._stages_backward_initialized,
             loss_kwargs=loss_kwargs,
         )
+
+        if self._stages_forward_initialized and (
+            not forward_initialized_before or reinit_for_mode_switch
+        ):
+            self._validate_adjacent_stage_communication()
+
+    def _validate_adjacent_stage_communication(self) -> None:
+        """Validate that stage communication follows adjacent-stage topology only."""
+
+        def _check_stage_indices(
+            stage_idx: int,
+            direction: str,
+            actual_stage_indices: set[int],
+            expected_stage_indices: set[int],
+        ) -> None:
+            non_adjacent_stage_indices = actual_stage_indices - expected_stage_indices
+            if non_adjacent_stage_indices:
+                raise RuntimeError(
+                    "PipelineScheduleMulti only supports adjacent-stage "
+                    f"communication, but stage {stage_idx} has {direction} "
+                    f"stages {sorted(actual_stage_indices)} with "
+                    f"non-adjacent stages {sorted(non_adjacent_stage_indices)} "
+                    f"(allowed adjacent stages: "
+                    f"{sorted(expected_stage_indices)}). This commonly "
+                    "indicates skip connections, which are unsupported in "
+                    "this schedule runtime."
+                )
+
+        for stage in self._stages:
+            stage_idx = stage.stage_index
+            actual_fwd_recv_sources: set[int] = {
+                info.source
+                for info in stage.args_recv_info[0]
+                if isinstance(info, _RecvInfo) and info.source is not None
+            }
+            expected_fwd_recv_sources = set() if stage.is_first else {stage_idx - 1}
+            _check_stage_indices(
+                stage_idx,
+                "forward recv",
+                actual_fwd_recv_sources,
+                expected_fwd_recv_sources,
+            )
+
+            # act_send_info is keyed by output index (not microbatch index),
+            # so .values() yields per-output destination lists.
+            actual_fwd_send_dests: set[int] = {
+                dst
+                for dsts in stage.act_send_info.values()
+                for dst in dsts
+                if dst is not None
+            }
+            expected_fwd_send_dests = set() if stage.is_last else {stage_idx + 1}
+            _check_stage_indices(
+                stage_idx,
+                "forward send",
+                actual_fwd_send_dests,
+                expected_fwd_send_dests,
+            )
 
     def _validate_and_set_stage_mapping(
         self, actions: dict[int, list[_Action | None]]


### PR DESCRIPTION
## Guard adjacent-stage communication in PipelineScheduleMulti via init-time validation

### Root Cause

`PipelineScheduleMulti` assumes communication only happens between adjacent stages (`stage_idx ± 1`), but this invariant was never enforced. Non-adjacent stage communication (e.g. skip-connection topologies) would proceed silently and produce incorrect results or cryptic runtime errors downstream.

### Implementation

Adds `_validate_adjacent_stage_communication()`, called once during `_initialize_stages` (first forward init or mode switch). It inspects `args_recv_info` for recv sources and `act_send_info` for send destinations, comparing against the expected adjacent-stage set. Raises a clear `RuntimeError` when non-adjacent peers are detected.

This approach was chosen over per-step validation to avoid any runtime overhead on the hot path.

### Tradeoffs & Limitations

- Only validates forward communication (recv sources + send destinations). Backward grad communication follows the same topology by construction via `_create_grad_send_info`.
- Runs at init-time only, not per-step. A topology that changes mid-execution (not currently possible) would not be caught.

### Testing Performed

- [x] Negative test: non-adjacent topology (skip connection) is rejected with clear error
- [x] Positive test: adjacent topology passes validation
- [x] Edge case test: middle stage with no recv info passes validation
- [x] Ran focused pytest locally against `test_schedule.py`