### PR TITLE
[Native DSL] Use vendored packaging instead of  external packaging dependency in torch/_native/

### DIFF
--- a/test/python_native/test_dsl_registry.py
+++ b/test/python_native/test_dsl_registry.py
@@ -3,7 +3,6 @@
 from unittest.mock import Mock
 
 from torch._vendor.packaging.version import Version
-
 from torch.testing._internal.common_utils import run_tests, TestCase
 
 

--- a/test/python_native/test_dsl_registry.py
+++ b/test/python_native/test_dsl_registry.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import Mock
 
-from packaging.version import Version
+from torch._vendor.packaging.version import Version
 
 from torch.testing._internal.common_utils import run_tests, TestCase
 

--- a/test/python_native/test_native_dsl_ops.py
+++ b/test/python_native/test_native_dsl_ops.py
@@ -141,7 +141,7 @@ class TestNativeDSLOps(TestCase):
                 # runtime_version should return Version or None
                 ver = mod.runtime_version()
                 if ver is not None:
-                    from packaging.version import Version
+                    from torch._vendor.packaging.version import Version
 
                     self.assertIsInstance(ver, Version)
 
@@ -161,6 +161,35 @@ class TestNativeDSLOps(TestCase):
         """)
         result = _subprocess_lastline(script)
         self.assertEqual(result, "[]", f"DSL modules leaked on import torch: {result}")
+
+    def test_no_external_packaging_dependency(self):
+        """torch._native must not import the external `packaging` package.
+
+        It should use the vendored copy at torch._vendor.packaging instead.
+        This guards against ModuleNotFoundError in environments where the
+        external `packaging` is not installed (e.g. torchvision Windows CI).
+        """
+        script = textwrap.dedent("""\
+            import sys
+            # Remove external packaging from sys.modules if already loaded
+            for mod_name in list(sys.modules):
+                if mod_name == "packaging" or mod_name.startswith("packaging."):
+                    del sys.modules[mod_name]
+            # Block external packaging from being imported
+            import importlib.abc
+            import importlib.machinery
+            class BlockPackaging(importlib.abc.MetaPathFinder):
+                def find_module(self, fullname, path=None):
+                    if fullname == "packaging" or fullname.startswith("packaging."):
+                        return self
+                def load_module(self, fullname):
+                    raise ImportError(f"External {fullname} is blocked")
+            sys.meta_path.insert(0, BlockPackaging())
+            import torch
+            print("OK")
+        """)
+        result = _subprocess_lastline(script)
+        self.assertEqual(result, "OK")
 
     @parametrize("env_value, expected", [(None, False), ("1", True)])
     def test_check_native_jit_disabled_environment_variable(self, env_value, expected):
@@ -193,7 +222,7 @@ class TestNativeDSLOps(TestCase):
 
     def test_available_version_parsing(self):
         """Test _available_version parses various version formats and handles invalid ones."""
-        from packaging.version import Version
+        from torch._vendor.packaging.version import Version
 
         common_utils = _import_module_directly(
             "torch._native.common_utils", "common_utils.py"
@@ -342,7 +371,7 @@ class TestNativeDSLOps(TestCase):
 
     def test_version_skip_env_var_overrides(self):
         """TORCH_NATIVE_SKIP_VERSION_CHECK=1 allows non-blessed versions."""
-        from packaging.version import Version
+        from torch._vendor.packaging.version import Version
 
         fake_version = Version("99.99.99")
 

--- a/torch/_native/common_utils.py
+++ b/torch/_native/common_utils.py
@@ -3,7 +3,7 @@ import importlib.metadata
 import os
 from functools import cache
 
-import packaging.version
+from torch._vendor.packaging import version as _packaging_version
 
 
 @cache
@@ -33,7 +33,7 @@ def _unavailable_reason(deps: list[tuple[str, str]]) -> None | str:
     return None
 
 
-def _available_version(package: str) -> packaging.version.Version | None:
+def _available_version(package: str) -> _packaging_version.Version | None:
     """
     Get the installed version of a package as (major, minor, patch).
 
@@ -47,8 +47,8 @@ def _available_version(package: str) -> packaging.version.Version | None:
         return None
 
     try:
-        v = packaging.version.parse(version)
-    except packaging.version.InvalidVersion:
+        v = _packaging_version.parse(version)
+    except _packaging_version.InvalidVersion:
         return None
 
     return v

--- a/torch/_native/cutedsl_utils.py
+++ b/torch/_native/cutedsl_utils.py
@@ -3,7 +3,7 @@ import logging
 import sys
 from typing import cast
 
-from packaging.version import Version
+from torch._vendor.packaging.version import Version
 
 from ..backends import cuda as _cuda
 from .common_utils import (

--- a/torch/_native/dsl_registry.py
+++ b/torch/_native/dsl_registry.py
@@ -4,7 +4,7 @@ import functools
 import logging
 from typing import Protocol
 
-from packaging.version import Version
+from torch._vendor.packaging.version import Version
 
 from .registry import _OpFn
 

--- a/torch/_native/triton_utils.py
+++ b/torch/_native/triton_utils.py
@@ -3,7 +3,7 @@ import logging
 import sys
 from typing import cast
 
-from packaging.version import Version
+from torch._vendor.packaging.version import Version
 
 from ..backends import cuda as _cuda
 from .common_utils import (


### PR DESCRIPTION
## Summary

Fixes: https://github.com/pytorch/vision/issues/9467 - ModuleNotFoundError: No module named 'packaging'` when importing torch in environments where the external `packaging` package is not installed (e.g. torchvision Windows CI nightly smoke tests).

  Failure can be seen here: https://github.com/pytorch/vision/actions/runs/23945110841/job/69839518285

  The `torch/_native/` module imports `from packaging.version import Version` at
  the top level. Since `torch/__init__.py` unconditionally does `import
  torch._native`, every `import torch` now requires the external `packaging`
  package — but `packaging` is not listed in `install_requires` in `setup.py`. It
  only works in most environments because `packaging` happens to be a transitive
  dependency of `pip` or `setuptools`.

  The failure started appearing in the 2026-04-06 nightly
  (43172938c77ce95e706aad37dd15fda0a909c66c) after #178381 restructured
  `torch/_native/__init__.py` to unconditionally import `cutedsl_utils` (and
  transitively `dsl_registry`, `triton_utils`, and `common_utils` — all of which
  import from `packaging`). Prior to that, the import path did not eagerly trigger
  the `packaging` dependency. The original `from packaging.version import Version`
  was introduced in #176280.

  PyTorch already vendors `packaging` at `torch._vendor.packaging/`, and
  `torch/torch_version.py` already imports from the vendored copy. This PR
  switches all `torch/_native/` source and test files to use
  `torch._vendor.packaging.version` instead of the external `packaging`.

  Adds a regression test (`test_no_external_packaging_dependency`) that blocks the
  external `packaging` package in a subprocess and verifies `import torch` still
  succeeds.

  ## Test plan

  - Existing tests in `test/python_native/test_native_dsl_ops.py` and
    `test/python_native/test_dsl_registry.py` pass with no behavior change
  - New `test_no_external_packaging_dependency` test verifies `import torch` works
    even when external `packaging` is blocked