### PR TITLE
[XPU] Register XPUPluggableAllocator pybind11 to fix c10::Allocator conversion

### DIFF
--- a/test/test_xpu.py
+++ b/test/test_xpu.py
@@ -3102,7 +3102,7 @@ class TestMemPool(TestCase):
 
         This test verifies the fix for XPUPluggableAllocator type registration,
         ensuring that pybind11 can properly convert the allocator when passed
-        to MemPool constructor. This mirrors how torchcomms uses custom allocators.
+        to MemPool constructor.
         """
         torch.xpu.init()
 
@@ -3146,14 +3146,58 @@ class TestMemPool(TestCase):
         # The fix adds proper pybind11 type registration for XPUPluggableAllocator
         pool = torch.xpu.MemPool(allocator.allocator())
 
+        torch.xpu.synchronize()
+        torch.xpu.empty_cache()
+        initial_allocated = torch.xpu.memory_allocated()
+
         # Verify the pool can be used for allocation
         with torch.xpu.use_mem_pool(pool):
-            tensor = torch.randn(100, 100, device="xpu")
-            self.assertEqual(tensor.device.type, "xpu")
-            self.assertEqual(tensor.shape, (100, 100))
+            t1 = torch.randn(100, 100, device="xpu")
 
-        # Cleanup
-        del tensor
+            self.assertEqual(t1.device.type, "xpu")
+            self.assertEqual(t1.shape, (100, 100))
+
+            ptr = t1.data_ptr()
+            self.assertNotEqual(ptr, 0)
+
+            # Memory allocated should increase after allocation
+            allocated_during = torch.xpu.memory_allocated()
+            self.assertTrue(allocated_during > initial_allocated)
+
+            del t1
+
+            t2 = torch.randn(100, 100, device="xpu")
+
+            self.assertEqual(t2.device.type, "xpu")
+            self.assertEqual(t2.shape, (100, 100))
+
+            ptr2 = t2.data_ptr()
+            self.assertNotEqual(ptr2, 0)
+
+            # Should reuse the same memory from the pool since t1 was deleted
+            # and we are using the same pool
+            self.assertEqual(ptr, ptr2)
+
+            del t2
+
+            # Test with zero-size tensor
+            empty = torch.tensor([], device="xpu")
+            self.assertEqual(empty.numel(), 0)
+
+            del empty
+
+        # Test pool survives exceptions
+        try:
+            with torch.xpu.use_mem_pool(pool):
+                raise RuntimeError("test error")
+        except RuntimeError:
+            pass
+
+        # Pool should still work
+        with torch.xpu.use_mem_pool(pool):
+            tensor = torch.randn(10, device="xpu")
+            self.assertIsNotNone(tensor)
+
         del pool
 
 

--- a/test/test_xpu.py
+++ b/test/test_xpu.py
@@ -1158,6 +1158,8 @@ print(torch.xpu.is_initialized())
         return allocator, dummy_allocator
 
     def test_xpu_pluggable_allocator(self):
+        from torch.utils.cpp_extension import load_inline
+
         torch.xpu.init()
         allocator, dummy_allocator = self.get_dummy_allocator(True)
         alloc_lib = ctypes.CDLL(dummy_allocator)
@@ -1231,6 +1233,40 @@ if __name__ == "__main__":
         called_dummy_alloc_value, called_dummy_free_value = rc.split()
         self.assertEqual(called_dummy_alloc_value, "123")
         self.assertEqual(called_dummy_free_value, "321")
+
+        cpp_source = r"""
+        #include <torch/extension.h>
+        #include <torch/csrc/xpu/XPUPluggableAllocator.h>
+        // Mimics what torchcomms' get_mem_allocator("xccl") does:
+        // creates an XPUPluggableAllocator and returns it as c10::Allocator*.
+        std::shared_ptr<c10::Allocator> get_xpu_allocator() {
+            auto allocator =
+                torch::xpu::XPUPluggableAllocator::createCustomAllocator(
+                    // alloc_fn
+                    [](size_t size, int device, sycl::queue* queue) -> void* {
+                        void* ptr = sycl::malloc_device(size, *queue);
+                        return ptr;
+                    },
+                    // free_fn
+                    [](void* ptr, size_t size, int device, sycl::queue* queue) {
+                        sycl::free(ptr, *queue);
+                    });
+            return allocator;
+        }
+        """
+        ext = load_inline(
+            name="repro_xpu_alloc",
+            cpp_sources=[cpp_source],
+            functions=["get_xpu_allocator"],
+            verbose=True,
+            is_python_module=True,
+            with_sycl=True,
+        )
+        # Verify that the XPUPluggableAllocator returned as
+        # std::shared_ptr<c10::Allocator> is correctly recognized as Python type.
+        # A TypeError here would mean the custom allocator lacks proper
+        # c10::Allocator pybind11 bindings.
+        allocator = ext.get_xpu_allocator()
 
     def test_torch_version_xpu(self):
         self.assertEqual(len(torch.version.xpu), 8)
@@ -3096,109 +3132,6 @@ class TestMemPool(TestCase):
 
         self.assertTrue(after_pool_release < peak_reserved)
         self.assertTrue(after_pool_release > 0)
-
-    def test_mempool_with_custom_allocator(self):
-        """Test that custom XPU allocators can be used with MemPool.
-
-        This test verifies the fix for XPUPluggableAllocator type registration,
-        ensuring that pybind11 can properly convert the allocator when passed
-        to MemPool constructor.
-        """
-        torch.xpu.init()
-
-        # Create a simple custom allocator using inline C++ extension
-        from torch.utils.cpp_extension import load_inline
-
-        custom_allocator_source = """
-        #include <torch/extension.h>
-        #include <c10/xpu/XPUFunctions.h>
-
-        extern "C" {
-          C10_EXPORT void* test_alloc(size_t size, int device, sycl::queue* queue) {
-            auto& sycl_device = c10::xpu::get_raw_device(device);
-            auto& sycl_context = c10::xpu::get_device_context();
-            void* ptr = sycl::malloc_shared(size, sycl_device, sycl_context);
-            return ptr;
-          }
-
-          C10_EXPORT void test_free(void* ptr, size_t size, int device, sycl::queue* queue) {
-            sycl::free(ptr, c10::xpu::get_device_context());
-          }
-        }
-        """
-
-        custom_allocator_lib = load_inline(
-            name="test_mempool_allocator",
-            cpp_sources=custom_allocator_source,
-            is_python_module=False,
-            keep_intermediates=False,
-            with_sycl=True,
-        )
-
-        # Create XPUPluggableAllocator - this returns c10::xpu::XPUCachingAllocator::XPUAllocator
-        allocator = torch.xpu.memory.XPUPluggableAllocator(
-            custom_allocator_lib,
-            "test_alloc",
-            "test_free",
-        )
-
-        # This should not raise "Unregistered type" error
-        # The fix adds proper pybind11 type registration for XPUPluggableAllocator
-        pool = torch.xpu.MemPool(allocator.allocator())
-
-        torch.xpu.synchronize()
-        torch.xpu.empty_cache()
-        initial_allocated = torch.xpu.memory_allocated()
-
-        # Verify the pool can be used for allocation
-        with torch.xpu.use_mem_pool(pool):
-            t1 = torch.randn(100, 100, device="xpu")
-
-            self.assertEqual(t1.device.type, "xpu")
-            self.assertEqual(t1.shape, (100, 100))
-
-            ptr = t1.data_ptr()
-            self.assertNotEqual(ptr, 0)
-
-            # Memory allocated should increase after allocation
-            allocated_during = torch.xpu.memory_allocated()
-            self.assertTrue(allocated_during > initial_allocated)
-
-            del t1
-
-            t2 = torch.randn(100, 100, device="xpu")
-
-            self.assertEqual(t2.device.type, "xpu")
-            self.assertEqual(t2.shape, (100, 100))
-
-            ptr2 = t2.data_ptr()
-            self.assertNotEqual(ptr2, 0)
-
-            # Should reuse the same memory from the pool since t1 was deleted
-            # and we are using the same pool
-            self.assertEqual(ptr, ptr2)
-
-            del t2
-
-            # Test with zero-size tensor
-            empty = torch.tensor([], device="xpu")
-            self.assertEqual(empty.numel(), 0)
-
-            del empty
-
-        # Test pool survives exceptions
-        try:
-            with torch.xpu.use_mem_pool(pool):
-                raise RuntimeError("test error")
-        except RuntimeError:
-            pass
-
-        # Pool should still work
-        with torch.xpu.use_mem_pool(pool):
-            tensor = torch.randn(10, device="xpu")
-            self.assertIsNotNone(tensor)
-
-        del pool
 
 
 instantiate_parametrized_tests(TestXpu)

--- a/test/test_xpu.py
+++ b/test/test_xpu.py
@@ -3097,6 +3097,65 @@ class TestMemPool(TestCase):
         self.assertTrue(after_pool_release < peak_reserved)
         self.assertTrue(after_pool_release > 0)
 
+    def test_mempool_with_custom_allocator(self):
+        """Test that custom XPU allocators can be used with MemPool.
+
+        This test verifies the fix for XPUPluggableAllocator type registration,
+        ensuring that pybind11 can properly convert the allocator when passed
+        to MemPool constructor. This mirrors how torchcomms uses custom allocators.
+        """
+        torch.xpu.init()
+
+        # Create a simple custom allocator using inline C++ extension
+        from torch.utils.cpp_extension import load_inline
+
+        custom_allocator_source = """
+        #include <torch/extension.h>
+        #include <c10/xpu/XPUFunctions.h>
+
+        extern "C" {
+          C10_EXPORT void* test_alloc(size_t size, int device, sycl::queue* queue) {
+            auto& sycl_device = c10::xpu::get_raw_device(device);
+            auto& sycl_context = c10::xpu::get_device_context();
+            void* ptr = sycl::malloc_shared(size, sycl_device, sycl_context);
+            return ptr;
+          }
+
+          C10_EXPORT void test_free(void* ptr, size_t size, int device, sycl::queue* queue) {
+            sycl::free(ptr, c10::xpu::get_device_context());
+          }
+        }
+        """
+
+        custom_allocator_lib = load_inline(
+            name="test_mempool_allocator",
+            cpp_sources=custom_allocator_source,
+            is_python_module=False,
+            keep_intermediates=False,
+            with_sycl=True,
+        )
+
+        # Create XPUPluggableAllocator - this returns c10::xpu::XPUCachingAllocator::XPUAllocator
+        allocator = torch.xpu.memory.XPUPluggableAllocator(
+            custom_allocator_lib,
+            "test_alloc",
+            "test_free",
+        )
+
+        # This should not raise "Unregistered type" error
+        # The fix adds proper pybind11 type registration for XPUPluggableAllocator
+        pool = torch.xpu.MemPool(allocator.allocator())
+
+        # Verify the pool can be used for allocation
+        with torch.xpu.use_mem_pool(pool):
+            tensor = torch.randn(100, 100, device="xpu")
+            self.assertEqual(tensor.device.type, "xpu")
+            self.assertEqual(tensor.shape, (100, 100))
+
+        # Cleanup
+        del tensor
+        del pool
+
 
 instantiate_parametrized_tests(TestXpu)
 instantiate_parametrized_tests(TestCachingHostAllocatorXpuGraph)

--- a/torch/csrc/xpu/Module.cpp
+++ b/torch/csrc/xpu/Module.cpp
@@ -395,6 +395,14 @@ static void registerXpuPluggableAllocator(PyObject* module) {
       std::shared_ptr<c10::xpu::XPUCachingAllocator::XPUAllocator>>(
       m, "_xpu_XPUAllocator");
 
+  // Register concrete XPUPluggableAllocator type with inheritance
+  py::class_<
+      torch::xpu::XPUPluggableAllocator::XPUPluggableAllocator,
+      c10::xpu::XPUCachingAllocator::XPUAllocator,
+      std::shared_ptr<
+          torch::xpu::XPUPluggableAllocator::XPUPluggableAllocator>>(
+      m, "_XPUPluggableAllocator");
+
   m.def("_xpu_getAllocator", []() {
     return py::cast(torch::xpu::XPUPluggableAllocator::getCurrentAllocator());
   });


### PR DESCRIPTION
Registers `XPUPluggableAllocator` as a pybind11 type with proper inheritance from `XPUAllocator`, so that pybind11 can convert `std::shared_ptr<c10::Allocator>` returned from C++ back to Python.

Fix is required for `XCCL`  backend in `TorchComms`.