### PR TITLE
[inductor] Guard FakeTensorUpdater lowering nodes

### DIFF
--- a/test/inductor/test_custom_post_grad_passes.py
+++ b/test/inductor/test_custom_post_grad_passes.py
@@ -15,9 +15,12 @@ from torch._inductor.custom_graph_pass import (
     CustomInferenceAwareGraphPass,
     get_hash_for_files,
 )
+from torch._inductor.fx_utils import FakeTensorUpdater
 from torch._inductor.lowering import lowerings as L
 from torch._inductor.pattern_matcher import Arg, CallFunction, PatternMatcherPass
 from torch._inductor.test_case import run_tests, TestCase
+from torch._inductor.virtualized import V
+from torch._subclasses.fake_tensor import FakeTensorMode
 from torch.testing._internal.common_utils import IS_LINUX
 from torch.testing._internal.inductor_utils import HAS_CPU, patch_inductor_backend
 
@@ -55,6 +58,58 @@ class TestCustomPassBase(TestCase):
                 counters["inductor"]["pattern_matcher_nodes"],
                 matcher_nodes,
             )
+
+
+class TestFakeTensorUpdater(TestCase):
+    def _build_graph_with_inductor_lowering_node(self):
+        def lowering_fn(x):
+            raise AssertionError("lowering_fn should not run under FakeTensorUpdater")
+
+        lowering_fn._inductor_lowering_function = True  # type: ignore[attr-defined]
+
+        graph = fx.Graph()
+        x = graph.placeholder("x")
+        y = graph.placeholder("y")
+        neg = graph.call_function(torch.ops.aten.neg.default, (x,))
+        lowered = graph.call_function(lowering_fn, (neg,))
+        graph.output(lowered)
+        return graph, x, y, neg, lowered
+
+    def test_unchanged_inductor_lowering_node_is_ignored(self):
+        graph, x, y, neg, lowered = self._build_graph_with_inductor_lowering_node()
+
+        with FakeTensorMode() as mode, torch.no_grad():
+            x.meta["val"] = mode.from_tensor(torch.randn(2, 3))
+            y.meta["val"] = mode.from_tensor(torch.randn(4, 5))
+            neg.meta["val"] = torch.ops.aten.neg.default(x.meta["val"])
+            lowered.meta["val"] = neg.meta["val"]
+
+            updater = FakeTensorUpdater(graph)
+            with V.set_fake_mode(mode):
+                updater.incremental_update()
+
+        self.assertEqual(lowered.meta["val"].shape, x.meta["val"].shape)
+
+    def test_raises_on_changed_inductor_lowering_node(self):
+        graph, x, y, neg, lowered = self._build_graph_with_inductor_lowering_node()
+
+        with FakeTensorMode() as mode, torch.no_grad():
+            x.meta["val"] = mode.from_tensor(torch.randn(2, 3))
+            y.meta["val"] = mode.from_tensor(torch.randn(4, 5))
+            neg.meta["val"] = torch.ops.aten.neg.default(x.meta["val"])
+            lowered.meta["val"] = neg.meta["val"]
+
+        updater = FakeTensorUpdater(graph)
+        with graph.inserting_before(lowered):
+            neg_replacement = graph.call_function(torch.ops.aten.neg.default, (y,))
+        lowered.args = (neg_replacement,)
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "_inductor_lowering_function nodes",
+        ):
+            with V.set_fake_mode(mode):
+                updater.incremental_update()
 
 
 aten = torch.ops.aten

--- a/test/inductor/test_custom_post_grad_passes.py
+++ b/test/inductor/test_custom_post_grad_passes.py
@@ -90,6 +90,32 @@ class TestFakeTensorUpdater(TestCase):
 
         self.assertEqual(lowered.meta["val"].shape, x.meta["val"].shape)
 
+    def test_new_inductor_lowering_node_with_metadata_is_ignored(self):
+        def lowering_fn(x):
+            raise AssertionError("lowering_fn should not run under FakeTensorUpdater")
+
+        lowering_fn._inductor_lowering_function = True  # type: ignore[attr-defined]
+
+        graph = fx.Graph()
+        x = graph.placeholder("x")
+        neg = graph.call_function(torch.ops.aten.neg.default, (x,))
+        output = graph.output(neg)
+
+        with FakeTensorMode() as mode, torch.no_grad():
+            x.meta["val"] = mode.from_tensor(torch.randn(2, 3))
+            neg.meta["val"] = torch.ops.aten.neg.default(x.meta["val"])
+
+            updater = FakeTensorUpdater(graph)
+            with graph.inserting_before(output):
+                lowered = graph.call_function(lowering_fn, (neg,))
+            lowered.meta["val"] = neg.meta["val"]
+            output.args = (lowered,)
+
+            with V.set_fake_mode(mode):
+                updater.incremental_update()
+
+        self.assertEqual(lowered.meta["val"].shape, x.meta["val"].shape)
+
     def test_raises_on_changed_inductor_lowering_node(self):
         graph, x, y, neg, lowered = self._build_graph_with_inductor_lowering_node()
 

--- a/torch/_inductor/fx_utils.py
+++ b/torch/_inductor/fx_utils.py
@@ -219,6 +219,13 @@ class FakeTensorUpdater:
                 continue
 
             if not should_process_node(node):
+                if hasattr(node.target, "_inductor_lowering_function"):
+                    raise RuntimeError(
+                        "FakeTensorUpdater cannot recompute metadata for changed "
+                        "_inductor_lowering_function nodes because those targets "
+                        "expect Inductor IR inputs rather than FakeTensor inputs. "
+                        f"Encountered changed node: {node.format_node()}"
+                    )
                 continue
 
             is_valid, args, kwargs = get_fake_args_kwargs(node)

--- a/torch/_inductor/fx_utils.py
+++ b/torch/_inductor/fx_utils.py
@@ -80,6 +80,7 @@ class FakeTensorUpdater:
 
     def __init__(self, graph: torch.fx.Graph) -> None:
         self.processed_hashes = OrderedSet[Any]()
+        self.tracked_node_ids = {id(node) for node in graph.nodes}
         self.graph = graph
 
         for node in self.graph.nodes:
@@ -208,24 +209,39 @@ class FakeTensorUpdater:
 
         to_process = OrderedSet[int]()
         for node in self.graph.nodes:
+            node_id = id(node)
+            node_hash = self.hash_node(node)
             # NB: Be very careful about skipping nodes (via continues) here
             # and ask for a careful review when changing this code. The
             # consequence for incorrect FakeTensor metadata is difficult-to-debug
             # silent incorrectness.
-            if (
-                self.hash_node(node) in self.processed_hashes
-                and id(node) not in to_process
-            ):
+            if node_hash in self.processed_hashes and node_id not in to_process:
+                continue
+
+            if hasattr(node.target, "_inductor_lowering_function"):
+                if node_id in self.tracked_node_ids:
+                    raise RuntimeError(
+                        "FakeTensorUpdater cannot recompute metadata for tracked "
+                        "_inductor_lowering_function nodes after their inputs or "
+                        "dependencies change because those targets expect "
+                        "Inductor IR inputs rather than FakeTensor inputs. "
+                        f"Encountered changed node: {node.format_node()}"
+                    )
+                if "val" not in node.meta:
+                    raise RuntimeError(
+                        "FakeTensorUpdater requires newly inserted "
+                        "_inductor_lowering_function nodes to already carry fake "
+                        "metadata in node.meta['val']. "
+                        f"Encountered new node without metadata: {node.format_node()}"
+                    )
+                # Pattern-based lowerings copy metadata from the node they replace,
+                # so newly inserted lowering nodes can be tracked without running
+                # their targets under fake mode.
+                self.processed_hashes.add(node_hash)
+                self.tracked_node_ids.add(node_id)
                 continue
 
             if not should_process_node(node):
-                if hasattr(node.target, "_inductor_lowering_function"):
-                    raise RuntimeError(
-                        "FakeTensorUpdater cannot recompute metadata for changed "
-                        "_inductor_lowering_function nodes because those targets "
-                        "expect Inductor IR inputs rather than FakeTensor inputs. "
-                        f"Encountered changed node: {node.format_node()}"
-                    )
                 continue
 
             is_valid, args, kwargs = get_fake_args_kwargs(node)
@@ -253,7 +269,8 @@ class FakeTensorUpdater:
 
             to_process.update([id(user) for user in node.users])
 
-            self.processed_hashes.add(self.hash_node(node))
+            self.processed_hashes.add(node_hash)
+            self.tracked_node_ids.add(node_id)
 
 
 def get_storage(t: torch.Tensor) -> int:


### PR DESCRIPTION
Fix #164920

## Summary

1. What is the root cause problem
FakeTensorUpdater intentionally skips `_inductor_lowering_function` nodes because those targets expect Inductor IR inputs, not FakeTensor inputs. When a graph rewrite makes one of those nodes dirty, the updater could otherwise leave stale metadata behind.

2. What is the proposed fix
Detect changed `_inductor_lowering_function` nodes during incremental updates and raise a clear `RuntimeError` instead of silently keeping invalid metadata. Add regression coverage for both unchanged and changed lowering-function nodes.

3. Why is this the right long term fix
Until these lowering targets have a real FakeTensor propagation path, failing loudly is the safest behavior. This preserves correctness today and gives future work an explicit contract to replace.

## Testing
- `python3 -m py_compile torch/_inductor/fx_utils.py test/inductor/test_custom_post_grad_passes.py`
- targeted `TestFakeTensorUpdater` execution in a CPU nightly wheel harness with the local `torch/_inductor/fx_utils.py` injected

Drafted via Codex, published after manual review by @bobrenjc93

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo