### PR TITLE
Fix contextvars regression in UP GPU tests (#179327)

### DIFF
--- a/torch/autograd/graph.py
+++ b/torch/autograd/graph.py
@@ -875,8 +875,15 @@ def _engine_run_backward(
     if attach_logging_hooks:
         unregister_hooks = _register_logging_hooks_on_whole_graph(t_outputs)
 
-    # Need to save the context so compiler config will be visible in device threads
-    torch._C._stash_obj_in_tls("context", contextvars.copy_context())
+    # Need to save the context so compiler config will be visible in device threads.
+    # Only stash when the context has actual overrides; on C++ worker threads
+    # (e.g., unified-parallelism GPU thread groups) the context is empty and
+    # stashing it creates unnecessary SafePyObject lifecycle management on
+    # autograd device threads that can cause GIL-related hangs.
+    ctx = contextvars.copy_context()
+    _stash_context = len(ctx) > 0
+    if _stash_context:
+        torch._C._stash_obj_in_tls("context", ctx)
 
     try:
         return Variable._execution_engine.run_backward(  # Calls into the C++ engine to run the backward pass
@@ -885,4 +892,5 @@ def _engine_run_backward(
     finally:
         if attach_logging_hooks:
             unregister_hooks()  # type: ignore[possibly-undefined]
-        torch._C._stash_obj_in_tls("context", None)
+        if _stash_context:
+            torch._C._stash_obj_in_tls("context", None)


### PR DESCRIPTION
Summary: Pull Request resolved: https://github.com/pytorch/pytorch/pull/179327

Test Plan:
devmate output omitted ...

test_correctness_fsdp_semi_frozen: ✅ Pass
test session: https://www.internalfb.com/intern/testinfra/testrun/24769797962255771

test_correctness_one_pp_clip_mixed: ✅ Pass
test session: https://www.internalfb.com/intern/testinfra/testrun/27866022706084619

Differential Revision: D99416390


