### PR TITLE
[torchelastic] Start health check server before MAST rendezvous in launch_agent (#179560)

### DIFF
--- a/test/distributed/elastic/agent/server/test/local_elastic_agent_test.py
+++ b/test/distributed/elastic/agent/server/test/local_elastic_agent_test.py
@@ -1705,52 +1705,6 @@ class LocalElasticAgentTest(unittest.TestCase):
             else:
                 os.environ[healthcheck_port_env_name] = original_value
 
-    def test_pre_invoke_run_calls_setup_healthcheck(self):
-        """Test _pre_invoke_run calls _setup_healthcheck when JK is enabled."""
-        node_conf = Conf(entrypoint=_happy_function, local_world_size=1)
-        self._backend = "c10d"
-        self._endpoint = f"localhost:{acquire_available_port()}"
-        spec = self.get_worker_spec(node_conf)
-        agent = self.get_agent(spec, node_config=node_conf)
-
-        with (
-            patch(
-                "torch.distributed.elastic.agent.server.local_elastic_agent.justknobs_check",
-                return_value=True,
-            ),
-            patch.object(agent, "_setup_healthcheck") as mock_setup,
-        ):
-            agent._pre_invoke_run()
-        mock_setup.assert_called_once()
-
-    def test_pre_invoke_run_skips_healthcheck_without_jk(self):
-        """Test _pre_invoke_run does NOT call _setup_healthcheck when JK is disabled."""
-        node_conf = Conf(entrypoint=_happy_function, local_world_size=1)
-
-        # Use a mocked rendezvous handler to avoid blocking on real connections
-        rdzv_handler = Mock()
-        rdzv_handler.get_backend.return_value = "c10d"
-        spec = WorkerSpec(
-            role=node_conf.role,
-            local_world_size=node_conf.local_world_size,
-            entrypoint=node_conf.entrypoint,
-            args=node_conf.args,
-            rdzv_handler=rdzv_handler,
-            max_restarts=0,
-            monitor_interval=0.01,
-        )
-        agent = self.get_agent(spec, node_config=node_conf)
-
-        with (
-            patch(
-                "torch.distributed.elastic.agent.server.local_elastic_agent.justknobs_check",
-                return_value=False,
-            ),
-            patch.object(agent, "_setup_healthcheck") as mock_setup,
-        ):
-            agent._pre_invoke_run()
-        mock_setup.assert_not_called()
-
     def test_healthcheck_with_watchdog_enabled(self):
         """Test healthcheck works with watchdog enabled during agent run."""
         # Set the env for watchdog and healthcheck

--- a/torch/distributed/elastic/agent/server/api.py
+++ b/torch/distributed/elastic/agent/server/api.py
@@ -903,18 +903,8 @@ class SimpleElasticAgent(ElasticAgent):
 
         put_metric(f"workers.{spec.role}.flakiness", int(flakiness))
 
-    def _pre_invoke_run(self) -> None:
-        """Hook called before the worker lifecycle loop in ``_invoke_run``.
-
-        Subclasses can override this to perform setup that must happen
-        before rendezvous and worker initialization (e.g. starting a
-        health check server).  The default implementation is a no-op.
-        """
-
     def _invoke_run(self, role: str = DEFAULT_ROLE) -> RunResult:
         # NOTE: currently only works for a single role
-
-        self._pre_invoke_run()
 
         spec = self._worker_group.spec
         role = spec.role

--- a/torch/distributed/elastic/agent/server/local_elastic_agent.py
+++ b/torch/distributed/elastic/agent/server/local_elastic_agent.py
@@ -7,6 +7,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
 
 import json
 import os
@@ -43,6 +44,8 @@ from torch.distributed.elastic.utils.logging import get_logger
 
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from torch.distributed.elastic.events.api import EventMetadataValue
 
 logger = get_logger(__name__)
@@ -57,6 +60,29 @@ __all__ = [
 TORCHELASTIC_ENABLE_FILE_TIMER = "TORCHELASTIC_ENABLE_FILE_TIMER"
 TORCHELASTIC_HEALTH_CHECK_PORT = "TORCHELASTIC_HEALTH_CHECK_PORT"
 TORCHELASTIC_TIMER_FILE = "TORCHELASTIC_TIMER_FILE"
+
+
+class _AliveCallbackProxy:
+    """Mutable callback wrapper for the health check server.
+
+    The C++ pybind ``HealthCheckThriftServer`` binds its ``alive_callback``
+    at construction time and cannot update it afterward.  This proxy is
+    created *before* the health check server so it can be passed as the
+    callback.  Initially it returns ``time.time()`` (signalling "alive").
+    After the agent is constructed, :meth:`set_delegate` wires it to
+    ``agent._get_alive_time`` for real liveness tracking.
+    """
+
+    def __init__(self) -> None:
+        self._delegate: Callable[[], int] | None = None
+
+    def __call__(self) -> int:
+        if self._delegate is not None:
+            return self._delegate()
+        return int(time.time())
+
+    def set_delegate(self, delegate: Callable[[], int]) -> None:
+        self._delegate = delegate
 
 
 class LocalElasticAgent(SimpleElasticAgent):
@@ -156,6 +182,7 @@ class LocalElasticAgent(SimpleElasticAgent):
         exit_barrier_timeout: float = 300,
         log_line_prefix_template: str | None = None,
         shutdown_timeout: int = 30,
+        health_check_server: HealthCheckServer | None = None,
     ):
         super().__init__(spec, exit_barrier_timeout, shutdown_timeout)
         self._start_method = start_method
@@ -164,7 +191,7 @@ class LocalElasticAgent(SimpleElasticAgent):
         self._log_line_prefix_template = log_line_prefix_template
         self._worker_watchdog: timer.FileTimerServer | None = None
         self._logs_specs = logs_specs
-        self._health_check_server: HealthCheckServer | None = None
+        self._health_check_server = health_check_server
 
     def _setup_local_watchdog(self, envs: dict[int, dict[str, str]]) -> None:
         enable_watchdog_env_name = TORCHELASTIC_ENABLE_FILE_TIMER
@@ -445,22 +472,6 @@ class LocalElasticAgent(SimpleElasticAgent):
 
         if "CUDA_VISIBLE_DEVICES" in os.environ:
             worker_env["CUDA_VISIBLE_DEVICES"] = os.environ["CUDA_VISIBLE_DEVICES"]
-
-    def _pre_invoke_run(self) -> None:
-        # Start the health check server immediately, before rendezvous,
-        # so that TW sees a healthy thrift port while the agent is still
-        # initializing (package fetch, rendezvous, model load, etc.).
-        # The _get_alive_time callback dynamically checks self._worker_watchdog:
-        # returns current time during init, real watchdog time once workers run.
-        if justknobs_check(
-            "ai_infra/pytorch_distributed:torchelastic_enable_healthcheck_before_rendezvous",
-            default=False,
-        ):
-            logger.info(
-                "Starting health check server before rendezvous "
-                "(torchelastic_enable_healthcheck_before_rendezvous=True)"
-            )
-            self._setup_healthcheck()
 
     def _shutdown(
         self, death_sig: signal.Signals = signal.SIGTERM, timeout: int = 30

--- a/torch/distributed/launcher/api.py
+++ b/torch/distributed/launcher/api.py
@@ -15,10 +15,17 @@ from typing import Any
 
 import torch
 import torch.distributed.elastic.rendezvous.registry as rdzv_registry
-from torch._utils_internal import get_default_numa_options
+from torch._utils_internal import get_default_numa_options, justknobs_check
 from torch.distributed.elastic import events, metrics
 from torch.distributed.elastic.agent.server.api import WorkerSpec
-from torch.distributed.elastic.agent.server.local_elastic_agent import LocalElasticAgent
+from torch.distributed.elastic.agent.server.health_check_server import (
+    create_healthcheck_server,
+)
+from torch.distributed.elastic.agent.server.local_elastic_agent import (
+    _AliveCallbackProxy,
+    LocalElasticAgent,
+    TORCHELASTIC_HEALTH_CHECK_PORT,
+)
 from torch.distributed.elastic.multiprocessing import (
     DefaultLogsSpecs,
     LogsSpecs,
@@ -290,6 +297,34 @@ def launch_agent(
     # Set the signals to handle in the environment variable
     os.environ["TORCHELASTIC_SIGNALS_TO_HANDLE"] = config.signals_to_handle
 
+    # Start health check server before rendezvous so TW sees a healthy
+    # thrift port during the potentially long MAST rendezvous store barrier
+    # (10-22+ min for large jobs).  The _AliveCallbackProxy returns
+    # time.time() until wired to the agent after construction.
+    health_check_server = None
+    alive_callback_proxy = None
+    healthcheck_port = os.getenv(TORCHELASTIC_HEALTH_CHECK_PORT)
+    if healthcheck_port is not None and justknobs_check(
+        "ai_infra/pytorch_distributed:torchelastic_enable_healthcheck_before_rendezvous",
+        default=False,
+    ):
+        try:
+            alive_callback_proxy = _AliveCallbackProxy()
+            health_check_server = create_healthcheck_server(
+                alive_callback=alive_callback_proxy,
+                port=int(healthcheck_port),
+                timeout=60,
+            )
+            health_check_server.start()
+            logger.info(
+                "Started early health check server on port %s before rendezvous",
+                healthcheck_port,
+            )
+        except Exception:
+            logger.warning("Failed to start early health check server", exc_info=True)
+            health_check_server = None
+            alive_callback_proxy = None
+
     spec = WorkerSpec(
         role=config.role,
         local_world_size=config.nproc_per_node,
@@ -314,7 +349,11 @@ def launch_agent(
         start_method=config.start_method,
         log_line_prefix_template=config.log_line_prefix_template,
         shutdown_timeout=config.shutdown_timeout,  # type: ignore[arg-type]
+        health_check_server=health_check_server,
     )
+
+    if alive_callback_proxy is not None:
+        alive_callback_proxy.set_delegate(agent._get_alive_time)
 
     shutdown_rdzv = True
     try:


### PR DESCRIPTION
Summary:

This diff moves the health check server start to `launch_agent()` BEFORE
`get_rendezvous_handler()` is called.

Key changes:
- Add `_AliveCallbackProxy` class: a mutable callable that initially returns
  `time.time()` and delegates to `agent._get_alive_time()` after `set_delegate()`.
  Needed because the C++ pybind `HealthCheckThriftServer` callback cannot be
  updated post-construction.
- Modify `LocalElasticAgent.__init__` to accept an optional pre-created
  `health_check_server` parameter. The existing idempotent guard in
  `_setup_healthcheck()` (`if self._health_check_server is not None: return`)
  prevents double-start when `_pre_invoke_run()` runs later.
- In `launch_agent()`, start the health check server before rendezvous, gated
  by existing JK `torchelastic_enable_healthcheck_before_rendezvous`.
- Pass the pre-created server and proxy to `LocalElasticAgent`, then wire
  up `alive_callback_proxy.set_delegate(agent._get_alive_time)`.

Test Plan:
- Added unit tests for `_AliveCallbackProxy` (default returns time, delegate
  override, multiple invocations).
- Added unit tests verifying `LocalElasticAgent.__init__` stores pre-created
  health check server and `_setup_healthcheck()` is a no-op when server exists.
- `buck2 test fbcode//caffe2/test/distributed/elastic/agent/server/test/fb:local_elastic_agent_fb_internal_test` — all 6 new tests pass.

Reviewed By: d4l3k

Differential Revision: D98952853
