### PR TITLE
Fix pattern matcher recompute tag leaking with nested replacement args

### DIFF
--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -2190,9 +2190,76 @@ class TestPatternMatcher(TestCase):
             TypeError,
             f"example_inputs must be a list or tuple, got {type(example_input)}",
         ):
-            register_replacement(
-                pattern, replacement, example_input, fwd_only, my_patterns
-            )
+             register_replacement(
+                 pattern, replacement, example_input, fwd_only, my_patterns
+             )
+
+    def test_replace_with_graph_nested_args_recompute_tags(self):
+        """
+        Test that recompute tags don't leak past nested replacement args.
+        Regression test for https://github.com/pytorch/pytorch/issues/178374
+        """
+        class M(torch.nn.Module):
+            def forward(self, x, y):
+                s1 = torch.sin(x)
+                s2 = torch.sin(y)
+                c = torch.cat([s1, s2], dim=1)
+                return torch.cos(c)
+
+        traced = torch.fx.symbolic_trace(M())
+        graph = traced.graph
+        nodes_before = set(graph.nodes)
+
+        call_nodes = [n for n in graph.nodes if n.op == "call_function"]
+        sin_nodes = [n for n in call_nodes if n.target == torch.sin]
+        self.assertEqual(len(sin_nodes), 2)
+        node_s1, node_s2 = sin_nodes
+        node_cat = next(n for n in call_nodes if n.target == torch.cat)
+
+        # Mark the cat node with recompute tags
+        node_cat.meta["recompute"] = "1"
+        node_cat.meta["ac_graph_id"] = 1
+
+        # Define replacement function that takes nested args
+        def rep_fn(nested):
+            x = nested[0]
+            y = nested[1]
+            return torch.add(x, y)
+
+        replacement_gm = torch.fx.symbolic_trace(rep_fn)
+
+        # Create match
+        pattern = Arg()
+        ctx = MatchContext([pattern], graph=graph)
+        ctx.pattern_to_node[pattern] = node_cat
+        match = Match(ctx, pattern)
+
+        # Replace with nested args: [(node_s1, node_s2)]
+        match.replace_with_graph(replacement_gm, args=[(node_s1, node_s2)])
+
+        # Verify replacement was created
+        nodes_after = [n for n in graph.nodes if n not in nodes_before and n.op != "output"]
+        new_add_nodes = [
+            n for n in nodes_after if n.op == "call_function" and n.target == torch.add
+        ]
+        self.assertEqual(len(new_add_nodes), 1)
+        new_add_node = new_add_nodes[0]
+
+        # Verify recompute tags ARE present on the new replacement node
+        self.assertEqual(new_add_node.meta.get("recompute"), "1")
+        self.assertEqual(new_add_node.meta.get("ac_graph_id"), 1)
+
+        # Verify recompute tags DO NOT leak to input nodes
+        self.assertNotIn("recompute", node_s1.meta)
+        self.assertNotIn("recompute", node_s2.meta)
+        self.assertNotIn("ac_graph_id", node_s1.meta)
+        self.assertNotIn("ac_graph_id", node_s2.meta)
+
+        # Verify recompute tags DO NOT leak to placeholders
+        placeholders = [n for n in graph.nodes if n.op == "placeholder"]
+        for n in placeholders:
+            self.assertNotIn("recompute", n.meta)
+            self.assertNotIn("ac_graph_id", n.meta)
 
 
 class TestPatternMatcherLogging(LoggingTestCase):

--- a/torch/_inductor/pattern_matcher.py
+++ b/torch/_inductor/pattern_matcher.py
@@ -1342,8 +1342,11 @@ class ReplacementPatternEntry(PatternEntry):
                     # incorrectly tag some nodes as recomputables.
                     for tag_name in ["recompute", "ac_graph_id"]:
                         if tag_name in old.meta:
+                            # Flatten nested args (e.g., [(node1, node2)]) to handle
+                            # pytree-structured arguments correctly
+                            flat_args = pytree.tree_leaves(args)
                             percolate_tags(
-                                new, tag_name, old.meta[tag_name], OrderedSet(args)
+                                new, tag_name, old.meta[tag_name], OrderedSet(flat_args)
                             )
 
                     old.replace_all_uses_with(


### PR DESCRIPTION
Fixes #178374. The replace_with_graph method was not properly handling nested replacement args when computing the boundary for recompute tag propagation. When args are nested (e.g., [(node_s1, node_s2)]), the pytree structure needs to be flattened to extract the individual leaf nodes before constructing the stop-node set.

This prevents recompute and ac_graph_id tags from leaking past the replacement graph inputs into the original graph nodes.

Changes:
- torch/_inductor/pattern_matcher.py: Use pytree.tree_leaves() to flatten nested args before constructing the input_stops set for tag percolation
- test/inductor/test_pattern_matcher.py: Add regression test with nested args


@pytorchbot label "module: inductor" "topic: not user facing" "release notes: label"

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo