### PR TITLE
[BE] Make `skipIfMPS` be more selective

### DIFF
--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -2170,12 +2170,31 @@ def skipIfXpu(func=None, *, msg="test doesn't currently work on the XPU stack"):
     return dec_fn
 
 def skipIfMPS(fn):
+    sig = inspect.signature(fn)
+    has_device_arg = "device" in sig.parameters
+
+    if not has_device_arg:
+        warnings.warn(
+            f"skipIfMPS applied to {fn.__qualname__} which has no 'device' parameter. "
+            "Consider using device-generic tests with instantiate_device_type_tests instead.",
+            stacklevel=2,
+        )
+
     @wraps(fn)
     def wrapper(*args, **kwargs):
-        if TEST_MPS:
+        if has_device_arg:
+            # For device-generic tests, only skip when actually running on MPS
+            slf = args[0] if args else None
+            if slf is not None:
+                device_type = getattr(slf, "device_type", None) or getattr(
+                    slf, "device", None
+                )
+                if isinstance(device_type, str) and device_type == "mps":
+                    raise unittest.SkipTest("test doesn't currently work with MPS")
+        elif TEST_MPS:
             raise unittest.SkipTest("test doesn't currently work with MPS")
-        else:
-            fn(*args, **kwargs)
+        return fn(*args, **kwargs)
+
     return wrapper
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #179435

I.e. if applied to a test with device argument, skips only if device property is equal to MPS

Tested by running
```python
from torch.testing._internal.common_device_type import instantiate_device_type_tests
from torch.testing._internal.common_utils import run_tests, skipIfMPS, TestCase

class TestSkipIfMPSDeviceGeneric(TestCase):
    @skipIfMPS
    def test_only_skips_mps_variant(self, device):
        self.assertNotEqual(self.device_type, "mps")


class TestSkipIfMPSNonParametrized(TestCase):
    @skipIfMPS
    def test_plain_method(self):
        self.assertEqual(2, 2)


instantiate_device_type_tests(TestSkipIfMPSDeviceGeneric, globals(), allow_mps=True)


if __name__ == "__main__":
    run_tests()

```