### PR TITLE
[XPU][oneDNN] Enforce const/mutable pointer semantics for mkldnn xpu detail

### DIFF
--- a/aten/src/ATen/native/mkldnn/xpu/detail/Attention.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Attention.cpp
@@ -845,10 +845,10 @@ void sdpa(
   compiled_partition = partition.compile(l_inputs, l_outputs, eng);
 
   std::vector<dnnl::graph::tensor> outputs = {
-      {l_outputs[0], eng, attention.data_ptr()},
+      {l_outputs[0], eng, attention.mutable_data_ptr()},
   };
   if (compute_logsumexp) {
-    outputs.emplace_back(l_outputs[1], eng, logsumexp.data_ptr());
+    outputs.emplace_back(l_outputs[1], eng, logsumexp.mutable_data_ptr());
   }
 
   size_t i = 0;
@@ -856,7 +856,7 @@ void sdpa(
   inputs.reserve(l_inputs.size());
 
 #define ADD_INPUT(variable) \
-  inputs.emplace_back(l_inputs[i++], eng, variable.data_ptr())
+  inputs.emplace_back(l_inputs[i++], eng, variable.const_data_ptr())
 
   ADD_INPUT(query);
   ADD_INPUT(key);
@@ -947,9 +947,9 @@ void sdpa_backward(
   compiled_partition = partition.compile(l_inputs, l_outputs, eng);
 
   std::vector<dnnl::graph::tensor> outputs = {
-      {l_outputs[0], eng, grad_query.data_ptr()},
-      {l_outputs[1], eng, grad_key.data_ptr()},
-      {l_outputs[2], eng, grad_value.data_ptr()},
+      {l_outputs[0], eng, grad_query.mutable_data_ptr()},
+      {l_outputs[1], eng, grad_key.mutable_data_ptr()},
+      {l_outputs[2], eng, grad_value.mutable_data_ptr()},
   };
 
   size_t i = 0;
@@ -957,7 +957,7 @@ void sdpa_backward(
   inputs.reserve(l_inputs.size());
 
 #define ADD_INPUT(variable) \
-  inputs.emplace_back(l_inputs[i++], eng, variable.data_ptr())
+  inputs.emplace_back(l_inputs[i++], eng, variable.const_data_ptr())
 
   ADD_INPUT(grad_out);
   ADD_INPUT(query);

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Attention.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Attention.cpp
@@ -16,6 +16,22 @@ using partition = dnnl::graph::partition;
 constexpr logical_tensor::data_type sdpa_intermediate_dtype =
     logical_tensor::data_type::f32;
 
+inline dnnl::graph::tensor make_graph_tensor(
+    const logical_tensor& lt,
+    const dnnl::engine& eng,
+    void* ptr) {
+  return {lt, eng, ptr};
+}
+
+// Overload for read-only inputs (see uxlfoundation/oneDNN#4843).
+inline dnnl::graph::tensor make_graph_tensor(
+    const logical_tensor& lt,
+    const dnnl::engine& eng,
+    const void* ptr) {
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+  return {lt, eng, const_cast<void*>(ptr)};
+}
+
 inline data_type to_logical_tensor_data_type(c10::ScalarType scalar_type) {
   return scalar_type == c10::ScalarType::Float   ? data_type::f32
       : scalar_type == c10::ScalarType::Half     ? data_type::f16
@@ -856,7 +872,7 @@ void sdpa(
   inputs.reserve(l_inputs.size());
 
 #define ADD_INPUT(variable) \
-  inputs.emplace_back(l_inputs[i++], eng, variable.const_data_ptr())
+  inputs.emplace_back(make_graph_tensor(l_inputs[i++], eng, variable.const_data_ptr()))
 
   ADD_INPUT(query);
   ADD_INPUT(key);
@@ -957,7 +973,7 @@ void sdpa_backward(
   inputs.reserve(l_inputs.size());
 
 #define ADD_INPUT(variable) \
-  inputs.emplace_back(l_inputs[i++], eng, variable.const_data_ptr())
+  inputs.emplace_back(make_graph_tensor(l_inputs[i++], eng, variable.const_data_ptr()))
 
   ADD_INPUT(grad_out);
   ADD_INPUT(query);

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Attr.h
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Attr.h
@@ -351,7 +351,7 @@ class Attr {
             DNNL_ARG_ATTR_MULTIPLE_POST_OP(i) | DNNL_ARG_SRC_1);
 
         binary_m = at::native::onednn::make_onednn_memory(
-            md, engine, binary.data_ptr());
+          md, engine, binary.const_data_ptr());
 
         args.insert(
             {DNNL_ARG_ATTR_MULTIPLE_POST_OP(i) | DNNL_ARG_SRC_1, binary_m});

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Conv.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Conv.cpp
@@ -138,13 +138,13 @@ sycl::event convolution(
   dnnl::memory src_m, weight_m, dst_m, bia_m;
   at::Tensor src_blocked, weight_blocked, dst_blocked = dst;
 
-  src_m = make_onednn_memory(src_md, engine, src.data_ptr());
-  weight_m = make_onednn_memory(weight_md, engine, weight.data_ptr());
-  dst_m = make_onednn_memory(dst_md, engine, dst.data_ptr());
+  src_m = make_onednn_memory(src_md, engine, src.const_data_ptr());
+  weight_m = make_onednn_memory(weight_md, engine, weight.const_data_ptr());
+  dst_m = make_onednn_memory(dst_md, engine, dst.mutable_data_ptr());
 
   std::unordered_map<int, dnnl::memory> args;
   if (bia.defined()) {
-    bia_m = make_onednn_memory(bia_md, engine, bia.data_ptr());
+    bia_m = make_onednn_memory(bia_md, engine, bia.const_data_ptr());
     args.insert({DNNL_ARG_BIAS, bia_m});
   }
   auto expected_dst_md = conv_fwd_pd.dst_desc();
@@ -161,7 +161,7 @@ sycl::event convolution(
       src.options().dtype(at::kByte),
       std::nullopt);
   auto scratchpad_m = make_onednn_memory(
-      conv_fwd_pd.scratchpad_desc(), engine, scratchpad_tensor.data_ptr());
+      conv_fwd_pd.scratchpad_desc(), engine, scratchpad_tensor.mutable_data_ptr());
   args.insert({DNNL_ARG_SCRATCHPAD, scratchpad_m});
 
   auto conv_forward = dnnl::convolution_forward(conv_fwd_pd);
@@ -247,9 +247,10 @@ sycl::event convolution_backward_weights(
   at::Tensor expected_src, expected_diff_dst, expected_diff_weight;
   dnnl::memory src_m, diff_dst_m, diff_weight_m;
 
-  src_m = make_onednn_memory(src_md, engine, src.data_ptr());
-  diff_dst_m = make_onednn_memory(dst_md, engine, diff_dst.data_ptr());
-  diff_weight_m = make_onednn_memory(weight_md, engine, diff_weight.data_ptr());
+  src_m = make_onednn_memory(src_md, engine, src.const_data_ptr());
+  diff_dst_m = make_onednn_memory(dst_md, engine, diff_dst.const_data_ptr());
+  diff_weight_m = make_onednn_memory(
+      weight_md, engine, diff_weight.mutable_data_ptr());
 
   // insert args
   std::unordered_map<int, dnnl::memory> args;
@@ -258,7 +259,7 @@ sycl::event convolution_backward_weights(
   args.insert({DNNL_ARG_DIFF_WEIGHTS, diff_weight_m});
   if (diff_bia.defined()) {
     dnnl::memory diff_bia_m =
-        make_onednn_memory(bia_md, engine, diff_bia.data_ptr());
+        make_onednn_memory(bia_md, engine, diff_bia.mutable_data_ptr());
     args.insert({DNNL_ARG_DIFF_BIAS, diff_bia_m});
   }
 
@@ -268,7 +269,7 @@ sycl::event convolution_backward_weights(
       src.options().dtype(at::kByte),
       std::nullopt);
   auto scratchpad_m = make_onednn_memory(
-      conv_bwd_w_pd.scratchpad_desc(), engine, scratchpad_tensor.data_ptr());
+      conv_bwd_w_pd.scratchpad_desc(), engine, scratchpad_tensor.mutable_data_ptr());
   args.insert({DNNL_ARG_SCRATCHPAD, scratchpad_m});
 
   // execute primitive
@@ -354,9 +355,9 @@ sycl::event convolution_backward_data(
   at::Tensor expected_src, expected_wei, expected_dst;
   dnnl::memory diff_dst_m, wei_m, diff_src_m;
 
-  diff_src_m = make_onednn_memory(src_md, engine, diff_src.data_ptr());
-  wei_m = make_onednn_memory(weight_md, engine, weight.data_ptr());
-  diff_dst_m = make_onednn_memory(dst_md, engine, diff_dst.data_ptr());
+  diff_src_m = make_onednn_memory(src_md, engine, diff_src.mutable_data_ptr());
+  wei_m = make_onednn_memory(weight_md, engine, weight.const_data_ptr());
+  diff_dst_m = make_onednn_memory(dst_md, engine, diff_dst.const_data_ptr());
 
   // insert args
   std::unordered_map<int, dnnl::memory> args;
@@ -368,7 +369,7 @@ sycl::event convolution_backward_data(
   auto scratchpad_memory = make_onednn_memory(
       conv_backward_data_pd.scratchpad_desc(),
       engine,
-      scratchpad_tensor.data_ptr());
+      scratchpad_tensor.mutable_data_ptr());
   args.insert({DNNL_ARG_SCRATCHPAD, scratchpad_memory});
   args.insert({DNNL_ARG_DIFF_DST, diff_dst_m});
   args.insert({DNNL_ARG_WEIGHTS, wei_m});

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Deconv.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Deconv.cpp
@@ -208,9 +208,9 @@ sycl::event deconvolution(
   dnnl::memory src_m, weight_m, dst_m, bia_m;
   at::Tensor src_blocked, weight_blocked, dst_blocked = dst;
 
-  src_m = make_onednn_memory(src_md, engine, src.data_ptr());
-  weight_m = make_onednn_memory(weight_md, engine, weight.data_ptr());
-  dst_m = make_onednn_memory(dst_md, engine, dst.data_ptr());
+  src_m = make_onednn_memory(src_md, engine, src.const_data_ptr());
+  weight_m = make_onednn_memory(weight_md, engine, weight.const_data_ptr());
+  dst_m = make_onednn_memory(dst_md, engine, dst.mutable_data_ptr());
 
   std::unordered_map<int, dnnl::memory> args;
   args.insert({DNNL_ARG_SRC, src_m});
@@ -218,7 +218,7 @@ sycl::event deconvolution(
   args.insert({DNNL_ARG_DST, dst_m});
 
   if (bia.defined()) {
-    auto bia_m = make_onednn_memory(bia_md, engine, bia.data_ptr());
+    auto bia_m = make_onednn_memory(bia_md, engine, bia.const_data_ptr());
     args.insert({DNNL_ARG_BIAS, bia_m});
   }
   if (attr.with_binary())
@@ -230,7 +230,9 @@ sycl::event deconvolution(
       src.options().dtype(at::kByte),
       std::nullopt);
   auto scratchpad_m = make_onednn_memory(
-      deconv_fwd_pd.scratchpad_desc(), engine, scratchpad_tensor.data_ptr());
+      deconv_fwd_pd.scratchpad_desc(),
+      engine,
+      scratchpad_tensor.mutable_data_ptr());
   args.insert({DNNL_ARG_SCRATCHPAD, scratchpad_m});
 
   auto deconv_fwd = dnnl::deconvolution_forward(deconv_fwd_pd);
@@ -310,9 +312,9 @@ sycl::event deconvolution_backward_data(
   // create memory
   dnnl::memory diff_dst_m, wei_m, diff_src_m;
 
-  diff_src_m = make_onednn_memory(src_md, engine, diff_src.data_ptr());
-  wei_m = make_onednn_memory(weight_md, engine, weight.data_ptr());
-  diff_dst_m = make_onednn_memory(dst_md, engine, diff_dst.data_ptr());
+  diff_src_m = make_onednn_memory(src_md, engine, diff_src.mutable_data_ptr());
+  wei_m = make_onednn_memory(weight_md, engine, weight.const_data_ptr());
+  diff_dst_m = make_onednn_memory(dst_md, engine, diff_dst.const_data_ptr());
 
   // insert args
   std::unordered_map<int, dnnl::memory> args;
@@ -324,7 +326,7 @@ sycl::event deconvolution_backward_data(
   auto scratchpad_memory = make_onednn_memory(
       deconv_backward_data_pd.scratchpad_desc(),
       engine,
-      scratchpad_tensor.data_ptr());
+      scratchpad_tensor.mutable_data_ptr());
   args.insert({DNNL_ARG_SCRATCHPAD, scratchpad_memory});
   args.insert({DNNL_ARG_DIFF_DST, diff_dst_m});
   args.insert({DNNL_ARG_WEIGHTS, wei_m});
@@ -407,9 +409,10 @@ sycl::event deconvolution_backward_weights(
   // create bwd dnnl::memory
   dnnl::memory src_m, diff_dst_m, diff_weight_m;
 
-  src_m = make_onednn_memory(src_md, engine, src.data_ptr());
-  diff_dst_m = make_onednn_memory(dst_md, engine, diff_dst.data_ptr());
-  diff_weight_m = make_onednn_memory(weight_md, engine, diff_weight.data_ptr());
+  src_m = make_onednn_memory(src_md, engine, src.const_data_ptr());
+  diff_dst_m = make_onednn_memory(dst_md, engine, diff_dst.const_data_ptr());
+  diff_weight_m =
+      make_onednn_memory(weight_md, engine, diff_weight.mutable_data_ptr());
 
   // insert args
   std::unordered_map<int, dnnl::memory> args;
@@ -419,7 +422,7 @@ sycl::event deconvolution_backward_weights(
 
   if (diff_bia.defined()) {
     dnnl::memory diff_bia_m =
-        make_onednn_memory(bia_md, engine, diff_bia.data_ptr());
+        make_onednn_memory(bia_md, engine, diff_bia.mutable_data_ptr());
     args.insert({DNNL_ARG_DIFF_BIAS, diff_bia_m});
   }
 
@@ -429,7 +432,9 @@ sycl::event deconvolution_backward_weights(
       src.options().dtype(at::kByte),
       std::nullopt);
   auto scratchpad_m = make_onednn_memory(
-      deconv_bwd_w_pd.scratchpad_desc(), engine, scratchpad_tensor.data_ptr());
+      deconv_bwd_w_pd.scratchpad_desc(),
+      engine,
+      scratchpad_tensor.mutable_data_ptr());
   args.insert({DNNL_ARG_SCRATCHPAD, scratchpad_m});
 
   // execute primitive

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Matmul.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Matmul.cpp
@@ -223,9 +223,9 @@ sycl::event matmul(
   dst_usr_md = dnnl::memory::desc(dst_dims, dst_usr_dt, dst_strides);
 
   // STEP4: create memory
-  auto m1_usr_m = make_onednn_memory(m1_usr_md, engine, m1.data_ptr());
-  auto m2_usr_m = make_onednn_memory(m2_usr_md, engine, m2.data_ptr());
-  auto dst_usr_m = make_onednn_memory(dst_usr_md, engine, dst.data_ptr());
+  auto m1_usr_m = make_onednn_memory(m1_usr_md, engine, m1.const_data_ptr());
+  auto m2_usr_m = make_onednn_memory(m2_usr_md, engine, m2.const_data_ptr());
+  auto dst_usr_m = make_onednn_memory(dst_usr_md, engine, dst.mutable_data_ptr());
 
   auto expected_m1_md = matmul_pd.src_desc();
   auto expected_m2_md = matmul_pd.weights_desc();
@@ -243,14 +243,14 @@ sycl::event matmul(
       m1.options().dtype(at::kByte),
       std::nullopt);
   auto scratchpad_memory = make_onednn_memory(
-      matmul_pd.scratchpad_desc(), engine, scratchpad_tensor.data_ptr());
+      matmul_pd.scratchpad_desc(), engine, scratchpad_tensor.mutable_data_ptr());
   args.insert({DNNL_ARG_SCRATCHPAD, scratchpad_memory});
 
   args.insert({DNNL_ARG_SRC, m1_m});
   args.insert({DNNL_ARG_WEIGHTS, m2_m});
   args.insert({DNNL_ARG_DST, dst_m});
   if (with_bias) {
-    auto bias_m = make_onednn_memory(bias_md, engine, b.data_ptr());
+    auto bias_m = make_onednn_memory(bias_md, engine, b.const_data_ptr());
     args.insert({DNNL_ARG_BIAS, bias_m});
   }
 

--- a/aten/src/ATen/native/mkldnn/xpu/detail/QConv.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/QConv.cpp
@@ -180,11 +180,11 @@ at::Tensor quantized_convolution(
 
   dnnl::memory src_m, weight_m, output_m, bias_m;
 
-  src_m = make_onednn_memory(src_md, engine, act.data_ptr());
-  output_m = make_onednn_memory(output_md, engine, output.data_ptr());
-  weight_m = make_onednn_memory(weight_md, engine, weight.data_ptr());
+  src_m = make_onednn_memory(src_md, engine, act.const_data_ptr());
+    output_m = make_onednn_memory(output_md, engine, output.mutable_data_ptr());
+  weight_m = make_onednn_memory(weight_md, engine, weight.const_data_ptr());
   if (bias.has_value()) {
-    bias_m = make_onednn_memory(bias_md, engine, bias.value().data_ptr());
+    bias_m = make_onednn_memory(bias_md, engine, bias.value().const_data_ptr());
   }
 
   std::unordered_map<int, dnnl::memory> args;
@@ -225,7 +225,7 @@ at::Tensor quantized_convolution(
       act.options().dtype(at::kByte),
       std::nullopt);
   auto scratchpad_m = make_onednn_memory(
-      conv_fwd_pd.scratchpad_desc(), engine, scratchpad_tensor.data_ptr());
+      conv_fwd_pd.scratchpad_desc(), engine, scratchpad_tensor.mutable_data_ptr());
   args.insert({DNNL_ARG_SCRATCHPAD, scratchpad_m});
 
   // Weight scale is now tensor in nature, directly create dnnl::memory from it
@@ -235,7 +235,7 @@ at::Tensor quantized_convolution(
       dnnl::memory::data_type::f32,
       dnnl::memory::format_tag::x);
   dnnl::memory weight_sc_m =
-      make_onednn_memory(weight_sc_md, engine, weight_scales.data_ptr());
+      make_onednn_memory(weight_sc_md, engine, weight_scales.const_data_ptr());
   args.insert({DNNL_ARG_ATTR_SCALES | DNNL_ARG_WEIGHTS, weight_sc_m});
 
   auto qconv_event = dnnl::sycl_interop::execute(conv_forward, stream, args);

--- a/aten/src/ATen/native/mkldnn/xpu/detail/QMatmul.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/QMatmul.cpp
@@ -261,9 +261,9 @@ void quantized_matmul(
   m2_usr_md = dnnl::memory::desc(m2_dims, m2_usr_dt, m2_strides);
   dst_usr_md = dnnl::memory::desc(dst_dims, dst_usr_dt, dst_strides);
 
-  auto m1_usr_m = make_onednn_memory(m1_usr_md, engine, m1.data_ptr());
-  auto m2_usr_m = make_onednn_memory(m2_usr_md, engine, m2.data_ptr());
-  auto dst_usr_m = make_onednn_memory(dst_usr_md, engine, dst.data_ptr());
+  auto m1_usr_m = make_onednn_memory(m1_usr_md, engine, m1.const_data_ptr());
+  auto m2_usr_m = make_onednn_memory(m2_usr_md, engine, m2.const_data_ptr());
+  auto dst_usr_m = make_onednn_memory(dst_usr_md, engine, dst.mutable_data_ptr());
 
   auto expected_m1_md = matmul_pd.src_desc();
   auto expected_m2_md = matmul_pd.weights_desc();
@@ -276,7 +276,7 @@ void quantized_matmul(
   at::Tensor scratchpad_tensor =
       at::empty({scratchpad_size}, m1.options().dtype(at::kByte), std::nullopt);
   auto scratchpad_memory = make_onednn_memory(
-      matmul_pd.scratchpad_desc(), engine, scratchpad_tensor.data_ptr());
+      matmul_pd.scratchpad_desc(), engine, scratchpad_tensor.mutable_data_ptr());
   args.insert({DNNL_ARG_SCRATCHPAD, scratchpad_memory});
 
   if (attr.with_binary())
@@ -286,7 +286,7 @@ void quantized_matmul(
   args.insert({DNNL_ARG_WEIGHTS, m2_m});
   args.insert({DNNL_ARG_DST, dst_m});
   if (b.defined()) {
-    auto b_m = make_onednn_memory(b_md, engine, b.data_ptr());
+    auto b_m = make_onednn_memory(b_md, engine, b.const_data_ptr());
     args.insert({DNNL_ARG_BIAS, b_m});
   }
 
@@ -297,7 +297,7 @@ void quantized_matmul(
       get_onednn_dims(weight_scales),
       dnnl::memory::data_type::f32,
       dnnl::memory::format_tag::x);
-  m2_sc_m = make_onednn_memory(m2_sc_md, engine, weight_scales.data_ptr());
+  m2_sc_m = make_onednn_memory(m2_sc_md, engine, weight_scales.const_data_ptr());
   args.insert({DNNL_ARG_ATTR_SCALES | DNNL_ARG_WEIGHTS, m2_sc_m});
 
   dnnl::memory m1_sc_m, m1_zp_m;
@@ -499,13 +499,13 @@ sycl::event scaled_matmul(
   // 2. Prepare memory
 
   // Create memory
-  auto src_usr_m = make_onednn_memory(src_md, engine, mat1.data_ptr());
-  auto weights_usr_m = make_onednn_memory(weights_md, engine, mat2.data_ptr());
-  auto dst_usr_m = make_onednn_memory(dst_md, engine, result.data_ptr());
+  auto src_usr_m = make_onednn_memory(src_md, engine, mat1.const_data_ptr());
+  auto weights_usr_m = make_onednn_memory(weights_md, engine, mat2.const_data_ptr());
+  auto dst_usr_m = make_onednn_memory(dst_md, engine, result.mutable_data_ptr());
   dnnl::memory b_usr_m;
   if (with_bias) {
     b_usr_m =
-        make_onednn_memory(bias_md, engine, possible_reshaped_bias.data_ptr());
+        make_onednn_memory(bias_md, engine, possible_reshaped_bias.const_data_ptr());
   }
 
   // Prepare runtime scale memories (flat 1-D views) using the specs
@@ -521,7 +521,7 @@ sycl::event scaled_matmul(
         prepared.numel());
     dnnl::memory::desc scale_md(
         {prepared.numel()}, spec.dtype, dnnl::memory::format_tag::x);
-    return make_onednn_memory(scale_md, engine, prepared.data_ptr());
+    return make_onednn_memory(scale_md, engine, prepared.const_data_ptr());
   };
 
   auto scratchpad =
@@ -550,7 +550,7 @@ sycl::event scaled_matmul(
     dnnl::memory::desc dst_sc_md(
         {1}, dnnl::memory::data_type::f32, dnnl::memory::format_tag::x);
     auto dst_sc_mem =
-        make_onednn_memory(dst_sc_md, engine, dst_scale_f32.data_ptr());
+        make_onednn_memory(dst_sc_md, engine, dst_scale_f32.const_data_ptr());
     args.insert({DNNL_ARG_ATTR_SCALES | DNNL_ARG_DST, dst_sc_mem});
   }
 

--- a/aten/src/ATen/native/mkldnn/xpu/detail/QMatmul.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/QMatmul.cpp
@@ -524,8 +524,8 @@ sycl::event scaled_matmul(
     return make_onednn_memory(scale_md, engine, prepared.const_data_ptr());
   };
 
-  auto scratchpad =
-      make_onednn_memory(matmul_pd.scratchpad_desc(), engine, nullptr);
+  auto scratchpad = make_onednn_memory(
+      matmul_pd.scratchpad_desc(), engine, static_cast<void*>(nullptr));
 
   // 3. Setup Args for exec
   std::unordered_map<int, dnnl::memory> args;

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Utils.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Utils.cpp
@@ -303,7 +303,8 @@ bool is_onednn_matmul_strides(const at::Tensor& tensor) {
   if (tensor.storage_offset() > 0) {
     // currently onednn asks 64 byte alignment
     constexpr int alignment_byte = 64;
-    if (reinterpret_cast<uintptr_t>(tensor.data_ptr()) % alignment_byte > 0)
+    if (reinterpret_cast<uintptr_t>(tensor.const_data_ptr()) % alignment_byte >
+        0)
       return false;
   }
 

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Utils.h
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Utils.h
@@ -121,7 +121,7 @@ dnnl::memory dnnl_memory_from_host_scalar(
                      .device(kXPU);
   holder = at::empty({1}, options).fill_(host_value);
   dnnl::memory::desc md = get_onednn_md(holder);
-  dnnl::memory mem = make_onednn_memory(md, engine, holder.data_ptr());
+  dnnl::memory mem = make_onednn_memory(md, engine, holder.const_data_ptr());
   return mem;
 }
 

--- a/aten/src/ATen/native/mkldnn/xpu/detail/WoQMatmul.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/WoQMatmul.cpp
@@ -65,9 +65,10 @@ void woq_matmul_int4_impl(
   dst_usr_md = dnnl::memory::desc(dst_usr_dims, dst_usr_dt, dst_usr_strides);
 
   // create usr memory
-  auto dst_usr_m = make_onednn_memory(dst_usr_md, engine, dst.data_ptr());
-  auto scale_usr_m = make_onednn_memory(scale_usr_md, engine, scale.data_ptr());
-  auto zp_usr_m = make_onednn_memory(zp_usr_md, engine, zp.data_ptr());
+  auto dst_usr_m = make_onednn_memory(dst_usr_md, engine, dst.mutable_data_ptr());
+  auto scale_usr_m =
+      make_onednn_memory(scale_usr_md, engine, scale.const_data_ptr());
+  auto zp_usr_m = make_onednn_memory(zp_usr_md, engine, zp.const_data_ptr());
 
   // Construct md for primitive creation
   // The xxx_md describes what kinds of matmul the oneDNN does.
@@ -109,8 +110,8 @@ void woq_matmul_int4_impl(
   dnnl::matmul matmul_p;
   dnnl::matmul::primitive_desc matmul_pd;
 
-  auto m1_usr_m = make_onednn_memory(m1_usr_md, engine, m1.data_ptr());
-  auto m2_usr_m = make_onednn_memory(m2_usr_md, engine, m2.data_ptr());
+  auto m1_usr_m = make_onednn_memory(m1_usr_md, engine, m1.const_data_ptr());
+  auto m2_usr_m = make_onednn_memory(m2_usr_md, engine, m2.const_data_ptr());
 
   void* handle_b = m2_usr_m.get_data_handle();
   // reinterpret m2_usr_memory as u4
@@ -158,7 +159,7 @@ void woq_matmul_int4_impl(
   Tensor scratchpad_tensor =
       at::empty({scratchpad_size}, m1.options().dtype(at::kByte), std::nullopt);
   auto scratchpad_memory = make_onednn_memory(
-      matmul_pd.scratchpad_desc(), engine, scratchpad_tensor.data_ptr());
+      matmul_pd.scratchpad_desc(), engine, scratchpad_tensor.mutable_data_ptr());
   args.insert({DNNL_ARG_SCRATCHPAD, scratchpad_memory});
 
   args.insert({DNNL_ARG_SRC, m1_m});
@@ -262,38 +263,38 @@ void woq_matmul_int4_impl_cache(
   matmul_ext.set_attribute(
       arg_off++,
       DNNL_ARG_ATTR_SCALES | DNNL_ARG_WEIGHTS,
-      scale.data_ptr(),
+    const_cast<void*>(scale.const_data_ptr()),
       [&]() {
         return make_onednn_memory(
-            get_onednn_md(scale), engine, scale.data_ptr());
+      get_onednn_md(scale), engine, scale.const_data_ptr());
       });
 
   // set zp_md for asymmetric quantization
   matmul_ext.set_attribute(
       arg_off++,
       DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_WEIGHTS,
-      zp.data_ptr(),
+      const_cast<void*>(zp.const_data_ptr()),
       [&]() {
         int num_groups = k / group_size;
-        memory zp_usr_m(
-            {{num_groups, n}, memory::data_type::s8, {n, 1}},
-            engine,
-            zp.data_ptr());
-        return zp_usr_m;
+        auto zp_md =
+            memory::desc({num_groups, n}, memory::data_type::s8, {n, 1});
+        return make_onednn_memory(zp_md, engine, zp.const_data_ptr());
       });
 
   // set general args
   std::vector<std::pair<int, void*>> arg_handles;
   arg_handles.reserve(8);
 
-  arg_handles.emplace_back(DNNL_ARG_SRC, mat1.data_ptr());
-  arg_handles.emplace_back(DNNL_ARG_WEIGHTS, mat2.data_ptr());
-  arg_handles.emplace_back(DNNL_ARG_DST, result.data_ptr());
+    arg_handles.emplace_back(
+      DNNL_ARG_SRC, const_cast<void*>(mat1.const_data_ptr()));
+    arg_handles.emplace_back(
+      DNNL_ARG_WEIGHTS, const_cast<void*>(mat2.const_data_ptr()));
+    arg_handles.emplace_back(DNNL_ARG_DST, result.mutable_data_ptr());
 
   int scratchpad_size = matmul_ext.get_scratchpad_size();
   Tensor scratchpad_tensor = at::empty(
       {scratchpad_size}, mat1.options().dtype(at::kByte), std::nullopt);
-  arg_handles.emplace_back(DNNL_ARG_SCRATCHPAD, scratchpad_tensor.data_ptr());
+  arg_handles.emplace_back(DNNL_ARG_SCRATCHPAD, scratchpad_tensor.mutable_data_ptr());
 
   auto& strm = GpuStreamManager::Instance().get_stream();
   auto qint4_matmul_event =

--- a/aten/src/ATen/native/mkldnn/xpu/detail/oneDNNContext.h
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/oneDNNContext.h
@@ -18,6 +18,16 @@ TORCH_XPU_API dnnl::memory make_onednn_memory(
     dnnl::engine& engine,
     void* ptr);
 
+// Overload for Input-only arguments(see uxlfoundation/oneDNN#4843).
+inline dnnl::memory make_onednn_memory(
+    dnnl::memory::desc md,
+    dnnl::engine& engine,
+    const void* ptr) {
+  TORCH_CHECK(ptr != nullptr, "make_onednn_memory: null pointer passed for Input-only argument");
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+  return make_onednn_memory(md, engine, const_cast<void*>(ptr));
+}
+
 // Keep non-static and non-inline
 bool set_onednn_verbose(int level);
 


### PR DESCRIPTION
Fixes: 
https://github.com/intel/torch-xpu-ops/issues/2919

This PR standardize the use of const_data_ptr() and mutable_data_ptr() according to oneDNN argument roles, eliminate raw data_ptr() usage in mkldnn/xpu/detail, and add lint checks based on the argument mutability classification from https://github.com/uxlfoundation/oneDNN/pull/4843

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01