### PR TITLE
[xplat][fbobjc imports] Fix clang-diagnostic-conditional-uninitialized-warnings (round 3) (#179478)

### DIFF
--- a/aten/src/ATen/native/Math.h
+++ b/aten/src/ATen/native/Math.h
@@ -2281,7 +2281,7 @@ inline C10_HOST_DEVICE T airy_ai_forward(T x) {
 
     int domain_flag = 0;
 
-    T ai;
+    T ai = T(0.0);
 
     if (std::isinf(x)) {
         return std::numeric_limits<T>::quiet_NaN();


### PR DESCRIPTION
Summary:

Initialize uninitialized variables at declaration with contextually appropriate values
to resolve clang-diagnostic-conditional-uninitialized warnings in non-FB-prefixed libraries.

Test Plan: CI

Reviewed By: d22yan

Differential Revision: D96985377
