### PR TITLE
[test] Fix env var leak in NCCLTraceTestBase causing named pipe errors

### DIFF
--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -5649,6 +5649,8 @@ class NCCLTraceTestBase(MultiProcessTestCase):
         return pg
 
     def tearDown(self):
+        os.environ.pop("TORCH_NCCL_DEBUG_INFO_TEMP_FILE", None)
+        os.environ.pop("TORCH_NCCL_DEBUG_INFO_PIPE_FILE", None)
         super().tearDown()
         try:
             os.remove(self.file_name)


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/179556

Fix a test environment leak in NCCLTraceTestBase where environment variables set in setUp were not cleaned up in tearDown.

The setUp method sets TORCH_NCCL_DEBUG_INFO_PIPE_FILE to a path inside a temporary directory. However, tearDown destroys this temporary directory without unsetting the environment variable.

This leak causes subsequent tests to fail during DumpPipe initialization. The C++ backend reads the stale environment variable and attempts to create a named pipe via mkfifo in the now non-existent directory. This results in a TORCH_CHECK failure from ProcessGroupNCCL.hpp: 'Error creating named pipe ... No such file or directory'.

This patch ensures these variables are removed from os.environ during teardown to prevent test pollution.

Test Plan:
Verified that environment variables are cleared after test execution and subsequent tests no longer encounter named pipe creation errors.