### PR TITLE
[inductor] Add a structured Triton codegen sidecar IR

### DIFF
--- a/test/inductor/test_codegen_triton.py
+++ b/test/inductor/test_codegen_triton.py
@@ -3,7 +3,6 @@ import contextlib
 import unittest
 
 import sympy
-
 import torch
 import torch._inductor.config as inductor_config
 from torch._inductor.codegen import triton_utils
@@ -15,8 +14,8 @@ from torch._inductor.codegen.common import (
     SizeArg,
 )
 from torch._inductor.codegen.triton import (
-    _materialize_trunc_to_float_expr,
     TritonKernelOverrides,
+    _materialize_trunc_to_float_expr,
 )
 from torch._inductor.codegen.triton_ir import StructuredTritonKernelIR
 from torch._inductor.dtype_propagation import DtypePropagationOpsHandler, promote_types
@@ -55,8 +54,8 @@ class TestCodegenTriton(InductorTestCase):
     @inductor_config.patch("triton.divisible_by_16", True)
     def test_config_of_sizearg(self):
         from torch._inductor.utils import (
-            get_triton_attrs_descriptor_version,
             TritonAttrsDescriptorVersion,
+            get_triton_attrs_descriptor_version,
         )
 
         two = sympy.Integer(2)
@@ -325,6 +324,9 @@ class TestCodegenTriton(InductorTestCase):
                     ],
                 )
 
+            def create_cse_var(self, name, bounds, dtype, shape):
+                return CSEVariable(name, bounds, dtype, shape)
+
             def record_codegen_operation(
                 self, *, name, args, kwargs, raw_value, result, section
             ):
@@ -362,6 +364,64 @@ class TestCodegenTriton(InductorTestCase):
         self.assertEqual(structured["nodes"][0]["outputs"][0]["name"], str(first))
         self.assertEqual(structured["nodes"][0]["inputs"][0]["value"], "tmp_lhs")
         self.assertEqual(structured["nodes"][0]["inputs"][1]["value"], "tmp_rhs")
+
+    def test_cse_proxy_records_partial_accumulate_with_named_args(self):
+        class FakeTritonKernel:
+            def __init__(self):
+                self.compute = IndentedBuffer()
+                self.cse = CSE()
+                self.current_node = None
+                self.node_to_bounds = None
+                self.saved_partial_accumulates = []
+                self.structured_ir = StructuredTritonKernelIR(
+                    kernel_name="fake_kernel",
+                    kernel_kind="FakeTritonKernel",
+                    numels={},
+                    range_trees=[],
+                )
+
+            def partial_accumulate(self, name, reduction_type, value, extra_meta):
+                self.saved_partial_accumulates.append(
+                    (name, reduction_type, value, extra_meta)
+                )
+
+            def record_codegen_partial_accumulate(
+                self, *, name, reduction_type, value, extra_meta
+            ):
+                self.structured_ir.record_node(
+                    kind="reduction",
+                    op="partial_accumulate",
+                    section="compute",
+                    inputs=(value,),
+                    attrs={
+                        "buffer": name,
+                        "reduction_type": reduction_type,
+                        "extra_meta": extra_meta,
+                    },
+                )
+
+        kernel = FakeTritonKernel()
+        proxy = CSEProxy(kernel, TritonKernelOverrides())
+        value = CSEVariable(
+            "tmp_val", ValueRanges.unknown(), torch.float32, ("XBLOCK",)
+        )
+
+        proxy.partial_accumulate(
+            "acc",
+            "sum",
+            value,
+            {"is_first_reduction": True},
+        )
+
+        self.assertEqual(
+            kernel.saved_partial_accumulates,
+            [("acc", "sum", value, {"is_first_reduction": True})],
+        )
+        structured = kernel.structured_ir.to_dict()
+        self.assertEqual(len(structured["nodes"]), 1)
+        self.assertEqual(structured["nodes"][0]["op"], "partial_accumulate")
+        self.assertEqual(structured["nodes"][0]["attrs"]["buffer"], "acc")
+        self.assertEqual(structured["nodes"][0]["attrs"]["reduction_type"], "sum")
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_codegen_triton.py
+++ b/test/inductor/test_codegen_triton.py
@@ -3,6 +3,7 @@ import contextlib
 import unittest
 
 import sympy
+
 import torch
 import torch._inductor.config as inductor_config
 from torch._inductor.codegen import triton_utils
@@ -14,8 +15,8 @@ from torch._inductor.codegen.common import (
     SizeArg,
 )
 from torch._inductor.codegen.triton import (
-    TritonKernelOverrides,
     _materialize_trunc_to_float_expr,
+    TritonKernelOverrides,
 )
 from torch._inductor.codegen.triton_ir import StructuredTritonKernelIR
 from torch._inductor.dtype_propagation import DtypePropagationOpsHandler, promote_types
@@ -54,8 +55,8 @@ class TestCodegenTriton(InductorTestCase):
     @inductor_config.patch("triton.divisible_by_16", True)
     def test_config_of_sizearg(self):
         from torch._inductor.utils import (
-            TritonAttrsDescriptorVersion,
             get_triton_attrs_descriptor_version,
+            TritonAttrsDescriptorVersion,
         )
 
         two = sympy.Integer(2)

--- a/test/inductor/test_codegen_triton.py
+++ b/test/inductor/test_codegen_triton.py
@@ -16,6 +16,7 @@ from torch._inductor.codegen.common import (
 )
 from torch._inductor.codegen.triton import (
     _materialize_trunc_to_float_expr,
+    TritonKernel,
     TritonKernelOverrides,
 )
 from torch._inductor.codegen.triton_ir import StructuredTritonKernelIR
@@ -423,6 +424,49 @@ class TestCodegenTriton(InductorTestCase):
         self.assertEqual(structured["nodes"][0]["op"], "partial_accumulate")
         self.assertEqual(structured["nodes"][0]["attrs"]["buffer"], "acc")
         self.assertEqual(structured["nodes"][0]["attrs"]["reduction_type"], "sum")
+
+    @unittest.skipUnless(HAS_GPU_AND_TRITON, "requires GPU and Triton")
+    def test_real_triton_codegen_exposes_structured_ir(self):
+        captured_structured_irs = []
+        original_codegen_kernel = TritonKernel.codegen_kernel
+
+        def capture_codegen_kernel(kernel, name=None):
+            code = original_codegen_kernel(kernel, name)
+            captured_structured_irs.append(kernel.structured_ir_to_dict())
+            return code
+
+        def fn(x):
+            return torch.argmax(x, dim=1)
+
+        x = torch.randn(64, 32, device=GPU_TYPE)
+        expected = fn(x)
+        with unittest.mock.patch.object(
+            TritonKernel,
+            "codegen_kernel",
+            new=capture_codegen_kernel,
+        ):
+            actual = torch.compile(fn)(x)
+
+        self.assertEqual(actual, expected)
+        self.assertTrue(captured_structured_irs)
+        self.assertTrue(
+            any(
+                any(node["op"] == "argmax" for node in structured_ir["nodes"])
+                for structured_ir in captured_structured_irs
+            )
+        )
+        self.assertTrue(
+            any(
+                any(
+                    value["name"].endswith("_index")
+                    and value["dtype"] is not None
+                    and value["shape"] is not None
+                    for scope in structured_ir["scopes"]
+                    for value in scope["loop_carried"]
+                )
+                for structured_ir in captured_structured_irs
+            )
+        )
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_codegen_triton.py
+++ b/test/inductor/test_codegen_triton.py
@@ -7,11 +7,18 @@ import sympy
 import torch
 import torch._inductor.config as inductor_config
 from torch._inductor.codegen import triton_utils
-from torch._inductor.codegen.common import CSEVariable, SizeArg
+from torch._inductor.codegen.common import (
+    CSE,
+    CSEProxy,
+    CSEVariable,
+    IndentedBuffer,
+    SizeArg,
+)
 from torch._inductor.codegen.triton import (
     _materialize_trunc_to_float_expr,
     TritonKernelOverrides,
 )
+from torch._inductor.codegen.triton_ir import StructuredTritonKernelIR
 from torch._inductor.dtype_propagation import DtypePropagationOpsHandler, promote_types
 from torch._inductor.graph import GraphLowering
 from torch._inductor.test_case import TestCase as InductorTestCase
@@ -243,6 +250,118 @@ class TestCodegenTriton(InductorTestCase):
         self.assertFalse(sv.statically_known_multiple_of(s4, 8))
         shape_env.axioms[sympy.Eq(Mod(s4, 8), 0)] = sympy.true
         self.assertTrue(sv.statically_known_multiple_of(s4, 8))
+
+    def test_structured_ir_tracks_reduction_loop_scope(self):
+        structured_ir = StructuredTritonKernelIR(
+            kernel_name=None,
+            kernel_kind="TritonKernel",
+            numels={"x": sympy.Integer(16), "r0_": sympy.Integer(8)},
+            range_trees=[
+                {
+                    "name": "xindex",
+                    "prefix": "x",
+                    "numel": sympy.Integer(16),
+                    "is_loop": False,
+                    "is_reduction": False,
+                    "grid_dim": 0,
+                    "tensor_dim": 0,
+                },
+                {
+                    "name": "r0_index",
+                    "prefix": "r0_",
+                    "numel": sympy.Integer(8),
+                    "is_loop": True,
+                    "is_reduction": True,
+                    "grid_dim": None,
+                    "tensor_dim": 1,
+                },
+            ],
+        )
+
+        structured_ir.register_loop_carried(
+            CSEVariable("accum0", ValueRanges.unknown(), torch.float32, ("XBLOCK",))
+        )
+        with structured_ir.scope(
+            "masked", "masked", section="compute", attrs={"mask": "xmask"}
+        ):
+            structured_ir.record_node(
+                kind="op",
+                op="add",
+                section="compute",
+                inputs=("tmp0", "tmp1"),
+                outputs=("tmp2",),
+                attrs={"expr": "(tmp0 + tmp1)"},
+                dedupe_outputs=True,
+            )
+
+        structured = structured_ir.to_dict()
+        self.assertEqual(structured["section_scopes"]["compute"], 1)
+        self.assertEqual(structured["scopes"][1]["kind"], "loop")
+        self.assertEqual(structured["scopes"][1]["loop_carried"][0]["name"], "accum0")
+        self.assertEqual(structured["scopes"][2]["parent"], 1)
+        self.assertEqual(structured["nodes"][0]["scope"], 2)
+
+    def test_cse_proxy_records_structured_ir_for_triton_ops(self):
+        class FakeTritonKernel:
+            def __init__(self):
+                self.compute = IndentedBuffer()
+                self.cse = CSE()
+                self.current_node = None
+                self.node_to_bounds = None
+                self.structured_ir = StructuredTritonKernelIR(
+                    kernel_name="fake_kernel",
+                    kernel_kind="FakeTritonKernel",
+                    numels={"x": sympy.Integer(8)},
+                    range_trees=[
+                        {
+                            "name": "xindex",
+                            "prefix": "x",
+                            "numel": sympy.Integer(8),
+                            "is_loop": False,
+                            "is_reduction": False,
+                            "grid_dim": 0,
+                            "tensor_dim": 0,
+                        }
+                    ],
+                )
+
+            def record_codegen_operation(
+                self, *, name, args, kwargs, raw_value, result, section
+            ):
+                self.structured_ir.record_node(
+                    kind="op",
+                    op=name,
+                    section=section,
+                    inputs=args,
+                    outputs=result,
+                    attrs={"expr": raw_value, "kwargs": kwargs},
+                    dedupe_outputs=True,
+                )
+
+        kernel = FakeTritonKernel()
+        proxy = CSEProxy(kernel, TritonKernelOverrides())
+        lhs = CSEVariable("tmp_lhs", ValueRanges.unknown(), torch.float32, ("XBLOCK",))
+        rhs = CSEVariable("tmp_rhs", ValueRanges.unknown(), torch.float32, ("XBLOCK",))
+
+        with (
+            unittest.mock.patch(
+                "torch._inductor.codegen.common.get_current_backend",
+                return_value="triton",
+            ),
+            V.set_kernel_handler(kernel),
+            V.set_ops_handler(proxy),
+        ):
+            first = V.ops.add(lhs, rhs)
+            second = V.ops.add(lhs, rhs)
+
+        self.assertEqual(str(first), str(second))
+        self.assertEqual(len(kernel.compute._lines), 1)
+        structured = kernel.structured_ir.to_dict()
+        self.assertEqual(len(structured["nodes"]), 1)
+        self.assertEqual(structured["nodes"][0]["op"], "add")
+        self.assertEqual(structured["nodes"][0]["outputs"][0]["name"], str(first))
+        self.assertEqual(structured["nodes"][0]["inputs"][0]["value"], "tmp_lhs")
+        self.assertEqual(structured["nodes"][0]["inputs"][1]["value"], "tmp_rhs")
 
 
 if __name__ == "__main__":

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -2718,7 +2718,20 @@ class CSEProxy(DefaultHandler):
 
             return csevar
 
-        return pytree.tree_map(do_cse, value)
+        result = pytree.tree_map(do_cse, value)
+        record_codegen_operation = getattr(
+            self.kernel, "record_codegen_operation", None
+        )
+        if record_codegen_operation is not None:
+            record_codegen_operation(
+                name=name,
+                args=args,
+                kwargs=kwargs,
+                raw_value=value,
+                result=result,
+                section="compute",
+            )
+        return result
 
     def _bound_variable(self, name: str, *args: Any, **kwargs: Any) -> ValueRanges[Any]:
         """
@@ -2834,7 +2847,11 @@ class CSEProxy(DefaultHandler):
             # keep the actual buffer around
             V.kernel.must_keep_buffers.add(name)
         if free_symbol_is_type(index, SymT.TMP):
-            return self.kernel.indirect_load(name, index)
+            out = self.kernel.indirect_load(name, index)
+            record_codegen_load = getattr(self.kernel, "record_codegen_load", None)
+            if record_codegen_load is not None:
+                record_codegen_load(name=name, index=index, result=out)
+            return out
         store_cache = self.kernel.cse.store_cache
         if name in store_cache:
             return store_cache[name]
@@ -2843,6 +2860,9 @@ class CSEProxy(DefaultHandler):
         # cse cache.
         if out.use_count == 1:
             self.kernel.num_load += 1
+        record_codegen_load = getattr(self.kernel, "record_codegen_load", None)
+        if record_codegen_load is not None:
+            record_codegen_load(name=name, index=index, result=out)
         return out
 
     def _update_store_cache(self, name: str, value: CSEVariable) -> None:
@@ -2862,6 +2882,9 @@ class CSEProxy(DefaultHandler):
         if name not in V.graph.removed_buffers:
             self.kernel.store(name, index, value, mode=mode)
             self.kernel.num_store += 1
+            record_codegen_store = getattr(self.kernel, "record_codegen_store", None)
+            if record_codegen_store is not None:
+                record_codegen_store(name=name, index=index, value=value, mode=mode)
 
     def device_assert_async(self, cond: CSEVariable, msg: str) -> None:
         self.kernel.device_assert_async(cond, msg)
@@ -2869,6 +2892,11 @@ class CSEProxy(DefaultHandler):
     # pyrefly: ignore [bad-override]
     def partial_accumulate(self, *args: Any) -> None:
         self.kernel.partial_accumulate(*args)
+        record_codegen_partial_accumulate = getattr(
+            self.kernel, "record_codegen_partial_accumulate", None
+        )
+        if record_codegen_partial_accumulate is not None:
+            record_codegen_partial_accumulate(*args)
 
     def store_reduction(self, name: str, index: sympy.Expr, value: CSEVariable) -> None:
         self.kernel.store_buffer_names.add(name)
@@ -2876,7 +2904,13 @@ class CSEProxy(DefaultHandler):
 
         if name not in V.graph.removed_buffers:
             self.kernel.num_store += 1
-            return self.kernel.store_reduction(name, index, value)
+            result = self.kernel.store_reduction(name, index, value)
+            record_codegen_store_reduction = getattr(
+                self.kernel, "record_codegen_store_reduction", None
+            )
+            if record_codegen_store_reduction is not None:
+                record_codegen_store_reduction(name=name, index=index, value=value)
+            return result
 
     def reduction(
         self,
@@ -2886,7 +2920,17 @@ class CSEProxy(DefaultHandler):
         value: CSEVariable | tuple[CSEVariable, ...],
     ) -> CSEVariable | tuple[CSEVariable, ...]:
         self.kernel.num_reduction += 1
-        return self.kernel.reduction(dtype, src_dtype, reduction_type, value)
+        result = self.kernel.reduction(dtype, src_dtype, reduction_type, value)
+        record_codegen_reduction = getattr(self.kernel, "record_codegen_reduction", None)
+        if record_codegen_reduction is not None:
+            record_codegen_reduction(
+                dtype=dtype,
+                src_dtype=src_dtype,
+                reduction_type=reduction_type,
+                value=value,
+                result=result,
+            )
+        return result
 
     def scan(
         self,
@@ -2897,7 +2941,13 @@ class CSEProxy(DefaultHandler):
         ],
         values: tuple[CSEVariable, ...],
     ) -> tuple[CSEVariable, ...]:
-        return self.kernel.scan(dtypes, combine_fn, values)
+        result = self.kernel.scan(dtypes, combine_fn, values)
+        record_codegen_scan = getattr(self.kernel, "record_codegen_scan", None)
+        if record_codegen_scan is not None:
+            record_codegen_scan(
+                dtypes=dtypes, combine_fn=combine_fn, values=values, result=result
+            )
+        return result
 
     def sort(
         self,
@@ -2906,7 +2956,17 @@ class CSEProxy(DefaultHandler):
         stable: bool,
         descending: bool,
     ) -> tuple[CSEVariable, ...]:
-        return self.kernel.sort(dtypes, values, stable, descending)
+        result = self.kernel.sort(dtypes, values, stable, descending)
+        record_codegen_sort = getattr(self.kernel, "record_codegen_sort", None)
+        if record_codegen_sort is not None:
+            record_codegen_sort(
+                dtypes=dtypes,
+                values=values,
+                stable=stable,
+                descending=descending,
+                result=result,
+            )
+        return result
 
     def bucketize(
         self,
@@ -2978,7 +3038,7 @@ class CSEProxy(DefaultHandler):
         would re-index offsets in a non-decreasing order (e.g. the second output
         of torch.sort(offsets)).  Otherwise, the result is undefined.
         """
-        return self.kernel.bucketize(
+        result = self.kernel.bucketize(
             values,
             boundaries,
             boundary_indices,
@@ -2987,3 +3047,16 @@ class CSEProxy(DefaultHandler):
             sorter,
             sorter_indices,
         )
+        record_codegen_bucketize = getattr(self.kernel, "record_codegen_bucketize", None)
+        if record_codegen_bucketize is not None:
+            record_codegen_bucketize(
+                values=values,
+                boundaries=boundaries,
+                boundary_indices=boundary_indices,
+                indexing_dtype=indexing_dtype,
+                right=right,
+                sorter=sorter,
+                sorter_indices=sorter_indices,
+                result=result,
+            )
+        return result

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -13,12 +13,12 @@ import os
 import re
 import tempfile
 from abc import ABC, abstractmethod
-from enum import Enum, auto
+from enum import auto, Enum
 from itertools import chain
-from typing import TYPE_CHECKING, Any, ClassVar, Generic, NamedTuple, cast
+from typing import Any, cast, ClassVar, Generic, NamedTuple, TYPE_CHECKING
+from typing_extensions import Self, TypeVar
 
 import sympy
-from typing_extensions import Self, TypeVar
 
 import torch
 import torch.fx
@@ -28,21 +28,21 @@ from torch.utils._config_module import ConfigModule
 from torch.utils._ordered_set import OrderedSet
 from torch.utils._sympy.numbers import int_oo
 from torch.utils._sympy.printers import PythonPrinter as _PythonPrinter
-from torch.utils._sympy.symbol import SymT, free_symbol_is_type, symbol_is_type
-from torch.utils._sympy.value_ranges import ValueRanges, bound_sympy
+from torch.utils._sympy.symbol import free_symbol_is_type, symbol_is_type, SymT
+from torch.utils._sympy.value_ranges import bound_sympy, ValueRanges
 
 from .. import config, metrics
 from ..dtype_propagation import DtypePropagationOpsHandler
 from ..ops_handler import BasicMathOpsMixin, DefaultHandler
 from ..shape_propagation import ShapePropagationOpsHandler
 from ..utils import (
-    DeferredLineBase,
-    IndentedBuffer,
-    ScopedDict,
     boolean_ops,
+    DeferredLineBase,
     generate_assert,
     get_current_backend,
+    IndentedBuffer,
     ir_dataclass,
+    ScopedDict,
     sympy_dot,
     sympy_index_symbol,
     sympy_subs,
@@ -51,13 +51,14 @@ from ..utils import (
 )
 from ..virtualized import (
     NullHandler,
+    ops,
     OpsHandler,
     OpsValue,
     ReductionType,
     StoreMode,
     V,
-    ops,
 )
+
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator, MutableMapping, Sequence
@@ -722,7 +723,7 @@ def check_dtype(
     if config.test_configs.runtime_triton_dtype_assert and backend == "triton":
         buffer.writeline(f"tl.static_assert({var}.dtype == {triton_type(dtype)})")
     elif config.test_configs.static_cpp_dtype_assert and backend == "cpp":
-        from .cpp_utils import DTYPE_TO_CPP, CppCSEVariable
+        from .cpp_utils import CppCSEVariable, DTYPE_TO_CPP
 
         assert isinstance(var, CppCSEVariable), type(var)
         if dtype == torch.bool:

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -13,12 +13,12 @@ import os
 import re
 import tempfile
 from abc import ABC, abstractmethod
-from enum import auto, Enum
+from enum import Enum, auto
 from itertools import chain
-from typing import Any, cast, ClassVar, Generic, NamedTuple, TYPE_CHECKING
-from typing_extensions import Self, TypeVar
+from typing import TYPE_CHECKING, Any, ClassVar, Generic, NamedTuple, cast
 
 import sympy
+from typing_extensions import Self, TypeVar
 
 import torch
 import torch.fx
@@ -28,21 +28,21 @@ from torch.utils._config_module import ConfigModule
 from torch.utils._ordered_set import OrderedSet
 from torch.utils._sympy.numbers import int_oo
 from torch.utils._sympy.printers import PythonPrinter as _PythonPrinter
-from torch.utils._sympy.symbol import free_symbol_is_type, symbol_is_type, SymT
-from torch.utils._sympy.value_ranges import bound_sympy, ValueRanges
+from torch.utils._sympy.symbol import SymT, free_symbol_is_type, symbol_is_type
+from torch.utils._sympy.value_ranges import ValueRanges, bound_sympy
 
 from .. import config, metrics
 from ..dtype_propagation import DtypePropagationOpsHandler
 from ..ops_handler import BasicMathOpsMixin, DefaultHandler
 from ..shape_propagation import ShapePropagationOpsHandler
 from ..utils import (
-    boolean_ops,
     DeferredLineBase,
+    IndentedBuffer,
+    ScopedDict,
+    boolean_ops,
     generate_assert,
     get_current_backend,
-    IndentedBuffer,
     ir_dataclass,
-    ScopedDict,
     sympy_dot,
     sympy_index_symbol,
     sympy_subs,
@@ -51,14 +51,13 @@ from ..utils import (
 )
 from ..virtualized import (
     NullHandler,
-    ops,
     OpsHandler,
     OpsValue,
     ReductionType,
     StoreMode,
     V,
+    ops,
 )
-
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator, MutableMapping, Sequence
@@ -723,7 +722,7 @@ def check_dtype(
     if config.test_configs.runtime_triton_dtype_assert and backend == "triton":
         buffer.writeline(f"tl.static_assert({var}.dtype == {triton_type(dtype)})")
     elif config.test_configs.static_cpp_dtype_assert and backend == "cpp":
-        from .cpp_utils import CppCSEVariable, DTYPE_TO_CPP
+        from .cpp_utils import DTYPE_TO_CPP, CppCSEVariable
 
         assert isinstance(var, CppCSEVariable), type(var)
         if dtype == torch.bool:
@@ -1290,9 +1289,9 @@ pointwise_overrides_data: dict[str, OverridesData] = dict(
     mul_rn=OverridesData(
         type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT,
         cpp=lambda x, y: f"({x}) * ({y})",  # C++ doesn't need special handling
-        triton=lambda x, y: f"({x}) * ({y})"
-        if torch.version.hip
-        else f"libdevice.mul_rn({x}, {y})",
+        triton=lambda x, y: (
+            f"({x}) * ({y})" if torch.version.hip else f"libdevice.mul_rn({x}, {y})"
+        ),
         name="mul_rn",
     ),
     # erfinv, exp2, expit, gammaln
@@ -1381,8 +1380,9 @@ pointwise_overrides_data: dict[str, OverridesData] = dict(
     ),
     polygamma=OverridesData(
         type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT,
-        cpp=lambda x,
-        y: f"{x} == 0 ? calc_digamma({y}) : ({x} == 1 ? trigamma({y}) : calc_polygamma({y}, {x}))",
+        cpp=lambda x, y: (
+            f"{x} == 0 ? calc_digamma({y}) : ({x} == 1 ? trigamma({y}) : calc_polygamma({y}, {x}))"
+        ),
         name="polygamma",
     ),
     # psi - alias to digamma
@@ -2854,6 +2854,8 @@ class CSEProxy(DefaultHandler):
             return out
         store_cache = self.kernel.cse.store_cache
         if name in store_cache:
+            # Store-cache hits intentionally reuse the producer of the forwarded
+            # value instead of emitting a synthetic load node in the sidecar IR.
             return store_cache[name]
         out = self.kernel.load(name, index)
         # count load that is not in the store_cache, and also not in the
@@ -2890,13 +2892,24 @@ class CSEProxy(DefaultHandler):
         self.kernel.device_assert_async(cond, msg)
 
     # pyrefly: ignore [bad-override]
-    def partial_accumulate(self, *args: Any) -> None:
-        self.kernel.partial_accumulate(*args)
+    def partial_accumulate(
+        self,
+        name: str,
+        reduction_type: ReductionType,
+        value: CSEVariable,
+        extra_meta: dict[str, Any],
+    ) -> None:
+        self.kernel.partial_accumulate(name, reduction_type, value, extra_meta)
         record_codegen_partial_accumulate = getattr(
             self.kernel, "record_codegen_partial_accumulate", None
         )
         if record_codegen_partial_accumulate is not None:
-            record_codegen_partial_accumulate(*args)
+            record_codegen_partial_accumulate(
+                name=name,
+                reduction_type=reduction_type,
+                value=value,
+                extra_meta=extra_meta,
+            )
 
     def store_reduction(self, name: str, index: sympy.Expr, value: CSEVariable) -> None:
         self.kernel.store_buffer_names.add(name)
@@ -2921,7 +2934,9 @@ class CSEProxy(DefaultHandler):
     ) -> CSEVariable | tuple[CSEVariable, ...]:
         self.kernel.num_reduction += 1
         result = self.kernel.reduction(dtype, src_dtype, reduction_type, value)
-        record_codegen_reduction = getattr(self.kernel, "record_codegen_reduction", None)
+        record_codegen_reduction = getattr(
+            self.kernel, "record_codegen_reduction", None
+        )
         if record_codegen_reduction is not None:
             record_codegen_reduction(
                 dtype=dtype,
@@ -3047,7 +3062,9 @@ class CSEProxy(DefaultHandler):
             sorter,
             sorter_indices,
         )
-        record_codegen_bucketize = getattr(self.kernel, "record_codegen_bucketize", None)
+        record_codegen_bucketize = getattr(
+            self.kernel, "record_codegen_bucketize", None
+        )
         if record_codegen_bucketize is not None:
             record_codegen_bucketize(
                 values=values,

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -16,7 +16,7 @@ import textwrap
 from abc import abstractmethod
 from collections.abc import Callable, Iterable, Sequence
 from functools import lru_cache
-from typing import Any, cast, TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 import sympy
 from sympy.printing.precedence import PRECEDENCE
@@ -41,21 +41,21 @@ from torch.utils._triton import (
     has_triton_stable_tma_api,
 )
 
-from ...utils._sympy.symbol import free_symbol_is_type, prefix_str, symbol_is_type, SymT
+from ...utils._sympy.symbol import SymT, free_symbol_is_type, prefix_str, symbol_is_type
 from ...utils._sympy.value_ranges import ValueRanges
 from .. import config, ir, metrics, utils
 from ..async_compile import AsyncCompile
-from ..codecache import code_hash, get_path, PyCodeCache, write_atomic
+from ..codecache import PyCodeCache, code_hash, get_path, write_atomic
 from ..debug import set_kernel_post_grad_provenance_tracing
 from ..ops_handler import DefaultHandler
 from ..runtime import triton_heuristics
 from ..runtime.benchmarking import benchmarker
 from ..runtime.hints import (
+    TRITON_MAX_BLOCK,
+    TRITON_MAX_RSPLIT,
     AutotuneHint,
     DeviceProperties,
     ReductionHint,
-    TRITON_MAX_BLOCK,
-    TRITON_MAX_RSPLIT,
 )
 from ..runtime.runtime_utils import get_max_y_grid, next_power_of_2
 from ..scheduler import (
@@ -67,13 +67,13 @@ from ..scheduler import (
 )
 from ..shape_propagation import get_broadcasted_shape
 from ..utils import (
-    cache_on_self,
     DelayReplaceLine,
+    Placeholder,
+    cache_on_self,
     get_bounds_index_expr,
     get_fused_kernel_name,
     get_kernel_metadata,
     is_welford_reduction,
-    Placeholder,
     prefix_is_reduction,
     sympy_dot,
     sympy_product,
@@ -82,19 +82,19 @@ from ..utils import (
     triton_version_uses_attrs_dict,
     upcast_compute_type,
 )
-from ..virtualized import _ops as ops, ReductionType, StoreMode, V
+from ..virtualized import ReductionType, StoreMode, V
+from ..virtualized import _ops as ops
 from ..wrapper_benchmark import get_kernel_category_by_source_code
 from .block_analysis import BlockPatternMatcher
 from .common import (
+    CSE,
     ArgName,
     BackendFeature,
     ConstexprArg,
-    CSE,
     CSEVariable,
     DeferredLine,
     IndentedBuffer,
     InplacedBuffer,
-    is_buffer_removed,
     OpOverrides,
     PythonPrinter,
     RemovedArg,
@@ -102,16 +102,18 @@ from .common import (
     TensorArg,
     WorkspaceArg,
     WorkspaceZeroMode,
+    is_buffer_removed,
 )
 from .simd import (
-    constant_repr,
     IterationRanges,
     IterationRangesEntry,
     IterationRangesRoot,
     PartialAccumulate,
     SIMDKernel,
     SIMDScheduling,
+    constant_repr,
 )
+from .triton_ir import StructuredTritonKernelIR
 from .triton_utils import (
     config_of,
     equal_1_arg_indices,
@@ -119,9 +121,7 @@ from .triton_utils import (
     should_unwrap_unspec_arg,
     signature_to_meta,
 )
-from .triton_ir import StructuredTritonKernelIR
 from .wrapper import SymbolicCallArg
-
 
 if TYPE_CHECKING:
     from types import ModuleType

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -16,7 +16,7 @@ import textwrap
 from abc import abstractmethod
 from collections.abc import Callable, Iterable, Sequence
 from functools import lru_cache
-from typing import TYPE_CHECKING, Any, TypeVar, cast
+from typing import Any, cast, TYPE_CHECKING, TypeVar
 
 import sympy
 from sympy.printing.precedence import PRECEDENCE
@@ -41,21 +41,21 @@ from torch.utils._triton import (
     has_triton_stable_tma_api,
 )
 
-from ...utils._sympy.symbol import SymT, free_symbol_is_type, prefix_str, symbol_is_type
+from ...utils._sympy.symbol import free_symbol_is_type, prefix_str, symbol_is_type, SymT
 from ...utils._sympy.value_ranges import ValueRanges
 from .. import config, ir, metrics, utils
 from ..async_compile import AsyncCompile
-from ..codecache import PyCodeCache, code_hash, get_path, write_atomic
+from ..codecache import code_hash, get_path, PyCodeCache, write_atomic
 from ..debug import set_kernel_post_grad_provenance_tracing
 from ..ops_handler import DefaultHandler
 from ..runtime import triton_heuristics
 from ..runtime.benchmarking import benchmarker
 from ..runtime.hints import (
-    TRITON_MAX_BLOCK,
-    TRITON_MAX_RSPLIT,
     AutotuneHint,
     DeviceProperties,
     ReductionHint,
+    TRITON_MAX_BLOCK,
+    TRITON_MAX_RSPLIT,
 )
 from ..runtime.runtime_utils import get_max_y_grid, next_power_of_2
 from ..scheduler import (
@@ -67,13 +67,13 @@ from ..scheduler import (
 )
 from ..shape_propagation import get_broadcasted_shape
 from ..utils import (
-    DelayReplaceLine,
-    Placeholder,
     cache_on_self,
+    DelayReplaceLine,
     get_bounds_index_expr,
     get_fused_kernel_name,
     get_kernel_metadata,
     is_welford_reduction,
+    Placeholder,
     prefix_is_reduction,
     sympy_dot,
     sympy_product,
@@ -82,19 +82,19 @@ from ..utils import (
     triton_version_uses_attrs_dict,
     upcast_compute_type,
 )
-from ..virtualized import ReductionType, StoreMode, V
-from ..virtualized import _ops as ops
+from ..virtualized import _ops as ops, ReductionType, StoreMode, V
 from ..wrapper_benchmark import get_kernel_category_by_source_code
 from .block_analysis import BlockPatternMatcher
 from .common import (
-    CSE,
     ArgName,
     BackendFeature,
     ConstexprArg,
+    CSE,
     CSEVariable,
     DeferredLine,
     IndentedBuffer,
     InplacedBuffer,
+    is_buffer_removed,
     OpOverrides,
     PythonPrinter,
     RemovedArg,
@@ -102,16 +102,15 @@ from .common import (
     TensorArg,
     WorkspaceArg,
     WorkspaceZeroMode,
-    is_buffer_removed,
 )
 from .simd import (
+    constant_repr,
     IterationRanges,
     IterationRangesEntry,
     IterationRangesRoot,
     PartialAccumulate,
     SIMDKernel,
     SIMDScheduling,
-    constant_repr,
 )
 from .triton_ir import StructuredTritonKernelIR
 from .triton_utils import (
@@ -122,6 +121,7 @@ from .triton_utils import (
     signature_to_meta,
 )
 from .wrapper import SymbolicCallArg
+
 
 if TYPE_CHECKING:
     from types import ModuleType
@@ -2911,6 +2911,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
 
     def record_codegen_partial_accumulate(
         self,
+        *,
         name: str,
         reduction_type: str,
         value: CSEVariable,

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -119,6 +119,7 @@ from .triton_utils import (
     should_unwrap_unspec_arg,
     signature_to_meta,
 )
+from .triton_ir import StructuredTritonKernelIR
 from .wrapper import SymbolicCallArg
 
 
@@ -2161,7 +2162,13 @@ class TritonKernelOverrides(TritonOverrides):
 
         value = None if need_where else other
 
-        with V.kernel.mask_loads(mask, value=value) as new_mask:
+        structured_masked_scope = getattr(V.kernel, "structured_masked_scope", None)
+        masked_scope = (
+            structured_masked_scope(mask, other)
+            if structured_masked_scope is not None
+            else contextlib.nullcontext()
+        )
+        with masked_scope, V.kernel.mask_loads(mask, value=value) as new_mask:
             result = body()
 
         if need_where:
@@ -2782,6 +2789,12 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             self.init_cooperative_reduction()
 
         self.codegen_range_tree()
+        self.structured_ir = StructuredTritonKernelIR(
+            kernel_name=self.kernel_name,
+            kernel_kind=type(self).__name__,
+            numels=self.numels,
+            range_trees=self._structured_range_trees(),
+        )
 
         if self.cooperative_reduction:
             self.init_cooperative_reduction_mask()
@@ -2789,6 +2802,234 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         self.has_load_with_contiguous_rdim = False
         # We track the store name since a store can be canceled later
         self.stores_with_contiguous_rdim: list[str] = []
+
+    def _structured_range_trees(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "name": tree.name,
+                "prefix": tree.prefix,
+                "numel": tree.numel,
+                "is_loop": tree.is_loop,
+                "is_reduction": tree.is_reduction,
+                "grid_dim": tree.grid_dim,
+                "tensor_dim": tree.tensor_dim,
+            }
+            for tree in self.range_trees
+        ]
+
+    def _structured_ir_origin(self) -> str | None:
+        if self.current_node is None:
+            return None
+        return self.current_node.get_name()
+
+    def _record_structured_ir(
+        self,
+        *,
+        kind: str,
+        op: str,
+        section: str,
+        inputs: Any = (),
+        outputs: Any = (),
+        attrs: dict[str, Any] | None = None,
+        dedupe_outputs: bool = False,
+    ) -> None:
+        self.structured_ir.record_node(
+            kind=kind,
+            op=op,
+            section=section,
+            inputs=inputs,
+            outputs=outputs,
+            attrs=attrs,
+            origin=self._structured_ir_origin(),
+            dedupe_outputs=dedupe_outputs,
+        )
+
+    def structured_ir_to_dict(self) -> dict[str, Any]:
+        return self.structured_ir.to_dict()
+
+    def structured_masked_scope(
+        self, mask: CSEVariable | str | None, other: Any
+    ) -> contextlib.AbstractContextManager[None]:
+        return self.structured_ir.scope(
+            "masked",
+            "masked",
+            section="compute",
+            attrs={"mask": mask, "other": other},
+        )
+
+    def record_codegen_operation(
+        self,
+        *,
+        name: str,
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+        raw_value: Any,
+        result: Any,
+        section: str,
+    ) -> None:
+        self._record_structured_ir(
+            kind="op",
+            op=name,
+            section=section,
+            inputs=args,
+            outputs=result,
+            attrs={"expr": raw_value, "kwargs": kwargs},
+            dedupe_outputs=True,
+        )
+
+    def record_codegen_load(
+        self, *, name: str, index: sympy.Expr, result: CSEVariable
+    ) -> None:
+        attrs: dict[str, Any] = {"buffer": name, "index": index}
+        if hasattr(result, "mask_vars"):
+            attrs["mask_vars"] = sorted(map(str, result.mask_vars))
+        self._record_structured_ir(
+            kind="memory",
+            op="load",
+            section="loads",
+            inputs=(index,),
+            outputs=(result,),
+            attrs=attrs,
+            dedupe_outputs=True,
+        )
+
+    def record_codegen_store(
+        self,
+        *,
+        name: str,
+        index: sympy.Expr,
+        value: CSEVariable,
+        mode: StoreMode,
+    ) -> None:
+        self._record_structured_ir(
+            kind="memory",
+            op="store",
+            section="stores",
+            inputs=(value, index),
+            attrs={"buffer": name, "mode": mode},
+        )
+
+    def record_codegen_partial_accumulate(
+        self,
+        name: str,
+        reduction_type: str,
+        value: CSEVariable,
+        extra_meta: dict[str, Any],
+    ) -> None:
+        self._record_structured_ir(
+            kind="reduction",
+            op="partial_accumulate",
+            section="compute",
+            inputs=(value,),
+            attrs={
+                "buffer": name,
+                "reduction_type": reduction_type,
+                "extra_meta": extra_meta,
+            },
+        )
+
+    def record_codegen_store_reduction(
+        self, *, name: str, index: sympy.Expr, value: CSEVariable
+    ) -> None:
+        self._record_structured_ir(
+            kind="memory",
+            op="store_reduction",
+            section="post_loop_store",
+            inputs=(value, index),
+            attrs={"buffer": name},
+        )
+
+    def record_codegen_reduction(
+        self,
+        *,
+        dtype: torch.dtype,
+        src_dtype: torch.dtype,
+        reduction_type: ReductionType,
+        value: CSEVariable | tuple[CSEVariable, ...],
+        result: CSEVariable | tuple[CSEVariable, ...],
+    ) -> None:
+        self._record_structured_ir(
+            kind="reduction",
+            op=reduction_type,
+            section="compute",
+            inputs=value,
+            outputs=result,
+            attrs={
+                "dtype": dtype,
+                "src_dtype": src_dtype,
+                "persistent_reduction": self.persistent_reduction,
+                "cooperative_reduction": self.cooperative_reduction,
+            },
+            dedupe_outputs=True,
+        )
+
+    def record_codegen_scan(
+        self,
+        *,
+        dtypes: tuple[torch.dtype, ...],
+        combine_fn: Callable[..., Any],
+        values: tuple[CSEVariable, ...],
+        result: tuple[CSEVariable, ...],
+    ) -> None:
+        self._record_structured_ir(
+            kind="scan",
+            op="scan",
+            section="compute",
+            inputs=values,
+            outputs=result,
+            attrs={"dtypes": dtypes, "combine_fn": combine_fn},
+            dedupe_outputs=True,
+        )
+
+    def record_codegen_sort(
+        self,
+        *,
+        dtypes: tuple[torch.dtype, ...],
+        values: tuple[CSEVariable, ...],
+        stable: bool,
+        descending: bool,
+        result: tuple[CSEVariable, ...],
+    ) -> None:
+        self._record_structured_ir(
+            kind="sort",
+            op="sort",
+            section="compute",
+            inputs=values,
+            outputs=result,
+            attrs={
+                "dtypes": dtypes,
+                "stable": stable,
+                "descending": descending,
+            },
+            dedupe_outputs=True,
+        )
+
+    def record_codegen_bucketize(
+        self,
+        *,
+        values: CSEVariable,
+        boundaries: tuple[str, sympy.Expr, sympy.Expr, sympy.Expr],
+        boundary_indices: CSEVariable,
+        indexing_dtype: torch.dtype,
+        right: bool,
+        sorter: tuple[str, sympy.Expr] | None,
+        sorter_indices: CSEVariable | None,
+        result: CSEVariable,
+    ) -> None:
+        self._record_structured_ir(
+            kind="search",
+            op="bucketize",
+            section="compute",
+            inputs=(values, boundary_indices, sorter_indices),
+            outputs=(result,),
+            attrs={
+                "boundaries": boundaries,
+                "indexing_dtype": indexing_dtype,
+                "right": right,
+                "sorter": sorter,
+            },
+            dedupe_outputs=True,
+        )
 
     @staticmethod
     def _has_stride1_on_rdim(index) -> bool:
@@ -4366,6 +4607,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 dtype=torch_acc_type,
                 shape=tuple(self.dense_size_list()),
             )
+            self.structured_ir.register_loop_carried(accumulator)
             default = ir.Reduction.default_accumulator(reduction_type, src_dtype)
             default = self._map_tuple_or_scalar(constant_repr, default)
             if not isinstance(default, tuple):
@@ -4387,6 +4629,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
 
             if reduction_type in ("argmax", "argmin"):
                 accumulator_index = f"_{result_var}_index"
+                self.structured_ir.register_loop_carried(accumulator_index)
                 index_dtype = self.features.select_index_dtype()
                 self.body.writeline(
                     f"{accumulator_index} = tl.full({self.dense_size_str()}, "
@@ -4418,6 +4661,9 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             elif reduction_type == "online_softmax_reduce":
                 accumulator_max = f"_{result_var}_max"
                 accumulator_sum = f"_{result_var}_sum"
+                self.structured_ir.register_loop_carried(
+                    accumulator_max, accumulator_sum
+                )
 
                 # setup accumulator
                 self.body.writeline(
@@ -4643,6 +4889,9 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             shape=tuple(self.dense_size_list()),
             dtype=acc_type,
             bounds=ValueRanges.unknown(),
+        )
+        self.structured_ir.register_loop_carried(
+            accumulator, accumulator_m2, accumulator_weight
         )
         self.body.writeline(
             f"{accumulator} = tl.zeros({self.dense_size_str()}, {acc_type})"
@@ -4952,6 +5201,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 )
 
                 accumulators.append(accumulator)
+                self.structured_ir.register_loop_carried(accumulator)
 
         def csv(values):
             return " ".join(f"{value}," for value in values)
@@ -5146,6 +5396,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 accumname2var[name] = self.cse.namedvar(
                     name, dtype=torch.float, shape=("1", "R0_BLOCK")
                 )
+                self.structured_ir.register_loop_carried(accumname2var[name])
             self.body.writeline("split_size = min(RSPLIT_SIZE, xnumel - xoffset)")
             self.body.writeline(
                 "for _ in tl.range(0, split_size, XBLOCK, num_stages=NUM_STAGES):"
@@ -5848,6 +6099,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             """
         code.splice(heuristics_line)
         kernel_name = name or str(Placeholder.KERNEL_NAME)
+        self.structured_ir.set_kernel_name(kernel_name)
         code.writeline(
             f"def {kernel_name}({', '.join(x.full_name() for x in argdefs)}):"
         )

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -112,7 +112,7 @@ from .simd import (
     SIMDKernel,
     SIMDScheduling,
 )
-from .triton_ir import StructuredTritonKernelIR
+from .triton_ir import StructuredTritonKernelIR, StructuredTritonValue
 from .triton_utils import (
     config_of,
     equal_1_arg_indices,
@@ -2162,13 +2162,10 @@ class TritonKernelOverrides(TritonOverrides):
 
         value = None if need_where else other
 
-        structured_masked_scope = getattr(V.kernel, "structured_masked_scope", None)
-        masked_scope = (
-            structured_masked_scope(mask, other)
-            if structured_masked_scope is not None
-            else contextlib.nullcontext()
-        )
-        with masked_scope, V.kernel.mask_loads(mask, value=value) as new_mask:
+        with (
+            V.kernel.structured_masked_scope(mask, other),
+            V.kernel.mask_loads(mask, value=value) as new_mask,
+        ):
             result = body()
 
         if need_where:
@@ -2789,6 +2786,8 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             self.init_cooperative_reduction()
 
         self.codegen_range_tree()
+        # Keep the sidecar always-on so downstream tooling can inspect any
+        # generated Triton kernel without coordinating a separate compile flag.
         self.structured_ir = StructuredTritonKernelIR(
             kernel_name=self.kernel_name,
             kernel_kind=type(self).__name__,
@@ -4630,8 +4629,14 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
 
             if reduction_type in ("argmax", "argmin"):
                 accumulator_index = f"_{result_var}_index"
-                self.structured_ir.register_loop_carried(accumulator_index)
                 index_dtype = self.features.select_index_dtype()
+                self.structured_ir.register_loop_carried(
+                    StructuredTritonValue(
+                        name=accumulator_index,
+                        dtype=str(index_dtype),
+                        shape=tuple(self.dense_size_list()),
+                    )
+                )
                 self.body.writeline(
                     f"{accumulator_index} = tl.full({self.dense_size_str()}, "
                     f"{torch.iinfo(index_dtype).max}, {self.dtype_to_str(index_dtype)})"
@@ -4663,7 +4668,16 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 accumulator_max = f"_{result_var}_max"
                 accumulator_sum = f"_{result_var}_sum"
                 self.structured_ir.register_loop_carried(
-                    accumulator_max, accumulator_sum
+                    StructuredTritonValue(
+                        name=accumulator_max,
+                        dtype=str(torch_acc_type),
+                        shape=tuple(self.dense_size_list()),
+                    ),
+                    StructuredTritonValue(
+                        name=accumulator_sum,
+                        dtype=str(torch_acc_type),
+                        shape=tuple(self.dense_size_list()),
+                    ),
                 )
 
                 # setup accumulator

--- a/torch/_inductor/codegen/triton_ir.py
+++ b/torch/_inductor/codegen/triton_ir.py
@@ -1,0 +1,357 @@
+from __future__ import annotations
+
+import contextlib
+import dataclasses
+from typing import Any
+
+import sympy
+
+import torch
+
+
+_SECTION_ORDER = (
+    "body",
+    "prologue",
+    "indexing",
+    "loads",
+    "compute",
+    "stores",
+    "post_loop_combine",
+    "post_loop_store",
+)
+_LOOP_SECTIONS = frozenset(("indexing", "loads", "compute", "stores"))
+
+
+@dataclasses.dataclass
+class StructuredTritonValue:
+    name: str
+    dtype: str | None = None
+    shape: tuple[str, ...] | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "dtype": self.dtype,
+            "shape": list(self.shape) if self.shape is not None else None,
+        }
+
+
+@dataclasses.dataclass
+class StructuredTritonOperand:
+    kind: str
+    value: Any
+    dtype: str | None = None
+    shape: tuple[str, ...] | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "kind": self.kind,
+            "value": self.value,
+            "dtype": self.dtype,
+            "shape": list(self.shape) if self.shape is not None else None,
+        }
+
+
+@dataclasses.dataclass
+class StructuredTritonScope:
+    id: int
+    kind: str
+    label: str
+    parent: int | None
+    attrs: dict[str, Any] = dataclasses.field(default_factory=dict)
+    loop_carried: list[StructuredTritonValue] = dataclasses.field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "kind": self.kind,
+            "label": self.label,
+            "parent": self.parent,
+            "attrs": self.attrs,
+            "loop_carried": [value.to_dict() for value in self.loop_carried],
+        }
+
+
+@dataclasses.dataclass
+class StructuredTritonNode:
+    id: int
+    kind: str
+    op: str
+    section: str
+    scope: int
+    inputs: list[StructuredTritonOperand]
+    outputs: list[StructuredTritonValue]
+    attrs: dict[str, Any] = dataclasses.field(default_factory=dict)
+    origin: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "kind": self.kind,
+            "op": self.op,
+            "section": self.section,
+            "scope": self.scope,
+            "inputs": [operand.to_dict() for operand in self.inputs],
+            "outputs": [value.to_dict() for value in self.outputs],
+            "attrs": self.attrs,
+            "origin": self.origin,
+        }
+
+
+class StructuredTritonKernelIR:
+    """
+    A sidecar IR that mirrors Triton codegen without changing the existing
+    string-based pipeline.  Nodes retain typed values and are attached to an
+    explicit scope tree so analyses do not need to reverse-engineer the final
+    source text.
+    """
+
+    def __init__(
+        self,
+        *,
+        kernel_name: str | None,
+        kernel_kind: str,
+        numels: dict[str, sympy.Expr],
+        range_trees: list[dict[str, Any]],
+    ) -> None:
+        self.kernel_name = kernel_name
+        self.kernel_kind = kernel_kind
+        self.numels = {
+            prefix: self._normalize_attr_value(numel) for prefix, numel in numels.items()
+        }
+        self.range_trees = [
+            {
+                str(key): self._normalize_attr_value(value)
+                for key, value in range_tree.items()
+            }
+            for range_tree in range_trees
+        ]
+        self.section_order = list(_SECTION_ORDER)
+        self.nodes: list[StructuredTritonNode] = []
+        self.scopes: list[StructuredTritonScope] = []
+        self.section_scopes: dict[str, int] = {}
+        self._active_scopes: list[int] = []
+        self._producer_by_output: dict[str, int] = {}
+
+        root = self._new_scope(
+            kind="kernel",
+            label=kernel_name or kernel_kind,
+            parent=None,
+            attrs={"kernel_kind": kernel_kind, "numels": self.numels},
+        )
+        self.root_scope = root.id
+        for section in _SECTION_ORDER:
+            self.section_scopes[section] = self.root_scope
+
+        self.reduction_loop_scope: int | None = None
+        loop_ranges = [range_tree for range_tree in self.range_trees if range_tree["is_loop"]]
+        if loop_ranges:
+            loop_scope = self._new_scope(
+                kind="loop",
+                label="reduction_loop",
+                parent=self.root_scope,
+                attrs={"ranges": loop_ranges},
+            )
+            self.reduction_loop_scope = loop_scope.id
+            for section in _LOOP_SECTIONS:
+                self.section_scopes[section] = loop_scope.id
+
+    def set_kernel_name(self, kernel_name: str) -> None:
+        self.kernel_name = kernel_name
+        self.scopes[self.root_scope].label = kernel_name
+
+    def scope(
+        self,
+        kind: str,
+        label: str,
+        *,
+        section: str = "compute",
+        attrs: dict[str, Any] | None = None,
+    ) -> contextlib.AbstractContextManager[None]:
+        @contextlib.contextmanager
+        def ctx():
+            parent = (
+                self._active_scopes[-1]
+                if self._active_scopes
+                else self.section_scopes.get(section, self.root_scope)
+            )
+            scope = self._new_scope(kind, label, parent, attrs)
+            self._active_scopes.append(scope.id)
+            try:
+                yield
+            finally:
+                popped_scope = self._active_scopes.pop()
+                assert popped_scope == scope.id
+
+        return ctx()
+
+    def register_loop_carried(self, *values: Any) -> None:
+        if self.reduction_loop_scope is None:
+            return
+        loop_scope = self.scopes[self.reduction_loop_scope]
+        for value in self._flatten(values):
+            normalized = self._normalize_output(value)
+            if all(existing.name != normalized.name for existing in loop_scope.loop_carried):
+                loop_scope.loop_carried.append(normalized)
+
+    def record_node(
+        self,
+        *,
+        kind: str,
+        op: str,
+        section: str,
+        inputs: Any = (),
+        outputs: Any = (),
+        attrs: dict[str, Any] | None = None,
+        origin: str | None = None,
+        dedupe_outputs: bool = False,
+    ) -> StructuredTritonNode | None:
+        normalized_outputs = [
+            self._normalize_output(value) for value in self._flatten(outputs)
+        ]
+        output_names = [value.name for value in normalized_outputs]
+        if (
+            dedupe_outputs
+            and output_names
+            and all(name in self._producer_by_output for name in output_names)
+        ):
+            return None
+
+        node = StructuredTritonNode(
+            id=len(self.nodes),
+            kind=kind,
+            op=op,
+            section=section,
+            scope=self._current_scope(section),
+            inputs=[self._normalize_operand(value) for value in self._flatten(inputs)],
+            outputs=normalized_outputs,
+            attrs=self._normalize_attr_value(attrs or {}),
+            origin=origin,
+        )
+        self.nodes.append(node)
+        for value in normalized_outputs:
+            self._producer_by_output.setdefault(value.name, node.id)
+        return node
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "kernel_name": self.kernel_name,
+            "kernel_kind": self.kernel_kind,
+            "numels": self.numels,
+            "range_trees": self.range_trees,
+            "section_order": list(self.section_order),
+            "section_scopes": dict(self.section_scopes),
+            "scopes": [scope.to_dict() for scope in self.scopes],
+            "nodes": [node.to_dict() for node in self.nodes],
+        }
+
+    def _new_scope(
+        self,
+        kind: str,
+        label: str,
+        parent: int | None,
+        attrs: dict[str, Any] | None = None,
+    ) -> StructuredTritonScope:
+        scope = StructuredTritonScope(
+            id=len(self.scopes),
+            kind=kind,
+            label=label,
+            parent=parent,
+            attrs=self._normalize_attr_value(attrs or {}),
+        )
+        self.scopes.append(scope)
+        return scope
+
+    def _current_scope(self, section: str) -> int:
+        if self._active_scopes:
+            return self._active_scopes[-1]
+        return self.section_scopes.get(section, self.root_scope)
+
+    def _normalize_output(self, value: Any) -> StructuredTritonValue:
+        if isinstance(value, StructuredTritonValue):
+            return value
+        name = getattr(value, "name", None)
+        if name is None:
+            name = self._normalize_attr_value(value)
+        return StructuredTritonValue(
+            name=str(name),
+            dtype=self._normalize_dtype(getattr(value, "dtype", None)),
+            shape=self._normalize_shape(getattr(value, "shape", None)),
+        )
+
+    def _normalize_operand(self, value: Any) -> StructuredTritonOperand:
+        if isinstance(value, StructuredTritonOperand):
+            return value
+        if getattr(value, "name", None) is not None:
+            kind = "value"
+            normalized = str(value.name)
+        elif isinstance(value, sympy.Expr):
+            kind = "sympy"
+            normalized = str(value)
+        elif isinstance(value, torch.dtype):
+            kind = "dtype"
+            normalized = str(value)
+        elif callable(value):
+            kind = "callable"
+            normalized = getattr(
+                value, "__qualname__", getattr(value, "__name__", repr(value))
+            )
+        elif isinstance(value, str):
+            kind = "expr"
+            normalized = value
+        else:
+            kind = type(value).__name__
+            normalized = self._normalize_attr_value(value)
+        return StructuredTritonOperand(
+            kind=kind,
+            value=normalized,
+            dtype=self._normalize_dtype(getattr(value, "dtype", None)),
+            shape=self._normalize_shape(getattr(value, "shape", None)),
+        )
+
+    def _normalize_shape(self, shape: Any) -> tuple[str, ...] | None:
+        if shape is None:
+            return None
+        if isinstance(shape, tuple):
+            return tuple(str(self._normalize_attr_value(dim)) for dim in shape)
+        if isinstance(shape, list):
+            return tuple(str(self._normalize_attr_value(dim)) for dim in shape)
+        return (str(self._normalize_attr_value(shape)),)
+
+    @staticmethod
+    def _normalize_dtype(dtype: torch.dtype | None) -> str | None:
+        return None if dtype is None else str(dtype)
+
+    def _normalize_attr_value(self, value: Any) -> Any:
+        if isinstance(value, (bool, float, int, str)) or value is None:
+            return value
+        if isinstance(value, sympy.Expr):
+            return str(value)
+        if isinstance(value, torch.dtype):
+            return str(value)
+        if isinstance(value, StructuredTritonValue):
+            return value.to_dict()
+        if isinstance(value, StructuredTritonOperand):
+            return value.to_dict()
+        if isinstance(value, dict):
+            return {
+                str(key): self._normalize_attr_value(inner)
+                for key, inner in value.items()
+            }
+        if isinstance(value, (list, tuple)):
+            return [self._normalize_attr_value(inner) for inner in value]
+        if getattr(value, "name", None) is not None:
+            return self._normalize_output(value).to_dict()
+        if callable(value):
+            return getattr(value, "__qualname__", getattr(value, "__name__", repr(value)))
+        return repr(value)
+
+    def _flatten(self, values: Any) -> list[Any]:
+        if values is None:
+            return []
+        if isinstance(values, (list, tuple)):
+            result: list[Any] = []
+            for value in values:
+                result.extend(self._flatten(value))
+            return result
+        return [values]

--- a/torch/_inductor/codegen/triton_ir.py
+++ b/torch/_inductor/codegen/triton_ir.py
@@ -8,6 +8,7 @@ import sympy
 
 import torch
 
+
 _SECTION_ORDER = (
     "body",
     "prologue",

--- a/torch/_inductor/codegen/triton_ir.py
+++ b/torch/_inductor/codegen/triton_ir.py
@@ -8,7 +8,6 @@ import sympy
 
 import torch
 
-
 _SECTION_ORDER = (
     "body",
     "prologue",
@@ -117,7 +116,8 @@ class StructuredTritonKernelIR:
         self.kernel_name = kernel_name
         self.kernel_kind = kernel_kind
         self.numels = {
-            prefix: self._normalize_attr_value(numel) for prefix, numel in numels.items()
+            prefix: self._normalize_attr_value(numel)
+            for prefix, numel in numels.items()
         }
         self.range_trees = [
             {
@@ -144,7 +144,9 @@ class StructuredTritonKernelIR:
             self.section_scopes[section] = self.root_scope
 
         self.reduction_loop_scope: int | None = None
-        loop_ranges = [range_tree for range_tree in self.range_trees if range_tree["is_loop"]]
+        loop_ranges = [
+            range_tree for range_tree in self.range_trees if range_tree["is_loop"]
+        ]
         if loop_ranges:
             loop_scope = self._new_scope(
                 kind="loop",
@@ -191,7 +193,9 @@ class StructuredTritonKernelIR:
         loop_scope = self.scopes[self.reduction_loop_scope]
         for value in self._flatten(values):
             normalized = self._normalize_output(value)
-            if all(existing.name != normalized.name for existing in loop_scope.loop_carried):
+            if all(
+                existing.name != normalized.name for existing in loop_scope.loop_carried
+            ):
                 loop_scope.loop_carried.append(normalized)
 
     def record_node(
@@ -343,7 +347,9 @@ class StructuredTritonKernelIR:
         if getattr(value, "name", None) is not None:
             return self._normalize_output(value).to_dict()
         if callable(value):
-            return getattr(value, "__qualname__", getattr(value, "__name__", repr(value)))
+            return getattr(
+                value, "__qualname__", getattr(value, "__name__", repr(value))
+            )
         return repr(value)
 
     def _flatten(self, values: Any) -> list[Any]:


### PR DESCRIPTION
## Summary

1. Root cause problem
   Triton codegen only materializes strings and spliced buffers, so there is no typed kernel representation available between the high-level IR and final Triton source. That makes downstream analysis and backend reuse depend on reverse-engineering emitted text.

2. Proposed fix
   Add an internal `StructuredTritonKernelIR` sidecar and wire it into the existing Triton/CSE codegen path. The sidecar records typed ops, memory ops, masked scopes, reduction-loop structure, and loop-carried state while leaving the existing generated Triton source unchanged.

3. Why the proposed fix is the right long term fix
   This introduces a stable intermediate seam without rewriting the current string codegen pipeline. Future analysis, optimization, and backend work can consume the structured kernel graph incrementally instead of depending on source parsing.

## Testing

- `python3 -m compileall torch/_inductor/codegen/triton_ir.py torch/_inductor/codegen/common.py torch/_inductor/codegen/triton.py test/inductor/test_codegen_triton.py`
- `python3` stubbed smoke test for `torch/_inductor/codegen/triton_ir.py`
- Full `test/inductor/test_codegen_triton.py` could not run in this container because `torch`, `sympy`, and `pytest` are unavailable.

Drafted via Codex, published after manual review by @bobrenjc93

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo