### PR TITLE
[BE] [CPU] Fix conver_int4_to_int8() -> convert_int4_to_int8()

### DIFF
--- a/aten/src/ATen/native/cpu/int4mm_kernel.cpp
+++ b/aten/src/ATen/native/cpu/int4mm_kernel.cpp
@@ -40,7 +40,7 @@ inline bool is_block_start(int index, int BLOCK_SIZE) {
 #if (defined(CPU_CAPABILITY_AVX512) || defined(CPU_CAPABILITY_AVX2)) && !defined(_MSC_VER)
 // convert 16x int4 to int8, handle 64 bits at a time
 // used in avx2 and avx512
-inline __m128i conver_int4_to_int8(const uint8_t* data) {
+inline __m128i convert_int4_to_int8(const uint8_t* data) {
   __m128i tmp = _mm_loadu_si64((const __m128i*)data);
   __m128i bytes = _mm_cvtepu8_epi16(tmp);
   const __m128i lowMask = _mm_set1_epi8(0xF);
@@ -169,7 +169,7 @@ inline void tinygemm_kernel(
           vb[3] = _mm512_fmadd_ps(vb[3], scale[3], zero[3]);
         }
       } else {
-        __m128i b8 = conver_int4_to_int8(B + k * ldb + col * 8);
+        __m128i b8 = convert_int4_to_int8(B + k * ldb + col * 8);
         __m512i b32 = _mm512_cvtepu8_epi32(b8);
         vb[col] = _mm512_permutexvar_ps(b32, lut);
         vb[col] = _mm512_fmadd_ps(vb[col], scale[col], zero[col]);
@@ -312,7 +312,7 @@ inline void tinygemm_kernel(
       } else {
         if constexpr (col % 2 == 0) {
           // de-quantize per 64 bits (16x int4)
-          __m128i b8 = conver_int4_to_int8(B + k * ldb + col * 4);
+          __m128i b8 = convert_int4_to_int8(B + k * ldb + col * 4);
           __m128i b8_val0 = _mm_set1_epi64x(_mm_extract_epi64(b8, 0));
           __m128i b8_val1 = _mm_set1_epi64x(_mm_extract_epi64(b8, 1));
           if (k + PREFETCH_SIZE_K < K) {


### PR DESCRIPTION
Just a typo

Contributed by Benedikt Johannes

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01