### PR TITLE
Unify duplicate create_fw_bw_graph helpers

### DIFF
--- a/torch/_higher_order_ops/base_hop.py
+++ b/torch/_higher_order_ops/base_hop.py
@@ -244,15 +244,11 @@ class BaseHOPFunction(torch.autograd.Function):
             torch.enable_grad(),
         ):
             with disable_proxy_modes_tracing():
-                from .invoke_subgraph import create_fw_bw_graph
+                from .invoke_subgraph import trace_joint_graph
                 from .utils import _from_fun
 
                 fw_inputs = pytree.tree_map(_from_fun, operands)
-                (
-                    _,
-                    joint_graph,
-                    _,
-                ) = create_fw_bw_graph(subgraph, fw_inputs, grad_outputs)
+                joint_graph = trace_joint_graph(subgraph, fw_inputs, grad_outputs)
 
         # The joint graph returns (*grad_inputs, *fwd_outputs).
         # We only need the grad_inputs.

--- a/torch/_higher_order_ops/invoke_subgraph.py
+++ b/torch/_higher_order_ops/invoke_subgraph.py
@@ -316,7 +316,6 @@ def get_invoke_subgraph_cache():
     return cache
 
 
-# TODO (@anijain2305) - Delete this function when base_hop uses invoke_subgraph infra
 def trace_joint_graph(fn, fw_inputs, fw_outputs):
     """
     Naively trace out a joint graph. This simplifies the reconstruction of joint
@@ -355,80 +354,6 @@ def trace_joint_graph(fn, fw_inputs, fw_outputs):
     joint_operands = primals + tangents
 
     return _maybe_reenter_make_fx(joint_fn)(*joint_operands)
-
-
-# TODO (@anijain2305) - Delete this function when base_hop uses invoke_subgraph infra
-def create_fw_bw_graph(subgraph, operands, grad_outputs=None):
-    with suspend_functionalization(), disable_functional_mode():
-        with disable_proxy_modes_tracing():
-            # args are functional tensors, generate some example tensors
-            fw_inputs = pytree.tree_map(_from_fun, operands)
-
-            from torch._guards import detect_fake_mode
-
-            fake_mode = detect_fake_mode(fw_inputs)
-            context = (
-                nullcontext()
-                if fake_mode is None or fake_mode.shape_env is None
-                else fake_mode.shape_env.ignore_fresh_unbacked_symbols()
-            )
-
-            with context:
-                fw_outs = pytree.tree_map(_from_fun, subgraph(*fw_inputs))
-
-            num_fw_outs = len(fw_outs)
-
-            # Collect the indexes of none in the output to check that the grad
-            # is None at the corresponding index in the backward. This check is
-            # performed in the autograd.Function - InvokeSubgraphAutogradOp.
-            # Also collect the indexes of no_grad in the output to filter out
-            # the grad_outs in the `backward` method.
-            output_metadata = OutputMetadata()
-
-            output_metadata.num_fw_outs = num_fw_outs
-            for idx, fw_out in enumerate(fw_outs):
-                if isinstance(fw_out, torch.SymInt):
-                    output_metadata.indexes_with_symint.add(idx)
-                elif not fw_out.requires_grad:
-                    output_metadata.indexes_with_no_grad.add(idx)
-
-            if grad_outputs is None:
-                # Infer grad_outputs to be the same properties as the fw_outputs
-                # if they're not passed in
-                # Although fw_outs are equivalent to grad_outputs for tracing
-                # purposes, we have to carefully handle the None and fw_out that do
-                # not have require_grad. At those indexes, we will have None in the
-                # backward graph.
-                grad_outputs = fw_outs
-                grad_outputs = [grad for grad in grad_outputs if grad is not None]
-                grad_outputs = [grad for grad in grad_outputs if grad.requires_grad]
-
-                # Force grad_out to be contiguous. This is because at runtime,
-                # grad_out could have different strides than fw_outs. So, we
-                # force the grad_outs to be contiguous for both tracing and
-                # runtime.
-                grad_outputs = [grad.contiguous() for grad in grad_outputs]
-
-            if any(
-                not isinstance(out, torch.Tensor)
-                for out in grad_outputs
-                if out is not None
-            ):
-                raise RuntimeError(
-                    "Expect outputs of invoke_subgraph to only contains tensors or None. "
-                    f"Got types {[type(out) for out in grad_outputs]}."
-                )
-
-            # Trace the forward subgraph
-            fw_graph = _maybe_reenter_make_fx(subgraph)(*fw_inputs)
-
-            # Trace the joint graph and assign it to the bwd graph
-            bw_graph = trace_joint_graph(
-                subgraph,
-                fw_inputs,
-                grad_outputs,
-            )
-            return fw_graph, bw_graph, output_metadata
 
 
 def get_output_metadata(subgraph, *operands):


### PR DESCRIPTION
## Summary
- remove the duplicate `create_fw_bw_graph` wrapper from `torch/_higher_order_ops/invoke_subgraph.py`
- route `BaseHOPFunction.backward` through `trace_joint_graph`, which already produces the same backward graph signature
- leave the specialized `flex_attention` helper in place as the remaining separate implementation

## Root cause
`create_fw_bw_graph` had diverged into three separate definitions. The `invoke_subgraph.py` copy only existed to serve `base_hop.py`, even though `invoke_subgraph` already exposed the lower-level joint-graph tracer that base HOP backward actually needed.

## Proposed fix
Delete the `invoke_subgraph.py` wrapper and have `BaseHOPFunction.backward` call `trace_joint_graph` directly with the same example operands and grad outputs.

## Why this is the right long term fix
This removes the redundant wrapper instead of maintaining another near-duplicate entry point. The shared backward tracing logic now lives in one place for the generic HOP path, while `flex_attention` keeps its separate implementation because its tracing contract is materially different.

## Testing
- `python3 -m compileall torch/_higher_order_ops/base_hop.py torch/_higher_order_ops/invoke_subgraph.py`
- attempted `python3 test/dynamo/test_base_hop.py -k test_aot_eager` but the local Python environment on this box has no `torch` installed, so runtime execution was blocked

Drafted via Codex, published after manual review by @bobrenjc93