### PR TITLE
Fix gaussian_nll_loss rejecting valid multi-dim broadcastable var shapes

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2728,6 +2728,29 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         self.assertEqual(component_wise_loss,
                          F.gaussian_nll_loss(input, target_part, var_part2, reduction='none'))
 
+    def test_gaussian_nll_loss_multi_dim_broadcasting(self):
+        input = torch.randn(4, 3, 2, 2)
+        target = torch.randn(4, 3, 2, 2)
+        var_full = torch.ones(4, 3, 2, 2)
+        expected = F.gaussian_nll_loss(input, target, var_full, reduction='none')
+
+        # var with two mismatched dims of size 1: (4, 3, 1, 1)
+        var_spatial = torch.ones(4, 3, 1, 1)
+        self.assertEqual(expected,
+                         F.gaussian_nll_loss(input, target, var_spatial, reduction='none'))
+
+        # var with three mismatched dims of size 1: (4, 1, 1, 1)
+        var_batch = torch.ones(4, 1, 1, 1)
+        expected_batch = F.gaussian_nll_loss(input, target, var_batch.expand_as(input), reduction='none')
+        self.assertEqual(expected_batch,
+                         F.gaussian_nll_loss(input, target, var_batch, reduction='none'))
+
+        # var with all dims size 1: (1, 1, 1, 1)
+        var_global = torch.ones(1, 1, 1, 1)
+        expected_global = F.gaussian_nll_loss(input, target, var_global.expand_as(input), reduction='none')
+        self.assertEqual(expected_global,
+                         F.gaussian_nll_loss(input, target, var_global, reduction='none'))
+
     def test_gaussian_nll_loss_args(self):
         input = torch.randn(3, 5)
         with self.assertRaisesRegex(ValueError, 'var is of incorrect size'):

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3307,15 +3307,14 @@ def gaussian_nll_loss(
         if input.size()[:-1] == var.size():
             var = torch.unsqueeze(var, -1)
 
-        # This checks if the var is broadcastable to the input and there is only one mismatched dimension.
-        # This is also a homoscedastic case.
+        # This checks if the var is broadcastable to the input, i.e. all mismatched
+        # dimensions in var are size 1.
         # e.g. input.size = (10, 2, 3), var.size = (10, 2, 1)
         # or  input.size = (4, 3, 32, 32), var.size = (4, 1, 32, 32)
-        elif (
-            input.ndim == var.ndim
-            and sum(y for x, y in zip(input.size(), var.size(), strict=True) if x != y)
-            == 1
-        ):  # Heteroscedastic case
+        # or  input.size = (4, 3, 2, 2), var.size = (4, 3, 1, 1)
+        elif input.ndim == var.ndim and all(
+            y == 1 for x, y in zip(input.size(), var.size(), strict=True) if x != y
+        ):
             pass
 
         # If none of the above pass, then the size of var is incorrect.


### PR DESCRIPTION
Fixes #176244

## What

`gaussian_nll_loss` now accepts `var` tensors with multiple mismatched dimensions of size 1, e.g. `var=(4, 3, 1, 1)` for `input=(4, 3, 2, 2)`.

Previously, the broadcastability check used `sum(y for x, y in zip(...) if x != y) == 1`, which summed the sizes of mismatched dimensions and required the sum to be exactly 1. This only worked when a single dimension differed. Shapes like `(4, 3, 1, 1)` have two mismatched dims (both size 1), giving a sum of 2, so they were incorrectly rejected.

**Before:**
```python
input = torch.randn(4, 3, 2, 2)
var = torch.ones(4, 3, 1, 1)  # per-channel variance shared across spatial dims
F.gaussian_nll_loss(input, target, var)
# ValueError: var is of incorrect size
```

**After:**
```python
F.gaussian_nll_loss(input, target, var)
# Works correctly — var is broadcast as expected
```

## How

Changed the check from `sum(y ...) == 1` to `all(y == 1 ...)`, so any number of mismatched dimensions are accepted as long as they are all size 1. This aligns with standard PyTorch broadcasting semantics.

This is a minimal one-line logic change in `torch/nn/functional.py`.

## Test

- Added `test_gaussian_nll_loss_multi_dim_broadcasting` covering:
  - `var=(4, 3, 1, 1)` — two mismatched dims
  - `var=(4, 1, 1, 1)` — three mismatched dims
  - `var=(1, 1, 1, 1)` — all dims mismatched
- Verified existing single-dim broadcast cases still pass
- Verified invalid `var` shapes (e.g. `(3, 3)` for `(3, 5)` input) are still rejected

cc @mikaylagawarecki @albanD @mruberry @jbschlosser