### PR TITLE
Fix incorrect `| None` in pyi stubs for `Tensor[]` list args (#179391)

### DIFF
--- a/torchgen/api/python.py
+++ b/torchgen/api/python.py
@@ -288,7 +288,7 @@ class PythonArgument:
             name += "_"
 
         # pyi merges the _out and functional variants into the same signature, with an optional out arg
-        if name == "out" and type_str == "Tensor" and not deprecated:
+        if name == "out" and not deprecated:
             type_str = f"{type_str} | None".replace(" | None | None", " | None")
 
         # pyi deprecated signatures don't get defaults for their out arg

--- a/torchgen/api/python.py
+++ b/torchgen/api/python.py
@@ -975,14 +975,17 @@ def argument_type_str_pyi(t: Type) -> str:
         if str(t.elem) == "int":
             ret = "_int | _size" if t.size is not None else "_size"
         elif t.is_tensor_like():
-            # TODO: this doesn't seem right...
-            # Tensor?[] currently translates to tuple[Tensor, ...] | list[Tensor] | None
-            # It should probably translate to   tuple[Tensor | None, ...] | list[Tensor | None]
-            add_optional = True
+            # Tensor?[] translates to tuple[Tensor | None, ...] | list[Tensor | None] | None
+            # Tensor[] translates to tuple[Tensor, ...] | list[Tensor]
+            if isinstance(t.elem, OptionalType):
+                add_optional = True
+                elem_str = "Tensor | None"
+            else:
+                elem_str = "Tensor"
             ret = (
-                "Tensor | tuple[Tensor, ...] | list[Tensor]"
+                f"Tensor | tuple[{elem_str}, ...] | list[{elem_str}]"
                 if t.size is not None
-                else "tuple[Tensor, ...] | list[Tensor]"
+                else f"tuple[{elem_str}, ...] | list[{elem_str}]"
             )
         elif str(t.elem) == "float":
             ret = "Sequence[_float]"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #179467

`argument_type_str_pyi` unconditionally added `| None` to all tensor-like list types,
making `Tensor[]` (used by `torch.cat`, `torch.stack`, etc.) generate `tuple[Tensor, ...] | list[Tensor] | None` even though the argument is not optional.
After this change only `Tensor?[]` gets the outer `| None`, and its element type is correctly rendered as `Tensor | None`.

This TODO were implicitly used for `out=` variants, that are always optional.

Test plan: `python -c "from torchgen.model import *; from torchgen.api.python import argument_type_str_pyi; print(argument_type_str_pyi(ListType(BaseType(BaseTy.Tensor), None)))" `

Fixes #179391

Authored with Claude.