### PR TITLE
[5/11][aoti] Add C-ABI-safe V2 interface for MinimalArrayref (#179483)

### DIFF
--- a/test/inductor/test_aot_inductor_arrayref.py
+++ b/test/inductor/test_aot_inductor_arrayref.py
@@ -2,7 +2,11 @@
 import sys
 import unittest
 
+import torch
+from torch._inductor import config
 from torch._inductor.test_case import TestCase
+from torch._inductor.utils import run_and_get_cpp_code
+from torch.testing import FileCheck
 from torch.testing._internal.common_utils import IS_CI, IS_FBCODE, IS_WINDOWS
 
 
@@ -18,6 +22,7 @@ try:
     try:
         from .test_aot_inductor import (
             AOTInductorTestsTemplate,
+            AOTIRunnerUtil,
             check_model,
             check_model_with_multiple_inputs,
             code_check_count,
@@ -26,6 +31,7 @@ try:
     except ImportError:
         from test_aot_inductor import (  # @manual
             AOTInductorTestsTemplate,
+            AOTIRunnerUtil,
             check_model,
             check_model_with_multiple_inputs,
             code_check_count,
@@ -55,6 +61,41 @@ def fail_minimal_arrayref_interface(is_skip=False):
         ("cpu_with_stack_allocation_and_minimal_arrayref_interface",),
         is_skip=is_skip,
     )
+
+
+class AOTInductorArrayRefTestsTemplate(AOTInductorTestsTemplate):
+    def test_simple_v2_interface(self):
+        class Model(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.linear = torch.nn.Linear(10, 10)
+
+            def forward(self, x, y):
+                return x + self.linear(y)
+
+        example_inputs = (
+            torch.randn(10, 10, device=self.device),
+            torch.randn(10, 10, device=self.device),
+        )
+        model = Model()
+        with config.patch(
+            {
+                "aot_inductor.allow_stack_allocation": self.allow_stack_allocation,
+                "aot_inductor.use_minimal_arrayref_interface": self.use_minimal_arrayref_interface,
+            }
+        ):
+            _, code = run_and_get_cpp_code(
+                AOTIRunnerUtil.compile, model, example_inputs
+            )
+
+        FileCheck().check("AOTInductorModelRunMinimalArrayrefInterfaceV2(").check(
+            "constexpr int32_t expected_num_inputs = 2;"
+        ).check("constexpr int32_t expected_num_outputs = 1;").check(
+            "if (num_inputs != expected_num_inputs)"
+        ).check("if (num_outputs != expected_num_outputs)").run(code)
+        self.code_check_count(
+            model, example_inputs, "AOTInductorModelRunMinimalArrayrefInterface(", 1
+        )
 
 
 # test_failures, xfail by default, set is_skip=True to skip
@@ -228,6 +269,12 @@ if IS_FBCODE:
     # See https://github.com/pytorch/pytorch/issues/123691
     copy_tests(
         AOTInductorTestsTemplate,
+        AOTInductorTestABICompatibleCpuWithStackAllocationAndMinimalArrayRefInterface,
+        "cpu_with_stack_allocation_and_minimal_arrayref_interface",
+        CPU_TEST_FAILURES,
+    )
+    copy_tests(
+        AOTInductorArrayRefTestsTemplate,
         AOTInductorTestABICompatibleCpuWithStackAllocationAndMinimalArrayRefInterface,
         "cpu_with_stack_allocation_and_minimal_arrayref_interface",
         CPU_TEST_FAILURES,

--- a/torch/_inductor/codegen/cpp_wrapper_cpu_array_ref.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu_array_ref.py
@@ -7,9 +7,10 @@ import sympy
 import torch
 import torch._inductor.async_compile  # noqa: F401 required to warm up AsyncCompile pools
 import torch._ops
+from torch.utils._ordered_set import OrderedSet
 
 from .. import config, ir
-from ..utils import sympy_product
+from ..utils import IndentedBuffer, sympy_product
 from ..virtualized import V
 from .cpp_utils import DTYPE_TO_CPP
 from .cpp_wrapper_cpu import CppWrapperCpu
@@ -46,6 +47,8 @@ class CppWrapperCpuArrayRef(CppWrapperCpu):
         assert self.device == "cpu", "ArrayRefTensor only supported on CPU!"
         self.allow_stack_allocation = config.aot_inductor.allow_stack_allocation
         self.stack_allocated_buffers: dict[BufferName, BufferLike] = {}
+        self.v2_raw_wrapper_body = IndentedBuffer()
+        self.v2_raw_output_refs: list[str] | None = None
 
     @staticmethod
     def create(
@@ -71,13 +74,24 @@ class CppWrapperCpuArrayRef(CppWrapperCpu):
         return f"ArrayRefTensor<{DTYPE_TO_CPP[input.get_dtype()]}>"
 
     @staticmethod
+    def get_input_element_cpp_type(input):
+        if isinstance(input, sympy.Expr):
+            from ..graph import may_get_constant_buffer_dtype
+
+            dtype = may_get_constant_buffer_dtype(input)
+            assert dtype is not None, f"Failed to get the dtype of sympy.Expr: {input}"
+            return DTYPE_TO_CPP[dtype]
+        return DTYPE_TO_CPP[input.get_dtype()]
+
+    @staticmethod
     def get_device_include_path(device: str) -> str:
         assert device == "cpu", "ArrayRef only supported on CPU!"
         if V.graph.aot_mode:
             return "#include <torch/csrc/inductor/aoti_include/array_ref.h>"
         return "#include <torch/csrc/inductor/cpp_wrapper/array_ref.h>"
 
-    def codegen_input_numel_asserts(self):
+    def codegen_input_numel_asserts(self, indented_buffer=None):
+        writer = indented_buffer or self.prefix
         for name, buf in V.graph.graph_inputs.items():
             if isinstance(buf, sympy.Expr):
                 continue
@@ -86,7 +100,154 @@ class CppWrapperCpuArrayRef(CppWrapperCpu):
             if sympy_product(buf.get_size()) == 0:
                 continue
             numel = buf.get_numel()
-            self.prefix.writeline(f"assert_numel({name}, {numel});")
+            writer.writeline(f"assert_numel({name}, {numel});")
+
+    def _codegen_v2_raw_input_bindings(self, code: IndentedBuffer):
+        for idx, (input_key, input_value) in enumerate(V.graph.graph_inputs.items()):
+            input_cpp_type = CppWrapperCpuArrayRef.get_input_element_cpp_type(
+                input_value
+            )
+            if isinstance(input_value, sympy.Expr):
+                # cond / symint wrappers can surface symbolic scalar inputs here.
+                from ..graph import may_get_constant_buffer_dtype
+
+                dtype = may_get_constant_buffer_dtype(input_value)
+                assert dtype is not None, "Fails to get the dtype of the sympy.Expr"
+                input_tensor = f"{input_key}_arrayref_tensor"
+                code.writeline(
+                    f"auto {input_tensor} = torch::aot_inductor::c_to_arrayref_tensor<{input_cpp_type}>(c_inputs[{idx}]);"
+                )
+                self.codegen_tensor_item(dtype, input_tensor, input_key, code)
+            else:
+                code.writeline(
+                    f"auto {input_key} = torch::aot_inductor::c_to_arrayref_tensor<{input_cpp_type}>(c_inputs[{idx}]);"
+                )
+
+    def _codegen_v2_raw_input_symbols(self, code: IndentedBuffer) -> None:
+        bound_vars = OrderedSet[sympy.Symbol]()
+        graph_inputs = self.get_graph_inputs()
+        inputs = [
+            (k, v) for k, v in graph_inputs.items() if isinstance(v, sympy.Symbol)
+        ] + [(k, v) for k, v in graph_inputs.items() if not isinstance(v, sympy.Symbol)]
+
+        # Temporarily redirect self.prefix so the base class
+        # codegen_input_symbol_assignment writes into our buffer.
+        orig_prefix = self.prefix
+        self.prefix = code
+        try:
+            for name, value in inputs:
+                self.codegen_input_symbol_assignment(name, value, bound_vars)
+        finally:
+            self.prefix = orig_prefix
+
+        for _, value in inputs:
+            if not isinstance(value, ir.TensorBox):
+                continue
+            for expr in [*value.get_size(), *value.get_stride()]:
+                if not isinstance(expr, sympy.Expr) or isinstance(expr, sympy.Symbol):
+                    continue
+                undefined_symbols = [
+                    sym for sym in expr.free_symbols if sym not in bound_vars
+                ]
+                if len(undefined_symbols) > 0:
+                    raise AssertionError(
+                        f"For {expr}, expected {undefined_symbols} to have been codegen-ed."
+                    )
+
+    def _codegen_v2_raw_prelude(self, code: IndentedBuffer):
+        self._codegen_v2_raw_input_bindings(code)
+
+        assert all(
+            isinstance(v, torch.Tensor) for v in list(V.graph.constants.values())
+        ), "Expect all constants to be Tensor"
+        for idx, constants_key in enumerate(V.graph.constants.keys()):
+            code.writeline(f"""auto {constants_key} = constants_->at({idx});""")
+
+        self._codegen_v2_raw_input_symbols(code)
+
+        self.codegen_input_numel_asserts(code)
+        code.writeline(
+            "[[maybe_unused]] auto& kernels = static_cast<AOTInductorModelKernels&>(*this->kernels_.get());"
+        )
+
+    def _codegen_v2_raw_outputs(
+        self, code: IndentedBuffer, output_refs: list[str]
+    ) -> None:
+        cst_names = V.graph.constants.keys()
+
+        def write_output_to_c_array(idx: int, output: str) -> None:
+            output_arrayref_name = f"output_arrayref_{idx}"
+            code.splice(
+                f"""
+                std::tuple_element_t<{idx}, AOTInductorModelOutputs> {output_arrayref_name};
+                convert_handle_to_arrayref_tensor({output}, {output_arrayref_name});
+                torch::aot_inductor::arrayref_tensor_to_c({output_arrayref_name}, c_outputs[{idx}]);
+                """
+            )
+
+        for idx, output in enumerate(output_refs):
+            if output == "nullptr":
+                continue
+
+            is_constant_buffer = output in cst_names
+            output_buffer = V.graph.graph_outputs[idx]
+            if isinstance(output_buffer, ir.BaseView):
+                output_storage = output_buffer.unwrap_view()
+                assert isinstance(output_storage, (ir.BaseView, ir.MutableBox))
+                if isinstance(output_storage.data, ir.ConstantBuffer):
+                    is_constant_buffer = True
+
+            if isinstance(output_buffer, ir.ShapeAsConstantBuffer):
+                output_tensor = f"scalar_to_tensor_{next(self.scalar_to_tensor_id)}"
+                code.writeline(
+                    f"RAIIAtenTensorHandle {output_tensor} = scalar_to_tensor_handle({output});"
+                )
+                write_output_to_c_array(idx, output_tensor)
+                continue
+
+            output_is_tensor_handle_expr = (
+                f"std::is_same_v<std::decay_t<decltype({output})>,"
+                "RAIIAtenTensorHandle> || "
+                f"std::is_same_v<std::decay_t<decltype({output})>,"
+                "AtenTensorHandle> || "
+                f"std::is_same_v<std::decay_t<decltype({output})>,"
+                "ConstantHandle>"
+            )
+            code.writeline(f"if constexpr ({output_is_tensor_handle_expr}) {{")
+            with code.indent():
+                cached_output_name = f"cached_output_{next(self.cached_output_id)}"
+                code.writeline(
+                    f"thread_local RAIIAtenTensorHandle {cached_output_name};"
+                )
+                if is_constant_buffer:
+                    code.splice(
+                        f"""
+                        AtenTensorHandle {cached_output_name}_tmp;
+                        aoti_torch_clone({output}, &{cached_output_name}_tmp);
+                        {cached_output_name} = {cached_output_name}_tmp;
+                        """
+                    )
+                else:
+                    code.writeline(f"{cached_output_name} = {output}.release();")
+                write_output_to_c_array(idx, cached_output_name)
+            code.writeline("} else {")
+            with code.indent():
+                cached_output_name = f"cached_output_{next(self.cached_output_id)}"
+                output_arrayref_type = f"output_arrayref_{idx}_type"
+                output_element_type = f"output_arrayref_{idx}_element_type"
+                output_arrayref_name = f"output_arrayref_{idx}"
+                code.splice(
+                    f"""
+                    thread_local ThreadLocalCachedOutputArray<std::decay_t<decltype({output})>>
+                        {cached_output_name}({output});
+                    {cached_output_name}.copy_data_from({output});
+                    using {output_arrayref_type} = std::tuple_element_t<{idx}, AOTInductorModelOutputs>;
+                    using {output_element_type} = typename {output_arrayref_type}::value_type;
+                    auto {output_arrayref_name} = {cached_output_name}.arrayref_tensor<{output_element_type}>();
+                    torch::aot_inductor::arrayref_tensor_to_c({output_arrayref_name}, c_outputs[{idx}]);
+                    """
+                )
+            code.writeline("}")
 
     def generate_extern_kernel_alloc(self, *args, **kwargs):
         # Disable stack allocation for extern kernels.
@@ -154,6 +315,7 @@ class CppWrapperCpuArrayRef(CppWrapperCpu):
             self.writeline(self.wrap_kernel_call(kernel_name, new_args))
 
     def write_wrapper_decl(self):
+        """Declare the generated AOTI wrapper entry points."""
         inputs_len = len(V.graph.graph_inputs.keys())
         if V.graph.aot_mode:
             if (
@@ -272,6 +434,54 @@ class CppWrapperCpuArrayRef(CppWrapperCpu):
                         }
                     """
                     )
+
+                    self.suffix.splice(
+                        f"""
+                        // C-ABI-safe variant: uses flat AOTInductorArrayRefTensor arrays
+                        // instead of std::tuple across the DSO boundary, and
+                        // runs directly on the descriptor arrays to avoid
+                        // DSO-side tuple marshaling.
+                        extern "C" AOTIRuntimeError AOTInductorModelRunMinimalArrayrefInterfaceV2(
+                            AOTInductorModelHandle model_handle,
+                            int32_t num_inputs,
+                            const AOTInductorArrayRefTensor* c_inputs,
+                            int32_t num_outputs,
+                            AOTInductorArrayRefTensor* c_outputs) {{
+                          constexpr int32_t expected_num_inputs = {len(V.graph.graph_inputs)};
+                          constexpr int32_t expected_num_outputs = {len(V.graph.graph_outputs)};
+                          auto model = reinterpret_cast<torch::aot_inductor::AOTInductorModel*>(model_handle);
+                          CONVERT_EXCEPTION_TO_ERROR_CODE({{
+                              if (num_inputs != expected_num_inputs) {{
+                                throw std::runtime_error(
+                                    std::string("AOTInductorModelRunMinimalArrayrefInterfaceV2 expected ")
+                                    + std::to_string(expected_num_inputs)
+                                    + " inputs but got "
+                                    + std::to_string(num_inputs));
+                              }}
+                              if (num_outputs != expected_num_outputs) {{
+                                throw std::runtime_error(
+                                    std::string("AOTInductorModelRunMinimalArrayrefInterfaceV2 expected ")
+                                    + std::to_string(expected_num_outputs)
+                                    + " outputs but got "
+                                    + std::to_string(num_outputs));
+                              }}
+                              if (num_inputs > 0 && c_inputs == nullptr) {{
+                                throw std::runtime_error(
+                                    "AOTInductorModelRunMinimalArrayrefInterfaceV2 received null input descriptors");
+                              }}
+                              if (num_outputs > 0 && c_outputs == nullptr) {{
+                                throw std::runtime_error(
+                                    "AOTInductorModelRunMinimalArrayrefInterfaceV2 received null output descriptors");
+                              }}
+                              model->run_impl_minimal_arrayref_interface_v2_raw(
+                                  c_inputs,
+                                  c_outputs,
+                                  (torch::aot_inductor::DeviceStreamType)nullptr,
+                                  nullptr);
+                          }})
+                        }}
+                    """
+                    )
                 else:
                     self.prefix.splice(run_impl_proto)
         else:
@@ -368,6 +578,11 @@ class CppWrapperCpuArrayRef(CppWrapperCpu):
             not V.graph.is_const_graph
             and config.aot_inductor.use_minimal_arrayref_interface
         )  # For brevity.
+
+        if arr_iface and V.graph.aot_mode:
+            self.v2_raw_wrapper_body.clear()
+            self.v2_raw_wrapper_body.splice(self.wrapper_call)
+            self.v2_raw_output_refs = list(output_refs)
 
         def use_thread_local_cached_output_tensor(idx, output):
             cached_output_name = f"cached_output_{next(self.cached_output_id)}"
@@ -490,6 +705,31 @@ class CppWrapperCpuArrayRef(CppWrapperCpu):
                 output2idx[output] = idx
         if arr_iface:
             self.wrapper_call.writeline("return output_arrayref_tensors;")
+
+    def generate_before_suffix(self, result):
+        super().generate_before_suffix(result)
+        if self.v2_raw_output_refs is None:
+            return
+
+        raw_impl = IndentedBuffer()
+        raw_impl.splice(
+            """
+            void AOTInductorModel::run_impl_minimal_arrayref_interface_v2_raw(
+                const AOTInductorArrayRefTensor* c_inputs,
+                AOTInductorArrayRefTensor* c_outputs,
+                DeviceStreamType stream,
+                AOTIProxyExecutorHandle proxy_executor
+            ) {
+            """
+        )
+        with raw_impl.indent():
+            self._codegen_v2_raw_prelude(raw_impl)
+            raw_impl.splice(self.v2_raw_wrapper_body)
+            self._codegen_v2_raw_outputs(raw_impl, self.v2_raw_output_refs)
+        raw_impl.writeline(
+            "} // AOTInductorModel::run_impl_minimal_arrayref_interface_v2_raw"
+        )
+        result.splice(raw_impl)
 
     def memory_plan(self):
         from .memory_planning import MemoryPlanner

--- a/torch/csrc/inductor/aoti_runtime/model.h
+++ b/torch/csrc/inductor/aoti_runtime/model.h
@@ -6,6 +6,8 @@
 // applies to other files under torch/csrc/inductor/aoti_runtime/.
 #include <torch/csrc/inductor/aoti_runtime/model_base.h>
 
+struct AOTInductorArrayRefTensor;
+
 namespace torch::aot_inductor {
 
 class AOTInductorModel : public AOTInductorModelBase<AOTInductorModel> {
@@ -40,6 +42,12 @@ class AOTInductorModel : public AOTInductorModelBase<AOTInductorModel> {
   template <typename Inputs, typename Outputs>
   Outputs run_impl_minimal_arrayref_interface(
       const Inputs& inputs,
+      DeviceStreamType stream,
+      AOTIProxyExecutorHandle proxy_executor);
+
+  void run_impl_minimal_arrayref_interface_v2_raw(
+      const AOTInductorArrayRefTensor* c_inputs,
+      AOTInductorArrayRefTensor* c_outputs,
       DeviceStreamType stream,
       AOTIProxyExecutorHandle proxy_executor);
 


### PR DESCRIPTION
Summary:

The previous diff introduced the `AOTInductorArrayRefTensor` descriptor ABI. This diff wires that ABI into generated CPU `MinimalArrayref` models by exporting `AOTInductorModelRunMinimalArrayrefInterfaceV2`, validating input and output counts at the wrapper boundary, and generating a raw `run_impl_minimal_arrayref_interface_v2_raw()` path so compiled models consume descriptor arrays directly instead of rebuilding tuples inside the DSO.

The generated CPU arrayref wrapper continues to export the legacy V1 symbol alongside the new V2 symbol, and the raw V2 path now binds symbolic inputs directly from the descriptor-array prelude so generated `cond` / symint wrappers compile in the C-array entrypoint as well.

The wrapper test continues to check that the emitted V2 symbol contains the expected argument-count validation.

Test Plan:
```bash
buck test fbcode//mode/opt fbcode//caffe2/test/inductor:aot_inductor_arrayref_cpu_local -- test_simple_v2_interface_cpu_with_stack_allocation_and_minimal_arrayref_interface
```
Representative generated wrapper code: https://www.internalfb.com/intern/paste/P2274480858/

Reviewed By: desertfire

Differential Revision: D93499366




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo