### PR TITLE
[inductor] Defer cudagraph static input checks to after replay

### DIFF
--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -2779,6 +2779,9 @@ if HAS_CUDA_AND_TRITON:
                 # Fwd + bwd graphs for each version of the function => 4 graphs
                 self.assertEqual(self.get_manager().new_graph_id().id, 4)
 
+        @torch._inductor.config.patch(
+            "triton.cudagraph_defer_static_input_checks", False
+        )
         @torch._dynamo.config.patch("error_on_recompile", True)
         def test_multi_dispatch_single_compile_param_inputs(self):
             # Verify that we can record multiple cudagraphs for a single
@@ -2789,6 +2792,9 @@ if HAS_CUDA_AND_TRITON:
             # Fwd + bwd graphs for each version of the function => 4 graphs
             self.run_static_input_param_test(fn, 4)
 
+        @torch._inductor.config.patch(
+            "triton.cudagraph_defer_static_input_checks", False
+        )
         @torch._dynamo.config.patch("error_on_recompile", True)
         def test_multi_dispatch_single_compile_builtin_module(self):
             # Verify that we don't recompile when changing the param of a builtin module
@@ -2796,6 +2802,9 @@ if HAS_CUDA_AND_TRITON:
             # Note: Linear is a builtin module so we enable that config setting above
             self._module_test(torch.nn.Linear(2, 3, device="cuda"))
 
+        @torch._inductor.config.patch(
+            "triton.cudagraph_defer_static_input_checks", False
+        )
         @torch._dynamo.config.patch("error_on_recompile", True)
         def test_multi_dispatch_single_compile_builtin_module_buffers(self):
             # Verify that we don't recompile when changing the buffer of a builtin module
@@ -2806,6 +2815,9 @@ if HAS_CUDA_AND_TRITON:
                 param_wrapping=False,
             )
 
+        @torch._inductor.config.patch(
+            "triton.cudagraph_defer_static_input_checks", False
+        )
         @torch._inductor.config.patch("triton.cudagraphs", True)
         @torch._dynamo.config.patch("error_on_recompile", True)
         def test_multi_dispatch_custom_module(self):
@@ -2823,6 +2835,9 @@ if HAS_CUDA_AND_TRITON:
                 TestModule(torch.nn.Parameter(torch.rand([2, 2], device="cuda")))
             )
 
+        @torch._inductor.config.patch(
+            "triton.cudagraph_defer_static_input_checks", False
+        )
         @torch._dynamo.config.patch("error_on_recompile", True)
         def test_multi_dispatch_custom_module_buffer(self):
             # Test that we can correctly dispatch multiple graphs
@@ -2845,6 +2860,9 @@ if HAS_CUDA_AND_TRITON:
                 param_wrapping=False,
             )
 
+        @torch._inductor.config.patch(
+            "triton.cudagraph_defer_static_input_checks", False
+        )
         @torch._inductor.config.patch("triton.cudagraphs", True)
         @torch._dynamo.config.patch("error_on_recompile", True)
         def test_multi_dispatch_child_node(self):
@@ -2864,6 +2882,9 @@ if HAS_CUDA_AND_TRITON:
             # and then two backward graphs
             self.run_static_input_param_test(fn, 5)
 
+        @torch._inductor.config.patch(
+            "triton.cudagraph_defer_static_input_checks", False
+        )
         @torch._dynamo.config.patch("error_on_recompile", True)
         def test_multi_dispatch_parent_node(self):
             def fn(x, p):
@@ -2883,6 +2904,9 @@ if HAS_CUDA_AND_TRITON:
             # and then two backward graphs
             self.run_static_input_param_test(fn, 6)
 
+        @torch._inductor.config.patch(
+            "triton.cudagraph_defer_static_input_checks", False
+        )
         @torch._dynamo.config.patch("error_on_recompile", True)
         @torch._inductor.config.patch("triton.cudagraph_unexpected_rerecord_limit", 1)
         def test_not_fallback_to_eager_if_have_not_recompiling_too_many_times(self):
@@ -3292,6 +3316,9 @@ if HAS_CUDA_AND_TRITON:
             for _ in range(3):
                 foo(inp)
 
+        @torch._inductor.config.patch(
+            "triton.cudagraph_defer_static_input_checks", False
+        )
         @torch._inductor.config.patch("triton.cudagraph_support_input_mutation", True)
         def test_rerecord_if_static_input_address_changed(self):
             # By setting triton.cudagraph_support_input_mutation=True, we force re-record

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1657,6 +1657,14 @@ class triton:
     # not incurring large memory overhead
     reorder_for_reducing_graph_partitions: bool = True
 
+    # Defer checking static input (parameter) data pointers to after
+    # graph.replay(). This moves the O(n_params) check off the critical
+    # path so it doesn't delay GPU launch. If a parameter change is
+    # detected post-replay, one invocation may return stale results, but
+    # the node permanently falls back to full pre-replay checking so
+    # subsequent invocations are correct.
+    cudagraph_defer_static_input_checks = True
+
     # assertions on the fast path
     fast_path_cudagraph_asserts = False
 

--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -834,6 +834,13 @@ class AliasesNewOutput(OutputAliasInfo):
         self.index = index
 
 
+def _check_invariants_success_str() -> str:
+    return str(CheckInvariantStatus.SUCCESS)
+
+
+_check_invariants_success_logger = _check_invariants_success_str
+
+
 class CUDAGraphNode:
     """
     A single recording of a function into a CUDA Graph. Recordings of CUDA Graphs share a single memory pool
@@ -950,6 +957,17 @@ class CUDAGraphNode:
             for i in wrapped_function.static_input_idxs
             if i not in self.cudagraph_managed_idxs
         ]
+
+        # For deferred static input checks: check one sentinel param before
+        # replay to catch the common all-params-changed case, then verify
+        # the rest after replay.
+        if self.non_managed_static_input_idxs:
+            self._sentinel_static_input_idxs = [
+                self.non_managed_static_input_idxs[0]
+            ]
+        else:
+            self._sentinel_static_input_idxs = []
+        self._force_full_static_input_check = False
 
         def maybe_get_static_data_ptr(
             idx: int,
@@ -1132,6 +1150,31 @@ class CUDAGraphNode:
             )
             torch._check(False, lambda: error_msg)
 
+    def _check_deferred_static_inputs(
+        self, new_inputs: list[InputType]
+    ) -> None:
+        if (
+            not config.triton.cudagraph_defer_static_input_checks
+            or self._force_full_static_input_check
+            or not self.non_managed_static_input_idxs
+        ):
+            return
+        if not torch._C._tensors_data_ptrs_at_indices_equal(
+            new_inputs,  # type: ignore[arg-type]
+            self.static_input_data_ptrs,
+            self.non_managed_static_input_idxs,
+        ):
+            # Sentinel passed but another param changed. We already replayed
+            # with stale data. Fall back to full pre-replay checking so
+            # future invocations catch this before replay.
+            self._force_full_static_input_check = True
+            raise RuntimeError(
+                "CUDA graph deferred static input check detected a parameter "
+                "change after replay. This invocation returned stale results. "
+                "Set torch._inductor.config.triton.cudagraph_defer_static_input_checks = False "
+                "to check all parameters before replay."
+            )
+
     def run_first_inputs(self, new_inputs: list[InputType]) -> OutputType:
         if config.triton.fast_path_cudagraph_asserts:
             self.debug_check_invariants_before_invocation()
@@ -1151,6 +1194,8 @@ class CUDAGraphNode:
 
         self.run_graph()
 
+        self._check_deferred_static_inputs(new_inputs)
+
         outputs = self.reconstruct_outputs()
         new_inputs.clear()
 
@@ -1159,9 +1204,6 @@ class CUDAGraphNode:
 
         if config.triton.force_cudagraph_sync:
             torch.cuda.synchronize()
-
-        # Reset this to run the check in the future
-        self.static_inputs_stable = False
 
         return outputs
 
@@ -1750,13 +1792,6 @@ class CUDAGraphNode:
         and tensors managed in the cudagraph private pool must remain stable.
         """
 
-        _logger = functools.partial(
-            log_data_ptr_mismatch,
-            self.wrapped_function.placeholders,
-            inputs,
-            self.static_input_data_ptrs,
-        )
-
         # previously managed data pointers remain stable
         # this is on the hot path so moved to C++. equivalent to:
         # return all(t.data_ptr() == data_ptr for (t, data_ptr) in zip(tensors, data_ptrs))
@@ -1767,7 +1802,10 @@ class CUDAGraphNode:
         ):
             status = CheckInvariantStatus.CudagraphManagedIdxMismatch
             _logger = functools.partial(
-                _logger,
+                log_data_ptr_mismatch,
+                self.wrapped_function.placeholders,
+                inputs,
+                self.static_input_data_ptrs,
                 self.cudagraph_managed_idxs,
                 status,
             )
@@ -1783,21 +1821,32 @@ class CUDAGraphNode:
         # if we are inlining builtin nn modules we re-record in this case
         # if we are not inlining builtin nn modules, we check this in check_static_inputs_are_stable
         # and error if they are not stable
-        if (
-            self.rerecord_if_static_inputs_change
-            and not torch._C._tensors_data_ptrs_at_indices_equal(
+        if self.rerecord_if_static_inputs_change:
+            # When deferred checks are enabled, only check a single sentinel
+            # param before replay to catch the common all-params-changed case.
+            # The full check happens after graph.replay() in run().
+            if (
+                config.triton.cudagraph_defer_static_input_checks
+                and not self._force_full_static_input_check
+            ):
+                check_idxs = self._sentinel_static_input_idxs
+            else:
+                check_idxs = self.non_managed_static_input_idxs
+            if check_idxs and not torch._C._tensors_data_ptrs_at_indices_equal(
                 inputs,  # type: ignore[arg-type]
                 self.static_input_data_ptrs,
-                self.static_input_idxs,
-            )
-        ):
-            status = CheckInvariantStatus.StaticInputIdxMismatch
-            _logger = functools.partial(
-                _logger,
-                self.static_input_idxs,
-                status,
-            )
-            return status, _logger
+                check_idxs,
+            ):
+                status = CheckInvariantStatus.StaticInputIdxMismatch
+                _logger = functools.partial(
+                    log_data_ptr_mismatch,
+                    self.wrapped_function.placeholders,
+                    inputs,
+                    self.static_input_data_ptrs,
+                    self.static_input_idxs,
+                    status,
+                )
+                return status, _logger
 
         # the cudagraph managed tensors which died upon recording must also die upon
         # this invocation. it is too late to check after we've replayed the graph,
@@ -1813,7 +1862,7 @@ class CUDAGraphNode:
             lambda: "TODO: graph recording observed an input tensor deallocate during graph "
             " recording that did not occur during replay. Please file an issue.",
         )
-        return CheckInvariantStatus.SUCCESS, lambda: f"{CheckInvariantStatus.SUCCESS}"
+        return CheckInvariantStatus.SUCCESS, _check_invariants_success_logger
 
     def num_descendants(self) -> int:
         "Total number of descendents of this node"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #179332
* #179331
* __->__ #179330

Move the O(n_params) static input data pointer check from before
graph.replay() to after, so it doesn't delay GPU launch. A single
sentinel parameter is still checked before replay to catch the common
all-params-changed case and trigger re-recording immediately. The
remaining parameters are verified after replay.

If the post-replay check detects a change the sentinel missed, it
raises a RuntimeError (since we already returned stale results) and
permanently falls back to full pre-replay checking on that node.
Controlled by `triton.cudagraph_defer_static_input_checks` (default
True).

Also removes a per-call functools.partial allocation and lambda on
the success path of check_invariants.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo