### PR TITLE
Replace erase idiom for map/set with erase_if

### DIFF
--- a/aten/src/ATen/cuda/CublasHandlePool.cpp
+++ b/aten/src/ATen/cuda/CublasHandlePool.cpp
@@ -142,24 +142,16 @@ void clearCublasWorkspacesForStream(cudaStream_t stream) {
   {
     auto& workspace = cublas_handle_stream_to_workspace();
     std::unique_lock<std::shared_mutex> lock(workspace.mutex);
-    for (auto it = workspace.map.begin(); it != workspace.map.end(); ) {
-      if (std::get<1>(it->first) == stream_ptr) {
-        it = workspace.map.erase(it);
-      } else {
-        ++it;
-      }
-    }
+    std::erase_if(workspace.map, [stream_ptr](const auto& entry) {
+      return std::get<1>(entry.first) == stream_ptr;
+    });
   }
   {
     auto& workspace = cublaslt_handle_stream_to_workspace();
     std::unique_lock<std::shared_mutex> lock(workspace.mutex);
-    for (auto it = workspace.map.begin(); it != workspace.map.end(); ) {
-      if (std::get<1>(it->first) == stream_ptr) {
-        it = workspace.map.erase(it);
-      } else {
-        ++it;
-      }
-    }
+    std::erase_if(workspace.map, [stream_ptr](const auto& entry) {
+      return std::get<1>(entry.first) == stream_ptr;
+    });
   }
 }
 

--- a/torch/csrc/distributed/c10d/TCPStoreBackend.cpp
+++ b/torch/csrc/distributed/c10d/TCPStoreBackend.cpp
@@ -221,27 +221,11 @@ void TCPStoreMasterDaemon::queryFds(std::vector<struct pollfd>& fds) {
 
 void TCPStoreMasterDaemon::clearSocketWaitState(int socket) {
   // Remove all the tracking state of the close FD
-  for (auto it = waitingSockets_.begin(); it != waitingSockets_.end();) {
-    for (auto vecIt = it->second.begin(); vecIt != it->second.end();) {
-      if (*vecIt == socket) {
-        vecIt = it->second.erase(vecIt);
-      } else {
-        ++vecIt;
-      }
-    }
-    if (it->second.empty()) {
-      it = waitingSockets_.erase(it);
-    } else {
-      ++it;
-    }
-  }
-  for (auto it = keysAwaited_.begin(); it != keysAwaited_.end();) {
-    if (it->first == socket) {
-      it = keysAwaited_.erase(it);
-    } else {
-      ++it;
-    }
-  }
+  std::erase_if(waitingSockets_, [&](auto& entry) {
+    std::erase(entry.second, socket);
+    return entry.second.empty();
+  });
+  keysAwaited_.erase(socket);
 }
 
 // query communicates with the worker. The format

--- a/torch/csrc/distributed/c10d/TCPStoreLibUvBackend.cpp
+++ b/torch/csrc/distributed/c10d/TCPStoreLibUvBackend.cpp
@@ -1405,20 +1405,10 @@ void LibUVStoreDaemon::clearClientWaitState(
     return;
   }
   keysAwaited_.erase(client);
-  for (auto it = waitingSockets_.begin(); it != waitingSockets_.end();) {
-    for (auto vecIt = it->second.begin(); vecIt != it->second.end();) {
-      if (*vecIt == client) {
-        vecIt = it->second.erase(vecIt);
-      } else {
-        ++vecIt;
-      }
-    }
-    if (it->second.empty()) {
-      it = waitingSockets_.erase(it);
-    } else {
-      ++it;
-    }
-  }
+  std::erase_if(waitingSockets_, [&](auto& entry) {
+    std::erase(entry.second, client);
+    return entry.second.empty();
+  });
 }
 
 void LibUVStoreDaemon::set(

--- a/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
@@ -1265,23 +1265,14 @@ void TensorPipeAgent::updateGroupMembership(
     workerNameToURL_.erase(name);
 
     // remove reverse device maps that are no longer used
-    for (auto it = reverseDeviceMaps_.begin();
-         it != reverseDeviceMaps_.end();) {
-      if (reverseDeviceMaps.find(it->first) == reverseDeviceMaps.end()) {
-        it = reverseDeviceMaps_.erase(it);
-      } else {
-        it++;
-      }
-    }
+    std::erase_if(reverseDeviceMaps_, [&reverseDeviceMaps](const auto& kv) {
+      return !reverseDeviceMaps.contains(kv.first);
+    });
 
     // remove devices that are no longer used
-    for (auto it = devices_.begin(); it != devices_.end();) {
-      if (std::find(devices.begin(), devices.end(), *it) == devices.end()) {
-        it = devices_.erase(it);
-      } else {
-        it++;
-      }
-    }
+    std::erase_if(devices_, [&](const auto& d) {
+      return std::find(devices.begin(), devices.end(), d) == devices.end();
+    });
   }
 }
 std::unordered_map<std::string, std::string> TensorPipeAgent::getMetrics() {

--- a/torch/csrc/jit/passes/onnx/helper.cpp
+++ b/torch/csrc/jit/passes/onnx/helper.cpp
@@ -39,14 +39,8 @@ void eraseUnusedBlockInputs(Block* b) {
 }
 
 void eraseUnusedValuesFromMap(ValueToParamPairMap& valsToParamsMap) {
-  auto it = valsToParamsMap.begin();
-  while (it != valsToParamsMap.end()) {
-    if (!it->first->hasUses()) {
-      it = valsToParamsMap.erase(it);
-    } else {
-      ++it;
-    }
-  }
+  std::erase_if(
+      valsToParamsMap, [](const auto& pr) { return !pr.first->hasUses(); });
 }
 
 void buildParamsMapFromValueToParamsMap(


### PR DESCRIPTION
C++20 provides `std::erase_if(container, pred)` which is equivalent to the following much longer code snippet for associative containers:

```cpp
auto it = container.begin();
while (it != container.end()) {
  if (pred(*it)) {
    it = container.erase(it);
  } else {
    ++it;
  }
}
```

PyTorch now supports C++20: #176662