### PR TITLE
[dynamo] Support sys.set_int_max_str_digits via polyfill

### DIFF
--- a/torch/_dynamo/polyfills/sys.py
+++ b/torch/_dynamo/polyfills/sys.py
@@ -32,4 +32,8 @@ if hasattr(sys, "get_int_max_str_digits"):
     def get_int_max_str_digits() -> int:
         return sys.get_int_max_str_digits()
 
-    __all__ += ["get_int_max_str_digits"]
+    @substitute_in_graph(sys.set_int_max_str_digits, can_constant_fold_through=True)
+    def set_int_max_str_digits(maxdigits: int, /) -> None:
+        sys.set_int_max_str_digits(maxdigits)
+
+    __all__ += ["get_int_max_str_digits", "set_int_max_str_digits"]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #179530
* __->__ #179529
* #179527
* #179521

Add a substitute_in_graph polyfill for sys.set_int_max_str_digits so
it runs at trace time without graph breaking, matching the existing
pattern for sys.get_int_max_str_digits.

Authored with Claude.