### PR TITLE
[inductor] Fix mix_order_reduction over-fusion via load count check

### DIFF
--- a/test/inductor/test_mix_order_reduction.py
+++ b/test/inductor/test_mix_order_reduction.py
@@ -1074,6 +1074,102 @@ class MixOrderReductionTest(TestBase):
         )
 
 
+class OverFusionTest(TestBase):
+    """
+    Regression test for mix-order reduction over-fusion in transformer backward
+    passes. When can_fuse_with absorbs too many pointwise nodes into a
+    mixed-order kernel, the resulting kernel has excessive buffer reads (loads)
+    per RSPLIT loop iteration, causing register spills and performance
+    regression. See #179423.
+    """
+
+    @inductor_config.patch(
+        {
+            "triton.mix_order_reduction": True,
+            "triton.mix_order_reduction_max_reads": 10,
+        }
+    )
+    def test_max_reads_limits_fusion(self):
+        """
+        Verify that max_reads limits over-fusion in a transformer backward
+        pass without disabling mix-order reduction entirely.
+
+        Uses the exact model pattern from #179423: GQA attention with QK-norm
+        and squared leaky-relu MLP. The QK-norm creates extra intermediate
+        buffers in the backward pass that push read counts above the threshold.
+        """
+        if not HAS_GPU:
+            self.skipTest("requires GPU")
+
+        num_heads = 8
+        num_kv_heads = 4
+        dim = 512
+        head_dim = dim // num_heads
+
+        class Attention(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.c_q = nn.Linear(dim, dim, bias=False)
+                self.c_k = nn.Linear(dim, num_kv_heads * head_dim, bias=False)
+                self.c_v = nn.Linear(dim, num_kv_heads * head_dim, bias=False)
+                self.proj = nn.Linear(dim, dim, bias=False)
+
+            def forward(self, x):
+                B, T, D = x.shape
+                q = self.c_q(x).reshape(B, T, num_heads, head_dim)
+                k = self.c_k(x).reshape(B, T, num_kv_heads, head_dim)
+                v = self.c_v(x).reshape(B, T, num_kv_heads, head_dim)
+                q = F.rms_norm(q, (q.size(-1),))
+                k = F.rms_norm(k, (k.size(-1),))
+                q = q.transpose(1, 2)
+                k = k.transpose(1, 2).repeat_interleave(
+                    num_heads // num_kv_heads, dim=1
+                )
+                v = v.transpose(1, 2).repeat_interleave(
+                    num_heads // num_kv_heads, dim=1
+                )
+                y = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+                return self.proj(y.transpose(1, 2).reshape(B, T, D))
+
+        class Block(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.attn_norm = nn.RMSNorm(dim)
+                self.mlp_norm = nn.RMSNorm(dim)
+                self.attn = Attention()
+                self.fc1 = nn.Linear(dim, dim * 4, bias=False)
+                self.fc2 = nn.Linear(dim * 4, dim, bias=False)
+
+            def forward(self, x):
+                x = x + self.attn(self.attn_norm(x))
+                h = self.mlp_norm(x)
+                x = x + self.fc2(F.leaky_relu(self.fc1(h), negative_slope=0.5).square())
+                return x
+
+        model = nn.Sequential(*[Block() for _ in range(3)]).to(GPU_TYPE).bfloat16()
+
+        x = torch.randn(
+            8, 2048, dim, device=GPU_TYPE, dtype=torch.bfloat16, requires_grad=True
+        )
+        dy = torch.randn_like(x)
+
+        out_ref = model(x)
+        out_ref.backward(dy)
+        grad_ref = x.grad.clone()
+        x.grad = None
+
+        compiled = torch.compile(model, dynamic=False, fullgraph=True)
+        out_act = compiled(x)
+        out_act.backward(dy)
+        grad_act = x.grad.clone()
+
+        self.assertTrue(same(grad_ref, grad_act, tol=5e-2))
+
+        # max_reads should limit over-fusion, not disable mix_order entirely
+        self.assertGreater(metrics.codegen_mix_order_reduction, 0)
+        self.assertGreater(metrics.rejected_mix_order_reduction_fusion, 0)
+
+
 @inductor_config.patch(
     "triton.mix_order_reduction", not inductor_config.triton.mix_order_reduction
 )

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1985,6 +1985,10 @@ class triton:
     # this could be helpful to avoid recompilations in some cases
     mix_order_reduction_non_strict_mode = False
 
+    # Maximum external read buffers (loads) in a mix-order reduction
+    # kernel. Set to 0 to disable the check.
+    mix_order_reduction_max_reads = 10
+
     # Don't allow multi-stages by default to avoid out of shared memory
     mix_order_reduction_allow_multi_stages = (
         os.environ.get("TORCHINDUCTOR_MIX_ORDER_REDUCTION_ALLOW_MULTI_STAGES", "1")

--- a/torch/_inductor/metrics.py
+++ b/torch/_inductor/metrics.py
@@ -59,6 +59,7 @@ num_auto_chunking: int = 0
 parallel_reduction_count = 0
 
 codegen_mix_order_reduction = 0
+rejected_mix_order_reduction_fusion = 0
 
 
 # reset all counters
@@ -74,6 +75,7 @@ def reset() -> None:
     global num_loop_reordering
     global parallel_reduction_count
     global codegen_mix_order_reduction
+    global rejected_mix_order_reduction_fusion
     global num_auto_chunking
 
     generated_kernel_count = 0
@@ -89,6 +91,7 @@ def reset() -> None:
     num_loop_reordering = 0
     parallel_reduction_count = 0
     codegen_mix_order_reduction = 0
+    rejected_mix_order_reduction_fusion = 0
     num_auto_chunking = 0
 
 

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -2198,6 +2198,8 @@ class FusedSchedulerNode(BaseSchedulerNode):
 
 
 class FusedMixOrderReductions(FusedSchedulerNode):
+    """Fused node for two reductions with different iteration orders (inner + outer)."""
+
     def __init__(self, node1: BaseSchedulerNode, node2: BaseSchedulerNode) -> None:
         if not MixOrderReduction.is_contiguous_node(node1):
             assert MixOrderReduction.is_contiguous_node(node2)
@@ -2261,6 +2263,19 @@ class FusedMixOrderReductions(FusedSchedulerNode):
         )
 
     def can_fuse_with(self, other: BaseSchedulerNode):
+        # Limit tl.load() count in the fused RSPLIT loop to avoid register
+        # spills. See https://github.com/pytorch/pytorch/issues/179423
+        max_reads = config.triton.mix_order_reduction_max_reads
+        if max_reads > 0:
+            all_reads: OrderedSet[str] = OrderedSet()
+            for sn in itertools.chain(self.get_nodes(), other.get_nodes()):
+                for dep in sn.read_writes.reads:
+                    if isinstance(dep, MemoryDep):
+                        all_reads.add(dep.name)
+            if len(all_reads) > max_reads:
+                # pyrefly: ignore [bad-assignment]
+                metrics.rejected_mix_order_reduction_fusion += 1
+                return False
         if not isinstance(other, FusedMixOrderReductions):
             return self.sub_node_can_fuse(
                 self.node1, other, (self.node2,)


### PR DESCRIPTION
# [inductor] Fix mix_order_reduction over-fusion via load count check

Fixes https://github.com/pytorch/pytorch/issues/179423

## Problem

`FusedMixOrderReductions.sub_node_can_fuse()` absorbs additional nodes into mixed-order reduction kernels without checking the resulting load count. This creates Triton kernels with excessive `tl.load()` calls in the RSPLIT loop, causing register spills and a **+6.3ms/step regression** on H100.

## Model

The regression was found training a small transformer for the Parameter Golf competition. The exact model:

```python
class RMSNorm(nn.Module):
    def forward(self, x):
        return F.rms_norm(x, (x.size(-1),))

class MLP(nn.Module):
    def __init__(self, dim, mult=4):
        super().__init__()
        hidden = int(dim * mult)
        self.fc = nn.Linear(dim, hidden, bias=False)
        self.proj = nn.Linear(hidden, dim, bias=False)
    def forward(self, x):
        return self.proj(F.leaky_relu(self.fc(x), negative_slope=0.5).square())

class Attention(nn.Module):
    def __init__(self, dim, num_heads=8, num_kv_heads=4):
        super().__init__()
        self.num_heads = num_heads
        self.num_kv_heads = num_kv_heads
        self.head_dim = dim // num_heads
        self.c_q = nn.Linear(dim, dim, bias=False)
        self.c_k = nn.Linear(dim, num_kv_heads * self.head_dim, bias=False)
        self.c_v = nn.Linear(dim, num_kv_heads * self.head_dim, bias=False)
        self.proj = nn.Linear(dim, dim, bias=False)
    def forward(self, x):
        B, T, D = x.shape
        q = self.c_q(x).reshape(B, T, self.num_heads, self.head_dim)
        k = self.c_k(x).reshape(B, T, self.num_kv_heads, self.head_dim)
        v = self.c_v(x).reshape(B, T, self.num_kv_heads, self.head_dim)
        q = F.rms_norm(q, (q.size(-1),))
        k = F.rms_norm(k, (k.size(-1),))
        q = q.transpose(1, 2)
        k = k.transpose(1, 2).repeat_interleave(self.num_heads // self.num_kv_heads, dim=1)
        v = v.transpose(1, 2).repeat_interleave(self.num_heads // self.num_kv_heads, dim=1)
        y = F.scaled_dot_product_attention(q, k, v, is_causal=True)
        return self.proj(y.transpose(1, 2).reshape(B, T, D))

class Block(nn.Module):
    def __init__(self, dim):
        super().__init__()
        self.attn_norm = RMSNorm()
        self.mlp_norm = RMSNorm()
        self.attn = Attention(dim)
        self.mlp = MLP(dim)
    def forward(self, x):
        x = x + self.attn(self.attn_norm(x))
        x = x + self.mlp(self.mlp_norm(x))
        return x

class Model(nn.Module):
    def __init__(self, vocab_size=4096, dim=512, num_layers=11):
        super().__init__()
        self.tok_emb = nn.Embedding(vocab_size, dim)
        self.blocks = nn.ModuleList([Block(dim) for _ in range(num_layers)])
        self.norm = RMSNorm()
        self.head = nn.Linear(dim, vocab_size, bias=False)
    def forward(self, x, y):
        h = self.tok_emb(x)
        h = F.rms_norm(h, (h.size(-1),))
        for block in self.blocks:
            h = block(h)
        h = self.norm(h)
        logits = self.head(h)
        return F.cross_entropy(logits.view(-1, logits.size(-1)), y.view(-1))

model = Model().cuda().bfloat16()
compiled = torch.compile(model, dynamic=False, fullgraph=True)
x = torch.randint(0, 4096, (32, 2048), device='cuda')
y = torch.randint(0, 4096, (32, 2048), device='cuda')
with torch.autocast(device_type='cuda', dtype=torch.bfloat16):
    compiled(x, y).backward()
```

Key properties: `dim=512`, 11 transformer blocks, GQA attention with QK-norm, squared leaky-relu MLP, bf16 autocast, `fullgraph=True`.

## Root Cause

During the backward pass, each block produces:
- **rms_norm backward**: inner reduction over `ncol=512`, `xnumel=98304` (batch×seq = 48×2048)
- **weight gradient sums**: outer reduction over `xnumel=98304`, keeping `ncol=512`

`mix_order_reduction` fuses these two reductions (different iteration orders, same data) into a single kernel. Then `sub_node_can_fuse` absorbs surrounding pointwise ops (residual connections, dtype casts, scaling) without any check on the resulting read count.

The fused kernel uses **persistent reduction** with `R0_BLOCK = ncol = 512` threads per block and an **RSPLIT loop** that iterates over chunks of the x-dimension. On H100 (65536 regs/SM), 512 threads/block gives **128 regs/thread**. That is the register budget.

Each external read buffer becomes a `tl.load()` inside the RSPLIT loop. Every additional load adds register pressure. The unfused kernel (7 reads) barely fits in 128 regs. The over-fused kernel (11+ reads, plus persistent accumulator arrays) overflows and spills to local memory.

The spill penalty (~100 cycles per access vs 0 for register) is paid **every RSPLIT loop iteration** (64 iterations per block, 1536 blocks total), producing the 6.3ms regression.

### Kernel comparison

**2.9.1 — unfused rms_norm backward** (kernel_8, Grid1D, 7 loads, 1 reduction):
```python
# No loop, no accumulators, no workspace — one thread block per row
def triton_per_fused__fused_rms_norm_backward_8(
    in_out_ptr0, in_ptr0, in_ptr1, in_ptr2, in_ptr3, in_ptr4, in_ptr5,
    out_ptr1, out_ptr2, xnumel, r0_numel, XBLOCK):
    # xnumel=98304, r0_numel=512, persistent R0_BLOCK=512
    # 7 loads → ~120 regs/thread, fits in 128 budget
    tmp0 = tl.load(in_ptr0 + ...)   # [98304, 512] rsqrt * Hessian
    tmp1 = tl.load(in_out_ptr0 + ...)  # [98304, 512] upstream grad
    tmp9 = tl.load(in_ptr1 + ...)   # [98304, 512] residual
    tmp10 = tl.load(in_ptr2 + ...)  # scalar: mix coefficient
    tmp20 = tl.load(in_ptr3 + ...)  # [98304, 1] rsqrt
    tmp25 = tl.load(in_ptr4 + ...)  # [512] norm weight 1
    tmp28 = tl.load(in_ptr5 + ...)  # [512] norm weight 2
    # ... 1 inner reduction (sum over 512), 3 stores
```

**2.11 — over-fused rms_norm backward + weight grad sums** (kernel_3, MixOrderReductionGrid, 11 loads, 3 reductions):
```python
# RSPLIT loop with persistent accumulators and workspace memory
def triton_per_fused__fused_rms_norm_backward__to_copy_..._3(
    in_out_ptr0, in_ptr0, in_ptr1, in_ptr2, in_ptr3, in_ptr4,
    in_ptr5, in_ptr6, in_ptr7, in_ptr8, in_ptr9,
    out_ptr0, out_ptr1, out_ptr3, out_ptr4, ws_ptr,
    xnumel, r0_numel, XBLOCK, RSPLIT_SIZE, NUM_STAGES):
    # 11 loads + 2 accumulators → ~200 regs/thread, EXCEEDS 128 budget
    accum0 = tl.full([R0_BLOCK], 0, tl.float32)  # [512] persists across loop
    accum1 = tl.full([R0_BLOCK], 0, tl.float32)  # [512] persists across loop
    for _ in tl.range(0, split_size, XBLOCK):
        tmp0 = tl.load(in_ptr0 + ...)     # [98304, 512]
        tmp1 = tl.load(in_ptr1 + ...)     # [98304, 512]
        tmp7 = tl.load(in_ptr2 + ...)     # [98304, 512]
        tmp13 = tl.load(in_ptr3 + ...)    # [98304, 512]
        tmp14 = tl.load(in_out_ptr0 + ...)# [98304, 512]
        tmp22 = tl.load(in_ptr4 + ...)    # scalar
        tmp32 = tl.load(in_ptr5 + ...)    # [98304, 1]
        tmp37 = tl.load(in_ptr6 + ...)    # [512]
        tmp40 = tl.load(in_ptr7 + ...)    # [512]
        tmp43 = tl.load(in_ptr8 + ...)    # [98304, 512]
        tmp46 = tl.load(in_ptr9 + ...)    # [98304, 512]
        # 3 inner reductions + 5 stores + 2 accumulator updates per iter
        # Spilled regs hit local memory EVERY iteration
    tl.store(ws_ptr + ..., accum0, ...)  # workspace for inter-block reduction
    tl.store(ws_ptr + ..., accum1, ...)
```

This same over-fusion pattern repeats across the backward pass, producing 9 MixOrderReductionGrid kernels with 6-19 loads each. The worst (kernel_34) has **19 loads**.

### Profiler data

H100 80GB SXM, `torch.profiler`:

| Config | Triton kernels | Self CUDA Time | Delta |
|--------|---------------|----------------|-------|
| 2.11, mix_order=1 (default) | 65 | 105.764ms | +6.3ms |
| 2.11, mix_order=0 | 71 | 99.471ms | baseline |
| 2.9.1 (no mix_order) | 71 | 99.5ms | baseline |

## Fix

Count unique read buffers across all subnodes in `FusedMixOrderReductions.can_fuse_with`. If the count exceeds `mix_order_reduction_max_reads` (default 10), reject the fusion:

```python
all_reads = {dep.name for all subnodes' reads if MemoryDep}
if len(all_reads) > max_reads:
    return False
```

Uses `all_reads` rather than `all_reads - all_writes` because mutated buffers (`in_out_ptr`) are both read and written — they are still `tl.load()` calls. Each unique read maps 1:1 to a `tl.load()` in the generated RSPLIT loop. The check runs at scheduling time with zero compilation cost — it just counts buffer names from the existing `read_writes` dependency data.

## Test Plan

- [x] `OverFusionTest.test_max_reads_limits_fusion` — 3-block transformer backward, verifies correctness and that mix_order_reduction still fires (not fully disabled)
- [x] Existing `MixOrderReductionTest` and `NoMixOrderReductionTest` suites unaffected
- [x] Verified on H100: step time with this fix matches 2.9.1 / mix_order=0 baseline


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo