### PR TITLE
[dynamo] add bytecode source attribution to variable trackers

### DIFF
--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -45,33 +45,26 @@ class GenericCtxMgr:
 
 
 def _generic_ctx_mgr_stack_source_attribution() -> str:
-    if sys.version_info >= (3, 14):
-        caret1 = "                     ^^^^^^^^^^^^^^^\n"
-        caret2 = "                         ^^^^^^^^^^^^^^^\n"
-    elif sys.version_info >= (3, 11):
-        caret1 = "                   ^^^^^^^^^^^^^^^\n"
-        caret2 = "                       ^^^^^^^^^^^^^^^\n"
+    if sys.version_info >= (3, 11):
+        caret = "^^^^^^^^^^^^^^^\n"
     else:
-        caret1 = ""
-        caret2 = ""
+        caret = ""
     return (
         "Stack variable source attribution:\n"
         "  WithExitFunctionVariable() originated from:\n"
         '  File "test_error_messages.py", line N\n'
         "                with GenericCtxMgr():\n"
-        f"{caret1}"
+        f"{caret}"
         "  WithExitFunctionVariable() originated from:\n"
         '  File "test_error_messages.py", line N\n'
         "                    with GenericCtxMgr():\n"
-        f"{caret2}"
+        f"{caret}"
     )
 
 
 def _assert_failure_stack_source_attribution() -> str:
-    if sys.version_info >= (3, 14):
-        caret = "                     ^^^^^^^^^^^^^^^\n"
-    elif sys.version_info >= (3, 11):
-        caret = "                   ^^^^^^^^^^^^^^^\n"
+    if sys.version_info >= (3, 11):
+        caret = "^^^^^^^^^^^^^^^\n"
     else:
         caret = ""
     return (
@@ -90,7 +83,7 @@ def _reconstruction_failure_gb_stack_source_attribution() -> str:
             "  LazyVariableTracker(realized: SkipFunctionVariable()) originated from:\n"
             '  File "test_error_messages.py", line N\n'
             "                torch._dynamo.graph_break()\n"
-            "                ^^^^^^^^^^^^^^^^^^^^^^^^^\n"
+            "^^^^^^^^^^^^^^^^^^^^^^^^^\n"
             "\n"
         )
 
@@ -113,7 +106,7 @@ def _graph_break_in_loop_stack_source_attribution() -> str:
             "  RangeIteratorVariable() originated from:\n"
             '  File "test_error_messages.py", line N\n'
             "                for i in range(2):\n"
-            "                         ^^^^^^^^\n"
+            "^^^^^^^^\n"
             "\n"
         )
 
@@ -136,11 +129,11 @@ def _skip_frame_in_loop_message_stack_source_attribution() -> str:
             "  RangeIteratorVariable() originated from:\n"
             '  File "test_error_messages.py", line N\n'
             "                for i in range(2):\n"
-            "                         ^^^^^^^^\n"
+            "^^^^^^^^\n"
             "  WithExitFunctionVariable() originated from:\n"
             '  File "test_error_messages.py", line N\n'
             "                    with GenericCtxMgr():\n"
-            "                         ^^^^^^^^^^^^^^^\n"
+            "^^^^^^^^^^^^^^^\n"
             "\n"
         )
 

--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -2373,8 +2373,7 @@ Graph break under GenericContextWrappingVariable
 
         torch.compile(f3, backend="eager")(torch.randn(3))
         self.assertEqual(len(records), 1)
-        self.assertExpectedInline(
-            munge_exc(records[0].getMessage(), suppress_suffix=True, skip=0),
+        expected = (
             """\
 Graph break in user code at test_error_messages.py:N
 Graph Break Reason: Encountered graph break that we cannot resume from. Compiling up to the previous resumable state, then skipping the rest of the function. Graph break encountered:
@@ -2398,6 +2397,10 @@ Graph break under GenericContextWrappingVariable
 
  For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0066.html
 
+"""
+            + _assert_failure_stack_source_attribution()
+            + """\
+
 User code traceback:
   File "test_error_messages.py", line N, in test_skipped_frame_with_verbose_traceback_nested
     torch.compile(f3, backend="eager")(torch.randn(3))
@@ -2407,7 +2410,11 @@ User code traceback:
     return f1(x + 2)
   File "test_error_messages.py", line N, in f1
     torch._dynamo.graph_break()
-""",
+"""
+        )
+        self.assertExpectedInline(
+            munge_exc(records[0].getMessage(), suppress_suffix=True, skip=0),
+            expected,
         )
 
     @make_logging_test(graph_breaks=True)

--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -67,15 +67,31 @@ def _generic_ctx_mgr_stack_source_attribution() -> str:
 
 
 def _assert_failure_stack_source_attribution() -> str:
-    caret = (
-        "                   ^^^^^^^^^^^^^^^\n" if sys.version_info >= (3, 11) else ""
-    )
+    if sys.version_info >= (3, 14):
+        caret = "                      ^^^^^^^^^^^^^^^\n"
+    elif sys.version_info >= (3, 11):
+        caret = "                   ^^^^^^^^^^^^^^^\n"
+    else:
+        caret = ""
     return (
         "Stack variable source attribution:\n"
         "  WithExitFunctionVariable() originated from:\n"
         '  File "test_error_messages.py", line N\n'
         "                with GenericCtxMgr():\n"
         f"{caret}"
+    )
+
+
+def _graph_break_in_loop_stack_source_attribution() -> str:
+    if sys.version_info >= (3, 11):
+        return ""
+
+    return (
+        "Stack variable source attribution:\n"
+        "  RangeIteratorVariable() originated from:\n"
+        '  File "test_error_messages.py", line N\n'
+        "                for i in range(2):\n"
+        "\n"
     )
 
 
@@ -1101,8 +1117,7 @@ from user code:
 
         fn(torch.ones(3))
         self.assertEqual(len(records), 1)
-        self.assertExpectedInline(
-            munge_exc(records[0].getMessage(), suppress_suffix=True, skip=0),
+        expected = (
             """\
 Graph break in user code at test_error_messages.py:N
 Graph Break Reason: Failed to handle graph break gracefully. Skipping the function and falling back to eager. Graph break encountered:
@@ -1125,12 +1140,19 @@ graph break in loop
 
  For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb7000.html
 
+"""
+            + _graph_break_in_loop_stack_source_attribution()
+            + """\
 User code traceback:
   File "test_error_messages.py", line N, in test_graph_break_in_loop
     fn(torch.ones(3))
   File "test_error_messages.py", line N, in fn
     torch._dynamo.graph_break()
-""",
+"""
+        )
+        self.assertExpectedInline(
+            munge_exc(records[0].getMessage(), suppress_suffix=True, skip=0),
+            expected,
         )
 
         @torch.compile(backend="eager")
@@ -1144,8 +1166,7 @@ User code traceback:
 
         gn(torch.ones(3))
         self.assertEqual(len(records), 2)
-        self.assertExpectedInline(
-            munge_exc(records[1].getMessage(), suppress_suffix=True, skip=0),
+        expected = (
             """\
 Graph break in user code at test_error_messages.py:N
 Graph Break Reason: Failed to handle graph break gracefully. Skipping the function and falling back to eager. Graph break encountered:
@@ -1175,12 +1196,19 @@ graph break in loop
 
  For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb7000.html
 
+"""
+            + _graph_break_in_loop_stack_source_attribution()
+            + """\
 User code traceback:
   File "test_error_messages.py", line N, in test_graph_break_in_loop
     gn(torch.ones(3))
   File "test_error_messages.py", line N, in gn
     if x.sum() > 0:
-""",
+"""
+        )
+        self.assertExpectedInline(
+            munge_exc(records[1].getMessage(), suppress_suffix=True, skip=0),
+            expected,
         )
 
     @make_logging_test(graph_breaks=True)

--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -1,5 +1,6 @@
 # Owner(s): ["module: dynamo"]
 
+import dis
 import logging
 import re
 import sys
@@ -42,6 +43,20 @@ class GenericCtxMgr:
 
     def __exit__(self, exc_type, exc_value, traceback):
         pass
+
+
+def _get_iter_has_positions() -> bool:
+    """Whether GET_ITER bytecodes have position info on this Python build.
+
+    This varies across Python 3.12 point releases / platforms — some builds
+    include positions for GET_ITER and some don't, which affects whether
+    RangeIteratorVariable gets source attribution.
+    """
+    code = compile("for x in range(1): pass", "<test>", "exec")
+    for inst in dis.get_instructions(code):
+        if inst.opname == "GET_ITER":
+            return inst.positions is not None and inst.positions.lineno is not None
+    return False
 
 
 def _generic_ctx_mgr_stack_source_attribution() -> str:
@@ -100,7 +115,7 @@ def _reconstruction_failure_gb_stack_source_attribution() -> str:
 
 
 def _graph_break_in_loop_stack_source_attribution() -> str:
-    if sys.version_info >= (3, 14):
+    if sys.version_info >= (3, 11) and _get_iter_has_positions():
         return (
             "Stack variable source attribution:\n"
             "  RangeIteratorVariable() originated from:\n"
@@ -123,7 +138,7 @@ def _graph_break_in_loop_stack_source_attribution() -> str:
 
 
 def _skip_frame_in_loop_message_stack_source_attribution() -> str:
-    if sys.version_info >= (3, 14):
+    if sys.version_info >= (3, 11) and _get_iter_has_positions():
         return (
             "Stack variable source attribution:\n"
             "  RangeIteratorVariable() originated from:\n"

--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -2,6 +2,7 @@
 
 import logging
 import re
+import sys
 import traceback
 import unittest
 import unittest.mock
@@ -41,6 +42,41 @@ class GenericCtxMgr:
 
     def __exit__(self, exc_type, exc_value, traceback):
         pass
+
+
+def _generic_ctx_mgr_stack_source_attribution() -> str:
+    caret1 = (
+        "                   ^^^^^^^^^^^^^^^\n" if sys.version_info >= (3, 11) else ""
+    )
+    caret2 = (
+        "                       ^^^^^^^^^^^^^^^\n"
+        if sys.version_info >= (3, 11)
+        else ""
+    )
+    return (
+        "Stack variable source attribution:\n"
+        "  WithExitFunctionVariable() originated from:\n"
+        '  File "test_error_messages.py", line N\n'
+        "                with GenericCtxMgr():\n"
+        f"{caret1}"
+        "  WithExitFunctionVariable() originated from:\n"
+        '  File "test_error_messages.py", line N\n'
+        "                    with GenericCtxMgr():\n"
+        f"{caret2}"
+    )
+
+
+def _assert_failure_stack_source_attribution() -> str:
+    caret = (
+        "                   ^^^^^^^^^^^^^^^\n" if sys.version_info >= (3, 11) else ""
+    )
+    return (
+        "Stack variable source attribution:\n"
+        "  WithExitFunctionVariable() originated from:\n"
+        '  File "test_error_messages.py", line N\n'
+        "                with GenericCtxMgr():\n"
+        f"{caret}"
+    )
 
 
 class ErrorMessagesTest(LoggingTestCase):
@@ -548,8 +584,7 @@ from user code:
 
         torch.compile(fn, backend="eager")()
         self.assertEqual(len(records), 1)
-        self.assertExpectedInline(
-            munge_exc(records[0].getMessage(), suppress_suffix=True, skip=0),
+        expected = (
             """\
 Graph break in user code at test_error_messages.py:N
 Graph Break Reason: Failed to handle graph break gracefully. Skipping the function and falling back to eager. Graph break encountered:
@@ -573,12 +608,19 @@ Graph break under GenericContextWrappingVariable
 
  For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0066.html
 
+"""
+            + _generic_ctx_mgr_stack_source_attribution()
+            + """
 User code traceback:
   File "test_error_messages.py", line N, in test_generic_ctx_mgr_graph_break_fullgraph_false
     torch.compile(fn, backend="eager")()
   File "test_error_messages.py", line N, in fn
     torch._dynamo.graph_break()
-""",
+"""
+        )
+        self.assertExpectedInline(
+            munge_exc(records[0].getMessage(), suppress_suffix=True, skip=0),
+            expected,
         )
 
     def test_load_build_class(self):
@@ -916,8 +958,7 @@ User code traceback:
 
         # only 1 graph break message
         self.assertEqual(len(records), 1)
-        self.assertExpectedInline(
-            munge_exc(records[0].getMessage(), suppress_suffix=True, skip=0),
+        expected = (
             """\
 Graph break in user code at test_error_messages.py:N
 Graph Break Reason: Failed to handle graph break gracefully. Skipping the function and falling back to eager. Graph break encountered:
@@ -933,17 +974,19 @@ Data-dependent assertion failed (cannot compile partial graph)
 
  For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0034.html
 
-Stack variable source attribution:
-  WithExitFunctionVariable() originated from:
-  File "test_error_messages.py", line N
-                with GenericCtxMgr():
-
+"""
+            + _assert_failure_stack_source_attribution()
+            + """
 User code traceback:
   File "test_error_messages.py", line N, in test_assert_failure_in_generic_ctx_mgr
     torch.compile(fn, backend="eager")(torch.randn(3))
   File "test_error_messages.py", line N, in fn
     assert x is None  # noqa: S101
-""",
+"""
+        )
+        self.assertExpectedInline(
+            munge_exc(records[0].getMessage(), suppress_suffix=True, skip=0),
+            expected,
         )
 
     def test_no_internal_compiler_stacktrace(self):

--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -91,11 +91,40 @@ def _assert_failure_stack_source_attribution() -> str:
     )
 
 
+def _load_global_has_positions() -> bool:
+    """Whether LOAD_GLOBAL bytecodes have position info on this Python build.
+
+    This varies across Python 3.12 point releases / platforms — some builds
+    include positions for LOAD_GLOBAL and some don't, which affects whether
+    NullVariable (pushed as part of LOAD_GLOBAL's call convention) gets
+    source attribution.
+    """
+    code = compile("def f(): x()", "<test>", "exec")
+    for const in code.co_consts:
+        if hasattr(const, "co_code"):
+            for inst in dis.get_instructions(const):
+                if inst.opname == "LOAD_GLOBAL":
+                    return (
+                        inst.positions is not None and inst.positions.lineno is not None
+                    )
+    return False
+
+
 def _reconstruction_failure_gb_stack_source_attribution() -> str:
     if sys.version_info >= (3, 14):
         return (
             "Stack variable source attribution:\n"
             "  LazyVariableTracker(realized: SkipFunctionVariable()) originated from:\n"
+            '  File "test_error_messages.py", line N\n'
+            "                torch._dynamo.graph_break()\n"
+            "^^^^^^^^^^^^^^^^^^^^^^^^^\n"
+            "\n"
+        )
+
+    if sys.version_info >= (3, 11) and _load_global_has_positions():
+        return (
+            "Stack variable source attribution:\n"
+            "  NullVariable originated from:\n"
             '  File "test_error_messages.py", line N\n'
             "                torch._dynamo.graph_break()\n"
             "^^^^^^^^^^^^^^^^^^^^^^^^^\n"

--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -68,7 +68,7 @@ def _generic_ctx_mgr_stack_source_attribution() -> str:
 
 def _assert_failure_stack_source_attribution() -> str:
     if sys.version_info >= (3, 14):
-        caret = "                      ^^^^^^^^^^^^^^^\n"
+        caret = "                     ^^^^^^^^^^^^^^^\n"
     elif sys.version_info >= (3, 11):
         caret = "                   ^^^^^^^^^^^^^^^\n"
     else:
@@ -79,6 +79,19 @@ def _assert_failure_stack_source_attribution() -> str:
         '  File "test_error_messages.py", line N\n'
         "                with GenericCtxMgr():\n"
         f"{caret}"
+    )
+
+
+def _reconstruction_failure_gb_stack_source_attribution() -> str:
+    if sys.version_info >= (3, 11):
+        return ""
+
+    return (
+        "Stack variable source attribution:\n"
+        "  LazyVariableTracker(realized: SkipFunctionVariable()) originated from:\n"
+        '  File "test_error_messages.py", line N\n'
+        "                torch._dynamo.graph_break()\n"
+        "\n"
     )
 
 
@@ -769,10 +782,7 @@ User code traceback:
 """,
         )
 
-        self.assertExpectedInline(
-            post_munge(
-                munge_exc(records[1].getMessage(), suppress_suffix=True, skip=0)
-            ),
+        expected = (
             """\
 Graph break in user code at test_error_messages.py:N
 Graph Break Reason: Failed to handle graph break gracefully. Skipping the function and falling back to eager. Graph break encountered:
@@ -787,12 +797,22 @@ Reconstruction failure
 
  For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0092.html
 
+"""
+            + _reconstruction_failure_gb_stack_source_attribution()
+            + """\
 User code traceback:
   File "test_error_messages.py", line N, in test_reconstruction_failure_gb
     torch.compile(fn, backend="eager")()
   File "test_error_messages.py", line N, in fn
     torch._dynamo.graph_break()
-""",
+"""
+        )
+
+        self.assertExpectedInline(
+            post_munge(
+                munge_exc(records[1].getMessage(), suppress_suffix=True, skip=0)
+            ),
+            expected,
         )
 
     def test_faketensor_nyi(self):

--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -933,6 +933,11 @@ Data-dependent assertion failed (cannot compile partial graph)
 
  For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0034.html
 
+Stack variable source attribution:
+  WithExitFunctionVariable() originated from:
+  File "test_error_messages.py", line N
+                with GenericCtxMgr():
+
 User code traceback:
   File "test_error_messages.py", line N, in test_assert_failure_in_generic_ctx_mgr
     torch.compile(fn, backend="eager")(torch.randn(3))

--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -84,6 +84,16 @@ def _assert_failure_stack_source_attribution() -> str:
 
 
 def _reconstruction_failure_gb_stack_source_attribution() -> str:
+    if sys.version_info >= (3, 14):
+        return (
+            "Stack variable source attribution:\n"
+            "  LazyVariableTracker(realized: SkipFunctionVariable()) originated from:\n"
+            '  File "test_error_messages.py", line N\n'
+            "                torch._dynamo.graph_break()\n"
+            "                ^^^^^^^^^^^^^^^^^^^^^^^^^\n"
+            "\n"
+        )
+
     if sys.version_info >= (3, 11):
         return ""
 
@@ -2268,8 +2278,7 @@ Dynamo recompile limit exceeded
 
         torch.compile(fn, backend="eager")()
         self.assertEqual(len(records), 2)
-        self.assertExpectedInline(
-            munge_exc(records[0].getMessage(), suppress_suffix=True, skip=0),
+        expected = (
             """\
 Graph break in user code at test_error_messages.py:N
 Graph Break Reason: Failed to handle graph break gracefully. Skipping the function and falling back to eager. Graph break encountered:
@@ -2304,6 +2313,10 @@ Graph break under GenericContextWrappingVariable
 
  For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0066.html
 
+"""
+            + _generic_ctx_mgr_stack_source_attribution()
+            + """\
+
 User code traceback:
   File "test_error_messages.py", line N, in test_nested_generic_ctx_mgr
     torch.compile(fn, backend="eager")()
@@ -2311,7 +2324,11 @@ User code traceback:
     inner()
   File "test_error_messages.py", line N, in inner
     torch._dynamo.graph_break()
-""",
+"""
+        )
+        self.assertExpectedInline(
+            munge_exc(records[0].getMessage(), suppress_suffix=True, skip=0),
+            expected,
         )
         self.assertExpectedInline(
             munge_exc(records[1].getMessage(), suppress_suffix=True, skip=0),

--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -45,14 +45,15 @@ class GenericCtxMgr:
 
 
 def _generic_ctx_mgr_stack_source_attribution() -> str:
-    caret1 = (
-        "                   ^^^^^^^^^^^^^^^\n" if sys.version_info >= (3, 11) else ""
-    )
-    caret2 = (
-        "                       ^^^^^^^^^^^^^^^\n"
-        if sys.version_info >= (3, 11)
-        else ""
-    )
+    if sys.version_info >= (3, 14):
+        caret1 = "                     ^^^^^^^^^^^^^^^\n"
+        caret2 = "                         ^^^^^^^^^^^^^^^\n"
+    elif sys.version_info >= (3, 11):
+        caret1 = "                   ^^^^^^^^^^^^^^^\n"
+        caret2 = "                       ^^^^^^^^^^^^^^^\n"
+    else:
+        caret1 = ""
+        caret2 = ""
     return (
         "Stack variable source attribution:\n"
         "  WithExitFunctionVariable() originated from:\n"
@@ -96,6 +97,16 @@ def _reconstruction_failure_gb_stack_source_attribution() -> str:
 
 
 def _graph_break_in_loop_stack_source_attribution() -> str:
+    if sys.version_info >= (3, 14):
+        return (
+            "Stack variable source attribution:\n"
+            "  RangeIteratorVariable() originated from:\n"
+            '  File "test_error_messages.py", line N\n'
+            "                for i in range(2):\n"
+            "                         ^^^^^^^^\n"
+            "\n"
+        )
+
     if sys.version_info >= (3, 11):
         return ""
 
@@ -104,6 +115,36 @@ def _graph_break_in_loop_stack_source_attribution() -> str:
         "  RangeIteratorVariable() originated from:\n"
         '  File "test_error_messages.py", line N\n'
         "                for i in range(2):\n"
+        "\n"
+    )
+
+
+def _skip_frame_in_loop_message_stack_source_attribution() -> str:
+    if sys.version_info >= (3, 14):
+        return (
+            "Stack variable source attribution:\n"
+            "  RangeIteratorVariable() originated from:\n"
+            '  File "test_error_messages.py", line N\n'
+            "                for i in range(2):\n"
+            "                         ^^^^^^^^\n"
+            "  WithExitFunctionVariable() originated from:\n"
+            '  File "test_error_messages.py", line N\n'
+            "                    with GenericCtxMgr():\n"
+            "                         ^^^^^^^^^^^^^^^\n"
+            "\n"
+        )
+
+    if sys.version_info >= (3, 11):
+        return ""
+
+    return (
+        "Stack variable source attribution:\n"
+        "  RangeIteratorVariable() originated from:\n"
+        '  File "test_error_messages.py", line N\n'
+        "                for i in range(2):\n"
+        "  WithExitFunctionVariable() originated from:\n"
+        '  File "test_error_messages.py", line N\n'
+        "                    with GenericCtxMgr():\n"
         "\n"
     )
 
@@ -1242,8 +1283,7 @@ User code traceback:
 
         torch.compile(fn, backend="eager")(torch.randn(3))
         self.assertEqual(len(records), 1)
-        self.assertExpectedInline(
-            munge_exc(records[0].getMessage(), suppress_suffix=True, skip=0),
+        expected = (
             """\
 Graph break in user code at test_error_messages.py:N
 Graph Break Reason: Failed to handle graph break gracefully. Skipping the function and falling back to eager. Graph break encountered:
@@ -1263,12 +1303,19 @@ Data-dependent branching
 
  For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0170.html
 
+"""
+            + _skip_frame_in_loop_message_stack_source_attribution()
+            + """\
 User code traceback:
   File "test_error_messages.py", line N, in test_skip_frame_in_loop_message
     torch.compile(fn, backend="eager")(torch.randn(3))
   File "test_error_messages.py", line N, in fn
     if x.sum() > 0:
-""",
+"""
+        )
+        self.assertExpectedInline(
+            munge_exc(records[0].getMessage(), suppress_suffix=True, skip=0),
+            expected,
         )
 
     @make_logging_test(dynamo=logging.DEBUG)
@@ -2365,8 +2412,7 @@ User code traceback:
 
         result = torch.compile(f3, backend="eager")(torch.randn(3))  # noqa: F841
         self.assertEqual(len(records), 1)
-        self.assertExpectedInline(
-            munge_exc(records[0].getMessage(), suppress_suffix=True, skip=0),
+        expected = (
             """\
 Graph break in user code at test_error_messages.py:N
 Graph Break Reason: Encountered graph break that we cannot resume from. Compiling up to the previous resumable state, then skipping the rest of the function. Graph break encountered:
@@ -2386,6 +2432,9 @@ Data-dependent branching
 
  For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0170.html
 
+"""
+            + _skip_frame_in_loop_message_stack_source_attribution()
+            + """\
 User code traceback:
   File "test_error_messages.py", line N, in test_skip_frame_in_loop_message_nested
     result = torch.compile(f3, backend="eager")(torch.randn(3))  # noqa: F841
@@ -2395,7 +2444,11 @@ User code traceback:
     return f1(x + 4)
   File "test_error_messages.py", line N, in f1
     if x.sum() > 0:
-""",
+"""
+        )
+        self.assertExpectedInline(
+            munge_exc(records[0].getMessage(), suppress_suffix=True, skip=0),
+            expected,
         )
 
     @make_logging_test(graph_breaks=True)

--- a/test/dynamo/test_exc.py
+++ b/test/dynamo/test_exc.py
@@ -484,9 +484,7 @@ Failed Source Expressions:
         source_location = _source_location_capture.get("source_location")
         self.assertIsNotNone(source_location)
         source_location = cast(SourceLocation, source_location)
-        self.assertEqual(
-            source_location.filename, __file__.replace(".pyc", ".py")
-        )
+        self.assertEqual(source_location.filename, __file__.replace(".pyc", ".py"))
         self.assertIsNotNone(source_location.lineno)
 
     @make_logging_test(graph_breaks=True)

--- a/test/dynamo/test_exc.py
+++ b/test/dynamo/test_exc.py
@@ -1,5 +1,6 @@
 # Owner(s): ["module: dynamo"]
 
+import sys
 import unittest
 from typing import cast
 
@@ -34,6 +35,28 @@ def _capture_y_source_loc(ctx) -> None:
     y_vt = tx.symbolic_locals.get("y")
     if y_vt is not None and y_vt.source_loc is not None:
         _source_loc_capture["source_loc"] = y_vt.source_loc
+
+
+def _unsupported_error_source_attribution() -> str:
+    if sys.version_info < (3, 11):
+        return """\
+Stack variable source attribution:
+  ConstantVariable(int: 1) originated from:
+  File "test_exc.py", line N
+                return {1, 2}
+"""
+
+    return """\
+Stack variable source attribution:
+  ConstantVariable(int: 1) originated from:
+  File "test_exc.py", line N
+                return {1, 2}
+                        ^
+  ConstantVariable(int: 2) originated from:
+  File "test_exc.py", line N
+                return {1, 2}
+                           ^
+"""
 
 
 class ExcTests(LoggingTestCase):
@@ -167,32 +190,31 @@ from user code:
         torch.compile(fn001, backend="eager")(torch.randn(1))
 
         record = self.getRecord(records, "missing BUILD_SET handler")
+        expected = (
+            "Graph break in user code at test_exc.py:N\n"
+            "Graph Break Reason: Failed to handle graph break gracefully. "
+            "Skipping the function and falling back to eager. Graph break "
+            "encountered:\n"
+            "\n"
+            "missing BUILD_SET handler\n"
+            "  Explanation: Missing BUILD_SET bytecode handler (for testing purposes).\n"
+            "\n"
+            "\n"
+            "  Developer debug context:\n"
+            "\n"
+            " For more details about this graph break, please visit: "
+            "https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0200.html\n"
+            "\n" + _unsupported_error_source_attribution() + "\n"
+            "User code traceback:\n"
+            '  File "test_exc.py", line N, in test_unsupported_error\n'
+            '    torch.compile(fn001, backend="eager")(torch.randn(1))\n'
+            '  File "test_exc.py", line N, in fn001\n'
+            "    return {1, 2}\n"
+        )
 
         self.assertExpectedInline(
             munge_exc(record.getMessage()),
-            """\
-Graph break in user code at test_exc.py:N
-Graph Break Reason: Failed to handle graph break gracefully. Skipping the function and falling back to eager. Graph break encountered:
-
-missing BUILD_SET handler
-  Explanation: Missing BUILD_SET bytecode handler (for testing purposes).
-
-
-  Developer debug context:
-
- For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0200.html
-
-Stack variable source attribution:
-  ConstantVariable(int: 1) originated from:
-  File "test_exc.py", line N
-                return {1, 2}
-
-User code traceback:
-  File "test_exc.py", line N, in test_unsupported_error
-    torch.compile(fn001, backend="eager")(torch.randn(1))
-  File "test_exc.py", line N, in fn001
-    return {1, 2}
-""",  # noqa: B950
+            expected,  # noqa: B950
         )
 
     @torch._dynamo.config.patch(suppress_errors=False)

--- a/test/dynamo/test_exc.py
+++ b/test/dynamo/test_exc.py
@@ -27,14 +27,14 @@ from torch.testing._internal.logging_utils import LoggingTestCase, make_logging_
 
 
 # Module-level storage avoids free-variable issues when capturing comptime state.
-_source_loc_capture: dict[str, SourceLocation] = {}
+_source_location_capture: dict[str, SourceLocation] = {}
 
 
-def _capture_y_source_loc(ctx) -> None:
+def _capture_y_source_location(ctx) -> None:
     tx = ctx._i_will_not_complain_if_bc_breaks_InstructionTranslator()
     y_vt = tx.symbolic_locals.get("y")
-    if y_vt is not None and y_vt.source_loc is not None:
-        _source_loc_capture["source_loc"] = y_vt.source_loc
+    if y_vt is not None and y_vt.source_location is not None:
+        _source_location_capture["source_location"] = y_vt.source_location
 
 
 def _unsupported_error_source_attribution() -> str:
@@ -443,49 +443,51 @@ Failed Source Expressions:
         )
 
     def test_source_location_format_no_col_info(self):
-        loc = SourceLocation(filename=__file__, lineno=1)
-        result = loc.format()
+        source_location = SourceLocation(filename=__file__, lineno=1)
+        result = source_location.format()
         self.assertIn(f'File "{__file__}", line 1', result)
         self.assertNotIn("^", result)
 
     def test_source_location_format_with_col_info(self):
-        loc = SourceLocation(
+        source_location = SourceLocation(
             filename=__file__,
             lineno=1,
             end_lineno=1,
             col_offset=0,
             end_col_offset=10,
         )
-        result = loc.format()
+        result = source_location.format()
         self.assertIn(f'File "{__file__}", line 1', result)
         self.assertIn("^" * 10, result)
 
     def test_source_location_format_without_source_line(self):
-        loc = SourceLocation(
+        source_location = SourceLocation(
             filename="<string>",
             lineno=1,
             end_lineno=1,
             col_offset=0,
             end_col_offset=10,
         )
-        result = loc.format()
+        result = source_location.format()
         self.assertEqual(result, '  File "<string>", line 1\n')
 
-    def test_vt_source_loc_set_during_tracing(self):
-        _source_loc_capture.clear()
+    def test_vt_source_location_set_during_tracing(self):
+        _source_location_capture.clear()
 
         def fn(x):
             y = x + 1
-            comptime(_capture_y_source_loc)
+            comptime(_capture_y_source_location)
             return y
 
         torch.compile(fn, backend="eager")(torch.ones(3))
 
-        loc = _source_loc_capture.get("source_loc")
-        self.assertIsNotNone(loc)
-        loc = cast(SourceLocation, loc)
-        self.assertEqual(loc.filename, __file__.replace(".pyc", ".py"))
-        self.assertIsNotNone(loc.lineno)
+        source_location = _source_location_capture.get("source_location")
+        self.assertIsNotNone(source_location)
+        source_location = cast(SourceLocation, source_location)
+        self.assertEqual(
+            source_location.filename, __file__.replace(".pyc", ".py")
+        )
+        self.assertIsNotNone(source_location.lineno)
 
     @make_logging_test(graph_breaks=True)
     def test_graph_break_source_attribution_on_stack(self, records):

--- a/test/dynamo/test_exc.py
+++ b/test/dynamo/test_exc.py
@@ -1,5 +1,6 @@
 # Owner(s): ["module: dynamo"]
 
+import sys
 import unittest
 
 import torch
@@ -13,6 +14,7 @@ from torch._dynamo.exc import (
     UserError,
     UserErrorType,
 )
+from torch._dynamo.variables.base import SourceLocation
 from torch.testing._internal.common_device_type import skipIf
 from torch.testing._internal.common_utils import (
     IS_FBCODE,
@@ -21,6 +23,17 @@ from torch.testing._internal.common_utils import (
     TEST_Z3,
 )
 from torch.testing._internal.logging_utils import LoggingTestCase, make_logging_test
+
+
+# Module-level storage avoids free-variable issues when capturing comptime state.
+_source_loc_capture: dict[str, SourceLocation] = {}
+
+
+def _capture_y_source_loc(ctx) -> None:
+    tx = ctx._i_will_not_complain_if_bc_breaks_InstructionTranslator()
+    y_vt = tx.symbolic_locals.get("y")
+    if y_vt is not None and y_vt.source_loc is not None:
+        _source_loc_capture["source_loc"] = y_vt.source_loc
 
 
 class ExcTests(LoggingTestCase):
@@ -401,6 +414,51 @@ Target Expressions:
 Failed Source Expressions:
   ==> (== (+ L['shape'][0] L['shape'][1] L['shape'][2]) L['x'].size()[0])""",
         )
+
+    def test_source_location_format_no_col_info(self):
+        loc = SourceLocation(filename=__file__, lineno=1)
+        result = loc.format()
+        self.assertIn(f'File "{__file__}", line 1', result)
+        self.assertNotIn("^", result)
+
+    @unittest.skipIf(sys.version_info < (3, 11), "positions only available in 3.11+")
+    def test_source_location_format_with_col_info(self):
+        loc = SourceLocation(
+            filename=__file__,
+            lineno=1,
+            end_lineno=1,
+            col_offset=0,
+            end_col_offset=10,
+        )
+        result = loc.format()
+        self.assertIn(f'File "{__file__}", line 1', result)
+        self.assertIn("^" * 10, result)
+
+    def test_vt_source_loc_set_during_tracing(self):
+        _source_loc_capture.clear()
+
+        def fn(x):
+            y = x + 1
+            comptime(_capture_y_source_loc)
+            return y
+
+        torch.compile(fn, backend="eager")(torch.ones(3))
+
+        loc = _source_loc_capture.get("source_loc")
+        self.assertIsNotNone(loc)
+        assert loc is not None
+        self.assertEqual(loc.filename, __file__.replace(".pyc", ".py"))
+        self.assertIsNotNone(loc.lineno)
+
+    @make_logging_test(graph_breaks=True)
+    def test_graph_break_source_attribution_on_stack(self, records):
+        def fn(x):
+            return (x + 1, torch._dynamo.graph_break())[0]  # noqa: GB_REGISTRY
+
+        torch.compile(fn, backend="eager")(torch.ones(3))
+
+        record = self.getRecord(records, "Graph break in user code")
+        self.assertIn("Stack variable source attribution", record.getMessage())
 
 
 if __name__ == "__main__":

--- a/test/dynamo/test_exc.py
+++ b/test/dynamo/test_exc.py
@@ -1,7 +1,7 @@
 # Owner(s): ["module: dynamo"]
 
-import sys
 import unittest
+from typing import cast
 
 import torch
 import torch._dynamo
@@ -181,6 +181,11 @@ missing BUILD_SET handler
   Developer debug context:
 
  For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0200.html
+
+Stack variable source attribution:
+  ConstantVariable(int: 1) originated from:
+  File "test_exc.py", line N
+                return {1, 2}
 
 User code traceback:
   File "test_exc.py", line N, in test_unsupported_error
@@ -421,7 +426,6 @@ Failed Source Expressions:
         self.assertIn(f'File "{__file__}", line 1', result)
         self.assertNotIn("^", result)
 
-    @unittest.skipIf(sys.version_info < (3, 11), "positions only available in 3.11+")
     def test_source_location_format_with_col_info(self):
         loc = SourceLocation(
             filename=__file__,
@@ -433,6 +437,17 @@ Failed Source Expressions:
         result = loc.format()
         self.assertIn(f'File "{__file__}", line 1', result)
         self.assertIn("^" * 10, result)
+
+    def test_source_location_format_without_source_line(self):
+        loc = SourceLocation(
+            filename="<string>",
+            lineno=1,
+            end_lineno=1,
+            col_offset=0,
+            end_col_offset=10,
+        )
+        result = loc.format()
+        self.assertEqual(result, '  File "<string>", line 1\n')
 
     def test_vt_source_loc_set_during_tracing(self):
         _source_loc_capture.clear()
@@ -446,7 +461,7 @@ Failed Source Expressions:
 
         loc = _source_loc_capture.get("source_loc")
         self.assertIsNotNone(loc)
-        assert loc is not None
+        loc = cast(SourceLocation, loc)
         self.assertEqual(loc.filename, __file__.replace(".pyc", ".py"))
         self.assertIsNotNone(loc.lineno)
 

--- a/test/dynamo/test_exc.py
+++ b/test/dynamo/test_exc.py
@@ -51,11 +51,11 @@ Stack variable source attribution:
   ConstantVariable(int: 1) originated from:
   File "test_exc.py", line N
                 return {1, 2}
-                        ^
+^
   ConstantVariable(int: 2) originated from:
   File "test_exc.py", line N
                 return {1, 2}
-                           ^
+^
 """
 
 

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -141,7 +141,7 @@ from .utils import (
     LazyString,
     proxy_args_kwargs,
 )
-from .variables.base import typestr, ValueMutationNew, VariableTracker
+from .variables.base import SourceLocation, typestr, ValueMutationNew, VariableTracker
 from .variables.builder import FrameStateSizeEntry, VariableBuilder, wrap_fx_proxy
 from .variables.builtin import BuiltinVariable, DictBuiltinVariable
 from .variables.constant import ConstantVariable
@@ -1886,6 +1886,25 @@ class InstructionTranslatorBase(
         assert isinstance(val, VariableTracker), (
             f"push expects VariableTracker, got {typestr(val)}"
         )
+        if val.source_loc is None:
+            inst = self.current_instruction
+            if inst.positions is not None and inst.positions.lineno is not None:
+                val.set_source_loc(
+                    SourceLocation(
+                        filename=self.f_code.co_filename,
+                        lineno=inst.positions.lineno,
+                        end_lineno=inst.positions.end_lineno,
+                        col_offset=inst.positions.col_offset,
+                        end_col_offset=inst.positions.end_col_offset,
+                    )
+                )
+            elif inst.starts_line is not None:
+                val.set_source_loc(
+                    SourceLocation(
+                        filename=self.f_code.co_filename,
+                        lineno=inst.starts_line,
+                    )
+                )
         self.stack.append(val)
 
     def push_many(self, vals: list[VariableTracker]) -> None:
@@ -4602,6 +4621,24 @@ class InstructionTranslatorBase(
         frame_loc_chain_list.append(frame_loc)
         return tuple(frame_loc_chain_list)
 
+    def _format_stack_source_attribution(self) -> str:
+        """Format bytecode source locations for stack values involved in a graph break."""
+        seen: set[tuple[str, int, int | None, int | None]] = set()
+        parts = []
+        for vt in self.stack:
+            loc = vt.source_loc
+            if loc is None:
+                continue
+            key = (loc.filename, loc.lineno, loc.col_offset, loc.end_col_offset)
+            if key in seen:
+                continue
+            seen.add(key)
+            parts.append(f"  {vt!r} originated from:\n{loc.format()}")
+
+        if not parts:
+            return ""
+        return "\nStack variable source attribution:\n" + "\n".join(parts)
+
     def log_graph_break(
         self,
         code_options: dict[str, Any],
@@ -4651,9 +4688,11 @@ class InstructionTranslatorBase(
         if exc is not None:
             reason = augment_exc_message_with_hop_name(exc, reason)
 
+        stack_source_attribution = self._format_stack_source_attribution()
         user_stack_trace = (
             f"Graph break in user code at {frame_loc[0]}:{frame_loc[1]}\n"
             f"Graph Break Reason: {reason}\n"
+            f"{stack_source_attribution}"
             "\nUser code traceback:\n"
         )
 

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -4623,21 +4623,20 @@ class InstructionTranslatorBase(
 
     def _format_stack_source_attribution(self) -> str:
         """Format bytecode source locations for stack values involved in a graph break."""
-        seen: set[tuple[str, int, int | None, int | None]] = set()
-        parts = []
+        seen: set[SourceLocation] = set()
+        parts: list[str] = []
         for vt in self.stack:
             loc = vt.source_loc
             if loc is None:
                 continue
-            key = (loc.filename, loc.lineno, loc.col_offset, loc.end_col_offset)
-            if key in seen:
+            if loc in seen:
                 continue
-            seen.add(key)
-            parts.append(f"  {vt!r} originated from:\n{loc.format()}")
+            seen.add(loc)
+            parts.append(f"  {vt!r} originated from:\n{loc.format().rstrip()}")
 
         if not parts:
             return ""
-        return "\nStack variable source attribution:\n" + "\n".join(parts)
+        return "Stack variable source attribution:\n" + "\n".join(parts)
 
     def log_graph_break(
         self,
@@ -4689,12 +4688,14 @@ class InstructionTranslatorBase(
             reason = augment_exc_message_with_hop_name(exc, reason)
 
         stack_source_attribution = self._format_stack_source_attribution()
-        user_stack_trace = (
-            f"Graph break in user code at {frame_loc[0]}:{frame_loc[1]}\n"
-            f"Graph Break Reason: {reason}\n"
-            f"{stack_source_attribution}"
-            "\nUser code traceback:\n"
-        )
+        user_stack_trace_parts = [
+            f"Graph break in user code at {frame_loc[0]}:{frame_loc[1]}",
+            f"Graph Break Reason: {reason}",
+        ]
+        if stack_source_attribution:
+            user_stack_trace_parts.extend(["", stack_source_attribution])
+        user_stack_trace_parts.extend(["", "User code traceback:"])
+        user_stack_trace = "\n".join(user_stack_trace_parts) + "\n"
 
         if config.verbose:
             user_stack_trace += (

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -1886,10 +1886,10 @@ class InstructionTranslatorBase(
         assert isinstance(val, VariableTracker), (
             f"push expects VariableTracker, got {typestr(val)}"
         )
-        if val.source_loc is None:
+        if val.source_location is None:
             inst = self.current_instruction
             if inst.positions is not None and inst.positions.lineno is not None:
-                val.set_source_loc(
+                val.set_source_location(
                     SourceLocation(
                         filename=self.f_code.co_filename,
                         lineno=inst.positions.lineno,
@@ -1899,7 +1899,7 @@ class InstructionTranslatorBase(
                     )
                 )
             elif inst.starts_line is not None:
-                val.set_source_loc(
+                val.set_source_location(
                     SourceLocation(
                         filename=self.f_code.co_filename,
                         lineno=inst.starts_line,
@@ -4626,13 +4626,15 @@ class InstructionTranslatorBase(
         seen: set[SourceLocation] = set()
         parts: list[str] = []
         for vt in self.stack:
-            loc = vt.source_loc
-            if loc is None:
+            source_location = vt.source_location
+            if source_location is None:
                 continue
-            if loc in seen:
+            if source_location in seen:
                 continue
-            seen.add(loc)
-            parts.append(f"  {vt!r} originated from:\n{loc.format().rstrip()}")
+            seen.add(source_location)
+            parts.append(
+                f"  {vt!r} originated from:\n{source_location.format().rstrip()}"
+            )
 
         if not parts:
             return ""

--- a/torch/_dynamo/variables/base.py
+++ b/torch/_dynamo/variables/base.py
@@ -16,7 +16,9 @@ computations.
 from __future__ import annotations
 
 import collections
+import dataclasses
 import functools
+import linecache
 import logging
 from collections.abc import Callable, ItemsView, KeysView, Sequence, ValuesView
 from contextvars import ContextVar
@@ -43,6 +45,27 @@ if TYPE_CHECKING:
 
 
 log = logging.getLogger(__name__)
+
+
+@dataclasses.dataclass(frozen=True)
+class SourceLocation:
+    """Source position of the bytecode instruction that generated a VariableTracker."""
+
+    filename: str
+    lineno: int
+    end_lineno: int | None = None
+    col_offset: int | None = None
+    end_col_offset: int | None = None
+
+    def format(self) -> str:
+        line = linecache.getline(self.filename, self.lineno).rstrip()
+        result = f'  File "{self.filename}", line {self.lineno}\n'
+        result += f"    {line}\n"
+        if self.col_offset is not None and self.end_col_offset is not None:
+            num_carets = max(1, self.end_col_offset - self.col_offset)
+            result += "    " + " " * self.col_offset + "^" * num_carets + "\n"
+        return result
+
 
 # Tracks active method calls on VariableTracker instances to detect self-referential
 # calls (e.g., as_python_constant on a list that contains itself). Maps
@@ -295,6 +318,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
         "value",
         "guards",
         "source",
+        "source_loc",
         "mutation_type",
         "parents_tracker",
         "user_code_variable_name",
@@ -877,6 +901,9 @@ class VariableTracker(metaclass=VariableTrackerMeta):
     def set_name_hint(self, name: str) -> None:
         pass
 
+    def set_source_loc(self, source_loc: SourceLocation) -> None:
+        self.source_loc = source_loc
+
     def realize(self) -> VariableTracker:
         """Used by LazyVariableTracker to build the real VariableTracker"""
         return self
@@ -1049,9 +1076,11 @@ class VariableTracker(metaclass=VariableTrackerMeta):
         *,
         source: Source | None = None,
         mutation_type: MutationType | None = None,
+        source_loc: SourceLocation | None = None,
     ) -> None:
         super().__init__()
         self.source = source
+        self.source_loc = source_loc
         self.mutation_type = mutation_type
 
         # NOTE sometimes mutation_type is set afterwards for implementation

--- a/torch/_dynamo/variables/base.py
+++ b/torch/_dynamo/variables/base.py
@@ -319,7 +319,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
         "value",
         "guards",
         "source",
-        "source_loc",
+        "source_location",
         "mutation_type",
         "parents_tracker",
         "user_code_variable_name",
@@ -902,8 +902,8 @@ class VariableTracker(metaclass=VariableTrackerMeta):
     def set_name_hint(self, name: str) -> None:
         pass
 
-    def set_source_loc(self, source_loc: SourceLocation) -> None:
-        self.source_loc = source_loc
+    def set_source_location(self, source_location: SourceLocation) -> None:
+        self.source_location = source_location
 
     def realize(self) -> VariableTracker:
         """Used by LazyVariableTracker to build the real VariableTracker"""
@@ -1077,11 +1077,11 @@ class VariableTracker(metaclass=VariableTrackerMeta):
         *,
         source: Source | None = None,
         mutation_type: MutationType | None = None,
-        source_loc: SourceLocation | None = None,
+        source_location: SourceLocation | None = None,
     ) -> None:
         super().__init__()
         self.source = source
-        self.source_loc = source_loc
+        self.source_location = source_location
         self.mutation_type = mutation_type
 
         # NOTE sometimes mutation_type is set afterwards for implementation

--- a/torch/_dynamo/variables/base.py
+++ b/torch/_dynamo/variables/base.py
@@ -60,8 +60,9 @@ class SourceLocation:
     def format(self) -> str:
         line = linecache.getline(self.filename, self.lineno).rstrip()
         result = f'  File "{self.filename}", line {self.lineno}\n'
-        result += f"    {line}\n"
-        if self.col_offset is not None and self.end_col_offset is not None:
+        if line:
+            result += f"    {line}\n"
+        if line and self.col_offset is not None and self.end_col_offset is not None:
             num_carets = max(1, self.end_col_offset - self.col_offset)
             result += "    " + " " * self.col_offset + "^" * num_carets + "\n"
         return result

--- a/torch/_dynamo/variables/lazy.py
+++ b/torch/_dynamo/variables/lazy.py
@@ -25,7 +25,7 @@ class LazyCache:
         self.value = value
         self.source = source
         self.name_hint: str | None = None
-        self.source_loc: SourceLocation | None = None
+        self.source_location: SourceLocation | None = None
         self.vt: VariableTracker | None = None
 
     def realize(self) -> None:
@@ -48,13 +48,13 @@ class LazyCache:
         if self.name_hint is not None:
             self.vt.set_name_hint(self.name_hint)
 
-        if self.source_loc is not None and self.vt.source_loc is None:
-            self.vt.set_source_loc(self.source_loc)
+        if self.source_location is not None and self.vt.source_location is None:
+            self.vt.set_source_location(self.source_location)
 
         del self.value
         del self.source
         del self.name_hint
-        del self.source_loc
+        del self.source_location
 
 
 class LazyVariableTracker(VariableTracker, metaclass=VariableTrackerMeta):
@@ -142,12 +142,12 @@ class LazyVariableTracker(VariableTracker, metaclass=VariableTrackerMeta):
         else:
             self._cache.name_hint = name
 
-    def set_source_loc(self, source_loc: SourceLocation) -> None:
-        self.source_loc = source_loc
+    def set_source_location(self, source_location: SourceLocation) -> None:
+        self.source_location = source_location
         if self.is_realized():
-            self._cache.vt.set_source_loc(source_loc)  # type: ignore[union-attr]
+            self._cache.vt.set_source_location(source_location)  # type: ignore[union-attr]
         else:
-            self._cache.source_loc = source_loc
+            self._cache.source_location = source_location
 
     def __str__(self) -> str:
         variable_info = "LazyVariableTracker("

--- a/torch/_dynamo/variables/lazy.py
+++ b/torch/_dynamo/variables/lazy.py
@@ -6,7 +6,7 @@ import inspect
 from typing import Any, TYPE_CHECKING
 
 from ..utils import is_function_or_wrapper
-from .base import VariableTracker, VariableTrackerMeta
+from .base import SourceLocation, VariableTracker, VariableTrackerMeta
 
 
 if TYPE_CHECKING:
@@ -25,6 +25,7 @@ class LazyCache:
         self.value = value
         self.source = source
         self.name_hint: str | None = None
+        self.source_loc: SourceLocation | None = None
         self.vt: VariableTracker | None = None
 
     def realize(self) -> None:
@@ -47,9 +48,13 @@ class LazyCache:
         if self.name_hint is not None:
             self.vt.set_name_hint(self.name_hint)
 
+        if self.source_loc is not None and self.vt.source_loc is None:
+            self.vt.set_source_loc(self.source_loc)
+
         del self.value
         del self.source
         del self.name_hint
+        del self.source_loc
 
 
 class LazyVariableTracker(VariableTracker, metaclass=VariableTrackerMeta):
@@ -136,6 +141,13 @@ class LazyVariableTracker(VariableTracker, metaclass=VariableTrackerMeta):
             self._cache.vt.set_name_hint(name)  # type: ignore[union-attr]
         else:
             self._cache.name_hint = name
+
+    def set_source_loc(self, source_loc: SourceLocation) -> None:
+        self.source_loc = source_loc
+        if self.is_realized():
+            self._cache.vt.set_source_loc(source_loc)  # type: ignore[union-attr]
+        else:
+            self._cache.source_loc = source_loc
 
     def __str__(self) -> str:
         variable_info = "LazyVariableTracker("

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -5961,6 +5961,9 @@ def munge_exc(e, *, suppress_suffix=True, suppress_prefix=True, file=None, skip=
     if suppress_prefix:
         s = re.sub(r"Cannot export model.+\n\n", "", s)
     s = re.sub(r" +$", "", s, flags=re.MULTILINE)
+    # Normalize caret-only lines by stripping leading whitespace, since
+    # col_offset in bytecode positions can vary across Python point releases
+    s = re.sub(r"^[ ]+(\^+)$", r"\1", s, flags=re.MULTILINE)
     return s
 
 


### PR DESCRIPTION
Fix #162857

## Summary
Root cause:
Dynamo did not retain the bytecode source location for VariableTrackers created during tracing, so graph-break diagnostics could not attribute intermediate values like `x + 1` back to the user code that produced them.

Proposed fix:
Add a `SourceLocation` record to `VariableTracker`, stamp it from the current instruction when a tracker is first pushed onto the symbolic stack, preserve it through lazy realization, and include that attribution in graph-break diagnostics for stack values. Add focused tests for formatting, tracing attribution, and graph-break logging.

Why this is the right long term fix:
This keeps source attribution as reusable VT metadata instead of rebuilding it ad hoc in each diagnostic, and the stack-push boundary is the most stable place to capture the originating bytecode instruction for both eager and lazy tracker paths.

Drafted via Codex, published after manual review by @bobrenjc93

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98