### PR TITLE
[4/11][aoti] Add MinimalArrayref V2 descriptor ABI (#179482)

### DIFF
--- a/torch/csrc/inductor/aoti_runtime/arrayref_tensor.h
+++ b/torch/csrc/inductor/aoti_runtime/arrayref_tensor.h
@@ -39,6 +39,8 @@ inline bool is_contiguous_strides_for_shape(
 template <typename T>
 class ArrayRefTensor {
  public:
+  using value_type = T;
+
   ArrayRefTensor() = default;
 
   explicit ArrayRefTensor(

--- a/torch/csrc/inductor/aoti_runtime/arrayref_tensor_conversion.h
+++ b/torch/csrc/inductor/aoti_runtime/arrayref_tensor_conversion.h
@@ -1,0 +1,85 @@
+#pragma once
+
+// Zero-copy conversion utilities between ArrayRefTensor<T> (C++ template) and
+// AOTInductorArrayRefTensor (plain C struct).
+//
+// These helpers allow the host process to marshal ArrayRefTensor objects into
+// the C-compatible AOTInductorArrayRefTensor descriptors before calling into a
+// DSO, and to unmarshal the descriptors back after the call.  Because only
+// C types cross the DSO boundary, the host and DSO can be linked against
+// different C++ standard libraries (e.g. libc++ vs libstdc++) without ABI
+// conflicts.
+//
+// IMPORTANT: Both sides share the same underlying data buffers -- no copies
+// are made.  The caller must ensure the data remains valid for the lifetime
+// of the descriptor.
+
+#include <torch/csrc/inductor/aoti_runtime/arrayref_tensor.h>
+#include <torch/csrc/inductor/aoti_runtime/interface.h>
+
+#include <cassert>
+#include <cstring>
+#include <stdexcept>
+#include <type_traits>
+
+namespace torch::aot_inductor {
+
+inline void validate_arrayref_tensor_ndim(int32_t ndim) {
+  if (ndim < 0 || ndim > AOTI_ARRAYREF_TENSOR_MAX_DIMS) {
+    throw std::runtime_error(
+        "AOTInductorArrayRefTensor ndim exceeds AOTI_ARRAYREF_TENSOR_MAX_DIMS");
+  }
+}
+
+// -------------------------------------------------------------------------
+// ArrayRefTensor<T> --> AOTInductorArrayRefTensor  (zero-copy)
+// -------------------------------------------------------------------------
+template <typename T>
+inline void arrayref_tensor_to_c(
+    const ArrayRefTensor<T>& src,
+    AOTInductorArrayRefTensor& dst) {
+  const auto sizes = src.sizes();
+  const auto strides = src.strides();
+  dst.data = const_cast<void*>(static_cast<const void*>(src.data()));
+  dst.numel = static_cast<int64_t>(src.numel());
+  dst.ndim = static_cast<int32_t>(sizes.size());
+  dst.dtype = aoti_torch_dtype<std::remove_const_t<T>>();
+  dst.device_type = src.device_type();
+  dst.device_idx = src.device_idx();
+
+  validate_arrayref_tensor_ndim(dst.ndim);
+  assert(dst.ndim <= AOTI_ARRAYREF_TENSOR_MAX_DIMS);
+  std::memcpy(dst.sizes, sizes.data(), dst.ndim * sizeof(int64_t));
+  std::memcpy(dst.strides, strides.data(), dst.ndim * sizeof(int64_t));
+  const int32_t remaining = AOTI_ARRAYREF_TENSOR_MAX_DIMS - dst.ndim;
+  std::memset(dst.sizes + dst.ndim, 0, remaining * sizeof(int64_t));
+  std::memset(dst.strides + dst.ndim, 0, remaining * sizeof(int64_t));
+  std::memset(dst.reserved, 0, sizeof(dst.reserved));
+}
+
+template <typename T>
+inline AOTInductorArrayRefTensor arrayref_tensor_to_c(
+    const ArrayRefTensor<T>& src) {
+  AOTInductorArrayRefTensor dst;
+  arrayref_tensor_to_c(src, dst);
+  return dst;
+}
+
+// -------------------------------------------------------------------------
+// AOTInductorArrayRefTensor --> ArrayRefTensor<T>  (zero-copy)
+// -------------------------------------------------------------------------
+template <typename T>
+inline ArrayRefTensor<T> c_to_arrayref_tensor(
+    const AOTInductorArrayRefTensor& src) {
+  validate_arrayref_tensor_ndim(src.ndim);
+  return ArrayRefTensor<T>(
+      MiniArrayRef<T>(
+          static_cast<T*>(const_cast<void*>(src.data)),
+          static_cast<size_t>(src.numel)),
+      MiniArrayRef<const int64_t>(src.sizes, static_cast<size_t>(src.ndim)),
+      MiniArrayRef<const int64_t>(src.strides, static_cast<size_t>(src.ndim)),
+      src.device_type,
+      src.device_idx);
+}
+
+} // namespace torch::aot_inductor

--- a/torch/csrc/inductor/aoti_runtime/interface.h
+++ b/torch/csrc/inductor/aoti_runtime/interface.h
@@ -35,6 +35,52 @@ struct AOTInductorConstantMapEntry {
   AtenTensorHandle handle;
 };
 
+// ---------------------------------------------------------------------------
+// C-compatible tensor descriptor for crossing the DSO boundary.
+//
+// This struct carries the same information as ArrayRefTensor<T> but uses only
+// C-compatible types so the host process and DSO can be built with different
+// C++ standard libraries (e.g. libc++ vs libstdc++).  All pointer fields
+// reference memory owned by the caller; no copies are made.
+//
+// Maximum supported number of dimensions.  8 covers all practical AOTI
+// models; tensors with more dims should fall back to the AtenTensorHandle
+// interface.
+// ---------------------------------------------------------------------------
+#define AOTI_ARRAYREF_TENSOR_MAX_DIMS 8
+
+struct AOTInductorArrayRefTensor {
+  // Pointer to the raw data buffer.  Not owned.
+  void* data;
+
+  // Number of elements in the data buffer (product of sizes for contiguous
+  // tensors).
+  int64_t numel;
+
+  // Static-size arrays for shape metadata.  Only the first `ndim` entries
+  // are meaningful.
+  int64_t sizes[AOTI_ARRAYREF_TENSOR_MAX_DIMS];
+  int64_t strides[AOTI_ARRAYREF_TENSOR_MAX_DIMS];
+
+  // Number of dimensions (0 <= ndim <= AOTI_ARRAYREF_TENSOR_MAX_DIMS).
+  int32_t ndim;
+
+  // Torch dtype encoded as int32_t (same encoding as aoti_torch_dtype_*()).
+  int32_t dtype;
+
+  // Device information.
+  int32_t device_type;
+  int32_t device_idx;
+
+  // Reserved for future extension.  Zero-initialize and do not read — a
+  // newer reader must tolerate zeros, and an older reader must ignore them.
+  int64_t reserved[4];
+};
+
+static_assert(
+    sizeof(AOTInductorArrayRefTensor) == 192,
+    "changing the size of AOTInductorArrayRefTensor breaks ABI compatibility!");
+
 // TODO: Deprecate this API. This was kept for BC compatibility.
 // Please use AOTInductorModelContainerCreateWithDevice instead.
 AOTI_API AOTIRuntimeError AOTInductorModelContainerCreate(
@@ -264,5 +310,26 @@ AOTI_API AOTIRuntimeError AOTInductorModelContainerGetCallSpec(
     AOTInductorModelContainerHandle container_handle,
     const char** in_spec,
     const char** out_spec);
+
+// ---------------------------------------------------------------------------
+// C-ABI-safe variant of AOTInductorModelRunMinimalArrayrefInterface.
+//
+// Instead of passing std::tuple<ArrayRefTensor<T>...>& (which encodes C++
+// standard library types into the ABI), this function accepts flat C arrays
+// of AOTInductorArrayRefTensor descriptors.  The descriptors reference the
+// same underlying data buffers -- no copies are made.
+//
+// The host process marshals its ArrayRefTensor<T> objects into
+// AOTInductorArrayRefTensor descriptors, calls into the DSO through this
+// pure-C interface, and then unmarshals the output descriptors back.
+// Because only C types cross the DSO boundary, the host and DSO can be
+// built with different C++ standard libraries (e.g. libc++ vs libstdc++).
+// ---------------------------------------------------------------------------
+AOTI_API AOTIRuntimeError AOTInductorModelRunMinimalArrayrefInterfaceV2(
+    AOTInductorModelHandle model_handle,
+    int32_t num_inputs,
+    const AOTInductorArrayRefTensor* inputs,
+    int32_t num_outputs,
+    AOTInductorArrayRefTensor* outputs);
 
 } // extern "C"

--- a/torch/csrc/inductor/array_ref_impl.h
+++ b/torch/csrc/inductor/array_ref_impl.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <torch/csrc/inductor/aoti_runtime/arrayref_tensor.h>
+#include <torch/csrc/inductor/aoti_runtime/arrayref_tensor_conversion.h>
 #include <torch/csrc/inductor/aoti_runtime/scalar_to_tensor.h>
 #include <torch/csrc/inductor/aoti_runtime/thread_local.h>
 #include <torch/csrc/inductor/aoti_torch/utils.h>


### PR DESCRIPTION
Summary:

Introduce `AOTInductorArrayRefTensor`, a C-compatible descriptor for `ArrayRefTensor<T>` values crossing the DSO boundary, plus zero-copy marshal and unmarshal helpers between the descriptor and the existing C++ `ArrayRefTensor<T>` runtime type.

This factors the descriptor ABI and helper layer out from the later `MinimalArrayref` V2 entrypoint wiring so `D93499366` can stay focused on the generated wrapper and raw DSO execution path. The descriptor carries `data`, `numel`, `dtype`, `device`, and inline `sizes[8]` / `strides[8]`, while `arrayref_tensor_conversion.h` centralizes the shared conversions used by runtime code.

Add runtime `ndim` validation in both marshal directions so release builds fail cleanly instead of overrunning the inline `sizes[8]` / `strides[8]` arrays when a tensor rank exceeds `AOTI_ARRAYREF_TENSOR_MAX_DIMS`.

Test Plan:
```bash
arc lint fbcode/caffe2/torch/csrc/inductor/aoti_runtime/arrayref_tensor.h fbcode/caffe2/torch/csrc/inductor/aoti_runtime/arrayref_tensor_conversion.h fbcode/caffe2/torch/csrc/inductor/aoti_runtime/interface.h fbcode/caffe2/torch/csrc/inductor/array_ref_impl.h xplat/caffe2/torch/csrc/inductor/aoti_runtime/arrayref_tensor.h xplat/caffe2/torch/csrc/inductor/aoti_runtime/arrayref_tensor_conversion.h xplat/caffe2/torch/csrc/inductor/aoti_runtime/interface.h xplat/caffe2/torch/csrc/inductor/array_ref_impl.h
```

Differential Revision: D98668149
