### PR TITLE
[dynamo] Make VariableTracker.visit walk side-effects attr mutations

### DIFF
--- a/torch/_dynamo/variables/base.py
+++ b/torch/_dynamo/variables/base.py
@@ -331,10 +331,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
             for key, subvalue in value.__dict__.items():
                 if key not in nonvars:
                     cls.visit(fn, subvalue, cache, side_effects)
-            if (
-                side_effects is not None
-                and value in side_effects.store_attr_mutations
-            ):
+            if side_effects is not None and value in side_effects.store_attr_mutations:
                 for attr_vt in side_effects.store_attr_mutations[value].values():
                     cls.visit(fn, attr_vt, cache, side_effects)
         elif istype(value, (list, tuple)):

--- a/torch/_dynamo/variables/base.py
+++ b/torch/_dynamo/variables/base.py
@@ -34,6 +34,7 @@ from ..utils import cmp_name_to_op_mapping, istype
 
 if TYPE_CHECKING:
     from ..codegen import PyCodegen
+    from ..side_effects import SideEffects
     from ..symbolic_convert import InstructionTranslator
     from .constant import ConstantVariable
     from .functions import UserFunctionVariable
@@ -304,9 +305,14 @@ class VariableTracker(metaclass=VariableTrackerMeta):
         fn: Callable[["VariableTracker"], None],
         value: Any,
         cache: dict[int, Any] | None = None,
+        side_effects: "SideEffects | None" = None,
     ) -> None:
         """
-        Walk value and call fn on all the VariableTracker instances
+        Walk value and call fn on all the VariableTracker instances.
+
+        When side_effects is provided, also walks attributes stored in
+        store_attr_mutations (e.g. dataclass fields set during tracing
+        that aren't in the VT's __dict__).
         """
         if cache is None:
             cache = {}
@@ -324,13 +330,19 @@ class VariableTracker(metaclass=VariableTrackerMeta):
             nonvars = value._nonvar_fields
             for key, subvalue in value.__dict__.items():
                 if key not in nonvars:
-                    cls.visit(fn, subvalue, cache)
+                    cls.visit(fn, subvalue, cache, side_effects)
+            if (
+                side_effects is not None
+                and value in side_effects.store_attr_mutations
+            ):
+                for attr_vt in side_effects.store_attr_mutations[value].values():
+                    cls.visit(fn, attr_vt, cache, side_effects)
         elif istype(value, (list, tuple)):
             for subvalue in value:
-                cls.visit(fn, subvalue, cache)
+                cls.visit(fn, subvalue, cache, side_effects)
         elif istype(value, (dict, collections.OrderedDict)):
             for subvalue in value.values():
-                cls.visit(fn, subvalue, cache)
+                cls.visit(fn, subvalue, cache, side_effects)
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}()"

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -1712,9 +1712,7 @@ def speculate_subgraph_with_auto_output_flattening(
                 ):
                     graph_output_vt_list.append(vt)
 
-            VariableTracker.visit(
-                visit, output, side_effects=tx.output.side_effects
-            )
+            VariableTracker.visit(visit, output, side_effects=tx.output.side_effects)
             graph_output_vts = tuple(graph_output_vt_list)
 
             # NOTE - [Return subgraph intermediates as subgraph outputs]

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -1712,7 +1712,9 @@ def speculate_subgraph_with_auto_output_flattening(
                 ):
                     graph_output_vt_list.append(vt)
 
-            VariableTracker.visit(visit, output)
+            VariableTracker.visit(
+                visit, output, side_effects=tx.output.side_effects
+            )
             graph_output_vts = tuple(graph_output_vt_list)
 
             # NOTE - [Return subgraph intermediates as subgraph outputs]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #179426
* __->__ #179477
* #179381

HOP output flattening uses VariableTracker.visit to discover tensor
children in subgraph return values. Attributes set during tracing
(e.g. frozen dataclass fields) are stored in
side_effects.store_attr_mutations rather than in the VT's __dict__,
so visit never found them — causing subgraphs to return empty outputs.

Pass side_effects through visit so it also walks store_attr_mutations.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98