### PR TITLE
[AOT Autograd] Support reverse tangent coercion for tensor subclasses

### DIFF
--- a/torch/_functorch/_aot_autograd/runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/runtime_wrappers.py
@@ -3042,14 +3042,24 @@ Your tensor subclass must implement __coerce_same_metadata_as_tangent__."""
             if same_type and same_meta:
                 return x
 
-            if not hasattr(x, "__coerce_same_metadata_as_tangent__"):
-                return None
+            if hasattr(x, "__coerce_same_metadata_as_tangent__"):
+                if same_type:
+                    # Backward Compatibility, as some Subclass impls can have original 1-arg function.
+                    return x.__coerce_same_metadata_as_tangent__(expected_meta)
+                return x.__coerce_same_metadata_as_tangent__(expected_meta, expected_type)
 
-            if same_type:
-                # Backward Compatibility, as some Subclass impls can have original 1-arg function.
-                return x.__coerce_same_metadata_as_tangent__(expected_meta)
+            # Reverse direction: when the runtime tangent (e.g. plain Tensor)
+            # doesn't know how to coerce itself, ask the expected type if it
+            # can accept the tangent. This handles cases like a plain Tensor
+            # tangent flowing into a region that traced with
+            # AsyncCollectiveTensor (an already-materialized tensor is a valid
+            # "resolved" async tensor).
+            if expected_type is not None and hasattr(
+                expected_type, "__coerce_tangent_from__"
+            ):
+                return expected_type.__coerce_tangent_from__(x, expected_meta)
 
-            return x.__coerce_same_metadata_as_tangent__(expected_meta, expected_type)
+            return None
 
         # Coerce to expected type and metadata
         orig_x = x

--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -1044,6 +1044,20 @@ class AsyncCollectiveTensor(torch.Tensor):
 
         return self.trigger_wait()
 
+    @classmethod
+    def __coerce_tangent_from__(
+        cls, tensor: torch.Tensor, expected_metadata: Any
+    ) -> torch.Tensor | None:
+        # A plain Tensor tangent is a valid tangent for an
+        # AsyncCollectiveTensor — it is semantically an already-resolved
+        # async collective result. This arises when an async collective
+        # output crosses a torch.compile boundary into eager code: the
+        # backward tangent is a plain Tensor but the compiled forward
+        # traced an AsyncCollectiveTensor.
+        if isinstance(tensor, torch.Tensor):
+            return cls(tensor)
+        return None
+
     def __repr__(self) -> str:  # type: ignore[override]
         return f"AsyncCollectiveTensor({self.trigger_wait()})"
 


### PR DESCRIPTION
When torch.compile is applied to individual sub-modules (e.g. in MoE models via apply_compile_sparse), AsyncCollectiveTensor outputs from RowwiseParallel can cross compile boundaries into eager code. During backward, the tangent is a plain Tensor (from eager) but the compiled forward traced an AsyncCollectiveTensor, causing process_runtime_tangent to reject it.

The existing __coerce_same_metadata_as_tangent__ protocol only handles coercion from the runtime tangent's perspective (e.g. AsyncCollectiveTensor -> Tensor). This adds a reverse-direction protocol: when the runtime tangent doesn't support coercion, maybe_coerce now checks if the expected type has a __coerce_tangent_from__ classmethod.

AsyncCollectiveTensor implements this classmethod since a plain Tensor is semantically an already-resolved async collective result, making it always valid to wrap as AsyncCollectiveTensor.

Authored with Claude.

<!-- ps-id: 1a21bdef-3e99-4b7c-82e9-f32bd3d5678b -->