### PR TITLE
Error on fullgraph dispatch-mode frame skips

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -458,7 +458,9 @@ graph():
 
         x = torch.ones(5)
         with YoloMode(), YoloMode2():
-            with self.assertRaisesRegex(torch._dynamo.exc.Unsupported, "fullgraph=True"):
+            with self.assertRaisesRegex(
+                torch._dynamo.exc.Unsupported, "fullgraph=True"
+            ):
                 torch.compile(
                     lambda x, y: torch.add(x, y), fullgraph=True, backend=backend
                 )(x, x)
@@ -533,7 +535,9 @@ graph():
 
         x = torch.ones(5)
         with YoloMode(), YoloMode2():
-            with self.assertRaisesRegex(torch._dynamo.exc.Unsupported, "fullgraph=True"):
+            with self.assertRaisesRegex(
+                torch._dynamo.exc.Unsupported, "fullgraph=True"
+            ):
                 torch.compile(
                     lambda x, y: torch.add(x, y), fullgraph=True, backend=backend
                 )(x, x)
@@ -549,7 +553,9 @@ graph():
         backend = torch._dynamo.testing.EagerAndRecordGraphs()
 
         with YoloMode2(), YoloMode():
-            with self.assertRaisesRegex(torch._dynamo.exc.Unsupported, "fullgraph=True"):
+            with self.assertRaisesRegex(
+                torch._dynamo.exc.Unsupported, "fullgraph=True"
+            ):
                 torch.compile(
                     lambda x, y: torch.add(x, y), fullgraph=True, backend=backend
                 )(x, x)

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -458,11 +458,12 @@ graph():
 
         x = torch.ones(5)
         with YoloMode(), YoloMode2():
-            torch.compile(
-                lambda x, y: torch.add(x, y), fullgraph=True, backend=backend
-            )(x, x)
+            with self.assertRaisesRegex(torch._dynamo.exc.Unsupported, "fullgraph=True"):
+                torch.compile(
+                    lambda x, y: torch.add(x, y), fullgraph=True, backend=backend
+                )(x, x)
 
-        self.assertEqual(len(backend2.graphs), 1)
+        self.assertEqual(len(backend2.graphs), 0)
         self.assertEqual(len(backend3.graphs), 0)
         self.assertEqual(len(backend.graphs), 0)
 
@@ -532,11 +533,12 @@ graph():
 
         x = torch.ones(5)
         with YoloMode(), YoloMode2():
-            torch.compile(
-                lambda x, y: torch.add(x, y), fullgraph=True, backend=backend
-            )(x, x)
+            with self.assertRaisesRegex(torch._dynamo.exc.Unsupported, "fullgraph=True"):
+                torch.compile(
+                    lambda x, y: torch.add(x, y), fullgraph=True, backend=backend
+                )(x, x)
 
-        self.assertEqual(len(backend2.graphs), 1)
+        self.assertEqual(len(backend2.graphs), 0)
         self.assertEqual(len(backend3.graphs), 0)
         self.assertEqual(len(backend.graphs), 0)
 
@@ -547,12 +549,13 @@ graph():
         backend = torch._dynamo.testing.EagerAndRecordGraphs()
 
         with YoloMode2(), YoloMode():
-            torch.compile(
-                lambda x, y: torch.add(x, y), fullgraph=True, backend=backend
-            )(x, x)
+            with self.assertRaisesRegex(torch._dynamo.exc.Unsupported, "fullgraph=True"):
+                torch.compile(
+                    lambda x, y: torch.add(x, y), fullgraph=True, backend=backend
+                )(x, x)
 
-        self.assertEqual(len(backend2.graphs), 1)
-        self.assertEqual(len(backend3.graphs), 1)
+        self.assertEqual(len(backend2.graphs), 0)
+        self.assertEqual(len(backend3.graphs), 0)
         self.assertEqual(len(backend.graphs), 0)
 
     @torch._dynamo.config.patch(inline_torch_dispatch_torch_compile=False)

--- a/test/dynamo/test_modes.py
+++ b/test/dynamo/test_modes.py
@@ -163,7 +163,9 @@ class TorchDispatchModeTests(torch._dynamo.test_case.TestCase):
 
         with ChecksumFoo():
             foo(x)
-            with self.assertRaisesRegex(torch._dynamo.exc.Unsupported, "fullgraph=True"):
+            with self.assertRaisesRegex(
+                torch._dynamo.exc.Unsupported, "fullgraph=True"
+            ):
                 g(x)
             foo(x)
 

--- a/test/dynamo/test_modes.py
+++ b/test/dynamo/test_modes.py
@@ -139,6 +139,36 @@ class TorchDispatchModeTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(eager_res, compiled_res)
         self.assertEqual(cnt.frame_count, 0)
 
+    def test_skip_torch_dispatch_modes_fullgraph_errors(self):
+        @torch.library.custom_op("mylib::modes_fullgraph_skip", mutates_args=())
+        def foo(x: torch.Tensor) -> torch.Tensor:
+            return x.clone()
+
+        checksums = []
+
+        class ChecksumFoo(TorchDispatchMode):
+            def __torch_dispatch__(self, func, types, args, kwargs=None):
+                kwargs = kwargs or {}
+
+                if func is torch.ops.mylib.modes_fullgraph_skip.default:
+                    checksums.append(args[0].abs().sum())
+
+                return func(*args, **kwargs)
+
+        @torch.compile(backend="eager", fullgraph=True)
+        def g(x):
+            return x.sin().cos()
+
+        x = torch.randn(3)
+
+        with ChecksumFoo():
+            foo(x)
+            with self.assertRaisesRegex(torch._dynamo.exc.Unsupported, "fullgraph=True"):
+                g(x)
+            foo(x)
+
+        self.assertEqual(len(checksums), 2)
+
 
 class TorchFunctionModeTests(torch._dynamo.test_case.TestCase):
     @classmethod

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -77,6 +77,7 @@ from torch.monitor import _WaitCounter
 from torch.nn.parallel.distributed import DistributedDataParallel
 from torch.utils._python_dispatch import (
     _disable_current_modes,
+    _get_current_dispatch_mode_stack,
     any_torch_dispatch_mode_on_stack,
     is_in_any_mode_without_ignore_compile_internals,
     is_traceable_wrapper_subclass,
@@ -194,6 +195,15 @@ if typing.TYPE_CHECKING:
 
 
 log = logging.getLogger(__name__)
+
+_TORCH_PACKAGE_PREFIX = os.path.dirname(os.path.realpath(torch.__file__)) + os.sep
+
+
+def _is_torch_internal_dispatch_mode(mode: object) -> bool:
+    module_name = type(mode).__module__
+    return module_name == "torch" or module_name.startswith("torch.")
+
+
 bytecode_log = torch._logging.getArtifactLogger(__name__, "bytecode")
 graph_break_log = torch._logging.getArtifactLogger(__name__, "graph_breaks")
 
@@ -2351,11 +2361,20 @@ class CatchErrorsWrapper:
             should_skip_for_dispatch_mode = (
                 is_in_any_mode_without_ignore_compile_internals()
             )
+        active_dispatch_modes = [
+            mode
+            for mode in _get_current_dispatch_mode_stack()
+            if not mode.is_infra_mode() and not mode.ignore_compile_internals()
+        ]
+        should_error_for_dispatch_mode = should_skip_for_dispatch_mode and (
+            not active_dispatch_modes
+            or any(
+                not _is_torch_internal_dispatch_mode(mode)
+                for mode in active_dispatch_modes
+            )
+        )
         export = getattr(self._torchdynamo_orig_backend, "_export", False)
         one_graph = getattr(self._torchdynamo_orig_backend, "_one_graph", False)
-        is_torch_internal_frame = os.path.realpath(frame.f_code.co_filename).startswith(
-            os.path.dirname(os.path.realpath(torch.__file__)) + os.sep
-        )
 
         if (
             # TODO: the first condition is not covered by any test
@@ -2365,13 +2384,17 @@ class CatchErrorsWrapper:
             or (should_skip_for_dispatch_mode and not export)
         ):
             if (
-                should_skip_for_dispatch_mode
+                should_error_for_dispatch_mode
                 and one_graph
                 and not export
-                and not is_torch_internal_frame
             ):
-                raise exc.Unsupported(
-                    (
+                # Allow internal torch helper frames to keep the legacy skip
+                # behavior while surfacing an Unsupported for user frames so
+                # fullgraph=True does not silently fall back to eager.
+                if not os.path.realpath(frame.f_code.co_filename).startswith(
+                    _TORCH_PACKAGE_PREFIX
+                ):
+                    raise exc.Unsupported(
                         exc.format_skip_frame_message(
                             frame.f_code,
                             "non-infra torch dispatch mode present, this is not supported today in torch.compile",
@@ -2380,7 +2403,6 @@ class CatchErrorsWrapper:
                         "Either remove the active TorchDispatchMode, set ignore_compile_internals() = True on it, "
                         "or use fullgraph=False."
                     )
-                )
 
             if log.isEnabledFor(logging.DEBUG):
                 if has_started_execution:

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -204,6 +204,12 @@ def _is_torch_internal_dispatch_mode(mode: object) -> bool:
     return module_name == "torch" or module_name.startswith("torch.")
 
 
+def _is_hop_compile() -> bool:
+    from torch._higher_order_ops.utils import _in_hop_compile
+
+    return _in_hop_compile()
+
+
 bytecode_log = torch._logging.getArtifactLogger(__name__, "bytecode")
 graph_break_log = torch._logging.getArtifactLogger(__name__, "graph_breaks")
 
@@ -2361,18 +2367,17 @@ class CatchErrorsWrapper:
             should_skip_for_dispatch_mode = (
                 is_in_any_mode_without_ignore_compile_internals()
             )
-        active_dispatch_modes = [
-            mode
-            for mode in _get_current_dispatch_mode_stack()
-            if not mode.is_infra_mode() and not mode.ignore_compile_internals()
-        ]
-        should_error_for_dispatch_mode = should_skip_for_dispatch_mode and (
-            not active_dispatch_modes
-            or any(
+        should_error_for_dispatch_mode = False
+        if should_skip_for_dispatch_mode:
+            active_dispatch_modes = [
+                mode
+                for mode in _get_current_dispatch_mode_stack()
+                if not mode.is_infra_mode() and not mode.ignore_compile_internals()
+            ]
+            should_error_for_dispatch_mode = not active_dispatch_modes or any(
                 not _is_torch_internal_dispatch_mode(mode)
                 for mode in active_dispatch_modes
             )
-        )
         export = getattr(self._torchdynamo_orig_backend, "_export", False)
         one_graph = getattr(self._torchdynamo_orig_backend, "_one_graph", False)
 
@@ -2387,21 +2392,32 @@ class CatchErrorsWrapper:
                 should_error_for_dispatch_mode
                 and one_graph
                 and not export
+                and not has_started_execution
+                and not is_skipfile
+                and not config.disable
+                and not _is_hop_compile()
             ):
+                # Only surface an Unsupported when the dispatch mode itself is
+                # the reason we would have skipped the frame.
                 # Allow internal torch helper frames to keep the legacy skip
                 # behavior while surfacing an Unsupported for user frames so
                 # fullgraph=True does not silently fall back to eager.
                 if not os.path.realpath(frame.f_code.co_filename).startswith(
                     _TORCH_PACKAGE_PREFIX
                 ):
-                    raise exc.Unsupported(
-                        exc.format_skip_frame_message(
+                    unimplemented(
+                        gb_type="Fullgraph skip due to non-infra torch dispatch mode",
+                        context=exc.format_skip_frame_message(
                             frame.f_code,
                             "non-infra torch dispatch mode present, this is not supported today in torch.compile",
-                        )
-                        + "\nfullgraph=True requires the frame to compile instead of silently falling back to eager. "
-                        "Either remove the active TorchDispatchMode, set ignore_compile_internals() = True on it, "
-                        "or use fullgraph=False."
+                        ),
+                        explanation="fullgraph=True requires the frame to compile instead of silently falling back to eager.",
+                        hints=[
+                            "Remove the active TorchDispatchMode.",
+                            "Set ignore_compile_internals() = True on the mode.",
+                            "Use fullgraph=False.",
+                        ],
+                        skip_frame=True,
                     )
 
             if log.isEnabledFor(logging.DEBUG):

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -2351,17 +2351,37 @@ class CatchErrorsWrapper:
             should_skip_for_dispatch_mode = (
                 is_in_any_mode_without_ignore_compile_internals()
             )
+        export = getattr(self._torchdynamo_orig_backend, "_export", False)
+        one_graph = getattr(self._torchdynamo_orig_backend, "_one_graph", False)
+        is_torch_internal_frame = os.path.realpath(frame.f_code.co_filename).startswith(
+            os.path.dirname(os.path.realpath(torch.__file__)) + os.sep
+        )
 
         if (
             # TODO: the first condition is not covered by any test
             has_started_execution
             or is_skipfile
             or config.disable
-            or (
-                should_skip_for_dispatch_mode
-                and not getattr(self._torchdynamo_orig_backend, "_export", False)
-            )
+            or (should_skip_for_dispatch_mode and not export)
         ):
+            if (
+                should_skip_for_dispatch_mode
+                and one_graph
+                and not export
+                and not is_torch_internal_frame
+            ):
+                raise exc.Unsupported(
+                    (
+                        exc.format_skip_frame_message(
+                            frame.f_code,
+                            "non-infra torch dispatch mode present, this is not supported today in torch.compile",
+                        )
+                        + "\nfullgraph=True requires the frame to compile instead of silently falling back to eager. "
+                        "Either remove the active TorchDispatchMode, set ignore_compile_internals() = True on it, "
+                        "or use fullgraph=False."
+                    )
+                )
+
             if log.isEnabledFor(logging.DEBUG):
                 if has_started_execution:
                     skip_reason = "traced frame already"

--- a/torch/_dynamo/graph_break_registry.json
+++ b/torch/_dynamo/graph_break_registry.json
@@ -980,6 +980,18 @@
       ]
     }
   ],
+  "GB8082": [
+    {
+      "Gb_type": "Fullgraph skip due to non-infra torch dispatch mode",
+      "Context": "exc.format_skip_frame_message(                             frame.f_code,                             \"non-infra torch dispatch mode present, this is not supported today in torch.compile\",                         )",
+      "Explanation": "fullgraph=True requires the frame to compile instead of silently falling back to eager.",
+      "Hints": [
+        "Remove the active TorchDispatchMode.",
+        "Set ignore_compile_internals() = True on the mode.",
+        "Use fullgraph=False."
+      ]
+    }
+  ],
   "GB7596": [
     {
       "Gb_type": "Indexing torch.Size with non-scalar tensor",


### PR DESCRIPTION
Fix #161790

## Summary

1. What is the root cause problem
Dynamo decides whether to skip for active `TorchDispatchMode`s in `CatchErrorsWrapper`, before fullgraph handling gets a chance to complain. That let `torch.compile(fullgraph=True)` silently fall back to eager for skipped user frames.

2. What is the proposed fix
Raise `torch._dynamo.exc.Unsupported` when a non-infra dispatch mode would skip a user-authored frame under `fullgraph=True`, and add regression coverage for the issue repro plus the affected dispatch-mode/fullgraph test cases.

3. Why is this the right long term fix
It restores the strict fullgraph contract for user code without changing the existing internal helper-frame behavior that `torch.compile` still relies on for top-level builtins and compile internals.

## Testing
- `python3 /tmp/repos/pytorch/pytorch/test/dynamo/test_modes.py -v TorchDispatchModeTests.test_skip_torch_dispatch_modes TorchDispatchModeTests.test_skip_torch_dispatch_modes_fullgraph_errors TorchDispatchModeTests.test_torch_dispatch_ignore_compile_internals`
- `python3 /tmp/repos/pytorch/pytorch/test/dynamo/test_misc.py -v MiscTests.test_compile_non_infra_inside_compile MiscTests.test_compile_non_infra_empty MiscTests.test_compile_non_infra_empty_with_disalloed_dispatch_mode MiscTests.test_compile_non_infra_multiple MiscTests.test_compile_non_infra_multiple_compile_internal MiscTests.test_compile_non_infra_multiple_compile_internal_mixed MiscTests.test_compile_non_infra_disabled_config`

Drafted via Codex, published after manual review by @bobrenjc93

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98