### PR TITLE
[Inductor] Fix view_as_complex stride requirement in Inductor backward by forcing contiguous layout

### DIFF
--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -2451,6 +2451,38 @@ class CPUReproTests(TestCase):
         actual = torch.compile(reduce_example, fullgraph=True)(*args)
         self.assertEqual(expected, actual)
 
+    @torch._inductor.config.patch({"layout_optimization": True})
+    @patch("torch.cuda.is_available", lambda: False)
+    def test_view_as_real_backward_with_conv(self):
+        class Model(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.conv = torch.nn.Conv2d(8, 8, 1, bias=False)
+
+            def forward(self, x):
+                x = torch.view_as_real(x)
+                x = x.permute(0, 4, 1, 2, 3).reshape(
+                    x.size(0), -1, x.size(2), x.size(3)
+                )
+                x = self.conv(x)
+                return x.sum()
+
+        torch.manual_seed(0)
+        eager_model = Model()
+        compiled_model = copy.deepcopy(eager_model)
+
+        eager_inp = torch.randn(1, 4, 8, 8, dtype=torch.complex64, requires_grad=True)
+        compiled_inp = eager_inp.detach().clone().requires_grad_(True)
+
+        eager_out = eager_model(eager_inp)
+        eager_out.backward()
+
+        compiled_out = torch.compile(compiled_model, fullgraph=True)(compiled_inp)
+        compiled_out.backward()
+
+        torch.testing.assert_close(compiled_out, eager_out)
+        torch.testing.assert_close(compiled_inp.grad, eager_inp.grad)
+
     def test_load_same_bool_tensor_twice(self):
         @torch.compile(backend="inductor")
         def fn(a, b):

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -1930,11 +1930,11 @@
   output_differentiability: [False]
 
 - name: view_as_real(Tensor(a) self) -> Tensor(a)
-  self: at::view_as_complex(grad.contiguous()) # gx0 + 1j * gx1
+  self: at::view_as_complex(grad.clone(c10::MemoryFormat::Contiguous)) # gx0 + 1j * gx1
   result: at::view_as_real(self_t)
 
 - name: view_as_complex(Tensor(a) self) -> Tensor(a)
-  self: at::view_as_real(grad.contiguous().resolve_conj()) # [gx, gy]
+  self: at::view_as_real(grad.clone(c10::MemoryFormat::Contiguous).resolve_conj()) # [gx, gy]
   result: at::view_as_complex(self_t)
 
 - name: where.self(Tensor condition, Tensor self, Tensor other) -> Tensor


### PR DESCRIPTION
**Summary**

This PR fixes a RuntimeError: Tensor must have a last dimension with stride 1 that occurs when using torch.compile on models involving complex number views and convolutions (Issue #179368).
The Root Cause

The view_as_complex operation (and the backward of view_as_real) has a strict hardware and mathematical requirement: the real and imaginary components must be adjacent in memory (last dimension stride = 1).

When a Conv2d follows these operations in a compiled graph, Inductor’s Layout Planner often optimizes the saved-for-backward tensors into a Channels Last (NHWC) format to maximize throughput on hardware like the NVIDIA H100. In NHWC, the stride of the last dimension is typically the number of channels, which is >1. When the autograd engine attempts to call the backward of view_as_real (which uses view_as_complex), it receives this re-laid-out tensor and crashes.

**The Fix**

Instead of a high-level workaround, this PR modifies the core autograd derivative formula for view_as_real in tools/autograd/derivatives.yaml.

I have updated the backward formula to explicitly call .clone(c10::MemoryFormat::Contiguous) before passing the gradient to view_as_complex.

    Why this works: By using an explicit clone with a specific MemoryFormat, we force Inductor to materialize a contiguous buffer with stride 1, satisfying the operation's requirements regardless of the layout chosen for the rest of the graph.

    Why not just .contiguous()? Plain .contiguous() calls are occasionally optimized away by Inductor's post_grad passes if the metadata incorrectly suggests the tensor is already contiguous. An explicit clone with format intent is a more robust "layout guard."

**Changes**

    tools/autograd/derivatives.yaml: Modified view_as_real backward to force a contiguous layout.

    test/inductor/test_cpu_repro.py: Added a new regression test test_view_as_real_backward_with_conv that reproduces the stride mismatch by chaining complex views with a convolution under torch.compile.

**Verification**

    Verified that the autograd code generation (tools/autograd/gen_autograd.py) accepts the new formula and generates valid C++ code.

    Regression test added to the Inductor suite to prevent future layout-planning regressions.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo