### PR TITLE
[DTensor] Fix Split(Flatten) sharding propagation for non-first flatten dims

### DIFF
--- a/test/distributed/tensor/test_view_ops.py
+++ b/test/distributed/tensor/test_view_ops.py
@@ -274,15 +274,6 @@ class TestViewOps(DTensorContinuousTestBase):
         with self.assertRaisesRegex(RuntimeError, "Sharding propagation failed"):
             shard.view(8, 2, -1)
 
-        # Split(Flatten) where the strided pattern is not representable
-        # in the output group_shape: (4,6)→(6,4) with Shard(1) has
-        # period=6 which doesn't fit into group_shape (6,4).
-        tensor = torch.randn(4, 6, device=self.device_type)
-        dtensor = distribute_tensor(tensor, device_mesh, [Replicate()])
-        shard = dtensor.redistribute(device_mesh=device_mesh, placements=[Shard(dim=1)])
-        with self.assertRaisesRegex(RuntimeError, "Sharding propagation failed"):
-            shard.view(6, 4)
-
     def test_double_shard_split_validation(self):
         """[Shard(0), Shard(0)] through Split correctly validates divisibility."""
         # Compatible: reshape (24,)→(6,4) with [Shard(0), Shard(0)] on mesh (2,3)
@@ -586,26 +577,6 @@ class TestViewOps(DTensorContinuousTestBase):
             ),
         )
 
-        # Split(Flatten) where a non-first flatten dim produces _StridedShard.
-        # Dim sizes are multiples of all mesh dim sizes so every Shard
-        # placement is exercised by call_dt_test.
-        self.dimmap_test(
-            Tensor.view,
-            (randn(12, 12), (6, 24)),
-            (
-                Split(
-                    Flatten(input_dims=(InputDim(0), InputDim(1))),
-                    group_shape=(6, 24),
-                    split_id=0,
-                ),
-                Split(
-                    Flatten(input_dims=(InputDim(0), InputDim(1))),
-                    group_shape=(6, 24),
-                    split_id=1,
-                ),
-            ),
-        )
-
     # TODO: Currently functional collectives on complex numbers are not fully supported,
     # so we are having a standalone test for view_as_complex and view_as_real combined.
     # Once complex numbers are supported, we can add the following to the dim_map test.
@@ -784,7 +755,12 @@ class TestViewOps(DTensorContinuousTestBase):
         self.assertEqual(out_dt.full_tensor(), expected)
 
     def test_dtensor_flatten_split(self):
-        """Test views producing Split(Flatten) rules — flatten then split.
+        """Test views producing Split(Flatten) rules.
+
+        Complements test_dtensor_flatten_multi_mesh (pure Flatten rules) and
+        test_dtensor_unflatten_multi_mesh (pure Split(InputDim) rules) by
+        covering the hybrid case: an input dim crosses two output groups,
+        so view_groups produces Split(Flatten(...)) rules.
 
         Uses {2*M-1, 2*M, 2*M+1} dim values (M = mesh size for the shard
         mesh dim) to cover even/uneven divisibility, following the same

--- a/test/distributed/tensor/test_view_ops.py
+++ b/test/distributed/tensor/test_view_ops.py
@@ -2182,6 +2182,16 @@ class TestViewOps(DTensorContinuousTestBase):
                 self.assertEqual(comm_mode.get_total_counts(), 0)
                 self.assertEqual(out.placements, expected_placements)
 
+    def test_view_flatten_split_unrepresentable(self):
+        # (12,8) → (16,6) with Shard(1): the strided pattern (period=8)
+        # can't be represented in group_shape (16,6), so view() must error
+        # instead of silently producing wrong data.
+        mesh = init_device_mesh(self.device_type, (self.world_size,))
+        full = torch.randn(12, 8, device=self.device_type)
+        dt = distribute_tensor(full, mesh, [Shard(1)])
+        with self.assertRaises(RuntimeError):
+            dt.view(16, 6)
+
     def test_input_dim_rejects_int_comparison(self):
         """InputDim.__eq__ should raise TypeError when compared with int.
 

--- a/test/distributed/tensor/test_view_ops.py
+++ b/test/distributed/tensor/test_view_ops.py
@@ -274,6 +274,15 @@ class TestViewOps(DTensorContinuousTestBase):
         with self.assertRaisesRegex(RuntimeError, "Sharding propagation failed"):
             shard.view(8, 2, -1)
 
+        # Split(Flatten) where the strided pattern is not representable
+        # in the output group_shape: (4,6)→(6,4) with Shard(1) has
+        # period=6 which doesn't fit into group_shape (6,4).
+        tensor = torch.randn(4, 6, device=self.device_type)
+        dtensor = distribute_tensor(tensor, device_mesh, [Replicate()])
+        shard = dtensor.redistribute(device_mesh=device_mesh, placements=[Shard(dim=1)])
+        with self.assertRaisesRegex(RuntimeError, "Sharding propagation failed"):
+            shard.view(6, 4)
+
     def test_double_shard_split_validation(self):
         """[Shard(0), Shard(0)] through Split correctly validates divisibility."""
         # Compatible: reshape (24,)→(6,4) with [Shard(0), Shard(0)] on mesh (2,3)
@@ -577,6 +586,26 @@ class TestViewOps(DTensorContinuousTestBase):
             ),
         )
 
+        # Split(Flatten) where a non-first flatten dim produces _StridedShard.
+        # Dim sizes are multiples of all mesh dim sizes so every Shard
+        # placement is exercised by call_dt_test.
+        self.dimmap_test(
+            Tensor.view,
+            (randn(12, 12), (6, 24)),
+            (
+                Split(
+                    Flatten(input_dims=(InputDim(0), InputDim(1))),
+                    group_shape=(6, 24),
+                    split_id=0,
+                ),
+                Split(
+                    Flatten(input_dims=(InputDim(0), InputDim(1))),
+                    group_shape=(6, 24),
+                    split_id=1,
+                ),
+            ),
+        )
+
     # TODO: Currently functional collectives on complex numbers are not fully supported,
     # so we are having a standalone test for view_as_complex and view_as_real combined.
     # Once complex numbers are supported, we can add the following to the dim_map test.
@@ -729,6 +758,78 @@ class TestViewOps(DTensorContinuousTestBase):
         if len(trailing_dims) > 0:
             view_shapes.extend(trailing_dims)
         return tuple(view_shapes)
+
+    def _test_flatten_split_case(self, in_shape, out_shape, placements, mesh):
+        """Test a single Split(Flatten) view case.
+
+        Representable cases must produce zero communication and correct output.
+        Unrepresentable cases must raise RuntimeError with a specific message.
+        """
+        nelem = math.prod(in_shape)
+        global_tensor = torch.arange(nelem).view(in_shape)
+        in_dt = distribute_tensor(global_tensor, mesh, placements, src_data_rank=None)
+        comm_mode = CommDebugMode()
+        try:
+            with comm_mode:
+                out_dt = in_dt.view(list(out_shape))
+        except RuntimeError as e:
+            self.assertRegex(
+                str(e),
+                r"no valid output dimension for the strided pattern"
+                r"|is not evenly divisible by mesh dimension",
+            )
+            return
+        self.assertEqual(comm_mode.get_total_counts(), 0)
+        expected = global_tensor.view(list(out_shape))
+        self.assertEqual(out_dt.full_tensor(), expected)
+
+    def test_dtensor_flatten_split(self):
+        """Test views producing Split(Flatten) rules — flatten then split.
+
+        Uses {2*M-1, 2*M, 2*M+1} dim values (M = mesh size for the shard
+        mesh dim) to cover even/uneven divisibility, following the same
+        pattern as _run_flatten_single_shard.
+        """
+        for mesh_shape in [(self.world_size,), (3, 2)]:
+            if self.world_size < math.prod(mesh_shape):
+                continue
+            mesh = init_device_mesh(self.device_type, mesh_shape)
+            for shard_mesh_dim in range(mesh.ndim):
+                M = mesh.size(shard_mesh_dim)
+                dim_vals = [2 * M - 1, 2 * M, 2 * M + 1]
+                for a, b in itertools.product(dim_vals, repeat=2):
+                    in_shape = (a, b)
+                    total = a * b
+                    all_factors = self._get_all_factorizations(total)
+                    for out_shape in all_factors:
+                        if in_shape == out_shape:
+                            continue
+                        rules = view_groups(list(in_shape), list(out_shape))
+                        if not any(
+                            isinstance(r, Split) and isinstance(r.input_dim, Flatten)
+                            for r in rules
+                        ):
+                            continue
+                        for shard_dim in range(len(in_shape)):
+                            if in_shape[shard_dim] % M != 0:
+                                continue
+                            placements = tuple(
+                                Shard(shard_dim) if i == shard_mesh_dim else Replicate()
+                                for i in range(mesh.ndim)
+                            )
+                            with self.subTest(
+                                in_shape=in_shape,
+                                out_shape=out_shape,
+                                shard=shard_dim,
+                                mesh_dim=shard_mesh_dim,
+                                mesh_shape=mesh_shape,
+                            ):
+                                self._test_flatten_split_case(
+                                    in_shape,
+                                    out_shape,
+                                    placements,
+                                    mesh,
+                                )
 
     def test_dtensor_flatten_multi_mesh(self):
         """Test flatten operations across 1D and 2D meshes with all placement patterns.
@@ -2134,64 +2235,6 @@ class TestViewOps(DTensorContinuousTestBase):
         )
         self.assertEqual(out_plc, [Replicate(), Replicate()])
 
-    def test_view_flatten_split_strided_shard(self):
-        mesh = init_device_mesh(self.device_type, (2, self.world_size // 2))
-
-        # (input_shape, view_shape, expected_placements)
-        cases = [
-            # (4,4,4) → (8,8): strided along dim 0, same dim but missing stride
-            (
-                (4, 4, 4),
-                (8, 8),
-                (_StridedShard(dim=0, split_factor=4), Replicate()),
-            ),
-            # (8,4) → (4,4,2): strided along dim 1, wrong dim entirely
-            (
-                (8, 4),
-                (4, 4, 2),
-                (_StridedShard(dim=1, split_factor=2), Replicate()),
-            ),
-        ]
-
-        for input_shape, view_shape, expected_placements in cases:
-            with self.subTest(input=input_shape, view=view_shape):
-                nelem = math.prod(input_shape)
-                full = (
-                    torch.arange(nelem, device=self.device_type)
-                    .float()
-                    .view(input_shape)
-                )
-                dt = distribute_tensor(full, mesh, [Shard(1), Replicate()])
-
-                # Prove expected placements are correct:
-                # 1) full_tensor() round-trips to single-device ground truth
-                # 2) local tensor matches what the input actually holds
-                expected_dt = distribute_tensor(
-                    full.view(view_shape), mesh, expected_placements, src_data_rank=None
-                )
-                self.assertEqual(expected_dt.full_tensor(), full.view(view_shape))
-                self.assertEqual(
-                    expected_dt._local_tensor,
-                    dt._local_tensor.view(expected_dt._local_tensor.shape),
-                )
-
-                # Check the actual view op output
-                comm_mode = CommDebugMode()
-                with comm_mode:
-                    out = dt.view(view_shape)
-                self.assertEqual(comm_mode.get_total_counts(), 0)
-                self.assertEqual(out.placements, expected_placements)
-
-    def test_view_flatten_split_unrepresentable(self):
-        # (12,8) → (16,6) with Shard(1): the strided pattern (period=8)
-        # can't be represented in group_shape (16,6), so view() must error
-        # instead of silently producing wrong data.
-        mesh = init_device_mesh(self.device_type, (self.world_size,))
-        full = torch.randn(12, 8, device=self.device_type)
-        dt = distribute_tensor(full, mesh, [Shard(1)])
-        with self.assertRaises(RuntimeError):
-            dt.view(16, 6)
-
     def test_input_dim_rejects_int_comparison(self):
         """InputDim.__eq__ should raise TypeError when compared with int.
 
@@ -2226,6 +2269,7 @@ TestViewOpsWithLocalTensor = create_local_tensor_test_class(
         "test_dtensor_flatten_1d",
         "test_dtensor_flatten_2d",
         "test_dtensor_flatten_multi_mesh",
+        "test_dtensor_flatten_split",
     ],
     base_class=LocalDTensorContinuousTestBase,
 )

--- a/test/distributed/tensor/test_view_ops.py
+++ b/test/distributed/tensor/test_view_ops.py
@@ -2134,6 +2134,54 @@ class TestViewOps(DTensorContinuousTestBase):
         )
         self.assertEqual(out_plc, [Replicate(), Replicate()])
 
+    def test_view_flatten_split_strided_shard(self):
+        mesh = init_device_mesh(self.device_type, (2, self.world_size // 2))
+
+        # (input_shape, view_shape, expected_placements)
+        cases = [
+            # (4,4,4) → (8,8): strided along dim 0, same dim but missing stride
+            (
+                (4, 4, 4),
+                (8, 8),
+                (_StridedShard(dim=0, split_factor=4), Replicate()),
+            ),
+            # (8,4) → (4,4,2): strided along dim 1, wrong dim entirely
+            (
+                (8, 4),
+                (4, 4, 2),
+                (_StridedShard(dim=1, split_factor=2), Replicate()),
+            ),
+        ]
+
+        for input_shape, view_shape, expected_placements in cases:
+            with self.subTest(input=input_shape, view=view_shape):
+                nelem = math.prod(input_shape)
+                full = (
+                    torch.arange(nelem, device=self.device_type)
+                    .float()
+                    .view(input_shape)
+                )
+                dt = distribute_tensor(full, mesh, [Shard(1), Replicate()])
+
+                # Prove expected placements are correct:
+                # 1) full_tensor() round-trips to single-device ground truth
+                # 2) local tensor matches what the input actually holds
+                expected_dt = distribute_tensor(
+                    full.view(view_shape), mesh, expected_placements, src_data_rank=None
+                )
+                self.assertEqual(expected_dt.full_tensor(), full.view(view_shape))
+                self.assertEqual(
+                    expected_dt._local_tensor,
+                    dt._local_tensor.view(expected_dt._local_tensor.shape),
+                )
+
+                # Check the actual view op output
+                comm_mode = CommDebugMode()
+                with comm_mode:
+                    out = dt.view(view_shape)
+                self.assertEqual(comm_mode.get_total_counts(), 0)
+                self.assertEqual(out.placements, expected_placements)
+
     def test_input_dim_rejects_int_comparison(self):
         """InputDim.__eq__ should raise TypeError when compared with int.
 

--- a/test/distributed/tensor/test_view_ops.py
+++ b/test/distributed/tensor/test_view_ops.py
@@ -730,7 +730,7 @@ class TestViewOps(DTensorContinuousTestBase):
             view_shapes.extend(trailing_dims)
         return tuple(view_shapes)
 
-    def _test_flatten_split_case(self, in_shape, out_shape, placements, mesh):
+    def _test_dtensor_flatten_split_case(self, in_shape, out_shape, placements, mesh):
         """Test a single Split(Flatten) view case.
 
         Representable cases must produce zero communication and correct output.
@@ -754,7 +754,7 @@ class TestViewOps(DTensorContinuousTestBase):
         expected = global_tensor.view(list(out_shape))
         self.assertEqual(out_dt.full_tensor(), expected)
 
-    def test_dtensor_flatten_split(self):
+    def test_dtensor_flatten_split_multi_mesh(self):
         """Test views producing Split(Flatten) rules.
 
         Complements test_dtensor_flatten_multi_mesh (pure Flatten rules) and
@@ -800,7 +800,7 @@ class TestViewOps(DTensorContinuousTestBase):
                                 mesh_dim=shard_mesh_dim,
                                 mesh_shape=mesh_shape,
                             ):
-                                self._test_flatten_split_case(
+                                self._test_dtensor_flatten_split_case(
                                     in_shape,
                                     out_shape,
                                     placements,
@@ -2245,7 +2245,7 @@ TestViewOpsWithLocalTensor = create_local_tensor_test_class(
         "test_dtensor_flatten_1d",
         "test_dtensor_flatten_2d",
         "test_dtensor_flatten_multi_mesh",
-        "test_dtensor_flatten_split",
+        "test_dtensor_flatten_split_multi_mesh",
     ],
     base_class=LocalDTensorContinuousTestBase,
 )

--- a/torch/distributed/tensor/_ops/_view_ops.py
+++ b/torch/distributed/tensor/_ops/_view_ops.py
@@ -705,20 +705,18 @@ class _ViewShardingPropagator:
                 root_spec = cmd.input_dim
                 while isinstance(root_spec, (Flatten, Split)):
                     if isinstance(root_spec, Flatten):
-                        # Use whichever input dim was used as the key by
-                        # split_id=0.  In strict mode _analyze_flatten may
-                        # return a non-first sharded dim (e.g. InputDim(1)),
-                        # so input_dims[0] is not always the right key.
-                        matched = None
-                        for fd in root_spec.input_dims:
-                            if (
-                                isinstance(fd, InputDim)
+                        # Find whichever input dim was used as the key by
+                        # split_id=0.  input_dims[0] is not always the key
+                        # because strict-mode _analyze_flatten may return a
+                        # non-first sharded dim (e.g. InputDim(1)).
+                        root_spec = next(
+                            (
+                                fd
+                                for fd in root_spec.input_dims
+                                if isinstance(fd, InputDim)
                                 and fd.input_dim in input_to_output_tensor_dims
-                            ):
-                                matched = fd
-                                break
-                        root_spec = (
-                            matched if matched is not None else root_spec.input_dims[0]
+                            ),
+                            root_spec.input_dims[0],
                         )
                     else:
                         root_spec = root_spec.input_dim
@@ -1078,6 +1076,109 @@ class _ViewShardingPropagator:
                     return candidate_dim
         return None
 
+    def _rewrite_split_flatten_shard(
+        self,
+        cmd: Split,
+        p: Shard,
+        mesh_dim: int,
+        tgt_shard_dim: int,
+        local_tensor_shapes: list[int],
+    ) -> tuple[Placement, list[int]]:
+        """Rewrite Shard through a Split(Flatten(...)) rule.
+
+        The sharded input dim lives inside a flatten group that is then split
+        into ``cmd.group_shape``.  Sharding the first flatten dim maps directly
+        to Shard on the split_id=0 output dim.  Sharding a later dim produces
+        a strided pattern whose period determines which output dim carries it.
+        """
+        flatten = cmd.input_dim
+        if not isinstance(flatten, Flatten):
+            raise AssertionError(f"Expected Flatten, got {type(flatten)}")
+        first_dim = flatten.input_dims[0]
+        if not isinstance(first_dim, InputDim):
+            raise AssertionError(f"Expected InputDim, got {type(first_dim)}")
+        input_start = first_dim.input_dim
+        new_shapes = list(local_tensor_shapes)
+        new_shapes[p.dim] //= self.mesh_sizes[mesh_dim]
+
+        # First flatten dim: sharding maps 1:1 to the split_id=0 output dim.
+        if p.dim == input_start:
+            return Shard(tgt_shard_dim), new_shapes
+
+        # Non-first flatten dim: compute the stride period, then find which
+        # output dim of the split can carry that stride.
+        #
+        # Example: input (4, 4, 4) → flatten → (64,) → split → (8, 8)
+        # Shard(dim=1) on mesh (2,):
+        #   sf_flat = prod(shape[0:1]) = 4  (stride groups in the flatten)
+        #   total  = prod((8, 8))     = 64
+        #   period = 64 / 4           = 16  (elements per stride group)
+        #
+        #   d=0: trailing=8, chunk=16/8=2, 2>=2 and 2%2==0 → match
+        #   sf_output = 8/2 = 4 → _StridedShard(dim=0, split_factor=4)
+        sf_flat = math.prod(local_tensor_shapes[input_start : p.dim])
+        total = math.prod(cmd.group_shape)
+        if sf_flat == 0 or total % sf_flat != 0:
+            raise AssertionError(
+                f"Flatten stride {sf_flat} does not evenly divide "
+                f"split total {total} for Shard(dim={p.dim})"
+            )
+        period = total // sf_flat
+        mesh_size = self.mesh_sizes[mesh_dim]
+
+        # Walk output dims outermost-first; find the first whose size can
+        # accommodate mesh_size sharding within one stride period.
+        target_split_id = None
+        sf_output = None
+        for d in range(len(cmd.group_shape)):
+            trailing = math.prod(cmd.group_shape[d + 1 :])
+            if trailing == 0 or period % trailing != 0:
+                continue
+            chunk = period // trailing
+            if (
+                chunk <= cmd.group_shape[d]
+                and cmd.group_shape[d] % chunk == 0
+                and chunk >= mesh_size
+                and chunk % mesh_size == 0
+            ):
+                target_split_id = d
+                sf_output = cmd.group_shape[d] // chunk
+                break
+
+        if target_split_id is None or sf_output is None:
+            raise RuntimeError(
+                f"Cannot propagate Shard(dim={p.dim}) through "
+                f"Split(Flatten(...), {cmd.group_shape}): no valid "
+                f"output dimension for the strided pattern."
+            )
+
+        # Map target_split_id back to the actual output tensor dim.
+        if target_split_id == cmd.split_id:
+            output_dim = tgt_shard_dim
+        else:
+            output_dim = next(
+                (
+                    od
+                    for od, r in enumerate(self.rule)
+                    if isinstance(r, Split)
+                    and r.input_dim is flatten
+                    and r.split_id == target_split_id
+                ),
+                None,
+            )
+            if output_dim is None:
+                raise AssertionError(
+                    f"No Split with split_id={target_split_id} found "
+                    f"in rule for the same Flatten group."
+                )
+
+        placement: Placement = (
+            Shard(output_dim)
+            if sf_output <= 1
+            else _StridedShard(output_dim, split_factor=sf_output)
+        )
+        return placement, new_shapes
+
     def _rewrite_plain_shard(
         self,
         p: Shard,
@@ -1132,72 +1233,9 @@ class _ViewShardingPropagator:
                 )
         cmd = self.rule[tgt_shard_dim]
         if isinstance(cmd, Split) and isinstance(cmd.input_dim, Flatten):
-            # Split(Flatten(...)): flatten-then-split.  The inner Flatten may
-            # produce a strided pattern that lands on a different output dim
-            # than the split_id=0 dim we selected above.
-            flatten_cmd = cmd.input_dim
-            first_dim = flatten_cmd.input_dims[0]
-            if not isinstance(first_dim, InputDim):
-                raise AssertionError(f"Expected InputDim, got {type(first_dim)}")
-            input_start = first_dim.input_dim
-            new_shapes = list(local_tensor_shapes)
-            new_shapes[p.dim] //= self.mesh_sizes[mesh_dim]
-            if p.dim == input_start:
-                return Shard(tgt_shard_dim), new_shapes
-            # Non-first flatten dim: compute _StridedShard through the split.
-            sf_flat = math.prod(local_tensor_shapes[input_start : p.dim])
-            total = math.prod(cmd.group_shape)
-            if sf_flat == 0 or total % sf_flat != 0:
-                raise AssertionError(
-                    f"Flatten stride {sf_flat} does not evenly divide "
-                    f"split total {total} for Shard(dim={p.dim})"
-                )
-            period = total // sf_flat
-            target_split_id = None
-            sf_output = None
-            for d in range(len(cmd.group_shape)):
-                suffix = math.prod(cmd.group_shape[d + 1 :])
-                if suffix > 0 and period % suffix == 0:
-                    k = period // suffix
-                    if (
-                        k <= cmd.group_shape[d]
-                        and cmd.group_shape[d] % k == 0
-                        and k >= self.mesh_sizes[mesh_dim]
-                        and k % self.mesh_sizes[mesh_dim] == 0
-                    ):
-                        target_split_id = d
-                        sf_output = cmd.group_shape[d] // k
-                        break
-            if target_split_id is None or sf_output is None:
-                raise RuntimeError(
-                    f"Cannot propagate Shard(dim={p.dim}) through "
-                    f"Split(Flatten(...), {cmd.group_shape}): no valid "
-                    f"output dimension for the strided pattern."
-                )
-            if target_split_id == cmd.split_id:
-                output_dim = tgt_shard_dim
-            else:
-                output_dim = next(
-                    (
-                        od
-                        for od, r in enumerate(self.rule)
-                        if isinstance(r, Split)
-                        and r.input_dim is cmd.input_dim
-                        and r.split_id == target_split_id
-                    ),
-                    None,
-                )
-                if output_dim is None:
-                    raise AssertionError(
-                        f"No Split with split_id={target_split_id} found "
-                        f"in rule for the same Flatten group."
-                    )
-            output_placement: Placement
-            if sf_output <= 1:
-                output_placement = Shard(output_dim)
-            else:
-                output_placement = _StridedShard(output_dim, split_factor=sf_output)
-            return output_placement, new_shapes
+            return self._rewrite_split_flatten_shard(
+                cmd, p, mesh_dim, tgt_shard_dim, local_tensor_shapes
+            )
         if isinstance(cmd, (Split, InputDim)):
             # Split/InputDim: 1:1 dim mapping, sharding transfers directly.
             # Flatten needs stride computation below (multiple dims merge).

--- a/torch/distributed/tensor/_ops/_view_ops.py
+++ b/torch/distributed/tensor/_ops/_view_ops.py
@@ -681,12 +681,13 @@ class _ViewShardingPropagator:
                         )
                     input_to_output_tensor_dims[in_dim.input_dim] = [output_dim]
             elif len(in_dims) > 0:
-                # InputDim (identity) or Split(split_id=0).
-                in_dim = in_dims[0]
-                if in_dim.input_dim not in input_to_output_tensor_dims:
-                    input_to_output_tensor_dims[in_dim.input_dim] = [output_dim]
-                else:
-                    input_to_output_tensor_dims[in_dim.input_dim].append(output_dim)
+                # InputDim (identity), Split(split_id=0), or
+                # Split(Flatten(...), split_id=0) which returns multiple dims.
+                for in_dim in in_dims:
+                    if in_dim.input_dim not in input_to_output_tensor_dims:
+                        input_to_output_tensor_dims[in_dim.input_dim] = [output_dim]
+                    else:
+                        input_to_output_tensor_dims[in_dim.input_dim].append(output_dim)
             elif isinstance(cmd, Split):
                 # Split(split_id>0): _analyze_split returned [], so chase the
                 # root input dim and append this output dim to its existing entry.
@@ -954,10 +955,12 @@ class _ViewShardingPropagator:
                     guard_or_false(out_size % self.mesh_sizes[shard_mesh_dim] == 0)
                     or is_last_split_dim
                 )
-        # Only split_id==0 returns the input dim for input_to_output_tensor_dims.
+        # Only split_id==0 returns input dims for input_to_output_tensor_dims.
         # Later split_ids refine shard_allowed above but return [] — their
         # output dims are linked via the root-input-dim chase in analyze().
-        return [in_dim] if cmd.split_id == 0 else []
+        # Return all in_dims (not just the first) so that Split(Flatten(...))
+        # populates input_to_output_tensor_dims for every flattened input dim.
+        return in_dims if cmd.split_id == 0 else []
 
     def _analyze_dim(self, cmd: DimSpec) -> list[InputDim]:
         """Dispatch one DimSpec: update self.shard_allowed, return input dim(s) to shard on."""
@@ -1149,7 +1152,11 @@ class _ViewShardingPropagator:
                 suffix = math.prod(cmd.group_shape[d + 1 :])
                 if suffix > 0 and period % suffix == 0:
                     k = period // suffix
-                    if k <= cmd.group_shape[d] and cmd.group_shape[d] % k == 0:
+                    if (
+                        k <= cmd.group_shape[d]
+                        and cmd.group_shape[d] % k == 0
+                        and k >= self.mesh_sizes[mesh_dim]
+                    ):
                         target_split_id = d
                         sf_output = cmd.group_shape[d] // k
                         break

--- a/torch/distributed/tensor/_ops/_view_ops.py
+++ b/torch/distributed/tensor/_ops/_view_ops.py
@@ -695,11 +695,13 @@ class _ViewShardingPropagator:
                 # Flatten+Split example: view([2, 3], [3, 2])
                 #   rule = (Split(Flatten(InputDim(0), InputDim(1)), (3,2), 0),
                 #           Split(Flatten(InputDim(0), InputDim(1)), (3,2), 1))
-                #   output_dim=0 (split_id=0): same as Split example above.
-                #     Result: {0: [0]}
-                #   output_dim=1 (split_id=1): same as Split example, but
-                #     the chase unwraps the inner Flatten to find InputDim(0).
-                #     Result: {0: [0, 1]}
+                #   output_dim=0 (split_id=0): _analyze_split returns all
+                #     sharded InputDims from the inner Flatten.  If only
+                #     InputDim(0) is sharded: {0: [0]}.  If both are sharded:
+                #     {0: [0], 1: [0]}.
+                #   output_dim=1 (split_id=1): chases the root input dim
+                #     used as key by split_id=0 and appends output_dim 1.
+                #     E.g. {0: [0, 1]} (or {0: [0, 1], 1: [0]} if both sharded).
                 root_spec = cmd.input_dim
                 while isinstance(root_spec, (Flatten, Split)):
                     if isinstance(root_spec, Flatten):
@@ -1145,6 +1147,11 @@ class _ViewShardingPropagator:
             # Non-first flatten dim: compute _StridedShard through the split.
             sf_flat = math.prod(local_tensor_shapes[input_start : p.dim])
             total = math.prod(cmd.group_shape)
+            if sf_flat == 0 or total % sf_flat != 0:
+                raise AssertionError(
+                    f"Flatten stride {sf_flat} does not evenly divide "
+                    f"split total {total} for Shard(dim={p.dim})"
+                )
             period = total // sf_flat
             target_split_id = None
             sf_output = None
@@ -1156,6 +1163,7 @@ class _ViewShardingPropagator:
                         k <= cmd.group_shape[d]
                         and cmd.group_shape[d] % k == 0
                         and k >= self.mesh_sizes[mesh_dim]
+                        and k % self.mesh_sizes[mesh_dim] == 0
                     ):
                         target_split_id = d
                         sf_output = cmd.group_shape[d] // k

--- a/torch/distributed/tensor/_ops/_view_ops.py
+++ b/torch/distributed/tensor/_ops/_view_ops.py
@@ -702,12 +702,21 @@ class _ViewShardingPropagator:
                 root_spec = cmd.input_dim
                 while isinstance(root_spec, (Flatten, Split)):
                     if isinstance(root_spec, Flatten):
-                        # _analyze_flatten always returns input_dims[0] as
-                        # the first element (either as the only shardable dim
-                        # in non-strict mode, or as the fallback when nothing
-                        # is sharded), so split_id=0 uses it as the key in
-                        # input_to_output_tensor_dims. Use [0] here to match.
-                        root_spec = root_spec.input_dims[0]
+                        # Use whichever input dim was used as the key by
+                        # split_id=0.  In strict mode _analyze_flatten may
+                        # return a non-first sharded dim (e.g. InputDim(1)),
+                        # so input_dims[0] is not always the right key.
+                        matched = None
+                        for fd in root_spec.input_dims:
+                            if (
+                                isinstance(fd, InputDim)
+                                and fd.input_dim in input_to_output_tensor_dims
+                            ):
+                                matched = fd
+                                break
+                        root_spec = (
+                            matched if matched is not None else root_spec.input_dims[0]
+                        )
                     else:
                         root_spec = root_spec.input_dim
                 root = root_spec if isinstance(root_spec, InputDim) else None
@@ -1117,6 +1126,63 @@ class _ViewShardingPropagator:
                     f"{tgt_shard_dims} for Shard(dim={p.dim}) on mesh dim {mesh_dim}."
                 )
         cmd = self.rule[tgt_shard_dim]
+        if isinstance(cmd, Split) and isinstance(cmd.input_dim, Flatten):
+            # Split(Flatten(...)): flatten-then-split.  The inner Flatten may
+            # produce a strided pattern that lands on a different output dim
+            # than the split_id=0 dim we selected above.
+            flatten_cmd = cmd.input_dim
+            first_dim = flatten_cmd.input_dims[0]
+            if not isinstance(first_dim, InputDim):
+                raise AssertionError(f"Expected InputDim, got {type(first_dim)}")
+            input_start = first_dim.input_dim
+            new_shapes = list(local_tensor_shapes)
+            new_shapes[p.dim] //= self.mesh_sizes[mesh_dim]
+            if p.dim == input_start:
+                return Shard(tgt_shard_dim), new_shapes
+            # Non-first flatten dim: compute _StridedShard through the split.
+            sf_flat = math.prod(local_tensor_shapes[input_start : p.dim])
+            total = math.prod(cmd.group_shape)
+            period = total // sf_flat
+            target_split_id = None
+            sf_output = None
+            for d in range(len(cmd.group_shape)):
+                suffix = math.prod(cmd.group_shape[d + 1 :])
+                if suffix > 0 and period % suffix == 0:
+                    k = period // suffix
+                    if k <= cmd.group_shape[d] and cmd.group_shape[d] % k == 0:
+                        target_split_id = d
+                        sf_output = cmd.group_shape[d] // k
+                        break
+            if target_split_id is None or sf_output is None:
+                raise RuntimeError(
+                    f"Cannot propagate Shard(dim={p.dim}) through "
+                    f"Split(Flatten(...), {cmd.group_shape}): no valid "
+                    f"output dimension for the strided pattern."
+                )
+            if target_split_id == cmd.split_id:
+                output_dim = tgt_shard_dim
+            else:
+                output_dim = next(
+                    (
+                        od
+                        for od, r in enumerate(self.rule)
+                        if isinstance(r, Split)
+                        and r.input_dim is cmd.input_dim
+                        and r.split_id == target_split_id
+                    ),
+                    None,
+                )
+                if output_dim is None:
+                    raise AssertionError(
+                        f"No Split with split_id={target_split_id} found "
+                        f"in rule for the same Flatten group."
+                    )
+            output_placement: Placement
+            if sf_output <= 1:
+                output_placement = Shard(output_dim)
+            else:
+                output_placement = _StridedShard(output_dim, split_factor=sf_output)
+            return output_placement, new_shapes
         if isinstance(cmd, (Split, InputDim)):
             # Split/InputDim: 1:1 dim mapping, sharding transfers directly.
             # Flatten needs stride computation below (multiple dims merge).


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #179664
* __->__ #179509

fix: https://github.com/pytorch/pytorch/issues/179502

we had silent wrong results for Split(Flatten(...)) rules. After fix,
* dt[4, 4, 4] → dt.view(8, 8) with [Shard(1), Replicate()] on mesh (2, 3): returns (_StridedShard(dim=0, sf=4),
  Replicate()) with zero communication
* dt[12, 8] → dt.view(16, 6) with Shard(1) on mesh (6,): raises RuntimeError("output dimension 0 (size 16) is not
   evenly divisible by mesh dimension 0 (size 6)")

fix
* `_rewrite_plain_shard`: previously only handled sharding on the first dim of a flatten group. Now computes the     
  strided shard factor from the sharded dim's position within the flatten, then finds which output dim can carry
  that stride. Also adds `k >= mesh_size` and `k % mesh_size == `0 checks so we never produce a _StridedShard whose chunk count doesn't evenly divide the dim size.                                                                
* `_analyze_split / analyze()`: `Split(Flatten(...))` has multiple input dims, but we were only tracking the first one. Now we track all of them, so sharding on any dim in the flatten group works.

