### PR TITLE
[inductor] Fix CUDA IMA during max_autotune bmm with broadcast batch dim (#179505)

### DIFF
--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -1549,6 +1549,39 @@ class TestMaxAutotune(TestCase):
         act = f(x, y)
         torch.testing.assert_close(act, ref, atol=2e-2, rtol=1e-2)
 
+    def test_broadcast_batch_bmm(self):
+        # Batch size > 1 with stride[0]=0 to exercise the broadcast batch
+        # guard that skips the Triton bmm template for stride-0 inputs.
+        x = rand_strided((4, 32, 64), (0, 64, 1), dtype=torch.bfloat16, device=GPU_TYPE)
+        y = rand_strided(
+            (4, 64, 16), (1024, 16, 1), dtype=torch.bfloat16, device=GPU_TYPE
+        )
+
+        @torch.compile(mode="max-autotune")
+        def f(x, y):
+            return torch.bmm(x, y)
+
+        ref = torch.bmm(x, y)
+        act = f(x, y)
+        torch.testing.assert_close(act, ref, atol=2e-2, rtol=1e-2)
+
+    def test_broadcast_batch_baddbmm(self):
+        # Batch size > 1 with stride[0]=0 to exercise the broadcast batch
+        # guard that skips the Triton bmm template for stride-0 inputs.
+        x = rand_strided((4, 32, 64), (0, 64, 1), dtype=torch.bfloat16, device=GPU_TYPE)
+        y = rand_strided(
+            (4, 64, 16), (1024, 16, 1), dtype=torch.bfloat16, device=GPU_TYPE
+        )
+        inp = torch.randn(4, 32, 16, dtype=torch.bfloat16, device=GPU_TYPE)
+
+        @torch.compile(mode="max-autotune")
+        def f(inp, x, y):
+            return torch.baddbmm(inp, x, y)
+
+        ref = torch.baddbmm(inp, x, y)
+        act = f(inp, x, y)
+        torch.testing.assert_close(act, ref, atol=2e-2, rtol=1e-2)
+
     @unittest.skipIf(
         config.triton.native_matmul,
         "native matmul and Triton template both have accuracy fail (2.2%)",

--- a/torch/_inductor/kernel/bmm.py
+++ b/torch/_inductor/kernel/bmm.py
@@ -76,6 +76,17 @@ aten_baddbmm = ExternKernelChoice(
 )
 
 
+def _has_broadcast_batch_dim(mat1, mat2):
+    """Check if either input has a broadcast batch dimension (stride=0).
+
+    The Triton bmm template can trigger CUDA IMA during autotuning with
+    stride-0 inputs; the aten bmm fallback handles broadcast correctly.
+    """
+    return V.graph.sizevars.statically_known_equals(
+        mat1.get_stride()[0], 0
+    ) or V.graph.sizevars.statically_known_equals(mat2.get_stride()[0], 0)
+
+
 @L.register_lowering(aten.bmm)
 def tuned_bmm(mat1, mat2, out_dtype=None, *, layout=None):
     """
@@ -187,7 +198,8 @@ def tuned_bmm(mat1, mat2, out_dtype=None, *, layout=None):
         kwarg_overrides[aten_handler.uid] = aten_extra_kwargs
 
     if use_triton_template(layout, check_max_autotune=False):
-        templates_to_use.append(bmm_template)
+        if not _has_broadcast_batch_dim(mat1, mat2):
+            templates_to_use.append(bmm_template)
 
     # Single unified call for all templates
     choices.extend(
@@ -283,7 +295,8 @@ def tuned_baddbmm(inp, mat1, mat2, *, alpha=1, beta=1, layout=None):
         templates_to_use.append(aten_baddbmm)
 
     if use_triton_template(layout, check_max_autotune=False):
-        templates_to_use.append(bmm_template)
+        if not _has_broadcast_batch_dim(mat1, mat2):
+            templates_to_use.append(bmm_template)
 
     # Single unified call for all templates
     choices.extend(


### PR DESCRIPTION
Summary:

Skip the Triton bmm template when either input has a broadcast batch dimension (stride=0). The template triggers CUDA IMA during `max_autotune` benchmarking with stride-0 inputs, corrupting the CUDA context and crashing the lowering job.

This was observed in a model where `bmm(1024x96x224, 1024x224x256)` with strides `[0, 224, 1]` caused an IMA. The aten bmm fallback handles broadcast correctly and is used instead. This mirrors the existing `is_batch_stride_largest_or_zero` guard already used for CUTLASS.

Test Plan:
- Ran E2E lowering of the failed model locally on H100 devgpu
  - Without fix: CUDA IMA cascade (20 consecutive IMA errors) → `LoweringLogicException`
  - With fix: Zero IMA errors, `aoti_compilation` completed successfully, `.so` generated
- Verified that non-broadcast bmm and mm autotuning still runs normally

Reviewed By: desertfire

Differential Revision: D99497345


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo