### PR TITLE
inductor: handle matmuls gracefully in foreach_map

### DIFF
--- a/test/inductor/test_foreach.py
+++ b/test/inductor/test_foreach.py
@@ -1457,6 +1457,38 @@ class ForeachTests(TestCase):
         self.assertEqual(actual, expected)
 
 
+@instantiate_parametrized_tests
+class ForeachMapMatmulTests(TestCase):
+    """Tests for foreach_map with non-pointwise ops like mm and matmul."""
+
+    @requires_gpu
+    @parametrize("op", [torch.mm, torch.matmul], name_fn=lambda f: f.__name__)
+    def test_foreach_map_matmul_correctness(self, op):
+        def fn(x0, x1, y0, y1):
+            return foreach_map(op, [x0, x1], [y0, y1])
+
+        x0 = torch.rand(4, 8, device=GPU_TYPE)
+        x1 = torch.rand(16, 32, device=GPU_TYPE)
+        y0 = torch.rand(8, 4, device=GPU_TYPE)
+        y1 = torch.rand(32, 16, device=GPU_TYPE)
+
+        expected = fn(x0, x1, y0, y1)
+        actual = torch.compile(fn)(x0, x1, y0, y1)
+        self.assertEqual(actual, expected)
+
+    @requires_gpu
+    def test_foreach_map_matmul_single_pair(self):
+        def fn(x, y):
+            return foreach_map(torch.mm, [x], [y])
+
+        x = torch.rand(8, 16, device=GPU_TYPE)
+        y = torch.rand(16, 8, device=GPU_TYPE)
+
+        expected = fn(x, y)
+        actual = torch.compile(fn)(x, y)
+        self.assertEqual(actual, expected)
+
+
 if __name__ == "__main__":
     from torch._inductor.test_case import run_tests
 

--- a/torch/_inductor/exc.py
+++ b/torch/_inductor/exc.py
@@ -79,6 +79,10 @@ class SubgraphLoweringException(RuntimeError):
     pass
 
 
+class SubgraphBufferCreationException(SubgraphLoweringException):
+    pass
+
+
 class InvalidCxxCompiler(RuntimeError):
     def __init__(self) -> None:
         from . import config

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -963,7 +963,7 @@ def _foreach_map(subgraph, *args, **kwargs):
     For non-pointwise ops (e.g. mm) that cannot be fused, we fall back to FallbackSubgraphLowering
     which delegates buffer creation to the root graph and skips horizontal fusion registration.
     """
-    from .exc import SubgraphLoweringException
+    from .exc import SubgraphBufferCreationException
     from .subgraph_lowering import FallbackSubgraphLowering, PointwiseSubgraphLowering
 
     inputs = args
@@ -973,8 +973,7 @@ def _foreach_map(subgraph, *args, **kwargs):
         pw_subgraph = PointwiseSubgraphLowering(gm, root_graph_lowering=V.graph)
         with V.set_graph_handler(pw_subgraph):  # type: ignore[arg-type]
             pw_subgraph.run(*inputs)
-        sub_outputs = pw_subgraph.graph_outputs
-    except SubgraphLoweringException:
+    except SubgraphBufferCreationException:
         fallback_subgraph = FallbackSubgraphLowering(gm, root_graph_lowering=V.graph)
         with V.set_graph_handler(fallback_subgraph):  # type: ignore[arg-type]
             fallback_subgraph.run(*inputs)

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -959,15 +959,28 @@ def _foreach_map(subgraph, *args, **kwargs):
     This code allows us to inline the subgraph into the main graph lowering using the PontwiseSubgraphLowering.
     The graph outputs represent the vertically fused sequence of ops, and then register_operation_list
     below registers the buffers as horizontally fuseable in the scheduler.
+
+    For non-pointwise ops (e.g. mm) that cannot be fused, we fall back to FallbackSubgraphLowering
+    which delegates buffer creation to the root graph and skips horizontal fusion registration.
     """
-    from .subgraph_lowering import PointwiseSubgraphLowering
+    from .exc import SubgraphLoweringException
+    from .subgraph_lowering import FallbackSubgraphLowering, PointwiseSubgraphLowering
 
     inputs = args
 
     gm = subgraph.graph_module
-    pw_subgraph = PointwiseSubgraphLowering(gm, root_graph_lowering=V.graph)
-    with V.set_graph_handler(pw_subgraph):  # type: ignore[arg-type]
-        pw_subgraph.run(*inputs)
+    try:
+        pw_subgraph = PointwiseSubgraphLowering(gm, root_graph_lowering=V.graph)
+        with V.set_graph_handler(pw_subgraph):  # type: ignore[arg-type]
+            pw_subgraph.run(*inputs)
+        sub_outputs = pw_subgraph.graph_outputs
+    except SubgraphLoweringException:
+        fallback_subgraph = FallbackSubgraphLowering(gm, root_graph_lowering=V.graph)
+        with V.set_graph_handler(fallback_subgraph):  # type: ignore[arg-type]
+            fallback_subgraph.run(*inputs)
+        assert fallback_subgraph.graph_outputs is not None
+        assert all(x is not None for x in fallback_subgraph.graph_outputs)
+        return fallback_subgraph.graph_outputs
 
     sub_outputs = pw_subgraph.graph_outputs
     # group outputs by device and register as foreach

--- a/torch/_inductor/subgraph_lowering.py
+++ b/torch/_inductor/subgraph_lowering.py
@@ -130,6 +130,56 @@ class PointwiseSubgraphLowering(torch.fx.Interpreter):
         self.graph_outputs = args[0]
 
 
+class FallbackSubgraphLowering(torch.fx.Interpreter):
+    """
+    Lowers a subgraph containing non-pointwise ops (e.g. mm) by delegating
+    buffer creation to the root graph. Used as fallback in foreach_map when
+    PointwiseSubgraphLowering raises SubgraphLoweringException.
+    """
+
+    graph_outputs: list[ir.IRNode] | None
+    root_graph: GraphLowering
+
+    def __init__(
+        self,
+        gm: torch.fx.GraphModule,
+        root_graph_lowering: GraphLowering,
+    ) -> None:
+        super().__init__(gm)
+        self.graph_outputs = None
+        self.root_graph = root_graph_lowering
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self.root_graph, name)
+
+    def register_buffer(self, buffer: ir.Buffer, *, set_name: bool = False) -> str:
+        return self.root_graph.register_buffer(buffer, set_name=set_name)
+
+    def mark_buffer_mutated(self, name: str) -> None:
+        self.root_graph.mark_buffer_mutated(name)
+
+    def call_function(
+        self,
+        target: TargetType,
+        args: Any,
+        kwargs: dict[str, Any],
+    ) -> Any:
+        from .lowering import lowerings
+
+        if target is operator.getitem and isinstance(args[0], (list, tuple, dict)):
+            return super().call_function(target, args, kwargs)
+
+        if target not in lowerings:
+            raise SubgraphLoweringException(
+                f"{target} not supported in subgraph, (missing lowering)"
+            )
+        return lowerings[target](*args, **kwargs)
+
+    def output(self, target: str, args: tuple[Any], kwargs: dict[str, Any]) -> None:  # type: ignore[override]
+        assert len(args) == 1
+        self.graph_outputs = args[0]
+
+
 @dataclass
 class InputDescriptor:
     dtype: torch.dtype

--- a/torch/_inductor/subgraph_lowering.py
+++ b/torch/_inductor/subgraph_lowering.py
@@ -14,7 +14,7 @@ import torch
 from torch.utils._ordered_set import OrderedSet
 
 from . import ir
-from .exc import SubgraphLoweringException
+from .exc import SubgraphBufferCreationException, SubgraphLoweringException
 from .graph import GraphLowering
 from .ops_handler import OpsHandler, SimpleCSEHandler
 from .virtualized import ops, V, WrapperHandler
@@ -92,7 +92,7 @@ class PointwiseSubgraphLowering(torch.fx.Interpreter):
             name = self.root_graph.register_buffer(buffer, set_name=set_name)
             return name
         else:
-            raise SubgraphLoweringException(
+            raise SubgraphBufferCreationException(
                 "Buffers cannot be created while lowering a pointwise subgraph. "
                 "This could be for a good reason (e.g. you're calling an op we can't codegen as a pointwise op), "
                 "but it could also be a bug. Please file a bug report if you think this should be supportable."


### PR DESCRIPTION
Add FallbackSubgraphLowering to handle non-pointwise ops like mm and matmul in foreach_map. Previously, SubgraphLoweringException would propagate when PointwiseSubgraphLowering encountered ops that require buffer creation. Now _foreach_map catches this exception and falls back to individual op lowerings via FallbackSubgraphLowering, delegating buffer creation to the root graph.

Fixes #158975

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo