### PR TITLE
fix: ensure dataclasses with uninitialized fields can be deserialized

### DIFF
--- a/test/dynamo/test_guard_serialization.py
+++ b/test/dynamo/test_guard_serialization.py
@@ -1868,6 +1868,17 @@ class TestGuardSerialization(TestGuardSerializationBase):
 
         self.assertEqual(pickle.dumps(src1), pickle.dumps(src2))
 
+    def test_source_serialization_init_false_fields(self):
+        # Test that source serialization handles fields that are not initialized
+        from torch._dynamo.source import DefaultsSource, LocalSource
+
+        base = LocalSource("x")
+        source = DefaultsSource(base=base, idx_key=0, is_kw=False)
+
+        # Round-trip through pickle should work even with init=False fields
+        restored = pickle.loads(pickle.dumps(source))
+        self.assertEqual(source, restored)
+
 
 class SimpleModule(torch.nn.Module):
     def __init__(self, c):

--- a/torch/_guards.py
+++ b/torch/_guards.py
@@ -1317,7 +1317,7 @@ def dataclass_with_cached_hash(
             # The _hash is a cached value that can be nondeterministically computed
             # (e.g., based on id() of objects), so it should not affect pickling.
             fields = dataclasses.fields(self)
-            field_values = tuple(getattr(self, f.name) for f in fields)
+            field_values = tuple(getattr(self, f.name) for f in fields if f.init)
             return (self.__class__, field_values)
 
         new_cls.__hash__ = __hash__


### PR DESCRIPTION
Fixes an issue in guard serialization that would cause dataclass fields set to `init=False` to get serialized. Upon loading objects like `DefaultsSource`, it would receive the error 

```
    restored = pickle.loads(pickle.dumps(source))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: DefaultsSource.__init__() takes from 3 to 4 positional arguments but 6 were given
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98