### PR TITLE
[inductor] Fix i32 overflow in triton template kernel signature for large storage offsets (#179333)

### DIFF
--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -3023,6 +3023,49 @@ class TestMaxAutotune(TestCase):
     @fresh_cache()
     @skipIfXpu
     @unittest.skipIf(TEST_WITH_ROCM, "Test requires CUDA")
+    @largeTensorTest("6 GB", device=GPU_TYPE)
+    def test_max_autotune_mm_large_storage_offset_i64_indexing(self):
+        """
+        Test mm with input having dynamic storage offset exceeding i32 range.
+        When a dynamic-shaped input is a slice with offset proportional to
+        the dynamic dim (e.g., offset=70000*s6), the ks parameter in the
+        triton template signature must use i64 to avoid overflow in pointer
+        arithmetic like `A = arg_A + 70000*ks0`.
+        """
+
+        def mm(x, w):
+            batch = x.shape[0] // 8
+            a = x[7 * batch :]
+            return torch.mm(a, w)
+
+        K, N = 10000, 32
+        batch = 32768
+        x = torch.randn(8 * batch, K, device=GPU_TYPE, dtype=torch.bfloat16)
+        w = torch.randn(K, N, device=GPU_TYPE, dtype=torch.bfloat16)
+
+        expected_offset = 7 * batch * K
+        self.assertTrue(
+            expected_offset > 2**31 - 1,
+            f"Test requires offset > i32_max, got {expected_offset}",
+        )
+
+        torch._dynamo.mark_dynamic(x, 0)
+
+        with config.patch(
+            {
+                "max_autotune": True,
+                "max_autotune_gemm_backends": "TRITON",
+                "test_configs.autotune_choice_name_regex": r"^triton_mm_",
+            }
+        ):
+            result = torch.compile(mm)(x, w)
+
+        a = x[7 * batch :]
+        torch.testing.assert_close(result, torch.mm(a, w), rtol=1e-2, atol=1e-2)
+
+    @fresh_cache()
+    @skipIfXpu
+    @unittest.skipIf(TEST_WITH_ROCM, "Test requires CUDA")
     @unittest.skipIf(
         not SM90OrLater, "Requires SM90+ (H100/B200) for sufficient GPU memory"
     )

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -512,6 +512,7 @@ class TritonTemplateKernel(TritonKernel):
         hint_override: int | None = None,
         triton_meta: dict[str, object] | None = None,
         always_freeze_layout: bool = False,
+        index_dtype_override: str | None = None,
     ) -> None:
         if tma_store:
             pass
@@ -582,6 +583,7 @@ class TritonTemplateKernel(TritonKernel):
         self.epilogue_fn = epilogue_fn
         self.render_hooks = {}  # type: ignore[var-annotated]
         self.triton_meta: dict[str, object] | None = triton_meta
+        self._index_dtype_override = index_dtype_override
         # For Templated Attention this can be a list of ir.Subgraph
         self.subgraphs: list[ir.ComputedBuffer] | None = subgraphs
 
@@ -645,6 +647,12 @@ class TritonTemplateKernel(TritonKernel):
 
         # Tracking for intermediate variables
         self.tmp_var_ctr = itertools.count()
+
+    @property
+    def index_dtype(self) -> str:
+        if self._index_dtype_override is not None:
+            return self._index_dtype_override
+        return super().index_dtype
 
     def _gen_tmp_var(self) -> str:
         return f"_tmp_var{next(self.tmp_var_ctr)}"
@@ -2611,6 +2619,7 @@ class TritonTemplate(KernelTemplate):
             "subgraphs": subgraphs,
             "prologue_loads_all_inputs": self.prologue_loads_all_inputs,
             "always_freeze_layout": self.always_freeze_layout,
+            "index_dtype_override": index_dtype,
         }
 
         if HAS_WARP_SPEC:


### PR DESCRIPTION
Summary:

## Issue
`TritonTemplateKernel` inherits `index_dtype` as a property from `SIMDKernel`, which derives it from `SIMDKernelFeatures`. However, the template kernel is constructed with `SIMDKernelFeatures([], numel)` — an empty node list — because templates bypass the scheduler. This means `self.index_dtype` only checks the output numel to decide between i32/i64, completely ignoring input buffer storage sizes and offsets.

Meanwhile, `generate_and_load()` from `TritonTemplate` already computes the correct `index_dtype` by calling `can_use_32bit_indexing(numel, buffers)` with the actual input nodes, and writes it as `INDEX_DTYPE` in the kernel body. But the signature generation in `jit_lines()` uses `self.index_dtype` (the wrong one) to type `ks` parameters.

When an input has a large dynamic storage offset (e.g., from slicing a tensor where `offset = 70000 * s6`), the output numel can fit in i32 while the input storage size exceeds i32. The kernel body correctly gets `INDEX_DTYPE = tl.int64`, but the signature has `ks0: 'i32'`. The pointer arithmetic `A = arg_A + 70000 * ks0` then overflows in i32, causing an illegal memory access.

## Proposed Fix
thread the correctly computed `index_dtype` from `generate_and_load()` into `TritonTemplateKernel` via `index_dtype_override`, and use it in `jit_lines()` for signature generation. This affects all triton template-based ops (mm, bmm, addmm, conv, flex attention, etc.).

Test Plan:
## Unit test
```
buck2 run @//mode/opt //caffe2/test/inductor:max_autotune -- -r 'test_max_autotune_mm_large_storage_offset_i64_indexing'
```
## Local e2e
previously failed lowering could now succeed (model 2131358031_0)

## OSS CI

Reviewed By: zoranzhao

Differential Revision: D99483771




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos