### PR TITLE
Add torchbind custom class inheritance support (#179485)

### DIFF
--- a/aten/src/ATen/core/class_type.cpp
+++ b/aten/src/ATen/core/class_type.cpp
@@ -462,6 +462,15 @@ bool ClassType::isSubtypeOfExt(const Type& rhs, std::ostream* why_not) const {
     }
     return true;
   }
+
+  // Check custom class inheritance chain.
+  if (auto rhsClass = rhs.castRaw<ClassType>()) {
+    for (auto cur = baseType_.get(); cur; cur = cur->baseType_.get()) {
+      if (cur == rhsClass) {
+        return true;
+      }
+    }
+  }
   return Type::isSubtypeOfExt(rhs, why_not);
 }
 

--- a/aten/src/ATen/core/class_type.h
+++ b/aten/src/ATen/core/class_type.h
@@ -379,6 +379,15 @@ struct TORCH_API ClassType : public NamedType {
 
   bool isSubtypeOfExt(const Type& rhs, std::ostream* why_not) const override;
 
+  // Base class support for custom class inheritance.
+  void setBaseType(ClassTypePtr base) {
+    baseType_ = std::move(base);
+  }
+
+  const ClassTypePtr& baseType() const {
+    return baseType_;
+  }
+
   static const TypeKind Kind = TypeKind::ClassType;
 
  private:
@@ -436,6 +445,9 @@ struct TORCH_API ClassType : public NamedType {
 
   // For error reporting accesses to class level attributes.
   std::vector<std::string> unresolved_class_attributes_;
+
+  // Optional base ClassType for custom class inheritance.
+  ClassTypePtr baseType_;
 };
 
 }

--- a/aten/src/ATen/core/ivalue.cpp
+++ b/aten/src/ATen/core/ivalue.cpp
@@ -30,10 +30,12 @@ namespace ivalue {
 // This is in ivalue.cpp because we need to access Type::annotation_str, which
 // is declared in jit_type.h
 void checkCustomClassType(const ClassType* expected_type, const Type* actual_type) {
-  // NB: doing pointer comparison here
-  // If in the future there ever arises a need to call operator== on custom class
-  // Type's, this needs to be changed!
-  TORCH_CHECK(actual_type == static_cast<const Type*>(expected_type),
+  // Fast path: pointer equality.
+  if (actual_type == static_cast<const Type*>(expected_type)) {
+    return;
+  }
+  // Slow path: check inheritance chain via isSubtypeOf.
+  TORCH_CHECK(actual_type && actual_type->isSubtypeOf(*expected_type),
               "Tried to convert an IValue of type ",
               actual_type ? actual_type->repr_str() : std::string("*NULL*"),
               " to custom class type ",

--- a/test/cpp/jit/test_custom_class.cpp
+++ b/test/cpp/jit/test_custom_class.cpp
@@ -146,5 +146,105 @@ TEST(CustomClassTest, Serialization) {
   auto loaded_frozen_module = torch::jit::load(iss_frozen, torch::kCPU);
 }
 
+// --- Torchbind inheritance tests ---
+
+TEST(CustomClassTest, DefBaseRegistersBaseType) {
+  // Verify that def_base<> correctly sets the base type on the ClassType.
+  auto dogType = c10::getCustomClassType<c10::intrusive_ptr<Dog>>();
+  auto animalType = c10::getCustomClassType<c10::intrusive_ptr<Animal>>();
+  ASSERT_TRUE(dogType != nullptr);
+  ASSERT_TRUE(animalType != nullptr);
+
+  auto dogClass = std::dynamic_pointer_cast<c10::ClassType>(dogType);
+  auto animalClass = std::dynamic_pointer_cast<c10::ClassType>(animalType);
+  ASSERT_TRUE(dogClass != nullptr);
+  ASSERT_TRUE(animalClass != nullptr);
+  ASSERT_TRUE(dogClass->baseType() != nullptr);
+  EXPECT_EQ(dogClass->baseType().get(), animalClass.get());
+}
+
+TEST(CustomClassTest, IsSubtypeOfWithInheritance) {
+  auto dogType = c10::getCustomClassType<c10::intrusive_ptr<Dog>>();
+  auto catType = c10::getCustomClassType<c10::intrusive_ptr<Cat>>();
+  auto animalType = c10::getCustomClassType<c10::intrusive_ptr<Animal>>();
+
+  // Dog is a subtype of Animal.
+  EXPECT_TRUE(dogType->isSubtypeOf(*animalType));
+  // Cat is a subtype of Animal.
+  EXPECT_TRUE(catType->isSubtypeOf(*animalType));
+  // Animal is NOT a subtype of Dog.
+  EXPECT_FALSE(animalType->isSubtypeOf(*dogType));
+  // Dog is NOT a subtype of Cat.
+  EXPECT_FALSE(dogType->isSubtypeOf(*catType));
+  // Reflexive: Dog is a subtype of itself.
+  EXPECT_TRUE(dogType->isSubtypeOf(*dogType));
+}
+
+TEST(CustomClassTest, IsSubtypeOfMultiLevel) {
+  // Puppy -> Dog -> Animal: Puppy should be a subtype of both Dog and Animal.
+  auto puppyType = c10::getCustomClassType<c10::intrusive_ptr<Puppy>>();
+  auto dogType = c10::getCustomClassType<c10::intrusive_ptr<Dog>>();
+  auto animalType = c10::getCustomClassType<c10::intrusive_ptr<Animal>>();
+
+  EXPECT_TRUE(puppyType->isSubtypeOf(*dogType));
+  EXPECT_TRUE(puppyType->isSubtypeOf(*animalType));
+  EXPECT_FALSE(animalType->isSubtypeOf(*puppyType));
+}
+
+TEST(CustomClassTest, DerivedToBaseIValueConversion) {
+  // Wrap a derived class in IValue, then extract as base type.
+  auto dog = c10::make_intrusive<Dog>();
+  c10::IValue iv(dog);
+
+  // Should succeed: extract Dog IValue as Animal.
+  auto asAnimal = iv.toCustomClass<Animal>();
+  ASSERT_TRUE(asAnimal != nullptr);
+  EXPECT_EQ(asAnimal->speak(), "woof");
+}
+
+TEST(CustomClassTest, MultiLevelIValueConversion) {
+  // Puppy -> Dog -> Animal: extract Puppy as Animal via IValue.
+  auto puppy = c10::make_intrusive<Puppy>();
+  c10::IValue iv(puppy);
+
+  auto asAnimal = iv.toCustomClass<Animal>();
+  ASSERT_TRUE(asAnimal != nullptr);
+  EXPECT_EQ(asAnimal->speak(), "yip");
+
+  auto asDog = iv.toCustomClass<Dog>();
+  ASSERT_TRUE(asDog != nullptr);
+  EXPECT_EQ(asDog->speak(), "yip");
+}
+
+TEST(CustomClassTest, DerivedPassedAsBaseToConstructor) {
+  // Simulate the torchbind path: pass a Dog to AnimalShelter(Animal).
+  auto dog = c10::make_intrusive<Dog>();
+  auto shelter = c10::make_intrusive<AnimalShelter>(dog);
+  EXPECT_EQ(shelter->resident_speak(), "woof");
+
+  auto cat = c10::make_intrusive<Cat>();
+  auto shelter2 = c10::make_intrusive<AnimalShelter>(cat);
+  EXPECT_EQ(shelter2->resident_speak(), "meow");
+}
+
+TEST(CustomClassTest, DerivedPassedAsBaseViaIValue) {
+  // Simulate the Python/TorchScript path: wrap derived in IValue, then pass to
+  // a function expecting the base type via toCustomClass<Base>().
+  auto cat = c10::make_intrusive<Cat>();
+  c10::IValue iv(cat);
+
+  auto asAnimal = iv.toCustomClass<Animal>();
+  ASSERT_TRUE(asAnimal != nullptr);
+  EXPECT_EQ(asAnimal->speak(), "meow");
+}
+
+TEST(CustomClassTest, InvalidCrossHierarchyConversionThrows) {
+  // Cat should NOT be convertible to Dog.
+  auto cat = c10::make_intrusive<Cat>();
+  c10::IValue iv(cat);
+
+  EXPECT_THROW(iv.toCustomClass<Dog>(), c10::Error);
+}
+
 } // namespace jit
 } // namespace torch

--- a/test/cpp/jit/test_custom_class_registrations.cpp
+++ b/test/cpp/jit/test_custom_class_registrations.cpp
@@ -777,3 +777,48 @@ TORCH_LIBRARY_IMPL(_TorchScriptTesting, BackendSelect, m) {
 }
 
 } // namespace
+
+// --- Torchbind inheritance test class implementations ---
+
+namespace torch {
+namespace jit {
+
+std::string Dog::speak() {
+  return "woof";
+}
+std::string Cat::speak() {
+  return "meow";
+}
+std::string Puppy::speak() {
+  return "yip";
+}
+AnimalShelter::AnimalShelter(c10::intrusive_ptr<Animal> animal)
+    : animal_(std::move(animal)) {}
+std::string AnimalShelter::resident_speak() {
+  return animal_->speak();
+}
+
+} // namespace jit
+} // namespace torch
+
+// --- Torchbind inheritance registrations ---
+
+using torch::jit::Animal;
+using torch::jit::AnimalShelter;
+using torch::jit::Cat;
+using torch::jit::Dog;
+using torch::jit::Puppy;
+
+TORCH_LIBRARY_FRAGMENT(_TorchScriptTesting, m) {
+  m.class_<Animal>("_Animal");
+
+  m.class_<Dog>("_Dog").def_base<Animal>().def(torch::init<>());
+
+  m.class_<Cat>("_Cat").def_base<Animal>().def(torch::init<>());
+
+  m.class_<Puppy>("_Puppy").def_base<Dog>().def(torch::init<>());
+
+  m.class_<AnimalShelter>("_AnimalShelter")
+      .def(torch::init<c10::intrusive_ptr<Animal>>())
+      .def("resident_speak", &AnimalShelter::resident_speak);
+}

--- a/test/cpp/jit/test_custom_class_registrations.h
+++ b/test/cpp/jit/test_custom_class_registrations.h
@@ -37,5 +37,31 @@ struct MyStackClass : torch::CustomClassHolder {
     return std::make_tuple(1337.0f, 123);
   }
 };
+
+// --- Torchbind inheritance test classes ---
+
+struct Animal : public torch::CustomClassHolder {
+  virtual std::string speak() = 0;
+  virtual ~Animal() = default;
+};
+
+struct Dog : Animal {
+  std::string speak() override;
+};
+
+struct Cat : Animal {
+  std::string speak() override;
+};
+
+struct Puppy : Dog {
+  std::string speak() override;
+};
+
+struct AnimalShelter : public torch::CustomClassHolder {
+  c10::intrusive_ptr<Animal> animal_;
+  explicit AnimalShelter(c10::intrusive_ptr<Animal> animal);
+  std::string resident_speak();
+};
+
 } // namespace jit
 } // namespace torch

--- a/torch/custom_class.h
+++ b/torch/custom_class.h
@@ -165,6 +165,21 @@ class class_ : public ::torch::detail::class_base {
     return *this;
   }
 
+  /// Declares that CurClass inherits from Base in the TorchScript type
+  /// system, enabling polymorphic use of derived custom classes where the
+  /// base type is expected.
+  template <typename Base>
+  class_& def_base() {
+    static_assert(
+        std::is_base_of_v<Base, CurClass>,
+        "def_base<Base>(): CurClass must inherit from Base");
+    auto baseType =
+        c10::getCustomClassType<c10::intrusive_ptr<Base>>();
+    classTypePtr->setBaseType(
+        std::dynamic_pointer_cast<c10::ClassType>(baseType));
+    return *this;
+  }
+
   /// Method registration API for static methods.
   template <typename Func>
   class_& def_static(std::string name, Func func, std::string doc_string = "") {

--- a/torch/library.h
+++ b/torch/library.h
@@ -489,6 +489,10 @@ class ClassNotSelected {
   ClassNotSelected& def(...) {
     return *this;
   }
+  template <typename Base>
+  ClassNotSelected& def_base() {
+    return *this;
+  }
 };
 
 // A SelectiveStr is like a const char*, except that it also comes


### PR DESCRIPTION
Summary:

Add support for declaring base classes in PyTorch's torchbind
custom class system via a new `def_base<Base>()` API on
`torch::class_<T>`. This enables polymorphic use of derived
custom classes where a base type is expected (e.g. passing a
"Animal" where "Dog" is expected).

Changes:
- ClassType: add baseType_ field with setBaseType/baseType accessors
- ClassType::isSubtypeOfExt: walk inheritance chain for subtype checks
- checkCustomClassType (ivalue.cpp): use isSubtypeOf instead of pointer
  equality, enabling IValue derived-to-base conversions
- torch::class_<T>::def_base<Base>(): new registration API with
  compile-time static_assert validation

Test Plan:
Tests cover def_base registration, single and multi-level isSubtypeOf
checks, IValue derived-to-base conversion, constructor polymorphism,
and invalid cross-hierarchy conversion rejection.

Differential Revision: D99685086


