### PR TITLE
[dynamo] Add identity expansion after unbacked sub (#179481)

### DIFF
--- a/test/inductor/test_indexing.py
+++ b/test/inductor/test_indexing.py
@@ -23,6 +23,7 @@ from torch.testing._internal.common_utils import (
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_CPU, HAS_GPU
 from torch.utils._sympy.functions import (
     FloorDiv,
+    Identity,
     Mod,
     ModularIndexing,
     PythonMod,
@@ -676,6 +677,25 @@ class TestOptimizationHintZeroDivision(InductorTestCase):
         expr = ModularIndexing(u0 + 1, u1, 4)
         hint = sizevars.optimization_hint(expr, fallback=8192)
         self.assertEqual(hint, 1)
+
+
+class TestOptimizationHintIdentityExpansion(InductorTestCase):
+    """Test that optimization_hint expands Identity wrappers after _sub_unbacked_exprs."""
+
+    def test_identity_wrapped_expr_resolves_to_int(self):
+        """An expression containing Identity-wrapped constants and an unbacked
+        symbol should resolve to a concrete int after substitution."""
+        sizevars = SizeVarAllocator()
+        u0 = sizevars.shape_env.create_unbacked_symint().node.expr
+
+        # Mirrors the real bug: -u0 * (-Identity(1) + Identity(0))
+        # simplifies to -u0 * (0 - 1) = u0.
+        # Without expand(identity=True) after _sub_unbacked_exprs,
+        # subs({u0: fallback}) leaves -Identity(1) + Identity(0) unexpanded,
+        # causing RuntimeError("Failed to realize expression to int").
+        expr = -u0 * (-Identity(sympy.Integer(1)) + Identity(sympy.Integer(0)))
+        hint = sizevars.optimization_hint(expr, fallback=42)
+        self.assertEqual(hint, 42)
 
 
 if __name__ == "__main__":

--- a/torch/fx/experimental/_size_hinting.py
+++ b/torch/fx/experimental/_size_hinting.py
@@ -350,10 +350,14 @@ def _optimization_hint_base(
 
         fallback = unbacked_symint_fallback
 
+    # to have expanded (Identity free) expr stored in original
+    if isinstance(expr, sympy.Expr):
+        expr = expr.expand(identity=True)
+
     original = expr
     # sympy.expand() doesn't work with boolean expressions like Or/And
     if isinstance(expr, sympy.Expr):
-        expr = sympy.expand(expr).xreplace(shape_env.replacements)
+        expr = expr.xreplace(shape_env.replacements)
     else:
         expr = sympy.sympify(expr).xreplace(shape_env.replacements)
 


### PR DESCRIPTION
Summary:


## Issue
While trying to resolve a sympy expr for optimization hint, in the middle of the processing chain, we did unbacked sub using the 'original' expression, which effectively erased the "identity expansion" that have done on the expr before. This would lead to the failure of realizing the expr to int.

For the problematic expr used in unittest, without the fix, we have:
```
size_dict = {u0: 1}

final_result = expr.subs(size_dict)

## here final_result is "-Identity(0) + Identity(1)"
```


## Fix
Do another identity expansion after the unbacked sub attempt.

Test Plan:
- Added the unittest to capture the issue with unbacked symbol + Identity in the expression

- E2E tests for internal recsys model with successful AOTI lowering with this patch applied

- OSS CI

Reviewed By: liangbeixu

Differential Revision: D99688518




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo