### PR TITLE
Run clang-tidy with modernize-use-starts-ends-with

### DIFF
--- a/c10/util/string_view.h
+++ b/c10/util/string_view.h
@@ -595,33 +595,26 @@ constexpr inline void swap(
 using string_view = std::string_view;
 using c10_string_view = basic_string_view<char>;
 
-// NOTE: In C++20, this function should be replaced by string_view.starts_with
 constexpr bool starts_with(
     const std::string_view s,
     const std::string_view prefix) noexcept {
-  return (prefix.size() > s.size()) ? false
-                                    : prefix == s.substr(0, prefix.size());
+  return s.starts_with(prefix);
 }
 
-// NOTE: In C++20, this function should be replaced by string_view.starts_with
 constexpr bool starts_with(
     const std::string_view s,
     const char prefix) noexcept {
-  return !s.empty() && prefix == s.front();
+  return s.starts_with(prefix);
 }
 
-// NOTE: In C++20, this function should be replaced by string_view.ends_with
 constexpr bool ends_with(
     const std::string_view s,
     const std::string_view suffix) noexcept {
-  return (suffix.size() > s.size())
-      ? false
-      : suffix == s.substr(s.size() - suffix.size(), suffix.size());
+  return s.ends_with(suffix);
 }
 
-// NOTE: In C++20, this function should be replaced by string_view.ends_with
-constexpr bool ends_with(const std::string_view s, const char prefix) noexcept {
-  return !s.empty() && prefix == s.back();
+constexpr bool ends_with(const std::string_view s, const char suffix) noexcept {
+  return s.ends_with(suffix);
 }
 
 } // namespace c10

--- a/c10/util/string_view.h
+++ b/c10/util/string_view.h
@@ -595,26 +595,33 @@ constexpr inline void swap(
 using string_view = std::string_view;
 using c10_string_view = basic_string_view<char>;
 
+// NOTE: In C++20, this function should be replaced by string_view.starts_with
 constexpr bool starts_with(
     const std::string_view s,
     const std::string_view prefix) noexcept {
-  return s.starts_with(prefix);
+  return (prefix.size() > s.size()) ? false
+                                    : prefix == s.substr(0, prefix.size());
 }
 
+// NOTE: In C++20, this function should be replaced by string_view.starts_with
 constexpr bool starts_with(
     const std::string_view s,
     const char prefix) noexcept {
-  return s.starts_with(prefix);
+  return !s.empty() && prefix == s.front();
 }
 
+// NOTE: In C++20, this function should be replaced by string_view.ends_with
 constexpr bool ends_with(
     const std::string_view s,
     const std::string_view suffix) noexcept {
-  return s.ends_with(suffix);
+  return (suffix.size() > s.size())
+      ? false
+      : suffix == s.substr(s.size() - suffix.size(), suffix.size());
 }
 
-constexpr bool ends_with(const std::string_view s, const char suffix) noexcept {
-  return s.ends_with(suffix);
+// NOTE: In C++20, this function should be replaced by string_view.ends_with
+constexpr bool ends_with(const std::string_view s, const char prefix) noexcept {
+  return !s.empty() && prefix == s.back();
 }
 
 } // namespace c10

--- a/torch/csrc/autograd/profiler_python.cpp
+++ b/torch/csrc/autograd/profiler_python.cpp
@@ -502,7 +502,7 @@ void ValueCache::trimPrefixes() {
   for (auto& it : std::get<CallType::PyCall>(state_)) {
     std::string filename = it.second.filename_.str();
     for (const auto& p : prefixes) {
-      if (filename.compare(0, p.size(), p) == 0) {
+      if (filename.starts_with(p)) {
         filename.erase(0, p.size());
         it.second.filename_ = at::StringView(filename);
         break;

--- a/torch/csrc/cuda/memory_snapshot.cpp
+++ b/torch/csrc/cuda/memory_snapshot.cpp
@@ -146,8 +146,7 @@ at::CallbackHandle _initCompileContexts() {
               -> std::unique_ptr<at::ObserverContext> {
             std::string functionName = fn.name();
             const std::string functionNamePrefix = "Torch-Compiled Region";
-            if (functionName.compare(
-                    0, functionNamePrefix.size(), functionNamePrefix) == 0) {
+            if (functionName.starts_with(functionNamePrefix)) {
               c10::cuda::CUDACachingAllocator::pushCompileContext(functionName);
             }
             return nullptr;
@@ -155,8 +154,7 @@ at::CallbackHandle _initCompileContexts() {
           [](const at::RecordFunction& fn, at::ObserverContext* ctx_ptr) {
             std::string functionName = fn.name();
             const std::string functionNamePrefix = "Torch-Compiled Region";
-            if (functionName.compare(
-                    0, functionNamePrefix.size(), functionNamePrefix) == 0) {
+            if (functionName.starts_with(functionNamePrefix)) {
               c10::cuda::CUDACachingAllocator::popCompileContext();
             }
           })

--- a/torch/csrc/distributed/c10d/FileStore.cpp
+++ b/torch/csrc/distributed/c10d/FileStore.cpp
@@ -275,7 +275,7 @@ off_t refresh(
     while (size > pos) {
       file.read(tmpKey);
       file.read(tmpValue);
-      if (tmpKey.compare(0, deletePrefix.size(), deletePrefix) == 0) {
+      if (tmpKey.starts_with(deletePrefix)) {
         cache.erase(tmpKey.substr(deletePrefix.size()));
       } else {
         cache[tmpKey] = std::move(tmpValue);

--- a/torch/csrc/distributed/c10d/PrefixStore.cpp
+++ b/torch/csrc/distributed/c10d/PrefixStore.cpp
@@ -152,7 +152,7 @@ std::vector<std::string> PrefixStore::listKeys() {
   filteredKeys.reserve(keys.size());
 
   for (auto& key : keys) {
-    if (key.find(prefix_) == 0) {
+    if (key.starts_with(prefix_)) {
       key = key.substr(prefix_.size() + 1);
       filteredKeys.push_back(std::move(key));
     }

--- a/torch/csrc/distributed/c10d/TCPStore.cpp
+++ b/torch/csrc/distributed/c10d/TCPStore.cpp
@@ -737,7 +737,7 @@ std::vector<std::string> TCPStore::listKeys() {
   for (auto i = 0; i < numKeys; ++i) {
     auto bits = client_->receiveBits();
     std::string str(bits.begin(), bits.end());
-    if (str.find(keyPrefix_) == 0) {
+    if (str.starts_with(keyPrefix_)) {
       str = str.substr(keyPrefix_.size());
     } else {
       continue;

--- a/torch/csrc/jit/frontend/function_schema_parser.cpp
+++ b/torch/csrc/jit/frontend/function_schema_parser.cpp
@@ -121,7 +121,7 @@ struct SchemaParser {
     // and so shouldn't be used as an overload name
     // also disallow dunder attribute names to be overload names
     bool is_a_valid_overload_name =
-        !((overload_name == "default") || (overload_name.rfind("__", 0) == 0));
+        !((overload_name == "default") || (overload_name.starts_with("__")));
     TORCH_CHECK(
         is_a_valid_overload_name,
         overload_name,
@@ -409,8 +409,8 @@ std::variant<OperatorName, FunctionSchema> parseSchemaOrName(
     const std::string& schemaOrName,
     bool allow_typevars) {
   // We're ignoring aten and prim for BC reasons
-  if (schemaOrName.rfind("aten::", 0) == 0 ||
-      schemaOrName.rfind("prim::", 0) == 0) {
+  if (schemaOrName.starts_with("aten::") ||
+      schemaOrName.starts_with("prim::")) {
     allow_typevars = true;
   }
   return SchemaParser(schemaOrName, allow_typevars)

--- a/torch/csrc/jit/frontend/script_type_parser.cpp
+++ b/torch/csrc/jit/frontend/script_type_parser.cpp
@@ -129,7 +129,7 @@ std::optional<std::pair<TypePtr, int32_t>> ScriptTypeParser::parseBroadcastList(
     constexpr auto _size_suffix = "_t";
     constexpr auto _size_n_len = 9; // strlen("_size_X_t")
     constexpr auto _size_prefix_len = 6; // strlen("_size_");
-    if (name.find(_size_prefix) == 0 && name.length() == _size_n_len &&
+    if (name.starts_with(_size_prefix) && name.length() == _size_n_len &&
         name.find(_size_suffix) == _size_prefix_len + 1 &&
         ::isdigit(name[_size_prefix_len])) {
       int n = name[_size_prefix_len] - '0';
@@ -154,7 +154,7 @@ std::optional<std::pair<TypePtr, int32_t>> ScriptTypeParser::parseBroadcastList(
     } else {
       return std::nullopt;
     }
-  } else if (var.name().name().find("BroadcastingList") != 0) {
+  } else if (!var.name().name().starts_with("BroadcastingList")) {
     return std::nullopt;
   }
 
@@ -266,7 +266,7 @@ TypePtr ScriptTypeParser::parseTypeFromExprImpl(const Expr& expr) const {
 
     // Check if the type is a custom class. This is done by checking
     // if type_name starts with "torch.classes."
-    if (type_name.find("torch.classes.") == 0) {
+    if (type_name.starts_with("torch.classes.")) {
       auto custom_class_type = getCustomClass("__torch__." + type_name);
       return custom_class_type;
     }
@@ -275,13 +275,13 @@ TypePtr ScriptTypeParser::parseTypeFromExprImpl(const Expr& expr) const {
     // custom classes of type torch.classes.cuda.Stream and
     // torch.classes.cuda.Event respectively. Return the respective
     // custom class types for these two cases.
-    if (type_name.find("torch.cuda.Stream") == 0) {
+    if (type_name.starts_with("torch.cuda.Stream")) {
       auto custom_class_type =
           getCustomClass("__torch__.torch.classes.cuda.Stream");
       return custom_class_type;
     }
 
-    if (type_name.find("torch.cuda.Event") == 0) {
+    if (type_name.starts_with("torch.cuda.Event")) {
       auto custom_class_type =
           getCustomClass("__torch__.torch.classes.cuda.Event");
       return custom_class_type;

--- a/torch/csrc/jit/ir/subgraph_matcher.cpp
+++ b/torch/csrc/jit/ir/subgraph_matcher.cpp
@@ -218,10 +218,6 @@ bool SubgraphMatcher::matchAttributes(const Node* n1, Node* n2) {
   return true;
 }
 
-static bool endsWith(const std::string& str, const std::string& suffix) {
-  return str.ends_with(suffix);
-}
-
 /**
  * Compare two Nodes. N1 is from pattern, N2 is from the actual graph.
  *
@@ -268,7 +264,7 @@ bool SubgraphMatcher::matchNodes(const Node* n1, Node* n2) {
       auto t = n2->output()->type()->expect<ClassType>();
       auto real_typename = t->name()->qualifiedName();
       auto pattern_typename = n1->s(attr::name);
-      if (!endsWith(real_typename, pattern_typename)) {
+      if (!real_typename.ends_with(pattern_typename)) {
         GRAPH_DEBUG(
             "Nodes did not match because expected module type is different:\n");
         GRAPH_DEBUG("  actualtype:    ", real_typename, '\n');

--- a/torch/csrc/jit/ir/subgraph_matcher.cpp
+++ b/torch/csrc/jit/ir/subgraph_matcher.cpp
@@ -219,8 +219,7 @@ bool SubgraphMatcher::matchAttributes(const Node* n1, Node* n2) {
 }
 
 static bool endsWith(const std::string& str, const std::string& suffix) {
-  return str.size() >= suffix.size() &&
-      0 == str.compare(str.size() - suffix.size(), suffix.size(), suffix);
+  return str.ends_with(suffix);
 }
 
 /**

--- a/torch/csrc/jit/mobile/import.cpp
+++ b/torch/csrc/jit/mobile/import.cpp
@@ -525,7 +525,7 @@ mobile::Module _load_for_mobile_impl(
     // https://www.internalfb.com/code/fbsource/[9996fcb7a6fb]/fbcode/caffe2/torch/csrc/jit/mobile/import.cpp?lines=427-434
     std::vector<std::string> all_files = reader->getAllRecords();
     for (auto& file_name : all_files) {
-      if (file_name.find("extra/") == 0) {
+      if (file_name.starts_with("extra/")) {
         extra_files[file_name.substr(6)] = "";
       }
     }

--- a/torch/csrc/jit/mobile/model_tracer/MobileModelRunner.cpp
+++ b/torch/csrc/jit/mobile/model_tracer/MobileModelRunner.cpp
@@ -200,8 +200,8 @@ void MobileModelRunner::run_argless_functions(
 bool MobileModelRunner::set_has_metal_gpu_operators(
     std::set<std::string> const& op_list) {
   for (std::string const& op : op_list) {
-    if (op.find("metal::") == 0 || op.find("metal_prepack::") == 0 ||
-        op.find("metal_prepack_unet::") == 0) {
+    if (op.starts_with("metal::") || op.starts_with("metal_prepack::") ||
+        op.starts_with("metal_prepack_unet::")) {
       return true;
     }
   }

--- a/torch/csrc/jit/python/pybind_utils.cpp
+++ b/torch/csrc/jit/python/pybind_utils.cpp
@@ -750,7 +750,7 @@ py::object toPyObject(IValue ivalue) {
     }
 
     auto pyCu = get_python_cu();
-    if (obj->name().find("__torch__.torch.classes") == 0) {
+    if (obj->name().starts_with("__torch__.torch.classes")) {
       return py::cast(Object(obj));
     }
     const auto classType = pyCu->get_class(c10::QualifiedName(obj->name()));

--- a/torch/csrc/jit/runtime/interpreter/code_impl.h
+++ b/torch/csrc/jit/runtime/interpreter/code_impl.h
@@ -446,7 +446,7 @@ struct CodeImpl {
     // check if the node should be emitted as instruction or operator
     const Operator& op = node->getOperator();
     std::string unique_op_name = c10::toString(op.schema().operator_name());
-    if (unique_op_name.find("aten::__getitem__.Dict") == 0) {
+    if (unique_op_name.starts_with("aten::__getitem__.Dict")) {
       // __get_item__ overloaded operator for Dict
       // needs to be emitted an instruction
       emitOperatorOrInstruction(node, DICT_INDEX);

--- a/torch/csrc/jit/runtime/symbolic_script.cpp
+++ b/torch/csrc/jit/runtime/symbolic_script.cpp
@@ -1541,7 +1541,7 @@ static std::string overloadedSchemaString(const FunctionSchema& schema) {
 
 static bool isHelperFunction(const std::string& method_name) {
   std::string helper_prefix = "AD_";
-  return method_name.compare(0, helper_prefix.length(), helper_prefix) == 0;
+  return method_name.starts_with(helper_prefix);
 }
 
 static void loadModule(const CompilationUnit& module) {

--- a/torch/csrc/jit/serialization/export_module.cpp
+++ b/torch/csrc/jit/serialization/export_module.cpp
@@ -230,7 +230,7 @@ std::pair<IValue, IValue> getFunctionTuple(
           get_named_tuple_str_or_default(compilation_unit, t, type_str);
       types.emplace_back(named_tuple_str);
       continue;
-    } else if (type_str.find(torch_prefix) == 0) {
+    } else if (type_str.starts_with(torch_prefix)) {
       TORCH_CHECK(
           type_str.find(class_prefix) == 0,
           "__torch__ types other than custom c++ classes (__torch__.torch.classes)"

--- a/torch/csrc/jit/serialization/flatbuffer_serializer.cpp
+++ b/torch/csrc/jit/serialization/flatbuffer_serializer.cpp
@@ -284,7 +284,7 @@ flatbuffers::Offset<mobile::serialization::Function> FlatbufferSerializer::
 
   for (const TypePtr& t : code.types_) {
     auto type_str = realType(t)->annotation_str();
-    if (type_str.find(torch_prefix) == 0) {
+    if (type_str.starts_with(torch_prefix)) {
       TORCH_CHECK(
           type_str.find(class_prefix) == 0,
           "__torch__ types other than custom c++ classes (__torch__.torch.classes)"

--- a/torch/csrc/lazy/core/metrics.cpp
+++ b/torch/csrc/lazy/core/metrics.cpp
@@ -409,7 +409,7 @@ std::string CreateMetricReport(
 
   static std::string fall_back_counter_prefix = "aten::";
   arena->ForEachCounter([&ss](const std::string& name, CounterData* data) {
-    if (name.rfind(fall_back_counter_prefix, 0) == 0) {
+    if (name.starts_with(fall_back_counter_prefix)) {
       // it might emit duplicated counter if user also specified exact aten
       // counter in the `counter_names` but it should be very rare.
       EmitCounterInfo(name, data, &ss);

--- a/torch/csrc/profiler/collection.cpp
+++ b/torch/csrc/profiler/collection.cpp
@@ -457,7 +457,7 @@ void ThreadLocalSubqueue::TorchOpStorage::materialize(
     auto& second = (++it)->basic_fields_;
     if (first.scope_ == at::RecordScope::FUNCTION &&
         second.scope_ == at::RecordScope::BACKWARD_FUNCTION &&
-        first.name_.rfind("autograd::engine::evaluate_function: ", 0) == 0) {
+        first.name_.starts_with("autograd::engine::evaluate_function: ")) {
       first.sequence_number_ = second.sequence_number_;
       first.forward_tid_ = second.forward_tid_;
     }

--- a/torch/csrc/utils/invalid_arguments.cpp
+++ b/torch/csrc/utils/invalid_arguments.cpp
@@ -143,14 +143,14 @@ std::unique_ptr<Type> _buildType(std::string type_name, bool is_nullable) {
     result = std::make_unique<MultiType>(MultiType{"float", "int", "long"});
   } else if (type_name == "int") {
     result = std::make_unique<MultiType>(MultiType{"int", "long"});
-  } else if (type_name.find("tuple[") == 0) {
+  } else if (type_name.starts_with("tuple[")) {
     auto type_list = type_name.substr(6);
     type_list.pop_back();
     std::vector<std::unique_ptr<Type>> types;
     for (auto& type : _splitString(type_list, ","))
       types.emplace_back(_buildType(type, false));
     result = std::make_unique<TupleType>(std::move(types));
-  } else if (type_name.find("sequence[") == 0) {
+  } else if (type_name.starts_with("sequence[")) {
     auto subtype = type_name.substr(9);
     subtype.pop_back();
     result = std::make_unique<SequenceType>(_buildType(subtype, false));


### PR DESCRIPTION
C++20 provides starts/ends_with member functions for string_view
.
Prior to C++20, the common pattern to perform this check was to use
find/rfind/substr and compare the resulting index with 0 or N-1.
This PR replaces those instances with starts/ends_with.

All the changes (except in c10/util/string_view.h) were done using
clang-tidy with [modernize-use-starts-ends-with][1] check enabled.

PyTorch now supports C++20 https://github.com/pytorch/pytorch/issues/176662

[1]: https://clang.llvm.org/extra/clang-tidy/checks/modernize/use-starts-ends-with.html