### PR TITLE
[fx] Fix split_module to place placeholders before get_attr nodes

### DIFF
--- a/test/test_fx_experimental.py
+++ b/test/test_fx_experimental.py
@@ -1114,6 +1114,49 @@ terrible spacing
         actual = torch.compile(moe, backend=backend)(inp)
         torch.testing.assert_close(actual, expected)
 
+    def test_split_module_placeholders_before_get_attr(self):
+        # Manually construct a graph matching what torch.cond + dynamo
+        # produces: placeholder, get_attr(nn.Module), placeholder, ...
+        # Manual construction avoids dynamo/torch.compile dependency.
+        class DummyModule(torch.nn.Module):
+            def forward(self, x):
+                return x
+
+        root = torch.nn.Module()
+        root.branch = DummyModule()
+
+        graph = torch.fx.Graph()
+        ph_x = graph.placeholder("x")
+        branch = graph.get_attr("branch")
+        ph_y = graph.placeholder("y")
+        op1 = graph.call_function(torch.mul, (ph_x, branch))
+        op2 = graph.call_function(torch.add, (op1, ph_y))
+        graph.output(op2)
+
+        for node in graph.nodes:
+            node.meta = {}
+
+        gm = torch.fx.GraphModule(root, graph)
+
+        split_gm = split_module(
+            gm,
+            root_m=None,
+            split_callback=lambda node: 0,
+            keep_original_order=True,
+        )
+
+        for name, submod in split_gm.named_children():
+            seen_get_attr = False
+            for node in submod.graph.nodes:
+                if node.op == "get_attr":
+                    seen_get_attr = True
+                elif node.op == "placeholder":
+                    self.assertFalse(
+                        seen_get_attr,
+                        f"placeholder '{node.name}' found after get_attr "
+                        f"in submodule '{name}'",
+                    )
+
     def test_normalize_binary_operators(self):
         ops_to_test = {
             torch.add,

--- a/torch/fx/passes/split_module.py
+++ b/torch/fx/passes/split_module.py
@@ -462,7 +462,25 @@ def split_module(
 
         counter = 0
 
+        # Process inputs that become placeholders before inputs that become
+        # get_attr nodes, so that all placeholders precede get_attr in the
+        # submodule graph.
+        placeholder_inputs: list[str] = []
+        get_attr_inputs: list[str] = []
         for inp in partition.inputs:
+            orig_node = orig_nodes[inp]
+            if (
+                orig_node.op == "get_attr"
+                and isinstance(orig_node.target, str)
+                and isinstance(
+                    _get_attr_from_qualname(m, orig_node.target), torch.nn.Module
+                )
+            ):
+                get_attr_inputs.append(inp)
+            else:
+                placeholder_inputs.append(inp)
+
+        for inp in placeholder_inputs + get_attr_inputs:
             orig_node = orig_nodes[inp]
             # We don't pass in get_attr nodes as inputs to the partition, but
             # instead set them as targets and use getattr within the module


### PR DESCRIPTION
## Summary
`split_module` can interleave `get_attr` nodes (e.g. `torch.cond` branch subgraphs referencing `nn.Module` attributes) between `placeholder` nodes in submodule graphs. This breaks downstream code that assumes placeholders come first (e.g. vLLM's piecewise compilation backend).

Fix by sorting partition inputs so that `nn.Module` `get_attr` inputs are processed after all placeholder inputs.

Fixes the root cause of https://github.com/vllm-project/vllm/pull/38958

## Test plan
- [x] Added `test_split_module_placeholders_before_get_attr` to `test/test_fx_experimental.py`
- [x] Test fails without fix, passes with fix