### PR TITLE
  [inductor] Add dedicated thread pool for nogil Triton compilation (#179548) (#179548) (#179548)

### DIFF
--- a/test/inductor/test_thread_pool.py
+++ b/test/inductor/test_thread_pool.py
@@ -1,0 +1,48 @@
+# Owner(s): ["module: inductor"]
+"""Test thread pool for Triton compilation."""
+
+from concurrent.futures import ThreadPoolExecutor
+
+import torch._inductor.config as config
+from torch._inductor.async_compile import AsyncCompile
+from torch._inductor.test_case import run_tests, TestCase
+
+
+class TestThreadPool(TestCase):
+    def setUp(self):
+        super().setUp()
+        self._orig_mode = config.compile_worker_mode
+        self._orig_threads = config.compile_threads
+        # Ensure we have multiple compile threads
+        if config.compile_threads is None or config.compile_threads <= 1:
+            config.compile_threads = 4
+
+    def tearDown(self):
+        config.compile_worker_mode = self._orig_mode
+        config.compile_threads = self._orig_threads
+        AsyncCompile.thread_pool.cache_clear()
+        AsyncCompile.process_pool.cache_clear()
+        super().tearDown()
+
+    def test_thread_pool_creation(self):
+        """Thread pool is created as a ThreadPoolExecutor with correct worker count."""
+        config.compile_worker_mode = "thread"
+        AsyncCompile.thread_pool.cache_clear()
+
+        pool = AsyncCompile.thread_pool()
+        self.assertIsInstance(pool, ThreadPoolExecutor)
+        self.assertEqual(pool._max_workers, config.compile_threads)
+
+    def test_should_use_thread_workers_thread_mode(self):
+        """should_use_thread_workers returns True in thread mode."""
+        config.compile_worker_mode = "thread"
+        self.assertTrue(AsyncCompile.should_use_thread_workers())
+
+    def test_should_use_thread_workers_process_mode(self):
+        """should_use_thread_workers returns False in process mode."""
+        config.compile_worker_mode = "process"
+        self.assertFalse(AsyncCompile.should_use_thread_workers())
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/inductor/test_thread_pool.py
+++ b/test/inductor/test_thread_pool.py
@@ -1,0 +1,50 @@
+# Owner(s): ["module: inductor"]
+"""Test thread pool for Triton compilation."""
+
+from concurrent.futures import ThreadPoolExecutor
+
+import torch._inductor.config as config
+from torch._inductor.async_compile import AsyncCompile, shutdown_compile_workers
+from torch._inductor.test_case import run_tests, TestCase
+
+
+class TestThreadPool(TestCase):
+    def setUp(self):
+        super().setUp()
+        self._orig_mode = config.compile_worker_mode
+        self._orig_threads = config.compile_threads
+        # Ensure we have multiple compile threads
+        if config.compile_threads is None or config.compile_threads <= 1:
+            config.compile_threads = 4
+
+    def tearDown(self):
+        config.compile_worker_mode = self._orig_mode
+        config.compile_threads = self._orig_threads
+        AsyncCompile.thread_pool.cache_clear()
+        AsyncCompile.process_pool.cache_clear()
+        shutdown_compile_workers()
+        super().tearDown()
+
+    def test_thread_pool_creation(self):
+        """Thread pool is created as a ThreadPoolExecutor with correct worker count."""
+        config.compile_worker_mode = "thread"
+        AsyncCompile.thread_pool.cache_clear()
+        shutdown_compile_workers()
+
+        pool = AsyncCompile.thread_pool()
+        self.assertIsInstance(pool, ThreadPoolExecutor)
+        self.assertEqual(pool._max_workers, config.compile_threads)
+
+    def test_should_use_thread_workers_thread_mode(self):
+        """should_use_thread_workers returns True in thread mode."""
+        config.compile_worker_mode = "thread"
+        self.assertTrue(AsyncCompile.should_use_thread_workers())
+
+    def test_should_use_thread_workers_process_mode(self):
+        """should_use_thread_workers returns False in process mode."""
+        config.compile_worker_mode = "process"
+        self.assertFalse(AsyncCompile.should_use_thread_workers())
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/_inductor/async_compile.py
+++ b/torch/_inductor/async_compile.py
@@ -195,6 +195,7 @@ def after_fork():
     _pool_set.clear()
     AsyncCompile._ready_future = None
     AsyncCompile.process_pool.cache_clear()
+    AsyncCompile.thread_pool.cache_clear()
 
 
 try:
@@ -351,6 +352,54 @@ class AsyncCompile:
 
         _pool_set.add(pool)
         return pool
+
+    @staticmethod
+    @functools.lru_cache(1)
+    def thread_pool() -> ThreadPoolExecutor:
+        """
+        Thread pool for Triton compilation in nogil mode.
+
+        Separate from pool() to allow different sizing/configuration
+        for CPU-intensive Triton compilation workloads.
+        """
+        if get_compile_threads() <= 1:
+            raise AssertionError(
+                f"expected get_compile_threads() > 1, got {get_compile_threads()}"
+            )
+        log.info(
+            "Creating thread pool with %d workers for nogil Triton compilation",
+            get_compile_threads(),
+        )
+        pool = ThreadPoolExecutor(
+            get_compile_threads(),
+            thread_name_prefix="triton_compile_",
+        )
+        _pool_set.add(pool)
+        return pool
+
+    @classmethod
+    def should_use_thread_workers(cls) -> bool:
+        """
+        Determine if thread workers should be used instead of process workers.
+
+        Returns True when running free-threaded Python or when explicitly
+        configured via compile_worker_mode.
+        """
+        from torch._inductor.utils import should_use_thread_workers
+
+        return should_use_thread_workers()
+
+    @classmethod
+    def get_worker_pool(cls) -> ThreadPoolExecutor | AnyPool:
+        """
+        Get the appropriate worker pool based on configuration.
+
+        Returns thread pool for nogil mode, process pool otherwise.
+        """
+        if cls.should_use_thread_workers():
+            return cls.thread_pool()
+        else:
+            return cls.process_pool()
 
     @classmethod
     def warm_pool(cls) -> None:

--- a/torch/_inductor/compile_worker/subproc_pool.py
+++ b/torch/_inductor/compile_worker/subproc_pool.py
@@ -14,7 +14,7 @@ import time
 import traceback
 import typing
 from collections.abc import Callable
-from concurrent.futures import Future, ProcessPoolExecutor
+from concurrent.futures import Future, ProcessPoolExecutor, ThreadPoolExecutor
 from concurrent.futures.process import BrokenProcessPool
 from dataclasses import dataclass
 from enum import Enum, IntEnum
@@ -933,7 +933,7 @@ class SubprocMain:
             watchdog.clear_current_job()
 
 
-AnyPool = ProcessPoolExecutor | SubprocPool
+AnyPool = ProcessPoolExecutor | SubprocPool | ThreadPoolExecutor
 
 
 def _get_process_pool_processes(pool: ProcessPoolExecutor) -> list[Any]:

--- a/torch/_inductor/compile_worker/subproc_pool.py
+++ b/torch/_inductor/compile_worker/subproc_pool.py
@@ -14,7 +14,7 @@ import time
 import traceback
 import typing
 from collections.abc import Callable
-from concurrent.futures import Future, ProcessPoolExecutor
+from concurrent.futures import Future, ProcessPoolExecutor, ThreadPoolExecutor
 from concurrent.futures.process import BrokenProcessPool
 from enum import Enum, IntEnum
 from pathlib import Path
@@ -763,7 +763,7 @@ class SubprocMain:
             watchdog.clear_current_job()
 
 
-AnyPool = ProcessPoolExecutor | SubprocPool
+AnyPool = ProcessPoolExecutor | SubprocPool | ThreadPoolExecutor
 
 
 def _get_process_pool_processes(pool: ProcessPoolExecutor) -> list[Any]:

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1436,6 +1436,41 @@ def decide_compile_threads() -> int:
 # TODO: Set directly after internal rollout.
 compile_threads: int | None = None if is_fbcode() else decide_compile_threads()
 
+
+def decide_compile_worker_mode() -> str:
+    """
+    Decide whether to use threads or processes for compilation workers.
+
+    Returns one of: "auto", "process", "thread"
+    - "auto": Automatically detect if Python is free-threaded (nogil) and use
+              threads if available, otherwise use processes
+    - "process": Force multiprocessing (current behavior, compatible with all Python)
+    - "thread": Force threading (requires free-threaded Python build)
+
+    Precedence:
+    1. TORCH_COMPILE_WORKER_MODE environment variable
+    2. Default to "process" for safe multiprocessing
+    """
+    mode = os.environ.get("TORCH_COMPILE_WORKER_MODE", "process")
+    valid_modes = ("auto", "process", "thread")
+    if mode not in valid_modes:
+        import logging
+
+        log = logging.getLogger(__name__)
+        log.warning(
+            "Invalid TORCH_COMPILE_WORKER_MODE='%s'. "
+            "Valid options: %s. Defaulting to 'process'.",
+            mode,
+            ", ".join(sorted(valid_modes)),
+        )
+        mode = "process"
+    return mode
+
+
+# Controls whether compilation workers use threads or processes.
+# Options: "auto" (detect nogil), "process" (force multiprocessing), "thread" (force threading)
+compile_worker_mode: str = decide_compile_worker_mode()
+
 # Whether to quiesce the Triton-compile subprocess pool at the end of each compilation.
 quiesce_async_compile_pool: bool = Config(
     justknob="pytorch/inductor:quiesce_async_compile_pool",

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1517,6 +1517,41 @@ def decide_compile_threads() -> int:
 # TODO: Set directly after internal rollout.
 compile_threads: int | None = None if is_fbcode() else decide_compile_threads()
 
+
+def decide_compile_worker_mode() -> str:
+    """
+    Decide whether to use threads or processes for compilation workers.
+
+    Returns one of: "auto", "process", "thread"
+    - "auto": Automatically detect if Python is free-threaded (nogil) and use
+              threads if available, otherwise use processes
+    - "process": Force multiprocessing (current behavior, compatible with all Python)
+    - "thread": Force threading (requires free-threaded Python build)
+
+    Precedence:
+    1. TORCH_COMPILE_WORKER_MODE environment variable
+    2. Default to "process" for safe multiprocessing
+    """
+    mode = os.environ.get("TORCH_COMPILE_WORKER_MODE", "process")
+    valid_modes = ("auto", "process", "thread")
+    if mode not in valid_modes:
+        import logging
+
+        log = logging.getLogger(__name__)
+        log.warning(
+            "Invalid TORCH_COMPILE_WORKER_MODE='%s'. "
+            "Valid options: %s. Defaulting to 'process'.",
+            mode,
+            ", ".join(sorted(valid_modes)),
+        )
+        mode = "process"
+    return mode
+
+
+# Controls whether compilation workers use threads or processes.
+# Options: "auto" (detect nogil), "process" (force multiprocessing), "thread" (force threading)
+compile_worker_mode: str = decide_compile_worker_mode()
+
 # Whether to quiesce the Triton-compile subprocess pool at the end of each compilation.
 quiesce_async_compile_pool: bool = Config(
     justknob="pytorch/inductor:quiesce_async_compile_pool",

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -121,6 +121,46 @@ def get_gpu_type() -> str:
     return gpu_type
 
 
+def has_free_threaded_python() -> bool:
+    """
+    Detect if Python is running in free-threaded mode (without GIL).
+
+    Uses the sys._is_gil_enabled() API available in Python 3.13+ with
+    the --disable-gil flag or PEP 703 implementation.
+
+    Returns:
+        bool: True if running free-threaded Python, False otherwise
+    """
+    # Python 3.13+ with free-threading support
+    # Standard Python (always has GIL)
+    return hasattr(sys, "_is_gil_enabled") and not sys._is_gil_enabled()
+
+
+def should_use_thread_workers() -> bool:
+    """
+    Determine if compilation workers should use threads instead of processes.
+
+    Checks the compile_worker_mode config and nogil availability.
+
+    Returns:
+        bool: True if thread workers should be used, False for process workers
+    """
+    from torch._inductor import config
+
+    mode = config.compile_worker_mode
+
+    if mode == "thread":
+        return True
+    elif mode == "process":
+        return False
+    elif mode == "auto":
+        return has_free_threaded_python()
+    else:
+        raise ValueError(
+            f"Invalid compile_worker_mode: {mode!r}. Expected one of 'thread', 'process', or 'auto'."
+        )
+
+
 from torch._dynamo.device_interface import get_interface_for_device
 from torch._dynamo.utils import detect_fake_mode
 from torch.autograd import DeviceType

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -171,6 +171,46 @@ def get_gpu_type() -> str:
     return chosen
 
 
+def has_free_threaded_python() -> bool:
+    """
+    Detect if Python is running in free-threaded mode (without GIL).
+
+    Uses the sys._is_gil_enabled() API available in Python 3.13+ with
+    the --disable-gil flag or PEP 703 implementation.
+
+    Returns:
+        bool: True if running free-threaded Python, False otherwise
+    """
+    # Python 3.13+ with free-threading support
+    # Standard Python (always has GIL)
+    return hasattr(sys, "_is_gil_enabled") and not sys._is_gil_enabled()
+
+
+def should_use_thread_workers() -> bool:
+    """
+    Determine if compilation workers should use threads instead of processes.
+
+    Checks the compile_worker_mode config and nogil availability.
+
+    Returns:
+        bool: True if thread workers should be used, False for process workers
+    """
+    from torch._inductor import config
+
+    mode = config.compile_worker_mode
+
+    if mode == "thread":
+        return True
+    elif mode == "process":
+        return False
+    elif mode == "auto":
+        return has_free_threaded_python()
+    else:
+        raise ValueError(
+            f"Invalid compile_worker_mode: {mode!r}. Expected one of 'thread', 'process', or 'auto'."
+        )
+
+
 from torch._dynamo.device_interface import get_interface_for_device
 from torch._dynamo.utils import detect_fake_mode
 from torch.autograd import DeviceType


### PR DESCRIPTION
Summary:
Create AsyncCompile.thread_pool() as parallel implementation to
process_pool() for use with free-threaded Python. This enables
zero-overhead kernel compilation when GIL is disabled.

This is Commit 3 of the nogil thread-mode compilation series.

Motivation:
- Fork overhead is 10-50ms and holds GIL
- Pickle/unpickle adds 1-5ms per kernel
- Thread mode eliminates both with nogil Python
- Need separate pool from pool() for Triton-specific configuration

Implementation:
- Add thread_pool() method returning ThreadPoolExecutor
- Add get_worker_pool() to dispatch between thread/process pools
- Add should_use_thread_workers() to check config + nogil detection
- Separate from existing pool() for different sizing/naming


Test Plan: ```buck test fbcode//caffe2/torch/_inductr/tests:test_thread_pool```

Reviewed By: atalman

Pulled By:
alrobichaud

alrobichaud

Differential Revision: D88420532




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo