### PR TITLE
Wrap plain tensor tangents as AsyncCollectiveTensor in AOT autograd b…

### DIFF
--- a/test/distributed/test_c10d_functional_native.py
+++ b/test/distributed/test_c10d_functional_native.py
@@ -1446,5 +1446,46 @@ class CompileTest(TestCase):
         (FileCheck().check("all_reduce_.default(buf0, 'avg', '0')").run(code))
 
 
+class ACTCompileTest(TestCase):
+    """
+    Test that AsyncCollectiveTensor (ACT) inputs to compiled regions
+    handle backward correctly. When ACT leaks into a compiled graph
+    via view ops, AOT autograd records ACT in SubclassCreationMeta.
+    At runtime, autograd produces plain tensor tangents which must be
+    wrapped as ACT to satisfy the type check.
+    """
+
+    def test_act_compile_backward_tangent_wrapping(self):
+        """
+        When a bare ACT enters a torch.compiled region and passes
+        through a view op, the output remains an ACT. AOT autograd
+        records ACT in SubclassCreationMeta. At runtime, autograd
+        produces a plain tensor tangent — process_runtime_tangent
+        must wrap it as ACT to avoid:
+            RuntimeError: Expected a AsyncCollectiveTensor tangent
+            but got a plain Tensor.
+
+        This occurs in practice when TP async collectives produce a
+        DTensor(ACT), an eager caller does to_local() to get a bare
+        ACT, and that ACT flows into a compiled sub-module whose
+        forward contains view ops (unsqueeze, reshape, transpose, etc.).
+        """
+        elem = torch.randn(4, 4, requires_grad=True)
+        act = AsyncCollectiveTensor(elem)
+
+        compiled_fn = torch.compile(
+            lambda x: x.unsqueeze(0), backend="aot_eager"
+        )
+        out = compiled_fn(act)
+        # Without tangent wrapping, this raises:
+        #   RuntimeError: Expected a AsyncCollectiveTensor tangent
+        #   but got a plain Tensor.
+        out.sum().backward()
+
+        # Verify numerics match plain tensor execution
+        ref = elem.detach().unsqueeze(0)
+        self.assertEqual(out.detach(), ref)
+
+
 if __name__ == "__main__":
     run_tests()

--- a/torch/_functorch/_aot_autograd/runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/runtime_wrappers.py
@@ -3050,6 +3050,21 @@ Your tensor subclass must implement __coerce_same_metadata_as_tangent__."""
         if isinstance(x, torch._subclasses.functional_tensor.FunctionalTensor):
             runtime_type = torch.Tensor
 
+        # Autograd produces plain tensor tangents, but when the forward
+        # traced an AsyncCollectiveTensor (ACT) input the metadata
+        # expects ACT type. Wrap the tangent so the type check passes.
+        # The tangent was never part of an async collective so
+        # trigger_wait() on this wrapper is a no-op.
+        from torch.distributed._functional_collectives import AsyncCollectiveTensor
+
+        if (
+            isinstance(meta, SubclassCreationMeta)
+            and meta.original_subclass_type is AsyncCollectiveTensor
+            and not isinstance(x, AsyncCollectiveTensor)
+        ):
+            x = AsyncCollectiveTensor(x)
+            runtime_type = AsyncCollectiveTensor
+
         runtime_meta = None
         runtime_subclass_keys: Sequence[str] = []
 


### PR DESCRIPTION
…ackward

When an AsyncCollectiveTensor (ACT) input enters a compiled region and passes through view ops, ACT's __torch_dispatch__ preserves the ACT wrapper on the output. AOT autograd then records ACT as the expected tangent type in SubclassCreationMeta. During backward, autograd produces plain tensor tangents which fail the type check:

  RuntimeError: Expected a AsyncCollectiveTensor tangent but got a
  plain Tensor

Fix: in process_runtime_tangent, when the metadata expects ACT but the runtime tangent is a plain tensor, wrap it as AsyncCollectiveTensor. This is analogous to the existing FunctionalTensor special-casing. The wrapping is trivial and zero-cost — the tangent was never part of an async collective, so trigger_wait() on the wrapper is a no-op.

First observed in torchtitan's GPT-OSS MoE model with TP + EP + compile enabled simultaneously.

Repro (torchtitan):

  NGPU=4 MODULE=gpt_oss CONFIG=gpt_oss_debugmodel ./run_train.sh \
    --parallelism.data_parallel_shard_degree 2 \
    --parallelism.tensor_parallel_degree 2 \
    --parallelism.expert_parallel_degree 2 \
    --parallelism.expert_tensor_parallel_degree 1 \
    --compile.enable

Without the fix, training crashes at backward with the tangent mismatch error above. With the fix, training completes (loss 5.48 → 3.93 over 10 steps).

Fixes https://github.com/pytorch/torchtitan/issues/2776