### PR TITLE
[Inductor][Triton] Codegen TMA store within fused pointwise epilogues

### DIFF
--- a/test/inductor/test_max_autotune_blackwell.py
+++ b/test/inductor/test_max_autotune_blackwell.py
@@ -379,7 +379,9 @@ class TestBlackwellTMAStoreFusion(TestCase):
 
         torch.testing.assert_close(actual, expected, atol=1e-1, rtol=1e-1)
 
-        FileCheck().check("triton_tem_fused_mm").check("tma_descriptor").check(".store").run(code[0])
+        FileCheck().check("triton_tem_fused_mm").check("tma_descriptor").check(
+            ".store"
+        ).run(code[0])
 
     @unittest.skipIf(
         not has_datacenter_blackwell_tma_device(),
@@ -434,7 +436,9 @@ class TestBlackwellTMAStoreFusion(TestCase):
 
         torch.testing.assert_close(actual, expected, atol=1e-1, rtol=1e-1)
 
-        FileCheck().check("triton_tem_fused").check("tma_descriptor").check(".store").run(code[0])
+        FileCheck().check("triton_tem_fused").check("tma_descriptor").check(
+            ".store"
+        ).run(code[0])
 
 
 @instantiate_parametrized_tests

--- a/test/inductor/test_max_autotune_blackwell.py
+++ b/test/inductor/test_max_autotune_blackwell.py
@@ -3,6 +3,7 @@ import unittest
 
 import torch
 from torch._inductor import config
+from torch._inductor.template_heuristics.registry import _HEURISTIC_CACHE
 from torch._inductor.template_heuristics.triton import (
     BlackwellGPUGemmConfig,
     CUDABlackwellAddmmPersistentTMATemplateConfigHeuristic,
@@ -303,6 +304,137 @@ class TestMaxAutotuneBlackwell(TestCase):
         ).check(write_api).run(code[0])
 
         torch.testing.assert_close(c_actual, c_expected, atol=1e-2, rtol=1e-2)
+
+
+@instantiate_parametrized_tests
+class TestBlackwellTMAStoreFusion(TestCase):
+    """Tests for TMA store with fused pointwise epilogues on Blackwell."""
+
+    @staticmethod
+    def _make_tma_store_test_config(epilogue_subtile: int) -> BlackwellGPUGemmConfig:
+        """FLATTEN=False test config for TMA store pointwise epilogue fusion.
+
+        The WS pipeline doesn't yet support FLATTEN=True + TMA descriptor store.
+        """
+        return BlackwellGPUGemmConfig(
+            128,
+            128,
+            64,
+            3,
+            4,
+            epilogue_subtile=epilogue_subtile,
+            warp_specialize=False,
+            flatten=False,
+        )
+
+    @unittest.skipIf(
+        not has_datacenter_blackwell_tma_device(),
+        "Need Blackwell with device-side TMA support in Triton",
+    )
+    @parametrize("shape", ((512, 256, 256), (4096, 256, 256)))
+    @parametrize("epilogue_subtile", (1, 2))
+    def test_blackwell_mm_sigmoid_epilogue_fusion_tma_store(
+        self,
+        shape: tuple[int, int, int],
+        epilogue_subtile: int,
+    ):
+        """Verify fused mm + sigmoid epilogue with TMA store (FLATTEN=False)."""
+
+        def fn(x, W):
+            mm = torch.mm(x, W.T)
+            return x * (2.0 * torch.sigmoid(mm))
+
+        M, N, K = shape
+        x = torch.randn(M, K, dtype=torch.bfloat16, device=GPU_TYPE)
+        W = torch.randn(N, K, dtype=torch.bfloat16, device=GPU_TYPE)
+
+        test_config = self._make_tma_store_test_config(epilogue_subtile)
+        # Ensure the heuristic cache is populated, then patch mm_configs.
+        from torch._inductor.template_heuristics.registry import get_template_heuristic
+
+        _cache_keys = [
+            ("triton::blackwell_ws_persistent_device_tma", "cuda", "mm"),
+            ("triton::blackwell_ws_persistent_device_tma", "cuda", "addmm"),
+        ]
+        orig_configs_by_key = {}
+        for key in _cache_keys:
+            h = get_template_heuristic(*key)
+            orig_configs_by_key[key] = h.mm_configs
+            h.mm_configs = [test_config]
+        try:
+            with config.patch(
+                {
+                    "max_autotune": True,
+                    "triton.enable_persistent_tma_matmul": True,
+                    "triton.enable_template_tma_store": True,
+                    "test_configs.autotune_choice_name_regex": "blackwell_ws_persistent_device_tma",
+                }
+            ):
+                actual, code = run_and_get_code(torch.compile(fn), x, W)
+                expected = fn(x, W)
+        finally:
+            for key, orig in orig_configs_by_key.items():
+                if key in _HEURISTIC_CACHE:
+                    _HEURISTIC_CACHE[key].mm_configs = orig
+
+        torch.testing.assert_close(actual, expected, atol=1e-1, rtol=1e-1)
+
+        FileCheck().check("triton_tem_fused_mm").check("tma_descriptor").check(".store").run(code[0])
+
+    @unittest.skipIf(
+        not has_datacenter_blackwell_tma_device(),
+        "Need Blackwell with device-side TMA support in Triton",
+    )
+    @parametrize("shape", ((512, 256, 256), (4096, 256, 256)))
+    @parametrize("epilogue_subtile", (1, 2))
+    def test_blackwell_addmm_relu_epilogue_fusion_tma_store(
+        self,
+        shape: tuple[int, int, int],
+        epilogue_subtile: int,
+    ):
+        """Verify fused addmm + relu epilogue with TMA store (FLATTEN=False)."""
+
+        def fn(x, W, bias):
+            mm = torch.mm(x, W.T)
+            return torch.relu(mm + bias)
+
+        M, N, K = shape
+        x = torch.randn(M, K, dtype=torch.bfloat16, device=GPU_TYPE)
+        W = torch.randn(N, K, dtype=torch.bfloat16, device=GPU_TYPE)
+        bias = torch.randn(N, dtype=torch.bfloat16, device=GPU_TYPE)
+
+        test_config = self._make_tma_store_test_config(epilogue_subtile)
+        # Ensure the heuristic cache is populated, then patch mm_configs.
+        from torch._inductor.template_heuristics.registry import get_template_heuristic
+
+        _cache_keys = [
+            ("triton::blackwell_ws_persistent_device_tma", "cuda", "mm"),
+            ("triton::blackwell_ws_persistent_device_tma", "cuda", "addmm"),
+        ]
+        orig_configs_by_key = {}
+        for key in _cache_keys:
+            h = get_template_heuristic(*key)
+            orig_configs_by_key[key] = h.mm_configs
+            h.mm_configs = [test_config]
+        try:
+            with config.patch(
+                {
+                    "max_autotune": True,
+                    "triton.enable_persistent_tma_matmul": True,
+                    "triton.enable_template_tma_store": True,
+                    "test_configs.autotune_choice_name_regex": "blackwell_ws_persistent_device_tma",
+                }
+            ):
+                actual, code = run_and_get_code(torch.compile(fn), x, W, bias)
+                expected = fn(x, W, bias)
+        finally:
+            for key, orig in orig_configs_by_key.items():
+                if key in _HEURISTIC_CACHE:
+                    _HEURISTIC_CACHE[key].mm_configs = orig
+
+        torch.testing.assert_close(actual, expected, atol=1e-1, rtol=1e-1)
+
+        FileCheck().check("triton_tem_fused").check("tma_descriptor").check(".store").run(code[0])
 
 
 @instantiate_parametrized_tests

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -3896,7 +3896,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
 
         tma_compatibility_checker = None
         if mode is None or mode == "tma":
-            force = mode == "tma"
+            force = mode == "tma" or getattr(self, "tma_store", False)
             tma_compatibility_checker = self.tma_compatibility_checker_cls(
                 self,
                 dtype,

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -1527,6 +1527,7 @@ class TritonTemplateKernel(TritonKernel):
             subgraph_name, self._make_codegen_hook(subgraph_name, indent_width)
         )
 
+
     def _register_hook(
         self,
         hook_name: str,

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -1527,7 +1527,6 @@ class TritonTemplateKernel(TritonKernel):
             subgraph_name, self._make_codegen_hook(subgraph_name, indent_width)
         )
 
-
     def _register_hook(
         self,
         hook_name: str,


### PR DESCRIPTION
Codegen TMA descriptor store for pointwise epilogue fusions on B200, gated behind `ENABLE_TEMPLATE_TMA_STORE=1`.

Limitation: `flatten=False` is required for Inductor to correctly codegen a kernel that works with warp specialization. Inductor does not currently have any Blackwell configs with `flatten=False`.

e.g. for
```
def fn(x, W):
    # x: [1152, 512, 256], W: [256, 256]
    permute = torch.ops.aten.permute.default(W, [1, 0])
    view = torch.ops.aten.view.default(x, [589824, 256])
    mm = torch.ops.aten.mm.default(view, permute)
    view_1 = torch.ops.aten.view.default(mm, [1152, 512, 256])
    sigmoid = torch.ops.aten.sigmoid.default(view_1)
    mul = torch.ops.aten.mul.Tensor(sigmoid, 2.0)
    return torch.ops.aten.mul.Tensor(x, mul)
```
Inductor generates the following epilogue (full output code here: [P2292454919](https://www.internalfb.com/phabricator/paste/view/P2292454919)):
```
...
for i in tl.static_range(EPILOGUE_SUBTILE):
            subtile = subtiles[i]
            offs_cn_i = offs_cn + i * (BLOCK_N // EPILOGUE_SUBTILE)
            xoffset = offs_cm
            xindex = (xoffset + tl.arange(0, XBLOCK))[:, None]
            xmask = xindex < 589824
            yoffset = offs_cn_i
            yindex = (yoffset + tl.arange(0, YBLOCK))[None, :, ]
            ymask = yindex < 256
            tmp0 = tl.load(arg_A + (yindex + 256*xindex), ymask, eviction_policy='evict_last').to(tl.float32)
            tmp1 = tl.sigmoid(subtile)
            tmp2 = tl.full([1, 1], 2.0, tl.float32)
            tmp3 = tmp1 * tmp2
            tmp4 = tmp0 * tmp3
            tma_descriptor1.store([xoffset, yoffset], tl.broadcast_to(tmp4, [XBLOCK, YBLOCK]).to(tl.bfloat16))
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo