### PR TITLE
[Dynamo] Handle data_ptr equality on detach aliases

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -14295,6 +14295,23 @@ fn
 
         self.assertEqual(expected, actual)
 
+    def test_data_ptr_equality_after_mutation_graph_break(self):
+        def f(x):
+            ptr_before = x.data_ptr()
+            x.add_(1)
+            ptr_after = x.detach().data_ptr()
+            return torch.tensor([ptr_before == ptr_after], dtype=torch.long)
+
+        x = torch.randn(4)
+
+        with self.assertRaises(torch._dynamo.exc.Unsupported):
+            torch.compile(f, backend="eager", fullgraph=True)(x.clone())
+
+        expected = f(x.clone())
+        actual = torch.compile(f, backend="eager")(x.clone())
+
+        self.assertEqual(expected, actual)
+
     def test_data_ptr_graph_break_aten(self):
         def f(a):
             # torch.add not implemented for DataPtrVariable

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -14278,6 +14278,23 @@ fn
 
         self.assertEqual(expected, actual)
 
+    def test_data_ptr_detach_equality_fullgraph(self):
+        def f(x):
+            detached = x.detach()
+            same_data = (
+                x.data_ptr() == detached.data_ptr()
+                and x.stride() == detached.stride()
+                and x.shape == detached.shape
+            )
+            return torch.tensor([same_data], dtype=torch.long, device=x.device)
+
+        x = torch.randn(1, 1, 1, 3)
+
+        expected = f(x)
+        actual = torch.compile(f, backend="eager", fullgraph=True)(x)
+
+        self.assertEqual(expected, actual)
+
     def test_data_ptr_graph_break_aten(self):
         def f(a):
             # torch.add not implemented for DataPtrVariable

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -14312,6 +14312,33 @@ fn
 
         self.assertEqual(expected, actual)
 
+    def test_data_ptr_constant_comparison_graph_break(self):
+        def ptr_eq_zero(x):
+            return x.data_ptr() == 0
+
+        def zero_eq_ptr(x):
+            return 0 == x.data_ptr()
+
+        def ptr_ne_zero(x):
+            return x.data_ptr() != 0
+
+        def zero_ne_ptr(x):
+            return 0 != x.data_ptr()
+
+        x = torch.randn(4)
+
+        for fn in (ptr_eq_zero, zero_eq_ptr, ptr_ne_zero, zero_ne_ptr):
+            with self.assertRaises(torch._dynamo.exc.Unsupported):
+                torch.compile(fn, backend="eager", fullgraph=True)(x)
+
+            torch._dynamo.reset()
+
+            expected = fn(x)
+            actual = torch.compile(fn, backend="eager")(x)
+
+            self.assertEqual(expected, actual)
+            torch._dynamo.reset()
+
     def test_data_ptr_graph_break_aten(self):
         def f(a):
             # torch.add not implemented for DataPtrVariable

--- a/torch/_dynamo/graph_break_registry.json
+++ b/torch/_dynamo/graph_break_registry.json
@@ -1562,6 +1562,14 @@
       ]
     }
   ],
+  "GB5976": [
+    {
+      "Gb_type": "Data pointer comparison",
+      "Context": "call_method {self} {name} {args} {kwargs}",
+      "Explanation": "Dynamo can only trace data pointer comparisons when it can prove both operands have the same data pointer.",
+      "Hints": []
+    }
+  ],
   "GB4695": [
     {
       "Gb_type": "torch.jit.script/freeze modules unsupported",

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -106,6 +106,7 @@ from .lists import (
 from .misc import NullVariable, StringFormatVariable
 from .sets import FrozensetVariable, OrderedSetClassVariable, SetVariable
 from .tensor import (
+    DataPtrVariable,
     FakeItemVariable,
     supported_comparison_ops,
     SymNodeVariable,
@@ -837,6 +838,20 @@ class BuiltinVariable(BaseBuiltinVariable):
                     ]
                 )
 
+                if op in (operator.eq, operator.ne):
+
+                    def compare_by_method(
+                        tx: "InstructionTranslator",
+                        a: VariableTracker,
+                        b: VariableTracker,
+                    ) -> VariableTracker:
+                        method_name = "__eq__" if op is operator.eq else "__ne__"
+                        return a.call_method(tx, method_name, [b], {})
+
+                    result.append(
+                        ((DataPtrVariable, VariableTracker), compare_by_method)
+                    )
+
                 def handler(
                     tx: "InstructionTranslator", a: VariableTracker, b: VariableTracker
                 ) -> VariableTracker:
@@ -1413,11 +1428,13 @@ class BuiltinVariable(BaseBuiltinVariable):
 
                 return wrap_fx_proxy_cls(variables.NumpyNdarrayVariable, tx, proxy)
 
-            if fn is operator.eq and len(args) == 2 and args[0].is_tensor():
-                # Dynamo expects `__eq__` str while operator.eq gives just `eq`
-                # TODO - supporting all comparison operators could also work but
-                # it fails lots of tests because graph str changes.
-                return args[0].call_method(tx, "__eq__", list(args[1:]), kwargs)
+            if fn in (operator.eq, operator.ne) and len(args) == 2 and (
+                args[0].is_tensor() or isinstance(args[0], DataPtrVariable)
+            ):
+                # Dynamo expects `__eq__` / `__ne__` strings while operator.{eq,ne}
+                # provides call_function dispatch first.
+                method_name = "__eq__" if fn is operator.eq else "__ne__"
+                return args[0].call_method(tx, method_name, list(args[1:]), kwargs)
             proxy = tx.output.create_proxy(
                 "call_function",
                 fn,

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -1428,8 +1428,10 @@ class BuiltinVariable(BaseBuiltinVariable):
 
                 return wrap_fx_proxy_cls(variables.NumpyNdarrayVariable, tx, proxy)
 
-            if fn in (operator.eq, operator.ne) and len(args) == 2 and (
-                args[0].is_tensor() or isinstance(args[0], DataPtrVariable)
+            if (
+                fn in (operator.eq, operator.ne)
+                and len(args) == 2
+                and args[0].is_tensor()
             ):
                 # Dynamo expects `__eq__` / `__ne__` strings while operator.{eq,ne}
                 # provides call_function dispatch first.

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -2683,6 +2683,11 @@ class UntypedStorageVariable(VariableTracker):
 
 
 class DataPtrVariable(VariableTracker):
+    _DATA_PTR_PRESERVING_TARGETS = {
+        ("call_method", "detach"),
+        ("call_function", torch.ops.aten.detach.default),
+    }
+
     def __init__(
         self,
         from_tensor: TensorVariable,
@@ -2692,9 +2697,48 @@ class DataPtrVariable(VariableTracker):
         super().__init__(**kwargs)
         self.from_tensor = from_tensor
         self.method_name = method_name
+        self.tensor_version = from_tensor._get_fake_version()
 
     def python_type(self) -> type:
         return int
+
+    @classmethod
+    def _strip_data_ptr_preserving_aliases(
+        cls, node: torch.fx.Node
+    ) -> torch.fx.Node:
+        while (
+            isinstance(node, torch.fx.Node)
+            and (node.op, node.target) in cls._DATA_PTR_PRESERVING_TARGETS
+            and len(node.args) == 1
+            and isinstance(node.args[0], torch.fx.Node)
+        ):
+            node = node.args[0]
+        return node
+
+    def _is_same_data_ptr(self, other: "VariableTracker") -> bool:
+        if not isinstance(other, DataPtrVariable):
+            return False
+
+        if self.tensor_version != other.tensor_version:
+            return False
+
+        return (
+            self._strip_data_ptr_preserving_aliases(self.from_tensor.as_proxy().node)
+            is self._strip_data_ptr_preserving_aliases(other.from_tensor.as_proxy().node)
+        )
+
+    def call_method(
+        self,
+        tx: "InstructionTranslator",
+        name: str,
+        args: list[VariableTracker],
+        kwargs: dict[str, VariableTracker],
+    ) -> VariableTracker:
+        if len(args) == 1 and not kwargs and name in ("__eq__", "__ne__"):
+            same_data_ptr = self._is_same_data_ptr(args[0])
+            if same_data_ptr:
+                return ConstantVariable.create(name == "__eq__")
+        return super().call_method(tx, name, args, kwargs)
 
     def reconstruct(self, codegen: "PyCodegen") -> None:
         codegen(self.from_tensor)

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -2739,8 +2739,13 @@ class DataPtrVariable(VariableTracker):
             same_data_ptr = self._is_same_data_ptr(args[0])
             if same_data_ptr:
                 return ConstantVariable.create(name == "__eq__")
-            # Fall through so the base implementation graph breaks when we
-            # cannot prove the data pointers are equivalent.
+            unimplemented(
+                gb_type="Data pointer comparison",
+                context=f"call_method {self} {name} {args} {kwargs}",
+                explanation="Dynamo can only trace data pointer comparisons "
+                "when it can prove both operands have the same data pointer.",
+                hints=[],
+            )
         return super().call_method(tx, name, args, kwargs)
 
     def reconstruct(self, codegen: "PyCodegen") -> None:

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -2703,9 +2703,7 @@ class DataPtrVariable(VariableTracker):
         return int
 
     @classmethod
-    def _strip_data_ptr_preserving_aliases(
-        cls, node: torch.fx.Node
-    ) -> torch.fx.Node:
+    def _strip_data_ptr_preserving_aliases(cls, node: torch.fx.Node) -> torch.fx.Node:
         while (
             isinstance(node, torch.fx.Node)
             and (node.op, node.target) in cls._DATA_PTR_PRESERVING_TARGETS
@@ -2719,13 +2717,16 @@ class DataPtrVariable(VariableTracker):
         if not isinstance(other, DataPtrVariable):
             return False
 
-        if self.tensor_version != other.tensor_version:
+        if self.tensor_version is None or self.tensor_version != other.tensor_version:
             return False
 
-        return (
-            self._strip_data_ptr_preserving_aliases(self.from_tensor.as_proxy().node)
-            is self._strip_data_ptr_preserving_aliases(other.from_tensor.as_proxy().node)
+        self_root = self._strip_data_ptr_preserving_aliases(
+            self.from_tensor.as_proxy().node
         )
+        other_root = self._strip_data_ptr_preserving_aliases(
+            other.from_tensor.as_proxy().node
+        )
+        return self_root is other_root
 
     def call_method(
         self,
@@ -2738,6 +2739,8 @@ class DataPtrVariable(VariableTracker):
             same_data_ptr = self._is_same_data_ptr(args[0])
             if same_data_ptr:
                 return ConstantVariable.create(name == "__eq__")
+            # Fall through so the base implementation graph breaks when we
+            # cannot prove the data pointers are equivalent.
         return super().call_method(tx, name, args, kwargs)
 
     def reconstruct(self, codegen: "PyCodegen") -> None:


### PR DESCRIPTION
## Summary
Fix #165408

### Root cause
- Dynamo represents `.data_ptr()` as `DataPtrVariable`, but equality currently falls back to the generic comparison polyfill.
- That polyfill assumes ordinary Python objects and trips on `DataPtrVariable` before Dynamo can reason about the comparison.
- Even after reaching `DataPtrVariable`, Dynamo had no special-case for the safe aliasing pattern produced by `detach()`.

### Proposed fix
- Route `operator.eq` and `operator.ne` on `DataPtrVariable` through `__eq__` / `__ne__` directly instead of the generic polyfill path.
- Teach `DataPtrVariable` to constant-fold equality only when both values provably come from the same underlying FX node after stripping `detach()` aliases and their fake-tensor versions still match.
- Add a Dynamo regression test that reproduces the reported `data_ptr()` + `detach()` + `fullgraph=True` failure.

### Why this is the right long term fix
- It keeps unsupported pointer arithmetic and unrelated pointer comparisons unchanged, while enabling the narrow case Dynamo can prove is safe.
- The fake-tensor version check prevents folding across intervening mutations.
- Keeping the logic in `DataPtrVariable` makes future pointer-safe alias cases straightforward to extend without weakening the generic comparison machinery.

## Testing
- `python test/dynamo/test_misc.py -k data_ptr_detach_equality_fullgraph`
- `python test/dynamo/test_misc.py -k data_ptr_graph_break`
- `python -m py_compile torch/_dynamo/variables/tensor.py torch/_dynamo/variables/builtin.py test/dynamo/test_misc.py`

Drafted via Codex, published after manual review by @bobrenjc93

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98