### PR TITLE
[ROCm] Fix flash attention meta kernel logsumexp shape for HIP

### DIFF
--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -6474,17 +6474,12 @@ def meta__flash_attention_forward(
         # ROCm CK flash attention returns logsumexp as (batch, seqlen, heads)
         # rather than CUDA's (batch, heads, seqlen)
         if torch.version.hip and torch.cuda.is_available():
-            logsumexp = torch.empty(
-                (batch_size, max_seqlen_batch_q, num_heads),
-                dtype=torch.float,
-                device=query.device,
-            )
+            logsumexp_shape = (batch_size, max_seqlen_batch_q, num_heads)
         else:
-            logsumexp = torch.empty(
-                (batch_size, num_heads, max_seqlen_batch_q),
-                dtype=torch.float,
-                device=query.device,
-            )
+            logsumexp_shape = (batch_size, num_heads, max_seqlen_batch_q)
+        logsumexp = torch.empty(
+            logsumexp_shape, dtype=torch.float, device=query.device
+        )
     else:
         total_q = query.size(0)
         logsumexp = torch.empty(

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -6477,9 +6477,7 @@ def meta__flash_attention_forward(
             logsumexp_shape = (batch_size, max_seqlen_batch_q, num_heads)
         else:
             logsumexp_shape = (batch_size, num_heads, max_seqlen_batch_q)
-        logsumexp = torch.empty(
-            logsumexp_shape, dtype=torch.float, device=query.device
-        )
+        logsumexp = torch.empty(logsumexp_shape, dtype=torch.float, device=query.device)
     else:
         total_q = query.size(0)
         logsumexp = torch.empty(

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -6469,14 +6469,22 @@ def meta__flash_attention_forward(
     num_heads = query.size(-2)
     head_dim = query.size(-1)
 
-    # Cuda Path
     attention = torch.empty_like(query)
     if cum_seq_q is None:
-        logsumexp = torch.empty(
-            (batch_size, num_heads, max_seqlen_batch_q),
-            dtype=torch.float,
-            device=query.device,
-        )
+        # ROCm CK flash attention returns logsumexp as (batch, seqlen, heads)
+        # rather than CUDA's (batch, heads, seqlen)
+        if torch.version.hip and torch.cuda.is_available():
+            logsumexp = torch.empty(
+                (batch_size, max_seqlen_batch_q, num_heads),
+                dtype=torch.float,
+                device=query.device,
+            )
+        else:
+            logsumexp = torch.empty(
+                (batch_size, num_heads, max_seqlen_batch_q),
+                dtype=torch.float,
+                device=query.device,
+            )
     else:
         total_q = query.size(0)
         logsumexp = torch.empty(


### PR DESCRIPTION
Fixes #171568

ROCm CK flash attention returns logsumexp with shape (batch, seqlen, heads) rather than CUDA's (batch, heads, seqlen). This adds a `torch.version.hip` conditional for the dense path, matching the existing pattern used for seed/offset in the same function (lines 6512-6518).

Scoped to the dense path (`cum_seq_q is None`) as reported in the issue.

Authored with assistance from Claude.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang