### PR TITLE
Move dill uninstall from Docker build time to test time

### DIFF
--- a/.ci/docker/build.sh
+++ b/.ci/docker/build.sh
@@ -215,7 +215,6 @@ case "$tag" in
     GCC_VERSION=11
     KATEX=yes
     DOCS=yes
-    UNINSTALL_DILL=yes
     ;;
   pytorch-linux-jammy-py3-clang18-executorch)
     ANACONDA_PYTHON_VERSION=3.10
@@ -358,7 +357,6 @@ docker buildx build \
        --build-arg "TPU=${TPU}" \
        --build-arg "XPU_VERSION=${XPU_VERSION}" \
        --build-arg "XPU_DRIVER_TYPE=${XPU_DRIVER_TYPE}" \
-       --build-arg "UNINSTALL_DILL=${UNINSTALL_DILL}" \
        --build-arg "ACL=${ACL:-}" \
        --build-arg "OPENBLAS=${OPENBLAS:-}" \
        --build-arg "SKIP_SCCACHE_INSTALL=${SKIP_SCCACHE_INSTALL:-}" \

--- a/.ci/docker/ubuntu/Dockerfile
+++ b/.ci/docker/ubuntu/Dockerfile
@@ -42,7 +42,6 @@ COPY ./common/install_conda.sh install_conda.sh
 COPY ./common/common_utils.sh common_utils.sh
 COPY ./common/install_magma_conda.sh install_magma_conda.sh
 RUN bash ./install_conda.sh && rm install_conda.sh install_magma_conda.sh common_utils.sh /opt/conda/requirements-ci.txt /opt/conda/requirements-docs.txt
-RUN if [ -n "${UNINSTALL_DILL}" ]; then pip uninstall -y dill; fi
 
 # Install gcc
 ARG GCC_VERSION

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -50,6 +50,11 @@ if [[ "$TEST_CONFIG" != "onnx" ]]; then
   pip uninstall -y onnxruntime 2>/dev/null || true
 fi
 
+# Remove dill to test that serialization works without it
+if [[ "$BUILD_ENVIRONMENT" == *py3.10-gcc11 ]]; then
+  pip uninstall -y dill 2>/dev/null || true
+fi
+
 echo "Environment variables:"
 env
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #179321
* __->__ #179320
* #179314

Instead of baking a separate Docker image without dill, uninstall it at
test time in test.sh for the py3.10-gcc11 build environment. This
eliminates the UNINSTALL_DILL build arg and makes the py3.10-gcc11
Docker image identical to py3-gcc11-inductor-benchmarks (minus the
benchmark deps).

Co-authored-by: Claude <noreply@anthropic.com>