### PR TITLE
[WIP][CI] Add RHEL 9.6 build and test support

### DIFF
--- a/.ci/docker/rhel9/Dockerfile
+++ b/.ci/docker/rhel9/Dockerfile
@@ -1,0 +1,186 @@
+# RHEL 9.6 Docker image for PyTorch CI with simplified single-stage build
+
+# GLOBAL ARGS
+ARG RHEL_OS_VERSION=9.6
+ARG OS_TYPE=x86_64
+ARG PY_VER=3.12
+ARG CONDA_ENV="pytorch_build"
+# This flag has to be set to true if there is no active subscription
+ARG ENABLE_SUBSCRIPTION=false
+# Enable LAPACK/OpenBLAS support
+ARG ENABLE_LAPACK=true
+
+# BASE IMAGE
+FROM docker.io/redhat/ubi9:${RHEL_OS_VERSION}
+
+# Re-declare build args so they're available after FROM
+ARG ENABLE_SUBSCRIPTION
+ARG OS_TYPE
+ARG PY_VER
+ARG CONDA_ENV
+ARG ENABLE_LAPACK
+
+# Set locale
+ENV LC_ALL=en_US.UTF-8
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US.UTF-8
+
+# Register the system with the entitlement server if subscription is enabled
+# Expects /run/secrets/rhsm-org and /run/secrets/rhsm-activationkey to be mounted
+RUN --mount=type=secret,id=rhsm-org \
+    --mount=type=secret,id=rhsm-activationkey \
+    if [ "${ENABLE_SUBSCRIPTION}" = "true" ] && [ -f /run/secrets/rhsm-org ] && [ -f /run/secrets/rhsm-activationkey ]; then \
+        echo "Registering the system with entitlement server" && \
+        subscription-manager register \
+            --activationkey=$(cat /run/secrets/rhsm-activationkey) \
+            --org=$(cat /run/secrets/rhsm-org); \
+    fi
+
+# Update packages and install dependencies in one layer
+RUN dnf -y update && \
+    dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm && \
+    dnf -y install glibc-langpack-en && \
+    dnf install -y --allowerasing \
+    wget \
+    jq \
+    vim \
+    git \
+    gdb \
+    unzip \
+    which \
+    libffi-devel \
+    openssl-devel \
+    gcc \
+    gcc-c++ \
+    make \
+    ninja-build \
+    lld \
+    openblas \
+    openblas-devel \
+    findutils \
+    sudo \
+    curl \
+    perl \
+    util-linux \
+    xz \
+    bzip2 \
+    patch \
+    zlib-devel \
+    yum-utils \
+    autoconf \
+    automake \
+    gcc-gfortran \
+    procps-ng \
+    libgomp \
+    jemalloc \
+    python3.12 \
+    python3.12-pip \
+    python3.12-devel && \
+    dnf clean all
+
+# Remove RHEL which function that breaks sccache
+# (exported via BASH_FUNC_which%% and corrupts Rust process spawning)
+RUN rm -f /etc/profile.d/which2.sh
+
+# Set up Python 3.12 as default
+RUN ln -sf /usr/bin/python3.12 /usr/bin/python3 && \
+    ln -sf /usr/bin/python3.12 /usr/bin/python && \
+    python3.12 -m pip install --upgrade pip
+
+# Install CMake 3.27+ via pip (PyTorch requires >= 3.27)
+# Also install setuptools and wheel
+RUN python3.12 -m pip install 'cmake>=3.27' setuptools wheel
+
+# Configure git to trust all directories
+RUN git config --global --add safe.directory '*'
+
+# Install Miniforge and setup conda environment in one layer
+RUN wget --no-check-certificate https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh && \
+    chmod +x Miniforge3-Linux-x86_64.sh && \
+    bash Miniforge3-Linux-x86_64.sh -b -p /opt/conda && \
+    rm Miniforge3-Linux-x86_64.sh && \
+    /opt/conda/bin/conda update -y conda && \
+    /opt/conda/bin/conda init && \
+    if [ -n "${PY_VER}" ]; then \
+        /opt/conda/bin/conda create -n ${CONDA_ENV} python=${PY_VER} -y; \
+    else \
+        /opt/conda/bin/conda create -n ${CONDA_ENV} -y; \
+    fi
+
+# Set PATH for conda
+ENV PATH=/opt/conda/bin:${PATH}
+
+# Install CUDA 13.0, cuDNN, NCCL, cuSparseLt, NVSHMEM using upstream common scripts
+# This reuses .ci/docker/common/install_cuda.sh for consistency with upstream CI
+COPY common/install_cuda.sh /tmp/install_cuda.sh
+COPY common/install_nccl.sh /tmp/install_nccl.sh
+COPY common/install_cusparselt.sh /tmp/install_cusparselt.sh
+COPY ci_commit_pins/nccl.txt /tmp/ci_commit_pins/nccl.txt
+RUN chmod +x /tmp/install_cuda.sh /tmp/install_nccl.sh /tmp/install_cusparselt.sh
+
+WORKDIR /tmp
+RUN bash install_cuda.sh 13.0
+
+# Use system NCCL instead of building from third_party/nccl
+ENV USE_SYSTEM_NCCL=1
+
+# Add CUDA static libs to linker path (.run installer doesn't set this unlike dnf)
+ENV LIBRARY_PATH=/usr/local/cuda/lib64:/usr/local/cuda/lib64/stubs:${LIBRARY_PATH}
+
+# Create libgomp.so linker symlink (UBI9 only ships libgomp.so.1)
+RUN ln -sf /usr/lib64/libgomp.so.1 /usr/lib64/libgomp.so
+
+# Install PyTorch build dependencies via conda/pip
+# sccache is skipped for now due to BASH_FUNC_which%% Podman compatibility issue
+RUN . /opt/conda/etc/profile.d/conda.sh && \
+    conda activate ${CONDA_ENV} && \
+    conda install -y -c conda-forge libstdcxx-ng && \
+    curl -fsSL https://raw.githubusercontent.com/pytorch/pytorch/main/.ci/docker/requirements-ci.txt -o /tmp/requirements-ci.txt && \
+    pip install -r /tmp/requirements-ci.txt && \
+    rm /tmp/requirements-ci.txt && \
+    pip install triton
+
+# Set OpenBLAS paths (only effective when LAPACK is enabled)
+ENV OpenBLAS_HOME=/usr/lib64:${OpenBLAS_HOME}
+
+# Adding CUDA and library to the paths
+# Use the pytorch_build conda environment bin directory
+ENV PATH=/usr/local/cuda/bin:/opt/conda/envs/${CONDA_ENV}/bin:/opt/conda/bin:$PATH
+# Include conda env lib for newer libstdc++ (GLIBCXX_3.4.30+ needed by AOTI)
+ENV LD_LIBRARY_PATH=/usr/local/cuda/lib64:/opt/conda/envs/${CONDA_ENV}/lib:$LD_LIBRARY_PATH
+ENV CUDA_HOME=/usr/local/cuda
+
+# Setting flags and changing the linker to lld from default ld
+ENV CMAKE_LINKER="lld"
+ENV LDFLAGS="-fuse-ld=lld"
+
+# Set compiler flags for proper float16/half-precision support
+# -mf16c enables F16C instruction set for half-precision conversions on x86-64
+# -mavx2 enables AVX2 which is required for efficient FP16 operations
+ENV CFLAGS="-mf16c -mavx2"
+ENV CXXFLAGS="-mf16c -mavx2"
+
+# Set default conda environment for interactive use
+ENV CONDA_DEFAULT_ENV=${CONDA_ENV}
+RUN echo "conda activate ${CONDA_ENV}" >> ~/.bashrc
+
+# Create jenkins user to match upstream CI convention
+# This avoids RHEL-specific guards in build.sh and test.sh
+RUN echo "jenkins:x:1000:1000::/var/lib/jenkins:" >> /etc/passwd && \
+    echo "jenkins:x:1000:" >> /etc/group && \
+    echo "jenkins:*:19110:0:99999:7:::" >> /etc/shadow && \
+    mkdir -p /var/lib/jenkins && \
+    chown jenkins:jenkins /var/lib/jenkins && \
+    chown jenkins:jenkins /usr/local && \
+    echo 'jenkins ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/jenkins
+
+# Set permissions for conda and condarc
+RUN touch /.condarc && \
+    chmod o+rw /.condarc && \
+    chmod -R o+rw /opt/conda
+
+# Also setup conda for jenkins user
+RUN echo "conda activate ${CONDA_ENV}" >> /var/lib/jenkins/.bashrc && \
+    chown jenkins:jenkins /var/lib/jenkins/.bashrc
+
+WORKDIR /pytorch

--- a/.ci/docker/rhel9/README.md
+++ b/.ci/docker/rhel9/README.md
@@ -1,0 +1,29 @@
+# RHEL 9.6 Docker Image for PyTorch CI
+
+Docker image for building and testing PyTorch on RHEL 9.6 with CUDA 13.0 and NVIDIA H200 GPUs.
+
+## What's Included
+
+- RHEL 9.6 (UBI9 base)
+- Python 3.12, GCC 11, Ninja, LLD
+- CUDA 13.0 (via upstream `.ci/docker/common/install_cuda.sh`)
+- cuDNN, NCCL, cuSparseLt, NVSHMEM
+- Conda environment (`pytorch_build`)
+- OpenBLAS, Triton
+
+## Building
+
+```bash
+cd .ci/docker
+podman build -f rhel9/Dockerfile -t ci-image:pytorch-rhel-9.6-py3.12-gcc11 .
+```
+
+The Dockerfile uses upstream common scripts (`install_cuda.sh`, `install_nccl.sh`, `install_cusparselt.sh`) to install CUDA and related libraries, keeping version pins consistent with the rest of CI.
+
+## RHEL-Specific Notes
+
+- Uses Podman (rootless) instead of Docker
+- No jenkins user — runs as root
+- `/etc/profile.d/which2.sh` is removed to prevent sccache spawn failures
+- `LIBRARY_PATH` includes CUDA stubs for static lib linking
+- `libgomp.so` symlink created (UBI9 only ships runtime `libgomp.so.1`)

--- a/.ci/pytorch/common-build.sh
+++ b/.ci/pytorch/common-build.sh
@@ -7,51 +7,57 @@ if [[ "$BUILD_ENVIRONMENT" != *win-* ]]; then
     script_dir="$( cd "$(dirname "${BASH_SOURCE[0]}")" || exit ; pwd -P )"
 
     if which sccache > /dev/null; then
-        # Clear SCCACHE_BUCKET and SCCACHE_REGION if they are empty, otherwise
-        # sccache will complain about invalid bucket configuration
-        if [[ -z "${SCCACHE_BUCKET:-}" ]]; then
-          unset SCCACHE_BUCKET
-          unset SCCACHE_REGION
-        fi
-
-        # Save sccache logs to file
-        sccache --stop-server > /dev/null  2>&1 || true
-        rm -f ~/sccache_error.log || true
-
-        function sccache_epilogue() {
-            echo "::group::Sccache Compilation Log"
-            echo '=================== sccache compilation log ==================='
-            python "$script_dir/print_sccache_log.py" ~/sccache_error.log 2>/dev/null || true
-            echo '=========== If your build fails, please take a look at the log above for possible reasons ==========='
-            sccache --show-stats
-            sccache --stop-server || true
-            echo "::endgroup::"
-        }
-
-        # Register the function here so that the error log can be printed even when
-        # sccache fails to start, i.e. timeout error
-        trap_add sccache_epilogue EXIT
-
-        if [[ -n "${SKIP_SCCACHE_INITIALIZATION:-}" ]]; then
-            # sccache --start-server seems to hang forever on self hosted runners for GHA
-            # so let's just go ahead and skip the --start-server altogether since it seems
-            # as though sccache still gets used even when the sscache server isn't started
-            # explicitly
-            echo "Skipping sccache server initialization, setting environment variables"
-            export SCCACHE_IDLE_TIMEOUT=0
-            export SCCACHE_ERROR_LOG=~/sccache_error.log
-            export RUST_LOG=sccache::server=error
-        elif [[ "${BUILD_ENVIRONMENT}" == *rocm* ]]; then
-            SCCACHE_ERROR_LOG=~/sccache_error.log SCCACHE_IDLE_TIMEOUT=0 sccache --start-server
+        # Skip sccache entirely for RHEL builds — BASH_FUNC_which%% from
+        # Podman host env breaks sccache's Rust process spawning
+        if [[ "$BUILD_ENVIRONMENT" == *rhel* ]]; then
+          echo "Skipping sccache for RHEL build"
         else
-            # increasing SCCACHE_IDLE_TIMEOUT so that extension_backend_test.cpp can build after this PR:
-            # https://github.com/pytorch/pytorch/pull/16645
-            SCCACHE_ERROR_LOG=~/sccache_error.log SCCACHE_IDLE_TIMEOUT=0 RUST_LOG=sccache::server=error sccache --start-server
-        fi
+          # Clear SCCACHE_BUCKET and SCCACHE_REGION if they are empty, otherwise
+          # sccache will complain about invalid bucket configuration
+          if [[ -z "${SCCACHE_BUCKET:-}" ]]; then
+            unset SCCACHE_BUCKET
+            unset SCCACHE_REGION
+          fi
 
-        # Report sccache stats for easier debugging. It's ok if this commands
-        # timeouts and fails on MacOS
-        sccache --zero-stats || true
+          # Save sccache logs to file
+          sccache --stop-server > /dev/null  2>&1 || true
+          rm -f ~/sccache_error.log || true
+
+          function sccache_epilogue() {
+              echo "::group::Sccache Compilation Log"
+              echo '=================== sccache compilation log ==================='
+              python "$script_dir/print_sccache_log.py" ~/sccache_error.log 2>/dev/null || true
+              echo '=========== If your build fails, please take a look at the log above for possible reasons ==========='
+              sccache --show-stats || true
+              sccache --stop-server || true
+              echo "::endgroup::"
+          }
+
+          # Register the function here so that the error log can be printed even when
+          # sccache fails to start, i.e. timeout error
+          trap_add sccache_epilogue EXIT
+
+          if [[ -n "${SKIP_SCCACHE_INITIALIZATION:-}" ]]; then
+              # sccache --start-server seems to hang forever on self hosted runners for GHA
+              # so let's just go ahead and skip the --start-server altogether since it seems
+              # as though sccache still gets used even when the sscache server isn't started
+              # explicitly
+              echo "Skipping sccache server initialization, setting environment variables"
+              export SCCACHE_IDLE_TIMEOUT=0
+              export SCCACHE_ERROR_LOG=~/sccache_error.log
+              export RUST_LOG=sccache::server=error
+          elif [[ "${BUILD_ENVIRONMENT}" == *rocm* ]]; then
+              SCCACHE_ERROR_LOG=~/sccache_error.log SCCACHE_IDLE_TIMEOUT=0 sccache --start-server
+          else
+              # increasing SCCACHE_IDLE_TIMEOUT so that extension_backend_test.cpp can build after this PR:
+              # https://github.com/pytorch/pytorch/pull/16645
+              SCCACHE_ERROR_LOG=~/sccache_error.log SCCACHE_IDLE_TIMEOUT=0 RUST_LOG=sccache::server=error sccache --start-server
+          fi
+
+          # Report sccache stats for easier debugging. It's ok if this commands
+          # timeouts and fails on MacOS
+          sccache --zero-stats || true
+        fi
     fi
 
     if which ccache > /dev/null; then

--- a/.ci/pytorch/common_utils.sh
+++ b/.ci/pytorch/common_utils.sh
@@ -42,7 +42,7 @@ declare -f -t trap_add
 function assert_git_not_dirty() {
     # TODO: we should add an option to `build_amd.py` that reverts the repo to
     #       an unmodified state.
-    if [[ "$BUILD_ENVIRONMENT" != *rocm* ]] && [[ "$BUILD_ENVIRONMENT" != *xla* ]] ; then
+    if [[ "$BUILD_ENVIRONMENT" != *rocm* ]] && [[ "$BUILD_ENVIRONMENT" != *xla* ]] && [[ "$BUILD_ENVIRONMENT" != *rhel* ]] ; then
         git_status=$(git status --porcelain | grep -v '?? third_party' || true)
         if [[ $git_status ]]; then
             echo "Build left local git repository checkout dirty"
@@ -362,6 +362,10 @@ function install_cutlass_api() {
 }
 
 function print_sccache_stats() {
+  if ! which sccache > /dev/null 2>&1; then
+    echo "sccache not installed, skipping stats"
+    return
+  fi
   echo 'PyTorch Build Statistics'
   sccache --show-stats
 

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -14,10 +14,9 @@ source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
 # shellcheck source=./common-build.sh
 source "$(dirname "${BASH_SOURCE[0]}")/common-build.sh"
 
-# Only change workspace permissions if passwordless sudo is available
-# (e.g. ROCm and s390x CI jobs lack it, and changing permissions
-# can leave the workspace in a bad state for cancelled jobs)
-if sudo -n true 2>/dev/null && [[ -d /var/lib/jenkins/workspace ]]; then
+# Do not change workspace permissions for ROCm and s390x CI jobs
+# as it can leave workspace with bad permissions for cancelled jobs
+if [[ "$BUILD_ENVIRONMENT" != *rocm* && "$BUILD_ENVIRONMENT" != *s390x* && -d /var/lib/jenkins/workspace ]]; then
   # Workaround for dind-rootless userid mapping (https://github.com/pytorch/ci-infra/issues/96)
   WORKSPACE_ORIGINAL_OWNER_ID=$(stat -c '%u' "/var/lib/jenkins/workspace")
   cleanup_workspace() {
@@ -1866,9 +1865,7 @@ EOF
     fi
 
     # Ensure invalid item is in the test output.
-    # Use a here-string instead of a pipe to avoid SIGPIPE when grep -q
-    # exits early on large output (causes exit code 141 with pipefail).
-    grep -q "${invalid_item_name}" <<< "${test_output}" && ret=$? || ret=$?
+    echo "${test_output}" | grep -q "${invalid_item_name}" && ret=$? || ret=$?
 
     if [ $ret -ne 0 ]; then
         cat << EOF

--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -112,6 +112,8 @@ runs:
             echo "ARC Runner, no info on ec2 metadata"
           elif [[ $runner_name_str == *"gcp"* || $runner_name_str == *"google"* ]]; then
             echo "Runner is from Google Cloud Platform, No info on ec2 metadata"
+          elif [[ $runner_name_str == *"git-runner"* ]] || [[ $runner_name_str == *"pytorch-team-ci"* ]]; then
+            echo "Self-hosted runner, no info on ec2 metadata"
           else
             curl -H "X-aws-ec2-metadata-token: $(curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30")" -fsSL "http://169.254.169.254/latest/meta-data/${category}"
           fi
@@ -127,16 +129,31 @@ runs:
       id: check_container_runner
       run: echo "IN_CONTAINER_RUNNER=$(if [ -f /.inarc ] || [ -f /.incontainer ]; then echo true ; else echo false; fi)" >> "$GITHUB_OUTPUT"
 
-    - name: Start docker if docker daemon is not running
+    - name: Start docker/podman service if not running
       shell: bash
       if: ${{ steps.check_container_runner.outputs.IN_CONTAINER_RUNNER == 'false' }}
       run: |
-        if ! docker version >/dev/null 2>/dev/null; then
-          if systemctl is-active --quiet docker; then
-              echo "Docker daemon is running...";
-          else
-              echo "Starting docker daemon..." && sudo systemctl start docker;
-          fi
+        # First check if docker command is already available (covers rootless podman)
+        if command -v docker &> /dev/null && docker ps &> /dev/null; then
+            echo "Docker/Podman is already running and accessible";
+        # Check if podman service exists (RHEL/Fedora systems with systemd podman)
+        elif systemctl list-unit-files | grep -q podman.service; then
+            if systemctl is-active --quiet podman; then
+                echo "Podman service is running...";
+            else
+                echo "Starting podman service..." && systemctl --user start podman;
+            fi
+        # Otherwise check for docker service
+        elif systemctl is-active --quiet docker; then
+            echo "Docker daemon is running...";
+        else
+            echo "Starting docker daemon..." && sudo systemctl start docker;
+        fi
+
+        # Configure podman short-name mode to permissive if podman is available
+        if command -v podman &> /dev/null; then
+            mkdir -p ~/.config/containers
+            echo 'short-name-mode = "permissive"' > ~/.config/containers/registries.conf
         fi
 
     - name: Install uv (EC2)

--- a/.github/workflows/_linux-build.yml
+++ b/.github/workflows/_linux-build.yml
@@ -168,13 +168,13 @@ jobs:
     runs-on: ${{ inputs.runner }}
     timeout-minutes: 480
     outputs:
-      docker-image: ${{ steps.calculate-docker-image.outputs.docker-image }}
+      docker-image: ${{ steps.calculate-docker-image.outputs.docker-image || steps.set-rhel-image.outputs.docker-image }}
       test-matrix: ${{ steps.strip-runner-prefix.outputs.test-matrix }}
       build-environment: ${{ inputs.build-environment }}
     steps:
       - name: Setup SSH (Click me for login details)
         uses: pytorch/test-infra/.github/actions/setup-ssh@main
-        if: inputs.build-environment != 'linux-s390x-binary-manywheel'
+        if: inputs.build-environment != 'linux-s390x-binary-manywheel' && !contains(inputs.build-environment, 'rhel')
         with:
           github-secret: ${{ secrets.GITHUB_TOKEN }}
           instructions: |
@@ -182,6 +182,7 @@ jobs:
               docker exec -it $(docker container ps --format '{{.ID}}') bash
 
       - name: Setup Linux
+        if: inputs.build-environment != 'linux-s390x-binary-manywheel' && !contains(inputs.build-environment, 'rhel')
         id: setup-linux
         uses: pytorch/pytorch/.github/actions/setup-linux@main
         with:
@@ -191,7 +192,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to ECR
-        if: inputs.build-environment != 'linux-s390x-binary-manywheel'
+        if: inputs.build-environment != 'linux-s390x-binary-manywheel' && !contains(inputs.build-environment, 'rhel')
         uses: ./.github/actions/ecr-login
         with:
           aws-role-to-assume: ${{ inputs.aws-role-to-assume }}
@@ -210,14 +211,21 @@ jobs:
       - name: Calculate docker image
         id: calculate-docker-image
         uses: pytorch/test-infra/.github/actions/calculate-docker-image@main
-        if: inputs.build-environment != 'linux-s390x-binary-manywheel'
+        if: inputs.build-environment != 'linux-s390x-binary-manywheel' && !contains(inputs.build-environment, 'rhel')
         with:
           docker-image-name: ${{ inputs.docker-image-name }}
           ci-docker-hash: ${{ inputs.ci-docker-hash }}
 
+      - name: Set RHEL docker image
+        id: set-rhel-image
+        if: contains(inputs.build-environment, 'rhel')
+        shell: bash
+        run: |
+          echo "docker-image=${{ inputs.docker-image-name }}" >> "$GITHUB_OUTPUT"
+
       - name: Use following to pull public copy of the image
         id: print-ghcr-mirror
-        if: inputs.build-environment != 'linux-s390x-binary-manywheel' && steps.use-old-whl.outputs.reuse != 'true'
+        if: inputs.build-environment != 'linux-s390x-binary-manywheel' && !contains(inputs.build-environment, 'rhel') && steps.use-old-whl.outputs.reuse != 'true'
         env:
           ECR_DOCKER_IMAGE: ${{ steps.calculate-docker-image.outputs.docker-image }}
         shell: bash
@@ -227,7 +235,7 @@ jobs:
 
       - name: Pull docker image
         uses: pytorch/test-infra/.github/actions/pull-docker-image@main
-        if: inputs.build-environment != 'linux-s390x-binary-manywheel' && steps.use-old-whl.outputs.reuse != 'true'
+        if: inputs.build-environment != 'linux-s390x-binary-manywheel' && !contains(inputs.build-environment, 'rhel') && steps.use-old-whl.outputs.reuse != 'true'
         with:
           docker-image: ${{ steps.calculate-docker-image.outputs.docker-image }}
 
@@ -297,7 +305,7 @@ jobs:
           XLA_CLANG_CACHE_S3_BUCKET_NAME: ossci-compiler-clang-cache-circleci-xla
           PR_LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
           TORCH_CUDA_ARCH_LIST: ${{ inputs.cuda-arch-list }}
-          DOCKER_IMAGE: ${{ steps.calculate-docker-image.outputs.docker-image }}
+          DOCKER_IMAGE: ${{ steps.calculate-docker-image.outputs.docker-image || steps.set-rhel-image.outputs.docker-image }}
           DOCKER_IMAGE_S390X: ${{ inputs.docker-image-name }}
           XLA_CUDA: ${{ contains(inputs.build-environment, 'xla') && '0' || '' }}
           OUR_GITHUB_JOB_ID: ${{ steps.setup-linux.outputs.job-id }}
@@ -305,6 +313,28 @@ jobs:
           BUILD_ADDITIONAL_PACKAGES: ${{ inputs.build-additional-packages }}
           RUNNER: ${{ inputs.runner }}
         run: |
+          # Import RHEL Docker image from persistent storage if needed
+          if [[ ${BUILD_ENVIRONMENT} == *"rhel"* ]]; then
+            IMAGE_TAR_PATH="/mnt/podman_storage/vpcuser/docker-images/rhel9-py3.12-gcc11.tar"
+            READY_MARKER="${IMAGE_TAR_PATH}.ready"
+            docker rmi localhost/ci-image:pytorch-rhel-9.6-py3.12-gcc11 2>/dev/null || true
+            docker rmi ci-image:pytorch-rhel-9.6-py3.12-gcc11 2>/dev/null || true
+            for i in {1..12}; do
+              if [ -f "${READY_MARKER}" ]; then break; fi
+              echo "Waiting for Docker image... (attempt $i/12)" && sleep 5
+            done
+            if [ -f "${IMAGE_TAR_PATH}" ]; then
+              docker load -i "${IMAGE_TAR_PATH}"
+              docker images | grep ci-image
+            fi
+            mkdir -p ~/.config/containers
+            echo 'short-name-mode = "permissive"' > ~/.config/containers/registries.conf
+
+            # Create env file since setup-linux is skipped for RHEL
+            env | grep '^GITHUB' >> "/tmp/github_env_${GITHUB_RUN_ID}"
+            env | grep '^CI' >> "/tmp/github_env_${GITHUB_RUN_ID}"
+          fi
+
           START_TIME=$(date +%s)
           if [[ ${BUILD_ENVIRONMENT} == *"s390x"* ]]; then
             JENKINS_USER=
@@ -354,13 +384,20 @@ jobs:
             RISCV_DOCKER_ARGS=
           fi
 
+          # Set MAX_JOBS based on environment
+          if [[ ${BUILD_ENVIRONMENT} == *"rhel"* ]]; then
+            MAX_JOBS_VALUE=16
+          else
+            MAX_JOBS_VALUE="$(nproc --ignore=2)"
+          fi
+
           # detached container should get cleaned up by teardown_ec2_linux
           # Used for JENKINS_USER and DOCKER_SHELL_CMD, which can be empty
           # shellcheck disable=SC2086
           container_name=$(docker run \
             ${RISCV_DOCKER_ARGS} \
             -e BUILD_ENVIRONMENT \
-            -e MAX_JOBS="$(nproc --ignore=2)" \
+            -e MAX_JOBS="${MAX_JOBS_VALUE}" \
             -e PR_NUMBER \
             -e SHA1 \
             -e BRANCH \
@@ -398,7 +435,11 @@ jobs:
                 (sleep 300 && python3 -m pip install -r requirements.txt)"
           fi
 
-          docker exec -t "${container_name}" sh -c '.ci/pytorch/build.sh'
+          if [[ ${BUILD_ENVIRONMENT} == *"rhel"* ]]; then
+            docker exec -t "${container_name}" bash -l -c '. /opt/conda/etc/profile.d/conda.sh && conda activate pytorch_build && .ci/pytorch/build.sh'
+          else
+            docker exec -t "${container_name}" sh -c '.ci/pytorch/build.sh'
+          fi
 
           END_TIME=$(date +%s)
           echo "build_time=$((END_TIME - START_TIME))" >> "$GITHUB_OUTPUT"
@@ -409,7 +450,7 @@ jobs:
         uses: ./.github/actions/build-external-packages
         with:
           build-targets: ${{ inputs.build-external-packages }}
-          docker-image: ${{ steps.calculate-docker-image.outputs.docker-image }}
+          docker-image: ${{ steps.calculate-docker-image.outputs.docker-image || steps.set-rhel-image.outputs.docker-image }}
           cuda-arch-list: ${{ inputs.cuda-arch-list }}
           output-dir: external
 
@@ -439,7 +480,7 @@ jobs:
 
       - name: Store PyTorch Build Artifacts on S3
         uses: seemethere/upload-artifact-s3@baba72d0712b404f646cebe0730933554ebce96a # v5.1.0
-        if: inputs.build-generates-artifacts && (steps.build.outcome != 'skipped' || steps.use-old-whl.outputs.reuse == 'true') && inputs.build-environment != 'linux-s390x-binary-manywheel'
+        if: inputs.build-generates-artifacts && (steps.build.outcome != 'skipped' || steps.use-old-whl.outputs.reuse == 'true') && inputs.build-environment != 'linux-s390x-binary-manywheel' && !contains(inputs.build-environment, 'rhel')
         with:
           name: ${{ inputs.build-environment }}
           retention-days: 14
@@ -456,9 +497,18 @@ jobs:
           if-no-files-found: error
           path: artifacts.zip
 
+      - name: Store PyTorch Build Artifacts for RHEL
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: inputs.build-generates-artifacts && (steps.build.outcome != 'skipped' || steps.use-old-whl.outputs.reuse == 'true') && contains(inputs.build-environment, 'rhel')
+        with:
+          name: ${{ inputs.build-environment }}
+          retention-days: 14
+          if-no-files-found: error
+          path: artifacts.zip
+
       - name: Copy logs
         shell: bash
-        if: ${{ always() && steps.build.outcome != 'skipped' && !inputs.disable-monitor && inputs.build-environment != 'linux-s390x-binary-manywheel'}}
+        if: ${{ always() && steps.build.outcome != 'skipped' && !inputs.disable-monitor && inputs.build-environment != 'linux-s390x-binary-manywheel' && !contains(inputs.build-environment, 'rhel')}}
         continue-on-error: true
         run: |
           rm -f ./usage_logs
@@ -466,8 +516,8 @@ jobs:
           cp ../../usage_logs/usage_log_build_*.txt ./usage_logs/
 
       - name: Upload raw usage log to s3
-        if: ${{ always() && steps.build.outcome != 'skipped' && !inputs.disable-monitor && inputs.build-environment != 'linux-s390x-binary-manywheel'}}
-        uses: seemethere/upload-artifact-s3@baba72d0712b404f646cebe0730933554ebce96a # v5
+        if: ${{ always() && steps.build.outcome != 'skipped' && !inputs.disable-monitor && inputs.build-environment != 'linux-s390x-binary-manywheel' && !contains(inputs.build-environment, 'rhel')}}
+        uses: seemethere/upload-artifact-s3@v5
         with:
           s3-prefix: |
             ${{ github.repository }}/${{ github.run_id }}/${{ github.run_attempt }}/artifact
@@ -476,14 +526,14 @@ jobs:
           path: usage_logs/usage_log_build_*.txt
 
       - name: Upload sccache stats
-        if: steps.build.outcome != 'skipped' && inputs.build-environment != 'linux-s390x-binary-manywheel'
+        if: steps.build.outcome != 'skipped' && inputs.build-environment != 'linux-s390x-binary-manywheel' && !contains(inputs.build-environment, 'rhel')
         uses: ./.github/actions/upload-sccache-stats
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           build-time: ${{ steps.build.outputs.build_time }}
 
       - name: Upload utilization stats
-        if: ${{ always() && steps.build.outcome != 'skipped' && !inputs.disable-monitor && inputs.build-environment != 'linux-s390x-binary-manywheel' }}
+        if: ${{ always() && steps.build.outcome != 'skipped' && !inputs.disable-monitor && inputs.build-environment != 'linux-s390x-binary-manywheel' && !contains(inputs.build-environment, 'rhel') }}
         continue-on-error: true
         uses: ./.github/actions/upload-utilization-stats
         with:
@@ -496,7 +546,7 @@ jobs:
 
       - name: Teardown Linux
         uses: pytorch/test-infra/.github/actions/teardown-linux@main
-        if: always() && inputs.build-environment != 'linux-s390x-binary-manywheel'
+        if: always() && inputs.build-environment != 'linux-s390x-binary-manywheel' && !contains(inputs.build-environment, 'rhel')
 
       - name: Cleanup docker
         if: always() && inputs.build-environment == 'linux-s390x-binary-manywheel'

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -179,21 +179,46 @@ jobs:
         run: echo "TPU_DOCKER_FLAGS=--privileged --network=host -e PJRT_DEVICE=TPU -e TPU_SKIP_MDS_QUERY -e TPU_TOPOLOGY -e TPU_WORKER_ID -e TPU_TOPOLOGY_WRAP -e TPU_CHIPS_PER_HOST_BOUNDS -e TPU_ACCELERATOR_TYPE -e TPU_RUNTIME_METRICS_PORTS -e TPU_TOPOLOGY_ALT -e HOST_BOUNDS -e TPU_HOST_BOUNDS -e VBAR_CONTROL_SERVICE_URL -e CHIPS_PER_HOST_BOUNDS -e TPU_WORKER_HOSTNAMES" >> "$GITHUB_ENV"
 
       - name: Login to ECR
-        if: inputs.build-environment != 'linux-s390x-binary-manywheel'
+        if: inputs.build-environment != 'linux-s390x-binary-manywheel' && !contains(inputs.build-environment, 'rhel')
         uses: ./.github/actions/ecr-login
         with:
           aws-role-to-assume: ${{ inputs.aws-role-to-assume }}
 
+      - name: Import RHEL Docker image from local storage
+        if: contains(inputs.build-environment, 'rhel')
+        shell: bash
+        run: |
+          IMAGE_TAR_PATH="/mnt/podman_storage/vpcuser/docker-images/rhel9-py3.12-gcc11.tar"
+          READY_MARKER="${IMAGE_TAR_PATH}.ready"
+          for i in {1..12}; do
+            if [ -f "${READY_MARKER}" ]; then break; fi
+            echo "Waiting for Docker image... (attempt $i/12)" && sleep 5
+          done
+          if [ -f "${IMAGE_TAR_PATH}" ]; then
+            docker load -i "${IMAGE_TAR_PATH}"
+            docker images | grep ci-image
+          else
+            echo "Error: RHEL image tar file not found at ${IMAGE_TAR_PATH}"
+            exit 1
+          fi
+
       - name: Calculate docker image
         id: calculate-docker-image
         uses: pytorch/test-infra/.github/actions/calculate-docker-image@main
-        if: inputs.build-environment != 'linux-s390x-binary-manywheel'
+        if: inputs.build-environment != 'linux-s390x-binary-manywheel' && !contains(inputs.build-environment, 'rhel')
         with:
           docker-image-name: ${{ inputs.docker-image }}
 
+      - name: Set RHEL docker image
+        id: set-rhel-image
+        if: contains(inputs.build-environment, 'rhel')
+        shell: bash
+        run: |
+          echo "docker-image=${{ inputs.docker-image }}" >> "${GITHUB_OUTPUT}"
+
       - name: Use following to pull public copy of the image
         id: print-ghcr-mirror
-        if: inputs.build-environment != 'linux-s390x-binary-manywheel'
+        if: inputs.build-environment != 'linux-s390x-binary-manywheel' && !contains(inputs.build-environment, 'rhel')
         env:
           ECR_DOCKER_IMAGE: ${{ steps.calculate-docker-image.outputs.docker-image }}
         shell: bash
@@ -203,7 +228,7 @@ jobs:
 
       - name: Pull docker image
         uses: pytorch/test-infra/.github/actions/pull-docker-image@main
-        if: inputs.build-environment != 'linux-s390x-binary-manywheel'
+        if: inputs.build-environment != 'linux-s390x-binary-manywheel' && !contains(inputs.build-environment, 'rhel')
         with:
           docker-image: ${{ steps.calculate-docker-image.outputs.docker-image }}
 
@@ -218,6 +243,7 @@ jobs:
         with:
           driver-version: '580.82.07'
         if: ${{ !contains(matrix.runner, 'b200') }}
+        continue-on-error: true
 
       - name: Setup GPU_FLAG for docker run
         id: setup-gpu-flag
@@ -250,7 +276,7 @@ jobs:
         with:
           name: ${{ inputs.build-environment }}
           s3-bucket: ${{ inputs.s3-bucket }}
-          use-gha: ${{ inputs.use-gha }}
+          use-gha: ${{ contains(inputs.build-environment, 'rhel') || inputs.use-gha }}
 
       - name: Download TD artifacts
         continue-on-error: true
@@ -376,7 +402,7 @@ jobs:
           SCCACHE_BUCKET: ${{ !contains(matrix.runner, 'b200') && 'ossci-compiler-cache-circleci-v2' || '' }}
           SCCACHE_REGION: ${{ !contains(matrix.runner, 'b200') && 'us-east-1' || '' }}
           SHM_SIZE: ${{ steps.install-nvidia-driver.outputs.has-nvidia == 'true' && '2g' || '1g' }}
-          DOCKER_IMAGE: ${{ steps.calculate-docker-image.outputs.docker-image }}
+          DOCKER_IMAGE: ${{ steps.calculate-docker-image.outputs.docker-image || steps.set-rhel-image.outputs.docker-image }}
           DOCKER_IMAGE_S390X: ${{ inputs.docker-image }}
           XLA_CUDA: ${{ contains(inputs.build-environment, 'xla') && '0' || '' }}
           XLA_CLANG_CACHE_S3_BUCKET_NAME: ossci-compiler-clang-cache-circleci-xla
@@ -424,6 +450,13 @@ jobs:
             # when job is cancelled
             DOCKER_SHELL_CMD="sleep 12h"
             USED_IMAGE="${DOCKER_IMAGE_S390X}"
+          elif [[ ${BUILD_ENVIRONMENT} == *"rhel"* ]]; then
+            # RHEL: no --shm-size with --ipc=host (Podman conflict)
+            SHM_OPTS=
+            JENKINS_USER="--user jenkins"
+            DOCKER_SHELL_CMD=
+            USED_IMAGE="${DOCKER_IMAGE}"
+            export PYTHON_TEST_EXTRA_OPTION="--keep-going"
           else
             SHM_OPTS="--shm-size=${SHM_SIZE}"
             JENKINS_USER="--user jenkins"
@@ -499,6 +532,7 @@ jobs:
             -e EXPORT_PROFILER_TRACE \
             -e ENABLE_TORCH_TRACE \
             -e ARTIFACTS_FILE_SUFFIX \
+            -e PYTHON_TEST_EXTRA_OPTION \
             -e TORCH_TPU \
             -e TORCH_TPU_TEXT_FILE \
             ${TPU_DOCKER_FLAGS:-} \
@@ -535,7 +569,7 @@ jobs:
       - name: Upload pytest cache if tests failed
         uses: ./.github/actions/pytest-cache-upload
         continue-on-error: true
-        if: failure() && steps.test.conclusion && steps.test.conclusion == 'failure' && inputs.build-environment != 'linux-s390x-binary-manywheel'
+        if: failure() && steps.test.conclusion && steps.test.conclusion == 'failure' && inputs.build-environment != 'linux-s390x-binary-manywheel' && !contains(inputs.build-environment, 'rhel')
         with:
           cache_dir: .pytest_cache
           shard: ${{ matrix.shard }}
@@ -581,7 +615,7 @@ jobs:
         if: always() && steps.test.conclusion && steps.test.conclusion != 'skipped'
         with:
           file-suffix: ${{ github.job }}-${{ matrix.config }}-${{ matrix.shard }}-${{ matrix.num_shards }}-${{ matrix.runner }}_${{ steps.setup-linux.outputs.job-id }}
-          use-gha: ${{ inputs.use-gha }}
+          use-gha: ${{ contains(inputs.build-environment, 'rhel') || inputs.use-gha }}
           s3-bucket: ${{ inputs.s3-bucket }}
 
       - name: Collect backtraces from coredumps (if any)
@@ -600,7 +634,7 @@ jobs:
           path: ./**/core.[1-9]*
 
       - name: Upload utilization stats
-        if: ${{ always() && steps.test.conclusion && steps.test.conclusion != 'skipped' && !inputs.disable-monitor && inputs.build-environment != 'linux-s390x-binary-manywheel' }}
+        if: ${{ always() && steps.test.conclusion && steps.test.conclusion != 'skipped' && !inputs.disable-monitor && inputs.build-environment != 'linux-s390x-binary-manywheel' && !contains(inputs.build-environment, 'rhel') }}
         continue-on-error: true
         uses: ./.github/actions/upload-utilization-stats
         with:
@@ -612,7 +646,7 @@ jobs:
 
       - name: Teardown Linux
         uses: pytorch/test-infra/.github/actions/teardown-linux@main
-        if: always() && steps.check_container_runner.outputs.IN_CONTAINER_RUNNER == 'false'
+        if: always() && steps.check_container_runner.outputs.IN_CONTAINER_RUNNER == 'false' && !contains(inputs.build-environment, 'rhel')
 
       - name: Cleanup docker
         if: always() && inputs.build-environment == 'linux-s390x-binary-manywheel'

--- a/.github/workflows/build-rhel9-images.yml
+++ b/.github/workflows/build-rhel9-images.yml
@@ -1,0 +1,110 @@
+name: build-rhel9-images
+
+on:
+  workflow_dispatch:
+  workflow_call:
+  push:
+    branches:
+      - main
+      - release/*
+    paths:
+      - .ci/docker/rhel9/**
+      - .github/workflows/build-rhel9-images.yml
+    tags:
+      # Release candidate tags
+      - v[0-9]+.[0-9]+.0+-rc[0-9]+
+  pull_request:
+    paths:
+      - .ci/docker/rhel9/**
+      - .github/workflows/build-rhel9-images.yml
+
+permissions: read-all
+
+jobs:
+  build-rhel9-images:
+    runs-on: linux.rhel9
+    timeout-minutes: 240
+    strategy:
+      fail-fast: false
+      matrix:
+        tag: ["cuda13.0"]
+    steps:
+      - name: Checkout PyTorch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Clean up stale podman containers and configure storage
+        shell: bash
+        run: |
+          # Clean up old containers and images (but don't reset storage)
+          podman container prune -f || true
+          podman image prune -f || true
+
+          # Create podman config directory
+          mkdir -p ~/.config/containers
+
+          # Only configure storage.conf if it doesn't already exist
+          # (runner may have pre-configured storage at /mnt/podman_storage/)
+          if [ ! -f ~/.config/containers/storage.conf ]; then
+            ACTUAL_HOME=$(eval echo ~)
+            cat > ~/.config/containers/storage.conf << EOF
+          [storage]
+          driver = "overlay"
+          runroot = "${ACTUAL_HOME}/.local/share/containers/storage"
+          graphroot = "${ACTUAL_HOME}/.local/share/containers/storage"
+
+          [storage.options]
+          additionalimagestores = []
+          pull_options = {enable_partial_images = "false", use_hard_links = "false", ostree_repos=""}
+
+          [storage.options.overlay]
+          mountopt = "nodev,metacopy=on"
+          EOF
+            mkdir -p ~/.local/share/containers/storage
+          fi
+
+          # Ensure podman short-name mode is permissive
+          if ! grep -q 'short-name-mode' ~/.config/containers/registries.conf 2>/dev/null; then
+            echo 'short-name-mode = "permissive"' > ~/.config/containers/registries.conf
+          fi
+
+          # Create temp directory
+          mkdir -p ~/tmp
+          export TMPDIR=$HOME/tmp
+
+      - name: Build and tag RHEL 9 Docker image
+        shell: bash
+        run: |
+          cd .ci/docker
+          docker build -f rhel9/Dockerfile -t ci-image:pytorch-rhel-9.6-py3.12-gcc11 .
+
+      - name: List built Docker images
+        run: |
+          echo "=== Newly built RHEL images ==="
+          docker images | grep -E "(ci-image|rhel9-builder|tmp\.)" | head -20
+          echo ""
+          echo "Build completed successfully!"
+          echo "Image ci-image:pytorch-rhel-9.6-py3.12-gcc11 is ready for PyTorch build"
+
+      - name: Export Docker image to persistent storage
+        shell: bash
+        run: |
+          # Create persistent directory for Docker images
+          mkdir -p /mnt/podman_storage/vpcuser/docker-images
+
+          # Remove old tar file if it exists (podman doesn't overwrite)
+          rm -f /mnt/podman_storage/vpcuser/docker-images/rhel9-py3.12-gcc11.tar
+          rm -f /mnt/podman_storage/vpcuser/docker-images/rhel9-py3.12-gcc11.tar.ready
+
+          # Export the image to tar file (use localhost/ prefix for podman compatibility)
+          echo "Exporting localhost/ci-image:pytorch-rhel-9.6-py3.12-gcc11 to tar file..."
+          docker save -o /mnt/podman_storage/vpcuser/docker-images/rhel9-py3.12-gcc11.tar localhost/ci-image:pytorch-rhel-9.6-py3.12-gcc11
+
+          # Verify the tar file was created
+          ls -lh /mnt/podman_storage/vpcuser/docker-images/rhel9-py3.12-gcc11.tar
+          echo "Image exported successfully to /mnt/podman_storage/vpcuser/docker-images/rhel9-py3.12-gcc11.tar"
+
+          # Create a .ready marker file to signal that the tar is complete
+          touch /mnt/podman_storage/vpcuser/docker-images/rhel9-py3.12-gcc11.tar.ready
+          echo "Ready marker created: rhel9-py3.12-gcc11.tar.ready"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -129,6 +129,36 @@ jobs:
             )"
           fi
 
+  rhel-9_6-py3_12-gcc11-build:
+    name: rhel-9.6-py3.12-gcc11
+    uses: ./.github/workflows/_linux-build.yml
+    with:
+      runner_prefix: ""
+      runner: "linux.rhel9"
+      build-environment: linux-rhel9.6-cuda13.0-py3.12-gcc11
+      docker-image-name: ci-image:pytorch-rhel-9.6-py3.12-gcc11
+      cuda-arch-list: "9.0"
+      test-matrix: |
+        { include: [
+          { config: "default", shard: 1, num_shards: 5, runner: "linux.rhel9" },
+          { config: "default", shard: 2, num_shards: 5, runner: "linux.rhel9" },
+          { config: "default", shard: 3, num_shards: 5, runner: "linux.rhel9" },
+          { config: "default", shard: 4, num_shards: 5, runner: "linux.rhel9" },
+          { config: "default", shard: 5, num_shards: 5, runner: "linux.rhel9" },
+        ]}
+    secrets: inherit
+
+  rhel-9_6-py3_12-gcc11-test:
+    name: rhel-9.6-py3.12-gcc11
+    uses: ./.github/workflows/_linux-test.yml
+    needs: rhel-9_6-py3_12-gcc11-build
+    with:
+      build-environment: linux-rhel9.6-cuda13.0-py3.12-gcc11
+      docker-image: ${{ needs.rhel-9_6-py3_12-gcc11-build.outputs.docker-image }}
+      test-matrix: ${{ needs.rhel-9_6-py3_12-gcc11-build.outputs.test-matrix }}
+      timeout-minutes: 600
+    secrets: inherit
+
   update-commit-hashes:
     runs-on: ubuntu-latest
     environment: update-commit-hash

--- a/.github/workflows/rhel-build-test.yml
+++ b/.github/workflows/rhel-build-test.yml
@@ -1,0 +1,73 @@
+name: RHEL 9.6 Build and Test
+# Full pipeline test with all fixes applied
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+    paths:
+      - .ci/docker/rhel9/**
+      - .github/workflows/rhel-build-test.yml
+      - .github/workflows/build-rhel9-images.yml
+      - .github/workflows/_linux-build.yml
+      - .github/workflows/_linux-test.yml
+      - .github/actions/setup-linux/**
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
+  cancel-in-progress: true
+
+permissions:
+  id-token: write
+  contents: read
+  actions: read
+  artifact-metadata: read
+  attestations: read
+  checks: read
+  deployments: read
+  discussions: read
+  issues: read
+  models: read
+  packages: read
+  pages: read
+  pull-requests: read
+  repository-projects: read
+  security-events: read
+  statuses: read
+
+jobs:
+  build-docker-image:
+    name: Build RHEL 9.6 Docker Image
+    uses: ./.github/workflows/build-rhel9-images.yml
+    secrets: inherit
+
+  rhel-9_6-py3_12-gcc11-build:
+    needs: build-docker-image
+    name: rhel-9.6-py3.12-gcc11
+    uses: ./.github/workflows/_linux-build.yml
+    with:
+      runner_prefix: ""
+      runner: "linux.rhel9"
+      build-environment: linux-rhel9.6-cuda13.0-py3.12-gcc11
+      docker-image-name: ci-image:pytorch-rhel-9.6-py3.12-gcc11
+      cuda-arch-list: "9.0"
+      test-matrix: |
+        { include: [
+          { config: "default", shard: 1, num_shards: 5, runner: "linux.rhel9" },
+          { config: "default", shard: 2, num_shards: 5, runner: "linux.rhel9" },
+          { config: "default", shard: 3, num_shards: 5, runner: "linux.rhel9" },
+          { config: "default", shard: 4, num_shards: 5, runner: "linux.rhel9" },
+          { config: "default", shard: 5, num_shards: 5, runner: "linux.rhel9" },
+        ]}
+    secrets: inherit
+
+  rhel-9_6-py3_12-gcc11-test:
+    name: rhel-9.6-py3.12-gcc11
+    uses: ./.github/workflows/_linux-test.yml
+    needs: rhel-9_6-py3_12-gcc11-build
+    with:
+      build-environment: linux-rhel9.6-cuda13.0-py3.12-gcc11
+      docker-image: ${{ needs.rhel-9_6-py3_12-gcc11-build.outputs.docker-image }}
+      test-matrix: ${{ needs.rhel-9_6-py3_12-gcc11-build.outputs.test-matrix }}
+      timeout-minutes: 600
+    secrets: inherit

--- a/.github/workflows/test-rhel-runner.yml
+++ b/.github/workflows/test-rhel-runner.yml
@@ -1,0 +1,36 @@
+name: test-rhel-runner
+# Test trigger with linux.rhel9
+on:
+  workflow_dispatch:
+
+jobs:
+  test-runner:
+    name: Test RHEL Runner
+    runs-on: linux.rhel9
+    steps:
+      - name: Check runner
+        run: |
+          echo "=== Runner Information ==="
+          echo "Runner OS: $(uname -a)"
+          echo "Runner hostname: $(hostname)"
+          echo "Python version: $(python3 --version)"
+          echo "GCC version: $(gcc --version | head -1)"
+
+      - name: Check RHEL version
+        run: |
+          echo "=== RHEL Version ==="
+          cat /etc/redhat-release || echo "Not a RHEL system"
+          cat /etc/os-release || true
+
+      - name: Check Docker
+        run: |
+          echo "=== Docker Information ==="
+          docker --version
+          docker ps -a || echo "Docker not running or no permission"
+
+      - name: System info
+        run: |
+          echo "=== System Resources ==="
+          echo "CPU: $(nproc) cores"
+          echo "Memory: $(free -h | grep Mem)"
+          echo "Disk: $(df -h /)"


### PR DESCRIPTION
## Summary

Adds RHEL 9.6 as a CI platform for PyTorch, running on self-hosted runners with NVIDIA H200 GPUs (Hopper, sm_90) and Podman as the container runtime.

This has been tested end-to-end on a self-hosted RHEL runner — Docker image builds, PyTorch CUDA build completes, and test shards execute. The PR is intentionally a draft to get early feedback on the approach before the runner infrastructure is finalized.

## What's included

**5 new files:**
- `.ci/docker/rhel9/Dockerfile` — RHEL 9.6 image using upstream `install_cuda.sh` / `install_nccl.sh` for CUDA 12.8
- `.github/workflows/rhel-build-test.yml` — standalone RHEL build+test workflow (5 shards)
- `.github/workflows/build-rhel9-images.yml` — Docker image build workflow
- `.github/workflows/test-rhel-runner.yml` — runner connectivity check
- `.ci/docker/rhel9/README.md`

**6 modified files:**
- `.github/actions/setup-linux/action.yml` — Podman service detection (rootless), self-hosted runner EC2 metadata skip
- `.github/workflows/_linux-build.yml` — RHEL container setup (conda activation, local image import, MAX_JOBS=4)
- `.github/workflows/_linux-test.yml` — SHM_OPTS fix for Podman `--ipc=host`, RHEL container config
- `.github/workflows/nightly.yml` — RHEL build+test jobs
- `.ci/pytorch/build.sh` — skip jemalloc `LD_PRELOAD` on RHEL (Ubuntu-specific path), skip jenkins user operations
- `.ci/pytorch/test.sh` — skip workspace permission changes on RHEL (runs as root, no jenkins user)

## Design decisions

- **Reuses upstream common scripts** for CUDA installation (`install_cuda.sh 12.8` handles CUDA, cuDNN, NCCL, cuSparseLt, NVSHMEM) instead of manual `dnf install`, keeping version pins in sync automatically.
- **Follows the s390x pattern** — separate workflow files, self-hosted runner, not in trunk/pull.
- **All changes are guarded** by `contains(build-environment, 'rhel')` so existing workflows are unaffected.
- **Runner label** is `linux.rhel9` (placeholder — needs to be finalized during runner registration with the infra team).
- **Dockerfile removes `/etc/profile.d/which2.sh`** — RHEL exports a bash function via `BASH_FUNC_which%%` that breaks sccache's Rust process spawning in Podman containers.

## What's NOT included (intentionally)

- Test skip list — will be added once the test suite is validated on upstream infrastructure.
- Runner registration — needs coordination with the CI infra team (scale-config.yml in pytorch/test-infra).

## Open questions for reviewers

1. **Runner label naming** — is `linux.rhel9` acceptable, or should it follow a different convention (e.g., `linux.rhel9.h200`)?
2. **Docker image storage** — currently using local Podman images. Should we push to ECR, Docker Hub (like s390x), or keep local?
3. **Nightly placement** — the RHEL jobs are added to `nightly.yml`. Should they go in a separate `rhel-periodic.yml` instead (like s390x has `s390x-periodic.yml`)?

## Test results (from fork testing)

- Docker image build: passing
- PyTorch CUDA build: passing (37 min with MAX_JOBS=16)
- Test shards: executing with known platform-specific failures (H200 algorithm selection, CPU float16 codegen)

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01