### PR TITLE
Make native_functions codegen mappings explicit

### DIFF
--- a/tools/test/test_codegen.py
+++ b/tools/test/test_codegen.py
@@ -17,6 +17,7 @@ from torchgen.api.types import (
 from torchgen.context import native_function_manager
 from torchgen.gen import (
     compute_declaration_yaml,
+    compute_registration_declarations,
     get_native_function_declarations,
     get_native_function_schema_registrations,
     LineLoader,
@@ -407,21 +408,48 @@ class TestNativeFunctionCodegenInfo(unittest.TestCase):
             valid_tags=set(),
         )
 
-        declaration = compute_declaration_yaml(native_function)
+        declaration = typing.cast(
+            dict[str, object], compute_declaration_yaml(native_function)
+        )
+        generated_headers = typing.cast(
+            dict[str, dict[str, str]], declaration["generated_headers"]
+        )
+        cpp_entry_points = typing.cast(
+            dict[str, object], declaration["cpp_entry_points"]
+        )
+        dispatcher_entry = typing.cast(dict[str, str], cpp_entry_points["dispatcher"])
+        operators_api_entry = typing.cast(
+            dict[str, str], cpp_entry_points["operators_api"]
+        )
+        function_entries = typing.cast(
+            list[dict[str, object]], cpp_entry_points["functions"]
+        )
         self.assertEqual(
-            declaration["generated_headers"]["per_operator"]["functions"],
+            generated_headers["per_operator"]["functions"],
             "ATen/ops/op.h",
         )
         self.assertEqual(
-            declaration["cpp_entry_points"]["dispatcher"]["name"],
+            generated_headers["per_operator"]["operators"],
+            "ATen/ops/op_ops.h",
+        )
+        self.assertEqual(
+            generated_headers["per_operator"]["native"],
+            "ATen/ops/op_native.h",
+        )
+        self.assertEqual(
+            generated_headers["aggregated"]["redispatch_functions"],
+            "ATen/RedispatchFunctions.h",
+        )
+        self.assertEqual(
+            dispatcher_entry["name"],
             "op_out",
         )
         self.assertEqual(
-            declaration["cpp_entry_points"]["operators_api"]["class"],
+            operators_api_entry["class"],
             "at::_ops::op_out",
         )
         self.assertEqual(
-            [entry["name"] for entry in declaration["cpp_entry_points"]["functions"]],
+            [typing.cast(str, entry["name"]) for entry in function_entries],
             ["op_out", "op_outf"],
         )
 
@@ -437,22 +465,97 @@ class TestNativeFunctionCodegenInfo(unittest.TestCase):
         )
 
         info = NativeFunctionCodegenInfo(native_function)
+        generated_headers = typing.cast(
+            dict[str, dict[str, str]], info.generated_headers()
+        )
+        cpp_entry_points = typing.cast(
+            dict[str, object], info.generated_cpp_entry_points()
+        )
+        operators_api_entry = typing.cast(
+            dict[str, str], cpp_entry_points["operators_api"]
+        )
+        method_entries = typing.cast(
+            list[dict[str, object]], cpp_entry_points["methods"]
+        )
         self.assertEqual(
-            info.generated_headers()["aggregated"]["methods"],
+            generated_headers["aggregated"]["methods"],
             "ATen/core/TensorBody.h",
         )
         self.assertEqual(
-            info.generated_cpp_entry_points()["operators_api"]["call"],
+            operators_api_entry["call"],
             "at::_ops::op::call",
         )
         self.assertEqual(
-            [entry["name"] for entry in info.generated_cpp_entry_points()["methods"]],
+            [typing.cast(str, entry["name"]) for entry in method_entries],
             ["op"],
         )
         self.assertTrue(
-            "Tensor::op("
-            in info.generated_cpp_entry_points()["methods"][0]["signature"]
+            "Tensor::op(" in typing.cast(str, method_entries[0]["signature"])
         )
+
+    def test_dispatcher_signatures_preserve_symint_variants(self) -> None:
+        native_function, _ = NativeFunction.from_yaml(
+            {
+                "func": "op(Tensor self, SymInt dim) -> Tensor",
+                "dispatch": {"CPU": "op"},
+            },
+            loc=Location(__file__, 1),
+            valid_tags=set(),
+        )
+
+        info = NativeFunctionCodegenInfo(native_function)
+        self.assertIn(
+            "c10::SymInt dim",
+            info.dispatcher_signature().decl(name=info.dispatcher_name),
+        )
+        self.assertIn(
+            "int64_t dim",
+            info.dispatcher_signature(symint=False).decl(name=info.dispatcher_name),
+        )
+
+    def test_cpp_signature_group_defaults_to_manual_cpp_binding(self) -> None:
+        native_function, _ = NativeFunction.from_yaml(
+            {
+                "func": "op(Tensor self) -> Tensor",
+                "manual_cpp_binding": True,
+            },
+            loc=Location(__file__, 1),
+            valid_tags=set(),
+        )
+
+        info = NativeFunctionCodegenInfo(native_function)
+        self.assertEqual(
+            [sig.name() for sig in info.function_cpp_signature_group().signatures()],
+            ["__dispatch_op"],
+        )
+
+    def test_registration_declarations_include_operators_api_breadcrumb(self) -> None:
+        native_function, backend_index = NativeFunction.from_yaml(
+            {
+                "func": "op(Tensor self) -> Tensor",
+                "dispatch": {"CPU": "op"},
+            },
+            loc=Location(__file__, 1),
+            valid_tags=set(),
+        )
+        backend_metadata: dict[DispatchKey, dict[OperatorName, BackendMetadata]] = {
+            DispatchKey.CPU: {}
+        }
+        BackendIndex.grow_index(backend_metadata, backend_index)
+        backend_indices = {
+            DispatchKey.CPU: BackendIndex(
+                dispatch_key=DispatchKey.CPU,
+                use_out_as_primary=True,
+                external=False,
+                device_guard=False,
+                index=backend_metadata[DispatchKey.CPU],
+            )
+        }
+
+        registration = compute_registration_declarations(
+            native_function, backend_indices
+        )
+        self.assertIn('"operators_api": "at::_ops::op"', registration)
 
 
 # Test for native_function_generation

--- a/tools/test/test_codegen.py
+++ b/tools/test/test_codegen.py
@@ -9,9 +9,14 @@ import yaml
 from tools.autograd import gen_autograd_functions, load_derivatives
 
 from torchgen import dest
-from torchgen.api.types import CppSignatureGroup, DispatcherSignature
+from torchgen.api.types import (
+    CppSignatureGroup,
+    DispatcherSignature,
+    NativeFunctionCodegenInfo,
+)
 from torchgen.context import native_function_manager
 from torchgen.gen import (
+    compute_declaration_yaml,
     get_native_function_declarations,
     get_native_function_schema_registrations,
     LineLoader,
@@ -389,6 +394,65 @@ TORCH_API bool kernel_1();
 } // namespace at
         """
         self.assertEqual("\n".join(declaration), target)
+
+
+class TestNativeFunctionCodegenInfo(unittest.TestCase):
+    def test_declarations_yaml_includes_cpp_entry_points(self) -> None:
+        native_function, _ = NativeFunction.from_yaml(
+            {
+                "func": "op.out(Tensor self, *, Tensor(a!) out) -> Tensor(a!)",
+                "dispatch": {"CPU": "op_out"},
+            },
+            loc=Location(__file__, 1),
+            valid_tags=set(),
+        )
+
+        declaration = compute_declaration_yaml(native_function)
+        self.assertEqual(
+            declaration["generated_headers"]["per_operator"]["functions"],
+            "ATen/ops/op.h",
+        )
+        self.assertEqual(
+            declaration["cpp_entry_points"]["dispatcher"]["name"],
+            "op_out",
+        )
+        self.assertEqual(
+            declaration["cpp_entry_points"]["operators_api"]["class"],
+            "at::_ops::op_out",
+        )
+        self.assertEqual(
+            [entry["name"] for entry in declaration["cpp_entry_points"]["functions"]],
+            ["op_out", "op_outf"],
+        )
+
+    def test_method_variants_report_tensor_method_mapping(self) -> None:
+        native_function, _ = NativeFunction.from_yaml(
+            {
+                "func": "op(Tensor self, Tensor other) -> Tensor",
+                "variants": "function, method",
+                "dispatch": {"CPU": "op"},
+            },
+            loc=Location(__file__, 1),
+            valid_tags=set(),
+        )
+
+        info = NativeFunctionCodegenInfo(native_function)
+        self.assertEqual(
+            info.generated_headers()["aggregated"]["methods"],
+            "ATen/core/TensorBody.h",
+        )
+        self.assertEqual(
+            info.generated_cpp_entry_points()["operators_api"]["call"],
+            "at::_ops::op::call",
+        )
+        self.assertEqual(
+            [entry["name"] for entry in info.generated_cpp_entry_points()["methods"]],
+            ["op"],
+        )
+        self.assertTrue(
+            "Tensor::op("
+            in info.generated_cpp_entry_points()["methods"][0]["signature"]
+        )
 
 
 # Test for native_function_generation

--- a/torchgen/api/types/signatures.py
+++ b/torchgen/api/types/signatures.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections import OrderedDict
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -290,6 +291,161 @@ class NativeSignature:
 
 
 @dataclass(frozen=True)
+class NativeFunctionCodegenInfo:
+    """
+    Centralizes how one native_functions.yaml entry fans out into generated C++ APIs.
+
+    This is the place to answer questions like:
+      aten::add.Tensor -> dispatcher wrapper: add_Tensor
+                       -> at::_ops handle: at::_ops::add_Tensor::{call, redispatch}
+                       -> public C++ API: at::add / Tensor::add
+    """
+
+    f: NativeFunction
+
+    @property
+    def func(self) -> FunctionSchema:
+        return self.f.func
+
+    @property
+    def schema(self) -> str:
+        return f"aten::{self.func}"
+
+    @property
+    def root_name(self) -> str:
+        return self.f.root_name
+
+    @property
+    def unambiguous_name(self) -> str:
+        return self.func.name.unambiguous_name()
+
+    @property
+    def dispatcher_name(self) -> str:
+        return dispatcher.name(self.func)
+
+    @property
+    def operators_api_name(self) -> str:
+        return f"at::_ops::{self.unambiguous_name}"
+
+    def dispatcher_signature(
+        self, *, prefix: str = "", symint: bool = True
+    ) -> DispatcherSignature:
+        return DispatcherSignature.from_schema(
+            self.func, prefix=prefix, symint=symint
+        )
+
+    def cpp_signature_group(
+        self, *, method: bool, fallback_binding: bool | None = None
+    ) -> CppSignatureGroup:
+        if fallback_binding is None:
+            fallback_binding = self.f.manual_cpp_binding
+        return CppSignatureGroup.from_native_function(
+            self.f, method=method, fallback_binding=fallback_binding
+        )
+
+    def function_cpp_signature_group(
+        self, *, fallback_binding: bool | None = None
+    ) -> CppSignatureGroup:
+        return self.cpp_signature_group(
+            method=False, fallback_binding=fallback_binding
+        )
+
+    def method_cpp_signature_group(
+        self, *, fallback_binding: bool | None = None
+    ) -> CppSignatureGroup | None:
+        if Variant.method not in self.f.variants:
+            return None
+        return self.cpp_signature_group(method=True, fallback_binding=fallback_binding)
+
+    def generated_headers(self) -> dict[str, object]:
+        aggregated_headers: OrderedDict[str, str] = OrderedDict(
+            [
+                ("operators", "ATen/Operators.h"),
+                ("functions", "ATen/Functions.h"),
+                ("redispatch_functions", "ATen/RedispatchFunctions.h"),
+                ("native", "ATen/NativeFunctions.h"),
+            ]
+        )
+        if Variant.method in self.f.variants:
+            aggregated_headers["methods"] = "ATen/core/TensorBody.h"
+
+        per_operator_headers: OrderedDict[str, str] = OrderedDict(
+            [
+                ("operators", f"ATen/ops/{self.root_name}_ops.h"),
+                ("functions", f"ATen/ops/{self.root_name}.h"),
+                ("native", f"ATen/ops/{self.root_name}_native.h"),
+            ]
+        )
+
+        return OrderedDict(
+            [
+                ("aggregated", aggregated_headers),
+                ("per_operator", per_operator_headers),
+            ]
+        )
+
+    @staticmethod
+    def _cpp_api_entry(
+        sig: CppSignature, *, name_prefix: str
+    ) -> OrderedDict[str, object]:
+        return OrderedDict(
+            [
+                ("name", sig.name()),
+                ("faithful", sig.faithful),
+                ("symint", sig.symint),
+                ("signature", sig.decl(name=f"{name_prefix}{sig.name()}")),
+            ]
+        )
+
+    def generated_cpp_entry_points(self) -> dict[str, object]:
+        dispatcher_sig = self.dispatcher_signature()
+        method_sig_group = self.method_cpp_signature_group()
+
+        return OrderedDict(
+            [
+                (
+                    "dispatcher",
+                    OrderedDict(
+                        [
+                            ("name", self.dispatcher_name),
+                            (
+                                "signature",
+                                dispatcher_sig.decl(name=self.dispatcher_name),
+                            ),
+                        ]
+                    ),
+                ),
+                (
+                    "operators_api",
+                    OrderedDict(
+                        [
+                            ("class", self.operators_api_name),
+                            ("call", f"{self.operators_api_name}::call"),
+                            ("redispatch", f"{self.operators_api_name}::redispatch"),
+                        ]
+                    ),
+                ),
+                (
+                    "functions",
+                    [
+                        self._cpp_api_entry(sig, name_prefix="at::")
+                        for sig in self.function_cpp_signature_group().signatures()
+                    ],
+                ),
+                (
+                    "methods",
+                    []
+                    if method_sig_group is None
+                    else [
+                        self._cpp_api_entry(sig, name_prefix="Tensor::")
+                        for sig in method_sig_group.signatures()
+                    ],
+                ),
+            ]
+        )
+
+
+@dataclass(frozen=True)
 class ViewInverseSignature:
     g: NativeFunctionsViewGroup
 
@@ -356,3 +512,4 @@ from torchgen.api import (
     structured,
     translate,
 )
+from torchgen.model import Variant

--- a/torchgen/api/types/signatures.py
+++ b/torchgen/api/types/signatures.py
@@ -330,9 +330,12 @@ class NativeFunctionCodegenInfo:
     def dispatcher_signature(
         self, *, prefix: str = "", symint: bool = True
     ) -> DispatcherSignature:
-        return DispatcherSignature.from_schema(
-            self.func, prefix=prefix, symint=symint
-        )
+        return DispatcherSignature.from_schema(self.func, prefix=prefix, symint=symint)
+
+    def native_signature(
+        self, *, prefix: str = "", symint: bool = False
+    ) -> NativeSignature:
+        return NativeSignature(self.func, prefix=prefix, symint=symint)
 
     def cpp_signature_group(
         self, *, method: bool, fallback_binding: bool | None = None
@@ -346,9 +349,7 @@ class NativeFunctionCodegenInfo:
     def function_cpp_signature_group(
         self, *, fallback_binding: bool | None = None
     ) -> CppSignatureGroup:
-        return self.cpp_signature_group(
-            method=False, fallback_binding=fallback_binding
-        )
+        return self.cpp_signature_group(method=False, fallback_binding=fallback_binding)
 
     def method_cpp_signature_group(
         self, *, fallback_binding: bool | None = None
@@ -358,6 +359,8 @@ class NativeFunctionCodegenInfo:
         return self.cpp_signature_group(method=True, fallback_binding=fallback_binding)
 
     def generated_headers(self) -> dict[str, object]:
+        # format_yaml() has a dedicated OrderedDict representer, so keep using it
+        # here to make the emitted key order explicit and stable.
         aggregated_headers: OrderedDict[str, str] = OrderedDict(
             [
                 ("operators", "ATen/Operators.h"),

--- a/torchgen/gen.py
+++ b/torchgen/gen.py
@@ -771,9 +771,7 @@ class ComputeTensorMethod:
             raise AssertionError(f"Method variant must have self_arg: {f.func}")
 
         info = NativeFunctionCodegenInfo(f)
-        sig_group = info.method_cpp_signature_group()
-        if sig_group is None:
-            raise AssertionError(f"Method variant must have signatures: {f.func}")
+        sig_group = info.cpp_signature_group(method=True)
 
         if self.target is Target.DECLARATION:
             result = ""
@@ -990,9 +988,9 @@ class ComputeBackendSelect:
             return None
 
         info = NativeFunctionCodegenInfo(f)
-        name = native.name(f.func)
         # BackendSelect can go to Meta, so it must preserve symints
-        native_sig = NativeSignature(f.func, symint=True)
+        native_sig = info.native_signature(symint=True)
+        name = native_sig.name()
 
         native_tensor_args = [
             a
@@ -1356,10 +1354,10 @@ def compute_registration_declarations(
     f: NativeFunction, backend_indices: dict[DispatchKey, BackendIndex]
 ) -> str:
     info = NativeFunctionCodegenInfo(f)
-    name = info.dispatcher_name
-    returns_type = dispatcher.returns_type(f.func.returns).cpp_type()
-    args = dispatcher.arguments(f.func)
-    args_str = ", ".join(a.no_default().decl() for a in args)
+    dispatcher_sig = info.dispatcher_signature()
+    name = dispatcher_sig.name()
+    returns_type = dispatcher_sig.returns_type().cpp_type()
+    args_str = ", ".join(a.no_default().decl() for a in dispatcher_sig.arguments())
     comment_data: dict[str, object] = {
         "schema": info.schema,
         "operators_api": info.operators_api_name,

--- a/torchgen/gen.py
+++ b/torchgen/gen.py
@@ -13,9 +13,7 @@ from typing_extensions import assert_never
 
 import yaml
 
-import torchgen.api.dispatcher as dispatcher
 import torchgen.api.meta as meta
-import torchgen.api.native as native
 import torchgen.api.structured as structured
 import torchgen.dest as dest
 from torchgen.api import cpp

--- a/torchgen/gen.py
+++ b/torchgen/gen.py
@@ -23,9 +23,9 @@ from torchgen.api.translate import translate
 from torchgen.api.types import (
     Binding,
     CppSignature,
-    CppSignatureGroup,
     DispatcherSignature,
     NamedCType,
+    NativeFunctionCodegenInfo,
     NativeSignature,
     SpecialArgName,
 )
@@ -488,8 +488,8 @@ def generate_static_dispatch_fallback_call(
     f: NativeFunction,
     backend_indices: list[BackendIndex],
 ) -> str:
-    cpp_sigs = CppSignatureGroup.from_native_function(
-        f, method=False, fallback_binding=False
+    cpp_sigs = NativeFunctionCodegenInfo(f).function_cpp_signature_group(
+        fallback_binding=False
     )
     if sig.symint and f.func.has_symint():
         cpp_sig = cpp_sigs.symint_signature
@@ -621,8 +621,9 @@ class ComputeOperators:
 
     @method_with_native_function
     def __call__(self, f: NativeFunction) -> str:
-        sig = DispatcherSignature.from_schema(f.func)
-        name = f.func.name.unambiguous_name()
+        info = NativeFunctionCodegenInfo(f)
+        sig = info.dispatcher_signature()
+        name = info.unambiguous_name
 
         if self.target is Target.DECLARATION:
             # Note [The ATen Operators API]
@@ -711,15 +712,14 @@ static C10_NOINLINE c10::TypedOperatorHandle<{name}::schema> create_{name}_typed
 class ComputeFunction:
     @method_with_native_function
     def __call__(self, f: NativeFunction) -> str | None:
-        sig_group = CppSignatureGroup.from_native_function(
-            f, method=False, fallback_binding=f.manual_cpp_binding
-        )
+        info = NativeFunctionCodegenInfo(f)
+        sig_group = info.function_cpp_signature_group()
         has_symint = f.func.has_symint()
 
         result = ""
         for sig in sig_group.signatures():
             # See Note [The ATen Operators API]
-            target_sig = DispatcherSignature.from_schema(f.func)
+            target_sig = info.dispatcher_signature()
             exprs = translate(sig.arguments(), target_sig.arguments())
             exprs_str = ", ".join([e.expr for e in exprs])
 
@@ -732,7 +732,7 @@ class ComputeFunction:
                 result += f"""
 // aten::{f.func}
 inline {sig.decl()} {{
-    return at::_ops::{f.func.name.unambiguous_name()}::call({exprs_str});
+    return {info.operators_api_name}::call({exprs_str});
 }}"""
 
             # The template function can be used from template situations
@@ -746,7 +746,7 @@ inline {sig.decl()} {{
 namespace symint {{
   template <typename T, typename = std::enable_if_t<std::is_same_v<T, {intlike_t}>>>
   {sig.decl(suppress_symint_suffix=True)} {{
-    return at::_ops::{f.func.name.unambiguous_name()}::call({exprs_str});
+    return {info.operators_api_name}::call({exprs_str});
   }}
 }}
 """
@@ -770,9 +770,10 @@ class ComputeTensorMethod:
         if f.func.arguments.self_arg is None:
             raise AssertionError(f"Method variant must have self_arg: {f.func}")
 
-        sig_group = CppSignatureGroup.from_native_function(
-            f, method=True, fallback_binding=f.manual_cpp_binding
-        )
+        info = NativeFunctionCodegenInfo(f)
+        sig_group = info.method_cpp_signature_group()
+        if sig_group is None:
+            raise AssertionError(f"Method variant must have signatures: {f.func}")
 
         if self.target is Target.DECLARATION:
             result = ""
@@ -786,14 +787,14 @@ class ComputeTensorMethod:
         result = ""
 
         for sig in sig_group.signatures():
-            target_sig = DispatcherSignature.from_schema(f.func)
+            target_sig = info.dispatcher_signature()
             exprs = translate(sig.arguments(), target_sig.arguments(), method=True)
             exprs_str = ", ".join([e.expr for e in exprs])
 
             result += f"""
 // aten::{f.func}
 inline {sig.defn(prefix="Tensor::")} const {{
-    return at::_ops::{f.func.name.unambiguous_name()}::call({exprs_str});
+    return {info.operators_api_name}::call({exprs_str});
 }}
 """
 
@@ -809,20 +810,19 @@ class ComputeRedispatchFunction:
     def __call__(self, f: NativeFunction) -> str | None:
         # We unconditionally generate function variants of the redispatch API.
         # This is mainly because we can namespace functions separately, but not methods,
-        sig_group = CppSignatureGroup.from_native_function(
-            f, method=False, fallback_binding=f.manual_cpp_binding
-        )
+        info = NativeFunctionCodegenInfo(f)
+        sig_group = info.function_cpp_signature_group()
 
         result = ""
         for sig in sig_group.signatures():
-            target_sig = DispatcherSignature.from_schema(f.func)
+            target_sig = info.dispatcher_signature()
             exprs = translate(sig.arguments(), target_sig.arguments())
             exprs_str = ", ".join(["dispatchKeySet"] + [a.expr for a in exprs])
 
             result += f"""
 // aten::{f.func}
 inline {sig.decl(is_redispatching_fn=True)} {{
-    return at::_ops::{f.func.name.unambiguous_name()}::redispatch({exprs_str});
+    return {info.operators_api_name}::redispatch({exprs_str});
 }}
 """
 
@@ -989,6 +989,7 @@ class ComputeBackendSelect:
         if not needs_backend_select(f, self.selector):
             return None
 
+        info = NativeFunctionCodegenInfo(f)
         name = native.name(f.func)
         # BackendSelect can go to Meta, so it must preserve symints
         native_sig = NativeSignature(f.func, symint=True)
@@ -999,7 +1000,7 @@ class ComputeBackendSelect:
             if isinstance(a.argument, Argument) and a.argument.type.is_tensor_like()
         ]
 
-        dispatcher_sig = DispatcherSignature.from_schema(f.func)
+        dispatcher_sig = info.dispatcher_signature()
 
         sig: NativeSignature | DispatcherSignature
         sig = dispatcher_sig
@@ -1034,7 +1035,7 @@ DispatchKeySet _dk = c10::impl::computeDispatchKeySet(_dk_set, _dk_mask);"""
 C10_ALWAYS_INLINE
 {sig.defn(name)} {{
   {compute_dk}
-  return at::_ops::{f.func.name.unambiguous_name()}::redispatch(
+  return {info.operators_api_name}::redispatch(
       _dk, {", ".join(a.expr for a in dispatcher_exprs)});
 }}
 """
@@ -1255,6 +1256,7 @@ def compute_argument_yaml(
 
 @with_native_function
 def compute_declaration_yaml(f: NativeFunction) -> object:
+    info = NativeFunctionCodegenInfo(f)
     returns, name_to_field_name = compute_returns_yaml(f)
 
     # These sets are used to conveniently test if an argument is a
@@ -1262,9 +1264,7 @@ def compute_declaration_yaml(f: NativeFunction) -> object:
     kwarg_only_set = {a.name for a in f.func.arguments.flat_kwarg_only}
     out_arg_set = {a.name for a in f.func.arguments.out}
 
-    sig_group = CppSignatureGroup.from_native_function(
-        f, method=False, fallback_binding=False
-    )
+    sig_group = info.function_cpp_signature_group(fallback_binding=False)
     cpp_args = sig_group.signature.arguments()
     arguments = [
         compute_cpp_argument_yaml(
@@ -1324,6 +1324,8 @@ def compute_declaration_yaml(f: NativeFunction) -> object:
                 f.category_override if f.category_override is not None else "",
             ),
             ("schema_string", f"aten::{f.func}"),
+            ("generated_headers", info.generated_headers()),
+            ("cpp_entry_points", info.generated_cpp_entry_points()),
             ("arguments", arguments),
             ("schema_order_cpp_signature", schema_order_cpp_signature),
             ("schema_order_arguments", schema_order_arguments),
@@ -1353,12 +1355,14 @@ def has_autogenerated_composite_kernel(f: NativeFunction) -> bool:
 def compute_registration_declarations(
     f: NativeFunction, backend_indices: dict[DispatchKey, BackendIndex]
 ) -> str:
-    name = dispatcher.name(f.func)
+    info = NativeFunctionCodegenInfo(f)
+    name = info.dispatcher_name
     returns_type = dispatcher.returns_type(f.func.returns).cpp_type()
     args = dispatcher.arguments(f.func)
     args_str = ", ".join(a.no_default().decl() for a in args)
-    comment_data: dict[str, str] = {
-        "schema": f"aten::{f.func}",
+    comment_data: dict[str, object] = {
+        "schema": info.schema,
+        "operators_api": info.operators_api_name,
         # TODO: What exactly is the semantics of the 'dispatch' field?
         "dispatch": str(
             {k for k, v in backend_indices.items() if v.has_kernel(f)}


### PR DESCRIPTION
## Summary

1) Root cause problem
`native_functions.yaml` schema-to-C++ mapping was derived ad hoc in several codegen paths, so it was hard to answer how one op fans out into dispatcher wrappers, `at::_ops`, and public C++ entry points.

2) Proposed fix
Introduce a shared `NativeFunctionCodegenInfo` abstraction, use it throughout `torchgen/gen.py`, and emit the generated header/entry-point mapping into `Declarations.yaml` with small breadcrumbs in `RegistrationDeclarations.h`.

3) Why the proposed fix is the right long term fix
This gives torchgen one source of truth for schema-derived C++ names and signatures, so future codegen changes keep the emitted metadata and wrapper generation in sync instead of drifting.

## Testing
- `tools.test.test_codegen`
- `tools.test.test_codegen_model`
- `tools.test.test_gen_backend_stubs`
- `torchgen/gen.py --source-path aten/src/ATen --install-dir /tmp/torchgen-smoke --aoti-install-dir /tmp/torchgen-smoke-aoti --per-operator-headers --generate headers sources declarations_yaml`

Drafted via Codex, published after manual review by @bobrenjc93