### PR TITLE
[Inductor] Remove fp8 special handling in signature_of

### DIFF
--- a/torch/_inductor/codegen/triton_utils.py
+++ b/torch/_inductor/codegen/triton_utils.py
@@ -34,18 +34,7 @@ def should_unwrap_unspec_arg(name: str):
 
 def signature_of(arg: KernelArgType, *, size_dtype: str | None) -> str:
     if isinstance(arg, TensorArg):
-        # TODO: Remove fp8 special handling when Triton supports PyTorch fp8 dtypes.
-        # Related PR: https://github.com/triton-lang/triton/pull/2279/
-        if arg.dtype == torch.float8_e4m3fn:
-            typ = "*fp8e4nv"
-        elif arg.dtype == torch.float8_e5m2:
-            typ = "*fp8e5"
-        elif arg.dtype == torch.float8_e4m3fnuz:
-            typ = "*fp8e4b8"
-        elif arg.dtype == torch.float8_e5m2fnuz:
-            typ = "*fp8e5b16"
-        else:
-            typ = _type_of(arg.dtype)
+        typ = _type_of(arg.dtype)
         if should_unwrap_unspec_arg(arg.buffer):
             # had unwrapped 0d tensor as scalar
             new_typ = typ.lstrip("*")

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -487,6 +487,8 @@ def _type_of(key: torch.dtype | None) -> str:
         "float8e4b15x4": "fp8e4b15x4",
         "float8_e4m3fn": "fp8e4nv",
         "float8_e5m2": "fp8e5",
+        "float8_e4m3fnuz": "fp8e4b8",
+        "float8_e5m2fnuz": "fp8e5b16",
         # TODO: remove when support is added in triton
         # https://github.com/triton-lang/triton/issues/6054
         "float8_e8m0fnu": "u8",


### PR DESCRIPTION
## Summary

Removes the redundant fp8 dtype special handling in `signature_of()` that was marked with a TODO since 2023. Triton now natively supports PyTorch fp8 dtypes ([triton-lang/triton#2279](https://github.com/triton-lang/triton/pull/2279)).

## Changes

1. **`torch/_inductor/utils.py`**: Added `float8_e4m3fnuz` → `fp8e4b8` and `float8_e5m2fnuz` → `fp8e5b16` to `_type_of()`, where all dtype mappings belong
2. **`torch/_inductor/codegen/triton_utils.py`**: Removed the 4 hand-rolled `if/elif` branches and the stale TODO comment, letting all dtypes (including fp8) go through `_type_of()`

This is a pure cleanup — the resulting Triton kernel signatures are identical.

This PR was authored with the help of AI (Claude).

Fixes #178938

## Test plan

The fp8 dtype mappings produce the same Triton type strings as before:
- `float8_e4m3fn` → `fp8e4nv` (was in `_type_of`, unchanged)
- `float8_e5m2` → `fp8e5` (was in `_type_of`, unchanged)
- `float8_e4m3fnuz` → `fp8e4b8` (moved from `signature_of` → `_type_of`)
- `float8_e5m2fnuz` → `fp8e5b16` (moved from `signature_of` → `_type_of`)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo