### PR TITLE
Fix _make_dep_token meta to return 0-dim tensor

### DIFF
--- a/test/test_meta.py
+++ b/test/test_meta.py
@@ -1947,6 +1947,17 @@ class TestMetaKernelConv(TestCase):
         self.assertTrue(gw2.is_contiguous(memory_format=torch.channels_last))
 
 
+
+
+class TestMetaKernelRegistrations(TestCase):
+    @skipIfTorchDynamo("tests raw meta kernel, not dynamo")
+    def test_make_dep_token(self):
+        cpu_result = torch.ops.aten._make_dep_token(device=torch.device("cpu"))
+        meta_result = torch.ops.aten._make_dep_token(device=torch.device("meta"))
+        self.assertEqual(cpu_result.shape, meta_result.shape)
+        self.assertEqual(cpu_result.dtype, meta_result.dtype)
+
+
 instantiate_device_type_tests(TestMeta, globals())
 
 

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -1002,7 +1002,7 @@ def make_dep_token(
     pin_memory=None,
     memory_format=None,
 ):
-    return torch.empty(0, device="meta")
+    return torch.empty((), device="meta")
 
 
 @register_meta(aten.sym_constrain_range.default)


### PR DESCRIPTION
The C++ implementation in [`aten/src/ATen/native/Constraints.cpp`](https://github.com/pytorch/pytorch/blob/main/aten/src/ATen/native/Constraints.cpp#L80-L88) calls `at::empty({}...)` which produces a 0-dimensional (scalar) tensor:

```cpp
Tensor _make_dep_token_cpu(
    std::optional<ScalarType> dtype_opt,
    std::optional<Layout> layout_opt,
    std::optional<Device> device_opt,
    std::optional<bool> pin_memory_opt,
    std::optional<c10::MemoryFormat> memory_format_opt) {
  return at::empty(
      {}, dtype_opt, layout_opt, device_opt, pin_memory_opt, memory_format_opt);
}
```

The Python meta kernel was returning a 1-dimensional tensor instead:

```python
# Before (wrong)
return torch.empty(0, device="meta")  # shape [0], 1-dim

# After (correct)
return torch.empty((), device="meta")  # shape [], 0-dim
```

This fix updates the meta registration to call `torch.empty(())` to match the C++ `at::empty({})` behavior exactly.