### PR TITLE
[dynamo] Add identity expansion after unbacked sub (#179479)

### DIFF
--- a/test/inductor/test_indexing.py
+++ b/test/inductor/test_indexing.py
@@ -23,6 +23,7 @@ from torch.testing._internal.common_utils import (
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_CPU, HAS_GPU
 from torch.utils._sympy.functions import (
     FloorDiv,
+    Identity,
     Mod,
     ModularIndexing,
     PythonMod,
@@ -653,6 +654,26 @@ class TestOptimizationHintZeroDivision(InductorTestCase):
         expr = ModularIndexing(u0 + 1, u1, 4)
         hint = sizevars.optimization_hint(expr, fallback=8192)
         self.assertEqual(hint, 1)
+
+
+class TestOptimizationHintIdentityExpansion(InductorTestCase):
+    """Test that optimization_hint expands Identity wrappers after _sub_unbacked_exprs."""
+
+    def test_identity_wrapped_expr_resolves_to_int(self):
+        """An expression containing Identity-wrapped constants and an unbacked
+        symbol should resolve to a concrete int after substitution."""
+        sizevars = SizeVarAllocator()
+        u0 = sizevars.shape_env.create_unbacked_symint().node.expr
+
+        # Mirrors the real bug: -u0 * (-Identity(1) + Identity(0))
+        # simplifies to -u0 * (0 - 1) = u0.
+        # Without expand(identity=True) after _sub_unbacked_exprs,
+        # subs({u0: fallback}) leaves -Identity(1) + Identity(0) unexpanded,
+        # causing RuntimeError("Failed to realize expression to int").
+        expr = -u0 * (-Identity(sympy.Integer(1)) + Identity(sympy.Integer(0)))
+        hint = sizevars.optimization_hint(expr, fallback=42)
+        self.assertEqual(hint, 42)
+
 
 
 if __name__ == "__main__":

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -3173,7 +3173,14 @@ class PythonWrapperCodegen(CodeGen):
             device = buf.get_device()
             dtype = buf.get_dtype()
             offset = V.graph.sizevars.optimization_hint(buf.get_layout().offset)
-            value = f"generate_example_value({size}, {stride}, '{device}', {dtype}, {offset}, {allocation_size})"
+            # Pad the underlying storage to prevent OOB during compile-time
+            # autotuning. Symbolic offsets (e.g., from index_select/slice
+            # fusions) are concretized independently from buffer sizes via
+            # optimization_hints, so the concretized offset can exceed the
+            # buffer allocation. Adding padding ensures these accesses land
+            # within allocated memory. See https://github.com/pytorch/pytorch/issues/XXXXX
+            extra_size = offset + config.unbacked_symint_fallback
+            value = f"generate_example_value({size}, {stride}, '{device}', {dtype}, {extra_size}, {allocation_size})"
             self.kernel_autotune_calls.writeline(f"{buf_name} = {value}")
 
             if isinstance(raw_arg, ir.TMADescriptor):

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -1308,12 +1308,13 @@ class Reduction(Loops):
 
     def constant_to_device(self, device: torch.device) -> IRNode:
         """Move this to a given device. Requires that all reads are to constants."""
-        loader = self.make_loader()
-        loader = patch.object(ConstantBuffer, "override_device", device)(loader)
+        inner_fn = patch.object(ConstantBuffer, "override_device", device)(
+            self.inner_fn
+        )
         return Reduction(
             device=device,
             dtype=self.dtype,
-            inner_fn=loader,
+            inner_fn=inner_fn,
             ranges=self.ranges,
             reduction_ranges=self.reduction_ranges,
             reduction_type=self.reduction_type,
@@ -8057,6 +8058,7 @@ class DeviceCopy(ExternKernelOut):
             not x.is_extern()
             # Can not apply this optimization if x has been mutated
             and try_get_name(x) not in V.graph.mutated_buffers
+            and x.get_read_names()
             and all(r in V.graph.constants for r in x.get_read_names())
             and not config.aot_inductor.use_runtime_constant_folding
         ):

--- a/torch/fx/experimental/_size_hinting.py
+++ b/torch/fx/experimental/_size_hinting.py
@@ -400,6 +400,8 @@ def _optimization_hint_base(
         ):
             original = sympy.factor(original)
         expr = _sub_unbacked_exprs(shape_env, original)
+        if isinstance(expr, sympy.Expr):
+            expr = expr.expand(identity=True)
 
     # For multiple expressions that depend on an unbacked symint,
     # we want to compute them consistently for a size hint we have chosen.


### PR DESCRIPTION
Summary:

## Issue
While trying to resolve a sympy expr for optimization hint, in the middle of the processing chain, we did unbacked sub using the 'original' expression, which effectively erased the "identity expansion" that have done on the expr before. This would lead to the failure of realizing the expr to int.



## Fix
Do another identity expansion after the unbacked sub attempt.

Test Plan:
- Added the unittest to capture the issue with unbacked symbol + Identity in the expression

- E2E tests for internal recsys model with successful AOTI lowering with this patch applied

- OSS CI

Differential Revision: D99688518


