### PR TITLE
Enforce C++20 for XPU SYCL device compilation

### DIFF
--- a/cmake/public/xpu.cmake
+++ b/cmake/public/xpu.cmake
@@ -37,6 +37,11 @@ torch_xpu_get_arch_list(XPU_ARCH_FLAGS)
 # propagate to torch-xpu-ops
 set(TORCH_XPU_ARCH_LIST ${XPU_ARCH_FLAGS})
 
+# Ensure SYCL device code compiles with C++20 (matching CMAKE_CXX_STANDARD).
+# SYCL_FLAGS flows into SYCL_COMPILE_FLAGS in torch-xpu-ops' BuildFlags.cmake
+# and is passed directly to icpx on the device compilation command line.
+list(APPEND SYCL_FLAGS -std=c++20)
+
 # Ensure USE_XPU is enabled.
 string(APPEND XPU_HOST_CXX_FLAGS " -DUSE_XPU")
 string(APPEND XPU_HOST_CXX_FLAGS " -DSYCL_COMPILER_VERSION=${SYCL_COMPILER_VERSION}")

--- a/torch/_inductor/codegen/xpu/compile_utils.py
+++ b/torch/_inductor/codegen/xpu/compile_utils.py
@@ -79,7 +79,7 @@ def _sycl_compiler_options() -> list[str]:
         "-DCUTLASS_VERSIONS_GENERATED",
         "-O3",
         "-DNDEBUG",
-        "-std=c++17",
+        "-std=c++20",
         "-fPIC",
         "-fsycl",
         f"-fsycl-targets={_sycl_arch_as_compile_option()}",


### PR DESCRIPTION
Summary:
The C++20 header guards in ATen.h (D95101335) trigger #error under the Intel SYCL device compiler (icpx) because it was not receiving -std=c++20.  The host compiler (gcc) already received it via -fsycl-host-compiler-options, but icpx itself defaulted to C++17.

Set SYCL_FLAGS in xpu.cmake so torch-xpu-ops' BuildFlags.cmake picks it up into SYCL_COMPILE_FLAGS, and update the inductor JIT SYCL compilation path to match.

Test Plan: Sandcastle

Differential Revision: D99700757




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo