### PR TITLE
[FSDP2] Detect shared modules/parameters across FSDP groups at init

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_training.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_training.py
@@ -1102,10 +1102,10 @@ class TestFullyShardSharedParams(FSDPTest):
         model.tok_embeddings.reshard()
 
     @skip_if_lt_x_gpu(2, allow_cpu=True)
-    def test_shared_params_separate_fsdp_groups_error(self):
+    def test_tied_weight_across_fsdp_groups_error(self):
         """
         Test that applying fully_shard to modules with shared parameters
-        in separate calls raises an error at lazy init (first forward).
+        in separate calls raises an error at init time.
         """
         hidden_size = 16
         vocab_size = 17
@@ -1122,11 +1122,31 @@ class TestFullyShardSharedParams(FSDPTest):
 
         model = TiedModel()
         fully_shard(model.tok_embeddings)
-        fully_shard(model.output)
-        fully_shard(model)
-        ids = torch.randint(0, vocab_size, (2, 8), device=device_type.type)
-        with self.assertRaisesRegex(ValueError, "already managed by another"):
-            model(ids)
+        with self.assertRaisesRegex(ValueError, "already managed by another FSDP"):
+            fully_shard(model.output)
+
+    @skip_if_lt_x_gpu(2, allow_cpu=True)
+    def test_shared_module_across_fsdp_groups_error(self):
+        """
+        Test that applying fully_shard to two modules that share the same
+        child module raises an error at init time (not a confusing
+        RuntimeError about overlapping meshes).
+        """
+
+        class SharedModuleModel(nn.Module):
+            def __init__(self):
+                super().__init__()
+                shared = nn.Linear(16, 16)
+                self.branch_a = nn.Sequential(shared, nn.ReLU())
+                self.branch_b = nn.Sequential(shared, nn.ReLU())
+
+            def forward(self, x):
+                return self.branch_a(x) + self.branch_b(x)
+
+        model = SharedModuleModel().to(device_type.type)
+        fully_shard(model.branch_a)
+        with self.assertRaisesRegex(ValueError, "already managed by another FSDP"):
+            fully_shard(model.branch_b)
 
     @skip_if_lt_x_gpu(2, allow_cpu=True)
     def test_layer_by_layer_shard_no_false_positive(self):

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param.py
@@ -260,8 +260,26 @@ class FSDPParam:
         # `distribute_tensor` after https://github.com/pytorch/pytorch/issues/116101
         # TODO: Simplify the following sharded parameter padding logic after
         # https://github.com/pytorch/pytorch/issues/113045
+        if hasattr(param, "_fsdp_orig_uid"):
+            prev_owner = getattr(param, "_fsdp_orig_owner", "unknown")
+            curr_owner = (
+                f"{type(self._module_info.module).__qualname__}."
+                f"{self._module_info.param_name}"
+            )
+            raise ValueError(
+                f"Parameter '{curr_owner}' is already managed by another FSDP "
+                f"group (first claimed as '{prev_owner}'). This usually means "
+                f"the same module or parameter appears under multiple parents "
+                f"that were sharded separately. Either:\n"
+                f"  1. fully_shard the shared module before its parents, or\n"
+                f"  2. use fully_shard([parent_a, parent_b]) to group them."
+            )
         self.is_dtensor = isinstance(param, DTensor)
         self._orig_param_uid = _get_orig_param_uid(param)
+        param._fsdp_orig_owner = (  # pyrefly: ignore[missing-attribute]
+            f"{type(self._module_info.module).__qualname__}."
+            f"{self._module_info.param_name}"
+        )
         param_data = self._init_sharding_spec(param, fsdp_placement, shard_dim)
         if not param_data.is_contiguous():
             raise AssertionError(
@@ -324,6 +342,12 @@ class FSDPParam:
         # Let `param_data` be freed normally when its ref count reaches 0 when
         # the `fully_shard` call returns to allow provided parameters to alias
         self._setattr_on_modules(self.sharded_param)
+        self.sharded_param._fsdp_orig_uid = (  # pyrefly: ignore[missing-attribute]
+            self._orig_param_uid
+        )
+        self.sharded_param._fsdp_orig_owner = (  # pyrefly: ignore[missing-attribute]
+            param._fsdp_orig_owner
+        )
         self.sharded_state = ShardedState.SHARDED
 
     def _init_sharding_spec(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #179532

fixes https://github.com/pytorch/torchtitan/issues/2817

FSDP2 requires shared parameters to live in exactly one FSDP group. Two ways to achieve this:
```
  Option 1: Group the parents together
  fully_shard([model.tok_embeddings, model.output])
  Both modules (and their shared parameter) go into a single FSDP group.

  Option 2: Shard the shared module first
  fully_shard(model.shared_linear)   # gets its own FSDP group
  fully_shard(model.branch_a)        # skips shared_linear (already has FSDP state)
  fully_shard(model.branch_b)        # skips shared_linear (already has FSDP state)
```

provide actionable error msg
```
ValueError: Parameter 'Linear.weight' is already managed by another FSDP
  group (first claimed as 'Embedding.weight'). This usually means the same
  module or parameter appears under multiple parents that were sharded
  separately. Either:
    1. fully_shard the shared module before its parents, or
    2. use fully_shard([parent_a, parent_b]) to group them.
```

Co-authored-by: Muhammad Shahir Abdurrahman <man2machine@users.noreply.github.com>