### PR TITLE
Enable MPS tests in test_torch.py by adding allow_mps=True to TestTorchDeviceType instantiation

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -10964,7 +10964,7 @@ class TestTensorDeviceOps(TestCase):
 add_neg_dim_tests()
 instantiate_device_type_tests(TestViewOps, globals())
 instantiate_device_type_tests(TestTensorDeviceOps, globals())
-instantiate_device_type_tests(TestTorchDeviceType, globals())
+instantiate_device_type_tests(TestTorchDeviceType, globals(), allow_mps=True)
 instantiate_device_type_tests(TestDevicePrecision, globals(), except_for='cpu')
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
Fix the issue where MPS tests decorated with `@skipIfMPS` were not being discovered and run in test_torch.py.

## Changes
- Added `allow_mps=True` parameter to the `instantiate_device_type_tests` call for `TestTorchDeviceType`

## Motivation
Previously, running `pytest test_torch.py -v -k _mps` would return no tests despite many tests having `@skipIfMPS` decorators. This parameter enables the test instantiation for MPS devices, allowing tests to be discovered and executed.

## Fixes
Fixes #179259 