### PR TITLE
Make config.patch reentrant across threads

### DIFF
--- a/test/test_utils_config_module.py
+++ b/test/test_utils_config_module.py
@@ -1,6 +1,7 @@
 # Owner(s): ["module: unknown"]
 import os
 import pickle
+import queue
 import threading
 import warnings
 from unittest.mock import patch
@@ -428,13 +429,13 @@ torch.testing._internal.fake_config_module3.e_func = _warnings.warn""",
 
     def _assert_patch_reentrant_across_threads(self, fn):
         barrier = threading.Barrier(2, timeout=5)
-        errors = []
+        errors: queue.SimpleQueue[str] = queue.SimpleQueue()
 
         def worker():
             try:
                 fn(barrier)
-            except BaseException as e:
-                errors.append(repr(e))
+            except Exception as e:
+                errors.put(repr(e))
 
         threads = [threading.Thread(target=worker) for _ in range(2)]
         for thread in threads:
@@ -442,7 +443,16 @@ torch.testing._internal.fake_config_module3.e_func = _warnings.warn""",
         for thread in threads:
             thread.join()
 
-        self.assertFalse(errors, f"concurrent patch usage failed: {errors}")
+        error_messages = []
+        while True:
+            try:
+                error_messages.append(errors.get_nowait())
+            except queue.Empty:
+                break
+
+        self.assertFalse(
+            error_messages, f"concurrent patch usage failed: {error_messages}"
+        )
         self.assertTrue(config.e_bool)
 
     def test_patch_context_manager_is_reentrant_across_threads(self):
@@ -455,6 +465,17 @@ torch.testing._internal.fake_config_module3.e_func = _warnings.warn""",
                 self.assertFalse(config.e_bool)
 
         self._assert_patch_reentrant_across_threads(fn)
+
+    def test_patch_context_manager_is_reentrant_when_nested(self):
+        patcher = config.patch(e_bool=False)
+
+        with patcher:
+            self.assertFalse(config.e_bool)
+            with patcher:
+                self.assertFalse(config.e_bool)
+            self.assertFalse(config.e_bool)
+
+        self.assertTrue(config.e_bool)
 
     def test_patch_decorator_is_reentrant_across_threads(self):
         @config.patch(e_bool=False)

--- a/test/test_utils_config_module.py
+++ b/test/test_utils_config_module.py
@@ -1,6 +1,7 @@
 # Owner(s): ["module: unknown"]
 import os
 import pickle
+import threading
 import warnings
 from unittest.mock import patch
 
@@ -424,6 +425,45 @@ torch.testing._internal.fake_config_module3.e_func = _warnings.warn""",
         with self.assertRaises(AssertionError):
             with config.patch("does_not_exist"):
                 pass
+
+    def _assert_patch_reentrant_across_threads(self, fn):
+        barrier = threading.Barrier(2, timeout=5)
+        errors = []
+
+        def worker():
+            try:
+                fn(barrier)
+            except BaseException as e:
+                errors.append(repr(e))
+
+        threads = [threading.Thread(target=worker) for _ in range(2)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        self.assertFalse(errors, f"concurrent patch usage failed: {errors}")
+        self.assertTrue(config.e_bool)
+
+    def test_patch_context_manager_is_reentrant_across_threads(self):
+        patcher = config.patch(e_bool=False)
+
+        def fn(barrier):
+            with patcher:
+                self.assertFalse(config.e_bool)
+                barrier.wait()
+                self.assertFalse(config.e_bool)
+
+        self._assert_patch_reentrant_across_threads(fn)
+
+    def test_patch_decorator_is_reentrant_across_threads(self):
+        @config.patch(e_bool=False)
+        def fn(barrier):
+            self.assertFalse(config.e_bool)
+            barrier.wait()
+            self.assertFalse(config.e_bool)
+
+        self._assert_patch_reentrant_across_threads(fn)
 
     def test_make_closur_patcher(self):
         revert = config._make_closure_patcher(e_bool=False)()

--- a/torch/utils/_config_module.py
+++ b/torch/utils/_config_module.py
@@ -746,28 +746,40 @@ class ConfigModule(ModuleType):
                 )
         if not isinstance(changes, dict):
             raise AssertionError(f"expected `dict` got {type(changes)}")
-        prior: dict[str, Any] = {}
         config = self
 
         class ConfigPatch(ContextDecorator):
             def __init__(self) -> None:
                 self.changes = changes
+                self._prior: ContextVar[tuple[dict[str, Any], ...]] = ContextVar(
+                    f"{config.__name__}.ConfigPatch[{id(self)}]",
+                    default=(),
+                )
 
             def __enter__(self) -> None:
-                if prior:
-                    raise AssertionError(
-                        "prior should be empty when entering ConfigPatch"
-                    )
+                prior: dict[str, Any] = {}
                 for key in self.changes:
                     # KeyError on invalid entry
                     prior[key] = config.__getattr__(key)
-                for k, v in self.changes.items():
-                    config.__setattr__(k, v)
+                prior_stack = self._prior.get()
+                self._prior.set((*prior_stack, prior))
+                try:
+                    for k, v in self.changes.items():
+                        config.__setattr__(k, v)
+                except Exception:
+                    self._prior.set(prior_stack)
+                    raise
 
             def __exit__(self, exc_type, exc_val, exc_tb):  # type: ignore[no-untyped-def]
+                prior_stack = self._prior.get()
+                if not prior_stack:
+                    raise AssertionError(
+                        "prior should not be empty when exiting ConfigPatch"
+                    )
+                prior = prior_stack[-1]
+                self._prior.set(prior_stack[:-1])
                 for k, v in prior.items():
                     config.__setattr__(k, v)
-                prior.clear()
 
         return ConfigPatch()
 


### PR DESCRIPTION
Fix #118387

## Summary

1. Root cause problem
`ConfigModule.patch()` stores the active patch state in a shared `prior` dict owned by the patch object itself. Reusing the same patch object as a decorator or shared context manager across threads makes those concurrent entries race, even though the underlying config values are already `ContextVar`-backed.

2. Proposed fix
Move the patch object's saved prior-state to a per-context `ContextVar` stack so the same patch object can be entered concurrently and nested safely. Add regression tests covering concurrent reuse through both the decorator form and a shared context-manager instance.

3. Why this is the right long term fix
This keeps the fix in the generic config patching primitive that Dynamo and Inductor already build on, so all existing decorator/context-manager call sites inherit the same thread-safe behavior without needing bespoke synchronization at each use site.

## Testing
- `python3 -m py_compile torch/utils/_config_module.py test/test_utils_config_module.py`
- Standalone concurrent regression harness against `torch.utils._config_module` with stubbed `torch` deps: reproduced the pre-fix `AssertionError: prior should be empty when entering ConfigPatch`, then verified concurrent decorator/context-manager reuse passes after the change
- `python3 test/test_utils_config_module.py` (fails in this environment because this checkout does not have a built/importable `torch`)

Drafted via Codex, published after manual review by @bobrenjc93