### PR TITLE
[DTensor] Fix precision loss in NestedRedistribute backward dtype handling

### DIFF
--- a/torch/distributed/tensor/_redistribute.py
+++ b/torch/distributed/tensor/_redistribute.py
@@ -1916,11 +1916,15 @@ class NestedRedistribute(torch.autograd.Function):
         backward_dtype: torch.dtype | None = None,
     ):
         ctx.async_op = async_op
-        ctx.backward_dtype = backward_dtype or ctx.original_dtype
         ctx.original_dtype = grad_output._local_tensor.dtype
+        ctx.backward_dtype = backward_dtype or ctx.original_dtype
 
         output, spec = _redistribute_backward(
-            grad_output, previous_spec, ctx.original_dtype, backward_dtype, async_op
+            grad_output,
+            previous_spec,
+            ctx.backward_dtype,
+            backward_dtype,
+            async_op,
         )
 
         ctx.current_spec = spec


### PR DESCRIPTION
#160509 introduced `NestedRedistribute` to make DTensor redistribution twice-differentiable. But it caused numerics issues in mix-precision training due to wrong `original_dtype` being passed to `_redistribute_backward`

It passed  `ctx.original_dtype` (the incoming gradient's dtype, bf16) as the target output dtype. Inside `_redistribute_backward`, after computing the redistribution in f32 via `backward_dtype`, the final check `output.dtype (f32) != original_dtype (bf16)` triggers a spurious downcast to bf16. The result is immediately cast back to f32 at the graph output boundary, creating a lossy `f32 → bf16 → f32` round-trip on every weight gradient.

Fix: pass `backward_dtype or ctx.original_dtype` instead. When `backward_dtype` is f32, the output stays in f32 (no downcast). When `backward_dtype` is None (no upcast was done), it falls back to the gradient's native dtype, preserving existing behavior.

Test Plan in torchtitan:
```
pytest -xs torchtitan/experiments/graph_trainer/tests/test_numerics.py -k TestGraphTrainerNumerics
```