### PR TITLE
fix distributed/elastic/rendezvous out_of_tree_rendezvous_test to use mocks instead of broken test package way

### DIFF
--- a/test/distributed/elastic/rendezvous/out_of_tree_rendezvous_test.py
+++ b/test/distributed/elastic/rendezvous/out_of_tree_rendezvous_test.py
@@ -5,34 +5,47 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
-import pathlib
-import sys
 import unittest
+from unittest.mock import MagicMock, patch
 
 import torch.distributed.elastic.rendezvous as rdvz
 
 
 BACKEND_NAME = "testbackend"
-TEST_PACKAGE_PATH = "/out_of_tree_test_package/src"
 
 
 class OutOfTreeRendezvousTest(unittest.TestCase):
     def test_out_of_tree_handler_loading(self):
-        current_path = str(pathlib.Path(__file__).parent.resolve())
         rdvz._register_out_of_tree_handlers()
         registry_dict = rdvz.rendezvous_handler_registry._registry
 
         # test backend should not be registered as a backend
         self.assertFalse(BACKEND_NAME in registry_dict)
 
-        # Including testbackend in python path
-        sys.path.append(current_path + TEST_PACKAGE_PATH)
+        # Create a mock handler function that will be returned by the entry point
+        def test_handler():
+            pass
 
-        # Registering the out of tree handlers again
-        rdvz._register_out_of_tree_handlers()
+        # Create a mock entry point
+        mock_entry_point = MagicMock()
+        mock_entry_point.name = BACKEND_NAME
+        mock_entry_point.load.return_value = test_handler
+
+        # Create a mock EntryPoints object
+        mock_entry_points = MagicMock()
+        mock_entry_points.__iter__.return_value = iter([mock_entry_point])
+        mock_entry_points.__getitem__.return_value = mock_entry_point
+
+        with patch(
+            "torch.distributed.elastic.rendezvous.registry.entry_points"
+        ) as mock_ep:
+            mock_ep.return_value = mock_entry_points
+
+            # Registering the out of tree handlers again
+            rdvz._register_out_of_tree_handlers()
+
+            # Verify entry_points was called with the correct group
+            mock_ep.assert_called_once_with(group="torchrun.handlers")
 
         # test backend should be registered as a backend
         self.assertTrue(BACKEND_NAME in registry_dict)
-
-        # Removing testbackend from python path
-        sys.path.remove(current_path + TEST_PACKAGE_PATH)

--- a/test/distributed/elastic/rendezvous/out_of_tree_test_package/pyproject.toml
+++ b/test/distributed/elastic/rendezvous/out_of_tree_test_package/pyproject.toml
@@ -1,6 +1,0 @@
-[project]
-name = "testbackend"
-version = "0.0.1"
-
-[project.entry-points.'torchrun.handlers']
-testbackend = 'testbackend:test_handler'

--- a/test/distributed/elastic/rendezvous/out_of_tree_test_package/src/testbackend/__init__.py
+++ b/test/distributed/elastic/rendezvous/out_of_tree_test_package/src/testbackend/__init__.py
@@ -1,2 +1,0 @@
-def test_handler():
-    return ""


### PR DESCRIPTION
## Motivation
To fix failing distributed elastic test
## Changes
**Issue:**
test_out_of_tree_handler_loading attempts to test out-of-tree handler registration by adding a directory to sys.path.
However, the real mechanism uses Python entry points, which require pip installation.
The original PR https://github.com/pytorch/pytorch/pull/132633 used pip install, but after review it was replaced with sys.path modification — which probably only worked locally due to stale installations.
**Fix:**
Remove the temporary package and instead mock entry points directly to validate registration logic.

@H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci can you please review