### PR TITLE
Fix order-dependent failures in expanded_weights context manager tests

### DIFF
--- a/test/test_expanded_weights.py
+++ b/test/test_expanded_weights.py
@@ -974,7 +974,7 @@ class ContextManagerTests(TestBase):
         module = self.constructor(*self.constructor_args).to(**kwargs)
         if "Embedding" in self.get_name():
             kwargs["dtype"] = torch.long
-        input = self._get_input().to(**kwargs)
+        input = self._get_input().detach().to(**kwargs)
         if len(input.shape) == 0 or input.shape[0] == 0:
             raise unittest.SkipTest(
                 "Can't get per sample gradients when no batch dim or batch dim is 0"
@@ -987,7 +987,7 @@ class ContextManagerTests(TestBase):
 
     def test_context_manager_multiple_inputs(self, test_case, device):
         module = self.constructor(*self.constructor_args).to(device)
-        input = self._get_input()
+        input = self._get_input().detach().to(device)
         if len(input.shape) == 0 or input.shape[0] == 0:
             raise unittest.SkipTest(
                 "Can't get per sample gradients when no batch dim or batch dim is 0"


### PR DESCRIPTION
### Fixing an Issue

#### Issue
Fixes #179237

#### Summary
This PR fixes order-dependent failures in expanded_weights module tests caused by shared cached input state across generated tests. The context-manager test paths now detach the cached input tensor before use, so each generated test starts from an independent autograd leaf state. This removes cross-test state leakage and makes results independent of execution order.

Minimal reproduction used:

Order 1:
`python test/test_expanded_weights.py TestExpandedWeightModuleCPU.test_Conv3d_1x1x1_no_bias_cpu TestExpandedWeightModuleCPU.test_Conv3d_1x1x1_no_bias_multiple_inputs_cpu`

Order 2:
`python test/test_expanded_weights.py TestExpandedWeightModuleCPU.test_Conv3d_1x1x1_no_bias_multiple_inputs_cpu TestExpandedWeightModuleCPU.test_Conv3d_1x1x1_no_bias_cpu`

Before this change, one order could fail with a None-related error in the second test.
After this change, both orders pass consistently.