### PR TITLE
[Native Ops] Skip Triton/CuteDSL dependency checks for CPU-only binaries

### DIFF
--- a/torch/_native/cutedsl_utils.py
+++ b/torch/_native/cutedsl_utils.py
@@ -5,6 +5,7 @@ from typing import cast
 
 from packaging.version import Version
 
+from ..backends import cuda as _cuda
 from .common_utils import (
     _available_version,
     _unavailable_reason,
@@ -39,8 +40,9 @@ def _check_runtime_available() -> tuple[bool, Version | None]:
     NOTE: Doesn't import at this point
     """
     # Skip all checks if running on CPU-only binary
-    if not torch.backends.cuda.is_built():
-        return False
+    if not _cuda.is_built():
+        return (False, None)
+
     deps = [
         ("nvidia_cutlass_dsl", "cutlass"),
         ("apache_tvm_ffi", "tvm_ffi"),

--- a/torch/_native/cutedsl_utils.py
+++ b/torch/_native/cutedsl_utils.py
@@ -38,6 +38,9 @@ def _check_runtime_available() -> tuple[bool, Version | None]:
 
     NOTE: Doesn't import at this point
     """
+    # Skip all checks if running on CPU-only binary
+    if not torch.backends.cuda.is_built():
+        return False
     deps = [
         ("nvidia_cutlass_dsl", "cutlass"),
         ("apache_tvm_ffi", "tvm_ffi"),

--- a/torch/_native/triton_utils.py
+++ b/torch/_native/triton_utils.py
@@ -5,6 +5,7 @@ from typing import cast
 
 from packaging.version import Version
 
+from ..backends import cuda as _cuda
 from .common_utils import (
     _available_version,
     _unavailable_reason,
@@ -34,6 +35,9 @@ def _check_runtime_available() -> tuple[bool, Version | None]:
 
     NOTE: must not import at this point
     """
+    # Skip all checks if running on CPU-only binary
+    if not _cuda.is_built():
+        return (False, None)
 
     deps = [
         ("triton", "triton"),


### PR DESCRIPTION
Fixes annoying warning on CPU
```
W0403 14:04:44.298000 55350 /Users/nshulga/git/pytorch/pytorch/torch/_native/cutedsl_utils.py:50] CuTeDSL operators require optional Python packages `nvidia-cutlass-dsl` and `apache-tvm-ffi`; missing optional dependency `nvidia_cutlass_dsl` (importlib.util.find_spec(nvidia_cutlass_dsl) failed)
```