### PR TITLE
Add structured call_hierarchy metadata to FX nodes

### DIFF
--- a/benchmarks/dynamo/pr_time_benchmarks/benchmarks/dynamo_inline.py
+++ b/benchmarks/dynamo/pr_time_benchmarks/benchmarks/dynamo_inline.py
@@ -3,6 +3,7 @@ import sys
 from benchmark_base import BenchmarkBase
 
 import torch
+import torch._dynamo.config
 import torch.nn as nn
 from torch._inductor.utils import fresh_cache
 
@@ -66,10 +67,12 @@ class Benchmark(BenchmarkBase):
         backend="eager",
         is_gpu=False,
         dynamic=False,
+        record_call_hierarchy=False,
     ):
         self.ModuleClass = ModuleClass
         self._name = ModuleClass.__name__
         self._is_gpu = is_gpu
+        self._record_call_hierarchy = record_call_hierarchy
 
         super().__init__(
             category="basic",
@@ -80,6 +83,8 @@ class Benchmark(BenchmarkBase):
 
     def name(self):
         prefix = f"{self.category()}_{self._name}_{self.backend()}"
+        if self._record_call_hierarchy:
+            prefix += "_call_hierarchy"
         return prefix
 
     def _prepare_once(self):
@@ -95,6 +100,9 @@ class Benchmark(BenchmarkBase):
         # Keep using False value for consistency.
         with (
             fresh_cache(),
+            torch._dynamo.config.patch(
+                record_call_hierarchy=self._record_call_hierarchy
+            ),
         ):
             opt_m = torch.compile(backend=self.backend(), dynamic=self.is_dynamic())(
                 self.m.cuda() if self._is_gpu else self.m
@@ -106,6 +114,7 @@ def main():
     result_path = sys.argv[1]
     benchmarks = [
         Benchmark(InlineMod),
+        Benchmark(InlineMod, record_call_hierarchy=True),
     ]
     for b in benchmarks:
         b.enable_compile_time_instruction_count().collect_all().append_results(

--- a/benchmarks/dynamo/pr_time_benchmarks/benchmarks/nested_module.py
+++ b/benchmarks/dynamo/pr_time_benchmarks/benchmarks/nested_module.py
@@ -3,6 +3,7 @@ import sys
 from benchmark_base import BenchmarkBase
 
 import torch
+import torch._dynamo.config
 import torch.nn as nn
 from torch._inductor.utils import fresh_cache
 
@@ -39,10 +40,12 @@ class Benchmark(BenchmarkBase):
         backend="eager",
         is_gpu=False,
         dynamic=False,
+        record_call_hierarchy=False,
     ):
         self.ModuleClass = ModuleClass
         self._name = ModuleClass.__name__
         self._is_gpu = is_gpu
+        self._record_call_hierarchy = record_call_hierarchy
 
         super().__init__(
             category="basic",
@@ -53,6 +56,8 @@ class Benchmark(BenchmarkBase):
 
     def name(self):
         prefix = f"{self.category()}_{self._name}_{self.backend()}"
+        if self._record_call_hierarchy:
+            prefix += "_call_hierarchy"
         return prefix
 
     def _prepare_once(self):
@@ -68,6 +73,9 @@ class Benchmark(BenchmarkBase):
         # Keep using False value for consistency.
         with (
             fresh_cache(),
+            torch._dynamo.config.patch(
+                record_call_hierarchy=self._record_call_hierarchy
+            ),
         ):
             opt_m = torch.compile(backend=self.backend(), dynamic=self.is_dynamic())(
                 self.m.cuda() if self._is_gpu else self.m
@@ -79,6 +87,7 @@ def main():
     result_path = sys.argv[1]
     benchmarks = [
         Benchmark(NestedModule),
+        Benchmark(NestedModule, record_call_hierarchy=True),
     ]
     for b in benchmarks:
         b.enable_compile_time_instruction_count().collect_all().append_results(

--- a/test/dynamo/test_call_hierarchy.py
+++ b/test/dynamo/test_call_hierarchy.py
@@ -9,7 +9,8 @@ hierarchy strings without parsing the unstructured stack_trace string.
 import torch
 import torch._dynamo.config
 import torch.nn as nn
-from torch.testing._internal.common_utils import TestCase, run_tests
+from torch._dynamo.test_case import run_tests
+from torch.testing._internal.common_utils import TestCase
 
 
 def forward(x):
@@ -70,6 +71,7 @@ class PureFunctional(nn.Module):
 
 class ModelCallingForwardFunc(nn.Module):
     """Calls a standalone function named 'forward'."""
+
     def __init__(self):
         super().__init__()
         self.linear = nn.Linear(4, 4)

--- a/test/dynamo/test_call_hierarchy.py
+++ b/test/dynamo/test_call_hierarchy.py
@@ -336,6 +336,32 @@ class TestCallHierarchy(TestCase):
                     break
         self.assertTrue(found, "standalone forward() function not captured")
 
+    def test_fwd_call_hierarchy_on_backward_nodes(self):
+        """Backward nodes should carry fwd_call_hierarchy from their
+        corresponding forward node."""
+        from torch._dynamo.backends.common import aot_autograd
+
+        model = SimpleLinear()
+        x = torch.randn(2, 4, requires_grad=True)
+
+        bw_hierarchies = []
+
+        def bw_compiler(gm, example_inputs):
+            for node in gm.graph.nodes:
+                h = node.meta.get("fwd_call_hierarchy")
+                if h is not None:
+                    bw_hierarchies.append(h)
+            return gm
+
+        backend = aot_autograd(fw_compiler=lambda gm, _: gm, bw_compiler=bw_compiler)
+        compiled = torch.compile(model, backend=backend)
+        compiled(x).sum().backward()
+
+        self.assertTrue(
+            len(bw_hierarchies) > 0,
+            "No backward nodes with fwd_call_hierarchy found",
+        )
+
 
 if __name__ == "__main__":
     run_tests()

--- a/test/dynamo/test_call_hierarchy.py
+++ b/test/dynamo/test_call_hierarchy.py
@@ -1,0 +1,339 @@
+# Owner(s): ["module: dynamo"]
+"""Tests for call_hierarchy metadata on FX nodes.
+call_hierarchy is a structured metadata field that provides a unified
+module+function call hierarchy for each FX node, built during Dynamo's
+tx chain walk. It enables compiler backends to produce profiler-quality
+hierarchy strings without parsing the unstructured stack_trace string.
+"""
+
+import torch
+import torch._dynamo.config
+import torch.nn as nn
+from torch.testing._internal.common_utils import TestCase, run_tests
+
+
+def forward(x):
+    """Standalone function named 'forward' — not a module method."""
+    return x * 3
+
+
+def helper_fn(x):
+    return x * 2 + 1
+
+
+class SimpleLinear(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear = nn.Linear(4, 4)
+
+    def forward(self, x):
+        return self.linear(x)
+
+
+class NestedModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.layer1 = SimpleLinear()
+        self.layer2 = nn.Linear(4, 2)
+
+    def forward(self, x):
+        x = self.layer1(x)
+        return self.layer2(x)
+
+
+class ModelWithHelper(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear = nn.Linear(4, 4)
+
+    def forward(self, x):
+        x = self.linear(x)
+        x = helper_fn(x)
+        return x
+
+
+class SharedModule(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.shared = nn.Linear(4, 4)
+
+    def forward(self, x):
+        x = self.shared(x)
+        x = self.shared(x)
+        return x
+
+
+class PureFunctional(nn.Module):
+    def forward(self, x):
+        return x * 2 + 1
+
+
+class ModelCallingForwardFunc(nn.Module):
+    """Calls a standalone function named 'forward'."""
+    def __init__(self):
+        super().__init__()
+        self.linear = nn.Linear(4, 4)
+
+    def forward(self, x):
+        x = self.linear(x)
+        x = forward(x)
+        return x
+
+
+def _get_nodes_with_call_hierarchy(model, x):
+    """Compile model and return nodes that have call_hierarchy metadata."""
+    nodes = []
+
+    def backend(gm, example_inputs):
+        for node in gm.graph.nodes:
+            if "call_hierarchy" in node.meta:
+                nodes.append(node)
+        return gm
+
+    compiled = torch.compile(model, backend=backend)
+    compiled(x)
+    return nodes
+
+
+class TestCallHierarchy(TestCase):
+    def setUp(self):
+        super().setUp()
+        torch._dynamo.reset()
+        self._orig = torch._dynamo.config.record_call_hierarchy
+        torch._dynamo.config.record_call_hierarchy = True
+
+    def tearDown(self):
+        torch._dynamo.config.record_call_hierarchy = self._orig
+        torch._dynamo.reset()
+        super().tearDown()
+
+    def test_disabled_by_default(self):
+        """No call_hierarchy when config flag is off."""
+        torch._dynamo.config.record_call_hierarchy = False
+        model = SimpleLinear()
+        x = torch.randn(2, 4)
+        nodes = _get_nodes_with_call_hierarchy(model, x)
+        self.assertEqual(len(nodes), 0)
+
+    def test_populated_for_module_ops(self):
+        model = SimpleLinear()
+        x = torch.randn(2, 4)
+        nodes = _get_nodes_with_call_hierarchy(model, x)
+        self.assertTrue(len(nodes) > 0)
+
+    def test_module_entry_structure(self):
+        model = SimpleLinear()
+        x = torch.randn(2, 4)
+        nodes = _get_nodes_with_call_hierarchy(model, x)
+
+        for node in nodes:
+            for entry in node.meta["call_hierarchy"]:
+                self.assertIn("type", entry)
+                if entry["type"] == "module":
+                    self.assertIn("class", entry)
+                    self.assertIn("attr", entry)
+                    self.assertIn("count", entry)
+
+    def test_function_entry_structure(self):
+        model = ModelWithHelper()
+        x = torch.randn(2, 4)
+        nodes = _get_nodes_with_call_hierarchy(model, x)
+
+        has_function = False
+        for node in nodes:
+            for entry in node.meta["call_hierarchy"]:
+                if entry["type"] == "function":
+                    self.assertIn("name", entry)
+                    self.assertIn("count", entry)
+                    has_function = True
+        self.assertTrue(has_function)
+
+    def test_nested_exact_hierarchy(self):
+        """Assert exact module nesting for a known model."""
+        model = NestedModel()
+        x = torch.randn(2, 4)
+        nodes = _get_nodes_with_call_hierarchy(model, x)
+
+        # Find a node from the inner linear of layer1 (SimpleLinear.linear).
+        # Its hierarchy should contain SimpleLinear > Linear.
+        found = False
+        for node in nodes:
+            hierarchy = node.meta["call_hierarchy"]
+            classes = [e["class"] for e in hierarchy if e["type"] == "module"]
+            if "SimpleLinear" in classes and "Linear" in classes:
+                idx = classes.index("SimpleLinear")
+                self.assertEqual(classes[idx:], ["SimpleLinear", "Linear"])
+                found = True
+                break
+        self.assertTrue(found, "Expected SimpleLinear > Linear nesting")
+
+    def test_helper_function_appears(self):
+        model = ModelWithHelper()
+        x = torch.randn(2, 4)
+        nodes = _get_nodes_with_call_hierarchy(model, x)
+
+        func_names = set()
+        for node in nodes:
+            for entry in node.meta["call_hierarchy"]:
+                if entry["type"] == "function":
+                    func_names.add(entry["name"])
+        self.assertIn("helper_fn", func_names)
+
+    def test_no_lself_prefix(self):
+        model = SimpleLinear()
+        x = torch.randn(2, 4)
+        nodes = _get_nodes_with_call_hierarchy(model, x)
+
+        for node in nodes:
+            for entry in node.meta["call_hierarchy"]:
+                if entry["type"] == "module":
+                    self.assertNotIn("L['self']", entry["attr"])
+
+    def test_pure_functional_no_module_hierarchy(self):
+        """A module with no sub-modules produces no module-type entries
+        in call_hierarchy."""
+        model = PureFunctional()
+        x = torch.randn(2, 4)
+        nodes = _get_nodes_with_call_hierarchy(model, x)
+
+        for node in nodes:
+            module_entries = [
+                e for e in node.meta["call_hierarchy"] if e["type"] == "module"
+            ]
+            self.assertEqual(len(module_entries), 0)
+
+    def test_shared_module_call_count(self):
+        """Shared module called twice should have count > 0 on second call."""
+        model = SharedModule()
+        x = torch.randn(2, 4)
+        nodes = _get_nodes_with_call_hierarchy(model, x)
+
+        counts = []
+        for node in nodes:
+            for entry in node.meta["call_hierarchy"]:
+                if entry["type"] == "module" and entry["class"] == "Linear":
+                    counts.append(entry["count"])
+        # We should see at least one invocation with count=0 and one with count=1
+        self.assertIn(0, counts)
+        self.assertIn(1, counts)
+
+    def test_sibling_modules_both_detected(self):
+        """Two sibling modules at the same depth should both appear as module
+        entries (regression test for depth-based detection bug)."""
+        model = NestedModel()
+        x = torch.randn(2, 4)
+        nodes = _get_nodes_with_call_hierarchy(model, x)
+
+        # layer2 is a sibling of layer1 at the same depth.  Nodes from layer2
+        # should have a hierarchy containing NestedModel > Linear with
+        # attr="layer2".
+        found_layer2 = False
+        for node in nodes:
+            hierarchy = node.meta["call_hierarchy"]
+            for entry in hierarchy:
+                if (
+                    entry["type"] == "module"
+                    and entry["class"] == "Linear"
+                    and entry["attr"] == "layer2"
+                ):
+                    found_layer2 = True
+                    break
+        self.assertTrue(found_layer2, "layer2 (sibling module) not detected")
+
+    def test_function_count_zero_indexed(self):
+        """Function call counts should be 0-indexed, matching module convention."""
+        model = ModelWithHelper()
+        x = torch.randn(2, 4)
+        nodes = _get_nodes_with_call_hierarchy(model, x)
+
+        for node in nodes:
+            for entry in node.meta["call_hierarchy"]:
+                if entry["type"] == "function" and entry["name"] == "helper_fn":
+                    self.assertEqual(entry["count"], 0)
+
+    def test_export_no_crash(self):
+        """call_hierarchy should not interfere with torch.export."""
+        model = NestedModel()
+        x = torch.randn(2, 4)
+        exported = torch.export.export(model, (x,))
+        # Verify export succeeds and produces a valid graph.
+        self.assertIsNotNone(exported)
+        result = exported.module()(x)
+        expected = model(x)
+        self.assertEqual(result, expected)
+
+    def test_graph_break_preserves_hierarchy(self):
+        """Nodes in both subgraphs around a graph break get valid hierarchy."""
+
+        class ModelWithBreak(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear1 = nn.Linear(4, 4)
+                self.linear2 = nn.Linear(4, 4)
+
+            def forward(self, x):
+                x = self.linear1(x)
+                torch._dynamo.graph_break()
+                x = self.linear2(x)
+                return x
+
+        model = ModelWithBreak()
+        x = torch.randn(2, 4)
+
+        all_nodes = []
+
+        def backend(gm, example_inputs):
+            for node in gm.graph.nodes:
+                if "call_hierarchy" in node.meta:
+                    all_nodes.append(node)
+            return gm
+
+        compiled = torch.compile(model, backend=backend)
+        compiled(x)
+
+        # Should have nodes from both subgraphs (before and after break).
+        attrs = set()
+        for node in all_nodes:
+            for entry in node.meta["call_hierarchy"]:
+                if entry["type"] == "module":
+                    attrs.add(entry["attr"])
+        self.assertIn("linear1", attrs)
+        self.assertIn("linear2", attrs)
+        # All entries should be structurally valid.
+        for node in all_nodes:
+            for entry in node.meta["call_hierarchy"]:
+                self.assertIn(entry["type"], ("module", "function"))
+
+    def test_module_forward_not_double_counted(self):
+        """Module's forward method should appear only as a module entry,
+        not duplicated as a function entry."""
+        model = SimpleLinear()
+        x = torch.randn(2, 4)
+        nodes = _get_nodes_with_call_hierarchy(model, x)
+
+        for node in nodes:
+            func_names = [
+                e["name"]
+                for e in node.meta["call_hierarchy"]
+                if e["type"] == "function"
+            ]
+            self.assertNotIn("forward", func_names)
+
+    def test_standalone_forward_function_captured(self):
+        """A standalone function named 'forward' (not a module method)
+        should appear as a function entry, not be suppressed."""
+        model = ModelCallingForwardFunc()
+        x = torch.randn(2, 4)
+        nodes = _get_nodes_with_call_hierarchy(model, x)
+
+        found = False
+        for node in nodes:
+            for entry in node.meta["call_hierarchy"]:
+                if entry["type"] == "function" and entry["name"] == "forward":
+                    found = True
+                    break
+        self.assertTrue(found, "standalone forward() function not captured")
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -627,6 +627,11 @@ debug_disable_compile_counter = False
 # torch._dynamo.utilsCompileTimeInstructionCounter.
 record_compile_time_instruction_count = False
 
+# When set, a structured call_hierarchy metadata field is attached to each FX
+# node during tracing.  The field is a list of dicts describing the interleaved
+# module + function call chain that produced the node, with invocation counts.
+record_call_hierarchy = False
+
 
 def default_debug_dir_root() -> str:
     # [@compile_ignored: debug]

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -79,6 +79,7 @@ from torch.fx.passes.runtime_assert import insert_deferred_runtime_asserts
 from torch.utils._ordered_set import OrderedSet
 from torch.utils._python_dispatch import is_traceable_wrapper_subclass
 
+
 # Cached prefix for filtering torch-internal frames in call_hierarchy.
 _TORCH_FILE_PREFIX: str = os.path.dirname(torch.__file__) + os.sep
 
@@ -3830,10 +3831,7 @@ class SubgraphTracer(fx.Tracer):
             msgs = traceback.StackSummary.from_list(filtered_frame_summaries).format()
             rv.node.stack_trace = "".join(msgs)
 
-        if (
-            config.record_call_hierarchy
-            and "call_hierarchy" not in rv.node.meta
-        ):
+        if config.record_call_hierarchy and "call_hierarchy" not in rv.node.meta:
             # Build a unified call hierarchy from the tx chain.
             # Collect frames first (inner→outer), then iterate outer→inner
             # to detect module entries by diffing nn_module_stack keys.
@@ -3860,26 +3858,18 @@ class SubgraphTracer(fx.Tracer):
                         path, cls = nn_stack[key]
                         # Strip the Dynamo-internal L['self']. prefix.
                         if path.startswith("L['self']."):
-                            path = path[len("L['self']."):]
+                            path = path[len("L['self'].") :]
                         elif path == "L['self']":
                             path = ""
                         cls_name = (
-                            cls.__name__
-                            if hasattr(cls, "__name__")
-                            else str(cls)
+                            cls.__name__ if hasattr(cls, "__name__") else str(cls)
                         )
-                        attr = (
-                            path.rsplit(".", 1)[-1] if "." in path else path
-                        )
+                        attr = path.rsplit(".", 1)[-1] if "." in path else path
                         # nn_module_stack keys use an @N suffix for the Nth
                         # invocation of a shared module instance (see
                         # record_nn_module_stack in variables/nn_module.py).
                         key_str = str(key)
-                        call_count = (
-                            int(key_str.split("@")[1])
-                            if "@" in key_str
-                            else 0
-                        )
+                        call_count = int(key_str.split("@")[1]) if "@" in key_str else 0
                         hierarchy.append(
                             {
                                 "type": "module",

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -28,6 +28,7 @@ import inspect
 import itertools
 import logging
 import operator
+import os
 import re
 import sys
 import time
@@ -77,6 +78,9 @@ from torch.fx.node import Target
 from torch.fx.passes.runtime_assert import insert_deferred_runtime_asserts
 from torch.utils._ordered_set import OrderedSet
 from torch.utils._python_dispatch import is_traceable_wrapper_subclass
+
+# Cached prefix for filtering torch-internal frames in call_hierarchy.
+_TORCH_FILE_PREFIX: str = os.path.dirname(torch.__file__) + os.sep
 
 from . import config, exc, logging as torchdynamo_logging, variables
 from .backends.registry import CompiledFn, CompilerFn
@@ -3804,14 +3808,14 @@ class SubgraphTracer(fx.Tracer):
                         )
                     ]
 
+        # Walk the tx parent chain for stack_trace.
         if "stack_trace" not in rv.node.meta:
             frame_summaries: list[traceback.FrameSummary] = []
-            while tx:
-                # Avoid frame summaries from inside the torch/nn/modules. This ensures that we keep the stack trace of
-                # the user code.
-                if not tx.is_co_filename_from_nn_modules():
-                    frame_summaries.append(tx.frame_summary())
-                tx = getattr(tx, "parent", None)
+            tx_walk = self.output_graph.current_tx
+            while tx_walk is not None:
+                if not tx_walk.is_co_filename_from_nn_modules():
+                    frame_summaries.append(tx_walk.frame_summary())
+                tx_walk = getattr(tx_walk, "parent", None)
 
             filtered_frame_summaries = [
                 frame
@@ -3825,6 +3829,102 @@ class SubgraphTracer(fx.Tracer):
             # official from_list stub doesn't have new-style type
             msgs = traceback.StackSummary.from_list(filtered_frame_summaries).format()
             rv.node.stack_trace = "".join(msgs)
+
+        if (
+            config.record_call_hierarchy
+            and "call_hierarchy" not in rv.node.meta
+        ):
+            # Build a unified call hierarchy from the tx chain.
+            # Collect frames first (inner→outer), then iterate outer→inner
+            # to detect module entries by diffing nn_module_stack keys.
+            all_frames: list[Any] = []
+            tx_walk = self.output_graph.current_tx
+            while tx_walk is not None:
+                all_frames.append(tx_walk)
+                tx_walk = getattr(tx_walk, "parent", None)
+
+            hierarchy: list[dict[str, Any]] = []
+            prev_module_keys: set[str] = set()
+
+            for frame in reversed(all_frames):
+                nn_stack = getattr(frame, "nn_module_stack", {})
+                cur_keys = set(nn_stack.keys())
+                new_keys = cur_keys - prev_module_keys
+
+                if new_keys:
+                    # New module scope(s) entered — emit one entry per new key,
+                    # preserving insertion order from the ordered dict.
+                    for key in nn_stack:
+                        if key not in new_keys:
+                            continue
+                        path, cls = nn_stack[key]
+                        # Strip the Dynamo-internal L['self']. prefix.
+                        if path.startswith("L['self']."):
+                            path = path[len("L['self']."):]
+                        elif path == "L['self']":
+                            path = ""
+                        cls_name = (
+                            cls.__name__
+                            if hasattr(cls, "__name__")
+                            else str(cls)
+                        )
+                        attr = (
+                            path.rsplit(".", 1)[-1] if "." in path else path
+                        )
+                        # nn_module_stack keys use an @N suffix for the Nth
+                        # invocation of a shared module instance (see
+                        # record_nn_module_stack in variables/nn_module.py).
+                        key_str = str(key)
+                        call_count = (
+                            int(key_str.split("@")[1])
+                            if "@" in key_str
+                            else 0
+                        )
+                        hierarchy.append(
+                            {
+                                "type": "module",
+                                "class": cls_name,
+                                "attr": attr,
+                                "count": call_count,
+                            }
+                        )
+                else:
+                    # No new modules — check if this is a user function frame.
+                    func_name = frame.f_code.co_name
+                    filename = frame.f_code.co_filename
+                    # Skip non-meaningful scopes:
+                    # - "<module>": top-level script scope, not a real call.
+                    # - "<lambda>": anonymous, unnamed — not useful in a
+                    #   hierarchy string.
+                    # Module entry points (e.g. "forward") are NOT excluded
+                    # here because they are already handled: when Dynamo
+                    # inlines a module's forward, record_nn_module_stack adds
+                    # to nn_module_stack before the frame is created, so the
+                    # frame always lands in the `if new_keys` branch above.
+                    # Torch-internal frames (e.g. _call_impl,
+                    # _wrapped_call_impl) are filtered by _TORCH_FILE_PREFIX.
+                    if func_name not in (
+                        "<module>",
+                        "<lambda>",
+                    ) and not filename.startswith(_TORCH_FILE_PREFIX):
+                        fcc = getattr(frame, "function_call_counts", {})
+                        fcc_key = f"{filename}:{func_name}"
+                        # 0-indexed to match module count convention:
+                        # first invocation = 0, second = 1, etc.
+                        count = fcc.get(fcc_key, 0) - 1
+                        hierarchy.append(
+                            {
+                                "type": "function",
+                                "name": func_name,
+                                "count": max(count, 0),
+                            }
+                        )
+
+                prev_module_keys = cur_keys
+
+            if hierarchy:
+                rv.node.meta["call_hierarchy"] = hierarchy
+
 
         if (
             torch._dynamo.config.use_graph_deduplication

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -4696,6 +4696,9 @@ class InstructionTranslatorBase(
         # in original hierarchy.  The second field is the type of current nn.module
         self.nn_module_stack: dict[str, tuple[str, type[Any]]] = {}
         self.num_calls: dict[str, int] = {}
+        # Tracks per-function invocation counts for call_hierarchy metadata.
+        # Shared across the entire tx chain (parent and all inlined children).
+        self.function_call_counts: dict[str, int] = {}
         # Flag to indicate whether tracing is used for export.
         self.export = export
         # NOTE: one_graph is used for export/fullgraph=True to always force errors on graph breaks.
@@ -5338,6 +5341,12 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
         parent.is_child_tracer_active = True
         code = self.f_code
 
+        # Track per-function invocation counts for call_hierarchy metadata
+        _fcc_key = f"{code.co_filename}:{code.co_name}"
+        self.function_call_counts[_fcc_key] = (
+            self.function_call_counts.get(_fcc_key, 0) + 1
+        )
+
         strict_ctx: Any = contextlib.nullcontext()
         if parent.strict_checks_fn:
             strict_ctx = self.strict_translation_mode(parent.strict_checks_fn)
@@ -5468,6 +5477,7 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
         self.funcvar = funcvar
         self.parent = parent
         self.num_calls = parent.num_calls
+        self.function_call_counts = parent.function_call_counts
         self.symbolic_result = None
         self.nn_module_stack = parent.nn_module_stack.copy()
         self.one_graph = parent.one_graph

--- a/torch/_functorch/_aot_autograd/utils.py
+++ b/torch/_functorch/_aot_autograd/utils.py
@@ -621,6 +621,7 @@ def _copy_metadata_to_bw_nodes_in_subgraph(
         if fwd_node is not None:
             node.meta["fwd_nn_module_stack"] = fwd_node.meta.get("nn_module_stack")
             node.meta["fwd_source_fn_stack"] = fwd_node.meta.get("source_fn_stack")
+            node.meta["fwd_call_hierarchy"] = fwd_node.meta.get("call_hierarchy")
             # TODO: better to change to a specific field of custom?
             custom = fwd_node.meta.get("custom")
             if custom is not None:

--- a/torch/fx/proxy.py
+++ b/torch/fx/proxy.py
@@ -166,6 +166,7 @@ _COPY_META_FIELDS = [
     "_numeric_debug_handle",  # TODO deprecated
     "custom",
     "partitioner_tag",
+    "call_hierarchy",
 ]
 
 


### PR DESCRIPTION
Add a new 'call_hierarchy' metadata field to FX nodes that provides a
unified, ordered list of module and function call entries for each
operation. Built during Dynamo's tx chain walk at proxy creation time,
it uses nn_module_stack depth changes to distinguish module entries
from function entries without relying on function name matching.

Changes:
- torch/_dynamo/config.py: Add record_call_hierarchy flag (default off)
- torch/_dynamo/output_graph.py: Build call_hierarchy in create_proxy
- torch/_dynamo/symbolic_convert.py: Add function_call_counts tracking
- torch/fx/proxy.py: Add call_hierarchy to _COPY_META_FIELDS
- test/dynamo/test_call_hierarchy.py: Tests for the new field

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98