### PR TITLE
[fx] Move proxy tensor decomposition state onto mode

### DIFF
--- a/test/test_proxy_tensor.py
+++ b/test/test_proxy_tensor.py
@@ -23,7 +23,13 @@ from torch.testing._internal.hop_db import hop_db
 from torch.testing._internal.common_device_type import ops
 import torch.testing._internal.optests as optests
 from torch._C import _disabled_torch_function_impl
-from torch.fx.experimental.proxy_tensor import make_fx, DecompositionInterpreter, get_isolated_graphmodule
+from torch.fx.experimental.proxy_tensor import (
+    DecompositionInterpreter,
+    get_isolated_graphmodule,
+    make_fx,
+    ProxyTorchDispatchMode,
+    PythonKeyTracer,
+)
 from torch.utils._pytree import tree_map
 from torch.fx.passes.runtime_assert import insert_deferred_runtime_asserts
 from torch import nn
@@ -361,6 +367,25 @@ def forward(self, x_1):
     copy_ = torch.ops.aten.copy_.default(zeros, x_1);  zeros = x_1 = None
     return copy_
     """)
+
+    def test_proxy_tensor_mode_tracks_nested_decomp_tables(self):
+        sin_table = {torch.ops.aten.sin.default: lambda x: x}
+        cos_table = {torch.ops.aten.cos.default: lambda x: x}
+        tan_table = {torch.ops.aten.tan.default: lambda x: x}
+
+        mode = ProxyTorchDispatchMode(
+            PythonKeyTracer(),
+            tracing_mode="real",
+            decomposition_table=sin_table,
+        )
+
+        self.assertIs(mode.decomposition_table, sin_table)
+        with mode.enable_decompositions(cos_table):
+            self.assertIs(mode.decomposition_table, cos_table)
+            with mode.enable_decompositions(tan_table):
+                self.assertIs(mode.decomposition_table, tan_table)
+            self.assertIs(mode.decomposition_table, cos_table)
+        self.assertIs(mode.decomposition_table, sin_table)
 
     def test_make_fx_reentrant_dispatch(self):
         def f(x):

--- a/torch/_dynamo/compiled_autograd.py
+++ b/torch/_dynamo/compiled_autograd.py
@@ -52,7 +52,6 @@ from torch._subclasses.fake_tensor import FakeTensor
 from torch.fx import GraphModule
 from torch.fx.experimental._backward_state import BackwardState
 from torch.fx.experimental.proxy_tensor import (
-    decompose,
     disable_autocast_cache,
     disable_proxy_modes_tracing,
     fetch_object_proxy,
@@ -411,7 +410,6 @@ class AutogradCompilerInstance:
             self.symnode_proxy_lookup[symval.node] = self.scalars_proxy[i]  # type: ignore[union-attr]
 
         # TODO(jansel): are all these modes needed?
-        self.stack.enter_context(decompose({}))
         self.stack.enter_context(self.fake_tensor_mode)
         self.stack.enter_context(self.proxy_mode)
         self.stack.enter_context(disable_autocast_cache())

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -121,10 +121,6 @@ prim = torch.ops.prim
 log = logging.getLogger(__name__)
 not_implemented_log = torch._logging.getArtifactLogger(__name__, "not_implemented")
 
-CURRENT_DECOMPOSITION_TABLE: contextvars.ContextVar[
-    Mapping[OpOverload, Callable[..., Any]]
-] = contextvars.ContextVar("CURRENT_DECOMPOSITION_TABLE")
-
 CONSTANT_NUMEL_LIMIT = 1
 
 T = TypeVar("T")
@@ -164,13 +160,13 @@ def fake_signature(fn: Callable[_P, R], nargs: int) -> Callable[_P, R]:
 @contextmanager
 def decompose(
     decomposition_table: Mapping[OpOverload, Callable[..., Any]] | None,
+    proxy_mode: ProxyTorchDispatchMode | None = None,
 ) -> Generator[Mapping[OpOverload, Callable[..., Any]], None, None]:
-    table = decomposition_table or {}
-    token = CURRENT_DECOMPOSITION_TABLE.set(table)
-    try:
+    mode = proxy_mode or get_proxy_mode()
+    if mode is None:
+        raise AssertionError("Expected proxy mode to be set")
+    with mode.enable_decompositions(decomposition_table) as table:
         yield table
-    finally:
-        CURRENT_DECOMPOSITION_TABLE.reset(token)
 
 
 # ensure we cannot collide with other properties
@@ -1932,6 +1928,7 @@ class ProxyTorchDispatchMode(TorchDispatchMode):
         self,
         tracer: _ProxyTracer,
         tracing_mode: _TracingMode,
+        decomposition_table: Mapping[OpOverload, Callable[..., Any]] | None = None,
         pre_dispatch: bool = False,
         _allow_fake_constant: bool = False,
         _error_on_data_dependent_ops: bool = True,
@@ -1950,6 +1947,12 @@ class ProxyTorchDispatchMode(TorchDispatchMode):
         # ProxyTorchDispatchMode state was (if there was any).
         # This lets us properly reset the state on exit.
         self.enter_stack: list[ProxyTorchDispatchMode | None] = []
+        self.decomposition_table: Mapping[OpOverload, Callable[..., Any]] = (
+            decomposition_table or {}
+        )
+        self._decomposition_table_stack: list[
+            Mapping[OpOverload, Callable[..., Any]]
+        ] = []
         self.decomp_layers: int = 0
         # See invoke_subgraph
         self._invoke_subgraph_names: set[str] = set()
@@ -2000,6 +2003,19 @@ class ProxyTorchDispatchMode(TorchDispatchMode):
     @classmethod
     def is_infra_mode(cls) -> bool:
         return True
+
+    @contextmanager
+    def enable_decompositions(
+        self,
+        decomposition_table: Mapping[OpOverload, Callable[..., Any]] | None,
+    ) -> Generator[Mapping[OpOverload, Callable[..., Any]], None, None]:
+        table = decomposition_table or {}
+        self._decomposition_table_stack.append(self.decomposition_table)
+        self.decomposition_table = table
+        try:
+            yield table
+        finally:
+            self.decomposition_table = self._decomposition_table_stack.pop()
 
     def __sym_dispatch__(
         self,
@@ -2107,7 +2123,11 @@ class DecompositionInterpreter(fx.Interpreter):
         self.tracer = _GraphAppendingTracerEx(self.new_graph)
         # Blegh
         self.decomposition_table = decomposition_table or {}
-        self.mode = ProxyTorchDispatchMode(self.tracer, tracing_mode="real")
+        self.mode = ProxyTorchDispatchMode(
+            self.tracer,
+            tracing_mode="real",
+            decomposition_table=self.decomposition_table,
+        )
 
     # pyrefly: ignore [bad-override]
     def placeholder(
@@ -2157,7 +2177,7 @@ class DecompositionInterpreter(fx.Interpreter):
     def run(self, *args: object, **kwargs: object) -> object:
         # Should enter the mode at least once for being able to restore it later
         # See: https://github.com/pytorch/pytorch/pull/82549#discussion_r934782025
-        with decompose(self.decomposition_table), self.mode:
+        with self.mode:
             return super().run(*args, **kwargs)  # type: ignore[arg-type]
 
 
@@ -2214,7 +2234,10 @@ class _SelectiveDecomposeInterpreter(fx.Interpreter):
 
     def run_node(self, n: fx.Node) -> Any:
         if self.should_decompose(n):
-            with decompose(self.decomposition_table):
+            mode = get_proxy_mode()
+            if mode is None:
+                raise AssertionError("Expected proxy mode to be set")
+            with decompose(self.decomposition_table, proxy_mode=mode):
                 result = super().run_node(n)
         else:
             result = super().run_node(n)
@@ -2734,6 +2757,7 @@ class _MakefxTracer:
         self.proxy_mode = ProxyTorchDispatchMode(
             fx_tracer,
             self.tracing_mode,
+            decomposition_table=self.decomposition_table,
             pre_dispatch=self.pre_dispatch,
             _allow_fake_constant=self._allow_fake_constant,
             _error_on_data_dependent_ops=self._error_on_data_dependent_ops,
@@ -2860,7 +2884,6 @@ class _MakefxTracer:
             ProxyTorchDispatchMode, self.proxy_mode
         )
         with ExitStack() as stack:
-            stack.enter_context(decompose(self.decomposition_table))
             if self.fake_tensor_mode:
                 stack.enter_context(self.fake_tensor_mode)
             stack.enter_context(self.python_dispatcher_mode)
@@ -3074,7 +3097,7 @@ def maybe_handle_decomp(
 ) -> object:
     from torch._inductor.compiler_bisector import CompilerBisector
 
-    decomp_table = CURRENT_DECOMPOSITION_TABLE.get({})
+    decomp_table = proxy_mode.decomposition_table
     if op in decomp_table:
         if CompilerBisector.disable_subsystem(
             "aot_eager_decomp_partition", "decomposition", lambda: repr(op)

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -160,9 +160,8 @@ def fake_signature(fn: Callable[_P, R], nargs: int) -> Callable[_P, R]:
 @contextmanager
 def decompose(
     decomposition_table: Mapping[OpOverload, Callable[..., Any]] | None,
-    proxy_mode: ProxyTorchDispatchMode | None = None,
 ) -> Generator[Mapping[OpOverload, Callable[..., Any]], None, None]:
-    mode = proxy_mode or get_proxy_mode()
+    mode = get_proxy_mode()
     if mode is None:
         raise AssertionError("Expected proxy mode to be set")
     with mode.enable_decompositions(decomposition_table) as table:
@@ -1928,10 +1927,10 @@ class ProxyTorchDispatchMode(TorchDispatchMode):
         self,
         tracer: _ProxyTracer,
         tracing_mode: _TracingMode,
-        decomposition_table: Mapping[OpOverload, Callable[..., Any]] | None = None,
         pre_dispatch: bool = False,
         _allow_fake_constant: bool = False,
         _error_on_data_dependent_ops: bool = True,
+        decomposition_table: Mapping[OpOverload, Callable[..., Any]] | None = None,
     ) -> None:
         dk = torch._C.DispatchKey.PreDispatch if pre_dispatch else None
         super().__init__(dk)
@@ -2234,10 +2233,7 @@ class _SelectiveDecomposeInterpreter(fx.Interpreter):
 
     def run_node(self, n: fx.Node) -> Any:
         if self.should_decompose(n):
-            mode = get_proxy_mode()
-            if mode is None:
-                raise AssertionError("Expected proxy mode to be set")
-            with decompose(self.decomposition_table, proxy_mode=mode):
+            with decompose(self.decomposition_table):
                 result = super().run_node(n)
         else:
             result = super().run_node(n)


### PR DESCRIPTION
## Summary
This moves the decomposition table onto `ProxyTorchDispatchMode` instead of reading it from module-level state.

## Root cause
`maybe_handle_decomp()` depended on a module-level decomposition context that was set far away from the proxy dispatch call sites, which made the control flow implicit and stateful.

## Proposed fix
- store the active decomposition table on `ProxyTorchDispatchMode`
- initialize each mode from its owning tracer/interpreter
- use a mode-local override stack for selective decomposition
- remove the now-redundant compiled autograd empty decompose context
- add a regression test covering nested decomposition-table overrides

## Why this is the right long term fix
The active decomposition table now travels with the active proxy mode, which removes the hidden module-level coupling and makes nested tracing/selective decomposition overrides explicit and local to the mode that is actually executing the trace.

Drafted via Codex, published after manual review by @bobrenjc93

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98 @xmfan @aditvenk