### PR TITLE
[dtensor] Use @exposed_in decorator for experimental re-exports

### DIFF
--- a/torch/distributed/tensor/experimental/__init__.py
+++ b/torch/distributed/tensor/experimental/__init__.py
@@ -25,10 +25,3 @@ def implicit_replication() -> Iterator[None]:
         yield
     finally:
         DTensor._op_dispatcher._allow_implicit_replication = False
-
-
-# Set namespace for exposed private names
-context_parallel.__module__ = "torch.distributed.tensor.experimental"
-implicit_replication.__module__ = "torch.distributed.tensor.experimental"
-local_map.__module__ = "torch.distributed.tensor.experimental"
-register_sharding.__module__ = "torch.distributed.tensor.experimental"

--- a/torch/distributed/tensor/experimental/_context_parallel/_attention.py
+++ b/torch/distributed/tensor/experimental/_context_parallel/_attention.py
@@ -23,6 +23,7 @@ from torch.nn.attention.flex_attention import (
     BlockMask,
     create_block_mask,
 )
+from torch.utils._exposed_in import exposed_in
 from torch.utils._pytree import tree_flatten, tree_unflatten
 
 from ._cp_custom_ops import flex_cp_allgather
@@ -1510,6 +1511,7 @@ def _disable_context_parallel_dispatcher() -> None:
 #####################################################
 # Current public APIs, but are also subject to change
 #####################################################
+@exposed_in("torch.distributed.tensor.experimental")
 @contextlib.contextmanager
 @torch.no_grad()
 def context_parallel(

--- a/torch/distributed/tensor/experimental/_func_map.py
+++ b/torch/distributed/tensor/experimental/_func_map.py
@@ -7,6 +7,7 @@ import torch
 from torch.distributed._functional_collectives import AsyncCollectiveTensor
 from torch.distributed.tensor import DeviceMesh, DTensor
 from torch.distributed.tensor.placement_types import Placement
+from torch.utils._exposed_in import exposed_in
 
 
 try:
@@ -22,6 +23,7 @@ InputPlacements = tuple[PlacementType, ...] | None
 OutputPlacements = PlacementType | tuple[PlacementType, ...]
 
 
+@exposed_in("torch.distributed.tensor.experimental")
 def local_map(
     func: Callable | None = None,
     out_placements: OutputPlacements = None,

--- a/torch/distributed/tensor/experimental/_register_sharding.py
+++ b/torch/distributed/tensor/experimental/_register_sharding.py
@@ -15,11 +15,13 @@ from torch.distributed.tensor._op_schema import (
     TupleStrategy,
 )
 from torch.distributed.tensor._ops.utils import expand_to_full_mesh_op_strategy
+from torch.utils._exposed_in import exposed_in
 
 
 __all__ = ["register_sharding"]
 
 
+@exposed_in("torch.distributed.tensor.experimental")
 def register_sharding(op: OpOverload | list[OpOverload]):
     """
     :meth:`register_sharding` is an experimental API that allows users to register sharding


### PR DESCRIPTION
## Summary
- Replace post-hoc `__module__` assignment in `torch.distributed.tensor.experimental.__init__` with `@exposed_in()` decorators at each function's definition site
- Remove redundant `__module__` assignment for `implicit_replication` (already defined in the target module)

## Motivation
Fixes #171905

The `__module__` hack pattern doesn't play well with type checkers and linters. PyTorch already has the `@exposed_in()` decorator (`torch.utils._exposed_in`) for exactly this purpose — it's used extensively in `torch.func`, `torch.library`, and other modules. This PR applies the same pattern to the distributed tensor experimental APIs.

## Changes
- **`_context_parallel/_attention.py`**: Added `@exposed_in("torch.distributed.tensor.experimental")` to `context_parallel`
- **`_func_map.py`**: Added `@exposed_in("torch.distributed.tensor.experimental")` to `local_map`
- **`_register_sharding.py`**: Added `@exposed_in("torch.distributed.tensor.experimental")` to `register_sharding`
- **`__init__.py`**: Removed all 5 `__module__` assignment lines (the 3 imported functions are now handled by the decorator, and `implicit_replication` was redundant since it's defined directly in this module)

## Test Plan
- Verified all modified files pass `ruff check` and `ast.parse`
- No behavioral change — `@exposed_in` is functionally identical to post-hoc `__module__` assignment, just applied at the definition site
- Existing distributed tensor tests (`test_local_map.py`, `test_register_sharding.py`, `test_attention.py`) cover these functions and will validate correctness in CI

cc @Skylion007