### PR TITLE
Fix incorrect type annotation in Future.set_exception

### DIFF
--- a/test/test_futures.py
+++ b/test/test_futures.py
@@ -24,7 +24,6 @@ class TestFuture(TestCase):
 
         f = Future[T]()  # type: ignore[valid-type]
         # Set exception
-        # pyrefly: ignore [bad-argument-type]
         f.set_exception(value_error)
         # Exception should throw on wait
         with self.assertRaisesRegex(ValueError, "Intentional"):
@@ -32,7 +31,6 @@ class TestFuture(TestCase):
 
         # Exception should also throw on value
         f = Future[T]()  # type: ignore[valid-type]
-        # pyrefly: ignore [bad-argument-type]
         f.set_exception(value_error)
         with self.assertRaisesRegex(ValueError, "Intentional"):
             f.value()
@@ -41,7 +39,6 @@ class TestFuture(TestCase):
             fut.value()
 
         f = Future[T]()  # type: ignore[valid-type]
-        # pyrefly: ignore [bad-argument-type]
         f.set_exception(value_error)
 
         with self.assertRaisesRegex(RuntimeError, "Got the following error"):
@@ -61,7 +58,6 @@ class TestFuture(TestCase):
         f = Future[T]()  # type: ignore[valid-type]
         t = threading.Thread(target=wait_future, args=(f, ))
         t.start()
-        # pyrefly: ignore [bad-argument-type]
         f.set_exception(value_error)
         t.join()
 
@@ -76,7 +72,6 @@ class TestFuture(TestCase):
         f = Future[T]()  # type: ignore[valid-type]
         t = threading.Thread(target=then_future, args=(f, ))
         t.start()
-        # pyrefly: ignore [bad-argument-type]
         f.set_exception(value_error)
         t.join()
 

--- a/torch/futures/__init__.py
+++ b/torch/futures/__init__.py
@@ -250,7 +250,7 @@ class Future(torch._C.Future, Generic[T]):
         """
         super().set_result(result)
 
-    def set_exception(self, result: T) -> None:
+    def set_exception(self, result: BaseException) -> None:
         r"""
         Set an exception for this ``Future``, which will mark this ``Future`` as
         completed with an error and trigger all attached callbacks. Note that


### PR DESCRIPTION
Summary:
`Future.set_exception()` parameter `result` was typed as `T` (the generic Future value type), but it should be `BaseException` since this method only accepts exception objects.

The docstring already correctly documents the type as `BaseException`, and the runtime check enforces `isinstance(result, Exception)`. This fixes the annotation to match the actual contract.

Also removes now-unnecessary `pyrefly: ignore [bad-argument-type]` comments from test_futures.py.

Test Plan:
```buck2 test fbcode//caffe2/test:futures```
https://www.internalfb.com/intern/testinfra/testrun/10133099325319091

Differential Revision: D99689019


