### PR TITLE
Deduplicate AOT dispatch graph capture setup

### DIFF
--- a/torch/_functorch/_aot_autograd/graph_capture.py
+++ b/torch/_functorch/_aot_autograd/graph_capture.py
@@ -203,6 +203,7 @@ def _detach_traced_inputs(flat_args: Any) -> Any:
     if detect_fake_mode():
         detach_tensor = _detach_and_copy_item_memo
     else:
+
         def detach_tensor(t: torch.Tensor) -> torch.Tensor:
             return t.detach()
 

--- a/torch/_functorch/_aot_autograd/graph_capture.py
+++ b/torch/_functorch/_aot_autograd/graph_capture.py
@@ -203,7 +203,9 @@ def _detach_traced_inputs(flat_args: Any) -> Any:
     if detect_fake_mode():
         detach_tensor = _detach_and_copy_item_memo
     else:
-        detach_tensor = lambda t: t.detach()
+        def detach_tensor(t: torch.Tensor) -> torch.Tensor:
+            return t.detach()
+
     return pytree.tree_map_only(torch.Tensor, detach_tensor, flat_args)
 
 

--- a/torch/_functorch/_aot_autograd/graph_capture.py
+++ b/torch/_functorch/_aot_autograd/graph_capture.py
@@ -192,7 +192,7 @@ def _detach_and_copy_item_memo(t: torch.Tensor) -> torch.Tensor:
 
 
 @dataclasses.dataclass
-class _GraphCaptureTracingState:
+class _GraphCaptureTracingResult:
     fn_to_trace: Callable[..., Any]
     flat_args: Any
     flat_args_descs: Any
@@ -220,7 +220,7 @@ def _prepare_graph_capture_tracing(
     aot_config: AOTConfig,
     trace_joint: bool,
     joint_fn_handle: Any | None = None,
-) -> _GraphCaptureTracingState:
+) -> _GraphCaptureTracingResult:
     if aot_config.disable_functionalization:
         updated_flat_args, updated_flat_args_descs = flat_args, flat_args_descs
     else:
@@ -259,7 +259,7 @@ def _prepare_graph_capture_tracing(
             )
         )
 
-    return _GraphCaptureTracingState(
+    return _GraphCaptureTracingResult(
         fn_to_trace=fn_to_trace,
         flat_args=updated_flat_args,
         flat_args_descs=updated_flat_args_descs,
@@ -279,15 +279,6 @@ def _create_graph_and_save_traced_inputs(
         _create_graph(fn_to_trace, flat_args, flat_args_descs, aot_config=aot_config),
         saved_flat_args,
     )
-
-
-def _assert_export_graph_support(
-    aot_config: AOTConfig, maybe_subclass_meta: SubclassMeta | None
-) -> None:
-    if aot_config.is_export and maybe_subclass_meta is not None:
-        raise AssertionError(
-            "aot_export_module does not support tensor subclass inputs for now."
-        )
 
 
 def aot_dispatch_base_graph(
@@ -458,7 +449,10 @@ def aot_dispatch_base_graph(
         )
 
     # TODO: should factor this into a separate function for export that always only returns just the graph.
-    _assert_export_graph_support(aot_config, maybe_subclass_meta)
+    if aot_config.is_export and maybe_subclass_meta is not None:
+        raise AssertionError(
+            "aot_export_module does not support tensor subclass inputs for now."
+        )
     return (
         fw_module,
         saved_updated_flat_args_subclasses_desugared,
@@ -579,7 +573,10 @@ def aot_dispatch_autograd_graph(
     # TODO: in AOTAutograd, we create metadata like _indices_of_inps_to_detach to detect
     # when we need to manually detach() some inputs in the forward.
     # Higher order ops might eventually need to do the same.
-    _assert_export_graph_support(aot_config, maybe_subclass_meta)
+    if aot_config.is_export and maybe_subclass_meta is not None:
+        raise AssertionError(
+            "aot_export_module does not support tensor subclass inputs for now."
+        )
     return (
         fx_g,
         saved_updated_joint_inputs,

--- a/torch/_functorch/_aot_autograd/graph_capture.py
+++ b/torch/_functorch/_aot_autograd/graph_capture.py
@@ -191,6 +191,102 @@ def _detach_and_copy_item_memo(t: torch.Tensor) -> torch.Tensor:
     return detached_t
 
 
+@dataclasses.dataclass
+class _GraphCaptureTracingState:
+    fn_to_trace: Callable[..., Any]
+    flat_args: Any
+    flat_args_descs: Any
+    maybe_subclass_meta: SubclassMeta | None
+
+
+def _detach_traced_inputs(flat_args: Any) -> Any:
+    if detect_fake_mode():
+        detach_tensor = _detach_and_copy_item_memo
+    else:
+        detach_tensor = lambda t: t.detach()
+    return pytree.tree_map_only(torch.Tensor, detach_tensor, flat_args)
+
+
+def _prepare_graph_capture_tracing(
+    fn_to_trace: Callable[..., Any],
+    flat_args: Any,
+    flat_args_descs: Any,
+    flat_fn: TraceFn,
+    *,
+    fw_metadata: ViewAndMutationMeta,
+    aot_config: AOTConfig,
+    trace_joint: bool,
+    joint_fn_handle: Any | None = None,
+) -> _GraphCaptureTracingState:
+    if aot_config.disable_functionalization:
+        updated_flat_args, updated_flat_args_descs = flat_args, flat_args_descs
+    else:
+        fn_to_trace, updated_flat_args, updated_flat_args_descs = (
+            create_functionalized_fn(
+                fn_to_trace,
+                flat_args,
+                flat_args_descs,
+                meta=fw_metadata,
+                aot_config=aot_config,
+                trace_joint=trace_joint,
+                joint_fn_handle=joint_fn_handle,
+            )
+        )
+
+    subclass_tracing_info = aot_dispatch_subclass(
+        fn_to_trace,
+        updated_flat_args,
+        updated_flat_args_descs,
+        is_joint_structure=trace_joint,
+        meta=fw_metadata,
+        fw_only=flat_fn,
+    )
+    fn_to_trace = subclass_tracing_info.plain_tensor_trace_fn
+    updated_flat_args = subclass_tracing_info.plain_tensor_args
+    updated_flat_args_descs = subclass_tracing_info.plain_tensor_args_descs
+
+    if not aot_config.disable_functionalization:
+        fn_to_trace, updated_flat_args, updated_flat_args_descs = (
+            handle_effect_tokens_fn(
+                fn_to_trace,
+                updated_flat_args,
+                updated_flat_args_descs,
+                meta=fw_metadata,
+                trace_joint=trace_joint,
+            )
+        )
+
+    return _GraphCaptureTracingState(
+        fn_to_trace=fn_to_trace,
+        flat_args=updated_flat_args,
+        flat_args_descs=updated_flat_args_descs,
+        maybe_subclass_meta=subclass_tracing_info.maybe_subclass_meta,
+    )
+
+
+def _create_graph_and_save_traced_inputs(
+    fn_to_trace: Callable[..., Any],
+    flat_args: Any,
+    flat_args_descs: Any,
+    *,
+    aot_config: AOTConfig,
+) -> tuple[torch.fx.GraphModule, Any]:
+    saved_flat_args = _detach_traced_inputs(flat_args)
+    return (
+        _create_graph(fn_to_trace, flat_args, flat_args_descs, aot_config=aot_config),
+        saved_flat_args,
+    )
+
+
+def _assert_export_graph_support(
+    aot_config: AOTConfig, maybe_subclass_meta: SubclassMeta | None
+) -> None:
+    if aot_config.is_export and maybe_subclass_meta is not None:
+        raise AssertionError(
+            "aot_export_module does not support tensor subclass inputs for now."
+        )
+
+
 def aot_dispatch_base_graph(
     flat_fn: TraceFn,
     flat_args: list[FxValue],
@@ -212,53 +308,22 @@ def aot_dispatch_base_graph(
         fw_metadata,
         keep_data_input_mutations=aot_config.keep_inference_input_mutations,
     )
-
-    if aot_config.disable_functionalization:
-        updated_flat_args, updated_flat_args_descs = (
-            flat_args,
-            flat_args_descs,
-        )
-    else:
-        fn_to_trace, updated_flat_args, updated_flat_args_descs = (
-            create_functionalized_fn(
-                fn_to_trace,
-                flat_args,
-                flat_args_descs,
-                meta=fw_metadata,
-                aot_config=aot_config,
-                trace_joint=False,
-            )
-        )
-
     # TODO: replace with AOTDispatchSubclassWrapper once we refactor
     # fn_input_mutations_to_outputs and create_functionalized_fn
     # into CompilerWrappers.
-    (
+    tracing_state = _prepare_graph_capture_tracing(
         fn_to_trace,
-        updated_flat_args_subclasses_desugared,
-        updated_flat_args_subclasses_desugared_descs,
-        maybe_subclass_meta,
-    ) = aot_dispatch_subclass(
-        fn_to_trace,
-        updated_flat_args,
-        updated_flat_args_descs,
-        is_joint_structure=False,
-        meta=fw_metadata,
-        fw_only=flat_fn,
+        flat_args,
+        flat_args_descs,
+        flat_fn,
+        fw_metadata=fw_metadata,
+        aot_config=aot_config,
+        trace_joint=False,
     )
-
-    if not aot_config.disable_functionalization:
-        (
-            fn_to_trace,
-            updated_flat_args_subclasses_desugared,
-            updated_flat_args_subclasses_desugared_descs,
-        ) = handle_effect_tokens_fn(
-            fn_to_trace,
-            updated_flat_args_subclasses_desugared,
-            updated_flat_args_subclasses_desugared_descs,
-            meta=fw_metadata,
-            trace_joint=False,
-        )
+    fn_to_trace = tracing_state.fn_to_trace
+    updated_flat_args_subclasses_desugared = tracing_state.flat_args
+    updated_flat_args_subclasses_desugared_descs = tracing_state.flat_args_descs
+    maybe_subclass_meta = tracing_state.maybe_subclass_meta
 
     aot_graphs_log.debug(
         "aot_config id: %s, fw_metadata=%s,subclass_metadata=%s",
@@ -278,26 +343,17 @@ def aot_dispatch_base_graph(
             mod_when_exporting_non_strict, assigned_buffers
         )
 
-    fake_mode = detect_fake_mode()
-    if fake_mode:
-        saved_updated_flat_args_subclasses_desugared = pytree.tree_map_only(
-            torch.Tensor,
-            _detach_and_copy_item_memo,
-            updated_flat_args_subclasses_desugared,
-        )
-    else:
-        saved_updated_flat_args_subclasses_desugared = pytree.tree_map_only(
-            torch.Tensor, lambda t: t.detach(), updated_flat_args_subclasses_desugared
-        )
-    saved_updated_flat_args_subclasses_desugared_descs = (
-        updated_flat_args_subclasses_desugared_descs
-    )
-
-    fw_module = _create_graph(
+    (
+        fw_module,
+        saved_updated_flat_args_subclasses_desugared,
+    ) = _create_graph_and_save_traced_inputs(
         fn_to_trace,
         updated_flat_args_subclasses_desugared,
         updated_flat_args_subclasses_desugared_descs,
         aot_config=aot_config,
+    )
+    saved_updated_flat_args_subclasses_desugared_descs = (
+        updated_flat_args_subclasses_desugared_descs
     )
 
     if aot_config.is_export and mod_when_exporting_non_strict is not None:
@@ -399,11 +455,7 @@ def aot_dispatch_base_graph(
         )
 
     # TODO: should factor this into a separate function for export that always only returns just the graph.
-    if aot_config.is_export:
-        if maybe_subclass_meta is not None:
-            raise AssertionError(
-                "aot_export_module does not support tensor subclass inputs for now."
-            )
+    _assert_export_graph_support(aot_config, maybe_subclass_meta)
     return (
         fw_module,
         saved_updated_flat_args_subclasses_desugared,
@@ -449,51 +501,23 @@ def aot_dispatch_autograd_graph(
     )
     # pyrefly: ignore[missing-attribute]
     joint_fn_handle = joint_fn_to_trace.handle
-
-    if aot_config.disable_functionalization:
-        updated_joint_inputs, updated_joint_inputs_descs = (
-            joint_inputs,
-            joint_inputs_descs,
-        )
-    else:
-        joint_fn_to_trace, updated_joint_inputs, updated_joint_inputs_descs = (
-            create_functionalized_fn(
-                joint_fn_to_trace,
-                joint_inputs,
-                joint_inputs_descs,
-                meta=fw_metadata,
-                aot_config=aot_config,
-                trace_joint=True,
-                joint_fn_handle=joint_fn_handle,
-            )
-        )
-
     # TODO: replace with AOTDispatchSubclassWrapper once we refactor
     # fn_input_mutations_to_outputs and create_functionalized_fn
     # into CompilerWrappers.
-    subclass_tracing_info = aot_dispatch_subclass(
+    tracing_state = _prepare_graph_capture_tracing(
         joint_fn_to_trace,
-        updated_joint_inputs,
-        updated_joint_inputs_descs,
-        is_joint_structure=True,
-        meta=fw_metadata,
-        fw_only=flat_fn,
+        joint_inputs,
+        joint_inputs_descs,
+        flat_fn,
+        fw_metadata=fw_metadata,
+        aot_config=aot_config,
+        trace_joint=True,
+        joint_fn_handle=joint_fn_handle,
     )
-
-    joint_fn_to_trace = subclass_tracing_info.plain_tensor_trace_fn
-    updated_joint_inputs = subclass_tracing_info.plain_tensor_args
-    updated_joint_inputs_descs = subclass_tracing_info.plain_tensor_args_descs
-
-    if not aot_config.disable_functionalization:
-        (joint_fn_to_trace, updated_joint_inputs, updated_joint_inputs_descs) = (
-            handle_effect_tokens_fn(
-                joint_fn_to_trace,
-                updated_joint_inputs,
-                updated_joint_inputs_descs,
-                meta=fw_metadata,
-                trace_joint=True,
-            )
-        )
+    joint_fn_to_trace = tracing_state.fn_to_trace
+    updated_joint_inputs = tracing_state.flat_args
+    updated_joint_inputs_descs = tracing_state.flat_args_descs
+    maybe_subclass_meta = tracing_state.maybe_subclass_meta
 
     # When we call _create_graph, this may mutate the metadata of joint
     # inputs.  But callers are expecting to get the original joint inputs.  So
@@ -503,19 +527,7 @@ def aot_dispatch_autograd_graph(
     # This destroys requires_grad/grad_fn information.  However, backends
     # beneath AOTAutograd are indifferent to this information, so it doesn't
     # matter.
-
-    fake_mode = detect_fake_mode()
-    if fake_mode:
-        saved_updated_joint_inputs = pytree.tree_map_only(
-            torch.Tensor, _detach_and_copy_item_memo, updated_joint_inputs
-        )
-    else:
-        saved_updated_joint_inputs = pytree.tree_map_only(
-            torch.Tensor, lambda t: t.detach(), updated_joint_inputs
-        )
-    maybe_subclass_meta = subclass_tracing_info.maybe_subclass_meta
-
-    fx_g = _create_graph(
+    fx_g, saved_updated_joint_inputs = _create_graph_and_save_traced_inputs(
         joint_fn_to_trace,
         updated_joint_inputs,
         updated_joint_inputs_descs,
@@ -564,11 +576,7 @@ def aot_dispatch_autograd_graph(
     # TODO: in AOTAutograd, we create metadata like _indices_of_inps_to_detach to detect
     # when we need to manually detach() some inputs in the forward.
     # Higher order ops might eventually need to do the same.
-    if aot_config.is_export:
-        if maybe_subclass_meta is not None:
-            raise AssertionError(
-                "aot_export_module does not support tensor subclass inputs for now."
-            )
+    _assert_export_graph_support(aot_config, maybe_subclass_meta)
     return (
         fx_g,
         saved_updated_joint_inputs,


### PR DESCRIPTION
## Summary
- deduplicate the shared graph-capture setup used by `aot_dispatch_base_graph` and `aot_dispatch_autograd_graph`
- keep the forward-only and autograd-specific cleanup passes in their existing call sites

## Root cause
- `graph_capture.py` had two large dispatch functions that repeated the same setup sequence: functionalization, subclass dispatch, effect token handling, saving detached tracing inputs, FX graph creation, and export subclass checks

## Proposed fix
- factor the shared setup into `_GraphCaptureTracingState` plus helpers for trace preparation, detached input saving, graph creation, and export subclass validation
- leave the divergent forward-only and backward-specific graph passes in `aot_dispatch_base_graph` and `aot_dispatch_autograd_graph` so their behavior stays explicit

## Why this is the right long term fix
- it centralizes the common tracing pipeline in one place, which reduces maintenance drift between the two entry points while preserving the narrow differences that actually matter for correctness

## Testing
- `python3 -m compileall torch/_functorch/_aot_autograd/graph_capture.py`
- isolated `python3` smoke test that executes the new helper functions directly from source with stubs to verify pipeline ordering, detach-before-trace behavior, and export guards

Drafted via Codex, published after manual review by @bobrenjc93