### PR TITLE
  [inductor] Add thread-based compilation support for free-threaded Python (#179547) (#179547) (#179547)

### DIFF
--- a/test/inductor/test_thread_pool.py
+++ b/test/inductor/test_thread_pool.py
@@ -1,0 +1,48 @@
+# Owner(s): ["module: inductor"]
+"""Test thread pool for Triton compilation."""
+
+from concurrent.futures import ThreadPoolExecutor
+
+import torch._inductor.config as config
+from torch._inductor.async_compile import AsyncCompile
+from torch._inductor.test_case import run_tests, TestCase
+
+
+class TestThreadPool(TestCase):
+    def setUp(self):
+        super().setUp()
+        self._orig_mode = config.compile_worker_mode
+        self._orig_threads = config.compile_threads
+        # Ensure we have multiple compile threads
+        if config.compile_threads is None or config.compile_threads <= 1:
+            config.compile_threads = 4
+
+    def tearDown(self):
+        config.compile_worker_mode = self._orig_mode
+        config.compile_threads = self._orig_threads
+        AsyncCompile.thread_pool.cache_clear()
+        AsyncCompile.process_pool.cache_clear()
+        super().tearDown()
+
+    def test_thread_pool_creation(self):
+        """Thread pool is created as a ThreadPoolExecutor with correct worker count."""
+        config.compile_worker_mode = "thread"
+        AsyncCompile.thread_pool.cache_clear()
+
+        pool = AsyncCompile.thread_pool()
+        self.assertIsInstance(pool, ThreadPoolExecutor)
+        self.assertEqual(pool._max_workers, config.compile_threads)
+
+    def test_should_use_thread_workers_thread_mode(self):
+        """should_use_thread_workers returns True in thread mode."""
+        config.compile_worker_mode = "thread"
+        self.assertTrue(AsyncCompile.should_use_thread_workers())
+
+    def test_should_use_thread_workers_process_mode(self):
+        """should_use_thread_workers returns False in process mode."""
+        config.compile_worker_mode = "process"
+        self.assertFalse(AsyncCompile.should_use_thread_workers())
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/inductor/test_thread_pool.py
+++ b/test/inductor/test_thread_pool.py
@@ -1,0 +1,50 @@
+# Owner(s): ["module: inductor"]
+"""Test thread pool for Triton compilation."""
+
+from concurrent.futures import ThreadPoolExecutor
+
+import torch._inductor.config as config
+from torch._inductor.async_compile import AsyncCompile, shutdown_compile_workers
+from torch._inductor.test_case import run_tests, TestCase
+
+
+class TestThreadPool(TestCase):
+    def setUp(self):
+        super().setUp()
+        self._orig_mode = config.compile_worker_mode
+        self._orig_threads = config.compile_threads
+        # Ensure we have multiple compile threads
+        if config.compile_threads is None or config.compile_threads <= 1:
+            config.compile_threads = 4
+
+    def tearDown(self):
+        config.compile_worker_mode = self._orig_mode
+        config.compile_threads = self._orig_threads
+        AsyncCompile.thread_pool.cache_clear()
+        AsyncCompile.process_pool.cache_clear()
+        shutdown_compile_workers()
+        super().tearDown()
+
+    def test_thread_pool_creation(self):
+        """Thread pool is created as a ThreadPoolExecutor with correct worker count."""
+        config.compile_worker_mode = "thread"
+        AsyncCompile.thread_pool.cache_clear()
+        shutdown_compile_workers()
+
+        pool = AsyncCompile.thread_pool()
+        self.assertIsInstance(pool, ThreadPoolExecutor)
+        self.assertEqual(pool._max_workers, config.compile_threads)
+
+    def test_should_use_thread_workers_thread_mode(self):
+        """should_use_thread_workers returns True in thread mode."""
+        config.compile_worker_mode = "thread"
+        self.assertTrue(AsyncCompile.should_use_thread_workers())
+
+    def test_should_use_thread_workers_process_mode(self):
+        """should_use_thread_workers returns False in process mode."""
+        config.compile_worker_mode = "process"
+        self.assertFalse(AsyncCompile.should_use_thread_workers())
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/_inductor/async_compile.py
+++ b/torch/_inductor/async_compile.py
@@ -195,6 +195,7 @@ def after_fork():
     _pool_set.clear()
     AsyncCompile._ready_future = None
     AsyncCompile.process_pool.cache_clear()
+    AsyncCompile.thread_pool.cache_clear()
 
 
 try:
@@ -351,6 +352,54 @@ class AsyncCompile:
 
         _pool_set.add(pool)
         return pool
+
+    @staticmethod
+    @functools.lru_cache(1)
+    def thread_pool() -> ThreadPoolExecutor:
+        """
+        Thread pool for Triton compilation in nogil mode.
+
+        Separate from pool() to allow different sizing/configuration
+        for CPU-intensive Triton compilation workloads.
+        """
+        if get_compile_threads() <= 1:
+            raise AssertionError(
+                f"expected get_compile_threads() > 1, got {get_compile_threads()}"
+            )
+        log.info(
+            "Creating thread pool with %d workers for nogil Triton compilation",
+            get_compile_threads(),
+        )
+        pool = ThreadPoolExecutor(
+            get_compile_threads(),
+            thread_name_prefix="triton_compile_",
+        )
+        _pool_set.add(pool)
+        return pool
+
+    @classmethod
+    def should_use_thread_workers(cls) -> bool:
+        """
+        Determine if thread workers should be used instead of process workers.
+
+        Returns True when running free-threaded Python or when explicitly
+        configured via compile_worker_mode.
+        """
+        from torch._inductor.utils import should_use_thread_workers
+
+        return should_use_thread_workers()
+
+    @classmethod
+    def get_worker_pool(cls) -> ThreadPoolExecutor | AnyPool:
+        """
+        Get the appropriate worker pool based on configuration.
+
+        Returns thread pool for nogil mode, process pool otherwise.
+        """
+        if cls.should_use_thread_workers():
+            return cls.thread_pool()
+        else:
+            return cls.process_pool()
 
     @classmethod
     def warm_pool(cls) -> None:

--- a/torch/_inductor/async_compile.py
+++ b/torch/_inductor/async_compile.py
@@ -56,6 +56,7 @@ from torch._inductor.runtime.compile_tasks import (
     _set_triton_ptxas_path,
     _worker_compile_pycodecache_kernel,
     _worker_compile_triton,
+    _worker_compile_triton_thread,
 )
 from torch._inductor.utils import clear_on_fresh_cache
 from torch._inductor.virtualized import V
@@ -336,6 +337,7 @@ class AsyncCompile:
             if config.worker_start_method == "spawn":
                 # Avoid creating pools in the spawned subprocs themselves:
                 os.environ["TORCH_WARM_POOL"] = "0"
+            # Only need pre-fork setup for process pools, not thread pools
             pre_fork_setup()
             ctx = multiprocessing.get_context(config.worker_start_method)
             pool = TrackedProcessPoolExecutor(
@@ -409,7 +411,11 @@ class AsyncCompile:
         # Pool is created on first access. Note for a SubprocPool, the sidecar process starts,
         # but its ProcessPoolExecutor does not initialize until a wakeup() call or the first
         # job is submitted.
-        cls.process_pool()
+        # For thread pools, this is a no-op since thread pool creation is very cheap.
+        if cls.should_use_thread_workers():
+            cls.thread_pool()
+        else:
+            cls.process_pool()
         _compile_end()
 
     @classmethod
@@ -584,8 +590,16 @@ class AsyncCompile:
                         fn_hash: torch._inductor.config.autotune_lookup_table[fn_hash]
                     }
 
-            task = self.process_pool().submit(
-                _worker_compile_triton,
+            # Select appropriate pool and worker function based on mode
+            pool = self.get_worker_pool()
+            worker_fn = (
+                _worker_compile_triton_thread
+                if self.should_use_thread_workers()
+                else _worker_compile_triton
+            )
+
+            task = pool.submit(
+                worker_fn,
                 load_kernel,
                 extra_env,
                 extra_config,
@@ -602,7 +616,10 @@ class AsyncCompile:
                 kernel.set_compile_info(compile_id, is_backward)
                 CompiledTritonKernels.remove_future(source_code)
 
-                kernel.restore_after_unpickle(old_values=None)
+                # Only restore after unpickle in process mode
+                # Thread mode doesn't pickle, so kernel is already in correct state
+                if not self.should_use_thread_workers():
+                    kernel.restore_after_unpickle(old_values=None)
 
                 kernel.precompile(
                     warm_cache_only=False,

--- a/torch/_inductor/autotune_process.py
+++ b/torch/_inductor/autotune_process.py
@@ -316,31 +316,26 @@ class TuningProcess:
         self.start()
 
 
-class TuningProcessPool:
+class TuningPoolBase:
     """
-    Maintains a pool of TuningProcesses to benchmark kernels in parallel
-    across devices. By default, we create one TuningProcess per device and
-    set the sub-process environment to make only that device visible.
+    Base class for pools that benchmark kernels in parallel across devices.
+
+    A ThreadPoolExecutor dispatches choices to workers, and each worker claims
+    one per-device resource for the duration of a benchmark. Subclasses decide
+    what that resource is (a benchmarking subprocess for TuningProcessPool, an
+    in-process device slot for TuningThreadPool) and implement target()
+    accordingly.
     """
 
     def __init__(self) -> None:
-        """
-        Start the child processes.
-        """
-        devices = self.get_device_list()
-        autotuning_log.debug("Sub-process autotune device list: %s", devices)
+        self.devices = self.get_device_list()
+        autotuning_log.debug(
+            "%s autotune device list: %s", type(self).__name__, self.devices
+        )
 
-        # Launch the child processes.
-        self.processes = [TuningProcess(device=device) for device in devices]
-
-        self.process_queue: queue.Queue[TuningProcess] = queue.Queue()
-        for p in self.processes:
-            self.process_queue.put(p)
-
-        # Use a thread pool to manage distributing work to the subprocesses.
-        # Threads block on an available process, so it makes sense to match
-        # the number of threads with the number of devices.
-        self.executor = ThreadPoolExecutor(max_workers=len(devices))
+        # Threads block on an available per-device resource, so match the
+        # number of threads to the number of devices.
+        self.executor = ThreadPoolExecutor(max_workers=len(self.devices))
 
     @staticmethod
     def get_device_list() -> Sequence[int | None]:
@@ -368,11 +363,55 @@ class TuningProcessPool:
 
         return list(range(count))
 
+    def target(self, choice: TritonTemplateCaller) -> float:
+        """
+        Benchmark a single choice on one per-device resource. Invoked by the
+        executor's worker threads.
+        """
+        raise NotImplementedError
+
+    def shutdown(self) -> None:
+        """
+        Shut down the executor.
+        """
+        self.executor.shutdown(wait=True)
+
+    def benchmark(
+        self,
+        choices: list[TritonTemplateCaller],
+    ) -> dict[TritonTemplateCaller, float]:
+        """
+        Benchmark each choice, spreading the work across the pool's workers and
+        grabbing per-device resources as soon as they're free.
+        """
+        return dict(zip(choices, self.executor.map(self.target, choices)))
+
+
+class TuningProcessPool(TuningPoolBase):
+    """
+    Maintains a pool of TuningProcesses to benchmark kernels in parallel
+    across devices. By default, we create one TuningProcess per device and
+    set the sub-process environment to make only that device visible.
+    """
+
+    def __init__(self) -> None:
+        """
+        Start the child processes.
+        """
+        super().__init__()
+
+        # Launch the child processes.
+        self.processes = [TuningProcess(device=device) for device in self.devices]
+
+        self.process_queue: queue.Queue[TuningProcess] = queue.Queue()
+        for p in self.processes:
+            self.process_queue.put(p)
+
     def shutdown(self) -> None:
         """
         Signal all child processes to exit.
         """
-        self.executor.shutdown()
+        super().shutdown()
 
         for p in self.processes:
             p.shutdown(wait=False)
@@ -381,9 +420,8 @@ class TuningProcessPool:
 
     def target(self, choice: TritonTemplateCaller) -> float:
         """
-        Entry point for the thread-pool helper threads: Wait for an open TuningProcess,
-        remove it from the queue, execute the benchmark in that subprocess, and return
-        the TuningProcess to the queue.
+        Wait for an open TuningProcess, remove it from the queue, execute the
+        benchmark in that subprocess, and return the TuningProcess to the queue.
         """
         if choice.bmreq is None:
             raise AssertionError(
@@ -422,19 +460,67 @@ class TuningProcessPool:
         finally:
             self.process_queue.put(process)
 
-    def benchmark(
-        self,
-        choices: list[TritonTemplateCaller],
-    ) -> dict[TritonTemplateCaller, float]:
-        """
-        Benchmark each choice in a separate process.
-        """
 
-        # Use a ThreadExecutorPool to spread the work across the subprocesses and
-        # to grab subprocesses as soon as they're free.
-        results = dict(zip(choices, self.executor.map(self.target, choices)))
+class TuningThreadPool(TuningPoolBase):
+    """
+    Thread-based version of TuningProcessPool for nogil Python.
 
-        return results
+    Simpler than process-based version since threads share memory:
+    - No subprocess management
+    - No pickling overhead
+    - No pipe communication
+    - Thread-safe device locking instead of process isolation
+    """
+
+    def __init__(self) -> None:
+        """
+        Initialize the thread pool with per-device locks.
+        """
+        super().__init__()
+
+        # Create locks for thread-safe device access
+        self.device_locks = {device: threading.Lock() for device in self.devices}
+
+        # Track which device each thread should use
+        self.device_queue: queue.Queue[int | None] = queue.Queue()
+        for device in self.devices:
+            self.device_queue.put(device)
+
+    def target(self, choice: TritonTemplateCaller) -> float:
+        """
+        Benchmark a single choice in a worker thread.
+        Acquires device lock to ensure thread-safe execution.
+        """
+        if choice.bmreq is None:
+            raise AssertionError(
+                f"Expected choice.bmreq to be set, but got None for choice '{choice}'"
+            )
+
+        # Get an available device
+        device = self.device_queue.get()
+        try:
+            # Acquire lock for this device
+            lock = self.device_locks[device]
+            with lock:
+                # Set device if specified
+                if device is not None:
+                    gpu_type = get_gpu_type()
+                    device_interface = get_interface_for_device(gpu_type)
+                    device_interface.set_device(device)
+
+                # Run benchmark directly (no subprocess, no pickling)
+                try:
+                    return choice.bmreq.benchmark()
+                except Exception:
+                    warnings.warn(
+                        f"Failed to benchmark choice '{choice}'. It will be ignored. "
+                        "Please debug the root cause in case the choice can bring perf gains."
+                    )
+                    # Set to INF so this choice will be ignored
+                    return float("inf")
+        finally:
+            # Return device to queue
+            self.device_queue.put(device)
 
 
 LayoutOrBuffer = ir.Layout | ir.Buffer
@@ -1409,19 +1495,48 @@ def get_tuning_process_pool() -> TuningProcessPool:
     return pool
 
 
+@functools.cache
+def get_tuning_thread_pool() -> TuningThreadPool:
+    """
+    Get the singleton TuningThreadPool for nogil autotuning.
+    """
+    pool = TuningThreadPool()
+    atexit.register(pool.shutdown)
+    return pool
+
+
+def get_tuning_pool() -> TuningThreadPool | TuningProcessPool:
+    """
+    Get the appropriate tuning pool based on compile_worker_mode.
+
+    Returns TuningThreadPool for thread mode, TuningProcessPool otherwise.
+    """
+    from torch._inductor.utils import should_use_thread_workers
+
+    if should_use_thread_workers():
+        return get_tuning_thread_pool()
+    else:
+        return get_tuning_process_pool()
+
+
 def benchmark_in_sub_process(
     choices: list[TritonTemplateCaller],
 ) -> dict[TritonTemplateCaller, float]:
     """
-    Do benchmarking in a subprocess and return the perf number (latency).
+    Do benchmarking in a worker (subprocess or thread) and return the perf number (latency).
+
+    Uses subprocess pool in process mode, thread pool in thread mode.
     """
-    return get_tuning_process_pool().benchmark(choices)
+    return get_tuning_pool().benchmark(choices)
 
 
 class AutotuneProcessPool:
     """
     Singleton pool manager for running autotuning (precompilation + benchmarking)
-    in a separate process.
+    in a separate worker.
+
+    Uses a subprocess pool by default and a thread pool when
+    `should_use_thread_workers()` is true (e.g. free-threaded Python).
     """
 
     _instance: AutotuneProcessPool | None = None
@@ -1429,7 +1544,7 @@ class AutotuneProcessPool:
     _shutdown_for_inactivity: bool = False
 
     def __init__(self):
-        self._pool: ProcessPoolExecutor | None = self._init_pool()
+        self._pool: ProcessPoolExecutor | ThreadPoolExecutor | None = self._init_pool()
         self._warmup_future: Future[Any] | None = None
         self._warmup_start_time: float | None = None
         self._timer: Timer | None = self._init_timer()
@@ -1446,7 +1561,7 @@ class AutotuneProcessPool:
 
     @property
     def pool(self):
-        """Get the process pool."""
+        """Get the worker pool (process or thread)."""
         if not config.pipeline_max_autotune_gemm:
             raise AssertionError(
                 "To use AutotuneProcessPool, pipeline_max_autotune_gemm must be enabled"
@@ -1484,22 +1599,31 @@ class AutotuneProcessPool:
 
     def _init_pool(self):
         """
-        Get or create the process pool.
+        Get or create the worker pool.
 
-        Uses ProcessPoolExecutor with 'spawn' context for CUDA safety.
-        ProcessPoolExecutor is lazily initialized - workers are not spawned
-        until the first submit() call, making this property non-blocking.
+        On free-threaded Python (or when thread workers are explicitly enabled
+        via TORCHINDUCTOR_COMPILE_THREADS) returns a ThreadPoolExecutor so
+        autotuning runs in-process without subprocess/spawn overhead.
+        Otherwise returns a ProcessPoolExecutor with 'spawn' context for CUDA
+        safety. Workers are spawned lazily on first submit().
         """
-        # Use 'spawn' context to avoid CUDA fork issues
-        # Workers are spawned lazily on first submit(), not here
-        ctx = mp.get_context("spawn")
-        pool = ProcessPoolExecutor(
-            max_workers=1,
-            mp_context=ctx,
-        )
-        atexit.register(self._shutdown)
-        autotuning_log.info("AutotuneProcessPool created (workers spawn lazily)")
+        from torch._inductor.utils import should_use_thread_workers
 
+        if should_use_thread_workers():
+            pool: ProcessPoolExecutor | ThreadPoolExecutor = ThreadPoolExecutor(
+                max_workers=1,
+            )
+            autotuning_log.info("AutotuneProcessPool created (thread mode)")
+        else:
+            # Use 'spawn' context to avoid CUDA fork issues
+            ctx = mp.get_context("spawn")
+            pool = ProcessPoolExecutor(
+                max_workers=1,
+                mp_context=ctx,
+            )
+            autotuning_log.info("AutotuneProcessPool created (workers spawn lazily)")
+
+        atexit.register(self._shutdown)
         return pool
 
     def warm_up(self) -> Future[Any]:

--- a/torch/_inductor/autotune_process.py
+++ b/torch/_inductor/autotune_process.py
@@ -431,6 +431,90 @@ class TuningProcessPool:
         return results
 
 
+class TuningThreadPool:
+    """
+    Thread-based version of TuningProcessPool for nogil Python.
+
+    Simpler than process-based version since threads share memory:
+    - No subprocess management
+    - No pickling overhead
+    - No pipe communication
+    - Thread-safe device locking instead of process isolation
+    """
+
+    def __init__(self) -> None:
+        """
+        Initialize the thread pool with per-device locks.
+        """
+        import threading
+
+        devices = TuningProcessPool.get_device_list()
+        autotuning_log.debug("Thread-pool autotune device list: %s", devices)
+
+        # Create locks for thread-safe device access
+        self.device_locks = {device: threading.Lock() for device in devices}
+
+        # Use a thread pool with one worker per device
+        self.executor = ThreadPoolExecutor(max_workers=len(devices))
+
+        # Track which device each thread should use
+        self.device_queue: queue.Queue[int | None] = queue.Queue()
+        for device in devices:
+            self.device_queue.put(device)
+
+    def shutdown(self) -> None:
+        """
+        Shutdown the thread pool.
+        """
+        self.executor.shutdown(wait=True)
+
+    def target(self, choice: TritonTemplateCaller) -> float:
+        """
+        Benchmark a single choice in a worker thread.
+        Acquires device lock to ensure thread-safe execution.
+        """
+        if choice.bmreq is None:
+            raise AssertionError(
+                f"Expected choice.bmreq to be set, but got None for choice '{choice}'"
+            )
+
+        # Get an available device
+        device = self.device_queue.get()
+        try:
+            # Acquire lock for this device
+            lock = self.device_locks[device]
+            with lock:
+                # Set device if specified
+                if device is not None:
+                    gpu_type = get_gpu_type()
+                    device_interface = get_interface_for_device(gpu_type)
+                    device_interface.set_device(device)
+
+                # Run benchmark directly (no subprocess, no pickling)
+                try:
+                    return choice.bmreq.benchmark()
+                except Exception:
+                    warnings.warn(
+                        f"Failed to benchmark choice '{choice}'. It will be ignored. "
+                        "Please debug the root cause in case the choice can bring perf gains."
+                    )
+                    # Set to INF so this choice will be ignored
+                    return float("inf")
+        finally:
+            # Return device to queue
+            self.device_queue.put(device)
+
+    def benchmark(
+        self,
+        choices: list[TritonTemplateCaller],
+    ) -> dict[TritonTemplateCaller, float]:
+        """
+        Benchmark each choice using the thread pool.
+        """
+        results = dict(zip(choices, self.executor.map(self.target, choices)))
+        return results
+
+
 LayoutOrBuffer = ir.Layout | ir.Buffer
 
 
@@ -1354,19 +1438,48 @@ def get_tuning_process_pool() -> TuningProcessPool:
     return pool
 
 
+@functools.cache
+def get_tuning_thread_pool() -> TuningThreadPool:
+    """
+    Get the singleton TuningThreadPool for nogil autotuning.
+    """
+    pool = TuningThreadPool()
+    atexit.register(pool.shutdown)
+    return pool
+
+
+def get_tuning_pool() -> TuningThreadPool | TuningProcessPool:
+    """
+    Get the appropriate tuning pool based on compile_worker_mode.
+
+    Returns TuningThreadPool for thread mode, TuningProcessPool otherwise.
+    """
+    from torch._inductor.utils import should_use_thread_workers
+
+    if should_use_thread_workers():
+        return get_tuning_thread_pool()
+    else:
+        return get_tuning_process_pool()
+
+
 def benchmark_in_sub_process(
     choices: list[TritonTemplateCaller],
 ) -> dict[TritonTemplateCaller, float]:
     """
-    Do benchmarking in a subprocess and return the perf number (latency).
+    Do benchmarking in a worker (subprocess or thread) and return the perf number (latency).
+
+    Uses subprocess pool in process mode, thread pool in thread mode.
     """
-    return get_tuning_process_pool().benchmark(choices)
+    return get_tuning_pool().benchmark(choices)
 
 
 class AutotuneProcessPool:
     """
     Singleton pool manager for running autotuning (precompilation + benchmarking)
-    in a separate process.
+    in a separate worker.
+
+    Uses a subprocess pool by default and a thread pool when
+    `should_use_thread_workers()` is true (e.g. free-threaded Python).
     """
 
     _instance: AutotuneProcessPool | None = None
@@ -1374,7 +1487,7 @@ class AutotuneProcessPool:
     _shutdown_for_inactivity: bool = False
 
     def __init__(self):
-        self._pool: ProcessPoolExecutor | None = self._init_pool()
+        self._pool: ProcessPoolExecutor | ThreadPoolExecutor | None = self._init_pool()
         self._warmup_future: Future[Any] | None = None
         self._warmup_start_time: float | None = None
         self._timer: Timer | None = self._init_timer()
@@ -1391,7 +1504,7 @@ class AutotuneProcessPool:
 
     @property
     def pool(self):
-        """Get the process pool."""
+        """Get the worker pool (process or thread)."""
         if not config.pipeline_max_autotune_gemm:
             raise AssertionError(
                 "To use AutotuneProcessPool, pipeline_max_autotune_gemm must be enabled"
@@ -1429,22 +1542,31 @@ class AutotuneProcessPool:
 
     def _init_pool(self):
         """
-        Get or create the process pool.
+        Get or create the worker pool.
 
-        Uses ProcessPoolExecutor with 'spawn' context for CUDA safety.
-        ProcessPoolExecutor is lazily initialized - workers are not spawned
-        until the first submit() call, making this property non-blocking.
+        On free-threaded Python (or when thread workers are explicitly enabled
+        via TORCHINDUCTOR_COMPILE_THREADS) returns a ThreadPoolExecutor so
+        autotuning runs in-process without subprocess/spawn overhead.
+        Otherwise returns a ProcessPoolExecutor with 'spawn' context for CUDA
+        safety. Workers are spawned lazily on first submit().
         """
-        # Use 'spawn' context to avoid CUDA fork issues
-        # Workers are spawned lazily on first submit(), not here
-        ctx = mp.get_context("spawn")
-        pool = ProcessPoolExecutor(
-            max_workers=1,
-            mp_context=ctx,
-        )
-        atexit.register(self._shutdown)
-        autotuning_log.info("AutotuneProcessPool created (workers spawn lazily)")
+        from torch._inductor.utils import should_use_thread_workers
 
+        if should_use_thread_workers():
+            pool: ProcessPoolExecutor | ThreadPoolExecutor = ThreadPoolExecutor(
+                max_workers=1,
+            )
+            autotuning_log.info("AutotuneProcessPool created (thread mode)")
+        else:
+            # Use 'spawn' context to avoid CUDA fork issues
+            ctx = mp.get_context("spawn")
+            pool = ProcessPoolExecutor(
+                max_workers=1,
+                mp_context=ctx,
+            )
+            autotuning_log.info("AutotuneProcessPool created (workers spawn lazily)")
+
+        atexit.register(self._shutdown)
         return pool
 
     def warm_up(self) -> Future[Any]:

--- a/torch/_inductor/compile_worker/subproc_pool.py
+++ b/torch/_inductor/compile_worker/subproc_pool.py
@@ -14,7 +14,7 @@ import time
 import traceback
 import typing
 from collections.abc import Callable
-from concurrent.futures import Future, ProcessPoolExecutor
+from concurrent.futures import Future, ProcessPoolExecutor, ThreadPoolExecutor
 from concurrent.futures.process import BrokenProcessPool
 from dataclasses import dataclass
 from enum import Enum, IntEnum
@@ -933,7 +933,7 @@ class SubprocMain:
             watchdog.clear_current_job()
 
 
-AnyPool = ProcessPoolExecutor | SubprocPool
+AnyPool = ProcessPoolExecutor | SubprocPool | ThreadPoolExecutor
 
 
 def _get_process_pool_processes(pool: ProcessPoolExecutor) -> list[Any]:

--- a/torch/_inductor/compile_worker/subproc_pool.py
+++ b/torch/_inductor/compile_worker/subproc_pool.py
@@ -14,7 +14,7 @@ import time
 import traceback
 import typing
 from collections.abc import Callable
-from concurrent.futures import Future, ProcessPoolExecutor
+from concurrent.futures import Future, ProcessPoolExecutor, ThreadPoolExecutor
 from concurrent.futures.process import BrokenProcessPool
 from enum import Enum, IntEnum
 from pathlib import Path
@@ -763,7 +763,7 @@ class SubprocMain:
             watchdog.clear_current_job()
 
 
-AnyPool = ProcessPoolExecutor | SubprocPool
+AnyPool = ProcessPoolExecutor | SubprocPool | ThreadPoolExecutor
 
 
 def _get_process_pool_processes(pool: ProcessPoolExecutor) -> list[Any]:

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -3004,6 +3004,7 @@ _cache_config_ignore_prefix: list[str] = [
     # not relevant
     "worker_start_method",
     "compile_threads",
+    "compile_worker_mode",
     # see CustomGraphPass; these are handled specially
     "post_grad_custom_post_pass",
     "post_grad_custom_pre_pass",

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1436,6 +1436,41 @@ def decide_compile_threads() -> int:
 # TODO: Set directly after internal rollout.
 compile_threads: int | None = None if is_fbcode() else decide_compile_threads()
 
+
+def decide_compile_worker_mode() -> str:
+    """
+    Decide whether to use threads or processes for compilation workers.
+
+    Returns one of: "auto", "process", "thread"
+    - "auto": Automatically detect if Python is free-threaded (nogil) and use
+              threads if available, otherwise use processes
+    - "process": Force multiprocessing (current behavior, compatible with all Python)
+    - "thread": Force threading (requires free-threaded Python build)
+
+    Precedence:
+    1. TORCH_COMPILE_WORKER_MODE environment variable
+    2. Default to "process" for safe multiprocessing
+    """
+    mode = os.environ.get("TORCH_COMPILE_WORKER_MODE", "process")
+    valid_modes = ("auto", "process", "thread")
+    if mode not in valid_modes:
+        import logging
+
+        log = logging.getLogger(__name__)
+        log.warning(
+            "Invalid TORCH_COMPILE_WORKER_MODE='%s'. "
+            "Valid options: %s. Defaulting to 'process'.",
+            mode,
+            ", ".join(sorted(valid_modes)),
+        )
+        mode = "process"
+    return mode
+
+
+# Controls whether compilation workers use threads or processes.
+# Options: "auto" (detect nogil), "process" (force multiprocessing), "thread" (force threading)
+compile_worker_mode: str = decide_compile_worker_mode()
+
 # Whether to quiesce the Triton-compile subprocess pool at the end of each compilation.
 quiesce_async_compile_pool: bool = Config(
     justknob="pytorch/inductor:quiesce_async_compile_pool",

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1517,6 +1517,41 @@ def decide_compile_threads() -> int:
 # TODO: Set directly after internal rollout.
 compile_threads: int | None = None if is_fbcode() else decide_compile_threads()
 
+
+def decide_compile_worker_mode() -> str:
+    """
+    Decide whether to use threads or processes for compilation workers.
+
+    Returns one of: "auto", "process", "thread"
+    - "auto": Automatically detect if Python is free-threaded (nogil) and use
+              threads if available, otherwise use processes
+    - "process": Force multiprocessing (current behavior, compatible with all Python)
+    - "thread": Force threading (requires free-threaded Python build)
+
+    Precedence:
+    1. TORCH_COMPILE_WORKER_MODE environment variable
+    2. Default to "process" for safe multiprocessing
+    """
+    mode = os.environ.get("TORCH_COMPILE_WORKER_MODE", "process")
+    valid_modes = ("auto", "process", "thread")
+    if mode not in valid_modes:
+        import logging
+
+        log = logging.getLogger(__name__)
+        log.warning(
+            "Invalid TORCH_COMPILE_WORKER_MODE='%s'. "
+            "Valid options: %s. Defaulting to 'process'.",
+            mode,
+            ", ".join(sorted(valid_modes)),
+        )
+        mode = "process"
+    return mode
+
+
+# Controls whether compilation workers use threads or processes.
+# Options: "auto" (detect nogil), "process" (force multiprocessing), "thread" (force threading)
+compile_worker_mode: str = decide_compile_worker_mode()
+
 # Whether to quiesce the Triton-compile subprocess pool at the end of each compilation.
 quiesce_async_compile_pool: bool = Config(
     justknob="pytorch/inductor:quiesce_async_compile_pool",

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -3122,6 +3122,7 @@ _cache_config_ignore_prefix: list[str] = [
     # it has no effect on compiled output, so including it would change the
     # config hash and needlessly invalidate every cache entry
     "compile_worker_watchdog_interval_seconds",
+    "compile_worker_mode",
     # see CustomGraphPass; these are handled specially
     "post_grad_custom_post_pass",
     "post_grad_custom_pre_pass",

--- a/torch/_inductor/runtime/compile_tasks.py
+++ b/torch/_inductor/runtime/compile_tasks.py
@@ -238,3 +238,55 @@ def _worker_compile_triton(
             raise
         finally:
             log_triton_builds(fail=fail)
+
+
+def _worker_compile_triton_thread(
+    load_kernel: Callable[[], CachingAutotuner],
+    extra_env: dict[str, str | None],
+    extra_config: dict[str, Any],
+) -> tuple[CachingAutotuner, int]:
+    """
+    Thread-mode worker for Triton compilation (nogil).
+
+    Unlike _worker_compile_triton, this doesn't need to:
+    - Prepare kernel for pickling (threads share memory)
+    - Handle subprocess-specific setup
+
+    But still needs to:
+    - Set TRITON_PTXAS_PATH
+    - Update environment (threads share environment, but updates persist)
+    - Patch config temporarily
+    """
+    _set_triton_ptxas_path()
+
+    # Environment updates in threads are shared across the process,
+    # but that's okay - these are compilation settings
+    if extra_env:
+        # os.environ values must be str; skip unset (None) entries.
+        os.environ.update({k: v for k, v in extra_env.items() if v is not None})
+        # Set libdevice path if passed via env from main process
+        libdevice_path = extra_env.get("TRITON_LIBDEVICE_PATH")
+        if libdevice_path:
+            try:
+                from triton import knobs
+
+                knobs.nvidia.libdevice_path = libdevice_path
+            except ImportError:
+                pass
+
+    from torch._inductor import config
+
+    with config.patch(extra_config):
+        fail = None
+        try:
+            start_ns = time.time_ns()
+            kernel = load_kernel()
+            kernel.precompile(warm_cache_only=True)
+            elapsed_ns = time.time_ns() - start_ns
+            # No need for prepare_for_pickle() - threads share memory
+            return kernel, elapsed_ns // 1000
+        except Exception as e:
+            fail = str(e)
+            raise
+        finally:
+            log_triton_builds(fail=fail)

--- a/torch/_inductor/runtime/compile_tasks.py
+++ b/torch/_inductor/runtime/compile_tasks.py
@@ -235,3 +235,55 @@ def _worker_compile_triton(
             raise
         finally:
             log_triton_builds(fail=fail)
+
+
+def _worker_compile_triton_thread(
+    load_kernel: Callable[[], CachingAutotuner],
+    extra_env: dict[str, str | None],
+    extra_config: dict[str, Any],
+) -> tuple[CachingAutotuner, int]:
+    """
+    Thread-mode worker for Triton compilation (nogil).
+
+    Unlike _worker_compile_triton, this doesn't need to:
+    - Prepare kernel for pickling (threads share memory)
+    - Handle subprocess-specific setup
+
+    But still needs to:
+    - Set TRITON_PTXAS_PATH
+    - Update environment (threads share environment, but updates persist)
+    - Patch config temporarily
+    """
+    _set_triton_ptxas_path()
+
+    # Environment updates in threads are shared across the process,
+    # but that's okay - these are compilation settings
+    if extra_env:
+        # os.environ values must be str; skip unset (None) entries.
+        os.environ.update({k: v for k, v in extra_env.items() if v is not None})
+        # Set libdevice path if passed via env from main process
+        libdevice_path = extra_env.get("TRITON_LIBDEVICE_PATH")
+        if libdevice_path:
+            try:
+                from triton import knobs
+
+                knobs.nvidia.libdevice_path = libdevice_path
+            except ImportError:
+                pass
+
+    from torch._inductor import config
+
+    with config.patch(extra_config):
+        fail = None
+        try:
+            start_ns = time.time_ns()
+            kernel = load_kernel()
+            kernel.precompile(warm_cache_only=True)
+            elapsed_ns = time.time_ns() - start_ns
+            # No need for prepare_for_pickle() - threads share memory
+            return kernel, elapsed_ns // 1000
+        except Exception as e:
+            fail = str(e)
+            raise
+        finally:
+            log_triton_builds(fail=fail)

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -4077,8 +4077,8 @@ class AlgorithmSelectorCache(PersistentCache):
 
         has_cutlass = any(isinstance(c, CUTLASSTemplateCaller) for c in choices)
         if config.autotune_in_subproc or has_cutlass:
-            # Warmup the subprocess pool early so it's ready for benchmarking
-            torch._inductor.autotune_process.get_tuning_process_pool()
+            # Initialize the worker pool (subprocess or thread) so it will warmup early.
+            torch._inductor.autotune_process.get_tuning_pool()
 
         precompile_fn = self.make_precompile_fn(
             choices,

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -4224,8 +4224,8 @@ class AlgorithmSelectorCache(PersistentCache):
 
         has_cutlass = any(isinstance(c, CUTLASSTemplateCaller) for c in choices)
         if config.autotune_in_subproc or has_cutlass:
-            # Warmup the subprocess pool early so it's ready for benchmarking
-            torch._inductor.autotune_process.get_tuning_process_pool()
+            # Initialize the worker pool (subprocess or thread) so it will warmup early.
+            torch._inductor.autotune_process.get_tuning_pool()
 
         precompile_fn = self.make_precompile_fn(
             choices,

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -121,6 +121,46 @@ def get_gpu_type() -> str:
     return gpu_type
 
 
+def has_free_threaded_python() -> bool:
+    """
+    Detect if Python is running in free-threaded mode (without GIL).
+
+    Uses the sys._is_gil_enabled() API available in Python 3.13+ with
+    the --disable-gil flag or PEP 703 implementation.
+
+    Returns:
+        bool: True if running free-threaded Python, False otherwise
+    """
+    # Python 3.13+ with free-threading support
+    # Standard Python (always has GIL)
+    return hasattr(sys, "_is_gil_enabled") and not sys._is_gil_enabled()
+
+
+def should_use_thread_workers() -> bool:
+    """
+    Determine if compilation workers should use threads instead of processes.
+
+    Checks the compile_worker_mode config and nogil availability.
+
+    Returns:
+        bool: True if thread workers should be used, False for process workers
+    """
+    from torch._inductor import config
+
+    mode = config.compile_worker_mode
+
+    if mode == "thread":
+        return True
+    elif mode == "process":
+        return False
+    elif mode == "auto":
+        return has_free_threaded_python()
+    else:
+        raise ValueError(
+            f"Invalid compile_worker_mode: {mode!r}. Expected one of 'thread', 'process', or 'auto'."
+        )
+
+
 from torch._dynamo.device_interface import get_interface_for_device
 from torch._dynamo.utils import detect_fake_mode
 from torch.autograd import DeviceType

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -171,6 +171,46 @@ def get_gpu_type() -> str:
     return chosen
 
 
+def has_free_threaded_python() -> bool:
+    """
+    Detect if Python is running in free-threaded mode (without GIL).
+
+    Uses the sys._is_gil_enabled() API available in Python 3.13+ with
+    the --disable-gil flag or PEP 703 implementation.
+
+    Returns:
+        bool: True if running free-threaded Python, False otherwise
+    """
+    # Python 3.13+ with free-threading support
+    # Standard Python (always has GIL)
+    return hasattr(sys, "_is_gil_enabled") and not sys._is_gil_enabled()
+
+
+def should_use_thread_workers() -> bool:
+    """
+    Determine if compilation workers should use threads instead of processes.
+
+    Checks the compile_worker_mode config and nogil availability.
+
+    Returns:
+        bool: True if thread workers should be used, False for process workers
+    """
+    from torch._inductor import config
+
+    mode = config.compile_worker_mode
+
+    if mode == "thread":
+        return True
+    elif mode == "process":
+        return False
+    elif mode == "auto":
+        return has_free_threaded_python()
+    else:
+        raise ValueError(
+            f"Invalid compile_worker_mode: {mode!r}. Expected one of 'thread', 'process', or 'auto'."
+        )
+
+
 from torch._dynamo.device_interface import get_interface_for_device
 from torch._dynamo.utils import detect_fake_mode
 from torch.autograd import DeviceType


### PR DESCRIPTION
Summary:
This change adds support for thread-based Triton compilation workers when running with free-threaded Python (PEP 703). When the GIL is disabled, we can use threads instead of processes for compilation, avoiding expensive process spawning overhead.

Key changes:
- Add `should_use_thread_workers()` to detect free-threaded Python or explicit thread mode configuration
- Add `AsyncCompile.thread_pool()` for thread-based Triton compilation
- Add `_worker_compile_triton_thread()` worker function that runs in thread context
- Add `TuningThreadPool` for autotuning with threads
- Update `AsyncCompile.triton()` to use thread pool when appropriate
- Skip fork-related workarounds when using threads

The implementation automatically detects free-threaded Python via `sys._is_gil_enabled()` and falls back to the existing process-based workers on standard Python. An environment variable `TORCHINDUCTOR_COMPILE_THREADS` can be used to explicitly enable thread mode.


Test Plan: Tested with Python 3.13t (free-threaded) and verified compilation works correctly with thread workers.

Reviewed By: atalman

Pulled By:
alrobichaud

alrobichaud

Differential Revision: D88426731




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo