### PR TITLE
[DTensor] Replace __module__ hacks with @exposed_in decorators

### DIFF
--- a/torch/distributed/tensor/__init__.py
+++ b/torch/distributed/tensor/__init__.py
@@ -78,17 +78,6 @@ if DTensor not in _util_foreach_supported_types:
     _util_foreach_supported_types.append(DTensor)  # type: ignore[arg-type]
 
 
-# Set namespace for exposed private names
-DTensor.__module__ = "torch.distributed.tensor"
-distribute_tensor.__module__ = "torch.distributed.tensor"
-distribute_module.__module__ = "torch.distributed.tensor"
-ones.__module__ = "torch.distributed.tensor"
-empty.__module__ = "torch.distributed.tensor"
-full.__module__ = "torch.distributed.tensor"
-rand.__module__ = "torch.distributed.tensor"
-randn.__module__ = "torch.distributed.tensor"
-zeros.__module__ = "torch.distributed.tensor"
-
 # Register DTensor dispatch for higher order operators
 from torch._higher_order_ops.print import _register_dtensor_impl
 

--- a/torch/distributed/tensor/_api.py
+++ b/torch/distributed/tensor/_api.py
@@ -38,6 +38,7 @@ from torch.distributed.tensor.placement_types import (
     Replicate,
     Shard,
 )
+from torch.utils._exposed_in import exposed_in
 
 
 __all__ = [
@@ -287,6 +288,7 @@ class _FromTorchTensor(torch.autograd.Function):
         return grad_output.to_local(), None, None, None, None, None, None
 
 
+@exposed_in("torch.distributed.tensor")
 class DTensor(torch.Tensor):
     """
     ``DTensor`` (Distributed Tensor) is a subclass of ``torch.Tensor`` that provides single-device like
@@ -807,6 +809,7 @@ class DTensor(torch.Tensor):
             raise RuntimeError("Unsupported tensor type!")
 
 
+@exposed_in("torch.distributed.tensor")
 def distribute_tensor(
     tensor: torch.Tensor,
     device_mesh: DeviceMesh | None = None,
@@ -1019,6 +1022,7 @@ def _shard_tensor(
     return distribute_tensor(full_tensor, device_mesh, placements, src_data_rank=None)
 
 
+@exposed_in("torch.distributed.tensor")
 def distribute_module(
     module: nn.Module,
     device_mesh: DeviceMesh | None = None,
@@ -1245,6 +1249,7 @@ def _dtensor_init_helper(  # type: ignore[no-untyped-def]
     )
 
 
+@exposed_in("torch.distributed.tensor")
 def ones(  # type: ignore[no-untyped-def]
     *size,
     dtype: torch.dtype | None = None,
@@ -1288,6 +1293,7 @@ def ones(  # type: ignore[no-untyped-def]
     )
 
 
+@exposed_in("torch.distributed.tensor")
 def empty(  # type: ignore[no-untyped-def]
     *size,
     dtype: torch.dtype | None = None,
@@ -1331,6 +1337,7 @@ def empty(  # type: ignore[no-untyped-def]
     )
 
 
+@exposed_in("torch.distributed.tensor")
 def full(  # type: ignore[no-untyped-def]
     size,
     fill_value,
@@ -1378,6 +1385,7 @@ def full(  # type: ignore[no-untyped-def]
     )
 
 
+@exposed_in("torch.distributed.tensor")
 def rand(  # type: ignore[no-untyped-def]
     *size,
     requires_grad: bool = False,
@@ -1422,6 +1430,7 @@ def rand(  # type: ignore[no-untyped-def]
     )
 
 
+@exposed_in("torch.distributed.tensor")
 def randn(  # type: ignore[no-untyped-def]
     *size,
     requires_grad: bool = False,
@@ -1466,6 +1475,7 @@ def randn(  # type: ignore[no-untyped-def]
     )
 
 
+@exposed_in("torch.distributed.tensor")
 def zeros(  # type: ignore[no-untyped-def]
     *size,
     requires_grad: bool = False,

--- a/torch/distributed/tensor/debug/__init__.py
+++ b/torch/distributed/tensor/debug/__init__.py
@@ -63,8 +63,3 @@ def _reinit_dispatch_logger():
     changing the log level on the ``torch.distributed.tensor._dispatch`` logger.
     """
     torch._C._reinit_DTensor_dispatch_logger()
-
-
-# Set namespace for exposed private names
-CommDebugMode.__module__ = "torch.distributed.tensor.debug"
-visualize_sharding.__module__ = "torch.distributed.tensor.debug"

--- a/torch/distributed/tensor/debug/_comm_mode.py
+++ b/torch/distributed/tensor/debug/_comm_mode.py
@@ -17,6 +17,7 @@ from torch.nn.modules.module import (
     register_module_forward_pre_hook,
     register_module_full_backward_pre_hook,
 )
+from torch.utils._exposed_in import exposed_in
 from torch.utils._python_dispatch import TorchDispatchMode
 from torch.utils._pytree import tree_flatten
 
@@ -220,6 +221,7 @@ class _CommModeModuleTracker(ModTracker):
             print(key + ": " + str(value))
 
 
+@exposed_in("torch.distributed.tensor.debug")
 class CommDebugMode(TorchDispatchMode):
     """
     :class:`CommDebugMode` is a context manager that counts the number of

--- a/torch/distributed/tensor/debug/_visualize_sharding.py
+++ b/torch/distributed/tensor/debug/_visualize_sharding.py
@@ -5,6 +5,7 @@ import numpy as np
 
 from torch._prims_common import ShapeType
 from torch.distributed.tensor._utils import _compute_local_shape_and_global_offset
+from torch.utils._exposed_in import exposed_in
 
 
 __all__ = ["visualize_sharding"]
@@ -152,6 +153,7 @@ def _create_rich_table(
     console.print(table, end="\n\n")
 
 
+@exposed_in("torch.distributed.tensor.debug")
 def visualize_sharding(dtensor, header="", use_rich: bool = False):
     """
     Visualizes sharding in the terminal for :class:`DTensor` that are 1D or 2D.

--- a/torch/distributed/tensor/experimental/__init__.py
+++ b/torch/distributed/tensor/experimental/__init__.py
@@ -25,10 +25,3 @@ def implicit_replication() -> Iterator[None]:
         yield
     finally:
         DTensor._op_dispatcher._allow_implicit_replication = False
-
-
-# Set namespace for exposed private names
-context_parallel.__module__ = "torch.distributed.tensor.experimental"
-implicit_replication.__module__ = "torch.distributed.tensor.experimental"
-local_map.__module__ = "torch.distributed.tensor.experimental"
-register_sharding.__module__ = "torch.distributed.tensor.experimental"

--- a/torch/distributed/tensor/experimental/_context_parallel/_attention.py
+++ b/torch/distributed/tensor/experimental/_context_parallel/_attention.py
@@ -23,6 +23,7 @@ from torch.nn.attention.flex_attention import (
     BlockMask,
     create_block_mask,
 )
+from torch.utils._exposed_in import exposed_in
 from torch.utils._pytree import tree_flatten, tree_unflatten
 
 from ._cp_custom_ops import flex_cp_allgather
@@ -1510,6 +1511,7 @@ def _disable_context_parallel_dispatcher() -> None:
 #####################################################
 # Current public APIs, but are also subject to change
 #####################################################
+@exposed_in("torch.distributed.tensor.experimental")
 @contextlib.contextmanager
 @torch.no_grad()
 def context_parallel(

--- a/torch/distributed/tensor/experimental/_func_map.py
+++ b/torch/distributed/tensor/experimental/_func_map.py
@@ -7,6 +7,7 @@ import torch
 from torch.distributed._functional_collectives import AsyncCollectiveTensor
 from torch.distributed.tensor import DeviceMesh, DTensor
 from torch.distributed.tensor.placement_types import Placement
+from torch.utils._exposed_in import exposed_in
 
 
 try:
@@ -22,6 +23,7 @@ InputPlacements = tuple[PlacementType, ...] | None
 OutputPlacements = PlacementType | tuple[PlacementType, ...]
 
 
+@exposed_in("torch.distributed.tensor.experimental")
 def local_map(
     func: Callable | None = None,
     out_placements: OutputPlacements = None,

--- a/torch/distributed/tensor/experimental/_register_sharding.py
+++ b/torch/distributed/tensor/experimental/_register_sharding.py
@@ -15,11 +15,13 @@ from torch.distributed.tensor._op_schema import (
     TupleStrategy,
 )
 from torch.distributed.tensor._ops.utils import expand_to_full_mesh_op_strategy
+from torch.utils._exposed_in import exposed_in
 
 
 __all__ = ["register_sharding"]
 
 
+@exposed_in("torch.distributed.tensor.experimental")
 def register_sharding(op: OpOverload | list[OpOverload]):
     """
     :meth:`register_sharding` is an experimental API that allows users to register sharding


### PR DESCRIPTION
## Summary

- Replace manual `__module__` attribute assignments in `torch.distributed.tensor` with `@exposed_in()` decorators applied at definition sites
- Covers `DTensor`, `distribute_tensor`, `distribute_module`, factory functions (`ones`, `empty`, `full`, `rand`, `randn`, `zeros`), `CommDebugMode`, `visualize_sharding`, `context_parallel`, `local_map`, and `register_sharding`
- Net reduction in boilerplate: 23 lines removed, 20 added across 9 files

## Motivation

Fixes #171905

The current pattern of setting `__module__` at import sites in `__init__.py` files is fragile and doesn't play well with type checkers or linters. The `@exposed_in()` decorator from `torch.utils._exposed_in` is already the established pattern in PyTorch (used in `torch._functorch`, `torch._library`, etc.) and produces identical runtime behavior — it just sets `__module__` at the definition site instead of the import site.

This is the first step toward cleaning up `__module__` hacks across the codebase. The scope is limited to `torch.distributed.tensor` (the module cited in the issue). The C extension type `Placement` is intentionally left unchanged since `@exposed_in` cannot be applied to C++ defined types.

## Changes

**Definition sites** (added `@exposed_in` decorator):
- `torch/distributed/tensor/_api.py` — `DTensor`, `distribute_tensor`, `distribute_module`, `ones`, `empty`, `full`, `rand`, `randn`, `zeros`
- `torch/distributed/tensor/experimental/_context_parallel/_attention.py` — `context_parallel`
- `torch/distributed/tensor/experimental/_func_map.py` — `local_map`
- `torch/distributed/tensor/experimental/_register_sharding.py` — `register_sharding`
- `torch/distributed/tensor/debug/_comm_mode.py` — `CommDebugMode`
- `torch/distributed/tensor/debug/_visualize_sharding.py` — `visualize_sharding`

**Import sites** (removed `__module__` hacks):
- `torch/distributed/tensor/__init__.py`
- `torch/distributed/tensor/experimental/__init__.py`
- `torch/distributed/tensor/debug/__init__.py`

## Test Plan

- The `@exposed_in` decorator sets `__module__` identically to the previous manual assignments, so `test_public_bindings.py::TestPublicBindings::test_correct_module_names` should pass unchanged
- No behavioral changes — the decorator is a thin wrapper that sets `fn.__module__` and returns `fn`

cc @Skylion007