### PR TITLE
[XPU] Fail build when XPU explicitly requested but SYCL not found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -267,6 +267,14 @@ endif()
 # CUDA is incompatible with TSAN
 cmake_dependent_option(USE_CUDA "Use CUDA" ON "NOT USE_TSAN" OFF)
 
+# Track whether USE_XPU was explicitly set by the user (before option() is called)
+# If USE_XPU is already defined in cache, it means user explicitly set it
+if(DEFINED CACHE{USE_XPU})
+  set(_USE_XPU_EXPLICITLY_SET TRUE)
+else()
+  set(_USE_XPU_EXPLICITLY_SET FALSE)
+endif()
+
 option(USE_XPU "Use XPU" ON)
 option(USE_MTIA "Use MTIA" OFF)
 cmake_dependent_option(

--- a/cmake/public/xpu.cmake
+++ b/cmake/public/xpu.cmake
@@ -11,6 +11,14 @@ set(XPU_HOST_CXX_FLAGS)
 find_package(SYCLToolkit REQUIRED)
 if(NOT SYCL_FOUND)
   set(PYTORCH_FOUND_XPU FALSE)
+  # If user explicitly set USE_XPU=1, error out instead of falling back
+  if(_USE_XPU_EXPLICITLY_SET AND USE_XPU)
+    message(FATAL_ERROR
+      "Pytorch: XPU was explicitly requested (USE_XPU=1) but could NOT find SYCL. "
+      "Please make sure Intel GPU requirements are met. "
+      "See: https://github.com/pytorch/pytorch?tab=readme-ov-file#intel-gpu-support for more details. "
+      "If you want to build without XPU, please set USE_XPU=0.")
+  endif()
   # Exit early to avoid populating XPU_HOST_CXX_FLAGS.
   return()
 endif()


### PR DESCRIPTION
Error out with clear message when `USE_XPU=1` is set but `SYCL` toolkit is not available, aligning with `CUDA` backend behavior. Previously would silently fall back and continue building without `XPU` support.

Tracks whether `USE_XPU` was explicitly set by user to distinguish between explicit requests (which should fail-fast) and default values (which can fall back gracefully).