### PR TITLE
[CooR] Add node dedup and impl caching for mesh custom ops

### DIFF
--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -1189,6 +1189,24 @@ def _expand_group(group: RANK_TYPES, tag: str = "") -> tuple[str, list[int], int
     return (tag, rankset, group_size)
 
 
+# Cache for CooR mesh_get_process_group node deduplication during make_fx
+# tracing. Keyed by (id(mesh), dim), stores (mesh_strong_ref, result).
+# Each unique (DeviceMesh, dim) pair produces exactly one FX node in the
+# traced graph, regardless of how many collectives reference it.
+_coor_mesh_get_pg_cache: dict[tuple[int, int], tuple[Any, Any]] = {}
+
+
+def _coor_cached_mesh_get_pg(mesh: "DeviceMesh", dim: int) -> Any:
+    key = (id(mesh), dim)
+    if key in _coor_mesh_get_pg_cache:
+        cached_mesh, cached_result = _coor_mesh_get_pg_cache[key]
+        if cached_mesh is mesh:
+            return cached_result
+    result = torch.ops._dtensor.mesh_get_process_group(mesh, dim)
+    _coor_mesh_get_pg_cache[key] = (mesh, result)
+    return result
+
+
 def _resolve_group(
     group: RANK_TYPES, tag: str = ""
 ) -> dist.ProcessGroup | c10d.GroupName:
@@ -1213,7 +1231,7 @@ def _resolve_group(
                 "Only 1D mesh is supported, pass in (DeviceMesh, int) together if mesh > 1D"
             )
         if dist.config.compile_on_one_rank:
-            return torch.ops._dtensor.mesh_get_process_group(group, 0)
+            return _coor_cached_mesh_get_pg(group, 0)
         return group._dim_group_names[0]
     elif isinstance(group, tuple):
         if (
@@ -1224,7 +1242,7 @@ def _resolve_group(
             dmesh = group[0]
             dim = group[1]
             if dist.config.compile_on_one_rank:
-                return torch.ops._dtensor.mesh_get_process_group(dmesh, dim)
+                return _coor_cached_mesh_get_pg(dmesh, dim)
             return dmesh._dim_group_names[dim]
         else:
             raise ValueError(

--- a/torch/distributed/_ops/device_mesh.py
+++ b/torch/distributed/_ops/device_mesh.py
@@ -95,7 +95,9 @@ def _get_submesh_impl(mesh: DeviceMesh, mesh_dims: list[int]) -> DeviceMesh:
     return mesh[dim_names]
 
 
-_get_submesh_cache: dict[tuple[int, tuple[int, ...]], tuple["DeviceMesh", "DeviceMesh"]] = {}
+_get_submesh_cache: dict[
+    tuple[int, tuple[int, ...]], tuple["DeviceMesh", "DeviceMesh"]
+] = {}
 
 
 @torch.library.custom_op("device_mesh::_get_submesh", mutates_args=())

--- a/torch/distributed/_ops/device_mesh.py
+++ b/torch/distributed/_ops/device_mesh.py
@@ -95,9 +95,19 @@ def _get_submesh_impl(mesh: DeviceMesh, mesh_dims: list[int]) -> DeviceMesh:
     return mesh[dim_names]
 
 
+_get_submesh_cache: dict[tuple[int, tuple[int, ...]], tuple["DeviceMesh", "DeviceMesh"]] = {}
+
+
 @torch.library.custom_op("device_mesh::_get_submesh", mutates_args=())
 def _get_submesh(mesh: DeviceMesh, mesh_dims: list[int]) -> DeviceMesh:
-    return _get_submesh_impl(mesh, mesh_dims)
+    key = (id(mesh), tuple(mesh_dims))
+    if key in _get_submesh_cache:
+        cached_mesh, cached_result = _get_submesh_cache[key]
+        if cached_mesh is mesh:
+            return cached_result
+    result = _get_submesh_impl(mesh, mesh_dims)
+    _get_submesh_cache[key] = (mesh, result)
+    return result
 
 
 @_get_submesh.register_fake

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -1599,6 +1599,13 @@ else:
 _distributed_opaque_types_registered = False
 
 
+# Cache for CooR _get_submesh node deduplication during make_fx tracing.
+# Keyed by (id(ancestor_proxy), tuple(mesh_dims)), stores (proxy_strong_ref, result).
+# Each unique (ancestor, dims) pair produces exactly one FX node in the
+# traced graph, regardless of how many submesh reconstructions reference it.
+_coor_get_submesh_cache: dict[tuple[int, tuple[int, ...]], tuple[Any, Any]] = {}
+
+
 def _device_mesh_reconstruct_fn(
     mesh: "OpaqueBase",
     get_tracked_proxy: Callable[["OpaqueBase"], "torch.fx.Proxy | None"],
@@ -1662,6 +1669,21 @@ def _device_mesh_reconstruct_fn(
 
     # Convert our dim names to indices into the ancestor mesh's dim names
     mesh_dims = [ancestor_dim_names.index(n) for n in dim_names]
+
+    # Under CooR, deduplicate _get_submesh nodes so each unique
+    # (ancestor, dims) pair produces exactly one FX node in the graph.
+    # This avoids O(num_collectives) redundant custom op dispatch overhead.
+    import torch.distributed as _dist
+
+    if _dist.config.compile_on_one_rank:
+        cache_key = (id(ancestor_proxy), tuple(mesh_dims))
+        if cache_key in _coor_get_submesh_cache:
+            cached_proxy, cached_result = _coor_get_submesh_cache[cache_key]
+            if cached_proxy is ancestor_proxy:
+                return cached_result
+        result = torch.ops.device_mesh._get_submesh(ancestor_proxy, mesh_dims)
+        _coor_get_submesh_cache[cache_key] = (ancestor_proxy, result)
+        return result
 
     # Dispatch through the custom op with proxy mode active so that
     # meta["val"] is set and the result is tracked in opaque_tracker.

--- a/torch/distributed/tensor/_collective_utils.py
+++ b/torch/distributed/tensor/_collective_utils.py
@@ -48,9 +48,19 @@ _dtensor_lib.define(
 )
 
 
+_mesh_get_pg_cache: dict[tuple[int, int], tuple[object, object]] = {}
+
+
 @torch.library.impl("_dtensor::mesh_get_process_group", "CompositeExplicitAutograd")
 def _mesh_get_process_group_impl(mesh, dim):
-    return mesh.get_group(dim)
+    key = (id(mesh), dim)
+    if key in _mesh_get_pg_cache:
+        cached_mesh, cached_result = _mesh_get_pg_cache[key]
+        if cached_mesh is mesh:
+            return cached_result
+    result = mesh.get_group(dim)
+    _mesh_get_pg_cache[key] = (mesh, result)
+    return result
 
 
 @torch.library.register_fake("_dtensor::mesh_get_process_group")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #179342

When using CooR (Compile-on-one-Rank) with aot_fx_trace, every collective
dispatches through `_get_submesh` and `mesh_get_process_group` custom ops
during make_fx tracing. For a typical DeepSeek V3 debug model, this produces
~364 redundant CooR FX nodes (182 _get_submesh + 182 mesh_get_process_group)
even though only ~5-6 unique (DeviceMesh, dim) pairs exist.

This PR adds two layers of caching:

1. **FX node deduplication (trace-time)**: Cache the FX proxy returned by each
   custom op keyed by (id(mesh/proxy), dim/mesh_dims) so that repeated calls
   with the same inputs during tracing return the existing proxy instead of
   creating new FX nodes. This reduces the graph from ~364 CooR nodes to ~5-6.
   - `_coor_cached_mesh_get_pg` in _functional_collectives.py
   - `_coor_get_submesh_cache` in device_mesh.py

2. **Impl-level caching (runtime)**: Cache results inside the custom op
   implementations so that at eager-execution time, repeated dispatches for the
   same (mesh, dim) pair return cached results without recomputation.
   - `_mesh_get_pg_cache` in _collective_utils.py
   - `_get_submesh_cache` in _ops/device_mesh.py

Both caches use (id(obj), args) keys with a strong-reference identity check to
avoid stale-id collisions.