### PR TITLE
[CI] Handle GitHub API error when getting the list of changed files

### DIFF
--- a/.github/workflows/_get-changed-files.yml
+++ b/.github/workflows/_get-changed-files.yml
@@ -38,12 +38,17 @@ jobs:
               echo "all_files input is true, returning all files"
               echo "changed-files=*" >> "$GITHUB_OUTPUT"
             else
-              # Use gh CLI to get changed files in the PR with explicit repo
-              if ! CHANGED_FILES=$(gh api repos/${{ github.repository }}/pulls/$PR_NUMBER/files --paginate --jq '.[] | select(.status != "removed") | .filename' | tr '\n' ' ' | sed 's/ $//'); then
+              # Use gh CLI to get changed files in the PR with explicit repo.
+              # The API call is separated from the tr/sed pipeline so that
+              # `if !` checks the gh exit code, not sed's (which always succeeds).
+              # Without this, an API error (e.g. 403 rate limit) would be silently
+              # captured as the file list and injected into downstream lint jobs.
+              if ! RAW_FILES=$(gh api repos/${{ github.repository }}/pulls/$PR_NUMBER/files --paginate --jq '.[] | select(.status != "removed") | .filename'); then
                 echo "Failed to get changed files from GitHub API, falling back to all files"
                 echo "changed-files=*" >> "$GITHUB_OUTPUT"
                 exit 0
               fi
+              CHANGED_FILES=$(echo "$RAW_FILES" | tr '\n' ' ' | sed 's/ $//')
 
               # See https://github.com/pytorch/pytorch/pull/134215#issuecomment-2332128790
               PYI_FILES_TO_ADD=""

--- a/.github/workflows/_get-changed-files.yml
+++ b/.github/workflows/_get-changed-files.yml
@@ -39,7 +39,11 @@ jobs:
               echo "changed-files=*" >> "$GITHUB_OUTPUT"
             else
               # Use gh CLI to get changed files in the PR with explicit repo
-              CHANGED_FILES=$(gh api repos/${{ github.repository }}/pulls/$PR_NUMBER/files --paginate --jq '.[] | select(.status != "removed") | .filename' | tr '\n' ' ' | sed 's/ $//')
+              if ! CHANGED_FILES=$(gh api repos/${{ github.repository }}/pulls/$PR_NUMBER/files --paginate --jq '.[] | select(.status != "removed") | .filename' | tr '\n' ' ' | sed 's/ $//'); then
+                echo "Failed to get changed files from GitHub API, falling back to all files"
+                echo "changed-files=*" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
 
               # See https://github.com/pytorch/pytorch/pull/134215#issuecomment-2332128790
               PYI_FILES_TO_ADD=""

--- a/.github/workflows/_get-changed-files.yml
+++ b/.github/workflows/_get-changed-files.yml
@@ -25,7 +25,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          set -e
+          set -eo pipefail
           # Check if we're in a pull request context
           if [ "${{ github.event_name }}" = "pull_request" ] || [ "${{ github.event_name }}" = "pull_request_target" ]; then
             echo "Running in PR context"
@@ -39,16 +39,14 @@ jobs:
               echo "changed-files=*" >> "$GITHUB_OUTPUT"
             else
               # Use gh CLI to get changed files in the PR with explicit repo.
-              # The API call is separated from the tr/sed pipeline so that
-              # `if !` checks the gh exit code, not sed's (which always succeeds).
-              # Without this, an API error (e.g. 403 rate limit) would be silently
+              # pipefail ensures that if gh fails (e.g. 403 rate limit), the
+              # error propagates through the pipe instead of being silently
               # captured as the file list and injected into downstream lint jobs.
-              if ! RAW_FILES=$(gh api repos/${{ github.repository }}/pulls/$PR_NUMBER/files --paginate --jq '.[] | select(.status != "removed") | .filename'); then
+              if ! CHANGED_FILES=$(gh api repos/${{ github.repository }}/pulls/$PR_NUMBER/files --paginate --jq '.[] | select(.status != "removed") | .filename' | tr '\n' ' ' | sed 's/ $//'); then
                 echo "Failed to get changed files from GitHub API, falling back to all files"
                 echo "changed-files=*" >> "$GITHUB_OUTPUT"
                 exit 0
               fi
-              CHANGED_FILES=$(echo "$RAW_FILES" | tr '\n' ' ' | sed 's/ $//')
 
               # See https://github.com/pytorch/pytorch/pull/134215#issuecomment-2332128790
               PYI_FILES_TO_ADD=""


### PR DESCRIPTION
Highlighted by @malfet in https://github.com/pytorch/pytorch/actions/runs/23962997110/job/69905669085 

When the GitHub API returns an error (e.g. HTTP 403 rate limit), the error JSON was being captured as the list of changed files and passed to downstream lint jobs, causing them to fail with confusing errors.

The root cause was that gh api ... | tr | sed piped through text-processing commands whose exit code (always 0) masked the API failure, so the error response body ended up in CHANGED_FILES. The fix separates the API call from the pipe so if ! checks the gh exit code directly. On any API failure, we now fall back to * (lint all files) instead of propagating the error text.