### PR TITLE
[inductor] Preserve explicit low-precision FP casts during fusion

### DIFF
--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -1579,6 +1579,24 @@ class CudaReproTests(TestCase):
         actual = opt_fn(x)
         self.assertEqual(expected, actual)
 
+    def test_explicit_precision_cast_not_elided(self):
+        # Regression test for #179561: explicit fp32->bf16->fp32 round-trip
+        # should preserve the mantissa truncation even with default config.
+        torch.manual_seed(0)
+        x = torch.randn(4, 32, 32, device=device_type)
+        w = torch.randn(32, 32, device=device_type)
+
+        def fn(x, w):
+            x = torch.matmul(x, w)
+            x = x.to(torch.bfloat16).float()
+            x = x * torch.sigmoid(x)
+            return x.sum(dim=1)
+
+        opt_fn = torch.compile(fn, backend="inductor", fullgraph=True)
+        expected = fn(x, w)
+        actual = opt_fn(x.clone(), w.clone())
+        self.assertEqual(expected, actual)
+
     @torch._inductor.config.patch(emulate_precision_casts=True)
     def test_emulate_precision_casts_norm_rounding(self):
         torch.manual_seed(0)

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -943,10 +943,9 @@ def _convert_element_type(x: TensorBox, dtype: torch.dtype):
             )(x, dtype)
     src_dtype = x.get_dtype()
     low_pr_fp = (torch.bfloat16, torch.float16)
-    use_compute_types = not (
-        config.emulate_precision_casts
-        and (src_dtype in low_pr_fp or dtype in low_pr_fp)
-    )
+    # Preserve explicit casts to/from low-precision FP so intentional precision
+    # truncation (e.g. x.to(bf16).float()) survives fusion.  See #179561.
+    use_compute_types = not (src_dtype in low_pr_fp or dtype in low_pr_fp)
     return to_dtype(x, dtype, copy=True, use_compute_types=use_compute_types)
 
 


### PR DESCRIPTION
Fixes #179561

## Summary

Inductor's compute-type promotion (`codegen_upcast_to_fp32`) silently elides explicit dtype casts like `x.to(bf16).float()`. When enabled (default), the bf16 downcast becomes `x.to(tl.float32)` — a no-op since x is already fp32 in the fused kernel. The mantissa truncation never happens.

**Root cause**: `_convert_element_type` gates `use_compute_types` on `config.emulate_precision_casts` (default `False`), so explicit user casts are treated as compute-type promotions rather than precision-narrowing ops.

**Fix**: Always set `use_compute_types=False` when the cast involves bf16/fp16, so the real low-precision cast is emitted in the Triton kernel. `emulate_precision_casts` continues to control FP fusion and pointwise barriers independently — this avoids the perf regression from disabling `enable_fp_fusion` globally.

The reproducer from the issue now matches eager:
```python
def fn(x, w):
    x = torch.matmul(x, w)
    x = x.to(torch.bfloat16).float()  # mantissa truncation preserved
    x = x * torch.sigmoid(x)
    return x.sum(dim=1)
```
Before: `max_diff = 0.109` (bf16 cast elided). After: `max_diff ≈ 0` (matches eager).

## Test plan

- Added `test_explicit_precision_cast_not_elided` in `test/inductor/test_cuda_repro.py` — verifies fp32→bf16→fp32 round-trip preserves truncation without any config override
- Existing `test_emulate_precision_casts_*` tests continue to pass (those tests now exercise a redundant code path since casts are always preserved)

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo