### PR TITLE
Fix Potential Infinite Loop in FlightRecorder When Multiple PGs are Running into Barrier

### DIFF
--- a/torch/csrc/distributed/c10d/FlightRecorderDetail.hpp
+++ b/torch/csrc/distributed/c10d/FlightRecorderDetail.hpp
@@ -89,13 +89,13 @@ typename FlightRecorder<EventType>::TraceIdentifier FlightRecorder<EventType>::
   if (!enabled_) {
     return TraceIdentifier{std::nullopt, std::nullopt};
   }
+  auto traceback =
+      torch::CapturedTraceback::gather(true, true, capture_cpp_stack_);
+  std::lock_guard<std::mutex> guard(mutex_);
   if (all_pg_status_.find(pg_id) == all_pg_status_.end()) {
     // Current pg_status is not in FR.
     all_pg_status_[pg_id] = std::move(pg_status);
   }
-  auto traceback =
-      torch::CapturedTraceback::gather(true, true, capture_cpp_stack_);
-  std::lock_guard<std::mutex> guard(mutex_);
 
   TORCH_CHECK(
       reset_epoch_start_idx_.find(reset_epoch_) !=


### PR DESCRIPTION
Summary:
Potential Race Condition Causing One Rank Stuck forever during TensorShuffling Library: 
                                        
  Rank 41 (single process, one FlightRecorder singleton)                                                                                                    
  ├── ThreadPoolExecutor Thread A (PG7 barrier)                                                                                                             
  │   │                                                                                                                                                     
  │   │  Python: dist.barrier(group=pg7)                                                                                                                    
  │   │    → ProcessGroupGloo::barrier()          [ProcessGroupGloo.cpp:2853]                                                                               
  │   │      → enqueue(work)                      [ProcessGroupGloo.cpp:2873]                                                                               
  │   │        → workMutex_.lock()                [ProcessGroupGloo.cpp:789]                                                                                
  │   │        → fr.recordWithResetEnabled(pg_id) [ProcessGroupGloo.cpp:793]                                                                                
  │   │          ┌─────────────────────────────────────────────┐                                                                                            
  │   │          │ FlightRecorderDetail.hpp:92-94  (NO MUTEX!) │                                                                                            
  │   │          │                                             │                                                                                            
  │   │          │  if (all_pg_status_.find(pg_id) == end())   │◄─── RACING                                                                                 
  │   │          │      all_pg_status_[pg_id] = pg_status;     │◄─── HERE                                                                                   
  │   │          │                                             │                                                                                            
  │   │          │ :98  std::lock_guard guard(mutex_);  // TOO LATE                                                                                         
  │   │          └─────────────────────────────────────────────┘                                                                                            
  │   │        → workQueue_.push(work)                                                                                                                      
  │   │        → workMutex_.unlock()                                                                                                                        
  │                                                                                                                                                         
  ├── ThreadPoolExecutor Thread B (PG8 barrier)  ← CONCURRENT                                                                                               
  │   │                                                                                                                                                     
  │   │  Python: dist.barrier(group=pg8)                                                                                                                    
  │   │    → ProcessGroupGloo::barrier()          [ProcessGroupGloo.cpp:2853]                                                                               
  │   │      → enqueue(work)                      [ProcessGroupGloo.cpp:2873]                                                                               
  │   │        → workMutex_.lock()                [ProcessGroupGloo.cpp:789]                                                                                
  │   │        → fr.recordWithResetEnabled(pg_id) [ProcessGroupGloo.cpp:793]                                                                                
  │   │          ┌─────────────────────────────────────────────┐                                                                                            
  │   │          │ FlightRecorderDetail.hpp:92-94  (NO MUTEX!) │                                                                                            
  │   │          │                                             │                                                                                            
  │   │          │  if (all_pg_status_.find(pg_id) == end())   │◄─── RACING                                                                                 
  │   │          │      all_pg_status_[pg_id] = pg_status;     │◄─── HERE                                                                                   
  │   │          │                                             │                                                                                            
  │   │          │ :98  std::lock_guard guard(mutex_);  // TOO LATE                                                                                         
  │   │          └─────────────────────────────────────────────┘                                                                                            
  │   │        → workQueue_.push(work)                                                                                                                      
  │   │        → workMutex_.unlock()                                                                                                                        
                                                                                                                                                            
  Key: workMutex_ is PER-PG (each PG has its own)                                                                                                           
       mutex_ is PER-FlightRecorder (singleton, shared across ALL PGs)                                                                                      
       all_pg_status_ is the SHARED std::map (red-black tree)                                                                                               
                                                                                                                                                            
  WHY BOTH THREADS REACH THE MAP SIMULTANEOUSLY:                                                                                                            
  ─────────────────────────────────────────────────                                                                                                         
    PG7.workMutex_ ≠ PG8.workMutex_    ← different locks, no mutual exclusion                                                                               
    PG7 and PG8 share the SAME FlightRecorder singleton                                                                                                     
    Lines 92-94 access all_pg_status_ BEFORE acquiring FR::mutex_ at line 98                                                                                
                                                                                                                                                            
  WHAT HAPPENS:                                                                                                                                             
  ─────────────────────────────────────────────────                                                                                                         
    Thread A: map.find(pg7_id)  ──┐                                                                                                                         
    Thread B: map[pg8_id] = ...   ├── concurrent read+write on std::map = UB                                                                                
    Thread A: map[pg7_id] = ...  ─┘   red-black tree rebalance corrupts pointers                                                                            
                                        → node->left points back to ancestor                                                                                
                                        → find() follows cycle FOREVER                                                                                      
                                                                                                                                                            
    Thread A now spins in corrupted tree, holding PG7.workMutex_                                                                                            
    PG7 barrier work never enqueued → rank 41 never reaches gloo barrier                                                                                    
    All other 127 ranks wait at gloo barrier → timeout after 1800s                                                                                          
                                                                                                                                                            
  THE FIX:                                                                                                                                                  
  ─────────────────────────────────────────────────                                                                                                         
    auto traceback = gather(...);           // outside mutex (avoids GIL deadlock)                                                                          
    std::lock_guard<std::mutex> guard(mutex_);  // lock FIRST                                                                                               
    if (all_pg_status_.find(pg_id) == end())    // now protected                                                                                            
        all_pg_status_[pg_id] = pg_status;      // now protected                                                                                            
                                                                                                                                                            
  The critical insight: workMutex_ is per-PG so it doesn't prevent two different PGs from entering recordWithResetEnabled() simultaneously. The             
  FlightRecorder's own mutex_ would protect the shared map, but it's acquired after the map access — 6 lines too late.

Test Plan:
g++ -std=c++17 -pthread -O2 -o map_race_loop map_race_loop.cpp
  ./map_race_loop          # BUGGY — shows infinite loops
  ./map_race_loop --fix    # FIXED — shows zero failures

Reviewed By: d4l3k

Differential Revision: D99389769


