### PR TITLE
Remove TRITON=yes from CPU-only GCC11 docker configs

### DIFF
--- a/.ci/docker/build.sh
+++ b/.ci/docker/build.sh
@@ -201,7 +201,6 @@ case "$tag" in
     ANACONDA_PYTHON_VERSION=3.10
     GCC_VERSION=11
     KATEX=yes
-    TRITON=yes
     DOCS=yes
     INDUCTOR_BENCHMARKS=yes
     ;;
@@ -215,7 +214,6 @@ case "$tag" in
     ANACONDA_PYTHON_VERSION=3.10
     GCC_VERSION=11
     KATEX=yes
-    TRITON=yes
     DOCS=yes
     UNINSTALL_DILL=yes
     ;;

--- a/test/distributed/test_nvshmem_triton.py
+++ b/test/distributed/test_nvshmem_triton.py
@@ -10,7 +10,7 @@ from torch.testing._internal.common_utils import TEST_WITH_ROCM
 
 # Skip entire module on ROCm before importing NVSHMEM-specific modules
 # NVSHMEM is NVIDIA-specific and can cause crashes during import on ROCm
-if TEST_WITH_ROCM:
+if TEST_WITH_ROCM or not torch.backends.cuda.is_built():
     print("NVSHMEM not available on ROCm, skipping tests")
     sys.exit(0)
 

--- a/test/distributed/test_nvshmem_triton.py
+++ b/test/distributed/test_nvshmem_triton.py
@@ -4,11 +4,13 @@
 
 import sys
 
+import torch
+
 # Import TEST_WITH_ROCM first to check for ROCm before importing NVSHMEM modules
 from torch.testing._internal.common_utils import TEST_WITH_ROCM
 
 
-# Skip entire module on ROCm before importing NVSHMEM-specific modules
+# Skip entire module on ROCm before importing NVSHMEM-specific modules or runing on CPU
 # NVSHMEM is NVIDIA-specific and can cause crashes during import on ROCm
 if TEST_WITH_ROCM or not torch.backends.cuda.is_built():
     print("NVSHMEM not available on ROCm, skipping tests")
@@ -16,7 +18,6 @@ if TEST_WITH_ROCM or not torch.backends.cuda.is_built():
 
 import triton.language as tl
 
-import torch
 import torch.distributed as dist
 import torch.distributed._symmetric_memory as symm_mem
 import torch.distributed._symmetric_memory._nvshmem_triton as nvshmem

--- a/test/distributed/test_nvshmem_triton.py
+++ b/test/distributed/test_nvshmem_triton.py
@@ -10,7 +10,7 @@ import torch
 from torch.testing._internal.common_utils import TEST_WITH_ROCM
 
 
-# Skip entire module on ROCm before importing NVSHMEM-specific modules or runing on CPU
+# Skip entire module on ROCm before importing NVSHMEM-specific modules or running on CPU
 # NVSHMEM is NVIDIA-specific and can cause crashes during import on ROCm
 if TEST_WITH_ROCM or not torch.backends.cuda.is_built():
     print("NVSHMEM not available on ROCm, skipping tests")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #179321
* #179320
* __->__ #179314

These two CPU-only configs (pytorch-linux-jammy-py3.10-gcc11 and
pytorch-linux-jammy-py3-gcc11-inductor-benchmarks) don't need the
GPU Triton package installed in the Docker image.

Co-authored-by: Claude <noreply@anthropic.com>