### PR TITLE
[host stats] Fix incorrect decrease in `active_bytes`

### DIFF
--- a/aten/src/ATen/core/CachingHostAllocator.h
+++ b/aten/src/ATen/core/CachingHostAllocator.h
@@ -723,7 +723,7 @@ struct CachingHostAllocatorImpl {
         std::lock_guard<std::mutex> g(pool.free_list_[index].mutex_);
         pool.free_list_[index].list_.push_back(block);
         stats_.active_bucket_stats[index].decrease(1);
-        stats_.active_bytes_bucket_stats[index].decrease(size);
+        stats_.active_bytes_bucket_stats[index].decrease(block->size_);
         if (size != -1) {
           return;
         }


### PR DESCRIPTION
https://github.com/pytorch/pytorch/blob/8c8414e5c03f21b5405acc2fd9115f4448dcd08a/aten/src/ATen/core/CachingHostAllocator.h#L637-L640
https://github.com/pytorch/pytorch/blob/8c8414e5c03f21b5405acc2fd9115f4448dcd08a/aten/src/ATen/core/CachingHostAllocator.h#L645
https://github.com/pytorch/pytorch/blob/8c8414e5c03f21b5405acc2fd9115f4448dcd08a/aten/src/ATen/core/CachingHostAllocator.h#L726

This means that the `decrease` becomes and `increase` by 1. We can fix by using the block's size.