### PR TITLE
Use PyModule_AddObjectRef in torch/carc/utils

### DIFF
--- a/torch/csrc/Dtype.cpp
+++ b/torch/csrc/Dtype.cpp
@@ -9,7 +9,6 @@
 #include <cstring>
 
 PyObject* THPDtype_New(at::ScalarType scalar_type, const std::string& name) {
-  HANDLE_TH_ERRORS
   AT_ASSERT(name.length() < DTYPE_NAME_LEN);
   auto type = &THPDtypeType;
   auto self = THPObjectPtr{type->tp_alloc(type, 0)};
@@ -19,7 +18,6 @@ PyObject* THPDtype_New(at::ScalarType scalar_type, const std::string& name) {
   self_->scalar_type = scalar_type;
   std::strncpy(self_->name, name.c_str(), DTYPE_NAME_LEN);
   return self.release();
-  END_HANDLE_TH_ERRORS
 }
 
 static PyObject* THPDtype_is_floating_point(THPDtype* self, PyObject* noargs) {

--- a/torch/csrc/utils/tensor_dtypes.cpp
+++ b/torch/csrc/utils/tensor_dtypes.cpp
@@ -20,17 +20,15 @@ void initializeDtypes() {
 
   for (at::ScalarType scalarType : all_scalar_types) {
     auto [primary_name, legacy_name] = c10::getDtypeNames(scalarType);
-    PyObject* dtype = THPDtype_New(scalarType, primary_name);
-    torch::registerDtypeObject((THPDtype*)dtype, scalarType);
-    Py_INCREF(dtype);
-    if (PyModule_AddObject(torch_module.get(), primary_name.c_str(), dtype) !=
-        0) {
+    THPObjectPtr dtype(THPDtype_New(scalarType, primary_name));
+    torch::registerDtypeObject((THPDtype*)dtype.get(), scalarType);
+    if (PyModule_AddObjectRef(
+            torch_module.get(), primary_name.c_str(), dtype.get()) != 0) {
       throw python_error();
     }
     if (!legacy_name.empty()) {
-      Py_INCREF(dtype);
-      if (PyModule_AddObject(torch_module.get(), legacy_name.c_str(), dtype) !=
-          0) {
+      if (PyModule_AddObjectRef(
+              torch_module.get(), legacy_name.c_str(), dtype.get()) != 0) {
         throw python_error();
       }
     }

--- a/torch/csrc/utils/tensor_layouts.cpp
+++ b/torch/csrc/utils/tensor_layouts.cpp
@@ -6,49 +6,36 @@
 
 namespace torch::utils {
 
-#define REGISTER_LAYOUT(layout, LAYOUT)                                     \
-  PyObject* layout##_layout =                                               \
-      THPLayout_New(at::Layout::LAYOUT, "torch." #layout);                  \
-  Py_INCREF(layout##_layout);                                               \
-  if (PyModule_AddObject(torch_module, "" #layout, layout##_layout) != 0) { \
-    throw python_error();                                                   \
-  }                                                                         \
-  registerLayoutObject((THPLayout*)layout##_layout, at::Layout::LAYOUT);
+static void registerLayout(
+    PyObject* torch_module,
+    at::Layout layout,
+    const char* name,
+    const char* qualified_name) {
+  THPObjectPtr obj(THPLayout_New(layout, qualified_name));
+  if (PyModule_AddObjectRef(torch_module, name, obj.get()) != 0) {
+    throw python_error();
+  }
+  registerLayoutObject((THPLayout*)obj.get(), layout);
+}
 
 void initializeLayouts() {
   auto torch_module = THPObjectPtr(PyImport_ImportModule("torch"));
   if (!torch_module)
     throw python_error();
 
-  PyObject* strided_layout =
-      THPLayout_New(at::Layout::Strided, "torch.strided");
-  Py_INCREF(strided_layout);
-  if (PyModule_AddObject(torch_module, "strided", strided_layout) != 0) {
-    throw python_error();
-  }
-  registerLayoutObject((THPLayout*)strided_layout, at::Layout::Strided);
-
-  PyObject* sparse_coo_layout =
-      THPLayout_New(at::Layout::Sparse, "torch.sparse_coo");
-  Py_INCREF(sparse_coo_layout);
-  if (PyModule_AddObject(torch_module, "sparse_coo", sparse_coo_layout) != 0) {
-    throw python_error();
-  }
-  registerLayoutObject((THPLayout*)sparse_coo_layout, at::Layout::Sparse);
-
-  REGISTER_LAYOUT(sparse_csr, SparseCsr)
-  REGISTER_LAYOUT(sparse_csc, SparseCsc)
-  REGISTER_LAYOUT(sparse_bsr, SparseBsr)
-  REGISTER_LAYOUT(sparse_bsc, SparseBsc)
-
-  PyObject* mkldnn_layout = THPLayout_New(at::Layout::Mkldnn, "torch._mkldnn");
-  Py_INCREF(mkldnn_layout);
-  if (PyModule_AddObject(torch_module, "_mkldnn", mkldnn_layout) != 0) {
-    throw python_error();
-  }
-  registerLayoutObject((THPLayout*)mkldnn_layout, at::Layout::Mkldnn);
-
-  REGISTER_LAYOUT(jagged, Jagged);
+  registerLayout(torch_module, at::Layout::Strided, "strided", "torch.strided");
+  registerLayout(
+      torch_module, at::Layout::Sparse, "sparse_coo", "torch.sparse_coo");
+  registerLayout(
+      torch_module, at::Layout::SparseCsr, "sparse_csr", "torch.sparse_csr");
+  registerLayout(
+      torch_module, at::Layout::SparseCsc, "sparse_csc", "torch.sparse_csc");
+  registerLayout(
+      torch_module, at::Layout::SparseBsr, "sparse_bsr", "torch.sparse_bsr");
+  registerLayout(
+      torch_module, at::Layout::SparseBsc, "sparse_bsc", "torch.sparse_bsc");
+  registerLayout(torch_module, at::Layout::Mkldnn, "_mkldnn", "torch._mkldnn");
+  registerLayout(torch_module, at::Layout::Jagged, "jagged", "torch.jagged");
 }
 
 } // namespace torch::utils

--- a/torch/csrc/utils/tensor_memoryformats.cpp
+++ b/torch/csrc/utils/tensor_memoryformats.cpp
@@ -31,14 +31,12 @@ void initializeMemoryFormats() {
 
   auto add_memory_format = [&](at::MemoryFormat format, const char* name) {
     std::string module_name = "torch.";
-    PyObject* memory_format = THPMemoryFormat_New(format, module_name + name);
-    Py_INCREF(memory_format);
-    if (PyModule_AddObject(torch_module, name, memory_format) != 0) {
-      Py_DECREF(memory_format);
+    THPObjectPtr memory_format(THPMemoryFormat_New(format, module_name + name));
+    if (PyModule_AddObjectRef(torch_module, name, memory_format.get()) != 0) {
       throw python_error();
     }
-    Py_INCREF(memory_format);
-    memory_format_registry[static_cast<size_t>(format)] = memory_format;
+    memory_format_registry[static_cast<size_t>(format)] =
+        memory_format.release();
   };
 
   add_memory_format(at::MemoryFormat::Preserve, "preserve_format");

--- a/torch/csrc/utils/tensor_qschemes.cpp
+++ b/torch/csrc/utils/tensor_qschemes.cpp
@@ -20,13 +20,12 @@ void initializeQSchemes() {
 
   for (const auto i : c10::irange(at::COMPILE_TIME_NUM_QSCHEMES)) {
     auto qscheme = static_cast<at::QScheme>(i);
-    PyObject* qscheme_obj = THPQScheme_New(qscheme, toString(qscheme));
-    thp_qscheme_array[static_cast<int>(qscheme)] = qscheme_obj;
-    Py_INCREF(qscheme_obj);
-    if (PyModule_AddObject(
-            torch_module, toString(qscheme).c_str(), qscheme_obj) != 0) {
+    THPObjectPtr qscheme_obj(THPQScheme_New(qscheme, toString(qscheme)));
+    if (PyModule_AddObjectRef(
+            torch_module, toString(qscheme).c_str(), qscheme_obj.get()) != 0) {
       throw python_error();
     }
+    thp_qscheme_array[static_cast<int>(qscheme)] = qscheme_obj.release();
   }
 }
 


### PR DESCRIPTION
This PR uses PyModule_AddObjectRef in torch/carc/utils for simpler code. It also uses THPObjectPtr to avoid leaking in failure paths.