### PR TITLE
Refactor control-flow HOP dispatch boilerplate

### DIFF
--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -15,6 +15,7 @@ from torch._dynamo.testing import (
 from torch._higher_order_ops.associative_scan import (
     _fake_associative_scan,
     associative_scan,
+    associative_scan_op,
 )
 from torch._higher_order_ops.cudagraph_conditional_nodes import (
     ControlFlowOpWarmupDispatchMode,
@@ -7002,6 +7003,19 @@ def forward(self, arg0_1):
         res = gm(x, y, z)
         self.assertEqual(res, g(x, y, z))
         self.check_map_count(gm, 1)
+
+    def test_tracing_associative_scan_op_symbolic(self):
+        def combine_fn(lhs, rhs):
+            return [lhs + rhs.sin()]
+
+        def f(x):
+            return associative_scan_op(combine_fn, [x], ())
+
+        gm = make_fx(f, tracing_mode="symbolic")(torch.ones(3, 4))
+        x = torch.randn(5, 4)
+        res = gm(x)
+        self.assertEqual(res, f(x))
+        self.assertTrue(hasattr(gm, "associative_scan_combine_graph_0"))
 
     def test_tracing_map_autograd_symbolic_simple(self):
         def f(x, y):

--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -7017,6 +7017,19 @@ def forward(self, arg0_1):
         self.assertEqual(res, f(x))
         self.assertTrue(hasattr(gm, "associative_scan_combine_graph_0"))
 
+    def test_tracing_associative_scan_op_real(self):
+        def combine_fn(lhs, rhs):
+            return [lhs + rhs.sin()]
+
+        def f(x):
+            return associative_scan_op(combine_fn, [x], ())
+
+        gm = make_fx(f, tracing_mode="real")(torch.ones(3, 4))
+        x = torch.randn(5, 4)
+        res = gm(x)
+        self.assertEqual(res, f(x))
+        self.assertTrue(hasattr(gm, "associative_scan_combine_graph_0"))
+
     def test_tracing_map_autograd_symbolic_simple(self):
         def f(x, y):
             return x + y

--- a/torch/_higher_order_ops/associative_scan.py
+++ b/torch/_higher_order_ops/associative_scan.py
@@ -7,30 +7,25 @@ from typing import Any
 import torch
 import torch._prims_common as utils
 import torch.utils._pytree as pytree
-from torch._C import DispatchKey
 from torch._higher_order_ops.utils import (
     _maybe_compile_and_run_fn,
     _maybe_run_with_interpreter,
     check_input_alias_and_mutation_return_outputs,
     check_meta_consistency,
+    create_hop_call_proxy,
     create_bw_fn,
     first_slice_copy,
     first_slice_copy_with_grad,
     materialize_as_graph,
-    reenter_make_fx,
+    register_hop_dispatches,
     save_values_for_backward,
     saved_values,
     split_into_chunks,
-    unique_graph_id,
+    trace_and_register_subgraphs,
     validate_subgraph_args_types,
 )
 from torch._ops import HigherOrderOperator
-from torch._subclasses.fake_tensor import FakeTensorMode
-from torch.fx.experimental.proxy_tensor import (
-    disable_proxy_modes_tracing,
-    ProxyTorchDispatchMode,
-    track_tensor_tree,
-)
+from torch.fx.experimental.proxy_tensor import disable_proxy_modes_tracing, track_tensor_tree
 
 
 aten = torch._ops.ops.aten
@@ -419,9 +414,15 @@ def trace_associative_scan(
             clone_input(x) if isinstance(x, torch.Tensor) else x
             for x in additional_inputs
         ]
-        combine_graph = reenter_make_fx(combine_fn)(
-            *sample_xs, *sample_additional_inputs
+        (combine_subgraph,) = trace_and_register_subgraphs(
+            proxy_mode,
+            (
+                "associative_scan_combine_graph",
+                combine_fn,
+                (*sample_xs, *sample_additional_inputs),
+            ),
         )
+        combine_graph = combine_subgraph.graph
 
     outputs = None
     for node in combine_graph.graph.nodes:
@@ -452,16 +453,12 @@ def trace_associative_scan(
         xs_fake_tensors, output_fake_tensors, "init", "carry", include_contiguity=False
     )
 
-    _, combine_graph_name = unique_graph_id(
-        proxy_mode, prefix="associative_scan_combine_graph"
-    )
-
-    proxy_mode.tracer.root.register_module(combine_graph_name, combine_graph)
-
     args = (combine_graph, xs, additional_inputs)
-    proxy_args = pytree.tree_map(proxy_mode.tracer.unwrap_proxy, args)
-    out_proxy = proxy_mode.tracer.create_proxy(
-        "call_function", func_overload, proxy_args, {}, name="associative_scan"
+    out_proxy = create_hop_call_proxy(
+        proxy_mode,
+        func_overload,
+        args,
+        name="associative_scan",
     )
 
     with disable_proxy_modes_tracing():
@@ -470,7 +467,6 @@ def trace_associative_scan(
     return track_tensor_tree(out, out_proxy, constant=None, tracer=proxy_mode.tracer)
 
 
-@associative_scan_op.py_impl(DispatchKey.CompositeExplicitAutograd)
 def associative_scan_op_dense(combine_fn, xs, additional_inputs):
     return generic_associative_scan(combine_fn, xs, additional_inputs=additional_inputs)
 
@@ -832,7 +828,6 @@ class AssociativeScanAutogradOp(torch.autograd.Function):
         return *[None] * 3, *g_xs, *[None] * num_additional_inputs
 
 
-@associative_scan_op.py_autograd_impl
 def associative_scan_autograd(combine_fn, xs, additional_inputs):
     num_xs = len(xs)
     num_additional_inputs = len(additional_inputs)
@@ -851,20 +846,17 @@ def associative_scan_autograd(combine_fn, xs, additional_inputs):
     return (*flat_out,)
 
 
-@associative_scan_op.py_impl(ProxyTorchDispatchMode)
 def associative_scan_proxy_mode(mode, combine_fn, xs, additional_inputs):
     return trace_associative_scan(
         mode, associative_scan_op, combine_fn, xs, additional_inputs
     )
 
 
-@associative_scan_op.py_impl(FakeTensorMode)
 def assoiciative_scan_fake_tensor_mode(mode, combine_fn, xs, additional_inputs):
     with mode:
         return tuple(x.clone() for x in xs)
 
 
-@associative_scan_op.py_functionalize_impl
 def associative_scan_functionalize(ctx, combine_fn, xs, additional_inputs):
     from torch._higher_order_ops.utils import _check_alias_and_mutation
 
@@ -893,6 +885,16 @@ def associative_scan_functionalize(ctx, combine_fn, xs, additional_inputs):
             unwrapped_additional_inputs,
         )
     return ctx.wrap_tensors(ret)
+
+
+register_hop_dispatches(
+    associative_scan_op,
+    autograd_impl=associative_scan_autograd,
+    functionalize_impl=associative_scan_functionalize,
+    proxy_mode_impl=associative_scan_proxy_mode,
+    fake_tensor_impl=assoiciative_scan_fake_tensor_mode,
+    composite_impl=associative_scan_op_dense,
+)
 
 
 def _fake_associative_scan(combine_fn, xs, dim, reverse=False):

--- a/torch/_higher_order_ops/base_hop.py
+++ b/torch/_higher_order_ops/base_hop.py
@@ -3,6 +3,7 @@
 import abc
 
 import torch
+import torch.utils._pytree as pytree
 from torch._dispatch.python import suspend_functionalization
 from torch._higher_order_ops.auto_functionalize import FunctionalCallableWithEpilogue
 from torch._higher_order_ops.utils import (
@@ -11,7 +12,7 @@ from torch._higher_order_ops.utils import (
     HopInstance,
     materialize_as_graph,
     register_hop_dispatches,
-    trace_and_register_subgraphs,
+    reenter_make_fx,
 )
 from torch._ops import HigherOrderOperator
 from torch._subclasses.functional_tensor import disable_functional_mode
@@ -100,15 +101,13 @@ class BaseHOP(HigherOrderOperator, abc.ABC):
         return subgraph(*operands)
 
     def _call_ProxyTorchDispatchMode(self, proxy_mode, subgraph, *operands, **kwargs):
-        (registered_subgraph,) = trace_and_register_subgraphs(
-            proxy_mode,
-            ("subgraph", subgraph, operands),
-        )
-        traced_graph = registered_subgraph.graph
+        traced_graph = reenter_make_fx(subgraph)(*operands)
         if not isinstance(proxy_mode.tracer, torch.fx.Tracer):
             raise AssertionError(
                 f"expected proxy_mode.tracer to be torch.fx.Tracer, got {type(proxy_mode.tracer)}"
             )
+        qualname = proxy_mode.tracer.get_fresh_qualname("subgraph")
+        proxy_mode.tracer.root.register_module(qualname, traced_graph)
 
         node_args = (traced_graph, *operands)
         out_proxy = create_hop_call_proxy(

--- a/torch/_higher_order_ops/base_hop.py
+++ b/torch/_higher_order_ops/base_hop.py
@@ -3,24 +3,19 @@
 import abc
 
 import torch
-import torch.utils._pytree as pytree
-from torch._C import DispatchKey
 from torch._dispatch.python import suspend_functionalization
 from torch._higher_order_ops.auto_functionalize import FunctionalCallableWithEpilogue
 from torch._higher_order_ops.utils import (
     check_input_alias_and_mutation_return_outputs,
+    create_hop_call_proxy,
     HopInstance,
     materialize_as_graph,
-    reenter_make_fx,
+    register_hop_dispatches,
+    trace_and_register_subgraphs,
 )
 from torch._ops import HigherOrderOperator
-from torch._subclasses import FakeTensorMode
 from torch._subclasses.functional_tensor import disable_functional_mode
-from torch.fx.experimental.proxy_tensor import (
-    disable_proxy_modes_tracing,
-    ProxyTorchDispatchMode,
-    track_tensor_tree,
-)
+from torch.fx.experimental.proxy_tensor import disable_proxy_modes_tracing, track_tensor_tree
 
 
 class BaseHOP(HigherOrderOperator, abc.ABC):
@@ -62,12 +57,13 @@ class BaseHOP(HigherOrderOperator, abc.ABC):
 
         # Set up the registrations
         # If you want to override any of these, override them in your subclass.
-        self.py_autograd_impl(self._call_Autograd)
-        self.py_functionalize_impl(self._call_Functionalize)
-        self.py_impl(ProxyTorchDispatchMode)(self._call_ProxyTorchDispatchMode)
-        self.py_impl(FakeTensorMode)(self._call_FakeTensorMode)
-        self.py_impl(DispatchKey.CompositeExplicitAutograd)(
-            self._call_CompositeExplicitAutograd
+        register_hop_dispatches(
+            self,
+            autograd_impl=self._call_Autograd,
+            functionalize_impl=self._call_Functionalize,
+            proxy_mode_impl=self._call_ProxyTorchDispatchMode,
+            fake_tensor_impl=self._call_FakeTensorMode,
+            composite_impl=self._call_CompositeExplicitAutograd,
         )
 
     def __call__(self, subgraph, *operands, **kwargs):
@@ -104,19 +100,22 @@ class BaseHOP(HigherOrderOperator, abc.ABC):
         return subgraph(*operands)
 
     def _call_ProxyTorchDispatchMode(self, proxy_mode, subgraph, *operands, **kwargs):
-        traced_graph = reenter_make_fx(subgraph)(*operands)
+        (registered_subgraph,) = trace_and_register_subgraphs(
+            proxy_mode,
+            ("subgraph", subgraph, operands),
+        )
+        traced_graph = registered_subgraph.graph
         if not isinstance(proxy_mode.tracer, torch.fx.Tracer):
             raise AssertionError(
                 f"expected proxy_mode.tracer to be torch.fx.Tracer, got {type(proxy_mode.tracer)}"
             )
-        qualname = proxy_mode.tracer.get_fresh_qualname("subgraph")
-        proxy_mode.tracer.root.register_module(qualname, traced_graph)
 
         node_args = (traced_graph, *operands)
-        proxy_args = pytree.tree_map(proxy_mode.tracer.unwrap_proxy, node_args)  # type: ignore[attr-defined]
-        proxy_kwargs = pytree.tree_map(proxy_mode.tracer.unwrap_proxy, kwargs)  # type: ignore[attr-defined]
-        out_proxy = proxy_mode.tracer.create_proxy(
-            "call_function", self, proxy_args, proxy_kwargs
+        out_proxy = create_hop_call_proxy(
+            proxy_mode,
+            self,
+            node_args,
+            kwargs,
         )
 
         out = self(subgraph, *operands, **kwargs)

--- a/torch/_higher_order_ops/cond.py
+++ b/torch/_higher_order_ops/cond.py
@@ -9,7 +9,6 @@ from typing import Any
 
 import torch
 import torch.utils._pytree as pytree
-from torch._C import DispatchKey
 from torch._C._functorch import (
     _add_batch_dim,
     get_unwrapped,
@@ -20,19 +19,20 @@ from torch._functorch.utils import exposed_in
 from torch._higher_order_ops.utils import (
     _maybe_run_with_interpreter,
     check_input_alias_and_mutation_return_outputs,
+    create_hop_call_proxy,
     create_bw_fn,
     fill_none_with_masks,
     filter_with_masks,
     materialize_as_graph,
-    reenter_make_fx,
+    register_hop_dispatches,
     save_values_for_backward,
     saved_values,
-    unique_graph_id,
+    trace_and_register_subgraphs,
     validate_subgraph_args_types,
 )
 from torch._ops import HigherOrderOperator
 from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode
-from torch.fx.experimental.proxy_tensor import ProxyTorchDispatchMode, track_tensor_tree
+from torch.fx.experimental.proxy_tensor import track_tensor_tree
 from torch.utils._python_dispatch import _get_current_dispatch_mode
 
 
@@ -255,8 +255,13 @@ def trace_cond(proxy_mode, func_overload, pred, true_fn, false_fn, operands):
             f"Cond operands must be a list or tuple of tensors and SymInts {operands}"
         )
 
-    true_graph = reenter_make_fx(true_fn)(*operands)
-    false_graph = reenter_make_fx(false_fn)(*operands)
+    true_subgraph, false_subgraph = trace_and_register_subgraphs(
+        proxy_mode,
+        ("true_graph", true_fn, operands),
+        ("false_graph", false_fn, operands),
+    )
+    true_graph = true_subgraph.graph
+    false_graph = false_subgraph.graph
 
     true_outs = []
     false_outs = []
@@ -277,31 +282,14 @@ def trace_cond(proxy_mode, func_overload, pred, true_fn, false_fn, operands):
             f"\n  false branch returns {len(flat_false_outs)} item(s)"
         )
 
-    i, true_name = unique_graph_id(proxy_mode, prefix="true_graph")
-
-    false_name = f"false_graph_{i}"
-    if hasattr(proxy_mode.tracer.root, false_name):
-        raise AssertionError(
-            f"proxy_mode.tracer.root already has attribute {false_name}"
-        )
-
-    proxy_mode.tracer.root.register_module(true_name, true_graph)
-    proxy_mode.tracer.root.register_module(false_name, false_graph)
-
     args = (pred, true_graph, false_graph, operands)
-
-    proxy_args = pytree.tree_map(proxy_mode.tracer.unwrap_proxy, args)
-
-    out_proxy = proxy_mode.tracer.create_proxy(
-        "call_function", func_overload, proxy_args, {}
-    )
+    out_proxy = create_hop_call_proxy(proxy_mode, func_overload, args)
 
     out = func_overload(pred, true_graph, false_graph, operands)
 
     return track_tensor_tree(out, out_proxy, constant=None, tracer=proxy_mode.tracer)
 
 
-@cond_op.py_impl(DispatchKey.CompositeExplicitAutograd)
 def cond_op_dense(pred, true_fn, false_fn, operands):
     if not all(isinstance(o, (torch.Tensor, int)) for o in operands):
         raise AssertionError(
@@ -393,7 +381,6 @@ class CondAutogradOp(torch.autograd.Function):
 # As long as one of the tensors in pred or operands requires grad,
 # all the output would require grad with backward fn set to be the CondAutogradOp.
 # This is consistent with autograd.Function's semantic.
-@cond_op.py_autograd_impl
 def cond_autograd(pred, true_fn, false_fn, operands):
     return CondAutogradOp.apply(
         pred,
@@ -403,12 +390,10 @@ def cond_autograd(pred, true_fn, false_fn, operands):
     )
 
 
-@cond_op.py_impl(ProxyTorchDispatchMode)
-def inner(mode, pred, true_fn, false_fn, operands):
+def cond_proxy_torch_dispatch_mode(mode, pred, true_fn, false_fn, operands):
     return trace_cond(mode, cond_op, pred, true_fn, false_fn, operands)
 
 
-@cond_op.py_impl(FakeTensorMode)
 def cond_fake_tensor_mode(mode, pred, true_fn, false_fn, operands):
     # Ignore here, because if you've gotten here but you're not manually
     # tracing the inner graphs, that means that you intend to reuse the graph
@@ -710,7 +695,6 @@ def _merge_output(
         )
 
 
-@cond_op.py_functionalize_impl
 def cond_func(ctx, pred, true_fn, false_fn, inputs):
     from torch._higher_order_ops.auto_functionalize import (
         can_auto_functionalize,
@@ -744,6 +728,16 @@ def cond_func(ctx, pred, true_fn, false_fn, inputs):
             unwrapped_pred, functional_true, functional_false, unwrapped_inputs
         )
         return ctx.wrap_tensors(cond_return)
+
+
+register_hop_dispatches(
+    cond_op,
+    autograd_impl=cond_autograd,
+    functionalize_impl=cond_func,
+    proxy_mode_impl=cond_proxy_torch_dispatch_mode,
+    fake_tensor_impl=cond_fake_tensor_mode,
+    composite_impl=cond_op_dense,
+)
 
 
 @cond_op.py_impl(torch._C._functorch.TransformType.Vmap)

--- a/torch/_higher_order_ops/map.py
+++ b/torch/_higher_order_ops/map.py
@@ -5,30 +5,27 @@ from typing_extensions import TypeVarTuple
 
 import torch
 import torch.utils._pytree as pytree
-from torch._C import DispatchKey
 from torch._dispatch.python import suspend_functionalization
-from torch._higher_order_ops.utils import _maybe_run_with_interpreter, reenter_make_fx
 from torch._ops import HigherOrderOperator
-from torch._subclasses.fake_tensor import FakeTensorMode
 from torch._subclasses.functional_tensor import disable_functional_mode
-from torch.fx.experimental.proxy_tensor import (
-    disable_proxy_modes_tracing,
-    ProxyTorchDispatchMode,
-    track_tensor_tree,
-)
+from torch.fx.experimental.proxy_tensor import disable_proxy_modes_tracing, track_tensor_tree
 
 from .utils import (
     _from_fun,
+    _maybe_run_with_interpreter,
     _stack_pytree,
     _unstack_pytree,
+    create_hop_call_proxy,
     create_bw_fn,
     fill_none_with_masks,
     filter_with_masks,
     first_slice_copy,
     materialize_as_graph,
+    register_hop_dispatches,
     save_values_for_backward,
     saved_values,
     split_into_chunks,
+    trace_and_register_subgraphs,
 )
 
 
@@ -248,46 +245,41 @@ def trace_map(proxy_mode, func_overload, f, xs, pos_args):
         # Use first_slice_copy instead of _unstack_pytree to avoid
         # iterating over batch dim, which would guard on symbolic sizes.
         example_input = pytree.tree_map(first_slice_copy, xs)
-
-        body_graph = f
-
-        body_graph = reenter_make_fx(body_graph)(*example_input, *pos_args)
-
-    next_name = proxy_mode.tracer.get_fresh_qualname("body_graph_")
-
-    proxy_mode.tracer.root.register_module(next_name, body_graph)
+        (body_subgraph,) = trace_and_register_subgraphs(
+            proxy_mode,
+            ("body_graph", f, (*example_input, *pos_args)),
+        )
+        body_graph = body_subgraph.graph
 
     fake_outs = map_impl(body_graph, xs, pos_args)
 
     node_args = (body_graph, list(xs), list(pos_args))
-    proxy_args = pytree.tree_map(proxy_mode.tracer.unwrap_proxy, node_args)
-    out_proxy = proxy_mode.tracer.create_proxy(
-        "call_function", func_overload, proxy_args, {}, name="map_impl"
+    out_proxy = create_hop_call_proxy(
+        proxy_mode,
+        func_overload,
+        node_args,
+        name="map_impl",
     )
     return track_tensor_tree(
         fake_outs, out_proxy, constant=None, tracer=proxy_mode.tracer
     )
 
 
-@map_impl.py_impl(DispatchKey.CompositeExplicitAutograd)
 def map_dense(f, xs, pos_args):
     pytrees = [f(*inp, *pos_args) for inp in _unstack_pytree(xs)]
     return _stack_pytree(pytrees)
 
 
-@map_impl.py_autograd_impl
 def map_autograd(f, xs, pos_args):
     num_mapped_args = len(xs)
     flat_out = MapAutogradOp.apply(f, num_mapped_args, *xs, *pos_args)
     return flat_out
 
 
-@map_impl.py_impl(ProxyTorchDispatchMode)
 def map_proxy_torch_dispatch_mode(mode, f, xs, args):
     return trace_map(mode, map_impl, f, xs, args)
 
 
-@map_impl.py_impl(FakeTensorMode)
 def map_fake_tensor_mode(mode, f, xs, args):
     from torch._higher_order_ops.utils import first_slice_copy
 
@@ -303,7 +295,6 @@ def map_fake_tensor_mode(mode, f, xs, args):
         return _broadcast_to_batch(example_output, batch_size)
 
 
-@map_impl.py_functionalize_impl
 def map_functionalize(ctx, f, xs, pos_args):
     from torch._higher_order_ops.utils import (
         _check_alias_and_mutation,
@@ -325,6 +316,16 @@ def map_functionalize(ctx, f, xs, pos_args):
         _check_alias_and_mutation(f, example_inputs, "map", pre_dispatch)
         map_return = map_impl(wrapped_fn, unwrapped_xs, unwrapped_args)
         return ctx.wrap_tensors(map_return)
+
+
+register_hop_dispatches(
+    map_impl,
+    autograd_impl=map_autograd,
+    functionalize_impl=map_functionalize,
+    proxy_mode_impl=map_proxy_torch_dispatch_mode,
+    fake_tensor_impl=map_fake_tensor_mode,
+    composite_impl=map_dense,
+)
 
 
 def _fake_map(f, x, *args):

--- a/torch/_higher_order_ops/scan.py
+++ b/torch/_higher_order_ops/scan.py
@@ -9,7 +9,6 @@ from typing import Any
 import torch
 import torch._prims_common as utils
 import torch.utils._pytree as pytree
-from torch._C import DispatchKey
 from torch._higher_order_ops.partitioner import (
     _find_hop_subgraph_outputs,
     HopGraphMinCutPartitioner,
@@ -19,24 +18,20 @@ from torch._higher_order_ops.utils import (
     _maybe_compile_and_run_fn,
     check_input_alias_and_mutation_return_outputs,
     check_meta_consistency,
+    create_hop_call_proxy,
     fill_none_with_masks,
     filter_with_masks,
     first_slice_copy,
     get_tensor_mask,
     mask_list,
     materialize_as_graph,
-    reenter_make_fx,
+    register_hop_dispatches,
     split_into_chunks,
-    unique_graph_id,
+    trace_and_register_subgraphs,
     validate_subgraph_args_types,
 )
 from torch._ops import HigherOrderOperator
-from torch._subclasses.fake_tensor import FakeTensorMode
-from torch.fx.experimental.proxy_tensor import (
-    disable_proxy_modes_tracing,
-    ProxyTorchDispatchMode,
-    track_tensor_tree,
-)
+from torch.fx.experimental.proxy_tensor import disable_proxy_modes_tracing, track_tensor_tree
 from torch.utils._python_dispatch import _get_current_dispatch_mode
 
 
@@ -387,9 +382,15 @@ def trace_scan(
             clone_input(x) if isinstance(x, torch.Tensor) else x
             for x in additional_inputs
         ]
-        combine_graph = reenter_make_fx(combine_fn)(
-            *sample_inits, *sample_inputs, *sample_additional_inputs
+        (combine_subgraph,) = trace_and_register_subgraphs(
+            proxy_mode,
+            (
+                "scan_combine_graph",
+                combine_fn,
+                (*sample_inits, *sample_inputs, *sample_additional_inputs),
+            ),
         )
+        combine_graph = combine_subgraph.graph
 
     outputs = None
     for node in combine_graph.graph.nodes:
@@ -416,14 +417,12 @@ def trace_scan(
         init_fake_tensors, carry_fake_tensors, "init", "carry", include_contiguity=False
     )
 
-    _, combine_graph_name = unique_graph_id(proxy_mode, prefix="scan_combine_graph")
-
-    proxy_mode.tracer.root.register_module(combine_graph_name, combine_graph)
-
     args = (combine_graph, init, xs, additional_inputs)
-    proxy_args = pytree.tree_map(proxy_mode.tracer.unwrap_proxy, args)
-    out_proxy = proxy_mode.tracer.create_proxy(
-        "call_function", func_overload, proxy_args, {}, name="scan"
+    out_proxy = create_hop_call_proxy(
+        proxy_mode,
+        func_overload,
+        args,
+        name="scan",
     )
 
     with disable_proxy_modes_tracing():
@@ -439,7 +438,6 @@ def trace_scan(
     return track_tensor_tree(out, out_proxy, constant=None, tracer=proxy_mode.tracer)
 
 
-@scan_op.py_impl(DispatchKey.CompositeExplicitAutograd)
 def scan_op_dense(combine_fn, init, xs, additional_inputs):
     mode = _get_current_dispatch_mode()
     if mode is not None:
@@ -814,7 +812,6 @@ class ScanAutogradImpl:
         )
 
 
-@scan_op.py_autograd_impl
 def scan_autograd(combine_fn, init, xs, additional_inputs):
     with disable_proxy_modes_tracing():
         hop_partitioned_graph: HopPartitionedGraph = (
@@ -836,12 +833,10 @@ def scan_autograd(combine_fn, init, xs, additional_inputs):
     )
 
 
-@scan_op.py_impl(ProxyTorchDispatchMode)
 def scan_proxy_mode(mode, combine_fn, init, xs, additional_inputs):
     return trace_scan(mode, scan_op, combine_fn, init, xs, additional_inputs)
 
 
-@scan_op.py_impl(FakeTensorMode)
 def scan_fake_tensor_mode(mode, combine_fn, init, xs, additional_inputs):
     with mode:
         scan_length = xs[0].shape[0]
@@ -860,7 +855,6 @@ def scan_fake_tensor_mode(mode, combine_fn, init, xs, additional_inputs):
         return out
 
 
-@scan_op.py_functionalize_impl
 def scan_functionalize(ctx, combine_fn, init, xs, additional_inputs):
     from torch._higher_order_ops.utils import (
         _check_alias_and_mutation,
@@ -892,6 +886,16 @@ def scan_functionalize(ctx, combine_fn, init, xs, additional_inputs):
             unwrapped_additional_inputs,
         )
     return ctx.wrap_tensors(ret)
+
+
+register_hop_dispatches(
+    scan_op,
+    autograd_impl=scan_autograd,
+    functionalize_impl=scan_functionalize,
+    proxy_mode_impl=scan_proxy_mode,
+    fake_tensor_impl=scan_fake_tensor_mode,
+    composite_impl=scan_op_dense,
+)
 
 
 @scan_op.py_impl(torch._C._functorch.TransformType.Vmap)

--- a/torch/_higher_order_ops/utils.py
+++ b/torch/_higher_order_ops/utils.py
@@ -9,13 +9,14 @@ from typing import Any, overload, TypeVar
 import torch
 import torch.fx.traceback as fx_traceback
 import torch.utils._pytree as pytree
+from torch._C import DispatchKey
 from torch._dispatch.python import suspend_functionalization
 from torch._guards import detect_fake_mode
 from torch._higher_order_ops.schema import HopSchema
 from torch._library.fake_class_registry import FakeScriptObject
 from torch._library.opaque_object import is_opaque_type
 from torch._ops import HigherOrderOperator, OperatorBase, OpOverload
-from torch._subclasses.fake_tensor import FakeTensor
+from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode
 from torch._subclasses.functional_tensor import (
     disable_functional_mode,
     FunctionalTensor,
@@ -24,6 +25,7 @@ from torch.fx.experimental.proxy_tensor import (
     _temp_remove_metadata_torch_function_mode,
     disable_proxy_modes_tracing,
     make_fx,
+    ProxyTorchDispatchMode,
 )
 from torch.fx.passes.runtime_assert import insert_deferred_runtime_asserts
 from torch.fx.passes.shape_prop import _extract_tensor_metadata, TensorMetadata
@@ -33,6 +35,12 @@ from torch.multiprocessing.reductions import StorageWeakRef
 @dataclass
 class UnsupportedAliasMutationException(RuntimeError):
     reason: str
+
+
+@dataclass(frozen=True)
+class RegisteredSubgraph:
+    name: str
+    graph: torch.fx.GraphModule
 
 
 def autograd_not_implemented_inner(
@@ -473,25 +481,75 @@ def _check_alias_and_mutation(graph_module, inputs_fake, name, pre_dispatch):
 
 def unique_graph_id(proxy_mode, prefix):
     """Returns a unique name and id for a graph to be added to a proxy_mode tracer"""
-    # There are probably better ways - I know that create_arg has some self incrementing name
-    # magic to it, but since we explicitly have to get the name for register_module,
-    # I was not sure how to do that. This kinda simulates it.
-    return unique_graph_name_with_root(proxy_mode.tracer.root, prefix)
+    i, names = unique_graph_names_with_root(proxy_mode.tracer.root, prefix)
+    return i, names[0]
 
 
 def unique_graph_name_with_root(
     root: torch.fx.GraphModule, prefix: str
 ) -> tuple[int, str]:
+    i, names = unique_graph_names_with_root(root, prefix)
+    return i, names[0]
+
+
+def unique_graph_names_with_root(
+    root: torch.fx.GraphModule, *prefixes: str
+) -> tuple[int, tuple[str, ...]]:
+    # There are probably better ways - I know that create_arg has some self incrementing name
+    # magic to it, but since we explicitly have to get the name for register_module,
+    # I was not sure how to do that. This kinda simulates it.
+    if len(prefixes) == 0:
+        raise AssertionError("Expected at least one prefix")
+
     next_name = None
     i = 0
     # pyrefly: ignore [bad-assignment]
     while not next_name:
-        candidate = f"{prefix}_{i}"
-        if hasattr(root, candidate):
+        candidates = tuple(f"{prefix}_{i}" for prefix in prefixes)
+        if any(hasattr(root, candidate) for candidate in candidates):
             i += 1
         else:
-            next_name = candidate
+            next_name = candidates
     return i, next_name
+
+
+def trace_and_register_subgraphs(
+    proxy_mode, *subgraph_specs: tuple[Any, ...]
+) -> tuple[RegisteredSubgraph, ...]:
+    traced_graphs = []
+    prefixes = []
+    for spec in subgraph_specs:
+        if len(spec) == 2:
+            prefix, graph = spec
+            if not isinstance(graph, torch.fx.GraphModule):
+                raise AssertionError(
+                    "Expected a GraphModule when registering a traced subgraph"
+                )
+        elif len(spec) == 3:
+            prefix, fn, args = spec
+            graph = reenter_make_fx(fn)(*args)
+        else:
+            raise AssertionError(
+                "Expected subgraph spec of the form (prefix, graph) or (prefix, fn, args)"
+            )
+        prefixes.append(prefix)
+        traced_graphs.append(graph)
+
+    _, names = unique_graph_names_with_root(proxy_mode.tracer.root, *prefixes)
+    registered_subgraphs = []
+    for name, graph in zip(names, traced_graphs):
+        proxy_mode.tracer.root.register_module(name, graph)
+        registered_subgraphs.append(RegisteredSubgraph(name, graph))
+
+    return tuple(registered_subgraphs)
+
+
+def create_hop_call_proxy(proxy_mode, hop, args, kwargs=None, *, name=None):
+    proxy_args = pytree.tree_map(proxy_mode.tracer.unwrap_proxy, args)
+    proxy_kwargs = pytree.tree_map(proxy_mode.tracer.unwrap_proxy, kwargs or {})
+    return proxy_mode.tracer.create_proxy(
+        "call_function", hop, proxy_args, proxy_kwargs, name=name
+    )
 
 
 def _from_fun(t):
@@ -636,6 +694,22 @@ def redirect_to_mode(hop: OperatorBase, mode):
         return mode.__torch_dispatch__(hop, [], args, kwargs)
 
     return impl
+
+
+def register_hop_dispatches(
+    hop: HigherOrderOperator,
+    *,
+    autograd_impl: Callable,
+    functionalize_impl: Callable,
+    proxy_mode_impl: Callable,
+    fake_tensor_impl: Callable,
+    composite_impl: Callable,
+) -> None:
+    hop.py_autograd_impl(autograd_impl)
+    hop.py_functionalize_impl(functionalize_impl)
+    hop.py_impl(ProxyTorchDispatchMode)(proxy_mode_impl)
+    hop.py_impl(FakeTensorMode)(fake_tensor_impl)
+    hop.py_impl(DispatchKey.CompositeExplicitAutograd)(composite_impl)
 
 
 # TODO: The parameter use_output_and_grad_bw is required because some operations

--- a/torch/_higher_order_ops/utils.py
+++ b/torch/_higher_order_ops/utils.py
@@ -43,6 +43,11 @@ class RegisteredSubgraph:
     graph: torch.fx.GraphModule
 
 
+TracedSubgraphSpec = tuple[str, torch.fx.GraphModule]
+UntracedSubgraphSpec = tuple[str, Callable[..., Any], tuple[Any, ...]]
+SubgraphSpec = TracedSubgraphSpec | UntracedSubgraphSpec
+
+
 def autograd_not_implemented_inner(
     operator: OperatorBase, delayed_error: bool, *args: Any, **kwargs: Any
 ) -> Any:
@@ -514,10 +519,10 @@ def unique_graph_names_with_root(
 
 
 def trace_and_register_subgraphs(
-    proxy_mode, *subgraph_specs: tuple[Any, ...]
+    proxy_mode: ProxyTorchDispatchMode, *subgraph_specs: SubgraphSpec
 ) -> tuple[RegisteredSubgraph, ...]:
-    traced_graphs = []
-    prefixes = []
+    traced_graphs: list[torch.fx.GraphModule] = []
+    prefixes: list[str] = []
     for spec in subgraph_specs:
         if len(spec) == 2:
             prefix, graph = spec
@@ -536,7 +541,7 @@ def trace_and_register_subgraphs(
         traced_graphs.append(graph)
 
     _, names = unique_graph_names_with_root(proxy_mode.tracer.root, *prefixes)
-    registered_subgraphs = []
+    registered_subgraphs: list[RegisteredSubgraph] = []
     for name, graph in zip(names, traced_graphs):
         proxy_mode.tracer.root.register_module(name, graph)
         registered_subgraphs.append(RegisteredSubgraph(name, graph))
@@ -544,7 +549,14 @@ def trace_and_register_subgraphs(
     return tuple(registered_subgraphs)
 
 
-def create_hop_call_proxy(proxy_mode, hop, args, kwargs=None, *, name=None):
+def create_hop_call_proxy(
+    proxy_mode: ProxyTorchDispatchMode,
+    hop: OperatorBase,
+    args: Any,
+    kwargs: Mapping[str, Any] | None = None,
+    *,
+    name: str | None = None,
+) -> torch.fx.Proxy:
     proxy_args = pytree.tree_map(proxy_mode.tracer.unwrap_proxy, args)
     proxy_kwargs = pytree.tree_map(proxy_mode.tracer.unwrap_proxy, kwargs or {})
     return proxy_mode.tracer.create_proxy(

--- a/torch/_higher_order_ops/while_loop.py
+++ b/torch/_higher_order_ops/while_loop.py
@@ -5,25 +5,23 @@ from collections.abc import Callable
 
 import torch
 import torch.utils._pytree as pytree
-from torch._C import DispatchKey
 from torch._higher_order_ops.utils import (
     _maybe_run_with_interpreter,
     autograd_not_implemented,
     check_input_alias_and_mutation_return_outputs,
     check_meta_consistency,
+    create_hop_call_proxy,
     fill_none_with_masks,
     filter_with_masks,
     materialize_as_graph,
+    register_hop_dispatches,
     reenter_make_fx,
+    trace_and_register_subgraphs,
     validate_subgraph_args_types,
 )
 from torch._ops import HigherOrderOperator
 from torch._subclasses.fake_tensor import FakeTensorMode
-from torch.fx.experimental.proxy_tensor import (
-    disable_proxy_modes_tracing,
-    ProxyTorchDispatchMode,
-    track_tensor_tree,
-)
+from torch.fx.experimental.proxy_tensor import disable_proxy_modes_tracing, track_tensor_tree
 
 
 class WhileLoopOp(HigherOrderOperator):
@@ -256,7 +254,6 @@ def while_loop(cond_fn, body_fn, carried_inputs):
         )
 
 
-@while_loop_op.py_impl(DispatchKey.CompositeExplicitAutograd)
 def while_loop_dense(
     cond_fn, body_fn, carried_inputs, additional_inputs, stack_output=False
 ):
@@ -322,7 +319,6 @@ def while_loop_dense(
     return carried_vals
 
 
-@while_loop_op.py_autograd_impl
 def while_loop_autograd(cond_fn, body_fn, operands, additional_inputs):
     return WhileLoopAutogradOp.apply(
         cond_fn,
@@ -358,7 +354,6 @@ def _create_unbacked_symint(
         return fake_mode.shape_env.create_unbacked_symint()
 
 
-@while_loop_op.py_impl(ProxyTorchDispatchMode)
 def while_loop_tracing(
     mode,
     cond_fn,
@@ -450,31 +445,20 @@ def while_loop_tracing(
             cond_graph = produce_graph(cond_fn)
             body_graph = produce_graph(body_fn)
 
-        next_name = None
-        i = 0
-        # pyrefly: ignore [bad-assignment]
-        while not next_name:
-            candidate = f"while_loop_cond_graph_{i}"
-            if hasattr(proxy_mode.tracer.root, candidate):
-                i += 1
-            else:
-                next_name = candidate
-        cond_graph_name = next_name
-        body_graph_name = f"while_loop_body_graph_{i}"
-        if hasattr(proxy_mode.tracer.root, body_graph_name):
-            raise AssertionError(
-                f"proxy_mode.tracer.root already has attribute {body_graph_name}"
-            )
-
-        proxy_mode.tracer.root.register_module(cond_graph_name, cond_graph)
-        proxy_mode.tracer.root.register_module(body_graph_name, body_graph)
+        cond_subgraph, body_subgraph = trace_and_register_subgraphs(
+            proxy_mode,
+            ("while_loop_cond_graph", cond_graph),
+            ("while_loop_body_graph", body_graph),
+        )
+        cond_graph = cond_subgraph.graph
+        body_graph = body_subgraph.graph
 
         args = (cond_graph, body_graph, carried_inputs, additional_inputs)
-
-        proxy_args = pytree.tree_map(proxy_mode.tracer.unwrap_proxy, args)
-
-        out_proxy = proxy_mode.tracer.create_proxy(
-            "call_function", op, proxy_args, {}, name=op._name
+        out_proxy = create_hop_call_proxy(
+            proxy_mode,
+            op,
+            args,
+            name=op._name,
         )
 
         out = op(
@@ -494,7 +478,6 @@ def while_loop_tracing(
     )
 
 
-@while_loop_op.py_impl(FakeTensorMode)
 def while_loop_fake_tensor_mode(
     mode, cond_fn, body_fn, carried_inputs, additional_inputs, stack_output=False
 ):
@@ -576,7 +559,6 @@ def while_loop_fake_tensor_mode(
         )
 
 
-@while_loop_op.py_functionalize_impl
 def while_loop_func(
     ctx, cond_fn, body_fn, carried_inputs, additional_inputs, stack_output=False
 ):
@@ -603,6 +585,16 @@ def while_loop_func(
             unwrapped_additional_inputs,
         )
         return ctx.wrap_tensors(ret)
+
+
+register_hop_dispatches(
+    while_loop_op,
+    autograd_impl=while_loop_autograd,
+    functionalize_impl=while_loop_func,
+    proxy_mode_impl=while_loop_tracing,
+    fake_tensor_impl=while_loop_fake_tensor_mode,
+    composite_impl=while_loop_dense,
+)
 
 
 class WhileLoopStackOutputOp(HigherOrderOperator):
@@ -932,22 +924,15 @@ class WhileLoopAutogradOp(torch.autograd.Function):
 
 while_loop_stack_output_op = WhileLoopStackOutputOp()
 
-while_loop_stack_output_op.py_impl(DispatchKey.CompositeExplicitAutograd)(
-    functools.partial(while_loop_dense, stack_output=True)
-)
-
-while_loop_stack_output_op.py_impl(ProxyTorchDispatchMode)(
-    functools.partial(while_loop_tracing, stack_output=True)
-)
-
-while_loop_stack_output_op.py_impl(FakeTensorMode)(
-    functools.partial(while_loop_fake_tensor_mode, stack_output=True)
-)
-
-while_loop_stack_output_op.py_functionalize_impl(
-    functools.partial(while_loop_func, stack_output=True)
-)
-
-while_loop_stack_output_op.py_autograd_impl(
-    autograd_not_implemented(while_loop_stack_output_op, deferred_error=True)
+register_hop_dispatches(
+    while_loop_stack_output_op,
+    autograd_impl=autograd_not_implemented(
+        while_loop_stack_output_op, deferred_error=True
+    ),
+    functionalize_impl=functools.partial(while_loop_func, stack_output=True),
+    proxy_mode_impl=functools.partial(while_loop_tracing, stack_output=True),
+    fake_tensor_impl=functools.partial(
+        while_loop_fake_tensor_mode, stack_output=True
+    ),
+    composite_impl=functools.partial(while_loop_dense, stack_output=True),
 )


### PR DESCRIPTION
## Summary
- extract shared helper utilities for higher-order op dispatch registration and proxy-call creation
- reuse the new helpers across `BaseHOP`, `cond`, `while_loop`, `map`, `scan`, and `associative_scan`
- add a tracing test for `associative_scan_op` so the internal HOP path is covered on CPU

## Root cause
The control-flow HOPs each manually wired the same five dispatch keys and repeated the same proxy-tracing/module-registration flow with small naming differences. That duplication made the implementations noisy and easy to drift.

## Proposed fix
Introduce shared helpers for dispatch registration plus proxy tracing/registration, then migrate the control-flow HOP implementations to call those helpers instead of open-coding the same logic in each file.

## Why this is the right long-term fix
This keeps the existing HOP signatures and semantics unchanged while centralizing the common mechanics in one place. Future control-flow HOPs can reuse the same helpers without needing a broader `BaseHOP` signature generalization first.

## Testing
- `python3.10 -m py_compile torch/_higher_order_ops/utils.py torch/_higher_order_ops/base_hop.py torch/_higher_order_ops/cond.py torch/_higher_order_ops/map.py torch/_higher_order_ops/scan.py torch/_higher_order_ops/associative_scan.py torch/_higher_order_ops/while_loop.py test/functorch/test_control_flow.py`
- `PATH=$HOME/.local/bin:$PATH PYTHONPATH=. python3.10 test/functorch/test_control_flow.py -v TestControlFlowTraced.test_cond_traced_not_nested TestControlFlowTraced.test_tracing_map_symbolic_simple TestControlFlowTraced.test_tracing_associative_scan_op_symbolic TestControlFlow.test_scan_simple_graph TestControlFlowTraced.test_while_loop_tracing_while_loop_test_nested TestControlFlowTraced.test_while_loop_tracing_while_loop_test_nested2 TestControlFlowTraced.test_while_loop_tracing_while_loop_test_nested_with_linear TestControlFlowTraced.test_while_loop_tracing_while_loop_test_simple TestControlFlowTraced.test_while_loop_tracing_while_loop_test_simple_with_linear TestControlFlowTraced.test_while_loop_tracing_while_loop_test_simple_with_mutation TestControlFlowTraced.test_while_loop_tracing_while_loop_test_simple_with_pytree_carry`

Drafted via Codex, published after manual review by @bobrenjc93