### PR TITLE
Fix quantile/nanquantile failing under torch.compile(dynamic=True)

### DIFF
--- a/aten/src/ATen/native/Sorting.cpp
+++ b/aten/src/ATen/native/Sorting.cpp
@@ -258,7 +258,11 @@ Tensor quantile_compute(
   // synchronizing an accelerator with the CPU
   // The check is also skipped when the actual q values are not available yet
   // e.g. with symbolic shapes or during export
-  if (self.device().is_cpu() && !isTensorSubclassLike(q)) {
+  // Also skip when self is a tensor subclass (e.g. FakeTensor) because
+  // at::scalar_tensor(q, self.options()) does not propagate the subclass
+  // dispatch key, so isTensorSubclassLike(q) alone is insufficient when
+  // the scalar q overload creates q internally.
+  if (self.device().is_cpu() && !isTensorSubclassLike(self) && !isTensorSubclassLike(q)) {
     auto all_q_in_range = q.ge(0).logical_and_(q.le(1)).all();
     TORCH_CHECK(at::is_scalar_tensor_true(all_q_in_range),
                 "quantile() q values must be in the range [0, 1]");

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -2791,6 +2791,47 @@ class TestReductions(TestCase):
                     RuntimeError, r'quantile\(\) out tensor must be on the same device as the input tensor'):
                 torch.quantile(torch.randn(1, device=device), 0.5, out=torch.scalar_tensor(1))
 
+    @onlyNativeDeviceTypes
+    @dtypes(torch.float, torch.double)
+    def test_quantile_compile_dynamic(self, device, dtype):
+        # Regression test for https://github.com/pytorch/pytorch/issues/179383
+        # quantile/nanquantile should work under torch.compile with dynamic=True
+        for op in [torch.quantile, torch.nanquantile]:
+            # scalar q
+            def fn_scalar(x):
+                return op(x, 0.5)
+
+            x = torch.tensor([1.0, 3.0, 2.0, 5.0, 4.0], device=device, dtype=dtype)
+            eager_out = fn_scalar(x)
+            compiled_fn = torch.compile(
+                fn_scalar, backend="aot_eager_decomp_partition", dynamic=True
+            )
+            compiled_out = compiled_fn(x)
+            self.assertEqual(eager_out, compiled_out)
+
+            # tensor q
+            def fn_tensor(x):
+                return op(x, torch.tensor([0.25, 0.5, 0.75], device=x.device, dtype=x.dtype))
+
+            eager_out2 = fn_tensor(x)
+            compiled_fn2 = torch.compile(
+                fn_tensor, backend="aot_eager_decomp_partition", dynamic=True
+            )
+            compiled_out2 = compiled_fn2(x)
+            self.assertEqual(eager_out2, compiled_out2)
+
+            # with dim
+            def fn_dim(x):
+                return op(x, 0.5, dim=0)
+
+            x2 = torch.randn(3, 4, device=device, dtype=dtype)
+            eager_out3 = fn_dim(x2)
+            compiled_fn3 = torch.compile(
+                fn_dim, backend="aot_eager_decomp_partition", dynamic=True
+            )
+            compiled_out3 = compiled_fn3(x2)
+            self.assertEqual(eager_out3, compiled_out3)
+
     def test_std_mean(self, device):
         x = torch.rand(100, 50, 20, device=device)
         for dim in range(x.dim()):


### PR DESCRIPTION
The q-range validation in quantile_compute calls at::equal (via is_scalar_tensor_true) which is tagged data_dependent_output and fails with FakeTensors. The existing guard only checked
isTensorSubclassLike(q), but when quantile is called with a scalar q, the C++ code creates q via at::scalar_tensor(q, self.options()) which does not propagate the FakeTensor dispatch key. So q is a real tensor while self is a FakeTensor, and the guard fails to skip the check.

Fix: also check isTensorSubclassLike(self) in the guard, matching the existing comment about symbolic shapes and export.

Fixes #179383

cc @mlazos