### PR TITLE
Use maybe_mark_dynamic instead of mark_dynamic in test_max_autotune_addmm_tma_dynamic_outer_dim (#179514)

### DIFF
--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -906,7 +906,7 @@ class TestMaxAutotune(TestCase):
         a = a.repeat(8, 8)
         b = b.repeat(8, 8)
 
-        torch._dynamo.mark_dynamic(a, 0)
+        torch._dynamo.maybe_mark_dynamic(a, 0)
 
         with config.patch(
             {


### PR DESCRIPTION
Summary:

Fixed the failing test `test_max_autotune_addmm_tma_dynamic_outer_dim` in `fbcode/caffe2/test/inductor/test_max_autotune.py`.

The revert diff D99582441 (reverting GitHub PR [pytorch/pytorch#172559](https://github.com/pytorch/pytorch/pull/178795)) incorrectly changed `torch._dynamo.maybe_mark_dynamic(a, 0)` back to `torch._dynamo.mark_dynamic(a, 0)`. The `mark_dynamic` call fails with a `ConstraintViolationError` because the dimension gets specialized to a constant (168), which violates the dynamic constraint. Changed it back to `maybe_mark_dynamic` which is the non-strict variant that doesn't error when specialization occurs.

Context: Internal task T263333891, fix diff D99621432.

Test Plan: Ran the affected test with `buck test mode/opt fbcode//caffe2/test/inductor:max_autotune -- --exact test_max_autotune_addmm_tma_dynamic_outer_dim` — 2/2 passed (previously failing with ConstraintViolationError).

Differential Revision: D99621432




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo