### PR TITLE
[inductor] Fix combo kernel XBLOCK default in lazy triton compile

### DIFF
--- a/test/inductor/test_gpu_cpp_wrapper.py
+++ b/test/inductor/test_gpu_cpp_wrapper.py
@@ -14,7 +14,11 @@ from torch._inductor.codegen.cpp_wrapper_gpu import DeferredTritonCallWrapper
 from torch._inductor.codegen.cuda.device_op_overrides import CUDADeviceOpOverrides
 from torch._inductor.test_case import TestCase as InductorTestCase
 from torch._inductor.utils import IndentedBuffer
-from torch.testing._internal.common_utils import slowTest
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+    slowTest,
+)
 from torch.testing._internal.inductor_utils import GPU_TYPE, RUN_GPU
 
 
@@ -145,7 +149,8 @@ class TestGpuWrapper(InductorTestCase):
 
         self.assertEqual(wrapper.scratch_spaces, {"global_scratch": 256 * 8})
 
-    def test_lazy_compile_combo_kernel_default_config(self):
+    @parametrize("per_subkernel_blocks", [False, True])
+    def test_lazy_compile_combo_kernel_default_config(self, per_subkernel_blocks):
         """Lazy compile should use default_config from combo_grid_meta for XBLOCK."""
         if not RUN_GPU:
             self.skipTest("GPU not available")
@@ -156,8 +161,6 @@ class TestGpuWrapper(InductorTestCase):
             DEFAULT_COMBO_BLOCK_SIZE_1D,
         )
         from torch._inductor.runtime import triton_lazy_compile as tlc
-
-        expected_xblock = DEFAULT_COMBO_BLOCK_SIZE_1D
 
         captured = {}
         original = tlc.run_triton_kernel_with_autotune
@@ -177,6 +180,7 @@ class TestGpuWrapper(InductorTestCase):
                     "cpp_wrapper": True,
                     "triton.autotune_at_compile_time": False,
                     "combo_kernels": True,
+                    "combo_kernel_per_subkernel_blocks": per_subkernel_blocks,
                 }
             )
             def fn(params, grads):
@@ -186,11 +190,20 @@ class TestGpuWrapper(InductorTestCase):
 
         self.assertTrue(len(captured) > 0, "No combo kernels were lazy-compiled")
         for name, xblock in captured.items():
-            self.assertEqual(
-                xblock,
-                expected_xblock,
-                f"{name} got XBLOCK={xblock}, expected {expected_xblock} from combo_grid_meta",
-            )
+            # When per_subkernel_blocks=False, default_config has a single XBLOCK
+            # that must be picked up correctly (not the hardcoded fallback of 128).
+            # When per_subkernel_blocks=True, default_config uses per-subkernel
+            # XBLOCK_N keys instead, so result.xblock is not used for grid
+            # computation; just verify compilation succeeded.
+            if not per_subkernel_blocks:
+                self.assertEqual(
+                    xblock,
+                    DEFAULT_COMBO_BLOCK_SIZE_1D,
+                    f"{name} got XBLOCK={xblock}, expected {DEFAULT_COMBO_BLOCK_SIZE_1D}",
+                )
+
+
+instantiate_parametrized_tests(TestGpuWrapper)
 
 
 # Helper script for test_lazy_compile_kernel_name_collision_across_modules.

--- a/test/inductor/test_gpu_cpp_wrapper.py
+++ b/test/inductor/test_gpu_cpp_wrapper.py
@@ -145,6 +145,53 @@ class TestGpuWrapper(InductorTestCase):
 
         self.assertEqual(wrapper.scratch_spaces, {"global_scratch": 256 * 8})
 
+    def test_lazy_compile_combo_kernel_default_config(self):
+        """Lazy compile should use default_config from combo_grid_meta for XBLOCK."""
+        if not RUN_GPU:
+            self.skipTest("GPU not available")
+
+        from unittest.mock import patch
+
+        from torch._inductor.codegen.triton_combo_kernel import (
+            DEFAULT_COMBO_BLOCK_SIZE_1D,
+        )
+        from torch._inductor.runtime import triton_lazy_compile as tlc
+
+        expected_xblock = DEFAULT_COMBO_BLOCK_SIZE_1D
+
+        captured = {}
+        original = tlc.run_triton_kernel_with_autotune
+
+        def capture(pending_kernels, kernel_name, stream, args):
+            result = original(pending_kernels, kernel_name, stream, args)
+            if "triton_for_fused" in kernel_name:
+                captured[kernel_name] = result.xblock
+            return result
+
+        with patch.object(tlc, "run_triton_kernel_with_autotune", side_effect=capture):
+            params = [torch.randn(1024, device=self.device) for _ in range(4)]
+            grads = [torch.randn_like(p) for p in params]
+
+            @torch.compile(
+                options={
+                    "cpp_wrapper": True,
+                    "triton.autotune_at_compile_time": False,
+                    "combo_kernels": True,
+                }
+            )
+            def fn(params, grads):
+                torch._foreach_add_(params, grads, alpha=-0.1)
+
+            fn(params, grads)
+
+        self.assertTrue(len(captured) > 0, "No combo kernels were lazy-compiled")
+        for name, xblock in captured.items():
+            self.assertEqual(
+                xblock,
+                expected_xblock,
+                f"{name} got XBLOCK={xblock}, expected {expected_xblock} from combo_grid_meta",
+            )
+
 
 # Helper script for test_lazy_compile_kernel_name_collision_across_modules.
 # Run as a subprocess so dlopen truly re-runs .so static initializers.

--- a/torch/_inductor/codegen/triton_combo_kernel.py
+++ b/torch/_inductor/codegen/triton_combo_kernel.py
@@ -40,6 +40,11 @@ from .triton import TritonKernel
 from .triton_utils import config_of, equal_1_arg_indices, signature_to_meta
 
 
+# Default block sizes used when combo kernel autotuning is disabled.
+DEFAULT_COMBO_BLOCK_SIZE_1D = 1024
+DEFAULT_COMBO_BLOCK_SIZE_2D = 32
+
+
 log = logging.getLogger(__name__)
 pexpr = PythonPrinter().doprint
 LARGE_NUMELS = 512e5
@@ -454,9 +459,9 @@ class ComboKernel(Kernel):
             | None
         ) = None
         self.block_args: list[str] = []
-        # there following are used when autotuning is disabled
-        self.block_size_1d = 1024  # Try tuning this value
-        self.block_size_2d = 32
+        # the following are used when autotuning is disabled
+        self.block_size_1d = DEFAULT_COMBO_BLOCK_SIZE_1D
+        self.block_size_2d = DEFAULT_COMBO_BLOCK_SIZE_2D
         self.num_warps = 8
         self.block_size_reduce = 256
         self.dynamic_shape_args: list[str] = []

--- a/torch/_inductor/runtime/triton_lazy_compile.py
+++ b/torch/_inductor/runtime/triton_lazy_compile.py
@@ -175,6 +175,15 @@ def run_triton_kernel_with_autotune(
     shared_mem = cached_params["shared_mem"]
 
     config = config_to_dict(launcher.config) if launcher.config else {}
+
+    # For combo/foreach kernels, the autotuned config may have empty kwargs
+    # (e.g., the foreach heuristic only tunes num_warps, not XBLOCK).
+    # In that case, use the default_config from combo_grid_meta
+    combo_grid_meta = inductor_meta.get("combo_grid_meta") if inductor_meta else None
+    default_config = combo_grid_meta.get("default_config") if combo_grid_meta else None
+    if default_config:
+        config = {**default_config, **config}
+
     xblock = config.get("XBLOCK", 128)
     yblock = config.get("YBLOCK", 1)
     zblock = config.get("ZBLOCK", 1)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #179329

This fixes a perf regression seen after switching cpp-wrapper default to
use lazy triton compile in https://github.com/pytorch/pytorch/pull/177732

When autotune_at_compile_time=False with cpp_wrapper, the lazy compile
path reads XBLOCK from the autotuner's chosen config. For combo/foreach
kernels using the `foreach` heuristic, the config has empty kwargs (only
num_warps is tuned, not XBLOCK). The code fell back to a hardcoded
default of 128, while the non-lazy-compile path correctly uses the
default_config from combo_grid_meta (XBLOCK=1024).

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos