### PR TITLE
Unwrap AsyncCollectiveTensor inputs before AOT autograd tracing

### DIFF
--- a/test/distributed/tensor/test_dtensor_compile.py
+++ b/test/distributed/tensor/test_dtensor_compile.py
@@ -1577,17 +1577,16 @@ def forward(self, L_x_ : torch.Tensor, L_mesh_ : torch.distributed.device_mesh.D
         x2 = x2.to_local()
         self.assertTrue(isinstance(x2, AsyncCollectiveTensor))
         opt_fn(x2)
-        # The important part: we get a wait_tensor() in the graph.
-        # At runtime, the input to the graph is an AsyncCollectiveTensor,
-        # and inside the graph we need to issue a wait() to synchronize.
+        # ACTs are unwrapped before AOT autograd tracing via
+        # _maybe_unwrap_tensor_list in process_inputs, so the graph
+        # receives a plain tensor with no wait_tensor op.
         self.assertExpectedInline(
             str(fw_graph_cell[0]).strip(),
             """\
-def forward(self, primals_1):
-    wait_tensor = torch.ops._c10d_functional.wait_tensor.default(primals_1)
-    sin = torch.ops.aten.sin.default(wait_tensor)
+def forward(self, arg0_1):
+    sin = torch.ops.aten.sin.default(arg0_1);  arg0_1 = None
     sin_1 = torch.ops.aten.sin.default(sin);  sin = None
-    return (sin_1, primals_1, wait_tensor)""",
+    return (sin_1,)""",
         )
 
     @skipIfTorchDynamo()

--- a/test/distributed/test_c10d_functional_native.py
+++ b/test/distributed/test_c10d_functional_native.py
@@ -1446,5 +1446,118 @@ class CompileTest(TestCase):
         (FileCheck().check("all_reduce_.default(buf0, 'avg', '0')").run(code))
 
 
+class ACTCompileTest(TestCase):
+    """
+    Test that AsyncCollectiveTensor inputs to compiled regions are resolved
+    before AOT autograd tracing begins. ACTs are transient eager-mode wrappers
+    for async collective overlap; if they leak into the traced graph as input
+    types, AOT autograd records them in tangent metadata and then hits a type
+    mismatch at runtime because autograd produces plain-tensor tangents.
+    """
+
+    def test_maybe_unwrap_tensor(self):
+        """
+        _maybe_unwrap_tensor should resolve ACTs to plain tensors via
+        trigger_wait(), and pass through non-ACT tensors unchanged.
+        """
+        from torch.distributed._functional_collectives import _maybe_unwrap_tensor
+
+        plain = torch.randn(4, 4)
+        self.assertIs(_maybe_unwrap_tensor(plain), plain)
+
+        elem = torch.randn(4, 4)
+        act = AsyncCollectiveTensor(elem)
+        unwrapped = _maybe_unwrap_tensor(act)
+        self.assertNotIsInstance(unwrapped, AsyncCollectiveTensor)
+        self.assertIsInstance(unwrapped, torch.Tensor)
+
+    def test_act_compile_backward_tangent_mismatch(self):
+        """
+        When a bare AsyncCollectiveTensor (ACT) enters a torch.compiled
+        region and passes through a view op, the output remains an ACT.
+        If the ACT is not unwrapped before tracing, AOT autograd
+        fakifies it as-is and records it in SubclassCreationMeta. At runtime, autograd
+        produces a plain tensor tangent, causing:
+            RuntimeError: Expected a AsyncCollectiveTensor tangent
+            but got a plain Tensor.
+
+        This occurs in practice when TP async collectives produce a
+        DTensor(ACT), an eager caller does to_local() to get a bare ACT,
+        and that ACT flows into a compiled sub-module whose forward
+        contains view ops (unsqueeze, reshape, transpose, etc.).
+
+        We use unsqueeze (a view op that preserves ACT) to ensure the
+        compiled function's output carries ACT type, which is what
+        triggers the tangent metadata recording.
+        """
+        from unittest.mock import patch
+
+        elem = torch.randn(4, 4, requires_grad=True)
+        act = AsyncCollectiveTensor(elem)
+
+        compiled_fn = torch.compile(lambda x: x.unsqueeze(0), backend="aot_eager")
+
+        original_trigger_wait = AsyncCollectiveTensor.trigger_wait
+        wait_called = False
+
+        def tracked_trigger_wait(self):
+            nonlocal wait_called
+            wait_called = True
+            return original_trigger_wait(self)
+
+        with patch.object(AsyncCollectiveTensor, "trigger_wait", tracked_trigger_wait):
+            out = compiled_fn(act)
+            # Without ACT unwrapping, this raises:
+            #   RuntimeError: Expected a AsyncCollectiveTensor tangent
+            #   but got a plain Tensor.
+            out.sum().backward()
+
+        self.assertTrue(wait_called, "trigger_wait() was never called")
+
+        # Verify numerics: trigger_wait() must fire so the correct data
+        # flows through. ACT wraps elem, so results must match elem directly.
+        ref = elem.detach().unsqueeze(0)
+        self.assertEqual(out.detach(), ref)
+
+    def test_act_runtime_unwrap(self):
+        """
+        Verify that ACT inputs are unwrapped at runtime, not just at
+        compile time. On the second call the compiled graph is reused —
+        the runtime wrapper must call trigger_wait() before passing args
+        to the compiled function.
+        """
+        from unittest.mock import patch
+
+        compiled_fn = torch.compile(lambda x: x * 2, backend="aot_eager")
+
+        # First call: compile with ACT input so the graph is cached for this type.
+        elem1 = torch.randn(4, 4)
+        act1 = AsyncCollectiveTensor(elem1)
+        _ = compiled_fn(act1)
+
+        # Second call: same input type → dynamo reuses the cached graph.
+        # process_inputs does NOT run again; only the runtime wrapper can
+        # unwrap ACTs at this point.
+        elem2 = torch.randn(4, 4)
+        act2 = AsyncCollectiveTensor(elem2)
+
+        original_trigger_wait = AsyncCollectiveTensor.trigger_wait
+        wait_called = False
+
+        def tracked_trigger_wait(self):
+            nonlocal wait_called
+            wait_called = True
+            return original_trigger_wait(self)
+
+        with patch.object(AsyncCollectiveTensor, "trigger_wait", tracked_trigger_wait):
+            result = compiled_fn(act2)
+
+        self.assertTrue(
+            wait_called,
+            "trigger_wait() was not called by the runtime wrapper",
+        )
+        self.assertEqual(result, elem2 * 2)
+
+
 if __name__ == "__main__":
     run_tests()

--- a/torch/_functorch/_aot_autograd/frontend_utils.py
+++ b/torch/_functorch/_aot_autograd/frontend_utils.py
@@ -35,6 +35,16 @@ def process_inputs(
     shape_env: ShapeEnv | None,
     ignore_shape_env: bool = False,
 ) -> FakifiedFlatArgs:
+    # Resolve AsyncCollectiveTensors before tracing. ACTs are transient
+    # eager-mode wrappers for async collective overlap; if they leak into the
+    # traced graph as input types, AOT autograd records them in tangent
+    # metadata and then hits a type mismatch at runtime because autograd
+    # produces plain-tensor tangents. Must happen before entering fake_mode
+    # because trigger_wait() calls wait_tensor() which is a real op.
+    from torch.distributed._functional_collectives import _maybe_unwrap_tensor_list
+
+    flat_args = _maybe_unwrap_tensor_list(flat_args)
+
     with fake_mode:
 
         def convert(idx: int, x: Any) -> Any:

--- a/torch/_functorch/_aot_autograd/runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/runtime_wrappers.py
@@ -724,6 +724,8 @@ def _create_runtime_wrapper(
     keep_input_mutations: bool,
     disable_amp: bool,
 ) -> Callable[..., Any]:
+    from torch.distributed._functional_collectives import _maybe_unwrap_tensor_list
+
     compiled_invoker = _RuntimeCompiledFnInvoker(
         compiled_fn=compiled_fn,
         indices_of_inps_to_detach=indices_of_inps_to_detach,
@@ -770,6 +772,16 @@ def _create_runtime_wrapper(
             # stash a ref to each input tensor we plan to use after the compiled function
             orig_inputs = runtime_epilogue.capture_orig_inputs(args)
             runtime_epilogue.increment_mutation_versions(args)
+
+            # Resolve AsyncCollectiveTensors before passing args to the
+            # compiled graph. ACTs are transient eager-mode wrappers for
+            # async collective overlap; inductor triton kernels bypass
+            # __torch_dispatch__ entirely, so an unwait-ed ACT would
+            # silently feed stale data to the kernel. Must happen after
+            # capture_orig_inputs (mutation writeback needs the original
+            # tensor refs) but before the compiled function runs.
+            args = _maybe_unwrap_tensor_list(args)
+
             all_outs = compiled_invoker.run(args, on_before_call=exit_prologue)
         finally:
             exit_prologue()

--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -1360,6 +1360,37 @@ def _maybe_wrap_tensor(self) -> torch.Tensor:
     return _wrap_tensor_autograd(self)
 
 
+def _maybe_unwrap_tensor(tensor: torch.Tensor) -> torch.Tensor:
+    """
+    If tensor is an AsyncCollectiveTensor, wait on the underlying collective
+    and return the plain result. Otherwise return the tensor unchanged.
+    This is the inverse of _maybe_wrap_tensor and should be used to resolve
+    ACTs at graph boundaries (e.g. before AOT autograd tracing).
+    """
+    if isinstance(tensor, AsyncCollectiveTensor):
+        return tensor.trigger_wait()
+    return tensor
+
+
+def _maybe_unwrap_tensor_list(args: list[Any]) -> list[Any]:
+    """
+    Resolve any AsyncCollectiveTensors in a list of args. Returns the
+    original list unmodified if no ACTs are present, avoiding a list
+    allocation in the common case.
+    """
+    # Written as an explicit loop with `type(a) is` instead of
+    # `any(isinstance(...) for ...)` to avoid generator overhead and
+    # MRO walks. This is on the runtime hot path for every compiled
+    # graph invocation, and the vast majority of calls have no ACTs.
+    for a in args:
+        if type(a) is AsyncCollectiveTensor:
+            return [
+                _maybe_unwrap_tensor(a) if isinstance(a, torch.Tensor) else a
+                for a in args
+            ]
+    return args
+
+
 @contextlib.contextmanager
 def allow_inflight_collective_as_graph_input_ctx(value: bool = True):
     """


### PR DESCRIPTION
Unwrap AsyncCollectiveTensor inputs before AOT autograd tracing and at runtime
When tensor parallel (TP) async collectives overlap with torch.compile,
AsyncCollectiveTensor (ACT) wrappers can leak into compiled regions as
input types. This happens in MoE models where:

1. PrepareModuleInputOutput hook triggers an all-gather, producing a
   DTensor whose _local_tensor is an ACT
2. MoE.forward (eager) calls x.to_local() → bare ACT
3. The bare ACT flows into a compiled sub-module (e.g. router)

This causes two problems:

Compile-time: When ACT reaches AOT autograd's process_inputs without
being resolved, it gets fakified as a tensor subclass. AOT autograd then
records ACT in SubclassCreationMeta for the output tangent metadata. At
runtime, autograd produces plain tensor tangents, causing:

  RuntimeError: Expected a AsyncCollectiveTensor tangent but got a
  plain Tensor

Runtime: ACT inputs to a compiled graph whose first usage is an inductor
triton kernel bypass __torch_dispatch__ entirely. The ACT's
trigger_wait() never fires, resulting in silent data corruption from
stale/uninitialized async collective data.

Fix:
1. Compile-time: resolve ACTs in process_inputs before entering
   FakeTensorMode by calling trigger_wait() via _maybe_unwrap_tensor().
   This prevents ACT from being recorded in tangent metadata.
2. Runtime: resolve ACTs in the runtime_wrapper closure (after
   capture_orig_inputs but before compiled_invoker.run) so the compiled
   graph always receives plain tensors with completed collective data.

ACTs are transient eager-mode wrappers that should never survive into
the traced graph or reach compiled kernels unresolved.

First observed in torchtitan's GPT-OSS MoE model with TP + EP + compile
enabled simultaneously.

Repro (torchtitan):

  NGPU=4 MODULE=gpt_oss CONFIG=gpt_oss_debugmodel ./run_train.sh \
    --parallelism.data_parallel_shard_degree 2 \
    --parallelism.tensor_parallel_degree 2 \
    --parallelism.expert_parallel_degree 2 \
    --parallelism.expert_tensor_parallel_degree 1 \
    --compile.enable

Without the fix, training crashes at backward with:

  RuntimeError: During the backward, we encountered a tensor subclass
  where we guessed its metadata incorrectly.
  Expected a AsyncCollectiveTensor tangent but got a plain Tensor.

With the fix, training completes (loss 5.58 → 4.01 over 10 steps).

Fixes https://github.com/pytorch/torchtitan/issues/2776

<!-- ps-id: 57c06123-2a36-488a-ab90-f3680bb314c1 -->