### PR TITLE
Fix for argmax/argmin with cpptile2dkernel

### DIFF
--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -3671,6 +3671,36 @@ class CPUReproTests(TestCase):
                     f"Expected generated_cpp_vec_kernel_count == 1, got {metrics.generated_cpp_vec_kernel_count}"
                 )
 
+    @requires_vectorization
+    def test_argmax_argmin_cpptile2d_2d_input(self):
+        def fn(a, b):
+            return (a + b).max(dim=1)
+
+        def fn_min(a, b):
+            return (a + b).min(dim=1)
+
+        torch.manual_seed(0)
+        for sz in [8, 32, 35]:
+            for f in [fn, fn_min]:
+                torch._dynamo.reset()
+                a = torch.randn(sz, sz).transpose(0, 1)
+                b = torch.randn(sz, sz)
+                self.common(f, (a, b))
+
+    @requires_vectorization
+    def test_argmax_argmin_cpptile2d_3d_input(self):
+        def fn_3d(a, b):
+            return (a + b).max(dim=2)
+
+        def fn_3d_min(a, b):
+            return (a + b).min(dim=2)
+
+        for f in [fn_3d, fn_3d_min]:
+            torch._dynamo.reset()
+            a = torch.randn(4, 16, 16).permute(0, 2, 1)
+            b = torch.randn(4, 16, 16)
+            self.common(f, (a, b))
+
     # Currently, we enabled AVX2 and AVX512 for vectorization. If the platform is not
     # supported, the vectorization will not work and skip this test case. For ARM or
     # other platforms support, we just need to add the ISA info to the supported_vector_isa

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -3066,6 +3066,9 @@ class CppVecKernel(CppKernel):
         else:
             raise NotImplementedError(f"store mode={mode}")
 
+    def _adjust_argreduce_index(self, index: sympy.Expr) -> sympy.Expr:
+        return index
+
     def reduction(self, dtype, src_dtype, reduction_type, value):
         """
         Perform vectorized reduction operation.
@@ -3525,7 +3528,7 @@ class CppVecKernel(CppKernel):
             if index is not None:
                 assert horizontal_reduction is not None
                 t_extra = f", {str(horizontal_reduction).lower()}"
-                arg_extra = f", {index}"
+                arg_extra = f", {self._adjust_argreduce_index(index)}"
             if self.tail_size:
                 return (
                     f"{reduction_type}_combine_vec<{cdtype}, {n_src}, {n_idx}{t_extra}>"
@@ -3835,6 +3838,8 @@ class CppTile2DKernel(CppVecKernel):
             offset=self.inner_itervar(),
         )
 
+    def _adjust_argreduce_index(self, index: sympy.Expr) -> sympy.Expr:
+        return self.transform_indexing(index)
 
 def get_loop_body_lowp_fp(_body: LoopBody) -> tuple[torch.dtype | None, bool]:
     """

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -3841,6 +3841,7 @@ class CppTile2DKernel(CppVecKernel):
     def _adjust_argreduce_index(self, index: sympy.Expr) -> sympy.Expr:
         return self.transform_indexing(index)
 
+
 def get_loop_body_lowp_fp(_body: LoopBody) -> tuple[torch.dtype | None, bool]:
     """
     Returns the low precision data type (torch.float16/torch.bfloat16) contained in the nodes


### PR DESCRIPTION
Fixes #178964

The root cause is that for CppTile2DKernel, the index used in the argmax and argmin calculations are incorrect. The value calculation is correctly determined using the linearized index. The reduce index was incorrectly missing the offset within the tile. The fix updates the reduce index to properly capture the offset.

Without transpose, the stride pattern of the two matrices match and CppVecKernel can be called which is why this was not hit without transpose. Similarly, the issue only would arise for >=8 dimension size because that is when vectorization begins to be utilized as determined in select_tiling. 

Before changes tmp_acc1_vec uses x1 (always) for storing the argmax value. _Looking at the penultimate line of code_
<img width="1403" height="619" alt="Screenshot From 2026-04-06 19-45-42" src="https://github.com/user-attachments/assets/5d9704f9-1f2f-43ce-bac2-5f8185212aed" />


After changes tmp_acc1_vec uses x2 + x2_inner to properly store index results
<img width="1403" height="619" alt="Screenshot From 2026-04-06 19-48-26" src="https://github.com/user-attachments/assets/a5596e70-b082-4d01-a836-af144dcad707" />


Testing over argmax and argmin with both 3d and 2d matrix inputs, number of tiles, and the presence of a tail.



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo