### PR TITLE
[DTensor] Fix select_int_strategy mutating input DTensorSpec

### DIFF
--- a/test/distributed/tensor/test_tensor_ops.py
+++ b/test/distributed/tensor/test_tensor_ops.py
@@ -740,6 +740,22 @@ class DistTensorOpsTest(DTensorContinuousTestBase):
             #     torch.randint(5, (12, 8, 12)),
             # )
 
+    def test_select_does_not_mutate_input_spec(self):
+        mesh = self.build_device_mesh()
+        local_tensor = torch.randn(4, 32, 64)
+        dt = distribute_tensor(local_tensor, mesh, [Replicate()])
+        original_shape = dt.shape
+        original_ndim = dt.dim()
+
+        _ = dt[1]
+        self.assertEqual(dt.shape, original_shape)
+        self.assertEqual(dt.dim(), original_ndim)
+
+        _ = dt[0]
+        _ = dt[2]
+        self.assertEqual(dt.shape, original_shape)
+        self.assertEqual(dt.dim(), original_ndim)
+
     def test_index_put_scalar(self):
         device_mesh = init_device_mesh(self.device_type, (2, self.world_size // 2))
         global_input = torch.randn(2, 4, 8, device=self.device_type)

--- a/torch/distributed/tensor/_ops/_tensor_ops.py
+++ b/torch/distributed/tensor/_ops/_tensor_ops.py
@@ -1,6 +1,7 @@
 # mypy: allow-untyped-defs
 # Copyright (c) Meta Platforms, Inc. and affiliates
 from collections.abc import Sequence, Sized
+from dataclasses import replace
 from typing import cast
 
 import torch
@@ -365,7 +366,7 @@ def select_int_strategy(op_schema: OpSchema) -> StrategyType:
             input_specs = DTensorSpec(arg_spec.mesh, arg_target_placements)  # R
 
         # determine output spec
-        output_specs = input_specs
+        output_specs = replace(input_specs)
         if input_specs.is_sharded():
             # handle cases with sharded_dim != selected_dim
             output_placements = shift_shard_dims_after_remove(


### PR DESCRIPTION
  The output spec was aliased to the input spec (`output_specs = input_specs`)
  for the non-sharded case. When sharding propagation later updated tensor_meta
  on the output spec, it mutated the original DTensor's spec, causing repeated
  indexing (e.g. `dt[0]; dt[1]`) to progressively reduce the DTensor's
  dimensions.

  Fix by using `dataclasses.replace` to create a fresh output spec.

  Fixes https://github.com/pytorch/pytorch/issues/179290

<!-- ps-id: aeb77822-4dc5-407b-b5aa-7b240e6e6275 -->