### PR TITLE
[inductor] Force contiguous inputs for custom ops in FallbackKernel

### DIFF
--- a/test/inductor/test_custom_op_reinterpret_tensor.py
+++ b/test/inductor/test_custom_op_reinterpret_tensor.py
@@ -1,0 +1,93 @@
+"""
+Test that custom ops receiving Inductor-generated reinterpret_tensor views
+can safely call .data_ptr() without crashing, and produce correct results.
+
+Regression test for: Custom C++ ops crash when Inductor passes
+reinterpret_tensor views that lack accessible storage.
+"""
+import unittest
+import torch
+from torch.testing._internal.common_utils import TestCase, run_tests
+
+HAS_CUDA = torch.cuda.is_available()
+
+# Register test custom op at module level (avoid re-registration across tests)
+_test_lib = torch.library.Library("test_reinterpret", "DEF")
+_test_lib.define("identity(Tensor x) -> Tensor")
+
+
+@torch.library.impl("test_reinterpret::identity", "cuda", lib=_test_lib)
+def _identity_impl(x):
+    x.data_ptr()  # this call must not crash
+    return x.clone()
+
+
+@torch.library.register_fake("test_reinterpret::identity", lib=_test_lib)
+def _identity_fake(x):
+    return x.new_empty(x.shape)
+
+
+class MyOp(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x):
+        return torch.ops.test_reinterpret.identity(x)
+
+    @staticmethod
+    def backward(ctx, go):
+        return torch.ops.test_reinterpret.identity(go)
+
+
+class Model(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.layers = torch.nn.ModuleList(
+            [torch.nn.Linear(128, 128, bias=False) for _ in range(4)]
+        )
+        self.norm = torch.nn.LayerNorm(128)
+
+    def forward(self, x):
+        for layer in self.layers:
+            x = x + MyOp.apply(self.norm(layer(x)))
+        return x.sum()
+
+
+@unittest.skipIf(not HAS_CUDA, "CUDA required")
+class TestCustomOpReinterpretTensor(TestCase):
+    def test_custom_op_data_ptr_with_compiled_model(self):
+        """Custom op calling .data_ptr() should work inside torch.compile
+        and produce results matching eager execution."""
+        model = Model().cuda().bfloat16()
+        model.train()
+
+        # Create a copy for eager reference
+        eager_model = Model().cuda().bfloat16()
+        eager_model.load_state_dict(model.state_dict())
+
+        compiled = torch.compile(model, dynamic=False, fullgraph=True)
+        x = torch.randn(32, 128, device="cuda", dtype=torch.bfloat16)
+
+        # Eager reference
+        with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+            expected = eager_model(x)
+
+        # Compiled should not crash AND should match eager
+        with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+            actual = compiled(x)
+
+        self.assertEqual(actual, expected)
+
+        # Backward should not crash
+        actual.backward()
+        expected.backward()
+
+        # Gradients should match
+        for (n1, p1), (n2, p2) in zip(
+            model.named_parameters(), eager_model.named_parameters()
+        ):
+            self.assertEqual(
+                p1.grad, p2.grad, msg=f"Gradient mismatch for {n1}"
+            )
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -117,6 +117,14 @@ from .utils import (
 )
 from .virtualized import ops, OpsValue, V
 
+# Op namespaces that handle ReinterpretView inputs natively.
+# Custom ops outside these namespaces get contiguous copies to ensure
+# .data_ptr() is callable (see FallbackKernel.process_kernel).
+_INTERNAL_OP_NAMESPACES = frozenset({
+    "aten", "prims", "inductor", "_c10d_functional",
+    "quantized", "quantized_decomposed",
+})
+
 
 if TYPE_CHECKING:
     from torch.fx.experimental.symbolic_shapes import SympyBoolean
@@ -6440,7 +6448,25 @@ class ExternKernel(InputsKernel):
             r = pytree.tree_unflatten(result, args_spec)
             return r.get("args", []), r.get("kwargs", {})
 
-        tensor_args = [cls.realize_input(x) for x in tensor_args]
+        # For custom (non-internal) ops, force contiguous copies instead of
+        # ReinterpretView to ensure C++ ops can safely call .data_ptr().
+        # realize_input() may return ReinterpretView which can lack accessible
+        # storage in Inductor's runtime, causing "Cannot access data pointer
+        # of Tensor that doesn't have storage" errors.
+        is_custom_op = (
+            isinstance(kernel, torch._ops.OpOverload)
+            and kernel.namespace not in _INTERNAL_OP_NAMESPACES
+        )
+        if is_custom_op:
+            realized = []
+            for x in tensor_args:
+                r = cls.realize_input(x)
+                if isinstance(r, ReinterpretView):
+                    r = cls.copy_input(x)
+                realized.append(r)
+            tensor_args = realized
+        else:
+            tensor_args = [cls.realize_input(x) for x in tensor_args]
 
         # freeze layout otherwise our output stride calculation might
         # become incorrect


### PR DESCRIPTION
## Summary

Custom C++ ops registered via `torch.library` that call `.data_ptr()` on their inputs crash when `torch.compile` is used, because Inductor passes `reinterpret_tensor` views that lack accessible storage.

**Works on PyTorch 2.9.1, crashes on 2.11.0.**

## Error
```
RuntimeError: Cannot access data pointer of Tensor that doesn't have storage
  Exception raised from throw_data_ptr_access_error at c10/core/TensorImpl.cpp:307
```

## Root Cause

`FallbackKernel.process_kernel()` calls `realize_input()` which may return `ReinterpretView` nodes. Internal ops (aten, prims, etc.) handle views natively, but custom C++ ops typically call `.data_ptr()` directly, which fails on storage-less views.

Between PyTorch 2.9.1 and 2.11.0, Inductor's codegen changed to create these storage-less views where it previously didn't.

## Fix

For non-internal ops, if `realize_input()` produces a `ReinterpretView`, fall back to `copy_input()` which creates a contiguous tensor with its own storage. Internal ops are identified by namespace (`aten`, `prims`, `inductor`, `_c10d_functional`, `quantized`, `quantized_decomposed`) and are unaffected. The copy only occurs for `ReinterpretView` inputs to custom ops.

## Test Plan

Added `test/inductor/test_custom_op_reinterpret_tensor.py`:
- Registers a custom op that calls `.data_ptr()`
- Uses it inside a `torch.autograd.Function` within a multi-layer compiled model
- Compares compiled output against eager execution (forward correctness)
- Compares compiled gradients against eager gradients (backward correctness)
- Skipped on CPU-only workers (`@unittest.skipIf(not HAS_CUDA, ...)`)

## Related

- https://github.com/pytorch/pytorch/issues/124601 (FakeTensor + Triton descriptor = data_ptr crash, same error family)

## Impact

Blocks all custom CUDA C++ ops that call `.data_ptr()` from working inside `torch.compile` on PyTorch 2.11+. Real-world example: fused CUTLASS EVT matmul+activation backward kernel providing 3.7% training speedup on H100.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo