### PR TITLE
Add a typed torch.cfg control-flow graph foundation

### DIFF
--- a/docs/source/torch.cfg.rst
+++ b/docs/source/torch.cfg.rst
@@ -1,0 +1,55 @@
+torch.cfg
+=========
+
+.. automodule:: torch.cfg
+.. currentmodule:: torch.cfg
+
+``torch.cfg`` provides a small, typed control-flow graph IR for analyses and
+transforms that need explicit basic blocks. Value names are globally unique
+across a graph, even across blocks, so textual rendering and validation can use
+them as stable identifiers.
+
+Core IR
+-------
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    Graph
+    Block
+    Value
+    Instruction
+    Successor
+    Jump
+    Branch
+    Return
+
+Value Specs
+-----------
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    Spec
+    TensorSpec
+    ScalarSpec
+    TupleSpec
+    ListSpec
+    DictSpec
+    OptionalSpec
+    ObjectSpec
+
+Utilities
+---------
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    Literal
+    literal
+    Location
+    ValidationError
+    from_fx

--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -841,4 +841,5 @@ Operator Tags
 .. toctree::
     :hidden:
 
+    torch.cfg.rst
     torch.aliases.md

--- a/test/allowlist_for_publicAPI.json
+++ b/test/allowlist_for_publicAPI.json
@@ -36,6 +36,7 @@
     "torch.nn.quantizable.modules.rnn": "torch.ao.nn.quantizable.modules.rnn",
     "torch.distributed.tensor.device_mesh": "torch.distributed.device_mesh"
   },
+  "torch.cfg": [],
   "torch.backends": [
     "contextmanager"
   ],

--- a/test/test_cfg.py
+++ b/test/test_cfg.py
@@ -1,0 +1,115 @@
+# Owner(s): ["module: fx"]
+
+import torch
+import torch.cfg as cfg
+from torch.fx import Graph
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+class TestTorchCfg(TestCase):
+    def test_manual_cfg_is_valid_and_printable(self):
+        x = cfg.Value("x", cfg.TensorSpec.from_tensor(torch.randn(2, 3)))
+        negative_input = cfg.Value("negative_input", x.spec)
+        result = cfg.Value("result", x.spec)
+        pred = cfg.Value("pred", cfg.ScalarSpec(bool))
+        negated = cfg.Value("negated", x.spec)
+
+        graph = cfg.Graph(
+            name="branchy",
+            entry="entry",
+            blocks=(
+                cfg.Block(
+                    name="entry",
+                    parameters=(x,),
+                    instructions=(
+                        cfg.Instruction(
+                            name="lt_zero",
+                            opcode="call_function",
+                            target=torch.ops.aten.lt.Scalar,
+                            inputs=(x, 0),
+                            outputs=(pred,),
+                        ),
+                    ),
+                    terminator=cfg.Branch(
+                        pred,
+                        cfg.Successor("negative", (x,)),
+                        cfg.Successor("done", (x,)),
+                    ),
+                ),
+                cfg.Block(
+                    name="negative",
+                    parameters=(negative_input,),
+                    instructions=(
+                        cfg.Instruction(
+                            name="negate",
+                            opcode="call_function",
+                            target=torch.neg,
+                            inputs=(negative_input,),
+                            outputs=(negated,),
+                        ),
+                    ),
+                    terminator=cfg.Jump(cfg.Successor("done", (negated,))),
+                ),
+                cfg.Block(
+                    name="done",
+                    parameters=(result,),
+                    instructions=(),
+                    terminator=cfg.Return(result),
+                ),
+            ),
+        )
+
+        rendered = graph.format()
+        self.assertIn("graph branchy:", rendered)
+        self.assertIn("block entry", rendered)
+        self.assertIn("branch %pred -> negative(%x), done(%x)", rendered)
+        self.assertIn("jump done(%negated)", rendered)
+
+    def test_from_fx_normalizes_metadata_and_preserves_structure(self):
+        fx_graph = Graph()
+        x = fx_graph.placeholder("x")
+        x.meta["example_value"] = torch.randn(2, 3)
+        add = fx_graph.call_function(torch.add, args=(x, 1.0))
+        add.meta["val"] = torch.randn(2, 3)
+        fx_graph.output((x, {"sum": add}))
+
+        graph = cfg.from_fx(fx_graph, name="from_fx")
+
+        entry = graph.block("entry")
+        self.assertEqual(entry.parameters[0].name, "x")
+        self.assertIsInstance(entry.parameters[0].spec, cfg.TensorSpec)
+        self.assertEqual(len(entry.instructions), 1)
+        instruction = entry.instructions[0]
+        self.assertEqual(instruction.name, "add")
+        self.assertEqual(str(instruction.inputs[1]), "1.0")
+        self.assertIsInstance(instruction.outputs[0].spec, cfg.TensorSpec)
+        self.assertEqual(
+            entry.terminator.format(),
+            "return (%x, {sum: %add})",
+        )
+
+    def test_invalid_cfg_raises_validation_error(self):
+        x = cfg.Value("x")
+        with self.assertRaisesRegex(cfg.ValidationError, "expects 1 arguments but received 2"):
+            cfg.Graph(
+                name="invalid",
+                entry="entry",
+                blocks=(
+                    cfg.Block(
+                        name="entry",
+                        parameters=(x,),
+                        terminator=cfg.Jump(
+                            cfg.Successor("done", (x, cfg.literal(1))),
+                        ),
+                    ),
+                    cfg.Block(
+                        name="done",
+                        parameters=(cfg.Value("y"),),
+                        terminator=cfg.Return(None),
+                    ),
+                ),
+            )
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/test_cfg.py
+++ b/test/test_cfg.py
@@ -3,7 +3,12 @@
 import torch
 import torch.cfg as cfg
 from torch.fx import Graph, GraphModule
+from torch.fx.passes.shape_prop import TensorMetadata
 from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+class SampleObject:
+    pass
 
 
 class TestTorchCfg(TestCase):
@@ -65,6 +70,56 @@ class TestTorchCfg(TestCase):
         self.assertIn("branch %pred -> negative(%x), done(%x)", rendered)
         self.assertIn("jump done(%negated)", rendered)
 
+        self.assertEqual(graph.block("done").name, "done")
+        with self.assertRaisesRegex(KeyError, "Unknown block"):
+            graph.block("missing")
+
+    def test_spec_and_format_helpers_cover_non_tensor_values(self):
+        tuple_spec = cfg.Spec.from_value((1, None))
+        list_spec = cfg.Spec.from_value([True, 3.5])
+        dict_spec = cfg.Spec.from_value({"value": [1, None]})
+        object_spec = cfg.Spec.from_value(SampleObject())
+
+        self.assertEqual(tuple_spec.format(), "tuple[int, Optional[unknown]]")
+        self.assertEqual(list_spec.format(), "list[bool, float]")
+        self.assertEqual(
+            dict_spec.format(),
+            "dict[value: list[int, Optional[unknown]]]",
+        )
+        self.assertIsInstance(object_spec, cfg.ObjectSpec)
+        self.assertIs(object_spec.python_type, SampleObject)
+        self.assertRegex(object_spec.format(), r"(?:^|\.)SampleObject$")
+        self.assertEqual(
+            cfg.Location(file="example.py", line=7).format(),
+            "example.py:7",
+        )
+        self.assertEqual(
+            cfg.Location(file="example.py", line=7, function="forward").format(),
+            "example.py:7 in forward",
+        )
+        self.assertEqual(cfg.Location(function="forward").format(), "forward")
+        self.assertEqual(
+            cfg.Location(stack="frame 0\nexample.py:9 in call").format(),
+            "example.py:9 in call",
+        )
+        self.assertEqual(cfg.Location().format(), "<unknown>")
+
+        x = cfg.Value("x")
+        y = cfg.Value("y")
+        instruction = cfg.Instruction(
+            name="add",
+            opcode="call_function",
+            target="add",
+            inputs=(x, (1,), [2], {"scale": 3}, slice(0, x, None)),
+            attributes={"alpha": 4},
+            outputs=(y,),
+        )
+        self.assertEqual(
+            instruction.format(),
+            "%y = call_function[target=add](%x, (1,), [2], {scale: 3}, "
+            "slice(0, %x, None), alpha=4)",
+        )
+
     def test_tensor_spec_from_tensor_handles_dense_and_nested_tensors(self):
         dense = torch.randn(2, 3, requires_grad=True)
         dense_spec = cfg.TensorSpec.from_tensor(dense)
@@ -81,7 +136,9 @@ class TestTorchCfg(TestCase):
         nested = torch.nested.nested_tensor([torch.randn(2, 3), torch.randn(4, 3)])
         nested_spec = cfg.TensorSpec.from_tensor(nested)
 
+        self.assertIsNone(nested_spec.shape)
         self.assertIsNone(nested_spec.stride)
+        self.assertEqual(nested_spec.nested_size, ((2, 3), (4, 3)))
 
     def test_from_fx_normalizes_metadata_and_preserves_structure(self):
         fx_graph = Graph()
@@ -128,6 +185,44 @@ class TestTorchCfg(TestCase):
             "example.py:5 in forward",
         )
 
+    def test_from_fx_uses_tensor_meta_and_python_type_fallbacks(self):
+        fx_graph = Graph()
+        tensor = fx_graph.placeholder("tensor")
+        tensor.meta["tensor_meta"] = TensorMetadata(
+            shape=torch.Size([2, 3]),
+            dtype=torch.float32,
+            requires_grad=True,
+            stride=(3, 1),
+            memory_format=torch.contiguous_format,
+            is_quantized=False,
+            qparams={},
+        )
+        flag = fx_graph.placeholder("flag")
+        flag.type = bool
+        obj = fx_graph.placeholder("obj")
+        obj.type = SampleObject
+        fx_graph.output((tensor, flag, obj))
+
+        graph = cfg.from_fx(fx_graph, name="fallbacks")
+        entry = graph.block("entry")
+
+        tensor_spec = entry.parameters[0].spec
+        self.assertIsInstance(tensor_spec, cfg.TensorSpec)
+        self.assertEqual(tensor_spec.shape, (2, 3))
+        self.assertEqual(tensor_spec.dtype, torch.float32)
+        self.assertEqual(tensor_spec.device, torch.device("meta"))
+        self.assertEqual(tensor_spec.stride, (3, 1))
+        self.assertTrue(tensor_spec.requires_grad)
+        self.assertEqual(entry.parameters[1].spec, cfg.ScalarSpec(bool))
+        self.assertEqual(entry.parameters[2].spec, cfg.ObjectSpec(SampleObject))
+
+    def test_from_fx_requires_output_node(self):
+        fx_graph = Graph()
+        fx_graph.placeholder("x")
+
+        with self.assertRaisesRegex(ValueError, "FX graph is missing an output node"):
+            cfg.from_fx(fx_graph)
+
     def test_invalid_cfg_raises_validation_error(self):
         x = cfg.Value("x")
         with self.assertRaisesRegex(
@@ -152,6 +247,164 @@ class TestTorchCfg(TestCase):
                     ),
                 ),
             )
+
+    def test_invalid_cfg_rejects_other_validation_failures(self):
+        x = cfg.Value("x")
+        y = cfg.Value("y")
+
+        cases = [
+            (
+                "empty graph name",
+                lambda: cfg.Graph(
+                    name="",
+                    entry="entry",
+                    blocks=(cfg.Block(name="entry", terminator=cfg.Return(None)),),
+                ),
+                "graph name must be non-empty",
+            ),
+            (
+                "empty block name",
+                lambda: cfg.Graph(
+                    name="invalid",
+                    entry="entry",
+                    blocks=(cfg.Block(name="", terminator=cfg.Return(None)),),
+                ),
+                "block name must be non-empty",
+            ),
+            (
+                "duplicate block names",
+                lambda: cfg.Graph(
+                    name="invalid",
+                    entry="entry",
+                    blocks=(
+                        cfg.Block(
+                            name="entry",
+                            terminator=cfg.Jump(cfg.Successor("done")),
+                        ),
+                        cfg.Block(name="entry", terminator=cfg.Return(None)),
+                    ),
+                ),
+                "duplicate block name 'entry'",
+            ),
+            (
+                "missing entry block",
+                lambda: cfg.Graph(
+                    name="invalid",
+                    entry="entry",
+                    blocks=(cfg.Block(name="other", terminator=cfg.Return(None)),),
+                ),
+                "entry block 'entry' does not exist",
+            ),
+            (
+                "empty instruction name",
+                lambda: cfg.Graph(
+                    name="invalid",
+                    entry="entry",
+                    blocks=(
+                        cfg.Block(
+                            name="entry",
+                            parameters=(x,),
+                            instructions=(
+                                cfg.Instruction(
+                                    name="",
+                                    opcode="call_function",
+                                    target=torch.neg,
+                                    inputs=(x,),
+                                    outputs=(y,),
+                                ),
+                            ),
+                            terminator=cfg.Return(y),
+                        ),
+                    ),
+                ),
+                "contains an instruction with an empty name",
+            ),
+            (
+                "empty value name",
+                lambda: cfg.Graph(
+                    name="invalid",
+                    entry="entry",
+                    blocks=(
+                        cfg.Block(
+                            name="entry",
+                            parameters=(cfg.Value(""),),
+                            terminator=cfg.Return(None),
+                        ),
+                    ),
+                ),
+                "defines a value with an empty name",
+            ),
+            (
+                "value redefinition in block",
+                lambda: cfg.Graph(
+                    name="invalid",
+                    entry="entry",
+                    blocks=(
+                        cfg.Block(
+                            name="entry",
+                            parameters=(x,),
+                            instructions=(
+                                cfg.Instruction(
+                                    name="negate",
+                                    opcode="call_function",
+                                    target=torch.neg,
+                                    inputs=(x,),
+                                    outputs=(cfg.Value("tmp"),),
+                                ),
+                                cfg.Instruction(
+                                    name="add",
+                                    opcode="call_function",
+                                    target=torch.add,
+                                    inputs=(x, 1),
+                                    outputs=(cfg.Value("tmp"),),
+                                ),
+                            ),
+                            terminator=cfg.Return(None),
+                        ),
+                    ),
+                ),
+                "redefines value 'tmp' in the same block",
+            ),
+            (
+                "value collision across blocks",
+                lambda: cfg.Graph(
+                    name="invalid",
+                    entry="entry",
+                    blocks=(
+                        cfg.Block(
+                            name="entry",
+                            parameters=(cfg.Value("x"),),
+                            terminator=cfg.Jump(cfg.Successor("done", (1,))),
+                        ),
+                        cfg.Block(
+                            name="done",
+                            parameters=(cfg.Value("x"),),
+                            terminator=cfg.Return(None),
+                        ),
+                    ),
+                ),
+                "collides with existing value 'x'",
+            ),
+            (
+                "jump to unknown block",
+                lambda: cfg.Graph(
+                    name="invalid",
+                    entry="entry",
+                    blocks=(
+                        cfg.Block(
+                            name="entry",
+                            terminator=cfg.Jump(cfg.Successor("missing")),
+                        ),
+                    ),
+                ),
+                "jumps to unknown block 'missing'",
+            ),
+        ]
+
+        for name, build_graph, error in cases:
+            with self.subTest(name=name):
+                with self.assertRaisesRegex(cfg.ValidationError, error):
+                    build_graph()
 
     def test_invalid_cfg_rejects_cross_block_reference(self):
         x = cfg.Value("x")

--- a/test/test_cfg.py
+++ b/test/test_cfg.py
@@ -2,7 +2,7 @@
 
 import torch
 import torch.cfg as cfg
-from torch.fx import Graph
+from torch.fx import Graph, GraphModule
 from torch.testing._internal.common_utils import run_tests, TestCase
 
 
@@ -65,6 +65,24 @@ class TestTorchCfg(TestCase):
         self.assertIn("branch %pred -> negative(%x), done(%x)", rendered)
         self.assertIn("jump done(%negated)", rendered)
 
+    def test_tensor_spec_from_tensor_handles_dense_and_nested_tensors(self):
+        dense = torch.randn(2, 3, requires_grad=True)
+        dense_spec = cfg.TensorSpec.from_tensor(dense)
+
+        self.assertEqual(dense_spec.shape, (2, 3))
+        self.assertEqual(dense_spec.dtype, dense.dtype)
+        self.assertEqual(dense_spec.device, dense.device)
+        self.assertEqual(dense_spec.stride, dense.stride())
+        self.assertTrue(dense_spec.requires_grad)
+
+        if not hasattr(torch, "nested") or not hasattr(torch.nested, "nested_tensor"):
+            self.skipTest("nested tensors are unavailable")
+
+        nested = torch.nested.nested_tensor([torch.randn(2, 3), torch.randn(4, 3)])
+        nested_spec = cfg.TensorSpec.from_tensor(nested)
+
+        self.assertIsNone(nested_spec.stride)
+
     def test_from_fx_normalizes_metadata_and_preserves_structure(self):
         fx_graph = Graph()
         x = fx_graph.placeholder("x")
@@ -88,9 +106,34 @@ class TestTorchCfg(TestCase):
             "return (%x, {sum: %add})",
         )
 
+    def test_from_fx_accepts_graph_module_and_preserves_stack_trace(self):
+        fx_graph = Graph()
+        x = fx_graph.placeholder("x")
+        x.meta["example_value"] = torch.randn(2, 3)
+        add = fx_graph.call_function(torch.add, args=(x, 1.0))
+        add.meta["val"] = torch.randn(2, 3)
+        add.meta["stack_trace"] = "frame 1\nexample.py:5 in forward"
+        fx_graph.output(add)
+
+        graph = cfg.from_fx(
+            GraphModule(torch.nn.Module(), fx_graph),
+            name="graph_module",
+        )
+
+        entry = graph.block("entry")
+        self.assertEqual(graph.name, "graph_module")
+        self.assertEqual(entry.terminator.format(), "return %add")
+        self.assertEqual(
+            entry.instructions[0].location.format(),
+            "example.py:5 in forward",
+        )
+
     def test_invalid_cfg_raises_validation_error(self):
         x = cfg.Value("x")
-        with self.assertRaisesRegex(cfg.ValidationError, "expects 1 arguments but received 2"):
+        with self.assertRaisesRegex(
+            cfg.ValidationError,
+            "expects 1 arguments but received 2",
+        ):
             cfg.Graph(
                 name="invalid",
                 entry="entry",
@@ -106,6 +149,39 @@ class TestTorchCfg(TestCase):
                         name="done",
                         parameters=(cfg.Value("y"),),
                         terminator=cfg.Return(None),
+                    ),
+                ),
+            )
+
+    def test_invalid_cfg_rejects_cross_block_reference(self):
+        x = cfg.Value("x")
+        y = cfg.Value("y")
+
+        with self.assertRaisesRegex(
+            cfg.ValidationError,
+            "references undefined value 'x'",
+        ):
+            cfg.Graph(
+                name="invalid",
+                entry="entry",
+                blocks=(
+                    cfg.Block(
+                        name="entry",
+                        parameters=(x,),
+                        terminator=cfg.Jump(cfg.Successor("done")),
+                    ),
+                    cfg.Block(
+                        name="done",
+                        instructions=(
+                            cfg.Instruction(
+                                name="negate",
+                                opcode="call_function",
+                                target=torch.neg,
+                                inputs=(x,),
+                                outputs=(y,),
+                            ),
+                        ),
+                        terminator=cfg.Return(y),
                     ),
                 ),
             )

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -2845,7 +2845,7 @@ if "TORCH_CUDA_SANITIZER" in os.environ:
 
 # Populate magic methods on SymInt and SymFloat
 import torch.fx.experimental.sym_node
-from torch import fx as fx, cfg as cfg
+from torch import cfg as cfg, fx as fx
 
 
 # Register MPS specific decomps

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -2845,8 +2845,7 @@ if "TORCH_CUDA_SANITIZER" in os.environ:
 
 # Populate magic methods on SymInt and SymFloat
 import torch.fx.experimental.sym_node
-from torch import fx as fx
-from torch import cfg as cfg
+from torch import fx as fx, cfg as cfg
 
 
 # Register MPS specific decomps

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -2845,8 +2845,8 @@ if "TORCH_CUDA_SANITIZER" in os.environ:
 
 # Populate magic methods on SymInt and SymFloat
 import torch.fx.experimental.sym_node
-from torch import cfg as cfg
 from torch import fx as fx
+from torch import cfg as cfg
 
 
 # Register MPS specific decomps

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -2845,6 +2845,7 @@ if "TORCH_CUDA_SANITIZER" in os.environ:
 
 # Populate magic methods on SymInt and SymFloat
 import torch.fx.experimental.sym_node
+from torch import cfg as cfg
 from torch import fx as fx
 
 

--- a/torch/cfg/__init__.py
+++ b/torch/cfg/__init__.py
@@ -4,6 +4,8 @@ Typed control-flow graphs for PyTorch.
 ``torch.cfg`` is a small, principled IR for analyses and transforms that need
 explicit basic blocks and typed values. Unlike FX nodes, semantic metadata lives
 in a single ``Value.spec`` field instead of an open-ended ``meta`` dictionary.
+Value names are globally unique across a graph, even across blocks, so textual
+rendering and validation can use them as stable identifiers.
 
 Example:
 
@@ -62,6 +64,7 @@ Example:
 
 from .fx import from_fx
 from .ir import (
+    _IR_PUBLIC_API as _IR_PUBLIC_API,
     Block,
     Branch,
     DictSpec,
@@ -85,26 +88,4 @@ from .ir import (
 )
 
 
-__all__ = [
-    "Block",
-    "Branch",
-    "DictSpec",
-    "Graph",
-    "Instruction",
-    "Jump",
-    "ListSpec",
-    "Literal",
-    "Location",
-    "ObjectSpec",
-    "OptionalSpec",
-    "Return",
-    "ScalarSpec",
-    "Spec",
-    "Successor",
-    "TensorSpec",
-    "TupleSpec",
-    "ValidationError",
-    "Value",
-    "from_fx",
-    "literal",
-]
+__all__ = [*_IR_PUBLIC_API, "from_fx"]

--- a/torch/cfg/__init__.py
+++ b/torch/cfg/__init__.py
@@ -7,8 +7,12 @@ in a single ``Value.spec`` field instead of an open-ended ``meta`` dictionary.
 Value names are globally unique across a graph, even across blocks, so textual
 rendering and validation can use them as stable identifiers.
 
-Example:
+Example
+-------
 
+.. code-block:: python
+
+    import torch
     import torch.cfg as cfg
 
     x = cfg.Value("x", cfg.TensorSpec.from_tensor(torch.randn(2, 3)))
@@ -64,7 +68,6 @@ Example:
 
 from .fx import from_fx
 from .ir import (
-    _IR_PUBLIC_API as _IR_PUBLIC_API,
     Block,
     Branch,
     DictSpec,
@@ -87,5 +90,26 @@ from .ir import (
     literal,
 )
 
-
-__all__ = [*_IR_PUBLIC_API, "from_fx"]
+__all__ = [
+    "Block",
+    "Branch",
+    "DictSpec",
+    "Graph",
+    "Instruction",
+    "Jump",
+    "ListSpec",
+    "Literal",
+    "Location",
+    "ObjectSpec",
+    "OptionalSpec",
+    "Return",
+    "ScalarSpec",
+    "Spec",
+    "Successor",
+    "TensorSpec",
+    "TupleSpec",
+    "ValidationError",
+    "Value",
+    "literal",
+    "from_fx",
+]

--- a/torch/cfg/__init__.py
+++ b/torch/cfg/__init__.py
@@ -1,0 +1,110 @@
+r"""
+Typed control-flow graphs for PyTorch.
+
+``torch.cfg`` is a small, principled IR for analyses and transforms that need
+explicit basic blocks and typed values. Unlike FX nodes, semantic metadata lives
+in a single ``Value.spec`` field instead of an open-ended ``meta`` dictionary.
+
+Example:
+
+    import torch.cfg as cfg
+
+    x = cfg.Value("x", cfg.TensorSpec.from_tensor(torch.randn(2, 3)))
+    pred = cfg.Value("pred", cfg.ScalarSpec(bool))
+    negative_input = cfg.Value("negative_input", x.spec)
+    result = cfg.Value("result", x.spec)
+    neg = cfg.Value("neg", x.spec)
+
+    graph = cfg.Graph(
+        name="branchy",
+        entry="entry",
+        blocks=(
+            cfg.Block(
+                "entry",
+                parameters=(x,),
+                instructions=(
+                    cfg.Instruction(
+                        name="lt_zero",
+                        opcode="call_function",
+                        target=torch.ops.aten.lt.Scalar,
+                        inputs=(x, 0),
+                        outputs=(pred,),
+                    ),
+                ),
+                terminator=cfg.Branch(
+                    pred,
+                    cfg.Successor("negative", (x,)),
+                    cfg.Successor("done", (x,)),
+                ),
+            ),
+            cfg.Block(
+                "negative",
+                parameters=(negative_input,),
+                instructions=(
+                    cfg.Instruction(
+                        name="negate",
+                        opcode="call_function",
+                        target=torch.neg,
+                        inputs=(negative_input,),
+                        outputs=(neg,),
+                    ),
+                ),
+                terminator=cfg.Jump(cfg.Successor("done", (neg,))),
+            ),
+            cfg.Block(
+                "done",
+                parameters=(result,),
+                terminator=cfg.Return(result),
+            ),
+        ),
+    )
+"""
+
+from .fx import from_fx
+from .ir import (
+    Block,
+    Branch,
+    DictSpec,
+    Graph,
+    Instruction,
+    Jump,
+    ListSpec,
+    Literal,
+    Location,
+    ObjectSpec,
+    OptionalSpec,
+    Return,
+    ScalarSpec,
+    Spec,
+    Successor,
+    TensorSpec,
+    TupleSpec,
+    ValidationError,
+    Value,
+    literal,
+)
+
+
+__all__ = [
+    "Block",
+    "Branch",
+    "DictSpec",
+    "Graph",
+    "Instruction",
+    "Jump",
+    "ListSpec",
+    "Literal",
+    "Location",
+    "ObjectSpec",
+    "OptionalSpec",
+    "Return",
+    "ScalarSpec",
+    "Spec",
+    "Successor",
+    "TensorSpec",
+    "TupleSpec",
+    "ValidationError",
+    "Value",
+    "from_fx",
+    "literal",
+]

--- a/torch/cfg/__init__.py
+++ b/torch/cfg/__init__.py
@@ -76,6 +76,7 @@ from .ir import (
     Jump,
     ListSpec,
     Literal,
+    literal,
     Location,
     ObjectSpec,
     OptionalSpec,
@@ -87,8 +88,8 @@ from .ir import (
     TupleSpec,
     ValidationError,
     Value,
-    literal,
 )
+
 
 __all__ = [
     "Block",

--- a/torch/cfg/fx.py
+++ b/torch/cfg/fx.py
@@ -30,7 +30,9 @@ def from_fx(graph: FxGraph | GraphModule, *, name: str | None = None) -> Graph:
 
     The adapter normalizes FX's metadata conventions into a single ``Value.spec``
     field, so downstream code never needs to branch on ``node.meta["val"]``
-    versus ``node.meta["example_value"]``.
+    versus ``node.meta["example_value"]``. It intentionally preserves FX
+    operations verbatim inside one block; higher-order control-flow operators
+    remain opaque instructions until a dedicated structured lowering is added.
     """
 
     fx_graph = graph.graph if isinstance(graph, GraphModule) else graph

--- a/torch/cfg/fx.py
+++ b/torch/cfg/fx.py
@@ -98,7 +98,10 @@ def _convert_argument(argument: Any, values: dict[Node, Value]) -> Any:
     if isinstance(argument, list):
         return [_convert_argument(elem, values) for elem in argument]
     if isinstance(argument, dict):
-        return {str(key): _convert_argument(value, values) for key, value in argument.items()}
+        return {
+            str(key): _convert_argument(value, values)
+            for key, value in argument.items()
+        }
     if isinstance(argument, slice):
         return slice(
             _convert_argument(argument.start, values),

--- a/torch/cfg/fx.py
+++ b/torch/cfg/fx.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+from torch.fx import Graph as FxGraph, GraphModule, Node
+from torch.fx.passes.shape_prop import TensorMetadata
+
+from .ir import (
+    Block,
+    Graph,
+    Instruction,
+    Literal,
+    Location,
+    ObjectSpec,
+    Return,
+    ScalarSpec,
+    Spec,
+    TensorSpec,
+    Value,
+)
+
+
+__all__ = ["from_fx"]
+
+
+def from_fx(graph: FxGraph | GraphModule, *, name: str | None = None) -> Graph:
+    """
+    Lower a straight-line FX graph into a single-block CFG.
+
+    The adapter normalizes FX's metadata conventions into a single ``Value.spec``
+    field, so downstream code never needs to branch on ``node.meta["val"]``
+    versus ``node.meta["example_value"]``.
+    """
+
+    fx_graph = graph.graph if isinstance(graph, GraphModule) else graph
+    graph_name = name
+    if graph_name is None:
+        graph_name = getattr(graph, "__class__", type(graph)).__name__
+
+    values: dict[Node, Value] = {}
+    parameters: list[Value] = []
+    instructions: list[Instruction] = []
+    terminator: Return | None = None
+
+    for node in fx_graph.nodes:
+        if node.op == "placeholder":
+            value = Value(node.name, spec=_node_spec(node))
+            values[node] = value
+            parameters.append(value)
+            continue
+
+        if node.op == "output":
+            terminator = Return(_convert_argument(node.args[0], values))
+            continue
+
+        value = Value(node.name, spec=_node_spec(node))
+        values[node] = value
+        instructions.append(
+            Instruction(
+                name=node.name,
+                opcode=node.op,
+                target=node.target,
+                inputs=tuple(_convert_argument(arg, values) for arg in node.args),
+                attributes={
+                    key: _convert_argument(arg, values)
+                    for key, arg in node.kwargs.items()
+                },
+                outputs=(value,),
+                location=_node_location(node),
+            )
+        )
+
+    if terminator is None:
+        raise ValueError("FX graph is missing an output node")
+
+    return Graph(
+        name=graph_name,
+        entry="entry",
+        blocks=(
+            Block(
+                name="entry",
+                parameters=tuple(parameters),
+                instructions=tuple(instructions),
+                terminator=terminator,
+            ),
+        ),
+    )
+
+
+def _convert_argument(argument: Any, values: dict[Node, Value]) -> Any:
+    if isinstance(argument, Node):
+        return values[argument]
+    if isinstance(argument, tuple):
+        return tuple(_convert_argument(elem, values) for elem in argument)
+    if isinstance(argument, list):
+        return [_convert_argument(elem, values) for elem in argument]
+    if isinstance(argument, dict):
+        return {str(key): _convert_argument(value, values) for key, value in argument.items()}
+    if isinstance(argument, slice):
+        return slice(
+            _convert_argument(argument.start, values),
+            _convert_argument(argument.stop, values),
+            _convert_argument(argument.step, values),
+        )
+    return Literal(argument)
+
+
+def _node_location(node: Node) -> Location | None:
+    stack = node.meta.get("stack_trace")
+    if stack is None:
+        return None
+    return Location(stack=stack)
+
+
+def _node_spec(node: Node) -> Spec | None:
+    if "val" in node.meta:
+        return Spec.from_value(node.meta["val"])
+    if "example_value" in node.meta:
+        return Spec.from_value(node.meta["example_value"])
+    tensor_meta = node.meta.get("tensor_meta")
+    if isinstance(tensor_meta, TensorMetadata):
+        return TensorSpec(
+            shape=tuple(tensor_meta.shape),
+            dtype=tensor_meta.dtype,
+            device=torch.device("meta"),
+            stride=tuple(tensor_meta.stride),
+            requires_grad=tensor_meta.requires_grad,
+        )
+    if isinstance(node.type, type):
+        if issubclass(node.type, (bool, int, float, complex, str, bytes)):
+            return ScalarSpec(node.type)
+        return ObjectSpec(node.type)
+    return None

--- a/torch/cfg/ir.py
+++ b/torch/cfg/ir.py
@@ -9,31 +9,8 @@ import torch
 from torch.fx.immutable_collections import immutable_dict, immutable_list
 
 
-__all__ = [
-    "Block",
-    "Branch",
-    "DictSpec",
-    "Graph",
-    "Instruction",
-    "Jump",
-    "ListSpec",
-    "Literal",
-    "Location",
-    "ObjectSpec",
-    "OptionalSpec",
-    "Return",
-    "ScalarSpec",
-    "Spec",
-    "Successor",
-    "TensorSpec",
-    "TupleSpec",
-    "ValidationError",
-    "Value",
-    "literal",
-]
-
-
 Dimension: TypeAlias = int | torch.SymInt
+NestedSize: TypeAlias = tuple[tuple[Dimension, ...], ...]
 _SCALAR_TYPES = (
     bool,
     int,
@@ -91,31 +68,54 @@ class Spec(ABC):
 
 @dataclass(frozen=True, slots=True)
 class TensorSpec(Spec):
-    shape: tuple[Dimension, ...]
+    shape: tuple[Dimension, ...] | None
     dtype: torch.dtype
     device: torch.device
     stride: tuple[Dimension, ...] | None = None
+    nested_size: NestedSize | None = None
     requires_grad: bool = False
 
     @classmethod
     def from_tensor(cls, tensor: torch.Tensor) -> "TensorSpec":
+        shape: tuple[Dimension, ...] | None
+        nested_size: NestedSize | None = None
+        if tensor.is_nested:
+            try:
+                shape = tuple(tensor.shape)
+            except RuntimeError:
+                shape = None
+                nested_size = tuple(
+                    tuple(int(dim) for dim in size)
+                    for size in tensor._nested_tensor_size().tolist()
+                )
+        else:
+            shape = tuple(tensor.shape)
+
         stride = (
             None
             if tensor.is_sparse or tensor.is_nested
             else tuple(tensor.stride())
         )
         return cls(
-            shape=tuple(tensor.shape),
+            shape=shape,
             dtype=tensor.dtype,
             device=tensor.device,
             stride=stride,
+            nested_size=nested_size,
             requires_grad=tensor.requires_grad,
         )
 
     def format(self) -> str:
-        shape = ", ".join(str(dim) for dim in self.shape)
         dtype = str(self.dtype).removeprefix("torch.")
-        pieces = [f"dtype={dtype}", f"shape=({shape})", f"device={self.device}"]
+        pieces = [f"dtype={dtype}"]
+        if self.shape is not None:
+            shape = ", ".join(str(dim) for dim in self.shape)
+            pieces.append(f"shape=({shape})")
+        elif self.nested_size is not None:
+            pieces.append(f"nested_size={self.nested_size}")
+        else:
+            pieces.append("shape=<unknown>")
+        pieces.append(f"device={self.device}")
         if self.requires_grad:
             pieces.append("requires_grad=True")
         return f"Tensor[{', '.join(pieces)}]"

--- a/torch/cfg/ir.py
+++ b/torch/cfg/ir.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
-from typing import Any, TypeAlias
+from typing import Any, Iterable, Mapping, TypeAlias
 
 import torch
 from torch.fx.immutable_collections import immutable_dict, immutable_list
@@ -27,6 +26,30 @@ _SCALAR_TYPES = (
     torch.memory_format,
 )
 
+_IR_PUBLIC_API = (
+    "Block",
+    "Branch",
+    "DictSpec",
+    "Graph",
+    "Instruction",
+    "Jump",
+    "ListSpec",
+    "Literal",
+    "Location",
+    "ObjectSpec",
+    "OptionalSpec",
+    "Return",
+    "ScalarSpec",
+    "Spec",
+    "Successor",
+    "TensorSpec",
+    "TupleSpec",
+    "ValidationError",
+    "Value",
+    "literal",
+)
+__all__ = list(_IR_PUBLIC_API)
+
 
 class ValidationError(ValueError):
     """Raised when a :class:`Graph` violates CFG invariants."""
@@ -41,7 +64,7 @@ class Spec(ABC):
     """
 
     @staticmethod
-    def from_value(value: object) -> "Spec":
+    def from_value(value: object) -> Spec:
         if isinstance(value, torch.Tensor):
             return TensorSpec.from_tensor(value)
         if value is None:
@@ -76,7 +99,7 @@ class TensorSpec(Spec):
     requires_grad: bool = False
 
     @classmethod
-    def from_tensor(cls, tensor: torch.Tensor) -> "TensorSpec":
+    def from_tensor(cls, tensor: torch.Tensor) -> TensorSpec:
         shape: tuple[Dimension, ...] | None
         nested_size: NestedSize | None = None
         if tensor.is_nested:
@@ -84,6 +107,8 @@ class TensorSpec(Spec):
                 shape = tuple(tensor.shape)
             except RuntimeError:
                 shape = None
+                # Nested tensor sizes are still exposed through a private API
+                # until nested tensor metadata is fully stabilized.
                 nested_size = tuple(
                     tuple(int(dim) for dim in size)
                     for size in tensor._nested_tensor_size().tolist()
@@ -189,6 +214,7 @@ class Literal:
 
 def literal(value: object, spec: Spec | None = None) -> Literal:
     return Literal(value=value, spec=spec)
+
 
 @dataclass(frozen=True, slots=True)
 class Value:
@@ -380,6 +406,13 @@ class Block:
 
 @dataclass(frozen=True, slots=True)
 class Graph:
+    """
+    Immutable block-based CFG.
+
+    Value names are globally unique across the whole graph, even across blocks,
+    so textual rendering and validation can use them as stable identifiers.
+    """
+
     name: str
     entry: str
     blocks: tuple[Block, ...]
@@ -567,7 +600,7 @@ def _iter_values(argument: Argument) -> Iterable[Value]:
         return
     if isinstance(argument, Literal) or argument is None:
         return
-    if isinstance(argument, tuple) or isinstance(argument, list):
+    if isinstance(argument, (tuple, list)):
         for elem in argument:
             yield from _iter_values(elem)
         return

--- a/torch/cfg/ir.py
+++ b/torch/cfg/ir.py
@@ -1,0 +1,610 @@
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
+from typing import Any, TypeAlias
+
+import torch
+from torch.fx.immutable_collections import immutable_dict, immutable_list
+
+
+__all__ = [
+    "Block",
+    "Branch",
+    "DictSpec",
+    "Graph",
+    "Instruction",
+    "Jump",
+    "ListSpec",
+    "Literal",
+    "Location",
+    "ObjectSpec",
+    "OptionalSpec",
+    "Return",
+    "ScalarSpec",
+    "Spec",
+    "Successor",
+    "TensorSpec",
+    "TupleSpec",
+    "ValidationError",
+    "Value",
+    "literal",
+]
+
+
+Dimension: TypeAlias = int | torch.SymInt
+_ScalarValue: TypeAlias = (
+    bool
+    | int
+    | float
+    | complex
+    | str
+    | bytes
+    | torch.SymBool
+    | torch.SymFloat
+    | torch.SymInt
+    | torch.dtype
+    | torch.device
+    | torch.layout
+    | torch.memory_format
+)
+
+
+class ValidationError(ValueError):
+    """Raised when a :class:`Graph` violates CFG invariants."""
+
+
+class Spec:
+    """
+    A typed, normalized description of a value.
+
+    ``Spec`` intentionally replaces the ad hoc ``node.meta["val"]`` /
+    ``node.meta["example_value"]`` pattern with a single explicit field.
+    """
+
+    @staticmethod
+    def from_value(value: object) -> "Spec":
+        if isinstance(value, torch.Tensor):
+            return TensorSpec.from_tensor(value)
+        if value is None:
+            return OptionalSpec(None)
+        if isinstance(value, tuple):
+            return TupleSpec(tuple(Spec.from_value(elem) for elem in value))
+        if isinstance(value, list):
+            return ListSpec(tuple(Spec.from_value(elem) for elem in value))
+        if isinstance(value, dict):
+            return DictSpec(
+                tuple((str(key), Spec.from_value(elem)) for key, elem in value.items())
+            )
+        if isinstance(
+            value,
+            (
+                bool,
+                int,
+                float,
+                complex,
+                str,
+                bytes,
+                torch.SymBool,
+                torch.SymFloat,
+                torch.SymInt,
+                torch.dtype,
+                torch.device,
+                torch.layout,
+                torch.memory_format,
+            ),
+        ):
+            return ScalarSpec(type(value))
+        return ObjectSpec(type(value))
+
+    def format(self) -> str:
+        raise NotImplementedError
+
+    def __str__(self) -> str:
+        return self.format()
+
+
+@dataclass(frozen=True, slots=True)
+class TensorSpec(Spec):
+    shape: tuple[Dimension, ...]
+    dtype: torch.dtype
+    device: torch.device
+    stride: tuple[Dimension, ...] | None = None
+    requires_grad: bool = False
+
+    @classmethod
+    def from_tensor(cls, tensor: torch.Tensor) -> "TensorSpec":
+        stride = None if tensor.is_sparse else tuple(tensor.stride())
+        return cls(
+            shape=tuple(tensor.shape),
+            dtype=tensor.dtype,
+            device=tensor.device,
+            stride=stride,
+            requires_grad=tensor.requires_grad,
+        )
+
+    def format(self) -> str:
+        shape = ", ".join(str(dim) for dim in self.shape)
+        dtype = str(self.dtype).removeprefix("torch.")
+        pieces = [f"dtype={dtype}", f"shape=({shape})", f"device={self.device}"]
+        if self.requires_grad:
+            pieces.append("requires_grad=True")
+        return f"Tensor[{', '.join(pieces)}]"
+
+
+@dataclass(frozen=True, slots=True)
+class ScalarSpec(Spec):
+    python_type: type[Any]
+
+    def format(self) -> str:
+        return _qualified_name(self.python_type)
+
+
+@dataclass(frozen=True, slots=True)
+class TupleSpec(Spec):
+    elements: tuple[Spec, ...]
+
+    def format(self) -> str:
+        inner = ", ".join(elem.format() for elem in self.elements)
+        return f"tuple[{inner}]"
+
+
+@dataclass(frozen=True, slots=True)
+class ListSpec(Spec):
+    elements: tuple[Spec, ...]
+
+    def format(self) -> str:
+        inner = ", ".join(elem.format() for elem in self.elements)
+        return f"list[{inner}]"
+
+
+@dataclass(frozen=True, slots=True)
+class DictSpec(Spec):
+    entries: tuple[tuple[str, Spec], ...]
+
+    def format(self) -> str:
+        inner = ", ".join(f"{key}: {spec.format()}" for key, spec in self.entries)
+        return f"dict[{inner}]"
+
+
+@dataclass(frozen=True, slots=True)
+class OptionalSpec(Spec):
+    element: Spec | None
+
+    def format(self) -> str:
+        if self.element is None:
+            return "Optional[unknown]"
+        return f"Optional[{self.element.format()}]"
+
+
+@dataclass(frozen=True, slots=True)
+class ObjectSpec(Spec):
+    python_type: type[Any]
+
+    def format(self) -> str:
+        return _qualified_name(self.python_type)
+
+
+@dataclass(frozen=True, slots=True)
+class Literal:
+    value: object
+    spec: Spec | None = None
+
+    def __post_init__(self) -> None:
+        if self.spec is None:
+            object.__setattr__(self, "spec", Spec.from_value(self.value))
+
+    def __str__(self) -> str:
+        return repr(self.value)
+
+
+def literal(value: object, spec: Spec | None = None) -> Literal:
+    return Literal(value=value, spec=spec)
+
+
+# Normalized operands are pytrees whose leaves are ``Value`` or ``Literal``.
+Argument: TypeAlias = Any
+
+
+@dataclass(frozen=True, slots=True)
+class Value:
+    name: str
+    spec: Spec | None = None
+    doc: str | None = None
+
+    def __str__(self) -> str:
+        return f"%{self.name}"
+
+
+@dataclass(frozen=True, slots=True)
+class Location:
+    file: str | None = None
+    line: int | None = None
+    function: str | None = None
+    stack: str | None = None
+
+    def format(self) -> str:
+        if self.file is not None and self.line is not None:
+            prefix = f"{self.file}:{self.line}"
+            if self.function is not None:
+                return f"{prefix} in {self.function}"
+            return prefix
+        if self.function is not None:
+            return self.function
+        if self.stack is not None:
+            return self.stack.strip().splitlines()[-1]
+        return "<unknown>"
+
+
+@dataclass(frozen=True, slots=True)
+class Instruction:
+    name: str
+    opcode: str
+    target: object
+    inputs: tuple[Argument, ...] = ()
+    attributes: Mapping[str, Argument] = field(default_factory=immutable_dict)
+    outputs: tuple[Value, ...] = ()
+    location: Location | None = None
+    doc: str | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "inputs", tuple(_normalize_argument(arg) for arg in self.inputs))
+        object.__setattr__(
+            self,
+            "attributes",
+            immutable_dict(
+                {key: _normalize_argument(arg) for key, arg in self.attributes.items()}
+            ),
+        )
+        object.__setattr__(self, "outputs", tuple(self.outputs))
+
+    def format(self) -> str:
+        outputs = ", ".join(str(output) for output in self.outputs)
+        rendered_inputs = ", ".join(_format_argument(arg) for arg in self.inputs)
+        rendered_attributes = ", ".join(
+            f"{key}={_format_argument(arg)}" for key, arg in self.attributes.items()
+        )
+        rendered_args = ", ".join(
+            piece for piece in (rendered_inputs, rendered_attributes) if piece
+        )
+        target = _format_target(self.target)
+        operation = f"{self.opcode}[target={target}]({rendered_args})"
+        if outputs:
+            return f"{outputs} = {operation}"
+        return operation
+
+
+@dataclass(frozen=True, slots=True)
+class Successor:
+    block: str
+    arguments: tuple[Argument, ...] = ()
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "arguments", tuple(_normalize_argument(arg) for arg in self.arguments)
+        )
+
+    def format(self) -> str:
+        if not self.arguments:
+            return self.block
+        args = ", ".join(_format_argument(arg) for arg in self.arguments)
+        return f"{self.block}({args})"
+
+
+class Terminator:
+    def successors(self) -> tuple[Successor, ...]:
+        return ()
+
+    def references(self) -> tuple[Argument, ...]:
+        return ()
+
+    def format(self) -> str:
+        raise NotImplementedError
+
+
+@dataclass(frozen=True, slots=True)
+class Jump(Terminator):
+    target: Successor
+
+    def successors(self) -> tuple[Successor, ...]:
+        return (self.target,)
+
+    def references(self) -> tuple[Argument, ...]:
+        return self.target.arguments
+
+    def format(self) -> str:
+        return f"jump {self.target.format()}"
+
+
+@dataclass(frozen=True, slots=True)
+class Branch(Terminator):
+    condition: Argument
+    true_branch: Successor
+    false_branch: Successor
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "condition", _normalize_argument(self.condition))
+
+    def successors(self) -> tuple[Successor, ...]:
+        return (self.true_branch, self.false_branch)
+
+    def references(self) -> tuple[Argument, ...]:
+        return (self.condition, *self.true_branch.arguments, *self.false_branch.arguments)
+
+    def format(self) -> str:
+        return (
+            f"branch {_format_argument(self.condition)} -> "
+            f"{self.true_branch.format()}, {self.false_branch.format()}"
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class Return(Terminator):
+    value: Argument
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "value", _normalize_argument(self.value))
+
+    def references(self) -> tuple[Argument, ...]:
+        return (self.value,)
+
+    def format(self) -> str:
+        return f"return {_format_argument(self.value)}"
+
+
+@dataclass(frozen=True, slots=True)
+class Block:
+    name: str
+    parameters: tuple[Value, ...] = ()
+    instructions: tuple[Instruction, ...] = ()
+    terminator: Terminator = field(default_factory=lambda: Return(None))
+    doc: str | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "parameters", tuple(self.parameters))
+        object.__setattr__(self, "instructions", tuple(self.instructions))
+
+    def format(self) -> str:
+        header = ", ".join(_format_value(value) for value in self.parameters)
+        lines = [f"block {self.name}({header}):"]
+        for instruction in self.instructions:
+            lines.append(f"  {instruction.format()}")
+        lines.append(f"  {self.terminator.format()}")
+        return "\n".join(lines)
+
+
+@dataclass(frozen=True, slots=True)
+class Graph:
+    name: str
+    entry: str
+    blocks: tuple[Block, ...]
+    doc: str | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "blocks", tuple(self.blocks))
+        self.validate()
+
+    def block(self, name: str) -> Block:
+        for block in self.blocks:
+            if block.name == name:
+                return block
+        raise KeyError(f"Unknown block {name!r}")
+
+    def validate(self) -> None:
+        if not self.name:
+            raise ValidationError("graph name must be non-empty")
+        if not self.blocks:
+            raise ValidationError("graph must contain at least one block")
+
+        block_map: dict[str, Block] = {}
+        for block in self.blocks:
+            if not block.name:
+                raise ValidationError("block name must be non-empty")
+            if block.name in block_map:
+                raise ValidationError(f"duplicate block name {block.name!r}")
+            block_map[block.name] = block
+
+        if self.entry not in block_map:
+            raise ValidationError(f"entry block {self.entry!r} does not exist")
+
+        values_by_name: dict[str, Value] = {}
+        for block in self.blocks:
+            local_scope: dict[str, Value] = {}
+            for parameter in block.parameters:
+                _register_value(
+                    parameter,
+                    where=f"block {block.name!r} parameter",
+                    local_scope=local_scope,
+                    global_scope=values_by_name,
+                )
+
+            for instruction in block.instructions:
+                if not instruction.name:
+                    raise ValidationError(
+                        f"block {block.name!r} contains an instruction with an empty name"
+                    )
+                for argument in instruction.inputs:
+                    _validate_argument(
+                        argument,
+                        where=f"instruction {instruction.name!r}",
+                        block_name=block.name,
+                        local_scope=local_scope,
+                        global_scope=values_by_name,
+                    )
+                for key, argument in instruction.attributes.items():
+                    _validate_argument(
+                        argument,
+                        where=f"instruction {instruction.name!r} attribute {key!r}",
+                        block_name=block.name,
+                        local_scope=local_scope,
+                        global_scope=values_by_name,
+                    )
+                for output in instruction.outputs:
+                    _register_value(
+                        output,
+                        where=f"instruction {instruction.name!r}",
+                        local_scope=local_scope,
+                        global_scope=values_by_name,
+                    )
+
+            for argument in block.terminator.references():
+                _validate_argument(
+                    argument,
+                    where=f"terminator of block {block.name!r}",
+                    block_name=block.name,
+                    local_scope=local_scope,
+                    global_scope=values_by_name,
+                )
+
+            for successor in block.terminator.successors():
+                if successor.block not in block_map:
+                    raise ValidationError(
+                        f"block {block.name!r} jumps to unknown block {successor.block!r}"
+                    )
+                target = block_map[successor.block]
+                if len(successor.arguments) != len(target.parameters):
+                    raise ValidationError(
+                        f"jump to block {successor.block!r} expects {len(target.parameters)} "
+                        f"arguments but received {len(successor.arguments)}"
+                    )
+
+    def format(self) -> str:
+        sections = [f"graph {self.name}:"]
+        for block in self.blocks:
+            sections.append(block.format())
+        return "\n\n".join(sections)
+
+    def __str__(self) -> str:
+        return self.format()
+
+
+def _qualified_name(obj: type[Any]) -> str:
+    module = getattr(obj, "__module__", None)
+    qualname = getattr(obj, "__qualname__", None)
+    if module is None or qualname is None or module == "builtins":
+        return getattr(obj, "__name__", repr(obj))
+    return f"{module}.{qualname}"
+
+
+def _format_target(target: object) -> str:
+    if isinstance(target, str):
+        return target
+    module = getattr(target, "__module__", None)
+    qualname = getattr(target, "__qualname__", None)
+    if module is not None and qualname is not None:
+        return f"{module}.{qualname}"
+    name = getattr(target, "__name__", None)
+    if module is not None and name is not None:
+        return f"{module}.{name}"
+    return repr(target)
+
+
+def _format_value(value: Value) -> str:
+    if value.spec is None:
+        return str(value)
+    return f"{value}: {value.spec.format()}"
+
+
+def _format_argument(argument: Argument) -> str:
+    if isinstance(argument, Value):
+        return str(argument)
+    if isinstance(argument, Literal):
+        return str(argument)
+    if argument is None:
+        return "None"
+    if isinstance(argument, tuple):
+        trailing_comma = "," if len(argument) == 1 else ""
+        return f"({', '.join(_format_argument(elem) for elem in argument)}{trailing_comma})"
+    if isinstance(argument, list):
+        return f"[{', '.join(_format_argument(elem) for elem in argument)}]"
+    if isinstance(argument, dict):
+        return "{" + ", ".join(
+            f"{key}: {_format_argument(value)}" for key, value in argument.items()
+        ) + "}"
+    if isinstance(argument, slice):
+        return (
+            "slice("
+            f"{_format_argument(argument.start)}, "
+            f"{_format_argument(argument.stop)}, "
+            f"{_format_argument(argument.step)})"
+        )
+    raise TypeError(f"Unexpected argument node: {type(argument)!r}")
+
+
+def _normalize_argument(argument: object) -> Argument:
+    if isinstance(argument, (Value, Literal)) or argument is None:
+        return argument
+    if isinstance(argument, tuple):
+        return tuple(_normalize_argument(elem) for elem in argument)
+    if isinstance(argument, list):
+        return immutable_list(_normalize_argument(elem) for elem in argument)
+    if isinstance(argument, dict):
+        return immutable_dict(
+            {str(key): _normalize_argument(value) for key, value in argument.items()}
+        )
+    if isinstance(argument, slice):
+        return slice(
+            _normalize_argument(argument.start),
+            _normalize_argument(argument.stop),
+            _normalize_argument(argument.step),
+        )
+    return Literal(argument)
+
+
+def _iter_values(argument: Argument) -> Iterable[Value]:
+    if isinstance(argument, Value):
+        yield argument
+        return
+    if isinstance(argument, Literal) or argument is None:
+        return
+    if isinstance(argument, tuple) or isinstance(argument, list):
+        for elem in argument:
+            yield from _iter_values(elem)
+        return
+    if isinstance(argument, dict):
+        for elem in argument.values():
+            yield from _iter_values(elem)
+        return
+    if isinstance(argument, slice):
+        yield from _iter_values(argument.start)
+        yield from _iter_values(argument.stop)
+        yield from _iter_values(argument.step)
+        return
+    raise TypeError(f"Unexpected argument node: {type(argument)!r}")
+
+
+def _register_value(
+    value: Value,
+    *,
+    where: str,
+    local_scope: dict[str, Value],
+    global_scope: dict[str, Value],
+) -> None:
+    if not value.name:
+        raise ValidationError(f"{where} defines a value with an empty name")
+    if value.name in local_scope:
+        raise ValidationError(f"{where} redefines value {value.name!r} in the same block")
+    if value.name in global_scope:
+        raise ValidationError(f"{where} collides with existing value {value.name!r}")
+    local_scope[value.name] = value
+    global_scope[value.name] = value
+
+
+def _validate_argument(
+    argument: Argument,
+    *,
+    where: str,
+    block_name: str,
+    local_scope: dict[str, Value],
+    global_scope: dict[str, Value],
+) -> None:
+    for value in _iter_values(argument):
+        if value.name not in local_scope:
+            raise ValidationError(
+                f"{where} in block {block_name!r} references undefined value {value.name!r}"
+            )
+        if global_scope.get(value.name) != value:
+            raise ValidationError(
+                f"{where} in block {block_name!r} references a non-canonical value object "
+                f"for {value.name!r}"
+            )

--- a/torch/cfg/ir.py
+++ b/torch/cfg/ir.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, TypeAlias
+from typing import Any, TYPE_CHECKING, TypeAlias
+
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping

--- a/torch/cfg/ir.py
+++ b/torch/cfg/ir.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Any, Iterable, Mapping, TypeAlias
+from typing import TYPE_CHECKING, Any, TypeAlias
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping
 
 import torch
 from torch.fx.immutable_collections import immutable_dict, immutable_list
@@ -117,9 +120,7 @@ class TensorSpec(Spec):
             shape = tuple(tensor.shape)
 
         stride = (
-            None
-            if tensor.is_sparse or tensor.is_nested
-            else tuple(tensor.stride())
+            None if tensor.is_sparse or tensor.is_nested else tuple(tensor.stride())
         )
         return cls(
             shape=shape,

--- a/torch/cfg/ir.py
+++ b/torch/cfg/ir.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
 from typing import Any, TypeAlias
@@ -33,20 +34,20 @@ __all__ = [
 
 
 Dimension: TypeAlias = int | torch.SymInt
-_ScalarValue: TypeAlias = (
-    bool
-    | int
-    | float
-    | complex
-    | str
-    | bytes
-    | torch.SymBool
-    | torch.SymFloat
-    | torch.SymInt
-    | torch.dtype
-    | torch.device
-    | torch.layout
-    | torch.memory_format
+_SCALAR_TYPES = (
+    bool,
+    int,
+    float,
+    complex,
+    str,
+    bytes,
+    torch.SymBool,
+    torch.SymFloat,
+    torch.SymInt,
+    torch.dtype,
+    torch.device,
+    torch.layout,
+    torch.memory_format,
 )
 
 
@@ -54,7 +55,7 @@ class ValidationError(ValueError):
     """Raised when a :class:`Graph` violates CFG invariants."""
 
 
-class Spec:
+class Spec(ABC):
     """
     A typed, normalized description of a value.
 
@@ -76,27 +77,11 @@ class Spec:
             return DictSpec(
                 tuple((str(key), Spec.from_value(elem)) for key, elem in value.items())
             )
-        if isinstance(
-            value,
-            (
-                bool,
-                int,
-                float,
-                complex,
-                str,
-                bytes,
-                torch.SymBool,
-                torch.SymFloat,
-                torch.SymInt,
-                torch.dtype,
-                torch.device,
-                torch.layout,
-                torch.memory_format,
-            ),
-        ):
+        if isinstance(value, _SCALAR_TYPES):
             return ScalarSpec(type(value))
         return ObjectSpec(type(value))
 
+    @abstractmethod
     def format(self) -> str:
         raise NotImplementedError
 
@@ -114,7 +99,11 @@ class TensorSpec(Spec):
 
     @classmethod
     def from_tensor(cls, tensor: torch.Tensor) -> "TensorSpec":
-        stride = None if tensor.is_sparse else tuple(tensor.stride())
+        stride = (
+            None
+            if tensor.is_sparse or tensor.is_nested
+            else tuple(tensor.stride())
+        )
         return cls(
             shape=tuple(tensor.shape),
             dtype=tensor.dtype,
@@ -201,11 +190,6 @@ class Literal:
 def literal(value: object, spec: Spec | None = None) -> Literal:
     return Literal(value=value, spec=spec)
 
-
-# Normalized operands are pytrees whose leaves are ``Value`` or ``Literal``.
-Argument: TypeAlias = Any
-
-
 @dataclass(frozen=True, slots=True)
 class Value:
     name: str
@@ -214,6 +198,18 @@ class Value:
 
     def __str__(self) -> str:
         return f"%{self.name}"
+
+
+# Normalized operands are pytrees whose leaves are ``Value`` or ``Literal``.
+Argument: TypeAlias = (
+    Value
+    | Literal
+    | None
+    | tuple["Argument", ...]
+    | list["Argument"]
+    | dict[str, "Argument"]
+    | slice
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -248,7 +244,11 @@ class Instruction:
     doc: str | None = None
 
     def __post_init__(self) -> None:
-        object.__setattr__(self, "inputs", tuple(_normalize_argument(arg) for arg in self.inputs))
+        object.__setattr__(
+            self,
+            "inputs",
+            tuple(_normalize_argument(arg) for arg in self.inputs),
+        )
         object.__setattr__(
             self,
             "attributes",
@@ -291,19 +291,20 @@ class Successor:
         return f"{self.block}({args})"
 
 
-class Terminator:
+class _Terminator(ABC):
     def successors(self) -> tuple[Successor, ...]:
         return ()
 
     def references(self) -> tuple[Argument, ...]:
         return ()
 
+    @abstractmethod
     def format(self) -> str:
         raise NotImplementedError
 
 
 @dataclass(frozen=True, slots=True)
-class Jump(Terminator):
+class Jump(_Terminator):
     target: Successor
 
     def successors(self) -> tuple[Successor, ...]:
@@ -317,7 +318,7 @@ class Jump(Terminator):
 
 
 @dataclass(frozen=True, slots=True)
-class Branch(Terminator):
+class Branch(_Terminator):
     condition: Argument
     true_branch: Successor
     false_branch: Successor
@@ -329,7 +330,11 @@ class Branch(Terminator):
         return (self.true_branch, self.false_branch)
 
     def references(self) -> tuple[Argument, ...]:
-        return (self.condition, *self.true_branch.arguments, *self.false_branch.arguments)
+        return (
+            self.condition,
+            *self.true_branch.arguments,
+            *self.false_branch.arguments,
+        )
 
     def format(self) -> str:
         return (
@@ -339,7 +344,7 @@ class Branch(Terminator):
 
 
 @dataclass(frozen=True, slots=True)
-class Return(Terminator):
+class Return(_Terminator):
     value: Argument
 
     def __post_init__(self) -> None:
@@ -357,7 +362,7 @@ class Block:
     name: str
     parameters: tuple[Value, ...] = ()
     instructions: tuple[Instruction, ...] = ()
-    terminator: Terminator = field(default_factory=lambda: Return(None))
+    terminator: _Terminator = field(default_factory=lambda: Return(None))
     doc: str | None = None
 
     def __post_init__(self) -> None:
@@ -421,7 +426,8 @@ class Graph:
             for instruction in block.instructions:
                 if not instruction.name:
                     raise ValidationError(
-                        f"block {block.name!r} contains an instruction with an empty name"
+                        f"block {block.name!r} contains an instruction "
+                        "with an empty name"
                     )
                 for argument in instruction.inputs:
                     _validate_argument(
@@ -459,13 +465,15 @@ class Graph:
             for successor in block.terminator.successors():
                 if successor.block not in block_map:
                     raise ValidationError(
-                        f"block {block.name!r} jumps to unknown block {successor.block!r}"
+                        f"block {block.name!r} jumps to unknown block "
+                        f"{successor.block!r}"
                     )
                 target = block_map[successor.block]
                 if len(successor.arguments) != len(target.parameters):
                     raise ValidationError(
-                        f"jump to block {successor.block!r} expects {len(target.parameters)} "
-                        f"arguments but received {len(successor.arguments)}"
+                        f"jump to block {successor.block!r} expects "
+                        f"{len(target.parameters)} arguments but received "
+                        f"{len(successor.arguments)}"
                     )
 
     def format(self) -> str:
@@ -514,13 +522,15 @@ def _format_argument(argument: Argument) -> str:
         return "None"
     if isinstance(argument, tuple):
         trailing_comma = "," if len(argument) == 1 else ""
-        return f"({', '.join(_format_argument(elem) for elem in argument)}{trailing_comma})"
+        rendered = ", ".join(_format_argument(elem) for elem in argument)
+        return f"({rendered}{trailing_comma})"
     if isinstance(argument, list):
         return f"[{', '.join(_format_argument(elem) for elem in argument)}]"
     if isinstance(argument, dict):
-        return "{" + ", ".join(
+        rendered_items = ", ".join(
             f"{key}: {_format_argument(value)}" for key, value in argument.items()
-        ) + "}"
+        )
+        return "{" + rendered_items + "}"
     if isinstance(argument, slice):
         return (
             "slice("
@@ -583,7 +593,9 @@ def _register_value(
     if not value.name:
         raise ValidationError(f"{where} defines a value with an empty name")
     if value.name in local_scope:
-        raise ValidationError(f"{where} redefines value {value.name!r} in the same block")
+        raise ValidationError(
+            f"{where} redefines value {value.name!r} in the same block"
+        )
     if value.name in global_scope:
         raise ValidationError(f"{where} collides with existing value {value.name!r}")
     local_scope[value.name] = value
@@ -601,10 +613,12 @@ def _validate_argument(
     for value in _iter_values(argument):
         if value.name not in local_scope:
             raise ValidationError(
-                f"{where} in block {block_name!r} references undefined value {value.name!r}"
+                f"{where} in block {block_name!r} references undefined value "
+                f"{value.name!r}"
             )
         if global_scope.get(value.name) != value:
             raise ValidationError(
-                f"{where} in block {block_name!r} references a non-canonical value object "
+                f"{where} in block {block_name!r} references a non-canonical "
+                f"value object "
                 f"for {value.name!r}"
             )


### PR DESCRIPTION
## Summary
- introduce a new public `torch.cfg` package for immutable control-flow graphs with explicit blocks, terminators, and typed SSA values
- normalize FX metadata behind a single `Value.spec` field plus a `from_fx()` adapter for straight-line FX graphs
- represent irregular nested tensor sizes explicitly in `TensorSpec` instead of assuming every tensor has a rectangular `shape`
- add focused tests for validation, formatting, FX lowering, and the remaining metadata/error fallback paths

## Root Cause
FX is a good linear graph IR, but it has no first-class control-flow surface and downstream passes often have to branch on ad hoc metadata conventions like `node.meta["val"]` versus `node.meta["example_value"]`. That makes analyses harder to reason about and makes APIs feel under-specified.

## Proposed Fix
Add a foundational `torch.cfg` abstraction with immutable graph objects, strict validation rules, explicit block successors/terminators, and typed `Spec` objects carried directly by values. The FX adapter collapses the existing FX metadata variants into that single typed surface instead of exposing the metadata dict downstream, and `TensorSpec` now models irregular nested-tensor sizes without forcing them through a rectangular `shape` field.

## Why This Is The Right Long Term Fix
This separates semantic IR state from incidental per-node metadata, gives control flow a first-class representation instead of encoding it implicitly around FX, and provides a clean migration path from existing FX graphs through `from_fx()` without forcing new consumers to depend on historical metadata key conventions. Modeling irregular nested sizes explicitly is also the right direction for a strict IR surface: it avoids lying about nested tensors that do not have a single rectangular shape.

## Validation
- `python3 -m compileall torch/cfg test/test_cfg.py`
- `python3 -m py_compile torch/cfg/__init__.py torch/cfg/ir.py torch/cfg/fx.py test/test_cfg.py`
- `/tmp/pytorch-cfg-venv/bin/python ...` harness that imports the branch's `torch.cfg` modules against a CPU torch wheel and runs `test/test_cfg.py` end-to-end (`10` tests passed)

Drafted via Codex, published after manual review by @bobrenjc93
