### PR TITLE
add health check to debug server

### DIFF
--- a/test/distributed/_composable/test_replicate_with_compiler.py
+++ b/test/distributed/_composable/test_replicate_with_compiler.py
@@ -390,10 +390,9 @@ class ReplicateTest(MultiProcessInductorTestCase):
 class DDP_TP_Test(InductorTestCase):
     def setUp(self):
         super().setUp()
-        # Hmm, why a specific set_device call for rank 0?
         self.rank = 0
         self.world_size = 4
-        torch.get_device_module(device_type).set_device(device_type)
+        torch.get_device_module(device_type).set_device(self.rank)
 
         store = FakeStore()
         dist.init_process_group(

--- a/test/distributed/test_debug.py
+++ b/test/distributed/test_debug.py
@@ -479,5 +479,166 @@ class TestHandlerPartialDumps(TestCase):
             self.assertIn("1/2 workers responded", content)
 
 
+class TestTorchCommsHealthCheckHandler(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        from torch.distributed.debug._debug_handlers import TorchCommsHealthCheckHandler
+
+        self.handler = TorchCommsHealthCheckHandler()
+
+    def test_routes(self) -> None:
+        routes = self.handler.routes()
+        self.assertEqual(len(routes), 1)
+        self.assertEqual(routes[0].path, "/torchcomms_health_check")
+
+    def test_nav_links(self) -> None:
+        links = self.handler.nav_links()
+        self.assertEqual(len(links), 1)
+        self.assertEqual(links[0].path, "/torchcomms_health_check")
+        self.assertEqual(links[0].label, "TorchComms Health")
+
+    def test_templates(self) -> None:
+        templates = self.handler.templates()
+        self.assertIn("torchcomms_health_check.html", templates)
+        self.assertIn("Health Status", templates["torchcomms_health_check.html"])
+
+    def test_dump_filename(self) -> None:
+        self.assertEqual(self.handler.dump_filename(), "torchcomms_health_check")
+
+    # -- _any_unhealthy tests --
+
+    def test_any_unhealthy_all_healthy(self) -> None:
+        from torch.distributed.debug._debug_handlers import TorchCommsHealthCheckHandler
+
+        resps = [
+            Response(200, '{"healthy": true}'),
+            Response(200, '{"healthy": true}'),
+        ]
+        self.assertFalse(TorchCommsHealthCheckHandler._any_unhealthy(resps))
+
+    def test_any_unhealthy_one_unhealthy(self) -> None:
+        from torch.distributed.debug._debug_handlers import TorchCommsHealthCheckHandler
+
+        resps = [
+            Response(200, '{"healthy": true}'),
+            Response(200, '{"healthy": false}'),
+        ]
+        self.assertTrue(TorchCommsHealthCheckHandler._any_unhealthy(resps))
+
+    def test_any_unhealthy_non_200_ignored(self) -> None:
+        """Non-200 responses (unreachable ranks) must not trigger a dump.
+
+        Only ranks that are reachable and positively report unhealthy should
+        cause an FR dump.  Treating connection failures as unhealthy would
+        cause expensive dumps whenever a single rank is temporarily unreachable.
+        """
+        from torch.distributed.debug._debug_handlers import TorchCommsHealthCheckHandler
+
+        resps = [Response(503, "unavailable")]
+        self.assertFalse(TorchCommsHealthCheckHandler._any_unhealthy(resps))
+
+    def test_any_unhealthy_bad_json_ignored(self) -> None:
+        from torch.distributed.debug._debug_handlers import TorchCommsHealthCheckHandler
+
+        resps = [Response(200, "not json")]
+        self.assertFalse(TorchCommsHealthCheckHandler._any_unhealthy(resps))
+
+    def test_any_unhealthy_missing_key_defaults_healthy(self) -> None:
+        from torch.distributed.debug._debug_handlers import TorchCommsHealthCheckHandler
+
+        resps = [Response(200, '{"uptime": 42}')]
+        self.assertFalse(TorchCommsHealthCheckHandler._any_unhealthy(resps))
+
+    def test_any_unhealthy_empty_list(self) -> None:
+        from torch.distributed.debug._debug_handlers import TorchCommsHealthCheckHandler
+
+        self.assertFalse(TorchCommsHealthCheckHandler._any_unhealthy([]))
+
+    # -- dump() tests --
+
+    @patch("torch.distributed.debug._debug_handlers.fetch_all")
+    @patch("torch.distributed.debug._debug_handlers.format_fetch_summary")
+    def test_dump_all_healthy(self, mock_summary, mock_fetch_all) -> None:
+        addrs = ["http://h0:1", "http://h1:1"]  # @lint-ignore
+        resps = [
+            Response(200, '{"healthy": true}'),
+            Response(200, '{"healthy": true}'),
+        ]
+        mock_fetch_all.return_value = (addrs, resps)
+        mock_summary.return_value = None
+
+        result = self.handler.dump()
+        self.assertIsNotNone(result)
+        self.assertIn("Rank 0", result)
+        self.assertIn("Rank 1", result)
+        self.assertNotIn("Unhealthy", result)
+        mock_fetch_all.assert_called_once()
+
+    @patch("torch.distributed.debug._debug_handlers.fetch_all")
+    @patch("torch.distributed.debug._debug_handlers.format_fetch_summary")
+    def test_dump_partial_failure(self, mock_summary, mock_fetch_all) -> None:
+        addrs = ["http://h0:1", "http://h1:1"]  # @lint-ignore
+        resps = [
+            Response(200, '{"healthy": true}'),
+            Response(503, "Worker unavailable"),
+        ]
+        mock_fetch_all.return_value = (addrs, resps)
+        mock_summary.return_value = "PARTIAL DATA: 1/2 workers responded"
+
+        result = self.handler.dump()
+        self.assertIn("PARTIAL DATA", result)
+        self.assertIn("Error: 503", result)
+        # no unhealthy rank (503 is not parsed as json), so no FR dump
+        self.assertNotIn("Unhealthy", result)
+
+    @patch("torch.distributed.debug._debug_handlers.fetch_all")
+    @patch("torch.distributed.debug._debug_handlers.format_fetch_summary")
+    def test_dump_unhealthy_triggers_fr_dump(
+        self, mock_summary, mock_fetch_all
+    ) -> None:
+        health_addrs = ["http://h0:1", "http://h1:1"]  # @lint-ignore
+        health_resps = [
+            Response(200, '{"healthy": true}'),
+            Response(200, '{"healthy": false}'),
+        ]
+        dump_addrs = ["http://h0:1", "http://h1:1"]  # @lint-ignore
+        dump_resps = [
+            Response(200, "fr_trace_rank0"),
+            Response(200, "fr_trace_rank1"),
+        ]
+        mock_fetch_all.side_effect = [
+            (health_addrs, health_resps),
+            (dump_addrs, dump_resps),
+        ]
+        mock_summary.return_value = None
+
+        result = self.handler.dump()
+        self.assertIn("Unhealthy rank detected, triggering FR dump", result)
+        self.assertIn("fr_trace_rank0", result)
+        self.assertIn("fr_trace_rank1", result)
+        self.assertEqual(mock_fetch_all.call_count, 2)
+        # second call should be for torchcomms_fr_dump_file
+        self.assertEqual(
+            mock_fetch_all.call_args_list[1][0][0], "torchcomms_fr_dump_file"
+        )
+
+    @patch("torch.distributed.debug._debug_handlers.fetch_all")
+    @patch("torch.distributed.debug._debug_handlers.format_fetch_summary")
+    def test_dump_fr_dump_partial_failure(self, mock_summary, mock_fetch_all) -> None:
+        health_addrs = ["http://h0:1"]  # @lint-ignore
+        health_resps = [Response(200, '{"healthy": false}')]
+        dump_addrs = ["http://h0:1"]  # @lint-ignore
+        dump_resps = [Response(503, "dump failed")]
+        mock_fetch_all.side_effect = [
+            (health_addrs, health_resps),
+            (dump_addrs, dump_resps),
+        ]
+        mock_summary.return_value = None
+
+        result = self.handler.dump()
+        self.assertIn("Unhealthy rank detected", result)
+        self.assertIn("Error: 503", result)
+
+
 if __name__ == "__main__":
     run_tests()

--- a/torch/distributed/debug/__init__.py
+++ b/torch/distributed/debug/__init__.py
@@ -102,6 +102,7 @@ def start_debug_server(
             enabled_dumps = {
                 "stacks",
                 "fr_trace",
+                "torchcomms_health_check",
             }
 
         main_kwargs = {

--- a/torch/distributed/debug/_debug_handlers.py
+++ b/torch/distributed/debug/_debug_handlers.py
@@ -575,6 +575,123 @@ class TorchCommsFlightRecorderHandler(DebugHandler):
         return "torchcomms_fr_trace"
 
 
+HEALTH_CHECK_TEMPLATE = """
+{% extends "base.html" %}
+{% block header %}
+    <h1>{% block title %}TorchComms Health Check{% endblock %}</h1>
+{% endblock %}
+{% block content %}
+    <h2>Health Status</h2>
+    {% if fetch_summary %}<pre>{{ fetch_summary }}</pre>{% endif %}
+    {% for i, (addr, resp) in enumerate(zip(addrs, resps)) %}
+        <h3>Rank {{ i }}: {{ addr }}</h3>
+        {% if resp.status_code != 200 %}
+            <p>Failed to fetch: status={{ resp.status_code }}</p>
+            <pre>{{ resp.text }}</pre>
+        {% else %}
+            <pre>{{ resp.text }}</pre>
+        {% endif %}
+    {% endfor %}
+    {% if dump_triggered %}
+        <h2>Flight Recorder Dump (triggered by unhealthy rank)</h2>
+        {% for i, (addr, resp) in enumerate(zip(dump_addrs, dump_resps)) %}
+            <h3>Rank {{ i }}: {{ addr }}</h3>
+            {% if resp.status_code != 200 %}
+                <p>Failed to dump: status={{ resp.status_code }}</p>
+                <pre>{{ resp.text }}</pre>
+            {% else %}
+                <pre>{{ resp.text }}</pre>
+            {% endif %}
+        {% endfor %}
+    {% endif %}
+{% endblock %}
+    """
+
+
+class TorchCommsHealthCheckHandler(DebugHandler):
+    """Health check that detects watchdog timeouts and triggers FR dumps."""
+
+    def routes(self) -> list[Route]:
+        return [Route("/torchcomms_health_check", self._handle)]
+
+    def nav_links(self) -> list[NavLink]:
+        return [NavLink("/torchcomms_health_check", "TorchComms Health")]
+
+    def templates(self) -> dict[str, str]:
+        return {"torchcomms_health_check.html": HEALTH_CHECK_TEMPLATE}
+
+    @staticmethod
+    def _any_unhealthy(resps: list[Response]) -> bool:
+        """Return True if any rank explicitly reports itself as unhealthy.
+
+        Only responses with a 200 status code are inspected.  Non-200
+        responses (connection errors, timeouts, etc.) are intentionally
+        ignored so that a single unreachable rank does not trigger an
+        expensive Flight Recorder dump across the entire job.  A dump is
+        only triggered when a rank is reachable *and* positively reports
+        ``{"healthy": false}``.
+        """
+        for resp in resps:
+            if resp.status_code == 200:
+                try:
+                    data = resp.json()
+                    if not data.get("healthy", True):
+                        return True
+                except Exception:
+                    pass
+        return False
+
+    def _handle(self, req: HTTPRequestHandler) -> bytes:
+        addrs, resps = fetch_all("torchcomms_health_check", timeout=self.fetch_timeout)
+        dump_triggered = False
+        dump_addrs: list[str] = []
+        dump_resps: list[Response] = []
+        if self._any_unhealthy(resps):
+            dump_addrs, dump_resps = fetch_all(
+                "torchcomms_fr_dump_file", timeout=self.fetch_timeout
+            )
+            dump_triggered = True
+        return req.frontend.render_template(
+            "torchcomms_health_check.html",
+            fetch_summary=format_fetch_summary(addrs, resps),
+            addrs=addrs,
+            resps=resps,
+            dump_triggered=dump_triggered,
+            dump_addrs=dump_addrs,
+            dump_resps=dump_resps,
+        )
+
+    def dump(self) -> str | None:
+        addrs, resps = fetch_all("torchcomms_health_check", timeout=self.fetch_timeout)
+        parts: list[str] = []
+        summary = format_fetch_summary(addrs, resps)
+        if summary:
+            parts.append(summary)
+            parts.append("")
+        for i, (addr, resp) in enumerate(zip(addrs, resps)):
+            parts.append(f"=== Rank {i}: {addr} ===")
+            parts.append(
+                resp.text if resp.status_code == 200 else f"Error: {resp.status_code}"
+            )
+        if self._any_unhealthy(resps):
+            parts.append("")
+            parts.append("=== Unhealthy rank detected, triggering FR dump ===")
+            dump_addrs, dump_resps = fetch_all(
+                "torchcomms_fr_dump_file", timeout=self.fetch_timeout
+            )
+            for i, (addr, resp) in enumerate(zip(dump_addrs, dump_resps)):
+                parts.append(f"--- Rank {i}: {addr} ---")
+                parts.append(
+                    resp.text
+                    if resp.status_code == 200
+                    else f"Error: {resp.status_code}"
+                )
+        return "\n".join(parts)
+
+    def dump_filename(self) -> str:
+        return "torchcomms_health_check"
+
+
 def default_handlers() -> list[DebugHandler]:
     return [
         IndexHandler(),
@@ -582,6 +699,7 @@ def default_handlers() -> list[DebugHandler]:
         PySpyHandler(),
         FlightRecorderHandler(),
         TorchCommsFlightRecorderHandler(),
+        TorchCommsHealthCheckHandler(),
         ProfilerHandler(),
         WaitCountersHandler(),
         TCPStoreHandler(),


### PR DESCRIPTION

Summary:
Add a health check endpoint to the distributed debug server so that unhealthy ranks (e.g. watchdog timeouts) can be detected and automatically trigger flight recorder dumps for faster diagnosis of distributed training issues.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/pytorch/pytorch/pull/179326).
* #179753
* __->__ #179326